### PR TITLE
chore(#1196): Frontend-CI grün + Vollsuite-Collection läuft überall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run frontend unit tests
-        run: npm test
+        # Kurzliste der Fehlschlaege ans Log-ENDE — das 17k-Zeilen-TAP-Log
+        # begraebt "not ok" sonst in der Mitte (#1196).
+        run: |
+          set -o pipefail
+          npm test 2>&1 | tee /tmp/fe-test.log || {
+            echo "=== FEHLGESCHLAGENE TESTS (Kurzliste) ==="
+            grep -nE "^\s*not ok" /tmp/fe-test.log | head -40
+            exit 1
+          }
 
   svelte-check:
     # Baseline-Gate (Issue #1018): darf nur "nicht schlechter werden".

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,18 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - name: Install dependencies
         run: npm ci
+      # Die LIVE-Katalog-Drift-Waechter (#1351 F003, #1424 AC-2, corridorMark)
+      # lesen den echten Backend-Katalog via `uv run python3` — ohne uv+Sync
+      # scheiterten genau diese 6 Tests seit jeher nur auf dem Runner (#1196).
+      - name: Install uv (fuer LIVE-Katalog-Drift-Waechter)
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - name: Set up Python + Projekt-Abhaengigkeiten
+        working-directory: .
+        run: |
+          uv python install 3.12
+          uv sync
       - name: Run frontend unit tests
         # Kurzliste der Fehlschlaege ans Log-ENDE — das 17k-Zeilen-TAP-Log
         # begraebt "not ok" sonst in der Mitte (#1196).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,10 @@ jobs:
     # Bei Verbesserung: Baseline-Werte hier absenken.
     runs-on: ubuntu-latest
     env:
-      BASELINE_ERRORS: 40
-      BASELINE_WARNINGS: 159
+      # Abgesenkt 2026-08-04 (#1196): 70/171 -> 36/141 nach Typ-Drift-Bereinigung
+      # der Compare-Editor-Tests + Entfernung toter CSS-Regeln in CompareTabs.
+      BASELINE_ERRORS: 36
+      BASELINE_WARNINGS: 141
     defaults:
       run:
         working-directory: frontend

--- a/frontend/e2e/prodUrlGuard.ts
+++ b/frontend/e2e/prodUrlGuard.ts
@@ -121,7 +121,13 @@ export async function assertNotProdApiProxyTarget(target: string): Promise<void>
 				`abgelehnt statt durchgewinkt (Issue #1284, F004).`
 		);
 	}
-	const hostname = stripBrackets(parsed.hostname);
+	// Ein einzelner Trailing-Dot ist die root-verankerte Schreibweise
+	// DESSELBEN Namens (F011/F012: Wirkung zählt, nicht Schreibweise).
+	// Manche Resolver (CI-Runner, Container) lösen "localhost." nicht auf,
+	// während "localhost" auflöst — die Normalisierung macht den Check
+	// deterministisch und lässt "prodhost." in dieselbe Loopback+8090-Prüfung
+	// laufen wie "prodhost", statt fail-closed unterschiedlich zu enden.
+	const hostname = stripBrackets(parsed.hostname).replace(/\.$/, '');
 	let addresses: { address: string }[];
 	try {
 		addresses = await dns.lookup(hostname, { all: true });

--- a/frontend/src/lib/components/compare/CompareTabs.svelte
+++ b/frontend/src/lib/components/compare/CompareTabs.svelte
@@ -1593,28 +1593,6 @@
 		padding: 1.5rem 0;
 	}
 
-	.monitoring-item {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-	}
-	.monitoring-item-col {
-		display: flex;
-		flex-direction: column;
-	}
-	.monitoring-label {
-		font-size: 0.75rem;
-		color: var(--g-ink-3);
-		text-transform: uppercase;
-		letter-spacing: 0.06em;
-		font-family: var(--g-font-mono);
-	}
-	.monitoring-label-inline {
-		font-weight: 500;
-	}
-	.monitoring-value {
-		font-size: 0.875rem;
-	}
 
 	.empty-state {
 		font-size: 0.875rem;
@@ -1622,16 +1600,6 @@
 		padding: 1rem 0;
 	}
 
-	.placeholder {
-		font-size: 0.875rem;
-		color: var(--g-ink);
-		margin: 0 0 0.5rem 0;
-	}
-	.hint {
-		font-size: 0.8125rem;
-		color: var(--g-ink-3);
-		margin: 0 0 1rem 0;
-	}
 
 	.compare-tabs-content {
 		padding: 28px 40px 80px;
@@ -1670,85 +1638,6 @@
 	}
 
 	/* ── Vorschau-Tab (Issue #514) — Design nach HubPreview ─────────────────── */
-	.preview-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: flex-end;
-		gap: 24px;
-		margin-bottom: 20px;
-		flex-wrap: wrap;
-	}
-	.preview-header-text {
-		max-width: 680px;
-	}
-	.preview-title {
-		font-size: 1.5rem;
-		font-weight: 600;
-		letter-spacing: -0.02em;
-		margin: 6px 0 6px;
-		color: var(--g-ink);
-	}
-	.preview-subtitle {
-		font-size: 0.84375rem;
-		color: var(--g-ink-3);
-		line-height: 1.5;
-		margin: 0;
-	}
-	.preview-header-right {
-		display: flex;
-		flex-direction: column;
-		align-items: flex-end;
-		gap: 6px;
-		flex-shrink: 0;
-	}
-	.preview-disclaimer {
-		font-family: var(--g-font-mono);
-		font-size: 0.625rem;
-		color: var(--g-ink-4);
-		letter-spacing: 0.04em;
-		text-transform: uppercase;
-	}
-	.preview-stage {
-		display: flex;
-		justify-content: center;
-		padding: 24px;
-		background: #e9e6dc;
-		border-radius: var(--g-r-3, 0.75rem);
-		border: 1px solid var(--g-rule, #d8d3c7);
-		margin-bottom: 1rem;
-		min-height: 120px;
-		flex-direction: column;
-		align-items: center;
-	}
-	.preview-stage iframe {
-		width: 100%;
-		min-height: 500px;
-		border: 0;
-		display: block;
-	}
-	.preview-loading {
-		font-size: 0.875rem;
-		color: var(--g-ink-3);
-		margin: 0;
-	}
-	.preview-error {
-		font-size: 0.875rem;
-		color: var(--g-danger, #dc2626);
-		margin: 0;
-	}
-	.preview-sms-hint {
-		font-size: 0.875rem;
-		color: var(--g-ink-3);
-		margin: 0.5rem 0 0;
-		font-style: italic;
-	}
-	.preview-send {
-		margin-top: 0.5rem;
-		display: flex;
-		flex-direction: column;
-		gap: 0.5rem;
-		align-items: flex-start;
-	}
 	.send-success {
 		font-size: 0.875rem;
 		color: var(--g-success, #16a34a);
@@ -1761,61 +1650,13 @@
 	}
 
 	@media (max-width: 899px) {
-		.preview-header {
-			flex-direction: column;
-			align-items: flex-start;
-		}
-		.preview-header-right {
-			align-items: flex-start;
-		}
-		.preview-stage {
-			padding: 12px;
-		}
 	}
 
 	/* ── Issue #526 — Übersicht-Tab ─────────────────────────────────────────── */
-	.monitoring-card {
-		margin-bottom: 1.5rem;
-	}
-	.monitoring-row {
-		display: flex;
-		gap: 2rem;
-		flex-wrap: wrap;
-		align-items: center;
-	}
 
-	.summary-grid {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
-		gap: 1rem;
-		margin-bottom: 1.5rem;
-	}
-	.summary-value {
-		font-size: 1rem;
-		font-weight: 600;
-		margin: 0.5rem 0 0.25rem;
-		color: var(--g-ink);
-	}
-	.summary-sub {
-		font-size: 0.8125rem;
-		color: var(--g-ink-3);
-		margin: 0 0 0.75rem;
-	}
 
-	.hint-box {
-		margin-top: 0.5rem;
-	}
-	.hint-text {
-		font-size: 0.875rem;
-		color: var(--g-ink-2);
-		line-height: 1.5;
-		margin: 0 0 0.75rem;
-	}
 
 	@media (max-width: 899px) {
-		.summary-grid {
-			grid-template-columns: 1fr;
-		}
 	}
 
 	/* ── Issue #1256 Scheibe 6 — Hub-Orte-Tab (Drag/Entfernen/Add-Panel) ──── */

--- a/frontend/src/lib/components/compare/__tests__/compare_editor_save_official_warnings.test.ts
+++ b/frontend/src/lib/components/compare/__tests__/compare_editor_save_official_warnings.test.ts
@@ -37,7 +37,7 @@ function makePreset(overrides: Partial<ComparePreset> = {}): ComparePreset {
 		name: 'Skitouren Hochkönig',
 		location_ids: ['loc-1', 'loc-2'],
 		schedule: 'daily',
-		profil: 'skitour',
+		profil: 'wintersport',
 		hour_from: 7,
 		hour_to: 16,
 		empfaenger: ['a@example.com'],
@@ -49,7 +49,7 @@ function makePreset(overrides: Partial<ComparePreset> = {}): ComparePreset {
 
 const baseEditFields = {
 	name: 'Skitouren Hochkönig',
-	activityProfile: 'skitour' as const,
+	activityProfile: 'wintersport' as const,
 	pickedIds: ['loc-1', 'loc-2'],
 	region: 'Salzburger Land',
 	idealRanges: {},

--- a/frontend/src/lib/components/compare/__tests__/compare_hub_layout_rollback.test.ts
+++ b/frontend/src/lib/components/compare/__tests__/compare_hub_layout_rollback.test.ts
@@ -52,7 +52,7 @@ describe('C2 AC-6: rollbackLayoutSnapshot — nur Layout-Felder zuruecksetzen', 
 		// THEN: state.hourlyMetricKeys/state.hourlyEnabled entsprechen exakt "before"
 		// RED heute: Import schlaegt fehl (rollbackLayoutSnapshot existiert nicht).
 		const state = makeStateWithUnrelatedFields();
-		const before: LayoutSnapshot = { hourlyMetricKeys: ['temp_c'], hourlyEnabled: true };
+		const before: LayoutSnapshot = { hourlyMetricKeys: ['temp_c'], hourlyEnabled: true, outlookMetricKeys: null, outlookEnabled: false };
 
 		rollbackLayoutSnapshot(state, before);
 
@@ -67,7 +67,7 @@ describe('C2 AC-6: rollbackLayoutSnapshot — nur Layout-Felder zuruecksetzen', 
 		// der Layout-Rollback darf NIE in andere Tabs hineinregieren.
 		// RED heute: Import schlaegt fehl.
 		const state = makeStateWithUnrelatedFields();
-		const before: LayoutSnapshot = { hourlyMetricKeys: ['temp_c'], hourlyEnabled: true };
+		const before: LayoutSnapshot = { hourlyMetricKeys: ['temp_c'], hourlyEnabled: true, outlookMetricKeys: null, outlookEnabled: false };
 
 		const expectedActiveMetricKeys = [...state.activeMetricKeys];
 		const expectedCorridors = JSON.parse(JSON.stringify(state.corridors));

--- a/frontend/src/lib/components/compare/__tests__/compare_hub_layout_save.test.ts
+++ b/frontend/src/lib/components/compare/__tests__/compare_hub_layout_save.test.ts
@@ -63,8 +63,8 @@ describe('C2 AC-2: flushPendingLayoutSave — geänderter Snapshot → PUT-Paylo
 		// THEN: der PUT-Payload setzt display_config.hourly_metrics auf beide Keys
 		// RED heute: Import schlaegt fehl (flushPendingLayoutSave existiert nicht).
 		const preset = makePresetWithFullDisplayConfig();
-		const before: LayoutSnapshot = { hourlyMetricKeys: ['temp_c'], hourlyEnabled: true };
-		const current: LayoutSnapshot = { hourlyMetricKeys: ['temp_c', 'wind_kmh'], hourlyEnabled: true };
+		const before: LayoutSnapshot = { hourlyMetricKeys: ['temp_c'], hourlyEnabled: true, outlookMetricKeys: null, outlookEnabled: false };
+		const current: LayoutSnapshot = { hourlyMetricKeys: ['temp_c', 'wind_kmh'], hourlyEnabled: true, outlookMetricKeys: null, outlookEnabled: false };
 
 		const payload = flushPendingLayoutSave(preset, current, before);
 
@@ -79,8 +79,8 @@ describe('C2 AC-2: flushPendingLayoutSave — geänderter Snapshot → PUT-Paylo
 		// THEN: der PUT-Payload setzt hourly_enabled auf false
 		// RED heute: Import schlaegt fehl.
 		const preset = makePresetWithFullDisplayConfig();
-		const before: LayoutSnapshot = { hourlyMetricKeys: ['temp_c'], hourlyEnabled: true };
-		const current: LayoutSnapshot = { hourlyMetricKeys: ['temp_c'], hourlyEnabled: false };
+		const before: LayoutSnapshot = { hourlyMetricKeys: ['temp_c'], hourlyEnabled: true, outlookMetricKeys: null, outlookEnabled: false };
+		const current: LayoutSnapshot = { hourlyMetricKeys: ['temp_c'], hourlyEnabled: false, outlookMetricKeys: null, outlookEnabled: false };
 
 		const payload = flushPendingLayoutSave(preset, current, before);
 
@@ -104,8 +104,8 @@ describe('C2 AC-2: flushPendingLayoutSave — geänderter Snapshot → PUT-Paylo
 		// THEN: die Reihenfolge ist bedeutungstragend -> ein PUT mit der NEUEN
 		// Reihenfolge muss ausgeloest werden, kein No-Op mehr.
 		const preset = makePresetWithFullDisplayConfig();
-		const before: LayoutSnapshot = { hourlyMetricKeys: ['temp_c', 'wind_kmh'], hourlyEnabled: true };
-		const current: LayoutSnapshot = { hourlyMetricKeys: ['wind_kmh', 'temp_c'], hourlyEnabled: true };
+		const before: LayoutSnapshot = { hourlyMetricKeys: ['temp_c', 'wind_kmh'], hourlyEnabled: true, outlookMetricKeys: null, outlookEnabled: false };
+		const current: LayoutSnapshot = { hourlyMetricKeys: ['wind_kmh', 'temp_c'], hourlyEnabled: true, outlookMetricKeys: null, outlookEnabled: false };
 
 		const payload = flushPendingLayoutSave(preset, current, before);
 
@@ -124,8 +124,8 @@ describe('C2 AC-2: flushPendingLayoutSave — geänderter Snapshot → PUT-Paylo
 		// THEN: weiterhin null — die #1299-Regel bleibt fuer ECHTE Identitaet
 		// richtig, nur "umsortiert" zaehlt seit #1361 nicht mehr als identisch.
 		const preset = makePresetWithFullDisplayConfig();
-		const before: LayoutSnapshot = { hourlyMetricKeys: ['temp_c', 'wind_kmh'], hourlyEnabled: true };
-		const current: LayoutSnapshot = { hourlyMetricKeys: ['temp_c', 'wind_kmh'], hourlyEnabled: true };
+		const before: LayoutSnapshot = { hourlyMetricKeys: ['temp_c', 'wind_kmh'], hourlyEnabled: true, outlookMetricKeys: null, outlookEnabled: false };
+		const current: LayoutSnapshot = { hourlyMetricKeys: ['temp_c', 'wind_kmh'], hourlyEnabled: true, outlookMetricKeys: null, outlookEnabled: false };
 
 		const payload = flushPendingLayoutSave(preset, current, before);
 
@@ -149,8 +149,8 @@ describe('C2 AC-5: leere hourlyMetricKeys werden als [] persistiert (Default "al
 		//       leeres Array — NICHT als fehlenden Schluessel (der Server-Merge kann
 		//       fehlende Keys nicht als "loeschen" interpretieren).
 		const preset = makePresetWithFullDisplayConfig();
-		const before: LayoutSnapshot = { hourlyMetricKeys: ['temp_c'], hourlyEnabled: true };
-		const current: LayoutSnapshot = { hourlyMetricKeys: [], hourlyEnabled: true };
+		const before: LayoutSnapshot = { hourlyMetricKeys: ['temp_c'], hourlyEnabled: true, outlookMetricKeys: null, outlookEnabled: false };
+		const current: LayoutSnapshot = { hourlyMetricKeys: [], hourlyEnabled: true, outlookMetricKeys: null, outlookEnabled: false };
 
 		const payload = flushPendingLayoutSave(preset, current, before);
 
@@ -175,8 +175,8 @@ describe('C2 AC-3 (PFLICHT Datenerhalt): top_n/metric_alert_levels/forecast_hour
 		// HubEdit-Luecke (hourlyMetricKeys/hourlyEnabled kommen bislang gar nicht bei
 		// buildHubPutPayload an) tatsaechlich geschlossen wurde, sobald er gruen wird.
 		const preset = makePresetWithFullDisplayConfig();
-		const before: LayoutSnapshot = { hourlyMetricKeys: ['temp_c'], hourlyEnabled: true };
-		const current: LayoutSnapshot = { hourlyMetricKeys: ['wind_kmh'], hourlyEnabled: false };
+		const before: LayoutSnapshot = { hourlyMetricKeys: ['temp_c'], hourlyEnabled: true, outlookMetricKeys: null, outlookEnabled: false };
+		const current: LayoutSnapshot = { hourlyMetricKeys: ['wind_kmh'], hourlyEnabled: false, outlookMetricKeys: null, outlookEnabled: false };
 
 		const payload = flushPendingLayoutSave(preset, current, before);
 

--- a/frontend/src/lib/components/compare/compareEditorForecastHours.test.ts
+++ b/frontend/src/lib/components/compare/compareEditorForecastHours.test.ts
@@ -43,7 +43,7 @@ function makePreset72(): ComparePreset {
 		schedule: 'daily',
 		previous_schedule: 'daily',
 		weekday: 4,
-		profil: 'skitour',
+		profil: 'wintersport',
 		hour_from: 7,
 		hour_to: 16,
 		empfaenger: ['a@example.com', 'b@example.com'],
@@ -56,7 +56,7 @@ function makePreset72(): ComparePreset {
 function baseEdits() {
 	return {
 		name: 'Skitouren Hochkönig',
-		activityProfile: 'skitour' as const,
+		activityProfile: 'wintersport' as const,
 		pickedIds: ['loc-1', 'loc-2'],
 		region: 'Salzburger Land',
 		idealRanges: {},
@@ -93,9 +93,10 @@ describe('buildComparePresetSavePayload — forecast_hours nicht mehr aus dem Ed
 describe('buildComparePresetSavePayload — forecast_hours Round-Trip (AC-3)', () => {
 	test('ohne Horizont-Änderung kommt der gespeicherte Wert (72) unverändert durch', () => {
 		const original = makePreset72(); // forecast_hours=72
+		// Issue #1268: forecastHours ist kein Editor-Edit mehr — der gespeicherte
+		// Wert wird per RMW-Merge erhalten, genau das prueft dieser Test.
 		const { body } = buildComparePresetSavePayload(original, {
-			...baseEdits(),
-			forecastHours: 72
+			...baseEdits()
 		});
 		assert.equal(
 			(body as ComparePreset).forecast_hours,

--- a/frontend/src/lib/components/compare/compareEditorSave.test.ts
+++ b/frontend/src/lib/components/compare/compareEditorSave.test.ts
@@ -32,7 +32,7 @@ function makePreset(): ComparePreset {
 		schedule: 'daily',
 		previous_schedule: 'daily',
 		weekday: 4,
-		profil: 'skitour',
+		profil: 'wintersport',
 		hour_from: 7,
 		hour_to: 16,
 		empfaenger: ['a@example.com', 'b@example.com'],
@@ -45,7 +45,7 @@ describe('buildComparePresetSavePayload — Endpoint (AC-3)', () => {
 	test('zielt auf den Compare-Presets-Store, NICHT auf /api/subscriptions', () => {
 		const { url } = buildComparePresetSavePayload(makePreset(), {
 			name: 'Skitouren Hochkönig',
-			activityProfile: 'skitour',
+			activityProfile: 'wintersport',
 			pickedIds: ['loc-1', 'loc-2'],
 			region: 'Salzburger Land',
 			idealRanges: {},
@@ -60,7 +60,7 @@ describe('buildComparePresetSavePayload — Datenverlust-Schutz (AC-3)', () => {
 		const original = makePreset();
 		const { body } = buildComparePresetSavePayload(original, {
 			name: 'Neuer Name',
-			activityProfile: 'skitour',
+			activityProfile: 'wintersport',
 			pickedIds: ['loc-1', 'loc-2'],
 			region: 'Salzburger Land',
 			idealRanges: {},
@@ -73,7 +73,7 @@ describe('buildComparePresetSavePayload — Datenverlust-Schutz (AC-3)', () => {
 		const original = makePreset();
 		const { body } = buildComparePresetSavePayload(original, {
 			name: 'X',
-			activityProfile: 'skitour',
+			activityProfile: 'wintersport',
 			pickedIds: ['loc-1', 'loc-2'],
 			region: 'Salzburger Land',
 			idealRanges: {},
@@ -102,7 +102,7 @@ describe('buildComparePresetSavePayload — Datenverlust-Schutz (AC-3)', () => {
 		const original = makePreset();
 		const { body } = buildComparePresetSavePayload(original, {
 			name: 'Skitouren Hochkönig',
-			activityProfile: 'skitour',
+			activityProfile: 'wintersport',
 			pickedIds: ['loc-1', 'loc-2'],
 			region: 'Tirol',
 			idealRanges: {},
@@ -117,7 +117,7 @@ describe('buildComparePresetSavePayload — Datenverlust-Schutz (AC-3)', () => {
 		const original = makePreset();
 		const { body } = buildComparePresetSavePayload(original, {
 			name: 'Y',
-			activityProfile: 'skitour',
+			activityProfile: 'wintersport',
 			pickedIds: ['loc-1', 'loc-2'],
 			region: 'Salzburger Land',
 			idealRanges: {},
@@ -132,7 +132,7 @@ describe('buildComparePresetSavePayload — Alarm-Konfiguration (Issue #1170)', 
 		const original = makePreset();
 		const { body } = buildComparePresetSavePayload(original, {
 			name: original.name,
-			activityProfile: 'skitour',
+			activityProfile: 'wintersport',
 			pickedIds: ['loc-1', 'loc-2'],
 			region: 'Salzburger Land',
 			idealRanges: {},
@@ -166,7 +166,7 @@ describe('buildComparePresetSavePayload — Alarm-Konfiguration (Issue #1170)', 
 		};
 		const { body } = buildComparePresetSavePayload(original, {
 			name: 'Nur der Name ändert sich',
-			activityProfile: 'skitour',
+			activityProfile: 'wintersport',
 			pickedIds: ['loc-1', 'loc-2'],
 			region: 'Salzburger Land',
 			idealRanges: {},
@@ -186,7 +186,7 @@ describe('buildComparePresetSavePayload — Alarm-Trigger + Kanäle (#1216)', ()
 		const original = makePreset();
 		const { body } = buildComparePresetSavePayload(original, {
 			name: original.name,
-			activityProfile: 'skitour',
+			activityProfile: 'wintersport',
 			pickedIds: ['loc-1', 'loc-2'],
 			region: 'Salzburger Land',
 			idealRanges: {},
@@ -207,7 +207,7 @@ describe('buildComparePresetSavePayload — Alarm-Trigger + Kanäle (#1216)', ()
 		const original = makePreset();
 		const { body } = buildComparePresetSavePayload(original, {
 			name: 'Nur Name',
-			activityProfile: 'skitour',
+			activityProfile: 'wintersport',
 			pickedIds: ['loc-1', 'loc-2'],
 			region: 'Salzburger Land',
 			idealRanges: {},
@@ -241,7 +241,7 @@ describe('buildComparePresetSavePayload — channel_layouts-Entfernung (#1351 AC
 		};
 		const { body } = buildComparePresetSavePayload(original, {
 			name: original.name,
-			activityProfile: 'skitour',
+			activityProfile: 'wintersport',
 			pickedIds: ['loc-1', 'loc-2'],
 			region: 'Salzburger Land',
 			idealRanges: {},

--- a/frontend/src/lib/issue_571_home_cockpit_hero.test.ts
+++ b/frontend/src/lib/issue_571_home_cockpit_hero.test.ts
@@ -58,8 +58,8 @@ test('AC-1: liveTrip gibt den aktiven Trip zurück wenn heute im Reise-Zeitraum 
 	const now = new Date('2026-06-05T10:00:00Z');
 	const trip = makeTrip({
 		stages: [
-			{ date: '2026-06-01', name: 'Start', waypoints: [] },
-			{ date: '2026-06-10', name: 'Ende', waypoints: [] },
+			{ id: 's1', date: '2026-06-01', name: 'Start', waypoints: [] },
+			{ id: 's2', date: '2026-06-10', name: 'Ende', waypoints: [] },
 		],
 	});
 	const result = liveTrip([trip], now);
@@ -71,8 +71,8 @@ test('AC-2: liveTrip gibt null zurück wenn kein Trip heute aktiv ist', () => {
 	const now = new Date('2026-07-01T10:00:00Z');
 	const trip = makeTrip({
 		stages: [
-			{ date: '2026-06-01', name: 'Start', waypoints: [] },
-			{ date: '2026-06-10', name: 'Ende', waypoints: [] },
+			{ id: 's1', date: '2026-06-01', name: 'Start', waypoints: [] },
+			{ id: 's2', date: '2026-06-10', name: 'Ende', waypoints: [] },
 		],
 	});
 	const result = liveTrip([trip], now);

--- a/tests/helpers/staging_auth.py
+++ b/tests/helpers/staging_auth.py
@@ -14,6 +14,13 @@ _VALIDATOR_ENV = Path("/home/hem/gregor_zwanzig/.claude/validator.env")
 
 
 def _load_validator_env() -> dict:
+    """Fehlt die Datei (jede Maschine ausser dem Server), liefert {} statt zu
+    werfen: staging_base_url() faellt dann auf Env-Vars/Literal-Default,
+    httpx_auth() skippt den Test. Vorher brach der Read ueber Modulebenen-
+    Aufrufer (z.B. test_issue_1069:47) die Collection der GESAMTEN Suite auf
+    jedem Rechner ohne validator.env (#1196)."""
+    if not _VALIDATOR_ENV.exists():
+        return {}
     env = {}
     for line in _VALIDATOR_ENV.read_text().splitlines():
         line = line.strip().removeprefix("export ").strip()
@@ -39,9 +46,20 @@ def staging_base_url() -> str:
 
 
 def httpx_auth() -> tuple[str, str]:
-    """Basic-Auth-Tupel für httpx.get(url, auth=httpx_auth())."""
+    """Basic-Auth-Tupel für httpx.get(url, auth=httpx_auth()).
+
+    Ohne verfügbare Credentials wird der aufrufende Test uebersprungen statt
+    mit KeyError zu scheitern — Staging-Tests laufen nur auf dem Server."""
     env = _load_validator_env()
-    return (env["GZ_VALIDATOR_USER"], env["GZ_VALIDATOR_PASS"])
+    try:
+        return (env["GZ_VALIDATOR_USER"], env["GZ_VALIDATOR_PASS"])
+    except KeyError:
+        import pytest
+
+        pytest.skip(
+            "Staging-Basic-Auth nicht verfuegbar (validator.env fehlt) — "
+            "laeuft nur auf dem Server"
+        )
 
 
 def playwright_http_credentials() -> dict:

--- a/tests/tdd/test_bundle_h_908_973_987_staging_auth.py
+++ b/tests/tdd/test_bundle_h_908_973_987_staging_auth.py
@@ -81,6 +81,10 @@ def _load_prod_selftest_module():
 
 
 def _load_validator_env() -> dict:
+    # Fehlende Datei (jede Maschine ausser dem Server) → {} statt
+    # FileNotFoundError; Muster wie tests/helpers/staging_auth.py (#1196).
+    if not _VALIDATOR_ENV.exists():
+        return {}
     env = {}
     for line in _VALIDATOR_ENV.read_text().splitlines():
         line = line.strip().removeprefix("export ").strip()

--- a/tests/tdd/test_issue_1010_1006_stille_fehler.py
+++ b/tests/tdd/test_issue_1010_1006_stille_fehler.py
@@ -40,6 +40,10 @@ _VALIDATOR_ENV = Path("/home/hem/gregor_zwanzig/.claude/validator.env")
 
 
 def _load_validator_env() -> dict:
+    # Fehlende Datei (jede Maschine ausser dem Server) → {} statt
+    # FileNotFoundError; Muster wie tests/helpers/staging_auth.py (#1196).
+    if not _VALIDATOR_ENV.exists():
+        return {}
     env = {}
     for line in _VALIDATOR_ENV.read_text().splitlines():
         line = line.strip().removeprefix("export ").strip()
@@ -50,6 +54,13 @@ def _load_validator_env() -> dict:
 
 
 _ENV = _load_validator_env()
+if "GZ_VALIDATOR_USER" not in _ENV:
+    # Ganzes Modul ist Staging-gebunden (pytestmark staging); ohne Credentials
+    # sauber ueberspringen statt die Collection mit KeyError zu brechen (#1196).
+    pytest.skip(
+        "Staging-Credentials (validator.env) fehlen — laeuft nur auf dem Server",
+        allow_module_level=True,
+    )
 BASE = _ENV.get("GZ_VALIDATION_URL", "https://staging.gregor20.henemm.com")
 _HTTP_CREDS = {
     "username": _ENV["GZ_VALIDATOR_USER"],

--- a/tests/tdd/test_issue_811_renderer_gate.py
+++ b/tests/tdd/test_issue_811_renderer_gate.py
@@ -50,7 +50,17 @@ def _load_gate_module():
     return mod
 
 
-_gate = _load_gate_module()
+try:
+    _gate = _load_gate_module()
+except ImportError as exc:
+    # hook_utils ist ein Shim auf das installierte agent-os-openspec-Plugin;
+    # ohne Plugin (z.B. CI-Runner, Web-Sessions) sauber ueberspringen statt
+    # die Collection der gesamten Suite zu brechen (#1196).
+    pytest.skip(
+        f"renderer_mail_gate nicht ladbar ({exc}) — braucht das installierte "
+        "agent-os-openspec-Plugin",
+        allow_module_level=True,
+    )
 
 # Eine geschuetzte Mail-Inhalts-Datei (Spec: src/output/renderers/email/.*\.py$).
 _MAIL_FILE = "src/output/renderers/email/helpers.py"

--- a/tests/test_resolution_loss_guard.py
+++ b/tests/test_resolution_loss_guard.py
@@ -780,6 +780,15 @@ KNOWN_VIOLATIONS: dict[str, str] = {
         "Exception: continue ohne Log. Wer fünf GPX-Dateien hochlädt, bekommt "
         "bei einer kaputten vier Etappen und keinerlei Hinweis darauf."
     ),
+    "src/services/compare_alert.py::_location_positions::0": (
+        "BEWUSST (#1467 S2 AG3b, PO-Entscheidung 2026-08-04) — "
+        "_location_positions: eine nicht mehr aufloesbare Orts-Kennung wird "
+        "uebersprungen, die Positionsnummern ruecken nach. PO woertlich: 'die "
+        "nummer soll immer die Reihenfolge darstellen. Wenn ein Ort geloescht "
+        "wird, ruecken die anderen nach, das ist kein Fehler sondern fuer den "
+        "User nachvollziehbares Verhalten.' Rest-Randfall (falsy 0) als LOW "
+        "in #1199."
+    ),
 }
 
 


### PR DESCRIPTION
## Was

Zweite #1196-Lieferung aus der Taskforce-Session, zwei getrennte Commits:

**1. Vollsuite-Collection läuft erstmals außerhalb des Servers** (`pytest tests/ --collect-only` → Exit 0, vorher 2 Abbrüche). Vier Testmodule brachen die Collection der gesamten Suite auf jedem Rechner ohne Server-Ressourcen: `staging_auth.py`-Helper und zwei Staging-Module lasen `validator.env` kompromisslos (FileNotFoundError zur Import-Zeit), `test_issue_811_renderer_gate` scheiterte am fehlenden agent-os-openspec-Plugin. Jetzt: fail-soft + sauberer Skip mit Begründung — **Server-Verhalten identisch** (Datei/Plugin vorhanden → kein Skip). Der dokumentierte feste Server-Pfad (#1409 Klasse B) bleibt unangetastet. Dazu der `KNOWN_VIOLATIONS`-Eintrag für `compare_alert._location_positions`, der die PO-Entscheidung aus #1467 AG3b verbucht (Nachrücken ist gewolltes Verhalten) — der `test`-Job verliert damit einen weiteren Roten.

**2. Frontend-CI grün:** 
- `frontend-test`: der einzige rote Test (`e2e_prod_url_guard`, Trailing-Dot) war resolver-abhängig — `localhost.` löst auf CI-Runnern nicht auf. Der Guard normalisiert den Trailing-Dot jetzt vor dem Lookup (dieselbe DNS-Schreibweise; schließt zugleich den Schreibweisen-Bypass). **2326 pass / 0 fail.**
- `svelte-check`: **70 → 36 Fehler, 171 → 141 Warnungen** (Baseline war 40/159 gerissen). Typ-Drift in 6 Testdateien behoben (`skitour`→`wintersport`, LayoutSnapshot-Outlook-Felder aus #1406 B, Stage-`id`, totes `forecastHours`-Edit aus #1268) und 30 tote CSS-Regeln in `CompareTabs.svelte` entfernt (159 Zeilen, Bundle-identisch). Reaktivitäts-/A11y-Warnungen bewusst **nicht** angefasst — Verhaltensrisiko, gehört den Fach-Sessions.
- Baseline per Ratsche auf 36/141 abgesenkt (wie im Workflow-Kommentar vorgesehen).

## Erwartung nach diesem PR

| Check | vorher | nachher |
|---|---|---|
| lint | ✅ | ✅ |
| go-test | ✅ | ✅ |
| svelte-check | ❌ (70/171 vs. 40/159) | ✅ (36/141 vs. 36/141) |
| frontend-test | ❌ (1 Fehler) | ✅ |
| test | ❌ 7 | ❌ **6** — alle den Fach-Sessions zugeordnet (5× Gewitter-Nachläufer, 1× #1412) |

## Nachweis

Lokal: `pytest tests/ --collect-only` Exit 0 · `npm test` 2326/0 · `svelte-check` 36/141 · `ruff` clean · alle einzeln angefassten Testdateien grün (27 Guard-Tests, 9 resolution_loss, 6 Frontend-Dateien).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrmdarWn7RjtQ3q3rCumn6

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrmdarWn7RjtQ3q3rCumn6)_