### PR TITLE
fix: Datums-Zeitbombe in forecast_budget_health_test.go entschärft

### DIFF
--- a/internal/scheduler/forecast_budget_health_test.go
+++ b/internal/scheduler/forecast_budget_health_test.go
@@ -46,8 +46,9 @@ func writeForecastBudgetFile(t *testing.T, tmpDir, contents string) {
 
 func TestForecastBudgetSnapshotValidFileReportsFieldsAndRatio(t *testing.T) {
 	tmpDir := t.TempDir()
+	today := time.Now().UTC().Format("2006-01-02")
 	writeForecastBudgetFile(t, tmpDir,
-		`{"date":"2026-08-05","calls":{"openmeteo":900},"cache_hits":10,"cache_misses":5}`)
+		`{"date":"`+today+`","calls":{"openmeteo":900},"cache_hits":10,"cache_misses":5}`)
 
 	snap := forecastBudgetSnapshot(filepath.Join(tmpDir, "diagnostics", "forecast_budget.json"))
 
@@ -107,8 +108,9 @@ func TestForecastBudgetSnapshotCorruptJSONIsUnavailable(t *testing.T) {
 
 func TestSchedulerStatusIncludesForecastBudgetKey(t *testing.T) {
 	tmpDir := t.TempDir()
+	today := time.Now().UTC().Format("2006-01-02")
 	writeForecastBudgetFile(t, tmpDir,
-		`{"date":"2026-08-05","calls":{"openmeteo":42},"cache_hits":1,"cache_misses":2}`)
+		`{"date":"`+today+`","calls":{"openmeteo":42},"cache_hits":1,"cache_misses":2}`)
 	sched := newForecastBudgetHealthTestScheduler(t, tmpDir)
 
 	status := sched.Status()


### PR DESCRIPTION
## Summary
- Zwei Tests hartkodierten `"2026-08-05"` als Datum in ihrer Test-Fixture; der geprüfte Code vergleicht dieses Datum gegen das tatsächliche heutige UTC-Datum und setzt Zähler bei Abweichung auf 0.
- Ab dem 6.8. schlagen beide Tests dadurch deterministisch fehl — unabhängig von jeder inhaltlichen Änderung, blockiert die CI-Ampel für jeden PR im Repo.
- Fix: dynamisches Datum statt hartkodiertem String, exakt nach dem bereits etablierten Muster der übrigen Tests in derselben Datei (Drive-to-Green, gefunden während #923).

## Test plan
- [x] `go test ./internal/scheduler/...` — komplett grün
- [x] Nur die eine Testdatei geändert, kein Produktivcode angefasst

🤖 Generated with [Claude Code](https://claude.com/claude-code)