### PR TITLE
#1196 Batch 1: test_epic_140 + test_issue_1165 saniert (Exclude 43 → 41)

### DIFF
--- a/.github/ci_tdd_excludes.txt
+++ b/.github/ci_tdd_excludes.txt
@@ -9,6 +9,12 @@
 # test_fix_911_visual_table, test_issue_733_briefing_mail_validator,
 # test_touched_tests_gate.
 #
+# Batch 1 der Sanierung (2026-08-07): test_epic_140_preview_endpoints
+# (Daten-Isolation #1133 statt real_data_root-Opt-out + Token-Alphabet an
+# sms_format.md §2 angeglichen) und test_issue_1165_adr_index_cleanup
+# (altes ADR-Dateinamen-Literal aus Spec-Doku entfernt) sind saniert und
+# laufen wieder mit.
+#
 # WICHTIG (Lektion aus PR #1551): Lokale Offline-Laeufe im Haupt-Checkout
 # (.env + befuellte data/users/) sind KEIN Beleg fuer CI-Gruen. Einzig
 # verbindliche Vermessung ist der Runner. Ursachen und Sanierungsreihenfolge:
@@ -27,14 +33,12 @@ tests/tdd/test_compare_official_alert.py
 tests/tdd/test_compare_sun_hours_full_day_window.py
 tests/tdd/test_corridor_no_longer_triggers_alerts.py
 tests/tdd/test_day_comparison_service.py
-tests/tdd/test_epic_140_preview_endpoints.py
 tests/tdd/test_feature_656_radar_nowcast.py
 tests/tdd/test_feature_660_convective_stage.py
 tests/tdd/test_issue_1040_alerts_toggle.py
 tests/tdd/test_issue_1088_official_alert_triggers.py
 tests/tdd/test_issue_1104_compare_config_foundation.py
 tests/tdd/test_issue_1107_compare_sections.py
-tests/tdd/test_issue_1165_adr_index_cleanup.py
 tests/tdd/test_issue_1168_alert_engine_extract.py
 tests/tdd/test_issue_586_alert_config_fidelity.py
 tests/tdd/test_issue_603_design_fidelity_gate.py

--- a/docs/specs/modules/fix_1196_s1_testnetz_entrauschen.md
+++ b/docs/specs/modules/fix_1196_s1_testnetz_entrauschen.md
@@ -238,7 +238,7 @@ Selbstzitate), keine Erwartung wurde gelockert.
 
 **Lebend-Gegenprobe (durchgeführt, schärfer als eine bloße Behauptung):**
 eine zusätzliche Datei `docs/specs/_archive/modules/zz_gegenprobe_1196.md`
-mit echtem `0013-node-test-frontend-unit-runner.md`-Verweis lässt
+mit echtem Verweis auf den alten ADR-Dateinamen (`0013-…`-Literal) lässt
 `test_no_adr_0013_reference_in_node_test_context` sofort wieder anschlagen
 (`AssertionError`); nach Entfernen der Gegenprobe-Datei ist der Test wieder
 grün. Der Wächter bleibt also außerhalb der zwei benannten Meta-Dokumente
@@ -490,7 +490,7 @@ Kein AC in dieser Spec; eigenes Ticket je nach Messergebnis.
   pauschaler `_archive/`-Ausschluss) / Then ist
   `test_no_adr_0013_reference_in_node_test_context` grün, UND eine
   Lebend-Gegenprobe (eine zusätzliche Datei mit echtem
-  `0013-node-test-frontend-unit-runner.md`-Verweis außerhalb der zwei
+  Verweis auf das `0013-…`-Literal außerhalb der zwei
   benannten Ausnahmen) lässt den Test weiterhin anschlagen, solange sie
   vorhanden ist, und wird nach Entfernen wieder grün.
   - Test: `uv run pytest tests/tdd/test_issue_1165_adr_index_cleanup.py` war

--- a/tests/tdd/test_epic_140_preview_endpoints.py
+++ b/tests/tdd/test_epic_140_preview_endpoints.py
@@ -9,16 +9,44 @@ werden im Test toleriert (HTTP 200 bei Erfolg, HTTP 503 bei API-Fehler — beide
 
 from __future__ import annotations
 
+import shutil
+from pathlib import Path
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-# Issue #1133: die gesamte Datei liest das echte, committete Trip-Fixture
-# data/users/default/trips/gr221-mallorca.json über PreviewService (echter
-# get_trips_dir()-Pfad) — bewusstes Opt-out aus der autouse-Isolation für
-# das gesamte Modul statt pro Test (Datei-Docstring: "Echte Trip-Fixtures aus
-# data/users/default").
-pytestmark = pytest.mark.real_data_root
+# Issue #1133/#1196: KEIN Opt-out mehr aus der autouse-Isolation
+# (frueher pytest.mark.real_data_root). Die Isolation lenkt app.loader._DATA_ROOT
+# auf eine tmp-Wurzel um; das committete Trip-Fixture wird dorthin kopiert
+# (autouse-Fixture unten). Grund: Das Laden loest die #1250-Cutover-Migration
+# aus und SCHREIBT briefings/gr221-mallorca.json — im echten Baum fuehrte das
+# je nach Host-Rechten zu PermissionError (u. a. genau das offline-Rot, das
+# die Datei auf die CI-Exclude-Liste brachte).
+
+
+@pytest.fixture(autouse=True)
+def _seed_trip_fixture(_isolate_data_root):
+    """Kopiert das committete Trip-Fixture in die isolierte Datenwurzel.
+
+    Ziel ist ``briefings/`` (seit #1250 S7a die einzige Lese-Wahrheit fuer
+    Trips, ADR-0023) — nicht das Legacy-``trips/``, das der Loader nicht
+    mehr liest. Die Abhaengigkeit auf ``_isolate_data_root`` (conftest,
+    #1133) erzwingt die Reihenfolge: erst Redirect der Datenwurzel, dann Seed.
+    """
+    from app import loader
+
+    repo_root = Path(__file__).resolve().parents[2]
+    src = repo_root / "data/users/default/trips/gr221-mallorca.json"
+    dst = (
+        Path(loader._DATA_ROOT)
+        / "users"
+        / "default"
+        / "briefings"
+        / "gr221-mallorca.json"
+    )
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
 
 
 @pytest.fixture
@@ -224,11 +252,11 @@ class TestT5SmsTokenPipeline:
             after_prefix = token_line.split(": ", 1)[1] if ": " in token_line else ""
             has_forecast = any(
                 after_prefix.startswith(tok)
-                for tok in ("N", "D", "R", "PR", "W", "G", "TH", "C")
+                for tok in ("N", "K", "D", "FN", "FK", "FD", "R", "PR", "W", "G", "TH", "C")
             )
             assert has_forecast, (
                 f"Nach dem Stage-Prefix muss ein Forecast-Token stehen "
-                f"(N/D/R/PR/W/G/TH/C), Rest war: {after_prefix!r}"
+                f"(N/K/D/FN/FK/FD/R/PR/W/G/TH/C, sms_format.md §2), Rest war: {after_prefix!r}"
             )
 
     def test_ac2_token_line_max_160_chars_via_service(self, service):


### PR DESCRIPTION
## Was

Zwei Dateien aus `.github/ci_tdd_excludes.txt` saniert und entfernt (Batch 1 des Plans in `docs/analysis/1196-tdd-excludes-sanierung-2026-08-06.md`):

### `test_epic_140_preview_endpoints.py` (24 der 38 lokal roten Tests)
- **Ursache:** Die Datei nutzte `pytest.mark.real_data_root` (Opt-out aus der #1133-Isolation). Der Lade-Pfad löst die #1250-Cutover-Migration aus und **schreibt** `briefings/gr221-mallorca.json` — im echten `data/users/`-Baum → je nach Host-Rechten `PermissionError`.
- **Fix:** Opt-out entfernt; eine autouse-Seed-Fixture kopiert das committete Trip-Fixture in die isolierte tmp-Datenwurzel (nach `briefings/`, der einzigen Lese-Wahrheit seit #1250 S7a). Reihenfolge über Fixture-Abhängigkeit auf `_isolate_data_root` erzwungen.
- **Bonus-Drift:** Der SMS-Token-Test erwartete das alte Alphabet ohne `K`/`FK`/`FD`/`FN` — an `sms_format.md` §2 angeglichen (Drift seit #1415/#1483).

### `test_issue_1165_adr_index_cleanup.py` (1 Test)
- **Ursache:** Der Wächter prüft wörtlich das alte ADR-Dateinamen-Literal; die Spec `fix_1196_s1_testnetz_entrauschen.md` zitierte es zweimal in Meta-Beschreibungen.
- **Fix:** Literale entfernt (Bedeutung als `0013-…`-Verweis erhalten). Ausnahmen des Scanners (`_archive/` + Kontext-Doku) unverändert.

## Verifikation

- Lokal offline (CI-Bedingungen): **28 passed, 1 skipped** (legitimer Skip: Vergangenheits-Trip), ruff sauber.
- Wie in PR #1551 gelernt: Der Runner entscheidet — bei unerwartetem Rot Ein-Zeilen-Revert.

Refs #1196