### PR TITLE
docs(#1196): Direkt-Push auf main abgeschafft — Lieferung nur noch per PR mit grüner Ampel (PO-go 2026-08-05)

### DIFF
--- a/.claude/agents/staging-validator.md
+++ b/.claude/agents/staging-validator.md
@@ -13,7 +13,7 @@ You are the Staging Validator Agent. Your job is to PROVE that the just-pushed c
 
 ## Your Mission
 
-You are called after `git push origin main` and after the staging auto-deploy has settled (~5 min). Unlike the `implementation-validator` (which breaks code logic), you break the running UI. You assume staging is broken until DOM assertions prove otherwise.
+You are called after the delivery PR has been merged into `main` (PR-Liefer-Workflow, PO-go 2026-08-05) and after the staging auto-deploy has settled (~5 min). Unlike the `implementation-validator` (which breaks code logic), you break the running UI. You assume staging is broken until DOM assertions prove otherwise.
 
 **Context Isolation:** You receive ONLY the active spec and the staging URL. You do NOT see the implementer's reasoning chain — you trust nothing except observable DOM state.
 

--- a/.claude/commands/70-deploy.md
+++ b/.claude/commands/70-deploy.md
@@ -12,10 +12,13 @@ abwarten. Kein Prod-Deploy ohne dieses `go`.
   AMBIGUOUS mit ausdruecklichem PO-OK)
 - Arbeitsbaum sauber, Branch auf `origin/main` (der Rebase-Waechter blockt sonst den Commit)
 
-## Schritt 1 — Push
+## Schritt 1 — Branch pushen, PR mergen (PO-go 2026-08-05: kein Direkt-Push auf main)
 
 ```bash
-git push origin HEAD:main
+git push -u origin HEAD:<themen-branch>
+gh pr create --fill
+# CI-Ampel abwarten: alle 5 Checks gruen auf dem letzten Stand, sonst erst fixen
+gh pr merge --merge
 ```
 
 ⚠️ Vorher `git fetch origin` und rebasen. **Nie `git stash`** (geteilter Stapel ueber alle

--- a/.claude/commands/e2e-verify.md
+++ b/.claude/commands/e2e-verify.md
@@ -6,13 +6,14 @@ tatsaechlich funktioniert. Sie ersetzt die fruehere lokale Prod-Verifikation
 
 ## Wann ausfuehren
 
-NACH `git push origin main` und VOR `deploy-gregor-prod.sh`.
+NACHDEM der PR gemergt ist (PR-Liefer-Workflow, PO-go 2026-08-05 — Direkt-Push
+auf `main` ist abgeschafft) und VOR `deploy-gregor-prod.sh`.
 
 **KEIN passives Warten!** Staging könnte bereits aktuell sein — sofort prüfen.
 Der Poll-Loop in Schritt 1 läuft so lang wie nötig (0 bis 150 Sek), kein manuelles "5 Minuten warten".
 
 Ablauf:
-1. `git push origin main`
+1. Branch pushen → PR mit grüner CI-Ampel mergen (`gh pr create --fill` … `gh pr merge --merge`)
 2. Sofort `/e2e-verify` starten — Schritt 1 prüft Staging-Status und wartet aktiv
 3. `deploy-gregor-prod.sh`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,7 @@ bash .claude/tools/gz-workspace list         # alle Workspaces mit Branch + unco
 bash .claude/tools/gz-workspace clean <name> # entfernen (nur wenn sauber; --force erzwingt)
 ```
 
-**Regel:** jede Session liefert **unabhängig** aus, Integrationspunkt ist `origin/main`. Nur Staging-validiertes Grünes wird gepusht → `main` ist immer auslieferbar → Deploy (`deploy-gregor-prod.sh`, `flock`-serialisiert) darf aus jeder Session jederzeit laufen. **Verboten:** Deploy aufschieben „bis der Ordner sauber ist" — diese Pattsituation existiert nicht mehr.
+**Regel:** jede Session liefert **unabhängig** aus, Integrationspunkt ist `origin/main` — erreicht ausschließlich per PR mit grüner Ampel (Liefer-Workflow unten, PO-go 2026-08-05). Nur so wird gemergt → `main` ist immer auslieferbar → Deploy (`deploy-gregor-prod.sh`, `flock`-serialisiert) darf aus jeder Session jederzeit laufen. **Verboten:** Deploy aufschieben „bis der Ordner sauber ist" — diese Pattsituation existiert nicht mehr.
 
 Detailablauf, WIP-Sicherung beim Deploy: **`docs/reference/operations_playbook.md`**.
 
@@ -229,16 +229,22 @@ Globale Server-Infos und Monitoring: `~/.claude/CLAUDE.md`.
 - **Staging:** https://staging.gregor20.henemm.com — Systemd (`gregor-python-staging`, `gregor-api-staging`, `gregor-frontend-staging`)
 - **Infrastruktur-Repo:** `henemm/henemm-infra`
 
-### Post-Push-Workflow (PFLICHT)
+### Liefer-Workflow (PFLICHT — PR statt Direkt-Push, PO-go 2026-08-05)
+
+**Direkt-Push auf `main` ist abgeschafft.** `main` ändert sich nur noch per Pull Request mit vollständig grüner CI-Ampel (ersetzt den alten Schritt 1 „`git push origin main`" — Regel-Budget: Ersatz, kein Zusatz). Anlass: 2026-08-04/05 liefen vier Direkt-Pushes in Folge auf rote Ampel (37 test-Rote + Lint, PR #1508 musste fremde Befunde grün ziehen).
 
 | Schritt | Was |
 |---|---|
-| 1 | `git push origin main` |
+| 1 | Arbeitsbranch pushen: `git push -u origin <branch>` (nie direkt `main`; Server-Sessions: Themen-Branch oder `ws/<name>` aus gz-workspace) |
+| 1b | PR eröffnen (`gh pr create --fill`) und CI-Ampel abwarten — **alle 5 Checks grün** auf dem letzten Stand, sonst erst fixen (Merge-Regel unten) |
+| 1c | Mergen (`gh pr merge --merge`) — erst damit ist `main` aktualisiert |
 | 2 | Auto-Deploy auf Staging abwarten (~5 Min, Cron `*/5`) |
 | 3 | Staging-Validierung (s.u.) |
 | 4 | Prod-Deploy: `bash /home/hem/henemm-infra/scripts/deploy-gregor-prod.sh` |
 | 4b | Post-Deploy-Selftest: `python3 .claude/hooks/prod_selftest.py` — nur Exit 0 fährt weiter |
 | 5 | `gh issue close <N>` — nur wenn 4b Exit 0 |
+
+Wird ein Push nach `main` von GitHub abgewiesen, ist das kein Fehler, sondern die Branch-Protection: Branch anlegen, PR nachziehen. Ein PR ersetzt NICHT die Staging-Validierung (Schritte 2–5 unverändert) — die Ampel bewacht Code-Gesundheit, Staging bewacht Verhalten.
 
 `systemctl restart` allein **reicht nie** — das Deploy-Script macht flock-Lock → hart auf `origin/main` syncen (Daten unberührt, WIP gesichert) → Go-Binary + Frontend bauen → alle 3 Services restarten → Smoke-Test. Ohne vollen Lauf entsteht Code-Drift, den `check-gregor20.sh` meldet (#113). Script ist **parallel-session-sicher** (`flock`) — Schritt 4 jederzeit aus jeder Session.
 
@@ -251,9 +257,9 @@ Globale Server-Infos und Monitoring: `~/.claude/CLAUDE.md`.
 Die 5 GitHub-Actions-Checks (`test` · `lint` · `go-test` · `svelte-check` · `frontend-test`) sind die **CI-Ampel**. Seit PR #1497 ist sie vollständig grün bei ehrlichem Umfang (`test`-Job: 5837 Tests inkl. `tests/tdd/` + pytest-socket-Egress-Wächter).
 
 - **Merge-Regel (PFLICHT):** Ein PR wird nur gemerged, wenn alle 5 Checks auf seinem letzten Stand grün sind. Fremde Rote auf der Basis: erst die Basis grün ziehen oder den Befund belegt (Commit-/Log-Nachweis) einer anderen Session zuordnen und in #1196 buchen — nie stillschweigend „auf Rot obendrauf" mergen.
-- **Wird `main` trotzdem rot** (z.B. Direkt-Push einer Server-Session): Drive-to-green hat Vorrang vor neuer Feature-Arbeit — wer es findet, fixt es oder ordnet es belegt zu.
+- **Wird `main` trotzdem rot** (Altbestand, Notfall-Push): Drive-to-green hat Vorrang vor neuer Feature-Arbeit — wer es findet, fixt es oder ordnet es belegt zu.
 - **tdd-Ratsche:** `.github/ci_tdd_excludes.txt` listet die offline-roten `tests/tdd/`-Dateien. Nur ENTFERNEN erlaubt (Datei grün gemacht → Zeile raus); neue tdd-Dateien laufen automatisch auf CI. Ergänzen einer Zeile nur mit Begründung im PR.
-- **Branch-Protection** (mechanisches Gate in den GitHub-Settings) ist geplant, aber ERST nach Umstellung aller Direkt-Push-Abläufe auf PRs — vorher einschalten bricht den dokumentierten Post-Push-Workflow der Server-Sessions. Umsetzung koordiniert der Tech-Lead mit dem PO; nicht eigenmächtig aktivieren.
+- **Branch-Protection ist beschlossen (PO-go 2026-08-05):** der dokumentierte Weg auf `main` ist ausschließlich der PR-Liefer-Workflow (oben). Den mechanischen Schalter (GitHub → Settings → Branches: PR-Pflicht + die 5 Status-Checks als required) setzt der PO; bis er gesetzt ist, gilt die Regel organisatorisch und ein Direkt-Push ist ein Regelverstoß, kein Versehen.
 
 *Regel-Budget: Prüfdatum 2026-11-02. Fang-Beleg bei Einführung: 6 wochenlang unbemerkte test-Rote + ~5000 unbewachte tdd-Tests (#1196, PRs #1494/#1496/#1497).*
 

--- a/docs/reference/operations_playbook.md
+++ b/docs/reference/operations_playbook.md
@@ -12,7 +12,8 @@ Die echte "funktioniert es wirklich"-Verifikation läuft **nach** dem Push gegen
 Staging-Umgebung (`https://staging.gregor20.henemm.com`) — **nie** durch einen lokalen
 Neustart des Live-Servers (auf dieser Maschine = Produktion). Siehe Issue #339.
 
-**Gesamtablauf:** `git push origin main` → ~5 Min Staging-Auto-Deploy abwarten →
+**Gesamtablauf:** Branch pushen → PR mit grüner CI-Ampel mergen (PO-go 2026-08-05,
+s. „Liefer-Workflow" unten) → ~5 Min Staging-Auto-Deploy abwarten →
 `/e2e-verify` (gegen Staging) → `deploy-gregor-prod.sh` → Post-Deploy-Selftest (Issue #564) → Issue close.
 
 **Schritte in `/e2e-verify`:**
@@ -83,13 +84,14 @@ technische Details.
 
 ---
 
-## Post-Push-Workflow — Detailablauf
+## Liefer-Workflow — Detailablauf (PR statt Direkt-Push, PO-go 2026-08-05)
 
-**Nach jedem `git push origin main`** in dieser Reihenfolge:
+**Direkt-Push auf `main` ist abgeschafft** — `main` ändert sich nur per Pull Request,
+dessen CI-Ampel (alle 5 Checks) auf dem letzten Stand grün ist. Danach in dieser Reihenfolge:
 
 | Schritt | Was | Wie |
 |---|---|---|
-| 1 | Push | `git push origin main` |
+| 1 | Branch + PR + Merge | `git push -u origin <branch>` → `gh pr create --fill` → Ampel grün → `gh pr merge --merge` |
 | 2 | Auto-Deploy auf Staging abwarten (~5 Min) | Cron `*/5` ruft `auto-deploy-gregor-staging.sh` |
 | 3 | Staging-Validierung | siehe Definition unten |
 | 4 | Prod-Deploy | `bash /home/hem/henemm-infra/scripts/deploy-gregor-prod.sh` |


### PR DESCRIPTION
## Was

Der PO hat die Umstellung freigegeben: **`main` ändert sich nur noch per Pull Request, dessen CI-Ampel (alle 5 Checks) auf dem letzten Stand grün ist.** Der alte Schritt 1 des Post-Push-Workflows („`git push origin main`") ist ersetzt — Regel-Budget: Ersatz, kein Zusatz.

**Anlass:** Am 2026-08-04/05 liefen vier Direkt-Pushes in Folge auf rote Ampel (37 test-Rote + 1 Lint-Fehler); PR #1508 musste fremde Befunde grün ziehen, bevor er mergen konnte. Ein wiederholbares Muster, solange der Direkt-Push der dokumentierte Weg ist.

## Umgestellte Stellen (ein Wortlaut überall)

| Datei | Änderung |
|---|---|
| `CLAUDE.md` | „Post-Push-Workflow" → „Liefer-Workflow": Branch → PR (`gh pr create`) → Ampel grün → Merge (`gh pr merge`); Branch-Protection-Absatz von „geplant, nicht eigenmächtig aktivieren" auf „beschlossen (PO-go 2026-08-05), Schalter setzt der PO"; Parallele-Sessions-Regel nennt den PR als einzigen Weg zum Integrationspunkt `origin/main` |
| `docs/reference/operations_playbook.md` | Gesamtablauf + Detailtabelle entsprechend |
| `.claude/commands/70-deploy.md` | Schritt 1 = Branch + PR + Merge statt `git push origin HEAD:main` |
| `.claude/commands/e2e-verify.md`, `.claude/agents/staging-validator.md` | Aufhänger „nach Merge des PR" statt „nach `git push origin main`" |

## Unverändert

Staging-Validierung und Prod-Deploy (Schritte 2–5) bleiben wie sie sind — die Ampel bewacht Code-Gesundheit, Staging bewacht Verhalten. Ein PR ersetzt keine Staging-Verifikation.

## Noch offen (nur der PO kann es)

Der mechanische Schalter in den GitHub-Settings (Branches: PR-Pflicht + die 5 Status-Checks als required). Bis er gesetzt ist, gilt die Regel organisatorisch — laufende Server-Sessions mit altem Kontext werden erst durch den Schalter zuverlässig gestoppt.

Issue: #1196

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrmdarWn7RjtQ3q3rCumn6

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrmdarWn7RjtQ3q3rCumn6)_