### PR TITLE
docs(#1555): Spec auf implemented gesetzt, Epic-Übersicht um Reserve-Regel ergänzt

### DIFF
--- a/docs/specs/modules/epic_user_tiers_overview.md
+++ b/docs/specs/modules/epic_user_tiers_overview.md
@@ -33,6 +33,14 @@ Tages-Obergrenzen mit Mitternachts-Reset, KEIN reiner Mindestabstand — ein Nut
 einem Tag maximal N Alerts/Updates, unabhängig vom zeitlichen Abstand dazwischen. Premium bleibt
 ein reiner Mindestabstand (Intervall-Semantik von „alle 15 Minuten"), ohne Tageszähler.
 
+**Ergänzung #1555 (2026-08-07):** Innerhalb der Free-/Standard-Obergrenze ist das Budget seit
+`fix_1555_nowcast_alert_priority.md` nicht mehr rein first-come-first-served — ein Anteil
+(Free 1 von 2, Standard 2 von 4) bleibt ausschließlich für akute NowCast-Gefahr
+(`reason="nowcast"`) reserviert, reine Vorhersage-Abweichungs-Alarme (`reason="forecast_change"`)
+können diesen Anteil nicht mehr belegen. Grund: system-weit wurde vorher **kein einziger**
+NowCast-Alarm je zugestellt, weil Abweichungs-Alarme das Budget faktisch immer zuerst
+verbrauchten. Details, Reserve-Tabelle und Adversary-Nachweis: siehe verlinkte Spec.
+
 ## Bestehende Systeme, die wir nutzen (Befund)
 
 - **Nutzerverwaltung existiert bereits, keine neue Persistenz nötig.** Ein Nutzer ist ein

--- a/docs/specs/modules/fix_1555_nowcast_alert_priority.md
+++ b/docs/specs/modules/fix_1555_nowcast_alert_priority.md
@@ -3,7 +3,7 @@ entity_id: fix_1555_nowcast_alert_priority
 type: bugfix
 created: 2026-08-07
 updated: 2026-08-07
-status: draft
+status: implemented
 workflow: fix-1555-nowcast-alert-priority
 version: "1.0"
 tags: [issue-1555, alerts, epic-1067, follow-up-1070]
@@ -13,7 +13,7 @@ tags: [issue-1555, alerts, epic-1067, follow-up-1070]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved
 
 ## Purpose
 
@@ -229,3 +229,4 @@ ein vergessenes `reason=` an der Aufrufstelle nicht sehen.
 ## Changelog
 
 - 2026-08-07: Initial spec created
+- 2026-08-07: Implemented, Adversary VERIFIED, live in Prod (`939e8c54`, PR #1565), Issue #1555 geschlossen


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
