### PR TITLE
fix(#1498): Gewitter-Vorschau der Trip-Mail auf Tagesfenster klemmen (Fall 2)

### DIFF
--- a/src/app/day_window.py
+++ b/src/app/day_window.py
@@ -1,0 +1,63 @@
+"""Tagesfenster-Grundlagen: Konstanten, Aufloesung, Stunden-Zugehoerigkeit.
+
+Hierher verschoben aus ``output/renderers/day_window.py`` (#1498, Fall 2):
+der Zeitplaner (``trip_report_scheduler``) braucht dieselben Fenster-Grenzen
+fuer die Gewitter-Vorschau, darf aber per Architektur-Wache
+(``tests/unit/test_notification_service.py``) nichts aus ``output``
+importieren. Die Fenster-SEMANTIK ist keine Render-Frage, sondern eine
+Domaenen-Konvention (ADR-0025) — sie wohnt deshalb in ``app``, wie schon
+``app/thunder_scale.py``. ``output/renderers/day_window.py`` re-exportiert
+alle drei Namen unveraendert (bestehende Importe bleiben gueltig).
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+DAY_WINDOW_START_HOUR = 4
+DAY_WINDOW_END_HOUR = 19
+
+
+def resolve_configured_window(
+    day_window_start_hour: Optional[int],
+    day_window_end_hour: Optional[int],
+) -> tuple[int, int]:
+    """Epic #1319 Scheibe B (erweitert Issue #1361/#1372 S1b, AC-3): eine
+    Quelle fuer die effektiven Fenster-Grenzen.
+
+    ``None``/fehlend (Alt-Trip, Rueckwaertskompatibilitaet) oder ein
+    ungueltiges Paar (ausserhalb 0-23, ``start == end``) faellt still auf
+    den Default 4/19 zurueck -- Defense-in-Depth, falls eine ungueltige
+    Kombination den Go-Store-Klemmpfad umgeht und dennoch bis zum Renderer
+    durchreicht (AC-4).
+
+    ``start > end`` ist seit #1361/#1372 S1b (PO-Entscheidung 2026-07-25)
+    ein GUELTIGES Fenster ueber Mitternacht (z. B. 22-2 Uhr) -- NICHT mehr
+    invalide. Nur ``start == end`` (Nullstunden- bzw. Ganztags-Mehrdeutigkeit)
+    bleibt abgelehnt. Konsumenten (``build_day_window_points()``,
+    ``comparison_engine._filter_by_target_date_and_window()``) muessen den
+    Mitternachts-Fall selbst wrap-aware behandeln.
+    """
+    if day_window_start_hour is None or day_window_end_hour is None:
+        return DAY_WINDOW_START_HOUR, DAY_WINDOW_END_HOUR
+    # F004: bool ist eine int-Subklasse in Python -- ohne den expliziten
+    # Ausschluss wuerde JSON true/false als Stunde 1/0 durchgehen.
+    if not (type(day_window_start_hour) is int and type(day_window_end_hour) is int):
+        return DAY_WINDOW_START_HOUR, DAY_WINDOW_END_HOUR
+    if not (0 <= day_window_start_hour <= 23 and 0 <= day_window_end_hour <= 23):
+        return DAY_WINDOW_START_HOUR, DAY_WINDOW_END_HOUR
+    if day_window_start_hour == day_window_end_hour:
+        return DAY_WINDOW_START_HOUR, DAY_WINDOW_END_HOUR
+    return day_window_start_hour, day_window_end_hour
+
+
+def hour_in_window(hour: int, start_hour: int, end_hour: int) -> bool:
+    """Liegt die Ortszeit-Stunde im Fenster? Beide Grenzen einschliesslich.
+
+    Wrap-aware (#1361/#1372 S1b): bei ``start > end`` (z. B. 22-2) zaehlen
+    die Stunden >= start ODER <= end. Innerhalb EINES Kalendertags bleibt
+    die chronologische Ordnung dabei die gewoehnliche Stundenordnung —
+    ein ``min()`` ueber Fenster-Treffer desselben Datums ist korrekt.
+    """
+    if start_hour <= end_hour:
+        return start_hour <= hour <= end_hour
+    return hour >= start_hour or hour <= end_hour

--- a/src/output/renderers/day_window.py
+++ b/src/output/renderers/day_window.py
@@ -20,8 +20,14 @@ from zoneinfo import ZoneInfo
 from app.models import ForecastDataPoint, NormalizedTimeseries, SegmentWeatherData
 from utils.timezone import local_dt, local_hour
 
-DAY_WINDOW_START_HOUR = 4
-DAY_WINDOW_END_HOUR = 19
+# #1498 (Fall 2): Konstanten + Aufloesung wohnen jetzt renderer-neutral in
+# app/day_window.py (der Zeitplaner braucht sie, darf aber nichts aus
+# `output` ziehen). Re-Export hier haelt alle bestehenden Importe gueltig.
+from app.day_window import (  # noqa: F401  (Re-Export)
+    DAY_WINDOW_END_HOUR,
+    DAY_WINDOW_START_HOUR,
+    resolve_configured_window,
+)
 
 
 def _max_optional(values: Sequence[Optional[float]]) -> Optional[float]:
@@ -65,39 +71,6 @@ def _merge_hour(dps: list[ForecastDataPoint]) -> ForecastDataPoint:
         wind10m_kmh=_max_optional([dp.wind10m_kmh for dp in dps]),
         gust_kmh=_max_optional([dp.gust_kmh for dp in dps]),
     )
-
-
-def resolve_configured_window(
-    day_window_start_hour: Optional[int],
-    day_window_end_hour: Optional[int],
-) -> tuple[int, int]:
-    """Epic #1319 Scheibe B (erweitert Issue #1361/#1372 S1b, AC-3): eine
-    Quelle fuer die effektiven Fenster-Grenzen.
-
-    ``None``/fehlend (Alt-Trip, Rueckwaertskompatibilitaet) oder ein
-    ungueltiges Paar (ausserhalb 0-23, ``start == end``) faellt still auf
-    den Default 4/19 zurueck -- Defense-in-Depth, falls eine ungueltige
-    Kombination den Go-Store-Klemmpfad umgeht und dennoch bis zum Renderer
-    durchreicht (AC-4).
-
-    ``start > end`` ist seit #1361/#1372 S1b (PO-Entscheidung 2026-07-25)
-    ein GUELTIGES Fenster ueber Mitternacht (z. B. 22-2 Uhr) -- NICHT mehr
-    invalide. Nur ``start == end`` (Nullstunden- bzw. Ganztags-Mehrdeutigkeit)
-    bleibt abgelehnt. Konsumenten (``build_day_window_points()``,
-    ``comparison_engine._filter_by_target_date_and_window()``) muessen den
-    Mitternachts-Fall selbst wrap-aware behandeln.
-    """
-    if day_window_start_hour is None or day_window_end_hour is None:
-        return DAY_WINDOW_START_HOUR, DAY_WINDOW_END_HOUR
-    # F004: bool ist eine int-Subklasse in Python -- ohne den expliziten
-    # Ausschluss wuerde JSON true/false als Stunde 1/0 durchgehen.
-    if not (type(day_window_start_hour) is int and type(day_window_end_hour) is int):
-        return DAY_WINDOW_START_HOUR, DAY_WINDOW_END_HOUR
-    if not (0 <= day_window_start_hour <= 23 and 0 <= day_window_end_hour <= 23):
-        return DAY_WINDOW_START_HOUR, DAY_WINDOW_END_HOUR
-    if day_window_start_hour == day_window_end_hour:
-        return DAY_WINDOW_START_HOUR, DAY_WINDOW_END_HOUR
-    return day_window_start_hour, day_window_end_hour
 
 
 def build_day_window_points(

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -1548,7 +1548,23 @@ class TripReportSchedulerService:
         beide Aufrufer (Versandpfad + Vorschau) übergeben immer eine echte,
         aus Koordinaten aufgeloeste Zone; Tests, die den Fail-soft-Pfad ohne
         aufloesbaren Ort pruefen, übergeben weiterhin bewusst `tz=None`.
+
+        Issue #1498 (Fall 2): beide Bauwege klemmen auf das geteilte
+        Tagesfenster (Default 04-19, pro Trip konfigurierbar) — vorher las
+        die Vorschau den vollen Kalendertag 00-23 und behauptete damit
+        Nachtstunden („ab 02:00"), fuer die die Nacht-Tabelle derselben
+        Mail mit eigener Quelle (`night_weather`) zustaendig ist; die zwei
+        Aussagen widersprachen sich an einer echt zugestellten Staging-Mail.
+        Die Vorschau ist eine TAGES-Aussage und nutzt dasselbe Fenster wie
+        SMS/Telegram/Fusszeile (ADR-0025).
         """
+        from app.day_window import resolve_configured_window
+
+        _rc = getattr(trip, "report_config", None)
+        win_start, win_end = resolve_configured_window(
+            getattr(_rc, "day_window_start_hour", None),
+            getattr(_rc, "day_window_end_hour", None),
+        )
         forecast: dict = {}
         trend_by_date = {
             row["date"]: row
@@ -1560,7 +1576,9 @@ class TripReportSchedulerService:
             fc_date = target_date + timedelta(days=offset)
             row = trend_by_date.get(fc_date)
             if row is not None:
-                forecast[key] = self._thunder_entry_from_trend_row(row, fc_date)
+                forecast[key] = self._thunder_entry_from_trend_row(
+                    row, fc_date, window_start=win_start, window_end=win_end,
+                )
             else:
                 missing_dates.add(fc_date)
 
@@ -1569,7 +1587,10 @@ class TripReportSchedulerService:
                 trip, target_date, wanted_dates=missing_dates,
             )
             fetched_fc = (
-                self._build_thunder_forecast(fetched, target_date, tz=tz)
+                self._build_thunder_forecast(
+                    fetched, target_date, tz=tz,
+                    window_start=win_start, window_end=win_end,
+                )
                 if fetched else None
             ) or {}
             for _offset, key in [(1, "+1"), (2, "+2")]:
@@ -1602,13 +1623,20 @@ class TripReportSchedulerService:
         self,
         row: dict,
         fc_date: date,
+        *,
+        window_start: Optional[int] = None,
+        window_end: Optional[int] = None,
     ) -> dict:
         """Map one ``multi_day_trend`` row to a thunder_forecast entry (#1275).
 
-        Level from ``row["thunder"]`` (name string), earliest "ab HH:MM" from
-        ``row["hourly_thunder"]`` (HourlyValue samples, already local hour). The
-        return format matches ``_build_thunder_forecast`` so all downstream
-        consumers (SMS/Telegram/E-Mail-Vorschau) stay unchanged.
+        Level und "ab HH:MM" aus den ``row["hourly_thunder"]``-Proben
+        (HourlyValue, bereits Ortszeit-Stunde) INNERHALB des Tagesfensters
+        ``window_start``..``window_end`` (#1498 Fall 2; ``None`` -> Default
+        4/19 via ``resolve_configured_window``). ``row["thunder"]``
+        (Kalendertags-Maximum) dient nur noch als Fail-soft, wenn keine
+        Stundenprobe im Fenster liegt. The return format matches
+        ``_build_thunder_forecast`` so all downstream consumers
+        (SMS/Telegram/E-Mail-Vorschau) stay unchanged.
 
         Issue #1402: der frühere ``tz``-Parameter wurde entfernt — er wurde
         nirgends im Funktionskörper gelesen (die Lokalisierung ist bereits
@@ -1623,19 +1651,44 @@ class TripReportSchedulerService:
         ``outlook.py::build_outlook_row``), also bleibt der Werte-Vergleich
         konsistent statt einer zweiten, driftenden Kopie.
         """
+        from app.day_window import hour_in_window, resolve_configured_window
         from app.models import ThunderLevel
-        from app.thunder_scale import thunder_label_value
+        from app.thunder_scale import thunder_label_value, thunder_ordinal
 
-        try:
-            level = ThunderLevel[row.get("thunder") or "NONE"]
-        except KeyError:
-            level = ThunderLevel.NONE
+        win_start, win_end = resolve_configured_window(window_start, window_end)
+        windowed = [
+            hv for hv in (row.get("hourly_thunder") or ())
+            if hour_in_window(int(hv.hour), win_start, win_end)
+        ]
+        if windowed:
+            # Issue #1498 (Fall 2): Level aus den Stundenproben IM Fenster,
+            # nicht aus dem Kalendertags-Maximum `row["thunder"]` — sonst
+            # setzt ein reines Nachtgewitter (02:00) die Tages-Vorschau.
+            # Rueckabbildung Sample-Wert -> Level ueber die geteilte
+            # Render-Skala selbst (#1474: keine Handkopie), Sortierung ueber
+            # thunder_ordinal (ADR-0025, Entscheidung 3: Skalen getrennt).
+            _value_to_level = {thunder_label_value(lv): lv for lv in ThunderLevel}
+            level = max(
+                (
+                    _value_to_level.get(int(hv.value), ThunderLevel.NONE)
+                    for hv in windowed
+                ),
+                key=thunder_ordinal,
+            )
+        else:
+            # Fail-soft (Known Limitation): ohne Stundenproben im Fenster
+            # keine Klemmung — Kalendertags-Maximum wie bisher, nie eine
+            # blinde Entwarnung ueber unbeobachtete Stunden (#1331-Lehre).
+            try:
+                level = ThunderLevel[row.get("thunder") or "NONE"]
+            except KeyError:
+                level = ThunderLevel.NONE
         when = None
         hour = None
         if level != ThunderLevel.NONE:
             hours = [
                 int(hv.hour)
-                for hv in (row.get("hourly_thunder") or ())
+                for hv in windowed
                 if hv.value == thunder_label_value(level)
             ]
             if hours:
@@ -1700,6 +1753,13 @@ class TripReportSchedulerService:
         """
         from providers.openmeteo import is_within_forecast_horizon
 
+        # #1498 (Fall 2, Beifang): ohne Trip-Objekt (Vorschau-Pfad, s.
+        # Fail-soft-Zusage oben und #1482-Guard im Aufrufer) gibt es keine
+        # Etappenliste — vorher stuerzte genau dieser Fall mit
+        # AttributeError, sobald der Trend einen Offset nicht abdeckte.
+        if trip is None:
+            return []
+
         collected: List[SegmentWeatherData] = []
         today = date.today()
         wanted = wanted_dates if wanted_dates is not None else {
@@ -1732,6 +1792,9 @@ class TripReportSchedulerService:
         segments,
         target_date: date,
         tz: Optional[ZoneInfo],
+        *,
+        window_start: Optional[int] = None,
+        window_end: Optional[int] = None,
     ) -> Optional[dict]:
         """
         Build thunder forecast for +1 and +2 days.
@@ -1792,6 +1855,14 @@ class TripReportSchedulerService:
             # UTC" (#1345). local_dt() geht ueber den zentralen Naiv-Guard.
             return local_dt(dt, tz) if tz else dt
 
+        # Issue #1498 (Fall 2): nur Stunden im geteilten Tagesfenster zaehlen
+        # — die Vorschau ist eine Tages-Aussage; Nachtstunden gehoeren der
+        # Nacht-Tabelle. Liegt im Fenster gar kein Datenpunkt, entsteht KEIN
+        # Eintrag — das greift in `_gap_offsets` (#1482) als ehrliche
+        # Datenluecke ("?") statt einer blinden Entwarnung (#1331-Lehre).
+        from app.day_window import hour_in_window, resolve_configured_window
+        win_start, win_end = resolve_configured_window(window_start, window_end)
+
         forecast = {}
         for offset, key in [(1, "+1"), (2, "+2")]:
             fc_date = target_date + timedelta(days=offset)
@@ -1801,6 +1872,7 @@ class TripReportSchedulerService:
                 if sw.timeseries and sw.timeseries.data
                 for dp in sw.timeseries.data
                 if _local(dp.ts).date() == fc_date and dp.thunder_level
+                and hour_in_window(_local(dp.ts).hour, win_start, win_end)
             ]
             if not thunder_dps:
                 continue

--- a/tests/tdd/test_thunder_forecast_stage_consistency.py
+++ b/tests/tdd/test_thunder_forecast_stage_consistency.py
@@ -225,19 +225,20 @@ class TestPeakTimeIndependentOfSegmentOrder:
     def test_earliest_peak_hour_wins_regardless_of_segment_order(self):
         """
         GIVEN: Zwei Segmente derselben Etappe, BEIDE HIGH — das ZUERST gelistete
-               spät (10:00), das zweite früher (02:00)
+               spät (15:00), das zweite früher (06:00; beide IM Tagesfenster
+               04-19 — seit #1498 Fall 2 zaehlen nur Fenster-Stunden)
         WHEN:  _build_thunder_forecast() die "+1"-Uhrzeit ableitet
-        THEN:  Text zeigt 'ab 02:00' (chronologisch früheste HIGH-Stunde),
-               NICHT 'ab 10:00' (Reihenfolge des ersten Segments)
+        THEN:  Text zeigt 'ab 06:00' (chronologisch früheste HIGH-Stunde),
+               NICHT 'ab 15:00' (Reihenfolge des ersten Segments)
         """
         seg_a_points = [
-            _dp(_TOMORROW, h, thunder=ThunderLevel.HIGH if h == 10 else ThunderLevel.NONE)
+            _dp(_TOMORROW, h, thunder=ThunderLevel.HIGH if h == 15 else ThunderLevel.NONE)
             for h in range(0, 24)
         ]
         seg_a = _segment(10, 47.30, 11.60, seg_a_points,
                          thunder_level_max=ThunderLevel.HIGH)
         seg_b_points = [
-            _dp(_TOMORROW, h, thunder=ThunderLevel.HIGH if h == 2 else ThunderLevel.NONE)
+            _dp(_TOMORROW, h, thunder=ThunderLevel.HIGH if h == 6 else ThunderLevel.NONE)
             for h in range(0, 24)
         ]
         seg_b = _segment(11, 47.32, 11.65, seg_b_points,
@@ -248,11 +249,11 @@ class TestPeakTimeIndependentOfSegmentOrder:
         )
 
         assert fc["+1"]["level"] == ThunderLevel.HIGH
-        assert "02:00" in fc["+1"]["text"], (
-            f"'ab HH:MM' muss die früheste HIGH-Stunde (02:00) zeigen, nicht die "
-            f"des zuerst gelisteten Segments (10:00): {fc['+1']['text']!r}"
+        assert "06:00" in fc["+1"]["text"], (
+            f"'ab HH:MM' muss die früheste HIGH-Stunde (06:00) zeigen, nicht die "
+            f"des zuerst gelisteten Segments (15:00): {fc['+1']['text']!r}"
         )
-        assert "10:00" not in fc["+1"]["text"]
+        assert "15:00" not in fc["+1"]["text"]
 
 
 class TestAC1RenderedOutputsAgree:

--- a/tests/tdd/test_thunder_forecast_trend_reuse.py
+++ b/tests/tdd/test_thunder_forecast_trend_reuse.py
@@ -82,25 +82,30 @@ class TestTrendReuseNoDoubleFetch:
                trip=None
         WHEN:  thunder_forecast abgeleitet wird
         THEN:  +2 kommt korrekt aus der Zeile; +1 ist NICHT vorhanden
-               (kein Index-Fehlgriff, der die +2-Zeile fälschlich als +1 nähme)
-               — die fehlende +1-Etappe würde einen Fetch auslösen; mit
-               trip=None crasht das → wir prüfen, dass NUR +2 aus dem Trend kommt
-               und der +1-Fetch den erwarteten AttributeError wirft.
+               (kein Index-Fehlgriff, der die +2-Zeile fälschlich als +1 nähme).
+               Die fehlende +1-Etappe löst den Fallback-Fetch aus, der ohne
+               Trip-Objekt seit #1498 (Fall 2) fail-soft leer bleibt — vorher
+               diente dessen AttributeError-Crash als Sonde; die Eigenschaft
+               beweist sich jetzt direkt am Ergebnis.
         """
-        import pytest
-
         rest_day_trend = [
             {
                 "date": _TARGET + timedelta(days=2),
                 "weekday": "Fr",
                 "name": "Nach Ruhetag",
                 "thunder": "HIGH",
-                "hourly_thunder": (HourlyValue(hour=15, value=2.0),),
+                # Issue #1474: Render-Skala {NONE:0, LOW:1, MED:2, HIGH:3} --
+                # HIGH traegt den Wert 3 (2.0 war die Vor-#1474-Skala).
+                "hourly_thunder": (HourlyValue(hour=15, value=3.0),),
             },
         ]
-        # +1 fehlt im Trend → missing_dates={+1} → Fallback-Fetch auf trip=None
-        # crasht. Das beweist zugleich, dass +2 NICHT als +1 verwechselt wurde.
-        with pytest.raises(AttributeError):
-            TripReportSchedulerService()._build_thunder_forecast_from_trend_or_fetch(
-                None, _TARGET, tz=None, multi_day_trend=rest_day_trend,
-            )
+        fc = TripReportSchedulerService()._build_thunder_forecast_from_trend_or_fetch(
+            None, _TARGET, tz=None, multi_day_trend=rest_day_trend,
+        )
+        assert "+1" not in fc, (
+            f"+2-Zeile wurde als +1 verwechselt (Index- statt Datums-Match): {fc!r}"
+        )
+        expected = (_TARGET + timedelta(days=2)).strftime("%d.%m.%Y")
+        assert fc["+2"]["date"] == expected
+        assert fc["+2"]["level"] == ThunderLevel.HIGH
+        assert fc["+2"]["hour"] == 15

--- a/tests/tdd/test_thunder_next_day_reference_by_report_type.py
+++ b/tests/tdd/test_thunder_next_day_reference_by_report_type.py
@@ -40,14 +40,16 @@ def _trend_rows_for(target: date) -> list[dict]:
             "weekday": "Tag+1",
             "name": "Etappe target+1",
             "thunder": "HIGH",
-            "hourly_thunder": (HourlyValue(hour=5, value=2.0),),
+            # Issue #1474: Render-Skala {NONE:0, LOW:1, MED:2, HIGH:3} --
+            # HIGH traegt den Wert 3 (2.0 war die Vor-#1474-Skala).
+            "hourly_thunder": (HourlyValue(hour=5, value=3.0),),
         },
         {
             "date": target + timedelta(days=2),
             "weekday": "Tag+2",
             "name": "Etappe target+2",
             "thunder": "HIGH",
-            "hourly_thunder": (HourlyValue(hour=6, value=2.0),),
+            "hourly_thunder": (HourlyValue(hour=6, value=3.0),),
         },
     ]
 

--- a/tests/unit/test_thunder_forecast_day_window.py
+++ b/tests/unit/test_thunder_forecast_day_window.py
@@ -1,0 +1,214 @@
+"""Gewitter-Vorschau der Trip-Mail: Tagesfenster statt Kalendertag (#1498, Fall 2).
+
+Repro aus dem Issue-Kommentar (Staging-Mail vom 2026-08-04): die
+„⚡ Gewitter-Vorschau" sagte „05.08.2026: Leichtes Gewitter moeglich ab
+02:00", die Nacht-Tabelle DERSELBEN Mail zeigte fuer 02:00 „kein". Beide
+Vorschau-Bauwege (Trend-Zeile UND Fallback-Fetch) lasen bisher den vollen
+Kalendertag 00-23 — also auch die Nachtstunden, fuer die die Nacht-Tabelle
+mit eigener Quelle (``night_weather``) zustaendig ist.
+
+Erwartung nach dem Fix: die Vorschau ist eine TAGES-Aussage und liest nur
+das geteilte Tagesfenster (Default 04-19, pro Trip konfigurierbar,
+``resolve_configured_window`` — dieselbe Konvention wie SMS/Telegram/
+Fusszeile, ADR-0025). Nachtstunden gehoeren der Nacht-Tabelle; die beiden
+Aussagen ueberlappen sich nicht mehr.
+
+KEINE Mocks: reale Model-Objekte, echte Scheduler-Methoden. Der Stub-Trip
+in den Konfigurations-Tests ist ein einfaches Datenobjekt (echte Attribute,
+kein Mock()/patch()).
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from zoneinfo import ZoneInfo
+
+from app.models import ThunderLevel
+
+_UTC = ZoneInfo("UTC")
+_TODAY = date(2026, 7, 3)
+_TOMORROW = date(2026, 7, 4)
+
+
+def _dp(day: date, hour: int, thunder: ThunderLevel = ThunderLevel.NONE):
+    from app.models import ForecastDataPoint
+    return ForecastDataPoint(
+        ts=datetime(day.year, day.month, day.day, hour, 0, tzinfo=timezone.utc),
+        thunder_level=thunder,
+    )
+
+
+def _segment(data_points, thunder_level_max=ThunderLevel.NONE):
+    from app.models import (
+        ForecastMeta, GPXPoint, NormalizedTimeseries, Provider,
+        SegmentWeatherData, SegmentWeatherSummary, TripSegment,
+    )
+    seg = TripSegment(
+        segment_id=1,
+        start_point=GPXPoint(lat=42.2, lon=9.05, elevation_m=400.0, distance_from_start_km=0.0),
+        end_point=GPXPoint(lat=42.25, lon=9.09, elevation_m=900.0, distance_from_start_km=6.0),
+        start_time=datetime(_TOMORROW.year, _TOMORROW.month, _TOMORROW.day, 6, 0, tzinfo=timezone.utc),
+        end_time=datetime(_TOMORROW.year, _TOMORROW.month, _TOMORROW.day, 14, 0, tzinfo=timezone.utc),
+        duration_hours=8.0, distance_km=6.0, ascent_m=500.0, descent_m=0.0,
+    )
+    meta = ForecastMeta(
+        provider=Provider.OPENMETEO, model="test",
+        run=datetime(_TODAY.year, _TODAY.month, _TODAY.day, 0, 0, tzinfo=timezone.utc),
+        grid_res_km=1.3,
+    )
+    agg = SegmentWeatherSummary(
+        temp_min_c=12.0, temp_max_c=18.0, wind_max_kmh=10.0,
+        precip_sum_mm=0.0, cloud_avg_pct=20, thunder_level_max=thunder_level_max,
+    )
+    return SegmentWeatherData(
+        segment=seg, timeseries=NormalizedTimeseries(meta=meta, data=data_points),
+        aggregated=agg, fetched_at=datetime.now(timezone.utc), provider="openmeteo",
+    )
+
+
+def _tomorrow_points(thunder_by_hour):
+    """Voller Kalendertag morgen, Gewitter nur in den genannten Stunden."""
+    return [
+        _dp(_TOMORROW, h, thunder_by_hour.get(h, ThunderLevel.NONE))
+        for h in range(0, 24)
+    ]
+
+
+# ===========================================================================
+# Fallback-Fetch-Pfad: _build_thunder_forecast()
+# ===========================================================================
+
+
+def test_fallback_nachtgewitter_ausserhalb_fenster_ist_entwarnung():
+    """Given morgen LOW NUR um 02:00 (Nacht), Tagstunden ruhig / When die
+    Vorschau gebaut wird / Then 'Kein Gewitter erwartet' — die Nacht gehoert
+    der Nacht-Tabelle, nicht der Tages-Vorschau (#1498-Repro)."""
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    seg = _segment(_tomorrow_points({2: ThunderLevel.LOW}),
+                   thunder_level_max=ThunderLevel.LOW)
+    fc = TripReportSchedulerService()._build_thunder_forecast(seg, _TODAY, tz=_UTC)
+    entry = (fc or {}).get("+1")
+    assert entry is not None, "Vorschau-Eintrag fuer morgen fehlt ganz"
+    assert entry["level"] == ThunderLevel.NONE, (
+        f"Nacht-LOW (02:00) darf die Tages-Vorschau nicht setzen: {entry!r}"
+    )
+    assert entry["text"] == "Kein Gewitter erwartet", entry["text"]
+
+
+def test_fallback_ab_stunde_kommt_aus_dem_fenster():
+    """Given LOW um 02:00 UND um 04:00 / When gebaut / Then 'ab 04:00' —
+    die frueheste Stunde IM Fenster (04 einschliesslich), nicht die
+    Nachtstunde."""
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    seg = _segment(
+        _tomorrow_points({2: ThunderLevel.LOW, 4: ThunderLevel.LOW}),
+        thunder_level_max=ThunderLevel.LOW,
+    )
+    fc = TripReportSchedulerService()._build_thunder_forecast(seg, _TODAY, tz=_UTC)
+    entry = (fc or {}).get("+1")
+    assert entry is not None
+    assert entry["level"] == ThunderLevel.LOW
+    assert entry["text"] == "Leichtes Gewitter möglich ab 04:00", entry["text"]
+    assert entry["hour"] == 4, entry
+
+
+# ===========================================================================
+# Trend-Zeilen-Pfad: _build_thunder_forecast_from_trend_or_fetch() mit
+# multi_day_trend (Abend-Default, kein Fetch)
+# ===========================================================================
+
+
+def _trend_row(thunder_by_hour, level_max):
+    from output.renderers.email.outlook import build_outlook_row
+
+    points = _tomorrow_points(thunder_by_hour)
+    seg = _segment(points, thunder_level_max=level_max)
+    row = build_outlook_row(seg.aggregated, points, "Sa", _UTC)
+    row["date"] = _TOMORROW
+    return row
+
+
+def test_trend_nachtgewitter_ausserhalb_fenster_ist_entwarnung():
+    """Derselbe Repro ueber den PRIMAEREN Bauweg (Trend-Zeile): LOW nur um
+    02:00 → 'Kein Gewitter erwartet', kein 'ab 02:00'."""
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    row = _trend_row({2: ThunderLevel.LOW}, ThunderLevel.LOW)
+    fc = TripReportSchedulerService()._build_thunder_forecast_from_trend_or_fetch(
+        None, _TODAY, _UTC, multi_day_trend=[row],
+    )
+    entry = (fc or {}).get("+1")
+    assert entry is not None, "Trend-Zeile fuer morgen wurde nicht verwendet"
+    assert entry["level"] == ThunderLevel.NONE, (
+        f"Nacht-LOW (02:00) darf die Tages-Vorschau nicht setzen: {entry!r}"
+    )
+    assert entry["text"] == "Kein Gewitter erwartet", entry["text"]
+
+
+def test_trend_ab_stunde_kommt_aus_dem_fenster():
+    """LOW um 02:00 UND um 19:00 → 'ab 19:00' (19 einschliesslich — Ende des
+    Default-Fensters), Level bleibt LOW."""
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    row = _trend_row({2: ThunderLevel.LOW, 19: ThunderLevel.LOW}, ThunderLevel.LOW)
+    fc = TripReportSchedulerService()._build_thunder_forecast_from_trend_or_fetch(
+        None, _TODAY, _UTC, multi_day_trend=[row],
+    )
+    entry = (fc or {}).get("+1")
+    assert entry is not None
+    assert entry["level"] == ThunderLevel.LOW
+    assert entry["text"] == "Leichtes Gewitter möglich ab 19:00", entry["text"]
+
+
+# ===========================================================================
+# Konfiguriertes Fenster (Epic #1319 Scheibe B): pro Trip, inkl. Wrap
+# ===========================================================================
+
+
+class _StubReportConfig:
+    def __init__(self, start, end):
+        self.day_window_start_hour = start
+        self.day_window_end_hour = end
+
+
+class _StubTrip:
+    """Echtes Datenobjekt (kein Mock): nur die zwei Zugriffe, die
+    _build_thunder_forecast_from_trend_or_fetch auf dem Trip macht."""
+
+    def __init__(self, start, end):
+        self.report_config = _StubReportConfig(start, end)
+
+    def get_future_stages(self, target_date):
+        return []
+
+
+def test_konfiguriertes_fenster_wird_beachtet():
+    """Given Trip-Fenster 06-18 / When LOW um 05:00 / Then Entwarnung —
+    05:00 liegt vor dem konfigurierten Fensterbeginn."""
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    row = _trend_row({5: ThunderLevel.LOW}, ThunderLevel.LOW)
+    fc = TripReportSchedulerService()._build_thunder_forecast_from_trend_or_fetch(
+        _StubTrip(6, 18), _TODAY, _UTC, multi_day_trend=[row],
+    )
+    entry = (fc or {}).get("+1")
+    assert entry is not None
+    assert entry["level"] == ThunderLevel.NONE, entry
+    assert entry["text"] == "Kein Gewitter erwartet", entry["text"]
+
+
+def test_mitternachts_fenster_wrap_zaehlt_nachtstunden():
+    """Given Trip-Fenster 22-2 (ueber Mitternacht, #1361/#1372 S1b gueltig) /
+    When LOW um 23:00, Mittag ruhig / Then 'ab 23:00' — im Wrap-Fenster ist
+    die Nachtstunde die konfigurierte Tages-Aussage."""
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    row = _trend_row({23: ThunderLevel.LOW}, ThunderLevel.LOW)
+    fc = TripReportSchedulerService()._build_thunder_forecast_from_trend_or_fetch(
+        _StubTrip(22, 2), _TODAY, _UTC, multi_day_trend=[row],
+    )
+    entry = (fc or {}).get("+1")
+    assert entry is not None
+    assert entry["level"] == ThunderLevel.LOW
+    assert entry["text"] == "Leichtes Gewitter möglich ab 23:00", entry["text"]


### PR DESCRIPTION
## Was

Fall 2 aus #1498 (Issue-Kommentar, an echt zugestellter Staging-Mail belegt): Die „⚡ Gewitter-Vorschau" der Trip-Mail sagte „Leichtes Gewitter möglich **ab 02:00**", die Nacht-Tabelle **derselben Mail** zeigte für 02:00 „kein". Wurzel: beide Vorschau-Bauwege (Trend-Zeile `_thunder_entry_from_trend_row` und Fallback-Fetch `_build_thunder_forecast`) lasen den **vollen Kalendertag 00–23** — auch die Nachtstunden, für die die Nacht-Tabelle mit eigener Quelle (`night_weather`) zuständig ist.

## Wie

- **Tagesfenster statt Kalendertag:** Beide Bauwege klemmen auf das geteilte Tagesfenster (Default 04–19, pro Trip konfigurierbar via `report_config`, wrap-fähig über Mitternacht, z.B. 22–2) — dieselbe ADR-0025-Konvention wie SMS, Telegram-Fußzeile und (seit PR #1524) Telegram-Kurzübersicht. Nachtstunden gehören der Nacht-Tabelle; die Aussagen überlappen sich nicht mehr.
- **Level aus Fenster-Proben:** Im Trend-Bauweg kommt der Level jetzt aus den `hourly_thunder`-Proben im Fenster (Rückabbildung über die geteilte Render-Skala, Sortierung über `thunder_ordinal` — keine Skalen-Handkopie, #1474-Lehre). `row["thunder"]` (Kalendertags-Maximum) bleibt nur als Fail-soft ohne Fenster-Proben — nie eine blinde Entwarnung (#1331-Lehre).
- **Neutrale Heimat `app/day_window.py`:** Der Scheduler darf per Architektur-Wache nichts aus `output` importieren; Konstanten + `resolve_configured_window` sind dorthin gezogen (Vorbild `app/thunder_scale.py`), `output/renderers/day_window.py` re-exportiert — kein bestehender Import bricht. Neu: wrap-aware `hour_in_window()`.
- **Ehrliche Lücke:** Ohne Datenpunkt im Fenster entsteht kein Vorschau-Eintrag → greift in `_gap_offsets` (#1482) als „?" statt Entwarnung.
- **Beifang:** `trip=None` (dokumentierter Vorschau-Pfad) stürzte in `_collect_future_stage_weather` mit `AttributeError` ab, sobald der Trend einen Offset nicht abdeckte — Fail-soft-Guard ergänzt (Docstring versprach das bereits).

## Tests

- **Neu:** `tests/unit/test_thunder_forecast_day_window.py` — Issue-Repro über **beide** Bauwege (RED zeigte „ab 02:00", jetzt „Kein Gewitter erwartet"), „ab"-Stunde aus dem Fenster (Grenzen 04/19 einschließlich), konfiguriertes Fenster, Mitternachts-Wrap.
- **Mutations-Gegenprobe:** 4 Verfälschungen (Fenster-Filter raus, Kalendertags-Level zurück, Wrap verfälscht, Konfiguration ignoriert) — alle von Tests gefangen.
- **Bestand saniert:** 2 Fixtures trugen noch die Vor-#1474-Skala (`value=2.0` als „HIGH") — unsichtbar, solange niemand die Samples als Level las; auf kanonisch 3.0 gehoben. Der Reihenfolge-Test nutzte die Nachtstunde 02:00 als Fixture (auf Fenster-Stunden umgestellt, Eigenschaft bleibt bewacht); der Datums-Match-Test nutzte den nun behobenen `trip=None`-Crash als Sonde (beweist die Eigenschaft jetzt direkt am Ergebnis).
- **Volllauf:** CI-äquivalent lokal — verbleibende Rote sind ausschließlich die bekannte Container-Artefakt-Klasse „gepinnter Playwright-Browser fehlt" (5× `test_issue_956_email_pixel_diff.py`, 2× `test_design_diff_requires_authenticated_page.py`; auf CI grün).

## Bezug

- Issue #1498 (bleibt offen: Staging-Funktionsprobe beider Fälle steht aus — Server-Session)
- Vorgänger: PR #1524 (Telegram-Fall, gemerged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrmdarWn7RjtQ3q3rCumn6

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrmdarWn7RjtQ3q3rCumn6)_