### PR TITLE
fix(#1552): Anlege-Dialog mountet den Wetter-Reiter nur noch einmal

### DIFF
--- a/frontend/e2e/trip-new-loads-without-effect-loop.spec.ts
+++ b/frontend/e2e/trip-new-loads-without-effect-loop.spec.ts
@@ -1,4 +1,8 @@
 import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import * as path from 'node:path';
+
+const MOBILE = { width: 390, height: 844 };
 
 // E2E — Staging-Befund Fix-Loop 2 (Issue #1552): /trips/new stürzt beim
 // Laden, ohne jede Interaktion, mit `effect_update_depth_exceeded` ab.
@@ -58,4 +62,98 @@ test('Staging-Befund #1552 Fix-Loop 2: /trips/new lädt ohne Konsolenfehler, Rea
 	await expect(page.getByText('⊘ Tour-Name fehlt')).toBeVisible();
 	await page.getByTestId('trip-new-name-input-desktop').fill('E2E Fix-Loop-2 Regressionstest');
 	await expect(page.getByText('⊘ Tour-Name fehlt')).not.toBeVisible();
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Fix-Loop 4 (Staging-Befund, 4x reproduziert): der Absturz aus Fix-Loop 2
+// kehrte zurueck, sobald im Anlege-Dialog EINE Checkbox im Wetter-Reiter
+// geklickt wird -- der obige Test klickt keine einzige Checkbox und liess
+// genau das durchrutschen, obwohl er gruen war.
+//
+// Root Cause (isoliert per Instanz-Markierung, s. docs/artifacts/
+// fix-1552-neuanlage-metrikverlust/red_effect_loop_playwright.txt):
+// TripNewEditor.svelte mountete WeatherMetricsTab ZWEIMAL (Desktop+Mobile,
+// Issue #941). Ein Klick erreicht nur EINE der beiden Instanzen -- danach
+// unterscheiden sich deren `buckets` DAUERHAFT (die beruehrte hat 8, die
+// unberuehrte weiterhin 7). Beide schreiben ihren fuer sich stabilen, aber
+// voneinander verschiedenen Inhalt in denselben Rueckkanal (weatherMetrics)
+// -- unbegrenztes Wechselspiel. Fix: isMobileViewport-Gate (Vorbild
+// activity-dropdown, Issue #932) haelt nur EINE Instanz im DOM.
+//
+// Reale Ziel-Oberflaeche des Klicks: /trips/new, Reiter „Wetter-Metriken",
+// Grundauswahl-Kacheln (WeatherV2Grundauswahl.svelte, Buttons mit
+// title=Metrik-Label). Navigationspfad (GPX-Upload je Etappe) 1:1 aus
+// issue-774-metrics-summary-persist.spec.ts / issue-776-metrics-toggle.spec.ts
+// uebernommen (bewaehrter, mobiler Pfad zum Wetter-Reiter).
+// ═══════════════════════════════════════════════════════════════════════
+
+async function openNewTripWetterTab(page: Page, name: string): Promise<void> {
+	await page.setViewportSize(MOBILE);
+	await page.goto('/trips/new');
+	await page.getByTestId('trip-new-name-input-mobile').fill(name);
+	await page.getByTestId('trip-new-date-input').fill(new Date().toISOString().slice(0, 10));
+
+	const tabbar = page.getByTestId('tn-mobile-tabbar');
+	await tabbar.getByRole('tab', { name: /Etappen/ }).click({ force: true });
+
+	const gpx = path.resolve('./e2e/fixtures/test-trip.gpx');
+	const stageCount = await page.locator('.tn-mobile input[type="file"][accept=".gpx"]').count();
+	for (let i = 0; i < stageCount; i++) {
+		const input = page.locator('.tn-mobile input[type="file"][accept=".gpx"]').first();
+		await Promise.all([
+			page.waitForResponse((r) => r.url().includes('/api/gpx/parse'), { timeout: 30_000 }).catch(() => null),
+			input.setInputFiles(gpx),
+		]);
+		await page.waitForTimeout(600);
+	}
+
+	await tabbar.getByRole('tab', { name: /Wetter/ }).click({ force: true });
+	await expect(page.locator('.tn-mobile').getByTestId('wm2-grundauswahl')).toBeVisible({ timeout: 15_000 });
+}
+
+test('Staging-Befund #1552 Fix-Loop 4: ein Checkbox-Klick im Wetter-Reiter darf die Seite nicht in eine Endlosschleife schicken', async ({ page }) => {
+	const consoleErrors: string[] = [];
+	page.on('console', (msg) => {
+		if (msg.type() === 'error') consoleErrors.push(msg.text());
+	});
+	const pageErrors: string[] = [];
+	page.on('pageerror', (err) => pageErrors.push(err.message));
+
+	await openNewTripWetterTab(page, 'E2E Fix-Loop-4 Regressionstest');
+
+	// Eine Groesse anhaken (Bewölkung ist NICHT Teil der 7 Standardgroessen,
+	// steht also aus), eine abwaehlen (Sichtweite ist Teil der 7 Standard-
+	// groessen, steht also an) -- exakt der vom Team Lead beschriebene
+	// Nutzerweg ("egal ob anhaken oder abwählen").
+	const grundauswahl = page.locator('.tn-mobile').getByTestId('wm2-grundauswahl');
+	await grundauswahl.locator('button[title="Bewölkung"]').click();
+	await page.waitForTimeout(300);
+	await grundauswahl.locator('button[title="Sichtweite"]').click();
+
+	// Die gemeldete Schleife trat ~1s NACH dem Klick auf -- Wartezeit analog
+	// zum Ladefall oben, aber grosszuegiger (der Staging-Befund nennt "etwa
+	// eine Sekunde danach").
+	await page.waitForTimeout(2000);
+
+	const allErrors = [...consoleErrors, ...pageErrors];
+	expect(
+		allErrors,
+		`Konsolenfehler nach Checkbox-Klick im Wetter-Reiter (erwartet: keine):\n${allErrors.join('\n')}`
+	).toHaveLength(0);
+
+	// (a) Reaktivitäts-Beweis Nr. 1 (Team-Lead-Symptom „Route-Tab lässt sich
+	// nicht mehr befüllen"): zurück zum Route-Tab, Name-Feld neu befüllen,
+	// muss ankommen.
+	const tabbar = page.getByTestId('tn-mobile-tabbar');
+	await tabbar.getByRole('tab', { name: 'Route', exact: true }).click({ force: true });
+	const nameInput = page.getByTestId('trip-new-name-input-mobile');
+	await nameInput.fill('E2E Fix-Loop-4 nach Checkbox-Klick');
+	await expect(nameInput).toHaveValue('E2E Fix-Loop-4 nach Checkbox-Klick');
+
+	// (b) Reaktivitäts-Beweis Nr. 2 (Team-Lead-Symptom „Trip speichern bleibt
+	// dauerhaft deaktiviert"): Zeitplan-Tab besuchen (setzt ztVisited, s.
+	// tripNewLogic.ts canSave()), danach muss der Speichern-Button bedienbar
+	// sein.
+	await tabbar.getByRole('tab', { name: /Zeitplan/ }).click({ force: true });
+	await expect(page.getByTestId('tn-mobile-save')).toBeEnabled({ timeout: 5000 });
 });

--- a/frontend/src/lib/components/trip-new/TripNewEditor.svelte
+++ b/frontend/src/lib/components/trip-new/TripNewEditor.svelte
@@ -789,11 +789,22 @@
 
 		<!-- Wetter-Tab: reuse WeatherMetricsTab im createMode -->
 		<!-- Issue #932 — Aktivitätstyp-Dropdown lebt jetzt im Route-Tab. -->
-		<!-- Issue #941 — WeatherMetricsTab IMMER gemountet (per display ausgeblendet),
-		     damit isDirty/buckets/savedSnapshot bei Tab-Wechseln nicht verloren gehen. -->
+		<!-- Issue #941 — WeatherMetricsTab bleibt beim Tab-Wechsel gemountet (per
+		     display ausgeblendet), damit isDirty/buckets/savedSnapshot erhalten
+		     bleiben. Fix-Loop 4 (Staging-Befund #1552, effect_update_depth_exceeded
+		     bei jedem Checkbox-Klick): NEU per isMobileViewport-Gate (Vorbild
+		     activity-dropdown, Issue #932) nur EINE Instanz im DOM -- Desktop UND
+		     Mobile hielten sonst je eine EIGENE Kopie von buckets/friendlyMap/... und
+		     schrieben unabhaengig in denselben Rueckkanal (weatherMetrics); nach einem
+		     Klick auf NUR einer Seite blieben beide Kopien dauerhaft verschieden und
+		     ueberschrieben sich gegenseitig unbegrenzt. catalogLoaded-Gate und
+		     Inhaltsgleichheitspruefung (Fix-Loop 2/3) bleiben als Zusatzschutz
+		     bestehen (Resize-Grenzfall: Tab kann kurzzeitig neu mounten). -->
+		{#if !isMobileViewport}
 		<div style:display={activeTab === 'metriken' ? '' : 'none'}>
 			<WeatherMetricsTab trip={stubTrip} createMode={true} onChannelsChange={handleChannelsChange} onWeatherMetricsChange={handleWeatherMetricsChange} />
 		</div>
+		{/if}
 		</div><!-- /.tn-desktop -->
 
 		<!-- ══════════════════════════════════════════════════════
@@ -1014,11 +1025,14 @@
 
 			<!-- Mobile Wetter-Tab: WeatherMetricsTab (bereits mobil, #618) -->
 			<!-- Issue #932 — Aktivitätstyp-Dropdown lebt jetzt im Route-Tab. -->
-			<!-- Issue #941 — WeatherMetricsTab IMMER gemountet (per display ausgeblendet),
-			     damit isDirty/buckets/savedSnapshot bei Tab-Wechseln nicht verloren gehen. -->
+			<!-- Issue #941 — WeatherMetricsTab bleibt beim Tab-Wechsel gemountet (per
+			     display ausgeblendet). Fix-Loop 4 (s. Desktop-Mount oben): per
+			     isMobileViewport-Gate nur EINE Instanz im DOM (Desktop XOR Mobile). -->
+			{#if isMobileViewport}
 			<div style:display={activeTab === 'metriken' ? '' : 'none'}>
 				<WeatherMetricsTab trip={stubTrip} createMode={true} onChannelsChange={handleChannelsChange} onWeatherMetricsChange={handleWeatherMetricsChange} />
 			</div>
+			{/if}
 
 			<!-- Lock-Toast (2s bei Tap auf gesperrten Tab) -->
 			{#if lockToastMsg}


### PR DESCRIPTION

Nach dem catalogLoaded-Gate bestanden AC-1/AC-5/AC-6/AC-7 auf Staging sauber,
aber derselbe Absturz kam bei echter Nutzerinteraktion zurueck: EIN Klick auf
eine Checkbox — anhaken wie abwaehlen — loeste erneut
effect_update_depth_exceeded aus, 4x unabhaengig reproduziert. Danach war die
Seite tot: "Trip speichern" dauerhaft deaktiviert, das Namensfeld liess sich
nicht mehr befuellen.

Ursache war nie das Timing allein, sondern die Struktur: TripNewEditor mountete
WeatherMetricsTab zweimal (Desktop + Mobile, beide dauerhaft im DOM, nur per CSS
ausgeblendet). Ein Klick erreicht nur EINE Instanz; danach unterscheiden sich
deren buckets DAUERHAFT (berührte 8, unberuehrte 7). Beide haben
catalogLoaded=true und schreiben ihren je fuer sich stabilen, aber voneinander
verschiedenen Inhalt in denselben Rueckkanal. Die Inhaltsgleichheitspruefung
fangt nur wiederholte IDENTISCHE Schreibvorgaenge einer Instanz — nicht das
Wechselspiel zweier Instanzen mit dauerhaft verschiedenem Inhalt.

Zwei Guards hatten damit zweimal ein Symptom abgefangen; beim dritten Mal war
dieselbe Klasse ueber einen neuen Weg wieder da. Deshalb kein dritter Guard,
sondern die Struktur: beide Mounts liegen jetzt hinter {#if !isMobileViewport}
bzw. {#if isMobileViewport} — nie mehr beide gleichzeitig im DOM.

Das ist kein neues Muster, sondern das bereits etablierte aus derselben Datei:
das Aktivitaetstyp-Dropdown (#932) wird aus exakt diesem Grund per
isMobileViewport nur einmal gerendert. catalogLoaded-Gate und
Gleichheitspruefung bleiben als Schutz fuer den Resize-Grenzfall bestehen.

Geprueft: Beim Ueberschreiten der Breitenschwelle unmountet die alte Instanz,
die neue liest weatherMetrics ueber initFromTrip() zurueck, inklusive
bucket/order — kein Datenverlust, allenfalls ein kurzer Reflow.

Der Test folgt jetzt dem Nutzerweg statt nur dem Seitenaufruf: Name + Datum,
GPX je Etappe, Wetter-Reiter oeffnen, eine Groesse anhaken und eine abwaehlen,
danach (a) keine Konsolenfehler, (b) Namensfeld nimmt wieder Eingaben an,
(c) "Speichern" bleibt bedienbar. Der alte Lade-Test blieb waehrend der
RED-Reproduktion gruen — er kann diese Fehlerklasse strukturell nicht sehen.
Genau deshalb rutschte sie durch.

Belege: RED gegen cd869b0b (Absturz exakt nach dem zweiten Klick), GREEN 3x
wiederholt mit jeweils geloeschtem Build-Cache, Regressionslauf ueber
issue-932-activity-type-route-tab.spec.ts und issue-661-trip-new-mobile.spec.ts
(7 Tests, mehrere Viewports) vollstaendig gruen.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Dritter Nachtrag zu Issue #1552 (nach #1554, #1560). Staging-Verifikation folgt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)