### PR TITLE
refactor(#1467 S3): beide Nowcast-Pfade laufen durch EINEN Freigabe-Baustein

### DIFF
--- a/docs/adr/0021-shared-deviation-alert-engine.md
+++ b/docs/adr/0021-shared-deviation-alert-engine.md
@@ -101,3 +101,19 @@ dieser Scheibe (Scheibe 2, #1169).
   (`effective_compare_channels()`) — derselbe Resolver wie die beiden anderen
   Compare-Alarmwege. Tageslimit und Alert-Log bleiben unverändert Trip-spezifisch
   im Adapter (kein Compare-Bedarf bekannt).
+- **Nachtrag (Issue #1467 S3, 2026-08-08):** der letzte Satz des vorigen
+  Nachtrags ist überholt. Die **Tages-Obergrenze gilt seit dieser Scheibe
+  gemeinsam** für den Trip- und den Ortsvergleich-Nowcast — beide laufen über
+  den geteilten Freigabe-Baustein `services/alert_gate.py` mit der festen
+  Reihenfolge Ruhezeit → Sperrzeit → Tages-Obergrenze. Der Ortsvergleich hatte
+  bis dahin **gar keine** Tages-Obergrenze (die Bremse gegen Meldungsfluten
+  fehlte vollständig) und führte seine Sperrzeit in einer eigenen, ungesicherten
+  Datei; beides ist auf die geteilten Bausteine gezogen (`ThrottleStore`, neuer
+  Scope `compare_radar`). Das **Alert-Log** ist ebenfalls kein Trip-Sonderweg
+  mehr: beide Nowcast-Pfade protokollieren jetzt auch, WARUM eine Meldung
+  unterdrückt wurde (`REASON_QUIET_HOURS`/`REASON_COOLDOWN`/
+  `REASON_DAILY_LIMIT`) — Änderungs- und amtlicher Alarm bewusst weiterhin
+  nicht (offene Lücke O3 in `feat_1459_alert_protokoll.md`). Kein neues
+  Architekturprinzip: das bestehende aus diesem ADR wird auf den letzten noch
+  abweichenden Pfad angewandt. Details:
+  `docs/specs/modules/rework_1467_s3_nowcast.md`.

--- a/docs/context/rework-1467-s3-nowcast.md
+++ b/docs/context/rework-1467-s3-nowcast.md
@@ -1,0 +1,256 @@
+# Context: rework-1467-s3-nowcast
+
+**Issue:** #1467 Scheibe **S3** von vier (Epic #1458, Teil 2 von #1460)
+**Vorgänger:** S1 live (`49cf1c22`, `entity_id`+`entity_type`), S2 vollständig live (AG1–AG6, zuletzt `b55bcc49`)
+**Track:** Full Process (Intake 5/6, PO-bestätigt 2026-08-08)
+**Nachfolger:** S4 (amtlich + `_day_window_end()`-Mitternachtsfenster); danach #1594
+
+## Request Summary
+
+Der **Nowcast-Pfad** (Regen-/Gewitter-Onset) des Ortsvergleichs wird an die gemeinsame
+Ablaufsteuerung angeschlossen. Nutzersichtbarer Gewinn: Der Ortsvergleich-Nowcast bekommt die
+**Tages-Obergrenze** (hat heute keine — die Bremse gegen Meldungsfluten fehlt), benutzt die
+**gemeinsame Sperrzeit** statt einer eigenen JSON-Datei, und die **Ruhezeiten-Prüfung wandert
+vor die Datenbeschaffung** (spart Abruf-Kontingent, gleiches Meldeverhalten).
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/compare_radar_alert.py` (262 Z.) | **Der zu ändernde Pfad.** Ablauf `_check_one_preset()` `:85-178`. Eigene Sperrzeit-Datei `:67`, eigener Cooldown-Check `:104-110`, Ruhezeit **nach** der Erkennung `:117-124`, **kein** `alert_daily_limit` |
+| `src/services/trip_alert.py` (1292 Z.) | **Die Vorlage.** Radar-Zweig `check_radar_alerts()` `:701-938`. Reihenfolge Ruhezeit `:748` → Sperrzeit `:752` → Tageslimit `:761` → Abruf `:767` → Erkennung `:780`. `ThrottleStore.record("radar", …)` `:935`, `increment()` `:930` — beide **erst nach** erfolgreicher Zustellung |
+| `src/services/throttle_store.py` (Scopes `trip`/`radar`/`compare_preset`) | Zielspeicher der Sperrzeit. Ein File `throttle_state.json` je Nutzer, `fcntl`-Lock, atomarer Write. Legacy-Migration `_migrate_flat_file()` `:184` — **genau das Format** der abzulösenden Datei. ⚠️ Fallstrick s. Risiken R1 |
+| `src/services/alert_daily_limit.py` | Tages-Obergrenze. `is_allowed(user_id, now, reason=None)` `:61`, `increment()` `:77`. Zähler `alert_daily_count.json`, Tageswechsel nach **Europe/Vienna**. `_FORECAST_CHANGE_RESERVE = {2:1, 4:2}` `:58` — NowCast-Reserve aus #1555 |
+| `src/services/deviation_alert_engine.py` | `is_quiet_hours(now, quiet_from, quiet_to, context_label)` `:78` — die kanonische Fassung, von allen vier Pfaden gerufen. `is_cooldown_active()` `:140` (heute die Cooldown-Prüfung des Compare-Nowcast) |
+| `src/services/compare_alert_guard.py` | `is_silenced(preset)` `:39` — sitzt bereits an `compare_radar_alert.py:95`, **vor** allem anderen (AG6) |
+| `src/services/compare_alert_channels.py` | `effective_compare_channels()` `:28` — sitzt bereits an `compare_radar_alert.py:133` |
+| `src/services/alert_log.py` | `append_entry()` `:135`. Gründe `REASON_NOWCAST` `:56`; **ungenutzt bisher:** `REASON_QUIET_HOURS` `:47`, `REASON_DAILY_LIMIT` `:48`, `REASON_COOLDOWN` `:49` |
+| `api/routers/scheduler.py` | `POST /api/scheduler/compare-radar-alert-checks` `:90-97` (Auslöser für die Staging-Verifikation), `radar-alert-checks` `:80-87` |
+| `internal/scheduler/scheduler.go` | Cron `*/15` Job `compare_radar_alert_checks` `:320-324` und `radar_alert_checks` `:305-309` |
+| `tests/tdd/test_compare_radar_alert.py` (754 Z., 10 Tests) | Bestandsschutz des Compare-Nowcast |
+| `tests/tdd/test_data_root_migration_services.py:81` | Verankert den Pfad `compare_radar_alert_throttle.json` — zieht bei einer Ablösung mit |
+
+## Ist-Stand: Trip-Nowcast vs. Ortsvergleich-Nowcast (gemessen 2026-08-08)
+
+| | Trip (`trip_alert.py:701-938`) | Ortsvergleich (`compare_radar_alert.py:85-178`) |
+|---|---|---|
+| **Reihenfolge** | Ruhezeit → Sperrzeit → **Tageslimit** → Abruf → Erkennung | Riegel → Sperrzeit → **Abruf + Erkennung** → Ruhezeit |
+| **Sperrzeit** | `ThrottleStore`, Scope `"radar"`, Key `trip.id`, `fcntl`-Lock, atomar | **eigene Datei** `compare_radar_alert_throttle.json` `:67`, flaches `{preset_id: iso}`, **kein Lock, kein atomarer Write** (`write_text` `:259`) |
+| **Tages-Obergrenze** | `is_allowed(…, reason="nowcast")` `:763`, `increment()` `:930` nach Zustellung | **fehlt vollständig** — Modul nicht importiert |
+| **Sperrdauer** | `trip.alert_cooldown_minutes`, sonst 120 Min | `preset["alert_cooldown_minutes"]`, sonst 120 Min (`_DEFAULT_COOLDOWN_MINUTES` `:36`) |
+| **Onset-Schwelle** | `radar_alert_due(result, threshold_min=20)` `:780` | dieselbe Funktion, importiert aus `trip_alert` `:27`, `_RADAR_ONSET_THRESHOLD_MIN=20` `:31` |
+
+**Bereits geteilt und in dieser Scheibe nicht anzufassen:** `is_silenced` (AG6), `effective_compare_channels` (AG1/AG4), `radar_alert_due`, `DeviationAlertEngine.is_quiet_hours`, `AlertStateService`, `alert_log.append_entry` (seit S1 mit `entity_id`/`entity_type`), `NotificationService.send_multi_location_radar_alert`, Dringlichkeit + Kanal-Schwelle (#1461 S3a/S3b).
+
+**Noch wortgleich dupliziert** über die drei Compare-Dateien: `_load_presets()`
+(`compare_radar_alert.py:241`, `compare_alert.py:536`, `compare_official_alert.py:297`),
+`_notification_service_for()` (`:221`/`:520`/`:283`), Kennungsschema `f"{preset_id}:{loc.id}"`.
+
+## Existing Patterns
+
+- **Es gibt bis heute KEINEN gemeinsamen Melder-Durchlauf.** Fünf `*/15`-Cronjobs → fünf
+  HTTP-Endpunkte → vier Service-Klassen. S1 und S2 haben *Bausteine* geteilt, nicht den Ablauf
+  zusammengelegt. Das Issue-Ziel „ein Melder-Durchlauf, parametriert über den Kontext" ist noch
+  offen — S3 entscheidet, ob es ein geteilter **Freigabe-Baustein** (Ruhezeit → Sperrzeit →
+  Tageslimit) wird oder wieder nur Einzelaufrufe.
+- **Riegel früh in der Schleife, vor der Datenbeschaffung** — Vorbild AG2
+  (`docs/context/fix-1467-ag2-ruhezeit-vor-abruf.md`) und `compare_official_alert.py:105-113`.
+  Wirkung damals: „gleiches Meldeverhalten, weniger Abrufe".
+- **Zähler und Sperrzeit erst nach erfolgreicher Zustellung schreiben** — Trip macht es so
+  (`:930`/`:935`), Compare-Nowcast auch (`:175-177`). Diese Invariante darf nicht kippen.
+- **Legacy-Migration statt Umschreiben der Historie** — `ThrottleStore._migrate_flat_file()`,
+  Präzedenz aus S1 („Lese-Regel statt Migration", BUG-DATALOSS-GR221).
+- **Ein Baustein, mehrere Aufrufer** statt Zweitfassung (ADR-0021, Trip/Compare-Teilungsregel).
+
+## Dependencies
+
+**Upstream:** `ThrottleStore`, `alert_daily_limit`, `user_tier.daily_alert_limit`,
+`DeviationAlertEngine`, `AlertStateService`, `alert_log`, `NotificationService`,
+`compare_alert_guard`, `compare_alert_channels`, `alert_urgency`, `alert_channel_threshold`,
+`RadarService.get_nowcast`, `utils/timezone.resolve_location_tz`.
+
+**Downstream:** `api/routers/scheduler.py:90-97`, `internal/scheduler/scheduler.go:320-324`,
+Alarm-Protokoll → Cockpit/Archiv-Statistik (Go), `/api/scheduler/status`.
+
+## Existing Specs
+
+- `docs/specs/modules/rework_1467_s1_alarm_kennung.md` — Kennung (live)
+- `docs/specs/modules/rework_1467_s2_aenderungsalarm.md` v1.2 — S2, AC-1…AC-28 (live)
+- `docs/specs/modules/throttle_store.md` — Zielspeicher der Sperrzeit
+- `docs/specs/modules/alert_daily_limit.md` + `docs/specs/modules/fix_1555_nowcast_alert_priority.md` — Tagesbudget und NowCast-Reserve
+- `docs/specs/modules/fix_1479_ruhezeit_wurzel.md` — Ruhezeit-Aufrufstelle 3 ist `compare_radar_alert.py`
+- `docs/specs/_archive/modules/issue_1041b_compare_radar_alert_service.md` — **archiviert**; von dort stammt die heutige Zusicherung „Ruhezeit erst nach der Erkennung" (Codekommentar `:116`). Archivablage sagt nichts über Gültigkeit — die Umkehrung ist eine bewusste Entscheidung und braucht ein eigenes AC
+- ADR-0021 — geteilter Auswertungskern
+
+## Risks & Considerations
+
+1. **🔴 R1 — Die Legacy-Migration des `ThrottleStore` läuft für Bestandsnutzer NICHT mehr.**
+   `_migrate_if_needed()` `:162-164` bricht sofort ab, wenn `throttle_state.json` bereits
+   existiert. Für alle drei realen Nutzer existiert sie (gemessen). Ein einfach ergänztes
+   `_LEGACY_COMPARE_RADAR_FILE` würde also **nie** greifen und die Sperrzeit stillschweigend
+   verlieren. Bestandsdaten sind real: `henning` trägt `{"cp-eb6ba0b239d90e37":
+   "2026-07-25T19:45:03…"}`. Der Verlust wäre hier folgenlos (Eintrag ist Wochen alt), das
+   Muster aber falsch — die Übernahme braucht einen eigenen, idempotenten Weg.
+2. **🔴 R2 — Die Tages-Obergrenze kann NowCast-Meldungen unterdrücken.** Genau das war #1555:
+   ein einziger geteilter Tageszähler über alle Trips und alle Alarm-Gründe, `free`-Stufe = 2/Tag,
+   Abweichungs-Alarme haben ihn regelmäßig aufgebraucht → system-weit **null** zugestellte
+   NowCast-Alarme. Behoben durch die Reserve `_FORECAST_CHANGE_RESERVE` `:58`. S3 hängt einen
+   **weiteren** Verbraucher an denselben Zähler. **Ausbleibende Alarme sind der gefährlichste
+   Fehler** — das gehört als ausdrückliche Entscheidung in die Spec, nicht als Nebeneffekt.
+3. **R3 — Ruhezeit vor die Erkennung ziehen ändert eine zugesicherte Zusage.** Der Kommentar
+   `:116` („Onset ist bereits erkannt — Ruhezeit unterdrückt erst hier den Versand") stammt aus
+   #1041b. Das Meldeverhalten bleibt gleich (in beiden Fällen geht nichts raus), Abrufe sinken.
+   Zu prüfen ist der Seiteneffekt auf den Dedup-Zustand `_finalize_triggered_state()` `:175`.
+4. **R4 — Schlüsselraum der Sperrzeit.** Scope `"radar"` ist heute mit `trip.id` belegt.
+   Preset-IDs (`cp-…`) kollidieren praktisch nicht, aber „praktisch nicht" ist keine Zusicherung.
+   Entweder eigener Scope oder Kennung nach S1-Muster (`compare:<preset_id>`) — Entscheidung
+   gehört in die Spec.
+5. **R5 — Alle fünf realen Ortsvergleiche des PO sind stillgelegt** (`schedule="manual"`, AG6).
+   Der Compare-Nowcast feuert in Produktion derzeit ohnehin nicht. Für die Staging-Verifikation
+   heißt das: ein Prüf-Preset braucht einen echten Zeitplan, sonst misst man den AG6-Riegel.
+6. **R6 — Nowcast ist live schwer provozierbar** (echter Regen-/Gewitter-Onset ≤ 20 Min). Der
+   Nachweis muss über den ausgelieferten Staging-Code + Zustandsdateien geführt werden
+   (Rezept aus AG5/AG6), nicht über „wir warten auf Regen".
+7. **R7 — #1594 hängt hinter dieser Umbaukette.** Die zusammengelegte Steuerung soll den
+   **nächsten geplanten Versandzeitpunkt** kennen. Gemessen: eine solche Funktion existiert
+   nirgends. Es gibt nur Ad-hoc-Stundenabgleiche (`trip_report_scheduler.py:464-474`,
+   `compare_slot_scheduler.py:109-111`) — beide werfen die **Minuten weg** und rechnen in
+   Wien-Zeit, nicht in Ortszeit. #1594 ist **nicht** Teil von S3; S3 darf sich den Weg dorthin
+   aber nicht verbauen.
+8. **R8 — Struktur-Wächter.** `tests/test_success_status_guard.py` und
+   `tests/test_resolution_loss_guard.py` verankern `compare_radar_alert.py` per
+   `datei::funktion::ordinal` samt `try/except`-Zahl. Ein zusätzlicher Riegel verschiebt die
+   Zählung ⇒ Schlüssel nachziehen, **Wächter nicht aufweichen**.
+9. **R9 — Mandantentrennung.** Zähler und Sperrzeit liegen unter `data/users/<user_id>/`.
+   Pflichttest mit **zwei** verschiedenen Nutzern.
+
+---
+
+# Analysis (Phase 2, 2026-08-08)
+
+## Type
+
+**Feature/Rework** — Umbau mit Zielmarke „Verhalten unverändert" plus drei ausdrücklich
+gewollten Verhaltensänderungen (Tages-Obergrenze, gemeinsame Sperrzeit, Reihenfolge).
+
+## Was die Analyse gegenüber der Issue-Beschreibung korrigiert
+
+| Behauptung im Issue (Stand 2026-08-02) | Gemessener Stand 2026-08-08 |
+|---|---|
+| Compare-Nowcast hat feste Kanäle / keine Stilllegung | **überholt** — `effective_compare_channels` `:133` und `is_silenced` `:95` sitzen bereits drin (AG1/AG4/AG6) |
+| „Bremse gegen Meldungsfluten fehlt" | **stimmt, wirkt aber nur bei getakteten Konten.** `daily_alert_limit()` liefert für `tier: premium` `None`. Von drei realen Konten ist eines premium (`henning`), zwei ohne `tier`-Feld (= `free`, 2/Tag) |
+| „spart Abruf-Kontingent" | **nur bedingt.** `get_nowcast` trifft oft den geteilten Cache (TTL 300 s) — ein Treffer kostet nichts. Nur ein echter Fehltreffer im open-meteo-Zweig verbraucht Kontingent; RADOLAN/INCA/DPC sind ungegatet |
+
+## Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/services/alert_gate.py` | **CREATE** | Geteilter Freigabe-Baustein: Ruhezeit → Sperrzeit → Tages-Obergrenze in fester Reihenfolge |
+| `src/services/compare_radar_alert.py` | MODIFY | Ruft den Baustein; eigene Sperrzeit-Datei + `_load/_save_throttle_times` entfallen |
+| `src/services/trip_alert.py` | MODIFY | Radar-Zweig `:748-765` ruft denselben Baustein (Ersetzung, keine Verhaltensänderung) |
+| `src/services/throttle_store.py` | MODIFY | Scope-Liste im Docstring um `compare_radar` ergänzen |
+| `tests/tdd/test_compare_radar_alert.py` | MODIFY | AC-7 misst die Mandantentrennung an der alten Datei → Messpunkt wandert auf `throttle_state.json` |
+| `tests/tdd/test_data_root_migration_services.py` | MODIFY | `:74-82` prüft `_throttle_file` namentlich → wird ohne Anpassung rot |
+| `tests/tdd/test_throttle_store.py` | MODIFY | neuer Scope braucht Abdeckung |
+| `tests/test_success_status_guard.py` | MODIFY (nur falls Zählung kippt) | Anker `compare_radar_alert.py::check_all_compare_presets::0` und `…: 1` |
+| `docs/adr/0021-shared-deviation-alert-engine.md` | MODIFY | Nachtrag: „Tageslimit bleibt Trip-spezifisch, kein Compare-Bedarf bekannt" wird durch S3 sachlich falsch |
+| Go-Seite, Frontend | **keine** | belegt: kein Treffer für `compare_radar_alert`/`radar_alert_throttle` |
+
+## Scope Assessment
+
+- Dateien: 4 Produktiv (1 neu), ~5 Test, 1 ADR-Nachtrag
+- Produktiv-LoC: **~150–190** (Baustein ~70–90, Compare netto ~+20–40, Trip netto ~−10, Docstring ~2)
+- Test-LoC: ~300–400
+- **Passt in EINEN Arbeitsgang** unter dem 250-Zeilen-Budget. Keine Unterteilung nötig
+- Risiko: **HOCH** — jeder Fehler im Baustein unterdrückt *alle* Nowcast-Alarme beider Pfade
+
+## Technical Approach
+
+**Ein geteilter Freigabe-Baustein, von Anfang an mit BEIDEN Verbrauchern verdrahtet.**
+
+```python
+# src/services/alert_gate.py
+class GateResult(NamedTuple):
+    allowed: bool
+    reason: Optional[str]   # REASON_QUIET_HOURS | REASON_COOLDOWN | REASON_DAILY_LIMIT
+
+def check_nowcast_gate(*, user_id, throttle_scope, throttle_key, cooldown_minutes,
+                       quiet_from, quiet_to, context_label, now,
+                       daily_limit_reason="nowcast", throttle_store=None) -> GateResult
+def record_nowcast_sent(*, user_id, throttle_scope, throttle_key, now,
+                        throttle_store=None) -> None
+```
+
+Der Baustein reicht `is_quiet_hours` **unverändert** durch (kein eigenes `try/except` —
+`fix_1479` AC-11 wird von einem AST-Wächter geprüft). `record_nowcast_sent` bündelt
+`increment()` + `record()` und wird **ausschließlich nach erfolgreicher Zustellung** gerufen,
+genau wie heute an beiden Stellen.
+
+**Abweichung von der Empfehlung des Strategie-Agenten:** Er wollte den Baustein zunächst nur
+vom Ortsvergleich rufen lassen und den Trip-Pfad später nachziehen. Dagegen spricht das
+Hausmuster aus S2 AG1: dort wurde der Kanal-Resolver extrahiert und **beide** Bestandsstellen
+wurden sofort zu dünnen Wrappern — Produktivcode schrumpfte netto. Ein „geteilter" Baustein
+mit genau einem Verbraucher ist keine Entdopplung, sondern eine **dritte** Fassung derselben
+Reihenfolge; und das Issue-Ziel lautet ausdrücklich Zusammenlegen, nicht Danebenlegen. Der
+Mehraufwand ist gering (der Trip-Zweig verliert ~18 Zeilen), das Risiko liegt allein bei den
+Struktur-Wächtern und ist messbar.
+
+**Sperrzeit:** neuer Scope `"compare_radar"`, Schlüssel = `preset_id`.
+- `"radar"` ist ausschließlich mit **Trip**-IDs belegt. Seit dem #1250-Cutover liegen Trips und
+  Ortsvergleiche im selben Verzeichnis `briefings/<id>.json`, unterschieden nur durch `kind`;
+  IDs sind frei gewählte Slugs, keine UUIDs ⇒ Kollision ist real möglich.
+- `"compare_preset"` ist durch den Änderungsalarm auf **demselben** `preset_id`-Schlüssel
+  belegt. Wiederverwendung würde `test_alert_log_compare_and_tenancy.py::test_ac12…` rot
+  machen — dort löst ein Preset im selben Lauf Δ-, Nowcast- und amtlichen Alarm aus und
+  erwartet `(1,1,1)`.
+
+**Altdaten:** bewusster Verzicht auf Migration, mit Begründung in der Spec.
+`_migrate_if_needed()` `:162-164` bricht ab, sobald `throttle_state.json` existiert — bei allen
+realen Nutzern der Fall. Eine vierte Legacy-Konstante wäre totes Gerüst; der wirksame Weg wäre
+ein ungegateter `_update()`-Aufruf mit `setdefault`-Semantik. Real existiert **ein** Alteintrag
+(`henning`, `cp-eb6ba0b239d90e37`, 25.07.), längst außerhalb jedes Cooldowns. Die Altdatei wird
+nicht mehr geschrieben und bleibt unangetastet liegen (kein Löschen).
+
+## Risiken, geordnet nach Schwere
+
+1. **Fehler im Baustein unterdrückt alle Nowcast-Alarme beider Pfade.** Genau die Bugklasse,
+   gegen die der `ThrottleStore` einst gebaut wurde („stiller Totalausfall"). Gegenmittel: jede
+   Gate-Stufe einzeln bewachen, Reihenfolge 1:1 gegen die Trip-Vorlage messen.
+2. **Geteilter Tageszähler** (#1555): ein weiterer Verbraucher am selben Topf. Entschärft durch
+   `reason="nowcast"` — die Reserve kappt nur `forecast_change`. Ein eigener Compare-Reason
+   würde diesen Schutz **verlieren**; das ist der Fehler, der hier lauert.
+3. **Zähler-Reihenfolge:** `increment`/`record` vor statt nach der Zustellung würde
+   fehlgeschlagene Versuche als verbraucht buchen.
+4. **Scope-Kollision** bei falscher Schlüsselwahl (s. o.).
+5. **Ruhezeit vor Erkennung** kippt zwei archivierte ACs (#1041/#1041b) — Meldeverhalten
+   bleibt gleich, die Ablösung gehört ausdrücklich in die Spec.
+6. **Struktur-Wächter** (`test_success_status_guard.py`) — Deploy-Blocker, kein Nutzerrisiko.
+
+## Nebenbefund (nicht in dieser Scheibe)
+
+`trip_report_scheduler.py:1159` prüft `is_allowed(reason="nowcast")` für den
+Starkregen-Kurzhinweis, ruft aber nirgends `increment()` — geprüft, aber nie verbucht.
+Einzige asymmetrische Stelle im Repo. → Sammel-Issue #1199.
+
+## Entscheidungen (getroffen 2026-08-08)
+
+- **E1 — geteilter Freigabe-Baustein, beide Nowcast-Pfade sofort verdrahtet.** Entschieden vom
+  Tech-Lead gegen die Empfehlung des Strategie-Agenten (der wollte zunächst nur den
+  Compare-Verbraucher). Begründung: ein Baustein mit genau einem Verbraucher ist keine
+  Entdopplung, sondern eine dritte Fassung derselben Reihenfolge. Hausmuster ist S2 AG1 —
+  dort wurden beide Bestandsstellen sofort zu dünnen Wrappern und der Produktivcode schrumpfte.
+- **E2 — Tages-Obergrenze exakt wie beim Trip-Nowcast, `reason="nowcast"`.** Damit erbt der
+  Ortsvergleich den Vorrang-Schutz aus #1555 (die Reserve kappt nur `forecast_change`). Ein
+  Compare-eigener Grund würde diesen Schutz still verlieren — das ist die Falle an dieser Stelle.
+- **E3 — neuer Scope `"compare_radar"`, Schlüssel `preset_id`; keine Migration der Altdaten,**
+  mit Begründung in der Spec (ein realer Alteintrag vom 25.07., längst außerhalb jedes
+  Cooldowns; der vorhandene Migrationsmechanismus greift bei Bestandsnutzern ohnehin nicht).
+- **E4 — JA, Unterdrückungen werden protokolliert (PO-Entscheidung 2026-08-08).**
+  `REASON_QUIET_HOURS`, `REASON_COOLDOWN`, `REASON_DAILY_LIMIT` (`alert_log.py:47-49`) werden
+  erstmals scharf geschaltet. Der Freigabe-Baustein kennt die sperrende Stufe ohnehin und gibt
+  sie über `GateResult.reason` zurück. **Geltungsbereich: die beiden Nowcast-Pfade** — Änderungs-
+  und amtliche Alarme bleiben unberührt (eigene Scheiben S4 bzw. Folgearbeit).
+  ⚠️ **LoC-Wirkung:** schätzungsweise +30–50 Zeilen ⇒ Gesamtschätzung rückt auf **~180–240**
+  Produktiv-Zeilen und damit nah an die 250er-Grenze. Wird es eng, ist die
+  Unterdrückungs-Protokollierung der Teil, der als eigener Arbeitsgang nachgezogen wird —
+  nicht der Kern (a)/(b)/(c).

--- a/docs/specs/modules/feat_1459_alert_protokoll.md
+++ b/docs/specs/modules/feat_1459_alert_protokoll.md
@@ -421,6 +421,17 @@ keinem Aufrufer gesetzt — bewusste Entscheidung, s.u.
 
 ### O3 — Wo genau greift die Protokollierung? (zentrale Frage)
 
+> ⚠️ **Fuer die beiden Nowcast-Pfade geschlossen seit Issue #1467 Scheibe S3**
+> (2026-08-08). `src/services/alert_gate.py::check_nowcast_gate()` protokolliert
+> Ruhezeit/Cooldown/Tageslimit-Unterdrueckungen jetzt fuer Tour-Radar UND
+> Vergleichs-Nowcast ueber `alert_log.append_suppressed_entry()`
+> (`REASON_QUIET_HOURS`/`REASON_COOLDOWN`/`REASON_DAILY_LIMIT`, Ziel-Liste
+> `not_delivered`, D4 bleibt gewahrt). Fuer Vorhersage-Aenderungsalarm und
+> amtliche Warnung (die vier uebrigen Zeilen der Tabelle unten) bleibt die
+> Luecke **unveraendert offen** — dort ist weiterhin die Vorziehung der
+> Auswertung aus Epic #1458 Scheibe 2 die Voraussetzung. Massgeblich:
+> `docs/specs/modules/rework_1467_s3_nowcast.md`.
+
 **Befund:** Ruhezeiten/Cooldown/Tageslimit laufen an **fast allen** Aufrufstellen VOR der
 eigentlichen Auswertung (Δ-Erkennung/Korridor-Check/Nowcast-Abruf) — zum Zeitpunkt, an dem
 das Gate greift, ist noch **gar nicht bekannt**, ob ueberhaupt eine Meldung faellig
@@ -434,6 +445,11 @@ gewesen waere:
 | Vergleich Δ (`compare_alert.py:112/:118`) | — (kein Ruhezeit-Gate) | vor `_detect_triggered_locations()` | vor Detect | **nein** |
 | Vergleich Radar (`compare_radar_alert.py:92/:103`) | nach `_detect_triggered_locations()` | vor Detect | — (kein Tageslimit-Gate) | gemischt |
 | Vergleich amtlich (`compare_official_alert.py:107/:125`) | vor `_detect()` | — (kein Cooldown, s. Docstring) | nach `_detect()` | gemischt |
+
+Zeile „Vergleich Radar" beschreibt den Stand vor #1467 S3: seit dieser Scheibe laufen
+Ruhezeit/Sperrzeit/Tageslimit dort — wie bei „Tour Radar" — VOR `_detect_triggered_locations()`
+ueber den geteilten `alert_gate.check_nowcast_gate()`, und ein Tageslimit-Gate existiert
+jetzt ebenfalls. Die uebrigen vier Zeilen (Δ/amtlich, Tour wie Vergleich) sind unveraendert.
 
 **Entscheidung:** In dieser Scheibe wird **nur** die Nicht-Zustellung „Auslöser war
 bekannt, aber kein Kanal hat sie erreicht" protokolliert — das ist an **allen sechs**
@@ -707,12 +723,17 @@ entscheidet ueber Ziel-Liste bzw. Auslassen (s.o.).
 
 ## Known Limitations
 
-- **Ruhezeit/Cooldown/Tageslimit bleiben unprotokolliert** (O3): Diese drei Gates laufen
-  an fast allen Aufrufstellen VOR der Auswertung — der Ausloeser ist zum Zeitpunkt der
-  Unterdrueckung strukturell noch nicht bekannt. Eine vollstaendige Abdeckung braucht die
-  Vorziehung der Auswertung, die Scheibe 2 des Epic #1458 ohnehin umsetzt. Bis dahin bleibt
-  eine Luecke: Eine durch Ruhezeit/Cooldown/Tageslimit unterdrueckte, aber tatsaechlich
-  faellige Meldung erscheint nicht im Protokoll (auch nicht in `not_delivered`).
+- **Ruhezeit/Cooldown/Tageslimit bleiben unprotokolliert** (O3) — **fuer den
+  Vorhersage-Aenderungsalarm und die amtliche Warnung weiterhin.** Diese beiden Gates
+  laufen VOR der Auswertung — der Ausloeser ist zum Zeitpunkt der Unterdrueckung
+  strukturell noch nicht bekannt. Eine vollstaendige Abdeckung braucht die Vorziehung der
+  Auswertung, die Scheibe 2 des Epic #1458 ohnehin umsetzt. Bis dahin bleibt eine Luecke:
+  eine durch Ruhezeit/Cooldown/Tageslimit unterdrueckte, aber tatsaechlich faellige Meldung
+  erscheint dort nicht im Protokoll (auch nicht in `not_delivered`). **Fuer die beiden
+  Nowcast-Pfade (Tour-Radar, Vergleichs-Nowcast) ist diese Luecke seit Issue #1467
+  Scheibe S3 geschlossen** — `alert_gate.check_nowcast_gate()` kennt den Ausloeser bereits
+  vor der Datenbeschaffung und protokolliert die Unterdrueckung ueber
+  `alert_log.append_suppressed_entry()`, s. O3.
 - **Die Warn-Ausgabe bei unaufloesbarer Mehrdeutigkeit ist im Betrieb nur schwach
   sichtbar.** `metric_and_aggregation_for_field()` meldet den Fall per `logger.warning` und
   liefert `None` (fail-soft, bewusst keine Exception — eine echte Gewitter- oder
@@ -762,6 +783,12 @@ entscheidet ueber Ziel-Liste bzw. Auslassen (s.o.).
 
 ## Changelog
 
+- 2026-08-08: O3-Hinweis praezisiert (Issue #1467 Scheibe S3, Doku-Nachzug) — die
+  Nicht-Protokollierung von Ruhezeit/Cooldown/Tageslimit ist fuer die beiden
+  Nowcast-Pfade (Tour-Radar, Vergleichs-Nowcast) geschlossen (`alert_gate.py`,
+  `alert_log.append_suppressed_entry()`). Fuer Vorhersage-Aenderungsalarm und amtliche
+  Warnung bleibt die Luecke unveraendert offen. Kein Code in dieser Spec geaendert,
+  Vorbehalt (Epic #1458 Scheibe 2) bleibt bestehen.
 - 2026-08-02: Initial spec created (Issue #1459, Epic #1458 Scheibe 1)
 - 2026-08-02: D4 ergaenzt (Nachbesserung Team-Lead/PO) — zweiter Top-Level-Key
   `not_delivered` verhindert, dass komplette Nicht-Zustellungen die Cockpit-Kachel oder

--- a/docs/specs/modules/rework_1467_s3_nowcast.md
+++ b/docs/specs/modules/rework_1467_s3_nowcast.md
@@ -1,0 +1,477 @@
+---
+entity_id: rework_1467_s3_nowcast
+type: refactor
+created: 2026-08-08
+updated: 2026-08-08
+status: draft
+version: "1.0"
+tags: [alerts, trip, compare, epic-1458, issue-1467, s3, nowcast]
+---
+
+# Nowcast-Alarm: gemeinsame Freigabe-Steuerung für Trip und Ortsvergleich (Issue #1467 Scheibe S3, Epic #1458 Teil 2)
+
+## Approval
+
+- [x] Approved — PO-„go" 2026-08-08 (Beleg: Issue-Kommentar zu #1467)
+
+## Purpose
+
+Der Ortsvergleich-Nowcast-Alarm (Regen-/Gewitter-Onset, `compare_radar_alert.py`) läuft
+heute an drei Stellen unbegründet anders als sein Trip-Gegenstück
+(`trip_alert.py::check_radar_alerts`): er kennt **keine Tages-Obergrenze** (die Bremse gegen
+Meldungsfluten fehlt vollständig), führt seine Sperrzeit in einer **eigenen, ungesicherten
+Datei** (`compare_radar_alert_throttle.json`, kein Lock, kein atomarer Write) statt im
+geteilten `ThrottleStore`, und prüft die Ruhezeit **nach** statt vor dem Wetterabruf.
+
+Diese Scheibe zieht beide Nowcast-Pfade — Trip UND Ortsvergleich — auf einen gemeinsamen
+Freigabe-Baustein (`src/services/alert_gate.py`) mit fester Reihenfolge Ruhezeit → Sperrzeit
+→ Tages-Obergrenze. Nutzersichtbarer Gewinn: der Ortsvergleich-Nowcast bekommt die
+Tages-Obergrenze, teilt sich die Sperrzeit-Ablage mit dem Trip-Pfad, und beide Pfade
+protokollieren künftig, WARUM ein Nowcast-Alarm unterdrückt wurde (Ruhezeit/Sperrzeit/
+Tageslimit) — eine seit #1459 vorbereitete, aber bis heute nie geschriebene Information im
+Alarm-Protokoll (PO-Entscheidung 2026-08-08).
+
+Sie ist die **dritte** von vier Scheiben in #1467 (S1 live, S2 vollständig live) und betrifft
+ausschließlich den Nowcast-Pfad. Der Δ-Wetter-Pfad (S2) und die amtliche Warnung (S4) werden
+**nicht** angefasst.
+
+**Leitsatz, unverändert aus S1/S2 übernommen:** Der gefährlichste Fehler ist der ausbleibende
+Alarm. Zielmarke ist „Verhalten unverändert", außer den ausdrücklich in dieser Spec benannten
+Änderungen — hier: Tages-Obergrenze (neu, wirksam), geteilte Sperrzeit-Ablage, vorgezogene
+Ruhezeit-Prüfung, Unterdrückungs-Protokollierung.
+
+## Source
+
+- **File:** `src/services/compare_radar_alert.py`
+- **Identifier:** `class CompareRadarAlertService`, Methode `_check_one_preset()`
+
+Betroffene Schicht: ausschließlich **Python-Core** (`src/services/`). Kein Go-Code, kein
+Frontend-Code — belegt: kein Treffer für `compare_radar_alert`/`radar_alert_throttle` in
+`internal/` oder `frontend/src/`.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `rework_1467_s2_aenderungsalarm` | module | Vorgänger-Scheibe (live) — liefert `compare_alert_guard.is_silenced`, `compare_alert_channels.effective_compare_channels`, beide bereits an dieser Datei verdrahtet und in dieser Scheibe unangetastet |
+| `rework_1467_s1_alarm_kennung` | module | `entity_id`/`entity_type` in `alert_log.append_entry()` sind hier bereits Pflicht |
+| `ThrottleStore` | module | Zielspeicher der Sperrzeit — neuer Scope `compare_radar` |
+| `alert_daily_limit` | module | Tages-Obergrenze, geteilter Zähler über alle Trips/Presets und Alarm-Gründe |
+| `fix_1555_nowcast_alert_priority` | module | Reserve-Mechanik `_FORECAST_CHANGE_RESERVE` — Vorrang-Schutz, den der Ortsvergleich-Nowcast erben MUSS |
+| `DeviationAlertEngine` | module | `is_quiet_hours()` — geteilte Ruhezeit-Prüfung, wird vom neuen Baustein unverändert durchgereicht |
+| `fix_1479_ruhezeit_wurzel` | module | AC-11 dort: kein eigenes `try/except` um `is_quiet_hours()` in `compare_radar_alert.py` |
+| `AlertStateService` | module | Melde-Gedächtnis je Ort — unverändert |
+| `feat_1459_alert_protokoll` | module | Protokoll-Format; `REASON_QUIET_HOURS`/`REASON_DAILY_LIMIT`/`REASON_COOLDOWN` werden hier erstmals scharf geschaltet |
+| `NotificationService` | module | Kanal-Fan-out — unverändert |
+
+## Estimated Scope
+
+- **LoC:** ~180–240 Produktivcode (Baustein `alert_gate.py` ~70–90, Compare-Umbau netto
+  ~+20–40, Trip-Umbau netto ~−10, Unterdrückungs-Protokollierung ~+30–50, Docstring-Ergänzung
+  `throttle_store.py` ~2). Passt unter das 250er-Budget, liegt aber nah an der Grenze.
+  **Rückfallebene, falls es eng wird:** die Unterdrückungs-Protokollierung (d) wird als
+  eigener, unmittelbar folgender Arbeitsgang ausgeliefert — nicht der Kern (a)/(b)/(c), der
+  die eigentliche Verhaltensangleichung trägt.
+- **Files:** 1 neu (`alert_gate.py`), 3 Produktiv geändert
+  (`compare_radar_alert.py`, `trip_alert.py`, `throttle_store.py`-Docstring), ~5 Testdateien
+  geändert/neu, 1 ADR-Nachtrag.
+- **Effort:** high — ein Baustein mit zwei Verbrauchern, hohes Regressionsrisiko.
+- **Risiko:** HOCH — jeder Fehler im Baustein unterdrückt *alle* Nowcast-Alarme beider Pfade
+  (Trip und Ortsvergleich gleichzeitig). Genau die Bugklasse, gegen die der `ThrottleStore`
+  einst gebaut wurde.
+
+## Ist-Stand (gemessen 2026-08-08)
+
+| | Trip (`trip_alert.py:701-938`) | Ortsvergleich (`compare_radar_alert.py:85-178`) |
+|---|---|---|
+| **Reihenfolge** | Ruhezeit → Sperrzeit → **Tageslimit** → Abruf → Erkennung | Riegel (Pausiert/Archiviert) → Sperrzeit → **Abruf + Erkennung** → Ruhezeit |
+| **Sperrzeit** | `ThrottleStore`, Scope `"radar"`, Key `trip.id`, `fcntl`-Lock, atomar | eigene Datei `compare_radar_alert_throttle.json`, flaches `{preset_id: iso}`, **kein Lock, kein atomarer Write** |
+| **Tages-Obergrenze** | `is_allowed(…, reason="nowcast")`, `increment()` nach Zustellung | **fehlt vollständig** — Modul nicht importiert |
+| **Unterdrückungs-Protokoll** | keins | keins |
+
+Bereits geteilt und **nicht** Gegenstand dieser Scheibe: `is_silenced` (Pausiert/Archiviert-
+Riegel, S2 AG6), `effective_compare_channels` (S2 AG1), `radar_alert_due`,
+`DeviationAlertEngine.is_quiet_hours`, `AlertStateService`, `alert_log.append_entry`
+(`entity_id`/`entity_type` seit S1), `NotificationService.send_multi_location_radar_alert`,
+Dringlichkeit + Kanal-Schwelle (#1461 S3a/S3b).
+
+## Implementation Details
+
+### Ein geteilter Freigabe-Baustein, von Anfang an mit beiden Nowcast-Pfaden verdrahtet
+
+Neues Modul `src/services/alert_gate.py`. Vorgeschlagene, in der Umsetzung präzisierbare
+Schnittstelle:
+
+```
+class GateResult(NamedTuple):
+    allowed: bool
+    reason: Optional[str]   # REASON_QUIET_HOURS | REASON_COOLDOWN | REASON_DAILY_LIMIT
+
+def check_nowcast_gate(*, user_id, throttle_scope, throttle_key, cooldown_minutes,
+                       quiet_from, quiet_to, context_label, now,
+                       daily_limit_reason="nowcast", throttle_store=None) -> GateResult
+
+def record_nowcast_sent(*, user_id, throttle_scope, throttle_key, now,
+                        throttle_store=None) -> None
+```
+
+Feste, in dieser Reihenfolge geprüfte Abfolge — 1:1 nach der Trip-Vorlage
+(`trip_alert.py:748-765`): **Ruhezeit → Sperrzeit → Tages-Obergrenze**, Abbruch beim ersten
+Treffer. `check_nowcast_gate` reicht `is_quiet_hours` **unverändert durch** — kein eigenes
+`try/except` um den Aufruf (`fix_1479_ruhezeit_wurzel` AC-11, AST-Wächter
+`tests/tdd/test_alert_quiet_hours_robustness.py`). `record_nowcast_sent` bündelt
+`ThrottleStore.record()` und `alert_daily_limit.increment()` und wird **ausschließlich nach
+erfolgreicher Zustellung** gerufen — genau wie heute an beiden Bestandsstellen
+(`trip_alert.py:930/935`, `compare_radar_alert.py:175-177`).
+
+**Warum beide Verbraucher sofort, nicht erst der Ortsvergleich:** ein Baustein mit genau
+einem Aufrufer ist keine Entdopplung, sondern eine dritte Fassung derselben Abfolge — das
+Issue-Ziel lautet Zusammenlegen, nicht Danebenlegen. Hausmuster S2 AG1: dort wurden beide
+Bestandsstellen des Kanal-Resolvers sofort zu dünnen Wrappern, der Trip-Radar-Zweig verliert
+netto ~18 Zeilen Inline-Logik.
+
+### (a) Tages-Obergrenze
+
+`compare_radar_alert.py::_check_one_preset` ruft `check_nowcast_gate(..., daily_limit_reason=
+"nowcast")` — exakt dieselbe Prüfung wie der Trip-Nowcast. Der Ortsvergleich erbt damit den
+Vorrang-Schutz aus #1555: `alert_daily_limit.is_allowed(..., reason="nowcast")` prüft gegen
+das **volle** Limit, die Reserve (`_FORECAST_CHANGE_RESERVE`) kappt ausschließlich
+`reason="forecast_change"`. Ein Compare-eigener Grund (z. B. `"compare_nowcast"`) würde diesen
+Schutz still verlieren — das ist die gefährlichste Falle dieser Scheibe (Randbedingung 5,
+eigenes AC).
+
+### (b) Geteilte Sperrzeit statt eigene Datei
+
+Neuer Scope `"compare_radar"` im `ThrottleStore`, Schlüssel = `preset_id`.
+
+- **Nicht `"radar"`**: dieser Scope ist ausschließlich mit **Trip**-IDs belegt. Seit dem
+  #1250-Cutover liegen Trips und Ortsvergleiche im selben Verzeichnis `briefings/<id>.json`,
+  unterschieden nur durch `kind`; IDs sind frei gewählte Slugs, keine UUIDs ⇒ Kollision ist
+  real möglich.
+- **Nicht `"compare_preset"`**: dieser Scope ist bereits vom Änderungsalarm (S2) auf
+  **demselben** `preset_id`-Schlüssel belegt. Wiederverwendung würde
+  `tests/tdd/test_alert_log_compare_and_tenancy.py::test_ac12_ortsvergleich_protokolliert_alle_drei_ausloeser`
+  rot machen — dort löst ein Preset im selben Lauf Δ-, Nowcast- und amtlichen Alarm aus und
+  erwartet `(1,1,1)` unabhängig gezählte Alarme.
+
+`compare_radar_alert.py` verliert `_load_throttle_times()`/`_save_throttle_times()` und den
+Konstruktor-Pfad `self._throttle_file`; die Sperrzeit-Prüfung läuft ausschließlich über den
+Baustein.
+
+**Altdaten:** bewusster Verzicht auf Migration. `ThrottleStore._migrate_if_needed()` bricht
+ab, sobald `throttle_state.json` bereits existiert — bei allen drei realen Nutzern der Fall.
+Eine zusätzliche Legacy-Konstante wäre totes Gerüst; der real existierende Alteintrag
+(`henning`, `cp-eb6ba0b239d90e37`, 25.07., längst außerhalb jedes Cooldowns) bleibt in der
+Altdatei liegen und wirkt nicht mehr. Die Altdatei wird nicht mehr geschrieben und nicht
+gelöscht.
+
+### (c) Ruhezeit vor Datenbeschaffung
+
+Die Ruhezeit-Prüfung (heute `compare_radar_alert.py:117-124`, NACH
+`_detect_triggered_locations()`) wandert in den Baustein und läuft damit VOR dem Nowcast-Abruf
+— Muster `compare_official_alert.py:105-113`. Das Meldeverhalten bleibt gleich: in beiden
+Fällen (alt: nach Erkennung unterdrückt, neu: vor Abruf gar nicht erst geprüft) geht während
+der Ruhezeit kein Alarm raus. Was sich ändert, ist ausschließlich der Kontingentverbrauch —
+und auch das nur bedingt (s. Known Limitations).
+
+**Zwei archivierte Zusicherungen werden dadurch abgelöst** und fallen mit dieser Scheibe:
+`docs/specs/_archive/modules/issue_1041b_compare_radar_alert_service.md` AC-5 und
+`docs/specs/_archive/modules/issue_1041_compare_radar_alert.md` AC-6 sichern „wird der Onset
+erkannt, der Alarm aber unterdrückt" zu. Mit dem Vorziehen kann während der Ruhezeit kein
+Onset mehr erkannt werden — die Ablösung ist beabsichtigt und hier dokumentiert (Archivablage
+sagt nichts über Gültigkeit; die Umkehrung ist eine bewusste Entscheidung dieser Scheibe).
+
+### (d) Unterdrückungen protokollieren (PO-Entscheidung 2026-08-08)
+
+Wird ein Nowcast-Lauf (Trip ODER Ortsvergleich) für eine Entität vom Baustein an einer der
+drei Stufen abgewiesen (`GateResult.allowed == False`), entsteht dafür GENAU EIN Eintrag im
+Alarm-Protokoll mit dem entsprechenden Grund — unabhängig davon, ob zum Zeitpunkt der
+Abweisung überhaupt ein Onset vorläge (das ist zu diesem Zeitpunkt strukturell noch nicht
+bekannt, da die Erkennung erst nach dem Gate läuft, s. (c)). Die drei Konstanten
+`REASON_QUIET_HOURS`, `REASON_COOLDOWN`, `REASON_DAILY_LIMIT` (`alert_log.py:47-49`) sind seit
+#1459 dokumentiert, aber repo-weit unbenutzt — diese Scheibe schaltet sie erstmals scharf.
+
+**Geltungsbereich strikt auf die beiden Nowcast-Pfade begrenzt:** `trip_alert.py::
+check_radar_alerts` und `compare_radar_alert.py::_check_one_preset`. Der Vorhersage-
+Änderungsalarm (S2) und die amtliche Warnung (S4) protokollieren Unterdrückungen weiterhin
+NICHT — das bleibt eine offene Lücke dort (dokumentiert in `feat_1459_alert_protokoll.md`
+Known Limitations, Punkt O3) und wird durch diese Scheibe nicht geschlossen.
+
+Der bestehende Schreibpfad `alert_log.append_entry()` ist auf tatsächliche Zustellversuche
+zugeschnitten (`changes_count`, `severity`, `metrics`, Kanal-Aufschlüsselung nach Zustellung)
+und passt nicht 1:1 auf eine Vor-Abruf-Abweisung, bei der weder Schweregrad noch betroffene
+Metrik bekannt sind. Die Umsetzung ergänzt `alert_log.py` um einen zweiten, schlanken
+Schreibpfad für genau diesen Fall (alle `effective_channels` der Entität erhalten denselben
+Gate-Grund als `channels_not_sent`-Eintrag, Ziel-Liste `not_delivered` — Go liest diese
+Liste ohnehin nicht, Cockpit-Kachel und Archiv-Statistik bleiben unverändert). Die genaue
+Funktionssignatur ist Implementierungsdetail; verbindlich ist die beobachtbare Wirkung in den
+Acceptance Criteria.
+
+## Invarianten
+
+- **Der gefährlichste Fehler ist der ausbleibende Alarm.** Zielmarke: Verhalten unverändert
+  außer den ausdrücklich benannten Punkten (a)–(d).
+- **Reihenfolge im Baustein ist fest:** Ruhezeit → Sperrzeit → Tages-Obergrenze, Abbruch beim
+  ersten Treffer.
+- **Zähler-Reihenfolge:** `record_nowcast_sent()` (bündelt `increment()` + `record()`) läuft
+  NIEMALS vor der erfolgreichen Zustellung.
+- **Vorrang-Schutz aus #1555 bleibt erhalten:** der Ortsvergleich-Nowcast prüft mit
+  `reason="nowcast"` gegen das volle Tageslimit, nie gegen ein Compare-eigenes, reduziertes
+  Limit.
+- Mandantentrennung: jeder Teil mit ZWEI verschiedenen Nutzern verifiziert, `user_id` nie auf
+  `"default"` zurückfallen lassen.
+- Datenbeschaffung wird NICHT fusioniert — Trip und Ortsvergleich holen weiterhin getrennt
+  Wetter.
+- Bestandsdaten: Read-Modify-Write mit Merge, nie Replace.
+- Testpolitik: kein Mock-Theater, keine Dateiinhalt-Checks als Verhaltensnachweis.
+- Testdateien nach VERHALTEN benennen, nie nach Issue-Nummer.
+
+## Nicht-Ziele / bewusst unverändert
+
+- **#1594 (nächster geplanter Versandzeitpunkt) wird NICHT mitgebaut.** Der Freigabe-Baustein
+  ist der spätere Andockpunkt, liefert diese Information in dieser Scheibe aber noch nicht.
+- **Datenbeschaffung wird nicht fusioniert** — Trip und Ortsvergleich holen weiterhin über
+  getrennte Aufrufe Wetter.
+- **Vorhersage-Änderungsalarm (S2) und amtliche Warnung (S4) bleiben unberührt** — insbesondere
+  bekommen sie durch diese Scheibe KEINE Unterdrückungs-Protokollierung (Geltungsbereich von
+  (d) ist strikt auf die beiden Nowcast-Pfade begrenzt).
+- **Keine Migration der Altdatei** `compare_radar_alert_throttle.json` — sie bleibt
+  unangetastet liegen, wird aber nicht mehr geschrieben oder gelesen.
+- **Handversand-Sonderregeln unverändert.** `compare_radar_alert.py` hat keinen eigenen
+  Handversand-Endpunkt (anders als der Δ-Wetter-Pfad, S2 AG5) — diese Scheibe führt keinen ein
+  und ändert am `on_demand`-Konzept nichts.
+- **Kein neuer Go-Endpunkt, kein neuer Cron-Job** — `api/routers/scheduler.py:80-97` und
+  `internal/scheduler/scheduler.go:305-324` bleiben unangetastet.
+- **Kein Frontend-Code.**
+
+## Risiken
+
+| | Risiko | Test, der es fängt |
+|---|---|---|
+| **R1** | Fehler im Baustein unterdrückt alle Nowcast-Alarme beider Pfade gleichzeitig (Trip UND Ortsvergleich) — die Bugklasse, gegen die der `ThrottleStore` einst gebaut wurde | AC-11 (Reihenfolge), AC-16 (Trip-Zustellverhalten unverändert), Gate-Stufen einzeln bewacht |
+| **R2** | Ein Compare-eigener Tageslimit-Grund verliert still den #1555-Vorrang-Schutz | AC-12 |
+| **R3** | `increment`/`record` vor statt nach der Zustellung bucht fehlgeschlagene Versuche als verbraucht | AC-13 |
+| **R4** | Scope-Kollision bei falscher Schlüsselwahl (`"radar"` oder `"compare_preset"` statt `"compare_radar"`) | AC-14 (Scope-Trennung, Bestandswächter `test_ac12_…`) |
+| **R5** | Ruhezeit-Vorziehen kippt zwei archivierte ACs (#1041/#1041b) unbemerkt — Meldeverhalten muss gleich bleiben | AC-5 |
+| **R6** | Struktur-Wächter (`tests/test_success_status_guard.py`, `tests/test_resolution_loss_guard.py`) verankern `compare_radar_alert.py` per Ordinal — ein zusätzlicher Riegel verschiebt die Zählung | Wächter-Lauf nach der Umsetzung; bei Verschiebung Ordinal-Schlüssel nachziehen, Wächter nicht aufweichen |
+| **R7** | Mandantentrennung — Zähler/Sperrzeit unter `data/users/<user_id>/` müssen strikt getrennt bleiben | AC-15 |
+| **R8** | Bestandstests (`test_data_root_migration_services.py`, `test_compare_radar_alert.py` AC-7) messen an der abgelösten Datei und werden ohne Anpassung fälschlich rot | Messpunkt wandert auf `throttle_state.json`, Zusicherung bleibt inhaltlich erhalten |
+
+## Test-Plan
+
+Kern-Schicht (deterministisch, kein Netz) sofern nicht anders vermerkt.
+
+| AC | Datei | Schicht |
+|---|---|---|
+| AC-1 (a) | `tests/tdd/test_compare_radar_alert_daily_limit.py` (neu) | Kern |
+| AC-2, AC-3 (b) | `tests/tdd/test_compare_radar_alert_shared_throttle.py` (neu) | Kern |
+| AC-4, AC-5 (c) | `tests/tdd/test_compare_radar_alert_quiet_hours_precedes_fetch.py` (neu, Muster analog S2 AG2) | Kern |
+| AC-6, AC-7, AC-8, AC-9 (d, Ortsvergleich + Geltungsbereich) | `tests/tdd/test_nowcast_suppression_logging.py` (neu) | Kern |
+| AC-10 (d, Trip) | `tests/tdd/test_nowcast_suppression_logging.py` (neu, gleiche Datei, Trip-Fälle) | Kern |
+| AC-11 (Reihenfolge) | `tests/tdd/test_alert_gate.py` (neu) | Kern |
+| AC-12 (Vorrang-Schutz) | `tests/tdd/test_alert_gate.py` (neu) | Kern |
+| AC-13 (Zähler-Invariante) | `tests/tdd/test_alert_gate.py` (neu) | Kern |
+| AC-14 (Scope-Trennung) | `tests/tdd/test_alert_log_compare_and_tenancy.py` (Bestand, MUSS unverändert grün bleiben) | Kern |
+| AC-15 (Mandantentrennung) | `tests/tdd/test_alert_gate.py` (neu, zwei Nutzer-Kontexte) | Kern |
+| AC-16 (Trip-Zustellverhalten unverändert) | `tests/tdd/test_trip_radar_nowcast_gate_migration.py` (neu) | Kern |
+| Pflicht-Nachzug (kein eigenes AC) | `tests/tdd/test_data_root_migration_services.py:74-82` (Messpunkt `throttle_state.json` statt `compare_radar_alert_throttle.json`) | Kern |
+| Pflicht-Nachzug (kein eigenes AC) | `tests/tdd/test_compare_radar_alert.py:688-693` (AC-7 dort, Messpunkt gewandelt) | Kern |
+| Regression | `tests/test_success_status_guard.py`, `tests/test_resolution_loss_guard.py` gezielt laufen lassen; bei Ordinal-Verschiebung Schlüssel nachziehen | Kern |
+
+Live-E2E: keine eigenen Live-Marker-Tests vorgesehen — Nowcast ist live schwer provozierbar
+(echter Regen-/Gewitter-Onset ≤20 Min, R6 aus der Analyse). Staging-Nachweis erfolgt über den
+ausgelieferten Code + gezielt gesetzte Zustandsdateien (Rezept aus S2 AG5/AG6), nicht über
+„auf Regen warten".
+
+## Acceptance Criteria
+
+**(a) Tages-Obergrenze**
+
+- **AC-1:** Given ein Ortsvergleich-Nutzer, dessen Tages-Obergrenze für Alarme bereits erreicht
+  ist (z. B. durch zwei vorangegangene Alarme desselben Tages), When für ein Preset dieses
+  Nutzers ein Nowcast-Onset eintritt, Then wird KEIN Nowcast-Alarm für den Ortsvergleich
+  versendet — vor dieser Scheibe wäre er versendet worden, da keine Tages-Obergrenze geprüft
+  wurde.
+  - Test: Tageszähler auf das Limit vorbelegen, Onset-Bedingung erfüllen, keine Zustellung auf
+    keinem Kanal, Protokoll bleibt ohne neuen Zustellungs-Eintrag.
+
+**(b) Geteilte Sperrzeit**
+
+- **AC-2:** Given ein Ortsvergleich-Preset, dessen letzter Nowcast-Alarm vor Kurzem über den
+  geteilten `ThrottleStore` (Scope `compare_radar`) vermerkt wurde und dessen Cooldown noch
+  läuft, When ein erneuter Onset für dasselbe Preset eintritt, Then bleibt der Alarm
+  unterdrückt — die Sperrzeit wirkt aus dem geteilten Speicher, nicht mehr aus einer
+  presetseigenen Datei.
+  - Test: Eintrag über `ThrottleStore.record("compare_radar", preset_id, …)` setzen, Onset
+    auslösen, keine Zustellung.
+
+- **AC-3:** Given ein Eintrag ausschließlich in der alten Datei
+  `compare_radar_alert_throttle.json` (kein entsprechender Eintrag im `ThrottleStore`), When
+  ein Onset für dasselbe Preset eintritt, Then wird der Alarm zugestellt — die Altdatei
+  entfaltet keine Sperrwirkung mehr, wie bewusst entschieden (kein Migrationsmechanismus).
+  - Test: Alte Datei mit frischem Sperrzeit-Eintrag vorbelegen, `ThrottleStore` leer lassen,
+    Onset auslösen, Zustellung erfolgt trotz „alter" Sperre.
+
+**(c) Ruhezeit vor Datenbeschaffung**
+
+- **AC-4:** Given ein Ortsvergleich-Preset mit aktiver Ruhezeit zur aktuellen Ortszeit, When
+  `CompareRadarAlertService.check_all_compare_presets()` läuft, Then wird für keinen Ort
+  dieses Presets ein Nowcast-Abruf (`get_nowcast`) ausgelöst — 0 Aufrufe.
+  - Test: Fetch-Spion (Zähl-Seam) auf den Radar-Service, Aufrufzähler nach dem Lauf bei 0.
+
+- **AC-5:** Given identische Ruhezeit-Bedingungen vor und nach dieser Scheibe, When ein
+  Nowcast-Onset während der Ruhezeit einträte, Then bleibt der Alarm in beiden Fällen
+  gleichermaßen aus — kein Alarm, der vorher unterdrückt wurde, geht jetzt durch, und
+  umgekehrt geht kein zuvor zugestellter Alarm jetzt verloren.
+  - Test: Szenario mit Ruhezeit AUS und Onset ⇒ Zustellung; Szenario mit Ruhezeit AN und
+    identischem Onset ⇒ keine Zustellung — beide Fälle vor und nach dem Umbau identisch.
+
+**(d) Unterdrückungen protokollieren**
+
+- **AC-6:** Given ein Ortsvergleich-Preset, dessen Nowcast-Lauf an der Ruhezeit scheitert,
+  When der Lauf beendet ist, Then enthält das Alarm-Protokoll des Nutzers für dieses Preset
+  einen Eintrag mit dem Unterdrückungs-Grund „Ruhezeit" (`REASON_QUIET_HOURS`).
+  - Test: Ruhezeit erzwingen, Lauf ausführen, `alert_log.json` laden, passenden
+    `not_delivered`-Eintrag mit dem Grund finden.
+
+- **AC-7:** Given ein Ortsvergleich-Preset, dessen Nowcast-Lauf an der Sperrzeit scheitert,
+  When der Lauf beendet ist, Then enthält das Alarm-Protokoll einen Eintrag mit dem
+  Unterdrückungs-Grund „Sperrzeit" (`REASON_COOLDOWN`).
+  - Test: aktiven `ThrottleStore`-Eintrag setzen, Lauf ausführen, Protokoll prüfen.
+
+- **AC-8:** Given ein Ortsvergleich-Nutzer, dessen Tages-Obergrenze erreicht ist, When ein
+  Nowcast-Lauf für ein Preset dieses Nutzers deswegen unterdrückt wird, Then enthält das
+  Alarm-Protokoll einen Eintrag mit dem Unterdrückungs-Grund „Tages-Obergrenze"
+  (`REASON_DAILY_LIMIT`).
+  - Test: Tageszähler auf Limit vorbelegen, Lauf ausführen, Protokoll prüfen.
+
+- **AC-9:** Given ein Vorhersage-Änderungsalarm oder ein amtlicher Alarm, der durch Ruhezeit,
+  Sperrzeit oder Tages-Obergrenze unterdrückt wird, When der jeweilige Lauf beendet ist, Then
+  entsteht dafür KEIN Protokolleintrag mit den drei neuen Unterdrückungsgründen — der
+  Geltungsbereich dieser Scheibe bleibt strikt auf die beiden Nowcast-Pfade begrenzt.
+  - Test: Δ-Wetter-Lauf bzw. amtlicher Lauf mit erzwungener Unterdrückung, Protokoll enthält
+    keinen neuen Eintrag mit `quiet_hours`/`cooldown`/`daily_limit` als Grund aus diesen Pfaden.
+
+- **AC-10:** Given ein Trip, dessen Nowcast-Lauf an Ruhezeit, Sperrzeit oder Tages-Obergrenze
+  scheitert, When der Lauf beendet ist, Then enthält das Alarm-Protokoll — anders als vor
+  dieser Scheibe — einen Eintrag mit dem jeweiligen Unterdrückungs-Grund. Der Trip-Nowcast-Pfad
+  bekommt die Protokollierung gleichermaßen wie der Ortsvergleich.
+  - Test: je eine der drei Bedingungen erzwingen, `check_radar_alerts()` laufen lassen,
+    Protokoll prüfen.
+
+**Reihenfolge, Vorrang-Schutz, Zähler-Invariante**
+
+- **AC-11:** Given eine Konstellation, in der sowohl Ruhezeit als auch Sperrzeit gleichzeitig
+  zuträfen, When der Freigabe-Baustein geprüft wird, Then stoppt der Ablauf an der Ruhezeit —
+  die Sperrzeit-Prüfung wird für diesen Aufruf nicht erreicht (nachgewiesen über einen
+  Aufrufzähler auf der Sperrzeit-Prüfung).
+  - Test: Ruhezeit AN + Sperrzeit-Bedingung erfüllt, Aufrufzähler der Sperrzeit-Prüfung bleibt
+    bei 0.
+
+- **AC-12:** Given einen Ortsvergleich-Nutzer mit endlichem Tageslimit, dessen Restbudget nur
+  noch innerhalb der #1555-Reserve für `reason="forecast_change"` liegt (z. B. Limit 2,
+  Reserve 1, ein Platz belegt), When ein Ortsvergleich-Nowcast-Onset eintritt, Then wird der
+  Nowcast-Alarm trotzdem zugestellt — der Ortsvergleich-Nowcast prüft wie der Trip-Nowcast
+  gegen das VOLLE Tageslimit, nicht gegen ein durch die Reserve reduziertes.
+  - Test: Tier mit Limit 2 (Reserve 1), einen Alarm-Slot verbrauchen, Ortsvergleich-Nowcast
+    auslösen, Zustellung erfolgt trotz „nur noch Reserve-Platz frei".
+
+- **AC-13:** Given einen Nowcast-Alarm-Versuch, bei dem die tatsächliche Zustellung fehlschlägt
+  (kein Kanal erreichbar), When der Lauf beendet ist, Then sind weder der Sperrzeit-Eintrag im
+  `ThrottleStore` noch der Tageszähler für diese Entität erhöht worden.
+  - Test: alle Kanäle unerreichbar simulieren, Onset auslösen, Zähler-Snapshot vor/nach dem
+    Lauf vergleichen — exakte Gleichheit.
+
+**Scope-Trennung, Mandantentrennung, Trip-Unveränderlichkeit**
+
+- **AC-14:** Given ein Ortsvergleich-Preset, das im selben Lauf einen Änderungsalarm, einen
+  Nowcast-Alarm und einen amtlichen Alarm auslöst, When alle drei Checker nacheinander laufen,
+  Then werden alle drei unabhängig gezählt — keiner unterdrückt fälschlich einen anderen über
+  eine geteilte Sperrzeit-Ablage.
+  - Test: `tests/tdd/test_alert_log_compare_and_tenancy.py::
+    test_ac12_ortsvergleich_protokolliert_alle_drei_ausloeser` bleibt nach dem Umbau
+    unverändert grün, Ergebnis weiterhin `(1, 1, 1)`.
+
+- **AC-15:** Given zwei verschiedene Nutzer mit je einem Ortsvergleich-Preset gleicher
+  Kennung, deren Sperrzeit- und Tageslimit-Zustand unabhängig geführt wird, When beide
+  unabhängig voneinander einen Nowcast-Onset auslösen, Then wirkt weder die Sperrzeit noch das
+  Tageslimit des einen Nutzers auf den anderen.
+  - Test: zwei Datenverzeichnisse (`user_id` A/B), gleiche Preset-Kennung, Onset für A
+    unterdrückt Alarm für A, Alarm für B geht trotzdem durch.
+
+- **AC-16:** Given den Trip-Radar-Nowcast-Pfad, When identische Szenarien (Ruhezeit an/aus,
+  Sperrzeit an/aus, Tageslimit erreicht/nicht erreicht, jeweils mit auslösendem Onset) vor und
+  nach dem Umklemmen auf den geteilten Baustein durchlaufen werden, Then bleibt die
+  Zustellentscheidung (versendet ja/nein, welcher Kanal) in jedem Szenario identisch zum Stand
+  vor dieser Scheibe — einzige neue Wirkung für den Trip ist die Protokollierung aus (d),
+  AC-10.
+  - Test: Szenario-Matrix (4 Kombinationen) vor/nach dem Umbau vergleichen, Zustellergebnis je
+    Szenario bit-identisch.
+  - Mutations-Gegenprobe (Pflicht): Reihenfolge im Baustein vertauschen (Sperrzeit vor
+    Ruhezeit) · `record_nowcast_sent` vor statt nach der Zustellung aufrufen · Scope
+    `compare_radar` durch `radar` ersetzen — jede dieser drei Verfälschungen MUSS mindestens
+    einen der obigen Tests rot machen.
+
+## Known Limitations
+
+**Nachtrag nach der RED-Phase (2026-08-08, am Ist-Code gemessen — ändert kein AC):**
+
+- **Ein Preset ohne jeden aktiven Kanal bekommt auch keinen Unterdrückungs-Eintrag.**
+  `alert_log.append_entry()` steigt bei leerem `effective_channels` wortlos aus
+  (`alert_log.py:190-192`). Das ist Bestandsverhalten und bleibt so; für (d) heißt es, dass die
+  Frage „warum kam kein Alarm?" für ein kanalloses Preset weiterhin unbeantwortet bleibt.
+- **Die Kanalauflösung muss für (d) vorgezogen werden.** `effective_compare_channels()` steht
+  heute erst **nach** der Erkennung (`compare_radar_alert.py:133`), der Unterdrückungs-Eintrag
+  braucht die Kanäle aber bereits am Gate. Die Funktion ist rein und nebenwirkungsfrei, das
+  Vorziehen ist gefahrlos — es ist aber eine bewusste Änderung, keine Nebensache.
+- **Im Nowcast-Pfad entstehen zwei Sorten `not_delivered`-Einträge.** Schon heute schreibt der
+  Compare-Nowcast bei gescheiterter Zustellung einen Eintrag mit `reason="nowcast"`, weil der
+  `append_entry`-Aufruf vor dem `notif_result.sent`-Guard steht. Die neuen Gate-Einträge sind
+  davon strikt zu unterscheiden (Filter auf die drei Gate-Konstanten).
+- **Risiko R3 der Analyse ist gegenstandslos:** `_finalize_triggered_state()` (Melde-Gedächtnis)
+  wird auch heute nur nach erfolgreicher Zustellung gerufen — das Vorziehen der Ruhezeit hat
+  darauf keinen Seiteneffekt. Gemessen, nicht angenommen.
+
+- **Tages-Obergrenze wirkt nicht für `tier: premium`.** `daily_alert_limit()` liefert dort
+  `None`, `is_allowed()` gibt dann immer `True` zurück. Von den drei realen Konten ist eines
+  premium — für dieses Konto bleibt der Nowcast-Alarmfluss unbegrenzt, wie beim Trip-Pfad
+  auch.
+- **Die Kontingent-Ersparnis von (c) tritt nur bei einem echten Cache-Fehltreffer im
+  open-meteo-Zweig ein.** `get_nowcast` trifft häufig den geteilten Cache (TTL 300 s) — ein
+  Treffer kostet ohnehin nichts. RADOLAN/INCA/DPC sind ungegatet. Die messbare Wirkung von (c)
+  ist damit primär das unveränderte Meldeverhalten, die Kontingent-Ersparnis ein Nebeneffekt
+  mit begrenzter Reichweite.
+- **Ein Rückbau der Entdopplung (Baustein → wieder zwei getrennte Fassungen) ist mit
+  Verhaltenstests grundsätzlich nicht fangbar** — beide Fassungen könnten sich weiterhin
+  identisch verhalten. Der strukturelle Schutz liegt außerhalb dieser Spec (Code-Review,
+  Pendant-Gate #1481 B greift hier nicht, da kein neues einseitiges Compare-/Trip-Verzeichnis
+  entsteht).
+- **Altdaten der abgelösten Datei bleiben dauerhaft ungenutzt liegen.** Kein Löschen, keine
+  Migration — der einzige reale Alteintrag (`henning`, 25.07.) ist längst außerhalb jedes
+  Cooldowns und damit folgenlos.
+- **#1594 (nächster geplanter Versandzeitpunkt) bleibt offen.** Der Baustein ist der spätere
+  Andockpunkt, liefert diese Information noch nicht.
+- **Struktur-Wächter können nach der Umsetzung nachzuziehen sein** — `compare_radar_alert.py`
+  ist per `datei::funktion::ordinal` in `tests/test_success_status_guard.py` und
+  `tests/test_resolution_loss_guard.py` verankert; verschiebt der Baustein-Aufruf die
+  Ordinal-Zählung, sind die Wächter-Schlüssel anzupassen, nicht die Wächter selbst
+  aufzuweichen.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue — ADR-0021 (geteilter Auswertungskern) bekommt einen **Nachtrag**.
+  Dessen bisheriger Satz „Tageslimit … bleiben unverändert Trip-spezifisch (kein
+  Compare-Bedarf bekannt)" ist durch diese Scheibe sachlich überholt und wird auf „Tageslimit
+  gilt seit #1467 S3 gemeinsam für Trip- und Ortsvergleich-Nowcast, über den geteilten
+  Freigabe-Baustein `alert_gate.py`" fortgeschrieben.
+- **Rationale:** Die Ablaufsteuerung bleibt im Muster von ADR-0021 — Ortsvergleich zieht an
+  den bestehenden Trip-Ablauf heran, ergänzt um einen echten Sammelbaustein, statt eine
+  Compare-eigene Zweitfassung fortzuführen. Kein neues Architekturprinzip, nur konsequente
+  Anwendung des bestehenden auf den letzten noch abweichenden Pfad.
+
+## Changelog
+
+- 2026-08-08: Initiale Spec. Vier Änderungen (a)–(d) nach PO-Entscheidungen E1–E4
+  (`docs/context/rework-1467-s3-nowcast.md`) zugeschnitten, geteilter Baustein von Anfang an
+  mit beiden Nowcast-Pfaden verdrahtet (Abweichung von der Strategie-Agent-Empfehlung, Analyse
+  E1). Zeilenangaben gegen den Ist-Stand vom 2026-08-08 verifiziert.

--- a/src/services/alert_gate.py
+++ b/src/services/alert_gate.py
@@ -1,0 +1,124 @@
+"""Geteilte Freigabe-Steuerung des Nowcast-Alarms (Issue #1467 Scheibe S3).
+
+SPEC: docs/specs/modules/rework_1467_s3_nowcast.md
+
+EIN Baustein fuer BEIDE Nowcast-Pfade — den Trip-Radar-Zweig
+(`trip_alert.py::check_radar_alerts`) und den Vergleichs-Nowcast
+(`compare_radar_alert.py::_check_one_preset`). Vorlage ist die bisherige
+Inline-Kette des Trip-Pfads (`trip_alert.py:748-765`); der Vergleichs-Pfad
+zieht damit an sie heran, statt eine zweite, unvollstaendige Fassung
+weiterzufuehren (ADR-0021, Trip/Vergleich-Teilungsregel).
+
+Feste Reihenfolge, Abbruch bei der ERSTEN zutreffenden Stufe:
+
+    Ruhezeit  ->  Sperrzeit  ->  Tages-Obergrenze
+
+Die Reihenfolge ist Teil der Zusicherung, nicht Geschmack: die Ruhezeit ist
+die billigste Pruefung und die einzige, die auch dann gilt, wenn gar kein
+Alarm anstuende; die Tages-Obergrenze ist die teuerste (Dateizugriff auf den
+Zaehler). Alle drei laufen VOR der Datenbeschaffung — ein gesperrter Lauf
+kostet damit keinen Nowcast-Abruf mehr.
+
+`is_quiet_hours()` wird UNVERAENDERT durchgereicht: kein eigenes `try/except`,
+kein `contextlib.suppress` an dieser Aufrufstelle. Der Schutz gegen
+unbrauchbare Ruhezeit-Werte lebt ausschliesslich in
+`DeviationAlertEngine.is_quiet_hours()` (fix_1479 AC-11, AST-Waechter
+`tests/tdd/test_alert_quiet_hours_robustness.py`).
+
+`record_nowcast_sent()` buendelt die beiden Buchungen (Tageszaehler +
+Sperrzeit) und wird AUSSCHLIESSLICH nach erfolgreicher Zustellung gerufen —
+ein fehlgeschlagener Versuch darf weder Budget noch Sperrzeit verbrauchen
+(F001-Semantik, unveraendert aus beiden Bestandsstellen uebernommen).
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import NamedTuple, Optional
+
+from services import alert_daily_limit, alert_log
+from services.deviation_alert_engine import DeviationAlertEngine
+from services.throttle_store import ThrottleStore
+
+logger = logging.getLogger("alert_gate")
+
+
+class GateResult(NamedTuple):
+    """Ergebnis der Freigabe-Pruefung.
+
+    `reason` traegt bei einer Abweisung die sperrende Stufe als
+    `alert_log`-Konstante (`REASON_QUIET_HOURS` | `REASON_COOLDOWN` |
+    `REASON_DAILY_LIMIT`) und ist bei einer Freigabe `None`.
+    """
+
+    allowed: bool
+    reason: Optional[str] = None
+
+
+_ALLOWED = GateResult(True, None)
+
+
+def _resolve_store(user_id: str, throttle_store: Optional[ThrottleStore]) -> ThrottleStore:
+    """Uebergebenen Speicher benutzen, sonst einen eigenen oeffnen.
+
+    Der Trip-Pfad haelt seit #1213 ohnehin einen `ThrottleStore` je Service —
+    er reicht ihn durch, statt einen zweiten zu oeffnen (jede Instanz laeuft
+    beim Anlegen durch die Legacy-Migrationspruefung).
+    """
+    return throttle_store if throttle_store is not None else ThrottleStore(user_id)
+
+
+def check_nowcast_gate(
+    *,
+    user_id: str,
+    throttle_scope: str,
+    throttle_key: str,
+    cooldown_minutes: Optional[int],
+    quiet_from: Optional[str],
+    quiet_to: Optional[str],
+    context_label: str,
+    now: datetime,
+    daily_limit_reason: str = "nowcast",
+    throttle_store: Optional[ThrottleStore] = None,
+) -> GateResult:
+    """Darf fuer diese Entitaet jetzt ein Nowcast-Alarm rausgehen?
+
+    `daily_limit_reason` ist mit Bedacht auf `"nowcast"` vorbelegt: nur dieser
+    Grund prueft gegen das VOLLE Tagesbudget. `reason="forecast_change"`
+    prueft gegen ein um die NowCast-Reserve reduziertes Limit (#1555) — ein
+    Compare-eigener Grund waere zwar heute gleichwertig, verloere den Schutz
+    aber still, sobald die Reserve-Tabelle waechst. Beide Nowcast-Pfade
+    benutzen deshalb denselben Grund.
+    """
+    if DeviationAlertEngine.is_quiet_hours(
+        now, quiet_from, quiet_to, context_label=context_label
+    ):
+        logger.debug("Nowcast-Alarm unterdrueckt (Ruhezeit) fuer %s", context_label)
+        return GateResult(False, alert_log.REASON_QUIET_HOURS)
+
+    if _resolve_store(user_id, throttle_store).is_throttled(
+        throttle_scope, throttle_key, cooldown_minutes, now
+    ):
+        logger.debug("Nowcast-Alarm unterdrueckt (Sperrzeit) fuer %s", context_label)
+        return GateResult(False, alert_log.REASON_COOLDOWN)
+
+    if not alert_daily_limit.is_allowed(user_id, now, reason=daily_limit_reason):
+        logger.debug(
+            "Nowcast-Alarm unterdrueckt (Tages-Obergrenze) fuer %s", context_label
+        )
+        return GateResult(False, alert_log.REASON_DAILY_LIMIT)
+
+    return _ALLOWED
+
+
+def record_nowcast_sent(
+    *,
+    user_id: str,
+    throttle_scope: str,
+    throttle_key: str,
+    now: datetime,
+    throttle_store: Optional[ThrottleStore] = None,
+) -> None:
+    """Tageszaehler und Sperrzeit buchen — NUR nach erfolgreicher Zustellung."""
+    alert_daily_limit.increment(user_id, now)
+    _resolve_store(user_id, throttle_store).record(throttle_scope, throttle_key, now)

--- a/src/services/alert_log.py
+++ b/src/services/alert_log.py
@@ -218,7 +218,11 @@ def append_entry(
         ),
     }
 
-    target = "entries" if reachable else "not_delivered"
+    _append(user_id, "entries" if reachable else "not_delivered", entry)
+
+
+def _append(user_id: str, target: str, entry: dict) -> None:
+    """Read-Modify-Write der ganzen Datei; Alt-Eintraege bleiben unangetastet."""
     path = get_data_dir(user_id) / "alert_log.json"
     path.parent.mkdir(parents=True, exist_ok=True)
     try:
@@ -230,6 +234,82 @@ def append_entry(
     data.setdefault(target, [])
     data[target].append(entry)
     path.write_text(json.dumps(data, indent=2))
+
+
+def append_suppressed_entry(
+    user_id: str,
+    *,
+    entity_id: str,
+    entity_type: str,
+    reason: str,
+    gate_reason: str,
+    effective_channels: Iterable[str],
+) -> None:
+    """Haengt GENAU EINEN Eintrag fuer eine VOR dem Versand abgewiesene
+    Meldung an (#1467 S3, Aenderung (d)).
+
+    Zweiter, schlanker Schreibpfad neben `append_entry()`: der ist auf
+    tatsaechliche Zustellversuche zugeschnitten (`changes_count`, `severity`,
+    Kanal-Aufschluesselung NACH dem Versand). Bei einer Abweisung durch die
+    Freigabe-Steuerung ist zu diesem Zeitpunkt strukturell noch nichts davon
+    bekannt — die Erkennung laeuft erst nach dem Gate.
+
+    Ziel-Liste ist immer `not_delivered`: kein Kanal wurde erreicht. Go liest
+    diese Liste nicht (D4), Cockpit-Kachel und Archiv-Statistik aendern sich
+    dadurch um keine Zahl. Jeder eingeschaltete Kanal bekommt denselben
+    `gate_reason` als Nicht-Zustellungs-Grund; `reason` bleibt der AUSLOESER
+    der Meldung (`REASON_NOWCAST`), damit die beiden Angaben nicht
+    verschmelzen.
+
+    Ohne eingeschalteten Kanal entsteht — wie in `append_entry()` — gar kein
+    Eintrag: der Nutzer hat Alarme dort bewusst abgeschaltet.
+
+    Geltungsbereich sind ausschliesslich die beiden Nowcast-Pfade. Der
+    Vorhersage-Aenderungsalarm und die amtliche Warnung protokollieren ihre
+    Unterdrueckungen weiterhin NICHT (offene Luecke O3 in
+    `feat_1459_alert_protokoll.md`).
+
+    `gate_reason` ist PFLICHT und muss gefuellt sein: ein leerer Wert wuerde
+    von `_missed_channels()` beim LESEN still zu `REASON_DELIVERY_FAILED`
+    umgedeutet — das Protokoll behauptete dann "Zustellung fehlgeschlagen", wo
+    in Wahrheit gar keine Sperre vorlag. Genau das hebt den Zweck dieser
+    Aenderung auf (das Protokoll soll wahrheitsgemaess beantworten, WARUM kein
+    Alarm kam), deshalb scheitert die Funktion hier laut statt still etwas
+    Falsches zu schreiben. Der Fall ist heute unerreichbar — beide Aufrufer
+    rufen nur bei `GateResult.allowed is False`, und dann traegt `reason`
+    immer eine der drei Konstanten; die Zusicherung steht an der Stelle, an
+    der sie WIRKT, nicht nur dort, wo sie heute zufaellig eingehalten wird.
+    Ein lautes Scheitern ist an dieser Stelle vertretbar: sie wird
+    ausschliesslich betreten, wenn ohnehin kein Alarm rausgeht.
+    """
+    if not gate_reason or not str(gate_reason).strip():
+        raise ValueError(
+            "append_suppressed_entry: gate_reason ist leer "
+            f"({gate_reason!r}) — ein Unterdrueckungs-Eintrag ohne Grund wird "
+            "beim Lesen still als 'Zustellung fehlgeschlagen' gedeutet und "
+            f"wuerde das Protokoll fuer {entity_type}/{entity_id} verfaelschen."
+        )
+    effective = set(effective_channels or ())
+    if not effective:
+        return
+    _append(user_id, "not_delivered", {
+        "entity_id": entity_id,
+        "entity_type": entity_type,
+        "sent_at": datetime.now(tz=timezone.utc).isoformat(),
+        # Zum Gate-Zeitpunkt ist noch nichts erkannt: keine Aenderungszahl,
+        # kein Schweregrad, keine Groesse. Die Felder bleiben im Schema
+        # (einheitlicher Aufbau), aber leer statt erfunden.
+        "changes_count": 0,
+        "severity": "",
+        "metrics": [],
+        "hazards": [],
+        "reason": reason,
+        "channels_sent": [],
+        "channels_not_sent": [
+            {"channel": channel, "reason": gate_reason}
+            for channel in _ALL_CHANNELS if channel in effective
+        ],
+    })
 
 
 # ---------------------------------------------------------------------------

--- a/src/services/compare_radar_alert.py
+++ b/src/services/compare_radar_alert.py
@@ -14,19 +14,18 @@ SPEC: docs/specs/modules/issue_1041b_compare_radar_alert_service.md
 """
 from __future__ import annotations
 
-import json
 import logging
 from datetime import datetime, timezone
 from typing import Optional
 
 from app.config import Settings
-from app.loader import compare_preset_to_dict, get_data_dir, load_all_locations, load_compare_presets
+from app.loader import compare_preset_to_dict, load_all_locations, load_compare_presets
 from services import alert_channel_threshold, alert_log
 import services.alert_urgency as alert_urgency
+from services.alert_gate import check_nowcast_gate, record_nowcast_sent
 from services.alert_state import AlertStateService
 from services.compare_alert_channels import effective_compare_channels
 from services.compare_alert_guard import is_silenced
-from services.deviation_alert_engine import DeviationAlertEngine
 from services.notification_service import NotificationService
 from services.trip_alert import radar_alert_due
 
@@ -34,6 +33,13 @@ logger = logging.getLogger("compare_radar_alert")
 
 _RADAR_ONSET_THRESHOLD_MIN = 20
 _DEFAULT_COOLDOWN_MINUTES = 120
+# Issue #1467 S3: eigener Sperrzeit-Scope im geteilten `ThrottleStore`.
+# NICHT `radar` (dort liegen Trip-Kennungen; seit dem #1250-Cutover sind Trip-
+# und Vergleichs-Kennungen frei gewaehlte Slugs im selben Verzeichnis, eine
+# Kollision ist real moeglich) und NICHT `compare_preset` (den belegt der
+# Aenderungsalarm auf demselben Preset-Schluessel — ein gemeinsamer Scope
+# liesse die beiden Alarmarten einander gegenseitig unterdruecken).
+_THROTTLE_SCOPE = "compare_radar"
 
 
 def _format_cooldown_display(cooldown_minutes: int) -> str:
@@ -64,8 +70,6 @@ class CompareRadarAlertService:
         self._user_id = user_id
         self._radar_service = radar_service
         self._mail_sink = mail_sink
-        self._throttle_file = get_data_dir(user_id) / "compare_radar_alert_throttle.json"
-        self._last_alert_times: dict[str, datetime] = self._load_throttle_times()
 
     def check_all_compare_presets(self) -> int:
         """Prüft alle Compare-Presets dieses Nutzers und versendet gebündelte
@@ -102,35 +106,65 @@ class CompareRadarAlertService:
             return False
 
         cooldown_minutes = preset.get("alert_cooldown_minutes", _DEFAULT_COOLDOWN_MINUTES)
-        last_alert = self._last_alert_times.get(preset_id)
-        if DeviationAlertEngine.is_cooldown_active(
-            datetime.now(timezone.utc), last_alert, cooldown_minutes
-        ):
-            logger.debug(f"Compare-Radar-Alert cooldown active for preset {preset_id}")
-            return False
-
-        triggered = self._detect_triggered_locations(preset_id, location_ids, all_locations)
-        if not triggered:
-            return False
-
-        # AC-5: Onset ist bereits erkannt — Ruhezeit unterdrückt erst hier den Versand.
-        if DeviationAlertEngine.is_quiet_hours(
-            datetime.now(timezone.utc),
-            preset.get("alert_quiet_from"),
-            preset.get("alert_quiet_to"),
-            context_label=preset_id,
-        ):
-            logger.debug(f"Compare-Radar-Alert quiet hours active for preset {preset_id}")
-            return False
-
-        notification_service = self._notification_service_for(preset)
         # Issue #1461 S3b-2b (AC-5): die Kanalliste war hier hart auf
         # `{"email"}` verdrahtet — unabhaengig vom Telegram-/SMS-Opt-in des
         # Nutzers (verfallene Begruendung aus #1041 Slice 1b, s. Spec
         # "Implementation Details" Punkt 3). Jetzt derselbe EINE Resolver wie
         # bei den beiden anderen Compare-Alarmwegen (ADR-0021, kein
         # Compare-eigener Filter).
+        # Issue #1467 S3: die Aufloesung steht VOR der Freigabe-Pruefung — der
+        # Protokoll-Eintrag einer Abweisung braucht die Kanaele des Nutzers.
+        # Die Funktion ist rein (liest nur Preset/Settings/Tier), das Vorziehen
+        # aendert am Versandverhalten nichts.
         effective_channels = effective_compare_channels(preset, self._settings, self._user_id)
+
+        # Issue #1467 S3: Ruhezeit -> Sperrzeit -> Tages-Obergrenze aus dem
+        # geteilten Baustein, VOR jedem Nowcast-Abruf. Ersetzt den frueheren
+        # eigenen Cooldown (presetseigene Datei `compare_radar_alert_throttle.json`)
+        # und die Ruhezeit-Pruefung NACH der Erkennung; die Tages-Obergrenze
+        # fehlte hier bisher vollstaendig.
+        gate = check_nowcast_gate(
+            user_id=self._user_id,
+            throttle_scope=_THROTTLE_SCOPE,
+            throttle_key=preset_id,
+            cooldown_minutes=cooldown_minutes,
+            quiet_from=preset.get("alert_quiet_from"),
+            quiet_to=preset.get("alert_quiet_to"),
+            context_label=preset_id,
+            now=datetime.now(timezone.utc),
+        )
+        if not gate.allowed:
+            # Die Protokollierung darf den Stapellauf NIE mitreissen: ein
+            # Ortsvergleich, dessen Eintrag scheitert, kostet sonst ALLE
+            # uebrigen Ortsvergleiche dieses Nutzers ihren Alarm — genau das
+            # Muster aus `fix_1479` (dort riss ein kaputter Ruhezeit-Wert den
+            # ganzen Lauf mit), und es widerspricht dem Leitsatz „der
+            # gefaehrlichste Fehler ist der ausbleibende Alarm".
+            # Bewusst breit auf `Exception` (Muster des Nowcast-Abrufs in
+            # `_detect_triggered_locations`): der Schaden einer zu engen
+            # Klausel ist der Totalausfall, der einer zu breiten eine
+            # Protokollzeile. Still verschluckt wird nichts — die Kennung
+            # steht namentlich in der Meldung.
+            try:
+                alert_log.append_suppressed_entry(
+                    self._user_id, entity_id=preset_id, entity_type="compare",
+                    reason=alert_log.REASON_NOWCAST, gate_reason=gate.reason,
+                    effective_channels=effective_channels,
+                )
+            except Exception as e:
+                logger.error(
+                    "Compare-Radar-Alert: Unterdrueckungs-Protokoll fuer Preset "
+                    "%s fehlgeschlagen (%s) — der Alarm blieb aus (Grund: %s), "
+                    "nur der Protokoll-Eintrag fehlt.",
+                    preset_id, e, gate.reason,
+                )
+            return False
+
+        triggered = self._detect_triggered_locations(preset_id, location_ids, all_locations)
+        if not triggered:
+            return False
+
+        notification_service = self._notification_service_for(preset)
         # Die Dringlichkeit wird VOR dem Versand hochgezogen (bisher entstand
         # sie erst inline im `append_entry`-Argument, also NACH dem Versand) --
         # `split_by_threshold()` braucht sie davor. `effective_channels`
@@ -173,8 +207,12 @@ class CompareRadarAlertService:
             return False
 
         self._finalize_triggered_state(preset_id, triggered)
-        self._last_alert_times[preset_id] = datetime.now(timezone.utc)
-        self._save_throttle_times()
+        # Issue #1467 S3: Tageszaehler + Sperrzeit im geteilten Speicher, erst
+        # NACH erfolgreicher Zustellung (F001-Semantik, unveraendert).
+        record_nowcast_sent(
+            user_id=self._user_id, throttle_scope=_THROTTLE_SCOPE,
+            throttle_key=preset_id, now=datetime.now(timezone.utc),
+        )
         return True
 
     def _detect_triggered_locations(
@@ -241,21 +279,3 @@ class CompareRadarAlertService:
     def _load_presets(self) -> list[dict]:
         # Issue #1250 Scheibe 1: zentraler Loader statt rohem json.loads.
         return [compare_preset_to_dict(p) for p in load_compare_presets(user_id=self._user_id)]
-
-    def _load_throttle_times(self) -> dict[str, datetime]:
-        if not self._throttle_file.exists():
-            return {}
-        try:
-            data = json.loads(self._throttle_file.read_text())
-            return {k: datetime.fromisoformat(v) for k, v in data.items()}
-        except (json.JSONDecodeError, ValueError, OSError) as e:
-            logger.warning(f"Failed to load compare radar alert throttle file: {e}")
-            return {}
-
-    def _save_throttle_times(self) -> None:
-        try:
-            self._throttle_file.parent.mkdir(parents=True, exist_ok=True)
-            data = {k: v.isoformat() for k, v in self._last_alert_times.items()}
-            self._throttle_file.write_text(json.dumps(data, indent=2))
-        except OSError as e:
-            logger.error(f"Failed to save compare radar alert throttle file: {e}")

--- a/src/services/throttle_store.py
+++ b/src/services/throttle_store.py
@@ -36,8 +36,20 @@ _LEGACY_RADAR_FILE = "radar_alert_throttle.json"
 class ThrottleStore:
     """Ein State-File pro Nutzer für alle Cooldown-Scopes.
 
-    Scopes: ``trip``, ``radar``, ``compare_preset``. Struktur der Datei:
-    ``{scope: {key: iso_timestamp}}``.
+    Scopes und ihr Schlüsselraum:
+
+    * ``trip`` — Trip-Kennung, Vorhersage-Änderungsalarm
+    * ``radar`` — Trip-Kennung, Trip-Nowcast
+    * ``compare_preset`` — Preset-Kennung, Vergleichs-Änderungsalarm
+    * ``compare_radar`` — Preset-Kennung, Vergleichs-Nowcast (Issue #1467 S3).
+      Bewusst ein EIGENER Scope: ``radar`` ist ausschließlich mit Trip-Kennungen
+      belegt (seit dem #1250-Cutover liegen Trips und Ortsvergleiche im selben
+      Verzeichnis und tragen frei gewählte Slugs — Kollision real möglich), und
+      ``compare_preset`` ist vom Änderungsalarm auf demselben Preset-Schlüssel
+      belegt; eine Wiederverwendung ließe die beiden Alarmarten einander
+      gegenseitig unterdrücken.
+
+    Struktur der Datei: ``{scope: {key: iso_timestamp}}``.
     """
 
     def __init__(self, user_id: str, data_dir: Optional[Path] = None) -> None:

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -18,6 +18,7 @@ from app.config import Settings
 from app.models import SegmentWeatherData, WeatherChange
 from services import alert_channel_threshold, alert_daily_limit, alert_log
 import services.alert_urgency as alert_urgency
+from services.alert_gate import check_nowcast_gate, record_nowcast_sent
 from services.deviation_alert_engine import DeviationAlertEngine
 from services.notification_service import (
     NotificationResult,
@@ -42,6 +43,11 @@ logger = logging.getLogger("trip_alert")
 # 90s Reserve gegenueber diesen 120s, analog FETCH_DEADLINE_SECONDS in
 # providers/meteofrance.py und providers/dwd.py.
 ALERT_RUN_DEADLINE_SECONDS = 90.0
+
+# Sperrzeit-Scope des Trip-Nowcast im geteilten `ThrottleStore` (#1213).
+# Ausschliesslich mit Trip-Kennungen belegt — der Vergleichs-Nowcast bekam mit
+# #1467 S3 deshalb einen eigenen Scope (`compare_radar`) statt diesen hier.
+_RADAR_THROTTLE_SCOPE = "radar"
 
 # Issue #1460 (P1a, loest #1444 S1 ab): der Wertebereich (`corridors[].notify`)
 # ist KEIN Alarm-Ausloeser mehr -- eine absolute Grenze widerspricht ADR-0009
@@ -655,19 +661,32 @@ class TripAlertService:
             self._radar_service = RadarNowcastService()
         return self._radar_service
 
-    def _is_radar_throttled(self, trip_id: str, cooldown_min: int = 120) -> bool:
-        """Return True if radar alert was sent within cooldown window (Issue #818 AC-6).
-
-        Issue #1213: liest jetzt aus dem gemeinsamen ThrottleStore statt aus
-        dem alert_state-Key `radar_throttle` (nur noch Migrationsquelle).
-        """
-        return self._throttle_store.is_throttled(
-            "radar", trip_id, cooldown_min, datetime.now(timezone.utc)
-        )
-
     def clear_radar_throttle(self, trip_id: str) -> None:
         """Clear radar throttle for a trip (test helper)."""
-        self._throttle_store.clear("radar", trip_id)
+        self._throttle_store.clear(_RADAR_THROTTLE_SCOPE, trip_id)
+
+    def _radar_effective_channels(self, trip: "Trip") -> set[str]:
+        """Kanal-Set des Radar-Alarms (Issue #1023): globale Faehigkeit UND
+        Trip-Opt-in, bei SMS zusaetzlich das Tier-Gate.
+
+        Issue #1467 S3 aus der Inline-Ableitung herausgezogen — die
+        Unterdrueckungs-Protokollierung braucht dieselbe Liste bereits am
+        Gate, also vor der Erkennung. Reine Ableitung ohne Seiteneffekt, das
+        Ergebnis ist an beiden Stellen identisch; eine zweite Fassung waere
+        genau die Duplikat-Falle, die diese Scheibe beseitigt.
+        """
+        config = trip.report_config
+        channels: set[str] = set()
+        if self._settings.can_send_email() and (not config or getattr(config, "send_email", True)):
+            channels.add("email")
+        if self._settings.can_send_telegram() and config and getattr(config, "send_telegram", False):
+            channels.add("telegram")
+        if (
+            self._settings.can_send_sms() and config
+            and getattr(config, "send_sms", False) and sms_allowed(self._user_id)
+        ):
+            channels.add("sms")
+        return channels
 
     def _briefing_precip_for_onset(
         self,
@@ -744,24 +763,49 @@ class TripAlertService:
                     )
                     continue
 
-            # QuietHours check (reuse existing)
-            if self._is_quiet_hours(trip, now_utc):
-                logger.debug(f"Radar alert suppressed (quiet hours) for trip {trip.id}")
-                continue
-
             cooldown_min = (
                 trip.alert_cooldown_minutes
                 if trip.alert_cooldown_minutes is not None
                 else self._throttle_hours * 60
             )
-            if self._is_radar_throttled(trip.id, cooldown_min=cooldown_min):
-                logger.debug(f"Radar alert throttled for trip {trip.id}")
-                continue
-
-            # Issue #1070: Tages-Obergrenze nach Nutzerlevel (Free/Standard/Premium)
-            # Issue #1555: reason="nowcast" prüft gegen das volle Limit (Reserve-Nutznießer).
-            if not alert_daily_limit.is_allowed(self._user_id, datetime.now(timezone.utc), reason="nowcast"):
-                logger.debug(f"Radar alert suppressed: daily limit reached for trip {trip.id}")
+            # Issue #1467 S3: dieselbe Kette wie bisher (Ruhezeit -> Sperrzeit
+            # -> Tages-Obergrenze, #1070/#1555), jetzt aus dem geteilten
+            # Baustein, den auch der Vergleichs-Nowcast benutzt. Reihenfolge,
+            # Scope (`radar`), Schluessel (`trip.id`) und Zustellverhalten
+            # bleiben unveraendert — neu ist allein der Protokoll-Eintrag.
+            gate = check_nowcast_gate(
+                user_id=self._user_id,
+                throttle_scope=_RADAR_THROTTLE_SCOPE,
+                throttle_key=trip.id,
+                cooldown_minutes=cooldown_min,
+                quiet_from=trip.alert_quiet_from,
+                quiet_to=trip.alert_quiet_to,
+                context_label=trip.id,
+                now=now_utc,
+                throttle_store=self._throttle_store,
+            )
+            if not gate.allowed:
+                logger.debug(
+                    f"Radar alert suppressed ({gate.reason}) for trip {trip.id}"
+                )
+                # Absicherung je Trip, nicht um den Stapellauf: scheitert der
+                # Protokoll-Eintrag EINES Trips, verlieren sonst ALLE weiteren
+                # Trips dieses Nutzers ihren Radar-Alarm (Muster `fix_1479`).
+                # Breite Klausel + laute Meldung mit Kennung, wie beim
+                # Nowcast-Abruf ein paar Zeilen weiter unten.
+                try:
+                    alert_log.append_suppressed_entry(
+                        self._user_id, entity_id=trip.id, entity_type="trip",
+                        reason=alert_log.REASON_NOWCAST, gate_reason=gate.reason,
+                        effective_channels=self._radar_effective_channels(trip),
+                    )
+                except Exception as e:
+                    logger.error(
+                        "Radar alert: Unterdrueckungs-Protokoll fuer Trip %s "
+                        "fehlgeschlagen (%s) — der Alarm blieb aus (Grund: %s), "
+                        "nur der Protokoll-Eintrag fehlt.",
+                        trip.id, e, gate.reason,
+                    )
                 continue
 
             # Genau EIN get_nowcast-Call pro Trip an Segment-Startpunkt
@@ -865,17 +909,9 @@ class TripAlertService:
                 tz=tz,
             )
 
-            config = trip.report_config
-
             # Issue #1023: Kanal-Set für NotificationService bauen; der Service prüft
             # selbst can_send_*(). Trip-Ebene darf Kanäle explizit deaktivieren.
-            effective_channels: set[str] = set()
-            if can_email and (not config or getattr(config, "send_email", True)):
-                effective_channels.add("email")
-            if can_telegram and config and getattr(config, "send_telegram", False):
-                effective_channels.add("telegram")
-            if can_sms and config and getattr(config, "send_sms", False) and sms_allowed(self._user_id):
-                effective_channels.add("sms")
+            effective_channels = self._radar_effective_channels(trip)
 
             if not effective_channels:
                 logger.info(f"Radar alert: alle Kanäle auf Trip-Ebene deaktiviert, kein Recording für {trip.id}")
@@ -927,12 +963,17 @@ class TripAlertService:
 
             # Recording nach Best-Effort-Zustellung (F001-Semantik)
             # Issue #1070: nur bei tatsaechlichem Versand zaehlen (F001-Symmetrie)
-            alert_daily_limit.increment(self._user_id, datetime.now(timezone.utc))
-            # Issue #1213: alleinige Radar-Throttle-Quelle ist jetzt der Store —
-            # der alert_state-Key `radar_throttle` und die Legacy-Datei
+            # Issue #1213: alleinige Radar-Throttle-Quelle ist der Store — der
+            # alert_state-Key `radar_throttle` und die Legacy-Datei
             # `radar_alert_throttle.json` werden nicht mehr geschrieben (nur
             # noch als Migrationsquellen gelesen).
-            self._throttle_store.record("radar", trip.id, datetime.now(timezone.utc))
+            # Issue #1467 S3: beide Buchungen buendelt jetzt der geteilte
+            # Baustein — unveraendert erst NACH der Zustellung.
+            record_nowcast_sent(
+                user_id=self._user_id, throttle_scope=_RADAR_THROTTLE_SCOPE,
+                throttle_key=trip.id, now=datetime.now(timezone.utc),
+                throttle_store=self._throttle_store,
+            )
             sent += 1
 
         return sent

--- a/tests/helpers/nowcast_gate_fixtures.py
+++ b/tests/helpers/nowcast_gate_fixtures.py
@@ -1,0 +1,406 @@
+"""Gemeinsame Bausteine der Nowcast-Freigabe-Tests (Issue #1467 Scheibe S3).
+
+SPEC: docs/specs/modules/rework_1467_s3_nowcast.md
+
+Mock-frei: echte Presets/Orte/Trips auf Platte, echte Services, echte
+Zustandsdateien (``throttle_state.json``, ``alert_daily_count.json``,
+``alert_log.json``). Der Versand laeuft ausschliesslich ueber die vorhandenen
+DI-Naehte (``radar_service``/``frame_source``, ``mail_sink``) — kein Netz,
+kein ``Mock()``/``patch()``.
+
+``Settings`` wird IMMER vollstaendig konstruiert (auch die Felder, die auf
+"aus" stehen sollen): ein weggelassenes Feld faellt bei pydantic still auf die
+Prod-``.env`` des Arbeitsverzeichnisses zurueck — genau so gingen am
+2026-08-03 echte Telegram-Nachrichten an den Produktiv-Chat des PO (#1477).
+
+Pfadregel #1409: alles wird relativ zu DIESER Datei bzw. ueber
+``app.loader.get_data_dir()`` aufgeloest, nie ueber einen festen
+Hauptrepo-Pfad. Einzige bewusste Ausnahme ist ``PRESET_ROOT``: der
+Vergleichs-Loader liest Presets cwd-relativ
+(``load_compare_presets(data_root="data")``) — die in CLAUDE.md ausgenommene
+"geteilte Ablage" (Vorbild ``tests/helpers/alert_log_fixtures.py``).
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from datetime import date as date_type
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from app.config import Settings
+from app.loader import get_briefings_dir, get_data_dir
+from app.models import TripReportConfig
+from app.trip import Stage, Trip, Waypoint
+from app.user import SavedLocation
+
+from tests.helpers.compare_briefings import write_compare_briefings
+
+# s. Modul-Docstring: cwd-relative Ablage des Vergleichs-Preset-Loaders.
+PRESET_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
+
+VIENNA = ZoneInfo("Europe/Vienna")
+
+LAT, LON = 47.0, 11.0
+
+# Trip-Wegpunkte liegen bewusst in einer Zeitzone MIT UTC-Versatz 0
+# (Atlantic/Reykjavik, ganzjaehrig UTC+0). ``convert_trip_to_segments()``
+# deutet ``arrival_calculated`` in der ORTSZEIT des Wegpunkts und vergleicht
+# das Ergebnis gegen ``datetime.now(timezone.utc)``; mit einem versetzten Ort
+# waeren die Tests um den Tageswechsel herum stundenweise instabil.
+TRIP_LAT, TRIP_LON = 64.13, -21.90
+
+# Scope-Namen der Sperrzeit-Ablage (Spec (b)).
+SCOPE_COMPARE_RADAR = "compare_radar"
+SCOPE_TRIP_RADAR = "radar"
+
+LEGACY_COMPARE_RADAR_FILE = "compare_radar_alert_throttle.json"
+
+
+# ───────────────────────────── Nutzer & Aufraeumen ──────────────────────────
+
+
+def fresh_uid(prefix: str) -> str:
+    return f"tdd-1467s3-{prefix}-{uuid.uuid4().hex[:6]}"
+
+
+def clean_uid(user_id: str) -> None:
+    """Beide Ablagen: die isolierte ``get_data_dir()``-Basis UND das
+    cwd-relative Preset-Verzeichnis."""
+    for d in (PRESET_ROOT / user_id, get_data_dir(user_id)):
+        if d.exists():
+            shutil.rmtree(d, ignore_errors=True)
+
+
+def write_user_tier(user_id: str, tier: str) -> None:
+    d = get_data_dir(user_id)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "user.json").write_text(json.dumps({"id": user_id, "tier": tier}))
+
+
+# ───────────────────────────────── Settings ─────────────────────────────────
+
+
+def settings_email_only() -> Settings:
+    """``can_send_email() == True``; Telegram und SMS ausdruecklich AUS."""
+    return Settings(
+        smtp_host="dummy.invalid", smtp_user="dummy", smtp_pass="dummy",
+        mail_to="dummy@example.invalid",
+        telegram_bot_token="", telegram_chat_id="",
+        seven_api_key="", sms_to="",
+    )
+
+
+def settings_no_channel_reachable() -> Settings:
+    """Kein einziger Kanal erreichbar: ``can_send_email/telegram/sms`` alle
+    False. Der Alarm-Pfad laeuft komplett durch, die Zustellung scheitert."""
+    return Settings(
+        smtp_host="", smtp_user="", smtp_pass="", mail_to="",
+        telegram_bot_token="", telegram_chat_id="",
+        seven_api_key="", sms_to="",
+    )
+
+
+# ───────────────────────────── Orte & Presets ───────────────────────────────
+
+
+def location(loc_id: str, name: str, lat: float = LAT, lon: float = LON) -> SavedLocation:
+    return SavedLocation(id=loc_id, name=name, lat=lat, lon=lon, elevation_m=1000)
+
+
+def radar_preset(
+    preset_id: str,
+    location_ids: list[str],
+    *,
+    user_id: str = "default",
+    cooldown_minutes: int | None = 120,
+    quiet_from: str | None = None,
+    quiet_to: str | None = None,
+) -> dict:
+    """Vergleichs-Preset mit scharfem Nowcast-Alarm und aktivem Zeitplan
+    (``schedule="daily"`` — sonst greift der Stilllegungs-Riegel aus S2 AG6
+    und der Test misst diesen statt der Freigabe-Stufen)."""
+    preset: dict = {
+        "id": preset_id,
+        "name": preset_id,
+        "user_id": user_id,
+        "location_ids": location_ids,
+        "schedule": "daily",
+        "weekday": 4,
+        "profil": "ALLGEMEIN",
+        "hour_from": 9,
+        "hour_to": 16,
+        "empfaenger": ["dummy@example.invalid"],
+        "created_at": "2026-08-08T00:00:00Z",
+        "radar_alert_enabled": True,
+    }
+    if cooldown_minutes is not None:
+        preset["alert_cooldown_minutes"] = cooldown_minutes
+    if quiet_from is not None:
+        preset["alert_quiet_from"] = quiet_from
+    if quiet_to is not None:
+        preset["alert_quiet_to"] = quiet_to
+    return preset
+
+
+def write_presets(user_id: str, presets: list[dict]) -> Path:
+    return write_compare_briefings(PRESET_ROOT / user_id, presets)
+
+
+# ─────────────────────────────── Radar-Naht ─────────────────────────────────
+
+
+def wet_frames(onset_minutes: int = 8, *, is_convective: bool = False, rate: float = 0.6) -> list:
+    """Ein echter, nasser ``RadarFrame`` ``onset_minutes`` in der Zukunft."""
+    from providers.brightsky import RadarFrame
+
+    ts = datetime.now(timezone.utc) + timedelta(minutes=onset_minutes)
+    return [RadarFrame(timestamp=ts, precip_mm_h=rate, is_convective=is_convective)]
+
+
+class CountingFrameSource:
+    """Echter, aufrufbarer ``frame_source``-Doppelgaenger (kein Mock): liefert
+    fuer JEDE Koordinate denselben ausloesenden Frame-Satz und zaehlt die
+    tatsaechlichen Abrufe. Die Zaehl-Naht sitzt an der Stelle, an der der
+    Nowcast-Abruf real Kosten verursacht."""
+
+    def __init__(self, onset_minutes: int = 8) -> None:
+        self._onset = onset_minutes
+        self.call_count = 0
+        self.calls: list[tuple[float, float]] = []
+
+    def __call__(self, lat: float, lon: float) -> list:
+        self.call_count += 1
+        self.calls.append((lat, lon))
+        return wet_frames(self._onset)
+
+
+def radar_service(frame_source) -> object:
+    from services.radar_service import RadarNowcastService
+
+    return RadarNowcastService(frame_source=frame_source)
+
+
+def reset_radar_cache() -> None:
+    """Der Frame-Cache ist ein Prozess-Singleton (TTL 300 s). Wer INNERHALB
+    eines Tests zweimal dieselbe Koordinate abruft und dabei Abrufe zaehlt,
+    muss ihn dazwischen leeren — sonst misst der zweite Lauf einen
+    Cache-Treffer statt des Freigabe-Verhaltens."""
+    from services.radar_cache import reset_shared_radar_cache_for_tests
+
+    reset_shared_radar_cache_for_tests()
+
+
+# ─────────────────────────── Ruhezeit-Fenster ───────────────────────────────
+
+
+def quiet_window_now(buffer_minutes: int = 5) -> tuple[str, str]:
+    """``(from, to)`` in Europe/Vienna-Lokalzeit, das den JETZIGEN Zeitpunkt
+    umschliesst — ``is_quiet_hours()`` vergleicht seit #1312 gegen Wien."""
+    now = datetime.now(timezone.utc).astimezone(VIENNA)
+    return (
+        (now - timedelta(minutes=buffer_minutes)).strftime("%H:%M"),
+        (now + timedelta(minutes=buffer_minutes)).strftime("%H:%M"),
+    )
+
+
+def quiet_window_elsewhere() -> tuple[str, str]:
+    """Ein GESETZTES Ruhezeit-Fenster, das „jetzt" NICHT enthaelt (2–3 h
+    voraus). Schaerfer als „gar keine Ruhezeit", weil der Wert damit real
+    ausgewertet wird statt in den ``not quiet_from``-Kurzschluss zu laufen."""
+    now = datetime.now(timezone.utc).astimezone(VIENNA)
+    return (
+        (now + timedelta(hours=2)).strftime("%H:%M"),
+        (now + timedelta(hours=3)).strftime("%H:%M"),
+    )
+
+
+# ───────────────────────── Zustandsdateien lesen/setzen ─────────────────────
+
+
+def daily_counter_path(user_id: str) -> Path:
+    return get_data_dir(user_id) / "alert_daily_count.json"
+
+
+def vienna_today() -> str:
+    return datetime.now(timezone.utc).astimezone(VIENNA).date().isoformat()
+
+
+def seed_daily_counter(user_id: str, count: int) -> None:
+    path = daily_counter_path(user_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"date": vienna_today(), "count": count}))
+
+
+def read_daily_counter(user_id: str) -> int:
+    path = daily_counter_path(user_id)
+    if not path.exists():
+        return 0
+    data = json.loads(path.read_text())
+    if data.get("date") != vienna_today():
+        return 0
+    return int(data.get("count", 0))
+
+
+def throttle_state_path(user_id: str) -> Path:
+    return get_data_dir(user_id) / "throttle_state.json"
+
+
+def read_throttle_state(user_id: str) -> dict:
+    path = throttle_state_path(user_id)
+    if not path.exists():
+        return {}
+    data = json.loads(path.read_text())
+    return data if isinstance(data, dict) else {}
+
+
+def record_throttle(user_id: str, scope: str, key: str, when: datetime | None = None) -> None:
+    """Sperrzeit-Eintrag ueber den ECHTEN ``ThrottleStore`` setzen (nicht per
+    Handschrift in die Datei) — damit misst der Test das Format, das der
+    Pruefling selbst schreibt."""
+    from services.throttle_store import ThrottleStore
+
+    ThrottleStore(user_id).record(scope, key, when or datetime.now(timezone.utc))
+
+
+def write_legacy_compare_throttle(user_id: str, preset_id: str, when: datetime) -> Path:
+    """Die ABGELOESTE Alt-Datei mit frischem Eintrag vorbelegen (AC-3)."""
+    d = get_data_dir(user_id)
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / LEGACY_COMPARE_RADAR_FILE
+    path.write_text(json.dumps({preset_id: when.isoformat()}, indent=2))
+    return path
+
+
+def read_log(user_id: str) -> dict:
+    path = get_data_dir(user_id) / "alert_log.json"
+    if not path.exists():
+        return {"entries": [], "not_delivered": []}
+    data = json.loads(path.read_text())
+    data.setdefault("entries", [])
+    data.setdefault("not_delivered", [])
+    return data
+
+
+def suppression_reasons(entry: dict) -> set[str]:
+    """Alle Unterdrueckungs-Gruende, die dieser Protokoll-Eintrag traegt.
+
+    Gelesen wird BEWUSST breit (Kanal-Aufschluesselung UND moegliche
+    Kopffelder): die Spec legt die beobachtbare Wirkung fest ("ein Eintrag mit
+    dem Unterdrueckungs-Grund"), die Traegerform ist Implementierungsdetail.
+    Der Eintrags-``reason`` (= Ausloeser, z.B. ``nowcast``) zaehlt nur mit,
+    wenn er einer der drei Gate-Gruende ist.
+    """
+    from services import alert_log
+
+    gate = {
+        alert_log.REASON_QUIET_HOURS,
+        alert_log.REASON_COOLDOWN,
+        alert_log.REASON_DAILY_LIMIT,
+    }
+    found: set[str] = set()
+    not_sent = entry.get("channels_not_sent")
+    if isinstance(not_sent, dict):
+        found.update(not_sent.values())
+    else:
+        for item in not_sent or []:
+            if isinstance(item, dict):
+                found.add(item.get("reason"))
+    for key in ("reason", "suppressed_reason", "gate_reason", "suppression_reason"):
+        found.add(entry.get(key))
+    return {r for r in found if r in gate}
+
+
+def entries_for(user_id: str, entity_id: str, *, bucket: str) -> list[dict]:
+    return [
+        e for e in read_log(user_id).get(bucket, [])
+        if isinstance(e, dict) and e.get("entity_id") == entity_id
+    ]
+
+
+# ─────────────────────────────── Trip-Bausteine ─────────────────────────────
+
+
+def make_trip(
+    trip_id: str,
+    *,
+    cooldown_minutes: int = 120,
+    quiet_from: str | None = None,
+    quiet_to: str | None = None,
+) -> Trip:
+    """Trip mit einer heute aktiven Etappe (Segment-Auswahl in
+    ``check_radar_alerts()`` braucht ``arrival_calculated``).
+
+    Die Etappe spannt bewusst den GANZEN Tag (00:00–23:59 Ortszeit = UTC, s.
+    ``TRIP_LAT``): so ist zu jeder Tageszeit ein Segment aktiv und der Test
+    misst die Freigabe-Stufen, nicht die Segment-Auswahl.
+    """
+    wp0 = Waypoint(
+        id="WP0", name="Start", lat=TRIP_LAT, lon=TRIP_LON, elevation_m=500.0,
+        arrival_calculated="00:00",
+    )
+    wp1 = Waypoint(
+        id="WP1", name="Ende", lat=TRIP_LAT + 0.1, lon=TRIP_LON + 0.1, elevation_m=600.0,
+        arrival_calculated="23:59",
+    )
+    stage = Stage(id="S1", name="Tag 1", date=date_type.today(), waypoints=[wp0, wp1])
+    trip = Trip(id=trip_id, name="S3 Nowcast-Trip", stages=[stage])
+    trip.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=True, send_telegram=False,
+    )
+    trip.alert_cooldown_minutes = cooldown_minutes
+    trip.alert_quiet_from = quiet_from
+    trip.alert_quiet_to = quiet_to
+    return trip
+
+
+def save_trip(trip: Trip, user_id: str) -> None:
+    trips_dir = get_briefings_dir(user_id)
+    trips_dir.mkdir(parents=True, exist_ok=True)
+    data = {
+        "id": trip.id,
+        "name": trip.name,
+        "alert_cooldown_minutes": trip.alert_cooldown_minutes,
+        "alert_quiet_from": trip.alert_quiet_from,
+        "alert_quiet_to": trip.alert_quiet_to,
+        "stages": [
+            {
+                "id": s.id, "name": s.name, "date": s.date.isoformat(),
+                "waypoints": [
+                    {
+                        "id": w.id, "name": w.name, "lat": w.lat, "lon": w.lon,
+                        "elevation_m": w.elevation_m,
+                        "arrival_calculated": w.arrival_calculated,
+                    }
+                    for w in s.waypoints
+                ],
+            }
+            for s in trip.stages
+        ],
+        "report_config": {
+            "trip_id": trip.report_config.trip_id,
+            "send_email": trip.report_config.send_email,
+            "send_telegram": trip.report_config.send_telegram,
+        },
+    }
+    (trips_dir / f"{trip.id}.json").write_text(json.dumps(data))
+
+
+def trip_alert_service(user_id: str, settings: Settings, frame_source, mail_sink):
+    from services.trip_alert import TripAlertService
+
+    return TripAlertService(
+        settings=settings, throttle_hours=2, user_id=user_id,
+        radar_service=radar_service(frame_source), mail_sink=mail_sink,
+    )
+
+
+def compare_radar_service(user_id: str, settings: Settings, frame_source, mail_sink):
+    from services.compare_radar_alert import CompareRadarAlertService
+
+    return CompareRadarAlertService(
+        settings=settings, user_id=user_id,
+        radar_service=radar_service(frame_source), mail_sink=mail_sink,
+    )

--- a/tests/tdd/test_alert_gate.py
+++ b/tests/tdd/test_alert_gate.py
@@ -1,0 +1,379 @@
+"""TDD RED — Der geteilte Nowcast-Freigabe-Baustein (Issue #1467 S3,
+AC-11 + AC-12 + AC-13 + AC-15).
+
+SPEC: docs/specs/modules/rework_1467_s3_nowcast.md
+
+``src/services/alert_gate.py`` existiert heute nicht — die Reihenfolge
+Ruhezeit → Sperrzeit → Tages-Obergrenze steht als Inline-Kette im Trip-Pfad
+(``trip_alert.py:748-765``), waehrend der Vergleichs-Pfad eine andere,
+unvollstaendige Reihenfolge fuehrt. RED-Grund fuer AC-11: ``ImportError`` —
+das Modul fehlt.
+
+Vier Zusicherungen:
+
+* **AC-11 Reihenfolge** — der Ablauf haelt an der ERSTEN zutreffenden Stufe
+  an. Nachgewiesen mit einem echten, zaehlenden ``ThrottleStore``
+  (Unterklasse, die den echten Speicher weiterbenutzt) statt eines
+  Aufruf-Spions auf einem gemockten Objekt.
+* **AC-12 Vorrang-Schutz** — der Vergleichs-Nowcast prueft mit
+  ``reason="nowcast"`` gegen das VOLLE Tagesbudget. Ein Compare-eigener Grund
+  oder ``"forecast_change"`` wuerde die NowCast-Reserve aus #1555 still
+  verlieren. Der Test belegt zuerst, dass der gewaehlte Zaehlerstand
+  tatsaechlich in der Reserve-Zone liegt — sonst waere die Zusicherung leer.
+* **AC-13 Zaehler-Invariante** — Sperrzeit und Tageszaehler werden NIEMALS vor
+  der erfolgreichen Zustellung gebucht. Gemessen an den echten Zustandsdateien
+  auf Platte, in beiden Richtungen (scheiternde und gelingende Zustellung).
+* **AC-15 Mandantentrennung** — zwei Nutzer mit DERSELBEN Preset-Kennung.
+
+Mock-frei, kein Netz: echte Zustandsdateien, echte Services, DI-Naehte fuer
+Radar und Versand.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.loader import save_location
+
+from tests.helpers.nowcast_gate_fixtures import (
+    SCOPE_COMPARE_RADAR, CountingFrameSource, clean_uid, compare_radar_service,
+    fresh_uid, location, quiet_window_elsewhere, quiet_window_now,
+    radar_preset, read_daily_counter, read_throttle_state, record_throttle,
+    reset_radar_cache, seed_daily_counter, settings_email_only,
+    settings_no_channel_reachable, write_presets, write_user_tier,
+)
+
+
+def _counting_store(user_id: str):
+    """Echter ``ThrottleStore`` (echte Datei, echte Sperrzeit-Semantik), der
+    seine Sperrzeit-Abfragen mitzaehlt. Kein Mock: die Unterklasse delegiert
+    jeden Aufruf an die Originalimplementierung."""
+    from services.throttle_store import ThrottleStore
+
+    class _CountingThrottleStore(ThrottleStore):
+        def __init__(self, uid: str) -> None:
+            super().__init__(uid)
+            self.is_throttled_calls = 0
+
+        def is_throttled(self, scope, key, cooldown_minutes, now):  # type: ignore[override]
+            self.is_throttled_calls += 1
+            return super().is_throttled(scope, key, cooldown_minutes, now)
+
+    return _CountingThrottleStore(user_id)
+
+
+def _setup_compare(uid: str, preset_id: str, *, quiet: bool = False) -> None:
+    save_location(location("loc-gate", "Gattersdorf"), user_id=uid)
+    quiet_from, quiet_to = quiet_window_now() if quiet else quiet_window_elsewhere()
+    write_presets(uid, [radar_preset(
+        preset_id, ["loc-gate"], user_id=uid, cooldown_minutes=120,
+        quiet_from=quiet_from, quiet_to=quiet_to,
+    )])
+
+
+def _run_compare(uid: str, settings=None) -> tuple[int, list]:
+    reset_radar_cache()
+    mails: list = []
+    sent = compare_radar_service(
+        uid, settings or settings_email_only(), CountingFrameSource(onset_minutes=8),
+        lambda subject, body: mails.append((subject, body)),
+    ).check_all_compare_presets()
+    return sent, mails
+
+
+# ═════════════════════════ AC-11: feste Reihenfolge ═════════════════════════
+
+
+def test_ac11_ruhezeit_stoppt_vor_der_sperrzeit_pruefung():
+    """AC-11: Treffen Ruhezeit UND Sperrzeit gleichzeitig zu, haelt der Ablauf
+    an der Ruhezeit an — die Sperrzeit-Pruefung wird fuer diesen Aufruf gar
+    nicht mehr erreicht (Aufrufzaehler bleibt bei 0).
+
+    RED heute: ``services.alert_gate`` existiert nicht (ImportError)."""
+    from services.alert_gate import check_nowcast_gate
+    from services.alert_log import REASON_QUIET_HOURS
+
+    uid, preset_id = fresh_uid("ac11-qh"), "cp-1467s3-ac11"
+    clean_uid(uid)
+    try:
+        write_user_tier(uid, "premium")
+        store = _counting_store(uid)
+        store.record(SCOPE_COMPARE_RADAR, preset_id,
+                     datetime.now(timezone.utc) - timedelta(minutes=5))
+        store.is_throttled_calls = 0
+        quiet_from, quiet_to = quiet_window_now()
+
+        ergebnis = check_nowcast_gate(
+            user_id=uid, throttle_scope=SCOPE_COMPARE_RADAR, throttle_key=preset_id,
+            cooldown_minutes=120, quiet_from=quiet_from, quiet_to=quiet_to,
+            context_label=preset_id, now=datetime.now(timezone.utc),
+            throttle_store=store,
+        )
+
+        assert ergebnis.allowed is False, (
+            f"Aktive Ruhezeit muss den Nowcast sperren: {ergebnis!r}"
+        )
+        assert ergebnis.reason == REASON_QUIET_HOURS, (
+            f"Der gemeldete Grund muss die ERSTE zutreffende Stufe sein "
+            f"({REASON_QUIET_HOURS!r}), gemeldet wurde {ergebnis.reason!r}"
+        )
+        assert store.is_throttled_calls == 0, (
+            f"Die Sperrzeit-Pruefung darf bei aktiver Ruhezeit gar nicht erst "
+            f"laufen, wurde aber {store.is_throttled_calls}x gerufen"
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_ac11_sperrzeit_stoppt_vor_der_tages_obergrenze():
+    """AC-11 (zweite Stufengrenze): Treffen Sperrzeit UND Tages-Obergrenze
+    gleichzeitig zu, meldet der Baustein die Sperrzeit — er haelt an der
+    ersten zutreffenden Stufe an, nicht an der letzten.
+
+    RED heute: ``services.alert_gate`` existiert nicht (ImportError)."""
+    from services.alert_gate import check_nowcast_gate
+    from services.alert_log import REASON_COOLDOWN
+
+    uid, preset_id = fresh_uid("ac11-cd"), "cp-1467s3-ac11b"
+    clean_uid(uid)
+    try:
+        write_user_tier(uid, "free")
+        seed_daily_counter(uid, 2)  # Tages-Obergrenze ebenfalls erreicht
+        record_throttle(uid, SCOPE_COMPARE_RADAR, preset_id,
+                        datetime.now(timezone.utc) - timedelta(minutes=5))
+        quiet_from, quiet_to = quiet_window_elsewhere()
+
+        ergebnis = check_nowcast_gate(
+            user_id=uid, throttle_scope=SCOPE_COMPARE_RADAR, throttle_key=preset_id,
+            cooldown_minutes=120, quiet_from=quiet_from, quiet_to=quiet_to,
+            context_label=preset_id, now=datetime.now(timezone.utc),
+        )
+
+        assert ergebnis.allowed is False, f"Die Sperrzeit muss sperren: {ergebnis!r}"
+        assert ergebnis.reason == REASON_COOLDOWN, (
+            f"Erwartet {REASON_COOLDOWN!r} (erste zutreffende Stufe), gemeldet "
+            f"wurde {ergebnis.reason!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_ac11_freie_bahn_wird_durchgelassen():
+    """AC-11 (Gegenprobe): Ohne Ruhezeit, ohne Sperrzeit, mit freiem
+    Tagesbudget laesst der Baustein durch und nennt keinen Grund. Ohne diese
+    Haelfte waere ein Baustein, der ALLES sperrt, formal AC-konform — der
+    gefaehrlichste Fehler dieser Scheibe.
+
+    RED heute: ``services.alert_gate`` existiert nicht (ImportError)."""
+    from services.alert_gate import check_nowcast_gate
+
+    uid, preset_id = fresh_uid("ac11-frei"), "cp-1467s3-ac11c"
+    clean_uid(uid)
+    try:
+        write_user_tier(uid, "free")
+        quiet_from, quiet_to = quiet_window_elsewhere()
+
+        ergebnis = check_nowcast_gate(
+            user_id=uid, throttle_scope=SCOPE_COMPARE_RADAR, throttle_key=preset_id,
+            cooldown_minutes=120, quiet_from=quiet_from, quiet_to=quiet_to,
+            context_label=preset_id, now=datetime.now(timezone.utc),
+        )
+
+        assert ergebnis.allowed is True, (
+            f"Ohne jede Sperre muss der Nowcast durchgelassen werden: {ergebnis!r}"
+        )
+        assert ergebnis.reason is None, (
+            f"Ein durchgelassener Lauf darf keinen Sperrgrund nennen: "
+            f"{ergebnis.reason!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+# ══════════════════ AC-12: Vorrang-Schutz aus #1555 bleibt ══════════════════
+
+
+def test_ac12_vergleichs_nowcast_prueft_gegen_das_volle_tagesbudget():
+    """AC-12: Bei Limit 2 und Reserve 1 (#1555) ist nach EINEM verbrauchten
+    Platz nur noch der Reserve-Platz frei. Der Vergleichs-Nowcast wird
+    trotzdem zugestellt — er prueft, wie der Trip-Nowcast, gegen das VOLLE
+    Limit (``reason="nowcast"``). Erst das erschoepfte volle Limit sperrt ihn.
+
+    Der erste Block belegt, dass der gewaehlte Zaehlerstand wirklich in der
+    Reserve-Zone liegt: mit ``reason="forecast_change"`` waere derselbe Stand
+    bereits gesperrt. Ohne diesen Nachweis koennte der Test auch dann gruen
+    sein, wenn die Reserve gar nicht griffe.
+
+    RED heute: der zweite Block stellt zu — der Vergleichs-Nowcast kennt gar
+    keine Tages-Obergrenze."""
+    from services import alert_daily_limit
+
+    reserve, voll = fresh_uid("ac12-res"), fresh_uid("ac12-voll")
+    clean_uid(reserve)
+    clean_uid(voll)
+    try:
+        jetzt = datetime.now(timezone.utc)
+
+        write_user_tier(reserve, "free")     # Limit 2, Reserve 1
+        seed_daily_counter(reserve, 1)
+        assert alert_daily_limit.is_allowed(reserve, jetzt, reason="forecast_change") is False, (
+            "Aufbau-Nachweis: bei count=1 und Limit 2 muss die #1555-Reserve den "
+            "Aenderungsalarm bereits sperren — sonst prueft dieser Test nichts"
+        )
+        assert alert_daily_limit.is_allowed(reserve, jetzt, reason="nowcast") is True, (
+            "Aufbau-Nachweis: derselbe Stand muss fuer den Nowcast frei sein"
+        )
+        _setup_compare(reserve, "cp-1467s3-ac12")
+        sent_reserve, mails_reserve = _run_compare(reserve)
+        assert (sent_reserve, len(mails_reserve)) == (1, 1), (
+            f"Der Vergleichs-Nowcast muss den Reserve-Platz nutzen duerfen "
+            f"(reason='nowcast' gegen das VOLLE Limit) — erhalten "
+            f"sent={sent_reserve}, Mails={len(mails_reserve)}"
+        )
+
+        write_user_tier(voll, "free")
+        seed_daily_counter(voll, 2)
+        _setup_compare(voll, "cp-1467s3-ac12")  # dieselbe Kennung, anderer Nutzer
+        sent_voll, mails_voll = _run_compare(voll)
+        assert (sent_voll, mails_voll) == (0, []), (
+            f"Bei erschoepftem VOLLEN Tagesbudget muss auch der Nowcast sperren — "
+            f"erhalten sent={sent_voll}, Mails={mails_voll!r}"
+        )
+    finally:
+        clean_uid(reserve)
+        clean_uid(voll)
+
+
+# ═════════════════ AC-13: Buchung erst NACH der Zustellung ══════════════════
+
+
+def test_ac13_gescheiterte_zustellung_bucht_weder_sperrzeit_noch_tageszaehler():
+    """AC-13: Ist kein Kanal erreichbar, bleiben Sperrzeit und Tageszaehler
+    exakt unveraendert — und wenn die Zustellung gelingt, wachsen beide um
+    genau eine Buchung.
+
+    Beide Haelften gehoeren zusammen: die erste allein waere auch von einer
+    Implementierung erfuellt, die NIE bucht (dann wuerde die Sperrzeit nie
+    wirken); die zweite allein waere auch von einer erfuellt, die IMMER bucht
+    (dann zaehlen fehlgeschlagene Versuche als verbraucht).
+
+    RED heute: in der zweiten Haelfte bleibt der Tageszaehler bei 0 und der
+    Sperrzeit-Eintrag landet in der presetseigenen Altdatei."""
+    gescheitert, gelungen = fresh_uid("ac13-fail"), fresh_uid("ac13-ok")
+    clean_uid(gescheitert)
+    clean_uid(gelungen)
+    try:
+        write_user_tier(gescheitert, "free")
+        _setup_compare(gescheitert, "cp-1467s3-ac13")
+        zaehler_vorher = read_daily_counter(gescheitert)
+        speicher_vorher = read_throttle_state(gescheitert)
+
+        sent, mails = _run_compare(gescheitert, settings_no_channel_reachable())
+
+        assert (sent, mails) == (0, []), (
+            f"Ohne erreichbaren Kanal darf nichts als versendet gelten — "
+            f"erhalten sent={sent}, Mails={mails!r}"
+        )
+        assert read_daily_counter(gescheitert) == zaehler_vorher, (
+            f"Der Tageszaehler wurde trotz gescheiterter Zustellung erhoeht: "
+            f"{zaehler_vorher} -> {read_daily_counter(gescheitert)}"
+        )
+        assert read_throttle_state(gescheitert) == speicher_vorher, (
+            f"Die Sperrzeit wurde trotz gescheiterter Zustellung gebucht: "
+            f"{speicher_vorher!r} -> {read_throttle_state(gescheitert)!r}"
+        )
+
+        write_user_tier(gelungen, "free")
+        _setup_compare(gelungen, "cp-1467s3-ac13")
+        sent_ok, mails_ok = _run_compare(gelungen)
+
+        assert (sent_ok, len(mails_ok)) == (1, 1), (
+            f"Voraussetzung der zweiten Haelfte: die Zustellung muss gelingen — "
+            f"erhalten sent={sent_ok}, Mails={len(mails_ok)}"
+        )
+        assert read_daily_counter(gelungen) == 1, (
+            f"Nach erfolgreicher Zustellung muss der Tageszaehler auf 1 stehen, "
+            f"steht auf {read_daily_counter(gelungen)}"
+        )
+        assert "cp-1467s3-ac13" in read_throttle_state(gelungen).get(SCOPE_COMPARE_RADAR, {}), (
+            f"Nach erfolgreicher Zustellung muss die Sperrzeit im geteilten "
+            f"Speicher stehen: {read_throttle_state(gelungen)!r}"
+        )
+    finally:
+        clean_uid(gescheitert)
+        clean_uid(gelungen)
+
+
+# ══════════════════════ AC-15: Mandantentrennung ════════════════════════════
+
+
+_GETEILTE_KENNUNG = "cp-1467s3-ac15"
+
+
+def test_ac15_sperrzeit_wirkt_nicht_ueber_die_nutzergrenze():
+    """AC-15: Zwei Nutzer mit DERSELBEN Preset-Kennung. Die laufende Sperrzeit
+    des einen darf den anderen nicht sperren.
+
+    RED heute: die Sperrzeit von A wirkt aus dessen eigener Datei, der
+    geteilte Speicher-Eintrag von A bleibt wirkungslos — A stellt zu."""
+    a, b = fresh_uid("ac15a-a"), fresh_uid("ac15a-b")
+    clean_uid(a)
+    clean_uid(b)
+    try:
+        for uid in (a, b):
+            write_user_tier(uid, "premium")  # Tageslimit aus dem Weg
+            _setup_compare(uid, _GETEILTE_KENNUNG)
+        record_throttle(a, SCOPE_COMPARE_RADAR, _GETEILTE_KENNUNG,
+                        datetime.now(timezone.utc) - timedelta(minutes=5))
+
+        sent_a, mails_a = _run_compare(a)
+        sent_b, mails_b = _run_compare(b)
+
+        assert (sent_a, mails_a) == (0, []), (
+            f"Die Sperrzeit von Nutzer A muss dessen eigenen Alarm sperren — "
+            f"erhalten sent={sent_a}, Mails={mails_a!r}"
+        )
+        assert (sent_b, len(mails_b)) == (1, 1), (
+            f"Die Sperrzeit von Nutzer A darf Nutzer B — gleiche Preset-Kennung, "
+            f"anderes Konto — NICHT sperren: sent={sent_b}, Mails={len(mails_b)}"
+        )
+        assert _GETEILTE_KENNUNG not in read_throttle_state(a).get("radar", {}), (
+            "Die Vergleichs-Sperrzeit darf nicht im Trip-Scope liegen"
+        )
+    finally:
+        clean_uid(a)
+        clean_uid(b)
+
+
+def test_ac15_tageslimit_wirkt_nicht_ueber_die_nutzergrenze():
+    """AC-15: Das erschoepfte Tagesbudget des einen Nutzers darf den anderen
+    nicht sperren — beide fuehren ihren Zaehler unter ``data/users/<id>/``.
+
+    RED heute: A stellt trotz erschoepftem Tagesbudget zu (keine Pruefung)."""
+    a, b = fresh_uid("ac15b-a"), fresh_uid("ac15b-b")
+    clean_uid(a)
+    clean_uid(b)
+    try:
+        for uid in (a, b):
+            write_user_tier(uid, "free")
+            _setup_compare(uid, _GETEILTE_KENNUNG)
+        seed_daily_counter(a, 2)
+        seed_daily_counter(b, 0)
+
+        sent_a, mails_a = _run_compare(a)
+        sent_b, mails_b = _run_compare(b)
+
+        assert (sent_a, mails_a) == (0, []), (
+            f"Nutzer A hat sein Tagesbudget aufgebraucht — kein Alarm erwartet, "
+            f"erhalten sent={sent_a}, Mails={mails_a!r}"
+        )
+        assert (sent_b, len(mails_b)) == (1, 1), (
+            f"Das Tagesbudget von A darf B nicht sperren: sent={sent_b}, "
+            f"Mails={len(mails_b)}"
+        )
+        assert read_daily_counter(a) == 2 and read_daily_counter(b) == 1, (
+            f"Zaehlerstaende nach dem Lauf: A={read_daily_counter(a)} (erwartet 2, "
+            f"unveraendert), B={read_daily_counter(b)} (erwartet 1)"
+        )
+    finally:
+        clean_uid(a)
+        clean_uid(b)

--- a/tests/tdd/test_alert_quiet_hours_robustness.py
+++ b/tests/tdd/test_alert_quiet_hours_robustness.py
@@ -982,9 +982,18 @@ _QUIET_CALL_NAMES = {"is_quiet_hours", "_is_quiet_hours"}
 # genau die geforderte Selbst-Erledigung. Ein spaeterer Rueckfall in die vom
 # PO verworfene Kopier-Loesung (eigenes try/except je Aufrufstelle) faellt
 # dann in allen vier Dateien auf.
+#
+# Issue #1467 S3: `compare_radar_alert.py` ist hier durch `alert_gate.py`
+# ERSETZT, nicht gestrichen — die Ruhezeit-Aufrufstelle des Vergleichs-Nowcast
+# ist mit dieser Scheibe in den geteilten Freigabe-Baustein umgezogen (dort
+# liegt sie jetzt fuer BEIDE Nowcast-Pfade). Der Waechter zieht mit dem Aufruf
+# um; bliebe der alte Eintrag stehen, liefe er in einer Datei ohne Aufruf ins
+# Leere und die Sicherung 1 unten (mindestens eine Aufrufstelle gefunden)
+# wuerde ihn zu Recht als Testfehler melden. `trip_alert.py` bleibt in der
+# Liste: dort rufen der Aenderungs- und der amtliche Pfad weiterhin selbst.
 _GUARDED_FILES = [
     "compare_official_alert.py",
-    "compare_radar_alert.py",
+    "alert_gate.py",
     "trip_alert.py",
     "compare_alert.py",
 ]

--- a/tests/tdd/test_compare_radar_alert.py
+++ b/tests/tdd/test_compare_radar_alert.py
@@ -28,6 +28,7 @@ SPEC: docs/specs/modules/issue_1041b_compare_radar_alert_service.md
 """
 from __future__ import annotations
 
+import json
 import re
 import shutil
 from datetime import datetime, timedelta, timezone
@@ -684,13 +685,30 @@ def test_two_users_isolated_locations_and_recipients():
             "Cross-User-Datenleck B→A in der Alarm-Mail von Nutzer A"
         )
 
-        # Datei-Isolation: nur A hat einen Throttle-Store, B (nie ausgelöst) nicht.
+        # Datei-Isolation: nur A hat einen Throttle-Eintrag, B (nie ausgelöst) nicht.
         # Der Service schreibt den Throttle-Store über get_data_dir() (isolierter
         # Root, #1133/#1265) — die Assertion muss demselben Pfad folgen.
-        a_throttle = get_data_dir(user_a) / "compare_radar_alert_throttle.json"
-        b_throttle = get_data_dir(user_b) / "compare_radar_alert_throttle.json"
-        assert a_throttle.exists(), "Throttle-Store für Nutzer A fehlt nach erfolgtem Alarm"
-        assert not b_throttle.exists(), "Nutzer B hat einen Throttle-Eintrag trotz Δ=trocken"
+        # Issue #1467 S3: Messpunkt gewandert — die Sperrzeit liegt seither im
+        # geteilten `throttle_state.json` (Scope `compare_radar`) statt in der
+        # presetseigenen `compare_radar_alert_throttle.json`. Die geprüfte
+        # Zusicherung (Mandantentrennung der Sperrzeit) ist unverändert.
+        from services.compare_radar_alert import _THROTTLE_SCOPE
+
+        def _throttled_presets(uid: str) -> dict:
+            path = get_data_dir(uid) / "throttle_state.json"
+            if not path.exists():
+                return {}
+            return json.loads(path.read_text()).get(_THROTTLE_SCOPE, {})
+
+        assert preset_a_id in _throttled_presets(user_a), (
+            "Sperrzeit-Eintrag für Nutzer A fehlt nach erfolgtem Alarm"
+        )
+        assert _throttled_presets(user_b) == {}, (
+            "Nutzer B hat einen Throttle-Eintrag trotz Δ=trocken"
+        )
+        assert preset_a_id not in _throttled_presets(user_b), (
+            "Cross-User-Datenleck A→B in der Sperrzeit-Ablage"
+        )
 
         b_dir = DATA_ROOT / user_b
         if b_dir.exists():

--- a/tests/tdd/test_compare_radar_alert_daily_limit.py
+++ b/tests/tdd/test_compare_radar_alert_daily_limit.py
@@ -1,0 +1,130 @@
+"""TDD RED — Der Ortsvergleich-Nowcast bekommt die Tages-Obergrenze
+(Issue #1467 Scheibe S3, AC-1).
+
+SPEC: docs/specs/modules/rework_1467_s3_nowcast.md — Aenderung (a)
+
+Heutiger Stand (gemessen 2026-08-08): ``compare_radar_alert.py`` importiert
+``alert_daily_limit`` ueberhaupt nicht. Die Bremse gegen Meldungsfluten fehlt
+im Vergleichs-Nowcast vollstaendig — er versendet auch dann noch, wenn das
+Tagesbudget des Nutzers laengst aufgebraucht ist.
+
+RED-Grund: der Lauf stellt trotz erreichter Tages-Obergrenze zu (``sent == 1``
+statt ``0``), weil keine Pruefung existiert.
+
+Mock-frei: echtes Preset/Ort auf Platte, echter ``CompareRadarAlertService``,
+echte Zaehlerdatei ``alert_daily_count.json``; Radar ueber den
+``frame_source``-Seam, Versand ueber ``mail_sink``. Kein Netz.
+"""
+from __future__ import annotations
+
+from tests.helpers.nowcast_gate_fixtures import (
+    CountingFrameSource, clean_uid, compare_radar_service, fresh_uid, location,
+    radar_preset, read_daily_counter, read_log, seed_daily_counter,
+    settings_email_only, write_presets, write_user_tier,
+)
+from app.loader import save_location
+
+
+def _setup(uid: str, preset_id: str, *, count: int) -> None:
+    write_user_tier(uid, "free")  # Tages-Obergrenze 2
+    seed_daily_counter(uid, count)
+    save_location(location("loc-dl", "Limitdorf"), user_id=uid)
+    write_presets(uid, [radar_preset(preset_id, ["loc-dl"], user_id=uid)])
+
+
+def test_erreichte_tages_obergrenze_unterdrueckt_den_vergleichs_nowcast():
+    """AC-1: Tagesbudget des Nutzers ist aufgebraucht (free = 2/Tag, zwei
+    Alarme heute bereits verschickt). Ein Nowcast-Onset in einem Preset dieses
+    Nutzers fuehrt trotzdem NICHT mehr zu einem Alarm — kein Versand auf
+    keinem Kanal, kein neuer Zustellungs-Eintrag im Protokoll, Zaehler bleibt
+    stehen.
+
+    RED heute: der Vergleichs-Nowcast kennt keine Tages-Obergrenze und stellt
+    zu."""
+    uid, preset_id = fresh_uid("ac1"), "cp-1467s3-ac1"
+    clean_uid(uid)
+    try:
+        _setup(uid, preset_id, count=2)
+        mails: list = []
+        sent = compare_radar_service(
+            uid, settings_email_only(), CountingFrameSource(onset_minutes=8),
+            lambda subject, body: mails.append((subject, body)),
+        ).check_all_compare_presets()
+
+        assert sent == 0, (
+            f"Tages-Obergrenze erreicht (2 von 2) — der Vergleichs-Nowcast darf "
+            f"nicht mehr zustellen, hat aber {sent} Alarm(e) versendet"
+        )
+        assert mails == [], (
+            f"Trotz aufgebrauchtem Tagesbudget wurde versendet: {mails!r}"
+        )
+        assert read_daily_counter(uid) == 2, (
+            f"Der Tageszaehler darf beim unterdrueckten Alarm nicht wachsen, "
+            f"steht auf {read_daily_counter(uid)}"
+        )
+        zustellungen = [
+            e for e in read_log(uid)["entries"] if e.get("entity_id") == preset_id
+        ]
+        assert zustellungen == [], (
+            f"Ein unterdrueckter Alarm darf keinen Zustellungs-Eintrag "
+            f"erzeugen: {zustellungen!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_freies_tagesbudget_stellt_den_vergleichs_nowcast_weiterhin_zu():
+    """Gegenprobe zum obigen Test: bei freiem Tagesbudget geht derselbe Onset
+    unveraendert raus, und die Zustellung verbraucht GENAU EINEN Platz des
+    Tagesbudgets.
+
+    Ohne diese Haelfte waere AC-1 auch von einer Implementierung erfuellt, die
+    den Vergleichs-Nowcast pauschal abschaltet — der gefaehrlichste Fehler
+    dieser Scheibe.
+
+    RED heute: der Zaehler wird nicht erhoeht (0 statt 1), weil der
+    Vergleichs-Nowcast das Tagesbudget nicht kennt."""
+    uid, preset_id = fresh_uid("ac1-frei"), "cp-1467s3-ac1-frei"
+    clean_uid(uid)
+    try:
+        _setup(uid, preset_id, count=0)
+        mails: list = []
+        sent = compare_radar_service(
+            uid, settings_email_only(), CountingFrameSource(onset_minutes=8),
+            lambda subject, body: mails.append((subject, body)),
+        ).check_all_compare_presets()
+
+        assert sent == 1, f"Bei freiem Tagesbudget muss der Onset alarmieren: {sent}"
+        assert len(mails) == 1, f"Erwartet genau EINE Mail, erhalten {len(mails)}"
+        assert read_daily_counter(uid) == 1, (
+            f"Eine zugestellte Vergleichs-Nowcast-Meldung muss GENAU EINEN Platz "
+            f"des Tagesbudgets verbrauchen, Zaehler steht auf "
+            f"{read_daily_counter(uid)}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_erreichte_tages_obergrenze_verhindert_auch_den_nowcast_abruf():
+    """AC-1 (Kostenseite): Die Freigabe-Stufen laufen — wie in der
+    Trip-Vorlage (``trip_alert.py:748-765``: Ruhezeit, Sperrzeit, Tageslimit,
+    DANN Abruf) — vollstaendig VOR der Datenbeschaffung. Ist das Tagesbudget
+    aufgebraucht, wird fuer keinen Ort des Presets ein Nowcast abgerufen.
+
+    RED heute: der Vergleichs-Nowcast holt zuerst die Daten und prueft
+    ueberhaupt kein Tagesbudget — der Abrufzaehler steht auf 1 statt 0."""
+    uid, preset_id = fresh_uid("ac1-abruf"), "cp-1467s3-ac1-abruf"
+    clean_uid(uid)
+    try:
+        _setup(uid, preset_id, count=2)
+        frames = CountingFrameSource(onset_minutes=8)
+        compare_radar_service(
+            uid, settings_email_only(), frames, lambda subject, body: None,
+        ).check_all_compare_presets()
+
+        assert frames.call_count == 0, (
+            f"Bei erreichter Tages-Obergrenze darf kein Nowcast abgerufen werden, "
+            f"es wurden aber {frames.call_count} Abrufe gezaehlt: {frames.calls!r}"
+        )
+    finally:
+        clean_uid(uid)

--- a/tests/tdd/test_compare_radar_alert_quiet_hours_precedes_fetch.py
+++ b/tests/tdd/test_compare_radar_alert_quiet_hours_precedes_fetch.py
@@ -1,0 +1,118 @@
+"""TDD RED + Invarianten-Waechter — Ruhezeit VOR der Datenbeschaffung
+(Issue #1467 S3, AC-4 + AC-5).
+
+SPEC: docs/specs/modules/rework_1467_s3_nowcast.md — Aenderung (c)
+
+Heutiger Stand (gemessen 2026-08-08): ``compare_radar_alert.py:117-124`` prueft
+die Ruhezeit ERST nach ``_detect_triggered_locations()`` — der Nowcast wird
+also fuer jeden Ort abgerufen und erst danach verworfen. Die Ruhezeit-Pruefung
+wandert vor den Abruf (Muster ``compare_official_alert.py:105-113``).
+
+Zwei verschiedene Sorten Test in dieser Datei:
+
+* ``test_ruhezeit_verhindert_jeden_nowcast_abruf`` (AC-4) ist ROT — er misst
+  die neue Wirkung (0 Abrufe).
+* ``test_meldeverhalten_bei_ruhezeit_bleibt_unveraendert`` (AC-5) ist HEUTE
+  GRUEN und muss es bleiben: das Vorziehen darf am Melde-Ergebnis nichts
+  aendern. Er loest zwei archivierte Zusicherungen ab (#1041 AC-6, #1041b
+  AC-5: "Onset wird erkannt, Alarm unterdrueckt") — abgeloest wird die
+  Erkennung, NICHT das Melde-Ergebnis.
+
+Mock-frei: echte Presets/Orte, echter Service, zaehlende ``frame_source``-Naht
+an der Stelle, an der der Abruf real Kosten verursacht. Kein Netz.
+"""
+from __future__ import annotations
+
+from app.loader import save_location
+
+from tests.helpers.nowcast_gate_fixtures import (
+    CountingFrameSource, clean_uid, compare_radar_service, fresh_uid, location,
+    quiet_window_elsewhere, quiet_window_now, radar_preset, reset_radar_cache,
+    settings_email_only, write_presets, write_user_tier,
+)
+
+
+def _setup(uid: str, preset_id: str, *, quiet: bool) -> None:
+    # premium = kein Tageslimit; Cooldown-Ablage leer -> isoliert die Ruhezeit.
+    write_user_tier(uid, "premium")
+    save_location(location("loc-qh", "Ruhezeitdorf"), user_id=uid)
+    quiet_from, quiet_to = quiet_window_now() if quiet else quiet_window_elsewhere()
+    write_presets(uid, [radar_preset(
+        preset_id, ["loc-qh"], user_id=uid,
+        quiet_from=quiet_from, quiet_to=quiet_to,
+    )])
+
+
+def _run(uid: str) -> tuple[int, list, CountingFrameSource]:
+    reset_radar_cache()
+    frames = CountingFrameSource(onset_minutes=8)
+    mails: list = []
+    sent = compare_radar_service(
+        uid, settings_email_only(), frames,
+        lambda subject, body: mails.append((subject, body)),
+    ).check_all_compare_presets()
+    return sent, mails, frames
+
+
+def test_ruhezeit_verhindert_jeden_nowcast_abruf():
+    """AC-4: Laeuft ``check_all_compare_presets()`` waehrend der Ruhezeit des
+    Presets, wird fuer KEINEN Ort ein Nowcast abgerufen — der Abrufzaehler an
+    der Radar-Naht bleibt bei 0.
+
+    Die Frames wuerden ausloesen, wenn sie geholt wuerden — der Test beweist
+    damit den unterlassenen Abruf, nicht einen zufaellig trockenen Ort.
+
+    RED heute: die Ruhezeit greift erst nach der Erkennung, es wird 1x
+    abgerufen."""
+    uid, preset_id = fresh_uid("ac4"), "cp-1467s3-ac4"
+    clean_uid(uid)
+    try:
+        _setup(uid, preset_id, quiet=True)
+        sent, mails, frames = _run(uid)
+
+        assert frames.call_count == 0, (
+            f"Waehrend der Ruhezeit darf kein Nowcast abgerufen werden, es wurden "
+            f"aber {frames.call_count} Abrufe gezaehlt: {frames.calls!r}"
+        )
+        assert sent == 0, f"Waehrend der Ruhezeit darf nichts rausgehen ({sent})"
+        assert mails == [], f"Waehrend der Ruhezeit versendet: {mails!r}"
+    finally:
+        clean_uid(uid)
+
+
+def test_meldeverhalten_bei_ruhezeit_bleibt_unveraendert():
+    """AC-5 (Invariante, heute GRUEN): Identische Onset-Bedingung, einmal mit
+    gesetztem Ruhezeit-Fenster um „jetzt" und einmal mit einem gesetzten
+    Fenster, das „jetzt" NICHT enthaelt.
+
+    Ergebnis vor UND nach dem Vorziehen gleich:
+      * Ruhezeit AKTIV   -> kein Alarm
+      * Ruhezeit INAKTIV -> Alarm
+
+    Beide Faelle tragen ein GESETZTES Fenster — sonst liefe der zweite Fall in
+    den ``not quiet_from``-Kurzschluss und wuerde die Auswertung gar nicht
+    beruehren.
+    """
+    aktiv, inaktiv = fresh_uid("ac5-an"), fresh_uid("ac5-aus")
+    clean_uid(aktiv)
+    clean_uid(inaktiv)
+    try:
+        _setup(aktiv, "cp-1467s3-ac5-an", quiet=True)
+        _setup(inaktiv, "cp-1467s3-ac5-aus", quiet=False)
+
+        sent_aktiv, mails_aktiv, _f1 = _run(aktiv)
+        sent_inaktiv, mails_inaktiv, _f2 = _run(inaktiv)
+
+        assert (sent_aktiv, len(mails_aktiv)) == (0, 0), (
+            f"Bei aktiver Ruhezeit darf KEIN Alarm rausgehen — erhalten "
+            f"sent={sent_aktiv}, Mails={len(mails_aktiv)}"
+        )
+        assert (sent_inaktiv, len(mails_inaktiv)) == (1, 1), (
+            f"Ausserhalb der Ruhezeit MUSS derselbe Onset alarmieren — erhalten "
+            f"sent={sent_inaktiv}, Mails={len(mails_inaktiv)}. Ein zu frueh oder "
+            f"zu breit gesetzter Riegel verschluckt echte Alarme (der "
+            f"gefaehrlichste Fehler dieser Scheibe)"
+        )
+    finally:
+        clean_uid(aktiv)
+        clean_uid(inaktiv)

--- a/tests/tdd/test_compare_radar_alert_shared_throttle.py
+++ b/tests/tdd/test_compare_radar_alert_shared_throttle.py
@@ -1,0 +1,188 @@
+"""TDD RED — Die Sperrzeit des Vergleichs-Nowcast wirkt aus dem GETEILTEN
+Speicher, nicht mehr aus einer eigenen Datei (Issue #1467 S3, AC-2 + AC-3).
+
+SPEC: docs/specs/modules/rework_1467_s3_nowcast.md — Aenderung (b)
+
+Heutiger Stand (gemessen 2026-08-08): ``compare_radar_alert.py`` fuehrt seine
+Sperrzeit in ``compare_radar_alert_throttle.json`` — einem flachen
+``{preset_id: iso}``-Dict ohne Dateisperre und ohne atomaren Schreibvorgang.
+Der geteilte ``ThrottleStore`` (``throttle_state.json``, ``fcntl``-Lock,
+atomar) kennt den Vergleichs-Nowcast nicht.
+
+Ziel: neuer Scope ``compare_radar`` mit dem Preset als Schluessel. Bewusst
+NICHT ``radar`` (dort liegen Trip-Kennungen; seit dem #1250-Cutover sind
+Trip- und Vergleichs-Kennungen frei gewaehlte Slugs im selben Verzeichnis,
+Kollision also real moeglich) und bewusst NICHT ``compare_preset`` (dort liegt
+bereits der Aenderungsalarm auf demselben Preset-Schluessel).
+
+RED-Gruende:
+- AC-2: ein Eintrag im geteilten Speicher entfaltet heute KEINE Sperrwirkung
+  (der Alarm geht raus, ``sent == 1`` statt ``0``).
+- AC-3: die Altdatei sperrt heute noch (``sent == 0`` statt ``1``).
+
+Mock-frei: echter ``ThrottleStore`` schreibt/liest die echte Zustandsdatei,
+echter Service, echtes Preset auf Platte; kein Netz.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+from app.loader import get_data_dir, save_location
+
+from tests.helpers.nowcast_gate_fixtures import (
+    LEGACY_COMPARE_RADAR_FILE, SCOPE_COMPARE_RADAR, CountingFrameSource,
+    clean_uid, compare_radar_service, fresh_uid, location, radar_preset,
+    read_throttle_state, record_throttle, settings_email_only,
+    write_legacy_compare_throttle, write_presets, write_user_tier,
+)
+
+
+def _setup(uid: str, preset_id: str) -> None:
+    # premium = kein Tageslimit: dieser Test misst ausschliesslich die
+    # Sperrzeit, nicht die Tages-Obergrenze aus Aenderung (a).
+    write_user_tier(uid, "premium")
+    save_location(location("loc-cd", "Sperrzeitdorf"), user_id=uid)
+    write_presets(uid, [radar_preset(preset_id, ["loc-cd"], user_id=uid,
+                                     cooldown_minutes=120)])
+
+
+def _run(uid: str) -> tuple[int, list]:
+    mails: list = []
+    sent = compare_radar_service(
+        uid, settings_email_only(), CountingFrameSource(onset_minutes=8),
+        lambda subject, body: mails.append((subject, body)),
+    ).check_all_compare_presets()
+    return sent, mails
+
+
+def test_eintrag_im_geteilten_speicher_sperrt_den_vergleichs_nowcast():
+    """AC-2: Ein frischer Sperrzeit-Eintrag im geteilten Speicher (Scope
+    ``compare_radar``, Schluessel = Preset-Kennung) unterdrueckt den erneuten
+    Alarm desselben Presets.
+
+    RED heute: der Vergleichs-Nowcast liest seine eigene Datei und ignoriert
+    den geteilten Speicher — der Alarm geht raus."""
+    uid, preset_id = fresh_uid("ac2"), "cp-1467s3-ac2"
+    clean_uid(uid)
+    try:
+        _setup(uid, preset_id)
+        record_throttle(uid, SCOPE_COMPARE_RADAR, preset_id,
+                        datetime.now(timezone.utc) - timedelta(minutes=5))
+
+        sent, mails = _run(uid)
+
+        assert sent == 0, (
+            f"Sperrzeit aus dem geteilten Speicher (Scope {SCOPE_COMPARE_RADAR!r}, "
+            f"Schluessel {preset_id!r}, vor 5 Minuten, Cooldown 120 Min) muss den "
+            f"Alarm unterdruecken — es wurden {sent} Alarm(e) versendet"
+        )
+        assert mails == [], f"Trotz laufender Sperrzeit versendet: {mails!r}"
+    finally:
+        clean_uid(uid)
+
+
+def test_zustellung_bucht_die_sperrzeit_im_geteilten_speicher():
+    """AC-2 (Schreibseite): Nach einer erfolgreichen Zustellung liegt die
+    Sperrzeit im geteilten Speicher unter Scope ``compare_radar`` mit der
+    Preset-Kennung — und ein zweiter Lauf ist dadurch gesperrt.
+
+    Der zweite Lauf ist die eigentliche Zusicherung: eine Buchung, die nicht
+    sperrt, waere Buchhaltung ohne Wirkung.
+
+    RED heute: der Eintrag landet in der presetseigenen Altdatei, der geteilte
+    Speicher bleibt fuer diesen Scope leer."""
+    uid, preset_id = fresh_uid("ac2-write"), "cp-1467s3-ac2-write"
+    clean_uid(uid)
+    try:
+        _setup(uid, preset_id)
+
+        erster, mails1 = _run(uid)
+        assert erster == 1, f"Voraussetzung: der erste Lauf muss alarmieren ({erster})"
+
+        state = read_throttle_state(uid)
+        assert preset_id in state.get(SCOPE_COMPARE_RADAR, {}), (
+            f"Nach der Zustellung fehlt die Sperrzeit im geteilten Speicher unter "
+            f"Scope {SCOPE_COMPARE_RADAR!r}: {state!r}"
+        )
+        assert preset_id not in state.get("radar", {}), (
+            "Die Vergleichs-Sperrzeit darf NICHT im Trip-Scope 'radar' landen — "
+            f"dort liegen Trip-Kennungen: {state!r}"
+        )
+        assert preset_id not in state.get("compare_preset", {}), (
+            "Die Nowcast-Sperrzeit darf NICHT im Scope 'compare_preset' landen — "
+            f"den belegt bereits der Aenderungsalarm auf demselben Schluessel: {state!r}"
+        )
+
+        zweiter, mails2 = _run(uid)
+        assert zweiter == 0, (
+            f"Der zweite Lauf innerhalb des Cooldown-Fensters darf nicht erneut "
+            f"versenden ({zweiter})"
+        )
+        assert len(mails1) + len(mails2) == 1, (
+            f"Erwartet genau EINE Mail ueber beide Laeufe, erhalten "
+            f"{len(mails1) + len(mails2)}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_alte_sperrzeit_datei_wirkt_nicht_mehr():
+    """AC-3: Ein frischer Eintrag ausschliesslich in der abgeloesten Datei
+    ``compare_radar_alert_throttle.json`` — der geteilte Speicher ist leer —
+    entfaltet KEINE Sperrwirkung mehr. Der Alarm geht raus. Es gibt bewusst
+    keinen Uebernahme-Mechanismus (Spec (b), "Altdaten").
+
+    Die Altdatei bleibt dabei unangetastet liegen: sie wird nicht mehr
+    geschrieben (Zeitstempel unveraendert) und nicht geloescht.
+
+    RED heute: die Altdatei sperrt — es geht nichts raus."""
+    uid, preset_id = fresh_uid("ac3"), "cp-1467s3-ac3"
+    clean_uid(uid)
+    try:
+        _setup(uid, preset_id)
+        alt_zeit = datetime.now(timezone.utc) - timedelta(minutes=5)
+        legacy_path = write_legacy_compare_throttle(uid, preset_id, alt_zeit)
+        assert read_throttle_state(uid) == {}, (
+            "Voraussetzung: der geteilte Speicher muss zu Beginn leer sein"
+        )
+
+        sent, mails = _run(uid)
+
+        assert sent == 1, (
+            f"Die abgeloeste Datei {LEGACY_COMPARE_RADAR_FILE} darf keine "
+            f"Sperrwirkung mehr haben — es wurden {sent} Alarme versendet"
+        )
+        assert len(mails) == 1, f"Erwartet genau EINE Mail, erhalten {len(mails)}"
+
+        inhalt = json.loads(legacy_path.read_text())
+        assert inhalt == {preset_id: alt_zeit.isoformat()}, (
+            f"Die Altdatei darf nicht mehr geschrieben werden, wurde aber "
+            f"veraendert: {inhalt!r}"
+        )
+        assert preset_id in read_throttle_state(uid).get(SCOPE_COMPARE_RADAR, {}), (
+            "Die neue Sperrzeit muss im geteilten Speicher landen"
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_alte_datei_wird_bei_leerer_ausgangslage_gar_nicht_mehr_angelegt():
+    """AC-3 (Ergaenzung): Ein Lauf ohne Altdatei legt sie auch nicht neu an —
+    der Vergleichs-Nowcast hat keine eigene Sperrzeit-Ablage mehr.
+
+    RED heute: der Service schreibt sie bei jeder Zustellung."""
+    uid, preset_id = fresh_uid("ac3-neu"), "cp-1467s3-ac3-neu"
+    clean_uid(uid)
+    try:
+        _setup(uid, preset_id)
+        sent, _mails = _run(uid)
+        assert sent == 1, f"Voraussetzung: der Lauf muss alarmieren ({sent})"
+
+        legacy = get_data_dir(uid) / LEGACY_COMPARE_RADAR_FILE
+        assert not legacy.exists(), (
+            f"Die abgeloeste Sperrzeit-Datei {legacy} wurde neu angelegt — "
+            "der Vergleichs-Nowcast fuehrt weiterhin eine eigene Ablage"
+        )
+    finally:
+        clean_uid(uid)

--- a/tests/tdd/test_data_root_migration_services.py
+++ b/tests/tdd/test_data_root_migration_services.py
@@ -71,15 +71,39 @@ def test_ac2_daily_alert_limit_reads_tier_from_isolated_root():
     assert user_tier.daily_alert_limit(uid) == 4
 
 
-# --- AC-3: CompareRadarAlertService-Throttle zeigt unter die isolierte Wurzel ---
+# --- AC-3: Compare-Radar-Sperrzeit zeigt unter die isolierte Wurzel ---
 def test_ac3_radar_alert_throttle_file_under_isolated_root():
-    from services.compare_radar_alert import CompareRadarAlertService
+    """Messpunkt gewandert (Issue #1467 S3): der Vergleichs-Nowcast fuehrt
+    seine Sperrzeit nicht mehr in der eigenen Datei
+    `compare_radar_alert_throttle.json`, sondern im geteilten `ThrottleStore`
+    (`throttle_state.json`, Scope `compare_radar`).
+
+    Die gepruefte Zusicherung ist unveraendert: die Sperrzeit-Ablage des
+    Vergleichs-Nowcast liegt unter der ISOLIERTEN `get_data_dir()`-Wurzel,
+    nicht unter einem hartkodierten `data/users/...`. Gemessen wird jetzt am
+    tatsaechlichen Schreibvorgang der Produktionsfunktion statt an einem
+    Attribut — schaerfer als vorher. Dass der Service genau diesen Scope und
+    diesen Schluessel benutzt, haelt
+    `tests/tdd/test_compare_radar_alert_shared_throttle.py` fest.
+    """
+    from services.alert_gate import record_nowcast_sent
+    from services.compare_radar_alert import _THROTTLE_SCOPE, CompareRadarAlertService
 
     uid = _uid()
-    service = CompareRadarAlertService(settings=Settings(), user_id=uid)
+    preset_id = "cp-datenwurzel"
+    CompareRadarAlertService(settings=Settings(), user_id=uid)  # muss anlegbar bleiben
 
-    expected = get_data_dir(uid) / "compare_radar_alert_throttle.json"
-    assert service._throttle_file == expected
+    record_nowcast_sent(
+        user_id=uid, throttle_scope=_THROTTLE_SCOPE, throttle_key=preset_id,
+        now=datetime.now(timezone.utc),
+    )
+
+    expected = get_data_dir(uid) / "throttle_state.json"
+    assert expected.exists(), (
+        f"Sperrzeit-Ablage {expected} fehlt unter der isolierten Wurzel — "
+        "der Vergleichs-Nowcast schreibt an ihr vorbei"
+    )
+    assert preset_id in json.loads(expected.read_text()).get(_THROTTLE_SCOPE, {})
 
 
 # --- AC-4: CompareWeatherSnapshotService save/load-Roundtrip unter isolierter Wurzel ---

--- a/tests/tdd/test_issue_1070_daily_alert_limit.py
+++ b/tests/tdd/test_issue_1070_daily_alert_limit.py
@@ -339,10 +339,34 @@ def test_ac1_radar_alert_suppressed_when_free_daily_limit_reached():
             f"AC-1: Zähler darf bei unterdrücktem Alert nicht erhöht werden, got {data}"
         )
 
+        # Issue #1467 S3: Messpunkt geschärft. Seither protokolliert der
+        # Nowcast-Pfad, WARUM unterdrückt wurde — der Eintrag landet in
+        # `not_delivered` (von Go nie gelesen, D4). Die hier gemeinte
+        # Zusicherung ist unverändert: es entsteht KEIN Zustellungs-Eintrag,
+        # Cockpit-Kachel und Archiv-Statistik bleiben zahlgleich. Zusätzlich
+        # festgenagelt: der Unterdrückungs-Eintrag nennt das Tageslimit als
+        # Grund und behauptet keine Zustellung.
+        from services import alert_log
+
         alert_log_path = get_data_dir(uid) / "alert_log.json"
-        assert not alert_log_path.exists(), (
-            "AC-1: alert_log.json wurde geschrieben, obwohl das Tageslimit erreicht war"
+        log = json.loads(alert_log_path.read_text()) if alert_log_path.exists() else {}
+        assert log.get("entries", []) == [], (
+            f"AC-1: trotz erreichtem Tageslimit wurde ein Zustellungs-Eintrag "
+            f"geschrieben: {log.get('entries')!r}"
         )
+        gruende = {
+            item.get("reason")
+            for eintrag in log.get("not_delivered", [])
+            for item in eintrag.get("channels_not_sent", [])
+        }
+        assert gruende == {alert_log.REASON_DAILY_LIMIT}, (
+            f"AC-1: der Unterdrückungs-Eintrag muss ausschließlich das "
+            f"Tageslimit als Grund nennen, nennt aber {gruende!r}"
+        )
+        assert all(
+            eintrag.get("channels_sent") == []
+            for eintrag in log.get("not_delivered", [])
+        ), "AC-1: ein unterdrückter Alarm darf keinen zugestellten Kanal führen"
     finally:
         _clean_user(uid)
 

--- a/tests/tdd/test_nowcast_suppression_logging.py
+++ b/tests/tdd/test_nowcast_suppression_logging.py
@@ -1,0 +1,640 @@
+"""TDD RED + Invarianten-Waechter — Unterdrueckte Nowcast-Alarme werden
+protokolliert (Issue #1467 S3, AC-6 bis AC-10).
+
+SPEC: docs/specs/modules/rework_1467_s3_nowcast.md — Aenderung (d)
+
+Die drei Konstanten ``REASON_QUIET_HOURS``/``REASON_COOLDOWN``/
+``REASON_DAILY_LIMIT`` (``alert_log.py:47-49``) sind seit #1459 dokumentiert,
+aber repo-weit von KEINEM Aufrufer gesetzt (gemessen 2026-08-08). Diese
+Scheibe schaltet sie fuer die beiden Nowcast-Pfade scharf: wird ein
+Nowcast-Lauf vom Freigabe-Baustein abgewiesen, entsteht dafuer GENAU EIN
+Protokoll-Eintrag mit dem Grund der sperrenden Stufe — in der Liste
+``not_delivered``, die Go nie liest (D4: Cockpit-Kachel und Archiv-Statistik
+bleiben zahlgleich).
+
+Zwei Sorten Test:
+
+* AC-6/AC-7/AC-8 (Ortsvergleich) und AC-10 (Trip) sind ROT — heute wird gar
+  nichts protokolliert.
+* AC-9 ist ein Invarianten-Waechter und HEUTE GRUEN: der Geltungsbereich
+  bleibt strikt auf die beiden Nowcast-Pfade begrenzt. Aenderungsalarm und
+  amtliche Warnung bekommen KEINEN der drei Gruende — auch nicht als
+  Nebenwirkung einer Protokollierung, die im geteilten Ruhezeit-/Tageslimit-
+  Baustein statt im Nowcast-Pfad sitzt.
+
+Mock-frei: echte Presets/Trips/Orte auf Platte, echte Services, echtes
+``alert_log.json``; DI-Naehte fuer Radar/Wetter/amtliche Quelle/Versand.
+Kein Netz.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.loader import save_location
+
+from tests.helpers.alert_log_fixtures import gust_alert_trip, weather
+from tests.helpers.nowcast_gate_fixtures import (
+    LAT, LON, SCOPE_COMPARE_RADAR, SCOPE_TRIP_RADAR, CountingFrameSource,
+    clean_uid, compare_radar_service, entries_for, fresh_uid, location,
+    make_trip, quiet_window_elsewhere, quiet_window_now, radar_preset,
+    read_log, record_throttle, save_trip, seed_daily_counter,
+    settings_email_only, suppression_reasons, trip_alert_service,
+    write_presets, write_user_tier,
+)
+
+
+class _FakeOfficialSource:
+    """Echte Quelle im Sinne des Quell-Protokolls (strukturelles Subtyping) —
+    Vorbild ``tests/tdd/test_alert_log_compare_and_tenancy.py``."""
+
+    def __init__(self, alerts) -> None:
+        self._alerts = alerts
+
+    @property
+    def name(self) -> str:
+        return "tdd-1467s3-source"
+
+    def covers(self, lat, lon) -> bool:
+        return True
+
+    def fetch(self, lat, lon):
+        return list(self._alerts)
+
+
+def _gate_reasons_in_log(uid: str) -> set[str]:
+    log = read_log(uid)
+    gefunden: set[str] = set()
+    for eintrag in log["entries"] + log["not_delivered"]:
+        gefunden |= suppression_reasons(eintrag)
+    return gefunden
+
+
+def _assert_zustellung_ohne_unterdrueckungs_eintrag(uid: str, entity_id: str) -> None:
+    """Ein ZUGESTELLTER Nowcast-Alarm darf keinen Unterdrueckungs-Eintrag
+    hinterlassen — weder mit einem der drei Gate-Gruende noch ueberhaupt.
+
+    Die zweite Haelfte ist die entscheidende: wird
+    ``append_suppressed_entry()`` bedingungslos statt nur bei
+    ``GateResult.allowed is False`` gerufen, traegt der Zusatz-Eintrag
+    ``gate_reason=None`` (bei einer Freigabe ist ``GateResult.reason`` leer).
+    Eine Pruefung, die nur nach den drei Gruenden sucht, laeuft an genau
+    dieser Verfaelschung vorbei — gemessen am 2026-08-08, sie liess beide
+    Pfade durch. Geprueft wird deshalb die Liste selbst: nach einer
+    erfolgreichen Zustellung steht fuer diese Kennung GENAU EIN Eintrag in
+    ``entries`` und KEINER in ``not_delivered``.
+
+    Fachlicher Grund: das Protokoll beantwortet die Frage „warum kam kein
+    Alarm?". Ein Eintrag, der auch dann erscheint, wenn der Alarm ankam,
+    macht diese Antwort unbrauchbar.
+    """
+    log = read_log(uid)
+    unterdrueckt = [
+        e for e in log["not_delivered"]
+        if isinstance(e, dict) and e.get("entity_id") == entity_id
+    ]
+    assert unterdrueckt == [], (
+        f"Ein ZUGESTELLTER Nowcast hat einen Unterdrueckungs-Eintrag fuer "
+        f"{entity_id!r} hinterlassen: {unterdrueckt!r}"
+    )
+    zugestellt = [
+        e for e in log["entries"]
+        if isinstance(e, dict) and e.get("entity_id") == entity_id
+    ]
+    assert len(zugestellt) == 1, (
+        f"Erwartet GENAU EINEN Zustellungs-Eintrag fuer {entity_id!r}, "
+        f"gefunden {len(zugestellt)}: {zugestellt!r}"
+    )
+    assert _gate_reasons_in_log(uid) == set(), (
+        f"Ein ZUGESTELLTER Nowcast darf keinen Unterdrueckungs-Grund "
+        f"protokollieren: {log!r}"
+    )
+
+
+# ═══════════════════ Ortsvergleich-Nowcast (AC-6/AC-7/AC-8) ═════════════════
+
+
+def _setup_compare(uid: str, preset_id: str, *, quiet: bool = False) -> None:
+    save_location(location("loc-log", "Protokolldorf"), user_id=uid)
+    quiet_from, quiet_to = quiet_window_now() if quiet else quiet_window_elsewhere()
+    write_presets(uid, [radar_preset(
+        preset_id, ["loc-log"], user_id=uid, cooldown_minutes=120,
+        quiet_from=quiet_from, quiet_to=quiet_to,
+    )])
+
+
+def _run_compare(uid: str) -> int:
+    return compare_radar_service(
+        uid, settings_email_only(), CountingFrameSource(onset_minutes=8),
+        lambda subject, body: None,
+    ).check_all_compare_presets()
+
+
+def _assert_genau_ein_unterdrueckungs_eintrag(
+    uid: str, entity_id: str, entity_type: str, grund: str,
+) -> None:
+    unterdrueckt = entries_for(uid, entity_id, bucket="not_delivered")
+    passend = [e for e in unterdrueckt if grund in suppression_reasons(e)]
+    assert len(passend) == 1, (
+        f"Erwartet GENAU EINEN Protokoll-Eintrag mit dem Unterdrueckungs-Grund "
+        f"{grund!r} fuer {entity_id!r} in 'not_delivered', gefunden "
+        f"{len(passend)}. Protokoll: {read_log(uid)!r}"
+    )
+    assert passend[0].get("entity_type") == entity_type, (
+        f"Der Eintrag muss den Typ {entity_type!r} tragen: {passend[0]!r}"
+    )
+    zugestellt = entries_for(uid, entity_id, bucket="entries")
+    assert zugestellt == [], (
+        f"Ein unterdrueckter Alarm darf NICHT in 'entries' landen — sonst "
+        f"zaehlen Cockpit-Kachel und Archiv-Statistik ihn als Meldung: "
+        f"{zugestellt!r}"
+    )
+
+
+def test_ac6_ruhezeit_erzeugt_protokoll_eintrag_im_ortsvergleich():
+    """AC-6: Scheitert der Vergleichs-Nowcast an der Ruhezeit, steht im
+    Alarm-Protokoll ein Eintrag mit dem Grund ``quiet_hours``.
+
+    RED heute: der Vergleichs-Nowcast protokolliert Unterdrueckungen
+    ueberhaupt nicht — das Protokoll bleibt leer."""
+    uid, preset_id = fresh_uid("ac6"), "cp-1467s3-ac6"
+    clean_uid(uid)
+    try:
+        from services.alert_log import REASON_QUIET_HOURS
+
+        write_user_tier(uid, "premium")  # Tageslimit aus dem Weg
+        _setup_compare(uid, preset_id, quiet=True)
+
+        assert _run_compare(uid) == 0, "Voraussetzung: die Ruhezeit muss sperren"
+        _assert_genau_ein_unterdrueckungs_eintrag(
+            uid, preset_id, "compare", REASON_QUIET_HOURS,
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_ac7_sperrzeit_erzeugt_protokoll_eintrag_im_ortsvergleich():
+    """AC-7: Scheitert der Vergleichs-Nowcast an der Sperrzeit, steht im
+    Alarm-Protokoll ein Eintrag mit dem Grund ``cooldown``.
+
+    RED heute: keine Protokollierung (und die Sperrzeit wirkt noch aus der
+    presetseigenen Altdatei, s. ``test_compare_radar_alert_shared_throttle``)."""
+    uid, preset_id = fresh_uid("ac7"), "cp-1467s3-ac7"
+    clean_uid(uid)
+    try:
+        from services.alert_log import REASON_COOLDOWN
+
+        write_user_tier(uid, "premium")
+        _setup_compare(uid, preset_id)
+        record_throttle(uid, SCOPE_COMPARE_RADAR, preset_id,
+                        datetime.now(timezone.utc) - timedelta(minutes=5))
+
+        assert _run_compare(uid) == 0, "Voraussetzung: die Sperrzeit muss sperren"
+        _assert_genau_ein_unterdrueckungs_eintrag(
+            uid, preset_id, "compare", REASON_COOLDOWN,
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_ac8_tageslimit_erzeugt_protokoll_eintrag_im_ortsvergleich():
+    """AC-8: Scheitert der Vergleichs-Nowcast an der Tages-Obergrenze, steht
+    im Alarm-Protokoll ein Eintrag mit dem Grund ``daily_limit``.
+
+    RED heute: der Vergleichs-Nowcast kennt weder die Tages-Obergrenze noch
+    die Protokollierung."""
+    uid, preset_id = fresh_uid("ac8"), "cp-1467s3-ac8"
+    clean_uid(uid)
+    try:
+        from services.alert_log import REASON_DAILY_LIMIT
+
+        write_user_tier(uid, "free")
+        seed_daily_counter(uid, 2)
+        _setup_compare(uid, preset_id)
+
+        assert _run_compare(uid) == 0, "Voraussetzung: das Tageslimit muss sperren"
+        _assert_genau_ein_unterdrueckungs_eintrag(
+            uid, preset_id, "compare", REASON_DAILY_LIMIT,
+        )
+    finally:
+        clean_uid(uid)
+
+
+# ═══════════════════════════ Trip-Nowcast (AC-10) ═══════════════════════════
+
+
+def _run_trip(
+    uid: str, trip_id: str, *, quiet: bool = False, throttled: bool = False,
+    daily_limit_reached: bool = False,
+) -> int:
+    quiet_from, quiet_to = quiet_window_now() if quiet else quiet_window_elsewhere()
+    save_trip(make_trip(trip_id, quiet_from=quiet_from, quiet_to=quiet_to), uid)
+    if throttled:
+        record_throttle(uid, SCOPE_TRIP_RADAR, trip_id,
+                        datetime.now(timezone.utc) - timedelta(minutes=5))
+    seed_daily_counter(uid, 2 if daily_limit_reached else 0)
+    return trip_alert_service(
+        uid, settings_email_only(), CountingFrameSource(onset_minutes=8),
+        lambda subject, body: None,
+    ).check_radar_alerts()
+
+
+def test_ac10_trip_nowcast_protokolliert_ruhezeit():
+    """AC-10: Auch der Trip-Nowcast protokolliert seine Unterdrueckung —
+    Ruhezeit.
+
+    RED heute: der Trip-Pfad bricht bei Ruhezeit mit einem Debug-Log ab und
+    schreibt nichts ins Alarm-Protokoll."""
+    uid, trip_id = fresh_uid("ac10-qh"), "trip-1467s3-ac10-qh"
+    clean_uid(uid)
+    try:
+        from services.alert_log import REASON_QUIET_HOURS
+
+        write_user_tier(uid, "premium")
+        assert _run_trip(uid, trip_id, quiet=True) == 0, (
+            "Voraussetzung: die Ruhezeit muss sperren"
+        )
+        _assert_genau_ein_unterdrueckungs_eintrag(
+            uid, trip_id, "trip", REASON_QUIET_HOURS,
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_ac10_trip_nowcast_protokolliert_sperrzeit():
+    """AC-10: Trip-Nowcast, Unterdrueckung durch die Sperrzeit.
+
+    RED heute: keine Protokollierung."""
+    uid, trip_id = fresh_uid("ac10-cd"), "trip-1467s3-ac10-cd"
+    clean_uid(uid)
+    try:
+        from services.alert_log import REASON_COOLDOWN
+
+        write_user_tier(uid, "premium")
+        assert _run_trip(uid, trip_id, throttled=True) == 0, (
+            "Voraussetzung: die Sperrzeit muss sperren"
+        )
+        _assert_genau_ein_unterdrueckungs_eintrag(
+            uid, trip_id, "trip", REASON_COOLDOWN,
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_ac10_trip_nowcast_protokolliert_tageslimit():
+    """AC-10: Trip-Nowcast, Unterdrueckung durch die Tages-Obergrenze.
+
+    RED heute: keine Protokollierung."""
+    uid, trip_id = fresh_uid("ac10-dl"), "trip-1467s3-ac10-dl"
+    clean_uid(uid)
+    try:
+        from services.alert_log import REASON_DAILY_LIMIT
+
+        write_user_tier(uid, "free")
+        assert _run_trip(uid, trip_id, daily_limit_reached=True) == 0, (
+            "Voraussetzung: das Tageslimit muss sperren"
+        )
+        _assert_genau_ein_unterdrueckungs_eintrag(
+            uid, trip_id, "trip", REASON_DAILY_LIMIT,
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_ac10_zugestellter_trip_nowcast_erzeugt_keinen_unterdrueckungs_grund():
+    """AC-10 (Gegenprobe, Trip): Geht der Trip-Nowcast raus, entsteht KEIN
+    Unterdrueckungs-Eintrag — die neue Protokollierung darf nicht bei jedem
+    Lauf mitschreiben.
+
+    Schuetzt die Implementierung davor, ``append_suppressed_entry()``
+    bedingungslos statt nur bei ``allowed == False`` zu rufen."""
+    uid, trip_id = fresh_uid("ac10-ok"), "trip-1467s3-ac10-ok"
+    clean_uid(uid)
+    try:
+        write_user_tier(uid, "premium")
+        assert _run_trip(uid, trip_id) == 1, (
+            "Voraussetzung: ohne Sperre muss der Trip-Nowcast zustellen"
+        )
+        _assert_zustellung_ohne_unterdrueckungs_eintrag(uid, trip_id)
+    finally:
+        clean_uid(uid)
+
+
+def test_zugestellter_ortsvergleich_nowcast_erzeugt_keinen_unterdrueckungs_grund():
+    """AC-6/7/8 (Gegenprobe, Ortsvergleich): das Gegenstueck zum Trip-Waechter
+    darueber — geht der Vergleichs-Nowcast raus, entsteht KEIN
+    Unterdrueckungs-Eintrag fuer dieses Preset.
+
+    Ohne diesen Waechter waere die Protokollierung auf der Vergleichs-Seite
+    unbewacht: AC-6/7/8 zeigen nur, dass bei einer SPERRE ein Eintrag
+    entsteht, nicht dass er bei einer ZUSTELLUNG ausbleibt. Beide Nowcast-
+    Pfade brauchen dieselbe Zusicherung — ein Waechter, den nur eine der
+    beiden Seiten hat, ist genau die Trip/Vergleich-Asymmetrie, die diese
+    Scheibe beseitigt."""
+    uid, preset_id = fresh_uid("ov-ok"), "cp-1467s3-zustellung"
+    clean_uid(uid)
+    try:
+        write_user_tier(uid, "premium")  # Tageslimit aus dem Weg
+        _setup_compare(uid, preset_id)
+
+        assert _run_compare(uid) == 1, (
+            "Voraussetzung: ohne Sperre muss der Vergleichs-Nowcast zustellen"
+        )
+        _assert_zustellung_ohne_unterdrueckungs_eintrag(uid, preset_id)
+    finally:
+        clean_uid(uid)
+
+
+# ═══════════ Der Protokoll-Eintrag darf nicht luegen (F003) ═════════════════
+
+
+@pytest.mark.parametrize("leerer_grund", [None, "", "   "])
+def test_unterdrueckungs_eintrag_ohne_grund_scheitert_laut(leerer_grund):
+    """Ein Unterdrueckungs-Eintrag OHNE Grund wird gar nicht erst geschrieben —
+    die Schreibfunktion scheitert laut.
+
+    Warum das inhaltlich zaehlt und nicht kosmetisch ist: beim LESEN deutet
+    ``alert_log._missed_channels()`` einen leeren Grund still zu
+    ``REASON_DELIVERY_FAILED`` um. Das Protokoll behauptete dann „Zustellung
+    fehlgeschlagen", wo in Wahrheit gar keine Sperre vorlag — und damit das
+    Gegenteil dessen, wofuer die Unterdrueckungs-Protokollierung ueberhaupt
+    eingefuehrt wurde: wahrheitsgemaess zu beantworten, WARUM kein Alarm kam.
+
+    Geprueft wird zusaetzlich, dass NICHTS auf Platte landet: ein Eintrag, der
+    halb geschrieben und dann verworfen wird, waere dieselbe Luege mit
+    Zwischenschritt.
+    """
+    from services import alert_log
+
+    uid = fresh_uid("f003")
+    clean_uid(uid)
+    try:
+        with pytest.raises(ValueError):
+            alert_log.append_suppressed_entry(
+                uid, entity_id="cp-1467s3-f003", entity_type="compare",
+                reason=alert_log.REASON_NOWCAST, gate_reason=leerer_grund,
+                effective_channels={"email"},
+            )
+
+        log = read_log(uid)
+        assert log["entries"] == [] and log["not_delivered"] == [], (
+            f"Trotz fehlendem Grund wurde ins Protokoll geschrieben: {log!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_unterdrueckungs_eintrag_mit_grund_wird_weiterhin_geschrieben():
+    """Gegenprobe zum Waechter darueber: mit gueltigem Grund schreibt dieselbe
+    Funktion unveraendert — der Schutz darf den Normalfall nicht mitnehmen.
+
+    Ohne diese Haelfte waere auch eine Fassung „konform", die grundsaetzlich
+    nichts mehr schreibt.
+    """
+    from services import alert_log
+
+    uid = fresh_uid("f003-ok")
+    clean_uid(uid)
+    try:
+        alert_log.append_suppressed_entry(
+            uid, entity_id="cp-1467s3-f003-ok", entity_type="compare",
+            reason=alert_log.REASON_NOWCAST,
+            gate_reason=alert_log.REASON_COOLDOWN,
+            effective_channels={"email"},
+        )
+
+        eintraege = entries_for(uid, "cp-1467s3-f003-ok", bucket="not_delivered")
+        assert len(eintraege) == 1, f"Erwartet EINEN Eintrag: {read_log(uid)!r}"
+        assert suppression_reasons(eintraege[0]) == {alert_log.REASON_COOLDOWN}
+    finally:
+        clean_uid(uid)
+
+
+# ═════ Ein gescheiterter Eintrag reisst den Stapellauf nicht mit (F004) ═════
+
+
+def _fehler_einspeisen(monkeypatch, kaputte_kennung: str) -> None:
+    """Laesst den Protokoll-Eintrag fuer GENAU EINE Kennung scheitern.
+
+    Kein Mock-Theater: die Ausnahme wird nicht erfunden, sondern von der
+    ECHTEN Schreibfunktion unter ihrem echten Vertrag ausgeloest — der Aufruf
+    wird mit leerem ``gate_reason`` durchgereicht, was die F003-Pruefung
+    zurecht mit ``ValueError`` quittiert. Jede andere Kennung laeuft
+    unveraendert in die Originalfunktion. Damit haengt dieser Test an genau der
+    Zusicherung, die er absichern soll, statt an einer Attrappe.
+    """
+    from services import alert_log
+
+    original = alert_log.append_suppressed_entry
+
+    def _injektor(user_id, *, entity_id, **kwargs):
+        if entity_id == kaputte_kennung:
+            kwargs["gate_reason"] = None  # loest den echten Vertragsbruch aus
+        return original(user_id, entity_id=entity_id, **kwargs)
+
+    monkeypatch.setattr(alert_log, "append_suppressed_entry", _injektor)
+
+
+def test_f004_gescheitertes_protokoll_stoppt_den_ortsvergleich_lauf_nicht(monkeypatch):
+    """F004: Scheitert der Unterdrueckungs-Eintrag EINES Ortsvergleichs, laeuft
+    der Stapellauf weiter — ein gesunder Ortsvergleich im selben Lauf bekommt
+    seinen Alarm.
+
+    Der kaputte Ortsvergleich steht ABSICHTLICH vorn in der Ladereihenfolge
+    (`load_compare_presets` sortiert nach Dateiname, `...-a-` vor `...-b-`);
+    stuende er hinten, bewiese der Test nichts.
+
+    Ohne die Absicherung im Schleifenkoerper verlaesst die Ausnahme
+    `check_all_compare_presets()` und der zweite Ortsvergleich wird nie
+    erreicht — der gefaehrlichste Fehler dieser Scheibe (ausbleibender Alarm),
+    ausgeloest ausgerechnet durch eine Haertung.
+    """
+    uid = fresh_uid("f004-ov")
+    kaputt, gesund = "cp-1467s3-a-kaputt", "cp-1467s3-b-gesund"
+    clean_uid(uid)
+    try:
+        write_user_tier(uid, "premium")  # Tageslimit aus dem Weg
+        save_location(location("loc-f004", "Nachbardorf"), user_id=uid)
+        quiet_from, quiet_to = quiet_window_elsewhere()
+        write_presets(uid, [
+            radar_preset(kaputt, ["loc-f004"], user_id=uid,
+                         quiet_from=quiet_from, quiet_to=quiet_to),
+            radar_preset(gesund, ["loc-f004"], user_id=uid,
+                         quiet_from=quiet_from, quiet_to=quiet_to),
+        ])
+        # Nur der erste Ortsvergleich ist gesperrt -> nur fuer ihn wird
+        # ueberhaupt ein Unterdrueckungs-Eintrag versucht.
+        record_throttle(uid, SCOPE_COMPARE_RADAR, kaputt,
+                        datetime.now(timezone.utc) - timedelta(minutes=5))
+        _fehler_einspeisen(monkeypatch, kaputt)
+
+        mails: list = []
+        sent = compare_radar_service(
+            uid, settings_email_only(), CountingFrameSource(onset_minutes=8),
+            lambda subject, body: mails.append((subject, body)),
+        ).check_all_compare_presets()
+
+        assert sent == 1, (
+            f"Der gesunde Ortsvergleich {gesund!r} muss seinen Alarm bekommen, "
+            f"obwohl das Protokoll von {kaputt!r} im selben Lauf scheiterte — "
+            f"erhalten sent={sent}"
+        )
+        assert len(mails) == 1, (
+            f"Genau EINE Mail erwartet (die des gesunden Ortsvergleichs), "
+            f"erhalten {len(mails)}"
+        )
+        # Der kaputte bleibt unterdrueckt und ohne Protokoll-Eintrag — sein
+        # Alarm geht NICHT etwa ersatzweise raus.
+        assert entries_for(uid, kaputt, bucket="entries") == []
+        assert entries_for(uid, kaputt, bucket="not_delivered") == []
+        assert len(entries_for(uid, gesund, bucket="entries")) == 1
+    finally:
+        clean_uid(uid)
+
+
+def test_f004_gescheitertes_protokoll_stoppt_den_trip_lauf_nicht(monkeypatch):
+    """F004, Trip-Pendant: derselbe Nachweis fuer `check_radar_alerts()` — ein
+    Trip, dessen Unterdrueckungs-Eintrag scheitert, kostet die uebrigen Trips
+    des Nutzers nicht ihren Alarm."""
+    uid = fresh_uid("f004-trip")
+    kaputt, gesund = "trip-1467s3-a-kaputt", "trip-1467s3-b-gesund"
+    clean_uid(uid)
+    try:
+        write_user_tier(uid, "premium")
+        quiet_from, quiet_to = quiet_window_elsewhere()
+        for trip_id in (kaputt, gesund):
+            save_trip(make_trip(trip_id, quiet_from=quiet_from, quiet_to=quiet_to), uid)
+        record_throttle(uid, SCOPE_TRIP_RADAR, kaputt,
+                        datetime.now(timezone.utc) - timedelta(minutes=5))
+        _fehler_einspeisen(monkeypatch, kaputt)
+
+        mails: list = []
+        sent = trip_alert_service(
+            uid, settings_email_only(), CountingFrameSource(onset_minutes=8),
+            lambda subject, body: mails.append((subject, body)),
+        ).check_radar_alerts()
+
+        assert sent == 1, (
+            f"Der gesunde Trip {gesund!r} muss seinen Alarm bekommen, obwohl "
+            f"das Protokoll von {kaputt!r} im selben Lauf scheiterte — "
+            f"erhalten sent={sent}"
+        )
+        assert len(mails) == 1, f"Genau EINE Mail erwartet, erhalten {len(mails)}"
+        assert entries_for(uid, kaputt, bucket="not_delivered") == []
+        assert len(entries_for(uid, gesund, bucket="entries")) == 1
+    finally:
+        clean_uid(uid)
+
+
+# ══════════════ Geltungsbereich: NUR die Nowcast-Pfade (AC-9) ═══════════════
+
+
+def test_ac9_aenderungsalarm_bekommt_keinen_unterdrueckungs_grund():
+    """AC-9 (Invariante, heute GRUEN): Ein durch die Ruhezeit unterdrueckter
+    Vorhersage-Aenderungsalarm erzeugt KEINEN Protokoll-Eintrag mit einem der
+    drei neuen Gruende — der Geltungsbereich von (d) bleibt strikt auf die
+    beiden Nowcast-Pfade begrenzt (offene Luecke O3 in
+    ``feat_1459_alert_protokoll.md``, hier ausdruecklich NICHT geschlossen).
+
+    Der Kontroll-Lauf (ohne Ruhezeit) beweist, dass derselbe Aufbau real
+    alarmiert — sonst waere die Zusicherung leer."""
+    kontrolle, gesperrt = fresh_uid("ac9d-ok"), fresh_uid("ac9d-quiet")
+    clean_uid(kontrolle)
+    clean_uid(gesperrt)
+    try:
+        write_user_tier(kontrolle, "premium")
+        write_user_tier(gesperrt, "premium")
+
+        offen = gust_alert_trip("trip-1467s3-ac9-ok")
+        offen.alert_quiet_from, offen.alert_quiet_to = quiet_window_elsewhere()
+        raus = trip_alert_service(
+            kontrolle, settings_email_only(), CountingFrameSource(), lambda s, b: None,
+        ).check_and_send_alerts(
+            offen, [weather(1, gust_max_kmh=20.0)],
+            fresh_weather=[weather(1, gust_max_kmh=60.0)],
+        )
+        assert raus is True, (
+            "Voraussetzung: der Aenderungsalarm muss ohne Ruhezeit rausgehen"
+        )
+
+        still = gust_alert_trip("trip-1467s3-ac9-quiet")
+        still.alert_quiet_from, still.alert_quiet_to = quiet_window_now()
+        unterdrueckt = trip_alert_service(
+            gesperrt, settings_email_only(), CountingFrameSource(), lambda s, b: None,
+        ).check_and_send_alerts(
+            still, [weather(1, gust_max_kmh=20.0)],
+            fresh_weather=[weather(1, gust_max_kmh=60.0)],
+        )
+        assert unterdrueckt is False, (
+            "Voraussetzung: die Ruhezeit muss den Aenderungsalarm unterdruecken"
+        )
+        assert _gate_reasons_in_log(gesperrt) == set(), (
+            f"Der Aenderungsalarm-Pfad darf keinen der drei Nowcast-"
+            f"Unterdrueckungsgruende protokollieren: {read_log(gesperrt)!r}"
+        )
+    finally:
+        clean_uid(kontrolle)
+        clean_uid(gesperrt)
+
+
+def test_ac9_amtlicher_alarm_bekommt_keinen_unterdrueckungs_grund():
+    """AC-9 (Invariante, heute GRUEN): Eine durch die Tages-Obergrenze
+    unterdrueckte amtliche Warnung erzeugt KEINEN Protokoll-Eintrag mit einem
+    der drei neuen Gruende.
+
+    Der Kontroll-Lauf (freies Tagesbudget) beweist, dass der Aufbau real
+    alarmiert — und dass der zweite Lauf tatsaechlich an der Tages-Obergrenze
+    scheitert und nicht schon vorher."""
+    import services.official_alerts.base as base
+    from services.compare_official_alert import CompareOfficialAlertService
+    from services.official_alerts import register_official_alert_source
+    from services.official_alerts.models import OfficialAlert
+
+    kontrolle, gesperrt = fresh_uid("ac9a-ok"), fresh_uid("ac9a-limit")
+    clean_uid(kontrolle)
+    clean_uid(gesperrt)
+    quellen = list(base._REGISTERED_SOURCES)
+    base._REGISTERED_SOURCES.clear()
+    try:
+        jetzt = datetime.now(timezone.utc)
+        register_official_alert_source(_FakeOfficialSource([OfficialAlert(
+            source="tdd-1467s3", hazard="thunderstorm", level=2, label="Gewitter",
+            valid_from=jetzt - timedelta(hours=1), valid_to=jetzt + timedelta(hours=6),
+            region_label="Testregion",
+        )]))
+
+        for uid, verbraucht in ((kontrolle, 0), (gesperrt, 2)):
+            write_user_tier(uid, "free")
+            seed_daily_counter(uid, verbraucht)
+            save_location(location("loc-amt", "Amtsdorf", LAT, LON), user_id=uid)
+            write_presets(uid, [radar_preset(
+                f"cp-1467s3-ac9-{uid[-6:]}", ["loc-amt"], user_id=uid,
+            )])
+
+        raus = CompareOfficialAlertService(
+            settings=settings_email_only(), user_id=kontrolle,
+            mail_sink=lambda subject, body: None,
+        ).check_all_compare_presets()
+        assert raus == 1, (
+            f"Voraussetzung: die amtliche Warnung muss bei freiem Tagesbudget "
+            f"rausgehen, erhalten {raus}"
+        )
+
+        unterdrueckt = CompareOfficialAlertService(
+            settings=settings_email_only(), user_id=gesperrt,
+            mail_sink=lambda subject, body: None,
+        ).check_all_compare_presets()
+        assert unterdrueckt == 0, (
+            "Voraussetzung: das erreichte Tageslimit muss die amtliche Warnung "
+            "unterdruecken"
+        )
+        assert _gate_reasons_in_log(gesperrt) == set(), (
+            f"Der amtliche Pfad darf keinen der drei Nowcast-"
+            f"Unterdrueckungsgruende protokollieren: {read_log(gesperrt)!r}"
+        )
+    finally:
+        base._REGISTERED_SOURCES.clear()
+        base._REGISTERED_SOURCES.extend(quellen)
+        clean_uid(kontrolle)
+        clean_uid(gesperrt)

--- a/tests/tdd/test_trip_radar_nowcast_gate_migration.py
+++ b/tests/tdd/test_trip_radar_nowcast_gate_migration.py
@@ -1,0 +1,161 @@
+"""Invarianten-Waechter — Trip-Nowcast bleibt beim Umklemmen auf den
+geteilten Freigabe-Baustein Bit fuer Bit gleich (Issue #1467 S3, AC-16).
+
+SPEC: docs/specs/modules/rework_1467_s3_nowcast.md
+
+Diese Datei ist KEIN RED-Test: sie ist HEUTE gruen und muss es nach dem Umbau
+bleiben. Die vier Szenarien wurden am Stand VOR dem Umbau gemessen; genau
+diese Tabelle gilt danach unveraendert weiter:
+
+    | # | Ruhezeit | Sperrzeit | Tageslimit | Ergebnis (gemessen 2026-08-08) |
+    |---|----------|-----------|------------|--------------------------------|
+    | A | aus      | frei      | frei       | ZUGESTELLT ueber "email"       |
+    | B | AN       | frei      | frei       | nicht zugestellt               |
+    | C | aus      | AKTIV     | frei       | nicht zugestellt               |
+    | D | aus      | frei      | ERREICHT   | nicht zugestellt               |
+
+Zusaetzlich haelt Szenario A die Buchungsseite fest: nach erfolgreicher
+Zustellung liegt der Sperrzeit-Eintrag im geteilten ``throttle_state.json``
+unter Scope ``radar`` mit dem Trip-Schluessel, und der Tageszaehler steht auf
+1. Wuerde der Umbau den Trip-Pfad auf einen anderen Scope umhaengen oder das
+Buchen vor die Zustellung ziehen, faellt das hier auf.
+
+Die einzige zugelassene NEUE Wirkung fuer den Trip ist die Unterdrueckungs-
+Protokollierung (AC-10, ``test_nowcast_suppression_logging.py``) — die
+Zustellentscheidung selbst aendert sich nicht.
+
+Mock-frei: echter Trip auf Platte, echter ``TripAlertService``, echte
+Zustandsdateien; Radar ueber den ``frame_source``-Seam, Versand ueber
+``mail_sink``. Kein Netz.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from tests.helpers.nowcast_gate_fixtures import (
+    SCOPE_TRIP_RADAR, CountingFrameSource, clean_uid, fresh_uid, make_trip,
+    quiet_window_elsewhere, quiet_window_now, read_daily_counter,
+    read_throttle_state, record_throttle, save_trip, seed_daily_counter,
+    settings_email_only, trip_alert_service, write_user_tier,
+)
+
+
+def _run_trip_scenario(
+    uid: str,
+    trip_id: str,
+    *,
+    quiet: bool,
+    throttled: bool,
+    daily_limit_reached: bool,
+) -> tuple[int, list]:
+    """EIN Trip-Nowcast-Lauf mit auslloesendem Onset. Liefert
+    ``(rueckgabewert, mail_aufrufe)``."""
+    write_user_tier(uid, "free")  # Limit 2/Tag
+    seed_daily_counter(uid, 2 if daily_limit_reached else 0)
+
+    quiet_from, quiet_to = quiet_window_now() if quiet else quiet_window_elsewhere()
+    trip = make_trip(trip_id, cooldown_minutes=120, quiet_from=quiet_from, quiet_to=quiet_to)
+    save_trip(trip, uid)
+
+    if throttled:
+        record_throttle(uid, SCOPE_TRIP_RADAR, trip_id, datetime.now(timezone.utc))
+
+    mail_calls: list = []
+    svc = trip_alert_service(
+        uid, settings_email_only(), CountingFrameSource(onset_minutes=8),
+        lambda subject, body: mail_calls.append((subject, body)),
+    )
+    return svc.check_radar_alerts(), mail_calls
+
+
+def test_szenario_a_ohne_sperre_wird_zugestellt_und_gebucht():
+    """AC-16 Szenario A: keine Ruhezeit, keine Sperrzeit, Tagesbudget frei —
+    der Trip-Nowcast geht raus (Kanal E-Mail). Danach steht die Buchung im
+    geteilten Speicher: Scope ``radar``, Schluessel = Trip-Kennung, und der
+    Tageszaehler ist um genau 1 gestiegen."""
+    uid, trip_id = fresh_uid("ac16-a"), "trip-ac16-a"
+    clean_uid(uid)
+    try:
+        sent, mails = _run_trip_scenario(
+            uid, trip_id, quiet=False, throttled=False, daily_limit_reached=False,
+        )
+
+        assert sent == 1, (
+            f"Szenario A muss GENAU EINEN Trip-Nowcast zustellen, erhalten: {sent}"
+        )
+        assert len(mails) == 1, (
+            f"Szenario A: erwartet genau EINE Mail ueber den mail_sink, "
+            f"erhalten {len(mails)}"
+        )
+
+        state = read_throttle_state(uid)
+        assert trip_id in state.get(SCOPE_TRIP_RADAR, {}), (
+            f"Sperrzeit des Trip-Nowcast fehlt unter Scope {SCOPE_TRIP_RADAR!r} "
+            f"mit Schluessel {trip_id!r}: {state!r}"
+        )
+        assert read_daily_counter(uid) == 1, (
+            f"Tageszaehler muss nach genau einer Zustellung auf 1 stehen, "
+            f"steht auf {read_daily_counter(uid)}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_szenario_b_ruhezeit_unterdrueckt():
+    """AC-16 Szenario B: Ruhezeit aktiv, sonst alles frei — keine Zustellung,
+    keine Buchung."""
+    uid, trip_id = fresh_uid("ac16-b"), "trip-ac16-b"
+    clean_uid(uid)
+    try:
+        sent, mails = _run_trip_scenario(
+            uid, trip_id, quiet=True, throttled=False, daily_limit_reached=False,
+        )
+
+        assert sent == 0, f"Ruhezeit muss den Trip-Nowcast unterdruecken, erhalten: {sent}"
+        assert mails == [], "Waehrend der Ruhezeit darf keine Mail rausgehen"
+        assert read_daily_counter(uid) == 0, "Unterdrueckter Alarm darf nicht zaehlen"
+        assert trip_id not in read_throttle_state(uid).get(SCOPE_TRIP_RADAR, {}), (
+            "Unterdrueckter Alarm darf keine Sperrzeit buchen"
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_szenario_c_sperrzeit_unterdrueckt():
+    """AC-16 Szenario C: Sperrzeit aktiv (frischer Eintrag im geteilten
+    Speicher), sonst alles frei — keine Zustellung."""
+    uid, trip_id = fresh_uid("ac16-c"), "trip-ac16-c"
+    clean_uid(uid)
+    try:
+        sent, mails = _run_trip_scenario(
+            uid, trip_id, quiet=False, throttled=True, daily_limit_reached=False,
+        )
+
+        assert sent == 0, f"Sperrzeit muss den Trip-Nowcast unterdruecken, erhalten: {sent}"
+        assert mails == [], "Innerhalb der Sperrzeit darf keine Mail rausgehen"
+        assert read_daily_counter(uid) == 0, "Unterdrueckter Alarm darf nicht zaehlen"
+    finally:
+        clean_uid(uid)
+
+
+def test_szenario_d_tageslimit_unterdrueckt():
+    """AC-16 Szenario D: Tages-Obergrenze erreicht (free = 2/Tag), sonst alles
+    frei — keine Zustellung, Zaehler bleibt stehen."""
+    uid, trip_id = fresh_uid("ac16-d"), "trip-ac16-d"
+    clean_uid(uid)
+    try:
+        sent, mails = _run_trip_scenario(
+            uid, trip_id, quiet=False, throttled=False, daily_limit_reached=True,
+        )
+
+        assert sent == 0, f"Tageslimit muss den Trip-Nowcast unterdruecken, erhalten: {sent}"
+        assert mails == [], "Bei erreichtem Tageslimit darf keine Mail rausgehen"
+        assert read_daily_counter(uid) == 2, (
+            f"Der Zaehler darf beim unterdrueckten Alarm nicht wachsen, steht auf "
+            f"{read_daily_counter(uid)}"
+        )
+        assert trip_id not in read_throttle_state(uid).get(SCOPE_TRIP_RADAR, {}), (
+            "Unterdrueckter Alarm darf keine Sperrzeit buchen"
+        )
+    finally:
+        clean_uid(uid)


### PR DESCRIPTION
Der Ortsvergleich-Nowcast lief an drei Stellen unbegruendet anders als sein
Trip-Gegenstueck: keine Tages-Obergrenze, eigene ungesicherte Sperrzeit-Datei,
Ruhezeit erst NACH dem Wetterabruf.

Neu: `services/alert_gate.py` mit fester Reihenfolge Ruhezeit -> Sperrzeit ->
Tages-Obergrenze. Beide Nowcast-Pfade rufen ihn sofort -- ein Baustein mit nur
einem Verbraucher waere keine Entdopplung, sondern eine dritte Fassung
derselben Reihenfolge (Hausmuster aus S2 AG1). Der Trip-Zweig gibt dabei ~18
Zeilen Inline-Logik ab; Produktivcode netto +153.

Nutzersichtbar:
- Ortsvergleich-Nowcast bekommt die Tages-Obergrenze (`reason="nowcast"`, erbt
  damit den Vorrang-Schutz aus #1555 -- ein eigener Grund haette ihn verloren).
- Sperrzeit im geteilten `ThrottleStore`, neuer Scope `compare_radar`. Nicht
  `radar` (mit Trip-Kennungen belegt; seit #1250 teilen sich Trips und
  Ortsvergleiche den Namensraum `briefings/<id>.json`), nicht `compare_preset`
  (vom Aenderungsalarm belegt).
- Ruhezeit vor der Datenbeschaffung: waehrend der Ruhezeit kein Abruf mehr.
- Beide Nowcast-Pfade protokollieren erstmals, WARUM ein Alarm unterdrueckt
  wurde. Die Gruende existierten seit #1459, wurden aber repo-weit nie
  geschrieben.

Altdaten: `compare_radar_alert_throttle.json` wird bewusst NICHT migriert --
`_migrate_if_needed()` bricht bei vorhandener `throttle_state.json` ab (bei
allen realen Nutzern der Fall), und der eine reale Alteintrag vom 25.07. liegt
laengst ausserhalb jedes Cooldowns. AC-3 prueft die Folge, statt sie zu
behaupten.

Loest zwei archivierte Zusicherungen aus #1041/#1041b ab ("der Onset wird
erkannt, der Alarm unterdrueckt"). Meldeverhalten unveraendert (AC-5).

Adversary VERIFIED nach 5 Runden, 44 Belege, 7 Mutationsfamilien. Drei Funde,
alle behoben:
- F001 HIGH: ein bedingungslos geschriebener Unterdrueckungs-Eintrag wurde von
  KEINEM Test gefangen -- auf beiden Pfaden. Der Pruefhelfer filterte auf die
  drei Gate-Gruende, und bei Freigabe ist der Grund `None`.
- F003 MEDIUM: `append_suppressed_entry()` haette einen Nullwert
  weitergeschrieben, den die Leseseite als "Zustellung fehlgeschlagen"
  umdeutet -- das Protokoll haette gelogen. Jetzt lautes `ValueError`.
- F004 CRITICAL: dieses laute Scheitern riss den ganzen Lauf ab, ein gesunder
  Nachbar wurde nie erreicht (Muster aus #1479). Jetzt je Entitaet abgesichert,
  mit Warnung, die die Kennung nennt.

Tests: 185 gruen ueber die beruehrten Suiten. `fix_1479` AC-11 gruen (kein
eigenes try/except um `is_quiet_hours`), Struktur-Waechter ohne Ordinal-Nachzug.

Spec: docs/specs/modules/rework_1467_s3_nowcast.md (16 ACs, PO-Freigabe
2026-08-08, Beleg #issuecomment-5226604204)
ADR-0021 Nachtrag: Tageslimit ist nicht mehr Trip-spezifisch.

Nicht in dieser Scheibe: #1594 (naechster geplanter Versandzeitpunkt),
Aenderungs- und amtlicher Alarmpfad (S4). Sammel-Eintraege in #1199.
