### PR TITLE
fix: ruff-Lint-Rot auf main beheben (Nachbesserung zu #1475)

### DIFF
--- a/tests/tdd/test_hail_kuerzel_hl_rename.py
+++ b/tests/tdd/test_hail_kuerzel_hl_rename.py
@@ -14,7 +14,6 @@ echter Token-Builder.
 """
 from __future__ import annotations
 
-import re
 import sys
 from pathlib import Path
 

--- a/tests/tdd/test_hail_multiday_preview_and_sms_tomorrow.py
+++ b/tests/tdd/test_hail_multiday_preview_and_sms_tomorrow.py
@@ -144,7 +144,7 @@ def test_ac5a_email_html_gewitter_vorschau_zeigt_hagel_hinweis():
         f"'{_HAGEL_HINWEIS}' zeigen, bekam Ausschnitt: {html_true[:2000]!r}"
     )
     assert _HAGEL_HINWEIS not in html_unbekannt, (
-        f"HTML-Gewitter-Vorschau mit hail=None darf keinen Zusatz zeigen"
+        "HTML-Gewitter-Vorschau mit hail=None darf keinen Zusatz zeigen"
     )
 
 


### PR DESCRIPTION
## Summary
- `tests/tdd/test_hail_kuerzel_hl_rename.py`: ungenutztes `re`-Import entfernt (ruff F401)
- `tests/tdd/test_hail_multiday_preview_and_sms_tomorrow.py`: überflüssiges f-Prefix ohne Platzhalter entfernt (ruff F541)

Beide durch Commit 7733d2fd (`feat(#1475): Hagel-Kennzeichen an allen Ausgabeorten — Nachbesserung`) auf `main` eingeführt — blockierte den `lint`-Check jedes nachfolgenden PRs (gefunden beim Öffnen von PR #1520 für #1354). Reine Ruff-Autofixes, kein Verhaltensunterschied.

## Test plan
- [x] `uv run ruff check tests/tdd/test_hail_kuerzel_hl_rename.py tests/tdd/test_hail_multiday_preview_and_sms_tomorrow.py` → 0 Fehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)