### PR TITLE
fix(#1555): offene Tier-Freischalt-Anträge werden dauerhaft sichtbar

### DIFF
--- a/docs/context/fix-1555-tier-antrag-sichtbarkeit.md
+++ b/docs/context/fix-1555-tier-antrag-sichtbarkeit.md
@@ -1,0 +1,249 @@
+# Context: Sichtbarkeit offener Tier-Freischalt-Anträge (#1555, Teil 1)
+
+## Request Summary
+
+Ein Antrag auf Level-Wechsel (`POST /api/auth/tier-change-request`) kann beliebig
+lange unbearbeitet liegen bleiben, ohne dass der **Betreiber** je wieder darauf
+gestoßen wird. Im konkreten Fall lag ein Premium-Antrag vom 2026-07-07 vier
+Wochen unbemerkt — mit der Folge, dass das Konto im Free-Tier (2 Alarme/Tag)
+feststeckte und während einer laufenden Tour keine NowCast-Alarme zugestellt
+bekam.
+
+## Abgrenzung zum parallel laufenden Workflow
+
+**#1555 wird von zwei Sessions bearbeitet.** Der zweite Teil des Issues
+(NowCast-Vorrang im geteilten Tagesbudget) läuft seit 2026-08-07 07:48 als
+eigener Workflow `fix-1555-nowcast-alert-priority` (Worktree
+`silly-growing-patterson`, Spec freigegeben, RED fertig, in Implementierung).
+Dieser Workflow hier fasst **ausschließlich** die Antrags-Sichtbarkeit an und
+lässt `src/services/alert_daily_limit.py`, `user_tier.py`, `trip_alert.py`,
+`compare_alert.py` unberührt.
+
+| Teilthema | Workflow |
+|---|---|
+| NowCast-Vorrang im Tagesbudget (Python-Core) | `fix-1555-nowcast-alert-priority` — **nicht hier** |
+| Sichtbarkeit offener Tier-Anträge (Go + ggf. Frontend) | dieser Workflow |
+
+## 🔴 Wichtigste Korrektur gegenüber der Issue-Formulierung
+
+Das Issue sagt, es werde „nirgends sichtbar, dass ein Antrag noch offen ist".
+Für die **Nutzer**-Seite stimmt das nicht — gemessen, nicht vermutet:
+
+`frontend/src/routes/account/+page.svelte:629-632` zeigt bereits
+„Level-Wechsel zu \<Level\> beantragt — wird vom Betreiber geprüft", abgeleitet
+aus `pendingTier` (`requested_tier` ≠ `tier`). Diese Anzeige kam mit #1071 und
+funktioniert.
+
+**Die Lücke liegt allein auf der Betreiber-Seite:** beim Antrag geht **genau
+eine** Mail an den PO raus (`internal/handler/auth.go:825-857`, Builder
+`internal/mail/tier_change.go:9-44`). Danach passiert nichts mehr — keine
+Erinnerung, keine Liste offener Anträge, kein Status-Endpoint-Feld, keine
+Frist. Geht diese eine Mail unter, ist der Antrag für immer unsichtbar.
+
+Konsequenz für die Spec: **keine Nutzer-Anzeige nachbauen, die es schon gibt.**
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `internal/handler/auth.go:779-859` | `RequestTierChangeHandler` — speichert `requested_tier`+`requested_at`, feuert die einmalige PO-Mail |
+| `internal/handler/auth.go:487-492` | `toProfileResponse()` — normalisiert fehlendes `tier` still auf `"free"` |
+| `internal/mail/tier_change.go:9-44` | `BuildTierChangeRequestMail` — Betreff, Text, Hinweis „tier-Feld manuell setzen" |
+| `internal/model/user.go:22-27` | Felder `Tier`, `RequestedTier`, `RequestedAt *time.Time` |
+| `internal/store/user.go:48-79` | `LoadUser`/`SaveUser` — JSON pro Nutzer unter `data/users/<id>/user.json` |
+| `internal/router/router.go:68` | Route-Registrierung `/api/auth/tier-change-request` |
+| `internal/handler/scheduler_status.go:11-15` | Status-Endpoint — heute ohne jeden Tier-Bezug |
+| `internal/scheduler/scheduler.go:611-680` | `Status()` — liefert `jobs`, `briefing_health`, `warn_service_health`, `forecast_budget` |
+| `internal/scheduler/scheduler.go:145-153` | Cron-Registrierung, Muster für einen etwaigen neuen Job |
+| `frontend/src/routes/account/+page.svelte:626-660` | Bestehende Nutzer-Anzeige + Antragsformular — **Referenz, nicht Baustelle** |
+| `internal/handler/auth_tier_change_test.go` | Bestehende Testabdeckung des Antragswegs |
+
+## Existing Patterns
+
+- **Freischaltung ist bewusst manuell.** Es existiert **kein** Code-Pfad, der
+  `tier` setzt — breit gegrept, kein Endpoint, kein CLI, kein Script. Der PO
+  bearbeitet `user.json` von Hand. Das ist Absicht (die Mail sagt es
+  ausdrücklich), begrenzt aber jede Lösung: ein „Erledigt"-Zustand kann nur
+  daran erkannt werden, dass `tier` == `requested_tier` wurde bzw.
+  `requested_tier` verschwand.
+- **Observability-Muster im Haus:** `/api/scheduler/status` sammelt
+  Gesundheits-Blöcke (`briefing_health`, `warn_service_health`,
+  `forecast_budget`) — das etablierte Andockmuster für „etwas stimmt nicht,
+  seit wann". Bislang ohne Nutzer-Bezug.
+- **Heartbeat-Konvention (global):** Pings nur bei fachlichem Erfolg
+  (Readiness statt Liveness). Für einen neuen Cronjob relevant.
+- **Mail-Versand:** SMTP mit Fallback, asynchron in Goroutine, 20s Timeout,
+  Fehler nur geloggt — Antrag schlägt nie wegen Mail-Problemen fehl
+  (`auth.go:846-857`). Genau diese Nachsicht macht den stillen Verlust möglich.
+
+## Dependencies
+
+- **Upstream:** `store.LoadUser`/`SaveUser`, `model.User`, Config `PoEmail`,
+  SMTP-Konfiguration, ggf. Scheduler-Registrierung.
+- **Downstream:** Wer `tier` liest, ist von dieser Änderung **nicht** betroffen
+  (`src/services/user_tier.py` → `daily_alert_limit()`, `sms_allowed()`;
+  `internal/model/tier.go` → `SmsAllowed()`). Diese Konsumenten gehören zum
+  Nachbar-Workflow bzw. bleiben ganz unberührt.
+
+## Existing Specs
+
+| Dokument | Aussage | Verlässlichkeit |
+|---|---|---|
+| `docs/specs/modules/epic_user_tiers_overview.md` | Epic #1067, Slices #1068–#1071; Free 2/Standard 4/Premium unbegrenzt; Antragsweg als Slice #1071 | Status `draft`, aber **vollständig live** seit 2026-07-07 — Status irreführend |
+| `docs/specs/modules/alert_daily_limit.md` | #1070 Tageslimit-Mechanik | live; **Zuständigkeit des Nachbar-Workflows** |
+| `docs/specs/modules/feat_1459_alert_protokoll.md` | `reason`-Werte inkl. `nowcast`; `daily_limit` als Nicht-Zustellungsgrund in S1 **unprotokolliert** | live seit 2026-08-02 |
+| `docs/reference/api_contract.md` | DTO-Vertrag — bei neuem Feld in Profile/Status-Antwort zu pflegen | hoch |
+
+Kein ADR zu Tiers, Antragsprozess oder Betreiber-Observability gefunden.
+
+## Risks & Considerations
+
+- **Doppelarbeit mit der Parallel-Session.** Strikt Go/Frontend bleiben; die
+  Python-Alarmpfade sind fremdes Revier.
+- **Datenschema `user.json`:** Falls ein Feld ergänzt wird — Read-Modify-Write
+  mit Merge, niemals Replace (BUG-DATALOSS-GR221/#102). `internal/model/user.go`
+  löst den Pre-Snapshot-Hook aus.
+- **Mandantentrennung:** Eine Übersicht offener Anträge ist per Definition
+  nutzerübergreifend und darf deshalb **nicht** über die normalen,
+  user-scoped Endpoints laufen. Wer sie sehen darf, ist eine offene
+  Designfrage — ohne Antwort droht ein Cross-User-Leck.
+- **Kein Freischalt-Endpoint vorhanden.** Ob dieser Workflow einen bauen soll
+  oder nur sichtbar macht, ist die zentrale offene Frage für `/20-analyse`.
+  Ein Freischalt-Endpoint wäre eine Auth-relevante Erweiterung mit deutlich
+  größerem Blast Radius.
+- **Regel-Budget:** Ein neuer Cronjob braucht laut globaler Konvention einen
+  BetterStack-Heartbeat; eine neue Erinnerungsmail darf nicht zur
+  Dauerbeschallung werden.
+- **Verifikation:** Eine Erinnerungsmail ist auf Staging nur über das
+  Test-Postfach `gregor-test@henemm.com` (`GZ_TEST_IMAP_*`) nachweisbar —
+  nicht über die Prod-Adresse des PO.
+
+---
+
+# Analysis
+
+## Type
+
+**Bug** (nutzersichtbares Fehlverhalten mit Sicherheitsfolge), behoben durch
+eine kleine Feature-Ergänzung.
+
+## Gemessene Produktivdaten — die Größenordnung des Problems
+
+- **3 echte Nutzerkonten** (`henning`, `steffi`, `default`) plus ein
+  Validator-Testkonto. Kein Mehrbenutzer-Betrieb im großen Stil.
+- **Aktuell 0 offene Anträge.** Nur `henning` hat überhaupt ein `tier`-Feld
+  (`premium` — die Sofortmaßnahme aus dem Issue); `steffi` und `default` haben
+  gar keins und laufen still auf dem `free`-Fallback.
+- Anträge sind also **sehr selten** (ein bekannter Fall seit Livegang von
+  #1071 am 2026-07-07). Jede Lösung, die ein Rollenmodell oder eine
+  Verwaltungsoberfläche voraussetzt, wäre für diese Größenordnung deutlich
+  überdimensioniert.
+
+## 🔴 Zusätzlicher Befund: Die Benachrichtigung geht an ein anderes Postfach
+
+`GZ_PO_EMAIL` ist in der Produktions-`.env` auf **`henning.emmrich@gmail.com`**
+gesetzt (`internal/config/config.go:39,52`, Präfix `GZ` bestätigt — die
+Variable greift also wirklich). Die einzige Benachrichtigung über einen
+Antrag landet damit **nicht** in einem `henemm.com`-Postfach.
+
+Das ist ein plausibler Teil der Ursache, warum die Mail vier Wochen unbemerkt
+blieb — und es ist eine offene Frage an den PO, kein technischer Mangel:
+Wenn dieses Gmail-Postfach selten gelesen wird, ist „mehr Mails dorthin
+schicken" wirkungslos, und die Adresse zu korrigieren wäre ein Ein-Zeilen-Fix
+ohne jede Code-Änderung.
+
+## 🔴 Der Status-Endpoint ist öffentlich — und hat dafür ein fertiges Muster
+
+`/api/scheduler/status` ist in `internal/middleware/auth.go:34` **von der
+Auth-Middleware ausgenommen**, also ohne Login erreichbar. Das Haus hat dafür
+bereits eine erprobte Leitplanke: `internal/scheduler/briefing_health.go:61-67`
+aggregiert über **alle** Nutzer, gibt aber ausdrücklich nur Zahlen, eine Dauer
+und einen Zeitstempel heraus — keine `user_id`, kein Trip, kein Name (#252).
+Bewacht wird das durch einen eigenen Test, der den Response-Body auf
+Nutzer-Identifikatoren prüft.
+
+Damit ist die im Kontext notierte Cross-User-Sorge für diesen Weg gelöst:
+Ein Block `{open_count, oldest_age_days}` verrät nicht, **wer** etwas
+beantragt hat.
+
+## Affected Files (Empfehlung B + Alarmweg)
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `internal/scheduler/tier_request_health.go` | CREATE | `TierRequestHealth()` — zählt offene Anträge über alle Nutzer, liefert nur Zahlen; 1:1 nach dem Muster von `briefing_health.go` |
+| `internal/scheduler/tier_request_health_test.go` | CREATE | Wirkungs- **und** Datenschutz-Test (Vorbild: `briefing_health_test.go`) |
+| `internal/scheduler/scheduler.go:676-678` | MODIFY | Neuen Schlüssel in die `Status()`-Map einhängen |
+| `docs/reference/api_contract.md:1074ff` | MODIFY | Antwortformat des Status-Endpoints nachziehen |
+| *(Fremd-Repo)* `henemm-infra/scripts/check-gregor20.sh` | MODIFY | Auswertung des neuen Blocks → nur so entsteht ein echter Alarm |
+
+## Scope Assessment
+
+- Files: 4 im Repo (+1 im Fremd-Repo `henemm-infra`)
+- Estimated LoC: ~+90/-0 im Repo (Code ~40, Tests ~50); Doku zählt nicht
+- Risk Level: **LOW** — reine additive Lesefunktion, kein Schreibpfad, kein
+  neues Berechtigungskonzept, kein Eingriff in Alarm- oder Versandwege
+
+## Technical Approach
+
+**Empfehlung: Option B (Status-Block) plus Auswertung im bestehenden Monitor.**
+
+Der Strategie-Agent empfiehlt B allein und schlägt vor, BetterStack direkt auf
+das Feld zu setzen. **Diese Ergänzung übernehme ich so nicht**: BetterStack-
+Uptime-Checks sind auf Erreichbarkeit und Antwortinhalt ausgelegt, nicht auf
+numerische Schwellen in einem JSON-Feld. Der im Haus **nachweislich** dafür
+gebaute Weg ist `check-gregor20.sh` — das Script liest `/api/scheduler/status`
+bereits aus (Zeile 119) und wertet die Antwort in Python mit `issues`- und
+`soft`-Kategorien aus. Dort gehört die Schwellenprüfung hin.
+
+Das ist zugleich die wichtigste Einschränkung dieser Lösung: **Option B allein
+wirkt nicht.** Ein Zahlenfeld, in das niemand schaut, ersetzt eine Mail, die
+niemand liest, nicht — es verlagert das Nicht-Hinschauen nur. Erst die
+Auswertung im Monitor macht daraus einen Alarm. Da diese im Fremd-Repo
+`henemm-infra` liegt, braucht es dort ein Issue bzw. eine MQ-Nachricht; dieser
+Workflow kann sie nicht selbst liefern.
+
+**Warum nicht die Alternativen** (Bewertung des Strategie-Agenten, von mir
+geteilt):
+
+- **Erinnerungsmail (A):** versucht ein Versagen des Mail-Kanals mit mehr Mails
+  desselben Kanals zu heilen. Braucht Cronjob samt Heartbeat-Pflicht und
+  Drossel-Logik (~120–180 LoC) und riskiert Alarm-Müdigkeit. Sinnvoll erst,
+  wenn die Postfach-Frage oben geklärt ist.
+- **Betreiber-Ansicht (C)** und **bedienbare Freischaltung (D):** beide setzen
+  eine Admin-Rolle voraus, die im Datenmodell schlicht nicht existiert. D
+  schafft zusätzlich einen mächtigen neuen Schreibpfad auf fremde Konten
+  (Privilegieneskalations-Risiko). Für drei Nutzer und ~einen Antrag im Monat
+  steht das in keinem Verhältnis. **D löst das gemeldete Problem ohnehin
+  nicht:** ein bequem genehmigbarer Antrag bleibt genauso liegen, wenn man
+  nichts von ihm weiß. Das ist ein eigenständiges Komfort-Feature mit eigener
+  Spec.
+
+## Wie die Wirkung nachgewiesen wird
+
+Nicht „die Funktion existiert", sondern: zwei Nutzer mit gesetztem
+`requested_tier` (einer mit altem `requested_at`) anlegen → `Status()` aufrufen
+→ `open_count == 2` und plausibles `oldest_age_days`. Der Test muss scheitern
+können — insbesondere gegen die Mutation „`requested_tier == ""` wird nicht
+herausgefiltert" und „ein bereits freigeschalteter Antrag (`tier ==
+requested_tier`) zählt weiter mit". Dazu der Datenschutz-Test nach Vorbild
+`TestBriefingHealthResponseContainsNoUserIdentifiers`.
+
+## PO-Entscheidungen (2026-08-07, verbindlich)
+
+- [x] **`GZ_PO_EMAIL` wird auf `henning@henemm.com` geändert.** Bisher
+      `henning.emmrich@gmail.com`. Produktions-`.env`, greift erst nach
+      Neustart von `gregor-api`. Eigener Lieferpunkt dieses Workflows.
+- [x] **Überfälligkeitsfrist: 7 Tage.** Ein Antrag, der älter als 7 Tage ist
+      und noch nicht freigeschaltet wurde, gilt als überfällig.
+- [x] **Monitor-Teil:** MQ-Nachricht an die `infra`-Instanz **plus** Issue in
+      `henemm-infra` (Nachricht macht aufmerksam, Issue hält den Auftrag fest).
+      `infra` ist eine Claude-Code-Instanz, kein Mensch — ein Issue allein
+      erreicht sie nicht. Erfolgt am Ende der Kette, blockiert die Spec nicht.
+
+## Lieferumfang dieses Workflows
+
+1. `TierRequestHealth()` + Einbindung in `Status()` (Go, dieses Repo)
+2. Tests: Wirkung + Datenschutz
+3. `docs/reference/api_contract.md` nachziehen
+4. `GZ_PO_EMAIL` in der Produktions-`.env` korrigieren + `gregor-api` neu starten
+5. MQ-Nachricht + Issue an/in `henemm-infra` für die Schwellenprüfung (7 Tage)

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -1116,7 +1116,11 @@ Returns current scheduler state with per-job metadata (next_run, last_run).
         "last_skipped_at": "2026-08-01T13:00:00Z"
       }
     }
-  ]
+  ],
+  "tier_request_health": {
+    "open_count": 1,
+    "oldest_open_age_hours": 192.4
+  }
 }
 ```
 
@@ -1137,6 +1141,9 @@ Returns current scheduler state with per-job metadata (next_run, last_run).
 | jobs[].overlap | object \| null (Issue #1447 S2a) | Present **only** when at least one tick has been skipped since the last executed run of this job, because the previous run of the same job ID was still in progress (`sync.Mutex.TryLock()` in `recordRun`). Absent field means no overlap is occurring — never an error signal. |
 | jobs[].overlap.skipped_since_last_run | int | Number of consecutive ticks skipped since the last executed run; resets to 0 (and the `overlap` field disappears) the next time the job actually runs, regardless of outcome |
 | jobs[].overlap.last_skipped_at | datetime | ISO-8601 UTC timestamp of the most recently skipped tick |
+| tier_request_health | object (Issue #1555) | Privacy-safe aggregate of open tier-change requests (`POST /api/auth/tier-change-request`, Issue #1071) across ALL users. Purely numeric — the endpoint is public, so no `user_id`, `display_name` or e-mail ever appears here (#252). A request counts as **done** when `requested_tier` is empty OR equals the effective `tier`; only otherwise it is **open**. |
+| tier_request_health.open_count | int | Number of currently open tier-change requests across all users. `0` when none are pending. |
+| tier_request_health.oldest_open_age_hours | float | Age in hours of the **oldest** open request (from its `requested_at`); `0.0` when `open_count` is 0 or no open request carries a `requested_at`. Raw hours only — the 7-day overdue threshold is evaluated by the external monitor (`check-gregor20.sh`), not here, analogous to `briefing_health`. |
 
 **Error Responses:**
 

--- a/docs/specs/modules/fix_1555_tier_antrag_sichtbarkeit.md
+++ b/docs/specs/modules/fix_1555_tier_antrag_sichtbarkeit.md
@@ -1,0 +1,220 @@
+---
+entity_id: fix_1555_tier_antrag_sichtbarkeit
+type: bugfix
+created: 2026-08-07
+updated: 2026-08-07
+status: draft
+workflow: fix-1555-tier-antrag-sichtbarkeit
+---
+
+# Sichtbarkeit offener Tier-Freischalt-Anträge
+
+## Approval
+
+- [x] Approved — PO-Freigabe („go") am 2026-08-07, alle 9 ACs auf Deutsch vorgelegt
+
+## Purpose
+
+Ein Nutzer-Antrag auf Level-Wechsel (`POST /api/auth/tier-change-request`) löst
+heute **genau eine** Mail an den Betreiber aus und danach nie wieder etwas —
+es gibt keinen Code-Pfad, der ihn erneut sichtbar macht. Geht diese eine Mail
+unter, bleibt der Antrag für immer unbemerkt. Real geschehen: ein Antrag lag
+vier Wochen unbemerkt, wodurch ein Nutzer im Free-Tier (2 Alarme/Tag)
+feststeckte und während einer laufenden Bergtour keine akuten Wetter-Alarme
+bekam. Diese Spec macht offene Anträge im bestehenden, bereits beobachteten
+Status-Endpoint dauerhaft sichtbar — ohne dabei preiszugeben, *wer* einen
+Antrag gestellt hat (der Endpoint ist ohne Login erreichbar).
+
+**Nicht Gegenstand:** Die Nutzer-seitige Anzeige „Level-Wechsel beantragt —
+wird vom Betreiber geprüft" existiert bereits seit #1071
+(`frontend/src/routes/account/+page.svelte:629-632`) und wird nicht
+angefasst. Der zweite Teil von Issue #1555 (NowCast-Vorrang im geteilten
+Tagesbudget, Python-Core) läuft als eigener Workflow
+`fix-1555-nowcast-alert-priority` und ist hier ebenfalls nicht Gegenstand.
+
+## Source
+
+- **File:** `internal/scheduler/tier_request_health.go` (neu)
+- **Identifier:** `func (s *Scheduler) TierRequestHealth() map[string]any`
+
+## Estimated Scope
+
+- **LoC:** ~105 (Code ~55 inkl. `EffectiveTier`-Umzug, Tests ~50)
+- **Files:** 7 im Repo (siehe Scope-Tabelle) + 1 Fremd-Repo-Auftrag (nicht Teil dieser Lieferung)
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `internal/scheduler/scheduler.go` (`Status()`) | Go-Funktion | Hängt `tier_request_health` als neuen Schlüssel in die bestehende Status-Map ein — 1:1 nach dem Muster von `briefing_health`/`warn_service_health`/`forecast_budget` |
+| `internal/store/user.go` (`ListUserIDs`, `LoadUser`) | Go-Funktion | Liest alle registrierten Nutzer und deren `user.json` |
+| `internal/model/user.go` (`User.Tier`, `User.RequestedTier`, `User.RequestedAt`) | Datenmodell | Quelle der Offen/Erledigt-Auswertung |
+| `internal/model/tier.go` (`EffectiveTier`, **neu zu exportieren**) | Go-Funktion | Normalisiert ein leeres/ungültiges `tier` auf `"free"` — dieselbe Regel muss die neue Auswertung anwenden, sonst driften Anzeige und Antragslogik auseinander. Liegt heute als **unexported** `effectiveTier` in `internal/handler/auth.go:767` und ist aus `package scheduler` **nicht erreichbar** — siehe Implementation Details |
+| `internal/mail/tier_change.go` (`BuildTierChangeRequestMail`) | Go-Funktion | Bedienungsanleitung an den PO — wird um den Hinweis „auch `requested_tier` entfernen" ergänzt |
+| `internal/middleware/auth.go:34` | Middleware | Bestätigt: `/api/scheduler/status` ist von der Auth-Ausnahme erfasst, also öffentlich — bindet die Datenschutz-Anforderung |
+| *(Fremd-Repo)* `henemm-infra/scripts/check-gregor20.sh:119` | Monitor-Script | Liest `/api/scheduler/status` bereits aus; muss die 7-Tage-Schwelle auswerten, damit ein echter Alarm entsteht — **nicht Teil dieser Lieferung**, siehe Known Limitations |
+
+## Scope
+
+### Affected Files
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `internal/scheduler/tier_request_health.go` | CREATE | `TierRequestHealth()` — aggregiert offene Anträge über alle Nutzer, liefert nur Zahlen (kein `user_id`/Name/E-Mail); 1:1 nach dem Muster von `briefing_health.go:67-149` |
+| `internal/scheduler/tier_request_health_test.go` | CREATE | Wirkungs-, Rand- und Datenschutz-Tests (Vorbild `briefing_health_test.go`) |
+| `internal/scheduler/scheduler.go:672-680` | MODIFY | Neuen Schlüssel `"tier_request_health": s.TierRequestHealth()` in die `Status()`-Map einhängen |
+| `internal/model/tier.go` | MODIFY | `effectiveTier` aus `handler` hierher als exportiertes `EffectiveTier()` heben (~6 LoC) — Voraussetzung dafür, dass der Scheduler dieselbe Normalisierung nutzt statt einer Kopie |
+| `internal/handler/auth.go:765-772,806` | MODIFY | Lokale `effectiveTier`-Definition entfernen, Aufrufstelle auf `model.EffectiveTier` umstellen — Verhalten unverändert |
+| `internal/mail/tier_change.go:22,34` | MODIFY | Hinweistext um „auch `requested_tier` entfernen" ergänzen (Plain- und HTML-Teil) |
+| `internal/mail/tier_change_test.go` | CREATE | Prüft, dass der Freigabe-Hinweis beide Felder (`tier` UND `requested_tier`) nennt |
+| `docs/reference/api_contract.md` (Abschnitt „12) Scheduler Status Endpoint", ab Zeile 1074) | MODIFY | Neues Antwortfeld `tier_request_health` dokumentieren |
+
+**Außerhalb des Repos, aber Teil des Lieferumfangs (kein Git-Diff):**
+
+| Ziel | Change Type | Description |
+|------|-------------|-------------|
+| Produktions-`.env` auf dem Server (nicht versioniert) | MODIFY | `GZ_PO_EMAIL` von `henning.emmrich@gmail.com` auf `henning@henemm.com`; danach `gregor-api` neu starten, damit die Config-Änderung greift (`internal/config/config.go:39`) |
+| `henemm-infra` (Fremd-Repo) | MQ-Nachricht + Issue | Auftrag an die `infra`-Instanz: `check-gregor20.sh` um die 7-Tage-Schwellenprüfung auf `tier_request_health` erweitern — **erst dadurch entsteht ein echter Alarm**, siehe Known Limitations |
+
+### Estimated Changes
+
+- Files: 6 im Repo (4 Code/Test, 2 Doku/Test-Mailtext)
+- LoC: +90/-4 im Repo (Doku zählt nicht gegen das LoC-Limit)
+
+## Implementation Details
+
+**Offen-Definition (nach Nachtrag, robust gegen abweichend gewährte Level):**
+Ein Antrag gilt als **erledigt**, wenn `RequestedTier == ""` **ODER**
+`effectiveTier(Tier) == RequestedTier`. Nur wenn `RequestedTier != ""` **und**
+sich von `effectiveTier(Tier)` unterscheidet, zählt der Antrag als **offen**.
+Das deckt beide in der Praxis beobachteten Freigabe-Handhabungen ab (PO setzt
+`tier` und lässt `requested_tier` stehen → über `tier == requested_tier`
+erkannt; PO setzt `tier` und löscht `requested_tier` → über die leere Prüfung
+erkannt) und vermeidet, dass eine reine „`requested_tier` nicht leer"-Prüfung
+einen längst erledigten Antrag für immer als offen zählt.
+
+**Voraussetzung: `effectiveTier` muss erst erreichbar werden.** Die
+Normalisierung liegt heute als **unexported** `effectiveTier` in
+`internal/handler/auth.go:767` (package `handler`) und ist aus
+`package scheduler` nicht aufrufbar. Sie wird deshalb nach
+`internal/model/tier.go` als exportiertes `model.EffectiveTier(tier string) string`
+gehoben — dort steht mit `SmsAllowed()` bereits die verwandte Tier-Logik. Die
+einzige bestehende Aufrufstelle (`auth.go:806`) wird umgestellt; Verhalten
+bleibt identisch. **Die Logik darf nicht im Scheduler kopiert werden** — eine
+zweite Kopie driftet unweigerlich von der Anzeige weg und ist genau der
+Fehlertyp, den diese Spec verhindern soll.
+
+`TierRequestHealth()` folgt dem Aufbau von `BriefingHealth()`
+(`internal/scheduler/briefing_health.go:67-149`):
+
+1. `s.store.ListUserIDs()` liefert alle Nutzer mit `user.json`.
+2. Pro Nutzer `s.store.LoadUser(id)`; liefert `LoadUser` einen Fehler oder
+   `nil` (fehlende/kaputte `user.json`), wird dieser Nutzer übersprungen —
+   **fail-soft**, ein einzelner defekter Datensatz darf die Gesamtauswertung
+   nicht kippen (Vorbild `briefing_health.go:85`).
+3. Ist der Antrag laut obiger Definition offen: `openCount++`; ist
+   `RequestedAt` gesetzt, fließt sein Alter in die Ältester-Antrag-Berechnung
+   ein (`if !haveOldest || requestedAt.Before(oldest)`).
+4. Rückgabe ausschließlich als Zahlen/Dauer — kein `user_id`, kein
+   `display_name`, keine E-Mail:
+
+```
+map[string]any{
+  "open_count":            int,
+  "oldest_open_age_hours": float64,  // 0.0 wenn open_count == 0
+}
+```
+
+Die 7-Tage-Überfälligkeitsschwelle wird **nicht** in diesem Endpoint
+kodiert — analog zum bestehenden Muster (`briefing_health` liefert rohe
+Stunden, keine Ampel-Bewertung). Die Schwellenprüfung gehört laut
+PO-Entscheidung in den externen Monitor (`check-gregor20.sh`, Fremd-Repo,
+separater Lieferpunkt).
+
+`scheduler.go`'s `Status()` bekommt einen zusätzlichen Map-Eintrag
+`"tier_request_health": s.TierRequestHealth()`, analog zu den drei
+bestehenden Health-Blöcken in derselben Zeile.
+
+Der Mailtext in `internal/mail/tier_change.go` (Zeilen 22 Plain, 34 HTML)
+wird von „Zum Freigeben das tier-Feld in der user.json dieses Nutzers manuell
+setzen." auf einen Wortlaut erweitert, der ausdrücklich beide Felder nennt
+(`tier` setzen **und** `requested_tier` entfernen).
+
+## Expected Behavior
+
+- **Input:** GET `/api/scheduler/status` (kein Auth-Header nötig, Endpoint ist öffentlich)
+- **Output:** bestehende Status-Antwort plus neuer Schlüssel `tier_request_health: {open_count, oldest_open_age_hours}`
+- **Side effects:** keine — reine Lesefunktion, kein Schreibpfad, kein neuer Cronjob, keine neue Mail
+
+## Acceptance Criteria
+
+- **AC-1:** Given es liegen keine offenen Level-Wechsel-Anträge vor / When `/api/scheduler/status` aufgerufen wird / Then meldet `tier_request_health.open_count == 0` und `oldest_open_age_hours == 0.0`, nicht Fehler oder ein fehlendes Feld.
+  - Test: Zwei Nutzer ohne `requested_tier` anlegen, echten HTTP-Roundtrip gegen `Status()` fahren, Nullwerte prüfen.
+
+- **AC-2:** Given **zwei** Nutzer haben offene Anträge — einer vor 8 Tagen, einer vor 2 Stunden / When der Status-Endpoint aufgerufen wird / Then zeigt `oldest_open_age_hours` das Alter des **älteren** Antrags (über 168 Stunden), nicht das des jüngeren, und `open_count == 2`.
+  - Test: Zwei Nutzer anlegen, `RequestedAt` auf `time.Now().Add(-8*24*time.Hour)` bzw. `-2*time.Hour`; `open_count == 2` und `oldest_open_age_hours > 168` prüfen.
+  - **Zwingend zwei Anträge:** Mit nur einem offenen Antrag sind „ältester" und „jüngster" derselbe Wert — der Test könnte die Verwechslung dann gar nicht sehen und würde nichts bewachen. Die Mutation `Before` → `After` in der Ältester-Auswahl MUSS diesen Test rot machen.
+
+- **AC-3:** Given ein Nutzer hat gar keinen Antrag gestellt (`requested_tier` leer) / When der Status-Endpoint aufgerufen wird / Then zählt dieser Nutzer nicht mit in `open_count`.
+  - Test: Nutzer ohne `requested_tier`-Feld anlegen, `open_count == 0` erwarten. Mutations-Gegenprobe: eine Implementierung, die auf „`Tier` leer" statt „`RequestedTier` leer" prüft, muss hier scheitern.
+
+- **AC-4:** Given ein Nutzer mit `tier="standard"` und `requested_tier="premium"` wurde vom PO durch Löschen von `requested_tier` als erledigt markiert / When der Status-Endpoint aufgerufen wird / Then zählt dieser Nutzer NICHT mehr als offen.
+  - Test: `user.json` mit `tier="standard"`, `requested_tier=""` (Feld entfernt) anlegen, `open_count == 0` erwarten.
+
+- **AC-5:** Given ein Nutzer mit `tier="free"` und `requested_tier="premium"` (Antrag unbearbeitet) / When der Status-Endpoint aufgerufen wird / Then zählt dieser Nutzer als offen.
+  - Test: `user.json` mit `tier="free"`, `requested_tier="premium"` anlegen, `open_count == 1` erwarten. AC-4 und AC-5 zusammen fangen eine Implementierung, die nur auf „`requested_tier` nicht leer" statt auf den Vergleich mit `tier` prüft.
+
+- **AC-6:** Given ein Nutzer wurde bereits exakt mit dem beantragten Level freigeschaltet (`tier == requested_tier`, Feld nicht gelöscht) / When der Status-Endpoint aufgerufen wird / Then zählt dieser Nutzer nicht mehr als offen.
+  - Test: `user.json` mit `tier="premium"`, `requested_tier="premium"` anlegen, `open_count == 0` erwarten. Mutations-Gegenprobe: eine Implementierung, die nur auf „`requested_tier` nicht leer" statt auf Ungleichheit zu `tier` prüft, muss hier scheitern.
+
+- **AC-7:** Given einer von mehreren Nutzern hat eine defekte/nicht parsebare `user.json` / When der Status-Endpoint aufgerufen wird / Then liefert er trotzdem HTTP 200 mit korrekten Zahlen für die übrigen Nutzer, statt Fehler oder Absturz.
+  - Test: Einen Nutzer mit ungültigem JSON in `user.json` anlegen, einen zweiten mit gültigem offenem Antrag; `open_count == 1` (nur der gültige zählt) und HTTP 200 erwarten.
+
+- **AC-8:** Given ein offener Antrag existiert / When die rohe Antwort von `/api/scheduler/status` auf Textebene durchsucht wird / Then enthält sie an keiner Stelle die `user_id`, den `display_name` oder die E-Mail-Adresse des Antragstellers.
+  - Test: Nach Vorbild `TestBriefingHealthResponseContainsNoUserIdentifiers` — Nutzer-ID mit erkennbarem Testpräfix vergeben, `rawBody` auf Enthaltensein dieser ID prüfen (`strings.Contains`), muss `false` sein.
+
+- **AC-9:** Given der Betreiber liest die Freigabe-Mail zu einem Antrag / When er den Hinweistext zum Freigeben liest / Then nennt der Text ausdrücklich beide notwendigen Schritte — `tier` setzen UND `requested_tier` entfernen — in Plain- und HTML-Teil.
+  - Test: `BuildTierChangeRequestMail(...)` aufrufen, `PlainBody` und `HTMLBody` auf das Vorkommen von `"requested_tier"` (oder einer gleichwertigen deutschen Formulierung, die das Entfernen explizit macht) prüfen; der bisherige Text ohne diesen Hinweis muss den Test scheitern lassen.
+
+## Known Limitations
+
+- **Der Status-Block allein wirkt nicht.** Ein Zahlenfeld, in das niemand
+  schaut, ersetzt keine Mail, die niemand liest — es verlagert das
+  Nicht-Hinschauen nur. Erst wenn `check-gregor20.sh` (Fremd-Repo
+  `henemm-infra`) die 7-Tage-Schwelle auf `tier_request_health` auswertet,
+  entsteht ein echter Alarm. Diese Änderung ist **nicht** Teil dieser
+  Lieferung, sondern eine MQ-Nachricht + ein Issue an die `infra`-Instanz.
+- **Abweichend gewährte Level bleiben als offen sichtbar.** Gewährt der PO ein
+  anderes Level als beantragt (z.B. „standard" statt beantragtem „premium")
+  und lässt `requested_tier` dabei stehen, zeigt der Endpoint diesen Antrag
+  weiterhin als offen — bewusst, weil sich „bewusst abweichend gewährt" vom
+  Code aus nicht von „noch nicht bearbeitet" unterscheiden lässt. Die
+  Gegenmaßnahme ist der ergänzte Mailtext (AC-9): Der Hinweis, `requested_tier`
+  in jedem Fall zu entfernen, macht den Fall bei korrekter Befolgung
+  irrelevant.
+- **Keine Erinnerungsmail.** Diese Lösung fügt keinen neuen Cronjob und keine
+  neue Benachrichtigung hinzu — bewusst gegen Alarm-Müdigkeit und die
+  Regel-Budget-Pflicht (neuer Cronjob bräuchte einen BetterStack-Heartbeat).
+- **Keine Freischalt-Funktion.** Der Endpoint macht offene Anträge nur
+  sichtbar; die Freigabe bleibt manuelle Handarbeit an `user.json` — es gibt
+  weiterhin keinen Code-Pfad, der `tier` setzt. Das ist Absicht (siehe
+  Analyse-Dokument, Option D verworfen: Privilegieneskalations-Risiko für
+  drei Nutzerkonten unverhältnismäßig).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Additive Lesefunktion nach einem bereits etablierten,
+  dreifach vorhandenen Muster (`briefing_health`, `warn_service_health`,
+  `forecast_budget` in `internal/scheduler/scheduler.go:672-680`). Kein neuer
+  Architektur-Layer, kein neues Persistenzformat, kein Schreibpfad, keine
+  Änderung an Auth/Mandantentrennung (der Endpoint war bereits vor dieser
+  Änderung öffentlich, die Datenschutz-Leitplanke aus #252 wird nur erneut
+  angewandt, nicht neu erfunden). Ein ADR wäre hier over-engineered — es
+  handelt sich um dieselbe Entscheidungsklasse, die schon durch die
+  bestehenden Health-Blöcke abgedeckt ist.
+
+## Changelog
+
+- 2026-08-07: Initial spec created

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -487,10 +487,8 @@ func toProfileResponse(u *model.User) profileResponse {
 	// Default-Fallback nur am Lesezeitpunkt — kein Schreibpfad setzt "free"
 	// zurück in die user.json (Read-Modify-Write-Prinzip, Issue #1068).
 	// Issue #1074: auch ungültige Werte (Tippfehler, Legacy-Daten) normalisieren.
-	tier := u.Tier
-	if tier != "free" && tier != "standard" && tier != "premium" {
-		tier = "free"
-	}
+	// Issue #1555: eine Quelle für alle Leser — model.EffectiveTier().
+	tier := model.EffectiveTier(u.Tier)
 	return profileResponse{
 		ID:             u.ID,
 		Email:          u.Email,
@@ -762,15 +760,6 @@ func ChangePasswordHandler(s *store.Store, bcryptCost int) http.HandlerFunc {
 	}
 }
 
-// effectiveTier normalisiert den gespeicherten Tier-Wert am Lesezeitpunkt auf
-// free/standard/premium — identischer Fallback wie in toProfileResponse().
-func effectiveTier(tier string) string {
-	if tier != "free" && tier != "standard" && tier != "premium" {
-		return "free"
-	}
-	return tier
-}
-
 // RequestTierChangeHandler nimmt einen Level-Änderungs-Antrag entgegen (Issue
 // #1071). Der Antrag wird per Read-Modify-Write in der user.json vermerkt
 // (requested_tier/requested_at) und löst asynchron eine Benachrichtigungsmail
@@ -803,7 +792,7 @@ func RequestTierChangeHandler(s *store.Store, cfg config.Config) http.HandlerFun
 			return
 		}
 
-		currentTier := effectiveTier(user.Tier)
+		currentTier := model.EffectiveTier(user.Tier)
 		if req.RequestedTier == currentTier {
 			w.WriteHeader(400)
 			w.Write([]byte(`{"error":"already_current_tier"}`))

--- a/internal/handler/auth_tier_change_test.go
+++ b/internal/handler/auth_tier_change_test.go
@@ -102,6 +102,73 @@ func TestRequestTierChange_AlreadyCurrentTier(t *testing.T) {
 	}
 }
 
+// Issue #1555: Bestandskonten (in Produktion z.B. "steffi", "default") haben
+// gar kein tier-Feld. Ihr faktisches Level ist "free" — ein Antrag auf "free"
+// muss deshalb genauso als already_current_tier abgelehnt werden wie bei einem
+// explizit gespeicherten "free". Sonst entsteht ein wirkungsloser offener
+// Antrag, den tier_request_health anschliessend als Rueckstand meldet.
+//
+// Bewacht model.EffectiveTier(user.Tier) in RequestTierChangeHandler: mit
+// rohem user.Tier ("") liefe der Antrag auf 200 durch.
+func TestRequestTierChange_EmptyTierCountsAsFree(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.SaveUser(model.User{ID: "steffi"}); err != nil {
+		t.Fatalf("SaveUser failed: %v", err)
+	}
+
+	h := RequestTierChangeHandler(s, config.Config{PoEmail: "po@example.com"})
+
+	body, _ := json.Marshal(map[string]string{"requested_tier": "free"})
+	req := httptest.NewRequest("POST", "/api/auth/tier-change-request", bytes.NewReader(body))
+	req = req.WithContext(middleware.ContextWithUserID(req.Context(), "steffi"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != 400 {
+		t.Fatalf("expected 400 for free-request of a user without tier field, got %d: %s", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("already_current_tier")) {
+		t.Errorf("expected error 'already_current_tier', got: %s", w.Body.String())
+	}
+
+	// Kein Antrag darf persistiert worden sein.
+	user, err := s.LoadUser("steffi")
+	if err != nil {
+		t.Fatalf("LoadUser failed: %v", err)
+	}
+	if user.RequestedTier != "" {
+		t.Errorf("expected no persisted request, got %q", user.RequestedTier)
+	}
+}
+
+// Gegenstueck: ein Konto ohne tier-Feld darf sehr wohl "standard" beantragen —
+// die Normalisierung darf nicht pauschal jeden Antrag blockieren.
+func TestRequestTierChange_EmptyTierCanRequestStandard(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.SaveUser(model.User{ID: "steffi"}); err != nil {
+		t.Fatalf("SaveUser failed: %v", err)
+	}
+
+	h := RequestTierChangeHandler(s, config.Config{PoEmail: "po@example.com"})
+
+	body, _ := json.Marshal(map[string]string{"requested_tier": "standard"})
+	req := httptest.NewRequest("POST", "/api/auth/tier-change-request", bytes.NewReader(body))
+	req = req.WithContext(middleware.ContextWithUserID(req.Context(), "steffi"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	user, err := s.LoadUser("steffi")
+	if err != nil {
+		t.Fatalf("LoadUser failed: %v", err)
+	}
+	if user.RequestedTier != "standard" {
+		t.Errorf("expected persisted request 'standard', got %q", user.RequestedTier)
+	}
+}
+
 func TestRequestTierChange_TwoUsersIsolated(t *testing.T) {
 	s := newTestStore(t)
 	if err := s.SaveUser(model.User{ID: "user_a", Tier: "free"}); err != nil {

--- a/internal/mail/tier_change.go
+++ b/internal/mail/tier_change.go
@@ -19,7 +19,10 @@ func BuildTierChangeRequestMail(username, currentTier, requestedTier string) Mai
 			"Aktuelles Level: %s\n"+
 			"Gewuenschtes Level: %s\n"+
 			"Beantragt am: %s\n\n"+
-			"Zum Freigeben das tier-Feld in der user.json dieses Nutzers manuell setzen.\n",
+			"Zum Freigeben in der user.json dieses Nutzers BEIDE Schritte ausfuehren:\n"+
+			"1. das Feld tier manuell auf das gewuenschte Level setzen\n"+
+			"2. das Feld requested_tier entfernen (loeschen)\n\n"+
+			"Bleibt requested_tier stehen, gilt der Antrag weiterhin als offen.\n",
 		username, currentTier, requestedTier, ts,
 	)
 	htmlBody := fmt.Sprintf(
@@ -31,7 +34,10 @@ func BuildTierChangeRequestMail(username, currentTier, requestedTier string) Mai
 			`<tr><td style="padding:2px 12px 2px 0"><b>Gew&uuml;nschtes Level</b></td><td>%s</td></tr>`+
 			`<tr><td style="padding:2px 12px 2px 0"><b>Beantragt am</b></td><td>%s</td></tr>`+
 			`</table>`+
-			`<p style="color:#888;font-size:0.85em">Zum Freigeben das <code>tier</code>-Feld in der user.json dieses Nutzers manuell setzen.</p>`+
+			`<p style="color:#888;font-size:0.85em">Zum Freigeben in der user.json dieses Nutzers <b>beide</b> Schritte ausf&uuml;hren: `+
+			`1. das Feld <code>tier</code> manuell auf das gew&uuml;nschte Level setzen, `+
+			`2. das Feld <code>requested_tier</code> entfernen (l&ouml;schen). `+
+			`Bleibt <code>requested_tier</code> stehen, gilt der Antrag weiterhin als offen.</p>`+
 			`</body></html>`,
 		html.EscapeString(username), html.EscapeString(currentTier),
 		html.EscapeString(requestedTier), ts,

--- a/internal/mail/tier_change_test.go
+++ b/internal/mail/tier_change_test.go
@@ -1,0 +1,48 @@
+package mail
+
+import (
+	"strings"
+	"testing"
+)
+
+// TDD RED: Issue #1555 AC-9 — die Freigabe-Mail muss BEIDE noetigen Schritte
+// nennen. Der bisherige Text nennt nur "das tier-Feld ... setzen"; genau
+// deshalb blieb requested_tier in der Praxis stehen und ein laengst erledigter
+// Antrag zaehlte weiter als offen.
+//
+// KEINE Mocks: echter Aufruf von BuildTierChangeRequestMail, echte Bodies.
+func TestTierChangeRequestMailNennsBeideFreigabeSchritte(t *testing.T) {
+	m := BuildTierChangeRequestMail("gz1555-nutzer", "free", "premium")
+
+	teile := []struct {
+		name string
+		body string
+	}{
+		{"PlainBody", m.PlainBody},
+		{"HTMLBody", m.HTMLBody},
+	}
+
+	for _, teil := range teile {
+		if teil.body == "" {
+			t.Fatalf("%s ist leer", teil.name)
+		}
+		lower := strings.ToLower(teil.body)
+
+		// Schritt 1: tier setzen (im Bestand bereits vorhanden).
+		if !strings.Contains(lower, "tier") || !strings.Contains(lower, "setzen") {
+			t.Errorf("%s: Schritt 1 fehlt — Text muss das Setzen des tier-Feldes nennen. Text: %q",
+				teil.name, teil.body)
+		}
+
+		// Schritt 2: requested_tier entfernen (neu, AC-9).
+		if !strings.Contains(lower, "requested_tier") {
+			t.Errorf("%s: Schritt 2 fehlt — Text nennt das Feld requested_tier nicht. Text: %q",
+				teil.name, teil.body)
+		}
+		if !strings.Contains(lower, "entfern") && !strings.Contains(lower, "loesch") &&
+			!strings.Contains(lower, "lösch") {
+			t.Errorf("%s: Schritt 2 unvollstaendig — Text macht das Entfernen/Loeschen nicht explizit. Text: %q",
+				teil.name, teil.body)
+		}
+	}
+}

--- a/internal/model/tier.go
+++ b/internal/model/tier.go
@@ -8,3 +8,18 @@ var smsAllowedTiers = map[string]bool{
 func SmsAllowed(tier string) bool {
 	return smsAllowedTiers[tier]
 }
+
+// EffectiveTier normalisiert den gespeicherten Tier-Wert am Lesezeitpunkt auf
+// free/standard/premium.
+//
+// Liegt hier (und nicht im handler-Paket), damit alle Leser dieselbe
+// Normalisierung benutzen statt driftender Kopien: Profil-Response
+// (toProfileResponse), Antragslogik (RequestTierChangeHandler) und die
+// Auswertung offener Anträge (internal/scheduler/tier_request_health.go,
+// Issue #1555).
+func EffectiveTier(tier string) string {
+	if tier != "free" && tier != "standard" && tier != "premium" {
+		return "free"
+	}
+	return tier
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -676,6 +676,7 @@ func (s *Scheduler) Status() map[string]any {
 		"briefing_health":     s.BriefingHealth(),
 		"warn_service_health": s.WarnServiceHealth(),
 		"forecast_budget":     s.ForecastBudgetHealth(),
+		"tier_request_health": s.TierRequestHealth(),
 	}
 }
 

--- a/internal/scheduler/tier_request_health.go
+++ b/internal/scheduler/tier_request_health.go
@@ -1,0 +1,64 @@
+package scheduler
+
+import (
+	"time"
+
+	"github.com/henemm/gregor-api/internal/model"
+)
+
+// TierRequestHealth aggregiert offene Level-Wechsel-Anträge (Issue #1071) über
+// ALLE Nutzer zu einer rein numerischen Zusammenfassung für den öffentlichen
+// /api/scheduler/status-Endpoint. Issue #1555.
+//
+// Ein Antrag gilt als ERLEDIGT, wenn requested_tier leer ist ODER
+// model.EffectiveTier(tier) dem beantragten Level entspricht — das deckt beide
+// in der Praxis beobachteten Freigabe-Handhabungen ab (Feld gelöscht bzw. Feld
+// stehen geblieben) und verhindert, dass ein längst erledigter Antrag für immer
+// als offen gezählt wird.
+//
+// Datenschutz (#252): Es landet niemals eine user_id, ein display_name oder
+// eine E-Mail-Adresse in der zurückgegebenen Map — nur Zahlen. Der Endpoint ist
+// ohne Login erreichbar.
+//
+// Die 7-Tage-Überfälligkeitsschwelle wird hier bewusst NICHT kodiert: analog zu
+// BriefingHealth liefert der Endpoint rohe Stunden, die Bewertung macht der
+// externe Monitor (check-gregor20.sh).
+func (s *Scheduler) TierRequestHealth() map[string]any {
+	var (
+		openCount       int
+		oldestRequested time.Time
+		haveOldest      bool
+	)
+
+	if s.store != nil {
+		ids, _ := s.store.ListUserIDs()
+		for _, uid := range ids {
+			user, err := s.store.LoadUser(uid)
+			if err != nil || user == nil {
+				continue // fail-soft: eine kaputte user.json darf das Aggregat nicht kippen
+			}
+			if user.RequestedTier == "" || model.EffectiveTier(user.Tier) == user.RequestedTier {
+				continue // kein Antrag bzw. bereits gewährt
+			}
+			openCount++
+			if user.RequestedAt == nil {
+				continue
+			}
+			requestedAt := *user.RequestedAt
+			if !haveOldest || requestedAt.Before(oldestRequested) {
+				oldestRequested = requestedAt
+				haveOldest = true
+			}
+		}
+	}
+
+	oldestAgeHours := 0.0
+	if haveOldest {
+		oldestAgeHours = time.Since(oldestRequested).Hours()
+	}
+
+	return map[string]any{
+		"open_count":            openCount,
+		"oldest_open_age_hours": oldestAgeHours,
+	}
+}

--- a/internal/scheduler/tier_request_health_test.go
+++ b/internal/scheduler/tier_request_health_test.go
@@ -1,0 +1,268 @@
+package scheduler
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/henemm/gregor-api/internal/config"
+	"github.com/henemm/gregor-api/internal/store"
+)
+
+// TDD RED: Issue #1555 — tier_request_health im oeffentlichen Status-Endpoint.
+//
+// Spec: docs/specs/modules/fix_1555_tier_antrag_sichtbarkeit.md
+//
+// KEINE Mocks: echte user.json-Dateien in t.TempDir(), echter httptest-
+// Roundtrip gegen Status() (Muster: briefing_health_test.go).
+//
+// Alle Test-Nutzer-IDs tragen das unverwechselbare Praefix "gz1555" — die
+// Datenschutz-Pruefung (AC-8) sucht danach im rohen Antwort-Text und darf
+// nicht zufaellig auf einem Teilstring von etwas anderem anschlagen.
+
+// tierUserJSON baut den Inhalt einer echten user.json. Leere Werte werden
+// weggelassen (genau wie omitempty es in der Produktion tut) — so entsteht der
+// Fall "Feld geloescht" wirklich als fehlendes Feld, nicht als Leerstring.
+func tierUserJSON(id, tier, requestedTier string, requestedAt time.Time) string {
+	parts := []string{
+		`"id":"` + id + `"`,
+		`"display_name":"` + id + `-anzeigename"`,
+		`"email":"` + id + `@example.invalid"`,
+	}
+	if tier != "" {
+		parts = append(parts, `"tier":"`+tier+`"`)
+	}
+	if requestedTier != "" {
+		parts = append(parts, `"requested_tier":"`+requestedTier+`"`)
+	}
+	if !requestedAt.IsZero() {
+		parts = append(parts, `"requested_at":"`+requestedAt.Format(time.RFC3339)+`"`)
+	}
+	return "{" + strings.Join(parts, ",") + "}"
+}
+
+// newTierRequestScheduler legt fuer jeden Eintrag (uid -> roher user.json-Inhalt)
+// eine echte Datei an und baut einen Scheduler darauf.
+func newTierRequestScheduler(t *testing.T, tmpDir string, users map[string]string) *Scheduler {
+	t.Helper()
+	st := store.New(tmpDir, "default")
+	for uid, content := range users {
+		dir := filepath.Join(tmpDir, "users", uid)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir user dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "user.json"), []byte(content), 0o644); err != nil {
+			t.Fatalf("write user.json: %v", err)
+		}
+	}
+	cfg := &config.Config{
+		PythonCoreURL:     "http://localhost:8000",
+		SchedulerTimezone: "Europe/Vienna",
+	}
+	sched, err := New(cfg, st)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return sched
+}
+
+// tierRequestHealthBlock fuehrt den echten HTTP-Roundtrip aus und liefert den
+// tier_request_health-Block plus den rohen Antworttext.
+func tierRequestHealthBlock(t *testing.T, sched *Scheduler) (map[string]any, string) {
+	t.Helper()
+	code, body, rawBody := callStatusEndpoint(t, sched)
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	th, ok := body["tier_request_health"].(map[string]any)
+	if !ok {
+		t.Fatalf("tier_request_health fehlt oder hat falschen Typ: %v", body["tier_request_health"])
+	}
+	return th, rawBody
+}
+
+// assertOpenCount prueft open_count als Zahl (JSON: float64).
+func assertOpenCount(t *testing.T, th map[string]any, want float64) {
+	t.Helper()
+	if got := th["open_count"]; got != want {
+		t.Errorf("open_count: want %v, got %v", want, got)
+	}
+}
+
+// AC-1: Keine offenen Antraege -> Nullwerte, kein Fehler, kein fehlendes Feld.
+func TestTierRequestHealthNullStateWhenNoOpenRequests(t *testing.T) {
+	tmpDir := t.TempDir()
+	sched := newTierRequestScheduler(t, tmpDir, map[string]string{
+		"gz1555-ac1-a": tierUserJSON("gz1555-ac1-a", "free", "", time.Time{}),
+		"gz1555-ac1-b": tierUserJSON("gz1555-ac1-b", "standard", "", time.Time{}),
+	})
+
+	th, _ := tierRequestHealthBlock(t, sched)
+	assertOpenCount(t, th, 0)
+	if got := th["oldest_open_age_hours"]; got != float64(0) {
+		t.Errorf("oldest_open_age_hours: want 0.0, got %v", got)
+	}
+}
+
+// AC-2: ZWEI offene Antraege (8 Tage / 2 Stunden alt) -> gemeldet wird das
+// Alter des AELTEREN. Zwingend zwei Antraege: bei nur einem waeren "aeltester"
+// und "juengster" derselbe Wert und der Test koennte die Verwechslung gar nicht
+// sehen. Die Mutation Before -> After in der Aeltester-Auswahl MUSS diesen Test
+// rot machen (sie liefert dann ~2h statt >168h).
+func TestTierRequestHealthReportsAgeOfOldestOpenRequest(t *testing.T) {
+	tmpDir := t.TempDir()
+	achtTage := time.Now().UTC().Add(-8 * 24 * time.Hour)
+	zweiStunden := time.Now().UTC().Add(-2 * time.Hour)
+	sched := newTierRequestScheduler(t, tmpDir, map[string]string{
+		"gz1555-ac2-alt": tierUserJSON("gz1555-ac2-alt", "free", "premium", achtTage),
+		"gz1555-ac2-neu": tierUserJSON("gz1555-ac2-neu", "free", "standard", zweiStunden),
+	})
+
+	th, _ := tierRequestHealthBlock(t, sched)
+	assertOpenCount(t, th, 2)
+
+	age, ok := th["oldest_open_age_hours"].(float64)
+	if !ok {
+		t.Fatalf("oldest_open_age_hours fehlt oder falscher Typ: %v", th["oldest_open_age_hours"])
+	}
+	if age <= 168 || age > 200 {
+		t.Errorf("oldest_open_age_hours: want Alter des AELTEREN Antrags (~192h, >168), got %v", age)
+	}
+}
+
+// AC-3: Nutzer ohne requested_tier zaehlt nicht mit. Das tier-Feld ist hier
+// absichtlich GESETZT: eine Implementierung, die auf "Tier leer" statt auf
+// "RequestedTier leer" prueft, zaehlt diesen Nutzer dann faelschlich als offen.
+func TestTierRequestHealthUserWithoutRequestDoesNotCount(t *testing.T) {
+	tmpDir := t.TempDir()
+	sched := newTierRequestScheduler(t, tmpDir, map[string]string{
+		"gz1555-ac3-ohne": tierUserJSON("gz1555-ac3-ohne", "standard", "", time.Time{}),
+	})
+
+	th, _ := tierRequestHealthBlock(t, sched)
+	assertOpenCount(t, th, 0)
+}
+
+// AC-4: PO hat requested_tier geloescht (tier="standard") -> nicht mehr offen.
+// requested_at bleibt absichtlich stehen: ein Aggregat, das das Alter aus
+// requested_at ohne Offen-Pruefung berechnet, wird hier rot.
+func TestTierRequestHealthClearedRequestedTierIsNotOpen(t *testing.T) {
+	tmpDir := t.TempDir()
+	achtTage := time.Now().UTC().Add(-8 * 24 * time.Hour)
+	sched := newTierRequestScheduler(t, tmpDir, map[string]string{
+		"gz1555-ac4-erledigt": tierUserJSON("gz1555-ac4-erledigt", "standard", "", achtTage),
+	})
+
+	th, _ := tierRequestHealthBlock(t, sched)
+	assertOpenCount(t, th, 0)
+	if got := th["oldest_open_age_hours"]; got != float64(0) {
+		t.Errorf("oldest_open_age_hours: want 0.0 (kein offener Antrag), got %v", got)
+	}
+}
+
+// AC-5: tier="free", requested_tier="premium" -> offen. Zusammen mit AC-4/AC-6
+// faengt das eine Implementierung, die nur auf "requested_tier nicht leer" oder
+// nur auf den Vergleich prueft.
+func TestTierRequestHealthUnhandledRequestIsOpen(t *testing.T) {
+	tmpDir := t.TempDir()
+	dreiStunden := time.Now().UTC().Add(-3 * time.Hour)
+	sched := newTierRequestScheduler(t, tmpDir, map[string]string{
+		"gz1555-ac5-offen": tierUserJSON("gz1555-ac5-offen", "free", "premium", dreiStunden),
+	})
+
+	th, _ := tierRequestHealthBlock(t, sched)
+	assertOpenCount(t, th, 1)
+
+	age, ok := th["oldest_open_age_hours"].(float64)
+	if !ok {
+		t.Fatalf("oldest_open_age_hours fehlt oder falscher Typ: %v", th["oldest_open_age_hours"])
+	}
+	if age < 2.9 || age > 3.1 {
+		t.Errorf("oldest_open_age_hours: want ~3.0, got %v", age)
+	}
+}
+
+// AC-6: bereits exakt so freigeschaltet (tier == requested_tier, Feld stehen
+// geblieben) -> nicht mehr offen. Mutations-Gegenprobe zu einer Pruefung, die
+// nur "requested_tier nicht leer" abfragt.
+func TestTierRequestHealthGrantedRequestWithLeftoverFieldIsNotOpen(t *testing.T) {
+	tmpDir := t.TempDir()
+	achtTage := time.Now().UTC().Add(-8 * 24 * time.Hour)
+	sched := newTierRequestScheduler(t, tmpDir, map[string]string{
+		"gz1555-ac6-gewaehrt": tierUserJSON("gz1555-ac6-gewaehrt", "premium", "premium", achtTage),
+	})
+
+	th, _ := tierRequestHealthBlock(t, sched)
+	assertOpenCount(t, th, 0)
+	if got := th["oldest_open_age_hours"]; got != float64(0) {
+		t.Errorf("oldest_open_age_hours: want 0.0 (Antrag bereits gewaehrt), got %v", got)
+	}
+}
+
+// Normalisierung (Spec "Implementation Details"): die Offen-Pruefung MUSS
+// model.EffectiveTier auf das gespeicherte tier anwenden. Ein Nutzer ohne
+// tier-Feld, der "free" beantragt hat, ist bereits auf dem beantragten Level —
+// eine Implementierung, die das rohe (leere) tier vergleicht, meldet ihn
+// faelschlich als offen.
+func TestTierRequestHealthEffectiveTierNormalizationApplied(t *testing.T) {
+	tmpDir := t.TempDir()
+	dreiStunden := time.Now().UTC().Add(-3 * time.Hour)
+	sched := newTierRequestScheduler(t, tmpDir, map[string]string{
+		"gz1555-norm-leer": tierUserJSON("gz1555-norm-leer", "", "free", dreiStunden),
+	})
+
+	th, _ := tierRequestHealthBlock(t, sched)
+	assertOpenCount(t, th, 0)
+}
+
+// AC-7: eine kaputte user.json darf die Gesamtauswertung nicht kippen. Der
+// defekte Nutzer steht lexikalisch VOR dem gueltigen, damit auch ein
+// vorzeitiges return statt continue auffliegt.
+func TestTierRequestHealthCorruptUserJsonIsSkippedFailSoft(t *testing.T) {
+	tmpDir := t.TempDir()
+	dreiStunden := time.Now().UTC().Add(-3 * time.Hour)
+	sched := newTierRequestScheduler(t, tmpDir, map[string]string{
+		"gz1555-aaa-defekt":  `{"id":"gz1555-aaa-defekt","tier":"free",`,
+		"gz1555-zzz-gueltig": tierUserJSON("gz1555-zzz-gueltig", "free", "premium", dreiStunden),
+	})
+
+	code, body, _ := callStatusEndpoint(t, sched)
+	if code != http.StatusOK {
+		t.Fatalf("expected 200 trotz defekter user.json, got %d", code)
+	}
+	th, ok := body["tier_request_health"].(map[string]any)
+	if !ok {
+		t.Fatalf("tier_request_health fehlt oder hat falschen Typ: %v", body["tier_request_health"])
+	}
+	assertOpenCount(t, th, 1)
+}
+
+// AC-8: Datenschutz (#252) — der Endpoint ist ohne Login erreichbar. Die rohe
+// Antwort darf weder user_id noch display_name noch E-Mail des Antragstellers
+// enthalten. Vorbild: TestBriefingHealthResponseContainsNoUserIdentifiers.
+func TestTierRequestHealthResponseContainsNoUserIdentifiers(t *testing.T) {
+	tmpDir := t.TempDir()
+	uid := "gz1555antragsteller7q"
+	dreiStunden := time.Now().UTC().Add(-3 * time.Hour)
+	sched := newTierRequestScheduler(t, tmpDir, map[string]string{
+		uid: tierUserJSON(uid, "free", "premium", dreiStunden),
+	})
+
+	th, rawBody := tierRequestHealthBlock(t, sched)
+	// Vorbedingung: es gibt ueberhaupt einen offenen Antrag zu verraten.
+	assertOpenCount(t, th, 1)
+
+	forbidden := []string{
+		uid,
+		uid + "-anzeigename",
+		uid + "@example.invalid",
+	}
+	for _, id := range forbidden {
+		if strings.Contains(rawBody, id) {
+			t.Errorf("Privacy-Leak: Antwort enthaelt Kennung %q", id)
+		}
+	}
+}


### PR DESCRIPTION
Behebt den ersten Teil von #1555 — die Sichtbarkeit offener Tier-Freischalt-Anträge.

> **Abgrenzung:** Der zweite Teil von #1555 (NowCast-Vorrang im geteilten Tagesbudget, Python-Core) läuft parallel als eigener Workflow `fix-1555-nowcast-alert-priority` und ist hier **nicht** enthalten. Dieser PR fasst ausschließlich Go-Code an.

## Problem

Ein Antrag auf Level-Wechsel löste genau **eine** Mail an den Betreiber aus — danach nie wieder etwas. Ging diese Mail unter, blieb der Antrag für immer unbemerkt. Real lag einer vier Wochen liegen; das betroffene Konto steckte dadurch im Free-Tier (2 Alarme/Tag) fest und bekam während einer laufenden Bergtour keine akuten Wetter-Alarme.

Die **nutzerseitige** Anzeige („Antrag wird geprüft") existiert seit #1071 und war nie das Problem — die Lücke lag allein auf der Betreiberseite.

## Lösung

`/api/scheduler/status` meldet zusätzlich `tier_request_health` mit `open_count` und `oldest_open_age_hours`, gebaut strikt nach dem Muster von `briefing_health.go`.

**Datenschutz:** Der Endpoint ist laut `internal/middleware/auth.go:34` ohne Login erreichbar. Die Antwort enthält deshalb ausschließlich Zahlen — niemals `user_id`, `display_name` oder E-Mail (Leitplanke aus #252). Ein eigener Test durchsucht die **komplette** Antwort darauf, nicht nur den neuen Abschnitt.

**Erledigt-Erkennung:** Ein Antrag gilt als erledigt, wenn `requested_tier` leer ist **oder** `EffectiveTier(tier)` dem beantragten Level entspricht. Die zweite Bedingung verhindert Dauerfehlalarme: Der Freigabe-Hinweis wies bisher nur an, `tier` zu setzen. Wäre ein abweichendes Level gewährt und `requested_tier` stehen geblieben, hätte der Antrag für immer als offen gezählt. Der Hinweistext nennt jetzt beide Schritte in Plain und HTML.

## Nebenbefund aus der Adversary-Runde

Die Tier-Normalisierung lag in **drei** wortgleichen Kopien vor (zwei davon in `auth.go`). Sie ist nach `model.EffectiveTier` zusammengeführt.

Dabei kam heraus: Die Normalisierung an der Antragsstelle war von **keinem** Test bewacht. Alle bestehenden Tests setzen `tier` explizit — die Normalisierung greift aber nur, wenn gar kein Level gesetzt ist. Genau das trifft auf **zwei von drei echten Konten** zu (`steffi`, `default` haben kein `tier`-Feld). Ohne sie hätte so ein Konto einen Antrag auf sein eigenes Level durchbekommen, der anschließend im neuen Zähler als offen erschienen wäre. Zwei Regressionstests schließen die Lücke; der zweite stellt sicher, dass der erste nicht durch ein pauschales „lehne alles ab" erfüllbar ist.

## Prüfung

- **Adversary: VERIFIED** — 3 Runden, 12/12 Punkte bewiesen
- **10 Mutationen gefahren**, 9 sofort rot; die zehnte deckte die oben genannte Lücke auf
- Nach dem Fix erneut geprüft, mit **unabhängig gefahrenen** Mutationen statt übernommener Angaben
- `go build ./...` und `go vet ./...` sauber, **alle 13 `internal/`-Pakete grün**
- Unabhängige Abnahmeprüfung: keine Regression, kein Konsument von `/api/scheduler/status` prüft die exakte Feldmenge

## Nicht in diesem PR

1. **7-Tage-Schwellenprüfung in `check-gregor20.sh`** (Repo `henemm-infra`) — **erst sie macht aus der Zahl einen Alarm.** Ohne diesen Schritt ist das Feld sichtbar, aber wirkungslos. Auftrag geht per MQ + Issue an `infra`.
2. **Umstellung von `GZ_PO_EMAIL`** auf eine `henemm.com`-Adresse (steht auf `henning.emmrich@gmail.com`) — Produktions-`.env`, nicht versioniert.

Beides ist in der Spec unter „Known Limitations" bzw. im Lieferumfang festgehalten.

Spec: `docs/specs/modules/fix_1555_tier_antrag_sichtbarkeit.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
