### PR TITLE
fix(#1492 S1): Gewitteraussage und Hagel ueberleben den Modell-Metrik-Ausfall

### DIFF
--- a/docs/context/feat-1492-gewitter-fallback-kette.md
+++ b/docs/context/feat-1492-gewitter-fallback-kette.md
@@ -1,0 +1,190 @@
+# Kontext & Analyse: #1492 — Gewitter S4, Ausfallschutz
+
+**Workflow:** `feat-1492-gewitter-fallback-kette` · **Stand:** 2026-08-05, gemessen an `94e4f331`
+**PO-Entscheidung 2026-08-05:** voller Umfang (inkl. Mehrquellen-Redundanz), nicht nur der kleine Fix.
+
+> Hinweis: Ein gleichnamiges Kontext-Dokument aus dem Vorlauf vom 2026-08-04 existiert nirgends
+> mehr (weder Worktree, Hauptrepo noch Git-Verlauf) — vermutlich mit einem aufgeräumten
+> Arbeitsbereich verloren. Die Befunde von damals sind im Issue-Kommentar zu #1492 erhalten und
+> unten eingearbeitet. Dieses Dokument ersetzt es.
+
+## Type
+
+Feature (Architektur-relevant, ADR-pflichtig)
+
+---
+
+## 1. Was das Ticket will — und wo die Wirklichkeit abweicht
+
+Ticket-Prämisse: „Gewitter überlebt den Providerausfall." Die Analyse zeigt **zwei getrennte
+Ausfallarten** mit sehr unterschiedlicher Schwere:
+
+| # | Ausfallart | Heute | Folge für den Nutzer | Schwere |
+|---|---|---|---|---|
+| **A1** | Open-Meteo-Primärmodell liefert kein `weather_code` | Ersatzmodell wird abgerufen und liefert es — aber die Zusammenführung verwirft es still | **Gewitteraussage verschwindet komplett** | 🔴 hoch |
+| **A2** | Direktquelle (Météo-France WCS / DWD GRIB) fällt aus | fail-soft, Signalfelder bleiben `None` | Aussage bleibt, wird nur **gröber** (nur Wettercode + CAPE) | 🟠 mittel |
+
+Das Ticket zielte auf A2. **A1 ist der gravierendere, bisher unbemerkte Fall** — dort geht die
+Aussage ganz verloren, nicht nur an Schärfe.
+
+---
+
+## 2. Teil A1 — `weather_code` wird beim Modell-Fallback verworfen
+
+### Mechanik (belegt)
+
+- `PROBE_PARAMS` (`openmeteo.py:207-214`) enthält `weather_code` ⇒ es kann als „fehlend" erkannt werden
+- Der Ersatz-Abruf fordert `weather_code` mit an (`openmeteo.py:1112`)
+- `_PARAM_TO_FIELD` (`openmeteo.py:378-397`, 18 Einträge) enthält **kein** `weather_code`
+- `merge_missing_fields` (`merge.py:38-40`): `field_name = param_to_field.get(param)` → `None` → `continue`
+  ⇒ **stiller Verwurf**
+
+### 🔴 Neuer Befund: der Fix ist NICHT einzeilig
+
+`weather_code` erzeugt beim Parsen **drei** Felder (`openmeteo.py:846-848`):
+
+```python
+thunder_level=self._parse_thunder_level(get_int("weather_code", i)),   # 846
+wmo_code=get_int("weather_code", i),                                   # 847
+hail_flag=self._parse_hail_flag(get_int("weather_code", i)),           # 848
+```
+
+`merge_missing_fields` ist aber strikt **1:1** (`param_to_field: Dict[str, str]`, `merge.py:22`).
+Ein einzelner Eintrag füllt genau ein Feld. Damit sind drei Wege denkbar — **das ist eine
+Design-Entscheidung für die Spec**, kein Implementierungsdetail:
+
+| Weg | Wirkung | Preis |
+|---|---|---|
+| (a) `weather_code` → `thunder_level` | Gewitteraussage kehrt zurück | `wmo_code` + `hail_flag` bleiben leer ⇒ Hagel-Kennzeichen (#1475) bleibt bei Modellausfall „unbekannt" |
+| (b) `weather_code` → `wmo_code` + Nachableitung nach dem Merge | alle drei Felder korrekt | `merge.py` braucht einen Nachbearbeitungs-Schritt (neuer Mechanismus) |
+| (c) `param_to_field` auf 1:N erweitern | alle drei Felder, generisch | Signaturänderung an gemeinsam genutzter Stelle, betrifft auch Schnee-Merge |
+
+**Semantik ist bereits sauber gelöst** (Entwarnung zur alten Sorge im Issue-Kommentar):
+`_parse_thunder_level(None)` liefert `None`, nicht `ThunderLevel.NONE` — Issue #1474 AC-4 hat die
+Unterscheidung ausdrücklich eingeführt („fehlt der Wettercode ist das *keine Aussage*, NICHT die
+geprüfte Entwarnung", `openmeteo.py:634-640`). Die Merge-Bedingung `getattr(dp, feld) is None`
+greift damit genau richtig: fehlende Aussage wird gefüllt, geprüfte Entwarnung nicht überschrieben.
+
+---
+
+## 3. Teil A2 — Vertretung bei Ausfall der Direktquelle
+
+### Heutiger Stand
+
+`thunder_routing.py:63-67` — first-match-wins, **genau ein** Provider je Ort:
+
+```python
+_REGIONS: tuple[_ThunderRegion, ...] = (
+    _ThunderRegion("FR",       41.3,  51.1,  -5.2,   9.7,  "fr_direct"),
+    _ThunderRegion("DE_ALPEN", 43.17, 58.09, -3.95, 20.35, "de_direct"),
+    _ThunderRegion("EU_REST",  -90.0, 90.0, -180.0, 180.0, "eu_direct"),
+)
+```
+
+Einziger Aufrufer: `thunder_enrichment.py:181`. Fehlerbehandlung: `try/except Exception` auf
+oberster Ebene (`thunder_enrichment.py:157-160`) — schluckt alles, Felder bleiben `None`, **keine
+Ausweichlogik, keine Herkunftsangabe**.
+
+### 🟢 Entschärfender Befund: das Muster existiert bereits — ADR-0018
+
+Der Abhängigkeits-Bericht fand das entscheidende Vorbild: **ADR-0018 „Modell-Fallback ohne
+Kaschieren"** ist bereits akzeptiert und im Grundvorhersage-Pfad implementiert
+(`openmeteo.py`, `REGIONAL_MODELS`-Kette bei 5xx/Timeout), inklusive der Transparenz-Pflicht:
+`ForecastMeta.fallback_model`, `fallback_reason`, `logger.warning`, `openmeteo_calls.jsonl`,
+plus Health-Signale im Status-Endpunkt.
+
+⇒ Eine Vertretungskette für Gewitter ist **kein Architektur-Neuland**, sondern die Anwendung
+eines bereits beschlossenen Musters auf eine zweite Domäne. Das ADR für #1492 kann sich darauf
+stützen statt eine neue Grundsatzentscheidung zu erfinden.
+
+**Heute fehlt die Nicht-Kaschieren-Hälfte komplett:** Für Gewitter gibt es keinerlei
+Herkunftsmarker — der Ausfall degradiert **still**. Das ist unabhängig von der Vertretung schon
+ein Mangel gemessen an ADR-0018.
+
+**Die Datenstruktur dafür ist aber schon da:** `ForecastMeta` (`app/models.py:81-95`) trägt
+bereits `fallback_model`, `fallback_reason` und `fallback_metrics` (aus #1115/ADR-0018). Für
+Gewitter ist keines davon je gesetzt (Grep ohne Treffer). Scheibe 2 muss also **kein neues
+Meldemodell erfinden**, sondern das vorhandene befüllen — weiterer Beleg dafür, dass hier ein
+etabliertes Muster ausgedehnt und nicht eine Architektur neu erfunden wird.
+
+### Fachliche Plausibilität der Vertretung
+
+| Primär | Vertretung | Feld-Sicht | Bewertung |
+|---|---|---|---|
+| `de_direct` (ICON-D2) | `eu_direct` (ICON-EU) | **dasselbe Feld** `lightning_potential_lpi_jkg` | 🟢 sauber — `api_contract.md` beschreibt beide bereits als „zwei Quellen, ein Feld". Preis: kein `grau_gsp` (Hagel) bei ICON-EU (KL-3) |
+| `fr_direct` (MF AROME) | `eu_direct` (ICON-EU) | **anderes Feld**: Blitzdichte → LPI | 🟠 fachlich vertretbar (beide speisen dieselbe Fusion), aber ein echter Wechsel der Messgröße — begründungspflichtig |
+| `eu_direct` | — | — | keine weitere Quelle vorhanden |
+
+---
+
+## 4. Kollisionen mit bestehenden Festlegungen
+
+| Festlegung | Fundstelle | Kollidiert? |
+|---|---|---|
+| **AC-8** „first-match-wins tragend", mit Mutations-Gegenprobe | `feat_1457_s2c_icon_eu_luekenfueller.md:251-261` | **Nein**, wenn die *Primärauswahl* first-match-wins bleibt und die Vertretung nur im Fehlerfall greift. Ja, wenn `_REGIONS` grundsätzlich zur Kandidatenliste umgebaut wird. |
+| **`api_contract.md`** „Herkunft ist über `thunder_provider_for()` rekonstruierbar" | `api_contract.md:241` | **Ja** — bei Vertretung stimmt die Positions-Rückrechnung nicht mehr. Muss ergänzt werden: Herkunft im Vertretungsfall **explizit festhalten** (deckt sich mit ADR-0018 Nicht-Kaschieren). |
+| **`decision_matrix.md`** „Die Reihenfolge ist tragend" | `decision_matrix.md:113-144` | **Nein** bei Primär/Vertretung-Trennung; Text braucht einen Zusatz zur Vertretung. |
+| **ADR-0025** „genau eine Rohdaten-Quelle für die Gewitteraussage" | ADR-0025, Entscheidung 1 | **Nein** — ADR-0025 meint `dp.thunder_level` als einzige *Ausgabe*-Quelle für alle Kanäle, nicht die Anzahl der *Bezugsquellen*. Sollte im neuen ADR ausdrücklich abgegrenzt werden, sonst wirkt es wie ein Widerspruch. |
+| **KL-4** „Herkunfts-Transparenz über Routing rekonstruierbar" | `feat_1457_s2b...md` | **Ja**, dieselbe Sache wie `api_contract.md:241` — dieselbe Abhilfe. |
+
+**Kein einziger Test setzt heute „mehrere Provider pro Ort" voraus oder verbietet es** — die
+bestehenden Tests prüfen ortsspezifische Zuständigkeit, die bei Primär/Vertretung-Trennung
+gültig bleibt.
+
+---
+
+## 5. Empfehlung (Tech Lead)
+
+**Vertretungskette statt genereller Kandidatenliste**, in zwei Scheiben:
+
+- **Scheibe 1 — A1 schließen** (`weather_code`-Merge): der schwerere Fehler, kleiner Umfang,
+  keine Architektur-Kollision. Braucht nur die Entscheidung (a)/(b)/(c) aus Abschnitt 2.
+- **Scheibe 2 — A2 Vertretung + Transparenz**: `_REGIONS` behält first-match-wins für die
+  Primärwahl; je Region eine **benannte Vertretung**; im Vertretungsfall Herkunft explizit
+  festhalten (ADR-0018-Muster). Eigenes ADR, das ADR-0018 auf Gewitter ausdehnt und die
+  Abgrenzung zu ADR-0025 festhält.
+
+Warum nicht die generelle Kandidatenliste: sie kauft keinen fachlichen Mehrwert (es gibt je Ort
+maximal eine sinnvolle Vertretung), kostet aber AC-8, den `decision_matrix`-Grundsatz und die
+Herkunfts-Eindeutigkeit.
+
+---
+
+## 6. Scope-Schätzung
+
+| | Scheibe 1 | Scheibe 2 |
+|---|---|---|
+| Dateien | 2 (`openmeteo.py`, ggf. `merge.py`) + Tests | 3–4 (`thunder_routing.py`, `thunder_enrichment.py`, Modell/Meta, Doku) + Tests |
+| LoC | ~40–80 je nach Weg (a)/(b)/(c) | ~120–180 |
+| Risiko | niedrig | mittel (kritischer Datenpfad, alle Kanäle) |
+| ADR nötig | nein | **ja** |
+| Doku-Folgeänderungen | keine | `api_contract.md:241`, `decision_matrix.md:113-144`, KL-4 |
+
+Zusammen deutlich über 250 LoC ⇒ **zwei getrennte Workflows**, nicht einer.
+
+---
+
+## 7. PO-Entscheidungen (2026-08-05, nach Erläuterung des Gesamtkonstrukts)
+
+- [x] **F1 (Scheibe 1) → Weg (b):** Gewitteraussage **und** Hagel-Kennzeichen müssen den
+      Modellausfall überleben. Begründung des PO-Entscheids: sonst zeigt das Briefing bei
+      Modellausfall „Hagel unbekannt", obwohl das Ersatzmodell „Gewitter mit Hagel" gemeldet hat —
+      Widerspruch zur gerade ausgelieferten Hagel-Arbeit (#1475). Der generische 1:N-Umbau
+      (Weg c) wurde **nicht** gewählt: kein Eingriff an der gemeinsam genutzten Merge-Signatur.
+      ⇒ Umsetzung: `weather_code` → `wmo_code` mergen, danach `thunder_level` und `hail_flag`
+      aus dem gemergten Rohcode **nachableiten** (derselbe Weg, den `_parse_response` geht).
+      Die Nachableitung darf einen vorhandenen Wert **nie** überschreiben (Merge-Invariante).
+- [x] **F2 (Scheibe 2) → ja:** `fr_direct` darf im Ausfall durch `eu_direct` vertreten werden,
+      obwohl die Messgröße von Blitzdichte auf Blitzpotenzial wechselt. Begründung: eine etwas
+      anders hergeleitete Gewitterstufe ist besser als keine — Bedingung ist, dass der Wechsel
+      **transparent vermerkt** wird (ADR-0018-Muster, `ForecastMeta`).
+- [x] **F3 → zwei Lieferungen:** erst Scheibe 1 (A1, verschwindende Gewitteraussage), danach
+      Scheibe 2 (A2, Vertretung + ADR).
+
+## 8. Nicht in diesem Umfang
+
+- Hagel-Fusion in die Gewitterstufe (bleibt #1475/S5, bewusst getrennt)
+- `thunder_probability_pct` (#1419 S6, von keiner Quelle befüllt)
+- Kontingent-Steuerung für DWD/Météo-France-Abrufe: eigene Dienste, zählen **nicht** gegen das
+  Open-Meteo-Budget (`forecast_budget.py`) — eine Vertretung erhöht die Last dort trotzdem
+  messbar, gehört als Beobachtungs-AC in Scheibe 2, nicht als eigener Zähler.

--- a/docs/specs/modules/fix_1492_s1_wettercode_fallback.md
+++ b/docs/specs/modules/fix_1492_s1_wettercode_fallback.md
@@ -1,0 +1,291 @@
+---
+entity_id: fix_1492_s1_wettercode_fallback
+status: draft
+type: module
+created: 2026-08-05
+updated: 2026-08-05
+version: "1.0"
+tags: [gewitter, provider, openmeteo, merge, fallback, s1]
+---
+
+# Wettercode-Fallback: Gewitteraussage und Hagel-Kennzeichen überleben den Modell-Metrik-Ausfall
+
+## Approval
+
+- [x] Approved — PO-Freigabe 2026-08-05 („approved")
+
+## Purpose
+
+Fehlt dem Open-Meteo-Primärmodell `weather_code`, wird zwar automatisch ein
+Ersatzmodell abgerufen, das den Wert liefert — beim Zusammenführen wird er
+aber heute **still verworfen**, weil `weather_code` in der
+Parameter-Feld-Tabelle des Merge-Mechanismus fehlt. Diese Scheibe schließt
+genau diese Lücke: der Wettercode wird gemergt, und Gewitteraussage
+(`thunder_level`) sowie Hagel-Kennzeichen (`hail_flag`) werden danach aus dem
+gemergten Rohcode nachgeleitet — mit derselben Ableitung, die der reguläre
+Parse-Pfad ohnehin verwendet.
+
+Erste von zwei Scheiben aus Issue #1492 (`docs/context/feat-1492-gewitter-fallback-kette.md`,
+Abschnitt 2 und 7, PO-Entscheidung F1). Scheibe 2 (Vertretung bei Ausfall der
+Direktquellen Météo-France/DWD) folgt als eigener Workflow mit eigenem ADR.
+
+## Source
+
+- **File:** `src/providers/openmeteo.py`
+- **Identifier:** `OpenMeteoProvider._PARAM_TO_FIELD` (Zeile 378, neuer
+  Eintrag), `OpenMeteoProvider._merge_fallback` (Zeile 423, ein Aufruf mehr),
+  `OpenMeteoProvider._derive_thunder_fields` (neu, private Methode)
+
+**Schicht:** Python-Core (`src/providers/`). Keine Go-API, kein Frontend.
+`src/providers/merge.py` (`merge_missing_fields`) wird **nicht** verändert —
+PO-Entscheidung F1: kein Eingriff an der gemeinsam genutzten 1:1-Merge-
+Signatur, die auch den Schnee-Merge trägt (Weg (c) aus der Analyse wurde
+verworfen).
+
+## Estimated Scope
+
+- **LoC:** ~40–60 Produktivcode (ein Dict-Eintrag, eine neue private Methode,
+  ein zusätzlicher Aufruf in `_merge_fallback`) + Tests
+- **Files:** 1 geändert (`src/providers/openmeteo.py`), 1 neue Testdatei
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `providers.merge.merge_missing_fields` | intern | Füllt `wmo_code` fill-only aus dem Ersatzmodell — unverändert, liefert nur den Rohcode |
+| `OpenMeteoProvider._parse_thunder_level` (Zeile 621) | intern | Dieselbe Ableitungsfunktion, die der reguläre Parse-Pfad (Zeile 846) nutzt — hier zur Nachableitung wiederverwendet, nicht neu gebaut |
+| `OpenMeteoProvider._parse_hail_flag` (Zeile 645) | intern | Analog, aus #1475 S5a |
+| `OpenMeteoProvider._find_fallback_model` (Zeile 399) | intern | Wählt das Ersatzmodell anhand von `missing_params` — AC-5 prüft, dass `weather_code` diesen Weg wie jede andere Metrik durchläuft |
+| `PROBE_PARAMS` (openmeteo.py:207-214) | Konstante | Sondierungsliste, über die eine Metrik überhaupt als „fehlend" erkannt werden kann — enthält `weather_code` bereits heute |
+| `app.models.ForecastDataPoint.{thunder_level,wmo_code,hail_flag}` | Datenmodell | Bereits vorhanden, keine Schema-Änderung |
+| `app.models.ThunderLevel` | Enum | `NONE` ≠ Python `None` (Issue #1474 AC-4) — trägt die Überschreib-Invariante dieser Scheibe |
+
+## Implementation Details
+
+```
+1. _PARAM_TO_FIELD (openmeteo.py:378-397) bekommt EINEN neuen Eintrag:
+       "weather_code": "wmo_code",
+   Damit erkennt merge_missing_fields den Rohcode als fuellbares 1:1-Feld
+   und fuellt ihn fill-only (Invariante aus merge.py unveraendert: "ueberschreibt
+   nie einen vorhandenen Wert").
+
+2. Neue private Methode _derive_thunder_fields(self, ts: NormalizedTimeseries) -> None:
+       fuer jeden dp in ts.data:
+           wenn dp.wmo_code is None: naechster dp (keine Grundlage zum Ableiten)
+           wenn dp.thunder_level is None:
+               dp.thunder_level = self._parse_thunder_level(dp.wmo_code)
+           wenn dp.hail_flag is None:
+               dp.hail_flag = self._parse_hail_flag(dp.wmo_code)
+   Liest bewusst dp.wmo_code (den GEMERGTEN Wert je Zeitpunkt), nicht den
+   rohen API-Parameter -- funktioniert damit unabhaengig davon, ob wmo_code
+   aus dem Primaer- oder dem Ersatzmodell stammt. Die beiden "is None"-Checks
+   sind die Ueberschreib-Invariante: ein bereits vom regulaeren Parse-Pfad
+   gesetzter Wert (auch ThunderLevel.NONE, das ist NICHT None) bleibt
+   unangetastet.
+
+3. _merge_fallback (openmeteo.py:423-428) bekommt EINEN Aufruf mehr, direkt
+   nach dem bestehenden merge_missing_fields-Aufruf:
+       filled = merge_missing_fields(primary, fallback, missing_params, self._PARAM_TO_FIELD)
+       if "weather_code" in filled:
+           self._derive_thunder_fields(primary)
+       return filled
+   Die Nachableitung laeuft NUR, wenn tatsaechlich mindestens ein wmo_code-Wert
+   gemergt wurde -- im Normalfall (kein Metrik-Ausfall) ist "weather_code"
+   nie in `missing_params`, der Zweig greift nicht, keine Verhaltensaenderung
+   fuer den unveraenderten Pfad.
+
+KEINE Aenderung an merge.py, an _parse_response, an thunder_routing.py oder
+an der Einstufungslogik (thunder_level_from_signals) -- diese Scheibe fuellt
+ausschliesslich einen fehlenden Wert nach, entscheidet nichts neu ein.
+```
+
+## Expected Behavior
+
+- **Input:** Eine Vorhersage, bei der das Primärmodell `weather_code` nicht
+  liefert (Metrik-Lücke, `weather_code` landet in `missing_params`), während
+  das automatisch ermittelte Ersatzmodell für denselben Zeitpunkt einen
+  gültigen WMO-Code liefert.
+- **Output:** `thunder_level`, `wmo_code` und `hail_flag` sind am
+  betroffenen Datenpunkt identisch zu dem, was ein direkter Parse desselben
+  Rohcodes ergäbe — statt wie heute bei allen drei `None` zu bleiben.
+- **Side effects:** keine zusätzlichen HTTP-Abrufe (der Ersatzmodell-Abruf
+  existiert bereits im WEATHER-05b-Mechanismus); keine Änderung an
+  `timeseries.meta.fallback_metrics` außer dass `"weather_code"` jetzt darin
+  auftauchen kann, wenn dieser Fall eintritt (unverändertes Verhalten von
+  `merge_missing_fields`, nicht neu in dieser Scheibe).
+
+## Acceptance Criteria
+
+- **AC-1 (Wirkungsnachweis über den produktiv verdrahteten Merge-Pfad):**
+  Given ein Primär-Datenpunkt ohne `weather_code` (`thunder_level`,
+  `wmo_code`, `hail_flag` alle `None`) und ein Ersatz-Datenpunkt mit
+  demselben Zeitstempel und `weather_code=96` (Gewitter mit Hagel) / When
+  `OpenMeteoProvider._merge_fallback(primary, fallback, ["weather_code"])`
+  aufgerufen wird — derselbe Aufruf, den `fetch_forecast` bei jeder
+  Metrik-Lücke produktiv ausführt (`openmeteo.py:1142`) / Then trägt der
+  Datenpunkt danach `thunder_level=ThunderLevel.HIGH`, `wmo_code=96` und
+  `hail_flag=True`.
+  - Test: Reproduziert den Bug aus Nutzersicht — vor dem Fix bleiben alle
+    drei Felder `None` trotz Gewittercode im Ersatzmodell (RED), nach dem
+    Fix sind alle drei korrekt gefüllt (GREEN). Kein neuer, unverdrahteter
+    Pfad: `_merge_fallback` wird bereits heute von `fetch_forecast`
+    aufgerufen (Zeile 1142) — diese Scheibe erweitert nur seinen Rumpf, baut
+    keinen neuen Aufrufer.
+
+- **AC-2 (Überschreib-Invariante, allgemein):** Given ein Primär-Datenpunkt
+  hat für denselben Zeitstempel bereits `thunder_level=ThunderLevel.HIGH`,
+  `wmo_code=95` und `hail_flag=None` gesetzt (regulär vom eigenen Primärmodell
+  geparst), das Ersatzmodell liefert für denselben Zeitstempel einen
+  abweichenden Code `weather_code=96` / When `_merge_fallback` läuft / Then
+  bleiben `thunder_level`, `wmo_code` und `hail_flag` exakt beim
+  ursprünglichen Wert (`HIGH`, `95`, `None`) — der abweichende Ersatzwert
+  wird nirgends übernommen.
+  - Test: Zwei Datenpunkte in derselben Reihe — einer bereits vollständig
+    gesetzt (wie oben), einer mit einer echten Lücke (alle drei `None`).
+    Nach dem Merge ist nur der Lücken-Datenpunkt verändert, der bereits
+    gesetzte bleibt Byte-für-Byte identisch. Gegenprobe: Prüft `_derive_
+    thunder_fields` nur global (z. B. per `if filled: ...` ohne den
+    `is None`-Check pro Feld), muss dieser Test rot werden.
+
+- **AC-3 (Nicht-Gewitter-Code ist eine geprüfte Entwarnung, kein Loch —
+  Issue #1474 AC-4):** Given ein Primär-Datenpunkt trägt die geprüfte
+  Entwarnung `thunder_level=ThunderLevel.NONE` (NICHT Python `None`),
+  **während sein Rohcode `wmo_code` fehlt** — der Merge füllt den Rohcode
+  also tatsächlich aus dem Ersatzmodell, und zwar mit dem Gewittercode `96`
+  / When `_merge_fallback` läuft / Then bleibt `thunder_level` exakt
+  `ThunderLevel.NONE` — wird weder auf Python `None` zurückgesetzt noch aus
+  dem frisch gemergten Ersatz-Rohcode zu `HIGH` hochgestuft.
+  - 🔴 **Die Konstellation „Entwarnung gesetzt, Rohcode fehlt" ist für dieses
+    AC konstitutiv.** Trüge der Datenpunkt seinen eigenen Rohcode (z. B. `1`),
+    liefe die Nachableitung auf denselben Wert `NONE` hinaus und der Test
+    könnte eine fehlerhafte Implementierung **nicht** von einer richtigen
+    unterscheiden — die Gegenprobe unten wäre wirkungslos. Gemessen
+    2026-08-05: mit gesetztem eigenem Rohcode bleibt die Mutation grün, mit
+    fehlendem Rohcode wird sie rot (`NONE` → `HIGH`).
+  - Test: Prüft konkret die Unterscheidung „Feld ist leer" vs. „Feld trägt
+    die geprüfte Entwarnung". Gegenprobe: Behandelt die Implementierung die
+    geprüfte Entwarnung als Lücke — etwa
+    `if dp.thunder_level in (None, ThunderLevel.NONE):` statt
+    `if dp.thunder_level is None:` — muss dieser Test rot werden: der
+    bereits geprüfte `NONE`-Wert würde dann fälschlich durch den
+    Gewittercode `96` des Ersatzmodells zu `HIGH` überschrieben.
+    - *Nicht* als Gegenprobe geeignet und deshalb ausdrücklich nicht
+      gefordert: ein falsy-Check (`if not dp.thunder_level`). `ThunderLevel`
+      ist `(str, Enum)` mit `NONE = "NONE"` und damit **truthy** — der
+      falsy-Check verhält sich für diesen Fall identisch zum `is None`-Check,
+      die Mutation bliebe grün. (Gemessen 2026-08-05, Review-Fund team-lead.)
+
+- **AC-4 (Fail-soft, beide Modelle ohne Wert):** Given weder Primär- noch
+  Ersatzmodell liefern für einen Zeitpunkt einen `weather_code` / When
+  `_merge_fallback` läuft / Then bleiben `thunder_level`, `wmo_code` und
+  `hail_flag` an diesem Zeitpunkt `None` — kein Absturz, keine Ausnahme.
+  - Test: Ersatz-Datenpunkt ohne `weather_code`-Wert für den betroffenen
+    Zeitstempel; nach dem Merge bleiben alle drei Felder `None`, der Aufruf
+    wirft nichts.
+
+- **AC-5 (Erkennungs-Vorbedingung — schließt die Kette am schwächsten
+  Glied):** Given die Erkennungs- und Auswahlkette, über die eine Metrik
+  überhaupt als „fehlend" erkannt und ein Ersatzmodell dafür gefunden wird /
+  When geprüft wird, ob `weather_code` diese Kette wie jede andere Metrik
+  durchläuft / Then ist `weather_code` (a) in `PROBE_PARAMS`
+  (`openmeteo.py:207-214`) enthalten — Voraussetzung, um überhaupt als
+  fehlend erkannt zu werden — und (b) wird von `_find_fallback_model`
+  (`openmeteo.py:399`) genauso behandelt wie jede andere fehlende Metrik,
+  nicht speziell ausgefiltert.
+  - Test: Zwei Assertions gegen echten Produktivcode, kein Netz.
+    (1) `assert "weather_code" in PROBE_PARAMS`.
+    (2) `OpenMeteoProvider()._find_fallback_model(primary_id, lat, lon,
+    ["weather_code"])` gegen eine Fake-Availability-Cache (Muster
+    `TestFindFallbackModel` aus `tests/unit/test_model_metric_fallback.py`),
+    in der ein Ersatzmodell `"weather_code"` als `available` führt — der
+    Aufruf muss dieses Modell zurückgeben.
+    Gegenprobe: Wird `weather_code` aus `PROBE_PARAMS` entfernt, wird (1)
+    rot; enthielte `_find_fallback_model` eine Sonderbehandlung, die
+    `weather_code` aus der Auswahl ausschließt, würde (2) rot.
+  - Begründung für dieses AC: AC-1 bis AC-4 prüfen ausschließlich das
+    Verhalten *innerhalb* von `_merge_fallback`, mit `missing_params`
+    bereits als Eingabe. Bricht die Vorbedingung — `weather_code` landet gar
+    nicht erst in `missing_params`, weil es aus `PROBE_PARAMS` verschwindet
+    oder `_find_fallback_model` es ausschließt — ist die gesamte Scheibe
+    **wirkungslos, während AC-1 bis AC-4 weiterhin grün blieben** (sie
+    bekommen `missing_params` ja synthetisch vorgegeben). Dass die letzte
+    Meile — der reine String-Join `",".join(missing)` beim Aufbau der
+    Ersatz-Request-Parameter (`openmeteo.py:1133`) — ungefiltert bleibt,
+    folgt aus Code-Inspektion (keine Filterlogik zwischen `missing` und
+    diesem Join) und wird nicht separat getestet, s. Known Limitations.
+
+## Known Limitations
+
+1. **Vertretung bei Ausfall der Direktquellen (Météo-France/DWD) ist NICHT
+   Teil dieser Scheibe.** Das ist Scheibe 2 (A2 aus der Analyse), eigener
+   Workflow, eigenes ADR (`thunder_routing.py`, `thunder_enrichment.py`
+   bleiben unangetastet).
+2. **Fehlwert-Marker im rohen `weather_code`-API-Parameter** (z. B. ein
+   API-seitiger Sentinel) werden von dieser Scheibe nicht neu behandelt —
+   das bestehende Parsing (`get_int("weather_code", i)`) liefert bereits
+   `None` bei fehlendem Rohwert, unverändert.
+3. **Zeitpunkt-Zuordnung** zwischen Primär- und Ersatzreihe läuft über den
+   bestehenden `ts`-Join in `merge_missing_fields` — diese Scheibe fügt
+   keine eigene Zuordnungslogik hinzu.
+4. **Keine Änderung an der Einstufung.** `thunder_level_from_signals` und
+   jede Fusion mit Direktquellen-Signalen (#1457) bleiben unverändert; diese
+   Scheibe füllt ausschließlich den WMO-Code-Pfad nach.
+5. **AC-5 prüft die Erkennungs- und Auswahlkette, nicht den vollen
+   HTTP-Roundtrip.** Dass der Ersatzabruf `weather_code` tatsächlich als
+   Query-Parameter sendet, ist eine reine String-Join-Operation
+   (`",".join(missing)`, `openmeteo.py:1133`) ohne Filterschritt dazwischen
+   — dafür ist kein zusätzlicher Test nötig, das folgt aus AC-5(b) plus
+   Code-Inspektion.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Additive Lückenschließung an einem bereits produktiven
+  Mechanismus (WEATHER-05b Model-Metric-Fallback, Issue #1302/Epic #1301) —
+  ein fehlender Eintrag in einer bestehenden Parameter-Feld-Tabelle wird
+  ergänzt, plus eine kleine Nachableitung, die dieselben Parse-Funktionen
+  wiederverwendet, die der reguläre Pfad ohnehin nutzt. Es entsteht keine
+  neue Entscheidungsfläche: die 1:1-Merge-Signatur (`merge.py`) bleibt exakt
+  wie sie ist (PO-Entscheidung F1, Weg (b) statt des generischen 1:N-Umbaus
+  Weg (c)), keine neue Quelle, kein neues Routing, kein neues Meldefeld. Das
+  verwandte, bereits akzeptierte Muster für Transparenz bei Modellausfall
+  (ADR-0018 „Modell-Fallback ohne Kaschieren") ist hier nicht zusätzlich
+  berührt, weil diese Scheibe keine neue Fallback-*Quelle* einführt, sondern
+  nur einen Wert innerhalb der bereits bestehenden, bereits markierten
+  Fallback-Kette (`fallback_model`/`fallback_metrics`) vollständiger macht.
+  Scheibe 2 bringt die neue Entscheidungsfläche (Vertretung zwischen
+  Direktquellen) und damit das eigene ADR.
+
+## Changelog
+
+- 2026-08-05 (Mutations-Gegenprobe nach GREEN): **AC-3 Szenario korrigiert.**
+  Die Mutations-Gegenprobe deckte auf, dass die AC-3-Fassung ihre eigene
+  Gegenprobe nicht auslösen konnte: Im ursprünglich beschriebenen Szenario
+  trug der Datenpunkt seinen **eigenen** Rohcode (`wmo_code=1`), den der
+  fill-only-Merge gar nicht ersetzt — eine Nachableitung daraus ergibt wieder
+  `NONE`, die Mutation blieb also grün. Gemessen: mit fehlendem Rohcode
+  (`wmo_code=None`, vom Ersatzmodell mit `96` gefüllt) wird dieselbe Mutation
+  rot (`NONE` → `HIGH`). AC-3 verlangt jetzt genau diese Konstellation.
+  Gegenprobe-Belege: Mutation „Schutz ganz entfernen" → rot über AC-2
+  (bestätigt); Mutation „Entwarnung als Lücke behandeln" → im alten Szenario
+  grün, im neuen rot.
+- 2026-08-05 (Review): **AC-3 Gegenprobe korrigiert** — die ursprünglich
+  geforderte Mutation (falsy-Check statt `is None`) ist strukturell nicht
+  auslösbar: `ThunderLevel` ist `(str, Enum)` mit `NONE = "NONE"` und damit
+  truthy, beide Checks verhalten sich für diesen Fall identisch, die Mutation
+  wäre grün geblieben. Ersetzt durch die fachlich naheliegende Mutation
+  `in (None, ThunderLevel.NONE)`, gegen die der Test tatsächlich wirkt.
+  **AC-5 nachgetragen und präzisiert** — die Erkennungs-Vorbedingung
+  (`weather_code` in `PROBE_PARAMS` und bei `_find_fallback_model` nicht
+  ausgefiltert) war ungetestet; bricht sie, ist die Scheibe wirkungslos, ohne
+  dass AC-1 bis AC-4 rot würden. Test konkretisiert auf zwei Assertions gegen
+  echten Produktivcode (`PROBE_PARAMS`-Membership,
+  `_find_fallback_model`-Aufruf), Zeilenverweis auf den String-Join
+  (`openmeteo.py:1133`) statt der ungenauen ursprünglichen `:1112`-Angabe
+  (das war nur der Kommentar-Marker, nicht der Aufruf selbst) korrigiert.
+- 2026-08-05: Initial spec created (Issue #1492 Scheibe 1, Analyse
+  `docs/context/feat-1492-gewitter-fallback-kette.md` Abschnitt 2 und 7,
+  PO-Entscheidung F1 vom 2026-08-05: Weg (b) — `weather_code` → `wmo_code`
+  mergen, `thunder_level`/`hail_flag` danach aus dem gemergten Rohcode
+  nachableiten, Merge-Signatur unangetastet).

--- a/docs/specs/modules/model_metric_fallback.md
+++ b/docs/specs/modules/model_metric_fallback.md
@@ -243,7 +243,19 @@ if meta and meta.fallback_model and meta.fallback_metrics:
 - Zeitliche Aufloesung identisch (stuendlich) — kein Interpolationsbedarf
 - Wenn Probe-Cache fehlt oder abgelaufen, kein Fallback (graceful degradation)
 - ECMWF als Primaermodell hat keinen Fallback (ist selbst der letzte Fallback)
+- **`weather_code` ist der einzige Parameter mit Nachbearbeitung** (Issue #1492 S1,
+  s. u.): Die Zuordnung `param → field` ist strikt 1:1, aus dem Wettercode entstehen
+  beim regulaeren Parsen aber DREI Felder (`wmo_code`, `thunder_level`, `hail_flag`).
+  Gemergt wird nur der Rohcode `wmo_code`; `thunder_level` und `hail_flag` werden
+  danach in `_derive_thunder_fields` aus dem gemergten Rohcode nachgeleitet — fill-only,
+  ein vorhandener Wert wird nie ueberschrieben. Wer hier einen weiteren Parameter mit
+  mehreren Zielfeldern ergaenzt, braucht dieselbe Nachbearbeitung; die 1:1-Signatur von
+  `merge_missing_fields` bleibt bewusst unangetastet (sie traegt auch den Schnee-Merge).
 
 ## Changelog
 
+- 2026-08-05: Known Limitation zu `weather_code` ergaenzt — Sonderfall „ein Parameter,
+  drei Zielfelder" aus Issue #1492 Scheibe 1
+  (`docs/specs/modules/fix_1492_s1_wettercode_fallback.md`). Der Mechanismus dieser Spec
+  bleibt unveraendert.
 - 2026-02-16: Initial spec created (WEATHER-05b, Phase B)

--- a/src/providers/openmeteo.py
+++ b/src/providers/openmeteo.py
@@ -394,6 +394,7 @@ class OpenMeteoProvider:
         "cape": "cape_jkg",
         "freezing_level_height": "freezing_level_m",
         "uv_index": "uv_index",
+        "weather_code": "wmo_code",
     }
 
     def _find_fallback_model(
@@ -420,12 +421,30 @@ class OpenMeteoProvider:
 
         return None
 
+    def _derive_thunder_fields(self, ts: "NormalizedTimeseries") -> None:
+        """Leitet thunder_level/hail_flag aus dem gemergten wmo_code nach.
+
+        Ueberschreib-Invariante: nur echte Luecken (Feld is None) werden
+        befuellt. ThunderLevel.NONE ist die geprueft Entwarnung, NICHT
+        Python None (Issue #1474 AC-4) -- bleibt unangetastet.
+        """
+        for dp in ts.data:
+            if dp.wmo_code is None:
+                continue
+            if dp.thunder_level is None:
+                dp.thunder_level = self._parse_thunder_level(dp.wmo_code)
+            if dp.hail_flag is None:
+                dp.hail_flag = self._parse_hail_flag(dp.wmo_code)
+
     def _merge_fallback(
         self, primary: "NormalizedTimeseries", fallback: "NormalizedTimeseries",
         missing_params: List[str]
     ) -> List[str]:
         """Thin-Wrapper. Vertrag lebt in providers/merge.py (Issue #1302, Epic #1301)."""
-        return merge_missing_fields(primary, fallback, missing_params, self._PARAM_TO_FIELD)
+        filled = merge_missing_fields(primary, fallback, missing_params, self._PARAM_TO_FIELD)
+        if "weather_code" in filled:
+            self._derive_thunder_fields(primary)
+        return filled
 
     def _enrich_snow(
         self, timeseries: "NormalizedTimeseries", lat: float, lon: float, enrich_snow: bool

--- a/tests/unit/test_weather_code_fallback_merge.py
+++ b/tests/unit/test_weather_code_fallback_merge.py
@@ -1,0 +1,327 @@
+"""
+Unit tests: weather_code ueberlebt den Model-Metric-Fallback (WEATHER-05b).
+
+Fehlt dem Primaermodell `weather_code`, wird der Rohcode zwar per Ersatzmodell
+abgerufen, beim Merge aber heute still verworfen -- `weather_code` fehlt in
+`OpenMeteoProvider._PARAM_TO_FIELD`. Diese Suite deckt AC-1 bis AC-5 der Spec
+ab: der gemergte Rohcode (`wmo_code`) UND die daraus nachgeleiteten Felder
+`thunder_level`/`hail_flag`.
+
+Fuenf Testklassen, je AC eine, pure In-Memory-Objekte, kein Netz.
+
+SPEC: docs/specs/modules/fix_1492_s1_wettercode_fallback.md v1.0
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from app.models import (
+    ForecastDataPoint,
+    ForecastMeta,
+    NormalizedTimeseries,
+    Provider,
+    ThunderLevel,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_meta(model: str = "meteofrance_arome") -> ForecastMeta:
+    return ForecastMeta(
+        provider=Provider.OPENMETEO,
+        model=model,
+        run=datetime(2026, 2, 16, 0, 0, tzinfo=timezone.utc),
+        grid_res_km=1.3,
+        interp="grid_point",
+    )
+
+
+def _make_dp(
+    hour: int,
+    wmo_code: int | None = None,
+    thunder_level: ThunderLevel | None = None,
+    hail_flag: bool | None = None,
+) -> ForecastDataPoint:
+    return ForecastDataPoint(
+        ts=datetime(2026, 2, 17, hour, 0, tzinfo=timezone.utc),
+        t2m_c=10.0,
+        wind10m_kmh=15.0,
+        gust_kmh=25.0,
+        precip_1h_mm=0.0,
+        cloud_total_pct=50,
+        humidity_pct=60,
+        wmo_code=wmo_code,
+        thunder_level=thunder_level,
+        hail_flag=hail_flag,
+    )
+
+
+def _make_timeseries(data: list[ForecastDataPoint], model: str = "meteofrance_arome") -> NormalizedTimeseries:
+    return NormalizedTimeseries(meta=_make_meta(model), data=data)
+
+
+# ---------------------------------------------------------------------------
+# AC-1: Wirkungsnachweis ueber den produktiv verdrahteten Merge-Pfad
+# ---------------------------------------------------------------------------
+
+class TestMergeFallbackFillsWeatherCode:
+    """AC-1: derselbe Aufruf, den fetch_forecast bei jeder Metrik-Luecke
+    produktiv ausfuehrt (openmeteo.py:1142) -- kein neuer, unverdrahteter
+    Pfad. Erwartet ROT: `weather_code` fehlt heute in `_PARAM_TO_FIELD`,
+    `_derive_thunder_fields` existiert nicht -- alle drei Felder bleiben
+    `None` statt gefuellt zu werden."""
+
+    def test_fills_wmo_code_and_derives_thunder_and_hail_from_fallback(self) -> None:
+        from providers.openmeteo import OpenMeteoProvider
+
+        primary_dp = _make_dp(8)  # thunder_level/wmo_code/hail_flag alle None
+        fallback_dp = _make_dp(8, wmo_code=96)  # Gewitter mit Hagel
+
+        primary = _make_timeseries([primary_dp])
+        fallback = _make_timeseries([fallback_dp], model="icon_eu")
+
+        provider = OpenMeteoProvider()
+        filled = provider._merge_fallback(primary, fallback, ["weather_code"])
+
+        assert "weather_code" in filled
+        assert primary.data[0].wmo_code == 96
+        assert primary.data[0].thunder_level == ThunderLevel.HIGH
+        assert primary.data[0].hail_flag is True
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Ueberschreib-Invariante, allgemein
+# ---------------------------------------------------------------------------
+
+class TestMergeFallbackDoesNotOverwriteAlreadySetFields:
+    """AC-2: ein bereits (aus einer anderen Quelle) gesetzter Datenpunkt
+    bleibt unangetastet -- nur der echte Luecken-Datenpunkt derselben Reihe
+    wird veraendert. Gegenprobe: prueft die Implementierung nur global
+    (z.B. `if filled: ...` ohne `is None`-Check pro Feld), wird dieser Test
+    rot, weil der bereits gesetzte Datenpunkt aus seinem EIGENEN wmo_code
+    (1, kein Gewittercode) auf ThunderLevel.NONE neu abgeleitet wuerde,
+    obwohl thunder_level bereits auf HIGH gesetzt war."""
+
+    def test_already_set_datapoint_untouched_only_gap_filled(self) -> None:
+        from providers.openmeteo import OpenMeteoProvider
+
+        # Bereits gesetzt (z.B. aus einer Direktquelle) -- wmo_code=1 (kein
+        # Gewittercode) wuerde bei Neuableitung NONE ergeben, nicht HIGH.
+        already_set = _make_dp(8, wmo_code=1, thunder_level=ThunderLevel.HIGH, hail_flag=None)
+        gap = _make_dp(9)  # echte Luecke: alle drei Felder None
+
+        primary = _make_timeseries([already_set, gap])
+
+        fb_already = _make_dp(8, wmo_code=96)  # abweichender Ersatzwert
+        fb_gap = _make_dp(9, wmo_code=96)
+        fallback = _make_timeseries([fb_already, fb_gap], model="icon_eu")
+
+        provider = OpenMeteoProvider()
+        provider._merge_fallback(primary, fallback, ["weather_code"])
+
+        # bereits gesetzter Datenpunkt: exakt unveraendert
+        assert primary.data[0].wmo_code == 1
+        assert primary.data[0].thunder_level == ThunderLevel.HIGH
+        assert primary.data[0].hail_flag is None
+
+        # Luecken-Datenpunkt: aus dem Ersatzmodell gefuellt
+        assert primary.data[1].wmo_code == 96
+        assert primary.data[1].thunder_level == ThunderLevel.HIGH
+        assert primary.data[1].hail_flag is True
+
+    def test_already_set_hail_flag_survives_merged_code_without_hail(self) -> None:
+        """F001-Nachbesserung: der `hail_flag`-Schutz in `_derive_thunder_fields`
+        (``if dp.hail_flag is None:``) ist von den bisherigen AC-2-Faellen NICHT
+        bewacht -- entfernt man dort nur die Zeile, bleiben alle bisherigen Tests
+        gruen, weil der dort verwendete `already_set`-Datenpunkt einen EIGENEN
+        `wmo_code=1` traegt: `_parse_hail_flag(1)` liefert selbst schon `None`,
+        eine Neuableitung waere von der geschuetzten Fassung nicht zu
+        unterscheiden.
+
+        Konstitutiv fuer DIESEN Test:
+        - `wmo_code=None` beim bereits gesetzten Datenpunkt (fehlt), NICHT ein
+          eigener Rohcode -- sonst erreicht ihn der (fill-only) Merge gar nicht,
+          und die Frage nach der Neuableitung stellt sich nie.
+        - Der gemergte Ersatzcode ist `95` (Gewitter OHNE Hagel-Zusatzcode),
+          bewusst NICHT `96`. Mit `96` waere `_parse_hail_flag(96) == True` --
+          identisch zum bereits gesetzten Wert, und eine fehlerhafte
+          Neuableitung faellt nicht auf. Erst mit `95` ergibt eine ungeschuetzte
+          Neuableitung `None` und ueberschreibt das gesetzte `True` sichtbar.
+
+        NICHT "vereinfachen" indem hier ein eigener `wmo_code` oder ein
+        Ersatzcode `96` verwendet wird -- das macht den Test wirkungslos, ohne
+        dass er dabei anders aussieht (Mutations-Gegenprobe 2026-08-05: ohne
+        den Schutz ``if dp.hail_flag is None:`` blieb dieser Test bei `96` bzw.
+        eigenem Rohcode faelschlich gruen)."""
+        from providers.openmeteo import OpenMeteoProvider
+
+        # hail_flag bereits gesetzt (z.B. aus einer Direktquelle), eigener
+        # wmo_code fehlt -- der Merge fuellt ihn frisch aus dem Ersatzmodell.
+        already_set = _make_dp(8, wmo_code=None, thunder_level=None, hail_flag=True)
+        gap = _make_dp(9)  # echte Luecke, unbeteiligt
+
+        primary = _make_timeseries([already_set, gap])
+
+        # Ersatzcode 95: Gewitter OHNE Hagel-Zusatzcode -- _parse_hail_flag(95)
+        # liefert selbst None, wuerde also das gesetzte True ueberschreiben.
+        fb_already = _make_dp(8, wmo_code=95)
+        fb_gap = _make_dp(9, wmo_code=95)
+        fallback = _make_timeseries([fb_already, fb_gap], model="icon_eu")
+
+        provider = OpenMeteoProvider()
+        provider._merge_fallback(primary, fallback, ["weather_code"])
+
+        # der Rohcode wird gefuellt -- nur die Ableitung bleibt geschuetzt
+        assert primary.data[0].wmo_code == 95
+        assert primary.data[0].hail_flag is True
+
+
+# ---------------------------------------------------------------------------
+# AC-3: Nicht-Gewitter-Code ist eine geprüfte Entwarnung, kein Loch (#1474 AC-4)
+# ---------------------------------------------------------------------------
+
+class TestMergeFallbackPreservesCheckedNoneLevel:
+    """AC-3 (#1474 AC-4): ThunderLevel.NONE ist die geprüfte Entwarnung, NICHT
+    Python None -- darf weder auf None zurueckgesetzt noch durch den
+    Ersatzwert ueberschrieben werden.
+
+    WICHTIG fuer spaetere Leser: der geprueft-entwarnte Datenpunkt MUSS mit
+    fehlendem eigenem `wmo_code` (None) konstruiert werden, NICHT mit einem
+    eigenen Rohcode wie `1`. Der Merge ist fill-only und ersetzt einen
+    bereits vorhandenen `wmo_code` nie -- ein Datenpunkt mit eigenem Rohcode
+    `1` wuerde vom Ersatzwert `96` also gar nicht erreicht, und eine
+    Nachableitung aus `1` ergibt ohnehin wieder `NONE`. Ein Test mit eigenem
+    Rohcode kann dann eine fehlerhafte Implementierung nicht von einer
+    richtigen unterscheiden (Mutations-Gegenprobe 2026-08-05: mit eigenem
+    Rohcode blieb die Mutation `in (None, ThunderLevel.NONE)` faelschlich
+    gruen). Erst wenn der Rohcode selbst fehlt und der Merge ihn frisch aus
+    dem Ersatzmodell fuellt (hier `96`, ein Gewittercode), kann die Mutation
+    ueberhaupt zuschlagen -- und tut es auch (`NONE` -> `HIGH`, rot).
+    NICHT "vereinfachen" indem `wmo_code` wieder gesetzt wird -- das macht
+    den Test wirkungslos, ohne dass er dabei anders aussieht.
+
+    Gegenprobe: ein Check `if dp.thunder_level in (None, ThunderLevel.NONE):`
+    statt `is None` wuerde diesen Datenpunkt faelschlich mit dem frisch
+    gemergten Gewittercode 96 auf HIGH ueberschreiben."""
+
+    def test_checked_none_level_survives_untouched(self) -> None:
+        from providers.openmeteo import OpenMeteoProvider
+
+        # wmo_code=None ist konstitutiv -- siehe Klassen-Docstring.
+        checked = _make_dp(8, wmo_code=None, thunder_level=ThunderLevel.NONE, hail_flag=None)
+        gap = _make_dp(9)
+
+        primary = _make_timeseries([checked, gap])
+
+        fb_checked = _make_dp(8, wmo_code=96)
+        fb_gap = _make_dp(9, wmo_code=96)
+        fallback = _make_timeseries([fb_checked, fb_gap], model="icon_eu")
+
+        provider = OpenMeteoProvider()
+        provider._merge_fallback(primary, fallback, ["weather_code"])
+
+        # der Rohcode wird sehr wohl gefuellt -- nur die Einstufung bleibt
+        # unangetastet; das ist der Kern der Zusicherung.
+        assert primary.data[0].wmo_code == 96
+        # geprüfte Entwarnung bleibt exakt NONE -- weder None noch HIGH
+        assert primary.data[0].thunder_level == ThunderLevel.NONE
+        assert primary.data[0].thunder_level is not None
+
+        # Luecken-Datenpunkt derselben Reihe wird ganz normal gefuellt
+        assert primary.data[1].thunder_level == ThunderLevel.HIGH
+
+
+# ---------------------------------------------------------------------------
+# AC-4: Fail-soft, beide Modelle ohne Wert
+# ---------------------------------------------------------------------------
+
+class TestMergeFallbackFailsSoftWithoutWeatherCode:
+    """AC-4: liefert weder Primaer- noch Ersatzmodell fuer einen Zeitpunkt
+    einen weather_code, bleiben alle drei Felder None -- kein Absturz, keine
+    Ausnahme. Der zweite Datenpunkt derselben Reihe hat einen echten Treffer,
+    damit `_derive_thunder_fields` ueberhaupt laeuft (sonst landet
+    "weather_code" nie in `filled` und der Fail-soft-Zweig wird gar nicht
+    durchlaufen)."""
+
+    def test_datapoint_without_any_weather_code_stays_none_no_crash(self) -> None:
+        from providers.openmeteo import OpenMeteoProvider
+
+        both_missing = _make_dp(8)  # weder primaer noch Ersatz liefert etwas
+        hit = _make_dp(9)  # anderer Zeitpunkt: Ersatz liefert einen Wert
+
+        primary = _make_timeseries([both_missing, hit])
+
+        fb_both_missing = _make_dp(8)  # auch hier kein wmo_code
+        fb_hit = _make_dp(9, wmo_code=95)
+        fallback = _make_timeseries([fb_both_missing, fb_hit], model="icon_eu")
+
+        provider = OpenMeteoProvider()
+        filled = provider._merge_fallback(primary, fallback, ["weather_code"])  # wirft nicht
+
+        assert primary.data[0].wmo_code is None
+        assert primary.data[0].thunder_level is None
+        assert primary.data[0].hail_flag is None
+
+        # Regelfall am zweiten Zeitpunkt: dort greift der Fallback normal
+        assert "weather_code" in filled
+        assert primary.data[1].wmo_code == 95
+        assert primary.data[1].thunder_level == ThunderLevel.HIGH
+
+
+# ---------------------------------------------------------------------------
+# AC-5: Erkennungs-Vorbedingung -- schliesst die Kette am schwaechsten Glied
+# ---------------------------------------------------------------------------
+
+class TestWeatherCodeDetectionPrecondition:
+    """AC-5: prueft die Erkennungs-/Auswahlkette VOR `_merge_fallback` --
+    ohne die landet `weather_code` gar nicht erst in `missing_params`, und
+    AC-1 bis AC-4 wuerden nie erreicht (sie bekommen `missing_params`
+    synthetisch vorgegeben, pruefen also nicht diese Vorbedingung).
+
+    BEIDE Tests dieser Klasse sind bereits vor der Implementierung dieser
+    Scheibe GRUEN: `weather_code` steht schon heute in `PROBE_PARAMS`
+    (openmeteo.py:214) und `_find_fallback_model` (openmeteo.py:399) filtert
+    keine Metrik gezielt aus. Das ist erwartet und in Ordnung -- diese Tests
+    sind Regressions-Waechter fuer eine BESTEHENDE Vorbedingung, kein neues
+    Verhalten dieser Scheibe. Sie bleiben in der Suite, damit ein spaeterer
+    Umbau (z.B. eine neue Ausschlussliste in `_find_fallback_model`) sofort
+    auffiele."""
+
+    def test_weather_code_is_a_probe_param(self) -> None:
+        from providers.openmeteo import PROBE_PARAMS
+
+        assert "weather_code" in PROBE_PARAMS
+
+    def test_find_fallback_model_treats_weather_code_like_any_other_metric(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        import providers.openmeteo as om
+
+        fake_cache = tmp_path / "model_availability.json"
+        monkeypatch.setattr(om, "AVAILABILITY_CACHE_PATH", fake_cache)
+
+        from providers.openmeteo import OpenMeteoProvider
+
+        cache = {
+            "probe_date": date.today().isoformat(),
+            "models": {
+                "meteofrance_arome": {"available": ["temperature_2m"], "unavailable": ["weather_code"]},
+                "icon_eu": {"available": ["temperature_2m", "weather_code"], "unavailable": []},
+            },
+        }
+        fake_cache.write_text(json.dumps(cache))
+
+        provider = OpenMeteoProvider()
+        result = provider._find_fallback_model("meteofrance_arome", 39.7, 2.6, ["weather_code"])
+
+        assert result is not None
+        fb_model_id, _fb_grid_res_km, _fb_endpoint = result
+        assert fb_model_id == "icon_eu"


### PR DESCRIPTION
## Summary

Fehlt dem Open-Meteo-Primaermodell `weather_code`, wird bereits heute automatisch ein Ersatzmodell abgerufen — der gelieferte Wert wurde beim Zusammenfuehren aber **still verworfen**, weil `weather_code` in `_PARAM_TO_FIELD` fehlte (`merge.py:38-40` macht dann `continue`). Damit verschwanden **Gewitteraussage, Rohcode und Hagel-Kennzeichen** gleichzeitig, obwohl die Information vorlag.

Umsetzung (Weg (b) nach PO-Entscheidung): `weather_code` → `wmo_code` mergen, danach `thunder_level` und `hail_flag` in `_derive_thunder_fields` aus dem gemergten Rohcode nachleiten — dieselben Parse-Funktionen wie der regulaere Pfad, fill-only. **`merge.py` bleibt unangetastet**, die geteilte 1:1-Signatur traegt auch den Schnee-Merge.

20 Zeilen Produktivcode in einer Datei.

## Bemerkenswert: zwei Testloecher desselben Musters

Die Mutations-Gegenprobe deckte auf, dass zwei der Schutzbedingungen **unbewacht** waren — beide Male, weil der Testdatenpunkt so konstruiert war, dass die Verfaelschung dort nicht wirken konnte:

| Mutation | vorher | jetzt |
|---|---|---|
| `hail_flag`-Schutz entfernt | alle 17 gruen ⇒ unbewacht (Adversary-Fund F001, HIGH) | ROT |
| Entwarnung als Luecke (`in (None, ThunderLevel.NONE)`) | gruen ⇒ unbewacht | ROT |
| `thunder_level`-Schutz entfernt | ROT | ROT |

Merkmal zum Wiedererkennen: *ein Test, dessen erwarteter Wert auch ohne den geprueften Schutz herauskaeme.* Der Produktivcode war durchgehend korrekt — verbessert wurde ausschliesslich die Absicherung.

## Test plan

- [x] `tests/unit/test_weather_code_fallback_merge.py` — 7/7 gruen, deckt AC-1..AC-5
- [x] `tests/unit/test_model_metric_fallback.py` (gleicher Merge-Pfad) — 11/11 gruen, unveraendert
- [x] Regression `tests/unit/` — **962 Tests gruen**, Exit 0, mit `--disable-socket` (kein Netz, kein Kontingent)
- [x] Mutations-Gegenprobe: alle drei Schutzbedingungen einzeln gefangen, Ausgangszustand je per `diff` als identisch verifiziert
- [x] Adversary **VERIFIED** (`docs/artifacts/feat-1492-gewitter-fallback-kette/adversary-dialog.md`)

Nebenbefund F002 (LOW, folgenlos) als Sammel-Eintrag in #1199.
Kein ADR — additive Lueckenschliessung am bestehenden WEATHER-05b-Mechanismus. Scheibe 2 (Vertretung zwischen den Direktquellen Meteo-France/DWD) folgt separat **mit** eigenem ADR.

Bezieht sich auf #1492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzaMdw2Cnt9o6iVx5QRwHD