### PR TITLE
fix(#1310): Akut-Override sagt "jetzt akut" statt nur "bereits angekuendigt"

### DIFF
--- a/docs/specs/fast/fix-1310-akut-wording.md
+++ b/docs/specs/fast/fix-1310-akut-wording.md
@@ -1,0 +1,69 @@
+# Mini-Spec: #1310 — Akut-Override sagt „jetzt akut"
+
+**Issue:** #1310 (Akut-Override, Rest aus #883 Slice 4)
+**Track:** Fast Track · **Erstellt:** 2026-08-07
+**PO-Freigabe Wortlaut:** 2026-08-07 (Beleg als Issue-Kommentar)
+
+## Ausgangslage (gemessen 2026-08-07, Stand `de3127b0`)
+
+Der Sicherheits-Override selbst **ist gebaut** (`trip_alert.py:788-794`): konvektive Gefahr
+durchbricht die Briefing-Unterdrückung. `tests/tdd/test_issue_883_acute_danger_override.py`
+läuft 5 grün / 1 xfail — offen ist **allein AC-4**, das Wording.
+
+Die Alarm-Mail führt seit #952 eine eigene Datenzeile „Briefing"
+(`renderers/alert/render.py:235-236`). Sie kennt heute zwei Zustände
+(`trip_alert.py:834`):
+
+```
+_briefing_context = "bereits angekündigt" if _briefing_announced else "nicht angekündigt"
+```
+
+Im Override-Fall — angekündigter Regen, der laut Radar konvektiv wird — steht dort
+„bereits angekündigt". Das ist wahr, verschweigt aber die Zuspitzung, wegen der der Alarm
+überhaupt gesendet wurde.
+
+Der **Ortsvergleich ist nicht betroffen**: `compare_radar_alert.py` vergleicht nicht gegen
+ein Briefing, `radar_alert_service.py:67` setzt `briefing_context=None`. Es gibt dort keinen
+Override-Fall — also keine Teilungs-Lücke (Trip/Compare-Invariante geprüft).
+
+## Was ändert sich
+
+- `src/services/trip_alert.py:834` — dritter Zustand, wenn angekündigt **und** konvektiv:
+  `"bereits angekündigt — jetzt akut"`
+- `tests/tdd/test_issue_883_acute_danger_override.py:319` — `xfail`-Marker entfällt (AC-4 wird scharf)
+- `docs/specs/_archive/modules/issue_883_acute_danger_override.md` → zurück nach
+  `docs/specs/modules/`, Status auf `implemented`
+
+## Was darf sich nicht ändern
+
+- Die beiden bestehenden Zustände „bereits angekündigt" (angekündigt, nicht konvektiv —
+  dieser Fall sendet ohnehin keinen Alarm) und „nicht angekündigt".
+- Die Override-Logik selbst, der Doppel-Alarm-Schutz, Cooldown, Ruhezeiten, Kanal-Schwelle.
+- Der Ortsvergleichs-Pfad (`briefing_context` bleibt dort `None`).
+- Kein Renderer wird angefasst — die Zeile wird bereits generisch gerendert.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Briefing hat Regen für die Onset-Stunde angekündigt und der Radar meldet
+  konvektive Gefahr / When der Radar-Alarm gebaut wird / Then enthält die Nachricht „jetzt akut"
+  und **nicht** „nicht angekündigt".
+
+- **AC-2:** Given der Radar meldet konvektiven Regen, den das Briefing **nicht** angekündigt hat
+  / When der Alarm gebaut wird / Then steht dort unverändert „nicht angekündigt" und **kein**
+  „jetzt akut".
+
+- **AC-3:** Given jemand entfernt die Fallunterscheidung später wieder
+  / When `tests/tdd/test_issue_883_acute_danger_override.py` läuft
+  / Then schlägt AC-4 fehl (kein `xfail` mehr, der das verdeckt).
+
+## Manuelle Test-Schritte
+
+1. Auf Staging den ausgelieferten Code mit gesteuerten Radar-Frames ausführen
+   (konvektiv + Briefing-Regen) — die abgefangene Mail enthält „bereits angekündigt — jetzt akut".
+2. Gegenprobe ohne Briefing-Regen: „nicht angekündigt", kein „jetzt akut".
+
+## Inline-Test
+
+- [x] `tests/tdd/test_issue_883_acute_danger_override.py::test_ac4_override_mail_wording_not_unannounced`
+      (bestehender Test, `xfail` fällt)
+- [ ] Gegenprobe für AC-2 (nicht angekündigt → kein „jetzt akut")

--- a/docs/specs/modules/issue_883_acute_danger_override.md
+++ b/docs/specs/modules/issue_883_acute_danger_override.md
@@ -2,9 +2,9 @@
 entity_id: issue_883_acute_danger_override
 type: feature
 created: 2026-06-25
-updated: 2026-06-25
-status: draft
-version: "1.0"
+updated: 2026-08-07
+status: implemented
+version: "1.1"
 tags: [alert, radar, nowcast, convective, safety-override, briefing-suppression, epic-813, slice-4]
 ---
 
@@ -12,7 +12,7 @@ tags: [alert, radar, nowcast, convective, safety-override, briefing-suppression,
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved (PO 2026-07-22 Umsetzung, 2026-08-07 Wortlaut)
 
 ## Purpose
 
@@ -66,22 +66,30 @@ if _briefing_announced and not result.is_convective:
 - Greift erst **nach** `radar_alert_due(...)` (Onset ≤20 Min) und **nach** dem QuietHours- und Throttle-Check — diese bleiben also wirksam.
 - Der Doppel-Alert-Guard (≈691-709) bleibt **unverändert** aktiv: hat ein Forecast-Alert für dasselbe Segment innerhalb des Cooldowns gefeuert, wird auch der Override unterdrückt (max. eine Meldung).
 
-### Mail-Wording fallabhängig (≈ trip_alert.py:734-735)
+### Mail-Wording fallabhängig
 
-Heute fix:
-```
-onset_text += ", im Briefing nicht angekündigt"
-```
+**Umgesetzt 2026-08-07 unter #1310 — an anderer Stelle als hier ursprünglich geplant.**
+Der Entwurf hängte den Hinweis an `onset_text` an. Seit **#952** trägt die Alarm-Mail dafür
+eine eigene Datenzeile „Briefing" (`renderers/alert/render.py:235-236`), gespeist aus
+`RadarAlertRequest.briefing_context`. Der Hinweis sitzt deshalb dort — der Renderer bleibt
+unverändert, wie im Entwurf beabsichtigt.
 
-Neu:
-```
-if _briefing_announced:
-    onset_text += ", jetzt akut"          # Override: Regen WAR angekündigt, ist jetzt Gewitter
+Ist-Stand (`trip_alert.py`, Zustand der Zeile „Briefing"):
+
+```python
+if _briefing_announced and result.is_convective:
+    _briefing_context = "bereits angekündigt — jetzt akut"   # Override
+elif _briefing_announced:
+    _briefing_context = "bereits angekündigt"
 else:
-    onset_text += ", im Briefing nicht angekündigt"
+    _briefing_context = "nicht angekündigt"
 ```
 
-Begründung: Im Override-Fall wäre "im Briefing nicht angekündigt" eine Falschaussage. `src/outputs/radar_alert.py` (Body-/Subject-Builder) bleibt unverändert — nur der eingespeiste `onset_text` ändert sich.
+Wortlaut PO-freigegeben 2026-08-07 (#1310). Begründung unverändert: Im Override-Fall wäre
+„nicht angekündigt" eine Falschaussage — der Regen **war** angekündigt, neu ist die
+Zuspitzung. Bewacht durch `test_ac4_override_mail_wording_not_unannounced` **und** die
+Gegenprobe `test_ac4b_unannounced_convective_keeps_plain_wording`; letztere verhindert, dass
+ein bedingungsloses „jetzt akut" den Hinweis entwertet.
 
 ### Unverändert (Invarianten)
 

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -831,7 +831,19 @@ class TripAlertService:
             # Issue #952 (reopened): kurzes Intensitäts-Label (kein format_now_text-Satz
             # mehr — der Renderer haengt selbst "ab {onset_time}" an). Briefing-Kontext
             # wandert in ein eigenes Feld (4. Datenblock-Zeile, nur E-Mail).
-            _briefing_context = "bereits angekündigt" if _briefing_announced else "nicht angekündigt"
+            # Issue #1310 (AC-4 aus #883 Slice 4): der Override-Fall braucht einen
+            # eigenen dritten Zustand. "bereits angekündigt" allein ist zwar wahr,
+            # verschweigt aber die Zuspitzung, wegen der überhaupt gesendet wurde --
+            # angekündigter Regen, der laut Radar konvektiv (Gewitter/Hagel) wird.
+            # Ohne Konvektion kommt der Zweig hier gar nicht an (oben `continue`);
+            # die Fallunterscheidung bleibt trotzdem explizit, damit die Aussage
+            # auch dann richtig ist, wenn die Unterdrückung oben je gelockert wird.
+            if _briefing_announced and result.is_convective:
+                _briefing_context = "bereits angekündigt — jetzt akut"
+            elif _briefing_announced:
+                _briefing_context = "bereits angekündigt"
+            else:
+                _briefing_context = "nicht angekündigt"
             # F002: Anzeige-Kontext mitten im Satz ("leichter Regen") -- erstes
             # Zeichen kleinschreiben; intensity_to_text() selbst bleibt Title-Case
             # (andere Caller nutzen es am Satzanfang). Alle Labels beginnen mit

--- a/tests/tdd/test_issue_883_acute_danger_override.py
+++ b/tests/tdd/test_issue_883_acute_danger_override.py
@@ -316,7 +316,6 @@ def test_ac3_override_respects_cooldown():
 # AC-4: Override-Mail-Wording — nicht "im Briefing nicht angekündigt"
 # --------------------------------------------------------------------------
 
-@pytest.mark.xfail(reason="#1310: Akut-Override ('jetzt akut'-Hinweis) nie implementiert (nie implementierte Alt-Spec)", strict=False)
 def test_ac4_override_mail_wording_not_unannounced():
     """AC-4: Im Override-Fall darf der Body NICHT "im Briefing nicht angekündigt"
     enthalten (das wäre falsch — der Regen WAR angekündigt) sondern den Akut-Hinweis.
@@ -346,6 +345,46 @@ def test_ac4_override_mail_wording_not_unannounced():
         )
         assert "jetzt akut" in body, (
             f"AC-4: Override-Body muss den Akut-Hinweis 'jetzt akut' enthalten.\nBody:\n{body}"
+        )
+    finally:
+        _clean_user(uid)
+
+
+def test_ac4b_unannounced_convective_keeps_plain_wording():
+    """GEGENPROBE zu AC-4 (Issue #1310): konvektiv, aber das Briefing hat NICHTS
+    angekündigt → die Briefing-Zeile bleibt "nicht angekündigt" und bekommt KEIN
+    "jetzt akut".
+
+    Ohne diesen Test wäre AC-4 auch mit einem bedingungslosen "jetzt akut" grün —
+    dann stünde der Akut-Hinweis auf JEDER Radar-Mail und sagte nichts mehr aus.
+    Der Unterschied zum AC-4-Fall ist allein der fehlende Briefing-Regen im
+    Schnappschuss.
+    """
+    uid = f"tdd-883-ac4b-{uuid.uuid4().hex[:6]}"
+    _clean_user(uid)
+    _ensure_real_user_dir(uid)
+    try:
+        trip_id = f"tdd-883-ac4b-{uuid.uuid4().hex[:6]}"
+        _save_trip_direct(_make_active_trip(trip_id), uid)
+        # Briefing kündigt NICHTS an (0.0 mm < 0.5 mm Schwelle).
+        _write_snapshot(uid, trip_id, segment_id=1, hourly_precip={_onset_hour(): 0.0})
+
+        captured: list = []
+        _new_service(uid, _convective_frames, captured).check_radar_alerts()
+
+        assert len(captured) >= 1, (
+            "Gegenprobe: unangekündigter konvektiver Regen muss erst recht einen "
+            "Alert erzeugen."
+        )
+        body = captured[0][1]
+        assert "nicht angekündigt" in body, (
+            f"Gegenprobe: ohne Briefing-Ankündigung muss die Briefing-Zeile "
+            f"'nicht angekündigt' lauten.\nBody:\n{body}"
+        )
+        assert "jetzt akut" not in body, (
+            f"Gegenprobe: 'jetzt akut' beschreibt die Zuspitzung einer BEREITS "
+            f"angekündigten Lage. Hier war nichts angekündigt — der Hinweis waere "
+            f"sinnlos und entwertete ihn in den Faellen, wo er zaehlt.\nBody:\n{body}"
         )
     finally:
         _clean_user(uid)


### PR DESCRIPTION
Der Sicherheits-Override aus #883 Slice 4 ist seit Juni gebaut: konvektive
Gefahr (Gewitter/Hagel) durchbricht die Briefing-Unterdrueckung. Nur die
Meldung sagte das nicht -- in der Zeile "Briefing" stand "bereits
angekuendigt", was zwar stimmt, aber genau die Zuspitzung verschweigt,
wegen der ueberhaupt gesendet wurde.

Dritter Zustand ergaenzt (Wortlaut PO-freigegeben 2026-08-07):
  angekuendigt + konvektiv -> "bereits angekuendigt — jetzt akut"
  angekuendigt             -> "bereits angekuendigt"
  sonst                    -> "nicht angekuendigt"

Der xfail an AC-4 faellt damit. Neu dazu die Gegenprobe
test_ac4b_unannounced_convective_keeps_plain_wording: ohne sie waere AC-4
auch mit einem BEDINGUNGSLOSEN "jetzt akut" gruen -- dann stuende der
Hinweis auf jeder Radar-Mail und sagte nichts mehr aus. Genau diese
Mutation faengt sie (3 Mutationen gesetzt, alle drei rot).

Spec zieht aus dem Archiv zurueck nach docs/specs/modules/ und beschreibt
jetzt den Ist-Ort: seit #952 ist der Briefing-Kontext eine eigene
Datenzeile, nicht mehr ein Anhang an onset_text.

Ortsvergleich nicht betroffen -- compare_radar_alert.py vergleicht nicht
gegen ein Briefing (briefing_context bleibt dort None).

Regression: 23 betroffene Testdateien, 21 gruen; die 2 roten sind
vorbestehend (A/B gegen den unveraenderten Stand gemessen) und stehen als
offline-rot auf .github/ci_tdd_excludes.txt.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
