### PR TITLE
#1196 Batch 2: Thunder-Ordinal-Tests an 4-Stufen-Skala angeglichen (Exclude 41 → 39)

### DIFF
--- a/.github/ci_tdd_excludes.txt
+++ b/.github/ci_tdd_excludes.txt
@@ -15,6 +15,11 @@
 # (altes ADR-Dateinamen-Literal aus Spec-Doku entfernt) sind saniert und
 # laufen wieder mit.
 #
+# Batch 2 (2026-08-07): test_compare_metric_catalog_endpoint +
+# test_day_comparison_service — Thunder-Ordinal-Tests an die seit #1474
+# gueltige 4-Stufen-Skala (NONE/LOW/MED/HIGH) angeglichen; die 3-Stufen-
+# Erwartung war Ueberstand aus der PO-Entscheidung 2026-07-12.
+#
 # WICHTIG (Lektion aus PR #1551): Lokale Offline-Laeufe im Haupt-Checkout
 # (.env + befuellte data/users/) sind KEIN Beleg fuer CI-Gruen. Einzig
 # verbindliche Vermessung ist der Runner. Ursachen und Sanierungsreihenfolge:
@@ -28,11 +33,9 @@ tests/tdd/test_alert_run_deadline.py
 tests/tdd/test_alert_tenancy_two_users.py
 tests/tdd/test_bundle_791_847_844_alerts.py
 tests/tdd/test_bundle_e_gate_tooling.py
-tests/tdd/test_compare_metric_catalog_endpoint.py
 tests/tdd/test_compare_official_alert.py
 tests/tdd/test_compare_sun_hours_full_day_window.py
 tests/tdd/test_corridor_no_longer_triggers_alerts.py
-tests/tdd/test_day_comparison_service.py
 tests/tdd/test_feature_656_radar_nowcast.py
 tests/tdd/test_feature_660_convective_stage.py
 tests/tdd/test_issue_1040_alerts_toggle.py

--- a/tests/tdd/test_compare_metric_catalog_endpoint.py
+++ b/tests/tdd/test_compare_metric_catalog_endpoint.py
@@ -217,15 +217,17 @@ class TestCompareMetricCatalogEndpoint:
             else:
                 pytest.fail(f"{entry['key']}: unbekannter kind {entry['kind']!r}")
 
-    def test_thunder_level_max_is_ordinal_with_three_labels(self, client: TestClient) -> None:
-        """AC-2 (Sonderfall): thunder_level_max ist 'ordinal' mit den drei sichtbaren
-        Editor-Labels (PO-Entscheidung 2026-07-12, nicht 'enum' wie im rohen
-        ALL_METRICS-Eintrag)."""
+    def test_thunder_level_max_is_ordinal_with_four_labels(self, client: TestClient) -> None:
+        """AC-2 (Sonderfall): thunder_level_max ist 'ordinal' mit den vier sichtbaren
+        Editor-Labels. Urspruenglich drei Labels (PO-Entscheidung 2026-07-12);
+        seit Issue #1474 (S3 zu #1419) vier Stufen — LOW 'leicht' besetzt den
+        vorher unerreichbaren Render-Platz L, und der Frontend-Schieberegler
+        leitet seinen Bereich aus len(ordinalLabels) ab."""
         response = client.get("/api/compare/metrics")
         metrics = {m["key"]: m for m in response.json()["metrics"]}
         thunder = metrics["thunder_level_max"]
         assert thunder["kind"] == "ordinal"
-        assert thunder["ordinalLabels"] == ["kein", "mittel", "hoch"]
+        assert thunder["ordinalLabels"] == ["kein", "leicht", "mittel", "hoch"]
 
     def test_precip_type_dominant_stays_enum(self, client: TestClient) -> None:
         """AC-2 (Sonderfall): precip_type_dominant bleibt 'enum' mit den vier

--- a/tests/tdd/test_day_comparison_service.py
+++ b/tests/tdd/test_day_comparison_service.py
@@ -174,7 +174,8 @@ class TestAC3_ThunderOrdinal:
         """
         GIVEN gestern ThunderLevel.HIGH, heute ThunderLevel.NONE
         WHEN compare()
-        THEN direction=BETTER, delta=-2 (ordinal)
+        THEN direction=BETTER, delta=-3 (ordinal, 4-stufig seit #1474:
+        NONE=0, LOW=1, MED=2, HIGH=3)
         """
         from app.models import ThunderLevel
         from services.day_comparison import ComparisonDirection, DayComparisonService
@@ -185,13 +186,13 @@ class TestAC3_ThunderOrdinal:
         entry = DayComparisonService().compare(today, yesterday).entries[0]
 
         assert entry.thunder.direction == ComparisonDirection.BETTER
-        assert entry.thunder.delta == -2
+        assert entry.thunder.delta == -3
 
     def test_thunder_none_to_med_is_worse(self):
         """
         GIVEN gestern ThunderLevel.NONE, heute ThunderLevel.MED
         WHEN compare()
-        THEN direction=WORSE, delta=+1
+        THEN direction=WORSE, delta=+2 (4-stufige Ordinal seit #1474)
         """
         from app.models import ThunderLevel
         from services.day_comparison import ComparisonDirection, DayComparisonService
@@ -202,7 +203,7 @@ class TestAC3_ThunderOrdinal:
         entry = DayComparisonService().compare(today, yesterday).entries[0]
 
         assert entry.thunder.direction == ComparisonDirection.WORSE
-        assert entry.thunder.delta == 1
+        assert entry.thunder.delta == 2
 
     def test_thunder_same_level_is_equal(self):
         """


### PR DESCRIPTION
## Was

Batch 2 des Sanierungsplans (`docs/analysis/1196-tdd-excludes-sanierung-2026-08-06.md`): zwei Dateien aus der Exclude-Liste entfernt.

**Faktenlage (recherchiert, keine Änderung am Produktivcode):** Die 4-stufige Gewitter-Skala `NONE/LOW/MED/HIGH` ist seit **#1474** (Commit 860a3baf, „Gewitter-Stärke bekommt ihre fehlende vierte Stufe leicht") absichtlicher Ist-Stand — LOW besetzt den zuvor unerreichbaren Render-Platz `L`, und der Frontend-Schieberegler leitet seinen Bereich aus `len(ordinalLabels)` ab. Die beiden Testdateien kodierten noch die 3-Stufen-Welt der PO-Entscheidung 2026-07-12 und sind damit veraltet, nicht der Code.

## Änderungen (nur Tests + Liste)

- `test_compare_metric_catalog_endpoint.py`: `ordinalLabels`-Erwartung `['kein','mittel','hoch']` → `['kein','leicht','mittel','hoch']`, Docstring mit #1474-Begründung.
- `test_day_comparison_service.py`: Ordinal-Deltas an 4 Stufen angepasst (HIGH→NONE: −3 statt −2; NONE→MED: +2 statt +1). Richtungen (BETTER/WORSE) unverändert.
- `ci_tdd_excludes.txt`: 41 → 39 Einträge, Batch-Vermerk im Header.

## Verifikation

Lokal offline (CI-Bedingungen): 33 Tests grün, ruff sauber. Runner-Lauf ist der verbindliche Beleg (Lektion PR #1551).

Refs #1196
