### PR TITLE
docs(#1492): Vertretung in der Entscheidungsmatrix, ADR-0047-Folgepflicht erledigt

### DIFF
--- a/docs/adr/0047-gewitter-vertretung-zwischen-direktquellen.md
+++ b/docs/adr/0047-gewitter-vertretung-zwischen-direktquellen.md
@@ -134,9 +134,18 @@ wirkte dieses ADR wie ein Bruch von ADR-0025 — das ist es nicht.
   - Das in ADR-0018 geforderte wachsende Health-Signal für andauernde Ausfälle ist für die
     Gewitter-Domäne **noch nicht** nachgezogen — bewusst vertagt auf ein eigenes Folge-Issue
     (Spec Known Limitations Punkt 2), keine offene Lücke innerhalb dieser Scheibe.
-  - Sichtbarkeit im Briefing (E-Mail-/Telegram-Fußzeile) ist eigene Folgescheibe 2b; 2a hält die
-    Herkunft nur intern fest. 2b darf sich dabei NICHT allein auf `fallback_model` stützen (s.
-    Spec Known Limitations Punkt 3), sondern muss auch `fallback_metrics` auswerten.
+  - ~~Sichtbarkeit im Briefing (E-Mail-/Telegram-Fußzeile) ist eigene Folgescheibe 2b; 2a hält die
+    Herkunft nur intern fest.~~ **Erledigt mit #1492 Scheibe 2b (live seit 2026-08-07,
+    `35b41753`).** Die Vertretung erscheint in Klartext in der Trip-Briefing-Mail (Vollversion
+    und Kompakt) sowie in der Telegram-Langform; SMS und Telegram-Kurzform bleiben bewusst
+    ausgenommen (160-Zeichen-Budget). Formulierung zentral in
+    `src/output/renderers/fallback_notice.py`, Spec
+    `docs/specs/modules/feat_1492_s2b_fallback_sichtbarkeit.md`. Die Auflage aus Known
+    Limitations Punkt 3 ist eingehalten: die Gewitterzeile erkennt die Vertretung an
+    `fallback_metrics`, **nicht** an `fallback_model`, und nennt im Kollisionsfall bewusst
+    keinen Quellennamen, statt den Namen des Grundvorhersage-Ersatzmodells zu führen.
+    **Offen bleibt allein die Ortsvergleichs-Mail** (mehrere Orte mit je eigener Herkunft) —
+    eigenes Folge-Issue **#1563**.
 
 ## Changelog
 

--- a/docs/reference/decision_matrix.md
+++ b/docs/reference/decision_matrix.md
@@ -143,6 +143,29 @@ ist die Landkarte der Gewittersignal-Beschaffung aus #1419 Schritt S2 vollständ
 (#1457). Fehlt ein Wert, bleibt das Feld `None` — „keine Aussage" ist nicht „keine
 Gefahr".
 
+**Vertretung bei echtem Ausfall (#1492 S2a, ADR-0047).** Neben der obigen
+Primärauswahl existiert eine **zweite, getrennte** Tabelle
+`thunder_routing.thunder_vertretung_for`: `de_direct → eu_direct`,
+`fr_direct → eu_direct`, `eu_direct → keine`. Sie greift **ausschließlich**, wenn
+alle tatsächlich versuchten Abrufe an Verbindungsfehlern scheiterten
+(`ThunderSourceUnavailableError`) — eine erfolgreiche, aber leere Antwort
+(Gitterrand, kein Gewitter) löst sie nicht aus. Die first-match-wins-Reihenfolge
+der Primärauswahl bleibt davon **unangetastet**; „Die Reihenfolge ist tragend"
+gilt unverändert. Der Ersatzwert landet strukturell im Feld der *Ersatzquelle*,
+nie in dem der Primärquelle — bei `fr_direct → eu_direct` wechselt damit die
+Messgröße von Blitz**dichte** auf Blitz**potenzial** (verschiedene Skalen, je
+eigene Schwellentabelle).
+
+Jede Vertretung wird markiert (`ForecastMeta.fallback_model` /
+`fallback_reason="thunder_source_unavailable"` / `fallback_metrics`) und **seit
+#1492 S2b im Briefing angezeigt** — E-Mail (Vollversion + Kompakt) und
+Telegram-Langform, in Klartext („Gewitterdaten von Ersatzquelle: DWD Europa
+(gröbere Auflösung)"), Formulierung zentral in
+`src/output/renderers/fallback_notice.py`. ⚠️ `fallback_model` überschreibt
+einen bereits vorhandenen Grundvorhersage-Fallback (#1115) **nicht**
+(Merge-Schutz) — wer eine Gewitter-Vertretung zuverlässig erkennen will, prüft
+`fallback_metrics` auf die Gewitter-Feldnamen, nicht den Modellnamen.
+
 ## Kontingent-Regeln (Open-Meteo)
 
 Der Radar-Pfad dominiert den API-Verbrauch (#1329): geteilter Forecast-Cache +

--- a/docs/specs/modules/feat_1492_s2b_fallback_sichtbarkeit.md
+++ b/docs/specs/modules/feat_1492_s2b_fallback_sichtbarkeit.md
@@ -17,9 +17,14 @@ workflow: feat-1492-s2b-fallback-sichtbarkeit
   Kommentar an Issue #1492). Freigegeben: die zehn Acceptance Criteria auf
   Deutsch, der Ausgaben-Umfang (Trip-Mail Vollversion + Kompakt + Telegram-
   Langform; **ohne** Ortsvergleich, Alarm-Mails, SMS, Telegram-Kurzform), der
-  Wortlaut-Stil „Quelle in Klartext + Folge in Klammern", sowie
+  Wortlaut-Stil „Quelle in Klartext + Folge in Klammern", sowie zunächst
   `loc_limit_override = 400` mit der ausdrücklichen Auflage, den Testumfang
   dafür **nicht** zu kürzen.
+- [x] **Nachtrag PO-Freigabe 2026-08-07:** `loc_limit_override` auf **700**
+  angehoben, nachdem die geschriebenen Tests allein +538 Zeilen ergaben (drei
+  Ausgabewege einzeln geprüft, fünf Bestandstests mitgezogen). Die Auflage
+  „Testumfang nicht kürzen" wurde dabei ausdrücklich bekräftigt; die
+  Alternative „Scheibe erneut teilen" wurde vom PO verworfen.
 
 ## Purpose
 
@@ -89,6 +94,16 @@ im Kollisionsfall aus zwei unabhängigen Mechanismen stammen können. Issue
   knapp über dem Standard-Limit von 250 LoC/Workflow. Ob ein
   `loc_limit_override` nötig wird, entscheidet der PO nach Prüfung des
   tatsächlichen Diffs — hier keine Vorfestlegung.
+- **Tatsächlich geliefert (2026-08-07, Commit `70adfce8`):** Produktivcode
+  **271 Zeilen** (`fallback_notice.py` 230 neu, plus 41 Zeilen Verpackung in
+  den vier Ausgaben) — die Schätzung von 110–130 lag zu niedrig, weil zwei
+  Adversary-Runden zusätzliche Fälle nötig machten (Etappen-Auswahl über alle
+  Segmente, Import-Entkopplung, Kollision bei nicht ermittelbaren
+  Gewitter-Feldnamen). Tests **rund 1 090 Zeilen** über vier Dateien.
+  Zusammen deutlich über der Erstschätzung; PO-Freigabe auf 700 (s. Approval).
+  **Lehre für künftige Schätzungen:** der Testumfang skaliert nicht mit dem
+  Produktivcode, sondern mit der **Zahl der Ausgabewege × Zahl der
+  Fehlerlagen** — hier vier Ausgaben × sechs Zustände.
 
 ## Dependencies
 


### PR DESCRIPTION
Nachtrag nach der Auslieferung von #1492 Scheibe 2b. Drei Doku-Stellen waren nicht auf dem Stand der Umsetzung.

- **`decision_matrix.md`** beschrieb die Gewitter-Zuständigkeit nur als Primärauswahl — die Vertretungstabelle aus S2a (ADR-0047) fehlte **vollständig** (0 Treffer für „Vertretung" im ganzen Dokument). Das war eine bei S2a offen gebliebene Folgepflicht. Ergänzt inklusive der Merge-Schutz-Falle: wer eine Gewitter-Vertretung zuverlässig erkennen will, prüft `fallback_metrics`, nicht `fallback_model`.
- **ADR-0047** führte „Sichtbarkeit im Briefing" noch als offene Folgescheibe. Erledigt mit S2b (live `35b41753`); offen bleibt allein die Ortsvergleichs-Mail → #1563.
- **Spec** trug im Freigabe-Vermerk das ursprüngliche Zeilen-Limit 400, obwohl der PO während der Umsetzung auf 700 angehoben hat. Nachgetragen samt tatsächlich geliefertem Umfang.

Reine Doku, kein Code berührt. `tests/test_adr_index_drift.py` grün.

Refs #1492

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzaMdw2Cnt9o6iVx5QRwHD