### PR TITLE
fix(#1364): get_data_dir() prüft user_id zentral — Pfadausbruch geschlossen

### DIFF
--- a/api/routers/gpx.py
+++ b/api/routers/gpx.py
@@ -4,7 +4,6 @@ Auth: user_id-Query-Param wird vom Go-Proxy aus der Session injiziert (Bug #1352
 Upload-Ziel ist user-scoped (`data/users/<user>/gpx/`), damit gilt: Uploads
 verschiedener Nutzer können sich nicht gegenseitig überschreiben.
 """
-import re
 from datetime import date
 from typing import Optional
 
@@ -13,11 +12,11 @@ from fastapi import APIRouter, File, HTTPException, Query, UploadFile
 router = APIRouter()
 
 # Zweite Verteidigungslinie hinter dem Go-Proxy (Bug #1352): der Proxy verwirft
-# client-gesetzte user_id-Werte und injiziert die Session-Kennung. Wird der
-# Python-Core direkt erreicht, verhindert dieses Muster -- identisch zu dem, das
-# die Go-Registrierung erzwingt (internal/handler/passkey.go) -- einen Ausbruch
-# aus dem eigenen Nutzerordner ueber Pfadanteile wie ``../users/bob``.
-_VALID_USER_ID = re.compile(r"^[a-zA-Z0-9_-]+$")
+# client-gesetzte user_id-Werte und injiziert die Session-Kennung. Seit #1364
+# prueft get_data_dir() zentral (und wirft ValueError); die Vorab-Pruefung hier
+# bleibt bewusst stehen, damit der Endpoint sauber HTTP 400 statt 500 liefert.
+# Muster-Quelle ist app.loader.VALID_USER_ID_RE (synchron zu
+# internal/handler/passkey.go) — keine lokale Kopie mehr.
 
 
 @router.post("/api/gpx/parse")
@@ -27,11 +26,11 @@ async def parse_gpx(
     stage_date: Optional[date] = Query(None),
     start_hour: int = Query(8, ge=0, le=23),
 ):
-    from app.loader import get_data_dir
+    from app.loader import VALID_USER_ID_RE, get_data_dir
     from services.gpx_processing import gpx_to_stage_data
 
     # Vor jedem Pfadbau und vor jedem Schreibzugriff pruefen.
-    if not _VALID_USER_ID.match(user_id):
+    if not VALID_USER_ID_RE.match(user_id):
         raise HTTPException(status_code=400, detail="invalid_user_id")
 
     content = await file.read()

--- a/src/app/loader.py
+++ b/src/app/loader.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+import re
 import uuid
 from datetime import date
 from pathlib import Path
@@ -1059,13 +1060,28 @@ def get_data_root() -> Path:
     return Path(_root) if _root else Path("data")
 
 
+# Issue #1364: kanonisches Zulassungsmuster fuer Nutzer-Kennungen im
+# Python-Core. MUSS synchron bleiben mit der Go-Registrierung
+# (internal/handler/passkey.go, validUsernameRe) — Paritaets-Test:
+# tests/unit/test_user_id_pattern_parity.py. Zweite Verteidigungslinie
+# hinter dem Go-Proxy (der injiziert die Session-Kennung, proxy.go).
+VALID_USER_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
 def get_data_dir(user_id: str = "default") -> Path:
     """Get the data directory for a user.
 
     Honors the module-level ``_DATA_ROOT`` override (used in tests) and,
     as a fallback, the ``GZ_DATA_DIR`` environment variable (Issue #1133).
     Priority: ``_DATA_ROOT`` > ``GZ_DATA_DIR`` > default ``data/users``.
+
+    Issue #1364: rejects any ``user_id`` that is not a plain directory name
+    (pattern above). Ohne Pruefung verliess der Pfad per ``../users/bob``
+    das eigene Nutzerverzeichnis — am GPX-Endpoint praktisch vorgefuehrt
+    (#1352). Zentral hier, damit alle Aufrufer gedeckt sind.
     """
+    if not VALID_USER_ID_RE.match(user_id):
+        raise ValueError(f"invalid user_id: {user_id!r}")
     return get_data_root() / "users" / user_id
 
 

--- a/tests/tdd/test_765_backend_hygiene_compliance.py
+++ b/tests/tdd/test_765_backend_hygiene_compliance.py
@@ -76,6 +76,12 @@ _SELF_EXEMPT = {
     # Kernlauf); geprueft wird Deckungsgleichheit zweier Listen, nicht das
     # Vorkommen eines Code-Strings. Spec: docs/specs/modules/egress_guard_go.md
     "test_egress_inventory_drift.py",
+    # #1364: user_id-Muster-Paritaet Python <-> Go. Liest
+    # internal/handler/passkey.go als DATEN, um das Go-Registrierungsmuster
+    # gegen app.loader.VALID_USER_ID_RE zu stellen (Go aus Python nur als
+    # Text erreichbar) — gleiche Werkzeug-Klasse wie
+    # test_egress_inventory_drift.py; # doc-compliance-test.
+    "test_user_id_pattern_parity.py",
     # #1412 S2a: Empfaenger-Regelwerk-Paritaet Python <-> Go. Zwei
     # Strukturregeln auf Quelltext-als-Daten — die Konstantenmengen aus
     # internal/mail/sender.go (Go aus Python nur als Text erreichbar) und eine

--- a/tests/unit/test_user_data_dir_isolation.py
+++ b/tests/unit/test_user_data_dir_isolation.py
@@ -1,0 +1,65 @@
+"""Zentrale user_id-Pruefung in get_data_dir() (#1364, Mandanten-Trennung).
+
+Adversary-Beleg aus #1352: user_id="../users/bob" schrieb byte-genau in
+bobs echten Ordner. Der GPX-Endpoint wurde lokal geflickt; die uebrigen
+~27 Aufrufer von get_data_dir() blieben ungeprueft. Erwartung: get_data_dir()
+weist jede user_id zurueck, die kein brauchbarer Ordnername ist — zentral,
+damit alle Aufrufer gedeckt sind (ADR-0003: Isolation haengt nicht an einer
+einzigen Schicht).
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.loader import get_data_dir, get_data_root, get_locations_dir
+
+
+@pytest.mark.parametrize(
+    "malicious",
+    [
+        "../users/bob",
+        "../../../tmp",
+        "a/b",
+        "a\\b",
+        "",
+        ".",
+        "..",
+        "a b",
+        "a\x00b",
+        "/etc",
+        "bob@example.com",
+    ],
+)
+def test_pfadanteile_und_unbrauchbare_kennungen_werden_zurueckgewiesen(malicious):
+    """Given eine user_id mit Pfadanteilen oder Sonderzeichen / When
+    get_data_dir sie aufloesen soll / Then ValueError statt Pfadausbruch."""
+    with pytest.raises(ValueError):
+        get_data_dir(malicious)
+
+
+@pytest.mark.parametrize(
+    "real_id", ["default", "henning", "steffi", "validator-issue110", "A_b-2"]
+)
+def test_reale_kennungen_bleiben_zugelassen(real_id):
+    """Given die real existierenden Kennungen aus #1364 / When get_data_dir
+    aufloest / Then liegt der Pfad unter <root>/users/<id> (niemand wird
+    ausgesperrt)."""
+    p = get_data_dir(real_id)
+    assert p == get_data_root() / "users" / real_id
+    resolved = p.resolve()
+    assert resolved.name == real_id
+    assert resolved.parent.name == "users"
+
+
+def test_abgeleitete_verzeichnisse_sind_mitgedeckt():
+    """Given ein Aufrufer nutzt einen abgeleiteten Helfer statt get_data_dir
+    direkt / When die user_id Pfadanteile traegt / Then greift die zentrale
+    Pruefung auch dort (ein Chokepoint, keine 27 Einzel-Flicken)."""
+    with pytest.raises(ValueError):
+        get_locations_dir("../users/bob")
+
+
+def test_default_aufruf_ohne_argument_funktioniert():
+    """Given der parameterlose Bestandsaufruf / When get_data_dir() laeuft /
+    Then Standard-Kennung 'default' wie bisher."""
+    assert get_data_dir().name == "default"

--- a/tests/unit/test_user_id_pattern_parity.py
+++ b/tests/unit/test_user_id_pattern_parity.py
@@ -1,0 +1,35 @@
+# doc-compliance-test
+"""user_id-Muster-Paritaet Python <-> Go (#1364).
+
+Das Zulassungsmuster fuer Nutzer-Kennungen existiert zweimal: in der
+Go-Registrierung (internal/handler/passkey.go, erzwingt es beim Anlegen)
+und im Python-Core (app.loader.VALID_USER_ID_RE, erzwingt es beim
+Pfadbau). Driften beide, sperrt Python real registrierte Nutzer aus oder
+laesst Kennungen durch, die Go nie vergeben haette.
+
+Strukturregel auf Quelltext-als-Daten: das Go-Muster ist aus Python nur
+als Text erreichbar (kein Go-Toolchain-Aufruf im Kernlauf) — gleiche
+Werkzeug-Klasse wie test_egress_inventory_drift.py (#1337) und
+test_mail_recipient_parity.py (#1412); daher ``# doc-compliance-test``.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from app.loader import VALID_USER_ID_RE
+
+_REPO = Path(__file__).resolve().parents[2]
+_PASSKEY_GO = _REPO / "internal" / "handler" / "passkey.go"
+
+
+def test_python_muster_ist_deckungsgleich_mit_go():
+    """Given das Go-Registrierungsmuster in passkey.go / When das Python-
+    Muster daneben gelegt wird / Then sind beide identisch (#1364:
+    'beide Stellen gehoeren zusammen')."""
+    go_src = _PASSKEY_GO.read_text(encoding="utf-8")
+    m = re.search(
+        r"validUsernameRe\s*=\s*regexp\.MustCompile\(`([^`]+)`\)", go_src
+    )
+    assert m, "validUsernameRe nicht in passkey.go gefunden — Muster verschoben?"
+    assert VALID_USER_ID_RE.pattern == m.group(1)


### PR DESCRIPTION
Schließt den Adversary-Befund F001 aus #1352: `user_id="../users/bob"` schrieb byte-genau in bobs echten Ordner. Bisher war nur der GPX-Endpoint lokal geflickt — die übrigen ~27 Aufrufer von `get_data_dir()` blieben ungeprüft und die Isolation hing vollständig an der Go-Schicht (ADR-0003 verlangt mehr als eine Verteidigungslinie).

## Änderung

- **`src/app/loader.py`:** `get_data_dir()` validiert `user_id` am Chokepoint gegen `^[a-zA-Z0-9_-]+$` und wirft `ValueError` bei Pfadanteilen, Leerstring, Nullbytes, Sonderzeichen. Damit sind alle Aufrufer gedeckt (Scheduler, Alarme, Throttling, Nutzerprofile, abgeleitete Helfer wie `get_locations_dir`) — zentral statt 27 Einzel-Flicken.
- **`api/routers/gpx.py`:** nutzt das kanonische `VALID_USER_ID_RE` aus `app.loader` statt einer eigenen Musterkopie. Die Vorab-Prüfung bleibt bewusst als zweite Linie stehen (sauberes HTTP 400 statt 500) — die im Issue geforderte Entscheidung, dokumentiert im Code-Kommentar.
- **Muster-Parität Python ↔ Go:** `tests/unit/test_user_id_pattern_parity.py` stellt das Python-Muster dauerhaft gegen `validUsernameRe` aus `internal/handler/passkey.go` (gleiche Werkzeug-Klasse wie `test_egress_inventory_drift.py`, entsprechender Hygiene-Gate-Eintrag mit Begründung).

## Nachweise

- **RED vor Fix:** 12 rote Tests (`tests/unit/test_user_data_dir_isolation.py`) — Traversal `../users/bob`, `../../../tmp`, `a/b`, Leerstring, Nullbyte, `bob@example.com` u.a. liefen ungehindert durch.
- **Keine Aussperrung:** alle real existierenden Kennungen aus dem Issue (`default`, `henning`, `steffi`, `validator-issue110`) sind testverankert zugelassen.
- **Bestand unberührt:** die 13 GPX-Isolationstests aus #1352 vor/nach identisch grün; Codebase-Survey fand keine einzige legitime `user_id`, die das Muster verletzt (einziger Nicht-Treffer ist der Angriffs-Repro selbst). Test-Isolation `_isolate_data_root` (#1133) greift an der Wurzel, nicht an der Kennung — unberührt.
- Voller CI-äquivalenter Lauf (Netz gesperrt, localhost erlaubt) läuft zusätzlich lokal als Blast-Radius-Kontrolle; die CI-Ampel dieses PRs ist der maßgebliche Nachweis.

Da Produktcode berührt ist (`src/`, `api/`), gilt der volle Liefer-Workflow: nach Merge Staging-Auto-Deploy abwarten und validieren, bevor Prod deployt wird.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrmdarWn7RjtQ3q3rCumn6

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrmdarWn7RjtQ3q3rCumn6)_