### PR TITLE
fix(#1498): Telegram-Kurzübersicht liest Gewitter aus derselben Quelle wie die Fußzeile

### DIFF
--- a/src/output/renderers/narrow.py
+++ b/src/output/renderers/narrow.py
@@ -184,6 +184,34 @@ _SEV_TO_THUNDER_LEVEL: tuple[ThunderLevel, ...] = (
 )
 
 
+def _day_window_thunder_severity(
+    segments: list[SegmentWeatherData],
+    night_weather: Optional["NormalizedTimeseries"],
+    tz: ZoneInfo,
+    *,
+    start_hour: int = DAY_WINDOW_START_HOUR,
+    end_hour: int = DAY_WINDOW_END_HOUR,
+) -> int:
+    """Schlimmstes Gewitter-Ordinal über das geteilte Tagesfenster (#1498).
+
+    EINE Quelle für JEDE Gewitter-Aussage derselben Bubble: Fußzeile
+    (``_tg_day_footer``) und Kurzübersicht (``_overview_line``) lesen beide
+    dieses Ergebnis — vorher las die Kurzübersicht nur die Gehzeit-Reihen,
+    und ein Gewitter nach der Ankunft (#1317) machte die zwei Zeilen
+    widersprüchlich (``⚡ ?`` gegen ``⚡ leicht``, Issue #1498).
+    """
+    from output.renderers.day_window import build_day_window_points
+
+    worst = 0
+    for dp in build_day_window_points(
+        segments, night_weather, tz, start_hour=start_hour, end_hour=end_hour,
+    ):
+        sev = _thunder_severity(dp.thunder_level)
+        if sev > worst:
+            worst = sev
+    return worst
+
+
 def _tg_day_footer(
     segments: list[SegmentWeatherData],
     enabled_metric_ids: set[str] | list[str],
@@ -216,13 +244,10 @@ def _tg_day_footer(
     rep_freeze: Optional[int] = None
 
     if "thunder" in enabled:
-        for dp in build_day_window_points(
+        max_thunder_sev = _day_window_thunder_severity(
             segments, night_weather, tz,
             start_hour=day_window_start_hour, end_hour=day_window_end_hour,
-        ):
-            sev = _thunder_severity(dp.thunder_level)
-            if sev > max_thunder_sev:
-                max_thunder_sev = sev
+        )
 
     for sd in segments:
         agg = sd.aggregated
@@ -405,6 +430,7 @@ def _overview_line(
     hiking_temp_extrema: Optional[tuple[float, float, str]] = None,
     hiking_felt_extrema: Optional[tuple[float, float, str]] = None,
     has_gap: bool = False,
+    day_thunder_sev: Optional[int] = None,
 ) -> str:
     """Eine Kurzübersicht-Zeile ``{Kürzel} {Min}-{Max}@{Peak-Stunde}`` (oder
     Einzelwert/kategorisch).
@@ -415,11 +441,19 @@ def _overview_line(
     angehaengt (``@{Stunde}``, gleiche Konvention wie die Peak-Token in
     ``format_trend_tokens()``/``render_threshold_peak_value()``) — die fuer
     Entscheidungen relevantere Spitze (z.B. Windboeen-Spitze). Fuer die
-    Gewitter-Metrik (``thunder``) wird analog zu ``_tg_day_footer()`` der
-    Tages-Schlimmstwert ueber ``_thunder_severity()`` ermittelt (Issue #1001
-    Adversary-Finding F001: sonst widerspricht sich diese Zeile mit der
-    Fusszeile derselben Bubble). Andere nicht-numerische Metriken zeigen
-    weiterhin den zuletzt beobachteten Wert ohne Uhrzeit.
+    Gewitter-Metrik (``thunder``) gilt seit #1498 DIESELBE Quelle wie fuer
+    die Fusszeile: ``day_thunder_sev`` traegt das vom Aufrufer ueber
+    ``_day_window_thunder_severity()`` (Tagesfenster 04-19 inkl.
+    ``night_weather``) ermittelte Schlimmst-Ordinal — vorher las dieser
+    Zweig nur die Gehzeit-Reihen (``seg_tables``) und ein Gewitter nach der
+    Ankunft (#1317) machte Kurzuebersicht und Fusszeile derselben Bubble
+    widerspruechlich (``⚡ ?`` gegen ``⚡ leicht``). Bewusste
+    Scheiben-Entscheidung (#1498): NUR Gewitter wechselt auf das
+    Tagesfenster; alle uebrigen Metriken behalten die Gehzeit als
+    Bezugsrahmen. Fehlt ``day_thunder_sev`` (None, z.B. Direktaufrufe ohne
+    Tagesfenster-Kontext), bleibt fail-soft der bisherige Gehzeit-Pfad.
+    Andere nicht-numerische Metriken zeigen weiterhin den zuletzt
+    beobachteten Wert ohne Uhrzeit.
 
     ``report_type``/``night_min_c``/``night_wind_chill_min_c``: abends steht
     fuer ``temperature``/``wind_chill`` der echte Nachtwert am Ziel als
@@ -484,15 +518,29 @@ def _overview_line(
             value = f"{lo}-{hi}@{peak_hour}" if peak_hour else f"{lo}-{hi}"
     except (TypeError, ValueError):
         if metric_id == "thunder":
-            worst_row = max(hits, key=lambda h: _thunder_severity(h.get(key)))
-            # Issue #1491 F001: schlimmster BEOBACHTETER Wert ist NONE, aber
-            # das Zielfenster ist (teilweise) unbeobachtet -- "kein" waere
-            # hier eine Fehl-Entwarnung ueber die Luecke hinweg (analog
-            # _tg_day_footer, Zeile ~242-248).
-            if _thunder_severity(worst_row.get(key)) == 0 and has_gap:
-                value = "?"
+            if day_thunder_sev is not None:
+                # #1498: identische Quelle UND identisches Wort wie die
+                # Fusszeile (THUNDER_LABEL_DE ueber die kanonische Ordnung,
+                # #1474) — die Bubble traegt genau EINE Gewitter-Aussage.
+                if day_thunder_sev == 0:
+                    value = ("?" if has_gap
+                             else THUNDER_LABEL_DE[ThunderLevel.NONE])
+                else:
+                    value = THUNDER_LABEL_DE[
+                        _SEV_TO_THUNDER_LEVEL[day_thunder_sev]
+                    ]
             else:
-                value = _cell(metric_id, worst_row, fkeys)
+                worst_row = max(
+                    hits, key=lambda h: _thunder_severity(h.get(key))
+                )
+                # Issue #1491 F001: schlimmster BEOBACHTETER Wert ist NONE,
+                # aber das Zielfenster ist (teilweise) unbeobachtet --
+                # "kein" waere hier eine Fehl-Entwarnung ueber die Luecke
+                # hinweg (analog _tg_day_footer).
+                if _thunder_severity(worst_row.get(key)) == 0 and has_gap:
+                    value = "?"
+                else:
+                    value = _cell(metric_id, worst_row, fkeys)
         else:
             value = _cell(metric_id, hits[-1], fkeys)
     return f"{label} {value}"
@@ -636,6 +684,15 @@ def render_telegram_bubbles(
 
     # 2. Kurzuebersicht-Bubble — ALLE konfigurierten Metriken (AC-3), immer
     # vorhanden, unabhaengig von telegram_kurzform (AC-10).
+    # #1498: EINE Tagesfenster-Berechnung fuer die Gewitter-Aussage, an die
+    # Kurzuebersicht durchgereicht — dieselbe Quelle (und Segment-Auswahl),
+    # aus der die Fusszeile unten liest. Kurzuebersicht und Fusszeile
+    # derselben Bubble koennen sich damit strukturell nicht mehr
+    # widersprechen (vorher: Gehzeit-Reihen vs. Tagesfenster).
+    _day_thunder_sev = _day_window_thunder_severity(
+        [sd for sd in segments if not sd.has_error], night_weather, tz,
+        start_hour=day_window_start_hour, end_hour=day_window_end_hour,
+    )
     overview_lines: list[str] = ["Kurzübersicht"]
     for mid in dc.get_enabled_metric_ids():
         overview_lines.extend(_wrap(_esc(_overview_line(
@@ -645,6 +702,7 @@ def render_telegram_bubbles(
             hiking_temp_extrema=_hiking_temp,
             hiking_felt_extrema=_hiking_felt,
             has_gap=has_gap,
+            day_thunder_sev=_day_thunder_sev,
         )), _TG_PROSE_WIDTH))
     # Issue #1331/#1334 F008: has_gap kommt als expliziter Parameter vom
     # echten Versandpfad (notification_service.compute_has_gap() aus

--- a/tests/unit/test_telegram_thunder_window_konsistenz.py
+++ b/tests/unit/test_telegram_thunder_window_konsistenz.py
@@ -1,0 +1,168 @@
+"""Telegram-Bubble: Kurzuebersicht und Fusszeile duerfen sich bei Gewitter
+nicht widersprechen (#1498).
+
+Repro aus dem Issue: Segment 08-12 vollstaendig beobachtet und ruhig,
+``night_weather`` meldet ``ThunderLevel.LOW`` um 16:00 (nach Ankunft, im
+Tagesfenster 04-19), ``has_gap=True``. Vor dem Fix sagte DIESELBE Bubble
+zwei Zeilen untereinander Widerspruechliches: Kurzuebersicht ``⚡ ?``
+(liest nur die Gehzeit-Stundenreihen), Fusszeile ``⚡ leicht`` (liest das
+geteilte Tagesfenster inkl. ``night_weather``).
+
+Erwartung (PO-Vorschlag im Issue): der Gewitter-Zweig der Kurzuebersicht
+liest DIESELBE Quelle wie die Fusszeile — ein nach Ankunft aufziehendes
+Gewitter (#1317-Szenario) wird sichtbar, und die Bubble traegt genau EINE
+Gewitter-Aussage. Alle uebrigen Metriken behalten die Gehzeit als
+Bezugsrahmen (bewusste Scheiben-Entscheidung, dokumentiert in #1498).
+
+KEINE Mocks, KEIN Dateiinhalt-Check: reale Model-Objekte, realer
+Renderaufruf (``render_telegram_bubbles``), Nutzersicht auf den Bubble-Text.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+_TZ = ZoneInfo("Europe/Berlin")
+
+
+def _make_segment(thunder_level):
+    from app.models import (
+        ForecastDataPoint, ForecastMeta, GPXPoint, NormalizedTimeseries,
+        Provider, SegmentWeatherData, SegmentWeatherSummary, TripSegment,
+    )
+    seg = TripSegment(
+        segment_id=1,
+        start_point=GPXPoint(lat=42.2, lon=9.05, elevation_m=400.0, distance_from_start_km=0.0),
+        end_point=GPXPoint(lat=42.25, lon=9.09, elevation_m=900.0, distance_from_start_km=6.0),
+        start_time=datetime(2026, 7, 3, 6, 0, tzinfo=timezone.utc),
+        end_time=datetime(2026, 7, 3, 10, 0, tzinfo=timezone.utc),
+        duration_hours=4.0, distance_km=6.0, ascent_m=500.0, descent_m=0.0,
+    )
+    meta = ForecastMeta(
+        provider=Provider.OPENMETEO, model="arome_france",
+        run=datetime(2026, 7, 3, 0, 0, tzinfo=timezone.utc),
+        grid_res_km=1.3, interp="point_grid",
+    )
+    dps = [
+        ForecastDataPoint(
+            ts=datetime(2026, 7, 3, h, 0, tzinfo=timezone.utc),
+            thunder_level=thunder_level,
+        )
+        for h in (6, 7, 8, 9)
+    ]
+    agg = SegmentWeatherSummary(
+        temp_min_c=12.0, temp_max_c=14.0, wind_max_kmh=8.0,
+        precip_sum_mm=0.0, cloud_avg_pct=20, thunder_level_max=thunder_level,
+    )
+    return SegmentWeatherData(
+        segment=seg, timeseries=NormalizedTimeseries(meta=meta, data=dps),
+        aggregated=agg, fetched_at=datetime.now(timezone.utc),
+        provider="openmeteo",
+    )
+
+
+def _make_night_weather(thunder_level):
+    """Zeitreihe am Ziel: 14:00 UTC = 16:00 lokal — nach Ankunft (12:00
+    lokal), aber im Tagesfenster 04-19."""
+    from app.models import (
+        ForecastDataPoint, ForecastMeta, NormalizedTimeseries, Provider,
+    )
+    meta = ForecastMeta(
+        provider=Provider.OPENMETEO, model="arome_france",
+        run=datetime(2026, 7, 3, 0, 0, tzinfo=timezone.utc),
+        grid_res_km=1.3, interp="point_grid",
+    )
+    dp = ForecastDataPoint(
+        ts=datetime(2026, 7, 3, 14, 0, tzinfo=timezone.utc),
+        thunder_level=thunder_level,
+    )
+    return NormalizedTimeseries(meta=meta, data=[dp])
+
+
+def _make_dc():
+    from app.models import MetricConfig, UnifiedWeatherDisplayConfig
+    return UnifiedWeatherDisplayConfig(
+        trip_id="test-1498",
+        metrics=[MetricConfig(metric_id="thunder", enabled=True, bucket="primary", order=0)],
+        updated_at=datetime.now(timezone.utc),
+    )
+
+
+_ROWS = [
+    {"time": "08", "temp": 12, "wind": 5, "precip": 0.0, "thunder": "NONE"},
+    {"time": "09", "temp": 13, "wind": 6, "precip": 0.0, "thunder": "NONE"},
+    {"time": "10", "temp": 14, "wind": 6, "precip": 0.0, "thunder": "NONE"},
+    {"time": "11", "temp": 14, "wind": 7, "precip": 0.0, "thunder": "NONE"},
+]
+
+
+def _thunder_statements(*, night_thunder, has_gap):
+    """Rendert die Bubbles fuer das Issue-Szenario und liefert alle
+    Gewitter-Aussagen (Text nach '⚡ ', vor einem etwaigen ' · ') der
+    Kurzuebersicht-Bubble."""
+    from app.models import ThunderLevel
+    from output.renderers.narrow import render_telegram_bubbles
+
+    night = (
+        _make_night_weather(night_thunder) if night_thunder is not None else None
+    )
+    bubbles = render_telegram_bubbles(
+        segments=[_make_segment(ThunderLevel.NONE)],
+        seg_tables=[[dict(r) for r in _ROWS]],
+        dc=_make_dc(), report_type="evening", tz=_TZ,
+        trip_name="Konsistenz 1498", night_weather=night, has_gap=has_gap,
+    )
+    overview = next(b.text for b in bubbles if "Kurzübersicht" in b.text)
+    statements = []
+    for line in overview.splitlines():
+        if "⚡" not in line:
+            continue
+        after = line.split("⚡", 1)[1].strip()
+        statements.append(after.split(" · ", 1)[0].strip())
+    return statements
+
+
+def test_nachzuegler_gewitter_widerspricht_sich_nicht():
+    """Given Gehzeit ruhig + LOW um 16:00 im night_weather + Ziel-Luecke /
+    When die Bubble gerendert wird / Then tragen Kurzuebersicht und
+    Fusszeile DIESELBE Aussage 'leicht' — kein '?' gegen 'leicht' mehr
+    (#1498-Repro; das Nach-Ankunft-Gewitter ist sichtbar, #1317)."""
+    from app.models import ThunderLevel
+
+    statements = _thunder_statements(
+        night_thunder=ThunderLevel.LOW, has_gap=True,
+    )
+    assert len(statements) >= 2, (
+        f"Erwartet Kurzuebersicht-Zeile UND Fusszeile mit ⚡, war: {statements!r}"
+    )
+    assert len(set(statements)) == 1, (
+        f"Widerspruch in derselben Bubble: {statements!r}"
+    )
+    assert statements[0] == "leicht", (
+        f"Nach-Ankunft-LOW muss 'leicht' zeigen, war: {statements!r}"
+    )
+
+
+def test_ruhiger_tag_mit_luecke_zeigt_ueberall_fragezeichen():
+    """Given ueberall NONE beobachtet, aber Ziel-Luecke / When gerendert /
+    Then zeigen beide Zeilen '?' (keine Fehl-Entwarnung, #1331/#1491) —
+    und weiterhin widerspruchsfrei."""
+    from app.models import ThunderLevel
+
+    statements = _thunder_statements(
+        night_thunder=ThunderLevel.NONE, has_gap=True,
+    )
+    assert len(statements) >= 2
+    assert set(statements) == {"?"}, f"Erwartet ueberall '?', war: {statements!r}"
+
+
+def test_ruhiger_tag_ohne_luecke_zeigt_ueberall_kein():
+    """Given ueberall NONE beobachtet, keine Luecke / When gerendert / Then
+    zeigen beide Zeilen 'kein' — Entwarnung bleibt Entwarnung."""
+    from app.models import ThunderLevel
+
+    statements = _thunder_statements(
+        night_thunder=ThunderLevel.NONE, has_gap=False,
+    )
+    assert len(statements) >= 2
+    assert set(statements) == {"kein"}, f"Erwartet ueberall 'kein', war: {statements!r}"


### PR DESCRIPTION
Behebt den Widerspruch aus #1498: dieselbe Telegram-Bubble sagte zwei Zeilen untereinander Gegenteiliges über Gewitter — Kurzübersicht `⚡ ?` (las nur die Gehzeit-Stundenreihen), Fußzeile `⚡ leicht` (las das geteilte Tagesfenster 04–19 inkl. `night_weather`). Ein Gewitter, das erst **nach der Ankunft** aufzieht (#1317-Szenario, sicherheitsrelevant fürs Lager), war für die Kurzübersicht strukturell unsichtbar.

## Änderung

Nach dem etablierten „EINE Berechnung, durchgereicht"-Muster (wie `_night_min_c`, `_hiking_points`):

- **Geteilter Helfer `_day_window_thunder_severity()`** — aus der Fußzeile extrahiert (schlimmstes Gewitter-Ordinal über `build_day_window_points` inkl. `night_weather`).
- **`_tg_day_footer`** nutzt den Helfer (Verhalten unverändert, nur dedupliziert).
- **`render_telegram_bubbles`** berechnet das Ergebnis einmal (gleiche Segment-Auswahl wie die Fußzeile) und reicht es als `day_thunder_sev` an `_overview_line` durch; der Gewitter-Zweig dort bildet das Wort über dieselbe `THUNDER_LABEL_DE`-Ordnung (#1474). Gap-Semantik unverändert: NONE + Ziel-Lücke = `?`, keine Fehl-Entwarnung (#1331/#1491). Fail-soft: ohne `day_thunder_sev` (Direktaufrufe) bleibt der bisherige Gehzeit-Pfad.

## Scheiben-Entscheidung (dokumentiert, zitierbar)

Die im Issue offene Produktfrage wurde per Rückfrage gestellt und blieb unbeantwortet — umgesetzt ist daher der **im Issue selbst formulierte Vorschlag des PO**: NUR Gewitter wechselt auf das Tagesfenster; alle übrigen Metriken der Kurzübersicht behalten die Gehzeit als Bezugsrahmen („kann ich gehen?"). Der im Issue-Kommentar angehängte **Trip-Mail-Fall** (Gewitter-Vorschau `thunder_forecast` vs. Stundentabelle `dp.thunder_level`) hat eine andere Wurzel, berührt gate-pflichtige Mail-Renderer und bleibt bewusst außerhalb dieser Scheibe — Vorschlag: eigenes Ticket bzw. Folge-Scheibe.

## Nachweise

- **RED vor Fix:** `tests/unit/test_telegram_thunder_window_konsistenz.py` reproduziert den Issue-Fall aus Nutzersicht (realer `render_telegram_bubbles`-Aufruf, reale Model-Objekte, keine Mocks): `{'?', 'leicht'}` in einer Bubble → jetzt genau EINE Aussage `leicht`. Mitverankert: Lücke → überall `?`, ruhig ohne Lücke → überall `kein`.
- **Mutations-Gegenprobe:** Draht kappen (`day_thunder_sev=None`), Gap-Wächter entfernen, `night_weather` abklemmen — jede Verfälschung macht mindestens einen Test rot.
- **Regression:** die 7 bestehenden Telegram-Suiten (33 Tests) grün; ruff sauber; CI-äquivalenter Volllauf lief lokal parallel mit.

Produktcode (`src/`) → volle Liefer-Kette: nach Merge braucht es die Staging-Funktionsprobe (echtes Telegram-Briefing mit Nach-Ankunft-Gewitter bzw. Kurzübersicht≡Fußzeile) durch eine Server-Session; diese Remote-Session erreicht Staging nicht (Netz-Policy, s. #1364).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrmdarWn7RjtQ3q3rCumn6

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrmdarWn7RjtQ3q3rCumn6)_