### PR TITLE
fix(#1510): Kontakt-Beschriftung + Verbindungsstatus der Kanal-Checkboxen gebündelt

### DIFF
--- a/docs/context/dedupe-1510-versand-ziel.md
+++ b/docs/context/dedupe-1510-versand-ziel.md
@@ -1,0 +1,157 @@
+# Context: dedupe-1510-versand-ziel (#1510)
+
+## Request Summary
+
+Sieben Stellen formulieren „an welches Ziel geht der Versand?" — nachgemessen sind es aber
+**zwei unabhängige Duplikat-Paare**, nicht eine einzige Wiederholung. #1510 verlangt, die
+Kontakt-Beschriftung der drei Kanal-Checkboxen (E-Mail/Telegram/SMS) an einer Stelle zu bündeln
+und `EditReportConfigSection` denselben Verbindungsstatus wie `VTBriefingChannels` benutzen zu
+lassen. `sendTargetLabel()` (aus #1471) bleibt eigenständig — sie liefert einen ganzen Satz
+für den Bestätigungsdialog, keine Checkbox-Beschriftung.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `frontend/src/lib/components/shared/versand-tab/VTBriefingChannels.svelte` | Geteilte Kanal-Card (Versand-Reiter, `context="route"\|"vergleich"`). Zeilen 67–71: `availableChannels`-Block. Zeilen 108,130,158: `E-Mail{profile?.mail_to ? \` (${profile.mail_to})\` : ''}` je Kanal. Zeile 75: nutzt bereits `channelConnectionStatus()` für Dot+Label. |
+| `frontend/src/lib/components/edit/EditReportConfigSection.svelte` | Trip-Editor-Kanal-Card. Zeilen 90–94: **wortgleicher** `availableChannels`-Block wie oben (dritte, bisher unbenannte Kopie). Zeilen 296,314,332: wortgleiche Kontakt-Beschriftung. Ruft `channelConnectionStatus()` **nicht** auf — hat keinen Dot/Label. |
+| `frontend/src/lib/components/shared/versand-tab/channelConnectionStatus.ts` | Bestehende geteilte Funktion (Issue #1258 S6). Liefert je Kanal `{ tone, label }` — u.a. E-Mail dreistufig (fehlt/unbestätigt/bestätigt). Wird heute nur von `VTBriefingChannels` aufgerufen. |
+| `frontend/src/lib/components/shared/versand-tab/sendTargetLabel.ts` | #1471. Liefert `{ text, deliverable, gesperrt }` für den Bestätigungsdialog — ein ganzer Satz, keine Checkbox-Beschriftung. Ruft intern bereits `channelConnectionStatus()` auf. Nur von `routes/compare/+page.svelte` benutzt (das ist der Gate-Befund aus #1510, siehe unten). |
+| `docs/specs/modules/fix_1471_sende_dialog_ziel.md` | Abschnitt „Offene Grenzen" benennt genau diese sechs Duplikate ausdrücklich als **bewusst nicht saniert** in #1471 — #1510 holt das nach. |
+
+## Existing Patterns
+
+- **Pure Ableitungsfunktion + `__tests__/`-node:test** ist das etablierte Muster im
+  `shared/versand-tab/`-Ordner (`channelConnectionStatus.ts`, `sendTargetLabel.ts`,
+  `dayWindowClamp.ts`) — kein DOM/Netz, direkt aus `profile`/`preset` abgeleitet.
+- `context="route"|"vergleich"`-Parametrisierung für geteilte Organismen (bereits in
+  `VTBriefingChannels` vorhanden).
+- Read-Modify-Write-Merge in `EditReportConfigSection` (`$effect`-Block) — von der Änderung
+  nicht betroffen, nur die Anzeige-Logik ändert sich.
+
+## Der entscheidende Befund für die Analyse-Phase
+
+**`availableChannels` (Checkbox-`disabled`) und `channelConnectionStatus()` (Dot+Label) sind
+heute zwei unterschiedliche Härtegrade — kein reiner Textdopplung-Fall:**
+
+| | `availableChannels.email` (beide Komponenten) | `channelConnectionStatus(profile).email.tone` |
+|---|---|---|
+| Bedingung | `!!profile?.mail_to` (Adresse vorhanden) | `mail_to` **und** `email_verified === true` |
+| Wirkung heute | steuert `disabled` der Checkbox | steuert nur Dot-Farbe + Text-Label in `VTBriefingChannels` |
+
+Würde `EditReportConfigSection` für `disabled` direkt auf `channelConnectionStatus().tone === 'good'`
+umgestellt, wäre das **kein reines Refactoring**, sondern eine Verhaltensänderung: Nutzer mit
+hinterlegter, aber unbestätigter E-Mail könnten den Kanal im Trip-Editor dann nicht mehr
+ankreuzen (heute können sie — der Versand scheitert dann serverseitig am
+Empfängerschutz, still). Das muss die Analyse-/Spec-Phase explizit entscheiden, nicht die
+Implementierung nebenbei.
+
+**PO-Entscheidung (2026-08-05, im Intake-Dialog):**
+1. `EditReportConfigSection` bekommt **zusätzlich** Dot+Label wie `VTBriefingChannels`
+   (`channelConnectionStatus()` wird dort neu aufgerufen und gerendert) — optische Parität zum
+   Versand-Reiter, entspricht der Teilungs-Invariante.
+2. Die `disabled`-Bedingung der E-Mail-Checkbox wechselt **in beiden Komponenten** von
+   „Adresse vorhanden" auf „Adresse vorhanden **und** bestätigt" (`channelConnectionStatus().email.tone
+   === 'good'`) — das ist eine bewusste Verhaltensänderung, kein reines Refactoring: sie verhindert
+   das stille Scheitern am Empfängerschutz, das heute möglich ist (Checkbox ankreuzbar, Versand
+   liefert serverseitig nichts aus).
+
+**Daraus folgt für den Baustein-Zuschnitt:**
+- `availableChannels.email` entfällt als eigener Existenz-Check; `disabled` leitet sich für
+  E-Mail direkt aus `channelConnectionStatus().email.tone` ab. Telegram/SMS bleiben bei
+  „hinterlegt" (kein Verifikations-Konzept für diese Kanäle vorhanden — `channelConnectionStatus()`
+  hat für sie ohnehin nur zwei Zustände, `good`/`neutral`, ohne Zwischenstufe).
+- Eine gemeinsame Funktion für die Kontakt-Beschriftung („E-Mail (a@b.de)" / „Telegram (12345)" /
+  „SMS (+49…)") ersetzt die sechs Checkbox-Label-Duplikate.
+- `VTBriefingChannels` ändert sich ebenfalls (E-Mail-`disabled` nutzt jetzt `channelConnectionStatus()`
+  statt `availableChannels.email`) — bisher war das dort schon berechnet, aber ungenutzt für
+  `disabled`; das ist die zweite Hälfte derselben Verhaltensänderung, nicht nur Trip-Editor-seitig.
+
+## Dependencies
+
+- **Upstream:** `GET /api/auth/profile` (beide Komponenten laden es per `onMount`/`fetch`,
+  identischer Code — evtl. vierte Duplikat-Klasse, aber **nicht** im Issue benannt, daher nicht
+  Teil dieses Scopes ohne PO-Bestätigung).
+- **Downstream:** Keine Komponente ruft `VTBriefingChannels`/`EditReportConfigSection` intern auf
+  Basis der Checkbox-Beschriftung ab — reine Anzeige, kein Datenfluss nach außen.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1471_sende_dialog_ziel.md` — Ursprung von `sendTargetLabel()` und
+  `channelConnectionStatus()`-Nutzung, explizit vorausschauend auf diese Aufräumarbeit verweisend.
+- `docs/specs/_archive/modules/issue_1258_alarme_tab_official_warnings.md` — Ursprung von
+  `channelConnectionStatus()` (Abschnitt 12, AC-21).
+
+## Analysis
+
+### Type
+
+Feature (Konsolidierung + eine bewusste Verhaltensänderung).
+
+### PO-Entscheidungen (2026-08-05, Intake-Dialog)
+
+1. **Dot+Label auch im Trip-Editor:** `EditReportConfigSection` ruft künftig `channelConnectionStatus()`
+   auf und rendert Dot+Label wie `VTBriefingChannels` — optische Parität zum Versand-Reiter.
+2. **E-Mail-Checkbox-Sperre verschärft:** `disabled` der E-Mail-Checkbox wechselt in **beiden**
+   Komponenten von „Adresse vorhanden" auf „Adresse vorhanden **und** bestätigt"
+   (`channelConnectionStatus(profile).email.tone === 'good'`). Telegram/SMS bleiben bei „hinterlegt"
+   (kein Verifikations-Konzept für diese Kanäle).
+3. **E2E-Testkonflikt (AC-7, `versand-tab-vergleich.spec.ts:139-164`):** Der Test setzt bewusst eine
+   unbestätigte Adresse und erwartet eine anklickbare Checkbox — das bricht mit Entscheidung 2. Eine
+   „ehrliche" Testkorrektur bräuchte IMAP-Tokenabruf (reale Verifikations-Mail) — unverhältnismäßig
+   für dieses Ticket. **Entschieden:** `email.uncheck({ force: true })` — der Test prüft die
+   Leerzustand-Anzeige („Kein Kanal aktiv"), nicht die neue Sperre selbst; `force: true` umgeht
+   bewusst nur die Interaktions-Blockade, nicht die Testaussage.
+
+### Affected Files (with changes)
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `frontend/src/lib/components/shared/versand-tab/channelContactLabel.ts` | CREATE | Neue pure Funktion: liefert Kontakt-Beschriftung je Kanal (`"E-Mail (a@b.de)"` / `"Telegram (12345)"` / `"SMS (+49…)"`, leer wenn kein Kontakt hinterlegt) aus `profile`. Ersetzt die sechs Ternary-Duplikate. |
+| `frontend/src/lib/components/shared/versand-tab/__tests__/channelContactLabel.test.ts` | CREATE | node:test, reine Verhaltenstests (alle drei Kanäle × vorhanden/fehlend). |
+| `frontend/src/lib/components/shared/versand-tab/VTBriefingChannels.svelte` | MODIFY | Checkbox-Labels nutzen `channelContactLabel()`; E-Mail-`disabled` wechselt von `availableChannels.email` auf `connectionStatus.email.tone === 'good'`; `availableChannels`-Block entfällt für E-Mail (Telegram/SMS bleiben wie bisher). |
+| `frontend/src/lib/components/edit/EditReportConfigSection.svelte` | MODIFY | Analog: `channelContactLabel()` für Labels, `channelConnectionStatus()` neu importiert + Dot/Label-Markup ergänzt (analog `VTBriefingChannels.svelte:112-115` etc.), E-Mail-`disabled` verschärft, `Profile`-Interface bekommt `email_verified?: boolean`. |
+| `frontend/e2e/versand-tab-vergleich.spec.ts` | MODIFY | AC-7-Test: `email.uncheck({ force: true })` statt `uncheck()`. |
+
+### Scope Assessment
+
+- Files: 6 (2 neu, 4 geändert)
+- Estimated LoC: ~+90/-40 (Netto unter dem 250-LoC-Workflow-Limit)
+- Risk Level: MEDIUM — sichtbare UI-Änderung im Trip-Editor (neues Dot/Label) + eine echte
+  Verhaltensänderung (Checkbox-Sperre), nicht nur internes Refactoring.
+
+### Technical Approach
+
+Ein neuer geteilter Baustein `channelContactLabel.ts` (analog `channelConnectionStatus.ts`,
+gleicher Ordner, gleiches Muster: pure Funktion, `profile`-Eingabe, node:test) übernimmt die
+Kontakt-Beschriftung. Beide Komponenten binden ihn identisch ein. `channelConnectionStatus()`
+wird in beiden Komponenten zur **einzigen** Quelle für den E-Mail-`disabled`-Zustand — das macht
+die Verhaltensänderung an beiden Stellen symmetrisch, keine Asymmetrie zwischen Versand-Reiter und
+Trip-Editor. `sendTargetLabel()` bleibt unangetastet (nutzt `channelConnectionStatus()` bereits
+intern, keine Überschneidung mit den beiden UI-Komponenten).
+
+### Dependencies
+
+- Kein neuer Backend-Endpoint nötig: `email_verified` liefert `/api/auth/profile` bereits
+  (`internal/handler/auth.go:453,503`, abgesichert durch `profile_test.go:517-562`).
+- `EditReportConfigSection`'s `Profile`-Interface muss um `email_verified?: boolean` erweitert
+  werden (fehlt heute, Backend liefert es aber schon mit).
+
+### Open Questions
+
+Keine offenen — beide Design-Entscheidungen (Dot+Label, Checkbox-Sperre) und der Testkonflikt sind
+vom PO entschieden.
+
+## Risks & Considerations
+
+- **Verhaltensänderung vs. reines Refactoring** (siehe oben) — größtes Risiko, muss in Phase 2/3
+  geklärt werden, sonst schleicht sich eine Checkbox-Sperre ein, die niemand angefordert hat.
+- **Pendant-Gate (#1481 B):** Eine neue Datei in `shared/versand-tab/**` ist unproblematisch
+  (das ist der geteilte Ordner selbst); falls eine neue Datei stattdessen in `edit/**` oder
+  `compare/**` läge, würde der Gate greifen.
+- **Mutations-Gegenprobe:** Die Kontakt-Beschriftung hat einen ternären Ausdruck
+  (`profile?.mail_to ? ... : ''`) — die Extraktion darf die drei bestehenden Fallgruben (fehlende
+  Adresse, gesetzte Adresse, `sms_allowed === false`) nicht durch die Zusammenführung verlieren.
+- **Punkt 3 des Issues** (Pendant-Gate um „geteilter Ordner, aber nur ein Aufrufer" erweitern)
+  ist laut vorheriger Einschätzung ein separates Vorhaben (Wächter-Änderung statt Produktfehler)
+  — hier **nicht** umgesetzt, geht als Sammel-Eintrag an #1199.

--- a/docs/specs/modules/fix_1471_sende_dialog_ziel.md
+++ b/docs/specs/modules/fix_1471_sende_dialog_ziel.md
@@ -185,6 +185,10 @@ passiert. Diese Entscheidung ist Teil der Spec-Freigabe (siehe AC-3/AC-4).
   und `EditReportConfigSection.svelte:296,311,332` werden in diesem Zug **nicht** saniert (Umfang
   bewusst auf den Dialog begrenzt). `sendTargetLabel()` ist aber der Ort, an dem sie bei
   künftiger Aufräumarbeit zusammenlaufen können.
+- Nachtrag 2026-08-05: Mit #1510 wurde das nachgeholt — die sechs Duplikate sind in
+  `channelContactLabel()` (`shared/versand-tab/channelContactLabel.ts`) gebündelt; siehe
+  `docs/specs/modules/fix_1510_versand_ziel_dedupe.md`. `sendTargetLabel()` bleibt davon
+  unberührt (eigener Baustein, eigener Zweck).
 - Ein Sofort-Versand aus der Trip-Liste existiert heute nicht (gemessen, einziger Treffer ist
   `compare/+page.svelte`) — die neue Funktion liegt deshalb bewusst im geteilten
   `shared/versand-tab/`-Ordner, damit ein künftiger Trip-Sofortversand dieselbe Quelle nutzen kann,
@@ -208,3 +212,5 @@ passiert. Diese Entscheidung ist Teil der Spec-Freigabe (siehe AC-3/AC-4).
 ## Changelog
 
 - 2026-08-04: Initial spec created
+- 2026-08-05: „Offene Grenzen" um Nachtrag ergänzt — die sechs Duplikate wurden mit #1510
+  (`channelContactLabel()`) saniert

--- a/docs/specs/modules/fix_1510_versand_ziel_dedupe.md
+++ b/docs/specs/modules/fix_1510_versand_ziel_dedupe.md
@@ -1,0 +1,245 @@
+---
+entity_id: fix_1510_versand_ziel_dedupe
+type: bugfix
+created: 2026-08-05
+updated: 2026-08-05
+status: draft
+version: "1.0"
+tags: [versand, trip-editor, compare, frontend]
+---
+
+# Kontakt-Beschriftung + Verbindungsstatus der Kanal-Checkboxen bündeln (#1510)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Die Kontakt-Beschriftung der drei Kanal-Checkboxen (E-Mail/Telegram/SMS) ist heute sechsfach als
+wortgleicher Ternary-Ausdruck dupliziert — dreimal in `VTBriefingChannels.svelte`, dreimal in
+`EditReportConfigSection.svelte`. Diese Spec bündelt sie in einer geteilten Funktion
+`channelContactLabel()`, gibt dem Trip-Editor (`EditReportConfigSection`) denselben
+Dot+Label-Verbindungsstatus wie dem Versand-Reiter (`VTBriefingChannels`), und verschärft dabei
+bewusst die E-Mail-Checkbox-Sperre: eine hinterlegte, aber unbestätigte Adresse macht den Kanal
+künftig in beiden Komponenten nicht mehr ankreuzbar — sie scheitert heute still am serverseitigen
+Empfängerschutz. `sendTargetLabel()` (#1471, Bestätigungsdialog-Satz) ist keine Überschneidung und
+bleibt unverändert.
+
+## Source
+
+- **File:** `frontend/src/lib/components/shared/versand-tab/VTBriefingChannels.svelte`
+- **Identifier:** Checkbox-Label-Ternaries (Zeilen 108,130,158) und `availableChannels`-Block
+  (Zeilen 67–71); Gegenstück `frontend/src/lib/components/edit/EditReportConfigSection.svelte`
+  (Zeilen 90–94, 296,314,332)
+
+## Estimated Scope
+
+- **LoC:** ~+90/-40
+- **Files:** 6 (2 neu, 4 geändert — siehe context-Dokument, hier 5 in der Tabelle plus Testdatei)
+- **Effort:** medium
+
+### Affected Files
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `frontend/src/lib/components/shared/versand-tab/channelContactLabel.ts` | CREATE | Neue pure Funktion: liefert die Kontakt-Beschriftungs-Suffixe je Kanal aus `ConnectionProfile` (z.B. `" (a@b.de)"` oder `""`). Ersetzt die sechs Ternary-Duplikate in beiden Komponenten. |
+| `frontend/src/lib/components/shared/versand-tab/__tests__/channelContactLabel.test.ts` | CREATE | node:test, reine Verhaltenstests: alle drei Kanäle × Kontakt vorhanden/fehlend. |
+| `frontend/src/lib/components/shared/versand-tab/__tests__/channel_checkbox_dedupe_render.test.ts` | CREATE | node:test, SSR-Render-Tests (svelte/server) für AC-2 bis AC-6 — ursprünglich in dieser Tabelle fehlend, aber von AC-2/AC-3/AC-4/AC-5/AC-6 bereits verlangt; in der RED-Phase nachgetragen (Zeile korrigiert 2026-08-05). |
+| `frontend/src/lib/components/shared/versand-tab/VTBriefingChannels.svelte` | MODIFY | Checkbox-Labels nutzen `channelContactLabel()` statt eigener Ternaries (Zeilen 108,130,158). E-Mail-`disabled` wechselt von `availableChannels.email` auf `connectionStatus.email.tone === 'good'` (Zeile 108); der `availableChannels`-Eintrag für `email` entfällt, Telegram/SMS bleiben unverändert (Zeilen 69–70 bestehen fort). |
+| `frontend/src/lib/components/edit/EditReportConfigSection.svelte` | MODIFY | Analog: `channelContactLabel()` für die drei Labels (Zeilen 296,314,332); neuer Import + Aufruf von `channelConnectionStatus()` (analog `VTBriefingChannels.svelte:17,75`) plus Dot/Label-Markup je Kanal (analog `VTBriefingChannels.svelte:112–115,133–136,161–164`); E-Mail-`disabled` verschärft wie oben; `Profile`-Interface (Zeilen 82–87) bekommt `email_verified?: boolean`. |
+| `frontend/e2e/versand-tab-vergleich.spec.ts` | MODIFY | AC-7-Test (Zeile ~155): `email.uncheck()` → `email.uncheck({ force: true })`, da die zuvor gesetzte, unbestätigte Testadresse die Checkbox jetzt sperrt; der Test prüft weiterhin die Leerzustand-Anzeige, nicht die neue Sperre. |
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `channelConnectionStatus()` (`shared/versand-tab/channelConnectionStatus.ts:29-51`) | function | Liefert bereits die Drei-Zustands-Logik für E-Mail (fehlt/unbestätigt/bestätigt) und den Verbunden-Status für Telegram/SMS — wird in `EditReportConfigSection` neu aufgerufen (bisher nur in `VTBriefingChannels`) und ist Basis der verschärften E-Mail-`disabled`-Bedingung in beiden Komponenten. |
+| `GET /api/auth/profile` | endpoint | Liefert `mail_to`, `email_verified`, `telegram_chat_id`, `sms_to`, `sms_allowed` des angemeldeten Nutzers (`internal/handler/auth.go:453,503`); beide Komponenten laden ihn bereits identisch per `onMount`/`fetch`, unverändert durch diese Spec. |
+| `ConnectionProfile`-Typ (`shared/versand-tab/channelConnectionStatus.ts:19-25`) | type | Wiederverwendete Eingabe-Form für `channelContactLabel()` — keine neue Profil-Form nötig. |
+
+## Implementation Details
+
+**Neue Funktion `channelContactLabel(profile)`** (Ort: `shared/versand-tab/`, gleicher Ordner wie
+`channelConnectionStatus.ts`/`sendTargetLabel.ts`, gleiches Muster: pure Funktion, ein Aufruf pro
+Komponente, `node:test`-testbar):
+
+```
+Eingabe:  ConnectionProfile | null | undefined  (mail_to, telegram_chat_id, sms_to, ...)
+Ausgabe:  { email: string; telegram: string; sms: string }
+          — je Kanal der Suffix " (<Kontakt>)", oder "" wenn kein Kontakt hinterlegt.
+```
+
+**Design-Entscheidung — EIN Aufruf, drei Felder (kein Kanal-Diskriminator, keine drei
+Einzelfunktionen):** Die Funktion spiegelt bewusst die Objektform von
+`channelConnectionStatus()` (ein Aufruf liefert alle drei Kanäle als Objekt-Felder). Das hält den
+Aufrufaufwand in beiden Komponenten bei je einem `$derived`-Aufruf (analog
+`connectionStatus = $derived(channelConnectionStatus(profile))`), statt drei separaten Aufrufen pro
+Komponente (sechs insgesamt). Die Funktion liefert bewusst nur den **Suffix**, nicht das ganze
+Label inklusive Kanalnamen (`"E-Mail (a@b.de)"`) — das lässt den Kanalnamen als literalen Text im
+Template stehen (`E-Mail{contactLabel.email}`) und minimiert den Diff gegenüber dem bisherigen
+`E-Mail{profile?.mail_to ? ` (${profile.mail_to})` : ''}` auf einen reinen Feldzugriff, ohne die
+Template-Struktur umzubauen.
+
+```ts
+export interface ChannelContactLabels {
+  email: string;
+  telegram: string;
+  sms: string;
+}
+
+export function channelContactLabel(
+  profile: ConnectionProfile | null | undefined
+): ChannelContactLabels {
+  const p = profile ?? {};
+  return {
+    email: p.mail_to ? ` (${p.mail_to})` : '',
+    telegram: p.telegram_chat_id ? ` (${p.telegram_chat_id})` : '',
+    sms: p.sms_to ? ` (${p.sms_to})` : ''
+  };
+}
+```
+
+**Einbindung `VTBriefingChannels.svelte`:**
+- Neu: `let contactLabel = $derived(channelContactLabel(profile));` (neben der bestehenden
+  `connectionStatus`-Zeile 75).
+- Zeile 108: `E-Mail{profile?.mail_to ? ... : ''}` → `E-Mail{contactLabel.email}`; analog Zeile 130
+  (Telegram) und 158 (SMS).
+- Zeile 108: `disabled={!availableChannels.email}` → `disabled={connectionStatus.email.tone !== 'good'}`.
+- `availableChannels`-Objekt (Zeilen 67–71) verliert den `email`-Eintrag; `telegram`/`sms` bleiben
+  unverändert, ebenso deren `disabled`-Bindungen (Zeilen 128,157) und die Hinweis-Blöcke
+  (`!availableChannels.email` an Zeile 117 wird durch die neue Bedingung ersetzt, damit der
+  „E-Mail-Adresse fehlt"-Hinweis weiterhin nur bei fehlender Adresse erscheint, nicht bei jeder
+  unbestätigten — siehe AC-4).
+
+**Einbindung `EditReportConfigSection.svelte`:**
+- Neuer Import: `import { channelConnectionStatus, type ConnectionProfile } from
+  '../shared/versand-tab/channelConnectionStatus';` und `import { channelContactLabel } from
+  '../shared/versand-tab/channelContactLabel';`.
+- `Profile`-Interface (Zeilen 82–87) bekommt `email_verified?: boolean;` (Backend liefert es
+  bereits mit, siehe Dependencies).
+- Neu: `let connectionStatus = $derived(channelConnectionStatus(profile));` und
+  `let contactLabel = $derived(channelContactLabel(profile));` (analog `VTBriefingChannels.svelte:75`
+  und der neuen Zeile oben).
+- Zeilen 296,314,332: Label-Ternaries → `contactLabel.email`/`.telegram`/`.sms`.
+- Zeile 294: `disabled={!availableChannels.email}` → `disabled={connectionStatus.email.tone !== 'good'}`.
+- Neues Dot/Label-Markup je Kanal-Block (E-Mail, Telegram, SMS), 1:1 nach dem Muster
+  `VTBriefingChannels.svelte:112–115,133–136,161–164` (`Dot`-Atom + Mono-Label-Span, Testids
+  `channel-status-email`/`channel-status-telegram`/`channel-status-sms`); dazu der Import von `Dot`
+  aus `$lib/components/atoms` (`VTBriefingChannels.svelte:14`).
+- `availableChannels`-Block (Zeilen 90–94) verliert den `email`-Eintrag, analog oben.
+
+## Expected Behavior
+
+- **Input:** Nutzer öffnet den Kanäle-Bereich im Versand-Reiter (`VTBriefingChannels`) oder im
+  Trip-Editor (`EditReportConfigSection`).
+- **Output:** Beide zeigen dieselbe Kontakt-Beschriftung aus derselben Quelle; der Trip-Editor
+  zeigt zusätzlich Dot+Label-Verbindungsstatus wie der Versand-Reiter. Die E-Mail-Checkbox ist in
+  beiden nur ankreuzbar, wenn die Adresse hinterlegt **und** bestätigt ist; Telegram/SMS bleiben bei
+  „hinterlegt" wie bisher.
+- **Side effects:** keine neuen Netzwerk-Aufrufe (beide Komponenten laden `/api/auth/profile`
+  bereits); kein Server-/Persistenz-Verhalten geändert — reine Anzeige- und Sperr-Logik.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein `ConnectionProfile` mit beliebiger Kombination aus vorhandenem/fehlendem
+  `mail_to`, `telegram_chat_id`, `sms_to` / When `channelContactLabel(profile)` aufgerufen wird /
+  Then liefert es je Kanal exakt den Suffix `" (<Kontakt>)"` bei vorhandenem Kontakt und `""` bei
+  fehlendem — für alle drei Kanäle unabhängig voneinander.
+  - Test: `channelContactLabel.test.ts`, mindestens 6 Fälle (jeder der drei Kanäle je einmal
+    vorhanden, einmal fehlend), plus ein Fall mit `profile = null`/`undefined` → alle drei Felder
+    `""`.
+
+- **AC-2:** Given `VTBriefingChannels` wird mit einem Profil gerendert, dessen `mail_to` auf eine
+  bestimmte Adresse gesetzt ist / When die Komponente rendert / Then enthält der sichtbare
+  Checkbox-Beschriftungstext genau diese Adresse im Format `channelContactLabel()` — nicht nur der
+  Quellcode enthält den Aufruf.
+  - Test: Component-/DOM-Render-Test (Svelte-Testing-Library oder Playwright gegen Staging), der den
+    tatsächlich gerenderten Text der `channel-email`-Checkbox liest und mit dem Wert vergleicht, den
+    `channelContactLabel()` für dasselbe Profil zurückgibt. Kein Quelltext-Scan auf den
+    Import-/Aufruf-Namen.
+
+- **AC-3:** Given `EditReportConfigSection` wird mit demselben Profil wie in AC-2 gerendert / When
+  die Komponente rendert / Then zeigt sie exakt dieselbe Kontakt-Beschriftung wie
+  `VTBriefingChannels` für dasselbe Profil — beide Komponenten weichen für dieselbe Eingabe nie
+  voneinander ab.
+  - Test: Component-Render-Test analog AC-2, zusätzlich ein direkter Vergleich der beiden
+    gerenderten Texte (bzw. der beiden `channelContactLabel()`-Rückgabewerte) für identische
+    Profil-Fixtures.
+
+- **AC-4:** Given ein Profil ohne `mail_to`, ein Profil mit `mail_to` aber `email_verified: false`
+  und ein Profil mit `mail_to` und `email_verified: true` / When die E-Mail-Checkbox in
+  `VTBriefingChannels` **und** in `EditReportConfigSection` jeweils für alle drei Profile gerendert
+  wird / Then ist die Checkbox nur im dritten Fall (`tone === 'good'`) anklickbar (`disabled=false`);
+  in den ersten beiden Fällen ist sie `disabled=true` — in beiden Komponenten symmetrisch, nicht nur
+  in einer.
+  - Test: Component-Render-Test, der das `disabled`-Attribut der jeweiligen Checkbox-DOM-Node für
+    alle drei Profil-Fixtures × beide Komponenten prüft (6 Kombinationen).
+
+- **AC-5:** Given ein Profil ohne `telegram_chat_id`/`sms_to` bzw. mit gesetztem
+  `telegram_chat_id`/`sms_to` (inkl. `sms_allowed: false`) / When die Telegram- bzw. SMS-Checkbox in
+  beiden Komponenten gerendert wird / Then ist ihr `disabled`-Zustand exakt derselbe wie vor dieser
+  Änderung (`!!profile?.telegram_chat_id` bzw. `!!profile?.sms_to && sms_allowed !== false`) — keine
+  Verschärfung, keine Lockerung.
+  - Test: Component-Render-Test mit denselben Profil-Fixtures wie vor der Änderung (Regressionstest);
+    Behauptung ist Gleichheit zum dokumentierten Vorverhalten, nicht nur „funktioniert irgendwie".
+
+- **AC-6:** Given ein Profil mit gesetztem `mail_to`, `telegram_chat_id` und `sms_to` / When
+  `EditReportConfigSection` rendert / Then erscheinen für alle drei Kanäle Dot+Label-Elemente mit
+  den Testids `channel-status-email`, `channel-status-telegram`, `channel-status-sms` — analog zu
+  `VTBriefingChannels` — wo vor dieser Änderung keines dieser Elemente existierte.
+  - Test: Component-Render-Test, der Existenz und Text der drei neuen Testid-Elemente in
+    `EditReportConfigSection` prüft (heute: Element nicht vorhanden → Test muss vor der
+    Implementierung rot sein).
+
+- **AC-7:** Given `sendTargetLabel.ts` und ihre bestehende Testsuite / When diese Spec umgesetzt
+  ist / Then ist die Datei `sendTargetLabel.ts` byteidentisch zum Stand vor dieser Spec, und
+  `sendTargetLabel.test.ts` läuft unverändert grün — die Kontakt-Beschriftung der Checkboxen und der
+  Ziel-Satz im Bestätigungsdialog bleiben getrennte, unabhängige Bausteine.
+  - Test: `git diff` auf `frontend/src/lib/components/shared/versand-tab/sendTargetLabel.ts` ist
+    leer nach Abschluss der Implementierung; `node --test` auf `sendTargetLabel.test.ts` bleibt
+    grün ohne Anpassung.
+
+- **AC-8:** Given `frontend/e2e/versand-tab-vergleich.spec.ts` AC-7 setzt eine unbestätigte
+  Test-E-Mail-Adresse / When die verschärfte E-Mail-Sperre aktiv ist / Then kann der Test die
+  Checkbox weiterhin gezielt abwählen (`{ force: true }`) und die Leerzustand-Anzeige
+  (`briefings-channel-empty`) bleibt wie zuvor erreichbar und sichtbar.
+  - Test: Der bestehende Playwright-Test `AC-7: alle Kanäle aus zeigt "Kein Kanal aktiv" statt
+    Zeitplan-Karten` läuft nach der Anpassung grün, ohne die geprüfte Aussage (Leerzustand
+    erscheint) zu verändern.
+
+## Was sich NICHT ändert
+
+- `sendTargetLabel()` (#1471) bleibt unverändert — sie liefert einen ganzen Satz für den
+  Bestätigungsdialog des Ortsvergleichs, keine Checkbox-Beschriftung, und ruft bereits intern
+  `channelConnectionStatus()` auf; es gibt keine Überschneidung mit dieser Spec.
+- Der `availableChannels`-Eintrag für Telegram und SMS bleibt in beiden Komponenten unverändert
+  (`!!profile?.telegram_chat_id` bzw. `!!profile?.sms_to && sms_allowed !== false`) — nur der
+  E-Mail-Eintrag entfällt zugunsten von `channelConnectionStatus().email.tone`.
+- Der Ladepfad `GET /api/auth/profile` (identischer `onMount`/`fetch`-Code in beiden Komponenten)
+  wird nicht konsolidiert — im Kontext-Dokument als mögliche vierte Duplikat-Klasse benannt, aber
+  nicht im Issue verlangt und daher nicht Teil dieses Scopes.
+
+## Known Limitations
+
+- Die Erweiterung des Pendant-Gates (#1481 B) um „geteilter Ordner, aber nur ein Aufrufer" (Punkt 3
+  des ursprünglichen Issue-Vorschlags) ist **nicht** Teil dieser Spec — das ist eine
+  Wächter-Änderung, kein Produktfehler, und geht als Sammel-Eintrag an #1199 (PO-Entscheidung im
+  Intake-Dialog vom 2026-08-05).
+- Ein serverseitiges Tier-Downgrade (`sms_allowed`) zwischen dem Laden des Profils und einer
+  tatsächlichen Interaktion wird wie bisher nicht neu geprüft (bestehendes Verhalten,
+  `channelConnectionStatus()` unverändert für SMS).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Konsolidierung einer Anzeige-Ableitung nach etabliertem Muster
+  (`channelConnectionStatus`, `sendTargetLabel`) plus eine einzelne, klar begründete
+  Verhaltensänderung (E-Mail-Checkbox-Sperre bei unbestätigter Adresse) — keine neue
+  Entscheidungsfläche (Kanal, Provider, Datenmodell, Auth) betroffen. Analog zur Einschätzung in
+  `docs/specs/modules/fix_1471_sende_dialog_ziel.md`.
+
+## Changelog
+
+- 2026-08-05: Initial spec created
+- 2026-08-05: Affected-Files-Tabelle um `channel_checkbox_dedupe_render.test.ts` ergänzt (war bereits durch AC-2/3/4/5/6 verlangt, fehlte aber in der Tabelle — Scope-Check bei `/60-validate` aufgedeckt)

--- a/frontend/e2e/versand-tab-vergleich.spec.ts
+++ b/frontend/e2e/versand-tab-vergleich.spec.ts
@@ -152,7 +152,10 @@ test.describe('Issue #1232 Scheibe 2b: VersandTab (vergleich) im Compare-Editor'
 				.locator('[data-testid="compare-step5-channel-email"]:visible')
 				.first()
 				.locator('input[type="checkbox"]');
-			if (await email.isChecked()) await email.uncheck();
+			// { force: true }: die per PUT gesetzte Adresse ist unbestätigt und sperrt
+			// die Checkbox seit #1510 real (AC-4) — dieser Test prüft weiterhin nur
+			// die Leerzustand-Anzeige bei "kein Kanal aktiv", nicht die Sperre selbst.
+			if (await email.isChecked()) await email.uncheck({ force: true });
 
 			await expect(
 				page.locator('[data-testid="briefings-channel-empty"]:visible').first()

--- a/frontend/src/lib/components/edit/EditReportConfigSection.svelte
+++ b/frontend/src/lib/components/edit/EditReportConfigSection.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import type { ReportConfig } from '$lib/types';
 	import { toHHMMSS } from '$lib/utils/time';
 	import { Checkbox } from '$lib/components/ui/checkbox';
@@ -95,7 +95,9 @@
 		sms_to?: string;
 		sms_allowed?: boolean;
 	}
-	let profile = $state<Profile | null>(profileOverride !== undefined ? profileOverride : null);
+	let profile = $state<Profile | null>(
+		untrack(() => (profileOverride !== undefined ? profileOverride : null))
+	);
 
 	let availableChannels = $derived({
 		email: !!profile?.mail_to,

--- a/frontend/src/lib/components/edit/EditReportConfigSection.svelte
+++ b/frontend/src/lib/components/edit/EditReportConfigSection.svelte
@@ -5,6 +5,9 @@
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import VTSchedulePlan from '../shared/versand-tab/VTSchedulePlan.svelte';
+	import { channelConnectionStatus } from '../shared/versand-tab/channelConnectionStatus';
+	import { channelContactLabel } from '../shared/versand-tab/channelContactLabel';
+	import { Dot } from '$lib/components/atoms';
 	import {
 		DEFAULT_DAILY_SUMMARY_METRICS,
 		CONTENT_MODULE_DESCRIPTIONS,
@@ -31,8 +34,14 @@
 		showSchedule?: boolean;
 		/** Issue #736: Callback bei Kanal-Toggle — für Auto-Save von display_config.channels. */
 		onChannelChange?: (channel: 'email' | 'telegram' | 'sms', value: boolean) => void;
+		/** RED-Infrastruktur (#1510): optionaler SSR-Test-Override fuer `profile`.
+		 * Falls gesetzt (auch explizit `null`) wird `profile` daraus initialisiert
+		 * und der `onMount`-Fetch uebersprungen — `svelte/server`s `render()` fuehrt
+		 * `onMount` nicht aus, ohne diesen Override bliebe `profile` in SSR-Tests
+		 * immer `null`. Ohne Uebergabe unveraendertes Verhalten (Fetch in onMount). */
+		profileOverride?: Profile | null;
 	}
-	let { reportConfig = $bindable(), mode = 'create', weatherChannels, showMailContent = true, showChannels = true, showSchedule = true, onChannelChange }: Props = $props();
+	let { reportConfig = $bindable(), mode = 'create', weatherChannels, showMailContent = true, showChannels = true, showSchedule = true, onChannelChange, profileOverride }: Props = $props();
 
 	// --- Original-Blob fuer Read-Modify-Write -----------------------------------
 	// Alle nicht UI-gepflegten Felder (insb. change_threshold_*, custom_unknown_*)
@@ -81,17 +90,23 @@
 	// --- Profile (Channel-Verfuegbarkeit) --------------------------------------
 	interface Profile {
 		mail_to?: string;
+		email_verified?: boolean;
 		telegram_chat_id?: string;
 		sms_to?: string;
 		sms_allowed?: boolean;
 	}
-	let profile = $state<Profile | null>(null);
+	let profile = $state<Profile | null>(profileOverride !== undefined ? profileOverride : null);
 
 	let availableChannels = $derived({
 		email: !!profile?.mail_to,
 		telegram: !!profile?.telegram_chat_id,
 		sms: !!profile?.sms_to && profile?.sms_allowed !== false
 	});
+
+	// Issue #1510: ehrlicher Verbindungsstatus + geteilte Kontakt-Beschriftung
+	// (analog VTBriefingChannels.svelte).
+	let connectionStatus = $derived(channelConnectionStatus(profile));
+	let contactLabel = $derived(channelContactLabel(profile));
 
 	// Issue #617: Wetter-Kanal-Gating (nur wenn weatherChannels gesetzt)
 	let weatherVisible = $derived(visibleChannels(weatherChannels));
@@ -172,10 +187,12 @@
 
 		// Profile laden (Channel-Verfuegbarkeit). Fail-soft: bei Fehler bleiben
 		// alle Channels disabled (mit Account-Link-Hinweis).
-		fetch('/api/auth/profile', { credentials: 'same-origin' })
-			.then((r) => (r.ok ? r.json() : null))
-			.then((p) => { profile = p as Profile | null; })
-			.catch(() => { profile = null; });
+		if (profileOverride === undefined) {
+			fetch('/api/auth/profile', { credentials: 'same-origin' })
+				.then((r) => (r.ok ? r.json() : null))
+				.then((p) => { profile = p as Profile | null; })
+				.catch(() => { profile = null; });
+		}
 	});
 
 	// --- Write-Back: Read-Modify-Write -----------------------------------------
@@ -291,9 +308,13 @@
 					<span data-testid="channel-email" class="inline-flex items-center gap-2">
 						<Checkbox
 							checked={send_email}
-							disabled={!availableChannels.email}
+							disabled={connectionStatus.email.tone !== 'good'}
 							onchange={(e) => { const v = (e.target as HTMLInputElement).checked; send_email = v; onChannelChange?.('email', v); }}
-						>E-Mail{profile?.mail_to ? ` (${profile.mail_to})` : ''}</Checkbox>
+						>E-Mail{contactLabel.email}</Checkbox>
+					</span>
+					<span data-testid="channel-status-email" class="rc-channel-status">
+						<Dot tone={connectionStatus.email.tone} size={7} />
+						<span class="rc-channel-status-label">{connectionStatus.email.label}</span>
 					</span>
 				</div>
 				{#if !availableChannels.email}
@@ -311,7 +332,11 @@
 							checked={send_telegram}
 							disabled={!availableChannels.telegram}
 							onchange={(e) => { const v = (e.target as HTMLInputElement).checked; send_telegram = v; onChannelChange?.('telegram', v); }}
-						>Telegram{profile?.telegram_chat_id ? ` (${profile.telegram_chat_id})` : ''}</Checkbox>
+						>Telegram{contactLabel.telegram}</Checkbox>
+					</span>
+					<span data-testid="channel-status-telegram" class="rc-channel-status">
+						<Dot tone={connectionStatus.telegram.tone} size={7} />
+						<span class="rc-channel-status-label">{connectionStatus.telegram.label}</span>
 					</span>
 				</div>
 				{#if !availableChannels.telegram}
@@ -329,7 +354,11 @@
 							checked={send_sms}
 							disabled={!availableChannels.sms}
 							onchange={(e) => { const v = (e.target as HTMLInputElement).checked; send_sms = v; onChannelChange?.('sms', v); }}
-						>SMS{profile?.sms_to ? ` (${profile.sms_to})` : ''}</Checkbox>
+						>SMS{contactLabel.sms}</Checkbox>
+					</span>
+					<span data-testid="channel-status-sms" class="rc-channel-status">
+						<Dot tone={connectionStatus.sms.tone} size={7} />
+						<span class="rc-channel-status-label">{connectionStatus.sms.label}</span>
 					</span>
 				</div>
 				{#if profile?.sms_allowed === false}
@@ -438,4 +467,22 @@
 	</Card.Root>
 	{/if}
 </div>
+
+<style>
+	/* Issue #1510: Verbindungsstatus-Dot + Mono-Label — 1:1 aus
+	   VTBriefingChannels.svelte (.vt-channel-status/-label), eigene Klassen hier
+	   weil EditReportConfigSection kein Tailwind-Utility dafuer hat. */
+	.rc-channel-status {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		margin-left: 10px;
+	}
+	.rc-channel-status-label {
+		font-family: var(--g-font-mono);
+		font-size: 11px;
+		letter-spacing: 0.04em;
+		color: var(--g-ink-3);
+	}
+</style>
 

--- a/frontend/src/lib/components/shared/versand-tab/VTBriefingChannels.svelte
+++ b/frontend/src/lib/components/shared/versand-tab/VTBriefingChannels.svelte
@@ -15,6 +15,7 @@
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { CHANNEL_COL_BUDGET } from '$lib/components/trip-detail/metricsEditor';
 	import { channelConnectionStatus } from './channelConnectionStatus';
+	import { channelContactLabel } from './channelContactLabel';
 	import TelegramKurzstilToggle from '$lib/components/shared/TelegramKurzstilToggle.svelte';
 
 	interface Channels {
@@ -41,6 +42,12 @@
 		 * Kanaelen im Alarme-Tab (dieselbe geteilte Komponente). */
 		telegramStyle?: 'rich' | 'kurzform';
 		onTelegramStyleChange?: (style: 'rich' | 'kurzform') => void;
+		/** RED-Infrastruktur (#1510): optionaler SSR-Test-Override fuer `profile`.
+		 * Falls gesetzt (auch explizit `null`) wird `profile` daraus initialisiert
+		 * und der `onMount`-Fetch uebersprungen — `svelte/server`s `render()` fuehrt
+		 * `onMount` nicht aus, ohne diesen Override bliebe `profile` in SSR-Tests
+		 * immer `null`. Ohne Uebergabe unveraendertes Verhalten (Fetch in onMount). */
+		profileOverride?: Profile | null;
 	}
 	let {
 		context = 'route',
@@ -52,7 +59,8 @@
 		telegramTestid = 'channel-telegram',
 		smsTestid = 'channel-sms',
 		telegramStyle = 'rich',
-		onTelegramStyleChange
+		onTelegramStyleChange,
+		profileOverride
 	}: Props = $props();
 
 	interface Profile {
@@ -62,7 +70,7 @@
 		sms_allowed?: boolean;
 		email_verified?: boolean;
 	}
-	let profile = $state<Profile | null>(null);
+	let profile = $state<Profile | null>(profileOverride !== undefined ? profileOverride : null);
 
 	let availableChannels = $derived({
 		email: !!profile?.mail_to,
@@ -73,8 +81,10 @@
 	// Issue #1258 S6 (R5): ehrlicher Verbindungsstatus je Kanal (Dot + Label),
 	// additiv zu den bestehenden Checkboxen.
 	let connectionStatus = $derived(channelConnectionStatus(profile));
+	let contactLabel = $derived(channelContactLabel(profile));
 
 	onMount(() => {
+		if (profileOverride !== undefined) return;
 		fetch('/api/auth/profile', { credentials: 'same-origin' })
 			.then((r) => (r.ok ? r.json() : null))
 			.then((p) => {
@@ -105,8 +115,8 @@
 		<div class="vt-channels-body">
 			<div class="text-sm">
 				<span data-testid={emailTestid} class="inline-flex items-center gap-2">
-					<Checkbox checked={channels.email} disabled={!availableChannels.email} onchange={onEmailChange}
-						>E-Mail{profile?.mail_to ? ` (${profile.mail_to})` : ''}</Checkbox
+					<Checkbox checked={channels.email} disabled={connectionStatus.email.tone !== 'good'} onchange={onEmailChange}
+						>E-Mail{contactLabel.email}</Checkbox
 					>
 				</span>
 				<span data-testid="channel-status-email" class="vt-channel-status">
@@ -127,7 +137,7 @@
 						checked={channels.telegram}
 						disabled={!availableChannels.telegram}
 						onchange={onTelegramChange}
-						>Telegram{profile?.telegram_chat_id ? ` (${profile.telegram_chat_id})` : ''}</Checkbox
+						>Telegram{contactLabel.telegram}</Checkbox
 					>
 				</span>
 				<span data-testid="channel-status-telegram" class="vt-channel-status">
@@ -155,7 +165,7 @@
 			<div class="text-sm">
 				<span data-testid={smsTestid} class="inline-flex items-center gap-2">
 					<Checkbox checked={channels.sms} disabled={!availableChannels.sms} onchange={onSmsChange}
-						>SMS{profile?.sms_to ? ` (${profile.sms_to})` : ''}</Checkbox
+						>SMS{contactLabel.sms}</Checkbox
 					>
 				</span>
 				<span data-testid="channel-status-sms" class="vt-channel-status">

--- a/frontend/src/lib/components/shared/versand-tab/VTBriefingChannels.svelte
+++ b/frontend/src/lib/components/shared/versand-tab/VTBriefingChannels.svelte
@@ -10,7 +10,7 @@
 	//
 	// Spec: docs/specs/modules/versand_tab_route.md (AC-2, AC-7)
 
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { Eyebrow, Card, Dot } from '$lib/components/atoms';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { CHANNEL_COL_BUDGET } from '$lib/components/trip-detail/metricsEditor';
@@ -70,7 +70,9 @@
 		sms_allowed?: boolean;
 		email_verified?: boolean;
 	}
-	let profile = $state<Profile | null>(profileOverride !== undefined ? profileOverride : null);
+	let profile = $state<Profile | null>(
+		untrack(() => (profileOverride !== undefined ? profileOverride : null))
+	);
 
 	let availableChannels = $derived({
 		email: !!profile?.mail_to,

--- a/frontend/src/lib/components/shared/versand-tab/__tests__/channelContactLabel.test.ts
+++ b/frontend/src/lib/components/shared/versand-tab/__tests__/channelContactLabel.test.ts
@@ -1,0 +1,89 @@
+// TDD RED — Bugfix "Kontakt-Beschriftung + Verbindungsstatus der Kanal-
+// Checkboxen bündeln" (#1510).
+// Spec: docs/specs/modules/fix_1510_versand_ziel_dedupe.md — AC-1.
+//
+// Reine Verhaltenstests der neuen geteilten Ableitung `channelContactLabel(profile)`.
+// Reine Funktion, kein Netz, kein DOM, keine Attrappe — der Prüfling wird echt
+// aufgerufen und sein Rückgabewert bewertet.
+//
+// RED heute: `../channelContactLabel.ts` existiert nicht (ERR_MODULE_NOT_FOUND) —
+// die sechs Ternary-Duplikate in VTBriefingChannels.svelte/EditReportConfigSection.svelte
+// sind bislang der einzige Ort, an dem diese Ableitung passiert.
+//
+// Pfadregel #1409: alle Pfade relativ zu DIESER Datei.
+//
+// Ausführung:
+//   cd frontend && node --experimental-strip-types --test \
+//     src/lib/components/shared/versand-tab/__tests__/channelContactLabel.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { channelContactLabel } from '../channelContactLabel.ts';
+
+const MAIL = 'anna@example.org';
+const CHAT_ID = '4711';
+const SMS = '+49150000000';
+
+describe('AC-1: channelContactLabel liefert je Kanal den Kontakt-Suffix oder ""', () => {
+	test('E-Mail vorhanden → Suffix " (<Adresse>)"', () => {
+		const { email } = channelContactLabel({ mail_to: MAIL });
+		assert.equal(email, ` (${MAIL})`, `Erwartet Suffix mit Adresse, erhielt "${email}" (AC-1).`);
+	});
+
+	test('E-Mail fehlt → leerer Suffix', () => {
+		const { email } = channelContactLabel({});
+		assert.equal(email, '', `Erwartet leeren Suffix ohne mail_to, erhielt "${email}" (AC-1).`);
+	});
+
+	test('Telegram vorhanden → Suffix " (<Chat-ID>)"', () => {
+		const { telegram } = channelContactLabel({ telegram_chat_id: CHAT_ID });
+		assert.equal(
+			telegram,
+			` (${CHAT_ID})`,
+			`Erwartet Suffix mit Chat-ID, erhielt "${telegram}" (AC-1).`
+		);
+	});
+
+	test('Telegram fehlt → leerer Suffix', () => {
+		const { telegram } = channelContactLabel({});
+		assert.equal(telegram, '', `Erwartet leeren Suffix ohne telegram_chat_id, erhielt "${telegram}" (AC-1).`);
+	});
+
+	test('SMS vorhanden → Suffix " (<Nummer>)"', () => {
+		const { sms } = channelContactLabel({ sms_to: SMS });
+		assert.equal(sms, ` (${SMS})`, `Erwartet Suffix mit Nummer, erhielt "${sms}" (AC-1).`);
+	});
+
+	test('SMS fehlt → leerer Suffix', () => {
+		const { sms } = channelContactLabel({});
+		assert.equal(sms, '', `Erwartet leeren Suffix ohne sms_to, erhielt "${sms}" (AC-1).`);
+	});
+
+	test('alle drei Kanäle unabhängig voneinander gefüllt', () => {
+		const labels = channelContactLabel({ mail_to: MAIL, telegram_chat_id: CHAT_ID, sms_to: SMS });
+		assert.deepEqual(
+			labels,
+			{ email: ` (${MAIL})`, telegram: ` (${CHAT_ID})`, sms: ` (${SMS})` },
+			`Erwartet alle drei Suffixe gefüllt, erhielt ${JSON.stringify(labels)} (AC-1).`
+		);
+	});
+
+	test('profile = null → alle drei Felder ""', () => {
+		const labels = channelContactLabel(null);
+		assert.deepEqual(
+			labels,
+			{ email: '', telegram: '', sms: '' },
+			`Erwartet alle drei Felder leer bei profile=null, erhielt ${JSON.stringify(labels)} (AC-1).`
+		);
+	});
+
+	test('profile = undefined → alle drei Felder ""', () => {
+		const labels = channelContactLabel(undefined);
+		assert.deepEqual(
+			labels,
+			{ email: '', telegram: '', sms: '' },
+			`Erwartet alle drei Felder leer bei profile=undefined, erhielt ${JSON.stringify(labels)} (AC-1).`
+		);
+	});
+});

--- a/frontend/src/lib/components/shared/versand-tab/__tests__/channel_checkbox_dedupe_render.test.ts
+++ b/frontend/src/lib/components/shared/versand-tab/__tests__/channel_checkbox_dedupe_render.test.ts
@@ -1,0 +1,272 @@
+// TDD RED — Bugfix "Kontakt-Beschriftung + Verbindungsstatus der Kanal-
+// Checkboxen bündeln" (#1510).
+// Spec: docs/specs/modules/fix_1510_versand_ziel_dedupe.md — AC-2, AC-3, AC-4, AC-5, AC-6.
+//
+// Echtes serverseitiges Rendern der echten Svelte-Komponenten
+// (svelte/server `render`, Hooks: frontend/test-svelte-ssr-hooks.mjs).
+// Keine Mocks, keine reine Datei-Inhalt-Prüfung (Ausnahme AC-6: Testid-Existenz
+// ist per Definition eine DOM-Prüfung, nicht Quelltext-Scan — der HTML-String
+// IST hier das geprüfte Verhalten, nicht der .svelte-Quelltext).
+//
+// RED heute:
+//   - `../channelContactLabel.ts` existiert nicht → die Datei crasht komplett
+//     beim Import (ERR_MODULE_NOT_FOUND), ALLE Tests unten schlagen fehl.
+//   - Zusätzlich, sobald `channelContactLabel.ts` existiert (nächste Phase):
+//     AC-4 bleibt rot, weil `VTBriefingChannels.svelte`/`EditReportConfigSection.svelte`
+//     die E-Mail-Checkbox heute an `!!profile?.mail_to` sperren (nicht an
+//     `channelConnectionStatus(profile).email.tone === 'good'`) — eine
+//     hinterlegte, aber unbestätigte Adresse macht die Checkbox heute NICHT
+//     disabled, obwohl AC-4 das verlangt.
+//   - AC-6 bleibt rot, weil `EditReportConfigSection.svelte` heute keine
+//     `channel-status-*`-Testids rendert (nur `VTBriefingChannels.svelte` tut das).
+//
+// `profileOverride`-Prop (RED-Infrastruktur, s. beide .svelte-Dateien): Beide
+// Komponenten laden `profile` sonst per `onMount`/`fetch`, das `svelte/server`s
+// `render()` nicht ausführt — ohne den Override bliebe `profile` in SSR immer
+// `null`.
+//
+// Pfadregel #1409: alle Pfade relativ zu DIESER Datei.
+//
+// Ausführung:
+//   cd frontend && node --experimental-strip-types --test \
+//     src/lib/components/shared/versand-tab/__tests__/channel_checkbox_dedupe_render.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { register } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// __tests__ -> versand-tab -> shared -> components -> lib -> src -> frontend
+const FRONTEND = path.resolve(HERE, '../../../../../..');
+
+register(
+	pathToFileURL(path.join(FRONTEND, 'test-svelte-ssr-hooks.mjs')).href,
+	pathToFileURL(FRONTEND + '/').href
+);
+
+const { render } = await import('svelte/server');
+const { channelContactLabel } = await import('../channelContactLabel.ts');
+const VTBriefingChannels = (
+	await import(
+		pathToFileURL(path.join(FRONTEND, 'src/lib/components/shared/versand-tab/VTBriefingChannels.svelte')).href
+	)
+).default;
+const EditReportConfigSection = (
+	await import(
+		pathToFileURL(path.join(FRONTEND, 'src/lib/components/edit/EditReportConfigSection.svelte')).href
+	)
+).default;
+
+interface Profile {
+	mail_to?: string;
+	email_verified?: boolean;
+	telegram_chat_id?: string;
+	sms_to?: string;
+	sms_allowed?: boolean;
+}
+
+const MAIL = 'anna@example.org';
+const CHAT_ID = '4711';
+const SMS = '+49150000000';
+
+/** Sichtbarer Text eines SSR-Ergebnisses (Tags + Svelte-Kommentar-Anker raus). */
+function visibleText(html: string): string {
+	return html
+		.replace(/<!--[\s\S]*?-->/g, ' ')
+		.replace(/<[^>]*>/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+function renderBriefingChannels(profile: Profile | null): string {
+	return render(VTBriefingChannels, {
+		props: {
+			channels: { email: false, telegram: false, sms: false },
+			onEmailChange: () => {},
+			onTelegramChange: () => {},
+			onSmsChange: () => {},
+			profileOverride: profile
+		}
+	}).body;
+}
+
+function renderEditSection(profile: Profile | null): string {
+	return render(EditReportConfigSection, {
+		props: {
+			reportConfig: {},
+			mode: 'edit',
+			showMailContent: false,
+			showSchedule: false,
+			showChannels: true,
+			profileOverride: profile
+		}
+	}).body;
+}
+
+/** Sichtbarer Text GENAU des Checkbox-Labels (Box + Beschriftung), das direkt
+ * hinter dem gegebenen Testid gerendert wird — robust gegen umgebende
+ * Markup-Unterschiede zwischen den beiden Komponenten. */
+function checkboxLabelText(html: string, testid: string): string {
+	const marker = `data-testid="${testid}"`;
+	const markerIdx = html.indexOf(marker);
+	assert.notEqual(markerIdx, -1, `Testid "${testid}" nicht im gerenderten HTML gefunden.`);
+	const labelStart = html.indexOf('<label', markerIdx);
+	assert.notEqual(labelStart, -1, `Kein <label> nach Testid "${testid}" gefunden.`);
+	const labelEnd = html.indexOf('</label>', labelStart);
+	assert.notEqual(labelEnd, -1, `Kein schliessendes </label> nach Testid "${testid}" gefunden.`);
+	return visibleText(html.slice(labelStart, labelEnd + '</label>'.length));
+}
+
+/** `<input .../>`-Tag direkt hinter dem gegebenen Testid. */
+function checkboxInputTag(html: string, testid: string): string {
+	const marker = `data-testid="${testid}"`;
+	const markerIdx = html.indexOf(marker);
+	assert.notEqual(markerIdx, -1, `Testid "${testid}" nicht im gerenderten HTML gefunden.`);
+	const inputStart = html.indexOf('<input', markerIdx);
+	assert.notEqual(inputStart, -1, `Kein <input> nach Testid "${testid}" gefunden.`);
+	const inputEnd = html.indexOf('>', inputStart);
+	return html.slice(inputStart, inputEnd + 1);
+}
+
+/** true nur, wenn das boolsche `disabled`-Attribut im Tag gesetzt ist
+ * (Svelte-SSR rendert es als `disabled=""`, oder laesst es bei `false` ganz weg). */
+function isDisabled(inputTag: string): boolean {
+	return /\bdisabled(=""|(?=[\s/>]))/.test(inputTag);
+}
+
+// ─── AC-2 ────────────────────────────────────────────────────────────────────
+
+describe('AC-2: VTBriefingChannels zeigt die E-Mail-Beschriftung aus channelContactLabel()', () => {
+	test('E-Mail-Checkbox-Text = "E-Mail" + channelContactLabel(profile).email', () => {
+		const profile: Profile = { mail_to: MAIL, email_verified: true };
+		const html = renderBriefingChannels(profile);
+		const text = checkboxLabelText(html, 'channel-email');
+		const expected = 'E-Mail' + channelContactLabel(profile).email;
+
+		assert.equal(
+			text,
+			expected,
+			`AC-2: Erwartet exakt "${expected}" als E-Mail-Checkbox-Text, gerendert "${text}".`
+		);
+	});
+});
+
+// ─── AC-3 ────────────────────────────────────────────────────────────────────
+
+describe('AC-3: EditReportConfigSection zeigt dieselbe Kontakt-Beschriftung wie VTBriefingChannels', () => {
+	test('E-Mail-Checkbox-Text von EditReportConfigSection = channelContactLabel(profile).email-Suffix', () => {
+		const profile: Profile = { mail_to: MAIL, email_verified: true };
+		const html = renderEditSection(profile);
+		const text = checkboxLabelText(html, 'channel-email');
+		const expected = 'E-Mail' + channelContactLabel(profile).email;
+
+		assert.equal(
+			text,
+			expected,
+			`AC-3: Erwartet exakt "${expected}" als E-Mail-Checkbox-Text in EditReportConfigSection, gerendert "${text}".`
+		);
+	});
+
+	test('beide Komponenten zeigen für IDENTISCHES Profil denselben E-Mail-Checkbox-Text', () => {
+		const profile: Profile = { mail_to: MAIL, email_verified: true };
+		const vtText = checkboxLabelText(renderBriefingChannels(profile), 'channel-email');
+		const editText = checkboxLabelText(renderEditSection(profile), 'channel-email');
+
+		assert.equal(
+			vtText,
+			editText,
+			`AC-3: VTBriefingChannels ("${vtText}") und EditReportConfigSection ("${editText}") weichen für dasselbe Profil ab.`
+		);
+	});
+});
+
+// ─── AC-4 ────────────────────────────────────────────────────────────────────
+
+describe('AC-4: E-Mail-Checkbox nur bei bestätigter Adresse anklickbar — in BEIDEN Komponenten', () => {
+	const FAELLE: Array<{ name: string; profile: Profile; erwartetDisabled: boolean }> = [
+		{ name: 'keine mail_to', profile: {}, erwartetDisabled: true },
+		{ name: 'mail_to gesetzt, email_verified: false', profile: { mail_to: MAIL, email_verified: false }, erwartetDisabled: true },
+		{ name: 'mail_to gesetzt, email_verified: true', profile: { mail_to: MAIL, email_verified: true }, erwartetDisabled: false }
+	];
+
+	for (const fall of FAELLE) {
+		test(`VTBriefingChannels — ${fall.name} → disabled === ${fall.erwartetDisabled}`, () => {
+			const inputTag = checkboxInputTag(renderBriefingChannels(fall.profile), 'channel-email');
+			assert.equal(
+				isDisabled(inputTag),
+				fall.erwartetDisabled,
+				`AC-4 (VTBriefingChannels, ${fall.name}): erwartet disabled=${fall.erwartetDisabled}, Tag: ${inputTag}`
+			);
+		});
+
+		test(`EditReportConfigSection — ${fall.name} → disabled === ${fall.erwartetDisabled}`, () => {
+			const inputTag = checkboxInputTag(renderEditSection(fall.profile), 'channel-email');
+			assert.equal(
+				isDisabled(inputTag),
+				fall.erwartetDisabled,
+				`AC-4 (EditReportConfigSection, ${fall.name}): erwartet disabled=${fall.erwartetDisabled}, Tag: ${inputTag}`
+			);
+		});
+	}
+});
+
+// ─── AC-5 ────────────────────────────────────────────────────────────────────
+
+describe('AC-5: Telegram-/SMS-Checkbox-Sperre bleibt unverändert (Regression)', () => {
+	const TELEGRAM_FAELLE: Array<{ name: string; profile: Profile; erwartetDisabled: boolean }> = [
+		{ name: 'keine telegram_chat_id', profile: {}, erwartetDisabled: true },
+		{ name: 'telegram_chat_id gesetzt', profile: { telegram_chat_id: CHAT_ID }, erwartetDisabled: false }
+	];
+	const SMS_FAELLE: Array<{ name: string; profile: Profile; erwartetDisabled: boolean }> = [
+		{ name: 'keine sms_to', profile: {}, erwartetDisabled: true },
+		{ name: 'sms_to gesetzt, sms_allowed: true', profile: { sms_to: SMS, sms_allowed: true }, erwartetDisabled: false },
+		{ name: 'sms_to gesetzt, sms_allowed: false', profile: { sms_to: SMS, sms_allowed: false }, erwartetDisabled: true }
+	];
+
+	for (const fall of TELEGRAM_FAELLE) {
+		test(`Telegram — VTBriefingChannels — ${fall.name} → disabled === ${fall.erwartetDisabled}`, () => {
+			const inputTag = checkboxInputTag(renderBriefingChannels(fall.profile), 'channel-telegram');
+			assert.equal(isDisabled(inputTag), fall.erwartetDisabled, `AC-5 (VT, Telegram, ${fall.name}): Tag ${inputTag}`);
+		});
+		test(`Telegram — EditReportConfigSection — ${fall.name} → disabled === ${fall.erwartetDisabled}`, () => {
+			const inputTag = checkboxInputTag(renderEditSection(fall.profile), 'channel-telegram');
+			assert.equal(isDisabled(inputTag), fall.erwartetDisabled, `AC-5 (Edit, Telegram, ${fall.name}): Tag ${inputTag}`);
+		});
+	}
+
+	for (const fall of SMS_FAELLE) {
+		test(`SMS — VTBriefingChannels — ${fall.name} → disabled === ${fall.erwartetDisabled}`, () => {
+			const inputTag = checkboxInputTag(renderBriefingChannels(fall.profile), 'channel-sms');
+			assert.equal(isDisabled(inputTag), fall.erwartetDisabled, `AC-5 (VT, SMS, ${fall.name}): Tag ${inputTag}`);
+		});
+		test(`SMS — EditReportConfigSection — ${fall.name} → disabled === ${fall.erwartetDisabled}`, () => {
+			const inputTag = checkboxInputTag(renderEditSection(fall.profile), 'channel-sms');
+			assert.equal(isDisabled(inputTag), fall.erwartetDisabled, `AC-5 (Edit, SMS, ${fall.name}): Tag ${inputTag}`);
+		});
+	}
+});
+
+// ─── AC-6 ────────────────────────────────────────────────────────────────────
+
+describe('AC-6: EditReportConfigSection zeigt Dot+Label-Verbindungsstatus wie VTBriefingChannels', () => {
+	test('alle drei channel-status-* Testids erscheinen bei vollständig hinterlegtem Profil', () => {
+		const profile: Profile = {
+			mail_to: MAIL,
+			email_verified: true,
+			telegram_chat_id: CHAT_ID,
+			sms_to: SMS,
+			sms_allowed: true
+		};
+		const html = renderEditSection(profile);
+
+		for (const testid of ['channel-status-email', 'channel-status-telegram', 'channel-status-sms']) {
+			assert.ok(
+				html.includes(`data-testid="${testid}"`),
+				`AC-6: Testid "${testid}" fehlt in EditReportConfigSection — heute existiert dort kein ` +
+					'Dot+Label-Verbindungsstatus (nur in VTBriefingChannels).'
+			);
+		}
+	});
+});

--- a/frontend/src/lib/components/shared/versand-tab/channelConnectionStatus.ts
+++ b/frontend/src/lib/components/shared/versand-tab/channelConnectionStatus.ts
@@ -2,6 +2,10 @@
 // Leitet je Kanal einen ehrlichen Verbindungsstatus aus dem Profil ab
 // (Zustands-Matrix: Spec docs/specs/modules/issue_1258_alarme_tab_official_warnings.md
 // Abschnitt 12, AC-21). Pure Funktion, kein Netz-/DOM-Zugriff — node:testbar.
+//
+// Verwandte Bausteine im selben Ordner, die dieselbe ConnectionProfile-Datenbasis
+// konsumieren: sendTargetLabel.ts (#1471, Ziel-Satz im Bestätigungsdialog) und
+// channelContactLabel.ts (#1510, Kontakt-Suffixe für die Checkbox-Labels).
 
 export type ConnectionTone = 'good' | 'neutral';
 

--- a/frontend/src/lib/components/shared/versand-tab/channelContactLabel.ts
+++ b/frontend/src/lib/components/shared/versand-tab/channelContactLabel.ts
@@ -1,0 +1,32 @@
+// channelContactLabel — Issue #1510.
+// Liefert die Kontakt-Beschriftungs-Suffixe je Kanal aus einem ConnectionProfile
+// (z.B. " (a@b.de)" oder "" wenn kein Kontakt hinterlegt). Ersetzt die sechs
+// bisherigen Ternary-Duplikate in VTBriefingChannels.svelte und
+// EditReportConfigSection.svelte.
+//
+// Design: EIN Aufruf liefert alle drei Kanäle als Objekt (analog
+// channelConnectionStatus()), statt drei Einzelfunktionen — hält den Aufrufaufwand
+// pro Komponente bei einem $derived-Aufruf. Liefert bewusst nur den Suffix, nicht
+// das ganze Label inkl. Kanalname — der Kanalname bleibt literaler Text im Template.
+//
+// Spec: docs/specs/modules/fix_1510_versand_ziel_dedupe.md (AC-1)
+// Pure Funktion, kein Netz-/DOM-Zugriff — node:testbar, analog channelConnectionStatus.
+
+import type { ConnectionProfile } from './channelConnectionStatus';
+
+export interface ChannelContactLabels {
+	email: string;
+	telegram: string;
+	sms: string;
+}
+
+export function channelContactLabel(
+	profile: ConnectionProfile | null | undefined
+): ChannelContactLabels {
+	const p = profile ?? {};
+	return {
+		email: p.mail_to ? ` (${p.mail_to})` : '',
+		telegram: p.telegram_chat_id ? ` (${p.telegram_chat_id})` : '',
+		sms: p.sms_to ? ` (${p.sms_to})` : ''
+	};
+}


### PR DESCRIPTION
Sechs duplizierte Kontakt-Beschriftungen (E-Mail/Telegram/SMS) in
VTBriefingChannels.svelte und EditReportConfigSection.svelte laufen jetzt in
einer geteilten Funktion channelContactLabel() zusammen. Der Trip-Editor
zeigt zusätzlich denselben Dot+Label-Verbindungsstatus wie der Versand-Reiter,
und die E-Mail-Checkbox ist in beiden gesperrt, wenn die Adresse zwar
hinterlegt, aber nicht bestätigt ist (verhindert stilles Scheitern am
Empfängerschutz).

sendTargetLabel.ts (#1471) bleibt unverändert und unabhängig.

Adversary: VERIFIED, 8/8 AC bestätigt, Mutations-Gegenprobe (2 Testlücken in
korrektem Code -> #1199, kein ausgelieferter Fehler).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
