### PR TITLE
#1196 Batch 4: Radar-Throttle-Tests 656/660 saniert (Exclude 39 → 37)

### DIFF
--- a/.github/ci_tdd_excludes.txt
+++ b/.github/ci_tdd_excludes.txt
@@ -20,6 +20,12 @@
 # gueltige 4-Stufen-Skala (NONE/LOW/MED/HIGH) angeglichen; die 3-Stufen-
 # Erwartung war Ueberstand aus der PO-Entscheidung 2026-07-12.
 #
+# Batch 4 (2026-08-07): test_feature_656_radar_nowcast +
+# test_feature_660_convective_stage — Radar-Throttle-Tests. Zwei Driften:
+# (a) can_send_email() nur mit Host-.env True → Dummy-SMTP-Settings +
+# mail_sink/DI-Naht im Test; (b) alert_log schreibt seit #1467 S1
+# entity_id statt trip_id — Testfilter angeglichen.
+#
 # WICHTIG (Lektion aus PR #1551): Lokale Offline-Laeufe im Haupt-Checkout
 # (.env + befuellte data/users/) sind KEIN Beleg fuer CI-Gruen. Einzig
 # verbindliche Vermessung ist der Runner. Ursachen und Sanierungsreihenfolge:
@@ -36,8 +42,6 @@ tests/tdd/test_bundle_e_gate_tooling.py
 tests/tdd/test_compare_official_alert.py
 tests/tdd/test_compare_sun_hours_full_day_window.py
 tests/tdd/test_corridor_no_longer_triggers_alerts.py
-tests/tdd/test_feature_656_radar_nowcast.py
-tests/tdd/test_feature_660_convective_stage.py
 tests/tdd/test_issue_1040_alerts_toggle.py
 tests/tdd/test_issue_1088_official_alert_triggers.py
 tests/tdd/test_issue_1104_compare_config_foundation.py

--- a/tests/tdd/test_feature_656_radar_nowcast.py
+++ b/tests/tdd/test_feature_656_radar_nowcast.py
@@ -264,20 +264,37 @@ def test_ac4_check_radar_alerts_sends_once_then_throttles():
     log_path = get_data_dir(user_id) / "alert_log.json"
     if log_path.exists():
         data = json.loads(log_path.read_text())
-        data["entries"] = [e for e in data.get("entries", []) if e.get("trip_id") != _TRIP_ID]
+        data["entries"] = [e for e in data.get("entries", []) if e.get("entity_id") != _TRIP_ID]  # #1467 S1: entity_id statt trip_id
         log_path.write_text(json.dumps(data, indent=2))
 
     try:
-        svc = TripAlertService(user_id=user_id, radar_service=radar_service)
+        # #1196 Batch 4: Kanal explizit konfigurieren — ohne Settings baut der
+        # Service Settings() aus der Umgebung, und can_send_email() ist nur mit
+        # Host-.env True (Grund des offline/CI-Rotseins: "No channel
+        # configured; skipping radar alert"). Dummy-SMTP + mail_sink (DI-Naht,
+        # ersetzt den echten SMTP-Versand) machen den Test deterministisch.
+        from app.config import Settings
+
+        settings = Settings(
+            smtp_host="test.invalid", smtp_user="u", smtp_pass="p",
+            mail_to="empfaenger@example.com",
+        )
+        sent_mails: list = []
+        svc = TripAlertService(
+            user_id=user_id, radar_service=radar_service,
+            settings=settings,
+            mail_sink=lambda subject, body: sent_mails.append((subject, body)),
+        )
         svc.clear_radar_throttle(_TRIP_ID)
         sent_first = svc.check_radar_alerts()
         sent_second = svc.check_radar_alerts()
 
         assert sent_first == 1
         assert sent_second == 0  # Throttle greift
+        assert len(sent_mails) == 1  # genau ein Versand, der zweite Lauf throttelt
 
         entries = json.loads(log_path.read_text()).get("entries", [])
-        radar_entries = [e for e in entries if e.get("trip_id") == _TRIP_ID]
+        radar_entries = [e for e in entries if e.get("entity_id") == _TRIP_ID]  # #1467 S1: entity_id statt trip_id
         assert len(radar_entries) == 1
         assert radar_entries[0].get("severity") == "HIGH"
     finally:

--- a/tests/tdd/test_feature_660_convective_stage.py
+++ b/tests/tdd/test_feature_660_convective_stage.py
@@ -186,7 +186,7 @@ def test_ac4_radar_alert_convective_marked_once_then_throttles():
     log_path = get_data_dir(user_id) / "alert_log.json"
     if log_path.exists():
         data = json.loads(log_path.read_text())
-        data["entries"] = [e for e in data.get("entries", []) if e.get("trip_id") != _TRIP_ID]
+        data["entries"] = [e for e in data.get("entries", []) if e.get("entity_id") != _TRIP_ID]  # #1467 S1: entity_id statt trip_id
         log_path.write_text(json.dumps(data, indent=2))
 
     # Echte Aufzeichnung der gebauten Alert-Nachricht (kein Mock — normale Funktion,
@@ -200,7 +200,18 @@ def test_ac4_radar_alert_convective_marked_once_then_throttles():
 
     EmailOutput.send = _recording_send
     try:
-        svc = TripAlertService(user_id=user_id, radar_service=radar_service)
+        # #1196 Batch 4: Kanal explizit konfigurieren — ohne Settings baut der
+        # Service Settings() aus der Umgebung, und can_send_email() ist nur mit
+        # Host-.env True (Grund des offline/CI-Rotseins: "No channel
+        # configured; skipping radar alert"). Dummy-Werte genuegen; der
+        # gepatchte EmailOutput.send faengt den Versand ab.
+        from app.config import Settings
+
+        settings = Settings(
+            smtp_host="test.invalid", smtp_user="u", smtp_pass="p",
+            mail_to="empfaenger@example.com",
+        )
+        svc = TripAlertService(user_id=user_id, radar_service=radar_service, settings=settings)
         svc.clear_radar_throttle(_TRIP_ID)
         sent_first = svc.check_radar_alerts()
         sent_second = svc.check_radar_alerts()
@@ -209,7 +220,7 @@ def test_ac4_radar_alert_convective_marked_once_then_throttles():
         assert sent_second == 0  # Throttle greift
 
         entries = json.loads(log_path.read_text()).get("entries", [])
-        radar_entries = [e for e in entries if e.get("trip_id") == _TRIP_ID]
+        radar_entries = [e for e in entries if e.get("entity_id") == _TRIP_ID]  # #1467 S1: entity_id statt trip_id
         assert len(radar_entries) == 1
         assert radar_entries[0].get("severity") == "HIGH"
 


### PR DESCRIPTION
## Was

Batch 4 des Sanierungsplans (`docs/analysis/1196-tdd-excludes-sanierung-2026-08-06.md`): `test_feature_656_radar_nowcast.py` + `test_feature_660_convective_stage.py` saniert, Exclude-Liste 39 → 37.

## Diagnose (zwei überlagerte Driften, beide Test-seitig)

1. **„No channel configured; skipping radar alert"** (`trip_alert.py:823`): Ohne explizite Settings baut der Service `Settings()` aus der Umgebung — `can_send_email()` ist nur mit der Host-`.env` des Haupt-Checkouts True. Auf dem Runner (keine `.env`) wurde der Alert immer übersprungen → `assert 0 == 1`.
   **Fix:** Dummy-SMTP-Settings im Test; der Versand läuft über die vorhandenen DI-Nahten (656: `mail_sink`, 660: bereits gepatchtes `EmailOutput.send`) — kein Socket, keine Mocks im fachlichen Pfad.
2. **alert_log-Filter:** Seit #1467 S1 schreibt das Protokoll bewusst `entity_id`/`entity_type` statt `trip_id` („Kein Doppelschreiben"). Die Tests filterten noch auf `trip_id` → 0 Treffer.
   **Fix:** Filter auf `entity_id` angeglichen (inkl. Kommentar-Verweis).

## Verifikation

Lokal offline (CI-Bedingungen): 11 Tests grün, ruff sauber. Runner-Lauf ist der verbindliche Beleg (Lektion PR #1551).

Refs #1196
