### PR TITLE
fix(#1435 E4): Schwellwert-Tabelle auf eine Quelle zurückgeführt

### DIFF
--- a/docs/context/fix-1435-e4-schwellwert-quelle.md
+++ b/docs/context/fix-1435-e4-schwellwert-quelle.md
@@ -1,0 +1,236 @@
+# Context: fix-1435-e4-schwellwert-quelle
+
+## Request Summary
+
+Etappe E4 aus #1435: Die Schwellwert-Tabelle („ab welchem Wert löst eine Wettergröße
+Alarm aus", je Empfindlichkeitsstufe entspannt/standard/sensibel) existiert zweimal
+handgepflegt — einmal im Python-Backend, einmal im Frontend. Die *Deklaration* soll auf
+eine Quelle zusammengeführt werden; über die *Zahlen* entscheidet der PO.
+
+## Messung: die beiden Tabellen weichen ab
+
+Zahl-für-Zahl-Vergleich `_PRESET_TABLE` (Backend) gegen `METRIC_PRESETS` (Frontend),
+Reihenfolge entspannt/standard/sensibel:
+
+| Metrik | Backend | Frontend | Urteil |
+|---|---|---|---|
+| `freezing_level` (Nullgradgrenze) | 600/400/200 | **400/200/100** | **weicht ab** |
+| `snow_line` | — | 600/400/200 | nur Frontend |
+| `humidity` | — | 25/15/10 | nur Frontend |
+| 11 weitere (`wind_gust`, `cape`, `visibility`, …) | | | deckungsgleich |
+
+### Der heute sichtbare Fehler: Nullgradgrenze
+
+`freezing_level` steht in `ALERTABLE_METRICS` (`alertMetricTable.ts:215`) und wird
+gerendert, sobald der Nutzer die Nullgradgrenze auswählt — die Zeile existiert seit
+E1a-2. Der angezeigte Schwellwerttext kommt aus `levelToThreshold()`, das
+`METRIC_PRESETS` liest. **Der Nutzer sieht also „Δ ≥ 200 m" bei Standard, während das
+Backend erst bei 400 m alarmiert.** Anzeige und Wirkung widersprechen sich.
+
+Ursache vermutlich #959: Dort wurde `snow_line` backendseitig auf `freezing_level`
+konsolidiert und die snow_line-Schwellen 600/400/200 übernommen. Das Frontend behielt
+beide Zeilen — `snow_line` mit den richtigen Zahlen, `freezing_level` mit den alten
+eigenen. Zu verifizieren in der Analyse-Phase.
+
+### Zwei tote Zeilen
+
+- `snow_line` steht **nicht** in `ALERTABLE_METRICS` → wird nie gerendert.
+- `humidity` steht zwar drin, ist aber seit #889/ADR-0010 im Register bewusst nicht als
+  alarmfähig deklariert → kommt nie über den Katalog herein.
+
+Beide sind Kandidaten für ersatzloses Löschen — das war schon in E3a der größere Gewinn.
+**Vor dem Löschen die Einbindung erneut messen**, nicht den Quelltext lesen (in #1435
+dreimal die Ursache falscher Prämissen).
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/alert_preset.py:39-53` | `_PRESET_TABLE` — 13 Metriken × 3 Stufen, die wirksame Quelle |
+| `frontend/src/lib/components/alerts-tab/alertMetricTable.ts:42-95` | `METRIC_PRESETS` — die abgetippte Kopie |
+| `frontend/.../alertMetricTable.ts:20-36` | `METRIC_DEFAULTS` — drittes Zahlen-Set (Fallback ohne Preset) |
+| `frontend/.../alertMetricTable.ts:246` | `levelToThreshold()` — einziger Leser von `METRIC_PRESETS` |
+| `frontend/.../AlertMetricLevelRow.svelte:5` | ruft `levelToThreshold()`, rendert den Text |
+| `frontend/.../shared/AlarmeTab.svelte:282` | bindet `AlertMetricLevelTable` ein — **lebendiger** Pfad, Trip **und** Vergleich |
+| `scripts/generate_alert_metric_mapping.py` | Erzeuger-Muster aus E5, direkt übertragbar |
+| `src/services/compare_alert.py:25`, `weather_change_detection.py:712`, `deviation_alert_engine.py:183` | Konsumenten der Backend-Tabelle |
+
+**Tot:** `AlertMetricTable.svelte` (nur ein Kommentar-Verweis in `ListTable.svelte:10`),
+`AlertsTab.svelte` (durch CorridorEditor ersetzt) — nicht mit `AlertMetricLevelTable`
+verwechseln, das ist der lebendige Pfad.
+
+## Existing Patterns
+
+- **ADR-0045 (aus E5):** generiertes, eingechecktes Artefakt statt Laufzeit-Kopplung oder
+  Handkopie. Python bleibt Quelle, ein Erzeuger-Skript schreibt JSON, das Frontend
+  importiert es direkt. Für E4 unmittelbar übertragbar — und hier **einfacher als bei
+  E5**, weil keine Go-Seite betroffen ist.
+- **Frische-Ratsche** (`test_alert_metric_mapping_parity.py`): fängt Drift zwischen
+  Quelle und generiertem Artefakt.
+- **Ratsche in der Testschicht** (aus E3b), falls eine Schichtgrenze eine direkte
+  Kopplung verbietet.
+
+## Dependencies
+
+- **Upstream:** `AlertMetric`/`AlertRuleKind` aus `src/app/models.py`; Empfindlichkeits-
+  stufen aus #1460 (`ORDINAL_LEVEL_BOUNDS` für `thunder_level` — Niveau statt Delta,
+  liegt neben der Zahlentabelle und ist **nicht** Teil davon).
+- **Downstream:** Alarmregel-Erzeugung beim Speichern eines Trips/Vergleichs; die
+  Schwellwert-Anzeige im Alarme-Reiter beider Editoren.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1435_e5_alert_mapping_unify.md` — direktes Vorbild
+- `docs/specs/modules/feat_864_859_alert_presets.md` — Herkunft der Zahlen
+- `docs/adr/0045-generiertes-eingebettetes-artefakt-fuer-cross-stack-abbildung.md`
+- `docs/adr/0043-empfindlichkeitsstufe-als-niveau-statt-zweiter-alarm-typ.md`
+
+## Risks & Considerations
+
+1. **Die Nullgradgrenzen-Zahlen sind eine PO-Entscheidung, keine Bugfix-Automatik.**
+   E4 wurde ausdrücklich als einzige Etappe mit erneutem PO-Entscheid geführt: Zahlen
+   könnten absichtlich unterschiedlich eingestellt sein. Hier gilt Backend = wirksam,
+   also ist Frontend-anpassen die naheliegende Richtung — vorlegen, nicht annehmen.
+2. **`METRIC_DEFAULTS` ist ein drittes Zahlen-Set** mit anderem Zweck (Fallback ohne
+   Preset). Nicht ungeprüft mit einziehen — sonst wird aus der Zusammenführung ein
+   verstecktes Verhaltensänderung.
+3. **`thunder_level` hat zwei Steuerungen**: Delta-Zahl (1/1/1) und Niveau-Grenzen aus
+   #1460. Eine Zusammenführung, die nur die Zahl zieht, lässt die halbe Wahrheit im
+   Backend — in der Spec als Grenze benennen.
+4. **Tote Zeilen erst nach Messung löschen** (Lehre aus E3a/E3b).
+5. **Neue Ratsche muss beim Einführen gebrochen werden** — ein Wächter zählt erst, wenn
+   jemand die geschützte Sache kaputtgemacht und gesehen hat, dass er anschlägt.
+
+---
+
+# Analysis
+
+## Type
+
+**Bug im Gewand einer Aufräum-Etappe.** E4 war als reine Zusammenführung geplant; die
+Messung fand **zwei nutzersichtbare Fehler**, die genau aus der doppelten Pflege folgen.
+
+## Fund 1 — Nullgradgrenze: Anzeige widerspricht Wirkung
+
+Hergang belegt (`git show e6eac45d`, `git show b65f22a0`):
+
+- **#946** führte `freezing_level` ein, damals **neben** `snow_line` als getrennte Größe.
+  Backend und Frontend waren identisch: `freezing_level` 400/200/100, `snow_line` 600/400/200.
+- **#959** legte beide backendseitig zu einer Größe zusammen und übernahm die
+  `snow_line`-Zahlen 600/400/200. Derselbe Commit fasste im Frontend `ALERTABLE_METRICS`
+  und die Katalog-Zuordnung an — **`METRIC_PRESETS` aber nicht.** Die Zahlen wurden vergessen.
+
+**Es braucht dafür keine neue PO-Entscheidung.** `docs/adr/0019-nullgradgrenze-eine-alert-metrik.md`
+Punkt 4 legt die Preset-Schwellen der konsolidierten Metrik ausdrücklich auf
+**600/400/200 m** fest. E4 setzt eine bestehende Entscheidung durch; das Alarmverhalten
+ändert sich nicht, nur die Anzeige wird ehrlich.
+
+## Fund 2 — Luftfeuchtigkeit ist ein Geister-Bedienelement (nur Trip-Pfad)
+
+Gemessen über `expand_per_metric_levels()`:
+
+```
+Eingabe: {'humidity':'standard', 'snow_line':'sensibel', 'wind_gust':'standard'}
+Erzeugte Regeln: [('freezing_level', 200.0), ('wind_gust', 20.0)]
+humidity erzeugt Regel? False
+```
+
+Ursache ist ein **Absicherungs-Unterschied zwischen den beiden Editoren** (`AlarmeTab.svelte:121`):
+
+| Pfad | Woher die Zeilenliste kommt | Folge |
+|---|---|---|
+| **Vergleich** | Katalog **und** `ALERTABLE_METRICS` gefiltert | Luftfeuchtigkeit erscheint nicht |
+| **Trip** | `Object.keys(metricLevels)` — die **persistierten** Schlüssel, roh (`AlarmeScheduleTab.svelte:39`) | Luftfeuchtigkeit erscheint, wenn gespeichert |
+
+Solche Werte sind real entstanden: Luftfeuchtigkeit war seit #864/#859 (`8682a645`)
+wählbar; das Backend entfernte das Preset erst mit #889 (`f9275fd3`). Wer damals gespeichert
+hat, sieht heute im Trip-Editor eine Zeile „Δ ≥ 15 %", die **nie** einen Alarm auslöst.
+
+`AlertMetricLevelTable.svelte:79` rendert jede übergebene Zeile ungefiltert — die Filterung
+ist allein Sache des Aufrufers, und einer der beiden filtert nicht.
+
+**Offen:** Wie viele Trips tragen tatsächlich einen `humidity`-Schlüssel? Im Worktree
+liegen keine Nutzerdaten; auf Staging/Prod zu messen.
+
+## Fund 3 — `snow_line` ist wirklich tot, `METRIC_DEFAULTS` ebenfalls
+
+- `snow_line`: doppelt abgesichert (`loader.py:711` Migration, `alert_preset.py:170`
+  Normalisierung). Die Frontend-Zeile ist folgenlos — **aber** die Absicherung liegt
+  allein im Backend.
+- `METRIC_DEFAULTS` (14 Einträge): einziger Leser `alertRulesToRowState()`, einziger
+  Aufrufer `AlertMetricTable.svelte` — **nirgends importiert** (nur Kommentar-Verweis in
+  `ListTable.svelte:10`). Kein Backend-Gegenstück. **Kein Zusammenführungsziel**, sondern
+  allenfalls Löschkandidat: sonst führt man Zahlen zusammen, die niemand liest.
+
+## Technischer Ansatz — generiertes Artefakt (ADR-0045), nicht Laufzeit-API
+
+Die Laufzeit-Variante (Werte über die bestehende Katalog-API ausliefern) scheitert an
+`levelToThreshold()`: eine **reine Funktion** `(metric, level)`, aufgerufen tief in
+`AlertMetricLevelRow.svelte:30`. Laufzeitwerte bräuchten Prop-Drilling durch drei
+Einbettungen in beiden Editoren, eine Signaturänderung mit ~15 Test-Aufrufstellen, ein
+Ladefenster in einem heute synchron rendernden Reiter **und** eine Fallback-Tabelle für
+„Core nicht erreichbar" — womit die Dublette durch die Hintertür zurückkäme.
+
+**Empfehlung:** `scripts/generate_alert_preset_table.py` erzeugt
+`frontend/src/lib/generated/alertPresetThresholds.generated.json` in der Form
+`{metric: {kind, entspannt, standard, sensibel}}`. Das `kind` mitzunehmen kostet ~5 Zeilen
+und löst `THRESHOLD_CROSSING_METRICS` — heute eine **zweite** Handkopie in derselben
+Datei — gleich mit ab. Eine Frische-Ratsche fängt jede Drift. Einfacher als E5: keine
+Go-Seite, also nur **eine** generierte Datei.
+
+## Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `scripts/generate_alert_preset_table.py` | CREATE | Erzeuger, ~85 LoC |
+| `frontend/src/lib/generated/alertPresetThresholds.generated.json` | CREATE (generiert) | zählt nicht aufs LoC-Limit |
+| `frontend/src/lib/components/alerts-tab/alertMetricTable.ts` | MODIFY | −58/+22: `METRIC_PRESETS` + `THRESHOLD_CROSSING_METRICS` abgeleitet |
+| `src/services/alert_preset.py` | MODIFY | ~5, Docstring „Quelle für das Frontend" |
+| `tests/tdd/test_alert_preset_table_parity.py` | CREATE | +90, Frische-Ratsche |
+| `frontend/.../alertMetricTable.test.ts` | MODIFY | +25, Wirkungstest der angezeigten Zeile |
+
+**Typbruch beachten:** `Record<AlertMetric, number>` verlangt alle 14 Schlüssel, Python
+liefert 12 → `Partial<Record<…>>`. `levelToThreshold` behandelt `undefined` bereits
+korrekt (`alertMetricTable.ts:249`).
+
+## Scope Assessment
+
+- Dateien: 6
+- Geschätzte LoC: ~170 berührt (Limit 250 — passt, aber nicht großzügig)
+- Risiko: **MEDIUM** — Anzeigepfad in beiden Editoren, Alarmverhalten unberührt
+- Kein neues ADR nötig: ADR-0045 deckt das Muster, ADR-0019 die Zahlen
+
+## Known Limitations (bewusst nicht in dieser Scheibe)
+
+- **`thunder_level` zeigt bei allen drei Stufen „Δ ≥ 1"**, obwohl seit #1460 die
+  Niveau-Grenzen (`ORDINAL_LEVEL_BOUNDS`) entscheiden. Zweiter Anzeigefehler derselben
+  Art, aber andere Fragestellung — braucht eine Wortlaut-Entscheidung, eigene Scheibe.
+- **`METRIC_DEFAULTS` + `AlertMetricTable.svelte`/`AlertMetricRow.svelte`** (toter
+  Alt-Editor) — Löschung wäre Aufräumen, nicht Zusammenführung.
+- **Go-seitiges `AlertableMetrics`** — offene Restlücke aus E5, unverändert.
+
+## Nachweis der Wirksamkeit
+
+Vier Mutationen für den Adversary:
+
+1. `_PRESET_TABLE`: `FREEZING_LEVEL` entspannt 600→999, **nicht** regenerieren → Ratsche
+   rot, nennt Größe und Stufe mit Soll und Ist.
+2. Generierte JSON von Hand verfälschen (`wind_gust` standard 20→21) → Ratsche rot.
+3. Ganze Zeile (`VISIBILITY`) aus `_PRESET_TABLE` löschen → Ratsche rot mit „fehlt",
+   nicht still grün (fängt die Falle, nur über die Schlüssel **einer** Seite zu iterieren).
+4. **Die entscheidende:** in `alertMetricTable.ts` die Ableitung durch ein Literal
+   ersetzen → wird irgendetwas rot? Wenn nein, bewacht die Ratsche nur Python↔JSON,
+   **nicht die angezeigte Zeile**. Deshalb Pflicht: ein `node:test`, der
+   `levelToThreshold('freezing_level','standard') === 'Δ ≥ 400 m'` prüft.
+
+**Staging-Nachweis:** Trip-Editor → Reiter Alarme, Zeile „Nullgradgrenze" auf Stufe
+Standard muss „Δ ≥ 400 m" zeigen (vorher „Δ ≥ 200 m"), Screenshot. Danach dieselbe
+Prüfung im Vergleichs-Editor — `AlarmeTab` ist geteilt.
+
+## Open Questions
+
+Keine offenen. **PO-Entscheid 2026-08-06:** Die Geisterzeile Luftfeuchtigkeit (Fund 2)
+wird **nicht** in dieser Scheibe behoben, sondern bekommt ein eigenes Ticket — anderer
+Fehlertyp (fehlende Filterung im Trip-Pfad, nicht die Zahlentabelle), und es fehlt noch
+die Messung, wie viele Trips überhaupt einen `humidity`-Schlüssel tragen.
+Zahlen der Nullgradgrenze: keine neue Entscheidung nötig, ADR-0019 Punkt 4 gilt (600/400/200).

--- a/docs/specs/modules/fix_1435_e4_schwellwert_quelle.md
+++ b/docs/specs/modules/fix_1435_e4_schwellwert_quelle.md
@@ -1,0 +1,341 @@
+---
+entity_id: fix_1435_e4_schwellwert_quelle
+type: bugfix
+created: 2026-08-06
+updated: 2026-08-06
+status: draft
+version: "1.0"
+tags: [metric-catalog, alerts, cross-stack, codegen, drift-prevention]
+workflow: fix-1435-e4-schwellwert-quelle
+---
+
+# Fix #1435 Etappe E4 — Schwellwert-Tabelle wird eine einzige Quelle
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Die Schwellwert-Tabelle „ab welchem Wert löst eine Wettergröße Alarm aus" (je
+Wettergröße und Empfindlichkeitsstufe entspannt/standard/sensibel) existiert
+heute zweimal handgepflegt — als Python-Liste im Backend (wirksam für den
+Alarmversand) und als abgetippte Kopie im Frontend (nur für die Anzeige der
+Zahl im Alarme-Reiter). Beide sind bei der Nullgradgrenze auseinandergedriftet:
+der Alarme-Reiter zeigt bei Standard „Δ ≥ 200 m", tatsächlich löst das Backend
+erst bei „Δ ≥ 400 m" aus. E4 macht Python zur einzigen Quelle; ein
+Erzeuger-Skript schreibt eine eingecheckte JSON-Datei, das Frontend leitet
+seine Anzeigewerte ausschließlich daraus ab, eine Frische-Ratsche fängt jede
+künftige Drift.
+
+## Source
+
+> **Schicht-Hinweis:** betrifft zwei Schichten — Python-Core (Quelle +
+> neues Erzeuger-Skript) und Frontend (SvelteKit, Alarme-Reiter, geteilt
+> zwischen Trip- und Ortsvergleichs-Editor). Keine Go-Seite betroffen.
+
+- **File:** `src/services/alert_preset.py`
+- **Identifier:** `_PRESET_TABLE` (Zeile 39-57)
+- **File:** `frontend/src/lib/components/alerts-tab/alertMetricTable.ts`
+- **Identifier:** `METRIC_PRESETS` (Zeile 42-95), `THRESHOLD_CROSSING_METRICS`
+  (Zeile 219-221), `levelToThreshold()` (Zeile 244-255)
+- **File (neu):** `scripts/generate_alert_preset_table.py`
+- **File (neu, generiert):** `frontend/src/lib/generated/alertPresetThresholds.generated.json`
+
+## Estimated Scope
+
+- **LoC:** ~170 berührt (Erzeuger-Skript ~85, `alertMetricTable.ts`-Diff
+  ~-58/+22, `alert_preset.py`-Docstring ~5, Testcode ~90+25). Bleibt unter
+  dem 250-Zeilen-Deckel, kein Override nötig. Die generierte JSON-Datei
+  selbst zählt laut CLAUDE.md nicht auf den Deckel.
+- **Files:** 6 — 2 Produktivdateien geändert (`alert_preset.py`,
+  `alertMetricTable.ts`), 1 neu (`scripts/generate_alert_preset_table.py`),
+  1 generierte JSON-Datei neu (eingecheckt), 1 neue Testdatei
+  (`tests/tdd/test_alert_preset_table_parity.py`), 1 bestehende Testdatei
+  neu angelegt (`alerts-tab/__tests__/alertPresetThresholdDisplay.test.ts`).
+- **Effort:** medium — die Zahlen selbst ändern sich nur bei der
+  Nullgradgrenze (ADR-0019 legt 600/400/200 bereits fest, keine neue
+  PO-Entscheidung nötig), der Aufwand steckt im bereits aus E5 bekannten
+  Baustein (generiertes Artefakt, ADR-0045) und im Nachweis, dass die
+  Ratsche wirklich etwas fängt — auch dann, wenn das Frontend die Ableitung
+  umgeht statt sie zu nutzen.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/services/alert_preset.py::_PRESET_TABLE` | READ (unverändert) | bleibt alleinige Quelle; das Erzeuger-Skript liest sie |
+| `scripts/generate_alert_preset_table.py` | NEU | erzeugt `alertPresetThresholds.generated.json` aus `_PRESET_TABLE`, bietet `write()`/`check()` analog zum Vorbild aus E5 |
+| `frontend/src/lib/generated/alertPresetThresholds.generated.json` | NEU (generiert, eingecheckt) | Vite-JSON-Import-Ziel (`resolveJsonModule` bereits aktiv) |
+| `alertMetricTable.ts::METRIC_PRESETS` | MODIFY | wird aus dem JSON-Import abgeleitet (`Partial<Record<AlertMetric, number>>` je Stufe) statt als Literal gepflegt |
+| `alertMetricTable.ts::THRESHOLD_CROSSING_METRICS` | MODIFY | wird aus dem `kind`-Feld der generierten Datei abgeleitet — löst die zweite, bisher unbewachte Handkopie mit auf |
+| `alertMetricTable.ts::levelToThreshold()` | UNVERÄNDERT (Signatur) | liest weiterhin `METRIC_PRESETS`; behandelt `undefined` bereits korrekt (Zeile 249) |
+| `AlertMetricLevelRow.svelte`, `AlarmeTab.svelte` | UNVERÄNDERT | rendern die Schwellwert-Spalte weiterhin über `levelToThreshold()` — geteilter Pfad für Trip **und** Ortsvergleich, keine Editor-spezifische Anpassung nötig |
+| `tests/tdd/test_alert_preset_table_parity.py` | NEU | Frische-Ratsche Python-Quelle ⇔ generierte Datei |
+| `frontend/.../alerts-tab/__tests__/alertPresetThresholdDisplay.test.ts` | CREATE | Wirkungstest gegen die tatsächlich zurückgegebene Zeichenkette (nicht nur Dateivergleich). **Neue Datei statt Erweiterung von `alertMetricTable.test.ts`:** co-located Tests (`*.test.ts` neben der Komponente) blockiert der `edit_gate` in der RED-Phase, ein Verzeichnis `__tests__/` ist erlaubt — im Projekt etabliert (`components/shared/__tests__/`). |
+| `frontend/package.json` | MODIFY | `test`-Script um `--experimental-test-module-mocks` ergänzt — ohne dieses Flag existiert `mock.module()` nicht, das der AC-9-Nachweis für `THRESHOLD_CROSSING_METRICS` braucht. Kein Verhaltenseffekt auf bestehende Tests (voller Frontend-Lauf unverändert grün). |
+| `docs/adr/0045-generiertes-eingebettetes-artefakt-fuer-cross-stack-abbildung.md` | REFERENCE | liefert das Muster (aus E5), unverändert übernommen — kein neues ADR nötig |
+| `docs/adr/0019-nullgradgrenze-eine-alert-metrik.md` | REFERENCE | legt die Nullgradgrenzen-Zahlen 600/400/200 bereits verbindlich fest (Punkt 4) — E4 setzt eine bestehende Entscheidung durch, entscheidet nichts neu |
+
+## Implementation Details
+
+### 1. Erzeuger-Skript
+
+`scripts/generate_alert_preset_table.py` importiert `_PRESET_TABLE` aus
+`src/services/alert_preset.py` und schreibt eine deterministische
+JSON-Serialisierung (sortierte Schlüssel, `indent=2`, abschließender
+Zeilenumbruch) nach
+`frontend/src/lib/generated/alertPresetThresholds.generated.json`, Form:
+
+```json
+{
+  "freezing_level": {"kind": "delta", "entspannt": 600, "standard": 400, "sensibel": 200},
+  "visibility": {"kind": "threshold_crossing", "entspannt": 500, "standard": 1000, "sensibel": 3000}
+}
+```
+
+Das `kind`-Feld wird mitgenommen, damit das Frontend `THRESHOLD_CROSSING_METRICS`
+— heute eine zweite, unbewachte Handkopie in derselben Datei — ebenfalls
+ableiten kann statt sie separat zu pflegen. Zwei Modi analog zum Vorbild aus
+E5 (`scripts/generate_alert_metric_mapping.py`): `write()` (Datei schreiben)
+und `check()` (nur vergleichen, gibt bei Abweichung eine Liste konkreter
+Meldungen mit Größe + erwartetem/gefundenem Wert zurück statt still zu
+bleiben) — Grundlage der Frische-Ratsche.
+
+**Nur eine physische Datei** (anders als bei E5): keine Go-Seite, also keine
+`go:embed`-Verzeichnis-Restriktion, die eine zweite Kopie erzwingen würde.
+
+### 2. Frontend: Ableitung statt Literal
+
+`alertMetricTable.ts` importiert die generierte Datei und leitet
+`METRIC_PRESETS` sowie `THRESHOLD_CROSSING_METRICS` daraus ab:
+
+```ts
+import rawPresets from '$lib/generated/alertPresetThresholds.generated.json';
+
+type GeneratedPresetEntry = { kind: 'delta' | 'threshold_crossing'; entspannt: number; standard: number; sensibel: number };
+const _RAW = rawPresets as Record<string, GeneratedPresetEntry>;
+
+export const METRIC_PRESETS: Record<PresetName, Partial<Record<AlertMetric, number>> | null> = {
+	deaktiviert: null,
+	entspannt: Object.fromEntries(Object.entries(_RAW).map(([m, v]) => [m, v.entspannt])),
+	standard: Object.fromEntries(Object.entries(_RAW).map(([m, v]) => [m, v.standard])),
+	sensibel: Object.fromEntries(Object.entries(_RAW).map(([m, v]) => [m, v.sensibel])),
+};
+
+export const THRESHOLD_CROSSING_METRICS: ReadonlySet<AlertMetric> = new Set(
+	Object.entries(_RAW).filter(([, v]) => v.kind === 'threshold_crossing').map(([m]) => m as AlertMetric),
+);
+```
+
+**Typbruch beachten:** `Record<AlertMetric, number>` verlangt alle 14
+Schlüssel, die Backend-Tabelle liefert 12 (kein `snow_line`, kein
+`humidity` — beide sind seit ADR-0019/#889 tot bzw. abgeschafft). Der Typ
+wird deshalb auf `Partial<Record<AlertMetric, number>>` geändert;
+`levelToThreshold()` behandelt einen fehlenden Schlüssel bereits korrekt
+(gibt `null` zurück, Zeile 249) — keine Signaturänderung nötig.
+
+`METRIC_DEFAULTS` (drittes, unabhängiges Zahlen-Set mit anderem Zweck —
+Fallback ohne Preset im toten Alt-Editor) bleibt unangetastet, siehe Known
+Limitations.
+
+### 3. Frische-Ratsche
+
+`tests/tdd/test_alert_preset_table_parity.py` (Kernschicht, kein Netz) ruft
+`scripts/generate_alert_preset_table.check()` direkt auf: frisch aus
+`_PRESET_TABLE` berechnete Abbildung gegen die eingecheckte generierte Datei,
+Abweichung je Größe konkret benannt (analog zu
+`test_alert_metric_mapping_parity.py` aus E5). Anders als bei E5 gibt es
+hier **keine** TS-seitigen benannten Ausnahmen zu prüfen — `METRIC_PRESETS`
+und `THRESHOLD_CROSSING_METRICS` werden vollständig und ohne Filter aus der
+generierten Datei abgeleitet.
+
+Diese Prüfung allein fängt aber **nicht**, wenn das Frontend die Ableitung
+gar nicht nutzt (z. B. versehentlich wieder auf ein festes Literal
+zurückgebaut wird) — die generierte Datei selbst bliebe dabei korrekt. Dafür
+ist zusätzlich ein Wirkungstest in `__tests__/alertPresetThresholdDisplay.test.ts` Pflicht, der
+die tatsächlich von `levelToThreshold()` zurückgegebene Zeichenkette prüft
+(`levelToThreshold('freezing_level', 'standard') === 'Δ ≥ 400 m'`), nicht
+nur Dateien gegeneinander vergleicht.
+
+## Expected Behavior
+
+- **Input:** Ein Entwickler ändert einen Schwellwert in `_PRESET_TABLE`
+  (`src/services/alert_preset.py`) und führt
+  `scripts/generate_alert_preset_table.py` aus.
+- **Output:** Die generierte JSON-Datei wird aktualisiert und eingecheckt;
+  beim nächsten Vite-Build übernimmt das Frontend den neuen Wert ohne
+  Codeänderung an `alertMetricTable.ts`. Vergisst der Entwickler den
+  Skriptlauf, meldet die Frische-Ratsche die Abweichung konkret.
+- **Side effects:** Die Nullgradgrenzen-Anzeige ändert sich sichtbar (von
+  „Δ ≥ 200 m" auf „Δ ≥ 400 m" bei Standard, entsprechend bei den anderen
+  Stufen) — das ist der beabsichtigte Fix von Fund 1, keine neue
+  PO-Entscheidung (ADR-0019 legt die Zahl bereits fest). Alle zwölf
+  übrigen Backend-Größen bleiben zahlenmäßig unverändert. Das
+  Alarmverhalten selbst (welche Regel bei welchem Wert tatsächlich feuert)
+  ändert sich nicht — `alert_preset.py` bleibt bis auf eine
+  Docstring-Ergänzung unverändert, `expand_preset()`/
+  `expand_per_metric_levels()` sind nicht betroffen.
+
+## Acceptance Criteria
+
+- **AC-1:** Given die Nullgradgrenze ist im Backend mit den Schwellen
+  600/400/200 Metern hinterlegt (ADR-0019) / When ein Nutzer im
+  Trip-Editor den Alarme-Reiter öffnet und bei der Zeile „Nullgradgrenze"
+  die Stufe „Standard" gewählt ist / Then zeigt die Schwellwert-Spalte
+  „Δ ≥ 400 m" — nicht mehr das bisherige, falsche „Δ ≥ 200 m".
+  - Test: `__tests__/alertPresetThresholdDisplay.test.ts` prüft
+    `levelToThreshold('freezing_level', 'standard') === 'Δ ≥ 400 m'`.
+
+- **AC-2:** Given dieselbe Zeile „Nullgradgrenze" / When die Stufen
+  „Entspannt" bzw. „Sensibel" gewählt sind / Then zeigt die
+  Schwellwert-Spalte „Δ ≥ 600 m" bzw. „Δ ≥ 200 m" — alle drei Stufen
+  stimmen mit dem tatsächlich wirksamen Backend-Wert überein.
+  - Test: `__tests__/alertPresetThresholdDisplay.test.ts`, je ein Fall pro Stufe.
+
+- **AC-3:** Given ein Nutzer hat die Nullgradgrenze sowohl in einem Trip
+  als auch in einem Orts-Vergleich als Alarm eingestellt / When er den
+  Alarme-Reiter beider Editoren nacheinander öffnet, Stufe Standard /
+  Then steht an beiden Stellen derselbe Text „Δ ≥ 400 m" — die Anzeige
+  unterscheidet sich nicht danach, aus welchem Editor man sie ansieht.
+  - Test: Staging-Verifikation — Screenshot des Alarme-Reiters im
+    Ortsvergleichs-Editor mit der Zeile „Nullgradgrenze" auf Standard.
+
+- **AC-4 (Verhaltensneutralität):** Given die zwölf übrigen
+  Backend-Größen (Windböen, Regenmenge, Gewitter, Temperatur-Minimum/
+  -Maximum/-Wechsel, Windwechsel, Regenmengen-Wechsel, Neuschnee,
+  Gewitterpotenzial, Sichtweite) / When ihre Schwellwerte nach der
+  Zusammenführung im Alarme-Reiter angezeigt werden / Then bleiben alle
+  Zahlen exakt wie vorher — z. B. Windböen weiterhin „Δ ≥ 20 km/h" bei
+  Standard, Regenmenge „Δ ≥ 10 mm" — kein einziger Wert weicht ab.
+  - Test: `tests/tdd/test_alert_preset_table_parity.py` vergleicht alle
+    zwölf Größen × drei Stufen automatisiert gegen `_PRESET_TABLE`.
+
+- **AC-5:** Given ein bestehender Trip mit eingestellten Alarmen / When
+  er nach der Umstellung gespeichert wird / Then entstehen exakt
+  dieselben Alarmregeln wie vorher — gleiche Größen, gleiche Schwellen,
+  gleiche Anzahl. Es ändert sich allein, was der Nutzer liest, nicht
+  wann ein Alarm ausgelöst wird.
+  - Test: bestehende Backend-Tests für `expand_preset()`/
+    `expand_per_metric_levels()`, unverändert grün (`alert_preset.py`
+    selbst bleibt bis auf die Docstring-Ergänzung unangetastet).
+
+- **AC-6:** Given die Sichtweite ist die einzige Größe, die bei
+  Unterschreiten eines Wertes warnt statt bei einer Änderung / When ihre
+  Zeile im Alarme-Reiter auf Stufe Standard angezeigt wird / Then steht
+  dort weiterhin „< 1000 m" und nicht „Δ ≥ 1000 m" — die Unterscheidung
+  zwischen beiden Warnarten geht bei der Zusammenführung nicht verloren.
+  - Test: `__tests__/alertPresetThresholdDisplay.test.ts` (muss nach der
+    Umstellung auf Ableitung weiterhin grün bleiben).
+
+- **AC-7 (Mutations-Gegenprobe, PFLICHT — Drift wird benannt):** Given
+  die generierte Datei wird lokal (nicht committet) von Hand verfälscht
+  (z. B. Windböen-Standard 20→21) ODER die Backend-Tabelle wird geändert,
+  ohne das Erzeuger-Skript erneut laufen zu lassen / When die
+  Frische-Ratsche läuft / Then schlägt sie fehl und benennt die betroffene
+  Größe mit erwartetem und gefundenem Wert — kein stilles Grün.
+  - Test: `tests/tdd/test_alert_preset_table_parity.py`, protokollierter
+    Nachweis (Mutation setzen → Test rot mit benanntem Wert → Mutation
+    zurücknehmen → Test wieder grün), Protokollpflicht analog
+    `fix_1435_e5_alert_mapping_unify.md` Abschnitt
+    „Wirksamkeitsnachweis der Ratsche".
+
+- **AC-8 (fehlende Größe wird nicht übersehen):** Given eine ganze Zeile
+  (z. B. Sichtweite) wird aus der Backend-Tabelle `_PRESET_TABLE`
+  gelöscht, ohne die generierte Datei neu zu erzeugen / When die
+  Frische-Ratsche läuft / Then meldet sie die fehlende Größe ausdrücklich
+  als „fehlt", statt stillschweigend grün zu bleiben — die Prüfung
+  iteriert über die Schlüssel BEIDER Seiten, nicht nur einer.
+  - Test: derselbe Wächter-Test, zusätzlicher Fall „Zeile komplett aus
+    der Quelle entfernt".
+
+- **AC-9 (die entscheidende Mutation — Ableitung wird wirklich genutzt):**
+  Given die Ableitung in `alertMetricTable.ts` wird versuchsweise durch
+  ein festes Literal ersetzt, während die generierte Datei unverändert
+  korrekt bleibt / When die Frontend-Tests laufen / Then wird mindestens
+  ein Test rot, weil er die tatsächlich von `levelToThreshold()`
+  zurückgegebene Zeichenkette prüft — nicht nur, ob die generierte Datei
+  zur Backend-Tabelle passt (das würde bei diesem Fehler weiterhin grün
+  bleiben, da nur der Frontend-Konsument die Ableitung ignoriert).
+  - Test: `__tests__/alertPresetThresholdDisplay.test.ts`, Wirkungstest gegen die exportierte
+    Funktion (kein Dateiinhalt-Check).
+
+## Known Limitations
+
+- **`thunder_level` zeigt bei allen drei Stufen „Δ ≥ 1"**, obwohl seit
+  #1460 die Niveau-Grenzen (`ORDINAL_LEVEL_BOUNDS`) entscheiden, nicht die
+  Sprunggröße. Zweiter Anzeigefehler derselben Art wie Fund 1 (Anzeige
+  widerspricht Wirkung), aber andere Fragestellung — braucht eine eigene
+  Wortlaut-Entscheidung und eigene Scheibe. Wird durch E4 nicht behoben.
+- **`METRIC_DEFAULTS` + `AlertMetricTable.svelte`/`AlertMetricRow.svelte`**
+  (toter Alt-Editor, nirgends importiert außer einem Kommentar-Verweis)
+  bleiben unverändert. Eine Löschung wäre Aufräumen, kein
+  Zusammenführungsziel — es gibt kein Backend-Gegenstück, das man
+  konsolidieren könnte.
+- **Go-seitiges `AlertableMetrics`** bleibt ein separates, unverändertes
+  Vokabular — offene Restlücke aus E5, durch E4 nicht angefasst.
+- **Die Geisterzeile Luftfeuchtigkeit im Trip-Editor** (Fund 2: ein Trip
+  mit alt-persistiertem `humidity`-Schlüssel zeigt im Trip-Pfad eine
+  Zeile, die nie einen Alarm auslöst, weil der Trip-Pfad — anders als der
+  Ortsvergleichs-Pfad — nicht gegen den Katalog filtert) wird **nicht**
+  in dieser Scheibe behoben (PO-Entscheid 2026-08-06, eigenes Ticket:
+  anderer Fehlertyp — fehlende Filterung, nicht die Zahlentabelle — und
+  es fehlt noch die Messung, wie viele Trips überhaupt betroffen sind).
+  **Nebenwirkung dieser Scheibe, kein Fix:** Da `_PRESET_TABLE` seit
+  #889/ADR-0010 keinen `humidity`-Eintrag mehr führt, zeigt eine solche
+  Geisterzeile nach E4 einen Gedankenstrich „—" statt der bisherigen,
+  irreführenden festen Zahl „Δ ≥ 15 %" — die Zeile selbst bleibt
+  unverändert sichtbar, nur ihr (ohnehin falscher) Zahlenwert verschwindet.
+  Das ist eine zulässige Nebenwirkung der Quellzusammenführung, kein
+  eigenständiges Kriterium dieser Spec.
+
+## Wirksamkeitsnachweis der Ratsche
+
+Analog zur Erfahrung aus E3a/E5 gilt die Frische-Ratsche aus AC-7/AC-8 erst
+als geliefert, wenn folgender Nachweis erbracht und im PR/Commit
+protokolliert ist:
+
+1. Ein Schwellwert (z. B. Windböen-Standard) wird in einer lokalen, nicht
+   committeten Kopie der generierten Datei verfälscht, ohne die
+   Python-Quelle zu ändern.
+2. Die Frische-Ratsche wird gegen diesen Zustand ausgeführt; Ausgabe
+   protokollieren — muss (a) fehlschlagen, (b) die betroffene Größe mit
+   erwartetem und gefundenem Wert benennen.
+3. Zweiter Durchlauf: die Backend-Tabelle wird lokal geändert (z. B. eine
+   Zeile entfernt), ohne das Erzeuger-Skript laufen zu lassen — derselbe
+   Nachweis (a)/(b) inkl. „fehlt"-Meldung.
+4. Dritter Durchlauf: die Ableitung in `alertMetricTable.ts` wird lokal
+   durch ein festes Literal ersetzt, die generierte Datei bleibt korrekt —
+   der Frontend-Wirkungstest (AC-9) muss rot werden, die Frische-Ratsche
+   (Python ⇔ Datei) darf dabei grün bleiben (sie prüft eine andere Naht).
+5. Alle drei Verfälschungen werden danach zurückgenommen; regulärer Code
+   läuft wieder vollständig grün.
+
+Ohne diesen protokollierten Nachweis gilt die Ratsche als nicht abgenommen,
+unabhängig davon, ob sie „grün" ist.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue — ADR-0045 (aus E5) deckt das Muster
+  (generiertes, eingecheckt zwischenges Artefakt statt Laufzeit-Kopplung
+  oder Handkopie), ADR-0019 legt die Nullgradgrenzen-Zahlen bereits fest.
+- **Rationale:** E4 ist strukturell derselbe Fall wie E5 (Cross-Stack-
+  Duplikat, eine Seite soll Quelle werden), nur ohne Go-Seite und damit
+  einfacher (eine statt zwei generierte Dateien). Ein zweites ADR für
+  dasselbe Muster würde Regel 3 aus ADR-0015 nicht neu begründen, sondern
+  nur wiederholen — ADR-0045 selbst benennt dieses Muster bereits als
+  Vorbild für strukturell ähnliche Fälle. Die Nullgradgrenzen-Zahlen
+  600/400/200 sind keine neue Entscheidung: ADR-0019 Punkt 4 legt sie für
+  die konsolidierte Metrik ausdrücklich fest: „die bisher tatsächlich
+  wirksamen `snow_line`-Werte" — E4 setzt diese Entscheidung durch,
+  entscheidet nichts neu.
+
+## Changelog
+
+- 2026-08-06: Initial spec created. Umfang, Randbedingungen und
+  PO-Entscheidung aus `docs/context/fix-1435-e4-schwellwert-quelle.md`
+  übernommen. Fundstellen (Python, TS) gegen den aktuellen Code-Stand neu
+  verifiziert (Zeilennummern in `alertMetricTable.ts` und `alert_preset.py`
+  aktualisiert). Vorbild-Muster (Erzeuger-Skript, Frische-Ratsche,
+  Wirksamkeitsnachweis-Protokoll) aus `fix_1435_e5_alert_mapping_unify.md`
+  übernommen und auf den Ein-Datei-Fall (keine Go-Seite) zugeschnitten.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"test": "node --import ./test-lib-loader.mjs --experimental-strip-types --test"
+		"test": "node --import ./test-lib-loader.mjs --experimental-strip-types --experimental-test-module-mocks --test"
 	},
 	"devDependencies": {
 		"@internationalized/date": "^3.12.0",

--- a/frontend/src/lib/components/alerts-tab/__tests__/alertPresetThresholdDisplay.test.ts
+++ b/frontend/src/lib/components/alerts-tab/__tests__/alertPresetThresholdDisplay.test.ts
@@ -1,0 +1,118 @@
+// TDD RED: Fix #1435 Etappe E4 — Schwellwert-Tabelle wird eine einzige Quelle
+//
+// Spec: docs/specs/modules/fix_1435_e4_schwellwert_quelle.md
+//
+// Wirkungstest (AC-1, AC-2, AC-6, AC-9): prüft die tatsächlich von
+// `levelToThreshold()` zurückgegebene Zeichenkette, nicht Dateien
+// gegeneinander. `METRIC_PRESETS`/`levelToThreshold()` selbst bleiben in
+// dieser Etappe UNVERÄNDERT (das Skript und die generierte Datei existieren
+// noch nicht) — die Nullgradgrenze-Fälle müssen deshalb jetzt ROT sein: die
+// heutige Handkopie liefert 400/200/100 statt der wirksamen Backend-Werte
+// 600/400/200 (ADR-0019 Punkt 4). Das ist der Bug, den E4 behebt.
+//
+// Ausfuehrung:
+//   cd frontend && node --import ./test-lib-loader.mjs --experimental-strip-types \
+//     --test src/lib/components/alerts-tab/__tests__/alertPresetThresholdDisplay.test.ts
+
+import { test, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+import { levelToThreshold } from '../alertMetricTable.ts';
+
+// ─────────────────────────────────────────────────────────────────────────
+// AC-1 / AC-2: Nullgradgrenze — die Anzeige muss den wirksamen Backend-Wert
+// zeigen (ADR-0019 Punkt 4: 600/400/200), nicht die abgetippte, gedriftete
+// Kopie (heute 400/200/100).
+// ─────────────────────────────────────────────────────────────────────────
+
+test('freezing_level > standard zeigt "Δ ≥ 400 m" (wirksamer Backend-Wert)', () => {
+	assert.equal(levelToThreshold('freezing_level', 'standard'), 'Δ ≥ 400 m');
+});
+
+test('freezing_level > entspannt zeigt "Δ ≥ 600 m" (wirksamer Backend-Wert)', () => {
+	assert.equal(levelToThreshold('freezing_level', 'entspannt'), 'Δ ≥ 600 m');
+});
+
+test('freezing_level > sensibel zeigt "Δ ≥ 200 m" (wirksamer Backend-Wert)', () => {
+	assert.equal(levelToThreshold('freezing_level', 'sensibel'), 'Δ ≥ 200 m');
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Gegenprobe Verhaltensneutralität (AC-4): eine Größe, die heute schon
+// deckungsgleich ist, darf durch die Zusammenführung nicht verändert werden.
+// Bleibt grün, sowohl vor als auch nach der Implementierung.
+// ─────────────────────────────────────────────────────────────────────────
+
+test('wind_gust > standard bleibt "Δ ≥ 20 km/h" (Verhaltensneutralität)', () => {
+	assert.equal(levelToThreshold('wind_gust', 'standard'), 'Δ ≥ 20 km/h');
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// AC-6: Sichtweite ist THRESHOLD_CROSSING (Unterschreiten), nicht DELTA —
+// die Zusammenführung darf diese Unterscheidung nicht verlieren.
+// ─────────────────────────────────────────────────────────────────────────
+
+test('visibility > standard zeigt "< 1000 m", nicht "Δ ≥ 1000 m" (AC-6)', () => {
+	assert.equal(levelToThreshold('visibility', 'standard'), '< 1000 m');
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Adversary-Finding F001 (Fix-Loop nach der Adversary-Runde): der bisherige
+// Wirkungstest allein prüft nur, dass 'visibility' im Set landet — das
+// stimmt heute sowohl bei echter Ableitung aus dem `kind`-Feld ALS AUCH bei
+// einem festen Literal `new Set(['visibility'])`, weil es aktuell zufällig
+// die einzige threshold_crossing-Größe ist. Ersetzt man die Ableitung durch
+// dieses Literal, blieben bisher alle 40 Tests grün.
+//
+// Dieser Test macht den Unterschied sichtbar, OHNE die echte generierte
+// Datei zu verändern: er ersetzt sie über Node's eingebautes
+// `mock.module()` (Flag `--experimental-test-module-mocks`, siehe
+// package.json) durch einen künstlichen Datenstand mit ZWEI
+// threshold_crossing-Größen ('cape' zusätzlich zu 'visibility') und lädt
+// `alertMetricTable.ts` danach frisch (Cache-Bust per Query-Parameter), damit
+// der echte Modulcode mit dem künstlichen Stand ausgeführt wird — kein
+// Dateiinhalt-Grep, sondern ein echter Wirkungsnachweis gegen den
+// tatsächlich exportierten Wert. Ein Literal würde 'cape' nicht enthalten
+// und diesen Test unabhängig vom heutigen realen Datenstand rot machen.
+// ─────────────────────────────────────────────────────────────────────────
+
+test(
+	'THRESHOLD_CROSSING_METRICS wird aus dem kind-Feld der generierten Datei abgeleitet, nicht aus einem Literal (F001)',
+	async () => {
+		const genUrl = pathToFileURL(
+			path.resolve(
+				path.dirname(fileURLToPath(import.meta.url)),
+				'../../../generated/alertPresetThresholds.generated.json',
+			),
+		).href;
+
+		const mocked = mock.module(genUrl, {
+			defaultExport: {
+				cape: { kind: 'threshold_crossing', entspannt: 1, standard: 2, sensibel: 3 },
+				visibility: { kind: 'threshold_crossing', entspannt: 500, standard: 1000, sensibel: 3000 },
+				wind_gust: { kind: 'delta', entspannt: 1, standard: 2, sensibel: 3 },
+			},
+		});
+
+		try {
+			const modUrl = pathToFileURL(
+				path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../alertMetricTable.ts'),
+			).href;
+			const fresh = (await import(`${modUrl}?f001-mutation-probe=${Date.now()}`)) as {
+				THRESHOLD_CROSSING_METRICS: ReadonlySet<string>;
+			};
+
+			assert.deepEqual(
+				[...fresh.THRESHOLD_CROSSING_METRICS].sort(),
+				['cape', 'visibility'],
+				'THRESHOLD_CROSSING_METRICS muss beide threshold_crossing-Größen aus dem ' +
+					"künstlichen Datenstand enthalten -- ein festes Literal wie new Set(['visibility']) " +
+					"würde 'cape' nicht mitziehen, obwohl die generierte Datei es als threshold_crossing führt.",
+			);
+		} finally {
+			mocked.restore();
+		}
+	},
+);

--- a/frontend/src/lib/components/alerts-tab/alertMetricTable.ts
+++ b/frontend/src/lib/components/alerts-tab/alertMetricTable.ts
@@ -15,6 +15,9 @@
 import type { AlertMetric, AlertRule, AlertSeverity, SensLevel } from '../../types.ts';
 import { DELTA_ONLY_METRICS } from '../alert-rules-editor/alertRuleDefaults.ts';
 import { ALERT_METRIC_LABELS } from '../../utils/alertMetricLabels.ts';
+// Fix #1435 Etappe E4: einzige Quelle der Preset-Schwellwerte, erzeugt von
+// scripts/generate_alert_preset_table.py aus src/services/alert_preset.py.
+import rawPresetThresholds from '../../generated/alertPresetThresholds.generated.json' with { type: 'json' };
 
 export const METRIC_DEFAULTS: Record<AlertMetric, number> = {
 	wind_gust: 50,
@@ -35,63 +38,43 @@ export const METRIC_DEFAULTS: Record<AlertMetric, number> = {
 	freezing_level: 200,
 };
 
-// Issue #846: Preset-Schwellwert-Tabelle (alle 13 Metriken × 3 Presets).
-// Wert null = Metrik im Preset "deaktiviert" nicht aktiv.
+// Issue #846 / Fix #1435 Etappe E4: Preset-Schwellwert-Tabelle wird aus der
+// generierten Datei abgeleitet (Quelle: `_PRESET_TABLE`,
+// `src/services/alert_preset.py` -- eingecheckte Kopie
+// `frontend/src/lib/generated/alertPresetThresholds.generated.json`,
+// erzeugt von `scripts/generate_alert_preset_table.py`). Nicht mehr als
+// Literal pflegen -- Werte aendern heisst: Python-Quelle aendern, Skript
+// erneut laufen lassen.
 export type PresetName = 'deaktiviert' | 'entspannt' | 'standard' | 'sensibel';
 
+type GeneratedPresetEntry = {
+	kind: 'delta' | 'threshold_crossing';
+	entspannt: number;
+	standard: number;
+	sensibel: number;
+};
+
+const _RAW_PRESETS = rawPresetThresholds as Record<string, GeneratedPresetEntry>;
+
+// Die generierte Quelle fuehrt nur die 12 tatsaechlich alarmfaehigen
+// Backend-Groessen (kein snow_line, kein humidity -- beide seit
+// ADR-0019/#889 tot bzw. abgeschafft) -- der Typ verlangt darum nicht mehr
+// alle 14 AlertMetric-Schluessel. `levelToThreshold()` behandelt einen
+// fehlenden Schluessel bereits korrekt (gibt null zurueck).
 export const METRIC_PRESETS: Record<
 	PresetName,
-	Record<AlertMetric, number> | null
+	Partial<Record<AlertMetric, number>> | null
 > = {
 	deaktiviert: null,
-	entspannt: {
-		wind_gust: 35,
-		precipitation_sum: 20,
-		thunder_level: 1,
-		snow_line: 600,
-		temperature_min: 8,
-		temperature_max: 10,
-		temperature_change: 14,
-		wind_change: 35,
-		precipitation_change: 15,
-		fresh_snow: 20,
-		cape: 1200,
-		visibility: 500,
-		humidity: 25,
-		freezing_level: 400,
-	},
-	standard: {
-		wind_gust: 20,
-		precipitation_sum: 10,
-		thunder_level: 1,
-		snow_line: 400,
-		temperature_min: 5,
-		temperature_max: 6,
-		temperature_change: 10,
-		wind_change: 25,
-		precipitation_change: 7,
-		fresh_snow: 8,
-		cape: 600,
-		visibility: 1000,
-		humidity: 15,
-		freezing_level: 200,
-	},
-	sensibel: {
-		wind_gust: 12,
-		precipitation_sum: 5,
-		thunder_level: 1,
-		snow_line: 200,
-		temperature_min: 3,
-		temperature_max: 4,
-		temperature_change: 6,
-		wind_change: 15,
-		precipitation_change: 3,
-		fresh_snow: 2,
-		cape: 200,
-		visibility: 3000,
-		humidity: 10,
-		freezing_level: 100,
-	},
+	entspannt: Object.fromEntries(
+		Object.entries(_RAW_PRESETS).map(([metric, entry]) => [metric, entry.entspannt]),
+	) as Partial<Record<AlertMetric, number>>,
+	standard: Object.fromEntries(
+		Object.entries(_RAW_PRESETS).map(([metric, entry]) => [metric, entry.standard]),
+	) as Partial<Record<AlertMetric, number>>,
+	sensibel: Object.fromEntries(
+		Object.entries(_RAW_PRESETS).map(([metric, entry]) => [metric, entry.sensibel]),
+	) as Partial<Record<AlertMetric, number>>,
 };
 
 // Anzeige-Reihenfolge der Zeilen — siehe Spec §Reihenfolge.
@@ -215,10 +198,14 @@ export const ALERTABLE_METRICS: readonly AlertMetric[] = [
 	'freezing_level',
 ];
 
-/** Metriken die THRESHOLD_CROSSING verwenden (absoluter Schwellwert, nicht Delta). */
-export const THRESHOLD_CROSSING_METRICS: ReadonlySet<AlertMetric> = new Set<AlertMetric>([
-	'visibility',
-]);
+/** Metriken die THRESHOLD_CROSSING verwenden (absoluter Schwellwert, nicht Delta).
+ * Fix #1435 Etappe E4: aus dem `kind`-Feld der generierten Datei abgeleitet
+ * statt als zweite Handkopie gepflegt. */
+export const THRESHOLD_CROSSING_METRICS: ReadonlySet<AlertMetric> = new Set(
+	Object.entries(_RAW_PRESETS)
+		.filter(([, entry]) => entry.kind === 'threshold_crossing')
+		.map(([metric]) => metric as AlertMetric),
+);
 
 const _METRIC_UNITS: Record<AlertMetric, string> = {
 	wind_gust: 'km/h',

--- a/frontend/src/lib/generated/alertPresetThresholds.generated.json
+++ b/frontend/src/lib/generated/alertPresetThresholds.generated.json
@@ -1,0 +1,74 @@
+{
+  "cape": {
+    "entspannt": 1200,
+    "kind": "delta",
+    "sensibel": 200,
+    "standard": 600
+  },
+  "freezing_level": {
+    "entspannt": 600,
+    "kind": "delta",
+    "sensibel": 200,
+    "standard": 400
+  },
+  "fresh_snow": {
+    "entspannt": 20,
+    "kind": "delta",
+    "sensibel": 2,
+    "standard": 8
+  },
+  "precipitation_change": {
+    "entspannt": 15,
+    "kind": "delta",
+    "sensibel": 3,
+    "standard": 7
+  },
+  "precipitation_sum": {
+    "entspannt": 20,
+    "kind": "delta",
+    "sensibel": 5,
+    "standard": 10
+  },
+  "temperature_change": {
+    "entspannt": 14,
+    "kind": "delta",
+    "sensibel": 6,
+    "standard": 10
+  },
+  "temperature_max": {
+    "entspannt": 10,
+    "kind": "delta",
+    "sensibel": 4,
+    "standard": 6
+  },
+  "temperature_min": {
+    "entspannt": 8,
+    "kind": "delta",
+    "sensibel": 3,
+    "standard": 5
+  },
+  "thunder_level": {
+    "entspannt": 1,
+    "kind": "delta",
+    "sensibel": 1,
+    "standard": 1
+  },
+  "visibility": {
+    "entspannt": 500,
+    "kind": "threshold_crossing",
+    "sensibel": 3000,
+    "standard": 1000
+  },
+  "wind_change": {
+    "entspannt": 35,
+    "kind": "delta",
+    "sensibel": 15,
+    "standard": 25
+  },
+  "wind_gust": {
+    "entspannt": 35,
+    "kind": "delta",
+    "sensibel": 12,
+    "standard": 20
+  }
+}

--- a/scripts/generate_alert_preset_table.py
+++ b/scripts/generate_alert_preset_table.py
@@ -1,0 +1,126 @@
+"""Erzeuger-Skript: Schwellwert-Tabelle -> EINE Quelle.
+
+Fix #1435 Etappe E4: `_PRESET_TABLE` (`src/services/alert_preset.py`) ist die
+wirksame Schwellwert-Quelle je Wettergroesse und Empfindlichkeitsstufe
+(entspannt/standard/sensibel). Dieses Skript serialisiert sie deterministisch
+(sortierte Schluessel, `indent=2`, abschliessender Zeilenumbruch) in eine
+eingecheckte JSON-Datei:
+
+- `frontend/src/lib/generated/alertPresetThresholds.generated.json`
+  (TypeScript, Vite-JSON-Import-Ziel)
+
+`write()` erzeugt/aktualisiert die Datei. `check()` vergleicht die frisch aus
+der Python-Quelle berechnete Abbildung gegen die eingecheckte Datei und
+meldet jede Abweichung konkret (Groesse + Stufe + erwarteter/gefundener Wert,
+fehlende Groesse ausdruecklich als "fehlt") statt still gruen zu bleiben —
+Grundlage des Ratchet-Tests in `tests/tdd/test_alert_preset_table_parity.py`.
+
+Anders als beim Vorbild aus E5 (`generate_alert_metric_mapping.py`) gibt es
+hier nur EINE physische Datei — keine Go-Seite, also keine
+`go:embed`-Restriktion, die eine zweite Kopie erzwingen wuerde.
+
+Spec: docs/specs/modules/fix_1435_e4_schwellwert_quelle.md
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import services.alert_preset as alert_preset
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+FRONTEND_JSON_PATH = (
+    _REPO_ROOT / "frontend" / "src" / "lib" / "generated" / "alertPresetThresholds.generated.json"
+)
+
+_LEVELS = ("entspannt", "standard", "sensibel")
+
+
+def _current_mapping() -> dict[str, dict[str, object]]:
+    """Frisch aus `services.alert_preset._PRESET_TABLE` berechnete Abbildung:
+    metric.value -> {kind, entspannt, standard, sensibel}. Liest bei jedem
+    Aufruf ueber die Modul-Referenz neu (kein Caching), damit
+    `monkeypatch.setattr(alert_preset, "_PRESET_TABLE", ...)` wirkt."""
+    mapping: dict[str, dict[str, object]] = {}
+    for row in alert_preset._PRESET_TABLE:
+        metric, kind, entspannt, standard, sensibel = row
+        mapping[metric.value] = {
+            "kind": kind.value,
+            "entspannt": entspannt,
+            "standard": standard,
+            "sensibel": sensibel,
+        }
+    return mapping
+
+
+def _serialize(mapping: dict[str, dict[str, object]]) -> str:
+    return json.dumps(mapping, indent=2, sort_keys=True) + "\n"
+
+
+def write() -> None:
+    """Schreibt die generierte JSON-Datei aus der aktuellen Python-Quelle."""
+    content = _serialize(_current_mapping())
+    FRONTEND_JSON_PATH.parent.mkdir(parents=True, exist_ok=True)
+    FRONTEND_JSON_PATH.write_text(content, encoding="utf-8")
+
+
+def check() -> list[str]:
+    """Vergleicht die frisch berechnete Python-Abbildung gegen die
+    eingecheckte generierte Datei.
+
+    Rueckgabe: Liste von Abweichungsmeldungen (Groesse + Stufe + erwarteter/
+    gefundener Wert), leer = keine Abweichung. Iteriert ueber die
+    VEREINIGUNG der Schluesselmengen aus Python-Quelle und generierter Datei
+    -- eine Groesse, die nur auf einer Seite existiert, wird ausdruecklich
+    als "fehlt" gemeldet, nicht stillschweigend uebersprungen. Faengt sowohl
+    eine geaenderte, nicht neu generierte Python-Quelle als auch eine von
+    Hand verfaelschte generierte Datei.
+    """
+    diffs: list[str] = []
+    expected = _current_mapping()
+
+    if not FRONTEND_JSON_PATH.exists():
+        return [
+            f"generierte Datei fehlt ({FRONTEND_JSON_PATH}) — "
+            "scripts/generate_alert_preset_table.py ausfuehren."
+        ]
+    try:
+        actual = json.loads(FRONTEND_JSON_PATH.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [f"{FRONTEND_JSON_PATH} ist kein gueltiges JSON ({exc})."]
+
+    for metric in sorted(set(expected) | set(actual)):
+        exp_row = expected.get(metric)
+        act_row = actual.get(metric)
+        if exp_row is None:
+            diffs.append(
+                f"[{metric}]: fehlt in _PRESET_TABLE, aber in der generierten "
+                f"Datei vorhanden ({FRONTEND_JSON_PATH})."
+            )
+            continue
+        if act_row is None:
+            diffs.append(
+                f"[{metric}]: fehlt in der generierten Datei "
+                f"({FRONTEND_JSON_PATH}), aber in _PRESET_TABLE vorhanden."
+            )
+            continue
+
+        if exp_row.get("kind") != act_row.get("kind"):
+            diffs.append(
+                f"[{metric}] kind: erwartet {exp_row.get('kind')!r}, "
+                f"gefunden {act_row.get('kind')!r} ({FRONTEND_JSON_PATH})"
+            )
+        for level in _LEVELS:
+            exp_value = exp_row.get(level)
+            act_value = act_row.get(level)
+            if exp_value != act_value:
+                diffs.append(
+                    f"[{metric}] {level}: erwartet {exp_value!r}, "
+                    f"gefunden {act_value!r} ({FRONTEND_JSON_PATH})"
+                )
+    return diffs
+
+
+if __name__ == "__main__":
+    write()

--- a/src/services/alert_preset.py
+++ b/src/services/alert_preset.py
@@ -36,6 +36,14 @@ if TYPE_CHECKING:
 # ───────────────────────── Schwellwert-Tabelle ──────────────────────────────
 
 # Jede Zeile: (metric, kind, threshold_entspannt, threshold_standard, threshold_sensibel)
+#
+# Fix #1435 Etappe E4: diese Tabelle ist die EINZIGE Quelle der Schwellwerte.
+# Das Frontend (`alertMetricTable.ts`, Alarme-Reiter) leitet seine
+# Anzeigewerte NICHT mehr per Handkopie, sondern aus der generierten Datei
+# `frontend/src/lib/generated/alertPresetThresholds.generated.json` ab.
+# Nach jeder Aenderung hier `scripts/generate_alert_preset_table.py`
+# ausfuehren -- sonst meldet die Frische-Ratsche
+# (`tests/tdd/test_alert_preset_table_parity.py`) die Abweichung.
 _PRESET_TABLE: Final[list[tuple]] = [
     (AlertMetric.WIND_GUST,            AlertRuleKind.DELTA,              35,    20,    12),
     (AlertMetric.PRECIPITATION_SUM,    AlertRuleKind.DELTA,              20,    10,     5),

--- a/tests/tdd/test_alert_preset_table_parity.py
+++ b/tests/tdd/test_alert_preset_table_parity.py
@@ -1,0 +1,318 @@
+"""RED test for Fix #1435 Etappe E4: Schwellwert-Tabelle wird eine Quelle.
+
+`_PRESET_TABLE` (`src/services/alert_preset.py`) ist die wirksame
+Schwellwert-Quelle fuer die drei Empfindlichkeitsstufen entspannt/standard/
+sensibel. Ein Erzeuger-Skript `scripts/generate_alert_preset_table.py` soll
+sie deterministisch nach
+`frontend/src/lib/generated/alertPresetThresholds.generated.json`
+serialisieren (Form je Groesse: `{kind, entspannt, standard, sensibel}`) und
+per `check()` eine Frische-Ratsche anbieten (Vorbild:
+`scripts/generate_alert_metric_mapping.py` aus Etappe E5, bewacht von
+`tests/tdd/test_alert_metric_mapping_parity.py`).
+
+Dieser Test ist RED (Phase 5): weder das Skript noch die generierte Datei
+existieren. Die meisten Tests importieren `scripts.generate_alert_preset_table`
+INNERHALB der Testfunktion (nicht auf Modulebene), damit sie beim
+AUSFUEHREN mit ModuleNotFoundError scheitern statt schon beim Sammeln der
+Datei alle Tests dieser Datei zu blockieren.
+
+Vertrag fuer `scripts/generate_alert_preset_table.py` (von diesen Tests
+vorausgesetzt, Phase 6 muss ihn erfuellen):
+  - Modulfunktion `check() -> list[str]`: leere Liste = keine Abweichung,
+    sonst je Abweichung ein Text, der die betroffene Groesse (und bei
+    Schwellwert-Abweichungen zusaetzlich die Stufe) nennt. Iteriert ueber
+    die VEREINIGUNG der Schluesselmengen aus Python-Quelle und generierter
+    Datei -- eine Groesse, die nur auf einer Seite existiert, wird
+    ausdruecklich als "fehlt" gemeldet, nicht stillschweigend uebersprungen.
+  - Modulfunktion `write() -> None`: schreibt die generierte Datei aus der
+    aktuellen Python-Quelle.
+  - Modul-Konstante `FRONTEND_JSON_PATH` (Path): Zielpfad der generierten
+    Datei -- ueber `monkeypatch.setattr` im Test umleitbar.
+  - `check()`/die interne Berechnung liest `services.alert_preset._PRESET_TABLE`
+    bei jedem Aufruf frisch ueber die Modul-Referenz (kein Caching beim
+    Import), damit `monkeypatch.setattr(alert_preset, "_PRESET_TABLE", ...)`
+    wirkt -- analog zu `catalog_id_to_alert_metrics()` in E5.
+
+No mocks -- deterministischer Kernschicht-Test gegen die echte Python-Quelle
+und echte (im Test tmp_path-isolierte) JSON-Dateien.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.models import AlertMetric
+from services.alert_preset import _PRESET_TABLE
+
+# Pfadregel #1409: Prüfling relativ zur eigenen Testdatei auflösen, NIE über
+# einen festen Hauptrepo-Pfad -- sonst prüft ein Lauf aus dem Worktree die
+# unveränderte Hauptrepo-Kopie und liefert falsches Grün.
+_REPO = Path(__file__).resolve().parents[2]
+_GENERATED_JSON = (
+    _REPO
+    / "frontend"
+    / "src"
+    / "lib"
+    / "generated"
+    / "alertPresetThresholds.generated.json"
+)
+
+
+def _expected_mapping() -> dict[str, dict[str, object]]:
+    """Frisch aus `_PRESET_TABLE` berechnete Abbildung:
+    metric.value -> {kind, entspannt, standard, sensibel}."""
+    mapping: dict[str, dict[str, object]] = {}
+    for row in _PRESET_TABLE:
+        metric, kind, entspannt, standard, sensibel = row
+        mapping[metric.value] = {
+            "kind": kind.value,
+            "entspannt": entspannt,
+            "standard": standard,
+            "sensibel": sensibel,
+        }
+    return mapping
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Ratschen-Selbstschutz (Lehre aus E3b): ein Wächter, der nichts prüft, ist
+# immer grün. Die erwartete Anzahl Größen wird aus `_PRESET_TABLE` selbst
+# abgeleitet -- keine gepflegte Liste, die veralten könnte -- und muss > 0
+# sein, sonst würden AC-4/AC-7/AC-8 unbemerkt eine leere Prüfmenge bewachen.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_preset_table_expected_mapping_is_not_empty():
+    expected = _expected_mapping()
+    assert len(expected) > 0, (
+        "_PRESET_TABLE liefert keine Zeilen -- die Frische-Ratsche haette "
+        "nichts zu vergleichen und waere strukturell immer gruen."
+    )
+    assert len(expected) == len(_PRESET_TABLE), (
+        "Zwei Zeilen in _PRESET_TABLE teilen sich denselben Metrik-Schluessel "
+        "-- eine wuerde beim Vergleich stillschweigend ueberschrieben."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AC-4 (Verhaltensneutralität): frisch berechnete Python-Abbildung == generierte
+# Datei, solange beide zueinander passen (Normalfall im Repo).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_generator_script_check_matches_python_source():
+    """AC-4: `check()` findet KEINE Abweichung zwischen der frisch berechneten
+    Python-Abbildung und der eingecheckten generierten Datei.
+
+    RED (Phase 5): `scripts.generate_alert_preset_table` existiert noch nicht
+    -- der Import schlaegt beim Ausfuehren dieses Tests mit
+    ModuleNotFoundError fehl.
+    """
+    import scripts.generate_alert_preset_table as gen
+
+    diffs = gen.check()
+    assert diffs == [], (
+        "check() meldet eine Abweichung, obwohl Python-Quelle und generierte "
+        f"Datei im Repo zueinander passen sollten: {diffs}"
+    )
+
+
+def test_generator_script_check_covers_all_twelve_non_freezing_metrics():
+    """AC-4: alle Größen außer der Nullgradgrenze bleiben zahlenmäßig
+    unverändert -- geprüft über dieselbe `check()`-Parität wie oben, hier
+    zusätzlich explizit auf die "übrigen" Größen (ohne freezing_level)
+    eingegrenzt, damit ein AC-1/AC-2-Fund (Nullgradgrenze bewusst geändert)
+    diesen Test nicht fälschlich rot macht.
+    """
+    import scripts.generate_alert_preset_table as gen
+
+    others = {
+        m: v for m, v in _expected_mapping().items() if m != AlertMetric.FREEZING_LEVEL.value
+    }
+    assert others, "Erwartungsmenge (ohne Nullgradgrenze) ist leer."
+
+    diffs = gen.check()
+    relevant = [d for d in diffs if AlertMetric.FREEZING_LEVEL.value not in d]
+    assert relevant == [], (
+        "check() meldet eine Abweichung bei einer der zwölf übrigen "
+        f"Backend-Größen (ohne freezing_level): {relevant}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AC-7 (Mutations-Gegenprobe, PFLICHT) — Fall 1: Backend-Quelle geändert, ohne
+# das Erzeuger-Skript erneut laufen zu lassen.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_generator_script_check_reports_python_source_value_mutation(monkeypatch):
+    """AC-7 Fall 1: Ein Schwellwert wird lokal in `_PRESET_TABLE` geändert
+    (Windböen-Standard 20→21), ohne das Skript neu laufen zu lassen. `check()`
+    muss die betroffene Größe MIT Stufe und erwartetem/gefundenem Wert nennen.
+
+    RED (Phase 5): Import von `scripts.generate_alert_preset_table` schlägt
+    fehl, solange das Skript nicht existiert.
+    """
+    import scripts.generate_alert_preset_table as gen
+    import services.alert_preset as alert_preset
+
+    mutated = [
+        (metric, kind, entspannt, 21 if metric == AlertMetric.WIND_GUST else standard, sensibel)
+        for (metric, kind, entspannt, standard, sensibel) in alert_preset._PRESET_TABLE
+    ]
+    monkeypatch.setattr(alert_preset, "_PRESET_TABLE", mutated)
+
+    diffs = gen.check()
+    assert diffs, (
+        "check() bleibt grün, obwohl die Windböen-Standard-Schwelle lokal von "
+        "20 auf 21 geändert wurde, ohne das Erzeuger-Skript erneut laufen zu "
+        "lassen -- die Ratsche fängt diese Drift nicht."
+    )
+    assert any("wind_gust" in d for d in diffs), (
+        f"'wind_gust' wird in keiner Abweichungs-Meldung genannt: {diffs}"
+    )
+    assert any("21" in d for d in diffs) and any("20" in d for d in diffs), (
+        f"Weder erwarteter (20) noch gefundener (21) Wert wird genannt: {diffs}"
+    )
+
+
+def test_generator_script_check_reports_missing_row_as_fehlt(monkeypatch):
+    """AC-8: Eine ganze Zeile (Sichtweite) wird aus `_PRESET_TABLE` gelöscht,
+    ohne die generierte Datei neu zu erzeugen. `check()` muss die fehlende
+    Größe AUSDRÜCKLICH als "fehlt" melden, nicht stillschweigend grün
+    bleiben -- die Prüfung iteriert über die Schlüssel BEIDER Seiten.
+
+    RED (Phase 5): Import von `scripts.generate_alert_preset_table` schlägt
+    fehl, solange das Skript nicht existiert.
+    """
+    import scripts.generate_alert_preset_table as gen
+    import services.alert_preset as alert_preset
+
+    mutated = [
+        row for row in alert_preset._PRESET_TABLE if row[0] != AlertMetric.VISIBILITY
+    ]
+    assert len(mutated) == len(alert_preset._PRESET_TABLE) - 1, (
+        "Testvoraussetzung verletzt: VISIBILITY stand nicht (mehr) genau "
+        "einmal in _PRESET_TABLE."
+    )
+    monkeypatch.setattr(alert_preset, "_PRESET_TABLE", mutated)
+
+    diffs = gen.check()
+    assert diffs, (
+        "check() bleibt grün, obwohl die Zeile 'visibility' lokal aus "
+        "_PRESET_TABLE entfernt wurde, ohne die generierte Datei neu zu "
+        "erzeugen -- die Ratsche fängt diese Drift nicht."
+    )
+    assert any("visibility" in d and "fehlt" in d.lower() for d in diffs), (
+        "'visibility' wird nicht ausdrücklich als 'fehlt' gemeldet -- Hinweis "
+        f"auf eine Prüfung, die nur eine Seite der Schlüsselmenge iteriert: {diffs}"
+    )
+
+
+def test_generator_script_check_reports_extra_key_in_generated_file(monkeypatch, tmp_path):
+    """AC-8 (Umkehrung): Die generierte Datei enthält eine Größe
+    ('snow_line'), die es in `_PRESET_TABLE` gar nicht (mehr) gibt. `check()`
+    muss auch das melden -- fängt konkret die Falle, nur über die Schlüssel
+    EINER Seite (der Python-Quelle) zu iterieren, statt über die Vereinigung.
+
+    RED (Phase 5): Import von `scripts.generate_alert_preset_table` schlägt
+    fehl, solange das Skript nicht existiert.
+    """
+    import scripts.generate_alert_preset_table as gen
+
+    mutated = _expected_mapping()
+    mutated["snow_line"] = {
+        "kind": "delta",
+        "entspannt": 600,
+        "standard": 400,
+        "sensibel": 200,
+    }
+    frontend_path = tmp_path / "alertPresetThresholds.generated.json"
+    frontend_path.write_text(json.dumps(mutated, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    monkeypatch.setattr(gen, "FRONTEND_JSON_PATH", frontend_path)
+
+    diffs = gen.check()
+    assert diffs, (
+        "check() bleibt grün, obwohl die generierte Datei eine Größe "
+        "('snow_line') enthält, die in _PRESET_TABLE nicht (mehr) existiert "
+        "-- die Prüfung iteriert vermutlich nur über die Python-Seite der "
+        "Schlüsselmenge."
+    )
+    assert any("snow_line" in d for d in diffs), (
+        f"'snow_line' wird in keiner Abweichungs-Meldung genannt: {diffs}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AC-7 Fall 2: generierte Datei von Hand verfälscht (Python-Quelle
+# unverändert). Arbeitet auf tmp_path-Kopien, damit die echte eingecheckte
+# Datei unangetastet bleibt.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_generator_script_check_reports_generated_file_value_mutation(monkeypatch, tmp_path):
+    """AC-7 Fall 2: Die generierte Datei wird direkt von Hand verfälscht
+    (Windböen-Standard 20→21), die Python-Quelle bleibt unverändert.
+    `check()` muss dieselbe Art Abweichung erkennen wie bei der
+    Quell-Mutation -- der Schutz gilt unabhängig von der Drift-Ursache.
+
+    RED (Phase 5): Import von `scripts.generate_alert_preset_table` schlägt
+    fehl, solange das Skript nicht existiert.
+    """
+    import scripts.generate_alert_preset_table as gen
+
+    mutated = _expected_mapping()
+    mutated["wind_gust"]["standard"] = 21
+
+    frontend_path = tmp_path / "alertPresetThresholds.generated.json"
+    frontend_path.write_text(json.dumps(mutated, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    monkeypatch.setattr(gen, "FRONTEND_JSON_PATH", frontend_path)
+
+    diffs = gen.check()
+    assert diffs, (
+        "check() bleibt grün, obwohl die generierte Datei von Hand um "
+        "'wind_gust'/'standard' auf 21 verfälscht wurde, während die "
+        "Python-Quelle unverändert ist -- die Ratsche fängt Handbearbeitung "
+        "nicht."
+    )
+    assert any("wind_gust" in d for d in diffs), (
+        f"'wind_gust' wird in keiner Abweichungs-Meldung genannt: {diffs}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AC-6: das `kind`-Feld (delta / threshold_crossing) gehört mit in den
+# Vergleich -- eine Verwechslung darf nicht stillschweigend durchrutschen.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_generator_script_check_reports_kind_mismatch(monkeypatch, tmp_path):
+    """AC-6: `check()` prüft auch das `kind`-Feld. Wird die generierte Datei
+    so verfälscht, dass 'visibility' als 'delta' statt als
+    'threshold_crossing' geführt wird, muss die Ratsche das melden -- sonst
+    ginge im Frontend die Unterscheidung zwischen "Δ ≥ X" und "< X" verloren.
+
+    RED (Phase 5): Import von `scripts.generate_alert_preset_table` schlägt
+    fehl, solange das Skript nicht existiert.
+    """
+    import scripts.generate_alert_preset_table as gen
+
+    mutated = _expected_mapping()
+    assert mutated["visibility"]["kind"] == "threshold_crossing", (
+        "Testvoraussetzung verletzt: 'visibility' ist nicht (mehr) "
+        "threshold_crossing in _PRESET_TABLE."
+    )
+    mutated["visibility"]["kind"] = "delta"
+
+    frontend_path = tmp_path / "alertPresetThresholds.generated.json"
+    frontend_path.write_text(json.dumps(mutated, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    monkeypatch.setattr(gen, "FRONTEND_JSON_PATH", frontend_path)
+
+    diffs = gen.check()
+    assert diffs, (
+        "check() bleibt grün, obwohl 'visibility' in der generierten Datei "
+        "als 'delta' statt 'threshold_crossing' geführt wird -- das "
+        "kind-Feld wird nicht mitgeprüft (AC-6)."
+    )
+    assert any("visibility" in d for d in diffs), (
+        f"'visibility' wird in keiner Abweichungs-Meldung genannt: {diffs}"
+    )


### PR DESCRIPTION
## Was war kaputt

Die **Nullgradgrenze** zeigte im Alarme-Reiter „Δ ≥ 200 m" (Stufe Standard), alarmiert wurde aber erst ab 400 m. Anzeige und Wirkung widersprachen sich — in beiden Editoren, Trip wie Ortsvergleich.

**Hergang belegt** (`git show e6eac45d`, `git show b65f22a0`):

| | Backend | Frontend |
|---|---|---|
| **#946** — `freezing_level` neu, **neben** `snow_line` | fl 400/200/100 · sl 600/400/200 | identisch |
| **#959** — beide zu einer Größe zusammengelegt | fl **600/400/200**, `snow_line` gelöscht | `ALERTABLE_METRICS` + Katalog-Zuordnung angefasst — **`METRIC_PRESETS` vergessen** |

Zahl-für-Zahl-Vergleich: **12 von 13 Größen deckungsgleich**, allein die Nullgradgrenze wich ab.

**Keine neue PO-Entscheidung nötig:** `docs/adr/0019-nullgradgrenze-eine-alert-metrik.md` Punkt 4 legt 600/400/200 fest. E4 setzt eine bestehende Entscheidung durch.

## Was sich ändert

`_PRESET_TABLE` ist alleinige Quelle. `scripts/generate_alert_preset_table.py` erzeugt daraus eine eingecheckte JSON-Datei, aus der das Frontend `METRIC_PRESETS` **und** `THRESHOLD_CROSSING_METRICS` ableitet — letzteres war eine zweite, bisher unbewachte Handkopie in derselben Datei. Muster wie E5 (ADR-0045), hier einfacher: keine Go-Seite, nur eine generierte Datei.

Die Laufzeit-Variante (Werte über die bestehende Katalog-API) wurde geprüft und verworfen: `levelToThreshold()` ist eine reine Funktion tief in drei Einbettungen beider Editoren; Laufzeitwerte bräuchten Prop-Drilling, ~15 Test-Aufrufstellen, ein Ladefenster in einem synchron rendernden Reiter **und** eine Fallback-Tabelle — womit die Dublette durch die Hintertür zurückkäme.

**Verhaltensneutral bis auf die korrigierte Anzeige.** `alert_preset.py` ist bis auf den Docstring unangetastet, die Alarmauslösung unberührt.

## Adversary: VERIFIED, 3 Runden, 8 Mutationen

**F001 (MEDIUM) gefunden und geschlossen** — der interessante Teil: `THRESHOLD_CROSSING_METRICS` ließ sich auf das alte Literal `new Set(['visibility'])` zurückbauen, **ohne dass ein einziger Test rot wurde**. Grund: heute existiert nur eine `threshold_crossing`-Größe, das Literal stimmte zufällig. Ein Wächter, der nur schweigt, weil der Datenstand ihn nicht auf die Probe stellt.

Der neue Testfall erzwingt die Ableitung über einen künstlichen Datenstand mit **zwei** solchen Größen. Wirksamkeit durch Mutation belegt, vom Adversary unabhängig nachgestellt — inklusive Gegenprobe, ob der Test den echten Produktivcode trifft oder nur sein eigenes Fixture (er trifft den echten).

## Nebenwirkung (dokumentiert, kein Fix)

Eine alt-persistierte **Luftfeuchtigkeits**-Zeile im Trip-Editor zeigt statt der irreführenden festen „Δ ≥ 15 %" nun „—" (`_PRESET_TABLE` führt seit #889/ADR-0010 keinen `humidity`-Eintrag). Die Zeile bleibt sichtbar; ihre fehlende Filterung im Trip-Pfad ist ein eigener Fehlertyp und bekommt ein eigenes Ticket (PO-Entscheid 2026-08-06).

## Bewusst nicht in dieser Scheibe

- `thunder_level` zeigt weiter „Δ ≥ 1" bei allen drei Stufen, obwohl seit #1460 die Niveau-Grenzen entscheiden — zweiter Anzeigefehler derselben Art, braucht eine Wortlaut-Entscheidung
- `METRIC_DEFAULTS` (drittes Zahlen-Set): gemessen **toter Code**, kein Zusammenführungsziel
- Go-seitiges `AlertableMetrics` — unveränderte Restlücke aus E5

## Tests

- 8/8 Parität (Python), 41/41 Anzeige (Frontend)
- Voller Frontend-Lauf: **2394 grün, 0 Fehler**
- 136 Backend-Tests zu `alert_preset` grün
- `svelte-check` unverändert bei CI-Baseline 36/141 (Vorher-Nachher gemessen)

Spec: `docs/specs/modules/fix_1435_e4_schwellwert_quelle.md` · PO-Freigabe: #1435, Kommentar 2026-08-06

Closes-part-of: #1435

🤖 Generated with [Claude Code](https://claude.com/claude-code)
