### PR TITLE
fix(#1462): Beispiel-Warnung im Alarme-Reiter nennt den richtigen Ausloeser

### DIFF
--- a/docs/specs/fast/fix-1462-alarme-beispieltext.md
+++ b/docs/specs/fast/fix-1462-alarme-beispieltext.md
@@ -1,0 +1,64 @@
+# Mini-Spec: #1462 — Beispiel-Warnung im Alarme-Reiter nennt den richtigen Auslöser
+
+**Issue:** #1462 (Alerts S4: Steuerung ausschliesslich im Reiter Alarme)
+**Track:** Fast Track · **Erstellt:** 2026-08-06
+**PO-Freigabe Wortlaut:** 2026-08-06 (Auswahl im Intake, Beleg als Issue-Kommentar)
+
+## Ausgangslage (auf Staging `21117b1f` durchgeklickt)
+
+Der im Issue beschriebene Umfang ist bereits erfüllt — belegt durch echten Klickpfad:
+
+| Forderung | Ist-Stand |
+|---|---|
+| Wertebereiche-Reiter steuert nicht mehr | ✅ #1371 S6 (Schalter), #1460 P1a (Auslöser), #1425 S2C (Text) |
+| Abschnitt „Korridor-Auslöser" im Alarme-Reiter | ✅ entfällt (`alarmeTabSections.ts`) |
+| Wertebereiche-Text verweist auf Alarme | ✅ „Warnungen zwischen den Briefings stellst du im Reiter Alarme ein." |
+| Amtliche Warnungen: Inhalt vs. Auslöser getrennt | ✅ #1301 D2 |
+
+**Ein Rest bleibt:** Im Reiter *Alarme* des **Ortsvergleichs** steht über der Beispiel-Karte
+„So sieht eine ausgelöste Warn-Mail aus, wenn ein Wert den Wertebereich verlässt."
+Seit #1460 löst der Wertebereich nichts mehr aus — Auslöser sind Vorhersage-Änderung,
+Nowcast und amtliche Warnung. Der Satz ist damit dasselbe falsche Versprechen, gegen das
+sich #1462 richtet, nur an anderer Stelle.
+
+Betroffen ist ausschließlich der Vergleichs-Zweig: `AlarmeTab.svelte:399` rendert
+`VTAlertSample context="vergleich"`; der Trip-Zweig nutzt `AlertPreviewCard` ohne diesen Satz.
+
+## Was ändert sich
+
+- `frontend/src/lib/components/shared/versand-tab/VTAlertSample.svelte:52`
+  - vorher: „So sieht eine ausgelöste Warn-Mail aus, wenn ein Wert den Wertebereich verlässt."
+  - nachher: „So sieht eine ausgelöste Warn-Mail aus, wenn sich die Vorhersage deutlich ändert."
+- Neuer Wächter, der den alten Wortlaut dauerhaft ausschließt (Muster: `corridorEditorCopy.test.ts`,
+  `# doc-compliance-test`-Klasse — reiner Anzeigetext hat keine ausführbare Logik).
+
+## Was darf sich nicht ändern
+
+- Die Beispiel-Karte selbst (Zeilen, Überschrift „Wetter-Änderung erkannt", Spalten) bleibt unberührt.
+- Der Trip-Zweig (`AlertPreviewCard`) bleibt unberührt.
+- Keine Logik, kein Datenfeld, kein Endpoint. `corridors[].notify` bleibt im Datenmodell.
+
+## Acceptance Criteria
+
+**AC-1:** Given ein Nutzer öffnet im Ortsvergleich den Reiter *Alarme*,
+When er zur Beispiel-Warnung scrollt,
+Then nennt der einleitende Satz die Vorhersage-Änderung als Auslöser und **nicht** den Wertebereich.
+
+**AC-2:** Given jemand setzt den alten Wortlaut („Wertebereich verlässt") später wieder ein,
+When die Frontend-Tests laufen,
+Then schlägt der Wächter fehl und benennt die Stelle.
+
+**AC-3:** Given der Trip-Reiter *Alarme*,
+When er geöffnet wird,
+Then ist seine Beispiel-Darstellung unverändert (kein Text aus `VTAlertSample`).
+
+## Manuelle Test-Schritte
+
+1. Auf Staging anmelden, Orts-Vergleich `Validator-1025 Compare` öffnen, Reiter *Alarme*.
+2. Nach unten zur *Beispiel-Warnung*: der Satz nennt die Vorhersage-Änderung.
+3. Einen Trip öffnen, Reiter *Alarme*: Darstellung unverändert.
+
+## Inline-Test
+
+- [ ] `frontend/src/lib/components/shared/versand-tab/__tests__/vtAlertSampleCopy.test.ts`
+      — alter Wortlaut ausgeschlossen, neuer Wortlaut vorhanden (AC-1, AC-2)

--- a/frontend/src/lib/components/shared/versand-tab/VTAlertSample.svelte
+++ b/frontend/src/lib/components/shared/versand-tab/VTAlertSample.svelte
@@ -48,8 +48,13 @@
 
 <div>
 	<Eyebrow style="margin-bottom: 4px;">Beispiel-Warnung</Eyebrow>
+	<!-- Issue #1462: der Wertebereich loest seit #1460 keinen Alarm mehr aus —
+	     Ausloeser sind Vorhersage-Aenderung, Nowcast und amtliche Warnung. Der
+	     alte Satz war dasselbe falsche Versprechen, das #1425 im Reiter
+	     *Wertebereiche* schon beseitigt hatte. Waechter:
+	     __tests__/vtAlertSampleCopy.test.ts -->
 	<p class="vt-sample-lead">
-		So sieht eine ausgelöste Warn-Mail aus, wenn ein Wert den Wertebereich verlässt.
+		So sieht eine ausgelöste Warn-Mail aus, wenn sich die Vorhersage deutlich ändert.
 	</p>
 	<div class="vt-sample-card" data-testid="versand-alert-sample">
 		<div class="vt-sample-head">

--- a/frontend/src/lib/components/shared/versand-tab/__tests__/vtAlertSampleCopy.test.ts
+++ b/frontend/src/lib/components/shared/versand-tab/__tests__/vtAlertSampleCopy.test.ts
@@ -1,0 +1,89 @@
+// Issue #1462 (Spec: docs/specs/fast/fix-1462-alarme-beispieltext.md).
+//
+// Der Reiter *Alarme* des Ortsvergleichs versprach ueber der Beispiel-Karte eine
+// Wirkung, die es seit #1460 nicht mehr gibt: "wenn ein Wert den Wertebereich
+// verlaesst". Der Wertebereich loest nichts mehr aus — Ausloeser sind
+// Vorhersage-Aenderung, Nowcast und amtliche Warnung. Genau dasselbe falsche
+// Versprechen hatte #1425 schon im Reiter *Wertebereiche* beseitigt; hier stand
+// es nur an anderer Stelle weiter.
+//
+// Reiner Anzeigetext hat keine ausfuehrbare Logik — deshalb ein bewusst
+// markierter doc-compliance-Check (CLAUDE.md, Test-Politik), Muster wie
+// corridor-editor/__tests__/corridorEditorCopy.test.ts. Geprueft wird der
+// Markup-Teil OHNE Kommentare: ein Kommentar, der den alten Wortlaut nur
+// ERWAEHNT (wie dieser Header), darf nicht anschlagen.
+//
+// Ausfuehrung: cd frontend && npm test -- \
+//   src/lib/components/shared/versand-tab/__tests__/vtAlertSampleCopy.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+// Pfadregel #1409: Pruefling relativ zur EIGENEN Testdatei aufloesen (Worktree),
+// nie ueber einen festen Hauptrepo-Pfad.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SAMPLE = resolve(HERE, '..', 'VTAlertSample.svelte');
+const ALARME_TAB = resolve(HERE, '..', '..', 'AlarmeTab.svelte');
+
+/** Der Teil einer .svelte-Datei, den der Nutzer als Text zu sehen bekommt. */
+function visibleCopy(path: string): string {
+	return readFileSync(path, 'utf-8')
+		.replace(/<script[\s\S]*?<\/script>/g, '')
+		.replace(/<style[\s\S]*?<\/style>/g, '')
+		.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+/** Zeilenumbrueche/Einrueckung im Markup sind Layout, kein Text. */
+function flat(s: string): string {
+	return s.replace(/\s+/g, ' ').trim();
+}
+
+const NEUER_TEXT = 'So sieht eine ausgelöste Warn-Mail aus, wenn sich die Vorhersage deutlich ändert.';
+
+// Formulierungen, die den Wertebereich als Ausloeser behaupten.
+const FALSCHE_AUSLOESER = ['Wertebereich verlässt', 'Wertebereich verlaesst', 'Korridor verlässt'];
+
+describe('AC-1/AC-2: die Beispiel-Warnung nennt den tatsaechlichen Ausloeser', () => {
+	test('AC-1: der einleitende Satz nennt die Vorhersage-Aenderung', () => {
+		const copy = flat(visibleCopy(SAMPLE)); // doc-compliance-test
+		assert.ok(
+			copy.includes(flat(NEUER_TEXT)),
+			`AC-1 FAIL: der freigegebene Satz fehlt. Erwartet: "${NEUER_TEXT}"`
+		);
+	});
+
+	test('AC-2: der Wertebereich wird nicht mehr als Ausloeser behauptet', () => {
+		const copy = visibleCopy(SAMPLE); // doc-compliance-test
+		for (const phrase of FALSCHE_AUSLOESER) {
+			assert.equal(
+				copy.includes(phrase),
+				false,
+				`AC-2 FAIL: die Beispiel-Warnung behauptet wieder "${phrase}". Seit #1460 loest der ` +
+					'Wertebereich keinen Alarm mehr aus — Ausloeser sind Vorhersage-Aenderung, Nowcast ' +
+					'und amtliche Warnung. Der Wertebereich markiert nur noch (#1371 S6, #1425).'
+			);
+		}
+	});
+});
+
+describe('AC-3: der Trip-Zweig bleibt unberuehrt', () => {
+	test('VTAlertSample wird im Alarme-Reiter nur im Vergleichs-Zweig gerendert', () => {
+		const src = readFileSync(ALARME_TAB, 'utf-8');
+		const mounts = src.match(/<VTAlertSample[^>]*>/g) ?? [];
+		assert.equal(
+			mounts.length,
+			1,
+			`AC-3 FAIL: erwartet genau eine <VTAlertSample>-Einbettung im Alarme-Reiter, gefunden ` +
+				`${mounts.length}. Kaeme eine zweite ohne context="vergleich" dazu, traefe der Satz ` +
+				'auch den Trip-Zweig, der stattdessen AlertPreviewCard zeigt.'
+		);
+		assert.match(
+			mounts[0],
+			/context="vergleich"/,
+			'AC-3 FAIL: die Einbettung laeuft nicht mehr ausschliesslich im Vergleichs-Kontext.'
+		);
+	});
+});


### PR DESCRIPTION
Der Reiter *Alarme* des Ortsvergleichs versprach ueber der Beispiel-Karte
"wenn ein Wert den Wertebereich verlaesst". Seit #1460 loest der Wertebereich
nichts mehr aus — Ausloeser sind Vorhersage-Aenderung, Nowcast und amtliche
Warnung. Es war dasselbe falsche Versprechen, das #1425 im Reiter
*Wertebereiche* schon beseitigt hatte, nur an anderer Stelle.

Der uebrige Umfang von #1462 war bereits erfuellt (#1371 S6, #1425 S2C,
#1460 P1a, #1301 D2) — auf Staging durchgeklickt und im Issue belegt
(#issuecomment-5203132963).

Waechter vtAlertSampleCopy.test.ts: 3 Mutationen gesetzt, alle gefangen
(alter Wortlaut zurueck, dritter Wortlaut ohne Ausloeser, context="vergleich"
an der Einbettung entfernt).

Betrifft nur den Vergleichs-Zweig; der Trip nutzt dort AlertPreviewCard.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
