### PR TITLE
fix(#1544,#1545): Trip-Alarmzeilen aus Auswahl x Register ableiten

### DIFF
--- a/docs/context/fix-1544-1545-alarm-zeilen-ableitung.md
+++ b/docs/context/fix-1544-1545-alarm-zeilen-ableitung.md
@@ -1,0 +1,223 @@
+# Context: fix-1544-1545-alarm-zeilen-ableitung
+
+**Issues:** #1544 (Neuer Trip kann Alarme nicht erstmalig einrichten) + #1545 (wirkungslose Zeile Luftfeuchtigkeit)
+**Track:** Full Process · **Erstellt:** 2026-08-07
+**Vorgeschichte:** Beide ausgegliedert aus #1435 E4 (PO-Entscheid 2026-08-06). Die E4-Spec kündigt #1545 wörtlich als Folge-Ticket an.
+
+## Request Summary
+
+Der Trip-Editor leitet die Zeilen seiner Alarm-Tabelle aus den **persistierten Schlüsseln**
+(`Object.keys(display_config.metric_alert_levels)`) ab, der Ortsvergleich dagegen aus
+**Auswahl × Katalog**. Aus diesem einen Unterschied folgen drei nutzersichtbare Fehler.
+
+## 🔴 Der Befund, der in keinem der beiden Tickets steht
+
+Die Tickets beschreiben den Fehler als „Alarme lassen sich nicht einrichten". **Gemessen am echten
+Datenbestand ist er das Gegenteil: die Alarme sind bereits scharf — nur unsichtbar und nicht
+abschaltbar.**
+
+Ursache ist ein Auffüll-Mechanismus im Backend (`src/services/alert_preset.py:309-348`): fehlt für
+eine im Reiter *Wetter-Metriken* aktivierte, alarmfähige Größe ein Eintrag in
+`metric_alert_levels`, wird stillschweigend `standard` angenommen — und daraus entsteht eine
+**scharfe** Regel im Live-Detektor (`deviation_alert_engine.py:191-198`), keine bloße Anzeige.
+
+### Messung an den 14 echten Trips
+
+Gelesen aus `data/users/*/briefings/*.json` (der maßgebliche Pfad seit #1250 S7a; `trips/` wird
+laut `internal/store/trip.go:215-216` nicht mehr geschrieben). Regeln nicht nachgerechnet, sondern
+mit dem echten Produktivcode erzeugt: `load_trip_from_dict()` → Guard aus
+`deviation_alert_engine.py:186-191` → `expand_per_metric_levels()`.
+
+| Fehlerklasse | Betroffen | Wirkung |
+|---|---|---|
+| **1 — unsichtbare Scharfschaltung** | **12 von 14** | 6–9 scharfe Regeln je Trip, **null** Zeilen im Datensatz. Kein Bedienelement existiert, über das der Nutzer sie sehen oder abschalten könnte. Keine einzige Nutzerentscheidung dahinter. |
+| **2 — Geisterzeile Luftfeuchtigkeit** | **2 von 14** | Zeile sichtbar, löst nie aus (seit #889/ADR-0010 backendseitig hart ausgeschlossen). Seit E4 zeigt sie „—" statt der irreführenden Zahl. |
+| **3 — vorgetäuschte Kontrolle** | **2 von 14** | Der Nutzer hat 13 Zeilen auf echte Stufen gesetzt (**nicht** „aus"); real wirken nur 8 bzw. 6. Bei „Lottis Abschiedfahrradtour" sind **7 von 13** Zeilen auf `standard` und trotzdem stumm, weil die zugehörige Wetter-Metrik im anderen Reiter nicht aktiviert ist. |
+
+**Kein einziger der 14 Trips zeigt korrekt an, was tatsächlich wirkt.**
+
+Klasse 3 steht in **keinem** der beiden Tickets. Verwerfende Stelle: `alert_preset.py:278-283` via
+`is_alert_metric_active()` (`weather_change_detection.py:181-221`) — dokumentiert als gewollte
+„Deaktivieren-Lücke" (#961), aus Nutzersicht aber nicht von einem echten „aus" zu unterscheiden.
+
+Der in #1544 vermutete Fall „ganz frischer Trip bekommt gar keinen Detektor" kommt im realen
+Bestand **nicht** vor — jeder Trip hat mindestens eine Wetter-Metrik aktiviert.
+
+## Der Lösungsweg löst alle drei Klassen mit einem Schnitt
+
+Leitet der Trip-Reiter seine Zeilen aus **Auswahl × Katalog** ab (wie der Ortsvergleich seit
+#1435 E1a-2, `53f88757`), fällt jede Klasse für sich weg:
+
+| Klasse | Warum sie verschwindet |
+|---|---|
+| 1 | Für jede aktivierte alarmfähige Größe entsteht eine Zeile — genau die Menge, die der Backfill scharf schaltet. Sichtbar und änderbar. |
+| 2 | Luftfeuchtigkeit ist im Register nicht alarmfähig → keine Zeile. |
+| 3 | Nicht aktivierte Größen liefern keine Zeile mehr → keine Stufe ohne Wirkung. Der gespeicherte Wert bleibt liegen und wirkt wieder, sobald die Größe erneut aktiviert wird. |
+
+Die Anzeige zeigt damit deckungsgleich, was das Backend auswertet — heute weichen beide voneinander ab.
+
+## ⚠️ Zwei Fallen, die ohne Messung zugeschnappt wären
+
+**Falle 1 — den toten Code wiederbeleben.** `frontend/src/lib/components/alerts-tab/AlertsTab.svelte`
+(nachgemessen nirgends eingebunden; einziger Treffer ist eine negative Assertion in
+`corridorEditorMobile.test.ts:193`) trägt mit `activeAlertableMetrics()` +
+`CATALOG_TO_ALERT_METRICS` (`alertMetricTable.ts:266-311`) bereits eine fertige Übersetzung. Sie
+führt aber weiterhin `humidity: ['humidity']` (`:277`) — ein naiver Fix würde **#1545
+verschlimmern** und eine weitere handgepflegte Liste zementieren (gegen #1435).
+
+**Falle 2 — den Vergleichs-Katalog recyceln.** `GET /api/compare/metrics` liefert die Alarm-Identität
+fertig mit (`alertMetric`), `GET /api/metrics` nicht. Naheliegend wäre, ihn auch für Trips zu
+nutzen. Das verschluckt zwei Alarmzeilen: **`temperature_change` und `precipitation_change` sind
+über keinen Compare-Auswahlschlüssel erreichbar** — der Vergleichskatalog führt Temperatur nur als
+`max`/`min`. Trips können beides. Belegt an allen 26 Compare-Einträgen.
+
+→ Die Ableitung muss auf Ebene der **Metrik-Kennung** gegen das zentrale Register laufen.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `frontend/src/lib/components/trip-detail/AlarmeScheduleTab.svelte:36-42` | **Der Fehler.** `activeMetrics = Object.keys(metricLevels)` |
+| `frontend/src/lib/components/shared/AlarmeTab.svelte:135-147` | Geteilter Baustein, `context`-Weiche; Vergleichs-Zweig als Vorbild |
+| `frontend/src/lib/components/shared/alarme-tab/activeAlertMetricsFromCatalog.ts:19-68` | `deriveActiveAlertMetricsFromCatalog` — das Vorbild, aber auf Compare-Keys |
+| `frontend/src/lib/components/alerts-tab/alertMetricTable.ts:185-197, 266-311` | `ALERTABLE_METRICS` (13, enthält `humidity`) + tote Übersetzungstabelle |
+| `frontend/src/lib/components/alerts-tab/AlertMetricLevelTable.svelte:70-79` | Rendert ungefiltert; Filterung ist Sache des Aufrufers |
+| `api/routers/config.py:58-107` | `GET /api/metrics` — gibt Alarm-Identität **nicht** vollständig heraus |
+| `src/app/metric_catalog.py:591-619` | `alert_metric_for(metric_id, aggregation)` — existiert, nicht exponiert |
+| `src/services/alert_preset.py:143-350` | Backfill (`:309-348`), „off" (`:275-276`), Verwerfen (`:278-283`) |
+| `src/services/weather_change_detection.py:181-221` | `is_alert_metric_active` — Kopplung an den Wetter-Reiter |
+| `src/output/renderers/trip_metric_ids.py:29-57` | Drei Zustände + Vorgabesatz (7 Kennungen) |
+
+## Zahlen aus dem Register (gelesen, nicht geschätzt)
+
+- 27 Katalog-Einträge, davon 25 wählbar (`temperature_cold`, `confidence` haben `selectable=False`)
+- **9** Größen sind alarmfähig, 16 nicht
+- **12** Alarm-Identitäten insgesamt (9 aus `alert_metrics`, 3 aus `change_alert_metric`) — eine Größe
+  kann mehrere tragen (`temperature` → `min`/`max`/`change`)
+- Frontend führt **13**; die Differenz zur generierten Backend-Datei ist exakt `{humidity}` und in der
+  Gegenrichtung leer. **Luftfeuchtigkeit ist die einzige Geisterzeile.**
+
+## Bindende Entscheidungen
+
+| Quelle | Bindender Inhalt |
+|---|---|
+| **ADR-0010** | Luftfeuchtigkeit ist Vorboten-Größe, kein Alarm-Auslöser. Enum bleibt für Altdaten. → Entfernen aus der Anzeige ist ADR-konform. |
+| **ADR-0032** | Progressive Tab-Editoren, kein Wizard. → Lösung bleibt im Reiter, **kein** neuer Onboarding-Schritt. |
+| **ADR-0043** | Empfindlichkeitsstufe ist der einzige Alarm-Regler. → keine zweite Steuergröße einführen. |
+| **#946 AC-4** | „…einen Onboarding-Zustand … **und keinen stillen Standard-Preset**." Der Mechanismus wurde in `AlertsTab.svelte` gebaut und ist heute toter Code. **Der stille Standard existiert trotzdem — im Backend-Backfill.** Die Zeilen anzuzeigen macht sichtbar, was ohnehin gilt; es schafft ihn nicht. |
+| **#1258 S3 D4** | Hat die Ableitung aus persistierten Schlüsseln für den Trip-Pfad festgeschrieben — die Stelle, die heute der Fehler ist. |
+| **#1435 E1a-2** | Stellte **nur** den Vergleichs-Zweig um, AC-3 ausdrücklich: „Trip-Zweig bleibt unangetastet". Ab da liefen die Pfade auseinander. |
+| **Teilungs-Invariante** | Ableitungslogik gehört nach `shared/alarme-tab/`. Eine **neue** Datei unter `trip-detail/**` löst die Pendant-Sperre aus; Änderungen an der bestehenden `AlarmeScheduleTab.svelte` sind frei. |
+
+## ⚠️ Test, der dem Fix im Weg steht
+
+`frontend/src/lib/components/shared/__tests__/alarme_tab_catalog_prop_structure.test.ts` prüft per
+AST (AC-7 aus #1258):
+
+- `:246-268` — der `context==='route'`-Zweig in `AlarmeTab.svelte` darf **ausschließlich**
+  `activeMetrics` lesen, nie `catalog` / `deriveActiveAlertMetricsFromCatalog` / `wiz`
+- `:270-284` — `AlarmeScheduleTab.svelte` darf **keinen** `catalog`-Prop an `<AlarmeTab>` übergeben
+
+Der Test zementiert exakt die Trennung, die den Fehler verursacht. **Regelkonformer Ausweg:**
+`activeMetrics` bereits fertig berechnet in `AlarmeScheduleTab.svelte` übergeben (dort ist die
+Katalog-Nutzung nicht verboten) — dann bleibt `AlarmeTab.svelte` unberührt und der Test grün. Ob das
+trägt oder der Test begründet zu ändern ist, entscheidet die Spec, nicht die Implementierung.
+
+## Persistenz
+
+- Python `src/app/models.py:667`: `metric_alert_levels: Optional[dict[str,str]]` — freies Dict
+- Go `internal/model/trip.go:111`: `DisplayConfig map[string]interface{}` — untypisiertes JSON
+- `internal/handler/config_merge.go:11-22`: **flacher** Top-Level-Merge. Nicht mitgesendete Keys
+  bleiben; ein mitgesendetes `metric_alert_levels` **ersetzt** den ganzen bisherigen Wert.
+- Migrationen existieren nur für `snow_line`→`freezing_level` (`loader.py:716-730`,
+  `internal/store/trip.go:283-299`). Für `humidity` gibt es **keine** — #889 lieferte keine mit,
+  deshalb überlebt der Schlüssel bis heute.
+
+## Offene Frage für die Spec (PO-Entscheidung)
+
+**Umfang.** Klasse 3 (vorgetäuschte Kontrolle) steht in keinem Ticket, verschwindet aber durch
+denselben Fix. Zwei Wege:
+
+- **A — mitnehmen** (Empfehlung): ein Schnitt, eine Ableitung, alle drei Klassen weg. Kein
+  Mehraufwand in der Umsetzung, aber die ACs müssen es abdecken, sonst ist es ungeprüfte Wirkung.
+- **B — Klasse 3 ausgliedern**: kleinerer Nachweis, aber der Fix ändert das Verhalten ohnehin — dann
+  bliebe eine Wirkung ohne AC, genau das Muster, das #1435 dreimal Findings gekostet hat.
+
+**Migration der `humidity`-Schlüssel:** nicht nötig. 2 Trips tragen den Schlüssel, er wirkt schon
+heute nicht, und die neue Ableitung zeigt ihn nicht mehr an. Ein Aufräumen wäre kosmetisch und
+brächte Datenrisiko ohne Nutzen.
+
+## Risks
+
+- **Verhaltensänderung ist Sichtbarmachung, keine Neuerung** — die 6–9 Regeln je Trip laufen bereits.
+  Der Nutzer sieht künftig Zeilen, die er nie gesetzt hat. Das ist beabsichtigt und muss in der
+  Oberfläche als „gilt derzeit" lesbar sein, nicht als „du hast das eingestellt".
+- Nach dem Fix kann der Nutzer diese Regeln erstmals auf „aus" stellen — das **verringert** Alarme
+  gegenüber heute. Erwünscht, aber eine echte Änderung am Versand.
+- ~~Der Trip-Katalog kennt heute keine Alarm-Identität; `GET /api/metrics` muss sie liefern → Backend-Änderung.~~
+  **Korrigiert 2026-08-07 nach Nachmessung an der Route:** `GET /api/metrics` liefert
+  `aggregations[].alert_metric` (`api/routers/config.py:98-105`) und `change_alert_metric`
+  (`:89`) **bereits**. Nur der Frontend-Typ `MetricEntry` (`frontend/src/lib/types.ts:159-194`)
+  nimmt beide Felder nicht auf. Der Umfang ist damit **frontend-only** — eine additive
+  Typ-Erweiterung, kein Backend-Change.
+- Volle Staging-Verifikation trotzdem: es ändert sich sichtbares Verhalten an echten Trip-Daten
+  (6–9 Regeln je Trip werden erstmals sichtbar und abschaltbar). Der Frontend/Backend-Schnitt ist
+  dafür nicht das Kriterium.
+- `frontend`-Änderung ⇒ Pflicht-Prüfung im echten Browser (PO-Vorgabe 2026-08-07, #1552).
+
+## 🔴 Zwei Fallen aus der Strategie-Bewertung (beide heute ungetestet)
+
+**Falle 3 — der Altbestands-Sonderfall.** `is_alert_metric_active()`
+(`weather_change_detection.py:213-216`) behandelt einen Trip mit leerem/fehlendem
+`display_config.metrics` als „**jede** alarmfähige Größe ist aktiv" — bewusst konservativ, damit
+Alt-Trips keinen stillen Alarmverlust erleiden. Eine naive Frontend-Ableitung („keine `metrics[]`
+→ keine aktiven Größen → keine Zeilen") zeigt für genau diese Trips **wieder null Zeilen**, während
+das Backend alles scharf hat — ein Rückfall in Klasse 1, unbemerkt von jedem Test, der nur Trips
+mit gesetztem `metrics[]` prüft. Braucht eigenen AC.
+
+**Falle 4 — Datenverlust beim Speichern.** `buildAlarmeDeliveryPayload`
+(`alarmeDeliveryPayload.ts:117-121`) sendet `metric_alert_levels` als **vollständigen Ersatz**; der
+Go-Merge ist flach (`config_merge.go:11-22`), der Top-Level-Key wird komplett überschrieben. Heute
+trägt die `metricLevels`-Prop den **ungefilterten** gespeicherten Dict
+(`AlarmeScheduleTab.svelte:36-38`). Ein naiver Fix, der sie mitfiltert („was nicht angezeigt wird,
+muss man auch nicht speichern"), löscht beim nächsten Speichern die Stufen aller deaktivierten
+Größen. **Die beiden Props müssen aus getrennten Quellen kommen: `activeMetrics` gefiltert,
+`metricLevels` ungefiltert.** Braucht eigenen AC.
+
+## Geklärt: der AC-7-Test steht dem Fix nicht im Weg
+
+`alarme_tab_catalog_prop_structure.test.ts` prüft (a) die Bezeichner im `route`-Zweig von
+`AlarmeTab.svelte` und (b) die Attribut-Allowlist der `<AlarmeTab>`-Einbettung in
+`AlarmeScheduleTab.svelte` (`:284-293`). Rechnet `AlarmeScheduleTab.svelte` die Ableitung **selbst**
+und übergibt weiterhin nur `activeMetrics` unter demselben Namen, bleiben beide Prüfungen grün —
+`AlarmeTab.svelte` wird nicht angefasst, die Attributliste ändert sich nicht. Der Test bewacht die
+Grenze zwischen den Komponenten, nicht die Datenquelle innerhalb des Containers. **Kein Testumbau,
+kein AC-7-Konflikt.** Im Adversary trotzdem mitlaufen lassen statt anzunehmen.
+
+## Technischer Ansatz (entschieden)
+
+1. `MetricEntry` in `frontend/src/lib/types.ts` additiv erweitern: `alert_metric` in
+   `aggregations[]`, `change_alert_metric` am Interface (~6 Zeilen).
+2. Geteilte Ableitung unter `frontend/src/lib/components/shared/alarme-tab/` — Kern
+   `alertIdentitiesForMetricEntry(entry)`: liest `aggregations[].alert_metric` **und**
+   `change_alert_metric`, dedupliziert. Belegt durch die Messung: ein Trip mit aktivierter
+   Temperatur erzeugt real alle drei Identitäten (`temperature_min=5`, `temperature_max=6`,
+   `temperature_change=10`) — beide Quellen zusammen, nicht die eine oder die andere.
+   Reihenfolge stabil über `ALERTABLE_METRICS`, sonst springen Zeilen bei jedem Speichern.
+3. `AlarmeScheduleTab.svelte` umverdrahten; `metricsCatalog` von `TripTabs.svelte:232`
+   durchreichen — dort bereits geladen (`:199`), **kein neuer Abruf**.
+4. **Keine** Vereinheitlichung mit `deriveActiveAlertMetricsFromCatalog`: das arbeitet auf
+   Compare-Auswahlschlüsseln, Trip auf nackten Metrik-Kennungen. Gemeinsamer Kern, zwei Aufrufer —
+   eine erzwungene gemeinsame Signatur liefe genau in Falle 2.
+
+**Umfang:** ~60–90 LoC produktiv, **eine Scheibe** (Limit 250). Ein Schnitt schadete hier: alle drei
+Fehlerklassen hängen an derselben Ableitung, ein Zwischenstand zeigt keine korrekte Zeilenliste.
+
+## Nebenbefunde (nicht in diesem Workflow)
+
+- **#1435 Ticket-Body führt E4 noch als offen**, obwohl am 6.8. live (`2a31fd60`). Genau dieses
+  Muster hat dort schon einmal eine Falschbuchung über drei Stellen fortgeschrieben → Body nachziehen.
+- `tripActiveMetricNames.ts:27` verweist auf `trip_report.py:119`, die Bedingung steht heute in
+  `:127` — veralteter Kommentar, Logik identisch.
+- Verwaister Workflow-State `fix-1544-1545-trip-alarm-onboarding` (behauptete Phase 6, Spec
+  freigegeben, rote Tests — nichts davon existierte) → abgebrochen, gebucht in #1197.

--- a/docs/specs/modules/fix_1544_1545_trip_alarm_zeilen_ableitung.md
+++ b/docs/specs/modules/fix_1544_1545_trip_alarm_zeilen_ableitung.md
@@ -1,0 +1,323 @@
+---
+entity_id: fix_1544_1545_trip_alarm_zeilen_ableitung
+type: module
+created: 2026-08-07
+updated: 2026-08-07
+status: draft
+version: "1.0"
+tags: [alarme, trip-editor, alarm-zeilen, register]
+---
+
+# Trip-Alarme: Zeilen aus Auswahl × Register statt aus persistierten Schlüsseln
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Der Reiter *Alarme* im Trip-Editor zeigt heute nur Zeilen für Größen, die bereits einen
+Eintrag in `display_config.metric_alert_levels` haben. Das Backend schaltet aber jede im
+Reiter *Wetter-Metriken* aktivierte, alarmfähige Größe scharf — auch ohne einen solchen
+Eintrag. Diese Spec bringt beide Mengen zur Deckung: der Trip-Reiter leitet seine Zeilen
+künftig aus **Auswahl × Alarmfähigkeit-aus-dem-zentralen-Register** ab, genau wie es der
+Ortsvergleichs-Reiter seit #1435 E1a-2 bereits tut. Was der Nutzer sieht, ist danach, was
+tatsächlich wirkt.
+
+## Source
+
+- **File:** `frontend/src/lib/components/trip-detail/AlarmeScheduleTab.svelte`
+- **Identifier:** `activeMetrics` (Zeile 39, `Object.keys(metricLevels)`)
+
+> **PFLICHT — Schicht-Hinweis:** betroffen ist ausschließlich die Frontend-Schicht
+> (`frontend/src/lib/...`, SvelteKit). Kein Go-, kein Python-Code wird geändert — das
+> Backend liefert die nötigen Register-Felder bereits (`api/routers/config.py:89,98-105`),
+> nur der Frontend-Typ nimmt sie noch nicht auf (`frontend/src/lib/types.ts:159-194`).
+
+## Estimated Scope
+
+- **LoC:** ~60–90 (Limit 250)
+- **Files:** ~4 (Typ-Erweiterung, neue Ableitungsfunktion + Test, Umverdrahtung
+  `AlarmeScheduleTab.svelte`, Weiterreichen des Katalogs in `TripTabs.svelte`)
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `frontend/src/lib/components/shared/alarme-tab/activeAlertMetricsFromCatalog.ts` | Vorbild (kein Aufrufer) | Zeigt das Ableitungsmuster für den Vergleichs-Pfad — Kern wird NICHT wiederverwendet, siehe „Warum keine Vereinheitlichung mit Compare" |
+| `frontend/src/lib/components/alerts-tab/alertMetricTable.ts` (`ALERTABLE_METRICS`) | Bestehende Konstante | Liefert die stabile Anzeige-Reihenfolge; unverändert weiterverwendet |
+| `api/routers/config.py::get_metrics()` | Bestehender Endpoint | Liefert `aggregations[].alert_metric` und `change_alert_metric` bereits — keine Backend-Änderung nötig |
+| `frontend/src/lib/components/trip-detail/TripTabs.svelte` (`metricsCatalog`) | Bestehender State | Bereits geladen (Zeile ~199), wird zusätzlich an `AlarmeScheduleTab` durchgereicht |
+
+## Implementation Details
+
+### 1. Register-Felder im Frontend-Typ sichtbar machen
+
+`MetricEntry` in `frontend/src/lib/types.ts` additiv erweitern:
+
+```
+aggregations?: { id: string; label: string; alert_metric?: string | null }[];
+change_alert_metric?: string | null;
+```
+
+Beide Felder liefert `GET /api/metrics` bereits (`api/routers/config.py:89` bzw.
+`:98-105`); nur der Frontend-Typ nahm sie bisher nicht auf. Rein additiv, kein
+Breaking Change für bestehende Aufrufer.
+
+### 2. Geteilte Ableitungsfunktion (Trip-eigene Kennungen, kein Compare-Namensraum)
+
+Neue Funktion unter `frontend/src/lib/components/shared/alarme-tab/` (Teilungs-Invariante:
+Ableitungslogik gehört dorthin, nicht nach `trip-detail/**`), z. B.
+`alertIdentitiesForMetricEntry(entry: MetricEntry): AlertMetric[]`:
+
+- liest `aggregations[].alert_metric` **und** `change_alert_metric` vom übergebenen
+  Katalog-Eintrag
+- dedupliziert (eine Größe wie Temperatur trägt real drei Identitäten:
+  `temperature_min`, `temperature_max`, `temperature_change` — belegt an echten
+  Trip-Daten, siehe Kontext-Dokument)
+- eine zweite Funktion (analog zu `deriveActiveAlertMetricsFromCatalog`) wendet das auf
+  die **aktivierten** Katalog-Einträge eines Trips an und ordnet das Ergebnis über
+  `ALERTABLE_METRICS` in stabile Anzeige-Reihenfolge — dieselbe Reihenfolge-Quelle wie
+  der Vergleichs-Pfad, damit Zeilen nicht bei jedem Speichern springen
+
+### 3. Falle 3 — Altbestands-Sonderfall (leere/fehlende Wetter-Metriken-Auswahl)
+
+`is_alert_metric_active()` (`src/services/weather_change_detection.py:186-191`) behandelt
+ein komplett leeres `display_config.metrics[]` als „jede alarmfähige Größe ist aktiv"
+(konservativ, kein stiller Alarmverlust für Alt-Trips). Die neue Frontend-Ableitung MUSS
+denselben Sonderfall abbilden: ist `trip.display_config.metrics` leer oder nicht gesetzt,
+gelten **alle** alarmfähigen Register-Einträge als aktiv — nicht keine. Sonst zeigt die
+Oberfläche für genau diese Trips wieder null Zeilen, während das Backend alles scharf hat
+(Rückfall in Fehlerklasse 1).
+
+### 4. Falle 4 — getrennte Quellen für Zeilen-Sichtbarkeit und Speicher-Payload
+
+`AlarmeScheduleTab.svelte` übergibt an `AlarmeTab` (`context="route"`) zwei Props, die aus
+**unterschiedlichen, unabhängig berechneten** Werten stammen dürfen:
+
+- `activeMetrics` — die NEUE, gefilterte Ableitung aus Auswahl × Register (bestimmt, welche
+  Zeilen sichtbar sind)
+- `metricLevels` — bleibt der **ungefilterte** gespeicherte `metric_alert_levels`-Dict wie
+  bisher (`trip.display_config?.metric_alert_levels ?? {}`, unverändert)
+
+Grund: `buildAlarmeDeliveryPayload` (`alarmeDeliveryPayload.ts:117-121`) sendet
+`metric_alert_levels` beim Speichern als **vollständigen Ersatz**, der Go-Merge ist flach
+(`internal/handler/config_merge.go:11-22`). Würde `metricLevels` mitgefiltert, verlöre eine
+deaktivierte Größe beim nächsten Speichern ihre zuvor gesetzte Stufe unwiderruflich (echter
+Datenverlust, nicht nur Anzeige). Die gefilterte Ableitung darf daher **nur** in
+`activeMetrics` einfließen, nie in `metricLevels`.
+
+### 5. Umverdrahtung
+
+- `AlarmeScheduleTab.svelte`: `activeMetrics` wird aus der neuen Ableitungsfunktion
+  berechnet (Katalog + `trip.display_config`), statt aus `Object.keys(metricLevels)`.
+  `metricLevels` bleibt unverändert (Punkt 4).
+- `TripTabs.svelte`: das dort bereits geladene `metricsCatalog` (Zeile ~199/232) wird
+  zusätzlich an `<AlarmeScheduleTab>` durchgereicht — **kein neuer Abruf**.
+- `AlarmeTab.svelte` selbst wird **nicht** angefasst: der `route`-Zweig liest weiterhin nur
+  `activeMetrics`/`metricLevels` als Props, unverändert zum bisherigen Vertrag (hält den
+  AC-7-Struktur-Test grün, siehe „Known Limitations").
+
+### Warum keine Vereinheitlichung mit dem Compare-Pfad (Falle 2)
+
+`deriveActiveAlertMetricsFromCatalog()` arbeitet auf **Compare-Auswahlschlüsseln**
+(`CompareSelectionEntry`), der Trip-Pfad auf **nackten Metrik-Kennungen** aus
+`display_config.metrics[]`. Eine erzwungene gemeinsame Signatur würde denselben Fehler
+reproduzieren, der schon den Compare-Katalog ungeeignet macht: `GET /api/compare/metrics`
+führt Temperatur nur als `max`/`min` — `temperature_change` und `precipitation_change`
+sind über keinen Compare-Auswahlschlüssel erreichbar (belegt an allen 26
+Compare-Einträgen), Trips können aber beides. Die Ableitung läuft deshalb bewusst auf
+Ebene der **Metrik-Kennung** gegen `MetricEntry` (Trip-Katalog), mit einem gemeinsamen
+Kern (`alertIdentitiesForMetricEntry`), aber zwei getrennten Aufrufern für die
+unterschiedlichen Auswahl-Räume.
+
+## Expected Behavior
+
+- **Input:** ein Trip mit `display_config.metrics[]` (aktivierte Wetter-Metriken) und
+  optional `display_config.metric_alert_levels` (gesetzte Empfindlichkeitsstufen); der
+  vollständige Metrik-Katalog aus `GET /api/metrics`.
+- **Output:** der Reiter *Alarme* zeigt genau eine Zeile je alarmfähiger Alarm-Identität,
+  die zu einer aktivierten Wetter-Metrik gehört — in stabiler, aus `ALERTABLE_METRICS`
+  abgeleiteter Reihenfolge. Jede Zeile zeigt die zuletzt gespeicherte Stufe (Default
+  `standard`, wenn nie gesetzt).
+- **Side effects:** keine neuen Netzwerk-Abrufe (Katalog ist bereits geladen); Speichern
+  schreibt weiterhin den vollständigen, ungefilterten `metric_alert_levels`-Dict.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip mit aktivierter alarmfähiger Wetter-Metrik ohne jeden
+  Eintrag in `metric_alert_levels` (Fehlerklasse 1 — unsichtbare Scharfschaltung) /
+  When der Nutzer den Reiter *Alarme* öffnet / Then zeigt der Reiter eine Zeile für
+  diese Größe mit der Stufe „standard", nicht leer.
+  - Test: an einem Trip mit realistisch nachgebildeter Datenlage (aktivierte Größe,
+    kein Alert-Level-Eintrag) prüfen, dass die Zeile im gerenderten/berechneten
+    Zeilensatz erscheint — kein Dateiinhalt-Check.
+
+- **AC-2:** Given ein Trip, dessen `display_config.metric_alert_levels` einen
+  `humidity`-Eintrag trägt (Fehlerklasse 2 — Geisterzeile) / When der Nutzer den Reiter
+  *Alarme* öffnet / Then erscheint keine Zeile „Luftfeuchtigkeit".
+  - Test: Trip mit `metric_alert_levels: {humidity: 'standard', ...}` gegen den echten
+    Metrik-Katalog auswerten; die berechnete Zeilenliste darf `humidity` nicht enthalten.
+
+- **AC-3:** Given ein Trip mit einer Größe, die im Reiter *Alarme* auf eine echte Stufe
+  gesetzt ist, deren zugehörige Wetter-Metrik aber im Reiter *Wetter-Metriken* NICHT
+  aktiviert ist (Fehlerklasse 3 — vorgetäuschte Kontrolle) / When der Nutzer den Reiter
+  *Alarme* öffnet / Then erscheint für diese Größe keine Zeile.
+  - Test: Trip mit gesetzter Stufe für eine deaktivierte Größe; die berechnete
+    Zeilenliste darf diese Größe nicht enthalten.
+
+- **AC-4 (Normalfall zu AC-3):** Given dieselbe Größe wird anschließend im Reiter
+  *Wetter-Metriken* aktiviert und gespeichert / When der Nutzer danach den Reiter
+  *Alarme* öffnet / Then erscheint die Zeile wieder — mit der zuvor gesetzten Stufe,
+  nicht mit „standard" oder „aus".
+  - Test: nach simuliertem Aktivieren prüfen, dass sowohl die Zeile erscheint als auch
+    die vorher gespeicherte (nicht zurückgesetzte) Stufe angezeigt wird.
+
+- **AC-5 (Altbestands-Sonderfall, Falle 3 aus dem Kontext-Dokument):** Given ein Trip,
+  dessen `display_config.metrics` leer oder nicht gesetzt ist (Wetter-Metriken-Reiter
+  nie angefasst) / When der Nutzer den Reiter *Alarme* öffnet / Then zeigt der Reiter
+  Zeilen für **alle** alarmfähigen Größen aus dem Register, nicht null.
+  - Test: Trip mit `display_config.metrics: []` bzw. `metrics: undefined` gegen den
+    vollständigen Katalog auswerten; die Zeilenanzahl muss der Anzahl alarmfähiger
+    Register-Einträge entsprechen, nicht 0.
+
+- **AC-6 (Kein Datenverlust, Falle 4 aus dem Kontext-Dokument):** Given eine Größe mit
+  gesetzter Empfindlichkeitsstufe wird im Reiter *Wetter-Metriken* deaktiviert und der
+  Trip gespeichert / When die Größe später wieder aktiviert wird / Then zeigt ihre
+  Zeile wieder die vor der Deaktivierung gesetzte Stufe — nicht „standard" und nicht
+  „aus".
+  - Test: Speicher-Payload nach dem Deaktivieren prüfen — der zur deaktivierten Größe
+    gehörende Schlüssel bleibt im gesendeten `metric_alert_levels`-Dict erhalten, wird
+    nicht entfernt, obwohl seine Zeile nicht mehr angezeigt wird.
+
+- **AC-7 (Mehrfach-Identität):** Given ein Trip mit aktivierter Temperatur-Metrik /
+  When der Nutzer den Reiter *Alarme* öffnet / Then erscheinen alle drei zugehörigen
+  Alarmzeilen (Minimum, Maximum, Änderungsrate) gleichzeitig, nicht nur eine.
+  - Test: an einer Metrik mit bekannt mehreren Alarm-Identitäten (Temperatur:
+    `temperature_min`, `temperature_max`, `temperature_change`) prüfen, dass alle drei
+    in der berechneten Zeilenliste stehen.
+
+- **AC-8 (Stabile Reihenfolge):** Given ein Trip mit mehreren aktivierten alarmfähigen
+  Größen / When der Reiter *Alarme* mehrfach hintereinander geöffnet wird — auch nach
+  einem Speichervorgang, der die Auswahl nicht ändert / Then steht die Zeilenreihenfolge
+  jedes Mal identisch.
+  - Test: Zeilenliste zweimal aus identischem Trip-Zustand berechnen und auf exakt
+    gleiche Reihenfolge (nicht nur gleiche Menge) prüfen.
+
+- **AC-9 (Deckungsgleichheit — die eigentliche Zusicherung dieser Scheibe):** Given ein
+  beliebiger Trip mit einer Wetter-Metriken-Auswahl / When der Reiter *Alarme* seine
+  Zeilen berechnet / Then ist die Menge der angezeigten Alarm-Identitäten exakt
+  identisch mit der Menge der Identitäten, die der Live-Alarm-Detektor für denselben
+  Trip tatsächlich auswertet (weder mehr noch weniger).
+  - Test: für mindestens einen Trip-Zustand die per Ableitung berechnete Zeilenmenge und
+    die vom echten Backend-Regel-Erzeuger (`expand_per_metric_levels()` /
+    `deviation_alert_engine`) tatsächlich erzeugten Regel-Metriken gegenüberstellen und
+    auf Mengengleichheit prüfen — kein indirekter Näherungsvergleich.
+
+- **AC-10 (Bestandsschutz):** Given ein Trip mit bereits sinnvoll gesetzten
+  Empfindlichkeitsstufen für seine aktivierten Größen / When die neue Ableitung
+  ausgeliefert wird, ohne dass der Nutzer etwas ändert / Then bleiben alle zuvor
+  gesetzten Stufen unverändert erhalten — nichts wird automatisch umgeschrieben oder
+  auf einen anderen Wert zurückgesetzt.
+  - Test: Trip-Zustand vor und nach Anwenden der neuen Ableitung vergleichen — die
+    gespeicherten Stufenwerte je Größe sind identisch, nur die Zeilen-**Sichtbarkeit**
+    ändert sich.
+
+## Nicht in dieser Scheibe
+
+- **Keine Kennzeichnung „gilt derzeit, nicht von dir gesetzt" an den Zeilen.** Für keine
+  der drei Fehlerklassen nötig — sie blähte den Umfang, ohne eine der drei Zusicherungen
+  zusätzlich zu erfüllen.
+- **Keine Migration der `humidity`-Schlüssel.** Betrifft 2 von 14 Trips, der Schlüssel
+  wirkt schon heute nicht (ADR-0010) und wird nach dieser Scheibe nicht mehr angezeigt.
+  Ein Aufräumen der Persistenz wäre kosmetisch und brächte Datenrisiko ohne Nutzen.
+- **Keine Änderung am Backend-Backfill** (`src/services/alert_preset.py:309-348`). Er
+  bleibt exakt wie er ist — diese Scheibe macht seine Wirkung sichtbar, ändert sie
+  nicht.
+- **Kein neuer Onboarding-Schritt oder Wizard.** ADR-0032 (progressive Tab-Editoren,
+  kein Wizard) bleibt bindend; die Lösung bleibt vollständig im bestehenden Reiter.
+- **Keine zweite persistierte Steuergröße neben der Empfindlichkeitsstufe.** ADR-0043
+  legt die Empfindlichkeitsstufe als einzigen Alarm-Regler fest; diese Scheibe führt
+  keinen zusätzlichen Schalter (z. B. ein separates „aktiv"-Flag) ein.
+
+## Bindende Entscheidungen
+
+| Quelle | Bindender Inhalt | Wie diese Spec ihn einhält |
+|---|---|---|
+| **ADR-0010** (Vorboten-Metriken kein Alert-Auslöser) | Luftfeuchtigkeit ist Vorboten-Größe, kein Alarm-Auslöser; Enum bleibt für Altdaten. | Die neue Ableitung liest die Alarmfähigkeit aus dem Register — `humidity` deklariert dort keine Alarm-Identität, erscheint also strukturell nicht mehr (AC-2). Keine Löschung der Altdaten. |
+| **ADR-0032** (Wizard-Abschaffung) | Progressive Tab-Editoren, kein Wizard. | Die Lösung bleibt im bestehenden Reiter *Alarme*; kein neuer Schritt, kein Wizard (siehe „Nicht in dieser Scheibe"). |
+| **ADR-0043** (Empfindlichkeitsstufe als einziger Alarm-Regler) | Keine zweite Steuergröße neben der Stufe einführen. | Die Ableitung steuert nur, **welche** Zeile sichtbar ist — nicht **wie** sie gesteuert wird. Die Empfindlichkeitsstufe bleibt der einzige Regler je Zeile. |
+| **#946 AC-4** | „…einen Onboarding-Zustand … und keinen stillen Standard-Preset." | Der stille Standard existiert weiterhin im Backend-Backfill (unverändert, s. o.); diese Scheibe macht ihn sichtbar und stellt einen Bedienweg her — sie schafft ihn nicht neu. |
+| **#1258 S3 D4** | Hatte die Ableitung aus persistierten Schlüsseln für den Trip-Pfad festgeschrieben. | Wird hier bewusst abgelöst — genau diese Festlegung ist die Fehlerursache, die diese Scheibe behebt. |
+| **#1435 E1a-2 AC-3** | Stellte nur den Vergleichs-Zweig um, AC-3 ausdrücklich „Trip-Zweig bleibt unangetastet". | War die dort bewusst gesetzte Grenze für E1a-2 — diese Scheibe ist die angekündigte Folge-Arbeit, die den Trip-Zweig jetzt nachzieht. |
+| **Teilungs-Invariante (Trip/Compare-Code-Teilung)** | Ableitungslogik gehört nach `shared/alarme-tab/`. | Die neue Ableitungsfunktion liegt unter `frontend/src/lib/components/shared/alarme-tab/`; `AlarmeScheduleTab.svelte` (bestehende Datei unter `trip-detail/**`) wird nur umverdrahtet, keine neue Datei dort angelegt — löst die Pendant-Sperre nicht aus. |
+
+## Test-Plan
+
+Kern-Schicht (deterministisch, kein Netz, echte aufgezeichnete Katalog-/Trip-Daten als
+Fixtures), Namensregel: nach Verhalten benennen, nicht nach Issue-Nummer.
+
+| Testdatei (Vorschlag) | Deckt ab | Was geprüft wird |
+|---|---|---|
+| `frontend/src/lib/components/shared/alarme-tab/__tests__/alert_identities_from_metric_entry.test.ts` | AC-1, AC-2, AC-7 | reine Funktionstests der neuen Ableitung gegen nachgebildete `MetricEntry`-Katalogeinträge (inkl. Temperatur mit drei Identitäten, Luftfeuchtigkeit ohne Identität) |
+| `frontend/src/lib/components/shared/alarme-tab/__tests__/trip_active_alert_metrics_derivation.test.ts` | AC-3, AC-4, AC-5, AC-8 | Ableitung Auswahl × Register gegen nachgebildete `display_config`-Zustände: aktiviert/deaktiviert, leeres `metrics[]` (Altbestands-Sonderfall), zweifacher Aufruf auf identischem Zustand (Reihenfolge) |
+| `frontend/src/lib/components/shared/alarme-tab/__tests__/alarme_delivery_payload_preserves_inactive_levels.test.ts` | AC-6 | `buildAlarmeDeliveryPayload`/vergleichbare Payload-Erzeugung: deaktivierte Größe bleibt im gesendeten `metric_alert_levels`-Dict erhalten |
+| `tests/unit/services/test_deviation_alert_engine_matches_frontend_derivation.py` (Python, Kern-Schicht) | AC-9 | Nachbildung eines Trip-Zustands, Regeln über den echten Produktivpfad (`load_trip_from_dict()` → `deviation_alert_engine` → `expand_per_metric_levels()`) erzeugen, die erzeugten Metrik-Identitäten gegen dieselbe Ableitungslogik (als portierte/gespiegelte Erwartung) auf Mengengleichheit prüfen — **kein** Mock des Regel-Erzeugers |
+| `frontend/src/lib/components/shared/__tests__/alarme_tab_catalog_prop_structure.test.ts` (bestehend) | Regressionsschutz | läuft unverändert mit — bewacht, dass `AlarmeTab.svelte` im `route`-Zweig weiterhin nur `activeMetrics`/`metricLevels` liest (kein `catalog`-Prop im Trip-Pfad) |
+| Bestandsschutz zu AC-10 | AC-10 | Snapshot-Vergleich gesetzter Stufen vor/nach Anwenden der neuen Ableitung an einem Fixture-Trip mit bereits konfigurierten Alarmen |
+
+**Mutations-Gegenprobe (Pflicht im Adversary):** u. a. den Altbestands-Sonderfall
+(Falle 3) gezielt entfernen (leeres `metrics[]` liefert dann `[]` statt „alle") und
+prüfen, ob AC-5 das fängt; die Trennung `activeMetrics`/`metricLevels` gezielt
+aufheben (beide aus derselben gefilterten Quelle) und prüfen, ob AC-6 das fängt.
+
+## Known Limitations
+
+- Die `humidity`-Altdaten in `metric_alert_levels` (2 von 14 Trips) bleiben in der
+  Persistenz liegen — unsichtbar, aber nicht entfernt. Siehe „Nicht in dieser Scheibe".
+- `alarme_tab_catalog_prop_structure.test.ts` (AC-7 aus #1258) bleibt unverändert
+  bestehen und wurde geprüft: er bewacht die Grenze zwischen `AlarmeTab.svelte` und
+  seinen Einbettungen, nicht die Datenquelle innerhalb von `AlarmeScheduleTab.svelte` —
+  kein Testumbau nötig, aber im Adversary trotzdem aktiv mitlaufen lassen statt
+  anzunehmen.
+- Der Nutzer sieht nach dieser Scheibe erstmals Alarmzeilen, die er nie selbst gesetzt
+  hat (die 6–9 Regeln je Trip aus Fehlerklasse 1 laufen bereits scharf). Das ist
+  beabsichtigt (Sichtbarmachung, keine Neuerung), bedeutet aber: der Nutzer kann diese
+  Regeln jetzt erstmals auf „aus" stellen, was den tatsächlichen Alarmversand
+  gegenüber heute verringern kann.
+- Kein Backend-Change: `GET /api/metrics` liefert die benötigten Felder bereits;
+  Fehlläufe der Ableitung sind ausschließlich im Frontend zu suchen.
+- **Bewusste Grenze der Namenslisten-Sperre** (Adversary Runde 3, ausdrücklich *nicht* als
+  Finding gemeldet): Die Tests schließen die Bypass-Klasse „Kennungen aufzählen statt
+  Register lesen" auf zwei Ebenen — im generischen Kern (`alertIdentitiesForMetricEntry`)
+  und beim Aufrufer (`deriveActiveAlertMetricsForTrip`). Beide Wächter verlangen für
+  **dieselbe** Katalog-Kennung gegensätzliche Ergebnisse (einmal mit, einmal ohne
+  Alarm-Identitäten); das kann keine ID-Tabelle auflösen, unabhängig von ihrer Länge.
+  Eine Ebene darüber — der Container ruft die Ableitung noch auf, überschreibt ihr
+  Ergebnis aber nachträglich per Handtabelle — bleibt ungefangen. Das ist die
+  prinzipielle Grenze des Musters: jede Aufrufebene ließe sich erneut umgehen, eine
+  vollständige Absicherung wäre eine unendliche Kette. **Nicht als Lücke nachtragen.**
+  Der direkte Fork ohne Aufruf ist dagegen abgedeckt (Ebene-2-AST-Wächter aus F001).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue — ADR-0010, ADR-0032, ADR-0043 bleiben unverändert bindend
+  (siehe „Bindende Entscheidungen"); diese Spec führt keine neue Architektur-Entscheidung
+  ein, sondern setzt bestehende konsequent um.
+- **Rationale:** Die Ableitung Auswahl × Register ist bereits für den Vergleichs-Pfad
+  ADR-Level-Praxis (#1435 E1a-2); diese Spec überträgt sie auf den Trip-Pfad, ohne neue
+  Grundsatzentscheidung.
+
+## Bezug zu #1435
+
+Diese Scheibe ist die in der Spec zu #1435 Etappe E4 (`AC-3`: „Trip-Zweig bleibt
+unangetastet") ausdrücklich angekündigte Folge-Arbeit. E4 hat den Zahlenwert der
+Geisterzeile Luftfeuchtigkeit bereits entschärft (zeigt „—" statt einer irreführenden
+festen Zahl); diese Spec entfernt die Zeile selbst und behebt zusätzlich die beiden
+weiteren, in #1435 nicht behandelten Fehlerklassen (unsichtbare Scharfschaltung,
+vorgetäuschte Kontrolle) in einem Zug (PO-Entscheid Zuschnitt A, 2026-08-07).
+
+## Changelog
+
+- 2026-08-07: Initial spec created (Issues #1544, #1545, Zuschnitt A)

--- a/frontend/src/lib/components/shared/alarme-tab/__tests__/alarme_delivery_payload_preserves_inactive_levels.test.ts
+++ b/frontend/src/lib/components/shared/alarme-tab/__tests__/alarme_delivery_payload_preserves_inactive_levels.test.ts
@@ -1,0 +1,361 @@
+// TDD RED — Fix #1544/#1545, Falle 4 (Kontext-Dokument): AC-6, der
+// Datenverlust-Waechter. `buildAlarmeDeliveryPayload` sendet
+// `metric_alert_levels` beim Speichern als VOLLSTAENDIGEN Ersatz
+// (alarmeDeliveryPayload.ts:117-121), der Go-Merge ist flach
+// (internal/handler/config_merge.go:11-22). Die neue, gefilterte
+// Zeilen-Ableitung (`deriveActiveAlertMetricsForTrip`, s.
+// trip_active_alert_metrics_derivation.test.ts) darf deshalb NUR in
+// `activeMetrics` (Zeilen-Sichtbarkeit) einfliessen, NIE in `metricLevels`
+// (Speicher-Quelle) -- sonst verliert eine deaktivierte Groesse beim
+// naechsten Speichern ihre zuvor gesetzte Stufe unwiderruflich.
+// Spec: docs/specs/modules/fix_1544_1545_trip_alarm_zeilen_ableitung.md
+//   Implementation Details Punkt 4, Acceptance Criteria AC-6.
+//
+// Zwei Ebenen, weil eine reine Payload-Pruefung die eigentliche
+// Fehlerquelle NICHT sieht (`buildAlarmeDeliveryPayload` selbst aendert sich
+// in dieser Scheibe nicht -- der Fehler entstuende beim Umverdrahten von
+// `AlarmeScheduleTab.svelte`):
+//
+//  1. Datenfluss-Nachweis: die neue Ableitung (gefiltert) UND der bestehende
+//     Passthrough (ungefiltert) nebeneinander in eine Payload gefuehrt --
+//     die deaktivierte Groesse bleibt im gesendeten Dict.
+//  2. Verdrahtungs-Wächter (AST, Vorbild
+//     shared/__tests__/alarme_tab_catalog_prop_structure.test.ts): in
+//     `AlarmeScheduleTab.svelte` duerfen `activeMetrics` und `metricLevels`
+//     NICHT aus derselben Quelle rechnen -- das ist der Punkt, an dem die
+//     Mutations-Gegenprobe aus der Spec ("die Trennung activeMetrics/
+//     metricLevels gezielt aufheben") tatsaechlich rot werden muss.
+//
+// RED heute: `deriveActiveAlertMetricsForTrip` fehlt (Ebene 1) UND
+// `AlarmeScheduleTab.svelte` berechnet `activeMetrics` noch als
+// `Object.keys(metricLevels)` -- am Register vorbei UND von `metricLevels`
+// abhaengig (Ebene 2, verletzt die geforderte Trennung schon heute).
+//
+// Pfadregel #1409: alle Importe/Pfade relativ zu DIESER Datei.
+//
+// Ausfuehrung:
+//   cd frontend && node --import ./test-lib-loader.mjs --experimental-strip-types --test \
+//     src/lib/components/shared/alarme-tab/__tests__/alarme_delivery_payload_preserves_inactive_levels.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { register } from 'node:module';
+import { dirname, join, resolve as resolvePath } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { parse } from 'svelte/compiler';
+
+import { buildAlarmeDeliveryPayload } from '../alarmeDeliveryPayload.ts';
+import type { AlertMetric, MetricEntry, WeatherConfigMetric } from '../../../../types.ts';
+import type { MetricCatalog } from '../../../trip-detail/metricsEditor.ts';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const ALARME_SCHEDULE_TAB = join(here, '..', '..', '..', 'trip-detail', 'AlarmeScheduleTab.svelte');
+
+type DeriveTripFn = (
+	metrics: WeatherConfigMetric[] | undefined,
+	catalog: MetricCatalog
+) => AlertMetric[];
+
+async function loadDeriveActiveAlertMetricsForTrip(): Promise<DeriveTripFn> {
+	try {
+		const mod = await import('../tripAlertMetricsFromCatalog.ts');
+		const fn = (mod as Record<string, unknown>).deriveActiveAlertMetricsForTrip;
+		if (typeof fn !== 'function') {
+			assert.fail(
+				'`deriveActiveAlertMetricsForTrip` ist in ' +
+					'shared/alarme-tab/tripAlertMetricsFromCatalog.ts nicht exportiert (#1544/#1545).'
+			);
+		}
+		return fn as DeriveTripFn;
+	} catch (err) {
+		assert.fail(
+			'Die trip-weite Ableitung fehlt noch: erwartet wird ' +
+				'`shared/alarme-tab/tripAlertMetricsFromCatalog.ts` mit ' +
+				`\`deriveActiveAlertMetricsForTrip(metrics, catalog)\` (#1544/#1545). Ursache: ${String(err)}`
+		);
+	}
+}
+
+const CATALOG: MetricCatalog = {
+	temperature: [
+		{
+			id: 'temperature',
+			label: 'Temperatur',
+			unit: '°C',
+			category: 'temperature',
+			default_enabled: true,
+			has_friendly_format: false,
+			change_alert_metric: 'temperature_change',
+			aggregations: [
+				{ id: 'min', label: 'Minimum', alert_metric: 'temperature_min' },
+				{ id: 'max', label: 'Maximum', alert_metric: 'temperature_max' },
+				{ id: 'avg', label: 'Mittel', alert_metric: null }
+			]
+		} as unknown as MetricEntry
+	],
+	wind: [
+		{
+			id: 'gust',
+			label: 'Böen',
+			unit: 'km/h',
+			category: 'wind',
+			default_enabled: true,
+			has_friendly_format: false,
+			change_alert_metric: null,
+			aggregations: [{ id: 'max', label: 'Maximum', alert_metric: 'wind_gust' }]
+		} as unknown as MetricEntry
+	]
+};
+
+describe('#1544/#1545 AC-6 Ebene 1: gesendete Payload behaelt die Stufe der deaktivierten Groesse', () => {
+	test('Böen deaktiviert -> Zeile verschwindet, gespeicherter Wert bleibt im Payload', async () => {
+		const derive = await loadDeriveActiveAlertMetricsForTrip();
+
+		// Bestand: der Nutzer hatte "Böen" (wind_gust) frueher auf "sensibel"
+		// gesetzt, deaktiviert die Groesse jetzt aber im Wetter-Reiter.
+		const persistierteStufen: Record<string, string> = {
+			wind_gust: 'sensibel',
+			temperature_max: 'standard'
+		};
+		const metrics: WeatherConfigMetric[] = [
+			{ metric_id: 'gust', enabled: false },
+			{ metric_id: 'temperature', enabled: true }
+		];
+
+		const zeilen = derive(metrics, CATALOG);
+		assert.ok(
+			!zeilen.includes('wind_gust'),
+			'Vorbedingung: die deaktivierte Groesse zeigt keine Zeile mehr.'
+		);
+
+		// `metricLevels` bleibt der UNGEFILTERTE Passthrough -- exakt das
+		// heutige Verhalten von AlarmeScheduleTab.svelte:36-38
+		// (`trip.display_config?.metric_alert_levels ?? {}`), das diese Etappe
+		// NICHT aendern darf.
+		const payload = buildAlarmeDeliveryPayload({
+			officialWarningsEnabled: false,
+			channels: { email: true, telegram: false, sms: false },
+			metricLevels: persistierteStufen
+		}) as { display_config?: { metric_alert_levels?: Record<string, string> } };
+
+		assert.equal(
+			payload.display_config?.metric_alert_levels?.wind_gust,
+			'sensibel',
+			'Die Stufe der deaktivierten Groesse "Böen" fehlt im gesendeten Payload ' +
+				`-- Datenverlust (AC-6). Erhalten: ${JSON.stringify(payload.display_config)}`
+		);
+	});
+});
+
+// ── Ebene 2: Verdrahtungs-Waechter ──────────────────────────────────────────
+// AST statt Dateiinhalt-Grep (Vorbild:
+// shared/__tests__/alarme_tab_catalog_prop_structure.test.ts).
+
+function parseFile(path: string): any {
+	return parse(readFileSync(path, 'utf-8'), { modern: true });
+}
+
+function identifiers(subtree: unknown): Set<string> {
+	const found = new Set<string>();
+	function visit(node: unknown): void {
+		if (node === null || typeof node !== 'object') return;
+		if (Array.isArray(node)) {
+			node.forEach(visit);
+			return;
+		}
+		const n = node as Record<string, any>;
+		if (n.type === 'Identifier' && typeof n.name === 'string') found.add(n.name);
+		for (const key of Object.keys(n)) {
+			if (key === 'parent') continue;
+			visit(n[key]);
+		}
+	}
+	visit(subtree);
+	return found;
+}
+
+/** Der `$derived(...)`-Initialisierer einer benannten Instanz-Variable. */
+function derivedInit(ast: any, name: string): any {
+	const decl = (ast.instance?.content?.body ?? [])
+		.filter((n: any) => n.type === 'VariableDeclaration')
+		.flatMap((n: any) => n.declarations)
+		.find((d: any) => d.id?.type === 'Identifier' && d.id.name === name);
+	assert.ok(decl, `Keine Variable \`${name}\` im Instance-Script von AlarmeScheduleTab.svelte gefunden.`);
+	assert.equal(decl.init?.type, 'CallExpression');
+	assert.equal(decl.init.callee?.name, '$derived');
+	return decl.init.arguments[0];
+}
+
+describe('#1544/#1545 AC-6 Ebene 2: `activeMetrics` und `metricLevels` rechnen unabhaengig', () => {
+	test('`activeMetrics` ruft die neue Register-Ableitung auf, nicht mehr `Object.keys(metricLevels)`', () => {
+		const namen = identifiers(derivedInit(parseFile(ALARME_SCHEDULE_TAB), 'activeMetrics'));
+		assert.ok(
+			namen.has('deriveActiveAlertMetricsForTrip'),
+			'`activeMetrics` in AlarmeScheduleTab.svelte ruft die neue, register-' +
+				'gestuetzte Ableitung `deriveActiveAlertMetricsForTrip` nicht auf ' +
+				'(Fehlerklasse 1, "Der Fehler": Object.keys(metricLevels)).'
+		);
+	});
+
+	test('`activeMetrics` haengt NICHT (mehr) an `metricLevels`', () => {
+		const namen = identifiers(derivedInit(parseFile(ALARME_SCHEDULE_TAB), 'activeMetrics'));
+		assert.equal(
+			namen.has('metricLevels'),
+			false,
+			'`activeMetrics` liest weiterhin `metricLevels` -- das ist exakt der ' +
+				'heutige Fehler (Zeilen nur fuer bereits persistierte Schluessel, ' +
+				'Fehlerklasse 1, unsichtbare Scharfschaltung).'
+		);
+	});
+
+	test('`metricLevels` bleibt der ungefilterte Passthrough -- kein Bezug zu `activeMetrics`', () => {
+		const namen = identifiers(derivedInit(parseFile(ALARME_SCHEDULE_TAB), 'metricLevels'));
+		for (const verboten of ['activeMetrics', 'deriveActiveAlertMetricsForTrip']) {
+			assert.equal(
+				namen.has(verboten),
+				false,
+				`\`metricLevels\` bezieht sich auf \`${verboten}\` -- damit teilen sich ` +
+					'Zeilen-Sichtbarkeit und Speicher-Quelle dieselbe gefilterte ' +
+					'Basis. Ein spaeteres Speichern wuerde dann die Stufe jeder ' +
+					'gerade nicht angezeigten Groesse unwiderruflich loeschen (AC-6, ' +
+					'Falle 4 aus dem Kontext-Dokument).'
+			);
+		}
+	});
+});
+
+// ── Ebene 3: LAUFZEIT-Wirkung statt Schreibweise ────────────────────────────
+// Adversary Fix-Loop, F001: Ebene 2 prueft nur die literalen Bezeichner im
+// `$derived`-Initialisierer. Koppelt man `metricLevels` funktional identisch an
+// die gefilterte Menge, aber ueber eine umbenannte Zwischenvariable, bleibt
+// Ebene 2 gruen und der Datenverlust traete trotzdem ein -- geprueft war, wo
+// der Code STEHT, nicht wo er WIRKT.
+//
+// Hier laeuft die echte Kette: Trip-Zustand -> ECHTES serverseitiges Rendern
+// von AlarmeScheduleTab.svelte (svelte/server + test-svelte-ssr-hooks.mjs,
+// Vorbild versand-tab/__tests__/channel_checkbox_dedupe_render.test.ts) ->
+// LAUFZEITWERT der `metricLevels`-Prop -> echter AlarmeTab (sein Markup zeigt
+// `routeMetricLevels`) -> echte `buildAlarmeDeliveryPayload`. Kein
+// Mock-Theater: ersetzt ist allein die SENKE (das Kind des Containers), um an
+// die vom unveraenderten Produktivcode erzeugten Werte zu kommen.
+//
+// Grenze (ehrlich): `$effect` laeuft unter SSR nicht, ein DOM-Shim fehlt (kein
+// jsdom/happy-dom in package.json) -- der Save-Effekt selbst ist nicht
+// ausloesbar. Die letzte Fuge (`routeMetricLevels` -> `buildAlarmeSaveFn`) ist
+// eine Zeile und durch shared/__tests__/alarme_save_single_writer.test.ts
+// abgedeckt; alles davor ist hier gemessen.
+
+const FRONTEND = resolvePath(here, '../../../../../..');
+register(
+	pathToFileURL(join(FRONTEND, 'test-svelte-ssr-hooks.mjs')).href,
+	pathToFileURL(FRONTEND + '/').href
+);
+
+(globalThis as any).__gzAlarmeTabProps = [];
+// Nur der Import AUS AlarmeScheduleTab.svelte heraus wird umgelenkt --
+// derselbe Import weiter unten in dieser Datei liefert die echte Komponente.
+register(
+	'data:text/javascript,' +
+		encodeURIComponent(`
+export async function resolve(specifier, context, nextResolve) {
+  if ((context.parentURL ?? '').endsWith('/AlarmeScheduleTab.svelte')
+      && specifier.endsWith('shared/AlarmeTab.svelte')) {
+    return { url: 'gz-stub:alarme-tab', shortCircuit: true };
+  }
+  return nextResolve(specifier, context);
+}
+export async function load(url, context, nextLoad) {
+  if (url === 'gz-stub:alarme-tab') {
+    return { format: 'module', shortCircuit: true,
+      source: 'export default function(_p, props) { globalThis.__gzAlarmeTabProps.push(props); }' };
+  }
+  return nextLoad(url, context);
+}`)
+);
+
+const { render } = await import('svelte/server');
+const AlarmeScheduleTab = (
+	await import(pathToFileURL(join(FRONTEND, 'src/lib/components/trip-detail/AlarmeScheduleTab.svelte')).href)
+).default;
+const AlarmeTab = (
+	await import(pathToFileURL(join(FRONTEND, 'src/lib/components/shared/AlarmeTab.svelte')).href)
+).default;
+
+/** Trip-Zustand des Bugs: "Böen" traegt eine gespeicherte Stufe UND ist im
+ *  Wetter-Reiter deaktiviert. */
+const TRIP_MIT_DEAKTIVIERTER_BOE = {
+	id: 'trip-ac6',
+	display_config: {
+		metric_alert_levels: { wind_gust: 'sensibel', temperature_max: 'standard' },
+		metrics: [
+			{ metric_id: 'gust', enabled: false },
+			{ metric_id: 'temperature', enabled: true }
+		]
+	}
+};
+
+describe('#1544/#1545 AC-6 Ebene 3: die Kette bis zur gesendeten Nutzlast, zur Laufzeit gemessen', () => {
+	test('Böen deaktiviert: Zeile weg, Stufe bleibt im Payload — unabhaengig von jeder Schreibweise', () => {
+		(globalThis as any).__gzAlarmeTabProps = [];
+		// `.body` lesen ist Pflicht: svelte/server rendert erst beim Zugriff.
+		const containerHtml = render(AlarmeScheduleTab, {
+			props: { trip: TRIP_MIT_DEAKTIVIERTER_BOE, metricsCatalog: CATALOG }
+		}).body;
+		assert.match(containerHtml, /alarme-schedule-tab/);
+		const props = (globalThis as any).__gzAlarmeTabProps;
+		assert.equal(props.length, 1, 'AlarmeScheduleTab hat den AlarmeTab nicht genau einmal gerendert.');
+		const { activeMetrics, metricLevels } = props[0] as {
+			activeMetrics: AlertMetric[];
+			metricLevels: Record<string, string>;
+		};
+
+		assert.ok(
+			!activeMetrics.includes('wind_gust' as AlertMetric),
+			`Vorbedingung: die deaktivierte Groesse zeigt keine Zeile mehr. Erhalten: ${JSON.stringify(activeMetrics)}`
+		);
+
+		// Der Kern: die SPEICHER-Quelle darf NICHT mitgefiltert sein. Gemessen am
+		// Laufzeitwert -- eine umbenannte Zwischenvariable rettet hier nichts.
+		assert.equal(
+			metricLevels?.wind_gust,
+			'sensibel',
+			'Die `metricLevels`-Prop, die AlarmeScheduleTab zur Laufzeit liefert, hat ' +
+				'die Stufe der deaktivierten Groesse verloren. Beim naechsten Speichern ' +
+				'ersetzt sie `metric_alert_levels` vollstaendig (Go-Merge ist flach) -- ' +
+				`unwiderruflicher Datenverlust (AC-6). Erhalten: ${JSON.stringify(metricLevels)}`
+		);
+
+		// Fuge 2, ebenfalls zur Laufzeit: der ECHTE AlarmeTab uebernimmt diesen
+		// Wert in `routeMetricLevels` (im Markup an `data-level` ablesbar) -- hier
+		// mit erzwungen sichtbarer Zeile, damit der Wert ueberhaupt gerendert wird.
+		const html = render(AlarmeTab, {
+			props: {
+				context: 'route',
+				trip: TRIP_MIT_DEAKTIVIERTER_BOE,
+				activeMetrics: ['wind_gust'],
+				metricLevels,
+				existingChannels: { email: true, telegram: false, sms: false }
+			}
+		}).body;
+		assert.match(
+			html,
+			/data-testid="alert-metric-row-wind_gust"[^>]*data-level="sensibel"/,
+			'Der echte AlarmeTab uebernimmt die durchgereichte Stufe nicht in seinen ' +
+				'`routeMetricLevels`-Zustand -- damit ginge sie im konsolidierten Save verloren.'
+		);
+
+		// Fuge 3: dieselben Werte durch die ECHTE Payload-Funktion.
+		const payload = buildAlarmeDeliveryPayload({
+			officialWarningsEnabled: false,
+			channels: { email: true, telegram: false, sms: false },
+			metricLevels
+		}) as { display_config?: { metric_alert_levels?: Record<string, string> } };
+		assert.equal(
+			payload.display_config?.metric_alert_levels?.wind_gust,
+			'sensibel',
+			'Die tatsaechlich gesendete Nutzlast hat die Stufe der deaktivierten ' +
+				`Groesse verloren (AC-6). Erhalten: ${JSON.stringify(payload.display_config)}`
+		);
+	});
+});

--- a/frontend/src/lib/components/shared/alarme-tab/__tests__/alert_identities_from_metric_entry.test.ts
+++ b/frontend/src/lib/components/shared/alarme-tab/__tests__/alert_identities_from_metric_entry.test.ts
@@ -1,0 +1,234 @@
+// TDD RED — Fix #1544/#1545: der Trip-Alarme-Reiter leitet seine Zeilen aus
+// Auswahl x Alarmfaehigkeit-aus-dem-zentralen-Register ab statt aus den
+// persistierten Schluesseln von `metric_alert_levels` (Fehlerklassen 1-3,
+// s. Kontext-Dokument).
+// Spec: docs/specs/modules/fix_1544_1545_trip_alarm_zeilen_ableitung.md
+//   Implementation Details Punkt 2, Acceptance Criteria AC-1, AC-2, AC-7.
+//
+// Diese Datei prueft den atomaren Baustein: `alertIdentitiesForMetricEntry`
+// liest `aggregations[].alert_metric` UND `change_alert_metric` eines
+// EINZELNEN Katalog-Eintrags (MetricEntry) und liefert die zugehoerigen
+// Alarm-Identitaeten, dedupliziert. Die zweite, trip-weite Ableitung
+// (Auswahl x Katalog, inkl. Altbestands-Sonderfall und Reihenfolge) steht in
+// `trip_active_alert_metrics_derivation.test.ts` (AC-3/4/5/8).
+//
+// RED heute: `frontend/src/lib/components/shared/alarme-tab/
+// tripAlertMetricsFromCatalog.ts` mit dem Export
+// `alertIdentitiesForMetricEntry(entry: MetricEntry): AlertMetric[]`
+// existiert noch nicht.
+//
+// Pfadregel #1409: alle Importe relativ zu DIESER Datei.
+//
+// Kein Mock-Theater: reine Funktionstests gegen Katalog-Fixtures, deren
+// Struktur UND Werte der echten `GET /api/metrics`-Antwort entsprechen
+// (api/routers/config.py:58-107), abgeleitet aus dem echten Register
+// `src/app/metric_catalog.py` (Temperatur :95-115, Boeen/"gust" :222-231,
+// Luftfeuchtigkeit :174-186). `alert_metric_for()`/`available_aggregations()`
+// (:591-632) wurden von Hand nachvollzogen, um die `aggregations[]`-Werte zu
+// bilden — siehe Kommentare je Fixture.
+//
+// Ausfuehrung:
+//   cd frontend && node --import ./test-lib-loader.mjs --experimental-strip-types --test \
+//     src/lib/components/shared/alarme-tab/__tests__/alert_identities_from_metric_entry.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { AlertMetric, MetricEntry } from '../../../../types.ts';
+
+type AlertIdentitiesFn = (entry: MetricEntry) => AlertMetric[];
+
+/** Laedt die neue Ableitung. Fehlt sie noch, ist DAS der Befund — mit einer
+ *  Meldung, die den Grund nennt statt eines nackten Auflose-Fehlers. */
+async function loadAlertIdentitiesForMetricEntry(): Promise<AlertIdentitiesFn> {
+	try {
+		const mod = await import('../tripAlertMetricsFromCatalog.ts');
+		const fn = (mod as Record<string, unknown>).alertIdentitiesForMetricEntry;
+		if (typeof fn !== 'function') {
+			assert.fail(
+				'`alertIdentitiesForMetricEntry` ist in ' +
+					'shared/alarme-tab/tripAlertMetricsFromCatalog.ts nicht exportiert ' +
+					'(#1544/#1545, Spec Implementation Details Punkt 2).'
+			);
+		}
+		return fn as AlertIdentitiesFn;
+	} catch (err) {
+		assert.fail(
+			'Die register-gestuetzte Identitaets-Ableitung fehlt noch: erwartet wird ' +
+				'`shared/alarme-tab/tripAlertMetricsFromCatalog.ts` mit ' +
+				'`alertIdentitiesForMetricEntry(entry)` (#1544/#1545). ' +
+				`Ursache: ${String(err)}`
+		);
+	}
+}
+
+// ── Fixtures — wortwoertlich aus dem echten Register abgeleitet ────────────
+
+// Temperatur (metric_catalog.py:95-115): summary_fields hat min/max/avg ->
+// available_aggregations() liefert genau diese drei in dieser Reihenfolge
+// (_AGGREGATION_ORDER = min,max,avg,sum). alert_metrics={"min":
+// "temperature_min","max":"temperature_max"} -> alert_metric_for() liefert
+// fuer "avg" NICHT den change-Fallback (die Groesse deklariert eigene
+// Identitaeten), sondern None -- siehe alert_metric_for() Docstring
+// Adversary-Fund F001. change_alert_metric="temperature_change" steht
+// SEPARAT am Eintrag (nicht an einer Auswertung).
+const TEMPERATURE_ENTRY: MetricEntry = {
+	id: 'temperature',
+	label: 'Temperatur',
+	unit: '°C',
+	category: 'temperature',
+	default_enabled: true,
+	has_friendly_format: false,
+	change_alert_metric: 'temperature_change',
+	aggregations: [
+		{ id: 'min', label: 'Minimum', alert_metric: 'temperature_min' },
+		{ id: 'max', label: 'Maximum', alert_metric: 'temperature_max' },
+		{ id: 'avg', label: 'Mittel', alert_metric: null }
+	]
+} as unknown as MetricEntry;
+
+// Boeen / "gust" (metric_catalog.py:222-231): summary_fields nur "max" ->
+// eine Auswertung, alert_metrics={"max":"wind_gust"}. Kein
+// change_alert_metric an dieser Groesse.
+const GUST_ENTRY: MetricEntry = {
+	id: 'gust',
+	label: 'Böen',
+	unit: 'km/h',
+	category: 'wind',
+	default_enabled: true,
+	has_friendly_format: false,
+	change_alert_metric: null,
+	aggregations: [{ id: 'max', label: 'Maximum', alert_metric: 'wind_gust' }]
+} as unknown as MetricEntry;
+
+// Luftfeuchtigkeit (metric_catalog.py:174-186, ADR-0010 Vorboten-Metrik):
+// alert_metrics={} (nie gesetzt) UND change_alert_metric=None -> KEINE
+// Alarm-Identitaet, strukturell -- nicht nur "off" per Konvention.
+const HUMIDITY_ENTRY: MetricEntry = {
+	id: 'humidity',
+	label: 'Luftfeuchtigkeit',
+	unit: '%',
+	category: 'temperature',
+	default_enabled: false,
+	has_friendly_format: false,
+	change_alert_metric: null,
+	aggregations: [{ id: 'avg', label: 'Mittel', alert_metric: null }]
+} as unknown as MetricEntry;
+
+describe('#1544/#1545 AC-7: Temperatur traegt alle drei Identitaeten gleichzeitig', () => {
+	test('Minimum, Maximum UND Aenderungsrate erscheinen zusammen, dedupliziert', async () => {
+		const fn = await loadAlertIdentitiesForMetricEntry();
+		const got = fn(TEMPERATURE_ENTRY);
+		assert.deepEqual(
+			[...got].sort(),
+			['temperature_change', 'temperature_max', 'temperature_min'].sort(),
+			'Eine aktivierte Temperatur-Metrik muss alle drei zugehoerigen Alarm-' +
+				`Identitaeten liefern (AC-7). Erhalten: ${JSON.stringify(got)}`
+		);
+		assert.equal(
+			new Set(got).size,
+			got.length,
+			`Ergebnis enthaelt Duplikate: ${JSON.stringify(got)}`
+		);
+	});
+});
+
+describe('#1544/#1545 AC-1: eine einfache alarmfaehige Groesse liefert ihre Identitaet', () => {
+	test('Boeen ("gust") liefert `wind_gust` — unabhaengig von jeder gespeicherten Stufe', async () => {
+		const fn = await loadAlertIdentitiesForMetricEntry();
+		const got = fn(GUST_ENTRY);
+		assert.deepEqual(
+			got,
+			['wind_gust'],
+			'Diese Ableitung kennt gar kein `metric_alert_levels` -- die Identitaet ' +
+				'muss allein aus der Aktivierung + Register kommen (Fehlerklasse 1, ' +
+				`unsichtbare Scharfschaltung). Erhalten: ${JSON.stringify(got)}`
+		);
+	});
+});
+
+describe('#1544/#1545 AC-2: Luftfeuchtigkeit erzeugt strukturell keine Zeile', () => {
+	test('Weder aus `aggregations[]` noch aus `change_alert_metric` entsteht eine Identitaet', async () => {
+		const fn = await loadAlertIdentitiesForMetricEntry();
+		const got = fn(HUMIDITY_ENTRY);
+		assert.deepEqual(
+			got,
+			[],
+			'Luftfeuchtigkeit ist laut Register nicht alarmfaehig (ADR-0010) -- eine ' +
+				'nicht-leere Rueckgabe waere die Geisterzeile aus #1545. ' +
+				`Erhalten: ${JSON.stringify(got)}`
+		);
+	});
+
+	test('Ein Eintrag ganz ohne Aggregations-Daten stuerzt nicht ab und liefert leer', async () => {
+		const fn = await loadAlertIdentitiesForMetricEntry();
+		const minimal = {
+			id: 'sunshine',
+			label: 'Sonnenstunden',
+			unit: 'h',
+			category: 'atmosphere',
+			default_enabled: true,
+			has_friendly_format: false
+		} as unknown as MetricEntry;
+		assert.deepEqual(fn(minimal), []);
+	});
+});
+
+// ── Adversary Fix-Loop, F002: Register-LESUNG statt Namensliste ─────────────
+// Befund: Ersetzt man den generischen Durchlauf durch `aggregations[]` /
+// `change_alert_metric` durch eine Handliste mit den vier Kennungen, die in
+// allen Fixtures vorkommen (`temperature`, `gust`, `cape`, `humidity`),
+// bleiben alle 18 betroffenen Tests gruen -- dieselbe Krankheit wie #1435 E4.
+// Die Eintraege unten sind darum BEWUSST erfunden (kein Mensch haette sie in
+// einer solchen Handliste), tragen aber echte `MetricEntry`-Struktur (Form aus
+// api/routers/config.py:58-107).
+describe('#1544/#1545 F002: die Ableitung LIEST das Register, sie zaehlt keine Namen auf', () => {
+	test('Eine im Fixture-Bestand unbekannte Kennung wird korrekt aufgeloest', async () => {
+		const fn = await loadAlertIdentitiesForMetricEntry();
+		const unbekannt = {
+			id: 'zenitstrahlung',
+			label: 'Zenitstrahlung',
+			unit: 'W/m²',
+			category: 'atmosphere',
+			default_enabled: false,
+			has_friendly_format: false,
+			change_alert_metric: 'zenitstrahlung_change',
+			aggregations: [
+				{ id: 'max', label: 'Maximum', alert_metric: 'zenitstrahlung_max' },
+				{ id: 'avg', label: 'Mittel', alert_metric: null }
+			]
+		} as unknown as MetricEntry;
+		const got = fn(unbekannt);
+		assert.deepEqual(
+			got,
+			['zenitstrahlung_max', 'zenitstrahlung_change'],
+			'Eine Groesse, die in KEINER plausiblen Handliste stuende, muss allein ' +
+				'aus ihrer Struktur (`aggregations[].alert_metric` + ' +
+				'`change_alert_metric`) aufgeloest werden. Leeres oder unvollstaendiges ' +
+				'Ergebnis heisst: die Ableitung zaehlt Namen auf, statt das Register zu ' +
+				`lesen (F002). Erhalten: ${JSON.stringify(got)}`
+		);
+	});
+
+	test('Gegenprobe: dieselbe unbekannte Kennung OHNE Identitaeten liefert leer', async () => {
+		// Sonst bestuende der Test oben auch eine Implementierung, die bei jeder
+		// unbekannten Kennung einfach etwas erfindet.
+		const fn = await loadAlertIdentitiesForMetricEntry();
+		const stumm = {
+			id: 'zenitstrahlung',
+			label: 'Zenitstrahlung',
+			unit: 'W/m²',
+			category: 'atmosphere',
+			default_enabled: false,
+			has_friendly_format: false,
+			change_alert_metric: null,
+			aggregations: [{ id: 'max', label: 'Maximum', alert_metric: null }]
+		} as unknown as MetricEntry;
+		assert.deepEqual(
+			fn(stumm),
+			[],
+			'Unbekannt heisst nicht automatisch alarmfaehig -- ohne hinterlegte ' +
+				'Identitaet bleibt die Groesse ohne Zeile (Geisterzeile aus #1545).'
+		);
+	});
+});

--- a/frontend/src/lib/components/shared/alarme-tab/__tests__/fixtures/ac9_trip_state.json
+++ b/frontend/src/lib/components/shared/alarme-tab/__tests__/fixtures/ac9_trip_state.json
@@ -1,0 +1,18 @@
+{
+  "description": "AC-9 Deckungsgleichheit (Fix #1544/#1545): EIN Trip-Zustand, ausgewertet auf beiden Seiten gegen die jeweils eigene Produktivrealitaet. `expected_alert_identities` wurde NICHT geschaetzt, sondern am 2026-08-07 mit dem echten Backend-Regel-Erzeuger erzeugt: `src/services/alert_preset.py::expand_per_metric_levels(metric_alert_levels, display_config)` -- siehe `tests/unit/services/test_deviation_alert_engine_matches_frontend_derivation.py`, der dieselbe Menge am selben Zustand nachrechnet und pruefend belegt. Der TS-Test (trip_active_alert_metrics_derivation.test.ts, Describe-Block AC-9) liest DIESE Datei und vergleicht die Ausgabe der neuen Frontend-Ableitung dagegen -- kein Mock, keine RPC, ein gemeinsamer, checked-in Fixpunkt.",
+  "metrics": [
+    { "metric_id": "temperature", "enabled": true },
+    { "metric_id": "gust", "enabled": true },
+    { "metric_id": "humidity", "enabled": true },
+    { "metric_id": "cape", "enabled": false }
+  ],
+  "metric_alert_levels": {
+    "wind_gust": "sensibel"
+  },
+  "expected_alert_identities": [
+    "temperature_change",
+    "temperature_max",
+    "temperature_min",
+    "wind_gust"
+  ]
+}

--- a/frontend/src/lib/components/shared/alarme-tab/__tests__/trip_active_alert_metrics_derivation.test.ts
+++ b/frontend/src/lib/components/shared/alarme-tab/__tests__/trip_active_alert_metrics_derivation.test.ts
@@ -1,0 +1,484 @@
+// TDD RED — Fix #1544/#1545: trip-weite Ableitung der Alarme-Reiter-Zeilen
+// aus Auswahl (`trip.display_config.metrics`) x Alarmfaehigkeit-aus-dem-
+// Register (Katalog), statt aus `Object.keys(metric_alert_levels)`
+// (AlarmeScheduleTab.svelte:36-42, "Der Fehler").
+// Spec: docs/specs/modules/fix_1544_1545_trip_alarm_zeilen_ableitung.md
+//   Implementation Details Punkt 2/3, Acceptance Criteria AC-3, AC-4, AC-5,
+//   AC-8, AC-9, AC-10.
+//
+// RED heute: `deriveActiveAlertMetricsForTrip` ist in
+// `shared/alarme-tab/tripAlertMetricsFromCatalog.ts` noch nicht exportiert
+// (dieselbe Datei wie `alertIdentitiesForMetricEntry`, s.
+// alert_identities_from_metric_entry.test.ts).
+//
+// Pfadregel #1409: alle Importe relativ zu DIESER Datei.
+//
+// Kein Mock-Theater: das `MetricCatalog`-Fixture (Record<category,
+// MetricEntry[]>) hat exakt die Struktur der echten `GET /api/metrics`-
+// Antwort (api/routers/config.py:58-107); die enthaltenen Register-Werte
+// (Temperatur, Boeen, Luftfeuchtigkeit) sind dieselben wie in
+// alert_identities_from_metric_entry.test.ts, aus src/app/metric_catalog.py
+// abgelesen -- keine erfundenen Werte.
+//
+// AC-9-Describe-Block unten: liest `fixtures/ac9_trip_state.json`, DIESELBE
+// Datei, die `tests/unit/services/
+// test_deviation_alert_engine_matches_frontend_derivation.py` gegen den
+// ECHTEN Backend-Regel-Erzeuger (`expand_per_metric_levels()`) verifiziert.
+// Beide Seiten rechnen unabhaengig gegen ihre eigene Produktivrealitaet und
+// treffen sich an `expected_alert_identities` -- kein Mock, keine RPC. Der
+// Python-Test ist heute bereits gruen (Backend unveraendert); das
+// RED-Signal fuer AC-9 liegt HIER, weil `deriveActiveAlertMetricsForTrip`
+// fehlt.
+//
+// Ausfuehrung:
+//   cd frontend && node --import ./test-lib-loader.mjs --experimental-strip-types --test \
+//     src/lib/components/shared/alarme-tab/__tests__/trip_active_alert_metrics_derivation.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { AlertMetric, MetricEntry, WeatherConfigMetric } from '../../../../types.ts';
+import type { MetricCatalog } from '../../../trip-detail/metricsEditor.ts';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+type DeriveTripFn = (
+	metrics: WeatherConfigMetric[] | undefined,
+	catalog: MetricCatalog
+) => AlertMetric[];
+
+/** Laedt die neue trip-weite Ableitung. Fehlt sie noch, ist DAS der Befund. */
+async function loadDeriveActiveAlertMetricsForTrip(): Promise<DeriveTripFn> {
+	try {
+		const mod = await import('../tripAlertMetricsFromCatalog.ts');
+		const fn = (mod as Record<string, unknown>).deriveActiveAlertMetricsForTrip;
+		if (typeof fn !== 'function') {
+			assert.fail(
+				'`deriveActiveAlertMetricsForTrip` ist in ' +
+					'shared/alarme-tab/tripAlertMetricsFromCatalog.ts nicht exportiert ' +
+					'(#1544/#1545, Spec Implementation Details Punkt 2).'
+			);
+		}
+		return fn as DeriveTripFn;
+	} catch (err) {
+		assert.fail(
+			'Die trip-weite Ableitung fehlt noch: erwartet wird ' +
+				'`shared/alarme-tab/tripAlertMetricsFromCatalog.ts` mit ' +
+				'`deriveActiveAlertMetricsForTrip(metrics, catalog)` (#1544/#1545). ' +
+				`Ursache: ${String(err)}`
+		);
+	}
+}
+
+// ── Fixture: Register-Ausschnitt wie GET /api/metrics ──────────────────────
+// Temperatur (3 Identitaeten), Boeen (1 Identitaet), Luftfeuchtigkeit (0 --
+// ADR-0010). Werte wie in alert_identities_from_metric_entry.test.ts.
+const CATALOG: MetricCatalog = {
+	temperature: [
+		{
+			id: 'temperature',
+			label: 'Temperatur',
+			unit: '°C',
+			category: 'temperature',
+			default_enabled: true,
+			has_friendly_format: false,
+			change_alert_metric: 'temperature_change',
+			aggregations: [
+				{ id: 'min', label: 'Minimum', alert_metric: 'temperature_min' },
+				{ id: 'max', label: 'Maximum', alert_metric: 'temperature_max' },
+				{ id: 'avg', label: 'Mittel', alert_metric: null }
+			]
+		} as unknown as MetricEntry,
+		{
+			id: 'humidity',
+			label: 'Luftfeuchtigkeit',
+			unit: '%',
+			category: 'temperature',
+			default_enabled: false,
+			has_friendly_format: false,
+			change_alert_metric: null,
+			aggregations: [{ id: 'avg', label: 'Mittel', alert_metric: null }]
+		} as unknown as MetricEntry
+	],
+	wind: [
+		{
+			id: 'gust',
+			label: 'Böen',
+			unit: 'km/h',
+			category: 'wind',
+			default_enabled: true,
+			has_friendly_format: false,
+			change_alert_metric: null,
+			aggregations: [{ id: 'max', label: 'Maximum', alert_metric: 'wind_gust' }]
+		} as unknown as MetricEntry
+	]
+};
+
+// Vollstaendige Menge alarmfaehiger Identitaeten in CATALOG, in
+// ALERTABLE_METRICS-Reihenfolge (wind_gust steht dort vor den drei
+// Temperatur-Identitaeten).
+const ALL_ALARMABLE_IN_CATALOG: AlertMetric[] = [
+	'wind_gust',
+	'temperature_min',
+	'temperature_max',
+	'temperature_change'
+];
+
+describe('#1544/#1545 AC-3: gesetzte Stufe ohne aktive Wetter-Metrik zeigt keine Zeile', () => {
+	test('Temperatur ist im Wetter-Reiter deaktiviert -> keine Temperatur-Zeilen, Böen bleibt', async () => {
+		const derive = await loadDeriveActiveAlertMetricsForTrip();
+		const metrics: WeatherConfigMetric[] = [
+			{ metric_id: 'temperature', enabled: false },
+			{ metric_id: 'gust', enabled: true }
+		];
+		const got = derive(metrics, CATALOG);
+		assert.deepEqual(
+			got,
+			['wind_gust'],
+			'Eine im Wetter-Reiter deaktivierte Groesse darf keine Alarm-Zeile mehr ' +
+				`zeigen, selbst wenn sie frueher eine echte Stufe hatte (AC-3). Erhalten: ${JSON.stringify(got)}`
+		);
+	});
+});
+
+describe('#1544/#1545 AC-4 (Normalfall zu AC-3): Reaktivierung bringt die Zeile zurueck', () => {
+	test('Dieselbe Groesse wird wieder aktiviert -> ihre Identitaeten erscheinen wieder', async () => {
+		const derive = await loadDeriveActiveAlertMetricsForTrip();
+		const vorher = derive(
+			[
+				{ metric_id: 'temperature', enabled: false },
+				{ metric_id: 'gust', enabled: true }
+			],
+			CATALOG
+		);
+		assert.ok(
+			!vorher.includes('temperature_max'),
+			'Vorbedingung: vor der Reaktivierung ist keine Temperatur-Zeile da.'
+		);
+
+		const nachher = derive(
+			[
+				{ metric_id: 'temperature', enabled: true },
+				{ metric_id: 'gust', enabled: true }
+			],
+			CATALOG
+		);
+		assert.deepEqual(
+			nachher,
+			ALL_ALARMABLE_IN_CATALOG,
+			`Nach der Reaktivierung muessen alle drei Temperatur-Identitaeten UND ` +
+				`Böen erscheinen (AC-4). Erhalten: ${JSON.stringify(nachher)}`
+		);
+
+		// AC-4 zweiter Teil: die vorher gespeicherte Stufe darf nicht auf
+		// "standard" zurueckgesetzt worden sein. Diese Ableitung kennt gar kein
+		// `metric_alert_levels` -- sie darf es folglich auch nicht anfassen. Der
+		// gespeicherte Stand bleibt daher unveraendert, unabhaengig vom Aufruf
+		// hier (separater, ungefilterter Wert, s. AC-6/Falle 4).
+		const gespeicherteStufen = { temperature_max: 'sensibel' };
+		const vorherJson = JSON.stringify(gespeicherteStufen);
+		derive(
+			[
+				{ metric_id: 'temperature', enabled: true },
+				{ metric_id: 'gust', enabled: true }
+			],
+			CATALOG
+		);
+		assert.equal(
+			JSON.stringify(gespeicherteStufen),
+			vorherJson,
+			'Die Zeilen-Ableitung hat einen aussenstehenden Stufen-Stand veraendert -- ' +
+				'sie darf `metric_alert_levels` nicht einmal kennen (AC-4/AC-6).'
+		);
+	});
+});
+
+describe('#1544/#1545 AC-5: Altbestands-Sonderfall (leere/fehlende Wetter-Metriken-Auswahl)', () => {
+	test('metrics === [] liefert ALLE alarmfaehigen Register-Eintraege, nicht leer', async () => {
+		const derive = await loadDeriveActiveAlertMetricsForTrip();
+		const got = derive([], CATALOG);
+		assert.deepEqual(
+			got,
+			ALL_ALARMABLE_IN_CATALOG,
+			'Ein Trip, dessen Wetter-Reiter nie angefasst wurde (leeres metrics[]), ' +
+				'muss ALLE alarmfaehigen Groessen als Zeile zeigen -- das Backend ' +
+				'(is_alert_metric_active, weather_change_detection.py:213-216) haelt ' +
+				`in diesem Zustand ebenfalls alles fuer aktiv. Erhalten: ${JSON.stringify(got)}`
+		);
+	});
+
+	test('metrics === undefined liefert dasselbe wie []', async () => {
+		const derive = await loadDeriveActiveAlertMetricsForTrip();
+		const got = derive(undefined, CATALOG);
+		assert.deepEqual(got, ALL_ALARMABLE_IN_CATALOG);
+	});
+
+	test('Gegenprobe: bei GESETZTER Auswahl greift der Sonderfall NICHT mehr', async () => {
+		const derive = await loadDeriveActiveAlertMetricsForTrip();
+		// Sobald mindestens ein Eintrag existiert, gilt die normale
+		// Aktivierungslogik -- ein einzelnes deaktiviertes metrics[] darf NICHT
+		// wie der leere Sonderfall behandelt werden (sonst waere AC-3 nie
+		// pruefbar).
+		const got = derive([{ metric_id: 'gust', enabled: false }], CATALOG);
+		assert.deepEqual(
+			got,
+			[],
+			'Ein bewusst leeres Auswahl-Ergebnis (Eintrag vorhanden, aber aus) ist ' +
+				`NICHT der Altbestands-Sonderfall. Erhalten: ${JSON.stringify(got)}`
+		);
+	});
+});
+
+describe('#1544/#1545 AC-8: stabile Reihenfolge, nicht Einfuege-Reihenfolge', () => {
+	// Eingabe bewusst mit Temperatur VOR Böen -- eine naive Implementierung,
+	// die einfach `metrics` durchlaeuft, wuerde die Temperatur-Identitaeten
+	// zuerst liefern. ALERTABLE_METRICS fuehrt aber `wind_gust` vor den
+	// Temperatur-Identitaeten (alertMetricTable.ts:185-199) -- nur eine
+	// Sortierung ueber diese Liste besteht den Test.
+	const metrics: WeatherConfigMetric[] = [
+		{ metric_id: 'temperature', enabled: true },
+		{ metric_id: 'gust', enabled: true }
+	];
+
+	test('Reihenfolge folgt ALERTABLE_METRICS, nicht der Eingabe-Reihenfolge', async () => {
+		const derive = await loadDeriveActiveAlertMetricsForTrip();
+		const got = derive(metrics, CATALOG);
+		assert.deepEqual(
+			got,
+			ALL_ALARMABLE_IN_CATALOG,
+			`Erwartete ALERTABLE_METRICS-Reihenfolge (wind_gust zuerst). Erhalten: ${JSON.stringify(got)}`
+		);
+	});
+
+	test('Zweiter Aufruf auf identischem Zustand liefert exakt dieselbe Reihenfolge', async () => {
+		const derive = await loadDeriveActiveAlertMetricsForTrip();
+		const erst = derive(metrics, CATALOG);
+		const zweit = derive(metrics, CATALOG);
+		assert.deepEqual(
+			zweit,
+			erst,
+			'Zwei Aufrufe auf demselben Trip-Zustand (auch nach einem ' +
+				'Speichervorgang, der die Auswahl nicht aendert) muessen identische ' +
+				'Reihenfolge liefern -- sonst springen Zeilen bei jedem Oeffnen (AC-8).'
+		);
+	});
+});
+
+describe('#1544/#1545 AC-10: Bestandsschutz — nur Sichtbarkeit aendert sich, keine Stufe', () => {
+	test('Ein eingefrorenes metric_alert_levels-Objekt bleibt unangetastet', async () => {
+		const derive = await loadDeriveActiveAlertMetricsForTrip();
+		// Ein Trip mit bereits sinnvoll gesetzten Stufen fuer AKTIVE UND eine
+		// inaktive Groesse (Bestand vor der Umstellung). Object.freeze macht aus
+		// jedem Schreibversuch der neuen Ableitung einen harten Fehlschlag (die
+		// Frontend-Test-Module laufen strict, ESM ist immer strict) statt eines
+		// stillen, unbemerkten Datenverlusts.
+		const bestehendeStufen = Object.freeze({
+			wind_gust: 'sensibel',
+			temperature_max: 'entspannt',
+			temperature_min: 'standard'
+		});
+		const vorherJson = JSON.stringify(bestehendeStufen);
+
+		const metrics: WeatherConfigMetric[] = [
+			{ metric_id: 'gust', enabled: true },
+			{ metric_id: 'temperature', enabled: true }
+		];
+		const zeilen = derive(metrics, CATALOG);
+
+		assert.deepEqual(
+			zeilen,
+			ALL_ALARMABLE_IN_CATALOG,
+			'Vorbedingung: alle drei bereits konfigurierten Groessen sind weiterhin ' +
+				'aktiv und muessen als Zeile erscheinen.'
+		);
+		assert.equal(
+			JSON.stringify(bestehendeStufen),
+			vorherJson,
+			'Die neue Ableitung hat das eingefrorene Stufen-Objekt veraendert oder ' +
+				'einen Schreibzugriff darauf versucht -- AC-10 verlangt, dass NUR die ' +
+				'Zeilen-Sichtbarkeit sich aendert, niemals eine gespeicherte Stufe.'
+		);
+	});
+});
+
+// ── Adversary Fix-Loop, F002: auch trip-weit wird das Register GELESEN ──────
+// Trip-weites Gegenstueck zum F002-Block in
+// alert_identities_from_metric_entry.test.ts. Erfundene Katalog-Kennung
+// (`boeen_pilot_2027`), aber ECHTE Alarm-Identitaet (`wind_gust`) -- nur so
+// ueberlebt sie den ALERTABLE_METRICS-Filter aus AC-8. Eine Handliste ueber
+// Katalog-Kennungen findet den Eintrag nicht und liefert leer.
+describe('#1544/#1545 F002: unbekannte Katalog-Kennung wird strukturell aufgeloest', () => {
+	const PILOT_CATALOG: MetricCatalog = {
+		wind: [
+			{
+				id: 'boeen_pilot_2027',
+				label: 'Böen (Pilotquelle)',
+				unit: 'km/h',
+				category: 'wind',
+				default_enabled: false,
+				has_friendly_format: false,
+				change_alert_metric: null,
+				aggregations: [{ id: 'max', label: 'Maximum', alert_metric: 'wind_gust' }]
+			} as unknown as MetricEntry
+		]
+	};
+
+	test('Aktivierte Groesse mit unbekannter Kennung liefert ihre Identitaet', async () => {
+		const derive = await loadDeriveActiveAlertMetricsForTrip();
+		const got = derive([{ metric_id: 'boeen_pilot_2027', enabled: true }], PILOT_CATALOG);
+		assert.deepEqual(
+			got,
+			['wind_gust'],
+			'Die trip-weite Ableitung muss die Alarm-Identitaet aus dem Katalog-' +
+				'Eintrag lesen, egal wie die Groesse heisst. Leeres Ergebnis heisst: ' +
+				`irgendwo wird eine Namensliste gefuehrt (F002). Erhalten: ${JSON.stringify(got)}`
+		);
+	});
+
+	test('Gegenprobe: dieselbe unbekannte Kennung deaktiviert liefert leer', async () => {
+		const derive = await loadDeriveActiveAlertMetricsForTrip();
+		assert.deepEqual(derive([{ metric_id: 'boeen_pilot_2027', enabled: false }], PILOT_CATALOG), []);
+	});
+});
+
+// ── Adversary Runde 2, F-ADV1: die Absicherung muss am AUFRUFER greifen ─────
+// Der F002-Block oben faellt NICHT, wenn `deriveActiveAlertMetricsForTrip`
+// `alertIdentitiesForMetricEntry` gar nicht mehr aufruft, sondern eine eigene
+// Handtabelle fuehrt, die `boeen_pilot_2027` einfach mit aufnimmt (Mutation
+// M8b: 23 von 23 gruen). Eine laengere Kennungsliste schliesst diese Luecke
+// nicht -- nur die Konstruktion, die den Kern-Test robust macht: DIESELBE
+// Katalog-Kennung in mehreren Varianten, die sich ausschliesslich in der
+// hinterlegten Struktur unterscheiden, mit GEGENSAETZLICHEN erwarteten
+// Ergebnissen. Eine Tabelle ueber Kennungen kann das nicht aufloesen: sie
+// liefert je Kennung immer dasselbe, egal wie lang sie ist.
+describe('#1544/#1545 F-ADV1: auch der trip-weite Aufrufer liest Struktur, nicht Namen', () => {
+	const KENNUNG = 'strahlungsbilanz_2031';
+	const AKTIV: WeatherConfigMetric[] = [{ metric_id: KENNUNG, enabled: true }];
+
+	/** Register mit genau EINEM Eintrag unter immer derselben Kennung. */
+	function registerMit(agg: string | null, change: string | null): MetricCatalog {
+		return {
+			atmosphere: [
+				{
+					id: KENNUNG,
+					label: 'Strahlungsbilanz',
+					unit: 'W/m²',
+					category: 'atmosphere',
+					default_enabled: false,
+					has_friendly_format: false,
+					change_alert_metric: change,
+					aggregations: [
+						{ id: 'max', label: 'Maximum', alert_metric: agg },
+						{ id: 'avg', label: 'Mittel', alert_metric: null }
+					]
+				} as unknown as MetricEntry
+			]
+		};
+	}
+
+	test('Gleiche Kennung, einmal mit und einmal ohne Identitaet -> gegensaetzliches Ergebnis', async () => {
+		const derive = await loadDeriveActiveAlertMetricsForTrip();
+		const mit = derive(AKTIV, registerMit('wind_gust', null));
+		const ohne = derive(AKTIV, registerMit(null, null));
+		assert.deepEqual(mit, ['wind_gust'], `Erhalten: ${JSON.stringify(mit)}`);
+		assert.deepEqual(
+			ohne,
+			[],
+			`Dieselbe Kennung OHNE hinterlegte Identitaet muss zeilenlos bleiben. Erhalten: ${JSON.stringify(ohne)}`
+		);
+		assert.notDeepEqual(
+			mit,
+			ohne,
+			`Zwei Register-Eintraege mit IDENTISCHER Kennung (${KENNUNG}) und ` +
+				'unterschiedlicher Struktur liefern dasselbe Ergebnis -- dann liest die ' +
+				'trip-weite Ableitung Namen statt Struktur (F-ADV1, Mutation M8b).'
+		);
+	});
+
+	test('Gleiche Kennung, ANDERE hinterlegte Identitaet -> anderes Ergebnis', async () => {
+		const derive = await loadDeriveActiveAlertMetricsForTrip();
+		// Schlaegt jede Tabelle, die je Kennung einen festen Wert liefert und
+		// hoechstens noch prueft, OB ueberhaupt eine Identitaet hinterlegt ist.
+		const ausAggregation = derive(AKTIV, registerMit('temperature_max', null));
+		assert.deepEqual(
+			ausAggregation,
+			['temperature_max'],
+			`Die Ableitung muss den hinterlegten WERT lesen. Erhalten: ${JSON.stringify(ausAggregation)}`
+		);
+		// Zweite Quelle am selben Eintrag (`change_alert_metric`), Aggregationen
+		// stumm -- faengt zusaetzlich einen Fork, der nur eine der beiden Quellen
+		// liest (die verschluckte Zeile aus AC-7).
+		const ausAenderungsrate = derive(AKTIV, registerMit(null, 'temperature_change'));
+		assert.deepEqual(
+			ausAenderungsrate,
+			['temperature_change'],
+			`Erhalten: ${JSON.stringify(ausAenderungsrate)}`
+		);
+	});
+});
+
+describe('#1544/#1545 AC-9: Deckungsgleichheit mit dem echten Backend-Regel-Erzeuger', () => {
+	// Register-Ausschnitt inkl. CAPE (im Fixture-Zustand deaktiviert) --
+	// bewusst eine EIGENE Katalog-Konstante, damit die "alle alarmfaehigen
+	// Eintraege"-Erwartung von AC-5 oben (ALL_ALARMABLE_IN_CATALOG) nicht
+	// durch das zusaetzliche CAPE verfaelscht wird. Register-Werte wie in
+	// alert_identities_from_metric_entry.test.ts (cape: metric_catalog.py
+	// :328-338, summary_fields={"max":"cape_max_jkg"}, alert_metrics=
+	// {"max":"cape"}, kein change_alert_metric).
+	const AC9_CATALOG: MetricCatalog = {
+		...CATALOG,
+		precipitation: [
+			{
+				id: 'cape',
+				label: 'Gewitterenergie (CAPE)',
+				unit: 'J/kg',
+				category: 'precipitation',
+				default_enabled: false,
+				has_friendly_format: false,
+				change_alert_metric: null,
+				aggregations: [{ id: 'max', label: 'Maximum', alert_metric: 'cape' }]
+			} as unknown as MetricEntry
+		]
+	};
+
+	function loadFixture(): {
+		metrics: WeatherConfigMetric[];
+		metric_alert_levels: Record<string, string>;
+		expected_alert_identities: AlertMetric[];
+	} {
+		const path = join(here, 'fixtures', 'ac9_trip_state.json');
+		return JSON.parse(readFileSync(path, 'utf-8'));
+	}
+
+	test('Frontend-Ableitung liefert exakt die vom echten Backend erzeugte Identitaeten-Menge', async () => {
+		const derive = await loadDeriveActiveAlertMetricsForTrip();
+		const fixture = loadFixture();
+
+		const got = derive(fixture.metrics, AC9_CATALOG);
+
+		assert.deepEqual(
+			[...got].sort(),
+			[...fixture.expected_alert_identities].sort(),
+			'Die Frontend-Ableitung weicht von der Menge ab, die ' +
+				'`expand_per_metric_levels()` fuer denselben Trip-Zustand ' +
+				'tatsaechlich auswertet (belegt in tests/unit/services/' +
+				'test_deviation_alert_engine_matches_frontend_derivation.py). ' +
+				`Erhalten: ${JSON.stringify(got)}, erwartet: ${JSON.stringify(fixture.expected_alert_identities)} (AC-9).`
+		);
+	});
+
+	test('Gegenprobe: die deaktivierte Groesse (CAPE) UND die nicht-alarmfaehige (Luftfeuchtigkeit) fehlen', async () => {
+		const derive = await loadDeriveActiveAlertMetricsForTrip();
+		const fixture = loadFixture();
+		const got = derive(fixture.metrics, AC9_CATALOG);
+
+		assert.ok(!got.includes('cape' as AlertMetric), 'CAPE ist im Fixture-Zustand deaktiviert.');
+		assert.ok(
+			!got.includes('humidity' as AlertMetric),
+			'Luftfeuchtigkeit ist strukturell nicht alarmfaehig (ADR-0010).'
+		);
+	});
+});

--- a/frontend/src/lib/components/shared/alarme-tab/tripAlertMetricsFromCatalog.ts
+++ b/frontend/src/lib/components/shared/alarme-tab/tripAlertMetricsFromCatalog.ts
@@ -1,0 +1,73 @@
+// Fix #1544/#1545: welche Alarm-Zeilen der Alarme-Reiter im TRIP zeigt,
+// entscheidet die Auswahl im Reiter "Wetter-Metriken" x die Alarmfaehigkeit
+// aus dem zentralen Register — nicht mehr `Object.keys(metric_alert_levels)`
+// (AlarmeScheduleTab.svelte:39, die Ursache der drei Fehlerklassen).
+// Gegenstueck fuer den Ortsvergleich: activeAlertMetricsFromCatalog.ts (#1435
+// E1a-2). Bewusst KEINE gemeinsame Signatur: der Compare-Pfad rechnet auf
+// Auswahl-Schluesseln, der Trip-Pfad auf nackten Metrik-Kennungen — ueber
+// Compare-Schluessel sind `temperature_change`/`precipitation_change` gar
+// nicht erreichbar (Falle 2 im Kontext-Dokument).
+// Spec: docs/specs/modules/fix_1544_1545_trip_alarm_zeilen_ableitung.md
+import { ALERTABLE_METRICS } from '$lib/components/alerts-tab/alertMetricTable';
+import type { AlertMetric, MetricEntry, WeatherConfigMetric } from '$lib/types';
+import type { MetricCatalog } from '$lib/components/trip-detail/metricsEditor';
+
+/**
+ * Alle Alarm-Identitaeten EINES Katalog-Eintrags, dedupliziert.
+ *
+ * Zwei Quellen, beide noetig: die je Auswertung hinterlegte Identitaet
+ * (`aggregations[].alert_metric`, aus `metric_catalog.alert_metric_for()`) UND
+ * die separat am Eintrag haengende Aenderungsrate (`change_alert_metric`).
+ * Eine aktivierte Temperatur traegt real alle drei — `temperature_min`,
+ * `temperature_max` und `temperature_change` (an echten Trip-Daten gemessen,
+ * AC-7). Wer nur eine der beiden Quellen liest, verschluckt Zeilen.
+ *
+ * Groessen ohne jede Identitaet (Luftfeuchtigkeit, ADR-0010) liefern `[]` —
+ * strukturell, nicht per Namensliste. Das ist die Geisterzeile aus #1545.
+ */
+export function alertIdentitiesForMetricEntry(entry: MetricEntry): AlertMetric[] {
+	const out: AlertMetric[] = [];
+	const seen = new Set<string>();
+	const add = (id: string | null | undefined): void => {
+		if (!id || seen.has(id)) return;
+		seen.add(id);
+		out.push(id as AlertMetric);
+	};
+	for (const agg of entry?.aggregations ?? []) add(agg?.alert_metric);
+	add(entry?.change_alert_metric);
+	return out;
+}
+
+/**
+ * Trip-weite Ableitung: aktivierte Wetter-Metriken x Register -> sichtbare
+ * Alarm-Zeilen. Kennt `metric_alert_levels` bewusst NICHT und fasst es nicht
+ * an — die gespeicherten Stufen bleiben eine getrennte, ungefilterte Quelle
+ * (AC-6/AC-10, Falle 4: der Speicherweg ersetzt das Feld vollstaendig, der
+ * Go-Merge ist flach).
+ *
+ * Altbestands-Sonderfall (AC-5): ein leeres/fehlendes `metrics[]` heisst
+ * "Wetter-Reiter nie angefasst" und gilt als "alles aktiv" — exakt wie
+ * `is_alert_metric_active()` (weather_change_detection.py:213-216). Sonst
+ * zeigte die Oberflaeche fuer genau diese Trips wieder null Zeilen, waehrend
+ * das Backend alles scharf hat. Sobald mindestens ein Eintrag existiert, zaehlt
+ * nur die tatsaechliche Aktivierung; ein fehlender Eintrag gilt als inaktiv.
+ *
+ * Reihenfolge und Filter laufen ueber `ALERTABLE_METRICS` (AC-8) — dieselbe
+ * Quelle wie im Vergleichs-Pfad, damit Zeilen beim Speichern nicht springen.
+ */
+export function deriveActiveAlertMetricsForTrip(
+	metrics: WeatherConfigMetric[] | undefined,
+	catalog: MetricCatalog
+): AlertMetric[] {
+	const nieKonfiguriert = !metrics || metrics.length === 0;
+	const aktivierteIds = new Set(
+		(metrics ?? []).filter((m) => m?.enabled).map((m) => m.metric_id)
+	);
+	const gefunden = new Set<AlertMetric>();
+	for (const entry of Object.values(catalog ?? {}).flat()) {
+		if (!entry) continue;
+		if (!nieKonfiguriert && !aktivierteIds.has(entry.id)) continue;
+		for (const identitaet of alertIdentitiesForMetricEntry(entry)) gefunden.add(identitaet);
+	}
+	return ALERTABLE_METRICS.filter((m) => gefunden.has(m));
+}

--- a/frontend/src/lib/components/trip-detail/AlarmeScheduleTab.svelte
+++ b/frontend/src/lib/components/trip-detail/AlarmeScheduleTab.svelte
@@ -22,21 +22,35 @@
 
 	import AlarmeTab from '$lib/components/shared/AlarmeTab.svelte';
 	import { reconstructTripAlertChannels } from '../shared/alarme-tab/tripChannelReconstruction.ts';
+	import { deriveActiveAlertMetricsForTrip } from '../shared/alarme-tab/tripAlertMetricsFromCatalog.ts';
 	import type { Trip, AlertMetric, SensLevel } from '$lib/types';
+	import type { MetricCatalog } from './metricsEditor.ts';
 	import type { SaveStatus } from '$lib/stores/saveStatusStore.svelte';
 
 	interface Props {
 		trip: Trip;
 		onTripUpdate?: (updated: Trip) => void;
 		saveController?: SaveStatus;
+		/** Fix #1544/#1545: der in TripTabs bereits geladene Metrik-Katalog —
+		 *  kein eigener Abruf. */
+		metricsCatalog?: MetricCatalog | null;
 	}
-	let { trip, onTripUpdate, saveController }: Props = $props();
+	let { trip, onTripUpdate, saveController, metricsCatalog = null }: Props = $props();
 
 	// ── (c) Metrik-Level-Tabelle: Initialwert aus display_config.metric_alert_levels ──
+	// Fix #1544/#1545 (AC-6, Falle 4): UNGEFILTERTER Passthrough. Diese Quelle
+	// speist den Speicherweg, der `metric_alert_levels` vollstaendig ersetzt —
+	// wuerde sie mitgefiltert, verloere jede gerade nicht angezeigte Groesse
+	// beim naechsten Speichern ihre Stufe. Getrennt von `activeMetrics`.
 	const metricLevels = $derived(
 		(trip.display_config?.metric_alert_levels ?? {}) as Record<AlertMetric, SensLevel>
 	);
-	const activeMetrics = $derived(Object.keys(metricLevels) as AlertMetric[]);
+	// Fix #1544/#1545: Zeilen aus Auswahl x Register statt aus den persistierten
+	// Schluesseln (Fehlerklassen 1-3). Rechnet hier im Container, damit der
+	// geteilte AlarmeTab im `route`-Zweig unveraendert nur `activeMetrics` liest.
+	const activeMetrics = $derived(
+		deriveActiveAlertMetricsForTrip(trip.display_config?.metrics, metricsCatalog ?? {})
+	);
 
 	// ── (d) Kanaele: AC-15 Ist-Zustand-Rekonstruktion als Initialwert ──────────
 	const existingChannels = $derived(reconstructTripAlertChannels(trip));

--- a/frontend/src/lib/components/trip-detail/TripTabs.svelte
+++ b/frontend/src/lib/components/trip-detail/TripTabs.svelte
@@ -229,7 +229,7 @@
 						<CorridorEditor {trip} {onTripUpdate} {saveController} />
 					{/if}
 				{:else if tab.value === 'alarme' && trip}
-					<AlarmeScheduleTab {trip} {onTripUpdate} {saveController} />
+					<AlarmeScheduleTab {trip} {onTripUpdate} {saveController} {metricsCatalog} />
 				{:else if tab.value === 'briefings' && trip}
 					<BriefingScheduleTab {trip} {onTripUpdate} {saveController} onJump={handleValueChange} />
 				{:else if tab.value === 'preview' && trip}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -189,8 +189,17 @@ export interface MetricEntry {
 	aggregation_label?: string;
 	/** Issue #1357: berechenbare Tagesauswertungen dieser Groesse, aus dem
 	 *  zentralen Katalog (`metric_catalog.available_aggregations`). Weniger als
-	 *  zwei Eintraege ⇒ der Editor zeigt keine Auswahl (AC-5). */
-	aggregations?: { id: string; label: string }[];
+	 *  zwei Eintraege ⇒ der Editor zeigt keine Auswahl (AC-5).
+	 *  Fix #1544/#1545: `alert_metric` ist die Alarm-Identitaet dieser
+	 *  Auswertung aus dem zentralen Register (`null` = nicht alarmfaehig).
+	 *  `GET /api/metrics` liefert sie laengst (api/routers/config.py:98-105),
+	 *  nur der Frontend-Typ nahm sie bisher nicht auf. */
+	aggregations?: { id: string; label: string; alert_metric?: string | null }[];
+	/** Fix #1544/#1545: Alarm-Identitaet der Aenderungsrate dieser Groesse
+	 *  (z.B. `temperature_change`) — haengt am Eintrag, nicht an einer
+	 *  Auswertung, und ist damit die zweite noetige Quelle neben
+	 *  `aggregations[].alert_metric` (api/routers/config.py:89). */
+	change_alert_metric?: string | null;
 }
 
 export interface WeatherConfigMetric {

--- a/tests/unit/services/test_deviation_alert_engine_matches_frontend_derivation.py
+++ b/tests/unit/services/test_deviation_alert_engine_matches_frontend_derivation.py
@@ -1,0 +1,186 @@
+"""TDD — Fix #1544/#1545, AC-9 (Deckungsgleichheit).
+
+Die eigentliche Zusicherung dieser Scheibe: die Menge der im Trip-Alarme-
+Reiter angezeigten Alarm-Identitaeten ist exakt die Menge, die der
+Live-Alarm-Detektor fuer denselben Trip tatsaechlich auswertet -- weder mehr
+noch weniger.
+
+Spec: docs/specs/modules/fix_1544_1545_trip_alarm_zeilen_ableitung.md
+  Acceptance Criteria AC-9.
+
+## Warum diese Datei ALLEIN heute schon gruen ist -- und das auch richtig so
+   ist
+
+Anzeige (TypeScript, neue Ableitung `deriveActiveAlertMetricsForTrip`) und
+Auswertung (Python, `expand_per_metric_levels()`) liegen in verschiedenen
+Sprachen. Ein Test, der die TS-Erwartung in Python nachbaut, wuerde nichts
+pruefen -- er spiegelte nur die eigene Annahme zurueck (s. Auftrag zu
+diesem Workflow).
+
+Backend-seitig ist an DIESER Scheibe nichts geaendert (Spec, Abschnitt
+"Schicht-Hinweis": ausschliesslich Frontend). `expand_per_metric_levels()`
+funktioniert also bereits heute korrekt -- diese Datei belegt das nur, sie
+kann durch diese Scheibe nicht rot werden.
+
+Das eigentliche RED-Signal fuer AC-9 liegt deshalb NICHT hier, sondern im
+TS-Test `frontend/src/lib/components/shared/alarme-tab/__tests__/
+trip_active_alert_metrics_derivation.test.ts` (Describe-Block "AC-9"): der
+importiert die noch nicht existierende `deriveActiveAlertMetricsForTrip`
+und liest DIESELBE Fixture-Datei, die DIESER Test hier erzeugt/verifiziert.
+Beide Seiten rechnen unabhaengig gegen ihre eigene Produktivrealitaet und
+treffen sich an einem gemeinsamen, aus dem echten Backend gewonnenen
+Fixpunkt -- kein Mock des Regel-Erzeugers, keine RPC zwischen den Sprachen.
+
+Diese Datei ist der Anker dieses Fixpunkts: sie haelt das Backend-Ergebnis
+fest UND bewacht es als Regression -- eine kuenftige Aenderung an
+`expand_per_metric_levels()`/`is_alert_metric_active()`, die die erzeugte
+Identitaeten-Menge fuer diesen Zustand veraendert, macht DIESEN Test rot
+(Mutations-Gegenprobe: s. unten).
+
+## Wahl des Trip-Zustands
+
+AC-9 verlangt "fuer mindestens einen Trip-Zustand" Deckungsgleichheit --
+nicht universell. Ein Zustand mit einem EXPLIZITEN `level: 'off'` wuerde in
+der Anzeige (Auswahl x Register, unabhaengig vom Stufenwert) weiterhin eine
+Zeile zeigen, waehrend der Regel-Erzeuger dafuer keine Regel baut -- die
+Mengen wichen dann bewusst voneinander ab (das ist kein Fehler, sondern
+Teil des Vertrags: eine "aus"-Zeile bleibt sichtbar, feuert aber nicht).
+Der hier gewaehlte Zustand enthaelt daher KEIN 'off': Temperatur ist aktiv
+und hat keinen expliziten Level-Eintrag (Backfill 'standard'), Boeen ist
+aktiv mit explizitem 'sensibel', Luftfeuchtigkeit ist aktiv aber nicht
+alarmfaehig (Register), CAPE ist im Wetter-Reiter deaktiviert. Fuer GENAU
+diesen Zustand muessen beide Mengen identisch sein.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.models import MetricConfig, UnifiedWeatherDisplayConfig
+from services.alert_preset import expand_per_metric_levels
+
+# Pfadregel #1409: relativ zu DIESER Datei aufgeloest (services -> unit ->
+# tests -> Repo-Wurzel), kein fester Hauptrepo-Pfad -- sonst prueft dieser
+# Test aus einem Worktree die unveraenderte Hauptrepo-Kopie der Fixture.
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "frontend"
+    / "src"
+    / "lib"
+    / "components"
+    / "shared"
+    / "alarme-tab"
+    / "__tests__"
+    / "fixtures"
+    / "ac9_trip_state.json"
+)
+
+
+def _load_fixture() -> dict:
+    assert _FIXTURE_PATH.exists(), (
+        f"AC-9-Fixture fehlt: {_FIXTURE_PATH}. Sie wird von BEIDEN Seiten "
+        "(dieser Python-Test UND der TS-Test trip_active_alert_metrics_"
+        "derivation.test.ts, Describe-Block AC-9) gelesen."
+    )
+    return json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _display_config(fixture: dict) -> UnifiedWeatherDisplayConfig:
+    metrics = [
+        MetricConfig(metric_id=m["metric_id"], enabled=m["enabled"])
+        for m in fixture["metrics"]
+    ]
+    return UnifiedWeatherDisplayConfig(
+        trip_id="ac9-fixture",
+        metrics=metrics,
+        metric_alert_levels=dict(fixture["metric_alert_levels"]),
+    )
+
+
+def test_fixture_fields_are_self_consistent():
+    """Rohdaten-Sanity: die Fixture ist kein erfundenes Format -- die
+    Gegenprobe unten haengt vollstaendig an ihrer korrekten Struktur."""
+    fixture = _load_fixture()
+    assert set(fixture.keys()) >= {
+        "metrics",
+        "metric_alert_levels",
+        "expected_alert_identities",
+    }
+    assert fixture["metric_alert_levels"], "Fixture sollte mindestens eine explizite Stufe enthalten (sonst prueft AC-4/Backfill nicht mit)."
+    metric_ids = {m["metric_id"] for m in fixture["metrics"]}
+    assert "cape" in metric_ids and any(
+        m["metric_id"] == "cape" and m["enabled"] is False for m in fixture["metrics"]
+    ), "Fixture braucht eine EXPLIZIT deaktivierte Groesse (CAPE), sonst prueft AC-3 im Backend-Pfad nicht mit."
+
+
+def test_backend_produces_exactly_the_fixtures_expected_identities():
+    """Der echte Regel-Erzeuger (kein Mock) erzeugt fuer den Fixture-Zustand
+    genau die in `expected_alert_identities` festgehaltene Menge."""
+    fixture = _load_fixture()
+    display_config = _display_config(fixture)
+
+    rules = expand_per_metric_levels(
+        dict(fixture["metric_alert_levels"]), display_config
+    )
+    got = sorted({str(rule.metric) for rule in rules})
+
+    assert got == sorted(fixture["expected_alert_identities"]), (
+        f"expand_per_metric_levels() liefert {got}, die Fixture erwartet "
+        f"{sorted(fixture['expected_alert_identities'])}. Beide Seiten "
+        "(Python-Backend, TS-Frontend) muessen sich an DIESEM Wert treffen "
+        "(AC-9) -- weicht der Backend-Wert ab, ist die Fixture veraltet "
+        "oder das Backend hat sich veraendert."
+    )
+
+
+def test_backend_excludes_the_deactivated_metric_and_the_unalertable_one():
+    """Gegenprobe zur Kernaussage: CAPE (deaktiviert) und Luftfeuchtigkeit
+    (nicht alarmfaehig) duerfen in KEINEM erzeugten Regel-Namen auftauchen
+    -- sonst waere die Fixture zufaellig richtig, statt die Trennschaerfe
+    tatsaechlich zu belegen."""
+    fixture = _load_fixture()
+    display_config = _display_config(fixture)
+
+    rules = expand_per_metric_levels(
+        dict(fixture["metric_alert_levels"]), display_config
+    )
+    got = {str(rule.metric) for rule in rules}
+
+    assert "cape" not in got, (
+        "CAPE ist im Fixture-Zustand deaktiviert -- eine erzeugte Regel "
+        "dafuer waere der Fehler aus Fehlerklasse 3 (vorgetaeuschte Kontrolle)."
+    )
+    assert "humidity" not in got, (
+        "Luftfeuchtigkeit ist laut Register nicht alarmfaehig (ADR-0010) -- "
+        "eine erzeugte Regel dafuer waere strukturell unmoeglich und ein "
+        "Zeichen dafuer, dass die Fixture nicht mehr zum Register passt."
+    )
+
+
+def test_mutation_guard_missing_backfill_would_be_caught():
+    """Mutations-Gegenprobe (CLAUDE.md, PFLICHT): simuliert den Ausfall des
+    Backfills fuer aktive Groessen OHNE expliziten Level-Eintrag (Temperatur
+    im Fixture-Zustand) durch Aufruf OHNE `display_config` -- das alte
+    Verhalten (keine Filterung, kein Backfill). Belegt, dass der Test bei
+    einer echten Regression tatsaechlich rot werden KANN, nicht nur
+    zufaellig gruen ist."""
+    fixture = _load_fixture()
+
+    # Ohne display_config: kein Backfill, keine Aktivierungs-Pruefung
+    # (Doku von expand_per_metric_levels(), Zeile "Ohne display_config
+    # (Default None): altes Verhalten"). Temperatur (kein expliziter
+    # Eintrag) faellt dann komplett weg -- exakt die Regression, die AC-9
+    # verhindern soll.
+    rules_ohne_backfill = expand_per_metric_levels(
+        dict(fixture["metric_alert_levels"]), None
+    )
+    got_ohne_backfill = {str(rule.metric) for rule in rules_ohne_backfill}
+
+    assert got_ohne_backfill != set(fixture["expected_alert_identities"]), (
+        "Diese Gegenprobe muss selbst eine Abweichung zeigen -- sonst waere "
+        "der Haupttest oben nicht in der Lage, einen fehlenden Backfill zu "
+        "fangen (Mutations-Pflicht)."
+    )
+    assert "temperature_min" not in got_ohne_backfill
+    assert "temperature_max" not in got_ohne_backfill
+    assert "temperature_change" not in got_ohne_backfill


### PR DESCRIPTION
Behebt **#1544** und **#1545** gemeinsam — sie haben dieselbe Wurzel. PO-Entscheid: **Zuschnitt A** (alle drei Fehlerklassen in einem Zug).

## Das Problem, an echten Daten gemessen

Der Trip-Editor leitete seine Alarmzeilen aus den **persistierten Schlüsseln** ab (`Object.keys(display_config.metric_alert_levels)`), der Ortsvergleich dagegen aus **Auswahl × Katalog**. Die Regeln wurden nicht nachgerechnet, sondern mit dem echten Produktivcode erzeugt (`expand_per_metric_levels()`, Guard aus `deviation_alert_engine.py:186-198`):

| Fehlerklasse | Betroffen | Wirkung |
|---|---|---|
| **1 — unsichtbare Scharfschaltung** | **12 von 14 Trips** | 6–9 **scharfe** Regeln je Trip, **null** Zeilen im Datensatz. Kein Bedienelement zum Ansehen oder Abschalten. Der Backfill (`alert_preset.py:309-348`) nimmt still `standard` an. |
| **2 — Geisterzeile Luftfeuchtigkeit** | 2 von 14 | Zeile sichtbar, löst seit #889/ADR-0010 nie aus |
| **3 — vorgetäuschte Kontrolle** | 2 von 14 | Bei „Lottis Abschiedfahrradtour" standen **7 von 13** Zeilen auf `standard` — also *an* — und wirkten trotzdem nicht, weil die Größe im Reiter *Wetter-Metriken* nicht aktiviert war |

**Kein einziger der 14 Trips zeigte an, was tatsächlich wirkt.** Klasse 3 steht in keinem der beiden Tickets; sie verschwindet durch denselben Fix.

## Die Lösung

Der Trip-Reiter leitet seine Zeilen aus **Auswahl × Alarmfähigkeit** ab — wie der Ortsvergleich seit #1435 E1a-2. Damit fällt jede Klasse für sich weg: Zeilen erscheinen und sind abschaltbar, Luftfeuchtigkeit ist im Register nicht alarmfähig, nicht aktivierte Größen liefern keine Zeile mehr.

**Frontend-only.** `GET /api/metrics` liefert die Alarm-Identität bereits (`api/routers/config.py:89, 98-105`) — nur der Frontend-Typ nahm sie nicht auf.

## Zwei naheliegende Wege, die verworfen wurden

- **Den toten `AlertsTab.svelte` wiederbeleben** (nirgends eingebunden, nachgemessen). Seine Übersetzungstabelle führt `humidity` weiter — hätte #1545 **verschlimmert** und eine weitere handgepflegte Liste zementiert.
- **Den Compare-Katalog recyceln.** `temperature_change` und `precipitation_change` sind über **keinen** Compare-Auswahlschlüssel erreichbar (geprüft an allen 26 Einträgen) — zwei Alarmzeilen wären still verschwunden.

## Adversary: 3 Runden, 12 Mutationen, VERIFIED

Drei CRITICAL-Findings, **alle drei in der Testabdeckung**, nicht in der Logik:

| Finding | Umgehung, die grün blieb | Geschlossen durch |
|---|---|---|
| **F001** | AST-Wächter prüft nur literale Bezeichner — dieselbe Kopplung über eine umbenannte Zwischenvariable blieb 4/4 grün, der Datenverlust träte trotzdem ein | Ebene-3-Laufzeittest: echtes Rendering, misst die **tatsächlich gesendete Nutzlast** |
| **F002** | Register-Ableitung durch handgepflegte 4-Einträge-Liste ersetzbar, **18/18 grün** — exakt das Muster aus #1435 E4 | Gegenprobe mit **derselben** Kennung, einmal mit und einmal ohne Alarm-Identität, gegensätzliche Erwartung |
| **F-ADV1** | Dieselbe Lücke eine Ebene höher: der Aufrufer lässt sich forken, 23/23 grün | Gleiche Konstruktion auf Aufrufer-Ebene |

**Keine ID-Tabelle kann diese Tests bestehen, unabhängig von ihrer Länge** — das ist strukturell belegt, nicht nur gegen eine konkrete Liste geprüft. Die prinzipielle Grenze (Ergebnis nachträglich überschreiben) ist als **bewusste Grenze** in der Spec dokumentiert, nicht als Lücke.

## Tests

- **2471 Frontend-Tests grün**, 0 Fehler (vollständige Suite), 4 Python-Tests grün
- Nach Rebase auf `origin/main` (16 fremde Commits) erneut gemessen — unverändert grün
- Bestehende Suiten laufen mit, insbesondere `alarme_tab_catalog_prop_structure.test.ts` (#1258 AC-7 „Trip-Zweig bleibt unangetastet") — kein Testumbau nötig

## Bewusst nicht in dieser Scheibe

Keine Kennzeichnung „gilt derzeit, nicht von dir gesetzt" · keine Migration der `humidity`-Altdaten (2 Trips, wirkt nicht, wird nicht mehr angezeigt) · keine Änderung am Backend-Backfill — diese Scheibe macht seine Wirkung **sichtbar**, ändert sie nicht · kein Onboarding-Schritt (ADR-0032) · keine zweite Steuergröße (ADR-0043).

## Hinweis für den Betrieb

Nach dem Deploy zeigen Trips Alarmzeilen, die nie jemand gesetzt hat — sie **waren die ganze Zeit scharf**, nur unsichtbar. Erstmals sind sie abschaltbar; der tatsächliche Versand kann dadurch **abnehmen**.

Spec: `docs/specs/modules/fix_1544_1545_trip_alarm_zeilen_ableitung.md`
Folge-Scheibe der in #1435 E4 angekündigten Arbeit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)