### PR TITLE
fix(#1575): Mail-Spaltenreihenfolge folgt der eingestellten Reihenfolge (Scheibe 1)

### DIFF
--- a/docs/specs/modules/fix_1575_mail_column_order.md
+++ b/docs/specs/modules/fix_1575_mail_column_order.md
@@ -1,0 +1,151 @@
+---
+entity_id: fix_1575_mail_column_order
+type: module
+created: 2026-08-07
+updated: 2026-08-07
+status: draft
+version: "1.0"
+tags: [trip, output, email, weather-metrics, khw]
+---
+
+# Fix #1575 Scheibe 1 — Die eingestellte Metrik-Reihenfolge wirkt in der Briefing-Mail
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Der Abschnitt „Reihenfolge" im Tab *Wetter-Metriken* verspricht wörtlich „links → rechts
+in der Email-Tabelle", hat aber **keine Wirkung**: die Spaltenfolge der Briefing-Mail ist
+für jeden Trip die Katalog-Reihenfolge. Diese Scheibe macht die Zusicherung für die
+HTML-Briefing-Mail wahr — an der **einen** Stelle, an der die kanal-bewusste
+Metrik-Auflösung ohnehin stattfindet.
+
+## Messung (Ist-Stand, nicht vermutet)
+
+Gemessen am 2026-08-07 gegen `9a932ef` über den echten Render-Pfad
+(`TripReportFormatter.format_email`, Messskript im Session-Scratchpad):
+
+| Fall | HTML-Spalten |
+|---|---|
+| `order` == Katalogreihenfolge | `Time, Temp, Feels, Wind, Gust, Rain, Thdr, SnowL, Cloud, Sun, TmpMin, Risk` |
+| `order` rotiert (letzte Größe auf Position 1) | **identisch** — die Einstellung verpufft |
+| `metrics`-Liste physisch nach `(bucket, order)` sortiert | `Time, **Sun**, Temp, Feels, …` — die Einstellung wirkt |
+
+**Ursachenkette (Code gelesen und nachgemessen):**
+
+1. Der Editor speichert die Drag-Position **nur** im Feld `order`; das `metrics`-Array
+   selbst wird bewusst in Katalog-Reihenfolge serialisiert
+   (`frontend/src/lib/components/trip-detail/metricsEditor.ts:329`, `:367-370`).
+2. Der HTML-Renderer baut seine Spaltenfolge aus `dc.metrics` in **Array-Reihenfolge**
+   und liest `mc.order` nie (`src/output/renderers/email/html.py:1018-1027`).
+3. `get_metrics_for_channel()` (`src/app/models.py:700-732`) gibt die Liste unsortiert
+   zurück — sie ist die einzige Stelle, die alle Kanäle durchlaufen.
+
+Zum Vergleich: Telegram und Ortsvergleich sortieren nach `(bucket, order)`
+(`src/output/renderers/channel_layout.py:89-94`) und zeigen die Einstellung korrekt.
+Die Mail ist der einzige Kanal, der ausschert.
+
+## Source
+
+- **File:** `src/app/models.py`
+- **Identifier:** `UnifiedWeatherDisplayConfig.get_metrics_for_channel`
+
+Schicht: **Python-Core / Domain-Backend**. Bewusst **keine** Änderung an
+`src/output/renderers/email/*.py` oder `trip_report.py` — siehe „Schnitt".
+
+## Acceptance Criteria
+
+**AC-1:** Given ein Trip, dessen Wettergrößen im Editor in eine vom Katalog abweichende
+Reihenfolge gezogen wurden / When das Briefing als E-Mail gerendert wird / Then folgen
+die Spalten der Stundentabelle im HTML-Teil genau dieser eingestellten Reihenfolge
+(links → rechts), nicht der Katalog-Reihenfolge.
+
+**AC-2:** Given zwei Größen im selben Bucket mit den Positionen 1 und 2 / When die beiden
+Positionen im Editor getauscht werden / Then tauschen auch die zugehörigen Spalten der
+Mail ihren Platz — die Wirkung ist an der Mail messbar, nicht nur am gespeicherten Wert.
+
+**AC-3:** Given ein Bestands-Trip, dessen gespeicherte Größen alle `order = 0` tragen
+(Altbestand vor der Reihenfolge-Funktion) / When das Briefing gerendert wird / Then ist
+die Spaltenfolge **unverändert** gegenüber heute — die Sortierung ist stabil und erfindet
+für Altbestand keine neue Reihenfolge.
+
+**AC-4:** Given eine Konfiguration mit Größen in beiden Buckets (`primary`, `secondary`)
+/ When die Mail gerendert wird / Then stehen alle `primary`-Größen (nach ihrer Position)
+vor allen `secondary`-Größen — beide Buckets zählen ihre Positionen ab 0, eine Sortierung
+allein nach `order` würde sie falsch verschränken.
+
+**AC-5:** Given derselbe Trip / When Telegram-Kurzform und Ortsvergleich gerendert werden
+/ Then ist deren Spalten-/Zeilenfolge unverändert gegenüber heute — diese Kanäle
+sortieren bereits selbst; die neue Sortierung darf dort nichts verschieben.
+
+**AC-6:** Given ein Trip mit kanal-eigenen Listen (`channel_layouts`, Altbestand aus
+#429/#434) / When die Mail gerendert wird / Then bleibt die Auswahl (welche Größen)
+unverändert; ausschließlich die Reihenfolge folgt der Einstellung.
+
+## Nicht in dieser Scheibe (bewusst)
+
+- **Plain-Text-Hälfte der Mail.** Gemessen: `plain.py` ordnet über
+  `visible_cols(rows)` strikt nach Katalog und kennt den `col_order`-Mechanismus gar
+  nicht — die Sortierung in `models.py` erreicht sie nicht. Der Fix erfordert eine
+  Änderung an `src/output/renderers/email/plain.py`, und das ist eine geschützte
+  Mail-Inhalts-Datei: `renderer_mail_gate.py` verlangt dafür einen frischen
+  `briefing_mail_validator.py`-Lauf gegen eine **echt zugestellte Staging-Mail** per
+  IMAP. Diese Session hat weder IMAP-Zugang noch Staging-Zugriff. → Folge-Scheibe für
+  eine Session mit Staging-Zugang.
+- **Divergenz HTML ↔ Plain (Zusatzbefund).** Schon heute unterscheiden sich beide
+  Hälften: `TmpMin` steht im Plain-Teil an Position 2, im HTML-Teil an vorletzter
+  Stelle. Ursache gemessen: `temperature_cold.selectable = False`, dadurch fällt die
+  Größe in `html.py:1024` aus `_col_order` heraus und landet über den
+  `remaining`-Zweig am Ende, während der Plain-Teil sie nach Katalog einsortiert. Das
+  ist ein Trip-seitiges Geschwister von #1356 und gehört in dieselbe Folge-Scheibe.
+- **Symptom B aus #1575 (Kanal-Trennung im Editor).** Eigene Spec, eigener Workflow —
+  braucht eine PO-Entscheidung zum Bedienkonzept (pro Kanal eigene Auswahl vs. Reiter
+  ehrlich als reine Vorschau beschriften).
+
+## Estimated Scope
+
+- **LoC:** ~15 Produktivcode + ~120 Test
+- **Files:** 1 Produktivdatei (`src/app/models.py`), 1 Testdatei
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `UnifiedWeatherDisplayConfig` | Datenmodell | trägt `bucket` + `order` je Größe |
+| `channel_layout.render_for_channel` | Referenz | belegt die etablierte Sortier-Semantik `(bucket, order)` |
+| `email/html.py` `_col_order` | Verbraucher | liest `dc.metrics` in Array-Reihenfolge (unverändert) |
+
+## Implementation Details
+
+```
+UnifiedWeatherDisplayConfig.get_metrics_for_channel(channel, report_type):
+    ... bestehende Dreistufen-Kaskade unverändert ...
+    return _sorted_by_layout(<Ergebnis der jeweiligen Ebene>)
+
+_sorted_by_layout(metrics):
+    # primary vor secondary, innerhalb des Buckets nach order.
+    # sorted() ist stabil -> Altbestand mit lauter order=0 behaelt
+    # exakt seine bisherige Reihenfolge (AC-3).
+    rank = {"primary": 0, "secondary": 1}
+    return sorted(metrics, key=lambda m: (rank.get(m.bucket, 2), m.order))
+```
+
+Alle drei Kaskadenebenen laufen durch dieselbe Sortierung — sonst verhielte sich ein
+Trip mit `channel_layouts` anders als einer ohne (AC-6).
+
+## Testing
+
+Kern-Schicht, deterministisch, ohne Netz. Nachweis am **Wirkort**: die gerenderte Mail
+(`format_email`), nicht die Sortierfunktion isoliert — Lehre aus #1457 („ist die
+Zusicherung dort geprüft, wo sie wirkt?").
+
+| AC | Testart |
+|---|---|
+| AC-1, AC-2 | `format_email` mit permutiertem `order`, Spaltenfolge aus dem `<thead>` gelesen |
+| AC-3 | Altbestand-Konfiguration (`order` überall 0) → Spaltenfolge identisch zum Ist-Stand |
+| AC-4 | Konfiguration über beide Buckets → primary-Block vollständig vor secondary-Block |
+| AC-5 | `render_for_channel("telegram", …)` und Compare-Pfad vor/nach identisch |
+| AC-6 | Konfiguration mit `per_channel_layouts` → Auswahl unverändert, Reihenfolge sortiert |

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -631,6 +631,32 @@ def _filter_metrics_by_report_type(
     return result
 
 
+# Issue #1575: Bucket-Rangfolge fuer die Spalten-/Zeilenreihenfolge.
+_BUCKET_RANK = {"primary": 0, "secondary": 1}
+
+
+def _sorted_by_layout(metrics: list["MetricConfig"]) -> list["MetricConfig"]:
+    """Sortiert nach der im Editor eingestellten Position (Issue #1575).
+
+    primary vor secondary, innerhalb des Buckets nach ``order`` -- exakt die
+    Semantik, die ``channel_layout.render_for_channel`` fuer Telegram und den
+    Ortsvergleich schon anwendet. Ohne diese Sortierung liest der Mail-Renderer
+    ``dc.metrics`` in Array-Reihenfolge (``email/html.py`` ``_col_order``), und
+    die Array-Reihenfolge ist die Katalog-Reihenfolge -- die im Editor gezogene
+    Position blieb damit wirkungslos.
+
+    Beide Buckets zaehlen ihre Positionen ab 0; eine Sortierung allein nach
+    ``order`` wuerde sie verschraenken -- daher der Bucket-Rang zuerst.
+
+    ``sorted()`` ist stabil: Altbestand, dessen Eintraege alle ``order = 0``
+    tragen, behaelt exakt seine bisherige Reihenfolge.
+    """
+    return sorted(
+        metrics,
+        key=lambda mc: (_BUCKET_RANK.get(mc.bucket, len(_BUCKET_RANK)), mc.order),
+    )
+
+
 @dataclass
 class UnifiedWeatherDisplayConfig:
     """
@@ -706,6 +732,10 @@ class UnifiedWeatherDisplayConfig:
         2. per_channel_layouts[channel] (Issue #429) — zweite Stufe.
            Leere Liste = expliziter User-Wunsch, kein Fallback.
         3. globale Liste via get_metrics_for_report_type(report_type) — Fallback.
+
+        Issue #1575: JEDE Ebene laeuft durch dieselbe Sortierung nach der im
+        Editor eingestellten Position — sonst verhielte sich ein Trip mit
+        kanal-eigenen Listen anders als einer ohne.
         """
         # Ebene 1 (#434): per_report_layouts[report_type][channel]
         if (
@@ -716,7 +746,9 @@ class UnifiedWeatherDisplayConfig:
             report_channel_metrics = self.per_report_layouts[report_type][channel]
             if len(report_channel_metrics) == 0:
                 return []
-            return _filter_metrics_by_report_type(report_channel_metrics, report_type)
+            return _sorted_by_layout(
+                _filter_metrics_by_report_type(report_channel_metrics, report_type),
+            )
 
         # Ebene 2 (#429): per_channel_layouts[channel]
         if (
@@ -726,10 +758,12 @@ class UnifiedWeatherDisplayConfig:
             channel_metrics = self.per_channel_layouts[channel]
             if len(channel_metrics) == 0:
                 return []
-            return _filter_metrics_by_report_type(channel_metrics, report_type)
+            return _sorted_by_layout(
+                _filter_metrics_by_report_type(channel_metrics, report_type),
+            )
 
         # Ebene 3: globaler Fallback
-        return self.get_metrics_for_report_type(report_type)
+        return _sorted_by_layout(self.get_metrics_for_report_type(report_type))
 
 
 # --- Ausblick-Zustand (Fix #1486) ---

--- a/tests/unit/test_mail_column_order.py
+++ b/tests/unit/test_mail_column_order.py
@@ -1,0 +1,297 @@
+"""Die im Editor eingestellte Metrik-Reihenfolge wirkt in der Briefing-Mail.
+
+Spec: docs/specs/modules/fix_1575_mail_column_order.md (Issue #1575, Scheibe 1).
+
+Gemessen wird am WIRKORT -- der gerenderten Mail (``format_email``), nicht an
+der Sortierfunktion isoliert. Lehre aus #1457: eine Zusicherung, die nur dort
+geprueft wird, wo der Code steht, kann erfuellt und wirkungslos zugleich sein.
+
+Der Nutzer zieht im Tab "Wetter-Metriken" eine Groesse nach vorn; der Abschnitt
+sagt ihm "links -> rechts in der Email-Tabelle". Genau das pruefen diese Tests.
+"""
+from datetime import datetime, timezone
+
+from app.metric_catalog import (
+    build_default_display_config, get_col_defs, get_metric,
+)
+from app.models import (
+    ForecastDataPoint,
+    ForecastMeta,
+    GPXPoint,
+    MetricConfig,
+    NormalizedTimeseries,
+    Provider,
+    SegmentWeatherData,
+    SegmentWeatherSummary,
+    ThunderLevel,
+    TripSegment,
+)
+from output.renderers.channel_layout import render_for_channel
+from output.renderers.trip_report import TripReportFormatter
+
+# Spalten, die der Renderer unabhaengig von der Metrik-Auswahl setzt.
+_FRAME_COLUMNS = {"Time", "Risk"}
+
+
+def _segment() -> SegmentWeatherData:
+    segment = TripSegment(
+        segment_id=1,
+        start_point=GPXPoint(lat=47.0, lon=11.0, elevation_m=1500),
+        end_point=GPXPoint(lat=47.1, lon=11.1, elevation_m=1800),
+        start_time=datetime(2026, 8, 29, 8, 0, tzinfo=timezone.utc),
+        end_time=datetime(2026, 8, 29, 10, 0, tzinfo=timezone.utc),
+        duration_hours=2.0, distance_km=5.0, ascent_m=300, descent_m=0,
+    )
+    summary = SegmentWeatherSummary(
+        temp_min_c=12.0, temp_max_c=18.0, temp_avg_c=15.0,
+        wind_max_kmh=25.0, gust_max_kmh=40.0, precip_sum_mm=5.0,
+    )
+    meta = ForecastMeta(
+        provider=Provider.OPENMETEO, model="test",
+        run=datetime(2026, 8, 29, 0, 0, tzinfo=timezone.utc),
+        grid_res_km=2.5, interp="point_grid",
+    )
+    data = [
+        ForecastDataPoint(
+            ts=datetime(2026, 8, 29, h, 0, tzinfo=timezone.utc),
+            t2m_c=12.0 + h, wind10m_kmh=15.0 + h, gust_kmh=25.0 + h,
+            precip_1h_mm=0.5, cloud_total_pct=50,
+            thunder_level=ThunderLevel.NONE, wind_chill_c=8.0 + h,
+        )
+        for h in range(0, 24)
+    ]
+    return SegmentWeatherData(
+        segment=segment,
+        timeseries=NormalizedTimeseries(data=data, meta=meta),
+        aggregated=summary,
+        fetched_at=datetime.now(timezone.utc),
+        provider="test",
+    )
+
+
+def _label_of(metric_id: str) -> str:
+    """Metrik-ID -> Spaltenbeschriftung, wie sie in der Mail steht."""
+    col_key = get_metric(metric_id).col_key
+    for key, label, _ in get_col_defs():
+        if key == col_key:
+            return label
+    raise AssertionError(f"keine Spaltenbeschriftung fuer {metric_id}")
+
+
+def _mail_columns(config) -> list[str]:
+    """Spaltenbeschriftungen der HTML-Stundentabelle, links -> rechts."""
+    import re
+
+    report = TripReportFormatter().format_email(
+        [_segment()], "Reihenfolge Trip", "morning", display_config=config,
+    )
+    head = re.search(r"<thead><tr>(.*?)</tr></thead>", report.email_html, re.S)
+    assert head, "Stundentabelle ohne Kopfzeile gerendert"
+    cells = [
+        re.sub(r"<[^>]+>", "", th).strip()
+        for th in re.findall(r"<th[^>]*>.*?</th>", head.group(1), re.S)
+    ]
+    return [c for c in cells if c not in _FRAME_COLUMNS]
+
+
+def _place(config, metric_ids: list[str], bucket: str = "primary") -> None:
+    """Setzt Bucket + Position genau so, wie der Editor es beim Ziehen tut."""
+    by_id = {mc.metric_id: mc for mc in config.metrics}
+    for position, metric_id in enumerate(metric_ids):
+        by_id[metric_id].bucket = bucket
+        by_id[metric_id].order = position
+
+
+# --- AC-1 -----------------------------------------------------------------
+
+def test_configured_order_drives_mail_columns():
+    """AC-1: Eine nach vorn gezogene Groesse steht in der Mail auch vorn."""
+    config = build_default_display_config()
+    active = [mc.metric_id for mc in config.metrics if mc.enabled]
+    # Nutzer zieht die letzte Groesse auf Position 1.
+    _place(config, [active[-1]] + active[:-1])
+
+    columns = _mail_columns(config)
+    moved_to_front = _label_of(active[-1])
+
+    assert columns[0] == moved_to_front, (
+        f"Die nach vorn gezogene Groesse '{moved_to_front}' muesste die erste "
+        f"Spalte sein, die Mail zeigt aber: {columns}"
+    )
+
+
+# --- AC-2 -----------------------------------------------------------------
+
+def test_swapping_two_positions_swaps_mail_columns():
+    """AC-2: Werden zwei Positionen getauscht, tauschen auch die Spalten."""
+    order = ["temperature", "wind", "gust", "precipitation", "cloud_total"]
+
+    config_a = build_default_display_config()
+    _place(config_a, order)
+    columns_a = _mail_columns(config_a)
+
+    config_b = build_default_display_config()
+    _place(config_b, ["wind", "temperature"] + order[2:])
+    columns_b = _mail_columns(config_b)
+
+    temp, wind = _label_of("temperature"), _label_of("wind")
+    assert columns_a.index(temp) < columns_a.index(wind)
+    assert columns_b.index(wind) < columns_b.index(temp), (
+        f"Nach dem Tausch muesste '{wind}' vor '{temp}' stehen, "
+        f"die Mail zeigt aber: {columns_b}"
+    )
+
+
+# --- AC-3 -----------------------------------------------------------------
+
+def test_legacy_config_without_order_keeps_catalog_order():
+    """AC-3: Altbestand (alle order = 0) behaelt exakt seine Reihenfolge.
+
+    Die Sortierung muss stabil sein -- sonst wuerde sie fuer Bestands-Trips,
+    die nie eine Reihenfolge gesetzt haben, eine neue erfinden.
+
+    Der Sollwert ist der GEMESSENE Vorzustand (2026-08-07 gegen 9a932ef), nicht
+    die ideale Katalog-Reihenfolge: 'TmpMin' steht hinten, weil
+    `temperature_cold.selectable = False` es aus `_col_order` fallen laesst und
+    der `remaining`-Zweig es anhaengt (html.py:1024/1680). Diese Abweichung ist
+    Bestand und gehoert zu Scheibe 2 -- dieser Test haelt sie fest, damit die
+    Sortierung sie nicht versehentlich mitverschiebt.
+    """
+    config = build_default_display_config()
+    assert all(mc.order == 0 for mc in config.metrics if mc.enabled), (
+        "Vorbedingung verletzt: die Vorgabe-Konfiguration traegt bereits "
+        "Positionen, dieser Test prueft dann nicht mehr den Altbestand"
+    )
+
+    baseline = [
+        "Temp", "Feels", "Wind", "Gust", "Rain",
+        "Thdr", "SnowL", "Cloud", "Sun", "TmpMin",
+    ]
+    assert _mail_columns(config) == baseline, (
+        "Altbestand-Reihenfolge veraendert -- ein Trip ohne je gesetzte "
+        "Positionen darf seine Mail nicht anders sortiert bekommen"
+    )
+
+
+# --- AC-4 -----------------------------------------------------------------
+
+def test_primary_metrics_come_before_secondary():
+    """AC-4: primary steht vollstaendig vor secondary.
+
+    Beide Buckets zaehlen ihre Positionen ab 0 -- eine Sortierung allein nach
+    `order` wuerde sie verschraenken (Wind[0] neben Temperatur[0]).
+    """
+    config = build_default_display_config()
+    _place(config, ["wind", "gust"], bucket="primary")
+    _place(config, ["temperature", "precipitation"], bucket="secondary")
+    for mc in config.metrics:
+        if mc.metric_id not in {"wind", "gust", "temperature", "precipitation"}:
+            mc.enabled = False
+
+    columns = _mail_columns(config)
+    last_primary = max(columns.index(_label_of(m)) for m in ("wind", "gust"))
+    first_secondary = min(
+        columns.index(_label_of(m)) for m in ("temperature", "precipitation")
+    )
+
+    assert last_primary < first_secondary, (
+        f"primary-Groessen muessen vor secondary stehen, Mail zeigt: {columns}"
+    )
+
+
+# --- AC-5 -----------------------------------------------------------------
+
+def test_telegram_layout_is_not_disturbed():
+    """AC-5: Telegram/Ortsvergleich sortieren selbst -- nichts darf sich dort
+    verschieben, egal in welcher Array-Reihenfolge die Liste ankommt."""
+    # ALLE aktiven Groessen bekommen eine eigene Position -- sonst pruefte der
+    # Test nur, wie Gleichstaende (lauter order = 0) aufgeloest werden, und
+    # nicht die Zusicherung.
+    def _fully_placed():
+        cfg = build_default_display_config()
+        active = [mc.metric_id for mc in cfg.metrics if mc.enabled]
+        _place(cfg, ["wind", "temperature", "gust", "precipitation"]
+               + [m for m in active
+                  if m not in {"wind", "temperature", "gust", "precipitation"}])
+        return cfg
+
+    before = render_for_channel("telegram", _fully_placed(), "morning").table_columns
+
+    scrambled = _fully_placed()
+    scrambled.metrics = list(reversed(scrambled.metrics))
+
+    after = render_for_channel("telegram", scrambled, "morning").table_columns
+
+    assert before == after, (
+        "Die Telegram-Spalten haengen an der Array-Reihenfolge statt an der "
+        f"eingestellten Position: {before} vs. {after}"
+    )
+
+
+# --- AC-6 -----------------------------------------------------------------
+
+def test_channel_layout_keeps_selection_and_applies_order():
+    """AC-6: Bei kanal-eigenen Listen aendert sich nur die Reihenfolge."""
+    config = build_default_display_config()
+    # Array-Reihenfolge (temperature, wind, gust) weicht bewusst von den
+    # Positionen ab -- sonst waere der Test auch ohne Sortierung gruen.
+    config.per_channel_layouts = {
+        "email": [
+            MetricConfig(metric_id="temperature", enabled=True, bucket="primary", order=2),
+            MetricConfig(metric_id="wind", enabled=True, bucket="primary", order=0),
+            MetricConfig(metric_id="gust", enabled=True, bucket="primary", order=1),
+        ],
+    }
+
+    columns = _mail_columns(config)
+
+    assert columns == [_label_of("wind"), _label_of("gust"), _label_of("temperature")], (
+        f"Kanal-Liste: Auswahl oder Reihenfolge stimmt nicht -- Mail zeigt {columns}"
+    )
+
+
+def test_per_report_layout_applies_order():
+    """AC-6, hoechste Kaskadenebene: auch der Pro-Report-Override sortiert.
+
+    Ohne diesen Test bliebe Ebene 1 (`per_report_layouts`, #434) unsortiert,
+    ohne dass ein Test rot wird -- aufgedeckt durch die Mutations-Gegenprobe.
+    """
+    config = build_default_display_config()
+    config.per_report_layouts = {
+        "morning": {
+            "email": [
+                MetricConfig(metric_id="temperature", enabled=True, bucket="primary", order=2),
+                MetricConfig(metric_id="wind", enabled=True, bucket="primary", order=0),
+                MetricConfig(metric_id="gust", enabled=True, bucket="primary", order=1),
+            ],
+        },
+    }
+
+    columns = _mail_columns(config)
+
+    assert columns == [_label_of("wind"), _label_of("gust"), _label_of("temperature")], (
+        f"Pro-Report-Liste ignoriert die eingestellte Position -- Mail zeigt {columns}"
+    )
+
+
+def test_unknown_bucket_never_jumps_ahead_of_primary():
+    """Ein unbekannter Bucket-Wert sortiert ans ENDE, nie nach vorn.
+
+    Bestandsdaten koennen einen Bucket tragen, den der Editor heute nicht mehr
+    schreibt. So ein Wert darf die bewusst gesetzten Positionen nicht
+    ueberholen -- sonst verschoebe ein Altdaten-Artefakt die Mail-Spalten.
+    """
+    config = build_default_display_config()
+    _place(config, ["wind", "gust"], bucket="primary")
+    for mc in config.metrics:
+        if mc.metric_id == "temperature":
+            mc.bucket = "unbekannt"
+            mc.order = 0
+        elif mc.metric_id not in {"wind", "gust"}:
+            mc.enabled = False
+
+    columns = _mail_columns(config)
+
+    assert columns.index(_label_of("temperature")) > columns.index(_label_of("gust")), (
+        f"Groesse mit unbekanntem Bucket ueberholt die gesetzten Positionen: {columns}"
+    )


### PR DESCRIPTION
Scheibe 1 von #1575, Symptom A. Spec + Implementierung + Tests.

## Problem

Der Abschnitt „Reihenfolge" im Tab *Wetter-Metriken* verspricht wörtlich „links → rechts in der Email-Tabelle", hat aber keine Wirkung. Am KHW-Trip vom PO beobachtet.

## Ursache (gemessen, nicht vermutet)

1. Der Editor legt die gezogene Position **nur** ins Feld `order`; das `metrics`-Array bleibt in Katalog-Reihenfolge (`metricsEditor.ts:329`, `:367-370`).
2. Der Mail-Renderer baut seine Spaltenfolge aus der **Array-Reihenfolge** (`email/html.py:1018-1027` `_col_order`) und liest `order` nie.
3. `get_metrics_for_channel()` (`models.py:700-732`) gab unsortiert zurück — die einzige Stelle, die alle Kanäle durchlaufen.

Telegram und Ortsvergleich sortieren längst nach `(bucket, order)` (`channel_layout.py:89-94`). Die Mail war der einzige ausscherende Kanal.

## Änderung

`_sorted_by_layout()` in `src/app/models.py`, angewandt auf **alle drei** Kaskadenebenen von `get_metrics_for_channel`. `sorted()` ist stabil — Altbestand mit lauter `order = 0` behält exakt seine bisherige Reihenfolge.

37 Zeilen Produktivcode, 1 Datei. Keine gate-geschützte Mail-Inhalts-Datei berührt.

## Wirkungsnachweis am Wirkort

Dieselbe Messung, die den Fehler belegt hat (gerenderte Mail, nicht die Sortierfunktion isoliert):

| | HTML-Spalten |
|---|---|
| vorher, `order` rotiert | `Time, Temp, Feels, Wind, …, Sun, TmpMin, Risk` — unverändert |
| nachher, `order` rotiert | `Time, `**`Sun`**`, Temp, Feels, Wind, …, TmpMin, Risk` |

## Adversary — Verdict HOLDS

Mutations-Gegenprobe mit 9 Verfälschungen (String-Ersetzung mit externer Sicherungskopie, kein `git checkout/stash/reset`). **Zunächst 2 ungefangen:**

- **F001 (MEDIUM):** Ebene 1 der Kaskade (`per_report_layouts`, #434) ließ sich unsortiert zurückbauen, **ohne dass ein Test rot wurde** — AC-6 war nur gegen Ebene 2 geprüft. `Code reference: src/app/models.py:746`
- **F002 (LOW):** Der Rang unbekannter Bucket-Werte war unbewacht. `Code reference: src/app/models.py:657`

Beide mit Tests geschlossen → **Endstand 9 von 9 gefangen.**

## Tests

8 neue Tests in `tests/unit/test_mail_column_order.py`, alle am Wirkort (`format_email`). RED-Stand vor dem Fix: 4 rot (der Fehler), 2 grün (Regressionswächter).

Blast-Radius grün: `test_issue_448_*` (6), `test_issue_429/434/360`, `test_compare_kanal_metriken`, `test_trip_empty_metric_selection`, Renderer-Suiten (157). `ruff` sauber.

## Bewusst nicht in dieser Scheibe (gate-erzwungen)

- **Plain-Text-Hälfte:** kennt den `col_order`-Mechanismus gar nicht (`plain.py:53-59`); ihr Fix berührt eine gate-geschützte Mail-Inhalts-Datei und braucht einen `briefing_mail_validator.py`-Lauf gegen eine echt zugestellte Staging-Mail. Diese Session hat keine IMAP-/Staging-Zugänge.
- **Zusatzbefund:** HTML und Plain divergieren schon heute (`TmpMin` Position 2 vs. vorletzter Platz; Ursache `temperature_cold.selectable = False`). In AC-3 als gemessener Vorzustand festgehalten, damit die Sortierung sie nicht mitverschiebt. Trip-seitiges Geschwister von #1356.
- **Symptom B** (Kanal-Trennung im Editor): eigene Spec, braucht PO-Entscheidung zum Bedienkonzept.

## Status

- [x] Analyse gemessen
- [x] Spec + ACs, PO-Freigabe erteilt
- [x] TDD RED (4 rot)
- [x] GREEN + Adversary (9/9 Mutationen gefangen)
- [ ] CI-Ampel grün
- [ ] Staging-Funktionsprobe (Übergabe — Produktcode, volle Liefer-Kette)