### PR TITLE
#1557: Test-Isolation repariert (Cache-Reset + SMTP-Env) — Exclude 30→29

### DIFF
--- a/.github/ci_tdd_excludes.txt
+++ b/.github/ci_tdd_excludes.txt
@@ -49,6 +49,13 @@
 # validator.env bzw. importierbares Hook-Plugin voraus — nur auf dem
 # Server gegeben, also Staging-Lane).
 #
+# Produkt-Bug: Service liefert korrekt no_weather, Router hat den 422-
+# Zweig seit #1325. Das Rot war Test-Isolation: (a) geteilter Wetter-Cache
+# bediente AC-3 aus AC-1s Eintrag (gleiches geklemmtes Fenster) →
+# reset_shared_weather_cache_for_tests() als autouse-Fixture (Muster:
+# test_compare_alert_day_window); (b) Router baut Settings() aus der
+# Umgebung → Dummy-SMTP-Env (Muster: Batch 4).
+#
 # WICHTIG (Lektion aus PR #1551): Lokale Offline-Laeufe im Haupt-Checkout
 # (.env + befuellte data/users/) sind KEIN Beleg fuer CI-Gruen. Einzig
 # verbindliche Vermessung ist der Runner. Ursachen und Sanierungsreihenfolge:
@@ -85,4 +92,3 @@ tests/tdd/test_telegram_kurzstil_compare_official_alert.py
 tests/tdd/test_telegram_kurzstil_parse_mode.py
 tests/tdd/test_telegram_kurzstil_trip_alert.py
 tests/tdd/test_telegram_kurzstil_trip_briefing.py
-tests/tdd/test_trip_report_test_send_past_stage_clamp.py

--- a/tests/tdd/test_trip_report_test_send_past_stage_clamp.py
+++ b/tests/tdd/test_trip_report_test_send_past_stage_clamp.py
@@ -151,6 +151,20 @@ def _patch_email_transport(monkeypatch) -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def _isolated_weather_cache():
+    """#1557: Der geteilte Wetter-Cache matcht ueber „Fenster deckt ab" —
+    ohne Reset bedient AC-3 (genuiner Ausfall) still aus dem Cache-Eintrag,
+    den AC-1 fuer dasselbe geklemmte Fenster geschrieben hat, und der Test
+    sieht 'sent' statt 'no_weather' (Muster: test_compare_alert_day_window).
+    Reset auch NACH dem Test, damit diese Datei keine spaeteren Suiten
+    desselben CI-Laufs kontaminiert."""
+    from services.weather_cache import reset_shared_weather_cache_for_tests
+    reset_shared_weather_cache_for_tests()
+    yield
+    reset_shared_weather_cache_for_tests()
+
+
 # ---------------------------------------------------------------------------
 # AC-1: Test-Fallback-Pfad klemmt die vergangene Etappe auf heute -> "sent"
 # ---------------------------------------------------------------------------
@@ -259,6 +273,15 @@ class TestAC3GenuineNoWeatherHonestOutcome:
         user_id, trip_id, _ = past_only_trip
         _patch_provider(monkeypatch, fail_for_today=True)
         _patch_email_transport(monkeypatch)
+        # #1557: Der Router baut Settings() aus der Umgebung — ohne Host-.env
+        # (CI-Runner) ist can_send_email() False und der Request endet mit 422
+        # "SMTP not configured", BEVOR der Service die ehrliche No-Weather-
+        # Meldung liefern kann. Dummy-SMTP-Env macht den Test deterministisch
+        # (Muster: #1196 Batch 4); der echte Versand ist oben per
+        # Netzgrenze-Substitut ersetzt.
+        monkeypatch.setenv("GZ_SMTP_HOST", "test.invalid")
+        monkeypatch.setenv("GZ_SMTP_USER", "u")
+        monkeypatch.setenv("GZ_SMTP_PASS", "p")
 
         client = TestClient(app)
         resp = client.post(


### PR DESCRIPTION
## #1557: Kein Produkt-Bug — Test-Isolation war der Defekt

**PO-Entscheid (2026-08-08): Option A** — bei nicht abrufbarem Wetter muss das
System ehrlich `no_weather`/422 melden, nicht `sent`/200.

### Befund bei der Umsetzung: Das Produktverhalten ist bereits korrekt

- `TripReportSchedulerService._send_trip_report_outcome` liefert bei
  Totalausfall des Wetter-Abrufs korrekt `no_weather`
  (`error_ratio > OUTAGE_WITHHOLD_RATIO`, #1113).
- Der Router `POST /api/scheduler/trips/{trip_id}/send` hat den ehrlichen
  422-Zweig („keine Wetterdaten für die gewählte Etappe verfügbar") seit #1325.
- Direkte Probe mit ausfallendem Provider bestätigt: Outcome `no_weather`. ✅

### Warum der Test trotzdem rot war (zwei Isolations-Defekte)

1. **Geteilter Wetter-Cache (#1329):** AC-1 schreibt erfolgreich abgerufenes
   Fixture-Wetter für das geklemmte Fenster (Innsbruck, heute) in den
   geteilten Cache. AC-3 (genuiner Ausfall) läuft mit demselben Fenster und
   wird still aus dem Cache bedient → `sent` statt `no_weather`. Der Cache
   matcht über „Fenster deckt ab" — klassische Intra-Datei-Kontamination.
   **Fix:** `reset_shared_weather_cache_for_tests()` als autouse-Fixture
   (vor UND nach jedem Test, Muster: `test_compare_alert_day_window.py`).
2. **Router-SMTP-Check:** `Settings()` wird im Router aus der Umgebung gebaut;
   ohne Host-`.env` (CI-Runner) endet der Request mit 422 „SMTP not
   configured", bevor der Service überhaupt läuft.
   **Fix:** Dummy-SMTP-Env per `monkeypatch.setenv` (Muster: #1196 Batch 4).

### Änderungen

- `tests/tdd/test_trip_report_test_send_past_stage_clamp.py`: +23 Zeilen
  (autouse-Cache-Reset-Fixture, Dummy-SMTP-Env im Router-Test, begründende
  Kommentare). Kein Produktcode geändert.
- `.github/ci_tdd_excludes.txt`: Zeile entfernt (30 → 29) + Vermerk.

### Verifikation

- Offline-Lauf der Datei (4/4, inkl. Datei-Reihenfolge AC-1→AC-3):
  `--disable-socket` grün. Vorher: 2 rot.
- Einzel- vs. Datei-Lauf bestätigte die Kontamination (isoliert grün, im
  Verbund rot) — jetzt beides grün.
- `ruff check` sauber.

`[no-adr]` — nur Test-Datei + Exclude-Liste, keine ADR-pflichtige Stelle.

Closes #1557 (nach Deploy; Produktverhalten entspricht bereits der
PO-Entscheidung, der Test bewacht es ab jetzt im CI-Kern).
