### PR TITLE
fix(#1320): Alarme-Tab hydratisiert activeMetricKeys beim Direkteinstieg

### DIFF
--- a/docs/specs/fast/fix-1320-alarm-tab-hydration.md
+++ b/docs/specs/fast/fix-1320-alarm-tab-hydration.md
@@ -1,0 +1,25 @@
+# Mini-Spec: fix-1320-alarm-tab-hydration
+
+## Was ändert sich
+- `compareHubWizardBridge.ts::hydrateAlarmFieldsFromPreset` befüllt zusätzlich `state.activeMetricKeys` (wiederverwendet `hydrateWeatherMetricsFromPreset(preset)` aus `weatherMetricsCompareSave.ts`, analog zum bereits bestehenden Idealwerte-/Wetter-Metriken-Pfad).
+- `AlarmHydrationTarget`-Interface um `activeMetricKeys?: string[]` erweitern.
+- Vorhandene Workaround-Klicks auf „Wetter-Metriken" in `compare-alarm-config.spec.ts` und `versand-tab-vergleich.spec.ts` entfernen, falls dort vorhanden — Direkteinstieg in den Alarme-Tab muss die Tabelle allein zeigen.
+
+## Was sich nicht ändern darf
+- Die anderen 8 hydratisierten Alarm-Felder (officialAlertsEnabled, radarAlertEnabled, metricAlertLevels, cooldown/quiet, corridors, telegramStyle) bleiben unverändert.
+- Wetter-Metriken-/Idealwerte-Tab-Hydration bleibt wie bisher (keine Regression an deren Snapshot-Logik).
+- Kein PUT-Payload-Feld ändert sich — `activeMetricKeys` ist im Alarme-Tab reine Leseansicht (Persistenz bleibt exklusiv beim Wetter-Metriken-Tab, analog zu `corridors`).
+
+## Acceptance Criteria
+- **AC-1:** Given ein Compare-Preset mit `display_config.active_metrics`, When `hydrateAlarmFieldsFromPreset(state, preset)` aufgerufen wird, Then ist `state.activeMetricKeys` mit der über `hydrateWeatherMetricsFromPreset(preset)` aufgelösten Metrik-Liste befüllt.
+- **AC-2:** Given der Alarme-Tab wird als erster Tab geöffnet (Deep-Link `?tab=alarme`, kein vorheriger Wetter-Metriken-/Idealwerte-Effekt), When die Empfindlichkeits-Tabelle rendert, Then zeigt sie die aktiven Metriken statt „keine Metriken" (`alarme-no-metrics`).
+
+## Manuelle Test-Schritte
+1. Compare-Preset mit aktiven Metriken anlegen (z. B. `wind_max_kmh`).
+2. Hub öffnen direkt mit `?tab=alarme` (Deep-Link) oder Alarme als ersten Tab-Klick.
+3. Empfindlichkeits-Tabelle muss sofort die aktiven Metriken zeigen (kein „keine Metriken"-Hinweis).
+4. Zur Kontrolle: Wetter-Metriken-Tab danach öffnen — Auswahl unverändert, kein Datenverlust.
+
+## Inline-Test (wird während Implementierung geschrieben)
+- [ ] Unit-Test für `hydrateAlarmFieldsFromPreset`: Preset mit `display_config.active_metrics` → `state.activeMetricKeys` entsprechend befüllt.
+- [ ] E2E: Alarme-Tab als erster geöffneter Tab zeigt `alert-metric-level-table` (kein vorheriger Tab-Besuch nötig) — Repro der beiden im Issue genannten Spec-Dateien ohne Workaround-Klick.

--- a/frontend/src/lib/components/compare/__tests__/compare_hub_alarme_bridge.test.ts
+++ b/frontend/src/lib/components/compare/__tests__/compare_hub_alarme_bridge.test.ts
@@ -133,6 +133,27 @@ describe('AC-29: hydrateAlarmFieldsFromPreset — Erst-Oeffnungs-Hydration OHNE 
 	});
 });
 
+describe('#1320: hydrateAlarmFieldsFromPreset befuellt activeMetricKeys (Alarme als Erst-Tab, kein "keine Metriken")', () => {
+	test('Preset mit display_config.active_metrics -> state.activeMetricKeys entspricht der aufgeloesten Metrik-Liste', () => {
+		const preset = makePreset({
+			display_config: {
+				region: 'Vorarlberg',
+				metric_alert_levels: { snow_depth_cm: 'warn', wind_gust: 'mark' },
+				active_metrics: ['wind_max_kmh']
+			}
+		});
+		const state: Record<string, unknown> = {};
+
+		hydrateAlarmFieldsFromPreset(state, preset);
+
+		assert.deepStrictEqual(
+			state.activeMetricKeys,
+			['wind_max_kmh'],
+			'ohne diese Verdrahtung bliebe activeMetricKeys leer und AlarmeTab.svelte zeigt faelschlich "keine Metriken" (Issue #1320)'
+		);
+	});
+});
+
 describe('AC-29 No-Op-Guard: flushPendingAlarmSave', () => {
 	function makeAlarmSnapshot(overrides: Partial<AlarmSnapshot> = {}): AlarmSnapshot {
 		return {

--- a/frontend/src/lib/components/compare/compareHubWizardBridge.ts
+++ b/frontend/src/lib/components/compare/compareHubWizardBridge.ts
@@ -19,6 +19,7 @@ import { buildComparePresetSavePayload } from './compareEditorSave.ts';
 import { rehydrateActiveMetrics } from './compareEditorLoad.ts';
 import type { CompareStatus } from './subscriptionHelpers.ts';
 import { computePauseToggle } from './subscriptionHelpers.ts';
+import { hydrateWeatherMetricsFromPreset } from '../shared/weather-metrics-tab/weatherMetricsCompareSave.ts';
 
 /** Plain-Objekt mit GENAU den 6 Feldern, die CorridorEditor.svelte im
  * vergleich-Kontext aus dem Wizard-State liest. Die Bridge-Komponente
@@ -399,6 +400,10 @@ export interface AlarmHydrationTarget {
 	// Issue #1260: Telegram-Kurzstil-Toggle im Hub-Alarme-Tab
 	// (display_config.telegram_style). Default "rich".
 	telegramStyle?: 'rich' | 'kurzform';
+	// Issue #1320: activeMetricKeys wird sonst nur von den Hydrations-Effekten
+	// der Tabs "wetter-metriken"/"idealwerte" befuellt — fehlt Alarme als
+	// Erst-Tab (Deep-Link), zeigt AlarmeTab.svelte faelschlich "keine Metriken".
+	activeMetricKeys?: string[];
 }
 
 /**
@@ -427,6 +432,11 @@ export function hydrateAlarmFieldsFromPreset(state: AlarmHydrationTarget, preset
 	state.alertQuietFrom = preset.alert_quiet_from;
 	state.alertQuietTo = preset.alert_quiet_to;
 	state.corridors = preset.corridors ?? [];
+	// Issue #1320: Alarme kann als ERSTER Tab geoeffnet werden — dann hat
+	// activeMetricKeys noch keinen Hydrations-Durchlauf vom Wetter-Metriken-/
+	// Idealwerte-Tab gesehen. Ohne diese Zeile zeigt die Empfindlichkeits-
+	// Tabelle faelschlich "keine Metriken", obwohl das Preset aktive Metriken hat.
+	state.activeMetricKeys = hydrateWeatherMetricsFromPreset(preset);
 	// Issue #1260: Kurzstil-Toggle aus display_config.telegram_style hydrieren,
 	// Default "rich" (analog CompareEditor). Ohne diese Zeile bliebe der Toggle
 	// im Hub-Alarme-Tab dauerhaft auf dem Klasse-Default stehen und ein


### PR DESCRIPTION
## Summary
- `hydrateAlarmFieldsFromPreset` befüllt jetzt zusätzlich `activeMetricKeys` (wiederverwendet `hydrateWeatherMetricsFromPreset`), sodass der Alarme-Tab im Ortsvergleich-Hub beim Direkteinstieg (Deep-Link `?tab=alarme` oder erster Tab-Klick) die Empfindlichkeits-Tabelle korrekt zeigt statt fälschlich "keine Metriken".
- Kein PUT-Payload-Feld geändert — reine Leseansicht, keine Persistenz-Verdrahtung nötig.

## Test plan
- [x] Unit-Test (node --test): 18/18 grün, inkl. neuem Test für #1320
- [x] Adversary-Verifikation: VERIFIED (2 Runden, Edge Cases geprüft — zyklischer Import unproblematisch, kein Clobbering bestehender Hydration-Pfade)
- [x] Scope-Check: 2 Quelldateien, 31 LoC
- [ ] Staging-E2E-Verifikation (folgt nach Merge über `/e2e-verify`)

Fixes #1320

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5XAghTXbR7ZGtoK7FGHCr