### PR TITLE
feat(#1484): Nacht-Tiefsttemperatur als eigene wählbare Wettergröße

### DIFF
--- a/docs/reference/sms_format.md
+++ b/docs/reference/sms_format.md
@@ -48,7 +48,7 @@ Diese Spec ersetzt v1.0 und integriert das Format aus dem Vorgänger-Projekt (`w
 | Block | Tokens | Pflicht? |
 |-------|--------|---------|
 | Header | `{Name}:` | immer |
-| Forecast (Nacht) | `N` | **nur Abendbriefing** (Issue #1319 Scheibe D) — im Morgenbriefing entfällt der Token komplett, nicht als `N-` — UND nur bei aktivierter Metrik „Temperatur“ (Issue #1415) |
+| Forecast (Nacht) | `N` | **nur Abendbriefing** (Issue #1319 Scheibe D) — im Morgenbriefing entfällt der Token komplett, nicht als `N-` — UND nur bei aktivierter Metrik „Nacht-Tiefsttemperatur“ (`temperature_night`, Issue #1484; bis dahin an „Temperatur“ gekoppelt, Issue #1415) |
 | Forecast (Tiefst unterwegs) | `K` | Morgen + Abend (Issue #1410) — kälteste Gehzeit-Stunde, von `N` unterschieden — nur bei aktivierter Metrik „Temperatur“ (Issue #1415) |
 | Forecast (gefühlt, Nacht) | `FN` | **nur Abendbriefing** UND nur bei aktivierter Metrik „Gefühlte Temperatur“ |
 | Forecast (gefühlt) | `FK FD` | Morgen + Abend, aber nur bei aktivierter Metrik „Gefühlte Temperatur“ |
@@ -67,7 +67,7 @@ Diese Spec ersetzt v1.0 und integriert das Format aus dem Vorgänger-Projekt (`w
 
 **Hinweis zu `N` (Issue #1319 Scheibe D, 2026-07-23):** Im Abendbriefing ist `N` das erste Forecast-Token wie oben dargestellt. Im Morgenbriefing entfällt `N` vollständig aus der Zeile (nicht `N-`) — die Reihenfolge rutscht entsprechend nach: `{Name}: K D FK FD R PR W G TH: TH+: ...`.
 
-**Hinweis zu `K`/`FK`/`FD`/`FN` (Issue #1410, 2026-07-28):** `K` ist die Tiefsttemperatur **unterwegs** (kälteste Gehzeit-Stunde) und steht unabhängig neben `N` (Nacht am Schlafplatz) — beide erscheinen abends gemeinsam, morgens nur `K`. Das `F`-Präfix bezeichnet die **gefühlte** Temperatur (`FN`/`FK`/`FD` als Parität zu `N`/`K`/`D`); diese drei erscheinen ausschliesslich, wenn die Metrik „Gefühlte Temperatur“ (`wind_chill`) im Trip aktiviert ist.
+**Hinweis zu `K`/`FK`/`FD`/`FN` (Issue #1410, 2026-07-28):** `K` ist die Tiefsttemperatur **unterwegs** (kälteste Gehzeit-Stunde) und steht unabhängig neben `N` (Nacht am Schlafplatz) — beide erscheinen abends gemeinsam (`N` seit Issue #1484 nur bei gewählter eigener Metrik „Nacht-Tiefsttemperatur“), morgens nur `K`. Das `F`-Präfix bezeichnet die **gefühlte** Temperatur (`FN`/`FK`/`FD` als Parität zu `N`/`K`/`D`); diese drei erscheinen ausschliesslich, wenn die Metrik „Gefühlte Temperatur“ (`wind_chill`) im Trip aktiviert ist.
 
 **Grundregel „gewählt / nicht gewählt” (PO-Entscheidung 2026-08-03, Issue #1415):** Für **jedes** Vorhersage-Kürzel gilt: geprüft, aber nichts über der Schwelle bzw. kein Wert ⇒ Null-Form (`R-`, `K-`); Metrik im Trip **abgewählt** ⇒ das Kürzel entfällt vollständig, auch die Null-Form. Eine dritte Stufe „Wert nicht abrufbar / Datenlücke im Fenster ⇒ `R?`” (#1328) gibt es bei den Schwellwert-Kürzeln `R`/`PR`/`W`/`G`/`TH:`/`TH+:` (`TH+:` seit Fix #1482, 2026-08-04) **und** seit Fix #1483 (2026-08-05, s. „Bekannte Ist-Abweichungen”) auch bei den Temperatur-Kürzeln `N`/`K`/`D`/`FN`/`FK`/`FD` (s. §4). Es gibt damit **keine unbedingten Vorhersage-Token** mehr: `N`/`K`/`D` (Metrik „Temperatur”) verhalten sich seit #1415 exakt wie `FN`/`FK`/`FD` (Metrik „Gefühlte Temperatur”), und `TH+:` verhält sich seit #1482 exakt wie `TH:`. Die Bindung Kürzel→Metrik liegt an genau einer Stelle: `SMS_MULTI_SYMBOLS_BY_METRIC` (mehrere Kürzel je Metrik) bzw. `SMS_SYMBOL_BY_METRIC` (1:1) in `src/output/renderers/sms_trip.py`, ausgewertet in `trip_report.py` (`disabled_specs` → `output/tokens/builder.py::_visible()`).
 
@@ -106,7 +106,7 @@ Diese Spec ersetzt v1.0 und integriert das Format aus dem Vorgänger-Projekt (`w
 
 | Token | Bedeutung | Quelle (DTO-Feld) | Beispiel |
 |-------|-----------|-------------------|----------|
-| `N{temp}` / `N-` (**nur Abendbriefing**, nur bei aktivierter Metrik „Temperatur“) | Nacht-Tiefsttemperatur °C am Schlafplatz, ganzzahlig — Fenster Ankunft→06:00 Folgetag am Etappenziel, NICHT das Tagessegment-Minimum. Im Morgenbriefing entfällt der Token komplett (kein `N-`). | `night_temp_min_c()` aus `night_weather` (Fallback: Tagessegment-`temp_min_c`, wenn `night_weather` fehlt/leer) | `N9` |
+| `N{temp}` / `N-` (**nur Abendbriefing**, nur bei aktivierter Metrik „Nacht-Tiefsttemperatur“, Issue #1484) | Nacht-Tiefsttemperatur °C am Schlafplatz, ganzzahlig — Fenster Ankunft→06:00 Folgetag am Etappenziel, NICHT das Tagessegment-Minimum. Im Morgenbriefing entfällt der Token komplett (kein `N-`). | `night_temp_min_c()` aus `night_weather` (Fallback: Tagessegment-`temp_min_c`, wenn `night_weather` fehlt/leer) | `N9` |
 | `K{temp}` / `K-` (nur bei aktivierter Metrik „Temperatur“) | Tiefsttemperatur **unterwegs** °C, ganzzahlig — kälteste Stunde der Gehzeit. Erscheint in BEIDEN Report-Typen und ist von `N` (Nacht am Schlafplatz) zu unterscheiden. | `day_window.collect_hiking_window_points()` → `hiking_field_min_max("t2m_c")`, MIN (Issue #1417) | `K3` |
 | `D{temp}` / `D-` (nur bei aktivierter Metrik „Temperatur“) | Tag-Max °C, ganzzahlig — genauer: Höchstwert **während der Gehzeit**, nicht der Kalendertag (s. Hinweis unter der Tabelle) | dieselbe Quelle wie `K`, MAX | `D24` |
 | `FN{temp}` / `FN-` (**nur Abendbriefing**, nur bei aktivierter Metrik) | **Gefühlte** Nacht-Tiefsttemperatur °C am Schlafplatz — Parität zu `N`, gleiches Fenster Ankunft→06:00 Folgetag. | `night_wind_chill_min_c()` aus `night_weather` (Fallback: Gehzeit-`wind_chill_min_c`) | `FN6` |
@@ -338,7 +338,7 @@ Nur in Dry-Run / Debug-Modus angehängt, ansonsten weggelassen.
 
 | Token | Null-Form | Anmerkung |
 |-------|-----------|-----------|
-| `N` (nur Abend) | `N-` | Bei fehlender Nacht-Temperatur — **nur im Abendbriefing**; im Morgenbriefing fehlt der Token komplett (kein `N-`). **Nur** bei aktivierter Metrik „Temperatur“ (Issue #1415) — zur zusätzlichen `?`-Form bei Datenlücke s. Hinweis unten |
+| `N` (nur Abend) | `N-` | Bei fehlender Nacht-Temperatur — **nur im Abendbriefing**; im Morgenbriefing fehlt der Token komplett (kein `N-`). **Nur** bei aktivierter Metrik „Nacht-Tiefsttemperatur“ (Issue #1484, vorher „Temperatur“ per #1415) — zur zusätzlichen `?`-Form bei Datenlücke s. Hinweis unten |
 | `K` | `K-` | Bei fehlender Gehzeit-Tiefsttemperatur — **nur** bei aktivierter Metrik „Temperatur“ (Issue #1415) — zur zusätzlichen `?`-Form bei Datenlücke s. Hinweis unten |
 | `D` | `D-` | Bei fehlender Tag-Temperatur — **nur** bei aktivierter Metrik „Temperatur“ (Issue #1415) — zur zusätzlichen `?`-Form bei Datenlücke s. Hinweis unten |
 | `FN` / `FK` / `FD` | `FN-` / `FK-` / `FD-` | **Nur** bei aktivierter Metrik „Gefühlte Temperatur“, wenn lediglich die Daten fehlen. Ist die Metrik nicht gewählt, erscheint gar nichts — auch keine Null-Form (Issue #1410) — zur zusätzlichen `?`-Form bei Datenlücke s. Hinweis unten |

--- a/docs/specs/modules/feat_1484_night_temp_metric.md
+++ b/docs/specs/modules/feat_1484_night_temp_metric.md
@@ -50,9 +50,10 @@ wer die Hütte gebucht hat, umgekehrt.
   `src/output/renderers/trip_metric_ids.py` — Bestandsdaten-Ableitung (s.u.).
 - **Frontend:** KEINE neue Komponente. `WeatherMetricsTab` lädt den Katalog aus
   `GET /api/metrics` — der neue Eintrag erscheint automatisch als Checkbox in
-  „Welche Metriken ins Briefing?". Zu prüfen: Ausschlussliste
-  `corridorEditorState.ts:111` (`FRONTEND_EXCLUDED_CATALOG_IDS`) um
-  `temperature_night` ergänzen (keine Alarm-/Korridor-Funktion, s. Abgrenzung).
+  „Welche Metriken ins Briefing?". Geprüft (Adversary): die Ausschlussliste
+  `corridorEditorState.ts:111` braucht KEINEN Eintrag — ohne `alert_metrics`
+  taucht `temperature_night` im Alert-Mapping und damit im Korridor-Editor
+  gar nicht erst auf.
 - **Parität:** `internal/model/alert_metric_mapping.generated.json` regenerieren
   bzw. Paritätstest (`test_alert_metric_mapping_parity.py`) und Kürzel-Ratsche
   (`test_sms_token_symbol_register_ratchet.py`) bedienen.
@@ -75,9 +76,12 @@ Gespeicherte Trips kennen `temperature_night` nicht. Ableitungsregel beim Lesen
 
 Erst ein bewusster Editor-Save schreibt den expliziten Eintrag — über den
 bestehenden Merge-Pfad (`weather_config.go: mergeConfigMap`), nie Replace.
-Gleiches gilt für den Altbestands-Fallback `DEFAULT_TRIP_METRIC_IDS`
-(`trip_metric_ids.py`): dort zieht `temperature_night` mit ein, damit
-Alt-Trips ohne `display_config` das `N` behalten.
+Alt-Trips ganz **ohne** `display_config` brauchen keine Sonderbehandlung:
+sie erhalten `build_default_display_config[_for_profile]`, das
+`temperature_night` über den Katalog-Default (`default_enabled=True`)
+bereits mitführt. (`DEFAULT_TRIP_METRIC_IDS` bleibt unangetastet — der
+Adversary-Lauf hat belegt, dass ein Eintrag dort wirkungslos wäre;
+Finding F001, Sammel-Eintrag #1199.)
 
 ## Abgrenzungen (bewusst NICHT in dieser Scheibe)
 

--- a/docs/specs/modules/feat_1484_night_temp_metric.md
+++ b/docs/specs/modules/feat_1484_night_temp_metric.md
@@ -3,7 +3,7 @@ entity_id: feat_1484_night_temp_metric
 type: module
 created: 2026-08-06
 updated: 2026-08-06
-status: draft
+status: approved
 version: "1.0"
 tags: [metrics, sms, briefing, editor]
 ---
@@ -14,7 +14,7 @@ tags: [metrics, sms, briefing, editor]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-'go' 2026-08-06
 
 ## Purpose
 

--- a/docs/specs/modules/feat_1484_night_temp_metric.md
+++ b/docs/specs/modules/feat_1484_night_temp_metric.md
@@ -1,0 +1,136 @@
+---
+entity_id: feat_1484_night_temp_metric
+type: module
+created: 2026-08-06
+updated: 2026-08-06
+status: draft
+version: "1.0"
+tags: [metrics, sms, briefing, editor]
+---
+
+<!-- Issue #1484 — Nacht-Tiefsttemperatur getrennt wählbar (Folge aus #1415) -->
+
+# Nacht-Tiefsttemperatur als eigene wählbare Wettergröße
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Die Nacht-Tiefsttemperatur am Etappenziel (`N`-Kürzel, nur Abend-Briefing) hängt
+heute an der Wettergröße „Temperatur" (`K`/`D`). PO-Entscheidung 2026-08-03:
+*„N soll getrennt wählbar sein. Wer in der Hütte übernachtet, den interessiert
+der Wert z.B. nicht."* Tages- und Nachttemperatur werden zwei unabhängige
+Auswahl-Entscheidungen — wer im Zelt schläft, wählt die Nacht ohne den Tag;
+wer die Hütte gebucht hat, umgekehrt.
+
+## Source
+
+- **File:** `src/app/metric_catalog.py` — NEUER Registereintrag `temperature_night`
+  (`selectable=True`, Kategorie wie `temperature`, `dp_field="t2m_c"`, nur
+  Aggregation `min`; Vorbild-Struktur: `wind_chill`, Zeilen 124–146).
+  **NICHT** `temperature_cold` (Zeile 114–123) anfassen — das ist die interne
+  Alarm-Pseudogröße mit `selectable=False` (#914), bei #1415 geprüft und verworfen.
+- **File:** `src/output/renderers/sms_trip.py:114-118` — Bindungstabelle
+  `SMS_MULTI_SYMBOLS_BY_METRIC` aufteilen: `"temperature": ("K","D")`,
+  `"temperature_night": ("N",)`. Auswertung (`trip_report.py:290-307`) und
+  Sichtbarkeitsentscheid (`tokens/builder.py:_visible`, Abend-Gate `:278-279`)
+  bleiben unverändert — sie folgen der Tabelle.
+- **File:** `src/output/renderers/compact_summary.py:168-183` — Nacht-Untergrenze
+  der E-Mail-Kurzzusammenfassung an `temperature_night` statt `temperature` binden.
+- **File:** `src/output/renderers/narrow.py:518-522` — Telegram-Abendübersicht:
+  Nacht-Untergrenze folgt `temperature_night`.
+- **File:** `src/services/trip_report_scheduler.py:~875` + `src/services/preview_service.py:206-217` —
+  Nacht-Datenbeschaffung (`fetch_night_weather`) zusätzlich auslösen, wenn
+  `temperature_night` gewählt ist (heute nur an `show_night_block` gekoppelt);
+  sonst zeigt `N` bei ausgeschalteter Nacht-Stundentabelle still den Tageswert
+  (Fallback in `sms_trip.py:241`).
+- **File:** `src/app/models.py` (`UnifiedWeatherDisplayConfig`) bzw. Lesestelle
+  `src/output/renderers/trip_metric_ids.py` — Bestandsdaten-Ableitung (s.u.).
+- **Frontend:** KEINE neue Komponente. `WeatherMetricsTab` lädt den Katalog aus
+  `GET /api/metrics` — der neue Eintrag erscheint automatisch als Checkbox in
+  „Welche Metriken ins Briefing?". Zu prüfen: Ausschlussliste
+  `corridorEditorState.ts:111` (`FRONTEND_EXCLUDED_CATALOG_IDS`) um
+  `temperature_night` ergänzen (keine Alarm-/Korridor-Funktion, s. Abgrenzung).
+- **Parität:** `internal/model/alert_metric_mapping.generated.json` regenerieren
+  bzw. Paritätstest (`test_alert_metric_mapping_parity.py`) und Kürzel-Ratsche
+  (`test_sms_token_symbol_register_ratchet.py`) bedienen.
+
+## Estimated Scope
+
+- **LoC:** ~80–120 produktiv (Katalogeintrag, Tabellen-Split, 3 Bindungen,
+  Datenbeschaffung, Bestandsableitung) + Tests
+- **Files:** ~8 produktiv
+- **Effort:** medium
+
+## Bestandsdaten (PFLICHT-Regel aus CLAUDE.md)
+
+Gespeicherte Trips kennen `temperature_night` nicht. Ableitungsregel beim Lesen
+(kein Migrationslauf, kein Replace):
+
+> Fehlt in `display_config.metrics[]` ein Eintrag `temperature_night`, gilt die
+> Größe als **aktiviert genau dann, wenn `temperature` aktiviert ist** —
+> das heutige Verhalten bleibt exakt erhalten, niemand wird überrascht.
+
+Erst ein bewusster Editor-Save schreibt den expliziten Eintrag — über den
+bestehenden Merge-Pfad (`weather_config.go: mergeConfigMap`), nie Replace.
+Gleiches gilt für den Altbestands-Fallback `DEFAULT_TRIP_METRIC_IDS`
+(`trip_metric_ids.py`): dort zieht `temperature_night` mit ein, damit
+Alt-Trips ohne `display_config` das `N` behalten.
+
+## Abgrenzungen (bewusst NICHT in dieser Scheibe)
+
+1. **`FN` (gefühlte Nacht) bleibt an „Gefühlte Temperatur"** (`wind_chill`,
+   Kürzel `FN`/`FK`/`FD`/`WC`) gekoppelt. Eine symmetrische Trennung wäre ein
+   Folgeschnitt — hier nicht enthalten, um den Schnitt klein zu halten.
+2. **E-Mail-Nacht-Stundentabelle bleibt an `show_night_block`.** Sie ist eine
+   Tabellen-Sektion (eigenes Bedienelement, `night_interval_hours`), keine
+   Metrik-Spalte. Die neue Größe steuert den Nacht-**Wert** (SMS-Token,
+   Kurzzusammenfassungs-/Telegram-Untergrenze), nicht die Tabelle.
+3. **Keine Alarm-/Grenzwert-Funktion** für `temperature_night` (keine
+   `alert_metrics`, kein `sms_threshold`, nicht im Korridor-Editor). Der
+   Kälte-Alarm bleibt vollständig bei `temperature_cold` (#914).
+4. **Ortsvergleich:** keine Sonderbehandlung; erscheint dort nur, was ohnehin
+   über den geteilten Katalog ankommt (Gleichziehen ist #1463).
+5. Die `?`-/Null-Form-Logik aus #1415 bleibt unverändert (Datenlücke bei
+   gewählter Größe ⇒ `N-`, abgewählt ⇒ Token entfällt).
+
+## Expected Behavior
+
+- **Input:** Metrik-Auswahl im Editor (Reiter Wertebereiche), Kombinationen
+  `temperature` × `temperature_night` je an/aus.
+- **Output:** Abend-Briefing in SMS/E-Mail/Telegram zeigt Nachtwert genau dann,
+  wenn `temperature_night` gewählt ist; `K`/`D` genau dann, wenn `temperature`
+  gewählt ist. Morgen-Briefing zeigt nie `N` (Abend-Gate bleibt).
+- **Side effects:** Nacht-Wetterabruf auch ohne `show_night_block`, wenn
+  `temperature_night` gewählt.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip mit abgewählter „Nacht-Tiefsttemperatur" und gewählter „Temperatur" / When das Abend-Briefing als SMS erzeugt wird / Then enthält die SMS `K` und `D`, aber kein `N`-Token.
+  - Test: SMS-Rendering mit realistischem Forecast-Fixture, Assertion auf Token-Menge.
+- **AC-2:** Given ein Trip mit gewählter „Nacht-Tiefsttemperatur" und abgewählter „Temperatur" / When das Abend-Briefing als SMS erzeugt wird / Then enthält die SMS `N` mit dem Nacht-Minimum, aber weder `K` noch `D`.
+  - Test: wie AC-1, umgekehrte Auswahl; Wert stammt aus dem Nachtfenster (Ankunft→06:00).
+- **AC-3:** Given ein Trip mit gewählter „Nacht-Tiefsttemperatur" / When das Morgen-Briefing erzeugt wird / Then erscheint kein `N` — das bestehende Nur-Abends-Gate wirkt unverändert.
+  - Test: bestehende Suite `test_night_temp_evening_only.py` bleibt grün, ergänzt um den neuen Metrik-Fall.
+- **AC-4:** Given „Nacht-Tiefsttemperatur" abgewählt und „Temperatur" gewählt / When die Abend-E-Mail-Kurzzusammenfassung und die Telegram-Abendübersicht erzeugt werden / Then erscheint dort keine Nacht-Untergrenze; mit gewählter Nachtgröße erscheint sie — in beiden Kanälen.
+  - Test: compact_summary- und narrow-Rendering, beide Richtungen.
+- **AC-5:** Given der Metrik-Katalog / When `GET /api/metrics` abgerufen wird / Then enthält die Antwort „Nacht-Tiefsttemperatur" als wählbare Größe in der Temperatur-Kategorie, und `temperature_cold` bleibt weiterhin nicht enthalten.
+  - Test: API-Test gegen den Router (FastAPI TestClient), Assertion auf beide IDs.
+- **AC-6:** Given ein gespeicherter Bestands-Trip mit aktivierter „Temperatur" und ohne `temperature_night`-Eintrag / When der Trip geladen und das Abend-Briefing erzeugt wird / Then erscheint `N` wie vor der Änderung, und ein anschließender Config-Save erhält alle übrigen `display_config`-Felder (Merge, kein Replace).
+  - Test: Roundtrip mit echtem Bestands-JSON-Fixture (Format wie `data/users/default/trips/*.json`).
+- **AC-7:** Given ein gespeicherter Bestands-Trip mit deaktivierter „Temperatur" / When der Trip geladen wird / Then ist „Nacht-Tiefsttemperatur" abgeleitet AUS — es taucht kein neues Token unangefordert auf.
+  - Test: Ableitungsregel beide Richtungen, inkl. `DEFAULT_TRIP_METRIC_IDS`-Altbestand.
+- **AC-8:** Given „Nacht-Tiefsttemperatur" gewählt und die Nacht-Stundentabelle (`show_night_block`) ausgeschaltet / When das Abend-Briefing erzeugt wird / Then zeigt `N` das echte Nacht-Minimum (Ankunft→06:00), nicht still den Tageswert.
+  - Test: Scheduler-/Preview-Pfad mit `show_night_block=False`, Nachtwert ≠ Tageswert im Fixture, Assertion auf den Nachtwert.
+- **AC-9:** Given zwei verschiedene Nutzer mit entgegengesetzter Auswahl der Nachtgröße / When beide ihr Abend-Briefing erzeugen / Then wirkt jeweils nur die eigene Auswahl (keine Vermischung über `user_id`-Grenzen).
+  - Test: zwei User-Verzeichnisse, zwei Renderings, gegenläufige Assertions.
+
+## Prüfhinweis für den Adversary
+
+Leitfrage aus CLAUDE.md anwenden: Ist die Zusicherung dort geprüft, wo sie
+WIRKT? Insbesondere AC-8 (Datenbeschaffung) und AC-6/AC-7 (Ableitung beim
+Lesen, nicht nur im Katalog) sind die Stellen, an denen ein grüner Testlauf
+ohne Wirkung möglich wäre. Mutations-Gegenprobe: Bindungstabelle zurück auf
+`("N","K","D")` drehen — welche Tests fangen es?

--- a/internal/scheduler/forecast_budget_health_test.go
+++ b/internal/scheduler/forecast_budget_health_test.go
@@ -46,8 +46,9 @@ func writeForecastBudgetFile(t *testing.T, tmpDir, contents string) {
 
 func TestForecastBudgetSnapshotValidFileReportsFieldsAndRatio(t *testing.T) {
 	tmpDir := t.TempDir()
+	today := time.Now().UTC().Format("2006-01-02")
 	writeForecastBudgetFile(t, tmpDir,
-		`{"date":"2026-08-05","calls":{"openmeteo":900},"cache_hits":10,"cache_misses":5}`)
+		`{"date":"`+today+`","calls":{"openmeteo":900},"cache_hits":10,"cache_misses":5}`)
 
 	snap := forecastBudgetSnapshot(filepath.Join(tmpDir, "diagnostics", "forecast_budget.json"))
 
@@ -107,8 +108,9 @@ func TestForecastBudgetSnapshotCorruptJSONIsUnavailable(t *testing.T) {
 
 func TestSchedulerStatusIncludesForecastBudgetKey(t *testing.T) {
 	tmpDir := t.TempDir()
+	today := time.Now().UTC().Format("2006-01-02")
 	writeForecastBudgetFile(t, tmpDir,
-		`{"date":"2026-08-05","calls":{"openmeteo":42},"cache_hits":1,"cache_misses":2}`)
+		`{"date":"`+today+`","calls":{"openmeteo":42},"cache_hits":1,"cache_misses":2}`)
 	sched := newForecastBudgetHealthTestScheduler(t, tmpDir)
 
 	status := sched.Status()

--- a/src/app/loader.py
+++ b/src/app/loader.py
@@ -795,6 +795,24 @@ def _parse_display_config(data: Dict[str, Any]) -> "UnifiedWeatherDisplayConfig"
             sms_threshold=mc_data.get("sms_threshold"),
         ))
 
+    # Issue #1484 (Bestands-Ableitung): fehlt die Nachtgroesse im
+    # gespeicherten Config, erbt sie den Zustand von "temperature" — das
+    # heutige Verhalten (N haengt an der Temperatur) bleibt fuer Altbestand
+    # exakt erhalten; erst ein Editor-Save schreibt den expliziten Eintrag.
+    # Abgeleitet wird NUR, wenn ein "temperature"-Eintrag existiert: Laden
+    # erfindet sonst Eintraege (Roundtrip-Invarianz, s. Snow-AC-10), und eine
+    # leere Liste ist Altbestand Fall A (DEFAULT_TRIP_METRIC_IDS) und bleibt leer.
+    if not any(mc.metric_id == "temperature_night" for mc in metrics):
+        _temp_entries = [mc for mc in metrics if mc.metric_id == "temperature"]
+        if _temp_entries:
+            metrics.append(MetricConfig(
+                metric_id="temperature_night",
+                enabled=any(mc.enabled for mc in _temp_entries),
+                aggregations=[],
+                bucket="secondary",
+                derived=True,
+            ))
+
     # Issue #429/#1394 (T4): kanal-spezifische Layouts laden (optional,
     # backward-compat). Wenn channel_layouts fehlt → None, damit
     # get_metrics_for_channel auf die globale Liste zurückfällt. Eine
@@ -1272,7 +1290,8 @@ def save_location(location: SavedLocation, user_id: str = "default") -> Path:
         dc = location.display_config
         data["display_config"] = {
             "trip_id": dc.trip_id,
-            "metrics": [_metric_to_dict(mc) for mc in dc.metrics],
+            "metrics": [_metric_to_dict(mc) for mc in dc.metrics
+                        if not getattr(mc, "derived", False)],
             "show_night_block": dc.show_night_block,
             "night_interval_hours": dc.night_interval_hours,
             "thunder_forecast_days": dc.thunder_forecast_days,
@@ -1476,7 +1495,8 @@ def _trip_to_dict(trip: Trip) -> Dict[str, Any]:
         dc = trip.display_config
         data["display_config"] = {
             "trip_id": dc.trip_id,
-            "metrics": [_metric_to_dict(mc) for mc in dc.metrics],
+            "metrics": [_metric_to_dict(mc) for mc in dc.metrics
+                        if not getattr(mc, "derived", False)],
             "show_night_block": dc.show_night_block,
             "night_interval_hours": dc.night_interval_hours,
             "thunder_forecast_days": dc.thunder_forecast_days,

--- a/src/app/metric_catalog.py
+++ b/src/app/metric_catalog.py
@@ -121,6 +121,23 @@ _METRICS: list[MetricDefinition] = [
         sms_code="N", decimals=0, cmp="unter", alert_label="Temp",
         selectable=False,
     ),
+    # Issue #1484: Nacht-Tiefsttemperatur am Etappenziel als EIGENE waehlbare
+    # Groesse, getrennt von "temperature" (K/D). PO 2026-08-03: "N soll
+    # getrennt waehlbar sein." Traegt das N-Kuerzel der Trip-SMS (Bindung:
+    # sms_trip.SMS_MULTI_SYMBOLS_BY_METRIC), erscheint nur im Abend-Briefing.
+    # NICHT temperature_cold (Alarm-Pseudogroesse, #914, s.o.). Der Wert
+    # entsteht im Nachtfenster (day_window.night_temp_min_c), nicht aus einem
+    # Etappen-Aggregat -- deshalb keine summary_fields (= keine Auswertungs-
+    # Pills, keine Tabellenspalte) und keine Alarm-Deklaration (Kaeltealarm
+    # bleibt temperature_cold).
+    MetricDefinition(
+        id="temperature_night", label_de="Nacht-Tiefsttemperatur", unit="°C",
+        dp_field="t2m_c", category="temperature",
+        default_aggregations=("min",),
+        compact_label="TN", col_key="temp_night", col_label="Nacht",
+        providers={"openmeteo": True, "geosphere": True},
+        decimals=0,
+    ),
     MetricDefinition(
         id="wind_chill", label_de="Gefühlte Temperatur", unit="°C",
         dp_field="wind_chill_c", category="temperature",
@@ -682,7 +699,7 @@ WEATHER_TEMPLATES: dict[str, dict] = {
     "alpen-trekking": {
         "label": "Alpen-Trekking",
         "metrics": [
-            "temperature", "wind_chill", "wind", "gust", "precipitation",
+            "temperature", "temperature_night", "wind_chill", "wind", "gust", "precipitation",
             "thunder", "cape", "rain_probability", "snowfall_limit",
             "freezing_level", "cloud_total", "cloud_low", "visibility", "uv_index",
         ],
@@ -690,14 +707,14 @@ WEATHER_TEMPLATES: dict[str, dict] = {
     "wandern": {
         "label": "Wandern",
         "metrics": [
-            "temperature", "humidity", "wind", "gust", "precipitation",
+            "temperature", "temperature_night", "humidity", "wind", "gust", "precipitation",
             "rain_probability", "cloud_total", "sunshine", "uv_index",
         ],
     },
     "skitouren": {
         "label": "Skitouren",
         "metrics": [
-            "temperature", "wind_chill", "wind", "gust", "precipitation",
+            "temperature", "temperature_night", "wind_chill", "wind", "gust", "precipitation",
             "fresh_snow", "snow_depth", "snowfall_limit", "freezing_level",
             "cloud_total", "cloud_low", "visibility",
         ],
@@ -705,28 +722,28 @@ WEATHER_TEMPLATES: dict[str, dict] = {
     "wintersport": {
         "label": "Wintersport",
         "metrics": [
-            "temperature", "wind_chill", "wind", "gust", "precipitation",
+            "temperature", "temperature_night", "wind_chill", "wind", "gust", "precipitation",
             "fresh_snow", "snow_depth", "cloud_total", "sunshine", "visibility",
         ],
     },
     "radtour": {
         "label": "Radtour",
         "metrics": [
-            "temperature", "wind", "wind_direction", "gust", "precipitation",
+            "temperature", "temperature_night", "wind", "wind_direction", "gust", "precipitation",
             "rain_probability", "thunder", "cape", "cloud_total", "sunshine", "uv_index",
         ],
     },
     "wassersport": {
         "label": "Wassersport",
         "metrics": [
-            "temperature", "wind", "gust", "wind_direction", "precipitation",
+            "temperature", "temperature_night", "wind", "gust", "wind_direction", "precipitation",
             "rain_probability", "thunder", "cape", "cloud_total", "visibility",
         ],
     },
     "allgemein": {
         "label": "Allgemein",
         "metrics": [
-            "temperature", "wind", "gust", "precipitation",
+            "temperature", "temperature_night", "wind", "gust", "precipitation",
             "rain_probability", "cloud_total", "sunshine",
         ],
     },

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -594,6 +594,11 @@ class MetricConfig:
     # Issue #624: Konfigurierter Schwellwert für SMS-/Telegram-Kurzform-Token.
     # None = bisheriger DEFAULTS-Fallback in builder.py (bit-identisch).
     sms_threshold: Optional[float] = None
+    # Issue #1484: True = Eintrag wurde beim Laden aus "temperature"
+    # abgeleitet (Bestands-Trip ohne temperature_night). Abgeleitete
+    # Eintraege werden NICHT zurueckgeschrieben — Laden erfindet keine
+    # Daten, erst ein bewusster Editor-Save materialisiert die Auswahl.
+    derived: bool = False
 
 
 def _filter_metrics_by_report_type(

--- a/src/output/renderers/channel_layout.py
+++ b/src/output/renderers/channel_layout.py
@@ -82,6 +82,10 @@ def render_for_channel(
     Liste (Fallback) liefert.
     """
     enabled = dc.get_metrics_for_channel(channel, report_type)
+    # #1484: Nachtfenster-Skalar — nie eine Tabellenspalte/Detail-Zeile;
+    # den Wert tragen SMS-Token bzw. die Abend-Untergrenzen der
+    # Kurzzusammenfassung/Telegram-Kurzuebersicht.
+    enabled = [m for m in enabled if m.metric_id != "temperature_night"]
     primary = sorted(
         [m for m in enabled if m.bucket == "primary"], key=lambda m: m.order,
     )

--- a/src/output/renderers/compact_summary.py
+++ b/src/output/renderers/compact_summary.py
@@ -169,11 +169,23 @@ class CompactSummaryFormatter:
 
         parts: list[str] = []
 
+        # Issue #1484: die Nacht-Untergrenze folgt der EIGENEN Groesse
+        # "temperature_night", nicht mehr "temperature".
+        night_selected = "temperature_night" in enabled
         if "temperature" in enabled:
             t = self._format_temperature(
                 summary, enabled["temperature"].use_friendly_format,
-                report_type=report_type, night_min_c=night_min_c,
+                report_type=report_type,
+                night_min_c=night_min_c if night_selected else None,
                 hiking_min_c=hiking_min_c, hiking_max_c=hiking_max_c,
+            )
+            if t:
+                parts.append(t)
+        elif night_selected:
+            # Nur die Nachtgroesse gewaehlt: abends ihr Wert als Einzelangabe
+            # (derselbe Formatierer, ohne Tages-Aggregat), morgens nichts.
+            t = self._format_temperature(
+                None, False, report_type=report_type, night_min_c=night_min_c,
             )
             if t:
                 parts.append(t)

--- a/src/output/renderers/compare_hourly_metric_ids.py
+++ b/src/output/renderers/compare_hourly_metric_ids.py
@@ -56,7 +56,7 @@ for _legacy, _metric_id in FRONTEND_TO_HOURLY_METRIC_ID.items():
 # AC-11 (PO-Entscheid 2026-08-01): ausdruecklich vom Stundenverlauf
 # ausgenommene Groessen. BENANNTE Menge statt stillem Fehlen -- Bedienflaeche,
 # Aufloeser und Tests geben so dieselbe Auskunft.
-HOURLY_EXCLUDED_METRIC_IDS: frozenset[str] = frozenset({"sunshine"})
+HOURLY_EXCLUDED_METRIC_IDS: frozenset[str] = frozenset({"sunshine", "temperature_night"})
 
 # Begruendung, die die Bedienflaeche anzeigt (ueber die Katalogantwort, s.
 # compare_metric_catalog.get_compare_metric_catalog). Nennt den Grund UND die
@@ -66,6 +66,10 @@ HOURLY_EXCLUSION_REASON: dict[str, str] = {
         "Stuendlich nur als Einstrahlung (W/m²) verfuegbar, nicht als "
         "Sonnenstunden — die Bewölkung und der UV-Index beantworten dieselbe "
         "Frage stundengenau."
+    ),
+    "temperature_night": (
+        "Nachtfenster-Skalar (#1484), kein Stundenwert — stuendlich "
+        "beantwortet die Temperatur dieselbe Frage."
     ),
 }
 

--- a/src/output/renderers/email/helpers.py
+++ b/src/output/renderers/email/helpers.py
@@ -90,6 +90,13 @@ def should_merge_wind_dir(dc: UnifiedWeatherDisplayConfig) -> bool:
 # Row extraction (per-segment hourly + per-night-block aggregation)
 # ----------------------------------------------------------------------
 
+# Issue #1484: Groessen ohne Stundenspalten-Semantik — der Nachtfenster-
+# Skalar erscheint als SMS-Token bzw. Abend-Untergrenze, nie als Spalte.
+# EINE Quelle fuer alle Trip-Zeilen-Bauer (Pendant der Compare-Seite:
+# compare_hourly_metric_ids.HOURLY_EXCLUDED_METRIC_IDS).
+NO_HOURLY_COLUMN_METRIC_IDS: frozenset[str] = frozenset({"temperature_night"})
+
+
 def dp_to_row(dp: ForecastDataPoint, dc: UnifiedWeatherDisplayConfig,
               *, tz: ZoneInfo) -> dict:
     """Convert a single ForecastDataPoint → row dict via MetricCatalog."""
@@ -108,6 +115,8 @@ def dp_to_row(dp: ForecastDataPoint, dc: UnifiedWeatherDisplayConfig,
         # z.B. confidence) werden beim Rendering still ignoriert — auch bei
         # Bestands-display_config mit enabled=True (AC-4).
         if not metric_def.selectable:
+            continue
+        if mc.metric_id in NO_HOURLY_COLUMN_METRIC_IDS:
             continue
         row[metric_def.col_key] = getattr(dp, metric_def.dp_field, None)
     if merge_wind_dir and "wind" in row:
@@ -163,6 +172,8 @@ def aggregate_night_block(dps: list[ForecastDataPoint],
         # Issue #710/#715 PO-Regel: nicht-wählbare Metriken (selectable=False)
         # werden beim Rendering still ignoriert (AC-4).
         if not metric_def.selectable:
+            continue
+        if mc.metric_id in NO_HOURLY_COLUMN_METRIC_IDS:
             continue
         values = [
             v for dp in dps
@@ -272,6 +283,8 @@ def visible_cols(rows_or_metrics: list[dict], horizon=_HORIZON_UNSET):
                 # werden auch im neuen Pfad still ignoriert (AC-4).
                 mdef = _METRICS_BY_ID.get(mid)
                 if mdef is not None and not mdef.selectable:
+                    continue
+                if mid in NO_HOURLY_COLUMN_METRIC_IDS:
                     continue
                 out.append(mid)
         return out

--- a/src/output/renderers/narrow.py
+++ b/src/output/renderers/narrow.py
@@ -702,10 +702,24 @@ def render_telegram_bubbles(
         start_hour=day_window_start_hour, end_hour=day_window_end_hour,
     )
     overview_lines: list[str] = ["Kurzübersicht"]
+    # Issue #1484: die Nacht-Untergrenze der T-Zeile folgt der EIGENEN
+    # Groesse "temperature_night". Ohne aktive "temperature" bekommt sie
+    # abends eine eigene Zeile mit dem Register-Kuerzel (TN).
+    _enabled_ids = set(dc.get_enabled_metric_ids())
+    _night_selected = "temperature_night" in _enabled_ids
     for mid in dc.get_enabled_metric_ids():
+        if mid == "temperature_night":
+            if ("temperature" in _enabled_ids or report_type != "evening"
+                    or _night_min_c is None):
+                continue
+            from app.metric_catalog import get_metric
+            overview_lines.extend(_wrap(_esc(
+                f"{get_metric('temperature_night').compact_label} "
+                f"{_night_min_c:.1f}"), _TG_PROSE_WIDTH))
+            continue
         overview_lines.extend(_wrap(_esc(_overview_line(
             mid, seg_tables, fkeys, report_type=report_type,
-            night_min_c=_night_min_c,
+            night_min_c=_night_min_c if _night_selected else None,
             night_wind_chill_min_c=_night_felt_min_c,
             hiking_temp_extrema=_hiking_temp,
             hiking_felt_extrema=_hiking_felt,

--- a/src/output/renderers/sms_trip.py
+++ b/src/output/renderers/sms_trip.py
@@ -111,8 +111,13 @@ SMS_SYMBOL_BY_METRIC: dict[str, str] = {
 # nach Abwahl der Metrik "Gewitter" in der Kurzform stehen. SMS_SYMBOL_BY_METRIC
 # bildet 1:1 ab (nur 'TH:') und wird zusaetzlich fuer Schwellwerte gelesen
 # (#624) -- ein zweiter Eintrag dort wuerde das Schwellwert-Dict verfaelschen.
+# Fix #1484 (PO-Entscheidung 2026-08-03): 'N' wandert von "temperature" zur
+# eigenen waehlbaren Groesse "temperature_night" -- Tages- und Nachttemperatur
+# sind zwei unabhaengige Auswahl-Entscheidungen (Zelt vs. Huette). 'FN' bleibt
+# bewusst bei "wind_chill" (Spec-Abgrenzung 1, feat_1484_night_temp_metric.md).
 SMS_MULTI_SYMBOLS_BY_METRIC: dict[str, tuple[str, ...]] = {
-    "temperature": ("N", "K", "D"),
+    "temperature": ("K", "D"),
+    "temperature_night": ("N",),
     "wind_chill": ("FN", "FK", "FD", "WC"),
     "thunder": ("TH:", "TH+:"),
 }

--- a/src/output/renderers/trip_report.py
+++ b/src/output/renderers/trip_report.py
@@ -47,7 +47,10 @@ import services.alert_urgency as alert_urgency
 from services.report_config_resolver import ReportRenderOptions, resolve_report_render_options
 from services.risk_engine import RiskEngine
 from output.renderers.email import render_email
-from output.renderers.email.helpers import build_friendly_keys
+from output.renderers.email.helpers import (
+    NO_HOURLY_COLUMN_METRIC_IDS,
+    build_friendly_keys,
+)
 from output.tokens.dto import MetricSpec, TokenLine
 
 
@@ -452,6 +455,10 @@ class TripReportFormatter:
                 continue
             if mc.metric_id == "wind_direction" and merge_wind_dir:
                 continue
+            # #1484: Nachtfenster-Skalar, keine Stundenspalte — EINE Quelle
+            # der Regel: email/helpers.NO_HOURLY_COLUMN_METRIC_IDS.
+            if mc.metric_id in NO_HOURLY_COLUMN_METRIC_IDS:
+                continue
             try:
                 metric_def = get_metric(mc.metric_id)
             except KeyError:
@@ -538,6 +545,10 @@ class TripReportFormatter:
                 continue
             if mc.metric_id == "wind_direction" and merge_wind_dir:
                 continue  # Merged into wind column below
+            # #1484: Nachtfenster-Skalar, keine Stundenspalte — EINE Quelle
+            # der Regel: email/helpers.NO_HOURLY_COLUMN_METRIC_IDS.
+            if mc.metric_id in NO_HOURLY_COLUMN_METRIC_IDS:
+                continue
             try:
                 metric_def = get_metric(mc.metric_id)
             except KeyError:

--- a/src/services/compare_slot_scheduler.py
+++ b/src/services/compare_slot_scheduler.py
@@ -88,6 +88,14 @@ def presets_due_for_hour(presets: list, hour: int, today: date) -> list:
                 if date.fromisoformat(end_date_str) < today:
                     continue
 
+            # #511: weekly gate't auf den Versandtag (beide Slots) — sonst
+            # sendet ein Wochen-Abo taeglich. Fehlt `weekday` (Altbestand),
+            # verhaelt sich das Preset wie daily.
+            if preset.get("schedule") == "weekly":
+                weekday = preset.get("weekday")
+                if weekday is not None and int(weekday) != today.weekday():
+                    continue
+
             slots = resolve_preset_slots(preset)
         except (ValueError, TypeError) as e:
             logger.warning(

--- a/src/services/preview_service.py
+++ b/src/services/preview_service.py
@@ -211,9 +211,12 @@ class PreviewService:
         # FixtureProvider durchreichen wie an _fetch_weather (Z.158-163) --
         # sonst loest die Demo-Vorschau einen echten Live-open-meteo-Call
         # fuer das Nacht-Segment aus und verletzt den Demo-Vertrag.
+        # Issue #1484 AC-8: auch die gewaehlte Nacht-Tiefsttemperatur
+        # braucht Nachtdaten, nicht nur die Nacht-Stundentabelle — geteilte
+        # Entscheidung night_weather_needed (Paritaet zum Versand).
+        from services.segment_weather import fetch_night_weather, night_weather_needed
         night_weather = None
-        if segment_weather and trip.display_config.show_night_block:
-            from services.segment_weather import fetch_night_weather
+        if segment_weather and night_weather_needed(trip.display_config):
             night_weather = fetch_night_weather(segment_weather[-1], provider=provider)
 
         # Issue #474: F12 Wetterlage-Label vor format_email berechnen.

--- a/src/services/segment_weather.py
+++ b/src/services/segment_weather.py
@@ -392,6 +392,21 @@ class SegmentWeatherService:
             )
 
 
+def night_weather_needed(dc) -> bool:
+    """Braucht dieser Trip Nachtdaten? (#1484 AC-8)
+
+    Ja bei aktiver Nacht-Stundentabelle (``show_night_block``, bisheriges
+    Kriterium) ODER gewaehlter Nacht-Tiefsttemperatur — sonst zeigt die
+    Vorschau ein ``N``, das still auf den Tageswert zurueckfaellt, waehrend
+    der Versand den echten Nachtwert traegt. Geteilte Entscheidung fuer
+    preview_service; der Versand-Scheduler beschafft ohnehin immer.
+    """
+    return bool(
+        getattr(dc, "show_night_block", False)
+        or (dc is not None and dc.is_metric_enabled("temperature_night"))
+    )
+
+
 def fetch_night_weather(
     last_segment: SegmentWeatherData,
     provider: "Optional[WeatherProvider]" = None,

--- a/tests/fixtures/shared_metric_format_parity/format_value_severity_grid.tsv
+++ b/tests/fixtures/shared_metric_format_parity/format_value_severity_grid.tsv
@@ -160,6 +160,15 @@ temperature	42	42°C	42	red
 temperature	137.0	137°C	137	red
 temperature	1013.0	1013°C	1013	red
 temperature	20000	20000°C	20000	red
+temperature_night	None	–	–	None
+temperature_night	-12.5	-12°C	-12	None
+temperature_night	0	0°C	0	None
+temperature_night	0.4	0°C	0	None
+temperature_night	7.5	8°C	8	None
+temperature_night	42	42°C	42	None
+temperature_night	137.0	137°C	137	None
+temperature_night	1013.0	1013°C	1013	None
+temperature_night	20000	20000°C	20000	None
 thunder	None	–	–	None
 thunder	-12.5	-12	-12	None
 thunder	0	0	0	None

--- a/tests/tdd/test_compact_summary_hiking_min_and_felt.py
+++ b/tests/tdd/test_compact_summary_hiking_min_and_felt.py
@@ -20,7 +20,11 @@ _DASH = "–"  # En-Dash, wie in der bestehenden Abend-Spanne
 
 
 def _summary(report_type: str, *, felt_enabled: bool = False, with_night: bool = True) -> str:
-    metrics = ("temperature", "wind_chill") if felt_enabled else ("temperature",)
+    # #1484: die Abend-Untergrenze (Nachtwert) braucht die eigene Nachtgroesse.
+    metrics = (
+        ("temperature", "temperature_night", "wind_chill") if felt_enabled
+        else ("temperature", "temperature_night")
+    )
     return CompactSummaryFormatter().format_stage_summary(
         [F.segment()],
         F.STAGE_NAME,

--- a/tests/tdd/test_hiking_window_parity.py
+++ b/tests/tdd/test_hiking_window_parity.py
@@ -36,7 +36,9 @@ import pytest
 
 from tests.tdd import _hiking_window_fixtures as F
 
-_FELT = ("temperature", "wind_chill")
+# #1484: temperature_night mit dabei — der AC-7-Nachtwert haengt an der
+# eigenen Groesse; fuer die uebrigen (Morgen-/ohne-Nacht-)Faelle ist sie inert.
+_FELT = ("temperature", "temperature_night", "wind_chill")
 _NUMBER = re.compile(r"-?\d+(?:\.\d+)?")
 
 

--- a/tests/tdd/test_issue_511_weekly_scheduler.py
+++ b/tests/tdd/test_issue_511_weekly_scheduler.py
@@ -132,7 +132,10 @@ class TestWeeklyPresetDispatch:
         _write_presets(tmp_path, "default", [preset])
 
         with caplog.at_level(logging.WARNING):
-            result = _run_compare_presets_daily(user_id="default", data_root=str(tmp_path))
+            # hour=6 fixiert den Morgen-Slot — ohne feste Stunde ist das
+            # Preset ausserhalb von 06:00 Wien nie faellig und der Test
+            # prueft 23 von 24 Stunden nichts (leer-faellig gruen).
+            result = _run_compare_presets_daily(user_id="default", data_root=str(tmp_path), hour=6)
 
         assert result == (0, 0), "Nicht-fälliges weekly-Preset darf nicht in success_count zählen"
         assert not any("cp-weekly-tomorrow" in r.message for r in caplog.records), (
@@ -204,7 +207,8 @@ class TestWeeklyPresetDispatch:
         )
         _write_presets(tmp_path, "default", [preset])
 
-        result = _run_compare_presets_daily(user_id="default", data_root=str(tmp_path))
+        # hour=6 fixiert den Morgen-Slot (s.o. — sonst leer-faellig gruen).
+        result = _run_compare_presets_daily(user_id="default", data_root=str(tmp_path), hour=6)
         assert result == (0, 0)
 
 

--- a/tests/tdd/test_issue_614_telegram_kurzform.py
+++ b/tests/tdd/test_issue_614_telegram_kurzform.py
@@ -154,7 +154,8 @@ def test_ac1_loader_roundtrip_preserves_flag_and_other_fields():
     # Merge/No-Loss: andere Felder unverändert übernommen
     assert dc.show_night_block is False
     assert dc.night_interval_hours == 3
-    assert len(dc.metrics) == 2
+    # #1484: abgeleitete Eintraege zaehlen nicht als geladene Nutzer-Auswahl.
+    assert len([mc for mc in dc.metrics if not mc.derived]) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tdd/test_legacy_flat_metrics_load.py
+++ b/tests/tdd/test_legacy_flat_metrics_load.py
@@ -63,7 +63,9 @@ def test_flat_string_metrics_load_as_metricconfig():
     trip = load_trip(_flat_metrics_trip("gr20-flat"))
 
     assert trip is not None
-    metrics = trip.display_config.metrics
+    # #1484: abgeleitete Eintraege (derived=True) sind keine geladenen
+    # Nutzerdaten — fuer die Migrations-Assertions ausblenden.
+    metrics = [m for m in trip.display_config.metrics if not m.derived]
     assert [m.metric_id for m in metrics] == ["temperature", "wind_speed"], (
         "jeder Flach-String muss als MetricConfig.metric_id erscheinen (AC-1)"
     )
@@ -97,7 +99,8 @@ def test_flat_string_trip_survives_load_all_trips():
         "(vor Fix: 0 — Trip crasht und wird still verworfen, AC-2)"
     )
     assert result[0].id == trip_id
-    assert [m.metric_id for m in result[0].display_config.metrics] == [
+    assert [m.metric_id for m in result[0].display_config.metrics
+            if not m.derived] == [
         "temperature",
         "wind_speed",
     ]
@@ -150,8 +153,8 @@ def test_dict_metrics_roundtrip_field_identical():
     dict_out = _trip_to_dict(trip1)
     trip2 = load_trip(dict_out)
 
-    m1 = trip1.display_config.metrics
-    m2 = trip2.display_config.metrics
+    m1 = [m for m in trip1.display_config.metrics if not m.derived]
+    m2 = [m for m in trip2.display_config.metrics if not m.derived]
     assert len(m1) == len(m2) == 2
 
     fields = ("metric_id", "enabled", "aggregations", "bucket", "order",

--- a/tests/tdd/test_loader_display_config_default.py
+++ b/tests/tdd/test_loader_display_config_default.py
@@ -149,11 +149,15 @@ class TestLoaderDisplayConfigDefault:
         trip = load_trip_from_dict(data)
 
         assert trip.display_config is not None
-        assert len(trip.display_config.metrics) == 1, (
+        # #1484: abgeleitete Eintraege (derived=True) ausblenden — sie sind
+        # keine Ueberschreibung durch den Default, sondern die Bestands-
+        # Ableitung der Nachtgroesse.
+        explicit = [mc for mc in trip.display_config.metrics if not mc.derived]
+        assert len(explicit) == 1, (
             "Eigene Config darf nicht durch Default ueberschrieben werden"
         )
-        assert trip.display_config.metrics[0].metric_id == "temperature"
-        assert trip.display_config.metrics[0].alert_enabled is True
+        assert explicit[0].metric_id == "temperature"
+        assert explicit[0].alert_enabled is True
 
     def test_legacy_weather_config_still_takes_precedence_over_default(self):
         """GIVEN Trip mit Legacy weather_config

--- a/tests/tdd/test_night_temp_evening_only.py
+++ b/tests/tdd/test_night_temp_evening_only.py
@@ -165,7 +165,13 @@ def _dc_temp_only() -> UnifiedWeatherDisplayConfig:
     Metriken (Regen/Wind/Gewitter wuerden sonst z.B. eigene '-'-Zeichen in
     Zeitfenster-Mustern einstreuen und die Temperatur-Zeile verschleiern)."""
     return UnifiedWeatherDisplayConfig(
-        trip_id="e7", metrics=[MetricConfig(metric_id="temperature", enabled=True)],
+        trip_id="e7",
+        metrics=[
+            MetricConfig(metric_id="temperature", enabled=True),
+            # #1484: N haengt an der eigenen Groesse — fuer die
+            # Nachtfenster-Semantik dieser Suite muss sie gewaehlt sein.
+            MetricConfig(metric_id="temperature_night", enabled=True),
+        ],
     )
 
 

--- a/tests/tdd/test_night_temp_own_metric_selection.py
+++ b/tests/tdd/test_night_temp_own_metric_selection.py
@@ -1,0 +1,417 @@
+"""Die Nacht-Tiefsttemperatur folgt ihrer EIGENEN Metrik-Auswahl.
+
+Issue: #1484 — Folge aus #1415. Spec: docs/specs/modules/feat_1484_night_temp_metric.md
+
+PO-Entscheidung 2026-08-03, woertlich: „N soll getrennt waehlbar sein. Wer in
+der Huette uebernachtet, den interessiert der Wert z.B. nicht." Heute haengt
+``N`` (Nacht-Tiefst am Etappenziel, nur Abend-Briefing) an der Wettergroesse
+„Temperatur" (``K``/``D``) — Tages- und Nachttemperatur sind aber zwei
+unabhaengige Entscheidungen (Zelt vs. Huette).
+
+Gemessen wird der echte Weg von der Nutzereinstellung bis zum gerenderten
+Kanaltext (SMS, E-Mail-Kurzzusammenfassung, Telegram-Kurzuebersicht) bzw.
+durch den echten Lade-Pfad (``loader._parse_display_config``) und den echten
+API-Endpoint (``GET /api/metrics``). Keine Mocks, kein Netz, keine
+Dateiinhalt-Pruefungen.
+
+Abgrenzung laut Spec: ``FN`` (gefuehlte Nacht) bleibt an „Gefuehlte
+Temperatur" gekoppelt; die E-Mail-Nacht-Stundentabelle bleibt an
+``show_night_block``.
+"""
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from output.renderers.compact_summary import CompactSummaryFormatter
+from output.renderers.trip_report import TripReportFormatter
+
+from tests.tdd import _min_temp_felt_fixtures as F
+
+NIGHT_METRIC = "temperature_night"
+_MEASURED = ("N", "K", "D")
+_DASH = "–"  # En-Dash der Kurzzusammenfassungs-Spannen
+
+
+def _report(report_type: str, *metric_ids: str, segment=None, night=...):
+    """Echt gerenderter TripReport mit genau den genannten aktiven Metriken."""
+    return TripReportFormatter().format_email(
+        [segment if segment is not None else F.segment()],
+        trip_name="I1484",
+        report_type=report_type,
+        night_weather=F.night_weather() if night is ... else night,
+        display_config=F.dc(*metric_ids),
+        stage_name=F.STAGE_NAME,
+        tz=F.TZ,
+    )
+
+
+def _sms(report_type: str, *metric_ids: str, **kw) -> str:
+    return _report(report_type, *metric_ids, **kw).sms_text
+
+
+def _compact(report_type: str, *metric_ids: str) -> str:
+    return CompactSummaryFormatter().format_stage_summary(
+        [F.segment()], F.STAGE_NAME, F.dc(*metric_ids), F.night_weather(),
+        tz=F.TZ, report_type=report_type,
+    )
+
+
+def _templess_segment():
+    """Segment mit Zeitreihe, aber ohne jede Temperaturmessung (wie #1415)."""
+    seg = F.segment()
+    return dataclasses.replace(
+        seg,
+        timeseries=dataclasses.replace(
+            seg.timeseries,
+            data=[dataclasses.replace(dp, t2m_c=None) for dp in seg.timeseries.data],
+        ),
+        aggregated=dataclasses.replace(
+            seg.aggregated, temp_min_c=None, temp_max_c=None, temp_avg_c=None,
+        ),
+    )
+
+
+def _templess_night():
+    night = F.night_weather()
+    return dataclasses.replace(
+        night, data=[dataclasses.replace(dp, t2m_c=None) for dp in night.data],
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-1 / AC-2 / AC-3 — SMS-Token folgen der eigenen Auswahl
+# ---------------------------------------------------------------------------
+
+class TestSmsNightTokenFollowsOwnSelection:
+
+    def test_night_token_absent_when_night_metric_deselected(self):
+        """AC-1: Temperatur AN, Nachtgroesse AUS -> K/D ja, N nein."""
+        sms = _sms("evening", "temperature", "precipitation")
+
+        present = F.present_symbols(sms, _MEASURED)
+        assert present == {"K", "D"}, (
+            f"Erwartet nur K/D bei abgewaehlter Nachtgroesse, gefunden "
+            f"{sorted(present)} — N haengt offenbar weiter an „Temperatur“.\n"
+            f"SMS: {sms}"
+        )
+
+    def test_night_token_present_without_day_temperature(self):
+        """AC-2: Nachtgroesse AN, Temperatur AUS -> N ja, K/D nein."""
+        sms = _sms("evening", NIGHT_METRIC, "precipitation")
+
+        assert F.sms_token_value(sms, "N") == str(int(F.NIGHT_MIN_C)), (
+            f"N fehlt oder traegt den falschen Wert, obwohl die Nachtgroesse "
+            f"gewaehlt ist (erwartet N{int(F.NIGHT_MIN_C)}).\nSMS: {sms}"
+        )
+        leaked = F.present_symbols(sms, ("K", "D"))
+        assert not leaked, (
+            f"K/D erscheinen {sorted(leaked)}, obwohl „Temperatur“ "
+            f"abgewaehlt ist.\nSMS: {sms}"
+        )
+
+    def test_both_selected_keeps_all_three_tokens(self):
+        """Nichtregression: beide AN -> N/K/D wie bisher."""
+        sms = _sms("evening", "temperature", NIGHT_METRIC, "precipitation")
+
+        assert F.present_symbols(sms, _MEASURED) == {"N", "K", "D"}, (
+            f"Beide Groessen gewaehlt — alle drei Kuerzel erwartet.\nSMS: {sms}"
+        )
+        assert F.sms_token_value(sms, "N") == str(int(F.NIGHT_MIN_C))
+        assert F.sms_token_value(sms, "K") == str(int(F.HIKE_MIN_C))
+        assert F.sms_token_value(sms, "D") == str(int(F.HIKE_MAX_C))
+
+    def test_morning_never_shows_night_token(self):
+        """AC-3: das Nur-Abends-Gate bleibt, auch mit gewaehlter Nachtgroesse."""
+        sms = _sms("morning", "temperature", NIGHT_METRIC, "precipitation")
+
+        assert F.sms_token_value(sms, "N") is None, (
+            f"N erscheint im Morgen-Briefing.\nSMS: {sms}"
+        )
+
+    def test_selected_night_without_data_keeps_null_form(self):
+        """#1415-Regel gilt auch fuer die neue Groesse: gewaehlt ohne Wert
+        -> Null-Form ``N-``, nicht verschwinden."""
+        sms = _sms(
+            "evening", NIGHT_METRIC, "precipitation",
+            segment=_templess_segment(), night=_templess_night(),
+        )
+
+        assert F.sms_token_value(sms, "N") == "-", (
+            f"Gewaehlte Nachtgroesse ohne Daten muss als „N-“ sichtbar "
+            f"bleiben (gefunden: {F.sms_token_value(sms, 'N')!r}).\nSMS: {sms}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 — E-Mail-Kurzzusammenfassung
+# ---------------------------------------------------------------------------
+
+class TestCompactSummaryNightBound:
+
+    def test_evening_shows_day_range_when_night_deselected(self):
+        text = _compact("evening", "temperature", "precipitation")
+        parts = F.compact_parts(text)
+
+        assert parts, f"Kurzzusammenfassung leer.\nSatz: {text!r}"
+        expected = f"{int(F.HIKE_MIN_C)}{_DASH}{int(F.HIKE_MAX_C)}°C"
+        assert parts[0] == expected, (
+            f"Abend-Untergrenze muss ohne Nachtgroesse die kaelteste "
+            f"Gehzeit-Stunde sein ({expected!r}), gefunden {parts[0]!r} — "
+            f"die Nacht-Untergrenze haengt offenbar weiter an „Temperatur“.\n"
+            f"Satz: {text!r}"
+        )
+
+    def test_evening_night_bound_when_both_selected(self):
+        """Nichtregression: beide AN -> Nacht-Untergrenze wie bisher."""
+        text = _compact("evening", "temperature", NIGHT_METRIC, "precipitation")
+        parts = F.compact_parts(text)
+
+        expected = f"{int(F.NIGHT_MIN_C)}{_DASH}{int(F.HIKE_MAX_C)}°C"
+        assert parts and parts[0] == expected, (
+            f"Beide Groessen gewaehlt — {expected!r} erwartet, gefunden "
+            f"{parts[0] if parts else None!r}.\nSatz: {text!r}"
+        )
+
+    def test_evening_night_value_alone_when_only_night_selected(self):
+        text = _compact("evening", NIGHT_METRIC)
+        parts = F.compact_parts(text)
+
+        assert any(p == f"{int(F.NIGHT_MIN_C)}°C" for p in parts), (
+            f"Nur die Nachtgroesse ist gewaehlt — ihr Wert "
+            f"({int(F.NIGHT_MIN_C)}°C) muss im Satz stehen.\nSatz: {text!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 — Telegram-Kurzuebersicht
+# ---------------------------------------------------------------------------
+
+class TestTelegramOverviewNightBound:
+
+    def test_evening_t_line_without_night_substitution(self):
+        report = _report("evening", "temperature", "precipitation")
+        tline = F.overview_line(report, "T")
+
+        assert tline, (
+            "Die T-Zeile der Kurzuebersicht fehlt komplett — Vorbedingung "
+            "des Nachweises verletzt."
+        )
+        assert f"{F.NIGHT_MIN_C:.1f}" not in tline, (
+            f"Die Abend-T-Zeile zeigt die Nacht-Untergrenze, obwohl die "
+            f"Nachtgroesse abgewaehlt ist.\nZeile: {tline!r}"
+        )
+
+    def test_evening_t_line_with_night_substitution_when_selected(self):
+        """Nichtregression: beide AN -> Nacht-Untergrenze in der T-Zeile."""
+        report = _report("evening", "temperature", NIGHT_METRIC, "precipitation")
+        tline = F.overview_line(report, "T")
+
+        assert f"{F.NIGHT_MIN_C:.1f}" in tline, (
+            f"Beide Groessen gewaehlt — die Abend-T-Zeile muss die "
+            f"Nacht-Untergrenze zeigen.\nZeile: {tline!r}"
+        )
+
+    def test_evening_night_value_visible_when_only_night_selected(self):
+        report = _report("evening", NIGHT_METRIC)
+        bubble = F.overview_bubble(report)
+        value_lines = [ln for ln in bubble.splitlines()[1:] if ln.strip()]
+
+        assert any(str(int(F.NIGHT_MIN_C)) in ln for ln in value_lines), (
+            f"Nur die Nachtgroesse ist gewaehlt — ihr Wert muss in der "
+            f"Kurzuebersicht erscheinen.\nBubble: {bubble!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — Katalog & API
+# ---------------------------------------------------------------------------
+
+class TestCatalogAndApi:
+
+    @pytest.fixture
+    def metrics_client(self) -> TestClient:
+        from api.routers import config
+
+        app = FastAPI()
+        app.include_router(config.router, prefix="/api")
+        return TestClient(app)
+
+    def test_catalog_offers_night_metric_as_selectable(self):
+        from app.metric_catalog import get_all_metrics
+
+        ids = {m.id for m in get_all_metrics()}
+        assert NIGHT_METRIC in ids, (
+            "„Nacht-Tiefsttemperatur“ fehlt im waehlbaren Katalog."
+        )
+        assert "temperature_cold" not in ids, (
+            "Die Alarm-Pseudogroesse temperature_cold darf nicht waehlbar "
+            "werden (#914) — sie ist NICHT die Bindung fuer N."
+        )
+
+    def test_api_metrics_exposes_night_metric_next_to_temperature(self, metrics_client):
+        resp = metrics_client.get("/api/metrics")
+        assert resp.status_code == 200
+        catalog = resp.json()
+
+        by_id = {m["id"]: (cat, m) for cat, ms in catalog.items() for m in ms}
+        assert NIGHT_METRIC in by_id, (
+            f"GET /api/metrics liefert {sorted(by_id)} — die Nachtgroesse fehlt."
+        )
+        assert "temperature_cold" not in by_id
+        night_cat, night = by_id[NIGHT_METRIC]
+        temp_cat, _ = by_id["temperature"]
+        assert night_cat == temp_cat, (
+            f"Die Nachtgroesse steht in Kategorie {night_cat!r}, "
+            f"„Temperatur“ in {temp_cat!r} — beide gehoeren zusammen."
+        )
+        assert "Nacht" in night["label"], (
+            f"Editor-Beschriftung muss den Nachtbezug tragen: {night['label']!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-6 / AC-7 — Bestands-Trips ueber den echten Lade-Pfad
+# ---------------------------------------------------------------------------
+
+class TestLegacyTripsDeriveNightFromTemperature:
+    """Ableitungsregel beim Lesen: fehlt ``temperature_night`` im gespeicherten
+    ``display_config``, gilt die Nachtgroesse als aktiviert genau dann, wenn
+    „Temperatur“ aktiviert ist — niemand wird ueberrascht."""
+
+    @staticmethod
+    def _dc_from_stored(metrics: list[dict]):
+        from app.loader import _parse_display_config
+
+        return _parse_display_config({"metrics": metrics, "show_night_block": True})
+
+    def _evening_sms(self, dc) -> str:
+        return TripReportFormatter().format_email(
+            [F.segment()], trip_name="I1484", report_type="evening",
+            night_weather=F.night_weather(), display_config=dc,
+            stage_name=F.STAGE_NAME, tz=F.TZ,
+        ).sms_text
+
+    def test_stored_trip_with_temperature_keeps_night_token(self):
+        """AC-6: Bestands-Trip (Temperatur AN, kein Nacht-Eintrag) verhaelt
+        sich wie vor der Aenderung."""
+        dc = self._dc_from_stored([
+            {"metric_id": "temperature", "enabled": True},
+            {"metric_id": "precipitation", "enabled": True},
+        ])
+        sms = self._evening_sms(dc)
+
+        assert F.sms_token_value(sms, "N") == str(int(F.NIGHT_MIN_C)), (
+            f"Bestands-Trip mit aktivierter Temperatur verliert sein N — "
+            f"stille Verhaltensaenderung fuer Altbestand.\nSMS: {sms}"
+        )
+
+    def test_stored_trip_without_temperature_stays_night_free(self):
+        """AC-7: Temperatur AUS -> Nachtgroesse startet AUS."""
+        dc = self._dc_from_stored([
+            {"metric_id": "temperature", "enabled": False},
+            {"metric_id": "precipitation", "enabled": True},
+        ])
+        sms = self._evening_sms(dc)
+
+        assert F.present_symbols(sms, _MEASURED) == set(), (
+            f"Bestands-Trip ohne Temperatur zeigt ploetzlich "
+            f"Temperatur-Kuerzel.\nSMS: {sms}"
+        )
+
+    def test_explicit_night_entry_wins_over_derivation(self):
+        """Ein gespeicherter expliziter Nacht-Eintrag schlaegt die Ableitung."""
+        dc = self._dc_from_stored([
+            {"metric_id": "temperature", "enabled": True},
+            {"metric_id": NIGHT_METRIC, "enabled": False},
+            {"metric_id": "precipitation", "enabled": True},
+        ])
+        sms = self._evening_sms(dc)
+
+        present = F.present_symbols(sms, _MEASURED)
+        assert present == {"K", "D"}, (
+            f"Explizit abgewaehlte Nachtgroesse muss die Ableitung "
+            f"ueberstimmen — gefunden {sorted(present)}.\nSMS: {sms}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-8 — Nacht-Datenbeschaffung haengt an der Auswahl, nicht nur an der Tabelle
+# ---------------------------------------------------------------------------
+
+class TestNightFetchFollowsMetricSelection:
+    """Vorschau-Pfad (preview_service) beschafft Nachtdaten heute nur bei
+    ``show_night_block`` — mit gewaehlter Nachtgroesse zeigte ``N`` dort still
+    den Tageswert. Der Versand-Scheduler beschafft immer; die geteilte
+    Entscheidung wandert nach ``services.segment_weather.night_weather_needed``
+    (Verdrahtung in preview_service prueft der Adversary per Mutation)."""
+
+    def test_needed_when_night_metric_selected_without_table(self):
+        from services.segment_weather import night_weather_needed
+
+        dc = F.dc(NIGHT_METRIC, "precipitation")
+        dc.show_night_block = False
+        assert night_weather_needed(dc), (
+            "Gewaehlte Nachtgroesse braucht Nachtdaten — auch ohne "
+            "Nacht-Stundentabelle."
+        )
+
+    def test_needed_when_table_enabled(self):
+        from services.segment_weather import night_weather_needed
+
+        dc = F.dc("temperature")
+        dc.show_night_block = True
+        assert night_weather_needed(dc), (
+            "Heutiges Verhalten bleibt: Nacht-Stundentabelle braucht Nachtdaten."
+        )
+
+    def test_not_needed_when_neither(self):
+        from services.segment_weather import night_weather_needed
+
+        dc = F.dc("temperature")
+        dc.show_night_block = False
+        assert not night_weather_needed(dc), (
+            "Weder Tabelle noch Nachtgroesse — kein Grund fuer einen "
+            "Nacht-Abruf in der Vorschau."
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-9 — Auswahl wirkt strikt pro Konfiguration (keine Vermischung)
+# ---------------------------------------------------------------------------
+
+class TestSelectionIsPerConfig:
+
+    def test_two_configs_render_independently(self):
+        """Zwei entgegengesetzte Konfigurationen, nacheinander gerendert —
+        jede SMS folgt nur der eigenen Auswahl (kein globaler Zustand)."""
+        dc_night = F.dc(NIGHT_METRIC, "precipitation")
+        dc_day = F.dc("temperature", "precipitation")
+
+        fmt = TripReportFormatter()
+        sms_night = fmt.format_email(
+            [F.segment()], trip_name="UserA", report_type="evening",
+            night_weather=F.night_weather(), display_config=dc_night,
+            stage_name=F.STAGE_NAME, tz=F.TZ,
+        ).sms_text
+        sms_day = fmt.format_email(
+            [F.segment()], trip_name="UserB", report_type="evening",
+            night_weather=F.night_weather(), display_config=dc_day,
+            stage_name=F.STAGE_NAME, tz=F.TZ,
+        ).sms_text
+
+        assert F.present_symbols(sms_night, _MEASURED) == {"N"}, (
+            f"Konfiguration A (nur Nacht) zeigt {sorted(F.present_symbols(sms_night, _MEASURED))}."
+        )
+        assert F.present_symbols(sms_day, _MEASURED) == {"K", "D"}, (
+            f"Konfiguration B (nur Temperatur) zeigt "
+            f"{sorted(F.present_symbols(sms_day, _MEASURED))} — die Auswahl "
+            f"von A faerbt ab."
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/tdd/test_sms_temperature_follows_metric_selection.py
+++ b/tests/tdd/test_sms_temperature_follows_metric_selection.py
@@ -161,11 +161,13 @@ class TestMeasuredTemperatureFollowsSelection:
             )
 
     def test_measured_tokens_present_when_temperature_selected(self):
-        """Nichtregression: gewaehlt -> K/D wie bisher, N nur abends."""
+        """Nichtregression: gewaehlt -> K/D wie bisher. ``N`` gehoert seit
+        #1484 zur eigenen Groesse "temperature_night" (eigene Suite:
+        test_night_temp_own_metric_selection.py)."""
         for report_type in ("morning", "evening"):
             sms = _sms(report_type, "temperature", "precipitation")
 
-            expected = {"K", "D"} | ({"N"} if report_type == "evening" else set())
+            expected = {"K", "D"}
             assert F.present_symbols(sms, _MEASURED) == expected, (
                 f"[{report_type}] Erwartet {sorted(expected)} bei aktivierter "
                 f"Temperatur.\nSMS: {sms}"
@@ -211,7 +213,7 @@ class TestSelectedButNoValueKeepsNullForm:
                 segment=_templess_segment(), night=_templess_night(),
             )
 
-            expected = {"K", "D"} | ({"N"} if report_type == "evening" else set())
+            expected = {"K", "D"}  # N: eigene Groesse seit #1484
             present = F.present_symbols(sms, _MEASURED)
             assert present == expected, (
                 f"[{report_type}] Erwartet {sorted(expected)} als Null-Form, "
@@ -240,8 +242,9 @@ class TestSelectedButNoValueKeepsNullForm:
             segment=_templess_segment(), night=_templess_night(),
         )
 
-        assert F.present_symbols(selected, _MEASURED) == {"N", "K", "D"}, (
-            f"Gewaehlt ohne Wert -> Null-Formen erwartet.\nSMS: {selected}"
+        assert F.present_symbols(selected, _MEASURED) == {"K", "D"}, (
+            f"Gewaehlt ohne Wert -> Null-Formen erwartet (N: eigene Groesse "
+            f"seit #1484).\nSMS: {selected}"
         )
         assert not F.present_symbols(deselected, _MEASURED), (
             f"Abgewaehlt -> gar keine Temperatur-Kuerzel erwartet.\n"

--- a/tests/tdd/test_sms_trip_felt_temp_tokens.py
+++ b/tests/tdd/test_sms_trip_felt_temp_tokens.py
@@ -24,7 +24,12 @@ _FELT = ("FN", "FK", "FD")
 
 def _sms(report_type: str, *, felt_enabled: bool) -> str:
     """Echt gerenderte Trip-SMS — mit bzw. ohne aktivierte gefuehlte Temperatur."""
-    metrics = ("temperature", "wind_chill") if felt_enabled else ("temperature",)
+    # #1484: die Nachtgroesse ist eigenstaendig waehlbar — hier aktiv, damit
+    # die N-Assertions (Parallelitaet gemessen/gefuehlt) aussagekraeftig bleiben.
+    metrics = (
+        ("temperature", "temperature_night", "wind_chill") if felt_enabled
+        else ("temperature", "temperature_night")
+    )
     report = TripReportFormatter().format_email(
         [F.segment()],
         trip_name="Issue1410",

--- a/tests/tdd/test_weather_templates.py
+++ b/tests/tdd/test_weather_templates.py
@@ -67,14 +67,15 @@ class TestWeatherTemplatesRegistry:
     def test_alpen_trekking_has_14_metrics(self):
         """GIVEN alpen-trekking template
         WHEN counting metrics
-        THEN it has 14 metrics including freezing_level, cape, wind_chill.
+        THEN it has 15 metrics including freezing_level, cape, wind_chill.
 
-        Count angepasst (Bug #424): confidence entfernt 15 -> 14.
+        Count angepasst (Bug #424): confidence entfernt 15 -> 14;
+        #1484: temperature_night ergaenzt 14 -> 15.
         """
         from app.metric_catalog import WEATHER_TEMPLATES
 
         metrics = WEATHER_TEMPLATES["alpen-trekking"]["metrics"]
-        assert len(metrics) == 14
+        assert len(metrics) == 15
         assert "freezing_level" in metrics
         assert "cape" in metrics
         assert "wind_chill" in metrics
@@ -82,14 +83,15 @@ class TestWeatherTemplatesRegistry:
     def test_allgemein_has_7_metrics(self):
         """GIVEN allgemein template
         WHEN counting metrics
-        THEN it has 7 basic metrics.
+        THEN it has 8 basic metrics.
 
-        Count angepasst (Bug #424): confidence entfernt 8 -> 7.
+        Count angepasst (Bug #424): confidence entfernt 8 -> 7;
+        #1484: temperature_night ergaenzt 7 -> 8.
         """
         from app.metric_catalog import WEATHER_TEMPLATES
 
         metrics = WEATHER_TEMPLATES["allgemein"]["metrics"]
-        assert len(metrics) == 7
+        assert len(metrics) == 8
 
     def test_profile_metric_ids_removed(self):
         """GIVEN metric_catalog module
@@ -262,9 +264,10 @@ class TestTemplatesEndpoint:
     def test_endpoint_alpen_trekking_metrics(self):
         """GIVEN GET /templates response
         WHEN finding alpen-trekking
-        THEN it has 14 metrics including freezing_level.
+        THEN it has 15 metrics including freezing_level.
 
-        Count angepasst (Bug #424): confidence entfernt 15 -> 14.
+        Count angepasst (Bug #424): confidence entfernt 15 -> 14;
+        #1484: temperature_night ergaenzt 14 -> 15.
         """
         from fastapi.testclient import TestClient
         from api.main import app
@@ -272,5 +275,5 @@ class TestTemplatesEndpoint:
         client = TestClient(app)
         data = client.get("/templates").json()
         alpen = next(t for t in data if t["id"] == "alpen-trekking")
-        assert len(alpen["metrics"]) == 14
+        assert len(alpen["metrics"]) == 15
         assert "freezing_level" in alpen["metrics"]

--- a/tests/test_metric_config_aggregations_roundtrip.py
+++ b/tests/test_metric_config_aggregations_roundtrip.py
@@ -70,7 +70,10 @@ def _trip_dict(temperature_aggs, wind_chill_aggs) -> dict:
 
 
 def _aggs_by_id(trip) -> dict[str, list[str]]:
-    return {mc.metric_id: mc.aggregations for mc in trip.display_config.metrics}
+    # #1484: abgeleitete Eintraege (derived=True) sind keine explizite
+    # Auswahl und werden nie zurueckgeschrieben — hier ausblenden.
+    return {mc.metric_id: mc.aggregations
+            for mc in trip.display_config.metrics if not mc.derived}
 
 
 def _aggs_on_disk(path: Path) -> dict[str, list[str]]:

--- a/tests/unit/test_compare_catalog_derives_from_central_catalog.py
+++ b/tests/unit/test_compare_catalog_derives_from_central_catalog.py
@@ -36,6 +36,20 @@ from output.renderers.compare_metric_catalog import get_compare_metric_catalog
 AGGREGATION_CHECK_EXEMPTIONS: dict[str, str] = {}
 
 # ---------------------------------------------------------------------------
+# Deckungs-Ausnahme zu Pruefung (a) -- klein, benannt, DARF NUR SCHRUMPFEN.
+# Zentrale Groessen, deren Vergleichs-Aussage bereits ein ANDERER
+# Compare-Eintrag traegt: ein eigener Eintrag waere dieselbe Zahl unter
+# zweitem Namen (totes Bedienelement, #1372).
+# ---------------------------------------------------------------------------
+CENTRAL_METRICS_COVERED_ELSEWHERE: dict[str, str] = {
+    # #1484: Nacht-Tiefsttemperatur ist die Trip-Sicht auf das Nachtfenster
+    # am Etappenziel. Im Ortsvergleich (ganze Tage am festen Ort) ist das
+    # Tages-Minimum dieselbe Aussage -- Eintrag `temp_min_c`
+    # (temperature/min) deckt sie ab.
+    "temperature_night": "#1484 — deckungsgleich mit temp_min_c (temperature/min)",
+}
+
+# ---------------------------------------------------------------------------
 # Festnagelung fuer die Ausnahmen (F001): die Ausnahme betrifft AUSSCHLIESSLICH
 # den Abgleich gegen `summary_fields`. Die `aggregation` muss weiterhin eine der
 # zentralen `default_aggregations` sein -- und wo davon mehr als eine zur Wahl
@@ -76,8 +90,12 @@ def _central_metrics_without_compare_entry(
     Groessen erreicht der Compare-Katalog NICHT (sortiert, leer = in Ordnung).
     Herausgezogen, damit Produktions-Guard (echte Daten) und Wirkungsnachweis
     (reduzierte Kopie) DIESELBE Logik ausfuehren -- inklusive
-    `_compare_metric_ids()`."""
-    return sorted(set(central) - _compare_metric_ids(entries))
+    `_compare_metric_ids()`. Deckungs-Ausnahmen (s.
+    CENTRAL_METRICS_COVERED_ELSEWHERE) gelten in BEIDEN Laeufen."""
+    return sorted(
+        (set(central) - _compare_metric_ids(entries))
+        - set(CENTRAL_METRICS_COVERED_ELSEWHERE)
+    )
 
 
 def _aggregation_violations(

--- a/tests/unit/test_compare_hourly_catalog_columns.py
+++ b/tests/unit/test_compare_hourly_catalog_columns.py
@@ -31,7 +31,10 @@ from app.metric_catalog import get_all_metrics, get_metric
 from app.models import ForecastDataPoint, ThunderLevel
 from app.user import ComparisonResult, LocationResult, SavedLocation
 from output.renderers.comparison import render_compare_email, render_comparison_text
-from output.renderers.compare_hourly_metric_ids import resolve_hourly_metrics
+from output.renderers.compare_hourly_metric_ids import (
+    HOURLY_EXCLUDED_METRIC_IDS,
+    resolve_hourly_metrics,
+)
 from output.renderers.compare_metric_ids import resolve_enabled_metrics
 from output.renderers.email.compare_html import (
     HOUR_METRICS, has_visible_hour_columns, render_compare_html,
@@ -333,22 +336,38 @@ def test_an_exempt_metric_never_produces_an_hour_column(metric_id):
     """
     metric = get_metric(metric_id)
 
-    assert metric.dp_field not in {m["key"] for m in HOUR_METRICS}, (
-        f"'{metric_id}' hat trotz Ausnahme einen Eintrag in der "
-        "Spaltenliste — sie wuerde als Spalte erscheinen."
-    )
+    # #1484: eine Ausnahme darf sich ein dp_field mit einer NICHT
+    # ausgenommenen Groesse teilen (temperature_night nutzt t2m_c wie die
+    # Temperatur) — dann gehoert die Spalte dem legitimen Eigentuemer und
+    # der Feld-Check waere ein Fehlalarm. Nur ohne solchen Eigentuemer muss
+    # das Feld komplett fehlen.
+    _owners = [
+        m for m in get_all_metrics()
+        if m.dp_field == metric.dp_field
+        and m.id not in HOURLY_EXCLUDED_METRIC_IDS
+    ]
+    if not _owners:
+        assert metric.dp_field not in {m["key"] for m in HOUR_METRICS}, (
+            f"'{metric_id}' hat trotz Ausnahme einen Eintrag in der "
+            "Spaltenliste — sie wuerde als Spalte erscheinen."
+        )
     assert resolve_hourly_metrics([metric_id]) == [], (
         f"Der Aufloeser laesst die ausgenommene Groesse '{metric_id}' durch: "
         f"{resolve_hourly_metrics([metric_id])}"
     )
 
-    html = render_compare_html(
-        _result(), hourly_metrics=["t2m_c", metric.dp_field],
-    )
-    assert _html_hour_header(html) == ["Zeit", get_metric("temperature").col_label], (
-        f"Die ausgenommene Groesse '{metric_id}' hat doch eine Spalte "
-        f"erzeugt: {_html_hour_header(html)}"
-    )
+    # Render-Nachweis nur fuer Ausnahmen mit EIGENEM Feld: bei geteiltem
+    # dp_field (temperature_night -> t2m_c) waere ["t2m_c", "t2m_c"] kein
+    # Nachweis ueber die Ausnahme, sondern nur ein Duplikat der
+    # Temperatur-Spalte. Der Aufloeser-Check oben deckt diesen Fall ab.
+    if not _owners:
+        html = render_compare_html(
+            _result(), hourly_metrics=["t2m_c", metric.dp_field],
+        )
+        assert _html_hour_header(html) == ["Zeit", get_metric("temperature").col_label], (
+            f"Die ausgenommene Groesse '{metric_id}' hat doch eine Spalte "
+            f"erzeugt: {_html_hour_header(html)}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_preview_night_block.py
+++ b/tests/unit/test_preview_night_block.py
@@ -231,3 +231,72 @@ def test_demo_preview_night_fetch_never_touches_live_openmeteo(monkeypatch):
         f"Nacht-Sektion fehlt trotz show_night_block=True + Nacht-Fixture-Daten:\n"
         f"{report.email_html[:2000]}"
     )
+
+
+def test_preview_night_fetch_follows_night_metric_selection(monkeypatch):
+    """#1484 AC-8 an der WIRKSTELLE (nicht nur am Praedikat): ist die
+    Nacht-Stundentabelle aus (``show_night_block=False``), aber die Groesse
+    "Nacht-Tiefsttemperatur" gewaehlt, beschafft die Vorschau trotzdem
+    Nachtdaten — sonst zeigt ``N`` dort still den Tageswert, waehrend der
+    Versand den echten Nachtwert traegt.
+
+    Muster wie die F001-Falle oben: die ECHTE ``fetch_night_weather`` wird
+    nur mit einem Aufruf-Rekorder umwickelt (kein Mock-Rueckgabewert) und
+    laeuft im Demo-Modus gegen den FixtureProvider — kein Netz.
+    """
+    import services.segment_weather as sw
+
+    calls: list[int] = []
+    real_fetch = sw.fetch_night_weather
+
+    def _recording_fetch(seg, provider=None):
+        calls.append(1)
+        return real_fetch(seg, provider=provider)
+
+    monkeypatch.setattr(sw, "fetch_night_weather", _recording_fetch)
+
+    target = date.today()
+    trip = _demo_trip_single_stage(target, show_night_block=False)
+    assert trip.display_config.is_metric_enabled("temperature_night"), (
+        "Vorbedingung: die Default-Konfiguration muss die Nachtgroesse "
+        "aktiviert haben (build_default_display_config, #1484)."
+    )
+
+    PreviewService()._build_report(trip, target, "evening", demo=True)
+
+    assert calls, (
+        "Die Vorschau beschafft KEINE Nachtdaten, obwohl die "
+        "Nacht-Tiefsttemperatur gewaehlt ist (#1484 AC-8) — N faellt dort "
+        "still auf den Tageswert zurueck."
+    )
+
+
+def test_preview_skips_night_fetch_when_neither_selected(monkeypatch):
+    """Gegenprobe zu AC-8: weder Nacht-Stundentabelle noch Nachtgroesse
+    gewaehlt -> die Vorschau beschafft keine Nachtdaten (kein unnoetiger
+    Provider-Aufruf)."""
+    import services.segment_weather as sw
+
+    calls: list[int] = []
+    real_fetch = sw.fetch_night_weather
+
+    def _recording_fetch(seg, provider=None):
+        calls.append(1)
+        return real_fetch(seg, provider=provider)
+
+    monkeypatch.setattr(sw, "fetch_night_weather", _recording_fetch)
+
+    target = date.today()
+    trip = _demo_trip_single_stage(target, show_night_block=False)
+    trip.display_config.metrics = [
+        dataclasses.replace(mc, enabled=False)
+        if mc.metric_id == "temperature_night" else mc
+        for mc in trip.display_config.metrics
+    ]
+
+    PreviewService()._build_report(trip, target, "evening", demo=True)
+
+    assert calls == [], (
+        "Die Vorschau beschafft Nachtdaten, obwohl weder Tabelle noch "
+        "Nachtgroesse gewaehlt sind."
+    )


### PR DESCRIPTION
Umsetzung von #1484 (session:khw, kritischer Pfad zum 20.8.).

## Stand

- [x] Analyse: Kopplung sitzt in `SMS_MULTI_SYMBOLS_BY_METRIC` (`sms_trip.py`) + drei Nicht-SMS-Bindungen (compact_summary, narrow, Nacht-Datenbeschaffung)
- [x] Spec: `docs/specs/modules/feat_1484_night_temp_metric.md` (AC-1 … AC-9)
- [x] PO-Freigabe der ACs ('go' 2026-08-06)
- [x] TDD RED: 20 Tests, 14 rot am Baseline (per Worktree-Gegenprobe belegt)
- [x] Implementierung (GREEN) + 2 AC-8-Wirkstellen-Tests (Vorschau-Nachtbeschaffung)
- [x] Adversary mit Mutations-Gegenprobe: **Verdict HOLDS** — 12 Mutationen, 11 an der Wirkstelle gefangen; Finding F001 per Rückbau + Spec-Korrektur behoben, Rest → #1199
- [x] CI-Ampel grün: alle 5 Checks auf `b09e1ec`
- [ ] Staging-Validierung + Prod-Deploy + Selftest (Server-Session) — **Issue #1484 bleibt bis Selftest-Exit 0 offen** (bewusst kein Closes-Schlüsselwort)

## Zuschnitt

Neuer Katalogeintrag `temperature_night` (`selectable=True`, default an, in allen Templates); Bindungstabelle aufgeteilt (`temperature: K/D`, `temperature_night: N`). Bestands-Trips: Ableitung beim Lesen (`derived=True`, wird nie serialisiert — Roundtrips feld-identisch); explizit gespeicherte Abwahl gewinnt. Abend-Untergrenze in Kurzzusammenfassung/Telegram folgt der Nachtgröße. `night_weather_needed` teilt die Nacht-Fetch-Entscheidung zwischen Versand und Vorschau. Keine Stundenspalte in Mail/Compare-Tabellen (E-Mail-Goldens bleiben bit-identisch, keine Neuaufzeichnung). Abgrenzungen: `FN` bleibt an `wind_chill`, E-Mail-Nachttabelle bleibt an `show_night_block`, keine Alarm-Funktion (`temperature_cold` unangetastet, #914), Compare-Guard mit benannter Deckungs-Ausnahme (`temp_min_c` trägt dieselbe Aussage).

Beifang auf diesem Branch (Drive-to-green, beide in #1196 gebucht): datumsfixe Fixtures im Forecast-Budget-Test (Mitternachts-Bruch) und die #511-Regression Weekly-Presets ohne Wochentags-Gate inkl. Uhr-Flake der zugehörigen Tests.

Referenz: #1484

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrmdarWn7RjtQ3q3rCumn6