### PR TITLE
feat(#1558): Frontend-Aenderungen erzwingen einen echten Browserlauf

### DIFF
--- a/.claude/hooks/e2e_frontend_browser_gate.py
+++ b/.claude/hooks/e2e_frontend_browser_gate.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+e2e_frontend_browser_gate.py — Frontend-Aenderungen erzwingen einen echten
+Browserlauf (Issue #1558, Spec docs/specs/modules/feat_1558_frontend_browser_gate.md).
+
+Beruehrt der auszuliefernde Aenderungssatz das Frontend, laedt dieses Gate die
+Kernseiten selbst in einem echten Browser und verweigert das Staging-Verdict,
+wenn dabei Konsolenfehler auftreten oder der Lauf nicht zustande kommt.
+
+Die Fail-Grenze verlaeuft NICHT entlang "Exception ja/nein", sondern entlang
+"liegt der Defekt im Gate oder im Nachweis":
+  - Nachweis nicht erbringbar (Playwright fehlt, Staging tot, Anmeldung
+    scheitert, Zugangsdaten fehlen, Konsolenfehler) → blockieren (!= 0).
+  - Das Gate-Modul selbst ist kaputt → das faengt der Aufrufer
+    (staging_gate._frontend_browser_gate) mit einer Warnung ab, nicht dieses
+    Modul. Ein pauschales try/except hier waere genau das Sicherheits-Theater,
+    das #1558 abschafft.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+# Fester Satz Kernseiten (Spec: nicht aus dem Diff abgeleitet — eine Zuordnung
+# "geaenderte Komponente → betroffene Route" waere ohne Dependency-Graph eine
+# Rate-Funktion, genau die Fehlerklasse, gegen die das Gate antritt).
+CORE_PAGES: tuple[str, ...] = (
+    "/", "/trips", "/trips/new", "/compare", "/compare/new", "/locations",
+)
+DEFAULT_BASE = "https://staging.gregor20.henemm.com"
+# Zwei Schranken, zwei Zugangsdaten-Paare (#1307 Scheibe B): GZ_VALIDATOR_* ist
+# der vorgeschaltete Basic-Auth-Schutz, GZ_AUTH_* die Anmeldung der Anwendung.
+REQUIRED_CREDENTIALS = (
+    "GZ_VALIDATOR_USER", "GZ_VALIDATOR_PASS", "GZ_AUTH_USER", "GZ_AUTH_PASS",
+)
+
+
+def _design_fidelity():
+    """Wiederverwendung statt Neubau: load_validator_env() und
+    unauthenticated_reason() leben in design_fidelity_diff.py (dort gemessen und
+    gehaertet, #1307 Scheibe B). Import per Pfad, weil .claude/hooks kein Package
+    ist (Muster staging_gate.py:45-53)."""
+    path = Path(__file__).resolve().parent / "design_fidelity_diff.py"
+    spec = importlib.util.spec_from_file_location("_dfd_for_frontend_gate", str(path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def load_validator_env() -> None:
+    """Zugangsdaten beider Ebenen nachladen — durchgereicht an
+    design_fidelity_diff.load_validator_env(). Bewusst NICHT aus gate() heraus
+    aufgerufen: os.environ.setdefault wuerde die Bedingung "Zugangsdaten fehlen"
+    wieder aufheben und damit unpruefbar machen."""
+    _design_fidelity().load_validator_env()
+
+
+def _login(page, base: str, env: dict, messages: list[str]) -> None:
+    """Formular-Anmeldung der Anwendung. Scheitert sie, wird das NICHT hier
+    entschieden — die Wahrheit steht auf der Zielseite (unauthenticated_reason)."""
+    user, pw = env.get("GZ_AUTH_USER", ""), env.get("GZ_AUTH_PASS", "")
+    if not (user and pw):
+        return
+    try:
+        page.goto(base + "/login", timeout=30000)
+        page.wait_for_load_state("networkidle", timeout=15000)
+        page.fill("input[name='username']", user)
+        page.fill("input[name='password']", pw)
+        page.click("button[type='submit']")
+        page.wait_for_load_state("networkidle", timeout=15000)
+    except Exception as exc:  # noqa: BLE001
+        messages.append(f"/login: Anmeldung nicht durchfuehrbar — {exc}")
+
+
+def _visit(page, base: str, path: str, errors: list[str], messages: list[str],
+           unauthenticated_reason) -> None:
+    """Eine Kernseite laden und bewerten. Meldungen nennen immer Seite UND Grund."""
+    del errors[:]
+    try:
+        page.goto(base + path, timeout=30000)
+        page.wait_for_load_state("networkidle", timeout=15000)
+    except Exception as exc:  # noqa: BLE001
+        messages.append(f"{path}: Seite nicht ladbar — {exc}")
+        return
+    # #1307: eine fehlerfreie Anmeldemaske ist KEINE bestandene Kernseite.
+    reason = unauthenticated_reason(
+        page.url, page.query_selector("input[type='password']") is not None
+    )
+    if reason is not None:
+        messages.append(f"{path}: keine angemeldete Kernseite — {reason}")
+    for err in errors:
+        messages.append(f"{path}: Konsolenfehler beim Laden — {err}")
+
+
+def check_pages(base: str, paths, env: dict) -> tuple[int, list[str]]:
+    """Kernseiten laden, Konsolenfehler sammeln. Getrennt von gate(), damit AC-2
+    ohne Staging pruefbar bleibt.
+
+    Erfasst werden ausschliesslich console(type == 'error') und pageerror —
+    Warnungen zaehlen nicht (sonst erstickt das Gate im Rauschen von
+    Drittbibliotheken; #1552 war ein 'error').
+
+    Returns: (0 = alle Seiten sauber, 1 = Nachweis nicht erbracht, Meldungen).
+    """
+    messages: list[str] = []
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as exc:
+        return 1, [f"Playwright nicht verfuegbar ({exc}) — Browserlauf nicht "
+                   "durchfuehrbar, Nachweis nicht erbringbar."]
+
+    unauthenticated_reason = _design_fidelity().unauthenticated_reason
+    errors: list[str] = []
+    try:
+        with sync_playwright() as pw:
+            browser = pw.chromium.launch(headless=True)
+            kwargs = {"viewport": {"width": 1400, "height": 900}}
+            basic_user = env.get("GZ_VALIDATOR_USER", "")
+            basic_pass = env.get("GZ_VALIDATOR_PASS", "")
+            if basic_user and basic_pass:
+                kwargs["http_credentials"] = {"username": basic_user, "password": basic_pass}
+            page = browser.new_context(**kwargs).new_page()
+            page.on("console", lambda m: errors.append(m.text) if m.type == "error" else None)
+            page.on("pageerror", lambda e: errors.append(str(e)))
+            try:
+                _login(page, base, env, messages)
+                for path in paths:
+                    _visit(page, base, path, errors, messages, unauthenticated_reason)
+            finally:
+                browser.close()
+    except Exception as exc:  # noqa: BLE001 — Nachweis nicht erbringbar, nicht "Gate kaputt"
+        messages.append(f"Browserlauf nicht zustande gekommen — {exc}")
+        return 1, messages
+    return (1 if messages else 0), messages
+
+
+def gate(scope: str, env: dict) -> int:
+    """0 = durchlassen, != 0 = blockieren.
+
+    Bewertet AUSSCHLIESSLICH das uebergebene ``env`` und laedt selbst keine
+    Zugangsdaten aus Dateien nach — das macht der Aufrufer
+    (staging_gate._frontend_browser_gate).
+    """
+    if scope not in ("frontend-only", "full-stack"):
+        return 0
+    base = env.get("GZ_VALIDATION_URL") or DEFAULT_BASE
+    missing = [k for k in REQUIRED_CREDENTIALS if not (env.get(k) or "").strip()]
+    if missing:
+        print(
+            f"FEHLER: Zugangsdaten fuer den Browserlauf fehlen ({', '.join(missing)}) — "
+            "der Nachweis ist nicht erbringbar. Kein Freifahrtschein: Gate blockt.",
+            file=sys.stderr,
+        )
+        return 1
+    rc, messages = check_pages(base, CORE_PAGES, env)
+    for msg in messages:
+        print(f"FEHLER: {msg}", file=sys.stderr)
+    if rc == 0:
+        print(f"OK: {len(CORE_PAGES)} Kernseiten ohne Konsolenfehler geladen ({base}).")
+    return rc
+
+
+if __name__ == "__main__":
+    load_validator_env()
+    sys.exit(gate(sys.argv[1] if len(sys.argv) > 1 else "frontend-only", dict(os.environ)))

--- a/.claude/hooks/staging_gate.py
+++ b/.claude/hooks/staging_gate.py
@@ -60,6 +60,11 @@ REPO_DIR = _DEFAULT_REPO_DIR
 STALE_HOURS = _e2e_paths.STALE_HOURS
 # Issue #666: max. behaltene commit-getaggte Attestationen (analog .backups/-Pattern)
 ATTESTATION_RETENTION = 20
+# Issue #1558: Pfad des Frontend-Browser-Gates bewusst als MODUL-Attribut (nicht
+# inline im Funktionsrumpf wie beim Telegram-Vorbild, Z. 224) — nur so kann ein
+# Test auf eine ECHT kaputte Datei zeigen und damit einen realen Importfehler
+# ausloesen statt eines gemockten (verbotenes Mock-Theater).
+FRONTEND_GATE_PATH = Path(__file__).resolve().parent / "e2e_frontend_browser_gate.py"
 
 
 def _log(msg: str, stream=sys.stdout) -> None:
@@ -248,6 +253,56 @@ def _telegram_live_gate() -> int:
     return 0
 
 
+def _frontend_browser_gate(scope: str, checked: list | None = None) -> int:
+    """Issue #1558: Beruehrt der Aenderungssatz das Frontend, muessen die
+    Kernseiten in einem echten Browser fehlerfrei laden — sonst kein Verdict.
+
+    Konsumiert bewusst den bereits berechneten ``scope`` statt eines eigenen
+    git-Diffs: das Telegram-Gate oben diefft fest HEAD~1..HEAD und uebersieht
+    dadurch alles, was weiter zurueckliegt als der letzte Commit (AC-5).
+
+    Fail-Grenze (AC-8): laesst sich das Gate-Modul SELBST nicht laden, laeuft
+    der Aufruf mit Warnung durch — ein kaputtes Gate darf nie der Grund sein,
+    dass niemand mehr ausliefert. Ist dagegen der NACHWEIS nicht erbringbar
+    (Playwright fehlt, Staging tot, Anmeldung scheitert, Zugangsdaten fehlen,
+    Konsolenfehler), blockiert es; das entscheidet das Gate-Modul selbst.
+
+    ``checked`` nimmt — nur bei bestandenem Lauf — die geprueften Seiten auf.
+    Returns: 0 = durchlassen, 1 = blocken.
+    """
+    if scope not in ("frontend-only", "full-stack"):
+        return 0
+
+    import importlib.util
+
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_e2e_frontend_browser_gate", str(FRONTEND_GATE_PATH)
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    except Exception as exc:  # noqa: BLE001 — fail-soft NUR beim Laden des Gates
+        _log(f"WARN: Browser-Gate e2e_frontend_browser_gate nicht ladbar ({exc}) — "
+             "Frontend-Browserlauf uebersprungen.", stream=sys.stderr)
+        return 0
+
+    # Zugangsdaten gehoeren HIER nachgeladen, nicht in gate(): dort wuerde
+    # os.environ.setdefault die Bedingung "Zugangsdaten fehlen" wieder aufheben
+    # und damit unpruefbar machen.
+    mod.load_validator_env()
+    if mod.gate(scope, dict(os.environ)) != 0:
+        _log(
+            f"FEHLER: Scope '{scope}' beruehrt das Frontend, aber der Browserlauf "
+            "ueber die Kernseiten wurde nicht bestanden (Issue #1558). Verdict "
+            "verweigert.",
+            stream=sys.stderr,
+        )
+        return 1
+    if checked is not None:
+        checked.extend(mod.CORE_PAGES)
+    return 0
+
+
 def write_verdict(verdict: str, findings_path: Path, e2e_path: Path | None = None,
                   scope_override: str | None = None) -> int:
     """Mode A: Verdict in die commit-getaggte Nachweis-Datei schreiben."""
@@ -294,6 +349,11 @@ def write_verdict(verdict: str, findings_path: Path, e2e_path: Path | None = Non
     ]
 
     scope = scope_override or _detect_committed_scope(head=sha)
+    # Issue #1558: NACH der Scope-Berechnung — nicht oben beim Telegram-Gate,
+    # wo `scope` noch gar nicht existiert.
+    frontend_pages: list[str] = []
+    if _frontend_browser_gate(scope, frontend_pages) != 0:
+        return 1
     payload = {
         "verified_commit": sha,
         "staging_verdict": verdict,
@@ -302,6 +362,8 @@ def write_verdict(verdict: str, findings_path: Path, e2e_path: Path | None = Non
         "scope": scope,
         "environment": "staging",
     }
+    if frontend_pages:
+        payload["frontend_pages_checked"] = frontend_pages
     # Issue #1197: Blind-Overwrite bei zwei Workflows auf demselben HEAD
     # vermeiden. Traegt eine bestehende Attestation denselben verified_commit,
     # werden die findings verlustfrei vereinigt (dedup ueber stabile

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,8 @@ Verifikation läuft **nach** dem Push gegen Staging (`https://staging.gregor20.h
 
 Detailablauf, Verdict-Ableitung PASS/PARTIAL/FAIL/SKIP, Rollback: **`docs/reference/operations_playbook.md`**. Kern: **Issue-Close nur bei Selftest-Exit 0**.
 
+**Frontend-Browser-Gate (#1558, seit 2026-08-08):** Berührt der committete Scope `frontend-only` oder `full-stack`, lädt `staging_gate.py --write-verdict` **selbst** die sechs Kernseiten (`/`, `/trips`, `/trips/new`, `/compare`, `/compare/new`, `/locations`) in einem echten Chromium gegen Staging und sammelt `console(type=error)` sowie `pageerror` — Warnungen zählen nicht. Schlägt das fehl, entsteht **keine** Attestation, der Prod-Deploy bleibt blockiert. **Fail-Grenze:** lässt sich das Gate-Modul selbst nicht laden (Import-/Syntaxfehler), läuft der Aufruf mit Warnung durch — ein kaputter Wächter darf nie die Ursache sein, dass niemand mehr ausliefert. Fehlt dagegen Playwright, ist Staging nicht erreichbar, scheitert die Anmeldung oder fehlen Zugangsdaten, wird **blockiert** — das ist „Nachweis nicht erbringbar", nicht „Gate kaputt". Notausgang für echte Ausfälle: `GZ_SKIP_E2E_GATE=1` (laut, geloggt — kein zweiter, stiller Ausgang). Bei bestandenem Lauf trägt die Attestation zusätzlich das Feld `frontend_pages_checked`. *Regel-Budget: Prüfdatum 2026-11-05. Fang-Beleg: #1552 (Kernseite auf Staging unbedienbar bei 5837 grünen Tests, Adversary VERIFIED, alle CI-Checks grün). Am Prüfdatum mitzubewerten: ob `ui_screenshot_gate.py` dadurch ganz oder teilweise entbehrlich wird.*
+
 ## Mail-Validatoren & Renderer-Gate (ZWINGEND)
 
 Zwei Mail-Pfade, zwei Gates. Falscher Validator auf einen Pfad → strukturell nie bestehbar → Gate-Erosion. Dispatch:

--- a/docs/context/feat-1558-frontend-browser-gate.md
+++ b/docs/context/feat-1558-frontend-browser-gate.md
@@ -1,0 +1,210 @@
+# Context: feat-1558-frontend-browser-gate
+
+Issue: #1558 — „Frontend-Änderungen erzwingen einen echten Browserlauf — Gate statt Einzelentscheidung"
+Erhoben: 2026-08-07 · Track: Full Process
+
+## Request Summary
+
+Berührt ein ausgelieferter Änderungssatz `frontend/**`, soll ein **Browser-Nachweis** Pflicht
+werden: die betroffene(n) Seite(n) wurden in einem echten Browser **geladen** und dabei auf
+**Konsolenfehler** geprüft. Fehlt der Nachweis, verweigert das Gate das Staging-Verdict — womit
+auch der Produktions-Rollout blockiert bleibt. Anlass: #1552, Kernseite unbedienbar bei 5837
+grünen Tests.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `.claude/hooks/staging_gate.py` (591 Z.) | Trägt das Gate. `write_verdict()` (251–363) schreibt die Attestation; `gate_check()` (366–559) liest sie beim Deploy. |
+| `.claude/hooks/staging_gate.py:215–248` | `_telegram_live_gate()` — **das Vorbild** (#686 AC-5). Aufgerufen in `write_verdict()` bei 275–276, **nicht** in `gate_check()`. |
+| `.claude/hooks/e2e_telegram_live.py:16–74` | Detektor + Verweigerung des Vorbilds. `_scope_touches_telegram()` (47–74) ist Substring-Match über Dateinamen. |
+| `.claude/hooks/_e2e_paths.py:181–233` | **Einzige** Scope-Klassifikation. Erzeugt genau vier Werte. |
+| `.claude/hooks/_e2e_paths.py:249–289` | Pfad-Auflösung: Attestation im *shared* Repo-Dir, Commit/Diff aus dem *Worktree*. |
+| `.claude/hooks/e2e_browser_test.py` (284 Z.) | Einziges Hook-seitiges Playwright-Werkzeug. Chromium headless, Screenshot nach `/tmp/`. **Erfasst keine Konsolenfehler** (0 Treffer für `page.on`). |
+| `.claude/agents/staging-validator.md` | Der empfohlene Nachweis-Erzeuger. Schreibt das Verdict selbst (Step 7). Verlangt DOM-/Sichtbarkeits-/Style-Assertions — **Konsolenfehler kommen nicht vor**. |
+| `.claude/commands/e2e-verify.md:69–78` | Schritt 3a: `staging-validator` empfohlen, `e2e_browser_test.py` als manueller Fallback. |
+| `.claude/hooks/ui_screenshot_gate.py` | Bestehendes UI-Gate (Vorher/Nachher-Screenshots). Kandidat für die Regel-Budget-Frage „Ersatz statt Zusatz". |
+| `frontend/playwright.config.ts` | Root-Config: `baseURL localhost:4173`, `webServer` startet Preview, `storageState playwright/.auth/admin.json`. |
+| `frontend/e2e/*.staging.config.ts` (10 Stück) | Ad-hoc-Configs gegen Staging: `GZ_SVELTE_BASE`, `httpCredentials`, eigenes `storageState` je Thema. |
+| `frontend/e2e/issue-1093-compare-layout-crash.spec.ts:54–67` | Vorhandenes Konsolenfehler-Muster, ad hoc. |
+| `.github/workflows/ci.yml` | 6 Jobs. **Keine** Playwright-TS-Ausführung, keine laufende App. |
+
+## Existing Patterns
+
+**Scope-Klassifikation (`_e2e_paths.py:198–233`)** — genau vier Werte:
+`docs-only` · `frontend-only` · `backend` · `full-stack`.
+`frontend/`-Präfix setzt `has_frontend`; `src/`, `api/`, `internal/`, `cmd/` setzen `has_backend`;
+neutral sind `docs/`, `.claude/`, `*.md`, `README*`, `.gitignore`, `tests/`, `openspec.yaml`;
+**unbekannte Pfade zählen konservativ als Backend**. Git-Fehler → `backend` (fail-closed).
+⇒ Ein Frontend-Gate muss auf `frontend-only` **und** `full-stack` greifen.
+
+**Verweigerungs-Muster (#686 AC-5)** — der Detektor sitzt in `write_verdict()`, *vor* dem Schreiben.
+Verweigert er, entsteht **kein Artefakt**; ohne Artefakt blockt `gate_check()` später den Deploy.
+Ein zweiter Prüfpunkt ist unnötig.
+
+**Attestations-Schema** (`.claude/e2e_verified/<sha>.json`), reale Felder:
+`verified_commit` · `staging_verdict` · `findings[]` (`{ac, status, url, evidence, workflow}`) ·
+`verified_at` · `scope` · `environment`. Findings werden über das `workflow`-Feld verlustfrei
+gemerged (310–352); Retention 20.
+
+**Staging-Playwright** — Login per API statt UI (Token-Bucket 30/h, #703), `storageState` mit
+`chmod 0600`, zwei Credential-Ebenen: nginx-Basic (`GZ_VALIDATOR_*`) und App-Login (`GZ_AUTH_*`).
+
+**Screenshot-Konvention:** `docs/artifacts/<workflow>/`. `e2e_browser_test.py:54` weicht ab (`/tmp/`).
+
+## Dependencies
+
+- **Upstream:** `_e2e_paths` (Scope, Pfade, Diff), git-Zustand des Worktrees, Playwright + Chromium,
+  Staging-Erreichbarkeit, beide Credential-Sätze.
+- **Downstream:** `deploy-gregor-prod.sh:174,210` (zwei `--check`-Aufrufe, blocken bei Exit≠0),
+  `prod_selftest.py:691–695` (verlangt `VERIFIED`-Präfix), `staging-validator` (Step 7),
+  `.claude/commands/e2e-verify.md`. **Jede Session dieses Repos** liefert über diesen Pfad aus.
+
+## Existing Specs
+
+- `docs/specs/_archive/modules/issue_686_telegram_functional_live_tests.md:150–154` — AC-5, das Vorbild.
+- Tests des Vorbilds: `tests/tdd/test_issue_686_telegram_functional_live.py`,
+  `test_issue_728_telegram_scope_neutral.py`, `test_issue_1121_git_diff_returncode.py`,
+  `test_staging_gate_verdict_merge.py` (neutralisiert `_telegram_live_gate` per monkeypatch —
+  dasselbe Seam wird ein Browser-Gate brauchen).
+
+## Risks & Considerations
+
+1. **Das Vorbild trägt einen Fehler.** `_telegram_live_gate()` diffft fest `HEAD~1..HEAD`
+   (`staging_gate.py:237`), während die reguläre Scope-Erkennung die Marker-Kette seit dem letzten
+   Gate-Lauf nutzt (`_scope_diff_base`, 112–153). Bei mehreren Commits seit dem letzten Lauf sieht
+   der Zweig **nur den letzten** — eine Frontend-Änderung zwei Commits zurück wäre unsichtbar.
+   Baugleiches Kopieren erbt einen blinden Wächter (Muster #1431).
+
+2. **Das Gate kann Echtheit nicht prüfen — nur Anwesenheit.** `--write-verdict` validiert heute
+   ausschließlich das Verdict-Präfix; ob Screenshots existieren oder Evidence echt ist, prüft es
+   nicht. Ein Nachweisfeld, das der Aufrufer selbst befüllt, ist eine Selbstauskunft.
+   ⇒ Der Nachweis muss **maschinell erzeugt** und vom Gate **nachgemessen** werden.
+
+3. **Login-Screenshot-Falle (#1307).** `page.fill`/`page.click` werfen nicht, wenn die Anmeldung
+   scheitert; der Lauf schreibt trotzdem einen Erfolgsbericht. „Keine Konsolenfehler" auf dem
+   Login-Screen ist wertlos. ⇒ Zwei unabhängige Merkmale, dass die Zielseite **angemeldet** erreicht
+   wurde, sonst Abbruch ohne Nachweis.
+
+4. **Anti-Stale.** Ein Glob nach „irgendeinem bestandenen Bericht" besteht mit einer Leiche.
+   Nachweis vor dem Lauf entfernen: erst weg, dann neu belegen.
+
+5. **Blast Radius.** Zu streng ⇒ die Auslieferung steht repo-weit, für alle Sessions.
+   Fail-soft bei **eigener** Störung (Import-/Playwright-Fehler) ist Hauskonvention — aber
+   fail-soft bei fehlendem Nachweis wäre genau das Sicherheits-Theater, das #1558 abschafft.
+   Die Grenze zwischen beidem gehört in die ACs.
+
+6. **Arbeitsverzeichnis.** `--write-verdict` nimmt den Commit aus `git rev-parse HEAD` des **cwd**.
+   Aufruf aus dem Hauptordner statt dem Worktree attestiert einen fremden Stand (#1447 S1).
+   `--e2e-path` ist praktisch unbenutzbar: `bash_gate.py` erkennt den Pfad als Freigabe-Marker.
+
+7. **Login-Rate-Limit 30/h.** Ein Smoke über vier Kernseiten darf nicht viermal einloggen —
+   einmal per API anmelden, `storageState` wiederverwenden.
+
+8. **CI-Variante ist teurer als sie aussieht.** Playwright läuft heute **nirgends** in der CI:
+   kein npm-Script, keine laufende App, kein Browser-Setup im `frontend-test`-Job. Der Smoke
+   bräuchte Build + Preview-Server + Chromium-Install im CI-Lauf. Der Staging-Weg nutzt dagegen
+   vorhandene Infrastruktur vollständig. ⇒ Getrennte Scheiben, Gate zuerst.
+
+9. **Regel-Budget.** Prüfdatum 2026-11-05, Fang-Beleg #1552 liegt vor. Zu prüfen, ob
+   `ui_screenshot_gate.py` ganz oder teilweise **ersetzt** werden kann statt danebenzustehen.
+
+## Analysis
+
+### Type
+Feature (neues Gate) — kein Bug.
+
+### Die Weichenstellung: Gate LIEST vs. Gate FÜHRT AUS
+
+Zwei Bauarten standen zur Wahl:
+
+- **A — Gate liest einen Nachweis.** Ein Agent führt den Browserlauf aus, legt einen Nachweis ab,
+  `write_verdict()` prüft dessen Anwesenheit und Frische.
+- **B — Gate führt den Browserlauf selbst aus.** `write_verdict()` startet bei Frontend-Scope
+  selbst einen Playwright-Lauf gegen Staging und verweigert das Verdict bei Konsolenfehlern.
+
+**Entschieden: B.** Bei A sind Nachweis-Erzeuger und Gate-Aufrufer dieselbe Instanz — wer den
+Nachweis schreiben kann, kann ihn erfinden. Das ist kein theoretisches Risiko:
+
+- `pre_issue_close_design_gate.py:64–72` ist ein Attestations-Leser im Betrieb. Er globt
+  `design-diff-*.json` und akzeptiert alles mit `passed: true` — ohne zu prüfen, ob die
+  referenzierten Bilder existieren. **Eine handgeschriebene JSON-Datei besteht dieses Gate.**
+- `write_verdict()` prüft `findings_path` heute nur auf JSON-Validität (278–282), nie darauf, ob
+  die genannten `evidence`-Pfade existieren.
+
+A wäre nur durch eine unabhängige Instanz zu retten (CI-Job) — das ist dann faktisch B an anderer
+Stelle. **Die tragende Eigenschaft ist: die Prüf-Logik läuft im Gate-Code, nicht im Agenten-Code.**
+
+**Preis von B, ehrlich benannt:** Staging-Erreichbarkeit wird Voraussetzung für jeden
+Frontend-Deploy. Der Agent entscheidet weiterhin, *ob* er `--write-verdict` aufruft — das ist
+unvermeidbar. Aber wenn er es aufruft, kann er das Ergebnis nicht mehr durch Behauptung erkaufen.
+
+### Machbarkeit — gemessen
+
+| Frage | Befund |
+|---|---|
+| Playwright verfügbar? | Ja. `pyproject.toml:87` (`>=1.57.0`), Chromium unter `~/.cache/ms-playwright/chromium-1200/` mit `INSTALLATION_COMPLETE`. |
+| Credentials? | `load_validator_env()` (`design_fidelity_diff.py:145–164`) lädt beide Ebenen: `.claude/validator.env` (`GZ_VALIDATOR_*`) und `.env` (`GZ_AUTH_*`). Direkt wiederverwendbar. |
+| Login-Screenshot-Falle gelöst? | **Ja, bereits.** `unauthenticated_reason()` (`design_fidelity_diff.py:167–194`) prüft zwei unabhängige Merkmale (Redirect auf `/login`, sichtbares Passwortfeld) und schreibt bei Misserfolg **kein** Artefakt. Genau die Anforderung aus Risk 3 — importierbar statt nachzubauen. |
+| Laufzeit? | **Gemessen: 1,0 s** für Browser-Start + eine Staging-Seite mit Basic-Auth (HTTP 200). Die kursierende „>30 s"-Zahl betrifft den vollen Fidelity-Diff-Lauf inkl. Screenshots, nicht das Laden. Sechs Seiten + einmal Formular-Login bleiben deutlich im Sekundenbereich. |
+| Import-Weg? | `.claude/hooks/` ist kein Package. `staging_gate.py:45–53` löst das bereits per `importlib.util.spec_from_file_location` für `_e2e_paths.py` — dasselbe Muster ist 1:1 übertragbar. |
+
+**Einschränkung:** Der Login-Code selbst steckt inline in `take_screenshot()` (239–248), ist also
+keine isolierte Funktion. `load_validator_env()` und `unauthenticated_reason()` sind dagegen sauber
+wiederverwendbar. Nicht geprüft: ob der Hook-Kontext dieselben Netzwerkrechte hat wie eine
+interaktive Sitzung.
+
+### Affected Files
+
+| Datei | Typ | Beschreibung |
+|---|---|---|
+| `.claude/hooks/e2e_frontend_browser_gate.py` | CREATE | Detektor + Browserlauf + Konsolenfehler-Auswertung. Vorbild `e2e_telegram_live.py`. |
+| `.claude/hooks/staging_gate.py` | MODIFY | `_frontend_browser_gate()` analog `_telegram_live_gate()`; Aufruf **nach** Zeile 296. |
+| `tests/tdd/test_frontend_browser_gate.py` | CREATE | Gate-Logik ohne Netz (Scope-Zweige, Fail-Grenzen). |
+| `tests/tdd/test_staging_gate_verdict_merge.py` | MODIFY | Neuen Seam neutralisieren, analog Z. 70–73 für Telegram. |
+
+### Entscheidungen
+
+1. **Einbauort:** nach der Scope-Berechnung (`staging_gate.py:296`), nicht bei 275 wie Telegram.
+   Gemessen: dort ist `scope` noch nicht berechnet. Das Gate **konsumiert** `scope in
+   ("frontend-only", "full-stack")` statt einen eigenen Diff zu ziehen — damit kann der
+   `HEAD~1`-Erbfehler strukturell nicht entstehen, weil keine zweite Diff-Logik existiert.
+2. **Seiten:** fester Kernseiten-Satz. Eine Zuordnung „geänderte Komponente → betroffene Route"
+   ist bei 235 `lib`-Komponenten gegen 27 Routen ohne Dependency-Graph eine Rate-Funktion mit hoher
+   Fehlerquote. `design_fidelity_diff.py:21–70` löst dasselbe Problem bereits mit einer festen Karte.
+3. **Fail-Grenze:**
+   - *Durchlassen + WARN* nur bei **eigener** Störung: Modul-Import-/Syntaxfehler des Gates.
+   - *Blockieren* bei: Playwright fehlt, Staging nicht erreichbar, Login scheitert, Credentials
+     fehlen, Konsolenfehler vorhanden. Das sind Fälle von „Nachweis nicht erbringbar" —
+     als Freifahrtschein wären sie genau das Sicherheits-Theater, das #1558 abschafft.
+   - Kein zweiter stiller Notausgang: `GZ_SKIP_E2E_GATE=1` (`staging_gate.py:383–385`) existiert
+     bereits, laut und geloggt.
+4. **Anti-Stale** entfällt als eigenes Problem: Es gibt keinen zwischengelagerten Nachweis, der
+   veralten könnte — der Lauf passiert im selben Aufruf, der das Verdict schreibt.
+
+### Scope Assessment
+
+- Dateien: 4 (2 neu, 2 geändert)
+- Geschätzt: **~190–220 LoC** — unter dem 250er-Limit, aber knapp. Konsolenfehler-Erfassung
+  bewusst einfach halten (`page.on('console')` + `page.on('pageerror')`, Filter auf `type=='error'`,
+  keine Retry-Heuristik).
+- **Risiko: MITTEL–HOCH.** Der Eingriff sitzt im gemeinsamen `write_verdict()`-Pfad, den *jede*
+  Session durchläuft. Greift die Scope-Prüfung falsch, blockiert das auch Backend-Deploys.
+  Mitigation: Test-Seam wie beim Telegram-Gate.
+
+### Scheiben-Schnitt
+
+- **Scheibe 1 (dieses Issue):** Variante B in `write_verdict()`, fester Kernseiten-Satz,
+  Scope-Wiederverwendung, Fail-Grenze wie oben.
+- **Scheibe 2 (eigenes Issue, NICHT hier):** CI-Playwright-Smoke. Braucht Build + Preview-Server +
+  Chromium im Runner und einen eigenen Login-/Fixture-Mechanismus — kein Copy-Paste aus Scheibe 1.
+  Das Issue markiert diesen Teil selbst als „alternativ oder ergänzend zu prüfen".
+
+### Offene Fragen
+
+- [ ] Blockieren Konsolen-**Warnungen** auch, oder nur `error`? (Vorschlag: nur `error`, sonst
+      erstickt das Gate an Rauschen aus Drittbibliotheken.)
+- [ ] Welcher Trip für `/trips/[id]`? Auf Staging existiert ein geseedeter Test-Trip
+      (`global.setup.ts:66–118` legt `e2e-cockpit-test` an) — zu prüfen, ob er dort vorhanden ist.
+- [ ] Greift das Gate auch bei `AMBIGUOUS`-Verdicts? (Vorschlag: ja — auch ein AMBIGUOUS-Verdict
+      wird abgelegt und kann später als Vorgänger dienen.)

--- a/docs/reference/operations_playbook.md
+++ b/docs/reference/operations_playbook.md
@@ -51,6 +51,39 @@ oder `staging_verdict` nicht mit `VERIFIED` beginnt (Issue #521).
 
 ---
 
+## Frontend-Browser-Gate (Issue #1558) — Detailablauf
+
+Berührt der committete Scope `frontend-only` oder `full-stack`, ruft `staging_gate.py
+--write-verdict` selbst `.claude/hooks/e2e_frontend_browser_gate.py` auf (Modul-Pfad
+`staging_gate.FRONTEND_GATE_PATH`) — nach der Scope-Berechnung, aber **bevor** die Attestation
+geschrieben wird. Ohne diesen bestandenen Lauf entsteht keine Datei in `.claude/e2e_verified/`.
+
+**Was passiert:** die sechs Kernseiten `/`, `/trips`, `/trips/new`, `/compare`, `/compare/new`,
+`/locations` werden in einem echten Chromium (Playwright, headless) gegen die übergebene
+Basis-URL (`GZ_VALIDATION_URL`, Default Staging) geladen. Gesammelt werden ausschließlich
+`console(type == "error")` und `pageerror` — Warnungen zählen nicht. Eine erreichte
+Anmeldemaske gilt NICHT als bestandene Kernseite (`unauthenticated_reason()`, Fix #1307).
+
+**Bei Fehlschlag:** keine Attestation, `write_verdict()` endet mit Exit 1 — kein Prod-Deploy
+für diesen Stand.
+
+**Fail-Grenze** — bewusst zwei verschiedene Ausgänge:
+- Gate-Modul selbst nicht ladbar (Import-/Syntaxfehler) → Warnung, der Aufruf läuft durch — ein
+  kaputter Wächter darf nie die Ursache sein, dass niemand mehr ausliefern kann.
+- Nachweis nicht erbringbar (Playwright fehlt, Staging nicht erreichbar, Anmeldung scheitert,
+  Zugangsdaten `GZ_VALIDATOR_USER`/`GZ_VALIDATOR_PASS`/`GZ_AUTH_USER`/`GZ_AUTH_PASS` fehlen,
+  Konsolenfehler auf einer Kernseite) → blockiert.
+
+**Attestation:** bei bestandenem Lauf trägt `.claude/e2e_verified/<sha>.json` zusätzlich das
+Feld `frontend_pages_checked` mit den geprüften Pfaden.
+
+**Notausgang:** bestehender Mechanismus `GZ_SKIP_E2E_GATE=1` (laut, geloggt) — kein eigener,
+zweiter Ausgang für dieses Gate.
+
+Details, Acceptance Criteria, Grenzen: Spec `docs/specs/modules/feat_1558_frontend_browser_gate.md`.
+
+---
+
 ## Post-Deploy-Selftest (Issue #564) — Detailablauf
 
 Nach jedem Prod-Deploy erfolgt eine automatische Nachverifikation gegen Produktion — ohne

--- a/docs/specs/modules/feat_1558_frontend_browser_gate.md
+++ b/docs/specs/modules/feat_1558_frontend_browser_gate.md
@@ -1,0 +1,215 @@
+---
+entity_id: feat_1558_frontend_browser_gate
+type: module
+created: 2026-08-07
+updated: 2026-08-07
+status: draft
+version: "1.0"
+tags: [gate, frontend, staging, browser]
+---
+
+# Spec: Frontend-Änderungen erzwingen einen echten Browserlauf
+
+- **Issue:** #1558 (Scheibe 1)
+- **Workflow:** `feat-1558-frontend-browser-gate`
+- **Kontext & Messungen:** `docs/context/feat-1558-frontend-browser-gate.md`
+- **Status:** Entwurf — wartet auf PO-Freigabe der Acceptance Criteria
+
+## Approval
+
+- [x] Approved — PO-Freigabe („go") 2026-08-08, ACs unverändert wie oben
+
+## Zweck in einem Satz
+
+Berührt der auszuliefernde Änderungssatz das Frontend, lädt das Gate die Kernseiten selbst in
+einem echten Browser und verweigert das Staging-Verdict, wenn dabei Konsolenfehler auftreten
+oder der Lauf nicht zustande kommt.
+
+## Warum
+
+Bei #1552 war die Seite *Trip anlegen* auf Staging vollständig unbedienbar — eine Endlosschleife
+im `$effect`, ausgelöst beim bloßen Laden. Der Stand dabei: 5837 grüne Tests, Adversary VERIFIED
+mit 11 Mutationen, alle CI-Checks grün. Alles grün, Seite tot.
+
+Kein Testsatz konnte das fangen: Die Frontend-Tests prüfen Quelltext statt Verhalten (kein jsdom),
+und serverseitiges Rendern führt `$effect` nie aus. Eine Reaktivitäts-Endlosschleife ist für beide
+Schichten strukturell unsichtbar — keine Lücke im Testsatz, sondern in der Test-*Art*. Gefunden
+wurde es nur, weil die Staging-Prüfung damals ausdrücklich über den echten Klickpfad beauftragt
+war: eine Einzelentscheidung, kein Mechanismus.
+
+## Die tragende Entwurfsentscheidung: das Gate führt aus, es liest nicht
+
+Ein Gate, das einen abgelegten Nachweis nur **liest**, prüft hier nichts — Nachweis-Erzeuger und
+Gate-Aufrufer sind dieselbe Instanz. Der Beleg läuft im Betrieb:
+`pre_issue_close_design_gate.py:64–72` globt `design-diff-*.json` und akzeptiert jede Datei mit
+`passed: true`, ohne zu prüfen, ob die referenzierten Bilder existieren. Drei Zeilen JSON von Hand
+bestehen dieses Gate. Ebenso prüft `write_verdict()` die Findings-Datei heute nur auf
+JSON-Validität (`staging_gate.py:278–282`), nie darauf, ob die genannten `evidence`-Pfade existieren.
+
+Deshalb: **Die Prüf-Logik läuft im Gate-Code, nicht im Agenten-Code.** Der Browserlauf passiert im
+selben Aufruf, der das Verdict schreibt. Damit entfällt auch das Anti-Stale-Problem — es gibt
+keinen zwischengelagerten Nachweis, der veralten könnte.
+
+**Der Preis, ausdrücklich:** Staging-Erreichbarkeit wird Voraussetzung für jeden Frontend-Deploy.
+Der Aufrufer entscheidet weiterhin, *ob* er `--write-verdict` startet; das ist unvermeidbar. Aber
+wenn er es startet, kann er das Ergebnis nicht mehr durch Behauptung erkaufen.
+
+## Zuschnitt
+
+**Auslöser:** `scope in ("frontend-only", "full-stack")` — der Wert, den `write_verdict()` bei
+`staging_gate.py:296` **bereits berechnet hat**. Das Gate zieht ausdrücklich **keinen eigenen
+git-Diff**. Begründung: das Telegram-Vorbild diffft fest `HEAD~1..HEAD` (`staging_gate.py:237`)
+und übersieht dadurch alles, was weiter zurückliegt als der letzte Commit. Ohne zweite Diff-Logik
+kann dieser Fehler strukturell nicht entstehen.
+
+**Einbauort:** in `write_verdict()` **nach** der Scope-Berechnung (Z. 296) — nicht bei Z. 275, wo
+das Telegram-Gate sitzt und `scope` noch nicht existiert.
+
+**Geprüfte Kernseiten** (fester Satz, nicht aus dem Diff abgeleitet):
+`/` · `/trips` · `/trips/new` · `/compare` · `/compare/new` · `/locations`
+
+Eine Zuordnung „geänderte Komponente → betroffene Route" wäre bei 235 `lib`-Komponenten gegen
+27 Routen ohne Dependency-Graph eine Rate-Funktion mit hoher Fehlerquote — genau die Fehlerklasse,
+gegen die das Gate antritt. `design_fidelity_diff.py:21–70` löst dasselbe Problem bereits mit einer
+festen Karte.
+
+**Bewusst nicht in dieser Scheibe:**
+- Trip-Detailseite `/trips/[id]` — braucht einen garantiert vorhandenen Trip auf Staging; die
+  Abhängigkeit von fremden Daten macht das Gate flatterig. Nachziehen, sobald ein fest geseedeter
+  Test-Trip dort verlässlich existiert.
+- Klickpfade. Geprüft wird **Laden**, nicht Bedienen. Genau das hätte #1552 gefangen.
+- Der CI-Playwright-Smoke (eigenes Folge-Issue): braucht Build, Preview-Server und Chromium im
+  Runner sowie einen eigenen Login-Mechanismus — kein Copy-Paste aus dieser Scheibe.
+
+## Wiederverwendung statt Neubau
+
+| Baustein | Herkunft |
+|---|---|
+| Credentials beider Ebenen laden | `design_fidelity_diff.py:145–164` (`load_validator_env()`) |
+| „Sind wir wirklich angemeldet auf der Zielseite?" | `design_fidelity_diff.py:167–194` (`unauthenticated_reason()`) — prüft Redirect auf `/login` **und** sichtbares Passwortfeld |
+| Modul-Import ohne Package | `staging_gate.py:45–53` (`importlib.util.spec_from_file_location`) |
+| Struktur des Gate-Moduls | `e2e_telegram_live.py` |
+
+## Schnittstelle — in der RED-Phase festgelegt
+
+Drei Festlegungen entstanden beim Testschreiben, weil die ACs sonst nur mit Mock-Theater
+prüfbar gewesen wären. Die Implementierung muss ihnen folgen:
+
+| Festlegung | Warum |
+|---|---|
+| `staging_gate.FRONTEND_GATE_PATH` als **Modul-Attribut** (nicht inline im Funktionsrumpf wie beim Telegram-Vorbild, `staging_gate.py:224`) | Nur so kann AC-8a auf eine **echt kaputte Datei** zeigen und einen realen Importfehler auslösen. Inline ginge es nur mit einem gemockten Importfehler — verbotenes Mock-Theater. |
+| `check_pages()` als eigene Ebene neben `gate()` | `gate()` prüft „Zugangsdaten fehlen" und blockiert; `check_pages()` lädt nur und sammelt Konsolenfehler. Ohne die Trennung bräche AC-2 schon vor dem Laden ab und wäre ohne Staging nicht prüfbar. |
+| `gate()` bewertet **ausschließlich das übergebene `env`-Mapping** und lädt keine Zugangsdaten nach | `os.environ.setdefault` in `load_validator_env()` würde die Testbedingung „Zugangsdaten fehlen" wieder aufheben. Das Nachladen gehört in `_frontend_browser_gate()`. |
+
+Feldname im Attestations-Payload für AC-7: **`frontend_pages_checked`**.
+
+## Acceptance Criteria
+
+**AC-1: Frontend-Änderung ohne bestandenen Browserlauf bekommt kein Verdict**
+Given der auszuliefernde Änderungssatz hat den Scope `frontend-only`
+When `staging_gate.py --write-verdict "VERIFIED: …"` aufgerufen wird und der Browserlauf nicht
+bestanden wird
+Then wird **keine** Attestations-Datei geschrieben und der Aufruf endet mit Exit-Code 1.
+- Test: `write_verdict()` mit Scope `frontend-only` und einem Browser-Gate, das Nicht-Bestehen
+  meldet; danach gemessen, dass `.claude/e2e_verified/<sha>.json` **nicht** existiert.
+
+**AC-2: Ein Konsolenfehler beim Laden verweigert das Verdict**
+Given eine der geprüften Kernseiten wirft beim Laden einen JavaScript-Fehler oder eine
+Konsolenmeldung der Stufe `error`
+When der Browserlauf des Gates diese Seite lädt
+Then meldet das Gate Nicht-Bestehen, die Meldung nennt Seite und Fehlertext, und es entsteht
+kein Verdict.
+- Test: Seite mit provoziertem `pageerror` gegen eine lokal ausgelieferte Testseite; gemessen,
+  dass das Gate Exit ≠ 0 liefert und der Fehlertext in der Meldung steht.
+
+**AC-3: Backend- und Doku-Änderungen bleiben unberührt**
+Given der Änderungssatz hat den Scope `backend` oder `docs-only`
+When `--write-verdict` aufgerufen wird
+Then startet **kein** Browserlauf, und das Verdict wird geschrieben wie bisher.
+- Test: `write_verdict()` mit beiden Scopes läuft in einer Umgebung, in der ein Browserlauf
+  **zwangsläufig scheitern würde** (Zugangsdaten entfernt); gemessen, dass die Attestation
+  trotzdem entsteht. Damit ist belegt, dass kein Browserlauf stattfand — ohne einen Aufruf-Zähler
+  zu befragen, der nur eine Implementierungs-Annahme bewacht.
+
+**AC-4: `full-stack` zählt wie `frontend-only`**
+Given der Änderungssatz berührt Frontend **und** Backend, Scope ist also `full-stack`
+When `--write-verdict` aufgerufen wird
+Then greift das Gate genauso wie bei `frontend-only`.
+- Test: derselbe Aufbau wie AC-1, nur mit Scope `full-stack`; gemessen, dass kein Verdict entsteht.
+
+**AC-5: Eine Frontend-Änderung mehrere Commits zurück wird trotzdem erkannt**
+Given seit dem letzten Gate-Lauf liegen mehrere Commits vor, die Frontend-Änderung liegt zwei
+Commits zurück, und der jüngste Commit ändert nur Dokumentation
+When `--write-verdict` aufgerufen wird
+Then greift das Gate trotzdem, weil es den bereits ermittelten Scope verwendet statt eines
+eigenen `HEAD~1`-Vergleichs.
+- Test: Wegwerf-Repo mit dieser Commit-Folge; gemessen, dass das Gate anspringt. **Dieser Test
+  ist der Wächter gegen den Erbfehler des Telegram-Vorbilds** — ohne ihn wäre die Zusicherung
+  „kein zweiter Diff" nur eine Behauptung.
+
+**AC-6: Nicht angemeldet erreichte Seite gilt als Nicht-Bestehen**
+Given die Anmeldung an der Staging-Anwendung schlägt fehl, sodass die Kernseiten auf die
+Anmeldemaske zurückleiten
+When der Browserlauf läuft
+Then meldet das Gate Nicht-Bestehen — eine fehlerfreie Anmeldemaske gilt **nicht** als bestandene
+Kernseite.
+- Test: Lauf mit ungültigem Anwendungs-Passwort; gemessen, dass Exit ≠ 0 und die Meldung den
+  Anmeldegrund nennt. Deckt die Falle aus #1307 ab, bei der ein Gate mit einem Foto der
+  Anmeldemaske bestand.
+
+**AC-7: Sauberer Frontend-Änderungssatz läuft durch und hinterlässt eine Spur**
+Given alle Kernseiten laden ohne Konsolenfehler
+When `--write-verdict "VERIFIED: …"` aufgerufen wird
+Then wird die Attestation geschrieben und enthält, welche Seiten geprüft wurden.
+- Test: Lauf gegen Staging; gemessen, dass die Attestation entsteht und die geprüften Seiten
+  benennt.
+
+**AC-8: Fehlendes Nachweismittel blockiert, ein defektes Gate lässt durch**
+Given das Gate-Modul selbst lässt sich nicht laden (Import-/Syntaxfehler)
+When `--write-verdict` bei Frontend-Scope aufgerufen wird
+Then läuft der Aufruf mit einer Warnung durch — ein kaputtes Gate darf nie die Ursache sein, dass
+niemand mehr ausliefern kann.
+Und Given Playwright fehlt, Staging ist nicht erreichbar oder die Zugangsdaten fehlen
+Then blockiert das Gate. Das ist „Nachweis nicht erbringbar", nicht „Gate kaputt" — als
+Freifahrtschein wäre es genau das Sicherheits-Theater, das dieses Ticket abschafft.
+- Test: beide Fälle getrennt; gemessen, dass der erste Exit 0 mit Warnung liefert und der zweite
+  Exit ≠ 0 ohne Attestation.
+
+## Festlegungen zu den offenen Punkten
+
+| Frage | Festlegung | Begründung |
+|---|---|---|
+| Warnungen auch? | Nein — nur Stufe `error` und `pageerror` | Warnungen aus Drittbibliotheken würden das Gate in Rauschen ersticken. #1552 war ein `error`. |
+| Auch bei `AMBIGUOUS`? | Ja | Ein AMBIGUOUS-Verdict wird abgelegt und kann später als Vorgänger dienen; die Lücke wäre sonst trivial zu nutzen. |
+| Trip-Detailseite? | Nicht in dieser Scheibe | Braucht garantiert vorhandene Fremddaten auf Staging. |
+
+## Estimated Scope
+
+- **LoC:** ~190–220 (Limit 250)
+- **Files:** 4 — 2 neu, 2 geändert
+- **Effort:** medium
+
+| Datei | Typ |
+|---|---|
+| `.claude/hooks/e2e_frontend_browser_gate.py` | CREATE |
+| `.claude/hooks/staging_gate.py` | MODIFY |
+| `tests/tdd/test_frontend_browser_gate.py` | CREATE |
+| `tests/tdd/test_staging_gate_verdict_merge.py` | MODIFY (Seam neutralisieren, analog Z. 70–73) |
+
+## Risiken
+
+- **Der Eingriff sitzt im gemeinsamen Auslieferungspfad**, den jede Sitzung durchläuft. Greift die
+  Scope-Prüfung falsch, blockiert das auch Backend-Deploys — AC-3 bewacht genau das.
+- **Staging wird zum Nadelöhr** für Frontend-Deploys. Bewusst in Kauf genommen; ein Notausgang für
+  echte Ausfälle existiert bereits (`GZ_SKIP_E2E_GATE=1`, `staging_gate.py:383–385`) — laut und
+  geloggt. Ein zweiter, stiller wird nicht gebaut.
+- **Laufzeit:** gemessen 1,0 s je Seitenaufruf inkl. Browser-Start und Basic-Auth. Sechs Seiten
+  plus einmal Anmelden bleiben im Sekundenbereich, in einem Schritt, der einmal je Auslieferung läuft.
+- **Nicht geprüft:** ob der Hook-Kontext dieselben Netzwerkrechte hat wie eine interaktive Sitzung.
+  Fällt das durch, greift AC-8 zweiter Teil (blockieren) — dann wäre nachzubessern.
+
+## Regel-Budget
+
+Neues Gate ⇒ **Prüfdatum 2026-11-05**. Fang-Beleg bei Einführung liegt vor: #1552 — Kernseite
+unbedienbar trotz vollständig grüner Ampel und bestandener Adversary-Prüfung. Ob
+`ui_screenshot_gate.py` dadurch ganz oder teilweise entbehrlich wird, ist am Prüfdatum mitzubewerten.

--- a/tests/tdd/test_frontend_browser_gate.py
+++ b/tests/tdd/test_frontend_browser_gate.py
@@ -1,0 +1,369 @@
+"""TDD RED (#1558): Frontend-Aenderungen erzwingen einen echten Browserlauf.
+
+Spec: docs/specs/modules/feat_1558_frontend_browser_gate.md — hier AC-1..AC-5, AC-8.
+AC-6/AC-7 liegen in der Live-Schicht (test_frontend_browser_gate_staging.py).
+
+GEPRUEFTE SCHNITTSTELLE (existiert noch nicht — genau deshalb ist die Suite rot):
+
+  .claude/hooks/e2e_frontend_browser_gate.py
+    CORE_PAGES: tuple[str, ...] — "/", "/trips", "/trips/new", "/compare",
+      "/compare/new", "/locations".
+    gate(scope, env) -> int — 0 = durchlassen, != 0 = blockieren. Springt NUR an
+      bei scope in ("frontend-only", "full-stack"). Basis-URL aus
+      env["GZ_VALIDATION_URL"] (Default wie design_fidelity_diff.py:374). gate()
+      bewertet AUSSCHLIESSLICH das uebergebene env und laedt selbst keine
+      Zugangsdaten aus Dateien nach — sonst waere "Zugangsdaten fehlen" nicht
+      pruefbar; das Nachladen macht der Aufrufer.
+    check_pages(base, paths, env) -> tuple[int, list[str]] — startet Chromium,
+      meldet sich nur an wenn env GZ_AUTH_USER/GZ_AUTH_PASS traegt, laedt jede
+      Seite, sammelt console(type=error) + pageerror. Meldungen nennen Seite UND
+      Fehlertext.
+
+  .claude/hooks/staging_gate.py
+    FRONTEND_GATE_PATH: Path — Modul-Attribut (nicht inline im Funktionsrumpf),
+      damit AC-8 mit einer ECHT kaputten Datei statt einem gemockten Importfehler
+      geprueft werden kann.
+    _frontend_browser_gate(scope) -> int — Aufruf in write_verdict() NACH der
+      Scope-Berechnung (Z. 296); Import-/Syntaxfehler → Warnung + 0.
+
+Deterministisch, ohne fremdes Netz: Wegwerf-Repo per git init, lokaler
+http.server auf 127.0.0.1, echtes Chromium. Lauf:
+  uv run pytest tests/tdd/test_frontend_browser_gate.py \
+      --disable-socket --allow-hosts=127.0.0.1
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOKS_DIR = REPO_ROOT / ".claude" / "hooks"
+GATE_PATH = HOOKS_DIR / "e2e_frontend_browser_gate.py"
+DEAD_BASE = "http://127.0.0.1:9"  # Discard-Port: garantiert kein Staging
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, str(path))
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+sg = _load("staging_gate_fbg", HOOKS_DIR / "staging_gate.py")
+
+
+def _gate_mod():
+    assert GATE_PATH.exists(), f"Gate-Modul fehlt: {GATE_PATH}"
+    return _load("e2e_frontend_browser_gate_under_test", GATE_PATH)
+
+
+@pytest.fixture
+def hostile(monkeypatch):
+    """Umgebung, in der ein Browserlauf zwangslaeufig scheitern WUERDE: totes
+    Staging, keine Zugangsdaten. Das unbeteiligte Telegram-Gate wird an seinem
+    ehrlichen Seam neutralisiert (Muster test_staging_gate_verdict_merge)."""
+    monkeypatch.setattr(sg, "_telegram_live_gate", lambda: 0)
+    monkeypatch.setenv("GZ_VALIDATION_URL", DEAD_BASE)
+    for k in ("GZ_AUTH_USER", "GZ_AUTH_PASS", "GZ_VALIDATOR_USER", "GZ_VALIDATOR_PASS"):
+        monkeypatch.delenv(k, raising=False)
+
+
+def _verdict(tmp_path, scope, e2e_path=None):
+    """write_verdict mit leerer Findings-Datei (nicht angelegt → findings=[])."""
+    return sg.write_verdict("VERIFIED: behauptet, aber unbelegt",
+                            tmp_path / "findings.json",
+                            e2e_path=e2e_path, scope_override=scope)
+
+
+@pytest.mark.parametrize("scope", ["frontend-only", "full-stack"])
+def test_frontend_scope_without_passed_browser_run_writes_no_attestation(
+    tmp_path, hostile, scope
+):
+    """AC-1 (frontend-only) + AC-4 (full-stack zaehlt genauso): der Browserlauf
+    kann nicht bestanden werden → Exit 1, KEINE Attestation."""
+    e2e_path = tmp_path / "attestation.json"
+    rc = _verdict(tmp_path, scope, e2e_path)
+    assert rc == 1, f"Scope {scope}: Verdict ohne belegten Browserlauf muss Exit 1 liefern"
+    assert not e2e_path.exists(), (
+        f"Scope {scope}: Attestation geschrieben, obwohl der Browserlauf nicht "
+        "bestanden werden konnte"
+    )
+
+
+@pytest.mark.parametrize("scope", ["backend", "docs-only"])
+def test_non_frontend_scope_still_gets_attestation_in_browser_hostile_env(
+    tmp_path, hostile, scope
+):
+    """AC-3: In einer Umgebung, in der ein Browserlauf zwangslaeufig scheitern
+    wuerde, entsteht die Attestation trotzdem — damit ist belegt, dass KEIN
+    Browserlauf stattfand, ohne einen Aufruf-Zaehler zu befragen."""
+    e2e_path = tmp_path / "attestation.json"
+    rc = _verdict(tmp_path, scope, e2e_path)
+    assert rc == 0, f"Scope {scope} darf vom Frontend-Gate nicht blockiert werden"
+    assert json.loads(e2e_path.read_text())["scope"] == scope
+
+
+def _git(repo: Path, *args: str) -> str:
+    r = subprocess.run(["git", *args], cwd=str(repo), capture_output=True,
+                       text=True, check=True)
+    return r.stdout.strip()
+
+
+def _commit(repo: Path, rel: str, msg: str) -> str:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(f"# {msg}\n")
+    _git(repo, "add", rel)
+    _git(repo, "-c", "user.email=t@example.invalid", "-c", "user.name=T",
+         "commit", "-q", "-m", msg)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def test_frontend_change_two_commits_back_still_triggers_gate(
+    tmp_path, hostile, monkeypatch
+):
+    """AC-5 (Waechter gegen den HEAD~1-Erbfehler aus staging_gate.py:237):
+    Commit-Folge A(backend) → B(frontend) → C(docs). Der juengste Commit zeigt
+    nur Doku; ein eigener HEAD~1-Diff wuerde das Gate schlafen lassen. Gemessen
+    wird die WIRKUNG: keine Attestation."""
+    repo = tmp_path / "wegwerf-repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    base = _commit(repo, "src/backend.py", "A backend")
+    _commit(repo, "frontend/src/lib/Foo.svelte", "B frontend")
+    _commit(repo, "docs/notiz.md", "C nur doku")
+
+    monkeypatch.setattr(sg, "REPO_DIR", repo)
+    sg._e2e_paths.write_last_gate_scope(repo, base)
+
+    # Vorbedingung 1: der letzte Commit allein sieht nur Dokumentation.
+    assert sg._e2e_paths._detect_scope_from_git_diff("HEAD~1", "HEAD", repo) == "docs-only"
+    # Vorbedingung 2: der bereits ermittelte Scope sieht die Frontend-Aenderung.
+    assert sg._detect_committed_scope() == "frontend-only"
+
+    rc = sg.write_verdict("VERIFIED: behauptet", tmp_path / "findings.json")
+
+    assert rc == 1, "Gate muss trotz Doku-Commit an der Spitze anspringen"
+    assert not sg._commit_e2e_path().exists(), (
+        "Attestation entstand — das Gate hat die zwei Commits zurueckliegende "
+        "Frontend-Aenderung nicht gesehen (HEAD~1-Erbfehler)"
+    )
+
+
+_CLEAN = "<!doctype html><html><head><title>ok</title></head><body><h1>Seite</h1></body></html>"
+_BOOM = ("<!doctype html><html><head><title>boom</title></head><body><h1>Seite</h1>"
+         "<script>null.gibtEsNichtHier();</script></body></html>")
+
+
+@pytest.fixture
+def local_site():
+    """Echter lokaler HTTP-Server: '/boom' wirft beim Laden eine Ausnahme, alle
+    anderen Pfade (inkl. der Kernseiten) sind sauber."""
+    class H(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            body = (_BOOM if self.path == "/boom" else _CLEAN).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *a):  # stumm
+            pass
+
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), H)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{srv.server_port}"
+    srv.shutdown()
+    srv.server_close()
+
+
+def test_console_error_while_loading_is_seen_and_named(local_site):
+    """AC-2: eine Seite wirft beim Laden — das Gate sieht den Fehler, meldet
+    Nicht-Bestehen und nennt Seite und Fehlertext."""
+    pytest.importorskip("playwright.sync_api")
+    rc, messages = _gate_mod().check_pages(local_site, ["/boom"], {})
+    joined = " ".join(messages)
+    assert rc != 0, f"Konsolenfehler blieb folgenlos (Meldungen: {messages})"
+    assert "/boom" in joined, f"Meldung nennt die Seite nicht: {joined!r}"
+    assert "gibtEsNichtHier" in joined, f"Meldung nennt den Fehlertext nicht: {joined!r}"
+
+
+def test_unloadable_gate_module_lets_verdict_through_with_warning(
+    tmp_path, hostile, monkeypatch, capsys
+):
+    """AC-8 erste Haelfte: ein defektes Gate darf nie die Ursache sein, dass
+    niemand mehr ausliefern kann — echte kaputte Datei, kein gemockter Fehler."""
+    broken = tmp_path / "e2e_frontend_browser_gate.py"
+    broken.write_text("def gate(scope, env):\n    return 0\n  das ist kein python(\n")
+    monkeypatch.setattr(sg, "FRONTEND_GATE_PATH", broken)
+
+    e2e_path = tmp_path / "attestation.json"
+    rc = _verdict(tmp_path, "frontend-only", e2e_path)
+
+    assert rc == 0 and e2e_path.exists(), "Kaputtes Gate darf nicht blockieren"
+    err = capsys.readouterr().err.lower()
+    assert "warn" in err and "browser" in err, f"Warnung fehlt/unklar: {err!r}"
+
+
+def test_missing_means_of_proof_blocks(local_site, hostile):
+    """AC-8 zweite Haelfte: Zugangsdaten fehlen bzw. Staging ist tot → blockieren.
+    Fall 1 laeuft gegen ein erreichbares, FEHLERFREIES Ziel — dort kann nur die
+    Zugangsdaten-Pruefung selbst blocken."""
+    g = _gate_mod()
+    no_creds = {"GZ_VALIDATION_URL": local_site}
+    dead = {"GZ_VALIDATION_URL": DEAD_BASE, "GZ_AUTH_USER": "u", "GZ_AUTH_PASS": "p",
+            "GZ_VALIDATOR_USER": "u", "GZ_VALIDATOR_PASS": "p"}
+    assert g.gate("frontend-only", no_creds) != 0, "fehlende Zugangsdaten muessen blocken"
+    assert g.gate("frontend-only", dead) != 0, "unerreichbares Staging muss blocken"
+
+
+# ---------------------------------------------------------------------------
+# Adversary-Fund F001: die Fail-Grenze aus AC-8 sitzt an der Modulgrenze und
+# war nur DORT geprueft, wo der Code steht (check_pages/gate direkt), nicht
+# dort, wo sie WIRKT (die Verdrahtung in staging_gate). Zieht man den Aufruf
+# `mod.gate(...)` mit in das try/except von _frontend_browser_gate(), blieben
+# 19 von 19 Tests gruen — aus dem Waechter wuerde lautlos ein Freifahrtschein.
+# ---------------------------------------------------------------------------
+
+def test_unexpected_error_inside_gate_blocks_instead_of_passing(
+    tmp_path, hostile, monkeypatch
+):
+    """AC-8, Grenzfall an der WIRKSTELLE: ein Gate-Modul, das sich sauber laden
+    laesst, dessen gate() aber unerwartet abbricht, ist kein KAPUTTES GATE
+    sondern ein NICHT ERBRACHTER NACHWEIS — es muss blockieren.
+
+    Echte Datei statt gemocktem Fehler. Geprueft wird die Wirkung: es darf
+    keine Attestation entstehen. Ob der Abbruch durchschlaegt oder als Exit 1
+    zurueckkommt, ist dabei gleichwertig — beides blockiert. Was NICHT passieren
+    darf, ist ein Durchlassen mit Warnung.
+    """
+    fake = tmp_path / "e2e_frontend_browser_gate.py"
+    fake.write_text(
+        "CORE_PAGES = ('/',)\n"
+        "def load_validator_env():\n"
+        "    pass\n"
+        "def gate(scope, env):\n"
+        "    raise RuntimeError('Browser-Start fehlgeschlagen 1558')\n"
+    )
+    monkeypatch.setattr(sg, "FRONTEND_GATE_PATH", fake)
+    e2e_path = tmp_path / "attestation.json"
+
+    try:
+        rc = _verdict(tmp_path, "frontend-only", e2e_path)
+    except RuntimeError:
+        rc = 1  # Durchschlagen blockiert ebenfalls — kein Verdict entsteht.
+
+    assert rc != 0, (
+        "Ein unerwarteter Abbruch IM Browserlauf wurde als 'Gate kaputt' "
+        "durchgelassen. Die Fail-Grenze verlaeuft aber zwischen 'Gate nicht "
+        "ladbar' (durchlassen) und 'Nachweis nicht erbringbar' (blocken) — "
+        "nicht entlang 'Exception ja/nein'."
+    )
+    assert not e2e_path.exists(), (
+        "Attestation entstand, obwohl der Browserlauf unerwartet abbrach"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Adversary-Fund F002: AC-6 ("eine fehlerfreie Anmeldemaske ist KEINE
+# bestandene Kernseite") war ausschliesslich in der Live-Schicht geprueft — und
+# die ist per pyproject.toml:65 (-m 'not ... and not staging') aus jedem
+# Standardlauf abgewaehlt. Entfernt man den unauthenticated_reason()-Aufruf,
+# blieben 8 von 8 Kern-Tests gruen. Deshalb hier zusaetzlich in der Kern-
+# Schicht, ohne Staging: derselbe lokale Server, echtes Chromium.
+# ---------------------------------------------------------------------------
+
+_LOGIN = ("<!doctype html><html><head><title>Anmeldung</title></head><body>"
+          "<form><input name='username'>"
+          "<input type='password' name='password'></form></body></html>")
+
+
+@pytest.fixture
+def unauth_site():
+    """Lokaler Server, der antwortet wie eine NICHT angemeldete Anwendung — und
+    dabei bewusst FEHLERFREI bleibt (kein Konsolenfehler, HTTP 200/302).
+    '/umleitung' leitet auf '/login' um (Merkmal 1), '/passwortfeld' liefert
+    direkt ein sichtbares Passwortfeld (Merkmal 2). Beide Merkmale sind
+    unabhaengig, damit ein einzelner Umbau die Pruefung nicht still aushebelt."""
+    class H(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            if self.path == "/umleitung":
+                self.send_response(302)
+                self.send_header("Location", "/login")
+                self.end_headers()
+                return
+            body = (_LOGIN if self.path in ("/login", "/passwortfeld")
+                    else _CLEAN).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *a):  # stumm
+            pass
+
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), H)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{srv.server_port}"
+    srv.shutdown()
+    srv.server_close()
+
+
+def test_missing_playwright_blocks_instead_of_skipping(monkeypatch, local_site):
+    """AC-8, dritter Fall: fehlt Playwright, ist der Nachweis NICHT erbringbar →
+    blocken. Kein Skip, kein stilles 0. Der ImportError ist echt (None in
+    sys.modules laesst den Import scheitern) und durchlaeuft den echten Zweig."""
+    monkeypatch.setitem(sys.modules, "playwright.sync_api", None)
+    g = _gate_mod()
+    rc, messages = g.check_pages(local_site, ["/"], {})
+    assert rc != 0, f"fehlendes Playwright blieb folgenlos: {messages}"
+    assert "playwright" in " ".join(messages).lower(), f"Grund unklar: {messages}"
+    creds = {"GZ_VALIDATION_URL": local_site, "GZ_AUTH_USER": "u", "GZ_AUTH_PASS": "p",
+             "GZ_VALIDATOR_USER": "u", "GZ_VALIDATOR_PASS": "p"}
+    assert g.gate("frontend-only", creds) != 0, "Gate muss blocken statt zu ueberspringen"
+
+
+def test_ambiguous_verdict_is_gated_like_verified(tmp_path, hostile):
+    """Spec-Festlegung "Auch bei AMBIGUOUS? Ja": ein AMBIGUOUS-Verdict wird
+    abgelegt und kann spaeter als Vorgaenger dienen — die Luecke waere sonst
+    trivial zu nutzen. Also greift das Gate hier genauso."""
+    e2e_path = tmp_path / "attestation.json"
+    rc = sg.write_verdict("AMBIGUOUS: unklar und unbelegt", tmp_path / "findings.json",
+                          e2e_path=e2e_path, scope_override="frontend-only")
+    assert rc == 1, "AMBIGUOUS muss bei Frontend-Scope gegated werden wie VERIFIED"
+    assert not e2e_path.exists(), "Attestation entstand trotz nicht bestandenem Browserlauf"
+
+
+@pytest.mark.parametrize("path", ["/umleitung", "/passwortfeld"])
+def test_unauthenticated_page_without_console_error_is_not_a_passed_page(
+    unauth_site, path
+):
+    """AC-6 in der Kern-Schicht: fehlerfrei ist NICHT dasselbe wie bestanden.
+
+    Die Seite laedt mit HTTP 200 und wirft keinerlei Konsolenfehler — sie ist
+    nur nicht die angemeldete Zielseite. Genau die Falle aus #1307, bei der ein
+    Gate mit einem Foto der Anmeldemaske bestand."""
+    pytest.importorskip("playwright.sync_api")
+    rc, messages = _gate_mod().check_pages(unauth_site, [path], {})
+    joined = " ".join(messages).lower()
+
+    assert rc != 0, (
+        f"{path}: eine fehlerfreie Anmeldemaske wurde als bestandene Kernseite "
+        f"gewertet (Meldungen: {messages})"
+    )
+    assert "konsolenfehler" not in joined, (
+        f"{path}: die Sperre kam von einem Konsolenfehler statt von der "
+        f"Anmelde-Pruefung — dann belegt der Test AC-6 nicht: {messages}"
+    )
+    assert any(w in joined for w in ("anmeld", "login", "passwort")), (
+        f"{path}: Meldung nennt den Anmeldegrund nicht: {messages}"
+    )

--- a/tests/tdd/test_frontend_browser_gate_staging.py
+++ b/tests/tdd/test_frontend_browser_gate_staging.py
@@ -1,0 +1,89 @@
+"""TDD RED (#1558), Live-Schicht: AC-6/AC-7 gegen echtes Staging.
+
+Spec: docs/specs/modules/feat_1558_frontend_browser_gate.md
+Schnittstelle: siehe Kopf von tests/tdd/test_frontend_browser_gate.py.
+
+Nur gegen https://staging.gregor20.henemm.com — NIE gegen Produktion.
+Zugangsdaten ausschliesslich ueber Variablennamen aus `.claude/validator.env`
+(GZ_VALIDATOR_*) und `.env` (GZ_AUTH_*); Lade-Muster wie
+design_fidelity_diff.load_validator_env().
+
+Lauf: uv run pytest tests/tdd/test_frontend_browser_gate_staging.py -m staging
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.staging
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOKS_DIR = REPO_ROOT / ".claude" / "hooks"
+GATE_PATH = HOOKS_DIR / "e2e_frontend_browser_gate.py"
+STAGING_BASE = "https://staging.gregor20.henemm.com"
+NEEDED = ("GZ_VALIDATOR_USER", "GZ_VALIDATOR_PASS", "GZ_AUTH_USER", "GZ_AUTH_PASS")
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, str(path))
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+sg = _load("staging_gate_fbg_live", HOOKS_DIR / "staging_gate.py")
+
+
+def _gate_mod():
+    assert GATE_PATH.exists(), f"Gate-Modul fehlt: {GATE_PATH}"
+    return _load("e2e_frontend_browser_gate_live", GATE_PATH)
+
+
+def _staging_env() -> dict:
+    env = {"GZ_VALIDATION_URL": STAGING_BASE}
+    for f in (REPO_ROOT / ".claude" / "validator.env", REPO_ROOT / ".env"):
+        if not f.exists():
+            continue
+        for line in f.read_text().splitlines():
+            line = line.strip()
+            if line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            env.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+    missing = [k for k in NEEDED if not env.get(k)]
+    if missing:
+        pytest.skip(f"Zugangsdaten fehlen: {', '.join(missing)}")
+    return env
+
+
+def test_invalid_app_password_is_not_a_passed_core_page(capsys):
+    """AC-6: falsches Anwendungs-Passwort → Nicht-Bestehen, Meldung nennt den
+    Anmeldegrund. Eine fehlerfreie Anmeldemaske gilt NICHT als bestanden (#1307)."""
+    env = {**_staging_env(), "GZ_AUTH_PASS": "definitiv-falsch-1558"}
+    rc = _gate_mod().gate("frontend-only", env)
+    text = "".join(capsys.readouterr()).lower()
+    assert rc != 0, "Anmeldemaske wurde als bestandene Kernseite gewertet"
+    assert any(w in text for w in ("anmeld", "login", "passwort")), (
+        f"Meldung nennt den Anmeldegrund nicht: {text!r}"
+    )
+
+
+def test_clean_run_writes_attestation_naming_checked_pages(tmp_path, monkeypatch):
+    """AC-7: sauberer Lauf gegen Staging → Attestation entsteht und benennt die
+    geprueften Seiten (Feld 'frontend_pages_checked')."""
+    for k, v in _staging_env().items():
+        monkeypatch.setenv(k, v)
+    monkeypatch.setattr(sg, "_telegram_live_gate", lambda: 0)
+
+    e2e_path = tmp_path / "attestation.json"
+    rc = sg.write_verdict("VERIFIED: #1558 Live-Nachweis", tmp_path / "findings.json",
+                          e2e_path=e2e_path, scope_override="frontend-only")
+
+    assert rc == 0, "sauberer Frontend-Lauf gegen Staging muss durchlaufen"
+    checked = json.loads(e2e_path.read_text()).get("frontend_pages_checked") or []
+    assert set(_gate_mod().CORE_PAGES) <= set(checked), (
+        f"Attestation benennt die geprueften Seiten nicht vollstaendig: {checked}"
+    )

--- a/tests/tdd/test_staging_gate_verdict_merge.py
+++ b/tests/tdd/test_staging_gate_verdict_merge.py
@@ -68,9 +68,13 @@ FINDING_SHARED = {
 
 @pytest.fixture(autouse=True)
 def _no_telegram_gate(monkeypatch):
-    """Ehrlicher Boundary-Seam eines UNBETEILIGTEN Gates: kein echter
-    Telegram-/Netz-Aufruf während des Merge-Tests."""
+    """Ehrliche Boundary-Seams UNBETEILIGTER Gates: kein echter Telegram-/Netz-
+    und kein Browser-Aufruf während des Merge-Tests. Das Frontend-Browser-Gate
+    (#1558) greift beim hier verwendeten Scope 'backend' ohnehin nicht — die
+    Neutralisierung hält den Merge-Test aber auch dann frei von fremden
+    Nebenwirkungen, wenn ein Fall später mit Frontend-Scope dazukommt."""
     monkeypatch.setattr(mod, "_telegram_live_gate", lambda: 0)
+    monkeypatch.setattr(mod, "_frontend_browser_gate", lambda scope, checked=None: 0)
 
 
 def _write_findings(tmp_path: Path, findings: list) -> Path:


### PR DESCRIPTION
Schließt #1558.

## Was sich ändert

Berührt der auszuliefernde Änderungssatz das Frontend (Scope `frontend-only` oder `full-stack`), lädt `staging_gate.py --write-verdict` ab jetzt **selbst** sechs Kernseiten in echtem Chromium gegen Staging und sammelt `console(type=error)` und `pageerror`. Schlägt das fehl, entsteht **keine** Attestation — und ohne Attestation blockiert der Produktions-Deploy.

Anlass: #1552, wo die Seite *Trip anlegen* auf Staging vollständig unbedienbar war — bei 5837 grünen Tests, Adversary VERIFIED mit 11 Mutationen und allen CI-Checks grün. Gefunden wurde es nur, weil die Staging-Prüfung damals ausdrücklich über den echten Klickpfad beauftragt war: eine Einzelentscheidung, kein Mechanismus.

## Die tragende Entwurfsentscheidung: das Gate führt aus, es liest nicht

Das Ticket schlug vor, einen Browser-Nachweis abzulegen und vom Gate prüfen zu lassen. Das wurde verworfen: **Nachweis-Erzeuger und Gate-Aufrufer sind dieselbe Instanz.** Wer die Datei schreiben kann, kann sie erfinden.

Kein hypothetisches Risiko — das Muster läuft im Betrieb:

- `pre_issue_close_design_gate.py:64-72` globt `design-diff-*.json` und akzeptiert jede Datei mit `passed: true`, ohne zu prüfen, ob die referenzierten Bilder existieren. **Drei Zeilen JSON von Hand bestehen dieses Gate.**
- `write_verdict()` prüft die Findings-Datei nur auf JSON-Validität, nie darauf, ob die genannten `evidence`-Pfade existieren.

Der Browserlauf passiert deshalb **im selben Aufruf, der das Verdict schreibt**. Nebeneffekt: Das Anti-Stale-Problem entfällt ersatzlos, weil kein zwischengelagerter Nachweis existiert, der veralten könnte.

## Der geerbte Fehler, der nicht mitkopiert wurde

Das Vorbild `_telegram_live_gate()` (#686 AC-5) diffft fest `HEAD~1..HEAD` (`staging_gate.py:237`), während die reguläre Scope-Erkennung die Marker-Kette nutzt. Bei mehreren Commits seit dem letzten Lauf sieht es **nur den letzten** — eine Frontend-Änderung zwei Commits zurück wäre unsichtbar (Muster #1431).

Das neue Gate zieht **keinen eigenen Diff**, sondern konsumiert den in `write_verdict()` bereits berechneten Scope. Ohne zweite Diff-Logik kann der Fehler strukturell nicht entstehen. AC-5 bewacht genau das: Mutation „eigener HEAD~1-Diff" → 4 Tests rot.

Nebenbefund: Der naheliegende Einbauort „analog Telegram bei Zeile 275" wäre falsch, dort ist `scope` noch nicht berechnet.

## Fail-Grenze: an der Modulgrenze, nicht am Ausnahmetyp

| Fall | Verhalten |
|---|---|
| Gate-Modul nicht ladbar (Import-/Syntaxfehler) | Warnung + durchlassen — ein kaputter Wächter darf nie die Auslieferung lahmlegen |
| Playwright fehlt, Staging tot, Anmeldung scheitert, Zugangsdaten fehlen | **blockieren** — das ist „Nachweis nicht erbringbar", nicht „Gate kaputt" |

Kein zweiter stiller Notausgang: `GZ_SKIP_E2E_GATE=1` existiert bereits, laut und geloggt.

## Adversary: 3 Runden, 10 Mutationen

| Mutation | Gefangen |
|---|---|
| Eigener `HEAD~1`-Diff statt Scope-Parameter | ✅ 4 Tests |
| `full-stack` aus der Bedingung streichen | ✅ 1 Test |
| `pageerror`-Listener entfernen | ✅ 1 Test |
| Aufruf vor die Scope-Berechnung ziehen | ✅ 16 Tests |
| Reihenfolge in `_visit()` vertauschen | strukturell folgenlos (belegt) |
| **`try/except` über den Gate-Aufruf ziehen** | ❌ → nachgebessert |
| **Anmelde-Prüfung entfernen** | ❌ → nachgebessert |
| **`ImportError`-Zweig auf `return 0`** | ❌ → nachgebessert |
| **Gate nur bei `VERIFIED` statt auch `AMBIGUOUS`** | ❌ → nachgebessert |

Die vier ungefangenen Mutationen wurden mit Tests geschlossen; jede wird jetzt von **genau einem** Test gefangen. Die Nachbesserung wurde vom Adversary unabhängig nachgemessen, nicht aus dem Entwicklerbericht übernommen.

Zwei der vier waren Spec-Zusagen, die nur im Code standen und von keinem Test gehalten wurden — „fehlt Playwright, wird blockiert" (der Zweig wurde von keinem Test ausgelöst; die vorhandenen Tests übersprangen sich per `importorskip` ausgerechnet dann selbst) und „das Gate greift auch bei `AMBIGUOUS`".

## Tests

- `tests/tdd/test_frontend_browser_gate.py` — 13 Tests, deterministisch: Wegwerf-Repos per `git init`, zwei lokale HTTP-Server auf `127.0.0.1`, echtes Chromium. Läuft unter `--disable-socket --allow-hosts=127.0.0.1`.
- `tests/tdd/test_frontend_browser_gate_staging.py` — 2 Tests, Marker `staging` (AC-6 gegen echte Anmeldemaske, AC-7).

Regression per A/B gegen den Basis-Commit über die **komplette** Suite: **keine**. Alle 16 aktuell roten Tests waren vorher schon rot.

## Offen bis /e2e-verify

- **AC-7** — dass `frontend_pages_checked` tatsächlich in der Attestation landet, ist in keinem Standardlauf geprüft.
- **AC-6 gegen die echte Anmeldemaske** — der Kern-Test prüft die zwei Erkennungsmerkmale gegen einen lokalen Server, nicht gegen das Markup der Anwendung.
- **Netzrechte des Hook-Kontexts** — ungemessen. Fällt das durch, blockiert das Gate korrekt, aber dann jede Frontend-Auslieferung. Erster Handgriff der Staging-Verifikation.

Diese Lücken bewusst nicht im Kern geschlossen: ein Test dafür wäre der Nachbau der eigenen Annahme — genau das, was hier zweimal ausgeräumt wurde.

## Nicht in dieser Scheibe

Der CI-Playwright-Smoke aus dem Ticket („alternativ oder ergänzend zu prüfen") wird ein eigenes Folge-Issue. Playwright läuft heute **nirgends** in der CI — kein npm-Script, keine laufende App, kein Browser-Setup. Der Smoke bräuchte Build, Preview-Server, Chromium-Install und einen eigenen Login-Mechanismus; kein Copy-Paste aus dieser Scheibe.

## Regel-Budget

Prüfdatum **2026-11-05**, Fang-Beleg #1552 liegt vor. Am Prüfdatum mitzubewerten: ob `ui_screenshot_gate.py` dadurch ganz oder teilweise entbehrlich wird.

Spec: `docs/specs/modules/feat_1558_frontend_browser_gate.md` · Kontext & Messungen: `docs/context/feat-1558-frontend-browser-gate.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Boo9S4srN3ZYLRiuhipci7
