### PR TITLE
docs: Mobile-Design-Vorlage aus dem nie gemergten PR #275 retten

### DIFF
--- a/docs/design/mobile/Gregor 20 - Mobile v1.html
+++ b/docs/design/mobile/Gregor 20 - Mobile v1.html
@@ -1,0 +1,201 @@
+<!doctype html>
+<html lang="de">
+<head>
+<meta charset="utf-8" />
+<title>Gregor 20 — Mobile v1</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="tokens.css">
+<style>
+  html, body { background: #f0eee9; height: 100%; }
+  #root { min-height: 100%; }
+</style>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+</head>
+<body>
+<div id="root"></div>
+
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="mock-data.jsx"></script>
+<script type="text/babel" src="mock-locations.jsx"></script>
+<script type="text/babel" src="atoms.jsx"></script>
+<script type="text/babel" src="mobile-shell.jsx"></script>
+<script type="text/babel" src="screen-design-system-mobile.jsx"></script>
+<script type="text/babel" src="screen-login-mobile.jsx"></script>
+<script type="text/babel" src="screen-home-mobile.jsx"></script>
+<script type="text/babel" src="screen-trips-mobile.jsx"></script>
+<script type="text/babel" src="screen-trip-detail-mobile.jsx"></script>
+<script type="text/babel" src="screen-trip-wizard-mobile.jsx"></script>
+<script type="text/babel" src="screen-waypoint-editor-mobile.jsx"></script>
+<script type="text/babel" src="screen-metrics-editor-mobile.jsx"></script>
+<script type="text/babel" src="screen-alert-config-mobile.jsx"></script>
+<script type="text/babel" src="screen-compare-mobile.jsx"></script>
+<script type="text/babel" src="screen-location-new-mobile.jsx"></script>
+<script type="text/babel" src="screen-output-preview-mobile.jsx"></script>
+<script type="text/babel" src="screen-patterns-mobile.jsx"></script>
+
+<script type="text/babel">
+  const PHONE_W = 387;   // 375 + 12 (Bezel 6px je Seite)
+
+  function App() {
+    return (
+      <DesignCanvas>
+        <DCSection id="intro" title="Mobile-Erweiterung · Übersicht" subtitle="11 Screens + übergreifende Patterns bei 375 px. tokens.css unverändert — alle Mobile-Entscheidungen daraus abgeleitet.">
+          <DCArtboard id="m-readme" label="Readme · Pattern-Entscheidungen" width={760} height={1100}>
+            <ReadmeCard/>
+          </DCArtboard>
+          <DCArtboard id="m-ds" label="Mobile-Tokens · Design-System" width={PHONE_W} height={1130}>
+            <ScreenDesignSystemMobile/>
+          </DCArtboard>
+        </DCSection>
+
+        <DCSection id="auth-and-shell" title="01 · Auth & App-Shell" subtitle="Login (frisch designt) und übergreifende Shell-Patterns: Bottom-Nav + Drawer (Hybrid-Navigation).">
+          <DCArtboard id="m-login" label="Login · Magic-Link / Passkey" width={PHONE_W} height={840}>
+            <ScreenLoginMobile/>
+          </DCArtboard>
+          <DCArtboard id="m-shell" label="App-Shell · Drawer offen" width={PHONE_W} height={840}>
+            <PatternAppShellDrawer/>
+          </DCArtboard>
+        </DCSection>
+
+        <DCSection id="hauptscreens" title="02 · Hauptscreens" subtitle="Übersicht, Trips-Liste, Trip-Detail. Bottom-Nav: home / trips / compare / archive.">
+          <DCArtboard id="m-home" label="Übersicht (screen-home)" width={PHONE_W} height={840}>
+            <ScreenHomeMobile/>
+          </DCArtboard>
+          <DCArtboard id="m-trips" label="Trips-Liste (screen-trips · Card-Stack)" width={PHONE_W} height={840}>
+            <ScreenTripsMobile/>
+          </DCArtboard>
+          <DCArtboard id="m-trip-detail" label="Trip-Detail (screen-trip-detail · Tab-Scroller)" width={PHONE_W} height={840}>
+            <ScreenTripDetailMobile/>
+          </DCArtboard>
+        </DCSection>
+
+        <DCSection id="wizard" title="03 · Trip-Wizard · 4 Vollbild-Schritte" subtitle="Jeder Schritt = eigener Screen. Sticky Top-Indicator, Sticky Bottom-Actions. Kein Bottom-Nav während Wizard.">
+          <DCArtboard id="m-wiz-1" label="Wizard · Schritt 1 · Profil" width={PHONE_W} height={840}>
+            <ScreenTripWizardMobile initialStep={1}/>
+          </DCArtboard>
+          <DCArtboard id="m-wiz-2" label="Wizard · Schritt 2 · GPX-Import" width={PHONE_W} height={840}>
+            <ScreenTripWizardMobile initialStep={2}/>
+          </DCArtboard>
+          <DCArtboard id="m-wiz-3" label="Wizard · Schritt 3 · Wegpunkte" width={PHONE_W} height={840}>
+            <ScreenTripWizardMobile initialStep={3}/>
+          </DCArtboard>
+          <DCArtboard id="m-wiz-4" label="Wizard · Schritt 4 · Briefings" width={PHONE_W} height={840}>
+            <ScreenTripWizardMobile initialStep={4}/>
+          </DCArtboard>
+        </DCSection>
+
+        <DCSection id="editors" title="04 · Editoren · Trip-Konfiguration" subtitle="Wegpunkte (Master/Detail mit Bottom-Sheet), Metriken (Accordion), Alerts (Modus-Cards).">
+          <DCArtboard id="m-wp-editor" label="Wegpunkt-Editor · Karte + Sheet" width={PHONE_W} height={840}>
+            <ScreenWaypointEditorMobile/>
+          </DCArtboard>
+          <DCArtboard id="m-metrics" label="Wetter-Metriken-Editor" width={PHONE_W} height={840}>
+            <ScreenMetricsEditorMobile/>
+          </DCArtboard>
+          <DCArtboard id="m-alerts" label="Alert-Konfigurator" width={PHONE_W} height={840}>
+            <ScreenAlertConfigMobile/>
+          </DCArtboard>
+        </DCSection>
+
+        <DCSection id="compare" title="05 · Ortsvergleich" subtitle="Compare mit H-Scroll-Matrix und sticky 1. Spalte. Locations-Auswahl in Bottom-Sheet.">
+          <DCArtboard id="m-compare" label="Compare · Matrix + Top-3" width={PHONE_W} height={840}>
+            <ScreenCompareMobile/>
+          </DCArtboard>
+          <DCArtboard id="m-location-new" label="POI anlegen · Smart-Import (Modal-Flow)" width={PHONE_W} height={840}>
+            <ScreenLocationNewMobile/>
+          </DCArtboard>
+        </DCSection>
+
+        <DCSection id="output" title="06 · Output-Vorschau" subtitle="Email · SMS · Signal in einem Screen. Segmented Control zum Wechseln.">
+          <DCArtboard id="m-output" label="Briefing-Vorschau · Multi-Kanal" width={PHONE_W} height={840}>
+            <ScreenOutputPreviewMobile/>
+          </DCArtboard>
+        </DCSection>
+
+        <DCSection id="patterns" title="07 · Übergreifende Patterns" subtitle="Modal · Bottom-Sheet · Toasts · States · Wizard-Abbruch · Push-Permission. Verbindlich für alle Mobile-Flows.">
+          <DCArtboard id="m-modal" label="Modal · Bestätigungs-Dialog" width={PHONE_W} height={840}>
+            <PatternModal/>
+          </DCArtboard>
+          <DCArtboard id="m-sheet" label="Bottom-Sheet · Half-Snap mit Aktionen" width={PHONE_W} height={840}>
+            <PatternBottomSheet/>
+          </DCArtboard>
+          <DCArtboard id="m-wiz-cancel" label="Wizard-Abbruch · Entwurf / Verwerfen / Weiter" width={PHONE_W} height={840}>
+            <PatternWizardCancel/>
+          </DCArtboard>
+          <DCArtboard id="m-push" label="Push-Permission · Pre-Prompt (Soft-Ask)" width={PHONE_W} height={840}>
+            <PatternPushPermission/>
+          </DCArtboard>
+          <DCArtboard id="m-toasts" label="Toasts · Info / Success / Warn / Error" width={PHONE_W} height={840}>
+            <PatternToasts/>
+          </DCArtboard>
+          <DCArtboard id="m-states" label="States · Loading / Empty / Error / Permission" width={PHONE_W} height={1130}>
+            <PatternStates/>
+          </DCArtboard>
+        </DCSection>
+      </DesignCanvas>
+    );
+  }
+
+  function ReadmeCard() {
+    return (
+      <div style={{ padding: 32, background: "var(--g-card)", height: "100%", overflow: "auto", border: "1px solid var(--g-rule)", borderRadius: 6 }}>
+        <div className="mono" style={{ fontSize: 10, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--g-ink-3)", marginBottom: 8 }}>Mobile-Erweiterung · v1</div>
+        <h1 style={{ fontSize: 28, fontWeight: 600, letterSpacing: "-0.02em", margin: "0 0 16px" }}>
+          Pattern-Entscheidungen
+        </h1>
+        <div style={{ fontSize: 14, lineHeight: 1.6, color: "var(--g-ink-2)", marginBottom: 24 }}>
+          Best-Practice-Defaults, abgeleitet aus iOS HIG / Material Guidelines und der bestehenden Desktop-Sprache.
+          Alle Tokens aus <code style={{ fontFamily: "var(--g-font-mono)", background: "var(--g-card-alt)", padding: "1px 5px", border: "1px solid var(--g-rule)" }}>tokens.css</code> unverändert.
+        </div>
+
+        <ReadmeRow tag="A · Navigation" verdict="Hybrid"
+          text="Bottom-Nav für Übersicht / Trips / Vergleich / Archiv (≥ 44 px Touch). Drawer (Hamburger oben links) für Kanäle, Einstellungen, Account. Hybrid ist iOS-HIG / Material Standard bei 3–5 Top-Destinationen + sekundärer Konfig-Navigation."/>
+
+        <ReadmeRow tag="B · Listen & Tabellen" verdict="Card-Stack + H-Scroll"
+          text="Trip-Liste, Etappen, Wegpunkte, Metriken → Card-Stack mit Chevron / mehr-Menü. Dichte Vergleichs- und Stunden-Matrizen → H-Scroll mit fixierter 1. Spalte (Standard für Data-Tables auf Mobile)."/>
+
+        <ReadmeRow tag="C · Wizard" verdict="Jeder Schritt eigener Screen"
+          text="4 Schritte = 4 Screens, sticky Indikator oben + sticky Action-Bar unten. Bottom-Nav während Wizard ausgeblendet. Verhindert Tiefen-Verschachtelung; Mobile-User wollen klare Linearität."/>
+
+        <ReadmeRow tag="D · Wegpunkt-Editor" verdict="Karte + Bottom-Sheet"
+          text="Karte vollflächig, Höhenprofil + Wegpunktliste im 3-stufigen Sheet (peek 92 / half 320 / full 540). Standardpattern aus Maps-Apps (Google Maps, Apple Maps, Komoot)."/>
+
+        <ReadmeRow tag="E · Compare" verdict="H-Scroll-Matrix"
+          text="Locations-Auswahl in Bottom-Sheet. Empfehlungs-Banner als Hero. Matrix H-Scroll mit sticky Metrik-Spalte. Stunden-Verlauf Top-3 ebenfalls als Tabelle mit sticky Zeit-Spalte."/>
+
+        <ReadmeRow tag="F · Modal vs. Sheet" verdict="Klare Trennung"
+          text="Modal-Flow (Vollbild) für lineare Flows wie Wizard, POI-Import, Bestätigung-Dialoge. Bottom-Sheet für kontextbezogene Auswahl / Aktionen / Quick-Edit (Drag-Handle, dismiss durch Backdrop-Tap)."/>
+
+        <ReadmeRow tag="G · Progressive Disclosure" verdict="Accordions + Tabs"
+          text="Trip-Detail in 6 Tabs (Pill-Scroller). Metriken (26 Spalten) in 5 Kategorien-Accordions. Etappen-Card zeigt nur Eckdaten; Summary erst nach Tap."/>
+
+        <ReadmeRow tag="H · Breakpoints" verdict="≤ 599 / 600–899 / ≥ 900"
+          text="Mobile primär 375 px, sekundär 414 / 768. Layout bei 768 px gleich Mobile (kein Splitscreen), aber Cards optional zweispaltig wo sinnvoll. ≥ 900 → bestehendes Desktop."/>
+
+        <ReadmeRow tag="I · Touch & Type" verdict="44 / 48 / 56 px, 16 px Inputs"
+          text="Buttons mindestens 44 × 44 (size=md), Primär-CTAs 48 (size=lg), Focus-CTAs 56 (size=xl). Alle Inputs fontSize 16 px (kein iOS-Zoom). Safe-Areas via env(safe-area-inset-*)."/>
+      </div>
+    );
+  }
+
+  function ReadmeRow({ tag, verdict, text }) {
+    return (
+      <div style={{ display: "grid", gridTemplateColumns: "160px 1fr", gap: 16, padding: "14px 0", borderTop: "1px solid var(--g-rule-soft)" }}>
+        <div>
+          <div className="mono" style={{ fontSize: 11, color: "var(--g-accent)", textTransform: "uppercase", letterSpacing: "0.08em", fontWeight: 600 }}>{tag}</div>
+          <div style={{ fontSize: 13, fontWeight: 600, marginTop: 4, color: "var(--g-ink)" }}>{verdict}</div>
+        </div>
+        <div style={{ fontSize: 13, color: "var(--g-ink-2)", lineHeight: 1.6 }}>{text}</div>
+      </div>
+    );
+  }
+
+  ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+</script>
+</body>
+</html>

--- a/docs/design/mobile/HERKUNFT.md
+++ b/docs/design/mobile/HERKUNFT.md
@@ -1,0 +1,32 @@
+# Herkunft dieser Mobile-Design-Vorlage
+
+Diese Dateien stammen aus **PR #275 („Mobile-Audit 2026-05-20")**, der nie gemergt wurde und
+am 2026-08-07 geschlossen worden ist. Die Vorlage selbst war davon unabhängig gültig — sie
+wurde hier nachträglich gerettet, weil sie sonst nur im Diff eines geschlossenen PR gelegen
+hätte.
+
+Die zugehörige README beschreibt eine Ordnerstruktur (`project/…`), die es so nie gab. Sie ist
+als Beschreibung der Vorlage zu lesen, nicht als Wegweiser durch dieses Verzeichnis.
+
+## Was hier NICHT liegt — und warum
+
+| Nicht übernommen | Grund |
+|---|---|
+| `mobile-shell.jsx` | inhaltlich **identisch** bereits unter `docs/design-requests/issue_15_atomic_design/spec/mobile-shell.jsx` |
+| `screen-metrics-editor-mobile.jsx` | identisch bereits unter `docs/design/epic_331_output_layout/` |
+| `screen-output-preview-mobile.jsx` | identisch bereits unter `docs/design/epic_331_output_layout/` |
+| `screen-waypoint-editor-mobile.jsx` | das Repo führt unter `docs/design-requests/` eine **neuere, umfangreichere** Fassung (21,7 kB gegen 15,5 kB) — die ältere hier abzulegen hätte eine irreführende Dublette erzeugt |
+| `docs/reference/design_system.md` | 🔴 die PR-Fassung ist vom Mai; an der Datei hängen seither **fünf Commits** (u.a. Farbkorrektur #277, Token-Aufräumen #541/#543/#544, Doku-Konsolidierung #1341). Ein Übernehmen hätte diese Arbeit zurückgedreht |
+| 97 Screenshots, `audit/`-Werkzeug | Momentaufnahme vom Mai, **vor** den daraus abgeleiteten Korrekturen; alle acht Befund-Issues (#267–#274) sind erledigt. Bleiben im Diff des geschlossenen PR #275 dauerhaft einsehbar |
+
+## Wofür die Vorlage taugt
+
+Sie ist das **Soll-Bild** für die mobile Ansicht (Primärziel 375 px, sekundär 414/768) und
+ausdrücklich eine Erweiterung des Desktop-Designs — keine neuen Muster, keine neuen Tokens.
+Die `.jsx`-Dateien sind Entwurfsartefakte aus dem Design-Werkzeug, **kein lauffähiger Code**
+(das Frontend ist Svelte). Sie dienen dem Abgleich „sieht die gebaute Ansicht so aus wie
+vorgesehen", nicht der Übernahme.
+
+Verbindlich für Kontrast- und Lesbarkeitsfragen bleibt `docs/reference/design_system.md` in
+seiner **aktuellen** Fassung, nicht die `tokens-reference.css` hier — letztere ist der Stand
+vom Mai.

--- a/docs/design/mobile/README.md
+++ b/docs/design/mobile/README.md
@@ -1,0 +1,108 @@
+# Gregor Zwanzig · Mobile-Erweiterung v1
+
+Mobile-Varianten (Primärziel 375 px, sekundär 414 / 768) für alle Hauptscreens des
+Gregor-Zwanzig-Webapps. **Reine Erweiterung** des bestehenden Desktop-Designs —
+keine neuen Patterns, keine neuen Tokens.
+
+## Was hier drin ist
+
+```
+gregor-zwanzig-mobile/
+├── README.md                       ← du bist hier
+└── project/
+    ├── tokens.css                  ← unverändert aus Desktop
+    ├── mobile-shell.jsx            ← Primitives (TopBar, BottomNav, Drawer, Sheet, Toast, Inputs)
+    ├── mobile-patterns.md          ← Mapping Mobile↔Desktop, Breakpoints, Entscheidungen
+    │
+    ├── screen-login-mobile.jsx           NEU (Desktop hatte noch keinen Login-Screen)
+    ├── screen-design-system-mobile.jsx   Mobile-Token-Übersicht
+    │
+    ├── screen-home-mobile.jsx            ↔ screen-home
+    ├── screen-trips-mobile.jsx           ↔ screen-trips
+    ├── screen-trip-detail-mobile.jsx     ↔ screen-trip-detail
+    ├── screen-trip-wizard-mobile.jsx     ↔ screen-trip-wizard (alle 4 Schritte)
+    ├── screen-waypoint-editor-mobile.jsx ↔ screen-waypoint-editor
+    ├── screen-metrics-editor-mobile.jsx  ↔ screen-metrics-editor
+    ├── screen-alert-config-mobile.jsx    ↔ screen-alert-config
+    ├── screen-compare-mobile.jsx         ↔ screen-compare
+    ├── screen-location-new-mobile.jsx    ↔ screen-location-new
+    ├── screen-output-preview-mobile.jsx  ↔ screen-output-preview (Email · SMS · Signal)
+    │
+    └── screen-patterns-mobile.jsx        App-Shell · Modal · Sheet · Toasts · States
+```
+
+Designs zu sehen im Repo-Root unter **`Gregor 20 - Mobile v1.html`** (alle Screens auf einem Design-Canvas).
+
+## Regeln, die eingehalten wurden
+
+1. **tokens.css ist die einzige Quelle** für Farben, Typo, Spacing, Radien.
+   Keine Datei verändert tokens.css, keine Datei definiert eigene Hex-Werte.
+2. **Komponenten-Namen identisch** zu bestehenden Atoms (`Card`, `Pill`, `Eyebrow`,
+   `Btn`, `ElevSparkline`, `WIcon`, `Dot`). Mobile-Spezifika sind als `M*`-Suffix
+   hinzugekommen (`MBtn`, `MInput`, `MField`, `MSwitch`, `MTab`, `MIcon`),
+   damit Desktop-Atoms vom Mobile-Set klar trennbar bleiben.
+3. **Touch-Targets ≥ 44 × 44 px** — `MBtn` Default `size="lg"` (48 px), `size="xl"`
+   für 56-px-Fokus-CTAs. Switches 44 px Hit-Area. Bottom-Nav-Items 64 px hoch.
+4. **Body-Schrift in Inputs ≥ 16 px** — fest in `MInput` verdrahtet
+   (verhindert iOS-Auto-Zoom beim Focus).
+5. **Safe-Areas** — `env(safe-area-inset-bottom)` in jeder Sticky-Bottom-Bar,
+   `safeTop` 44 px in der Status-Bar-Region.
+6. **Spacing-Skala konsistent** — Mobile verwendet `--g-s-3` (12 px) für Gaps,
+   `--g-s-4` (16 px) für Außenrand statt 40 px Desktop, Card-Innenrand 16 px statt
+   20/24 px. Skala selbst unverändert.
+7. **Keine neue visuelle Sprache** — gleiche Farb-Logik (Accent burnt-orange, semantische
+   Farben für Risk/Status), gleiche Schriften (Inter Tight + JetBrains Mono),
+   gleiche Card-Anatomie (3-px-Accent-Left-Border für aktive Items),
+   gleiche Eyebrow/Mono-Behandlung.
+
+## Wie das in die SvelteKit-App übersetzt wird
+
+Die JSX-Dateien sind **Spec-Layer**, nicht Produktion. Workflow für Übersetzung:
+
+1. **Pattern-Komponenten** aus `mobile-shell.jsx` als Svelte-Komponenten anlegen:
+   `TopAppBar.svelte`, `BottomNav.svelte`, `Drawer.svelte`, `BottomSheet.svelte`,
+   `Toast.svelte`, `MInput.svelte`, `MBtn.svelte`, `MField.svelte`, `MSwitch.svelte`,
+   `MTab.svelte`. Tokens via CSS-Variablen aus `app.css`.
+2. **Breakpoint-Logik** in `app.css`:
+   ```css
+   /* Mobile-first */
+   .gz-screen-padding { padding: var(--g-s-4); }       /* 16px */
+   @media (min-width: 900px) {                          /* Desktop */
+     .gz-screen-padding { padding: var(--g-s-10); }    /* 40px */
+   }
+   ```
+3. **Routes** spiegeln die Mobile-Screens 1:1 — gleiche URLs, andere Layouts.
+   Mobile-Layout aktiv bei `viewport ≤ 899 px`, Desktop sonst. Wizard und
+   Location-New laufen auf Mobile als **Vollbild-Route** ohne BottomNav.
+4. **Sheet vs. Modal Convention** — siehe `mobile-patterns.md` §F. Verwende
+   `BottomSheet` für kontextuelle Aktionen / Multi-Select / Quick-Edit,
+   `Modal` (Vollbild-Route) für lineare Flows und destruktive Bestätigung.
+
+## Touch-Test
+
+Vor dem Merge bitte auf echtem Gerät prüfen:
+
+- iPhone SE (375 × 667) — engster Primärfall
+- iPhone 14 / 15 (390 × 844) — Standard
+- iPhone 14 Plus (430 × 932) — sekundär 414+
+- iPad mini (768 × 1024) — Tablet-Breakpoint
+- Android Pixel 7 (412 × 915) — Material-Verhalten der Sheets
+
+Insbesondere checken:
+- Hat die Bottom-Nav auf Geräten mit Home-Indikator den richtigen Safe-Area-Abstand?
+- Lässt sich die Compare-Matrix horizontal scrollen ohne den vertikalen Scroll zu hijacken? `overscroll-behavior: contain` setzen.
+- Sheet-Snap-Drag funktioniert auf Touch, Backdrop-Tap schließt sicher.
+- Bei Focus auf Input nicht zoomen (iOS) — Test mit `font-size: 16px`.
+
+## Offene Punkte zur Klärung mit Design
+
+*(Stand v1: alle ursprünglichen Open-Items adressiert.)*
+
+- **Etappen-Switcher im Wegpunkt-Editor** → ersetzt durch Dropdown-Trigger + Sheet (`StageSelectSheet`); skaliert auch bei 13+ Etappen, zeigt Risiko + Distanz + WP-Count pro Etappe.
+- **Wizard-Abbruch** → Sheet-Pattern `PatternWizardCancel` mit 3 Optionen *Entwurf speichern / Weiter editieren / Verwerfen*. Verbindlich für alle mehrstufigen Flows wenn User schon Daten eingegeben hat. Siehe `mobile-patterns.md` §F.
+- **Push-Permission** → eigener Pre-Prompt-Screen `PatternPushPermission`. Erscheint einmalig nach erster Alert-Konfig. Tappt User „Aktivieren" → erst dann triggern wir den nativen Permission-Dialog. Schutz davor, die Single-Shot-Permission auf iOS/Android zu verbrennen.
+- Push-Settings müssen in Settings auch nachträglich änderbar sein, mit Deep-Link in die OS-Settings, falls der User initial „Nein" gewählt hat.
+
+## Kontakt
+
+Pattern-Entscheidungen + Begründungen siehe `mobile-patterns.md` im selben Ordner.

--- a/docs/design/mobile/screen-alert-config-mobile.jsx
+++ b/docs/design/mobile/screen-alert-config-mobile.jsx
@@ -1,0 +1,218 @@
+/* Mobile · Alert-Konfigurator
+ * Pattern: Modus-Auswahl als Card-Stack (3 Karten), Metriken-Liste mit Slidern (eingebaut).
+ * Sticky Save-Bar unten.
+ */
+
+const ALERT_METRICS_M = [
+  { id: "wind",      label: "Wind",            unit: "km/h", abs: 50,   delta: 20,  cmp: "über",  on: true },
+  { id: "gust",      label: "Böen",            unit: "km/h", abs: 70,   delta: 25,  cmp: "über",  on: true },
+  { id: "thunder",   label: "Gewitter-Wahrsch.", unit: "%",  abs: 40,   delta: 20,  cmp: "über",  on: true },
+  { id: "precip",    label: "Niederschlag",    unit: "mm",   abs: 5,    delta: 10,  cmp: "über",  on: true },
+  { id: "rainProb",  label: "Regen-Wahrsch.",  unit: "%",    abs: 70,   delta: 30,  cmp: "über",  on: false },
+  { id: "temp",      label: "Temperatur",      unit: "°C",   abs: -5,   delta: 5,   cmp: "unter", on: false },
+  { id: "visibility",label: "Sichtweite",      unit: "km",   abs: 1,    delta: 5,   cmp: "unter", on: true },
+  { id: "freezeLine",label: "Nullgrad-Grenze", unit: "m",    abs: 2000, delta: 200, cmp: "unter", on: true },
+  { id: "snowfall",  label: "Schneefall",      unit: "cm",   abs: 10,   delta: 5,   cmp: "über",  on: false },
+];
+
+function ScreenAlertConfigMobile() {
+  const [mode, setMode] = React.useState("both");
+  const onCount = ALERT_METRICS_M.filter(m => m.on).length;
+
+  return (
+    <PhoneFrame height={812}>
+      <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", background: "var(--g-paper)" }}>
+        <TopAppBar
+          title="Alerts"
+          eyebrow="KHW 403 · Sofort-Benachrichtigung"
+          leftIcon="back"
+          right={<button style={{ padding: "0 12px", minHeight: 44, background: "transparent", border: "none", fontSize: 14, color: "var(--g-ink-3)" }}>Verwerfen</button>}
+        />
+
+        <ScreenScroll padding={16}>
+          {/* Intro */}
+          <div style={{ marginBottom: 18 }}>
+            <h2 style={{ fontSize: 20, fontWeight: 600, letterSpacing: "-0.01em", margin: 0, lineHeight: 1.25 }}>
+              Wann soll ein Alert ausgelöst werden?
+            </h2>
+            <div style={{ fontSize: 13, color: "var(--g-ink-3)", marginTop: 6, lineHeight: 1.5 }}>
+              Alerts kommen zwischen Morgen- und Abend-Briefing. Wähle den Modus.
+            </div>
+          </div>
+
+          {/* Modus-Auswahl */}
+          <Eyebrow style={{ marginBottom: 8 }}>Auslöse-Modus</Eyebrow>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 24 }}>
+            <ModeCardM
+              id="delta" active={mode === "delta"} onClick={() => setMode("delta")}
+              title="Δ-Änderung" eyebrow="Reaktiv"
+              desc="Wert ändert sich seit letztem Report stark."
+              example="z.B. Wind +20 km/h, Gewitter +30 %"
+            />
+            <ModeCardM
+              id="absolute" active={mode === "absolute"} onClick={() => setMode("absolute")}
+              title="Schwellwert" eyebrow="Absolut"
+              desc="Wert über- oder unterschreitet eine Grenze."
+              example="z.B. Wind > 50 km/h, Sicht < 1 km"
+            />
+            <ModeCardM
+              id="both" active={mode === "both"} onClick={() => setMode("both")}
+              title="Beides" eyebrow="Empfohlen"
+              desc="Δ und absolut kombiniert. Maximale Abdeckung."
+              example="Standard für aktive Trips"
+            />
+          </div>
+
+          {/* Metriken-Liste */}
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 8 }}>
+            <Eyebrow>Metriken & Schwellen</Eyebrow>
+            <span className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)" }}>
+              {onCount} von {ALERT_METRICS_M.length} aktiv
+            </span>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 16 }}>
+            {ALERT_METRICS_M.map(m => (
+              <AlertMetricCardM key={m.id} m={m} mode={mode}/>
+            ))}
+          </div>
+
+          {/* Channel-Routing */}
+          <Card padding={14} style={{ marginBottom: 16 }}>
+            <Eyebrow style={{ marginBottom: 8 }}>Alert-Kanal</Eyebrow>
+            <div style={{ fontSize: 13, color: "var(--g-ink-3)", marginBottom: 10, lineHeight: 1.5 }}>
+              Alerts gehen NUR auf diesen Kanal — separat von Briefings.
+            </div>
+            <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+              {["Signal","SMS","Telegram","Email"].map((k, i) => (
+                <button key={k} style={{
+                  padding: "8px 14px", minHeight: 40, borderRadius: "var(--g-r-pill)",
+                  background: i === 0 ? "var(--g-accent)" : "var(--g-card-alt)",
+                  color: i === 0 ? "#fff" : "var(--g-ink-2)",
+                  border: `1px solid ${i === 0 ? "var(--g-accent)" : "var(--g-rule)"}`,
+                  fontSize: 13, fontFamily: "var(--g-font-mono)", fontWeight: 500, cursor: "pointer",
+                }}>{k}</button>
+              ))}
+            </div>
+          </Card>
+
+          {/* Quiet hours */}
+          <Card padding={14}>
+            <Eyebrow style={{ marginBottom: 8 }}>Ruhezeit</Eyebrow>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <div>
+                <div style={{ fontSize: 14, fontWeight: 600 }}>22:00 – 06:00</div>
+                <div style={{ fontSize: 12, color: "var(--g-ink-3)", marginTop: 2 }}>Nur Gewitter-Alerts werden zugestellt</div>
+              </div>
+              <MSwitch checked/>
+            </div>
+          </Card>
+        </ScreenScroll>
+
+        {/* Sticky Save */}
+        <div style={{
+          padding: "10px 16px",
+          paddingBottom: "calc(10px + env(safe-area-inset-bottom))",
+          background: "var(--g-paper)", borderTop: "1px solid var(--g-rule)",
+          display: "flex", gap: 8, flexShrink: 0,
+        }}>
+          <MBtn variant="ghost" size="lg" style={{ flex: 1 }}>Test-Alert</MBtn>
+          <MBtn variant="primary" size="lg" style={{ flex: 1.6 }}>Speichern</MBtn>
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+function ModeCardM({ id, active, onClick, title, eyebrow, desc, example }) {
+  return (
+    <button onClick={onClick} style={{
+      padding: "14px 14px", textAlign: "left", cursor: "pointer", minHeight: 84,
+      background: active ? "var(--g-accent-tint)" : "var(--g-card)",
+      border: active ? "1px solid var(--g-accent)" : "1px solid var(--g-rule)",
+      borderRadius: "var(--g-r-3)",
+      display: "flex", gap: 12, alignItems: "flex-start",
+    }}>
+      <div style={{
+        width: 22, height: 22, borderRadius: "50%", flexShrink: 0,
+        border: `2px solid ${active ? "var(--g-accent)" : "var(--g-rule)"}`,
+        background: active ? "var(--g-accent)" : "transparent",
+        display: "flex", alignItems: "center", justifyContent: "center",
+        marginTop: 2,
+      }}>
+        {active && <span style={{ width: 8, height: 8, borderRadius: "50%", background: "#fff" }}/>}
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 8, marginBottom: 2 }}>
+          <span style={{ fontSize: 15, fontWeight: 600, color: active ? "var(--g-accent-deep)" : "var(--g-ink)" }}>{title}</span>
+          <span className="mono" style={{ fontSize: 10, color: "var(--g-ink-4)", textTransform: "uppercase", letterSpacing: "0.1em" }}>· {eyebrow}</span>
+        </div>
+        <div style={{ fontSize: 13, color: "var(--g-ink-2)", lineHeight: 1.4 }}>{desc}</div>
+        <div className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)", marginTop: 4 }}>{example}</div>
+      </div>
+    </button>
+  );
+}
+
+function AlertMetricCardM({ m, mode }) {
+  return (
+    <div style={{
+      padding: "12px 14px", background: m.on ? "var(--g-card)" : "var(--g-card-alt)",
+      border: "1px solid var(--g-rule)", borderRadius: "var(--g-r-3)",
+      opacity: m.on ? 1 : 0.7,
+    }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: m.on ? 10 : 0 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 14, fontWeight: 600 }}>{m.label}</div>
+          <div className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)", marginTop: 2 }}>
+            {mode === "delta" ? `Δ ≥ ${m.delta} ${m.unit}` :
+             mode === "absolute" ? `${m.cmp} ${m.abs}${m.unit}` :
+             `${m.cmp} ${m.abs}${m.unit} · Δ ≥ ${m.delta}`}
+          </div>
+        </div>
+        <MSwitch checked={m.on}/>
+      </div>
+      {m.on && (
+        <div style={{ borderTop: "1px solid var(--g-rule-soft)", paddingTop: 10, display: "flex", flexDirection: "column", gap: 8 }}>
+          {(mode === "absolute" || mode === "both") && (
+            <ThresholdRowM label={m.cmp === "über" ? "Über" : "Unter"} value={`${m.abs}`} unit={m.unit}/>
+          )}
+          {(mode === "delta" || mode === "both") && (
+            <ThresholdRowM label="Δ ≥" value={`${m.delta}`} unit={m.unit} delta/>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ThresholdRowM({ label, value, unit, delta }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+      <span className="mono" style={{
+        fontSize: 11, color: delta ? "var(--g-accent)" : "var(--g-ink-3)",
+        textTransform: "uppercase", letterSpacing: "0.06em", width: 60, fontWeight: 600,
+      }}>{label}</span>
+      <button style={{
+        width: 32, height: 32, borderRadius: "var(--g-r-2)",
+        background: "var(--g-card-alt)", border: "1px solid var(--g-rule)", cursor: "pointer",
+        fontSize: 16, color: "var(--g-ink-2)", lineHeight: 1,
+      }}>−</button>
+      <div style={{
+        flex: 1, minHeight: 36, padding: "8px 10px", textAlign: "center",
+        background: "var(--g-paper)", border: "1px solid var(--g-rule)",
+        borderRadius: "var(--g-r-2)", fontFamily: "var(--g-font-mono)", fontWeight: 600, fontSize: 14,
+        display: "flex", alignItems: "center", justifyContent: "center", gap: 4,
+      }}>
+        <span>{value}</span>
+        <span style={{ color: "var(--g-ink-4)", fontSize: 12 }}>{unit}</span>
+      </div>
+      <button style={{
+        width: 32, height: 32, borderRadius: "var(--g-r-2)",
+        background: "var(--g-card-alt)", border: "1px solid var(--g-rule)", cursor: "pointer",
+        fontSize: 16, color: "var(--g-ink-2)", lineHeight: 1,
+      }}>+</button>
+    </div>
+  );
+}
+
+window.ScreenAlertConfigMobile = ScreenAlertConfigMobile;

--- a/docs/design/mobile/screen-compare-mobile.jsx
+++ b/docs/design/mobile/screen-compare-mobile.jsx
@@ -1,0 +1,426 @@
+/* Mobile · Ortsvergleich (Compare)
+ * Pattern: Preset-Header → Empfehlung Hero → Matrix als H-Scroll mit sticky 1. Spalte
+ *          → Stunden-Verlauf Top-3 (H-Scroll) → Auto-Briefings.
+ * Locations-Auswahl in Bottom-Sheet.
+ */
+
+function ScreenCompareMobile() {
+  const locs = MOCK_LOCATIONS;
+  const rows = MOCK_COMPARE_ROWS;
+  const top3 = rows.slice(0, 3);
+  const winner = locs.find(l => l.id === rows[0].id);
+
+  const [locSheet, setLocSheet] = React.useState(false);
+  const [presetSheet, setPresetSheet] = React.useState(false);
+
+  const right = <IconBtn kind="plus" label="Als Auto-Briefing"/>;
+
+  return (
+    <MobileShell active="compare" title="Ortsvergleich" eyebrow="Ad-hoc · Sa 09. Mai" right={right} phoneHeight={812}
+                 sheet={
+                   (locSheet && <LocSheetM locs={locs} onClose={() => setLocSheet(false)}/>) ||
+                   (presetSheet && <PresetSheetM onClose={() => setPresetSheet(false)}/>)
+                 }>
+      <ScreenScroll padding={0}>
+        <div style={{ padding: "12px 16px 6px" }}>
+          <div style={{ fontSize: 18, fontWeight: 600, lineHeight: 1.3, letterSpacing: "-0.01em", marginBottom: 12 }}>
+            Wo finde ich am Wochenende den besten Schnee?
+          </div>
+
+          {/* Preset-Header als 2x2-Grid */}
+          <div style={{
+            display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6,
+            background: "var(--g-card)", border: "1px solid var(--g-rule)",
+            borderRadius: "var(--g-r-3)", padding: 10, marginBottom: 12,
+          }}>
+            <PresetCell label="Datum"        value="Sa, 09.05.26"/>
+            <PresetCell label="Forecast"     value="48h"/>
+            <PresetCell label="Zeitfenster"  value="09:00 – 16:00"/>
+            <PresetCell label="Profil"       value="Wintersport · Piste"/>
+          </div>
+
+          {/* Locations-Chip-Row */}
+          <button onClick={() => setLocSheet(true)} style={{
+            display: "flex", alignItems: "center", gap: 10, width: "100%", minHeight: 48,
+            padding: "10px 14px", background: "var(--g-card-alt)",
+            border: "1px solid var(--g-rule)", borderRadius: "var(--g-r-3)",
+            cursor: "pointer", marginBottom: 12,
+          }}>
+            <MIcon kind="map" size={18} color="var(--g-ink-2)"/>
+            <div style={{ flex: 1, textAlign: "left", minWidth: 0 }}>
+              <div className="mono" style={{ fontSize: 9, color: "var(--g-ink-4)", letterSpacing: "0.1em", textTransform: "uppercase" }}>Verglichene Orte</div>
+              <div style={{ fontSize: 13, fontWeight: 500, color: "var(--g-ink)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                5 von {locs.length}: Hintertux, Zillertal Arena, Hochkönig, …
+              </div>
+            </div>
+            <MIcon kind="chevron" size={16} color="var(--g-ink-3)"/>
+          </button>
+
+          {/* Empfehlungs-Banner */}
+          <RecommendationCardM winner={winner} row={rows[0]}/>
+        </div>
+
+        {/* Vergleichs-Matrix */}
+        <div style={{ padding: "12px 16px 0" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 8 }}>
+            <Eyebrow>Matrix · sortiert nach Score</Eyebrow>
+            <span className="mono" style={{ fontSize: 10, color: "var(--g-ink-4)" }}>→ scrollen</span>
+          </div>
+        </div>
+        <CompareMatrixM rows={rows} locs={locs}/>
+
+        {/* Stunden-Verlauf Top-3 */}
+        <div style={{ padding: "16px 16px 0" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 8 }}>
+            <Eyebrow>Stunden · Top-3</Eyebrow>
+            <span className="mono" style={{ fontSize: 10, color: "var(--g-ink-4)" }}>09:00 – 16:00</span>
+          </div>
+        </div>
+        <HourlyMatrixM top={top3} locs={locs}/>
+
+        {/* Auto-Briefings */}
+        <div style={{ padding: "20px 16px 24px" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 8 }}>
+            <Eyebrow>Auto-Briefings · {MOCK_COMPARE_PRESETS.length}</Eyebrow>
+            <button onClick={() => setPresetSheet(true)} style={{ fontSize: 12, color: "var(--g-accent)", background: "transparent", border: "none", fontWeight: 600, cursor: "pointer" }}>
+              + Aktuellen speichern
+            </button>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {MOCK_COMPARE_PRESETS.map(p => <SubRowM key={p.id} sub={p}/>)}
+          </div>
+        </div>
+      </ScreenScroll>
+    </MobileShell>
+  );
+}
+
+function PresetCell({ label, value }) {
+  return (
+    <div>
+      <div className="mono" style={{ fontSize: 9, color: "var(--g-ink-4)", letterSpacing: "0.1em", textTransform: "uppercase", marginBottom: 2 }}>{label}</div>
+      <div style={{ fontSize: 13, fontWeight: 600, fontFamily: "var(--g-font-mono)", color: "var(--g-ink)", lineHeight: 1.3 }}>{value}</div>
+    </div>
+  );
+}
+
+function RecommendationCardM({ winner, row }) {
+  return (
+    <div style={{
+      background: "linear-gradient(135deg, rgba(61,107,58,0.10), rgba(61,107,58,0.02))",
+      border: "1px solid rgba(61,107,58,0.25)",
+      borderLeft: "3px solid var(--g-good)",
+      borderRadius: "var(--g-r-3)", padding: 14,
+      display: "flex", gap: 12,
+    }}>
+      <div style={{
+        width: 44, height: 44, borderRadius: "50%", flexShrink: 0,
+        background: "var(--g-good)", color: "#fff",
+        display: "flex", alignItems: "center", justifyContent: "center",
+        fontSize: 16, fontWeight: 700, fontFamily: "var(--g-font-mono)",
+      }}>#1</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <Eyebrow style={{ color: "var(--g-good)", marginBottom: 2 }}>Empfehlung</Eyebrow>
+        <div style={{ fontSize: 16, fontWeight: 600, letterSpacing: "-0.005em", lineHeight: 1.25 }}>{winner.name}</div>
+        <div className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)", marginTop: 4, lineHeight: 1.5 }}>
+          Score <strong style={{ color: "var(--g-good)" }}>{row.score}</strong> · {row.snow} cm · ~{row.sun}h Sonne<br/>
+          Wind {row.wind}/{row.gust} {row.dir} · gef. {row.feels >= 0 ? "+" : ""}{row.feels}°C
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────── Matrix · H-Scroll mit sticky 1. Spalte ─────────────────── */
+function CompareMatrixM({ rows, locs }) {
+  const cols = [
+    { key: "score",     label: "Score",     unit: "",   highlight: "max" },
+    { key: "snow",      label: "Schneeh.",  unit: "cm", highlight: "max" },
+    { key: "newSnow",   label: "Neuschnee", unit: "cm", highlight: "max", prefix: "+" },
+    { key: "wg",        label: "Wind/Böen", custom: r => `${r.wind}/${r.gust}${r.dir}`, highlight: "min" },
+    { key: "feels",     label: "Gef.",      unit: "°", highlight: "max", prefix: r => r >= 0 ? "+" : "" },
+    { key: "sun",       label: "Sonne",     unit: "h", highlight: "max", prefix: "~" },
+    { key: "cloud",     label: "Bewölk.",   unit: "%", highlight: "min" },
+    { key: "cloudTag",  label: "Wolken",    custom: r => r.cloudTag === "über" ? "über" : r.cloudTag === "klar" ? "klar" : "in", highlight: "tag" },
+  ];
+  const bestByKey = {};
+  cols.forEach(c => {
+    if (c.highlight === "tag" || c.custom) return;
+    const vals = rows.map(r => r[c.key]).filter(v => v != null);
+    if (!vals.length) return;
+    bestByKey[c.key] = c.highlight === "max" ? Math.max(...vals) : Math.min(...vals);
+  });
+
+  const colW = 96;
+  const firstW = 120;
+
+  return (
+    <div style={{
+      overflowX: "auto", WebkitOverflowScrolling: "touch",
+      borderTop: "1px solid var(--g-rule-soft)",
+      borderBottom: "1px solid var(--g-rule-soft)",
+      background: "var(--g-card)",
+    }}>
+      <div style={{ display: "inline-flex", minWidth: "100%" }}>
+        {/* Sticky first col */}
+        <div style={{
+          position: "sticky", left: 0, zIndex: 2, flexShrink: 0, width: firstW,
+          background: "var(--g-card-alt)",
+          borderRight: "1px solid var(--g-rule)",
+        }}>
+          <div style={{ ...thMStyle(), borderBottom: "1px solid var(--g-rule-soft)" }}>Metrik</div>
+          {cols.map(c => (
+            <div key={c.key} style={{
+              ...tdMStyle(), borderBottom: "1px solid var(--g-rule-soft)",
+              fontFamily: "var(--g-font-sans)", fontWeight: 500, color: "var(--g-ink-2)",
+              textAlign: "left", padding: "12px 12px",
+            }}>{c.label}</div>
+          ))}
+        </div>
+
+        {/* Scrollable columns */}
+        <div style={{ display: "flex" }}>
+          {rows.map(r => {
+            const l = locs.find(x => x.id === r.id);
+            const isTop = r.rank === 1;
+            return (
+              <div key={r.id} style={{
+                width: colW, flexShrink: 0,
+                background: isTop ? "rgba(61,107,58,0.05)" : "transparent",
+                borderRight: "1px solid var(--g-rule-soft)",
+              }}>
+                {/* Header */}
+                <div style={{
+                  padding: "10px 8px", borderBottom: "1px solid var(--g-rule-soft)",
+                  display: "flex", flexDirection: "column", alignItems: "center", gap: 4,
+                }}>
+                  <span style={{
+                    display: "inline-flex", alignItems: "center", justifyContent: "center",
+                    width: 22, height: 16, background: isTop ? "var(--g-good)" : "var(--g-ink)",
+                    color: "#fff", fontSize: 9, fontWeight: 600, borderRadius: 3,
+                    fontFamily: "var(--g-font-mono)",
+                  }}>#{r.rank}</span>
+                  <span style={{ fontSize: 11, fontWeight: 600, color: "var(--g-ink)", textAlign: "center", lineHeight: 1.2, height: 26, overflow: "hidden" }}>{l.name}</span>
+                </div>
+                {/* Cells */}
+                {cols.map(c => {
+                  const raw = c.custom ? c.custom(r) : r[c.key];
+                  const display = raw == null ? "—" : (typeof raw === "number" ?
+                    `${typeof c.prefix === "function" ? c.prefix(raw) : (c.prefix || "")}${raw}${c.unit || ""}` : raw);
+                  const isBest = !c.custom && c.highlight !== "tag" && raw === bestByKey[c.key];
+                  const isBestTag = c.key === "cloudTag" && r.cloudBest;
+                  const best = isBest || isBestTag;
+                  return (
+                    <div key={c.key} style={{
+                      ...tdMStyle(),
+                      borderBottom: "1px solid var(--g-rule-soft)",
+                      color: best ? "var(--g-good)" : "var(--g-ink)",
+                      fontWeight: best ? 700 : 500,
+                      background: best ? "rgba(61,107,58,0.08)" : "transparent",
+                    }}>{display}</div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const thMStyle = () => ({
+  fontFamily: "var(--g-font-mono)", fontSize: 10, letterSpacing: "0.1em",
+  textTransform: "uppercase", color: "var(--g-ink-4)", fontWeight: 600,
+  padding: "12px 12px", textAlign: "left",
+});
+const tdMStyle = () => ({
+  fontSize: 13, padding: "12px 8px", textAlign: "center",
+  fontFamily: "var(--g-font-mono)", fontVariantNumeric: "tabular-nums",
+});
+
+/* ─────────────────── Stunden-Matrix · Top-3 ─────────────────── */
+function HourlyMatrixM({ top, locs }) {
+  const hours = MOCK_COMPARE_HOURS[top[0].id];
+  const colW = 110;
+  return (
+    <div style={{
+      overflowX: "auto", WebkitOverflowScrolling: "touch",
+      borderTop: "1px solid var(--g-rule-soft)",
+      borderBottom: "1px solid var(--g-rule-soft)",
+      background: "var(--g-card)",
+    }}>
+      <div style={{ display: "inline-flex", minWidth: "100%" }}>
+        {/* Sticky time col */}
+        <div style={{
+          position: "sticky", left: 0, zIndex: 2, flexShrink: 0, width: 60,
+          background: "var(--g-card-alt)", borderRight: "1px solid var(--g-rule)",
+        }}>
+          <div style={{ ...thMStyle(), borderBottom: "1px solid var(--g-rule-soft)", padding: "10px 10px", height: 50, boxSizing: "border-box" }}>Zeit</div>
+          {hours.map((h, i) => (
+            <div key={i} style={{
+              ...tdMStyle(), borderBottom: "1px solid var(--g-rule-soft)",
+              textAlign: "left", padding: "10px 10px", color: "var(--g-ink-3)",
+            }}>{h.h}:00</div>
+          ))}
+        </div>
+        <div style={{ display: "flex" }}>
+          {top.map(r => {
+            const l = locs.find(x => x.id === r.id);
+            const isTop = r.rank === 1;
+            const data = MOCK_COMPARE_HOURS[r.id];
+            return (
+              <div key={r.id} style={{
+                width: colW, flexShrink: 0,
+                background: isTop ? "rgba(61,107,58,0.05)" : "transparent",
+                borderRight: "1px solid var(--g-rule-soft)",
+              }}>
+                <div style={{
+                  padding: "8px 6px", height: 50, boxSizing: "border-box",
+                  borderBottom: "1px solid var(--g-rule-soft)",
+                  display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 2,
+                }}>
+                  <span style={{
+                    display: "inline-flex", alignItems: "center", justifyContent: "center",
+                    width: 22, height: 14, background: isTop ? "var(--g-good)" : "var(--g-ink)",
+                    color: "#fff", fontSize: 9, fontWeight: 600, borderRadius: 3,
+                    fontFamily: "var(--g-font-mono)",
+                  }}>#{r.rank}</span>
+                  <span style={{ fontSize: 10, fontWeight: 600, color: "var(--g-ink)", textAlign: "center", lineHeight: 1.1, overflow: "hidden" }}>{l.name.split(" ")[0]}</span>
+                </div>
+                {data.map((h, i) => <HourCellM key={i} h={h}/>)}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HourCellM({ h }) {
+  const cloudColor = { few: "var(--g-weather-sun)", some: "#c4a05a", many: "var(--g-weather-cloud)", snow: "var(--g-weather-snow)" }[h.cloud] || "var(--g-ink-4)";
+  const cloudGlyph = { few: "☼", some: "☼", many: "☁", snow: "❄" }[h.cloud] || "·";
+  return (
+    <div style={{
+      padding: "10px 6px", borderBottom: "1px solid var(--g-rule-soft)",
+      display: "flex", alignItems: "center", gap: 4,
+      fontFamily: "var(--g-font-mono)", fontSize: 11, fontVariantNumeric: "tabular-nums",
+    }}>
+      <span style={{ color: cloudColor, width: 10, fontWeight: 700 }}>{cloudGlyph}</span>
+      <span style={{ fontWeight: 600, minWidth: 20 }}>{h.t >= 0 ? "+" : ""}{h.t}°</span>
+      <span style={{ color: "var(--g-ink-3)", marginLeft: "auto" }}>{h.w}{h.d}</span>
+    </div>
+  );
+}
+
+/* ─────────────────── Subscription Row ─────────────────── */
+function SubRowM({ sub }) {
+  return (
+    <div style={{
+      display: "flex", alignItems: "center", gap: 12,
+      padding: "12px 14px", background: "var(--g-card)",
+      border: "1px solid var(--g-rule)", borderRadius: "var(--g-r-3)",
+    }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 2 }}>{sub.name}</div>
+        <div className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)" }}>
+          {sub.locations} Orte · {sub.schedule} · {sub.profile}
+        </div>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, flexShrink: 0 }}>
+        <Dot tone={sub.active ? "good" : "neutral"}/>
+        <span className="mono" style={{ fontSize: 10, color: "var(--g-ink-4)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+          {sub.active ? "live" : "off"}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────── Locations-Sheet ─────────────────── */
+function LocSheetM({ locs, onClose }) {
+  const groups = locs.reduce((acc, l) => {
+    (acc[l.group] = acc[l.group] || []).push(l);
+    return acc;
+  }, {});
+  return (
+    <Sheet open onClose={onClose} title="Orte auswählen" eyebrow={`Meine Orte · ${locs.length}`} snap="full"
+           footer={
+             <div style={{ display: "flex", gap: 8 }}>
+               <MBtn variant="ghost" size="lg" block onClick={onClose}>Abbrechen</MBtn>
+               <MBtn variant="primary" size="lg" block onClick={onClose}>5 übernehmen</MBtn>
+             </div>
+           }>
+      <div style={{ position: "sticky", top: 0, background: "var(--g-card)", paddingBottom: 8, marginBottom: 4, zIndex: 1 }}>
+        <MInput leftIcon="search" placeholder="Orte suchen…"/>
+      </div>
+      {Object.entries(groups).map(([group, items]) => (
+        <div key={group} style={{ marginBottom: 12 }}>
+          <div className="mono" style={{
+            padding: "8px 0 6px", fontSize: 10, letterSpacing: "0.14em",
+            color: "var(--g-ink-4)", textTransform: "uppercase",
+          }}>{group} · {items.length}</div>
+          {items.map(l => <LocRowM key={l.id} loc={l} checked={items.indexOf(l) < 2}/>)}
+        </div>
+      ))}
+    </Sheet>
+  );
+}
+
+function LocRowM({ loc, checked }) {
+  return (
+    <div style={{
+      display: "flex", alignItems: "center", gap: 12, minHeight: 48,
+      padding: "10px 0", borderBottom: "1px solid var(--g-rule-soft)",
+    }}>
+      <div style={{
+        width: 22, height: 22, borderRadius: 5,
+        border: `2px solid ${checked ? "var(--g-accent)" : "var(--g-rule)"}`,
+        background: checked ? "var(--g-accent)" : "transparent",
+        display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0,
+      }}>
+        {checked && <MIcon kind="check" size={14} color="#fff"/>}
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 14, color: "var(--g-ink)", fontWeight: checked ? 600 : 500 }}>{loc.name}</div>
+        <div className="mono" style={{ fontSize: 10, color: "var(--g-ink-4)", marginTop: 2 }}>{loc.elev} m · {loc.focus}</div>
+      </div>
+    </div>
+  );
+}
+
+function PresetSheetM({ onClose }) {
+  return (
+    <Sheet open onClose={onClose} title="Vergleich speichern" eyebrow="Neues Auto-Briefing" snap="half"
+           footer={
+             <div style={{ display: "flex", gap: 8 }}>
+               <MBtn variant="ghost" size="lg" block onClick={onClose}>Abbrechen</MBtn>
+               <MBtn variant="primary" size="lg" block onClick={onClose}>Speichern</MBtn>
+             </div>
+           }>
+      <MField label="Name">
+        <MInput placeholder="Skitouren Wochenende"/>
+      </MField>
+      <MField label="Zeitplan">
+        <MInput defaultValue="Fr 18:00"/>
+      </MField>
+      <MField label="Kanäle">
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+          {["Email","Signal","Telegram","SMS"].map((k, i) => (
+            <span key={k} style={{
+              padding: "8px 12px", minHeight: 36, borderRadius: "var(--g-r-pill)",
+              background: i === 0 ? "var(--g-ink)" : "var(--g-card-alt)",
+              color: i === 0 ? "var(--g-paper)" : "var(--g-ink-2)",
+              border: `1px solid ${i === 0 ? "var(--g-ink)" : "var(--g-rule)"}`,
+              fontSize: 12, fontFamily: "var(--g-font-mono)", fontWeight: 500,
+            }}>{k}</span>
+          ))}
+        </div>
+      </MField>
+    </Sheet>
+  );
+}
+
+window.ScreenCompareMobile = ScreenCompareMobile;
+window.LocSheetM = LocSheetM;

--- a/docs/design/mobile/screen-design-system-mobile.jsx
+++ b/docs/design/mobile/screen-design-system-mobile.jsx
@@ -1,0 +1,172 @@
+/* Mobile · Design-System / Token-Übersicht
+ * Mobile-spezifische Tokens: Touch-Targets, Spacing-Verdichtung, Inputs ≥ 16 px,
+ *   Safe-Areas, Bottom-Nav-Höhe etc. Verwendet ausschließlich tokens.css.
+ * Layout: scrollbarer Single-Column.
+ */
+
+function ScreenDesignSystemMobile() {
+  return (
+    <PhoneFrame height={1100}>
+      <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", background: "var(--g-paper)" }}>
+        <TopAppBar title="Mobile-Tokens" eyebrow="Design-System · Mobile-Spezifikation" leftIcon="back"/>
+
+        <ScreenScroll padding={16}>
+
+          {/* Touch-Targets */}
+          <DSGroup title="Touch-Targets" sub="Mindestmaße für tappbare Elemente (Apple HIG / Material).">
+            <DSRow tk="--touch-min"     val="44 × 44 px"   note="Buttons, Nav-Items, Switches"/>
+            <DSRow tk="--touch-pref"    val="48 × 48 px"   note="Primäre Actions (MBtn size=lg)"/>
+            <DSRow tk="--touch-cta"     val="56 × 56 px"   note="Fokus-CTAs (size=xl)"/>
+            <DSRow tk="--input-h"       val="48 px"        note="Inputs (MInput)"/>
+            <DSRow tk="--input-fs"      val="16 px"        note="iOS verhindert Zoom bei ≥ 16 px"/>
+          </DSGroup>
+
+          {/* Spacing */}
+          <DSGroup title="Spacing · mobil verdichtet" sub="Skalen aus tokens.css; mobile Innenränder kompakter.">
+            <DSRow tk="--g-s-3 (12)"   val="Card-Gaps"     note="zwischen Cards"/>
+            <DSRow tk="--g-s-4 (16)"   val="Screen-Padding" note="Außenrand · statt 40 px Desktop"/>
+            <DSRow tk="--g-s-4 (16)"   val="Card-Padding"   note="Karten-Innenrand · statt 20 px"/>
+            <DSRow tk="--g-s-2 (8)"    val="Inline-Gap"     note="zwischen Inline-Elementen"/>
+            <DSRow tk="--g-s-1 (4)"    val="Hairline-Gap"   note="zwischen Pills, Chips"/>
+          </DSGroup>
+
+          {/* App-Shell-Maße */}
+          <DSGroup title="App-Shell · Höhen" sub="Feste Maße der Mobile-Shell.">
+            <DSRow tk="topbar-h"      val="56 px"   note="Top-App-Bar"/>
+            <DSRow tk="bottomnav-h"   val="64 px"   note="Bottom-Nav"/>
+            <DSRow tk="safe-top"      val="44 px"   note="Statusbar · env(safe-area-inset-top)"/>
+            <DSRow tk="safe-bottom"   val="34 px"   note="Home-Indicator · env(safe-area-inset-bottom)"/>
+            <DSRow tk="content-w"     val="375 / 414 / 768" note="Primär · Sekundär · Tablet"/>
+          </DSGroup>
+
+          {/* Typografie */}
+          <DSGroup title="Typografie · Mobile-Scale" sub="Body 14 px Default, 16 px in Inputs. Display kleiner als Desktop.">
+            <DSTypeRow size={28} weight={600} label="Hero" note="Trip-Titel, Login"/>
+            <DSTypeRow size={22} weight={600} label="Section-H1" note="Trip-Detail Hero"/>
+            <DSTypeRow size={17} weight={600} label="TopAppBar-Title" note="Sticky-Header"/>
+            <DSTypeRow size={16} weight={600} label="Card-Title"/>
+            <DSTypeRow size={15} weight={500} label="Drawer-Item · Body-CTA"/>
+            <DSTypeRow size={14} weight={400} label="Body" note="Lesetext"/>
+            <DSTypeRow size={13} weight={500} label="Sub · Card-Body"/>
+            <DSTypeRow size={11} weight={500} mono label="Eyebrow · Meta-Daten"/>
+            <DSTypeRow size={10} weight={500} mono label="Caption · Stat-Label"/>
+          </DSGroup>
+
+          {/* Farben */}
+          <DSGroup title="Farben · aus tokens.css" sub="Keine Mobile-spezifischen Farben. Verwende --g-* unverändert.">
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 6 }}>
+              <Swatch color="var(--g-paper)" name="paper"/>
+              <Swatch color="var(--g-paper-deep)" name="paper-d"/>
+              <Swatch color="var(--g-card)" name="card"/>
+              <Swatch color="var(--g-card-alt)" name="card-alt"/>
+              <Swatch color="var(--g-ink)" name="ink" dark/>
+              <Swatch color="var(--g-ink-2)" name="ink-2" dark/>
+              <Swatch color="var(--g-ink-3)" name="ink-3" dark/>
+              <Swatch color="var(--g-ink-4)" name="ink-4" dark/>
+              <Swatch color="var(--g-accent)" name="accent" dark/>
+              <Swatch color="var(--g-good)" name="good" dark/>
+              <Swatch color="var(--g-warn)" name="warn" dark/>
+              <Swatch color="var(--g-bad)" name="bad" dark/>
+            </div>
+          </DSGroup>
+
+          {/* Radii */}
+          <DSGroup title="Radien" sub="Mobile bevorzugt --g-r-3 für Cards, --g-r-pill für Chips.">
+            <div style={{ display: "flex", gap: 6 }}>
+              <RadiusBox r="2" tk="--g-r-1"/>
+              <RadiusBox r="4" tk="--g-r-2"/>
+              <RadiusBox r="6" tk="--g-r-3"/>
+              <RadiusBox r="10" tk="--g-r-4"/>
+              <RadiusBox r="999" tk="--g-r-pill" label="∞"/>
+            </div>
+          </DSGroup>
+
+          {/* Komponenten-Beispiele */}
+          <DSGroup title="Komponenten · live" sub="Gleicher Code wie in Production-Screens.">
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              <MBtn variant="primary" block>Primary · 48 px hoch</MBtn>
+              <MBtn variant="accent" block>Accent</MBtn>
+              <MBtn variant="ghost" block>Ghost</MBtn>
+              <div style={{ display: "flex", gap: 6 }}>
+                <Pill tone="good">low</Pill>
+                <Pill tone="warn">med</Pill>
+                <Pill tone="bad">high</Pill>
+                <Pill tone="accent">Live</Pill>
+              </div>
+              <MInput placeholder="Input · fontSize 16 px" leftIcon="search"/>
+              <MSwitch label="Switch · 44 px Touch" checked/>
+            </div>
+          </DSGroup>
+
+          {/* Breakpoints */}
+          <DSGroup title="Breakpoints" sub="@media-Query-Logik in app.css.">
+            <DSRow tk="≤ 599 px"   val="Mobile"   note="Primärziel 375 · Sekundär 414"/>
+            <DSRow tk="600–899 px" val="Wide-M"   note="Tablet 768 · 2-spaltige Cards wo sinnvoll"/>
+            <DSRow tk="≥ 900 px"   val="Desktop"  note="Bestehendes Layout unverändert"/>
+          </DSGroup>
+
+        </ScreenScroll>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+function DSGroup({ title, sub, children }) {
+  return (
+    <div style={{ marginBottom: 22 }}>
+      <div style={{ marginBottom: 10 }}>
+        <Eyebrow style={{ marginBottom: 4 }}>{title}</Eyebrow>
+        {sub && <div style={{ fontSize: 12, color: "var(--g-ink-3)", lineHeight: 1.5 }}>{sub}</div>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function DSRow({ tk, val, note }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", padding: "10px 0", borderBottom: "1px solid var(--g-rule-soft)", gap: 10 }}>
+      <span className="mono" style={{ fontSize: 11, color: "var(--g-accent)", fontWeight: 600, minWidth: 110 }}>{tk}</span>
+      <span className="mono" style={{ fontSize: 12, color: "var(--g-ink)", fontWeight: 600, minWidth: 80 }}>{val}</span>
+      <span style={{ flex: 1, fontSize: 12, color: "var(--g-ink-3)", lineHeight: 1.4 }}>{note}</span>
+    </div>
+  );
+}
+
+function DSTypeRow({ size, weight, label, note, mono }) {
+  return (
+    <div style={{ display: "flex", alignItems: "baseline", padding: "8px 0", borderBottom: "1px solid var(--g-rule-soft)", gap: 12 }}>
+      <span style={{
+        fontSize: size, fontWeight: weight, letterSpacing: size > 20 ? "-0.02em" : 0,
+        color: "var(--g-ink)", lineHeight: 1, fontFamily: mono ? "var(--g-font-mono)" : "var(--g-font-sans)",
+        minWidth: 40, flexShrink: 0,
+      }}>Aa</span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 13, fontWeight: 500 }}>{label}</div>
+        {note && <div className="mono" style={{ fontSize: 10, color: "var(--g-ink-4)", marginTop: 2 }}>{note}</div>}
+      </div>
+      <span className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)" }}>{size}/{weight}</span>
+    </div>
+  );
+}
+
+function Swatch({ color, name, dark }) {
+  return (
+    <div>
+      <div style={{ height: 48, background: color, borderRadius: "var(--g-r-2)", border: "1px solid var(--g-rule-soft)" }}/>
+      <div className="mono" style={{ fontSize: 9, color: "var(--g-ink-3)", marginTop: 4, textAlign: "center", letterSpacing: "0.04em" }}>{name}</div>
+    </div>
+  );
+}
+
+function RadiusBox({ r, tk, label }) {
+  return (
+    <div style={{ flex: 1, textAlign: "center" }}>
+      <div style={{ height: 48, background: "var(--g-card)", border: "1px solid var(--g-rule)", borderRadius: r === "999" ? 24 : Number(r) }}/>
+      <div className="mono" style={{ fontSize: 9, color: "var(--g-ink-3)", marginTop: 4 }}>{tk}</div>
+      <div className="mono" style={{ fontSize: 9, color: "var(--g-ink-4)" }}>{label || r + "px"}</div>
+    </div>
+  );
+}
+
+window.ScreenDesignSystemMobile = ScreenDesignSystemMobile;

--- a/docs/design/mobile/screen-home-mobile.jsx
+++ b/docs/design/mobile/screen-home-mobile.jsx
@@ -1,0 +1,185 @@
+/* Mobile · Übersicht / Heute
+ * Hero: aktiver Trip, heutige Etappe, Sparkline, Briefings-Heute, Alerts.
+ * Pattern: vertikale Card-Stacks. Bottom-Nav: home aktiv. Top-App-Bar mit Hamburger + Glocke.
+ */
+
+function ScreenHomeMobile() {
+  const trip = MOCK_TRIP;
+  const today = MOCK_TODAY_STAGE;
+  const tomorrow = trip.stages[1];
+
+  const right = (
+    <div style={{ display: "flex" }}>
+      <IconBtn kind="bell" badge={2} label="Alerts"/>
+      <IconBtn kind="plus" label="Neuer Trip"/>
+    </div>
+  );
+
+  return (
+    <MobileShell active="home" title="Guten Morgen, Gregor" eyebrow="Mi · 06. Mai" right={right} phoneHeight={812}>
+      <ScreenScroll padding={0}>
+        <div style={{ padding: "12px 16px 20px" }}>
+
+          {/* Aktiver Trip Hero */}
+          <div style={{
+            background: "var(--g-card)", borderRadius: "var(--g-r-3)",
+            border: "1px solid var(--g-rule)", borderLeft: "3px solid var(--g-accent)",
+            boxShadow: "var(--g-shadow-1)", overflow: "hidden", marginBottom: 16,
+          }}>
+            <div style={{ padding: "16px 16px 0" }}>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 8 }}>
+                <Pill tone="accent"><Dot tone="bad" size={6}/> Live · Tag 1/12</Pill>
+                <Pill tone="ghost">Sommer-Trekking</Pill>
+              </div>
+              <div style={{ fontSize: 28, fontWeight: 600, letterSpacing: "-0.02em", lineHeight: 1.05 }}>KHW 403</div>
+              <div style={{ fontSize: 14, color: "var(--g-ink-2)", marginTop: 4, lineHeight: 1.4 }}>
+                Karnischer Höhenweg<br/>
+                <span className="mono" style={{ fontSize: 12, color: "var(--g-ink-3)" }}>
+                  {trip.totalKm.toFixed(1)} km · ↑{trip.totalAscent} ↓{trip.totalDescent}
+                </span>
+              </div>
+            </div>
+
+            {/* Heutige Etappe */}
+            <div style={{ padding: "14px 16px 16px", marginTop: 14, background: "var(--g-card-alt)", borderTop: "1px solid var(--g-rule-soft)" }}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 10 }}>
+                <div style={{ minWidth: 0 }}>
+                  <Eyebrow style={{ marginBottom: 3 }}>Heute · {today.code}</Eyebrow>
+                  <div style={{ fontSize: 16, fontWeight: 600, lineHeight: 1.25 }}>{today.title.replace(/^.*: /, "")}</div>
+                  <div className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)", marginTop: 4 }}>
+                    08:00–12:45 · {today.km} km · ↑{today.ascent} ↓{today.descent}
+                  </div>
+                </div>
+                <Pill tone="good">low</Pill>
+              </div>
+              <ElevSparkline data={today.profile} width={310} height={48}/>
+              <div style={{ fontSize: 13, color: "var(--g-ink-2)", marginTop: 10, paddingTop: 10, borderTop: "1px dashed var(--g-rule-soft)", lineHeight: 1.5 }}>
+                {today.summary}
+              </div>
+            </div>
+
+            {/* Etappen-Strip */}
+            <div style={{ padding: "12px 16px 14px", borderTop: "1px solid var(--g-rule-soft)", display: "flex", gap: 4, overflowX: "auto", WebkitOverflowScrolling: "touch" }}>
+              {trip.stages.map((s, i) => (
+                <div key={s.id} style={{
+                  flex: "0 0 36px", padding: "6px 4px", borderRadius: "var(--g-r-2)",
+                  background: i === 0 ? "var(--g-accent-tint)" : "var(--g-paper)",
+                  border: i === 0 ? "1px solid var(--g-accent)" : "1px solid var(--g-rule-soft)",
+                  textAlign: "center",
+                }}>
+                  <div className="mono" style={{ fontSize: 9, color: i === 0 ? "var(--g-accent-deep)" : "var(--g-ink-3)", letterSpacing: "0.04em", fontWeight: 600 }}>
+                    {s.code.slice(-3)}
+                  </div>
+                  <div style={{ marginTop: 4, height: 3, background: s.risk === "high" ? "var(--g-bad)" : s.risk === "med" ? "var(--g-warn)" : "var(--g-good)", borderRadius: 2 }}/>
+                </div>
+              ))}
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={"f"+i} style={{ flex: "0 0 36px", padding: "6px 4px", background: "var(--g-paper-deep)", border: "1px solid var(--g-rule-soft)", borderRadius: "var(--g-r-2)", opacity: 0.5, textAlign: "center" }}>
+                  <div className="mono" style={{ fontSize: 9, color: "var(--g-ink-4)", letterSpacing: "0.04em" }}>{String(i+4).padStart(2,"0")}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Briefings heute */}
+          <Card padding={16} style={{ marginBottom: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+              <div>
+                <Eyebrow style={{ marginBottom: 3 }}>Heute</Eyebrow>
+                <div style={{ fontSize: 16, fontWeight: 600 }}>Was geht raus</div>
+              </div>
+              <Pill tone="good">3 ok</Pill>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              {MOCK_REPORT_TIMELINE.map((r, i) => (
+                <MobileReportRow key={i} report={r}/>
+              ))}
+            </div>
+          </Card>
+
+          {/* Alerts */}
+          <Card padding={16} style={{ marginBottom: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+              <div>
+                <Eyebrow style={{ marginBottom: 3 }}>Alerts · 24 h</Eyebrow>
+                <div style={{ fontSize: 16, fontWeight: 600 }}>2 ausgelöst</div>
+              </div>
+              <a href="#" style={{ fontSize: 12, color: "var(--g-ink-3)", textDecoration: "none", fontFamily: "var(--g-font-mono)" }}>Schwellen →</a>
+            </div>
+            {MOCK_ALERTS_RECENT.map((a, i) => (
+              <MobileAlertRow key={i} alert={a} last={i === MOCK_ALERTS_RECENT.length - 1}/>
+            ))}
+          </Card>
+
+          {/* Morgen Card */}
+          <Card padding={16} style={{ marginBottom: 12 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 8 }}>
+              <div>
+                <Eyebrow style={{ marginBottom: 3 }}>Morgen · Do 07. Mai</Eyebrow>
+                <div style={{ fontSize: 16, fontWeight: 600, lineHeight: 1.25 }}>{tomorrow.title.replace(/^.*: /, "")}</div>
+              </div>
+              <Pill tone="warn">med</Pill>
+            </div>
+            <div className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)", marginBottom: 10 }}>
+              {tomorrow.code} · {tomorrow.km} km · ↑{tomorrow.ascent} ↓{tomorrow.descent}
+            </div>
+            <ElevSparkline data={tomorrow.profile} width={310} height={44}/>
+            <div style={{ fontSize: 13, color: "var(--g-ink-2)", marginTop: 10, paddingTop: 10, borderTop: "1px dashed var(--g-rule-soft)", lineHeight: 1.5 }}>
+              {tomorrow.summary}
+            </div>
+          </Card>
+
+          {/* Quick-Action: Test-Briefing */}
+          <MBtn variant="ghost" block size="lg">Test-Briefing jetzt senden</MBtn>
+        </div>
+      </ScreenScroll>
+    </MobileShell>
+  );
+}
+
+function MobileReportRow({ report }) {
+  const isSent = report.status === "sent";
+  const glyph = (k) => k === "email" ? "✉" : k === "signal" ? "▲" : k === "telegram" ? "✈" : "·";
+  return (
+    <div style={{
+      display: "flex", alignItems: "center", gap: 10,
+      padding: "10px 12px", borderRadius: "var(--g-r-2)",
+      background: isSent ? "var(--g-card-alt)" : "var(--g-card)",
+      border: "1px solid var(--g-rule-soft)",
+    }}>
+      <Dot tone={isSent ? "good" : "neutral"}/>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: "flex", gap: 6, alignItems: "baseline" }}>
+          <span className="mono" style={{ fontSize: 12, fontWeight: 600 }}>{report.when}</span>
+          <span style={{ fontSize: 12, color: "var(--g-ink-3)", textTransform: "capitalize" }}>{report.kind}</span>
+        </div>
+        <div className="mono" style={{ fontSize: 10, color: "var(--g-ink-3)", marginTop: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{report.etappe}</div>
+      </div>
+      <div style={{ display: "flex", gap: 2 }}>
+        {report.channels.map(c => (
+          <span key={c} className="mono" style={{
+            fontSize: 10, padding: "2px 5px", border: "1px solid var(--g-rule)",
+            borderRadius: "var(--g-r-pill)", color: "var(--g-ink-3)",
+          }}>{glyph(c)}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MobileAlertRow({ alert, last }) {
+  const tone = alert.kind === "thunder" ? "bad" : "warn";
+  return (
+    <div style={{ display: "flex", gap: 10, padding: "10px 0", borderBottom: last ? "none" : "1px dashed var(--g-rule-soft)" }}>
+      <div style={{ marginTop: 1 }}>
+        <WIcon kind={alert.kind === "thunder" ? "thunder" : "wind"} size={18} color={tone === "bad" ? "var(--g-bad)" : "var(--g-warn)"}/>
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)", marginBottom: 2 }}>{alert.when} · {alert.channel}</div>
+        <div style={{ fontSize: 13, color: "var(--g-ink)", lineHeight: 1.4 }}>{alert.msg}</div>
+      </div>
+    </div>
+  );
+}
+
+window.ScreenHomeMobile = ScreenHomeMobile;

--- a/docs/design/mobile/screen-location-new-mobile.jsx
+++ b/docs/design/mobile/screen-location-new-mobile.jsx
@@ -1,0 +1,198 @@
+/* Mobile · POI anlegen (Location New) — Smart-Import-Flow
+ * Pattern: Vollbild-Modal-Flow (kein Bottom-Nav). Step-Indikator wie Wizard.
+ * Steps: 1) Quelle wählen   2) URL / Suche eingeben   3) Vorschlag prüfen  4) speichern
+ */
+
+function ScreenLocationNewMobile() {
+  const [step, setStep] = React.useState(2);
+
+  const title = {
+    1: "Quelle wählen",
+    2: "Ort importieren",
+    3: "Vorschlag prüfen",
+  }[step];
+
+  return (
+    <PhoneFrame height={812}>
+      <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", background: "var(--g-paper)" }}>
+        <TopAppBar
+          title={title}
+          eyebrow={`Neuer Ort · ${step}/3`}
+          leftIcon={step === 1 ? "close" : "back"}
+          right={<button style={{ padding: "0 12px", minHeight: 44, background: "transparent", border: "none", fontSize: 14, color: "var(--g-ink-3)" }}>Abbrechen</button>}
+          onMenu={() => step > 1 && setStep(step - 1)}
+        />
+
+        <div style={{ display: "flex", gap: 4, padding: "8px 16px 12px", borderBottom: "1px solid var(--g-rule-soft)", flexShrink: 0 }}>
+          {[1,2,3].map(n => (
+            <div key={n} style={{ flex: 1, height: 3, borderRadius: 2, background: n <= step ? "var(--g-accent)" : "var(--g-rule)" }}/>
+          ))}
+        </div>
+
+        <ScreenScroll padding={16}>
+          {step === 1 && <LocSource onPick={() => setStep(2)}/>}
+          {step === 2 && <LocImport onParsed={() => setStep(3)}/>}
+          {step === 3 && <LocPreview/>}
+        </ScreenScroll>
+
+        <div style={{
+          flexShrink: 0, padding: "10px 16px",
+          paddingBottom: "calc(10px + env(safe-area-inset-bottom))",
+          background: "var(--g-paper)", borderTop: "1px solid var(--g-rule)",
+          display: "flex", gap: 8,
+        }}>
+          {step > 1 && <MBtn variant="ghost" size="lg" onClick={() => setStep(step - 1)} style={{ flex: 1 }}>← Zurück</MBtn>}
+          {step < 3 ? (
+            <MBtn variant="primary" size="lg" onClick={() => setStep(step + 1)} style={{ flex: 1.6 }}>Weiter →</MBtn>
+          ) : (
+            <MBtn variant="accent" size="lg" style={{ flex: 1.6 }}>Ort speichern</MBtn>
+          )}
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+function LocSource({ onPick }) {
+  const sources = [
+    { id: "url", icon: "external", label: "URL einfügen", sub: "Komoot, Outdooractive, Google-Maps, Bergfex" },
+    { id: "search", icon: "search", label: "Ort suchen", sub: "Volltextsuche nach Berg, Hütte, Skigebiet" },
+    { id: "map", icon: "map", label: "Auf Karte tippen", sub: "Beliebigen Punkt setzen" },
+    { id: "gpx", icon: "plus", label: "Aus GPX", sub: "Start- oder Endpunkt aus Tracks" },
+  ];
+  return (
+    <>
+      <div style={{ fontSize: 22, fontWeight: 600, letterSpacing: "-0.01em", marginBottom: 4 }}>
+        Woher kommt der Ort?
+      </div>
+      <div style={{ fontSize: 13, color: "var(--g-ink-3)", lineHeight: 1.5, marginBottom: 18 }}>
+        Smart-Import erkennt Name, Höhe und Koordinaten automatisch — du musst keine Lat/Lon eintippen.
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {sources.map(s => (
+          <button key={s.id} onClick={onPick} style={{
+            display: "flex", alignItems: "center", gap: 14, padding: "16px 14px",
+            background: "var(--g-card)", border: "1px solid var(--g-rule)",
+            borderRadius: "var(--g-r-3)", cursor: "pointer", minHeight: 64,
+            textAlign: "left",
+          }}>
+            <span style={{
+              width: 40, height: 40, borderRadius: "var(--g-r-3)",
+              background: "var(--g-paper-deep)",
+              display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0,
+            }}>
+              <MIcon kind={s.icon} size={20} color="var(--g-ink)"/>
+            </span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 15, fontWeight: 600 }}>{s.label}</div>
+              <div style={{ fontSize: 12, color: "var(--g-ink-3)", marginTop: 2 }}>{s.sub}</div>
+            </div>
+            <MIcon kind="chevron" size={18} color="var(--g-ink-3)"/>
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}
+
+function LocImport({ onParsed }) {
+  return (
+    <>
+      <div style={{ fontSize: 22, fontWeight: 600, letterSpacing: "-0.01em", marginBottom: 4 }}>
+        URL einfügen
+      </div>
+      <div style={{ fontSize: 13, color: "var(--g-ink-3)", lineHeight: 1.5, marginBottom: 18 }}>
+        Komoot, Outdooractive, Google-Maps, Bergfex, Skigebiete.de — wir erkennen den Ort.
+      </div>
+
+      <MField label="URL oder Adresse">
+        <MInput defaultValue="komoot.com/smarttour/15...…" leftIcon="external"/>
+      </MField>
+
+      {/* Parsed Preview */}
+      <Card padding={14} style={{ background: "var(--g-card-alt)", marginTop: 12 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+          <Dot tone="good"/>
+          <span className="mono" style={{ fontSize: 11, color: "var(--g-good)", textTransform: "uppercase", letterSpacing: "0.1em", fontWeight: 600 }}>erkannt · komoot</span>
+        </div>
+        <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 2 }}>Hintertuxer Gletscher</div>
+        <div className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)", lineHeight: 1.5 }}>
+          47.0789°N · 11.6856°E<br/>
+          3250 m · Skigebiet · Zillertal, AT
+        </div>
+      </Card>
+
+      <button onClick={onParsed} style={{
+        marginTop: 14, padding: "10px 14px", minHeight: 44, width: "100%",
+        background: "transparent", border: "1px dashed var(--g-rule)",
+        borderRadius: "var(--g-r-3)", cursor: "pointer",
+        fontSize: 13, color: "var(--g-ink-3)",
+      }}>Andere Quelle versuchen</button>
+    </>
+  );
+}
+
+function LocPreview() {
+  return (
+    <>
+      <div style={{ fontSize: 22, fontWeight: 600, letterSpacing: "-0.01em", marginBottom: 4 }}>
+        Vorschlag prüfen
+      </div>
+      <div style={{ fontSize: 13, color: "var(--g-ink-3)", lineHeight: 1.5, marginBottom: 18 }}>
+        Pass den Namen an oder weise Gruppe und Aktivitäts-Fokus zu, damit der Vergleich passt.
+      </div>
+
+      {/* Karten-Placeholder */}
+      <div style={{
+        position: "relative", height: 160, borderRadius: "var(--g-r-3)",
+        background: "linear-gradient(180deg, #d4dcc5 0%, #e8e6d0 100%)",
+        marginBottom: 14, overflow: "hidden", border: "1px solid var(--g-rule)",
+      }}>
+        <svg viewBox="0 0 343 160" width="100%" height="100%" style={{ position: "absolute", inset: 0 }}>
+          <path d="M0 110 Q50 80 100 95 T200 75 T343 90" stroke="rgba(26,26,24,0.15)" strokeWidth="1" fill="none"/>
+          <path d="M0 130 Q60 100 120 115 T250 95 T343 110" stroke="rgba(26,26,24,0.1)" strokeWidth="1" fill="none"/>
+        </svg>
+        <div style={{
+          position: "absolute", top: "50%", left: "50%", transform: "translate(-50%, -50%)",
+          width: 16, height: 16, borderRadius: "50%", background: "var(--g-accent)",
+          border: "3px solid #fff", boxShadow: "0 2px 6px rgba(0,0,0,0.2)",
+        }}/>
+        <div className="mono" style={{
+          position: "absolute", bottom: 8, left: 8, fontSize: 9, color: "var(--g-ink-3)",
+          background: "rgba(255,255,255,0.85)", padding: "2px 6px", borderRadius: 3,
+        }}>47.0789°N · 11.6856°E</div>
+      </div>
+
+      <MField label="Name">
+        <MInput defaultValue="Hintertuxer Gletscher"/>
+      </MField>
+      <MField label="Höhe (m)">
+        <MInput defaultValue="3250"/>
+      </MField>
+      <MField label="Gruppe">
+        <MInput defaultValue="Zillertal"/>
+      </MField>
+      <MField label="Aktivitäts-Fokus">
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+          {[
+            { id: "wintersport-glacier", label: "Gletscher", active: true },
+            { id: "wintersport", label: "Wintersport" },
+            { id: "alpine-touring", label: "Skitour" },
+            { id: "hiking", label: "Wandern" },
+            { id: "trail-running", label: "Trail" },
+          ].map(c => (
+            <span key={c.id} style={{
+              padding: "8px 12px", minHeight: 36, borderRadius: "var(--g-r-pill)",
+              background: c.active ? "var(--g-ink)" : "var(--g-card)",
+              color: c.active ? "var(--g-paper)" : "var(--g-ink-2)",
+              border: `1px solid ${c.active ? "var(--g-ink)" : "var(--g-rule)"}`,
+              fontSize: 12, fontFamily: "var(--g-font-mono)", fontWeight: 500,
+            }}>{c.label}</span>
+          ))}
+        </div>
+      </MField>
+    </>
+  );
+}
+
+window.ScreenLocationNewMobile = ScreenLocationNewMobile;

--- a/docs/design/mobile/screen-login-mobile.jsx
+++ b/docs/design/mobile/screen-login-mobile.jsx
@@ -1,0 +1,67 @@
+/* Mobile · Login
+ * Pattern: Vollbild ohne Shell. Logo + Form. Magic-Link bevorzugt, Passwort als Sekundär.
+ */
+
+function ScreenLoginMobile() {
+  return (
+    <PhoneFrame height={812}>
+      <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", background: "var(--g-paper)" }}>
+        <TopoBg opacity={0.18}/>
+
+        <div style={{ position: "relative", flex: 1, display: "flex", flexDirection: "column", padding: "24px 20px 0", justifyContent: "space-between" }}>
+
+          {/* Top: Logo */}
+          <div style={{ marginTop: 24 }}>
+            <Logo size={28}/>
+          </div>
+
+          {/* Mid: Form */}
+          <div style={{ marginBottom: 40 }}>
+            <h1 style={{ fontSize: 30, fontWeight: 600, letterSpacing: "-0.02em", lineHeight: 1.1, margin: "0 0 8px" }}>
+              Willkommen zurück.
+            </h1>
+            <div style={{ fontSize: 14, color: "var(--g-ink-3)", lineHeight: 1.5, marginBottom: 28 }}>
+              Wetter-Briefings für deine Touren — wann, wo und in welcher Tiefe DU sie willst.
+            </div>
+
+            <MField label="Email">
+              <MInput type="email" placeholder="dein@email.com" defaultValue="gregor_zwanzig@henemm.com"/>
+            </MField>
+
+            <MBtn variant="primary" size="lg" block style={{ marginTop: 8, marginBottom: 14 }}>
+              Magic-Link anfordern →
+            </MBtn>
+
+            <div style={{
+              display: "flex", alignItems: "center", gap: 10, color: "var(--g-ink-4)",
+              fontSize: 11, fontFamily: "var(--g-font-mono)", textTransform: "uppercase",
+              letterSpacing: "0.1em", margin: "12px 0 14px",
+            }}>
+              <div style={{ flex: 1, height: 1, background: "var(--g-rule)" }}/>
+              <span>oder</span>
+              <div style={{ flex: 1, height: 1, background: "var(--g-rule)" }}/>
+            </div>
+
+            <MBtn variant="ghost" size="lg" block style={{ marginBottom: 8 }}>Mit Passkey anmelden</MBtn>
+            <MBtn variant="quiet" size="md" block>Mit Passwort anmelden</MBtn>
+          </div>
+
+          {/* Bottom: Footer */}
+          <div style={{
+            paddingBottom: "calc(20px + env(safe-area-inset-bottom))",
+            fontSize: 12, color: "var(--g-ink-4)", textAlign: "center", lineHeight: 1.5,
+          }}>
+            Neu hier?{" "}
+            <a href="#" style={{ color: "var(--g-accent)", textDecoration: "none", fontWeight: 600 }}>Konto erstellen</a>
+            <div className="mono" style={{ fontSize: 10, color: "var(--g-ink-4)", marginTop: 12, letterSpacing: "0.08em" }}>
+              Gregor Zwanzig · Wetter-Briefings · Headless
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+window.ScreenLoginMobile = ScreenLoginMobile;

--- a/docs/design/mobile/screen-patterns-mobile.jsx
+++ b/docs/design/mobile/screen-patterns-mobile.jsx
@@ -1,0 +1,534 @@
+/* Mobile · Übergreifende Patterns
+ * App-Shell, Drawer offen, Modal/Bottom-Sheet, Toasts, Loading/Empty/Error.
+ * Jede Variante als eigener Artboard, damit Devs alle Zustände als Referenz haben.
+ */
+
+/* ─────────────────── App-Shell · Drawer offen ─────────────────── */
+function PatternAppShellDrawer() {
+  return (
+    <PhoneFrame height={812}>
+      <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", background: "var(--g-paper)" }}>
+        <TopAppBar title="Trips" eyebrow="Workspace" leftIcon="menu" right={<IconBtn kind="plus"/>}/>
+        <div style={{ flex: 1, padding: 16, opacity: 0.4 }}>
+          <Card padding={14} style={{ marginBottom: 8 }}>
+            <div style={{ fontSize: 14, fontWeight: 600 }}>KHW 403</div>
+            <div className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)" }}>2026-05-04 → 2026-05-17</div>
+          </Card>
+          <Card padding={14}>
+            <div style={{ fontSize: 14, fontWeight: 600 }}>GR221 Mallorca</div>
+            <div className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)" }}>2026-02-23 → 2026-02-26</div>
+          </Card>
+        </div>
+        <BottomNav active="trips"/>
+      </div>
+      {/* Drawer */}
+      <div style={{ position: "absolute", inset: 6, borderRadius: 32, overflow: "hidden", pointerEvents: "none" }}>
+        <div style={{ position: "absolute", inset: 0, background: "rgba(26,26,24,0.45)" }}/>
+        <aside style={{
+          position: "absolute", top: 0, left: 0, bottom: 0, width: 296,
+          background: "var(--g-paper-deep)",
+          display: "flex", flexDirection: "column",
+        }}>
+          <div style={{ height: 44, flexShrink: 0 }}/>
+          <div style={{ padding: "12px 20px 18px", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <Logo size={20}/>
+            <IconBtn kind="close"/>
+          </div>
+          <div style={{ padding: "0 12px", flex: 1 }}>
+            <DrawerGroup label="Workspace">
+              <DrawerItem icon="home"    label="Übersicht"/>
+              <DrawerItem icon="trip"    label="Trips" badge="1" active/>
+              <DrawerItem icon="compare" label="Ortsvergleich"/>
+              <DrawerItem icon="archive" label="Archiv" badge="8"/>
+            </DrawerGroup>
+            <DrawerGroup label="Konfiguration">
+              <DrawerItem icon="channels" label="Kanäle"/>
+              <DrawerItem icon="settings" label="Einstellungen"/>
+            </DrawerGroup>
+          </div>
+          <div style={{ padding: "16px 20px", borderTop: "1px solid var(--g-rule)", display: "flex", alignItems: "center", gap: 12 }}>
+            <div style={{
+              width: 36, height: 36, borderRadius: "50%", background: "var(--g-accent)",
+              color: "#fff", fontSize: 13, fontWeight: 600,
+              display: "flex", alignItems: "center", justifyContent: "center",
+            }}>GH</div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 14, fontWeight: 600 }}>Gregor Henemm</div>
+              <div className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)" }}>henemm.com</div>
+            </div>
+            <IconBtn kind="external"/>
+          </div>
+          <div style={{ height: 34, flexShrink: 0 }}/>
+        </aside>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+/* ─────────────────── Modal · Vollbild ─────────────────── */
+function PatternModal() {
+  return (
+    <PhoneFrame height={812}>
+      <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", background: "var(--g-paper)" }}>
+        <TopAppBar
+          title="Trip löschen?"
+          eyebrow="Bestätigung erforderlich"
+          leftIcon="close"
+          right={<button style={{ padding: "0 12px", minHeight: 44, background: "transparent", border: "none", fontSize: 14, color: "var(--g-ink-3)" }}>Abbrechen</button>}
+        />
+
+        <ScreenScroll padding={20}>
+          {/* Big icon */}
+          <div style={{ display: "flex", justifyContent: "center", marginTop: 12, marginBottom: 14 }}>
+            <div style={{
+              width: 80, height: 80, borderRadius: "50%",
+              background: "rgba(168,50,50,0.10)",
+              display: "flex", alignItems: "center", justifyContent: "center",
+            }}>
+              <MIcon kind="trash" size={36} color="var(--g-bad)"/>
+            </div>
+          </div>
+
+          <h2 style={{ fontSize: 20, fontWeight: 600, letterSpacing: "-0.01em", margin: 0, marginBottom: 8, textAlign: "center" }}>
+            "KHW 403" wirklich löschen?
+          </h2>
+          <p style={{ fontSize: 14, color: "var(--g-ink-3)", lineHeight: 1.5, textAlign: "center", marginBottom: 24 }}>
+            Alle Etappen, Wegpunkte, Metriken-Konfigs und gespeicherten Briefings dieses Trips gehen verloren.
+          </p>
+
+          <Card padding={14} style={{ background: "rgba(168,50,50,0.06)", borderLeft: "3px solid var(--g-bad)", marginBottom: 20 }}>
+            <Eyebrow style={{ color: "var(--g-bad)", marginBottom: 6 }}>Wird mit gelöscht</Eyebrow>
+            <ul style={{ margin: 0, paddingLeft: 18, fontSize: 13, color: "var(--g-ink-2)", lineHeight: 1.8 }}>
+              <li>13 Etappen mit Wegpunkten</li>
+              <li>Metriken-Preset · 14 Spalten</li>
+              <li>Alert-Schwellen</li>
+              <li>23 archivierte Briefings</li>
+            </ul>
+          </Card>
+
+          <MField label="Tippe »LÖSCHEN« zum Bestätigen">
+            <MInput placeholder="LÖSCHEN"/>
+          </MField>
+        </ScreenScroll>
+
+        <div style={{
+          padding: "10px 16px",
+          paddingBottom: "calc(10px + env(safe-area-inset-bottom))",
+          background: "var(--g-paper)", borderTop: "1px solid var(--g-rule)",
+          display: "flex", gap: 8, flexShrink: 0,
+        }}>
+          <MBtn variant="ghost" size="lg" style={{ flex: 1 }}>Abbrechen</MBtn>
+          <MBtn variant="danger" size="lg" style={{ flex: 1.4, background: "var(--g-bad)", color: "#fff", border: "1px solid var(--g-bad)" }}>Endgültig löschen</MBtn>
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+/* ─────────────────── Bottom-Sheet · expanded ─────────────────── */
+function PatternBottomSheet() {
+  return (
+    <PhoneFrame height={812}>
+      <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", background: "var(--g-paper)" }}>
+        <TopAppBar title="Trips" eyebrow="Workspace" leftIcon="menu" right={<IconBtn kind="plus"/>}/>
+        <div style={{ flex: 1, padding: 16, opacity: 0.35 }}>
+          <Card padding={14} style={{ marginBottom: 8 }}>
+            <div style={{ fontSize: 14, fontWeight: 600 }}>KHW 403</div>
+          </Card>
+        </div>
+        <BottomNav active="trips"/>
+      </div>
+      {/* Sheet overlay */}
+      <div style={{ position: "absolute", inset: 6, borderRadius: 32, overflow: "hidden", pointerEvents: "none" }}>
+        <div style={{ position: "absolute", inset: 0, background: "rgba(26,26,24,0.42)" }}/>
+        <div style={{
+          position: "absolute", left: 0, right: 0, bottom: 0, height: "55%",
+          background: "var(--g-card)",
+          borderTopLeftRadius: 18, borderTopRightRadius: 18,
+          display: "flex", flexDirection: "column",
+        }}>
+          <div style={{ display: "flex", justifyContent: "center", paddingTop: 8 }}>
+            <span style={{ width: 36, height: 4, borderRadius: 2, background: "var(--g-rule)" }}/>
+          </div>
+          <div style={{ padding: "8px 20px 12px", display: "flex", alignItems: "flex-start", gap: 8 }}>
+            <div style={{ flex: 1 }}>
+              <Eyebrow style={{ marginBottom: 4 }}>Aktionen · aktiver Trip</Eyebrow>
+              <div style={{ fontSize: 18, fontWeight: 600 }}>KHW 403</div>
+            </div>
+            <IconBtn kind="close"/>
+          </div>
+          <div style={{ padding: "0 20px 20px" }}>
+            {[
+              { icon: "send", label: "Briefing jetzt senden", sub: "Manueller Trigger" },
+              { icon: "external", label: "Email-Vorschau", sub: "Nächstes Briefing" },
+              { icon: "bell", label: "Alert-Konfiguration", sub: "Schwellen & Δ-Regeln" },
+              { icon: "edit", label: "Bearbeiten", sub: "Wegpunkte, Profil, Kanäle" },
+              { icon: "trash", label: "Löschen", danger: true },
+            ].map((it, i) => (
+              <div key={i} style={{
+                display: "flex", alignItems: "center", gap: 14,
+                padding: "14px 4px", minHeight: 56,
+                borderBottom: i < 4 ? "1px solid var(--g-rule-soft)" : "none",
+              }}>
+                <span style={{
+                  width: 40, height: 40, borderRadius: "var(--g-r-3)",
+                  background: it.danger ? "rgba(168,50,50,0.08)" : "var(--g-paper-deep)",
+                  display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0,
+                }}>
+                  <MIcon kind={it.icon} size={20} color={it.danger ? "var(--g-bad)" : "var(--g-ink)"}/>
+                </span>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 15, fontWeight: 500, color: it.danger ? "var(--g-bad)" : "var(--g-ink)" }}>{it.label}</div>
+                  {it.sub && <div style={{ fontSize: 12, color: "var(--g-ink-3)", marginTop: 2 }}>{it.sub}</div>}
+                </div>
+                <MIcon kind="chevron" size={16} color="var(--g-ink-4)"/>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+/* ─────────────────── Toasts · 4 Varianten gestapelt ─────────────────── */
+function PatternToasts() {
+  return (
+    <PhoneFrame height={812}>
+      <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", background: "var(--g-paper)" }}>
+        <TopAppBar title="Toasts · 4 Varianten" eyebrow="Notifications" leftIcon="back"/>
+        <ScreenScroll padding={16}>
+          <Eyebrow style={{ marginBottom: 8 }}>Info · neutral</Eyebrow>
+          <ToastStatic kind="info" msg="Briefing-Zeitplan aktualisiert. Nächstes Briefing 18:00." action="OK"/>
+
+          <div style={{ height: 12 }}/>
+          <Eyebrow style={{ marginBottom: 8 }}>Success · grün</Eyebrow>
+          <ToastStatic kind="success" hint="Gesendet · 06:00" msg="Morgen-Briefing an 2 Kanäle ausgeliefert." action="Anzeigen"/>
+
+          <div style={{ height: 12 }}/>
+          <Eyebrow style={{ marginBottom: 8 }}>Warning · gelb</Eyebrow>
+          <ToastStatic kind="warn" hint="Schwellwert nahe" msg="Wind 48 km/h — Schwelle 50 km/h." action="Details"/>
+
+          <div style={{ height: 12 }}/>
+          <Eyebrow style={{ marginBottom: 8 }}>Error · rot</Eyebrow>
+          <ToastStatic kind="error" hint="Kanal Signal offline" msg="Briefing konnte nicht zugestellt werden. SMS-Fallback aktiviert." action="Erneut"/>
+
+          <div style={{ height: 24 }}/>
+          <Eyebrow style={{ marginBottom: 8 }}>Position</Eyebrow>
+          <div style={{ fontSize: 13, color: "var(--g-ink-3)", lineHeight: 1.6 }}>
+            Toasts erscheinen über der Bottom-Nav (16 px Abstand zu allen Rändern). Auto-Dismiss nach 4 s, persistent für Errors.
+          </div>
+        </ScreenScroll>
+        <BottomNav active="home"/>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+function ToastStatic({ kind, msg, action, hint }) {
+  const map = {
+    info:    { bg: "var(--g-ink)",   fg: "var(--g-paper)" },
+    success: { bg: "var(--g-good)",  fg: "#fff" },
+    warn:    { bg: "var(--g-warn)",  fg: "#fff" },
+    error:   { bg: "var(--g-bad)",   fg: "#fff" },
+  };
+  const t = map[kind] || map.info;
+  return (
+    <div style={{
+      background: t.bg, color: t.fg, borderRadius: "var(--g-r-3)",
+      padding: "12px 16px", display: "flex", alignItems: "center", gap: 12,
+      boxShadow: "var(--g-shadow-2)",
+    }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        {hint && (
+          <div className="mono" style={{ fontSize: 10, letterSpacing: "0.1em", textTransform: "uppercase", opacity: 0.7, marginBottom: 2 }}>{hint}</div>
+        )}
+        <div style={{ fontSize: 14, lineHeight: 1.4 }}>{msg}</div>
+      </div>
+      {action && (
+        <button style={{
+          background: "transparent", border: "none", color: t.fg,
+          fontSize: 13, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.06em",
+          fontFamily: "var(--g-font-mono)", cursor: "pointer", minHeight: 44, padding: "0 4px",
+        }}>{action}</button>
+      )}
+    </div>
+  );
+}
+
+/* ─────────────────── States: Loading / Empty / Error ─────────────────── */
+function PatternStates() {
+  return (
+    <PhoneFrame height={1100}>
+      <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", background: "var(--g-paper)" }}>
+        <TopAppBar title="States" eyebrow="Loading · Empty · Error" leftIcon="back"/>
+        <ScreenScroll padding={16}>
+          {/* Loading */}
+          <Eyebrow style={{ marginBottom: 8 }}>Loading · Skeleton</Eyebrow>
+          <Card padding={14} style={{ marginBottom: 14 }}>
+            <SkeletonRow w="60%" h={12}/>
+            <div style={{ height: 8 }}/>
+            <SkeletonRow w="40%" h={10}/>
+            <div style={{ height: 14 }}/>
+            <SkeletonRow w="100%" h={48}/>
+            <div style={{ height: 8 }}/>
+            <SkeletonRow w="100%" h={48}/>
+          </Card>
+
+          {/* Empty */}
+          <Eyebrow style={{ marginBottom: 8 }}>Empty · keine Daten</Eyebrow>
+          <Card padding={20} style={{ marginBottom: 14, textAlign: "center" }}>
+            <div style={{
+              width: 56, height: 56, borderRadius: "var(--g-r-3)",
+              background: "var(--g-card-alt)", margin: "8px auto 14px",
+              display: "flex", alignItems: "center", justifyContent: "center",
+            }}>
+              <MIcon kind="trip" size={28} color="var(--g-ink-3)"/>
+            </div>
+            <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 4 }}>Noch keine Trips</div>
+            <div style={{ fontSize: 13, color: "var(--g-ink-3)", lineHeight: 1.5, marginBottom: 16, maxWidth: 260, margin: "0 auto 16px" }}>
+              Lege deinen ersten Trip an — wir berechnen ETAs und Wegpunkte automatisch aus deinen GPX-Files.
+            </div>
+            <MBtn variant="primary" size="lg" icon={<MIcon kind="plus" size={16} color="var(--g-paper)"/>}>Ersten Trip anlegen</MBtn>
+          </Card>
+
+          {/* Error */}
+          <Eyebrow style={{ marginBottom: 8 }}>Error · Netzwerk</Eyebrow>
+          <Card padding={20} style={{ marginBottom: 14, textAlign: "center", borderLeft: "3px solid var(--g-bad)" }}>
+            <div style={{
+              width: 56, height: 56, borderRadius: "var(--g-r-3)",
+              background: "rgba(168,50,50,0.10)", margin: "8px auto 14px",
+              display: "flex", alignItems: "center", justifyContent: "center",
+            }}>
+              <MIcon kind="bell" size={28} color="var(--g-bad)"/>
+            </div>
+            <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 4 }}>Briefing konnte nicht laden</div>
+            <div style={{ fontSize: 13, color: "var(--g-ink-3)", lineHeight: 1.5, marginBottom: 8 }}>
+              Verbindung zu Wetterdienst MeteoBlue verloren. Wir versuchen es alle 30 s erneut.
+            </div>
+            <div className="mono" style={{ fontSize: 10, color: "var(--g-ink-4)", marginBottom: 16 }}>
+              ERR_NET_502 · 14:32:08
+            </div>
+            <div style={{ display: "flex", gap: 6, justifyContent: "center" }}>
+              <MBtn variant="ghost" size="md">Details</MBtn>
+              <MBtn variant="primary" size="md">Jetzt erneut</MBtn>
+            </div>
+          </Card>
+
+          {/* Permission-Hint */}
+          <Eyebrow style={{ marginBottom: 8 }}>Permission · Hint</Eyebrow>
+          <Card padding={14} style={{ background: "var(--g-accent-tint)", borderLeft: "3px solid var(--g-accent)" }}>
+            <div style={{ display: "flex", alignItems: "flex-start", gap: 12 }}>
+              <MIcon kind="bell" size={24} color="var(--g-accent)"/>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>Benachrichtigungen aktivieren?</div>
+                <div style={{ fontSize: 12, color: "var(--g-ink-2)", lineHeight: 1.5, marginBottom: 10 }}>
+                  Sonst kommen Alerts nur per Signal/SMS — Push wäre schneller.
+                </div>
+                <div style={{ display: "flex", gap: 6 }}>
+                  <MBtn variant="ghost" size="md">Später</MBtn>
+                  <MBtn variant="accent" size="md">Aktivieren</MBtn>
+                </div>
+              </div>
+            </div>
+          </Card>
+        </ScreenScroll>
+        <BottomNav active="home"/>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+function SkeletonRow({ w = "100%", h = 12 }) {
+  return (
+    <div style={{
+      width: w, height: h, borderRadius: 4,
+      background: "linear-gradient(90deg, var(--g-card-alt) 0%, var(--g-paper-deep) 50%, var(--g-card-alt) 100%)",
+    }}/>
+  );
+}
+
+/* ─────────────────── Wizard-Abbruch · Sheet ─────────────────── */
+function PatternWizardCancel() {
+  return (
+    <PhoneFrame height={812}>
+      <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", background: "var(--g-paper)" }}>
+        <TopAppBar title="GPX-Import" eyebrow="Schritt 2 von 4 · Neuer Trip" leftIcon="close"
+                   right={<button style={{ padding: "0 12px", minHeight: 44, background: "transparent", border: "none", fontSize: 14, color: "var(--g-ink-3)" }}>Abbrechen</button>}/>
+        <div style={{ display: "flex", gap: 4, padding: "8px 16px 12px", borderBottom: "1px solid var(--g-rule-soft)", flexShrink: 0, opacity: 0.4 }}>
+          {[1,2,3,4].map(n => (
+            <div key={n} style={{ flex: 1, height: 3, borderRadius: 2, background: n <= 2 ? "var(--g-accent)" : "var(--g-rule)" }}/>
+          ))}
+        </div>
+        <div style={{ flex: 1, padding: 16, opacity: 0.35 }}>
+          <Card padding={14}>
+            <Eyebrow>Etappen-Liste · 3</Eyebrow>
+            <div style={{ fontSize: 14, color: "var(--g-ink-3)", marginTop: 6 }}>2 GPX hochgeladen, 1 Pausentag …</div>
+          </Card>
+        </div>
+      </div>
+
+      {/* Sheet overlay */}
+      <div style={{ position: "absolute", inset: 6, borderRadius: 32, overflow: "hidden", pointerEvents: "none" }}>
+        <div style={{ position: "absolute", inset: 0, background: "rgba(26,26,24,0.42)" }}/>
+        <div style={{
+          position: "absolute", left: 0, right: 0, bottom: 0,
+          background: "var(--g-card)",
+          borderTopLeftRadius: 18, borderTopRightRadius: 18,
+          display: "flex", flexDirection: "column", maxHeight: "70%",
+        }}>
+          <div style={{ display: "flex", justifyContent: "center", paddingTop: 8 }}>
+            <span style={{ width: 36, height: 4, borderRadius: 2, background: "var(--g-rule)" }}/>
+          </div>
+          <div style={{ padding: "12px 20px 20px" }}>
+            <Eyebrow style={{ marginBottom: 4 }}>Trip-Anlage abbrechen?</Eyebrow>
+            <div style={{ fontSize: 18, fontWeight: 600, marginBottom: 6, letterSpacing: "-0.01em" }}>
+              Du hast schon Etappen importiert.
+            </div>
+            <div style={{ fontSize: 13, color: "var(--g-ink-3)", lineHeight: 1.5, marginBottom: 20 }}>
+              Speichere als Entwurf und mach später weiter, oder verwirf alles.
+            </div>
+
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              <button style={{
+                display: "flex", alignItems: "center", gap: 12, padding: "14px 14px",
+                background: "var(--g-accent)", color: "#fff", border: "1px solid var(--g-accent)",
+                borderRadius: "var(--g-r-3)", cursor: "pointer", minHeight: 56, textAlign: "left",
+              }}>
+                <MIcon kind="check" size={20} color="#fff"/>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 15, fontWeight: 600 }}>Als Entwurf speichern</div>
+                  <div style={{ fontSize: 12, opacity: 0.85, marginTop: 2 }}>In Trips-Liste als Draft. Fortsetzen jederzeit möglich.</div>
+                </div>
+              </button>
+
+              <button style={{
+                display: "flex", alignItems: "center", gap: 12, padding: "14px 14px",
+                background: "var(--g-card)", color: "var(--g-ink)", border: "1px solid var(--g-rule)",
+                borderRadius: "var(--g-r-3)", cursor: "pointer", minHeight: 56, textAlign: "left",
+              }}>
+                <MIcon kind="back" size={20} color="var(--g-ink-2)"/>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 15, fontWeight: 600 }}>Weiter editieren</div>
+                  <div style={{ fontSize: 12, color: "var(--g-ink-3)", marginTop: 2 }}>Zurück zum Wizard.</div>
+                </div>
+              </button>
+
+              <button style={{
+                display: "flex", alignItems: "center", gap: 12, padding: "14px 14px",
+                background: "transparent", color: "var(--g-bad)", border: "1px solid var(--g-rule)",
+                borderRadius: "var(--g-r-3)", cursor: "pointer", minHeight: 56, textAlign: "left",
+              }}>
+                <MIcon kind="trash" size={20} color="var(--g-bad)"/>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 15, fontWeight: 600 }}>Verwerfen</div>
+                  <div style={{ fontSize: 12, color: "var(--g-ink-3)", marginTop: 2 }}>Eingaben gehen verloren.</div>
+                </div>
+              </button>
+            </div>
+          </div>
+          <div style={{ height: 34 }}/>
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+/* ─────────────────── Push-Permission · Pre-Prompt ───────────────────
+ * Eigener Vollbild-Screen, der NACH erster Alert-Konfig (oder erstem Trip) erscheint.
+ * Tappt User "Aktivieren" → erst dann erscheint der native iOS/Android-Permission-Dialog.
+ * Tappt User "Später" → Pre-Prompt wird in 7 Tagen oder bei nächster Alert-Auslösung wieder gezeigt.
+ */
+function PatternPushPermission() {
+  return (
+    <PhoneFrame height={812}>
+      <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", background: "var(--g-paper)" }}>
+        <TopoBg opacity={0.16}/>
+
+        <div style={{ position: "relative", flex: 1, display: "flex", flexDirection: "column", padding: "24px 20px 0" }}>
+
+          {/* Top: Skip-Link */}
+          <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: 16 }}>
+            <button style={{
+              padding: "8px 12px", minHeight: 44, background: "transparent",
+              border: "none", fontSize: 14, color: "var(--g-ink-3)", cursor: "pointer", fontWeight: 500,
+            }}>Überspringen</button>
+          </div>
+
+          {/* Hero Icon */}
+          <div style={{ display: "flex", justifyContent: "center", marginTop: 24, marginBottom: 24 }}>
+            <div style={{
+              width: 88, height: 88, borderRadius: 24,
+              background: "var(--g-accent)",
+              display: "flex", alignItems: "center", justifyContent: "center",
+              boxShadow: "0 8px 24px rgba(196,90,42,0.32)",
+              position: "relative",
+            }}>
+              <MIcon kind="bell" size={42} color="#fff"/>
+              <span style={{
+                position: "absolute", top: 14, right: 14,
+                width: 14, height: 14, borderRadius: "50%",
+                background: "var(--g-bad)", border: "3px solid var(--g-accent)",
+              }}/>
+            </div>
+          </div>
+
+          {/* Copy */}
+          <h1 style={{ fontSize: 26, fontWeight: 600, letterSpacing: "-0.02em", margin: 0, marginBottom: 10, textAlign: "center", lineHeight: 1.2 }}>
+            Push-Alerts aktivieren?
+          </h1>
+          <div style={{ fontSize: 14, color: "var(--g-ink-2)", lineHeight: 1.55, textAlign: "center", marginBottom: 24, padding: "0 8px" }}>
+            Push ist die schnellste Route für kritische Wetter-Alerts —
+            spürbar schneller als Email oder SMS. Du behältst die volle Kontrolle, was wann ankommt.
+          </div>
+
+          {/* Bullets */}
+          <div style={{ marginBottom: 28 }}>
+            <PushBullet icon="check" text="Sofort-Alert bei Gewitter, Sturm oder kritischer Wetteränderung"/>
+            <PushBullet icon="check" text="Nur Trip-Alerts, kein Marketing — versprochen"/>
+            <PushBullet icon="check" text="Ruhezeit & Kanäle bleiben pro Trip konfigurierbar"/>
+          </div>
+
+          {/* Spacer */}
+          <div style={{ flex: 1 }}/>
+
+          {/* Action-Stack */}
+          <div style={{
+            paddingBottom: "calc(20px + env(safe-area-inset-bottom))",
+            display: "flex", flexDirection: "column", gap: 8,
+          }}>
+            <MBtn variant="accent" size="xl" block>Aktivieren</MBtn>
+            <MBtn variant="quiet" size="lg" block>Später erinnern</MBtn>
+            <div className="mono" style={{ fontSize: 10, color: "var(--g-ink-4)", textAlign: "center", marginTop: 8, letterSpacing: "0.06em" }}>
+              Erscheint einmalig nach erster Alert-Konfig.
+            </div>
+          </div>
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+function PushBullet({ icon, text }) {
+  return (
+    <div style={{ display: "flex", gap: 12, padding: "10px 0", alignItems: "flex-start" }}>
+      <span style={{
+        width: 22, height: 22, borderRadius: "50%", flexShrink: 0,
+        background: "rgba(61,107,58,0.12)",
+        display: "flex", alignItems: "center", justifyContent: "center",
+        marginTop: 1,
+      }}>
+        <MIcon kind={icon} size={14} color="var(--g-good)"/>
+      </span>
+      <div style={{ flex: 1, fontSize: 13, color: "var(--g-ink-2)", lineHeight: 1.55 }}>{text}</div>
+    </div>
+  );
+}
+
+window.PatternAppShellDrawer = PatternAppShellDrawer;
+window.PatternModal = PatternModal;
+window.PatternBottomSheet = PatternBottomSheet;
+window.PatternToasts = PatternToasts;
+window.PatternStates = PatternStates;
+window.PatternWizardCancel = PatternWizardCancel;
+window.PatternPushPermission = PatternPushPermission;

--- a/docs/design/mobile/screen-trip-detail-mobile.jsx
+++ b/docs/design/mobile/screen-trip-detail-mobile.jsx
@@ -1,0 +1,367 @@
+/* Mobile · Trip-Detail
+ * Pattern: Hero + Tab-Scroller + Card-Stack. Sticky Tabs. Status-Badge unter Hero.
+ * Tabs: Übersicht · Etappen · Metriken · Briefings · Alerts · Vorschau (Pill-Scroller).
+ */
+
+function ScreenTripDetailMobile() {
+  const trip = MOCK_TRIP;
+  const [tab, setTab] = React.useState("uebersicht");
+  const [activeStage, setActiveStage] = React.useState(1);
+
+  const tabs = [
+    { id: "uebersicht", label: "Übersicht" },
+    { id: "etappen",    label: "Etappen", badge: trip.stages.length },
+    { id: "metriken",   label: "Metriken", badge: 14 },
+    { id: "briefings",  label: "Briefings" },
+    { id: "alerts",     label: "Alerts", badge: 2, accent: true },
+    { id: "vorschau",   label: "Vorschau" },
+  ];
+
+  const right = (
+    <div style={{ display: "flex" }}>
+      <IconBtn kind="send" label="Test-Senden"/>
+      <IconBtn kind="more" label="Mehr"/>
+    </div>
+  );
+
+  return (
+    <MobileShell active="trips" title="KHW 403" eyebrow="Trips ›" leftIcon="back" right={right} phoneHeight={812}>
+      <ScreenScroll padding={0}>
+        {/* Hero */}
+        <div style={{ padding: "12px 16px 16px", background: "var(--g-paper)" }}>
+          <h1 style={{ fontSize: 26, fontWeight: 600, letterSpacing: "-0.02em", margin: 0, lineHeight: 1.1 }}>{trip.name}</h1>
+          <div className="mono" style={{ fontSize: 12, color: "var(--g-ink-3)", marginTop: 8, lineHeight: 1.5 }}>
+            {trip.startDate} → {trip.endDate}<br/>
+            {trip.stages.length} Etappen · {trip.totalKm} km · ↑{trip.totalAscent} m
+          </div>
+
+          {/* Status + Quick Stats */}
+          <div style={{ display: "flex", gap: 6, marginTop: 12, flexWrap: "wrap" }}>
+            <span className="mono" style={{
+              display: "inline-flex", alignItems: "center", gap: 6,
+              fontSize: 11, padding: "5px 10px", borderRadius: "var(--g-r-pill)",
+              border: "1px solid var(--g-good)", color: "var(--g-good)",
+              letterSpacing: "0.06em", fontWeight: 600, textTransform: "uppercase",
+            }}>
+              <span style={{ width: 6, height: 6, borderRadius: "50%", background: "var(--g-good)" }}/>
+              Aktiv · Briefings laufen
+            </span>
+          </div>
+
+          {/* Stat row */}
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 8, marginTop: 16, padding: "12px 0", borderTop: "1px solid var(--g-rule-soft)", borderBottom: "1px solid var(--g-rule-soft)" }}>
+            <DetailStatM label="Etappe" value={`${activeStage + 1}/${trip.stages.length}`} accent/>
+            <DetailStatM label="Briefing" value="06:00" accent/>
+            <DetailStatM label="Start in" value="3 Tg"/>
+          </div>
+        </div>
+
+        {/* Tabs */}
+        <div style={{ position: "sticky", top: 0, background: "var(--g-paper)", zIndex: 5, paddingLeft: 8 }}>
+          <MTab items={tabs} active={tab} onChange={setTab}/>
+        </div>
+
+        {/* Tab Content */}
+        <div style={{ padding: "16px 16px 24px" }}>
+          {tab === "uebersicht" && <DetailOverview trip={trip} activeStage={activeStage} onStage={setActiveStage}/>}
+          {tab === "etappen"    && <DetailStages trip={trip} active={activeStage} onActive={setActiveStage}/>}
+          {tab === "metriken"   && <DetailMetrics/>}
+          {tab === "briefings"  && <DetailBriefings/>}
+          {tab === "alerts"     && <DetailAlerts/>}
+          {tab === "vorschau"   && <DetailVorschau/>}
+        </div>
+      </ScreenScroll>
+    </MobileShell>
+  );
+}
+
+function DetailStatM({ label, value, accent }) {
+  return (
+    <div>
+      <div className="mono" style={{ fontSize: 9, color: "var(--g-ink-4)", letterSpacing: "0.12em", textTransform: "uppercase", marginBottom: 3 }}>{label}</div>
+      <div style={{ fontSize: 18, fontWeight: 600, color: accent ? "var(--g-accent-deep)" : "var(--g-ink)", fontFamily: "var(--g-font-mono)", fontVariantNumeric: "tabular-nums" }}>{value}</div>
+    </div>
+  );
+}
+
+/* ─────────────────── Tab: Übersicht ─────────────────── */
+function DetailOverview({ trip, activeStage, onStage }) {
+  return (
+    <>
+      <Card padding={14} style={{ marginBottom: 12 }}>
+        <Eyebrow style={{ marginBottom: 6 }}>Höhenprofil · Gesamt</Eyebrow>
+        <MiniFullProfile stages={trip.stages} active={activeStage} onClick={onStage}/>
+      </Card>
+
+      <Card padding={14} style={{ marginBottom: 12 }}>
+        <Eyebrow style={{ marginBottom: 8 }}>Briefings laufen</Eyebrow>
+        <ReportLineM kind="Morgen" time="06:00" channels={["email","signal"]} active/>
+        <ReportLineM kind="Abend"  time="18:00" channels={["email"]} active/>
+        <ReportLineM kind="Alert"  time="bei Δ / Schwellwert" channels={["signal"]} active alert last/>
+      </Card>
+
+      <Card padding={14} style={{ marginBottom: 12 }}>
+        <Eyebrow style={{ marginBottom: 6 }}>Alerts · letzte 7 Tage</Eyebrow>
+        {MOCK_ALERTS_RECENT.slice(0, 2).map((a, i) => (
+          <AlertItemM key={i} alert={a} last={i === 1}/>
+        ))}
+      </Card>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+        <MBtn variant="primary" block size="lg">Email-Vorschau</MBtn>
+        <MBtn variant="ghost" block size="lg">SMS-Vorschau</MBtn>
+      </div>
+    </>
+  );
+}
+
+function MiniFullProfile({ stages, active, onClick }) {
+  const W = 343, H = 90;
+  const all = stages.flatMap(s => s.profile);
+  const min = Math.min(...all), max = Math.max(...all);
+  const range = max - min || 1;
+  let xOffset = 0;
+  const totalKm = stages.reduce((sum, s) => sum + s.km, 0);
+  const sections = stages.map((s, i) => {
+    const w = (s.km / totalKm) * W;
+    const pts = s.profile.map((v, j) => {
+      const x = xOffset + (j / (s.profile.length - 1)) * w;
+      const y = H - ((v - min) / range) * (H - 14) - 7;
+      return [x, y];
+    });
+    const data = { idx: i, x0: xOffset, x1: xOffset + w, pts, stage: s };
+    xOffset += w;
+    return data;
+  });
+  const allPath = "M" + sections.flatMap(s => s.pts).map(([x,y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(" L");
+  const fillPath = allPath + ` L${W},${H} L0,${H} Z`;
+  return (
+    <svg viewBox={`0 0 ${W} ${H+18}`} width="100%" height={H+18} style={{ display: "block" }}>
+      <path d={fillPath} fill="rgba(196, 90, 42, 0.08)"/>
+      <path d={allPath} fill="none" stroke="var(--g-accent)" strokeWidth="1.5"/>
+      {sections.map((s, i) => (
+        <g key={i}>
+          {i < sections.length - 1 && <line x1={s.x1} x2={s.x1} y1={0} y2={H} stroke="var(--g-rule-soft)" strokeWidth="1"/>}
+          <rect x={s.x0} y={0} width={s.x1 - s.x0} height={H} fill={i === active ? "rgba(196,90,42,0.06)" : "transparent"} onClick={() => onClick(i)}/>
+          {(i === active || i === 0 || i === sections.length - 1) && (
+            <text x={s.x0 + 3} y={H + 12} className="mono" style={{ fontSize: 9, fill: i === active ? "var(--g-accent)" : "var(--g-ink-4)" }}>{s.stage.code.slice(-3)}</text>
+          )}
+        </g>
+      ))}
+    </svg>
+  );
+}
+
+function ReportLineM({ kind, time, channels, active, alert, last }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", padding: "10px 0", borderBottom: last ? "none" : "1px solid var(--g-rule-soft)" }}>
+      <span style={{
+        width: 6, height: 6, borderRadius: "50%",
+        background: active ? (alert ? "var(--g-accent)" : "var(--g-good)") : "var(--g-rule)",
+        marginRight: 10, flexShrink: 0,
+      }}/>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 14, fontWeight: 600 }}>{kind}</div>
+        <div className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)" }}>{time}</div>
+      </div>
+      <div style={{ display: "flex", gap: 4 }}>
+        {channels.map((c, i) => <ChannelChipM key={i} kind={c}/>)}
+      </div>
+    </div>
+  );
+}
+
+function ChannelChipM({ kind }) {
+  const map = { email: "✉", signal: "▲", telegram: "✈", sms: "·" };
+  return <span className="mono" style={{ width: 24, height: 24, borderRadius: 4, background: "var(--g-paper-deep)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 12, color: "var(--g-ink-2)" }}>{map[kind]}</span>;
+}
+
+function AlertItemM({ alert, last }) {
+  return (
+    <div style={{ padding: "10px 0", borderBottom: last ? "none" : "1px dashed var(--g-rule-soft)" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 2 }}>
+        <span style={{ width: 6, height: 6, borderRadius: "50%", background: "var(--g-accent)" }}/>
+        <span className="mono" style={{ fontSize: 10, color: "var(--g-ink-3)" }}>{alert.when} · {alert.channel}</span>
+      </div>
+      <div style={{ fontSize: 13, color: "var(--g-ink-2)", lineHeight: 1.4 }}>{alert.msg}</div>
+    </div>
+  );
+}
+
+/* ─────────────────── Tab: Etappen ─────────────────── */
+function DetailStages({ trip, active, onActive }) {
+  return (
+    <>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+        <Eyebrow>{trip.stages.length} Etappen</Eyebrow>
+        <MBtn variant="ghost" size="md" icon={<MIcon kind="plus" size={14}/>}>Etappe</MBtn>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {trip.stages.map((s, i) => (
+          <StageCardM key={s.id} stage={s} active={i === active} onClick={() => onActive(i)} index={i}/>
+        ))}
+      </div>
+    </>
+  );
+}
+
+function StageCardM({ stage, active, onClick, index }) {
+  const tone = stage.risk === "high" ? "bad" : stage.risk === "med" ? "warn" : "good";
+  const toneColor = stage.risk === "high" ? "var(--g-bad)" : stage.risk === "med" ? "var(--g-warn)" : "var(--g-good)";
+  return (
+    <div onClick={onClick} style={{
+      background: active ? "var(--g-accent-tint)" : "var(--g-card)",
+      border: active ? "1px solid var(--g-accent)" : "1px solid var(--g-rule)",
+      borderLeft: active ? "3px solid var(--g-accent)" : "1px solid var(--g-rule)",
+      borderRadius: "var(--g-r-3)", padding: "12px 14px",
+      cursor: "pointer",
+    }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 8 }}>
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div style={{ display: "flex", alignItems: "baseline", gap: 8, marginBottom: 2 }}>
+            <span className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)", letterSpacing: "0.04em" }}>{stage.code}</span>
+            <span className="mono" style={{ fontSize: 10, color: "var(--g-ink-4)" }}>· {stage.date}</span>
+          </div>
+          <div style={{ fontSize: 14, fontWeight: 600, lineHeight: 1.3 }}>{stage.title.replace(/^[^:]+: /,"")}</div>
+          <div className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)", marginTop: 4 }}>
+            {stage.km} km · ↑{stage.ascent} ↓{stage.descent} · {stage.waypoints.length} WP
+          </div>
+        </div>
+        <Pill tone={tone}>{stage.risk === "high" ? "high" : stage.risk === "med" ? "med" : "low"}</Pill>
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────── Tab: Metriken (Preview-Variante) ─────────────────── */
+function DetailMetrics() {
+  const metrics = [
+    { name: "Temp", on: true }, { name: "Feels", on: true }, { name: "Luftf", on: false },
+    { name: "Wind", on: true }, { name: "Böen", on: true }, { name: "Windri", on: true },
+    { name: "Niedersch", on: true }, { name: "Regen%", on: true }, { name: "Gewitter", on: true },
+    { name: "Schneefall", on: false }, { name: "Bewölkung", on: true }, { name: "Sicht", on: true },
+    { name: "UV", on: true }, { name: "Nullgrad", on: true }, { name: "Taupunkt", on: false },
+    { name: "CAPE", on: false }, { name: "Druck", on: false }, { name: "Strahlung", on: false },
+  ];
+  const onCount = metrics.filter(m => m.on).length;
+  return (
+    <>
+      <Card padding={14} style={{ marginBottom: 12 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 4 }}>
+          <Eyebrow>Preset · Alpen-Trekking</Eyebrow>
+          <span className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)" }}>{onCount}/{metrics.length}</span>
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 5, marginTop: 10 }}>
+          {metrics.map((m, i) => (
+            <span key={i} className="mono" style={{
+              fontSize: 11, padding: "5px 9px", borderRadius: "var(--g-r-2)",
+              background: m.on ? "var(--g-ink)" : "transparent",
+              color: m.on ? "var(--g-paper)" : "var(--g-ink-4)",
+              border: m.on ? "1px solid var(--g-ink)" : "1px solid var(--g-rule)",
+            }}>{m.name}</span>
+          ))}
+        </div>
+      </Card>
+      <MBtn variant="primary" block>Metriken bearbeiten →</MBtn>
+    </>
+  );
+}
+
+/* ─────────────────── Tab: Briefings ─────────────────── */
+function DetailBriefings() {
+  return (
+    <>
+      <Card padding={14} style={{ marginBottom: 10 }}>
+        <Eyebrow style={{ marginBottom: 8 }}>Zeitplan</Eyebrow>
+        <ReportToggleM label="Morgen-Briefing" time="06:00" sub="Vor Etappenstart, alles für den Tag" enabled/>
+        <ReportToggleM label="Abend-Briefing" time="18:00" sub="Nach Tagesende, Ausblick morgen" enabled/>
+        <ReportToggleM label="Alert-Trigger" time="Δ / Schwelle" sub="Sofort bei kritischer Änderung" enabled last/>
+      </Card>
+      <Card padding={14} style={{ marginBottom: 12 }}>
+        <Eyebrow style={{ marginBottom: 8 }}>Aktive Kanäle</Eyebrow>
+        <ChannelLineM kind="Email"    target="gregor_zwanzig@henemm.com" active/>
+        <ChannelLineM kind="Signal"   target="+49 151 ••• 8847" active/>
+        <ChannelLineM kind="Telegram" target="@gregor_henemm"/>
+        <ChannelLineM kind="SMS"      target="+49 151 ••• 8847" sub="Fallback" last/>
+      </Card>
+      <MBtn variant="ghost" block>Zeitplan & Kanäle bearbeiten →</MBtn>
+    </>
+  );
+}
+
+function ReportToggleM({ label, time, sub, enabled, last }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", padding: "10px 0", borderBottom: last ? "none" : "1px solid var(--g-rule-soft)", gap: 12 }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 14, fontWeight: 600 }}>{label}</div>
+        <div style={{ fontSize: 12, color: "var(--g-ink-3)", marginTop: 1 }}>{sub}</div>
+      </div>
+      <span className="mono" style={{ fontSize: 12, fontWeight: 600, color: "var(--g-accent-deep)", whiteSpace: "nowrap" }}>{time}</span>
+      <MSwitch checked={enabled}/>
+    </div>
+  );
+}
+
+function ChannelLineM({ kind, target, active, sub, last }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", padding: "10px 0", borderBottom: last ? "none" : "1px solid var(--g-rule-soft)", gap: 12 }}>
+      <span className="mono" style={{ fontSize: 10, width: 60, textTransform: "uppercase", letterSpacing: "0.08em", color: "var(--g-ink-3)" }}>{kind}</span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div className="mono" style={{ fontSize: 12, color: "var(--g-ink)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{target}</div>
+        {sub && <div style={{ fontSize: 10, color: "var(--g-ink-4)", marginTop: 2 }}>{sub}</div>}
+      </div>
+      <MSwitch checked={!!active}/>
+    </div>
+  );
+}
+
+/* ─────────────────── Tab: Alerts ─────────────────── */
+function DetailAlerts() {
+  return (
+    <>
+      <Card padding={14} style={{ marginBottom: 12 }}>
+        <Eyebrow style={{ marginBottom: 8 }}>Schwellen · aktiv</Eyebrow>
+        <ThresholdM label="Wind / Böen" value="≥ 50 km/h"/>
+        <ThresholdM label="Niederschlag" value="≥ 10 mm/h"/>
+        <ThresholdM label="Gewitter-Wahrsch." value="≥ 40 %"/>
+        <ThresholdM label="Nullgrad-Grenze" value="−200 m unter Tour" last/>
+      </Card>
+      <Card padding={14} style={{ marginBottom: 12 }}>
+        <Eyebrow style={{ marginBottom: 6 }}>Letzte Auslöser · 7 Tage</Eyebrow>
+        {MOCK_ALERTS_RECENT.map((a, i) => (
+          <AlertItemM key={i} alert={a} last={i === MOCK_ALERTS_RECENT.length - 1}/>
+        ))}
+      </Card>
+      <MBtn variant="ghost" block>Schwellen bearbeiten →</MBtn>
+    </>
+  );
+}
+
+function ThresholdM({ label, value, last }) {
+  return (
+    <div style={{ display: "flex", justifyContent: "space-between", padding: "10px 0", borderBottom: last ? "none" : "1px solid var(--g-rule-soft)" }}>
+      <span style={{ fontSize: 13, color: "var(--g-ink-2)" }}>{label}</span>
+      <span className="mono" style={{ fontSize: 13, color: "var(--g-ink)", fontWeight: 600 }}>{value}</span>
+    </div>
+  );
+}
+
+/* ─────────────────── Tab: Vorschau ─────────────────── */
+function DetailVorschau() {
+  return (
+    <>
+      <Card padding={14} style={{ marginBottom: 10 }}>
+        <Eyebrow style={{ marginBottom: 6 }}>Nächstes Briefing</Eyebrow>
+        <div style={{ fontSize: 15, fontWeight: 600 }}>Morgen, Do 07. Mai · 06:00</div>
+        <div className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)", marginTop: 3 }}>
+          KHW_00b · Birnlücke → Clarahütte
+        </div>
+      </Card>
+      <MBtn variant="primary" block size="lg" style={{ marginBottom: 8 }}>Email-Vorschau öffnen</MBtn>
+      <MBtn variant="ghost" block size="lg" style={{ marginBottom: 8 }}>SMS / Signal-Vorschau</MBtn>
+      <MBtn variant="ghost" block size="lg">Test jetzt an mich senden</MBtn>
+    </>
+  );
+}
+
+window.ScreenTripDetailMobile = ScreenTripDetailMobile;

--- a/docs/design/mobile/screen-trip-wizard-mobile.jsx
+++ b/docs/design/mobile/screen-trip-wizard-mobile.jsx
@@ -1,0 +1,411 @@
+/* Mobile · Trip-Wizard
+ * Pattern: Jeder Schritt = eigener Vollbild-Screen.
+ * Sticky Top: Schritt-Indikator + Abbrechen.
+ * Sticky Bottom: Zurück / Weiter Action-Bar.
+ * Bottom-Nav ausgeblendet (Wizard ist fokussierter Modal-Flow).
+ */
+
+const ACTIVITY_PROFILES_M = [
+  { id: "trekking",   label: "Trekking & Wandern", sub: "Hütten- & Höhenwanderung", pace: "4 km/h · ↑300 m/h", icon: "▲" },
+  { id: "skitour",    label: "Skitour",            sub: "Aufstieg + Abfahrt",       pace: "300 hm/h",          icon: "◆" },
+  { id: "alpine",     label: "Hochtour",           sub: "Gletscher, Fels, Eis",     pace: "350 hm/h",          icon: "▲▲" },
+  { id: "ferrata",    label: "Klettersteig",       sub: "Gesicherte Routen",        pace: "200 hm/h",          icon: "≈" },
+  { id: "mtb",        label: "MTB",                sub: "Mountainbike-Touren",      pace: "12 km/h",           icon: "○○" },
+];
+
+function ScreenTripWizardMobile({ initialStep = 1 }) {
+  const [step, setStep] = React.useState(initialStep);
+  const [profile, setProfile] = React.useState("trekking");
+  const trip = MOCK_TRIP;
+
+  const stepTitles = {
+    1: "Profil & Eckdaten",
+    2: "GPX-Import",
+    3: "Wegpunkte",
+    4: "Briefings",
+  };
+
+  const next = step < 4 ? () => setStep(step + 1) : null;
+  const prev = step > 1 ? () => setStep(step - 1) : null;
+
+  const right = (
+    <button style={{
+      padding: "8px 12px", minHeight: 44, background: "transparent", border: "none",
+      fontSize: 14, color: "var(--g-ink-3)", cursor: "pointer", fontWeight: 500,
+    }}>Abbrechen</button>
+  );
+
+  return (
+    <PhoneFrame height={812}>
+      <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", background: "var(--g-paper)" }}>
+        <TopAppBar
+          title={stepTitles[step]}
+          eyebrow={`Schritt ${step} von 4 · Neuer Trip`}
+          leftIcon={prev ? "back" : "close"}
+          right={right}
+          onMenu={prev}
+        />
+
+        {/* Stepper-Strip */}
+        <div style={{
+          display: "flex", gap: 4, padding: "8px 16px 12px",
+          borderBottom: "1px solid var(--g-rule-soft)", flexShrink: 0,
+        }}>
+          {[1,2,3,4].map(n => (
+            <div key={n} style={{
+              flex: 1, height: 3, borderRadius: 2,
+              background: n <= step ? "var(--g-accent)" : "var(--g-rule)",
+            }}/>
+          ))}
+        </div>
+
+        <ScreenScroll padding={16}>
+          {step === 1 && <WStepProfile profile={profile} onProfile={setProfile}/>}
+          {step === 2 && <WStepGpx/>}
+          {step === 3 && <WStepStages trip={trip}/>}
+          {step === 4 && <WStepBriefings/>}
+        </ScreenScroll>
+
+        {/* Bottom Action-Bar */}
+        <div style={{
+          flexShrink: 0, padding: "10px 16px",
+          paddingBottom: "calc(10px + env(safe-area-inset-bottom))",
+          background: "var(--g-paper)", borderTop: "1px solid var(--g-rule)",
+          display: "flex", gap: 8,
+        }}>
+          {prev && <MBtn variant="ghost" size="lg" onClick={prev} style={{ flex: 1 }}>← Zurück</MBtn>}
+          {next ? (
+            <MBtn variant="primary" size="lg" onClick={next} style={{ flex: prev ? 1.6 : 1 }}>
+              Weiter · {stepTitles[step + 1]} →
+            </MBtn>
+          ) : (
+            <MBtn variant="accent" size="lg" style={{ flex: prev ? 1.6 : 1 }}>
+              Trip anlegen
+            </MBtn>
+          )}
+        </div>
+      </div>
+    </PhoneFrame>
+  );
+}
+
+/* ─────────────────── Schritt 1 · Profil ─────────────────── */
+function WStepProfile({ profile, onProfile }) {
+  return (
+    <>
+      <Card padding={16} style={{ marginBottom: 12 }}>
+        <Eyebrow>Trip-Eckdaten</Eyebrow>
+        <div style={{ fontSize: 16, fontWeight: 600, marginTop: 4, marginBottom: 14 }}>Wie soll der Trip heißen?</div>
+        <MField label="Trip-Name">
+          <MInput defaultValue="Karnischer Höhenweg 403" placeholder="z.B. KHW 2026"/>
+        </MField>
+        <MField label="Kürzel" sub="Erscheint in Briefing-Header und SMS">
+          <MInput defaultValue="KHW 403"/>
+        </MField>
+        <MField label="Reisezeitraum" sub="Tatsächliche Daten kommen aus den GPX-Files">
+          <div style={{ display: "grid", gridTemplateColumns: "1fr auto 1fr", gap: 6, alignItems: "center" }}>
+            <MInput defaultValue="06.05.2026"/>
+            <span style={{ color: "var(--g-ink-4)", textAlign: "center" }}>–</span>
+            <MInput defaultValue="12.05.2026"/>
+          </div>
+        </MField>
+      </Card>
+
+      <Card padding={16}>
+        <Eyebrow>Aktivitätsprofil</Eyebrow>
+        <div style={{ fontSize: 16, fontWeight: 600, marginTop: 4, marginBottom: 4 }}>Was für eine Tour?</div>
+        <div style={{ fontSize: 12, color: "var(--g-ink-3)", marginBottom: 14, lineHeight: 1.5 }}>
+          Bestimmt ETA-Tempo an Wegpunkten und schlägt ein passendes Metrikenset für die Briefings vor.
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          {ACTIVITY_PROFILES_M.map(p => (
+            <ProfileChipM key={p.id} profile={p} active={p.id === profile} onClick={() => onProfile(p.id)}/>
+          ))}
+        </div>
+      </Card>
+    </>
+  );
+}
+
+function ProfileChipM({ profile, active, onClick }) {
+  return (
+    <button onClick={onClick} style={{
+      padding: "14px 14px", textAlign: "left", cursor: "pointer", minHeight: 56,
+      background: active ? "var(--g-accent-tint)" : "var(--g-card-alt)",
+      border: active ? "1px solid var(--g-accent)" : "1px solid var(--g-rule)",
+      borderRadius: "var(--g-r-3)",
+      display: "flex", alignItems: "center", gap: 12,
+    }}>
+      <span className="mono" style={{
+        width: 36, height: 36, borderRadius: "var(--g-r-2)",
+        background: active ? "var(--g-accent)" : "var(--g-paper-deep)",
+        color: active ? "#fff" : "var(--g-ink-3)",
+        display: "inline-flex", alignItems: "center", justifyContent: "center",
+        fontSize: 14, flexShrink: 0,
+      }}>{profile.icon}</span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 14, fontWeight: 600, color: active ? "var(--g-accent-deep)" : "var(--g-ink)" }}>{profile.label}</div>
+        <div style={{ fontSize: 12, color: "var(--g-ink-3)", marginTop: 1 }}>{profile.sub}</div>
+        <div className="mono" style={{ fontSize: 10, color: "var(--g-ink-4)", marginTop: 4, letterSpacing: "0.04em" }}>
+          Tempo: {profile.pace}
+        </div>
+      </div>
+      {active && <MIcon kind="check" size={20} color="var(--g-accent)"/>}
+    </button>
+  );
+}
+
+/* ─────────────────── Schritt 2 · GPX-Import ─────────────────── */
+function WStepGpx() {
+  const items = [
+    { id: "g1", file: "tag1_birnlücke.gpx",     from: "Kasseler Hütte", to: "Birnlücke",  km: 14.2, ascent: 980 },
+    { id: "g2", file: "tag2_clarahütte.gpx",    from: "Birnlücke",      to: "Clarahütte", km: 11.8, ascent: 420 },
+    { id: "p1", pause: true, name: "Pausentag · Clarahütte" },
+    { id: "g3", file: "tag4_essener_hütte.gpx", from: "Clarahütte",     to: "Essener H.", km: 16.4, ascent: 1320 },
+  ];
+  return (
+    <>
+      {/* Drop-Zone */}
+      <div style={{
+        padding: "24px 16px", marginBottom: 14,
+        border: "2px dashed var(--g-rule)", borderRadius: "var(--g-r-3)",
+        textAlign: "center", background: "var(--g-card-alt)",
+      }}>
+        <MIcon kind="plus" size={28} color="var(--g-ink-3)"/>
+        <div style={{ fontSize: 14, fontWeight: 600, color: "var(--g-ink)", marginTop: 8 }}>
+          GPX-Dateien wählen
+        </div>
+        <div className="mono" style={{ fontSize: 10, color: "var(--g-ink-4)", marginTop: 4, lineHeight: 1.5 }}>
+          Mehrfachauswahl möglich<br/>
+          Komoot · Outdooractive · Garmin · FootPath
+        </div>
+      </div>
+
+      {/* Items */}
+      <div style={{ marginBottom: 12 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 8 }}>
+          <Eyebrow>Etappen-Liste · {items.length}</Eyebrow>
+          <span className="mono" style={{ fontSize: 11, color: "var(--g-ink-4)" }}>
+            {items.filter(i => !i.pause).length} GPX · {items.filter(i => i.pause).length} Pause
+          </span>
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {items.map((it, i) => <GpxItemM key={it.id} item={it} index={i}/>)}
+        </div>
+      </div>
+
+      {/* Vorlagen Accordion */}
+      <Card padding={14}>
+        <button style={{
+          display: "flex", justifyContent: "space-between", alignItems: "center",
+          width: "100%", padding: 0, background: "transparent", border: "none", cursor: "pointer",
+          minHeight: 32,
+        }}>
+          <div style={{ textAlign: "left" }}>
+            <Eyebrow style={{ marginBottom: 2 }}>Vorlagen statt eigenem Trip</Eyebrow>
+            <div style={{ fontSize: 13, color: "var(--g-ink-2)" }}>Bekannte Mehrtagestouren importieren</div>
+          </div>
+          <MIcon kind="chevron-down" size={18} color="var(--g-ink-3)"/>
+        </button>
+      </Card>
+    </>
+  );
+}
+
+function GpxItemM({ item, index }) {
+  const num = String(index + 1).padStart(2, "0");
+  if (item.pause) {
+    return (
+      <div style={{
+        display: "flex", alignItems: "center", gap: 10, minHeight: 56,
+        padding: "10px 12px", background: "var(--g-card-alt)",
+        border: "1px dashed var(--g-rule)", borderRadius: "var(--g-r-3)",
+      }}>
+        <MIcon kind="drag" size={16} color="var(--g-ink-4)"/>
+        <span className="mono" style={{ fontSize: 11, fontWeight: 600, color: "var(--g-ink-3)", minWidth: 26 }}>T{num}</span>
+        <div style={{ flex: 1, minWidth: 0, fontSize: 13, color: "var(--g-ink-2)", fontStyle: "italic" }}>
+          {item.name}
+          <div style={{ fontStyle: "normal", fontSize: 11, color: "var(--g-ink-4)", marginTop: 2 }}>keine GPX nötig</div>
+        </div>
+        <IconBtn kind="trash" label="Entfernen"/>
+      </div>
+    );
+  }
+  return (
+    <div style={{
+      display: "flex", alignItems: "center", gap: 10, minHeight: 56,
+      padding: "10px 12px", background: "var(--g-card)",
+      border: "1px solid var(--g-rule)", borderRadius: "var(--g-r-3)",
+    }}>
+      <MIcon kind="drag" size={16} color="var(--g-ink-4)"/>
+      <span className="mono" style={{ fontSize: 11, fontWeight: 600, color: "var(--g-accent)", minWidth: 26 }}>T{num}</span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 13, fontWeight: 600, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+          {item.from} <span style={{ color: "var(--g-ink-4)", fontWeight: 400 }}>→</span> {item.to}
+        </div>
+        <div className="mono" style={{ fontSize: 10, color: "var(--g-ink-3)", marginTop: 3, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+          {item.file} · {item.km}km · ↑{item.ascent}
+        </div>
+      </div>
+      <IconBtn kind="more" label="Mehr"/>
+    </div>
+  );
+}
+
+/* ─────────────────── Schritt 3 · Wegpunkte ─────────────────── */
+function WStepStages({ trip }) {
+  const [active, setActive] = React.useState(1);
+  const stage = trip.stages[active];
+  return (
+    <>
+      {/* Etappen-Pill-Scroller */}
+      <div style={{ marginBottom: 14 }}>
+        <Eyebrow style={{ marginBottom: 8 }}>Etappe wählen · {trip.stages.length}</Eyebrow>
+        <div style={{
+          display: "flex", gap: 6, overflowX: "auto", padding: "2px 0 6px",
+          WebkitOverflowScrolling: "touch", scrollbarWidth: "none",
+        }}>
+          {trip.stages.map((s, i) => {
+            const isActive = i === active;
+            return (
+              <button key={s.id} onClick={() => setActive(i)} style={{
+                flexShrink: 0, padding: "8px 12px", minHeight: 40,
+                background: isActive ? "var(--g-accent)" : "var(--g-card)",
+                color: isActive ? "#fff" : "var(--g-ink-2)",
+                border: `1px solid ${isActive ? "var(--g-accent)" : "var(--g-rule)"}`,
+                borderRadius: "var(--g-r-pill)", cursor: "pointer",
+                fontSize: 12, fontFamily: "var(--g-font-mono)", fontWeight: 600,
+                letterSpacing: "0.04em", whiteSpace: "nowrap",
+              }}>{s.code}</button>
+            );
+          })}
+        </div>
+      </div>
+
+      <Card padding={14} style={{ marginBottom: 12 }}>
+        <Eyebrow>KI-Vorschläge prüfen</Eyebrow>
+        <div style={{ fontSize: 16, fontWeight: 600, marginTop: 4, marginBottom: 4 }}>
+          {stage.title.replace(/^[^:]+: /,"")}
+        </div>
+        <div style={{ fontSize: 12, color: "var(--g-ink-3)", lineHeight: 1.5, marginBottom: 12 }}>
+          {stage.waypoints.filter(w=>w.ai).length} Wetterscheiden vorgeschlagen — Punkte mit signifikanter Höhen- oder Expositions-Änderung.
+        </div>
+        <ProfileSVG stage={stage}/>
+      </Card>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 6, marginBottom: 12 }}>
+        {stage.waypoints.map((wp, i) => (
+          <WaypointRowM key={i} wp={wp} index={i}/>
+        ))}
+      </div>
+
+      <div style={{
+        padding: 12, background: "var(--g-accent-tint)",
+        borderLeft: "3px solid var(--g-accent)", borderRadius: "var(--g-r-2)",
+        fontSize: 13, color: "var(--g-ink-2)", lineHeight: 1.5,
+      }}>
+        <strong>Tipp:</strong> Wegpunkte kannst du später auf der Karte umsetzen — keine Lat/Lon-Eingabe.
+      </div>
+    </>
+  );
+}
+
+function ProfileSVG({ stage }) {
+  const W = 313, H = 90;
+  const min = Math.min(...stage.profile), max = Math.max(...stage.profile);
+  const range = max - min || 1;
+  const pts = stage.profile.map((v, i) => {
+    const x = (i / (stage.profile.length - 1)) * W;
+    const y = H - ((v - min) / range) * (H - 12) - 6;
+    return [x, y];
+  });
+  const path = "M" + pts.map(([x,y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(" L");
+  const fill = path + ` L${W},${H} L0,${H} Z`;
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} width="100%" height={H} style={{ display: "block", background: "var(--g-card-alt)", borderRadius: "var(--g-r-2)" }}>
+      <path d={fill} fill="rgba(196, 90, 42, 0.1)"/>
+      <path d={path} fill="none" stroke="var(--g-accent)" strokeWidth="1.5"/>
+      {stage.waypoints.map((wp, i) => {
+        const t = i / (stage.waypoints.length - 1);
+        const idx = Math.round(t * (stage.profile.length - 1));
+        const [x, y] = pts[idx];
+        return <circle key={i} cx={x} cy={y} r="4" fill={wp.ai ? "rgba(196,90,42,0.2)" : "#fff"} stroke="var(--g-accent)" strokeWidth="1.5" strokeDasharray={wp.ai ? "2,1.5" : "0"}/>;
+      })}
+    </svg>
+  );
+}
+
+function WaypointRowM({ wp, index }) {
+  return (
+    <div style={{
+      display: "flex", alignItems: "center", gap: 12, minHeight: 56,
+      padding: "10px 12px", background: "var(--g-card)",
+      borderRadius: "var(--g-r-3)",
+      border: wp.ai ? "1px dashed var(--g-accent)" : "1px solid var(--g-rule)",
+    }}>
+      <span style={{
+        width: 26, height: 26, borderRadius: "50%", flexShrink: 0,
+        display: "flex", alignItems: "center", justifyContent: "center",
+        background: wp.ai ? "rgba(196,90,42,0.15)" : "var(--g-paper)",
+        border: `2px ${wp.ai ? "dashed" : "solid"} var(--g-accent)`,
+        fontFamily: "var(--g-font-mono)", fontSize: 11, fontWeight: 700, color: "var(--g-accent-deep)",
+      }}>{index + 1}</span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 14, fontWeight: 500, lineHeight: 1.3 }}>{wp.name}</div>
+        <div className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)", marginTop: 2 }}>
+          {wp.elev} m · ETA {wp.time} {wp.ai && <span style={{ color: "var(--g-accent)", fontWeight: 600 }}>· Vorschlag</span>}
+        </div>
+      </div>
+      {wp.ai ? (
+        <div style={{ display: "flex", gap: 4 }}>
+          <button aria-label="Übernehmen" style={{ width: 36, height: 36, borderRadius: "var(--g-r-2)", background: "var(--g-accent)", border: "none", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer" }}>
+            <MIcon kind="check" size={16} color="#fff"/>
+          </button>
+          <button aria-label="Verwerfen" style={{ width: 36, height: 36, borderRadius: "var(--g-r-2)", background: "var(--g-card)", border: "1px solid var(--g-rule)", display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer" }}>
+            <MIcon kind="close" size={16} color="var(--g-ink-3)"/>
+          </button>
+        </div>
+      ) : (
+        <span className="mono" style={{ fontSize: 10, color: "var(--g-good)", textTransform: "uppercase", letterSpacing: "0.1em", fontWeight: 600 }}>fix</span>
+      )}
+    </div>
+  );
+}
+
+/* ─────────────────── Schritt 4 · Briefings ─────────────────── */
+function WStepBriefings() {
+  return (
+    <>
+      <Card padding={14} style={{ marginBottom: 12 }}>
+        <Eyebrow>Deine Kanäle</Eyebrow>
+        <div style={{ fontSize: 16, fontWeight: 600, marginTop: 4, marginBottom: 4 }}>Wohin sollen Briefings?</div>
+        <div style={{ fontSize: 12, color: "var(--g-ink-3)", marginBottom: 12, lineHeight: 1.5 }}>
+          Pro Kanal aktivierbar. Mehr in Einstellungen.
+        </div>
+        <ChannelLineM kind="Email"    target="gregor_zwanzig@henemm.com" active/>
+        <ChannelLineM kind="Signal"   target="+49 151 ••• 8847" active/>
+        <ChannelLineM kind="Telegram" target="@gregor_henemm"/>
+        <ChannelLineM kind="SMS"      target="+49 151 ••• 8847" sub="Fallback" last/>
+      </Card>
+
+      <Card padding={14} style={{ marginBottom: 12 }}>
+        <Eyebrow style={{ marginBottom: 8 }}>Briefings · Wann & was</Eyebrow>
+        <ReportToggleM label="Morgen-Briefing" time="06:00" sub="Vor Etappenstart" enabled/>
+        <ReportToggleM label="Abend-Briefing" time="18:00" sub="Ausblick morgen" enabled last/>
+      </Card>
+
+      <Card padding={14}>
+        <Eyebrow style={{ marginBottom: 4 }}>Alert-Schwellen</Eyebrow>
+        <div style={{ fontSize: 12, color: "var(--g-ink-3)", marginBottom: 10 }}>
+          Sofort bei Überschreitung
+        </div>
+        <ThresholdM label="Windböen" value="≥ 50 km/h"/>
+        <ThresholdM label="Niederschlag" value="≥ 10 mm/h"/>
+        <ThresholdM label="Gewitter-Wahrsch." value="≥ 40 %"/>
+        <ThresholdM label="Schneefallgrenze" value="−200 m unter Tour" last/>
+      </Card>
+    </>
+  );
+}
+
+window.ScreenTripWizardMobile = ScreenTripWizardMobile;

--- a/docs/design/mobile/screen-trips-mobile.jsx
+++ b/docs/design/mobile/screen-trips-mobile.jsx
@@ -1,0 +1,191 @@
+/* Mobile · Trips-Liste
+ * Pattern: Card-Stack statt Tabelle. Aktionen kollabieren in "more"-Menü (öffnet Bottom-Sheet).
+ * Sticky Filter-Chip-Reihe unter dem Header.
+ */
+
+const TRIPS_LIST_M = [
+  { id: "khw-403",   name: "KHW 403",                   stages: 13, from: "2026-05-04", to: "2026-05-17", status: "active",    subtitle: "Karnischer Höhenweg" },
+  { id: "gr221",     name: "GR221 Mallorca",            stages:  4, from: "2026-02-23", to: "2026-02-26", status: "scheduled", subtitle: "Trockenmauer-Weg" },
+  { id: "zillertal", name: "Zillertal mit Steffi",      stages:  1, from: "2025-12-28", to: null,         status: "completed", subtitle: "Wochenende Skitour" },
+  { id: "e2e-2",     name: "E2E Test Trip",             stages:  1, from: "2026-04-13", to: null,         status: "draft",     subtitle: "Test-Konfiguration" },
+  { id: "e2e-1",     name: "E2E Test Trip",             stages:  1, from: "2026-04-13", to: null,         status: "draft",     subtitle: "Test-Konfiguration" },
+];
+
+function ScreenTripsMobile() {
+  const [query, setQuery] = React.useState("");
+  const [filter, setFilter] = React.useState("all");
+  const [sheetOpen, setSheetOpen] = React.useState(false);
+  const filtered = TRIPS_LIST_M.filter(t =>
+    (filter === "all" || t.status === filter) &&
+    t.name.toLowerCase().includes(query.toLowerCase())
+  );
+
+  const right = <IconBtn kind="plus" label="Neuer Trip"/>;
+
+  const chips = [
+    { id: "all",       label: "Alle",       n: TRIPS_LIST_M.length },
+    { id: "active",    label: "Aktiv",      n: 1 },
+    { id: "scheduled", label: "Geplant",    n: 1 },
+    { id: "completed", label: "Fertig",     n: 1 },
+    { id: "draft",     label: "Drafts",     n: 2 },
+  ];
+
+  return (
+    <MobileShell active="trips" title="Trips" eyebrow="Workspace" right={right} phoneHeight={812}
+                 sheet={sheetOpen && <TripActionsSheet onClose={() => setSheetOpen(false)}/>}>
+      <ScreenScroll padding={0}>
+        {/* Search */}
+        <div style={{ padding: "8px 16px 6px" }}>
+          <MInput leftIcon="search" placeholder="Trips suchen…" value={query} onChange={e => setQuery(e.target.value)}/>
+        </div>
+
+        {/* Filter Chips */}
+        <div style={{
+          display: "flex", gap: 6, padding: "4px 16px 12px",
+          overflowX: "auto", WebkitOverflowScrolling: "touch", scrollbarWidth: "none",
+        }}>
+          {chips.map(c => {
+            const isActive = filter === c.id;
+            return (
+              <button key={c.id} onClick={() => setFilter(c.id)} style={{
+                flexShrink: 0, padding: "8px 12px", minHeight: 36,
+                background: isActive ? "var(--g-ink)" : "var(--g-card)",
+                color: isActive ? "var(--g-paper)" : "var(--g-ink-2)",
+                border: `1px solid ${isActive ? "var(--g-ink)" : "var(--g-rule)"}`,
+                borderRadius: "var(--g-r-pill)", cursor: "pointer",
+                fontFamily: "var(--g-font-mono)", fontSize: 12, fontWeight: 500,
+                letterSpacing: "0.02em", whiteSpace: "nowrap",
+                display: "inline-flex", alignItems: "center", gap: 6,
+              }}>
+                {c.label}
+                <span style={{
+                  fontSize: 10, padding: "1px 5px", borderRadius: 8,
+                  background: isActive ? "rgba(255,255,255,0.18)" : "var(--g-paper-deep)",
+                  color: isActive ? "var(--g-paper)" : "var(--g-ink-3)",
+                }}>{c.n}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Trip Cards */}
+        <div style={{ padding: "0 16px 20px", display: "flex", flexDirection: "column", gap: 10 }}>
+          {filtered.map(t => (
+            <TripCardM key={t.id} trip={t} onMore={() => setSheetOpen(true)}/>
+          ))}
+          {filtered.length === 0 && (
+            <div style={{ padding: "60px 20px", textAlign: "center", color: "var(--g-ink-3)" }}>
+              <div style={{ fontSize: 14, marginBottom: 4 }}>Keine Trips gefunden</div>
+              <div className="mono" style={{ fontSize: 11, color: "var(--g-ink-4)" }}>Filter zurücksetzen oder neuen Trip anlegen</div>
+            </div>
+          )}
+        </div>
+      </ScreenScroll>
+    </MobileShell>
+  );
+}
+
+function TripCardM({ trip, onMore }) {
+  const statusMap = {
+    active:    { label: "aktiv",    dot: "var(--g-accent)" },
+    scheduled: { label: "geplant",  dot: "var(--g-good)" },
+    completed: { label: "fertig",   dot: "var(--g-ink-3)" },
+    draft:     { label: "draft",    dot: "var(--g-ink-4)" },
+  };
+  const st = statusMap[trip.status] || statusMap.draft;
+  const range = trip.to ? `${trip.from} → ${trip.to}` : trip.from;
+  const isActive = trip.status === "active";
+
+  return (
+    <div style={{
+      background: "var(--g-card)",
+      border: "1px solid var(--g-rule)",
+      borderLeft: isActive ? "3px solid var(--g-accent)" : "1px solid var(--g-rule)",
+      borderRadius: "var(--g-r-3)",
+      boxShadow: "var(--g-shadow-1)",
+      overflow: "hidden",
+    }}>
+      <div style={{ padding: "14px 14px 12px", display: "flex", alignItems: "flex-start", gap: 12 }}>
+        <span style={{ width: 9, height: 9, borderRadius: "50%", background: st.dot, marginTop: 6, flexShrink: 0 }}/>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: "flex", alignItems: "baseline", gap: 8, marginBottom: 2 }}>
+            <span style={{ fontSize: 16, fontWeight: 600, letterSpacing: "-0.01em", color: "var(--g-ink)" }}>{trip.name}</span>
+            <span className="mono" style={{ fontSize: 10, color: "var(--g-ink-4)", textTransform: "uppercase", letterSpacing: "0.12em" }}>· {st.label}</span>
+          </div>
+          <div style={{ fontSize: 13, color: "var(--g-ink-2)", marginBottom: 6 }}>{trip.subtitle}</div>
+          <div className="mono" style={{ fontSize: 11, color: "var(--g-ink-3)", letterSpacing: "0.02em" }}>
+            {range} · {trip.stages} {trip.stages === 1 ? "Etappe" : "Etappen"}
+          </div>
+        </div>
+        <IconBtn kind="more" onClick={onMore} label="Aktionen"/>
+      </div>
+      {isActive && (
+        <div style={{
+          display: "flex", gap: 0, borderTop: "1px solid var(--g-rule-soft)",
+          background: "var(--g-card-alt)",
+        }}>
+          <ActionLink label="Briefing senden" icon="send"/>
+          <ActionLink label="Vorschau" icon="external"/>
+          <ActionLink label="Alerts" icon="bell"/>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ActionLink({ label, icon }) {
+  return (
+    <button style={{
+      flex: 1, display: "inline-flex", alignItems: "center", justifyContent: "center",
+      gap: 6, padding: "12px 6px", minHeight: 44,
+      background: "transparent", border: "none", borderRight: "1px solid var(--g-rule-soft)",
+      fontSize: 12, fontWeight: 500, color: "var(--g-ink-2)",
+      fontFamily: "var(--g-font-sans)", cursor: "pointer",
+    }}>
+      <MIcon kind={icon} size={14} color="var(--g-ink-2)"/>
+      {label}
+    </button>
+  );
+}
+
+function TripActionsSheet({ onClose }) {
+  const items = [
+    { icon: "send",   label: "Briefing jetzt senden", sub: "Manueller Trigger" },
+    { icon: "external", label: "Email-Vorschau", sub: "So sieht das nächste Briefing aus" },
+    { icon: "bell",   label: "Alert-Konfiguration", sub: "Schwellen & Δ-Regeln" },
+    { icon: "filter", label: "Wetter-Metriken", sub: "14 Spalten · Preset Alpen" },
+    { icon: "edit",   label: "Bearbeiten", sub: "Wegpunkte, Profil, Kanäle" },
+    { icon: "trash",  label: "Löschen", danger: true },
+  ];
+  return (
+    <Sheet open onClose={onClose} title="KHW 403" eyebrow="Aktionen · aktiver Trip" snap="half">
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        {items.map((it, i) => (
+          <button key={i} style={{
+            display: "flex", alignItems: "center", gap: 14,
+            padding: "14px 4px", minHeight: 56,
+            background: "transparent", border: "none",
+            borderBottom: i < items.length - 1 ? "1px solid var(--g-rule-soft)" : "none",
+            cursor: "pointer", textAlign: "left",
+          }}>
+            <span style={{
+              width: 40, height: 40, borderRadius: "var(--g-r-3)",
+              background: it.danger ? "rgba(168,50,50,0.08)" : "var(--g-paper-deep)",
+              display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0,
+            }}>
+              <MIcon kind={it.icon} size={20} color={it.danger ? "var(--g-bad)" : "var(--g-ink)"}/>
+            </span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 15, fontWeight: 500, color: it.danger ? "var(--g-bad)" : "var(--g-ink)" }}>{it.label}</div>
+              {it.sub && <div style={{ fontSize: 12, color: "var(--g-ink-3)", marginTop: 2 }}>{it.sub}</div>}
+            </div>
+            <MIcon kind="chevron" size={16} color="var(--g-ink-4)"/>
+          </button>
+        ))}
+      </div>
+    </Sheet>
+  );
+}
+
+window.ScreenTripsMobile = ScreenTripsMobile;
+window.TripActionsSheet = TripActionsSheet;

--- a/docs/design/mobile/tokens-reference.css
+++ b/docs/design/mobile/tokens-reference.css
@@ -1,0 +1,109 @@
+/* Gregor 20 — Design Tokens v2
+ * Alpine-modern. CSS-Variables, übergabefähig nach app.css (SvelteKit).
+ * Drop-in: kopiere :root + .dark in src/app.css, ersetze tailwind-Defaults via Theme-Plugin.
+ */
+
+:root {
+  /* Surface (Paper-Palette) */
+  --g-paper:        #f6f4ee;   /* App-Hintergrund — leicht warmes Off-White */
+  --g-paper-deep:   #ecead9;   /* gedämpfter Akzent für Sektionen */
+  --g-card:         #ffffff;   /* Karten, Tabellen */
+  --g-card-alt:     #faf8f1;   /* Zebra, sekundäre Karten */
+  --g-rule:         #d8d3c2;   /* Standard-Linien */
+  --g-rule-soft:    #e7e2d3;   /* sanfte Trennlinien */
+
+  /* Ink (Typografie) */
+  --g-ink:          #1a1a18;   /* Primärtext */
+  --g-ink-2:        #45433d;   /* Sekundärtext, Body */
+  --g-ink-3:        #6b675c;   /* Tertiär, Labels */
+  --g-ink-4:        #9a958a;   /* Hint, Placeholder */
+
+  /* Accent — burnt orange (alpin/markant) */
+  --g-accent:       #c45a2a;
+  --g-accent-deep:  #8c3e1a;
+  --g-accent-soft:  #f3d9c8;
+  --g-accent-tint:  rgba(196, 90, 42, 0.08);
+
+  /* Semantic */
+  --g-good:         #3d6b3a;   /* Wetter ok, low risk */
+  --g-warn:         #c08a1a;   /* Achtung, Schwellwert nahe */
+  --g-bad:          #a83232;   /* Alarm, kritisch */
+  --g-info:         #2c5a8c;   /* neutrale Daten-Highlight */
+
+  /* Wetter-Farben (aus echtem Email-Report abgeleitet) */
+  --g-weather-rain:    #4a7ab8;
+  --g-weather-snow:    #8aa4c0;
+  --g-weather-thunder: #c43a2a;
+  --g-weather-sun:     #d99a2a;
+  --g-weather-cloud:   #9a958a;
+
+  /* Typography */
+  --g-font-sans: "Inter Tight", "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --g-font-mono: "JetBrains Mono", "SF Mono", ui-monospace, "Cascadia Mono", monospace;
+
+  /* Type Scale (1.200 minor third) */
+  --g-text-xs:  11px;
+  --g-text-sm:  13px;
+  --g-text-md:  15px;
+  --g-text-lg:  17px;
+  --g-text-xl:  20px;
+  --g-text-2xl: 24px;
+  --g-text-3xl: 32px;
+  --g-text-4xl: 44px;
+  --g-text-5xl: 60px;
+
+  /* Tracking — bewusst eng für Display, neutral für Body */
+  --g-track-tight: -0.02em;
+  --g-track-normal: 0;
+  --g-track-wide: 0.06em;
+  --g-track-caps: 0.12em;
+
+  /* Spacing — 4px-Grid */
+  --g-s-1:  4px;
+  --g-s-2:  8px;
+  --g-s-3:  12px;
+  --g-s-4:  16px;
+  --g-s-5:  20px;
+  --g-s-6:  24px;
+  --g-s-8:  32px;
+  --g-s-10: 40px;
+  --g-s-12: 48px;
+  --g-s-16: 64px;
+  --g-s-20: 80px;
+
+  /* Radii — bewusst zurückhaltend */
+  --g-r-1: 2px;
+  --g-r-2: 4px;
+  --g-r-3: 6px;
+  --g-r-4: 10px;
+  --g-r-pill: 999px;
+
+  /* Elevation — sehr dezent */
+  --g-shadow-1: 0 1px 0 rgba(26, 26, 24, 0.04), 0 1px 2px rgba(26, 26, 24, 0.04);
+  --g-shadow-2: 0 1px 0 rgba(26, 26, 24, 0.04), 0 4px 14px rgba(26, 26, 24, 0.06);
+  --g-shadow-3: 0 2px 0 rgba(26, 26, 24, 0.04), 0 12px 32px rgba(26, 26, 24, 0.08);
+}
+
+/* Topo-Pattern als CSS-Background — abstrahierte Höhenlinien */
+.g-topo {
+  background-image:
+    radial-gradient(ellipse 800px 400px at 20% 30%, transparent 30%, rgba(26, 26, 24, 0.025) 30.5%, transparent 31%),
+    radial-gradient(ellipse 700px 350px at 22% 32%, transparent 35%, rgba(26, 26, 24, 0.03) 35.5%, transparent 36%),
+    radial-gradient(ellipse 600px 300px at 24% 34%, transparent 40%, rgba(26, 26, 24, 0.035) 40.5%, transparent 41%),
+    radial-gradient(ellipse 900px 450px at 80% 70%, transparent 30%, rgba(26, 26, 24, 0.025) 30.5%, transparent 31%),
+    radial-gradient(ellipse 800px 400px at 78% 68%, transparent 35%, rgba(26, 26, 24, 0.03) 35.5%, transparent 36%);
+  background-color: var(--g-paper);
+}
+
+/* Reset für Demos */
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: var(--g-font-sans);
+  color: var(--g-ink);
+  background: var(--g-paper);
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "ss01", "cv11";
+}
+.mono { font-family: var(--g-font-mono); font-feature-settings: "tnum", "zero"; }
+.tnum { font-variant-numeric: tabular-nums; }


### PR DESCRIPTION
Aufräumen zweier sehr alter offener Pull Requests. Dieser PR sichert das einzige Stück daraus, das noch Wert hat.

## Warum PR #275 nicht gemergt wird

Offen seit dem 2026-05-20, **1 725 Commits** hinter `main`. Sein Zweck ist erfüllt: alle acht daraus abgeleiteten Issues (#267–#274) sind **geschlossen**.

🔴 Ein Merge wäre zudem **schädlich**: Der PR enthält `docs/reference/design_system.md` in der Mai-Fassung. An dieser Datei hängen seither **fünf Commits** — Farbkorrektur #277, Token-Aufräumen #541/#543/#544, Doku-Konsolidierung #1341. Ein Merge würde all das zurückdrehen.

## Was übersehen wurde

Der PR enthält die vollständige **Mobile-Design-Vorlage** („Mobile-Erweiterung v1") — und die liegt **nirgends sonst im Repo**. Die PR-Beschreibung behauptet, sie sei „dauerhaft archiviert"; tatsächlich existierte `docs/design/mobile/` in `main` nie.

**Übernommen: 13 Dateien** — Übersichts-HTML, README, 10 Screen-Vorlagen, `tokens-reference.css`.

**Bewusst nicht übernommen**, je mit Begründung in `docs/design/mobile/HERKUNFT.md`:
- drei inhaltlich **identische** Dubletten (per Prüfsumme verglichen, nicht per Dateiname)
- `screen-waypoint-editor-mobile.jsx` — das Repo führt eine **neuere** Fassung (21,7 kB gegen 15,5 kB)
- `design_system.md` (s. o.)
- 97 Screenshots und das Audit-Werkzeug — Momentaufnahme von **vor** den Korrekturen; im Diff des geschlossenen PR dauerhaft einsehbar

## Wert der Vorlage

Sie ist das Soll-Bild für die mobile Ansicht (375 px primär). Die `.jsx`-Dateien sind Entwurfsartefakte, **kein lauffähiger Code** — das Frontend ist Svelte. Sie dienen dem Abgleich „sieht die gebaute Ansicht aus wie vorgesehen".

Reine Doku, kein Code berührt.

Refs #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzaMdw2Cnt9o6iVx5QRwHD