### PR TITLE
fix(#1552): Anlege-Seite laeuft nicht mehr in eine Effekt-Endlosschleife

### DIFF
--- a/frontend/e2e/trip-new-loads-without-effect-loop.spec.ts
+++ b/frontend/e2e/trip-new-loads-without-effect-loop.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+
+// E2E — Staging-Befund Fix-Loop 2 (Issue #1552): /trips/new stürzt beim
+// Laden, ohne jede Interaktion, mit `effect_update_depth_exceeded` ab.
+//
+// Root Cause: WeatherMetricsTab.svelte hatte einen $effect, der
+// buildWeatherPayload() aufrief -- diese Funktion liest `trip!.display_config`
+// und macht damit den `trip`-Prop zur getrackten Abhängigkeit des Effects. Im
+// Anlege-Modus ist `trip` (`stubTrip` in TripNewEditor.svelte) ein `$derived`
+// über `weatherMetrics`, das derselbe Effect via `onWeatherMetricsChange`
+// schreibt (neue Array-Referenz bei jedem Aufruf) -- Kreis: Effect liest
+// `trip` -> ruft onWeatherMetricsChange -> weatherMetrics neu -> stubTrip
+// rechnet neu -> trip-Prop ändert sich -> derselbe Effect feuert erneut.
+//
+// Danach ist die gesamte Reaktivität der Seite tot (Symptom auf Staging:
+// Tippen im Tour-Name-Feld ändert den DOM sichtbar, der State kommt nie an,
+// der Hinweis "Tour-Name fehlt" bleibt stehen).
+//
+// Kein bestehender Test hätte das gefangen: Frontend-Unit-Tests lesen nur
+// Quelltext (kein Mount, kein $effect-Lauf), serverseitig gerenderte Tests
+// führen $effect nie aus. Dieser Test lädt die Seite tatsächlich.
+//
+// RED vor dem Fix: `effect_update_depth_exceeded` als Konsolenfehler,
+// zusätzlich bleibt der "Tour-Name fehlt"-Hinweis nach dem Ausfüllen stehen.
+//
+// Ausführen (lokal, gegen den per Vite-Proxy erreichbaren Staging-Go-Server,
+// Vorbild: issue-932-activity-type-route-tab.spec.ts):
+//   cd frontend && npx playwright test e2e/trip-new-loads-without-effect-loop.spec.ts
+
+test('Staging-Befund #1552 Fix-Loop 2: /trips/new lädt ohne Konsolenfehler, Reaktivität bleibt lebendig', async ({ page }) => {
+	const consoleErrors: string[] = [];
+	page.on('console', (msg) => {
+		if (msg.type() === 'error') consoleErrors.push(msg.text());
+	});
+	const pageErrors: string[] = [];
+	page.on('pageerror', (err) => pageErrors.push(err.message));
+
+	await page.goto('/trips/new');
+	await expect(page.getByTestId('trip-new-editor')).toBeVisible();
+
+	// Die gemeldete Schleife trat OHNE jede Interaktion beim Laden auf --
+	// kurze Wartezeit, damit ein re-entrant $effect überhaupt Zeit hat, sich
+	// als Konsolenfehler zu zeigen (Svelte wirft erst nach wiederholten
+	// Zyklen `effect_update_depth_exceeded`).
+	await page.waitForTimeout(1500);
+
+	const allErrors = [...consoleErrors, ...pageErrors];
+	expect(
+		allErrors,
+		`Konsolenfehler beim Laden von /trips/new (erwartet: keine):\n${allErrors.join('\n')}`
+	).toHaveLength(0);
+
+	// Reaktivitäts-Beweis (das eigentliche Nutzersymptom): Tippen im
+	// Tour-Name-Feld muss den Hinweis "Tour-Name fehlt" verschwinden lassen.
+	// Bei toter Reaktivität ändert sich der DOM des Inputs zwar (Browser-
+	// Default-Verhalten), der Svelte-State kommt aber nie an -- der Hinweis
+	// bleibt stehen und der Weiter-Button bleibt für immer deaktiviert.
+	await expect(page.getByText('⊘ Tour-Name fehlt')).toBeVisible();
+	await page.getByTestId('trip-new-name-input-desktop').fill('E2E Fix-Loop-2 Regressionstest');
+	await expect(page.getByText('⊘ Tour-Name fehlt')).not.toBeVisible();
+});

--- a/frontend/src/lib/components/shared/WeatherMetricsTab.svelte
+++ b/frontend/src/lib/components/shared/WeatherMetricsTab.svelte
@@ -524,9 +524,34 @@
 	// (analog Kanal-Rückkanal oben). Ohne diesen Effekt verwirft der Anlege-
 	// Dialog die sichtbar angehakte Auswahl beim Speichern (kein PUT im
 	// createMode, s. handleSave()).
+	//
+	// Fix-Loop 2 (Staging-Befund, effect_update_depth_exceeded): ruft bewusst
+	// buildWeatherMetricsList() statt buildWeatherPayload() -- Letztere liest
+	// `trip!.display_config` und macht damit den `trip`-Prop zur getrackten
+	// Abhaengigkeit dieses Effects. buildWeatherMetricsList() liest `trip`
+	// gar nicht mehr.
+	//
+	// Fix-Loop 3 (Staging-Befund, Wiederauftreten trotz obigem Fix, per
+	// Playwright reproduziert und mit Instanz-Markierung isoliert): TripNew
+	// Editor.svelte mountet WeatherMetricsTab ZWEIMAL (Desktop + Mobile,
+	// Issue #941 -- beide immer im DOM, nur per CSS ausgeblendet). Beide
+	// Instanzen laden UNABHAENGIG voneinander ihren eigenen Katalog und
+	// schreiben in denselben Rueckkanal (`weatherMetrics` in TripNewEditor).
+	// Solange eine Instanz ihren Katalog noch nicht geladen hat, liefert ihr
+	// buildWeatherMetricsList() eine LEERE Liste -- die ueberschreibt die
+	// laengst gueltigen 25 Eintraege der anderen Instanz, was wiederum DEREN
+	// Effect erneut ausloest (die andere Instanz schreibt zurueck) usw.: die
+	// Gleichheitspruefung in handleWeatherMetricsChange (TripNewEditor.svelte)
+	// verhindert nur wiederholte IDENTISCHE Schreibvorgaenge EINER Instanz,
+	// nicht das Wechselspiel ZWEIER Instanzen mit UNTERSCHIEDLICHEM Inhalt.
+	// `catalogLoaded` gate schliesst das: eine Instanz, deren eigener Katalog
+	// noch nicht da ist, emittiert gar nichts -- sobald ihr Katalog laedt,
+	// berechnet sie denselben deterministischen Satz wie die andere Instanz
+	// (identischer Register-Stand), die Gleichheitspruefung erkennt dann
+	// Gleichheit und die Schreibkette kommt zur Ruhe.
 	$effect(() => {
-		if (createMode && onWeatherMetricsChange) {
-			onWeatherMetricsChange(buildWeatherPayload().metrics);
+		if (createMode && onWeatherMetricsChange && catalogLoaded) {
+			onWeatherMetricsChange(buildWeatherMetricsList());
 		}
 	});
 
@@ -642,9 +667,16 @@
 		}
 	}
 
-	function buildWeatherPayload() {
+	// Issue #1552 Fix-Loop 2 (Staging-Befund, effect_update_depth_exceeded):
+	// aus buildWeatherPayload() herausgezogen, damit der Rueckkanal-Effect
+	// unten NUR von der Metrik-Auswahl abhaengt, nicht vom `trip`-Prop. Liest
+	// bewusst NICHT `trip!.display_config` (das speiste im Payload ohnehin nur
+	// Felder AUSSER `metrics`, die hier ueberschrieben werden -- fuer die
+	// Metrik-Liste war der trip-Read nie noetig, nur ein zufaelliges
+	// Abhaengigkeits-Nebenprodukt).
+	function buildWeatherMetricsList() {
 		const baseMetrics = buildWeatherConfigMetrics(buckets, friendlyMap, horizonsMap, catalog, aggregationsMap);
-		const metrics = baseMetrics.map((m) => {
+		return baseMetrics.map((m) => {
 			if (!SMS_THRESHOLD_METRIC_IDS.includes(m.metric_id)) return m;
 			const rawThr = smsThresholds[m.metric_id];
 			const parsed = rawThr !== undefined && rawThr !== '' ? parseFloat(rawThr) : null;
@@ -653,9 +685,12 @@
 			}
 			return m;
 		});
+	}
+
+	function buildWeatherPayload() {
 		return {
 			...(trip!.display_config ?? {}),
-			metrics,
+			metrics: buildWeatherMetricsList(),
 			preset_name: selectedTemplate || undefined,
 			telegram_kurzform: telegramKurzform,
 		};

--- a/frontend/src/lib/components/shared/__tests__/weather_metrics_tab_create_mode_callback.test.ts
+++ b/frontend/src/lib/components/shared/__tests__/weather_metrics_tab_create_mode_callback.test.ts
@@ -38,26 +38,47 @@ describe('AC-1/AC-2/AC-3 (Test 3): onWeatherMetricsChange-Rückkanal im Anlege-M
 		);
 	});
 
-	test('ein $effect ruft im createMode onWeatherMetricsChange mit buildWeatherPayload().metrics auf', () => {
+	test('ein $effect ruft im createMode+catalogLoaded onWeatherMetricsChange mit buildWeatherMetricsList() auf', () => {
 		// Bewusst NICHT nur "kommt der Text vor" — die Guard-Bedingung und der
 		// übergebene Ausdruck müssen exakt zusammenhängen (derselbe Effect-Block),
 		// sonst könnte ein leerer/falscher Callback-Aufruf denselben Text streuen.
+		//
+		// Fix-Loop 3 (Staging-Befund, effect_update_depth_exceeded trotz
+		// Fix-Loop 2): der Effect ruft jetzt buildWeatherMetricsList() (liest
+		// `trip` gar nicht) statt buildWeatherPayload().metrics, UND das Guard
+		// verlangt zusaetzlich catalogLoaded -- ohne dieses Gate ueberschreiben
+		// sich die zwei WeatherMetricsTab-Mounts (Desktop+Mobile,
+		// TripNewEditor.svelte) gegenseitig, solange eine der beiden Instanzen
+		// ihren eigenen Katalog noch nicht geladen hat (leere Liste schlaegt
+		// die laengst gueltige Liste der anderen Instanz tot -- Endlosschleife
+		// per Playwright reproduziert, docs/artifacts/fix-1552-neuanlage-
+		// metrikverlust/red_effect_loop_playwright.txt).
 		const effectMatch = code.match(
-			/\$effect\(\(\)\s*=>\s*\{\s*if\s*\(createMode\s*&&\s*onWeatherMetricsChange\)\s*\{\s*onWeatherMetricsChange\(buildWeatherPayload\(\)\.metrics\);/
+			/\$effect\(\(\)\s*=>\s*\{\s*if\s*\(createMode\s*&&\s*onWeatherMetricsChange\s*&&\s*catalogLoaded\)\s*\{\s*onWeatherMetricsChange\(buildWeatherMetricsList\(\)\);/
 		);
 		assert.ok(
 			effectMatch,
-			'Kein $effect gefunden, der bei createMode && onWeatherMetricsChange ' +
-				'onWeatherMetricsChange(buildWeatherPayload().metrics) aufruft — ' +
-				'die Auswahl aus dem Anlege-Dialog würde weiterhin nicht nach oben emittiert'
+			'Kein $effect gefunden, der bei createMode && onWeatherMetricsChange && ' +
+				'catalogLoaded onWeatherMetricsChange(buildWeatherMetricsList()) aufruft'
 		);
 	});
 
 	test('der neue Effect ist NICHT identisch mit dem bestehenden onChannelsChange-Effect (eigener Block)', () => {
 		const weatherEffectCount = (
-			code.match(/\$effect\(\(\)\s*=>\s*\{\s*if\s*\(createMode\s*&&\s*onWeatherMetricsChange\)/g) ?? []
+			code.match(/\$effect\(\(\)\s*=>\s*\{\s*if\s*\(createMode\s*&&\s*onWeatherMetricsChange\s*&&\s*catalogLoaded\)/g) ?? []
 		).length;
 		assert.equal(weatherEffectCount, 1, 'Der Wetter-Metrik-Rückkanal-Effect muss genau einmal vorkommen');
+	});
+
+	test('buildWeatherMetricsList() liest trip nicht (Fix-Loop 3, Root-Cause-Guard)', () => {
+		const fnMatch = code.match(/function buildWeatherMetricsList\(\)\s*\{[\s\S]*?\n\t\}/);
+		assert.ok(fnMatch, 'buildWeatherMetricsList() nicht gefunden');
+		assert.doesNotMatch(
+			fnMatch[0],
+			/trip[!?.]/,
+			'buildWeatherMetricsList() liest trip -- damit waere trip wieder eine ' +
+				'getrackte Abhaengigkeit des Rueckkanal-Effects (Fix-Loop-2-Regression)'
+		);
 	});
 });
 

--- a/frontend/src/lib/components/trip-new/TripNewEditor.svelte
+++ b/frontend/src/lib/components/trip-new/TripNewEditor.svelte
@@ -300,6 +300,14 @@
 	// Rückkanal analog handleChannelsChange — ohne ihn verwirft der Anlege-
 	// Dialog die sichtbar angehakte Auswahl still beim Speichern.
 	function handleWeatherMetricsChange(m: WeatherConfigMetric[]) {
+		// Fix-Loop 2 (Staging-Befund effect_update_depth_exceeded): defensiv
+		// zusaetzlich zum Effect-Scope-Fix in WeatherMetricsTab.svelte --
+		// inhaltsgleicher Aufruf darf KEINE neue Array-Referenz erzeugen, sonst
+		// rechnet `stubTrip` ($derived) unnoetig neu und schleust eine neue
+		// `trip`-Prop-Referenz durch, die einen kuenftigen trip-lesenden Effect
+		// erneut ausloesen koennte. Schliesst die ganze Schleifen-Klasse aus,
+		// unabhaengig davon, was WeatherMetricsTab intern liest.
+		if (JSON.stringify(m) === JSON.stringify(weatherMetrics)) return;
 		weatherMetrics = [...m];
 	}
 

--- a/frontend/src/lib/components/trip-new/__tests__/trip_new_editor_weather_metrics_wiring.test.ts
+++ b/frontend/src/lib/components/trip-new/__tests__/trip_new_editor_weather_metrics_wiring.test.ts
@@ -25,11 +25,26 @@ const code = readFileSync(FILE, 'utf-8');
 
 describe('AC-1/AC-2/AC-3 (Test 4): handleWeatherMetricsChange schreibt weatherMetrics', () => {
 	test('ein handleWeatherMetricsChange-Handler existiert und schreibt weatherMetrics', () => {
+		// Fix-Loop 2: der Handler prueft jetzt zuerst auf Inhaltsgleichheit
+		// (JSON.stringify) und schreibt nur bei echter Aenderung -- die
+		// Zuweisung folgt deshalb nicht mehr direkt auf die oeffnende Klammer.
 		assert.match(
 			code,
-			/function handleWeatherMetricsChange\([^)]*\)\s*\{\s*weatherMetrics\s*=/,
+			/function handleWeatherMetricsChange\([^)]*\)\s*\{[\s\S]*?weatherMetrics\s*=/,
 			'Kein handleWeatherMetricsChange-Handler gefunden, der weatherMetrics schreibt — ' +
 				'ohne ihn bleibt weatherMetrics dauerhaft [] (Bug-Ursache #1552)'
+		);
+	});
+
+	test('handleWeatherMetricsChange ueberspringt inhaltsgleiche Aufrufe (Fix-Loop 2, Regressionsschutz)', () => {
+		const fnMatch = code.match(/function handleWeatherMetricsChange\([^)]*\)\s*\{[\s\S]*?\n\t\}/);
+		assert.ok(fnMatch, 'handleWeatherMetricsChange nicht gefunden');
+		assert.match(
+			fnMatch[0],
+			/JSON\.stringify\(m\)\s*===\s*JSON\.stringify\(weatherMetrics\)/,
+			'Kein Inhaltsgleichheits-Guard vor dem Schreiben -- zwei WeatherMetricsTab-' +
+				'Mounts (Desktop+Mobile) koennten sich sonst mit unterschiedlichem Inhalt ' +
+				'gegenseitig ueberschreiben (Fix-Loop-2/3-Regression, effect_update_depth_exceeded)'
 		);
 	});
 


### PR DESCRIPTION

Der Rueckkanal aus dem vorigen Commit machte /trips/new unbedienbar:
effect_update_depth_exceeded schon beim Laden, ohne jede Interaktion. Optisch
sah die Seite normal aus, war aber tot — Tippen aenderte den DOM, der Zustand
nie; der Weiter-Knopf blieb dauerhaft deaktiviert. Auf Staging zweimal in
frischen Browser-Kontexten reproduziert.

Die naheliegende Diagnose (Effekt liest trip -> stubTrip rechnet neu -> Effekt
feuert wieder) war nur der halbe Weg: nach deren Behebung blieb der Playwright-
Lauf mit demselben Fehler rot. Gemessen per Instanz-Markierung liegt die
eigentliche Ursache tiefer:

TripNewEditor mountet WeatherMetricsTab ZWEIMAL (Desktop + Mobile, #941 — beide
dauerhaft im DOM, nur per CSS ausgeblendet). Beide Instanzen laden unabhaengig
ihren eigenen Katalog und schreiben in DENSELBEN Rueckkanal. Solange eine ihren
Katalog noch nicht hat, liefert sie eine leere Liste und ueberschreibt damit die
gueltigen 25 Eintraege der anderen; deren Effekt feuert, schreibt zurueck,
unbegrenzt alternierend. Eine reine Gleichheitspruefung fangt das nicht — sie
verhindert nur wiederholt IDENTISCHE Schreibvorgaenge einer Instanz, nicht das
Wechselspiel zweier Instanzen mit unterschiedlichem Inhalt.

Drei Bausteine:
- buildWeatherMetricsList() aus buildWeatherPayload() herausgezogen; liest trip
  nicht mehr, damit der Prop keine getrackte Abhaengigkeit des Effekts ist.
- Effekt-Guard um catalogLoaded erweitert: eine Instanz ohne geladenen Katalog
  emittiert gar nichts, statt eine leere Liste zu schreiben. Sobald ihr Katalog
  da ist, berechnet sie denselben Satz wie die andere — die Kette kommt zur Ruhe.
- Inhaltsgleichheitspruefung in handleWeatherMetricsChange. Per Mutationsprobe
  belegt fuer dieses Fehlerbild redundant (Test bleibt auch ohne sie gruen);
  behalten als Schutz gegen kuenftige, andersartige Schleifen.

Der eigentliche Gewinn ist der Test: frontend/e2e/trip-new-loads-without-effect-loop.spec.ts
laedt die Seite WIRKLICH, sammelt Konsolen- und Seitenfehler und prueft
zusaetzlich das Nutzer-Symptom (Tippen laesst den Hinweis "Tour-Name fehlt"
verschwinden) — "kein Fehler geloggt" allein waere zu schwach.

Warum das noetig war: 5837 gruene Tests, Adversary VERIFIED mit 11 Mutationen,
alle 5 CI-Checks gruen — und die Seite war tot. Die Frontend-Tests pruefen
Quelltext, serverseitiges Rendern fuehrt $effect nie aus. Fuer diese Fehlerklasse
sind beide Schichten strukturell blind. PO-Vorgabe 2026-08-07: Frontend-Themen
werden immer auch im echten Browser geprueft; mechanische Durchsetzung als #1558.

Belege: RED gegen fe04f3e8 und RED auch gegen den ersten, unvollstaendigen
Reparaturversuch (beide in docs/artifacts/.../red_effect_loop_playwright.txt);
GREEN 3x wiederholt mit jeweils geloeschtem Build-Cache; Mutationsprobe am
catalogLoaded-Gate wieder rot.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Nachtrag zu #1554 (Issue #1552). Bleibt offen bis Staging-Verifikation durch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)