### PR TITLE
docs: Spec-Ablage beschreibt, was wahr ist — statt einer Sortierung, die es nicht gibt

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,8 +21,7 @@
 
 | Ort | Charakter |
 |---|---|
-| `specs/modules/` u. a. | Specs: thematische Modul-Specs + Specs OFFENER Issues. Template: `specs/_template.md` |
-| `specs/_archive/` | Wegwerf-Specs GESCHLOSSENER Issues (2026-07-21 archiviert; durchsuchbar, nicht maßgeblich) |
+| `specs/modules/`, `specs/fast/`, `specs/_archive/` | **Datierte Umsetzungs-Berichte: was wann gebaut wurde — kein Ist-Stand.** Verlässlich ist allein `created`/`updated` im Kopf. Weder der Ordner noch das `status:`-Feld sagen, ob eine Spec noch gilt: gemessen 2026-08-07 liegen 115 von 140 issue-benannten Specs zu **geschlossenen** Issues in `modules/`, und 297 von 367 Dateien stehen auf `status: draft`, obwohl längst live. Wer wissen will, wie das System **heute** arbeitet, liest `reference/` und `adr/` (oben) — nie eine Spec. Template: `specs/_template.md` |
 | `artifacts/` | Workflow-Artefakte laufender Vorgänge — Ordner abgeschlossener Workflows werden gelöscht (Git-Historie bewahrt sie) |
 | `analysis/` | Punktuelle Analysen (datiert, nicht gepflegt) |
 | `design-requests/`, `claude-design-queue/`, `design/` | Design-Austausch-Artefakte (Momentaufnahmen) |


### PR DESCRIPTION
Der Wegweiser behauptete: specs/modules/ = Specs OFFENER Issues,
specs/_archive/ = Specs GESCHLOSSENER Issues ("nicht massgeblich").

Gemessen 2026-08-07 hat diese Regel 115 Gegenbeispiele: von 140
issue-benannten Specs in modules/ gehoeren 115 zu geschlossenen Issues.
Der zweite Mechanismus taugt genauso wenig -- 297 von 367 Dateien stehen
auf `status: draft`, obwohl laengst live, daneben 9 konkurrierende Werte
(implemented/live/active/completed/...) und 22 Dateien ohne das Feld.

Eine Regel mit 115 Gegenbeispielen ist keine Regel, sondern eine Falle:
sie haette bei #1310 fast dazu gefuehrt, eine korrekt abgelegte Datei
"zurueckzukorrigieren", waehrend 115 andere liegen bleiben.

Nicht geflickt wird, was aus demselben Grund wieder verrottet -- weder
115 Dateien verschieben noch 297 Statusfelder von Hand nachziehen.
Stattdessen sagt der Wegweiser jetzt die Wahrheit und nennt die einzige
Angabe, die nicht luegen kann (created/updated) sowie den Ort, an dem
der Ist-Stand wirklich steht: reference/ und adr/. Beide nachgeprueft --
api_contract.md fuehrt korrekt, dass der Wertebereich seit #1460 keinen
Alarm ausloest; ADR-0040 traegt "Abgeloest durch ADR-0043".

Regel-Budget: Ersatz, kein Zusatz -- eine falsche Behauptung faellt weg,
es kommt keine neue Pflicht hinzu.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
