### PR TITLE
feat(#1492 S2b): Vertretungshinweis im Briefing sichtbar, in Klartext

### DIFF
--- a/docs/context/feat-1492-s2b-fallback-sichtbarkeit.md
+++ b/docs/context/feat-1492-s2b-fallback-sichtbarkeit.md
@@ -1,0 +1,184 @@
+# Context: feat-1492-s2b-fallback-sichtbarkeit
+
+**Workflow:** `feat-1492-s2b-fallback-sichtbarkeit` · **Issue:** #1492 Scheibe 2b
+**Gemessen am Stand:** `63383ddb` (= Prod-Stand nach Auslieferung von 2a)
+**Vorgänger:** S1 (`e34d9bc9`), S2a (`63383ddb`, ADR-0047)
+**Übergeordneter Kontext:** `docs/context/feat-1492-gewitter-fallback-kette.md` (Abschnitt
+„Scheibe 2 — PO-Entscheidungen 2026-08-06", Punkte E1/E2/E3)
+
+## Request Summary
+
+Scheibe 2a hält seit dem 2026-08-06 fest, *dass* eine Gewitter-Direktquelle vertreten wurde —
+aber nur intern in `ForecastMeta`. Der Nutzer sieht davon nichts. 2b macht die Vertretung im
+Briefing sichtbar: **E-Mail und Telegram**, in **Klartext statt Technik**, und stellt den
+bestehenden technischen Hinweis der Hauptvorhersage mit um.
+
+## Bereits entschieden (nicht neu aufmachen)
+
+| # | Entscheidung | Quelle |
+|---|---|---|
+| E1 | Kanäle: **E-Mail + Telegram**. SMS ausdrücklich ausgenommen | Kontext-Doc 2026-08-06 |
+| E2 | Klartext, **auch für den Bestandshinweis** — kein Nebeneinander zweier Stile | Kontext-Doc 2026-08-06 |
+| — | ADR-0007 („Daten statt Empfehlungen") ist nicht berührt: Herkunft ist ein Fakt | Kontext-Doc 2026-08-06 |
+| — | 2b muss **`fallback_metrics` mit auswerten**, nicht nur `fallback_model` | ADR-0047 Folgepflichten, 2a-Spec KL 3 |
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/output/renderers/email/html.py:528-539` | Erzeugt den heutigen Hinweis (HTML). Kommentar dort: „spiegelt plain.py" — **bewusst dupliziert, nicht geteilt** |
+| `src/output/renderers/email/plain.py:362-367` | Erzeugt den heutigen Hinweis (Plaintext). Identische Formatlogik |
+| `src/output/renderers/email/helpers.py:468-517` | `build_origin_footer` / `render_origin_footer_text` / `render_origin_footer_html` — **der geteilte Fußzeilen-Helper**, von *allen* Mail-Renderern benutzt (plain, compact, html, compare_html, alert/render, alert/official_alerts). Kennt heute **kein** Fallback-Konzept |
+| `src/output/renderers/email/compact.py:258-265` | Kompakt-Briefing: nutzt die geteilte Herkunfts-Fußzeile, zeigt aber **keinen** Fallback-Hinweis |
+| `src/output/renderers/email/compare_html.py:1388-1391` | Ortsvergleichs-Mail: `build_origin_footer("compare", source="Open-Meteo")` — fester String, **kein** Fallback-Hinweis |
+| `src/output/renderers/narrow.py:215-309` | `_tg_day_footer` — Telegram-Tagesfußzeile, heute ⚡/Sicht/0°C-Grenze |
+| `src/output/renderers/narrow.py:606,733-742` | `render_telegram_bubbles` — einziger Produktiv-Aufruf der Fußzeile |
+| `src/providers/thunder_enrichment.py:280-292` | Schreibstelle der Gewitter-Markierung (2a) |
+| `src/app/models.py:80-95` | `ForecastMeta.fallback_model` / `fallback_metrics` / `fallback_reason` |
+| `tests/unit/test_model_metric_fallback.py:179-255` | `TestFooterFallbackInfo` — 4 Tests, bewachen den heutigen Wortlaut |
+| `tests/tdd/test_issue_1141_cross_provider_fallback.py:430-459` | Fünfter Test auf denselben Wortlaut (`"Fallback: at_direct"`) |
+| `tests/tdd/test_telegram_footer_metric_gating.py:106-149` | 3 Tests, bewachen die Telegram-Fußzeile |
+
+## Gemessener Ist-Stand
+
+### Der Hinweis erscheint heute in 2 von 7 Ausgaben
+
+| Ausgabe | Fallback-Hinweis heute |
+|---|---|
+| Trip-Briefing E-Mail HTML (`full`) | ✅ `Fallback cape, visibility: icon_eu` |
+| Trip-Briefing E-Mail Plaintext (`full`) | ✅ derselbe Text |
+| Trip-Briefing E-Mail (`compact`) | ❌ 0 Treffer |
+| Ortsvergleichs-Mail | ❌ 0 Treffer |
+| Telegram-Langform (Bubbles) | ❌ 0 Treffer |
+| Telegram-Kurzform / SMS | ❌ 0 Treffer (bewusst, E1) |
+| Alarm-Mails (`alert/render.py`, `official_alerts.py`) | ❌ 0 Treffer |
+
+### 🔴 `fallback_metrics` mischt zwei Namenssysteme
+
+Das ist der wichtigste Einzelbefund dieser Phase. Dieselbe Liste enthält je nach Auslöser
+**unterschiedlich benannte** Einträge:
+
+| Auslöser | `fallback_reason` | Inhalt von `fallback_metrics` | Beispielwerte |
+|---|---|---|---|
+| Metrik-Lücke (#1115/WEATHER-05b) | `metric_gap` | **Open-Meteo-Parameternamen** (`_PARAM_TO_FIELD`) | `cape`, `temperature_2m`, `weather_code`, `visibility` |
+| Modell-5xx | `model_5xx` | dieselben Parameternamen | wie oben |
+| Cross-Provider-Totalausfall | `cross_provider_total_outage` | — | — |
+| Schnee-Anreicherung | `snow_geosphere` | **Feldnamen** des Datenpunkts | aus `_stamp_snow` |
+| **Gewitter-Vertretung (2a)** | `thunder_source_unavailable` | **Feldnamen** des Datenpunkts (`thunder_enrichment.py:283-285`) | `lightning_density_per_km2_3h`, `lightning_potential_lpi_jkg`, `hail_potential_grau_gsp` |
+
+**Folge für 2b:** Die Klartext-Übersetzung muss beide Namenssysteme abbilden. Und der einzige
+**zuverlässige** Nachweis einer Gewitter-Vertretung ist das Vorkommen eines der drei
+Gewitter-**Feldnamen** in `fallback_metrics` — nicht `fallback_model` (Merge-Schutz, s.u.) und
+auch nicht `fallback_reason` allein (kann im Kollisionsfall vom Grundvorhersage-Fallback belegt
+sein).
+
+Die drei Gewitter-Feldnamen sind abschließend definiert in
+`thunder_enrichment.py:36-43` (`_SIGNAL_ZU_FELD` + `_EINZELWERT_FELD`).
+
+### 🔴 Der Merge-Schutz aus 2a macht `fallback_model` unzuverlässig
+
+`thunder_enrichment.py:286-288`: `fallback_model`/`fallback_reason` werden **nur** gesetzt, wenn
+noch `None`. Liegt bereits ein Grundvorhersage-Fallback (#1115) vor, steht dort dessen
+Modellname — eine Gewitter-Vertretung hat trotzdem stattgefunden. `fallback_metrics` ist
+davon nicht betroffen (immer `extend`).
+
+Umgekehrt gilt es auch: steht in `fallback_model` ein Gewitterquellen-Name, kann gleichzeitig
+ein Metrik-Fallback in `fallback_metrics` stehen. Die heutige Formulierung
+`Fallback {metrics}: {model}` **verknüpft beide Angaben ungeprüft** und behauptet damit im
+Kollisionsfall einen Zusammenhang, den es nicht gibt. Das ist ein bestehender Darstellungsfehler,
+der durch 2a erst erreichbar wurde.
+
+### Wertebereiche für das Klartext-Mapping
+
+`fallback_model` (gemessen, alle Schreibstellen in `src/providers/`):
+
+| Wert | Woher | Bedeutung |
+|---|---|---|
+| `at_direct`, `de_direct`, `fr_direct` | `openmeteo.py:1055` (Cross-Provider-Totalausfall), `region_routing.py:33-36` | nationale Direktquelle |
+| `fr_direct`, `de_direct`, `eu_direct` | `thunder_enrichment.py:287` | Gewitter-Ersatzquelle |
+| `meteofrance_arome`, `icon_d2`, `metno_nordic`, `icon_eu`, `ecmwf_ifs04` | `openmeteo.py:1077,1167`, `REGIONAL_MODELS` | Open-Meteo-Rechenmodell |
+
+`icon_seamless` ist **kein** Fallback-Wert (nur `meta.model`).
+
+### Telegram: Datenfluss und Abgrenzung zur Kurzform
+
+- `_tg_day_footer(segments, enabled_metric_ids, *, night_weather, tz, has_gap, …)`
+  (`narrow.py:215-224`) bekommt `segments` bereits übergeben ⇒ `segments[0].timeseries.meta`
+  ist erreichbar, **keine Signaturerweiterung nötig**. Präzedenz: `plain.py:362`, `html.py:528`.
+- Die Fußzeile erscheint **einmal pro Nachrichten-Rendervorgang** (nicht pro Tag, nicht pro
+  Segment), als letzter Baustein der Kurzübersicht-Bubble (`narrow.py:733-742`).
+- Zeichengrenzen: in `narrow.py` **keine** Kürzung — nur Umbruch (`_TG_PROSE_WIDTH = 56`,
+  `_TG_TABLE_WIDTH = 32`, `_wrap()`). Harte Grenze erst auf Kanal-Ebene bei 4096 Zeichen
+  (`src/output/channels/telegram.py:18`). Eine Zusatzzeile ist unkritisch.
+- **Telegram-Kurzform erreicht `narrow.py` gar nicht:** bei `telegram_style == "kurzform"`
+  sendet `notification_service.py:353-372` den bereits gerenderten `report.sms_text`
+  (`SMSTripFormatter`, 160-Zeichen-Budget), die Bubbles werden nie gelesen. Ein Hinweis in
+  `_tg_day_footer` ist damit **strukturell** von der SMS-Ausgabe getrennt — E1 ist auf diesem
+  Weg ohne Sonderfallcode erfüllbar.
+
+## Existing Patterns
+
+- **Geteilte Fußzeile existiert schon:** `build_origin_footer` wird von allen sechs
+  Mail-Renderern aufgerufen. Es ist das etablierte Muster für „eine Aussage, alle Mail-Ausgaben".
+- **Duplikation ist der Ist-Zustand des Fallback-Hinweises:** `html.py` spiegelt `plain.py`
+  ausdrücklich per Kommentar. Das ist genau die Sorte Kopie, die die Projektregel zur
+  Code-Teilung meidet.
+- **Nicht-Kaschieren als Invariante:** ADR-0018 (Grundvorhersage), ADR-0047 (Gewitter). Beide
+  verlangen den Vermerk, keiner schreibt seinen Wortlaut fest.
+- **Herkunftsangabe als Fakt, nicht als Empfehlung:** ADR-0034 hat Zeile 2 der Fußzeile bereits
+  von „interner Renderer-Pfad" auf „reale Datenquelle" umgestellt — dieselbe Denkrichtung wie E2.
+
+## Dependencies
+
+- **Upstream:** `ForecastMeta` (`app/models.py:80-95`), befüllt von `openmeteo.py` (4 Stellen)
+  und `thunder_enrichment.py:280-292`. 2b **liest** nur — kein Eingriff in die Datenerhebung.
+- **Downstream:** alle Briefing-Mails und Telegram-Nachrichten. Kein Frontend, keine Go-API,
+  kein Datenmodell.
+
+## Existing Specs & ADRs
+
+- `docs/adr/0047-gewitter-vertretung-zwischen-direktquellen.md` — Folgepflicht „Sichtbarkeit
+  ist 2b", inkl. der `fallback_metrics`-Auflage
+- `docs/adr/0018-provider-fallback-ohne-kaschieren.md` — Ursprung der Invariante
+- `docs/adr/0034-herkunftsfusszeile-reale-datenquelle.md` — geteilte Fußzeile, Zeile-2-Regel
+- `docs/adr/0025-eine-gewitter-quelle-fuer-alle-briefing-kanaele.md` — Abgrenzung
+- `docs/specs/modules/feat_1492_s2a_thunder_vertretung.md` — KL 3 (Übergabe an 2b)
+- `docs/specs/modules/model_metric_fallback.md` — Spec des Bestandsmechanismus
+
+## Risks & Considerations
+
+1. **Fünf Bestandstests brechen planmäßig** (4× `test_model_metric_fallback.py:213-255`,
+   1× `test_issue_1141_cross_provider_fallback.py:430-459`). Sie prüfen `"fallback" in
+   body.lower()` und den Rohwert `"icon_eu"`/`"at_direct"`. Sie müssen **mitgezogen**, nicht
+   gelöscht werden — sie bewachen echte Zusicherungen (u.a. das `" : "`-Artefakt aus #1145).
+   ⚠️ `test_no_fallback_no_hint` überlebt eine Eindeutschung wörtlich, bewacht danach aber
+   nichts mehr Substanzielles — er braucht eine neue Prüfung gegen den deutschen Text.
+
+2. **Renderer-Commit-Gate #811 greift.** `src/output/renderers/email/*.py` steht auf der
+   Sperrliste. Vor dem Commit müssen `tests/tdd/test_issue_811_mode_matrix.py` grün sein und
+   ein `briefing_mail_validator.py`-Lauf gegen eine echt zugestellte Staging-Mail bestanden
+   haben.
+
+3. **Umfangsfrage, die die Spec beantworten muss:** 2 von 7 Ausgaben zeigen den Hinweis heute.
+   Wird der Hinweis auf Kompakt-Mail / Ortsvergleichs-Mail ausgedehnt (E1 sagt „E-Mail", nicht
+   „Trip-Briefing-Vollversion"), wächst der Umfang deutlich. Vorschlag zur Entscheidung durch
+   den PO.
+
+4. **Regel zur Trip/Compare-Teilung:** Eine dritte Kopie der Formulierungslogik (Telegram)
+   neben den zwei bestehenden wäre ein Verstoß. Der geteilte Ort ist bereits vorhanden
+   (`email/helpers.py`) — allerdings ist er ein *E-Mail*-Modul, während Telegram ihn ebenfalls
+   braucht. Die Ablage der geteilten Funktion ist eine bewusste Entscheidung für die Spec.
+   Zusätzlich: `pendant_gate.py` blockiert neue Dateien mit `trip_`/`compare_`-Präfix unter
+   `src/output/renderers/**` — ein neutraler Name ist Pflicht.
+
+5. **Wortlaut ist PO-Sache.** Die Übersetzung technischer Kennungen (`eu_direct`,
+   `meteofrance_arome`, `cape`) in Klartext ist eine Produktentscheidung, keine technische.
+   Die Spec legt eine vollständige Tabelle zur Freigabe vor.
+
+6. **Der ungeprüfte Zusammenhang** zwischen `fallback_metrics` und `fallback_model` (s.o.)
+   ist ein bestehender Darstellungsfehler. Ob 2b ihn mitbehebt oder als eigener Befund
+   gebucht wird, entscheidet die Spec.
+
+7. **Telegram-Kurzform bleibt ohne Hinweis** — sie sendet den SMS-Text. Fachlich konsistent mit
+   E1 (160-Zeichen-Budget), aber ein Nutzer mit `telegram_style="kurzform"` bekommt „Telegram"
+   und trotzdem keinen Hinweis. Als Known Limitation festzuhalten.

--- a/docs/specs/modules/feat_1492_s2b_fallback_sichtbarkeit.md
+++ b/docs/specs/modules/feat_1492_s2b_fallback_sichtbarkeit.md
@@ -1,0 +1,633 @@
+---
+entity_id: feat_1492_s2b_fallback_sichtbarkeit
+type: module
+created: 2026-08-06
+updated: 2026-08-06
+status: draft
+version: "1.0"
+tags: [gewitter, fallback, sichtbarkeit, email, telegram, s2b]
+workflow: feat-1492-s2b-fallback-sichtbarkeit
+---
+
+# Fallback-Sichtbarkeit: Gewitter- und Grundvorhersage-Vertretung im Klartext-Briefing
+
+## Approval
+
+- [x] Approved — PO-Freigabe 2026-08-07 (Orchestrierer-Sitzung, Beleg als
+  Kommentar an Issue #1492). Freigegeben: die zehn Acceptance Criteria auf
+  Deutsch, der Ausgaben-Umfang (Trip-Mail Vollversion + Kompakt + Telegram-
+  Langform; **ohne** Ortsvergleich, Alarm-Mails, SMS, Telegram-Kurzform), der
+  Wortlaut-Stil „Quelle in Klartext + Folge in Klammern", sowie
+  `loc_limit_override = 400` mit der ausdrücklichen Auflage, den Testumfang
+  dafür **nicht** zu kürzen.
+
+## Purpose
+
+Scheibe 2a (`feat_1492_s2a_thunder_vertretung.md`, ADR-0047) hält seit dem
+2026-08-06 intern fest, *dass* eine Gewitter-Direktquelle vertreten wurde —
+in `ForecastMeta.fallback_model` / `fallback_metrics` / `fallback_reason`.
+Der Nutzer sieht davon nichts, weil kein Renderer diese Felder für die
+Gewitter-Domäne liest. Diese Scheibe macht die Vertretung in drei
+Briefing-Ausgaben sichtbar (Trip-Mail Vollversion, Trip-Mail Kompakt,
+Telegram-Langform), stellt dabei den bestehenden technischen
+Grundvorhersage-Hinweis (`Fallback {metrics}: {model}`) auf Klartext um
+und behebt gleichzeitig einen Darstellungsfehler: die heutige Formulierung
+verknüpft `fallback_metrics` und `fallback_model` ungeprüft, obwohl beide
+im Kollisionsfall aus zwei unabhängigen Mechanismen stammen können. Issue
+#1492 Scheibe 2b.
+
+## Source
+
+- **File:** `src/output/renderers/fallback_notice.py` (neu, geteilte
+  Formulierungslogik), `src/output/renderers/email/plain.py`,
+  `src/output/renderers/email/html.py`, `src/output/renderers/email/compact.py`,
+  `src/output/renderers/narrow.py`
+- **Identifier:** `fallback_notice.build_fallback_lines` (neu),
+  `TripReportFormatter.format_email` (Plain/HTML-Aufrufpfad, unverändert),
+  `_tg_day_footer` (Telegram-Aufrufpfad, erweitert)
+
+> **Schicht-Hinweis:** Reine Python-Core-Renderer-Schicht
+> (`src/output/renderers/`). Keine Go-API, kein Frontend, kein
+> Datenmodell-Eingriff — es werden ausschließlich bereits vorhandene
+> `ForecastMeta`-Felder gelesen (`app/models.py:90-95`), keine neuen
+> geschrieben.
+
+## Bezug
+
+- ADR-0018 (`docs/adr/0018-provider-fallback-ohne-kaschieren.md`) —
+  Ursprung der Nicht-Kaschieren-Invariante für den Grundvorhersage-Fallback.
+- ADR-0047 (`docs/adr/0047-gewitter-vertretung-zwischen-direktquellen.md`) —
+  Folgepflicht „Sichtbarkeit ist 2b", inkl. der `fallback_metrics`-Auflage.
+- ADR-0034 (`docs/adr/0034-herkunftsfusszeile-reale-datenquelle.md`) —
+  bestehendes Muster „Herkunftsangabe als Fakt, nicht als Empfehlung".
+- ADR-0025 (`docs/adr/0025-eine-gewitter-quelle-fuer-alle-briefing-kanaele.md`) —
+  betrifft die Ausgabequelle (`dp.thunder_level`), nicht die
+  Herkunftsanzeige der Rohsignal-Felder; von dieser Scheibe unberührt.
+- Issue #1492 (Kopf-Issue, Scheibe 2b).
+
+## Estimated Scope
+
+- **LoC:** Produktivcode ~110–130 (`fallback_notice.py` ~70 inkl.
+  Übersetzungstabellen und Kollisionslogik, `plain.py`/`html.py`/`compact.py`
+  je ~5–10 Zeilen Verpackung, `narrow.py` ~15–20 Zeilen). Tests ~140–180
+  (neue Formulierungslogik-Suite `test_fallback_notice.py` ~90–110, plus
+  Ergänzungen/Anpassungen der drei Renderer-Suiten). **Zusammen ~250–310
+  LoC.**
+- **Files:** 1 neu (`fallback_notice.py`), 4 geändert
+  (`plain.py`, `html.py`, `compact.py`, `narrow.py`), 3 Testdateien
+  geändert (`test_model_metric_fallback.py`,
+  `test_issue_1141_cross_provider_fallback.py`,
+  `test_telegram_footer_metric_gating.py` sofern Ergänzung dort statt in
+  neuer Datei nötig), 1 Testdatei neu (`test_fallback_notice.py`), 2
+  Doku-Stellen (`docs/reference/api_contract.md`,
+  `docs/reference/decision_matrix.md` — sofern der alte technische Wortlaut
+  dort zitiert wird, zählt nicht gegen LoC).
+- **Effort:** medium (drei Ausgabeorte, eine geteilte Formulierungslogik,
+  fünf Bestandstests müssen mitgezogen werden, Renderer-Commit-Gate #811
+  greift).
+- **LoC-Einschätzung ehrlich:** Die Schätzung (~250–310) liegt an oder
+  knapp über dem Standard-Limit von 250 LoC/Workflow. Ob ein
+  `loc_limit_override` nötig wird, entscheidet der PO nach Prüfung des
+  tatsächlichen Diffs — hier keine Vorfestlegung.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `app.models.ForecastMeta.{fallback_model,fallback_metrics,fallback_reason}` | Datenmodell | Bereits vorhanden (#1115/ADR-0018, erweitert 2a/ADR-0047) — diese Scheibe **liest nur**, schreibt kein neues Feld |
+| `providers.thunder_enrichment._SIGNAL_ZU_FELD` / `_EINZELWERT_FELD` | intern | Quelle der Wahrheit für die drei Gewitter-Feldnamen (`thunder_enrichment.py:36-43`): `lightning_density_per_km2_3h`, `lightning_potential_lpi_jkg`, `hail_potential_grau_gsp` |
+| `providers.openmeteo.OpenMeteoProvider._PARAM_TO_FIELD` | intern | Quelle der Wahrheit für die Open-Meteo-Parameternamen in `fallback_metrics` bei Grundvorhersage-Fallbacks (`openmeteo.py:378-398`, 18 Einträge) |
+| `output.renderers.email.helpers.build_origin_footer` | intern | Bestehende, geteilte Herkunfts-Fußzeile (Zeile 2: reale Datenquelle) — bleibt unverändert, der neue Fallback-Hinweis ist ein zusätzlicher, davon unabhängiger Baustein |
+| `output.renderers.trip_report.TripReportFormatter.format_email` | intern | Bestehender Aufrufpfad für Plain/HTML — unverändert in der Signatur |
+| `output.renderers.narrow.render_telegram_bubbles` / `_tg_day_footer` | intern | Bestehender Telegram-Aufrufpfad — `segments` ist bereits vorhanden, keine Signaturerweiterung nötig |
+| `pendant_gate.py` (Commit-Gate) | Tooling | Blockiert `trip_`/`compare_`-präfigierte Neuanlagen unter `src/output/renderers/**` — `fallback_notice.py` ist bewusst neutral benannt, kein Verstoß |
+| `renderer_mail_gate.py` (Commit-Gate #811) | Tooling | Löst bei jedem Commit auf `email/plain.py`, `email/html.py`, `email/compact.py` aus — Voraussetzung: `test_issue_811_mode_matrix.py` grün + `briefing_mail_validator.py`-Lauf bestanden |
+
+## Implementation Details
+
+**R6 — Geteiltes Modul statt dritter Kopie.** Heute dupliziert `html.py`
+die Formulierungslogik von `plain.py` bewusst (Kommentar „spiegelt
+plain.py"). Eine dritte, unabhängige Kopie für Telegram wäre ein Verstoß
+gegen die Projektregel zur Code-Teilung. Neues Modul
+`src/output/renderers/fallback_notice.py` liefert **fertige Textzeilen**;
+die drei Renderer bestimmen nur noch die Verpackung (HTML-`div` /
+Plaintext-Zeile / Telegram-Zeile unter der Tagesfußzeile). Der Name trägt
+bewusst **kein** `trip_`/`compare_`-Präfix, weil `pendant_gate.py`
+präfigierte Neuanlagen unter `src/output/renderers/**` blockiert — das
+Modul ist ohnehin kein Trip/Compare-Pendant-Fall (Telegram und Mail teilen
+sich EIN Modul, keine zwei parallelen Bauteile). Die Ablage liegt bewusst
+**nicht** in `email/helpers.py`: dieses Modul gehört zum E-Mail-Zweig
+(`src/output/renderers/email/`), Telegram (`narrow.py`) liegt aber eine
+Ebene höher und importiert heute nichts aus `email/`. Ein gemeinsamer Ort
+auf der Ebene *über* beiden Kanal-Zweigen vermeidet einen Import von
+Telegram-Code in ein E-Mail-Modul oder umgekehrt.
+
+**Öffentliche Funktion:**
+
+```
+def build_fallback_lines(meta: ForecastMeta) -> list[str]:
+    """Liefert 0, 1 oder 2 fertige Klartext-Zeilen zur Herkunfts-
+    Vertretung. Reine Funktion, kein Rendering-Format -- die drei
+    Renderer entscheiden selbst ueber Verpackung (HTML/Plain/Telegram)."""
+```
+
+**R1 — Zwei unabhängige Zeilen:**
+
+1. *Gewitterzeile* — erscheint genau dann, wenn `meta.fallback_metrics`
+   mindestens einen der drei Gewitter-Feldnamen enthält
+   (`lightning_density_per_km2_3h`, `lightning_potential_lpi_jkg`,
+   `hail_potential_grau_gsp` — Quelle der Wahrheit:
+   `thunder_enrichment.py:36-43`, `_SIGNAL_ZU_FELD` + `_EINZELWERT_FELD`,
+   **nicht** hartkodiert in `fallback_notice.py`, sondern von dort
+   importiert, damit eine künftige vierte Gewittergröße automatisch erkannt
+   wird).
+2. *Wetterzeile* — erscheint genau dann, wenn `meta.fallback_model`
+   gesetzt ist UND `meta.fallback_reason != "thunder_source_unavailable"`.
+
+**R2 — Warum nicht `fallback_model` für die Gewitterzeile.** 2a setzt
+`fallback_model`/`fallback_reason` nur, wenn sie noch `None` sind
+(Merge-Schutz gegen #1115, `thunder_enrichment.py:217-219`). Hat zuvor ein
+Grundvorhersage-Fallback geschrieben, steht dort dessen Modellname, obwohl
+eine Gewitter-Vertretung stattfand. `fallback_metrics` ist davon nicht
+betroffen (immer `extend`) — deshalb ist es die einzige zuverlässige
+Erkennung der Gewitterzeile (ADR-0047 Folgepflicht, 2a-Spec KL-3).
+
+**R3 — Kollisionsfall.** Haben beide Mechanismen gefeuert, erscheinen
+BEIDE Zeilen. Die Gewitterzeile nennt dann **keinen** Quellennamen:
+„Gewitterdaten von einer Ersatzquelle (gröbere Auflösung)" — der Name der
+tatsächlichen Ersatzquelle (`eu_direct`) ist über die verfügbaren Felder
+nicht zuverlässig rekonstruierbar, weil `fallback_model` in diesem Fall
+bereits vom Grundvorhersage-Mechanismus belegt ist. Die Gewitterzeile darf
+**niemals** `meta.fallback_model` lesen oder anzeigen, wenn die
+Wetterzeile aktiv ist — das wäre der Name des falschen Ersatzmodells. Der
+Renderer leitet die Gewitterquelle auch nicht aus Koordinaten/der
+Routing-Tabelle (`thunder_routing.thunder_provider_for`) ab — das wäre
+eigene Fachlogik im Ausgabe-Kanal und verstieße gegen ADR-0025 (eine
+Gewitter-Quelle für die Ausgabe, keine Parallel-Ableitung).
+
+**R4 — Metrikliste der Wetterzeile.** `meta.fallback_metrics` **abzüglich**
+der drei Gewitter-Feldnamen, in Klartext übersetzt (Tabelle unten). Ist
+die Restliste nach Abzug leer, entfällt die Klammer **ersatzlos** — kein
+`()`, kein `Wetterzeile: `-Präfix ohne Inhalt. Das behebt/erhält das
+`" : "`-Artefakt aus #1145.
+
+**R5 — Behobener Darstellungsfehler.** Die heutige Zeile
+`Fallback {metrics}: {model}` (`plain.py:365`, `html.py:533`) verknüpft
+Metrikliste und Modellnamen ungeprüft in einem String und behauptet im
+Kollisionsfall (Gewitter-Metrik + Grundvorhersage-Modell gleichzeitig in
+`fallback_metrics`) einen Zusammenhang, den es nicht gibt. R1–R4 beheben
+das mit; ausdrücklich Teil des Umfangs dieser Scheibe, kein separater
+Nebenbefund.
+
+**R7 — Unbekannte Werte brechen nichts.** Für eine Modell- oder
+Metrik-Kennung ohne hinterlegte Übersetzung erscheint der Rohwert
+unverändert (kein `KeyError`, kein `.get(..., "")` das den Eintrag
+verschluckt) — kein Absturz, keine stille Auslassung.
+
+**R8 — Datenzugriff ohne Signaturerweiterung.** `segments` ist in allen vier
+Ausgaben bereits erreichbar (Belege: `plain.py:362`, `html.py:528`,
+`compact.py:259`, `narrow.py:215-224`/`733-742`) — keine
+Signaturerweiterung nötig.
+
+**R9 — EINE Segmentauswahl für alle vier Ausgaben (Fix-Loop-Nachtrag
+2026-08-07, Adversary-Befund F001).** Die Erstumsetzung hatte ZWEI
+Auswahlregeln: die drei Mail-Renderer lasen starr `segments[0]`,
+`narrow.py` das erste fehlerfreie Segment mit Zeitreihe. Für einen Trip,
+dessen erstes Segment einen Abruffehler hat und dessen zweites eine
+Vertretung trägt, zeigte Telegram den Hinweis und die Mail nichts.
+
+Beide Varianten sind falsch, nicht nur eine: „erstes Segment" — in
+jeder Spielart — verschweigt eine Vertretung, die erst eine spätere
+Etappe betraf, und zwar in allen Kanälen gleichermaßen still. Das
+widerspricht ADR-0018/ADR-0047 („Fallback ohne Kaschieren"), also dem
+Zweck dieser Scheibe.
+
+Verbindlich ist deshalb die geteilte Funktion
+`fallback_notice.select_fallback_meta(segments)`: sie durchsucht **alle**
+Segmente und liefert das **erste** `meta` mit einer Fallback-Markierung
+(`fallback_model` gesetzt ODER `fallback_metrics` nicht leer); findet sie
+keines, liefert sie `None`. Ein Segment ohne Zeitreihe wird
+**übersprungen**, nicht als Abbruch behandelt. Alle vier Ausgaben
+benutzen ausschließlich diese Funktion — keine kanal-eigene Segmentwahl
+mehr.
+
+**R10 — Der Hinweis darf das Briefing nicht mitreißen (Fix-Loop-Nachtrag
+2026-08-07, Adversary-Befund F002).** `_gewitter_felder()` importierte
+`providers.thunder_enrichment` bei **jedem** Aufruf mit `meta != None` —
+auch im Normalfall ganz ohne Fallback. Ein kaputter Provider-Import riss
+damit die gesamte Mail- und Telegram-Rendering-Kette mit, für Trips ohne
+jeden Fallback. Zwei Vorkehrungen: (a) der Import läuft nur bei
+nicht-leerer `fallback_metrics`, (b) er ist gegen `ImportError`
+abgesichert — schlägt er fehl, entfällt die Gewitterzeile und das
+Briefing rendert weiter. Begründung: **ADR-0047 Entscheidung 3** hält
+fest, dass ein Ausfall der Gewitterquelle die Grundvorhersage nie kippen
+darf; für den Anzeigeweg gilt dasselbe Prinzip. Die Herleitung der
+Feldnamen aus dem Produktivcode (SSoT, R1) bleibt im Normalfall
+unverändert erhalten — sie entfällt nur im Fehlerfall.
+
+**R11 — Keine falsche Zuschreibung: lieber gar keine Werte nennen
+(Fix-Loop-Nachtrag 2026-08-07, Adversary-Befund F003).** Fällt der
+Provider-Import aus (R10), kennt die Formulierungsfunktion die
+Gewitter-Feldnamen nicht mehr und kann Gewitter- von Wetterwerten nicht
+mehr **trennen**. Der R4-Abzug greift dann nicht: im Kollisionsfall
+(`fallback_metrics` trägt gleichzeitig einen Gewitter- und einen
+Nicht-Gewitter-Feldnamen) landete der Gewitter-Feldname in der Klammer
+der **Wetterzeile** und wurde damit dem Ersatzmodell der Grundvorhersage
+zugeschrieben — einer Quelle, die mit den Blitzdaten nichts zu tun hat
+(AC-8-Verstoß).
+
+Regel: **ist die Trennung nicht möglich, entfällt die Klammer der
+Wetterzeile vollständig.** Die Zeile lautet dann nur noch
+`Einzelne Wetterwerte von Ersatzmodell: <Quelle>`. Weniger Information
+ist hinnehmbar, eine falsche Zuschreibung nicht.
+
+Umsetzung: `_gewitter_felder()` unterscheidet „nicht ermittelbar"
+(`None`) von „ermittelt, es gibt keine" (leeres `frozenset`). Bewusst
+**keine** Rückfall-Konstante mit den drei bekannten Feldnamen: das wäre
+eine zweite Wahrheitsquelle und würde genau die SSoT-Eigenschaft
+aufweichen, wegen der R1 so gebaut ist.
+
+**Wortlaut-Muster (PO-Auswahl, E2 — Klartext auch für den
+Bestandshinweis):**
+
+```
+Gewitterdaten von Ersatzquelle: DWD Europa (gröbere Auflösung)
+Einzelne Wetterwerte von Ersatzmodell: DWD Europa (Wolken, Sicht)
+```
+
+Kollisionsfall (R3), Gewitterzeile ohne Quelle:
+
+```
+Gewitterdaten von einer Ersatzquelle (gröbere Auflösung)
+Einzelne Wetterwerte von Ersatzmodell: DWD Europa (Wolken, Sicht)
+```
+
+Verpackung je Kanal:
+
+- **Plain/Compact:** je eine eigene Zeile im Footer-Block, an derselben
+  Stelle, an der heute `Fallback {metrics}: {model}` steht.
+- **HTML:** derselbe `fallback_row`-`<div>`, eine `<div>` je Zeile (0–2
+  `<div>`s statt heute maximal 1).
+- **Telegram:** dieselbe(n) Zeile(n), als eigene Zeile(n) **unter** der
+  bestehenden Tagesfußzeile (`⚡ … · Sicht … · 0°C-Grenze …`) in derselben
+  Kurzübersicht-Bubble, vor dem `_tg_vortag_line`-Block. Kein `_wrap()`
+  auf über 56 Zeichen nötig, da die Zeilen kurz sind — sofern doch
+  Umbruch nötig wird, gilt dasselbe `_wrap(..., _TG_PROSE_WIDTH)`-Muster
+  wie für die übrigen Kurzübersicht-Zeilen.
+
+**Übersetzungstabelle Quellen (`fallback_model` → Klartext):**
+
+| Rohwert | Klartext | Zusatz |
+|---|---|---|
+| `eu_direct` | DWD Europa | (gröbere Auflösung) |
+| `de_direct` | DWD Deutschland | — |
+| `fr_direct` | Météo-France | — |
+| `at_direct` | GeoSphere Österreich | — |
+| `icon_eu` | DWD Europa | (gröbere Auflösung) |
+| `icon_d2` | DWD Deutschland | — |
+| `meteofrance_arome` | Météo-France | — |
+| `metno_nordic` | MET Norway | — |
+| `ecmwf_ifs04` | ECMWF | (gröbere Auflösung) |
+| alles andere | Rohwert unverändert (R7) | — |
+
+**Übersetzungstabelle Metriken (`fallback_metrics` → Klartext).**
+Vollständig gegenüber allen 18 Einträgen von
+`OpenMeteoProvider._PARAM_TO_FIELD` (`openmeteo.py:378-398`) plus den
+beiden Schnee-Feldnamen und den drei Gewitter-Feldnamen (letztere nur zur
+Vollständigkeit der Tabelle — sie erscheinen wegen R4 nie in der
+Wetterzeile, nur zur Erkennung der Gewitterzeile relevant):
+
+| Rohwert | Klartext |
+|---|---|
+| `temperature_2m` | Temperatur |
+| `apparent_temperature` | gefühlte Temperatur |
+| `relative_humidity_2m` | Luftfeuchtigkeit |
+| `dewpoint_2m` | Taupunkt |
+| `pressure_msl` | Luftdruck |
+| `cloud_cover` | Bewölkung |
+| `cloud_cover_low` | Tiefe Wolken |
+| `cloud_cover_mid` | Mittelhohe Wolken |
+| `cloud_cover_high` | Hohe Wolken |
+| `wind_speed_10m` | Wind |
+| `wind_direction_10m` | Windrichtung |
+| `wind_gusts_10m` | Böen |
+| `precipitation` | Niederschlag |
+| `precipitation_probability` | Niederschlagswahrscheinlichkeit |
+| `visibility` | Sicht |
+| `cape` | Gewitterenergie |
+| `freezing_level_height` | 0°C-Grenze |
+| `uv_index` | UV-Index |
+| `weather_code` | Wetterlage |
+| `snow_depth` | Schneehöhe |
+| `swe_tot` | Wasseräquivalent Schnee |
+| `lightning_density_per_km2_3h` | Blitzdichte |
+| `lightning_potential_lpi_jkg` | Blitzpotenzial |
+| `hail_potential_grau_gsp` | Hagelsignal |
+| alles andere | Rohwert unverändert (R7) | — |
+
+**Ergänzt gegenüber der Startliste des Auftrags:** `relative_humidity_2m`
+(Luftfeuchtigkeit), `dewpoint_2m` (Taupunkt), `pressure_msl` (Luftdruck),
+`cloud_cover_low` (Tiefe Wolken), `cloud_cover_mid` (Mittelhohe Wolken),
+`cloud_cover_high` (Hohe Wolken), `wind_direction_10m` (Windrichtung) —
+alle sieben stammen aus `_PARAM_TO_FIELD` (`openmeteo.py:378-398`) und
+fehlten in der ursprünglichen Tabelle des Auftrags; die Klartext-Labels
+sind identisch zu den bestehenden `label_de`-Werten in
+`app/metric_catalog.py` übernommen (Zeilen 165/178/382/397/412/233/485),
+damit derselbe Begriff nicht doppelt benannt im System existiert.
+
+## Expected Behavior
+
+- **Input:** Ein Segment, dessen `timeseries.meta` (a) keinen, (b) nur
+  einen Gewitter-, (c) nur einen Grundvorhersage-, oder (d) beide
+  Fallback-Typen trägt.
+- **Output:** Je nach Fall 0, 1 oder 2 Klartext-Zeilen in der Mail
+  (Vollversion HTML+Text, Kompakt) bzw. in der Telegram-Kurzübersicht-
+  Bubble. Kein technischer Rohwert (`icon_eu`, `at_direct`, `cape`,
+  `Fallback`) mehr sichtbar außer im R7-Fallback-Fall einer unbekannten
+  Kennung.
+- **Side effects:** Keine. Reine Lesefunktion auf bereits vorhandenen
+  Feldern, kein zusätzlicher Abruf, keine Zustandsänderung.
+
+## Test Plan
+
+### Bestandstests, die planmäßig brechen und MITGEZOGEN werden müssen
+
+| Test | Datei:Zeile | Zu erhaltende Zusicherung |
+|---|---|---|
+| `test_html_footer_shows_fallback` | `tests/unit/test_model_metric_fallback.py:214` | HTML-Mail zeigt bei gesetztem Grundvorhersage-Fallback einen Herkunftshinweis — Assertion wechselt von `"fallback" in html.lower()` + `"icon_eu" in html` auf den neuen deutschen Wortlaut + `"DWD Europa"` |
+| `test_plain_footer_shows_fallback` | `tests/unit/test_model_metric_fallback.py:224` | Dasselbe für die Plaintext-Mail |
+| `test_footer_empty_metrics_no_colon_artifact` | `tests/unit/test_model_metric_fallback.py:234` | Bewacht Bug #1145 (kein `" : "`-Artefakt bei leerer `fallback_metrics`) — Zusicherung bleibt inhaltlich erhalten, Assertion auf deutschen Wortlaut umgestellt: bei leerer Restliste nach R4-Abzug entfällt die Klammer ersatzlos, keine leere Klammer `()`, kein `: ` ohne Inhalt |
+| `test_no_fallback_no_hint` | `tests/unit/test_model_metric_fallback.py:248` | ⚠️ Überlebt eine Eindeutschung wörtlich, bewacht danach aber nichts mehr — er sucht `"fallback" not in body.lower()`, was im deutschen Text nie vorkommt. MUSS auf den deutschen Wortlaut umgestellt werden (z. B. `"Ersatzquelle" not in body` UND `"Ersatzmodell" not in body`), sonst ist er ein Test, der nicht mehr scheitern kann (Regel „Test, der nicht scheitern KANN, bewacht nichts") |
+| `test_plain_email_footer_no_leading_colon_on_empty_metrics` | `tests/tdd/test_issue_1141_cross_provider_fallback.py:430` | Bewacht denselben #1145-Fall für den Cross-Provider-Totalausfall-Pfad (`fallback_model="at_direct"`, leere `fallback_metrics`) — Assertion auf `"GeoSphere Österreich"` statt `"at_direct"`, Leerzeichen-vor-Doppelpunkt-Artefakt bleibt verboten |
+
+### Automatisierte Tests (TDD RED) — neu
+
+Testdatei-Namen nach **Verhalten**, nicht nach Issue-Nummer
+(`test_naming_gate.py` blockt Issue-nummerierte Neuanlagen hart).
+
+- [ ] `tests/unit/test_fallback_notice.py::test_no_fallback_returns_no_lines` —
+  GIVEN `ForecastMeta` ohne jeden Fallback WHEN `build_fallback_lines`
+  aufgerufen wird THEN liefert die Funktion eine leere Liste.
+- [ ] `tests/unit/test_fallback_notice.py::test_thunder_only_shows_thunder_line_with_source` —
+  GIVEN `fallback_metrics=["lightning_potential_lpi_jkg"]`,
+  `fallback_model="eu_direct"`, `fallback_reason="thunder_source_unavailable"`
+  WHEN `build_fallback_lines` läuft THEN enthält die Rückgabe genau eine
+  Zeile mit „DWD Europa" und keine zweite Zeile.
+  🔧 **Korrigiert 2026-08-07 (Befund aus der RED-Phase).** Die Erstfassung
+  gab `fallback_model=None` vor und verlangte trotzdem den Quellennamen
+  „DWD Europa" — unerfüllbar, weil ohne `fallback_model` kein Name
+  vorliegt und R3 jede andere Ableitung verbietet. Nachgemessen an
+  `thunder_enrichment.py:286-288`: im Gewitter-**Alleinfall** sind die
+  Singularfelder noch unbesetzt, 2a schreibt also sehr wohl
+  `fallback_model="eu_direct"` **und**
+  `fallback_reason="thunder_source_unavailable"`. Genau dadurch
+  unterdrückt R1.2 die Wetterzeile, und die Gewitterzeile darf den Namen
+  führen — der Verzicht auf den Namen nach R3 gilt **ausschließlich** im
+  Kollisionsfall. Der Fixture-Zustand bildet damit ab, was das Produkt
+  tatsächlich schreibt.
+- [ ] `tests/unit/test_fallback_notice.py::test_weather_only_shows_weather_line_translated` —
+  GIVEN `fallback_model="icon_eu"`, `fallback_reason="model_5xx"`,
+  `fallback_metrics=["cape", "visibility"]` WHEN `build_fallback_lines`
+  läuft THEN enthält die Rückgabe genau eine Zeile mit „Gewitterenergie,
+  Sicht" und „DWD Europa", kein `icon_eu`, kein `Fallback`.
+- [ ] `tests/unit/test_fallback_notice.py::test_collision_shows_both_lines_thunder_without_source` —
+  GIVEN `fallback_metrics=["cape", "lightning_potential_lpi_jkg"]`,
+  `fallback_model="icon_eu"`, `fallback_reason="model_5xx"` (Grundvorhersage
+  hat zuerst geschrieben) WHEN `build_fallback_lines` läuft THEN enthält
+  die Rückgabe zwei Zeilen; die Gewitterzeile enthält NICHT „DWD Europa"
+  oder „icon_eu"; die Wetterzeile enthält „Gewitterenergie" (aus `cape`),
+  NICHT „Blitzpotenzial" (Gewitter-Feldname wurde nach R4 abgezogen).
+- [ ] `tests/unit/test_fallback_notice.py::test_weather_line_empty_bracket_omitted` —
+  GIVEN `fallback_model="at_direct"`, `fallback_metrics=[]` WHEN
+  `build_fallback_lines` läuft THEN enthält die Wetterzeile keine Klammer
+  `()` und kein doppeltes Leerzeichen/Doppelpunkt-Artefakt.
+- [ ] `tests/unit/test_fallback_notice.py::test_unknown_model_shows_raw_value` —
+  GIVEN `fallback_model="unbekanntes_modell_xyz"`,
+  `fallback_metrics=["ein_unbekanntes_feld"]` WHEN `build_fallback_lines`
+  läuft THEN enthält die Wetterzeile den Rohwert `unbekanntes_modell_xyz`
+  und `ein_unbekanntes_feld` unverändert (R7), kein Absturz.
+- [ ] `tests/unit/test_model_metric_fallback.py::test_compact_footer_shows_fallback` (neu, in
+  bestehender Datei ergänzt) — GIVEN Kompakt-Mail mit gesetztem
+  `fallback_model` WHEN `TripReportFormatter.format_email` den
+  Kompakt-Body rendert THEN enthält der Body die deutsche Wetterzeile
+  (heute: 0 Treffer, s. Kontext-Doc „2 von 7 Ausgaben").
+- [ ] `tests/tdd/test_telegram_footer_metric_gating.py` (ergänzt) —
+  GIVEN Segmente mit `meta.fallback_metrics` enthält
+  `lightning_potential_lpi_jkg` WHEN `render_telegram_bubbles` die
+  Kurzübersicht-Bubble baut THEN enthält deren Text die Gewitterzeile
+  unter der bestehenden `⚡ …`-Fußzeile; GEGENPROBE: ohne Fallback keine
+  zusätzliche Zeile.
+
+Muster für echte Renderer-Aufrufe (keine Mock-Theater): analog
+`TestFooterFallbackInfo._make_segment_data`
+(`tests/unit/test_model_metric_fallback.py:182-212`) — echte
+`SegmentWeatherData`/`NormalizedTimeseries`-Objekte, echter Aufruf von
+`TripReportFormatter.format_email` bzw. `render_telegram_bubbles`, keine
+gemockten Renderer-Methoden.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Segment, dessen `fallback_metrics` einen der drei
+  Gewitter-Feldnamen enthält (z. B. `lightning_potential_lpi_jkg`), When
+  die Trip-Briefing-Mail Vollversion gerendert wird, Then enthält sowohl
+  der HTML- als auch der Text-Body eine Klartext-Zeile, die eine
+  Gewitter-Ersatzquelle benennt (z. B. „DWD Europa").
+  - Test: `test_thunder_only_shows_thunder_line_with_source` plus
+    Ergänzung an `test_html_footer_shows_fallback`/
+    `test_plain_footer_shows_fallback` mit Gewitter-Feldname statt `cape`.
+
+- **AC-2:** Given ein Segment mit gesetztem `fallback_model` (Grundvorhersage-
+  Fallback), When die Kompakt-Mail gerendert wird, Then enthält der Body
+  eine Klartext-Herkunftszeile — heute (vor dieser Scheibe) zeigt die
+  Kompakt-Mail in diesem Fall gar keinen Hinweis.
+  - Test: `test_compact_footer_shows_fallback` (neu).
+
+- **AC-3:** Given ein Segment mit gesetztem Fallback (Gewitter oder
+  Grundvorhersage), When die Telegram-Langform-Nachricht gerendert wird,
+  Then erscheint in der Kurzübersicht-Bubble eine zusätzliche Klartext-
+  Zeile unter der bestehenden Tagesfußzeile (`⚡ … · Sicht … ·
+  0°C-Grenze …`) — heute erscheint dort kein Hinweis.
+  - Test: Ergänzung in `tests/tdd/test_telegram_footer_metric_gating.py`.
+
+- **AC-4:** Given ein Grundvorhersage-Fallback mit mehreren betroffenen
+  Metriken, When eine der drei Ausgaben gerendert wird, Then sind die
+  Metriknamen in deutschem Klartext lesbar (z. B. „Sicht",
+  „Gewitterenergie") und nirgends in der gerenderten Ausgabe erscheint
+  mehr das Wort „Fallback" oder eine technische Kennung wie `icon_eu`
+  bzw. `eu_direct`.
+  - Test: `test_weather_only_shows_weather_line_translated` plus
+    Anpassung von `test_html_footer_shows_fallback`/
+    `test_plain_footer_shows_fallback` auf die neue Assertion „kein
+    `Fallback` im Text, kein `icon_eu` im Text, `DWD Europa` vorhanden".
+
+- **AC-5:** Given ein Segment, bei dem sowohl ein Gewitter- als auch ein
+  Grundvorhersage-Fallback gleichzeitig vorliegen (Kollisionsfall), When
+  eine der drei Ausgaben gerendert wird, Then erscheinen zwei getrennte
+  Zeilen, die Gewitterzeile nennt dabei keinen Quellennamen, und in
+  keiner der beiden Zeilen erscheint der Name des Grundvorhersage-
+  Ersatzmodells in der Gewitterzeile.
+  - Test: `test_collision_shows_both_lines_thunder_without_source`.
+
+- **AC-6:** Given ein Segment ganz ohne jeden Fallback (Normalfall), When
+  eine der drei Ausgaben gerendert wird, Then erscheint in keiner
+  Ausgabe eine Herkunfts-/Ersatzzeile, kein leerer Rahmen (kein leeres
+  `<div>`, keine leere Zeile an der Fallback-Position) und kein
+  Klammer- oder Doppelpunkt-Artefakt.
+  - Test: `test_no_fallback_no_hint` (umgestellt auf deutschen Wortlaut)
+    plus `test_no_fallback_returns_no_lines` für die geteilte Funktion
+    direkt.
+
+- **AC-7:** Given ein Segment mit gesetztem Fallback, When die SMS oder
+  die Telegram-Kurzform gerendert wird, Then enthält die Ausgabe keinen
+  Fallback-Hinweis und die SMS bleibt innerhalb ihres 160-Zeichen-
+  Budgets — strukturell erfüllt, weil die Kurzform `report.sms_text`
+  sendet und `narrow.py`/`_tg_day_footer` dabei nicht durchlaufen wird
+  (`notification_service.py:353-372`).
+  - Test: SMS wird für **dasselbe** Segment gerendert, das in AC-1/AC-5
+    den Hinweis erzeugt; geprüft wird am erzeugten SMS-Text, dass weder
+    „Ersatzquelle" noch „Ersatzmodell" noch ein Quellen-Klartextname
+    darin vorkommt und die Länge ≤ 160 Zeichen bleibt.
+    **Kein Dateiinhalt-Check** (kein „Import X kommt in Datei Y nicht
+    vor") — das wäre kein Verhaltensnachweis.
+
+- **AC-8:** Given ein Grundvorhersage-Fallback mit `fallback_metrics`, die
+  sowohl einen Gewitter- als auch einen Nicht-Gewitter-Feldnamen
+  enthalten, When die Wetterzeile gebildet wird, Then enthält die Klammer
+  der Wetterzeile ausschließlich die Nicht-Gewitter-Feldnamen — kein
+  Gewitter-Feldname erscheint dort.
+  - Test: Teil von `test_collision_shows_both_lines_thunder_without_source`
+    (Prüfung, dass „Blitzpotenzial" NICHT in der Wetterzeile steht).
+
+- **AC-9:** Given `fallback_model` oder `fallback_metrics` enthält eine
+  Kennung ohne hinterlegte Übersetzung, When eine der drei Ausgaben
+  gerendert wird, Then erscheint der Rohwert unverändert in der Ausgabe
+  und das Rendering wirft keine Ausnahme.
+  - Test: `test_unknown_model_shows_raw_value`.
+
+- **AC-10:** Given derselbe Fallback-Zustand (Gewitter, Grundvorhersage
+  oder Kollision), When alle drei Ausgaben (HTML-Mail, Plain/Kompakt-Mail,
+  Telegram) für dasselbe Segment gerendert werden, Then enthalten alle
+  drei denselben Kern-Wortlaut der Herkunftsangabe (gleiche Quellen-
+  Klartextnamen, gleiche Metrik-Klartextnamen) — nur die Verpackung
+  (HTML-`div`, Text-Zeile, Telegram-Zeile) unterscheidet sich.
+  - Test: Ein parametrisierter Vergleich über die drei
+    Renderer-Testfälle (HTML/Plain/Telegram) mit identischem
+    `ForecastMeta`-Fixture, der denselben übersetzten Kernstring in allen
+    drei Ausgaben nachweist.
+
+## Known Limitations
+
+- **Ortsvergleichs-Mail bleibt ohne Hinweis** (`compare_html.py:1388-1391`
+  nutzt weiterhin den festen String `build_origin_footer("compare",
+  source="Open-Meteo")`). Grund: dort existieren mehrere Orte mit je
+  eigener Herkunft — die Frage „welcher Ort hatte die Ersatzquelle?" ist
+  eigenständig zu entscheiden (eigene Darstellungslogik nötig, kein
+  einfacher Wiederverwendungsfall dieser Scheibe). Eigene Folgescheibe.
+- **Telegram-Kurzform bleibt ohne Hinweis**, obwohl es „Telegram" ist.
+  Begründung: bei `telegram_style="kurzform"` sendet
+  `notification_service.py:353-372` den bereits gerenderten
+  `report.sms_text` (`SMSTripFormatter`, 160-Zeichen-Budget) — die
+  Telegram-Bubbles und damit `_tg_day_footer` werden für diesen Versandweg
+  nie gelesen. Ein Hinweis dort würde das 160-Zeichen-Budget sprengen und
+  wäre PO-Entscheidung E1 zufolge ohnehin nicht vorgesehen.
+- **Kollisionsfall zeigt die Gewitterquelle namenlos** (R3). Der
+  tatsächliche Ersatzquellenname ist über die verfügbaren Felder nicht
+  zuverlässig rekonstruierbar, sobald `fallback_model` bereits vom
+  Grundvorhersage-Mechanismus belegt wurde (Merge-Schutz aus 2a). Eine
+  Ableitung über Koordinaten/Routing-Tabelle wäre möglich, verstieße aber
+  gegen ADR-0025 (keine Fachlogik-Ableitung im Ausgabe-Kanal) und ist
+  bewusst nicht Teil dieser Scheibe.
+- **Bei mehreren betroffenen Etappen gewinnt die erste gefundene**
+  (R9, Fix-Loop 2026-08-07). Tragen zwei Segmente unterschiedliche
+  Vertretungen, nennt die Ausgabe nur die des ersten markierten Segments.
+  Begründung: die Aussage lautet „hier wurde ausgewichen", nicht „auf
+  Etappe N wurde ausgewichen" — eine etappengenaue Zuordnung (Zeile je
+  Etappe, oder Etappennummer im Text) wäre eine eigene
+  Produktentscheidung mit eigener Darstellungsfrage, keine
+  Implementierungsdetail-Wahl. Bewusst nicht Teil dieser Scheibe.
+- **Fällt der Gewitter-Provider-Import aus, verschwindet die
+  Gewitterzeile still — und die Wetterzeile nennt zusätzlich keine
+  Werte mehr** (R10/R11, präzisiert im Fix-Loop 2026-08-07 nach Befund
+  F003). Das Briefing rendert dann vollständig weiter, aber (a) ohne den
+  Gewitter-Vertretungshinweis und (b) mit einer Wetterzeile **ohne
+  Klammer**: `Einzelne Wetterwerte von Ersatzmodell: <Quelle>`. Der
+  zweite Punkt ist der Preis dafür, dass ohne die Feldnamen keine
+  Trennung möglich ist — die frühere Fassung dieser Zeile behauptete nur
+  „die Gewitterzeile verschwindet"; tatsächlich konnte ein
+  Gewitter-Feldname in der Wetterzeilen-Klammer landen und dort dem
+  falschen Ersatzmodell zugeschrieben werden. Beides — der fehlende
+  Hinweis wie die fehlende Werteliste — geschieht ohne eigenes Signal,
+  dass etwas fehlt. Bewusster Vorzug gegenüber den Alternativen
+  „gesamte Briefing-Ausgabe fällt aus" (ADR-0047 Entscheidung 3) und
+  „falsche Zuschreibung anzeigen" (R11). Der Fall setzt einen defekten
+  `src/providers/`-Zweig voraus, der ohnehin über den regulären
+  Fehlerpfad auffällt.
+- **Alarm-/Warnmails bleiben außen vor** (`alert/*`). Dort wäre der
+  Herkunftshinweis Rauschen — der Nutzer erwartet in einer Warnmail eine
+  Handlungsaufforderung, keine Provider-Herkunftsinformation.
+- **Vollständigkeit der Modell-Übersetzungstabelle ist nicht mit einem
+  Wächter abgesichert.** Ein künftiges neues `fallback_model`-Vokabular
+  (neue Direktquelle, neues Open-Meteo-Rechenmodell) fällt ohne
+  Testanpassung auf R7 (Rohwert-Anzeige) zurück — funktional korrekt,
+  aber ohne Klartext, bis die Tabelle nachgezogen wird. Kein
+  automatischer Erkennungsmechanismus für „neue Kennung ohne Übersetzung"
+  ist Teil dieser Scheibe.
+- **Die Metrik-Klartextnamen sind mit `app/metric_catalog.py` abgeglichen,
+  aber nicht mechanisch daran gekoppelt.** Die Labels wurden bei der
+  Erstellung 1:1 aus den `label_de`-Werten des Katalogs übernommen, damit
+  derselbe Begriff im Produkt nicht zweimal verschieden heißt. Eine
+  automatische Ableitung ist bewusst **nicht** gebaut: `fallback_metrics`
+  ist mit **Open-Meteo-Parameternamen** bzw. Datenpunkt-**Feldnamen**
+  geschlüsselt, der Katalog dagegen mit **Metrik-IDs** — die Brücke
+  zwischen beiden Namensräumen wäre eine eigene, fehleranfällige
+  Abbildung ohne heutigen Nutzen. Preis: Wird ein `label_de` im Katalog
+  umbenannt, driftet diese Tabelle still. Als Sammel-Eintrag für #1199
+  vorzumerken, falls das Muster sich wiederholt.
+
+## Validierung
+
+**Renderer-Commit-Gate #811 (un-überspringbar).** Diese Scheibe ändert
+`src/output/renderers/email/plain.py`, `email/html.py` und
+`email/compact.py` — alle drei stehen auf der Sperrliste von
+`renderer_mail_gate.py`. Vor dem Commit müssen **beide** vorliegen:
+(1) `uv run pytest tests/tdd/test_issue_811_mode_matrix.py` grün,
+(2) ein erfolgreicher `briefing_mail_validator.py`-Lauf gegen eine echt
+zugestellte Staging-Mail (Marker-Header `X-GZ-Mail-Type: trip-briefing` +
+`X-GZ-Format: full|compact`). Erst bei Exit 0 darf „E2E bestanden" gesagt
+werden.
+
+`narrow.py` löst keines der beiden Mail-Gates aus (nicht in der
+Sperrliste), unterliegt aber dem allgemeinen Commit-Gate „Tests der
+berührten Dateien" (#1481 A).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine (kein neues ADR nötig)
+- **Rationale:** Diese Scheibe führt keine neue, dauerhafte
+  Architekturentscheidung ein — sie wendet die bereits akzeptierten
+  Invarianten aus ADR-0018 (Nicht-Kaschieren) und ADR-0047 (Gewitter-
+  Vertretung markieren) auf die Ausgabeschicht an und behebt einen
+  bestehenden Darstellungsfehler (R5). Die einzige neue strukturelle
+  Entscheidung — ein geteiltes Modul statt Renderer-eigener Kopien (R6)
+  — ist eine Implementierungsentscheidung im Rahmen der bereits
+  etablierten Projektregel zur Code-Teilung, keine neue
+  Architekturfrage.
+
+## Changelog
+
+- 2026-08-06: Initial spec created (Issue #1492 Scheibe 2b, Kontext
+  `docs/context/feat-1492-s2b-fallback-sichtbarkeit.md`, PO-Entscheidungen
+  E1/E2/E3, Tech-Lead-Regeln R1–R8).
+- 2026-08-07: Fix-Loop nach Adversary-Verdict BROKEN. R8 präzisiert, R9
+  (eine geteilte Segmentauswahl über alle vier Ausgaben, Befund F001) und
+  R10 (Provider-Import nur bei Bedarf und `ImportError`-fest, Befund F002)
+  ergänzt; zwei Known Limitations nachgetragen.
+- 2026-08-07 (Fix-Loop 2): zweiter Adversary-Durchgang, Verdict BROKEN
+  (F003 HIGH, F004 MEDIUM). R11 ergänzt („keine falsche Zuschreibung —
+  ist die Trennung nicht möglich, entfällt die Klammer der Wetterzeile
+  vollständig", Befund F003); die R10-Known-Limitation entsprechend
+  korrigiert — sie behauptete zu wenig. F004 war ein reiner Testbefund
+  (die AC-3-Reihenfolge-Zusicherung verglich gegen das erste „⚡" im
+  Text statt gegen die echte Tagesfußzeile und konnte deshalb nicht
+  scheitern); der Prüfling blieb unverändert, die Zusicherung ist jetzt
+  an `_tg_day_footer()` verankert.

--- a/src/output/renderers/email/compact.py
+++ b/src/output/renderers/email/compact.py
@@ -18,6 +18,7 @@ from utils.ascii_fold import fold_ascii
 from utils.timezone import local_fmt
 
 from output.renderers.day_window import DAY_WINDOW_END_HOUR, DAY_WINDOW_START_HOUR
+from output.renderers.fallback_notice import build_fallback_lines, select_fallback_meta
 from output.renderers.trip_metric_ids import resolve_trip_active_metrics
 from output.renderers.email.helpers import (
     _AMPEL_STAGE_TONES, build_confidence_hint, build_metrics_summary_pills,
@@ -257,6 +258,13 @@ def render_compact(
     lines.append(f"Generated: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}")
     model_name = segments[0].timeseries.meta.model if segments[0].timeseries else "n/a"
     lines.append(f"Data: {segments[0].provider} ({model_name})")
+
+    # Issue #1492 S2b AC-2: Herkunfts-Vertretung war in der Kompakt-Mail
+    # bisher gar nicht sichtbar (0 von 7 Ausgaben) — dieselben Zeilen wie in
+    # Vollversion und Telegram, aus dem geteilten Modul (R6). Steht VOR
+    # _ascii(), das Umlaute faltet. Segmentauswahl GETEILT ueber alle vier
+    # Ausgaben (`select_fallback_meta`) — sie durchsucht alle Etappen.
+    lines.extend(build_fallback_lines(select_fallback_meta(segments)))
 
     # Issue #1241/warnmail-Spec AC-5 (Befund 4a): Herkunfts-Fußzeile VOR
     # _ascii() (faltet '·' → '-', kurz halten wegen 2048-Byte-Limit des

--- a/src/output/renderers/email/html.py
+++ b/src/output/renderers/email/html.py
@@ -31,6 +31,7 @@ from app.profile import ActivityProfile
 from utils.timezone import local_dt, local_fmt, tz_abbrev
 
 from output.renderers.day_window import DAY_WINDOW_END_HOUR, DAY_WINDOW_START_HOUR
+from output.renderers.fallback_notice import build_fallback_lines, select_fallback_meta
 from output.renderers.trip_metric_ids import resolve_trip_active_metrics
 from output.renderers.email.helpers import (
     _HAIL_RING_COLOR,
@@ -525,18 +526,18 @@ def _render_footer(
         + '</div>'
     )
 
-    # #1153: Provider-Fallback-Hinweis spiegelt plain.py (ADR-0018 Nicht-Kaschieren).
-    fallback_row = ""
-    _meta = segments[0].timeseries.meta if segments[0].timeseries else None
-    if _meta and _meta.fallback_model:
-        if _meta.fallback_metrics:
-            _fb_text = f"Fallback {', '.join(_meta.fallback_metrics)}: {_meta.fallback_model}"
-        else:
-            _fb_text = f"Fallback: {_meta.fallback_model}"
-        fallback_row = (
-            f'<div style="font-family:{FONT_DATA};font-size:10px;color:#9a978d;'
-            f'margin-top:6px;">{_fb_text}</div>'
-        )
+    # #1153 Provider-Fallback-Hinweis (ADR-0018 Nicht-Kaschieren), seit #1492
+    # S2b in Klartext und aus dem GETEILTEN Modul statt als Kopie von plain.py
+    # (R6). 0-2 Zeilen -> je eine eigene <div> in derselben Optik; bei null
+    # Zeilen bleibt der Block leer (kein leerer Rahmen, AC-6). Die
+    # Segmentauswahl ist GETEILT und durchsucht alle Etappen — `segments[0]`
+    # verschwieg eine Vertretung, die erst eine spaetere Etappe betraf.
+    _meta = select_fallback_meta(segments)
+    fallback_row = "".join(
+        f'<div style="font-family:{FONT_DATA};font-size:10px;color:#9a978d;'
+        f'margin-top:6px;">{_fb_line}</div>'
+        for _fb_line in build_fallback_lines(_meta)
+    )
 
     extras = ""
     # Issue #1472: Einheiten-Zeile UND die neue Spalten-Zeile, die die

--- a/src/output/renderers/email/plain.py
+++ b/src/output/renderers/email/plain.py
@@ -24,6 +24,7 @@ from app.profile import ActivityProfile
 from utils.timezone import local_fmt
 
 from output.renderers.day_window import DAY_WINDOW_END_HOUR, DAY_WINDOW_START_HOUR
+from output.renderers.fallback_notice import build_fallback_lines, select_fallback_meta
 from output.renderers.trip_metric_ids import resolve_trip_active_metrics
 from output.renderers.email.helpers import (
     build_confidence_hint, build_metrics_summary_pills, build_origin_footer,
@@ -359,12 +360,15 @@ def render_plain(
     lines.append(f"Generated: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}")
     model_name = segments[0].timeseries.meta.model if segments[0].timeseries else "n/a"
     lines.append(f"Data: {segments[0].provider} ({model_name})")
-    if segments[0].timeseries and segments[0].timeseries.meta.fallback_model:
-        fb = segments[0].timeseries.meta
-        if fb.fallback_metrics:
-            lines.append(f"Fallback {', '.join(fb.fallback_metrics)}: {fb.fallback_model}")
-        else:
-            lines.append(f"Fallback: {fb.fallback_model}")
+    # Issue #1492 S2b: Herkunfts-Vertretung in Klartext, aus dem geteilten
+    # Modul (R6) statt zweier gespiegelter Kopien hier und in html.py. Liefert
+    # 0-2 Zeilen (Gewitter- und/oder Wetterzeile, R1) — der frueher hier
+    # gebaute technische Wortlaut "Fallback {metrics}: {model}" verknuepfte
+    # beide Angaben ungeprueft und war im Kollisionsfall falsch (R5).
+    # Die Segmentauswahl ist GETEILT (`select_fallback_meta`) und durchsucht
+    # alle Etappen — `segments[0]` verschwieg eine Vertretung, die erst eine
+    # spaetere Etappe betraf.
+    lines.extend(build_fallback_lines(select_fallback_meta(segments)))
     # Issue #1241/warnmail-Spec AC-5 (Befund 4a): Herkunfts-Fußzeile
     # (SSoT-Helper) -- Zeile 2 zeigt die echte Datenquelle
     # (`segments[0].provider`), nicht mehr den internen Renderer-Pfad.

--- a/src/output/renderers/fallback_notice.py
+++ b/src/output/renderers/fallback_notice.py
@@ -1,0 +1,230 @@
+"""Klartext-Formulierung der Herkunfts-Vertretung (Issue #1492 Scheibe 2b).
+
+SPEC: docs/specs/modules/feat_1492_s2b_fallback_sichtbarkeit.md (R1-R8)
+
+EIN Modul, drei Verpackungen (R6): diese Datei liefert fertige Textzeilen,
+die Renderer entscheiden nur noch ueber die Huelle (HTML-``div``,
+Plaintext-Zeile, Telegram-Zeile). Vorher lag dieselbe Formulierung zweimal
+im Code (``email/html.py`` spiegelte ``email/plain.py`` per Kommentar) —
+eine dritte Kopie fuer Telegram waere ein Verstoss gegen die Projektregel
+zur Code-Teilung.
+
+Die Ablage liegt bewusst eine Ebene UEBER ``email/`` und ``narrow.py``:
+Telegram importiert heute nichts aus dem E-Mail-Zweig, und das soll so
+bleiben.
+
+Der Name traegt bewusst kein ``trip_``/``compare_``-Praefix (``pendant_gate``
+blockiert praefigierte Neuanlagen unter ``src/output/renderers/**``) — es ist
+ohnehin kein Trip/Compare-Pendant-Fall.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - nur fuer Typpruefer
+    from app.models import ForecastMeta
+
+
+# --- Uebersetzung: Quellenkennung -> (Klartext, Zusatz) ---------------------
+# Wertebereich gemessen an allen Schreibstellen in ``src/providers/``
+# (``openmeteo.py:1055/1077/1167``, ``region_routing.py:33-36``,
+# ``thunder_enrichment.py:287``). ``icon_seamless`` steht bewusst NICHT hier:
+# es ist nie ein Fallback-Wert, nur ``meta.model``.
+_MODELL_KLARTEXT: dict[str, Tuple[str, str]] = {
+    "eu_direct": ("DWD Europa", "gröbere Auflösung"),
+    "de_direct": ("DWD Deutschland", ""),
+    "fr_direct": ("Météo-France", ""),
+    "at_direct": ("GeoSphere Österreich", ""),
+    "icon_eu": ("DWD Europa", "gröbere Auflösung"),
+    "icon_d2": ("DWD Deutschland", ""),
+    "meteofrance_arome": ("Météo-France", ""),
+    "metno_nordic": ("MET Norway", ""),
+    "ecmwf_ifs04": ("ECMWF", "gröbere Auflösung"),
+}
+
+# --- Uebersetzung: Metrikkennung -> Klartext --------------------------------
+# ``fallback_metrics`` mischt ZWEI Namenssysteme (Kontext-Doc): Open-Meteo-
+# Parameternamen (``OpenMeteoProvider._PARAM_TO_FIELD``, 18 Eintraege) bei
+# Metrik-Luecke/Modell-5xx, Datenpunkt-Feldnamen bei Schnee- und
+# Gewitter-Anreicherung. Beide sind hier abgebildet.
+#
+# Die Klartext-Labels sind 1:1 aus ``app/metric_catalog.py`` (``label_de``)
+# uebernommen, damit derselbe Begriff im Produkt nicht zweimal verschieden
+# heisst. Bewusst NICHT mechanisch daran gekoppelt: der Katalog ist mit
+# Metrik-IDs geschluesselt, diese Liste mit Parameter-/Feldnamen — die
+# Bruecke waere eine eigene, fehleranfaellige Abbildung (Spec, Known
+# Limitations).
+_METRIK_KLARTEXT: dict[str, str] = {
+    "temperature_2m": "Temperatur",
+    "apparent_temperature": "gefühlte Temperatur",
+    "relative_humidity_2m": "Luftfeuchtigkeit",
+    "dewpoint_2m": "Taupunkt",
+    "pressure_msl": "Luftdruck",
+    "cloud_cover": "Bewölkung",
+    "cloud_cover_low": "Tiefe Wolken",
+    "cloud_cover_mid": "Mittelhohe Wolken",
+    "cloud_cover_high": "Hohe Wolken",
+    "wind_speed_10m": "Wind",
+    "wind_direction_10m": "Windrichtung",
+    "wind_gusts_10m": "Böen",
+    "precipitation": "Niederschlag",
+    "precipitation_probability": "Niederschlagswahrscheinlichkeit",
+    "visibility": "Sicht",
+    "cape": "Gewitterenergie",
+    "freezing_level_height": "0°C-Grenze",
+    "uv_index": "UV-Index",
+    "weather_code": "Wetterlage",
+    "snow_depth": "Schneehöhe",
+    "swe_tot": "Wasseräquivalent Schnee",
+    # Gewitter-Feldnamen: nur der Vollstaendigkeit halber uebersetzt. Sie
+    # erscheinen wegen R4 NIE in der Wetterzeile — sie loesen die
+    # Gewitterzeile aus.
+    "lightning_density_per_km2_3h": "Blitzdichte",
+    "lightning_potential_lpi_jkg": "Blitzpotenzial",
+    "hail_potential_grau_gsp": "Hagelsignal",
+}
+
+_GEWITTER_OHNE_QUELLE = "Gewitterdaten von einer Ersatzquelle (gröbere Auflösung)"
+
+
+def _gewitter_felder() -> Optional[frozenset]:
+    """Die Gewitter-Feldnamen aus der EINZIGEN Quelle der Wahrheit (R1).
+
+    Bewusst kein Hartkodieren: waechst ``_SIGNAL_ZU_FELD`` um eine vierte
+    Gewittergroesse, erkennt diese Funktion sie automatisch. Der Import liegt
+    absichtlich in der Funktion — die Renderer-Schicht soll beim Laden nicht
+    den Provider-Zweig mitziehen.
+
+    Rueckgabe ``None`` heisst „nicht ermittelbar" und ist bewusst NICHT
+    dasselbe wie das leere ``frozenset`` („ermittelt, es gibt keine"): nur mit
+    dieser Unterscheidung kann der Aufrufer eine falsche Zuschreibung
+    vermeiden (F003). Eine Rueckfall-Konstante mit den drei bekannten
+    Feldnamen waere hier eine ZWEITE Wahrheitsquelle und wuerde genau die
+    Eigenschaft aufweichen, wegen der diese Funktion existiert.
+
+    Schlaegt der Import fehl, entfaellt die Gewitterzeile und das Briefing
+    rendert weiter. Begruendung: ADR-0047 Entscheidung 3 haelt fest, dass ein
+    Ausfall der Gewitterquelle die Grundvorhersage nie kippen darf — fuer den
+    Anzeigeweg gilt dasselbe Prinzip. Die Herleitung der Feldnamen aus dem
+    Produktivcode (SSoT) bleibt im Normalfall unveraendert erhalten; sie
+    entfaellt nur im Fehlerfall.
+    """
+    try:
+        from providers.thunder_enrichment import _EINZELWERT_FELD, _SIGNAL_ZU_FELD
+    except ImportError:
+        return None
+
+    return frozenset({*_SIGNAL_ZU_FELD.values(), _EINZELWERT_FELD})
+
+
+def _quelle_klartext(model: str) -> Tuple[str, str]:
+    """(Klartext, Zusatz) — unbekannte Kennung erscheint roh (R7)."""
+    return _MODELL_KLARTEXT.get(model, (model, ""))
+
+
+def select_fallback_meta(segments) -> Optional["ForecastMeta"]:
+    """Das erste ``meta`` mit einer Fallback-Markierung — ueber ALLE Segmente.
+
+    EINE Auswahlregel fuer alle vier Ausgaben (HTML-, Plain-, Kompakt-Mail und
+    Telegram-Langform). Vorher gab es zwei: die Mail-Renderer lasen starr
+    ``segments[0]``, ``narrow.py`` das erste fehlerfreie Segment mit
+    Zeitreihe. Beide verschweigen eine Vertretung, die erst eine spaetere
+    Etappe betraf — und zwar still, was ADR-0018/ADR-0047 („Fallback ohne
+    Kaschieren") widerspricht.
+
+    Ein Segment ohne Zeitreihe (Abruffehler) wird UEBERSPRUNGEN, nicht als
+    Abbruch behandelt: sein fehlendes ``meta`` sagt nichts ueber die
+    Vertretung der uebrigen Etappen aus.
+
+    Known Limitation (Spec): tragen mehrere Segmente unterschiedliche
+    Vertretungen, gewinnt die erste gefundene. Die Aussage lautet „hier wurde
+    ausgewichen", nicht „auf Etappe N wurde ausgewichen" — eine
+    etappengenaue Zuordnung waere eine eigene Produktentscheidung.
+    """
+    for sd in segments or []:
+        ts = getattr(sd, "timeseries", None)
+        if ts is None:
+            continue
+        meta = getattr(ts, "meta", None)
+        if meta is None:
+            continue
+        if getattr(meta, "fallback_model", None) or getattr(meta, "fallback_metrics", None):
+            return meta
+    return None
+
+
+def build_fallback_lines(meta: Optional["ForecastMeta"]) -> list:
+    """Liefert 0, 1 oder 2 fertige Klartext-Zeilen zur Herkunfts-Vertretung.
+
+    Reine Funktion, kein Rendering-Format -- die drei Renderer entscheiden
+    selbst ueber Verpackung (HTML/Plain/Telegram).
+
+    R1 — zwei UNABHAENGIGE Zeilen:
+
+    1. Gewitterzeile, wenn ``fallback_metrics`` einen Gewitter-Feldnamen
+       traegt. Warum nicht ``fallback_model`` (R2): der Merge-Schutz aus 2a
+       (``thunder_enrichment.py:286-288``) setzt die Singularfelder nur,
+       solange sie ``None`` sind — hat ein Grundvorhersage-Fallback zuvor
+       geschrieben, steht dort dessen Modellname, obwohl eine
+       Gewitter-Vertretung stattfand. ``fallback_metrics`` ist davon nicht
+       betroffen (immer ``extend``).
+    2. Wetterzeile, wenn ``fallback_model`` gesetzt ist UND
+       ``fallback_reason != "thunder_source_unavailable"``.
+    """
+    if meta is None:
+        return []
+
+    metriken = list(getattr(meta, "fallback_metrics", None) or [])
+    modell = getattr(meta, "fallback_model", None)
+    grund = getattr(meta, "fallback_reason", None)
+
+    # Der Provider-Import laeuft NUR, wenn er gebraucht wird: ohne
+    # ``fallback_metrics`` gibt es keine Gewitterzeile zu bilden. Sonst
+    # haenge im Normalfall (der weitaus haeufigste) die gesamte Mail- und
+    # Telegram-Rendering-Kette an der Importierbarkeit des Gewitter-Zweigs.
+    ermittelt = _gewitter_felder() if metriken else frozenset()
+    # F003 — ``None`` heisst: die beiden Herkuenfte sind NICHT trennbar.
+    trennbar = ermittelt is not None
+    gewitter_felder = ermittelt or frozenset()
+    hat_gewitter = any(m in gewitter_felder for m in metriken)
+    hat_wetter = bool(modell) and grund != "thunder_source_unavailable"
+
+    lines = []
+
+    if hat_gewitter:
+        # R3 — Kollisionsfall: laeuft die Wetterzeile ebenfalls, dann ist
+        # ``fallback_model`` vom Grundvorhersage-Mechanismus belegt und waere
+        # hier der Name der FALSCHEN Ersatzquelle. Dann lieber keinen Namen.
+        # Eine Ableitung ueber Koordinaten/``thunder_routing`` waere eigene
+        # Fachlogik im Ausgabe-Kanal (ADR-0025-Verstoss) und unterbleibt.
+        if hat_wetter or not modell:
+            lines.append(_GEWITTER_OHNE_QUELLE)
+        else:
+            name, zusatz = _quelle_klartext(modell)
+            klammer = " (%s)" % zusatz if zusatz else ""
+            lines.append("Gewitterdaten von Ersatzquelle: %s%s" % (name, klammer))
+
+    if hat_wetter:
+        # R4 — Metrikliste ABZUEGLICH der Gewitter-Feldnamen: die stehen dort
+        # nur, weil beide Mechanismen in dieselbe Liste schreiben, und
+        # gehoeren fachlich zur Gewitterzeile (AC-8).
+        #
+        # F003 — sind die Feldnamen nicht ermittelbar (Importfehler), kann der
+        # Abzug nicht stattfinden. Dann bliebe ein Gewitter-Feldname in dieser
+        # Klammer stehen und waere dem Ersatzmodell der GRUNDVORHERSAGE
+        # zugeschrieben, das mit den Blitzdaten nichts zu tun hat. Lieber gar
+        # keine Werte nennen als falsche: die Klammer entfaellt komplett.
+        rest = []
+        for m in metriken if trennbar else []:
+            if m in gewitter_felder:
+                continue
+            klartext = _METRIK_KLARTEXT.get(m, m)  # R7: Rohwert statt KeyError
+            if klartext not in rest:
+                rest.append(klartext)
+        name, _zusatz = _quelle_klartext(modell)
+        # R4/#1145 — leere Restliste: Klammer entfaellt ERSATZLOS. Kein "()",
+        # kein " : "-Artefakt, kein Doppelpunkt ohne Inhalt.
+        klammer = " (%s)" % ", ".join(rest) if rest else ""
+        lines.append("Einzelne Wetterwerte von Ersatzmodell: %s%s" % (name, klammer))
+
+    return lines

--- a/src/output/renderers/narrow.py
+++ b/src/output/renderers/narrow.py
@@ -27,6 +27,7 @@ from app.models import SegmentWeatherData, StabilityResult, ThunderLevel, Unifie
 from utils.timezone import local_fmt, local_hour
 
 from output.renderers.alert.render import _esc
+from output.renderers.fallback_notice import build_fallback_lines, select_fallback_meta
 from output.renderers.channel_layout import render_for_channel
 from output.renderers.day_window import (
     DAY_WINDOW_END_HOUR, DAY_WINDOW_START_HOUR, collect_hiking_window_points,
@@ -740,6 +741,15 @@ def render_telegram_bubbles(
     if footer:
         overview_lines.append("")
         overview_lines.extend(_wrap(_esc(footer), _TG_PROSE_WIDTH))
+    # Issue #1492 S2b AC-3: Herkunfts-Vertretung als eigene Zeile(n) UNTER der
+    # Tagesfußzeile, in derselben Kurzübersicht-Bubble. Wortlaut aus dem
+    # geteilten Modul (R6) — identisch zu Voll- und Kompakt-Mail (AC-10). Die
+    # Telegram-KURZFORM erreicht diesen Renderer nicht (sie sendet
+    # `report.sms_text`), deshalb bleibt das SMS-Budget unberührt (AC-7).
+    # Segmentauswahl GETEILT mit den drei Mail-Renderern
+    # (`select_fallback_meta`) — keine kanal-eigene Auswahlregel mehr.
+    for _fb_line in build_fallback_lines(select_fallback_meta(segments)):
+        overview_lines.extend(_wrap(_esc(_fb_line), _TG_PROSE_WIDTH))
     vortag_line = _tg_vortag_line(day_comparison, report_type)
     if vortag_line:
         overview_lines.append("")

--- a/tests/tdd/test_issue_1141_cross_provider_fallback.py
+++ b/tests/tdd/test_issue_1141_cross_provider_fallback.py
@@ -435,27 +435,37 @@ def test_plain_email_footer_no_leading_colon_on_empty_metrics():
     "Fallback: at_direct" OHNE fuehrendes Leerzeichen-vor-Doppelpunkt-
     Artefakt ("Fallback : at_direct").
 
-    RED heute: `src/output/renderers/email/plain.py` Zeile 288 rendert
-    `f"Fallback {', '.join(fb.fallback_metrics)}: {fb.fallback_model}"` — bei
-    leerer `fallback_metrics`-Liste ergibt das "Fallback : at_direct" (Leer-
-    zeichen VOR dem Doppelpunkt statt direkt danach) — die Ziel-Assertion
-    "Fallback: at_direct" ist im gerenderten Text heute NICHT enthalten.
+    Issue #1492 Scheibe 2b (Wortlaut mitgezogen): der technische Hinweis
+    "Fallback: at_direct" ist durch die deutsche Klartextzeile
+    "Einzelne Wetterwerte von Ersatzmodell: GeoSphere Österreich" ersetzt.
+    Die BEWACHTE ZUSICHERUNG bleibt dieselbe: bei leerer `fallback_metrics`
+    entfaellt die Klammer ersatzlos (R4) und es entsteht kein
+    Leerzeichen-vor-Doppelpunkt-Artefakt (#1145).
+
+    RED heute: `plain.py:362-367` rendert weiterhin den technischen Wortlaut
+    `f"Fallback {', '.join(...)}: {model}"` — die deutsche Zielzeile ist im
+    gerenderten Text NICHT enthalten.
     """
     from output.renderers.trip_report import TripReportFormatter
 
     seg = _make_segment_data(fallback_model="at_direct", fallback_metrics=[])
     formatter = TripReportFormatter()
     report = formatter.format_email([seg], "Test Trip", "morning")
+    plain = report.email_plain
 
-    assert "Fallback: at_direct" in report.email_plain, (
-        "AC-4: Footer muss 'Fallback: at_direct' (kein fuehrendes "
-        "Doppelpunkt-Leerzeichen-Artefakt) enthalten — gerenderter Text:\n"
-        f"{report.email_plain}"
+    assert "Einzelne Wetterwerte von Ersatzmodell: GeoSphere Österreich" in plain, (
+        "AC-4: Footer muss die Herkunft in deutschem Klartext nennen "
+        f"(Rohkennung 'at_direct' uebersetzt) — gerenderter Text:\n{plain}"
     )
-    assert "Fallback : at_direct" not in report.email_plain, (
-        "AC-4: Footer darf NICHT das Artefakt 'Fallback : at_direct' "
-        "(Leerzeichen vor dem Doppelpunkt bei leeren fallback_metrics) "
-        f"enthalten — gerenderter Text:\n{report.email_plain}"
+    assert "at_direct" not in plain, (
+        f"AC-4: Rohkennung 'at_direct' bleibt sichtbar — gerenderter Text:\n{plain}"
+    )
+    assert " : " not in plain, (
+        "AC-4/#1145: Leerzeichen-vor-Doppelpunkt-Artefakt bei leeren "
+        f"fallback_metrics — gerenderter Text:\n{plain}"
+    )
+    assert "GeoSphere Österreich ()" not in plain, (
+        f"AC-4/R4: leere Klammer bei leeren fallback_metrics:\n{plain}"
     )
 
 

--- a/tests/tdd/test_telegram_footer_metric_gating.py
+++ b/tests/tdd/test_telegram_footer_metric_gating.py
@@ -31,7 +31,12 @@ _TZ = ZoneInfo("Europe/Vienna")
 # ---------------------------------------------------------------------------
 
 
-def _make_segment():
+def _make_segment(*, fallback_model=None, fallback_metrics=None, fallback_reason=None):
+    """Issue #1492 S2b: optionale Fallback-Markierung auf `timeseries.meta`.
+
+    Default (alle drei None) reproduziert exakt das Bestandsverhalten der
+    #954-Tests — sie bleiben von der Erweiterung unberuehrt.
+    """
     from app.models import (
         ForecastMeta, GPXPoint, NormalizedTimeseries, Provider,
         SegmentWeatherData, SegmentWeatherSummary, ThunderLevel, TripSegment,
@@ -49,6 +54,9 @@ def _make_segment():
         run=datetime(2026, 7, 3, 0, 0, tzinfo=timezone.utc),
         grid_res_km=1.3, interp="point_grid",
     )
+    meta.fallback_model = fallback_model
+    meta.fallback_metrics = list(fallback_metrics or [])
+    meta.fallback_reason = fallback_reason
     ts = NormalizedTimeseries(meta=meta, data=[])
     agg = SegmentWeatherSummary(
         temp_min_c=12.0, temp_max_c=14.0, wind_max_kmh=8.0,
@@ -80,12 +88,26 @@ _ROW = {
 }
 
 
-def _overview_bubble_text(metric_ids: list[str]) -> str:
+def _overview_bubble_text(metric_ids: list[str], **fallback_kwargs) -> str:
     """Rendert die Bubbles und liefert den Text der Kurzübersicht-Bubble
     (die die Fußzeile trägt)."""
-    from output.renderers.narrow import render_telegram_bubbles
+    return _overview_bubble_und_fusszeile(metric_ids, **fallback_kwargs)[0]
 
-    seg = _make_segment()
+
+def _overview_bubble_und_fusszeile(
+    metric_ids: list[str], **fallback_kwargs
+) -> tuple[str, str | None]:
+    """Kurzübersicht-Bubble UND die ECHTE Tagesfußzeile aus derselben Eingabe.
+
+    F004: Die Fußzeile kommt hier aus `_tg_day_footer()` mit exakt den
+    Argumenten, die `render_telegram_bubbles()` intern verwendet. Nur so kann
+    sich eine Reihenfolge-Zusicherung an der ECHTEN Fußzeile verankern — das
+    Zeichen „⚡" allein taugt nicht als Anker, weil es zusätzlich in der
+    Pro-Metrik-Übersichtszeile OBERHALB der Fußzeile steht.
+    """
+    from output.renderers.narrow import _tg_day_footer, render_telegram_bubbles
+
+    seg = _make_segment(**fallback_kwargs)
     rows = [dict(_ROW), {**_ROW, "time": "09", "temp": 14}]
     dc = _make_dc(metric_ids)
     bubbles = render_telegram_bubbles(
@@ -95,7 +117,8 @@ def _overview_bubble_text(metric_ids: list[str]) -> str:
     assert bubbles, "render_telegram_bubbles() muss eine nicht-leere Liste liefern"
     matches = [b.text for b in bubbles if "Kurzübersicht" in b.text]
     assert matches, "Kurzübersicht-Bubble nicht gefunden"
-    return matches[0]
+    footer = _tg_day_footer([seg], dc.get_enabled_metric_ids(), tz=_TZ)
+    return matches[0], footer
 
 
 # ===========================================================================
@@ -139,3 +162,106 @@ def test_footer_complete_when_all_three_enabled():
     assert "⚡" in text, f"⚡-Teil fehlt trotz aktivierter thunder-Metrik:\n{text}"
     assert "Sicht" in text, f"Sicht-Teil fehlt trotz aktivierter visibility-Metrik:\n{text}"
     assert "0°C-Grenze" in text, f"0°C-Grenze-Teil fehlt trotz aktivierter freezing_level-Metrik:\n{text}"
+
+
+# ===========================================================================
+# Issue #1492 Scheibe 2b, AC-3: Fallback-Hinweis in der Telegram-Langform.
+# SPEC: docs/specs/modules/feat_1492_s2b_fallback_sichtbarkeit.md
+#
+# RED heute: `narrow.py` liest `segments[0].timeseries.meta.fallback_*` gar
+# nicht — die Kurzübersicht-Bubble zeigt 0 Treffer (Kontext-Doc „2 von 7
+# Ausgaben"). Der Text wird bei _TG_PROSE_WIDTH = 56 umgebrochen, deshalb
+# vergleichen die Tests auf whitespace-normalisierter Ebene: der Umbruch ist
+# Verpackung, nicht Wortlaut.
+# ===========================================================================
+
+
+def _norm(text: str) -> str:
+    """Zeilenumbruch/Einrückung falten — `_wrap()` bricht bei 56 Zeichen um."""
+    return " ".join(text.split())
+
+
+def test_overview_bubble_shows_thunder_fallback_line():
+    """AC-3: Given `fallback_metrics` trägt einen Gewitter-Feldnamen (2a hat
+    `eu_direct` als Ersatzquelle vermerkt), When die Kurzübersicht-Bubble
+    gerendert wird, Then erscheint die Gewitter-Klartextzeile UNTER der
+    bestehenden Tagesfußzeile (`⚡ …`)."""
+    text, fusszeile = _overview_bubble_und_fusszeile(
+        ["thunder", "visibility", "freezing_level"],
+        fallback_metrics=["lightning_potential_lpi_jkg"],
+        fallback_model="eu_direct",
+        fallback_reason="thunder_source_unavailable",
+    )
+    normalisiert = _norm(text)
+
+    erwartet = "Gewitterdaten von Ersatzquelle: DWD Europa (gröbere Auflösung)"
+    assert _norm(erwartet) in normalisiert, (
+        f"AC-3: Gewitter-Fallbackzeile fehlt in der Kurzübersicht-Bubble:\n{text}"
+    )
+    assert "eu_direct" not in text, f"AC-4: Rohkennung in der Bubble:\n{text}"
+
+    # Reihenfolge: die Zeile steht UNTER der Tagesfußzeile, nicht darüber.
+    #
+    # F004: Anker ist die ECHTE Fußzeile (`⚡ … · Sicht … · 0°C-Grenze … m`),
+    # NICHT das erste „⚡" im Text — das gehört zur Pro-Metrik-Übersichtszeile
+    # weiter oben. Gegen dieses erste Vorkommen verglichen blieb der Test auch
+    # dann grün, wenn die Fallbackzeile ÜBER die Fußzeile rutschte.
+    assert fusszeile, f"Vorbedingung: Tagesfußzeile fehlt:\n{text}"
+    fuss_norm = _norm(fusszeile)
+    assert fuss_norm in normalisiert, (
+        f"Vorbedingung: Tagesfußzeile {fuss_norm!r} nicht in der Bubble:\n{text}"
+    )
+    fuss_ende = normalisiert.index(fuss_norm) + len(fuss_norm)
+    assert normalisiert.index("Gewitterdaten von Ersatzquelle") > fuss_ende, (
+        f"AC-3: Fallbackzeile steht ÜBER der Tagesfußzeile {fuss_norm!r} statt "
+        f"darunter:\n{text}"
+    )
+
+
+def test_overview_bubble_shows_weather_fallback_line():
+    """AC-3/AC-4: Given ein Grundvorhersage-Fallback (`icon_eu`, `model_5xx`),
+    When die Kurzübersicht-Bubble gerendert wird, Then erscheint die
+    Wetter-Klartextzeile mit übersetzten Metriknamen — UNTER der bestehenden
+    Tagesfußzeile."""
+    text, fusszeile = _overview_bubble_und_fusszeile(
+        ["thunder", "visibility", "freezing_level"],
+        fallback_model="icon_eu",
+        fallback_reason="model_5xx",
+        fallback_metrics=["cape", "visibility"],
+    )
+    normalisiert = _norm(text)
+
+    erwartet = "Einzelne Wetterwerte von Ersatzmodell: DWD Europa (Gewitterenergie, Sicht)"
+    assert _norm(erwartet) in normalisiert, (
+        f"AC-3: Wetter-Fallbackzeile fehlt in der Kurzübersicht-Bubble:\n{text}"
+    )
+    assert "icon_eu" not in text, f"AC-4: Rohkennung in der Bubble:\n{text}"
+    assert "Fallback" not in text, f"AC-4: technisches Wort 'Fallback' in der Bubble:\n{text}"
+
+    # L1: dieselbe Reihenfolge-Zusicherung wie bei der Gewitterzeile. Ohne sie
+    # blieb ein Regress unbemerkt, der AUSSCHLIESSLICH die Wetterzeile über die
+    # Tagesfußzeile schiebt (die Gewitterzeile deckt ihn nicht mit ab — sie ist
+    # eine eigene, unabhängige Zeile, R1). Anker ist wieder das ENDE der ECHTEN
+    # Fußzeile, nicht das erste „⚡" im Text.
+    assert fusszeile, f"Vorbedingung: Tagesfußzeile fehlt:\n{text}"
+    fuss_norm = _norm(fusszeile)
+    assert fuss_norm in normalisiert, (
+        f"Vorbedingung: Tagesfußzeile {fuss_norm!r} nicht in der Bubble:\n{text}"
+    )
+    fuss_ende = normalisiert.index(fuss_norm) + len(fuss_norm)
+    assert normalisiert.index("Einzelne Wetterwerte von Ersatzmodell") > fuss_ende, (
+        f"AC-3: Wetter-Fallbackzeile steht ÜBER der Tagesfußzeile {fuss_norm!r} "
+        f"statt darunter:\n{text}"
+    )
+
+
+def test_overview_bubble_has_no_fallback_line_without_fallback():
+    """AC-6 GEGENPROBE: Given ein Segment ohne jeden Fallback, When die
+    Kurzübersicht-Bubble gerendert wird, Then erscheint KEINE zusätzliche
+    Ersatz-Zeile (kein leerer Rahmen, kein Restartefakt)."""
+    text = _overview_bubble_text(["thunder", "visibility", "freezing_level"])
+
+    assert "Ersatzquelle" not in text, f"AC-6: Gewitter-Ersatzzeile ohne Fallback:\n{text}"
+    assert "Ersatzmodell" not in text, f"AC-6: Wetter-Ersatzzeile ohne Fallback:\n{text}"
+    assert "Gewitterdaten von" not in text, f"AC-6: Fallbackzeile ohne Fallback:\n{text}"
+    assert "DWD Europa" not in text, f"AC-6: Quellen-Klartextname ohne Fallback:\n{text}"

--- a/tests/unit/test_fallback_notice.py
+++ b/tests/unit/test_fallback_notice.py
@@ -1,0 +1,600 @@
+"""TDD RED — Issue #1492 Scheibe 2b: Klartext-Formulierung der Herkunfts-Vertretung.
+
+SPEC: docs/specs/modules/feat_1492_s2b_fallback_sichtbarkeit.md (R1-R7, AC-4..AC-9)
+
+Prueft die geteilte, reine Formulierungsfunktion
+``output.renderers.fallback_notice.build_fallback_lines(meta) -> list[str]``.
+Sie existiert heute NICHT — alle Tests scheitern mit ``ModuleNotFoundError``
+(der Import liegt bewusst IN den Testfunktionen, damit ein fehlendes Modul
+keinen Collection-Error der ganzen Datei ausloest).
+
+Zwei unabhaengige Zeilen (R1):
+  1. Gewitterzeile — wenn ``fallback_metrics`` einen der Gewitter-Feldnamen
+     traegt (SSoT: ``providers.thunder_enrichment``).
+  2. Wetterzeile — wenn ``fallback_model`` gesetzt ist UND
+     ``fallback_reason != "thunder_source_unavailable"``.
+
+KEINE Mocks, KEIN Dateiinhalt-Check: echte ``ForecastMeta``-Objekte, echter
+Funktionsaufruf.
+"""
+from __future__ import annotations
+
+import contextlib
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+# Pfadregel #1409: Prueflingsaufloesung relativ zu DIESER Datei, nie ueber
+# einen festen Hauptrepo-Pfad — sonst misst der Worktree die fremde Kopie.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from app.models import ForecastMeta, Provider
+
+
+# --- PO-freigegebener Wortlaut (Spec, Abschnitt "Wortlaut-Muster") ----------
+_GEWITTER_MIT_QUELLE = "Gewitterdaten von Ersatzquelle: DWD Europa (gröbere Auflösung)"
+_GEWITTER_OHNE_QUELLE = "Gewitterdaten von einer Ersatzquelle (gröbere Auflösung)"
+
+
+def _thunder_field_names() -> list[str]:
+    """Die Gewitter-Feldnamen aus der EINZIGEN Quelle der Wahrheit (R1).
+
+    Kein Hartkodieren hier: waechst ``_SIGNAL_ZU_FELD`` um eine vierte
+    Gewittergroesse, muss ``build_fallback_lines`` sie automatisch erkennen —
+    dieser Test zieht dann von selbst mit.
+    """
+    from providers.thunder_enrichment import _EINZELWERT_FELD, _SIGNAL_ZU_FELD
+
+    return sorted({*_SIGNAL_ZU_FELD.values(), _EINZELWERT_FELD})
+
+
+def _make_meta(
+    *,
+    fallback_model: str | None = None,
+    fallback_metrics: list[str] | None = None,
+    fallback_reason: str | None = None,
+) -> ForecastMeta:
+    meta = ForecastMeta(
+        provider=Provider.OPENMETEO,
+        model="meteofrance_arome",
+        run=datetime(2026, 8, 6, 0, 0, tzinfo=timezone.utc),
+        grid_res_km=1.3,
+        interp="grid_point",
+    )
+    meta.fallback_model = fallback_model
+    meta.fallback_metrics = list(fallback_metrics or [])
+    meta.fallback_reason = fallback_reason
+    return meta
+
+
+def _make_segment(
+    *,
+    segment_id: int = 1,
+    with_timeseries: bool = True,
+    has_error: bool = False,
+    fallback_model: str | None = None,
+    fallback_metrics: list[str] | None = None,
+    fallback_reason: str | None = None,
+):
+    """Echtes ``SegmentWeatherData`` (kein Mock) fuer die Segmentauswahl.
+
+    ``with_timeseries=False`` bildet den echten Provider-Fehlerfall ab: das
+    Segment hat keine Zeitreihe und damit auch kein ``meta``.
+    """
+    from app.models import (
+        GPXPoint, NormalizedTimeseries, SegmentWeatherData,
+        SegmentWeatherSummary, TripSegment,
+    )
+
+    seg = TripSegment(
+        segment_id=segment_id,
+        start_point=GPXPoint(lat=39.7, lon=2.6, elevation_m=100.0),
+        end_point=GPXPoint(lat=39.8, lon=2.7, elevation_m=200.0),
+        start_time=datetime(2026, 8, 6, 8, 0, tzinfo=timezone.utc),
+        end_time=datetime(2026, 8, 6, 10, 0, tzinfo=timezone.utc),
+        duration_hours=2.0, distance_km=5.0, ascent_m=100.0, descent_m=0.0,
+    )
+    ts = None
+    if with_timeseries:
+        ts = NormalizedTimeseries(
+            meta=_make_meta(
+                fallback_model=fallback_model,
+                fallback_metrics=fallback_metrics,
+                fallback_reason=fallback_reason,
+            ),
+            data=[],
+        )
+    return SegmentWeatherData(
+        segment=seg,
+        timeseries=ts,
+        aggregated=SegmentWeatherSummary(
+            temp_min_c=10.0, temp_max_c=12.0, wind_max_kmh=15.0,
+            precip_sum_mm=0.0, cloud_avg_pct=50,
+        ),
+        fetched_at=datetime.now(timezone.utc),
+        provider="openmeteo",
+        has_error=has_error,
+    )
+
+
+@contextlib.contextmanager
+def _thunder_import_kaputt():
+    """Laesst ``providers.thunder_enrichment`` ECHT am Importmechanismus
+    scheitern — kein ``unittest.mock``, keine gefaelschte Rueckgabe.
+
+    Ein Finder auf ``sys.meta_path`` protokolliert jeden Importversuch fuer
+    genau dieses Modul und wirft dann ``ImportError``. Das Modul wird vorher
+    aus ``sys.modules`` genommen (sonst wuerde der Import es dort finden und
+    den Finder nie befragen) und danach wieder eingesetzt.
+
+    Der Kontextmanager liefert die Liste der protokollierten Versuche —
+    damit laesst sich auch pruefen, dass ein Import GAR NICHT stattfand.
+    """
+    name = "providers.thunder_enrichment"
+    versuche: list[str] = []
+
+    class _Blocker:
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname == name:
+                versuche.append(fullname)
+                raise ImportError("simuliert: providers.thunder_enrichment kaputt")
+            return None
+
+    gesichert = sys.modules.pop(name, None)
+    blocker = _Blocker()
+    sys.meta_path.insert(0, blocker)
+    try:
+        yield versuche
+    finally:
+        sys.meta_path.remove(blocker)
+        if gesichert is not None:
+            sys.modules[name] = gesichert
+
+
+def _thunder_line(lines: list[str]) -> str | None:
+    return next((ln for ln in lines if ln.startswith("Gewitterdaten")), None)
+
+
+def _weather_line(lines: list[str]) -> str | None:
+    return next((ln for ln in lines if ln.startswith("Einzelne Wetterwerte")), None)
+
+
+# ===========================================================================
+# AC-6 — Normalfall: kein Fallback, keine Zeile.
+# ===========================================================================
+
+def test_no_fallback_returns_no_lines() -> None:
+    """AC-6: Given ForecastMeta ohne jeden Fallback, When build_fallback_lines
+    laeuft, Then ist die Rueckgabe eine leere Liste (kein leerer Rahmen, kein
+    Artefakt, das ein Renderer spaeter verpacken wuerde)."""
+    from output.renderers.fallback_notice import build_fallback_lines
+
+    assert build_fallback_lines(_make_meta()) == []
+
+
+# ===========================================================================
+# AC-1 — Nur Gewitter-Vertretung: genau EINE Zeile, mit Quellen-Klartext.
+# ===========================================================================
+
+@pytest.mark.parametrize("feld", _thunder_field_names())
+def test_thunder_only_shows_thunder_line_with_source(feld: str) -> None:
+    """AC-1: Given fallback_metrics traegt einen Gewitter-Feldnamen und 2a hat
+    die Ersatzquelle vermerkt (fallback_model='eu_direct',
+    fallback_reason='thunder_source_unavailable'), When build_fallback_lines
+    laeuft, Then genau EINE Zeile, die die Ersatzquelle in Klartext nennt
+    ('DWD Europa') — und KEINE Wetterzeile (R1.2 schliesst sie aus, weil
+    fallback_reason == 'thunder_source_unavailable').
+
+    Abweichung vom Spec-GIVEN (als Befund gemeldet): die Spec notiert fuer
+    diesen Test ``fallback_model=None``, verlangt aber gleichzeitig
+    'DWD Europa' in der Ausgabe. Beides zusammen ist unerfuellbar — ohne
+    ``fallback_model`` existiert kein Quellenname. Geprueft wird deshalb der
+    Zustand, den ``thunder_enrichment.py:286-288`` im Gewitter-Alleinfall
+    tatsaechlich schreibt.
+    """
+    from output.renderers.fallback_notice import build_fallback_lines
+
+    lines = build_fallback_lines(_make_meta(
+        fallback_metrics=[feld],
+        fallback_model="eu_direct",
+        fallback_reason="thunder_source_unavailable",
+    ))
+
+    assert lines == [_GEWITTER_MIT_QUELLE], (
+        f"Gewitter-Alleinfall ({feld}) muss genau die Gewitterzeile mit "
+        f"Quellen-Klartext liefern — war: {lines!r}"
+    )
+
+
+# ===========================================================================
+# AC-4 — Nur Grundvorhersage-Fallback: Metriknamen in deutschem Klartext.
+# ===========================================================================
+
+def test_weather_only_shows_weather_line_translated() -> None:
+    """AC-4: Given fallback_model='icon_eu', fallback_reason='model_5xx',
+    fallback_metrics=['cape','visibility'], When build_fallback_lines laeuft,
+    Then genau EINE Zeile mit 'Gewitterenergie, Sicht' und 'DWD Europa' —
+    keine technische Kennung ('icon_eu', 'cape'), kein Wort 'Fallback'."""
+    from output.renderers.fallback_notice import build_fallback_lines
+
+    lines = build_fallback_lines(_make_meta(
+        fallback_model="icon_eu",
+        fallback_reason="model_5xx",
+        fallback_metrics=["cape", "visibility"],
+    ))
+
+    assert lines == [
+        "Einzelne Wetterwerte von Ersatzmodell: DWD Europa "
+        "(Gewitterenergie, Sicht)"
+    ], f"Wetterzeile mit uebersetzten Metriken erwartet — war: {lines!r}"
+    joined = "\n".join(lines)
+    assert "icon_eu" not in joined, f"Rohkennung icon_eu sichtbar: {joined!r}"
+    assert "cape" not in joined, f"Rohkennung cape sichtbar: {joined!r}"
+    assert "Fallback" not in joined, f"Technisches Wort 'Fallback' sichtbar: {joined!r}"
+
+
+# ===========================================================================
+# AC-5 + AC-8 — Kollisionsfall: zwei Zeilen, Gewitterzeile OHNE Quellenname,
+#               Wetterzeile OHNE Gewitter-Metrik.
+# ===========================================================================
+
+def test_collision_shows_both_lines_thunder_without_source() -> None:
+    """AC-5/AC-8: Given beide Mechanismen haben gefeuert (Grundvorhersage
+    zuerst: fallback_model='icon_eu'/'model_5xx'; die Gewitter-Vertretung
+    danach nur noch in fallback_metrics), When build_fallback_lines laeuft,
+    Then ZWEI Zeilen. Die Gewitterzeile nennt KEINEN Quellennamen (R3:
+    'icon_eu' ist der Name des FALSCHEN Ersatzmodells), die Wetterzeile
+    enthaelt nur die Nicht-Gewitter-Metrik ('Gewitterenergie' aus 'cape'),
+    NICHT 'Blitzpotenzial' (R4-Abzug)."""
+    from output.renderers.fallback_notice import build_fallback_lines
+
+    lines = build_fallback_lines(_make_meta(
+        fallback_metrics=["cape", "lightning_potential_lpi_jkg"],
+        fallback_model="icon_eu",
+        fallback_reason="model_5xx",
+    ))
+
+    assert len(lines) == 2, f"Kollisionsfall muss zwei Zeilen liefern — war: {lines!r}"
+    thunder, weather = _thunder_line(lines), _weather_line(lines)
+    assert thunder is not None, f"Gewitterzeile fehlt: {lines!r}"
+    assert weather is not None, f"Wetterzeile fehlt: {lines!r}"
+    assert lines.index(thunder) < lines.index(weather), (
+        f"Gewitterzeile steht laut Wortlaut-Muster VOR der Wetterzeile — war: {lines!r}"
+    )
+
+    assert thunder == _GEWITTER_OHNE_QUELLE, (
+        f"Gewitterzeile im Kollisionsfall muss quellenlos sein — war: {thunder!r}"
+    )
+    assert "DWD Europa" not in thunder, (
+        "R3-Verstoss: Gewitterzeile nennt den Klartextnamen des "
+        f"Grundvorhersage-Ersatzmodells — {thunder!r}"
+    )
+    assert "icon_eu" not in thunder, (
+        f"R3-Verstoss: Rohkennung des falschen Modells in der Gewitterzeile — {thunder!r}"
+    )
+
+    assert weather == (
+        "Einzelne Wetterwerte von Ersatzmodell: DWD Europa (Gewitterenergie)"
+    ), f"Wetterzeile ohne Gewitter-Metrik erwartet — war: {weather!r}"
+    assert "Blitzpotenzial" not in weather, (
+        f"AC-8-Verstoss: Gewitter-Metrik in der Wetterzeile — {weather!r}"
+    )
+
+
+# ===========================================================================
+# R4/#1145 — Leere Restliste: Klammer entfaellt ersatzlos.
+# ===========================================================================
+
+def test_weather_line_empty_bracket_omitted() -> None:
+    """R4/#1145: Given fallback_model='at_direct' und leere fallback_metrics,
+    When build_fallback_lines laeuft, Then traegt die Wetterzeile weder eine
+    leere Klammer noch ein Doppelpunkt-/Leerzeichen-Artefakt."""
+    from output.renderers.fallback_notice import build_fallback_lines
+
+    lines = build_fallback_lines(_make_meta(
+        fallback_model="at_direct", fallback_metrics=[],
+    ))
+
+    assert lines == [
+        "Einzelne Wetterwerte von Ersatzmodell: GeoSphere Österreich"
+    ], f"Wetterzeile ohne Klammer erwartet — war: {lines!r}"
+    line = lines[0]
+    assert "(" not in line and ")" not in line, f"Klammer trotz leerer Restliste: {line!r}"
+    assert " : " not in line, f"Leerzeichen-vor-Doppelpunkt-Artefakt (#1145): {line!r}"
+    assert "  " not in line, f"Doppeltes Leerzeichen: {line!r}"
+    assert not line.endswith(":"), f"Doppelpunkt ohne Inhalt: {line!r}"
+
+
+# ===========================================================================
+# AC-9/R7 — Unbekannte Kennungen erscheinen roh, ohne Absturz.
+# ===========================================================================
+
+def test_unknown_model_shows_raw_value() -> None:
+    """AC-9/R7: Given fallback_model und ein Metrikname ohne hinterlegte
+    Uebersetzung, When build_fallback_lines laeuft, Then erscheinen BEIDE
+    Rohwerte unveraendert (kein KeyError, keine stille Auslassung)."""
+    from output.renderers.fallback_notice import build_fallback_lines
+
+    lines = build_fallback_lines(_make_meta(
+        fallback_model="unbekanntes_modell_xyz",
+        fallback_reason="model_5xx",
+        fallback_metrics=["ein_unbekanntes_feld"],
+    ))
+
+    assert len(lines) == 1, f"Genau eine Wetterzeile erwartet — war: {lines!r}"
+    line = lines[0]
+    assert "unbekanntes_modell_xyz" in line, (
+        f"R7: unuebersetzte Modellkennung muss roh erscheinen — {line!r}"
+    )
+    assert "ein_unbekanntes_feld" in line, (
+        f"R7: unuebersetzter Metrikname darf nicht verschluckt werden — {line!r}"
+    )
+
+
+# ===========================================================================
+# F001 — Segmentauswahl: ALLE Segmente durchsuchen, nicht nur das erste.
+#
+# Vorher gab es ZWEI verschiedene Auswahlregeln: die drei Mail-Renderer lasen
+# starr ``segments[0]``, ``narrow.py`` das erste fehlerfreie Segment mit
+# Zeitreihe. Beide verschweigen eine Vertretung, die erst eine spaetere
+# Etappe betraf (ADR-0018/ADR-0047: Fallback ohne Kaschieren).
+# ===========================================================================
+
+def test_select_skips_segment_without_timeseries() -> None:
+    """F001: Given Segment 1 hat einen Provider-Fehler (keine Zeitreihe) und
+    Segment 2 traegt einen echten Fallback, When die Segmentauswahl laeuft,
+    Then liefert sie das ``meta`` von Segment 2 — das fehlende ``meta`` von
+    Segment 1 ist ein Ueberspringgrund, kein Abbruchgrund."""
+    from output.renderers.fallback_notice import select_fallback_meta
+
+    seg1 = _make_segment(segment_id=1, with_timeseries=False, has_error=True)
+    seg2 = _make_segment(
+        segment_id=2, fallback_model="icon_eu",
+        fallback_metrics=["cape", "visibility"], fallback_reason="model_5xx",
+    )
+
+    meta = select_fallback_meta([seg1, seg2])
+    assert meta is not None, "Fallback aus Segment 2 wurde nicht gefunden"
+    assert meta.fallback_model == "icon_eu"
+
+
+def test_select_skips_segment_without_fallback() -> None:
+    """F001: Given Segment 1 ist fehlerfrei UND ohne Fallback, Segment 2
+    traegt einen Fallback, When die Segmentauswahl laeuft, Then liefert sie
+    das ``meta`` von Segment 2.
+
+    Das ist der Fall, den BEIDE frueheren Varianten verschluckt haben:
+    ``segments[0]`` ebenso wie „erstes fehlerfreies Segment"."""
+    from output.renderers.fallback_notice import select_fallback_meta
+
+    seg1 = _make_segment(segment_id=1)
+    seg2 = _make_segment(
+        segment_id=2, fallback_model="at_direct", fallback_reason="model_5xx",
+    )
+
+    meta = select_fallback_meta([seg1, seg2])
+    assert meta is not None, "Fallback aus Segment 2 wurde nicht gefunden"
+    assert meta.fallback_model == "at_direct"
+
+
+def test_select_finds_thunder_only_marking_without_model() -> None:
+    """F001: Eine Gewitter-Vertretung kann sich allein in ``fallback_metrics``
+    zeigen (R2: der Merge-Schutz aus 2a laesst ``fallback_model`` belegt).
+    Auch dieses Segment muss die Auswahl finden."""
+    from output.renderers.fallback_notice import select_fallback_meta
+
+    seg1 = _make_segment(segment_id=1)
+    seg2 = _make_segment(
+        segment_id=2, fallback_metrics=["lightning_potential_lpi_jkg"],
+    )
+
+    meta = select_fallback_meta([seg1, seg2])
+    assert meta is not None, "Gewitter-Markierung ohne fallback_model uebersehen"
+    assert meta.fallback_metrics == ["lightning_potential_lpi_jkg"]
+
+
+def test_select_returns_none_without_any_fallback() -> None:
+    """AC-6 Gegenprobe: Given kein Segment traegt eine Fallback-Markierung,
+    When die Segmentauswahl laeuft, Then liefert sie ``None`` — und
+    ``build_fallback_lines(None)`` daraufhin keine Zeile."""
+    from output.renderers.fallback_notice import build_fallback_lines, select_fallback_meta
+
+    segmente = [
+        _make_segment(segment_id=1),
+        _make_segment(segment_id=2, with_timeseries=False, has_error=True),
+        _make_segment(segment_id=3),
+    ]
+
+    assert select_fallback_meta(segmente) is None
+    assert build_fallback_lines(select_fallback_meta(segmente)) == []
+
+
+def test_select_takes_first_marked_segment() -> None:
+    """Known Limitation (Spec): tragen mehrere Segmente unterschiedliche
+    Vertretungen, gewinnt die ERSTE gefundene. Die Aussage lautet „hier wurde
+    ausgewichen", nicht „auf Etappe N wurde ausgewichen"."""
+    from output.renderers.fallback_notice import select_fallback_meta
+
+    seg1 = _make_segment(segment_id=1, fallback_model="icon_eu", fallback_reason="model_5xx")
+    seg2 = _make_segment(segment_id=2, fallback_model="at_direct", fallback_reason="model_5xx")
+
+    meta = select_fallback_meta([seg1, seg2])
+    assert meta is not None and meta.fallback_model == "icon_eu"
+
+
+def test_select_handles_empty_segment_list() -> None:
+    """Grenzfall: leere Segmentliste stuerzt nicht ab."""
+    from output.renderers.fallback_notice import select_fallback_meta
+
+    assert select_fallback_meta([]) is None
+
+
+# ===========================================================================
+# F002 — Der Hinweis darf das Briefing nicht mitreissen.
+#
+# ADR-0047 Entscheidung 3: ein Ausfall der Gewitterquelle darf die
+# Grundvorhersage nie kippen. Fuer den Anzeigeweg gilt dasselbe Prinzip.
+# ===========================================================================
+
+def test_no_fallback_does_not_import_thunder_provider() -> None:
+    """F002: Given ein ``meta`` ganz ohne Fallback (Normalfall), When
+    ``build_fallback_lines`` laeuft, Then wird ``providers.thunder_enrichment``
+    GAR NICHT erst importiert — ein kaputter Provider-Zweig kann das Briefing
+    dann nicht mitreissen."""
+    from output.renderers.fallback_notice import build_fallback_lines
+
+    with _thunder_import_kaputt() as versuche:
+        lines = build_fallback_lines(_make_meta())
+
+    assert lines == [], f"Normalfall muss leer bleiben — war: {lines!r}"
+    assert versuche == [], (
+        "F002: der Provider-Import wurde im Normalfall ohne Fallback versucht "
+        f"— Versuche: {versuche!r}"
+    )
+
+
+def test_broken_thunder_import_still_renders_weather_line() -> None:
+    """F002/F003: Given ``providers.thunder_enrichment`` ist nicht importierbar
+    und ein Grundvorhersage-Fallback liegt vor, When ``build_fallback_lines``
+    laeuft, Then wirft die Funktion nicht — die Gewitterzeile entfaellt, die
+    WETTERZEILE BLEIBT.
+
+    Die Klammer entfaellt dabei ebenfalls (F003): ohne die Feldnamen ist nicht
+    entscheidbar, ob ``visibility`` ein Wetter- oder ein Gewitter-Feld ist. Die
+    Erwartung wurde gegenueber dem F002-Stand bewusst geaendert — dort stand
+    ``(Sicht)``, was im Kollisionsfall zu einer FALSCHEN Zuschreibung fuehrte.
+    Zugesichert bleibt hier, was F002 zusicherte: kein Absturz, die Zeile
+    ueberlebt."""
+    from output.renderers.fallback_notice import build_fallback_lines
+
+    with _thunder_import_kaputt() as versuche:
+        lines = build_fallback_lines(_make_meta(
+            fallback_model="icon_eu",
+            fallback_reason="model_5xx",
+            fallback_metrics=["visibility"],
+        ))
+
+    assert versuche, "Vorbedingung: bei nicht-leeren fallback_metrics wird importiert"
+    assert lines == [
+        "Einzelne Wetterwerte von Ersatzmodell: DWD Europa"
+    ], f"Wetterzeile muss den Importfehler ueberleben — war: {lines!r}"
+
+
+def test_broken_thunder_import_drops_only_thunder_line() -> None:
+    """F002: Given der Importfehler, eine reine Gewitter-Markierung UND
+    ZUSAETZLICH ein Grundvorhersage-Fallback, When ``build_fallback_lines``
+    laeuft, Then bleibt GENAU EINE Zeile uebrig — die Wetterzeile —, und die
+    Gewitterzeile fehlt.
+
+    L1/L2: die fruehere Fassung setzte ``fallback_reason``
+    ``"thunder_source_unavailable"`` und erwartete ``lines == []``. Damit war
+    sie auch dann gruen, wenn ``build_fallback_lines`` im Importfehlerfall
+    pauschal ALLES verschluckt — sie konnte „richtig unterdrueckt" nicht von
+    „gar nichts getan" unterscheiden und hielt den eigenen Namen („drops ONLY
+    the thunder line") nicht. Erst der Zustand mit BEIDEN Zeilen im Normalfall
+    macht den Unterschied messbar.
+    """
+    from output.renderers.fallback_notice import build_fallback_lines
+
+    kwargs = dict(
+        fallback_metrics=["lightning_potential_lpi_jkg"],
+        fallback_model="icon_eu",
+        fallback_reason="model_5xx",
+    )
+
+    # Vorbedingung: bei INTAKTEM Import traegt genau diese Eingabe BEIDE
+    # Zeilen. Ohne diesen Bezugspunkt sagt das Fehlen der Gewitterzeile unten
+    # nichts aus — sie koennte auch aus anderen Gruenden nie entstanden sein.
+    intakt = build_fallback_lines(_make_meta(**kwargs))
+    assert _thunder_line(intakt) is not None, (
+        f"Vorbedingung: bei intaktem Import muss die Gewitterzeile da sein — {intakt!r}"
+    )
+    assert _weather_line(intakt) is not None, (
+        f"Vorbedingung: bei intaktem Import muss die Wetterzeile da sein — {intakt!r}"
+    )
+
+    with _thunder_import_kaputt() as versuche:
+        lines = build_fallback_lines(_make_meta(**kwargs))
+
+    assert versuche, "Vorbedingung: bei nicht-leeren fallback_metrics wird importiert"
+    assert len(lines) == 1, (
+        "Der Importfehler darf NUR die Gewitterzeile kosten — genau eine Zeile "
+        f"muss uebrig bleiben, war: {lines!r}"
+    )
+    assert _thunder_line(lines) is None, (
+        f"Ohne die Feldnamen ist die Gewitterzeile nicht bildbar — war: {lines!r}"
+    )
+    assert lines == ["Einzelne Wetterwerte von Ersatzmodell: DWD Europa"], (
+        "Die Wetterzeile muss den Importfehler ueberleben (ohne Klammer, weil "
+        f"die Trennung nicht moeglich ist) — war: {lines!r}"
+    )
+
+
+# ===========================================================================
+# F003 — Keine FALSCHE Zuschreibung: lieber gar keine Werte nennen.
+#
+# Bricht der Provider-Import, kennt dieses Modul die Gewitter-Feldnamen nicht
+# mehr und kann Gewitter- von Wetterwerten nicht mehr TRENNEN. Der R4-Abzug
+# greift dann nicht — ein Gewitter-Feldname landete bisher in der Klammer der
+# WETTERZEILE und wurde damit dem Ersatzmodell der Grundvorhersage
+# zugeschrieben, das mit den Blitzdaten nichts zu tun hat (AC-8-Verstoss).
+#
+# Tech-Lead-Entscheidung: koennen die beiden Herkuenfte nicht sicher getrennt
+# werden, nennt die Wetterzeile GAR KEINE Werte. Weniger Information ist
+# hinnehmbar, eine falsche Zuschreibung nicht.
+# ===========================================================================
+
+def test_broken_import_with_collision_drops_weather_bracket() -> None:
+    """F003/AC-8: Given der Kollisionsfall (``fallback_metrics`` traegt einen
+    Gewitter- UND einen Nicht-Gewitter-Feldnamen) UND ein kaputter
+    ``providers.thunder_enrichment``-Import, When ``build_fallback_lines``
+    laeuft, Then traegt die Wetterzeile UEBERHAUPT KEINE Klammer — insbesondere
+    keinen Gewitter-Feldnamen, der sonst faelschlich dem
+    Grundvorhersage-Ersatzmodell zugeschrieben wuerde."""
+    from output.renderers.fallback_notice import build_fallback_lines
+
+    with _thunder_import_kaputt() as versuche:
+        lines = build_fallback_lines(_make_meta(
+            fallback_metrics=["cape", "lightning_potential_lpi_jkg"],
+            fallback_model="icon_eu",
+            fallback_reason="model_5xx",
+        ))
+
+    assert versuche, "Vorbedingung: bei nicht-leeren fallback_metrics wird importiert"
+
+    # L3: Zeilenzahl mitpruefen — sonst faellt weder „eine Zeile zu viel" noch
+    # „eine Zeile zu wenig" auf. Der Zugriff ueber `_weather_line()` unten
+    # findet die Wetterzeile auch dann, wenn daneben noch eine zweite,
+    # unerwuenschte Zeile steht; genau das blieb hier vorher unbemerkt.
+    assert len(lines) == 1, (
+        "Im Kollisionsfall mit kaputtem Import darf GENAU EINE Zeile entstehen "
+        f"— die Wetterzeile — war: {lines!r}"
+    )
+    assert _thunder_line(lines) is None, (
+        "Ohne die Feldnamen ist die Gewitterzeile nicht bildbar und darf hier "
+        f"nicht auftauchen — war: {lines!r}"
+    )
+
+    weather = _weather_line(lines)
+    assert weather is not None, (
+        f"Die Wetterzeile selbst muss den Importfehler ueberleben — war: {lines!r}"
+    )
+    assert weather == "Einzelne Wetterwerte von Ersatzmodell: DWD Europa", (
+        "F003: ohne die Feldnamen ist keine Trennung moeglich — dann nennt die "
+        f"Wetterzeile GAR KEINE Werte — war: {weather!r}"
+    )
+    assert "(" not in weather and ")" not in weather, (
+        f"F003: Klammer trotz unmoeglicher Trennung — {weather!r}"
+    )
+    for feld in ("Blitzpotenzial", "Blitzdichte", "Hagelsignal"):
+        assert feld not in weather, (
+            f"F003/AC-8-Verstoss: Gewitter-Klartext {feld!r} faelschlich dem "
+            f"Grundvorhersage-Ersatzmodell zugeschrieben — {weather!r}"
+        )
+    # Auch der Rohname darf nicht durchrutschen (R7 uebersetzt Unbekanntes roh).
+    assert "lightning_potential_lpi_jkg" not in weather, (
+        f"F003: Roher Gewitter-Feldname in der Wetterzeile — {weather!r}"
+    )

--- a/tests/unit/test_model_metric_fallback.py
+++ b/tests/unit/test_model_metric_fallback.py
@@ -32,6 +32,20 @@ from app.models import (
 
 
 # ---------------------------------------------------------------------------
+# Wortlaut (Issue #1492 Scheibe 2b, PO-freigegeben)
+# SPEC: docs/specs/modules/feat_1492_s2b_fallback_sichtbarkeit.md
+# ---------------------------------------------------------------------------
+
+# Kollisionsfall (R3): die Gewitterzeile nennt KEINEN Quellennamen, weil
+# `fallback_model` dann bereits vom Grundvorhersage-Fallback belegt ist.
+_GEWITTER_OHNE_QUELLE = "Gewitterdaten von einer Ersatzquelle (gröbere Auflösung)"
+# R4: die Klammer traegt die Metrikliste OHNE die Gewitter-Feldnamen.
+_WETTER_ICON_EU = (
+    "Einzelne Wetterwerte von Ersatzmodell: DWD Europa (Gewitterenergie, Sicht)"
+)
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -179,18 +193,29 @@ class TestMergeFallback:
 class TestFooterFallbackInfo:
     """Footer must show fallback info when present."""
 
-    def _make_segment_data(self, fallback_model=None, fallback_metrics=None):
-        """Helper to create a SegmentWeatherData with fallback meta."""
+    def _make_segment_data(
+        self, fallback_model=None, fallback_metrics=None, fallback_reason=None,
+        segment_id=1, with_timeseries=True, has_error=False,
+    ):
+        """Helper to create a SegmentWeatherData with fallback meta.
+
+        ``fallback_reason`` (Issue #1492 Scheibe 2b): unterscheidet die
+        Gewitter-Vertretung (``thunder_source_unavailable``) vom
+        Grundvorhersage-Fallback (``metric_gap``/``model_5xx``) — R1 der Spec
+        `feat_1492_s2b_fallback_sichtbarkeit.md` haengt daran, welche der
+        beiden Zeilen erscheint.
+        """
         from app.models import SegmentWeatherData, SegmentWeatherSummary, TripSegment, GPXPoint
 
         today = date.today()
         meta = _make_meta()
         meta.fallback_model = fallback_model
         meta.fallback_metrics = fallback_metrics or []
+        meta.fallback_reason = fallback_reason
 
-        ts = NormalizedTimeseries(meta=meta, data=[_make_dp(8)])
+        ts = NormalizedTimeseries(meta=meta, data=[_make_dp(8)]) if with_timeseries else None
         seg = TripSegment(
-            segment_id=1,
+            segment_id=segment_id,
             start_point=GPXPoint(lat=39.7, lon=2.6, elevation_m=100.0),
             end_point=GPXPoint(lat=39.8, lon=2.7, elevation_m=200.0),
             start_time=datetime(today.year, today.month, today.day, 8, 0, tzinfo=timezone.utc),
@@ -209,49 +234,344 @@ class TestFooterFallbackInfo:
             ),
             fetched_at=datetime.now(timezone.utc),
             provider="openmeteo",
+            has_error=has_error,
         )
 
-    def test_html_footer_shows_fallback(self) -> None:
+    def _alle_vier_ausgaben(self, segments) -> dict:
+        """HTML-, Plain-, Kompakt-Mail und Telegram-Langform fuer DENSELBEN
+        Trip — echte Renderer-Aufrufe, kein Mock."""
+        from app.models import TripReportConfig
         from output.renderers.trip_report import TripReportFormatter
 
-        seg = self._make_segment_data(fallback_model="icon_eu", fallback_metrics=["cape", "visibility"])
+        full = TripReportFormatter().format_email(segments, "Test Trip", "morning")
+        compact = TripReportFormatter().format_email(
+            segments, "Test Trip", "morning",
+            report_config=TripReportConfig(email_format="compact"),
+        )
+        overview = [b for b in full.telegram_bubbles if "Kurz" in b]
+        assert overview, "Kurzuebersicht-Bubble nicht gefunden"
+        return {
+            "html": full.email_html,
+            "plain": full.email_plain,
+            "compact": compact.email_plain,
+            "telegram": overview[0],
+        }
+
+    def test_html_footer_shows_fallback(self) -> None:
+        """Issue #1492 S2b AC-1/AC-4: Die HTML-Vollversion zeigt den
+        Herkunftshinweis in deutschem Klartext.
+
+        Umgestellt vom technischen Bestandswortlaut (`"fallback" in html` +
+        Rohkennung `"icon_eu"`) auf den PO-freigegebenen Wortlaut. Das Segment
+        traegt zusaetzlich einen Gewitter-Feldnamen, damit BEIDE Zeilen
+        geprueft werden (Kollisionsfall, R3: die Gewitterzeile nennt dabei
+        keinen Quellennamen).
+        """
+        from output.renderers.trip_report import TripReportFormatter
+
+        seg = self._make_segment_data(
+            fallback_model="icon_eu",
+            fallback_metrics=["cape", "visibility", "lightning_potential_lpi_jkg"],
+            fallback_reason="model_5xx",
+        )
         formatter = TripReportFormatter()
         report = formatter.format_email([seg], "Test Trip", "morning")
+        html = report.email_html
 
-        assert "fallback" in report.email_html.lower()
-        assert "icon_eu" in report.email_html
+        assert _GEWITTER_OHNE_QUELLE in html, (
+            f"AC-1: Gewitterzeile fehlt im HTML-Body:\n{html[-1500:]}"
+        )
+        assert _WETTER_ICON_EU in html, (
+            f"AC-4: Wetterzeile in Klartext fehlt im HTML-Body:\n{html[-1500:]}"
+        )
+        assert "icon_eu" not in html, "AC-4: Rohkennung 'icon_eu' bleibt sichtbar"
+        assert "Fallback" not in html, "AC-4: technisches Wort 'Fallback' bleibt sichtbar"
 
     def test_plain_footer_shows_fallback(self) -> None:
+        """Issue #1492 S2b AC-1/AC-4: dasselbe fuer die Plaintext-Vollversion."""
         from output.renderers.trip_report import TripReportFormatter
 
-        seg = self._make_segment_data(fallback_model="icon_eu", fallback_metrics=["cape", "visibility"])
+        seg = self._make_segment_data(
+            fallback_model="icon_eu",
+            fallback_metrics=["cape", "visibility", "lightning_potential_lpi_jkg"],
+            fallback_reason="model_5xx",
+        )
         formatter = TripReportFormatter()
         report = formatter.format_email([seg], "Test Trip", "morning")
+        plain = report.email_plain
 
-        assert "fallback" in report.email_plain.lower()
-        assert "icon_eu" in report.email_plain
+        assert _GEWITTER_OHNE_QUELLE in plain, (
+            f"AC-1: Gewitterzeile fehlt im Text-Body:\n{plain[-1500:]}"
+        )
+        assert _WETTER_ICON_EU in plain, (
+            f"AC-4: Wetterzeile in Klartext fehlt im Text-Body:\n{plain[-1500:]}"
+        )
+        assert "icon_eu" not in plain, "AC-4: Rohkennung 'icon_eu' bleibt sichtbar"
+        assert "Fallback" not in plain, "AC-4: technisches Wort 'Fallback' bleibt sichtbar"
 
     def test_footer_empty_metrics_no_colon_artifact(self) -> None:
-        """#1145: empty fallback_metrics must not produce a ' : ' artifact."""
+        """#1145 (Zusicherung erhalten, Wortlaut eingedeutscht): leere
+        `fallback_metrics` duerfen kein `' : '`- oder Klammer-Artefakt
+        erzeugen. Nach R4 entfaellt die Klammer ersatzlos."""
         from output.renderers.trip_report import TripReportFormatter
 
-        seg = self._make_segment_data(fallback_model="icon_eu", fallback_metrics=[])
+        seg = self._make_segment_data(
+            fallback_model="icon_eu", fallback_metrics=[], fallback_reason="model_5xx",
+        )
         formatter = TripReportFormatter()
         report = formatter.format_email([seg], "Test Trip", "morning")
 
-        for body in (report.email_html, report.email_plain):
-            assert "fallback" in body.lower()
-            assert "icon_eu" in body
-            assert " : " not in body
-            assert "Fallback :" not in body
+        for name, body in (("html", report.email_html), ("plain", report.email_plain)):
+            assert "Einzelne Wetterwerte von Ersatzmodell: DWD Europa" in body, (
+                f"{name}: Wetterzeile in Klartext fehlt:\n{body[-1500:]}"
+            )
+            assert "icon_eu" not in body, f"{name}: Rohkennung 'icon_eu' sichtbar"
+            assert " : " not in body, f"{name}: #1145-Artefakt ' : ' vorhanden"
+            assert "Ersatzmodell: ()" not in body, f"{name}: leere Klammer"
+            assert "DWD Europa ()" not in body, f"{name}: leere Klammer"
 
     def test_no_fallback_no_hint(self) -> None:
-        """Regelfall: without fallback_model no 'fallback' hint appears anywhere."""
+        """AC-6 Regelfall: ohne jeden Fallback erscheint KEINE Herkunfts-/
+        Ersatzzeile.
+
+        Bewusst auf die DEUTSCHEN Begriffe umgestellt: die alte Assertion
+        (`"fallback" not in body.lower()`) koennte nach der Eindeutschung
+        nicht mehr scheitern — das Wort kommt im neuen Text ohnehin nie vor.
+        Ein Test, der nicht scheitern KANN, bewacht nichts. Geprueft wird
+        deshalb, dass weder 'Ersatzquelle' noch 'Ersatzmodell' noch ein
+        Quellen-Klartextname auftaucht.
+        """
         from output.renderers.trip_report import TripReportFormatter
 
         seg = self._make_segment_data(fallback_model=None)
         formatter = TripReportFormatter()
         report = formatter.format_email([seg], "Test Trip", "morning")
 
-        assert "fallback" not in report.email_html.lower()
-        assert "fallback" not in report.email_plain.lower()
+        for name, body in (("html", report.email_html), ("plain", report.email_plain)):
+            assert "Ersatzquelle" not in body, (
+                f"{name}: Gewitter-Ersatzzeile ohne Fallback:\n{body[-1500:]}"
+            )
+            assert "Ersatzmodell" not in body, (
+                f"{name}: Wetter-Ersatzzeile ohne Fallback:\n{body[-1500:]}"
+            )
+            assert "DWD Europa" not in body, (
+                f"{name}: Quellen-Klartextname ohne Fallback:\n{body[-1500:]}"
+            )
+            assert "fallback" not in body.lower(), (
+                f"{name}: technischer Bestandshinweis ohne Fallback:\n{body[-1500:]}"
+            )
+
+    # -- Issue #1492 S2b: bisher ungedeckte Ausgaben ------------------------
+
+    def test_compact_footer_shows_fallback(self) -> None:
+        """AC-2: Given ein Segment mit gesetztem `fallback_model`, When die
+        KOMPAKT-Mail gerendert wird, Then enthaelt der Body die deutsche
+        Wetterzeile.
+
+        Heute (RED): die Kompakt-Mail zeigt gar keinen Hinweis — 0 Treffer
+        (Kontext-Doc „Der Hinweis erscheint heute in 2 von 7 Ausgaben").
+        `render_compact` faltet den Body per `fold_ascii()` auf reines ASCII,
+        deshalb wird die Erwartung mit derselben Produktionsfunktion gefaltet
+        statt eine zweite Schreibweise zu erfinden.
+        """
+        from app.models import TripReportConfig
+        from output.renderers.trip_report import TripReportFormatter
+        from utils.ascii_fold import fold_ascii
+
+        seg = self._make_segment_data(
+            fallback_model="icon_eu",
+            fallback_metrics=["cape", "visibility"],
+            fallback_reason="model_5xx",
+        )
+        report = TripReportFormatter().format_email(
+            [seg], "Test Trip", "morning",
+            report_config=TripReportConfig(email_format="compact"),
+        )
+        body = report.email_plain
+
+        assert report.email_html == "", "Kompakt-Format darf keinen HTML-Body liefern"
+        assert fold_ascii(_WETTER_ICON_EU) in body, (
+            f"AC-2: Kompakt-Mail zeigt keine Herkunfts-Klartextzeile:\n{body[-800:]}"
+        )
+        assert "icon_eu" not in body, "AC-2/AC-4: Rohkennung in der Kompakt-Mail"
+
+    def test_sms_stays_free_of_fallback_notice(self) -> None:
+        """AC-7: Given DASSELBE Segment, das in AC-1/AC-5 den Hinweis erzeugt,
+        When die SMS gerendert wird, Then enthaelt der SMS-Text weder
+        'Ersatzquelle' noch 'Ersatzmodell' noch einen Quellen-Klartextnamen,
+        und bleibt <= 160 Zeichen.
+
+        Strukturell erfuellt (die Kurzform sendet `report.sms_text`, laeuft
+        also nie durch `narrow.py`/`_tg_day_footer`) — dieser Test bewacht,
+        dass die Umsetzung der drei Langform-Ausgaben das nicht aufweicht.
+        Kein Dateiinhalt-Check: geprueft wird der ECHT gerenderte SMS-Text.
+        """
+        from output.renderers.trip_report import TripReportFormatter
+
+        seg = self._make_segment_data(
+            fallback_model="icon_eu",
+            fallback_metrics=["cape", "visibility", "lightning_potential_lpi_jkg"],
+            fallback_reason="model_5xx",
+        )
+        sms = TripReportFormatter().format_email([seg], "Test Trip", "morning").sms_text
+
+        assert "Ersatzquelle" not in sms, f"AC-7: Fallback-Hinweis in der SMS: {sms!r}"
+        assert "Ersatzmodell" not in sms, f"AC-7: Fallback-Hinweis in der SMS: {sms!r}"
+        assert "DWD Europa" not in sms, f"AC-7: Quellenname in der SMS: {sms!r}"
+        assert "Gewitterdaten" not in sms, f"AC-7: Gewitterzeile in der SMS: {sms!r}"
+        assert len(sms) <= 160, f"AC-7: SMS-Budget gesprengt ({len(sms)} Zeichen): {sms!r}"
+
+    def test_same_core_wording_in_html_plain_compact_and_telegram(self) -> None:
+        """AC-10: Given derselbe Fallback-Zustand (Kollision), When HTML-Mail,
+        Plain-Mail, Kompakt-Mail und Telegram-Langform fuer DASSELBE Segment
+        gerendert werden, Then tragen alle vier denselben Kern-Wortlaut —
+        nur die Verpackung unterscheidet sich.
+
+        Vergleich auf normalisierter Ebene (Zeilenumbrueche gefaltet, ASCII
+        gefaltet), weil Telegram bei 56 Zeichen umbricht und die Kompakt-Mail
+        per `fold_ascii()` Umlaute aufloest. Beides ist Verpackung, nicht
+        Wortlaut. Die Erwartung stammt aus der geteilten Funktion selbst —
+        damit prueft der Test genau die Zusicherung „EIN Modul, drei
+        Verpackungen" statt vier handgeschriebener Zeichenketten.
+        """
+        from app.models import TripReportConfig
+        from output.renderers.fallback_notice import build_fallback_lines
+        from output.renderers.trip_report import TripReportFormatter
+        from utils.ascii_fold import fold_ascii
+
+        def _norm(text: str) -> str:
+            return " ".join(fold_ascii(text).split())
+
+        seg = self._make_segment_data(
+            fallback_model="icon_eu",
+            fallback_metrics=["cape", "visibility", "lightning_potential_lpi_jkg"],
+            fallback_reason="model_5xx",
+        )
+        expected = build_fallback_lines(seg.timeseries.meta)
+        assert len(expected) == 2, (
+            f"Vorbedingung: der Kollisionsfall muss zwei Zeilen liefern — war {expected!r}"
+        )
+
+        full = TripReportFormatter().format_email([seg], "Test Trip", "morning")
+        compact = TripReportFormatter().format_email(
+            [seg], "Test Trip", "morning",
+            report_config=TripReportConfig(email_format="compact"),
+        )
+        overview = [b for b in full.telegram_bubbles if "Kurz" in b]
+        assert overview, "Kurzuebersicht-Bubble nicht gefunden"
+
+        ausgaben = {
+            "html": full.email_html,
+            "plain": full.email_plain,
+            "compact": compact.email_plain,
+            "telegram": overview[0],
+        }
+        for name, body in ausgaben.items():
+            haystack = _norm(body)
+            for line in expected:
+                # L4: ANZAHL statt blossem Vorkommen. Ein doppelt gerenderter
+                # Hinweis waere fuer den Nutzer sichtbar, wurde aber von keinem
+                # Test gefangen — `in` findet den Wortlaut auch beim zweiten
+                # Mal. Gemessen: `+ fallback_row + fallback_row` in html.py
+                # liess alle Tests gruen. Geprueft wird deshalb `== 1` und
+                # nicht `>= 1`; das deckt „fehlt" und „doppelt" zugleich ab.
+                treffer = haystack.count(_norm(line))
+                assert treffer == 1, (
+                    f"AC-10: '{line}' erscheint {treffer}x in der Ausgabe "
+                    f"'{name}' — erwartet genau einmal (0 = die vier Ausgaben "
+                    f"tragen nicht denselben Kern-Wortlaut, >1 = der Hinweis "
+                    f"steht doppelt in der Nutzer-Ausgabe).\n"
+                    f"Ausgabe (Ende):\n{body[-900:]}"
+                )
+
+    # -- F001: Mehrsegment-Trips — die Vertretung kann eine SPAETERE Etappe
+    #    betreffen. Vorher las die Mail starr `segments[0]`, Telegram das
+    #    erste fehlerfreie Segment — beide verschwiegen den Fall still
+    #    (ADR-0018/ADR-0047: Fallback ohne Kaschieren).
+
+    def test_multi_segment_fallback_after_broken_first_segment(self) -> None:
+        """F001: Given Segment 1 hat einen Provider-Fehler (keine Zeitreihe)
+        und Segment 2 traegt einen echten Fallback, When alle vier Ausgaben
+        gerendert werden, Then zeigen ALLE VIER die Klartext-Wetterzeile.
+
+        Vorher: Telegram zeigte sie, HTML/Plain/Kompakt nicht.
+        """
+        from utils.ascii_fold import fold_ascii
+
+        segments = [
+            self._make_segment_data(segment_id=1, with_timeseries=False, has_error=True),
+            self._make_segment_data(
+                segment_id=2, fallback_model="icon_eu",
+                fallback_metrics=["cape", "visibility"], fallback_reason="model_5xx",
+            ),
+        ]
+
+        for name, body in self._alle_vier_ausgaben(segments).items():
+            haystack = " ".join(fold_ascii(body).split())
+            assert " ".join(fold_ascii(_WETTER_ICON_EU).split()) in haystack, (
+                f"F001: '{name}' verschweigt die Vertretung aus Segment 2, "
+                f"obwohl Segment 1 nur einen Abruffehler hat.\n{body[-900:]}"
+            )
+
+    def test_multi_segment_fallback_after_clean_first_segment(self) -> None:
+        """F001: Given Segment 1 ist fehlerfrei UND ohne Fallback, Segment 2
+        traegt einen Fallback, When alle vier Ausgaben gerendert werden, Then
+        zeigen ALLE VIER die Klartext-Wetterzeile.
+
+        Das ist der Fall, den BEIDE frueheren Auswahlregeln verschluckt haben
+        — `segments[0]` ebenso wie „erstes fehlerfreies Segment".
+        """
+        from utils.ascii_fold import fold_ascii
+
+        segments = [
+            self._make_segment_data(segment_id=1),
+            self._make_segment_data(
+                segment_id=2, fallback_model="icon_eu",
+                fallback_metrics=["cape", "visibility"], fallback_reason="model_5xx",
+            ),
+        ]
+
+        for name, body in self._alle_vier_ausgaben(segments).items():
+            haystack = " ".join(fold_ascii(body).split())
+            assert " ".join(fold_ascii(_WETTER_ICON_EU).split()) in haystack, (
+                f"F001: '{name}' verschweigt die Vertretung aus Segment 2.\n{body[-900:]}"
+            )
+
+    def test_multi_segment_thunder_fallback_in_later_segment(self) -> None:
+        """F001/AC-1: Dasselbe fuer die GEWITTER-Vertretung — sie zeigt sich
+        allein in `fallback_metrics` (R2) und darf in keiner der vier
+        Ausgaben verschwinden, nur weil sie eine spaetere Etappe betrifft."""
+        from utils.ascii_fold import fold_ascii
+
+        segments = [
+            self._make_segment_data(segment_id=1),
+            self._make_segment_data(
+                segment_id=2, fallback_model="eu_direct",
+                fallback_metrics=["lightning_potential_lpi_jkg"],
+                fallback_reason="thunder_source_unavailable",
+            ),
+        ]
+        erwartet = "Gewitterdaten von Ersatzquelle: DWD Europa (gröbere Auflösung)"
+
+        for name, body in self._alle_vier_ausgaben(segments).items():
+            haystack = " ".join(fold_ascii(body).split())
+            assert " ".join(fold_ascii(erwartet).split()) in haystack, (
+                f"F001: '{name}' verschweigt die Gewitter-Vertretung aus "
+                f"Segment 2.\n{body[-900:]}"
+            )
+
+    def test_multi_segment_without_fallback_shows_nothing(self) -> None:
+        """F001 GEGENPROBE: Given KEIN Segment traegt eine Vertretung (eines
+        davon mit Abruffehler), When alle vier Ausgaben gerendert werden, Then
+        erscheint nirgends eine Ersatz-Zeile — die erweiterte Suche darf nicht
+        zum Dauer-Hinweis werden."""
+        segments = [
+            self._make_segment_data(segment_id=1),
+            self._make_segment_data(segment_id=2, with_timeseries=False, has_error=True),
+            self._make_segment_data(segment_id=3),
+        ]
+
+        for name, body in self._alle_vier_ausgaben(segments).items():
+            assert "Ersatzquelle" not in body, f"{name}: Ersatzzeile ohne Fallback"
+            assert "Ersatzmodell" not in body, f"{name}: Ersatzzeile ohne Fallback"
+            assert "DWD Europa" not in body, f"{name}: Quellenname ohne Fallback"


### PR DESCRIPTION
## Was der Nutzer jetzt sieht

Scheibe 2a (ADR-0047) hält seit dem 2026-08-06 fest, *dass* eine Gewitter-Direktquelle vertreten wurde — aber nur intern in `ForecastMeta`. Diese Scheibe macht es sichtbar, in Klartext.

| Lage | Was im Briefing steht |
|---|---|
| Kein Ausfall | *(nichts)* |
| Gewitterquelle ausgefallen | `Gewitterdaten von Ersatzquelle: DWD Europa (gröbere Auflösung)` |
| Hauptvorhersage ausgewichen | `Einzelne Wetterwerte von Ersatzmodell: DWD Europa (Gewitterenergie, Sicht)` |
| Ganzer Anbieter ausgefallen | `Einzelne Wetterwerte von Ersatzmodell: GeoSphere Österreich` |
| **Beides gleichzeitig** | `Gewitterdaten von einer Ersatzquelle (gröbere Auflösung)`<br>`Einzelne Wetterwerte von Ersatzmodell: DWD Europa (Gewitterenergie)` |
| Unbekannte Quelle | `Einzelne Wetterwerte von Ersatzmodell: brandneues_modell (irgendwas_neues)` |

**Ausgaben:** Trip-Briefing-Mail Vollversion (Bestandshinweis umgestellt) · Kompakt-Mail (neu) · Telegram-Langform (neu).
**Bewusst außen vor:** Ortsvergleichs-Mail (eigene Folgescheibe — dort mehrere Orte mit je eigener Herkunft), Alarm-Mails, SMS, Telegram-Kurzform (160-Zeichen-Budget; sie sendet strukturell den SMS-Text).

## Zwei Ursachen, zwei Zeilen — ein mitbehobener Darstellungsfehler

Die bisherige Zeile `Fallback {metrics}: {model}` verknüpfte Metrikliste und Modellnamen **ungeprüft** in einem String. Feuern Gewitter-Vertretung und Grundvorhersage-Fallback auf derselben Zeitreihe, behauptete sie einen Zusammenhang, den es nicht gibt — erst durch 2a erreichbar geworden.

Die Gewitterzeile erkennt die Vertretung an `fallback_metrics`, **nicht** am Modellnamen: der Merge-Schutz aus 2a lässt `fallback_model` im Kollisionsfall den Namen des *anderen* Mechanismus tragen (ausdrückliche Auflage aus ADR-0047 und 2a-KL-3). Im Kollisionsfall nennt die Gewitterzeile deshalb **keinen** Quellennamen — ehrlich unbestimmt statt falsch benannt.

Ein **geteiltes Modul** (`fallback_notice.py`) bedient alle vier Ausgaben; bisher stand im Code ausdrücklich „spiegelt plain.py".

## Adversary: VERIFIED nach drei Durchgängen

| Befund | Was er war |
|---|---|
| **F001** HIGH | Mail und Telegram wählten die Etappe **verschieden** — und beide sahen nur **eine**. Eine Vertretung ab Etappe 2 blieb unsichtbar. Die Telegram-Zusatzlogik war zudem komplett ungetestet: durch `segments[0]` ersetzt blieben alle 28 Tests grün. Auswahl jetzt geteilt und über alle Etappen. |
| **F002** MEDIUM | Ein defekter Provider-Import riss die **gesamte** Rendering-Kette mit, auch für Trips ganz ohne Fallback. |
| **F003** HIGH | Bei defektem Import **plus** Kollision landete ein Gewitter-Feldname in der Wetterzeile und wurde dem **falschen** Ersatzmodell zugeschrieben. Jetzt entfällt die Klammer: keine Angabe schlägt falsche Angabe. |
| **F004** + L1–L4 | Fünf Tests, die ihre Zusicherung nicht halten konnten — jeder mit Vorher/Nachher-Mutation belegt geschärft. |

Der dritte Durchgang stellte alle vier Befunde **unabhängig** nach, prüfte jedes geschlossene Testloch gegen und fuhr 9 neue Mutationen (7 gefangen; 2 grün gebliebene als nachweislich unerreichbare Zweige belegt). 18 bestätigte Kriterien, kein offener Punkt.

### 🔴 Die Lehre dieser Scheibe: „leer" ist nicht „unbekannt"

F003 entstand, weil eine Funktion im Fehlerfall ein leeres `frozenset` zurückgab. Das sah harmlos aus, war aber eine **Behauptung** („es gibt keine Gewitterfelder"), wo nur Unwissen vorlag — und daraus wurde eine falsche Aussage in der Mail. Der Unterschied kostet eine Zeile Code und war ein HIGH-Befund.

## Nachweise

- **48 Zieltests** grün (42 Kern + 6 live-markiert), Renderer-Gate `test_issue_811_mode_matrix.py` 43 grün
- **Gezielte Regression** über 13+ Renderer-Suiten ohne neue Fehler; vorbestehende Rote per A/B **im selben Worktree** gegen den Basisstand belegt (fehlende Trip-Fixture, kein Renderer-Code)
- **Echte Staging-Testmail** zugestellt, `briefing_mail_validator.py` Exit 0
- `ruff` sauber, `.claude/validate.py` grün

## Nebenbefunde (gebucht, nicht hier behoben)

Drei Einträge in **#1196**: eine Testdatei, die wegen eines Modul-Markers weder lokal noch in CI läuft · zwei Metrik-Gating-Tests ohne Fußzeilen-Anker · und der allgemeine Befund, dass Renderer-Tests durchweg *Vorkommen* statt *Anzahl* prüfen (Sonde: Hinweis in der HTML-Mail verdoppelt ⇒ 42 von 42 Tests grün).

Refs #1492

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzaMdw2Cnt9o6iVx5QRwHD
