### PR TITLE
docs(#1307 B): ADR-Feld in der kanonischen Form

### DIFF
--- a/docs/specs/modules/fix_1307b_gates.md
+++ b/docs/specs/modules/fix_1307b_gates.md
@@ -309,8 +309,10 @@ einer bestehenden — kein zusätzliches Prüfdatum nötig.
 
 ## Architektur-Entscheidung (ADR)
 
-**Kein neues ADR erforderlich.** Die beiden Richtungsentscheidungen wenden bestehende,
-dokumentierte Muster an:
+- **ADR-Nr.:** keine — die beiden Richtungsentscheidungen wenden bestehende, dokumentierte
+  Muster an, sie weichen nicht davon ab.
+
+Im Einzelnen:
 
 - „Frage umdrehen statt Formen jagen" (Befund 4) — belegt in #1431, #1471 und
   #1307 Scheibe A, festgehalten in `CLAUDE.md` und


### PR DESCRIPTION
Nachtrag zu #1522.

Der Abschluss-Wächter (`workflow.py`) sucht in der ADR-Sektion die Zeile `**ADR-Nr.:** <Wert>` und erkannte die Prosa-Formulierung „Kein neues ADR erforderlich" nicht.

**Inhalt unverändert:** keine ADR nötig, weil die Scheibe bestehende dokumentierte Muster anwendet statt von ihnen abzuweichen.

Reine Doku-Änderung, eine Datei.

🤖 Generated with [Claude Code](https://claude.com/claude-code)