### PR TITLE
docs: Gewitter-Gesamtkonzept — Ende zu Ende, mit vier neuen Befunden

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@
 | `reference/` | Technische Referenz: `api_contract.md` (DTOs, SSOT — driftgesichert via `tests/test_api_contract_drift.py`), `decision_matrix.md` (Provider-Ist-Stand), `operations_playbook.md` (Deploy/E2E/Rollback), `mail_validators.md`, `navigation.md` (URL-Modell), `frontend_components.md` (Konzepte, kein Inventar), `design_system.md`, `critical_lessons.md` (Regeln ohne anderen Wächter) |
 | `adr/` | Architektur-Entscheidungen (nummeriert; Status beachten — einzelne sind superseded) |
 | `design-system/` | CHARTER, COMPONENTS, TOKENS, SCREENS |
-| `features/` | `architecture.md` (Systemarchitektur), `scope.md` (Vision), `openspec_workflow.md` (Workflow-Wegweiser) + aktive Epic-Dokumente |
+| `features/` | `architecture.md` (Systemarchitektur), `scope.md` (Vision), **`gewitter-gesamtkonzept.md`** (Gewitter Ende zu Ende: was der Nutzer sieht, wie die Stufe entsteht, Eichung, Fahrplan — führend gegenüber den Einzel-Specs), `openspec_workflow.md` (Workflow-Wegweiser) + aktive Epic-Dokumente |
 | `project/` | `known_issues.md` (Root-Cause-Archiv), Architektur-Programm 2026-07. (`strategic-directions.md` 2026-08-05 aufgelöst, #1166 — strategische Entscheidungen leben in `docs/adr/`) |
 | `runbooks/` | Betriebsanleitungen (z. B. `telegram-webhook.md`) |
 

--- a/docs/context/feat-1531-dwd-gewittergroessen.md
+++ b/docs/context/feat-1531-dwd-gewittergroessen.md
@@ -1,0 +1,169 @@
+# Context: feat-1531-dwd-gewittergroessen (#1531 Scheibe 1)
+
+## Request Summary
+
+#1457 (S2) wurde geschlossen, obwohl von den in Epic #1419 §2a/§3.2 vereinbarten DWD-Gewitter-
+größen nur zwei abgerufen werden. Diese Scheibe holt die fehlenden ICON-D2-Größen nach
+(`sdi_2`, `cin_ml`, `cape_ml`, `lpi_max`, `uh_max`) sowie die Energiegrößen aus ICON-EU.
+DWD ist kontingentfrei — die Größen liegen in denselben Verzeichnissen, aus denen täglich
+geladen wird.
+
+**Abgrenzung:** Nur **Abruf und Feldbefüllung**. Keine Einstufung, keine Schwellen, keine
+Ausgabe — der Provider füllt Felder und kennt keine Stufen (#1419 §5). Météo-France ist eine
+eigene Scheibe (Kostenasymmetrie: dort ein Abruf je Größe **und** Stunde).
+
+## 🟢 Vorbedingung geklärt — Abrufnamen gegen das echte Angebot geprüft
+
+Gemessen 2026-08-08 gegen das Verzeichnislisting von `opendata.dwd.de`. Das ist die Lehre aus
+#1457 S2a, wo `LITOTA3` beim Dienst gar nicht existierte und jeder Abruf lautlos in 404 lief —
+bei 24 grünen Tests.
+
+| Größe | ICON-D2 (129 Parameter) | ICON-EU (94 Parameter) |
+|---|---|---|
+| `sdi_2` | ✅ | ❌ **nicht angeboten** |
+| `cin_ml` | ✅ | ✅ |
+| `cape_ml` | ✅ | ✅ |
+| `lpi_max` | ✅ | ❌ (dort `lpi_con_max`) |
+| `uh_max` (+ `uh_max_low`, `uh_max_med`) | ✅ | ❌ **nicht angeboten** |
+| `cape_con` | ❌ nicht angeboten | ✅ |
+| `sdi_1` | ❌ nicht angeboten | ❌ |
+
+Alle vorhanden **auch als `regular-lat-lon`** — das ist das Gitter, das `_build_url`
+(`dwd.py:190`) verwendet. Dateien real abrufbar (HTTP 206 bei Range-Request).
+
+Dass `sdi_2` in ICON-EU fehlt, deckt sich mit der DWD-Aussage, dass der Index für gröbere
+Auflösungen nicht gilt („nicht auf das COSMO-EU übertragbar").
+
+## 🟢 Semantik je Größe — gemessen, nicht angenommen
+
+Punkt 47,40 N / 11,00 O (Tirol) sowie am jeweiligen Feldmaximum, Lauf 21 UTC:
+
+| Größe | Verlauf | Einstufung | nodata |
+|---|---|---|---|
+| `cin_ml` | 1,41 → 1,69 → 1,88 → 8,29 → 11,63 → 17,44 → 73,97 → **71,01** → **3,91** | **Momentanwert** (fällt 2×) | 9999.0 |
+| `cape_ml` | 169 → 94,6 → 74,3 → 58,1 → 71,9 → 38 → 6,1 | **Momentanwert** (fällt 6×) | 9999.0 |
+| `uh_max` | −0,001 → 0,002 → 0,016 → 0,032 → 0,031 → 0,011 | **Momentanwert** (fällt 3×) | 9999.0 |
+| `sdi_2` | am Maximum: 0 → **−0,0007** → 0 | **Momentanwert** | 9999.0 |
+| `lpi_max` | am Maximum: 0 → **95,45** → **88,69** → 0 | **Momentanwert** (fällt 2×) | 9999.0 |
+| `grau_gsp` *(Bestand)* | nie fallend | **kumuliert** (unverändert) | 9999.0 |
+
+⇒ **Keine der fünf neuen Größen gehört in `THUNDER_CUMULATIVE_PARAMS`.** Wichtig, weil ein
+kumulierter Parameter, der dort fehlt, den seit Laufbeginn aufsummierten Wert still
+durchreichen würde (`dwd.py:453-456`, `else`-Zweig).
+
+⚠️ `lpi_max` musste **am Feldmaximum** gemessen werden — am ursprünglichen Messpunkt war es
+durchgehend 0, dort wäre die Frage unbeantwortbar geblieben und „nie fallend" hätte fälschlich
+nach kumuliert ausgesehen.
+
+## 🟢 Skalen tragen die publizierten Schwellen
+
+Maximum über das gesamte ICON-D2-Gitter (Beträge), Lauf 21 UTC:
+
+| Größe | Feld-Maximum | publizierte Schwelle | erreichbar? |
+|---|---|---|---|
+| `sdi_2` | 0,000739 | 0,0003 / 0,003 1/s | ✅ minimale Schwelle erreicht |
+| `uh_max` | 126,9 | (US-Werte 75/150 — **nicht übertragbar**) | Skala plausibel |
+| `lpi_max` | 95,45 | 1 / 30 / 50 | ✅ |
+| `cape_ml` | 4233 | 1000 / 2000 | ✅ |
+| `cin_ml` | 526 (echte Werte, ohne Marker) | — | ✅ plausibel |
+
+**`sdi_2` trägt am Maximum ein negatives Vorzeichen (−0,0007).** Bestätigt die DWD-Regel:
+Vorzeichen kodiert den Rotationssinn (`>0` zyklonal, `<0` antizyklonal) ⇒ **Betrag verwenden**.
+Wer das Vorzeichen ignoriert, verliert die antizyklonalen Superzellen vollständig.
+
+## 🔴 Risiken und offene Punkte
+
+1. **GRIB-Metadaten sind für DWD-Spezialgrößen fehlzugeordnet.** GDAL meldet für `sdi_2`
+   „Best (4 layer) Lifted Index **[C]**" — das ist nicht der Supercell Detection Index (DWD:
+   Einheit 1/s). `lpi_max` kommt als „(prodType 0, cat 17, subcat 192) [-]", also unbekannt.
+   ⇒ Einheiten/Bedeutung **niemals** aus `ds.tags()` ableiten; maßgeblich ist die
+   DWD-Dokumentation plus Plausibilitätsprüfung gegen die publizierten Schwellen.
+2. **🔴 `cin_ml` hat einen ZWEITEN Fehlwert-Marker: −999,9 — bei 46 % aller Gitterpunkte.**
+   Gemessen über das gesamte Gitter (+6 h, 906.390 Punkte):
+
+   | Größe | Anteil 9999,0 (außer Gebiet) | Anteil **−999,9** | echte Werte |
+   |---|---|---|---|
+   | `cin_ml` | 16,7 % | **46,0 %** | 0,006 … 526 J/kg (P50 = 7,8) |
+   | `cape_ml` | 16,7 % | 0,0 % | 0 … 3950 J/kg |
+   | `sdi_2` | 16,7 % | 0,0 % | −0,000151 … 0,000454 |
+   | `uh_max` | 16,7 % | 0,0 % | −11,2 … 15,5 |
+   | `lpi_max` | 16,7 % | 0,0 % | 0 … 33,1 |
+
+   Der bestehende Filter prüft `wert >= sentinel` mit `sentinel = 9999,0`
+   (`dwd.py:212-217`) — **−999,9 ist kleiner und würde durchgereicht**, als
+   Konvektionshemmung von −999,9 J/kg. Fachlich fatal: genau daraus würde später „praktisch
+   kein Deckel, CAPE schlägt voll durch" gelesen, und das bei fast der Hälfte der Punkte.
+   Plausible Bedeutung: CIN ist undefiniert, wo keine Konvektion möglich ist (ohne CAPE gibt
+   es nichts zu hemmen) — also **„keine Aussage", nicht „keine Hemmung"** (`None`-Kontrakt
+   #1377). Die 16,7 % bei 9999,0 decken sich exakt mit dem dokumentierten Überstand des
+   ausgelieferten Rechtecks („rund 17 % größer als das Modellgebiet", `dwd.py:96-97`).
+
+   Präzedenz mahnt zusätzlich: `dwd_eu.py:219-221` hält fest, der Analogieschluss vom
+   D2-Fehlwert wäre „der dritte Analogieschluss in Folge, der sich als falsch erweist".
+3. **Der Live-Namenswächter deckt die neuen Parameter nicht ab.**
+   `tests/tdd/test_dwd_thunder_parameter_names_live.py:44` parametrisiert hartkodiert über
+   `param_index in [0, 1]` statt über `len(dwd.THUNDER_PARAMS)`. Wird `THUNDER_PARAMS`
+   erweitert, prüft der Wächter die neuen Namen **stillschweigend nicht** — ein Test, der
+   nicht scheitern kann. Muss mit erweitert werden.
+4. **Stiller Teilausfall bei Budget-Ende.** `_thunder_budget_erschoepft` bricht die innere
+   Offset-Schleife ab (`dwd.py:446-448`) und danach die äußere (`:457-458`). Die Parameter, die
+   in der Iterationsreihenfolge **hinten** stehen, werden dann gar nicht erst angefragt und
+   bleiben komplett leer — ohne Meldung. Die Reihenfolge in `THUNDER_PARAMS` entscheidet damit
+   fachlich, was im Zweifel ausfällt.
+5. **`cape_jkg` ist bereits belegt.** Das Feld existiert (`models.py:113`) und wird von einer
+   anderen Quelle gefüllt. Ob `cape_ml` dorthin darf oder ein eigenes Feld braucht, ist zu
+   entscheiden — ein gemeinsames Feld für zwei Quellen widerspräche „je Größe ein eigenes
+   Feld" (#1419 §3.1/§5).
+
+## 🟢 Zeitbudget — entwarnt, aber knapp im Randfall
+
+Gemessen über 10 echte Abrufe: **Mittel 0,24 s** je Abruf (Spanne 0,05–1,14 s; entpackt
+1,6–6,5 MB je Datei).
+
+| | Abrufe | erwartete Dauer | Budget |
+|---|---|---|---|
+| heute (2 Größen × 24 h + Anker) | 49 | ~12 s | 90 s |
+| geplant (7 Größen × 24 h) | 168 | **~40 s** | 90 s |
+| ungünstiger Fall (1,14 s je Abruf) | 168 | **~191 s** | 🔴 reißt |
+
+Der im Code hinterlegte Richtwert von ~1,9 s je Abruf stammt aus der **Météo-France**-Herleitung
+(`dwd.py:105-106`) und trifft für den DWD nicht zu — er überschätzt um das Achtfache. Das
+Budget trägt den Regelfall bequem; für den Randfall ist zu entscheiden, ob
+`THUNDER_FETCH_DEADLINE_SECONDS` steigt oder die Parameter-Reihenfolge fachlich priorisiert
+wird (siehe Risiko 4). Abrufe laufen **sequenziell** (kein Threading/async im Modul).
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/providers/dwd.py:86` | `THUNDER_PARAMS = ("lpi", "grau_gsp")` — zentrale Erweiterung |
+| `src/providers/dwd.py:93` | `THUNDER_CUMULATIVE_PARAMS` — bleibt unverändert |
+| `src/providers/dwd.py:100` | `THUNDER_FILL_VALUE`, genutzt in `_read_point_value:212-217` |
+| `src/providers/dwd.py:108` | `THUNDER_FETCH_DEADLINE_SECONDS = 90.0` |
+| `src/providers/dwd.py:382-469` | `fetch_thunder_signals_named` — Abrufschleife, Budget-Abbruch |
+| `src/providers/dwd_eu.py:88` | `THUNDER_PARAMS = ("lpi_con_max",)`; eigenständige Implementierung |
+| `src/providers/dwd_eu.py:96` | `_SIGNAL_KEYS` mappt `lpi_con_max` → `lpi` |
+| `src/providers/thunder_enrichment.py:36-39` | `_SIGNAL_ZU_FELD` — kennt heute zwei Signale |
+| `src/providers/thunder_enrichment.py:261-268` | `setattr(dp, feld, wert)`, nur wenn nicht `None` |
+| `src/app/models.py:113, 151, 160, 161` | bestehende Gewitterfelder; fünf neue kommen dazu |
+| `src/providers/thunder_routing.py:63-67` | Gebietszuordnung `fr_direct` / `de_direct` / `eu_direct` |
+| `tests/tdd/test_dwd_thunder_parameter_names_live.py:44` | Live-Namenswächter, hartkodiert auf 2 Parameter |
+| `tests/tdd/test_dwd_thunder_signal_fetch.py` | Kernabdeckung (Anker, Fehlwert, Budget, Fallback) |
+
+## Dependencies
+
+- **Upstream:** `opendata.dwd.de` ICON-D2 und ICON-EU (frei, kontingentfrei)
+- **Downstream:** `ForecastDataPoint`-Felder → später Fusion in `thunder_level_from_signals()`
+  (`metric_format.py:326`). **In dieser Scheibe bewusst nicht angeschlossen** — erst wenn die
+  Felder da sind und Messwerte vorliegen (Muster #1474).
+
+## Open Questions
+
+- [ ] Bekommt `cape_ml` ein eigenes Feld oder teilt es sich `cape_jkg` mit der anderen Quelle?
+      (Empfehlung: eigenes Feld — „je Größe ein eigenes Feld", #1419 §3.1/§5)
+- [x] Ist `cin_ml = 999,9` ein Deckel oder ein Fehlwert? → **Geklärt: −999,9 ist ein zweiter
+      Fehlwert-Marker bei 46 % der Punkte, muss zu `None` werden.**
+- [ ] Steigt das Zeitbudget, oder wird die Parameter-Reihenfolge fachlich priorisiert?
+      (Regelfall ~40 s von 90 s; Randfall reißt)
+- [ ] Werden `uh_max_low`/`uh_max_med` mitgeholt? Beide sind verfügbar, aber ohne belegte
+      Schwelle und ohne offizielle DWD-Felddefinition — Empfehlung: **nein**, nicht auf Vorrat.

--- a/docs/features/gewitter-gesamtkonzept.md
+++ b/docs/features/gewitter-gesamtkonzept.md
@@ -166,6 +166,40 @@ Superzellenlagen erreicht wird, ist offen. Zudem nennt der DWD den Index selbst 
 
 ⇒ Deshalb: **erst Felder befüllen und mitlaufen lassen, dann einstufen.** Nicht umgekehrt.
 
+### 3.4b 🔴 CAPE ≠ CAPE — eine Schwelle auf unvergleichbare Werte (gemessen 2026-08-08)
+
+**CAPE ist ein modellabhängiges Konstrukt, kein Messwert.** Die Modelle unterscheiden sich in
+der Parcel-Wahl: ICON liefert **Mixed-Layer**-CAPE (`CAPE_ML`), Météo-France **Most-Unstable**
+(`CAPE_INS`), GFS **Surface-Based**. Open-Meteo reicht die native Variable je Modell durch —
+**ohne zu harmonisieren und ohne es zu dokumentieren**.
+
+Unser Code holt `cape_jkg` über Open-Meteo (`openmeteo.py:870`) und prüft es gegen **eine**
+Schwelle von 1000 J/kg (`metric_format.py::_cape_low_min_jkg`), unabhängig vom Modell. Gemessen
+am selben Ort, zur selben Stunde:
+
+| Südfrankreich | CAPE-Maximum | P90 | Anteil Stunden ≥ 1000 J/kg |
+|---|---|---|---|
+| **AROME** (unser Modell für Frankreich, Priorität 1) | 840 | 460 | **0,0 %** |
+| ICON-D2 | 1730 | 1340 | 17,3 % |
+| ICON-EU | 2560 | 1850 | 31,9 % |
+| ECMWF | 3670 | 3520 | **65,3 %** |
+| GFS | 2530 | 2130 | 40,3 % |
+
+Dieselbe Schwelle löst je nach Modell **nie** oder in **zwei Dritteln** aller Stunden aus. Auch
+auf Korsika erreicht AROME an keiner Stunde 1000 J/kg, während ICON-EU dort 29 % meldet.
+
+⇒ **Das CAPE-Signal ist in der Gewitterfusion für Frankreich faktisch wirkungslos.** Eines der
+vier Signale trägt dort nichts bei — nicht weil keine Energie da wäre, sondern weil eine
+Schwelle aus einer anderen Modellwelt angelegt wird. Das ist unabhängig von allem anderen in
+diesem Konzept zu beheben:
+
+- entweder **Perzentil- statt Absolutschwelle** („CAPE > 95. Perzentil **dieses** Modells"),
+- oder **je Modell eine eigene Schwelle**, geeicht wie in 4.5 beschrieben,
+- oder CAPE nur dort werten, wo die Schwelle belegt gilt.
+
+Dieselbe Falle gilt für jede künftige Modellgröße: **Feste Schwellen nie über Modellgrenzen
+tragen.**
+
 ### 3.5 Die CAPE-Deckelung ist belegt ersetzbar (Recherche 2026-08-08)
 
 Die heutige Notbremse („CAPE eskaliert nie über *leicht*") existiert nur, weil uns die
@@ -414,8 +448,12 @@ es überhaupt" nennt. Die drei geeichten Werte lägen zudem eng beieinander (155
 ein sicheres Zeichen, dass im dünnen Ausläufer der Verteilung gerechnet wurde.
 
 **Der Grund ist die Datenbasis, nicht das Verfahren:** eine einzelne, ruhige Wetterlage ist
-keine Klimatologie. Für eine belastbare Eichung braucht es mehrere Wochen über verschiedene
-Lagen — was mit dem laufenden Abruf (Rang 4) ohnehin anfällt.
+keine Klimatologie. Nötig ist mindestens **eine Konvektionssaison (April–September)**.
+
+🟢 **Und dafür braucht es kein eigenes Archiv:** Open-Meteo stellt mit der **Historical
+Forecast API / Previous Runs API** genau diese historischen Modellläufe bereit. Die Eichung ist
+damit **sofort rechenbar** und nicht, wie zuvor angenommen, durch wochenlanges Sammeln
+blockiert. Das verschiebt die Feineichung (Rang 7) nach vorn.
 
 ⇒ **Antwort auf E1b: ja, ICON-EU braucht eine eigene Leiter** — aber sie wird nicht geraten,
 sondern aus gesammelten Daten geeicht. Bis dahin darf die ICON-EU-Stufe nicht so behandelt
@@ -496,6 +534,17 @@ für Italien. Gewitter erscheint dort als `hazard="thunderstorm"`.
 🔴 **Für Deutschland ist kein Warndienst registriert.** Der DWD betreibt einen amtlichen
 Warndienst, wir binden ihn nicht an. Wer in Deutschland unterwegs ist, bekommt also
 Gewitterwarnungen der Behörde nicht — anders als in Frankreich, Italien und Österreich.
+
+**Der einfachste Weg dorthin (E6)** ist nicht der DWD-Einzelanschluss, sondern der
+**Meteoalarm-Feed**: EUMETNET betreibt damit die fertige EU-weite Harmonisierung — jeder
+nationale Dienst mappt seine Warnungen **selbst** auf Gelb/Orange/Rot, Awareness-Type
+**3 = Thunderstorm**. Maschinenzugang kostenlos über CAP-Feeds (`feeds.meteoalarm.org`) und die
+OGC-EDR-API (`api.meteoalarm.org`, GeoJSON, auch historisch), CC BY 4.0.
+
+⇒ **Nicht selbst mappen — das offizielle Mapping konsumieren.** Das deckt Deutschland und alle
+übrigen Zielgebiete in einem Schritt ab. Einzige Verluststelle: DWD-Stufen 3 und 4 fallen bei
+Meteoalarm beide auf Rot zusammen. Wer die feinere DWD-Abstufung braucht, nimmt zusätzlich den
+DWD-CAP-Feed (auch über BrightSky `/alerts` erreichbar).
 
 Auch hier gilt: **Die amtliche Warnung ist mit der berechneten Stufe nicht verknüpft.** In
 `official_alerts.py` (1919 Zeilen) kommt `thunder_level` kein einziges Mal vor. Die beiden
@@ -622,7 +671,8 @@ CAPE-Deckelung zu ersetzen. #1531 ist damit **nicht** eine spätere Scheibe, son
 
 | Rang | Scheibe | Warum hier | Stand |
 |---|---|---|---|
-| **1** | **Fehlende DWD-Größen abrufen** (#1531) — Felder befüllen, **nicht** einstufen | Liefert `lpi_max` (gleiche Statistik) und `cin_ml` (ersetzt die Deckelung). Ohne diese Daten ist keine Eichung möglich. Spec liegt fertig vor | Spec fertig, Freigabe offen |
+| **0** | 🔴 **CAPE-Schwelle modellabhängig machen** (3.4b) | **Laufender Fehler**: In Frankreich löst die 1000-J/kg-Schwelle **nie** aus, bei ECMWF in 65 % der Stunden. Ein Viertel der Fusionssignale ist dort tot. Unabhängig von allem anderen | sofort |
+| **1** | **Fehlende DWD-Größen abrufen** (#1531) — Felder befüllen, **nicht** einstufen | Liefert `lpi_max` (gleiche Statistik) und `cin_ml` (ersetzt die Deckelung). **CIN gibt es bei Open-Meteo nicht für ICON/AROME** — der Direktabruf ist der einzige Weg. Spec liegt fertig vor | Spec fertig, Freigabe offen |
 | **2** | **Belegte Leitern übernehmen**: LPI **1/30/50** statt 5/**20**/50 · CAPE **1000/2500/4000** statt binär · CIN-Paarung **−25/−50/−100/−200** statt Deckelung | Beseitigt eine der beiden erfundenen Zahlen und macht CAPE zu einem vollwertigen Signal. Alles belegt (3.5, 3.5b) | ✅ E1 |
 | **3** | **Gleiche Statistik**: `lpi_max` statt `lpi` gegen `lpi_con_max` | Nimmt allein **Faktor 5** aus dem Gebietsbruch — ohne jede Kalibrierung | ✅ E1 |
 | **4** | **Herkunft mitführen** — die Stufe trägt sichtbar, worauf sie beruht | Macht im Ortsvergleich erkennbar, dass Korsika und Alpen auf verschiedenen Größen fußen | ✅ E1 |

--- a/docs/features/gewitter-gesamtkonzept.md
+++ b/docs/features/gewitter-gesamtkonzept.md
@@ -1,0 +1,345 @@
+# Gewitter — Gesamtkonzept
+
+**Stand:** 2026-08-08 · **Status:** Entwurf, PO-Entscheidungen offen (Abschnitt 10)
+
+Dieses Dokument beschreibt Gewitter in Gregor Zwanzig **Ende zu Ende**: was der Nutzer bekommt,
+woraus es entsteht, was gemessen belegt ist und was nicht, und in welcher Reihenfolge gebaut
+wird. Es ersetzt die verstreuten Einzelbetrachtungen als führende Beschreibung — bislang
+existierten zwölf Kontext-Fragmente und vier ADRs, aber **kein Gesamtbild**.
+
+Alle Zahlenangaben mit „gemessen" sind Live-Messungen vom 2026-08-07/08 gegen die echten
+Dienste, keine Literaturübernahmen.
+
+---
+
+## 1. Wozu Gewitter in diesem Produkt
+
+Die Zielgruppe sind Weitwanderer mit eingeschränkter Konnektivität. Gewitter ist für sie die
+**entscheidungsrelevanteste Wetterlage überhaupt** — anders als Regen oder Wind bestimmt es, ob
+eine Etappe über einen Grat überhaupt begehbar ist, und es entsteht schnell.
+
+Drei Leitsätze, die alles Weitere binden:
+
+1. **Daten, keine Empfehlung** (ADR-0007). Wir sagen „hoch", nicht „geh nicht los". Eine
+   Stufeneinteilung ist erlaubt, eine Handlungsanweisung nicht.
+2. **Eine Aussage für alle Kanäle** (ADR-0025). Dieselbe Etappe ergibt in E-Mail, SMS, Telegram
+   und Ortsvergleich dieselbe Stufe, aus denselben Rohdaten und mit derselben Fensterung auf die
+   Wanderzeit. Abweichungen davon waren dreimal derselbe Bug (#874, #1275 zweifach).
+3. **„Leer" heißt „keine Aussage", nie „keine Gefahr"** (#1377). Eine fehlende Quelle darf nie
+   wie Entwarnung aussehen.
+
+---
+
+## 2. Was der Nutzer sieht — die Antwort
+
+**Genau zwei Größen erreichen den Nutzer.** Alles andere ist Zutat und bleibt unsichtbar.
+
+| Größe | Frage | Werte | Status |
+|---|---|---|---|
+| **Gewitter-Stärke** (`thunder`) | Wie stark? | kein · leicht · mittel · hoch | existiert; wird heute **unvollständig** berechnet |
+| **Hagel** (`hail_flag`) | Hagel dabei? | ja · unbekannt | existiert; eigenes Kennzeichen, **keine** Metrik (#1475) |
+
+### 2.1 Die Wahrscheinlichkeit entfällt — gemessen, nicht vermutet
+
+Geplant war eine zweite Achse „Gewitter-Wahrscheinlichkeit 0–100 %". **Es gibt dafür keine
+tragfähige Quelle.** Alle vier Wege wurden live geprüft:
+
+| Weg | Messergebnis |
+|---|---|
+| Anteil der Ensemble-Läufe mit Gewittercode | **0,04 %** Treffer in 53.760 Werten; in allen 9 Stunden mit Gewitter im Hauptlauf zeigten **0 von 40** Läufen Gewitter |
+| Open-Meteo `thunderstorm_probability` | Name akzeptiert, bei **allen 11** Modellen leere Reihen — Scheinparameter |
+| DWD MOSMIX `wwT` | echte Prozentwerte, aber vom DWD **selbst abgekündigt** (Newsletter 25.06.2025: „empfehlen … auf andere Produkte umzusteigen"); im Alpenraum nur 6 von 14 Stationen befüllt; nächste Station zum GR20-Kamm auf **10 m Höhe, 31 km** entfernt |
+| CAPE je Ensemble-Lauf | verfügbar — aber eine Prozentskala daraus wäre Eigenkalibrierung (verboten, #1456) |
+
+⇒ **Das Produkt zeigt vorerst EINE Gewitter-Metrik, nicht zwei.** Die Unsicherheit trägt
+niemand — das ist eine bewusste Lücke, keine vergessene. Sollte je eine flächige, publizierte
+Quelle auftauchen, ist das Feld `thunder_probability_pct` bereits vorbereitet.
+
+### 2.2 Warum die Zutaten unsichtbar bleiben
+
+CAPE, Konvektionshemmung, Blitzdichte, Blitzpotenzial, Superzellen-Index sind **Zutaten** der
+Stufe. Sie sind der Weg zur Antwort, nicht die Antwort. Zwei Gründe, warum sie keine eigenen
+Spalten bekommen:
+
+- **Gebietsabhängige Verfügbarkeit** — dieselbe Spalte trüge je nach Ort eine andere Größe oder
+  wäre leer (s. Abschnitt 4).
+- **Unvereinbare Skalen** — Blitzdichte liegt bei ~0,2, Blitzpotenzial bei ~88. Nebeneinander
+  in einer Stundentabelle sind sie nicht lesbar, in einer SMS (≤ 160 Zeichen) gar nicht.
+
+Heute ist genau **eine** Zutat sichtbar: CAPE — nicht weil das entschieden wurde, sondern weil
+sie historisch zuerst im Katalog stand. ⇒ **CAPE wird unsichtbar** (`selectable=False`), aus
+demselben Grund wie alle anderen Zutaten. Sie bleibt intern Teil der Berechnung.
+Präzedenz: `confidence` (ADR-0005). Bestandsdaten laden still weiter, keine Migration.
+
+---
+
+## 3. Wie die Stärke entsteht
+
+### 3.1 Das Verfahren heute
+
+`thunder_level_from_signals()` (`metric_format.py:326`) übersetzt **jedes Signal einzeln** in
+eine Stufe und nimmt dann **das schärfste**. Sind alle leer, ist das Ergebnis leer.
+
+| # | Signal | Schwellen (leicht / mittel / hoch) | Beleglage |
+|---|---|---|---|
+| 1 | WMO-Wettercode | 95 / 96 / 99 | vom Anbieter geliefert |
+| 2 | Blitzdichte (Blitze/km²/3 h) | 0,003 / 0,015 / **0,075** | ECMWF-Leitfaden; **0,075 nicht publiziert** |
+| 3 | Blitzpotenzial LPI (J/kg) | 5 / **20** / 50 | DWD/Copernicus; **20 interpoliert** |
+| 4 | CAPE (J/kg) | ≥ 1000 → nur „leicht", **deckelt** | Katalog-Risikoschwelle |
+
+### 3.2 Die Annahmen darin — offen ausgesprochen
+
+- **„Das schärfste Signal gewinnt."** Kein Mitteln, kein Gewichten. Sicherheitsgerichtet, aber
+  ein einzelner Ausreißer hebt die Stufe.
+- **Signale werden nicht kombiniert.** Hohe Energie *und* hohes Blitzpotenzial ergibt nicht mehr
+  als Blitzpotenzial allein. Vereinfachung, keine Physik.
+- **Zwei von acht Schwellen sind interpoliert**, nicht publiziert (0,075 und 20). Das ist
+  faktisch Eigenkalibrierung im Bestand — dieselbe Sache, die als Verbot die Schließung von
+  #1456 begründet hat. Beide stehen ehrlich als Kommentar im Code.
+- **CAPE ist gedeckelt, weil die Gegengröße fehlt.** Viel Energie unter einem Deckel heißt: es
+  passiert nichts. Da die Konvektionshemmung nie abgerufen wurde, wird CAPE vorsorglich nie
+  höher als „leicht" gewertet. Das ist eine **Notbremse, kein Modell**.
+
+### 3.3 Was fehlt — und was davon belegbar nachrüstbar ist
+
+| Signal | Nutzen | Belegte Schwelle? | Verfügbar? |
+|---|---|---|---|
+| **Konvektionshemmung** `cin_ml` | macht CAPE erst verwertbar, ersetzt die Deckelung | ❌ keine publizierte Paarungsregel | ✅ ICON-D2 + ICON-EU |
+| **Superzellen-Index** `sdi_2` | einziges Signal für die gefährlichste Gewitterform | ✅ **DWD: 0,0003 / 0,003 1/s** | ✅ nur ICON-D2 |
+| **Updraft-Helizität** `uh_max*` | Rotationsstärke | ❌ US-Werte 2019 vom Betreiber selbst verworfen | ✅ nur ICON-D2, drei Schichten |
+| **Blitzpotenzial-Maximum** `lpi_max` | Spitzenwert statt Momentanwert | wie LPI | ✅ ICON-D2 |
+| **Radar-Beobachtung** | „passiert gerade" statt „wird vorhergesagt" | ✅ Regel in #1419 §4 | ✅ angebunden, fließt aber **nicht** ein (Abschnitt 5) |
+
+**Nicht nachrüstbar** (recherchiert 2026-08-07, nicht erneut zu prüfen): Reflektivität
+`dbz_cmax` (Faustregeln gelten für gemessenes Radar, unser Wert ist Modellsimulation),
+Zellhöhe `echotop` (DWD liefert 18 dBZ = Wolkenoberkante, kein Intensitätsmaß).
+
+### 3.4 Realitätsdämpfer zum Superzellen-Index
+
+Gemessen über das gesamte ICON-D2-Gitter lag das Feldmaximum bei **0,00074** — über der
+minimalen Schwelle (0,0003), aber **weit unter der signifikanten** (0,003). In dieser Lage hätte
+`sdi_2` also höchstens die mittlere Stufe ausgelöst. Ob die obere Schwelle in echten
+Superzellenlagen erreicht wird, ist offen. Zudem nennt der DWD den Index selbst ein
+**„experimentelles Produkt"** auf Basis „einiger weniger Fallstudien", kalibriert für COSMO-DE
+(2,8 km) — die Übertragung auf ICON-D2 (2,2 km, feiner) ist plausibel, aber nicht validiert.
+
+⇒ Deshalb: **erst Felder befüllen und mitlaufen lassen, dann einstufen.** Nicht umgekehrt.
+
+---
+
+## 4. Das ungelöste Kernproblem: die Stufe bedeutet je nach Ort etwas anderes
+
+Dies ist der wichtigste Punkt des Konzepts und bislang nirgends adressiert.
+
+Gewittersignale kommen je Gebiet aus verschiedenen Quellen mit **verschiedenen Größen**:
+
+| Gebiet | Quelle | Signale, die ankommen |
+|---|---|---|
+| Frankreich/Korsika (**GR20**) | Météo-France AROME | Wettercode + **Blitzdichte** |
+| Deutschland/Alpen/Österreich | DWD ICON-D2 | Wettercode + **Blitzpotenzial** + Hagel |
+| Übriges Europa | DWD ICON-EU | Wettercode + **Blitzpotenzial**, kein Hagel |
+
+Daraus folgt: **„mittel" auf Korsika entsteht aus einer anderen Größe als „mittel" in den
+Alpen.** Auf Korsika trägt es die Blitzdichte, in den Alpen das Blitzpotenzial — zwei Größen auf
+unvereinbaren Skalen, jede mit eigener, teils interpolierter Schwellenleiter.
+
+Konsequenzen, die eine Entscheidung brauchen:
+
+- **Im Ortsvergleich stehen diese Stufen nebeneinander in einer Tabelle** und suggerieren
+  Vergleichbarkeit, die sie nicht haben. Ein Vergleich Korsika ↔ Alpen vergleicht faktisch zwei
+  verschiedene Messverfahren.
+- **`sdi_2` verschärft das**: Es gibt ihn nur im ICON-D2-Gebiet. Wird er eingehängt, kann eine
+  Etappe in den Alpen „hoch" erreichen, eine identisch gefährliche auf Korsika aber nicht —
+  weil dort das Signal schlicht fehlt.
+
+### 4.1 Verschärfend: dasselbe Feld trägt zwei verschiedene Statistiken
+
+Innerhalb des DWD-Zweigs gibt es einen zweiten, bisher unbenannten Bruch. ICON-D2 liefert `lpi`,
+ICON-EU liefert `lpi_con_max`. Beide werden über denselben Signalschlüssel auf **dasselbe Feld**
+`lightning_potential_lpi_jkg` gelegt (`dwd_eu.py:96`) und mit **derselben Schwellenleiter**
+(5 / 20 / 50 J/kg) bewertet — mit der Begründung, es sei „fachlich dieselbe Größe".
+
+Der Code selbst dokumentiert aber den Unterschied: `lpi_con_max` ist laut GRIB-Kopf ein
+**Maximum über die letzten 60 Minuten** (`dwd_eu.py:43-45`), `lpi` ein **Momentanwert**.
+
+Ein Stundenmaximum ist per Definition **immer ≥** dem Momentanwert derselben Größe. Dieselbe
+Schwellenleiter auf beide anzuwenden heißt: **Rest-Europa wird bei gleicher Wetterlage
+systematisch höher eingestuft als Deutschland und die Alpen** — nicht weil dort mehr Gefahr
+herrscht, sondern weil anders gemessen wird.
+
+Gegenläufig wirkt die Auflösung: ICON-EU (6,5 km) mittelt stärker als ICON-D2 (2,2 km) und
+dämpft Spitzenwerte. Welcher Effekt überwiegt, ist **nicht bekannt**.
+
+> **Messstand:** Am identischen Ausschnitt (DE/Alpen, 1020 Gitterpunkte, +15 h) war die
+> Stichprobe an einem ruhigen Tag zu klein für eine Quantifizierung — nur 2 Punkte trugen
+> überhaupt Werte, beide nur in ICON-EU. Die Richtung stimmt, der Betrag ist **offen**. Der
+> strukturelle Befund folgt aus der Definition der Statistik, nicht aus dieser Messung.
+
+⇒ Zu klären ist, ob `lpi_con_max` eine eigene Schwellenleiter braucht oder ein eigenes Feld.
+Solange beides offen ist, ist die Stufe zwischen DWD-Gebieten nicht sauber vergleichbar.
+
+**Optionen** (Entscheidung offen, s. Abschnitt 10):
+- **(a) Hinnehmen und benennen** — die Stufe bleibt „bestes verfügbares Urteil vor Ort", und der
+  Vergleich weist aus, dass die Grundlage je Ort verschieden ist.
+- **(b) Kleinster gemeinsamer Nenner** — nur Signale nutzen, die überall verfügbar sind
+  (praktisch: nur der Wettercode). Vergleichbar, aber deutlich schwächer.
+- **(c) Herkunft mitführen** — die Stufe trägt sichtbar, worauf sie beruht (z. B. „hoch,
+  Blitzdichte" vs. „hoch, Blitzpotenzial+Superzelle").
+
+---
+
+## 5. Beobachtung und Vorhersage — zwei getrennte Welten
+
+Das Produkt weiß auch, was **gerade** passiert: Ein Radar-Nowcast ist angebunden, mit eigener
+Quellenkette je Gebiet (`radar_service.py:280-313`): RADOLAN/BrightSky für Deutschland, INCA für
+Österreich, Radar-DPC für Italien **inklusive Korsika**, AROME-HD für Frankreich, ICON-D2 für die
+Alpen, `minutely_15` als globaler Rückfall. Ob es gewittert, kommt aus dem WMO-Code 95/96/99 je
+Einzelbild (`radar_service.py:151-153`).
+
+🔴 **Diese Beobachtung fließt an keiner Stelle in die Gewitterstufe ein.**
+`thunder_level_from_signals()` hat gar keinen Parameter dafür (`metric_format.py:326-370`), und
+`thunder_level_max` ist schlicht das Maximum über die vorhergesagten Stundenwerte
+(`weather_metrics.py:589-601`). Vorhersage und Beobachtung sind zwei Datenströme, die einander
+nicht kennen — sie benutzen nur zufällig dieselbe Codenummer für „konvektiv".
+
+Praktisch heißt das: Das Radar kann eine Gewitterzelle über der Etappe sehen, während die
+Stufe im Briefing „kein Gewitter" sagt. Beides ist für sich korrekt, zusammen ist es ein
+Widerspruch für den Nutzer.
+
+Der Nowcast erreicht ihn heute auf zwei Wegen: über das `/jetzt`-Kommando
+(`trip_command_processor.py:1293`) und über einen eigenen Radar-Alarm (Abschnitt 7).
+
+**Schwachstelle:** Fällt die Gewitterprüfung im Nowcast aus, erscheint „Gewitter-Check nicht
+verfügbar." **nur** im `/jetzt`-Text (`radar_service.py:268-269`) — im Alarm-Pfad gibt es
+dafür keine Entsprechung. Für die Vorhersage-Quellen ist die Ausfallsichtbarkeit dagegen
+sauber gebaut (Abschnitt 6.1).
+
+---
+
+## 6. Amtliche Warnungen
+
+Warnungen der Wetterdienste kommen aus sieben registrierten Quellen
+(`official_alerts/__init__.py:36-42`): Vigilance und Meteo-Forêts für Frankreich,
+Massif-Sperrungen, GeoSphere für Österreich, MeteoAlarm-Feeds für Italien und Österreich, DPC
+für Italien. Gewitter erscheint dort als `hazard="thunderstorm"`.
+
+🔴 **Für Deutschland ist kein Warndienst registriert.** Der DWD betreibt einen amtlichen
+Warndienst, wir binden ihn nicht an. Wer in Deutschland unterwegs ist, bekommt also
+Gewitterwarnungen der Behörde nicht — anders als in Frankreich, Italien und Österreich.
+
+Auch hier gilt: **Die amtliche Warnung ist mit der berechneten Stufe nicht verknüpft.** In
+`official_alerts.py` (1919 Zeilen) kommt `thunder_level` kein einziges Mal vor. Die beiden
+Aussagen stehen unverbunden nebeneinander.
+
+### 6.1 Wenn eine Gewitterquelle ausfällt
+
+Fällt eine Direktquelle aus, springt eine Vertretung ein: DWD-D2 → ICON-EU, Météo-France →
+ICON-EU; für ICON-EU selbst gibt es keine (`thunder_routing.py:88-92`). Das geschieht **nicht
+stillschweigend** — der Nutzer bekommt eine Klartextzeile („Gewitterdaten von Ersatzquelle: DWD
+Europa (gröbere Auflösung)", `fallback_notice.py:87`), eingebunden in HTML-, Text- und
+Kompakt-Mail sowie Telegram. Das ist vorbildlich gelöst (ADR-0047) und der Maßstab, an dem sich
+die Radar-Seite messen lassen muss.
+
+---
+
+## 7. Alarme — wann meldet sich das System von selbst
+
+### 7.1 Der Regler
+
+Gewitter ist die **einzige Gefahrenstufen-Größe** des Produkts. Der Nutzer stellt keine
+Zahlenschwelle ein, sondern eine **Empfindlichkeitsstufe** je Metrik (ADR-0043). Bei Gewitter
+wirkt sie über das erreichte Niveau (`alert_preset.py:102-106`):
+
+| Stufe | Es meldet sich, wenn … |
+|---|---|
+| entspannt | die Stufe den vollen Weg von „kein" auf „hoch" springt |
+| standard | die Höchststufe erreicht oder verlassen wird |
+| sensibel | sich die Stufe überhaupt ändert (ab „mittel") |
+
+Trip und Ortsvergleich nutzen dieselbe Maschinerie (`compare_alert.py:63-107`) — nur der
+Ablageort der Einstellung unterscheidet sich. Das entspricht der Teilungspflicht.
+
+### 7.2 🔴 Drei getrennte Alarme für dasselbe Gewitter
+
+Zum selben Gewitter kann der Nutzer **drei voneinander unabhängige Nachrichten** bekommen:
+
+| # | Alarm | Auslöser | Versand |
+|---|---|---|---|
+| 1 | Änderungsalarm | die berechnete Stufe ändert sich | `send_location_deviation_alert` |
+| 2 | Radar-Alarm | Beobachtung sieht Konvektion aufziehen (≤ 20 min) | `send_radar_alert` |
+| 3 | Amtliche Warnung | Behörde warnt neu oder höher | `send_official_alert` |
+
+Die drei Wege werden **nie zusammengeführt**. Es gibt zwar eine gemeinsame
+Dringlichkeitsableitung (`alert_urgency.py:52-57`), die aber nur das Maximum für Protokoll und
+Schweregrad bildet — die Inhalte bleiben getrennt.
+
+Für einen Wanderer mit knapper Verbindung ist das relevant: Drei Nachrichten zu einer Gefahr
+kosten Aufmerksamkeit und Datenvolumen, und sie können sich widersprechen (Radar meldet
+Gewitter, die Stufe sagt „kein" — siehe Abschnitt 5).
+
+---
+
+## 8. Wo Gewitter erscheint — neun Ausgabeorte
+
+Eine Wettermetrik hat in diesem Produkt **diverse Ausgabeorte, alle müssen bedient werden**
+(PO-Vorgabe 2026-08-05; bei Hagel wurden 5 von 9 vergessen).
+
+| # | Ort | Fundstelle |
+|---|---|---|
+| 1 | E-Mail-Zusammenfassungszeile (Pill) | `email/helpers.py:1670` |
+| 2 | Trip-Stundentabelle | `email/helpers.py:185` |
+| 3 | Nachtblock | `email/helpers.py:154-236` |
+| 4 | Kurzzusammenfassung | `compact_summary.py:571` |
+| 5 | SMS-Token | `sms_trip.py:280` |
+| 6 | Telegram-Fußzeile | `narrow.py:210` |
+| 7 | GEWITTER-Kommando + Telegram-Drilldown | `trip_command_processor.py:228, 114, 126, 980` |
+| 8 | Ortsvergleich (drei Unterstellen) | `compare_html.py:158, 331, 600` |
+| 9 | Mehrtages-Vorschau | `outlook.py:200, 371`; `trip_report_scheduler.py:1820` |
+
+---
+
+## 9. Was bewusst NICHT gemacht wird
+
+| Nicht | Grund |
+|---|---|
+| Fließtext, Sätze, formulierte Warnungen | Das Produkt gibt Metriken, Stufen, Spalten und Kurz-Token aus — keine Sätze (PO 2026-08-07) |
+| Go/No-Go-Empfehlung, Timing-Rat | ADR-0007: Daten statt Empfehlungen |
+| Zweite Achse „möglich/wahrscheinlich/akut" **in der Stufe** | Die Stufe ist eine **Stärke**-Skala. Unsicherheit ist eine andere Achse und wird nicht hineingemischt |
+| Eigene Kalibrierung von Schwellen | PO-Verbot (#1456). Bestandsausnahmen (0,075 / 20) sind Altlast, kein Präzedenzfall |
+| Hagel als Rang der Stufe | Eigenes Kennzeichen, kann kein „nein" (#1475) |
+| Rohwerte als eigene Spalten | Abschnitt 2.2 |
+
+---
+
+## 10. Offene Entscheidungen (PO)
+
+| # | Frage | Empfehlung |
+|---|---|---|
+| E1 | Umgang mit der gebietsabhängigen Bedeutung der Stufe (Abschnitt 4) | **(a) hinnehmen + im Vergleich benennen** — (b) verschenkt die guten Signale, (c) ist teuer |
+| E1b | Bekommt `lpi_con_max` eine eigene Schwellenleiter (Abschnitt 4.1)? | **Ja, sobald messbar** — vorher an ein paar echten Gewitterlagen den Versatz bestimmen; ohne Beleg keine erfundene Leiter |
+| E2 | Wird CAPE unsichtbar, obwohl die Wahrscheinlichkeit als Ersatz entfällt? | **Ja** — die Begründung („Zutat ist nicht Antwort") gilt unabhängig; die Stärke bleibt als Antwort |
+| E3 | Darf die Radar-Beobachtung die Stufe anheben (Abschnitt 5)? | **Ja** — sonst bleibt der Widerspruch „Radar sieht Gewitter, Stufe sagt kein Gewitter" bestehen. Regel liegt in #1419 §4 |
+| E4 | Bleibt es dauerhaft bei EINER Gewitter-Metrik? | Ja, bis eine flächige publizierte Wahrscheinlichkeitsquelle existiert |
+| E5 | Drei getrennte Gewitter-Alarme zusammenführen (Abschnitt 7.2)? | **Ja, mindestens entkoppeln** — für einen Wanderer mit knapper Verbindung sind drei Nachrichten zu einer Gefahr zu viel |
+| E6 | DWD-Warndienst für Deutschland anbinden (Abschnitt 6)? | **Ja** — Frankreich, Italien und Österreich haben amtliche Warnungen, Deutschland nicht |
+| E7 | Ausfallsichtbarkeit auch für den Radar-Pfad (Abschnitt 5)? | **Ja** — für die Vorhersagequellen ist es gebaut, für Radar fehlt es |
+
+---
+
+## 11. Umsetzung in Scheiben
+
+Reihenfolge folgt einem Grundsatz: **erst eichen, dann erweitern.** Mehr Signale in eine Fusion
+zu geben, deren bestehende Signale untereinander nicht vergleichbar sind, verschlimmert das
+Problem, statt es zu lösen.
+
+| Rang | Scheibe | Warum hier | Vorbedingung |
+|---|---|---|---|
+| **1** | **Eichung klären** (E1, E1b): Bedeutet „mittel" überall dasselbe? Braucht `lpi_con_max` eine eigene Leiter? | Fundament. Ohne das ist jede weitere Größe Rauschen auf schiefer Skala | PO-Entscheid |
+| **2** | **CAPE unsichtbar** (`selectable=False`) | Klein, unabhängig, beendet den historischen Zufall. Im Kern ein Katalog-Kwarg — die Render-Pfade prüfen `selectable` bereits generisch | E2 |
+| **3** | **Radar hebt die Stufe an** | Größter Nutzen ohne neue Quelle; beseitigt den Widerspruch aus Abschnitt 5 | E3 |
+| **4** | **Fehlende DWD-Größen abrufen** (#1531) — Felder befüllen, mitlaufen lassen, **nicht** einstufen | Datensammlung als Voraussetzung für Rang 5. Spec liegt fertig vor | — |
+| **5** | **Einstufung nachziehen**: `sdi_2` (publizierte Schwelle), `cin_ml` statt CAPE-Deckelung | Erst wenn Rang 4 echte Messwerte geliefert hat | Rang 4 + belegte Schwellen |
+| **6** | **Alarme entkoppeln** (E5), **DWD-Warnungen** (E6), **Radar-Ausfallsichtbarkeit** (E7) | Unabhängig von der Signalkette, jederzeit einschiebbar | E5–E7 |
+
+**Nicht geplant:** Gewitter-Wahrscheinlichkeit (keine Quelle, Abschnitt 2.1), `uh_max`-Einstufung
+(keine übertragbare Zahl), `dbz_cmax`/`echotop` (falsch kalibriert bzw. falsche Größe).

--- a/docs/features/gewitter-gesamtkonzept.md
+++ b/docs/features/gewitter-gesamtkonzept.md
@@ -173,7 +173,7 @@ Superzellenlagen erreicht wird, ist offen. Zudem nennt der DWD den Index selbst 
 
 ⇒ Deshalb: **erst Felder befüllen und mitlaufen lassen, dann einstufen.** Nicht umgekehrt.
 
-### 3.4b 🔴 CAPE ≠ CAPE — eine Schwelle auf unvergleichbare Werte (gemessen 2026-08-08)
+### 3.4b 🔴 CAPE ≠ CAPE — eine Schwelle auf unvergleichbare Werte (gemessen 2026-08-08, → #1592)
 
 **CAPE ist ein modellabhängiges Konstrukt, kein Messwert.** Die Modelle unterscheiden sich in
 der Parcel-Wahl: ICON liefert **Mixed-Layer**-CAPE (`CAPE_ML`), Météo-France **Most-Unstable**
@@ -678,7 +678,7 @@ CAPE-Deckelung zu ersetzen. #1531 ist damit **nicht** eine spätere Scheibe, son
 
 | Rang | Scheibe | Warum hier | Stand |
 |---|---|---|---|
-| **0** | 🔴 **CAPE-Schwelle modellabhängig machen** (3.4b) | **Laufender Fehler**: In Frankreich löst die 1000-J/kg-Schwelle **nie** aus, bei ECMWF in 65 % der Stunden. Ein Viertel der Fusionssignale ist dort tot. Unabhängig von allem anderen | sofort |
+| **0** | 🔴 **CAPE-Schwelle modellabhängig machen** (3.4b, **#1592**) | **Laufender Fehler**: In Frankreich löst die 1000-J/kg-Schwelle **nie** aus, bei ECMWF in 65 % der Stunden. Ein Viertel der Fusionssignale ist dort tot. Unabhängig von allem anderen | sofort |
 | **1** | **Fehlende DWD-Größen abrufen** (#1531) — Felder befüllen, **nicht** einstufen | Liefert `lpi_max` (gleiche Statistik) und `cin_ml` (ersetzt die Deckelung). **CIN gibt es bei Open-Meteo nicht für ICON/AROME** — der Direktabruf ist der einzige Weg. Spec liegt fertig vor | Spec fertig, Freigabe offen |
 | **2** | **Belegte Leitern übernehmen**: LPI **1/30/50** statt 5/**20**/50 · CAPE **1000/2500/4000** statt binär · CIN-Paarung **−25/−50/−100/−200** statt Deckelung | Beseitigt eine der beiden erfundenen Zahlen und macht CAPE zu einem vollwertigen Signal. Alles belegt (3.5, 3.5b) | ✅ E1 |
 | **3** | **Gleiche Statistik**: `lpi_max` statt `lpi` gegen `lpi_con_max` | Nimmt allein **Faktor 5** aus dem Gebietsbruch — ohne jede Kalibrierung | ✅ E1 |

--- a/docs/features/gewitter-gesamtkonzept.md
+++ b/docs/features/gewitter-gesamtkonzept.md
@@ -550,28 +550,46 @@ Gewitterwarnungen der Behörde nicht — anders als in Frankreich, Italien und �
 | #1442 | MeteoAlarm-Ländererweiterung (CH → Skandinavien → Rest-EU) | hängt am Budget-Refactor #1397 |
 | **#1445** | MeteoAlarm via MQTT statt REST-Polling | 🔴 `priority:critical`, `status:deferred` |
 
-**Zwei Wege, mit unterschiedlichen Haken:**
+### 🟢 Der Weg ist bereits gebaut — E6 ist eine Länder-Ergänzung, kein Projekt
 
-*Der harmonisierte Weg* wäre der **Meteoalarm-Feed** — EUMETNET betreibt damit die fertige
-EU-weite Harmonisierung, jeder nationale Dienst mappt selbst auf Gelb/Orange/Rot, Awareness-Type
-**3 = Thunderstorm**, CC BY 4.0. Grundsatz: **nicht selbst mappen, das offizielle Mapping
-konsumieren.**
+**Das Kontingentproblem aus #1445 ist gelöst.** `MeteoAlarmFeedSource`
+(`services/official_alerts/meteoalarm_feed.py`) läuft produktiv für Italien und Österreich und
+ersetzt laut eigenem Modul-Kopf den kontingentierten Weg:
 
-🔴 **Aber der Zugang ist verkontingentiert.** Laut #1445 ist die MeteoAlarm-REST-API seit
-30.04.2025 auf **100 Requests/Tag** begrenzt (gemessen ~160 im rollierenden 24-h-Fenster,
-Kurzzeitbremse ~1 req/4 s, 429 ohne `Retry-After`), und eine Länder-Index-Auffrischung kostet
-durch Pagination **40–160 Calls** allein für AT+IT. Eine Ausweitung auf Deutschland über diesen
-Weg ist damit **nicht** der billige Schritt, als der er zunächst erscheint — deshalb steht
-#1445 auf `priority:critical`. Ob die **statischen CAP-Feeds** (`feeds.meteoalarm.org`)
-demselben Limit unterliegen wie die Archiv-REST-API, ist **ungeprüft** und vor einer
-Entscheidung zu klären.
+> „**kontingentfreier CAP-Feed** … Ersetzt den kontingentierten EDR-Index-Weg (`meteoalarm.py`)
+> durch `feeds.meteoalarm.org` — eine Momentaufnahme ALLER aktuell gültigen Warnungen des
+> jeweiligen Landes mit vollem CAP-Inhalt **in einem einzigen, unauthentifizierten Abruf**."
 
-*Der direkte Weg* ist **#1440**: der DWD-CAP-Feed, auch über BrightSky `/alerts` erreichbar.
-Deckt nur Deutschland, hat dafür kein Kontingentproblem und liefert die **feinere Abstufung** —
-bei Meteoalarm fallen DWD-Stufe 3 und 4 beide auf Rot zusammen.
+Der paginierte EDR-Weg ist seit #1445 S3 **nicht mehr registriert**
+(`official_alerts/__init__.py:30-35`). Die 100-Requests-Grenze betrifft ihn, nicht den Feed.
 
-⇒ **Empfehlung: #1440 zuerst** (löst die konkrete Lücke ohne Kontingentrisiko), Meteoalarm-
-Ausweitung erst nach #1445.
+**Für Deutschland gemessen (2026-08-08):**
+
+| | Abruf | Größe | Gewitterwarnungen |
+|---|---|---|---|
+| Italien *(produktiv)* | 0,5 s | 2,1 MB | — |
+| Österreich *(produktiv)* | 1,0 s | 3,1 MB | — |
+| **Deutschland** | **4,0 s** | **13,5 MB** | **878** |
+
+Der DE-Feed liefert dieselbe JSON-Struktur, die der bestehende Code verarbeitet, mit
+`EMMA_ID`-Geocodes (Zonenauflösung wie bei IT/AT) und der **vollen DWD-Abstufung** im
+Ereignistext: `GEWITTER` · `STARKES GEWITTER` · `SCHWERES GEWITTER mit HEFTIGEM STARKREGEN und
+HAGEL` · `SCHWERES GEWITTER mit ORKANBÖEN, HEFTIGEM STARKREGEN und HAGEL`.
+
+⇒ **E6 = `MeteoAlarmFeedSource("DE")` ergänzen**: ein Eintrag in `_FEED_PATHS`
+(`/api/v1/warnings/feeds-germany`), die `Literal`-Signatur erweitern, registrieren — plus die
+Punkt→Zone-Auflösung für Deutschland, die der nicht-triviale Teil ist (Italien nutzt reine
+Geometrie, Österreich die gecachte ZAMG-Antwort).
+
+⚠️ **Einziger echter Vorbehalt: die Größe.** 13,5 MB gegen 2–3 MB bei IT/AT, **ohne gzip**
+(gemessen: `Accept-Encoding: gzip` ändert nichts). Das Zeitbudget von 15 s
+(`meteoalarm_feed.py:55`) trägt die gemessenen 4 s, ist aber knapper als bei den Nachbarn —
+bei schlechter Netzlage zu beobachten.
+
+**Damit entfallen zwei frühere Annahmen dieses Konzepts:** Der Meteoalarm-Weg ist *nicht*
+verkontingentiert, und die DWD-Stufen 3 und 4 fallen im Feed *nicht* zusammen — beides steht im
+Ereignistext. **#1440** (DWD-Einzelanbindung über BrightSky) wird dadurch womöglich
+überflüssig; das ist dort zu entscheiden.
 
 Auch hier gilt: **Die amtliche Warnung ist mit der berechneten Stufe nicht verknüpft.** In
 `official_alerts.py` (1919 Zeilen) kommt `thunder_level` kein einziges Mal vor. Die beiden
@@ -667,7 +685,7 @@ Eine Wettermetrik hat in diesem Produkt **diverse Ausgabeorte, alle müssen bedi
 | **E3** | Darf die Radar-Beobachtung die Stufe anheben? | **Ja.** Beobachtung hebt die Stufe — auch wenn die Vorhersage schweigt. Beseitigt den Widerspruch aus Abschnitt 5 |
 | **E4** | Bleibt es bei EINER sichtbaren Gewitter-Metrik? | **Ja**, bis eine flächige publizierte Wahrscheinlichkeitsquelle existiert |
 | **E5** | Die drei getrennten Gewitter-Alarme zusammenführen? | **Teilweise: amtliche Warnung und Änderungsalarm werden zusammengeführt, der Radar-Nowcast bleibt getrennt.** Fachlich stimmig — die beiden ersten beruhen auf Vorhersage und teilen den Zeithorizont; der Nowcast ist eine akute Beobachtung mit eigener Dringlichkeit und darf nicht in einer Sammelnachricht untergehen |
-| **E6** | DWD-Warndienst für Deutschland anbinden? | **Ja.** Ticket existiert bereits: **#1440**. Meteoalarm-Ausweitung (#1442) erst nach dem Kontingent-Problem #1445 |
+| **E6** | DWD-Warndienst für Deutschland anbinden? | **Ja — über `MeteoAlarmFeedSource("DE")`.** Der kontingentfreie Feed-Weg läuft bereits produktiv für IT/AT (#1445 S1/S3); Deutschland ist eine Länder-Ergänzung. Gemessen: 878 Gewitterwarnungen, volle DWD-Abstufung |
 | **E7** | Ausfallsichtbarkeit für den Radar-Pfad? | **Nein**, vorerst nicht. Bleibt als bekannte Schwachstelle dokumentiert (Abschnitt 5) |
 | **E1** | Umgang mit der ortsabhängigen Bedeutung der Stufe? | **Je Quelle eichen + Herkunft mitführen.** Eigene Schwellen je Modell, geeicht auf gleiche Häufigkeit (Prinzip der Wetterdienste); zusätzlich trägt die Stufe sichtbar, worauf sie beruht |
 | **E1b** | Eigene Schwellenleiter für das ICON-EU-Stundenmaximum? | **Ja** — Faktor 235 gemessen (4.2). Sofort wirksam ohne Kalibrierung: gleiche Statistik verwenden (`lpi_max`), das nimmt Faktor 5 heraus |
@@ -708,7 +726,7 @@ CAPE-Deckelung zu ersetzen. #1531 ist damit **nicht** eine spätere Scheibe, son
 | **7** | **Feineichung je Quelle** (E1b): eigene Leiter für `lpi_con_max`, kalibriert auf gleiche Überschreitungshäufigkeit | Braucht mehrere Wochen Daten über verschiedene Wetterlagen — fällt mit Rang 1 an | ✅ E1b, Daten offen |
 | **8** | **`sdi_2` einhängen** | Publizierte DWD-Schwelle vorhanden; erst sinnvoll, wenn die Skala geeicht ist | nach Rang 7 |
 | **9** | **Amtliche Warnung + Änderungsalarm zusammenführen** (E5); Radar-Nowcast bleibt eigener Kanal | Unabhängig von der Signalkette | ✅ E5 |
-| **10** | **DWD-Warndienst anbinden** — **#1440** (nicht neu anlegen) | Deutschland ist das einzige Zielgebiet ohne amtliche Warnungen. Meteoalarm-Weg erst nach #1445 (REST-Limit 100/Tag) | ✅ E6 |
+| **10** | **Deutschland an den Meteoalarm-Feed** — `MeteoAlarmFeedSource("DE")` | Der Weg läuft produktiv für IT/AT und ist kontingentfrei. Offen: Punkt→Zone-Auflösung für DE, und 13,5 MB je Abruf ohne gzip | ✅ E6 |
 
 **Nicht geplant:** Gewitter-Wahrscheinlichkeit (keine Quelle, Abschnitt 2.1),
 `dbz_cmax`/`echotop` (falsch kalibriert bzw. falsche Größe), Ausfallsichtbarkeit im Radar-Pfad

--- a/docs/features/gewitter-gesamtkonzept.md
+++ b/docs/features/gewitter-gesamtkonzept.md
@@ -542,16 +542,36 @@ für Italien. Gewitter erscheint dort als `hazard="thunderstorm"`.
 Warndienst, wir binden ihn nicht an. Wer in Deutschland unterwegs ist, bekommt also
 Gewitterwarnungen der Behörde nicht — anders als in Frankreich, Italien und Österreich.
 
-**Der einfachste Weg dorthin (E6)** ist nicht der DWD-Einzelanschluss, sondern der
-**Meteoalarm-Feed**: EUMETNET betreibt damit die fertige EU-weite Harmonisierung — jeder
-nationale Dienst mappt seine Warnungen **selbst** auf Gelb/Orange/Rot, Awareness-Type
-**3 = Thunderstorm**. Maschinenzugang kostenlos über CAP-Feeds (`feeds.meteoalarm.org`) und die
-OGC-EDR-API (`api.meteoalarm.org`, GeoJSON, auch historisch), CC BY 4.0.
+**Für E6 gibt es bereits Tickets — kein neues anlegen** (geprüft 2026-08-08):
 
-⇒ **Nicht selbst mappen — das offizielle Mapping konsumieren.** Das deckt Deutschland und alle
-übrigen Zielgebiete in einem Schritt ab. Einzige Verluststelle: DWD-Stufen 3 und 4 fallen bei
-Meteoalarm beide auf Rot zusammen. Wer die feinere DWD-Abstufung braucht, nimmt zusätzlich den
-DWD-CAP-Feed (auch über BrightSky `/alerts` erreichbar).
+| Issue | Inhalt | Stand |
+|---|---|---|
+| **#1440** | DWD-CAP-Warnungen als `OfficialAlertSource` (Deutschland) | PO-beauftragt 2026-07-31, `needs-po-approval`, `priority:low` |
+| #1442 | MeteoAlarm-Ländererweiterung (CH → Skandinavien → Rest-EU) | hängt am Budget-Refactor #1397 |
+| **#1445** | MeteoAlarm via MQTT statt REST-Polling | 🔴 `priority:critical`, `status:deferred` |
+
+**Zwei Wege, mit unterschiedlichen Haken:**
+
+*Der harmonisierte Weg* wäre der **Meteoalarm-Feed** — EUMETNET betreibt damit die fertige
+EU-weite Harmonisierung, jeder nationale Dienst mappt selbst auf Gelb/Orange/Rot, Awareness-Type
+**3 = Thunderstorm**, CC BY 4.0. Grundsatz: **nicht selbst mappen, das offizielle Mapping
+konsumieren.**
+
+🔴 **Aber der Zugang ist verkontingentiert.** Laut #1445 ist die MeteoAlarm-REST-API seit
+30.04.2025 auf **100 Requests/Tag** begrenzt (gemessen ~160 im rollierenden 24-h-Fenster,
+Kurzzeitbremse ~1 req/4 s, 429 ohne `Retry-After`), und eine Länder-Index-Auffrischung kostet
+durch Pagination **40–160 Calls** allein für AT+IT. Eine Ausweitung auf Deutschland über diesen
+Weg ist damit **nicht** der billige Schritt, als der er zunächst erscheint — deshalb steht
+#1445 auf `priority:critical`. Ob die **statischen CAP-Feeds** (`feeds.meteoalarm.org`)
+demselben Limit unterliegen wie die Archiv-REST-API, ist **ungeprüft** und vor einer
+Entscheidung zu klären.
+
+*Der direkte Weg* ist **#1440**: der DWD-CAP-Feed, auch über BrightSky `/alerts` erreichbar.
+Deckt nur Deutschland, hat dafür kein Kontingentproblem und liefert die **feinere Abstufung** —
+bei Meteoalarm fallen DWD-Stufe 3 und 4 beide auf Rot zusammen.
+
+⇒ **Empfehlung: #1440 zuerst** (löst die konkrete Lücke ohne Kontingentrisiko), Meteoalarm-
+Ausweitung erst nach #1445.
 
 Auch hier gilt: **Die amtliche Warnung ist mit der berechneten Stufe nicht verknüpft.** In
 `official_alerts.py` (1919 Zeilen) kommt `thunder_level` kein einziges Mal vor. Die beiden
@@ -647,7 +667,7 @@ Eine Wettermetrik hat in diesem Produkt **diverse Ausgabeorte, alle müssen bedi
 | **E3** | Darf die Radar-Beobachtung die Stufe anheben? | **Ja.** Beobachtung hebt die Stufe — auch wenn die Vorhersage schweigt. Beseitigt den Widerspruch aus Abschnitt 5 |
 | **E4** | Bleibt es bei EINER sichtbaren Gewitter-Metrik? | **Ja**, bis eine flächige publizierte Wahrscheinlichkeitsquelle existiert |
 | **E5** | Die drei getrennten Gewitter-Alarme zusammenführen? | **Teilweise: amtliche Warnung und Änderungsalarm werden zusammengeführt, der Radar-Nowcast bleibt getrennt.** Fachlich stimmig — die beiden ersten beruhen auf Vorhersage und teilen den Zeithorizont; der Nowcast ist eine akute Beobachtung mit eigener Dringlichkeit und darf nicht in einer Sammelnachricht untergehen |
-| **E6** | DWD-Warndienst für Deutschland anbinden? | **Ja.** Schließt die Lücke, dass Deutschland als einziges Zielgebiet ohne amtliche Warnungen dasteht |
+| **E6** | DWD-Warndienst für Deutschland anbinden? | **Ja.** Ticket existiert bereits: **#1440**. Meteoalarm-Ausweitung (#1442) erst nach dem Kontingent-Problem #1445 |
 | **E7** | Ausfallsichtbarkeit für den Radar-Pfad? | **Nein**, vorerst nicht. Bleibt als bekannte Schwachstelle dokumentiert (Abschnitt 5) |
 | **E1** | Umgang mit der ortsabhängigen Bedeutung der Stufe? | **Je Quelle eichen + Herkunft mitführen.** Eigene Schwellen je Modell, geeicht auf gleiche Häufigkeit (Prinzip der Wetterdienste); zusätzlich trägt die Stufe sichtbar, worauf sie beruht |
 | **E1b** | Eigene Schwellenleiter für das ICON-EU-Stundenmaximum? | **Ja** — Faktor 235 gemessen (4.2). Sofort wirksam ohne Kalibrierung: gleiche Statistik verwenden (`lpi_max`), das nimmt Faktor 5 heraus |
@@ -688,7 +708,7 @@ CAPE-Deckelung zu ersetzen. #1531 ist damit **nicht** eine spätere Scheibe, son
 | **7** | **Feineichung je Quelle** (E1b): eigene Leiter für `lpi_con_max`, kalibriert auf gleiche Überschreitungshäufigkeit | Braucht mehrere Wochen Daten über verschiedene Wetterlagen — fällt mit Rang 1 an | ✅ E1b, Daten offen |
 | **8** | **`sdi_2` einhängen** | Publizierte DWD-Schwelle vorhanden; erst sinnvoll, wenn die Skala geeicht ist | nach Rang 7 |
 | **9** | **Amtliche Warnung + Änderungsalarm zusammenführen** (E5); Radar-Nowcast bleibt eigener Kanal | Unabhängig von der Signalkette | ✅ E5 |
-| **10** | **DWD-Warndienst anbinden** (E6) | Deutschland ist das einzige Zielgebiet ohne amtliche Warnungen | ✅ E6 |
+| **10** | **DWD-Warndienst anbinden** — **#1440** (nicht neu anlegen) | Deutschland ist das einzige Zielgebiet ohne amtliche Warnungen. Meteoalarm-Weg erst nach #1445 (REST-Limit 100/Tag) | ✅ E6 |
 
 **Nicht geplant:** Gewitter-Wahrscheinlichkeit (keine Quelle, Abschnitt 2.1),
 `dbz_cmax`/`echotop` (falsch kalibriert bzw. falsche Größe), Ausfallsichtbarkeit im Radar-Pfad

--- a/docs/features/gewitter-gesamtkonzept.md
+++ b/docs/features/gewitter-gesamtkonzept.md
@@ -170,13 +170,57 @@ herrscht, sondern weil anders gemessen wird.
 Gegenläufig wirkt die Auflösung: ICON-EU (6,5 km) mittelt stärker als ICON-D2 (2,2 km) und
 dämpft Spitzenwerte. Welcher Effekt überwiegt, ist **nicht bekannt**.
 
-> **Messstand:** Am identischen Ausschnitt (DE/Alpen, 1020 Gitterpunkte, +15 h) war die
-> Stichprobe an einem ruhigen Tag zu klein für eine Quantifizierung — nur 2 Punkte trugen
-> überhaupt Werte, beide nur in ICON-EU. Die Richtung stimmt, der Betrag ist **offen**. Der
-> strukturelle Befund folgt aus der Definition der Statistik, nicht aus dieser Messung.
+### 4.2 Der Bruch ist vermessen — und größer als erwartet
 
-⇒ Zu klären ist, ob `lpi_con_max` eine eigene Schwellenleiter braucht oder ein eigenes Feld.
-Solange beides offen ist, ist die Stufe zwischen DWD-Gebieten nicht sauber vergleichbar.
+Messung 2026-08-08, ICON-D2-Gebiet, Zeitschritte +15/16/17 h, 3,77 Mio. bzw. 459 Tsd.
+Gitterwerte. Anteil der Punkte, die die **gemeinsame** Schwellenleiter überschreiten:
+
+| Schwelle | ICON-D2 `lpi` | ICON-EU `lpi_con_max` | Faktor |
+|---|---|---|---|
+| ≥ 5 („leicht") | 0,007 % | 1,72 % | **235×** |
+| ≥ 20 („mittel") | 0,003 % | 0,47 % | **137×** |
+| ≥ 50 („hoch") | 0,001 % | 0,053 % | **57×** |
+
+An 5631 Punkten der Vereinigungsmenge (mindestens eine Quelle mit Signal) trug ICON-D2 nur in
+**5 %** der Fälle einen Wert > 0, ICON-EU in **97 %**; ICON-EU war an **96 %** der Punkte größer.
+
+⇒ **Ein Ort im ICON-EU-Gebiet bekommt bei gleicher Wetterlage rund zweihundertmal häufiger die
+Stufe „leicht" als einer im ICON-D2-Gebiet.** Das ist keine Feinheit, das ist ein struktureller
+Fehler mit direkter Alarmwirkung.
+
+### 4.3 Zwei Ursachen — eine davon ist behebbar
+
+**Ursache 1: verschiedene Statistik.** `lpi` ist ein Momentanwert, `lpi_con_max` ein
+Stundenmaximum. Vergleicht man stattdessen `lpi_max` (ICON-D2 bietet es an, wird mit #1531
+ohnehin geholt) mit `lpi_con_max`, also **Maximum gegen Maximum**, schrumpft der Bruch um
+Faktor 5:
+
+| Schwelle | Momentan ↔ Maximum | Maximum ↔ Maximum |
+|---|---|---|
+| ≥ 5 | 235× | **51×** |
+| ≥ 20 | 137× | **27×** |
+| ≥ 50 | 57× | **8,7×** |
+
+**Ursache 2: verschiedene Physik — nicht behebbar, nur berücksichtigbar.** Der Rest steckt im
+Namen: `lpi_**con**_max`. ICON-EU (6,5 km) **parametrisiert** Konvektion, ICON-D2 (2,2 km)
+**löst sie explizit auf**. Das sind zwei grundverschiedene Darstellungen desselben Vorgangs. Die
+Annahme im Code, es sei „fachlich dieselbe Größe" (`dwd_eu.py:90-95`), trifft damit nicht zu.
+
+### 4.4 Warum ein reiner Häufigkeits-Abgleich hier nicht reicht
+
+Das naheliegende Verfahren — nicht die Zahl übertragen, sondern die **Seltenheit** (so hat der
+US-Dienst SPC 2019 feste Schwellen durch Perzentile ersetzt) — wurde gerechnet und liefert für
+ICON-EU eine „leicht"-Schwelle von **155 J/kg**, während der DWD 5 J/kg als Grenze für „blitzt
+es überhaupt" nennt. Die drei geeichten Werte lägen zudem eng beieinander (155 / 176 / 208) —
+ein sicheres Zeichen, dass im dünnen Ausläufer der Verteilung gerechnet wurde.
+
+**Der Grund ist die Datenbasis, nicht das Verfahren:** eine einzelne, ruhige Wetterlage ist
+keine Klimatologie. Für eine belastbare Eichung braucht es mehrere Wochen über verschiedene
+Lagen — was mit dem laufenden Abruf (Rang 4) ohnehin anfällt.
+
+⇒ **Antwort auf E1b: ja, ICON-EU braucht eine eigene Leiter** — aber sie wird nicht geraten,
+sondern aus gesammelten Daten geeicht. Bis dahin darf die ICON-EU-Stufe nicht so behandelt
+werden, als wäre sie mit der ICON-D2-Stufe gleichbedeutend.
 
 **Optionen** (Entscheidung offen, s. Abschnitt 10):
 - **(a) Hinnehmen und benennen** — die Stufe bleibt „bestes verfügbares Urteil vor Ort", und der
@@ -311,20 +355,25 @@ Eine Wettermetrik hat in diesem Produkt **diverse Ausgabeorte, alle müssen bedi
 
 ---
 
-## 10. Offene Entscheidungen (PO)
+## 10. Entscheidungen
 
-| # | Frage | Empfehlung |
+### 10.1 Getroffen (PO, 2026-08-08)
+
+| # | Frage | **Entscheidung** |
 |---|---|---|
-| E1 | Umgang mit der gebietsabhängigen Bedeutung der Stufe (Abschnitt 4) | **(a) hinnehmen + im Vergleich benennen** — (b) verschenkt die guten Signale, (c) ist teuer |
-| E1b | Bekommt `lpi_con_max` eine eigene Schwellenleiter (Abschnitt 4.1)? | **Ja, sobald messbar** — vorher an ein paar echten Gewitterlagen den Versatz bestimmen; ohne Beleg keine erfundene Leiter |
-| E2 | Wird CAPE unsichtbar, obwohl die Wahrscheinlichkeit als Ersatz entfällt? | **Ja** — die Begründung („Zutat ist nicht Antwort") gilt unabhängig; die Stärke bleibt als Antwort |
-| E3 | Darf die Radar-Beobachtung die Stufe anheben (Abschnitt 5)? | **Ja** — sonst bleibt der Widerspruch „Radar sieht Gewitter, Stufe sagt kein Gewitter" bestehen. Regel liegt in #1419 §4 |
-| E4 | Bleibt es dauerhaft bei EINER Gewitter-Metrik? | Ja, bis eine flächige publizierte Wahrscheinlichkeitsquelle existiert |
-| E5 | Drei getrennte Gewitter-Alarme zusammenführen (Abschnitt 7.2)? | **Ja, mindestens entkoppeln** — für einen Wanderer mit knapper Verbindung sind drei Nachrichten zu einer Gefahr zu viel |
-| E6 | DWD-Warndienst für Deutschland anbinden (Abschnitt 6)? | **Ja** — Frankreich, Italien und Österreich haben amtliche Warnungen, Deutschland nicht |
-| E7 | Ausfallsichtbarkeit auch für den Radar-Pfad (Abschnitt 5)? | **Ja** — für die Vorhersagequellen ist es gebaut, für Radar fehlt es |
+| **E2** | CAPE unsichtbar, obwohl die Wahrscheinlichkeit als Ersatz entfällt? | **Ja.** `selectable=False`. Die Begründung „Zutat ist nicht Antwort" gilt unabhängig davon, ob je ein Ersatz kommt |
+| **E3** | Darf die Radar-Beobachtung die Stufe anheben? | **Ja.** Beobachtung hebt die Stufe — auch wenn die Vorhersage schweigt. Beseitigt den Widerspruch aus Abschnitt 5 |
+| **E4** | Bleibt es bei EINER sichtbaren Gewitter-Metrik? | **Ja**, bis eine flächige publizierte Wahrscheinlichkeitsquelle existiert |
+| **E5** | Die drei getrennten Gewitter-Alarme zusammenführen? | **Teilweise: amtliche Warnung und Änderungsalarm werden zusammengeführt, der Radar-Nowcast bleibt getrennt.** Fachlich stimmig — die beiden ersten beruhen auf Vorhersage und teilen den Zeithorizont; der Nowcast ist eine akute Beobachtung mit eigener Dringlichkeit und darf nicht in einer Sammelnachricht untergehen |
+| **E6** | DWD-Warndienst für Deutschland anbinden? | **Ja.** Schließt die Lücke, dass Deutschland als einziges Zielgebiet ohne amtliche Warnungen dasteht |
+| **E7** | Ausfallsichtbarkeit für den Radar-Pfad? | **Nein**, vorerst nicht. Bleibt als bekannte Schwachstelle dokumentiert (Abschnitt 5) |
 
----
+### 10.2 Offen — hängen an der Schwellen-Recherche
+
+| # | Frage | Stand |
+|---|---|---|
+| **E1** | Wie umgehen mit der ortsabhängigen Bedeutung der Stufe (Abschnitt 4)? | Wird erst entschieden, wenn geklärt ist, ob sich die Größen seriös aufeinander eichen lassen. Bei brauchbaren Zuordnungen wird aus „hinnehmen und benennen" ein „richtig eichen" |
+| **E1b** | Eigene Schwellenleiter für das ICON-EU-Stundenmaximum (Abschnitt 4.1)? | dito |
 
 ## 11. Umsetzung in Scheiben
 
@@ -334,12 +383,19 @@ Problem, statt es zu lösen.
 
 | Rang | Scheibe | Warum hier | Vorbedingung |
 |---|---|---|---|
-| **1** | **Eichung klären** (E1, E1b): Bedeutet „mittel" überall dasselbe? Braucht `lpi_con_max` eine eigene Leiter? | Fundament. Ohne das ist jede weitere Größe Rauschen auf schiefer Skala | PO-Entscheid |
-| **2** | **CAPE unsichtbar** (`selectable=False`) | Klein, unabhängig, beendet den historischen Zufall. Im Kern ein Katalog-Kwarg — die Render-Pfade prüfen `selectable` bereits generisch | E2 |
-| **3** | **Radar hebt die Stufe an** | Größter Nutzen ohne neue Quelle; beseitigt den Widerspruch aus Abschnitt 5 | E3 |
+| **1** | 🔴 **Eichung** (E1, E1b) — **jetzt, PO-Vorgabe 2026-08-08: vor jedem größeren Umbau.** Bedeutet „mittel" überall dasselbe? Braucht das ICON-EU-Stundenmaximum eine eigene Leiter? | Fundament. Ohne das ist jede weitere Größe Rauschen auf schiefer Skala | Schwellen-Recherche |
+| **2** | **CAPE unsichtbar** (`selectable=False`) | Klein, unabhängig, beendet den historischen Zufall. Im Kern ein Katalog-Kwarg — die Render-Pfade prüfen `selectable` bereits generisch | ✅ E2 |
+| **3** | **Radar hebt die Stufe an** | Größter Nutzen ohne neue Quelle; beseitigt den Widerspruch aus Abschnitt 5 | ✅ E3 |
 | **4** | **Fehlende DWD-Größen abrufen** (#1531) — Felder befüllen, mitlaufen lassen, **nicht** einstufen | Datensammlung als Voraussetzung für Rang 5. Spec liegt fertig vor | — |
-| **5** | **Einstufung nachziehen**: `sdi_2` (publizierte Schwelle), `cin_ml` statt CAPE-Deckelung | Erst wenn Rang 4 echte Messwerte geliefert hat | Rang 4 + belegte Schwellen |
-| **6** | **Alarme entkoppeln** (E5), **DWD-Warnungen** (E6), **Radar-Ausfallsichtbarkeit** (E7) | Unabhängig von der Signalkette, jederzeit einschiebbar | E5–E7 |
+| **5** | **Einstufung nachziehen**: `sdi_2`, `cin_ml` statt CAPE-Deckelung | Erst wenn Rang 1 die Skala geeicht und Rang 4 Messwerte geliefert hat | Rang 1 + 4 |
+| **6** | **Amtliche Warnung + Änderungsalarm zusammenführen** (E5); Radar-Nowcast bleibt eigener Kanal | Unabhängig von der Signalkette | ✅ E5 |
+| **7** | **DWD-Warndienst anbinden** (E6) | Deutschland ist das einzige Zielgebiet ohne amtliche Warnungen | ✅ E6 |
 
-**Nicht geplant:** Gewitter-Wahrscheinlichkeit (keine Quelle, Abschnitt 2.1), `uh_max`-Einstufung
-(keine übertragbare Zahl), `dbz_cmax`/`echotop` (falsch kalibriert bzw. falsche Größe).
+**Nicht geplant:** Gewitter-Wahrscheinlichkeit (keine Quelle, Abschnitt 2.1),
+`dbz_cmax`/`echotop` (falsch kalibriert bzw. falsche Größe), Ausfallsichtbarkeit im Radar-Pfad
+(E7 zurückgestellt).
+
+**In Prüfung, entscheidet Rang 1:** Ob sich die Signale seriös auf die vier groben Stufen
+abbilden lassen. Die bisherige Haltung „keine exakt publizierte Schwelle, also gar keine
+Einstufung" war womöglich zu streng — eine vierstufige Skala braucht keine
+Präzisionskalibrierung, sondern eine belastbare Zuordnung „ab hier wird es ernst".

--- a/docs/features/gewitter-gesamtkonzept.md
+++ b/docs/features/gewitter-gesamtkonzept.md
@@ -96,6 +96,8 @@ eine Stufe und nimmt dann **das schärfste**. Sind alle leer, ist das Ergebnis l
 - **Zwei von acht Schwellen sind interpoliert**, nicht publiziert (0,075 und 20). Das ist
   faktisch Eigenkalibrierung im Bestand — dieselbe Sache, die als Verbot die Schließung von
   #1456 begründet hat. Beide stehen ehrlich als Kommentar im Code.
+  ⇒ Für die LPI-Zwischenstufe gibt es inzwischen Ersatz: **30 J/kg ist publiziert**
+  (s. 3.5b), die interpolierte 20 kann entfallen.
 - **CAPE ist gedeckelt, weil die Gegengröße fehlt.** Viel Energie unter einem Deckel heißt: es
   passiert nichts. Da die Konvektionshemmung nie abgerufen wurde, wird CAPE vorsorglich nie
   höher als „leicht" gewertet. Das ist eine **Notbremse, kein Modell**.
@@ -104,7 +106,7 @@ eine Stufe und nimmt dann **das schärfste**. Sind alle leer, ist das Ergebnis l
 
 | Signal | Nutzen | Belegte Schwelle? | Verfügbar? |
 |---|---|---|---|
-| **Konvektionshemmung** `cin_ml` | macht CAPE erst verwertbar, ersetzt die Deckelung | ❌ keine publizierte Paarungsregel | ✅ ICON-D2 + ICON-EU |
+| **Konvektionshemmung** `cin_ml` | macht CAPE erst verwertbar, ersetzt die Deckelung | ✅ **50 J/kg belegt** (s. 3.5) | ✅ ICON-D2 + ICON-EU |
 | **Superzellen-Index** `sdi_2` | einziges Signal für die gefährlichste Gewitterform | ✅ **DWD: 0,0003 / 0,003 1/s** | ✅ nur ICON-D2 |
 | **Updraft-Helizität** `uh_max*` | Rotationsstärke | ❌ US-Werte 2019 vom Betreiber selbst verworfen | ✅ nur ICON-D2, drei Schichten |
 | **Blitzpotenzial-Maximum** `lpi_max` | Spitzenwert statt Momentanwert | wie LPI | ✅ ICON-D2 |
@@ -124,6 +126,71 @@ Superzellenlagen erreicht wird, ist offen. Zudem nennt der DWD den Index selbst 
 (2,8 km) — die Übertragung auf ICON-D2 (2,2 km, feiner) ist plausibel, aber nicht validiert.
 
 ⇒ Deshalb: **erst Felder befüllen und mitlaufen lassen, dann einstufen.** Nicht umgekehrt.
+
+### 3.5 Die CAPE-Deckelung ist belegt ersetzbar (Recherche 2026-08-08)
+
+Die heutige Notbremse („CAPE eskaliert nie über *leicht*") existiert nur, weil uns die
+Gegengröße fehlt. Für die CIN-Grenze gibt es einen über mehrere unabhängige Quellen
+konsistenten Korridor, darunter zwei Primärquellen:
+
+| Quelle | Aussage | Kategorie |
+|---|---|---|
+| **Penn State / COMET-Lehrmaterial** | „rank CIN values between 0 and minus 25 … as **weak** inhibition" · „between minus 25 and minus 50 … **moderate**" · „minus 50 … minus 100 …, think **large** inhibition" | belegt |
+| **SPC (NOAA)**, STP-Formel | CIN-Term `((mlCIN + 200) / 150)`, gedeckelt: bei CIN schwächer als **−50** kein Malus, bei **−200** fällt der Beitrag auf **null** | belegt |
+| **SPC**, Effective Inflow Layer | Schichten mit CIN unter **−250 J/kg** fallen ganz aus der Betrachtung | belegt |
+| **ECMWF** Forecast User Guide | ab **50 J/kg** wird CAPE auf Karten grau maskiert — eine **Darstellungs**schwelle, keine Kausalregel | belegt |
+| **DWD** | „Je größer die CIN-Werte sind, desto unwahrscheinlicher ist die Auslöse von Gewittern" — **ohne Zahl** | qualitativ |
+
+⇒ Belegte Eckpunkte sind **−25 / −50 / −100 / −200 J/kg**. Vorschlag für die Paarung:
+schwächer als −25 → CAPE zählt voll · −25 bis −50 → leicht gedämpft · −50 bis −100 → stark
+gedämpft, nur mit kräftigem Auslöser · unter −100 → kein Beitrag.
+
+🔴 **Korrektur einer verbreiteten Angabe:** Die kursierenden Werte „CIN > −10 = frei
+auslösbar" und „genau −50 als Schaltschwelle" sind **so nicht belegt** — sie klingen präzise,
+haben aber keine Quelle. Die tatsächlich belegten Grenzen sind die vier oben.
+
+🔴 **Gegenbefund, der mitgeschrieben gehört:** Rasmussen & Blanchard (1998), die
+meistzitierte Klimatologie dazu, findet **CIN als eigenständigen Schwere-Prädiktor nur schwach**
+— der stärkste Diskriminator war die LCL-Höhe. Für unseren Zweck trägt es trotzdem: Wir
+brauchen CIN als **Auslöse-Filter** („wird die Energie überhaupt abgerufen"), nicht als
+Schweremaß. Diese Unterscheidung muss in der Spec stehen, sonst wird daraus stillschweigend
+ein Schwere-Signal.
+
+### 3.5b Zwei weitere Leitern lassen sich belegen statt raten
+
+**LPI — die interpolierte Zwischenstufe wird überflüssig.** Bína et al. (Atmospheric Research
+2022 und ASR/Copernicus 2022, COSMO-D2, 2,2 km — dieselbe Modellfamilie wie ICON-D2):
+
+> „for 2-moment cloud microphysics a skilful forecast was reached at scales around 90 km for
+> LPI thresholds **30, 40 and 50 J/kg**" · als Nachweisschwelle: **„LPI > 1 J/kg"**
+
+⇒ Statt der heutigen Leiter **5 / 20 / 50** (mit interpolierter 20) ist **1 / 30 / 50**
+durchgehend belegt. Zu prüfen: ob die untere Grenze auf 1 sinken soll (mehr Meldungen) oder
+die operative DWD-Zahl 5 bleibt.
+
+**CAPE — es gibt eine echte Leiter, wir nutzen nur eine Stufe.** Mehrfach unabhängig bei NWS
+und SPC: „Weak instability: less than 1000 J/kg · Moderate: 1000 to 2500 · Strong: 2500–4000 ·
+Extreme: greater than 4000". Heute wertet das Produkt CAPE nur binär (≥ 1000 → „leicht",
+gedeckelt). Zusammen mit der Hemmung aus 3.5 könnte CAPE eine vollwertige, belegte Leiter
+tragen — **1000 / 2500 / 4000 J/kg**.
+
+### 3.6 Wo es weiterhin nichts gibt: Blitzdichte
+
+Für die Blitz**dichte pro km²** — die Korsika-Größe — existiert **keine publizierte
+Stufenskala** (mehrfach gesucht, deutsch und englisch). Gefunden wurden nur:
+zellbezogene Blitzraten (Lightning-Jump-Verfahren: 5/10/15 Blitze/min, aber **relativ** zum
+Zellverlauf, keine feste Stufe) und die LAL-Skala der US-Feuerwehrbehörden (1–2 / 2–3 / > 3
+Erdblitze/min) — Beobachtungsgrößen aus dem Feuerwetter-Kontext, nicht auf Modell-Blitzdichte
+je km² übertragbar.
+
+Auch die **Wetterdienste selbst quantifizieren Blitz nicht**: Der DWD führt Gewitter in seinen
+Warnkriterien nur qualitativ als „elektrische Entladung"; die Stufen 2–4 hängen an Böen
+(105–140 km/h), Starkregen (25–40 l/m²/h) und Hagelkorngröße — **keine Blitzrate**. Météo-France
+veröffentlicht seine Vigilance-Kriterien gar nicht.
+
+⇒ Die heutigen Blitzdichte-Schwellen (0,003 / 0,015 / 0,075) bleiben teilweise interpoliert.
+Das ist keine Nachlässigkeit, sondern der Stand der Veröffentlichungen — es muss aber als
+solches gekennzeichnet bleiben.
 
 ---
 
@@ -222,6 +289,30 @@ Lagen — was mit dem laufenden Abruf (Rang 4) ohnehin anfällt.
 sondern aus gesammelten Daten geeicht. Bis dahin darf die ICON-EU-Stufe nicht so behandelt
 werden, als wäre sie mit der ICON-D2-Stufe gleichbedeutend.
 
+### 4.5 Die Lösung steht bei den Wetterdiensten — Bedeutung harmonisieren, nicht Zahlen
+
+Genau dieses Problem haben die europäischen Wetterdienste bei ihren Warnstufen, und sie lösen
+es nicht durch einheitliche Zahlen. EMMA/Meteoalarm-Konferenzpapier (ECMWF 2008, ZAMG-Autoren):
+
+> „4-level matrix for impact, advice, return periods and meteorological thresholds.
+> **The meteorological thresholds differ from region to region due to the climatology of
+> extreme events.**"
+
+Harmonisiert sind **Farbcode, Bedeutungsebene und Verhaltensempfehlung**. Die Zahlenschwellen
+legt jeder nationale Dienst selbst fest, kalibriert über **Wiederkehrperioden** auf seine
+Klimatologie. Unabhängig bestätigt die LPI-Verifikationsliteratur dasselbe Prinzip für unsere
+Größe: die verlässliche LPI-Schwelle hängt von Auflösung und akzeptiertem räumlichen
+Toleranzradius ab (ASR 2022, COSMO-D2 2,2 km — dort **LPI > 1 J/kg** als Nachweisschwelle).
+
+⚠️ **Grenze dieses Vorbilds:** Übernommen wird das **Prinzip**, nicht die Methode. Die
+Wetterdienste stufen **wirkungsbasiert** ein (Böen in km/h, Regen in l/m², Hagelkorngröße) und
+kalibrieren über Wiederkehrperioden extremer Ereignisse. Wir stufen **modellparameterbasiert**
+ein. Eine „wie der DWD"-Rechtfertigung für unsere vier Stufen gibt es also nicht — der DWD
+stuft nach Wirkung, nicht nach CAPE oder Blitzpotenzial.
+
+⇒ **Leitlinie: je Quelle eine eigene Schwellenleiter, geeicht auf dieselbe Bedeutung.** Nicht
+dieselbe Zahl überall. Das ist kein Notbehelf, sondern der Stand der Praxis.
+
 **Optionen** (Entscheidung offen, s. Abschnitt 10):
 - **(a) Hinnehmen und benennen** — die Stufe bleibt „bestes verfügbares Urteil vor Ort", und der
   Vergleich weist aus, dass die Grundlage je Ort verschieden ist.
@@ -229,6 +320,9 @@ werden, als wäre sie mit der ICON-D2-Stufe gleichbedeutend.
   (praktisch: nur der Wettercode). Vergleichbar, aber deutlich schwächer.
 - **(c) Herkunft mitführen** — die Stufe trägt sichtbar, worauf sie beruht (z. B. „hoch,
   Blitzdichte" vs. „hoch, Blitzpotenzial+Superzelle").
+- **(d) Je Quelle eichen** *(neu, nach dem Meteoalarm-Vorbild)* — eigene Schwellen je
+  Modell/Auflösung, kalibriert auf gleiche Überschreitungshäufigkeit. Braucht mehrere Wochen
+  Daten (fällt mit Rang 4 ohnehin an) und ist mit (c) kombinierbar.
 
 ---
 

--- a/docs/features/gewitter-gesamtkonzept.md
+++ b/docs/features/gewitter-gesamtkonzept.md
@@ -67,7 +67,7 @@ Damit nichts durchs Raster fällt — das Produkt kennt **elf** Größen mit Gew
 | **Starkregen** `precipitation` | Sturzbäche | ✅ **sichtbar**, eigene Metrik — **bewusst nicht verrechnet** (E9) | überall |
 | CAPE | Energie | Zutat ⇒ unsichtbar (E2) | überall |
 | Konvektionshemmung `cin_ml` | hält der Deckel? | Zutat, ersetzt die CAPE-Notbremse | DWD-Gebiet |
-| Blitzdichte | Blitzaktivität (FR) | Zutat | nur FR/Korsika |
+| Blitzdichte | Blitzaktivität (FR) | Zutat | nur Frankreich inkl. Korsika |
 | Blitzpotenzial `lpi`/`lpi_max`/`lpi_con_max` | Blitzaktivität (DWD) | Zutat | DWD-Gebiete |
 | **Superzellen-Index** `sdi_2` | gefährlichste Form | **Zutat** (E8) — hebt die Stufe, kein eigenes Kennzeichen | nur ICON-D2 |
 | Updraft-Helizität `uh_max*` | Rotation | Zutat, vorerst ohne Schwelle | nur ICON-D2 |
@@ -79,10 +79,10 @@ aus unserer Berechnung (Abschnitt 6).
 
 **E8 — Superzellen bleiben Zutat, kein eigenes Kennzeichen.** Fachlich wäre ein Kennzeichen
 konsistent zu Hagel (beide beantworten „was für ein Gewitter", nicht „wie stark"). Ausschlag
-gab die Verfügbarkeit: Den Index gibt es **nur im ICON-D2-Gebiet**. Auf dem GR20 — dem
-Kernzielgebiet — erschiene er strukturell nie, und „kein Hinweis" läse sich dort als „keine
-Superzelle". Als Zutat hebt er die Stufe, ohne ein Schweigen zu erzeugen, das nach Entwarnung
-aussieht.
+gab die Verfügbarkeit: Den Index gibt es **nur im ICON-D2-Gebiet**. In **ganz Frankreich**
+— und damit auf dem GR20 — erschiene er strukturell nie, und „kein Hinweis" läse sich dort als
+„keine Superzelle". Als Zutat hebt er die Stufe, ohne ein Schweigen zu erzeugen, das nach
+Entwarnung aussieht.
 
 **E9 — Böen und Starkregen bleiben getrennte Metriken.** Der DWD stuft Gewitter zwar genau nach
 diesen Größen ein, aber er warnt **wirkungsbasiert**, wir beschreiben **Wetter**. Eine
@@ -243,7 +243,7 @@ ersetzt die heutige Fassung aus 3.1.
 | Zutat | kein | leicht | mittel | hoch | Beleg |
 |---|---|---|---|---|---|
 | **WMO-Wettercode** | < 95 | 95 | 96 | 99 | Anbieter |
-| **Blitzdichte** (FR/Korsika, Blitze/km²/3 h) | < 0,003 | ≥ 0,003 | ≥ 0,015 | ≥ 0,075 | ECMWF; **oberste Grenze interpoliert** |
+| **Blitzdichte** (Frankreich inkl. Korsika, Blitze/km²/3 h) | < 0,003 | ≥ 0,003 | ≥ 0,015 | ≥ 0,075 | ECMWF; **oberste Grenze interpoliert** |
 | **Blitzpotenzial ICON-D2** (J/kg) | < 1 | ≥ 1 | ≥ 30 | ≥ 50 | Bína et al., COSMO-D2 — **alle drei belegt** |
 | **Blitzpotenzial ICON-EU** (J/kg) | eigene Leiter — **zu eichen** (Rang 7), bis dahin nicht gleichwertig | | | | Faktor 235 gemessen |
 | **CAPE, gepaart mit Hemmung** | s. Schritt 2 | | | | NWS/SPC + Penn State |
@@ -294,20 +294,35 @@ nebeneinanderzustellen, die vergleichbar aussehen und es nicht sind.
 
 ### Was das je Gebiet konkret bedeutet
 
-| | **FR / Korsika (GR20)** | **DE / Alpen / AT** | **Übriges Europa** |
+Die Gebietsgrenzen sind **ganze Länderregionen**, nicht einzelne Touren: „FR" umfasst
+41,3–51,1° N / −5,2–9,7° O, also **ganz Frankreich einschließlich Korsika**
+(`thunder_routing.py:63-67`).
+
+| | **Frankreich inkl. Korsika** | **DE / Alpen / AT** | **Übriges Europa** |
 |---|---|---|---|
-| Wettercode | ✅ | ✅ | ✅ |
+| **Auflösung der Grundvorhersage** | **AROME 1,3 km — die feinste im System** | ICON-D2 2,0–2,2 km | ICON-EU / global, ab 6,5 km |
+| Wettercode (überall wirksam) | ✅ aus dem feinsten Modell | ✅ | ✅ |
 | Blitzsignal | Blitz**dichte** | Blitz**potenzial** (2,2 km) | Blitzpotenzial (6,5 km, eigene Leiter) |
 | CAPE + Hemmung | CAPE ja, **Hemmung nein** ⇒ bleibt gedeckelt | ✅ beides | ✅ beides |
 | Superzellen | ❌ nicht verfügbar | ✅ | ❌ |
 | Hagel-Kennzeichen | ❌ (→ #1507) | ✅ | ❌ |
 | Radar | ✅ (Radar-DPC) | ✅ | ✅ (global) |
 
-🔴 **Das Zielbild ist ehrlich, nicht schön:** Der GR20 — das Kernzielgebiet — bekommt die
-**schwächste** Signallage. Kein Superzellen-Index, kein Hagel-Kennzeichen, keine Hemmung, und
-das einzige Blitzsignal hat die am schlechtesten belegte Schwellenleiter. Wer das ändern will,
-muss bei Météo-France ansetzen (#1507 für Hagel, Energiegrößen offen) — dort kostet jede Größe
-allerdings einen Abruf **je Stunde**, anders als beim kostenlosen DWD.
+⚠️ **Signalanzahl ist nicht Vorhersagegüte — die beiden bitte nicht verwechseln.** Frankreich
+und Korsika haben die **wenigsten Zusatzsignale**, aber die **feinste Grundvorhersage**:
+AROME läuft mit 1,3 km und steht im Modellkatalog auf Priorität 1
+(`openmeteo.py:118-126`), feiner als ICON-D2 (2,0 km) und mehr als viermal feiner als ICON-EU.
+Der WMO-Wettercode — das einzige Signal, das überall wirkt und in der Fusion unmittelbar eine
+Stufe setzt — kommt dort also aus dem besten verfügbaren Modell, und bei 1,3 km wird Konvektion
+feiner aufgelöst als anderswo. Praxiserfahrung des PO aus dem Vorgängerprojekt bestätigt hohe
+Trefferqualität für Korsika.
+
+**Was für Frankreich/Korsika wirklich fehlt**, ist enger gefasst: die **Zusatz**signale
+(Superzellen-Index, Hagel-Kennzeichen, Konvektionshemmung) und eine belegte oberste Schwelle
+für die Blitzdichte. Wer das schließen will, muss bei Météo-France ansetzen (#1507 für Hagel,
+Energiegrößen offen) — dort kostet jede Größe allerdings einen Abruf **je Stunde**, anders als
+beim kostenlosen DWD. Die Kosten-Nutzen-Abwägung ist deshalb eine andere als beim DWD, und sie
+ist offen.
 
 ---
 
@@ -319,7 +334,7 @@ Gewittersignale kommen je Gebiet aus verschiedenen Quellen mit **verschiedenen G
 
 | Gebiet | Quelle | Signale, die ankommen |
 |---|---|---|
-| Frankreich/Korsika (**GR20**) | Météo-France AROME | Wettercode + **Blitzdichte** |
+| **Frankreich inkl. Korsika** (Region FR: 41,3–51,1 N / −5,2–9,7 O) | Météo-France AROME, **1,3 km** | Wettercode + **Blitzdichte** |
 | Deutschland/Alpen/Österreich | DWD ICON-D2 | Wettercode + **Blitzpotenzial** + Hagel |
 | Übriges Europa | DWD ICON-EU | Wettercode + **Blitzpotenzial**, kein Hagel |
 

--- a/docs/features/gewitter-gesamtkonzept.md
+++ b/docs/features/gewitter-gesamtkonzept.md
@@ -1,6 +1,8 @@
 # Gewitter — Gesamtkonzept
 
-**Stand:** 2026-08-08 · **Status:** Entwurf, PO-Entscheidungen offen (Abschnitt 10)
+**Stand:** 2026-08-08 · **Status:** **Final** — alle Grundsatzentscheidungen (E1–E9) vom PO
+getroffen und in Abschnitt 10 eingetragen. Änderungen an den Entscheidungsflächen erfordern
+künftig ein ADR, keine stille Anpassung.
 
 Dieses Dokument beschreibt Gewitter in Gregor Zwanzig **Ende zu Ende**: was der Nutzer bekommt,
 woraus es entsteht, was gemessen belegt ist und was nicht, und in welcher Reihenfolge gebaut
@@ -32,12 +34,17 @@ Drei Leitsätze, die alles Weitere binden:
 
 ## 2. Was der Nutzer sieht — die Antwort
 
-**Genau zwei Größen erreichen den Nutzer.** Alles andere ist Zutat und bleibt unsichtbar.
+**Genau zwei gewitter-eigene Größen erreichen den Nutzer.** Alle Zutaten der Berechnung bleiben
+unsichtbar.
 
 | Größe | Frage | Werte | Status |
 |---|---|---|---|
 | **Gewitter-Stärke** (`thunder`) | Wie stark? | kein · leicht · mittel · hoch | existiert; wird heute **unvollständig** berechnet |
 | **Hagel** (`hail_flag`) | Hagel dabei? | ja · unbekannt | existiert; eigenes Kennzeichen, **keine** Metrik (#1475) |
+
+Davon zu unterscheiden sind **Böen** und **Starkregen**: Sie sind eigenständige Wettermetriken,
+die auch ohne Gewitter existieren, und bleiben es (E9). Sie erscheinen also ebenfalls, aber
+nicht als Gewitteraussage — die vollständige Liste steht in 2.1b.
 
 ### 2.1 Die Wahrscheinlichkeit entfällt — gemessen, nicht vermutet
 
@@ -123,7 +130,7 @@ eine Stufe und nimmt dann **das schärfste**. Sind alle leer, ist das Ergebnis l
 |---|---|---|---|
 | 1 | WMO-Wettercode | 95 / 96 / 99 | vom Anbieter geliefert |
 | 2 | Blitzdichte (Blitze/km²/3 h) | 0,003 / 0,015 / **0,075** | ECMWF-Leitfaden; **0,075 nicht publiziert** |
-| 3 | Blitzpotenzial LPI (J/kg) | 5 / **20** / 50 | DWD/Copernicus; **20 interpoliert** |
+| 3 | Blitzpotenzial LPI (J/kg) | 5 / **20** / 50 | DWD/Copernicus; **20 interpoliert** ⇒ ersetzbar durch 1/30/50, s. 3.5b |
 | 4 | CAPE (J/kg) | ≥ 1000 → nur „leicht", **deckelt** | Katalog-Risikoschwelle |
 
 ### 3.2 Die Annahmen darin — offen ausgesprochen
@@ -267,7 +274,7 @@ solches gekennzeichnet bleiben.
 
 ---
 
-## 3.7 🎯 Das Zielverfahren — wie alle Zutaten zusammenwirken
+### 3.7 🎯 Das Zielverfahren — wie alle Zutaten zusammenwirken
 
 Dies ist die vollständige Rechenvorschrift, wenn alles aus diesem Konzept umgesetzt ist. Sie
 ersetzt die heutige Fassung aus 3.1.

--- a/docs/features/gewitter-gesamtkonzept.md
+++ b/docs/features/gewitter-gesamtkonzept.md
@@ -55,6 +55,45 @@ tragfähige Quelle.** Alle vier Wege wurden live geprüft:
 niemand — das ist eine bewusste Lücke, keine vergessene. Sollte je eine flächige, publizierte
 Quelle auftauchen, ist das Feld `thunder_probability_pct` bereits vorbereitet.
 
+### 2.1b Alle gewitterbezogenen Größen im Überblick
+
+Damit nichts durchs Raster fällt — das Produkt kennt **elf** Größen mit Gewitterbezug:
+
+| Größe | Beantwortet | Status | Verfügbar |
+|---|---|---|---|
+| **Gewitter-Stärke** `thunder` | wie stark | ✅ **sichtbar** | überall |
+| **Hagel** `hail_flag` | Hagel dabei? | ✅ **sichtbar**, eigenes Kennzeichen | nur DWD-Gebiet |
+| **Böen** `gust` | Sturm im Gewitter | ✅ **sichtbar**, eigene Metrik — **bewusst nicht verrechnet** (E9) | überall |
+| **Starkregen** `precipitation` | Sturzbäche | ✅ **sichtbar**, eigene Metrik — **bewusst nicht verrechnet** (E9) | überall |
+| CAPE | Energie | Zutat ⇒ unsichtbar (E2) | überall |
+| Konvektionshemmung `cin_ml` | hält der Deckel? | Zutat, ersetzt die CAPE-Notbremse | DWD-Gebiet |
+| Blitzdichte | Blitzaktivität (FR) | Zutat | nur FR/Korsika |
+| Blitzpotenzial `lpi`/`lpi_max`/`lpi_con_max` | Blitzaktivität (DWD) | Zutat | DWD-Gebiete |
+| **Superzellen-Index** `sdi_2` | gefährlichste Form | **Zutat** (E8) — hebt die Stufe, kein eigenes Kennzeichen | nur ICON-D2 |
+| Updraft-Helizität `uh_max*` | Rotation | Zutat, vorerst ohne Schwelle | nur ICON-D2 |
+| Gewitter-Wahrscheinlichkeit | wie sicher | **entfällt** — keine Quelle (2.1) | — |
+
+Dazu kommt `thunder_squall` als **amtlicher Warntyp** aus den Wetterdienst-Meldungen
+(Gewitterböe) — eine Aussage, die es bereits gibt, aber aus der Behördenmeldung stammt, nicht
+aus unserer Berechnung (Abschnitt 6).
+
+**E8 — Superzellen bleiben Zutat, kein eigenes Kennzeichen.** Fachlich wäre ein Kennzeichen
+konsistent zu Hagel (beide beantworten „was für ein Gewitter", nicht „wie stark"). Ausschlag
+gab die Verfügbarkeit: Den Index gibt es **nur im ICON-D2-Gebiet**. Auf dem GR20 — dem
+Kernzielgebiet — erschiene er strukturell nie, und „kein Hinweis" läse sich dort als „keine
+Superzelle". Als Zutat hebt er die Stufe, ohne ein Schweigen zu erzeugen, das nach Entwarnung
+aussieht.
+
+**E9 — Böen und Starkregen bleiben getrennte Metriken.** Der DWD stuft Gewitter zwar genau nach
+diesen Größen ein, aber er warnt **wirkungsbasiert**, wir beschreiben **Wetter**. Eine
+kombinierte Gefahrenstufe wäre bereits Bewertung und verstieße gegen ADR-0007 („Daten statt
+Empfehlungen"). Der Nutzer sieht beide Zahlen und kombiniert selbst — das ist die Zielgruppe.
+
+⚠️ Zu beachten: **Unsere Böen-Schwellen sind bewusst schärfer als die amtlichen.** Wir werten ab
+60 km/h „rot", der DWD beginnt seine Warnstufe 1 bei 50 und Stufe 2 erst bei 65 km/h. Richtig
+so — die Zielgruppe steht auf einem Grat, nicht in der Fußgängerzone. Es heißt aber auch: Eine
+Eichung „wie der DWD" wäre für dieses Produkt zu lasch.
+
 ### 2.2 Warum die Zutaten unsichtbar bleiben
 
 CAPE, Konvektionshemmung, Blitzdichte, Blitzpotenzial, Superzellen-Index sind **Zutaten** der
@@ -191,6 +230,84 @@ veröffentlicht seine Vigilance-Kriterien gar nicht.
 ⇒ Die heutigen Blitzdichte-Schwellen (0,003 / 0,015 / 0,075) bleiben teilweise interpoliert.
 Das ist keine Nachlässigkeit, sondern der Stand der Veröffentlichungen — es muss aber als
 solches gekennzeichnet bleiben.
+
+---
+
+## 3.7 🎯 Das Zielverfahren — wie alle Zutaten zusammenwirken
+
+Dies ist die vollständige Rechenvorschrift, wenn alles aus diesem Konzept umgesetzt ist. Sie
+ersetzt die heutige Fassung aus 3.1.
+
+### Schritt 1 — Jede Zutat wird für sich in eine Stufe übersetzt
+
+| Zutat | kein | leicht | mittel | hoch | Beleg |
+|---|---|---|---|---|---|
+| **WMO-Wettercode** | < 95 | 95 | 96 | 99 | Anbieter |
+| **Blitzdichte** (FR/Korsika, Blitze/km²/3 h) | < 0,003 | ≥ 0,003 | ≥ 0,015 | ≥ 0,075 | ECMWF; **oberste Grenze interpoliert** |
+| **Blitzpotenzial ICON-D2** (J/kg) | < 1 | ≥ 1 | ≥ 30 | ≥ 50 | Bína et al., COSMO-D2 — **alle drei belegt** |
+| **Blitzpotenzial ICON-EU** (J/kg) | eigene Leiter — **zu eichen** (Rang 7), bis dahin nicht gleichwertig | | | | Faktor 235 gemessen |
+| **CAPE, gepaart mit Hemmung** | s. Schritt 2 | | | | NWS/SPC + Penn State |
+| **Superzellen-Index** (Betrag, 1/s) | < 0,0003 | — | ≥ 0,0003 | ≥ 0,003 | DWD publiziert |
+| **Radar-Beobachtung** | nicht konvektiv | — | konvektiv | — | #1419 §4 |
+| **Updraft-Helizität** | trägt vorerst **nichts** bei — keine übertragbare Schwelle | | | | — |
+
+Der Superzellen-Index kennt bewusst **kein „leicht"**: Der DWD nennt ihn ein experimentelles
+Produkt mit zwei Schwellen; eine dritte zu erfinden wäre Eigenkalibrierung.
+
+### Schritt 2 — CAPE zählt nur so weit, wie die Hemmung es zulässt
+
+Heute wird CAPE pauschal auf „leicht" gedeckelt, weil die Gegengröße fehlt. Künftig entscheidet
+die Konvektionshemmung, **wie viel** von der Energie überhaupt zählt:
+
+| Hemmung (CIN) | Bedeutung | CAPE darf höchstens |
+|---|---|---|
+| 0 bis −25 J/kg | schwacher Deckel | **voll wirken** — Leiter 1000 / 2500 / 4000 J/kg |
+| −25 bis −50 | moderat | **eine Stufe weniger** |
+| −50 bis −100 | großer Deckel | **höchstens „leicht"** (heutiges Verhalten) |
+| unter −100 | Deckel hält | **kein Beitrag** |
+| Hemmung unbekannt | keine Aussage | **höchstens „leicht"** — die heutige Notbremse bleibt als sicherer Rückfall |
+
+⚠️ **Ausdrücklich:** Die Hemmung ist ein **Auslöse-Filter**, kein Schweremaß. Rasmussen &
+Blanchard (1998) zeigen, dass CIN die Schwere nur schwach vorhersagt — sie darf die Stufe
+deshalb **dämpfen, aber nie anheben**.
+
+### Schritt 3 — Fusion: das schärfste Signal gewinnt
+
+Unverändert. Alle vorhandenen Einzelstufen werden verglichen, die höchste zählt. Sind **alle**
+Zutaten leer, ist das Ergebnis leer — „keine Aussage", nicht „keine Gefahr".
+
+Bewusst **keine** Mittelung und **keine** Gewichtung: Ein Signal, das Gefahr meldet, wiegt
+schwerer als drei, die schweigen. Der Preis ist bekannt — ein einzelner Ausreißer hebt die
+Stufe.
+
+### Schritt 4 — Beobachtung darf anheben, nie senken
+
+Meldet das Radar für die Etappenzeit Konvektion, wird die Stufe auf mindestens „mittel"
+gehoben (E3). Umgekehrt gilt es nicht: Ein ruhiges Radarbild senkt eine hohe Vorhersagestufe
+**nicht** — das Gewitter kann noch entstehen.
+
+### Schritt 5 — Die Stufe trägt ihre Herkunft mit
+
+Jede Stufe merkt sich, **welche Zutat sie ausgelöst hat** (E1). Im Ortsvergleich wird damit
+erkennbar, dass Korsika und die Alpen auf verschiedenen Größen fußen — statt zwei Zahlen
+nebeneinanderzustellen, die vergleichbar aussehen und es nicht sind.
+
+### Was das je Gebiet konkret bedeutet
+
+| | **FR / Korsika (GR20)** | **DE / Alpen / AT** | **Übriges Europa** |
+|---|---|---|---|
+| Wettercode | ✅ | ✅ | ✅ |
+| Blitzsignal | Blitz**dichte** | Blitz**potenzial** (2,2 km) | Blitzpotenzial (6,5 km, eigene Leiter) |
+| CAPE + Hemmung | CAPE ja, **Hemmung nein** ⇒ bleibt gedeckelt | ✅ beides | ✅ beides |
+| Superzellen | ❌ nicht verfügbar | ✅ | ❌ |
+| Hagel-Kennzeichen | ❌ (→ #1507) | ✅ | ❌ |
+| Radar | ✅ (Radar-DPC) | ✅ | ✅ (global) |
+
+🔴 **Das Zielbild ist ehrlich, nicht schön:** Der GR20 — das Kernzielgebiet — bekommt die
+**schwächste** Signallage. Kein Superzellen-Index, kein Hagel-Kennzeichen, keine Hemmung, und
+das einzige Blitzsignal hat die am schlechtesten belegte Schwellenleiter. Wer das ändern will,
+muss bei Météo-France ansetzen (#1507 für Hagel, Energiegrößen offen) — dort kostet jede Größe
+allerdings einen Abruf **je Stunde**, anders als beim kostenlosen DWD.
 
 ---
 
@@ -461,13 +578,19 @@ Eine Wettermetrik hat in diesem Produkt **diverse Ausgabeorte, alle müssen bedi
 | **E5** | Die drei getrennten Gewitter-Alarme zusammenführen? | **Teilweise: amtliche Warnung und Änderungsalarm werden zusammengeführt, der Radar-Nowcast bleibt getrennt.** Fachlich stimmig — die beiden ersten beruhen auf Vorhersage und teilen den Zeithorizont; der Nowcast ist eine akute Beobachtung mit eigener Dringlichkeit und darf nicht in einer Sammelnachricht untergehen |
 | **E6** | DWD-Warndienst für Deutschland anbinden? | **Ja.** Schließt die Lücke, dass Deutschland als einziges Zielgebiet ohne amtliche Warnungen dasteht |
 | **E7** | Ausfallsichtbarkeit für den Radar-Pfad? | **Nein**, vorerst nicht. Bleibt als bekannte Schwachstelle dokumentiert (Abschnitt 5) |
+| **E1** | Umgang mit der ortsabhängigen Bedeutung der Stufe? | **Je Quelle eichen + Herkunft mitführen.** Eigene Schwellen je Modell, geeicht auf gleiche Häufigkeit (Prinzip der Wetterdienste); zusätzlich trägt die Stufe sichtbar, worauf sie beruht |
+| **E1b** | Eigene Schwellenleiter für das ICON-EU-Stundenmaximum? | **Ja** — Faktor 235 gemessen (4.2). Sofort wirksam ohne Kalibrierung: gleiche Statistik verwenden (`lpi_max`), das nimmt Faktor 5 heraus |
+| **E8** | Superzellen: Zutat oder eigenes Kennzeichen? | **Zutat.** Hebt die Stufe, bleibt unsichtbar — weil es den Index nur im DWD-Gebiet gibt und ein Schweigen auf dem GR20 wie Entwarnung aussähe (2.1b) |
+| **E9** | Böen und Starkregen in die Gewitterstufe einrechnen? | **Nein, getrennt lassen.** Eine kombinierte Gefahrenstufe wäre Bewertung statt Beschreibung (ADR-0007) |
 
-### 10.2 Offen — hängen an der Schwellen-Recherche
+### 10.2 Offen
 
-| # | Frage | Stand |
-|---|---|---|
-| **E1** | Wie umgehen mit der ortsabhängigen Bedeutung der Stufe (Abschnitt 4)? | Wird erst entschieden, wenn geklärt ist, ob sich die Größen seriös aufeinander eichen lassen. Bei brauchbaren Zuordnungen wird aus „hinnehmen und benennen" ein „richtig eichen" |
-| **E1b** | Eigene Schwellenleiter für das ICON-EU-Stundenmaximum (Abschnitt 4.1)? | dito |
+Keine offenen Grundsatzfragen mehr. Was bleibt, ist **Arbeit, nicht Entscheidung**:
+
+| Was | Braucht |
+|---|---|
+| Feineichung der Schwellen je Quelle (E1b, Rang 7) | mehrere Wochen Messdaten über verschiedene Wetterlagen — fällt mit Rang 1 an |
+| Einstufung des Superzellen-Index (Rang 8) | Beobachtung, wie oft er überhaupt anschlägt |
 
 ## 11. Umsetzung in Scheiben
 
@@ -477,13 +600,23 @@ Problem, statt es zu lösen.
 
 | Rang | Scheibe | Warum hier | Vorbedingung |
 |---|---|---|---|
-| **1** | 🔴 **Eichung** (E1, E1b) — **jetzt, PO-Vorgabe 2026-08-08: vor jedem größeren Umbau.** Bedeutet „mittel" überall dasselbe? Braucht das ICON-EU-Stundenmaximum eine eigene Leiter? | Fundament. Ohne das ist jede weitere Größe Rauschen auf schiefer Skala | Schwellen-Recherche |
-| **2** | **CAPE unsichtbar** (`selectable=False`) | Klein, unabhängig, beendet den historischen Zufall. Im Kern ein Katalog-Kwarg — die Render-Pfade prüfen `selectable` bereits generisch | ✅ E2 |
-| **3** | **Radar hebt die Stufe an** | Größter Nutzen ohne neue Quelle; beseitigt den Widerspruch aus Abschnitt 5 | ✅ E3 |
-| **4** | **Fehlende DWD-Größen abrufen** (#1531) — Felder befüllen, mitlaufen lassen, **nicht** einstufen | Datensammlung als Voraussetzung für Rang 5. Spec liegt fertig vor | — |
-| **5** | **Einstufung nachziehen**: `sdi_2`, `cin_ml` statt CAPE-Deckelung | Erst wenn Rang 1 die Skala geeicht und Rang 4 Messwerte geliefert hat | Rang 1 + 4 |
-| **6** | **Amtliche Warnung + Änderungsalarm zusammenführen** (E5); Radar-Nowcast bleibt eigener Kanal | Unabhängig von der Signalkette | ✅ E5 |
-| **7** | **DWD-Warndienst anbinden** (E6) | Deutschland ist das einzige Zielgebiet ohne amtliche Warnungen | ✅ E6 |
+🔴 **Umstellung 2026-08-08:** Die Eichung (E1) braucht genau die Größen, die #1531 holt —
+`lpi_max`, um gleiche Statistik gegen gleiche Statistik zu stellen, und `cin_ml`, um die
+CAPE-Deckelung zu ersetzen. #1531 ist damit **nicht** eine spätere Scheibe, sondern die
+**Voraussetzung** der Eichung.
+
+| Rang | Scheibe | Warum hier | Stand |
+|---|---|---|---|
+| **1** | **Fehlende DWD-Größen abrufen** (#1531) — Felder befüllen, **nicht** einstufen | Liefert `lpi_max` (gleiche Statistik) und `cin_ml` (ersetzt die Deckelung). Ohne diese Daten ist keine Eichung möglich. Spec liegt fertig vor | Spec fertig, Freigabe offen |
+| **2** | **Belegte Leitern übernehmen**: LPI **1/30/50** statt 5/**20**/50 · CAPE **1000/2500/4000** statt binär · CIN-Paarung **−25/−50/−100/−200** statt Deckelung | Beseitigt eine der beiden erfundenen Zahlen und macht CAPE zu einem vollwertigen Signal. Alles belegt (3.5, 3.5b) | ✅ E1 |
+| **3** | **Gleiche Statistik**: `lpi_max` statt `lpi` gegen `lpi_con_max` | Nimmt allein **Faktor 5** aus dem Gebietsbruch — ohne jede Kalibrierung | ✅ E1 |
+| **4** | **Herkunft mitführen** — die Stufe trägt sichtbar, worauf sie beruht | Macht im Ortsvergleich erkennbar, dass Korsika und Alpen auf verschiedenen Größen fußen | ✅ E1 |
+| **5** | **CAPE unsichtbar** (`selectable=False`) | Klein, unabhängig. Im Kern ein Katalog-Kwarg — die Render-Pfade prüfen `selectable` bereits generisch | ✅ E2 |
+| **6** | **Radar hebt die Stufe an** | Beseitigt den Widerspruch aus Abschnitt 5 | ✅ E3 |
+| **7** | **Feineichung je Quelle** (E1b): eigene Leiter für `lpi_con_max`, kalibriert auf gleiche Überschreitungshäufigkeit | Braucht mehrere Wochen Daten über verschiedene Wetterlagen — fällt mit Rang 1 an | ✅ E1b, Daten offen |
+| **8** | **`sdi_2` einhängen** | Publizierte DWD-Schwelle vorhanden; erst sinnvoll, wenn die Skala geeicht ist | nach Rang 7 |
+| **9** | **Amtliche Warnung + Änderungsalarm zusammenführen** (E5); Radar-Nowcast bleibt eigener Kanal | Unabhängig von der Signalkette | ✅ E5 |
+| **10** | **DWD-Warndienst anbinden** (E6) | Deutschland ist das einzige Zielgebiet ohne amtliche Warnungen | ✅ E6 |
 
 **Nicht geplant:** Gewitter-Wahrscheinlichkeit (keine Quelle, Abschnitt 2.1),
 `dbz_cmax`/`echotop` (falsch kalibriert bzw. falsche Größe), Ausfallsichtbarkeit im Radar-Pfad

--- a/docs/specs/modules/feat_1531_s1_dwd_gewittergroessen.md
+++ b/docs/specs/modules/feat_1531_s1_dwd_gewittergroessen.md
@@ -1,0 +1,249 @@
+---
+entity_id: feat_1531_s1_dwd_gewittergroessen
+status: draft
+type: module
+created: 2026-08-08
+updated: 2026-08-08
+version: "1.0"
+tags: [gewitter, provider, dwd, icon-d2, icon-eu, 1531]
+---
+
+# DWD liefert die fehlenden Gewittergrößen (sdi_2, cin_ml, cape_ml, lpi_max, uh_max)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Epic #1419 §2a/§3.2 vereinbart je Gebiet eine **Liste** von Gewittergrößen. #1457 (S2) wurde
+geschlossen, obwohl davon nur zwei abgerufen werden (`lpi`, `grau_gsp`). Diese Scheibe holt die
+fehlenden ICON-D2-Größen nach und ergänzt die Energiegrößen in ICON-EU.
+
+Zwei davon sind nicht Kür:
+- **`sdi_2`** (Superzellen) — Superzellen sind die gefährlichste Gewitterform; dafür gibt es
+  heute **kein** Signal, auch nicht indirekt.
+- **`cin_ml`** (Konvektionshemmung) — CAPE fließt heute **ohne** seine Gegengröße in die
+  Einstufung. Genau deshalb ist CAPE in der Fusion vorsorglich auf `LOW` gedeckelt; mit der
+  Hemmung wäre die Deckelung fachlich ersetzbar statt Notbremse.
+
+DWD ist **kontingentfrei** — die Größen liegen in denselben Verzeichnissen, aus denen täglich
+geladen wird.
+
+## Scope-Abgrenzung
+
+**In dieser Scheibe:** Abruf und Befüllung eigener Felder. Sonst nichts.
+
+**NICHT in dieser Scheibe:** keine Einstufung, keine Schwellen, keine Fusion in
+`thunder_level`, keine Katalogmetrik, keine Ausgabe in Mail/SMS/Telegram/Compare. Der Provider
+füllt Felder und kennt keine Stufen (#1419 §5). Die Einstufung folgt erst, wenn die Felder da
+sind und Messwerte vorliegen (Muster #1474). **Météo-France ist eine eigene Scheibe** — dort
+kostet jede Größe einen Abruf je Stunde (#1419 §3.2), hier ist es kostenlos.
+
+## Source
+
+- **File:** `src/providers/dwd.py`, `src/providers/dwd_eu.py`,
+  `src/providers/thunder_enrichment.py`, `src/app/models.py`
+- **Identifier:** `THUNDER_PARAMS`, `_read_point_value`, `_SIGNAL_ZU_FELD`,
+  `ForecastDataPoint`
+
+Schicht: **Python-Core** (`src/providers/`, `src/app/`). Kein Go, kein Frontend.
+
+## Vorbedingung — bereits geklärt (live gemessen 2026-08-08)
+
+Die Namensfalle aus #1457 S2a (`LITOTA3` existierte beim Dienst nicht, jeder Abruf lief lautlos
+in 404 bei 24 grünen Tests) ist für diese Scheibe **vorab ausgeschlossen**. Gemessen gegen das
+Verzeichnislisting von `opendata.dwd.de`:
+
+| Größe | ICON-D2 | ICON-EU | Semantik (gemessen) | Fehlwerte (gemessen) |
+|---|---|---|---|---|
+| `sdi_2` | ✅ | ❌ nicht angeboten | Momentanwert, **vorzeichenbehaftet** | 9999,0 (16,7 %) |
+| `cin_ml` | ✅ | ✅ | Momentanwert | 9999,0 **und −999,9 (46 %)** |
+| `cape_ml` | ✅ | ✅ | Momentanwert | 9999,0 |
+| `lpi_max` | ✅ | ❌ (dort `lpi_con_max`) | Momentanwert | 9999,0 |
+| `uh_max`, `uh_max_med`, `uh_max_low` | ✅ | ❌ nicht angeboten | Momentanwert, drei **verschiedene** Felder | 9999,0 |
+| `cape_con` | ❌ nicht angeboten | ✅ | — | — |
+
+Alle auch als `regular-lat-lon` verfügbar (das Gitter aus `_build_url`, `dwd.py:190`).
+
+## Implementation Details
+
+### 1. Sieben neue Felder in `ForecastDataPoint` (`src/app/models.py`)
+
+```python
+supercell_index_sdi2_1s: Optional[float] = None          # 1/s, vorzeichenbehaftet
+convective_inhibition_jkg: Optional[float] = None        # J/kg
+cape_ml_jkg: Optional[float] = None                      # J/kg, ICON-D2/EU
+lightning_potential_max_lpi_jkg: Optional[float] = None
+updraft_helicity_max_m2s2: Optional[float] = None        # m²/s², Gesamtsäule
+updraft_helicity_max_med_m2s2: Optional[float] = None    # m²/s², mittlere Schicht (2–5 km)
+updraft_helicity_max_low_m2s2: Optional[float] = None    # m²/s², untere Schicht
+```
+
+Sieben neue Felder. Je Größe ein eigenes Feld — die drei Updraft-Varianten tragen
+**verschiedene** Werte (s. u.) und dürften niemals dieselbe Spalte teilen.
+
+`cape_ml` bekommt ein **eigenes** Feld statt `cape_jkg` mitzubenutzen: „je Größe ein eigenes
+Feld" (#1419 §3.1/§5), und `cape_jkg` wird bereits von einer anderen Quelle gefüllt
+(`models.py:113`). Ein geteiltes Feld für zwei Quellen wäre nicht mehr zuordenbar.
+
+### 2. Abrufliste erweitern
+
+```python
+# dwd.py — Reihenfolge = Ausfallreihenfolge bei Budget-Ende (s. AC-7)
+THUNDER_PARAMS = (
+    "lpi", "grau_gsp", "cin_ml", "sdi_2", "cape_ml", "lpi_max",
+    "uh_max_med", "uh_max", "uh_max_low",
+)
+THUNDER_CUMULATIVE_PARAMS = ("grau_gsp",)   # UNVERÄNDERT — alle neuen sind Momentanwerte
+THUNDER_FETCH_DEADLINE_SECONDS = 150.0      # war 90.0 (PO-Entscheid 2026-08-08)
+
+# dwd_eu.py
+THUNDER_PARAMS = ("lpi_con_max", "cape_ml", "cape_con", "cin_ml")
+```
+
+**Alle drei Updraft-Varianten werden geholt** (PO-Entscheid 2026-08-08). Gemessen sind es drei
+verschiedene Felder, kein Duplikat:
+
+| Größe | Wertebereich (+15 h) | am Ort des Gesamtmaximums |
+|---|---|---|
+| `uh_max` | −114 … 127 | 126,9 |
+| `uh_max_low` | −18 … 25 | 9,7 |
+| `uh_max_med` | −30 … 39 | 17,7 |
+
+`uh_max` ist am selben Punkt rund **siebenmal größer** als die Schichtvarianten — also nicht
+deren Maximum, sondern eine andere Schicht oder Rechenweise. Entscheidend: Die einzigen je
+publizierten Zahlen (SPC: 75/150 m²/s²) beziehen sich auf die Schicht **2–5 km**, also auf
+`uh_max_med`. Ohne die Schichtvarianten ließe sich später gar nicht prüfen, welche Variante
+einstufbar ist. `uh_max_med` steht deshalb **vor** `uh_max` in der Reihenfolge.
+
+### 3. Zweiter Fehlwert-Marker für `cin_ml`
+
+`_read_point_value` prüft heute nur nach oben (`wert >= sentinel`, `dwd.py:212-217`).
+**−999,9 ist kleiner und würde durchgereicht** — als Konvektionshemmung von −999,9 J/kg, bei
+46 % der Gitterpunkte. Fachlich fatal: daraus würde später „praktisch kein Deckel, CAPE schlägt
+voll durch" gelesen. Der Marker bedeutet **„keine Aussage"**, nicht „keine Hemmung"
+(`None`-Kontrakt #1377) — plausibel, weil CIN undefiniert ist, wo mangels CAPE nichts zu hemmen
+ist.
+
+Die Prüfung wird **je Parameter** geführt, nicht global — genau der Analogieschluss, vor dem
+`dwd_eu.py:219-221` warnt („der dritte Analogieschluss in Folge, der sich als falsch erweist").
+
+### 4. Signal→Feld-Zuordnung (`thunder_enrichment.py:36-39`)
+
+Die sieben neuen Paare kommen in `_SIGNAL_ZU_FELD`. Der bestehende Weg
+(`setattr(dp, feld, wert)` nur bei `wert is not None`, `:261-268`) bleibt unverändert.
+
+## Expected Behavior
+
+- **Input:** Ort + Zeitfenster wie heute; keine neue Schnittstelle nach außen
+- **Output:** sieben zusätzlich befüllte Felder je `ForecastDataPoint` im ICON-D2-Gebiet,
+  drei im ICON-EU-Gebiet
+- **Side effects:** mehr HTTP-Abrufe gegen `opendata.dwd.de` (kontingentfrei); **keine**
+  Änderung an irgendeiner Nutzerausgabe
+
+## Acceptance Criteria
+
+> **Hinweis zur Testart:** Diese Scheibe ist reiner Datenabruf und **darf per AC-9 keine
+> Ausgabe verändern** — ein Nachweis über Mail/SMS/Compare ist deshalb strukturell unmöglich
+> und wäre ein Widerspruch zum Scope. Beobachtbares Verhalten ist hier: *die Anreicherung
+> ausführen und den entstandenen Datenpunkt befragen.* Alle Tests unten führen den echten
+> Ablauf (`enrich_thunder` → Provider → Datenpunkt) gegen aufgezeichnete GRIB-Dateien aus.
+> **Kein** Test liest Quelltext oder prüft Dateiinhalte per `read_text()`.
+
+- **AC-1:** Given ein Ort im ICON-D2-Gebiet mit veröffentlichtem Lauf / When die
+  Gewitter-Anreicherung läuft / Then tragen die Datenpunkte Werte in allen sieben neuen Feldern,
+  und zwar dieselben Zahlen, die die DWD-Datei an diesem Gitterpunkt enthält.
+  - Test: `enrich_thunder()` gegen aufgezeichnete GRIB-Dateien ausführen; die entstandenen
+    Datenpunkte gegen die unabhängig aus derselben Datei ausgelesenen Gitterwerte vergleichen
+    — nicht gegen eine im Test notierte Konstante, die mitwandern würde.
+
+- **AC-2:** Given `cin_ml` steht an einem Gitterpunkt auf dem Marker −999,9 / When der Wert
+  gelesen wird / Then bleibt das Feld `None` und trägt **nicht** die Zahl −999,9.
+  - Test: Anreicherung für einen Ort ausführen, dessen Gitterpunkt −999,9 trägt; der
+    entstandene Datenpunkt hat `convective_inhibition_jkg is None`. **Gegenprobe im selben
+    Test:** ein Ort mit echtem Wert (gemessen z.B. 7,8 J/kg) behält ihn — sonst würde ein
+    Filter, der pauschal alles verwirft, ebenfalls grün werden.
+
+- **AC-3:** Given ein Gitterpunkt außerhalb des Modellgebiets (Marker 9999,0) / When der Wert
+  gelesen wird / Then bleibt das jeweilige Feld `None` für **jede** der sieben neuen Größen.
+  - Test: je Größe ein Punkt außerhalb des Gebiets; alle sieben Felder `None`.
+
+- **AC-4:** Given `sdi_2` liefert an einem Punkt einen negativen Wert (antizyklonale Rotation)
+  / When der Wert gespeichert wird / Then steht die Zahl **mit Vorzeichen** im Feld, also
+  −0,0007 und nicht 0,0007.
+  - Test: Punkt mit negativem `sdi_2`; Feldwert muss negativ sein. Begründung: der Provider
+    liefert Rohwerte; die Betragsbildung gehört in die spätere Einstufung, nicht hierher.
+
+- **AC-5:** Given eine Stunde mit einem Gewitter im Modell / When die Werte über mehrere
+  Zeitschritte gelesen werden / Then entsprechen die Feldwerte den **Momentanwerten** der
+  jeweiligen Stunde; keine der sieben neuen Größen wird als kumuliert zurückgerechnet.
+  - Test: Zeitreihe, in der ein Wert wieder fällt (gemessen: `lpi_max` 0 → 95,45 → 88,69 → 0);
+    Feldwerte müssen diesem Verlauf folgen. Bei kumulierter Behandlung wären sie Differenzen
+    und der Test rot.
+
+- **AC-6:** Given ein Ort im ICON-EU-Gebiet / When die Anreicherung läuft / Then werden
+  `cape_ml`, `cape_con` und `cin_ml` befüllt, und `sdi_2` sowie alle drei `uh_max*`-Varianten bleiben `None`, weil ICON-EU
+  sie nicht anbietet.
+  - Test: Ort außerhalb des D2-Gebiets (z.B. Mallorca); die drei Energiefelder tragen Werte,
+    die vier anderen sind `None`.
+
+- **AC-7:** Given das Zeitbudget der Anreicherung (150 s) wird erschöpft / When der Abbruch
+  greift / Then sind `lpi`, `grau_gsp` und `cin_ml` bereits abgerufen, weil sie in der
+  Reihenfolge vorn stehen; die Anreicherung bricht fail-soft ab und die Grundvorhersage bleibt
+  unberührt.
+  - Test: künstlich kleines Budget setzen; prüfen, welche Felder befüllt sind. Begründung: bei
+    Budget-Ende fallen die **hinteren** Parameter still komplett aus (`dwd.py:446-448`,
+    `:457-458`) — die Reihenfolge ist damit eine fachliche Entscheidung, keine Formalie.
+
+- **AC-8:** Given der Live-Namenswächter läuft / When `THUNDER_PARAMS` erweitert wurde / Then
+  prüft er **jeden** Eintrag der Liste gegen das echte DWD-Angebot, nicht nur die ersten zwei.
+  - Test: **Verhalten des Wächters**, nicht seine Schreibweise. Mutations-Gegenprobe: einen
+    erfundenen Parameternamen an **letzter** Position in `THUNDER_PARAMS` setzen und den
+    Wächter laufen lassen ⇒ er MUSS rot werden. Heute bliebe er grün, weil er nur
+    `param_index in [0, 1]` prüft (Zeile 44) — ein Wächter, der nicht scheitern kann, bewacht
+    nichts. Die Mutation wird per String-Ersetzung mit externer Sicherungskopie gemacht,
+    nie per `git checkout/stash/reset`.
+
+- **AC-9:** Given ein Trip-Briefing, ein Ortsvergleich und eine SMS werden erzeugt / When die
+  neuen Felder befüllt sind / Then ist keine einzige Ausgabe anders als vorher — keine neue
+  Spalte, kein neues Token, keine geänderte Gewitterstufe.
+  - Test: Briefing-Mail, Compare-Mail und SMS aus identischen Eingangsdaten erzeugen — einmal
+    mit befüllten neuen Feldern, einmal mit leeren — und die erzeugten Ausgaben zeichenweise
+    vergleichen. Sie müssen identisch sein. Das ist der einzige AC, der Nutzerausgaben prüft,
+    und er prüft bewusst deren **Unveränderlichkeit**.
+
+## Estimated Scope
+
+- **LoC:** ~180–230
+- **Files:** 4 Produktivdateien (`models.py`, `dwd.py`, `dwd_eu.py`, `thunder_enrichment.py`)
+  + Tests
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `opendata.dwd.de` ICON-D2/ICON-EU | extern | Datenquelle, kontingentfrei |
+| `thunder_routing.py` | intern | Gebietszuordnung, unverändert |
+| `thunder_enrichment.py` | intern | einziger Anreicherungspunkt, unverändert im Ablauf |
+| #1419 §2a/§3.2/§5 | Konzept | Größenliste je Gebiet, `None`-Kontrakt |
+
+## Known Limitations
+
+- **GRIB-Metadaten sind unbrauchbar für Bedeutung/Einheit.** GDAL meldet für `sdi_2`
+  „Best (4 layer) Lifted Index [C]" und für `lpi_max` einen unbekannten Parameter. Maßgeblich
+  ist die DWD-Dokumentation, nicht `ds.tags()`.
+- **Alle drei `uh_max*` bleiben vorerst ohne belegte Schwelle.** Die Felder werden befüllt,
+  sind aber nicht einstufbar (SPC hat feste Schwellen 2019 selbst verworfen; Faktor 2 zwischen
+  Modellkernen). Bewusst: erst Daten sammeln, dann entscheiden — und zwar über alle drei
+  Schichten, weil ungeklärt ist, welche die publizierten Zahlen meinen.
+- **Die DWD-Felddefinition der Updraft-Schichten ist nicht auffindbar.** Dass `_low` 0–3 km und
+  `_med` 2–5 km meint, stammt aus einem Drittanbieter-Portal, nicht vom DWD. Deshalb werden
+  alle drei geholt statt auf eine gewettet.
+- **`cin_ml` in ICON-EU ist ungemessen.** Ob der −999,9-Marker dort ebenso auftritt, ist offen;
+  AC-2 gilt zunächst für ICON-D2. Für ICON-EU wird derselbe Schutz vorsorglich mitgeführt,
+  aber nicht als gemessen behauptet.
+- Zeitbudget: 9 Größen × 24 h = 216 Abrufe, Regelfall ~52 s (gemessen 0,24 s je Abruf).
+  Budget auf **150 s** angehoben (war 90 s), damit auch ein langsamer Lauf trägt. Erst ab
+  ~0,69 s je Abruf reißt es — AC-7 regelt, was dann zuerst da ist.


### PR DESCRIPTION
## Was drin ist

Ein **Gesamtkonzept für Gewitter** (`docs/features/gewitter-gesamtkonzept.md`, 700 Zeilen) — Ende zu Ende, mit allen neun Grundsatzentscheidungen. **Kein Code**, keine Verhaltensänderung.

Bislang gab es zwölf verstreute Kontext-Fragmente und vier ADRs, aber kein Gesamtbild. Anlass war die PO-Feststellung, dass immer nur Einzelscheiben vorgelegt wurden.

## Was das Konzept beantwortet

**Was der Nutzer sieht:** Zwei gewitter-eigene Größen — Stärke und Hagel. Die geplante Wahrscheinlichkeit **entfällt**, weil keine tragfähige Quelle existiert (vier Wege live geprüft). Alle Zutaten bleiben unsichtbar, CAPE wird es künftig auch.

**Wie die Stärke entsteht:** Vollständige Rechenvorschrift in fünf Schritten (Abschnitt 3.7) — jede Zutat einzeln in eine Stufe, CAPE gepaart mit der Konvektionshemmung statt pauschal gedeckelt, schärfstes Signal gewinnt, Radar hebt an, Herkunft wird mitgeführt.

## Vier Befunde, die vorher nicht benannt waren

| # | Befund | Beleg |
|---|---|---|
| 1 | 🔴 **Die CAPE-Schwelle wirkt modellabhängig.** In Frankreich löst sie **nie** aus (AROME 0,0 %), bei ECMWF in 65 % der Stunden — dieselbe Schwelle, derselbe Ort. Ein Viertel der Fusionssignale ist dort tot | live gemessen |
| 2 | **Die Stufe bedeutet je nach Ort etwas anderes.** ICON-EU stuft mit gemeinsamer Leiter **235-mal häufiger** „leicht" ein als ICON-D2 | 3,77 Mio. Gitterwerte |
| 3 | **Radar fließt nirgends in die Stufe ein** — es kann eine Zelle über der Etappe sehen, während das Briefing „kein Gewitter" sagt | `metric_format.py:326-370` |
| 4 | **Drei getrennte Alarme** zum selben Gewitter; für Deutschland fehlt der amtliche Warndienst ganz | `official_alerts/__init__.py:36-42` |

## Was sich belegen ließ statt zu raten

Die bisherige Haltung „keine publizierte Schwelle, also keine Einstufung" war zu streng:

- **CIN-Klassen −25/−50/−100/−200 J/kg** (Penn State/COMET, SPC-Formel) ⇒ die CAPE-Deckelung ist ersetzbar
- **LPI 1/30/50** (Bína et al., COSMO-D2) ⇒ die interpolierte Zwischenstufe 20 entfällt
- **CAPE 1000/2500/4000** (NWS, SPC) ⇒ statt binärer Nutzung eine echte Leiter

Gegenbefund mitgeschrieben: Rasmussen & Blanchard (1998) finden CIN als Schwere-Prädiktor nur schwach — es wird deshalb als Auslöse-Filter genutzt, nicht als Schweremaß.

## Fahrplan

Elf Ränge, angeführt von der modellabhängigen CAPE-Schwelle (Rang 0, laufender Fehler) und dem Abruf der fehlenden DWD-Größen (#1531, liefert die Datengrundlage für die Eichung).

## Auslieferung

Reine Doku-Änderung (`docs/` only) — Staging-Validierung entfällt nach der dokumentierten Ausnahme.

Refs #1419 #1531 #1585

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MzaMdw2Cnt9o6iVx5QRwHD
