### PR TITLE
feat(#1439): Starkregen-Kurzfristhinweis im planmaessigen Trip-Briefing

### DIFF
--- a/docs/context/feat-1439-starkregen-minutely15.md
+++ b/docs/context/feat-1439-starkregen-minutely15.md
@@ -1,0 +1,95 @@
+# Context: feat-1439-starkregen-minutely15
+
+## Request Summary
+
+Issue #1439: Starkregen-Kurzfristhinweis im **planmäßigen** Trip-Briefing (Morgen-/
+Abend-Mail + Telegram). Deadline 20.8.2026 (KHW-Wanderung AT/IT), `priority:critical`,
+PO-Entscheidung 2026-08-05 „machen VOR der Tour". Einzige Vorbedingung (#1492) ist seit
+heute (2026-08-07) geschlossen.
+
+**Modus-Korrektur gegenüber Issue-Text:** AENDERUNG, nicht NEU. Das Issue beschreibt
+Stufe A als Neubau auf Basis von Open-Meteo `minutely_15` — diese Infrastruktur existiert
+bereits produktiv seit #656 (`RadarNowcastService`). Zu bauen ist die fehlende
+**Einbindung in den planmäßigen Briefing-Pfad**, nicht der Nowcast selbst.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `src/services/radar_service.py` | `RadarNowcastService`, `INTENSITY_HEAVY="Starker Regen"` bei `mm_per_h>=4.0` (Z.68,147-149) — das ist bereits die im Issue geforderte Starkregen-Schwelle. Mehrschichtige Provider-Kaskade RADOLAN→INCA→DPC/ARPAE→AROME-FR→ICON-D2→`minutely_15` (`_fetch_frames_with_fallback`, Z.280), Fail-soft nach ADR-0018. `format_now_text()` (Z.224) liefert bereits das im Issue gewünschte Format „Starker Regen ab ca. HH:MM (in ~N Min)" |
+| `src/services/trip_alert.py:763,775,783-848` | Einziger heutiger Aufrufer im planmäßigen Takt: 15-Min-Cron ruft `radar_svc.get_nowcast(..., priority="polling")`, gated durch `alert_daily_limit.is_allowed(..., reason="nowcast")` (Budget-Gate, #1555-Reserve seit heute live). Danach Konsistenzprüfung gegen `WeatherSnapshotService.load_dated()` + `_briefing_precip_for_onset` mit drei Wortlaut-Zuständen (#1310-Präzedenz: „bereits angekündigt — jetzt akut" / „bereits angekündigt" / „nicht angekündigt") |
+| `src/services/trip_report_scheduler.py` | Baut `TripReportRequest` für das planmäßige Briefing — **ruft `radar_service` heute NICHT auf** (grep bestätigt). Das ist die Lücke, die #1439 schließen soll |
+| `src/services/radar_cache.py` | TTL 300s (5 Min) — bei 15-Min-Polling-Kadenz meist kein Cache-Hit; ein zweiter unabhängiger Aufrufort würde reale Zusatzkosten erzeugen |
+| `src/output/renderers/email/unavailable_hint.py` | Vorbild-Muster für eine orthogonale Hinweis-Zeile: `any_..._unavailable()`-Gate + `render_..._html/plain()`, bewusst NICHT unter `renderers/alert/` (triggert sonst das Warn-Renderer-Mail-Gate) |
+| `docs/specs/data_sources.md` | Enthält aktuell KEINEN Eintrag für `minutely_15` — Governance-Nachtrag nötig (Parameter läuft seit #656 in Prod, ist aber nie eingetragen worden). Als Nachtrag bestehender Nutzung, nicht als Neuantrag |
+| `openspec/changes/` | Existiert NICHT in diesem Repo — projekteigene Struktur ist `.claude/workflows/<name>.json` + `docs/specs/modules/<entity>.md` |
+
+## Existing Patterns
+
+- **Budget-Gate wiederverwenden, nicht danebenstellen:** jeder neue Nowcast-Zugriff MUSS
+  durch `alert_daily_limit.is_allowed(..., reason="nowcast")` laufen (`trip_alert.py:763`)
+  — ein zweiter, unabhängiger Aufrufort würde den am selben Tag geschlossenen #1555-Fix
+  sofort wieder unterlaufen.
+- **Konsistenz mit dem Alert-Pfad:** der neue Briefing-Hinweis muss gegen denselben
+  Snapshot-/Alert-State geprüft werden wie `trip_alert.py:787-848`, sonst kann Briefing
+  „kein Starkregen" sagen während 15 Min später der Alert „jetzt akut" auslöst (oder
+  umgekehrt) — Wortlaut-Präzedenz #1310 gilt analog.
+- **Zeitfenster-Guard:** `_fetch_openmeteo_15` deckt 24h ab (`forecast_minutely_15=96`).
+  „Starkregen jetzt" ist für ein Abend-vorher-Briefing bedeutungslos — der Hinweis darf
+  nur erscheinen, wenn der Onset nah am nächsten aktiven Segment liegt.
+- **Fail-soft** (ADR-0018): Provider/Region ohne Abdeckung → Hinweis-Zeile entfällt still,
+  Briefing geht normal raus.
+
+## Dependencies
+
+- **Upstream:** #656 (RadarNowcastService, live), #1555 (Nowcast-Reserve/Budget-Gate,
+  heute 2026-08-07 geschlossen), #1492 (Gewitter S4 Fallback-Kette, heute geschlossen —
+  einzige Vorbedingung aus der Issue-Historie), #1310 (Akut-Wording-Präzedenz).
+- **Downstream:** keine bekannten Abnehmer außer E-Mail/Telegram-Renderer für das
+  planmäßige Briefing. Compare/Ortsvergleich ist NICHT im Scope (Trip-Briefing-only,
+  Pendant-Gate `pendant_gate.py` beachten falls doch Compare-Bedarf entsteht).
+
+## Existing Specs
+
+- Kein bestehendes Spec-Modul für Nowcast-im-Briefing. `docs/specs/modules/ampel_schwellen_katalog.md`
+  dient als Struktur-Vorbild.
+
+## Scope Assessment
+
+- **Files:** ~4 (`trip_report_scheduler.py` MODIFY, neues Hinweis-Modul CREATE analog
+  `unavailable_hint.py`, Einbindung in `html.py`/`plain.py` + Telegram-Renderer MODIFY)
+- **Estimated LoC:** ~50-70 — realistisch NUR wenn kein eigener Fetch-/Throttle-Code
+  entsteht, sondern der bestehende gegatete Aufruf wiederverwendet/minimal erweitert wird
+- **Risk Level:** MEDIUM — Budget-Gate-Umgehung und Alert/Briefing-Widerspruch sind reale,
+  am selben Tag erst geschlossene Fehlerklassen (#1555), keine hypothetischen Risiken
+
+## Technical Approach
+
+Bestehenden `RadarNowcastService`-Pfad aus `trip_alert.py` als Vorbild wiederverwenden,
+NICHT neu implementieren. Drei Pflicht-Korrekturen (siehe Risks) fließen als eigene ACs
+in die Spec ein. MVP-Scope: E-Mail + Telegram, SMS zurückgestellt (Token-Format eigener
+Aufwand, Deadline spricht für kleinen Schnitt — als Folge-Issue vormerken).
+
+## Open Questions
+
+Keine offenen technischen Fragen mehr — SMS-Scope-Entscheidung (MVP ohne SMS) und
+Architektur-Ansatz (Budget-Gate-Wiederverwendung) sind getroffen. Verbleibt: PO-Freigabe
+der ACs in `/30-write-spec` (Pflicht-Halt).
+
+## Risks & Considerations
+
+1. **Budget-Gate-Pflicht:** neuer Nowcast-Zugriff MUSS `alert_daily_limit.is_allowed(...,
+   reason="nowcast")` durchlaufen (`trip_alert.py:763`) — sonst Umgehung des #1555-Fixes
+   vom selben Tag.
+2. **Konsistenz-Pflicht:** Hinweis-Rendering MUSS gegen denselben Snapshot-/Alert-State
+   geprüft werden wie `trip_alert.py:787-848` (#1310-Wording-Präzedenz), sonst Widerspruch
+   zwischen Briefing und Alert möglich.
+3. **Zeitfenster-Guard-Pflicht:** Hinweis nur bei Onset innerhalb eines definierten
+   Nähe-Fensters zum nächsten aktiven Segment — sonst zeigt ein Abend-Briefing Regen für
+   Stunden später als „jetzt".
+4. **Renderer-Mail-Gate:** liegt das neue Hinweis-Modul unter
+   `src/output/renderers/email/*.py`, triggert automatisch `renderer_mail_gate.py` —
+   vor Commit `tests/tdd/test_issue_811_mode_matrix.py` grün + frischer
+   `briefing_mail_validator.py`-Lauf nötig.
+5. **Governance:** `data_sources.md`-Nachtrag ist reine Doku, kein Gate-Blocker — parallel
+   zur Implementierung, nicht davor.

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -270,6 +270,7 @@ Scheibe 3 (#1170). Scheduler: `POST /api/scheduler/compare-alert-checks`, Go-Cro
      - `AlertMessage.cooldown_display` trägt den dynamischen Cooldown-Text (z.B. „2 Stunden")
      - `src/outputs/radar_alert.py` ist gelöscht — kein separater Inline-Body-Bau mehr
    - **Throttle-Semantik unverändert** (Issue #773): `radar_alert_throttle.json` + `alert_log` auch bei Best-Effort-Versandfehlern
+   - **Zweiter Schreiber seit Issue #1439:** Der planmäßige Briefing-Versand (`_send_briefing_report()`, s. Datenfluss unten) kann denselben Throttle-Eintrag (`ThrottleStore`, Scope `"radar"`) schreiben, wenn er einen Starkregen-Kurzfristhinweis versendet — dieselbe Cooldown-Prüfung in `check_radar_alerts` unterdrückt dadurch einen widersprüchlichen Folge-Alert im Cooldown-Fenster, ohne dass diese Stelle selbst geändert wurde.
 
 6. **Konvektiver Sicherheits-Override (Issue #883, Epic #813 Slice 4)**
    - Der Radar-Wächter unterdrückt einen Alert normalerweise, wenn das Briefing den Regen für die Onset-Stunde bereits angekündigt hatte (`_briefing_precip >= 0.5` → kein Alert).
@@ -323,6 +324,8 @@ check_radar_alerts(user_id)  [Issue #822 + #919]
 _send_briefing_report() [trip_report_scheduler.py]
   ↓ WeatherSnapshotService.save(snapshot)
   ↓ AlertStateService.reset(trip_id)
+  ↓ _build_starkregen_hint() → Nähe-Guard (60 Min) + Budget-Gate ("nowcast") → get_nowcast() [Issue #1439]
+  ↓ bei Treffer: Hinweiszeile in E-Mail/Telegram + ThrottleStore("radar").record(trip_id) (s. Punkt 5 oben)
 
 check_all_compare_presets(user_id)  [CompareAlertService, Issue #1169]
   ↓ pro Preset × Ort: compare_weather_snapshot.load(preset_id, location_id)  (Anker, ggf. leer)

--- a/docs/specs/data_sources.md
+++ b/docs/specs/data_sources.md
@@ -225,6 +225,23 @@ uns taeglich fuer 24 h aus; amtliche Warnungen waren dadurch den groessten Teil 
 veraltet — bei einem Sicherheitswerkzeug fuer Weitwanderungen nicht hinnehmbar. Der Feed liefert
 zusaetzlich eine laengere Rueckschau (5,8 Tage statt 23 h) und deutschsprachige Texte fuer AT.
 
+#### Antrag #3 (Nachtrag): Open-Meteo `minutely_15` — Radar-Nowcast
+
+**Datum:** 2026-08-07
+**Status:** ✅ APPROVED (Nachtrag — bereits seit #656 produktiv genutzt)
+**Antragsteller:** Claude (Issue #1439, Governance-Nachtrag zu Issue #656)
+**Spec:** `docs/specs/modules/feat_1439_starkregen_kurzfristhinweis.md`
+
+**Zusammenfassung:** `minutely_15` (Open-Meteo, Parameter `precipitation`/`weather_code`) ist der
+globale Fallback des bereits produktiven `RadarNowcastService` (Issue #656, `src/services/radar_service.py`)
+fuer den 60-Minuten-Regen-/Gewitter-Nowcast — ausserhalb der RADOLAN/INCA/DPC/AROME-Bounding-Boxen sowie
+als Sidecar-Quelle fuer den Konvektions-Check. War in dieser Spec bisher nicht eingetragen; kein neuer
+Parameter, reiner Nachtrag.
+
+| Daten | Status | Bemerkung |
+|-------|--------|-----------|
+| `minutely_15` (precipitation, weather_code) | approved (Nachtrag) | Open-Meteo, seit #656 produktiv im Nowcast-Pfad (Fallback + Konvektions-Sidecar) |
+
 #### Antrag #1: Open-Meteo Wetter-Parameter (Regional Models)
 
 **Datum:** 2026-01-24

--- a/docs/specs/modules/feat_1439_starkregen_kurzfristhinweis.md
+++ b/docs/specs/modules/feat_1439_starkregen_kurzfristhinweis.md
@@ -1,0 +1,284 @@
+---
+entity_id: feat_1439_starkregen_kurzfristhinweis
+type: module
+created: 2026-08-07
+updated: 2026-08-07
+status: draft
+version: "1.0"
+workflow: feat-1439-starkregen-minutely15
+tags: [radar-nowcast, trip-briefing, email, telegram, alerts]
+---
+
+<!-- Issue #1439 -->
+
+# Starkregen-Kurzfristhinweis im planmäßigen Trip-Briefing
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Das planmäßige Trip-Briefing (Morgen-/Abend-Mail + Telegram) bekommt eine
+kurze Hinweiszeile, wenn der bereits produktiv laufende `RadarNowcastService`
+(Issue #656) für den Startpunkt des aktiven/nächsten Segments **Starkregen
+innerhalb der nächsten 60 Minuten** erkennt. Das ist eine **Änderung**, kein
+Neubau: die Nowcast-Infrastruktur existiert bereits (u.a. im 15-Minuten-
+Alarm-Poll, `trip_alert.py`); es fehlt nur die Einbindung in den
+**planmäßigen** Briefing-Versandpfad.
+
+**Wichtige Grenze (durch die Nowcast-Technologie selbst gesetzt, keine
+Implementierungslücke):** `RadarNowcastService` erkennt Regen ausschließlich
+innerhalb eines 60-Minuten-Fensters ab Abrufzeitpunkt. Der Hinweis kann daher
+**keine** Tage- oder Stunden-vorher-Vorhersage für morgen leisten — bei einer
+Abend-Mail (die die Etappe des Folgetags beschreibt) erscheint er nur, wenn
+die Etappe zufällig kurz nach Versandzeit beginnt. Der reguläre
+Niederschlags-Ausblick in der Stundentabelle bleibt davon unberührt und ist
+weiterhin die maßgebliche Vorschau für spätere Stunden/Tage.
+
+## Source
+
+- **File:** `src/services/trip_report_scheduler.py` (MODIFY) — Ermittlung
+  des Kurzfristhinweises (gated Fetch, Zeitfenster-Guard) und Übergabe an
+  `TripReportRequest`
+- **File:** `src/output/renderers/email/starkregen_hint.py` (NEU) —
+  gemeinsamer Text-Baustein + `render_html()`/`render_plain()`, analog
+  `unavailable_hint.py` (Issue #1348)
+- **File:** `src/services/notification_service.py` (MODIFY) —
+  `TripReportRequest` um `starkregen_hint_text: str | None` erweitern, an
+  E-Mail- und Telegram-Renderer durchreichen
+- **File:** `src/output/renderers/email/html.py` (MODIFY) — Hinweis-Box
+  einbauen
+- **File:** `src/output/renderers/email/plain.py` (MODIFY) — Hinweis-Zeile
+  einbauen
+- **File:** `src/output/renderers/narrow.py` (MODIFY) — Telegram-Bubble
+  einbauen (`render_telegram_bubbles`, analog dem bestehenden
+  „Amtliche Warnungen nicht abrufbar"-Block)
+- **File:** `src/services/radar_service.py` (MODIFY, minimal) — bestehende
+  private `_NOWCAST_HORIZON_MIN = 60` bekommt einen öffentlichen Alias
+  `NOWCAST_HORIZON_MIN`, damit der Zeitfenster-Guard im Scheduler dieselbe
+  Zahl referenziert statt eine zweite Kopie zu pflegen
+- **File:** `docs/specs/data_sources.md` (MODIFY, Governance-Nachtrag) —
+  Eintrag für `minutely_15` als bereits seit #656 produktiv genutzte Quelle
+
+> **Schicht-Hinweis:** Alle betroffenen Dateien liegen im Python-Core
+> (`src/services/`, `src/output/renderers/`) — keine Go-/Frontend-Berührung.
+
+## Estimated Scope
+
+- **LoC:** ~90–140 (größer als die ursprüngliche Grobschätzung von ~50–70,
+  weil der Konsistenz-Mechanismus aus AC-6 einen zusätzlichen, aber sehr
+  kleinen Eingriff braucht — Details siehe Implementation)
+- **Files:** ~8 (siehe Source)
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `RadarNowcastService.get_nowcast()` (`src/services/radar_service.py`) | Service | Liefert `NowcastResult` (onset_minutes, intensity_label, source) für Koordinate |
+| `INTENSITY_HEAVY` (`src/services/radar_service.py`) | Konstante | Schwellwert-Label für „Starkregen" (mm/h >= 4.0) |
+| `alert_daily_limit.is_allowed(user_id, now, reason="nowcast")` (`src/services/alert_daily_limit.py`) | Gate | Tagesbudget-Prüfung — MUSS vor jedem neuen Nowcast-Fetch stehen (#1555) |
+| `ThrottleStore` (`src/services/throttle_store.py`), Scope `"radar"` | Service | Bestehender Cooldown-Speicher für Radar-Alerts — wird für die Konsistenz-Pflicht (AC-6) wiederverwendet, keine neue State-Datei |
+| `tz_for_coords()` (`src/utils/timezone.py`) | Utility | Ortszeit für die Uhrzeit-Formatierung der Hinweiszeile |
+| `unavailable_hint.py`-Muster (`src/output/renderers/email/unavailable_hint.py`) | Vorbild | Struktur-Vorbild für den neuen Hinweis-Baustein (bewusst NICHT unter `renderers/alert/`, sonst greift das Warn-Renderer-Mail-Gate) |
+
+## Implementation Details
+
+### 1. Ermittlung im Scheduler (`trip_report_scheduler.py`)
+
+Neue private Methode, aufgerufen in `_send_trip_report_outcome()` nachdem
+`segments`/`trip_tz` feststehen, vor dem Bau von `TripReportRequest`:
+
+```
+def _build_starkregen_hint(self, trip, segments, tz, now_utc) -> Optional[str]:
+    # 1. Aktives/naechstes Segment waehlen — dieselbe Auswahl wie
+    #    TripAlertService.check_radar_alerts() (trip_alert.py:730-745)
+    # 2. Naehe-Guard: Segment muss aktiv sein ODER innerhalb
+    #    NOWCAST_HORIZON_MIN (60 Min) starten, sonst -> None
+    # 3. Budget-Gate: alert_daily_limit.is_allowed(user_id, now_utc,
+    #    reason="nowcast") -- False -> None, KEIN Fetch
+    # 4. get_nowcast(lat, lon, priority="polling") -- Exception -> None
+    #    (fail-soft, ADR-0018)
+    # 5. Nur wenn intensity_label == INTENSITY_HEAVY und onset_minutes
+    #    gesetzt -> Text bauen, sonst None
+```
+
+Die Segment-Auswahl (Schritt 1) und der Nähe-Guard (Schritt 2) laufen VOR
+dem Budget-Gate und dem Fetch — ein zu weit entferntes Segment verursacht
+weder einen Nowcast-Call noch Budgetverbrauch.
+
+`priority="polling"` (nicht `"user_briefing"`): der Scheduler ist ein
+Hintergrund-/Cron-Prozess wie der 15-Minuten-Alarm-Poll, kein direkter
+Nutzerklick — dieselbe Einstufung wie `trip_alert.py:775`.
+
+### 2. Text-Baustein (`starkregen_hint.py`, neu)
+
+Eine einzige Funktion `format_starkregen_hint(intensity_label, onset_minutes,
+*, tz) -> str`, die exakt dasselbe Format wie der bestehende
+`RadarNowcastService.format_now_text()`-Zweig für Starkregen erzeugt
+(„Starker Regen ab ca. HH:MM (in ~N Min)."), damit E-Mail und Telegram
+wortgleich sind und die Formulierung nicht zweimal getrennt gepflegt wird.
+Dazu je eine dünne `render_html()`/`render_plain()`-Funktion (Box bzw. Zeile,
+Muster `unavailable_hint.py`).
+
+### 3. Konsistenz-Pflicht (AC-6) — Wiederverwendung des bestehenden Radar-Throttles
+
+Statt eines neuen State-Mechanismus wird der **bereits existierende**
+Cooldown wiederverwendet, den `TripAlertService.check_radar_alerts()` selbst
+als ALLERERSTE Prüfung liest (`trip_alert.py:757`,
+`self._is_radar_throttled(trip.id, cooldown_min=...)` →
+`ThrottleStore.is_throttled("radar", trip.id, ...)`):
+
+Sobald der Kurzfristhinweis erfolgreich in einem Briefing versendet wurde,
+schreibt der Scheduler `ThrottleStore(user_id).record("radar", trip.id,
+now_utc)` — denselben Eintrag, den ein echter Radar-Alert nach Versand
+ohnehin schreibt (`trip_alert.py:935`). Der nächste 15-Minuten-Poll für
+denselben Trip ist dadurch für die reguläre Cooldown-Dauer
+(`trip.alert_cooldown_minutes` bzw. Standard-Throttle) bereits an seiner
+ERSTEN Prüfung blockiert — bevor er überhaupt einen zweiten Nowcast-Call
+absetzt. Das verhindert strukturell sowohl einen widersprüchlichen
+Alert-Wortlaut als auch einen doppelten Budgetverbrauch für dasselbe
+Ereignis. Kein Eingriff in `trip_alert.py` oder `alert_state.py` nötig.
+
+### 4. Renderer-Mail-Gate (Hinweis, keine AC)
+
+`starkregen_hint.py` liegt unter `src/output/renderers/email/*.py` →
+`renderer_mail_gate.py` greift automatisch. Vor Commit:
+`tests/tdd/test_issue_811_mode_matrix.py` grün + frischer
+`briefing_mail_validator.py`-Lauf (Marker `X-GZ-Mail-Type: trip-briefing`).
+
+### 5. Governance-Nachtrag `data_sources.md`
+
+Die Datei trägt die Klausel „Claude darf KEINE neuen Datenquellen oder
+Parameter hinzufuegen ohne explizite Genehmigung." Der Nachtrag hier fügt
+**keinen neuen Parameter** hinzu (minutely_15 läuft seit #656 in Prod) —
+die PO-Freigabe dieser Spec-ACs (das reguläre `go`) deckt den Nachtrag mit
+ab; der Eintrag bleibt bewusst auf eine Zeile beschränkt.
+
+## Expected Behavior
+
+- **Input:** Trip mit aktivem/nächstem Segment, dessen Startpunkt-Koordinate
+  Starkregen (mm/h >= 4.0) innerhalb der nächsten 60 Minuten zeigt
+- **Output:** Hinweiszeile „Starker Regen ab ca. HH:MM (in ~N Min)." in
+  E-Mail (HTML + Plain) und Telegram-Bubble des planmäßigen Briefings;
+  ohne Treffer/außerhalb des Fensters/ohne Budget entfällt die Zeile
+  ersatzlos, das Briefing wird unverändert versendet
+- **Side effects:** bei gerendertem Hinweis wird derselbe Radar-Cooldown
+  geschrieben, den ein echter Radar-Alert schreiben würde (verhindert
+  einen widersprüchlichen Folge-Alert im Cooldown-Fenster)
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip mit ausgeschöpftem Tagesbudget für
+  `reason="nowcast"` (`alert_daily_limit.is_allowed(...)` liefert False) /
+  When das planmäßige Briefing für diesen Trip gerendert wird / Then
+  erscheint keine Starkregen-Kurzfristhinweis-Zeile, und
+  `RadarNowcastService.get_nowcast()` wird für diesen Trip nicht
+  aufgerufen — kein zusätzlicher Nowcast-Call trotz ausgeschöpftem Budget.
+  - Test: Budget-Gate auf „nicht erlaubt" setzen, Briefing bauen, prüfen
+    dass die Hinweis-Zeile fehlt UND `get_nowcast` (Spy/Zähler) nicht
+    aufgerufen wurde.
+
+- **AC-2:** Given die aktive/nächste Etappe eines Trips beginnt erst in
+  mehr als `NOWCAST_HORIZON_MIN` (60) Minuten / When das planmäßige
+  Briefing gerendert wird / Then erscheint kein Starkregen-Kurzfristhinweis
+  und `RadarNowcastService.get_nowcast()` wird für diesen Trip nicht
+  aufgerufen, selbst wenn ein injizierter Nowcast Starkregen melden würde.
+  - Test: Segment-Startzeit auf „in 90 Minuten" setzen, Fetch-Spy prüft
+    Nicht-Aufruf; Segment-Startzeit auf „in 30 Minuten" setzen, Fetch wird
+    aufgerufen (Gegenprobe im selben Test).
+
+- **AC-3:** Given ein Trip, dessen aktive/nächste Etappe innerhalb der
+  nächsten 60 Minuten beginnt UND `get_nowcast()` für den
+  Etappen-Startpunkt `INTENSITY_HEAVY` mit gesetztem `onset_minutes`
+  liefert / When das planmäßige Briefing versendet wird / Then enthalten
+  sowohl die E-Mail (HTML und Plain) als auch die Telegram-Nachricht eine
+  Hinweiszeile im Format „Starker Regen ab ca. HH:MM (in ~N Min)." mit
+  identischer Uhrzeit in Ortszeit.
+  - Test: Injizierten Nowcast mit `INTENSITY_HEAVY`, `onset_minutes=15`
+    verwenden, Briefing für alle drei Ausgaben rendern, exakten
+    Zeit-String in allen dreien vergleichen (kein Dateiinhalt-Grep,
+    echte Renderer-Ausgabe).
+
+- **AC-4:** Given eine Trip-Koordinate ohne verwertbare Nowcast-Antwort
+  (Exception beim Fetch, oder `onset_minutes=None`, oder Intensität unter
+  `INTENSITY_HEAVY`) / When das planmäßige Briefing gerendert wird / Then
+  entfällt die Hinweiszeile ersatzlos, und das restliche Briefing wird
+  ohne Fehler und unverändert versendet (ADR-0018 Fail-soft).
+  - Test: `get_nowcast()` wirft eine Exception → Briefing-Versand-Ergebnis
+    bleibt „sent", keine Hinweiszeile in E-Mail/Telegram, kein Crash.
+
+- **AC-5:** Given ein Trip mit aktivem SMS-Kanal und einem Trigger, der bei
+  E-Mail/Telegram einen Starkregen-Kurzfristhinweis auslösen würde / When
+  das Briefing versendet wird / Then bleibt der SMS-Text unverändert (keine
+  Kurzfristhinweis-Zeile in der SMS) — MVP-Scope ist ausschließlich E-Mail
+  und Telegram, SMS ist bewusst zurückgestellt.
+  - Test: Denselben Trigger-Trip mit `send_sms=True` rendern, SMS-Ausgabe
+    vor/nach der Änderung byte-identisch vergleichen.
+
+- **AC-6:** Given ein planmäßiges Briefing hat den Starkregen-Kurzfrist-
+  hinweis erfolgreich versendet / When `TripAlertService.check_radar_alerts()`
+  innerhalb des Cooldown-Fensters (`trip.alert_cooldown_minutes` bzw.
+  Standard-Throttle) für denselben Trip erneut läuft / Then wird der
+  Radar-Alert durch den bestehenden Throttle (`ThrottleStore`, Scope
+  `"radar"`) unterdrückt, weil der Kurzfristhinweis denselben Cooldown-
+  Eintrag geschrieben hat wie ein echter Radar-Alert — kein
+  widersprüchlicher zweiter Hinweis für dasselbe Ereignis in kurzem
+  Abstand.
+  - Test (Mutations-Gegenprobe PFLICHT): Briefing mit Kurzfristhinweis
+    versenden, danach `check_radar_alerts()` mit injiziertem Starkregen-
+    Nowcast für denselben Trip aufrufen — Alert MUSS unterdrückt bleiben.
+    Wird die `ThrottleStore.record(...)`-Zeile im Scheduler entfernt, MUSS
+    genau dieser Test rot werden (nicht nur ein Test, der bloß prüft, dass
+    die Hinweiszeile selbst existiert).
+
+- **AC-7:** Given Gewitter/Hagel (`is_convective=True`, Label
+  `INTENSITY_CONVECTIVE`) am Etappen-Startpunkt / When das planmäßige
+  Briefing gerendert wird / Then erscheint KEIN Starkregen-Kurzfrist-
+  hinweis (der ist ausschließlich für `INTENSITY_HEAVY` reserviert) — der
+  bestehende, separate Gewitter/Hagel-Bereich (#1474/#1492) bleibt
+  unberührt und wird durch dieses Feature nicht verdoppelt.
+  - Test: Injizierten Nowcast mit `is_convective=True` verwenden, prüfen
+    dass keine Starkregen-Zeile erscheint.
+
+- **AC-8:** Given `docs/specs/data_sources.md` enthält aktuell keinen
+  Eintrag für `minutely_15` / When diese Spec-Scheibe abgeschlossen wird /
+  Then enthält die Datenquellen-Tabelle einen Nachtrags-Eintrag für
+  `minutely_15` mit dem Hinweis „bereits seit #656 produktiv genutzt,
+  Nachtrag".
+  - Test: `# doc-compliance-test` — Datei enthält die Zeichenkette
+    `minutely_15` in der Datenquellen-Tabelle.
+
+## Known Limitations
+
+- **Kein Tage-vorher-Hinweis:** Durch das 60-Minuten-Nowcast-Fenster von
+  `RadarNowcastService` greift der Kurzfristhinweis bei Abend-Mails
+  (Etappe = Folgetag) praktisch nur, wenn die Etappe zufällig kurz nach
+  Versandzeit beginnt. Das ist eine bewusste, technisch bedingte Grenze,
+  keine Implementierungslücke — für eine echte Vorabend-Vorhersage bleibt
+  die reguläre Stundentabelle maßgeblich.
+- **SMS nicht im Scope:** Token-Format-Aufwand für SMS wird als eigenes
+  Folge-Issue vorgemerkt (PO-Entscheidung, Deadline-getrieben).
+- **Konsistenz-Mechanismus ist ein Cooldown, keine Wortlaut-Korrektur:**
+  AC-6 verhindert einen WIDERSPRÜCHLICHEN Folge-Alert, indem er ihn ganz
+  unterdrückt (bestehendes Cooldown-Verhalten) — er ändert NICHT den
+  Wortlaut eines späteren Alerts, falls der Cooldown zwischenzeitlich
+  abläuft und danach ein neuer, tatsächlich eigenständiger Regenschauer
+  eintrifft (gewünschtes Verhalten, kein Bug).
+- **Ortsvergleich/Compare nicht im Scope:** reines Trip-Briefing-Feature
+  (Pendant-Gate `pendant_gate.py` greift nicht, da keine neue Compare-
+  Komponente entsteht).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine (nutzt ADR-0018 Fail-soft-Prinzip, keine neue
+  Grundsatzentscheidung)
+- **Rationale:** Reine Einbindung einer bestehenden, bereits
+  ADR-konformen Service-Schicht (`RadarNowcastService`) in einen
+  zusätzlichen Aufrufort. Kein neuer Provider, kein neues Datenmodell,
+  keine neue Channel-Entscheidung.
+
+## Changelog
+
+- 2026-08-07: Initial spec erstellt — Issue #1439

--- a/src/output/renderers/email/__init__.py
+++ b/src/output/renderers/email/__init__.py
@@ -66,6 +66,7 @@ def render_email(
     corridors: Optional[list[Corridor]] = None,
     trip_metrics_altbestand: bool = True,
     undelivered: Optional[list] = None,
+    starkregen_hint_text: Optional[str] = None,
     **_ignored,
 ) -> tuple[str, str]:
     """Returns (html_body, plain_body). Pure function.
@@ -170,6 +171,7 @@ def render_email(
         corridors=corridors,
         trip_metrics_altbestand=trip_metrics_altbestand,
         undelivered=undelivered,
+        starkregen_hint_text=starkregen_hint_text,
     )
     plain_body = render_plain(
         segments=segments,
@@ -201,6 +203,7 @@ def render_email(
         day_comparison=day_comparison,
         trip_metrics_altbestand=trip_metrics_altbestand,
         undelivered=undelivered,
+        starkregen_hint_text=starkregen_hint_text,
     )
     return html_body, plain_body
 

--- a/src/output/renderers/email/html.py
+++ b/src/output/renderers/email/html.py
@@ -57,6 +57,7 @@ from output.renderers.alert.official_alerts import (
 from output.renderers.email.unavailable_hint import (
     any_official_alerts_unavailable, render_official_alerts_unavailable_html,
 )
+from output.renderers.email.starkregen_hint import render_starkregen_hint_html
 from output.renderers.email.undelivered_hint import (
     has_undelivered, render_undelivered_html,
 )
@@ -982,6 +983,7 @@ def render_html(
     corridors: Optional[list[Corridor]] = None,
     trip_metrics_altbestand: bool = True,
     undelivered: Optional[list] = None,
+    starkregen_hint_text: Optional[str] = None,
     **_ignored,
 ) -> str:
     """Render full HTML e-mail body. Pure function.
@@ -1613,6 +1615,11 @@ def render_html(
     # gesetztem Flag -> Byte-Gleichheit im "keine Warnungen, alle Quellen ok"-Fall.
     if any_official_alerts_unavailable(segments):
         warn_block_html += render_official_alerts_unavailable_html()
+
+    # Issue #1439: Starkregen-Kurzfristhinweis (planmaessiger Pfad) — bereits
+    # als fertig formatierte Zeile vom Scheduler ermittelt (Guards/Fetch dort).
+    if starkregen_hint_text:
+        warn_block_html += render_starkregen_hint_html(starkregen_hint_text)
 
     # Issue #1461 S3b-1: was seit dem letzten Briefing einen Kanal NICHT
     # erreicht hat — am Ende des Briefings, geteilter Baustein mit dem

--- a/src/output/renderers/email/plain.py
+++ b/src/output/renderers/email/plain.py
@@ -40,6 +40,7 @@ from output.renderers.alert.official_alerts import (
 from output.renderers.email.unavailable_hint import (
     any_official_alerts_unavailable, render_official_alerts_unavailable_plain,
 )
+from output.renderers.email.starkregen_hint import render_starkregen_hint_plain
 from output.renderers.email.undelivered_hint import (
     has_undelivered, render_undelivered_plain,
 )
@@ -116,6 +117,7 @@ def render_plain(
     day_comparison: Optional["DayComparison"] = None,
     trip_metrics_altbestand: bool = True,
     undelivered: Optional[list] = None,
+    starkregen_hint_text: Optional[str] = None,
     **_ignored,
 ) -> str:
     """Render full plain-text e-mail body. Pure function.
@@ -250,6 +252,11 @@ def render_plain(
     # echten Warnungen, nur bei gesetztem Ausfall-Flag (Byte-Gleichheit sonst).
     if any_official_alerts_unavailable(segments):
         lines.append(f"  {render_official_alerts_unavailable_plain()}")
+        lines.append("")
+
+    # Issue #1439: Starkregen-Kurzfristhinweis (planmaessiger Pfad).
+    if starkregen_hint_text:
+        lines.append(f"  {render_starkregen_hint_plain(starkregen_hint_text)}")
         lines.append("")
 
     for seg_data, rows in zip(segments, seg_tables):

--- a/src/output/renderers/email/starkregen_hint.py
+++ b/src/output/renderers/email/starkregen_hint.py
@@ -1,0 +1,49 @@
+"""Starkregen-Kurzfristhinweis im planmaessigen Trip-Briefing (Issue #1439).
+
+Nutzt den bereits produktiven `RadarNowcastService` (#656) fuer eine kurze
+Hinweiszeile im planmaessigen Briefing — 60-Minuten-Nowcast-Fenster
+(`NOWCAST_HORIZON_MIN`), keine Tage-vorher-Vorhersage (s. Spec
+"Known Limitations").
+
+Bewusst im Briefing-/E-Mail-Renderer-Bereich (nicht unter `renderers/alert/`):
+ein Briefing-Baustein, kein amtliche-Warnung-Renderer — Muster
+`unavailable_hint.py` (Issue #1348).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+
+def format_starkregen_hint(intensity_label: str, onset_minutes: int, *, tz: ZoneInfo) -> str:
+    """"Starker Regen ab ca. HH:MM (in ~N Min)." — identisches Format wie
+    `RadarNowcastService.format_now_text()` fuer den Starkregen-Zweig, damit
+    E-Mail und Telegram wortgleich sind (Onset-Zeit in Trip-Ortszeit)."""
+    from utils.timezone import local_dt
+
+    now = datetime.now(timezone.utc)
+    onset_time = now + timedelta(minutes=onset_minutes)
+    time_str = local_dt(onset_time, tz).strftime("%H:%M")
+    return f"{intensity_label} ab ca. {time_str} (in ~{onset_minutes} Min)."
+
+
+def render_starkregen_hint_html(hint_text: str) -> str:
+    """Hochkontrastiger Danger-Box-Baustein, analog
+    `unavailable_hint.render_official_alerts_unavailable_html()`."""
+    from output.renderers.email.design_tokens import (
+        FONT_UI, G_BOX_DANGER_BG, G_DANGER,
+    )
+
+    return (
+        f'<div style="background:{G_BOX_DANGER_BG};'
+        f'border-left:4px solid {G_DANGER};padding:12px;margin:8px 20px;'
+        f'border-radius:4px;font-family:{FONT_UI};">'
+        f'<strong style="color:{G_DANGER};font-size:14px;">{hint_text}</strong>'
+        f'</div>'
+    )
+
+
+def render_starkregen_hint_plain(hint_text: str) -> str:
+    """Einzeilige Text-Fassung, analog
+    `unavailable_hint.render_official_alerts_unavailable_plain()`."""
+    return f"⚠️ {hint_text}"

--- a/src/output/renderers/narrow.py
+++ b/src/output/renderers/narrow.py
@@ -39,6 +39,7 @@ from output.renderers.email.unavailable_hint import (
     any_official_alerts_unavailable,
     render_official_alerts_unavailable_plain,
 )
+from output.renderers.email.starkregen_hint import render_starkregen_hint_plain
 from output.renderers.email.outlook_state_hint import (
     OutlookState as _OutlookState, render_outlook_state_plain,
 )
@@ -623,6 +624,7 @@ def render_telegram_bubbles(
     has_gap: bool = False,
     day_window_start_hour: int = DAY_WINDOW_START_HOUR,
     day_window_end_hour: int = DAY_WINDOW_END_HOUR,
+    starkregen_hint_text: Optional[str] = None,
 ) -> list[TelegramBubble]:
     """Render die Telegram-Briefing-Bubble-Liste (Issue #1001). Pure function.
 
@@ -683,6 +685,13 @@ def render_telegram_bubbles(
     if any_official_alerts_unavailable(segments):
         bubbles.append(TelegramBubble(
             text=_esc(render_official_alerts_unavailable_plain(ascii_safe=False))
+        ))
+
+    # Issue #1439: Starkregen-Kurzfristhinweis (planmaessiger Pfad) — direkt
+    # nach dem Kopf, weil zeitkritisch.
+    if starkregen_hint_text:
+        bubbles.append(TelegramBubble(
+            text=_esc(render_starkregen_hint_plain(starkregen_hint_text))
         ))
 
     # 1b. Amtliche Warnungen (#1318 AC-8) — direkt nach dem Kopf, weil

--- a/src/output/renderers/trip_report.py
+++ b/src/output/renderers/trip_report.py
@@ -86,6 +86,7 @@ class TripReportFormatter:
         trip: Optional["Trip"] = None,
         has_gap: bool = False,
         undelivered: Optional[list] = None,
+        starkregen_hint_text: Optional[str] = None,
     ) -> TripReport:
         """Format trip segments into HTML + plain-text email.
 
@@ -233,6 +234,7 @@ class TripReportFormatter:
             # Renderer bleibt rein und laedt nichts nach (Spec §A1/§A5/§A6).
             # Ohne den kwarg (Vorschau, Goldens, CLI) unveraendert.
             undelivered=undelivered,
+            starkregen_hint_text=starkregen_hint_text,
         )
         first_agg = segments[0].aggregated
         email_subject = self._generate_subject(
@@ -266,6 +268,7 @@ class TripReportFormatter:
             has_gap=has_gap,
             day_window_start_hour=_dw_start,
             day_window_end_hour=_dw_end,
+            starkregen_hint_text=starkregen_hint_text,
         )
         telegram_bubbles = [b.text for b in telegram_bubbles_result]
         telegram_actions_markup = (

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -100,9 +100,11 @@ class TripReportRequest:
     # Issue #1208: aufgeloeste render-wirksame Optionen (einziger Ableitungsweg
     # von report_config zu format_email); None → interner Resolver-Fallback.
     render_options: Optional["ReportRenderOptions"] = None
-    # Issue #1439: Starkregen-Kurzfristhinweis (planmaessiger Pfad), vom
-    # Scheduler ermittelt — None = kein Treffer/Guard aktiv, Briefing unveraendert.
-    starkregen_hint_text: str | None = None
+    # Issue #1439: Starkregen-Kurzfristhinweis (planmaessiger Pfad) — Rohdaten
+    # (intensity_label, onset_minutes) vom Scheduler ermittelt (kein Renderer-
+    # Import dort, Architektur-Grenze). None = kein Treffer/Guard aktiv.
+    # Die Textformatierung passiert hier im NotificationService.
+    starkregen_nowcast: tuple[str, int] | None = None
 
 
 @dataclass
@@ -298,6 +300,18 @@ class NotificationService:
             user_id=self._user_id, entity_id=request.trip.id, entity_type="trip",
         )
 
+        # Issue #1439: Starkregen-Kurzfristhinweis — der Scheduler liefert nur
+        # Rohdaten (Architektur-Grenze), die Textformatierung (Renderer-Aufruf)
+        # passiert hier.
+        starkregen_hint_text = None
+        if request.starkregen_nowcast is not None:
+            from output.renderers.email.starkregen_hint import format_starkregen_hint
+
+            _intensity_label, _onset_minutes = request.starkregen_nowcast
+            starkregen_hint_text = format_starkregen_hint(
+                _intensity_label, _onset_minutes, tz=request.trip_tz,
+            )
+
         report = self._formatter.format_email(
             segments=request.segment_weather,
             trip_name=request.trip.name,
@@ -323,7 +337,7 @@ class NotificationService:
             trip_url=request.trip_url,
             render_options=request.render_options,
             has_gap=has_gap,
-            starkregen_hint_text=request.starkregen_hint_text,
+            starkregen_hint_text=starkregen_hint_text,
         )
 
         self._apply_prefixes(report, request)

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -100,6 +100,9 @@ class TripReportRequest:
     # Issue #1208: aufgeloeste render-wirksame Optionen (einziger Ableitungsweg
     # von report_config zu format_email); None → interner Resolver-Fallback.
     render_options: Optional["ReportRenderOptions"] = None
+    # Issue #1439: Starkregen-Kurzfristhinweis (planmaessiger Pfad), vom
+    # Scheduler ermittelt — None = kein Treffer/Guard aktiv, Briefing unveraendert.
+    starkregen_hint_text: str | None = None
 
 
 @dataclass
@@ -320,6 +323,7 @@ class NotificationService:
             trip_url=request.trip_url,
             render_options=request.render_options,
             has_gap=has_gap,
+            starkregen_hint_text=request.starkregen_hint_text,
         )
 
         self._apply_prefixes(report, request)

--- a/src/services/radar_service.py
+++ b/src/services/radar_service.py
@@ -59,6 +59,9 @@ _ICON_D2_LON_MAX = 19.0
 
 # Onset threshold: frames within 60 min from now considered "nowcast"
 _NOWCAST_HORIZON_MIN = 60
+# Issue #1439: oeffentlicher Alias, damit der Scheduler-Zeitfenster-Guard
+# dieselbe Zahl referenziert statt eine zweite Kopie zu pflegen.
+NOWCAST_HORIZON_MIN = _NOWCAST_HORIZON_MIN
 _DRY_THRESHOLD_MM_H = 0.1
 
 # Issue #1461 S3a: benannte Intensitaets-Label-Konstanten statt Inline-Strings

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -923,9 +923,11 @@ class TripReportSchedulerService:
         # 7c. Issue #1439: Starkregen-Kurzfristhinweis (planmaessiger Pfad) —
         # Segment-Auswahl/Naehe-Guard/Budget-Gate/Fetch laufen VOR dem Bau des
         # TripReportRequest, damit ein zu weit entferntes Segment oder ein
-        # ausgeschoepftes Tagesbudget keinen Nowcast-Call verursacht.
-        starkregen_hint_text = self._build_starkregen_hint(
-            trip, segments, trip_tz, datetime.now(timezone.utc),
+        # ausgeschoepftes Tagesbudget keinen Nowcast-Call verursacht. Liefert
+        # nur Rohdaten (intensity_label, onset_minutes) — die Textformatierung
+        # (Renderer-Aufruf) passiert im NotificationService (Architektur-Grenze).
+        starkregen_nowcast = self._build_starkregen_hint(
+            trip, segments, datetime.now(timezone.utc),
         )
 
         # 8. NotificationService: render + send (Issue #1022).
@@ -951,7 +953,7 @@ class TripReportSchedulerService:
             catchup_prefix=catchup_prefix,
             partial_outage_hint=partial_outage_hint,
             render_options=render_options,
-            starkregen_hint_text=starkregen_hint_text,
+            starkregen_nowcast=starkregen_nowcast,
         )
         result = self._notification_service.send_trip_report(request)
         errors = request.failed_segments
@@ -962,7 +964,7 @@ class TripReportSchedulerService:
         # bestehenden Throttles statt eines neuen State-Mechanismus. Der
         # naechste 15-Minuten-Poll ist dadurch an seiner ERSTEN Pruefung
         # bereits blockiert (kein widerspruechlicher Folge-Alert).
-        if starkregen_hint_text and result.sent:
+        if starkregen_nowcast and result.sent:
             from services.throttle_store import ThrottleStore
             ThrottleStore(self._user_id).record("radar", trip.id, datetime.now(timezone.utc))
 
@@ -1066,7 +1068,7 @@ class TripReportSchedulerService:
         catchup_prefix: str | None,
         partial_outage_hint: str | None = None,
         render_options: Optional["ReportRenderOptions"] = None,
-        starkregen_hint_text: str | None = None,
+        starkregen_nowcast: Optional[Tuple[str, int]] = None,
     ) -> TripReportRequest:
         """Baut das DTO, das an den NotificationService übergeben wird (Issue #1022).
 
@@ -1107,20 +1109,25 @@ class TripReportSchedulerService:
             failed_segments=errors,
             on_demand=on_demand,
             render_options=render_options,
-            starkregen_hint_text=starkregen_hint_text,
+            starkregen_nowcast=starkregen_nowcast,
         )
 
     def _build_starkregen_hint(
         self,
         trip: "Trip",
         segments: List[TripSegment],
-        tz: ZoneInfo,
         now_utc: datetime,
-    ) -> Optional[str]:
-        """Starkregen-Kurzfristhinweis (Issue #1439): Nachrichtenzeile fuer das
-        planmaessige Briefing, wenn der bereits produktive `RadarNowcastService`
+    ) -> Optional[Tuple[str, int]]:
+        """Starkregen-Kurzfristhinweis (Issue #1439): liefert die Rohdaten
+        (``intensity_label``, ``onset_minutes``) fuer den planmaessigen
+        Briefing-Pfad, wenn der bereits produktive `RadarNowcastService`
         (#656) fuer den Startpunkt des aktiven/naechsten Segments Starkregen
         innerhalb von `NOWCAST_HORIZON_MIN` erkennt.
+
+        Architektur-Grenze (`tests/unit/test_notification_service.py::
+        test_scheduler_has_no_output_imports`): der Scheduler liefert nur ein
+        DTO, KEINEN Renderer-Aufruf — die Textformatierung
+        (`format_starkregen_hint()`) passiert in `notification_service.py`.
 
         Segment-Auswahl identisch zu `TripAlertService.check_radar_alerts()`
         (trip_alert.py:730-745). Naehe-Guard und Budget-Gate laufen VOR dem
@@ -1168,9 +1175,7 @@ class TripReportSchedulerService:
         if result.onset_minutes is None or result.intensity_label != INTENSITY_HEAVY:
             return None
 
-        from output.renderers.email.starkregen_hint import format_starkregen_hint
-
-        return format_starkregen_hint(result.intensity_label, result.onset_minutes, tz=tz)
+        return (result.intensity_label, result.onset_minutes)
 
     def _reset_alert_state_after_briefing(self, trip_id: str) -> None:
         """Issue #816 (B): Alert-Melde-Gedächtnis nach Briefing-Versand löschen.

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -29,6 +29,7 @@ from app.models import (
     StabilityResult,
     TripSegment,
 )
+from services import alert_daily_limit
 from services.alert_briefing_anchor import reset_alert_memory, write_anchor_and_reset_memory
 from services.day_comparison import DayComparison
 from services.notification_service import NotificationService, TripReportRequest
@@ -919,6 +920,14 @@ class TripReportSchedulerService:
                 logger.warning(f"Vortag-Vergleich übersprungen für {trip.id}: {e}")
                 day_comparison = None
 
+        # 7c. Issue #1439: Starkregen-Kurzfristhinweis (planmaessiger Pfad) —
+        # Segment-Auswahl/Naehe-Guard/Budget-Gate/Fetch laufen VOR dem Bau des
+        # TripReportRequest, damit ein zu weit entferntes Segment oder ein
+        # ausgeschoepftes Tagesbudget keinen Nowcast-Call verursacht.
+        starkregen_hint_text = self._build_starkregen_hint(
+            trip, segments, trip_tz, datetime.now(timezone.utc),
+        )
+
         # 8. NotificationService: render + send (Issue #1022).
         # Der Scheduler liefert nur noch ein DTO; Renderer-/Transport-Imports
         # bleiben im NotificationService.
@@ -942,9 +951,20 @@ class TripReportSchedulerService:
             catchup_prefix=catchup_prefix,
             partial_outage_hint=partial_outage_hint,
             render_options=render_options,
+            starkregen_hint_text=starkregen_hint_text,
         )
         result = self._notification_service.send_trip_report(request)
         errors = request.failed_segments
+
+        # Issue #1439 AC-6: ein erfolgreich versendeter Kurzfristhinweis
+        # schreibt denselben Radar-Cooldown, den ein echter Radar-Alert nach
+        # Versand ohnehin schreibt (trip_alert.py:935) — Wiederverwendung des
+        # bestehenden Throttles statt eines neuen State-Mechanismus. Der
+        # naechste 15-Minuten-Poll ist dadurch an seiner ERSTEN Pruefung
+        # bereits blockiert (kein widerspruechlicher Folge-Alert).
+        if starkregen_hint_text and result.sent:
+            from services.throttle_store import ThrottleStore
+            ThrottleStore(self._user_id).record("radar", trip.id, datetime.now(timezone.utc))
 
         # Issue #393: Briefing-Log für Cockpit-Kachel "Was geht heute raus".
         # Issue #1007 Adversary-Fix F001: bei explizit konfiguriertem "kein
@@ -1046,6 +1066,7 @@ class TripReportSchedulerService:
         catchup_prefix: str | None,
         partial_outage_hint: str | None = None,
         render_options: Optional["ReportRenderOptions"] = None,
+        starkregen_hint_text: str | None = None,
     ) -> TripReportRequest:
         """Baut das DTO, das an den NotificationService übergeben wird (Issue #1022).
 
@@ -1086,7 +1107,70 @@ class TripReportSchedulerService:
             failed_segments=errors,
             on_demand=on_demand,
             render_options=render_options,
+            starkregen_hint_text=starkregen_hint_text,
         )
+
+    def _build_starkregen_hint(
+        self,
+        trip: "Trip",
+        segments: List[TripSegment],
+        tz: ZoneInfo,
+        now_utc: datetime,
+    ) -> Optional[str]:
+        """Starkregen-Kurzfristhinweis (Issue #1439): Nachrichtenzeile fuer das
+        planmaessige Briefing, wenn der bereits produktive `RadarNowcastService`
+        (#656) fuer den Startpunkt des aktiven/naechsten Segments Starkregen
+        innerhalb von `NOWCAST_HORIZON_MIN` erkennt.
+
+        Segment-Auswahl identisch zu `TripAlertService.check_radar_alerts()`
+        (trip_alert.py:730-745). Naehe-Guard und Budget-Gate laufen VOR dem
+        Fetch — ein zu weit entferntes Segment oder ausgeschoepftes Tagesbudget
+        verursacht keinen Nowcast-Call (AC-1/AC-2). Fail-soft bei Fetch-Fehlern
+        (ADR-0018, AC-4).
+        """
+        if not segments:
+            return None
+
+        active = None
+        for seg in segments:
+            if seg.start_time <= now_utc <= seg.end_time:
+                active = seg
+                break
+        if active is None:
+            if now_utc < segments[0].start_time:
+                active = segments[0]
+            else:
+                return None
+
+        from services.radar_service import NOWCAST_HORIZON_MIN
+
+        if active.start_time > now_utc:
+            minutes_until_start = (active.start_time - now_utc).total_seconds() / 60.0
+            if minutes_until_start > NOWCAST_HORIZON_MIN:
+                return None
+
+        if not alert_daily_limit.is_allowed(self._user_id, now_utc, reason="nowcast"):
+            return None
+
+        from services.radar_service import INTENSITY_HEAVY, RadarNowcastService
+
+        lat = active.start_point.lat
+        lon = active.start_point.lon
+        try:
+            radar_svc = RadarNowcastService()
+            # Issue #1329 C2: der Scheduler ist ein Hintergrund-/Cron-Prozess
+            # wie der 15-Minuten-Alarm-Poll, kein direkter Nutzerklick.
+            result = radar_svc.get_nowcast(lat, lon, priority="polling")
+        except Exception as e:
+            logger.warning(f"Starkregen-Kurzfristhinweis: Nowcast fehlgeschlagen fuer {trip.id}: {e}")
+            return None
+
+        if result.onset_minutes is None or result.intensity_label != INTENSITY_HEAVY:
+            return None
+
+        from output.renderers.email.starkregen_hint import format_starkregen_hint
+
+        return format_starkregen_hint(result.intensity_label, result.onset_minutes, tz=tz)
 
     def _reset_alert_state_after_briefing(self, trip_id: str) -> None:
         """Issue #816 (B): Alert-Melde-Gedächtnis nach Briefing-Versand löschen.

--- a/tests/tdd/test_starkregen_kurzfristhinweis.py
+++ b/tests/tdd/test_starkregen_kurzfristhinweis.py
@@ -1,0 +1,633 @@
+"""TDD RED — Issue #1439: Starkregen-Kurzfristhinweis im planmaessigen Trip-Briefing.
+
+SPEC: docs/specs/modules/feat_1439_starkregen_kurzfristhinweis.md (AC-1 … AC-8)
+
+RED-Grund heute (gemessen): die Einbindung existiert noch nicht.
+- `services.trip_report_scheduler.TripReportSchedulerService._build_starkregen_hint`
+  (o.ae.) fehlt -> der Kurzfristhinweis erscheint nie, `RadarNowcastService.get_nowcast()`
+  wird fuer den Scheduler-Pfad nie aufgerufen.
+- `services.radar_service.NOWCAST_HORIZON_MIN` (oeffentlicher Alias) fehlt (AC-2).
+- `docs/specs/data_sources.md` hat noch keinen `minutely_15`-Eintrag (AC-8).
+
+Testpolitik (CLAUDE.md "Test-Politik: Zwei Schichten"):
+- Kein Mock-Theater: kein `Mock()`/`patch()`/`MagicMock`. `RadarNowcastService.get_nowcast`
+  wird per `monkeypatch.setattr` durch eine echte Python-Funktion ersetzt, die ein echtes
+  `NowcastResult`-Dataclass-Objekt liefert (Transport-Grenze, analog dem projektweiten
+  `mail_sink`-Muster) — kein Live-Netz, kein Objekt-Double, das nur die eigene Annahme
+  zurueckspiegelt.
+- Wirkung statt Faehigkeit: AC-3/AC-7 pruefen den ECHTEN gerenderten Text (E-Mail HTML+Plain,
+  Telegram-Bubbles) ueber den echten Versandpfad `_send_trip_report_outcome`, abgegriffen
+  per DELEGIERENDEM Beobachter auf `TripReportFormatter.format_email` (Muster
+  `tests/tdd/test_alert_undelivered_hint.py::_ReportRecorder` /
+  `tests/tdd/test_trip_briefing_anchor_unchanged.py`) — kein Dateiinhalt-Grep.
+- AC-6 (Mutations-Pflicht, PFLICHT laut Spec): der Test laeuft ueber den ECHTEN
+  `TripAlertService.check_radar_alerts()`-Pfad (Muster
+  `tests/tdd/test_issue_818_radar_briefing_integration.py`) — wird die
+  `ThrottleStore.record("radar", trip.id, ...)`-Zeile im Scheduler entfernt, feuert der
+  zweite Radar-Alert-Lauf wirklich (count >= 1 statt 0).
+
+Pfadregel #1409: `REPO_ROOT` wird relativ zu DIESER Datei aufgeloest.
+Isolation: `tests/conftest.py::_isolate_data_root` (autouse, #1133) — keine manuelle
+Aufraeumung noetig.
+"""
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import date as date_type, datetime, time, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from app.config import Settings
+from app.models import TripReportConfig
+from app.trip import Stage, Trip, Waypoint
+from services import alert_daily_limit
+from services.radar_service import (
+    INTENSITY_CONVECTIVE, INTENSITY_DRY, INTENSITY_HEAVY, INTENSITY_MODERATE,
+    NowcastResult, RadarNowcastService,
+)
+
+from tests.helpers.alert_log_fixtures import settings_email_only, weather
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Island: UTC+0 ganzjaehrig (kein DST) — vereinfacht Zeit-Arithmetik fuer
+# arrival_override-Zeitstrings (Muster test_issue_818_radar_briefing_integration.py).
+LAT, LON = 64.0, -22.0
+
+_HINT_MARKER = "Starker Regen ab ca."
+
+# Adversary-Finding F001 (#1439): `format_starkregen_hint()` baut den Text aus
+# dem UEBERGEBENEN `intensity_label`, nicht aus einer festen Konstante — ein
+# entfernter Intensitaets-Filter in `_build_starkregen_hint` wuerde weiterhin
+# einen Hinweistext erzeugen (nur mit einem ANDEREN Label als Praefix), den
+# der feste `_HINT_MARKER`-Substring-Check nicht saehe. Fuer "Hinweis darf
+# NICHT erscheinen"-Assertions bei nicht-HEAVY-Intensitaeten (AC-4b/AC-7) wird
+# deshalb das intensitaetsunabhaengige Zeitformat geprueft, nicht der feste String.
+_HINT_TIME_PATTERN = re.compile(r"ab ca\. \d{2}:\d{2} \(in ~\d+ Min\)\.")
+
+_NO_TRANSPORT_FIELDS: dict = {
+    "smtp_host": "", "smtp_user": "", "smtp_pass": "", "mail_to": "",
+    "telegram_bot_token": "", "telegram_chat_id": "",
+    "telegram_test_bot_token": "", "telegram_test_chat_id": "",
+    "sms_gateway_url": "", "seven_api_key": "", "sms_to": "",
+}
+
+
+def _uid(prefix: str) -> str:
+    return f"tdd-1439-{prefix}-{uuid.uuid4().hex[:6]}"
+
+
+def _settings_no_transport() -> Settings:
+    return Settings(**_NO_TRANSPORT_FIELDS)
+
+
+# ═══════════════════════════ Trip-Fixtures ═══════════════════════════
+
+
+def _active_trip(trip_id: str) -> Trip:
+    """2-Waypoint-Trip mit ganztaegig aktivem Segment (00:00-23:59 Ortszeit).
+
+    Muster: test_issue_818_radar_briefing_integration.py::_make_active_trip.
+    """
+    today = date_type.today()
+    wp0 = Waypoint(
+        id="WP0", name="Start", lat=LAT, lon=LON, elevation_m=100.0,
+        arrival_override="00:00",
+    )
+    wp1 = Waypoint(
+        id="WP1", name="Ziel", lat=LAT + 0.05, lon=LON + 0.05, elevation_m=200.0,
+        arrival_override="23:59",
+    )
+    stage = Stage(id="S1", name="Tag 1", date=today, start_time=time(0, 0), waypoints=[wp0, wp1])
+    trip = Trip(id=trip_id, name=f"Starkregen {trip_id}", stages=[stage], official_alerts_enabled=False)
+    trip.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=False, send_telegram=False, send_sms=False,
+    )
+    return trip
+
+
+def _trip_with_segment_offset(trip_id: str, *, start_in_min: float, duration_min: float = 20.0) -> Trip:
+    """Aktives/naechstes Segment beginnt in `start_in_min` Minuten ab jetzt (UTC).
+
+    Skip statt Fehlschlag, wenn der Offset eine Mitternachtsgrenze (UTC) beruehrt —
+    Stage.date ist ein einzelner Kalendertag, ein Tageswechsel wuerde die
+    HH:MM-Arithmetik verfaelschen (analog dem now.hour<4-Guard in
+    test_issue_818_radar_briefing_integration.py::test_ac5).
+    """
+    now = datetime.now(timezone.utc).replace(second=0, microsecond=0)
+    start = now + timedelta(minutes=start_in_min)
+    end = start + timedelta(minutes=duration_min)
+    if start.date() != end.date() or start.date() != date_type.today():
+        pytest.skip("Testzeitpunkt zu nah an einer Mitternachtsgrenze (UTC) fuer Offset-Segment")
+
+    wp0 = Waypoint(
+        id="WP0", name="Start", lat=LAT, lon=LON, elevation_m=100.0,
+        arrival_override=start.strftime("%H:%M"),
+    )
+    wp1 = Waypoint(
+        id="WP1", name="Ziel", lat=LAT + 0.05, lon=LON + 0.05, elevation_m=200.0,
+        arrival_override=end.strftime("%H:%M"),
+    )
+    stage = Stage(id="S1", name="Tag 1", date=start.date(), waypoints=[wp0, wp1])
+    trip = Trip(id=trip_id, name=f"Starkregen {trip_id}", stages=[stage], official_alerts_enabled=False)
+    trip.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=False, send_telegram=False, send_sms=False,
+    )
+    return trip
+
+
+def _save_trip_direct(trip: Trip, user_id: str) -> None:
+    """Schreibt die Trip-JSON direkt — noetig fuer TripAlertService.check_radar_alerts()
+    (liest ueber app.loader.load_all_trips(), nicht aus dem In-Memory-Objekt).
+
+    Muster: test_issue_818_radar_briefing_integration.py::_save_trip_direct.
+    """
+    import json
+
+    from app.loader import get_briefings_dir
+
+    trips_dir = get_briefings_dir(user_id)
+    trips_dir.mkdir(parents=True, exist_ok=True)
+    stage = trip.stages[0]
+    wp_list = []
+    for wp in stage.waypoints:
+        d: dict = {"id": wp.id, "name": wp.name, "lat": wp.lat, "lon": wp.lon}
+        if wp.elevation_m is not None:
+            d["elevation_m"] = wp.elevation_m
+        if wp.arrival_override is not None:
+            d["arrival_override"] = wp.arrival_override
+        wp_list.append(d)
+    data = {
+        "id": trip.id,
+        "name": trip.name,
+        "official_alerts_enabled": False,
+        "stages": [{
+            "id": stage.id, "name": stage.name,
+            "date": stage.date.isoformat(), "waypoints": wp_list,
+        }],
+        "report_config": {"trip_id": trip.id, "send_email": True, "send_telegram": False},
+    }
+    (trips_dir / f"{trip.id}.json").write_text(json.dumps(data, indent=2))
+
+
+# ═══════════════════════════ Scheduler / Recorder ═══════════════════════════
+
+
+def _scheduler_class():
+    """Echte Unterklasse (kein Mock): Wetter kommt aus der Fixture, kein Netz."""
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    class _FixtureScheduler(TripReportSchedulerService):
+        def _fetch_weather(self, segments, provider=None):
+            return [weather(s.segment_id) for s in segments]
+
+    return _FixtureScheduler
+
+
+class _ReportRecorder:
+    """DELEGIERENDER Beobachter auf `TripReportFormatter.format_email`.
+
+    Kein Mock: die echte Methode laeuft unveraendert, es wird nur festgehalten,
+    WAS sie zurueckgegeben hat. Muster: test_alert_undelivered_hint.py::_ReportRecorder.
+    """
+
+    def __init__(self) -> None:
+        self.reports: list = []
+
+    def install(self, monkeypatch) -> None:
+        from output.renderers.trip_report import TripReportFormatter
+
+        original = TripReportFormatter.format_email
+        recorder = self
+
+        def _recording_format_email(self, *args, **kwargs):
+            report = original(self, *args, **kwargs)
+            recorder.reports.append(report)
+            return report
+
+        monkeypatch.setattr(TripReportFormatter, "format_email", _recording_format_email)
+
+
+def _run_briefing(recorder: _ReportRecorder, uid: str, trip: Trip, *, settings: Settings | None = None):
+    """Fuehrt den ECHTEN Briefing-Pfad aus und liefert (outcome, report)."""
+    scheduler = _scheduler_class()(settings=settings or _settings_no_transport(), user_id=uid)
+    outcome = scheduler._send_trip_report_outcome(trip, "morning")
+    assert recorder.reports, "Voraussetzung: es wurde keine Briefing-Mail gebaut"
+    return outcome, recorder.reports[-1]
+
+
+# ═══════════════════════════ Nowcast-DI-Naht (kein Mock) ═══════════════════════════
+
+
+def _install_fake_nowcast(
+    monkeypatch,
+    calls: list,
+    *,
+    onset_minutes: int | None = None,
+    intensity_label: str = INTENSITY_DRY,
+    is_convective: bool = False,
+    raise_exc: Exception | None = None,
+) -> None:
+    """Ersetzt `RadarNowcastService.get_nowcast` durch eine echte Funktion, die ein
+    echtes `NowcastResult` liefert (Transport-Grenze, kein Live-Netz, kein Mock-Objekt).
+    `calls` haelt (lat, lon, priority)-Tupel jedes Aufrufs fest (AC-1/AC-2-Nachweis)."""
+
+    def _fake_get_nowcast(self, lat, lon, priority="user_briefing"):
+        calls.append((lat, lon, priority))
+        if raise_exc is not None:
+            raise raise_exc
+        return NowcastResult(
+            onset_minutes=onset_minutes, intensity_label=intensity_label,
+            source="radar", is_convective=is_convective,
+        )
+
+    monkeypatch.setattr(RadarNowcastService, "get_nowcast", _fake_get_nowcast)
+
+
+def _install_fake_email_send(monkeypatch, sent: list) -> None:
+    """Ersetzt den Transport-Rand `EmailOutput.send` — echte Funktion, kein Netz,
+    kein Mock-Objekt. Noetig fuer AC-6 (echtes outcome='sent')."""
+    from output.channels.email import EmailOutput
+
+    def _fake_send(self, *, subject, body, **kwargs):
+        sent.append((subject, body))
+
+    monkeypatch.setattr(EmailOutput, "send", _fake_send)
+
+
+def _wet_frames(lat: float, lon: float) -> list:
+    """Deterministische Regen-Frames (onset in 5 Min) — DI-Seam, kein Mock.
+
+    Muster: test_issue_818_radar_briefing_integration.py::_wet_frames.
+    """
+    from providers.brightsky import RadarFrame
+
+    now = datetime.now(timezone.utc)
+    return [
+        RadarFrame(timestamp=now + timedelta(minutes=5), precip_mm_h=4.0),
+        RadarFrame(timestamp=now + timedelta(minutes=20), precip_mm_h=8.0),
+    ]
+
+
+# ══════════════════════════════════ AC-1 ══════════════════════════════════
+
+
+def test_ac1_budget_erschoepft_blockiert_fetch_und_hinweis(monkeypatch):
+    """AC-1: ausgeschoepftes Tagesbudget (reason='nowcast') -> kein get_nowcast()-
+    Aufruf, keine Hinweiszeile.
+
+    Nicht-Leerlauf zuerst (Muster test_alert_undelivered_hint.py AC-10): OHNE
+    ausgeschoepftes Budget MUSS derselbe Trigger einen Hinweis erzeugen — sonst
+    prueft der Budget-Vergleich gegen ein bereits leeres Ergebnis (Feature fehlt
+    komplett) und waere nie in der Lage, rot zu werden.
+    """
+    calls_frei: list = []
+    _install_fake_nowcast(monkeypatch, calls_frei, onset_minutes=10, intensity_label=INTENSITY_HEAVY)
+    uid_frei = _uid("ac1-frei")
+    trip_frei = _active_trip(f"trip-ac1-frei-{uuid.uuid4().hex[:6]}")
+    rec_frei = _ReportRecorder()
+    rec_frei.install(monkeypatch)
+    _outcome_frei, report_frei = _run_briefing(rec_frei, uid_frei, trip_frei)
+    assert len(calls_frei) >= 1 and _HINT_MARKER in report_frei.email_plain, (
+        "Testvoraussetzung (Nicht-Leerlauf): OHNE ausgeschoepftes Budget MUSS "
+        f"derselbe Trigger get_nowcast() aufrufen und einen Hinweis erzeugen "
+        f"— calls={calls_frei!r}\n{report_frei.email_plain}"
+    )
+
+    uid = _uid("ac1")
+    trip = _active_trip(f"trip-ac1-{uuid.uuid4().hex[:6]}")
+
+    now = datetime.now(timezone.utc)
+    alert_daily_limit.increment(uid, now)
+    alert_daily_limit.increment(uid, now)
+    assert alert_daily_limit.is_allowed(uid, now, reason="nowcast") is False, (
+        "Testvoraussetzung: Free-Tier-Tageslimit (2) muss ausgeschoepft sein."
+    )
+
+    calls: list = []
+    _install_fake_nowcast(monkeypatch, calls, onset_minutes=10, intensity_label=INTENSITY_HEAVY)
+
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+    _outcome, report = _run_briefing(recorder, uid, trip)
+
+    assert calls == [], (
+        "AC-1: RadarNowcastService.get_nowcast() darf bei ausgeschoepftem "
+        f"Tagesbudget NICHT aufgerufen werden, war {calls!r}. "
+        "RED: Budget-Gate vor dem Fetch ist noch nicht implementiert."
+    )
+    assert _HINT_MARKER not in report.email_plain, (
+        "AC-1: Bei ausgeschoepftem Budget darf keine Starkregen-Kurzfristhinweis-"
+        f"Zeile erscheinen.\n--- Klartext ---\n{report.email_plain}"
+    )
+
+
+# ══════════════════════════════════ AC-2 ══════════════════════════════════
+
+
+def test_ac2_zeitfenster_guard_kein_fetch_ausserhalb_horizon(monkeypatch):
+    """AC-2: Segment > NOWCAST_HORIZON_MIN entfernt -> kein Fetch/Hinweis;
+    Segment innerhalb -> Fetch UND Hinweis (Gegenprobe im selben Test)."""
+    from services.radar_service import NOWCAST_HORIZON_MIN
+
+    assert NOWCAST_HORIZON_MIN == 60, (
+        f"Testvoraussetzung: NOWCAST_HORIZON_MIN muss 60 sein, war {NOWCAST_HORIZON_MIN!r}."
+    )
+
+    # Fern: Segment beginnt in 90 Minuten (> 60) -> kein Fetch, kein Hinweis.
+    uid_fern = _uid("ac2-fern")
+    trip_fern = _trip_with_segment_offset(f"trip-ac2-fern-{uuid.uuid4().hex[:6]}", start_in_min=90)
+    calls_fern: list = []
+    _install_fake_nowcast(monkeypatch, calls_fern, onset_minutes=10, intensity_label=INTENSITY_HEAVY)
+    rec_fern = _ReportRecorder()
+    rec_fern.install(monkeypatch)
+    _outcome_fern, report_fern = _run_briefing(rec_fern, uid_fern, trip_fern)
+
+    assert calls_fern == [], (
+        "AC-2: Segment beginnt erst in 90 Minuten (> NOWCAST_HORIZON_MIN=60) -> "
+        f"get_nowcast() darf NICHT aufgerufen werden, war {calls_fern!r}."
+    )
+    assert _HINT_MARKER not in report_fern.email_plain, (
+        f"AC-2: kein Hinweis erwartet ausserhalb des Horizonts.\n{report_fern.email_plain}"
+    )
+
+    # Nah: Segment beginnt in 30 Minuten (<= 60) -> Fetch UND Hinweis.
+    uid_nah = _uid("ac2-nah")
+    trip_nah = _trip_with_segment_offset(f"trip-ac2-nah-{uuid.uuid4().hex[:6]}", start_in_min=30)
+    calls_nah: list = []
+    _install_fake_nowcast(monkeypatch, calls_nah, onset_minutes=10, intensity_label=INTENSITY_HEAVY)
+    rec_nah = _ReportRecorder()
+    rec_nah.install(monkeypatch)
+    _outcome_nah, report_nah = _run_briefing(rec_nah, uid_nah, trip_nah)
+
+    assert len(calls_nah) >= 1, (
+        "AC-2 (Gegenprobe): Segment beginnt in 30 Minuten (<= Horizont) -> "
+        f"get_nowcast() MUSS aufgerufen werden, war {calls_nah!r}."
+    )
+    assert _HINT_MARKER in report_nah.email_plain, (
+        "AC-2 (Gegenprobe): innerhalb des Horizonts MUSS der Hinweis erscheinen.\n"
+        f"{report_nah.email_plain}"
+    )
+
+
+# ══════════════════════════════════ AC-3 ══════════════════════════════════
+
+
+def test_ac3_email_und_telegram_zeigen_identische_hinweiszeile(monkeypatch):
+    """AC-3: HTML, Plain und Telegram tragen dieselbe Hinweiszeile mit
+    identischer Uhrzeit — echte Renderer-Ausgabe, kein Dateiinhalt-Grep."""
+    uid = _uid("ac3")
+    trip = _active_trip(f"trip-ac3-{uuid.uuid4().hex[:6]}")
+
+    calls: list = []
+    _install_fake_nowcast(monkeypatch, calls, onset_minutes=15, intensity_label=INTENSITY_HEAVY)
+
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+    _outcome, report = _run_briefing(recorder, uid, trip)
+
+    assert len(calls) >= 1, "Testvoraussetzung: get_nowcast() muss aufgerufen worden sein."
+
+    match = re.search(r"Starker Regen ab ca\. \d{2}:\d{2} \(in ~15 Min\)\.", report.email_plain)
+    assert match is not None, (
+        "AC-3: Der Klartext-Teil muss die Hinweiszeile im Format "
+        f"'Starker Regen ab ca. HH:MM (in ~15 Min).' enthalten.\n{report.email_plain}"
+    )
+    hint_line = match.group(0)
+
+    html_text = re.sub(r"<[^>]+>", "\n", report.email_html)
+    assert hint_line in html_text, (
+        f"AC-3: Dieselbe Hinweiszeile muss im HTML-Teil erscheinen.\n--- HTML als Text ---\n{html_text}"
+    )
+
+    telegram_text = "\n".join(report.telegram_bubbles)
+    assert hint_line in telegram_text, (
+        f"AC-3: Dieselbe Hinweiszeile muss in der Telegram-Ausgabe erscheinen.\n{telegram_text}"
+    )
+
+
+# ══════════════════════════════════ AC-4 ══════════════════════════════════
+
+
+def _assert_hint_control_case_works(monkeypatch, prefix: str) -> None:
+    """Nicht-Leerlauf-Voraussetzung (Muster test_alert_undelivered_hint.py AC-10):
+    ein regulaerer INTENSITY_HEAVY-Trigger MUSS einen Hinweis erzeugen — sonst
+    pruefen die Negativ-Faelle unten gegen ein strukturell immer leeres Ergebnis
+    (Feature fehlt komplett) und koennten nie rot werden."""
+    calls: list = []
+    _install_fake_nowcast(monkeypatch, calls, onset_minutes=10, intensity_label=INTENSITY_HEAVY)
+    uid = _uid(f"{prefix}-kontrolle")
+    trip = _active_trip(f"trip-{prefix}-kontrolle-{uuid.uuid4().hex[:6]}")
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+    _outcome, report = _run_briefing(recorder, uid, trip)
+    assert len(calls) >= 1 and _HINT_MARKER in report.email_plain, (
+        "Testvoraussetzung (Nicht-Leerlauf): ein INTENSITY_HEAVY-Trigger MUSS "
+        f"einen Hinweis erzeugen — calls={calls!r}\n{report.email_plain}"
+    )
+
+
+def test_ac4_nowcast_fehler_kein_absturz_kein_hinweis(monkeypatch):
+    """AC-4 (Fail-soft, ADR-0018): get_nowcast() wirft -> Versand laeuft
+    unveraendert durch, keine Hinweiszeile, kein Crash."""
+    _assert_hint_control_case_works(monkeypatch, "ac4")
+
+    uid = _uid("ac4")
+    trip = _active_trip(f"trip-ac4-{uuid.uuid4().hex[:6]}")
+
+    calls: list = []
+    _install_fake_nowcast(monkeypatch, calls, raise_exc=RuntimeError("simulierter Nowcast-Ausfall"))
+
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+    outcome, report = _run_briefing(recorder, uid, trip)
+
+    assert outcome in ("sent", "no_channels"), (
+        f"AC-4: der Versand-Lauf darf trotz Nowcast-Fehler nicht abbrechen, war {outcome!r}."
+    )
+    assert _HINT_MARKER not in report.email_plain
+    assert _HINT_MARKER not in report.email_html
+    assert _HINT_MARKER not in "\n".join(report.telegram_bubbles)
+
+
+def test_ac4b_kein_treffer_oder_unterschwellig_kein_hinweis(monkeypatch):
+    """AC-4 (Rest): onset_minutes=None bzw. Intensitaet unter INTENSITY_HEAVY
+    -> ebenfalls kein Hinweis."""
+    _assert_hint_control_case_works(monkeypatch, "ac4b")
+
+    for label, kwargs in (
+        ("kein_treffer", dict(onset_minutes=None, intensity_label=INTENSITY_DRY)),
+        ("unterschwellig", dict(onset_minutes=10, intensity_label=INTENSITY_MODERATE)),
+    ):
+        uid = _uid(f"ac4b-{label}")
+        trip = _active_trip(f"trip-ac4b-{label}-{uuid.uuid4().hex[:6]}")
+        calls: list = []
+        _install_fake_nowcast(monkeypatch, calls, **kwargs)
+        recorder = _ReportRecorder()
+        recorder.install(monkeypatch)
+        _outcome, report = _run_briefing(recorder, uid, trip)
+        assert _HINT_TIME_PATTERN.search(report.email_plain) is None, (
+            f"AC-4 ({label}): kwargs={kwargs!r} darf keinen Hinweis (in keinem "
+            f"Intensitaets-Wortlaut) erzeugen.\n{report.email_plain}"
+        )
+
+
+# ══════════════════════════════════ AC-5 ══════════════════════════════════
+
+
+def test_ac5_sms_bleibt_zeichengleich_trotz_trigger(monkeypatch):
+    """AC-5: SMS-Text bleibt byte-identisch, egal ob der Starkregen-Trigger
+    vorliegt oder nicht (SMS ist bewusst ausserhalb des MVP-Scopes)."""
+    trip_id = f"trip-ac5-{uuid.uuid4().hex[:6]}"
+
+    uid_mit = _uid("ac5-mit")
+    trip_mit = _active_trip(trip_id)
+    trip_mit.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=False, send_telegram=False, send_sms=True,
+    )
+    _install_fake_nowcast(monkeypatch, [], onset_minutes=10, intensity_label=INTENSITY_HEAVY)
+    rec_mit = _ReportRecorder()
+    rec_mit.install(monkeypatch)
+    _outcome_mit, report_mit = _run_briefing(rec_mit, uid_mit, trip_mit)
+
+    assert _HINT_MARKER in report_mit.email_plain, (
+        "Testvoraussetzung: der Trigger muss die E-Mail-Ausgabe DIESES Laufs "
+        f"beeinflussen, sonst prueft der SMS-Vergleich nichts.\n{report_mit.email_plain}"
+    )
+
+    uid_ohne = _uid("ac5-ohne")
+    trip_ohne = _active_trip(trip_id)
+    trip_ohne.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=False, send_telegram=False, send_sms=True,
+    )
+    _install_fake_nowcast(monkeypatch, [], onset_minutes=None, intensity_label=INTENSITY_DRY)
+    rec_ohne = _ReportRecorder()
+    rec_ohne.install(monkeypatch)
+    _outcome_ohne, report_ohne = _run_briefing(rec_ohne, uid_ohne, trip_ohne)
+
+    assert report_mit.sms_text == report_ohne.sms_text, (
+        "AC-5: Der SMS-Text muss trotz Starkregen-Trigger byte-identisch bleiben.\n"
+        f"mit:  {report_mit.sms_text!r}\nohne: {report_ohne.sms_text!r}"
+    )
+
+
+# ══════════════════════════════════ AC-6 (Mutations-Pflicht) ══════════════════════════════════
+
+
+def test_ac6_versendeter_hinweis_wirft_throttle_der_folgealarm_unterdrueckt(monkeypatch):
+    """AC-6 (PFLICHT laut Spec — Mutations-Gegenprobe): nach einem versendeten
+    Kurzfristhinweis unterdrueckt der bestehende Radar-Throttle einen erneuten
+    Radar-Alert im Cooldown-Fenster.
+
+    Wird `ThrottleStore.record("radar", trip.id, ...)` im Scheduler entfernt,
+    MUSS genau dieser Test rot werden: `_is_radar_throttled` findet dann keinen
+    Eintrag, der zweite Lauf faehrt bis zum injizierten Nowcast durch und sendet
+    tatsaechlich (count >= 1 statt 0).
+    """
+    from services.throttle_store import ThrottleStore
+    from services.trip_alert import TripAlertService
+
+    uid = _uid("ac6")
+    trip_id = f"trip-ac6-{uuid.uuid4().hex[:6]}"
+    trip = _active_trip(trip_id)
+    trip.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=True, send_telegram=False, send_sms=False,
+    )
+    _save_trip_direct(trip, uid)
+
+    calls: list = []
+    _install_fake_nowcast(monkeypatch, calls, onset_minutes=15, intensity_label=INTENSITY_HEAVY)
+    sent_mails: list = []
+    _install_fake_email_send(monkeypatch, sent_mails)
+
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+
+    outcome, report = _run_briefing(recorder, uid, trip, settings=settings_email_only())
+
+    assert outcome == "sent", (
+        f"Testvoraussetzung: der Briefing-Versand muss als 'sent' durchlaufen, war {outcome!r}."
+    )
+    assert _HINT_MARKER in report.email_plain, (
+        "Testvoraussetzung: der Kurzfristhinweis muss im versendeten Briefing stehen.\n"
+        f"--- Klartext ---\n{report.email_plain}"
+    )
+
+    last_sent = ThrottleStore(uid).last_sent("radar", trip.id)
+    assert last_sent is not None, (
+        "AC-6: Nach einem versendeten Kurzfristhinweis MUSS der Radar-Throttle "
+        "gesetzt sein (ThrottleStore.record('radar', trip.id, ...)). "
+        "RED: Der Scheduler schreibt den Throttle noch nicht."
+    )
+
+    captured: list = []
+    svc = TripAlertService(
+        throttle_hours=2, user_id=uid,
+        radar_service=RadarNowcastService(frame_source=_wet_frames),
+        mail_sink=lambda subject, body: captured.append((subject, body)),
+    )
+    count = svc.check_radar_alerts()
+
+    assert count == 0, (
+        "AC-6 (Mutations-Pflicht): Ein Radar-Alert innerhalb des Cooldown-Fensters "
+        "MUSS durch denselben Throttle-Eintrag unterdrueckt werden, den der "
+        f"Kurzfristhinweis geschrieben hat — war count={count}. Wird "
+        "ThrottleStore.record('radar', trip.id, ...) im Scheduler entfernt (oder nie "
+        "erreicht), feuert dieser zweite Lauf tatsaechlich einen Alert."
+    )
+    assert captured == [], (
+        "AC-6: mail_sink darf nicht aufgerufen werden — der Folge-Alert muss "
+        f"unterdrueckt bleiben, war {captured!r}."
+    )
+
+
+# ══════════════════════════════════ AC-7 ══════════════════════════════════
+
+
+def test_ac7_gewitter_erzeugt_keinen_starkregen_hinweis(monkeypatch):
+    """AC-7: Gewitter/Hagel (is_convective=True, INTENSITY_CONVECTIVE) erzeugt
+    KEINEN Starkregen-Kurzfristhinweis — der ist ausschliesslich fuer
+    INTENSITY_HEAVY reserviert."""
+    _assert_hint_control_case_works(monkeypatch, "ac7")
+
+    uid = _uid("ac7")
+    trip = _active_trip(f"trip-ac7-{uuid.uuid4().hex[:6]}")
+
+    calls: list = []
+    _install_fake_nowcast(
+        monkeypatch, calls, onset_minutes=10,
+        intensity_label=INTENSITY_CONVECTIVE, is_convective=True,
+    )
+
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+    _outcome, report = _run_briefing(recorder, uid, trip)
+
+    assert _HINT_TIME_PATTERN.search(report.email_plain) is None, (
+        "AC-7: Gewitter/Hagel darf keinen Starkregen-Hinweis (in keinem "
+        f"Intensitaets-Wortlaut) im Klartext erzeugen.\n{report.email_plain}"
+    )
+    assert _HINT_TIME_PATTERN.search(report.email_html) is None, (
+        "AC-7: Gewitter/Hagel darf keinen Starkregen-Hinweis (in keinem "
+        "Intensitaets-Wortlaut) im HTML erzeugen."
+    )
+    telegram_text = "\n".join(report.telegram_bubbles)
+    assert _HINT_TIME_PATTERN.search(telegram_text) is None, (
+        "AC-7: Gewitter/Hagel darf keinen Starkregen-Hinweis (in keinem "
+        f"Intensitaets-Wortlaut) in Telegram erzeugen.\n{telegram_text}"
+    )
+
+
+# ══════════════════════════════════ AC-8 ══════════════════════════════════
+
+
+def test_ac8_data_sources_doku_traegt_minutely15_nachtrag():
+    """AC-8. # doc-compliance-test"""
+    path = REPO_ROOT / "docs" / "specs" / "data_sources.md"
+    text = path.read_text(encoding="utf-8")
+    assert "minutely_15" in text, (
+        "AC-8: docs/specs/data_sources.md muss einen Eintrag fuer 'minutely_15' "
+        "enthalten (Nachtrag — bereits seit #656 produktiv genutzt)."
+    )


### PR DESCRIPTION
## Summary
- Erweitert den bestehenden `RadarNowcastService` (#656) um Einbindung in den planmäßigen Trip-Briefing-Versandpfad (E-Mail + Telegram) — Hinweiszeile bei Starkregen innerhalb der nächsten 60 Minuten
- Budget-Gate (`alert_daily_limit`, reason="nowcast") und Zeitfenster-Guard laufen vor jedem Fetch; kein zusätzlicher Nowcast-Call bei ausgeschöpftem Budget oder zu weit entfernter Etappe
- Ein versendeter Hinweis nutzt den bestehenden Radar-Cooldown (`ThrottleStore`) mit, um einen widersprüchlichen Folge-Alert im Cooldown-Fenster zu vermeiden
- SMS bewusst unverändert (MVP-Scope, Token-Format als Folge-Issue vorgemerkt)
- Governance-Nachtrag `docs/specs/data_sources.md` für `minutely_15` (bereits seit #656 produktiv genutzt)

Spec: `docs/specs/modules/feat_1439_starkregen_kurzfristhinweis.md` (PO-freigegeben)
Adversary: VERIFIED (1 Fix-Loop-Iteration — Testrobustheits-Finding F001 behoben, kein Verhaltensfehler)

## Test plan
- [x] `tests/tdd/test_starkregen_kurzfristhinweis.py` — 9/9 grün, deckt AC-1 bis AC-8
- [x] Mutationsgegenprobe für AC-1, AC-2, AC-4b, AC-6, AC-7 — jede gezielte Regression wird vom zugehörigen Test gefangen
- [x] Gezielter Regressionscheck (5 verwandte Testdateien, 67 Tests) — keine Regressionen
- [x] `tests/tdd/test_issue_811_mode_matrix.py` grün + `briefing_mail_validator.py` gegen echt zugestellte Staging-Mail — Renderer-Mail-Gate erfüllt
- [ ] Staging-Verifikation (folgt nach Merge, `/e2e-verify`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)