### PR TITLE
fix(#1584): Alarme am Tagesziel enden am Tagesfenster statt 2 Stunden nach Ankunft

### DIFF
--- a/docs/adr/0035-ein-tagesfenster-fuer-trip-und-ortsvergleich.md
+++ b/docs/adr/0035-ein-tagesfenster-fuer-trip-und-ortsvergleich.md
@@ -80,3 +80,12 @@ die Stundentabelle zeigte durchgehend 24 Zeilen.
   müssen sich verhalten wie bisher; die bestehenden Trip-Tagesfenster-Tests sind
   die Regressionsgrenze. Was eine **leere Metrik-Auswahl** bedeutet, ist hiervon
   unberührt und wird gesondert entschieden (Etappe S3, #1366).
+- **Konsument Ziel-Segment (#1584):** Das Ziel-Segment einer Etappe
+  (`src/services/trip_segments.py::convert_trip_to_segments()`) nutzt seit #1584
+  die ortszeit-aufgelöste `day_window_end_hour` statt `arrival_time + 2 Stunden`.
+  Damit ziehen die Alarmpfade (`weather_change_detection.py`, `trip_alert.py`)
+  und die Aggregation (`segment_weather.py`) denselben Zeitbegriff wie Anzeige
+  und Bewertung — die Folgepflicht wird auf diesen Konsumenten angewandt.
+  **Grenze:** Tagesfenster über Mitternacht (`start_hour > end_hour`) werden am
+  Zielsegment nicht abgebildet; dort greift ein Mindestfenster von einer Stunde
+  (PO-Entscheidung 2026-08-08, Spec `docs/specs/modules/fix_1584_alarm_zeitfenster.md`).

--- a/docs/context/fix-1584-alarm-zeitfenster.md
+++ b/docs/context/fix-1584-alarm-zeitfenster.md
@@ -1,0 +1,161 @@
+# Context: Alarme schalten 2 Stunden nach Ankunft ab (#1584)
+
+## Request Summary
+
+Am 2026-08-07 zog ein Hagelgewitter (Böen bis 44 km/h, 21,5 mm Regen) über das
+Tagesziel des laufenden Trips „KHW 403" — **kein einziger Alarm** ging raus.
+Ursache ist nicht das Tageslimit aus #1555, sondern die Bindung des Alarmpfads
+an ein hartcodiertes Zwei-Stunden-Fenster nach Ankunft.
+
+## Analysis
+
+### Type
+
+**Bug** mit einer Design-Entscheidung (welches Zeitfenster gilt für Alarme).
+
+### Belegte Ursachenkette
+
+| Stelle | Befund |
+|---|---|
+| `src/services/trip_segments.py:258` | Ziel-Segment endet hart bei `arrival_time + timedelta(hours=2)`. Ursprünglich Aktivitäts-Marker für den Radar-Check (#822), inzwischen faktisch die einzige Quelle für „Wetter am Zielort". |
+| `src/services/segment_weather.py:254-271` | `_aggregate_for_segment` filtert strikt auf `[start_floor, end_floor)` des Segments — obwohl `timeseries` desselben Objekts **24 Stunden** enthält. |
+| `src/services/weather_change_detection.py:43,593-607` | Alarmregeln lesen ausschließlich `aggregated`. Folge: die Regel `thunder_level` kann **strukturell nie** auslösen, wenn das Gewitter nach Ankunft+2h liegt. |
+| `src/services/trip_alert.py:964-969` | Deviations-Fetch überspringt alle Segmente mit `end_time < now` → leere Liste → `No fresh weather data`. |
+| `src/services/trip_alert.py:737-750` | Radar-Pfad bricht bei „alle Segmente vorbei" ab (Z. 741-745) — **vor** der Ruhezeiten-Prüfung (Z. 748), die dadurch nie erreicht wird. |
+
+### 🔴 Widerlegt — nicht Gegenstand
+
+„Das Briefing verschweigt die Gefahr" ist durch eine Staging-Gegenprobe
+**widerlegt** (Issue-Kommentar 3): Die zugestellte Mail enthält Gewittersymbole,
+Böen bis 44 km/h und 21,5 mm Regen im Nacht-Block, dazu Hinweise in Kopfzeile
+und Metriken-Überblick. Der Nacht-Block holt seine Daten über
+`fetch_night_weather()` (Ankunft → 06:00 Folgetag), unabhängig vom
+Segment-Zuschnitt. **Kein Renderer-Fix nötig.**
+
+Die falsche Behauptung entstand aus dem Lesen einer Zwischendatei statt der
+zugestellten Nachricht — dieselbe Fehlerklasse, die bei #1555 drei
+Arbeitsstränge fehlgeleitet hat.
+
+### PO-Entscheidungen (2026-08-07, verbindlich)
+
+- Beobachteter Ort außerhalb der Gehzeit: **das Tagesziel**
+- Maßgebliches Zeitfenster: **das Tagesfenster** (`day_window_start_hour`/
+  `-end_hour`, Default 4/19), nicht die Etappenzeit
+
+### Technischer Ansatz (Empfehlung)
+
+**Das Ziel-Segment-Ende von `arrival_time + 2h` auf die ortszeit-aufgelöste
+`day_window_end_hour` umstellen** (`trip_segments.py:258`).
+
+Warum diese Stelle: Beide Alarmpfade und die Aggregation lesen
+`segment.end_time`. Eine Korrektur an der Quelle zieht Alarm, Aggregation und
+Anzeige automatisch auf denselben Zeitbegriff — ohne dass diese Dateien selbst
+angefasst werden. Der Provider liefert ohnehin volle 24 Stunden, es entsteht
+kein zusätzlicher Abruf.
+
+**Zeitzone:** Kein neuer Helfer nötig. `trip_segments.py:181-191` enthält das
+Muster bereits (`tz_for_coords(lat, lon)` → lokale Zeit → `.astimezone(utc)`).
+
+**Verworfen:**
+- *Zweites Fenster an `_aggregate_for_segment` durchreichen* — erodiert den
+  dokumentierten Vertrag („Aggregat entsteht aus GENAU diesem Fenster") und
+  schafft eine neue Diskrepanz zwischen Anzeige- und Alarm-Fenster. Genau die
+  Fehlerklasse, die dieses Issue aufgedeckt hat.
+- *Separater „Aufenthalt am Ziel"-Datensatz* — größter Eingriff, dupliziert
+  Aggregationslogik mit Divergenz-Risiko, löst die strukturelle Bindung nicht.
+
+### 🔴 Kollision mit #1329 geprüft — besteht nicht
+
+`tests/unit/test_forecast_cache_sharing.py:385-457` fordert, dass Aggregat und
+Identität aus dem **eigenen** Segment-Fenster des jeweiligen Aufrufers
+entstehen — Schutz gegen Kontamination zwischen Trip und Ortsvergleich. Die
+Absicht gilt **pro Aufrufer**, nicht **pro Segmentgröße**. Ein größeres, aber
+weiterhin eindeutig zugeordnetes Fenster verletzt sie nicht. Keine Ablösung
+nötig, die Tests bleiben grün.
+
+(Der verworfene Ansatz „zweites Fenster" hätte hier zwar auch keinen Test rot
+gemacht — aber die Schutz*absicht* unterlaufen. Der Unterschied zwischen „Tests
+bleiben grün" und „Schutz bleibt gültig" war die Kernfrage.)
+
+### Ruhezeiten vs. Tagesfenster — Empfehlung revidiert
+
+Meine erste Empfehlung („Tagesfenster ersetzt Ruhezeiten für Alarme") ist
+**zurückgezogen.** Gegenargument, das sie schlägt:
+
+Ruhezeiten sind eine **explizit gesetzte Nutzereinstellung**, das Tagesfenster
+meist ein unangetasteter Default (beim KHW-Trip nicht gesetzt). Wer seine
+Ruhezeiten bewusst auf 22–05 gestellt hat, bekäme bei einer Ablösung plötzlich
+Alarme zwischen 19 und 22 Uhr — eine Regression, die größer wäre als der
+behobene Fehler.
+
+Zudem sind es zwei verschiedene Fragen: Das Tagesfenster ist ein
+**Daten-Geltungsbereich** („welche Stunden zählen als heute am Ziel"), die
+Ruhezeiten ein **Zustellungs-Gate** („darf mich jetzt etwas erreichen").
+
+**Empfehlung: beide gelten (Schnittmenge, ≈6–19 Uhr bei Standardwerten).** Das
+Regel-Budget ist gewahrt, weil das Tagesfenster den Segment-Zuschnitt ablöst —
+eine Regel ersetzt eine andere, nur eben nicht die Ruhezeiten. Entscheidung
+liegt beim PO in der Spec.
+
+**Nebenbefund:** `deviation_alert_engine.py:78-106` rechnet Ruhezeiten hart in
+`Europe/Vienna`, nicht in der Ortszeit des Ziels. Bestehender Sonderfall, nicht
+Gegenstand dieser Scheibe, aber relevant für Trips außerhalb Mitteleuropas.
+
+### Affected Files — Scheibe 1
+
+| File | Change | Beschreibung |
+|------|--------|--------------|
+| `src/services/trip_segments.py:258` | MODIFY | Ziel-Segment-Ende auf ortszeit-aufgelöste `day_window_end_hour`; Randfall „Ankunft nach Fensterende" analog zum bestehenden Mitternachts-Guard (Z. 193-204) |
+| `tests/unit/test_destination_segment.py:101-109` | MODIFY | `test_destination_segment_time_window` fixiert heute die 2 Stunden — muss auf das neue Verhalten umgeschrieben werden |
+| *(neu)* E2E-Test am Sendepfad | CREATE | s.u. |
+
+- Scope: 3 Dateien, ~60–90 LoC
+- Risk: **MEDIUM** — nutzersichtbare Nebenwirkung (s.u.)
+
+### Wie die Wirkung nachgewiesen wird
+
+Der Test muss am **Alarm-Sendepfad** hängen, nicht am Briefing — das zeigt die
+Gefahr bereits heute korrekt und wäre auch ohne Fix grün.
+
+```
+GEGEBEN  Trip, dessen letztes Segment vor 17:00 Ortszeit endet (Ankunft 13:18),
+         Tagesfenster 4–19, Fixture liefert um 17:00 thunder_level=HIGH
+WENN     der Alarm-Check zu einer simulierten Zeit von 17:05 Ortszeit läuft
+DANN     wird tatsächlich ein Alarm ausgeliefert (sent == True)
+
+GEGENPROBE (muss weiterhin ausbleiben)
+WENN     dieselbe Prüfung um 22:00 Ortszeit läuft
+DANN     kein Alarm — außerhalb des Tagesfensters
+```
+
+Heute rot, weil Ankunft+2h < 17:00 → Segment übersprungen. Vorbild für einen
+Test über echte Produktionspfade: `test_forecast_cache_sharing.py:460+`.
+
+### Risks & Considerations
+
+- **Nutzersichtbare Nebenwirkung:** Zielsegment-Zeile und Highlights im
+  Trip-Report zeigen künftig Aggregate über ein 5–15-Stunden-Fenster statt über
+  2 Stunden. Gewollt — es beseitigt die Diskrepanz (Segment 0,0 mm vs.
+  Metriken-Überblick 8,9 mm für denselben Tag), aber der PO sollte es wissen.
+- **Ein bestehender Test fixiert die 2 Stunden** und muss bewusst umgeschrieben
+  werden — kein Nebenbei-Anpassen.
+- **Nicht einzeln verifiziert:** weitere `aggregated`-Konsumenten
+  (`risk_engine.py`, `corridor_threshold.py`, `day_comparison.py`,
+  `point_weather.py`) könnten für das Zielsegment andere Schwellen auslösen.
+  Restrisiko, durch die bestehende Suite teilweise abgedeckt.
+- **Nicht belegt:** ob das SMS-Zeichenbudget bei größeren Niederschlagswerten
+  Formatierungsprobleme bekommt.
+
+### Folge-Scheiben (nicht in Scheibe 1)
+
+1. Ruhezeiten-Prüfung im Radar-Pfad **vor** den Segment-Check ziehen
+   (`trip_alert.py:737-750`) — verhindert, dass die Architektur denselben
+   Fehler erneut ermöglicht. ~10 LoC.
+2. Tagesfenster beim Trip-Anlegen editierbar machen
+   (`WeatherMetricsTab.svelte:1244`) — durch die Alarmrelevanz aufgewertet.
+3. Prüfen, ob der Compare-Pfad dieselbe Zeitfenster-Bindung hat.
+
+### Open Questions (für die Spec-Freigabe)
+
+- [ ] Ruhezeiten: Schnittmenge (empfohlen) oder Ablösung?
+- [ ] Ist die geänderte Darstellung der Ziel-Zeile im Briefing so gewollt?

--- a/docs/specs/modules/fix_1584_alarm_zeitfenster.md
+++ b/docs/specs/modules/fix_1584_alarm_zeitfenster.md
@@ -1,0 +1,389 @@
+---
+entity_id: fix_1584_alarm_zeitfenster
+type: bugfix
+created: 2026-08-07
+updated: 2026-08-07
+status: draft
+workflow: fix-1584-alarm-zeitfenster
+version: "1.0"
+tags: [issue-1584, alerts, day-window, trip-segments, adr-0035]
+---
+
+# Ziel-Segment endet am Tagesfenster statt hart 2 Stunden nach Ankunft
+
+## Approval
+
+- [x] Approved
+
+## Purpose
+
+Das Ziel-Segment einer Etappe (`segment_id="Ziel"`) endet heute hart bei
+`arrival_time + timedelta(hours=2)`. Beide Alarmpfade
+(`weather_change_detection.py`, Radar-/NowCast-Check in `trip_alert.py`) und
+die Aggregation (`segment_weather.py`) lesen ausschließlich `segment.end_time`
+— die Gefahren-Überwachung für das Tagesziel ist damit strukturell zwei
+Stunden nach Ankunft abgeschaltet. Am 2026-08-07 zog ein Hagelgewitter (Böen
+44 km/h, 21,5 mm) über das Tagesziel des Trips „KHW 403", ohne dass ein
+einziger Alarm ausging. Diese Änderung stellt das Ziel-Segment-Ende auf die
+ortszeit-aufgelöste `day_window_end_hour` um, damit Alarm und Aggregation für
+das Ziel denselben, bereits etablierten Zeitbegriff (ADR-0035) nutzen wie
+Anzeige und Bewertung.
+
+## Source
+
+- **File:** `src/services/trip_segments.py`
+- **Identifier:** `convert_trip_to_segments(trip, target_date)` — Konstruktion
+  des `destination_segment` (Zeile 243-263, konkret `end_time=` in Zeile 258)
+
+> **Schicht-Hinweis:** Alle Code-Änderungen liegen im Python-Core unter
+> `src/services/` und `tests/unit/` (FastAPI-Domain-Backend). Keine Go-,
+> keine Frontend-Änderung. Kein Eingriff in `weather_change_detection.py`
+> oder `trip_alert.py` selbst — beide lesen unverändert `segment.end_time`
+> und ziehen den Fix automatisch nach, ohne angefasst zu werden.
+
+## Estimated Scope
+
+- **LoC:** ~60-90 (Code ~15-25 in `trip_segments.py`, Test-Umschreibung
+  ~15-20, neuer E2E-Test ~30-45)
+- **Files:** 3 Produktionscode/Test (`trip_segments.py`,
+  `tests/unit/test_destination_segment.py`, ein neuer Test am
+  Alarm-Sendepfad) + `docs/adr/0035-...md` (Ergänzung, zählt laut
+  Regel-Budget nicht zum LoC-Limit)
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/app/day_window.py::resolve_configured_window()` | module | Einzige Quelle für die effektiven Fenster-Grenzen (Default 4/19, Rückwärtskompatibilität bei `None`) — wird für das Ziel-Segment wiederverwendet, kein neuer Auflöser |
+| `src/app/models.py::TripReportConfig.day_window_start_hour`/`_end_hour` (Zeile 885-886) | model | Konfigurierbares Tagesfenster liegt NICHT direkt auf `Trip`, sondern auf `TripReportConfig` — erreichbar über das optionale Feld `trip.report_config` |
+| `src/utils/timezone.py::tz_for_coords()` | module | Bereits im selben File für die regulären Segmente verwendet (Zeile 181); liefert die Ortszeit-Zone für die letzte Wegpunkt-Koordinate |
+| `src/services/segment_weather.py::_aggregate_for_segment()` | module | Liest unverändert `segment.start_time`/`segment.end_time` — Konsument, nicht geändert |
+| `src/services/weather_change_detection.py` | module | Liest unverändert `aggregated` (aus dem größeren Fenster) für die Alarmregel `thunder_level` — Konsument, nicht geändert |
+| `src/services/trip_alert.py` | module | Radar-/NowCast-Pfad (Zeile 730-745) und Deviations-Fetch (Zeile 964-969) werten `segment.end_time` aus — Konsument, nicht geändert |
+| `docs/adr/0035-ein-tagesfenster-fuer-trip-und-ortsvergleich.md` | doc | Bestehendes ADR — wird um diesen neuen Konsumenten ergänzt (s. Architektur-Entscheidung) |
+
+## Implementation Details
+
+**`trip_segments.py::convert_trip_to_segments()`, Konstruktion des
+`destination_segment` (aktuell Zeile 243-263):**
+
+Statt `end_time=arrival_time + timedelta(hours=2)` wird das Fensterende über
+`resolve_configured_window(...)` bestimmt. Die konfigurierten Grenzen liegen
+NICHT direkt auf `Trip`, sondern auf `TripReportConfig`
+(`src/app/models.py:885-886`), erreichbar über das optionale Feld
+`trip.report_config` (kann `None` sein). Analog zum bereits etablierten,
+defensiven Muster in `notification_service.py:281-282`
+(`getattr(_rc, "day_window_start_hour", None) if _rc else None`) wird
+`_rc = trip.report_config` gebildet und
+`resolve_configured_window(getattr(_rc, "day_window_start_hour", None) if
+_rc else None, getattr(_rc, "day_window_end_hour", None) if _rc else None)`
+aufgerufen — ein Trip ganz ohne `report_config` fällt damit über denselben
+Defensive-Pfad still auf den Default 4/19 zurück, genau wie ein Trip mit
+`report_config`, aber unbesetzten Tagesfenster-Feldern. Das Ergebnis wird auf
+die Ortszeit der letzten Wegpunkt-Koordinate (`last_wp.lat`, `last_wp.lon`)
+aufgelöst — exakt das Muster, das für die regulären Segmente bereits im
+selben File steht (Zeile 181-191: `tz_for_coords()` →
+`datetime.combine(...)` mit der aufgelösten Zeit → `.replace(tzinfo=seg_tz)`
+→ `.astimezone(timezone.utc)`).
+
+Ablauf:
+1. `_rc = trip.report_config`; `_, end_hour = resolve_configured_window(getattr(_rc, "day_window_start_hour", None) if _rc else None, getattr(_rc, "day_window_end_hour", None) if _rc else None)`
+2. Ortszeit-Zone der Ziel-Koordinate: `dest_tz = tz_for_coords(last_wp.lat, last_wp.lon)`
+3. Fensterende in Ortszeit am Kalendertag der Ankunft konstruieren, nach UTC
+   konvertieren (`.astimezone(timezone.utc)`), analog zum bestehenden Muster.
+4. **Randfall „Ankunft liegt bereits nach `day_window_end_hour`"**: wenn das
+   so berechnete Fensterende `<= arrival_time` ist, greift derselbe Klemm-
+   Gedanke wie beim bestehenden Mitternachts-Guard (Zeile 193-204) — statt
+   einer negativen oder kollabierten Dauer wird ein minimales Fenster
+   verwendet (`end_time = arrival_time + timedelta(hours=1)`, analog zur
+   bisherigen Fehlerbehandlung: lieber ein kurzes, aber gültiges Fenster als
+   ein Segment, das komplett verschwindet oder rückwärts läuft).
+5. `duration_hours` wird aus der tatsächlichen Differenz berechnet statt
+   fest `2.0` zu sein.
+
+**Wo die Zusicherung tatsächlich WIRKT (Mutations-Gegenprobe-relevant):** Die
+Änderung sitzt ausschließlich an der Segment-Konstruktion. Weder
+`weather_change_detection.py` noch `trip_alert.py` noch
+`segment_weather.py` werden angefasst — sie lesen weiterhin
+`segment.end_time` und `segment.start_time` unverändert. Ein Test, der nur
+`convert_trip_to_segments()` isoliert aufruft und `dest.end_time` prüft,
+beweist NICHT, dass ein Alarm tatsächlich zugestellt wird — dafür muss der
+Test über den echten Alarm-Sendepfad laufen (`TripAlertService` bzw. den
+Deviation-Check, analog zu `test_forecast_cache_sharing.py:460+`), sonst
+wiederholt sich exakt der Fehler aus diesem Issue: ein Zwischenwert wird
+geprüft statt der zugestellten Wirkung.
+
+## Expected Behavior
+
+- **Input:** `trip` (mit optional gesetztem `trip.report_config` und darauf
+  optional gesetzten `day_window_start_hour`/`day_window_end_hour`),
+  `target_date`.
+- **Output:** `destination_segment.end_time` reicht bis zur Ortszeit-
+  aufgelösten `day_window_end_hour` (Default 19 Uhr) statt bis
+  `arrival_time + 2h`; `duration_hours` entsprechend variabel (5-15h statt
+  fix 2h, abhängig von der Ankunftszeit).
+- **Side effects:** Aggregation (`segment_weather.py`) und beide Alarmpfade
+  sehen automatisch das größere Fenster, ohne selbst geändert zu werden.
+  Zielsegment-Zeile und Highlights im Trip-Briefing zeigen künftig
+  Aggregate über das größere Fenster (s. Known Limitations —
+  nutzersichtbare Nebenwirkung, gewollt).
+
+## Acceptance Criteria
+
+**Zentrale Regel für alle folgenden ACs:** Abnahme hängt an der
+**zugestellten Wirkung** — ein Alarm wird tatsächlich versendet (z.B.
+`mail_sink`/`sent`-Zustand über den echten `TripAlertService`- bzw.
+Deviation-Sendepfad) oder nicht. Ein Test, der nur einen internen
+Zwischenwert wie `aggregated.thunder_level_max` oder `segment.end_time`
+isoliert prüft, ist NICHT ausreichend — genau diese Verwechslung hat in
+diesem Issue bereits zu einer falschen Behauptung geführt. Ebenso reicht ein
+Test, der nur das Briefing auf Gewittersymbole prüft, nicht — das ist bereits
+heute korrekt und wäre auch ohne diesen Fix grün. **Einzige benannte
+Ausnahme: AC-5** — dort geht es ausschließlich um eine
+Rückwärtskompatibilitäts-Zusicherung für einen Default-Wert ohne eigene
+Wirkungsdimension (kein Verhalten, das an einem Sendepfad unterscheidbar
+wäre); AC-5 bleibt deshalb bewusst eine Strukturprüfung. Ein Test muss außerdem
+**diskriminierend** sein: er darf nicht in beiden Welten (mit und ohne Fix)
+gleichermaßen grün bleiben — ein Zeitpunkt weit außerhalb jedes plausiblen
+Fensters beweist nichts, nur ein Zeitpunkt nah an der tatsächlichen Grenze tut
+das (s. AC-2a/AC-2b, AC-6).
+
+- **AC-1:** Given ein Trip mit Tagesfenster 4-19 Uhr (Default), dessen letztes
+  reguläres Segment um 13:18 Ortszeit am Tagesziel endet, und ein simuliertes
+  Gewitter (`thunder_level=HIGH`) um 17:00 Ortszeit am selben Ort / When der
+  Alarm-Check zu einer simulierten Zeit von 17:05 Ortszeit läuft / Then wird
+  tatsächlich ein Alarm ausgeliefert (Versand über den echten Sendepfad
+  nachweisbar, nicht nur ein interner Aggregatwert).
+  - Test: Fixture-Zeitreihe mit `thunder_level=HIGH` um 17:00 Ortszeit,
+    Ankunft 13:18, Tagesfenster unverändert (4/19). Echter Lauf über
+    `TripAlertService`/Deviation-Pfad; Assert über tatsächlich erfolgten
+    Versand (z.B. `mail_sink` gefüllt oder äquivalenter Sende-Nachweis) —
+    kein Assert allein auf `aggregated.thunder_level_max`.
+
+- **AC-2a (Grenzwert innerhalb, diskriminierende Hälfte):** Given derselbe
+  Trip wie AC-1 (Tagesfenster 4-19 Uhr, Ankunft 13:18), und ein simuliertes
+  Gewitter (`thunder_level=HIGH`) um 18:45 Ortszeit — knapp innerhalb der
+  neuen Fenster-Obergrenze 19:00, aber deutlich außerhalb des alten,
+  fehlerhaften 2-Stunden-Fensters (das bei Ankunft 13:18 bereits um 15:18
+  endet) / When der Alarm-Check zu einer simulierten Zeit von 18:50 Ortszeit
+  läuft / Then wird der Alarm tatsächlich zugestellt. Das ist die
+  diskriminierende Hälfte: bliebe der alte 2-Stunden-Fehler bestehen, wäre
+  dieser Test rot.
+  - Test: Fixture-Zeitreihe mit `thunder_level=HIGH` um 18:45 Ortszeit,
+    Ankunft 13:18, Tagesfenster 4/19. Echter Lauf über
+    `TripAlertService`/Deviation-Pfad zu simulierter Zeit 18:50 Ortszeit;
+    Assert Versand erfolgt über denselben echten Sendepfad wie AC-1.
+
+- **AC-2b (Grenzwert außerhalb, fachlicher Zweck: kein nächtlicher Alarm):**
+  Given derselbe Trip wie AC-1/AC-2a, und ein simuliertes Gewitter
+  (`thunder_level=HIGH`) um 19:15 Ortszeit — knapp außerhalb der
+  Fenster-Obergrenze 19:00 / When der Alarm-Check zu einer simulierten Zeit
+  von 19:20 Ortszeit läuft / Then bleibt der Alarm aus. Bewacht die
+  ausdrückliche PO-Vorgabe, dass nachts/spätabends kein teurer Alarm
+  ausgelöst wird („auf einer Hüttenwanderung braucht das niemand") — und
+  dass das neue Fenster nicht versehentlich zu weit geöffnet wird (z.B. bis
+  Mitternacht oder unbegrenzt).
+  - Test: identischer Aufbau wie AC-2a, Gewitterzeitpunkt auf 19:15
+    Ortszeit verschoben, Alarm-Check zu simulierter Zeit 19:20 Ortszeit;
+    Assert kein Versand über denselben echten Sendepfad.
+
+- **AC-3:** Given ein Trip, dessen letztes reguläres Segment erst um 20:30
+  Ortszeit am Tagesziel ankommt (Fenster 4-19 Uhr, also NACH
+  `day_window_end_hour`), und ein simuliertes Gewitter (`thunder_level=HIGH`)
+  um 20:45 Ortszeit — innerhalb des minimalen Randfall-Fensters / When der
+  Alarm-Check zu einer simulierten Zeit von 20:50 Ortszeit läuft / Then wird
+  der Alarm tatsächlich ausgeliefert — der Trip fällt durch die
+  Spätankunft NICHT stillschweigend aus der Überwachung (kein Absturz, kein
+  „alle Segmente vorbei"-Abbruch im Radar-Pfad).
+  - Test: Fixture mit Ankunft 20:30 Ortszeit, `thunder_level=HIGH` um 20:45
+    Ortszeit. Echter Lauf über `TripAlertService`/Radar-Pfad zu simulierter
+    Zeit 20:50 Ortszeit; Assert Versand erfolgt über denselben echten
+    Sendepfad wie in AC-1. Beweist gleichzeitig, dass das Segment gültig
+    bleibt (sonst würde der bestehende Radar-Pfad-Abbruch aus
+    `trip_alert.py:737-745` greifen und den Trip stumm überspringen).
+
+- **AC-4:** Given ein Trip mit Tagesziel deutlich außerhalb Mitteleuropas
+  (Koordinate mit klarem UTC-Versatz zu `Europe/Vienna`, Tagesfenster 4-19
+  Uhr Ortszeit am Ziel, Default), und ein simuliertes Gewitter
+  (`thunder_level=HIGH`) um 17:00 **Ortszeit am Ziel** / When der Alarm-Check
+  zu einer simulierten Zeit von 17:05 Ortszeit am Ziel läuft / Then wird der
+  Alarm tatsächlich ausgeliefert — die Fenstergrenze wurde nach der Ortszeit
+  am Zielort aufgelöst, nicht nach `Europe/Vienna` (bei fest verdrahteter
+  Wiener Zeitzone läge dasselbe UTC-Ereignis außerhalb des dort berechneten
+  Fensters und der Alarm bliebe aus).
+  - Test: analog AC-1, aber Ziel-Koordinate in einer deutlich versetzten
+    Zeitzone; Gewitter-Zeitpunkt und Alarm-Check-Zeitpunkt beide in
+    Ortszeit am Ziel angegeben (nicht in Vienna-Zeit umgerechnet). Echter
+    Lauf über `TripAlertService`/Deviation-Pfad; Assert Versand erfolgt.
+    Ein Testfehlschlag bei fest verdrahteter Vienna-Zeit ist der beweisende
+    Fall.
+
+- **AC-5 (strukturell, Rückwärtskompatibilität ohne eigene
+  Wirkungsdimension):** Given ein Trip ohne gesetzte
+  `day_window_start_hour`/`day_window_end_hour` (Alt-Trip, `None`) / When
+  das Ziel-Segment konstruiert wird / Then wird der Default 4/19 Uhr
+  verwendet — exakt wie `resolve_configured_window()` es für alle anderen
+  Konsumenten bereits tut.
+  - Test: Trip-Fixture ohne Tagesfenster-Felder; Assert `dest.end_time`
+    entspricht 19:00 Ortszeit (in UTC umgerechnet) am Ankunftstag.
+
+- **AC-6 (konfiguriertes Fenster, diskriminierend gegen fest verdrahteten
+  Default — Wächter, kein RED-Test):** Given ein Trip mit **abweichend
+  konfiguriertem** Tagesfenster (`report_config.day_window_start_hour = 6`,
+  `report_config.day_window_end_hour = 16`, statt Default 4/19), Ankunft
+  wie in AC-1 (13:18 Ortszeit), und ein simuliertes Gewitter
+  (`thunder_level=HIGH`) um 16:30 Ortszeit — zwischen der konfigurierten
+  Obergrenze (16:00) und der Default-Obergrenze (19:00) / When der
+  Alarm-Check zu einer simulierten Zeit von 16:35 Ortszeit läuft / Then
+  bleibt der Alarm aus, weil 16:30 außerhalb des tatsächlich konfigurierten
+  Fensters liegt. Diskriminierend gegen ein hartcodiertes `(4, 19)`: dort
+  läge 16:30 innerhalb, der Alarm ginge fälschlich raus und der Test würde
+  rot. **Erwarteter RED-Status vor dem Fix: vermutlich bereits grün** — das
+  alte 2-Stunden-Fenster endet bei Ankunft 13:18 bereits um 15:18, 16:30
+  liegt auch dort außerhalb. AC-6 ist ein Wächter gegen das Aushebeln der
+  Einstellbarkeit des Tagesfensters, kein Nachweis des ursprünglichen Bugs
+  — er darf nicht künstlich rot gebogen werden, analog zu AC-2b und AC-3.
+  - Test: Fixture-Zeitreihe mit `thunder_level=HIGH` um 16:30 Ortszeit,
+    Ankunft 13:18, `report_config.day_window_start_hour=6`,
+    `day_window_end_hour=16`. Echter Lauf über
+    `TripAlertService`/Deviation-Pfad zu simulierter Zeit 16:35 Ortszeit;
+    Assert kein Versand über denselben echten Sendepfad.
+
+**Mutations-Gegenprobe (Hinweis für den Adversary):**
+- `resolve_configured_window(...)` durch die alten `timedelta(hours=2)`
+  ersetzt (Revert auf das alte Fehlverhalten) → AC-1 und AC-2a müssen rot
+  werden (18:45/17:00 lägen dann außerhalb des alten Fensters bis 15:18).
+- `resolve_configured_window(...)` durch ein hartcodiertes `(4, 19)` ersetzt
+  (Konfigurierbarkeit ausgehebelt, Default-Fall bleibt zufällig korrekt) →
+  AC-1 bis AC-2b bleiben davon unberührt grün, weil sie alle mit dem
+  Default-Fenster arbeiten. **Nur AC-6 fängt diese Mutation**: das
+  abweichend konfigurierte Fenster (6-16 Uhr) würde bei hartcodiertem
+  `(4, 19)` fälschlich bis 19 Uhr reichen, der Alarm um 16:30 ginge raus,
+  AC-6 wird rot.
+- Obergrenze des Fensters entfernt (Segment läuft bis Mitternacht oder
+  unbegrenzt statt bis `day_window_end_hour`) → die 19:15-Hälfte (AC-2b)
+  muss rot werden, weil dann auch ein Gewitter kurz nach 19:00 noch einen
+  Alarm auslöst.
+- Ortszeit-Auflösung (`tz_for_coords`) entfernt, stattdessen `Europe/Vienna`
+  fest verwendet → AC-4 muss rot werden (AC-1/AC-2a/AC-2b/AC-3/AC-6 nutzen
+  Ziel-Orte in Mitteleuropa und würden diese Mutation nicht sehen — AC-4 ist
+  der einzige AC, der auf einem UTC-Versatz zu Vienna basiert).
+- Randfall-Guard aus Schritt 4 entfernt → AC-3 muss rot werden (das
+  Segment kollabiert oder wird negativ, das Gewitter um 20:45 Ortszeit
+  fällt außerhalb des dann falsch berechneten Fensters).
+
+## Known Limitations
+
+- **Nutzersichtbare Nebenwirkung:** Zielsegment-Zeile und Highlights im
+  Trip-Briefing zeigen künftig Aggregate über ein 5-15-Stunden-Fenster statt
+  über fix 2 Stunden. Gewollt — beseitigt den Widerspruch zwischen
+  Zielsegment-Wert und Metriken-Überblick derselben Mail (0,0 mm vs.
+  8,9 mm im Belegfall), aber sichtbar anders als bisher.
+- **Nicht einzeln verifiziert:** weitere `aggregated`-Konsumenten
+  (`risk_engine.py`, `corridor_threshold.py`, `day_comparison.py`,
+  `point_weather.py`) könnten für das größere Zielsegment-Fenster andere
+  Schwellen auslösen als bisher. Restrisiko, durch die bestehende Suite nur
+  teilweise abgedeckt — nicht Gegenstand dieser Scheibe.
+- **Nicht belegt:** ob das SMS-Zeichenbudget bei größeren
+  Niederschlags-/Windwerten (aus dem größeren Fenster) an seine Grenze
+  kommt. Nicht geprüft, kein bekannter Vorfall.
+- **Kollision mit #1329 geprüft, besteht nicht:**
+  `tests/unit/test_forecast_cache_sharing.py:385-457` schützt, dass Aggregat
+  und Cache-Identität aus dem eigenen Segment-Fenster des jeweiligen
+  Aufrufers entstehen (Trip vs. Ortsvergleich) — die Absicht gilt pro
+  Aufrufer, nicht pro Segmentgröße. Ein größeres, aber weiterhin eindeutig
+  zugeordnetes Fenster verletzt diesen Schutz nicht; keine Anpassung an
+  diesem Test nötig.
+- **PO-Entscheidung „Ruhezeiten vs. Tagesfenster" (freigegeben):**
+  Nach dieser Änderung begrenzen zwei unabhängige Mechanismen die
+  Alarmzeit für das Ziel: das Tagesfenster (Daten-Geltungsbereich, hier
+  umgesetzt) und die bestehenden Ruhezeiten (Zustellungs-Gate, unverändert).
+  **Beide gelten als Schnittmenge** (bei Default-Werten ≈6-19 Uhr), keine
+  Ablösung — Ruhezeiten sind eine explizit gesetzte Nutzereinstellung, das
+  Tagesfenster meist ein unangetasteter Default. Eine Ablösung würde
+  jemandem mit bewusst gesetzten Ruhezeiten (z.B. 22-05 Uhr) plötzlich
+  Alarme zwischen 19 und 22 Uhr zustellen. Diese Scheibe ändert an den
+  Ruhezeiten selbst nichts — die Schnittmenge ergibt sich automatisch aus
+  den bereits bestehenden, unveränderten Ruhezeiten-Prüfungen
+  (`_is_quiet_hours()` in `trip_alert.py`, `deviation_alert_engine.py`).
+- **Mitternachts-Tagesfenster werden am Zielsegment NICHT abgebildet
+  (PO-Entscheidung 2026-08-08, aus Adversary-Befund F005):** Ein Fenster mit
+  `day_window_start_hour > day_window_end_hour` (z. B. 22-2 Uhr) ist seit
+  #1361/#1372 S1b gültig, hat aber ein **Loch** (im Beispiel 2:00-22:00). Das
+  Zielsegment ist ein einzelnes zusammenhängendes Intervall und kann ein Loch
+  nicht darstellen. Für solche Trips greift deshalb der Randfall-Guard
+  (Mindestfenster 1 h) — bewusst, nicht versehentlich. Der naheliegende
+  Ausweg „Fensterende = nächstes Auftreten von `end_hour` ab der Ankunft"
+  wurde erprobt und **verworfen**: er schüttet das Loch still zu und liefert
+  je nach Ankunftszeit 1 h bis fast 24 h Alarmfenster (bei Tagesankünften
+  zwischen 02:01 und 21:59 Ortszeit sogar 16-24 h), was AC-2b und AC-3b
+  direkt aushebelt. Eine saubere Lösung müsste das Zielsegment **aufspalten**
+  — eigene Scheibe. Bewacht durch
+  `test_mitternachtsfenster_22_2_klemmt_auf_mindestfenster`.
+- **Nicht Gegenstand:** `deviation_alert_engine.py:78-106` rechnet
+  Ruhezeiten hart in `Europe/Vienna`, nicht in der Ortszeit des Ziels.
+  Bestehender Sonderfall, eigene Scheibe (relevant für Trips außerhalb
+  Mitteleuropas).
+- **Kein Renderer-Fix:** Die frühere Annahme „das Briefing verschweigt die
+  Gefahr" ist durch eine Staging-Gegenprobe widerlegt (Issue-Kommentar 3)
+  — die zugestellte Mail enthielt Gewittersymbole, Böen und 21,5 mm Regen
+  im Nacht-Block (`fetch_night_weather()`, unabhängig vom Segment-Zuschnitt).
+  Diese Scheibe fasst keinen Renderer-Code an.
+
+**Folge-Scheiben (nicht Teil dieser Spec):**
+1. Ruhezeiten-Prüfung im Radar-Pfad vor den Segment-Check ziehen
+   (`trip_alert.py:737-750`), damit die Architektur denselben Fehler nicht
+   erneut ermöglicht.
+2. Tagesfenster beim Trip-Anlegen editierbar machen
+   (`WeatherMetricsTab.svelte:1244`) — durch die Alarmrelevanz aufgewertet.
+3. Prüfen, ob der Compare-Pfad dieselbe Zeitfenster-Bindung hat.
+
+**Folge-Scheibe aus F005:** Zielsegment für Mitternachts-Tagesfenster
+aufspalten (zwei Intervalle statt eines), damit `start_hour > end_hour` auch
+am Ziel wirkt statt auf das Mindestfenster zu fallen.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** ADR-0035 (bestehend, wird ergänzt — kein neues ADR)
+- **Rationale:** ADR-0035 hat bereits entschieden, dass es EIN Tagesfenster
+  gibt (`resolve_configured_window()`), das auf Anzeige UND Bewertung wirkt,
+  und benennt als Folgepflicht ausdrücklich: „Neue Ausgaben (Kanäle,
+  Tabellen) beziehen ihr Zeitfenster aus derselben Quelle — kein weiterer
+  Auflöser." Diese Scheibe wendet genau diese Folgepflicht auf einen
+  bislang unabgedeckten Konsumenten an (die Konstruktion des Ziel-Segments,
+  die wiederum Alarm UND Aggregation speist) — sie widerspricht ADR-0035
+  nicht und löst es nicht ab, sondern schließt eine Lücke in seiner
+  Anwendung. Ein neues ADR wäre hier Overhead: es entsteht kein neuer
+  Zeitbegriff, keine neue Quelle, keine neue Bedienfläche — nur ein
+  zusätzlicher Aufrufer derselben, bereits etablierten Auflösung. Als Teil
+  dieser Scheibe bekommt `docs/adr/0035-...md` einen kurzen Ergänzungs-
+  Absatz, der den Ziel-Segment-Alarmpfad als weiteren Konsumenten nennt.
+
+## Changelog
+
+- 2026-08-07: Initial spec created
+- 2026-08-07: AC-3/AC-4 auf den Alarm-Sendepfad gehoben (spec-validator
+  INVALID-Befund) — beide prüften zuvor nur Segment-Strukturwerte
+  (`dest.end_time`), die auch bei kaputter Alarmzustellung grün geblieben
+  wären. AC-5 bleibt bewusst strukturell und ist jetzt explizit als
+  Ausnahme von der zentralen Wirkungs-Regel gekennzeichnet.
+- 2026-08-07: AC-2 als nicht-diskriminierend erkannt (spec-validator
+  INVALID-Befund, Runde 3) — 22:00 Ortszeit lag sowohl im alten als auch im
+  neuen Fenster außerhalb, der Test wäre in beiden Welten grün geblieben.
+  Ersetzt durch Grenzwert-Paar AC-2a (18:45 Ortszeit, innerhalb, beweist den
+  Fix) / AC-2b (19:15 Ortszeit, außerhalb, bewacht die PO-Vorgabe „kein
+  nächtlicher Alarm" an der tatsächlichen Fenstergrenze). Mutations-Block
+  entsprechend ergänzt.
+- 2026-08-07: Zwei PO-freigegebene Nachträge — (1) Sachfehler korrigiert:
+  das Tagesfenster liegt auf `TripReportConfig` (`models.py:885-886`),
+  erreichbar über `trip.report_config` (optional), NICHT direkt auf `Trip`
+  — korrigiert in „Dependencies", „Implementation Details" und „Expected
+  Behavior". (2) AC-6 ergänzt: die RED-Phase maß, dass ein hartcodiertes
+  `(4, 19)` von keinem der bisherigen sechs — jetzt fünf plus AC-6 — ACs
+  gefangen wird, weil alle mit dem Default-Fenster arbeiten. AC-6 nutzt ein
+  abweichend konfiguriertes Fenster (6-16 Uhr) mit einem Gewitter um 16:30
+  Ortszeit, um genau diese Lücke diskriminierend zu schließen; ausdrücklich
+  als Wächter ohne eigenen RED-Nachweis gekennzeichnet, analog zu AC-2b/
+  AC-3. Mutations-Block entsprechend aufgeteilt (`timedelta(hours=2)` →
+  AC-1/AC-2a, hartcodiertes `(4, 19)` → AC-6).

--- a/src/services/trip_segments.py
+++ b/src/services/trip_segments.py
@@ -14,6 +14,7 @@ import math
 from datetime import date, datetime, time, timedelta, timezone
 from typing import TYPE_CHECKING, List, Optional
 
+from app.day_window import resolve_configured_window
 from app.models import GPXPoint, TripSegment
 from utils.geo import haversine_km
 from utils.timezone import tz_for_coords
@@ -240,6 +241,54 @@ def convert_trip_to_segments(trip: "Trip", target_date: date) -> List[TripSegmen
         arrival_time = segments[-1].end_time
         elev = float(last_wp.elevation_m) if last_wp.elevation_m else 0.0
 
+        # Issue #1584: Das Ziel-Segment endete bisher hart bei
+        # arrival_time + 2 h. Beide Alarmpfade (weather_change_detection,
+        # Radar-/NowCast-Check in trip_alert) und die Aggregation
+        # (segment_weather) lesen ausschliesslich segment.end_time — die
+        # Gefahren-Ueberwachung fuer das Tagesziel war damit strukturell zwei
+        # Stunden nach Ankunft abgeschaltet. Das Ende folgt jetzt derselben
+        # Tagesfenster-Quelle wie Anzeige und Bewertung (ADR-0035), damit es
+        # KEINEN zweiten Zeitbegriff gibt.
+        # PO-Entscheidung 2026-08-08: Ein Tagesfenster ueber Mitternacht
+        # (start_hour > end_hour, seit #1361 gueltig) wird hier BEWUSST nicht
+        # abgebildet — ein solches Fenster hat ein Loch (z. B. 2-22 Uhr), das
+        # ein einzelnes zusammenhaengendes Segment nicht darstellen kann. Es
+        # greift dann der Randfall-Guard unten (Mindestfenster). Deshalb wird
+        # start_hour hier nicht gebraucht. Details: Known Limitations der Spec.
+        _rc = getattr(trip, "report_config", None)
+        _, end_hour = resolve_configured_window(
+            getattr(_rc, "day_window_start_hour", None) if _rc else None,
+            getattr(_rc, "day_window_end_hour", None) if _rc else None,
+        )
+        dest_tz = tz_for_coords(last_wp.lat, last_wp.lon)
+        # Der Kalendertag ist der LOKALE Ankunftstag am Ziel, nicht der
+        # UTC-Tag: bei einem Ziel westlich von Greenwich faellt die Ankunft
+        # in UTC schon auf den Folgetag, waehrend es am Ziel noch derselbe
+        # Tag ist — der UTC-Tag wuerde das Fenster um 24 h verschieben.
+        arrival_local_date = arrival_time.astimezone(dest_tz).date()
+        window_end = (
+            datetime.combine(arrival_local_date, time(end_hour))
+            .replace(tzinfo=dest_tz)
+            .astimezone(timezone.utc)
+        )
+
+        if window_end <= arrival_time:
+            # Ankunft liegt bereits nach day_window_end_hour (Spaetankunft,
+            # z. B. 20:30 bei Fenster bis 19:00) — oder das Fenster laeuft
+            # ueber Mitternacht (s. o.). Anders als der Mitternachts-
+            # Guard oben wird hier NICHT uebersprungen: ein fehlendes
+            # Ziel-Segment laesst den Trip still aus der Ueberwachung fallen
+            # (genau der Fehler aus #1584). Stattdessen ein minimales, aber
+            # gueltiges Fenster.
+            logger.warning(
+                f"Ziel-Segment: Ankunft {arrival_time.isoformat()} liegt nach "
+                f"dem Tagesfenster-Ende ({end_hour}:00 Ortszeit) — minimales "
+                "Fenster von 1 h wird verwendet"
+            )
+            dest_end_time = arrival_time + timedelta(hours=1)
+        else:
+            dest_end_time = window_end
+
         destination_segment = TripSegment(
             segment_id="Ziel",
             start_point=GPXPoint(
@@ -255,8 +304,8 @@ def convert_trip_to_segments(trip: "Trip", target_date: date) -> List[TripSegmen
                 distance_from_start_km=cumulative_dist_km,
             ),
             start_time=arrival_time,
-            end_time=arrival_time + timedelta(hours=2),
-            duration_hours=2.0,
+            end_time=dest_end_time,
+            duration_hours=(dest_end_time - arrival_time).total_seconds() / 3600,
             distance_km=0.0,
             ascent_m=0.0,
             descent_m=0.0,

--- a/tests/tdd/test_issue_303_waypoint_suggestions.py
+++ b/tests/tdd/test_issue_303_waypoint_suggestions.py
@@ -194,6 +194,20 @@ class TestLoaderNewFields:
 # AC-7 + AC-9 — Scheduler: arrival_override Prioritätskette
 # ---------------------------------------------------------------------------
 
+def _local_times(segments) -> list:
+    """Segment-Zeitstempel (UTC) in die Ortszeit der Fixture-Koordinaten.
+
+    ``arrival_calculated``/``arrival_override`` sind Ortszeit-Angaben — nur in
+    Ortszeit sind die Fixture-Werte ("13:30", "14:00") ueberhaupt vergleichbar.
+    """
+    from utils.timezone import tz_for_coords
+
+    tz = tz_for_coords(47.1, 11.1)  # Fixture-Wegpunkte, Europe/Vienna
+    return [s.start_time.astimezone(tz) for s in segments] + [
+        s.end_time.astimezone(tz) for s in segments
+    ]
+
+
 class TestSchedulerArrivalPriority:
     """_convert_trip_to_segments bevorzugt arrival_override vor arrival_calculated."""
 
@@ -241,7 +255,15 @@ class TestSchedulerArrivalPriority:
         # Flexibler Check: Startzeit des Segments, das von W1→W2 geht.
         # Je nach Scheduler-Internals kann der Zeitpunkt am end oder start liegen.
         # Kernforderung: kein Segment darf 13:30:00 als W2-Ankunft verwenden.
-        all_times = [s.start_time for s in segments] + [s.end_time for s in segments]
+        #
+        # #1584: "14:00"/"13:30" sind ORTSZEIT-Angaben aus der Fixture; die
+        # Segment-Zeitstempel sind UTC. Frueher verglich dieser Test die
+        # Ortszeit-Ziffern direkt mit UTC-Stunden und war nur durch einen
+        # Zufall gruen — das hartcodierte 2-h-Ziel-Fenster war genau so lang
+        # wie der CEST-Versatz (+2 h), sodass ausgerechnet das ZIEL-Segment-
+        # Ende die gesuchte Ziffernfolge traf. Mit den echten Ankunftszeiten
+        # hatte das nichts zu tun. Jetzt wird in Ortszeit verglichen.
+        all_times = _local_times(segments)
         has_override_time = any(
             t.hour == 14 and t.minute == 0 for t in all_times
         )
@@ -267,7 +289,8 @@ class TestSchedulerArrivalPriority:
         target = date(2026, 5, 26)
         segments = svc._convert_trip_to_segments(trip, target)
 
-        all_times = [s.start_time for s in segments] + [s.end_time for s in segments]
+        # #1584: Vergleich in Ortszeit — s. Begruendung im Test oben.
+        all_times = _local_times(segments)
         has_calculated_time = any(
             t.hour == 13 and t.minute == 30 for t in all_times
         )

--- a/tests/unit/test_alarm_zeitfenster_ziel.py
+++ b/tests/unit/test_alarm_zeitfenster_ziel.py
@@ -1,0 +1,711 @@
+"""TDD RED — Issue #1584: Ziel-Segment endet am Tagesfenster, nicht nach 2 h.
+
+SPEC: docs/specs/modules/fix_1584_alarm_zeitfenster.md (AC-1, AC-2a, AC-2b,
+AC-3, AC-4, AC-5).
+
+Abgenommen wird die ZUGESTELLTE WIRKUNG: geht ein Alarm ueber den echten
+``TripAlertService``-Sendepfad raus (``mail_sink`` gefuellt) oder nicht.
+Kein Assert auf ``segment.end_time`` oder ``aggregated.thunder_level_max``
+— einzige Ausnahme ist AC-5, das die Spec ausdruecklich als
+Struktur-Zusicherung ohne eigene Wirkungsdimension ausweist.
+
+Netz- und versandfrei: Der Provider unten ist ein echter Fake (kein
+``Mock``/``patch``/``MagicMock``), E-Mail laeuft ueber die vorhandene
+``mail_sink``-DI-Naht, Telegram/SMS sind auf Trip-Ebene aus und in den
+Settings leer. Persistenz liegt in der pytest-isolierten
+``app.loader.get_data_dir()``-Basis (#1133).
+
+Ausfuehrung:
+    uv run pytest tests/unit/test_alarm_zeitfenster_ziel.py -v \
+        --disable-socket --allow-hosts=127.0.0.1
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, time, timedelta, timezone
+
+import pytest
+
+from app.models import (
+    ForecastDataPoint,
+    ForecastMeta,
+    MetricConfig,
+    NormalizedTimeseries,
+    Provider,
+    SegmentWeatherData,
+    SegmentWeatherSummary,
+    ThunderLevel,
+    TripReportConfig,
+    UnifiedWeatherDisplayConfig,
+)
+from app.trip import Stage, Trip, Waypoint
+from services.segment_weather import SegmentWeatherService
+from services.trip_alert import TripAlertService
+from services.trip_segments import convert_trip_to_segments
+from services.weather_cache import reset_shared_weather_cache_for_tests
+from utils.timezone import tz_for_coords
+
+from tests.helpers.alert_log_fixtures import settings_email_only
+
+# Mitteleuropa (Europe/Vienna) — AC-1/AC-2a/AC-2b/AC-3.
+ALPEN_LAT, ALPEN_LON = 47.0500, 11.5500
+# Deutlicher UTC-Versatz WESTLICH von Wien (America/Los_Angeles, UTC-7/-8) —
+# AC-4. Westlich ist Pflicht: bei fest verdrahtetem Europe/Vienna liegt das
+# dort berechnete Fensterende VOR der Ankunft am Ziel, das Gewitter faellt
+# heraus und der Alarm bleibt aus. Eine oestliche Zone (z.B. Neuseeland)
+# wuerde die Mutation NICHT sehen, weil das Wiener Fenster dort zu weit ist.
+SIERRA_LAT, SIERRA_LON = 39.1900, -120.2400
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    reset_shared_weather_cache_for_tests()
+    yield
+    reset_shared_weather_cache_for_tests()
+
+
+def _utc(tz, day: date, hour: int, minute: int = 0) -> datetime:
+    """Ortszeit -> UTC, exakt nach dem Muster aus trip_segments.py:182-191."""
+    return (
+        datetime.combine(day, time(hour, minute))
+        .replace(tzinfo=tz)
+        .astimezone(timezone.utc)
+    )
+
+
+class ThunderAtHourProvider:
+    """Fake-Provider (KEIN Mock): liefert wie Open-Meteo eine volle,
+    stuendliche Zeitreihe unabhaengig vom angefragten Fenster — 72 h ab
+    ``anchor``. Genau die uebergebenen UTC-Stunden tragen
+    ``thunder_level=HIGH``, alle anderen ``NONE``."""
+
+    def __init__(self, anchor: datetime, thunder_hours: set[datetime]) -> None:
+        self._anchor = anchor
+        self._thunder = set(thunder_hours)
+
+    @property
+    def name(self) -> str:
+        return "openmeteo"
+
+    def fetch_forecast(
+        self, location, start=None, end=None,
+        enrich_ensemble: bool = True, enrich_snow: bool = True,
+    ) -> NormalizedTimeseries:
+        meta = ForecastMeta(
+            provider=Provider.OPENMETEO, model="icon_d2", grid_res_km=2.2,
+            run=self._anchor, interp="grid_point",
+        )
+        data = [
+            ForecastDataPoint(
+                ts=self._anchor + timedelta(hours=h),
+                t2m_c=15.0,
+                thunder_level=(
+                    ThunderLevel.HIGH
+                    if self._anchor + timedelta(hours=h) in self._thunder
+                    else ThunderLevel.NONE
+                ),
+            )
+            for h in range(72)
+        ]
+        return NormalizedTimeseries(meta=meta, data=data)
+
+
+def _trip(
+    trip_id: str, lat: float, lon: float, day: date, arrival_local: str,
+    day_window: tuple[int, int] | None = None,
+) -> Trip:
+    """Tour mit scharfer Gewitter-Empfindlichkeit, E-Mail als einzigem Kanal.
+
+    ``day_window=None`` -> keine ``day_window_*``-Felder gesetzt, also Default
+    4/19 (AC-1..AC-5). ``day_window=(start, end)`` setzt die Felder dort, wo
+    sie tatsaechlich wohnen: auf ``TripReportConfig`` (``models.py:885-886``),
+    erreichbar ueber ``trip.report_config`` — NICHT direkt auf ``Trip`` (AC-6).
+    """
+    stage = Stage(
+        id="T1", name="Tag 1", date=day,
+        waypoints=[
+            Waypoint(id="G1", name="Start", lat=lat - 0.05, lon=lon - 0.05,
+                     elevation_m=1000, arrival_calculated="08:00"),
+            Waypoint(id="G2", name="Tagesziel", lat=lat, lon=lon,
+                     elevation_m=1400, arrival_calculated=arrival_local),
+        ],
+    )
+    trip = Trip(
+        id=trip_id, name="Zielsegment-Trip", stages=[stage], official_warnings=None,
+        display_config=UnifiedWeatherDisplayConfig(
+            trip_id=trip_id,
+            metrics=[MetricConfig(metric_id="thunder", enabled=True)],
+            metric_alert_levels={"thunder_level": "standard"},
+        ),
+    )
+    trip.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=True, alert_on_changes=True,
+    )
+    if day_window is not None:
+        trip.report_config.day_window_start_hour = day_window[0]
+        trip.report_config.day_window_end_hour = day_window[1]
+    trip.alert_cooldown_minutes = 0
+    trip.official_alert_triggers_enabled = False
+    trip.alert_channels = {"email": True, "telegram": False, "sms": False}
+    return trip
+
+
+def _calm(segment) -> SegmentWeatherData:
+    """Briefing-Schnappschuss ohne Gewitter (= ``cached``-Seite)."""
+    return SegmentWeatherData(
+        segment=segment,
+        timeseries=NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="icon_d2",
+                              grid_res_km=2.2),
+            data=[],
+        ),
+        aggregated=SegmentWeatherSummary(thunder_level_max=ThunderLevel.NONE),
+        fetched_at=datetime.now(timezone.utc),
+        provider="openmeteo",
+    )
+
+
+def _alarm_mails(
+    lat: float, lon: float, arrival_local: str, thunder_hour: int,
+    day_window: tuple[int, int] | None = None,
+) -> list:
+    """Ein vollstaendiger Alarm-Lauf; gibt die tatsaechlich zugestellten
+    Mails zurueck.
+
+    Die frischen Daten entstehen ueber denselben Produktionsweg wie in
+    ``TripAlertService._fetch_fresh_weather`` (``SegmentWeatherService.
+    fetch_segment_weather(..., priority="alert_check")``, Fehler pro Segment
+    verschluckt) — nur die dortigen ``datetime.now()``-Filter entfallen,
+    damit der Test nicht von der realen Uhrzeit abhaengt.
+    """
+    tz = tz_for_coords(lat, lon)
+    day = date.today()
+    trip = _trip(f"t-{uuid.uuid4().hex[:8]}", lat, lon, day, arrival_local, day_window)
+
+    segments = convert_trip_to_segments(trip, day)
+    anchor = datetime.combine(day - timedelta(days=1), time(0, 0), tzinfo=timezone.utc)
+    provider = ThunderAtHourProvider(anchor, {_utc(tz, day, thunder_hour)})
+
+    fresh = []
+    for seg in segments:
+        try:
+            fresh.append(
+                SegmentWeatherService(provider).fetch_segment_weather(
+                    seg, enrich_ensemble=False, enrich_snow=False,
+                    priority="alert_check",
+                )
+            )
+        except Exception:  # noqa: BLE001 — 1:1 wie _fetch_fresh_weather
+            continue
+
+    mails: list = []
+    TripAlertService(
+        settings=settings_email_only(),
+        user_id=f"tdd-1584-{uuid.uuid4().hex[:6]}",
+        throttle_hours=0,
+        mail_sink=lambda subject, body: mails.append((subject, body)),
+    ).check_and_send_alerts(trip, [_calm(s) for s in segments], fresh_weather=fresh)
+    return mails
+
+
+# ---------------------------------------------------------------------------
+# Radar-/NowCast-Pfad (F003). Alle ACs oben laufen ueber
+# ``check_and_send_alerts()`` — den Deviations-Pfad. Der Radar-Pfad
+# (``check_radar_alerts()``, Produktionsaufruf api/routers/scheduler.py:86)
+# hat eine EIGENE Segment-Auswahl mit einem eigenen „alle Segmente vorbei"-
+# Abbruch (trip_alert.py:737-745) und wird davon nicht beruehrt. Genau dieser
+# Pfad lieferte im Belegfall von #1584 systemweit nie einen Alarm.
+# ---------------------------------------------------------------------------
+
+# Reykjavik: Atlantic/Reykjavik ist ganzjaehrig UTC+0 OHNE Sommerzeit. Damit
+# sind Ortszeit und UTC identisch und die Fixture kommt ohne Offset-Rechnung
+# aus — der Radar-Pfad haengt an der echten Wanduhr (``datetime.now()``),
+# die Zeiten muessen also zur Laufzeit gebildet werden.
+ISLAND_LAT, ISLAND_LON = 64.1466, -21.9426
+# Ausweichort fuer die UTC-Stunde 0 (Pacific/Auckland, UTC+12/+13) — s.
+# ``radar_fixture_ort()``.
+AUCKLAND_LAT, AUCKLAND_LON = -36.8485, 174.7633
+
+
+def _radar_wet_frames(lat: float, lon: float) -> list:
+    """Echte ``RadarFrame``-Objekte (kein Mock) ueber den dokumentierten
+    DI-Seam ``frame_source``; kraeftiger Regen ab +5 Minuten, damit
+    ``radar_alert_due(..., threshold_min=20)`` anschlaegt."""
+    from providers.brightsky import RadarFrame
+
+    now = datetime.now(timezone.utc)
+    return [
+        RadarFrame(timestamp=now + timedelta(minutes=5), precip_mm_h=12.0),
+        RadarFrame(timestamp=now + timedelta(minutes=15), precip_mm_h=20.0),
+    ]
+
+
+def _persist_trip(trip, user_id: str) -> None:
+    """Trip-JSON in die pytest-isolierte Nutzerablage schreiben.
+
+    ``check_radar_alerts()`` liest die Trips selbst ueber ``load_all_trips()``
+    — der Trip muss also auf Platte liegen. ``save_trip()`` scheidet aus, weil
+    es Naismith-Compute-on-Save ausloest (#802) und die exakt gesetzten
+    ``arrival_calculated`` ueberschreibt; genau darauf steht dieser Test.
+    Muster aus ``tests/tdd/test_issue_822_radar_nowcast_segment.py``, hier
+    zusaetzlich mit den Tagesfenster-Feldern.
+    """
+    import json
+
+    from app.loader import get_briefings_dir
+
+    rc = trip.report_config
+    briefings = get_briefings_dir(user_id)
+    briefings.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "id": trip.id,
+        "name": trip.name,
+        "alert_cooldown_minutes": 0,
+        "stages": [
+            {
+                "id": s.id, "name": s.name, "date": s.date.isoformat(),
+                "waypoints": [
+                    {"id": w.id, "name": w.name, "lat": w.lat, "lon": w.lon,
+                     "elevation_m": w.elevation_m,
+                     "arrival_calculated": w.arrival_calculated}
+                    for w in s.waypoints
+                ],
+            }
+            for s in trip.stages
+        ],
+        "report_config": {
+            "trip_id": rc.trip_id, "send_email": True,
+            "send_telegram": False, "send_sms": False,
+            "day_window_start_hour": rc.day_window_start_hour,
+            "day_window_end_hour": rc.day_window_end_hour,
+        },
+    }
+    (briefings / f"{trip.id}.json").write_text(json.dumps(payload, indent=2))
+
+
+def radar_fixture_window(arrival_utc: datetime) -> tuple[int, int]:
+    """Tagesfenster-Grenzen fuer die Radar-Fixture — REINE Funktion, damit die
+    Tageszeit-Unabhaengigkeit deterministisch pruefbar ist (s.
+    ``test_radar_fixture_ist_zu_jeder_tageszeit_kein_mitternachtsfenster``).
+
+    Anforderung an die Fixture: ``end_hour`` muss <= der ORTS-Stunde der
+    Ankunft sein, damit das Fensterende (HH:00) vor der Ankunft (HH:MM) liegt
+    und der Randfall-Guard greift — das ist der Zweig, den der Test beweisen
+    soll. Gleichzeitig MUSS ``start_hour < end_hour`` gelten: bei
+    ``start_hour > end_hour`` entsteht ein Mitternachts-Fenster, und der Test
+    liefe versehentlich durch einen anderen Zweig (F004).
+
+    Die erste Fassung bildete ``start_hour = (end_hour - 6) % 24`` und wrappte
+    dadurch fuer jede Ankunftsstunde < 6 auf einen groesseren Wert — zwischen
+    00:00 und 05:59 UTC bewachte der Test nichts. ``start_hour = 0`` kann
+    nicht wrappen; noetig ist dann nur noch ``end_hour >= 1``, worum sich
+    ``radar_fixture_ort()`` kuemmert.
+    """
+    return 0, arrival_utc.astimezone(radar_fixture_tz(arrival_utc)).hour
+
+
+def radar_fixture_tz(arrival_utc: datetime):
+    """Zeitzone des Zielorts fuer die Radar-Fixture — s. ``radar_fixture_ort``."""
+    from zoneinfo import ZoneInfo
+
+    if arrival_utc.hour >= 1:
+        return ZoneInfo("Atlantic/Reykjavik")
+    return ZoneInfo("Pacific/Auckland")
+
+
+def radar_fixture_ort(arrival_utc: datetime) -> tuple[float, float]:
+    """Zielkoordinate der Radar-Fixture — REINE Funktion (s. Invarianten-Test).
+
+    Standard ist Reykjavik (``Atlantic/Reykjavik``, ganzjaehrig UTC+0 OHNE
+    Sommerzeit): Ortszeit == UTC, keine Offset-Rechnung, kein DST-Flattern.
+    Die Ortsstunde ist dort gleich der UTC-Stunde — und muss >= 1 sein, damit
+    ``start_hour = 0`` echt kleiner als ``end_hour`` ist. Verletzt ist das nur
+    in der UTC-Stunde 0; dann weicht die Fixture nach Auckland (UTC+12/+13)
+    aus, wo dieselbe UTC-Zeit auf 12:xx bzw. 13:xx Ortszeit faellt — und wo
+    das Ortsdatum in dieser UTC-Stunde weiterhin dem UTC-Datum entspricht
+    (fuer ``date.today()`` in ``check_radar_alerts()`` zwingend).
+    """
+    if arrival_utc.hour >= 1:
+        return ISLAND_LAT, ISLAND_LON
+    return AUCKLAND_LAT, AUCKLAND_LON
+
+
+def _radar_mails_fuer_spaetankunft() -> list:
+    """Baut einen Trip mit Spaetankunft RELATIV ZUM TAGESFENSTER und laesst den
+    echten ``check_radar_alerts()`` darueber laufen. Gibt die zugestellten
+    Mails zurueck (``mail_sink``, kein echter Versand).
+
+    Der Radar-Pfad liest ``datetime.now()`` und ``date.today()`` direkt, es
+    gibt keine Einspeise-Naht fuer die Zeit. Die Fixture wird deshalb um die
+    aktuelle Uhr herum gebaut: Ankunft drei Minuten in der Vergangenheit,
+    ``day_window_end_hour`` auf die ORTS-Stunde der Ankunft — damit liegt das
+    Fensterende (HH:00) zwangslaeufig VOR der Ankunft (HH:MM) und der
+    Randfall-Guard greift, unabhaengig davon, wie spaet es gerade ist.
+    """
+    from services.radar_service import RadarNowcastService
+
+    now = datetime.now(timezone.utc)
+    arrival = now - timedelta(minutes=3)
+    if arrival.date() != date.today():
+        pytest.skip(
+            "Fixture nicht konstruierbar: 'jetzt minus 3 Minuten' liegt vor "
+            "UTC-Mitternacht, waehrend check_radar_alerts() bereits den neuen "
+            "date.today() verwendet. Betrifft nur die ersten 3 Minuten des "
+            "UTC-Tages."
+        )
+
+    dest_lat, dest_lon = radar_fixture_ort(arrival)
+    dest_tz = radar_fixture_tz(arrival)
+    start_hour, end_hour = radar_fixture_window(arrival)
+    arrival_local = arrival.astimezone(dest_tz)
+    start_local = (arrival - timedelta(hours=4)).astimezone(dest_tz)
+
+    trip_id = f"radar-{uuid.uuid4().hex[:8]}"
+    stage = Stage(
+        id="S1", name="Tag 1", date=date.today(),
+        waypoints=[
+            Waypoint(id="W1", name="Start",
+                     lat=dest_lat - 0.05, lon=dest_lon - 0.05,
+                     elevation_m=100,
+                     arrival_calculated=start_local.strftime("%H:%M")),
+            Waypoint(id="W2", name="Tagesziel",
+                     lat=dest_lat, lon=dest_lon, elevation_m=200,
+                     arrival_calculated=arrival_local.strftime("%H:%M")),
+        ],
+    )
+    trip = Trip(id=trip_id, name="Radar-Zielsegment-Trip", stages=[stage])
+    trip.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=True,
+        day_window_start_hour=start_hour,
+        day_window_end_hour=end_hour,
+    )
+
+    user_id = f"tdd-1584-radar-{uuid.uuid4().hex[:6]}"
+    _persist_trip(trip, user_id)
+
+    mails: list = []
+    svc = TripAlertService(
+        settings=settings_email_only(),
+        user_id=user_id,
+        throttle_hours=0,
+        mail_sink=lambda subject, body: mails.append((subject, body)),
+        radar_service=RadarNowcastService(frame_source=_radar_wet_frames),
+    )
+    svc.clear_radar_throttle(trip_id)
+    svc.check_radar_alerts()
+    return mails
+
+
+def test_ac1_gewitter_17_uhr_am_tagesziel_wird_zugestellt():
+    """AC-1: Ankunft 13:18 Ortszeit, Gewitter 17:00 Ortszeit -> Alarm geht raus."""
+    mails = _alarm_mails(ALPEN_LAT, ALPEN_LON, "13:18", 17)
+    assert mails, (
+        "AC-1: Ein Gewitter (HIGH) um 17:00 Ortszeit am Tagesziel muss einen "
+        "zugestellten Alarm ausloesen. Es wurde KEINE Mail zugestellt — das "
+        "Ziel-Segment endet bei arrival_time + 2 h (15:18 Ortszeit), 17:00 "
+        "liegt ausserhalb und wird nie aggregiert (trip_segments.py:258)."
+    )
+
+
+def test_ac2a_gewitter_1845_knapp_vor_fensterende_wird_zugestellt():
+    """AC-2a: Gewitter 18:45 Ortszeit — innerhalb 19:00, weit ausserhalb der
+    alten 2-h-Grenze (15:18). Die diskriminierende Haelfte des Grenzwertpaars."""
+    mails = _alarm_mails(ALPEN_LAT, ALPEN_LON, "13:18", 18)
+    assert mails, (
+        "AC-2a: Ein Gewitter (HIGH) um 18:45 Ortszeit liegt knapp INNERHALB "
+        "der Fenster-Obergrenze 19:00 und muss zugestellt werden. Es wurde "
+        "keine Mail zugestellt — mit dem festen 2-h-Fenster (bis 15:18) faellt "
+        "18:45 heraus."
+    )
+
+
+def test_ac2b_gewitter_1915_knapp_nach_fensterende_bleibt_aus():
+    """AC-2b: Gewitter 19:15 Ortszeit — knapp ausserhalb 19:00. Bewacht die
+    PO-Vorgabe „kein naechtlicher Alarm" an der tatsaechlichen Grenze."""
+    mails = _alarm_mails(ALPEN_LAT, ALPEN_LON, "13:18", 19)
+    assert not mails, (
+        "AC-2b: Ein Gewitter um 19:15 Ortszeit liegt ausserhalb der "
+        "Fenster-Obergrenze 19:00 — es darf KEIN Alarm zugestellt werden. "
+        f"Tatsaechlich zugestellt: {[s for s, _ in mails]} (das Ziel-Segment "
+        "reicht zu weit, z.B. bis Mitternacht oder unbegrenzt)."
+    )
+
+
+def test_ac3_spaetankunft_2030_faellt_nicht_aus_der_ueberwachung():
+    """AC-3: Ankunft 20:30 Ortszeit (NACH day_window_end_hour), Gewitter
+    20:45 -> Alarm geht trotzdem raus; der Randfall-Guard haelt ein
+    minimales, gueltiges Fenster statt eines kollabierten Segments."""
+    mails = _alarm_mails(ALPEN_LAT, ALPEN_LON, "20:30", 20)
+    assert mails, (
+        "AC-3: Bei Ankunft 20:30 Ortszeit (nach dem Tagesfenster-Ende 19:00) "
+        "muss ein Gewitter um 20:45 weiterhin einen zugestellten Alarm "
+        "ausloesen. Es kam keine Mail an — das Ziel-Segment ist kollabiert "
+        "oder laeuft rueckwaerts, der Trip faellt still aus der Ueberwachung."
+    )
+
+
+def test_radar_fixture_ist_zu_jeder_tageszeit_kein_mitternachtsfenster():
+    """F004: Beweist die Tageszeit-Unabhaengigkeit der Radar-Fixture.
+
+    Der Radar-Test haengt an der echten Wanduhr — er laeuft immer nur zu
+    genau einer Tageszeit, und dort, wo er gerade laeuft, sieht man den Fehler
+    nicht. Die erste Fassung bildete ``start_hour = (end_hour - 6) % 24`` und
+    erzeugte fuer jede Ankunftsstunde < 6 ein MITTERNACHTS-Fenster
+    (``start_hour > end_hour``). Zwischen 00:00 und 05:59 UTC pruefte der Test
+    damit einen anderen Zweig als den, den er beweisen soll — und blieb selbst
+    dann gruen, wenn der Randfall-Guard komplett entfernt war.
+
+    Weil die Uhr im Test nicht gestellt werden kann, ist die Fixture-Rechnung
+    in reine Funktionen ausgelagert. Hier werden sie fuer JEDE Minute eines
+    vollen Tages (1440 Faelle) gegen die beiden Invarianten geprueft:
+
+      1. ``start_hour < end_hour``  -> niemals ein Mitternachts-Fenster
+      2. ``end_hour`` == Ortsstunde der Ankunft -> das Fensterende (HH:00)
+         liegt vor der Ankunft (HH:MM), der Randfall-Guard greift
+
+    Zusaetzlich wird geprueft, dass das Ortsdatum dem UTC-Datum entspricht —
+    ``check_radar_alerts()`` sucht die Etappe ueber ``date.today()`` (UTC).
+    """
+    basis = datetime(2026, 8, 8, tzinfo=timezone.utc)
+    for minute in range(24 * 60):
+        arrival = basis + timedelta(minutes=minute)
+        tz = radar_fixture_tz(arrival)
+        start_hour, end_hour = radar_fixture_window(arrival)
+        lokal = arrival.astimezone(tz)
+
+        assert start_hour < end_hour, (
+            f"F004: Bei Ankunft {arrival.isoformat()} ({lokal.strftime('%H:%M')} "
+            f"Ortszeit, {tz}) ergibt die Fixture start_hour={start_hour} >= "
+            f"end_hour={end_hour} — das ist ein Mitternachts-Fenster. Der "
+            "Radar-Test pruefte dann einen anderen Zweig als den "
+            "Randfall-Guard und bewachte nichts."
+        )
+        assert end_hour == lokal.hour, (
+            f"F004: end_hour={end_hour} passt nicht zur Ortsstunde "
+            f"{lokal.hour} bei {arrival.isoformat()} — das Fensterende laege "
+            "nicht vor der Ankunft und der Randfall-Guard griefe nicht."
+        )
+        assert lokal.date() == arrival.date(), (
+            f"F004: Ortsdatum {lokal.date()} != UTC-Datum {arrival.date()} bei "
+            f"{arrival.isoformat()} ({tz}) — check_radar_alerts() sucht die "
+            "Etappe ueber date.today() in UTC und faende sie nicht."
+        )
+
+
+def test_radarpfad_spaetankunft_faellt_nicht_in_alle_segmente_vorbei():
+    """F003: Derselbe Fall wie AC-3 — aber ueber den RADAR-Pfad.
+
+    AC-3 behauptet in seinem Docstring, er beweise, dass der Trip nicht ueber
+    den „alle Segmente vorbei"-Abbruch in ``trip_alert.py:737-745`` aus der
+    Ueberwachung faellt. Das tut er NICHT: er laeuft ausschliesslich ueber
+    ``check_and_send_alerts()`` (Deviations-Pfad) und beruehrt diesen Code
+    nie. Der Radar-/NowCast-Pfad hat eine eigene Segment-Auswahl — und genau
+    er lieferte im Belegfall von #1584 systemweit keinen Alarm.
+
+    Aufbau (die Zeiten entstehen zur Laufzeit, weil der Radar-Pfad an der
+    echten Wanduhr haengt; Ortszeit == UTC durch Atlantic/Reykjavik):
+
+        Ankunft am Tagesziel   = jetzt - 3 Minuten
+        day_window_end_hour    = Stunde der Ankunft
+        -> Fensterende HH:00 liegt VOR der Ankunft HH:MM
+           => Randfall-Guard greift => Zielsegment [Ankunft, Ankunft + 1 h]
+        -> „jetzt" liegt in diesem Fenster, das Zielsegment ist das aktive
+
+    Ohne den Randfall-Guard kollabiert das Zielsegment (Ende <= Start). Dann
+    ist kein Segment aktiv, ``now`` liegt hinter dem Start des ersten
+    Segments, und der Radar-Pfad nimmt den Zweig „alle Segmente vorbei" —
+    der Trip verschwindet stumm aus der Ueberwachung, obwohl es regnet.
+
+    Geprueft wird die WIRKUNG (zugestellte Mail ueber ``mail_sink``), nicht
+    dass die Funktion durchlaeuft.
+    """
+    mails = _radar_mails_fuer_spaetankunft()
+    assert mails, (
+        "F003: Bei Spaetankunft muss der Radar-Pfad einen Alarm zustellen. Es "
+        "kam keine Mail an — das Zielsegment ist kollabiert, kein Segment gilt "
+        "als aktiv und check_radar_alerts() nimmt den Zweig 'alle Segmente "
+        "vorbei' (trip_alert.py:737-745). Genau so faellt ein Trip stumm aus "
+        "der Ueberwachung."
+    )
+
+
+def test_ac3b_spaetankunft_mindestfenster_reicht_nicht_in_die_nacht():
+    """AC-3 Ergaenzung (Waechter): Das Randfall-Mindestfenster bei Spaetankunft
+    darf NICHT in die Nacht hineinreichen.
+
+    Warum AC-3 diese Aufweichung allein NICHT faengt: dort liegt das Gewitter
+    um 20:45 Ortszeit, also 15 Minuten nach der Ankunft um 20:30 — das ist in
+    JEDEM Mindestfenster ab einer Stunde enthalten. AC-3 beweist, DASS der
+    Guard greift, aber nichts ueber die LAENGE des Fensters; es koennte still
+    auf sechs Stunden wachsen und AC-3 bliebe gruen.
+
+    Nachgerechnet fuer den 08.08. (CEST = UTC+2):
+
+        Ankunft 20:30 Ortszeit         = 18:30 UTC
+        Fensterende 19:00 Ortszeit     = 17:00 UTC  -> <= Ankunft,
+                                         also greift der Randfall-Guard
+        Mindestfenster RICHTIG (1 h)   = 19:30 UTC = 21:30 Ortszeit
+        Mindestfenster AUFGEWEICHT(6h) = 00:30 UTC = 02:30 Ortszeit (Folgetag)
+
+    Das Gewitter liegt um 22:00 Ortszeit (= 20:00 UTC): eine halbe Stunde NACH
+    dem richtigen Mindestfenster-Ende (21:30) und damit ausserhalb — aber
+    mitten in einem aufgeweichten Fenster, das bis in die Nacht reicht.
+
+    Was NICHT funktioniert haette: jeder Zeitpunkt innerhalb der ersten Stunde
+    nach der Ankunft (20:30-21:30 Ortszeit) liegt in BEIDEN Varianten
+    innerhalb — gemessen fuer 21:00 Ortszeit: richtig drin, aufgeweicht drin.
+    Genau das ist der blinde Fleck von AC-3.
+
+    Fachlich ist das die Spaetankunfts-Haelfte derselben PO-Vorgabe, die
+    AC-2b fuer den Normalfall bewacht: nachts geht kein teurer Alarm raus.
+    """
+    mails = _alarm_mails(ALPEN_LAT, ALPEN_LON, "20:30", 22)
+    assert not mails, (
+        "AC-3b: Das Mindestfenster bei Spaetankunft (20:30 Ortszeit) darf nur "
+        "eine Stunde umfassen — ein Gewitter um 22:00 Ortszeit liegt danach "
+        "und darf KEINEN Alarm ausloesen. Tatsaechlich zugestellt: "
+        f"{[s for s, _ in mails]} — das Randfall-Fenster reicht weiter als "
+        "arrival_time + 1 h und ueberwacht damit in die Nacht hinein, obwohl "
+        "AC-2b genau das fuer den Normalfall ausschliesst."
+    )
+
+
+def test_mitternachtsfenster_22_2_klemmt_auf_mindestfenster():
+    """F005 (Waechter): Ein Tagesfenster ueber Mitternacht (``start > end``,
+    hier 22-2 Uhr) fuehrt am Zielsegment zum MINDESTFENSTER — und darf kein
+    ueberweites Fenster erzeugen.
+
+    Ein solches Fenster ist seit #1361/#1372 S1b gueltig, hat aber ein LOCH
+    (hier 2:00-22:00). Das Zielsegment ist ein einzelnes zusammenhaengendes
+    Intervall und kann ein Loch nicht abbilden. PO-Entscheidung 2026-08-08:
+    Mitternachts-Fenster werden am Zielsegment bewusst NICHT unterstuetzt; es
+    greift der Randfall-Guard (Mindestfenster 1 h).
+
+    Dieser Test bewacht die Regression, die beim ersten Loesungsversuch
+    entstanden war: „Fensterende = naechstes Auftreten von ``end_hour`` ab
+    der Ankunft" schuettet das Loch still zu und liefert je nach Ankunftszeit
+    1 h bis fast 24 h Fenster — fuer die meisten Tagesankuenfte (02:01-21:59)
+    sogar 16-24 Stunden. Das widerspricht direkt AC-2b und AC-3b („kein
+    ueberweites Fenster, nachts kein teurer Alarm").
+
+    Nachgerechnet (CEST = UTC+2, Fenster 22-2 Uhr, Ankunft 14:00 Ortszeit):
+
+        Fensterende 02:00 Ortszeit am Ankunftstag liegt VOR der Ankunft
+        -> Randfall-Guard -> Zielsegment 14:00-15:00 Ortszeit
+        (verworfene Wrap-Variante haette bis 02:00 des Folgetags gereicht
+         = 12 Stunden, bei Ankunft 02:30 sogar 23,5 Stunden)
+
+    Das Gewitter liegt um 23:00 Ortszeit: ausserhalb des Mindestfensters,
+    aber mitten in der verworfenen Wrap-Variante. Was NICHT funktioniert
+    haette: jeder Zeitpunkt zwischen 14:00 und 15:00 Ortszeit laege in
+    BEIDEN Varianten innerhalb und bewiese nichts.
+    """
+    mails = _alarm_mails(ALPEN_LAT, ALPEN_LON, "14:00", 23, day_window=(22, 2))
+    assert not mails, (
+        "F005: Bei einem Mitternachts-Tagesfenster (22-2 Uhr) greift am "
+        "Zielsegment das Mindestfenster (14:00-15:00 Ortszeit) — ein Gewitter "
+        "um 23:00 Ortszeit liegt ausserhalb und darf KEINEN Alarm ausloesen. "
+        f"Tatsaechlich zugestellt: {[s for s, _ in mails]} — das Fensterende "
+        "wurde offenbar auf den Folgetag geschoben (Wrap-Behandlung). Damit "
+        "entsteht ein 12- bis 24-stuendiges Alarmfenster, das AC-2b und AC-3b "
+        "aushebelt."
+    )
+
+
+def test_ac4_ziel_ausserhalb_mitteleuropas_nutzt_ortszeit_am_ziel():
+    """AC-4: Ziel in America/Los_Angeles (UTC-7/-8). Gewitter 17:00 ORTSZEIT
+    am Ziel. Bei fest verdrahtetem Europe/Vienna laege das Fensterende vor
+    der Ankunft und der Alarm bliebe aus."""
+    mails = _alarm_mails(SIERRA_LAT, SIERRA_LON, "13:18", 17)
+    assert mails, (
+        "AC-4: Die Fenstergrenze muss nach der Ortszeit am ZIEL aufgeloest "
+        "werden (tz_for_coords der letzten Wegpunkt-Koordinate). Es kam keine "
+        "Mail an — entweder gilt weiterhin arrival_time + 2 h oder das Fenster "
+        "wurde in Europe/Vienna statt in America/Los_Angeles berechnet."
+    )
+
+
+def test_ac4b_westzone_spaete_ankunft_fenster_endet_am_ortstag():
+    """AC-4 Ergaenzung (Waechter): Der Kalendertag des Fensterendes ist der
+    LOKALE Ankunftstag am Ziel — nicht der UTC-Tag.
+
+    Warum AC-4 diese Verwechslung allein NICHT faengt: dort kommt der Trip um
+    13:18 Ortszeit an; in America/Los_Angeles (UTC-7) ist das 20:18 UTC am
+    SELBEN Datum. UTC-Tag und Ortstag stimmen ueberein, ein Vertauschen der
+    beiden bleibt folgenlos und AC-4 bleibt gruen.
+
+    Hier kommt der Trip um 18:00 Ortszeit an — damit faellt die Ankunft in UTC
+    bereits auf den Folgetag und die beiden Tagesbegriffe trennen sich
+    (nachgerechnet fuer den 08.08., PDT = UTC-7):
+
+        Ankunft 18:00 Ortszeit      = 09.08. 01:00 UTC  (UTC-Datum 09.08.,
+                                                         Ortsdatum 08.08.)
+        Fensterende RICHTIG (Ortstag) = 08.08. 19:00 Ortszeit
+                                      = 09.08. 02:00 UTC
+        Fensterende FALSCH  (UTC-Tag) = 09.08. 19:00 Ortszeit
+                                      = 10.08. 02:00 UTC   -> 24 h zu lang
+
+    Das Gewitter liegt um 22:00 Ortszeit am Ankunftstag (= 09.08. 05:00 UTC):
+    drei Stunden NACH dem richtigen Fensterende und damit klar ausserhalb —
+    aber mitten im 24 h zu langen Fenster der UTC-Tag-Variante. Genau diese
+    Differenz trennt die Faelle. 18:30 Ortszeit laege in BEIDEN Varianten
+    innerhalb, 20:00 Ortszeit des Folgetages in BEIDEN ausserhalb; beide
+    bewiesen nichts (derselbe Fehler wie beim urspruenglichen AC-2).
+
+    Fachlich bewacht der Test dieselbe PO-Vorgabe wie AC-2b: nachts geht kein
+    Alarm raus. Ein um einen ganzen Tag verschobenes Fenster wuerde das
+    Tagesziel die komplette Nacht und den Folgetag hindurch ueberwachen.
+    """
+    mails = _alarm_mails(SIERRA_LAT, SIERRA_LON, "18:00", 22)
+    assert not mails, (
+        "AC-4b: Das Fensterende muss am LOKALEN Ankunftstag am Ziel gebildet "
+        "werden. Ein Gewitter um 22:00 Ortszeit liegt nach dem Fensterende "
+        "19:00 desselben Tages und darf KEINEN Alarm ausloesen. Tatsaechlich "
+        f"zugestellt: {[s for s, _ in mails]} — der Kalendertag stammt "
+        "offenbar aus dem UTC-Zeitstempel der Ankunft (arrival_time.date()) "
+        "statt aus arrival_time.astimezone(dest_tz).date(); westlich von "
+        "Greenwich ist das der Folgetag und das Fenster 24 h zu lang."
+    )
+
+
+def test_ac5_alt_trip_ohne_tagesfenster_nutzt_default_4_19():
+    """AC-5 (strukturell, von der Spec ausdruecklich als Ausnahme von der
+    Wirkungs-Regel ausgewiesen): Alt-Trip ohne ``day_window_*`` -> Default
+    4/19, Fensterende 19:00 Ortszeit am Ankunftstag."""
+    tz = tz_for_coords(ALPEN_LAT, ALPEN_LON)
+    day = date.today()
+    trip = _trip("t-ac5-alttrip", ALPEN_LAT, ALPEN_LON, day, "13:18")
+    assert trip.report_config.day_window_start_hour is None
+    assert trip.report_config.day_window_end_hour is None
+
+    dest = convert_trip_to_segments(trip, day)[-1]
+    expected = _utc(tz, day, 19)
+    assert dest.segment_id == "Ziel"
+    assert dest.end_time == expected, (
+        "AC-5: Ein Trip ohne konfiguriertes Tagesfenster muss den Default "
+        f"4/19 verwenden — das Ziel-Segment muss um {expected.isoformat()} "
+        f"(19:00 Ortszeit) enden, tatsaechlich: {dest.end_time.isoformat()} "
+        "(= Ankunft + 2 h)."
+    )
+
+
+def test_ac6_konfiguriertes_fenster_6_16_schliesst_gewitter_1630_aus():
+    """AC-6 (Waechter, kein RED-Test — s. Spec): Tagesfenster abweichend auf
+    6-16 Uhr konfiguriert, Ankunft 13:18, Gewitter 16:30 Ortszeit.
+
+    16:30 liegt ZWISCHEN der konfigurierten Obergrenze (16:00) und der
+    Default-Obergrenze (19:00) — genau deshalb trennt dieser Zeitpunkt die
+    Faelle: bei hartcodiertem ``(4, 19)`` laege er innerhalb, der Alarm ginge
+    faelschlich raus. 15:30 laege in beiden Varianten innerhalb, 19:30 in
+    beiden ausserhalb; beide bewiesen nichts (derselbe Fehler wie beim
+    urspruenglichen AC-2).
+    """
+    mails = _alarm_mails(ALPEN_LAT, ALPEN_LON, "13:18", 16, day_window=(6, 16))
+    assert not mails, (
+        "AC-6: Bei konfiguriertem Tagesfenster 6-16 Uhr liegt ein Gewitter um "
+        "16:30 Ortszeit AUSSERHALB — es darf kein Alarm zugestellt werden. "
+        f"Tatsaechlich zugestellt: {[s for s, _ in mails]}. Das Ziel-Segment "
+        "reicht bis zur Default-Obergrenze 19:00 statt bis zur konfigurierten "
+        "16:00 — resolve_configured_window() wird nicht (oder mit einem "
+        "hartcodierten (4, 19)) aufgerufen, die Einstellbarkeit ist ausgehebelt."
+    )

--- a/tests/unit/test_destination_segment.py
+++ b/tests/unit/test_destination_segment.py
@@ -99,6 +99,19 @@ class TestSchedulerDestinationSegment:
         assert abs(dest[0].start_point.lat - 39.7662) < 0.01
 
     def test_destination_segment_time_window(self):
+        """Issue #1584: Das Ziel-Segment endet am Tagesfenster-Ende in ORTSZEIT
+        am Ziel, nicht mehr hart bei Ankunft + 2 h.
+
+        Der alte Vertrag (``+ timedelta(hours=2)``) schaltete die Gefahren-
+        Ueberwachung fuer das Tagesziel zwei Stunden nach Ankunft ab und ist
+        mit ``fix_1584_alarm_zeitfenster`` ungueltig geworden. Die Erwartung
+        wird hier UNABHAENGIG vom Prueflings-Code aus der Fixture gebildet:
+        ``gr221-mallorca.json`` setzt kein ``day_window_end_hour``, also gilt
+        der dokumentierte Default 19 Uhr (``app.day_window``), aufgeloest in
+        der Zeitzone des letzten Wegpunkts.
+        """
+        from zoneinfo import ZoneInfo
+
         segments = self._load_trip_and_get_segments()
         normal_segments = [s for s in segments if s.segment_id != "Ziel"]
         dest = [s for s in segments if s.segment_id == "Ziel"]
@@ -106,7 +119,26 @@ class TestSchedulerDestinationSegment:
 
         last_normal_end = max(s.end_time for s in normal_segments)
         assert dest[0].start_time == last_normal_end
-        assert dest[0].end_time == last_normal_end + datetime.timedelta(hours=2)
+
+        tz = ZoneInfo("Europe/Madrid")  # Mallorca, Ziel des GR221
+        arrival_local = last_normal_end.astimezone(tz)
+        expected_end = (
+            datetime.datetime.combine(
+                arrival_local.date(), datetime.time(19, 0)
+            )
+            .replace(tzinfo=tz)
+            .astimezone(datetime.timezone.utc)
+        )
+        assert dest[0].end_time == expected_end, (
+            "Ziel-Segment muss bis 19:00 Ortszeit (Default-Tagesfenster) "
+            f"reichen, erwartet {expected_end.isoformat()}, tatsaechlich "
+            f"{dest[0].end_time.isoformat()}"
+        )
+        # Ankunft 12:20 Ortszeit -> deutlich mehr als die alten fixen 2 h.
+        assert dest[0].duration_hours > 2.0
+        assert dest[0].duration_hours == (
+            expected_end - last_normal_end
+        ).total_seconds() / 3600
 
 
 class TestFormatterDestinationRendering:


### PR DESCRIPTION
Behebt #1584 — die tatsächliche Ursache dafür, dass system-weit nie ein Gewitter-Alarm zugestellt wurde.

## Problem

Das Ziel-Segment einer Etappe endete hart bei `arrival_time + timedelta(hours=2)` (`trip_segments.py:258`). Da **beide** Alarmpfade und die Wetter-Aggregation `segment.end_time` lesen, war die Gefahren-Überwachung für den Zielort zwei Stunden nach Ankunft abgeschaltet — und die Alarmregel `thunder_level` konnte **strukturell nie** auslösen, wenn das Gewitter danach lag.

Die zwei Stunden waren ursprünglich ein Aktivitäts-Marker für den Radar-Check (#822) und wurden stillschweigend zur alleinigen Quelle für „Wetter am Zielort".

**Belegter Vorfall (2026-08-07, Trip „KHW 403"):** Etappe endete 11:18 UTC, ab 11:30 meldete der Check durchgehend `No fresh weather data` (15× im Log). Um 15:00 und 16:00 UTC zog ein Gewitter mit Hagel (WMO 96, Böen bis 44 km/h, 18,7 mm) über das Tagesziel. Kein Alarm.

## Lösung

Das Ziel-Segment endet zur **ortszeit-aufgelösten** `day_window_end_hour` (Tagesfenster, Default 19 Uhr).

Der Eingriff sitzt an **einer** Stelle: `trip_alert.py`, `weather_change_detection.py` und `segment_weather.py` sind **unverändert** — sie lesen weiterhin `segment.end_time` und ziehen automatisch nach. Verifiziert per `git diff --stat`: null Zeilen.

Zeitzone über das im selben File etablierte `tz_for_coords`-Muster. **Maßgeblich ist der lokale Ankunftstag, nicht der UTC-Tag** — westlich von Greenwich fallen beide auseinander und das Fenster wäre 24 Stunden zu lang.

## Bewusst nicht unterstützt

Tagesfenster über Mitternacht (`start_hour > end_hour`, seit #1361 gültig) werden am Ziel-Segment nicht abgebildet; dort greift ein Mindestfenster von einer Stunde. Ein solches Fenster hat ein Loch (z.B. 2:00–22:00), das ein zusammenhängendes Segment nicht darstellen kann. Der naheliegende Fix wurde gebaut, erzeugte Fenster von 16 bis 24 Stunden und wurde nach PO-Entscheidung zurückgenommen. ADR-0035 hält das fest, ein Test bewacht die Rücknahme.

## Prüfung — vier Adversary-Runden, zweimal BROKEN

| Runde | Befund |
|---|---|
| 2 | **Der Radar-Pfad war ungetestet**, obwohl ein AC ausdrücklich behauptete, ihn zu bewachen — ausgerechnet der Pfad, der nie einen Alarm lieferte. Zusätzlich: Wrap-Fenster nicht behandelt. |
| 3 | Der Wrap-Fix erzeugte **16–24-Stunden-Fenster**. Der neue Radar-Test war zwischen 00:00 und 05:59 UTC **blind** — live um 05:34 reproduziert. |
| 4 | **VERIFIED.** Rücknahme per Diff gegen Baseline belegt, Fensterlängen an 9 Ankunftszeiten nachgemessen (0,02–2,0 h statt 1–24 h), Radar-Test live um 05:57 UTC in der zuvor blinden Stunde verifiziert. |

Alle 9 Acceptance Criteria hängen am **echten Alarmversand** (`mail_sink` über `TripAlertService`), nicht an Zwischenwerten. Einzige Ausnahme ist AC-5 (Rückwärtskompatibilität eines Defaults), in der Spec ausdrücklich als strukturell ausgewiesen.

Mutations-Matrix: 5 von 6 Verfälschungen werden gefangen; die sechste (`<=` → `<`, Schaden wäre ein Segment der Länge null) ist nach #1199 gebucht.

## Nebenbefund mitrepariert

Zwei Tests in `test_issue_303_waypoint_suggestions.py` waren **seit jeher aus einem Zufall grün**: Sie verglichen Ortszeit-Ziffern mit UTC-Stunden und trafen nur, weil das alte 2-Stunden-Fenster zufällig dem CEST-Versatz (+2 h) entsprach. Sie laufen in CI und wären durch diesen Fix rot geworden. Der Vergleich läuft jetzt auf Ortszeit; der Test prüft, was er behauptet.

## Testlage

- 34 Tests der Änderung grün, Kern-Suite **1079 grün**, keine Regression
- `test_forecast_cache_sharing.py` grün — die Schutzabsicht aus #1329 gilt **pro Aufrufer**, nicht pro Segmentgröße, und wird nicht verletzt
- `test_adr_index_drift.py` grün nach der ADR-Ergänzung

## Folge-Scheiben (nicht in diesem PR)

1. Ruhezeiten-Prüfung im Radar-Pfad **vor** den Segment-Check ziehen (`trip_alert.py:737-750`) — verhindert, dass dieselbe Konstellation erneut entstehen kann
2. Tagesfenster beim Trip-Anlegen editierbar (`WeatherMetricsTab.svelte:1244`) — durch die Alarmrelevanz aufgewertet
3. Prüfen, ob der Compare-Pfad dieselbe Zeitfenster-Bindung hat
4. Ziel-Segment für Mitternachts-Fenster aufspalten

Spec: `docs/specs/modules/fix_1584_alarm_zeitfenster.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
