### PR TITLE
fix(#1575): Kanal-eigene Metrik-Auswahl im Trip-Editor (Scheibe 3)

### DIFF
--- a/docs/context/fix-1575-channel-metric-selection.md
+++ b/docs/context/fix-1575-channel-metric-selection.md
@@ -1,0 +1,168 @@
+# Context: fix-1575-channel-metric-selection
+
+## Request Summary
+
+#1575 Scheibe 3 (Symptom B): Die Kanal-Reiter Email/Telegram/SMS im
+Wetter-Metriken-Tab des **Trip**-Editors (`shared/WeatherMetricsTab.svelte`,
+`context="route"`) sollen eine echte Wirkung bekommen — Metrik-Auswahl,
+Reihenfolge und Roh/Einfach-Modus werden PRO Kanal gespeichert, statt (wie
+heute) eine einzige globale Liste zu mutieren, während der Reiter nur die
+Vorschau umschaltet. PO-Entscheidung: "Eigene Metrik-Auswahl je Kanal" (nicht
+die Alternative "Reiter nur ehrlich als Vorschau beschriften").
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `frontend/src/lib/components/shared/WeatherMetricsTab.svelte` (1723 Z.) | Haupt-Organism, GETEILT zwischen Trip (`context="route"`) und Compare (`context="vergleich"`) — enthält `activeChannel`-State, mountet `LayoutTab` |
+| `frontend/src/lib/components/shared/layout-tab/{LayoutTab,LTChannelPicker,LTCapNote,LTCutLine}.svelte`, `ltChannels.ts` | Geteilte Kanal-Picker-Hülle aus #1232 Scheibe 3a — `ChannelId = 'email'\|'telegram'\|'sms'`, `channel` ist bisher explizit reiner View-State (`$bindable`, KEINE Persistenz) |
+| `frontend/src/lib/components/trip-detail/metricsEditor.ts` (514 Z.) | Trip-Kern-Editor-Logik: `CHANNEL_COL_BUDGET`, `buildWeatherConfigMetrics`, `move`, `diffHighlight` — arbeitet auf EINER globalen `buckets`-Struktur |
+| `frontend/src/lib/components/trip-detail/WeatherV2Reihenfolge.svelte` | Reihenfolge-Editor (DnD), aktuell `activeChannel` nur für Cut-Line-Anzeige, nicht für Dateninhalt |
+| `frontend/src/lib/components/shared/OutputLayoutEditor.svelte` | **TOTER CODE** (0 Instanziierungen, per Kommentar in `WeatherMetricsTab.svelte` explizit "abgelöst: OutputLayoutEditor-basiertes Layout, Issue #364/#431") — KEIN Wiederverwendungs-Vorbild, siehe Analysis unten |
+| `src/app/models.py:682-758` | `UnifiedWeatherDisplayConfig.per_channel_layouts`/`per_report_layouts` + `get_metrics_for_channel()` — Kaskade (#429/#434), **liest bereits korrekt**, Scheibe 1 (#1575) hat `_sorted_by_layout()` ergänzt |
+| `src/output/renderers/trip_report.py:128-134` | `format_email` kollabiert `dc.metrics` bereits VOR dem Rendern via `dc.get_metrics_for_channel("email", report_type)` — Email-Selektion ist backend-seitig fertig verdrahtet |
+| `src/output/renderers/narrow.py:644` | Trip-Telegram ruft `render_for_channel("telegram", dc, report_type)` — ebenfalls fertig verdrahtet |
+| `src/output/renderers/channel_layout.py` | `render_for_channel()`, `CHANNEL_LIMITS` (inkl. `"sms"`) — pure functions, kanal-bewusst |
+| `src/output/renderers/sms_trip.py::format_sms` | **Trip-SMS nutzt `dc.metrics`/die Kaskade NICHT** — fixes, nicht metrik-konfigurierbares Format. Einziger Aufrufer von `render_for_channel("sms", …)` im ganzen Baum ist `comparison.py` (Compare), nicht Trip |
+| `internal/handler/weather_config.go`, `internal/handler/config_merge.go` | Go-API: `mergeConfigMap` ist generisches `map[string]interface{}`-Merge (Read-Modify-Write) — **kein Go-Struct-Feld nötig**, neue Keys wie `per_channel_layouts` würden schon heute schemafrei durchgereicht |
+
+## Existing Patterns
+
+- **Kaskade-Pattern (#429/#434):** `per_report_layouts[report_type][channel]` > `per_channel_layouts[channel]` > global. Bereits für Email und Telegram (Trip) sowie Email/Telegram/SMS (Compare) verdrahtet.
+- **Geteilter Organism mit `context`-Prop** (#1232): `WeatherMetricsTab`/`LayoutTab` nehmen `context="route"|"vergleich"` und reichen `editor`/`preview`-Snippets durch — etabliertes Muster für die Teilungs-Invariante, hier fortzusetzen statt Trip-Sonderbau.
+- **Kein bestehendes Vorbild für persistierte Pro-Kanal-Daten:** Weder Trip (`buckets.primary` → `display_config.metrics[].bucket/order`) noch Compare (`wiz.activeMetricKeys` → `display_config.active_metrics`, seit #1351 ebenfalls auf EINE globale Liste zurückgebaut) halten heute editierbare Kanal-Buckets. `LayoutTab.svelte` bleibt als zustandsarme UI-Hülle (Kanal-Umschalter + Grid, `editor`/`preview`-Snippets) brauchbar — die neue Datenstruktur darunter muss neu gebaut werden.
+
+## Dependencies
+
+- **Upstream (Backend-Kaskade):** existiert bereits vollständig für `email`/`telegram` im Trip-Kontext (siehe oben) — kein Neubau, nur ein Schreibweg fehlt.
+- **Downstream (Regressionsgates):** `frontend/e2e/layout-tab-route.spec.ts` **AC-6** prüft explizit "Kanalwechsel allein löst KEINEN Auto-Save aus und bleibt nicht-dirty" — dieses Verhalten wird durch die neue Anforderung bewusst umgekehrt, der Test muss überarbeitet, nicht zufällig gebrochen werden. Ebenso `epic-138-metriken-editor.spec.ts`, `epic-138-block-b.spec.ts`, `issue-736/723/619/343/690/1117/932`-Specs als Regressionsgates.
+- **Renderer-Mail-Gate (#811):** greift nur, falls `src/output/renderers/email/*.py` oder `trip_report.py` verändert werden. Falls sich der Email-Pfad wie vermutet unverändert lässt (Kaskade liest bereits), greift das Gate nicht — muss aber in `/20-analyse` bestätigt werden, sobald der SMS-Fund (s.u.) geklärt ist.
+- **Pendant-Gate (#1481 B):** greift bei NEU angelegten Dateien in `trip-detail/**`/`compare/**` einseitig — Ziel ist, Kanal-Logik in `shared/**` zu bauen, dann irrelevant.
+
+## Existing Specs
+
+- `docs/specs/modules/layout_tab_route.md` (#1232 Scheibe 3b, status `draft`, aber implementiert & live) — **etabliert exakt das Gegenteil** der jetzigen Anforderung: "Der Kanal (`channel`) ist reiner UI-View-State ohne Persistenz — er geht NIE in `snapshot()`/`isDirty` ein", testgesichert über AC-6. Diese Spec/dieser Test müssen bewusst abgelöst werden, nicht umgangen.
+- `docs/specs/modules/layout_tab_vergleich.md` (#1232 Scheibe 3a) — Compare-Seite des geteilten Organism, liefert `OutputLayoutEditor`/Bucket-Modell als Vorbild.
+- `docs/specs/modules/rework_1351_compare_catalog.md` (#1351, PO-Entscheidung 2026-07-24) — **harte Leitplanke**: `channel_layouts` "bleibt Trip-only"; Compare hat `channel_layouts` bewusst als Ballast entfernt (widerspricht #1287/#1291 + Konvergenz-Richtung Epic #1230). Eine künftige Kanal-Auswahl für Compare wäre "eine neue Spec" — **diese Scheibe darf `context="vergleich"` NICHT berühren.**
+- `docs/specs/modules/compare_layout_tab_dissolution.md` (#1360) — anderer, älterer, bereits entfernter Compare-Layout-Tab (Pillen-UI); nicht direkt betroffen, aber Referenzpunkt für "Attrappen-Verbot".
+
+## Risks & Considerations
+
+1. **🔴 Bewusste Abweichung von einer dokumentierten, testgesicherten Entscheidung (#1232 Scheibe 3b):** Die aktuelle "Kanalwechsel ist reiner Ansichtswechsel"-Regel war kein Versehen, sondern explizit spezifiziert und per Playwright-AC-6 erzwungen. Diese Scheibe hebt sie für `context="route"` bewusst auf — das muss in der neuen Spec als **Ablösung**, nicht als Nebenwirkung, benannt werden (analog ADR-Status "Abgelöst durch", auch ohne formale `docs/adr/`-Nummer).
+2. **🔴 SMS-Pfad ist im Trip NICHT kaskaden-fähig:** `sms_trip.py::format_sms` liest `dc.metrics`/die Kaskade gar nicht — anders als Email/Telegram. Der KHW-Anwendungsfall ("SMS an Garmin inReach soll andere/weniger Größen zeigen") ist die zentrale Motivation des Issues, trifft aber auf eine Lücke, die über einen reinen Frontend-Schreibweg NICHT lösbar ist. Muss in `/20-analyse` geklärt werden: (a) `sms_trip.py` auf die Kaskade umstellen (zusätzlicher Backend-Scope), oder (b) der SMS-Reiter im Editor wirkt zunächst nur auf den bereits kaskaden-fähigen Telegram-Kurzform-Ersatzpfad, oder (c) Scope-Reduktion auf Email+Telegram, SMS bleibt Folge-Scheibe — PO-Entscheidung nötig.
+3. **Compare darf nicht berührt werden:** geteilte Komponente + PO-Entscheidung #1351 verbieten eine Kanal-Auswahl für `context="vergleich"`. Die Implementierung muss das strukturell sicherstellen (z.B. neue Schreiblogik nur unter `context==="route"` aktiv), nicht nur durch Disziplin.
+4. **Datenschema-Regel:** `per_channel_layouts`/`per_report_layouts` in `models.py` sind schema-relevant (Read-Modify-Write-Pflicht, löst `data_schema_backup`-Hook aus) — bereits als optionale Felder vorhanden, Migration vermutlich nicht nötig (Ebene ist additiv), aber in Analyse zu bestätigen.
+5. **LoC-Risiko:** Das Vorbild `layout_tab_route.md` (kleinerer Scope, nur Restrukturierung) lag schon bei ~150-220 LoC Produktivcode + ~150-200 Tests. Diese Scheibe fügt zusätzlich eine neue Datenstruktur + Persistenz-Pfad hinzu — Überschreitung des 250-LoC-Limits ist wahrscheinlich, PO-Freigabe für `loc_limit_override` ist vorzubereiten, nicht eigenmächtig zu setzen.
+
+## Analysis
+
+### Type
+
+Feature (Full Process) — Frontend-Editor-Persistenzpfad + ein kleiner, notwendiger Backend-Fix.
+
+### SMS-Backend-Fund aufgelöst (war Risk 2)
+
+`sms_trip.py::format_sms` selbst muss **nicht** umgebaut werden. Der eigentliche Bug sitzt in
+`trip_report.py` (Methode, die auch `format_email` speist): Zeile ~128-134 kollabiert `dc.metrics`
+via `dc.get_metrics_for_channel("email", report_type)` — und Zeile ~296
+(`active_metric_ids = {m.metric_id for m in dc.metrics}`), die die SMS-Specs/-Schwellwerte baut,
+liest genau diese bereits **email-kollabierte** `dc`. SMS erbt dadurch strukturell die
+Email-Metrikauswahl, nie eine eigene. Fix: `sms_metrics = dc.get_metrics_for_channel("sms",
+report_type)` separat ziehen, `active_metric_ids` daraus bilden statt aus dem kollabierten `dc`.
+Klein (~15-25 LoC + Test). Realer SMS-Versand bestätigt über `src/output/channels/sms.py`
+(seven.io) — `format_sms`-Text ist tatsächlich das Zugestellte. Einschränkung (kein Blocker): nur
+~12 Metriken sind über `SMS_SYMBOL_BY_METRIC`/`SMS_MULTI_SYMBOLS_BY_METRIC` überhaupt SMS-fähig.
+
+### Kein Wiederverwendungs-Vorbild für Pro-Kanal-Persistenz
+
+`OutputLayoutEditor.svelte` ist toter Code (0 Instanziierungen). Sowohl Trip als auch Compare
+(seit #1351, "channel_layouts-Ballast" bewusst entfernt) sind heute auf eine globale, geordnete
+Liste zurückgebaut. `LayoutTab.svelte` (Kanal-Umschalter-Hülle) bleibt brauchbar, die Datenstruktur
+darunter (`channelBuckets: Record<ChannelId, Buckets>` + `channelFriendlyMap`) ist Neubau. Isolation
+Trip/Compare ist strukturell bereits sauber (hartes `{#if context==='vergleich'}`-Branching,
+komplett getrennte Save-Pfade `metricsEditor.ts` vs. `compareEditorSave.ts`/`weatherMetricsCompareSave.ts`).
+
+### 🔴 Neuer Fund: Shallow-Merge-Datenverlust-Risiko
+
+Der rohe JSON-Key ist `channel_layouts` (nicht `per_channel_layouts` — das ist nur der
+Python-Feldname) unter `display_config` (nicht `weather_config` — Issue-Text ist hier ungenau).
+Go mergt `DisplayConfig` nur **shallow auf oberster Schlüsselebene**
+(`internal/handler/config_merge.go:11-22`, aufgerufen `trip.go:304`). Sendet das Frontend beim
+Speichern unter Reiter "SMS" nur `channel_layouts: {sms: [...]}`, **ersetzt das den kompletten
+`channel_layouts`-Wert** — bereits gespeicherte `email`/`telegram`-Einträge werden lautlos
+gelöscht. Ein neuer BUG-DATALOSS-GR221-Fall, den diese Scheibe selbst einführen würde, wenn das
+Frontend nicht bei jedem Save den vollständigen `channel_layouts`-Stand alle bereits berührten
+Kanäle mitsendet. **Pflicht-AC:** "Speichern in Kanal X lässt Kanal Y unverändert" — eigener Test.
+
+### Copy-on-write statt Eager-Init
+
+Ein Kanal bekommt erst beim ersten tatsächlichen Edit unter diesem Reiter einen eigenen Eintrag;
+bis dahin liest der Reiter die globale Liste (spiegelt die Backend-Kaskade: `None` = Fallback auf
+global). Verhindert, dass ein nie berührter Kanal fälschlich als "eigene leere Auswahl" gespeichert
+wird.
+
+### AC-6 (`layout_tab_route.md`): aufspalten, nicht ersetzen
+
+Die alte Garantie "reiner Kanal**wechsel** (ohne Edit) bleibt clean/nicht-dirty" bleibt ein
+sinnvolles eigenständiges Invariant. Neu daneben: "Kanal-**Edit** macht dirty UND das Speichern
+schreibt nur den aktiven Kanal in `channel_layouts[kanal]`, andere Kanäle bleiben unverändert"
+(deckt auch den Shallow-Merge-Test ab).
+
+### Affected Files (with changes)
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/output/renderers/trip_report.py` | MODIFY | SMS-Fix: `active_metric_ids` aus `get_metrics_for_channel("sms", …)` statt kollabiertem `dc` |
+| `tests/tdd/` oder passende Modul-Suite | CREATE | RED/GREEN-Nachweis SMS-Fix |
+| `frontend/src/lib/components/shared/WeatherMetricsTab.svelte` | MODIFY | neue Kanal-State-Vars, `snapshot()`/`isDirty`-Erweiterung, Save-Payload |
+| `frontend/src/lib/components/shared/` neue Datei (z.B. `channelLayouts.ts`) oder Erweiterung `metricsEditor.ts` | CREATE/MODIFY | `channelBuckets`/`channelFriendlyMap`-Struktur, Serialisierung zu `channel_layouts` (voller Stand, alle berührten Kanäle) |
+| `frontend/src/lib/components/shared/weather-metrics-tab/WeatherV2Reihenfolge.svelte` | MODIFY | liest/schreibt kanalspezifische Buckets statt nur `activeChannel` für Cut-Line |
+| `frontend/e2e/layout-tab-route.spec.ts` | MODIFY | AC-6 aufspalten (s.o.) + neuer Datenverlust-Test |
+| `frontend/src/lib/components/shared/weatherMetricsTabSharing.test.ts` (bestehend) | MODIFY | Fall ergänzen: neue Kanal-State-Vars werden im `vergleich`-Zweig nie gelesen |
+
+### Scope Assessment
+
+- Files: ~7-9 (2 Backend, 5-7 Frontend inkl. Tests)
+- Estimated LoC: Produktivcode ~200-350, Tests ~200-300 — **Überschreitung des 250-LoC-Limits
+  wahrscheinlich**, `loc_limit_override` (Richtwert ~500, analog `layout_tab_route.md`-Vorgänger)
+  vor Phase 6 explizit beim PO einholen, nicht eigenmächtig setzen.
+- Risk Level: MEDIUM — Backend-Kaskade fertig, Isolation Trip/Compare strukturell sauber; Hauptrisiko
+  ist der neue Shallow-Merge-Fund (gut testbar) und das Aufspalten von AC-6 sauber umzusetzen.
+
+### Technical Approach
+
+Ein Workflow (nicht mehrere Scheiben) — UI ohne den SMS-Backend-Fix wäre für SMS wirkungslos
+(Attrappen-Verbot). Reihenfolge innerhalb des Workflows: TDD-RED zuerst isoliert für den kleinen,
+unabhängig prüfbaren SMS-Backend-Fix, danach der größere Frontend-Persistenzpfad. Telegram-Backend
+ist bereits fertig verdrahtet (`narrow.py:644`) — bei LoC-Druck wäre eine Zurückstellung der
+Telegram-Editor-UI ein möglicher Trade-off, aber PO-Entscheidung, keine Vorentscheidung dieser Analyse.
+
+### Dependencies
+
+Wie in Related Files/Existing Specs oben — zusätzlich bestätigt: Renderer-Mail-Gate (#811) greift
+sicher, da `trip_report.py` verändert wird → `briefing_mail_validator.py` gegen echte Staging-Mail
+ist Pflicht vor "E2E bestanden".
+
+### Open Questions
+
+- [ ] Scope-Bestätigung: nur Metrik-Auswahl/Reihenfolge/Roh-Einfach pro Kanal — Horizonte,
+      SMS-Schwellwerte, Auswertungswahl bleiben global?
+- [x] Alt-`channel_layouts`-Datenfalle: **PO-go 2026-08-08, per Prod-Check verifiziert.**
+      `sudo -u claude-gregor grep -rl "channel_layouts\|per_channel_layouts\|per_report_layouts"
+      /home/hem/gregor_zwanzig/data/users/` (137 Briefing-Dateien durchsucht) findet **keine**
+      Treffer in `briefings/` (Trip-Daten). Die einzigen zwei Treffer liegen in
+      `henning/compare_presets.json` und `compare_subscriptions.json.bak` — Compare-Altlast,
+      bereits durch #1351 als zu bereinigender Ballast bekannt, außerhalb dieser (Trip-)Scheibe.
+      **Migration/Bereinigung ist NICHT Teil dieser Scheibe** — kein Bestands-Trip betroffen.
+- [x] Telegram: **PO-go 2026-08-08** — vollwertig, alle drei Kanäle in dieser Scheibe.
+- [x] Vererbung beim ersten Kanal-Edit: **PO-go 2026-08-08** — Kopie der aktuellen globalen
+      Auswahl als Startpunkt.
+- [x] Scope je Kanal: **PO-go 2026-08-08** — nur Auswahl/Reihenfolge/Roh-Einfach; Horizonte,
+      SMS-Schwellwerte, Auswertungswahl bleiben global.
+- Shallow-Merge-Schutz bleibt Pflicht-AC (kein PO-Ermessen — Datenverlust-Vermeidung ist Standard-
+  Regel, nicht optional).
+
+## Next Step
+
+Kontext und Analyse vollständig. Weiter mit `/30-write-spec` — die fünf offenen Fragen oben werden
+in die Spec aufgenommen und dem PO zur Freigabe vorgelegt (nicht separat vorab entschieden).

--- a/docs/specs/modules/fix_1575_channel_metric_selection.md
+++ b/docs/specs/modules/fix_1575_channel_metric_selection.md
@@ -1,0 +1,444 @@
+---
+entity_id: fix_1575_channel_metric_selection
+type: feature
+created: 2026-08-08
+updated: 2026-08-08
+status: draft
+workflow: fix-1575-channel-metric-selection
+---
+
+# Kanal-eigene Metrik-Auswahl im Trip-Editor — #1575 Scheibe 3 (Symptom B)
+
+- **Issue:** #1575 Scheibe 3 von 3, Symptom B
+- **Vorgänger (geteilter Organism):** `docs/specs/modules/layout_tab_route.md` (#1232 Scheibe 3b, live) — diese Scheibe löst dessen AC-6 teilweise ab, siehe „Architektur-Entscheidung" unten
+- **Typ:** Full-Stack-Fix — ein kleiner Backend-Bugfix (Python) + ein neuer Frontend-Persistenzpfad (Svelte/TS), kein neues Datenschema (additive, bereits vorhandene Backend-Felder)
+
+## Approval
+
+- [x] Approved (PO, 2026-08-08)
+
+## Purpose
+
+Die Kanal-Reiter Email/Telegram/SMS im Wetter-Metriken-Tab des **Trip**-Editors
+(`WeatherMetricsTab.svelte`, `context="route"`) schalten heute nur die
+Vorschau um, ohne eigene Daten zu tragen — ein Klick auf "SMS" zeigt ein
+SMS-Template, aber mit exakt derselben (globalen) Metrik-Auswahl wie Email.
+Diese Scheibe gibt den Reitern eine echte Wirkung: Metrik-Auswahl,
+Reihenfolge und Roh/Einfach-Modus werden pro Kanal gespeichert. Motivation
+ist der KHW-Anwendungsfall — SMS an ein Garmin inReach soll andere/weniger
+Größen zeigen können als die Email. Die Backend-Kaskade dafür existiert seit
+#429/#434 bereits für Email und Telegram; SMS hat zusätzlich einen isolierten
+Bug, der die Kaskade für SMS strukturell wirkungslos macht (siehe Teil 1).
+
+## Source
+
+- **Files:**
+  - `src/output/renderers/trip_report.py` — MODIFY (SMS-Backend-Fix)
+  - `frontend/src/lib/components/shared/WeatherMetricsTab.svelte` (1723 Z.) — MODIFY (neue Kanal-State, Save-Payload)
+  - `frontend/src/lib/components/trip-detail/metricsEditor.ts` (514 Z.) — MODIFY (per-Kanal-Bucket-Helfer)
+  - `frontend/src/lib/components/shared/weather-metrics-tab/WeatherV2Reihenfolge.svelte` — MODIFY
+  - `frontend/src/lib/components/shared/weather-metrics-tab/WeatherV2MailPreview.svelte` — MODIFY (Fund, s. u.)
+  - `frontend/e2e/layout-tab-route.spec.ts` — MODIFY
+  - `frontend/src/lib/components/shared/__tests__/weatherMetricsTabSharing.test.ts` — MODIFY
+- **Identifier:** `dc.get_metrics_for_channel()` (`src/app/models.py:726`, unverändert genutzt), `channel_layouts` (Wire-Key unter `display_config`), `ChannelId`/`ChannelLayouts`/`WeatherConfigMetric` (`frontend/src/lib/types.ts`)
+
+> **Schicht-Hinweis bestätigt:** Backend-Teil liegt in Python-Core (`src/output/renderers/`), Frontend-Teil in `frontend/src/lib/components/shared/**` (geteilte Trip/Compare-Schicht, hier nur der `route`-Zweig betroffen). Kein Go-Struct-Feld nötig — `DisplayConfig` ist in `internal/model` bereits `map[string]interface{}` (schemafrei).
+
+## Estimated Scope
+
+- **LoC:** Produktivcode ~200–350, Tests ~200–300 — **Überschreitung des
+  250-LoC-Standardlimits wahrscheinlich.** `loc_limit_override` (Richtwert
+  ~500, analog `layout_tab_route.md`-Vorgänger) ist vor Phase 6 **explizit
+  beim PO einzuholen**, nicht eigenmächtig zu setzen.
+- **Files:** ~7–9 (2 Backend inkl. Test, 5–7 Frontend inkl. Tests)
+- **Effort:** high — neue Datenstruktur + Persistenzpfad in der am dichtesten
+  getesteten Editor-Komponente des Projekts, plus eine bewusste Ablösung
+  einer testgesicherten Vorgänger-Garantie (AC-6, s. u.)
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/app/models.py:682-766` (`UnifiedWeatherDisplayConfig.per_channel_layouts`, `get_metrics_for_channel()`) | module | Backend-Kaskade (#429/#434) — bereits vollständig vorhanden für Email/Telegram, wird für SMS erst durch Teil 1 dieser Scheibe erreichbar; kein Neubau |
+| `src/output/renderers/narrow.py:644` (`render_for_channel("telegram", dc, report_type)`) | module | Telegram-Backend bereits fertig verdrahtet — reiner Regressionsbeweis in dieser Scheibe, keine Änderung |
+| `frontend/src/lib/components/shared/layout-tab/{LayoutTab,LTChannelPicker,LTCapNote,LTCutLine}.svelte`, `ltChannels.ts` | module | Geteilte Kanal-Picker-Hülle (#1232 Scheibe 3a/3b) — `channel`/`ChannelId` bleibt unverändert die UI-Steuergröße, wird hier zusätzlich zur Dateninhalt-Auswahl |
+| `frontend/src/lib/types.ts:272-291` (`ChannelLayouts`, `ChannelLayoutsPerReport`, `WeatherConfigMetric`) | module | Wire-Typen existieren bereits (Issue #429/#434) — kein neuer Typ nötig, nur ein neuer Schreibweg dorthin |
+| `frontend/src/lib/components/shared/layout-tab/channelLayoutsDirty.ts` (`channelLayoutsChangedByUser`) | module | **Fund:** bereits vorhandene, wertbasierte Dirty-Erkennung für `ChannelLayouts` aus #1269 (ursprünglich für den Compare-Kanal-Picker gebaut) — seit #1351 (Compare verwirft `channel_layouts` beim Speichern) nur noch von der eigenen Testdatei referenziert, sonst ungenutzt. Wiederverwendbar für die neue Trip-`isDirty`-Erweiterung statt eines Neubaus; ggf. Anpassung, falls die Trip-Bucket-Form von der Compare-Rohform abweicht — in Phase 5 zu prüfen |
+| `internal/handler/config_merge.go:11-22` (`mergeConfigMap`), `internal/handler/trip.go:303-304` | module | Go-Merge ist **shallow auf oberster Schlüsselebene** von `display_config` — der Grund für den Pflicht-Test AC-3 (s. u.); kein Go-Code-Change nötig, wenn das Frontend beim Speichern den vollen `channel_layouts`-Stand mitsendet |
+| `docs/specs/modules/layout_tab_route.md` (#1232 Scheibe 3b, live) | module | **Wird teilweise abgelöst**, s. „Architektur-Entscheidung" |
+| `docs/specs/modules/rework_1351_compare_catalog.md` (#1351) | module | Harte Leitplanke: `channel_layouts` bleibt Trip-only — Compare (`context="vergleich"`) darf strukturell nicht berührt werden |
+| `frontend/e2e/layout-tab-route.spec.ts`, `epic-138-metriken-editor.spec.ts`, `epic-138-block-b.spec.ts`, `issue-736/723/619/343/690/1117/932`-Specs | tests | Regressionsgates — bestehende Selektoren (`wm2-*`, `weather-metrics-*`, `sms-thresholds`) müssen unverändert grün bleiben |
+
+## Implementation Details
+
+### Teil 1 — Backend-Fix: SMS erbt die Email-Auswahl statt einer eigenen (`trip_report.py`)
+
+`format_email()` in `trip_report.py` kollabiert `dc` **vor** dem eigentlichen
+Rendern für Email (Z. 129–134):
+
+```python
+if report_type in ("morning", "evening"):
+    active_metrics = dc.get_metrics_for_channel("email", report_type)
+    active_metrics = [dataclasses.replace(mc, enabled=True) for mc in active_metrics]
+    dc = dataclasses.replace(dc, metrics=active_metrics)
+```
+
+Ab hier ist `dc.metrics` bereits die **Email**-Auswahl. Der SMS-Aufbau
+weiter unten (Z. 281–314, insbesondere `_sms_thr` Z. 282–286 und
+`active_metric_ids` Z. 296) liest **dieselbe**, bereits kollabierte `dc`:
+
+```python
+_sms_thr = {
+    SMS_SYMBOL_BY_METRIC[m.metric_id]: m.sms_threshold
+    for m in dc.metrics                       # ← Email-kollabiert
+    if m.metric_id in SMS_SYMBOL_BY_METRIC and m.sms_threshold is not None
+}
+...
+active_metric_ids = {m.metric_id for m in dc.metrics}   # ← Email-kollabiert
+```
+
+SMS erbt dadurch strukturell die Email-Metrikauswahl und kann nie eine
+eigene haben — unabhängig davon, was im Frontend unter `channel_layouts.sms`
+gespeichert wird. **Fix:** vor der SMS-Symbol-Konstruktion eine eigene,
+SMS-spezifische Metrikliste aus dem noch **ungekollabierten** `display_config`
+ziehen (nicht aus dem oben bereits mutierten `dc`), um die **Menge** der
+SMS-relevanten Metriken zu bestimmen — der **Schwellwert-Wert** selbst muss
+weiterhin aus der **globalen** Metrikliste kommen:
+
+> **Korrektur (RED-Phase, 2026-08-08):** Die ursprüngliche Fassung dieses
+> Code-Beispiels baute `_sms_thr` direkt aus `sms_metrics` (`m.sms_threshold`
+> für `m in sms_metrics`). Das ist falsch und wurde durch
+> `test_globaler_sms_schwellwert_wirkt_auch_bei_sms_eigener_auswahl`
+> (`tests/unit/test_trip_sms_channel_metric_selection.py`) widerlegt: die vom
+> Editor geschriebenen Kanal-Layouts (`buildWeatherConfigMetrics`,
+> `metricsEditor.ts:332`) führen **kein** `sms_threshold`-Feld — dessen Wert
+> lebt ausschließlich in der globalen Metrikliste (PO-Scope-Entscheidung 1,
+> KL-4). Bei kanal-eigener Auswahl wäre `m.sms_threshold` für jede Metrik in
+> `sms_metrics` `None`, die konfigurierten Schwellwerte gingen lautlos
+> verloren. Korrigierter Fix — Menge aus `sms_metrics`, Schwellwert-Wert aus
+> der ungekollabierten globalen Liste:
+
+```python
+sms_metrics = (display_config or dc).get_metrics_for_channel("sms", report_type)
+sms_metric_ids = {m.metric_id for m in sms_metrics}
+_global_metrics = {m.metric_id: m for m in (display_config or dc).metrics}
+_sms_thr = {
+    SMS_SYMBOL_BY_METRIC[mid]: _global_metrics[mid].sms_threshold
+    for mid in sms_metric_ids
+    if mid in SMS_SYMBOL_BY_METRIC
+    and mid in _global_metrics
+    and _global_metrics[mid].sms_threshold is not None
+}
+...
+active_metric_ids = sms_metric_ids
+```
+
+`sms_trip.py::format_sms` selbst bleibt unverändert — es ist ein reiner
+Symbol-Renderer, der die bereits fertig gefilterten `MetricSpec`-Objekte aus
+`trip_report.py` konsumiert; der Fund sitzt ausschließlich im Aufrufer.
+`sms_threshold` selbst bleibt eine globale (nicht kanal-eigene) Konfiguration
+pro Metrik (PO-Scope-Entscheidung, s. u.) — nur die **Menge der SMS-relevanten
+Metriken** wird kanalspezifisch, nicht der Schwellwert-Wert.
+
+### Teil 2 — Frontend: `channel_layouts` als eigener Persistenzpfad
+
+**Neue State-Struktur** in `WeatherMetricsTab.svelte` (nur unter
+`context === 'route'` aktiv gepflegt):
+
+```ts
+type ChannelOverride = { buckets: Buckets; friendlyMap: Record<string, boolean> } | null;
+let channelBuckets = $state<Record<ChannelId, ChannelOverride>>({
+  email: null, telegram: null, sms: null,
+});
+```
+
+`null` = **kein eigener Eintrag** (copy-on-write, PO-Entscheidung 4) — der
+Reiter zeigt und editiert in diesem Zustand die globale `buckets`/`friendlyMap`
+direkt (analog Kaskaden-Ebene 3 im Backend: „kein `per_channel_layouts[channel]`
+→ Fallback auf global"). Erst der erste tatsächliche Edit unter einem Reiter
+(Drag&Drop, Modus-Wechsel, Entfernen) legt `channelBuckets[channel]` an — als
+**Kopie** der zu diesem Zeitpunkt aktuellen globalen `buckets`/`friendlyMap`
+(PO-Entscheidung: Startpunkt ist die globale Auswahl, nicht leer).
+
+`WeatherV2Reihenfolge.svelte` und `WeatherV2MailPreview.svelte` lesen/schreiben
+ab dieser Scheibe die **effektiven** Buckets/den effektiven `friendlyMap` für
+den aktiven Kanal:
+
+```ts
+const effectiveBuckets = $derived(channelBuckets[activeChannel] ?? { buckets, friendlyMap });
+```
+
+**Fund (über die vom Auftraggeber gelieferte Dateiliste hinaus):**
+`WeatherV2MailPreview.svelte` erhält heute `primaryColumns`/`friendlyMap` als
+rohe, globale Props — nur `channel` steuert, welches Template (Email/
+Telegram/SMS) gerendert wird, nicht welcher INHALT. Ohne Anpassung würde die
+Vorschau weiterhin die globale Auswahl zeigen, selbst wenn der aktive Kanal
+einen eigenen Eintrag hat. `WeatherMetricsTab.svelte` muss beim Rendern des
+`preview`-Snippets die für den jeweiligen Kanal **effektiven** `primaryColumns`/
+`friendlyMap` übergeben (aus `effectiveBuckets`, s. o.) statt der globalen
+Variablen unverändert durchzureichen.
+
+**Horizonte bleiben explizit global** (`horizonsMap` wird NICHT Teil von
+`channelBuckets` — PO-Scope-Entscheidung 1): Reihenfolge und Roh/Einfach-Modus
+sind die einzigen Bucket-Eigenschaften, die pro Kanal divergieren dürfen.
+
+**Save-Payload** (`buildWeatherPayload()`, Z. 690–697) erhält einen neuen
+Zweig, der — analog zum bestehenden Muster `...(trip!.display_config ?? {})`
+— den **vollständigen bisherigen** `channel_layouts`-Stand aus `trip!.display_config`
+übernimmt und nur den gerade aktiven Kanal überschreibt:
+
+```ts
+function buildWeatherPayload() {
+  const prevLayouts = trip!.display_config?.channel_layouts ?? {};
+  const nextLayouts = channelBuckets[activeChannel]
+    ? { ...prevLayouts, [activeChannel]: buildWeatherConfigMetrics(
+        channelBuckets[activeChannel]!.buckets,
+        channelBuckets[activeChannel]!.friendlyMap,
+        horizonsMap, catalog, aggregationsMap) }
+    : prevLayouts;               // Kanal nie editiert → nichts Eigenes zu senden
+  return {
+    ...(trip!.display_config ?? {}),
+    metrics: buildWeatherMetricsList(),
+    channel_layouts: nextLayouts,
+    preset_name: selectedTemplate || undefined,
+    telegram_kurzform: telegramKurzform,
+  };
+}
+```
+
+Das schützt gegen den **Shallow-Merge-Datenverlust** (`config_merge.go`
+ersetzt `channel_layouts` komplett, nicht feldweise): Speichert der Nutzer
+im SMS-Reiter, ohne den Stand von zuvor bereits editierten Email-/Telegram-
+Einträgen mitzusenden, würden diese sonst beim nächsten `PUT` lautlos
+gelöscht (neuer BUG-DATALOSS-GR221-Fall). Deshalb liest `buildWeatherPayload()`
+den `prevLayouts`-Stand immer aus `trip!.display_config` (der aktuellsten
+bekannten Serverantwort), nicht aus einem lokalen Zwischenspeicher, der
+zwischen Reitern veralten könnte.
+
+**`isDirty`/`snapshot()`** (Z. 288–298) werden um `channelBuckets` erweitert.
+Der reine Kanalwechsel (kein Edit) darf **weiterhin nicht** dirty machen
+— dafür wird `channelBuckets` selbst nicht bei jedem Reiter-Klick verändert
+(bleibt `null` bzw. unverändert, solange nichts editiert wurde), sondern nur
+bei einem tatsächlichen Edit-Callback. Für den Vergleich `savedSnapshot`
+vs. aktuellem State wird — analog dem Fund unter Dependencies —
+`channelLayoutsChangedByUser`-artige, wertbasierte Normalisierung genutzt
+statt eines rohen `JSON.stringify`-Vergleichs auf `channelBuckets`, damit
+Kanonisierungs-Rauschen (z. B. `off`-Metriken-Reihenfolge) keine
+Fehlalarme erzeugt (gleiches Prinzip wie in `channelLayoutsDirty.ts`
+dokumentiert).
+
+### Isolation zu `context="vergleich"` (strukturell, nicht nur Disziplin)
+
+`channelBuckets`, `effectiveBuckets` und der neue Save-Zweig werden
+ausschließlich in Codepfaden gelesen/geschrieben, die bereits heute hinter
+`context === 'route'`-Branches liegen (Save-Handler, `buildWeatherPayload`,
+`WeatherV2Reihenfolge`/`WeatherV2MailPreview`-Aufrufe im `route`-Zweig der
+Komponente). Keine der neuen Funktionen wird von einer Stelle aus
+aufgerufen, die auch vom `vergleich`-Zweig durchlaufen wird — Diff-Review
+(AC-8) prüft das explizit, nicht nur über eine Konvention.
+
+## Expected Behavior
+
+- **Input:** Der Nutzer öffnet den Wetter-Metriken-Tab eines Trips, wechselt
+  über den `LTChannelPicker` zwischen Email/Telegram/SMS und editiert
+  innerhalb eines Reiters die Reihenfolge (Drag&Drop), den Roh/Einfach-Modus
+  oder entfernt eine Metrik.
+- **Output:** Ein reiner Kanal**wechsel** ändert nur die angezeigten Daten
+  (zeigt entweder den eigenen Kanal-Eintrag oder — falls noch nie editiert —
+  die globale Auswahl), macht den Tab NICHT dirty, löst KEINEN Auto-Save aus.
+  Ein Kanal-**Edit** legt (beim ersten Mal, als Kopie der globalen Auswahl)
+  einen eigenen `channelBuckets[kanal]`-Eintrag an, macht den Tab dirty, und
+  der Auto-Save schreibt den vollständigen `channel_layouts`-Stand (alle
+  bereits berührten Kanäle) nach `PUT /api/trips/{id}/weather-config`. Nach
+  einem Reload zeigt jeder editierte Reiter weiterhin seine eigene Auswahl,
+  unedierte Reiter weiterhin die globale.
+- **Side effects:** Email- und Telegram-Trip-Renderer lesen die neue
+  Kanal-Auswahl bereits über die bestehende Kaskade (`get_metrics_for_channel`)
+  — keine weitere Backend-Änderung nötig. SMS-Trip-Renderer liest sie erst
+  nach dem Fix aus Teil 1 korrekt. `context="vergleich"` ist vollständig
+  unberührt — Compare zeigt weiterhin eine einzige globale Auswahl ohne
+  Kanal-Persistenz (#1351 bleibt in Kraft).
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip mit globaler Metrik-Auswahl (z. B. A, B, C) und noch
+  keinem eigenen Kanal-Eintrag / When der Nutzer zwischen Email, Telegram und
+  SMS wechselt, ohne etwas zu editieren / Then zeigen alle drei Reiter
+  dieselbe (globale) Auswahl A, B, C, und der Tab bleibt nicht-dirty
+  (`weather-metrics-dirty-pill` unsichtbar, kein Auto-Save-Request).
+  - Test: Playwright wechselt die drei Kanäle nacheinander, prüft Vorschau-
+    Inhalt und Netzwerk-Requests. (Fortführung der alten AC-6-Hälfte
+    „reiner Kanalwechsel bleibt clean" aus `layout_tab_route.md`.)
+
+- **AC-2 (Copy-on-write):** Given der SMS-Reiter zeigt noch die globale Auswahl
+  A, B, C / When der Nutzer im SMS-Reiter Metrik C entfernt / Then entsteht ein
+  eigener `channelBuckets.sms`-Eintrag mit Startpunkt A, B, C (Kopie der
+  globalen Auswahl zum Edit-Zeitpunkt), nicht leer beginnend, und zeigt nach
+  dem Edit A, B. Email/Telegram zeigen weiterhin unverändert die globale
+  Auswahl A, B, C.
+  - Test: Playwright entfernt eine Metrik im SMS-Reiter, wechselt zu
+    Email/Telegram und prüft, dass dort die volle globale Auswahl weiterhin
+    sichtbar ist.
+
+- **AC-3 (Pflicht — Shallow-Merge-Datenverlust-Schutz):** Given der Trip hat
+  bereits gespeicherte, unterschiedliche Kanal-Layouts unter
+  `display_config.channel_layouts.email` und `.telegram` / When der Nutzer
+  ausschließlich im SMS-Reiter editiert und speichert / Then bleiben die
+  gespeicherten `email`- und `telegram`-Einträge nach dem `PUT` unverändert
+  (per Folge-`GET` desselben Trips verifiziert) — kein lautloser Verlust
+  analog BUG-DATALOSS-GR221.
+  - Test: End-to-End über die echte Save-API (kein Mock): PUT SMS-Edit →
+    GET Trip → assert `channel_layouts.email`/`.telegram` unverändert,
+    `channel_layouts.sms` neu/geändert. Muster analog
+    `rework_1351_compare_catalog.md` AC-6/AC-7.
+
+- **AC-4:** Given eine Metrik-Reihenfolge A, B, C im Email-Reiter (bereits
+  eigener Eintrag) / When im Telegram-Reiter die Reihenfolge auf C, A, B
+  geändert und gespeichert wird / Then bleibt Email nach einem Reload A, B, C,
+  Telegram zeigt C, A, B.
+  - Test: Playwright Drag&Drop in beiden Reitern nacheinander, Reload,
+    Reihenfolge je Kanal geprüft.
+
+- **AC-5 (Roh/Einfach pro Kanal):** Given Metrik X ist im Email-Reiter auf
+  "Einfach" gesetzt (eigener Eintrag) / When im SMS-Reiter Metrik X auf "Roh"
+  umgeschaltet und beides gespeichert wird / Then bleibt der Email-Modus für X
+  nach einem Reload "Einfach", der SMS-Modus "Roh".
+  - Test: Playwright Modus-Toggle in beiden Reitern, Reload, Modus je Kanal
+    geprüft.
+
+- **AC-6 (SMS-Backend-Fix, RED vor Fix):** Given ein Trip mit Email-Auswahl
+  {A, B, C} und SMS-eigener Auswahl {A} (`channel_layouts.sms` gesetzt) / When
+  das SMS-Briefing gerendert wird (`trip_report.py` → `format_sms`) / Then
+  enthält der SMS-Text ausschließlich die für A definierten SMS-Symbole, NICHT
+  die zusätzlichen Symbole von B/C — vor dem Fix (Teil 1) enthält er
+  fälschlich auch B/C, weil `active_metric_ids`/`_sms_thr` aus dem bereits
+  Email-kollabierten `dc` gebildet werden.
+  - Test: Kern-Suite, Modul-Test (nach Verhalten benannt, nicht nach
+    Issue-Nummer) reproduziert den Bug rot vor Fix, grün danach — direkter
+    Aufruf von `trip_report.py`s Render-Pfad mit präparierter
+    `display_config`, Assertion auf den zusammengesetzten SMS-Text.
+
+- **AC-7 (Telegram bereits verdrahtet, Regressionsbeweis):** Given eine
+  Telegram-eigene Metrik-Auswahl, die von der Email-Auswahl abweicht / When
+  das Telegram-Briefing gerendert wird (`narrow.py` → `render_for_channel`)
+  / Then zeigt die Telegram-Bubble die Telegram-eigene Auswahl — ohne
+  Code-Änderung an `narrow.py`, ausschließlich über den neuen Frontend-
+  Schreibweg nachgewiesen.
+  - Test: E2E-Mail-/Telegram-Nachweis über eine echt zugestellte Staging-
+    Mail bzw. Telegram-Testnachricht (Pflicht laut Test-Nachweis-Abschnitt).
+
+- **AC-8 (Compare strukturell unberührt):** Given der Compare-Editor
+  (`context="vergleich"`) / When diese Scheibe abgeschlossen ist / Then ist
+  keine Compare-eigene Datei verändert, und `weatherMetricsTabSharing.test.ts`
+  belegt zusätzlich, dass die neuen State-Variablen (`channelBuckets`,
+  `effectiveBuckets`) in keiner Funktion gelesen werden, die der
+  `vergleich`-Zweig durchläuft.
+  - Test: Diff-Review (nur gelistete Affected Files verändert) + erweiterter
+    `weatherMetricsTabSharing.test.ts`-Fall.
+
+- **AC-9 (globale Größen bleiben global):** Given Horizonte, SMS-Schwellwerte
+  und Auswertungswahl (min/max) sind Trip-weit konfiguriert / When ein Kanal
+  editiert und gespeichert wird / Then ändern sich diese drei Werte NICHT pro
+  Kanal — sie bleiben eine einzige globale Konfiguration, unabhängig vom
+  aktiven Reiter.
+  - Test: Playwright ändert einen Horizont-Chip/SMS-Schwellwert im Email-
+    Reiter, wechselt zu SMS, prüft denselben (nicht kanal-eigenen) Wert.
+
+- **AC-10:** Given die bestehenden Testids und Regressions-Specs (`wm2-*`,
+  `weather-metrics-*`, `sms-thresholds`, `layout-tab-route.spec.ts` außer der
+  bewusst abgelösten Teil-AC, `epic-138-metriken-editor.spec.ts`,
+  `epic-138-block-b.spec.ts`, `issue-736/723/619/343/690/1117/932`-Specs) /
+  When die Seite gerendert bzw. die Specs ausgeführt werden / Then existieren
+  die Testids unverändert und alle genannten Bestands-Specs bleiben grün.
+  - Test: Playwright-Regressionslauf der genannten Specs.
+
+- **AC-11 (Renderer-Mail-Gate #811 erfüllt):** Given `trip_report.py` wurde
+  verändert (Teil 1) / When ein Commit die Datei staged / Then blockiert
+  `renderer_mail_gate.py` erst nach erfolgreichem `briefing_mail_validator.py`-
+  Lauf gegen eine echt zugestellte Staging-Mail (`X-GZ-Mail-Type: trip-briefing`).
+  - Test: `uv run pytest tests/tdd/test_issue_811_mode_matrix.py` +
+    `uv run python3 .claude/hooks/briefing_mail_validator.py` grün vor
+    Commit.
+
+## Known Limitations
+
+- **KL-1 · Nur ~12 SMS-fähige Metriken:** eine Kanal-eigene SMS-Auswahl kann
+  nur Metriken enthalten, die über `SMS_SYMBOL_BY_METRIC`/
+  `SMS_MULTI_SYMBOLS_BY_METRIC` (`sms_trip.py`) überhaupt ein SMS-Symbol
+  haben — andere Metriken in der SMS-Auswahl bleiben wirkungslos (kein
+  Blocker, bestehende Einschränkung des SMS-Formats).
+- **KL-2 · `per_report_layouts` (Morgen ≠ Abend) bleibt außerhalb:** diese
+  Scheibe schreibt ausschließlich `per_channel_layouts` (`channel_layouts`
+  auf der Wire); eine zusätzliche Report-Type-Differenzierung
+  (`channel_layouts_per_report`) ist nicht Teil dieser Scheibe.
+- **KL-3 · Kein Re-Sync bei globaler Änderung nach Copy-on-write:** ändert
+  der Nutzer die globale Auswahl, NACHDEM ein Kanal bereits einen eigenen
+  Eintrag hat, bleibt der Kanal-Eintrag unverändert (Kaskaden-Ebene 2
+  gewinnt immer über Ebene 3, sobald gesetzt) — entspricht der bestehenden
+  Backend-Kaskaden-Semantik, kein neues Verhalten dieser Scheibe.
+- **KL-4 · Horizonte/SMS-Schwellwerte/Auswertungswahl bleiben global:**
+  PO-Scope-Entscheidung 1 — nur Auswahl, Reihenfolge, Roh/Einfach-Modus sind
+  pro Kanal. Eine künftige Erweiterung dieser drei Größen auf Kanal-Ebene
+  wäre eine neue Spec.
+- **KL-5 · LoC-Schätzung ~400–650 (Produktivcode + Tests):** über dem
+  250-LoC-Standardlimit. `loc_limit_override` wird vor Phase 6 explizit
+  beim PO eingeholt (`workflow.py set-field loc_limit_override <N>`), nicht
+  eigenmächtig gesetzt.
+- **KL-6 · Compare-Altlast (`compare_presets.json`/`.bak`) bleibt
+  unberührt:** die einzigen bestehenden `channel_layouts`-Treffer in
+  Produktionsdaten liegen in Compare-Presets (#1351-Ballast) — Migration/
+  Bereinigung ist ausdrücklich NICHT Teil dieser (Trip-)Scheibe.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine (kein formaler `docs/adr/`-Eintrag), aber ausdrückliche
+  Ablösung einer dokumentierten, testgesicherten Entscheidung:
+
+**Ablösung von AC-6 aus `docs/specs/modules/layout_tab_route.md` (#1232
+Scheibe 3b):** Jene Spec etabliert explizit "Der Kanal (`channel`) ist
+reiner UI-View-State ohne Persistenz — er geht NIE in `snapshot()`/`isDirty`
+ein" und sichert das per Playwright-AC-6 ab. Diese Garantie wird durch
+diese Scheibe **bewusst aufgespalten, nicht ersetzt**:
+
+1. **Bleibt bestehen (AC-1 dieser Spec):** ein reiner Kanal**wechsel** (Klick
+   auf den `LTChannelPicker`, ohne inhaltlichen Edit) bleibt weiterhin ein
+   reiner Ansichtswechsel — macht den Tab nicht dirty, löst keinen Auto-Save
+   aus. Das ursprüngliche Invariant war korrekt für "Wechsel", nicht für
+   "Edit".
+2. **Neu (AC-2/AC-3/AC-4/AC-5 dieser Spec):** ein Kanal-**Edit** (Reihenfolge,
+   Roh/Einfach, Entfernen innerhalb eines Reiters) macht den Tab dirty und
+   der Auto-Save schreibt ausschließlich den aktiven Kanal in
+   `channel_layouts[kanal]`, während zuvor gespeicherte andere Kanäle
+   unverändert bleiben (Shallow-Merge-Schutz).
+
+Diese Aufspaltung ist keine stille Verhaltensänderung, sondern eine
+explizite Produktentscheidung dieser Scheibe (PO-go 2026-08-08): der
+Kanal-Reiter bekommt zusätzlich zur reinen Vorschau-Funktion eine
+Dateninhalt-Funktion. `layout_tab_route.md` bleibt als historisches Dokument
+bestehen; sein AC-6 gilt ab dieser Scheibe nur noch für den
+Kanal-**Wechsel**-Fall, nicht mehr für den Kanal-Inhalt insgesamt.
+
+## Test-Nachweis
+
+- **Kern:** neuer Modul-Test für den SMS-Backend-Fix (Teil 1), benannt nach
+  Verhalten (z. B. `tests/unit/output/test_sms_channel_metric_selection.py`
+  oder passende bestehende Modul-Suite), RED vor Fix, GREEN danach. Kein
+  bestehender Test darf durch die Änderung rot werden (`touched_tests_gate.py`).
+- **Frontend (node:test):** `weatherMetricsTabSharing.test.ts` erweitert um
+  den Isolationsfall aus AC-8; ggf. neuer Test für die
+  `channelBuckets`-Dirty-Normalisierung (Wiederverwendung/Adaption von
+  `channelLayoutsDirty.ts`).
+- **Staging-E2E (`/60-validate`):** Playwright gegen einen echten Trip (kein
+  Mock) für AC-1 bis AC-5, AC-9, AC-10.
+- **Mail-Validator (Pflicht vor "E2E bestanden", da `trip_report.py`
+  verändert wird — Renderer-Commit-Gate #811 greift):**
+  `uv run python3 .claude/hooks/briefing_mail_validator.py` gegen eine echt
+  zugestellte Staging-Mail (`X-GZ-Mail-Type: trip-briefing`), zusätzlich
+  `uv run pytest tests/tdd/test_issue_811_mode_matrix.py`.
+- **Telegram/SMS-Zustellnachweis (AC-6/AC-7):** echte Staging-Zustellung
+  über die konfigurierten Test-Postfächer/Test-Bot (kein Mock, kein
+  PO-Privatpostfach) — analog `docs/reference/mail_validators.md`.
+
+## Changelog
+
+- 2026-08-08: Initial spec created

--- a/frontend/e2e/layout-tab-route.spec.ts
+++ b/frontend/e2e/layout-tab-route.spec.ts
@@ -368,3 +368,98 @@ test.describe('Issue #1232 Scheibe 3b: LayoutTab (context="route")', () => {
 		});
 	});
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #1575 Scheibe 3: die Kanal-Reiter tragen eigene Daten. Ergaenzt die
+// AC-6-Garantie oben (reiner Kanal-WECHSEL bleibt clean) um ihre zweite
+// Haelfte — ein Kanal-EDIT macht dirty und schreibt NUR den aktiven Kanal.
+// Spec: docs/specs/modules/fix_1575_channel_metric_selection.md § AC-2/AC-3
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CHANNEL_TRIP_ID = 'e2e-1575-channel-metrics';
+
+const PRE_EMAIL_LAYOUT = [
+	{ metric_id: 'temperature', enabled: true, use_friendly_format: true, bucket: 'primary', order: 0 },
+	{ metric_id: 'wind', enabled: true, use_friendly_format: true, bucket: 'primary', order: 1 }
+];
+const PRE_TELEGRAM_LAYOUT = [
+	{ metric_id: 'precipitation', enabled: true, use_friendly_format: true, bucket: 'primary', order: 0 }
+];
+
+test.describe('Issue #1575 Scheibe 3: kanal-eigene Metrik-Auswahl (context="route")', () => {
+	test.beforeEach(async ({ page }) => {
+		await login(page);
+		await page.setViewportSize({ width: 1440, height: 900 });
+	});
+
+	test.beforeAll(async ({ request }) => {
+		await createTrip(request, CHANNEL_TRIP_ID, [
+			{ metric_id: 'temperature', order: 0 },
+			{ metric_id: 'wind', order: 1 },
+			{ metric_id: 'precipitation', order: 2 }
+		]);
+		// Vorbelegte, unterschiedliche Kanal-Layouts (AC-3-Ausgangslage).
+		await request.put(`/api/trips/${CHANNEL_TRIP_ID}/weather-config`, {
+			data: {
+				metrics: [
+					{ metric_id: 'temperature', enabled: true, bucket: 'primary', order: 0 },
+					{ metric_id: 'wind', enabled: true, bucket: 'primary', order: 1 },
+					{ metric_id: 'precipitation', enabled: true, bucket: 'primary', order: 2 }
+				],
+				channel_layouts: { email: PRE_EMAIL_LAYOUT, telegram: PRE_TELEGRAM_LAYOUT }
+			}
+		});
+	});
+
+	test.afterAll(async ({ request }) => {
+		await request.delete(`/api/trips/${CHANNEL_TRIP_ID}`).catch(() => {});
+	});
+
+	test('AC-2/AC-3: SMS-Edit wirkt nur auf SMS und laesst email/telegram unveraendert', async ({
+		page,
+		request
+	}) => {
+		const tab = await openMetricsTab(page, CHANNEL_TRIP_ID);
+		await expect(page.getByTestId('save-indicator')).toHaveAttribute('data-state', 'idle');
+
+		// SMS-Reiter startet ohne eigenen Eintrag → globale Auswahl (3 Metriken).
+		await tab.getByTestId('channel-tab-sms').click();
+		const rows = tab.locator('[data-testid="wm2-reihenfolge-row"]');
+		await expect(rows).toHaveCount(3);
+
+		// Copy-on-write: der erste Edit legt den SMS-Eintrag als Kopie an (AC-2).
+		await tab
+			.locator('[data-testid="wm2-reihenfolge-row"][data-metric-id="wind"]')
+			.getByRole('button', { name: 'Aus' })
+			.click();
+		await expect(rows).toHaveCount(2);
+		await expect(page.getByTestId('save-indicator')).toHaveAttribute('data-state', 'idle', {
+			timeout: 10_000
+		});
+
+		// AC-3: die gespeicherten Layouts der anderen Kanaele ueberleben den Save.
+		const trip = await (await request.get(`/api/trips/${CHANNEL_TRIP_ID}`)).json();
+		const layouts = trip.display_config?.channel_layouts ?? {};
+		expect(
+			layouts.email?.filter((m: { enabled: boolean }) => m.enabled).map((m: { metric_id: string }) => m.metric_id)
+		).toEqual(['temperature', 'wind']);
+		expect(
+			layouts.telegram?.filter((m: { enabled: boolean }) => m.enabled).map((m: { metric_id: string }) => m.metric_id)
+		).toEqual(['precipitation']);
+		expect(
+			layouts.sms?.filter((m: { enabled: boolean }) => m.enabled).map((m: { metric_id: string }) => m.metric_id)
+		).not.toContain('wind');
+
+		// AC-4/AC-5-Vorstufe: nach dem Reload zeigt jeder Reiter seinen Stand.
+		await page.reload();
+		await page.getByTestId('trip-detail-tab-weather').click();
+		const reloaded = page.getByTestId('weather-metrics-tab');
+		await reloaded.getByTestId('channel-tab-email').click();
+		await expect(reloaded.locator('[data-testid="wm2-reihenfolge-row"]')).toHaveCount(2);
+		await reloaded.getByTestId('channel-tab-sms').click();
+		await expect(reloaded.locator('[data-testid="wm2-reihenfolge-row"]')).toHaveCount(2);
+		await expect(
+			reloaded.locator('[data-testid="wm2-reihenfolge-row"][data-metric-id="wind"]')
+		).toHaveCount(0);
+	});
+});

--- a/frontend/src/lib/components/shared/WeatherMetricsTab.svelte
+++ b/frontend/src/lib/components/shared/WeatherMetricsTab.svelte
@@ -32,6 +32,11 @@
 	// bisherige `.v2-layout`-Grid für den Ausgabe-Teil (Reihenfolge + Vorschau).
 	import LayoutTab from '$lib/components/shared/layout-tab/LayoutTab.svelte';
 	import type { ChannelId } from '$lib/components/shared/layout-tab/ltChannels';
+	// Issue #1575 Scheibe 3: kanal-eigene Metrik-Auswahl (nur context="route").
+	import {
+		mergeChannelLayoutsForSave, startChannelOverride, channelOverrideFromMetrics,
+		type ChannelOverride,
+	} from './weather-metrics-tab/channelMetricLayouts.ts';
 	import ThresholdMetricRow from './weather-metrics-tab/ThresholdMetricRow.svelte';
 	// Issue #1357: Auswertungswahl je Wettergroesse (Mail-Kachelzeile).
 	import AggregationMetricRow from './weather-metrics-tab/AggregationMetricRow.svelte';
@@ -224,6 +229,20 @@
 	// View-State (analog Scheibe 3a im Compare-Editor), NIE in snapshot()/isDirty.
 	let activeChannel = $state<ChannelId>('email');
 
+	// Issue #1575 Scheibe 3: kanal-eigene Auswahl/Reihenfolge/Modus. `null` =
+	// kein eigener Eintrag -> der Reiter zeigt die globale Auswahl (copy-on-write,
+	// spiegelt die Backend-Kaskade). Wird ausschliesslich in route-Codepfaden
+	// gelesen und geschrieben; der vergleich-Zweig hat eigene Handler
+	// (onCompareRemove/onCompareDndReorder/noopMode) und beruehrt das nie.
+	let channelBuckets = $state<Record<ChannelId, ChannelOverride | null>>({
+		email: null, telegram: null, sms: null,
+	});
+
+	// Effektive Sicht eines Kanals: eigener Eintrag, sonst die globale Auswahl.
+	function channelView(ch: ChannelId): ChannelOverride {
+		return channelBuckets[ch] ?? { buckets, friendlyMap };
+	}
+
 	// AC-2 Diff-Highlight: 2,5s Aufleuchten nach jeder Änderung.
 	let highlight: Highlight | null = $state(null);
 	let highlightTimer: ReturnType<typeof setTimeout> | null = null;
@@ -246,8 +265,11 @@
 		};
 	}
 
-	function applyDiff(nextCols: string[], nextMode: Record<string, boolean>, nextPresetId: string) {
-		const prev = prevSnapshot();
+	function applyDiff(
+		nextCols: string[], nextMode: Record<string, boolean>, nextPresetId: string,
+		prevOverride: WeatherSnapshot | null = null,
+	) {
+		const prev = prevOverride ?? prevSnapshot();
 		const next: WeatherSnapshot = {
 			columns: nextCols,
 			mode: Object.fromEntries(nextCols.map(id => [id, nextMode[id] === true ? 'indicator' : 'raw'])) as Record<string, 'raw' | 'indicator'>,
@@ -285,16 +307,21 @@
 	// Issue #1357: aggregationsMap gehoert in Dirty-Vergleich UND Snapshot — sonst
 	// bleibt die Auswertungswahl unspeicherbar (der Dirty-Check sieht nur, was im
 	// Snapshot steht).
+	// Issue #1575 Scheibe 3: channelBuckets gehoert in Dirty-Vergleich UND
+	// Snapshot — sonst bliebe ein Kanal-Edit unspeicherbar. Der reine
+	// Kanal-WECHSEL veraendert channelBuckets nicht und bleibt damit clean
+	// (AC-1); erst ein Edit-Callback legt einen Eintrag an (AC-2).
 	const isDirty = $derived(
-		JSON.stringify({ buckets, friendlyMap, horizonsMap, telegramKurzform, smsThresholds, aggregationsMap, reportConfig, officialAlertsEnabled }) !== savedSnapshot,
+		JSON.stringify({ buckets, friendlyMap, horizonsMap, telegramKurzform, smsThresholds, aggregationsMap, reportConfig, officialAlertsEnabled, channelBuckets }) !== savedSnapshot,
 	);
 
 	function snapshot(
 		b: Buckets, f: Record<string, boolean>, h: Record<string, Horizons>,
 		tk: boolean, st: Record<string, string>, rc: ReportConfig | undefined, oae: boolean,
-		ag: Record<string, string[]> = aggregationsMap
+		ag: Record<string, string[]> = aggregationsMap,
+		cb: Record<ChannelId, ChannelOverride | null> = channelBuckets
 	): string {
-		return JSON.stringify({ buckets: b, friendlyMap: f, horizonsMap: h, telegramKurzform: tk, smsThresholds: st, aggregationsMap: ag, reportConfig: rc ?? {}, officialAlertsEnabled: oae });
+		return JSON.stringify({ buckets: b, friendlyMap: f, horizonsMap: h, telegramKurzform: tk, smsThresholds: st, aggregationsMap: ag, reportConfig: rc ?? {}, officialAlertsEnabled: oae, channelBuckets: cb });
 	}
 
 	function allCatalogIds(): string[] {
@@ -376,7 +403,16 @@
 		// Issue #774: reportConfig in snapshot aufnehmen.
 		smsThresholds = thrMap;
 		aggregationsMap = aggMap;
-		savedSnapshot = snapshot(b, fMap, hMap, telegramKurzform, thrMap, reportConfig, officialAlertsEnabled, aggMap);
+		// Issue #1575 Scheibe 3: gespeicherte Kanal-Layouts zurueckbauen, damit ein
+		// editierter Reiter nach dem Reload seine eigene Auswahl zeigt.
+		const savedLayouts = trip!.display_config?.channel_layouts;
+		const cb: Record<ChannelId, ChannelOverride | null> = { email: null, telegram: null, sms: null };
+		for (const ch of ['email', 'telegram', 'sms'] as ChannelId[]) {
+			const layout = savedLayouts?.[ch];
+			if (layout) cb[ch] = channelOverrideFromMetrics(layout, allCatalogIds(), fMap);
+		}
+		channelBuckets = cb;
+		savedSnapshot = snapshot(b, fMap, hMap, telegramKurzform, thrMap, reportConfig, officialAlertsEnabled, aggMap, cb);
 	}
 
 	// Issue #1332 F003 (Fix-Loop 2): eigener, idempotenter Ladepfad fuer die
@@ -590,11 +626,31 @@
 		pendingPreset = null;
 	}
 
+	// Issue #1575 Scheibe 3: die drei Edit-Callbacks der Reihenfolge-Karte
+	// (Modus, Entfernen, Drag&Drop) wirken auf den AKTIVEN Kanal. Beim ersten
+	// Edit entsteht der Eintrag als Kopie der globalen Auswahl (copy-on-write).
+	function editActiveChannel(
+		mutate: (view: ChannelOverride) => ChannelOverride,
+	) {
+		const base = channelBuckets[activeChannel] ?? startChannelOverride(buckets, friendlyMap);
+		const prev: WeatherSnapshot = {
+			columns: [...base.buckets.primary],
+			mode: Object.fromEntries(
+				base.buckets.primary.map((id) => [id, base.friendlyMap[id] === true ? 'indicator' : 'raw'])
+			) as Record<string, 'raw' | 'indicator'>,
+			presetId: selectedTemplate,
+		};
+		const next = mutate(base);
+		applyDiff(next.buckets.primary, next.friendlyMap, selectedTemplate, prev);
+		channelBuckets = { ...channelBuckets, [activeChannel]: next };
+	}
+
 	function onMode(id: string, useIndicator: boolean) {
 		userTouched = true;
-		const newFriendly = { ...friendlyMap, [id]: useIndicator };
-		applyDiff(buckets.primary, newFriendly, selectedTemplate);
-		friendlyMap = newFriendly;
+		editActiveChannel((view) => ({
+			buckets: view.buckets,
+			friendlyMap: { ...view.friendlyMap, [id]: useIndicator },
+		}));
 		scheduleAutoSave();
 	}
 
@@ -621,12 +677,13 @@
 		scheduleAutoSave();
 	}
 
-	// Aus Abschnitt 3 entfernen (→ off).
+	// Aus Abschnitt 3 entfernen (→ off) — kanal-eigen (#1575 Scheibe 3).
 	function onRemove(id: string) {
 		userTouched = true;
-		const newBuckets = move(buckets, id, 'primary', 'off');
-		applyDiff(newBuckets.primary, friendlyMap, selectedTemplate);
-		buckets = newBuckets;
+		editActiveChannel((view) => ({
+			buckets: move(view.buckets, id, 'primary', 'off'),
+			friendlyMap: view.friendlyMap,
+		}));
 		if (selectedTemplate) selectedTemplate = '';
 		scheduleAutoSave();
 	}
@@ -636,9 +693,10 @@
 	// aus (fromId, toId) entfaellt.
 	function onDndReorder(newOrder: string[]) {
 		userTouched = true;
-		const newBuckets = { ...buckets, primary: newOrder };
-		applyDiff(newBuckets.primary, friendlyMap, selectedTemplate);
-		buckets = newBuckets;
+		editActiveChannel((view) => ({
+			buckets: { ...view.buckets, primary: newOrder },
+			friendlyMap: view.friendlyMap,
+		}));
 		scheduleAutoSave();
 	}
 
@@ -656,6 +714,9 @@
 			reportConfig = snap.reportConfig ?? {};
 			// Issue #1117: officialAlertsEnabled wiederherstellen (Konsistenz-Vollständigkeit).
 			officialAlertsEnabled = snap.officialAlertsEnabled ?? true;
+			// Issue #1575 Scheibe 3: Kanal-Eintraege mit zuruecknehmen, sonst bleibt
+			// der Tab nach dem Verwerfen dirty.
+			channelBuckets = snap.channelBuckets ?? { email: null, telegram: null, sms: null };
 		} catch (e) {
 			console.error(e);
 			initFromTrip();
@@ -688,9 +749,23 @@
 	}
 
 	function buildWeatherPayload() {
+		// Issue #1575 Scheibe 3: `config_merge.go` ersetzt `channel_layouts`
+		// komplett — deshalb geht IMMER der vollstaendige Stand aller bereits
+		// editierten Kanaele mit, nicht nur der aktive (AC-3, Datenverlust-Schutz).
+		const override = channelBuckets[activeChannel];
+		const nextLayouts = mergeChannelLayoutsForSave(
+			trip!.display_config?.channel_layouts,
+			activeChannel,
+			override
+				? buildWeatherConfigMetrics(
+					override.buckets, override.friendlyMap, horizonsMap, catalog, aggregationsMap,
+				)
+				: null,
+		);
 		return {
 			...(trip!.display_config ?? {}),
 			metrics: buildWeatherMetricsList(),
+			channel_layouts: nextLayouts,
 			preset_name: selectedTemplate || undefined,
 			telegram_kurzform: telegramKurzform,
 		};
@@ -1188,18 +1263,21 @@
 			     Metriken-Zählung, sonst weicht der Overflow-Chip von Cut-Line
 			     und Vorschau-Hinweis ab. -->
 			{#if sections.includes('reihenfolge')}
+			<!-- Issue #1575 Scheibe 3: Reihenfolge-Karte UND Vorschau zeigen die
+			     EFFEKTIVE Auswahl des aktiven Kanals (eigener Eintrag, sonst die
+			     globale) — ohne das bliebe der Reiter eine reine Vorschau-Umschaltung. -->
 			<LayoutTab
 				context="route"
 				bind:channel={activeChannel}
-				colCount={buckets.primary.length}
+				colCount={channelView(activeChannel).buckets.primary.length}
 				subjectLabel="Metriken"
 			>
 				{#snippet editor({ channel })}
 					<Card padding={0}>
 						<WeatherV2Reihenfolge
-							primaryColumns={buckets.primary}
+							primaryColumns={channelView(channel).buckets.primary}
 							{metricById}
-							{friendlyMap}
+							friendlyMap={channelView(channel).friendlyMap}
 							activeChannel={channel}
 							{highlight}
 							onRemove={onRemove}
@@ -1210,9 +1288,9 @@
 				{/snippet}
 				{#snippet preview({ channel })}
 					<WeatherV2MailPreview
-						primaryColumns={buckets.primary}
+						primaryColumns={channelView(channel).buckets.primary}
 						{metricById}
-						{friendlyMap}
+						friendlyMap={channelView(channel).friendlyMap}
 						{telegramKurzform}
 						{highlight}
 						{channel}
@@ -1469,9 +1547,9 @@
 		<Sheet open={mailSheetOpen} onClose={() => (mailSheetOpen = false)} title="So kommt es an">
 			<div data-testid="mobile-mail-sheet" style="padding: 4px 16px 24px;">
 				<WeatherV2MailPreview
-					primaryColumns={buckets.primary}
+					primaryColumns={channelView(activeChannel).buckets.primary}
 					{metricById}
-					{friendlyMap}
+					friendlyMap={channelView(activeChannel).friendlyMap}
 					{telegramKurzform}
 					{highlight}
 					channel={activeChannel}

--- a/frontend/src/lib/components/shared/__tests__/channelMetricLayouts.test.ts
+++ b/frontend/src/lib/components/shared/__tests__/channelMetricLayouts.test.ts
@@ -1,0 +1,176 @@
+// TDD RED — Issue #1575 Scheibe 3, AC-3 (Shallow-Merge-Datenverlust-Schutz)
+// und AC-2 (Copy-on-write beim ersten Kanal-Edit).
+//
+// Spec: docs/specs/modules/fix_1575_channel_metric_selection.md
+//   § Teil 2 ("Save-Payload", "Copy-on-write"), § AC-2, § AC-3
+// Kontext: docs/context/fix-1575-channel-metric-selection.md
+//   § "🔴 Neuer Fund: Shallow-Merge-Datenverlust-Risiko"
+//
+// Befund: `internal/handler/config_merge.go:11-22` mergt `display_config` nur
+// SHALLOW auf oberster Schluesselebene. Sendet der Editor beim Speichern im
+// SMS-Reiter nur `channel_layouts: { sms: [...] }`, ERSETZT das den kompletten
+// `channel_layouts`-Wert — bereits gespeicherte `email`/`telegram`-Eintraege
+// gehen lautlos verloren (neuer BUG-DATALOSS-GR221-Fall).
+//
+// Das Modul `../weather-metrics-tab/channelMetricLayouts.ts` existiert noch
+// NICHT → der Import wirft einen Modul-Resolve-Fehler und ALLE Tests dieser
+// Datei scheitern (RED). Muster: shared/__tests__/reportConfigDirty.test.ts.
+//
+// Kontrakt fuer GREEN (reine Funktionen, kein Svelte-State, kein DOM):
+//
+//   mergeChannelLayoutsForSave(
+//     prevLayouts: ChannelLayouts | undefined,
+//     channel: ChannelId,
+//     metrics: WeatherConfigMetric[] | null,
+//   ): ChannelLayouts
+//     - `metrics === null` (Kanal nie editiert, copy-on-write nicht ausgeloest)
+//       → `prevLayouts` inhaltlich unveraendert zurueck
+//     - sonst: alle bisherigen Kanal-Eintraege bleiben erhalten, NUR `channel`
+//       wird ersetzt
+//     - mutiert `prevLayouts` nicht
+//
+//   startChannelOverride(
+//     buckets: Buckets,
+//     friendlyMap: Record<string, boolean>,
+//   ): { buckets: Buckets; friendlyMap: Record<string, boolean> }
+//     - liefert eine tiefe KOPIE der globalen Auswahl als Startpunkt (AC-2:
+//       "Startpunkt ist die globale Auswahl, nicht leer")
+//     - spaetere Aenderungen an der Kopie duerfen die globale Struktur nicht
+//       beruehren
+//
+// Liegt die Logik in GREEN stattdessen in `trip-detail/metricsEditor.ts`,
+// wird hier nur der Import-Pfad angepasst — der Kontrakt bleibt derselbe.
+//
+// Ausfuehren:
+//   cd frontend && node --import ./test-lib-loader.mjs --experimental-strip-types \
+//     --test src/lib/components/shared/__tests__/channelMetricLayouts.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import type { ChannelLayouts, WeatherConfigMetric } from '$lib/types';
+
+const { mergeChannelLayoutsForSave, startChannelOverride } = await import(
+	'../weather-metrics-tab/channelMetricLayouts.ts'
+);
+
+const metric = (metric_id: string, order: number): WeatherConfigMetric => ({
+	metric_id,
+	enabled: true,
+	use_friendly_format: true,
+	bucket: 'primary',
+	order
+});
+
+const emailLayout: WeatherConfigMetric[] = [metric('temperature', 0), metric('wind', 1)];
+const telegramLayout: WeatherConfigMetric[] = [metric('gust', 0)];
+const smsLayout: WeatherConfigMetric[] = [metric('precipitation', 0)];
+
+describe('AC-3: Speichern in einem Kanal laesst die anderen Kanaele unveraendert', () => {
+	test('SMS-Edit erhaelt die gespeicherten email-/telegram-Eintraege', () => {
+		const prev: ChannelLayouts = { email: emailLayout, telegram: telegramLayout };
+
+		const next = mergeChannelLayoutsForSave(prev, 'sms', smsLayout);
+
+		assert.deepEqual(
+			next.email,
+			emailLayout,
+			'AC-3 FAIL: der gespeicherte email-Eintrag ueberlebt ein SMS-Edit nicht — ' +
+				'config_merge.go ersetzt channel_layouts komplett (BUG-DATALOSS-GR221-Muster)'
+		);
+		assert.deepEqual(
+			next.telegram,
+			telegramLayout,
+			'AC-3 FAIL: der gespeicherte telegram-Eintrag ueberlebt ein SMS-Edit nicht'
+		);
+		assert.deepEqual(next.sms, smsLayout, 'AC-3 FAIL: der SMS-Eintrag wurde nicht geschrieben');
+	});
+
+	test('ein bereits vorhandener Eintrag desselben Kanals wird ersetzt, nicht angehaengt', () => {
+		const prev: ChannelLayouts = { email: emailLayout, sms: [metric('thunder', 0)] };
+
+		const next = mergeChannelLayoutsForSave(prev, 'sms', smsLayout);
+
+		assert.deepEqual(
+			next.sms,
+			smsLayout,
+			'AC-3 FAIL: der neue SMS-Stand ersetzt den alten nicht'
+		);
+		assert.deepEqual(next.email, emailLayout, 'AC-3 FAIL: email wurde beim SMS-Edit veraendert');
+	});
+
+	test('nie editierter Kanal (metrics === null) schreibt keinen eigenen Eintrag', () => {
+		const prev: ChannelLayouts = { email: emailLayout };
+
+		const next = mergeChannelLayoutsForSave(prev, 'sms', null);
+
+		assert.equal(
+			next.sms,
+			undefined,
+			'AC-3/Copy-on-write FAIL: ein nie editierter Kanal darf keinen eigenen ' +
+				'(womoeglich leeren) Eintrag bekommen — sonst faellt die Backend-Kaskade ' +
+				'nicht mehr auf die globale Auswahl zurueck'
+		);
+		assert.deepEqual(next.email, emailLayout, 'AC-3 FAIL: email ging beim Nicht-Edit verloren');
+	});
+
+	test('ohne bisherigen Stand (undefined) entsteht ein Objekt mit nur diesem Kanal', () => {
+		const next = mergeChannelLayoutsForSave(undefined, 'telegram', telegramLayout);
+
+		assert.deepEqual(next, { telegram: telegramLayout });
+	});
+
+	test('der bisherige Stand wird nicht mutiert', () => {
+		const prev: ChannelLayouts = { email: emailLayout };
+
+		mergeChannelLayoutsForSave(prev, 'sms', smsLayout);
+
+		assert.equal(
+			prev.sms,
+			undefined,
+			'AC-3 FAIL: mergeChannelLayoutsForSave mutiert den uebergebenen Vorstand — ' +
+				'der Vorstand ist die aktuellste bekannte Serverantwort und muss unberuehrt bleiben'
+		);
+	});
+});
+
+describe('AC-2: erster Kanal-Edit startet als Kopie der globalen Auswahl', () => {
+	const globalBuckets = {
+		primary: ['temperature', 'wind'],
+		secondary: ['gust'],
+		off: ['thunder']
+	};
+	const globalFriendly: Record<string, boolean> = { temperature: true, wind: false };
+
+	test('startet inhaltlich mit der globalen Auswahl, nicht leer', () => {
+		const override = startChannelOverride(globalBuckets, globalFriendly);
+
+		assert.deepEqual(
+			override.buckets,
+			globalBuckets,
+			'AC-2 FAIL: der erste Edit unter einem Kanal muss mit der globalen Auswahl ' +
+				'starten (PO-Entscheidung 2026-08-08), nicht mit einer leeren Liste'
+		);
+		assert.deepEqual(override.friendlyMap, globalFriendly);
+	});
+
+	test('ist eine tiefe Kopie — Aenderungen schlagen nicht auf die globale Auswahl durch', () => {
+		const override = startChannelOverride(globalBuckets, globalFriendly);
+
+		override.buckets.primary.push('precipitation');
+		override.buckets.off.length = 0;
+		override.friendlyMap.temperature = false;
+
+		assert.deepEqual(
+			globalBuckets.primary,
+			['temperature', 'wind'],
+			'AC-2 FAIL: der Kanal-Override teilt sein Array mit der globalen Auswahl — ' +
+				'ein SMS-Edit wuerde damit auch Email/Telegram veraendern'
+		);
+		assert.deepEqual(globalBuckets.off, ['thunder'], 'AC-2 FAIL: off-Bucket wird geteilt');
+		assert.equal(
+			globalFriendly.temperature,
+			true,
+			'AC-2 FAIL: friendlyMap wird zwischen Kanal und globaler Auswahl geteilt'
+		);
+	});
+});

--- a/frontend/src/lib/components/shared/__tests__/weatherMetricsTabSharing.test.ts
+++ b/frontend/src/lib/components/shared/__tests__/weatherMetricsTabSharing.test.ts
@@ -191,3 +191,46 @@ describe('AC-1/AC-8: weatherMetricsTabSections(context) — reine Funktion (Vorb
 		}
 	);
 });
+
+// Issue #1575 Scheibe 3, AC-8: die kanal-eigene Metrik-Auswahl ist Trip-only
+// (#1351 haelt `channel_layouts` bewusst aus dem Ortsvergleich heraus). Geprueft
+// wird die STELLE im Quelltext, nicht die blosse Anwesenheit eines Wortes:
+// jedes Vorkommen der neuen Kanal-Ableitung im Markup muss hinter dem `{:else}`
+// des `{#if context === 'vergleich'}`-Blocks liegen, und keiner der
+// vergleich-eigenen Handler darf sie aufrufen.
+describe('AC-8 (#1575): Kanal-eigene Auswahl bleibt strukturell aus dem vergleich-Zweig heraus', () => {
+	const compareHandlers = [
+		'onCompareDndReorder', 'onCompareRemove', 'noopMode', 'onToggleVergleichOfficialAlerts',
+	];
+
+	test('channelView()/channelBuckets stehen im Markup nur im route-Zweig', { skip: !sharedExists() }, () => {
+		const code = readFileSync(SHARED_FILE, 'utf-8');
+		const markupStart = code.indexOf("{#if context === 'vergleich'}");
+		const routeStart = code.indexOf('\n{:else}', markupStart);
+		assert.ok(markupStart > 0 && routeStart > markupStart, 'Markup-Verzweigung nicht gefunden');
+
+		for (const m of code.matchAll(/channelView\(|channelBuckets/g)) {
+			if (m.index! < markupStart) continue; // <script>-Teil: Definition + route-Handler
+			assert.ok(
+				m.index! > routeStart,
+				`AC-8 FAIL: "${m[0]}" steht im vergleich-Zweig des Markups (Position ${m.index}, ` +
+					`vergleich-Block ${markupStart}..${routeStart}) — der Ortsvergleich bekommt ` +
+					'laut #1351 keine Kanal-Persistenz'
+			);
+		}
+	});
+
+	test('kein vergleich-Handler ruft die neuen Kanal-Funktionen', { skip: !sharedExists() }, () => {
+		const code = readFileSync(SHARED_FILE, 'utf-8');
+		for (const name of compareHandlers) {
+			const start = code.indexOf(`function ${name}(`);
+			assert.ok(start > 0, `${name} nicht gefunden — Test ist blind geworden`);
+			const body = code.slice(start, code.indexOf('\n\t}', start));
+			assert.doesNotMatch(
+				body,
+				/editActiveChannel|channelBuckets|channelView\(|mergeChannelLayoutsForSave|startChannelOverride/,
+				`AC-8 FAIL: ${name} (vergleich-Zweig) greift auf die kanal-eigene Auswahl zu`
+			);
+		}
+	});
+});

--- a/frontend/src/lib/components/shared/weather-metrics-tab/channelMetricLayouts.ts
+++ b/frontend/src/lib/components/shared/weather-metrics-tab/channelMetricLayouts.ts
@@ -1,0 +1,79 @@
+// channelMetricLayouts.ts — Issue #1575 Scheibe 3: kanal-eigene Metrik-Auswahl
+// im Trip-Editor (context="route").
+//
+// Spec: docs/specs/modules/fix_1575_channel_metric_selection.md (Teil 2)
+
+import type { ChannelLayouts, WeatherConfigMetric } from '$lib/types';
+import type { ChannelId } from '$lib/components/shared/layout-tab/ltChannels';
+import type { Buckets } from '$lib/components/trip-detail/metricsEditor';
+
+export interface ChannelOverride {
+	buckets: Buckets;
+	friendlyMap: Record<string, boolean>;
+}
+
+/**
+ * Setzt den Kanal-Eintrag von `channel` auf `metrics` und laesst alle anderen
+ * Kanaele unberuehrt.
+ *
+ * `internal/handler/config_merge.go` mergt `display_config` nur shallow auf
+ * oberster Schluesselebene — wer beim Speichern nur den aktiven Kanal sendet,
+ * loescht die uebrigen lautlos (BUG-DATALOSS-GR221-Muster). `metrics === null`
+ * bedeutet: dieser Kanal wurde nie editiert und bekommt keinen eigenen
+ * Eintrag, damit die Backend-Kaskade weiter auf die globale Auswahl faellt.
+ */
+export function mergeChannelLayoutsForSave(
+	prevLayouts: ChannelLayouts | undefined,
+	channel: ChannelId,
+	metrics: WeatherConfigMetric[] | null
+): ChannelLayouts {
+	const next: ChannelLayouts = { ...(prevLayouts ?? {}) };
+	if (metrics === null) return next;
+	next[channel] = metrics;
+	return next;
+}
+
+/**
+ * Baut den Kanal-Eintrag aus einer gespeicherten `channel_layouts[kanal]`-Liste
+ * zurueck, damit ein editierter Reiter nach dem Reload seine eigene Auswahl
+ * zeigt (AC-4/AC-5). Der Trip-Editor kennt kein Detail-Bucket (#587) — alles
+ * Aktive landet in `primary`.
+ */
+export function channelOverrideFromMetrics(
+	metrics: WeatherConfigMetric[],
+	catalogIds: string[],
+	fallbackFriendly: Record<string, boolean>
+): ChannelOverride {
+	const active = metrics
+		.filter((m) => m.enabled)
+		.slice()
+		.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+	const activeIds = new Set(active.map((m) => m.metric_id));
+	const friendlyMap = { ...fallbackFriendly };
+	for (const m of metrics) {
+		if (m.use_friendly_format !== undefined) friendlyMap[m.metric_id] = m.use_friendly_format;
+	}
+	return {
+		buckets: {
+			primary: active.map((m) => m.metric_id),
+			secondary: [],
+			off: catalogIds.filter((id) => !activeIds.has(id))
+		},
+		friendlyMap
+	};
+}
+
+/** Startpunkt eines Kanal-Eintrags: tiefe Kopie der globalen Auswahl (AC-2). */
+export function startChannelOverride(
+	buckets: Buckets,
+	friendlyMap: Record<string, boolean>
+): ChannelOverride {
+	return {
+		buckets: {
+			primary: [...buckets.primary],
+			secondary: [...buckets.secondary],
+			off: [...buckets.off]
+		},
+		friendlyMap: { ...friendlyMap }
+	};
+}

--- a/src/output/renderers/trip_report.py
+++ b/src/output/renderers/trip_report.py
@@ -126,6 +126,10 @@ class TripReportFormatter:
         # alle enabled=False) unterscheidet. Die Kollabierung unten filtert
         # in beiden Faellen auf eine leere Liste (Kritischer Befund, Spec).
         _trip_metrics_altbestand = len(dc.metrics) == 0
+        # Issue #1575 Scheibe 3: die SMS-Auswahl muss VOR der Email-Kollabierung
+        # gezogen werden -- danach traegt ``dc.metrics`` nur noch die
+        # Email-Auswahl und die SMS koennte strukturell nie eine eigene haben.
+        _dc_uncollapsed = dc
         if report_type in ("morning", "evening"):
             # Issue #434: kanal-bewusste Auflösung (per_report > per_channel > global).
             active_metrics = dc.get_metrics_for_channel("email", report_type)
@@ -278,22 +282,37 @@ class TripReportFormatter:
         from output.renderers.sms_trip import (
             SMSTripFormatter, SMS_MULTI_SYMBOLS_BY_METRIC, SMS_SYMBOL_BY_METRIC,
         )
+        # Issue #1575 Scheibe 3: die MENGE der SMS-Metriken kommt aus der
+        # SMS-eigenen Kaskade (per_report > per_channel > global), der
+        # SCHWELLWERT je Metrik bleibt eine globale Groesse (KL-4) -- die vom
+        # Editor geschriebenen Kanal-Layouts fuehren kein ``sms_threshold``.
+        sms_metric_ids = {
+            m.metric_id
+            for m in _dc_uncollapsed.get_metrics_for_channel("sms", report_type)
+        }
+        _global_metrics = {m.metric_id: m for m in _dc_uncollapsed.metrics}
         # Issue #624: konfigurierte Schwellwerte aus MetricConfig ableiten.
         _sms_thr = {
-            SMS_SYMBOL_BY_METRIC[m.metric_id]: m.sms_threshold
-            for m in dc.metrics
-            if m.metric_id in SMS_SYMBOL_BY_METRIC and m.sms_threshold is not None
+            SMS_SYMBOL_BY_METRIC[mid]: _global_metrics[mid].sms_threshold
+            for mid in sms_metric_ids
+            if mid in SMS_SYMBOL_BY_METRIC
+            and mid in _global_metrics
+            and _global_metrics[mid].sms_threshold is not None
         }
         # Fix #1482 (AC-6): der Gewitter-Schwellwert gilt fuer BEIDE Kuerzel.
         # SMS_SYMBOL_BY_METRIC bildet 1:1 ab und kennt nur 'TH:', deshalb fiel
         # 'TH+:' bisher immer auf den hartkodierten Default (1.0) zurueck.
-        for m in dc.metrics:
-            if m.metric_id == "thunder" and m.sms_threshold is not None:
-                _sms_thr["TH+:"] = m.sms_threshold
+        _thunder_global = _global_metrics.get("thunder")
+        if (
+            "thunder" in sms_metric_ids
+            and _thunder_global is not None
+            and _thunder_global.sms_threshold is not None
+        ):
+            _sms_thr["TH+:"] = _thunder_global.sms_threshold
         # Bug #944: SMS-Symbole ohne aktive Metrik als deaktivierte Specs führen,
         # damit SD/SL nicht erscheinen, wenn die Metrik im Trip nicht gewählt ist —
         # unabhängig davon, ob Schneedaten in der Vorhersage vorhanden sind.
-        active_metric_ids = {m.metric_id for m in dc.metrics}
+        active_metric_ids = sms_metric_ids
         _disabled_sms_specs = [
             MetricSpec(symbol=sym, enabled=False)
             for metric_id, sym in SMS_SYMBOL_BY_METRIC.items()

--- a/tests/unit/test_trip_sms_channel_metric_selection.py
+++ b/tests/unit/test_trip_sms_channel_metric_selection.py
@@ -1,0 +1,220 @@
+"""SMS-Kurznachricht folgt der SMS-eigenen Metrikauswahl — #1575 Scheibe 3, AC-6.
+
+Spec: docs/specs/modules/fix_1575_channel_metric_selection.md (Teil 1)
+Kontext: docs/context/fix-1575-channel-metric-selection.md
+
+Befund: ``TripReportFormatter.format_email()`` kollabiert ``dc.metrics`` in
+Zeile 129-134 auf die **Email**-Auswahl (``get_metrics_for_channel("email",
+...)``). Der SMS-Aufbau weiter unten (``_sms_thr`` Z. 282-286,
+``active_metric_ids`` Z. 296) liest genau diese bereits kollabierte ``dc`` —
+die SMS erbt dadurch strukturell die Email-Auswahl und kann nie eine eigene
+haben, egal was unter ``per_channel_layouts["sms"]`` gespeichert ist.
+
+Kern-Schicht (Test-Politik "Zwei Schichten", CLAUDE.md): kein Netz, kein
+Versand, kein Mock/patch — echter Aufruf des Formatters mit praeparierten
+``UnifiedWeatherDisplayConfig``-Objekten, Assertion auf den zusammengesetzten
+SMS-Text (das tatsaechlich Zugestellte, s. src/output/channels/sms.py).
+
+Die vier Faelle sind bewusst gemischt:
+  * zwei ROT-Faelle (AC-6) — das Verhalten, das der Fix herstellen muss,
+  * zwei GRUEN-Leitplanken — sie halten den Fix davon ab, den Fallback bzw.
+    die global konfigurierten SMS-Schwellwerte zu zerstoeren, und belegen
+    zugleich, dass die Assertion der ROT-Faelle ueberhaupt erfuellbar ist
+    (Falsifizierbarkeit: ohne den Fallback-Fall waere unklar, ob die
+    erwartete Symbolmenge vom Renderer je erzeugt werden KANN).
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from app.models import (
+    ForecastDataPoint, ForecastMeta, GPXPoint, MetricConfig,
+    NormalizedTimeseries, Provider, SegmentWeatherData,
+    SegmentWeatherSummary, ThunderLevel, TripSegment,
+    UnifiedWeatherDisplayConfig,
+)
+
+TZ = ZoneInfo("Europe/Berlin")
+
+
+# ---------------------------------------------------------------------------
+# Fixture (Muster aus tests/unit/test_trip_empty_metric_selection.py)
+# ---------------------------------------------------------------------------
+
+
+def _build_segments() -> list[SegmentWeatherData]:
+    tl = ThunderLevel.MED
+
+    def _dp(h, temp, precip, gust, vis):
+        return ForecastDataPoint(
+            ts=datetime(2026, 7, 11, h, 0, tzinfo=timezone.utc),
+            t2m_c=temp, wind10m_kmh=gust * 0.5, gust_kmh=gust,
+            precip_1h_mm=precip, pop_pct=int(min(precip * 20, 100)),
+            cloud_total_pct=60, thunder_level=tl,
+            visibility_m=vis, freezing_level_m=2500,
+        )
+
+    seg = TripSegment(
+        segment_id=1,
+        start_point=GPXPoint(lat=42.13, lon=9.13, elevation_m=400.0),
+        end_point=GPXPoint(lat=42.10, lon=9.18, elevation_m=1200.0),
+        start_time=datetime(2026, 7, 11, 6, 0, tzinfo=timezone.utc),
+        end_time=datetime(2026, 7, 11, 10, 0, tzinfo=timezone.utc),
+        duration_hours=4.0, distance_km=9.3, ascent_m=800.0, descent_m=0.0,
+    )
+    meta = ForecastMeta(
+        provider=Provider.OPENMETEO, model="demo", grid_res_km=1.3,
+        run=datetime(2026, 7, 11, 0, 0, tzinfo=timezone.utc),
+    )
+    rows = [
+        _dp(6, 12.0, 0.0, 10.0, 2000), _dp(7, 13.0, 1.0, 20.0, 1500),
+        _dp(8, 14.0, 2.0, 30.0, 1200), _dp(9, 14.5, 0.5, 25.0, 1800),
+    ]
+    agg = SegmentWeatherSummary(
+        temp_min_c=10.0, temp_max_c=14.5, temp_avg_c=12.0,
+        wind_max_kmh=20.0, gust_max_kmh=30.0,
+        precip_sum_mm=3.5, cloud_avg_pct=60, humidity_avg_pct=55,
+        thunder_level_max=tl,
+    )
+    return [SegmentWeatherData(
+        segment=seg, timeseries=NormalizedTimeseries(meta=meta, data=rows),
+        aggregated=agg, fetched_at=datetime.now(timezone.utc), provider="demo",
+    )]
+
+
+def _render_sms(dc: UnifiedWeatherDisplayConfig, report_type: str = "morning") -> str:
+    from output.renderers.trip_report import TripReportFormatter
+    report = TripReportFormatter().format_email(
+        segments=_build_segments(), trip_name="GR20 Test",
+        report_type=report_type, display_config=dc, tz=TZ,
+    )
+    assert report.sms_text, "Fixture-Fehler: kein SMS-Text erzeugt"
+    return report.sms_text
+
+
+_TOKEN_SYMBOL = re.compile(r"^([A-Z]+\+?:?)")
+
+
+def _sms_symbols(sms_text: str) -> set[str]:
+    """Kuerzel der SMS-Token — 'K12' -> 'K', 'TH+:-' -> 'TH+:', 'W10@9(15@10)' -> 'W'.
+
+    Bewusst KEIN ``in``-Test auf dem Rohtext: der Trip-Name ("GR20 Test")
+    enthaelt selbst 'G' und 'R' und wuerde eine Symbol-Presence-Pruefung
+    zufaellig gruen faerben.
+    """
+    body = sms_text.split(": ", 1)[1] if ": " in sms_text else sms_text
+    out = set()
+    for token in body.split():
+        m = _TOKEN_SYMBOL.match(token)
+        if m:
+            out.add(m.group(1))
+    return out
+
+
+def _mc(metric_id: str, **kw) -> MetricConfig:
+    return MetricConfig(metric_id=metric_id, enabled=True, **kw)
+
+
+_GLOBAL_FIVE = ["temperature", "wind", "gust", "precipitation", "thunder"]
+
+
+# ---------------------------------------------------------------------------
+# AC-6 — ROT vor dem Fix
+# ---------------------------------------------------------------------------
+
+
+def test_sms_zeigt_nur_die_sms_eigene_auswahl():
+    """AC-6: SMS-Layout {precipitation} -> ausschliesslich das Regen-Kuerzel.
+
+    Heute erbt die SMS die (globale, ueber den Email-Zweig kollabierte)
+    Auswahl und zeigt zusaetzlich K/D/W/G/TH.
+    """
+    dc = UnifiedWeatherDisplayConfig(
+        trip_id="sms-eigene-auswahl",
+        metrics=[_mc(m) for m in _GLOBAL_FIVE],
+        per_channel_layouts={"sms": [_mc("precipitation")]},
+    )
+    sms = _render_sms(dc)
+    assert _sms_symbols(sms) == {"R"}, (
+        "AC-6 FAIL: die SMS-eigene Metrikauswahl (per_channel_layouts['sms'] = "
+        f"['precipitation']) bleibt wirkungslos. SMS-Text: {sms!r}. Ursache: "
+        "trip_report.py bildet active_metric_ids/_sms_thr aus der bereits "
+        "email-kollabierten dc (Z. 129-134 vs. Z. 282-296) statt aus "
+        "dc.get_metrics_for_channel('sms', report_type)."
+    )
+
+
+def test_sms_folgt_nicht_dem_email_layout():
+    """AC-6: eigenes Email-Layout darf die SMS-Auswahl nicht ueberschreiben.
+
+    Email = {temperature}, SMS = {wind, gust}. Heute zeigt die SMS 'K12 D14'
+    (die Email-Auswahl) und kein einziges Wind-/Boeen-Kuerzel — der direkte
+    Beweis, dass SMS die Email-Kaskade erbt statt der eigenen.
+    """
+    dc = UnifiedWeatherDisplayConfig(
+        trip_id="email-vs-sms",
+        metrics=[_mc(m) for m in _GLOBAL_FIVE],
+        per_channel_layouts={
+            "email": [_mc("temperature")],
+            "sms": [_mc("wind"), _mc("gust")],
+        },
+    )
+    sms = _render_sms(dc)
+    symbols = _sms_symbols(sms)
+    assert symbols == {"W", "G"}, (
+        "AC-6 FAIL: die SMS zeigt nicht ihre eigene Auswahl {wind, gust}, "
+        f"sondern die des Email-Kanals. SMS-Text: {sms!r}, Kuerzel: {sorted(symbols)}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Leitplanken — heute GRUEN, muessen es nach dem Fix bleiben
+# ---------------------------------------------------------------------------
+
+
+def test_ohne_sms_layout_gilt_weiterhin_die_globale_auswahl():
+    """Kaskadenebene 3 (Fallback) bleibt unveraendert.
+
+    Zugleich der Falsifizierbarkeits-Beleg fuer die beiden ROT-Faelle: die
+    Symbolmenge {'R'} IST vom Renderer erreichbar — die Assertion oben kann
+    also grundsaetzlich erfuellt werden und scheitert nicht an der Fixture.
+    """
+    dc = UnifiedWeatherDisplayConfig(
+        trip_id="kein-sms-layout", metrics=[_mc("precipitation")],
+    )
+    sms = _render_sms(dc)
+    assert _sms_symbols(sms) == {"R"}, (
+        "Leitplanke FAIL: ohne per_channel_layouts muss die SMS weiterhin der "
+        f"globalen Auswahl folgen. SMS-Text: {sms!r}."
+    )
+
+
+def test_globaler_sms_schwellwert_wirkt_auch_bei_sms_eigener_auswahl():
+    """AC-9-Leitplanke: ``sms_threshold`` bleibt eine GLOBALE Groesse.
+
+    Die vom Editor geschriebenen Kanal-Layouts (``buildWeatherConfigMetrics``,
+    metricsEditor.ts:332) fuehren KEIN ``sms_threshold``-Feld. Wird ``_sms_thr``
+    im Fix naiv nur aus ``get_metrics_for_channel('sms', ...)`` gebildet, gehen
+    die global konfigurierten Schwellwerte lautlos verloren und unterdrueckte
+    Werte tauchen wieder auf ('W-' -> 'W10@9(15@10)'). Der Schwellwert muss
+    weiterhin aus der globalen Metrikliste aufgeloest werden.
+    """
+    dc = UnifiedWeatherDisplayConfig(
+        trip_id="globale-schwelle",
+        metrics=[
+            _mc("wind", sms_threshold=50.0),
+            _mc("gust", sms_threshold=50.0),
+            _mc("precipitation"),
+        ],
+        per_channel_layouts={
+            "sms": [_mc("wind"), _mc("gust"), _mc("precipitation")],
+        },
+    )
+    sms = _render_sms(dc)
+    assert "W-" in sms.split() and "G-" in sms.split(), (
+        "AC-9-Leitplanke FAIL: der global konfigurierte SMS-Schwellwert (50 km/h) "
+        "unterdrueckt Wind/Boeen nicht mehr, sobald der SMS-Kanal eine eigene "
+        f"Metrikliste hat. SMS-Text: {sms!r}."
+    )


### PR DESCRIPTION
## Summary
- Die Kanal-Reiter Email/Telegram/SMS im Wetter-Metriken-Tab des Trip-Editors bekommen eine echte Wirkung: Metrik-Auswahl, Reihenfolge und Roh/Einfach-Modus werden pro Kanal gespeichert.
- SMS-Backend-Fix (`trip_report.py`): SMS erbte strukturell die Email-Metrikauswahl statt einer eigenen — behoben über die ungekollabierte Kanal-Kaskade, Schwellwert-Wert bleibt bewusst global.
- Neuer Frontend-Persistenzpfad (`channelMetricLayouts.ts`): Copy-on-write pro Kanal, Shallow-Merge-Datenverlust-Schutz beim Speichern (verhindert einen neuen BUG-DATALOSS-GR221-Fall).
- `context="vergleich"` (Compare) bleibt strukturell unberührt (PO-Entscheidung #1351/#1287/#1291).

Spec: `docs/specs/modules/fix_1575_channel_metric_selection.md` (11 ACs, freigegeben)
Adversary-Verifikation: **VERIFIED**, 6 Mutationstests, 2 LOW/MEDIUM-Findings (Testlücken, kein Implementierungsfehler) — `docs/artifacts/fix-1575-channel-metric-selection/adversary-dialog.md`

## Test plan
- [x] `tests/unit/test_trip_sms_channel_metric_selection.py` — 4/4 grün (SMS-Backend-Fix)
- [x] `frontend/src/lib/components/shared/__tests__/channelMetricLayouts.test.ts` — 7/7 grün (Shallow-Merge-Schutz, Copy-on-write)
- [x] `frontend/src/lib/components/shared/__tests__/weatherMetricsTabSharing.test.ts` — 11/11 grün (Compare-Isolation)
- [x] Regressionslauf SMS/Trip-Report-Nachbarschaft — 122 Tests grün, keine Regression
- [x] Renderer-Mail-Gate #811: `test_issue_811_mode_matrix.py` (43/43) + `briefing_mail_validator.py` gegen echt zugestellte Testmail — beide grün
- [ ] Staging: Playwright-Nachweis (`layout-tab-route.spec.ts`, neuer Block AC-2/AC-3) — folgt in der Post-Merge-Staging-Validierung

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3iLWZx3rrfRA1eetw43pH