### PR TITLE
fix(#1329 AC-8): Forecast-Budget-Verbrauch im Go-Status-Endpoint

### DIFF
--- a/docs/specs/fast/fix-1329-ac8-budget-status.md
+++ b/docs/specs/fast/fix-1329-ac8-budget-status.md
@@ -1,0 +1,67 @@
+# Mini-Spec: #1329 AC-8 — Forecast-Budget-Verbrauchsanzeige im Go-Status-Endpoint
+
+## Kontext
+
+`ForecastBudgetGate.snapshot()` (`src/services/forecast_budget.py:93-119`) liefert bereits
+alle Felder für den Kontingent-Verbrauch (`calls_today`, `daily_budget`, `usage_ratio`,
+`cache_hits`, `cache_misses`, `status`), ist aber im Python-Kern noch an nichts angebunden.
+Der Docstring des Feldes verweist explizit auf „Go-Status-Endpunkt, AC-8". Genau dieses
+Muster gibt es bereits für einen anderen Provider: `meteoalarmBudgetSnapshot()`
+(`internal/scheduler/warn_service_health.go:201-237`) liest
+`data/diagnostics/meteoalarm_budget.json` direkt (kein HTTP-Call zu Python-Core) und hängt
+das Ergebnis in `WarnServiceHealth()` unter `"meteoalarm_budget"` ein, was wiederum über
+`Scheduler.Status()` (`internal/scheduler/scheduler.go:677`) ausgeliefert wird.
+
+Diese Slice überträgt exakt dieses Muster auf `data/diagnostics/forecast_budget.json`
+(`src/services/forecast_budget.py:139-159` — Schreibformat: `{"date", "calls": {"openmeteo": N},
+"cache_hits", "cache_misses"}`, `calls` ist hier ein Dict pro Provider statt eines Int, anders
+als bei meteoalarm).
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine gültige `data/diagnostics/forecast_budget.json` existiert, When `/api/scheduler/status` aufgerufen wird, Then enthält die Antwort unter `forecast_budget` die Felder `calls_today`, `daily_budget`, `usage_ratio`, `cache_hits`, `cache_misses`, `status: "ok"` mit korrekt berechnetem `usage_ratio`.
+- **AC-2:** Given die Datei `data/diagnostics/forecast_budget.json` fehlt oder ist nicht lesbar, When `/api/scheduler/status` aufgerufen wird, Then liefert `forecast_budget.status` `"unavailable"` mit Nullwerten und der Endpoint antwortet weiterhin ohne Fehler (kein 500er, kein Panic).
+- **AC-3:** Given die Datei enthält kaputtes/unerwartetes JSON, When gelesen wird, Then verhält sich das System wie bei AC-2 (Fail-soft, `status: "unavailable"`).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine — additive Erweiterung eines bestehenden Status-Endpoints nach etabliertem Muster (`meteoalarmBudgetSnapshot`), keine neue Architektur-Entscheidung nötig.
+
+## Was ändert sich
+
+- Neue Funktion `forecastBudgetSnapshot(path string) map[string]any` in
+  `internal/scheduler/warn_service_health.go` (oder neue Datei `forecast_budget_health.go`),
+  analog `meteoalarmBudgetSnapshot`: liest `data/diagnostics/forecast_budget.json`, liefert
+  `calls_today` (Wert unter `calls.openmeteo`), `daily_budget` (Konstante 9000, wie Python
+  `ForecastBudgetGate.DAILY_BUDGET`), `usage_ratio`, `cache_hits`, `cache_misses`, `status`
+  (`"ok"`/`"unavailable"`)
+- Ergebnis wird in `Scheduler.Status()` unter dem Schlüssel `"forecast_budget"` eingehängt
+  (Pfad: `filepath.Join(s.store.DataDir, "diagnostics", "forecast_budget.json")`)
+- Fail-soft: fehlende/kaputte Datei → `status: "unavailable"`, Nullwerte — Endpoint darf nie
+  einen Fehler werfen (Spiegel des Python-`snapshot()`-Fail-open-Verhaltens)
+
+## Was darf sich nicht ändern
+
+- Bestehende Felder von `Scheduler.Status()` (`jobs`, `warn_service_health`, …) bleiben
+  unverändert
+- `ForecastBudgetGate` (Python-Seite) wird nicht angefasst — sie ist bereits fertig
+- Kein neuer HTTP-Call Go→Python-Core (Direktzugriff auf die Diagnose-Datei wie beim
+  bestehenden Muster)
+- Kein UI-Element auf der Account-Seite — der Verbrauch ist eine Ops-/Monitoring-Größe
+  (Konsument: `check-gregor20.sh` bzw. manuelle Prüfung des Endpoints), kein
+  Nutzer-sichtbares Feature
+
+## Manuelle Test-Schritte
+
+1. Lokal `data/diagnostics/forecast_budget.json` mit Testwerten anlegen
+   (`{"date":"2026-08-05","calls":{"openmeteo":42},"cache_hits":10,"cache_misses":5}`)
+2. `curl localhost:8090/api/scheduler/status | jq .forecast_budget` → erwartete Felder mit
+   korrekten Werten
+3. Datei löschen/umbenennen → erneuter Aufruf → `status: "unavailable"`, keine 500er-Antwort
+
+## Inline-Test (wird während Implementierung geschrieben)
+
+- [x] Test für `forecastBudgetSnapshot()`: gültige Datei → korrekte Felder + `usage_ratio`-Berechnung
+- [x] Test: fehlende Datei → `status: "unavailable"`, Nullwerte, kein Panic
+- [x] Test: kaputtes JSON → `status: "unavailable"` (Fail-soft)
+- [x] Test: `Scheduler.Status()` enthält `"forecast_budget"`-Schlüssel

--- a/internal/scheduler/forecast_budget_health.go
+++ b/internal/scheduler/forecast_budget_health.go
@@ -1,0 +1,75 @@
+package scheduler
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// forecastDailyBudget mirrors ForecastBudgetGate.DAILY_BUDGET
+// (src/services/forecast_budget.py:40) — a plain constant, not
+// env-overridable (unlike meteoalarmDailyBudget). Mini-Spec #1329 AC-8.
+const forecastDailyBudget = 9000
+
+// forecastBudgetFile mirrors the shape written by ForecastBudgetGate._write
+// (data/diagnostics/forecast_budget.json): {"date", "calls": {"openmeteo": N},
+// "cache_hits", "cache_misses"}. Unlike meteoalarmBudgetFile.Calls (a plain
+// int), Calls here is a per-provider map.
+type forecastBudgetFile struct {
+	Date        string         `json:"date"`
+	Calls       map[string]int `json:"calls"`
+	CacheHits   int            `json:"cache_hits"`
+	CacheMisses int            `json:"cache_misses"`
+}
+
+// forecastBudgetSnapshot reads path (data/diagnostics/forecast_budget.json)
+// and returns the same field set as ForecastBudgetGate.snapshot() (Python),
+// fail-soft exactly like snapshot() itself ("unavailable" instead of
+// raising). path=="" (no s.store) is treated the same as a read failure,
+// analog meteoalarmBudgetSnapshot.
+func forecastBudgetSnapshot(path string) map[string]any {
+	unavailable := map[string]any{
+		"calls_today":  0,
+		"daily_budget": forecastDailyBudget,
+		"usage_ratio":  0.0,
+		"cache_hits":   0,
+		"cache_misses": 0,
+		"status":       "unavailable",
+	}
+	if path == "" {
+		return unavailable
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return unavailable
+	}
+	var file forecastBudgetFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return unavailable
+	}
+
+	calls := file.Calls["openmeteo"] // zero value if key absent, s. spec
+	ratio := 0.0
+	if forecastDailyBudget > 0 {
+		ratio = float64(calls) / float64(forecastDailyBudget)
+	}
+	return map[string]any{
+		"calls_today":  calls,
+		"daily_budget": forecastDailyBudget,
+		"usage_ratio":  ratio,
+		"cache_hits":   file.CacheHits,
+		"cache_misses": file.CacheMisses,
+		"status":       "ok",
+	}
+}
+
+// ForecastBudgetHealth reads the open-meteo daily-call budget snapshot from
+// data/diagnostics/forecast_budget.json directly — no Python-Core HTTP call,
+// analog WarnServiceHealth's meteoalarm_budget field. Issue #1329 AC-8.
+func (s *Scheduler) ForecastBudgetHealth() map[string]any {
+	if s.store == nil {
+		return forecastBudgetSnapshot("")
+	}
+	path := filepath.Join(s.store.DataDir, "diagnostics", "forecast_budget.json")
+	return forecastBudgetSnapshot(path)
+}

--- a/internal/scheduler/forecast_budget_health_test.go
+++ b/internal/scheduler/forecast_budget_health_test.go
@@ -1,0 +1,122 @@
+package scheduler
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/henemm/gregor-api/internal/config"
+	"github.com/henemm/gregor-api/internal/store"
+)
+
+// Issue #1329 AC-8 — forecast_budget im /api/scheduler/status.
+// Spec: docs/specs/fast/fix-1329-ac8-budget-status.md
+// KEINE Mocks: echte JSON-Fixture-Dateien in t.TempDir().
+
+// newForecastBudgetHealthTestScheduler builds a Scheduler backed by tmpDir.
+func newForecastBudgetHealthTestScheduler(t *testing.T, tmpDir string) *Scheduler {
+	t.Helper()
+	s := store.New(tmpDir, "default")
+	cfg := &config.Config{
+		PythonCoreURL:     "http://localhost:8000",
+		SchedulerTimezone: "Europe/Vienna",
+	}
+	sched, err := New(cfg, s)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return sched
+}
+
+func writeForecastBudgetFile(t *testing.T, tmpDir, contents string) {
+	t.Helper()
+	dir := filepath.Join(tmpDir, "diagnostics")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir diagnostics: %v", err)
+	}
+	path := filepath.Join(dir, "forecast_budget.json")
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatalf("write forecast_budget.json: %v", err)
+	}
+}
+
+func TestForecastBudgetSnapshotValidFileReportsFieldsAndRatio(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeForecastBudgetFile(t, tmpDir,
+		`{"date":"2026-08-05","calls":{"openmeteo":900},"cache_hits":10,"cache_misses":5}`)
+
+	snap := forecastBudgetSnapshot(filepath.Join(tmpDir, "diagnostics", "forecast_budget.json"))
+
+	if got := snap["status"]; got != "ok" {
+		t.Errorf("status: want ok, got %v", got)
+	}
+	if got := snap["calls_today"]; got != 900 {
+		t.Errorf("calls_today: want 900, got %v", got)
+	}
+	if got := snap["daily_budget"]; got != 9000 {
+		t.Errorf("daily_budget: want 9000, got %v", got)
+	}
+	if got, ok := snap["usage_ratio"].(float64); !ok || got != 0.1 {
+		t.Errorf("usage_ratio: want 0.1, got %v", snap["usage_ratio"])
+	}
+	if got := snap["cache_hits"]; got != 10 {
+		t.Errorf("cache_hits: want 10, got %v", got)
+	}
+	if got := snap["cache_misses"]; got != 5 {
+		t.Errorf("cache_misses: want 5, got %v", got)
+	}
+}
+
+func TestForecastBudgetSnapshotMissingFileIsUnavailableNotPanic(t *testing.T) {
+	tmpDir := t.TempDir()
+	missingPath := filepath.Join(tmpDir, "diagnostics", "forecast_budget.json")
+
+	snap := forecastBudgetSnapshot(missingPath)
+
+	if got := snap["status"]; got != "unavailable" {
+		t.Errorf("status: want unavailable, got %v", got)
+	}
+	if got := snap["calls_today"]; got != 0 {
+		t.Errorf("calls_today: want 0, got %v", got)
+	}
+	if got, ok := snap["usage_ratio"].(float64); !ok || got != 0.0 {
+		t.Errorf("usage_ratio: want 0.0, got %v", snap["usage_ratio"])
+	}
+	if got := snap["cache_hits"]; got != 0 {
+		t.Errorf("cache_hits: want 0, got %v", got)
+	}
+	if got := snap["cache_misses"]; got != 0 {
+		t.Errorf("cache_misses: want 0, got %v", got)
+	}
+}
+
+func TestForecastBudgetSnapshotCorruptJSONIsUnavailable(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeForecastBudgetFile(t, tmpDir, `{not valid json`)
+
+	snap := forecastBudgetSnapshot(filepath.Join(tmpDir, "diagnostics", "forecast_budget.json"))
+
+	if got := snap["status"]; got != "unavailable" {
+		t.Errorf("status: want unavailable, got %v", got)
+	}
+}
+
+func TestSchedulerStatusIncludesForecastBudgetKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeForecastBudgetFile(t, tmpDir,
+		`{"date":"2026-08-05","calls":{"openmeteo":42},"cache_hits":1,"cache_misses":2}`)
+	sched := newForecastBudgetHealthTestScheduler(t, tmpDir)
+
+	status := sched.Status()
+
+	budget, ok := status["forecast_budget"].(map[string]any)
+	if !ok {
+		t.Fatalf("forecast_budget key missing or wrong type: %v", status["forecast_budget"])
+	}
+	if got := budget["calls_today"]; got != 42 {
+		t.Errorf("calls_today: want 42, got %v", got)
+	}
+	if got := budget["status"]; got != "ok" {
+		t.Errorf("status: want ok, got %v", got)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -675,6 +675,7 @@ func (s *Scheduler) Status() map[string]any {
 		"timezone":            s.cron.Location().String(),
 		"briefing_health":     s.BriefingHealth(),
 		"warn_service_health": s.WarnServiceHealth(),
+		"forecast_budget":     s.ForecastBudgetHealth(),
 	}
 }
 


### PR DESCRIPTION
## Summary
- Der taegliche Open-Meteo-Kontingentverbrauch (bereits von `ForecastBudgetGate` im Python-Kern gezaehlt, s. `src/services/forecast_budget.py`) ist jetzt unter `forecast_budget` im `/api/scheduler/status`-Endpoint sichtbar -- analog dem bestehenden `meteoalarm_budget`-Muster (`internal/scheduler/warn_service_health.go`).
- Fail-soft: fehlende/kaputte Diagnose-Datei -> `status: "unavailable"`, kein Fehler.
- Letzte offene Voraussetzung fuer #1439 (Starkregen-Kurzfristhinweis via `minutely_15`) -- ohne Bezahltarif ist diese Anzeige der einzige Fruehwarn-Schutz gegen ein leerlaufendes Kontingent (s. PO-Entscheidung in #1439-Kommentar vom 2026-08-04).

## Test plan
- [x] `go test ./internal/scheduler/...` -- 4 neue Tests gruen
- [x] `go test ./internal/...` -- gesamtes Go-Paket gruen, keine Regressionen
- [x] `go vet` / `gofmt` sauber
- [x] Mini-Spec mit AC-1/AC-2/AC-3 freigegeben (`docs/specs/fast/fix-1329-ac8-budget-status.md`)

Bezieht sich auf #1329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzaMdw2Cnt9o6iVx5QRwHD