### PR TITLE
fix(#1469, #1432) + chore(#1196): Zwei Gate-Fehlalarme behoben, tdd-Ratsche 50→48

### DIFF
--- a/.claude/hooks/briefing_mail_validator.py
+++ b/.claude/hooks/briefing_mail_validator.py
@@ -162,8 +162,22 @@ def _table_blocks(html: str) -> list[str]:
     Tabellen (Stundentabelle(n) je Etappe vs. 9-spaltige Trend-Tabelle) — der
     Guard `len(cells) == len(headers)` matchte dann gegen die GLOBALE Summe und
     keine reale Zeile passte mehr (stummer False-Negative).
+
+    Issue #1432: byte-identische Blöcke werden DEDUPLIZIERT. Der Renderer
+    stellt jede Stundentabelle zweimal ins HTML — Desktop-Fassung und
+    Handy-Fassung stammen aus demselben _render_html_table-Aufruf und sind
+    byte-gleich, nur die Wrapper-Divs unterscheiden sich. Ohne Dedup fiel
+    jede Spalten-SUMME exakt doppelt aus (Beleg: Pill 552 min vs. "Tabelle"
+    1104 min). Echte Mehr-Etappen-Tabellen unterscheiden sich immer in den
+    Zeitzellen und summieren unverändert.
     """
-    return _TABLE_RE.findall(html)
+    seen: set[str] = set()
+    blocks: list[str] = []
+    for block in _TABLE_RE.findall(html):
+        if block not in seen:
+            seen.add(block)
+            blocks.append(block)
+    return blocks
 
 
 def _mobile_header_tokens(html: str) -> list[str]:
@@ -229,6 +243,52 @@ def _column_hours_sum(html: str, *header_names: str) -> float | None:
     return total if found else None
 
 
+def _column_cells(html: str, *header_names: str) -> list[str]:
+    """Roh-Zelltexte (Tags gestrippt) der Spalte — für den Emoji-Pfad (#1432).
+
+    Gleiche Scoping-Regeln wie _column_values: pro (dedupliziertem)
+    <table>-Block, nur Zeilen mit passender Spaltenzahl.
+    """
+    cells: list[str] = []
+    for block in _table_blocks(html):
+        headers = _th_tokens(block)
+        idx = next((headers.index(h) for h in header_names if h in headers), None)
+        if idx is None:
+            continue
+        for row_html in _ROW_RE.findall(block):
+            row_cells = _TD_RE.findall(row_html)
+            if len(row_cells) != len(headers):
+                continue
+            cells.append(_strip_tags(row_cells[idx]))
+    return cells
+
+
+def _sun_capacity_minutes(html: str, *header_names: str) -> float | None:
+    """Obergrenze plausibler Sonnenminuten aus der Emoji-Sonne-Spalte (#1432).
+
+    Im Emoji-Modus trägt die Spalte keine 'X h'-Zahlen; exakt nachrechnen
+    lässt sich die Pill dann nicht. Was IMMER gilt: pro Stundenzeile höchstens
+    60 min Sonne. Zellen, die sicher (nahezu) keine Sonne bedeuten, senken
+    die Obergrenze — ☁️ heißt DNI<=0 (0 min; im DNI-losen Wolken-Fallback
+    <=6 min, daher 6), 🌙-Familie ist Nacht (0), '–'/'?' sind Leerwerte (0).
+    Alle übrigen Zellen (Sonnen- wie Niederschlags-Emojis — WMO-Codes können
+    sonnige DNI-Stunden überdecken) zählen konservativ mit 60 min.
+    None, wenn keine Sonne-Spalte gefunden wurde.
+    """
+    cells = _column_cells(html, *header_names)
+    if not cells:
+        return None
+    cap = 0.0
+    for cell in cells:
+        if cell in ("", "–", "-", "?") or cell.startswith("🌙"):
+            continue
+        if cell == "☁️":
+            cap += 6.0
+            continue
+        cap += 60.0
+    return cap
+
+
 def _column_num_sum(html: str, *header_names: str) -> float | None:
     """Summe numerischer Zellen der Spalte. None, wenn keiner der Header-Namen
     in irgendeiner Tabelle vorkommt.
@@ -281,7 +341,16 @@ def _check_metric_plausibility(html: str) -> list[str]:
         pill_min = int(m.group(1))
         sun_h = _column_hours_sum(html, "Sonne", "Sun")
         if sun_h is None:
-            continue  # Einfach-Modus (Emoji, keine Zahl) → überspringen
+            # Emoji-Modus (#1432): keine 'X h'-Zahlen — statt (wie früher)
+            # blind zu überspringen, greift die Obergrenzen-Prüfung: mehr
+            # Sonnenminuten als sonnenfähige Stundenzeilen kann es nicht geben.
+            cap = _sun_capacity_minutes(html, "Sonne", "Sun")
+            if cap is not None and pill_min > cap + _SONNE_TOL_MIN:
+                errors.append(
+                    f"FULL: Sonne-Widerspruch (Emoji-Modus) — Pill {pill_min} "
+                    f"min > Obergrenze {cap:.0f} min der Sonne-Spalte"
+                )
+            continue
         if abs(pill_min - sun_h * 60) > _SONNE_TOL_MIN:
             errors.append(
                 f"FULL: Sonne-Widerspruch — Pill {pill_min} min vs. Tabelle "

--- a/.github/ci_tdd_excludes.txt
+++ b/.github/ci_tdd_excludes.txt
@@ -20,7 +20,6 @@ tests/tdd/test_compare_sun_hours_full_day_window.py
 tests/tdd/test_corridor_migration.py
 tests/tdd/test_corridor_no_longer_triggers_alerts.py
 tests/tdd/test_day_comparison_service.py
-tests/tdd/test_dwd_eu_thunder_run_fallback.py
 tests/tdd/test_epic_140_preview_endpoints.py
 tests/tdd/test_feature_656_radar_nowcast.py
 tests/tdd/test_feature_660_convective_stage.py
@@ -47,7 +46,6 @@ tests/tdd/test_issue_833_gate.py
 tests/tdd/test_issue_883_acute_danger_override.py
 tests/tdd/test_issue_995_scheduler_pause.py
 tests/tdd/test_pytest_collection_and_timeout_safety.py
-tests/tdd/test_repo_path_hardcoding_ratchet.py
 tests/tdd/test_staging_gate.py
 tests/tdd/test_telegram_html_escaping.py
 tests/tdd/test_telegram_kurzstil_compare_official_alert.py

--- a/tests/tdd/test_765_backend_hygiene_compliance.py
+++ b/tests/tdd/test_765_backend_hygiene_compliance.py
@@ -84,21 +84,13 @@ _SELF_EXEMPT = {
     # den echten Guard auf (Sentinel statt SMTP) und haengt an keinem
     # Dateiinhalt. Spec: docs/specs/modules/fix_1412_s2a_regelwerk_paritaet.md
     "test_mail_recipient_parity.py",
-    # #1408 F005: KEIN Gate und KEINE Werkzeug-Klasse, sondern ein
-    # FEHLALARM der Heuristik oben — der Test liest ueberhaupt keinen
-    # Produkt-Quelltext. Seine `read_text()`-Ziele sind YAML-Protokolle unter
-    # `tmp_path`; die vier Produktpfade in `_GATE_CASES` sind reine NAMENS-
-    # Daten (der Test LEGT unter tmp_path gleichnamige Attrappen an und
-    # uebergibt den Namen an renderer_mail_gate). Weil ein `read_text()`-Ziel
-    # eine Schleifen-/Comprehension-Variable ist, erntet
-    # `_collect_listed_product_paths()` jedes Listen-/Tupel-Literal der Datei —
-    # auch solche, die gar keine Dateiliste sind. Die Heuristik gehoert
-    # praeziser gefasst (nur homogene Pfadlisten); das ist eine Aenderung AM
-    # GATE und bewusst nicht Teil dieser Lieferung (#1466 AP4, im Bericht
-    # benannt). Bis dahin steht die Datei hier — mit dem ausdruecklichen
-    # Vermerk, dass sie NICHT als Werkzeug-Klasse gilt.
-    "test_validator_log_unique_filenames.py",
 }
+# #1408 F005 / #1469: `test_validator_log_unique_filenames.py` stand hier als
+# ausdruecklicher FEHLALARM-Eintrag, weil `_collect_listed_product_paths()`
+# jedes Listen-/Tupel-Literal erntete. Seit die Heuristik nur homogene
+# Pfadlisten erntet, ist die Datei ohne Ausnahme konform — Eintrag entfernt,
+# damit ein echter Quelltext-Zugriff dort wieder gefangen wird
+# (Regressionstests: tests/unit/test_hygiene_gate_path_harvest.py).
 
 
 def _iter_test_files() -> list[Path]:
@@ -203,20 +195,31 @@ def _module_path_assignments(tree: ast.AST) -> dict:
 
 
 def _collect_listed_product_paths(tree: ast.AST) -> set[str]:
-    """Produkt-Pfade aus List-/Tuple-Literalen (z.B. `FILES = [REPO/"src/...", ...]`).
+    """Produkt-Pfade aus HOMOGENEN Pfadlisten (z.B. `FILES = [REPO/"src/...", ...]`).
 
     Deckt das `for f in FILES: f.read_text()`-Muster ab, bei dem das
     read_text-Ziel eine Schleifenvariable ist und nicht direkt auflösbar.
+
+    Geerntet wird ein List-/Tuple-Literal nur, wenn JEDES Element zu einem
+    existierenden Produkt-Pfad auflöst (#1469): Gemischte Literale — etwa
+    parametrize-Fälle, die Produktpfade als reine Namensdaten neben anderen
+    Werten führen — sind keine Dateilisten und lösten vorher Fehlalarme aus,
+    sobald irgendwo in der Datei ein nicht auflösbares read_text()-Ziel stand.
     """
     listed: set[str] = set()
     for node in ast.walk(tree):
-        if isinstance(node, (ast.List, ast.Tuple)):
-            for elt in node.elts:
-                segs = _flatten_path_expr(elt)
-                if segs:
-                    resolved = _resolve_product_path("/".join(segs))
-                    if resolved:
-                        listed.add(str(resolved.relative_to(_REPO)))
+        if not isinstance(node, (ast.List, ast.Tuple)) or not node.elts:
+            continue
+        resolved_elts: list[Path] = []
+        for elt in node.elts:
+            segs = _flatten_path_expr(elt)
+            resolved = _resolve_product_path("/".join(segs)) if segs else None
+            if resolved is None:
+                resolved_elts = []
+                break
+            resolved_elts.append(resolved)
+        for resolved in resolved_elts:
+            listed.add(str(resolved.relative_to(_REPO)))
     return listed
 
 

--- a/tests/unit/test_briefing_validator_sonne_plausibilitaet.py
+++ b/tests/unit/test_briefing_validator_sonne_plausibilitaet.py
@@ -1,0 +1,101 @@
+# doc-compliance-test
+"""Sonnen-Plausibilitaet des Briefing-Mail-Pruefers (#1432).
+
+Zwei Fehlerbilder, eine Ursache: Jede Stundentabelle steht doppelt im HTML
+(Desktop-Fassung + byte-identische Handy-Fassung aus demselben
+_render_html_table-Aufruf). Der Pruefer summierte ueber ALLE Tabellenbloecke:
+
+1. Roh-Modus: Summe exakt verdoppelt -> falscher Alarm bei korrekter Mail
+   (Beleg #1432: "Pill 552 min vs. Tabelle 1104 min", 1104 = 2 x 552).
+2. Emoji-Modus (Standardfall): Spalte ohne 'X h'-Zahlen -> Pruefung wurde
+   uebersprungen und hat faktisch nie etwas geprueft.
+
+Erwartung nach Fix: identische Tabellenbloecke werden dedupliziert (echte
+Mehr-Etappen-Tabellen mit unterschiedlichen Zeitzellen summieren weiter),
+und im Emoji-Modus greift eine Obergrenzen-Pruefung ueber die Sonne-Spalte.
+
+Prueft den PRUEFER (Werkzeug-Compliance), kein Produkt-Verhalten — daher
+``# doc-compliance-test``; die HTML-Prueflinge sind synthetisch.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_VALIDATOR = _HERE.parents[2] / ".claude" / "hooks" / "briefing_mail_validator.py"
+
+
+def _load_validator():
+    spec = importlib.util.spec_from_file_location("bmv1432", str(_VALIDATOR))
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _tbl(rows: list[tuple[str, str]]) -> str:
+    trs = "".join(f"<tr><td>{t}</td><td>{s}</td></tr>" for t, s in rows)
+    return (
+        "<table><tr><th>Zeit</th><th>Sonne</th></tr>" + trs + "</table>"
+    )
+
+
+def _mail(pill_min: int, desktop_tables: list[str]) -> str:
+    """Baut das Renderer-Muster nach: Pill + je Tabelle Desktop- UND
+    byte-identische Mobile-Fassung (nur anders gewickelt)."""
+    parts = [f"<span>Sonne {pill_min} min</span>"]
+    for tbl in desktop_tables:
+        parts.append('<div class="section desktop-only">' + tbl + "</div>")
+        parts.append(
+            '<div class="mobile-compact">'
+            '<div style="overflow-x:auto;">' + tbl + "</div></div>"
+        )
+    return "".join(parts)
+
+
+def test_doppelt_gerenderte_tabelle_zaehlt_einfach():
+    """Given Pill 552 min und eine 9.2-h-Tabelle in Desktop- UND
+    Mobile-Fassung / When der Pruefer die Plausibilitaet prueft / Then
+    meldet er KEINEN Widerspruch (#1432 Fall 1: vorher 1104 vs. 552)."""
+    v = _load_validator()
+    tbl = _tbl([("09:00", "4.6 h"), ("10:00", "4.6 h")])
+    errors = v._check_metric_plausibility(_mail(552, [tbl]))
+    assert errors == []
+
+
+def test_zwei_echte_etappen_summieren_weiter():
+    """Given zwei VERSCHIEDENE Etappen-Tabellen (andere Zeitzellen) mit je
+    4.6 h / When der Pruefer prueft / Then summiert er beide (Dedup frisst
+    keine echten Etappen): Pill 552 ist stimmig, Pill 300 widerspricht."""
+    v = _load_validator()
+    t1 = _tbl([("09:00", "2.3 h"), ("10:00", "2.3 h")])
+    t2 = _tbl([("13:00", "2.3 h"), ("14:00", "2.3 h")])
+    assert v._check_metric_plausibility(_mail(552, [t1, t2])) == []
+    errors = v._check_metric_plausibility(_mail(300, [t1, t2]))
+    assert len(errors) == 1 and "Sonne" in errors[0]
+
+
+def test_emoji_modus_obergrenze_greift():
+    """Given Pill 552 min, aber die Sonne-Spalte zeigt nur 4 Emoji-Stunden
+    (Obergrenze 240 min) / When der Pruefer prueft / Then schlaegt er an
+    (#1432 Fall 2: vorher blind uebersprungen)."""
+    v = _load_validator()
+    tbl = _tbl(
+        [("09:00", "☀️"), ("10:00", "🌤️"), ("11:00", "⛅"), ("12:00", "🌥️")]
+    )
+    errors = v._check_metric_plausibility(_mail(552, [tbl]))
+    assert len(errors) == 1 and "Sonne" in errors[0]
+
+
+def test_emoji_modus_plausible_pille_bleibt_stumm():
+    """Given Pill 180 min bei 8 sonnenfaehigen Emoji-Stunden plus Nacht-,
+    Wolken- und Leerzellen / When der Pruefer prueft / Then bleibt er stumm
+    (Nacht/dichte Wolken/Leer zaehlen nicht als Fehl-Obergrenze)."""
+    v = _load_validator()
+    tbl = _tbl(
+        [(f"{h:02d}:00", "☀️") for h in range(9, 17)]
+        + [("06:00", "☁️"), ("21:00", "🌙"), ("22:00", "–")]
+    )
+    errors = v._check_metric_plausibility(_mail(180, [tbl]))
+    assert errors == []

--- a/tests/unit/test_hygiene_gate_path_harvest.py
+++ b/tests/unit/test_hygiene_gate_path_harvest.py
@@ -1,0 +1,107 @@
+# doc-compliance-test
+"""Regressionstests fuer die Pfadlisten-Heuristik des Hygiene-Gates (#1469).
+
+Das Gate (tests/tdd/test_765_backend_hygiene_compliance.py) erntet Pfade aus
+Listen-/Tupel-Literalen nur, wenn das Literal eine HOMOGENE Produktpfad-Liste
+ist — jedes Element loest zu einem existierenden Produkt-``.py``/``.go`` auf.
+Vorher wurde jedes Literal der Datei geerntet, sobald irgendwo ein nicht
+aufloesbares ``read_text()``-Ziel existierte; dadurch galten reine Namensdaten
+(parametrize-Faelle wie in test_validator_log_unique_filenames.py) als
+Quelltext-Lektuere und die Datei musste per Ausnahmeeintrag stillgelegt
+werden (#1466 AP4 — das Loch, das dieses Ticket schliesst).
+
+Prueft die Gate-FUNKTIONEN (Werkzeug-Compliance), kein Produkt-Verhalten —
+daher ``# doc-compliance-test``. Die synthetischen Prueflinge entstehen unter
+``tmp_path``; Produktpfade kommen in dieser Datei bewusst NIE als homogenes
+Listen-Literal vor, damit das Gate diese Datei nicht selbst erntet.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_REPO = _HERE.parents[2]
+_GATE_FILE = _REPO / "tests" / "tdd" / "test_765_backend_hygiene_compliance.py"
+_NAMESDATA_FILE = (
+    _REPO / "tests" / "tdd" / "test_validator_log_unique_filenames.py"
+)
+
+
+def _load_gate():
+    spec = importlib.util.spec_from_file_location("hygiene_gate_765", _GATE_FILE)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_namensdaten_literal_wird_nicht_geerntet(tmp_path):
+    """Given eine Testdatei mit gemischtem parametrize-Literal (Namensdaten,
+    darunter ein echter Produktpfad) und einem read_text() ueber eine
+    Comprehension-Variable auf tmp-Protokolle / When das Gate sie prueft /
+    Then meldet es KEINE Produkt-Quelltext-Lektuere (#1469-Fehlalarm)."""
+    gate = _load_gate()
+    offender = tmp_path / "test_namensdaten.py"
+    offender.write_text(
+        "_CASES = [\n"
+        '    ("briefing_mail_validator.py", "src/app/models.py", {}),\n'
+        '    ("email_spec_validator.py", "src/app/trip.py", {"n": 3}),\n'
+        "]\n"
+        "def test_x(tmp_path):\n"
+        '    logs = [p for p in tmp_path.glob("*.yaml")]\n'
+        "    data = [p.read_text() for p in logs]\n",
+        encoding="utf-8",
+    )
+    assert gate._find_product_reads(offender) == []
+
+
+def test_homogene_produktpfadliste_wird_weiter_gefangen(tmp_path):
+    """Given eine Testdatei, die eine homogene Liste echter Produktpfade per
+    Schleifen-read_text() liest / When das Gate sie prueft / Then bleibt der
+    Verstoss gefangen (die Praezisierung reisst kein Loch)."""
+    gate = _load_gate()
+    offender = tmp_path / "test_quelltextleser.py"
+    offender.write_text(
+        "from pathlib import Path\n"
+        "_R = Path(__file__).resolve().parents[2]\n"
+        "FILES = [\n"
+        '    _R / "src" / "app" / "models.py",\n'
+        '    _R / "src" / "app" / "trip.py",\n'
+        "]\n"
+        "def test_y():\n"
+        "    for f in FILES:\n"
+        '        assert "class" in f.read_text(encoding="utf-8")\n',
+        encoding="utf-8",
+    )
+    expected = sorted("src/app/" + name for name in ("models.py", "trip.py"))
+    assert gate._find_product_reads(offender) == expected
+
+
+def test_namensdaten_datei_ist_ohne_ausnahmeeintrag_konform():
+    """Given die reale Namensdaten-Datei aus #1408/#1466 / When das Gate sie
+    direkt prueft / Then ist sie konform UND steht nicht mehr in _SELF_EXEMPT
+    (das Loch aus #1466 AP4 ist geschlossen)."""
+    gate = _load_gate()
+    assert gate._find_product_reads(_NAMESDATA_FILE) == []
+    assert _NAMESDATA_FILE.name not in gate._SELF_EXEMPT
+
+
+def test_echter_quelltextzugriff_wird_wieder_gefangen(tmp_path):
+    """Given dieselbe Namensdaten-Datei, ergaenzt um einen ECHTEN
+    Quelltext-Zugriff im Schleifen-Muster / When das Gate sie prueft / Then
+    schlaegt es an — die Gegenprobe aus #1469 Schritt 3."""
+    gate = _load_gate()
+    original = _NAMESDATA_FILE.read_text(encoding="utf-8")
+    mutated = tmp_path / _NAMESDATA_FILE.name
+    mutated.write_text(
+        original
+        + "\n\nfrom pathlib import Path as _P\n"
+        '_MUT = [_P(__file__).resolve().parents[3] / "src" / "app" / "models.py"]\n'
+        "def test_mutationsprobe():\n"
+        "    for f in _MUT:\n"
+        '        assert "class" in f.read_text(encoding="utf-8")\n',
+        encoding="utf-8",
+    )
+    hits = gate._find_product_reads(mutated)
+    assert hits == ["src/app/" + "models.py"]


### PR DESCRIPTION
Drei Tooling-/Test-Lieferungen aus der Backlog-Abarbeitung (PO-go 2026-08-05). Kein Produktcode berührt (`src/`-Änderung ist ausschließlich der Mail-**Prüfer**-Hook unter `.claude/hooks/`) — Doku-/Tooling-Ausnahme des Liefer-Workflows greift.

## #1469 — Hygiene-Gate erntet nur noch homogene Produktpfad-Listen

`_collect_listed_product_paths()` in `tests/tdd/test_765_backend_hygiene_compliance.py` erntete **jedes** Listen-/Tupel-Literal der Datei, sobald irgendwo ein nicht auflösbares `read_text()`-Ziel stand — reine Namensdaten (parametrize-Fälle) galten damit als Quelltext-Lektüre. Jetzt wird ein Literal nur geerntet, wenn **jedes** Element zu einem existierenden Produktpfad auflöst.

- Fehlalarm-Ausnahmeeintrag für `test_validator_log_unique_filenames.py` (#1466 AP4) **entfernt** — das dort dokumentierte Loch ist zu: ein echter Quelltext-Zugriff in der Datei wird wieder gefangen (als Dauertest verankert).
- Regressionstests inkl. Gegenprobe: `tests/unit/test_hygiene_gate_path_harvest.py` (4 Tests, RED vor Fix).

## #1432 — Mail-Prüfer: Sonnenstunden einfach zählen, Emoji-Modus prüfen

Desktop- und Handy-Fassung jeder Stundentabelle sind byte-identische Ausgaben desselben `_render_html_table`-Aufrufs — der Prüfer summierte beide (Beleg aus dem Issue: Pill 552 min vs. „Tabelle" 1104 min = exakt 2×). `_table_blocks` dedupliziert jetzt byte-gleiche Blöcke; echte Mehr-Etappen-Tabellen summieren unverändert (Testfall).

Im Emoji-Standardmodus wurde die Prüfung bisher still übersprungen („Gate ohne Fangwirkung"). Neu: Obergrenzen-Prüfung — höchstens 60 min je sonnenfähiger Stundenzeile (☁️ 6 min, 🌙/Leerwerte 0; Niederschlags-Emojis zählen konservativ mit, weil WMO-Codes sonnige DNI-Stunden überdecken können).

- Tests: `tests/unit/test_briefing_validator_sonne_plausibilitaet.py` (4 Tests, RED vor Fix). Die 3 vorbestehenden Roten in `tests/tdd/test_issue_733_briefing_mail_validator.py` (Ausschlussliste) sind vor/nach identisch — nicht von diesem PR.

## #1196 — tdd-Ratsche: 50 → 48

`test_dwd_eu_thunder_run_fallback.py` und `test_repo_path_hardcoding_ratchet.py` sind mit CI-Flags (`--disable-socket --allow-unix-socket --allow-hosts=localhost`) grün nachgemessen (voller Lauf 2026-08-05) — Zeilen entfernt, beide laufen ab jetzt auf CI.

Messbericht der Kernsuite-Vollvermessung (#1495) folgt als Kommentar in #1196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrmdarWn7RjtQ3q3rCumn6

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrmdarWn7RjtQ3q3rCumn6)_