### PR TITLE
fix(#1552): Trip-Neuanlage uebernimmt die Wetter-Auswahl statt sie zu verwerfen

### DIFF
--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -72,6 +72,9 @@ def get_metrics():
             "unit": m.display_unit if m.display_unit else m.unit,
             "category": m.category,
             "default_enabled": m.default_enabled,
+            # Issue #1552: eigene Trip-Anlege-Vorbelegung, unabhaengig von
+            # default_enabled (das Orte/Abonnements weiter versorgt).
+            "trip_default_enabled": m.trip_default_rank is not None,
             "has_friendly_format": m.has_friendly_format,
             # Issue #435: Format-Modi pro Metrik (raw/scale/simplified/symbol)
             "format_modes": list(m.format_modes),

--- a/docs/specs/modules/fix_1552_neuanlage_metrikauswahl.md
+++ b/docs/specs/modules/fix_1552_neuanlage_metrikauswahl.md
@@ -1,0 +1,380 @@
+---
+entity_id: fix_1552_neuanlage_metrikauswahl
+type: bugfix
+created: 2026-08-06
+updated: 2026-08-06
+status: draft
+version: "1.0"
+tags: [trip, trip-new, weather-metrics, register, bugfix]
+---
+
+<!-- Issue #1552 — Trip-Neuanlage verwirft die Wetter-Metrik-Auswahl still -->
+
+# Trip-Neuanlage verwirft die Wetter-Metrik-Auswahl still
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Beim Anlegen eines neuen Trips zeigt der Reiter „Wetter-Metriken" eine
+Auswahl von ankreuzbaren Wettergrößen, die der Nutzer bestätigen oder
+ändern kann. Diese Auswahl geht beim Speichern vollständig verloren — der
+neue Trip landet immer mit einer leeren Wettergrößen-Liste in der
+Datenbank, unabhängig davon, was im Dialog sichtbar angehakt war. Ein Trip
+mit leerer Liste bekommt strukturell keine Wetter-Alarme. Zusätzlich zeigt
+der Anlege-Dialog heute eine andere Vorbelegung (11 vorbelegte Größen) als
+die, die tatsächlich in Briefings landet, wenn nie gespeichert wurde (7
+Größen) — diese Spec richtet die Anzeige am wirksamen Siebener-Satz aus
+(PO-Entscheidung 2026-08-06) und schließt den Speicherverlust.
+
+## Source
+
+- **File:** `frontend/src/lib/components/shared/WeatherMetricsTab.svelte`
+  — fehlender Rückkanal aus dem Anlege-Modus (`createMode`); Vorbelegungs-
+  Fallback bei Zeile 337
+- **File:** `frontend/src/lib/components/trip-new/TripNewEditor.svelte`
+  — hält `weatherMetrics = $state([])` ohne je beschrieben zu werden
+  (Zeile 60), mountet `WeatherMetricsTab` zweimal (Desktop/Mobile, Zeile
+  780/1005)
+- **File:** `src/app/metric_catalog.py` — `MetricDefinition`-Register,
+  `default_enabled`-Feld (Zeile 40), `build_default_display_config()`
+  (Zeile 671)
+- **File:** `src/output/renderers/trip_metric_ids.py` — hartkodierte
+  `DEFAULT_TRIP_METRIC_IDS`
+- **File:** `api/routers/config.py` — `GET /api/metrics` (Zeile 58)
+- **File:** `frontend/src/lib/types.ts` — `MetricEntry`-Interface (Zeile
+  159), Single Source of Truth für die Katalog-Antwort im Frontend
+
+> **Schicht-Hinweis:** betrifft Frontend (`frontend/src/lib/components/...`)
+> UND Python-Core (`src/app/`, `src/output/renderers/`, `api/routers/`).
+> Kein Go-Anteil — `internal/handler/trip.go` wurde geprüft und braucht
+> keine Änderung (s. Implementation Details).
+
+## Estimated Scope
+
+- **LoC:** ~45–60 Quelle, ~90–140 Tests (deutlich unter dem 250-LoC-Limit)
+- **Files:** 6 geänderte Quelldateien, 2–3 Testdateien (1 bestehend
+  erweitert, 1–2 neu)
+- **Effort:** low-medium
+
+### Affected Files
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `src/app/metric_catalog.py` | MODIFY | Neues Feld `trip_default_rank: Optional[int] = None` auf `MetricDefinition`; explizit gesetzt auf den 7 Ziel-IDs (Rang 1–7) |
+| `src/output/renderers/trip_metric_ids.py` | MODIFY | `DEFAULT_TRIP_METRIC_IDS` wird aus dem Register abgeleitet (sortiert nach `trip_default_rank`) statt als Literal geführt |
+| `api/routers/config.py` | MODIFY | `GET /api/metrics` liefert zusätzliches Feld `trip_default_enabled` (= `trip_default_rank is not None`) je Wettergröße |
+| `frontend/src/lib/types.ts` | MODIFY | `MetricEntry` bekommt `trip_default_enabled: boolean` |
+| `frontend/src/lib/components/shared/WeatherMetricsTab.svelte` | MODIFY | Neuer Prop `onWeatherMetricsChange`, neuer `$effect` (Muster `onChannelsChange`, Zeile 509-514); Vorbelegungs-Fallback (Zeile 337) liest `trip_default_enabled` statt `default_enabled` |
+| `frontend/src/lib/components/trip-new/TripNewEditor.svelte` | MODIFY | Neuer Handler `handleWeatherMetricsChange`, Prop an beiden `WeatherMetricsTab`-Mounts (Zeile 780, 1005) |
+| `tests/unit/test_trip_metric_ids.py` | MODIFY | Bestehender Order-Test (Zeile 32-35) bleibt Regressionsschutz; neuer Test: Ableitung aus dem Register liefert dieselbe Menge/Reihenfolge |
+| `tests/unit/test_metric_catalog_trip_defaults.py` (NEU) | CREATE | Register-Ebene: genau 7 IDs mit `trip_default_rank` gesetzt, korrekte Reihenfolge, alle 7 `selectable=True` |
+| `frontend/.../trip-new/__tests__/*.test.ts` (erweitert oder neu) | MODIFY/CREATE | Verhaltensnachweis: eine im Anlege-Dialog sichtbar geänderte Auswahl landet im Speicher-Payload |
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `resolve_trip_active_metrics()` / `DEFAULT_TRIP_METRIC_IDS` (`trip_metric_ids.py`, #1394) | intern (MODIFY) | Bestehender Fall-A/Fall-B-Mechanismus des Trip-Versands — bleibt inhaltlich unverändert, nur die Herkunft der Sieben-ID-Liste wechselt von Literal zu Register-Ableitung |
+| `onChannelsChange`-Muster (`WeatherMetricsTab.svelte`/`TripNewEditor.svelte`, #622) | intern (Vorbild) | Bereits funktionierender Rückkanal für Kanal-Änderungen im Anlege-Modus — der neue Metrik-Rückkanal ist strukturell identisch |
+| `get_all_metrics()` (`metric_catalog.py`) | intern (bestehend) | Filtert bereits auf `selectable=True` — Grundlage für die Ableitung von `DEFAULT_TRIP_METRIC_IDS` |
+| `buildWeatherConfigMetrics()` (`metricsEditor.ts`, bestehend) | intern (unverändert) | Baut aus `buckets`/`friendlyMap` eine vollständige Metrik-Liste mit `enabled`-Flag je Katalog-Eintrag — liefert bei vollständiger Abwahl korrekt Fall B (Einträge mit `enabled=false`), nicht `[]` |
+| `.claude/hooks/pendant_gate.py` (#1481 B) | Gate | Keine neu angelegte Compare-/Trip-Pendant-Datei in dieser Scheibe — nur Bestandsdateien geändert |
+| `.claude/hooks/touched_tests_gate.py` (#1481 A) | Gate | Prüft `tests/unit/` der geänderten Dateien vor Commit |
+
+## Implementation Details
+
+### A) Fehlender Rückkanal (Kernfix)
+
+`WeatherMetricsTab.svelte` bekommt einen neuen optionalen Prop
+`onWeatherMetricsChange?: (metrics: WeatherConfigMetric[]) => void` und
+einen `$effect`, der — analog zum bestehenden Kanal-Rückkanal (Zeile
+509-514) — im Anlege-Modus bei jeder Änderung von `buckets`/`friendlyMap`/
+`horizonsMap`/`aggregationsMap` den aktuellen Payload
+(`buildWeatherPayload().metrics`) nach oben emittiert:
+
+```
+$effect(() => {
+    if (createMode && onWeatherMetricsChange) {
+        onWeatherMetricsChange(buildWeatherPayload().metrics);
+    }
+});
+```
+
+`TripNewEditor.svelte` bekommt einen Handler `handleWeatherMetricsChange`
+(Muster `handleChannelsChange`, Zeile 295-297), der `weatherMetrics`
+überschreibt, und übergibt ihn an beiden Mount-Stellen (Desktop Zeile 780,
+Mobile Zeile 1005) als neuen Prop. `weatherMetrics` fließt danach
+unverändert über `tripNewLogic.ts:buildCreateTripPayload()` (Zeile
+142-145) in den POST-Body — dieser Teil ist bereits korrekt verdrahtet und
+bleibt unangetastet.
+
+Kein Endlosschleifen-Risiko: `initFromTrip()` — die Funktion, die
+`buckets` aus `trip.display_config.metrics` aufbaut — läuft im
+Anlege-Modus nur einmal beim ersten Laden des Katalogs (`load()`, guarded
+durch `Object.keys(catalog).length === 0`, Zeile 438). Der neue Rückschreib-
+Effekt ändert nur `weatherMetrics` in `TripNewEditor`, was den
+`stubTrip`-Snapshot aktualisiert, aber `initFromTrip()` nicht erneut
+auslöst.
+
+### B) Register-Angleichung — geprüft, NICHT wie im Briefing vorgeschlagen umgesetzt
+
+**Gemessene Abweichung vom vorgeschlagenen Weg** (Umsetzungsrichtung im
+Auftrag: `default_enabled` global auf den Siebener-Satz umstellen):
+`default_enabled` speist nicht nur die Anzeige im Trip-Anlege-Dialog,
+sondern auch `build_default_display_config()` (`metric_catalog.py:671`).
+Diese Funktion ist der Fallback für **jeden** Fall, in dem `display_config`
+komplett `None` ist (nicht nur „Metrik-Liste leer") — Laufzeitpfad
+u.a. `report_config_resolver.py:130`, `trip_report.py:121,402` — sowie
+die Vorbelegung für neue Orte/Alarm-Abonnements
+(`WeatherConfigDialog.svelte:51`, Route `/locations`) und wird direkt oder
+indirekt von über 100 Test-Aufrufstellen (golden/characterization Tests
+unter `tests/golden/`, `tests/integration/`, `tests/tdd/`) als Fixture
+genutzt. Eine globale `default_enabled`-Änderung auf den Siebener-Satz
+würde die Wettergrößen-Vorbelegung für Orte/Abonnements mitverändern (vom
+PO nicht verlangt) und liefe Gefahr, einen zweistelligen Teil dieser Tests
+rot zu ziehen — beides weit außerhalb des Umfangs dieser Scheibe.
+
+**Gewählte Lösung:** ein neues, zusätzliches Feld
+`trip_default_rank: Optional[int] = None` auf `MetricDefinition`, explizit
+gesetzt auf genau den 7 Ziel-Größen (`temperature=1, wind=2, gust=3,
+precipitation=4, thunder=5, freezing_level=6, visibility=7` — dieselbe
+Reihenfolge wie die bisherige `DEFAULT_TRIP_METRIC_IDS`-Liste, s.
+Reihenfolge-Erhalt unten). `default_enabled` bleibt für alle Größen exakt
+wie heute — keine Änderung an `build_default_display_config()`, an
+`WeatherConfigDialog.svelte` oder an einem der ~100 Testaufrufe.
+`trip_default_rank` ist eine reine Zusatz-Markierung „gehört zum
+Trip-Anlege-Standard", unabhängig von `default_enabled`.
+
+`DEFAULT_TRIP_METRIC_IDS` in `trip_metric_ids.py` wird aus dem Register
+abgeleitet:
+
+```
+DEFAULT_TRIP_METRIC_IDS: tuple[str, ...] = tuple(
+    m.id for m in sorted(
+        (m for m in get_all_metrics() if m.trip_default_rank is not None),
+        key=lambda m: m.trip_default_rank,
+    )
+)
+```
+
+`GET /api/metrics` (`config.py:58`) liefert zusätzlich
+`"trip_default_enabled": m.trip_default_rank is not None` je Größe (kein
+Rang-Wert im Frontend nötig — die Reihenfolge des Fall-A-Rückfalls ist
+reine Backend-Logik). `MetricEntry` (`types.ts:159`) bekommt das
+gleichnamige Feld. `WeatherMetricsTab.svelte:337` liest
+`metricById[id]?.trip_default_enabled` statt `default_enabled`.
+
+Damit bleibt **eine Quelle** für „was ist Trip-Anlege-Standard" (das
+Register, `trip_default_rank`) — sowohl der Server-Rückfall
+(`DEFAULT_TRIP_METRIC_IDS`) als auch die Frontend-Vorbelegung lesen
+denselben Marker, keine zweite Liste, keine Frontend-Konstante
+(Struktur-Test `tripActiveMetricNames_noHardcodedVocabulary_structure.test.ts`
+bleibt unverletzt).
+
+### C) Reihenfolge-Erhalt (Regressionsschutz)
+
+`tests/unit/test_trip_metric_ids.py:32-35` zementiert die exakte
+Reihenfolge `["temperature", "wind", "gust", "precipitation", "thunder",
+"freezing_level", "visibility"]`. Eine Ableitung nach Katalog-
+Deklarationsreihenfolge (statt nach explizitem Rang) würde `visibility`
+vor `freezing_level` einsortieren (Deklarationsreihenfolge im Register) und
+diesen Test sowie die tatsächliche Spaltenreihenfolge im Briefing für
+Bestandstrips ohne gespeicherte Auswahl unbeabsichtigt ändern. Der
+explizite `trip_default_rank` verhindert das unabhängig von einer
+künftigen Umsortierung der `MetricDefinition`-Deklarationen.
+
+### Gemessen, betrifft diese Scheibe NICHT: Go-Handler
+
+`internal/handler/trip.go:131-191` (`CreateTripHandler`) setzt für
+`display_config.metrics` keine eigenen Defaults und normalisiert das Feld
+nicht — das ist unverändert korrekt: der vollständige, bereits validierte
+Payload aus dem Frontend (nach Fix A) wird 1:1 persistiert, wie bei jedem
+anderen `display_config`-Feld auch.
+
+## Expected Behavior
+
+- **Input:** Anlege-Dialog `/trips/new`, Reiter „Wetter-Metriken" — Nutzer
+  bestätigt die Vorbelegung, ändert sie, oder wählt alle Größen bewusst ab.
+- **Output:** Der beim Speichern gesendete Trip enthält exakt die zuletzt
+  im Dialog sichtbar angehakten Wettergrößen (bzw. bei bewusster
+  Komplett-Abwahl eine vollständige Liste mit `enabled=false` je Größe,
+  nicht `[]`). Die Vorbelegung im Dialog zeigt genau die 7 Größen, die auch
+  ein Trip ohne je gespeicherte Auswahl tatsächlich versendet.
+- **Side effects:** Bestandstrips ohne gespeicherte Auswahl ändern beim
+  Öffnen im Editor ihre angezeigte Vorbelegung (von der bisherigen
+  10er-Anzeige auf die 7 tatsächlich versendeten Größen) — ihr Versand
+  bleibt dabei unverändert, weil er schon vorher auf denselben 7 Größen
+  beruhte. Orte- und Abonnement-Konfiguration bleiben vollständig
+  unberührt.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Nutzer legt einen neuen Trip an und öffnet den Reiter
+  „Wetter-Metriken", ohne die vorgeschlagene Auswahl zu verändern / When er
+  den Trip speichert / Then enthält der gespeicherte Trip genau die 7
+  vorgeschlagenen Wettergrößen (Temperatur, Wind, Böen, Niederschlag,
+  Gewitter, Nullgradgrenze, Sichtweite) als aktiviert, und sein erstes
+  Briefing zeigt exakt diese 7 Größen.
+  - Test: Anlege-Dialog durchlaufen ohne die Wetter-Auswahl anzufassen,
+    speichern, gespeicherten Trip-Datensatz UND ein daraus gerendertes
+    Briefing prüfen — kein Dateiinhalt-Check.
+
+- **AC-2:** Given ein Nutzer hakt beim Anlegen zusätzliche Wettergrößen an
+  oder bestehende ab, bevor er speichert / When der Trip gespeichert wird /
+  Then enthält der gespeicherte Trip genau die beim Speichern sichtbar
+  angehakten Größen — nicht die ursprüngliche Vorbelegung und nicht eine
+  leere Liste.
+  - Test: im Anlege-Dialog mindestens eine Größe zusätzlich anhaken und
+    eine vorbelegte abwählen, speichern, gespeicherten Trip-Datensatz
+    prüfen.
+
+- **AC-3:** Given ein Nutzer hakt beim Anlegen alle Wettergrößen bewusst ab
+  / When der Trip gespeichert wird / Then wird diese bewusste Leerauswahl
+  übernommen — das erste Briefing zeigt keinen
+  Wettergrößen-Überblicksblock, nicht die 7 Standardgrößen.
+  - Test: im Anlege-Dialog alle Größen abwählen, speichern, ein daraus
+    gerendertes Briefing prüft das Fehlen des Überblicksblocks.
+
+- **AC-4:** Given ein Trip, der vor diesem Fix ohne gespeicherte
+  Wettergrößen-Auswahl angelegt wurde / When sein Briefing erzeugt wird /
+  Then zeigt es weiterhin genau dieselben 7 Standardgrößen wie vor dieser
+  Änderung — der tatsächliche Versand ändert sich für solche Bestandstrips
+  nicht.
+  - Test: bestehenden Trip-Datensatz mit fehlender/leerer Metrik-Liste
+    rendern, Ergebnis vor und nach dem Fix vergleichen.
+
+- **AC-5:** Given derselbe Bestandstrip wie AC-4 / When ihn ein Nutzer im
+  Editor öffnet / Then zeigt der Reiter „Wetter-Metriken" jetzt genau die 7
+  tatsächlich versendeten Größen als angehakt — nicht mehr die bisher
+  zusätzlich angezeigten, aber nie versendeten Größen.
+  - Test: Editor mit einem Bestandstrip ohne gespeicherte Auswahl öffnen,
+    angezeigte angehakte Größen prüfen.
+
+- **AC-6:** Given ein Trip, bei dem ein Nutzer zuvor bewusst alle
+  Wettergrößen abgewählt und gespeichert hat / When er im Editor geöffnet
+  wird / Then zeigt der Reiter weiterhin „alles aus" — die Vorbelegung mit
+  den 7 Standardgrößen darf diese bereits gespeicherte, bewusste
+  Entscheidung nicht überschreiben.
+  - Test: Editor mit einem Trip öffnen, dessen gespeicherte Metrik-Liste
+    Einträge mit durchgehend `enabled=false` enthält; angezeigte Auswahl
+    muss leer bleiben.
+
+- **AC-7:** Given die Wetter-Einstellungen für einen Ort oder ein
+  Alarm-Abonnement / When ein Nutzer dort eine neue Konfiguration anlegt /
+  Then bleibt die dort vorgeschlagene Wettergrößen-Auswahl exakt wie vor
+  diesem Fix — sie ist nicht Teil dieser Änderung.
+  - Test: Orte-/Abonnement-Konfigurationsdialog vor und nach dem Fix
+    vergleichen, keine Abweichung in der vorgeschlagenen Auswahl.
+
+- **AC-8:** Given der Server / When das Frontend die Liste der
+  Wettergrößen abruft / Then bezieht das Frontend die Information „gehört
+  zur Trip-Vorbelegung" ausschließlich aus dieser Serverantwort — ohne eine
+  eigene, fest im Frontend-Code stehende Liste von Wettergrößen-Namen.
+  - Test: bestehender Struktur-Test
+    `tripActiveMetricNames_noHardcodedVocabulary_structure.test.ts` bleibt
+    grün.
+
+## Nicht in dieser Scheibe
+
+- **`default_enabled` global umstellen** — geprüft und bewusst verworfen
+  (s. Implementation Details B): zu großer Blast Radius (Orte/Abonnements,
+  `build_default_display_config()`, >100 Testaufrufstellen). Eine
+  eigenständige Änderung, falls der PO die Orte/Abo-Vorbelegung später
+  ebenfalls auf den Siebener-Satz ausrichten will.
+- **Ortsvergleich-Anlage (`/compare/new`, `CompareNewEditor.svelte`)** —
+  gemessen: `WeatherMetricsTab` läuft dort ohne `createMode` und
+  persistiert die Vergleichs-Metrik-Auswahl über einen eigenen
+  `wiz.activeMetricKeys`-Mechanismus (CompareTabs Hub-Hydrate/-Flush,
+  `toggleCompareMetric`), nicht über den hier reparierten Rückkanal — die
+  exakte Fehlerklasse aus #1552 tritt dort strukturell nicht in derselben
+  Form auf. Unklar geblieben (nicht abschließend gemessen): ob die
+  ebenfalls im Vergleichs-Anlege-Kontext sichtbare „02 — Grundauswahl"-
+  Karte (dieselbe Komponente, Toggle-Pfad über `buckets`/`onToggleMetric`)
+  dort tatsächlich wirkungslos ist. Eigener Prüfauftrag empfohlen, kein
+  Teil dieser Scheibe.
+- **`temperature_cold`** behält implizites `default_enabled=True`, obwohl
+  es wegen `selectable=False` nirgends in einer Auswahl-UI erscheint —
+  kosmetischer Bestand, unverändert seit vor diesem Fix.
+- **Neue Alarm-Regeln für neu angelegte Trips** — dass ein Trip mit
+  aktivierten Größen jetzt auch tatsächlich Alarme bekommen kann, ist eine
+  Folge dieses Fixes, aber keine eigene AC dieser Scheibe (die
+  Alarm-Erzeugung selbst ist unverändertes Bestandsverhalten, s.
+  `tests/tdd/test_issue_946_alert_architecture.py`).
+
+## Test Plan
+
+Test-Politik (CLAUDE.md „Zwei Schichten"): Kern-Tests deterministisch ohne
+Netz/Live-Dienste sind Pflicht. Keine neuen Testdateien mit Issue-Nummer im
+Namen.
+
+### Automated Tests (TDD RED)
+
+- [ ] Test 1 (Python, Register): GIVEN das Metrik-Register / WHEN
+  `get_all_metrics()` nach `trip_default_rank` gefiltert wird / THEN sind
+  es genau 7 Einträge, alle `selectable=True`, in der Reihenfolge
+  temperature, wind, gust, precipitation, thunder, freezing_level,
+  visibility.
+- [ ] Test 2 (Python, Ableitung): GIVEN `trip_metric_ids.py` / WHEN
+  `DEFAULT_TRIP_METRIC_IDS` importiert wird / THEN entspricht es exakt der
+  bisherigen Literal-Liste (Regressionsschutz gegen den bestehenden
+  Order-Test `test_trip_metric_ids.py:32-35`).
+- [ ] Test 3 (Frontend, Rückkanal-Verhalten): GIVEN `WeatherMetricsTab` im
+  Anlege-Modus mit `onWeatherMetricsChange` / WHEN eine Wettergröße
+  an-/abgewählt wird / THEN wird der Callback mit der aktualisierten
+  Metrik-Liste aufgerufen (nicht nur „Komponente rendert", sondern
+  konkreter Payload-Inhalt).
+- [ ] Test 4 (Frontend, End-to-End der Anlage): GIVEN den Anlege-Flow in
+  `TripNewEditor.svelte` / WHEN eine Größe abgewählt und gespeichert wird /
+  THEN enthält der an `buildCreateTripPayload()` übergebene State genau die
+  angepasste Auswahl (nicht die anfängliche `[]`).
+- [ ] Test 5 (Frontend, API-Feld): GIVEN die `/api/metrics`-Antwort / WHEN
+  `metricById[id].trip_default_enabled` für die Vorbelegung im
+  Anlege-Dialog gelesen wird / THEN zeigt der Dialog ohne Nutzereingriff
+  genau die 7 Größen als angehakt an.
+- [ ] Test 6 (Regression, dritter Zustand): GIVEN ein Trip mit gespeicherter,
+  vollständig deaktivierter Metrik-Liste / WHEN der Editor ihn lädt / THEN
+  bleibt die Anzeige „alles aus" (kein Rückfall auf `trip_default_enabled`).
+- [ ] Test 7 (Regression, Orte/Abo unberührt): GIVEN
+  `WeatherConfigDialog.svelte` (Orte/Abonnements) / WHEN eine neue
+  Konfiguration angelegt wird / THEN bleibt die vorgeschlagene Auswahl
+  identisch zum Stand vor diesem Fix (`default_enabled` unverändert).
+
+### Live-E2E (Staging, vor „E2E bestanden")
+
+Neuer Trip über den echten Anlege-Dialog auf Staging anlegen, Auswahl
+NICHT verändern, speichern, erstes Briefing per IMAP abrufen und mit
+`.claude/hooks/briefing_mail_validator.py` gegen die erwarteten 7
+Standardgrößen prüfen (AC-1). Zweiter Durchlauf: alle Größen im
+Anlege-Dialog bewusst abwählen, Briefing zeigt keinen
+Wettergrößen-Überblicksblock (AC-3).
+
+## Known Limitations
+
+- `trip_default_rank` ist eine reine Zusatz-Markierung, unabhängig von
+  `default_enabled` — beide Felder müssen künftig unabhängig gepflegt
+  werden, falls sich die Zielmenge des einen oder anderen ändert; es gibt
+  keinen automatischen Abgleich zwischen ihnen.
+- Der Ortsvergleich-Anlage-Pfad (`/compare/new`) wurde nur soweit
+  gemessen, wie nötig war um festzustellen, dass die exakte Fehlerklasse
+  aus #1552 dort strukturell nicht auftritt — eine vollständige Prüfung
+  des dortigen Grundauswahl-Kartenverhaltens ist offen (s. „Nicht in dieser
+  Scheibe").
+- Migrierte Bestandstrips ohne gespeicherte Auswahl zeigen nach diesem Fix
+  im Editor eine andere (kleinere) Vorbelegung als vorher — gewollte
+  Konsequenz der PO-Entscheidung „eine Quelle", kein Fehler.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Diese Scheibe repariert eine fehlende Datenweiterleitung
+  im Anlege-Flow und gleicht eine Register-Zusatzmarkierung an einen
+  bereits bestehenden, dokumentierten Server-Vertrag
+  (`DEFAULT_TRIP_METRIC_IDS`, ADR-los seit #1394) an. Keine neue
+  Architektur-, Kanal- oder Persistenzentscheidung.
+
+## Changelog
+
+- 2026-08-06: Initial spec erstellt — Issue #1552.

--- a/frontend/src/lib/components/shared/WeatherMetricsTab.svelte
+++ b/frontend/src/lib/components/shared/WeatherMetricsTab.svelte
@@ -9,7 +9,7 @@
 	// Spec: docs/specs/modules/issue_587_weather_tab_v2.md
 	// Spec: docs/specs/modules/issue_618_mobile_weather_tab.md
 	import { api } from '$lib/api.js';
-	import type { Trip, MetricPreset, Horizons, ReportConfig } from '$lib/types';
+	import type { Trip, MetricPreset, Horizons, ReportConfig, WeatherConfigMetric } from '$lib/types';
 	import { HORIZONS_ALL } from '$lib/types';
 	import { Btn, Card, Eyebrow, Pill } from '$lib/components/atoms';
 	// Issue #1311 (C1, Fix-Loop 1 / F001): private Sub-Komponenten von
@@ -115,6 +115,10 @@
 		/** Issue #622: Create-Modus — kein PUT; Kanäle per onChannelsChange nach oben emittieren */
 		createMode?: boolean;
 		onChannelsChange?: (c: ChannelConfig) => void;
+		/** Issue #1552: Create-Modus — Wetter-Metrik-Auswahl per Rückkanal nach
+		 *  oben emittieren (analog onChannelsChange), da im Anlege-Modus kein
+		 *  PUT möglich ist. */
+		onWeatherMetricsChange?: (metrics: WeatherConfigMetric[]) => void;
 		/** Issue #694: Trip-State in +page.svelte nach erfolgreichem PUT aktualisieren */
 		onTripUpdate?: (t: Trip) => void;
 		/** Issue #758: SaveStatus controller — wenn gesetzt, entfällt der explizite Speichern-Button. */
@@ -138,7 +142,7 @@
 		 *  Stundenverlauf). Reine Weiterreichung an CompareOutlookLayoutControls. */
 		onOutlookCommit?: () => void;
 	}
-	let { context = 'route', trip, createMode = false, onChannelsChange, onTripUpdate, saveController, wiz, onCompareCommit, onHourlyCommit, onOutlookCommit }: Props = $props();
+	let { context = 'route', trip, createMode = false, onChannelsChange, onWeatherMetricsChange, onTripUpdate, saveController, wiz, onCompareCommit, onHourlyCommit, onOutlookCommit }: Props = $props();
 
 	// Issue #1311: Abschnittsreihenfolge kommt aus einer reinen Funktion, kein
 	// Duplikat der Reihenfolge im Markup (AC-1, AC-8-Attrappen-Verbot).
@@ -334,7 +338,10 @@
 			const activeIds = savedMetrics.filter((m) => m.enabled).map((m) => m.metric_id);
 			b = autoAssign(activeIds, catalog);
 		} else {
-			const activeIds = allCatalogIds().filter((id) => metricById[id]?.default_enabled);
+			// Issue #1552: Vorbelegung im Anlege-Dialog folgt dem wirksamen
+			// Siebener-Satz (trip_default_enabled), nicht mehr default_enabled
+			// (das speist weiterhin Orte/Abonnements, AC-7 unberührt).
+			const activeIds = allCatalogIds().filter((id) => metricById[id]?.trip_default_enabled);
 			b = autoAssign(activeIds, catalog);
 		}
 
@@ -510,6 +517,16 @@
 	$effect(() => {
 		if (createMode && onChannelsChange) {
 			onChannelsChange({ ...channels });
+		}
+	});
+
+	// Issue #1552: Create-Modus — Wetter-Metrik-Auswahl nach oben propagieren
+	// (analog Kanal-Rückkanal oben). Ohne diesen Effekt verwirft der Anlege-
+	// Dialog die sichtbar angehakte Auswahl beim Speichern (kein PUT im
+	// createMode, s. handleSave()).
+	$effect(() => {
+		if (createMode && onWeatherMetricsChange) {
+			onWeatherMetricsChange(buildWeatherPayload().metrics);
 		}
 	});
 

--- a/frontend/src/lib/components/shared/__tests__/weather_metrics_tab_create_mode_callback.test.ts
+++ b/frontend/src/lib/components/shared/__tests__/weather_metrics_tab_create_mode_callback.test.ts
@@ -1,0 +1,123 @@
+// Issue #1552 — fehlender Rückkanal aus dem Trip-Anlege-Modus.
+//
+// Spec: docs/specs/modules/fix_1552_neuanlage_metrikauswahl.md § Test 3, Test 5
+//
+// Kein Mount-/DOM-Test möglich (kein jsdom/happy-dom im Frontend-Test-Setup,
+// $effect ist per SSR nie sichtbar) — Source-Inspection-Muster analog
+// shared/__tests__/weatherMetricsTabSharing.test.ts: readFileSync auf die
+// Produktivdatei + Assertions auf die konkrete Wirkung (Guard-Bedingung UND
+// übergebener Payload-Ausdruck), nicht bloße String-Presence.
+//
+// Ausführung:
+//   cd frontend && node --import ./test-lib-loader.mjs --experimental-strip-types \
+//     --test src/lib/components/shared/__tests__/weather_metrics_tab_create_mode_callback.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+
+const FILE = join(dirname(fileURLToPath(import.meta.url)), '..', 'WeatherMetricsTab.svelte');
+const code = readFileSync(FILE, 'utf-8');
+
+describe('AC-1/AC-2/AC-3 (Test 3): onWeatherMetricsChange-Rückkanal im Anlege-Modus', () => {
+	test('Props-Interface hat eine onWeatherMetricsChange-Prop mit WeatherConfigMetric[]-Callback', () => {
+		assert.match(
+			code,
+			/onWeatherMetricsChange\??\s*:\s*\(\s*metrics\s*:\s*WeatherConfigMetric\[\]\s*\)\s*=>\s*void/,
+			'Keine onWeatherMetricsChange-Prop vom erwarteten Typ gefunden'
+		);
+	});
+
+	test('onWeatherMetricsChange wird aus den Props destrukturiert', () => {
+		assert.match(
+			code,
+			/let\s*\{[^}]*onWeatherMetricsChange[^}]*\}\s*:\s*Props\s*=\s*\$props\(\)/,
+			'onWeatherMetricsChange fehlt in der Props-Destrukturierung'
+		);
+	});
+
+	test('ein $effect ruft im createMode onWeatherMetricsChange mit buildWeatherPayload().metrics auf', () => {
+		// Bewusst NICHT nur "kommt der Text vor" — die Guard-Bedingung und der
+		// übergebene Ausdruck müssen exakt zusammenhängen (derselbe Effect-Block),
+		// sonst könnte ein leerer/falscher Callback-Aufruf denselben Text streuen.
+		const effectMatch = code.match(
+			/\$effect\(\(\)\s*=>\s*\{\s*if\s*\(createMode\s*&&\s*onWeatherMetricsChange\)\s*\{\s*onWeatherMetricsChange\(buildWeatherPayload\(\)\.metrics\);/
+		);
+		assert.ok(
+			effectMatch,
+			'Kein $effect gefunden, der bei createMode && onWeatherMetricsChange ' +
+				'onWeatherMetricsChange(buildWeatherPayload().metrics) aufruft — ' +
+				'die Auswahl aus dem Anlege-Dialog würde weiterhin nicht nach oben emittiert'
+		);
+	});
+
+	test('der neue Effect ist NICHT identisch mit dem bestehenden onChannelsChange-Effect (eigener Block)', () => {
+		const weatherEffectCount = (
+			code.match(/\$effect\(\(\)\s*=>\s*\{\s*if\s*\(createMode\s*&&\s*onWeatherMetricsChange\)/g) ?? []
+		).length;
+		assert.equal(weatherEffectCount, 1, 'Der Wetter-Metrik-Rückkanal-Effect muss genau einmal vorkommen');
+	});
+});
+
+describe('Test 5: Vorbelegungs-Fallback liest trip_default_enabled statt default_enabled', () => {
+	test('der createMode-Fallback-Zweig (keine gespeicherten Metriken) filtert nach trip_default_enabled', () => {
+		// Zielt gezielt auf den else-Zweig in initFromTrip() (Fall "savedMetrics
+		// fehlt/leer") -- NICHT auf irgendeine Stelle im File, sonst faengt der
+		// Test einen Treffer im falschen Zweig (AC-6 Regression) nicht.
+		assert.match(
+			code,
+			/\}\s*else\s*\{\s*\/\/[^\n]*\n(?:\s*\/\/[^\n]*\n)*\s*const activeIds = allCatalogIds\(\)\.filter\(\(id\) => metricById\[id\]\?\.trip_default_enabled\);/,
+			'Der Vorbelegungs-Fallback (initFromTrip, else-Zweig) liest noch ' +
+				'default_enabled statt trip_default_enabled — die Anzeige im Anlege-' +
+				'Dialog würde weiterhin von der Orte/Abo-Vorbelegung abweichen'
+		);
+	});
+
+	test('kein direkter Zugriff auf metricById[id]?.default_enabled bleibt uebrig', () => {
+		// Regressionsschutz: die Ersetzung soll gezielt sein (nur der eine
+		// Fallback-Zweig), nicht bloss ein zweites Vorkommen daneben stehen
+		// lassen, das denselben Bug an anderer Stelle weiterleben liesse.
+		assert.doesNotMatch(
+			code,
+			/metricById\[id\]\?\.default_enabled(?!\s*\??:)/,
+			'default_enabled wird an unerwarteter Stelle noch direkt gelesen'
+		);
+	});
+});
+
+describe('AC-6 (Adversary-Befund F002, Fix-Loop 1, HIGH): die vollstaendige if/else-if/else-Kette bleibt erhalten', () => {
+	// Der Fallback-Zweig-Test oben prueft NUR den Koerper des else-Zweigs, nicht
+	// die BEDINGUNG des mittleren else-if-Zweigs, der ueberhaupt erst entscheidet,
+	// ob der Fallback erreicht wird. Der Adversary hat genau diese Bedingung zu
+	// `savedMetrics.length > 100` verfaelscht (Realtrips haben typischerweise
+	// weit unter 100 Katalog-Eintraege, ihr eigener else-if-Zweig ist damit
+	// NIE mehr erreichbar -- jeder Trip mit gespeicherter, bewusster
+	// Komplett-Abwahl faellt still auf die 7 Standardgroessen zurueck, AC-6-
+	// Regression) -- alle Tests oben blieben dabei gruen, weil sie nur den
+	// unveraenderten else-Zweig-KOERPER matchen, nicht die Kette drumherum.
+	// Kein Mount-/DOM-Test moeglich (kein jsdom); dieser Test haelt daher die
+	// GESAMTE Kette (alle drei Bedingungen + der bekannte Fallback-Ausdruck im
+	// dritten Zweig) als EINEN zusammenhaengenden Treffer fest.
+	test('if (savedMetrics && hasBuckets) / else if (savedMetrics && savedMetrics.length) / else {...trip_default_enabled...} bilden EINE zusammenhaengende Kette', () => {
+		const chainMatch = code.match(
+			/if\s*\(savedMetrics\s*&&\s*hasBuckets\)\s*\{[\s\S]*?\}\s*else if\s*\(savedMetrics\s*&&\s*savedMetrics\.length\)\s*\{[\s\S]*?\}\s*else\s*\{[\s\S]*?metricById\[id\]\?\.trip_default_enabled[\s\S]*?\}/
+		);
+		assert.ok(
+			chainMatch,
+			'Die vollstaendige Drei-Wege-Kette (inkl. der Bedingung ' +
+				'"savedMetrics && savedMetrics.length" des mittleren Zweigs) ist ' +
+				'nicht mehr im erwarteten Zusammenhang -- eine verfaelschte ' +
+				'Zwischenbedingung (z.B. eine zusaetzliche Laengen-Schwelle) wuerde ' +
+				'jede gespeicherte Auswahl am Fallback-Zweig vorbeischleusen (AC-6)'
+		);
+	});
+
+	test('genau EINE Kette dieser Form existiert (kein zweites, abweichendes Duplikat)', () => {
+		const matches = code.match(
+			/if\s*\(savedMetrics\s*&&\s*hasBuckets\)\s*\{[\s\S]*?\}\s*else if\s*\(savedMetrics\s*&&\s*savedMetrics\.length\)\s*\{[\s\S]*?\}\s*else\s*\{[\s\S]*?metricById\[id\]\?\.trip_default_enabled[\s\S]*?\}/g
+		) ?? [];
+		assert.equal(matches.length, 1, `Erwartet genau 1 Treffer, gefunden: ${matches.length}`);
+	});
+});

--- a/frontend/src/lib/components/trip-new/TripNewEditor.svelte
+++ b/frontend/src/lib/components/trip-new/TripNewEditor.svelte
@@ -296,6 +296,13 @@
 		channels = { ...c };
 	}
 
+	// ── Wetter-Metrik-Änderung aus WeatherMetricsTab (Issue #1552) ────────────
+	// Rückkanal analog handleChannelsChange — ohne ihn verwirft der Anlege-
+	// Dialog die sichtbar angehakte Auswahl still beim Speichern.
+	function handleWeatherMetricsChange(m: WeatherConfigMetric[]) {
+		weatherMetrics = [...m];
+	}
+
 	// ── Speichern ─────────────────────────────────────────────────────────────
 	async function buildAndSave(): Promise<string | null> {
 		if (!ready || saving || savedTripId) return null;
@@ -777,7 +784,7 @@
 		<!-- Issue #941 — WeatherMetricsTab IMMER gemountet (per display ausgeblendet),
 		     damit isDirty/buckets/savedSnapshot bei Tab-Wechseln nicht verloren gehen. -->
 		<div style:display={activeTab === 'metriken' ? '' : 'none'}>
-			<WeatherMetricsTab trip={stubTrip} createMode={true} onChannelsChange={handleChannelsChange} />
+			<WeatherMetricsTab trip={stubTrip} createMode={true} onChannelsChange={handleChannelsChange} onWeatherMetricsChange={handleWeatherMetricsChange} />
 		</div>
 		</div><!-- /.tn-desktop -->
 
@@ -1002,7 +1009,7 @@
 			<!-- Issue #941 — WeatherMetricsTab IMMER gemountet (per display ausgeblendet),
 			     damit isDirty/buckets/savedSnapshot bei Tab-Wechseln nicht verloren gehen. -->
 			<div style:display={activeTab === 'metriken' ? '' : 'none'}>
-				<WeatherMetricsTab trip={stubTrip} createMode={true} onChannelsChange={handleChannelsChange} />
+				<WeatherMetricsTab trip={stubTrip} createMode={true} onChannelsChange={handleChannelsChange} onWeatherMetricsChange={handleWeatherMetricsChange} />
 			</div>
 
 			<!-- Lock-Toast (2s bei Tap auf gesperrten Tab) -->

--- a/frontend/src/lib/components/trip-new/__tests__/trip_new_editor_weather_metrics_wiring.test.ts
+++ b/frontend/src/lib/components/trip-new/__tests__/trip_new_editor_weather_metrics_wiring.test.ts
@@ -1,0 +1,73 @@
+// Issue #1552 — TripNewEditor verwirft die Wetter-Metrik-Auswahl still.
+//
+// Spec: docs/specs/modules/fix_1552_neuanlage_metrikauswahl.md § Test 4
+//
+// Source-Inspection-Muster (kein Mount möglich, s. shared/__tests__/
+// weather_metrics_tab_create_mode_callback.test.ts): beweist, dass
+// `weatherMetrics` einen echten Schreibpfad aus WeatherMetricsTab bekommt
+// (vorher: 0 Schreibstellen, Bug-Ursache aus der Spec) UND dass beide Mounts
+// (Desktop/Mobile) ihn verdrahten — ein Duplizierungsfehler haette sonst nur
+// eine Ansicht repariert.
+//
+// Ausführung:
+//   cd frontend && node --import ./test-lib-loader.mjs --experimental-strip-types \
+//     --test src/lib/components/trip-new/__tests__/trip_new_editor_weather_metrics_wiring.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+import { buildCreateTripPayload, type CreateTripState } from '../tripNewLogic.ts';
+
+const FILE = join(dirname(fileURLToPath(import.meta.url)), '..', 'TripNewEditor.svelte');
+const code = readFileSync(FILE, 'utf-8');
+
+describe('AC-1/AC-2/AC-3 (Test 4): handleWeatherMetricsChange schreibt weatherMetrics', () => {
+	test('ein handleWeatherMetricsChange-Handler existiert und schreibt weatherMetrics', () => {
+		assert.match(
+			code,
+			/function handleWeatherMetricsChange\([^)]*\)\s*\{\s*weatherMetrics\s*=/,
+			'Kein handleWeatherMetricsChange-Handler gefunden, der weatherMetrics schreibt — ' +
+				'ohne ihn bleibt weatherMetrics dauerhaft [] (Bug-Ursache #1552)'
+		);
+	});
+
+	test('beide WeatherMetricsTab-Mounts (Desktop+Mobile) uebergeben onWeatherMetricsChange', () => {
+		const mounts = code.match(/<WeatherMetricsTab\b[^>]*\/>/g) ?? [];
+		assert.equal(mounts.length, 2, `Erwartet genau 2 WeatherMetricsTab-Mounts, gefunden: ${mounts.length}`);
+		for (const [i, m] of mounts.entries()) {
+			assert.match(
+				m,
+				/onWeatherMetricsChange=\{handleWeatherMetricsChange\}/,
+				`Mount #${i + 1} uebergibt onWeatherMetricsChange nicht — ` +
+					`nur eine Ansicht (Desktop ODER Mobile) waere repariert`
+			);
+			// Regression: der bestehende Kanal-Ruckkanal darf nicht verloren gehen.
+			assert.match(m, /onChannelsChange=\{handleChannelsChange\}/, `Mount #${i + 1} verliert onChannelsChange`);
+		}
+	});
+});
+
+describe('Test 4 (Ende-zu-Ende der Anlage): buildCreateTripPayload uebernimmt eine geaenderte Auswahl', () => {
+	// Beweist die Kehrseite: SOBALD weatherMetrics tatsaechlich befuellt ist
+	// (was der oben bewiesene Handler jetzt leistet), landet die geaenderte
+	// Auswahl unveraendert im POST-Payload -- nicht die anfaengliche [].
+	test('eine im Dialog abgewaehlte Groesse (enabled=false) bleibt im Payload erhalten', () => {
+		const state: CreateTripState = {
+			name: 'Testtour',
+			startDate: '2026-06-15',
+			stages: [{ id: 1, name: 'Etappe 1', waypoints: [] }],
+			weatherMetrics: [
+				{ metric_id: 'temperature', enabled: true },
+				{ metric_id: 'wind', enabled: false },
+			],
+			channels: { email: true, telegram: true, sms: false },
+		};
+		const payload = buildCreateTripPayload(state);
+		assert.deepEqual(payload.display_config!.metrics, [
+			{ metric_id: 'temperature', enabled: true },
+			{ metric_id: 'wind', enabled: false },
+		]);
+	});
+});

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -163,8 +163,15 @@ export interface MetricEntry {
 	category: string;
 	default_enabled: boolean;
 	/** Issue #1552: Trip-Anlege-Vorbelegung — eigener Marker, unabhaengig von
-	 *  default_enabled (das weiterhin Orte/Abonnements versorgt). */
-	trip_default_enabled: boolean;
+	 *  default_enabled (das weiterhin Orte/Abonnements versorgt). Optional wie
+	 *  die anderen additiven Katalog-Felder unten: die echte Serverantwort
+	 *  liefert es immer (s. api/routers/config.py::get_metrics(),
+	 *  test_metrics_endpoint_trip_default_field.py), aber bestehende
+	 *  Test-/Mock-Kataloge in diesem Repo bauen MetricEntry-Literale ohne
+	 *  jedes Feld nachzuruesten — als Pflichtfeld waeren sie strukturell
+	 *  unvollstaendig, ohne dass sich an ihrem getesteten Verhalten etwas
+	 *  aendert (CI-Regression svelte-check 36->94, #1554 Fix-Loop). */
+	trip_default_enabled?: boolean;
 	has_friendly_format: boolean;
 	/** Issue #435: erlaubte Format-Modi pro Metrik (raw/scale/simplified/symbol). */
 	format_modes?: string[];

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -162,6 +162,9 @@ export interface MetricEntry {
 	unit: string;
 	category: string;
 	default_enabled: boolean;
+	/** Issue #1552: Trip-Anlege-Vorbelegung — eigener Marker, unabhaengig von
+	 *  default_enabled (das weiterhin Orte/Abonnements versorgt). */
+	trip_default_enabled: boolean;
 	has_friendly_format: boolean;
 	/** Issue #435: erlaubte Format-Modi pro Metrik (raw/scale/simplified/symbol). */
 	format_modes?: string[];

--- a/src/app/metric_catalog.py
+++ b/src/app/metric_catalog.py
@@ -76,6 +76,11 @@ class MetricDefinition:
     # für Katalog-Vollständigkeit, lösen aber KEINEN Abweichungs-Alert aus.
     # from_display_config() und from_alert_rules() ignorieren is_precursor=True.
     is_precursor: bool = False
+    # Issue #1552: reine Zusatz-Markierung "gehoert zum Trip-Anlege-Standard",
+    # unabhaengig von default_enabled (das Orte/Abonnements weiter versorgt).
+    # Gesetzt auf genau 7 Groessen mit expliziter Rangfolge (Reihenfolge der
+    # Sieben-ID-Liste in DEFAULT_TRIP_METRIC_IDS, trip_metric_ids.py).
+    trip_default_rank: Optional[int] = None
 
     @property
     def has_friendly_format(self) -> bool:
@@ -106,6 +111,7 @@ _METRICS: list[MetricDefinition] = [
             "yellow_lt": 0.0, "orange_lt": -5.0, "red_lt": -15.0,
         },
         sms_code="D", decimals=0, cmp="über", alert_label="Temp",
+        trip_default_rank=1,  # Issue #1552: Trip-Anlege-Standard, Rang 1
     ),
     # Issue #914: Internal-only entry for AlertMetric.TEMPERATURE_MIN (Kältealarm).
     # cmp="unter" because cold alarm fires when temp_min_c FALLS BELOW threshold.
@@ -212,6 +218,7 @@ _METRICS: list[MetricDefinition] = [
         format_modes=("raw", "simplified"),
         default_format_mode="raw",
         sms_code="W", decimals=0, cmp="über", alert_label="Wind",
+        trip_default_rank=2,  # Issue #1552: Trip-Anlege-Standard, Rang 2
     ),
     MetricDefinition(
         id="gust", label_de="Böen", unit="km/h",
@@ -232,6 +239,7 @@ _METRICS: list[MetricDefinition] = [
         format_modes=("raw", "simplified"),
         default_format_mode="raw",
         sms_code="G", decimals=0, cmp="über", alert_label="Böen",
+        trip_default_rank=3,  # Issue #1552: Trip-Anlege-Standard, Rang 3
     ),
     MetricDefinition(
         id="wind_direction", label_de="Windrichtung", unit="°",
@@ -264,6 +272,7 @@ _METRICS: list[MetricDefinition] = [
         format_modes=("raw", "simplified"),
         default_format_mode="raw",
         sms_code="R", decimals=1, cmp="über", alert_label="Niedersch",
+        trip_default_rank=4,  # Issue #1552: Trip-Anlege-Standard, Rang 4
     ),
     MetricDefinition(
         id="rain_probability", label_de="Regenwahrscheinlichkeit", unit="%",
@@ -314,6 +323,7 @@ _METRICS: list[MetricDefinition] = [
         format_modes=("raw", "symbol"),
         default_format_mode="symbol",
         sms_code="TH", decimals=0, cmp="über", alert_label="Gewitter",
+        trip_default_rank=5,  # Issue #1552: Trip-Anlege-Standard, Rang 5
     ),
     MetricDefinition(
         id="cape", label_de="Gewitterenergie (CAPE)", unit="J/kg",
@@ -449,6 +459,7 @@ _METRICS: list[MetricDefinition] = [
         format_modes=("raw",),
         default_format_mode="raw",
         sms_code="VS", decimals=1, cmp="unter", alert_label="Sicht",
+        trip_default_rank=7,  # Issue #1552: Trip-Anlege-Standard, Rang 7
     ),
     MetricDefinition(
         # #1401 A1: "Sonnenstunden" benennt die Einheit (h) korrekt (PO-Freigabe).
@@ -514,6 +525,7 @@ _METRICS: list[MetricDefinition] = [
         default_change_threshold=200,
         alert_metrics={"min": "freezing_level"},  # #1435 E1a
         sms_code="NL", decimals=0, cmp="unter", alert_label="Nullgradgrenze",
+        trip_default_rank=6,  # Issue #1552: Trip-Anlege-Standard, Rang 6
     ),
     MetricDefinition(
         id="snow_depth", label_de="Schneehöhe", unit="cm",

--- a/src/output/renderers/trip_metric_ids.py
+++ b/src/output/renderers/trip_metric_ids.py
@@ -21,9 +21,16 @@ from __future__ import annotations
 
 from typing import Sequence
 
-DEFAULT_TRIP_METRIC_IDS: tuple[str, ...] = (
-    "temperature", "wind", "gust", "precipitation",
-    "thunder", "freezing_level", "visibility",
+from app.metric_catalog import get_all_metrics
+
+# Issue #1552: aus dem Register abgeleitet (trip_default_rank), statt als
+# Literal gefuehrt -- eine Quelle fuer "was ist Trip-Anlege-Standard"
+# (Register + Frontend-Vorbelegung lesen denselben Marker).
+DEFAULT_TRIP_METRIC_IDS: tuple[str, ...] = tuple(
+    m.id for m in sorted(
+        (m for m in get_all_metrics() if m.trip_default_rank is not None),
+        key=lambda m: m.trip_default_rank,
+    )
 )
 
 

--- a/tests/unit/test_metric_catalog_trip_defaults.py
+++ b/tests/unit/test_metric_catalog_trip_defaults.py
@@ -1,0 +1,71 @@
+"""Trip-Anlege-Standard im Register — Issue #1552.
+
+Spec: docs/specs/modules/fix_1552_neuanlage_metrikauswahl.md
+
+Kern-Tests (Test-Politik "Zwei Schichten", CLAUDE.md): kein Netz, keine
+Live-Dienste, kein Mock/patch. Reine Registrierungs-Abfragen.
+
+Prueft die Register-Ebene: genau 7 Groessen tragen `trip_default_rank`,
+alle sind `selectable=True`, in der dokumentierten Reihenfolge. Zusaetzlich
+Regressionsschutz fuer AC-7: `default_enabled` (Orte/Abonnements-Vorbelegung)
+bleibt fuer alle betroffenen Groessen unveraendert -- `trip_default_rank`
+ist eine reine Zusatz-Markierung, kein Ersatz.
+"""
+from __future__ import annotations
+
+from app.metric_catalog import get_all_metrics
+
+EXPECTED_ORDER = [
+    "temperature", "wind", "gust", "precipitation",
+    "thunder", "freezing_level", "visibility",
+]
+
+
+def _ranked_metrics():
+    return sorted(
+        (m for m in get_all_metrics() if m.trip_default_rank is not None),
+        key=lambda m: m.trip_default_rank,
+    )
+
+
+class TestTripDefaultRankRegister:
+    def test_exactly_seven_metrics_carry_trip_default_rank(self):
+        ranked = _ranked_metrics()
+        assert [m.id for m in ranked] == EXPECTED_ORDER, (
+            f"Erwartete genau die 7 Standard-Groessen in dieser Reihenfolge, "
+            f"bekam: {[m.id for m in ranked]!r}"
+        )
+
+    def test_all_seven_are_selectable(self):
+        ranked = _ranked_metrics()
+        assert all(m.selectable for m in ranked), (
+            "Alle 7 Trip-Anlege-Standardgroessen muessen selectable=True sein "
+            "(sonst waeren sie nie im Anlege-Dialog waehlbar)"
+        )
+
+    def test_rank_values_are_1_to_7_without_gaps(self):
+        ranked = _ranked_metrics()
+        assert [m.trip_default_rank for m in ranked] == [1, 2, 3, 4, 5, 6, 7]
+
+    def test_no_other_metric_carries_trip_default_rank(self):
+        all_ids = {m.id for m in get_all_metrics()}
+        ranked_ids = {m.id for m in _ranked_metrics()}
+        others = all_ids - ranked_ids
+        # Stichprobe: eine Groesse, die frueher (default_enabled) den
+        # Anlege-Dialog fuellte, aber NICHT zu den 7 Ziel-Groessen gehoert,
+        # darf jetzt kein trip_default_rank tragen.
+        assert "cloud_total" in others
+        assert "sunshine" in others
+
+    def test_default_enabled_unchanged_for_ranked_metrics_ac7(self):
+        # AC-7: default_enabled (Orte/Abonnements) bleibt unberuehrt.
+        # freezing_level/visibility sind default_enabled=False (nie Teil der
+        # Orte-Vorbelegung) -- das war schon vor #1552 so und muss es bleiben.
+        by_id = {m.id: m for m in get_all_metrics()}
+        assert by_id["freezing_level"].default_enabled is False
+        assert by_id["visibility"].default_enabled is False
+        assert by_id["temperature"].default_enabled is True
+        assert by_id["wind"].default_enabled is True
+        assert by_id["gust"].default_enabled is True
+        assert by_id["precipitation"].default_enabled is True
+        assert by_id["thunder"].default_enabled is True

--- a/tests/unit/test_metrics_endpoint_trip_default_field.py
+++ b/tests/unit/test_metrics_endpoint_trip_default_field.py
@@ -1,0 +1,60 @@
+"""GET /api/metrics liefert das Trip-Anlege-Vorbelegungs-Feld -- Issue #1552.
+
+Spec: docs/specs/modules/fix_1552_neuanlage_metrikauswahl.md (AC-8, Test 5)
+
+Echter FastAPI-TestClient gegen den realen Router, kein Mock, kein Netz
+(Vorbild: test_alert_metric_identity_delivery.py). Das Frontend darf die
+Information "gehoert zur Trip-Vorbelegung" ausschliesslich aus dieser
+Antwort beziehen (AC-8) -- dieser Test beweist, dass der Server sie liefert.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+EXPECTED_TRUE = {
+    "temperature", "wind", "gust", "precipitation",
+    "thunder", "freezing_level", "visibility",
+}
+
+
+@pytest.fixture
+def client() -> TestClient:
+    from api.routers import config
+
+    app = FastAPI()
+    app.include_router(config.router, prefix="/api")
+    return TestClient(app)
+
+
+def _all_metrics(payload: dict) -> list[dict]:
+    out = []
+    for metrics in payload.values():
+        out.extend(metrics)
+    return out
+
+
+def test_exactly_the_seven_target_metrics_are_marked_trip_default_enabled(client: TestClient):
+    payload = client.get("/api/metrics").json()
+    metrics = _all_metrics(payload)
+    true_ids = {m["id"] for m in metrics if m["trip_default_enabled"] is True}
+    assert true_ids == EXPECTED_TRUE, (
+        f"AC-8 FAIL: /api/metrics markiert nicht genau die 7 Ziel-Groessen als "
+        f"trip_default_enabled. Ist: {true_ids!r}"
+    )
+
+
+def test_trip_default_enabled_is_independent_of_default_enabled(client: TestClient):
+    payload = client.get("/api/metrics").json()
+    metrics = {m["id"]: m for m in _all_metrics(payload)}
+    # freezing_level/visibility: default_enabled=False (Orte/Abo), aber
+    # trip_default_enabled=True (Trip-Anlege-Standard) -- der Beweis, dass
+    # beide Felder unabhaengig sind (AC-7 Kehrseite).
+    assert metrics["freezing_level"]["default_enabled"] is False
+    assert metrics["freezing_level"]["trip_default_enabled"] is True
+    assert metrics["visibility"]["default_enabled"] is False
+    assert metrics["visibility"]["trip_default_enabled"] is True
+    # cloud_total: default_enabled=True (Orte/Abo), aber kein Trip-Standard.
+    assert metrics["cloud_total"]["default_enabled"] is True
+    assert metrics["cloud_total"]["trip_default_enabled"] is False

--- a/tests/unit/test_trip_empty_metric_selection.py
+++ b/tests/unit/test_trip_empty_metric_selection.py
@@ -271,6 +271,109 @@ class TestEndToEndVersandpfad:
 
 
 # ===========================================================================
+# Issue #1552 AC-1/AC-3: der Payload, wie ihn der reparierte Anlege-Flow
+# TATSAECHLICH erzeugt (WeatherMetricsTab.buildWeatherConfigMetrics() emittiert
+# JEDE Katalog-ID genau einmal, kein leeres Feld, keine Nur-7-Teilmenge) --
+# weder Fall A (leere Liste) noch Fall B (nur 7 Eintraege) oben bilden diese
+# Form ab. Adversary-Befund F001: AC-1/AC-3 verlangen woertlich ein
+# gerendertes Briefing, kein Register-/Ableitungs-/Payload-Assert.
+# ===========================================================================
+
+
+def _create_flow_dc(*, seven_enabled: bool) -> UnifiedWeatherDisplayConfig:
+    """Baut dc.metrics so, wie es der Anlege-Flow nach dem Fix persistiert:
+    eine vollstaendige Katalogliste (eine MetricConfig je selektierbarer
+    Groesse), mit `enabled=True` genau fuer die sieben Standardgroessen
+    (AC-1, `seven_enabled=True`) bzw. fuer KEINE Groesse (AC-3, bewusste
+    Komplett-Abwahl, `seven_enabled=False`).
+
+    Liest die Vorbelegung ueber den ECHTEN `/api/metrics`-Endpoint
+    (`api.routers.config.get_metrics()`), nicht ueber `DEFAULT_TRIP_METRIC_IDS`
+    direkt -- das spiegelt exakt den Lesepfad, den `WeatherMetricsTab.svelte`
+    (`metricById[id]?.trip_default_enabled`) im Anlege-Modus nutzt (Spec § B).
+    Ohne das neue Feld `trip_default_enabled` schlaegt dieser Aufbau mit
+    KeyError fehl (RED-Beweis vor dem API-Fix, s. Testbericht)."""
+    from api.routers.config import get_metrics
+
+    catalog = get_metrics()
+    metrics = [
+        MetricConfig(
+            metric_id=m["id"],
+            enabled=seven_enabled and m["trip_default_enabled"],
+        )
+        for entries in catalog.values()
+        for m in entries
+    ]
+    return UnifiedWeatherDisplayConfig(trip_id="create-flow", metrics=metrics)
+
+
+class TestCreateFlowPayloadRendersExactlySevenDefaults:
+    """AC-1/AC-3 ueber den echten Versandpfad (TripReportFormatter, wie
+    TestEndToEndVersandpfad oben) -- diesmal mit der vollstaendigen
+    Katalogliste als dc.metrics, nicht mit den kuenstlichen Fall-A/Fall-B-
+    Kurzformen."""
+
+    def _format(self, report_type, dc):
+        from output.renderers.trip_report import TripReportFormatter
+        return TripReportFormatter().format_email(
+            segments=_build_segments(), trip_name="GR20 Test",
+            report_type=report_type, display_config=dc, tz=TZ,
+        )
+
+    # Issue #1552 Nachbesserung (Adversary-Befund Fix-Loop 1): die Mail hat
+    # eine feste Kommando-/Einheiten-Legende ("Einheiten: Temp °C · Wind, Gust
+    # km/h ...", "Spalten: ... Gust = Böen ... Visib = Sichtweite ...",
+    # Kommando "GEWITTER"), die UNABHAENGIG von den Pillen immer im Text
+    # steht. Bloss "°C"/"Wind"/"Böen"/"Gewitter"/"Sicht" waeren dort false-
+    # positive gruen -- deshalb die vollen, nur in der Pillen-Zeile
+    # vorkommenden Textformen (mit der fixen Fixture deterministisch, s.
+    # _build_segments()/oben).
+    _PILL_MARKERS = (
+        ("°C · Max", "temperature"),
+        ("Wind >10 km/h", "wind"),
+        ("Böen >20 km/h", "gust"),
+        ("Regen ab 09:00", "precipitation"),
+        ("Gewitter ab 08:00", "thunder"),
+        ("0°-Linie 2.500 m", "freezing_level"),
+        ("Sicht <2 km", "visibility"),
+    )
+
+    def test_ac1_seven_enabled_shows_exactly_the_seven_target_metrics(self):
+        report = self._format("morning", _create_flow_dc(seven_enabled=True))
+        plain = report.email_plain
+        assert "Metriken-Überblick" in plain, (
+            "AC-1: der aus buildCreateTripPayload()-aehnlichem Payload "
+            "gerenderte Briefing-Teil zeigt keinen Ueberblicksblock."
+        )
+        for marker, name in self._PILL_MARKERS:
+            assert marker in plain, f"AC-1: Pille fuer {name} ({marker!r}) fehlt im Briefing"
+        # Gegenprobe "genau diese 7, nicht irgendwelche": rain_probability
+        # hat im Fixture ebenfalls Rohdaten (pop_pct), ist aber NICHT in
+        # DEFAULT_TRIP_METRIC_IDS -- ihr eigenes Label "Regen-W." darf trotz
+        # vorhandener Daten nicht erscheinen, weil enabled=False.
+        assert "Regen-W." not in plain, (
+            "AC-1: rain_probability (nicht Teil der 7 Standardgroessen) "
+            "erscheint trotzdem -- der Payload wird nicht auf die 7 begrenzt."
+        )
+
+    def test_ac3_all_disabled_shows_no_overview_block_and_no_default_fallback(self):
+        report = self._format("morning", _create_flow_dc(seven_enabled=False))
+        plain = report.email_plain
+        assert "Metriken-Überblick" not in plain, (
+            "AC-3: bewusste Komplett-Abwahl (alle enabled=False in der vollen "
+            "Katalogliste) muss den Ueberblicksblock vollstaendig entfernen."
+        )
+        # Kein stiller Rueckfall auf die sieben Standardgroessen (das waere
+        # das #1552-Symptom in neuer Form): keine der sieben Pillen-Textformen
+        # darf auftauchen, obwohl dieselben Rohdaten wie oben vorliegen.
+        for marker, name in self._PILL_MARKERS:
+            assert marker not in plain, (
+                f"AC-3: Pille fuer {name} ({marker!r}) erscheint trotz "
+                "bewusster Leerauswahl -- stiller Rueckfall auf den Standardsatz"
+            )
+
+
+# ===========================================================================
 # AC-4/AC-5: Vortagszeile summarize_day_comparison()
 # ===========================================================================
 

--- a/tests/unit/test_trip_metric_ids.py
+++ b/tests/unit/test_trip_metric_ids.py
@@ -105,3 +105,54 @@ class TestGefuellteAuswahlUnabhaengigVonAltbestand:
         ]
         result = resolve_trip_active_metrics(metrics, altbestand=False)
         assert result == ["visibility", "temperature", "gust"]
+
+
+class TestDefaultTripMetricIdsIstAusDemRegisterAbgeleitet:
+    """Issue #1552: DEFAULT_TRIP_METRIC_IDS muss aus dem Register (`trip_default_
+    rank`) abgeleitet sein, nicht als Literal gefuehrt werden -- sonst laeuft das
+    Register (Frontend-Vorbelegung liest `trip_default_enabled`) und der Server-
+    Rueckfall (`DEFAULT_TRIP_METRIC_IDS`) irgendwann auseinander (zwei Quellen
+    statt einer, s. Spec § B).
+
+    Mutations-Falle (CLAUDE.md, Regel-Budget-Familie "Ableitung durch das alte
+    Literal ersetzen"): weil der heutige Registerstand zufaellig dieselbe
+    Reihenfolge/Menge liefert wie die frueher hartkodierte Liste, wuerde ein Test,
+    der nur den RESULTIERENDEN Wert prueft (wie die Klasse oben), eine
+    Ruecksubstitution durch das alte Literal NICHT bemerken. Dieser Test stoert
+    stattdessen echt die Registerdaten (kein Mock -- eine reale Kopie der
+    `_METRICS`-Liste mit einem echten zusaetzlichen `MetricDefinition`-Objekt) und
+    erzwingt einen frischen Import, um zu beweisen, dass die Ableitung tatsaechlich
+    zur Laufzeit aus dem Register liest.
+    """
+
+    def test_derivation_tracks_a_real_registry_change(self, monkeypatch):
+        import importlib
+
+        from app import metric_catalog
+        from output.renderers import trip_metric_ids as tmi_module
+
+        extra = dataclasses_replace_temperature_with_rank_eight(metric_catalog)
+        monkeypatch.setattr(
+            metric_catalog, "_METRICS", metric_catalog._METRICS + [extra],
+        )
+        try:
+            reloaded = importlib.reload(tmi_module)
+            assert reloaded.DEFAULT_TRIP_METRIC_IDS[-1] == "trip_1552_mutation_probe", (
+                "DEFAULT_TRIP_METRIC_IDS reagiert nicht auf eine echte "
+                "Registeraenderung -- das ist nur moeglich, wenn die Liste (wieder) "
+                "hartkodiert ist statt aus get_all_metrics() abgeleitet zu werden"
+            )
+        finally:
+            importlib.reload(tmi_module)  # Modul-Cache fuer alle Folgetests bereinigen
+
+
+def dataclasses_replace_temperature_with_rank_eight(metric_catalog):
+    """Baut ein echtes zusaetzliches MetricDefinition-Objekt (Rang 8) -- kein
+    Mock, reale Dataclass-Instanz aus dem Produktivtyp."""
+    temperature = metric_catalog.get_metric("temperature")
+    import dataclasses
+    return dataclasses.replace(
+        temperature,
+        id="trip_1552_mutation_probe",
+        trip_default_rank=8,
+    )


### PR DESCRIPTION

Beim Anlegen eines Trips war die Auswahl im Reiter "Wetter-Metriken" bedienbar
und reagierte sichtbar, landete aber nie im gespeicherten Trip: der Wetter-Reiter
hielt sie nur lokal (scheduleAutoSave bricht im createMode ab), und der
Anlege-Editor besass keinen Rueckkanal — weatherMetrics hatte null Schreibstellen.
Jeder neue Trip startete deshalb mit display_config.metrics = [] und bekam damit
strukturell keine Alarme (trip_alert.py:190-208, deviation_alert_engine.py:154-170).
Gemessen im Produktivbestand: 8 von 14 Trips in diesem Zustand.

Zweiter Teil desselben Fehlerbildes: Die im Anlege-Dialog gezeigte Vorbelegung
(10 Groessen, aus default_enabled) war eine andere Liste als der Satz, den ein nie
eingestellter Trip tatsaechlich verschickt (7 Groessen, DEFAULT_TRIP_METRIC_IDS) —
Ueberschneidung nur 5. PO-Entscheid 2026-08-06: es gilt der wirksame Sieben-Satz,
die Anzeige wird daran angeglichen.

Umsetzung:
- metric_catalog.py: neues Registerfeld trip_default_rank auf genau den sieben
  Zielgroessen, mit expliziter Rangfolge (Deklarationsreihenfolge haette
  freezing_level/visibility vertauscht).
- trip_metric_ids.py: DEFAULT_TRIP_METRIC_IDS wird daraus abgeleitet statt hart
  gelistet — eine Liste weniger, nicht eine mehr.
- /api/metrics liefert trip_default_enabled; WeatherMetricsTab liest im
  Vorbelegungs-Zweig dieses Feld statt default_enabled.
- default_enabled bleibt unangetastet: es speist build_default_display_config()
  und darueber die Orte-/Abo-Seite plus ueber 100 Testaufrufstellen (AC-7).
- Rueckkanal onWeatherMetricsChange nach dem Muster des vorhandenen
  onChannelsChange, an beiden Mounts (Desktop + Mobile).

Der dritte Zustand bleibt unberuehrt: wer bewusst alle Groessen abwaehlt, bekommt
keine Vorbelegung untergeschoben (AC-6).

Adversary: VERIFIED, 3 Runden, 8/8 ACs, 11 Mutationen. Runde 2 war BROKEN — zwei
HIGH-Findings: AC-1/AC-3 waren nirgends am gerenderten Briefing geprueft (nur auf
Payload-Ebene), und die Bedingung, die den dritten Zustand schuetzt, liess sich
verfaelschen, ohne dass ein Test rot wurde. Beide geschlossen und per Mutation
als fangend belegt.

Spec: docs/specs/modules/fix_1552_neuanlage_metrikauswahl.md

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Closes #1552

🤖 Generated with [Claude Code](https://claude.com/claude-code)