### PR TITLE
fix(#1289): E2E-Preview-Server bekommt nur noch die Env-Variablen, die er liest

### DIFF
--- a/docs/context/fix-1289-e2e-env-minimal.md
+++ b/docs/context/fix-1289-e2e-env-minimal.md
@@ -1,0 +1,142 @@
+# Context: fix-1289-e2e-env-minimal
+
+## Request Summary
+
+`frontend/e2e/start-preview.sh` lädt per `set -a; source ../../.env` alle 41 Schlüssel der
+Haupt-`.env` (u.a. `GZ_SMTP_PASS`, `GZ_TELEGRAM_BOT_TOKEN`, `GZ_IMAP_PASS`,
+`GZ_METEOFRANCE_APIKEY`) in den Prozess des lokalen E2E-Preview-Servers, obwohl dieser nur
+einen Bruchteil davon liest. Ziel: den Kindprozess auf den tatsächlich benötigten Variablensatz
+begrenzen.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `frontend/e2e/start-preview.sh` | Zu ändernde Datei — lädt aktuell blanket alle `.env`-Keys |
+| `frontend/playwright.config.ts:12` | setzt `GZ_API_BASE`-Default im Playwright-Hauptprozess, spawnt `start-preview.sh` als `webServer.command` |
+| `frontend/e2e/global.setup.ts:24-33` | prüft `GZ_API_BASE` gegen Prod-Guard, loggt sich per `E2E_USER`/`E2E_PASS` gegen den echten Login-Endpoint ein — der Login-Erfolg hängt an einem korrekt verifizierbaren `gz_session`-Cookie |
+| `frontend/src/hooks.server.ts:16-18` | SvelteKit verifiziert `gz_session` selbst mit `env.GZ_SESSION_SECRET ?? 'dev-secret-change-me'` — **das ist die einzige echte Secret-Abhängigkeit des Preview-Prozesses** |
+| `frontend/src/routes/login/+page.server.ts:10`, `frontend/src/routes/register/+page.server.ts:9` | lesen nur `!!env.GZ_GOOGLE_CLIENT_ID` (Boolean-Toggle, keine Anmeldelogik, keine Secret-Nutzung — Client-ID ist ohnehin kein Geheimnis) |
+| `.env.e2e` (Repo-Root) | **git-getrackt** (kein `.gitignore`-Treffer, da Pattern `.env` nicht auf `.env.e2e` matcht), aktuell nur `GZ_TEST_FIXTURE_DIR=fixtures/openmeteo` — **darf nie ein Secret enthalten**, sonst neuer #1537-Fall |
+| `internal/config/config.go:16` | Go-API: `SessionSecret` via `envconfig:"SESSION_SECRET"` mit Prefix `GZ` → `GZ_SESSION_SECRET`, Default ebenfalls `dev-secret-change-me` |
+| `internal/middleware/auth.go:77-111` | `SignSession`/`validateSession` — HMAC-SHA256 mit dem Secret; Cookie ist nur verifizierbar, wenn Signierer (Go) und Prüfer (SvelteKit) denselben Wert nutzen |
+| `internal/router/router.go:37,47` | Go-API nutzt `deps.Config.SessionSecret` für `AuthMiddleware` und `LoginHandler` |
+
+## Existing Patterns
+
+- **Playwright-Proxy-Ziel ist Staging, nicht lokal gestartet:** `frontend/e2e/apiProxyTarget.ts:12`
+  und `playwright.config.ts:12` zeigen `GZ_API_BASE`/`GZ_E2E_API_PROXY_TARGET` per Default auf
+  `http://localhost:8091` — den **dauerhaft laufenden Staging-Go-Server** (`gregor-api-staging`,
+  systemd, `EnvironmentFile=/home/hem/gregor_zwanzig_staging/.env`). `start-preview.sh` startet
+  **nur** den SvelteKit-Preview-Prozess, nicht die Go-API — die läuft bereits, unabhängig vom
+  Skript, mit ihrer **eigenen** Env-Datei.
+- **Gemessen: `GZ_SESSION_SECRET` ist zwischen Repo-`.env` und Staging-`.env` aktuell identisch**
+  (SHA-256-Vergleich der Zeilen, kein Klartext gelesen). Das ist aber Konvention, keine erzwungene
+  Garantie — der Preview-Prozess MUSS weiterhin genau diesen einen Wert aus der Haupt-`.env`
+  beziehen, sonst verifiziert `hooks.server.ts` kein vom Staging-Server signiertes Cookie mehr und
+  **jeder** authentifizierte E2E-Test scheitert still (Redirect-Loop auf `/login`, kein klarer
+  Fehler).
+- **`.env`-Ausnahmen sind die wiederkehrende Fehlerquelle in diesem Projekt** (#1537: Negation in
+  `.gitignore` für `frontend/.env.test`). Konsequenz hier: keine neue Datei mit Secret-Inhalt
+  anlegen, insbesondere nicht `.env.e2e` (ist bereits getrackt).
+- **Referenz-Stil für gezielte Env-Weitergabe:** kein bestehendes Beispiel im Repo für "Werte aus
+  `.env` gezielt herausgreifen statt blanket sourcen" — das ist Neuland für dieses Skript, aber ein
+  einfaches `grep -m1 '^KEY=' .env | cut -d= -f2-`-Muster genügt.
+
+## Dependencies
+
+- **Upstream (was der Preview-Prozess selbst braucht):** `GZ_API_BASE` (kein Secret, bereits mit
+  Inline-Default abgesichert), `GZ_SESSION_SECRET` (Secret, **muss** mit Staging-Go
+  übereinstimmen), `GZ_GOOGLE_CLIENT_ID` (kein Secret), `NODE_ENV` (kein Secret, bereits separat
+  exportiert).
+- **Downstream (was von `start-preview.sh` abhängt):** `playwright.config.ts` (`webServer.command`),
+  darüber alle ~150 Spec-Dateien in `frontend/e2e/`, die einen laufenden Preview-Server
+  voraussetzen. Ein zu knapper Variablensatz bricht die gesamte lokale E2E-Suite, nicht nur
+  einzelne Tests.
+- **Nicht benötigt vom Preview-Prozess (verifiziert durch Grep, 0 Treffer in `frontend/`):**
+  `GZ_TEST_FIXTURE_DIR` (nur Python-Core), alle SMTP-/IMAP-/Telegram-/API-Key-Variablen (0
+  Fundstellen in `frontend/src` oder `frontend/e2e`).
+
+## Existing Specs
+
+- `docs/specs/_archive/modules/fix_1284_admin_prod_testdata.md` — führte den Staging-Proxy
+  (Port 8091) und die Guard-Kette (`assertNotProdApiProxyTarget`) ein; direkter Vorgänger-Kontext
+  für dieses Skript.
+- Kein bestehendes Spec-Modul zu `start-preview.sh` selbst.
+
+## Risks & Considerations
+
+- **Größtes Risiko:** `GZ_SESSION_SECRET` versehentlich weglassen oder falsch extrahieren → alle
+  authentifizierten E2E-Tests scheitern lokal, mit einer irreführenden Fehlermeldung (Redirect
+  statt klarer Secret-Fehler), da `hooks.server.ts` klaglos auf den Dev-Fallback zurückfällt.
+- **Zweitgrößtes Risiko:** eine neue/duplizierte Env-Datei mit dem extrahierten Secret anlegen und
+  dabei versehentlich in einer getrackten Datei landen (`.env.e2e` ist bereits getrackt) — das
+  wäre ein neuer #1537-Fall, diesmal selbst verursacht.
+- **Testbarkeit:** Der Kern-Testlayer darf keine echten Netzwerkaufrufe machen. Eine Prüfung
+  „welche Variablen landen im Kindprozess" muss ohne echten `npm run build`/`preview`-Lauf
+  auskommen — die Env-Extraktionslogik muss so geschnitten sein, dass sie isoliert (z. B. per
+  `bash -c 'source ...; env'` vor der letzten Zeile) prüfbar ist, ohne den Server tatsächlich zu
+  starten.
+- **Kein Blast-Radius auf Staging/Prod:** Das Skript läuft ausschließlich lokal (Playwright
+  `webServer`), nicht als systemd-Unit — Änderungen hier berühren keine laufenden Dienste.
+
+## Analysis
+
+### Type
+Bug (GitHub-Label `bug`) — unerwünschtes Verhalten (Secret-Überexposition), keine neue
+Funktionalität.
+
+### Vollständige Env-Lesestellen des Frontend-Server-Codes (erschöpfend gegrept, `env\.[A-Z]`
+über `frontend/src`, ohne Tests)
+
+| Variable | Datei | Secret? | Quelle |
+|---|---|---|---|
+| `GZ_SESSION_SECRET` | `hooks.server.ts:16` | **JA** | muss mit Staging-Go (`internal/config/config.go:16`) übereinstimmen |
+| `GZ_API_BASE` | `lib/server/apiBase.ts:5` | nein (URL) | kommt NICHT aus `.env` (0 Treffer dort) — ausschließlich über Shell-Env/Playwright-Default gesetzt |
+| `GZ_GOOGLE_CLIENT_ID` | `routes/login/+page.server.ts:10`, `routes/register/+page.server.ts:9` | nein (Client-ID ist kein Geheimnis) | nur Boolean-Toggle, kein E2E-Test prüft ihn |
+| `NODE_ENV` | `routes/login/+page.server.ts:47`, `routes/magic-link/verify/+page.server.ts:46` | nein | bereits separat exportiert |
+
+Kein weiterer Treffer — insbesondere **keine** SMTP-/IMAP-/Telegram-/API-Key-Variable wird vom
+Frontend-Code je gelesen. Die verbleibenden 37 in `.env` gesetzten Schlüssel sind für
+`start-preview.sh` beweisbar überflüssig.
+
+### Affected Files (with changes)
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `frontend/e2e/start-preview.sh` | MODIFY | Blanket-`source ../../.env` ersetzen durch gezielten Export von genau `GZ_SESSION_SECRET` + `GZ_GOOGLE_CLIENT_ID`; `.env.e2e`-Sourcing bleibt (enthält kein Secret, ist getrackt) |
+| `frontend/e2e/e2e-env.sh` (neu) | CREATE | Ausgelagerte, isoliert testbare Extraktionslogik (kein `npm run build`/`preview` darin) — `start-preview.sh` sourced sie |
+| `frontend/src/lib/__tests__/e2e_env_minimal.test.ts` (neu) | CREATE | Kern-Test (kein Netz): sourced `e2e-env.sh` gegen eine Fixture-`.env`, prüft per `env`-Ausgabe, dass NUR die erlaubten Keys exportiert werden |
+
+### Scope Assessment
+- Files: 3 (1 modify, 2 create)
+- Estimated LoC: ~+45/-4 (deutlich unter dem 250-LoC-Limit)
+- Risk Level: **LOW** — lokal laufendes Skript, keine systemd-Unit, kein Staging-/Prod-Pfad berührt; einziges echtes Risiko ist ein falsch extrahierter `GZ_SESSION_SECRET` (durch den Kern-Test abgesichert)
+
+### Technical Approach
+1. `e2e-env.sh` liest `GZ_SESSION_SECRET` und `GZ_GOOGLE_CLIENT_ID` gezielt aus der
+   Haupt-`.env` (`grep -m1 '^KEY=' … | cut -d= -f2-`) und exportiert nur diese beiden — keine
+   Duplizierung des Wertes in eine zweite Datei (vermeidet einen neuen #1537-Fall über
+   `.env.e2e`, die getrackt ist).
+2. `start-preview.sh` sourced `e2e-env.sh` statt blanket `.env` zu sourcen; `.env.e2e`
+   (unverändert, secret-frei) bleibt wie bisher.
+3. Kommentar an der Stelle referenziert #1289 und die Messung (welche Variablen der
+   Preview-Prozess tatsächlich liest), damit eine künftige Erweiterung bewusst erfolgt statt
+   versehentlich auf Blanket-Sourcing zurückzufallen.
+4. Kern-Test sourced `e2e-env.sh` mit `GZ_REPO_ENV_FILE` auf eine Scratch-Fixture umgebogen
+   (kein Zugriff auf die echte `.env`, kein Netz), prüft: erlaubte Keys vorhanden, mindestens
+   ein bekannter Secret-Key (`GZ_SMTP_PASS` o. ä.) explizit NICHT in der resultierenden
+   Umgebung.
+
+### Dependencies
+- Kein Downstream-Bruch erwartet: `playwright.config.ts` ruft `start-preview.sh` unverändert per
+  `webServer.command` auf; das Interface (welche Env-Variablen am Ende im Kindprozess sichtbar
+  sind) bleibt für die 4 tatsächlich gelesenen Variablen identisch, nur die 37 unnötigen
+  entfallen.
+- `npm run test` (node:test, `frontend/package.json`) ist der bestehende Testrunner für den
+  neuen Kern-Test — kein neues Tool nötig.
+
+### Open Questions
+Keine offenen Fragen — alle Unsicherheiten aus der Context-Phase (Secret-Übereinstimmung
+Staging/Repo, tatsächlich gelesene Variablen, Tracked-Status von `.env.e2e`) wurden durch
+direkte Messung geklärt.

--- a/docs/specs/modules/fix_1289_e2e_env_minimal.md
+++ b/docs/specs/modules/fix_1289_e2e_env_minimal.md
@@ -1,0 +1,190 @@
+---
+entity_id: fix_1289_e2e_env_minimal
+type: bugfix
+created: 2026-08-07
+updated: 2026-08-07
+status: draft
+version: "1.0"
+tags: [e2e, secrets, playwright, security]
+workflow: fix-1289-e2e-env-minimal
+---
+
+# Fix #1289 — E2E-Preview-Server bekommt nur die Environment-Variablen, die er wirklich liest
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`frontend/e2e/start-preview.sh` sourced heute blanket die komplette
+Haupt-`.env` (`set -a; source ../../.env; set +a`) und reicht damit alle
+41 dort gesetzten Schlüssel — darunter echte Secrets wie `GZ_SMTP_PASS`,
+`GZ_TELEGRAM_BOT_TOKEN`, `GZ_IMAP_PASS`, `GZ_METEOFRANCE_APIKEY` — in den
+Prozess-Environment des lokalen Playwright-Preview-Servers weiter, obwohl
+der SvelteKit-Preview-Prozess laut vollständiger Messung nur genau vier
+Variablen tatsächlich liest. Der Fix verkleinert die Weitergabe auf exakt
+diese vier, ohne das Verhalten des Preview-Servers zu ändern (Login/Session
+funktionieren unverändert), und macht das E2E-Testtooling damit unabhängig
+von der Sensitivität der Haupt-`.env` — Härtung derselben Fehlerklasse wie
+#1537 (Repo ist öffentlich, Secrets dürfen nicht unnötig zirkulieren).
+
+## Source
+
+> **Schicht-Hinweis:** reines E2E-Tooling (Playwright, lokal), keine
+> Produktions- oder Staging-Laufzeit betroffen. Berührt Bash-Skripte unter
+> `frontend/e2e/` und einen Node-Test unter `frontend/src/lib/__tests__/`.
+> Keine Go-Seite, keine Python-Core-Seite.
+
+- **File:** `frontend/e2e/start-preview.sh`
+- **Identifier:** `set -a; source ../../.env; set +a` (Blanket-Source-Zeile)
+- **File (neu):** `frontend/e2e/e2e-env.sh`
+- **File (neu):** `frontend/src/lib/__tests__/e2e_env_minimal.test.ts`
+
+## Estimated Scope
+
+- **LoC:** ~+45/-4
+- **Files:** 3 (1 MODIFY, 2 CREATE)
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `frontend/playwright.config.ts` (`webServer.command`) | READ (unverändert) | ruft `bash e2e/start-preview.sh` unverändert auf — Fix ändert nur, welche Variablen darin gesetzt werden, nicht die Aufrufschnittstelle |
+| `frontend/e2e/global.setup.ts` | READ (unverändert) | Login-Flow hängt an einem korrekt verifizierbaren `gz_session`-Cookie, also indirekt an korrektem `GZ_SESSION_SECRET` |
+| `frontend/src/hooks.server.ts:16` (`env.GZ_SESSION_SECRET ?? 'dev-secret-change-me'`) | READ (unverändert) | einziger Ort, der `GZ_SESSION_SECRET` aus der Preview-Server-Environment liest |
+| `frontend/src/lib/server/apiBase.ts:5`, `frontend/src/routes/login/+page.server.ts`, `.../register/+page.server.ts`, `.../magic-link/verify/+page.server.ts` | READ (unverändert) | lesen `GZ_API_BASE`/`GZ_GOOGLE_CLIENT_ID`/`NODE_ENV` — bleiben wie bisher gesetzt, nicht Teil dieses Fixes |
+| `internal/config/config.go:16`, `internal/middleware/auth.go` (Go-API, Staging Port 8091) | READ (unverändert, fremder Prozess) | signiert das `gz_session`-Cookie mit dem `GZ_SESSION_SECRET` aus der separaten Staging-Env-Datei (`/home/hem/gregor_zwanzig_staging/.env`) — muss weiterhin mit dem Wert übereinstimmen, den `e2e-env.sh` aus der Repo-`.env` extrahiert |
+| `.env.e2e` (Repo-Root, git-getrackt) | UNVERÄNDERT | bleibt secret-frei (`GZ_TEST_FIXTURE_DIR=fixtures/openmeteo`), wird weiterhin separat gesourced — `GZ_SESSION_SECRET` wird bewusst NICHT dorthin dupliziert |
+
+## Implementation Details
+
+### 1. Neues Extraktions-Skript `frontend/e2e/e2e-env.sh`
+
+Isolierte, für sich testbare Logik ohne `npm run build`/`preview` — nur
+Environment-Setup. Liest genau zwei Schlüssel gezielt aus einer per
+Umgebungsvariable überschreibbaren `.env`-Datei (Default: `../../.env`
+relativ zum Skriptpfad, überschreibbar über `GZ_REPO_ENV_FILE` — das ist
+der Haken, den der Test in Punkt 4 nutzt, um eine Fixture-Datei statt der
+echten Repo-`.env` einzuspeisen) und exportiert nur diese beiden:
+
+```bash
+#!/usr/bin/env bash
+# Issue #1289: nur die Variablen extrahieren, die der Preview-Server
+# tatsächlich liest (siehe Kommentar unten) — kein Blanket-Source.
+ENV_FILE="${GZ_REPO_ENV_FILE:-$(dirname "$0")/../../.env}"
+
+_extract() {
+  [ -f "$ENV_FILE" ] || return 0
+  grep -m1 "^$1=" "$ENV_FILE" | cut -d= -f2-
+}
+
+GZ_SESSION_SECRET_VAL="$(_extract GZ_SESSION_SECRET)"
+GZ_GOOGLE_CLIENT_ID_VAL="$(_extract GZ_GOOGLE_CLIENT_ID)"
+[ -n "$GZ_SESSION_SECRET_VAL" ] && export GZ_SESSION_SECRET="$GZ_SESSION_SECRET_VAL"
+[ -n "$GZ_GOOGLE_CLIENT_ID_VAL" ] && export GZ_GOOGLE_CLIENT_ID="$GZ_GOOGLE_CLIENT_ID_VAL"
+```
+
+Kein Schlüssel wird geloggt oder ausgegeben, nur exportiert.
+
+### 2. `frontend/e2e/start-preview.sh` sourced das neue Skript
+
+Die Blanket-Zeile `set -a; source ../../.env; set +a` wird ersetzt durch
+`source "$(dirname "$0")/e2e-env.sh"`. Ein Kommentar an dieser Stelle
+verweist auf #1289 und listet die vier tatsächlich benötigten Variablen
+(`GZ_SESSION_SECRET`, `GZ_GOOGLE_CLIENT_ID`, `GZ_API_BASE`, `NODE_ENV`),
+damit eine künftige Erweiterung bewusst erfolgt statt versehentlich wieder
+auf Blanket-Sourcing zurückzufallen. Das `.env.e2e`-Sourcing (secret-frei)
+sowie der bestehende `GZ_API_BASE`-Default-Export
+(`export GZ_API_BASE="${GZ_API_BASE:-http://localhost:8091}"`) und der
+`NODE_ENV`-Export bleiben unverändert an ihrer bisherigen Stelle im Skript.
+
+### 3. Kern-Test `frontend/src/lib/__tests__/e2e_env_minimal.test.ts`
+
+Node-Test (Testrunner `npm run test` in `frontend/`, Muster analog
+`frontend/src/lib/__tests__/e2e_setup_guard_coverage.test.ts`):
+
+1. Erzeugt eine Fixture-`.env` in einem Scratch-/Tempverzeichnis mit den
+   erlaubten Schlüsseln (`GZ_SESSION_SECRET`, `GZ_GOOGLE_CLIENT_ID`) UND
+   mindestens zwei verbotenen Secret-Schlüsseln (z. B.
+   `GZ_SMTP_PASS=darf-nicht-durchsickern`, `GZ_TELEGRAM_BOT_TOKEN=...`).
+2. Ruft `e2e-env.sh` per `child_process.spawnSync('bash', [...])` auf,
+   mit `GZ_REPO_ENV_FILE` auf die Fixture-Datei gesetzt, und lässt den
+   Kindprozess anschließend `env` ausgeben (z. B.
+   `bash -c 'source e2e-env.sh && env'`).
+3. Prüft die tatsächliche `env`-Ausgabe des Kindprozesses (kein
+   Dateiinhalt-Check am Skript selbst, echtes Verhalten):
+   - `GZ_SESSION_SECRET` und `GZ_GOOGLE_CLIENT_ID` sind vorhanden und
+     tragen die Fixture-Werte (AC-1).
+   - `GZ_SMTP_PASS` und `GZ_TELEGRAM_BOT_TOKEN` sind NICHT vorhanden
+     (AC-2).
+
+Kein Netzwerk, keine echte `.env`, keine echten Secrets im Test — alle
+Werte sind erfundene Test-Fixtures.
+
+## Expected Behavior
+
+- **Input:** `start-preview.sh` wird von Playwright (`webServer.command`)
+  mit einer Repo-`.env` gestartet, die sowohl `GZ_SESSION_SECRET` als auch
+  36 weitere, für den Preview-Server irrelevante Schlüssel enthält
+  (Secrets wie SMTP/IMAP/Telegram/Meteofrance sowie Nicht-Secrets).
+- **Output:** Der laufende Preview-Server-Prozess hat `GZ_SESSION_SECRET`,
+  `GZ_GOOGLE_CLIENT_ID`, `GZ_API_BASE`, `NODE_ENV` in seiner Environment —
+  identisch zum bisherigen Verhalten für diese vier. Alle 37 übrigen
+  Schlüssel aus der Haupt-`.env` fehlen im Prozess-Environment, wo sie
+  vorher vorhanden waren.
+- **Side effects:** Login/Session-Verifikation in E2E-Tests bleibt
+  unverändert funktionsfähig (gleicher `GZ_SESSION_SECRET`-Wert wie
+  bisher). Kein Verhaltensunterschied für `.env.e2e`-Werte, `GZ_API_BASE`
+  oder `NODE_ENV`. Kein Effekt auf Staging oder Produktion — reines
+  lokales Tooling.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine `.env`-Fixture enthält sowohl `GZ_SESSION_SECRET`
+  als auch nicht benötigte Secrets / When der E2E-Preview-Server über
+  `start-preview.sh`/`e2e-env.sh` mit dieser Datei gestartet wird / Then
+  sind im resultierenden Prozess-Environment `GZ_SESSION_SECRET` und
+  `GZ_GOOGLE_CLIENT_ID` vorhanden und tragen die erwarteten Werte (Login/
+  Session funktionieren weiterhin).
+  - Test: `frontend/src/lib/__tests__/e2e_env_minimal.test.ts` liest die
+    `env`-Ausgabe des Kindprozesses und prüft beide Werte.
+
+- **AC-2 (der eigentliche Sicherheitsgewinn):** Given dieselbe
+  `.env`-Fixture enthält ein nicht benötigtes Secret wie `GZ_SMTP_PASS` /
+  When derselbe Startvorgang läuft / Then ist `GZ_SMTP_PASS` NICHT im
+  resultierenden Prozess-Environment vorhanden — die frühere
+  Blanket-Weitergabe ist beseitigt.
+  - Test: `frontend/src/lib/__tests__/e2e_env_minimal.test.ts` prüft die
+    Abwesenheit von `GZ_SMTP_PASS` (und mindestens eines zweiten
+    Fixture-Secrets, z. B. `GZ_TELEGRAM_BOT_TOKEN`) in der `env`-Ausgabe
+    des Kindprozesses.
+
+## Known Limitations
+
+- Die Übereinstimmung von `GZ_SESSION_SECRET` zwischen Repo-`.env` und
+  Staging-`.env` (`/home/hem/gregor_zwanzig_staging/.env`) ist weiterhin
+  Konvention, keine technisch erzwungene Garantie — bei Rotation eines der
+  beiden Werte ohne den anderen bricht die lokale E2E-Suite (stiller
+  Redirect-Loop auf `/login`). Das bestand aber schon vor diesem Fix
+  genauso und wird durch ihn weder verbessert noch verschlechtert.
+- `GZ_GOOGLE_CLIENT_ID` wird weiterhin mitgenommen, obwohl kein E2E-Test
+  sie prüft — bewusste Entscheidung: das Verhalten des Preview-Servers
+  (Sichtbarkeit des Google-Login-Buttons) bleibt 1:1 erhalten, statt
+  stillschweigend eine zweite, ungeprüfte Funktionsänderung einzuführen.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** lokales E2E-Tooling-Skript, keine Architekturentscheidung
+  im Sinne der ADR-Kategorien (Kanäle, Provider, Datenmodell/Persistenz,
+  Auth-Konzept, Editor-Paradigma, Test-/Deploy-Strategie) — nur eine
+  Härtung der bestehenden Env-Weitergabe an einen bereits existierenden
+  lokalen Prozess, kein neues Konzept.
+
+## Changelog
+
+- 2026-08-07: Initial spec created. Umfang, Messung (4 tatsächlich
+  gelesene Variablen, 41 gesetzte Schlüssel in Haupt-`.env`) und
+  technischer Ansatz aus der Analyse zu Issue #1289 übernommen.

--- a/frontend/e2e/e2e-env.sh
+++ b/frontend/e2e/e2e-env.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Issue #1289: nur die Variablen extrahieren, die der Preview-Server
+# tatsächlich liest (GZ_SESSION_SECRET, GZ_GOOGLE_CLIENT_ID) — kein
+# Blanket-Source der kompletten .env mehr. GZ_API_BASE und NODE_ENV
+# werden weiterhin separat in start-preview.sh gesetzt.
+ENV_FILE="${GZ_REPO_ENV_FILE:-$(dirname "$0")/../../.env}"
+
+_extract() {
+  [ -f "$ENV_FILE" ] || return 0
+  local val
+  val="$(grep -m1 "^$1=" "$ENV_FILE" | cut -d= -f2-)"
+  # Der frueher genutzte `source`-Pfad entfernt umschliessende Anfuehrungs-
+  # zeichen, `grep | cut` nicht. In der Haupt-.env stehen die Werte in
+  # doppelten Anfuehrungszeichen -- ohne dieses Abstreifen kaeme ein um zwei
+  # Zeichen laengeres GZ_SESSION_SECRET an, das nicht zum Staging-Go-Server
+  # passt und alle authentifizierten E2E-Tests STILL brechen liesse.
+  case "$val" in
+    '"'*'"') val="${val#\"}"; val="${val%\"}" ;;
+    "'"*"'") val="${val#\'}"; val="${val%\'}" ;;
+  esac
+  printf '%s' "$val"
+}
+
+GZ_SESSION_SECRET_VAL="$(_extract GZ_SESSION_SECRET)"
+GZ_GOOGLE_CLIENT_ID_VAL="$(_extract GZ_GOOGLE_CLIENT_ID)"
+[ -n "$GZ_SESSION_SECRET_VAL" ] && export GZ_SESSION_SECRET="$GZ_SESSION_SECRET_VAL"
+[ -n "$GZ_GOOGLE_CLIENT_ID_VAL" ] && export GZ_GOOGLE_CLIENT_ID="$GZ_GOOGLE_CLIENT_ID_VAL"

--- a/frontend/e2e/start-preview.sh
+++ b/frontend/e2e/start-preview.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
-# Load env from project root for E2E tests
+# Issue #1289: gezielter statt blanket Env-Load — .env.e2e ist secret-frei
+# (git-getrackt, öffentliches Repo!) und wird weiter komplett gesourced;
+# aus der Haupt-.env werden NUR GZ_SESSION_SECRET + GZ_GOOGLE_CLIENT_ID
+# gezogen (siehe e2e-env.sh) statt aller 41 Schlüssel dort.
+source "$(dirname "$0")/e2e-env.sh"
 set -a
-source "$(dirname "$0")/../../.env"
 [ -f "$(dirname "$0")/../../.env.e2e" ] && source "$(dirname "$0")/../../.env.e2e"
 set +a
 export NODE_ENV=test

--- a/frontend/src/lib/__tests__/e2e_env_minimal.test.ts
+++ b/frontend/src/lib/__tests__/e2e_env_minimal.test.ts
@@ -1,0 +1,98 @@
+// Issue #1289 — start-preview.sh lädt heute blanket die komplette Haupt-.env
+// in den E2E-Preview-Server-Prozess (41 Schlüssel, u.a. GZ_SMTP_PASS,
+// GZ_TELEGRAM_BOT_TOKEN). Spec: docs/specs/modules/fix_1289_e2e_env_minimal.md,
+// AC-1 + AC-2.
+//
+// Dieser Test prüft ECHTES Prozessverhalten (kein Dateiinhalt-Check): er
+// erzeugt eine Fixture-.env mit erlaubten UND verbotenen Schlüsseln, ruft
+// frontend/e2e/e2e-env.sh als eigenständigen Bash-Prozess auf und liest die
+// tatsächliche `env`-Ausgabe des Kindprozesses aus.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const E2E_ENV_SCRIPT = join(here, '..', '..', '..', 'e2e', 'e2e-env.sh'); // frontend/e2e/e2e-env.sh
+
+function runWithFixtureEnv(fixtureEnvContent: string): Record<string, string> {
+	const dir = mkdtempSync(join(tmpdir(), 'gz-e2e-env-test-'));
+	const fixtureEnvFile = join(dir, '.env');
+	writeFileSync(fixtureEnvFile, fixtureEnvContent, 'utf-8');
+
+	try {
+		const result = spawnSync('bash', ['-c', 'source "$0" && env', E2E_ENV_SCRIPT], {
+			env: {
+				PATH: process.env.PATH ?? '/usr/bin:/bin',
+				GZ_REPO_ENV_FILE: fixtureEnvFile
+			},
+			encoding: 'utf-8'
+		});
+
+		assert.equal(
+			result.status,
+			0,
+			`e2e-env.sh sollte fehlerfrei durchlaufen (stderr: ${result.stderr})`
+		);
+
+		const env: Record<string, string> = {};
+		for (const line of result.stdout.split('\n')) {
+			const idx = line.indexOf('=');
+			if (idx === -1) continue;
+			env[line.slice(0, idx)] = line.slice(idx + 1);
+		}
+		return env;
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+const FIXTURE_ENV = [
+	'GZ_SESSION_SECRET=fixture-session-secret-value',
+	'GZ_GOOGLE_CLIENT_ID=fixture-google-client-id',
+	'GZ_SMTP_PASS=darf-nicht-durchsickern',
+	'GZ_TELEGRAM_BOT_TOKEN=darf-auch-nicht-durchsickern'
+].join('\n');
+
+test('#1289 AC-1: benötigte Variablen (GZ_SESSION_SECRET, GZ_GOOGLE_CLIENT_ID) kommen im Kindprozess an', () => {
+	const env = runWithFixtureEnv(FIXTURE_ENV);
+
+	assert.equal(env.GZ_SESSION_SECRET, 'fixture-session-secret-value');
+	assert.equal(env.GZ_GOOGLE_CLIENT_ID, 'fixture-google-client-id');
+});
+
+test('#1289 AC-2: nicht benötigte Secrets (GZ_SMTP_PASS, GZ_TELEGRAM_BOT_TOKEN) kommen NICHT im Kindprozess an', () => {
+	const env = runWithFixtureEnv(FIXTURE_ENV);
+
+	assert.equal(env.GZ_SMTP_PASS, undefined, 'GZ_SMTP_PASS darf nicht in die Preview-Server-Umgebung durchsickern');
+	assert.equal(
+		env.GZ_TELEGRAM_BOT_TOKEN,
+		undefined,
+		'GZ_TELEGRAM_BOT_TOKEN darf nicht in die Preview-Server-Umgebung durchsickern'
+	);
+});
+
+// Zusatz zur freigegebenen Spec (Befund bei der Implementierung, gemessen an
+// der echten Haupt-.env): dort stehen die Werte in doppelten Anfuehrungs-
+// zeichen. Der abgeloeste `source`-Pfad streift die ab, `grep | cut` nicht.
+// Ohne Abstreifen kaeme ein um zwei Zeichen laengeres GZ_SESSION_SECRET an
+// (66 statt 64) -- es passt dann nicht zum Staging-Go-Server und alle
+// authentifizierten E2E-Tests brechen STILL. Die beiden Fixtures oben nutzen
+// unquotierte Werte und koennen diesen Fall nicht sehen.
+const FIXTURE_ENV_QUOTED = [
+	'GZ_SESSION_SECRET="fixture-session-secret-value"',
+	"GZ_GOOGLE_CLIENT_ID='fixture-google-client-id'",
+	'GZ_SMTP_PASS="darf-nicht-durchsickern"'
+].join('\n');
+
+test('#1289 AC-1 (Realitaets-Fixture): quotierte .env-Werte kommen OHNE Anfuehrungszeichen an', () => {
+	const env = runWithFixtureEnv(FIXTURE_ENV_QUOTED);
+
+	assert.equal(env.GZ_SESSION_SECRET, 'fixture-session-secret-value');
+	assert.equal(env.GZ_GOOGLE_CLIENT_ID, 'fixture-google-client-id');
+	assert.equal(env.GZ_SMTP_PASS, undefined);
+});


### PR DESCRIPTION
start-preview.sh lud bisher blanket alle 41 Schluessel der Haupt-.env in den
lokalen Playwright-Preview-Prozess, darunter echte Secrets wie GZ_SMTP_PASS
und GZ_TELEGRAM_BOT_TOKEN. Ein neues e2e-env.sh extrahiert gezielt nur die
2 tatsaechlich benoetigten Werte (GZ_SESSION_SECRET, GZ_GOOGLE_CLIENT_ID) und
streift dabei die Anfuehrungszeichen der echten .env-Werte korrekt ab.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
