### PR TITLE
fix(#1537): Commit-Gate gegen Geheimnisse im oeffentlichen Repo

### DIFF
--- a/.claude/hooks/secret_in_repo_gate.py
+++ b/.claude/hooks/secret_in_repo_gate.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Commit-Gate „Secret-in-Repo-Sperre" — Issue #1537 Scheibe 1 (Stufe C).
+
+Blockiert `git commit`, wenn eine der zum Commit vorgemerkten Dateien den
+AUSGESCHRIEBENEN Wert eines Geheimnisses aus der lokalen `.env` enthaelt
+(Schluessel endet auf `_PASS`, `_TOKEN`, `_KEY` oder `_SECRET`, Wert mind.
+10 Zeichen lang).
+
+Anlass: `secret_egress_guard.py` (Plugin, #1380) prueft nur, ob ein Geheimnis
+als Literal IM BEFEHL steht. Ein Wert, der zur Laufzeit aus einer Datei
+gelesen und in eine andere geschrieben wird (z.B. per Edit/Write-Tool, nicht
+per Bash-Kommando), laeuft daran vorbei — genau so ist #1537 entstanden
+(`GZ_AUTH_PASS` im Klartext in `frontend/.env.test` und einem Archiv-Dokument).
+Dieses Gate schliesst die Luecke NICHT beim Schreiben, sondern an der letzten
+moeglichen Stelle davor: dem Commit selbst.
+
+Exit-Codes (Hook-Vertrag):
+  0  durchlassen
+  2  blockieren (stderr wird Claude gezeigt)
+
+Drei Ausgaenge (Tech-Lead-Entscheid #1537 Runde 3):
+
+  1. Commit erkannt, KEIN Umlenkungs-Anzeichen (oder -C/--git-dir/--work-tree
+     loest sauber auf)                                 -> dort pruefen (0/2
+                                                            je nach Fund)
+  2. Commit erkannt, ein Anzeichen fuer ein moeglicherweise ANDERES Ziel
+     (cd-Umlenkung, GIT_DIR=/GIT_WORK_TREE= als Env-Zuweisung, unbekanntes
+     Hilfsprogramm davor, verschachtelte Shell/eval, nicht sauber aufloesbares
+     -C/--git-dir/--work-tree)                          -> BLOCKIEREN (Exit 2)
+  3. Eigene Stoerung (git fehlt, .env unlesbar, Zerlegungs-Werkzeug fehlt)
+                                                          -> durchlassen, sagen
+
+Warum Zeile 2 blockiert statt durchzulassen: bei einem Struktur-Waechter wie
+`pendant_gate.py` (#1481 Scheibe B) kostet ein verpasster Fall Doppelarbeit —
+"durchlassen und sagen" ist dort vertretbar (und dort auch die etablierte
+Loesung, nach vier Adversary-Runden F002->F006->F008->F010, die alle an
+derselben Frage "wo wird committet?" scheiterten). Bei DIESEM Gate stellt ein
+verpasster Fall ein gueltiges Passwort ins oeffentliche Internet — "durchlassen
+und sagen" waere hier ein stilles Sicherheitsloch. Zeile 2 ist deshalb KEIN
+Defekt des Waechters, sondern ein Fall, den er nachweislich nicht pruefen
+kann; das ist zumutbar, weil immer ein erlaubter Weg offensteht (einfacher
+`git commit` im eigenen Ordner oder `git -C <pfad> commit`) — die
+Blockade-Meldung nennt diesen Weg ausdruecklich.
+
+Vorgeschichte: Runde 1 dieses Gates nahm das Ziel per `os.getcwd()` (F001:
+bei `git -C <anderswo> commit` falsch). Runde 2 versuchte, die #1481-Loesung
+("Anzeichen? -> trotzdem eigenes Verzeichnis pruefen und sagen") 1:1 zu
+uebernehmen — fuer ein Sicherheits-Gate falsch, siehe oben.
+
+Nicht verhandelbar: Eigene Stoerungen (Zeile 3) blockieren NIE — ein
+defektes Gate darf nicht die Ursache sein, dass nicht mehr gearbeitet werden
+kann. Ein GEFUNDENES Geheimnis UND ein nicht sicher bestimmbares Ziel
+blockieren dagegen hart.
+
+Strikte Auflage: Geheimniswerte werden AUSSCHLIESSLICH im Arbeitsspeicher
+dieses einen Prozesses gehalten — nie in eine Datei geschrieben, nie in
+Log-/Fehlermeldungen ausgegeben. Meldungen nennen nur Dateiname + Schluessel.
+
+Regel-Budget: dieses Gate schliesst eine akut ausgenutzte Sicherheitsluecke
+(oeffentliches Repo, gueltige Zugangsdaten im Klartext) — anders als die
+prozessualen Commit-Gates schaltet es sich deshalb NICHT nach einem
+Pruefdatum automatisch ab. Wirksamkeits-Pruefung (Regel-Budget-Ledger):
+2026-11-04.
+
+Verdrahtung: `.claude/settings.json`, geschuetzte Form
+`if [ -f … ]; then python3 … ; fi` (Vorbild: `pendant_gate.py`, #1481 B) —
+ohne diese Form legt ein noch nicht nachgezogener Hauptordner jede Sitzung
+lahm (#1307 A).
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Schluessel-Endungen, deren Wert als Geheimnis gilt. Bewusst eng (keine
+# breite Regex wie im Egress-Guard) — sonst traefe z.B. der Projektname
+# "gregor_zwanzig" ueberall.
+_SECRET_KEY_SUFFIXES = ("_PASS", "_TOKEN", "_KEY", "_SECRET")
+# Unterhalb dieser Laenge sind es fast immer Benutzernamen oder kurze
+# Konfigwerte, keine echten Geheimnisse.
+_MIN_WERT_LAENGE = 10
+# Zu grosse Dateien werden nicht gescannt (Notbremse, kein Fehler) — echte
+# Geheimnisse in mehrstelligen-MB-Dateien sind unrealistisch, das Einlesen
+# waere aber teuer.
+_MAX_DATEI_BYTES = 2 * 1024 * 1024
+
+# Issue #1431: Commit-Erkennung ueber die Aufrufform, nicht ueber den
+# Wortlaut. Ohne das Werkzeug wird NICHT auf `"git commit" in befehl`
+# zurueckgefallen (das waere die stille Zweitfassung genau des Defekts, den
+# #1431 beseitigt hat) — sondern durchgelassen und gesagt (siehe main()).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from hook_utils import is_git_subcommand  # noqa: E402
+    WERKZEUG_FEHLT: str | None = None
+except Exception as _fehler:  # noqa: BLE001
+    is_git_subcommand = None  # type: ignore[assignment]
+    WERKZEUG_FEHLT = f"{type(_fehler).__name__}: {_fehler}"
+
+# Fuer die Sicherheitslage-Einstufung (F001) werden dieselben GEPRUEFTEN
+# Zerlegungs-Bausteine wie oben nachgeladen — bewusst KEIN eigener Tokenizer
+# (#1431: zweimal BROKEN durch nachgebaute Zerlegung). Eigener Import, weil
+# diese (mit Unterstrich als hausintern markierten) Namen in einer aelteren
+# Plugin-Version fehlen koennten, waehrend is_git_subcommand schon vorhanden
+# ist.
+try:
+    from hook_utils import (  # noqa: E402
+        _ENV_ASSIGN_RE,
+        _GIT_COMMAND_PREFIXES,
+        _GIT_OPTS_WITH_VALUE,
+        _GIT_SHELL_BINARY_RE,
+        _git_segments,
+        _git_subcommand_of_segment,
+        _git_subcommands_in_segment,
+        git_subcommands,
+    )
+    ZIEL_WERKZEUG_FEHLT: str | None = None
+except Exception as _fehler2:  # noqa: BLE001
+    _git_segments = None  # type: ignore[assignment]
+    ZIEL_WERKZEUG_FEHLT = f"{type(_fehler2).__name__}: {_fehler2}"
+
+
+def _lauf(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(args, cwd=str(cwd), capture_output=True, text=True, timeout=60)
+
+
+# ------------------------------------------------------------- Sicherheitslage
+
+
+def _commit_sicherheitslage(befehl: str) -> tuple[str, list[Path], str | None]:
+    """Bestimmt, WO der commit-Aufruf sicher geprueft werden kann.
+
+    Rueckgabe (lage, wurzeln, grund):
+      "sicher"    -> wurzeln enthaelt >=1 Pfad, dort wird geprueft
+      "unsicher"  -> wurzeln ist leer, BLOCKIEREN (grund nennt die Ursache)
+      "gestoert"  -> wurzeln ist leer, DURCHLASSEN (grund nennt die eigene
+                     Stoerung — z.B. fehlendes Zerlegungs-Werkzeug)
+
+    Nur Segmente, die tatsaechlich `git` aufrufen, werden auf Ziel-Anzeichen
+    durchsucht — sonst waere `grep -C 3 muster datei && git commit` ein
+    Fehlalarm (`-C` gehoert dort zu `grep`, nicht zu `git`).
+    """
+    if _git_segments is None:
+        return "gestoert", [], (
+            f"Zerlegungs-Baustein fuer die Ziel-Erkennung fehlt ({ZIEL_WERKZEUG_FEHLT})"
+        )
+    segmente = _git_segments(befehl)
+    if segmente is None:
+        return "unsicher", [], "Kommando nicht verlaesslich zerlegbar (kaputte/unklare Quotes)"
+
+    if any(tokens and tokens[0] == "cd" for tokens in segmente):
+        return "unsicher", [], "Kommando enthaelt 'cd' vor dem Commit — Ziel nicht sicher bestimmbar"
+
+    wurzeln: list[Path] = []
+    fand_commit_segment = False
+
+    for tokens in segmente:
+        # Verschachtelte Shell (`sh -c "..."`, `eval ...`): IMMER unsicher, wenn
+        # darin ein commit steckt — unabhaengig davon, was sonst noch drinsteht.
+        for i, tok in enumerate(tokens):
+            basis = tok.rsplit("/", 1)[-1]
+            if _GIT_SHELL_BINARY_RE.match(basis) and i + 2 < len(tokens) and tokens[i + 1] == "-c":
+                if "commit" in git_subcommands(tokens[i + 2]):
+                    return "unsicher", [], "Commit steckt in einer verschachtelten Shell (sh -c/bash -c)"
+            elif basis == "eval":
+                for rest in tokens[i + 1:]:
+                    if "commit" in git_subcommands(rest):
+                        return "unsicher", [], "Commit steckt in einem `eval`-Aufruf"
+
+        if not any(t == "git" or t.endswith("/git") for t in tokens):
+            continue  # dieses Segment ruft gar kein git auf
+        if "commit" not in _git_subcommands_in_segment(tokens):
+            continue  # dieses Segment betrifft keinen commit
+
+        fand_commit_segment = True
+
+        if _git_subcommand_of_segment(tokens) != "commit":
+            # `git` steht nicht kopf-gebunden (ggf. nach bekannten transparenten
+            # Praefixen/Env-Zuweisungen) vor `commit` — ein NICHT erkanntes
+            # Hilfsprogramm (timeout/flock/xargs/Schleife/...) steht davor.
+            return "unsicher", [], "Commit-Aufruf steht hinter einem nicht erkannten Hilfsprogramm"
+
+        i = 0
+        while i < len(tokens) and (
+            _ENV_ASSIGN_RE.match(tokens[i]) or tokens[i] in _GIT_COMMAND_PREFIXES
+        ):
+            if tokens[i].startswith(("GIT_DIR=", "GIT_WORK_TREE=")):
+                return "unsicher", [], "GIT_DIR/GIT_WORK_TREE als Umgebungszuweisung vor dem Commit"
+            i += 1
+        # tokens[i] ist an dieser Stelle 'git' (durch den kopf-gebundenen Treffer oben).
+        j = i + 1
+        praefix: list[str] = []
+        while j < len(tokens):
+            tok = tokens[j]
+            if tok in _GIT_OPTS_WITH_VALUE:
+                if j + 1 >= len(tokens):
+                    j += 1
+                    break
+                praefix.extend([tok, tokens[j + 1]])
+                j += 2
+                continue
+            if tok.startswith("-"):
+                praefix.append(tok)
+                j += 1
+                continue
+            break
+
+        ziel_flags = [t for t in praefix if t == "-C" or t.startswith(("--git-dir", "--work-tree"))]
+        if not ziel_flags:
+            wurzeln.append(Path.cwd())
+            continue
+
+        r = _lauf(["git", *praefix, "rev-parse", "--show-toplevel"], Path.cwd())
+        if r.returncode != 0 or not r.stdout.strip():
+            return "unsicher", [], (
+                "-C/--git-dir/--work-tree loest nicht sauber auf "
+                f"({r.stderr.strip()[:120] or 'kein Pfad zurueckgegeben'})"
+            )
+        wurzeln.append(Path(r.stdout.strip()))
+
+    if not fand_commit_segment:
+        # Defensiv: sollte wegen der vorherigen is_git_subcommand-Pruefung in
+        # main() nicht vorkommen. Im Zweifel unsicher, nicht raten.
+        return "unsicher", [], "Kein commit-Segment in der Zerlegung gefunden, obwohl einer erkannt wurde"
+
+    eindeutig: list[Path] = []
+    gesehen_pfade: set[str] = set()
+    for w in wurzeln:
+        schluessel = str(w)
+        if schluessel not in gesehen_pfade:
+            gesehen_pfade.add(schluessel)
+            eindeutig.append(w)
+    return "sicher", eindeutig, None
+
+
+# --------------------------------------------------------------------- .env
+
+
+def _parse_env_zeilen(text: str) -> list[tuple[str, str]]:
+    """Minimal-Parser: KEY=WERT je Zeile, Anfuehrungszeichen und `export `
+    werden entfernt, Kommentare und Leerzeilen uebersprungen."""
+    paare: list[tuple[str, str]] = []
+    for zeile in text.splitlines():
+        zeile = zeile.strip()
+        if not zeile or zeile.startswith("#") or "=" not in zeile:
+            continue
+        if zeile.startswith("export "):
+            zeile = zeile[len("export "):].lstrip()
+        schluessel, _, wert = zeile.partition("=")
+        schluessel = schluessel.strip()
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", schluessel):
+            continue
+        wert = wert.strip()
+        if len(wert) >= 2 and wert[0] == wert[-1] and wert[0] in ("'", '"'):
+            wert = wert[1:-1]
+        else:
+            wert = re.split(r"\s+#", wert, maxsplit=1)[0].strip()
+        paare.append((schluessel, wert))
+    return paare
+
+
+def _lade_geheimnisse(env_pfad: Path) -> tuple[list[tuple[str, str]], str | None]:
+    """(Schluessel, Wert)-Paare aus der lokalen `.env`, deren Schluessel auf
+    einen der gesuchten Suffixe endet und deren Wert lang genug ist. Wird bei
+    jedem Lauf frisch gelesen (kein Cache) — sonst greift das Gate nach einer
+    Rotation ins Leere."""
+    try:
+        text = env_pfad.read_text(errors="ignore")
+    except OSError as fehler:
+        return [], f".env nicht lesbar ({fehler})"
+    geheimnisse: list[tuple[str, str]] = []
+    for schluessel, wert in _parse_env_zeilen(text):
+        if not wert or len(wert) < _MIN_WERT_LAENGE:
+            continue
+        if not schluessel.upper().endswith(_SECRET_KEY_SUFFIXES):
+            continue
+        geheimnisse.append((schluessel, wert))
+    return geheimnisse, None
+
+
+# --------------------------------------------------------------- Vormerk-Stand
+
+
+def _vorgemerkte_dateien(wurzel: Path) -> tuple[list[str], str | None]:
+    """Pfade der zum Commit vorgemerkten Dateien — Binaerdateien werden
+    anhand der numstat-Markierung `-` ausgeschlossen (dort steht kein Text,
+    der ein Geheimnis im Klartext tragen koennte)."""
+    r = _lauf(["git", "diff", "--cached", "--numstat"], wurzel)
+    if r.returncode != 0:
+        return [], f"Vormerk-Stand nicht lesbar ({r.stderr.strip()[:120]})"
+    dateien: list[str] = []
+    for zeile in r.stdout.splitlines():
+        teile = zeile.split("\t")
+        if len(teile) != 3:
+            continue
+        hinzugefuegt, entfernt, pfad = teile
+        if hinzugefuegt == "-" and entfernt == "-":
+            continue  # Binaerdatei laut git
+        dateien.append(pfad)
+    return dateien, None
+
+
+def _vorgemerkter_inhalt(wurzel: Path, pfad: str) -> str | None:
+    """Inhalt der Datei im INDEX (Vormerk-Stand, das was in den Commit
+    ginge) — nicht der Arbeitsstand. `None` bei geloeschten Dateien (die
+    koennen kein Geheimnis neu einbringen) oder wenn die Datei die
+    Groessengrenze ueberschreitet."""
+    groesse_r = _lauf(["git", "cat-file", "-s", f":{pfad}"], wurzel)
+    if groesse_r.returncode == 0:
+        try:
+            if int(groesse_r.stdout.strip()) > _MAX_DATEI_BYTES:
+                return None
+        except ValueError:
+            pass
+    inhalt_r = _lauf(["git", "show", f":{pfad}"], wurzel)
+    if inhalt_r.returncode != 0:
+        return None
+    return inhalt_r.stdout
+
+
+# ------------------------------------------------------------------- Hauptlauf
+
+
+def main() -> int:
+    try:
+        eingabe = json.loads(sys.stdin.read() or "{}")
+    except Exception:  # noqa: BLE001
+        return 0
+    befehl = (eingabe.get("tool_input") or {}).get("command", "")
+
+    if WERKZEUG_FEHLT:  # ohne Werkzeug wird nicht geraten, sondern gesagt
+        print(f"[secret_in_repo_gate] gestoert: Werkzeug-Paket hook_utils nicht "
+              f"verfuegbar ({WERKZEUG_FEHLT}) — Commit UNGEPRUEFT durchgelassen. "
+              "Es wird bewusst NICHT auf eine Wortlaut-Pruefung zurueckgefallen "
+              "(#1431).", file=sys.stderr)
+        return 0
+    if not is_git_subcommand(befehl, "commit"):
+        return 0
+
+    if not shutil.which("git"):
+        print("[secret_in_repo_gate] gestoert: kein `git` auffindbar — Commit "
+              "ungeprueft durchgelassen.", file=sys.stderr)
+        return 0
+
+    lage, wurzeln, grund = _commit_sicherheitslage(befehl)
+    if lage == "gestoert":
+        print(f"[secret_in_repo_gate] gestoert: {grund} — Commit ungeprueft "
+              "durchgelassen.", file=sys.stderr)
+        return 0
+    if lage == "unsicher":
+        print(
+            f"ZIEL-NICHT-SICHER-BESTIMMBAR (#1537) — {grund}.\n"
+            "Hier wird NICHT geraten, sondern blockiert (ein stilles "
+            "Sicherheitsloch waere schlimmer als ein Fehlalarm).\n"
+            "Erlaubter Weg: ein einfacher 'git commit' im eigenen Ordner ODER "
+            "'git -C <pfad> commit' (wird dann an diesem Pfad geprueft).",
+            file=sys.stderr,
+        )
+        return 2
+
+    treffer: list[tuple[str, str]] = []
+    gesehen: set[tuple[str, str, str]] = set()
+    stoerungen: list[str] = []
+    for wurzel in wurzeln:
+        geheimnisse, env_stoerung = _lade_geheimnisse(wurzel / ".env")
+        if env_stoerung:
+            stoerungen.append(f"{wurzel}: {env_stoerung}")
+            continue
+        if not geheimnisse:
+            continue  # keine passenden Schluessel in dieser .env -> nichts zu pruefen
+
+        dateien, diff_stoerung = _vorgemerkte_dateien(wurzel)
+        if diff_stoerung:
+            stoerungen.append(f"{wurzel}: {diff_stoerung}")
+            continue
+
+        for pfad in dateien:
+            inhalt = _vorgemerkter_inhalt(wurzel, pfad)
+            if inhalt is None:
+                continue
+            for schluessel, wert in geheimnisse:
+                marke = (str(wurzel), pfad, schluessel)
+                if wert in inhalt and marke not in gesehen:
+                    gesehen.add(marke)
+                    treffer.append((pfad, schluessel))
+
+    if treffer:
+        meldung = [
+            "SECRET-IN-REPO-SPERRE (#1537) — vorgemerkte Datei(en) enthalten den "
+            "gueltigen Wert eines Zugangsdatums aus der lokalen .env:",
+        ]
+        for pfad, schluessel in treffer:
+            meldung.append(f"   {pfad}   [Schluessel: {schluessel}]")
+        meldung += [
+            "",
+            "Der Wert selbst wird hier bewusst nicht angezeigt.",
+            "Abhilfe: Wert aus der Datei entfernen, zur Laufzeit aus der Umgebung "
+            "lesen (Python: os.environ[\"<SCHLUESSEL>\"] / Bash: \"$<SCHLUESSEL>\") "
+            "und die Datei neu vormerken. Bereits vorgemerkte Datei aus dem Commit "
+            "nehmen: git restore --staged <datei>",
+        ]
+        print("\n".join(meldung), file=sys.stderr)
+        return 2
+
+    if stoerungen:
+        print(f"[secret_in_repo_gate] gestoert: {'; '.join(stoerungen)} — Commit "
+              "ungeprueft durchgelassen.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:  # noqa: BLE001 — eine eigene Stoerung blockiert NIE
+        print(f"[secret_in_repo_gate] gestoert, Commit nicht blockiert: {e}",
+              file=sys.stderr)
+        sys.exit(0)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -84,6 +84,16 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [ -f \"${CLAUDE_PROJECT_DIR}/.claude/hooks/secret_in_repo_gate.py\" ]; then python3 \"${CLAUDE_PROJECT_DIR}/.claude/hooks/secret_in_repo_gate.py\"; fi",
+            "timeout": 60
+          }
+        ]
+      },
+      {
         "matcher": "Write|Edit",
         "hooks": [
           {

--- a/docs/specs/_archive/modules/epic_404_phase2_ist_screenshots.md
+++ b/docs/specs/_archive/modules/epic_404_phase2_ist_screenshots.md
@@ -49,7 +49,7 @@ const fs   = require('fs');
 
 const BASE_URL = 'https://staging.gregor20.henemm.com';
 const OUT_DIR  = path.join(__dirname, 'ist-screenshots');
-const CREDS    = { user: 'default', pass: 'ZfDOKJTre8udPtG' };
+const CREDS    = { user: 'default', pass: '<aus .env: GZ_AUTH_PASS>' };
 const TRIP_ID  = 'e2e-cockpit-test';
 const GPX_FILE = '/home/hem/gregor_zwanzig/frontend/e2e/fixtures/test-trip.gpx';
 ```

--- a/frontend/.env.test
+++ b/frontend/.env.test
@@ -1,2 +1,0 @@
-E2E_USER=default
-E2E_PASS=ZfDOKJTre8udPtG

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -16,7 +16,6 @@ Thumbs.db
 .env
 .env.*
 !.env.example
-!.env.test
 
 # Vite
 vite.config.js.timestamp-*

--- a/tests/unit/test_secret_in_repo_gate.py
+++ b/tests/unit/test_secret_in_repo_gate.py
@@ -1,0 +1,452 @@
+"""Verhaltensnachweis fuer das Commit-Gate „Secret-in-Repo-Sperre" (#1537 Scheibe 1).
+
+Eine zum Commit vorgemerkte Datei, die den ausgeschriebenen Wert eines Geheimnisses aus
+der lokalen `.env` enthaelt (Schluessel endet auf `_PASS`/`_TOKEN`/`_KEY`/`_SECRET`, Wert
+mind. 10 Zeichen), blockiert den Commit. Der Wert selbst darf NIE in der Blockade-Meldung
+auftauchen — nur Dateiname und Schluesselname.
+
+Kern-Schicht, deterministisch: jeder Fall baut ein eigenes Wegwerf-Repository mit einer
+SYNTHETISCHEN `.env` (nie die echte Projekt-`.env`) und ruft den Waechter als echten
+Unterprozess auf — kein Mock, kein patch(). Damit ist die Suite hermetisch: sie liest nie
+die reale `.env` des Ausfuehrungsortes (genau das machte PR #1534 auf CI rot).
+
+Pfadregel #1409: Der Pruefling wird relativ zu DIESER Datei aufgeloest, damit der Test aus
+einem Worktree den Worktree-Stand prueft und nicht die Hauptrepo-Kopie.
+"""
+from __future__ import annotations
+
+import importlib.util as _gz_ilu
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+HOOKS = REPO / ".claude" / "hooks"
+# Ueberschreibbar fuer die Mutationsprobe (#1537 Runde 3): der Adversary mutiert
+# eine EXTERNE Kopie im Scratchpad statt der geschuetzten Originaldatei — dafuer
+# muss der Pruefling-Pfad umstellbar sein. Ohne die Variable unveraendertes
+# Verhalten: der echte Hook im Repo.
+GATE = Path(os.environ.get("GZ_SECRET_GATE_PATH", "")) if os.environ.get("GZ_SECRET_GATE_PATH") \
+    else HOOKS / "secret_in_repo_gate.py"
+
+# Plugin-Sonde (Muster aus tests/tdd/test_pendant_gate.py): der Waechter laeuft ueber
+# hook_utils, einen Shim auf das installierte agent-os-openspec-Plugin. Ohne Plugin
+# (CI-Runner ohne Plugin-Installation) meldet das Gate fail-open "gestoert ... UNGEPRUEFT
+# durchgelassen" fuer JEDEN Commit — die Block-Tests waeren dann strukturell rot. Sauber
+# ueberspringen statt rot; auf dem Server (Plugin vorhanden) laeuft die Suite vollstaendig.
+_gz_hook_utils = HOOKS / "hook_utils.py"
+try:
+    _gz_spec = _gz_ilu.spec_from_file_location("_gz_hook_utils_probe", _gz_hook_utils)
+    _gz_mod = _gz_ilu.module_from_spec(_gz_spec)
+    _gz_spec.loader.exec_module(_gz_mod)
+except ImportError as _gz_exc:
+    pytest.skip(
+        f"agent-os-openspec-Plugin fehlt ({_gz_exc}) — Hook-Suite braucht die "
+        "installierten Server-Hooks (#1196)",
+        allow_module_level=True,
+    )
+
+# Synthetische Geheimnisse — bewusst NICHT aus der echten Projekt-.env. Frei erfunden,
+# Kollision mit einem echten Zugangsdatum ist praktisch ausgeschlossen.
+GEHEIM_SCHLUESSEL = "GZ_TEST_DUMMY_TOKEN"
+GEHEIM_WERT = "unit-test-fixture-secret-9f8e7d6c"  # > 10 Zeichen
+KURZER_SCHLUESSEL = "GZ_SHORT_KEY"
+KURZER_WERT = "1234567"  # < 10 Zeichen -> darf NIE als Geheimnis gelten
+HARMLOSER_SCHLUESSEL = "GZ_SMTP_HOST"
+HARMLOSER_WERT = "smtp.example.invalid"  # Suffix passt zu keiner der vier Endungen
+
+
+def _env_text() -> str:
+    return (
+        f"{GEHEIM_SCHLUESSEL}={GEHEIM_WERT}\n"
+        f"{KURZER_SCHLUESSEL}={KURZER_WERT}\n"
+        f"{HARMLOSER_SCHLUESSEL}={HARMLOSER_WERT}\n"
+    )
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True)
+
+
+def _wegwerf_repo(tmp_path: Path, mit_env: bool = True) -> Path:
+    """Repo mit committetem Ausgangsstand und (optional) lokaler `.env`.
+
+    Die `.env` wird bewusst NICHT vorgemerkt/committet — genau wie im echten Projekt ist
+    sie eine lokale, gitignorierte Datei, die der Waechter direkt von der Platte liest.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "README.md").write_text("Ausgangsstand\n")
+    _git(repo.parent, "init", "-q", str(repo))
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "Ausgangsstand")
+    if mit_env:
+        (repo / ".env").write_text(_env_text())
+    return repo
+
+
+def _stage(repo: Path, pfad: str, inhalt: str) -> None:
+    ziel = repo / pfad
+    ziel.parent.mkdir(parents=True, exist_ok=True)
+    ziel.write_text(inhalt)
+    _git(repo, "add", "--", pfad)
+
+
+def _hook(repo: Path, kommando: str = "git commit -m 'x'",
+          cwd: Path | None = None) -> subprocess.CompletedProcess:
+    """Ruft den Waechter wie die Hook-Schicht auf: stdin-JSON, cwd = Wegwerf-Repo.
+
+    `cwd` erlaubt, die Prozess-cwd des Hooks vom Repo zu ENTKOPPELN — genau der
+    Fall, den F001 prueft: der Hook laeuft in `haupt`, das Kommando zielt per
+    `-C <ziel>`/`--git-dir`/`--work-tree` auf ein ANDERES Repo.
+    """
+    eingabe = json.dumps({"tool_name": "Bash", "tool_input": {"command": kommando}})
+    env = dict(os.environ)
+    env.pop("GIT_DIR", None)
+    env.pop("GIT_WORK_TREE", None)
+    return subprocess.run(
+        [sys.executable, str(GATE)], input=eingabe, cwd=str(cwd or repo),
+        capture_output=True, text=True, timeout=60, env=env,
+    )
+
+
+def _text(r: subprocess.CompletedProcess) -> str:
+    return r.stderr + r.stdout
+
+
+# --------------------------------------------------------------------------------- Faelle
+
+
+def test_gate_blocks_staged_file_with_env_secret(tmp_path):
+    """(1) Vorgemerkte Datei mit echtem .env-Wert -> Gate blockiert.
+
+    GIVEN eine .env mit einem Geheimnis (Schluessel endet auf _TOKEN, Wert >= 10 Zeichen)
+    WHEN eine neue Datei mit genau diesem Wert vorgemerkt und committet wird
+    THEN blockiert das Gate (Exit 2) und nennt die betroffene Datei.
+    """
+    repo = _wegwerf_repo(tmp_path)
+    _stage(repo, "config/leaked.txt", f"token = {GEHEIM_WERT}\n")
+    r = _hook(repo)
+    ausgabe = _text(r)
+    assert r.returncode == 2, f"Erwartete Blockade (Exit 2), bekam {r.returncode}: {ausgabe}"
+    assert "leaked.txt" in ausgabe, f"Meldung nennt nicht die betroffene Datei: {ausgabe}"
+    assert GEHEIM_SCHLUESSEL in ausgabe, f"Meldung nennt nicht den Schluesselnamen: {ausgabe}"
+
+
+def test_gate_allows_harmless_staged_file(tmp_path):
+    """(2) Harmlose Datei ohne Geheimnis -> Gate laesst durch.
+
+    GIVEN eine .env mit einem Geheimnis
+    WHEN eine neue Datei vorgemerkt wird, die diesen Wert NICHT enthaelt
+    THEN laesst das Gate den Commit durch (Exit 0).
+    """
+    repo = _wegwerf_repo(tmp_path)
+    _stage(repo, "docs/notes.md", "Nur ganz normaler Text, kein Geheimnis.\n")
+    r = _hook(repo)
+    assert r.returncode == 0, f"Harmlose Datei wurde blockiert: {_text(r)}"
+
+
+def test_block_message_never_contains_the_secret_value(tmp_path):
+    """(3) Blockade-Meldung enthaelt den Schluesselnamen, NIE den Wert.
+
+    Wichtigste Einzelanforderung des Auftrags: der Wert selbst darf unter keinen
+    Umstaenden in Log-/Fehlermeldungen erscheinen.
+    """
+    repo = _wegwerf_repo(tmp_path)
+    _stage(repo, "config/leaked.txt", f"token = {GEHEIM_WERT}\n")
+    r = _hook(repo)
+    ausgabe = _text(r)
+    assert r.returncode == 2, f"Erwartete Blockade, bekam {r.returncode}: {ausgabe}"
+    assert GEHEIM_SCHLUESSEL in ausgabe
+    assert GEHEIM_WERT not in ausgabe, (
+        "Der Geheimniswert selbst ist in der Ausgabe aufgetaucht — das ist die "
+        "wichtigste verbotene Wirkung dieses Gates."
+    )
+
+
+def test_gate_allows_when_env_missing(tmp_path):
+    """(4a) Keine .env vorhanden -> Gate stoert sich selbst, laesst durch und sagt das.
+
+    GIVEN kein .env im Repo-Wurzelverzeichnis
+    WHEN eine Datei mit einem geheimnis-aehnlichen Text vorgemerkt wird
+    THEN laesst das Gate durch (Exit 0) — es hat nichts, wogegen es pruefen koennte —
+         und die Meldung erwaehnt die .env als Ursache der eigenen Stoerung.
+    """
+    repo = _wegwerf_repo(tmp_path, mit_env=False)
+    _stage(repo, "config/leaked.txt", f"token = {GEHEIM_WERT}\n")
+    r = _hook(repo)
+    ausgabe = _text(r)
+    assert r.returncode == 0, f"Fehlende .env haette NIE blockieren duerfen: {ausgabe}"
+    assert ".env nicht lesbar" in ausgabe.lower(), (
+        f"Eigene Stoerung wird nicht mit vollstaendiger Ursache gemeldet: {ausgabe}"
+    )
+
+
+def test_gate_allows_when_env_unreadable(tmp_path):
+    """(4b) .env nicht als Datei lesbar (hier: ein Verzeichnis gleichen Namens)
+    -> Gate laesst durch und meldet die Stoerung.
+
+    Ein Verzeichnis statt einer Datei ist eine plattformunabhaengige, nicht von
+    Dateirechten abhaengige Art, einen OSError beim Lesen zu erzwingen (root-Prozesse
+    ignorieren `chmod 000`, ein IsADirectoryError trifft aber jeden).
+    """
+    repo = _wegwerf_repo(tmp_path, mit_env=False)
+    (repo / ".env").mkdir()
+    _stage(repo, "config/leaked.txt", f"token = {GEHEIM_WERT}\n")
+    r = _hook(repo)
+    ausgabe = _text(r)
+    assert r.returncode == 0, f"Unlesbare .env haette NIE blockieren duerfen: {ausgabe}"
+    assert ".env nicht lesbar" in ausgabe.lower()
+
+
+def test_gate_ignores_short_values_and_non_matching_keys(tmp_path):
+    """Laengen- und Schluessel-Filter greifen: kurze Werte und Schluessel ohne die
+    gesuchten Endungen sind KEINE Geheimnisse — sonst traefe z.B. der Projektname
+    ueberall.
+    """
+    repo = _wegwerf_repo(tmp_path)
+    _stage(repo, "config/notes.txt", f"kurz={KURZER_WERT} host={HARMLOSER_WERT}\n")
+    r = _hook(repo)
+    assert r.returncode == 0, f"Kurzer/nicht passender Wert haette nicht blocken duerfen: {_text(r)}"
+
+
+def test_gate_skips_binary_files(tmp_path):
+    """Binaerdateien werden uebersprungen — auch wenn sie das Geheimnis als Bytes
+    enthalten, kann/soll das Gate sie nicht sinnvoll als Text durchsuchen.
+    """
+    repo = _wegwerf_repo(tmp_path)
+    ziel = repo / "assets/blob.bin"
+    ziel.parent.mkdir(parents=True, exist_ok=True)
+    ziel.write_bytes(b"\x00\x01\x02" + GEHEIM_WERT.encode() + b"\x00\x03")
+    _git(repo, "add", "--", "assets/blob.bin")
+    r = _hook(repo)
+    assert r.returncode == 0, f"Binaerdatei haette uebersprungen werden muessen: {_text(r)}"
+
+
+# --------------------------------------------------- F001 Runde 3: Sicherheitslage
+#
+# Drei Ausgaenge (Tech-Lead-Entscheid, siehe Kopf-Docstring des Prueflings):
+#   sicher   -> geprueft (Exit 0 oder 2, je nach Fund)
+#   unsicher -> BLOCKIERT (Exit 2, Marker UNSICHER_MARKER)
+#   gestoert -> durchgelassen (Exit 0, eigene Stoerung)
+#
+# F007-Lehre (Runde 3 Adversary-Fund): Zusicherungen NIE gegen einen bloss
+# zufaellig im temporaeren Pfad vorkommenden Teilstring pruefen (der von pytest
+# erzeugte tmp_path-Name enthaelt den Testnamen, z.B. "..._on_cd0" — ein reiner
+# `"cd" in ausgabe`-Test war dadurch unabhaengig vom tatsaechlichen Verhalten
+# gruen). Jede Zusicherung hier prueft stattdessen einen FESTEN Marker aus dem
+# Pruefling (SECRET_MARKER/UNSICHER_MARKER) UND einen vollstaendigen, nur vom
+# Pruefling erzeugten Formulierungs-Ausschnitt.
+
+SECRET_MARKER = "SECRET-IN-REPO-SPERRE"
+UNSICHER_MARKER = "ZIEL-NICHT-SICHER-BESTIMMBAR"
+
+
+def _zweitrepo(tmp_path: Path, name: str, mit_geheimnis: bool = True) -> Path:
+    """Ein zweites, eigenstaendiges Wegwerf-Repo (eigener Ordnername noetig,
+    `_wegwerf_repo` legt sein Repo fest unter `tmp_path/'repo'` an)."""
+    repo = tmp_path / name
+    repo.mkdir()
+    (repo / "README.md").write_text("Ausgangsstand\n")
+    _git(repo.parent, "init", "-q", str(repo))
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "Ausgangsstand")
+    if mit_geheimnis:
+        (repo / ".env").write_text(_env_text())
+        _stage(repo, "config/leaked.txt", f"token = {GEHEIM_WERT}\n")
+    return repo
+
+
+def test_gate_checks_resolved_target_with_dash_c_flag(tmp_path):
+    """(1/5 Umlenkungswege) `git -C <ziel> commit` loest SAUBER auf -> Zeile 1
+    der Tabelle: dort wird geprueft (nicht blockiert, nicht lautlos durch).
+
+    GIVEN `haupt` (Prozess-cwd, KEINE .env) und `ziel` (eigene .env mit
+          Geheimnis, vorgemerkte Datei mit genau diesem Wert)
+    WHEN  `git -C <ziel> commit` aus `haupt` heraus aufgerufen wird
+    THEN  blockiert das Gate mit SECRET_MARKER und nennt die Datei aus `ziel`.
+    """
+    haupt = _wegwerf_repo(tmp_path, mit_env=False)
+    ziel = _zweitrepo(tmp_path, "ziel_repo")
+    r = _hook(haupt, kommando=f"git -C {ziel} commit -m 'x'", cwd=haupt)
+    ausgabe = _text(r)
+    assert r.returncode == 2, f"Sauber aufloesbares -C haette geprueft werden muessen: {ausgabe}"
+    assert SECRET_MARKER in ausgabe, f"Kein Fund-Marker in der Meldung: {ausgabe}"
+    assert "leaked.txt" in ausgabe and GEHEIM_SCHLUESSEL in ausgabe
+
+
+def test_gate_checks_resolved_target_with_git_dir_and_work_tree_flags(tmp_path):
+    """(2/5 Umlenkungswege) `git --git-dir=X --work-tree=Y commit` (getrennte
+    Flags, sauber aufloesbar) -> ebenfalls Zeile 1: geprueft."""
+    haupt = _wegwerf_repo(tmp_path, mit_env=False)
+    ziel = _zweitrepo(tmp_path, "ziel_repo")
+    kommando = f"git --git-dir={ziel}/.git --work-tree={ziel} commit -m 'x'"
+    r = _hook(haupt, kommando=kommando, cwd=haupt)
+    ausgabe = _text(r)
+    assert r.returncode == 2, f"Sauber aufloesbares --git-dir/--work-tree haette geprueft werden muessen: {ausgabe}"
+    assert SECRET_MARKER in ausgabe, f"Kein Fund-Marker in der Meldung: {ausgabe}"
+    assert "leaked.txt" in ausgabe and GEHEIM_SCHLUESSEL in ausgabe
+
+
+def test_gate_blocks_cd_redirect(tmp_path):
+    """(3/5 Umlenkungswege) `cd <ziel> && git commit` traegt kein git-Vor-Options-
+    Anzeichen -> Zeile 2: BLOCKIERT, nicht lautlos durchgelassen."""
+    haupt = _wegwerf_repo(tmp_path, mit_env=False)
+    ziel = _zweitrepo(tmp_path, "ziel_repo")
+    r = _hook(haupt, kommando=f"cd {ziel} && git commit -m 'x'", cwd=haupt)
+    ausgabe = _text(r)
+    assert r.returncode == 2, f"cd-Umlenkung haette blockieren muessen, nicht durchlassen: {ausgabe}"
+    assert UNSICHER_MARKER in ausgabe
+    assert "enthaelt 'cd' vor dem Commit" in ausgabe, f"Grund nicht genannt: {ausgabe}"
+    assert "-C <pfad> commit" in ausgabe, f"Erlaubter Weg nicht genannt: {ausgabe}"
+
+
+def test_gate_blocks_git_dir_env_assignment(tmp_path):
+    """(4/5 Umlenkungswege) `GIT_DIR=... GIT_WORK_TREE=... git commit` als
+    Umgebungszuweisung -> Zeile 2: BLOCKIERT."""
+    haupt = _wegwerf_repo(tmp_path, mit_env=False)
+    ziel = _zweitrepo(tmp_path, "ziel_repo")
+    kommando = f"GIT_DIR={ziel}/.git GIT_WORK_TREE={ziel} git commit -m 'x'"
+    r = _hook(haupt, kommando=kommando, cwd=haupt)
+    ausgabe = _text(r)
+    assert r.returncode == 2, f"GIT_DIR=/GIT_WORK_TREE= haette blockieren muessen: {ausgabe}"
+    assert UNSICHER_MARKER in ausgabe
+    assert "GIT_DIR/GIT_WORK_TREE als Umgebungszuweisung" in ausgabe, f"Grund nicht genannt: {ausgabe}"
+
+
+def test_gate_blocks_cd_redirect_in_subshell(tmp_path):
+    """(5/5 Umlenkungswege) `(cd <ziel> && git commit)` in einer Subshell ->
+    Zeile 2: BLOCKIERT (Klammern sind fuer die Zerlegung Trenner wie `&&`)."""
+    haupt = _wegwerf_repo(tmp_path, mit_env=False)
+    ziel = _zweitrepo(tmp_path, "ziel_repo")
+    r = _hook(haupt, kommando=f"(cd {ziel} && git commit -m 'x')", cwd=haupt)
+    ausgabe = _text(r)
+    assert r.returncode == 2, f"cd-Umlenkung in Subshell haette blockieren muessen: {ausgabe}"
+    assert UNSICHER_MARKER in ausgabe
+    assert "enthaelt 'cd' vor dem Commit" in ausgabe, f"Grund nicht genannt: {ausgabe}"
+
+
+@pytest.mark.parametrize("wrapper", [
+    "timeout 5",
+    "flock /tmp/irgendeine.lock",
+    "xargs -I{}",
+    "nice -n 10",
+])
+def test_gate_blocks_commit_behind_unrecognized_wrapper(tmp_path, wrapper):
+    """Unbekanntes Hilfsprogramm vor `git commit` -> Zeile 2: BLOCKIERT.
+
+    `nice` steht absichtlich mit einem eigenen Argument (`-n 10`) in der Liste:
+    `nice` ALLEIN ist ein bekannter transparenter Praefix (sicher), `nice -n 10`
+    ist es nicht (das Token direkt vor `git` ist dann `10`, kein bekannter
+    Praefix mehr) — die Unterscheidung ist beabsichtigt scharf.
+    """
+    repo = _wegwerf_repo(tmp_path)
+    _stage(repo, "config/leaked.txt", f"token = {GEHEIM_WERT}\n")
+    r = _hook(repo, kommando=f"{wrapper} git commit -m 'x'")
+    ausgabe = _text(r)
+    assert r.returncode == 2, f"'{wrapper} git commit' haette blockieren muessen: {ausgabe}"
+    assert UNSICHER_MARKER in ausgabe
+    assert "nicht erkannten Hilfsprogramm" in ausgabe, f"Grund nicht genannt: {ausgabe}"
+
+
+def test_gate_blocks_commit_behind_loop(tmp_path):
+    """Schleife vor `git commit` -> Zeile 2: BLOCKIERT."""
+    repo = _wegwerf_repo(tmp_path)
+    _stage(repo, "config/leaked.txt", f"token = {GEHEIM_WERT}\n")
+    r = _hook(repo, kommando="for i in 1; do git commit -m 'x'; done")
+    ausgabe = _text(r)
+    assert r.returncode == 2, f"Commit in einer Schleife haette blockieren muessen: {ausgabe}"
+    assert UNSICHER_MARKER in ausgabe
+
+
+def test_gate_blocks_commit_inside_sh_dash_c(tmp_path):
+    """`sh -c "git commit -m x"` -> Zeile 2: BLOCKIERT (verschachtelte Shell)."""
+    repo = _wegwerf_repo(tmp_path)
+    _stage(repo, "config/leaked.txt", f"token = {GEHEIM_WERT}\n")
+    r = _hook(repo, kommando='sh -c "git commit -m x"')
+    ausgabe = _text(r)
+    assert r.returncode == 2, f"'sh -c \"git commit\"' haette blockieren muessen: {ausgabe}"
+    assert UNSICHER_MARKER in ausgabe
+    assert "verschachtelten Shell" in ausgabe, f"Grund nicht genannt: {ausgabe}"
+
+
+def test_gate_blocks_commit_inside_eval(tmp_path):
+    """`eval "git commit -m x"` -> Zeile 2: BLOCKIERT (verschachtelter Aufruf)."""
+    repo = _wegwerf_repo(tmp_path)
+    _stage(repo, "config/leaked.txt", f"token = {GEHEIM_WERT}\n")
+    r = _hook(repo, kommando='eval "git commit -m x"')
+    ausgabe = _text(r)
+    assert r.returncode == 2, f"'eval \"git commit\"' haette blockieren muessen: {ausgabe}"
+    assert UNSICHER_MARKER in ausgabe
+    assert "eval" in ausgabe, f"Grund nicht genannt: {ausgabe}"
+
+
+def test_gate_blocks_unresolvable_dash_c_target(tmp_path):
+    """`-C` auf einen nicht existierenden Pfad loest NICHT sauber auf -> Zeile 2:
+    BLOCKIERT (nicht Zeile 3 'eigene Stoerung', da `git rev-parse` selbst
+    laeuft und lediglich einen Fehler meldet)."""
+    haupt = _wegwerf_repo(tmp_path, mit_env=False)
+    r = _hook(haupt, kommando="git -C /pfad/der/garantiert/nicht/existiert commit -m 'x'", cwd=haupt)
+    ausgabe = _text(r)
+    assert r.returncode == 2, f"Nicht aufloesbares -C haette blockieren muessen, nicht durchlassen: {ausgabe}"
+    assert UNSICHER_MARKER in ausgabe
+    assert "loest nicht sauber auf" in ausgabe, f"Grund nicht genannt: {ausgabe}"
+
+
+def test_gate_does_not_block_mere_mention_of_commit(tmp_path):
+    """Gegenfall: die Woerter "git commit" kommen nur als Text vor (z.B. in
+    einem `--grep`-Suchbegriff) — das ist KEIN Commit-Aufruf und darf nicht
+    blockieren, obwohl eine vorgemerkte Datei das Geheimnis enthaelt. Ein
+    naiver Teilstring-Vergleich wuerde hier faelschlich blockieren.
+    """
+    repo = _wegwerf_repo(tmp_path)
+    _stage(repo, "config/leaked.txt", f"token = {GEHEIM_WERT}\n")
+    r = _hook(repo, kommando='git log --grep="git commit" -1')
+    ausgabe = _text(r)
+    assert r.returncode == 0, f"Blosse Erwaehnung haette nicht blockieren duerfen: {ausgabe}"
+    assert SECRET_MARKER not in ausgabe and UNSICHER_MARKER not in ausgabe
+
+
+# --------------------------------------------------------- F002: Aufrufform-Netz
+
+
+def test_gate_detects_commit_via_dash_capital_c_flag_same_repo(tmp_path):
+    """(F002) `git -C <repo> commit` muss erkannt werden — ein reiner
+    Teilstring-Vergleich auf "git commit" findet diese Form NICHT (dazwischen
+    steht `-C <repo>`)."""
+    repo = _wegwerf_repo(tmp_path)
+    _stage(repo, "config/leaked.txt", f"token = {GEHEIM_WERT}\n")
+    r = _hook(repo, kommando=f"git -C {repo} commit -m 'x'")
+    ausgabe = _text(r)
+    assert r.returncode == 2, f"'git -C <repo> commit' wurde nicht erkannt: {ausgabe}"
+    assert SECRET_MARKER in ausgabe and GEHEIM_SCHLUESSEL in ausgabe
+
+
+def test_gate_detects_commit_via_dash_c_option(tmp_path):
+    """(F002) `git -c user.name=x commit` — Teilstring "git commit" fehlt
+    (dazwischen steht `-c user.name=x`)."""
+    repo = _wegwerf_repo(tmp_path)
+    _stage(repo, "config/leaked.txt", f"token = {GEHEIM_WERT}\n")
+    r = _hook(repo, kommando="git -c user.name=x commit -m 'x'")
+    ausgabe = _text(r)
+    assert r.returncode == 2, f"'git -c k=v commit' wurde nicht erkannt: {ausgabe}"
+    assert SECRET_MARKER in ausgabe and GEHEIM_SCHLUESSEL in ausgabe
+
+
+def test_gate_detects_commit_via_no_pager_flag(tmp_path):
+    """(F002) `git --no-pager commit` — Teilstring "git commit" fehlt
+    (dazwischen steht `--no-pager`)."""
+    repo = _wegwerf_repo(tmp_path)
+    _stage(repo, "config/leaked.txt", f"token = {GEHEIM_WERT}\n")
+    r = _hook(repo, kommando="git --no-pager commit -m 'x'")
+    ausgabe = _text(r)
+    assert r.returncode == 2, f"'git --no-pager commit' wurde nicht erkannt: {ausgabe}"
+    assert SECRET_MARKER in ausgabe and GEHEIM_SCHLUESSEL in ausgabe


### PR DESCRIPTION
Das Repository ist oeffentlich. Vier heute gueltige Zugangsdaten lagen
darin im Klartext: GZ_AUTH_PASS im aktuellen Stand (frontend/.env.test,
Archiv-Doku), GZ_SMTP_PASS / GZ_TEST_SMTP_PASS / GZ_TEST_IMAP_PASS in der
Versionsgeschichte, alle seit 2026-05-17.

Bereinigung:
- frontend/.env.test entfernt (toter Code, 0 Lader)
- frontend/.gitignore: die !.env.test-Ausnahme entfernt — sie war die
  eigentliche Ursache, dass die Datei trotz .env.*-Ausschluss drin lag
- Klartext in der Archiv-Doku durch Platzhalter ersetzt

Neuer Waechter secret_in_repo_gate.py, drei Ausgaenge:
1. Commit erkannt, Ziel sicher bestimmbar -> vorgemerkte Dateien gegen die
   .env-Werte pruefen; bei Fund Exit 2 mit Datei + SCHLUESSELNAME, niemals
   dem Wert.
2. Commit erkannt, Ziel nicht sicher bestimmbar (cd, GIT_DIR=, unbekanntes
   Hilfsprogramm, sh -c/eval, Subshell, nicht aufloesbares -C) -> BLOCKIEREN,
   Meldung nennt den erlaubten Weg. Kein Defekt des Waechters, sondern ein
   nachweislich unpruefbarer Fall — Durchlassen waere ein stilles Loch.
3. Eigene Stoerung (.env unlesbar, git fehlt) -> durchlassen und sagen.

Ausgang 2 weicht bewusst von pendant_gate.py ab (dort: durchlassen und
sagen). Grund im Datei-Kopf: dort kostet ein verpasster Fall Doppelarbeit,
hier stellt er ein gueltiges Passwort ins oeffentliche Netz.

Der bestehende secret_egress_guard.py (#1380) deckt das nicht ab: er prueft
den Inhalt eines Tool-Aufrufs. Beim Commit steht im Befehl nur "git commit",
der Wert steckt in einer Datei, die ihn seit Monaten enthaelt.

24 Tests, hermetisch (gruen mit UND ohne .env). Adversary VERIFIED nach drei
Runden — Runde 1 und 2 waren BROKEN: erst -C/--git-dir ignoriert, dann drei
weitere Umgehungen (GIT_DIR=, timeout-Wrapper, sh -c), alle mit einer
Meldung, die wie ein harmloser Durchlauf aussah. Daraufhin die Umstellung
auf fail-closed. Alle 5 Pflicht-Mutationen werden gefangen.

Verdrahtung in geschuetzter Form (if [ -f … ]) — greift erst ab der
naechsten Sitzung, laufende Sitzungen brauchen einen Neustart.

Offen (Scheibe 2): F008 Fehlalarm bei unquotiertem Heredoc mit cd-Zeile,
F009 Testluecke bei kaputten Anfuehrungszeichen. Beides MEDIUM, kein Bypass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
