### PR TITLE
fix(#1307 B): Vier Waechter tun jetzt, was sie behaupten

### DIFF
--- a/.claude/hooks/_e2e_paths.py
+++ b/.claude/hooks/_e2e_paths.py
@@ -162,6 +162,22 @@ def _git_diff_names(base, target, repo_dir) -> "list[str] | None":
     return [f.strip() for f in result.stdout.splitlines() if f.strip()]
 
 
+def commit_exists(sha, repo_dir) -> bool:
+    """Prüft per `git cat-file -e`, ob `sha` in repo_dir auflösbar ist.
+
+    Gemeinsame Stelle für die zuvor fünffach duplizierte Existenzprüfung
+    (#1307 Scheibe B, Befund 4): staging_gate._scope_diff_base() (2x) und
+    prod_selftest._scope_diff_base() (3x) setzten je einen eigenen Subprozess
+    ab. Verhalten unverändert übernommen: Rückgabecode 0 → True, sonst False
+    (der Aufrufer weicht dann auf seine nächste Basis aus).
+    """
+    result = subprocess.run(
+        ["git", "cat-file", "-e", sha],
+        capture_output=True, text=True, cwd=str(repo_dir),
+    )
+    return result.returncode == 0
+
+
 def _detect_scope_from_git_diff(base, target, repo_dir) -> str:
     """Scope-Klassifikation des Diffs base..target (Issue #1121).
 

--- a/.claude/hooks/design_fidelity_diff.py
+++ b/.claude/hooks/design_fidelity_diff.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 SCREEN_URL_MAP = {
     # Home (D) — gleiche Route, verschiedene Cockpit-Varianten
@@ -142,15 +143,55 @@ SCREEN_PRE_ACTIONS: dict[str, list[tuple[str, str]]] = {
 
 
 def load_validator_env() -> None:
-    validator_env = Path(".claude/validator.env")
-    if not validator_env.exists():
-        return
-    for line in validator_env.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
+    """Zugangsdaten nachladen — ZWEI Quellen, zwei verschiedene Schranken:
+
+    - `.claude/validator.env` (GZ_VALIDATOR_*) → der vorgeschaltete
+      Basic-Auth-Schutz vor Staging.
+    - `.env` (GZ_AUTH_*) → die Anmeldung der Anwendung selbst.
+
+    Beides wurde frueher aus GZ_VALIDATOR_* bedient; die Anwendung lehnt diese
+    Daten ab (#1307 Scheibe B), wodurch das Werkzeug still die Anmeldemaske
+    fotografierte. Bereits gesetzte Umgebungsvariablen haben Vorrang.
+    """
+    for env_file in (Path(".claude/validator.env"), Path(".env")):
+        if not env_file.exists():
             continue
-        k, v = line.split("=", 1)
-        os.environ.setdefault(k.strip(), v.strip())
+        for line in env_file.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+
+
+def unauthenticated_reason(final_url: str, has_password_field: bool) -> "str | None":
+    """Warum die aufgenommene Seite KEINE gueltige, angemeldete Zielseite ist.
+
+    Rueckgabe: Begruendung als Text, oder None wenn die Aufnahme gueltig ist.
+
+    Hintergrund (#1307 Scheibe B): Die Formular-Anmeldung scheitert LAUTLOS —
+    `page.fill`/`page.click` werfen keine Ausnahme, wenn die Anwendung die
+    Zugangsdaten ablehnt. Das Werkzeug lief weiter, fotografierte die
+    Anmeldemaske und schrieb einen Bericht mit `passed: true` (23,35 % bei
+    Schwelle 30 %). Ein Design-Waechter, der sich damit zufriedengibt, prueft
+    nichts. Diese Funktion prueft deshalb an der Stelle, an der es zaehlt:
+    unmittelbar vor der Aufnahme.
+
+    Zwei unabhaengige Merkmale, damit ein einzelner Umbau (umbenanntes Feld,
+    andere Rueckleitung) die Pruefung nicht still aushebelt.
+    """
+    path = urlparse(final_url).path
+    if path == "/login" or path.startswith("/login/"):
+        return (
+            f"die Seite steht nach der Anmeldung auf {final_url} — "
+            "zurueckgeleitet auf die Anmeldemaske"
+        )
+    if has_password_field:
+        return (
+            "auf der Zielseite ist noch ein Passwortfeld sichtbar — "
+            "die Anmeldung hat nicht gegriffen"
+        )
+    return None
 
 
 def take_screenshot(
@@ -167,21 +208,40 @@ def take_screenshot(
         print("playwright not available — skipping live screenshot", file=sys.stderr)
         return False
 
-    user = os.environ.get("GZ_VALIDATOR_USER", "")
-    password = os.environ.get("GZ_VALIDATOR_PASS", "")
+    # Zwei Schranken, zwei Zugangsdaten-Paare (#1307 Scheibe B):
+    #   basic_* → vorgeschalteter Basic-Auth-Schutz (nginx, realm "Staging")
+    #   app_*   → Anmeldung der Anwendung selbst
+    # Frueher bediente GZ_VALIDATOR_* beides. Die Anwendung lehnt diese Daten
+    # ab (gemessen: POST /api/auth/login → 401 "invalid credentials"), ohne
+    # dass page.fill/click eine Ausnahme werfen — deshalb blieb es still.
+    basic_user = os.environ.get("GZ_VALIDATOR_USER", "")
+    basic_pass = os.environ.get("GZ_VALIDATOR_PASS", "")
+    app_user = os.environ.get("GZ_AUTH_USER", "")
+    app_pass = os.environ.get("GZ_AUTH_PASS", "")
 
     try:
         with sync_playwright() as p:
             browser = p.chromium.launch(headless=True)
-            context = browser.new_context(viewport={"width": viewport[0], "height": viewport[1]})
+            # Staging liegt hinter einem vorgeschalteten Basic-Auth-Schutz
+            # (nginx, realm "Staging"): /login antwortet ohne Zugangsdaten mit
+            # 401 (gemessen 2026-08-05). Ohne http_credentials fotografiert das
+            # Werkzeug die Sperrseite statt der angeforderten Seite
+            # (#1307 Scheibe B, AC-11). Die Formular-Anmeldung unten bleibt
+            # davon unberuehrt — beide Schritte sind noetig.
+            context_kwargs = {"viewport": {"width": viewport[0], "height": viewport[1]}}
+            if basic_user and basic_pass:
+                context_kwargs["http_credentials"] = {
+                    "username": basic_user, "password": basic_pass,
+                }
+            context = browser.new_context(**context_kwargs)
             page = context.new_page()
 
-            if user and password:
+            if app_user and app_pass:
                 try:
                     page.goto(base + "/login", timeout=30000)
                     page.wait_for_load_state("networkidle", timeout=15000)
-                    page.fill("input[name='username']", user)
-                    page.fill("input[name='password']", password)
+                    page.fill("input[name='username']", app_user)
+                    page.fill("input[name='password']", app_pass)
                     page.click("button[type='submit']")
                     page.wait_for_load_state("networkidle", timeout=15000)
                 except Exception as e:
@@ -228,6 +288,26 @@ def take_screenshot(
                 # Modal-Render-Zeit
                 page.wait_for_timeout(800)
 
+            # Fail-closed VOR der Aufnahme (#1307 Scheibe B): ist die Anmeldung
+            # nicht gegriffen, wird NICHT fotografiert — sonst entsteht ein
+            # Bericht ueber die Anmeldemaske, der unter der Schwelle liegt und
+            # `passed: true` traegt. Genau so ist es passiert.
+            reason = unauthenticated_reason(
+                page.url,
+                page.query_selector("input[type='password']") is not None,
+            )
+            if reason is not None:
+                print(
+                    f"ERROR: keine gueltige Aufnahme — {reason}. "
+                    "Erwartet wird die angemeldete Zielseite; geprueft werden "
+                    "GZ_AUTH_USER/GZ_AUTH_PASS (Anwendung) und "
+                    "GZ_VALIDATOR_USER/GZ_VALIDATOR_PASS (vorgeschalteter "
+                    "Schutz). Kein Bericht geschrieben.",
+                    file=sys.stderr,
+                )
+                browser.close()
+                return False
+
             page.screenshot(path=str(ist_path), full_page=False)
             browser.close()
         return True
@@ -268,7 +348,15 @@ def main() -> None:
     parser.add_argument("--threshold", type=float, default=10.0, help="Max allowed diff %% (default: 10.0)")
     parser.add_argument(
         "--workflow",
-        default=os.environ.get("GZ_ACTIVE_WORKFLOW", "issue-603-design-fidelity-gate"),
+        # #1307 Scheibe B (AC-12): beide Schreibweisen der Workflow-Kennung,
+        # in DERSELBEN Reihenfolge wie pre_issue_close_design_gate.py — sonst
+        # legt das Werkzeug seinen Bericht in einem anderen Ordner ab als der
+        # Waechter durchsucht, und der frische Bericht wird nie gefunden.
+        default=(
+            os.environ.get("OPENSPEC_ACTIVE_WORKFLOW")
+            or os.environ.get("GZ_ACTIVE_WORKFLOW")
+            or "issue-603-design-fidelity-gate"
+        ),
         help="Workflow name for artifact directory",
     )
     args = parser.parse_args()
@@ -297,6 +385,12 @@ def main() -> None:
     ist_path = artifact_dir / f"design-diff-{screen}-ist.png"
     diff_path = artifact_dir / f"design-diff-{screen}-diff.png"
     report_path = artifact_dir / f"design-diff-{screen}.json"
+
+    # Ein frueherer, bestandener Bericht darf einen jetzt scheiternden Lauf
+    # nicht ueberleben (#1307 Scheibe B): der Waechter sucht per Glob nach
+    # IRGENDEINEM `passed: true` und wuerde sonst den alten Nachweis fuer den
+    # neuen Stand halten. Fail-closed: erst weg, dann neu belegen.
+    report_path.unlink(missing_ok=True)
 
     # Check soll-PNG
     if not soll_path.exists():

--- a/.claude/hooks/pre_issue_close_design_gate.py
+++ b/.claude/hooks/pre_issue_close_design_gate.py
@@ -46,8 +46,17 @@ def main() -> None:
     if "design-compliance" not in labels:
         sys.exit(0)
 
-    # Need active workflow to find artefacts
-    workflow = os.environ.get("OPENSPEC_ACTIVE_WORKFLOW", "")
+    # Need active workflow to find artefacts.
+    # #1307 Scheibe B (AC-13): beide Schreibweisen der Workflow-Kennung
+    # akzeptieren — dieselbe Fallback-Kette wie die Geschwister-Gates
+    # (prod_send_gate.py, staging_gate.py, prod_selftest.py). Die Reihenfolge
+    # muss mit design_fidelity_diff.py uebereinstimmen, sonst schreibt das
+    # Werkzeug in einen anderen Ordner als der Waechter durchsucht.
+    workflow = (
+        os.environ.get("OPENSPEC_ACTIVE_WORKFLOW")
+        or os.environ.get("GZ_ACTIVE_WORKFLOW")
+        or ""
+    ).strip()
     if not workflow:
         sys.exit(0)  # fail-open when no active workflow
 

--- a/.claude/hooks/prod_selftest.py
+++ b/.claude/hooks/prod_selftest.py
@@ -614,31 +614,21 @@ def _scope_diff_base(repo_dir: Path = REPO_DIR) -> str:
         except (OSError, json.JSONDecodeError, ValueError):
             prod_deploy_data = {}
 
+        # #1307 Scheibe B (AC-5): Existenzpruefungen laufen ueber die gemeinsame
+        # Stelle _e2e_paths.commit_exists() statt je eigener git-Subprozesse.
         previous_commit = prod_deploy_data.get("previous_commit")
         if previous_commit and previous_commit != head:
-            resolvable = subprocess.run(
-                ["git", "cat-file", "-e", previous_commit],
-                capture_output=True, text=True, cwd=str(repo_dir),
-            )
-            if resolvable.returncode == 0:
+            if _e2e_paths.commit_exists(previous_commit, repo_dir):
                 return previous_commit
 
         deployed_commit = prod_deploy_data.get("deployed_commit")
         if deployed_commit and deployed_commit != head:
-            resolvable = subprocess.run(
-                ["git", "cat-file", "-e", deployed_commit],
-                capture_output=True, text=True, cwd=str(repo_dir),
-            )
-            if resolvable.returncode == 0:
+            if _e2e_paths.commit_exists(deployed_commit, repo_dir):
                 return deployed_commit
 
     marker_sha = _e2e_paths.read_last_gate_scope(repo_dir)
     if marker_sha and marker_sha != head:
-        resolvable = subprocess.run(
-            ["git", "cat-file", "-e", marker_sha],
-            capture_output=True, text=True, cwd=str(repo_dir),
-        )
-        if resolvable.returncode == 0:
+        if _e2e_paths.commit_exists(marker_sha, repo_dir):
             return marker_sha
     return "HEAD~1"
 

--- a/.claude/hooks/staging_gate.py
+++ b/.claude/hooks/staging_gate.py
@@ -109,8 +109,16 @@ def _commit_e2e_path(sha: str | None = None) -> Path:
     return _e2e_paths.commit_e2e_path(_shared_repo_dir(), sha or _head_sha())
 
 
-def _scope_diff_base() -> str:
+def _scope_diff_base(head: str | None = None) -> str:
     """Diff-Basis für die Scope-Erkennung (Issue #916).
+
+    #1307 Scheibe B (AC-1): ``head`` wird vom Aufrufer durchgereicht, damit der
+    Commit-Stand pro write_verdict()-Lauf genau EINMAL ermittelt wird. Ohne
+    Argument (Direktaufruf) bleibt das Verhalten unverändert — der Stand wird
+    dann hier selbst frisch geholt. Bewusst KEIN Zwischenspeicher über
+    Aufrufgrenzen hinweg: tests/tdd/test_e2e_commit_namespacing.py:104-111 ruft
+    write_verdict() zweimal im selben Prozess mit einem Commit-Wechsel dazwischen
+    auf und verlangt je den eigenen Stand.
 
     Ist ein Gate-Marker vorhanden UND der SHA im Repo auflösbar → Marker-SHA
     (deckt ALLE Commits seit dem letzten erfolgreichen Gate-Lauf ab). Sonst
@@ -132,28 +140,21 @@ def _scope_diff_base() -> str:
     übernommen, nie ein gecachter Scope-WERT — der Scope wird weiterhin immer
     frisch aus dem echten git-diff berechnet (F001 bleibt unberührt).
     """
-    head = _head_sha()
+    head = head if head is not None else _head_sha()
     preflight_base = _e2e_paths.read_preflight_base(_shared_repo_dir(), head)
     if preflight_base is not None:
-        resolvable = subprocess.run(
-            ["git", "cat-file", "-e", preflight_base],
-            capture_output=True, text=True, cwd=str(_verified_repo_dir()),
-        )
-        if resolvable.returncode == 0:
+        if _e2e_paths.commit_exists(preflight_base, _verified_repo_dir()):
             return preflight_base
 
     marker_sha = _e2e_paths.read_last_gate_scope(_shared_repo_dir())
-    if marker_sha and marker_sha != _head_sha():
-        resolvable = subprocess.run(
-            ["git", "cat-file", "-e", marker_sha],
-            capture_output=True, text=True, cwd=str(_verified_repo_dir()),
-        )
-        if resolvable.returncode == 0:
+    if marker_sha and marker_sha != head:
+        if _e2e_paths.commit_exists(marker_sha, _verified_repo_dir()):
             return marker_sha
     return "HEAD~1"
 
 
-def _detect_committed_scope(expected_commit: str | None = None) -> str:
+def _detect_committed_scope(expected_commit: str | None = None,
+                            head: str | None = None) -> str:
     """Klassifiziert die Commits seit dem Gate-Marker (Fallback HEAD~1..HEAD).
 
     Issue #1096: läuft ein zweiter --check-Lauf auf demselben HEAD (z.B.
@@ -171,10 +172,16 @@ def _detect_committed_scope(expected_commit: str | None = None) -> str:
     Returns: frontend-only | backend | full-stack | docs-only
     """
     if expected_commit is None:
-        cached = _e2e_paths.cached_scope_for_sha(_shared_repo_dir(), _head_sha())
+        # #1307 Scheibe B (AC-1): durchgereichten Stand nutzen, sonst genau hier
+        # einmal frisch ermitteln und an _scope_diff_base() weitergeben. Bewusst
+        # IN diesem Zweig statt am Funktionsanfang: der Preflight-Zweig unten
+        # braucht HEAD nicht, und beim Beheben von "fragt zu oft" darf keine
+        # zusaetzliche Abfrage entstehen.
+        head = head if head is not None else _head_sha()
+        cached = _e2e_paths.cached_scope_for_sha(_shared_repo_dir(), head)
         if cached is not None:
             return cached
-        base, target = _scope_diff_base(), "HEAD"
+        base, target = _scope_diff_base(head), "HEAD"
     else:
         base, target = "HEAD", expected_commit
 
@@ -223,16 +230,11 @@ def _telegram_live_gate() -> int:
         _log(f"WARN: e2e_telegram_live nicht ladbar ({exc}) — Telegram-Gate übersprungen.", stream=sys.stderr)
         return 0
 
-    result = subprocess.run(
-        ["git", "diff", "--name-only", "HEAD~1", "HEAD"],
-        capture_output=True, text=True, cwd=str(_verified_repo_dir()),
-    )
-    if result.returncode != 0:
-        # Fehlgeschlagener Diff (z.B. kein HEAD~1) -> konservativ als
-        # potenziell Telegram-relevant behandeln (Issue #1121, AC-5).
-        changed = None
-    else:
-        changed = [f.strip() for f in result.stdout.splitlines() if f.strip()]
+    # #1307 Scheibe B (AC-5): Datei-Diff ueber die gemeinsame Stelle statt eines
+    # eigenen Subprozesses. Semantik unveraendert — _git_diff_names() liefert
+    # None bei fehlgeschlagenem Diff (z.B. kein HEAD~1), was unten konservativ
+    # als potenziell Telegram-relevant behandelt wird (Issue #1121, AC-5).
+    changed = _e2e_paths._git_diff_names("HEAD~1", "HEAD", _verified_repo_dir())
     if changed is not None and not mod._scope_touches_telegram(changed):
         return 0
     if mod.gate(scope_touches_telegram=True, env=dict(os.environ)) != 0:
@@ -291,7 +293,7 @@ def write_verdict(verdict: str, findings_path: Path, e2e_path: Path | None = Non
         for f in findings
     ]
 
-    scope = scope_override or _detect_committed_scope()
+    scope = scope_override or _detect_committed_scope(head=sha)
     payload = {
         "verified_commit": sha,
         "staging_verdict": verdict,
@@ -396,6 +398,11 @@ def gate_check(e2e_path: Path | None, scope_override: str | None,
     # fälschlich "docs-only" → fail-open Exit 0 OHNE Attestations-Prüfung. Genau
     # das darf dieser Preflight nie: fail-closed VOR jeder Scope-/Skip-Logik.
     if preflight:
+        # Bewusst eigenstaendig (AC-7, #1307 Scheibe B): `rev-parse --verify`
+        # liefert die volle SHA auf stdout — das kann eine reine
+        # Existenzpruefung (_e2e_paths.commit_exists) nicht, und genau die
+        # volle SHA braucht die #1382-Normalisierung wenige Zeilen weiter unten.
+        # Deshalb NICHT an die gemeinsame Stelle delegiert.
         resolved = subprocess.run(
             ["git", "rev-parse", "--verify", "--quiet", f"{expected_commit}^{{commit}}"],
             capture_output=True, text=True, cwd=str(_verified_repo_dir()),
@@ -461,6 +468,9 @@ def gate_check(e2e_path: Path | None, scope_override: str | None,
         if not explicit_path:
             ancestor, _cdata = _e2e_paths._nearest_verified_ancestor(ref, git_dir, _shared_repo_dir())
         if ancestor is not None:
+            # Bewusst eigenstaendig (AC-7, #1307 Scheibe B): einzige
+            # Ancestor-Pruefung im Hook-Baum, kein Gegenstueck im gemeinsamen
+            # Modul — deshalb NICHT an die gemeinsame Stelle delegiert.
             is_anc = subprocess.run(
                 ["git", "merge-base", "--is-ancestor", ancestor, ref],
                 capture_output=True, text=True, cwd=str(git_dir),

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -74,6 +74,16 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [ -f \"${CLAUDE_PROJECT_DIR}/.claude/hooks/pre_issue_close_design_gate.py\" ]; then python3 \"${CLAUDE_PROJECT_DIR}/.claude/hooks/pre_issue_close_design_gate.py\"; fi",
+            "timeout": 60
+          }
+        ]
+      },
+      {
         "matcher": "Write|Edit",
         "hooks": [
           {

--- a/docs/context/fix-1307b-gates.md
+++ b/docs/context/fix-1307b-gates.md
@@ -1,0 +1,343 @@
+# Context: fix-1307b-gates (#1307 Scheibe B — Befunde 2 bis 5)
+
+## Request Summary
+
+Issue #1307 listet fünf Gate-/Tooling-Befunde. Befund 1 ist mit Scheibe A erledigt
+(`cf33590a`). Scheibe B soll die verbleibenden Befunde 2 bis 5 abarbeiten — jeweils
+**mit gemessenem Ausgangsstand**, weil die schriftliche Diagnose im Issue sich bereits
+zweimal als falsch erwiesen hat.
+
+## Gemessener Ausgangsstand (2026-08-05, HEAD `584fa6de`)
+
+Lauf: `uv run pytest --runxfail --color=no -q --disable-socket --allow-hosts=127.0.0.1`
+über die vier genannten Testdateien. `--runxfail` schaltet die „bekannt offen"-Maskierung
+ab und zeigt das echte Ergebnis.
+
+| Befund | Testfall | Ergebnis |
+|---|---|---|
+| 2 | `test_issue_603_design_fidelity_gate.py::…::test_gate_allows_close_with_pass_artefact` | rot |
+| 3 | `test_issue_668_head_sha_dedup.py::test_ac1_head_sha_called_once_without_override` | rot |
+| 3 | `test_issue_668_head_sha_dedup.py::test_ac3_override_path_still_works` | rot |
+| 4 | `test_e2e_path_helper.py::TestPathLogicConsolidated::test_path_logic_only_in_shared_module` | rot |
+| 5 | `test_issue_816_alert_deviation.py::test_ac7_header_set_and_validator_noop` | rot |
+
+Damit ist der Issue-Kommentar vom 2026-08-04 früh („3+4 im Code behoben, 5 via #1282
+adressiert") zum dritten Mal widerlegt. Er war aus dem Code gelesen, nicht gemessen.
+
+## Kernbefund: nur EINER der vier ist ein Code-Fehler
+
+Die Recherche zeigt, dass „vier kaputte Wächter" die falsche Beschreibung ist.
+
+| Befund | Was wirklich vorliegt | Klasse |
+|---|---|---|
+| 2 | Test setzt eine Umgebungsvariable, die es nicht mehr gibt | **veralteter Test** |
+| 3 | `write_verdict()` fragt den Commit-Stand dreimal statt einmal ab | **echter Code-Fehler** |
+| 4 | Test sucht per Textsuche nach `rev-parse` und trifft eine legitime Zeile | **untauglicher Test** |
+| 5 | Zwei Tests fordern gegenteiliges Verhalten voneinander | **Spec-Widerspruch** |
+
+## Befund 2 — Design-Gate
+
+**Wurzel:** `.claude/hooks/pre_issue_close_design_gate.py:50` liest
+`OPENSPEC_ACTIVE_WORKFLOW`. Der Test setzt `GZ_ACTIVE_WORKFLOW`
+(`tests/tdd/test_issue_603_design_fidelity_gate.py:228`). Commit `93ef0741`
+(„GZ_ACTIVE_WORKFLOW → OPENSPEC_ACTIVE_WORKFLOW in Projekt-Hooks") stellte acht
+Hook-Dateien um — den Test aber nicht.
+
+Folge: Das Gate löst den Workflow-Namen aus der ambient gesetzten Variable auf, sucht das
+Pass-Artefakt im falschen Ordner, findet keines und beendet mit Exit 2
+(`pre_issue_close_design_gate.py:72`). Der Test legt das Artefakt korrekt an — er redet
+nur mit einer Variable, auf die niemand mehr hört.
+
+Andere Gates (`prod_send_gate.py:307`, `staging_gate.py:285`, `prod_selftest.py:857`)
+akzeptieren **beide** Namen mit Fallback-Kette. Das Design-Gate ist der einzige Ausreißer.
+
+**Zusätzlicher, schwererer Befund — steht nicht im Issue:**
+`pre_issue_close_design_gate.py` ist in **keiner** Settings-Datei verdrahtet
+(selbst nachgemessen: `.claude/settings.json`, `.claude/settings.local.json`,
+`~/.claude/settings.json` — kein Treffer). Es existiert nur als Skript und läuft
+ausschließlich im Testkontext. Der Wächter, der das Schließen von Design-Issues bewachen
+soll, ist seit seiner Einführung (#603) nie gelaufen.
+
+Das ist exakt die Krankheit aus Scheibe A: eine Regel, die dasteht und nicht beißt.
+
+## Befund 3 — Commit-Stand wird dreifach abgefragt
+
+**Wurzel:** `write_verdict()` in `.claude/hooks/staging_gate.py` löst pro Lauf drei
+`git rev-parse HEAD`-Aufrufe aus (gemessen per PATH-Shim, der echte Subprozesse zählt —
+kein Mock):
+
+1. `staging_gate.py:252` — `sha = _head_sha()` direkt in `write_verdict()`
+2. `staging_gate.py:174` — via `_detect_committed_scope()`
+3. `staging_gate.py:135` — via `_scope_diff_base()`, das aus (2) heraus aufgerufen wird
+
+`_head_sha()` selbst (`staging_gate.py:95-96`) delegiert korrekt an
+`_e2e_paths.head_sha()`, und dort steht genau **ein** Aufruf (`_e2e_paths.py:222-227`).
+Der Fehler liegt nicht im Helfer, sondern in der Zahl seiner Aufrufe.
+
+**Rückfall, kein Neubefund:** #668 hat genau das im Juni behoben (`3ef67003`,
+Adversary VERIFIED, 22 grün). Der Commit steckt nachweislich noch in HEAD
+(`git merge-base --is-ancestor` → ja). Seitdem kamen über #916/#988, #1084, #1096 und
+#1428 neue Aufrufpfade dazu, die den Stand erneut selbst abfragen. Aus 1 wurden 3.
+
+Der zugehörige Test war die ganze Zeit als „bekannt offen" markiert und damit grün —
+niemand hat den Rückfall bemerkt. Dieselbe Mechanik, die in Scheibe A aus 5 unbemerkt 8
+gemacht hat.
+
+## Befund 4 — Struktur-Test prüft Text statt Verhalten
+
+`tests/tdd/test_e2e_path_helper.py:182` prüft:
+
+```python
+assert "rev-parse" not in src
+```
+
+über den kompletten Quelltext von `staging_gate.py` und `prod_selftest.py`.
+
+**Warum er rot ist:** Er trifft `staging_gate.py:399-401` —
+`git rev-parse --verify --quiet <expected_commit>^{commit}`. Das ist eine
+Existenzprüfung für einen übergebenen Commit, **keine** duplizierte Pfad-Logik. Der Test
+schlägt also über eine Zeile an, die er nicht meint.
+
+**Warum er trotzdem nichts taugt:**
+- Trivial umgehbar durch `"rev-" + "parse"` oder implizite String-Verkettung
+- Er übersieht vier weitere direkte git-Aufrufe, die das gemeinsame Modul genauso
+  umgehen: `cat-file -e` (`:138`, `:147`), `diff --name-only` (`:226`),
+  `merge-base --is-ancestor` (`:465`)
+- Er würde bei einer harmlosen Erwähnung von `rev-parse` in einem Kommentar ebenfalls rot
+- Ein Umbau, der den Text entfernt aber weiter dreimal abfragt, macht ihn grün, ohne
+  Befund 3 zu lösen
+
+Das ist die Klasse „Formprüfung ist bodenlos" — im Projekt bereits dreimal aufgetreten
+(#1431 Kommandozeilen, #1471 AST, #1307 Scheibe A Hook-Einträge). Jedes Mal war die
+Lösung, **die Frage umzudrehen**: nicht „erkenne ich eine verbotene Form?", sondern
+„ist die Zusicherung an der Stelle erfüllt, an der sie wirkt?".
+
+## Befund 5 — zwei Tests fordern Gegenteiliges
+
+`.claude/hooks/briefing_mail_validator.py:505-512` liefert für
+`X-GZ-Mail-Type: compare` und `deviation-alert` bewusst `ok=False` mit dem Fehlertext
+`"… — falscher Validator, uebersprungen"`.
+
+Das ist **Absicht aus #1282**: Der Marker `uebersprungen` wird in
+`_write_validation_log()` (`:638-648`) ausgewertet. Gäbe der Validator `ok=True` zurück,
+würde `passed: true` ins Protokoll geschrieben, und das Renderer-Commit-Gate (#811)
+könnte diesen No-Op als echten Erfolgsnachweis akzeptieren — obwohl nichts geprüft wurde.
+Genau diese Gate-Erosion sollte #1282 verhindern.
+
+Abgesichert ist das durch `tests/tdd/test_briefing_validator_noop_not_pass.py`
+(`test_compare_mail_type_noop_is_not_a_pass`, `test_deviation_alert_mail_type_noop_is_not_a_pass`,
+beide `assert success is False`).
+
+`tests/tdd/test_issue_816_alert_deviation.py:611-628` (AC-7) fordert für denselben Header
+`ok=True`.
+
+**Beide Tests können nicht gleichzeitig gelten.** Einer von beiden muss weichen.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `.claude/hooks/pre_issue_close_design_gate.py` | Befund 2 — Prüfling; liest nur `OPENSPEC_ACTIVE_WORKFLOW` (`:50`); nirgends verdrahtet |
+| `.claude/hooks/staging_gate.py` | Befund 3+4 — Prüfling; `_head_sha()` `:95`, Aufrufer `:135`/`:174`/`:252`; direkte git-Aufrufe `:138`/`:147`/`:226`/`:400`/`:465` |
+| `.claude/hooks/_e2e_paths.py` | gemeinsames Modul; `head_sha()` `:220-230` mit genau einem Aufruf |
+| `.claude/hooks/briefing_mail_validator.py` | Befund 5 — Prüfling; Typ-Weiche `:493-523`, Protokoll-Marker `:638-648` |
+| `tests/tdd/test_issue_603_design_fidelity_gate.py` | Befund 2 — setzt veraltete Variable `:228` |
+| `tests/tdd/test_issue_668_head_sha_dedup.py` | Befund 3 — zählt echte Subprozesse per PATH-Shim `:61-74` |
+| `tests/tdd/test_e2e_path_helper.py` | Befund 4 — Substring-Test `:182` |
+| `tests/tdd/test_issue_816_alert_deviation.py` | Befund 5 — AC-7 `:611-628`, xfail `:598` |
+| `tests/tdd/test_briefing_validator_noop_not_pass.py` | Befund 5 — Gegentest aus #1282 |
+| `.claude/settings.json` | Verdrahtung der Hooks; Design-Gate fehlt dort |
+
+## Existing Patterns
+
+- **Fallback-Kette für den Workflow-Namen:** `prod_send_gate.py:307-308`,
+  `staging_gate.py:285-286`, `prod_selftest.py:857-858` akzeptieren beide Variablennamen.
+  Vorbild für Befund 2.
+- **Zuständigkeit strukturell lösen statt quittieren:** `email_spec_validator.py:241-258`
+  filtert schon bei der Mail-Auswahl per IMAP-Scan auf den eigenen Typ, statt einen
+  fremden Typ in `validate_message()` mit `True` durchzuwinken.
+- **Zählnachweis ohne Mock:** `test_issue_668_head_sha_dedup.py:61-74` — PATH-Shim, das
+  echte Subprozessaufrufe in eine Datei zählt und dann echtes `git` ausführt. Der saubere
+  Weg, eine Aufrufzahl zu belegen.
+- **Fail-open-Form für Hook-Einträge:** `if [ -f "…" ]; then python3 "…"; fi`
+  (nie `&&`/`||`, die verschlucken den Rückgabewert) — aus Scheibe A.
+
+## Dependencies
+
+- **Upstream:** `staging_gate.py` und `prod_selftest.py` hängen an `_e2e_paths.py`.
+  `briefing_mail_validator.py` hängt an `_validator_log.py`.
+- **Downstream:** `renderer_mail_gate.py` liest die Protokolle des Mail-Prüfers und
+  entscheidet daran über Commits. `deploy-gregor-prod.sh` und der Post-Deploy-Selbsttest
+  hängen am Urteil von `staging_gate.py`. Eine Änderung an der Rückgabe des Mail-Prüfers
+  wirkt direkt auf die Commit-Fähigkeit.
+
+## Existing Specs
+
+- `docs/specs/modules/rework_1211b_rot_triage.md` — Herkunft aller fünf Befunde
+- `docs/specs/_archive/modules/issue_603_design_fidelity_gate.md` — Design-Gate,
+  nennt `:116` einen `PreToolUse:Bash`-Hook, der nie eingetragen wurde
+- `docs/specs/modules/fix_1409_worktree_test_paths.md` — Pfadregel; führt das Design-Gate
+  `:61` ausdrücklich als unbedenklich
+- `docs/reference/mail_validators.md` — Zuständigkeit der beiden Mail-Prüfer
+
+## Risks & Considerations
+
+1. **Befund 4 verleitet zum falschen Fix.** Die Zeile `rev-parse --verify` zu
+   umschreiben, macht den Test grün und ändert fachlich nichts. Der Test muss ersetzt
+   werden, nicht der Code angepasst.
+2. **Befund 5 ist eine Entscheidung, kein Fix.** Wer den Validator auf `ok=True` umstellt,
+   öffnet das Renderer-Gate für falsche Erfolgsnachweise. Der Beschluss aus #1282 ist der
+   jüngere und der besser begründete.
+3. **Das Design-Gate zu verdrahten ist eine Verhaltensänderung**, keine Reparatur — es
+   würde erstmals echte `gh issue close`-Aufrufe blockieren können. Getrennt zu
+   entscheiden.
+4. **Befund 3 kann zurückkommen.** Er ist schon einmal zurückgekommen, weil der Test als
+   „bekannt offen" markiert war. Ohne Entfernen dieser Markierung ist der Fix wertlos —
+   die Lehre aus Scheibe A.
+5. **`tests/tdd/conftest.py:37`** hält einen festen Hauptrepo-Pfad. Die drei hier
+   betroffenen Tests nutzen ihn nicht, andere Fixtures schon — beim Ändern nicht
+   versehentlich anfassen.
+6. **Nur `.claude/`, `tests/`, `docs/` betroffen** → kein Produktions-Runtime-Code →
+   Doku-/Tooling-Ausnahme greift, Staging- und Prod-Schritt entfallen (wie Scheibe A).
+
+---
+
+# Analysis
+
+## Type
+
+Bug (vier Wächter-/Prüfungsfehler), Tooling-Ebene. Kein Produktions-Runtime-Code.
+
+## PO-Entscheidungen (2026-08-05)
+
+1. **Design-Wächter wird eingehängt und scharf geschaltet**, mit Prüfdatum nach Regel-Budget.
+2. **Beim Mail-Prüfer gilt #1282** — „übersprungen ist kein bestanden" bleibt. Der
+   widersprechende AC-7-Test aus #816 wird korrigiert.
+3. **Der Bildvergleich wird in dieser Scheibe wirklich gefahren**, nicht umgangen
+   (PO-Einwand: Playwright und Staging sind vorhanden — nutzen).
+
+## Nachgemessen nach der PO-Entscheidung: Befund 2 ist dreiteilig
+
+Der Versuch, das Gate scharf zu schalten, deckte auf, dass es gar nicht bestehbar wäre.
+Belegt durch einen echten Lauf
+(`design_fidelity_diff.py --screen G-compare-uebersicht-kacheln`):
+
+| Teil | Belegter Fehler | Beleg |
+|---|---|---|
+| 2a | Werkzeug legt den Bericht unter `GZ_ACTIVE_WORKFLOW` ab (`design_fidelity_diff.py:271`), Gate sucht unter `OPENSPEC_ACTIVE_WORKFLOW` (`pre_issue_close_design_gate.py:50`) | zwei verschiedene Ordner — Gate findet den frischen Bericht nie |
+| 2b | Werkzeug reicht die Zugangsdaten nur ans Anmeldeformular, nicht an den vorgeschalteten Schutz (`design_fidelity_diff.py:174-186`, `new_context()` ohne `http_credentials`) | Staging `/login` → **401**, `WWW-Authenticate: Basic realm="Staging"`; mit Basic-Auth → **200** und Formular vorhanden. Lauf ergab `diff_pct=33.44%`, weil die Sperrseite fotografiert wurde |
+| 2c | Gate in keiner Settings-Datei verdrahtet | grep über `.claude/settings.json`, `.claude/settings.local.json`, `~/.claude/settings.json` → kein Treffer |
+| 2d | Test setzt `GZ_ACTIVE_WORKFLOW` (`test_issue_603_design_fidelity_gate.py:228`) und lässt die ambient gesetzte `OPENSPEC_ACTIVE_WORKFLOW` durch `**os.environ` mitlaufen | Test misst nicht, was er zu messen glaubt |
+
+Vorhanden und nutzbar: 29 Soll-Bilder unter `claude-code-handoff/current/soll/`,
+Python-Playwright installiert, `.claude/validator.env` mit `GZ_VALIDATION_URL`,
+`GZ_VALIDATOR_USER`, `GZ_VALIDATOR_PASS`.
+
+## Befund 3 — Ansatz: SHA durchreichen, kein Cache
+
+**Vierter Aufrufpfad gefunden:** `staging_gate.py:146`
+(`if marker_sha and marker_sha != _head_sha():`) feuert nur, wenn
+`read_last_gate_scope()` einen Wert liefert. Im Testrepo ohne Marker-Datei bleibt er
+stumm — im echten Betrieb mit vorhandener `.claude/last_gate_scope.json` zählt er mit.
+**Der Test misst also weniger als der Fehler groß ist.** Ein Fix, der nur die gemessenen
+drei erfasst, behebt den Befund nicht.
+
+**Ansatz (a): SHA einmal ermitteln, als Parameter durchreichen.**
+`_scope_diff_base(head: str | None = None)` und
+`_detect_committed_scope(expected_commit=None, head=None)`, jeweils
+`head = head if head is not None else _head_sha()` am Funktionsanfang; alle internen
+Aufrufe inklusive `:146` durch die lokale Variable ersetzen. `write_verdict()` reicht
+`head=sha` durch. Default `None` hält Direktaufrufe ohne Argument lauffähig
+(`test_fix_1428_preflight_scope_base.py:130,153`, `test_scope_tests_neutral.py:131`).
+
+**Ansatz (b) Cache ist am Code widerlegt, nicht nur riskant:**
+`tests/tdd/test_e2e_commit_namespacing.py:104-111` lädt `staging_gate` einmal und ruft
+`write_verdict()` zweimal im selben Prozess auf, mit `git checkout` auf einen anderen
+Commit dazwischen — und erwartet zwei verschiedene, je korrekte Attestationen. Jeder
+Cache über Aufrufgrenzen hinweg bricht diesen Test. Innerhalb **eines**
+`write_verdict()`-Laufs ändert sich HEAD nie; genau so weit trägt Ansatz (a).
+
+**Wichtig:** Der Preflight-Zweig (`gate_check():422`) ruft `_detect_committed_scope(expected_commit)`
+positional ohne `head` und muss weiterhin frisch rechnen — kein Override.
+
+## Befund 4 — Delegations-Nachweis statt Textsuche
+
+Der Substring-Test bleibt fachlich nötig (er deckt auch `prod_selftest.py` ab, was der
+668er-Test nicht tut), muss aber umgebaut werden. Bewertung der fünf direkten
+git-Aufrufe einzeln:
+
+| Aufruf | Fundstellen | Urteil |
+|---|---|---|
+| `cat-file -e` | `staging_gate.py:139,148`, `prod_selftest.py:620,629,638` | **echte Duplikation, 5× über zwei Dateien** → nach `_e2e_paths.commit_exists(sha, repo_dir)` extrahieren |
+| `diff --name-only HEAD~1 HEAD` | `staging_gate.py:226-229` | reimplementiert `_e2e_paths._git_diff_names()` (`:147-162`), das dieselbe Datei bei `:480` schon nutzt → **migrieren** |
+| `merge-base --is-ancestor` | `staging_gate.py:465` | einzige Fundstelle im Hook-Baum, kein Gegenstück → **bleibt** |
+| `rev-parse --verify --quiet <ref>^{commit}` | `staging_gate.py:400` | liefert die volle SHA im stdout (`cat-file -e` kann das nicht), nötig für die #1382-Normalisierung → **bleibt** |
+
+**Ersatztest — Delegations-Zähler:** `_e2e_paths.commit_exists` und
+`_e2e_paths._git_diff_names` werden in beiden geladenen Modulen mit einem zählenden
+Wrapper versehen (echte Funktion bleibt aktiv, kein Mock), dann die Abläufe gegen ein
+reales Temp-Repo gefahren. Behauptung: jede beobachtete `cat-file -e`- bzw.
+`diff --name-only`-Ausführung lief über den Zähler. Die Zusicherung wirkt damit an der
+Stelle, an der sie gemeint ist (Delegation), statt an einer Textform.
+`merge-base`/`rev-parse --verify` bleiben ausdrücklich außerhalb — als Kommentar im Test,
+nicht als Verbotsliste.
+
+## Rückfall-Sicherung — kein neues Gate nötig
+
+`.github/workflows/ci.yml:44-50` fährt `tests/tdd/` bei jedem Push/PR gegen `main`.
+`test_issue_668_head_sha_dedup.py` steht **nicht** in `.github/ci_tdd_excludes.txt`.
+Der `deploy`-Job hängt an `needs: [test, lint]` (`ci.yml:157`) — ein roter Testfall
+blockiert also den automatischen Prod-Deploy, nicht nur eine Anzeige. Das reicht als
+Ratsche; es genügt, die `xfail`-Decorator zu entfernen.
+
+`touched_tests_gate.py` kann das **nicht** leisten — es prüft bewusst nur `tests/unit/`
+(`:126-136`), `tests/tdd/` bleibt dort ausgenommen.
+
+## Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `.claude/hooks/design_fidelity_diff.py` | MODIFY | Zugangsdaten an den vorgeschalteten Schutz durchreichen; Ordnername aus beiden Variablen auflösen |
+| `.claude/hooks/pre_issue_close_design_gate.py` | MODIFY | Workflow-Namen aus beiden Variablen auflösen (wie die Geschwister-Gates) |
+| `.claude/settings.json` | MODIFY | Gate als `PreToolUse:Bash` einhängen, in der Fail-open-Form aus Scheibe A |
+| `.claude/hooks/staging_gate.py` | MODIFY | SHA durchreichen (4 Aufrufe → 1); `cat-file`/`diff` an gemeinsames Modul delegieren |
+| `.claude/hooks/_e2e_paths.py` | MODIFY | `commit_exists(sha, repo_dir)` ergänzen |
+| `.claude/hooks/prod_selftest.py` | MODIFY | 3× `cat-file -e` an `commit_exists` delegieren |
+| `tests/tdd/test_issue_603_design_fidelity_gate.py` | MODIFY | Umgebung isolieren; beide Variablennamen prüfen; xfail raus |
+| `tests/tdd/test_issue_668_head_sha_dedup.py` | MODIFY | xfail raus; Fall mit vorhandenem Marker ergänzen (vierter Pfad) |
+| `tests/tdd/test_e2e_path_helper.py` | MODIFY | Substring-Test durch Delegations-Zähler ersetzen |
+| `tests/tdd/test_issue_816_alert_deviation.py` | MODIFY | AC-7 auf `ok=False` + Marker „uebersprungen" korrigieren; xfail raus |
+
+## Scope Assessment
+
+- Dateien: 10
+- Geschätzte Zeilen: ~180–200 (Limit 250; Doku zählt nicht)
+- Risiko: **MEDIUM-HIGH** — `staging_gate.py` entscheidet über Prod-Deploys
+
+## Risks
+
+**Teuerste Regression:** `gate_check()` fällt fälschlich auf `docs-only` oder überspringt
+die Attestationsprüfung → Prod deployt ungeprüften Code. Gegenmaßnahme: vor Abschluss
+gezielt die bestehenden mockfreien Scope-Tests fahren —
+`test_issue_916_gate_scope_marker.py`, `test_issue_1084_gate_scope_cache.py`,
+`test_issue_1096_gate_scope_selfpoison.py`, `test_issue_1109_prod_deploy_marker.py`,
+`test_issue_1121_git_diff_returncode.py`, `test_fix_1428_preflight_scope_base.py`,
+`test_staging_gate.py`, `test_e2e_commit_namespacing.py`,
+`test_e2e_verified_retention.py`, `test_staging_gate_verdict_merge.py`.
+
+**Zweitgrößtes Risiko:** Das Scharfschalten des Design-Gates kann das Schließen von
+Issues blockieren. Ausweg ohne Lockout: Label `design-compliance` entfernen. Zusätzlich
+greift die Fail-open-Form — fehlt die Datei, läuft das Gate still nicht.
+
+**Umsetzungshürde:** `.claude/settings.json` ist Orchestrator-Domäne
+(`edit_gate.py:324-334`) — Developer-Agent UND Orchestrierer werden blockiert. Der Eintrag
+verlangt ein vom **User getipptes** `override`. Das ist beim Bauen einzuplanen, nicht zu
+umgehen.
+
+## Reihenfolge
+
+1. Befund 3 (legt die `head`-Signatur fest)
+2. Befund 4 (baut in denselben Funktionen die `cat-file`-Zeilen um)
+3. Befund 5 (unabhängig, klein)
+4. Befund 2a/2b (Werkzeug reparieren), dann echter Vergleichslauf als Nachweis
+5. Befund 2c (einhängen — braucht `override` vom User)

--- a/docs/specs/modules/fix_1307b_gates.md
+++ b/docs/specs/modules/fix_1307b_gates.md
@@ -1,0 +1,341 @@
+---
+entity_id: fix_1307b_gates
+type: module
+created: 2026-08-05
+updated: 2026-08-05
+status: draft
+version: "1.0"
+tags: [gate, tooling, staging-gate, design-gate, mail-validator]
+---
+
+# Spec: #1307 Scheibe B — vier Wächter, die nicht tun was sie behaupten
+
+- **Issue:** #1307, Befunde 2 bis 5
+- **Workflow:** `fix-1307b-gates`
+- **Kontext & Messungen:** `docs/context/fix-1307b-gates.md`
+
+## Approval
+
+- [x] Approved
+
+Status: **Freigegeben durch PO am 2026-08-05** („go" auf alle 17 Acceptance Criteria).
+
+## Purpose
+
+Vier Prüfungen, die heute etwas anderes behaupten als sie leisten, sagen danach die
+Wahrheit: eine misst wieder den echten Fehler, eine prüft Verhalten statt Text, eine
+widerspricht sich nicht länger selbst, und eine läuft überhaupt zum ersten Mal.
+
+## Warum
+
+Der schriftliche Stand dieses Issues war dreimal falsch, weil er aus dem Code gelesen
+statt gemessen wurde. Gemessen (`--runxfail`, 2026-08-05) sind alle vier Befunde offen.
+
+Der gemeinsame Nenner ist nicht „vier kaputte Wächter", sondern **eine Regel, die dasteht
+und nicht beißt** — dieselbe Krankheit wie in Scheibe A, wo aus fünf ungeschützten
+Einträgen unbemerkt acht wurden. Befund 3 belegt das am härtesten: Er war im Juni bereits
+behoben (#668, `3ef67003`, Adversary VERIFIED) und ist zurückgekommen, weil der
+zugehörige Test als „bekannt offen" markiert und deshalb grün war.
+
+## Source
+
+| Datei | Rolle | Änderung |
+|---|---|---|
+| `.claude/hooks/staging_gate.py` | Prüfling Befund 3+4 | `_head_sha()` `:95`; Aufrufer `:135`, `:146`, `:174`, `:252`; direkte git-Aufrufe `:139`, `:148`, `:226`, `:400`, `:465` |
+| `.claude/hooks/_e2e_paths.py` | gemeinsames Modul | `head_sha()` `:220-230`; neu: `commit_exists(sha, repo_dir)` |
+| `.claude/hooks/prod_selftest.py` | Prüfling Befund 4 | `cat-file -e` bei `:620`, `:629`, `:638` |
+| `.claude/hooks/briefing_mail_validator.py` | Prüfling Befund 5 | Typ-Weiche `:493-523`, Protokoll-Marker `:638-648` |
+| `.claude/hooks/pre_issue_close_design_gate.py` | Prüfling Befund 2 | Workflow-Auflösung `:50`, Blockade `:72` |
+| `.claude/hooks/design_fidelity_diff.py` | Werkzeug Befund 2 | Ordnername `:271`, Playwright-Kontext `:174-186` |
+| `.claude/settings.json` | Verdrahtung | neuer `PreToolUse:Bash`-Eintrag |
+| `tests/tdd/test_issue_603_design_fidelity_gate.py` | Prüfung Befund 2 | veraltete Variable `:228`, xfail `:173` |
+| `tests/tdd/test_issue_668_head_sha_dedup.py` | Prüfung Befund 3 | PATH-Shim `:61-74`, xfail `:103`, `:122` |
+| `tests/tdd/test_e2e_path_helper.py` | Prüfung Befund 4 | Substring-Test `:182` |
+| `tests/tdd/test_issue_816_alert_deviation.py` | Prüfung Befund 5 | AC-7 `:611-628`, xfail `:598` |
+
+**Unverändert, aber maßgeblich:** `tests/tdd/test_briefing_validator_noop_not_pass.py`
+(hält den Beschluss aus #1282), `tests/tdd/test_e2e_commit_namespacing.py:104-111`
+(widerlegt die Zwischenspeicher-Variante).
+
+## Estimated Scope
+
+- Dateien: 11
+- Geschätzte Zeilen: ~180–200 (Limit 250; Dokumentation zählt nicht)
+- Risiko: **MEDIUM-HIGH** — `staging_gate.py` entscheidet über Prod-Deploys
+- Kein Produktions-Runtime-Code → Doku-/Tooling-Ausnahme, kein Staging-/Prod-Schritt
+  (der Vergleichslauf gegen Staging ist ein **Lesezugriff**, kein Deploy)
+
+## Dependencies
+
+**Woran die geänderten Teile hängen (upstream):**
+- `staging_gate.py` und `prod_selftest.py` beziehen Pfad- und Stand-Ermittlung aus
+  `_e2e_paths.py`.
+- `briefing_mail_validator.py` schreibt sein Protokoll über `_validator_log.py`.
+- `design_fidelity_diff.py` braucht Python-Playwright, die 29 Soll-Bilder unter
+  `claude-code-handoff/current/soll/` und die Zugangsdaten aus `.claude/validator.env`.
+
+**Was von den geänderten Teilen abhängt (downstream):**
+- `renderer_mail_gate.py` liest die Protokolle des Mail-Prüfers und entscheidet daran
+  über Commits.
+- `deploy-gregor-prod.sh` und der Post-Deploy-Selbsttest hängen am Urteil des
+  Staging-Wächters. Eine Fehlentscheidung dort deployt ungeprüften Code nach Produktion.
+- Die Nachweis-Ablage `.claude/e2e_verified/<sha>.json` wird von Deploy-Gate und
+  Selbsttest gelesen.
+- Der Prüflauf bei jeder Änderung (`.github/workflows/ci.yml:44-50`) fährt `tests/tdd/`;
+  der Deploy-Schritt hängt an dessen Ergebnis (`ci.yml:157`).
+
+## PO-Entscheidungen (2026-08-05)
+
+1. Der Design-Wächter wird **eingehängt und scharf geschaltet** — nicht nur die Prüfung
+   nachgezogen.
+2. Beim Mail-Prüfer gilt **#1282**: „übersprungen ist kein bestanden" bleibt. Der
+   widersprechende AC-7-Test aus #816 wird korrigiert.
+3. Der Bildvergleich wird **wirklich gefahren**, nicht umgangen.
+
+## Ausgangsstand (gemessen, nicht gelesen)
+
+| Befund | Testfall | heute |
+|---|---|---|
+| 2 | `test_issue_603_design_fidelity_gate.py::…::test_gate_allows_close_with_pass_artefact` | rot |
+| 3 | `test_issue_668_head_sha_dedup.py::test_ac1_head_sha_called_once_without_override` | rot |
+| 3 | `test_issue_668_head_sha_dedup.py::test_ac3_override_path_still_works` | rot |
+| 4 | `test_e2e_path_helper.py::…::test_path_logic_only_in_shared_module` | rot |
+| 5 | `test_issue_816_alert_deviation.py::test_ac7_header_set_and_validator_noop` | rot |
+
+Zusätzlich gemessen: `git rev-parse HEAD` läuft **3×** statt 1× pro `write_verdict()`;
+ein **vierter** Aufrufpfad (`staging_gate.py:146`) schweigt im Test nur, weil das Testrepo
+keine Marker-Datei hat. Der Design-Wächter ist in **keiner** Settings-Datei verdrahtet.
+Das Vergleichswerkzeug scheitert am vorgeschalteten Staging-Zugangsschutz
+(`/login` → 401, `WWW-Authenticate: Basic realm="Staging"`) und fotografiert die
+Sperrseite (`diff_pct=33.44%`).
+
+## Implementation Details
+
+**Befund 3 — Stand einmal ermitteln, durchreichen.**
+`_scope_diff_base(head: str | None = None)` und
+`_detect_committed_scope(expected_commit=None, head=None)`; jeweils am Funktionsanfang
+`head = head if head is not None else _head_sha()`, danach **alle** internen Aufrufe
+inklusive `:146` durch die lokale Variable ersetzen. `write_verdict()` reicht `head=sha`
+durch. Default `None` hält Direktaufrufe ohne Argument lauffähig.
+
+**Zwischenspeicher ist ausgeschlossen, nicht bloß unerwünscht:**
+`tests/tdd/test_e2e_commit_namespacing.py:104-111` lädt das Modul einmal, ruft
+`write_verdict()` zweimal auf und stellt dazwischen per `git checkout` einen anderen
+Commit ein — beide Aufrufe müssen je den eigenen Stand schreiben. Jeder Speicher über
+Aufrufgrenzen bricht das.
+
+**Befund 4 — gemeinsame Stelle statt Wiederholung.**
+Neue Funktion `_e2e_paths.commit_exists(sha, repo_dir) -> bool`, eingesetzt an allen fünf
+Fundstellen (`staging_gate.py:139`, `:148`; `prod_selftest.py:620`, `:629`, `:638`).
+`_telegram_live_gate()` (`staging_gate.py:226-229`) wechselt auf
+`_e2e_paths._git_diff_names()` — dieselbe Datei nutzt das bei `:480` bereits.
+
+**Befund 5 — Erwartung an den Beschluss angleichen.**
+AC-7 in `test_issue_816_alert_deviation.py` prüft künftig „kein Bestehen, begründet als
+unzuständig" statt „Bestehen". Der Produktivcode bleibt unverändert.
+
+**Befund 2 — drei Reparaturen, dann scharf schalten.**
+(a) `design_fidelity_diff.py:271` löst den Ordnernamen aus **beiden** Variablennamen auf;
+(b) `new_context()` bekommt die Zugangsdaten für den vorgeschalteten Schutz mit;
+(c) `pre_issue_close_design_gate.py:50` bekommt dieselbe Fallback-Kette wie seine
+Geschwister (`prod_send_gate.py:305-309`); (d) Eintrag in `.claude/settings.json` in der
+abgesicherten Form.
+
+## Expected Behavior
+
+**Vorher → Nachher:**
+
+| Vorgang | heute | danach |
+|---|---|---|
+| `write_verdict()` einmal ausführen | 3–4 Abfragen des Commit-Stands | genau 1 |
+| Doppelte Logik aufspüren | Wortsuche, trifft eine harmlose Zeile, umgehbar | Mitzählen an der gemeinsamen Stelle |
+| Mail-Prüfer sieht `deviation-alert` | zwei Prüfungen fordern Gegenteiliges | eine klare Aussage: kein Bestehen, als unzuständig begründet |
+| Design-Issue schließen | Wächter läuft nie | blockiert ohne Nachweis, lässt mit Nachweis durch |
+| Vergleichswerkzeug | fotografiert die Zugangssperre | nimmt die angeforderte Seite auf |
+
+## Test Plan
+
+Zuordnung der Kriterien zu Prüfungen. Alle deterministisch (Kern-Schicht), kein Netz außer
+dem ausdrücklich benannten Staging-Lesezugriff bei AC-11.
+
+| AC | Prüfung | Art |
+|---|---|---|
+| AC-1, AC-2 | `tests/tdd/test_issue_668_head_sha_dedup.py` | Zählung echter Subprozesse per Ersatzskript im Suchpfad; AC-1 **neu** mit vorhandener Marker-Datei (deckt den vierten Pfad) |
+| AC-3 | `tests/tdd/test_e2e_commit_namespacing.py` (bestehend) | zwei Aufrufe im selben Prozess mit Stand-Wechsel |
+| AC-4 | `tests/tdd/test_fix_1428_preflight_scope_base.py` (bestehend) | Preflight rechnet frisch |
+| AC-5, AC-7 | `tests/tdd/test_e2e_path_helper.py` | **Ersatz** des Substring-Tests durch Delegations-Zähler gegen echtes Temp-Repo |
+| AC-6 | Mutations-Gegenprobe im Adversary-Lauf | direkter Aufruf wieder eingebaut ⇒ Prüfung muss rot werden; Umbenennung allein darf nicht grün lassen |
+| AC-8, AC-9 | `tests/tdd/test_issue_816_alert_deviation.py` (AC-7 korrigiert) | Rückgabe und Protokoll-Marker |
+| AC-10 | `tests/tdd/test_briefing_validator_noop_not_pass.py` (bestehend) | bleibt grün |
+| AC-11, AC-12 | echter Lauf `design_fidelity_diff.py --screen …` gegen Staging | Nachweis am Lauf, keine Nachbildung; Bericht im erwarteten Ordner |
+| AC-13, AC-14 | `tests/tdd/test_issue_603_design_fidelity_gate.py` | beide Richtungen; Umgebung im Test selbst gesetzt und bereinigt |
+| AC-15 | `tests/tdd/test_issue_384_hook_fail_open.py` (bestehend, seit Scheibe A scharf) | der neue Eintrag muss die abgesicherte Form tragen |
+| AC-16 | Lauf ohne `--runxfail` über alle vier Dateien | alle grün, keine Markierungen mehr vorhanden |
+| AC-17 | Regressionsumfang (s.u.) | Umfangs-Erkennung unverändert |
+
+**Regressionsumfang vor Abschluss (mockfrei, bestehend):**
+`test_issue_916_gate_scope_marker.py`, `test_issue_1084_gate_scope_cache.py`,
+`test_issue_1096_gate_scope_selfpoison.py`, `test_issue_1109_prod_deploy_marker.py`,
+`test_issue_1121_git_diff_returncode.py`, `test_fix_1428_preflight_scope_base.py`,
+`test_staging_gate.py`, `test_e2e_commit_namespacing.py`,
+`test_e2e_verified_retention.py`, `test_staging_gate_verdict_merge.py`.
+
+## Acceptance Criteria
+
+### Befund 3 — der Commit-Stand wird einmal ermittelt
+
+**AC-1:** Given ein echtes Repo, in dem eine Marker-Datei `.claude/last_gate_scope.json`
+bereits vorliegt, When `staging_gate.write_verdict()` ohne Pfad-Übergabe läuft, Then wird
+`git rev-parse HEAD` **genau einmal** als echter Subprozess ausgeführt, gezählt über ein
+vorgeschaltetes `git`-Ersatzskript im Suchpfad — nicht über einen Mock.
+
+**AC-2:** Given dasselbe Repo, When `write_verdict()` mit ausdrücklich übergebenem
+Nachweis-Pfad läuft, Then wird `git rev-parse HEAD` ebenfalls genau einmal ausgeführt.
+
+**AC-3:** Given ein Prozess, der `write_verdict()` zweimal aufruft und zwischen den beiden
+Aufrufen den Stand des Repos auf einen anderen Commit umstellt, When beide Aufrufe
+durchlaufen, Then schreibt jeder Aufruf den Nachweis für **seinen eigenen** Commit — ein
+zwischengespeicherter Wert aus dem ersten Aufruf darf den zweiten nicht verfälschen.
+
+**AC-4:** Given der Preflight-Zweig mit vorgegebenem Ziel-Commit, When er läuft, Then
+ermittelt er den Umfang weiterhin frisch und übernimmt **keinen** von außen gereichten
+Commit-Stand — die bisherige Bedeutung bleibt unverändert.
+
+### Befund 4 — Delegation wird an ihrer Wirkung geprüft, nicht am Wortlaut
+
+**AC-5:** Given `staging_gate` und `prod_selftest` laufen gegen ein echtes Repo im
+Temp-Verzeichnis, When einer ihrer Abläufe prüft, ob ein Commit existiert, oder ermittelt,
+welche Dateien sich zwischen zwei Ständen geändert haben, Then läuft **jede** dieser
+Ermittlungen über die gemeinsame Stelle — nachgewiesen durch Mitzählen an der gemeinsamen
+Funktion, während die echte Funktion weiterarbeitet.
+
+**AC-6:** Given jemand baut an einer der bisherigen Stellen wieder einen direkten
+`git cat-file -e`-Aufruf ein, statt die gemeinsame Stelle zu benutzen, When die Prüfung
+läuft, Then wird sie rot. Ein Umbau, der lediglich die Schreibweise ändert (etwa den
+Kommandonamen aus Teilstücken zusammensetzt), darf sie **nicht** grün lassen.
+
+**AC-7:** Given die beiden Aufrufe, die bewusst eigenständig bleiben
+(`merge-base --is-ancestor` und `rev-parse --verify` zur Auflösung eines übergebenen
+Verweises), When die Prüfung läuft, Then schlägt sie deswegen **nicht** an, und der Grund
+steht als Kommentar an der Stelle.
+
+### Befund 5 — „übersprungen" bleibt vom „bestanden" unterscheidbar
+
+**AC-8:** Given eine Mail mit der Kennzeichnung `X-GZ-Mail-Type: deviation-alert`, When
+der Briefing-Mail-Prüfer sie bewertet, Then meldet er **kein** Bestehen und begründet es
+mit einem Eintrag, der ihn als unzuständig ausweist — damit kein nachgelagertes Gate
+diesen Leerlauf als echten Nachweis wertet.
+
+**AC-9:** Given derselbe Vorgang, When das Prüfprotokoll geschrieben wird, Then trägt es
+„nicht bestanden" **und** „übersprungen" — die beiden Zustände bleiben getrennt lesbar.
+
+**AC-10:** Given die bestehenden Prüfungen aus #1282, When sie nach der Änderung laufen,
+Then bleiben sie grün — die neue Formulierung ersetzt den Widerspruch, sie dreht ihn nicht
+auf die andere Seite.
+
+### Befund 2 — der Design-Wächter läuft, und er ist bestehbar
+
+**AC-11:** Given das Vergleichswerkzeug läuft gegen Staging, When es die angeforderte
+Seite aufnimmt, Then kommt es am vorgeschalteten Zugangsschutz vorbei und meldet **keinen**
+Anmeldefehler mehr — nachgewiesen an einem echten Lauf, nicht an einer Nachbildung.
+
+**AC-12:** Given dasselbe Werkzeug, When es seinen Bericht ablegt, Then landet dieser in
+genau dem Ordner, in dem der Wächter danach sucht — auch wenn nur die ältere Schreibweise
+der Workflow-Kennung gesetzt ist.
+
+**AC-13:** Given ein Issue mit dem Design-Kennzeichen und ein bestandener Bericht im
+zugehörigen Ordner, When das Schließen des Issues versucht wird, Then lässt der Wächter es
+durch. Given derselbe Fall **ohne** bestandenen Bericht, Then blockiert er und benennt,
+was fehlt.
+
+**AC-14:** Given die Prüfung zu AC-13, When sie läuft, Then setzt sie ihre Umgebung selbst
+und lässt keine von außen gesetzte Workflow-Kennung durchschlagen — sie muss messen, was
+sie zu messen behauptet.
+
+**AC-15:** Given der Wächter ist in der Hook-Verdrahtung eingetragen, When die Datei
+einmal fehlt (etwa weil ein anderer Arbeitsordner hinterherhängt), Then blockiert er
+**nichts**, sondern läuft still nicht — die abgesicherte Form aus Scheibe A
+(`if [ -f … ]; then …; fi`, niemals `&&`/`||`).
+
+### Übergreifend
+
+**AC-16:** Given alle fünf eingangs roten Testfälle, When sie ohne die „bekannt
+offen"-Markierung laufen, Then sind sie grün, und die Markierungen sind aus den Dateien
+entfernt — eine Regel, die weiterhin nicht beißt, gilt als nicht erfüllt.
+
+**AC-17:** Given die bestehenden Prüfungen rund um die Umfangs-Erkennung des
+Staging-Wächters, When sie nach der Änderung laufen, Then bleiben sie grün — insbesondere
+darf der Wächter nicht fälschlich auf „nur Dokumentation" fallen oder die Nachweisprüfung
+überspringen.
+
+## Was sich NICHT ändern darf
+
+- Die Bedeutung des Staging-Wächters bei der Entscheidung über einen Prod-Deploy. Die
+  teuerste denkbare Regression ist ein Wächter, der ungeprüften Code durchlässt.
+- Der Beschluss aus #1282: ein Leerlauf des Mail-Prüfers darf nie als Nachweis zählen.
+- Die Nachweis-Ablage `.claude/e2e_verified/<sha>.json` und ihr Format.
+- Direktaufrufe der geänderten Funktionen ohne Argumente müssen weiter laufen
+  (bestehende Prüfungen rufen sie so auf).
+
+## Known Limitations
+
+**Nicht in dieser Scheibe:**
+- **Ob der Bildvergleich fachlich besteht.** Diese Scheibe stellt sicher, dass das
+  Werkzeug die richtige Seite aufnimmt und der Wächter den Bericht findet. Ob das aktuelle
+  Design nah genug am Soll-Bild liegt, ist eine Design-Frage, keine Werkzeug-Frage.
+- **Die anderen 28 Soll-Bilder.** Ein Bildschirm als Nachweis genügt.
+- **Befund 1** — mit Scheibe A erledigt (`cf33590a`).
+- **#1478** (Scheibe C) — liegt im Fremd-Repo `agent-os-openspec`.
+- Die Nutzer-Ebene `~/.claude/settings.json` und `.claude/settings.local.json` — in #1196
+  gebucht.
+
+**Bewusste Grenzen des Delegations-Zählers (AC-5):** Er deckt Commit-Existenz und
+Datei-Diff ab. `merge-base --is-ancestor` und `rev-parse --verify` bleiben außerhalb, weil
+es dafür kein Gegenstück im gemeinsamen Modul gibt. Ein künftiger dritter Aufrufer, der
+eine ganz neue git-Operation dupliziert, wird von dieser Prüfung nicht gefangen.
+
+## Regel-Budget
+
+Das Scharfschalten des Design-Wächters führt eine **wirksame** Pflicht neu ein (bisher lief
+sie nie). Nach der Regel-Budget-Vorgabe trägt sie ein **Prüfdatum: 2026-11-03**. Bis dahin
+muss ein belegter Fang vorliegen — ein Fall, in dem der Wächter ein Schließen ohne
+Design-Nachweis verhindert hat. Sonst Rückbau.
+
+Ausweg ohne Steckenbleiben: das Design-Kennzeichen von der Aufgabe nehmen. Zusätzlich
+greift die Fail-open-Form.
+
+Der Ersatz des Substring-Tests (Befund 4) ist **keine neue Regel**, sondern die Reparatur
+einer bestehenden — kein zusätzliches Prüfdatum nötig.
+
+## Architektur-Entscheidung (ADR)
+
+**Kein neues ADR erforderlich.** Die beiden Richtungsentscheidungen wenden bestehende,
+dokumentierte Muster an:
+
+- „Frage umdrehen statt Formen jagen" (Befund 4) — belegt in #1431, #1471 und
+  #1307 Scheibe A, festgehalten in `CLAUDE.md` und
+  `docs/context/fix-1307b-gates.md`.
+- „No-Op ist kein Pass" (Befund 5) — Beschluss aus #1282, hier bestätigt statt geändert.
+
+Berührt wird die Entscheidungsfläche **Teststrategie**; da die Scheibe das dokumentierte
+Muster anwendet und nicht davon abweicht, entsteht kein ADR-Pflichtfall.
+
+## Umsetzungshürde
+
+`.claude/settings.json` ist Orchestrator-Domäne (`edit_gate.py:324-334`) — sowohl der
+Developer-Agent als auch der Orchestrierer werden dort blockiert. Der Eintrag verlangt ein
+vom **User getipptes** `override`. Das ist einzuplanen, nicht zu umgehen.
+
+## Reihenfolge
+
+1. Befund 3 — legt die Signatur fest, über die der Commit-Stand durchgereicht wird
+2. Befund 4 — baut in denselben Funktionen die Existenzprüfungen um
+3. Befund 5 — unabhängig, klein
+4. Befund 2a/2b — Werkzeug reparieren, dann echter Vergleichslauf als Nachweis
+5. Befund 2c — einhängen (braucht `override`)
+
+## Changelog
+
+| Datum | Version | Änderung |
+|---|---|---|
+| 2026-08-05 | 1.0 | Erstfassung. Ausgangsstand aller vier Befunde gemessen statt gelesen (`--runxfail`). Befund 2 dabei als dreiteilig erkannt (Ordner-Bruch, Zugangsschutz, fehlende Verdrahtung), vierter Abfragepfad bei Befund 3 gefunden, Zwischenspeicher-Variante am Code widerlegt. PO-Entscheidungen: Design-Wächter scharf schalten, #1282 gilt beim Mail-Prüfer, Bildvergleich wirklich fahren. |

--- a/tests/tdd/conftest.py
+++ b/tests/tdd/conftest.py
@@ -6,6 +6,7 @@ Provides ground truth fetcher for TDD tests.
 
 import importlib.util as _importlib_util
 import json
+import os
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -124,6 +125,79 @@ def _init_evidence_free_repo(root: Path) -> str:
     return subprocess.run(
         ["git", "rev-parse", "HEAD"], cwd=root, capture_output=True, text=True
     ).stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Aufgezeichnetes `gh` als PATH-Shim (#1307 Scheibe B, CI-Rot vom 2026-08-05)
+#
+# `pre_issue_close_design_gate.py` holt die Kennzeichen eines Issues per
+# `gh issue view <N> --json labels` und laeuft bei jedem gh-Fehler bewusst
+# fail-open (Exit 0). Auf dem Bauserver gibt es kein angemeldetes gh — dort
+# belegten die Waechter-Tests deshalb NICHTS: sie waeren auch dann gruen
+# geblieben, wenn der Waechter kaputt ist, sobald das Fail-open zufaellig zum
+# erwarteten Ergebnis passt.
+#
+# Gegenmittel ohne Mock-Theater: ein echtes ausfuehrbares Ersatzskript an
+# erster PATH-Stelle, das AUFGEZEICHNETE Antworten liefert (Muster: der
+# git-Shim in test_issue_668_head_sha_dedup.py). Echtes Skript, echter
+# Subprozess, deterministisch und netzfrei.
+# ---------------------------------------------------------------------------
+
+# Abgerufen am 2026-08-05 mit `gh -R henemm/gregor_zwanzig issue view <N>
+# --json labels`. #603 traegt design-compliance (der Waechter greift), #1
+# traegt gar kein Kennzeichen (der Waechter darf nicht greifen).
+RECORDED_ISSUE_LABELS = {
+    "603": ["type:rework", "frontend", "design-compliance"],
+    "1": [],
+}
+
+_GH_SHIM_TEMPLATE = '''#!{python}
+"""Aufgezeichnetes `gh` fuer Waechter-Tests — echtes Skript, kein Mock."""
+import json
+import sys
+
+RECORDED = {recorded}
+argv = sys.argv[1:]
+with open({log!r}, "a") as fh:
+    fh.write(" ".join(argv) + "\\n")
+if argv[:2] == ["issue", "view"] and "--json" in argv:
+    labels = RECORDED.get(argv[2])
+    if labels is None:
+        sys.stderr.write("gh-Ersatz: Issue %s ist nicht aufgezeichnet\\n" % argv[2])
+        sys.exit(1)
+    print(json.dumps({{"labels": [{{"name": n}} for n in labels]}}))
+    sys.exit(0)
+sys.stderr.write("gh-Ersatz: unerwarteter Aufruf: %r\\n" % (argv,))
+sys.exit(1)
+'''
+
+
+def gh_shim_call_log(shim_dir: Path) -> list[str]:
+    """Die Aufrufe, die das Ersatz-`gh` tatsaechlich gesehen hat.
+
+    Damit laesst sich pruefen, dass der Waechter die Kennzeichen wirklich
+    abgefragt hat — ein leeres Protokoll heisst, er ist vorher ausgestiegen.
+    """
+    log = shim_dir / "gh-calls.log"
+    return log.read_text().splitlines() if log.exists() else []
+
+
+def install_recorded_gh(shim_dir: Path) -> Path:
+    """Legt das Ersatz-`gh` in ``shim_dir`` an und gibt das Verzeichnis zurueck."""
+    shim_dir.mkdir(parents=True, exist_ok=True)
+    shim = shim_dir / "gh"
+    shim.write_text(_GH_SHIM_TEMPLATE.format(
+        python=sys.executable,
+        recorded=repr(RECORDED_ISSUE_LABELS),
+        log=str(shim_dir / "gh-calls.log"),
+    ))
+    shim.chmod(0o755)
+    return shim_dir
+
+
+def gh_shim_path(shim_dir: Path) -> str:
+    """PATH-Wert mit dem Ersatz-`gh` an erster Stelle."""
+    return f"{install_recorded_gh(shim_dir)}{os.pathsep}{os.environ.get('PATH', '')}"
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/tests/tdd/test_design_diff_requires_authenticated_page.py
+++ b/tests/tdd/test_design_diff_requires_authenticated_page.py
@@ -27,7 +27,6 @@ import os
 import re
 import subprocess
 import sys
-import time
 from pathlib import Path
 
 import pytest

--- a/tests/tdd/test_design_diff_requires_authenticated_page.py
+++ b/tests/tdd/test_design_diff_requires_authenticated_page.py
@@ -1,0 +1,195 @@
+"""Der Bildvergleich darf keine Anmeldemaske als bestandenen Nachweis ausgeben.
+
+Hintergrund (#1307 Scheibe B): `design_fidelity_diff.py` verlor die Anmeldung
+LAUTLOS — `page.fill`/`page.click` werfen keine Ausnahme, wenn die Anwendung
+die Zugangsdaten ablehnt. Das Werkzeug lief weiter, fotografierte das
+Anmeldeformular und schrieb einen Bericht mit `passed: true` (23,35 % bei
+Schwelle 30 %). Der Design-Waechter haette diesen Bericht als echten Nachweis
+akzeptiert.
+
+Zwei Schichten, beide ohne Mock:
+
+1. Die Entscheidung selbst (`unauthenticated_reason`) wird direkt aufgerufen.
+2. Die WIRKUNG wird an einem echten Lauf gemessen: das Werkzeug laeuft als
+   Subprozess mit echtem Playwright gegen einen echten lokalen HTTP-Server
+   (127.0.0.1, kein Netz nach draussen). A/B — dieselbe Konfiguration, nur die
+   ausgelieferte Seite unterscheidet sich:
+     A) Seite mit Passwortfeld  → KEIN Bericht, Rueckgabewert != 0
+     B) Seite ohne Passwortfeld → Bericht entsteht (die Pruefung schlaegt also
+        nicht pauschal an, sondern unterscheidet)
+   Ohne (B) waere (A) auch dann gruen, wenn das Werkzeug generell scheitert.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# Pruefling relativ zu DIESER Testdatei (Pfadregel #1409) — sonst prueft ein
+# Worktree-Lauf die unveraenderte Hauptrepo-Kopie und meldet falsches Gruen.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+DIFF_TOOL = _REPO_ROOT / ".claude" / "hooks" / "design_fidelity_diff.py"
+
+# Bewusst NICHT in SCREEN_URL_MAP → das Werkzeug ruft "/" auf, also die
+# Startseite des lokalen Testservers.
+_SCREEN = "test-auth-guard-screen"
+
+_PAGE_WITH_PASSWORD = """<!doctype html><html><body style="background:#fff">
+<h1>Anmelden um fortzufahren</h1>
+<form><input name="username"><input name="password" type="password">
+<button type="submit">Anmelden</button></form>
+</body></html>"""
+
+_PAGE_WITHOUT_PASSWORD = """<!doctype html><html><body style="background:#fff">
+<h1>Orts-Vergleiche</h1>
+<form><input name="username"><button type="submit">Weiter</button></form>
+</body></html>"""
+
+
+def _load_tool():
+    spec = importlib.util.spec_from_file_location("design_fidelity_diff", str(DIFF_TOOL))
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Schicht 1: die Entscheidung
+# ---------------------------------------------------------------------------
+class TestUnauthenticatedReason:
+    def test_redirect_to_login_is_no_valid_capture(self):
+        reason = _load_tool().unauthenticated_reason(
+            "https://staging.example.com/login", False
+        )
+        assert reason is not None and "Anmeldemaske" in reason
+
+    def test_visible_password_field_is_no_valid_capture(self):
+        reason = _load_tool().unauthenticated_reason(
+            "https://staging.example.com/compare", True
+        )
+        assert reason is not None and "Passwortfeld" in reason
+
+    def test_authenticated_target_page_is_accepted(self):
+        """Gegenprobe: ohne diese Zusicherung wuerde eine Pruefung, die IMMER
+        anschlaegt, die beiden Faelle oben ebenfalls bestehen."""
+        assert _load_tool().unauthenticated_reason(
+            "https://staging.example.com/compare", False
+        ) is None
+
+
+# ---------------------------------------------------------------------------
+# Schicht 2: die Wirkung am echten Lauf
+# ---------------------------------------------------------------------------
+def _serve(directory: Path):
+    """Echter lokaler HTTP-Server als Subprozess (kein Socket im Testprozess,
+    damit pytest-socket unberuehrt bleibt). Gibt (Popen, base_url) zurueck."""
+    # `-u`: ohne ungepufferte Ausgabe bleibt die Startmeldung im Puffer des
+    # Kindprozesses haengen und readline() blockiert bis zum Test-Timeout.
+    # Die Meldung geht auf STDOUT (http.server nutzt print), nicht auf stderr.
+    proc = subprocess.Popen(
+        [sys.executable, "-u", "-m", "http.server", "0", "--bind", "127.0.0.1",
+         "--directory", str(directory)],
+        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True,
+    )
+    line = proc.stdout.readline()
+    match = re.search(r"port (\d+)", line)
+    if match is None:
+        proc.kill()
+        pytest.fail(f"Lokaler Testserver nicht gestartet: {line!r}")
+    return proc, f"http://127.0.0.1:{match.group(1)}"
+
+
+def _project(tmp_path: Path, page_html: str) -> Path:
+    """Arbeitsverzeichnis mit Soll-Bild und ausgelieferter Seite."""
+    from PIL import Image
+
+    www = tmp_path / "www"
+    www.mkdir()
+    (www / "index.html").write_text(page_html)
+
+    soll = tmp_path / "claude-code-handoff" / "current" / "soll"
+    soll.mkdir(parents=True)
+    Image.new("RGB", (1024, 683), (255, 255, 255)).save(soll / f"{_SCREEN}.png")
+    return www
+
+
+def _run_tool(tmp_path: Path, base: str, workflow: str) -> subprocess.CompletedProcess:
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("OPENSPEC_ACTIVE_WORKFLOW", "GZ_ACTIVE_WORKFLOW")}
+    env["GZ_VALIDATION_URL"] = base
+    # Zugangsdaten sind gesetzt, damit der Anmelde-Zweig wirklich durchlaufen
+    # wird — genau dort scheiterte es lautlos. Werte sind bedeutungslos, die
+    # Testseite nimmt jede Eingabe an.
+    env["GZ_AUTH_USER"] = "irgendwer"
+    env["GZ_AUTH_PASS"] = "irgendwas"
+    return subprocess.run(
+        [sys.executable, str(DIFF_TOOL), "--screen", _SCREEN, "--workflow", workflow],
+        capture_output=True, text=True, cwd=str(tmp_path), env=env, timeout=120,
+    )
+
+
+@pytest.mark.timeout(180)
+def test_login_page_yields_no_passed_report(tmp_path):
+    """A: Bleibt das Passwortfeld stehen, entsteht KEIN Bericht — auch ein
+    frueher bestandener wird nicht stehen gelassen — und der Rueckgabewert ist
+    von Null verschieden."""
+    workflow = "test-auth-guard"
+    www = _project(tmp_path, _PAGE_WITH_PASSWORD)
+
+    # Altlast: ein bestandener Bericht aus einem frueheren Lauf. Der Waechter
+    # sucht per Glob nach IRGENDEINEM `passed: true` — er darf einen
+    # gescheiterten Lauf nicht ueberleben.
+    report = tmp_path / "docs" / "artifacts" / workflow / f"design-diff-{_SCREEN}.json"
+    report.parent.mkdir(parents=True)
+    report.write_text(json.dumps({"screen": _SCREEN, "passed": True, "diff_pct": 0.0}))
+
+    proc, base = _serve(www)
+    try:
+        result = _run_tool(tmp_path, base, workflow)
+    finally:
+        proc.kill()
+
+    assert result.returncode != 0, (
+        f"Werkzeug muss mit von Null verschiedenem Rueckgabewert abbrechen, "
+        f"lieferte {result.returncode}.\nstdout: {result.stdout[:300]}"
+    )
+    assert "keine gueltige Aufnahme" in result.stderr, (
+        "Der Abbruch muss benennen, was fehlt (Anmeldung), statt an einer "
+        f"anderen Stelle zu scheitern.\nstderr: {result.stderr[:400]}"
+    )
+    assert not report.exists(), (
+        "Der bestandene Bericht aus dem frueheren Lauf hat einen gescheiterten "
+        "Lauf ueberlebt — der Waechter wuerde ihn als Nachweis akzeptieren."
+    )
+
+
+@pytest.mark.timeout(180)
+def test_page_without_password_field_still_produces_report(tmp_path):
+    """B: Dieselbe Konfiguration, nur ohne Passwortfeld — hier MUSS ein Bericht
+    entstehen. Ohne diesen Fall waere A auch dann gruen, wenn das Werkzeug aus
+    ganz anderem Grund immer scheitert."""
+    workflow = "test-auth-guard-ok"
+    www = _project(tmp_path, _PAGE_WITHOUT_PASSWORD)
+
+    proc, base = _serve(www)
+    try:
+        result = _run_tool(tmp_path, base, workflow)
+    finally:
+        proc.kill()
+
+    report = tmp_path / "docs" / "artifacts" / workflow / f"design-diff-{_SCREEN}.json"
+    assert report.exists(), (
+        "Ohne Passwortfeld muss das Werkzeug aufnehmen und berichten — die "
+        "Pruefung darf nicht pauschal anschlagen.\n"
+        f"stdout: {result.stdout[:300]}\nstderr: {result.stderr[:400]}"
+    )
+    assert "keine gueltige Aufnahme" not in result.stderr
+    assert "diff_pct" in json.loads(report.read_text())

--- a/tests/tdd/test_design_gate_artifact_dir_resolution.py
+++ b/tests/tdd/test_design_gate_artifact_dir_resolution.py
@@ -1,0 +1,120 @@
+"""TDD RED — #1307 Scheibe B, AC-12: Werkzeug und Wächter müssen denselben
+Ordner meinen.
+
+Das Vergleichswerkzeug `design_fidelity_diff.py` löst den Ordnernamen für
+seinen Bericht über `GZ_ACTIVE_WORKFLOW` auf (`:271`), der Wächter
+`pre_issue_close_design_gate.py` sucht ihn über `OPENSPEC_ACTIVE_WORKFLOW`
+(`:50`). Werkzeug schreibt nach A, Wächter sucht in B — der frische Bericht
+wird nie gefunden.
+
+Geprüft wird die WIRKUNG, nicht der Quelltext: das Werkzeug wird echt
+ausgeführt (es legt sein Artefakt-Verzeichnis an, bevor es das fehlende
+Soll-Bild bemerkt — kein Netz, kein Playwright nötig), und der Wächter wird
+echt ausgeführt. Für jede der beiden Schreibweisen der Workflow-Kennung muss
+gelten: der vom Werkzeug angelegte Ordner ist genau der, in dem der Wächter
+nachsieht.
+
+Der Wächter wird dabei in BEIDE Richtungen gemessen (mit Nachweis → durch,
+ohne Nachweis → blockiert). Nur so ist ein echtes „hier habe ich gesucht" von
+einem stillen Fail-open (Exit 0, weil die Kennung gar nicht aufgelöst wurde)
+unterscheidbar.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Prüflinge relativ zu DIESER Testdatei (Pfadregel #1409) — sonst prüft ein
+# Worktree-Lauf die unveränderte Hauptrepo-Kopie und meldet falsches Grün.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+DIFF_TOOL = _REPO_ROOT / ".claude" / "hooks" / "design_fidelity_diff.py"
+GATE_HOOK = _REPO_ROOT / ".claude" / "hooks" / "pre_issue_close_design_gate.py"
+
+_WORKFLOW_ENV_VARS = ("OPENSPEC_ACTIVE_WORKFLOW", "GZ_ACTIVE_WORKFLOW")
+# Trägt das Label design-compliance (sonst greift der Wächter gar nicht).
+_GATE_ISSUE = "603"
+# Kein Eintrag in SCREEN_URL_MAP und kein Soll-Bild: das Werkzeug bricht nach
+# dem Anlegen des Artefakt-Verzeichnisses ab — genau der Seitenblick, den wir
+# brauchen, ohne Staging-Zugriff.
+_SCREEN = "test-1307b-kein-sollbild"
+
+
+def _clean_env(project_dir: Path, workflow: str, var: str) -> dict:
+    """Umgebung vollständig selbst gesetzt: beide Schreibweisen erst raus,
+    dann genau eine gezielt rein (AC-14-Muster)."""
+    env = {k: v for k, v in os.environ.items() if k not in _WORKFLOW_ENV_VARS}
+    env[var] = workflow
+    env["CLAUDE_PROJECT_DIR"] = str(project_dir)
+    env.setdefault("GH_REPO", "henemm/gregor_zwanzig")
+    return env
+
+
+def _run_tool(project_dir: Path, env: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(DIFF_TOOL), "--screen", _SCREEN],
+        capture_output=True, text=True, env=env, cwd=str(project_dir),
+    )
+
+
+def _run_gate(project_dir: Path, env: dict) -> subprocess.CompletedProcess:
+    env = {**env, "CLAUDE_TOOL_INPUT": json.dumps(
+        {"command": f"gh issue close {_GATE_ISSUE}"})}
+    return subprocess.run(
+        [sys.executable, str(GATE_HOOK)],
+        capture_output=True, text=True, env=env, cwd=str(project_dir),
+    )
+
+
+def _artifact_dirs(project_dir: Path) -> list[str]:
+    root = project_dir / "docs" / "artifacts"
+    return sorted(p.name for p in root.iterdir()) if root.is_dir() else []
+
+
+@pytest.mark.parametrize("var", ["OPENSPEC_ACTIVE_WORKFLOW", "GZ_ACTIVE_WORKFLOW"])
+def test_tool_and_gate_resolve_the_same_artifact_dir(tmp_path, var):
+    """AC-12: Egal welche der beiden Kennungen gesetzt ist — der Bericht landet
+    in genau dem Ordner, in dem der Wächter danach sucht."""
+    workflow = f"test-1307b-artifact-dir-{var.lower()}"
+    env = _clean_env(tmp_path, workflow, var)
+    expected = tmp_path / "docs" / "artifacts" / workflow
+
+    # 1) Werkzeug laufen lassen — legt sein Artefakt-Verzeichnis an.
+    tool = _run_tool(tmp_path, env)
+    assert _artifact_dirs(tmp_path), (
+        "Das Werkzeug hat gar kein Artefakt-Verzeichnis angelegt — der Test "
+        f"misst nichts. stdout={tool.stdout[:200]!r} stderr={tool.stderr[:200]!r}"
+    )
+    assert _artifact_dirs(tmp_path) == [workflow], (
+        f"Das Werkzeug legt seinen Bericht unter {_artifact_dirs(tmp_path)} ab, "
+        f"erwartet wurde der Ordner der gesetzten Workflow-Kennung ({workflow}). "
+        f"Gesetzt war {var}."
+    )
+
+    # 2) Wächter mit bestandenem Bericht in genau diesem Ordner → lässt durch.
+    (expected / f"design-diff-{_SCREEN}.json").write_text(json.dumps({
+        "screen": _SCREEN, "diff_pct": 1.0, "passed": True, "workflow": workflow,
+    }))
+    allowed = _run_gate(tmp_path, env)
+    assert allowed.returncode == 0, (
+        f"Wächter findet den Bericht in {expected} nicht (Exit "
+        f"{allowed.returncode}) — er sucht in einem anderen Ordner als das "
+        f"Werkzeug schreibt. Gesetzt war {var}.\n"
+        f"stdout: {allowed.stdout[:300]}\nstderr: {allowed.stderr[:300]}"
+    )
+
+    # 3) Gegenprobe: ohne Bericht muss er blockieren. Ohne diesen Schritt wäre
+    #    ein stilles Fail-open (Kennung gar nicht aufgelöst → Exit 0) von einem
+    #    echten Treffer nicht zu unterscheiden.
+    (expected / f"design-diff-{_SCREEN}.json").unlink()
+    blocked = _run_gate(tmp_path, env)
+    assert blocked.returncode == 2, (
+        f"Wächter muss ohne Bericht blockieren (Exit 2), lieferte Exit "
+        f"{blocked.returncode} — vermutlich hat er die Workflow-Kennung {var} "
+        "gar nicht aufgelöst und ist still durchgelaufen.\n"
+        f"stdout: {blocked.stdout[:300]}\nstderr: {blocked.stderr[:300]}"
+    )

--- a/tests/tdd/test_design_gate_artifact_dir_resolution.py
+++ b/tests/tdd/test_design_gate_artifact_dir_resolution.py
@@ -29,6 +29,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.tdd.conftest import gh_shim_call_log, gh_shim_path
+
 # Prüflinge relativ zu DIESER Testdatei (Pfadregel #1409) — sonst prüft ein
 # Worktree-Lauf die unveränderte Hauptrepo-Kopie und meldet falsches Grün.
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -44,13 +46,26 @@ _GATE_ISSUE = "603"
 _SCREEN = "test-1307b-kein-sollbild"
 
 
+def _shim_dir(project_dir: Path) -> Path:
+    return project_dir / "_bin"
+
+
 def _clean_env(project_dir: Path, workflow: str, var: str) -> dict:
     """Umgebung vollständig selbst gesetzt: beide Schreibweisen erst raus,
-    dann genau eine gezielt rein (AC-14-Muster)."""
+    dann genau eine gezielt rein (AC-14-Muster).
+
+    Zusätzlich liegt ein aufgezeichnetes `gh` an erster PATH-Stelle. Ohne das
+    hing dieser Test an einem angemeldeten gh: auf dem Bauserver gibt es keins,
+    der Wächter läuft dann fail-open (Exit 0) und der Test belegt nichts —
+    genau so wurde er am 2026-08-05 auf CI rot. Echtes Skript, echter
+    Subprozess, kein Mock (Muster: der git-Shim in
+    test_issue_668_head_sha_dedup.py).
+    """
     env = {k: v for k, v in os.environ.items() if k not in _WORKFLOW_ENV_VARS}
     env[var] = workflow
     env["CLAUDE_PROJECT_DIR"] = str(project_dir)
     env.setdefault("GH_REPO", "henemm/gregor_zwanzig")
+    env["PATH"] = gh_shim_path(_shim_dir(project_dir))
     return env
 
 
@@ -114,7 +129,16 @@ def test_tool_and_gate_resolve_the_same_artifact_dir(tmp_path, var):
     blocked = _run_gate(tmp_path, env)
     assert blocked.returncode == 2, (
         f"Wächter muss ohne Bericht blockieren (Exit 2), lieferte Exit "
-        f"{blocked.returncode} — vermutlich hat er die Workflow-Kennung {var} "
-        "gar nicht aufgelöst und ist still durchgelaufen.\n"
+        f"{blocked.returncode} — er hat die Workflow-Kennung {var} nicht "
+        "aufgelöst und ist still durchgelaufen.\n"
         f"stdout: {blocked.stdout[:300]}\nstderr: {blocked.stderr[:300]}"
+    )
+
+    # 4) Der Wächter muss die Kennzeichen wirklich abgefragt haben. Ein leeres
+    #    Aufruf-Protokoll hiesse: er ist schon vor der Label-Prüfung raus —
+    #    dann messen die Schritte 2 und 3 ein Fail-open statt eines Treffers.
+    calls = gh_shim_call_log(_shim_dir(tmp_path))
+    assert any(c.startswith(f"issue view {_GATE_ISSUE}") for c in calls), (
+        "Der Wächter hat die Kennzeichen des Issues nie abgefragt — die "
+        f"Aussage der Schritte 2/3 ist damit wertlos. Aufrufe: {calls!r}"
     )

--- a/tests/tdd/test_e2e_path_helper.py
+++ b/tests/tdd/test_e2e_path_helper.py
@@ -19,7 +19,11 @@ vs "UNKNOWN", kaputter .json-Name, fehlender Import).
 """
 
 import importlib.util
+import json
+import os
+import shutil
 import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -165,18 +169,248 @@ class TestCommitPathHardening:
 
 
 # ---------------------------------------------------------------------------
-# AC-5: Pfad-Logik nur noch im gemeinsamen Modul (doc-compliance-test)
+# AC-5 / AC-7 (#1307 Scheibe B): Delegation wird an ihrer WIRKUNG geprüft.
+#
+# Der frühere Test dieser Klasse suchte per `assert "rev-parse" not in src` im
+# Quelltext beider Hooks. Das war eine Formprüfung: durch `"rev-" + "parse"`
+# trivial umgehbar, blind für vier weitere direkte git-Aufrufe und zugleich
+# ein Fehlalarm auf `staging_gate.py:400` (eine legitime, bewusst
+# eigenständige Zeile). Ersetzt durch einen Delegations-Zähler gegen ein
+# echtes Temp-Repo.
+#
+# Messprinzip (kein Mock): ein echtes `git`-Ersatzskript im Suchpfad zählt die
+# tatsächlich ausgeführten Subprozesse; parallel zählt ein Wrapper um die
+# gemeinsame Funktion, wie viele davon INNERHALB eines Aufrufs dieser Funktion
+# passierten. Die echte Funktion läuft dabei unverändert weiter. Was übrig
+# bleibt (`outside`), lief an der gemeinsamen Stelle vorbei.
 # ---------------------------------------------------------------------------
-class TestPathLogicConsolidated:
-    @pytest.mark.xfail(reason="#1307: staging_gate umgeht Shared-Modul _e2e_paths (direkte git rev-parse-Aufrufe), bricht #665-Konsolidierung", strict=False)
-    def test_path_logic_only_in_shared_module(self):
-        # doc-compliance-test
-        """Beide Hooks importieren _e2e_paths und delegieren — keine duplizierte
-        git-rev-parse-Logik mehr in beiden Hook-Dateien."""
-        assert E2E_PATHS.exists(), "_e2e_paths.py muss existieren"
-        sg_src = STAGING_GATE.read_text()
-        ps_src = PROD_SELFTEST.read_text()
-        for src, name in ((sg_src, "staging_gate"), (ps_src, "prod_selftest")):
-            assert "_e2e_paths" in src, f"{name} importiert _e2e_paths nicht"
-            # git rev-parse darf nur noch im gemeinsamen Modul stehen, nicht im Hook.
-            assert "rev-parse" not in src, f"{name} enthält noch duplizierte rev-parse-Logik"
+
+_SHIM = """#!/usr/bin/env bash
+if [ "$1" = "cat-file" ] && [ "$2" = "-e" ]; then printf x >> "{catfile}"; fi
+if [ "$1" = "diff" ] && [ "$2" = "--name-only" ]; then printf x >> "{diff}"; fi
+if [ "$1" = "merge-base" ] && [ "$2" = "--is-ancestor" ]; then printf x >> "{mergebase}"; fi
+if [ "$1" = "rev-parse" ] && [ "$2" = "--verify" ]; then printf x >> "{revverify}"; fi
+exec "{real_git}" "$@"
+"""
+
+
+def _count(path: Path) -> int:
+    return len(path.read_text()) if path.exists() else 0
+
+
+class _GitProbe:
+    """Zählt echte git-Subprozesse (PATH-Shim) je Kommando-Art."""
+
+    def __init__(self, tmp_path: Path, monkeypatch):
+        self.catfile = tmp_path / "n_catfile"
+        self.diff = tmp_path / "n_diff"
+        self.mergebase = tmp_path / "n_mergebase"
+        self.revverify = tmp_path / "n_revverify"
+        real_git = shutil.which("git")
+        assert real_git, "echtes git nicht auf PATH"
+        shim_dir = tmp_path / "bin"
+        shim_dir.mkdir(exist_ok=True)
+        shim = shim_dir / "git"
+        shim.write_text(
+            _SHIM.format(
+                catfile=self.catfile, diff=self.diff, mergebase=self.mergebase,
+                revverify=self.revverify, real_git=real_git,
+            )
+        )
+        shim.chmod(0o755)
+        monkeypatch.setenv("PATH", f"{shim_dir}:{os.environ['PATH']}")
+
+    def reset(self) -> None:
+        for p in (self.catfile, self.diff, self.mergebase, self.revverify):
+            p.unlink(missing_ok=True)
+
+
+class _Delegation:
+    """Wrapper um eine gemeinsame Funktion: zählt Aufrufe UND die dabei
+    ausgelösten Subprozesse. Die echte Funktion bleibt aktiv (kein Mock,
+    kein verändertes Verhalten)."""
+
+    def __init__(self, counter: Path):
+        self.counter = counter
+        self.calls = 0
+        self.inside = 0
+
+    def wrap(self, module, attr: str) -> None:
+        orig = getattr(module, attr)
+
+        def wrapped(*args, **kwargs):
+            before = _count(self.counter)
+            try:
+                return orig(*args, **kwargs)
+            finally:
+                self.calls += 1
+                self.inside += _count(self.counter) - before
+
+        setattr(module, attr, wrapped)
+
+    @property
+    def outside(self) -> int:
+        return _count(self.counter) - self.inside
+
+
+def _init_repo_two_commits(root: Path) -> "tuple[str, str]":
+    """Echtes Repo mit zwei Commits — HEAD~1 muss auflösbar sein."""
+    _init_repo(root)
+    (root / "src" / "y.py").write_text("b = 2\n")
+    _git(["add", "-A"], root)
+    _git(["commit", "-qm", "c2"], root)
+    head = _git(["rev-parse", "HEAD"], root).stdout.strip()
+    prev = _git(["rev-parse", "HEAD~1"], root).stdout.strip()
+    return head, prev
+
+
+class TestSharedGitDelegation:
+    def test_commit_existence_checks_go_through_shared_module(self, monkeypatch, tmp_path):
+        """AC-5: Jede Prüfung 'existiert dieser Commit?' in staging_gate UND
+        prod_selftest läuft über `_e2e_paths.commit_exists()`.
+
+        RED heute: die gemeinsame Funktion existiert noch nicht; beide Hooks
+        setzen fünfmal ein eigenes `git cat-file -e` ab.
+        """
+        root = tmp_path / "repo"
+        root.mkdir()
+        head, prev = _init_repo_two_commits(root)
+
+        sg, ps = _both_hooks()
+        _patch_paths(monkeypatch, sg, root)
+        _patch_paths(monkeypatch, ps, root)
+        monkeypatch.setattr(ps, "REPO_DIR", root)
+
+        for mod, name in ((sg, "staging_gate"), (ps, "prod_selftest")):
+            assert hasattr(mod._e2e_paths, "commit_exists"), (
+                f"{name}: die gemeinsame Stelle _e2e_paths.commit_exists(sha, repo_dir) "
+                "fehlt — Commit-Existenzprüfungen sind noch je Hook dupliziert "
+                "(staging_gate.py:139/:148, prod_selftest.py:620/:629/:638)"
+            )
+
+        probe = _GitProbe(tmp_path, monkeypatch)
+        deleg = _Delegation(probe.catfile)
+        deleg.wrap(sg._e2e_paths, "commit_exists")
+        deleg.wrap(ps._e2e_paths, "commit_exists")
+
+        marker = root / ".claude" / "last_gate_scope.json"
+        preflight = root / ".claude" / "last_preflight_base.json"
+        prod_deploy = root / ".claude" / "last_prod_deploy.json"
+
+        # (1) staging_gate: hinterlegte Preflight-Basis
+        sg._e2e_paths.write_preflight_base(root, head, prev)
+        sg._scope_diff_base()
+        preflight.unlink(missing_ok=True)
+
+        # (2) staging_gate: Gate-Marker
+        sg._e2e_paths.write_last_gate_scope(root, prev)
+        sg._scope_diff_base()
+
+        # (3) prod_selftest: previous_commit aus last_prod_deploy.json
+        prod_deploy.write_text(json.dumps({"previous_commit": prev}))
+        ps._scope_diff_base(root)
+
+        # (4) prod_selftest: deployed_commit
+        prod_deploy.write_text(json.dumps({"deployed_commit": prev}))
+        ps._scope_diff_base(root)
+
+        # (5) prod_selftest: Gate-Marker
+        prod_deploy.unlink(missing_ok=True)
+        ps._scope_diff_base(root)
+
+        assert marker.exists(), "Marker-Datei muss für (2)/(5) wirksam sein"
+        assert deleg.calls >= 5, (
+            f"Nur {deleg.calls} Aufruf(e) der gemeinsamen Stelle beobachtet — der "
+            "Ablauf hat gar nicht geprüft, ob ein Commit existiert (der Test misst nichts)"
+        )
+        assert deleg.outside == 0, (
+            f"{deleg.outside} Commit-Existenzprüfung(en) liefen als direkter "
+            "git-Subprozess an _e2e_paths.commit_exists() vorbei"
+        )
+
+    def test_file_diff_lookups_go_through_shared_module(self, monkeypatch, tmp_path):
+        """AC-5: Jede Ermittlung 'welche Dateien haben sich geändert?' läuft
+        über `_e2e_paths._git_diff_names()`.
+
+        RED heute: `staging_gate._telegram_live_gate()` (:226-229) setzt ein
+        eigenes `git diff --name-only HEAD~1 HEAD` ab.
+        """
+        root = tmp_path / "repo"
+        root.mkdir()
+        _init_repo_two_commits(root)
+
+        sg, ps = _both_hooks()
+        _patch_paths(monkeypatch, sg, root)
+        _patch_paths(monkeypatch, ps, root)
+        monkeypatch.setattr(ps, "REPO_DIR", root)
+
+        probe = _GitProbe(tmp_path, monkeypatch)
+        deleg = _Delegation(probe.diff)
+        deleg.wrap(sg._e2e_paths, "_git_diff_names")
+        deleg.wrap(ps._e2e_paths, "_git_diff_names")
+
+        sg._telegram_live_gate()
+        sg._detect_committed_scope()
+        ps._detect_committed_scope(root)
+
+        assert deleg.calls > 0, (
+            "Kein Aufruf der gemeinsamen Stelle beobachtet — der Ablauf hat gar "
+            "keinen Datei-Diff ermittelt (der Test misst nichts)"
+        )
+        assert deleg.outside == 0, (
+            f"{deleg.outside} Datei-Diff(s) liefen als direkter git-Subprozess an "
+            "_e2e_paths._git_diff_names() vorbei"
+        )
+
+    def test_merge_base_and_rev_parse_verify_stay_outside_this_check(
+        self, monkeypatch, tmp_path
+    ):
+        """AC-7: `git merge-base --is-ancestor` (staging_gate.py:465) und
+        `git rev-parse --verify <ref>^{commit}` (:400) bleiben BEWUSST
+        eigenständig — für beide gibt es kein Gegenstück im gemeinsamen Modul
+        (`rev-parse --verify` liefert zusätzlich die volle SHA auf stdout, was
+        eine reine Existenzprüfung nicht kann; die Ancestor-Prüfung ist die
+        einzige Fundstelle im Hook-Baum). Der Delegations-Zähler darf deshalb
+        NICHT anschlagen, obwohl beide Kommandos hier nachweislich laufen.
+        """
+        root = tmp_path / "repo"
+        root.mkdir()
+        head, prev = _init_repo_two_commits(root)
+
+        sg, _ps = _both_hooks()
+        _patch_paths(monkeypatch, sg, root)
+
+        # VERIFIED-Nachweis für den Vorgänger → die Ancestor-Auflösung greift
+        # und löst `merge-base --is-ancestor` aus.
+        att = root / ".claude" / "e2e_verified" / f"{prev}.json"
+        att.parent.mkdir(parents=True, exist_ok=True)
+        att.write_text(json.dumps({
+            "verified_commit": prev,
+            "staging_verdict": "VERIFIED: ok",
+            "verified_at": datetime.now(timezone.utc).isoformat(),
+            "scope": "backend",
+        }))
+
+        probe = _GitProbe(tmp_path, monkeypatch)
+        catfile = _Delegation(probe.catfile)
+        diffs = _Delegation(probe.diff)
+        if hasattr(sg._e2e_paths, "commit_exists"):
+            catfile.wrap(sg._e2e_paths, "commit_exists")
+        diffs.wrap(sg._e2e_paths, "_git_diff_names")
+
+        sg.gate_check(None, "backend", expected_commit=head)
+
+        assert _count(probe.revverify) > 0, (
+            "rev-parse --verify lief gar nicht — der Test belegt nichts"
+        )
+        assert _count(probe.mergebase) > 0, (
+            "merge-base --is-ancestor lief gar nicht — der Test belegt nichts"
+        )
+        assert catfile.outside == 0, (
+            "Der Delegations-Zähler hat auf einen der beiden bewusst "
+            "eigenständigen Aufrufe angeschlagen (cat-file-Zähler)"
+        )
+        assert diffs.outside == 0, (
+            "Der Delegations-Zähler hat auf einen der beiden bewusst "
+            "eigenständigen Aufrufe angeschlagen (diff-Zähler)"
+        )

--- a/tests/tdd/test_issue_603_design_fidelity_gate.py
+++ b/tests/tdd/test_issue_603_design_fidelity_gate.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.tdd.conftest import gh_shim_call_log, gh_shim_path
+
 # #1307: design_fidelity_diff.py macht einen echten Playwright-Login-Versuch
 # gegen Staging; unter dem globalen 30s-Test-Timeout (#1210) reissen 4 von 5
 # vormals roten Tests rein durch Timeout, nicht durch echten Fehlschlag
@@ -187,6 +189,10 @@ _GATE_ISSUE = "603"          # trägt das Label design-compliance
 _PLAIN_ISSUE = "1"           # trägt es nicht
 
 
+def _shim_dir(project_dir: Path) -> Path:
+    return project_dir / "_bin"
+
+
 def _gate_env(project_dir: Path, command: str, workflow: str | None,
               var: str = "OPENSPEC_ACTIVE_WORKFLOW") -> dict:
     """Vollständig selbst gesetzte Umgebung für einen Gate-Lauf.
@@ -194,13 +200,19 @@ def _gate_env(project_dir: Path, command: str, workflow: str | None,
     Beide Schreibweisen der Workflow-Kennung werden zuerst ausdrücklich
     entfernt, damit keine von aussen gesetzte Kennung durchschlägt.
     `CLAUDE_PROJECT_DIR` hält die Artefakt-Ablage im Testverzeichnis (das echte
-    Repo bleibt unberührt), `GH_REPO` macht den `gh issue view`-Aufruf des
-    Gates unabhängig vom Arbeitsverzeichnis.
+    Repo bleibt unberührt).
+
+    Ein aufgezeichnetes `gh` liegt an erster PATH-Stelle: das Gate holt die
+    Kennzeichen des Issues per `gh issue view` und läuft bei jedem gh-Fehler
+    fail-open (Exit 0). Ohne angemeldetes gh — auf dem Bauserver der Normalfall
+    — belegten diese Prüfungen deshalb nichts. Echtes Ersatzskript, echter
+    Subprozess, kein Mock; Details in tests/tdd/conftest.py.
     """
     env = {k: v for k, v in os.environ.items() if k not in _WORKFLOW_ENV_VARS}
     env["CLAUDE_TOOL_INPUT"] = json.dumps({"command": command})
     env["CLAUDE_PROJECT_DIR"] = str(project_dir)
     env.setdefault("GH_REPO", "henemm/gregor_zwanzig")
+    env["PATH"] = gh_shim_path(_shim_dir(project_dir))
     if workflow:
         env[var] = workflow
     return env
@@ -210,6 +222,17 @@ def _run_gate(env: dict) -> subprocess.CompletedProcess:
     return subprocess.run(
         [sys.executable, str(GATE_HOOK)],
         capture_output=True, text=True, env=env, cwd=env["CLAUDE_PROJECT_DIR"],
+    )
+
+
+def _assert_labels_were_fetched(project_dir: Path, issue: str) -> None:
+    """Exit 0 ist mehrdeutig: es kann „Nachweis gefunden" heissen oder
+    „gh-Aufruf fehlgeschlagen, also fail-open". Das Aufruf-Protokoll des
+    Ersatz-`gh` trennt die beiden Fälle."""
+    calls = gh_shim_call_log(_shim_dir(project_dir))
+    assert any(c.startswith(f"issue view {issue}") for c in calls), (
+        "Das Gate hat die Kennzeichen nie abgefragt — ein Exit 0 belegt hier "
+        f"nichts. Aufrufe: {calls!r}"
     )
 
 
@@ -287,6 +310,7 @@ class TestAC2GateBlocksWithoutArtefact:
             f"got Exit {result.returncode}\n"
             f"stdout: {result.stdout[:300]}\nstderr: {result.stderr[:300]}"
         )
+        _assert_labels_were_fetched(tmp_path, _GATE_ISSUE)
 
     def test_gate_reads_legacy_workflow_variable(self, tmp_path):
         """
@@ -332,6 +356,7 @@ class TestAC2GateBlocksWithoutArtefact:
             f"Gate muss mit Pass-Artefakt Exit 0 liefern, got Exit {result.returncode}\n"
             f"stdout: {result.stdout[:300]}\nstderr: {result.stderr[:300]}"
         )
+        _assert_labels_were_fetched(tmp_path, _GATE_ISSUE)
 
     def test_gate_environment_is_self_set_not_inherited(self, tmp_path, monkeypatch):
         """
@@ -376,6 +401,7 @@ class TestAC2GateBlocksWithoutArtefact:
             f"Gate darf normale Issues nicht blockieren, got Exit {result.returncode}\n"
             f"stderr: {result.stderr[:300]}"
         )
+        _assert_labels_were_fetched(tmp_path, _PLAIN_ISSUE)
 
 
 class TestAC4PillowDependency:

--- a/tests/tdd/test_issue_603_design_fidelity_gate.py
+++ b/tests/tdd/test_issue_603_design_fidelity_gate.py
@@ -44,6 +44,22 @@ SOLL_DIR = MAIN_REPO / "claude-code-handoff/current/soll"
 PILOT_SCREEN = "G-compare-uebersicht-kacheln"
 
 
+def _tool_env(workflow: str) -> dict:
+    """AC-14 für die Werkzeug-Läufe: Umgebung selbst gesetzt.
+
+    Der frühere Aufbau `{**os.environ, "GZ_ACTIVE_WORKFLOW": …}` liess die von
+    aussen gesetzte OPENSPEC_ACTIVE_WORKFLOW mitlaufen. Seit #1307 Scheibe B
+    loest auch das Werkzeug den Ordnernamen aus BEIDEN Schreibweisen auf, mit
+    OPENSPEC zuerst (gleiche Reihenfolge wie der Waechter, sonst kehrt der
+    Ordner-Bruch aus AC-12 zurueck). Der Test mass damit nicht mehr, was er zu
+    messen behauptet: er legte den Ordner A an und das Werkzeug schrieb nach B.
+    Beide Schreibweisen deshalb erst raus, dann genau eine gezielt rein.
+    """
+    env = {k: v for k, v in os.environ.items() if k not in _WORKFLOW_ENV_VARS}
+    env["GZ_ACTIVE_WORKFLOW"] = workflow
+    return env
+
+
 class TestAC1DiffToolProducesReport:
     """AC-1: design_fidelity_diff.py erzeugt JSON-Report + Diff-PNG."""
 
@@ -93,7 +109,7 @@ class TestAC1DiffToolProducesReport:
         result = subprocess.run(
             [sys.executable, str(DIFF_TOOL), "--screen", PILOT_SCREEN],
             capture_output=True, text=True, cwd=str(MAIN_REPO),
-            env={**os.environ, "GZ_ACTIVE_WORKFLOW": workflow}
+            env=_tool_env(workflow)
         )
 
         assert report_path.exists(), (
@@ -122,7 +138,7 @@ class TestAC1DiffToolProducesReport:
         subprocess.run(
             [sys.executable, str(DIFF_TOOL), "--screen", PILOT_SCREEN],
             capture_output=True, text=True, cwd=str(MAIN_REPO),
-            env={**os.environ, "GZ_ACTIVE_WORKFLOW": workflow}
+            env=_tool_env(workflow)
         )
 
         assert diff_png.exists(), (
@@ -144,7 +160,7 @@ class TestAC1DiffToolProducesReport:
         result = subprocess.run(
             [sys.executable, str(DIFF_TOOL), "--screen", PILOT_SCREEN],
             capture_output=True, text=True, cwd=str(MAIN_REPO),
-            env={**os.environ, "GZ_ACTIVE_WORKFLOW": workflow}
+            env=_tool_env(workflow)
         )
 
         assert report_path.exists(), "JSON-Report muss existieren"
@@ -156,8 +172,67 @@ class TestAC1DiffToolProducesReport:
             assert result.returncode == 1, f"passed=false aber Exit {result.returncode}"
 
 
+# ---------------------------------------------------------------------------
+# AC-14 (#1307 Scheibe B): Die Gate-Prüfungen setzen ihre Umgebung SELBST.
+#
+# Der frühere Aufbau `{**os.environ, "GZ_ACTIVE_WORKFLOW": …}` liess die von
+# aussen gesetzte OPENSPEC_ACTIVE_WORKFLOW mitlaufen — und die gewinnt im Gate
+# (pre_issue_close_design_gate.py:50). Der Test mass damit nicht, was er zu
+# messen behauptete: das Gate suchte im Ordner des AKTIVEN Workflows statt in
+# dem, den der Test angelegt hatte.
+# ---------------------------------------------------------------------------
+
+_WORKFLOW_ENV_VARS = ("OPENSPEC_ACTIVE_WORKFLOW", "GZ_ACTIVE_WORKFLOW")
+_GATE_ISSUE = "603"          # trägt das Label design-compliance
+_PLAIN_ISSUE = "1"           # trägt es nicht
+
+
+def _gate_env(project_dir: Path, command: str, workflow: str | None,
+              var: str = "OPENSPEC_ACTIVE_WORKFLOW") -> dict:
+    """Vollständig selbst gesetzte Umgebung für einen Gate-Lauf.
+
+    Beide Schreibweisen der Workflow-Kennung werden zuerst ausdrücklich
+    entfernt, damit keine von aussen gesetzte Kennung durchschlägt.
+    `CLAUDE_PROJECT_DIR` hält die Artefakt-Ablage im Testverzeichnis (das echte
+    Repo bleibt unberührt), `GH_REPO` macht den `gh issue view`-Aufruf des
+    Gates unabhängig vom Arbeitsverzeichnis.
+    """
+    env = {k: v for k, v in os.environ.items() if k not in _WORKFLOW_ENV_VARS}
+    env["CLAUDE_TOOL_INPUT"] = json.dumps({"command": command})
+    env["CLAUDE_PROJECT_DIR"] = str(project_dir)
+    env.setdefault("GH_REPO", "henemm/gregor_zwanzig")
+    if workflow:
+        env[var] = workflow
+    return env
+
+
+def _run_gate(env: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(GATE_HOOK)],
+        capture_output=True, text=True, env=env, cwd=env["CLAUDE_PROJECT_DIR"],
+    )
+
+
+def _artefact_dir(project_dir: Path, workflow: str) -> Path:
+    d = project_dir / "docs" / "artifacts" / workflow
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _write_pass_artefact(project_dir: Path, workflow: str) -> Path:
+    path = _artefact_dir(project_dir, workflow) / f"design-diff-{PILOT_SCREEN}.json"
+    path.write_text(json.dumps({
+        "screen": PILOT_SCREEN,
+        "diff_pct": 7.3,
+        "passed": True,
+        "workflow": workflow,
+    }))
+    return path
+
+
 class TestAC2GateBlocksWithoutArtefact:
-    """AC-2: pre_issue_close_design_gate.py blockiert gh issue close ohne Pass-Artefakt."""
+    """AC-13/AC-14: pre_issue_close_design_gate.py lässt mit Nachweis durch und
+    blockiert ohne — in beiden Schreibweisen der Workflow-Kennung."""
 
     def test_gate_hook_file_exists(self):
         """
@@ -170,93 +245,136 @@ class TestAC2GateBlocksWithoutArtefact:
             "Implementierung fehlt noch (erwartetes RED)"
         )
 
-    @pytest.mark.xfail(reason="#1307: pre_issue_close_design_gate.py liefert Exit 0 statt Exit 2 bei fehlendem Pass-Artefakt (Gate blockt faelschlich NICHT)", strict=False)
-    def test_gate_blocks_issue_close_without_pass_artefact(self):
+    def test_gate_blocks_issue_close_without_pass_artefact(self, tmp_path):
         """
-        GIVEN: Issue #603 mit Label design-compliance, kein Pass-Artefakt im Workflow
+        AC-13 (Richtung 1)
+        GIVEN: Issue mit Label design-compliance, kein Pass-Artefakt im Workflow
         WHEN: Hook mit 'gh issue close 603' als CLAUDE_TOOL_INPUT aufgerufen
-        THEN: Exit-Code 2 (blockiert)
+        THEN: Exit-Code 2, und die Meldung benennt, was fehlt
         """
-        assert GATE_HOOK.exists(), (
-            f"pre_issue_close_design_gate.py nicht gefunden: {GATE_HOOK}\n"
-            "Implementierung fehlt noch (erwartetes RED)"
-        )
-        workflow = "issue-603-design-fidelity-gate"
-        # Artefakt-Verzeichnis leer halten
-        artefact_dir = MAIN_REPO / "docs/artifacts" / workflow
-        artefact_dir.mkdir(parents=True, exist_ok=True)
-        for f in artefact_dir.glob("design-diff-*.json"):
-            f.unlink()
+        workflow = "test-1307b-design-gate-blocks"
+        _artefact_dir(tmp_path, workflow)  # existiert, aber leer
 
-        env = {
-            **os.environ,
-            "CLAUDE_TOOL_INPUT": json.dumps({"command": "gh issue close 603"}),
-            "GZ_ACTIVE_WORKFLOW": workflow,
-        }
-        result = subprocess.run(
-            [sys.executable, str(GATE_HOOK)],
-            capture_output=True, text=True, env=env, cwd=str(MAIN_REPO)
-        )
+        env = _gate_env(tmp_path, f"gh issue close {_GATE_ISSUE}", workflow)
+        result = _run_gate(env)
+
         assert result.returncode == 2, (
             f"Gate muss bei fehlendem Pass-Artefakt Exit 2 liefern, "
             f"got Exit {result.returncode}\n"
             f"stdout: {result.stdout[:300]}\nstderr: {result.stderr[:300]}"
         )
+        combined = result.stdout + result.stderr
+        assert "design" in combined.lower() and _GATE_ISSUE in combined, (
+            "Die Blockade-Meldung muss benennen, um welches Issue es geht und "
+            f"welcher Nachweis fehlt. Ausgabe: {combined[:400]!r}"
+        )
 
-    def test_gate_allows_close_with_pass_artefact(self):
+    def test_gate_allows_close_with_pass_artefact(self, tmp_path):
         """
+        AC-13 (Richtung 2)
         GIVEN: Pass-Artefakt mit passed=true im Workflow-Artefaktordner
         WHEN: Hook mit 'gh issue close 603' aufgerufen
         THEN: Exit-Code 0 (erlaubt)
         """
-        workflow = "issue-603-design-fidelity-gate"
-        artefact_dir = MAIN_REPO / "docs/artifacts" / workflow
-        artefact_dir.mkdir(parents=True, exist_ok=True)
+        workflow = "test-1307b-design-gate-allows"
+        _write_pass_artefact(tmp_path, workflow)
 
-        # Valides Pass-Artefakt anlegen
-        pass_artefact = artefact_dir / "design-diff-G-compare-uebersicht-kacheln.json"
-        pass_artefact.write_text(json.dumps({
-            "screen": "G-compare-uebersicht-kacheln",
-            "diff_pct": 7.3,
-            "passed": True,
-            "workflow": workflow
-        }))
-
-        env = {
-            **os.environ,
-            "CLAUDE_TOOL_INPUT": json.dumps({"command": "gh issue close 603"}),
-            "GZ_ACTIVE_WORKFLOW": workflow,
-        }
-        result = subprocess.run(
-            [sys.executable, str(GATE_HOOK)],
-            capture_output=True, text=True, env=env, cwd=str(MAIN_REPO)
-        )
-
-        pass_artefact.unlink(missing_ok=True)
+        env = _gate_env(tmp_path, f"gh issue close {_GATE_ISSUE}", workflow)
+        result = _run_gate(env)
 
         assert result.returncode == 0, (
             f"Gate muss mit Pass-Artefakt Exit 0 liefern, "
             f"got Exit {result.returncode}\n"
-            f"stdout: {result.stdout[:300]}"
+            f"stdout: {result.stdout[:300]}\nstderr: {result.stderr[:300]}"
         )
 
-    def test_gate_ignores_non_design_compliance_issues(self):
+    def test_gate_reads_legacy_workflow_variable(self, tmp_path):
+        """
+        AC-13/AC-12 (Rückwärtskompatibilität)
+        GIVEN: nur die ältere Schreibweise GZ_ACTIVE_WORKFLOW ist gesetzt
+        WHEN: das Schliessen eines Design-Issues ohne Nachweis versucht wird
+        THEN: das Gate blockiert trotzdem (Exit 2)
+
+        Die Geschwister-Gates akzeptieren beide Schreibweisen
+        (prod_send_gate.py:305-309). Dieses Gate liest heute nur
+        OPENSPEC_ACTIVE_WORKFLOW und läuft bei der älteren Schreibweise still
+        ins Fail-open — es bewacht dann gar nichts.
+        """
+        workflow = "test-1307b-design-gate-legacy"
+        _artefact_dir(tmp_path, workflow)  # leer
+
+        env = _gate_env(tmp_path, f"gh issue close {_GATE_ISSUE}", workflow,
+                        var="GZ_ACTIVE_WORKFLOW")
+        result = _run_gate(env)
+
+        assert result.returncode == 2, (
+            "Gate muss auch bei gesetztem GZ_ACTIVE_WORKFLOW (ohne "
+            "OPENSPEC_ACTIVE_WORKFLOW) blockieren, wenn kein Nachweis vorliegt; "
+            f"got Exit {result.returncode}\n"
+            f"stdout: {result.stdout[:300]}\nstderr: {result.stderr[:300]}"
+        )
+
+    def test_gate_reads_legacy_workflow_variable_and_allows_with_artefact(self, tmp_path):
+        """AC-12/AC-13: derselbe Fall mit Nachweis — dann lässt das Gate durch.
+
+        Zusammen mit dem vorigen Fall belegt das, dass die ältere Schreibweise
+        wirklich AUFGELÖST wird und nicht bloss beide Male fail-open Exit 0
+        liefert.
+        """
+        workflow = "test-1307b-design-gate-legacy-pass"
+        _write_pass_artefact(tmp_path, workflow)
+
+        env = _gate_env(tmp_path, f"gh issue close {_GATE_ISSUE}", workflow,
+                        var="GZ_ACTIVE_WORKFLOW")
+        result = _run_gate(env)
+
+        assert result.returncode == 0, (
+            f"Gate muss mit Pass-Artefakt Exit 0 liefern, got Exit {result.returncode}\n"
+            f"stdout: {result.stdout[:300]}\nstderr: {result.stderr[:300]}"
+        )
+
+    def test_gate_environment_is_self_set_not_inherited(self, tmp_path, monkeypatch):
+        """
+        AC-14: Eine von aussen gesetzte Workflow-Kennung darf nicht durchschlagen.
+
+        Aufbau: im Prozess-Environment steht eine FREMDE Kennung, deren Ordner
+        einen bestandenen Nachweis enthält. Der Gate-Lauf bekommt eine eigene
+        Kennung ohne Nachweis. Läuft die fremde Kennung mit (der alte
+        `{**os.environ, …}`-Aufbau), findet das Gate den fremden Nachweis und
+        lässt durch — der Test wäre blind.
+        """
+        poison = "test-1307b-design-gate-poison"
+        _write_pass_artefact(tmp_path, poison)
+        monkeypatch.setenv("OPENSPEC_ACTIVE_WORKFLOW", poison)
+        monkeypatch.setenv("GZ_ACTIVE_WORKFLOW", poison)
+
+        workflow = "test-1307b-design-gate-own"
+        _artefact_dir(tmp_path, workflow)  # leer
+
+        env = _gate_env(tmp_path, f"gh issue close {_GATE_ISSUE}", workflow)
+        assert env.get("OPENSPEC_ACTIVE_WORKFLOW") == workflow
+        assert "GZ_ACTIVE_WORKFLOW" not in env
+        result = _run_gate(env)
+
+        assert result.returncode == 2, (
+            "Gate muss blockieren — der bestandene Nachweis gehört zu einem "
+            f"FREMDEN Workflow ({poison}). Exit {result.returncode} bedeutet, dass "
+            "die ambient gesetzte Kennung durchgeschlagen ist.\n"
+            f"stdout: {result.stdout[:300]}\nstderr: {result.stderr[:300]}"
+        )
+
+    def test_gate_ignores_non_design_compliance_issues(self, tmp_path):
         """
         GIVEN: Issue ohne design-compliance Label
         WHEN: Hook mit 'gh issue close 1' aufgerufen (normales Issue)
         THEN: Exit-Code 0 (Gate greift nicht)
         """
-        env = {
-            **os.environ,
-            "CLAUDE_TOOL_INPUT": json.dumps({"command": "gh issue close 1"}),
-            "GZ_ACTIVE_WORKFLOW": "issue-603-design-fidelity-gate",
-        }
-        result = subprocess.run(
-            [sys.executable, str(GATE_HOOK)],
-            capture_output=True, text=True, env=env, cwd=str(MAIN_REPO)
-        )
+        env = _gate_env(tmp_path, f"gh issue close {_PLAIN_ISSUE}",
+                        "test-1307b-design-gate-plain")
+        result = _run_gate(env)
         assert result.returncode == 0, (
-            f"Gate darf normale Issues nicht blockieren, got Exit {result.returncode}"
+            f"Gate darf normale Issues nicht blockieren, got Exit {result.returncode}\n"
+            f"stderr: {result.stderr[:300]}"
         )
 
 

--- a/tests/tdd/test_issue_668_head_sha_dedup.py
+++ b/tests/tdd/test_issue_668_head_sha_dedup.py
@@ -6,10 +6,12 @@ PATH-Shim-`git` (echtes ausführbares Skript, das in eine Zählerdatei schreibt 
 an das echte git delegiert). REPO_DIR wird auf ein echtes temporäres Git-Repo
 gepatcht, damit der No-Override-Schreibpfad das Hauptrepo nicht verschmutzt.
 
-ACs:
-  AC-1: ohne --e2e-path-Override → genau 1× `git rev-parse HEAD` (vor Fix: 2)
-  AC-2: verified_commit == aktueller HEAD-SHA (Regressionsschutz)
-  AC-3: mit Override → Datei am Override-Pfad, verified_commit korrekt
+ACs (#1307 Scheibe B, AC-1/AC-2):
+  AC-1: ohne --e2e-path-Override → genau 1× `git rev-parse HEAD`
+        (a) ohne Marker-Datei   (deckt die Pfade :135, :174, :252)
+        (b) MIT Marker-Datei    (deckt zusätzlich den vierten Pfad :146)
+  AC-2 (#668, Regressionsschutz): verified_commit == aktueller HEAD-SHA
+  AC-2 (#1307): mit Override → Datei am Override-Pfad, ebenfalls genau 1×
 """
 
 import importlib.util
@@ -100,9 +102,58 @@ def patched_repo(tmp_path, monkeypatch):
     return {"repo": repo, "head": head, "findings": findings, "counter": counter}
 
 
-@pytest.mark.xfail(reason="#1307: staging_gate _head_sha() ruft git rev-parse HEAD 2x statt 1x (Ex-#1132-Wiedergaenger)", strict=False)
+@pytest.fixture
+def patched_repo_with_marker(patched_repo):
+    """patched_repo + vorhandene Marker-Datei `.claude/last_gate_scope.json`.
+
+    Warum eigens: `staging_gate._scope_diff_base()` fragt bei
+    `if marker_sha and marker_sha != _head_sha():` ein VIERTES Mal nach dem
+    Commit-Stand. Dieser Zweig feuert nur, wenn der Marker existiert UND auf
+    einen anderen Commit als HEAD zeigt. Im markerlosen Testrepo bleibt er
+    stumm — der bisherige AC-1-Test misst dadurch weniger, als der Fehler
+    gross ist (#1307 Befund 3).
+
+    Das Marker-Format wird NICHT nachgebaut, sondern über den echten Schreiber
+    `_e2e_paths.write_last_gate_scope()` erzeugt. Bewusst OHNE `scope`: mit
+    `gate_last_scope` würde `cached_scope_for_sha()` in
+    `_detect_committed_scope()` greifen und `_scope_diff_base()` gar nicht
+    erst aufrufen.
+    """
+    repo = patched_repo["repo"]
+    prev = subprocess.run(
+        ["git", "rev-parse", "HEAD~1"], cwd=repo, capture_output=True, text=True
+    ).stdout.strip()
+    assert prev and prev != patched_repo["head"], "HEAD~1 muss ein anderer Commit sein"
+
+    staging_gate._e2e_paths.write_last_gate_scope(repo, prev)
+    # Gegenprobe: der Marker ist wirklich wirksam (sonst misst der Test nichts).
+    assert staging_gate._e2e_paths.read_last_gate_scope(repo) == prev, (
+        "Marker-Datei .claude/last_gate_scope.json wurde nicht wirksam angelegt"
+    )
+    # Zähler auf 0 — der Fixture-Aufbau selbst soll nicht mitgezählt werden.
+    patched_repo["counter"].unlink(missing_ok=True)
+    patched_repo["marker_sha"] = prev
+    return patched_repo
+
+
+def test_ac1_head_sha_called_once_with_gate_scope_marker(patched_repo_with_marker):
+    """AC-1 (b): mit vorhandener Marker-Datei darf `git rev-parse HEAD` genau
+    1× laufen. Vor Fix: 4× (drei bekannte Pfade + `_scope_diff_base():146`,
+    der ohne Marker nie erreicht wird)."""
+    rc = staging_gate.write_verdict(
+        "VERIFIED: alle ACs grün", patched_repo_with_marker["findings"]
+    )
+    assert rc == 0
+    n = _count(patched_repo_with_marker["counter"])
+    assert n == 1, (
+        f"git rev-parse HEAD wurde {n}x ausgeführt, erwartet genau 1 "
+        "(vierter Aufrufpfad _scope_diff_base():146 zählt bei vorhandener "
+        "Marker-Datei mit)"
+    )
+
+
 def test_ac1_head_sha_called_once_without_override(patched_repo):
-    """AC-1: ohne Override darf `git rev-parse HEAD` nur 1× laufen (vor Fix: 2×)."""
+    """AC-1 (a): ohne Override darf `git rev-parse HEAD` nur 1× laufen (vor Fix: 3×)."""
     rc = staging_gate.write_verdict("VERIFIED: alle ACs grün", patched_repo["findings"])
     assert rc == 0
     n = _count(patched_repo["counter"])
@@ -119,7 +170,6 @@ def test_ac2_verified_commit_matches_head(patched_repo):
     assert data["verified_commit"] == head
 
 
-@pytest.mark.xfail(reason="#1307: staging_gate _head_sha() ruft git rev-parse HEAD 2x statt 1x (Ex-#1132-Wiedergaenger)", strict=False)
 def test_ac3_override_path_still_works(patched_repo, tmp_path):
     """AC-3: mit --e2e-path-Override wird dorthin geschrieben, SHA korrekt, 1× rev-parse."""
     override = tmp_path / "custom_e2e.json"

--- a/tests/tdd/test_issue_816_alert_deviation.py
+++ b/tests/tdd/test_issue_816_alert_deviation.py
@@ -595,10 +595,41 @@ def test_ac6b_km_shown_when_start_is_zero_but_end_positive():
 # ═════════════════════════════ AC-7 ═════════════════════════════════════════
 # Header X-GZ-Mail-Type: deviation-alert + Validator-No-Op.
 
-@pytest.mark.xfail(reason="#1307: briefing_mail_validator liefert kein sauberes No-Op fuer X-GZ-Mail-Type: deviation-alert", strict=False)
-def test_ac7_header_set_and_validator_noop():
-    """AC-7: Die Mail trägt X-GZ-Mail-Type: deviation-alert und der
-    briefing_mail_validator macht für diesen Typ ein No-Op (ok=True).
+def _load_briefing_validator(tmp_path: Path, module_name: str):
+    """Isolierte Kopie des Briefing-Mail-Prüflings.
+
+    `_write_validation_log()` berechnet sein Log-Verzeichnis relativ zu seinem
+    eigenen `__file__` (Fallback ausserhalb eines Git-Repos) — die Kopie unter
+    tmp_path hält Test-Protokolle vom echten Repo fern. Prüfling ist die
+    Fassung DIESES Checkouts (Pfadregel #1409), nicht die Hauptrepo-Kopie.
+    """
+    import importlib.util
+    import shutil as _shutil
+
+    hooks_src = Path(__file__).resolve().parents[2] / ".claude" / "hooks"
+    hooks_copy = tmp_path / f"hooks_{module_name}"
+    hooks_copy.mkdir(parents=True, exist_ok=True)
+    _shutil.copy(hooks_src / "briefing_mail_validator.py",
+                 hooks_copy / "briefing_mail_validator.py")
+    spec = importlib.util.spec_from_file_location(
+        module_name, str(hooks_copy / "briefing_mail_validator.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_ac7_header_set_and_validator_reports_not_responsible(tmp_path):
+    """AC-8 (#1307 Scheibe B, korrigiert die frühere AC-7-Erwartung):
+
+    Die Mail trägt `X-GZ-Mail-Type: deviation-alert` — und der
+    Briefing-Mail-Prüfer meldet dafür KEIN Bestehen, sondern weist sich per
+    Fehlereintrag als unzuständig aus.
+
+    Die frühere Fassung forderte hier `ok=True`. Das widersprach dem Beschluss
+    aus #1282: ein `ok=True` schriebe `passed: true` ins Protokoll, und das
+    Renderer-Commit-Gate (#811) würde diesen Leerlauf als echten Nachweis
+    werten. Von zwei einander widersprechenden Prüfungen weicht diese.
     """
     seg = _segment(1)
     seg_data = SegmentWeatherData(
@@ -612,19 +643,53 @@ def test_ac7_header_set_and_validator_noop():
         "Marker-Header X-GZ-Mail-Type: deviation-alert fehlt"
     )
 
-    # briefing_mail_validator muss für fremden Typ sauber No-Op machen (ok=True).
-    import importlib.util
-    validator_path = (
-        Path(__file__).resolve().parents[2] / ".claude" / "hooks" / "briefing_mail_validator.py"
-    )
-    spec = importlib.util.spec_from_file_location("briefing_mail_validator", validator_path)
-    validator = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(validator)
+    validator = _load_briefing_validator(tmp_path, "briefing_validator_ac7_deviation")
 
-    ok, _errors = validator.validate_message(msg)
-    assert ok is True, (
-        "briefing_mail_validator muss für X-GZ-Mail-Type: deviation-alert No-Op "
-        "(ok=True) liefern — er ist nur für trip-briefing zuständig"
+    ok, errors = validator.validate_message(msg)
+    assert ok is False, (
+        "briefing_mail_validator darf für X-GZ-Mail-Type: deviation-alert KEIN "
+        "Bestehen melden — er hat nichts geprüft (#1282: No-Op ist kein Pass). "
+        f"ok={ok!r} errors={errors!r}"
+    )
+    assert any("uebersprungen" in str(e) for e in errors), (
+        "Der Fehlereintrag muss den Prüfer als unzuständig ausweisen (Marker "
+        "'uebersprungen') — daran erkennt _write_validation_log() den Leerlauf "
+        f"und trennt ihn vom echten Fehlschlag. errors={errors!r}"
+    )
+
+
+def test_ac9_deviation_alert_log_separates_failed_from_skipped(tmp_path):
+    """AC-9: Das geschriebene Prüfprotokoll trägt BEIDE Zustände getrennt —
+    'nicht bestanden' UND 'übersprungen'.
+
+    Ohne die Trennung wäre der Leerlauf im Protokoll nicht mehr von einem
+    echten Fehlschlag unterscheidbar (Diagnose) bzw. — bei `passed: true` —
+    ein falscher Erfolgsnachweis für das Renderer-Gate.
+    """
+    seg = _segment(1)
+    seg_data = SegmentWeatherData(
+        segment=seg, timeseries=None, aggregated=SegmentWeatherSummary(),
+        fetched_at=datetime.now(timezone.utc), provider="openmeteo",
+    )
+    change = _change("precip_sum_mm", 2.0, 18.0, 10.0, seg="1")
+    msg = _build_alert_mime(changes=[change], segments=[seg_data], trip_name="GR20")
+
+    validator = _load_briefing_validator(tmp_path, "briefing_validator_ac9_log")
+    ok, errors = validator.validate_message(msg)
+    validator._write_validation_log(ok, errors)
+
+    log_dir = (tmp_path / "hooks_briefing_validator_ac9_log").parent / "workflows" / "_log"
+    logs = list(log_dir.glob("*_briefing_validation.yaml"))
+    assert logs, f"_write_validation_log() muss ein Protokoll schreiben (log_dir={log_dir})"
+
+    import yaml as _yaml
+    data = _yaml.safe_load(logs[0].read_text())
+    assert data.get("passed") is False, (
+        f"Protokoll muss 'nicht bestanden' tragen (passed: false), ist: {data!r}"
+    )
+    assert data.get("skipped") is True, (
+        "Protokoll muss den Leerlauf zusätzlich als 'übersprungen' ausweisen "
+        f"(skipped: true), ist: {data!r}"
     )
 
 


### PR DESCRIPTION
Scheibe B von #1307 — Befunde 2 bis 5.

**Ausgangsstand gemessen statt gelesen** (`--runxfail`): alle vier offen, obwohl ein Issue-Kommentar drei als erledigt führte. Dritte Widerlegung derselben schriftlichen Diagnose.

## Was sich ändert

| Befund | Vorher | Nachher |
|---|---|---|
| 3 | Commit-Stand wird bis zu **4×** abgefragt | genau 1× |
| 4 | Doppelte Logik per **Textsuche** gesucht, umgehbar | echte Aufrufe der gemeinsamen Stelle gezählt |
| 5 | zwei Prüfungen fordern **Gegenteiliges** | #1282 gilt, Widerspruch aufgelöst |
| 2 | Design-Wächter **lief nie** (nirgends eingehängt) | eingehängt, bestehbar, scharf |

## Bemerkenswert

**Befund 3 ist ein Rückfall.** Im Juni behoben (#668, `3ef67003`, Adversary VERIFIED), unbemerkt zurückgekommen — weil der Test als „bekannt offen" markiert und deshalb grün war. Ein **vierter** Aufrufpfad (`_scope_diff_base:146`) feuert nur bei vorhandener Marker-Datei und wurde vom alten Test nie erreicht.

**Kein Cache** als Lösung: `test_e2e_commit_namespacing.py:104-111` wechselt HEAD mitten im Prozess und erwartet zwei verschiedene Ergebnisse. Am Code widerlegt, nicht vermutet.

**Der Design-Wächter hätte mit einem Foto der Anmeldemaske bestanden.** Beim Scharfschalten kamen zwei weitere Bruchstellen ans Licht: Das Werkzeug legte seinen Bericht im Ordner der alten Kennung ab, während der Wächter im Ordner der neuen suchte — und es kam nicht durch den vorgeschalteten Staging-Zugangsschutz, fotografierte die Sperrseite und meldete trotzdem „bestanden". Beides behoben; zusätzlich bricht das Werkzeug jetzt ab, statt bei misslungener Anmeldung still einen Erfolgsbericht zu schreiben.

**Alle „bekannt offen"-Markierungen entfernt.** Die CI-Ratsche übernimmt die Bewachung — kein neues Gate nötig.

## Nachweis

- **109 Testfälle grün** über 7 Dateien
- **Adversary VERIFIED** — 17 belegte Kriterien, 2 Runden, **sieben Mutationen** gegen den Produktivcode, jede von einem Test gefangen (inkl. Umgehungsversuch per String-Verkettung)
- Echter Bildvergleich gegen Staging zeigt die Vergleichs-Übersicht statt der Anmeldemaske
- Gegenprobe mit ungültiger Anmeldung erzeugt **keinen** Bericht und entfernt den alten
- Regression über 11 empfindliche Suiten: **93 grün, 0 rot**

## Rahmen

- Netto **+119 Zeilen** Produktivcode (Limit 250)
- **Kein Produktions-Runtime-Code** (nur `.claude/`, `tests/`, `docs/`) → Doku-/Tooling-Ausnahme
- Regel-Budget: Design-Wächter trägt **Prüfdatum 2026-11-03**; ohne belegten Fang bis dahin Rückbau

Spec: `docs/specs/modules/fix_1307b_gates.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)