### PR TITLE
Deploy: Staging-Wait mit Ancestor-Check statt exakter Gleichheit (Fehlalarm 2026-08-07)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,15 +171,28 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
+      - uses: actions/checkout@v4
+        with:
+          # Volle Historie fuer den Ancestor-Check im Staging-Wait (s. u.).
+          fetch-depth: 0
       - name: Warten bis Staging aktuellen Commit hat
+        # 2026-08-07 (Deploy-Run zu PR #1566): Der exakte Gleichheits-Check
+        # schlug als Fehlalarm fehl, weil Staging im Wartefenster einen
+        # NEUEREN main-Commit auslieferte (anderer Merge zwischendurch).
+        # Jetzt: ok, sobald der Staging-Commit EXPECTED ENTHAELT
+        # (merge-base --is-ancestor). Das frische Fetch pro Versuch ist
+        # noetig, weil Staging neuer sein kann als der ausgecheckte Stand.
         run: |
           EXPECTED="${{ github.sha }}"
           BASE="https://staging.gregor20.henemm.com"
-          echo "Erwarte Commit ${EXPECTED:0:7} auf Staging..."
+          echo "Erwarte Commit ${EXPECTED:0:7} (oder Nachfolger) auf Staging..."
           for i in $(seq 1 12); do
-            STAGING=$(curl -s "$BASE/api/health" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('commit','')[:7])" 2>/dev/null || echo "")
-            echo "Versuch $i/12: Staging=$STAGING Erwartet=${EXPECTED:0:7}"
-            [ "$STAGING" = "${EXPECTED:0:7}" ] && echo "Staging aktuell." && break
+            git fetch -q origin main
+            STAGING=$(curl -s "$BASE/api/health" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('commit',''))" 2>/dev/null || echo "")
+            echo "Versuch $i/12: Staging=${STAGING:0:7} Erwartet=${EXPECTED:0:7}"
+            if [ -n "$STAGING" ] && git merge-base --is-ancestor "$EXPECTED" "$STAGING" 2>/dev/null; then
+              echo "Staging aktuell (enthaelt Erwartet)." && break
+            fi
             [ $i -eq 12 ] && echo "FEHLER: Staging nach 6 Min nicht aktuell." && exit 1
             sleep 30
           done


### PR DESCRIPTION
## Was

Der Staging-Wait im Deploy-Job pruefte auf exakte Commit-Gleichheit. Fehlalarm 2026-08-07 (Deploy-Run zu PR #1566): Staging lieferte im Wartefenster bereits einen NEUEREN main-Commit aus (anderer Merge zwischendurch) — der Check meldete 'Staging nicht aktuell' und der Deploy brach ab, obwohl Staging den eigenen Commit laengst enthielt.

## Fix

- Neuer Deploy-Job-Step nutzt `git merge-base --is-ancestor EXPECTED STAGING`: ok, sobald Staging den eigenen Commit **enthaelt** (gleich oder neuer).
- `actions/checkout` mit `fetch-depth: 0` im Deploy-Job (vorher kein Checkout) + frisches `git fetch origin main` pro Versuch — Staging kann neuer sein als der ausgecheckte Stand.
- Beide Richtungen lokal verifiziert (Staging neuer → Pass; Staging aelter → weiter Warten/Fehler).