### PR TITLE
fix(#1329 AC-8): cache_hit_ratio und throttle_level nachgeliefert

### DIFF
--- a/docs/context/feat-1329-ac8-budget-sichtbar.md
+++ b/docs/context/feat-1329-ac8-budget-sichtbar.md
@@ -1,0 +1,89 @@
+# Context: feat-1329-ac8-budget-sichtbar
+
+## Request Summary
+
+Letzter offener Rest von Issue #1329: der Go-Status-Endpoint `/api/scheduler/status` soll
+einen `forecast_budget`-Block mit `calls_today`, `cache_hit_ratio` und `throttle_level`
+liefern, damit ein leerlaufendes open-meteo-Tageskontingent auffällt, **bevor** Briefings
+ausbleiben. AC-8 ist in `docs/specs/modules/fix_1329_forecast_cache_budget.md:351`
+bereits freigegeben spezifiziert — dies ist reine Umsetzung, keine neue Spec.
+
+Vorbedingung für #1439 (Starkregen-Kurzfrist): dessen `minutely_15`-Abrufe ziehen
+zusätzliches Kontingent, das ohne Verbrauchssicht unbeobachtbar wäre.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `src/services/forecast_budget.py:93` | `snapshot()` — beim Bau von Scheibe C **ausdrücklich für AC-8 vorbereitet**; liefert `date`, `calls_today`, `daily_budget`, `usage_ratio`, `cache_hits`, `cache_misses`, `status`. Wird bisher nur in Tests verwendet, von keinem Endpoint. |
+| `src/services/forecast_budget.py:40-42` | Die drei zu spiegelnden Zahlen: `DAILY_BUDGET = 9000`, `POLLING_THRESHOLD = 0.80`, `BRIEFING_ONLY_THRESHOLD = 0.95`. |
+| `data/diagnostics/forecast_budget.json` | Persistierter Zählerstand, Format `{"date", "calls": {"openmeteo": N}, "cache_hits", "cache_misses"}`. Pfad prod/staging getrennt über `app.loader.get_data_root()`. |
+| `internal/scheduler/scheduler.go:611-679` | `Scheduler.Status() map[string]any` — hier wird der neue Top-Level-Key eingehängt (`:676-677` zeigen `briefing_health` und `warn_service_health` als Vorbild). |
+| `internal/scheduler/warn_service_health.go:189-237` | **Das direkte Vorbild:** `meteoalarmBudgetFile`-Struct + `meteoalarmBudgetSnapshot(path)` mit fail-soft `unavailable`-Default. Gleiche Aufgabe, gleiche Bauform. |
+| `internal/handler/scheduler_status.go:11-16` | HTTP-Handler, reines `Encode(sched.Status())` — braucht keine Änderung. |
+| `internal/router/router.go:198` | Route `/api/scheduler/status` — unverändert. |
+| `internal/scheduler/warn_service_health_test.go:107-146` | Test-Vorbild: JSON-Fixture per `os.WriteFile` in `t.TempDir()/diagnostics/`, Scheduler über `store.New(tmpDir, "default")`, Felder per Type-Assertion auf `map[string]any`. |
+| `docs/specs/modules/fix_1329_forecast_cache_budget.md:280-309,351,450-452` | AC-8 im Wortlaut, das Ziel-JSON, die Stufennamen und die Test-Vorgabe. |
+
+## Existing Patterns
+
+- **Budget-JSON von Go direkt lesen, fail-soft:** `meteoalarmBudgetSnapshot` liefert bei
+  leerem Pfad, Lesefehler **und** kaputtem JSON denselben Default-Block mit
+  `status: "unavailable"` — nie ein Panic, nie ein halb gefüllter Block. Erfolgsfall setzt
+  `status: "ok"`. Genau diese Semantik fordert AC-8 auch.
+- **Status-Antwort ist eine `map[string]any`**, kein benanntes Struct — neuer Block wird als
+  ein Literal-Key ergänzt.
+- **Python bleibt Entscheidungslogik, Go zeigt nur an** (Spec `:303-309`): Go leitet
+  `throttle_level` aus `usage_ratio` ab, trifft aber keine eigene Drossel-Entscheidung.
+- **Fail-open des Zählers:** `ForecastBudgetGate._safe_update` verschluckt jeden Fehler
+  (`:214-215`). Ein kaputter Zähler darf nie einen Versand blockieren — und folglich auch
+  die Anzeige nie einen Statusabruf.
+
+## Dependencies
+
+- **Upstream (was wir lesen):** die von `ForecastBudgetGate` geschriebene Zählerdatei unter
+  `<store.DataDir>/diagnostics/forecast_budget.json`. Kein Netz, kein Python-Prozess nötig —
+  der Statusabruf funktioniert auch, wenn `gregor-python` hängt.
+- **Downstream (was uns nutzt):** `check-gregor20.sh` in `henemm-infra` liest den
+  Status-Endpoint; ein neuer Top-Level-Key ist additiv und bricht dort nichts. Eine
+  Auswertung des neuen Blocks (Alarm bei hoher Auslastung) wäre eine eigene, spätere
+  Arbeit im Infra-Repo.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1329_forecast_cache_budget.md` — AC-8 (dieser Workflow),
+  AC-1 bis AC-7 und AC-9 sind live.
+- `docs/specs/modules/fix_1329_c2_radar_nowcast_cache.md` — Radar-Pfad zählt gegen dasselbe
+  Budget (dortiges AC-8), erklärt, warum `record_cache_hit/miss` zwei Aufrufer hat.
+- `docs/specs/modules/fix_1397_meteoalarm_coverage_budget.md` — das gespiegelte Vorbild.
+
+## Risks & Considerations
+
+1. **Die gespiegelten Zahlen driften unbewacht.** Das Vorbild trägt den Kommentar
+   „mirrors MeteoAlarmBudgetGate.DEFAULT_DAILY_BUDGET" (`warn_service_health.go:170`),
+   aber `grep -rn "DEFAULT_DAILY_BUDGET" --include=*_test.go` findet **keinen** Test. Wird
+   die Python-Zahl geändert, zeigt der Status still eine falsche Auslastung. Gegenmittel in
+   diesem Workflow: ein Paritäts-Test, der die drei Zahlen aus `forecast_budget.py` liest
+   und gegen die Go-Konstanten prüft (Muster: Paritäts-Test gegen `passkey.go` aus #1364).
+   Ein Kommentar ist eine Bitte, ein Test ist eine Zusicherung.
+2. **`cache_hit_ratio` existiert nirgends fertig.** Weder `weather_cache.stats()`
+   (`src/services/weather_cache.py:208` — nur `total_entries`/`max_entries`/`ttl_seconds`)
+   noch `radar_cache.py` (kein Zähler) noch ein HTTP-Endpoint liefern es. Es muss aus
+   `cache_hits / (cache_hits + cache_misses)` abgeleitet werden. **Division durch Null bei
+   frisch zurückgesetztem Tageszähler ist der naheliegende Fehler** — beide Zähler sind
+   dann 0.
+3. **Go-Tests liegen co-located** (`internal/scheduler/*_test.go`), lassen sich in Phase
+   `phase5_tdd_red` also nicht anlegen (`edit_gate` blockt `.go` außerhalb von
+   `test`/`tests`-Verzeichnissen). Dokumentierter Ausweg ohne Gate-Eingriff:
+   `go test -overlay` mit der Testdatei außerhalb des Repos, RED-Artefakt registrieren,
+   danach wandert die Datei an ihren co-located Platz.
+4. **`go` ist nicht im PATH** — `/usr/local/go/bin/go` explizit aufrufen.
+5. **Der Zähler ist pro Datenraum getrennt.** Prod, Staging und der Entwicklungs-Datenraum
+   haben eigene Dateien mit stark abweichenden Werten. Ein Test darf niemals gegen den
+   echten Datenraum prüfen, immer gegen `t.TempDir()`.
+6. **Beobachtung, ausdrücklich NICHT Teil dieser Arbeit:** Prod meldet heute 164 Calls bei
+   **0** Cache-Treffern, während der Entwicklungs-Datenraum 483 Treffer zeigt. Der Zähler
+   funktioniert also grundsätzlich. Ob der Cache auf Prod wirklich nie trifft (plausibel:
+   Dienst-Neustarts durch die heutigen Deploys, der Cache lebt nur im Arbeitsspeicher) oder
+   etwas anderes vorliegt, ist **unbewiesen**. Genau das soll diese Anzeige messbar machen —
+   erst bauen, dann über Tage beobachten, dann entscheiden. Vorher wäre es Spekulation.

--- a/internal/scheduler/forecast_budget_health.go
+++ b/internal/scheduler/forecast_budget_health.go
@@ -4,12 +4,35 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // forecastDailyBudget mirrors ForecastBudgetGate.DAILY_BUDGET
 // (src/services/forecast_budget.py:40) — a plain constant, not
 // env-overridable (unlike meteoalarmDailyBudget). Mini-Spec #1329 AC-8.
+// Guarded at runtime by TestForecastBudgetConstantsMatchPython.
 const forecastDailyBudget = 9000
+
+// forecastPollingThreshold/forecastBriefingOnlyThreshold mirror
+// ForecastBudgetGate.POLLING_THRESHOLD/.BRIEFING_ONLY_THRESHOLD
+// (src/services/forecast_budget.py:41-42). Display-only: Python's
+// allow() remains the sole decision-maker; Go derives throttle_level
+// purely for observability (Spec fix_1329_forecast_cache_budget.md:303-309).
+// Python allows while ratio < threshold, i.e. it throttles from
+// ratio >= threshold on — Go mirrors that exact boundary.
+const forecastPollingThreshold = 0.80
+const forecastBriefingOnlyThreshold = 0.95
+
+// forecastThrottleLevel derives the AC-8 display stage from usage_ratio.
+func forecastThrottleLevel(usageRatio float64) string {
+	if usageRatio >= forecastBriefingOnlyThreshold {
+		return "briefing_only"
+	}
+	if usageRatio >= forecastPollingThreshold {
+		return "polling_throttled"
+	}
+	return "none"
+}
 
 // forecastBudgetFile mirrors the shape written by ForecastBudgetGate._write
 // (data/diagnostics/forecast_budget.json): {"date", "calls": {"openmeteo": N},
@@ -29,16 +52,26 @@ type forecastBudgetFile struct {
 // analog meteoalarmBudgetSnapshot.
 func forecastBudgetSnapshot(path string) map[string]any {
 	unavailable := map[string]any{
-		"calls_today":  0,
-		"daily_budget": forecastDailyBudget,
-		"usage_ratio":  0.0,
-		"cache_hits":   0,
-		"cache_misses": 0,
-		"status":       "unavailable",
+		"date":            nil,
+		"calls_today":     0,
+		"daily_budget":    forecastDailyBudget,
+		"usage_ratio":     0.0,
+		"cache_hits":      0,
+		"cache_misses":    0,
+		"cache_hit_ratio": 0.0,
+		"throttle_level":  "none",
+		"status":          "unavailable",
 	}
 	if path == "" {
 		return unavailable
 	}
+	// Adversary-Fund F001/F002 (feat-1329-ac8-budget-sichtbar): kein
+	// separater os.ReadFile-Fehlercheck jenseits dieses -- gemessen liefert
+	// os.ReadFile bei jedem real erreichbaren Lesefehler len(data) == 0, was
+	// json.Unmarshal ohnehin auf denselben Default-Zweig scheitern laesst;
+	// der Schreibpfad ist zudem atomar (ForecastBudgetGate._write, mkstemp +
+	// os.replace, src/services/forecast_budget.py:159-171), ein Leser sieht
+	// also nie eine halb geschriebene Datei.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return unavailable
@@ -48,18 +81,37 @@ func forecastBudgetSnapshot(path string) map[string]any {
 		return unavailable
 	}
 
-	calls := file.Calls["openmeteo"] // zero value if key absent, s. spec
+	// Stale-Date (mirrors ForecastBudgetGate._load_for_today,
+	// src/services/forecast_budget.py:139-159): Python resets the counters
+	// lazily, only on the next write. A persisted date that isn't today's
+	// UTC date means the counters are logically reset -- reporting
+	// yesterday's calls_today as "heute" would be factually wrong.
+	today := time.Now().UTC().Format("2006-01-02")
+	calls, cacheHits, cacheMisses := 0, 0, 0
+	if file.Date == today {
+		calls = file.Calls["openmeteo"] // zero value if key absent, s. spec
+		cacheHits = file.CacheHits
+		cacheMisses = file.CacheMisses
+	}
+
 	ratio := 0.0
 	if forecastDailyBudget > 0 {
 		ratio = float64(calls) / float64(forecastDailyBudget)
 	}
+	hitRatio := 0.0
+	if total := cacheHits + cacheMisses; total > 0 {
+		hitRatio = float64(cacheHits) / float64(total)
+	}
 	return map[string]any{
-		"calls_today":  calls,
-		"daily_budget": forecastDailyBudget,
-		"usage_ratio":  ratio,
-		"cache_hits":   file.CacheHits,
-		"cache_misses": file.CacheMisses,
-		"status":       "ok",
+		"date":            today,
+		"calls_today":     calls,
+		"daily_budget":    forecastDailyBudget,
+		"usage_ratio":     ratio,
+		"cache_hits":      cacheHits,
+		"cache_misses":    cacheMisses,
+		"cache_hit_ratio": hitRatio,
+		"throttle_level":  forecastThrottleLevel(ratio),
+		"status":          "ok",
 	}
 }
 

--- a/internal/scheduler/forecast_budget_health_test.go
+++ b/internal/scheduler/forecast_budget_health_test.go
@@ -1,9 +1,13 @@
 package scheduler
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/henemm/gregor-api/internal/config"
 	"github.com/henemm/gregor-api/internal/store"
@@ -118,5 +122,163 @@ func TestSchedulerStatusIncludesForecastBudgetKey(t *testing.T) {
 	}
 	if got := budget["status"]; got != "ok" {
 		t.Errorf("status: want ok, got %v", got)
+	}
+}
+
+// AC-8: cache_hit_ratio = cache_hits / (cache_hits + cache_misses).
+func TestForecastBudgetSnapshotCacheHitRatio(t *testing.T) {
+	tmpDir := t.TempDir()
+	today := time.Now().UTC().Format("2006-01-02")
+	writeForecastBudgetFile(t, tmpDir, `{"date":"`+today+`","calls":{"openmeteo":100},"cache_hits":678,"cache_misses":322}`)
+
+	snap := forecastBudgetSnapshot(filepath.Join(tmpDir, "diagnostics", "forecast_budget.json"))
+
+	want := 678.0 / (678.0 + 322.0)
+	got, ok := snap["cache_hit_ratio"].(float64)
+	if !ok || got != want {
+		t.Errorf("cache_hit_ratio: want %v, got %v", want, snap["cache_hit_ratio"])
+	}
+}
+
+// Division durch Null: cache_hits UND cache_misses bei 0 muss 0.0 liefern,
+// nicht NaN -- NaN killt json.Marshal fuer den GESAMTEN Status-Endpunkt.
+func TestForecastBudgetSnapshotZeroCacheCountsGiveZeroRatioAndMarshalableStatus(t *testing.T) {
+	tmpDir := t.TempDir()
+	today := time.Now().UTC().Format("2006-01-02")
+	writeForecastBudgetFile(t, tmpDir, `{"date":"`+today+`","calls":{},"cache_hits":0,"cache_misses":0}`)
+	sched := newForecastBudgetHealthTestScheduler(t, tmpDir)
+
+	status := sched.Status()
+
+	budget := status["forecast_budget"].(map[string]any)
+	if got, ok := budget["cache_hit_ratio"].(float64); !ok || got != 0.0 {
+		t.Errorf("cache_hit_ratio: want 0.0, got %v", budget["cache_hit_ratio"])
+	}
+	if _, err := json.Marshal(status); err != nil {
+		t.Fatalf("json.Marshal(sched.Status()) failed: %v", err)
+	}
+}
+
+// AC-8: throttle_level-Grenzen exakt wie ForecastBudgetGate.allow()
+// (src/services/forecast_budget.py:54-74) -- Python erlaubt bei
+// ratio < Schwelle, drosselt also ab ratio >= Schwelle.
+func TestForecastBudgetSnapshotThrottleLevelBoundaries(t *testing.T) {
+	today := time.Now().UTC().Format("2006-01-02")
+	cases := []struct {
+		calls int
+		want  string
+	}{
+		{7199, "none"},              // 0.79989 < 0.80
+		{7200, "polling_throttled"}, // exakt 0.80
+		{8549, "polling_throttled"}, // 0.94989 < 0.95
+		{8550, "briefing_only"},     // exakt 0.95
+	}
+	for _, tc := range cases {
+		t.Run(tc.want+"_"+strconv.Itoa(tc.calls), func(t *testing.T) {
+			tmpDir := t.TempDir()
+			writeForecastBudgetFile(t, tmpDir, `{"date":"`+today+`","calls":{"openmeteo":`+strconv.Itoa(tc.calls)+`},"cache_hits":0,"cache_misses":0}`)
+			snap := forecastBudgetSnapshot(filepath.Join(tmpDir, "diagnostics", "forecast_budget.json"))
+			if got := snap["throttle_level"]; got != tc.want {
+				t.Errorf("calls=%d: throttle_level want %q, got %v", tc.calls, tc.want, got)
+			}
+		})
+	}
+}
+
+// Stale-Date: ein gestriger Zaehlerstand (Python setzt erst beim naechsten
+// Schreibzugriff zurueck, s. _load_for_today) darf NICHT als "calls_today"
+// erscheinen -- Zaehler gelten als zurueckgesetzt, "date" zeigt HEUTE.
+func TestForecastBudgetSnapshotStaleDateReportsZeroCounts(t *testing.T) {
+	tmpDir := t.TempDir()
+	yesterday := time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02")
+	writeForecastBudgetFile(t, tmpDir, `{"date":"`+yesterday+`","calls":{"openmeteo":8000},"cache_hits":500,"cache_misses":10}`)
+
+	snap := forecastBudgetSnapshot(filepath.Join(tmpDir, "diagnostics", "forecast_budget.json"))
+
+	today := time.Now().UTC().Format("2006-01-02")
+	if got := snap["date"]; got != today {
+		t.Errorf("date: want today %q, got %v (stale date must not leak through)", today, got)
+	}
+	if got := snap["calls_today"]; got != 0 {
+		t.Errorf("calls_today: want 0 for a stale-date file, got %v", got)
+	}
+	if got := snap["throttle_level"]; got != "none" {
+		t.Errorf("throttle_level: want none (reset), got %v", got)
+	}
+	// F003 (Adversary): cache_hits/cache_misses/cache_hit_ratio muessen an
+	// dieselbe Datumspruefung gebunden sein wie calls_today -- sonst
+	// widerspraeche sich der Block selbst (date=heute, calls_today=0, aber
+	// cache_hit_ratio aus gestrigen Zahlen).
+	if got := snap["cache_hits"]; got != 0 {
+		t.Errorf("cache_hits: want 0 for a stale-date file, got %v", got)
+	}
+	if got := snap["cache_misses"]; got != 0 {
+		t.Errorf("cache_misses: want 0 for a stale-date file, got %v", got)
+	}
+	if got, ok := snap["cache_hit_ratio"].(float64); !ok || got != 0.0 {
+		t.Errorf("cache_hit_ratio: want 0.0 for a stale-date file, got %v", snap["cache_hit_ratio"])
+	}
+}
+
+const maxForecastBudgetRepoRootAscent = 6
+
+// findForecastBudgetRepoRoot steigt von os.Getwd() auf, bis go.mod gefunden
+// wird -- NICHT runtime.Caller(0) (bricht unter -overlay/-trimpath still,
+// Muster internal/mail/recipient_parity_test.go).
+func findForecastBudgetRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("findForecastBudgetRepoRoot: os.Getwd() fehlgeschlagen: %v", err)
+	}
+	for i := 0; i < maxForecastBudgetRepoRootAscent; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	t.Fatalf("findForecastBudgetRepoRoot: kein go.mod innerhalb von %d Ebenen ueber %q gefunden",
+		maxForecastBudgetRepoRootAscent, dir)
+	return ""
+}
+
+// Paritaets-Test (Muster: passkey.go-Paritaet aus #1364): die drei
+// gespiegelten Zahlen (DAILY_BUDGET, POLLING_THRESHOLD,
+// BRIEFING_ONLY_THRESHOLD) werden zur Laufzeit aus src/services/forecast_budget.py
+// gelesen und gegen die Go-Konstanten geprueft -- ein Kommentar ist eine
+// Bitte, ein Test ist eine Zusicherung.
+func TestForecastBudgetConstantsMatchPython(t *testing.T) {
+	repoRoot := findForecastBudgetRepoRoot(t)
+	pySrc, err := os.ReadFile(filepath.Join(repoRoot, "src", "services", "forecast_budget.py"))
+	if err != nil {
+		t.Fatalf("forecast_budget.py nicht lesbar: %v", err)
+	}
+	text := string(pySrc)
+
+	checks := []struct {
+		re   *regexp.Regexp
+		name string
+		want string
+	}{
+		{regexp.MustCompile(`DAILY_BUDGET\s*=\s*(\d+)`), "DAILY_BUDGET", "9000"},
+		{regexp.MustCompile(`POLLING_THRESHOLD\s*=\s*([\d.]+)`), "POLLING_THRESHOLD", "0.80"},
+		{regexp.MustCompile(`BRIEFING_ONLY_THRESHOLD\s*=\s*([\d.]+)`), "BRIEFING_ONLY_THRESHOLD", "0.95"},
+	}
+	for _, c := range checks {
+		m := c.re.FindStringSubmatch(text)
+		if m == nil {
+			t.Fatalf("%s nicht in forecast_budget.py gefunden — Konstante verschoben/umbenannt?", c.name)
+		}
+		if m[1] != c.want {
+			t.Errorf("%s (Python) = %s, Go-Konstante = %s -- Drift!", c.name, m[1], c.want)
+		}
+	}
+	if forecastDailyBudget != 9000 || forecastPollingThreshold != 0.80 || forecastBriefingOnlyThreshold != 0.95 {
+		t.Fatalf("Go-Konstanten selbst weichen von den erwarteten Werten ab: %d/%v/%v",
+			forecastDailyBudget, forecastPollingThreshold, forecastBriefingOnlyThreshold)
 	}
 }


### PR DESCRIPTION
## Warum das Ticket noch einmal aufgeht

AC-8 verlangt wortlautgetreu einen `forecast_budget`-Block mit **`calls_today`, `cache_hit_ratio` und `throttle_level`** (`docs/specs/modules/fix_1329_forecast_cache_budget.md:351`). Am laufenden Produktionssystem gemessen lieferte der Block nur `calls_today` plus Rohzähler:

```json
{"cache_hits":0,"cache_misses":164,"calls_today":164,"daily_budget":9000,"status":"ok","usage_ratio":0.0182}
```

Eines von drei namentlich genannten Feldern. Die parallel entstandene Mini-Spec `docs/specs/fast/fix-1329-ac8-budget-status.md` führt die beiden fehlenden in ihren eigenen ACs nicht auf; #1329 wurde auf dieser Basis geschlossen.

## Was dieser PR macht

Ergänzt **in der bereits ausgelieferten Datei** — keine zweite Implementierung. Die parallel gebaute `forecast_budget_status.go` wurde verworfen, ihre Substanz ist hier aufgegangen.

| Ergänzung | Absicherung |
|---|---|
| `cache_hit_ratio` = hits/(hits+misses) | bei 0/0 definiert `0.0` statt `NaN`. `NaN` ist in Go nicht serialisierbar und würde den **gesamten** Status-Endpoint mit einem Encoder-Fehler killen. Test marshalt die echte `Status()`-Map. |
| `throttle_level` `none`/`polling_throttled`/`briefing_only` | gegen dieselben Schwellen wie `ForecastBudgetGate.allow()`, Grenzwerte exakt getestet (7199/7200/8549/8550 = 0.79988/0.80/0.94988/0.95) |
| `date` + Stale-Date-Reset | spiegelt `_load_for_today`: bei abweichendem UTC-Datum sind **alle** Zähler 0 und `date` zeigt heute. Ohne das gilt der Stand von gestern als "heute". |
| Paritäts-Test gegen die drei Python-Zahlen | das Vorbild `meteoalarmDefaultDailyBudget` trägt nur einen Kommentar "mirrors …" und hat **keinen** Test — die Kopie driftete unbewacht |

## Prüfung

Adversary 4 Runden **VERIFIED**. Drei Findings geschlossen statt gesammelt:

- **F001** redundanter `os.ReadFile`-Fehlercheck — als nicht isoliert erreichbar belegt (`len(raw)==0` in jedem real erreichbaren Fehlerfall, Schreibpfad atomar per `mkstemp`+`os.replace`) und im Code dokumentiert.
- **F002** der dafür ergänzte Testfall war Dekoration (strukturell deckungsgleich mit `missing_file`) — gestrichen. Lieber ein Test weniger als einer, der Sicherheit vortäuscht.
- **F003** der Stale-Date-Test prüfte die Cache-Zähler nicht; eine Mutation, die nur `calls` zurücksetzt, blieb bei allen 9 Tests grün und lieferte `calls_today=0` neben `cache_hit_ratio=0.98` aus gestrigen Zahlen. Drei Zusicherungen ergänzt, Rot-Beleg erbracht.

**Die vier Tests der Parallelsitzung sind unverändert und grün** — keine ihrer Zeilen angefasst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)