### PR TITLE
fix(#1555): NowCast-Alarme bekommen reservierten Vorrang im geteilten Tagesbudget

### DIFF
--- a/docs/context/fix-1555-nowcast-alert-priority.md
+++ b/docs/context/fix-1555-nowcast-alert-priority.md
@@ -1,0 +1,108 @@
+# Context: fix-1555-nowcast-alert-priority
+
+Issue: #1555 — NowCast-Alarme wurden system-weit nie zugestellt: stille Tier-Lücke +
+geteiltes Tagesbudget starvt akute Gefahr.
+
+Der akute Teil (Tier-Lücke bei `henning`) ist bereits per Datenfix behoben
+(`data/users/henning/user.json` → `tier: "premium"`). Dieser Workflow behandelt den
+verbleibenden strukturellen Vorschlag aus #1555: NowCast/akute Gefahr soll im geteilten
+Tages-Alarmbudget nicht mehr "wer zuerst kommt" gegenüber reinen
+Vorhersage-Abweichungs-Alarmen verlieren können.
+
+## Analysis
+
+### Type
+
+Bug-Folgefeature (strukturelle Korrektur eines bestehenden, PO-entschiedenen Mechanismus
+aus #1070) — kein neues Vorhersage-Abweichungs- oder NowCast-Feature, nur eine geänderte
+interne Priorisierung innerhalb des bestehenden Tagesbudgets.
+
+### Root Cause (bereits verifiziert, Step 0/1/2 aus der Bug-Analyse #1555)
+
+1. `daily_alert_limit()` (`src/services/user_tier.py:17-31`) liefert `{"free": 2,
+   "standard": 4, "premium": None}` je Konto — Gesamtobergrenze, PO-Entscheidung #1070
+   (2026-07-07), **nicht Gegenstand dieses Workflows**.
+2. Das Limit ist EIN geteilter Integer-Zähler pro Nutzer über ALLE Trips und ALLE
+   Alarm-Gründe (`data/users/<uid>/alert_daily_count.json`,
+   `src/services/alert_daily_limit.py::is_allowed()`/`increment()`).
+3. Fünf Aufrufstellen teilen sich denselben Zähler, ohne Kenntnis voneinander:
+   - `src/services/trip_alert.py:221` — Deviation-Alarm (`check_and_send_alerts`)
+   - `src/services/trip_alert.py:761` — Radar/NowCast-Alarm (`check_radar_alerts`)
+   - `src/services/trip_alert.py:1169` — amtliche Warnung (Official-Only-Pfad)
+   - `src/services/compare_alert.py:145` — Compare-Deviation-Alarm
+   - `src/services/compare_official_alert.py:136` — Compare-amtliche Warnung
+4. `src/services/compare_radar_alert.py` (Compare-NowCast) ruft `alert_daily_limit`
+   **gar nicht** auf — bereits heute ungebudgetiert. Bewusst NICHT Teil dieses
+   Workflows (Scope-Explosion), nur als bekannte Inkonsistenz dokumentiert.
+5. Cron: `internal/scheduler/scheduler.go:145` (`alertChecks`, Deviation+Official) und
+   `:149` (`radarAlertChecks`, NowCast) sind zwei unabhängige `*/15 * * * *`-Jobs.
+   `robfig/cron` startet fällige Jobs in getrennten Goroutinen — die
+   Registrierungsreihenfolge hat **keinen** Effekt auf die tatsächliche
+   Ausführungsreihenfolge. Ein reines Vertauschen der Zeilen würde nichts bewirken.
+6. Befund system-weit: 0 von 118+ Alarm-Protokoll-Einträgen (alle 3 Nutzer) tragen
+   `"reason": "nowcast"` — Deviation/Official verbrauchen das Budget faktisch immer
+   zuerst.
+
+### Affected Files (Empfehlung Option B, s. Technical Approach)
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/services/alert_daily_limit.py` | MODIFY | `is_allowed()` bekommt optionalen `reason`-Parameter (Default `None` = Altverhalten); bei `reason="forecast_change"` gegen `limit - RESERVE` statt `limit` prüfen |
+| `src/services/trip_alert.py` | MODIFY | `reason=` an den 3 bestehenden `is_allowed()`-Aufrufen (:221, :761, :1169) ergänzen |
+| `src/services/compare_alert.py` | MODIFY | `reason=` an Aufruf :145 ergänzen |
+| `src/services/compare_official_alert.py` | MODIFY | `reason=` an Aufruf :136 ergänzen |
+| `docs/specs/modules/alert_daily_limit.md` | MODIFY | Reserve-Regel dokumentieren |
+| `tests/tdd/test_issue_1070_daily_alert_limit.py` | MODIFY | 1-2 neue AC-Tests für Reserve-Verhalten (Rückrichtung: Deviation zuerst, NowCast danach trotzdem noch möglich — heute ungetestet) |
+
+Kein Eingriff in `internal/scheduler/scheduler.go`, kein Schemawechsel an
+`alert_daily_count.json` (bleibt flacher Integer-Zähler).
+
+### Scope Assessment
+
+- Files: 6 (4 Code, 1 Spec, 1 Test)
+- Estimated LoC: ~100–170 (Code ~20–35, Spec ~15–30, Tests ~60–100)
+- Risk Level: MEDIUM — geteilter Modul-Kern mit 5 Aufrufstellen; Fehler in einer Stelle
+  wirkt sich auf alle anderen aus. Bestehender Test
+  `test_ac5_cross_path_daily_limit_shared_between_radar_and_deviation`
+  (`tests/tdd/test_issue_1070_daily_alert_limit.py:463-536`) verankert die Gegenrichtung
+  (Radar zuerst blockiert nachfolgenden Deviation-Alarm) und bleibt bei additivem
+  `reason`-Parameter unverändert grün.
+
+### Technical Approach
+
+**Empfehlung: Option B — reserviertes Mindest-Kontingent für `nowcast`/`official_alert`
+in `alert_daily_limit.is_allowed()`.**
+
+Verworfene Alternativen:
+- **Cron-Reihenfolge umkehren** — wirkungslos (getrennte Goroutinen, s.o.) und würde
+  ohnehin unnötig Go/Scheduler anfassen.
+- **Gewichtete Zählung** (NowCast zählt 0,5) — bricht das getestete Integer-Format,
+  garantiert trotzdem keinen Vorrang (nur langsamer verbraucht).
+- **Eigener Zähler pro Alarm-Grund + Gesamt-Obergrenze** — Schemawechsel an
+  produktiver Datei, größter Test-Umbau, Risiko einer stillen Aufweichung des
+  #1070-Gesamtlimits (2+2+2 statt 2). Für diesen Scope nicht gerechtfertigt.
+
+**Offene Produktentscheidung vor Implementierung:** die konkrete Reserve-Größe (z. B. 1
+von 2 Slots bei Free für `nowcast`/`official_alert`) halbiert faktisch die
+Deviation-Alarm-Quote für Free-Nutzer — das ist eine PO-Entscheidung, keine rein
+technische. Gehört in die Spec-Freigabe (`/30-write-spec`, ACs auf Deutsch).
+
+### Dependencies
+
+- Compare-Pfad (`compare_alert.py`, `compare_official_alert.py`) MUSS mitgeändert
+  werden — teilt sich denselben Zähler mit Trip; sonst inkonsistentes Verhalten pro
+  Nutzer (Trip priorisiert, Compare nicht).
+- Keine Abhängigkeit zu `scheduler.go` (s.o.).
+- `compare_radar_alert.py` bleibt unangetastet — als Nebenbefund im Spec-Text und
+  ggf. #1199 vermerken, nicht in diesem Workflow beheben.
+
+### Open Questions — PO-Entscheidung 2026-08-07 (geklärt)
+
+- **Reserve-Umfang:** ausschließlich `reason="nowcast"` bekommt Vorrang. `official_alert`
+  bleibt im normalen (nicht reservierten) Budget wie bisher — PO-Entscheidung, entgegen
+  der Agent-Empfehlung "beide", da amtliche Warnungen bereits über einen eigenen,
+  unabhängigen Trigger-Pfad laufen (`check_official_alert_triggers()`).
+- **Reserve-Größe:** Free `limit=2` → `forecast_change`-Obergrenze `1` (1 Slot bleibt für
+  NowCast reserviert). Standard `limit=4` → `forecast_change`-Obergrenze `2` (2 Slots
+  reserviert). Premium (`limit=None`) unverändert kein Limit, kein Reserve-Konzept nötig.
+  `nowcast` selbst prüft in allen Tiers weiterhin gegen das volle `limit`.

--- a/docs/specs/modules/alert_daily_limit.md
+++ b/docs/specs/modules/alert_daily_limit.md
@@ -155,6 +155,31 @@ betroffen (PO-Entscheidung 2026-07-07).
   `user_tier.py`-Fassade neben `sms_allowed()` ein. Es entsteht kein
   strukturell neues Architekturmuster, das eine ADR rechtfertigen würde.
 
+## Ergänzung: NowCast-Reserve im geteilten Tagesbudget (#1555)
+
+Seit #1555 kennt `is_allowed(user_id, now, reason=None)` einen optionalen
+dritten Parameter `reason`. Details, Motivation und Acceptance Criteria:
+`docs/specs/modules/fix_1555_nowcast_alert_priority.md`.
+
+- `reason is None` oder `reason != "forecast_change"` (inkl. `"nowcast"`,
+  `"official_alert"`, unbekannte Werte): unverändertes Altverhalten — Prüfung
+  gegen das volle `limit`. Rückwärtskompatibel zu jedem Aufruf ohne `reason`.
+- `reason == "forecast_change"` UND `limit` endlich: Prüfung gegen `limit -
+  RESERVE` statt `limit`, feste Tabelle: `limit=2` → Obergrenze `1`,
+  `limit=4` → Obergrenze `2`.
+- `reason == "forecast_change"` UND `limit is None` (Premium): unverändert
+  sofort `True`, keine Reserve.
+- `load()`/`increment()` unverändert — derselbe flache `{"date", "count"}`-
+  Zähler für alle `reason`-Werte, kein getrennter Zählerstand.
+
+Aufrufstellen mit `reason=`: `trip_alert.py` Deviation-Pfad
+(`"forecast_change"`) und Radar/NowCast-Pfad (`"nowcast"`),
+`compare_alert.py` Compare-Deviation (`"forecast_change"`). Official-Pfade
+(`trip_alert.py` Official-Only, `compare_official_alert.py`) bleiben
+unverändert ohne Reserve (PO-Entscheidung, s. Known Limitations in
+`fix_1555_nowcast_alert_priority.md`).
+
 ## Changelog
 
 - 2026-07-07: Initial spec created
+- 2026-08-07: NowCast-Reserve (#1555) additiv ergänzt

--- a/docs/specs/modules/fix_1555_nowcast_alert_priority.md
+++ b/docs/specs/modules/fix_1555_nowcast_alert_priority.md
@@ -1,0 +1,231 @@
+---
+entity_id: fix_1555_nowcast_alert_priority
+type: bugfix
+created: 2026-08-07
+updated: 2026-08-07
+status: draft
+workflow: fix-1555-nowcast-alert-priority
+version: "1.0"
+tags: [issue-1555, alerts, epic-1067, follow-up-1070]
+---
+
+# NowCast-Alarme bekommen reservierten Vorrang im geteilten Tagesbudget
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`is_allowed()` (`src/services/alert_daily_limit.py`) reserviert innerhalb des
+bestehenden, geteilten Tages-Alarmbudgets (Free 2/Standard 4/Premium
+unbegrenzt, #1070) einen Mindestanteil ausschließlich für akute
+NowCast-Alarme (`reason="nowcast"`). Vorhersage-Abweichungs-Alarme
+(`reason="forecast_change"`) dürfen diesen reservierten Anteil nicht mehr
+belegen. Grund: 0 von 118+ Alarm-Log-Einträgen system-weit trugen bislang
+`"reason": "nowcast"` — Deviation-Alarme verbrauchten das Budget faktisch
+immer zuerst und akute Gefahrenmeldungen wurden dadurch strukturell nie
+zugestellt (#1555).
+
+## Source
+
+- **File:** `src/services/alert_daily_limit.py`
+- **Identifier:** `is_allowed(user_id, now, reason=None)`
+
+> **Schicht-Hinweis:** Alle Code-Änderungen liegen im Python-Core unter
+> `src/services/` (FastAPI-Domain-Backend). Keine Go-/Frontend-Änderung.
+> Kein Eingriff in `internal/scheduler/scheduler.go` (Cron-Reihenfolge ist
+> wirkungslos, s. Known Limitations).
+
+## Estimated Scope
+
+- **LoC:** ~100-170 (Code ~20-35, Spec-Ergänzung ~15-30, Tests ~60-100)
+- **Files:** 6 (4 Produktionscode, 1 Spec, 1 Testdatei)
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/services/alert_daily_limit.py` | module | Ort der Reserve-Logik selbst (`is_allowed`) |
+| `src/services/user_tier.py` | module | Liefert unverändert `daily_alert_limit(user_id)` (Free 2/Standard 4/Premium `None`) — Basis der Reserve-Berechnung |
+| `src/services/trip_alert.py` | module | 3 bestehende `is_allowed()`-Aufrufstellen bekommen `reason=` |
+| `src/services/compare_alert.py` | module | 1 bestehende Aufrufstelle (Compare-Deviation) bekommt `reason="forecast_change"` |
+| `src/services/compare_official_alert.py` | module | 1 bestehende Aufrufstelle (Compare-Official) — unverändertes Verhalten, kein Reserve-Grund |
+| `docs/specs/modules/alert_daily_limit.md` | spec | Bestehende #1070-Spec — additiv um Reserve-Regel ergänzen, nicht ersetzen |
+| `data/users/<user_id>/alert_daily_count.json` | data | Geteilter Zähler bleibt unverändertes Format (`{"date", "count"}`), keine Migration |
+
+## Implementation Details
+
+**`src/services/alert_daily_limit.py::is_allowed()`** bekommt einen
+optionalen dritten Parameter `reason: str | None = None`:
+
+- `reason is None` oder `reason != "forecast_change"` (also u.a.
+  `"nowcast"`, `"official_alert"`, unbekannte Werte): Altverhalten
+  unverändert — Prüfung gegen das volle `limit` aus `daily_alert_limit()`.
+  Das ist die Rückwärtskompatibilitäts-Garantie: ein Aufruf ohne `reason`
+  verhält sich exakt wie vor dieser Änderung.
+- `reason == "forecast_change"` UND `limit` ist nicht `None`: Prüfung gegen
+  `limit - RESERVE` statt `limit`, wobei `RESERVE` aus einer festen Tabelle
+  je `limit`-Wert kommt: `limit=2` → `RESERVE=1` (Obergrenze für
+  `forecast_change` wird `1`), `limit=4` → `RESERVE=2` (Obergrenze wird
+  `2`). Kein anderer `limit`-Wert ist heute über `user_tier.daily_alert_limit`
+  erreichbar (nur `2`, `4`, `None`); die Reserve-Tabelle deckt exakt diese
+  beiden endlichen Werte ab.
+- `reason == "forecast_change"` UND `limit is None` (Premium): keine
+  Reserve — Premium bleibt für alle Gründe unbegrenzt, `is_allowed` liefert
+  weiterhin sofort `True` ohne Zähler-Load.
+- `load()` und `increment()` bleiben komplett unverändert — beide kennen
+  keinen `reason`, schreiben/lesen weiterhin denselben flachen
+  `{"date", "count"}`-Zähler. `nowcast` und `forecast_change` erhöhen
+  denselben Zähler; die Reserve wirkt ausschließlich als eine niedrigere
+  Vergleichs-Obergrenze für den `forecast_change`-Pfad, nicht als getrennter
+  Zählerstand.
+
+**Aufrufstellen (`reason=` ergänzen, kein anderer Code-Pfad geändert):**
+
+| Datei:Zeile | Alarmart | `reason=` |
+|---|---|---|
+| `src/services/trip_alert.py:221` (`check_and_send_alerts`, Deviation) | Vorhersage-Abweichung | `"forecast_change"` |
+| `src/services/trip_alert.py:761` (`check_radar_alerts`, Radar/NowCast) | Akute Gefahr | `"nowcast"` |
+| `src/services/trip_alert.py:1169` (Official-Only-Pfad) | amtliche Warnung | unverändert (kein `reason` oder `reason="official_alert"` — beides prüft gegen das volle `limit`) |
+| `src/services/compare_alert.py:145` (Compare-Deviation) | Vorhersage-Abweichung | `"forecast_change"` |
+| `src/services/compare_official_alert.py:136` (Compare-Official) | amtliche Warnung | unverändert |
+
+**Wo die Zusicherung tatsächlich WIRKT (Mutations-Gegenprobe-relevant):**
+Die Reserve wirkt ausschließlich dort, wo `is_allowed()` mit
+`reason="forecast_change"` tatsächlich aufgerufen wird — nicht dort, wo die
+Reserve-Tabelle im Modul steht. Ein an einer der beiden
+Deviation-Aufrufstellen (`trip_alert.py:221` bzw. `compare_alert.py:145`)
+vergessenes `reason=`-Argument fällt still auf Altverhalten zurück: kein
+Fehler, keine Ausnahme, einfach keine Reserve an dieser Stelle — der Bug aus
+#1555 wäre an genau dieser Stelle unbemerkt reproduziert. Tests müssen daher
+gegen die echten Aufrufstellen in `trip_alert.py`/`compare_alert.py` laufen
+(reale `TripAlertService`/`CompareAlertService`-Läufe wie im bestehenden
+AC-5-Test aus `test_issue_1070_daily_alert_limit.py`), nicht nur gegen
+`alert_daily_limit.is_allowed()` isoliert — ein isolierter Modultest würde
+ein vergessenes `reason=` an der Aufrufstelle nicht sehen.
+
+## Expected Behavior
+
+- **Input:** `user_id`, `now` (UTC), optional `reason` (`"forecast_change"`
+  oder `None`/anderer Wert), Nutzer-Tier aus `user.json`, aktueller
+  Tageszählerstand.
+- **Output:** `is_allowed()` liefert `True`/`False` wie bisher — Rückgabetyp
+  und Signatur-Grundverhalten unverändert, nur die Vergleichs-Obergrenze
+  ändert sich bedingt.
+- **Side effects:** keine neuen — `increment()`/`load()` unverändert, kein
+  neues State-File, kein Schemawechsel an `alert_daily_count.json`.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Free-Nutzer (`limit=2`) hat am aktuellen Vienna-Tag
+  noch keinen Alarm erhalten (`count=0`) / When ein `forecast_change`-Alarm
+  ausgelöst wird / Then wird er zugestellt, weil `count=0 < 1` (reduzierte
+  Obergrenze für `forecast_change` bei `limit=2`).
+  - Test: `alert_daily_count.json` mit `count=0` (oder keine Datei) vorseeden,
+    echten `check_and_send_alerts`-Lauf über `TripAlertService` für einen
+    Free-Nutzer ausführen, Assert über tatsächlichen Versand (`mail_sink`
+    gefüllt) und resultierenden Zählerstand `count=1`.
+
+- **AC-2:** Given ein Free-Nutzer (`limit=2`) hat am aktuellen Vienna-Tag
+  bereits 1 `forecast_change`-Alarm erhalten (`count=1`, insgesamt wären laut
+  Gesamtlimit `2` noch 1 Slot frei) / When ein weiterer
+  `forecast_change`-Alarm ausgelöst wird / Then wird er unterdrückt (Reserve
+  greift: `count=1` ist nicht `< 1`), aber ein `nowcast`-Alarm für denselben
+  Nutzer im selben Zustand wird trotzdem noch zugestellt (`count=1 < 2`, dem
+  vollen Limit).
+  - Test: Zählerdatei auf `count=1` vorseeden, echten
+    `check_and_send_alerts`-Lauf ausführen → Assert `mail_sink` bleibt leer,
+    Zähler bleibt `1`; danach echten `check_radar_alerts`-Lauf für denselben
+    `user_id` (anderer Trip) ausführen → Assert Versand erfolgt, Zähler auf
+    `2`. Beweist die Vorrang-Wirkung, nicht nur die Reserve-Zahl isoliert.
+
+- **AC-3:** Given ein Standard-Nutzer (`limit=4`) hat am aktuellen Vienna-Tag
+  bereits 2 `forecast_change`-Alarme erhalten (`count=2`) / When ein dritter
+  `forecast_change`-Alarm ausgelöst wird / Then wird er unterdrückt (Reserve
+  greift: `count=2` ist nicht `< 2`), aber ein `nowcast`-Alarm im selben
+  Zustand wird trotzdem noch zugestellt (`count=2 < 4`).
+  - Test: analog AC-2 mit Standard-Tier und Zählerstand `2`; echter Lauf über
+    beide Pfade, Assert über `mail_sink`-Inhalt und Zählerstand nach jedem
+    Schritt.
+
+- **AC-4:** Given ein Premium-Nutzer (`limit=None`) hat am aktuellen
+  Vienna-Tag bereits 6 Alarme jeglicher Art erhalten / When sowohl ein
+  `forecast_change`- als auch ein `nowcast`-Alarm ausgelöst werden / Then
+  werden beide zugestellt, weil für Premium unverändert kein Tageslimit und
+  damit auch keine Reserve gilt.
+  - Test: Zählerdatei mit `count=6` vorseeden, Premium-Tier setzen, echte
+    Läufe für beide Pfade ausführen; Assert `mail_sink` enthält beide neuen
+    Einträge, kein Deckel greift.
+
+- **AC-5:** Given ein bestehender Aufruf von
+  `alert_daily_limit.is_allowed(user_id, now)` OHNE `reason`-Argument (wie
+  vor dieser Änderung) / When er gegen einen Zählerstand geprüft wird, der
+  zwischen der reduzierten und der vollen Obergrenze liegt (z.B. Free,
+  `count=1`) / Then verhält er sich exakt wie vor dieser Änderung — geprüft
+  gegen das volle `limit`, hier `1 < 2` → `True` — und nicht wie der
+  reduzierte `forecast_change`-Pfad.
+  - Test: `is_allowed(uid, now)` direkt ohne drittes Argument aufrufen bei
+    `count=1`, Free-Tier; Assert `True`. Zusätzlich MUSS der bestehende Test
+    `test_ac5_cross_path_daily_limit_shared_between_radar_and_deviation`
+    (`tests/tdd/test_issue_1070_daily_alert_limit.py:463-536`) unverändert
+    grün bleiben — er ruft die Aufrufstellen über die reale
+    `TripAlertService` auf, nicht `is_allowed()` isoliert, und verankert
+    damit die Rückwärtskompatibilität an der Stelle, wo sie wirkt.
+
+- **AC-6:** Given der Compare-Pfad (`compare_alert.py`) befindet sich im
+  selben Zählerstand wie in AC-2 beschrieben (Free, `count=1`,
+  `forecast_change` bereits einmal versendet) / When ein weiterer
+  Compare-`forecast_change`-Alarm für dasselbe Preset ausgelöst wird / Then
+  wird er ebenso unterdrückt wie im Trip-Pfad — dieselbe Reserve-Regel gilt
+  identisch für Compare.
+  - Test: echten `CompareAlertService`-Lauf (oder äquivalente Funktion aus
+    `compare_alert.py`) mit vorgeseedetem Zähler `count=1` und Free-Tier
+    ausführen; Assert kein Versand, Zähler bleibt `1` — analog zum
+    bestehenden Compare-AC-6-Test aus #1213 in
+    `test_issue_1070_daily_alert_limit.py`, falls dort ein passendes Vorbild
+    existiert, sonst neu nach demselben Muster wie AC-2.
+
+## Known Limitations
+
+- **`compare_radar_alert.py` bleibt ungebudgetiert:** Dieser Compare-NowCast-
+  Pfad ruft `alert_daily_limit` heute gar nicht auf (weder mit noch ohne
+  `reason`). Das ist eine bereits vor diesem Workflow bestehende
+  Inkonsistenz — bewusst NICHT Teil dieses Fixes, um Scope-Explosion zu
+  vermeiden. Dokumentiert hier, ggf. Sammel-Eintrag in #1199.
+- **Cron-Reihenfolge ist wirkungslos:** `internal/scheduler/scheduler.go`
+  registriert Deviation/Official- und Radar-Checks als zwei unabhängige
+  `robfig/cron`-Jobs in getrennten Goroutinen. Ein Vertauschen der
+  Registrierungsreihenfolge hätte keinen Effekt auf die tatsächliche
+  Ausführungsreihenfolge und ist deshalb kein Lösungsansatz — die Reserve im
+  geteilten Zähler ist der einzige wirksame Hebel.
+- **`official_alert` bleibt unreserviert (PO-Entscheidung 2026-08-07):**
+  Amtliche Warnungen laufen über einen eigenen, unabhängigen
+  Trigger-Pfad (`check_official_alert_triggers()`) und wurden bewusst NICHT
+  in die Reserve aufgenommen, obwohl die technische Analyse dies als
+  gleichwertige Option vorschlug. Keine offene Frage — abschließend
+  entschieden.
+- **Feste Reserve-Tabelle statt Formel:** Die Reserve-Werte (1 bei `limit=2`,
+  2 bei `limit=4`) sind als explizite Tabelle statt als generische Formel
+  (z.B. `limit // 2`) implementiert, weil `user_tier.daily_alert_limit` heute
+  ausschließlich `2`, `4` oder `None` liefert. Sollte künftig ein neues Tier
+  mit anderem `limit`-Wert eingeführt werden, muss die Tabelle explizit
+  erweitert werden — ein unbekannter `limit`-Wert würde sonst stillschweigend
+  keine Reserve anwenden (Fallback-Verhalten muss beim Erweitern geprüft
+  werden, ist in diesem Fix nicht Gegenstand, da heute nicht erreichbar).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine additive Erweiterung des bestehenden, in
+  `docs/specs/modules/alert_daily_limit.md` bereits als ADR-frei
+  eingestuften #1070-Mechanismus (JSON-Read-Modify-Write-Zähler,
+  `user_tier.py`-Fassade). Es entsteht kein neuer Architektur-Layer, kein
+  neues Persistenzformat, keine neue Kanal- oder Provider-Entscheidung — nur
+  ein optionaler Funktionsparameter mit eng begrenzter interner
+  Verzweigungslogik in einem bereits etablierten Modul.
+
+## Changelog
+
+- 2026-08-07: Initial spec created

--- a/src/services/alert_daily_limit.py
+++ b/src/services/alert_daily_limit.py
@@ -50,12 +50,28 @@ def load(user_id: str, now: datetime) -> int:
     return int(data.get("count", 0))
 
 
-def is_allowed(user_id: str, now: datetime) -> bool:
-    """Return True if another alert may be sent today for this user."""
+# Issue #1555: feste Reserve-Tabelle je endlichem `limit`-Wert. Reserviert
+# einen Mindestanteil des geteilten Tagesbudgets ausschließlich für
+# `reason="nowcast"` -- `reason="forecast_change"` prüft gegen `limit -
+# RESERVE` statt gegen das volle `limit`. Nur `2`/`4` sind heute über
+# `user_tier.daily_alert_limit` erreichbar (s. Spec "Known Limitations").
+_FORECAST_CHANGE_RESERVE = {2: 1, 4: 2}
+
+
+def is_allowed(user_id: str, now: datetime, reason: str | None = None) -> bool:
+    """Return True if another alert may be sent today for this user.
+
+    `reason="forecast_change"` prüft bei endlichem `limit` gegen eine um die
+    NowCast-Reserve reduzierte Obergrenze (#1555). Jeder andere `reason`
+    (inkl. `None`) prüft unverändert gegen das volle `limit`.
+    """
     limit = daily_alert_limit(user_id)
     if limit is None:
         return True
-    return load(user_id, now) < limit
+    effective_limit = limit
+    if reason == "forecast_change":
+        effective_limit = limit - _FORECAST_CHANGE_RESERVE.get(limit, 0)
+    return load(user_id, now) < effective_limit
 
 
 def increment(user_id: str, now: datetime) -> None:

--- a/src/services/compare_alert.py
+++ b/src/services/compare_alert.py
@@ -142,7 +142,8 @@ class CompareAlertService:
 
             # Issue #1213 (AC-6): Compare an dieselbe Tageslimit-Prüfung
             # anbinden wie der Trip-Pfad (Epic #1067 Slice 3, #1070).
-            if not alert_daily_limit.is_allowed(self._user_id, now):
+            # Issue #1555: reason="forecast_change" reserviert einen Anteil für NowCast.
+            if not alert_daily_limit.is_allowed(self._user_id, now, reason="forecast_change"):
                 logger.debug(f"Compare-Alert suppressed: daily limit reached for preset {preset_id}")
                 continue
 

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -218,7 +218,8 @@ class TripAlertService:
             return False
 
         # 1c. Issue #1070: Tages-Obergrenze nach Nutzerlevel (Free/Standard/Premium)
-        if not alert_daily_limit.is_allowed(self._user_id, datetime.now(timezone.utc)):
+        # Issue #1555: reason="forecast_change" reserviert einen Anteil für NowCast.
+        if not alert_daily_limit.is_allowed(self._user_id, datetime.now(timezone.utc), reason="forecast_change"):
             logger.debug(f"Alert suppressed: daily limit reached for trip {trip.id}")
             return False
 
@@ -758,7 +759,8 @@ class TripAlertService:
                 continue
 
             # Issue #1070: Tages-Obergrenze nach Nutzerlevel (Free/Standard/Premium)
-            if not alert_daily_limit.is_allowed(self._user_id, datetime.now(timezone.utc)):
+            # Issue #1555: reason="nowcast" prüft gegen das volle Limit (Reserve-Nutznießer).
+            if not alert_daily_limit.is_allowed(self._user_id, datetime.now(timezone.utc), reason="nowcast"):
                 logger.debug(f"Radar alert suppressed: daily limit reached for trip {trip.id}")
                 continue
 

--- a/tests/tdd/test_compare_alert_quiet_hours_precedes_fetch.py
+++ b/tests/tdd/test_compare_alert_quiet_hours_precedes_fetch.py
@@ -31,6 +31,7 @@ echten `ThrottleStore`-/`alert_daily_limit`-Dateien.
 """
 from __future__ import annotations
 
+import json
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -57,6 +58,18 @@ def _clean_user(user_id: str) -> None:
     d = DATA_ROOT / user_id
     if d.exists():
         shutil.rmtree(d)
+
+
+def _write_user_tier(uid: str, tier: str) -> None:
+    """Setzt den Tarif eines Test-Nutzers — Vorbild: `test_issue_1070_daily_
+    alert_limit.py:75-78`. Nutzt bewusst `app.loader.get_data_dir()` statt der
+    lokalen `DATA_ROOT`-Konstante dieser Datei, sonst greift die #1133-
+    Testisolation nicht."""
+    from app.loader import get_data_dir
+
+    d = get_data_dir(uid)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "user.json").write_text(json.dumps({"id": uid, "tier": tier}))
 
 
 def _settings_email_capable_dummy() -> Settings:
@@ -467,6 +480,7 @@ def test_f001_broken_quiet_value_does_not_abort_other_presets_same_user():
     preset_id_broken = f"cp-f001-broken-{uuid.uuid4().hex[:6]}"
     preset_id_healthy = f"cp-f001-healthy-{uuid.uuid4().hex[:6]}"
     _clean_user(uid)
+    _write_user_tier(uid, "premium")
     try:
         from services.compare_weather_snapshot import CompareWeatherSnapshotService
 
@@ -606,6 +620,7 @@ def test_f003_non_string_quiet_value_does_not_abort_other_presets_same_user():
     preset_id_broken = f"cp-f003-broken-{uuid.uuid4().hex[:6]}"
     preset_id_healthy = f"cp-f003-healthy-{uuid.uuid4().hex[:6]}"
     _clean_user(uid)
+    _write_user_tier(uid, "premium")
     try:
         from services.compare_weather_snapshot import CompareWeatherSnapshotService
 

--- a/tests/tdd/test_issue_1070_daily_alert_limit.py
+++ b/tests/tdd/test_issue_1070_daily_alert_limit.py
@@ -714,3 +714,352 @@ def test_ac6_deviation_gate_passes_but_no_channel_delivered_leaves_counter_uncha
         )
     finally:
         _clean_user(uid)
+
+
+# ═══════════════════ Issue #1555: NowCast-Reserve im Tagesbudget ═════════════
+#
+# `alert_daily_limit.is_allowed()` bekommt einen optionalen `reason`-Parameter.
+# `reason="forecast_change"` UND endliches `limit` -> Prüfung gegen
+# `limit - RESERVE` (Free 2->1, Standard 4->2) statt gegen das volle `limit`.
+# `reason=None`/jeder andere Wert (u.a. "nowcast") -> unverändertes
+# Altverhalten (volles `limit`). Premium (`limit=None`) bleibt unbegrenzt.
+#
+# RED-Status je Test (Mutations-Gegenprobe-Vorgabe, Spec Abschnitt "Wo die
+# Zusicherung tatsächlich WIRKT"): AC-1/AC-4/AC-5 sind an ihrer eigenen
+# Grenze nicht diskriminierend (der Reserve-Effekt greift dort inhärent
+# nicht bzw. noch nicht) und bleiben deshalb sowohl heute als auch nach der
+# Implementierung GRÜN — sie sind Regressionsschutz, kein RED-Beweis (analog
+# AC-5/AC-6 in `test_compare_alert_quiet_hours_precedes_fetch.py`). AC-2,
+# AC-3 und AC-6 treffen exakt die Reserve-Grenze und sind heute ROT, weil
+# `trip_alert.py:221/761` und `compare_alert.py:145` `is_allowed()` noch
+# ohne `reason=` aufrufen (Altverhalten = volles Limit statt Reserve).
+
+_COMPARE_DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
+# Pfadregel #1409: compare_alert.py::_load_presets() ruft load_compare_presets()
+# OHNE data_root auf -> Default "data" (bewusster Bypass der _DATA_ROOT-
+# Testisolation, dokumentiert in app.loader.get_data_root()). ComparePreset-
+# Dateien müssen deshalb -- anders als der Rest dieser Datei (get_data_dir(),
+# isolierte _DATA_ROOT) -- unter dem ECHTEN, relativ zu dieser Testdatei
+# aufgelösten "data/users/"-Baum liegen (Vorbild:
+# test_compare_alert_quiet_hours_precedes_fetch.py::DATA_ROOT).
+
+
+def _clean_compare_preset_dir(uid: str) -> None:
+    d = _COMPARE_DATA_ROOT / uid
+    if d.exists():
+        shutil.rmtree(d)
+
+
+def _compare_preset_active(preset_id: str, location_ids: list[str], empfaenger: list[str]) -> dict:
+    """Minimaler, aktiver (nicht stillgelegter) Compare-Preset-Dict --
+    1:1 aus `test_compare_alert_quiet_hours_precedes_fetch.py::_preset_multi`."""
+    return {
+        "id": preset_id, "name": preset_id, "user_id": "default",
+        "location_ids": location_ids, "schedule": "daily", "weekday": 4,
+        "profil": "ALLGEMEIN", "hour_from": 0, "hour_to": 23,
+        "empfaenger": empfaenger, "letzter_versand": None,
+        "top_ort_letzter_versand": None, "created_at": "2026-08-07T00:00:00Z",
+    }
+
+
+class _ScriptedComparePointSource:
+    """Kein Mock: echter `LocationWeatherSource`-Seam, liefert ein festes
+    `PointWeatherData` mit vorgegebenem `precip_sum_mm` ohne Netzzugriff."""
+
+    def __init__(self, precip_sum_mm: float) -> None:
+        self._precip = precip_sum_mm
+
+    def fetch(self, point_id: str, lat: float, lon: float):
+        from services.point_weather import PointWeatherData
+
+        return PointWeatherData(
+            id=point_id, name=point_id, lat=lat, lon=lon, timeseries=None,
+            aggregated=SegmentWeatherSummary(precip_sum_mm=self._precip),
+            fetched_at=datetime.now(timezone.utc), provider="test-scripted",
+        )
+
+
+def test_ac1_1555_free_tier_first_forecast_change_alert_delivered_at_reduced_boundary(
+    telegram_sink,
+):
+    """AC-1 (#1555): Free-Nutzer (`limit=2`) ohne Alarm heute (`count=0`) --
+    ein `forecast_change`-Alarm wird zugestellt, weil `count=0 < 1` (reduzierte
+    Obergrenze). GRÜN heute wie nach der Implementierung (Regressionsschutz):
+    bei `count=0` liefert sowohl das volle Limit (0<2) als auch die reduzierte
+    Obergrenze (0<1) `True` -- diese Grenze ist an sich nicht diskriminierend,
+    RED-Beweis kommt von AC-2/AC-3/AC-6 weiter unten."""
+    from services.alert_daily_limit import load
+    from services.trip_alert import TripAlertService
+
+    uid = f"tdd-1555-ac1-{uuid.uuid4().hex[:6]}"
+    _clean_user(uid)
+    try:
+        _write_user_tier(uid, "free")
+
+        dev_trip = _deviation_trip(f"trip-dev-{uid}")
+        cached = [_weather_data(precip_sum_mm=2.0)]
+        fresh = [_weather_data(precip_sum_mm=18.0)]
+
+        svc = TripAlertService(settings=_settings_telegram_only(), throttle_hours=0, user_id=uid)
+        result = svc.check_and_send_alerts(dev_trip, cached, fresh_weather=fresh)
+
+        assert result is True, (
+            f"AC-1: erster forecast_change-Alarm bei count=0 muss zugestellt werden, got {result}"
+        )
+        assert telegram_sink.send_count() == 1, "AC-1: Telegram-Sink muss genau 1 Versand zeigen"
+        assert load(uid, datetime.now(timezone.utc)) == 1, "AC-1: Zähler muss auf 1 steigen"
+    finally:
+        _clean_user(uid)
+
+
+def test_ac2_1555_free_tier_forecast_change_suppressed_but_nowcast_still_delivered():
+    """AC-2 (#1555, RED heute): Free-Nutzer mit `count=1` -- ein weiterer
+    `forecast_change`-Alarm wird unterdrückt (Reserve: `count=1` ist nicht
+    `< 1`), aber ein `nowcast`-Alarm im selben Zustand wird trotzdem
+    zugestellt (`count=1 < 2`, volles Limit).
+
+    RED-Grund (heute): `trip_alert.py:221` ruft `is_allowed(uid, now)` OHNE
+    `reason=` auf -- bei count=1/Limit=2 ist 1<2=True, der Deviation-Alarm
+    wird heute FÄLSCHLICH zugestellt statt unterdrückt.
+    """
+    from services.alert_daily_limit import load
+    from services.radar_service import RadarNowcastService
+    from services.trip_alert import TripAlertService
+
+    uid = f"tdd-1555-ac2-{uuid.uuid4().hex[:6]}"
+    _clean_user(uid)
+    try:
+        _write_user_tier(uid, "free")
+        _seed_daily_counter(uid, 1)
+
+        # forecast_change (Deviation, Telegram) -- muss unterdrückt bleiben.
+        # Kein telegram_sink-Fixture noetig: TripAlertService versendet ohne
+        # erreichbaren TELEGRAM_API_BASE nicht wirklich, aber `is_allowed()`
+        # entscheidet VOR dem Versandversuch -- ein unterdrückter Alarm ruft
+        # den Kanal gar nicht erst auf.
+        dev_trip = _deviation_trip(f"trip-dev-{uid}")
+        cached = [_weather_data(precip_sum_mm=2.0)]
+        fresh = [_weather_data(precip_sum_mm=18.0)]
+        dev_svc = TripAlertService(settings=_settings_telegram_only(), throttle_hours=0, user_id=uid)
+        dev_result = dev_svc.check_and_send_alerts(dev_trip, cached, fresh_weather=fresh)
+
+        assert dev_result is False, (
+            f"AC-2: forecast_change muss bei count=1 (Reserve-Grenze 1) "
+            f"unterdrückt werden, got {dev_result}"
+        )
+        assert load(uid, datetime.now(timezone.utc)) == 1, (
+            "AC-2: Zähler darf durch den unterdrückten forecast_change-Alarm nicht steigen"
+        )
+
+        # nowcast (Radar, E-Mail) -- muss trotzdem noch zugestellt werden.
+        trip_id = f"trip-radar-{uid}"
+        radar_trip = _make_trip(trip_id, send_email=True, send_telegram=False)
+        _save_trip(radar_trip, uid)
+        mail_calls: list = []
+        radar_svc = TripAlertService(
+            settings=_make_settings_with_email(),
+            throttle_hours=0,
+            user_id=uid,
+            radar_service=RadarNowcastService(frame_source=_wet_frames),
+            mail_sink=lambda subject, body: mail_calls.append((subject, body)),
+        )
+        radar_result = radar_svc.check_radar_alerts()
+
+        assert radar_result == 1, (
+            f"AC-2: nowcast muss bei count=1 gegen das volle Limit (2) noch "
+            f"erlaubt sein, got {radar_result}"
+        )
+        assert len(mail_calls) == 1, "AC-2: nowcast-Alarm muss tatsächlich versendet werden"
+        assert load(uid, datetime.now(timezone.utc)) == 2, "AC-2: Zähler muss nach nowcast auf 2 steigen"
+    finally:
+        _clean_user(uid)
+
+
+def test_ac3_1555_standard_tier_forecast_change_suppressed_but_nowcast_still_delivered():
+    """AC-3 (#1555, RED heute): Standard-Nutzer (`limit=4`) mit `count=2` --
+    ein dritter `forecast_change`-Alarm wird unterdrückt (Reserve: `count=2`
+    ist nicht `< 2`), aber ein `nowcast`-Alarm wird trotzdem zugestellt
+    (`count=2 < 4`).
+
+    RED-Grund: analog AC-2 -- `is_allowed(uid, now)` ohne `reason=` prüft
+    heute 2<4=True, der Deviation-Alarm wird fälschlich zugestellt.
+    """
+    from services.alert_daily_limit import load
+    from services.radar_service import RadarNowcastService
+    from services.trip_alert import TripAlertService
+
+    uid = f"tdd-1555-ac3-{uuid.uuid4().hex[:6]}"
+    _clean_user(uid)
+    try:
+        _write_user_tier(uid, "standard")
+        _seed_daily_counter(uid, 2)
+
+        dev_trip = _deviation_trip(f"trip-dev-{uid}")
+        cached = [_weather_data(precip_sum_mm=2.0)]
+        fresh = [_weather_data(precip_sum_mm=18.0)]
+        dev_svc = TripAlertService(settings=_settings_telegram_only(), throttle_hours=0, user_id=uid)
+        dev_result = dev_svc.check_and_send_alerts(dev_trip, cached, fresh_weather=fresh)
+
+        assert dev_result is False, (
+            f"AC-3: forecast_change muss bei count=2 (Standard, Reserve-Grenze 2) "
+            f"unterdrückt werden, got {dev_result}"
+        )
+        assert load(uid, datetime.now(timezone.utc)) == 2, (
+            "AC-3: Zähler darf durch den unterdrückten forecast_change-Alarm nicht steigen"
+        )
+
+        trip_id = f"trip-radar-{uid}"
+        radar_trip = _make_trip(trip_id, send_email=True, send_telegram=False)
+        _save_trip(radar_trip, uid)
+        mail_calls: list = []
+        radar_svc = TripAlertService(
+            settings=_make_settings_with_email(),
+            throttle_hours=0,
+            user_id=uid,
+            radar_service=RadarNowcastService(frame_source=_wet_frames),
+            mail_sink=lambda subject, body: mail_calls.append((subject, body)),
+        )
+        radar_result = radar_svc.check_radar_alerts()
+
+        assert radar_result == 1, (
+            f"AC-3: nowcast muss bei count=2 gegen das volle Limit (4) noch "
+            f"erlaubt sein, got {radar_result}"
+        )
+        assert len(mail_calls) == 1, "AC-3: nowcast-Alarm muss tatsächlich versendet werden"
+        assert load(uid, datetime.now(timezone.utc)) == 3, "AC-3: Zähler muss nach nowcast auf 3 steigen"
+    finally:
+        _clean_user(uid)
+
+
+def test_ac4_1555_premium_tier_unlimited_for_both_forecast_change_and_nowcast(telegram_sink):
+    """AC-4 (#1555): Premium-Nutzer (`limit=None`) mit `count=6` -- sowohl
+    `forecast_change` als auch `nowcast` werden zugestellt, kein Deckel
+    greift. GRÜN heute wie nach der Implementierung (Regressionsschutz):
+    Premium kurzschließt `is_allowed()` unabhängig von `reason` immer auf
+    `True` (Spec: "keine Reserve, is_allowed liefert weiterhin sofort True
+    ohne Zähler-Load") -- dieses Verhalten ist per Definition der AC in
+    keinem der beiden Regime unterscheidbar."""
+    from services.alert_daily_limit import load
+    from services.radar_service import RadarNowcastService
+    from services.trip_alert import TripAlertService
+
+    uid = f"tdd-1555-ac4-{uuid.uuid4().hex[:6]}"
+    _clean_user(uid)
+    try:
+        _write_user_tier(uid, "premium")
+        _seed_daily_counter(uid, 6)
+
+        dev_trip = _deviation_trip(f"trip-dev-{uid}")
+        cached = [_weather_data(precip_sum_mm=2.0)]
+        fresh = [_weather_data(precip_sum_mm=18.0)]
+        dev_svc = TripAlertService(settings=_settings_telegram_only(), throttle_hours=0, user_id=uid)
+        dev_result = dev_svc.check_and_send_alerts(dev_trip, cached, fresh_weather=fresh)
+
+        assert dev_result is True, f"AC-4: Premium forecast_change trotz count=6 muss zugestellt werden, got {dev_result}"
+        assert telegram_sink.send_count() == 1
+        assert load(uid, datetime.now(timezone.utc)) == 7, "AC-4: Zähler steigt weiter (kein Deckel)"
+
+        trip_id = f"trip-radar-{uid}"
+        radar_trip = _make_trip(trip_id, send_email=True, send_telegram=False)
+        _save_trip(radar_trip, uid)
+        mail_calls: list = []
+        radar_svc = TripAlertService(
+            settings=_make_settings_with_email(),
+            throttle_hours=0,
+            user_id=uid,
+            radar_service=RadarNowcastService(frame_source=_wet_frames),
+            mail_sink=lambda subject, body: mail_calls.append((subject, body)),
+        )
+        radar_result = radar_svc.check_radar_alerts()
+
+        assert radar_result == 1, f"AC-4: Premium nowcast trotz count=7 muss zugestellt werden, got {radar_result}"
+        assert len(mail_calls) == 1
+        assert load(uid, datetime.now(timezone.utc)) == 8
+    finally:
+        _clean_user(uid)
+
+
+def test_ac5_1555_is_allowed_without_reason_argument_uses_full_limit_backward_compat():
+    """AC-5 (#1555): ein bestehender Aufruf `is_allowed(user_id, now)` OHNE
+    `reason`-Argument verhält sich exakt wie vor dieser Änderung -- geprüft
+    gegen das volle `limit`, nicht gegen die reduzierte `forecast_change`-
+    Obergrenze. GRÜN heute wie danach (das IST die Rückwärtskompatibilitäts-
+    Garantie, keine RED-Grenze): bei count=1/Free ist 1<2=True unabhängig
+    von der Implementierung dieses Fixes. Der bestehende Wiring-Vorbild-Test
+    `test_ac5_cross_path_daily_limit_shared_between_radar_and_deviation`
+    (oben in dieser Datei) bleibt unverändert grün und verankert dieselbe
+    Garantie an der Aufrufstelle."""
+    from services.alert_daily_limit import is_allowed
+
+    uid = f"tdd-1555-ac5-{uuid.uuid4().hex[:6]}"
+    _clean_user(uid)
+    try:
+        _write_user_tier(uid, "free")
+        _seed_daily_counter(uid, 1)
+        now = datetime.now(timezone.utc)
+
+        assert is_allowed(uid, now) is True, (
+            "AC-5: is_allowed(uid, now) ohne reason muss bei count=1/Free "
+            "gegen das volle Limit (2) prüfen -> True, nicht gegen die "
+            "reduzierte forecast_change-Obergrenze (1)"
+        )
+    finally:
+        _clean_user(uid)
+
+
+def test_ac6_1555_compare_forecast_change_suppressed_at_reserve_boundary():
+    """AC-6 (#1555, RED heute): Compare-Pfad im selben Zählerstand wie AC-2
+    (Free, `count=1`) -- ein weiterer Compare-`forecast_change`-Alarm wird
+    ebenso unterdrückt wie im Trip-Pfad, dieselbe Reserve-Regel gilt
+    identisch für Compare.
+
+    RED-Grund (heute): `compare_alert.py:145` ruft `is_allowed(uid, now)`
+    OHNE `reason=` auf -- bei count=1/Limit=2 ist 1<2=True, der Alarm wird
+    heute FÄLSCHLICH zugestellt statt unterdrückt.
+    """
+    from app.loader import save_location
+    from app.user import SavedLocation
+    from services import alert_daily_limit
+    from services.compare_alert import CompareAlertService
+    from services.compare_weather_snapshot import CompareWeatherSnapshotService
+
+    from tests.helpers.compare_briefings import write_compare_briefings
+
+    uid = f"tdd-1555-ac6-{uuid.uuid4().hex[:6]}"
+    preset_id = f"cp-1555-ac6-{uuid.uuid4().hex[:6]}"
+    _clean_user(uid)
+    _clean_compare_preset_dir(uid)
+    try:
+        _write_user_tier(uid, "free")
+        _seed_daily_counter(uid, 1)
+
+        loc = SavedLocation(id="loc-1555", name="ReserveOrt", lat=46.9, lon=10.9, elevation_m=900)
+        save_location(loc, user_id=uid)
+        write_compare_briefings(
+            _COMPARE_DATA_ROOT / uid,
+            [_compare_preset_active(preset_id, ["loc-1555"], ["gregor-test@henemm.com"])],
+        )
+        CompareWeatherSnapshotService(user_id=uid).save(
+            preset_id, "loc-1555",
+            _ScriptedComparePointSource(2.0).fetch("loc-1555", loc.lat, loc.lon),
+        )
+
+        sent_subjects: list[str] = []
+        svc = CompareAlertService(
+            settings=_make_settings_with_email(), user_id=uid,
+            weather_source=_ScriptedComparePointSource(30.0),  # Δ=28, weit über jeder Schwelle
+            mail_sink=lambda subject, body: sent_subjects.append(subject),
+        )
+        sent = svc.check_all_compare_presets()
+
+        assert sent == 0, (
+            f"AC-6: Reserve muss den 2. Compare-forecast_change-Alarm bei "
+            f"count=1 (Free, Reserve-Grenze 1) unterdrücken, got sent={sent}"
+        )
+        assert sent_subjects == [], "AC-6: mail_sink wurde trotz Reserve aufgerufen"
+        assert alert_daily_limit.load(uid, datetime.now(timezone.utc)) == 1, (
+            "AC-6: Zähler darf bei unterdrücktem Compare-Alarm nicht steigen"
+        )
+    finally:
+        _clean_user(uid)
+        _clean_compare_preset_dir(uid)

--- a/tests/tdd/test_issue_1070_daily_alert_limit.py
+++ b/tests/tdd/test_issue_1070_daily_alert_limit.py
@@ -401,6 +401,7 @@ def telegram_sink(monkeypatch):
 
     sink = _TelegramSink()
     monkeypatch.setattr(telegram_mod, "TELEGRAM_API_BASE", sink.base)
+    monkeypatch.setenv("GZ_TELEGRAM_TEST_CHAT_ID", "1070-fixture-test-chat")
     yield sink
     sink.stop()
 


### PR DESCRIPTION
Free-/Standard-Konten reservierten bislang keinen Anteil ihres geteilten
Tages-Alarmbudgets fuer akute NowCast-Warnungen -- Vorhersage-Abweichungs-
Alarme verbrauchten es faktisch immer zuerst, wodurch system-weit noch nie
ein einziger NowCast-Alarm zugestellt wurde (#1555). alert_daily_limit.is_
allowed() bekommt einen optionalen reason-Parameter: reason="forecast_change"
prueft bei endlichem Limit gegen eine reduzierte Obergrenze (Free 2->1,
Standard 4->2), reason="nowcast" und alles andere (inkl. kein reason, also
Rueckwaertskompatibilitaet) weiterhin gegen das volle Limit. Amtliche
Warnungen bleiben bewusst unreserviert (PO-Entscheidung).

6 ACs, Adversary VERIFIED (9/9 Punkte, 4/4 Mutationen gefangen). Ein
bestehender Ruhezeit-Test kollidierte mit der neuen Reserve (erwartete 2
Zustellungen fuer denselben tariflosen Testnutzer) -- Fixture-Fix (tier=
premium), kein Produktionscode betroffen.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
