### PR TITLE
docs(#1552): api_contract kennt trip_default_enabled

### DIFF
--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -1430,6 +1430,7 @@ Returns catalog of all available weather metrics with format mode options and de
 | metrics[].format_modes | string[] | Supported format modes for this metric (`raw`, `scale`, `simplified`, `symbol`) |
 | metrics[].default_format_mode | string | Recommended default format mode (must be in `format_modes`) |
 | metrics[].selectable | bool | Whether this metric appears in the user-facing selector (Wizard/Editor). Backend internal metric (`confidence`) has `selectable=false` (Issue #710) — these are never returned by `/api/metrics` but used internally for aggregation/forecast-hints (UI-Auswahl heißt heute Editor-Metrik-Auswahl, kein Wizard) |
+| metrics[].trip_default_enabled | bool | **Neu Issue #1552.** Ob die Größe zur Vorbelegung eines **neu angelegten Trips** gehört — unabhängig von `default_enabled` (das weiterhin die Orte-/Abonnement-Konfiguration über `build_default_display_config()` versorgt; vor #1552 zeigte der Anlege-Dialog `default_enabled` als Vorbelegung an, während der Versand eines nie eingestellten Trips tatsächlich einem anderen Siebener-Satz folgte — Überschneidung nur 5 von 10). Quelle: `MetricDefinition.trip_default_rank is not None` (`metric_catalog.py`). Genau sieben Größen tragen einen Rang: `temperature`(1), `wind`(2), `gust`(3), `precipitation`(4), `thunder`(5), `freezing_level`(6), `visibility`(7) — dieselbe Rangfolge, aus der `DEFAULT_TRIP_METRIC_IDS` (`src/output/renderers/trip_metric_ids.py`) jetzt abgeleitet wird, statt sie hart zu listen |
 | metrics[].sms_code | string | GSM-7-safe short token for the metric in SMS/Subject/Telegram alert tokens (e.g., `W`, `G`, `R`, `PR`, `TH`, `CP`, `SL`, `VS`, `HU`). Single source for alert renderers (Issue #914 Slice 1); the metric catalog is the only place these are defined |
 | metrics[].decimals | int \| null | Rounding precision for display (e.g., `precipitation: 1`, `visibility: 1`, most metrics `0`). `null` ⇒ fall back to the unit-based heuristic in `format_metric_value()` |
 | metrics[].aggregations | `{id, label, alert_metric}[]` | **Neu Issue #1357, `alert_metric` neu #1435 E1a:** die für diese Größe tatsächlich berechenbaren Tagesauswertungen in fester Reihenfolge (`min`, `max`, `avg`, `sum`), mit deutschem Label. Quelle: `metric_catalog.available_aggregations()`/`aggregation_label_de()` über `MetricDefinition.summary_fields` — **nicht** `default_aggregations` (verspricht bei `snowfall_limit`/`freezing_level` mehr, als berechenbar ist). Weniger als zwei Einträge ⇒ der Editor zeigt keine Auswahl (kein wirkungsloses Bedienelement) |
@@ -3387,6 +3388,23 @@ function corridorInside(value, min, max) {
 
 ## Changelog
 
+- 2026-08-07: Issue #1552 — `GET /api/metrics` liefert je Größe zusätzlich
+  `trip_default_enabled` (bool), gesetzt aus dem neuen Registerfeld
+  `trip_default_rank` (`src/app/metric_catalog.py`). Es markiert die
+  Vorbelegung eines **neu angelegten Trips** und ist bewusst unabhängig von
+  `default_enabled` (das weiterhin `build_default_display_config()` und damit
+  die Orte-/Abonnement-Konfiguration versorgt und dafür unverändert bleibt).
+  Anlass: Anlege-Dialog zeigte bislang `default_enabled` (10 Größen) als
+  Vorbelegung, während ein nie eingestellter Trip tatsächlich einen anderen
+  Siebener-Satz (`DEFAULT_TRIP_METRIC_IDS`) verschickte — Überschneidung nur
+  5. Seit #1552 gilt einheitlich der Sieben-Satz mit expliziter Rangfolge
+  (`temperature`(1) … `visibility`(7)); `DEFAULT_TRIP_METRIC_IDS`
+  (`src/output/renderers/trip_metric_ids.py`) wird jetzt aus dem Register
+  abgeleitet statt hart gelistet. Frontend-Typ `MetricEntry.trip_default_enabled`
+  (`frontend/src/lib/types.ts`) ist bewusst optional, um bestehende
+  Test-/Mock-Kataloge nicht nachrüsten zu müssen — die echte Serverantwort
+  liefert das Feld unbedingt. Section 15 aktualisiert. Siehe
+  `docs/specs/modules/fix_1552_neuanlage_metrikauswahl.md`.
 - 2026-08-03: Issue #1460 Teil 1 (Epic #1458 Scheibe 2, ADR-0043 löst ADR-0040 ab) —
   `corridors[].notify` fällt als Alarm-Auslöser weg; die Empfindlichkeitsstufe
   (`metric_alert_levels`) ist wieder der einzige Regler. Bei Gefahrenstufen-Größen


### PR DESCRIPTION

Die verbindliche DTO-Referenz hinkte hinter der Auslieferung her: GET /api/metrics
liefert seit 939e8c54 je Groesse trip_default_enabled, die Feldtabelle in
Section 15 kannte es nicht.

Nachgezogen: Tabellenzeile bei den uebrigen Feldern plus Changelog-Eintrag im
Stil der Nachbareintraege. Festgehalten ist dabei der Punkt, der die eigentliche
Falle war — trip_default_enabled ist bewusst UNABHAENGIG von default_enabled:
letzteres versorgt weiterhin build_default_display_config() und damit die
Orte-/Abonnement-Konfiguration und blieb deshalb unangetastet. Vor #1552 zeigte
der Anlege-Dialog default_enabled (10 Groessen) als Vorbelegung, waehrend ein nie
eingestellter Trip einem anderen Siebener-Satz folgte; Ueberschneidung 5.

Der bestehende Drift-Test haette diese Luecke nie gemeldet: er prueft
Go-Router-Routen und Go-Struct-Tags, trip_default_enabled ist ein reines
Python-DTO-Feld. Der Test laeuft gruen (3 passed) — er deckt diese Klasse
strukturell nicht ab. Als Befund verbucht, nicht hier repariert.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Reine Doku — keine Staging-Validierung noetig (CLAUDE.md, Ausnahme fuer .md/docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)