### PR TITLE
docs(#1592): Ist-Stand und Konzept auf die gelieferte CAPE-Eichung ziehen

### DIFF
--- a/docs/features/gewitter-gesamtkonzept.md
+++ b/docs/features/gewitter-gesamtkonzept.md
@@ -173,7 +173,7 @@ Superzellenlagen erreicht wird, ist offen. Zudem nennt der DWD den Index selbst 
 
 ⇒ Deshalb: **erst Felder befüllen und mitlaufen lassen, dann einstufen.** Nicht umgekehrt.
 
-### 3.4b 🔴 CAPE ≠ CAPE — eine Schwelle auf unvergleichbare Werte (gemessen 2026-08-08, → #1592)
+### 3.4b ✅ CAPE ≠ CAPE — eine Schwelle auf unvergleichbare Werte (gemessen 2026-08-08, → #1592, BEHOBEN für die Fusion)
 
 **CAPE ist ein modellabhängiges Konstrukt, kein Messwert.** Die Modelle unterscheiden sich in
 der Parcel-Wahl: ICON liefert **Mixed-Layer**-CAPE (`CAPE_ML`), Météo-France **Most-Unstable**
@@ -206,6 +206,27 @@ diesem Konzept zu beheben:
 
 Dieselbe Falle gilt für jede künftige Modellgröße: **Feste Schwellen nie über Modellgrenzen
 tragen.**
+
+> **✅ Stand 2026-08-08 — für die Fusion behoben und live** (#1592 Scheibe B0+C0+C1, ADR-0048).
+> Gewählt wurde der zweite Weg, aber als **Perzentil-Eichung** statt geratener Einzelwerte:
+> Schwelle je Modell × Gebiet = 95. Perzentil der CAPE-Klimatologie dieses Modells in diesem
+> Gebiet über eine Konvektionssaison (April–September), mindestens 300 J/kg. Die Werte stehen
+> als statische Tabelle in `src/app/model_registry.py`; erzeugt von
+> `scripts/eichung_cape_schwelle.py` gegen die Historical Forecast API — einmalig, keine
+> Laufzeit-Abhängigkeit. Auf dem GR20 gilt jetzt **300 statt 1000**, ein realer AROME-Wert von
+> 840 J/kg ergibt dort „leicht" statt „kein Gewitter".
+>
+> **Beim Eichen fiel eine zweite Ebene desselben Fehlers auf:** Unser Code ruft Open-Meteo über
+> **Endpunkte** ab, nicht über benannte Modellvarianten. `/v1/meteofrance` liefert
+> `meteofrance_seamless`, nicht `arome_france_hd` — ein erster Eichlauf gegen die falsche
+> Variante hätte für Rest-Europa **gar keinen Eintrag** erzeugt und CAPE dort dauerhaft stumm
+> gelassen. Die Zuordnung Endpunkt → Variante ist deshalb empirisch ermittelt (Wert-für-Wert-
+> Vergleich) und im Eichskript dokumentiert. **Wer neu eicht, prüft sie zuerst nach.**
+>
+> ⚠️ **Nur die Fusion.** Der RiskEngine-Pfad und die Δ-Alarm-Schwellen prüfen weiterhin gegen
+> die feste, unbelegte Zahl — Scheiben C2 und C3 unter #1592. Ortsvergleich und
+> Schnappschuss-Reload führen strukturell keine Modell-Herkunft, dort trägt CAPE dauerhaft
+> nicht bei.
 
 ### 3.5 Die CAPE-Deckelung ist belegt ersetzbar (Recherche 2026-08-08)
 
@@ -716,7 +737,7 @@ CAPE-Deckelung zu ersetzen. #1531 ist damit **nicht** eine spätere Scheibe, son
 
 | Rang | Scheibe | Warum hier | Stand |
 |---|---|---|---|
-| **0** | 🔴 **CAPE-Schwelle modellabhängig machen** (3.4b, **#1592**) | **Laufender Fehler**: In Frankreich löst die 1000-J/kg-Schwelle **nie** aus, bei ECMWF in 65 % der Stunden. Ein Viertel der Fusionssignale ist dort tot. Unabhängig von allem anderen | sofort |
+| **0** | ✅ **CAPE-Schwelle modellabhängig gemacht** (3.4b, **#1592**, ADR-0048) | **Fusion erledigt und live seit 2026-08-08**: Schwelle je Modell × Gebiet, geeicht am 95. Perzentil der Modellklimatologie (mind. 300 J/kg). Auf dem GR20 gilt jetzt 300 statt 1000 — CAPE trägt dort erstmals bei. **Offen: C2** (RiskEngine, dort noch ungedeckelt bis `HIGH` gegen die feste 1000) **und C3** (Δ-Alarme) | teils erledigt |
 | **1** | **Fehlende DWD-Größen abrufen** (#1531) — Felder befüllen, **nicht** einstufen | Liefert `lpi_max` (gleiche Statistik) und `cin_ml` (ersetzt die Deckelung). **CIN gibt es bei Open-Meteo nicht für ICON/AROME** — der Direktabruf ist der einzige Weg. Spec liegt fertig vor | Spec fertig, Freigabe offen |
 | **2** | **Belegte Leitern übernehmen**: LPI **1/30/50** statt 5/**20**/50 · CAPE **1000/2500/4000** statt binär · CIN-Paarung **−25/−50/−100/−200** statt Deckelung | Beseitigt eine der beiden erfundenen Zahlen und macht CAPE zu einem vollwertigen Signal. Alles belegt (3.5, 3.5b) | ✅ E1 |
 | **3** | **Gleiche Statistik**: `lpi_max` statt `lpi` gegen `lpi_con_max` | Nimmt allein **Faktor 5** aus dem Gebietsbruch — ohne jede Kalibrierung | ✅ E1 |

--- a/docs/reference/decision_matrix.md
+++ b/docs/reference/decision_matrix.md
@@ -73,7 +73,7 @@ das schärfste vorhandene Ergebnis (`max_thunder()`).
 | Signal | leicht | mittel | hoch | Gebiet | Quelle der Schwellen |
 |---|---|---|---|---|---|
 | Blitzdichte `lightning_density_per_km2_3h` | > 0,003 | ≥ 0,015 | ≥ 0,075 | FR/Korsika | ECMWF Forecast User Guide 8.1.13 (0,1 bzw. 0,5 Blitze/100 km²/h über 3 h) — 🔴 **die oberste Grenze ist NICHT publiziert**, dokumentierte Fortschreibung |
-| Gewitterenergie `cape_jkg` | ≥ 1000 | — **deckelt** | — | überall | `metric_catalog.py` `risk_thresholds["cape"]["medium"]`, deckt sich mit der NWS-Grenze zur „mäßigen Instabilität" |
+| Gewitterenergie `cape_jkg` | **je Modell × Gebiet** (300–850) | — **deckelt** | — | überall, wo die Herkunft bekannt ist | ✅ **geeicht seit #1592** (ADR-0048): `CAPE_THRESHOLDS_JKG` in `src/app/model_registry.py`, 95. Perzentil der Modellklimatologie einer Konvektionssaison (April–September), mindestens 300 J/kg |
 | Wettercode (WMO 95/96/99) | — | — | ✓ | überall | unverändert |
 | **DWD-Blitzpotenzial `lpi`** (J/kg) | **≥ 5** | **≥ 20** | **≥ 50** | DE/Alpen/AT + Rest-Europa (`eu_direct`) | ✅ **angebunden seit #1474c**. 5 J/kg = betrieblicher DWD-Schwellenwert (Blitz-ja/nein), 50 J/kg = oberes Ende der publizierten Verifikationsspanne (~90 % Blitzwahrscheinlichkeit) — [ASR 19, 29 (2022)](https://asr.copernicus.org/articles/19/29/2022/), [DWD ICON-Bericht 2022/10](https://www.dwd.de/EN/ourservices/reports_on_icon/pdf_einzelbaende/2022_10.pdf). 🔴 20 J/kg ("leicht"→"mittel") ist NICHT publiziert, sondern innerhalb der belegten Spanne interpoliert (PO-freigegeben 2026-08-04) |
 
@@ -81,6 +81,29 @@ das schärfste vorhandene Ergebnis (`max_thunder()`).
 Ereignis — ohne Auslöser passiert trotz hoher Werte nichts. „mittel"/„hoch" bleiben
 Signalen vorbehalten, die tatsächliche Blitzaktivität vorhersagen. CAPE ist zugleich die
 einzige Größe, die „leicht" **außerhalb Frankreichs** überhaupt erreichbar macht.
+
+🔴 **Die CAPE-Schwelle ist modellabhängig — eine Zahl für alle Quellen war ein Fehler
+(#1592, ADR-0048).** CAPE ist ein modellabhängiges Konstrukt, kein Messwert: ICON liefert
+Mixed-Layer, Météo-France Most-Unstable, GFS Surface-Based. Die frühere feste Grenze von
+1000 J/kg löste in Frankreich (AROME) in **0 %** aller Stunden aus und bei ECMWF in **65 %**
+— auf dem GR20 war das Signal damit strukturell stumm. Gültige Werte (Stand 2026-08-08):
+
+| Modell | FR/Korsika | DE/Alpen | Rest-Europa |
+|---|---|---|---|
+| `meteofrance_arome` | 300 | 380 | 310 |
+| `icon_d2` | *keine Abdeckung* | 300 | — |
+| `icon_eu` | 850 | 360 | 300 |
+| `ecmwf_ifs04` | 710 | 650 | 420 |
+
+**Ist die Modell-Herkunft unbekannt, trägt CAPE KEIN Signal bei** — auch kein
+`ThunderLevel.NONE`. „Keine Aussage" ist nicht „geprüft, unauffällig". Betroffen sind
+dauerhaft der Ortsvergleich (`model="aggregate"`) und der Schnappschuss-Reload
+(`model="snapshot"`), die strukturell keine Herkunft führen.
+
+⚠️ **Nur die Fusion ist umgestellt.** Der RiskEngine-Pfad (`risk_engine.py`, CAPE →
+`Risk(THUNDERSTORM, MODERATE|HIGH)`, dort **ungedeckelt**) und die Δ-Alarm-Schwellen
+(`alert_preset.py`) prüfen weiterhin gegen die feste, unbelegte 1000 bzw. 500/1200/600/200.
+Scheiben C2 und C3 unter #1592.
 
 **Für jede weitere Quelle (z. B. Hagel, S5/#1475):** Eine neue Größe dockt mit **einer
 Tabellenzeile** an — Provider füllt nur Felder, die Einstufung liest nur Felder (Konzept


### PR DESCRIPTION
Reine Doku-Nachführung nach der Lieferung von #1592 Scheibe B0+C0+C1.

**`docs/reference/decision_matrix.md`** führte CAPE in der Signal-Tabelle weiter mit `≥ 1000 … risk_thresholds["cape"]["medium"]` — seit #1592 falsch für die Fusion. Das ist die Datei, die den Ist-Stand führt; sie nennt jetzt die geeichten Werte je Modell × Gebiet (300–850), die Eichregel und die Zusicherung, dass unbekannte Herkunft **kein** Signal beiträgt (auch kein `ThunderLevel.NONE`).

Ausdrücklich vermerkt, was **nicht** umgestellt ist: der RiskEngine-Pfad (dort ungedeckelt bis `HIGH`) und die Δ-Alarm-Schwellen prüfen weiterhin gegen die feste Zahl — Scheiben C2/C3.

**`docs/features/gewitter-gesamtkonzept.md`**: Fahrplan-Rang 0 von „laufender Fehler, sofort" auf „teils erledigt", Abschnitt 3.4b um den Ergebnisabsatz ergänzt — inklusive der zweiten Ebene desselben Fehlers, die beim Eichen auffiel: der Endpunkt liefert eine andere Modellvariante, als der Name vermuten lässt. Wer neu eicht, prüft die Zuordnung zuerst nach.

Kein Code. Refs #1592, ADR-0048.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxyuCgpKtbf16da3Cx88zy