### PR TITLE
fix(#1403): Sofort-Versand meldet keinen Erfolg mehr ohne echten Versand

### DIFF
--- a/api/routers/scheduler.py
+++ b/api/routers/scheduler.py
@@ -204,6 +204,34 @@ def send_test_trip_report(trip_id: str, user_id: str = "default", report_type: s
             status_code=422,
             detail=f"Kein Briefing für {report_type} — keine Wetterdaten für die gewählte Etappe verfügbar",
         )
+    # Issue #1403: "no_channels" bedeutet Etappe+Wetter waren da, aber E-Mail,
+    # Telegram und SMS sind alle deaktiviert — bisher fiel das fälschlich auf
+    # die Erfolgsantwort {"sent": true} durch. Analog zu "no_stage"/"no_weather"
+    # oben: eigener 422-Zweig mit sprechendem Grund statt stillem Erfolg.
+    if outcome == "no_channels":
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Kein Briefing für {report_type} versendet — kein "
+                "Versandweg aktiv (E-Mail, Telegram und SMS sind alle "
+                "deaktiviert)"
+            ),
+        )
+    # Issue #1403 AC-4: anderer Auslöser, gleiches Symptom — mindestens ein
+    # Versandweg war konfiguriert (send_telegram/send_sms/send_email=true),
+    # aber technisch nicht erreichbar (z.B. Telegram ohne gültige Bot-
+    # Verbindung), sodass kein einziger Kanal tatsächlich betreten wurde.
+    # Eigene Meldung, damit sie sich von "no_channels" (Konfiguration) und
+    # nicht mit ihr verwechseln lässt.
+    if outcome == "channels_unreachable":
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Kein Briefing für {report_type} versendet — Versandweg "
+                "konfiguriert, aber nicht einsatzbereit (Kanal technisch "
+                "nicht erreichbar)"
+            ),
+        )
     return {"status": "ok", "trip_id": trip_id, "report_type": report_type, "sent": True}
 
 

--- a/src/services/trip_command_processor.py
+++ b/src/services/trip_command_processor.py
@@ -239,7 +239,8 @@ _DRILLDOWN_METRICS: dict[str, tuple] = {
 def _on_demand_failure_body(outcome: str, label: str, target_date: date) -> str:
     """Formatiert den Antworttext für einen nicht-erfolgreichen On-Demand-Versand.
 
-    outcome: "no_stage" | "no_weather" | "no_channels" (alles außer "sent").
+    outcome: "no_stage" | "no_weather" | "no_channels" | "channels_unreachable"
+    (alles außer "sent").
     """
     human_date = f"{target_date:%d.%m.%Y}"
     if outcome == "no_weather":
@@ -251,6 +252,15 @@ def _on_demand_failure_body(outcome: str, label: str, target_date: date) -> str:
         return (
             "Keine Versandkanäle für diesen Trip aktiv — Briefing nicht "
             "gesendet. Kanäle im Trip-Editor aktivieren."
+        )
+    # Issue #1403 AC-4: Versandweg konfiguriert, aber technisch nicht
+    # erreichbar (z.B. Telegram ohne gültige Bot-Verbindung) — eigene
+    # Meldung, damit sie sich nicht mit "no_channels" (Konfiguration)
+    # verwechseln lässt.
+    if outcome == "channels_unreachable":
+        return (
+            "Versandweg für diesen Trip konfiguriert, aber nicht erreichbar "
+            "— Briefing nicht gesendet. Verbindung prüfen."
         )
     # "no_stage" (Default/Fallback)
     return f"{label} ({human_date}): Keine Etappe geplant"

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -635,7 +635,8 @@ class TripReportSchedulerService:
             report_type: "morning" or "evening"
 
         Returns:
-            Outcome string: "sent" | "no_stage" | "no_weather" | "no_channels"
+            Outcome string: "sent" | "no_stage" | "no_weather" | "no_channels" |
+            "channels_unreachable"
 
         Raises:
             ValueError: If report_type is invalid
@@ -658,7 +659,8 @@ class TripReportSchedulerService:
             report_type: "morning" (heute) or "evening" (morgen)
 
         Returns:
-            Outcome string: "sent" | "no_stage" | "no_weather" | "no_channels"
+            Outcome string: "sent" | "no_stage" | "no_weather" | "no_channels" |
+            "channels_unreachable"
             (Issue #1007 Adversary-Fix F001/F002 — Outcome-Unterscheidung statt
             eines bloßen bool, damit der Aufrufer "keine Etappe" von "keine
             Wetterdaten" und von "kein Kanal aktiv" unterscheiden kann).
@@ -714,7 +716,9 @@ class TripReportSchedulerService:
         Returns:
             "no_stage" if no matching stage, "no_weather" if the weather
             fetch failed, "no_channels" if stage+weather were fine but no
-            channel is configured for the trip, "sent" otherwise.
+            channel is configured for the trip, "channels_unreachable" if a
+            channel was configured but none was actually reached (Issue
+            #1403 AC-4), "sent" otherwise.
 
         Raises:
             Exception: If weather fetch or email send fails
@@ -945,10 +949,29 @@ class TripReportSchedulerService:
         # Issue #393: Briefing-Log für Cockpit-Kachel "Was geht heute raus".
         # Issue #1007 Adversary-Fix F001: bei explizit konfiguriertem "kein
         # Kanal aktiv" wird KEIN Log-Eintrag mit channels=[] geschrieben.
-        if not result.no_channel_configured:
+        # Issue #1403: dieselbe Unterscheidung gilt für die Protokollzeile —
+        # "Trip report sent" nur bei tatsächlichem Versand, sonst eine
+        # abweichende Warnzeile, damit echter und ausgebliebener Versand im
+        # Protokoll unterscheidbar sind.
+        # Issue #1403 AC-4: ein Kanal kann konfiguriert, aber technisch nicht
+        # erreichbar sein (z.B. Telegram ohne gültige Bot-Verbindung) —
+        # result.sent_channels bleibt dann leer, obwohl no_channel_configured
+        # False ist (result.sent ist die ehrliche Zustellfähigkeits-Aussage,
+        # notification_service.py:408). Gleiche Konsequenz wie beim
+        # "kein Kanal aktiv"-Fall: kein briefing_log-Eintrag (sonst täuscht ein
+        # Eintrag mit channels=[] der Cockpit-Kachel #393/#1007 einen Versand
+        # vor), aber eine eigene, unterscheidbare Protokollzeile.
+        if result.no_channel_configured:
+            logger.warning(
+                f"Trip report NOT sent (no channel configured): {trip.name} ({report_type})"
+            )
+        elif not result.sent:
+            logger.warning(
+                f"Trip report NOT sent (configured channel unreachable): {trip.name} ({report_type})"
+            )
+        else:
             self._append_briefing_log(trip.id, report_type, result.sent_channels)
-
-        logger.info(f"Trip report sent: {trip.name} ({report_type})")
+            logger.info(f"Trip report sent: {trip.name} ({report_type})")
 
         # 9. Issue #1012: Teilausfall-Marker (Service-Error-Mail wurde bereits
         # vom NotificationService verschickt, weil failed_segments im Request
@@ -992,7 +1015,14 @@ class TripReportSchedulerService:
             briefing_entity_type="trip",
         )
 
-        return "no_channels" if result.no_channel_configured else "sent"
+        if result.no_channel_configured:
+            return "no_channels"
+        if not result.sent:
+            # Issue #1403 AC-4: konfiguriert, aber kein Kanal tatsächlich
+            # betreten (z.B. Telegram ohne gültige Bot-Verbindung) — ehrlich
+            # unterscheidbar vom "no_channels"-Fall oben.
+            return "channels_unreachable"
+        return "sent"
 
     def _build_trip_report_request(
         self,

--- a/tests/unit/test_trip_send_endpoint_no_channels.py
+++ b/tests/unit/test_trip_send_endpoint_no_channels.py
@@ -1,0 +1,391 @@
+"""
+Issue #1403: Sofort-Versand meldet keinen Erfolg mehr, wenn fuer den Trip
+kein einziger Versandweg aktiv ist.
+
+Spec/Workflow: fix-1403-versand-antwort-ehrlich
+
+Verhaltenstests -- kein Mock-Theater. Ein datumsbezogener Provider-Double
+liefert echte, aufgezeichnete Innsbruck-Fixturdaten fuer "heute" (identisches
+Muster zu tests/tdd/test_trip_report_test_send_past_stage_clamp.py, Issue
+#1325) -- Rendering, Outcome-Ableitung und die Router-Antwort bleiben
+unveraendert echter Code. Der SMTP-Transport wird per monkeypatch durch
+einen No-Op ersetzt (reines Netzgrenze-Substitut), damit dieser Kern-Test
+netzfrei bleibt.
+
+AC-1: Trip mit send_email=false/send_telegram=false/send_sms=false ->
+      POST .../send liefert 422 mit sprechendem Grund statt 200 sent:true.
+AC-2: Im selben Fall erscheint NICHT die Protokollzeile "Trip report sent:
+      ..." -- stattdessen eine unterscheidbare Warnzeile.
+AC-3: Trip mit mindestens einem aktiven Versandweg bleibt unveraendert:
+      200 sent:true, briefing_log.json-Eintrag, "Trip report sent"-Zeile.
+AC-4: Trip mit konfiguriertem, aber technisch nicht erreichbarem Versandweg
+      (z.B. Telegram ohne gueltige Bot-Verbindung) -> derselbe 422-Fehlschlag,
+      aber mit einer von AC-1 UNTERSCHIEDLICHEN Meldung ("nicht erreichbar"
+      statt "nicht aktiv") -- kein briefing_log-Eintrag, keine "Trip report
+      sent"-Zeile.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date
+from pathlib import Path
+
+import pytest
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[2] / ".env")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Test-Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _innsbruck_waypoints() -> list[dict]:
+    return [
+        {"id": "wp1", "name": "Innsbruck", "lat": 47.2692, "lon": 11.4041, "elevation_m": 574},
+        {"id": "wp2", "name": "Hafelekar", "lat": 47.3103, "lon": 11.3844, "elevation_m": 2269},
+    ]
+
+
+def _write_trip(user_id: str, trip_id: str, report_config: dict) -> Path:
+    """Issue #1133/#1265: get_data_dir()/get_briefings_dir() statt eines
+    hartkodierten Repo-Pfads, damit dieselbe Datei existiert, die der
+    TestClient unter der aktiven Fixture-Isolation liest."""
+    from app.loader import get_briefings_dir, get_data_dir
+
+    briefings_dir = get_briefings_dir(user_id)
+    briefings_dir.mkdir(parents=True, exist_ok=True)
+    profile = get_data_dir(user_id) / "user.json"
+    profile.write_text(json.dumps({"mail_to": "gregor-test@henemm.com"}))
+
+    trip_path = briefings_dir / f"{trip_id}.json"
+    trip_path.write_text(json.dumps({
+        "id": trip_id,
+        "name": "TDD-1403 Trip",
+        "kind": "route",
+        "stages": [{
+            "id": "st-today",
+            "name": "Etappe heute",
+            "date": date.today().isoformat(),
+            "waypoints": _innsbruck_waypoints(),
+        }],
+        # official_alerts_enabled=False: strukturell kein MeteoAlarm-Fetch
+        # (Kern-Test bleibt netzfrei, s. trip_report_scheduler.py:784).
+        "official_alerts_enabled": False,
+        "report_config": report_config,
+        "alert_rules": [],
+    }))
+    return trip_path
+
+
+@pytest.fixture
+def trip_no_channels():
+    """Trip mit allen drei Versandwegen deaktiviert (Issue #1403 Kernfall)."""
+    user_id = "tdd-1403-no-channels"
+    trip_id = "tdd-1403-no-channels-trip"
+    trip_path = _write_trip(user_id, trip_id, {
+        "send_email": False, "send_telegram": False, "send_sms": False,
+    })
+    yield user_id, trip_id
+    trip_path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def trip_with_email_channel():
+    """Trip mit aktivem E-Mail-Versandweg (Regressions-Gegenprobe AC-3)."""
+    user_id = "tdd-1403-with-channel"
+    trip_id = "tdd-1403-with-channel-trip"
+    trip_path = _write_trip(user_id, trip_id, {
+        "send_email": True, "send_telegram": False, "send_sms": False,
+    })
+    yield user_id, trip_id
+    trip_path.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def trip_with_unreachable_telegram():
+    """Trip mit send_telegram=true, aber Settings.can_send_telegram() wird
+    per monkeypatch auf False gesetzt (Issue #1403 AC-4: Kanal konfiguriert,
+    technisch nicht erreichbar -- z.B. Telegram ohne gueltige Bot-Verbindung).
+    send_email/send_sms bleiben false, damit ausschliesslich der
+    unerreichbare Kanal ueber den Ausgang entscheidet."""
+    user_id = "tdd-1403-unreachable"
+    trip_id = "tdd-1403-unreachable-trip"
+    trip_path = _write_trip(user_id, trip_id, {
+        "send_email": False, "send_telegram": True, "send_sms": False,
+    })
+    yield user_id, trip_id
+    trip_path.unlink(missing_ok=True)
+
+
+def _patch_telegram_unreachable(monkeypatch) -> None:
+    """Netzgrenze-Substitut: Telegram ist konfiguriert (globale Bot-Credentials
+    in .env), aber die Zustellfaehigkeits-Pruefung meldet 'nicht erreichbar' --
+    identisch zu einem ungueltigen Bot-Token/Chat, ohne echten Netzwerk-Call."""
+    monkeypatch.setattr("app.config.Settings.can_send_telegram", lambda self: False)
+
+
+# ---------------------------------------------------------------------------
+# Datumsbezogener Provider-Double (Netzgrenze-Substitut, kein Mock-Theater)
+# ---------------------------------------------------------------------------
+
+
+class _TodayOnlyOpenMeteoDouble:
+    """Liefert echte, real aufgezeichnete Innsbruck-Fixturdaten fuer 'heute'
+    (delegiert an FixtureProvider) -- identisches Muster zu Issue #1325."""
+
+    name = "openmeteo"
+
+    def __init__(self) -> None:
+        from providers.fixture import FixtureProvider
+        self._fixture = FixtureProvider(str(REPO_ROOT / "fixtures" / "openmeteo"))
+
+    def fetch_forecast(self, location, start=None, end=None,
+                        enrich_ensemble=True, enrich_snow=True):
+        return self._fixture.fetch_forecast(
+            location, start=start, end=end,
+            enrich_ensemble=enrich_ensemble, enrich_snow=enrich_snow,
+        )
+
+
+def _patch_provider(monkeypatch) -> None:
+    double = _TodayOnlyOpenMeteoDouble()
+    monkeypatch.setattr("providers.base.get_provider", lambda name: double)
+
+
+def _patch_email_transport(monkeypatch) -> None:
+    """Netzgrenze-Substitut fuer den SMTP-Transport -- ersetzt NUR den
+    ausgehenden Netzwerk-Call, Rendering/Outcome-Ableitung bleiben echt."""
+    monkeypatch.setattr(
+        "services.notification_service.NotificationService._send_email",
+        lambda self, report: None,
+    )
+
+
+def _client():
+    from api.main import app
+    from fastapi.testclient import TestClient
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# AC-1: kein aktiver Versandweg -> 422 statt stillem 200-Erfolg
+# ---------------------------------------------------------------------------
+
+
+class TestAC1NoChannelsReturns422:
+    def test_no_active_channel_returns_422_not_200(
+        self, trip_no_channels, monkeypatch,
+    ):
+        """RED vor Fix: Endpoint gab {"status": "ok", "sent": True} zurueck,
+        obwohl send_email/send_telegram/send_sms alle False sind."""
+        _patch_provider(monkeypatch)
+        _patch_email_transport(monkeypatch)
+
+        user_id, trip_id = trip_no_channels
+        resp = _client().post(
+            f"/api/scheduler/trips/{trip_id}/send",
+            params={"user_id": user_id, "report_type": "morning"},
+        )
+        assert resp.status_code == 422, (
+            f"Erwartet 422 wenn kein Versandweg aktiv ist, bekommen: "
+            f"{resp.status_code}. Body: {resp.text}\n"
+            "BUG #1403: stiller Erfolg trotz keinem aktiven Versandweg."
+        )
+        body = resp.json()
+        assert "detail" in body, f"Kein 'detail'-Feld in 422-Antwort: {body}"
+        detail_lower = body["detail"].lower()
+        assert "versandweg" in detail_lower or "kanal" in detail_lower, (
+            f"'detail' sollte den fehlenden Versandweg benennen: {body['detail']}"
+        )
+
+    def test_no_active_channel_response_has_no_sent_true(
+        self, trip_no_channels, monkeypatch,
+    ):
+        """Regressionssicherung: das fruehere {"sent": true} darf im
+        Fehlerfall unter keinem Feldnamen mehr auftauchen."""
+        _patch_provider(monkeypatch)
+        _patch_email_transport(monkeypatch)
+
+        user_id, trip_id = trip_no_channels
+        resp = _client().post(
+            f"/api/scheduler/trips/{trip_id}/send",
+            params={"user_id": user_id, "report_type": "morning"},
+        )
+        assert resp.json().get("sent") is not True, (
+            f"Antwort darf kein 'sent: true' enthalten: {resp.json()}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Protokollzeile unterscheidet echten von ausgebliebenem Versand
+# ---------------------------------------------------------------------------
+
+
+class TestAC2LogLineDistinguishesOutcome:
+    def test_no_channels_case_does_not_log_trip_report_sent(
+        self, trip_no_channels, monkeypatch, caplog,
+    ):
+        """RED vor Fix: logger.info("Trip report sent: ...") lief
+        unbedingt, auch wenn kein Kanal aktiv war -- ununterscheidbar von
+        einem echten Versand im Protokoll."""
+        from app.loader import load_trip
+        from app.loader import get_briefings_dir
+        from services.trip_report_scheduler import TripReportSchedulerService
+
+        _patch_provider(monkeypatch)
+        _patch_email_transport(monkeypatch)
+
+        user_id, trip_id = trip_no_channels
+        trip = load_trip(get_briefings_dir(user_id) / f"{trip_id}.json")
+        service = TripReportSchedulerService(user_id=user_id)
+
+        with caplog.at_level(logging.INFO, logger="trip_report_scheduler"):
+            outcome = service.send_test_report_outcome(trip, "morning")
+
+        assert outcome == "no_channels", f"Erwartet 'no_channels', bekommen {outcome!r}"
+        sent_lines = [r.message for r in caplog.records if "Trip report sent:" in r.message]
+        assert sent_lines == [], (
+            f"'Trip report sent'-Zeile darf bei no_channels NICHT erscheinen: {sent_lines}"
+        )
+        warning_lines = [
+            r.message for r in caplog.records
+            if r.levelno == logging.WARNING and "not sent" in r.message.lower()
+        ]
+        assert warning_lines, (
+            "Erwartet eine Warnzeile, die den ausgebliebenen Versand benennt "
+            f"-- bekommen: {[r.message for r in caplog.records]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-3: mit aktivem Versandweg bleibt alles unveraendert (Regression)
+# ---------------------------------------------------------------------------
+
+
+class TestAC3ActiveChannelUnchanged:
+    def test_active_email_channel_still_returns_200_sent_true(
+        self, trip_with_email_channel, monkeypatch,
+    ):
+        _patch_provider(monkeypatch)
+        _patch_email_transport(monkeypatch)
+
+        user_id, trip_id = trip_with_email_channel
+        resp = _client().post(
+            f"/api/scheduler/trips/{trip_id}/send",
+            params={"user_id": user_id, "report_type": "morning"},
+        )
+        assert resp.status_code == 200, (
+            f"Erwartet 200 bei aktivem Versandweg, bekommen {resp.status_code}: {resp.text}"
+        )
+        assert resp.json().get("sent") is True, resp.json()
+
+    def test_active_email_channel_writes_briefing_log_and_sent_line(
+        self, trip_with_email_channel, monkeypatch, caplog,
+    ):
+        from app.loader import load_trip
+        from app.loader import get_briefings_dir, get_data_dir
+        from services.trip_report_scheduler import TripReportSchedulerService
+
+        _patch_provider(monkeypatch)
+        _patch_email_transport(monkeypatch)
+
+        user_id, trip_id = trip_with_email_channel
+        trip = load_trip(get_briefings_dir(user_id) / f"{trip_id}.json")
+        service = TripReportSchedulerService(user_id=user_id)
+
+        with caplog.at_level(logging.INFO, logger="trip_report_scheduler"):
+            outcome = service.send_test_report_outcome(trip, "morning")
+
+        assert outcome == "sent", f"Erwartet 'sent', bekommen {outcome!r}"
+        sent_lines = [r.message for r in caplog.records if "Trip report sent:" in r.message]
+        assert sent_lines, (
+            "Erwartet unveraendert die 'Trip report sent'-Zeile bei echtem Versand"
+        )
+
+        log_path = get_data_dir(user_id) / "briefing_log.json"
+        assert log_path.exists(), "briefing_log.json muss bei echtem Versand geschrieben werden"
+        entries = json.loads(log_path.read_text())["entries"]
+        assert any(e["trip_id"] == trip_id for e in entries), (
+            f"Kein Eintrag fuer {trip_id} in briefing_log.json: {entries}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-4: konfigurierter, aber technisch nicht erreichbarer Kanal -> derselbe
+# 422-Fehlschlag wie AC-1, aber mit unterscheidbarer Meldung/Protokollzeile
+# ---------------------------------------------------------------------------
+
+
+class TestAC4ConfiguredButUnreachableChannel:
+    def test_unreachable_telegram_returns_422_distinct_from_no_channels(
+        self, trip_with_unreachable_telegram, monkeypatch,
+    ):
+        """RED vor Fix: Endpoint gab {"sent": true} zurueck, obwohl Telegram
+        konfiguriert, aber technisch nicht erreichbar war (sent_channels==[]).
+        Nach Fix: 422 mit einer Meldung, die sich von AC-1 ("nicht aktiv")
+        unterscheidet ("nicht erreichbar")."""
+        _patch_provider(monkeypatch)
+        _patch_telegram_unreachable(monkeypatch)
+
+        user_id, trip_id = trip_with_unreachable_telegram
+        resp = _client().post(
+            f"/api/scheduler/trips/{trip_id}/send",
+            params={"user_id": user_id, "report_type": "morning"},
+        )
+        assert resp.status_code == 422, (
+            f"Erwartet 422 wenn der konfigurierte Kanal unerreichbar ist, "
+            f"bekommen: {resp.status_code}. Body: {resp.text}\n"
+            "BUG #1403 AC-4: stiller Erfolg trotz technisch unerreichbarem Kanal."
+        )
+        detail_lower = resp.json().get("detail", "").lower()
+        assert "erreichbar" in detail_lower, (
+            f"'detail' sollte die technische Unerreichbarkeit benennen: {resp.json()}"
+        )
+        assert "kein versandweg aktiv" not in detail_lower, (
+            "Meldung darf sich NICHT mit dem 'no_channels'-Fall (AC-1) "
+            f"verwechseln lassen: {resp.json()}"
+        )
+
+    def test_unreachable_telegram_does_not_log_sent_or_write_briefing_log(
+        self, trip_with_unreachable_telegram, monkeypatch, caplog,
+    ):
+        from app.loader import get_briefings_dir, get_data_dir, load_trip
+        from services.trip_report_scheduler import TripReportSchedulerService
+
+        _patch_provider(monkeypatch)
+        _patch_telegram_unreachable(monkeypatch)
+
+        user_id, trip_id = trip_with_unreachable_telegram
+        trip = load_trip(get_briefings_dir(user_id) / f"{trip_id}.json")
+        service = TripReportSchedulerService(user_id=user_id)
+
+        with caplog.at_level(logging.INFO, logger="trip_report_scheduler"):
+            outcome = service.send_test_report_outcome(trip, "morning")
+
+        assert outcome == "channels_unreachable", (
+            f"Erwartet 'channels_unreachable', bekommen {outcome!r}"
+        )
+        sent_lines = [r.message for r in caplog.records if "Trip report sent:" in r.message]
+        assert sent_lines == [], (
+            f"'Trip report sent'-Zeile darf bei channels_unreachable NICHT erscheinen: {sent_lines}"
+        )
+        warning_lines = [
+            r.message for r in caplog.records
+            if r.levelno == logging.WARNING and "unreachable" in r.message.lower()
+        ]
+        assert warning_lines, (
+            "Erwartet eine eigene Warnzeile fuer den unerreichbaren Kanal "
+            f"-- bekommen: {[r.message for r in caplog.records]}"
+        )
+
+        log_path = get_data_dir(user_id) / "briefing_log.json"
+        entries = json.loads(log_path.read_text())["entries"] if log_path.exists() else []
+        assert not any(e["trip_id"] == trip_id for e in entries), (
+            f"Kein briefing_log-Eintrag erwartet (kein Kanal tatsaechlich "
+            f"betreten): {entries}"
+        )

--- a/tests/unit/test_trip_send_endpoint_no_channels.py
+++ b/tests/unit/test_trip_send_endpoint_no_channels.py
@@ -166,6 +166,17 @@ def _patch_email_transport(monkeypatch) -> None:
     )
 
 
+def _patch_can_send_email(monkeypatch) -> None:
+    """Hermetik: der Router-Vorbedingungs-Riegel (`can_send_email()`,
+    api/routers/scheduler.py:183 -- prueft global konfigurierte SMTP-Zugangs-
+    daten, unabhaengig vom hier getesteten Trip) ist KEIN Teil der in diesem
+    Modul geprueften Zusicherung (AC-1/AC-3/AC-4). Ohne diesen Patch haengt
+    das Testergebnis davon ab, ob am Ausfuehrungsort eine .env mit SMTP-
+    Credentials existiert (lokal ja, auf dem CI-Runner nein) -- genau die
+    Umgebungsabhaengigkeit, die den Testfall sonst nicht hermetisch macht."""
+    monkeypatch.setattr("app.config.Settings.can_send_email", lambda self: True)
+
+
 def _client():
     from api.main import app
     from fastapi.testclient import TestClient
@@ -185,6 +196,7 @@ class TestAC1NoChannelsReturns422:
         obwohl send_email/send_telegram/send_sms alle False sind."""
         _patch_provider(monkeypatch)
         _patch_email_transport(monkeypatch)
+        _patch_can_send_email(monkeypatch)
 
         user_id, trip_id = trip_no_channels
         resp = _client().post(
@@ -210,6 +222,7 @@ class TestAC1NoChannelsReturns422:
         Fehlerfall unter keinem Feldnamen mehr auftauchen."""
         _patch_provider(monkeypatch)
         _patch_email_transport(monkeypatch)
+        _patch_can_send_email(monkeypatch)
 
         user_id, trip_id = trip_no_channels
         resp = _client().post(
@@ -273,6 +286,7 @@ class TestAC3ActiveChannelUnchanged:
     ):
         _patch_provider(monkeypatch)
         _patch_email_transport(monkeypatch)
+        _patch_can_send_email(monkeypatch)
 
         user_id, trip_id = trip_with_email_channel
         resp = _client().post(
@@ -331,6 +345,7 @@ class TestAC4ConfiguredButUnreachableChannel:
         unterscheidet ("nicht erreichbar")."""
         _patch_provider(monkeypatch)
         _patch_telegram_unreachable(monkeypatch)
+        _patch_can_send_email(monkeypatch)
 
         user_id, trip_id = trip_with_unreachable_telegram
         resp = _client().post(


### PR DESCRIPTION
Der Endpoint POST /api/scheduler/trips/{id}/send gab sent:true als
festverdrahtetes Literal zurueck und fing nur no_stage/no_weather ab.
War fuer den Trip kein Versandweg aktiv, fiel der Fall auf die
Erfolgsantwort durch — und die Protokollzeile "Trip report sent" lief
unbedingt, also auch dann.

- AC-1: no_channels -> HTTP 422 mit Grund, analog no_stage/no_weather
- AC-2: "Trip report sent" nur noch bei echtem Versand; sonst eigene
  Warnzeile. Echter und ausgebliebener Versand sind unterscheidbar.
- AC-3: mit aktivem Kanal unveraendert (Antwort, Versand, briefing_log)
- AC-4: konfigurierter, aber nicht erreichbarer Kanal (sent_channels
  leer) liefert eigenen Outcome channels_unreachable + eigene
  422-Meldung. Nutzt result.sent, keine neue Wahrheitsquelle.
  Kein briefing_log-Eintrag mit channels=[] (Cockpit-Kachel #393/#1007).
- On-Demand-Pfad (trip_command_processor) bekommt den neuen Outcome
  zugeordnet, sonst haette er faelschlich "Keine Etappe geplant" gemeldet.

Adversary VERIFIED (3 Runden, 8 von 8 Mutationen gefangen). Der urspruengliche
Ticket-Befund war ein Messfehler (falsches Testpostfach) und ist im Issue
widerlegt; dieser Fix behebt den dabei gefundenen echten Defekt.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
