### PR TITLE
feat(#1461) S3b-1: Briefing zeigt, welche Alarme einen Kanal nicht erreicht haben (+ fix #1432: Gate-Testmail)

### DIFF
--- a/docs/context/feat-1461-s3b1-briefing-sichtbarkeit.md
+++ b/docs/context/feat-1461-s3b1-briefing-sichtbarkeit.md
@@ -1,0 +1,265 @@
+# Context: feat-1461-s3b1-briefing-sichtbarkeit
+
+**Issue:** #1461 (Epic #1458, Scheibe S3) — Teilscheibe **S3b-1**
+**Vorgänger:** S3a live (`cf7d8fc0`), #1503 live (`61165987`), #1459 (Protokoll) live
+**Nachfolger:** S3b-2 — die einstellbare Dringlichkeits-Schwelle je Kanal
+
+## Request Summary
+
+Das Briefing soll zeigen, welche Alarme einen Kanal **nicht** erreicht haben. Das ist
+Pflicht 2 aus #1461 („was ein Kanal nicht bekommen hat, wird protokolliert **und im nächsten
+Briefing sichtbar**") und die Voraussetzung dafür, dass S3b-2 keine Meldungen still
+verschwinden lässt (rote Linie #638).
+
+## Der Befund, der die Scheibe begründet
+
+Das Alarm-Protokoll aus #1459 hat **sechs Schreibstellen und null Leser** auf der
+Python-Seite — gemessen:
+
+| Schreibstelle | Datei:Zeile | Auslöser |
+|---|---|---|
+| Trip / Vorhersage-Änderung | `src/services/trip_alert.py:278` | `REASON_FORECAST_CHANGE` |
+| Trip / Radar-Nowcast | `src/services/trip_alert.py:877` | `REASON_NOWCAST` |
+| Trip / amtliche Warnung | `src/services/trip_alert.py:1150` | `REASON_OFFICIAL_ALERT` |
+| Compare / Vorhersage-Änderung | `src/services/compare_alert.py:192` | `REASON_FORECAST_CHANGE` |
+| Compare / Radar | `src/services/compare_radar_alert.py` | `REASON_NOWCAST` |
+| Compare / amtliche Warnung | `src/services/compare_official_alert.py:150` | `REASON_OFFICIAL_ALERT` |
+
+Gelesen wird es ausschließlich von **Go** (`internal/store/log.go`) für die Cockpit-Kachel
+und die Archiv-Statistik — und zwar **nur** der Schlüssel `entries`, **nie** `not_delivered`
+(Zusicherung D4 aus #1459). Kein Renderer, kein Scheduler, keine Mail liest das Protokoll.
+
+## Datenlage: was im Protokoll steht
+
+`src/services/alert_log.py` — Read-Modify-Write über die volle Datei
+`data/users/<user_id>/alert_log.json`. Zwei Top-Level-Schlüssel:
+
+* **`entries`** — mindestens ein Kanal war **erreichbar**. Enthält pro Eintrag
+  `channels_sent` (Liste) und `channels_not_sent` (Liste aus `{channel, reason}`).
+* **`not_delivered`** — **kein** Kanal erreichbar. Für Go unsichtbar (D4).
+
+Pro Eintrag außerdem: `entity_id` + `entity_type` (`"trip"`|`"compare"`, seit #1467 S1
+genau EINE Kennung), `sent_at` (UTC-ISO), `changes_count`, `severity`, `metrics`
+(Register-Paare), `hazards`, `reason`.
+
+Gründe einer Nicht-Zustellung (`alert_log.py:44-48`), bewusst freie Strings, damit
+S3b-2 additiv „unter der Kanal-Schwelle" ergänzen kann:
+`channel_disabled` · `delivery_failed` · `quiet_hours` · `daily_limit` · `cooldown`.
+**Gemessen: nur die ersten beiden werden heute von einem Aufrufer gesetzt** —
+`quiet_hours`/`daily_limit`/`cooldown` sind dokumentiert, aber tot (O3 aus #1459: zum
+Gate-Zeitpunkt ist der Auslöser noch nicht bekannt).
+
+⇒ **Zwei Quellen für „hat einen Kanal nicht erreicht":** `channels_not_sent` innerhalb von
+`entries` (Teilausfall) **und** die ganzen Einträge in `not_delivered` (Totalausfall).
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/alert_log.py` | Schreibfunktion + Schema; hier gehört die neue **Lesefunktion** hin (kein neuer präfigierter Renderer → Pendant-Sperre #1481 B) |
+| `src/services/alert_briefing_anchor.py` | **Die Naht „nächstes Briefing"** — schreibt den Δ-Anker und leert das Melde-Gedächtnis. Wird von Trip **und** Compare gerufen; `on_demand=True` ⇒ passiert nichts |
+| `src/services/notification_service.py` | Baut das Trip-Briefing (`TripReportFormatter`, Z.263) und ruft alle Kanäle (`effective_channels`, Z.467ff) |
+| `src/services/trip_report_scheduler.py` | Der Auslöser des geplanten Briefings; `_reset_alert_state_after_briefing` delegiert an den Anker-Baustein |
+| `src/output/renderers/email/__init__.py:34` | `render_email()` — **reine Funktion**, „identical inputs → bit-identical output". Neue Daten müssen als kwarg hereingereicht werden, der Renderer darf nichts nachladen |
+| `src/output/renderers/email/html.py`, `plain.py`, `compact.py` | Die drei Trip-Mail-Ausgaben (HTML full, Klartext, compact) |
+| `src/output/renderers/narrow.py`, `sms_trip.py` | Telegram-Kurzform / SMS — 160 Zeichen, hier passt allenfalls eine Zahl |
+| `src/output/renderers/email/compare_html.py` | Ortsvergleichs-Mail |
+| `src/output/renderers/email/unavailable_hint.py` | **Das Vorbild**: kleiner Briefing-Hinweisblock, HTML + Klartext + Telegram, an vier Stellen eingebunden, bewusst NICHT unter `renderers/alert/` abgelegt, damit das Warn-Renderer-Gate unberührt bleibt |
+| `src/output/renderers/email/outlook_state_hint.py` | Zweites Exemplar derselben Bauart (#1349) — DRY-Vorbild |
+| `internal/store/log.go` | Go-Leser; `AlertCountByEntity()` zählt **Einträge**, nicht Kanäle (D1) |
+
+## Existing Patterns
+
+1. **Hinweisblock im Briefing** (`unavailable_hint.py`, `outlook_state_hint.py`): ein Modul mit
+   (a) einer Prüffunktion auf den Daten, (b) `…_html()`, (c) `…_plain()`; eingebunden in
+   `html.py`, `plain.py`, `compact.py`, `narrow.py` und `compare_html.py`. Genau der Zuschnitt,
+   den S3b-1 braucht.
+2. **Geteilter Baustein statt zwei Zweigen** (`alert_briefing_anchor.py`, `alert_log.py`,
+   `alert_urgency.py` aus S3a): ein Modul in `src/services/`, von Trip- und Compare-Pfad
+   gleichermaßen gerufen. PO-Vorgabe wörtlich: „Verwende zwingend den gleichen Code."
+3. **Renderer bleibt rein**: Domänenwerte rechnet der Aufrufer (`TripReportFormatter`), der
+   Renderer bekommt sie als expliziten kwarg (Spec §A1+§A5+§A6).
+4. **Fail-soft beim Lesen**: `alert_log.append_entry()` fängt kaputte Dateien ab und macht
+   weiter — eine unlesbare Protokolldatei darf ein Briefing nicht verhindern.
+
+## Dependencies
+
+* **Upstream** (was wir lesen): `alert_log.json` je Nutzer über `app.loader.get_data_dir()`;
+  `app.metric_catalog` für sprechende Namen der Register-Paare; `output.metric_format` für
+  ordinale Größen (nie roh — s. #1503/#1474).
+* **Downstream** (was auf uns aufbaut): S3b-2 (die Schwelle) hängt an dieser Sichtbarkeit;
+  der neue Grund „unter der Kanal-Schwelle" kommt dort additiv dazu.
+
+## Existing Specs
+
+| Spec | Inhalt |
+|---|---|
+| `docs/specs/modules/feat_1459_alert_protokoll.md` | Schema, D1/D4, O1–O3 |
+| `docs/specs/modules/feat_1461_s3a_alarm_dringlichkeit.md` | Einstufung (v1.4, 16 ACs) |
+| `docs/specs/modules/fix_1503_delta_dringlichkeit.md` | Δ-Einstufung, ordinale Sonderbehandlung |
+| `docs/specs/modules/rework_1467_s1_alarm_kennung.md` | `entity_id`/`entity_type` |
+| `docs/specs/modules/rework_1467_s2_aenderungsalarm.md` | AG5 = Briefing-Anker |
+| `docs/specs/modules/output_channel_renderers.md` | §A1/§A5/§A6 — Renderer-Reinheit |
+
+## Risks & Considerations
+
+1. **🔴 Doppelzählung.** Treffen Vorhersage-Änderung, amtliche Warnung und ein kompletter
+   Versandausfall zusammen, entstehen **zwei** `not_delivered`-Einträge für **eine**
+   Nutzer-Meldung (drei getrennte `append_entry`-Aufrufe im selben Lauf). Wer zählt, zählt
+   doppelt. Entweder je Meldung entdoppeln (`sent_at` + `entity_id` + `reason`) oder den
+   Pfad mitbereinigen. Vom PO in #1461 (Kommentar 2026-08-02) ausdrücklich dieser Scheibe
+   zugewiesen. Die im Kommentar genannten Zeilen `trip_alert.py:526-536` sind **veraltet** —
+   der Code ist seither verschoben; die Fundstelle ist über die drei `append_entry`-Aufrufe
+   zu bestimmen, nicht über die Zeilennummer.
+2. **Zeitraum unbestimmt.** „Seit dem letzten Briefing" hat heute **keinen gespeicherten
+   Anker**: es gibt `throttle_store.last_sent()` (Alarm-Drossel, nicht Briefing) und den
+   Δ-Anker (Wetterwerte, kein Zeitstempel je Trip). Muss in der Analyse entschieden werden —
+   Kandidaten: Zeitstempel beim Anker-Schreiben mitführen, oder fester Rückblick.
+3. **Renderer-Commit-Gate (#811)** greift, sobald `email/*.py`, `trip_report.py`,
+   `compact_summary.py`, `sms_trip.py` oder `channels/email.py` angefasst werden: verlangt
+   `tests/tdd/test_issue_811_mode_matrix.py` grün **plus** frischen
+   `briefing_mail_validator.py`-Lauf gegen eine echt zugestellte Staging-Mail.
+4. **Pendant-Sperre (#1481 B):** keine neu angelegte Datei unter
+   `frontend/src/lib/components/{compare,compare-new,trip-detail,trip-new}/**` und kein neuer
+   Renderer mit `compare_`/`trip_`-Präfix. Der geteilte Baustein gehört nach `src/services/`
+   bzw. — für den Darstellungsteil — neben `unavailable_hint.py`.
+5. **D4 muss halten:** Cockpit-Kachel und Archiv-Statistik dürfen sich um **keine Zahl**
+   ändern. Sie lesen `entries`; `not_delivered` bleibt für Go unsichtbar. Reines Lesen ist
+   dafür unkritisch — sobald aber entdoppelt/umgeschrieben wird, ist es die Hauptgefahr.
+6. **Mandantentrennung:** `alert_log.json` liegt je Nutzer; die Lesefunktion braucht die echte
+   `user_id`, nie `"default"`. Mit **zwei** Nutzern zu testen.
+7. **SMS/Telegram-Enge:** Die Kurznachricht nennt keinen Ort und hat 160 Zeichen — dort ist
+   höchstens eine Zahl unterzubringen, nicht die Liste.
+8. **Leerer Normalfall:** Der überwiegende Fall ist „alles zugestellt". Der Abschnitt darf dann
+   **nicht** erscheinen — sonst steht in jedem Briefing eine Null-Zeile.
+9. **Determinismus:** `render_email()` sichert bit-identische Ausgabe bei gleicher Eingabe zu.
+   Zeitstempel und „jetzt" müssen von außen hereingereicht werden.
+
+---
+
+# Analysis
+
+## Type
+
+**Feature** (Epic-Scheibe, kein Fehlverhalten im Bestand).
+
+## PO-Entscheidungen 2026-08-05
+
+| Frage | Entscheidung |
+|---|---|
+| Detailtiefe | **Je Meldung eine Zeile** — Zeitpunkt · worum es ging · welcher Kanal · warum. Gedeckelt, darunter „und N weitere" |
+| Umfang | **Beide Fälle** — Totalausfall *und* Teilausfall („E-Mail kam an, SMS nicht") |
+| Kanäle | **Nur E-Mail.** Telegram-Kurzform und SMS bleiben **unberührt** |
+
+Abgeleitete Routine-Entscheidungen (keine Rückfrage nötig, in der Spec festzuhalten):
+* E-Mail heißt **beide** Mail-Formate (`full` **und** `compact`) — beides sind E-Mails.
+* Trip **und** Ortsvergleich bekommen denselben Baustein (Teilungs-Gate, PO-Vorgabe
+  „Verwende zwingend den gleichen Code").
+
+## Technischer Ansatz
+
+**Drei Bausteine, keiner davon neu erfunden.**
+
+### 1. Lesen — `src/services/alert_log.py` (MODIFY)
+
+Neue reine Lesefunktion neben `append_entry()`. Liefert für **eine** Kennung
+(`entity_id` + `entity_type`) und einen Zeitraum die Meldungen, die mindestens einen Kanal
+nicht erreicht haben. Speist sich aus **beiden** Quellen:
+
+* `entries[*].channels_not_sent` — Teilausfall
+* `not_delivered[*]` — Totalausfall (dort ist per Definition **jeder** Kanal betroffen)
+
+Fail-soft wie die Schreibseite: unlesbare Datei ⇒ leeres Ergebnis + Warnung, nie eine
+Ausnahme ins Briefing.
+
+**Entdoppelung** (Risiko 1) an genau dieser Stelle: mehrere Einträge derselben Kennung mit
+demselben Zeitstempel-Fenster und **verschiedenem** `reason` sind **ein** Vorfall für den
+Nutzer, keine drei. Das Protokoll selbst bleibt unangetastet — es wird nur beim Lesen
+zusammengefasst. Damit bleibt D4 zwingend gewahrt: an `entries` und `not_delivered` wird
+nichts geschrieben, Cockpit-Zahl und Archiv-Statistik ändern sich um nichts.
+
+### 2. Zeitraum — `src/services/alert_briefing_anchor.py` (MODIFY)
+
+„Seit dem letzten Briefing" hat heute keinen Anker. Der **richtige Ort** ist der bestehende
+geteilte Baustein: er wird in **beiden** Pfaden **nach** dem Versand gerufen
+(`trip_report_scheduler.py:983`, `scheduler_dispatch_service.py:413`) und ist bereits die
+Definition von „ein Briefing ist rausgegangen". Dort zusätzlich einen Zeitstempel je Kennung
+fortschreiben; das Briefing liest **vorher** den alten Wert.
+
+Die Reihenfolge ist damit von selbst richtig — gerendert wird vor dem Fortschreiben. Ein
+`on_demand`-Abruf schreibt nichts fort (Bestandsverhalten, Issue #1007), zeigt den Hinweis
+aber trotzdem an.
+
+**🔴 Fallstrick, gemessen:** Der Anker-Baustein bekommt im Compare-Fall
+`entity_ids = [f"{preset_id}:{loc.id}", …]` (je Ort), das **Protokoll** schreibt dagegen
+`entity_id = preset_id` (`compare_alert.py:193`, `compare_official_alert.py:151`). Wer den
+Briefing-Zeitstempel unter den Anker-Kennungen ablegt, findet beim Lesen **nie** einen
+Treffer und zeigt dauerhaft einen leeren Hinweis. Die Kennung für den Zeitstempel muss die
+**Protokoll-Kennung** sein.
+
+Fehlt der Zeitstempel (erstes Briefing nach der Auslieferung, Bestandsnutzer): kein
+Rückblick über unbestimmte Vergangenheit, sondern ab jetzt — sonst kippt beim ersten
+Briefing die gesamte Historie in die Mail.
+
+### 3. Anzeigen — `src/output/renderers/email/undelivered_hint.py` (CREATE)
+
+Bauform 1:1 nach `unavailable_hint.py` (#1348) und `outlook_state_hint.py` (#1349): ein
+Modul mit einer HTML- und einer Klartext-Fassung, eingebunden in `html.py`, `plain.py`,
+`compact.py` und `compare_html.py`. Bewusst **nicht** unter `renderers/alert/` — es ist ein
+Briefing-Baustein, kein Alarm-Renderer; so bleibt das Warn-Renderer-Gate unberührt (die
+Begründung steht wörtlich im Kopf von `unavailable_hint.py`).
+
+Der Dateiname trägt **kein** `trip_`/`compare_`-Präfix ⇒ Pendant-Sperre (#1481 B) greift nicht.
+
+Hochkontrastig nach dem Design-Leitprinzip (Token `G_BOX_DANGER_BG`/`G_DANGER`, **kein**
+`G_INK_FAINT`). Wettergrößen über `app.metric_catalog` in Klartext, ordinale Größen über
+`output.metric_format.thunder_ordinal()` — nie roh (#1503/#1474).
+
+**Leerer Normalfall ⇒ der Block erscheint gar nicht.** Kein „0 Meldungen".
+
+### Durchreichung
+
+`render_email()` sichert bit-identische Ausgabe bei gleicher Eingabe zu und darf nichts
+nachladen. Die geladenen Daten wandern deshalb als **expliziter kwarg** durch
+`notification_service` → `TripReportFormatter.format_email()` → `render_email()` (Muster
+§A1/§A5/§A6). Ohne den kwarg (Vorschau, Golden-Tests, CLI) verhält sich alles wie bisher.
+
+## Affected Files
+
+| Datei | Änderung | Inhalt |
+|---|---|---|
+| `src/services/alert_log.py` | MODIFY | Lesefunktion + Entdoppelung |
+| `src/services/alert_briefing_anchor.py` | MODIFY | Briefing-Zeitstempel je Protokoll-Kennung |
+| `src/output/renderers/email/undelivered_hint.py` | CREATE | HTML- + Klartext-Baustein |
+| `src/output/renderers/email/html.py` | MODIFY | Einbindung (Mail `full`) |
+| `src/output/renderers/email/plain.py` | MODIFY | Einbindung (Klartext) |
+| `src/output/renderers/email/compact.py` | MODIFY | Einbindung (Mail `compact`) |
+| `src/output/renderers/email/compare_html.py` | MODIFY | Einbindung (Ortsvergleich) |
+| `src/output/renderers/email/__init__.py` | MODIFY | kwarg durchreichen |
+| `src/output/renderers/trip_report.py` | MODIFY | kwarg durchreichen |
+| `src/services/notification_service.py` | MODIFY | Daten laden, echte `user_id` |
+| `src/services/scheduler_dispatch_service.py` | MODIFY | dito für den Ortsvergleich |
+| `tests/tdd/test_alert_undelivered_hint.py` | CREATE | Verhaltensnachweis |
+
+**Unberührt:** `narrow.py`, `sms_trip.py`, `compact_summary.py` (PO: Kurznachricht bleibt
+unberührt) · `internal/store/log.go` und die gesamte Go-Seite · das Frontend.
+
+## Scope Assessment
+
+* Dateien: **11 geändert, 2 neu**
+* Geschätzt: **~280–320 Zeilen inkl. Tests**
+* Risiko: **MEDIUM** — nur additive Anzeige, kein Eingriff in den Versand; die Gefahr liegt
+  in der Entdoppelung (D4) und in der Kennungs-Verwechslung beim Compare-Zeitstempel
+
+⚠️ **Die 250-Zeilen-Grenze je Arbeitsgang wird voraussichtlich gerissen.** Der Treiber ist
+nicht der Ortsvergleich (dessen Einbindung sind ~20 Zeilen, weil der Baustein geteilt ist),
+sondern die vier Einbindungsstellen plus die Testabdeckung. Ein Anheben der Grenze ist
+PO-Entscheidung und wird erst erfragt, wenn sie tatsächlich erreicht ist.
+
+## Open Questions
+
+- [x] Detailtiefe — beantwortet: je Meldung eine Zeile
+- [x] Umfang — beantwortet: beide Fälle
+- [x] Kanäle — beantwortet: nur E-Mail
+- [ ] Deckelung: bei wie vielen Zeilen abschneiden? (Vorschlag 5 — wird in der Spec
+      vorgelegt, keine eigene Rückfrage)

--- a/docs/specs/modules/feat_1461_s3b1_briefing_sichtbarkeit.md
+++ b/docs/specs/modules/feat_1461_s3b1_briefing_sichtbarkeit.md
@@ -1,0 +1,326 @@
+---
+entity_id: feat_1461_s3b1_briefing_sichtbarkeit
+type: module
+created: 2026-08-05
+updated: 2026-08-05
+status: draft
+version: "1.2"
+tags: [alerts, briefing, email, epic-1458, issue-1461]
+---
+
+# Briefing zeigt, welche Alarme nicht angekommen sind (#1461 S3b-1)
+
+## Approval
+
+- [x] Approved — PO, 2026-08-05 („go"). Deckelung bei 5 Zeilen ohne Widerspruch übernommen.
+  Beleg: Kommentar an Issue #1461.
+
+## Purpose
+
+Das Briefing weist am Ende aus, welche Alarm-Meldungen seit dem letzten Briefing einen Kanal
+**nicht** erreicht haben. Damit ist Pflicht 2 aus #1461 erfüllt („was ein Kanal nicht bekommen
+hat, wird protokolliert **und im nächsten Briefing sichtbar**") — die Voraussetzung dafür, dass
+die Kanal-Schwelle aus S3b-2 keine Meldung spurlos verschwinden lassen kann (rote Linie #638).
+
+Heute ist das unmöglich: das Alarm-Protokoll aus #1459 hat sechs Schreibstellen und **null
+Leser** auf der Python-Seite.
+
+## Source
+
+- **Datei (neu):** `src/output/renderers/email/undelivered_hint.py`
+- **Dateien (geändert):** `src/services/alert_log.py` ·
+  `src/services/alert_briefing_anchor.py` · `src/services/notification_service.py` ·
+  `src/services/scheduler_dispatch_service.py` · `src/output/renderers/trip_report.py` ·
+  `src/output/renderers/email/{__init__,html,plain,compact,compare_html}.py` ·
+  `src/output/renderers/comparison.py` (Klartext des Ortsvergleichs, v1.2)
+- **Schicht:** Python-Core (`src/services/`, `src/output/`). **Keine** Go-Änderung, **keine**
+  Frontend-Änderung.
+
+## Estimated Scope
+
+- **LoC:** ~280–320 inkl. Tests
+- **Files:** 11 geändert, 2 neu
+- **Effort:** medium
+
+**Korrektur v1.1 (gemessen):** Die Schätzung war deutlich zu niedrig. Allein die Testdatei
+`tests/tdd/test_alert_undelivered_hint.py` hat **1367 Zeilen** (23 Tests mit echten
+Protokolldateien, keine Attrappen). Produktivcode weiterhin ~300 Zeilen.
+
+**PO-Entscheid 2026-08-05:** Grenze für diesen Arbeitsgang auf **2000** angehoben
+(`loc_limit_override 2000`), Begründung: ~1400 der Zeilen sind Tests — also genau das, was die
+Änderung überprüfbar macht. Die Alternativen (Tests ausdünnen, nochmals teilen) wurden vorgelegt
+und verworfen.
+
+## Dependencies
+
+| Entity | Typ | Zweck |
+|---|---|---|
+| `feat_1459_alert_protokoll` | liest | Schema `entries` / `not_delivered`, Zusicherungen D1/D4 |
+| `rework_1467_s1_alarm_kennung` | liest | `entity_id` + `entity_type` als einzige Kennung |
+| `rework_1467_s2_aenderungsalarm` (AG5) | erweitert | `alert_briefing_anchor` = die Naht „ein Briefing ist raus" |
+| `feat_1461_s3a_alarm_dringlichkeit` | liest | `severity` je Eintrag |
+| `output_channel_renderers` §A1/§A5/§A6 | befolgt | Renderer bleibt rein, Daten kommen als kwarg |
+| `app.metric_catalog` | nutzt | Wettergrößen in Klartext |
+| `output.metric_format.thunder_ordinal()` | nutzt | ordinale Größen nie roh (#1503/#1474) |
+
+## Implementation Details
+
+### PO-Entscheidungen 2026-08-05
+
+| Frage | Entscheidung |
+|---|---|
+| Detailtiefe | je Meldung eine Zeile: Zeitpunkt · worum es ging · welcher Kanal · warum |
+| Umfang | **beide** Fälle — Totalausfall **und** Teilausfall („E-Mail kam an, SMS nicht") |
+| Kanäle | **nur E-Mail.** Telegram-Kurzform und SMS bleiben unberührt |
+| Deckelung | **5 Zeilen**, darunter „und N weitere" — *zur Freigabe vorgelegt* |
+
+Abgeleitet (Routine, keine Rückfrage): „E-Mail" heißt **beide** Mail-Formate (`full` und
+`compact`); Trip und Ortsvergleich bekommen **denselben** Baustein (Teilungs-Gate).
+
+### Drei Bausteine
+
+**1. Lesen** — neue reine Lesefunktion neben `append_entry()` in `alert_log.py`. Liefert für
+eine Kennung (`entity_id` + `entity_type`) ab einem Zeitpunkt die Meldungen, die mindestens
+einen Kanal nicht erreicht haben. Beide Quellen:
+
+* `entries[*].channels_not_sent` — Teilausfall
+* `not_delivered[*]` — Totalausfall (dort ist per Definition jeder Kanal betroffen)
+
+🔴 **Ein vom Nutzer abgeschalteter Kanal ist KEIN Vorfall** (v1.1, gemessen in der RED-Phase).
+`alert_log._channels_not_sent()` schreibt für **jeden** Kanal, der nicht in `effective_channels`
+steht, einen Eintrag mit Grund `channel_disabled` — bei **jedem erfolgreichen** Alarm. Ein
+Nutzer mit nur E-Mail hätte damit in jedem Eintrag zwei solche Einträge, und der Abschnitt
+stünde in **jedem** Briefing. Der Grund `channel_disabled` wird deshalb übersprungen; AC-3
+spricht ausdrücklich von „jedem **eingeschalteten** Kanal".
+
+Die Abgrenzung ist **`channel_disabled`**, nicht „nur `delivery_failed`": der in S3b-2
+hinzukommende Grund „unter der Kanal-Schwelle" ist ein gewolltes Stummschalten und MUSS
+erscheinen (Pflicht 1 des Issues) — ebenso `quiet_hours`, `daily_limit`, `cooldown`, sobald
+sie geschrieben werden.
+
+Fail-soft wie die Schreibseite: unlesbare Datei ⇒ leeres Ergebnis + Warnung, nie eine Ausnahme
+ins Briefing.
+
+**Entdoppelung beim LESEN, nicht im Protokoll.** Ein Lauf kann für **eine** Nutzer-Meldung bis
+zu drei Einträge erzeugen (Vorhersage-Änderung, Radar, amtliche Warnung sind drei getrennte
+`append_entry`-Aufrufe). Für den Nutzer ist das ein Vorfall. Zusammengefasst wird über
+Kennung + Zeitfenster; die betroffenen Kanäle und Gründe werden vereinigt. Am Protokoll selbst
+wird **nichts** geändert — dadurch bleibt D4 zwingend gewahrt.
+
+**2. Zeitraum** — `alert_briefing_anchor.write_anchor_and_reset_memory()` ist bereits die
+Definition von „ein Briefing ist rausgegangen" und wird in **beiden** Pfaden **nach** dem
+Versand gerufen (`trip_report_scheduler.py:983`, `scheduler_dispatch_service.py:413`). Dort
+zusätzlich einen Zeitstempel je Kennung fortschreiben. Das Briefing liest den alten Wert,
+bevor er überschrieben wird — die Reihenfolge stimmt von selbst.
+
+🔴 **Kennungs-Fallstrick, gemessen:** Der Anker-Baustein bekommt im Compare-Fall
+`entity_ids = [f"{preset_id}:{loc.id}", …]` (je Ort); das **Protokoll** schreibt dagegen
+`entity_id = preset_id` (`compare_alert.py:193`, `compare_official_alert.py:151`). Der
+Briefing-Zeitstempel MUSS unter der **Protokoll-Kennung** abgelegt werden — sonst findet die
+Lesefunktion nie einen Treffer und der Hinweis bleibt beim Ortsvergleich dauerhaft leer.
+
+Fehlt der Zeitstempel (erstes Briefing nach Auslieferung, Bestandsnutzer): Rückblick beginnt
+**ab jetzt**, nicht über die unbestimmte Vergangenheit.
+
+**3. Anzeigen** — `src/output/renderers/email/undelivered_hint.py`, Bauform 1:1 nach
+`unavailable_hint.py` (#1348) und `outlook_state_hint.py` (#1349): eine Prüffunktion, eine
+HTML-Fassung, eine Klartext-Fassung; eingebunden in `html.py`, `plain.py`, `compact.py`,
+`compare_html.py`. Bewusst **nicht** unter `renderers/alert/` — es ist ein Briefing-Baustein,
+kein Alarm-Renderer (Begründung wörtlich im Kopf von `unavailable_hint.py`); so bleibt das
+Warn-Renderer-Gate unberührt. Kein `trip_`/`compare_`-Präfix ⇒ Pendant-Sperre (#1481 B)
+greift nicht.
+
+Hochkontrastig nach Design-Leitprinzip (`G_BOX_DANGER_BG`/`G_DANGER`, **kein** `G_INK_FAINT`).
+
+**Durchreichung:** `render_email()` sichert bit-identische Ausgabe bei gleicher Eingabe zu und
+darf nichts nachladen. Die Daten wandern als expliziter kwarg durch `notification_service` →
+`TripReportFormatter.format_email()` → `render_email()`. Ohne kwarg (Vorschau, Golden-Tests,
+CLI) verhält sich alles wie bisher.
+
+### Beispiel-Ausgabe (Klartext)
+
+```
+NICHT BEI DIR ANGEKOMMEN
+
+  04.08. 18:42 · Gewitter · SMS nicht zugestellt
+  04.08. 06:15 · Wind · SMS nicht zugestellt
+  05.08. 05:30 · Amtliche Warnung · SMS, Telegram nicht zugestellt
+  … und 2 weitere
+```
+
+Zeitform `TT.MM. HH:MM` statt „Gestern/Heute" (v1.2, Begründung aus der GREEN-Phase): „Gestern"
+hinge vom Erzeugungszeitpunkt ab und bräche damit die Reinheit des Renderers — gleiche Eingabe
+müsste sonst nicht mehr die gleiche Ausgabe liefern. Zusätzlich verlangt AC-15, dass außer dem
+Zeitstempel keine Ziffer in der Zeile steht; ein Wortpräfix macht diese Prüfung mehrdeutig.
+
+## Expected Behavior
+
+- **Input:** Alarm-Protokoll des Nutzers (`data/users/<user_id>/alert_log.json`), die Kennung
+  des Trips bzw. Presets, der Zeitpunkt des letzten Briefings, die Zeitzone des Briefings.
+- **Output:** Ein Abschnitt in HTML- und Klartext-E-Mail (Trip `full`, Trip `compact`,
+  Ortsvergleich) — **oder gar nichts**, wenn nichts fehlt.
+- **Side effects:** Ein Zeitstempel je Kennung wird nach dem Versand fortgeschrieben. Am
+  Alarm-Protokoll (`entries`, `not_delivered`) wird nichts geändert. Am Versandverhalten wird
+  nichts geändert.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Alarm wurde per E-Mail zugestellt, erreichte aber die SMS nicht /
+  When das nächste Briefing des Trips erzeugt wird / Then enthält die Briefing-Mail eine
+  Zeile, die den Zeitpunkt in der Zeitzone des Briefings, die betroffene Wettergröße, den
+  Kanal „SMS" und den Grund nennt.
+  - Test: Protokoll mit einem Eintrag `channels_not_sent=[{sms, delivery_failed}]` anlegen,
+    Briefing rendern, alle vier Angaben im erzeugten Text nachweisen.
+
+- **AC-2:** Given eine Alarm-Meldung erreichte **keinen einzigen** Kanal /
+  When das nächste Briefing erzeugt wird / Then erscheint sie ebenfalls als Zeile, mit allen
+  betroffenen Kanälen.
+  - Test: Eintrag unter `not_delivered` anlegen; alle drei Kanalnamen erscheinen in der Zeile.
+
+- **AC-3:** Given seit dem letzten Briefing wurde jede Meldung auf jedem **eingeschalteten**
+  Kanal zugestellt / When das Briefing erzeugt wird / Then enthält es **keinerlei**
+  Hinweis-Abschnitt — auch keine Überschrift und keine Null-Zeile. Das gilt insbesondere für
+  Kanäle, die der Nutzer selbst **abgeschaltet** hat: sie sind kein Vorfall.
+  - Test: (a) Protokoll nur mit vollständig zugestellten Einträgen; (b) Ein-Kanal-Nutzer, dessen
+    Einträge Telegram und SMS mit Grund `channel_disabled` führen. In beiden Fällen kommt die
+    Überschrift im erzeugten Text nicht vor.
+
+- **AC-4:** Given eine nicht zugestellte Meldung wurde in einem früheren Briefing bereits
+  ausgewiesen / When das darauffolgende Briefing erzeugt wird / Then erscheint sie **nicht
+  erneut**.
+  - Test: Zwei Briefings nacheinander erzeugen; die Zeile steht im ersten, nicht im zweiten.
+
+- **AC-5:** Given ein einziger Alarm-Lauf hat wegen gleichzeitiger Vorhersage-Änderung und
+  amtlicher Warnung mehrere Protokolleinträge erzeugt, die alle niemanden erreichten /
+  When das Briefing erzeugt wird / Then steht dafür **eine** Zeile, nicht mehrere, und die
+  betroffenen Kanäle sind darin zusammengefasst.
+  - Test: Zwei Einträge derselben Kennung mit demselben Zeitstempel und verschiedenem Grund;
+    genau eine Zeile im Ergebnis.
+
+- **AC-6:** Given mehr als fünf Meldungen haben seit dem letzten Briefing einen Kanal nicht
+  erreicht / When das Briefing erzeugt wird / Then stehen die fünf jüngsten als Zeilen da,
+  gefolgt von einem Hinweis, wie viele weitere es sind.
+  - Test: Acht Vorfälle anlegen; fünf Zeilen plus „und 3 weitere" nachweisen.
+
+- **AC-7:** Given ein Nutzer bekommt zum ersten Mal ein Briefing, nachdem diese Funktion
+  ausgeliefert wurde, und sein Protokoll enthält alte nicht zugestellte Meldungen /
+  When das Briefing erzeugt wird / Then wird **keine** dieser Alt-Meldungen ausgewiesen.
+  - Test: Protokoll mit Einträgen von vor Tagen, kein gespeicherter Briefing-Zeitpunkt;
+    Abschnitt erscheint nicht.
+
+- **AC-8:** Given ein Nutzer ruft ein Briefing selbst ab (kein geplanter Versand) /
+  When er danach das nächste geplante Briefing bekommt / Then sind die nicht zugestellten
+  Meldungen dort **immer noch** ausgewiesen — der Selbstabruf hat den Zeitraum nicht
+  abgeschnitten.
+  - Test: Abruf mit `on_demand=True`, danach reguläres Briefing; Zeile ist in beiden enthalten.
+
+- **AC-9:** Given es liegen nicht zugestellte Meldungen vor / When ein Briefing im Format
+  `full` **und** eines im Format `compact` erzeugt wird / Then enthalten **beide** den
+  Abschnitt.
+  - Test: Beide Formate rendern, in beiden nachweisen.
+
+- **AC-10:** Given es liegen nicht zugestellte Meldungen vor / When die Kurznachrichten für
+  Telegram und SMS erzeugt werden / Then sind diese Zeichen für Zeichen identisch mit denen
+  ohne solche Meldungen.
+  - Test: Kurznachricht mit und ohne Vorfälle im Protokoll erzeugen und auf Gleichheit prüfen.
+
+- **AC-11:** Given ein Ortsvergleich hat eine Meldung, die einen Kanal nicht erreicht hat /
+  When das Ortsvergleichs-Briefing erzeugt wird / Then erscheint der Abschnitt dort mit
+  derselben Zeilenform wie beim Trip — und ist **nicht leer**.
+  - Test: Compare-Protokolleintrag unter der Preset-Kennung anlegen, Compare-Mail rendern,
+    Zeile nachweisen. Deckt den Kennungs-Fallstrick ab.
+
+- **AC-17:** Given dieselbe Lage wie in AC-11 / When die Ortsvergleichs-Mail erzeugt wird /
+  Then enthält **auch ihr Klartext-Teil** den Abschnitt — nicht nur die HTML-Fassung.
+  - Test: `render_comparison_text()` mit demselben Protokollstand; Überschrift und Zeile im
+    Klartext nachweisen.
+  - Begründung (v1.2): Eine Mail hat zwei Fassungen, beide werden zugestellt
+    (`scheduler_dispatch_service.py:394` reicht `text_body` mit). Die PO-Entscheidung „nur
+    E-Mail" meint die Mail, nicht ihre HTML-Hälfte. Der Pflicht-Validator
+    `email_spec_validator.py` liest **ausschließlich** HTML und kann einen Fehler im
+    Klartext strukturell nicht fangen — in #1366 blieb dort ein Schalter deshalb dauerhaft
+    wirkungslos, bei grünen Tests und grünem Validator. Beim Trip ist die Klartext-Fassung
+    (`email/plain.py`) von Anfang an dabei; ohne AC-17 wäre der Ortsvergleich schlechter
+    gestellt, was zusätzlich die Teilungs-Invariante verletzt.
+
+- **AC-12:** Given zwei verschiedene Nutzer haben je eigene nicht zugestellte Meldungen /
+  When das Briefing des einen erzeugt wird / Then enthält es ausschließlich dessen eigene
+  Meldungen.
+  - Test: Zwei Nutzerverzeichnisse mit unterscheidbaren Einträgen; Kreuzprüfung in beide
+    Richtungen.
+
+- **AC-13:** Given ein Protokoll enthält nicht zugestellte Meldungen / When Cockpit-Kachel und
+  Archiv-Statistik abgefragt werden / Then zeigen sie **dieselben Zahlen** wie vor dieser
+  Änderung.
+  - Test: Zählung vor und nach dem Erzeugen eines Briefings vergleichen (Zusicherung D4).
+
+- **AC-14:** Given die Protokolldatei fehlt oder ist beschädigt / When ein Briefing erzeugt
+  wird / Then geht das Briefing vollständig und ohne Fehler raus, nur ohne den Abschnitt.
+  - Test: Datei mit unlesbarem Inhalt anlegen; Briefing enthält alle übrigen Abschnitte.
+
+- **AC-15:** Given eine nicht zugestellte Meldung betraf das Gewitter-Niveau /
+  When die Zeile erzeugt wird / Then nennt sie die Wettergröße in Worten aus dem Register
+  („Gewitter") und enthält außer dem Zeitstempel **keine Ziffer**.
+  - Test: Eintrag mit dem Register-Paar der ordinalen Größe; die Bezeichnung steht in der Zeile,
+    eine nackte Zahl kommt nicht vor.
+  - Präzisierung v1.1 (gemessen in der RED-Phase): Das Protokoll speichert **keinen**
+    Gewitter-Wert, nur das Register-Paar, `severity` und `changes_count`. Es gibt daher gar
+    keine Stufenzahl zu wandeln; `thunder_ordinal()` hat hier nichts zu tun. Eine Stufenangabe
+    in der Zeile setzte voraus, dass die **Schreibseite** den Wert mitschreibt — Schema-Änderung,
+    nicht diese Scheibe.
+
+- **AC-16:** Given beliebige Alarm-Lagen / When ein kompletter Alarm- und Briefing-Lauf
+  durchläuft / Then wird **kein** Alarm anders verschickt als vor dieser Änderung — gleiche
+  Kanäle, gleiche Anzahl.
+  - Test: Versandzähler je Kanal vor und nach dem Patch vergleichen.
+
+## Known Limitations
+
+- Die Gründe `quiet_hours`, `daily_limit` und `cooldown` sind im Schema vorgesehen, werden aber
+  von **keinem** Aufrufer gesetzt (O3 aus #1459: zum Gate-Zeitpunkt ist der Auslöser noch nicht
+  bekannt). Sie können daher heute in keiner Zeile erscheinen. Wer sie sichtbar machen will,
+  muss zuerst die Schreibseite nachziehen — nicht Teil dieser Scheibe.
+- Die Kurznachricht (Telegram/SMS) weist nichts aus. Wer ausschließlich per SMS liest, erfährt
+  von fehlgeschlagenen Zustellungen nichts. PO-Entscheidung 2026-08-05.
+- Die Entdoppelung fasst über Kennung und Zeitfenster zusammen. Zwei **echt verschiedene**
+  Meldungen derselben Kennung innerhalb desselben Fensters würden ebenfalls zu einer Zeile
+  zusammengezogen. Praktisch ausgeschlossen, weil ein Alarm-Lauf pro Kennung höchstens einmal
+  je Auslöser protokolliert; für den Nutzer wäre es ohnehin ein Vorfall.
+- Der Rückblick reicht nur bis zum letzten Briefing. Wer sein Briefing abschaltet, sieht
+  nichts — dann gibt es aber auch kein Briefing, in dem es stehen könnte.
+- **Keine Stufen-/Messwerte in der Zeile.** Das Protokoll hält nur fest, *worum* es ging
+  (Register-Paar bzw. Gefahrenart), nicht *wie stark*. Die Zeile nennt deshalb „Gewitter", nicht
+  „Gewitter hoch". Nachrüstbar nur über die Schreibseite.
+- **Ortsvergleich ohne Briefing-Zeitzone.** `render_compare_html()` nimmt kein `tz` — die
+  Vergleichs-Mail rechnet je Ort in Ortszeit. Die Zeitzonen-Zusicherung aus AC-1 gilt daher für
+  den Trip; beim Ortsvergleich sichert AC-11 nur zu, dass Anlass und Kanal da und die Zeile
+  **nicht leer** ist.
+- **AC-16 ist nicht als Vorher/Nachher-Vergleich testbar** — ein Testlauf kennt nur einen Stand.
+  Nachgewiesen wird stattdessen im selben Lauf: derselbe Alarm für einen Nutzer mit vorbelastetem
+  und einen mit leerem Protokoll muss Kanäle, Anzahl, Betreff und Mail-Inhalt gleich lassen,
+  **während** nachweislich ein Abschnitt erscheint (sonst bewacht der Test nichts). Dasselbe
+  Muster in AC-10, AC-13 und AC-14.
+- **AC-13 ist Python-seitig eine Struktur-Zusicherung:** `entries` und `not_delivered` müssen nach
+  dem Briefing Feld für Feld unverändert sein. Genau das macht die Go-Zahlen unveränderlich;
+  der Go-Store selbst ist aus pytest nicht erreichbar.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Keine Entscheidungsfläche wird verschoben. Kanäle, Provider, Datenmodell,
+  Auth und Test-/Deploy-Strategie bleiben unverändert; das Protokoll-Schema wird nur gelesen.
+  Der zusätzliche Briefing-Zeitstempel ist additiv und bleibt für Go unsichtbar — dieselbe
+  Bauart wie `not_delivered` aus #1459 (dort ebenfalls ohne ADR).
+
+## Changelog
+
+- 2026-08-05 (v1.2): AC-17 ergänzt — der **Klartext-Teil** der Ortsvergleichs-Mail bekommt den
+  Abschnitt ebenfalls. In der GREEN-Phase war er ausgelassen worden, weil die Dateiliste
+  `comparison.py` nicht nannte und AC-11 nur HTML prüft. Beide Fassungen werden zugestellt; der
+  Pflicht-Validator liest nur HTML (blinder Fleck, belegt in #1366).
+- 2026-08-05 (v1.1): Drei Präzisierungen aus der RED-Phase, alle gemessen — (1) ein vom Nutzer
+  abgeschalteter Kanal (`channel_disabled`) ist kein Vorfall, sonst stünde der Abschnitt bei
+  jedem Ein-Kanal-Nutzer in jedem Briefing und AC-3 wäre strukturell unerfüllbar; (2) AC-15
+  kann keine Stufenzahl unterdrücken, weil das Protokoll keine speichert; (3) Grenzen von
+  AC-10/13/14/16 als Nicht-Leerlauf-Nachweis im selben Lauf statt Vorher/Nachher.
+- 2026-08-05: Initial spec (v1.0) — auf Basis von `docs/context/feat-1461-s3b1-briefing-sichtbarkeit.md`

--- a/scripts/send_gate_test_mails.py
+++ b/scripts/send_gate_test_mails.py
@@ -120,6 +120,33 @@ def send_official_alert_mail(settings: Settings, token: str) -> bool:
 #     echten Renderer-Einstiegspunkt render_email() (segments tragen
 #     official_alerts, analog test_warn_block_trip_placement.py).
 # ---------------------------------------------------------------------------
+# Direktstrahlung (DNI) der Briefing-Fixture -- NICHT frei gegriffen, sondern
+# je Zeile aus der Bewoelkung DERSELBEN Zeile abgeleitet (Issue #1432):
+#
+#   dni_wm2 = round(clear_sky_dni(Ortsstunde) * (1 - cloud_total_pct/100 * 0.8))
+#
+# `clear_sky_dni` sind Groessenordnungen eines wolkenlosen 13.-Juli-Tages auf
+# ~46.6 N in 600-1200 m (Sonnenhoechststand ~13:20 Ortszeit): vormittags noch
+# im Anstieg, um die Mittagszeit am hoechsten, am spaeten Nachmittag wieder
+# fallend. Der Faktor 0.8 ist die uebliche Annahme, dass Bewoelkung die
+# DIREKTE Strahlung ueberproportional daempft (Diffusanteil faellt weg).
+# Damit gilt zeilenweise: mehr Wolken -> weniger Direktstrahlung.
+#
+# Warum es diese Werte ueberhaupt braucht: ohne `dni_wm2` bleibt die
+# Sonne-Spalte der Stundentabelle leer ('-'), waehrend die Sonne-Pille aus dem
+# Wolken-Rueckfall gefuellt wird -- ein Widerspruch, den der Briefing-Validator
+# seit #1432 zu Recht meldet. `is_day=1` gehoert dazu, weil der Emoji-Pfad
+# (get_weather_emoji) DNI nur bei bekanntem Tag-Flag auswertet; alle vier
+# Stunden liegen im Juli zwischen 10 und 16 Uhr Ortszeit, also am Tag.
+_BRIEFING_CLEAR_SKY_DNI = {8: 780.0, 10: 870.0, 12: 850.0, 14: 700.0}  # UTC-Stunde
+_BRIEFING_CLOUD_DIRECT_DAMPING = 0.8
+
+
+def _briefing_dni(hour_utc: int, cloud_pct: int) -> float:
+    return round(_BRIEFING_CLEAR_SKY_DNI[hour_utc]
+                 * (1.0 - cloud_pct / 100.0 * _BRIEFING_CLOUD_DIRECT_DAMPING))
+
+
 def _briefing_dps() -> list[ForecastDataPoint]:
     return [
         ForecastDataPoint(
@@ -127,6 +154,7 @@ def _briefing_dps() -> list[ForecastDataPoint]:
             t2m_c=t, wind10m_kmh=w, gust_kmh=w + 8, precip_1h_mm=p,
             pop_pct=15, cloud_total_pct=c, thunder_level=ThunderLevel.NONE,
             visibility_m=20000, freezing_level_m=3000,
+            is_day=1, dni_wm2=_briefing_dni(h, c),
         )
         for h, t, w, c, p in (
             (8, 14.0, 10.0, 30, 0.0),

--- a/src/output/renderers/comparison.py
+++ b/src/output/renderers/comparison.py
@@ -34,6 +34,9 @@ from output.renderers.email.compare_html import (
     _units_legend_text, _visible_hour_metrics, derive_row_labels,
     location_render_order,
 )
+from output.renderers.email.undelivered_hint import (
+    has_undelivered, render_undelivered_plain,
+)
 from utils.geo import degrees_to_compass
 from utils.timezone import (
     local_fmt, local_stamp, location_tz, resolve_location_tz, tz_abbrev,
@@ -141,6 +144,7 @@ def render_comparison_text(
     outlook_metrics: list[dict] | None = None,
     hourly_metrics: list[str] | None = None,
     hourly_enabled: bool = True,
+    undelivered: list | None = None,
 ) -> str:
     """
     Render ComparisonResult als Klartext (v2, Issue #1110).
@@ -172,6 +176,15 @@ def render_comparison_text(
             Stundenverlauf-Abschnitt (Ueberschrift + Tabellenzeilen) je Ort
             entfallen -- der 3-Tage-Ausblick haengt NICHT an dieser
             Bedingung und bleibt unveraendert sichtbar (Issue #1323).
+        undelivered: Issue #1461 S3b-1 (AC-17): Vorfaelle, die seit dem
+            letzten Briefing einen Kanal nicht erreicht haben. GLEICHER
+            geteilter Baustein wie HTML-Pfad und Trip-Briefing. Der
+            Klartext-Teil wird mitgesendet (`send_compare_report(...,
+            plain_text_body=text_body)`) und ist kein toter Pfad -- ein hier
+            fehlender Baustein wird von KEINEM Pflicht-Validator gefunden
+            (`email_spec_validator` liest nur den HTML-Body; genau so blieb
+            in #1366 `hourly_enabled` im Klartext monatelang wirkungslos).
+            ``None``/leer = kein Abschnitt, keine Ueberschrift.
 
     Returns:
         Klartext-String fuer die E-Mail.
@@ -330,6 +343,16 @@ def render_comparison_text(
             if _legend:
                 lines.append(_legend)
 
+    # Issue #1461 S3b-1 (AC-17): an derselben Stelle wie im HTML-Teil (vor
+    # Legende/Fuss) und ueber DENSELBEN Baustein wie Trip und Compare-HTML --
+    # keine zweite Fassung. Zeitbasis wie die Kopfzeile derselben Mail.
+    if has_undelivered(undelivered):
+        lines.append("")
+        lines.append(render_undelivered_plain(
+            undelivered, tz=location_tz(locations[0].location),
+        ))
+        lines.append("")
+
     lines.append("---")
     lines.append("Gregor Zwanzig")
 
@@ -350,6 +373,7 @@ def render_compare_email(
     corridors: list[Corridor] | None = None,
     outlook_enabled: bool = False,
     outlook_metrics: list[dict] | None = None,
+    undelivered: list | None = None,
 ) -> tuple[str, str]:
     """Render both HTML and plain-text parts for a compare email (v2, #1110).
 
@@ -385,6 +409,8 @@ def render_compare_email(
         corridors=corridors,
         outlook_enabled=outlook_enabled,
         outlook_metrics=outlook_metrics,
+        # Issue #1461 S3b-1: geteilter Hinweis-Baustein, derselbe wie im Trip.
+        undelivered=undelivered,
     )
     text_body = render_comparison_text(
         result, profile=profile, enabled_metrics=enabled_metrics,
@@ -399,6 +425,11 @@ def render_compare_email(
         # unabhaengig von Auswahl/Schalter.
         hourly_metrics=hourly_metrics,
         hourly_enabled=hourly_enabled,
+        # Issue #1461 S3b-1 (AC-17): beide Fassungen der Mail werden
+        # zugestellt -- der Abschnitt gehoert in BEIDE, sonst waere der
+        # Ortsvergleich gegenueber dem Trip (`email/plain.py`) schlechter
+        # gestellt (Teilungs-Invariante).
+        undelivered=undelivered,
     )
     return html_body, text_body
 

--- a/src/output/renderers/email/__init__.py
+++ b/src/output/renderers/email/__init__.py
@@ -65,6 +65,7 @@ def render_email(
     trip_url: Optional[str] = None,
     corridors: Optional[list[Corridor]] = None,
     trip_metrics_altbestand: bool = True,
+    undelivered: Optional[list] = None,
     **_ignored,
 ) -> tuple[str, str]:
     """Returns (html_body, plain_body). Pure function.
@@ -122,6 +123,7 @@ def render_email(
             day_window_start_hour=day_window_start_hour,
             day_window_end_hour=day_window_end_hour,
             trip_metrics_altbestand=trip_metrics_altbestand,
+            undelivered=undelivered,
         )
         return "", compact_text
 
@@ -167,6 +169,7 @@ def render_email(
         trip_url=trip_url,
         corridors=corridors,
         trip_metrics_altbestand=trip_metrics_altbestand,
+        undelivered=undelivered,
     )
     plain_body = render_plain(
         segments=segments,
@@ -197,6 +200,7 @@ def render_email(
         show_outlook=show_outlook,
         day_comparison=day_comparison,
         trip_metrics_altbestand=trip_metrics_altbestand,
+        undelivered=undelivered,
     )
     return html_body, plain_body
 

--- a/src/output/renderers/email/compact.py
+++ b/src/output/renderers/email/compact.py
@@ -30,6 +30,9 @@ from output.renderers.alert.official_alerts import (
 from output.renderers.email.unavailable_hint import (
     any_official_alerts_unavailable, render_official_alerts_unavailable_plain,
 )
+from output.renderers.email.undelivered_hint import (
+    has_undelivered, render_undelivered_plain,
+)
 from output.renderers.email.outlook_state_hint import (
     OutlookState as _OutlookState, render_outlook_state_plain,
 )
@@ -108,6 +111,7 @@ def render_compact(
     day_window_start_hour: int = DAY_WINDOW_START_HOUR,
     day_window_end_hour: int = DAY_WINDOW_END_HOUR,
     trip_metrics_altbestand: bool = True,
+    undelivered: Optional[list] = None,
     **_ignored,
 ) -> str:
     """Render compact plain-text e-mail body. Pure function.
@@ -237,6 +241,14 @@ def render_compact(
         lines.append("Naechste Etappen")
         lines.append(_ascii(render_outlook_state_plain(
             outlook_state, outlook_horizon_days, ascii_safe=True,
+        )))
+        lines.append("")
+
+    # Issue #1461 S3b-1: "E-Mail" heisst BEIDE Mail-Formate — das Kurzformat
+    # zeigt denselben Abschnitt (AC-9), ascii_safe wie der uebrige Body.
+    if has_undelivered(undelivered):
+        lines.append(_ascii(render_undelivered_plain(
+            undelivered, tz=tz, ascii_safe=True,
         )))
         lines.append("")
 

--- a/src/output/renderers/email/compare_html.py
+++ b/src/output/renderers/email/compare_html.py
@@ -1394,6 +1394,7 @@ def render_compare_html(
     corridors: list[Corridor] | None = None,
     outlook_enabled: bool = False,
     outlook_metrics: list[dict] | None = None,
+    undelivered: list | None = None,
 ) -> str:
     """Rendert ComparisonResult als HTML-Mail (v2-Layout, Issue #1110).
 
@@ -1511,6 +1512,17 @@ def render_compare_html(
         _per_location(loc, i) for i, loc in enumerate(locations)
     )
 
+    # Issue #1461 S3b-1: derselbe Baustein wie im Trip-Briefing (kein Nachbau,
+    # Teilungs-Invariante). Zeitbasis ist die Kopfzeilen-Zeitzone des
+    # erstgenannten Ortes -- `render_compare_html()` kennt keine eigene `tz`.
+    from output.renderers.email.undelivered_hint import (
+        has_undelivered, render_undelivered_html,
+    )
+    undelivered_html = (
+        render_undelivered_html(undelivered, tz=header_tz)
+        if has_undelivered(undelivered) else ""
+    )
+
     legend_html = _render_legend(hourly_metrics, hourly_enabled)
     abo_html = _render_abo_footer(preset_name, preset_schedule, preset_weekday, len(locations), sig)
     app_footer_html = _render_app_footer()
@@ -1521,7 +1533,7 @@ def render_compare_html(
         part for part in (
             header_html, warnings_html, warn_banner_html, unavailable_banner_html,
             overview_html, hourly_head_html, per_location_html,
-            legend_html, abo_html, app_footer_html,
+            undelivered_html, legend_html, abo_html, app_footer_html,
         ) if part
     )
 

--- a/src/output/renderers/email/html.py
+++ b/src/output/renderers/email/html.py
@@ -55,6 +55,9 @@ from output.renderers.alert.official_alerts import (
 from output.renderers.email.unavailable_hint import (
     any_official_alerts_unavailable, render_official_alerts_unavailable_html,
 )
+from output.renderers.email.undelivered_hint import (
+    has_undelivered, render_undelivered_html,
+)
 from output.renderers.email.outlook_state_hint import (
     OutlookState as _OutlookState, render_outlook_state_html,
 )
@@ -957,6 +960,7 @@ def render_html(
     trip_url: Optional[str] = None,
     corridors: Optional[list[Corridor]] = None,
     trip_metrics_altbestand: bool = True,
+    undelivered: Optional[list] = None,
     **_ignored,
 ) -> str:
     """Render full HTML e-mail body. Pure function.
@@ -1584,6 +1588,14 @@ def render_html(
     if any_official_alerts_unavailable(segments):
         warn_block_html += render_official_alerts_unavailable_html()
 
+    # Issue #1461 S3b-1: was seit dem letzten Briefing einen Kanal NICHT
+    # erreicht hat — am Ende des Briefings, geteilter Baustein mit dem
+    # Ortsvergleich. Ohne Vorfaelle leer -> HTML byte-identisch wie bisher.
+    undelivered_html = (
+        render_undelivered_html(undelivered, tz=tz)
+        if has_undelivered(undelivered) else ""
+    )
+
     all_rows = [r for tbl in seg_tables for r in tbl]
     legend_text = build_units_legend(all_rows) if all_rows else ""
     column_legend_text = build_column_legend(all_rows) if all_rows else ""
@@ -1692,7 +1704,7 @@ def render_html(
         {segments_html}
         {night_html}
         {thunder_html}
-        {trend_html}
+        {trend_html}{undelivered_html}
 
         {_render_kommandos_section()}
 

--- a/src/output/renderers/email/plain.py
+++ b/src/output/renderers/email/plain.py
@@ -39,6 +39,9 @@ from output.renderers.alert.official_alerts import (
 from output.renderers.email.unavailable_hint import (
     any_official_alerts_unavailable, render_official_alerts_unavailable_plain,
 )
+from output.renderers.email.undelivered_hint import (
+    has_undelivered, render_undelivered_plain,
+)
 # Epic #1301 B4: geteilter Ausblick-Renderer (Trip/Compare-Teilungs-Invariante)
 from output.renderers.email.outlook import render_outlook_plain
 from output.renderers.email.outlook_state_hint import (
@@ -111,6 +114,7 @@ def render_plain(
     show_outlook: bool = True,
     day_comparison: Optional["DayComparison"] = None,
     trip_metrics_altbestand: bool = True,
+    undelivered: Optional[list] = None,
     **_ignored,
 ) -> str:
     """Render full plain-text e-mail body. Pure function.
@@ -312,6 +316,14 @@ def render_plain(
         # Aufrufer ohne `outlook_state` (Default None) bleiben unveraendert.
         lines.append("━━ Nächste Etappen ━━")
         lines.append(render_outlook_state_plain(outlook_state, outlook_horizon_days))
+        lines.append("")
+
+    # Issue #1461 S3b-1: was seit dem letzten Briefing einen Kanal NICHT
+    # erreicht hat. Geteilter Baustein (Trip + Ortsvergleich); ohne Vorfaelle
+    # erscheint gar nichts -> Zeichen-Gleichheit im Normalfall.
+    if has_undelivered(undelivered):
+        lines.append("")
+        lines.append(render_undelivered_plain(undelivered, tz=tz))
         lines.append("")
 
     # Antwort-Kommandos (Issue #731: abruf-zentrierter Grundbefehlssatz)

--- a/src/output/renderers/email/undelivered_hint.py
+++ b/src/output/renderers/email/undelivered_hint.py
@@ -1,0 +1,135 @@
+"""Briefing-Abschnitt "was hat dich nicht erreicht" (Issue #1461 S3b-1).
+
+Bauform 1:1 nach ``unavailable_hint.py`` (#1348) und ``outlook_state_hint.py``
+(#1349): eine Pruefunktion, eine HTML-Fassung, eine Klartext-Fassung —
+eingebunden in ``html.py``, ``plain.py``, ``compact.py`` und
+``compare_html.py``.
+
+Bewusst im Briefing-/E-Mail-Renderer-Bereich (nicht in ``renderers/alert/``):
+es ist ein Briefing-Baustein, kein Alarm-Renderer — so bleibt das
+Warn-Renderer-Mail-Gate unberuehrt. Der Dateiname traegt kein
+``trip_``/``compare_``-Praefix: derselbe Baustein bedient Trip UND
+Ortsvergleich (Teilungs-Invariante, Pendant-Sperre #1481 B).
+
+Reine Funktionen: die Vorfaelle kommen als expliziter Parameter herein
+(``services.alert_log.read_undelivered()``), hier wird nichts nachgeladen.
+"""
+from __future__ import annotations
+
+import html as _html
+from typing import TYPE_CHECKING, Optional, Sequence
+from zoneinfo import ZoneInfo
+
+if TYPE_CHECKING:
+    from services.alert_log import UndeliveredIncident
+
+UNDELIVERED_HEADING = "NICHT BEI DIR ANGEKOMMEN"
+
+# PO-Entscheidung 2026-08-05: hoechstens fuenf Zeilen, darunter "und N weitere".
+MAX_UNDELIVERED_LINES = 5
+
+_CHANNEL_LABELS = {"email": "E-Mail", "telegram": "Telegram", "sms": "SMS"}
+
+# O2 aus #1459. `channel_disabled` fehlt bewusst — ein abgeschalteter Kanal
+# ist kein Vorfall und erreicht diesen Baustein gar nicht erst.
+_REASON_LABELS = {
+    "delivery_failed": "Versand fehlgeschlagen",
+    "quiet_hours": "Ruhezeit",
+    "daily_limit": "Tageslimit",
+    "cooldown": "Sperrzeit",
+}
+
+_TRIGGER_LABELS = {
+    "official_alert": "Amtliche Warnung",
+    "nowcast": "Regenradar",
+    "forecast_change": "Wetteränderung",
+}
+
+
+def has_undelivered(incidents: Optional[Sequence]) -> bool:
+    """True, wenn ein Abschnitt zu zeigen ist. Der Normalfall ist "alles
+    zugestellt" — dann erscheint gar nichts, auch keine Null-Zeile (AC-3)."""
+    return bool(incidents)
+
+
+def _subject(inc: "UndeliveredIncident") -> str:
+    """Worum es ging, in Worten aus dem Register.
+
+    Ordinale Groessen erscheinen nie als Zahl (#1503/#1474) — das Protokoll
+    haelt ohnehin nur das Register-Paar fest, keinen Messwert (Spec v1.1
+    AC-15).
+    """
+    from app.metric_catalog import get_alert_label
+
+    if inc.metrics:
+        namen = []
+        for metric_id, _aggregation in inc.metrics:
+            label = get_alert_label(str(metric_id))
+            if label not in namen:
+                namen.append(label)
+        return ", ".join(namen)
+    if inc.hazards or inc.trigger == "official_alert":
+        return _TRIGGER_LABELS["official_alert"]
+    return _TRIGGER_LABELS.get(inc.trigger, "Alarm")
+
+
+def _line(inc: "UndeliveredIncident", tz: ZoneInfo) -> str:
+    """Eine Vorfall-Zeile: Zeitpunkt · worum es ging · welcher Kanal · warum."""
+    from utils.timezone import local_fmt
+
+    wann = local_fmt(inc.at, tz, "%d.%m. %H:%M")
+    kanaele = ", ".join(_CHANNEL_LABELS.get(c, c) for c in inc.channels)
+    gruende = ", ".join(_REASON_LABELS.get(r, r) for r in inc.reasons)
+    return f"{wann} · {_subject(inc)} · {kanaele} nicht zugestellt ({gruende})"
+
+
+def _rest_hinweis(anzahl: int) -> str:
+    return f"und {anzahl} weitere"
+
+
+def render_undelivered_plain(
+    incidents: Sequence, *, tz: ZoneInfo, ascii_safe: bool = False,
+) -> str:
+    """Klartext-Fassung. ``ascii_safe=True`` (compact.py) liefert garantiert
+    reines ASCII (``str.isascii()``) — inklusive Umlaut-Faltung ueber
+    ``fold_ascii`` (SSoT, #1253), damit der Block nicht davon abhaengt, dass
+    der Aufrufer noch einmal darueberfaltet."""
+    from utils.ascii_fold import fold_ascii
+
+    zeilen = [UNDELIVERED_HEADING, ""]
+    zeilen += [f"  {_line(inc, tz)}" for inc in incidents[:MAX_UNDELIVERED_LINES]]
+    rest = len(incidents) - MAX_UNDELIVERED_LINES
+    if rest > 0:
+        zeilen.append(f"  … {_rest_hinweis(rest)}")
+    text = "\n".join(zeilen)
+    if not ascii_safe:
+        return text
+    return fold_ascii(text.replace("·", "-").replace("…", "..."))
+
+
+def render_undelivered_html(incidents: Sequence, *, tz: ZoneInfo) -> str:
+    """Hochkontrastiger Danger-Box-Baustein, Token ``G_BOX_DANGER_BG``/
+    ``G_DANGER`` — bewusst KEIN ``G_INK_FAINT`` (Design-Leitprinzip:
+    Lesbarkeit unter Zeitdruck). Jede Vorfall-Zeile ist ein eigenes Element."""
+    from output.renderers.email.design_tokens import (
+        FONT_UI, G_BOX_DANGER_BG, G_DANGER, G_INK,
+    )
+
+    zeilen = "".join(
+        f'<div style="margin:4px 0 0 0;color:{G_INK};font-size:13px;">'
+        f'{_html.escape(_line(inc, tz))}</div>'
+        for inc in incidents[:MAX_UNDELIVERED_LINES]
+    )
+    rest = len(incidents) - MAX_UNDELIVERED_LINES
+    if rest > 0:
+        zeilen += (
+            f'<div style="margin:4px 0 0 0;color:{G_INK};font-size:13px;">'
+            f'… {_rest_hinweis(rest)}</div>'
+        )
+    return (
+        f'<div style="background:{G_BOX_DANGER_BG};'
+        f'border-left:4px solid {G_DANGER};padding:12px;margin:8px 20px;'
+        f'border-radius:4px;font-family:{FONT_UI};">'
+        f'<strong style="color:{G_DANGER};font-size:14px;">'
+        f'{UNDELIVERED_HEADING}</strong>{zeilen}</div>'
+    )

--- a/src/output/renderers/trip_report.py
+++ b/src/output/renderers/trip_report.py
@@ -81,6 +81,7 @@ class TripReportFormatter:
         render_options: Optional[ReportRenderOptions] = None,
         trip: Optional["Trip"] = None,
         has_gap: bool = False,
+        undelivered: Optional[list] = None,
     ) -> TripReport:
         """Format trip segments into HTML + plain-text email.
 
@@ -224,6 +225,10 @@ class TripReportFormatter:
             # Zellen im HTML-Teil (Durchreichweg trip.py:193 -> render_email
             # -> render_html, geteilter Baustein mit dem Compare-Renderer).
             corridors=trip.corridors if trip is not None else None,
+            # Issue #1461 S3b-1: Vorfaelle als expliziter kwarg — der
+            # Renderer bleibt rein und laedt nichts nach (Spec §A1/§A5/§A6).
+            # Ohne den kwarg (Vorschau, Goldens, CLI) unveraendert.
+            undelivered=undelivered,
         )
         first_agg = segments[0].aggregated
         email_subject = self._generate_subject(

--- a/src/services/alert_briefing_anchor.py
+++ b/src/services/alert_briefing_anchor.py
@@ -23,10 +23,92 @@ AC-14..AC-19 und AC-27.
 """
 from __future__ import annotations
 
+import json
 import logging
+from datetime import datetime, timezone
 from typing import Callable, Iterable, Optional
 
 logger = logging.getLogger("alert_briefing_anchor")
+
+# Eigene Ablage, bewusst NICHT als weiterer Top-Level-Schluessel in
+# `alert_log.json`: die Protokolldatei wird von `append_entry()` per
+# Read-Modify-Write ueber die volle Datei geschrieben, und Go liest sie
+# (`internal/store/log.go`). Ein zusaetzlicher Schluessel dort waere ein
+# Fremdkoerper im geteilten Schema — hier ist er strukturell folgenlos (D4).
+_BRIEFING_ANCHOR_FILE = "briefing_anchor.json"
+
+
+def _anchor_path(user_id: str):
+    from app.loader import get_data_dir
+
+    return get_data_dir(user_id) / _BRIEFING_ANCHOR_FILE
+
+
+def record_briefing_sent(
+    *, user_id: str, entity_id: str, entity_type: str,
+    at: Optional[datetime] = None,
+) -> None:
+    """Haelt fest, WANN zuletzt ein Briefing dieser Kennung rausging (#1461).
+
+    🔴 `entity_id` MUSS die **Protokoll**-Kennung sein — Trip: `trip.id`;
+    Ortsvergleich: `preset_id` (so schreibt `compare_alert.py` das Protokoll),
+    NICHT die Anker-Kennungen `f"{preset_id}:{loc.id}"`. Unter denen faende
+    `read_undelivered()` nie einen Treffer und der Hinweis bliebe beim
+    Ortsvergleich dauerhaft leer.
+
+    Fail-soft: ein Schreibfehler darf einen bereits versandten Report nicht
+    rueckwirkend zum Fehler machen.
+    """
+    moment = (at or datetime.now(tz=timezone.utc)).astimezone(timezone.utc)
+    path = _anchor_path(user_id)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = json.loads(path.read_text()) if path.exists() else {}
+        if not isinstance(data, dict):
+            data = {}
+        data.setdefault(entity_type, {})[entity_id] = moment.isoformat()
+        path.write_text(json.dumps(data, indent=2))
+    except (OSError, ValueError, AttributeError) as e:
+        logger.warning("Briefing-Zeitstempel fuer %s nicht schreibbar: %s", entity_id, e)
+
+
+def last_briefing_at(
+    *, user_id: str, entity_id: str, entity_type: str,
+) -> Optional[datetime]:
+    """Zeitpunkt des letzten Briefings dieser Kennung — `None`, wenn es noch
+    keins gab (Bestandsnutzer, erstes Briefing nach der Auslieferung)."""
+    path = _anchor_path(user_id)
+    try:
+        data = json.loads(path.read_text()) if path.exists() else {}
+        raw = (data.get(entity_type) or {}).get(entity_id)
+        if not raw:
+            return None
+        ts = datetime.fromisoformat(str(raw))
+    except (OSError, ValueError, AttributeError) as e:
+        logger.warning("Briefing-Zeitstempel fuer %s nicht lesbar: %s", entity_id, e)
+        return None
+    return ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
+
+
+def undelivered_since_last_briefing(
+    *, user_id: str, entity_id: str, entity_type: str,
+) -> list:
+    """DIE Naht, aus der beide Briefing-Pfade den Hinweis speisen (#1461).
+
+    Ohne gespeicherten Zeitpunkt beginnt der Rueckblick **ab jetzt** — sonst
+    kippte beim ersten Briefing nach der Auslieferung die gesamte Historie in
+    die Mail (AC-7).
+    """
+    from services.alert_log import read_undelivered
+
+    since = last_briefing_at(
+        user_id=user_id, entity_id=entity_id, entity_type=entity_type,
+    )
+    if since is None:
+        return []
+    return read_undelivered(
+        user_id, entity_id=entity_id, entity_type=entity_type, since=since,
+    )
 
 
 def write_anchor_and_reset_memory(
@@ -36,6 +118,8 @@ def write_anchor_and_reset_memory(
     write_anchor: Callable[[], None],
     on_demand: bool = False,
     reset_memory: Optional[Callable[[str], None]] = None,
+    briefing_entity_id: Optional[str] = None,
+    briefing_entity_type: Optional[str] = None,
 ) -> None:
     """Schreibt den Δ-Anker und leert danach das Melde-Gedächtnis.
 
@@ -58,9 +142,23 @@ def write_anchor_and_reset_memory(
             muss). Diese Naht delegiert ihrerseits an `reset_alert_memory()`,
             es gibt also nur EINE Reset-Fassung. Ohne Angabe wird
             `reset_alert_memory()` direkt gerufen.
+        briefing_entity_id/briefing_entity_type: Kennung, unter der der
+            Briefing-Zeitstempel fortgeschrieben wird (#1461 S3b-1). Das ist
+            die PROTOKOLL-Kennung, die im Compare-Fall von `entity_ids`
+            abweicht (dort `preset_id` statt `f"{preset_id}:{loc.id}"`).
+            Ohne Angabe wird nichts fortgeschrieben (Bestandsaufrufer).
     """
     if on_demand:
         return
+
+    # Vor dem Anker: ein fehlgeschlagener Snapshot-Write darf den Zeitpunkt
+    # nicht verschlucken — sonst zeigte das naechste Briefing dieselben
+    # Vorfaelle erneut.
+    if briefing_entity_id and briefing_entity_type:
+        record_briefing_sent(
+            user_id=user_id, entity_id=briefing_entity_id,
+            entity_type=briefing_entity_type,
+        )
 
     write_anchor()
 

--- a/src/services/alert_log.py
+++ b/src/services/alert_log.py
@@ -28,7 +28,8 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timezone
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from typing import Iterable, Optional
 
 from app.loader import get_data_dir
@@ -210,3 +211,137 @@ def append_entry(
     data.setdefault(target, [])
     data[target].append(entry)
     path.write_text(json.dumps(data, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Lesen: was hat einen Kanal NICHT erreicht (#1461 S3b-1)
+# ---------------------------------------------------------------------------
+
+# Ein Alarm-Lauf erzeugt bis zu drei Eintraege (Vorhersage-Aenderung, Radar,
+# amtliche Warnung sind drei getrennte `append_entry`-Aufrufe, Millisekunden
+# auseinander). Fuer den Nutzer ist das EIN Vorfall -- zusammengefasst wird
+# beim LESEN, nie im Protokoll (sonst kippt D4).
+DEDUP_WINDOW = timedelta(minutes=2)
+
+
+@dataclass(frozen=True)
+class UndeliveredIncident:
+    """Eine Nutzer-Meldung, die mindestens einen Kanal nicht erreicht hat."""
+    at: datetime
+    channels: tuple[str, ...]
+    reasons: tuple[str, ...]
+    metrics: tuple[tuple[str, str], ...]
+    hazards: tuple[str, ...]
+    trigger: str
+
+
+def _parse_ts(raw: object) -> Optional[datetime]:
+    try:
+        ts = datetime.fromisoformat(str(raw))
+    except (TypeError, ValueError):
+        return None
+    return ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
+
+
+def _missed_channels(entry: dict) -> tuple[list[str], set[str]]:
+    """Kanaele + Gruende, die als Vorfall zaehlen.
+
+    `channel_disabled` faellt heraus: ein vom Nutzer ABGESCHALTETER Kanal ist
+    keine fehlgeschlagene Zustellung. `_channels_not_sent()` schreibt ihn bei
+    JEDEM erfolgreichen Alarm mit; wer ihn mitzaehlt, zeigt jedem
+    Ein-Kanal-Nutzer in JEDEM Briefing einen Abschnitt (Spec v1.1, AC-3).
+    Alle uebrigen Gruende -- auch die spaeter hinzukommenden (`quiet_hours`,
+    `daily_limit`, `cooldown`, "unter der Kanal-Schwelle" aus S3b-2) -- sind
+    ausdruecklich Vorfaelle.
+    """
+    channels, reasons = [], set()
+    for item in entry.get("channels_not_sent") or []:
+        if not isinstance(item, dict):
+            continue
+        reason = item.get("reason")
+        channel = item.get("channel")
+        if not channel or reason == REASON_CHANNEL_DISABLED:
+            continue
+        channels.append(channel)
+        reasons.add(reason or REASON_DELIVERY_FAILED)
+    return channels, reasons
+
+
+def read_undelivered(
+    user_id: str,
+    *,
+    entity_id: str,
+    entity_type: str,
+    since: Optional[datetime] = None,
+) -> list[UndeliveredIncident]:
+    """Meldungen EINER Kennung, die seit `since` einen Kanal nicht erreichten.
+
+    Reine Lesefunktion -- an `entries`/`not_delivered` wird nichts geschrieben
+    (Zusicherung D4: Cockpit-Kachel und Archiv-Statistik bleiben zahlgleich).
+    Beide Quellen: `entries[*].channels_not_sent` (Teilausfall) und die ganzen
+    Eintraege unter `not_delivered` (Totalausfall).
+
+    Fail-soft wie die Schreibseite: unlesbare Datei ⇒ leeres Ergebnis plus
+    Warnung, nie eine Ausnahme ins Briefing. `since=None` liest ohne
+    Zeitgrenze; die Entscheidung "ohne Anker gar nichts" trifft der Aufrufer
+    (`alert_briefing_anchor.undelivered_since_last_briefing`).
+
+    Rueckgabe: juengster Vorfall zuerst.
+    """
+    path = get_data_dir(user_id) / "alert_log.json"
+    try:
+        data = json.loads(path.read_text()) if path.exists() else {}
+    except (OSError, ValueError) as e:
+        logger.warning("alert_log: %s nicht lesbar (%s) -- kein Briefing-Hinweis", path, e)
+        return []
+    if not isinstance(data, dict):
+        return []
+
+    roh: list[tuple[datetime, list[str], set[str], dict]] = []
+    for key in ("entries", "not_delivered"):
+        for entry in data.get(key) or []:
+            if not isinstance(entry, dict):
+                continue
+            # Alt-Eintraege ohne die #1467-S1-Felder wie Go lesen
+            # (`internal/store/log.go LoadAlertLog()`).
+            if (entry.get("entity_id") or entry.get("trip_id")) != entity_id:
+                continue
+            if (entry.get("entity_type") or "trip") != entity_type:
+                continue
+            at = _parse_ts(entry.get("sent_at"))
+            if at is None or (since is not None and at < since):
+                continue
+            channels, reasons = _missed_channels(entry)
+            if channels:
+                roh.append((at, channels, reasons, entry))
+
+    roh.sort(key=lambda r: r[0], reverse=True)
+
+    vorfaelle: list[UndeliveredIncident] = []
+    gruppen: list[dict] = []
+    for at, channels, reasons, entry in roh:
+        if gruppen and gruppen[-1]["at"] - at <= DEDUP_WINDOW:
+            g = gruppen[-1]
+        else:
+            g = {"at": at, "channels": [], "reasons": set(),
+                 "metrics": [], "hazards": [], "trigger": entry.get("reason") or ""}
+            gruppen.append(g)
+        g["channels"] += [c for c in channels if c not in g["channels"]]
+        g["reasons"] |= reasons
+        g["metrics"] += [
+            (m.get("metric_id"), m.get("aggregation"))
+            for m in entry.get("metrics") or []
+            if (m.get("metric_id"), m.get("aggregation")) not in g["metrics"]
+        ]
+        g["hazards"] += [h for h in entry.get("hazards") or [] if h not in g["hazards"]]
+
+    for g in gruppen:
+        vorfaelle.append(UndeliveredIncident(
+            at=g["at"],
+            channels=tuple(c for c in _ALL_CHANNELS if c in g["channels"]),
+            reasons=tuple(sorted(g["reasons"])),
+            metrics=tuple(g["metrics"]),
+            hazards=tuple(g["hazards"]),
+            trigger=g["trigger"],
+        ))
+    return vorfaelle

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -286,10 +286,20 @@ class NotificationService:
             start_hour=_dw_start, end_hour=_dw_end,
         )
 
+        # Issue #1461 S3b-1: was seit dem letzten Briefing dieses Trips einen
+        # Kanal nicht erreicht hat. Echte `user_id` (Mandantentrennung, nie
+        # "default") und die Protokoll-Kennung `trip.id`.
+        from services.alert_briefing_anchor import undelivered_since_last_briefing
+
+        undelivered = undelivered_since_last_briefing(
+            user_id=self._user_id, entity_id=request.trip.id, entity_type="trip",
+        )
+
         report = self._formatter.format_email(
             segments=request.segment_weather,
             trip_name=request.trip.name,
             trip=request.trip,
+            undelivered=undelivered,
             report_type=request.report_type,
             display_config=request.display_config,
             night_weather=request.night_weather,

--- a/src/services/scheduler_dispatch_service.py
+++ b/src/services/scheduler_dispatch_service.py
@@ -19,7 +19,9 @@ from app.loader import (
     load_all_locations,
     load_compare_presets,
 )
-from services.alert_briefing_anchor import write_anchor_and_reset_memory
+from services.alert_briefing_anchor import (
+    undelivered_since_last_briefing, write_anchor_and_reset_memory,
+)
 from services.compare_alert_channels import effective_compare_channels
 
 logger = logging.getLogger("scheduler.dispatch")
@@ -371,8 +373,15 @@ def send_one_compare_preset(
     opts = resolve_compare_render_options(preset)
     # Issue #1110: Abo-Footer-Metadaten (Preset-Name/Schedule/Weekday) zusaetzlich
     # zu den #1104-Parametern durchreichen (Merge beider Feature-Branches).
+    # Issue #1461 S3b-1: die Vorfaelle haengen an der PROTOKOLL-Kennung
+    # (`preset_id`, so schreiben compare_alert.py/compare_official_alert.py) --
+    # NICHT an den Anker-Kennungen f"{preset_id}:{loc.id}" weiter unten.
+    undelivered = undelivered_since_last_briefing(
+        user_id=user_id, entity_id=preset_id, entity_type="compare",
+    )
     html_body, text_body = render_compare_email(
         result,
+        undelivered=undelivered,
         profile=profile,
         enabled_metrics=opts.enabled_metrics,
         hourly_metrics=opts.hourly_metrics,
@@ -415,6 +424,11 @@ def send_one_compare_preset(
         entity_ids=[f"{preset_id}:{loc.id}" for loc in locations],
         write_anchor=lambda: _write_compare_alert_snapshots(preset_id, locations, user_id),
         on_demand=on_demand,
+        # Issue #1461 S3b-1: der Briefing-Zeitstempel gehoert unter die
+        # Protokoll-Kennung `preset_id` — unter den Anker-Kennungen oben
+        # faende `read_undelivered()` nie einen Treffer.
+        briefing_entity_id=preset_id,
+        briefing_entity_type="compare",
     )
 
     save_compare_preset_status(user_id, preset_id, top_ort, data_root=data_root)

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -986,6 +986,10 @@ class TripReportSchedulerService:
             write_anchor=_write_briefing_anchor,
             on_demand=on_demand,
             reset_memory=self._reset_alert_state_after_briefing,
+            # Issue #1461 S3b-1: Briefing-Zeitstempel unter der PROTOKOLL-
+            # Kennung (hier deckungsgleich mit der Anker-Kennung).
+            briefing_entity_id=trip.id,
+            briefing_entity_type="trip",
         )
 
         return "no_channels" if result.no_channel_configured else "sent"

--- a/tests/tdd/test_alert_undelivered_hint.py
+++ b/tests/tdd/test_alert_undelivered_hint.py
@@ -1,0 +1,1596 @@
+"""TDD RED — Issue #1461 Scheibe S3b-1: das Briefing weist aus, welche
+Alarm-Meldungen seit dem letzten Briefing einen Kanal NICHT erreicht haben.
+
+SPEC: docs/specs/modules/feat_1461_s3b1_briefing_sichtbarkeit.md (AC-1 … AC-16)
+
+RED-Grund heute (gemessen): das Alarm-Protokoll aus #1459 hat sechs
+Schreibstellen und NULL Leser auf der Python-Seite. Konkret fehlen:
+
+* ``services.alert_log.read_undelivered()``  — die Lesefunktion
+* ``services.alert_briefing_anchor.record_briefing_sent()`` /
+  ``last_briefing_at()`` — der Zeitraum "seit dem letzten Briefing"
+* ``output.renderers.email.undelivered_hint`` — der Anzeige-Baustein
+* die Durchreichung als kwarg durch ``notification_service`` →
+  ``TripReportFormatter.format_email()`` → ``render_email()`` bzw.
+  ``scheduler_dispatch_service`` → ``render_compare_email()``
+
+Testpolitik (CLAUDE.md "Test-Politik: Zwei Schichten"):
+
+* **Kein Mock-Theater.** Es gibt kein ``Mock()``/``patch()``/``MagicMock``.
+  Die Protokolldateien sind ECHTE ``alert_log.json``-Dateien im echten Schema
+  unter der pytest-isolierten ``app.loader.get_data_dir()``-Basis (#1133).
+  Das Schema der Fixture wird von
+  ``test_fixtur_schema_deckt_sich_mit_der_echten_schreibfunktion`` gegen die
+  echte Schreibfunktion ``alert_log.append_entry()`` gehalten — die Fixture
+  kann also nicht von der Wirklichkeit wegdriften.
+* **Wirkung statt Fähigkeit.** Geprueft wird der TEXT der erzeugten Mail, nicht
+  der Rueckgabewert einer Hilfsfunktion. Das Briefing entsteht ueber den echten
+  Versandpfad (``TripReportSchedulerService._send_trip_report_outcome`` bzw.
+  ``scheduler_dispatch_service.send_one_compare_preset``); der Report wird an
+  einem DELEGIERENDEN Beobachter auf ``TripReportFormatter.format_email``
+  abgegriffen — die echte Methode laeuft unveraendert, es wird nur
+  mitgeschrieben, was sie zurueckgibt (Muster aus
+  ``tests/tdd/test_trip_briefing_anchor_unchanged.py::_ResetRecorder``).
+* **Kein Netz, kein Versand.** Trip: alle Transport-Felder leer (``Settings()``
+  faellt bei fehlenden Feldern still auf die Prod-``.env`` zurueck, #1477).
+  Ortsvergleich: ``mail_sink``-Naht. Wetter ueber den autouse
+  Offline-Fixture-Provider.
+
+Pfadregel #1409: ``REPO_ROOT`` wird relativ zu DIESER Datei aufgeloest.
+
+────────────────────────────────────────────────────────────────────────────
+Der Anzeige-Vertrag, den diese Tests festschreiben (Spec "Beispiel-Ausgabe"):
+
+    NICHT BEI DIR ANGEKOMMEN
+
+      05.08. 18:42 · Gewitter · SMS nicht zugestellt
+      … und 3 weitere
+
+* Ueberschrift: ``UNDELIVERED_HEADING``
+* je Vorfall EINE Zeile, erkennbar am Marker ``"nicht zugestellt"``
+  (im ganzen Repo sonst nirgends im Ausgabetext, gemessen)
+* die Zeile nennt Zeitpunkt (Briefing-Zeitzone), Anlass, Kanaele, Grund
+* Deckelung bei ``MAX_UNDELIVERED_LINES`` = 5, darunter "und N weitere"
+
+Die STRUKTUR je Zeile wird am Klartext-Teil geprueft (dort gibt die Spec ein
+woertliches Beispiel vor); fuer HTML wird die Anwesenheit aller vier Angaben
+und die Zeilen-ANZAHL geprueft, nicht das Markup — sonst schriebe der Test das
+HTML-Geruest fest statt der Zusicherung.
+────────────────────────────────────────────────────────────────────────────
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from app.config import Settings
+from app.loader import get_data_dir, save_location
+from app.models import TripReportConfig
+from app.trip import Stage, Trip, Waypoint
+
+from tests.helpers.alert_log_fixtures import (
+    LAT,
+    LON,
+    gust_alert_trip,
+    settings_email_only,
+    weather,
+)
+
+# Pfadregel #1409: Pruefling relativ zur Testdatei — nie ueber einen festen
+# Hauptrepo-Pfad, sonst pruefte dieser Test aus dem Worktree die unveraenderte
+# Hauptrepo-Kopie und meldete falsches Gruen.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Zeilen-Marker des Hinweis-Abschnitts (s. Modul-Docstring).
+LINE_MARKER = "nicht zugestellt"
+
+ALL_CHANNELS = ("email", "telegram", "sms")
+
+# Alle Transport-Felder ausdruecklich unbrauchbar (#1477).
+_NO_TRANSPORT_FIELDS: dict = {
+    "smtp_host": "", "smtp_user": "", "smtp_pass": "", "mail_to": "",
+    "telegram_bot_token": "", "telegram_chat_id": "",
+    "telegram_test_bot_token": "", "telegram_test_chat_id": "",
+    "sms_gateway_url": "", "seven_api_key": "", "sms_to": "",
+}
+
+
+def _uid(prefix: str) -> str:
+    return f"tdd-1461-s3b1-{prefix}-{uuid.uuid4().hex[:6]}"
+
+
+def _settings_no_transport() -> Settings:
+    return Settings(**_NO_TRANSPORT_FIELDS)
+
+
+def _jetzt() -> datetime:
+    return datetime.now(timezone.utc).replace(second=0, microsecond=0)
+
+
+# ═══════════════════════════ Protokoll-Fixtures ═══════════════════════════
+#
+# Echtes ``alert_log.json`` im Schema von ``alert_log.append_entry()``.
+# Direkt geschrieben (statt ueber ``append_entry``), weil ``append_entry`` den
+# Zeitstempel immer auf "jetzt" setzt — und dieser Test genau die Zeitachse
+# pruefen muss. Das Schema haelt der Drift-Waechter unten fest.
+
+
+def _entry(
+    *,
+    entity_id: str,
+    entity_type: str = "trip",
+    sent_at: datetime,
+    metrics: tuple = (),
+    hazards: tuple = (),
+    reason: str = "forecast_change",
+    channels_sent: tuple = (),
+    not_sent: tuple = (),
+    severity: str = "MODERATE",
+    changes_count: int = 1,
+) -> dict:
+    """Ein Protokoll-Eintrag. ``not_sent`` ist eine Folge von
+    ``(kanal, grund)``-Paaren — genau die Traegerform, die
+    ``alert_log._channels_not_sent()`` erzeugt."""
+    return {
+        "entity_id": entity_id,
+        "entity_type": entity_type,
+        "sent_at": sent_at.astimezone(timezone.utc).isoformat(),
+        "changes_count": changes_count,
+        "severity": severity,
+        "metrics": [{"metric_id": m, "aggregation": a} for m, a in metrics],
+        "hazards": sorted(hazards),
+        "reason": reason,
+        "channels_sent": sorted(channels_sent),
+        "channels_not_sent": [{"channel": c, "reason": r} for c, r in not_sent],
+    }
+
+
+def _write_log(user_id: str, *, entries=(), not_delivered=()) -> Path:
+    path = get_data_dir(user_id) / "alert_log.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(
+        {"entries": list(entries), "not_delivered": list(not_delivered)},
+        indent=2,
+    ))
+    return path
+
+
+def _read_log(user_id: str) -> dict:
+    path = get_data_dir(user_id) / "alert_log.json"
+    data = json.loads(path.read_text())
+    data.setdefault("entries", [])
+    data.setdefault("not_delivered", [])
+    return data
+
+
+def _seed(
+    user_id: str,
+    *,
+    entity_id: str,
+    entity_type: str = "trip",
+    entries=(),
+    not_delivered=(),
+    letztes_briefing: datetime | None = None,
+) -> None:
+    """Protokoll UND Briefing-Zeitstempel setzen — in DIESER Reihenfolge.
+
+    Umgekehrt waere der Test still wertlos, falls der Zeitstempel (eine
+    naheliegende Umsetzung) als weiterer Top-Level-Schluessel IN
+    ``alert_log.json`` landet: das nachtraegliche Schreiben der Protokolldatei
+    wuerde ihn wieder wegwerfen.
+    """
+    _write_log(user_id, entries=entries, not_delivered=not_delivered)
+    if letztes_briefing is not None:
+        from services.alert_briefing_anchor import record_briefing_sent
+
+        record_briefing_sent(
+            user_id=user_id, entity_id=entity_id, entity_type=entity_type,
+            at=letztes_briefing,
+        )
+
+
+# ═══════════════════════════ Briefing-Fixtures ════════════════════════════
+
+
+def _trip(trip_id: str, *, email_format: str = "full") -> Trip:
+    """Tour ohne scharfen Kanal: der Briefing-Pfad laeuft VOLLSTAENDIG durch
+    (Ergebnis ``no_channels``) und rendert die Mail — versendet wird nichts.
+    Muster aus ``test_trip_briefing_anchor_unchanged.py::_trip``."""
+    stage = Stage(
+        id="T1", name="Tag 1", date=date.today(),
+        waypoints=[
+            Waypoint(id="G1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0),
+            Waypoint(id="G2", name="Ziel", lat=LAT + 0.1, lon=LON + 0.1, elevation_m=1500.0),
+        ],
+    )
+    trip = Trip(id=trip_id, name="Hinweis-Trip", stages=[stage], official_warnings=None)
+    trip.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=False, send_telegram=False, send_sms=False,
+        email_format=email_format,
+    )
+    trip.alert_cooldown_minutes = 0
+    return trip
+
+
+def _scheduler_class(gust: float):
+    """Echte Unterklasse des Schedulers (kein Mock): Wetter aus der Fixture."""
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    class _FixtureScheduler(TripReportSchedulerService):
+        def _fetch_weather(self, segments, provider=None):
+            return [weather(s.segment_id, gust_max_kmh=gust) for s in segments]
+
+    return _FixtureScheduler
+
+
+class _ReportRecorder:
+    """DELEGIERENDER Beobachter auf ``TripReportFormatter.format_email``.
+
+    Kein Mock: die echte Methode laeuft unveraendert (die Mail wird also
+    wirklich gebaut), es wird nur festgehalten, WAS sie zurueckgegeben hat.
+    Anders als ein Direktaufruf des Renderers laeuft damit der komplette
+    Versandpfad inklusive echter ``user_id`` — genau der Ort, an dem die
+    Mandantentrennung entschieden wird.
+    """
+
+    def __init__(self) -> None:
+        self.reports: list = []
+
+    def install(self, monkeypatch) -> None:
+        from output.renderers.trip_report import TripReportFormatter
+
+        original = TripReportFormatter.format_email
+        recorder = self
+
+        def _recording_format_email(self, *args, **kwargs):
+            report = original(self, *args, **kwargs)
+            recorder.reports.append(report)
+            return report
+
+        monkeypatch.setattr(TripReportFormatter, "format_email", _recording_format_email)
+
+
+def _run_trip_briefing(recorder, uid: str, trip: Trip, *, on_demand: bool = False,
+                       gust: float = 25.0):
+    """Fuehrt den ECHTEN Briefing-Pfad aus und liefert den erzeugten Report."""
+    scheduler = _scheduler_class(gust)(settings=_settings_no_transport(), user_id=uid)
+    outcome = scheduler._send_trip_report_outcome(trip, "morning", on_demand=on_demand)
+    assert outcome in ("sent", "no_channels"), (
+        f"Voraussetzung: der Briefing-Lauf muss durchlaufen, erhalten {outcome!r}"
+    )
+    assert recorder.reports, "Voraussetzung: es wurde keine Briefing-Mail gebaut"
+    return recorder.reports[-1]
+
+
+def _trip_tz():
+    from utils.timezone import tz_for_coords
+    return tz_for_coords(LAT, LON)
+
+
+# ═══════════════════════════ Text-Auswertung ══════════════════════════════
+
+
+def _heading() -> str:
+    from output.renderers.email.undelivered_hint import UNDELIVERED_HEADING
+    return UNDELIVERED_HEADING
+
+
+def _hint_lines(text: str) -> list[str]:
+    """Die Vorfall-Zeilen des Hinweis-Abschnitts (Marker s. Modul-Docstring)."""
+    return [line.strip() for line in text.splitlines() if LINE_MARKER in line]
+
+
+def _html_as_text(html: str) -> str:
+    """HTML auf Text reduzieren — jedes Element auf eine eigene Zeile."""
+    return re.sub(r"<[^>]+>", "\n", html)
+
+
+def _local_hhmm(moment: datetime) -> str:
+    return moment.astimezone(_trip_tz()).strftime("%H:%M")
+
+
+def _ohne_uhrzeiten(text: str) -> str:
+    """Uhrzeiten entfernen — fuer Gleichheits-Vergleiche zweier Laeufe.
+
+    Die Mail traegt einen Erzeugungs-Zeitstempel auf die Minute genau; zwei
+    Laeufe koennten sonst allein wegen eines Minutenwechsels auseinanderfallen.
+    Die Wetterwerte beider Laeufe sind identisch, es geht also nichts
+    Pruefbares verloren.
+    """
+    return re.sub(r"\d{1,2}:\d{2}(:\d{2})?", "", text)
+
+
+# ═══════════════════ Schema-Waechter fuer die Fixture ═════════════════════
+
+
+def test_fixtur_schema_deckt_sich_mit_der_echten_schreibfunktion():
+    """Die Protokoll-Fixture dieses Tests muss dasselbe Schema haben wie das,
+    was die echte Schreibfunktion erzeugt — sonst pruefen alle folgenden Tests
+    an der Wirklichkeit vorbei (CLAUDE.md: "Fixtures gegen Wirklichkeit").
+
+    Kein Verhaltens-Test des Features, sondern der Waechter ueber der Fixture.
+    """
+    from services import alert_log
+
+    uid = _uid("schema")
+    alert_log.append_entry(
+        uid, entity_id="trip-schema", entity_type="trip", changes_count=1,
+        severity="MODERATE", metrics=[("gust", "max")], hazards=[],
+        reason="forecast_change",
+        effective_channels={"email", "sms"}, sent_channels=["email"],
+    )
+    echt = _read_log(uid)["entries"][0]
+    fixtur = _entry(
+        entity_id="trip-schema", sent_at=datetime.now(timezone.utc),
+        metrics=(("gust", "max"),), reason="forecast_change",
+        channels_sent=("email",), not_sent=(("sms", "delivery_failed"),),
+    )
+    assert set(fixtur) == set(echt), (
+        "Die Fixture-Schluessel weichen von der echten Schreibfunktion ab: "
+        f"nur Fixture {set(fixtur) - set(echt)!r}, nur echt {set(echt) - set(fixtur)!r}"
+    )
+    assert fixtur["channels_not_sent"][0].keys() == echt["channels_not_sent"][0].keys(), (
+        "Die Kanal-Traegerform der Fixture weicht ab: "
+        f"{fixtur['channels_not_sent'][0]!r} vs. {echt['channels_not_sent'][0]!r}"
+    )
+
+
+# ══════════════════════════════════ AC-1 ══════════════════════════════════
+
+
+def test_ac1_teilausfall_zeile_nennt_zeit_groesse_kanal_und_grund(monkeypatch):
+    """AC-1.
+
+    GIVEN ein Alarm wurde per E-Mail zugestellt, erreichte aber die SMS nicht
+          (``entries[*].channels_not_sent = [{sms, delivery_failed}]``).
+    WHEN  das naechste Briefing des Trips erzeugt wird.
+    THEN  enthaelt die Briefing-Mail EINE Zeile, die den Zeitpunkt in der
+          Zeitzone des Briefings, die betroffene Wettergroesse, den Kanal
+          'SMS' und den Grund nennt.
+
+    Die Zeitzone ist der Kern: der Protokoll-Zeitstempel steht in UTC. Steht
+    in der Zeile die UTC-Uhrzeit, ist AC-1 verletzt — auch wenn 'eine Zeile'
+    da ist.
+    """
+    uid = _uid("ac1")
+    trip = _trip(f"trip-ac1-{uuid.uuid4().hex[:6]}")
+
+    jetzt = _jetzt()
+    vorfall = jetzt - timedelta(hours=3)
+    _seed(uid, entity_id=trip.id, letztes_briefing=jetzt - timedelta(hours=6),
+          entries=[_entry(
+              entity_id=trip.id, sent_at=vorfall, metrics=(("gust", "max"),),
+              reason="forecast_change", channels_sent=("email",),
+              not_sent=(("sms", "delivery_failed"),),
+          )])
+
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+    report = _run_trip_briefing(recorder, uid, trip)
+
+    zeilen = _hint_lines(report.email_plain)
+    assert len(zeilen) == 1, (
+        "AC-1: Genau EINE Vorfall-Zeile erwartet, gefunden "
+        f"{len(zeilen)}: {zeilen!r}\n--- Klartext-Mail ---\n{report.email_plain}"
+    )
+    zeile = zeilen[0]
+    lokal = _local_hhmm(vorfall)
+    utc = vorfall.strftime("%H:%M")
+    assert lokal in zeile, (
+        f"AC-1: Der Zeitpunkt muss in der Briefing-Zeitzone stehen ({lokal}), "
+        f"Zeile: {zeile!r}"
+    )
+    if utc != lokal:
+        assert utc not in zeile, (
+            f"AC-1: In der Zeile steht die UTC-Uhrzeit {utc} statt der "
+            f"Ortszeit {lokal}: {zeile!r}"
+        )
+    assert "Böen" in zeile, (
+        f"AC-1: Die betroffene Wettergroesse (Katalog-Name 'Böen') fehlt: {zeile!r}"
+    )
+    assert "SMS" in zeile, f"AC-1: Der betroffene Kanal 'SMS' fehlt: {zeile!r}"
+    assert "Telegram" not in zeile and "E-Mail" not in zeile, (
+        f"AC-1: Nur der SMS-Kanal war betroffen — die Zeile nennt weitere: {zeile!r}"
+    )
+
+    # Dieselbe Zusicherung im HTML-Teil derselben Mail.
+    html_text = _html_as_text(report.email_html)
+    assert _heading() in html_text, "AC-1: Die HTML-Mail traegt keine Ueberschrift."
+    assert len(_hint_lines(html_text)) == 1, (
+        f"AC-1: Die HTML-Mail muss genau eine Vorfall-Zeile tragen, gefunden "
+        f"{_hint_lines(html_text)!r}"
+    )
+    for angabe in (lokal, "Böen", "SMS"):
+        assert angabe in html_text, (
+            f"AC-1: {angabe!r} fehlt im HTML-Teil der Briefing-Mail."
+        )
+
+
+# ══════════════════════════════════ AC-2 ══════════════════════════════════
+
+
+def test_ac2_totalausfall_nennt_alle_betroffenen_kanaele(monkeypatch):
+    """AC-2.
+
+    GIVEN eine Alarm-Meldung erreichte KEINEN einzigen Kanal (Eintrag unter
+          ``not_delivered``, alle drei Kanaele ``delivery_failed``).
+    WHEN  das naechste Briefing erzeugt wird.
+    THEN  erscheint sie ebenfalls als Zeile — mit ALLEN betroffenen Kanaelen.
+    """
+    uid = _uid("ac2")
+    trip = _trip(f"trip-ac2-{uuid.uuid4().hex[:6]}")
+
+    jetzt = _jetzt()
+    vorfall = jetzt - timedelta(hours=2)
+    _seed(uid, entity_id=trip.id, letztes_briefing=jetzt - timedelta(hours=6),
+          not_delivered=[_entry(
+              entity_id=trip.id, sent_at=vorfall, hazards=("thunderstorm",),
+              reason="official_alert", channels_sent=(),
+              not_sent=tuple((c, "delivery_failed") for c in ALL_CHANNELS),
+          )])
+
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+    report = _run_trip_briefing(recorder, uid, trip)
+
+    zeilen = _hint_lines(report.email_plain)
+    assert len(zeilen) == 1, (
+        f"AC-2: Der Totalausfall muss als genau eine Zeile erscheinen, gefunden "
+        f"{zeilen!r}\n--- Klartext-Mail ---\n{report.email_plain}"
+    )
+    zeile = zeilen[0]
+    for kanal in ("E-Mail", "Telegram", "SMS"):
+        assert kanal in zeile, (
+            f"AC-2: Bei einem Totalausfall muessen ALLE betroffenen Kanaele in "
+            f"der Zeile stehen — {kanal!r} fehlt: {zeile!r}"
+        )
+    assert "Amtliche Warnung" in zeile, (
+        f"AC-2: Der Anlass (amtliche Warnung) fehlt in der Zeile: {zeile!r}"
+    )
+
+
+# ══════════════════════════════════ AC-3 ══════════════════════════════════
+
+
+def test_ac3_alles_zugestellt_erzeugt_keinen_abschnitt(monkeypatch):
+    """AC-3.
+
+    GIVEN seit dem letzten Briefing wurde jede Meldung auf jedem
+          EINGESCHALTETEN Kanal zugestellt.
+    WHEN  das Briefing erzeugt wird.
+    THEN  enthaelt es KEINERLEI Hinweis-Abschnitt — auch keine Ueberschrift
+          und keine Null-Zeile.
+    """
+    uid = _uid("ac3")
+    trip = _trip(f"trip-ac3-{uuid.uuid4().hex[:6]}")
+
+    jetzt = _jetzt()
+    _seed(uid, entity_id=trip.id, letztes_briefing=jetzt - timedelta(hours=6),
+          entries=[_entry(
+              entity_id=trip.id, sent_at=jetzt - timedelta(hours=2),
+              metrics=(("gust", "max"),), reason="forecast_change",
+              channels_sent=("email", "sms", "telegram"), not_sent=(),
+          )])
+
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+    report = _run_trip_briefing(recorder, uid, trip)
+
+    for teil, name in ((report.email_plain, "Klartext"),
+                       (_html_as_text(report.email_html), "HTML")):
+        assert _heading() not in teil, (
+            f"AC-3: Ohne fehlende Zustellung darf im {name}-Teil keine "
+            f"Ueberschrift stehen."
+        )
+        assert _hint_lines(teil) == [], (
+            f"AC-3: Ohne fehlende Zustellung darf im {name}-Teil keine Zeile "
+            f"stehen, gefunden {_hint_lines(teil)!r}"
+        )
+
+
+def test_ac3_abgeschalteter_kanal_ist_kein_vorfall(monkeypatch):
+    """AC-3 (die entscheidende Haelfte — Wortlaut 'auf jedem EINGESCHALTETEN
+    Kanal').
+
+    GIVEN ein Nutzer hat nur E-Mail eingeschaltet; die Meldung ging per E-Mail
+          raus, und ``channels_not_sent`` fuehrt Telegram und SMS mit dem Grund
+          ``channel_disabled`` (genau das schreibt
+          ``alert_log._channels_not_sent()`` fuer JEDEN erfolgreichen Alarm
+          eines Ein-Kanal-Nutzers).
+    WHEN  das Briefing erzeugt wird.
+    THEN  erscheint KEIN Hinweis-Abschnitt.
+
+    Ohne diese Abgrenzung stuende der Abschnitt bei jedem Ein-Kanal-Nutzer in
+    JEDEM Briefing und meldete abgeschaltete Kanaele als 'nicht angekommen' —
+    AC-3 waere strukturell nie erfuellbar.
+    """
+    uid = _uid("ac3b")
+    trip = _trip(f"trip-ac3b-{uuid.uuid4().hex[:6]}")
+
+    jetzt = _jetzt()
+    _seed(uid, entity_id=trip.id, letztes_briefing=jetzt - timedelta(hours=6),
+          entries=[_entry(
+              entity_id=trip.id, sent_at=jetzt - timedelta(hours=2),
+              metrics=(("gust", "max"),), reason="forecast_change",
+              channels_sent=("email",),
+              not_sent=(("telegram", "channel_disabled"), ("sms", "channel_disabled")),
+          )])
+
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+    report = _run_trip_briefing(recorder, uid, trip)
+
+    assert _heading() not in report.email_plain, (
+        "AC-3: Ein vom Nutzer ABGESCHALTETER Kanal ist keine fehlgeschlagene "
+        "Zustellung — es darf kein Abschnitt erscheinen.\n"
+        f"--- Klartext-Mail ---\n{report.email_plain}"
+    )
+    assert _hint_lines(report.email_plain) == [], (
+        f"AC-3: unerwartete Zeilen: {_hint_lines(report.email_plain)!r}"
+    )
+
+
+# ══════════════════════════════════ AC-4 ══════════════════════════════════
+
+
+def test_ac4_bereits_ausgewiesener_vorfall_erscheint_nicht_erneut(monkeypatch):
+    """AC-4.
+
+    GIVEN eine nicht zugestellte Meldung wurde in einem frueheren Briefing
+          bereits ausgewiesen.
+    WHEN  das darauffolgende Briefing erzeugt wird.
+    THEN  erscheint sie NICHT erneut.
+
+    Zwei ECHTE Briefing-Laeufe hintereinander: der erste schreibt beim
+    Anker-Baustein den Briefing-Zeitstempel fort, der zweite liest ihn.
+    """
+    uid = _uid("ac4")
+    trip = _trip(f"trip-ac4-{uuid.uuid4().hex[:6]}")
+
+    jetzt = _jetzt()
+    _seed(uid, entity_id=trip.id, letztes_briefing=jetzt - timedelta(hours=6),
+          not_delivered=[_entry(
+              entity_id=trip.id, sent_at=jetzt - timedelta(hours=2),
+              metrics=(("thunder", "max"),), reason="forecast_change",
+              channels_sent=(), not_sent=(("sms", "delivery_failed"),),
+          )])
+
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+
+    erstes = _run_trip_briefing(recorder, uid, trip)
+    assert len(_hint_lines(erstes.email_plain)) == 1, (
+        "AC-4 Voraussetzung: das ERSTE Briefing muss den Vorfall ausweisen, "
+        f"gefunden {_hint_lines(erstes.email_plain)!r}"
+    )
+
+    zweites = _run_trip_briefing(recorder, uid, trip)
+    assert _hint_lines(zweites.email_plain) == [], (
+        "AC-4: Ein bereits ausgewiesener Vorfall darf im darauffolgenden "
+        f"Briefing nicht erneut erscheinen: {_hint_lines(zweites.email_plain)!r}"
+    )
+    assert _heading() not in zweites.email_plain, (
+        "AC-4: Im zweiten Briefing darf auch die Ueberschrift nicht mehr stehen."
+    )
+
+
+# ══════════════════════════════════ AC-5 ══════════════════════════════════
+
+
+def test_ac5_ein_lauf_mit_zwei_eintraegen_ergibt_eine_zeile(monkeypatch):
+    """AC-5 — Entdoppelung (Risiko 1 des Kontexts).
+
+    GIVEN ein einziger Alarm-Lauf hat wegen gleichzeitiger Vorhersage-Aenderung
+          und amtlicher Warnung MEHRERE Protokolleintraege erzeugt (drei
+          getrennte ``append_entry``-Aufrufe: ``trip_alert.py:278``, ``:877``,
+          ``:1150``), die alle niemanden erreichten.
+    WHEN  das Briefing erzeugt wird.
+    THEN  steht dafuer EINE Zeile, nicht mehrere, und die betroffenen Kanaele
+          sind darin zusammengefasst.
+    """
+    uid = _uid("ac5")
+    trip = _trip(f"trip-ac5-{uuid.uuid4().hex[:6]}")
+
+    jetzt = _jetzt()
+    lauf = jetzt - timedelta(hours=2)
+    _seed(uid, entity_id=trip.id, letztes_briefing=jetzt - timedelta(hours=6),
+          not_delivered=[
+              _entry(entity_id=trip.id, sent_at=lauf, metrics=(("thunder", "max"),),
+                     reason="forecast_change", channels_sent=(),
+                     not_sent=(("sms", "delivery_failed"),)),
+              _entry(entity_id=trip.id, sent_at=lauf, hazards=("thunderstorm",),
+                     reason="official_alert", channels_sent=(),
+                     not_sent=(("telegram", "delivery_failed"),)),
+          ])
+
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+    report = _run_trip_briefing(recorder, uid, trip)
+
+    zeilen = _hint_lines(report.email_plain)
+    assert len(zeilen) == 1, (
+        "AC-5: Mehrere Protokolleintraege desselben Laufs sind fuer den Nutzer "
+        f"EIN Vorfall — erwartet 1 Zeile, gefunden {len(zeilen)}: "
+        f"{zeilen!r}\n--- Klartext-Mail ---\n{report.email_plain}"
+    )
+    zeile = zeilen[0]
+    assert "SMS" in zeile and "Telegram" in zeile, (
+        "AC-5: Die betroffenen Kanaele beider Eintraege muessen in der EINEN "
+        f"Zeile zusammengefasst sein: {zeile!r}"
+    )
+
+
+# ══════════════════════════════════ AC-6 ══════════════════════════════════
+
+
+def test_ac6_deckelung_fuenf_zeilen_plus_und_drei_weitere(monkeypatch):
+    """AC-6.
+
+    GIVEN mehr als fuenf Meldungen haben seit dem letzten Briefing einen Kanal
+          nicht erreicht (hier acht, je eine volle Stunde auseinander — also
+          ausserhalb jedes Entdoppelungs-Fensters).
+    WHEN  das Briefing erzeugt wird.
+    THEN  stehen die FUENF JUENGSTEN als Zeilen da, gefolgt von einem Hinweis,
+          wie viele weitere es sind.
+    """
+    from output.renderers.email.undelivered_hint import MAX_UNDELIVERED_LINES
+
+    uid = _uid("ac6")
+    trip = _trip(f"trip-ac6-{uuid.uuid4().hex[:6]}")
+
+    jetzt = _jetzt()
+    zeitpunkte = [jetzt - timedelta(hours=n) for n in range(1, 9)]
+    _seed(uid, entity_id=trip.id, letztes_briefing=jetzt - timedelta(hours=24),
+          not_delivered=[
+              _entry(entity_id=trip.id, sent_at=t, metrics=(("thunder", "max"),),
+                     reason="forecast_change", channels_sent=(),
+                     not_sent=(("sms", "delivery_failed"),))
+              for t in zeitpunkte
+          ])
+
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+    report = _run_trip_briefing(recorder, uid, trip)
+
+    zeilen = _hint_lines(report.email_plain)
+    assert MAX_UNDELIVERED_LINES == 5, (
+        f"Die Deckelung ist auf 5 Zeilen freigegeben, ist {MAX_UNDELIVERED_LINES}"
+    )
+    assert len(zeilen) == 5, (
+        f"AC-6: Bei acht Vorfaellen erwartet 5 Zeilen, gefunden {len(zeilen)}: "
+        f"{zeilen!r}\n--- Klartext-Mail ---\n{report.email_plain}"
+    )
+    gezeigt = "\n".join(zeilen)
+    for t in zeitpunkte[:5]:
+        assert _local_hhmm(t) in gezeigt, (
+            f"AC-6: Der Vorfall von {_local_hhmm(t)} gehoert zu den fuenf "
+            f"juengsten und fehlt: {zeilen!r}"
+        )
+    for t in zeitpunkte[5:]:
+        assert _local_hhmm(t) not in gezeigt, (
+            f"AC-6: Der Vorfall von {_local_hhmm(t)} ist aelter als die fuenf "
+            f"juengsten und darf keine eigene Zeile haben: {zeilen!r}"
+        )
+    assert re.search(r"und\s+3\s+weitere", report.email_plain), (
+        "AC-6: Der Hinweis 'und 3 weitere' fehlt.\n"
+        f"--- Klartext-Mail ---\n{report.email_plain}"
+    )
+
+
+# ══════════════════════════════════ AC-7 ══════════════════════════════════
+
+
+def test_ac7_erstes_briefing_ohne_anker_zeigt_keine_altlasten(monkeypatch):
+    """AC-7.
+
+    GIVEN ein Nutzer bekommt zum ersten Mal ein Briefing, nachdem diese
+          Funktion ausgeliefert wurde; sein Protokoll enthaelt alte nicht
+          zugestellte Meldungen und es gibt KEINEN gespeicherten
+          Briefing-Zeitpunkt.
+    WHEN  das Briefing erzeugt wird.
+    THEN  wird KEINE dieser Alt-Meldungen ausgewiesen (Rueckblick beginnt ab
+          jetzt, nicht ueber die unbestimmte Vergangenheit).
+    """
+    from services.alert_briefing_anchor import last_briefing_at
+
+    uid = _uid("ac7")
+    trip = _trip(f"trip-ac7-{uuid.uuid4().hex[:6]}")
+
+    jetzt = _jetzt()
+    _seed(uid, entity_id=trip.id, not_delivered=[
+        _entry(entity_id=trip.id, sent_at=jetzt - timedelta(days=n),
+               metrics=(("thunder", "max"),), reason="forecast_change",
+               channels_sent=(), not_sent=(("sms", "delivery_failed"),))
+        for n in (2, 3, 5)
+    ])
+    assert last_briefing_at(user_id=uid, entity_id=trip.id, entity_type="trip") is None, (
+        "AC-7 Voraussetzung: es darf noch kein Briefing-Zeitstempel existieren"
+    )
+
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+    report = _run_trip_briefing(recorder, uid, trip)
+
+    assert _hint_lines(report.email_plain) == [], (
+        "AC-7: Beim ersten Briefing nach der Auslieferung darf keine "
+        f"Alt-Meldung erscheinen: {_hint_lines(report.email_plain)!r}"
+    )
+    assert _heading() not in report.email_plain, (
+        "AC-7: Auch die Ueberschrift darf nicht erscheinen."
+    )
+    assert last_briefing_at(user_id=uid, entity_id=trip.id, entity_type="trip") is not None, (
+        "AC-7: Nach dem Briefing muss der Zeitstempel gesetzt sein — sonst "
+        "faengt der Rueckblick nie an zu laufen."
+    )
+
+
+# ══════════════════════════════════ AC-8 ══════════════════════════════════
+
+
+def test_ac8_selbstabruf_schneidet_den_zeitraum_nicht_ab(monkeypatch):
+    """AC-8.
+
+    GIVEN ein Nutzer ruft ein Briefing selbst ab (``on_demand=True``, kein
+          geplanter Versand).
+    WHEN  er danach das naechste GEPLANTE Briefing bekommt.
+    THEN  sind die nicht zugestellten Meldungen dort IMMER NOCH ausgewiesen —
+          der Selbstabruf hat den Zeitraum nicht abgeschnitten. Im Selbstabruf
+          selbst stehen sie ebenfalls.
+    """
+    uid = _uid("ac8")
+    trip = _trip(f"trip-ac8-{uuid.uuid4().hex[:6]}")
+
+    jetzt = _jetzt()
+    _seed(uid, entity_id=trip.id, letztes_briefing=jetzt - timedelta(hours=6),
+          not_delivered=[_entry(
+              entity_id=trip.id, sent_at=jetzt - timedelta(hours=2),
+              metrics=(("thunder", "max"),), reason="forecast_change",
+              channels_sent=(), not_sent=(("sms", "delivery_failed"),),
+          )])
+
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+
+    abruf = _run_trip_briefing(recorder, uid, trip, on_demand=True)
+    assert len(_hint_lines(abruf.email_plain)) == 1, (
+        "AC-8: Auch der Selbstabruf weist den Vorfall aus, gefunden "
+        f"{_hint_lines(abruf.email_plain)!r}"
+    )
+
+    geplant = _run_trip_briefing(recorder, uid, trip, on_demand=False)
+    assert len(_hint_lines(geplant.email_plain)) == 1, (
+        "AC-8: Der Selbstabruf darf den Zeitraum NICHT abschneiden — im "
+        "darauffolgenden geplanten Briefing muss der Vorfall immer noch "
+        f"stehen, gefunden {_hint_lines(geplant.email_plain)!r}"
+    )
+
+
+# ══════════════════════════════════ AC-9 ══════════════════════════════════
+
+
+def test_ac9_abschnitt_erscheint_in_full_und_compact(monkeypatch):
+    """AC-9.
+
+    GIVEN es liegen nicht zugestellte Meldungen vor.
+    WHEN  ein Briefing im Format ``full`` UND eines im Format ``compact``
+          erzeugt wird.
+    THEN  enthalten BEIDE den Abschnitt.
+    """
+    jetzt = _jetzt()
+    ergebnis = {}
+    for fmt in ("full", "compact"):
+        uid = _uid(f"ac9-{fmt}")
+        trip = _trip(f"trip-ac9-{fmt}-{uuid.uuid4().hex[:6]}", email_format=fmt)
+        _seed(uid, entity_id=trip.id, letztes_briefing=jetzt - timedelta(hours=6),
+              not_delivered=[_entry(
+                  entity_id=trip.id, sent_at=jetzt - timedelta(hours=2),
+                  metrics=(("thunder", "max"),), reason="forecast_change",
+                  channels_sent=(), not_sent=(("sms", "delivery_failed"),),
+              )])
+        recorder = _ReportRecorder()
+        recorder.install(monkeypatch)
+        ergebnis[fmt] = _run_trip_briefing(recorder, uid, trip)
+
+    voll = ergebnis["full"]
+    kompakt = ergebnis["compact"]
+
+    assert len(_hint_lines(voll.email_plain)) == 1, (
+        f"AC-9 (full): Abschnitt fehlt.\n{voll.email_plain}"
+    )
+    assert len(_hint_lines(_html_as_text(voll.email_html))) == 1, (
+        "AC-9 (full/HTML): Abschnitt fehlt im HTML-Teil."
+    )
+    assert kompakt.email_html == "", (
+        "Voraussetzung: das compact-Format erzeugt kein HTML"
+    )
+    assert len(_hint_lines(kompakt.email_plain)) == 1, (
+        "AC-9 (compact): Der Abschnitt MUSS auch im Kurzformat der Mail "
+        f"stehen.\n--- compact ---\n{kompakt.email_plain}"
+    )
+    assert _heading() in kompakt.email_plain, (
+        "AC-9 (compact): Die Ueberschrift fehlt."
+    )
+    assert kompakt.email_plain.isascii(), (
+        "AC-9 (compact): Das Kurzformat muss reines ASCII bleiben — der neue "
+        "Abschnitt bricht das."
+    )
+
+
+# ══════════════════════════════════ AC-10 ═════════════════════════════════
+
+
+def test_ac10_kurznachricht_zeichengleich_mit_und_ohne_vorfaelle(monkeypatch):
+    """AC-10.
+
+    GIVEN es liegen nicht zugestellte Meldungen vor.
+    WHEN  die Kurznachrichten fuer Telegram und SMS erzeugt werden.
+    THEN  sind diese Zeichen fuer Zeichen identisch mit denen ohne solche
+          Meldungen (PO: die Kurznachricht bleibt unberuehrt).
+
+    Der Test ist bewusst NICHT leer-laufend: er stellt zuerst fest, dass der
+    Abschnitt in der MAIL desselben Laufs tatsaechlich erscheint — sonst
+    verglichen wir zwei Male dasselbe Nichts.
+    """
+    jetzt = _jetzt()
+
+    uid_mit = _uid("ac10-mit")
+    trip_mit = _trip(f"trip-ac10-{uuid.uuid4().hex[:6]}")
+    _seed(uid_mit, entity_id=trip_mit.id, letztes_briefing=jetzt - timedelta(hours=6),
+          not_delivered=[_entry(
+              entity_id=trip_mit.id, sent_at=jetzt - timedelta(hours=2),
+              metrics=(("thunder", "max"),), reason="forecast_change",
+              channels_sent=(), not_sent=(("sms", "delivery_failed"),),
+          )])
+    rec_mit = _ReportRecorder()
+    rec_mit.install(monkeypatch)
+    mit = _run_trip_briefing(rec_mit, uid_mit, trip_mit)
+
+    uid_ohne = _uid("ac10-ohne")
+    trip_ohne = _trip(f"trip-ac10-{uuid.uuid4().hex[:6]}")
+    _write_log(uid_ohne)
+    rec_ohne = _ReportRecorder()
+    rec_ohne.install(monkeypatch)
+    ohne = _run_trip_briefing(rec_ohne, uid_ohne, trip_ohne)
+
+    assert len(_hint_lines(mit.email_plain)) == 1, (
+        "AC-10 Voraussetzung: der Lauf MIT Vorfaellen muss den Abschnitt in "
+        f"der Mail zeigen, sonst prueft der Vergleich nichts.\n{mit.email_plain}"
+    )
+    assert _hint_lines(ohne.email_plain) == [], (
+        "AC-10 Voraussetzung: der Lauf OHNE Vorfaelle darf keinen Abschnitt zeigen."
+    )
+
+    assert mit.sms_text == ohne.sms_text, (
+        "AC-10: Der SMS-Text muss Zeichen fuer Zeichen identisch bleiben.\n"
+        f"mit:  {mit.sms_text!r}\nohne: {ohne.sms_text!r}"
+    )
+    assert mit.telegram_bubbles == ohne.telegram_bubbles, (
+        "AC-10: Die Telegram-Kurzform muss Zeichen fuer Zeichen identisch "
+        f"bleiben.\nmit:  {mit.telegram_bubbles!r}\nohne: {ohne.telegram_bubbles!r}"
+    )
+
+
+# ══════════════════════════════════ AC-11 ═════════════════════════════════
+
+
+def _compare_preset(uid: str, preset_id: str) -> dict:
+    return {
+        "id": preset_id, "name": "Vergleich S3b-1", "user_id": uid,
+        "location_ids": ["loc-a", "loc-b"], "schedule": "daily", "weekday": 4,
+        "profil": "ALLGEMEIN", "hour_from": 9, "hour_to": 16,
+        "empfaenger": ["dummy@example.com"], "created_at": "2026-08-01T00:00:00Z",
+    }
+
+
+def _setup_compare_locations(uid: str) -> None:
+    from app.user import SavedLocation
+
+    save_location(SavedLocation(id="loc-a", name="Vergleichsort", lat=LAT, lon=LON,
+                                elevation_m=1000), user_id=uid)
+    save_location(SavedLocation(id="loc-b", name="Zweitort", lat=LAT + 0.2, lon=LON + 0.2,
+                                elevation_m=900), user_id=uid)
+
+
+def _run_compare_briefing(uid: str, preset: dict, data_root, *, on_demand: bool = False) -> str:
+    """ECHTER Ortsvergleichs-Versandpfad; liefert den HTML-Body der Mail."""
+    from services.scheduler_dispatch_service import send_one_compare_preset
+
+    mails: list = []
+    send_one_compare_preset(
+        preset, settings_email_only(), uid, data_root=str(data_root),
+        mail_sink=lambda subject, body: mails.append((subject, body)),
+        on_demand=on_demand,
+    )
+    assert mails, "Voraussetzung: die Vergleichs-Mail wurde nicht erzeugt"
+    return mails[-1][1]
+
+
+def test_ac11_ortsvergleich_zeigt_vorfall_unter_der_preset_kennung(tmp_path):
+    """AC-11 — deckt den gemessenen KENNUNGS-FALLSTRICK ab.
+
+    GIVEN ein Ortsvergleich hat eine Meldung, die einen Kanal nicht erreicht
+          hat. Das Protokoll schreibt sie unter ``entity_id = preset_id``
+          (``compare_alert.py:193``, ``compare_official_alert.py:151``) —
+          NICHT unter ``f"{preset_id}:{loc.id}"``, das nur der Anker-Baustein
+          bekommt (``scheduler_dispatch_service.py:413``).
+    WHEN  das Ortsvergleichs-Briefing erzeugt wird.
+    THEN  erscheint der Abschnitt dort mit derselben Zeilenform wie beim Trip
+          — und ist NICHT leer.
+
+    Wer den Briefing-Zeitstempel unter den Anker-Kennungen ablegt, findet beim
+    Lesen nie einen Treffer: ``last_briefing_at(preset_id)`` bliebe ``None``,
+    der Rueckblick begaenne 'ab jetzt' und der Vorfall verschwaende. Genau das
+    macht dieser Test rot.
+    """
+    uid = _uid("ac11")
+    preset_id = f"cp-ac11-{uuid.uuid4().hex[:6]}"
+    _setup_compare_locations(uid)
+
+    jetzt = _jetzt()
+    _seed(uid, entity_id=preset_id, entity_type="compare",
+          letztes_briefing=jetzt - timedelta(hours=6),
+          not_delivered=[_entry(
+              entity_id=preset_id, entity_type="compare",
+              sent_at=jetzt - timedelta(hours=2), metrics=(("thunder", "max"),),
+              reason="forecast_change", channels_sent=(),
+              not_sent=(("sms", "delivery_failed"),),
+          )])
+
+    html = _run_compare_briefing(uid, _compare_preset(uid, preset_id), tmp_path)
+    text = _html_as_text(html)
+
+    assert _heading() in text, (
+        "AC-11: Die Ortsvergleichs-Mail traegt keine Hinweis-Ueberschrift."
+    )
+    zeilen = _hint_lines(text)
+    assert len(zeilen) == 1, (
+        "AC-11: Der Abschnitt muss im Ortsvergleich mit derselben Zeilenform "
+        f"erscheinen und darf NICHT leer sein, gefunden {zeilen!r}"
+    )
+    assert "Gewitter" in zeilen[0] and "SMS" in zeilen[0], (
+        f"AC-11: Anlass und Kanal fehlen in der Zeile: {zeilen[0]!r}"
+    )
+
+
+def test_ac11_ortsvergleich_schreibt_zeitstempel_unter_die_protokoll_kennung(tmp_path):
+    """AC-11 (die andere Haelfte des Fallstricks — die SCHREIBSEITE).
+
+    GIVEN ein Ortsvergleichs-Briefing laeuft regulaer durch.
+    WHEN  danach der Briefing-Zeitstempel gesucht wird.
+    THEN  steht er unter der PROTOKOLL-Kennung (``preset_id`` / ``compare``),
+          nicht unter den Anker-Kennungen ``f"{preset_id}:{loc.id}"``.
+
+    Ohne diesen Test bliebe die Verwechslung unbemerkt: der Hinweis waere beim
+    Ortsvergleich dauerhaft leer, und kein Test wuerde rot.
+    """
+    from services.alert_briefing_anchor import last_briefing_at
+
+    uid = _uid("ac11b")
+    preset_id = f"cp-ac11b-{uuid.uuid4().hex[:6]}"
+    _setup_compare_locations(uid)
+    _write_log(uid)
+
+    assert last_briefing_at(user_id=uid, entity_id=preset_id, entity_type="compare") is None, (
+        "Voraussetzung: noch kein Briefing-Zeitstempel"
+    )
+    _run_compare_briefing(uid, _compare_preset(uid, preset_id), tmp_path)
+
+    unter_protokoll = last_briefing_at(user_id=uid, entity_id=preset_id, entity_type="compare")
+    assert unter_protokoll is not None, (
+        "AC-11: Nach dem Ortsvergleichs-Briefing MUSS ein Zeitstempel unter der "
+        f"Protokoll-Kennung {preset_id!r} stehen. Liegt er unter den "
+        f"Anker-Kennungen '{preset_id}:loc-a'/'{preset_id}:loc-b', findet die "
+        "Lesefunktion nie einen Treffer und der Hinweis bleibt dauerhaft leer."
+    )
+    for loc_id in ("loc-a", "loc-b"):
+        assert last_briefing_at(
+            user_id=uid, entity_id=f"{preset_id}:{loc_id}", entity_type="compare",
+        ) is None, (
+            f"AC-11: Unter der Anker-Kennung '{preset_id}:{loc_id}' darf KEIN "
+            "Briefing-Zeitstempel liegen — das ist genau die Verwechslung."
+        )
+
+
+# ══════════════════════════════════ AC-17 ═════════════════════════════════
+
+
+class _CompareMailRecorder:
+    """DELEGIERENDER Beobachter auf ``render_compare_email``.
+
+    Kein Mock: die echte Funktion laeuft unveraendert, es wird nur
+    festgehalten, WAS sie zurueckgegeben hat (Muster ``_ReportRecorder``).
+
+    Noetig, weil der ``mail_sink`` ausschliesslich den HTML-Body bekommt
+    (``notification_service.send_compare_report``); der Klartext-Teil geht als
+    ``plain_text_body`` an den echten Transport und waere aus dem Test sonst
+    gar nicht sichtbar. Genau dieser blinde Fleck liess in #1366 den Schalter
+    ``hourly_enabled`` im Klartext monatelang wirkungslos — der
+    Pflicht-Validator ``email_spec_validator`` liest nur HTML.
+    """
+
+    def __init__(self) -> None:
+        self.bodies: list[tuple[str, str]] = []
+
+    def install(self, monkeypatch) -> None:
+        import output.renderers.comparison as _cmp
+
+        original = _cmp.render_compare_email
+        recorder = self
+
+        def _recording_render_compare_email(*args, **kwargs):
+            html_body, text_body = original(*args, **kwargs)
+            recorder.bodies.append((html_body, text_body))
+            return html_body, text_body
+
+        # `scheduler_dispatch_service` importiert die Funktion erst IM Aufruf
+        # (`from output.renderers.comparison import render_compare_email`),
+        # deshalb wirkt das Setzen am Ursprungsmodul.
+        monkeypatch.setattr(_cmp, "render_compare_email", _recording_render_compare_email)
+
+
+def _run_compare_briefing_texts(recorder, uid, preset, data_root) -> tuple[str, str]:
+    _run_compare_briefing(uid, preset, data_root)
+    assert recorder.bodies, "Voraussetzung: die Vergleichs-Mail wurde nicht gebaut"
+    return recorder.bodies[-1]
+
+
+def test_ac17_ortsvergleich_klartext_zeigt_den_abschnitt_ebenfalls(tmp_path, monkeypatch):
+    """AC-17 (Spec v1.2).
+
+    GIVEN ein Ortsvergleich hat eine Meldung, die einen Kanal nicht erreicht
+          hat.
+    WHEN  das Ortsvergleichs-Briefing erzeugt wird.
+    THEN  traegt auch der KLARTEXT-Teil der Mail den Abschnitt — dieselbe
+          Zeilenform wie HTML und Trip.
+
+    Beide Fassungen werden zugestellt (`send_compare_report(..., html_body,
+    plain_text_body=text_body)`); "nur E-Mail" meint die Mail, nicht ihre
+    HTML-Haelfte. Ohne diesen Test bliebe der Klartext-Teil des Ortsvergleichs
+    schlechter gestellt als der des Trips (`email/plain.py`) — und kein
+    Pflicht-Validator wuerde es merken (#1366).
+    """
+    uid = _uid("ac17")
+    preset_id = f"cp-ac17-{uuid.uuid4().hex[:6]}"
+    _setup_compare_locations(uid)
+
+    jetzt = _jetzt()
+    _seed(uid, entity_id=preset_id, entity_type="compare",
+          letztes_briefing=jetzt - timedelta(hours=6),
+          not_delivered=[_entry(
+              entity_id=preset_id, entity_type="compare",
+              sent_at=jetzt - timedelta(hours=2), metrics=(("thunder", "max"),),
+              reason="forecast_change", channels_sent=(),
+              not_sent=(("sms", "delivery_failed"),),
+          )])
+
+    recorder = _CompareMailRecorder()
+    recorder.install(monkeypatch)
+    html, text = _run_compare_briefing_texts(
+        recorder, uid, _compare_preset(uid, preset_id), tmp_path,
+    )
+
+    assert _heading() in text, (
+        "AC-17: Der Klartext-Teil der Vergleichs-Mail traegt keine "
+        f"Hinweis-Ueberschrift.\n--- Klartext ---\n{text}"
+    )
+    zeilen = _hint_lines(text)
+    assert len(zeilen) == 1, (
+        "AC-17: Der Klartext-Teil muss genau eine Vorfall-Zeile tragen, "
+        f"gefunden {zeilen!r}\n--- Klartext ---\n{text}"
+    )
+    assert "Gewitter" in zeilen[0] and "SMS" in zeilen[0], (
+        f"AC-17: Anlass und Kanal fehlen in der Klartext-Zeile: {zeilen[0]!r}"
+    )
+    # Nicht-Leerlauf: derselbe Lauf zeigt den Abschnitt auch im HTML-Teil —
+    # die beiden Fassungen laufen nicht auseinander.
+    assert len(_hint_lines(_html_as_text(html))) == 1, (
+        "AC-17: HTML- und Klartext-Teil derselben Mail muessen dieselbe "
+        "Anzahl Vorfall-Zeilen tragen."
+    )
+
+
+def test_ac17_ortsvergleich_klartext_ohne_vorfaelle_ohne_abschnitt(tmp_path, monkeypatch):
+    """AC-17 (Leerfall, wie AC-3).
+
+    GIVEN dem Ortsvergleich fehlt nichts.
+    WHEN  das Briefing erzeugt wird.
+    THEN  steht im Klartext-Teil KEIN Abschnitt — auch keine Ueberschrift.
+    """
+    uid = _uid("ac17b")
+    preset_id = f"cp-ac17b-{uuid.uuid4().hex[:6]}"
+    _setup_compare_locations(uid)
+    _write_log(uid)
+
+    recorder = _CompareMailRecorder()
+    recorder.install(monkeypatch)
+    _html_body, text = _run_compare_briefing_texts(
+        recorder, uid, _compare_preset(uid, preset_id), tmp_path,
+    )
+
+    assert _heading() not in text, (
+        "AC-17: Ohne fehlende Zustellung darf im Klartext-Teil keine "
+        f"Ueberschrift stehen.\n--- Klartext ---\n{text}"
+    )
+    assert _hint_lines(text) == [], (
+        f"AC-17: unerwartete Zeilen im Klartext-Teil: {_hint_lines(text)!r}"
+    )
+
+
+# ══════════════════════════════════ AC-12 ═════════════════════════════════
+
+
+def test_ac12_zwei_nutzer_sehen_nur_die_eigenen_vorfaelle(monkeypatch):
+    """AC-12 — Mandantentrennung, Kreuzpruefung in BEIDE Richtungen.
+
+    GIVEN zwei verschiedene Nutzer haben je eigene nicht zugestellte Meldungen
+          (unterscheidbar an der Wettergroesse), unter derselben Trip-Kennung —
+          nur die ``user_id`` trennt sie.
+    WHEN  das Briefing des einen erzeugt wird.
+    THEN  enthaelt es ausschliesslich dessen eigene Meldungen.
+    """
+    jetzt = _jetzt()
+    alice, bob = _uid("alice"), _uid("bob")
+    trip_id = "trip-ac12-geteilte-kennung"
+    marker = {alice: (("thunder", "max"), "Gewitter", "Böen"),
+              bob: (("gust", "max"), "Böen", "Gewitter")}
+
+    for uid, (metrik, _eigen, _fremd) in marker.items():
+        _seed(uid, entity_id=trip_id, letztes_briefing=jetzt - timedelta(hours=6),
+              not_delivered=[_entry(
+                  entity_id=trip_id, sent_at=jetzt - timedelta(hours=2),
+                  metrics=(metrik,), reason="forecast_change", channels_sent=(),
+                  not_sent=(("sms", "delivery_failed"),),
+              )])
+
+    for uid, (_metrik, eigen, fremd) in marker.items():
+        trip = _trip(trip_id)
+        recorder = _ReportRecorder()
+        recorder.install(monkeypatch)
+        report = _run_trip_briefing(recorder, uid, trip)
+        zeilen = _hint_lines(report.email_plain)
+        assert len(zeilen) == 1, (
+            f"AC-12: {uid} muss genau seinen eigenen Vorfall sehen, gefunden "
+            f"{zeilen!r}"
+        )
+        assert eigen in zeilen[0], (
+            f"AC-12: Der eigene Vorfall ({eigen}) fehlt bei {uid}: {zeilen[0]!r}"
+        )
+        assert fremd not in zeilen[0], (
+            f"AC-12: Der Vorfall des ANDEREN Nutzers ({fremd}) steht im Briefing "
+            f"von {uid} — Cross-User-Datenleck: {zeilen[0]!r}"
+        )
+
+
+# ══════════════════════════════════ AC-13 ═════════════════════════════════
+
+
+def test_ac13_briefing_veraendert_das_protokoll_um_keine_zahl(monkeypatch):
+    """AC-13 — Zusicherung D4 aus #1459.
+
+    GIVEN ein Protokoll enthaelt nicht zugestellte Meldungen.
+    WHEN  ein Briefing erzeugt wird (Cockpit-Kachel und Archiv-Statistik lesen
+          ueber ``internal/store/log.go`` GENAU den Schluessel ``entries``).
+    THEN  stehen ``entries`` UND ``not_delivered`` danach Feld fuer Feld
+          unveraendert da — und die Datei wurde ueberhaupt NICHT angefasst.
+
+    Der Test ist nicht leer-laufend: er stellt zuerst fest, dass der Abschnitt
+    tatsaechlich erscheint (sonst bewiese die Unveraendertheit nichts).
+
+    Warum zusaetzlich die Datei-Metadaten (Adversary-Befund F002): reine
+    Wertgleichheit uebersieht einen INHALTSGLEICHEN Rueckschreibvorgang. "Lesen
+    schreibt nicht" ist aber die staerkere und die eigentlich gemeinte
+    Zusicherung — ein Rueckschreiben waere eine echte Kollisionsgefahr, wenn
+    parallel ein Alarm-Lauf schreibt (`append_entry()` macht Read-Modify-Write
+    ueber die VOLLE Datei; ein gleichzeitiger Rueckschreiber verloere dessen
+    frischen Eintrag).
+
+    Die Aenderungszeit wird vorher bewusst weit in die Vergangenheit gesetzt:
+    damit haengt der Nachweis nicht an der Zeitaufloesung des Dateisystems —
+    jeder Schreibvorgang, auch ein inhaltsgleicher, zieht sie auf "jetzt".
+    """
+    uid = _uid("ac13")
+    trip = _trip(f"trip-ac13-{uuid.uuid4().hex[:6]}")
+    jetzt = _jetzt()
+    _seed(
+        uid, entity_id=trip.id, letztes_briefing=jetzt - timedelta(hours=6),
+        entries=[_entry(entity_id=trip.id, sent_at=jetzt - timedelta(hours=3),
+                        metrics=(("gust", "max"),), reason="forecast_change",
+                        channels_sent=("email",),
+                        not_sent=(("sms", "delivery_failed"),))],
+        not_delivered=[_entry(entity_id=trip.id, sent_at=jetzt - timedelta(hours=2),
+                              metrics=(("thunder", "max"),), reason="forecast_change",
+                              channels_sent=(),
+                              not_sent=(("sms", "delivery_failed"),))],
+    )
+    vorher = _read_log(uid)
+    log_path = get_data_dir(uid) / "alert_log.json"
+    rohbytes_vorher = log_path.read_bytes()
+    alt_ns = int((jetzt - timedelta(days=1)).timestamp()) * 1_000_000_000
+    os.utime(log_path, ns=(alt_ns, alt_ns))
+
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+    report = _run_trip_briefing(recorder, uid, trip)
+    assert _hint_lines(report.email_plain), (
+        "AC-13 Voraussetzung: der Abschnitt muss erscheinen, sonst prueft die "
+        "Unveraendertheit nichts."
+    )
+
+    assert log_path.stat().st_mtime_ns == alt_ns, (
+        "AC-13/D4: Die Protokolldatei wurde beim Briefing GESCHRIEBEN — die "
+        "Aenderungszeit hat sich bewegt. Auch ein inhaltsgleicher "
+        "Rueckschreibvorgang ist verboten: `append_entry()` arbeitet per "
+        "Read-Modify-Write ueber die volle Datei, ein gleichzeitiger Alarm-Lauf "
+        "verloere seinen frischen Eintrag."
+    )
+    assert log_path.read_bytes() == rohbytes_vorher, (
+        "AC-13/D4: Die Protokolldatei ist Byte fuer Byte nicht mehr dieselbe."
+    )
+
+    nachher = _read_log(uid)
+    assert nachher["entries"] == vorher["entries"], (
+        "AC-13/D4: Der Schluessel `entries` (Cockpit-Kachel und Archiv-"
+        "Statistik) darf sich durch das Briefing um KEINE Zahl aendern.\n"
+        f"vorher:  {vorher['entries']!r}\nnachher: {nachher['entries']!r}"
+    )
+    assert nachher["not_delivered"] == vorher["not_delivered"], (
+        "AC-13/D4: Auch `not_delivered` wird nur gelesen, nie umgeschrieben.\n"
+        f"vorher:  {vorher['not_delivered']!r}\nnachher: {nachher['not_delivered']!r}"
+    )
+
+
+# ══════════════════════════════════ AC-14 ═════════════════════════════════
+
+
+def test_ac14_kaputte_protokolldatei_laesst_das_briefing_vollstaendig(monkeypatch):
+    """AC-14 — Fail-soft wie die Schreibseite.
+
+    GIVEN die Protokolldatei ist beschaedigt (kein gueltiges JSON).
+    WHEN  ein Briefing erzeugt wird.
+    THEN  geht das Briefing vollstaendig und ohne Fehler raus, nur ohne den
+          Abschnitt.
+
+    Die Vergleichsgroesse ist ein Lauf mit INTAKTER, leerer Protokolldatei:
+    beide Mails muessen dieselben uebrigen Abschnitte tragen (Uhrzeiten
+    herausgerechnet, s. ``_ohne_uhrzeiten``).
+    """
+    uid_kaputt = _uid("ac14-kaputt")
+    trip_kaputt = _trip("trip-ac14-vergleichbar")
+    path = get_data_dir(uid_kaputt) / "alert_log.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{ das ist kein JSON ][")
+
+    rec_kaputt = _ReportRecorder()
+    rec_kaputt.install(monkeypatch)
+    kaputt = _run_trip_briefing(rec_kaputt, uid_kaputt, trip_kaputt)
+
+    uid_heil = _uid("ac14-heil")
+    trip_heil = _trip("trip-ac14-vergleichbar")
+    _write_log(uid_heil)
+    rec_heil = _ReportRecorder()
+    rec_heil.install(monkeypatch)
+    heil = _run_trip_briefing(rec_heil, uid_heil, trip_heil)
+
+    assert _hint_lines(kaputt.email_plain) == [], (
+        "AC-14: Bei kaputter Protokolldatei darf kein Abschnitt erscheinen."
+    )
+    assert _heading() not in kaputt.email_plain
+    assert _ohne_uhrzeiten(kaputt.email_plain) == _ohne_uhrzeiten(heil.email_plain), (
+        "AC-14: Das Briefing muss bei kaputter Protokolldatei VOLLSTAENDIG "
+        "rausgehen — der Klartext-Teil unterscheidet sich vom Lauf mit "
+        "intakter Datei."
+    )
+    assert _ohne_uhrzeiten(kaputt.email_html) == _ohne_uhrzeiten(heil.email_html), (
+        "AC-14: Auch der HTML-Teil muss vollstaendig bleiben."
+    )
+
+
+def test_ac14_fehlende_protokolldatei_laesst_das_briefing_vollstaendig(monkeypatch):
+    """AC-14 (zweite Haelfte): die Protokolldatei FEHLT ganz (Neu-Nutzer).
+
+    Zugleich der Nicht-Leerlauf-Nachweis fuer den Test darueber: derselbe
+    Aufbau MIT einem Vorfall zeigt den Abschnitt sehr wohl.
+    """
+    uid = _uid("ac14b")
+    trip = _trip(f"trip-ac14b-{uuid.uuid4().hex[:6]}")
+    assert not (get_data_dir(uid) / "alert_log.json").exists(), (
+        "Voraussetzung: die Protokolldatei darf nicht existieren"
+    )
+    rec = _ReportRecorder()
+    rec.install(monkeypatch)
+    ohne_datei = _run_trip_briefing(rec, uid, trip)
+    assert _heading() not in ohne_datei.email_plain, (
+        "AC-14: Ohne Protokolldatei darf kein Abschnitt erscheinen."
+    )
+
+    uid2 = _uid("ac14c")
+    trip2 = _trip(f"trip-ac14c-{uuid.uuid4().hex[:6]}")
+    jetzt = _jetzt()
+    _seed(uid2, entity_id=trip2.id, letztes_briefing=jetzt - timedelta(hours=6),
+          not_delivered=[_entry(
+              entity_id=trip2.id, sent_at=jetzt - timedelta(hours=2),
+              metrics=(("thunder", "max"),), reason="forecast_change",
+              channels_sent=(), not_sent=(("sms", "delivery_failed"),),
+          )])
+    rec2 = _ReportRecorder()
+    rec2.install(monkeypatch)
+    mit_vorfall = _run_trip_briefing(rec2, uid2, trip2)
+    assert _heading() in mit_vorfall.email_plain, (
+        "AC-14 (Nicht-Leerlauf): derselbe Aufbau MIT Vorfall muss den Abschnitt "
+        "sehr wohl zeigen — sonst prueft die Abwesenheits-Zusicherung nichts."
+    )
+
+
+# ══════════════════════════════════ AC-15 ═════════════════════════════════
+
+
+def test_ac15_ordinale_groesse_erscheint_als_wort_ohne_zahl(monkeypatch):
+    """AC-15 — ordinale Groessen nie roh (#1503/#1474).
+
+    GIVEN eine nicht zugestellte Meldung betraf das Gewitter-Niveau
+          (Register-Paar ``("thunder", "max")``, Einstufung ``severity="MAJOR"``,
+          ``changes_count=3``).
+    WHEN  die Zeile erzeugt wird.
+    THEN  steht dort die Bezeichnung in WORTEN, nie eine nackte Zahl.
+
+    Bei ordinalen Groessen ist eine Zahl bedeutungslos bis irrefuehrend — die
+    Zeile darf ausser dem Zeitstempel keine Ziffer tragen.
+    """
+    uid = _uid("ac15")
+    trip = _trip(f"trip-ac15-{uuid.uuid4().hex[:6]}")
+    jetzt = _jetzt()
+    vorfall = jetzt - timedelta(hours=2)
+    _seed(uid, entity_id=trip.id, letztes_briefing=jetzt - timedelta(hours=6),
+          not_delivered=[_entry(
+              entity_id=trip.id, sent_at=vorfall, metrics=(("thunder", "max"),),
+              reason="forecast_change", severity="MAJOR", changes_count=3,
+              channels_sent=(), not_sent=(("sms", "delivery_failed"),),
+          )])
+
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+    report = _run_trip_briefing(recorder, uid, trip)
+
+    zeilen = _hint_lines(report.email_plain)
+    assert len(zeilen) == 1, f"AC-15: erwartet 1 Zeile, gefunden {zeilen!r}"
+    zeile = zeilen[0]
+    assert "Gewitter" in zeile, (
+        f"AC-15: Die Bezeichnung in Worten ('Gewitter') fehlt: {zeile!r}"
+    )
+    # Zeitstempel-Ziffern herausnehmen, dann darf keine Ziffer uebrig bleiben.
+    ohne_zeit = re.sub(r"\d{1,2}[.:]\d{2}\.?|\d{1,2}\.\d{1,2}\.", "", zeile)
+    assert not re.search(r"\d", ohne_zeit), (
+        "AC-15: Ausser dem Zeitstempel darf in der Zeile keine nackte Zahl "
+        f"stehen (ordinale Groesse) — uebrig: {ohne_zeit!r}, Zeile: {zeile!r}"
+    )
+
+
+# ══════════════════════════════════ AC-16 ═════════════════════════════════
+
+
+def test_ac16_alarmversand_bleibt_kanal_und_zahlgleich(monkeypatch):
+    """AC-16.
+
+    GIVEN beliebige Alarm-Lagen.
+    WHEN  ein kompletter Alarm- und Briefing-Lauf durchlaeuft.
+    THEN  wird KEIN Alarm anders verschickt als vor dieser Aenderung — gleiche
+          Kanaele, gleiche Anzahl.
+
+    Umgesetzt als A/B im selben Lauf: derselbe Alarm fuer zwei Nutzer, einer
+    mit vorbelastetem Protokoll (dessen Briefing den Abschnitt nachweislich
+    zeigt), einer mit leerem. Versandzahl, Kanaele und Mail-Inhalt des ALARMS
+    muessen identisch sein — der Briefing-Hinweis darf in den Alarm-Pfad nicht
+    hineinlecken.
+    """
+    from services.trip_alert import TripAlertService
+
+    jetzt = _jetzt()
+    trip_id = "trip-ac16-geteilte-kennung"
+
+    uid_vorbelastet = _uid("ac16-mit")
+    _seed(uid_vorbelastet, entity_id=trip_id,
+          letztes_briefing=jetzt - timedelta(hours=6),
+          not_delivered=[_entry(
+              entity_id=trip_id, sent_at=jetzt - timedelta(hours=2),
+              metrics=(("thunder", "max"),), reason="forecast_change",
+              channels_sent=(), not_sent=(("sms", "delivery_failed"),),
+          )])
+
+    uid_leer = _uid("ac16-ohne")
+    _write_log(uid_leer)
+
+    # Nicht-Leerlauf-Nachweis: das Briefing des vorbelasteten Nutzers zeigt
+    # den Abschnitt tatsaechlich.
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+    briefing = _run_trip_briefing(recorder, uid_vorbelastet, _trip(trip_id))
+    assert _hint_lines(briefing.email_plain), (
+        "AC-16 Voraussetzung: der Abschnitt muss erscheinen, sonst vergleicht "
+        "der Test zwei unveraenderte Bestandslaeufe."
+    )
+
+    ergebnis = {}
+    for uid in (uid_vorbelastet, uid_leer):
+        mails: list = []
+        gesendet = TripAlertService(
+            settings=settings_email_only(), user_id=uid, throttle_hours=0,
+            mail_sink=lambda subject, body: mails.append((subject, body)),
+        ).check_and_send_alerts(
+            gust_alert_trip(trip_id), [weather(1, gust_max_kmh=20.0)],
+            fresh_weather=[weather(1, gust_max_kmh=60.0)],
+        )
+        ergebnis[uid] = (gesendet, mails)
+
+    gesendet_mit, mails_mit = ergebnis[uid_vorbelastet]
+    gesendet_ohne, mails_ohne = ergebnis[uid_leer]
+
+    assert gesendet_mit is gesendet_ohne is True, (
+        f"AC-16: Beide Alarm-Laeufe muessen rausgehen: {gesendet_mit!r} / "
+        f"{gesendet_ohne!r}"
+    )
+    assert len(mails_mit) == len(mails_ohne) == 1, (
+        "AC-16: Die Zahl der Alarm-Mails je Kanal darf sich nicht aendern: "
+        f"{len(mails_mit)} vs. {len(mails_ohne)}"
+    )
+    assert mails_mit[0][0] == mails_ohne[0][0], (
+        f"AC-16: Der Alarm-Betreff hat sich geaendert: {mails_mit[0][0]!r} vs. "
+        f"{mails_ohne[0][0]!r}"
+    )
+    assert _heading() not in mails_mit[0][1], (
+        "AC-16: Der Briefing-Hinweis darf NICHT in der Alarm-Mail auftauchen."
+    )
+    assert _ohne_uhrzeiten(mails_mit[0][1]) == _ohne_uhrzeiten(mails_ohne[0][1]), (
+        "AC-16: Der Inhalt der Alarm-Mail haengt jetzt vom Protokoll ab — der "
+        "Briefing-Hinweis leckt in den Alarm-Pfad."
+    )
+
+
+# ════════════ Vertrag des Anker-Bausteins (Reihenfolge, F001) ═════════════
+
+
+def test_zeitstempel_ueberlebt_einen_fehlschlagenden_ankerschreibvorgang():
+    """Der Briefing-Zeitstempel wird VOR dem Δ-Anker fortgeschrieben.
+
+    GIVEN das Briefing ist raus, der Δ-Anker-Schreibvorgang scheitert aber.
+    WHEN  der geteilte Baustein durchlaeuft.
+    THEN  ist der Briefing-Zeitstempel TROTZDEM gesetzt.
+
+    Ohne diese Reihenfolge zeigte das naechste Briefing dieselben Vorfaelle
+    erneut, sobald der Anker einmal klemmt. Heute werfen beide Produktiv-
+    Lambdas nicht (sie sind selbst fail-soft) — die Zusicherung waere also
+    strukturell unbewacht und die Reihenfolge koennte beim naechsten Umbau
+    still zurueckkippen (Adversary-Befund F001).
+
+    Kein Mock: ``write_anchor`` IST ein Callable-Parameter des Bausteins; hier
+    wird schlicht eines uebergeben, das scheitert — der echte Fehlerpfad.
+    """
+    from services.alert_briefing_anchor import (
+        last_briefing_at, write_anchor_and_reset_memory,
+    )
+
+    uid = _uid("anker")
+    trip_id = "trip-anker-fehlschlag"
+    zurueckgesetzt: list[str] = []
+
+    def _scheiternder_anker() -> None:
+        raise RuntimeError("Snapshot-Write gescheitert")
+
+    with pytest.raises(RuntimeError):
+        write_anchor_and_reset_memory(
+            user_id=uid,
+            entity_ids=[trip_id],
+            write_anchor=_scheiternder_anker,
+            reset_memory=zurueckgesetzt.append,
+            briefing_entity_id=trip_id,
+            briefing_entity_type="trip",
+        )
+
+    assert last_briefing_at(
+        user_id=uid, entity_id=trip_id, entity_type="trip",
+    ) is not None, (
+        "Der Briefing-Zeitstempel muss VOR dem Δ-Anker geschrieben werden — "
+        "sonst verschluckt ein fehlschlagender Anker-Schreibvorgang den "
+        "Zeitpunkt, und das naechste Briefing weist dieselben Vorfaelle "
+        "erneut aus."
+    )
+    assert zurueckgesetzt == [], (
+        "Voraussetzung dieses Tests: der Anker scheitert VOR dem "
+        "Gedaechtnis-Reset — sonst prueft er eine andere Reihenfolge als die "
+        "gemeinte."
+    )
+
+
+def test_ohne_kennung_wird_kein_zeitstempel_geschrieben():
+    """Bestandsaufrufer ohne die neuen Parameter bleiben unveraendert: der
+    Baustein schreibt dann KEINEN Zeitstempel (Rueckwaertskompatibilitaet)."""
+    from services.alert_briefing_anchor import (
+        last_briefing_at, write_anchor_and_reset_memory,
+    )
+
+    uid = _uid("anker-alt")
+    trip_id = "trip-anker-altbestand"
+    write_anchor_and_reset_memory(
+        user_id=uid, entity_ids=[trip_id], write_anchor=lambda: None,
+        reset_memory=lambda _e: None,
+    )
+    assert last_briefing_at(
+        user_id=uid, entity_id=trip_id, entity_type="trip",
+    ) is None, (
+        "Ohne `briefing_entity_id`/`briefing_entity_type` darf der Baustein "
+        "keinen Zeitstempel anlegen."
+    )
+
+
+# ═════════════════ Vertrag der Lesefunktion (Entdoppelung) ════════════════
+
+
+def test_lesefunktion_entdoppelt_und_vereinigt_kanaele():
+    """Vertrag zu AC-5 direkt an der Lesefunktion — die Wirkung im Briefing
+    prueft ``test_ac5_...``; dieser Test macht sichtbar, WO die Entdoppelung
+    passiert (beim LESEN, nie im Protokoll — sonst kippt D4).
+    """
+    from services.alert_log import read_undelivered
+
+    uid = _uid("read")
+    entity_id = "trip-read"
+    jetzt = _jetzt()
+    lauf = jetzt - timedelta(hours=1)
+    _write_log(uid, not_delivered=[
+        _entry(entity_id=entity_id, sent_at=lauf, metrics=(("thunder", "max"),),
+               reason="forecast_change", channels_sent=(),
+               not_sent=(("sms", "delivery_failed"),)),
+        _entry(entity_id=entity_id, sent_at=lauf, hazards=("thunderstorm",),
+               reason="official_alert", channels_sent=(),
+               not_sent=(("telegram", "delivery_failed"),)),
+    ], entries=[
+        _entry(entity_id="trip-fremd", sent_at=lauf, metrics=(("gust", "max"),),
+               reason="forecast_change", channels_sent=("email",),
+               not_sent=(("sms", "delivery_failed"),)),
+    ])
+
+    vorfaelle = read_undelivered(
+        uid, entity_id=entity_id, entity_type="trip", since=jetzt - timedelta(hours=6),
+    )
+    assert len(vorfaelle) == 1, (
+        f"Zwei Eintraege desselben Laufs sind EIN Vorfall: {vorfaelle!r}"
+    )
+    kanaele = set(vorfaelle[0].channels)
+    assert kanaele == {"sms", "telegram"}, (
+        f"Die Kanaele beider Eintraege muessen vereinigt werden: {kanaele!r}"
+    )
+
+    ohne_fenster = read_undelivered(
+        uid, entity_id=entity_id, entity_type="trip", since=jetzt + timedelta(minutes=1),
+    )
+    assert ohne_fenster == [], (
+        f"Vorfaelle vor `since` duerfen nicht geliefert werden: {ohne_fenster!r}"
+    )
+
+
+@pytest.mark.parametrize("entity_type", ["trip", "compare"])
+def test_lesefunktion_liest_nur_die_eigene_kennung(entity_type):
+    """Kennung UND Typ trennen (seit #1467 S1 die EINZIGE Kennung)."""
+    from services.alert_log import read_undelivered
+
+    uid = _uid(f"kennung-{entity_type}")
+    jetzt = _jetzt()
+    _write_log(uid, not_delivered=[
+        _entry(entity_id="x-1", entity_type="trip", sent_at=jetzt - timedelta(hours=1),
+               metrics=(("gust", "max"),), reason="forecast_change",
+               channels_sent=(), not_sent=(("sms", "delivery_failed"),)),
+        _entry(entity_id="x-1", entity_type="compare", sent_at=jetzt - timedelta(hours=1),
+               metrics=(("thunder", "max"),), reason="forecast_change",
+               channels_sent=(), not_sent=(("sms", "delivery_failed"),)),
+    ])
+    vorfaelle = read_undelivered(
+        uid, entity_id="x-1", entity_type=entity_type, since=jetzt - timedelta(hours=6),
+    )
+    assert len(vorfaelle) == 1, (
+        f"Gleiche Kennung, anderer Typ darf nicht mitgelesen werden: {vorfaelle!r}"
+    )


### PR DESCRIPTION
Scheibe **S3b-1** von Epic #1458 (Issue #1461). Erfuellt Pflicht 2 des Issues: *„was ein Kanal
nicht bekommen hat, wird protokolliert **und im naechsten Briefing sichtbar**"* — die
Voraussetzung dafuer, dass die Kanal-Schwelle aus S3b-2 keine Meldung spurlos verschwinden
lassen kann (rote Linie #638).

## Warum diese Scheibe zuerst kommt

Das Alarm-Protokoll aus #1459 hatte **sechs Schreibstellen und null Leser** auf der
Python-Seite. Die Schwelle zuerst zu bauen haette unterdrueckte Meldungen in ein Protokoll
geschrieben, das niemand sieht. PO-Entscheid 2026-08-05, belegt in
`#1461#issuecomment-5188989158`.

## Was der Nutzer sieht

```
NICHT BEI DIR ANGEKOMMEN

  04.08. 18:42 · Gewitter · SMS nicht zugestellt
  04.08. 06:15 · Wind · SMS nicht zugestellt
  05.08. 05:30 · Amtliche Warnung · SMS, Telegram nicht zugestellt
  … und 2 weitere
```

Nur E-Mail (Trip `full`, Trip `compact`, Ortsvergleich **HTML und Klartext**), hoechstens
5 Zeilen. Kam alles an ⇒ kein Abschnitt, keine Ueberschrift, keine Null-Zeile.

## Bauform — drei Bausteine, keiner neu erfunden

| Baustein | Wo | Anmerkung |
|---|---|---|
| Lesen | `alert_log.read_undelivered()` | beide Quellen; entdoppelt **beim Lesen**, schreibt nie |
| Zeitraum | `alert_briefing_anchor.record_briefing_sent()` / `last_briefing_at()` | im bereits geteilten Baustein, laeuft in beiden Pfaden **nach** dem Versand |
| Anzeigen | `email/undelivered_hint.py` | 1:1 nach `unavailable_hint.py` (#1348); nicht unter `renderers/alert/`, kein `trip_`/`compare_`-Praefix |

Zeitstempel in eigener Datei `briefing_anchor.json`, **nicht** im Protokoll — das liest Go
(`internal/store/log.go`).

## Drei Befunde, die still gescheitert waeren

1. **Ein vom Nutzer abgeschalteter Kanal ist kein Vorfall.** `_channels_not_sent()` schreibt
   `channel_disabled` bei **jedem erfolgreichen** Alarm. Ungefiltert stuende der Abschnitt bei
   jedem Ein-Kanal-Nutzer in **jedem** Briefing — AC-3 waere strukturell unerfuellbar. (AC-3)
2. **Der Ortsvergleich benennt dieselbe Sache zweimal verschieden:** Anker-Kennung
   `{preset_id}:{loc_id}` vs. Protokoll-Kennung `preset_id`. Falsch abgelegt bliebe der Hinweis
   dort **dauerhaft leer**, ohne dass ein Test es merkt. (AC-11)
3. **Der Klartext-Teil der Vergleichs-Mail** wird zugestellt, aber von keinem Pflicht-Validator
   gelesen (`email_spec_validator` liest nur HTML) — derselbe blinde Fleck, durch den in #1366
   der Schalter „Stundenverlauf zeigen" dort **nie** wirkte. (AC-17)

## Enthaelt zusaetzlich: fix(#1432) — Gate war seit heute unpassierbar

`briefing_mail_validator.py` wies seit `adc92fdb` **jede** Mail-Aenderung ab:
`FULL: Sonne-Widerspruch (Emoji-Modus) — Pill 156 min > Obergrenze 0 min`.

Ursache: `_briefing_dps()` in `scripts/send_gate_test_mails.py` setzte kein `dni_wm2`, die
DNI-basierte Sonne-Spalte zeigte viermal `–` ⇒ Obergrenze 0. Die Pille dagegen leitet sich aus
der **Bewoelkung** ab (30/35/40/38 % ⇒ ~156 min). Zwei Quellen, eine in der Fixture leer.

**Gegen den unveraenderten Stand `ec246836` nachgemessen: identischer Fehlschlag** ⇒ vorbestehend,
nicht von dieser Aenderung. Repariert wurden die **Testdaten** (`dni_wm2` + `is_day`, je Zeile aus
der Bewoelkung derselben Zeile hergeleitet) — **der Pruefer ist unangetastet**, er hatte recht.

## Nachweise

- **191 Tests gruen**, 0 Fehler: 27 neue (`tests/tdd/test_alert_undelivered_hint.py`) + 121
  Basis-Dateien rund um Alarm-Protokoll/Briefing-Anker/Mail-Renderer + 43 Mode-Matrix.
- **Regressions-A/B:** dieselben 121 Basis-Tests waren **vor** jeder Aenderung gruen (Nachweis
  `docs/artifacts/…/baseline-green.txt`) — keine Regression, keine Altlast als Ausrede.
- **Adversary VERIFIED** (2 Runden, 17/17 ACs belegt): **11 Mutationen gesetzt, 9 sofort
  gefangen.** Die 2 unbemerkten (Reihenfolge Zeitstempel/Anker · inhaltsgleiches
  Rueckschreiben der Protokolldatei) sind nachtraeglich mit Tests geschlossen, **beide
  Gegenproben rot**.
- **Beide Mail-Validatoren Exit 0** gegen echt zugestellte Mails aus `gregor-test@henemm.com`:
  `briefing_mail_validator.py` und `email_spec_validator.py`.

## Bewusst nicht in dieser Scheibe

- Die Gruende `quiet_hours` / `daily_limit` / `cooldown` stehen im Schema, werden aber von
  **keinem** Aufrufer gesetzt (O3 aus #1459) — sie koennen heute in keiner Zeile erscheinen.
- Kurznachricht (Telegram/SMS) unberuehrt, **zeichengleich** (AC-10, PO-Entscheid).
- Keine Zeile traegt Stufen-/Messwerte: das Protokoll haelt nur fest, *worum* es ging, nicht
  *wie stark*.
- Nebenbefund in #1199 gebucht: der `mail_sink` reicht nur den HTML-Body durch — ueber diese
  Naht ist der Compare-Klartext strukturell untestbar.

Spec: `docs/specs/modules/feat_1461_s3b1_briefing_sichtbarkeit.md` (v1.2, 17 ACs, PO-freigegeben)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
