### PR TITLE
fix(#1592): CAPE nicht mehr doppelt zaehlen, Eichluecke ICON-D2xFR schliessen (Scheibe C2)

### DIFF
--- a/docs/context/fix-1592-c2-cape-riskengine.md
+++ b/docs/context/fix-1592-c2-cape-riskengine.md
@@ -1,0 +1,257 @@
+# Context: fix-1592-c2-cape-riskengine
+
+**Issue:** #1592 Scheibe C2 · **Track:** Full Process · **Vorgänger:** Scheibe 1 (B0+C0+C1),
+live seit `64e50203`, Spec `docs/specs/modules/fix_1592_s1_cape_modellschwelle.md`, ADR-0048.
+
+## Request Summary
+
+Die zweite Wirkstelle der unbelegten CAPE-Schwelle schließen: `RiskEngine` bewertet CAPE
+heute über den generischen Katalogpfad gegen 1000/2000 J/kg und erzeugt daraus
+`Risk(THUNDERSTORM, MODERATE|HIGH)`. Sie soll stattdessen die in Scheibe 1 eingeführte
+geeichte Schwelle je Modell × Gebiet verwenden und bei unbekannter Herkunft schweigen.
+
+## Kernbefund — gemessen, nicht gelesen
+
+Der Issue-Text beschreibt C2 als „dieselbe unbelegte 1000, nur ungedeckelt". Gemessen am
+laufenden Code ist es mehr: **die RiskEngine unterläuft die Deckelung, die ADR-0048 und
+feat_1474 AC-6 zusichern.**
+
+```
+CAPE=2500  thunder_level_max=LOW   ->  thunderstorm/low, thunderstorm/high
+CAPE=2500  thunder_level_max=None  ->  thunderstorm/high
+CAPE=1500  thunder_level_max=None  ->  thunderstorm/moderate
+CAPE= 900  thunder_level_max=None  ->  (kein Risiko)
+```
+
+Die Kette dahinter:
+
+1. Die Fusion (`metric_format.thunder_level_from_signals`, Scheibe C1) hängt CAPE ≥ geeichter
+   Schwelle als `ThunderLevel.LOW` ein — **auf LOW gedeckelt**, ausdrücklich „misst Energie,
+   kein Ereignis".
+2. Dieses Ergebnis landet als `thunder_level_max` im Aggregat und wird von
+   `RiskEngine._check_thunder` (`risk_engine.py:121-135`) zu `Risk(THUNDERSTORM, LOW)`.
+3. **Danach zählt `RiskEngine` dieselbe Größe ein zweites Mal:**
+   `_check_catalog_metric(agg, "cape", …)` (`risk_engine.py:56-58`) gegen die Katalogleiter
+   1000 → `MODERATE`, >2000 → `HIGH`.
+4. `_deduplicate()` behält je `RiskType` die höchste Stufe — also gewinnt der ungedeckelte
+   CAPE-Zweig.
+
+Zeile 2 der Messung ist der schärfere Fall: Liefert die Fusion `None` („keine Aussage" —
+genau der Zustand, den Scheibe C1 für unbekannte Herkunft erzeugt), macht CAPE allein daraus
+ein **hohes** Gewitterrisiko. Das ist dieselbe Fehlerklasse wie in C1, nur mit umgekehrtem
+Vorzeichen: dort wurde „nicht belegt" als Entwarnung ausgegeben, hier als Alarm.
+
+**Folge für den Zuschnitt:** Die im Intake vermutete Frage („wie leite ich `MODERATE`/`HIGH`
+aus einem einzigen Eichwert ab?") ist nachgelagert. Zuerst zu klären ist, ob CAPE in der
+RiskEngine überhaupt eine **eigene, zweite** Stufe tragen darf, wo es über `thunder_level_max`
+bereits vertreten ist.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/risk_engine.py:56-58` | Der Prüfling: CAPE im generischen Katalogpfad |
+| `src/services/risk_engine.py:121-135` | `_check_thunder` — CAPE ist hier über die Fusion schon vertreten |
+| `src/services/risk_engine.py:137-173` | `_check_catalog_metric` — generisch, wird von 7 weiteren Metriken genutzt; darf nicht CAPE-spezifisch werden |
+| `src/app/metric_catalog.py:348` | `risk_thresholds={"medium": 1000.0, "high": 2000.0}` — die unbelegte Leiter |
+| `src/app/model_registry.py` | Fertig aus C0/B0: `normalize_model_id`, `effective_cape_model_id`, `CAPE_THRESHOLDS_JKG`, `cape_threshold_jkg(modell, gebiet)` |
+| `src/providers/thunder_routing.py:70-86` | `thunder_region_for(lat, lon)` — dasselbe Raster, kein zweites |
+| `src/providers/thunder_enrichment.py:171-186` | **Vorbild**: so löst C1 Modell + Gebiet auf und übergibt die Schwelle |
+| `src/output/metric_format.py:314-370` | Die Fusion mit der Deckelung, die C2 nicht brechen darf |
+| `src/app/models.py:454` | `SegmentWeatherSummary.cape_model_id` (aus C0) |
+| `src/app/models.py:371-385` | `TripSegment.start_point: GPXPoint` — die Koordinate für das Gebiet |
+| `src/services/weather_metrics.py:802, 837, 1196-1204` | Befüllung und Etappen-Aggregation von `cape_model_id` (Regel `agreement`) |
+
+## Existing Patterns
+
+- **Herkunft auflösen** (C1, `thunder_enrichment.py:176-182`): `cape_threshold_jkg(effective_cape_model_id(meta), thunder_region_for(lat, lon))` — einmal je Reihe, kein neuer Mechanismus.
+- **Abstain-Muster** (ADR-0048 Punkt 5): fehlende Herkunft ⇒ **kein** Signal, insbesondere kein `NONE`. „Keine Aussage" ≠ „geprüft, unauffällig".
+- **Kein stiller Rückfall** (ADR-0048 Punkt 6): der Schwellenparameter der Fusion ist keyword-only **ohne Default** — wer die Herkunft vergisst, bricht hart.
+- **Uneinigkeit ⇒ `None`** (`weather_metrics.py:1196-1204`, Regel `agreement`): stimmen die Herkünfte mehrerer Segmente einer Etappe nicht überein, gilt keine.
+
+## Dependencies
+
+- **Upstream:** `app.metric_catalog.get_metric`, `app.model_registry`, `providers.thunder_routing`, `SegmentWeatherData.segment.start_point`, `SegmentWeatherSummary.cape_model_id`.
+- **Downstream:** siehe „Dependents" unten.
+
+## Dependents — wo das CAPE-Risiko heute wirkt
+
+Produktive Aufrufer der RiskEngine (selbst nachgemessen, `grep` über `src/` und `api/`):
+
+| Aufrufer | Wirkung | Unterscheidet HIGH von MODERATE? |
+|---|---|---|
+| `src/services/stage_weather.py:97-133` | Cockpit-/Etappen-Ampel `red`/`yellow`/`green`, ausgeliefert über `GET /api/internal/trips/{id}/stage-weather` | **ja** — `HIGH` ⇒ rot, `MODERATE` ⇒ gelb |
+| `src/output/renderers/sms_trip.py:501` (`_detect_risk`) | Alert-/SMS-Pfad, sucht das Grat-Label | indirekt, s. Befund unten |
+
+**Nicht** an der RiskEngine hängen (gegen die erste Agenten-Auskunft nachgeprüft): die
+E-Mail-Gewitterspalte und die Telegram-Kurzübersicht lesen `ThunderLevel` direkt, nicht das
+`RiskAssessment`. `trip_report.py:822 _determine_risk()` hat **keinen** produktiven Aufrufer —
+nur Tests rufen es (`test_wind_exposition_pipeline.py`). Ebenso ist `TokenLine.main_risk`
+(`tokens/dto.py:122`) nirgends im Produktivcode befüllt; `subject.py:161` übersetzt damit
+faktisch immer `None`.
+
+### Nebenbefund: ungedeckeltes CAPE verdrängt das Grat-Label in der SMS
+
+`_deduplicate()` sortiert `HIGH` nach vorn (`risk_engine.py:240-251`); `_detect_risk()` liest
+nur `assessment.risks[0]` (`sms_trip.py:607`). Gemessen:
+
+```
+heute  (CAPE ungedeckelt)  -> risks[0] = thunderstorm/high
+gedeckelt (LOW)            -> risks[0] = wind_exposition/moderate
+```
+
+Ein allein von CAPE erzeugtes `THUNDERSTORM/HIGH` schiebt sich damit vor ein
+`WIND_EXPOSITION/MODERATE`, und die Schleife in `sms_trip.py:498-506` findet „GratWind"
+nicht mehr — der Grat-Hinweis fehlt in der Kurznachricht. Die Ursache liegt in
+`_detect_risk` („nur das oberste Risiko"), nicht in CAPE; die ungedeckelte CAPE-Eskalation
+löst sie nur aus. C2 entschärft das als Nebenwirkung, behebt es aber nicht.
+
+## Reichweite der Katalog-Zahlen — selbst nachgemessen
+
+`risk_thresholds` wird im gesamten Produktivcode **nur** in `risk_engine.py:151` gelesen
+(`grep` über `src/`, `api/`). Die CAPE-Zahlen 1000/2000 wirken also ausschließlich an der
+Stelle, die C2 anfasst — ein Umbau dort berührt keine Ampel und kein Rendering.
+
+**Gegenprobe zu zwei Fehlzuordnungen aus der Test-Recherche** (beide selbst nachgesehen, der
+Agent hatte sie C2 zugeschlagen):
+
+- `test_compare_cape_severity_ampel.py` prüft `_sev_cape` → `severity_for("cape", …)`, das
+  liest `display_thresholds` (300/800/1500), **nicht** `risk_thresholds`. Dass 1000 dort
+  „warn" und 2000 „danger" ergibt, ist Zufall der Ampelstufen — von C2 unberührt.
+- `test_friendly_format_email_and_alerts.py::test_cape_extreme_*` hängt an
+  `highlight_threshold=1000.0`, ebenfalls eine andere Katalogzahl.
+
+## Tests, die C2 wirklich bewegt
+
+| Test | Zusicherung heute | Erwartung |
+|---|---|---|
+| `tests/integration/test_risk_engine.py::test_cape_high` | CAPE ≥ 2000 ⇒ `Risk(THUNDERSTORM, HIGH)` | **muss rot werden** — genau diese Zusicherung ist der Bug |
+| `tests/integration/test_risk_engine.py::test_cape_moderate` | 1000 ≤ CAPE < 2000 ⇒ `MODERATE` | **muss rot werden** |
+| `tests/unit/test_configurable_thresholds.py:104::test_cape_risk_thresholds` | Katalog trägt `{"medium": 1000, "high": 2000}` | rot, falls die Leiter aus dem Katalog verschwindet |
+
+Alles aus der C0/C1-Familie (`test_cape_model_threshold.py`, `test_model_registry_normalization.py`,
+`test_cape_model_id_*.py`, `test_thunder_enrichment_fuses_level_shared_path.py`) muss **grün
+bleiben** — es sichert die Grundlage, auf der C2 aufsetzt. Keine dieser Dateien steht in
+`.github/ci_tdd_excludes.txt`; alle laufen auf CI.
+
+## Risks & Considerations
+
+1. **Doppelzählung ist der eigentliche Gegenstand.** Wird nur die Schwelle ausgetauscht und
+   die zweite Zählung bleibt, bleibt der Deckel aus ADR-0048 weiter unterlaufen — der Fix
+   wäre halb.
+2. **`_check_catalog_metric` ist generisch** und bedient sieben weitere Metriken. CAPE braucht
+   einen **eigenen** Zweig (`_check_cape`), keine Sonderlogik im gemeinsamen Pfad — das war
+   bereits die Vorgabe im Intake-Kommentar des Issues.
+3. **Abstain kostet hier ein bestehendes Signal.** Wo die Herkunft fehlt (Ortsvergleich
+   `aggregate`, Schnappschuss-Reload `snapshot`, Etappen mit uneinheitlicher Herkunft), fällt
+   das CAPE-Risiko ersatzlos weg. Das ist gewollt, muss aber in der Spec als Known Limitation
+   stehen — und die Fusion über `thunder_level_max` deckt diese Fälle ohnehin nicht ab.
+4. **Die Koordinate muss stimmen.** Das Gebiet kommt aus `segment.start_point`; bei langen
+   Etappen über eine Gebietsgrenze hinweg ist das eine Näherung — dieselbe, die
+   `thunder_routing` produktiv schon trifft. Kein neues Raster einführen.
+5. **Persistenz:** `cape_model_id` ist bereits additiv im Aggregat. C2 braucht **kein** neues
+   Feld und fasst den Schnappschuss nicht an.
+6. **Eichung nicht erfinden (PO-Vorgabe 2026-08-08).** Braucht C2 eine zweite Stufe, wird sie
+   zuerst in veröffentlichter, operationell genutzter Eichung gesucht — mit ausdrücklicher
+   Angabe der Parcel-Variante — und erst bei belegter Fehlanzeige aus historischen Daten
+   abgeleitet. Mahnung aus Scheibe 1: die Spec `configurable_thresholds.md` schrieb das
+   CAPE-Raster einer „WHO thunderstorm energy scale" zu, die es nicht gibt.
+
+---
+
+## Analysis
+
+### Type
+Bug (Fehlverhalten im ausgelieferten Pfad).
+
+### Beleglage der Schwellen — Ergebnis, Reihenfolge nach PO-Vorgabe
+
+**Stufe 1 — eigenes Gedächtnis (hätte zuerst kommen müssen):** Die Skala
+`<300 marginal · 300–1000 moderat · 1000–2500 stark · 2500–4000 sehr stark · >4000 extrem`
+lag bereits als PO-Recherche vom 2026-08-08 vor, samt Parcel-Tabelle je Modell
+(ICON = `CAPE_ML` Mixed-Layer, Météo-France = `CAPE_INS` Most-Unstable) und dem
+Quantil-Mapping-Verfahren. Ebenso die Präzedenzfälle #1506 (keine Schwelle gefunden ⇒ PO
+stellte zurück) und #1474c (LPI 5/20/50, Mittelwert interpoliert und als Known Limitation
+ausgewiesen).
+
+**Stufe 2 — veröffentlichte Eichung, an der Primärquelle nachgeprüft:** SPC Mesoanalysis Help
+(spc.noaa.gov/exper/mesoanalysis/help/sfcoa.html) trägt die Leiter wörtlich —
+`weak <1000 · moderate 1000–2500 · strong 2500–4000 · extreme >4000` — und bindet sie im
+selben Absatz an das Beispiel *„lifting the „non-virtual" surface parcel"*, also an **SBCAPE**.
+Dieselbe Seite definiert SB/MU/ML sauber, gibt aber für MUCAPE und MLCAPE **keine eigene
+Stufeneinteilung**. Für AROME und ICON existiert keine veröffentlichte CAPE-Schwellen-
+dokumentation, für die Umrechnung zwischen den Varianten keine belegte Quelle.
+
+⇒ **Für keines unserer beiden Hauptmodelle gibt es eine übernehmbare Leiter.** Nebenbefund:
+die Katalogzahlen 1000/**2000** sind nicht einmal die SPC-Leiter (die wäre 1000/**2500**/4000) —
+eine dritte, nirgends belegte Variante.
+
+**Stufe 3 — historische Daten:** verfügbar (`scripts/eichung_cape_schwelle.py`, ein zweiter
+Perzentilrang wäre `quantiles(...)[94]` → `[98]`, derselbe Abruf). **Wird nach dem Befund
+unten nicht gebraucht.**
+
+### Die Stufenfrage stellt sich nicht — CAPE ist bereits vertreten
+
+Beide produktiven Aufrufer von `assess_segment` (`stage_weather.py:104`, `sms_trip.py:600`)
+arbeiten mit live über `compute_extended_metrics()` berechneten Segment-Summaries. Dort ist
+`enrich_thunder()` bereits gelaufen; die Fusion hat jede Stunde gegen **dieselbe** kalibrierte
+Schwelle geprüft. Erreicht `agg.cape_max_jkg` die Schwelle, hat die Stunde mit diesem
+Maximalwert bei der Fusion mindestens `ThunderLevel.LOW` erhalten ⇒ `thunder_level_max >= LOW`
+⇒ `_check_thunder` liefert das Risiko bereits.
+
+Eine korrekt gedeckelte eigene `_check_cape` (Option B) wäre nach `_deduplicate()` damit ein
+**No-op** — sie könnte nur noch ein Signal erzeugen, das ohnehin schon da ist. Mutations-Probe
+bestätigt das von der anderen Seite: Mutanten in `_check_cape` änderten den
+`assess_segment`-Ausgang nicht, solange `_check_thunder` mitläuft. Ein Baustein, dessen
+Verfälschung nichts bewirkt, bewacht nichts.
+
+### Technical Approach — Empfehlung: Option A
+
+**Die CAPE-Regel in der RiskEngine ersatzlos streichen** (`risk_engine.py:56-58`).
+
+| | Option A (streichen) | Option B (`_check_cape`, LOW-gedeckelt) | Option C (zwei Stufen) |
+|---|---|---|---|
+| Doppelzählung weg | ja | ja | ja |
+| Deckel aus ADR-0048 gehalten | ja | ja | **nein — Verstoß** |
+| Neue Eichung nötig | nein | nein | ja, und keine belegte vorhanden |
+| Wirkung gegenüber heute | — | **keine** (No-op) | — |
+| Mutations-testbar | gut | schlecht (Mutanten sterben nicht) | schlecht |
+| LoC | ~50–100 | ~150–220 | ~180–260 (Limit 250) |
+
+Option C scheidet doppelt aus: Widerspruch zu ADR-0048 („die Deckelung bleibt") **und** keine
+belegte HIGH-Schwelle. Option B baut Code ohne Wirkung. Option A entfernt die
+Deckel-Unterlaufung und lässt CAPE dort wirken, wo alle Gewittersignale zusammenlaufen — in
+der Fusion.
+
+### Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/services/risk_engine.py` | MODIFY | Regel 2 (CAPE) entfällt; `_check_catalog_metric` bleibt generisch für die übrigen 6 Metriken |
+| `src/app/metric_catalog.py` | MODIFY | `risk_thresholds` bei `cape` entfernen — nach dem Streichen toter Konfigurationswert |
+| `tests/integration/test_risk_engine.py` | MODIFY | `test_cape_high`/`test_cape_moderate` ersetzen durch den Nachweis, dass CAPE **nur noch** über `thunder_level_max` wirkt |
+| `tests/unit/test_configurable_thresholds.py` | MODIFY | `test_cape_risk_thresholds` entfällt bzw. kehrt sich um |
+
+### Scope Assessment
+Dateien: 4 · geschätzt +60/−30 LoC · Risiko: MEDIUM (zentraler Risiko-Pfad, aber enge Fläche).
+
+### Was sich für den Nutzer ändert
+
+| Fall | heute | nach A |
+|---|---|---|
+| CAPE 2500, Fusion sagt „leicht" | Etappe **rot** | Etappe **gelb** — der Deckel wirkt endlich |
+| CAPE 2500, Fusion sagt „keine Aussage" | Etappe **rot** | **grün** |
+| CAPE 1500, Fusion sagt „keine Aussage" | Etappe gelb | grün |
+
+Der zweite und dritte Fall sind der Preis. Sie treten nur ein, wo die Modell-Herkunft fehlt
+oder keine Kalibrierung vorliegt — gemessen: `icon_d2×FR`, `icon_d2×EU_REST`, alle
+`metno_nordic`-Kombinationen. Ortsvergleich (`aggregate`) und Schnappschuss-Reload
+(`snapshot`) erreichen die RiskEngine **gar nicht** (nachgemessen: kein Snapshot-Konsument
+ruft `assess_segment`) — die im Kontext-Abschnitt oben befürchtete Reichweite war zu groß
+geschätzt.
+
+### Open Questions
+
+- [ ] Akzeptiert der PO „rot → grün" bei fehlender Modell-Herkunft als Known Limitation
+      (analog zur bereits akzeptierten Fusions-Limitation in ADR-0048)? Alternative wäre,
+      die drei Lücken der Eichtabelle zu schließen, statt an dieser Stelle zu schweigen.

--- a/docs/specs/modules/fix_1592_c2_cape_riskengine.md
+++ b/docs/specs/modules/fix_1592_c2_cape_riskengine.md
@@ -1,0 +1,340 @@
+---
+entity_id: fix_1592_c2_cape_riskengine
+type: bugfix
+created: 2026-08-08
+updated: 2026-08-08
+status: draft
+version: "1.0"
+tags: [gewitter, cape, risk-engine, model-registry, deckelung, issue-1592]
+---
+
+# CAPE wird in der RiskEngine nicht mehr doppelt gezählt — Eichlücke ICON-D2×FR geschlossen (Issue #1592 Scheibe C2)
+
+## Approval
+
+- [x] Approved — PO-„go" 2026-08-08 (die sieben ACs wurden auf Deutsch vorgelegt und freigegeben;
+      Beleg: Issue #1592, Kommentar „Spec freigegeben — Scheibe C2")
+
+## Purpose
+
+`RiskEngine` bewertet CAPE heute ein zweites Mal gegen eine eigene, unbelegte Katalogleiter
+(1000/2000 J/kg) — obendrauf zu der Fusion, die CAPE in Scheibe 1 bereits geeicht und auf
+`ThunderLevel.LOW` gedeckelt einhängt. `_deduplicate()` behält je Risikotyp die höchste Stufe,
+also gewinnt die ungedeckelte zweite Zählung und unterläuft damit die Deckelung, die ADR-0048
+und `feat_1474` AC-6 zusichern. Diese Scheibe streicht die zweite Zählung ersatzlos (Teil 2) und
+schließt nebenbei die eine echte Lücke der Eichtabelle aus Scheibe 1, `("icon_d2", "FR")`, indem
+sie je Gebiet eine geordnete Liste von Referenzpunkten statt eines einzelnen Punkts einführt
+(Teil 1) — Korsika deckt ICON-D2 nicht ab, ein zweiter Punkt in den französischen Alpen schon.
+
+**Bewusst NICHT Teil dieser Scheibe:** Familie 3 (Δ-Alarm-Beleg-Gate) bleibt bei der festen
+Katalogschwelle — eigene Folgescheibe (C3). Der Same-Model-Guard für den Δ-Alarm-Pfad ist ein
+eigenes Bug-Ticket (Spec S1, Known Limitations). `sms_trip.py::_detect_risk` liest weiterhin nur
+`assessment.risks[0]`; diese Scheibe entschärft nur die Nebenwirkung (ungedeckeltes CAPE
+verdrängt das Grat-Label), behebt aber nicht die Ursache (Known Limitations unten).
+
+## Source
+
+- **File:** `src/services/risk_engine.py`, `src/app/metric_catalog.py`,
+  `scripts/eichung_cape_schwelle.py`, `src/app/model_registry.py`
+- **Identifier:** `RiskEngine.assess_segment()` (Regel 2 entfällt),
+  `RiskEngine._check_catalog_metric()` (bleibt generisch, unverändert),
+  `MetricDefinition.risk_thresholds` bei `"cape"` (entfernt),
+  `_REGION_REFERENCE_POINTS` (wird zu geordneter Liste je Gebiet),
+  `CAPE_THRESHOLDS_JKG` (ein Eintrag `("icon_d2", "FR")` kommt hinzu, alle zehn
+  bestehenden Einträge bleiben unverändert)
+
+**Schicht:** ausschließlich Python-Core (`src/services/`, `src/app/`) plus das bestehende
+einmalige Auswertungsskript unter `scripts/`. Kein Go, kein Frontend.
+
+## Estimated Scope
+
+- **LoC:** ~+60/−30 (Workflow-Limit 250, unverdächtig).
+- **Files:** 4 Quelldateien (2 modifiziert an der Risiko-Regel, 2 an der Eichung), 2 Testdateien
+  modifiziert, mindestens 1 Testdatei neu (Kernfall/Gegenprobe/Abstain über
+  `RiskEngine.assess_segment()`, s. „Tests" unten).
+- **Effort:** low-medium — Teil 2 ist eine Streichung an einer klar begrenzten Stelle; Teil 1
+  ändert eine Datenstruktur (Punkt → Liste) an zwei bereits bestehenden Modulen, führt aber
+  keinen neuen Mechanismus ein.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| ADR-0048 | bindende Vorgabe, unverändert gültig | „Feste Schwellen werden nie über Modellgrenzen getragen" + „die Deckelung bleibt" (Punkt „Unberührt bleibt..."). Diese Scheibe stellt die Deckelung erst her, ändert die Entscheidung nicht |
+| `feat_1474_gewitter_befund_stufen.md` AC-6 | Regressionsanker | „CAPE misst Energie, kein Ereignis" — eskaliert nie über LOW. C2 macht diese Zusicherung an der RiskEngine erstmals wirksam |
+| `fix_1592_s1_cape_modellschwelle.md` (Scheibe 1) | Grundlage, unverändert | `model_registry.effective_cape_model_id()`, `thunder_routing.thunder_region_for()`, `thunder_level_from_signals()`, `enrich_thunder()` — C2 fasst keinen dieser Bausteine an |
+| `src/app/model_registry.CAPE_THRESHOLDS_JKG` | erweitert, nicht ersetzt | bekommt einen zusätzlichen Eintrag `("icon_d2", "FR")`; alle zehn bestehenden Werte bleiben identisch |
+| `tests/tdd/test_cape_model_threshold.py`, `test_model_registry_normalization.py`, `test_cape_model_id_*.py`, `test_thunder_enrichment_fuses_level_shared_path.py` | **unverändert grün zu halten** | sichern die Grundlage aus Scheibe 1; keine dieser Dateien steht in `.github/ci_tdd_excludes.txt` |
+
+## Teil 1 (Eichpunkt-Liste) — die eine echte Lücke der Eichtabelle schließen
+
+**Befund:** `scripts/eichung_cape_schwelle.py::_REGION_REFERENCE_POINTS` führt heute genau **einen**
+Referenzpunkt je Gebiet. Für FR ist das Korsika (42.22, 9.07) — der GR20-Referenzpunkt. Korsika
+liegt aber **außerhalb des ICON-D2-Gitters** (gemessen: Archiv-API, drei Julitage 2025,
+`models=icon_d2`, 0 Werte). Deshalb fehlt `("icon_d2", "FR")` in `CAPE_THRESHOLDS_JKG`, obwohl
+ICON-D2 in Frankreich real als AROME-Fallback zum Zug kommt (`providers.openmeteo.REGIONAL_MODELS`,
+Priorität 2). Ohne Eintrag liefert `cape_threshold_jkg("icon_d2", "FR")` `None` — CAPE trägt dort
+über den Fallback-Pfad strukturell nie zur Gewitterstufe bei, obwohl ICON-D2 andernorts real
+Werte liefert.
+
+**Änderung:** `_REGION_REFERENCE_POINTS` wird von `dict[str, tuple[float, float]]` zu
+`dict[str, list[tuple[float, float]]]` — je Gebiet eine **geordnete** Liste von Referenzpunkten
+statt eines einzelnen. `calibrate()` versucht für jedes (Modell, Gebiet)-Paar die Punkte der
+Liste **der Reihe nach**; der **erste** Punkt, an dem das Modell tatsächlich CAPE-Werte liefert
+(mindestens ein Wert ≠ `null`), bestimmt die Eichung dieser Kombination. Liefert **kein** Punkt
+der Liste einen Wert, entsteht weiterhin kein Tabelleneintrag (unverändertes Verhalten aus
+Scheibe 1, Abschnitt 1 Punkt 4).
+
+**Punktlisten:**
+- `FR`: `[(42.22, 9.07), (45.00, 6.50)]` — Korsika bleibt **erster** Punkt (dadurch bleiben alle
+  heute belegten Werte für FR unverändert, da jedes bisher belegte Modell dort bereits Werte
+  liefert). Zweiter Punkt: französische Alpen (45.00, 6.50) — vom PO gemessen (Archiv-API, drei
+  Julitage 2025, `models=icon_d2`): 72 Werte, max 670 J/kg. Liegt auch im AROME-Gebiet, ist also
+  für beide in FR geführten Modelle gültig.
+- `DE_ALPEN`, `EU_REST`: unverändert je ein Punkt (bestehende Werte aus Scheibe 1) — keine
+  gemessene Lücke, keine Änderung nötig.
+
+**Warum keine dritte Kombination ergänzt wird — zwei gemessene Nicht-Lücken:**
+- `icon_d2 × EU_REST` ist eine leere Menge: die einzige Fläche, wo ICON-D2-Gitter und
+  EU_REST-Gebiet zusammenfallen, liegt unterhalb 43,17° N (darüber beginnt laut
+  `thunder_routing._REGIONS` das Gebiet DE_ALPEN); an vier dort geprüften Punkten liefert
+  ICON-D2 überall 0 Werte. Ein dritter FR-Punkt für EU_REST würde also nichts eichen, was der
+  Produktivpfad je erreicht.
+- `metno_nordic × *`: der **Produktiv**-Endpunkt `/v1/metno` liefert überhaupt kein CAPE
+  (Stockholm, Jotunheimen, Tromsø je 0 Werte; Gegenprobe `/v1/dwd-icon` am selben Ort: 48 Werte).
+  Wo kein Wert je ankommt, fehlt keine Schwelle — ein zusätzlicher Referenzpunkt würde daran
+  nichts ändern.
+
+Beide Fälle sind Known Limitations, nicht offene Lücken (s. unten, mit den Messwerten).
+
+**Warum die Alpen und nicht das Rhône-Tal** (beide Kandidaten liefern ICON-D2-Werte): Die
+Punktwahl entscheidet über die Schwelle. Vorab gemessen an der vollen Saison April–September
+2025, n = 4392 Stunden je Punkt:
+
+| Kandidat | P95 | Schwelle `max(P95, 300)` |
+|---|---|---|
+| **Französische Alpen 45,00/6,50** | 230 | **300,0** (Untergrenze greift) |
+| Rhône-Tal 44,50/4,80 | 390 | 390,0 |
+
+Gewählt werden die **Alpen**: gleiche Landschaftsart wie der erste FR-Punkt (Korsika, Gebirge)
+und passend zur Zielgruppe, die im Gebirge unterwegs ist. Das Rhône-Tal würde eine
+Flachland-Klimatologie auf Bergetappen anwenden — derselbe Fehler wie der dieses Issues, nur
+eine Ebene tiefer.
+
+**`src/app/model_registry.py`:** `CAPE_THRESHOLDS_JKG` bekommt einen zusätzlichen Eintrag
+`("icon_d2", "FR"): 300.0` — der Wert des erneuten Skriptlaufs für den zweiten FR-Punkt
+(max(P95, 300.0), dieselbe Regel wie alle bestehenden Einträge, ADR-0048 Punkt 2). Der
+Kommentarblock über der Tabelle wird um die Punktliste ergänzt; die bestehende Begründung
+„fehlende Kombinationen ... haben BEWUSST keinen Eintrag" wird präzisiert auf die zwei verbliebenen
+gemessenen Nicht-Lücken (`icon_d2 × EU_REST`, `metno_nordic × *`). Alle zehn bisher belegten
+Werte bleiben **byte-identisch** — das ist der tragende Regressionsschutz dieser Scheibe (AC-2).
+
+## Teil 2 (RiskEngine) — die zweite CAPE-Zählung streichen
+
+**Befund** (`context/fix-1592-c2-cape-riskengine.md`, gemessen):
+
+```
+CAPE=2500  thunder_level_max=LOW   ->  thunderstorm/low, thunderstorm/high
+CAPE=2500  thunder_level_max=None  ->  thunderstorm/high
+CAPE=1500  thunder_level_max=None  ->  thunderstorm/moderate
+```
+
+`_check_catalog_metric(agg, "cape", agg.cape_max_jkg, RiskType.THUNDERSTORM, risks)`
+(`risk_engine.py:57-59`, Regel 2) zählt CAPE gegen die unbelegte Leiter 1000/2000 — obendrauf zu
+`_check_thunder` (Regel 1), das `thunder_level_max` bereits als `Risk(THUNDERSTORM, …)` einhängt.
+`_deduplicate()` behält je `RiskType` die höchste Stufe; die ungedeckelte zweite Zählung gewinnt
+gegen die gedeckelte erste. Bei fehlender Fusions-Aussage (`thunder_level_max is None`, genau der
+Zustand, den Scheibe 1 für unbekannte Modell-Herkunft erzeugt) macht CAPE allein daraus ein
+**hohes** Gewitterrisiko — dieselbe Fehlerklasse wie in Scheibe 1, nur mit umgekehrtem Vorzeichen
+(dort wurde „nicht belegt" als Entwarnung ausgegeben, hier als Alarm).
+
+**Warum keine eigene, gedeckelte `_check_cape`-Regel (verworfene Option B):** Beide produktiven
+Aufrufer von `assess_segment()` (`stage_weather.py:104`, `sms_trip.py:600`) arbeiten mit live über
+`compute_extended_metrics()` berechneten Summaries, bei denen `enrich_thunder()` bereits gelaufen
+ist. Erreicht `agg.cape_max_jkg` die kalibrierte Schwelle, hat die Stunde mit diesem Maximalwert
+bei der Fusion mindestens `ThunderLevel.LOW` erhalten ⇒ `thunder_level_max >= LOW` ⇒
+`_check_thunder` liefert das Risiko bereits. Eine zweite, korrekt auf LOW gedeckelte
+`_check_cape`-Regel wäre nach `_deduplicate()` ein reiner No-op — ein Baustein, dessen
+Verfälschung nichts am Ergebnis von `assess_segment()` ändert, bewacht nichts (Mutations-Probe im
+Kontextdokument bestätigt das).
+
+**Änderung:**
+1. `risk_engine.py`: Regel 2 (Zeilen 57-59, Aufruf von `_check_catalog_metric(agg, "cape", …)`)
+   entfällt ersatzlos. `_check_catalog_metric` selbst bleibt unverändert — sie bedient weiterhin
+   Wind, Böe, Niederschlag, Regenwahrscheinlichkeit, Wind-Chill und Sichtweite (die verbleibenden
+   sechs Aufrufer in `assess_segment()`).
+2. `metric_catalog.py:348`: `risk_thresholds={"medium": 1000.0, "high": 2000.0}` beim
+   `MetricDefinition`-Eintrag `"cape"` wird entfernt (Feld hat einen Default, kein Pflichtfeld —
+   nach dem Streichen von Regel 2 gibt es im gesamten Produktivcode keinen Leser mehr; gemessen
+   per `grep` über `src/`, `api/`: `risk_thresholds` wird ausschließlich in
+   `risk_engine.py:151` gelesen, also genau an der Stelle, die diese Scheibe anfasst).
+   `display_thresholds` (Ampel-Farben, 300/800/1500) und `highlight_threshold` bleiben
+   unverändert — andere Konsumenten, von dieser Scheibe unberührt.
+
+## Tests
+
+**Werden rot (die Zusicherung selbst ist der Bug — ersetzt, nicht repariert):**
+- `tests/integration/test_risk_engine.py::test_cape_high` — prüft heute `CAPE=2500` ⇒
+  `Risk(THUNDERSTORM, HIGH)`. Ersetzt durch den AC-4/AC-5-Nachweis unten.
+- `tests/integration/test_risk_engine.py::test_cape_moderate` — prüft heute `CAPE=1500` ⇒
+  `Risk(THUNDERSTORM, MODERATE)`. Entfällt ersatzlos (kein Ersatzverhalten — CAPE ohne
+  Fusions-Aussage erzeugt künftig kein Risiko, AC-5).
+- `tests/unit/test_configurable_thresholds.py::test_cape_risk_thresholds` — prüft heute
+  `get_metric("cape").risk_thresholds == {"medium": 1000.0, "high": 2000.0}`. Kehrt sich um zu
+  AC-7 (leer/entfernt).
+- `tests/unit/test_trip_report_formatter_v2.py::TestRiskPopCape::test_extreme_cape_high_risk` —
+  prüfte `_determine_risk()` (`TripReportFormatter`, kein Produktiv-Aufrufer, `trip_report.py:822`)
+  mit `thunder_level_max=ThunderLevel.NONE` und `cape=2500`, erwartete `"high"`. Dieselbe Lage wie
+  `test_cape_high` oben — CAPE allein erzeugt ein Risiko, obwohl die Fusion „geprüft, kein
+  Gewitter" sagt. Nachträglich gefunden am 2026-08-08 durch den CI-gespiegelten Vollsuite-Lauf
+  (nicht durch die vorherige Test-Recherche, s. Changelog).
+- `tests/unit/test_trip_report_formatter_v2.py::TestRiskPopCape::test_moderate_cape_medium_risk` —
+  dieselbe Lage, `cape=1200`, erwartete `"moderate"`. Ebenfalls nachträglich gefunden.
+
+**Neu (Kernfall, Gegenprobe, Abstain — über die echte Einstiegsfunktion):** eine neue
+Testdatei/-klasse in `tests/integration/test_risk_engine.py` (oder ein neuer Testmodul im selben
+Verzeichnis, Namensregel „nach Verhalten" — z. B. `test_cape_no_double_count`), die
+`RiskEngine().assess_segment()` end-to-end mit gesetztem `agg.cape_max_jkg` UND
+`agg.thunder_level_max` aufruft (beide Felder direkt auf dem Summary-Fixture gesetzt — keine
+Fusion nötig, das ist bereits durch die C1-Testfamilie gedeckt). Deckt AC-3/AC-4/AC-5 ab.
+
+**Müssen grün bleiben (Grundlage aus Scheibe 1, unverändert von dieser Scheibe berührt):**
+`tests/tdd/test_cape_model_threshold.py`, `tests/tdd/test_model_registry_normalization.py`,
+`tests/tdd/test_cape_model_id_*.py`, `tests/tdd/test_thunder_enrichment_fuses_level_shared_path.py`.
+Sowie die übrigen `TestRiskEngine*`-Fälle in `test_risk_engine.py` (Wind, Böe, Niederschlag,
+Regenwahrscheinlichkeit, Wind-Chill, Sichtweite, Wind-Exposition, Confidence, Dedup) — Nachweis
+für AC-6.
+
+**Neu für Teil 1:** ein Test, der mindestens zwei der zehn bestehenden `CAPE_THRESHOLDS_JKG`-Werte
+gegen die konkrete Zahl festnagelt (u. a. `("meteofrance_arome", "FR") == 300.0`, der Wert, der in
+Scheibe 1 selbst als Kernfall diente) UND prüft, dass `("icon_d2", "FR")` jetzt ein Eintrag ist —
+Nachweis für AC-1/AC-2.
+
+## Was sich für den Nutzer ändert
+
+| Fall | heute | nach C2 |
+|---|---|---|
+| CAPE 2500, Fusion sagt „leicht" | Etappe **rot** (Cockpit-Ampel) | Etappe **gelb** — der Deckel aus ADR-0048 wirkt endlich |
+| CAPE 2500, Fusion sagt „keine Aussage" (`thunder_level_max is None`) | Etappe **rot** | Etappe **grün** |
+| CAPE 1500, Fusion sagt „keine Aussage" | Etappe **gelb** | Etappe **grün** |
+
+Betroffen: Cockpit-/Etappen-Ampel `services/stage_weather.py:97-133` (`GET
+/api/internal/trips/{id}/stage-weather`, `HIGH` ⇒ rot, `MODERATE` ⇒ gelb) und, als
+Nebenwirkung, die SMS/Alert-Grat-Erkennung (`sms_trip.py::_detect_risk`, s. Known Limitations).
+Zeile 2 und 3 sind der Preis dieser Scheibe. Sie setzen `thunder_level_max is None` voraus, also
+eine Etappe **ohne jedes** Gewittersignal — auch ohne Wettercode, Blitzdichte und Blitzpotenzial,
+denn jedes einzelne davon setzt die Stufe bereits. Erreichbar ist das im Wesentlichen dort, wo
+die Gewitter-Anreicherung ausgefallen ist. Die naheliegende zweite Ursache — fehlende
+Modell-Herkunft aus Ortsvergleich (`aggregate`) und Schnappschuss-Reload (`snapshot`) — greift
+hier **nicht**: diese Pfade rufen `assess_segment()` gar nicht auf (nachgemessen, s. Known
+Limitations). Nach Teil 1 bleiben als Kalibrierungslücken nur noch `icon_d2 × EU_REST` und
+`metno_nordic × *`, und beide sind gemessen leere Mengen.
+
+## Known Limitations
+
+- **Ortsvergleich (`aggregate`) und Schnappschuss-Reload (`snapshot`) erreichen die RiskEngine
+  nicht.** Nachgemessen (Scheibe 1, im Kontext bestätigt): kein Snapshot-/Vergleichs-Konsument
+  ruft `assess_segment()`. Die dort ohnehin fehlende Modell-Herkunft (Scheibe 1, Abschnitt 2)
+  wirkt sich auf diese Scheibe folglich gar nicht aus.
+- **`icon_d2 × EU_REST` bleibt ohne Eintrag** — gemessen: die einzige Fläche, in der
+  ICON-D2-Gitter und EU_REST-Gebiet zusammenfallen, liegt unterhalb 43,17° N (Grenze zu
+  DE_ALPEN); an vier dort geprüften Punkten liefert ICON-D2 überall 0 Werte. Kein Mangel,
+  sondern eine leere Menge.
+- **`metno_nordic × *` bleibt ohne Eintrag** — gemessen: der Produktiv-Endpunkt `/v1/metno`
+  liefert überhaupt kein CAPE (Stockholm, Jotunheimen, Tromsø je 0 Werte; Gegenprobe
+  `/v1/dwd-icon` am selben Ort: 48 Werte). Wo kein Wert ankommt, fehlt keine Schwelle.
+- **Ungedeckeltes CAPE verdrängt heute das Grat-Label in der SMS — C2 entschärft das nur als
+  Nebenwirkung, behebt es nicht.** `_deduplicate()` sortiert `HIGH` nach vorn
+  (`risk_engine.py:240-251`), `sms_trip.py::_detect_risk` liest nur `assessment.risks[0]`
+  (`sms_trip.py:607`). Solange CAPE ungedeckelt `THUNDERSTORM/HIGH` erzeugen konnte, schob sich
+  das vor ein `WIND_EXPOSITION/MODERATE` und der Grat-Hinweis fehlte in der Kurznachricht. Nach
+  C2 kann CAPE allein kein `HIGH` mehr erzeugen — das Symptom tritt seltener auf —, aber die
+  Ursache (`_detect_risk` liest nur das oberste Risiko statt gezielt nach `WIND_EXPOSITION` zu
+  suchen) bleibt bestehen und kann von jedem anderen `HIGH`-Risiko weiterhin ausgelöst werden.
+  Eigenes Ticket, falls gewünscht.
+- **Ein Referenzpunkt-Kandidat je fehlender Kombination, nicht systematisch alle Gebiete
+  durchsucht.** Diese Scheibe schließt genau die eine Lücke, die Issue #1592 nennt
+  (`icon_d2 × FR`). Ob weitere Gebiete von einer zweiten Punktliste profitieren würden, ist nicht
+  geprüft — spätere Verfeinerung, kein Bestandteil dieser Scheibe.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue — ADR-0048 gilt unverändert.
+- **Rationale:** ADR-0048 legt bereits fest, dass die Deckelung von CAPE auf `LOW` bestehen
+  bleibt („Unberührt bleibt die Produktentscheidung aus feat_1474 AC-6 ... Die Schwelle wird
+  variabel, die Deckelung bleibt") und dass Familie 2 (RiskEngine) in einer eigenen Scheibe
+  folgt („Die Familien RiskEngine (C2) und Δ-Alarme (C3) sind in dieser Scheibe noch nicht
+  umgestellt"). Diese Scheibe **stellt diese bereits getroffene Entscheidung erst her** — sie
+  entfernt eine Regel, die der Entscheidung zuwiderlief, führt aber kein neues Prinzip, kein
+  neues Raster und keine neue Schwellenlogik ein. Kein neuer ADR nötig.
+
+## Acceptance Criteria
+
+- **AC-1 (Eichlücke geschlossen, mit Begründung):** Given die Punktliste des Gebiets FR enthält
+  jetzt zwei Referenzpunkte (Korsika zuerst, dann die französischen Alpen) / When das Eichskript
+  für `icon_d2 × FR` läuft und am ersten Punkt keine Werte findet / Then versucht es den zweiten
+  Punkt, findet dort Werte, und die committete Eichtabelle `CAPE_THRESHOLDS_JKG` trägt einen
+  Eintrag `("icon_d2", "FR")` mit dem Wert **300,0**.
+  - Test: `CAPE_THRESHOLDS_JKG[("icon_d2", "FR")] == 300.0`. Der Schlüssel existiert **nur
+    dann**, wenn der zweite Punkt tatsächlich befragt wurde — am ersten liefert ICON-D2 keine
+    Werte. Der exakte Wert nagelt zusätzlich den gewählten Punkt fest: der verworfene
+    Rhône-Kandidat hätte 390,0 ergeben, ein Test auf „≥ 300" würde beide durchlassen.
+
+- **AC-2 (Regressionsschutz, tragend — Umstellung auf Punktlisten verändert keinen bestehenden
+  Wert):** Given die Umstellung von `_REGION_REFERENCE_POINTS` von Einzelpunkt auf geordnete
+  Liste je Gebiet / When alle zehn heute belegten (Modell, Gebiet)-Kombinationen erneut
+  nachgeschlagen werden / Then liefern sie ausnahmslos denselben Zahlenwert wie vor der
+  Umstellung — insbesondere `("meteofrance_arome", "FR") == 300.0`.
+  - Test: mindestens zwei bestehende Einträge (darunter `("meteofrance_arome", "FR")`) werden
+    fest gegen ihren bisherigen Zahlenwert geprüft. Würde die Punktlisten-Umstellung
+    versehentlich die Reihenfolge vertauschen oder einen anderen Punkt zuerst prüfen, fiele
+    dieser Test durch.
+
+- **AC-3 (Kernfall — genau eine Zählung statt zwei):** Given ein Segment mit hohem CAPE (2500
+  J/kg), dessen Fusions-Ergebnis „leicht" ist (`thunder_level_max == ThunderLevel.LOW`) / When
+  `RiskEngine.assess_segment()` aufgerufen wird / Then enthält das Ergebnis **genau ein**
+  `Risk(THUNDERSTORM, …)` der Stufe `LOW` — vorher enthielt es zusätzlich ein
+  `Risk(THUNDERSTORM, HIGH)`.
+  - Test: über die echte Einstiegsfunktion `RiskEngine().assess_segment()`, nicht über eine
+    interne Hilfsmethode.
+
+- **AC-4 (Gegenprobe zur Deckelung — funktioniert für jeden CAPE-Wert):** Given ein Segment mit
+  einem extrem hohen CAPE-Wert (z. B. 50000 J/kg) und `thunder_level_max == ThunderLevel.LOW` /
+  When `assess_segment()` aufgerufen wird / Then erzeugt die RiskEngine kein
+  `Risk(THUNDERSTORM, …)` über der Stufe, die `thunder_level_max` vorgibt — unabhängig davon, wie
+  hoch CAPE numerisch ist.
+  - Test: CAPE=50000 mit `thunder_level_max=LOW` liefert weiterhin nur `LOW`, niemals
+    `MODERATE`/`HIGH`.
+
+- **AC-5 (Abstain — fehlende Fusions-Aussage erzeugt kein Alarm-Risiko):** Given ein Segment mit
+  vorhandenem CAPE-Wert (z. B. 2500 J/kg oder 1500 J/kg), aber `thunder_level_max is None`
+  („keine Aussage") / When `assess_segment()` aufgerufen wird / Then enthält das Ergebnis **kein**
+  `Risk(THUNDERSTORM, …)` — vorher lieferte derselbe Fall `HIGH` bzw. `MODERATE`.
+  - Test: CAPE=2500 und CAPE=1500, jeweils mit `thunder_level_max=None`, liefern in beiden
+    Fällen keine `THUNDERSTORM`-Risiken.
+
+- **AC-6 (generischer Katalogpfad bleibt für die übrigen sechs Metriken unverändert):** Given die
+  bestehenden Regeln für Wind, Böe, Niederschlag, Regenwahrscheinlichkeit, Wind-Chill und
+  Sichtweite in `_check_catalog_metric()` / When das Streichen der CAPE-Regel implementiert wird
+  / Then verhalten sich alle sechs übrigen Aufrufer unverändert — dieselben Eingaben liefern
+  dieselben Risiken wie vor der Änderung.
+  - Test: die bestehende `TestRiskEngine*`-Suite in `test_risk_engine.py` für Wind, Böe,
+    Niederschlag, Regenwahrscheinlichkeit, Wind-Chill, Sichtweite bleibt unverändert grün (kein
+    neuer Test nötig, Regressionsnachweis über den unveränderten Bestand).
+
+- **AC-7 (tote Konfiguration entfernt):** Given `MetricDefinition` für `"cape"` trug bisher
+  `risk_thresholds={"medium": 1000.0, "high": 2000.0}` / When die CAPE-Regel aus der RiskEngine
+  gestrichen ist / Then ist `get_metric("cape").risk_thresholds` entfernt oder leer, und kein
+  Produktivpfad liest den Wert mehr (`display_thresholds`, `highlight_threshold` bleiben
+  unverändert bestehen).
+  - Test: `get_metric("cape").risk_thresholds` ist `None`/leer bzw. das Attribut existiert mit
+    Default; `grep -r "risk_thresholds" src/ api/` zeigt keinen Leser mehr außerhalb von
+    `risk_engine.py:151` (dem generischen, CAPE-freien Pfad).
+
+## Changelog
+
+- 2026-08-08: Initial spec created (Issue #1592, Scheibe C2).
+- 2026-08-08: Zwei weitere rot werdende Tests nachgetragen
+  (`TestRiskPopCape::test_extreme_cape_high_risk`,
+  `::test_moderate_cape_medium_risk`), gefunden durch den CI-gespiegelten Vollsuite-Lauf, nicht
+  durch die vorherige Spec-Erstellung/Test-Recherche erfasst.

--- a/scripts/eichung_cape_schwelle.py
+++ b/scripts/eichung_cape_schwelle.py
@@ -18,9 +18,11 @@ waehlbaren IDs. GFS ist NICHT dabei -- Gregor Zwanzig waehlt es nie aus.
 
 Gebiete: dieselben Gewitter-Zustaendigkeitsgebiete wie
 `providers.thunder_routing._REGIONS` (FR, DE_ALPEN, EU_REST) -- KEIN zweites
-Raster. Je Gebiet EIN fest verdrahteter Referenzpunkt:
-- FR: GR20/Korsika (42.22, 9.05) -- derselbe Punkt wie in der
-  Analyse-Messung und in der Orientierungs-Abfrage des Auftrags.
+Raster. Je Gebiet eine GEORDNETE LISTE fest verdrahteter Referenzpunkte
+(Issue #1592 Scheibe C2; vorher genau ein Punkt je Gebiet):
+- FR: (1) GR20/Korsika (42.22, 9.07) -- derselbe Punkt wie in der
+  Analyse-Messung und in der Orientierungs-Abfrage des Auftrags;
+  (2) franzoesische Alpen (45.00, 6.50).
 - DE_ALPEN: Muenchen-Raum (48.14, 11.58) -- derselbe Punkt wie in der
   Analyse-Messung, bereits kanonischer Referenzpunkt im Repo
   (`tests/unit/test_openmeteo_endpoint_routing.py`).
@@ -46,9 +48,10 @@ Modelle vom REGIONAL_MODELS-`id` ab -- s. Kommentar an `_MODEL_ARCHIVE_ID`
 unten fuer die empirische Herleitung (Endpunkt-vs-benannte-Variante-
 Vergleich, PO-Korrektur 2026-08-08).
 
-Liefert die API fuer eine (Modell, Gebiet)-Kombination keine oder eine
-durchgaengig leere ("null") Reihe, entsteht KEIN Tabelleneintrag (Spec
-Abschnitt 1 Punkt 4) -- kein Fehler, sondern "nicht abgedeckt".
+Liefert KEIN Punkt der Liste eines Gebiets fuer eine (Modell, Gebiet)-
+Kombination Werte (jede Reihe leer bzw. durchgaengig "null"), entsteht KEIN
+Tabelleneintrag (Spec Abschnitt 1 Punkt 4) -- kein Fehler, sondern "nicht
+abgedeckt".
 """
 from __future__ import annotations
 
@@ -65,6 +68,20 @@ SEASON_END = "2025-09-30"
 
 # Untergrenze der Eichregel (NWS/SPC-Leiter, Gesamtkonzept 3.5b).
 MIN_THRESHOLD_JKG = 300.0
+
+# Mindestzahl stuendlicher Werte, damit ein Referenzpunkt ueberhaupt als
+# "abgedeckt" zaehlt (Adversary-Fund Issue #1592 C2: `statistics.quantiles()`
+# wirft `StatisticsError`, sobald ein Punkt genau EINEN Nicht-Null-Wert
+# liefert -- die alte Pruefung `if not values` deckte nur die leere Liste
+# ab). Eine volle Woche Stundenwerte (24 * 7) ist die Untergrenze, ab der
+# ein 95. Perzentil ueberhaupt eine Aussage ueber die Verteilung sein kann:
+# bei P95 wird statistisch nur jeder zwanzigste Wert erwartet, der ueber der
+# Schwelle liegt -- mit weniger als 168 Werten waere das rechnerische P95
+# nicht mehr aus Verteilung, sondern aus wenigen Einzelwerten abgeleitet,
+# also Rauschen statt Klimatologie. Zu wenige Werte gelten deshalb wie die
+# leere Liste als "keine Abdeckung" -- das Skript geht zum naechsten Punkt
+# der Liste weiter statt abzustuerzen.
+MIN_SAMPLE_SIZE = 24 * 7
 
 # REGIONAL_MODELS-id -> Historical-Forecast-API-Bezeichner.
 #
@@ -101,13 +118,38 @@ _MODEL_ARCHIVE_ID = {
     "ecmwf_ifs04": "ecmwf_ifs025",
 }
 
-# Gebiet -> Referenzpunkt (lat, lon). Dieselben Gebietsnamen wie
-# `thunder_routing._REGIONS`. FR: GR20 Refuge de Petra Piana -- derselbe
-# Punkt wie `tests/tdd/test_cape_model_threshold.py::_KORSIKA`.
-_REGION_REFERENCE_POINTS = {
-    "FR": (42.22, 9.07),
-    "DE_ALPEN": (48.14, 11.58),
-    "EU_REST": (59.33, 18.06),
+# Gebiet -> GEORDNETE Liste von Referenzpunkten [(lat, lon), ...].
+# Dieselben Gebietsnamen wie `thunder_routing._REGIONS`.
+#
+# `calibrate()` probiert die Punkte eines Gebiets der Reihe nach; der ERSTE
+# Punkt, an dem das Modell tatsaechlich CAPE-Werte liefert, bestimmt die
+# Eichung dieser (Modell, Gebiet)-Kombination.
+#
+# FR, Punkt 1: GR20 Refuge de Petra Piana -- derselbe Punkt wie
+# `tests/tdd/test_cape_model_threshold.py::_KORSIKA`. Korsika steht BEWUSST
+# zuerst: jedes bisher belegte FR-Modell liefert dort Werte, damit bleiben
+# alle in Scheibe B0 erhobenen FR-Schwellen beim Umstieg auf Punktlisten
+# unveraendert (Regressionsschutz, Spec C2 AC-2). Wuerde ein anderer Punkt
+# zuerst geprueft, verschoeben sich bestehende Werte.
+#
+# FR, Punkt 2: franzoesische Alpen (45.00, 6.50) -- noetig, weil Korsika
+# ausserhalb des ICON-D2-Gitters liegt (dort 0 Werte) und `icon_d2 x FR`
+# deshalb in B0 keinen Eintrag bekam, obwohl ICON-D2 in Frankreich real als
+# AROME-Fallback zum Zug kommt. Gewaehlt wurden die Alpen und NICHT das
+# Rhone-Tal (44.50, 4.80), obwohl beide ICON-D2-Werte liefern: die Alpen
+# sind dieselbe Landschaftsart wie der erste FR-Punkt (Gebirge) und passen
+# zur Zielgruppe, die im Gebirge unterwegs ist. Das Rhone-Tal wuerde eine
+# Flachland-Klimatologie auf Bergetappen anwenden -- derselbe Fehler, den
+# Issue #1592 behebt, nur eine Ebene tiefer. Die Punktwahl entscheidet ueber
+# die Zahl: Alpen P95=230 -> Schwelle 300.0 (Untergrenze greift),
+# Rhone-Tal P95=390 -> Schwelle 390.0.
+#
+# DE_ALPEN (Muenchen-Raum) und EU_REST (Stockholm) behalten je genau einen
+# Punkt -- dort ist keine Eichluecke gemessen worden.
+_REGION_REFERENCE_POINTS: dict[str, list[tuple[float, float]]] = {
+    "FR": [(42.22, 9.07), (45.00, 6.50)],
+    "DE_ALPEN": [(48.14, 11.58)],
+    "EU_REST": [(59.33, 18.06)],
 }
 
 
@@ -142,18 +184,28 @@ def calibrate() -> dict:
     liefert `{(model_id, region): threshold_jkg}`."""
     table: dict = {}
     for model_id, archive_id in _MODEL_ARCHIVE_ID.items():
-        for region, (lat, lon) in _REGION_REFERENCE_POINTS.items():
-            values = _fetch_hourly_cape(archive_id, lat, lon)
-            if not values:
-                print(f"  {model_id:20s} x {region:9s} -> keine Abdeckung (0 Werte)")
-                continue
-            p95 = statistics.quantiles(values, n=100)[94]
-            threshold = max(p95, MIN_THRESHOLD_JKG)
-            table[(model_id, region)] = round(threshold, 1)
-            print(
-                f"  {model_id:20s} x {region:9s} -> P95={p95:.1f} "
-                f"J/kg -> Schwelle={threshold:.1f} J/kg ({len(values)} Werte)"
-            )
+        for region, points in _REGION_REFERENCE_POINTS.items():
+            # Punkte der Reihe nach; der ERSTE mit GENUG Werten eicht die
+            # Kombination. Liefert keiner genug Werte -> kein Tabelleneintrag.
+            for lat, lon in points:
+                values = _fetch_hourly_cape(archive_id, lat, lon)
+                if len(values) < MIN_SAMPLE_SIZE:
+                    continue
+                p95 = statistics.quantiles(values, n=100)[94]
+                threshold = max(p95, MIN_THRESHOLD_JKG)
+                table[(model_id, region)] = round(threshold, 1)
+                print(
+                    f"  {model_id:20s} x {region:9s} -> P95={p95:.1f} "
+                    f"J/kg -> Schwelle={threshold:.1f} J/kg ({len(values)} "
+                    f"Werte, Punkt {lat}/{lon})"
+                )
+                break
+            else:
+                print(
+                    f"  {model_id:20s} x {region:9s} -> keine Abdeckung "
+                    f"(kein Punkt von {len(points)} lieferte mindestens "
+                    f"{MIN_SAMPLE_SIZE} Werte)"
+                )
     return table
 
 

--- a/src/app/metric_catalog.py
+++ b/src/app/metric_catalog.py
@@ -345,7 +345,9 @@ _METRICS: list[MetricDefinition] = [
         # (separate Metrik-Bedeutung).
         display_thresholds={"yellow": 300.0, "orange": 800.0, "red": 1500.0},
         highlight_threshold=1000.0,
-        risk_thresholds={"medium": 1000.0, "high": 2000.0},
+        # risk_thresholds bewusst NICHT gesetzt (Issue #1592 Scheibe C2,
+        # AC-7): die Leiter 1000/2000 J/kg war unbelegt und wurde nur von
+        # der gestrichenen CAPE-Regel der RiskEngine gelesen.
         format_modes=("raw", "symbol"),
         default_format_mode="symbol",
         sms_code="CP", decimals=0, cmp="über", alert_label="CAPE",

--- a/src/app/model_registry.py
+++ b/src/app/model_registry.py
@@ -79,11 +79,28 @@ def effective_cape_model_id(meta: "ForecastMeta") -> Optional[str]:
 # Forecast API, Konvektionssaison April-September 2025 (letzte vollstaendige
 # Saison, wortgetreu nach Spec Abschnitt 1). Regel je Eintrag: max(95.
 # Perzentil, 300.0 J/kg). Gebiete = `providers.thunder_routing._REGIONS`
-# (FR, DE_ALPEN, EU_REST) -- KEIN zweites Raster. Fehlende Kombinationen
-# (z. B. icon_d2 x FR: das ICON-D2-Gitter deckt Korsika nicht ab;
-# metno_nordic: die Historical Forecast API liefert fuer dieses Modell
-# durchgaengig kein CAPE) haben BEWUSST keinen Eintrag -- das ist "nicht
-# belegt", kein Fehler.
+# (FR, DE_ALPEN, EU_REST) -- KEIN zweites Raster.
+#
+# Je Gebiet fuehrt das Skript eine GEORDNETE LISTE von Referenzpunkten
+# (Issue #1592 Scheibe C2); der erste Punkt, an dem ein Modell Werte
+# liefert, eicht die Kombination. FR: Korsika (42.22, 9.07) zuerst, dann
+# franzoesische Alpen (45.00, 6.50); DE_ALPEN und EU_REST je ein Punkt.
+# Der Eintrag ("icon_d2", "FR") stammt vom zweiten FR-Punkt -- Korsika liegt
+# ausserhalb des ICON-D2-Gitters. Alle uebrigen zehn Werte stammen
+# unveraendert vom jeweils ersten Punkt (Regressionsschutz, C2 AC-2).
+#
+# Die verbliebenen zwei fehlenden Kombinationen haben BEWUSST keinen Eintrag
+# -- das ist "nicht belegt", kein Fehler, und in beiden Faellen eine
+# gemessene leere Menge, keine offene Luecke:
+# - `icon_d2 x EU_REST`: die einzige Flaeche, auf der ICON-D2-Gitter und
+#   EU_REST-Gebiet zusammenfallen, liegt unterhalb 43,17 Grad N (darueber
+#   beginnt laut `thunder_routing._REGIONS` das Gebiet DE_ALPEN); an vier
+#   dort geprueften Punkten liefert ICON-D2 ueberall 0 Werte. Ein weiterer
+#   Referenzpunkt wuerde nichts eichen, was der Produktivpfad je erreicht.
+# - `metno_nordic x *`: der Produktiv-Endpunkt `/v1/metno` liefert
+#   ueberhaupt kein CAPE (Stockholm, Jotunheimen, Tromsoe je 0 Werte;
+#   Gegenprobe `/v1/dwd-icon` am selben Ort: 48 Werte). Wo nie ein Wert
+#   ankommt, fehlt keine Schwelle.
 #
 # WICHTIG (PO-Korrektur 2026-08-08): `meteofrance_arome` wird ueber die
 # benannte Variante `meteofrance_seamless` geeicht, NICHT
@@ -105,6 +122,7 @@ CAPE_THRESHOLDS_JKG: Dict[Tuple[str, str], float] = {
     ("meteofrance_arome", "DE_ALPEN"): 380.0,
     ("meteofrance_arome", "EU_REST"): 310.0,
     ("icon_d2", "DE_ALPEN"): 300.0,
+    ("icon_d2", "FR"): 300.0,
     ("icon_eu", "FR"): 850.0,
     ("icon_eu", "DE_ALPEN"): 360.0,
     ("icon_eu", "EU_REST"): 300.0,

--- a/src/services/risk_engine.py
+++ b/src/services/risk_engine.py
@@ -54,10 +54,15 @@ class RiskEngine:
         # Rule 1: Thunder (enum-based)
         self._check_thunder(agg, risks)
 
-        # Rule 2: CAPE (thunderstorm energy)
-        self._check_catalog_metric(
-            agg, "cape", agg.cape_max_jkg, RiskType.THUNDERSTORM, risks
-        )
+        # Rule 2 (CAPE) wurde ersatzlos gestrichen -- Issue #1592 Scheibe C2.
+        # NICHT wieder einbauen: CAPE ist ueber die Fusion
+        # (`thunder_level_from_signals`, geeichte Modell-/Gebietsschwelle,
+        # auf `ThunderLevel.LOW` gedeckelt) bereits in `thunder_level_max`
+        # enthalten und wird von Regel 1 (`_check_thunder`) ausgewertet.
+        # Eine zweite Zaehlung gegen die Katalogleiter unterlief die
+        # Deckelung aus ADR-0048 / feat_1474 AC-6 ("CAPE misst Energie, kein
+        # Ereignis"), weil `_deduplicate()` je RiskType die hoechste Stufe
+        # behaelt und die ungedeckelte Zaehlung dort gewann.
 
         # Rule 3: Wind
         self._check_catalog_metric(

--- a/tests/integration/test_cape_no_double_count.py
+++ b/tests/integration/test_cape_no_double_count.py
@@ -1,0 +1,370 @@
+"""TDD RED — Issue #1592 Scheibe C2.
+
+SPEC: docs/specs/modules/fix_1592_c2_cape_riskengine.md AC-1 .. AC-7 (AC-6 ohne
+neuen Test, s. Spec).
+
+`RiskEngine` zaehlt CAPE heute ZWEIMAL: einmal ueber die Fusion
+(`thunder_level_max`, bereits in Scheibe 1 auf `ThunderLevel.LOW` gedeckelt)
+und einmal ueber eine eigene, unbelegte Katalogleiter (1000/2000 J/kg) in
+`_check_catalog_metric(agg, "cape", ...)`. `_deduplicate()` behaelt je
+`RiskType` die hoechste Stufe -- die ungedeckelte zweite Zaehlung gewinnt
+gegen die gedeckelte erste und unterlaeuft damit ADR-0048.
+
+Diese Datei deckt:
+- AC-1: Eichluecke `("icon_d2", "FR")` in `CAPE_THRESHOLDS_JKG` geschlossen.
+- AC-2: Regressionsschutz -- bestehende Eichwerte bleiben byte-identisch
+  (dieser Test ist JETZT SCHON gruen und MUSS es in Phase GREEN bleiben).
+- AC-3: Kernfall -- genau EIN THUNDERSTORM-Risiko statt zwei.
+- AC-4: Gegenprobe -- Deckelung wirkt unabhaengig vom CAPE-Zahlenwert.
+- AC-5: Abstain -- fehlende Fusions-Aussage erzeugt kein Alarm-Risiko.
+- AC-7: tote `risk_thresholds`-Konfiguration bei "cape" entfernt.
+
+AC-6 braucht keinen neuen Test (Spec: Nachweis ueber den unveraenderten
+Bestand in `test_risk_engine.py`).
+
+Keine Mocks, kein `patch()`, kein `MagicMock`: echte DTOs, echte
+`RiskEngine().assess_segment()`, echter `MetricCatalog`.
+"""
+from __future__ import annotations
+
+import ast
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from app.model_registry import CAPE_THRESHOLDS_JKG
+from app.metric_catalog import get_metric
+from app.models import (
+    GPXPoint,
+    RiskLevel,
+    RiskType,
+    SegmentWeatherData,
+    SegmentWeatherSummary,
+    ThunderLevel,
+    TripSegment,
+)
+from services.risk_engine import RiskEngine
+
+
+# --- Helper: Eichskript relativ zur Testdatei laden (niemals fest
+# verdrahteter Hauptrepo-Pfad, s. Gate `test_repo_path_hardcoding_ratchet.py`
+# / #1409) ---
+
+def _load_region_reference_points() -> dict:
+    """Liest `_REGION_REFERENCE_POINTS` per AST direkt aus dem Quelltext von
+    `scripts/eichung_cape_schwelle.py` -- KEIN `import`/`exec_module`.
+
+    Grund (gemessen, s. Issue #1592 Nachtrag): Pythons Bytecode-Cache
+    invalidiert `scripts/__pycache__/*.pyc` nur auf Sekunden-Genauigkeit ueber
+    die mtime. Schreibt eine Mutations-Gegenprobe die Quelle und die `.pyc`
+    in derselben Sekunde, haelt Python die vorhandene `.pyc` fuer aktuell und
+    ein `import`/`exec_module` laedt die VERALTETE Fassung -- der Test saehe
+    dann eine Verfaelschung nicht (falsches Gruen bei der Gegenprobe) bzw.
+    ein falsches Rot bei unveraendertem Quelltext. `ast.parse()` +
+    `ast.literal_eval()` fuehrt den Modulrumpf gar nicht erst aus und
+    beruehrt damit keinen Bytecode-Cache."""
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "eichung_cape_schwelle.py"
+    source = script_path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(script_path))
+
+    for node in ast.walk(tree):
+        target = None
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            target = node.target
+        elif isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(
+            node.targets[0], ast.Name
+        ):
+            target = node.targets[0]
+        if target is not None and target.id == "_REGION_REFERENCE_POINTS" and node.value is not None:
+            return ast.literal_eval(node.value)
+
+    raise AssertionError(
+        f"_REGION_REFERENCE_POINTS nicht in {script_path} gefunden -- "
+        "Konstante umbenannt, geloescht oder Datei verschoben? Dieser Test "
+        "kann ohne sie nichts pruefen und darf deshalb nicht still gruen "
+        "werden."
+    )
+
+
+# --- Helper (gleichwertig zu tests/integration/test_risk_engine.py) ---
+
+def _make_segment_weather(
+    thunder_level_max: ThunderLevel | None = None,
+    cape_max_jkg: float | None = None,
+) -> SegmentWeatherData:
+    """Erzeugt ein minimales SegmentWeatherData fuer Risk-Tests.
+
+    Beide Felder (`thunder_level_max`, `cape_max_jkg`) werden direkt auf dem
+    Summary-Fixture gesetzt -- keine Fusion noetig, die ist bereits durch die
+    C1-Testfamilie (`test_thunder_level_from_signals_fusion.py`) gedeckt.
+    """
+    point = GPXPoint(lat=47.0, lon=13.0, elevation_m=1500, distance_from_start_km=0.0)
+    segment = TripSegment(
+        segment_id=1,
+        start_point=point,
+        end_point=point,
+        start_time=datetime(2026, 2, 18, 8, 0, tzinfo=timezone.utc),
+        end_time=datetime(2026, 2, 18, 10, 0, tzinfo=timezone.utc),
+        duration_hours=2.0,
+        distance_km=6.0,
+        ascent_m=400,
+        descent_m=200,
+    )
+    summary = SegmentWeatherSummary(
+        thunder_level_max=thunder_level_max,
+        cape_max_jkg=cape_max_jkg,
+    )
+    return SegmentWeatherData(
+        segment=segment,
+        timeseries=None,
+        aggregated=summary,
+        fetched_at=datetime.now(timezone.utc),
+        provider="openmeteo",
+    )
+
+
+# ─────────────────────── AC-1 — Eichluecke geschlossen ───────────────────
+
+def test_icon_d2_fr_eichluecke_geschlossen():
+    """AC-1: Given die FR-Punktliste enthaelt jetzt zwei Referenzpunkte
+    (Korsika zuerst, dann franz. Alpen 45.00/6.50) / When das Eichskript fuer
+    icon_d2 x FR laeuft und am ersten Punkt (Korsika) keine ICON-D2-Werte
+    findet / Then versucht es den zweiten Punkt, findet dort Werte, und die
+    committete Eichtabelle traegt ("icon_d2", "FR") == 300.0.
+
+    RED-Ursache (heute): `_REGION_REFERENCE_POINTS["FR"]` ist ein einzelner
+    Punkt (Korsika), der ausserhalb des ICON-D2-Gitters liegt -- das Skript
+    kann fuer diese Kombination nie einen Wert erheben, der Schluessel fehlt
+    in CAPE_THRESHOLDS_JKG, direkter Zugriff wirft KeyError.
+    """
+    key = ("icon_d2", "FR")
+    assert key in CAPE_THRESHOLDS_JKG, (
+        f"CAPE_THRESHOLDS_JKG hat keinen Eintrag fuer {key} -- der Schluessel "
+        "entsteht nur, wenn die FR-Punktliste einen zweiten Referenzpunkt "
+        "(franzoesische Alpen, 45.00/6.50) enthaelt UND das Eichskript ihn "
+        "tatsaechlich befragt hat, nachdem der erste Punkt (Korsika) keine "
+        "ICON-D2-Werte liefert. Vorhandene Schluessel: "
+        f"{sorted(CAPE_THRESHOLDS_JKG.keys())}"
+    )
+    value = CAPE_THRESHOLDS_JKG[key]
+    assert value == 300.0, (
+        f"CAPE_THRESHOLDS_JKG[{key}] == {value!r}, erwartet 300.0 "
+        "(max(P95=230, 300) am zweiten FR-Punkt, franzoesische Alpen). "
+        "Ein Wert von 390.0 waere der verworfene Rhone-Tal-Kandidat -- "
+        "falscher Punkt gewaehlt."
+    )
+
+
+# ──────────────── AC-2 — Regressionsschutz (JETZT SCHON GRUEN) ───────────
+
+def test_bestehende_cape_schwellen_unveraendert():
+    """AC-2 (Regressionsschutz, tragend): Given die Umstellung von
+    `_REGION_REFERENCE_POINTS` von Einzelpunkt auf geordnete Liste je Gebiet
+    / When alle bereits belegten (Modell, Gebiet)-Kombinationen erneut
+    nachgeschlagen werden / Then liefern sie ausnahmslos denselben Zahlenwert
+    wie vor der Umstellung.
+
+    Dieser Test ist JETZT SCHON GRUEN (Regressionsschutz, kein RED-Nachweis)
+    und MUSS es in Phase GREEN bleiben -- er bewacht, dass die COMMITTETE
+    TABELLE `CAPE_THRESHOLDS_JKG` unveraendert bleibt.
+
+    ACHTUNG (Mutations-Gegenprobe, gemessen): dieser Test liest nur die
+    bereits committete Tabelle, NICHT die Punktliste im Eichskript. Eine
+    vertauschte Reihenfolge in `_REGION_REFERENCE_POINTS["FR"]` wirkt sich
+    erst beim naechsten Skriptlauf auf die Tabelle aus -- dieser Test bleibt
+    dabei gruen und faengt die Vertauschung NICHT. Die Reihenfolge selbst
+    bewacht `test_fr_referenzpunkte_reihenfolge_korsika_zuerst` unten, direkt
+    an der Datenstruktur, in der sie wirkt.
+    """
+    arome_fr = CAPE_THRESHOLDS_JKG[("meteofrance_arome", "FR")]
+    assert arome_fr == 300.0, (
+        f'CAPE_THRESHOLDS_JKG[("meteofrance_arome", "FR")] == {arome_fr!r}, '
+        "erwartet 300.0 -- dieser Wert diente in Scheibe 1 selbst als "
+        "Kernfall und darf durch die Punktlisten-Umstellung nicht verschoben "
+        "werden."
+    )
+
+    icon_eu_fr = CAPE_THRESHOLDS_JKG[("icon_eu", "FR")]
+    assert icon_eu_fr == 850.0, (
+        f'CAPE_THRESHOLDS_JKG[("icon_eu", "FR")] == {icon_eu_fr!r}, erwartet '
+        "850.0 -- ein zweiter Bestandswert mit anderem Zahlenwert als "
+        "meteofrance_arome/FR, damit ein Test, der beide gegenprueft, nicht "
+        "zufaellig durch einen einzigen falschen Konstantwert bestehen kann."
+    )
+
+
+def test_fr_referenzpunkte_reihenfolge_korsika_zuerst():
+    """AC-2 (Regressionsschutz, Reihenfolge): Given
+    `_REGION_REFERENCE_POINTS["FR"]` im Eichskript / Then steht Korsika
+    (42.22, 9.07) an Position 0 und die franzoesischen Alpen (45.00, 6.50)
+    an Position 1.
+
+    Diese Reihenfolge traegt inhaltlich: `calibrate()` fragt die Punkte
+    eines Gebiets der Reihe nach ab und uebernimmt den ERSTEN Punkt, der
+    Werte liefert, als Eichgrundlage (s. `eichung_cape_schwelle.py`,
+    `calibrate()`). Korsika liefert fuer alle bereits belegten FR-Modelle
+    (u. a. `meteofrance_arome`) Werte -- steht es an Position 0, bleiben die
+    zehn bestehenden Eichwerte unveraendert. Eine Vertauschung wuerde beim
+    naechsten Eichlauf still einen anderen Referenzpunkt (die Alpen) fuer
+    diese Modelle heranziehen und deren Schwellen verschieben, OHNE dass
+    `CAPE_THRESHOLDS_JKG` sich sofort aendert -- die committete Tabelle ist
+    ja nur ein eingefrorener Snapshot des letzten Laufs.
+
+    Ergaenzt `test_bestehende_cape_schwellen_unveraendert`: jener Test
+    bewacht die committete Tabelle (den Snapshot), dieser Test bewacht die
+    Datenstruktur, aus der ein KUENFTIGER Snapshot entsteht.
+    """
+    region_points = _load_region_reference_points()
+    fr_points = region_points["FR"]
+
+    assert fr_points[0] == (42.22, 9.07), (
+        f'_REGION_REFERENCE_POINTS["FR"][0] == {fr_points[0]!r}, erwartet '
+        "(42.22, 9.07) (Korsika). Korsika muss an Position 0 stehen, weil "
+        "calibrate() den ERSTEN Punkt mit Werten als Eichgrundlage "
+        "uebernimmt -- alle zehn bereits committeten FR-Eichwerte wurden "
+        "gegen Korsika erhoben. Stuende ein anderer Punkt zuerst, wuerde "
+        "der naechste Eichlauf diese Werte still verschieben, ohne dass "
+        "ein Test es meldet, solange nur die committete Tabelle geprueft "
+        "wird."
+    )
+    assert fr_points[1] == (45.00, 6.50), (
+        f'_REGION_REFERENCE_POINTS["FR"][1] == {fr_points[1]!r}, erwartet '
+        "(45.00, 6.50) (franzoesische Alpen). Dieser zweite Punkt ist die "
+        "Quelle fuer (\"icon_d2\", \"FR\") == 300.0 (AC-1) -- ICON-D2 deckt "
+        "Korsika nicht ab, calibrate() faellt deshalb auf ihn zurueck. "
+        "Faellt er weg oder rueckt er auf Position 0, verliert die Tabelle "
+        "diesen Eintrag oder erhebt ihn gegen den falschen Punkt."
+    )
+
+
+# ─────────────────── AC-3 — Kernfall: genau eine Zaehlung ────────────────
+
+def test_cape_hoch_mit_leichter_fusion_erzeugt_genau_ein_low_risiko():
+    """AC-3 (Kernfall): Given ein Segment mit hohem CAPE (2500 J/kg), dessen
+    Fusions-Ergebnis "leicht" ist (thunder_level_max == ThunderLevel.LOW) /
+    When RiskEngine.assess_segment() aufgerufen wird / Then enthaelt das
+    Ergebnis GENAU EIN Risk(THUNDERSTORM, ...) der Stufe LOW.
+
+    RED-Ursache (heute, gemessen): Regel 1 (`_check_thunder`) haengt
+    Risk(THUNDERSTORM, LOW) ein, Regel 2 (`_check_catalog_metric(agg,
+    "cape", ...)`) zaehlt CAPE=2500 zusaetzlich gegen die ungedeckelte Leiter
+    1000/2000 und haengt Risk(THUNDERSTORM, HIGH) ein.
+    `_deduplicate()` behaelt je RiskType die hoechste Stufe -> heraus kommen
+    ZWEI Eintraege vor der Deduplizierung, und nach der Deduplizierung
+    gewinnt HIGH gegen den gedeckelten LOW-Befund -- die Deckelung aus
+    ADR-0048 wird unterlaufen.
+
+    Nutzt die echte Einstiegsfunktion assess_segment(), nicht
+    _check_thunder()/_check_catalog_metric() direkt.
+    """
+    seg = _make_segment_weather(
+        thunder_level_max=ThunderLevel.LOW, cape_max_jkg=2500.0
+    )
+
+    assessment = RiskEngine().assess_segment(seg)
+
+    thunder_risks = [r for r in assessment.risks if r.type == RiskType.THUNDERSTORM]
+    assert len(thunder_risks) == 1, (
+        f"assess_segment() lieferte {len(thunder_risks)} THUNDERSTORM-Risiken "
+        f"({[r.level for r in thunder_risks]!r}), erwartet genau 1. Die "
+        "Katalog-Regel fuer CAPE zaehlt offenbar zusaetzlich zur Fusion -- "
+        "genau die doppelte Zaehlung, die diese Scheibe streicht."
+    )
+    assert thunder_risks[0].level == RiskLevel.LOW, (
+        f"Die verbleibende THUNDERSTORM-Stufe ist {thunder_risks[0].level!r}, "
+        "erwartet RiskLevel.LOW -- die ungedeckelte zweite CAPE-Zaehlung "
+        "(Leiter 1000/2000 J/kg) darf die gedeckelte Fusions-Aussage nicht "
+        "mehr ueberschreiben."
+    )
+
+
+# ────────────── AC-4 — Gegenprobe: Deckelung fuer JEDEN CAPE-Wert ────────
+
+def test_extrem_hohes_cape_eskaliert_nicht_ueber_die_fusion_hinaus():
+    """AC-4 (Gegenprobe zur Deckelung): Given ein Segment mit einem extrem
+    hohen CAPE-Wert (50000 J/kg) und thunder_level_max == ThunderLevel.LOW /
+    When assess_segment() aufgerufen wird / Then erzeugt die RiskEngine kein
+    Risk(THUNDERSTORM, ...) ueber der Stufe, die thunder_level_max vorgibt --
+    UNABHAENGIG davon, wie hoch CAPE numerisch ist.
+
+    RED-Ursache (heute): 50000 J/kg liegt weit ueber der Katalogleiter-
+    Schwelle "high" (2000 J/kg) -> Regel 2 erzeugt Risk(THUNDERSTORM, HIGH),
+    das nach _deduplicate() den gedeckelten LOW-Befund verdraengt.
+    """
+    seg = _make_segment_weather(
+        thunder_level_max=ThunderLevel.LOW, cape_max_jkg=50000.0
+    )
+
+    assessment = RiskEngine().assess_segment(seg)
+
+    thunder_risks = [r for r in assessment.risks if r.type == RiskType.THUNDERSTORM]
+    levels_over_low = [
+        r.level for r in thunder_risks if r.level != RiskLevel.LOW
+    ]
+    assert not levels_over_low, (
+        f"assess_segment() lieferte THUNDERSTORM-Risiken oberhalb LOW: "
+        f"{levels_over_low!r} (alle THUNDERSTORM-Stufen: "
+        f"{[r.level for r in thunder_risks]!r}), obwohl thunder_level_max == "
+        "LOW gesetzt war. CAPE=50000 J/kg darf die Deckelung NIEMALS "
+        "durchbrechen, unabhaengig vom numerischen CAPE-Wert."
+    )
+    assert len(thunder_risks) == 1 and thunder_risks[0].level == RiskLevel.LOW, (
+        f"Erwartet genau ein Risk(THUNDERSTORM, LOW), gefunden: "
+        f"{[(r.type, r.level) for r in thunder_risks]!r}."
+    )
+
+
+# ───────────────── AC-5 — Abstain: keine Fusions-Aussage ─────────────────
+
+@pytest.mark.parametrize(
+    "cape_max_jkg",
+    [2500.0, 1500.0],
+    ids=["cape-2500-vormals-high", "cape-1500-vormals-moderate"],
+)
+def test_cape_ohne_fusions_aussage_erzeugt_kein_alarm_risiko(cape_max_jkg):
+    """AC-5 (Abstain): Given ein Segment mit vorhandenem CAPE-Wert (2500 oder
+    1500 J/kg), aber thunder_level_max is None ("keine Aussage") / When
+    assess_segment() aufgerufen wird / Then enthaelt das Ergebnis KEIN
+    Risk(THUNDERSTORM, ...).
+
+    RED-Ursache (heute, gemessen): CAPE=2500 mit thunder_level_max=None
+    liefert Risk(THUNDERSTORM, HIGH); CAPE=1500 liefert
+    Risk(THUNDERSTORM, MODERATE) -- die Katalog-Regel macht aus "keine
+    Fusions-Aussage" faelschlich einen Alarm, obwohl kein einziges
+    Gewittersignal (Wettercode, Blitzdichte, Blitzpotenzial) vorlag.
+    """
+    seg = _make_segment_weather(
+        thunder_level_max=None, cape_max_jkg=cape_max_jkg
+    )
+
+    assessment = RiskEngine().assess_segment(seg)
+
+    thunder_risks = [r for r in assessment.risks if r.type == RiskType.THUNDERSTORM]
+    assert thunder_risks == [], (
+        f"assess_segment() lieferte bei cape_max_jkg={cape_max_jkg!r} und "
+        f"thunder_level_max=None dennoch THUNDERSTORM-Risiken: "
+        f"{[(r.type, r.level) for r in thunder_risks]!r}, erwartet keines. "
+        '"Keine Aussage" (thunder_level_max is None) darf kein Alarm-Risiko '
+        "erzeugen -- CAPE allein, ohne Fusions-Ergebnis, ist kein Ereignis."
+    )
+
+
+# ───────────────────── AC-7 — tote Konfiguration entfernt ────────────────
+
+def test_cape_metric_hat_keine_risk_thresholds_mehr():
+    """AC-7: Given MetricDefinition fuer "cape" trug bisher
+    risk_thresholds={"medium": 1000.0, "high": 2000.0} / When die CAPE-Regel
+    aus der RiskEngine gestrichen ist / Then ist get_metric("cape").
+    risk_thresholds entfernt oder leer.
+
+    RED-Ursache (heute): das Feld traegt noch die alte Katalogleiter.
+    """
+    risk_thresholds = get_metric("cape").risk_thresholds
+    assert not risk_thresholds, (
+        f'get_metric("cape").risk_thresholds == {risk_thresholds!r}, '
+        "erwartet leer/None -- nach dem Streichen von Regel 2 in "
+        "assess_segment() gibt es im gesamten Produktivcode keinen Leser "
+        "mehr fuer diesen Wert, die tote Konfiguration muss entfernt sein."
+    )

--- a/tests/integration/test_risk_engine.py
+++ b/tests/integration/test_risk_engine.py
@@ -178,21 +178,11 @@ class TestRiskEngineAssessSegment:
         assessment = RiskEngine().assess_segment(seg)
         assert len(assessment.risks) == 0
 
-    def test_cape_high(self):
-        """CAPE >= 2000 → Risk(THUNDERSTORM, HIGH)."""
-        seg = _make_segment_weather(cape_max_jkg=2500)
-        assessment = RiskEngine().assess_segment(seg)
-        thunder = [r for r in assessment.risks if r.type == RiskType.THUNDERSTORM]
-        assert len(thunder) == 1
-        assert thunder[0].level == RiskLevel.HIGH
-
-    def test_cape_moderate(self):
-        """CAPE >= 1000 but < 2000 → Risk(THUNDERSTORM, MODERATE)."""
-        seg = _make_segment_weather(cape_max_jkg=1500)
-        assessment = RiskEngine().assess_segment(seg)
-        thunder = [r for r in assessment.risks if r.type == RiskType.THUNDERSTORM]
-        assert len(thunder) == 1
-        assert thunder[0].level == RiskLevel.MODERATE
+    # test_cape_high / test_cape_moderate ENTFERNT (Issue #1592 Scheibe C2):
+    # sie pruegten genau das Fehlverhalten -- die zweite, ungedeckelte
+    # CAPE-Zaehlung gegen die Katalogleiter 1000/2000 J/kg, die die
+    # Deckelung aus ADR-0048 unterlief. Der Ersatz steht in
+    # tests/integration/test_cape_no_double_count.py (AC-3/AC-4/AC-5).
 
 
 class TestRiskEngineAssessSegments:

--- a/tests/unit/test_configurable_thresholds.py
+++ b/tests/unit/test_configurable_thresholds.py
@@ -102,9 +102,16 @@ class TestCatalogPopulation:
         assert md.display_thresholds == {"yellow": 300.0, "orange": 800.0, "red": 1500.0}
 
     def test_cape_risk_thresholds(self) -> None:
-        """CAPE risk: medium >= 1000, high >= 2000."""
+        """CAPE hat KEINE risk_thresholds mehr (Issue #1592 Scheibe C2).
+
+        Die frueheren Werte (medium 1000, high 2000 J/kg) waren eine
+        unbelegte Katalogleiter und wurden nur von der zweiten CAPE-Zaehlung
+        der RiskEngine gelesen. Diese Regel ist gestrichen -- CAPE geht
+        ausschliesslich ueber die geeichte Fusion (`thunder_level_max`, auf
+        LOW gedeckelt) in die Bewertung ein.
+        """
         md = get_metric("cape")
-        assert md.risk_thresholds == {"medium": 1000.0, "high": 2000.0}
+        assert not md.risk_thresholds
 
     def test_visibility_display_thresholds(self) -> None:
         """Visibility: vollstaendige invertierte Dreier-Staffel (< 2000/1000/500m).

--- a/tests/unit/test_trip_report_formatter_v2.py
+++ b/tests/unit/test_trip_report_formatter_v2.py
@@ -454,21 +454,12 @@ class TestRiskPopCape:
             fetched_at=datetime.now(timezone.utc), provider="openmeteo",
         )
 
-    def test_extreme_cape_high_risk(self):
-        """GIVEN cape=2500, WHEN risk determined, THEN high risk."""
-        seg = self._make_seg_with_risk(cape=2500.0)
-        formatter = TripReportFormatter()
-        level, label = formatter._determine_risk(seg)
-        assert level == "high"
-        assert "Thunder" in label
-
-    def test_moderate_cape_medium_risk(self):
-        """GIVEN cape=1200, WHEN risk determined, THEN moderate risk."""
-        seg = self._make_seg_with_risk(cape=1200.0)
-        formatter = TripReportFormatter()
-        level, label = formatter._determine_risk(seg)
-        assert level == "moderate"
-        assert "Thunder" in label
+    # test_extreme_cape_high_risk und test_moderate_cape_medium_risk entfernt
+    # (#1592 C2, 2026-08-08): sie setzten thunder_level_max=ThunderLevel.NONE
+    # (Fusion sagt "geprueft, kein Gewitter") und erwarteten trotzdem, dass CAPE
+    # allein ein hohes bzw. maessiges Gewitterrisiko erzeugt -- genau das
+    # Fehlverhalten, das C2 behebt. Ersatznachweis:
+    # tests/integration/test_cape_no_double_count.py
 
     def test_high_pop_medium_risk(self):
         """GIVEN pop=85, WHEN risk determined, THEN moderate risk."""


### PR DESCRIPTION
Scheibe C2 zu #1592. Spec: `docs/specs/modules/fix_1592_c2_cape_riskengine.md` (7 ACs, PO-Freigabe im Issue belegt).

## Der Befund

`RiskEngine` zaehlte CAPE **zweimal**: einmal ueber `_check_thunder` (aus `thunder_level_max`, das die Fusion auf `ThunderLevel.LOW` deckelt) und ein zweites Mal ungedeckelt gegen die Katalogleiter 1000/2000. `_deduplicate()` behaelt je Risikotyp die hoechste Stufe -- die ungedeckelte Zaehlung gewann. **Der Deckel aus ADR-0048 / feat_1474 AC-6 galt damit nur auf dem Papier.**

Gemessen am Ausgangsstand:

```
CAPE=2500  thunder_level_max=LOW   ->  thunderstorm/low, thunderstorm/high
CAPE=2500  thunder_level_max=None  ->  thunderstorm/high
CAPE=1500  thunder_level_max=None  ->  thunderstorm/moderate
```

Zeile 2 ist der schaerfere Fall: "keine Aussage" der Fusion wurde allein durch CAPE zu einem hohen Gewitterrisiko.

Die Katalogleiter war zudem **unbelegt**. Die publizierte SPC-Leiter lautet 1000/2500/4000 und gilt laut Primaerquelle fuer **Surface-Based** CAPE ("lifting the 'non-virtual' surface parcel"); ICON liefert Mixed-Layer, Meteo-France Most-Unstable. Fuer diese beiden Varianten gibt es keine veroeffentlichte Leiter -- deshalb wird **keine** neue Stufenleiter eingefuehrt, sondern die Regel gestrichen. CAPE bleibt ueber die gedeckelte Fusion vertreten.

## Zwei Teile

**Teil 1 -- RiskEngine:** Die CAPE-Regel entfaellt ersatzlos (`risk_engine.py`), die tote Katalogkonfiguration `risk_thresholds` bei `cape` wird entfernt. `_check_catalog_metric` bleibt unveraendert generisch fuer die sechs uebrigen Metriken.

**Teil 2 -- Eichung:** `_REGION_REFERENCE_POINTS` fuehrt je Gebiet eine geordnete Liste; je (Modell, Gebiet) eicht der **erste** Punkt mit Werten. Korsika bleibt fuer FR erster Punkt -- dadurch bleiben alle zehn Bestandswerte unveraendert --, ICON-D2 faellt auf die franzoesischen Alpen durch und bekommt erstmals einen Eintrag (300.0). Korsika liegt ausserhalb des ICON-D2-Gitters, weshalb die Kombination bisher fehlte, obwohl ICON-D2 in Frankreich real als AROME-Fallback zum Zug kommt.

Von drei vermuteten Eichluecken war nur diese echt. `icon_d2 x EU_REST` ist eine gemessene leere Menge (die Ueberschneidungsflaeche liegt unterhalb 43,17 N, dort liefert ICON-D2 an vier geprueften Punkten 0 Werte); `/v1/metno` liefert ueberhaupt kein CAPE (drei Orte, 0 Werte; Gegenprobe `/v1/dwd-icon` am selben Ort: 48 Werte).

## Nutzerwirkung

| Fall | vorher | nachher |
|---|---|---|
| CAPE 2500, Gewitterstufe "leicht" | Etappe **rot** | Etappe **gelb** |
| CAPE 2500, keine Gewitteraussage | Etappe **rot** | **gruen** |
| CAPE 1500, keine Gewitteraussage | **gelb** | **gruen** |

Die letzten beiden setzen eine Etappe ohne **jedes** Gewittersignal voraus (kein Wettercode, keine Blitzdichte, kein Blitzpotenzial) -- praktisch eine ausgefallene Gewitter-Anreicherung. Dass dort eine unbelegte Zahl eine rote Etappe erzeugte, war der Fehler.

## Qualitaetsnachweis

- 7 Akzeptanzkriterien, alle belegt; Spec-Konformitaet unabhaengig geprueft
- **Adversary VERIFIED**, 3 Runden, 0 offene Befunde. 6 Mutationen gesetzt, alle gefangen
- Wirkung **dort** geprueft, wo sie ankommt: echte Aufrufe an Cockpit-Ampel (`stage_weather.py`) und SMS-Pfad (`sms_trip.py`), nicht nur an `assess_segment()`
- Vollsuite mit exakt der CI-Konfiguration: **7043 gruen**

## Zwei Befunde aus der Pruefung, die erwaehnenswert sind

1. **Ein Test bewachte nicht, was er behauptete.** Der AC-2-Test sicherte laut Docstring zu, eine vertauschte Referenzpunkt-Reihenfolge falle durch -- er liest aber die committete Tabelle, nicht das Skript. Die Mutation blieb gruen. Behoben durch einen Test, der die Reihenfolge dort festnagelt, wo sie wirkt; Gegenprobe belegt, dass er die Vertauschung meldet.
2. **Der Reihenfolge-Test las zunaechst veralteten Bytecode.** Python invalidiert `.pyc` nach Aenderungszeit in Sekunden-Aufloesung, und beim Vertauschen gleich langer Tupel bleibt die Dateigroesse gleich -- eine Mutations-Gegenprobe kann dadurch stillschweigend verschluckt werden. Der Test liest die Datei jetzt als Text und wertet sie ueber den Syntaxbaum aus; beide Varianten (mit und ohne vorhandenen Cache) melden die Mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxyuCgpKtbf16da3Cx88zy