### PR TITLE
feat(#1537): Ausgabe-Waechter maskiert Geheimnisse in Werkzeug-Ergebnissen (Scheibe 2, Stufe B)

### DIFF
--- a/.claude/hooks/secret_output_gate.py
+++ b/.claude/hooks/secret_output_gate.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Ausgabe-Waechter „Secret-Output-Sperre" — Issue #1537 Scheibe 2, Stufe B.
+
+`PostToolUse`-Waechter: durchsucht das ERGEBNIS jedes Werkzeugaufrufs nach dem
+ausgeschriebenen Wert eines Geheimnisses aus der lokalen `.env` und ersetzt jeden
+Treffer durch `***<SCHLUESSELNAME>***`, bevor Claude das Ergebnis sieht.
+
+Warum ueberhaupt: Scheibe 1 (`secret_in_repo_gate.py`) schuetzt nur einen Austrittsweg
+(vorgemerkte Dateien beim `git commit`). Der Egress-Waechter des Plugins
+(`secret_egress_guard.py`, #1380) prueft nur ausgehende EINGABEN. Ein Wert, der in der
+AUSGABE eines Werkzeugs zurueckkommt, obwohl er im Aufruf nie stand, lief bisher an
+beiden vorbei — genau so trat in #1535 ein gueltiger Bot-Zugang ueber die Testausgabe
+eines `Bash`-Aufrufs aus.
+
+Vier Bauvorgaben, alle nicht verhandelbar:
+
+  1. STUMM IM NORMALFALL. VOLLSTAENDIG geprueft und nichts gefunden heisst: keinerlei
+     stdout, keinerlei stderr, Exit 0, Ergebnis unangetastet. Nur dann. „Konnte nicht
+     pruefen" ist kein Normalfall und wird gemeldet (Bauvorgabe 2).
+  2. DURCHGEHEND FAIL-OPEN — die Umkehrung von Scheibe 1. Dieser Waechter laeuft nach
+     JEDEM Werkzeugaufruf in JEDER Sitzung; eine eigene Stoerung (Plugin fehlt, .env
+     unlesbar, kaputtes JSON, unerwartete Gestalt, beliebige Ausnahme) darf niemals ein
+     Werkzeug-Ergebnis zerstoeren oder eine Sitzung blockieren. Jede Stoerung endet mit
+     Exit 0 und unveraendertem Ergebnis — aber NICHT lautlos: sie hinterlaesst eine
+     stderr-Zeile mit dem Ausnahme-TYP (nie deren Text, der Nutzlast-Bruchstuecke tragen
+     kann). Ein stiller Abbruch ist von „nichts gefunden" nicht unterscheidbar, waehrend
+     der Wert weiterhin im Klartext bei Claude ankommt (Befund F005).
+     GEMELDET WIRD, WER UNERWARTET MITTEN IN DER ARBEIT SCHEITERT — nicht, wer von
+     vornherein weiss, dass er nicht arbeiten kann. Deshalb bleibt der Fall „Plugin fehlt"
+     bewusst still: das ist ein Dauerzustand, und eine Zeile nach JEDEM Werkzeugaufruf waere
+     Laerm, bis jemand das Plugin installiert — Laerm hat hier schon einmal einen Befund
+     erzeugt (F003). Diese Unterscheidung ist die Regel fuer kuenftige Aenderungen.
+  3. ERKENNUNG WIRD GELIEHEN, NICHT NEU GEBAUT. `collect_secrets`, `_is_secret_key`,
+     `_is_secret_value` kommen per importlib aus `core/hooks/secret_egress_guard.py` des
+     Plugins agent-os-openspec (Ladeweg wie `.claude/hooks/hook_utils.py`). Ein dritter
+     eigener Geheimnis-Begriff waere der Fehler. Zwei getrennte try-Bloecke (Vorbild
+     `secret_in_repo_gate.py:96-123`): fehlt das Modul ODER fehlt eine der Funktionen in
+     einer aelteren Plugin-Fassung, wird der Waechter fail-open statt kaputt.
+  4. STRUKTURERHALTENDER ERSATZ. Gemessen am 2026-08-07 (neun Laeufe einer eigenstaendigen
+     Sitzung, Claude Code 2.1.224, Zufallsmarker): die Plattform uebernimmt
+     `updatedToolOutput` nur, wenn es ALLE Schluessel des urspruenglichen Ergebnisses
+     traegt. Ein String oder ein unvollstaendiges Objekt wird STILLSCHWEIGEND VERWORFEN —
+     kein Fehler, kein Hinweis, Exit 0, auch unter `--debug hooks` keine Diagnosezeile.
+     Ein falsch geformter Ersatz ist damit von einem funktionierenden Waechter nicht
+     unterscheidbar. Deshalb: das empfangene `tool_response` wird KOPIERT und darin werden
+     nur Werte ersetzt — nie ein frisches Objekt gebaut.
+
+GEMESSENE GRENZE (2026-08-07, Nachmessung zur offenen Luecke bei AC-3): bei einem
+FEHLGESCHLAGENEN Bash-Aufruf (Exit-Code != 0) laeuft dieser Hook UEBERHAUPT NICHT — die
+Plattform ruft `PostToolUse` dort nicht auf. Zwei Laeufe mit Zufallsmarker ergaben null
+Hook-Aufrufe, waehrend derselbe Befehl mit Exit-Code 0 den Hook normal ausloeste. Die
+String-Behandlung unten bleibt trotzdem drin (andere Werkzeuge koennen String-Ergebnisse
+liefern), ist fuer den Bash-Fehlschlag aber wirkungslos — nicht weil der Ersatz abgelehnt
+wuerde, sondern weil es gar nicht erst dazu kommt.
+
+KEINE REKURSION, NIRGENDS (Adversary-Befund F005, gemessen 2026-08-08, Python 3.12,
+recursionlimit 1000). Traversierung UND Tiefenkopie laufen iterativ ueber einen Stapel. Die
+frueheren Grenzen waren beide unsichtbar: eine feste Grenze von 25 Ebenen (bis F003) und
+danach `copy.deepcopy`, das ab Tiefe 498 einen `RecursionError` warf — GEFANGEN vom Notfall-
+Handler unten, und zwar bevor `main()` irgendetwas ausgegeben hatte. Das sah von aussen aus
+wie „geprueft, nichts gefunden", waehrend die Plattform das Ergebnis MIT dem Wert im Klartext
+weiterreichte: der schwerste Fehler, den dieser Waechter haben kann. Gemessen liegt die
+verbleibende Grenze jetzt bei `json.loads` bzw. `json.dumps`: Tiefe 9997 geht, ab 9998 kommt
+ein `RecursionError` — also rund das Zwanzigfache. Jenseits davon bleibt es fail-open, aber
+NICHT MEHR STUMM (siehe `_melde_abbruch`). Zyklen sind ausgeschlossen, weil das Ergebnis
+ausschliesslich aus `json.loads` stammt.
+
+Kein `.env`-Cache (sonst greift der Waechter nach einer Rotation ins Leere) und kein
+Werkzeugname-Filter: fuer AUSGABEN ist `Read` gerade der wahrscheinlichste Austrittsweg,
+waehrend der Egress-Waechter ihn (fuer Eingaben zu Recht) ueberspringt.
+
+Meldungen nennen ausschliesslich Werkzeug- und Schluesselnamen — nie den Wert.
+
+Regel-Budget: schliesst einen Weg, ueber den in #1535 nachweislich ein aktiver Zugang
+ausgetreten ist. Schaltet sich deshalb nicht automatisch ab;
+Wirksamkeits-Pruefung: 2026-11-05.
+
+Exit-Code immer 0 — `PostToolUse` kann laut Hook-Vertrag ohnehin nicht blockieren.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+# ------------------------------------------------------- Plugin-Erkennung leihen
+# Block 1: Modul ueberhaupt laden. Derselbe Ladeweg wie `.claude/hooks/hook_utils.py`
+# (Registry -> installPath -> importlib von der Datei), nur mit anderem Zieldateipfad.
+
+
+def _plugin_modul():
+    registry = os.path.expanduser("~/.claude/plugins/installed_plugins.json")
+    with open(registry) as fh:
+        daten = json.load(fh)
+    install_pfad = ""
+    for schluessel, eintraege in daten.get("plugins", {}).items():
+        if not schluessel.startswith("agent-os-openspec@"):
+            continue
+        eintrag = next((e for e in eintraege if e.get("scope") == "user"), eintraege[0])
+        install_pfad = eintrag.get("installPath", "")
+        break
+    if not install_pfad:
+        raise ImportError("agent-os-openspec nicht in der Plugin-Registry")
+    modul_pfad = os.path.join(install_pfad, "core", "hooks", "secret_egress_guard.py")
+    if not os.path.isfile(modul_pfad):
+        raise ImportError(f"secret_egress_guard.py nicht gefunden ({modul_pfad})")
+    spec = importlib.util.spec_from_file_location("_gz_secret_egress_guard", modul_pfad)
+    modul = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(modul)
+    return modul
+
+
+try:
+    _EGRESS = _plugin_modul()
+    MODUL_FEHLT: str | None = None
+except Exception as _fehler:  # noqa: BLE001 — fehlendes Plugin macht fail-open, nicht kaputt
+    _EGRESS = None
+    MODUL_FEHLT = f"{type(_fehler).__name__}: {_fehler}"
+
+# Block 2: die drei Funktionen einzeln greifen. Bewusst getrennt vom Modul-Import: eine
+# aeltere Plugin-Fassung koennte das Modul haben, aber nicht (alle) diese Namen — dann
+# soll der Waechter ebenfalls nur fail-open werden, nicht abstuerzen.
+try:
+    if _EGRESS is None:
+        raise ImportError(MODUL_FEHLT or "Modul nicht geladen")
+    collect_secrets = _EGRESS.collect_secrets
+    _is_secret_key = _EGRESS._is_secret_key
+    _is_secret_value = _EGRESS._is_secret_value
+    FUNKTION_FEHLT: str | None = None
+except Exception as _fehler2:  # noqa: BLE001
+    collect_secrets = None  # type: ignore[assignment]
+    _is_secret_key = None  # type: ignore[assignment]
+    _is_secret_value = None  # type: ignore[assignment]
+    FUNKTION_FEHLT = f"{type(_fehler2).__name__}: {_fehler2}"
+
+
+def _konfiguration() -> dict:
+    """Erkennungs-Konfiguration des Plugins (ehrt `openspec.yaml`, z.B. `ignore_keys`).
+
+    Faellt auf die dokumentierten Vorgabewerte zurueck, falls die (hausinterne)
+    Hilfsfunktion in einer aelteren Plugin-Fassung fehlt oder die Konfiguration nicht
+    lesbar ist — wieder fail-open statt kaputt.
+    """
+    try:
+        return _EGRESS._get_config()
+    except Exception:  # noqa: BLE001
+        return {
+            "enabled": True, "min_length": 8, "ignore_keys": set(),
+            "extra_key_patterns": [], "scan_all_keys": False,
+        }
+
+
+def _geheimnisse() -> list[tuple[str, str]]:
+    """(Schluessel, Wert)-Paare aus der lokalen `.env`, frisch von Platte (kein Cache).
+
+    Doppelte Werte werden zusammengefasst; steht derselbe Wert unter mehreren Schluesseln,
+    gewinnt der, den das Plugin als echten Geheimnis-Schluessel einstuft (`_is_secret_key`)
+    — sonst traegt der Ersatz z.B. `***DATABASE_URL***` statt `***DB_PASS***`, wenn das
+    Passwort zusaetzlich in einer Verbindungs-URL steckt.
+
+    Sortiert nach absteigender Wertlaenge: sonst koennte ein kurzes Geheimnis, das
+    Teilstring eines langen ist, den langen Treffer zerschneiden.
+    """
+    cfg = _konfiguration()
+    if not cfg.get("enabled", True):
+        return []
+    wurzel = Path(os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd())
+    nach_wert: dict[str, str] = {}
+    for schluessel, wert in collect_secrets(cfg, wurzel):
+        if not wert or not _is_secret_value(wert, cfg):
+            continue
+        bisher = nach_wert.get(wert)
+        if bisher is None or (
+            not _is_secret_key(bisher, cfg) and _is_secret_key(schluessel, cfg)
+        ):
+            nach_wert[wert] = schluessel
+    return sorted(
+        ((s, w) for w, s in nach_wert.items()), key=lambda p: len(p[1]), reverse=True
+    )
+
+
+# ------------------------------------------------------------------- Maskierung
+
+
+def _ersetze(text: str, paare: list[tuple[str, str]], gefunden: set[str]) -> str:
+    for schluessel, wert in paare:
+        if wert in text:
+            text = text.replace(wert, f"***{schluessel}***")
+            gefunden.add(schluessel)
+    return text
+
+
+def _tiefe_kopie(knoten):
+    """Tiefenkopie OHNE Rekursion — Ersatz fuer `copy.deepcopy` (Befund F005).
+
+    `copy.deepcopy` steigt je Ebene einen Stack-Rahmen tief und warf ab Tiefe 498 einen
+    `RecursionError`, noch bevor die Maskierung ueberhaupt begann. Hier laeuft dieselbe
+    Arbeit ueber einen Arbeitsstapel: Quelle und zugehoeriges Ziel wandern paarweise durch.
+
+    Nur JSON-Typen — mehr kann in einem `tool_response` nicht stehen, er kommt aus
+    `json.loads`. Strings, Zahlen, `bool` und `None` sind unveraenderlich und werden direkt
+    uebernommen; alles Unbekannte ebenso (kann hier nicht auftreten, waere sonst geteilt).
+    Die SCHLUESSELREIHENFOLGE bleibt erhalten — sie einzusammeln und neu zu setzen wuerde
+    die Gestalt aendern, an der die Plattform den Ersatz annimmt oder verwirft (AC-13).
+    """
+    if not isinstance(knoten, (dict, list)):
+        return knoten
+    wurzel: dict | list = {} if isinstance(knoten, dict) else []
+    stapel: list[tuple[dict | list, dict | list]] = [(knoten, wurzel)]
+    while stapel:
+        quelle, ziel = stapel.pop()
+        paare = quelle.items() if isinstance(quelle, dict) else enumerate(quelle)
+        for schluessel, wert in paare:
+            if isinstance(wert, dict):
+                neu: object = {}
+            elif isinstance(wert, list):
+                neu = []
+            else:
+                neu = wert
+            if isinstance(ziel, list):
+                ziel.append(neu)
+            else:
+                ziel[schluessel] = neu
+            if isinstance(wert, (dict, list)):
+                stapel.append((wert, neu))   # type: ignore[arg-type]
+    return wurzel
+
+
+def _neue_notizen() -> dict:
+    """Was ausser der reinen Maskierung noch gemeldet werden muss (Regel: NIE LAUTLOS)."""
+    return {"oberste_schluessel": set()}
+
+
+def _maskiere_schluessel(knoten: dict, paare: list[tuple[str, str]], gefunden: set[str],
+                         notizen: dict, oberste_ebene: bool) -> None:
+    """Ein Geheimnis kann auch als SCHLUESSELNAME auftreten (Adversary-Befund F001).
+
+    Unterhalb der obersten Ebene wird umbenannt — die Plattform prueft dort die
+    Schluesselmenge nicht. AUF der obersten Ebene wird bewusst NICHT umbenannt: gemessen
+    verwirft die Plattform den GESAMTEN Ersatz, sobald ein Schluessel des Originals fehlt
+    (Bauvorgabe 4) — aus einer Teilluecke wuerde ein Totalausfall, auch fuer alle Werte.
+    Stattdessen wird laut gemeldet (in `main`), nie stillschweigend uebergangen.
+    """
+    umbenennungen: dict[str, str] = {}
+    for schluessel in list(knoten):
+        if not isinstance(schluessel, str):
+            continue
+        treffer: set[str] = set()
+        neuer = _ersetze(schluessel, paare, treffer)
+        if not treffer:
+            continue
+        if oberste_ebene:
+            notizen["oberste_schluessel"].add(neuer)   # maskierte Form, nie der Rohwert
+        else:
+            gefunden.update(treffer)
+            umbenennungen[schluessel] = neuer
+    if umbenennungen:
+        neu = [(umbenennungen.get(s, s), w) for s, w in knoten.items()]  # Reihenfolge bleibt
+        knoten.clear()
+        knoten.update(neu)
+
+
+def _maskiere_inplace(knoten, paare: list[tuple[str, str]], gefunden: set[str],
+                      notizen: dict, oberste_ebene: bool = False) -> None:
+    """Ersetzt Werte IN der uebergebenen Kopie — Reihenfolge und alle uebrigen Felder
+    bleiben unangetastet (Bauvorgabe 4). Laeuft ITERATIV ueber einen Stapel durch dicts und
+    Listen (keine Tiefengrenze, siehe Kopf), damit auch verschachtelte Formen
+    (`Read` -> `file.content`) und unbekannte Werkzeuge lueckenlos erfasst sind.
+    Schluesselnamen: siehe `_maskiere_schluessel` — `oberste_ebene` gilt nur fuer den
+    Wurzelknoten, alles darunter wird umbenannt."""
+    stapel: list[tuple[object, bool]] = [(knoten, oberste_ebene)]
+    while stapel:
+        aktuell, ist_oberste = stapel.pop()
+        if isinstance(aktuell, dict):
+            for schluessel, wert in list(aktuell.items()):
+                if isinstance(wert, str):
+                    neu = _ersetze(wert, paare, gefunden)
+                    if neu != wert:
+                        aktuell[schluessel] = neu
+                elif isinstance(wert, (dict, list)):
+                    stapel.append((wert, False))
+            # Erst nach den Werten: das Umbenennen laesst die Kindobjekte unberuehrt.
+            _maskiere_schluessel(aktuell, paare, gefunden, notizen, ist_oberste)
+        elif isinstance(aktuell, list):
+            for i, wert in enumerate(aktuell):
+                if isinstance(wert, str):
+                    neu = _ersetze(wert, paare, gefunden)
+                    if neu != wert:
+                        aktuell[i] = neu
+                elif isinstance(wert, (dict, list)):
+                    stapel.append((wert, False))
+
+
+# ------------------------------------------------------------------- Hauptlauf
+
+# Letztes bekanntes Werkzeug, damit die Notfallmeldung sagen kann, WELCHES Ergebnis
+# ungeprueft durchging. Steht auf "?" bis die Nutzlast gelesen ist.
+_WERKZEUG = "?"
+
+
+def _melde_abbruch(fehler: BaseException) -> None:
+    """Fail-open bleibt — lautlos bleibt es nicht (Befund F005).
+
+    Wird dieser Weg genommen, ist das Ergebnis UNGEPRUEFT bei Claude angekommen und kann
+    Zugangsdaten im Klartext enthalten. Genannt wird ausschliesslich der Ausnahme-TYP: der
+    TEXT einer Ausnahme kann Bruchstuecke der Nutzlast tragen, und ein Waechter, der beim
+    Scheitern das Geheimnis in seine Fehlermeldung schreibt, waere die Luecke in Reinform.
+    """
+    print(f"[secret_output_gate] Pruefung des Ergebnisses von {_WERKZEUG} NICHT abgeschlossen "
+          f"({type(fehler).__name__}) — das Ergebnis ging UNVERAENDERT durch und kann "
+          f"Zugangsdaten im Klartext enthalten.", file=sys.stderr)
+
+
+def main() -> int:
+    # Kein eigener try-Block: jede Stoerung faellt in den Notfall-Handler unten, der sie
+    # meldet. Frueher endete sie hier lautlos — ununterscheidbar von „nichts gefunden".
+    global _WERKZEUG
+    eingabe = json.loads(sys.stdin.read() or "{}")
+    if not isinstance(eingabe, dict):
+        return 0
+    _WERKZEUG = eingabe.get("tool_name") or "?"
+
+    if collect_secrets is None:
+        # Plugin fehlt oder ist zu alt: Ergebnis unveraendert, lautlos. Eine Meldung nach
+        # JEDEM Werkzeugaufruf waere unbrauchbarer Laerm.
+        return 0
+
+    ergebnis = eingabe.get("tool_response")
+    if not isinstance(ergebnis, (str, dict, list)):
+        return 0  # null/Zahl/bool: nichts zu maskieren
+
+    paare = _geheimnisse()
+    if not paare:
+        return 0
+
+    gefunden: set[str] = set()
+    notizen = _neue_notizen()
+    if isinstance(ergebnis, str):
+        # String-Form eines Ergebnisses. Fuer den Bash-Fehlschlag nachweislich
+        # unerreichbar (siehe „GEMESSENE GRENZE" im Kopf) — andere Werkzeuge koennen
+        # String-Ergebnisse aber sehr wohl liefern, deshalb bleibt der Zweig.
+        ersatz = _ersetze(ergebnis, paare, gefunden)
+    else:
+        ersatz = _tiefe_kopie(ergebnis)
+        _maskiere_inplace(ersatz, paare, gefunden, notizen,
+                          oberste_ebene=isinstance(ergebnis, dict))
+
+    werkzeug = _WERKZEUG
+    if gefunden:
+        print(json.dumps({"hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "updatedToolOutput": ersatz,
+        }}, ensure_ascii=False))
+        print(f"[secret_output_gate] Zugangsdaten im Ergebnis von {werkzeug} maskiert: "
+              f"{', '.join(sorted(gefunden))} (Wert bewusst nicht angezeigt).",
+              file=sys.stderr)
+    # Kein Fund UND nichts zu melden -> keinerlei Ausgabe, Ergebnis unangetastet (AC-1).
+    if notizen["oberste_schluessel"]:
+        print(f"[secret_output_gate] Zugangsdaten im SCHLUESSELNAMEN auf oberster Ebene des "
+              f"Ergebnisses von {werkzeug}: "
+              f"{', '.join(sorted(notizen['oberste_schluessel']))} (maskiert dargestellt, "
+              f"Wert bewusst nicht angezeigt). Dort NICHT umbenannt — die Plattform verwirft "
+              f"sonst den gesamten Ersatz und es bliebe auch jeder Wert unmaskiert. Der "
+              f"Schluesselname erreicht Claude daher im Klartext.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as _abbruch:  # noqa: BLE001 — Stoerung veraendert NIE ein Ergebnis ...
+        _melde_abbruch(_abbruch)   # ... bleibt aber nicht unerwaehnt (Befund F005)
+        sys.exit(0)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -145,6 +145,16 @@
             "timeout": 30
           }
         ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [ -f \"${CLAUDE_PROJECT_DIR}/.claude/hooks/secret_output_gate.py\" ]; then python3 \"${CLAUDE_PROJECT_DIR}/.claude/hooks/secret_output_gate.py\"; fi",
+            "timeout": 5
+          }
+        ]
       }
     ]
   }

--- a/docs/context/fix-1537-s2-laufzeit-lecks.md
+++ b/docs/context/fix-1537-s2-laufzeit-lecks.md
@@ -1,0 +1,280 @@
+# Context: fix-1537-s2-laufzeit-lecks
+
+**Issue:** #1537 (Scheibe 2) · verwandt: #1535, #1380, henemm-security #199
+**Erstellt:** 2026-08-07
+
+## Request Summary
+
+Scheibe 1 von #1537 schützt nur einen einzigen Austrittsweg: vorgemerkte Dateien beim
+Einchecken. Scheibe 2 schließt die beiden bewusst offen gelassenen Wege — **Stufe A**:
+Werte, die erst zur Laufzeit aus der `.env` in eine andere Datei wandern (ein Skript liest,
+ein Skript schreibt; im Werkzeug-Aufruf steht der Wert nie). **Stufe B**: Werte, die in einer
+Werkzeug-**Ausgabe** zurückkommen (`PreToolUse` prüft vor der Ausführung und sieht sie nicht).
+Dazu die Nebenbefunde F008/F009 am bestehenden Wächter.
+
+## Ausgangslage (gemessen 2026-08-07, nicht übernommen)
+
+| Zugang | Treffer des **heutigen** Werts in der öffentlichen Historie |
+|---|---|
+| `GZ_AUTH_PASS` | 0 — erneuert |
+| `GZ_SMTP_PASS` | 3 Commits — unverändert kompromittiert |
+| `GZ_TEST_SMTP_PASS` | 3 Commits — unverändert kompromittiert |
+| `GZ_TEST_IMAP_PASS` | 3 Commits — unverändert kompromittiert |
+
+Die Erneuerung läuft außerhalb dieses Workflows (PO: Resend · `infra`: Stalwart-Postfach,
+MQ 60308 offen, Erinnerung 60711).
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `.claude/hooks/secret_in_repo_gate.py` (421 Z.) | Scheibe 1. Vorbild für Aufbau, Ausgänge, Meldungsform. F008/F009 sitzen hier. |
+| `tests/unit/test_secret_in_repo_gate.py` (21 Tests) | Vorbild: echter Subprozess + stdin-Payload, keine Mocks; `GZ_SECRET_GATE_PATH` macht den Prüfling austauschbar (Mutationsprobe ohne Freigabe) |
+| `.claude/hooks/hook_utils.py` (56 Z.) | **Shim** — enthält keine Logik, lädt das Plugin-Modul per `importlib` und re-exportiert |
+| `.claude/settings.json:138-149` | einziger projekteigener `PostToolUse`-Block (`auto_restart_server.py`, Matcher `Bash`) |
+| `.claude/hooks/auto_restart_server.py:52,57-62` | einziger Präzedenzfall: liest `tool_response`, meldet auf stderr, Exit 0 |
+| `tests/tdd/test_issue_384_hook_fail_open.py:129-136,181` | erzwingt die Verdrahtungsform — macht einen falsch geschriebenen Eintrag sofort rot |
+| `tests/tdd/test_issue_348_parallel_workspaces.py:110,123,242` | verlangt `${CLAUDE_PROJECT_DIR}` und Zeichengleichheit Worktree ↔ Hauptordner |
+
+### Außerhalb dieses Repos (Plugin `agent-os-openspec` 3.10.2)
+
+| Datei | Relevanz |
+|---|---|
+| `core/hooks/secret_egress_guard.py` (322 Z.) | **Der eigentliche Baukasten für Stufe B.** `collect_secrets:184`, `_is_secret_key:165`, `_is_secret_value:174`, Platzhalter-Filter `:78-97` |
+| `core/hooks/hook_utils.py` (786 Z.) | `is_git_subcommand:281`, `get_tool_input:405`, `find_project_root:593`, `strip_heredoc_bodies:498` |
+| `hooks/hooks.json:86-107` | Plugin hat bereits zwei `PostToolUse`-Hooks (`post_bash.py`, `edit_verify.py`) |
+
+## Existing Patterns
+
+- **Verdrahtungsform (unverhandelbar, testgeprüft):**
+  `if [ -f "${CLAUDE_PROJECT_DIR}/.claude/hooks/<name>.py" ]; then python3 "${CLAUDE_PROJECT_DIR}/.claude/hooks/<name>.py"; fi`
+  `&&`/`|| exit 0` ist ausdrücklich verboten (verschluckt den Rückgabewert 2).
+- **Ein Hook = eine Gruppe** im `PreToolUse`-Array (9 Gruppen, alle mit Matcher `Bash`).
+  Nur `Stop` bündelt drei Hooks in einer Liste.
+- **Dateiname nur `[A-Za-z0-9_]`** — Bindestriche macht `_HOOK_RE` unsichtbar.
+- **Meldung nennt nie den Wert**, nur Datei + Schlüsselname (`secret_in_repo_gate.py:55-57,396`).
+- **Kein `.env`-Cache** in beiden Wächtern — ausdrücklich wegen Rotation.
+- **Tests fahren den Hook als echten Subprozess** mit stdin-JSON gegen synthetische `.env`-Werte
+  in `tmp_path`. Plugin-Sonde am Modulkopf: fehlt das Plugin, `skip` statt strukturellem Rot.
+
+## Dependencies
+
+- **Upstream:** Plugin `agent-os-openspec ≥ 3.10.0` (via Shim). Fehlt es, geht jeder Wächter
+  fail-open — die Tests überspringen dann, statt falsch rot zu werden.
+- **Downstream:** `.claude/settings.json` — wirkt auf **jede** Sitzung in diesem Projekt,
+  auch auf fremde Worktrees.
+
+## Risks & Considerations
+
+### R1 — `PostToolUse` kann nicht blockieren (Doku selbst gelesen, nicht vermutet)
+
+Belegt in der Hook-Doku: Exit 2 bei `PostToolUse` „shows stderr to Claude; **the tool already
+ran**". `FileChanged` ebenso wenig. **Folge für Stufe A:** Eine Sperre ist technisch nicht
+möglich; nur Nachsorge — Datei auf `600` setzen oder entfernen und melden. Gegen den
+tatsächlichen Schadensfall (#1380: weltlesbare `/tmp`-Datei) wirkt das, aber die ACs dürfen
+keine Sperre versprechen, die es nicht gibt.
+
+`updatedToolOutput` **existiert** und Redaction ist ausdrücklich als Anwendungsfall genannt
+(„intercept at `PreToolUse` for outbound tool inputs and `PostToolUse` for inbound tool
+results"). Struktur: `{"hookSpecificOutput": {"hookEventName": "PostToolUse",
+"updatedToolOutput": "…"}}`. Stufe B ist damit tragfähig.
+
+### R2 — Es gibt bereits ZWEI verschiedene Begriffe von „Geheimnis". Ein dritter wäre der Fehler.
+
+| | `secret_in_repo_gate` (Projekt) | `secret_egress_guard` (Plugin) |
+|---|---|---|
+| Schlüssel | Suffix-Allowlist, 4 Einträge | Regex-Denylist, 18 Muster |
+| Mindestlänge | 10 | 8 |
+| Platzhalter-Filter | keiner | 26 Werte + 6 Regex + URL/Pfad |
+| Störungsverhalten | drei Ausgänge, teils fail-closed | durchgehend fail-open |
+
+Stufe B braucht genau die Erkennung, die das Plugin schon hat — die liegt aber in einem
+**anderen Repository**. Zu entscheiden in der Analyse: Wiederverwendung über den
+`hook_utils`-Shim (dann muss das Plugin die Funktionen exportieren — Fremd-Repo-Änderung)
+oder bewusste Kopie im Projekt (dann drei Begriffe). **Nicht in der Implementierung
+nebenbei entscheiden.**
+
+### R3 — Verdrahtung legt potenziell ALLE Sitzungen lahm
+
+`CLAUDE_PROJECT_DIR` zeigt auf den **Hauptordner**, nicht auf den Arbeitsordner. Ist der
+Hauptordner nach dem Merge nicht nachgezogen, scheitert der Hook in **jeder** Sitzung
+(am 2026-08-04 eine Stunde Totalblockade). Die geschützte `if [ -f … ]`-Form verhindert genau
+das — deshalb ist sie hier Pflicht, nicht Kosmetik.
+
+Zusätzlich: `.claude/settings.json` wird **beim Sitzungsstart** eingelesen. Der Hook ist erst
+ab der nächsten Sitzung scharf; das gehört in die Abschlussmeldung.
+
+### R4 — `.claude/settings.json` ist orchestrator-geschützt
+
+`edit_gate.py` blockiert Edits daran; nur der **User** kann per getipptem `override` freigeben,
+**TTL 1 Stunde**. Die Verdrahtung braucht also einen PO-Eingriff und muss in einem Zug
+erledigt werden. Zusätzlich verlangt `test_issue_348_parallel_workspaces.py:242`
+Zeichengleichheit zwischen Hauptordner und Worktree.
+
+### R5 — Mutations-Gegenprobe darf `.claude/**` nicht anfassen
+
+Bei Scheibe 1 lief der Freigabe-Token mitten in der Gegenprobe ab und die Datei blieb
+**mutiert** liegen (Sicherheitsblockade stand offen, PO musste 4× freigeben). Richtig:
+Mutationen auf einer Kopie im Scratchpad, Prüflingspfad per Env-Var umstellbar — das Muster
+`GZ_SECRET_GATE_PATH` (`test_secret_in_repo_gate.py:32`) existiert schon und ist zu übernehmen.
+
+### R6 — LoC-Limit
+
+Scheibe 1 war allein 421 Zeilen Hook. Stufe A und Stufe B zusammen plus Tests sprengen das
+Limit von 250 sicher. **Empfehlung: zwei getrennte Workflows** (Stufe B zuerst — sie schließt
+den Weg, über den #1535 tatsächlich Werte ausgegeben hat) statt eines LoC-Overrides.
+
+### R7 — Reichweite von Stufe B ist zu bestimmen, nicht anzunehmen
+
+`PostToolUse` bekommt `tool_name`, `tool_input`, `tool_response`. Welche Werkzeuge maskiert
+werden sollen (nur `Bash`? auch `Read`? auch MCP-Werkzeuge?) ist eine Spec-Frage: Der
+Egress-Guard arbeitet mit einer Negativliste, in der `Read` und `Grep` **übersprungen** werden —
+für Ausgaben ist gerade `Read` aber ein realistischer Austrittsweg.
+
+## Existing Specs
+
+Für Scheibe 1 wurde **keine** Spec unter `docs/specs/modules/` abgelegt (geprüft: kein Treffer
+auf `1537` oder `secret`). Verwandte Specs betreffen den namensgleichen, aber thematisch
+anderen Netzwerk-Egress (`docs/specs/modules/egress_guard*.md`) — **nicht** verwechseln.
+Beste vorhandene Gate-Übersicht: `docs/context/fix-1307b-gates.md`.
+
+## Offene Nebenbefunde aus Scheibe 1
+
+- **F008** (MEDIUM, Fehlalarm): Die `cd`-Erkennung prüft nicht, ob das Segment zu einem
+  git-Aufruf gehört. Ein unquotiertes `git commit -F - <<'EOF'` mit einer Nachrichtenzeile,
+  die mit „cd" beginnt, blockiert fälschlich. `strip_heredoc_bodies` (`hook_utils:498`)
+  existiert bereits und wird hier offenbar nicht genutzt.
+- **F009** (MEDIUM, Testlücke): Bei kaputten Anführungszeichen verhält sich der Code korrekt
+  (blockiert), aber kein Test bewacht das.
+
+## Analysis (Phase 2, 2026-08-07)
+
+### Type
+
+**Feature** — neuer Wächter. Ausgelöst durch einen Sicherheitsbefund, aber es wird kein
+fehlerhaftes Verhalten repariert, sondern ein bisher unbewachter Weg geschlossen.
+
+### Zuschnitt-Entscheidung
+
+Dieser Workflow deckt **nur Stufe B** ab (Maskierung in Werkzeug-Ausgaben). Begründung:
+Scheibe 1 war allein 421 Zeilen Hook; Stufe A + B + Tests sprengen das 250-Zeilen-Limit
+sicher, und ein LoC-Override wäre die Regel umgehen statt die Arbeit schneiden. Stufe B
+zuerst, weil sie den Weg schließt, über den in #1535 nachweislich ein aktiver Zugang
+ausgetreten ist. Stufe A und F008/F009 folgen als eigene Workflows.
+
+### A1 — Wiederverwendung statt drittem Geheimnis-Begriff (löst R2)
+
+Das Plugin-Repo `henemm/agent-os-openspec` gehört uns (Eigentümer `henemm`, öffentlich);
+Quelle `/home/hem/agent-os-openspec` und ausgelieferte Kopie
+`~/.claude/plugins/cache/henemm-private/agent-os-openspec/3.10.2` sind deckungsgleich,
+HEAD == installierter `gitCommitSha`.
+
+**Eine Plugin-Änderung ist trotzdem der falsche Weg.** Sie verlangt Versions-Bump in
+`.claude-plugin/plugin.json` + `claude plugin update`, und das Plugin ist auf **allen sechs**
+Claude-Instanzen dieses Servers aktiv. Ein Sicherheitsfix in einem Projekt würde die
+Werkzeugbasis aller anderen anfassen.
+
+**Stattdessen:** `secret_egress_guard.py` ist importierbar — der ausführende Code steht
+vollständig hinter `if __name__ == "__main__"` (`:317-322`). `collect_secrets:184`,
+`_is_secret_key:165`, `_is_secret_value:174`, `_PLACEHOLDER_VALUES:78` sind normale
+Modulsymbole. Der Ladeweg existiert bereits als erprobtes Muster: `.claude/hooks/hook_utils.py`
+lädt das Plugin-Modul per `importlib` über `installed_plugins.json`.
+
+Preis, der in der Spec stehen muss: Wir importieren **private** (unterstrich-präfigierte)
+Funktionen aus einem fremden Repo. Absicherung wie in `secret_in_repo_gate.py:96-123` — zwei
+getrennte `try`-Blöcke, damit eine ältere Plugin-Fassung den Wächter nicht lahmlegt, sondern
+nur fail-open werden lässt. Nebeneffekt beim Import: `_setup()` läuft auf Modulebene und
+verändert `sys.path` (`:43-51`) — per `importlib` mit direktem Dateipfad umgehbar.
+
+### A2 — Gestalt der Nutzlast (empirisch, ~46.000 echte Werkzeug-Ergebnisse)
+
+`tool_response` ist **kein einheitlicher Typ**:
+
+| Fall | Gestalt |
+|---|---|
+| Bash, Erfolg (33.681 Fälle) | dict: `stdout`, `stderr`, `interrupted`, `isImage`, `noOutputExpected` (+ optional `gitOperation`, `persistedOutputPath`, …) |
+| Bash, **Fehlschlag** (2.576) | **reiner String**: `"Error: Exit code 1\n…"` — die Exit-Code-Information steht nur dort |
+| `Read` (3.468) | `{"type":"text","file":{"filePath":…,"content":…}}` — Inhalt **verschachtelt** unter `file.content` |
+| `Write` (1.916) | `{"type":"create","filePath",…,"content": …}` — Inhalt auf oberster Ebene |
+| `Edit` (2.739) | `oldString`, `newString`, `originalFile`, `structuredPatch` — **kein** `stdout`/`content` |
+
+Es gibt **kein** `exit_code`-Feld. Ein `content`-Feld existiert bei Bash **nicht** — der
+Fallback in `auto_restart_server.py:62` greift dort ins Leere (kein Fehler, nur tote Zeile).
+
+**Folge:** Eine Maskierung, die nur `stdout` anfasst, verfehlt `Read` (verschachtelt) und
+jeden Fehlschlag (String). Genau diese beiden sind die realistischen Austrittswege.
+
+### A3 — Der entscheidende Unbekannte: die Ausgabeform ist im Haus unerprobt
+
+**Kein einziger Hook** im Projekt oder im Plugin gibt JSON auf stdout aus — 0 Treffer auf
+`hookSpecificOutput` in beiden Repos. Alle 20+ Hooks melden über stderr und Exit-Code.
+Stufe B wäre der erste. Unbeantwortet und **nicht durch Code-Lesen beantwortbar**:
+
+- Erwartet `updatedToolOutput` einen **String**, oder darf/muss es die ursprüngliche
+  **Struktur** (dict) tragen?
+- Was passiert, wenn ein dict-förmiges Bash-Ergebnis durch einen String ersetzt wird —
+  bricht das nachgelagerte Verarbeitung?
+- Wirkt es überhaupt in dieser Claude-Code-Fassung?
+
+**Deshalb Pflicht vor der Implementierung: ein Vorab-Experiment** mit einem
+Wegwerf-Hook gegen einen harmlosen Marker-String. Ohne diesen Nachweis wäre die gesamte
+Implementierung auf einer Vermutung gebaut — genau das Muster, das in diesem Projekt
+wiederholt in falsches Grün geführt hat.
+
+### A4 — Risiko-Bewertung
+
+**HIGH.** Der Hook läuft nach **jedem** Werkzeugaufruf in **jeder** Sitzung dieses Projekts.
+Ein Fehler verfälscht nicht ein Feature, sondern jedes Werkzeug-Ergebnis.
+
+Daraus abgeleitete, nicht verhandelbare Bauvorgaben:
+
+1. **Stumm im Normalfall.** Kein Fund ⇒ **keinerlei** stdout, Exit 0. Nur bei einem echten
+   Treffer wird überhaupt etwas ausgegeben.
+2. **Durchgehend fail-open.** Jede eigene Störung (Plugin fehlt, `.env` unlesbar, unerwartete
+   Nutzlast, Ausnahme) ⇒ Exit 0, unverändertes Ergebnis. Anders als Scheibe 1, wo fail-closed
+   richtig war: dort kostet ein Irrtum einen blockierten Commit, hier ein zerstörtes
+   Werkzeug-Ergebnis in jeder Sitzung.
+3. **Zeitbudget klein** (Vorbild Egress-Guard: 5 s), damit der Wächter nicht jede Aktion bremst.
+4. **Die Meldung nennt nie den Wert** — nur Werkzeug + Schlüsselname (Regel aus Scheibe 1).
+
+### Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `.claude/hooks/secret_output_gate.py` | CREATE | der Wächter (Name nur `[A-Za-z0-9_]`) |
+| `tests/unit/test_secret_output_gate.py` | CREATE | Subprozess + stdin-Payload, synthetische `.env` in `tmp_path`, Prüflingspfad per Env-Var austauschbar |
+| `.claude/settings.json` | MODIFY | neue `PostToolUse`-Gruppe in der geschützten `if [ -f … ]`-Form — **orchestrator-geschützt, braucht PO-`override`** |
+| `docs/specs/modules/fix_1537_s2b_secret_output_gate.md` | CREATE | Spec (zählt nicht gegen LoC) |
+
+### Scope Assessment
+
+- Dateien: 4 (2 neu Code, 1 Änderung, 1 Doku)
+- Geschätzt: ~200 Zeilen Hook + ~150 Zeilen Test. **Test-Zeilen zählen mit** — das LoC-Limit
+  von 250 wird voraussichtlich gerissen. Vor einem Override wird geprüft, ob der Hook durch
+  konsequente Wiederverwendung der Plugin-Funktionen deutlich unter 200 Zeilen bleibt.
+- Risiko: **HIGH** (siehe A4)
+
+### Open Questions
+
+- [x] **Q1 (technisch, geklärt wie sie zu behandeln ist):** Nimmt `updatedToolOutput` einen
+      String oder die Originalstruktur? — **Nicht vor der Spec zu beantworten und auch nicht
+      nötig.** Eine AC darf den Mechanismus nicht voraussetzen; zugesichert wird die
+      *Wirkung* („der Wert erscheint nicht mehr im Klartext im Werkzeug-Ergebnis"). Das
+      Experiment ist der **erste Schritt der Implementierungsphase** (Wegwerf-Hook, eigenes
+      Projekt im Scratchpad, Marker-String statt echtem Geheimnis). Die Spec benennt den
+      **Rückfall**, falls `updatedToolOutput` in dieser Claude-Code-Fassung nicht trägt: der
+      Wächter meldet den Fund dann auf stderr mit Werkzeug + Schlüsselname — schlechter als
+      Maskierung, aber immer noch ein Fund statt eines stillen Lecks.
+- [ ] **Q2 (Spec-Frage):** Welche Werkzeuge werden maskiert? Der Egress-Guard überspringt
+      `Read`/`Grep` für **ausgehende** Eingaben — für **Ausgaben** ist gerade `Read` der
+      realistischste Austrittsweg. Vorschlag: alle Werkzeuge, kein Ausschluss.
+- [ ] **Q3 (Spec-Frage):** Was tun, wenn ein Wert im Ergebnis steht — vollständig ersetzen
+      (`***`) oder mit Schlüsselnamen kenntlich machen (`***GZ_SMTP_PASS***`)? Letzteres hilft
+      beim Verstehen, verrät aber, welcher Schlüssel wo auftaucht.
+
+## Verwandtes Issue #1535
+
+`tests/tdd/test_issue_1014_live_optin.py:89` vergleicht `os.environ`-Abbilder und druckt bei
+Fehlschlag den **Wert** von `GZ_TELEGRAM_TEST_BOT_TOKEN` in die Testausgabe. Das ist genau die
+Klasse, die Stufe B abfangen würde — der richtige Fix bleibt trotzdem im Test (Zusicherung auf
+Schlüsselnamen umstellen). Stufe B ist das Netz, nicht der Ersatz.

--- a/docs/specs/modules/fix_1537_s2b_secret_output_gate.md
+++ b/docs/specs/modules/fix_1537_s2b_secret_output_gate.md
@@ -1,0 +1,486 @@
+---
+entity_id: fix_1537_s2b_secret_output_gate
+type: feature
+created: 2026-08-07
+updated: 2026-08-07
+status: draft
+version: "1.0"
+tags: [gate, security, post-tool-use, secrets]
+---
+
+# Spec: Ausgabe-Wächter „Secret-Output-Sperre" (Stufe B)
+
+- **Issue:** #1537 Scheibe 2, Stufe B
+- **Workflow:** `fix-1537-s2-laufzeit-lecks`
+- **created:** 2026-08-07
+- **Kontext & Messungen:** `docs/context/fix-1537-s2-laufzeit-lecks.md`
+- **Status:** Entwurf — wartet auf PO-Freigabe der Acceptance Criteria
+
+## Approval
+
+- [x] Approved — Product Owner, 2026-08-07 („go", Freigabe der 12 Acceptance Criteria auf Deutsch)
+
+## Zweck in einem Satz
+
+Ein `PostToolUse`-Wächter durchsucht das **Ergebnis** jedes Werkzeugaufrufs nach dem
+ausgeschriebenen Wert eines Geheimnisses aus der lokalen `.env` und ersetzt jeden Treffer
+durch `***<SCHLÜSSELNAME>***`, bevor Claude das Ergebnis sieht — im Normalfall (kein Fund)
+bleibt das Ergebnis unangetastet und es erscheint keinerlei Ausgabe.
+
+## Warum
+
+Scheibe 1 (`secret_in_repo_gate.py`) schützt nur einen einzigen Austrittsweg: vorgemerkte
+Dateien beim `git commit`. Zwei Wege bleiben offen. **Stufe A** (Werte, die zur Laufzeit von
+einer Datei in eine andere wandern) ist ein eigener Workflow. **Stufe B** — dieser hier —
+schließt den zweiten Weg: einen Geheimniswert, der in der **Ausgabe** eines Werkzeugs
+zurückkommt, obwohl er im Aufruf selbst nie stand. `PreToolUse` prüft vor der Ausführung und
+sieht diesen Wert nicht; der bestehende Egress-Wächter des Plugins (`secret_egress_guard.py`,
+#1380) deckt nur ausgehende *Eingaben* ab.
+
+Anlassfall: `tests/tdd/test_issue_1014_live_optin.py:89` vergleicht `os.environ`-Abbilder und
+druckt bei Fehlschlag den **Wert** von `GZ_TELEGRAM_TEST_BOT_TOKEN` in die Testausgabe (#1535).
+Genau diese Klasse — ein Geheimnis, das über ein Werkzeug-Ergebnis (hier: `Bash`-`stdout`)
+sichtbar wird — fängt Stufe B ab. Der eigentliche Fix bleibt im Test (Zusicherung auf
+Schlüsselnamen statt Wert umstellen, siehe „Nicht in dieser Scheibe") — dieser Wächter ist das
+Netz, nicht der Ersatz.
+
+## Zuschnitt
+
+**Umfang: alle Werkzeuge, kein Ausschluss.** Der bestehende Egress-Wächter überspringt `Read`
+und `Grep`, weil er ausgehende *Eingaben* prüft (dort ist ein gelesener Dateiname kein
+Geheimnis). Für *Ausgaben* gilt das Gegenteil: `Read` ist gerade der wahrscheinlichste
+Austrittsweg — jede Datei, die ein Geheimnis im Klartext enthält (versehentlich committet, aus
+einer `.env` kopiert, in einem Log), tritt beim Vorlesen aus. Der Wächter filtert deshalb nicht
+nach `tool_name`.
+
+**Ersatzform: `***<SCHLÜSSELNAME>***`**, z.B. `***GZ_SMTP_PASS***`. Nie der nackte Wert, aber
+auch nie ein anonymes `***` — ein Ersatz ohne Schlüsselnamen macht die Ausgabe unverständlich
+(„wieso ist da plötzlich `***`?"), der Schlüsselname selbst ist nicht das Geheimnis, und die
+Form bleibt konsistent zur Meldungsform aus Scheibe 1 (dort: „Schlüssel: GZ_SMTP_PASS", nie der
+Wert).
+
+**Durchgehend fail-open — die Umkehrung von Scheibe 1.** Dort ist fail-closed richtig: ein
+Irrtum beim Commit-Gate kostet einen blockierten Commit, das ist unbequem, aber ungefährlich.
+Hier ist die Lage umgekehrt: der Wächter läuft nach **jedem** Werkzeugaufruf in **jeder**
+laufenden Sitzung — ein Irrtum (Plugin fehlt, `.env` unlesbar, unerwartete Nutzlast-Gestalt,
+eine nicht vorhergesehene Ausnahme) darf niemals ein Werkzeug-Ergebnis zerstören oder eine
+Sitzung blockieren. Jede eigene Störung führt zu: Ergebnis unverändert, Exit 0.
+
+**Stumm im Normalfall.** Kein Fund heißt keinerlei Ausgabe und ein unverändertes Ergebnis. Nur
+ein echter Treffer erzeugt überhaupt eine Wirkung.
+
+**Geheimnis-Erkennung wird wiederverwendet, nicht neu gebaut.** Es gibt im Projekt bereits zwei
+verschiedene Begriffe von „Geheimnis" (Scheibe 1: enge Suffix-Allowlist mit vier Endungen;
+Plugin-Egress-Wächter: breite Regex-Denylist mit Platzhalter-Filter). Ein dritter, eigener
+Begriff wäre der Fehler. Dieser Wächter lädt `collect_secrets`, `_is_secret_key`,
+`_is_secret_value` aus `core/hooks/secret_egress_guard.py` des Plugins `agent-os-openspec`
+per `importlib` — analog zum bestehenden Muster in `.claude/hooks/hook_utils.py` (dort für
+`hook_utils.py` des Plugins). Der Import passiert in **zwei getrennten `try`-Blöcken** (Vorbild
+`secret_in_repo_gate.py:96-123`), damit eine ältere Plugin-Fassung ohne diese Funktionen den
+Wächter nur fail-open werden lässt, statt ihn komplett lahmzulegen.
+
+**Der Mechanismus trägt — gemessen 2026-08-07, der frühere Rückfall entfällt.** Neun Läufe einer
+eigenständigen Sitzung (Claude Code 2.1.224) im Scratchpad, mit einem Zufallsmarker, den die
+Kindsitzung nur aus dem Werkzeug-Ergebnis kennen konnte. Ergebnis:
+
+| Gesendeter Ersatzwert | Wirkung |
+|---|---|
+| dict mit **allen fünf** Originalschlüsseln | **ersetzt** |
+| dict mit allen fünf **plus** eigenem Zusatzschlüssel | **ersetzt** |
+| String | still verworfen |
+| dict mit nur `stdout` | still verworfen |
+| dict mit nur `stdout` + `stderr` | still verworfen |
+
+🔴 **Das Verwerfen ist vollständig lautlos.** Kein Fehler, kein Hinweis, Hook-Exit 0, Sitzung
+läuft normal weiter — auch unter `--debug hooks` erscheint keine Diagnosezeile. Ein falsch
+geformter Ersatzwert ist damit **von einem funktionierenden Wächter nicht unterscheidbar**.
+
+**Bauvorgabe, zwingend:** das empfangene `tool_response` **kopieren** und darin nur Werte
+ersetzen. Niemals ein frisches Objekt bauen, niemals einen String zurückgeben. Fehlende
+Schlüssel führen zur Ablehnung, zusätzliche nicht.
+
+**Zusatznutzen, gemessen:** Bei wirksamer Ersetzung enthält auch das auf Platte gespeicherte
+Sitzungsprotokoll (`~/.claude/projects/…/*.jsonl`) den Ersatzwert an beiden Stellen; der
+Zufallsanteil des Originals war per Suche in keinem Protokoll auffindbar. Die Maskierung wirkt
+also nicht nur auf den Modellkontext, sondern auch auf die dauerhafte Ablage.
+
+## Acceptance Criteria
+
+- **AC-1:** Kein Fund bleibt vollständig unsichtbar.
+  Given ein Werkzeug-Ergebnis enthält keinen Wert aus der lokalen `.env`, der als Geheimnis gilt
+  When der Wächter nach dem Werkzeugaufruf läuft
+  Then bleibt das Ergebnis, das Claude sieht, unverändert, und es erscheint keinerlei zusätzliche
+  Ausgabe (kein stderr, kein stdout-Zusatz).
+  - Test: Wegwerf-Sitzung mit synthetischer `.env`, ein `Bash`-Aufruf ohne Geheimnis im Ergebnis
+    → Prozess-Exit 0, leere zusätzliche Ausgabe.
+
+- **AC-2:** Ein Geheimnis in einer erfolgreichen Bash-Ausgabe erscheint danach nicht mehr im
+  Klartext.
+  Given eine `.env` mit einem Geheimnis (Schlüssel-Endung passend, Wert lang genug)
+  When ein `Bash`-Aufruf erfolgreich durchläuft und der Wert im `stdout` des Ergebnisses steht
+  Then ist der ausgeschriebene Wert im Ergebnis, das Claude sieht, nicht mehr im Klartext
+  lesbar — an seiner Stelle steht `***<SCHLÜSSELNAME>***`.
+  - Test: synthetisches Bash-Erfolgsergebnis (dict mit `stdout`) mit eingebettetem Geheimnis als
+    stdin-Payload an den Wächter, geprüft wird die vom Wächter erzeugte Ersatz-Ausgabe.
+
+- **AC-3:** ~~Ein Geheimnis in einer fehlgeschlagenen Bash-Ausgabe erscheint danach nicht mehr im
+  Klartext~~ — ENTFÄLLT, belegt unmöglich (2026-08-07).
+
+  Diese Zusicherung ist mit dem Hook-Vertrag **nicht erfüllbar**. Zwei unabhängige Belege:
+
+  1. **Gemessen:** Bei `Exit ≠ 0` wird der `PostToolUse`-Hook **überhaupt nicht aufgerufen**.
+     Kontrollläufe mit Zufallsmarker: Exit 0 → eine Protokollzeile im Hook, Exit 1 → **null**
+     Zeilen, und die Sitzung sah den Marker wörtlich. Nicht „Ersatz verworfen" — nie aufgerufen.
+  2. **Dokumentiert:** „PostToolUse | After a tool call **succeeds**" gegenüber
+     „PostToolUseFailure | After a tool call **fails**". Und `PostToolUseFailure` unterstützt
+     laut Decision-Control-Tabelle **kein** `updatedToolOutput` — nur `decision: "block"` und
+     `additionalContext`. Ein fehlgeschlagenes Ergebnis kann also gemeldet, aber nicht ersetzt
+     werden.
+
+  Der zugehörige Test bleibt als Absicherung des String-Zweigs im Wächter erhalten (andere
+  Werkzeuge können String-Ergebnisse liefern), verweist aber im Docstring auf diese Grenze. Er
+  belegt eine **Fähigkeit**, keine **Wirkung** — und wird deshalb nicht als erfüllte AC gezählt.
+
+  🔴 **Tragweite, offen benannt:** Der Anlassfall #1535 ist ein *fehlschlagender* Test; pytest
+  endet dann mit Exit ≠ 0. **Stufe B verhindert den Vorfall nicht, für den sie gebaut wurde.**
+  Sie schützt weiterhin: gelesene Dateiinhalte, erfolgreiche Befehlsausgaben, geschriebene
+  Dateien und Textänderungen. Der eigentliche Fix für #1535 bleibt im Test selbst — das stand
+  schon immer so im Issue, ist jetzt aber keine Empfehlung mehr, sondern die einzige Möglichkeit.
+
+- **AC-4:** Ein Geheimnis in einem gelesenen Dateiinhalt erscheint danach nicht mehr im Klartext.
+  Given dieselbe `.env`
+  When das `Read`-Werkzeug eine Datei liest, deren Inhalt (verschachtelt unter `file.content`)
+  den Wert enthält
+  Then ist der Wert im Ergebnis, das Claude sieht, nicht mehr im Klartext lesbar.
+  - Test: synthetisches `Read`-Ergebnis mit der gemessenen verschachtelten Form
+    `{"file": {"content": "…GEHEIMNIS…"}}` — ohne diesen Test bliebe der wahrscheinlichste
+    Austrittsweg ungeprüft.
+
+- **AC-5:** Ein Geheimnis in einem geschriebenen Dateiinhalt erscheint danach nicht mehr im
+  Klartext.
+  Given dieselbe `.env`
+  When das `Write`-Werkzeug eine Datei anlegt, deren Ergebnis (`content` auf oberster Ebene) den
+  Wert enthält
+  Then ist der Wert im Ergebnis nicht mehr im Klartext lesbar.
+  - Test: synthetisches `Write`-Ergebnis mit `content`-Feld auf oberster Ebene.
+
+- **AC-6:** Ein Geheimnis in einer Textänderung erscheint danach nicht mehr im Klartext.
+  Given dieselbe `.env`
+  When das `Edit`-Werkzeug einen Text ändert und der Wert in `oldString`, `newString` oder
+  `originalFile` steht
+  Then ist der Wert in keinem dieser drei Felder mehr im Klartext lesbar.
+  - Test: synthetisches `Edit`-Ergebnis, Geheimnis einmal in `oldString`, einmal in `newString`,
+    einmal in `originalFile` — je einzeln geprüft, damit keines der drei Felder unbemerkt
+    durchrutscht.
+
+- **AC-7:** Kurze oder nicht passende Werte lösen keine Maskierung aus.
+  Given eine `.env` enthält einen Wert, der entweder zu kurz ist oder dessen Schlüssel nicht zu
+  den gesuchten Mustern passt, oder einen bekannten Platzhalterwert (z.B. `changeme`)
+  When dieser Wert in einem Werkzeug-Ergebnis vorkommt
+  Then bleibt das Ergebnis unverändert — keine Maskierung, keine Ausgabe.
+  - Test: Ergebnis mit kurzem Wert und mit einem der vom Plugin-Filter erfassten
+    Platzhalterwerte, jeweils Exit 0 und unverändertes Ergebnis. Verhindert, dass der Wächter
+    harmlose Werte (Projektnamen, Beispielwerte) fälschlich maskiert.
+
+- **AC-8:** Eine eigene Störung des Wächters führt nie zu einem veränderten oder blockierten
+  Ergebnis.
+  Given der Wächter selbst kann nicht arbeiten (Plugin-Modul nicht ladbar, `.env` unlesbar, die
+  Nutzlast hat eine nicht vorhergesehene Gestalt, oder eine sonstige Ausnahme tritt auf)
+  When ein Werkzeugaufruf durchläuft, dessen Ergebnis ein Geheimnis enthält
+  Then bleibt das Ergebnis unverändert (Exit 0) — der Wächter blockiert nie und verfälscht das
+  Ergebnis nie durch einen eigenen Fehler.
+  - Test: Wächter-Aufruf mit fehlendem/nicht ladbarem Plugin (Umgebung ohne Plugin-Registrierung)
+    → Ergebnis unverändert. Zusätzlich: kaputtes JSON auf stdin, `tool_response` als unerwarteter
+    Typ (z.B. `null`/Zahl) → Ergebnis unverändert, kein Absturz.
+
+- **AC-9:** Eine Fund-Meldung nennt nie den Wert selbst.
+  Given der Wächter maskiert einen Fund oder greift auf den Rückfall (stderr-Meldung) zurück
+  When die Meldung erzeugt wird
+  Then enthält sie ausschließlich Werkzeugname und Schlüsselname — der Wert selbst taucht in
+  keiner Ausgabe (stdout, stderr, Ersatz-Ergebnis) auf.
+  - Test: Fund-Fall auslösen, Prozess-Gesamtausgabe (stdout + stderr) auf Abwesenheit des rohen
+    Werts prüfen, Anwesenheit des Schlüsselnamens prüfen — wichtigste Einzelzusicherung, analog
+    zu `test_block_message_never_contains_the_secret_value` aus Scheibe 1.
+
+- **AC-10:** Die Maskierung gilt unabhängig vom Werkzeugnamen.
+  Given ein Geheimnis steht im Ergebnis eines Werkzeugs, das weder `Bash`, `Read`, `Write` noch
+  `Edit` heißt (z.B. ein MCP-Werkzeug oder ein zukünftig hinzukommendes Werkzeug)
+  When dieses Ergebnis den Wert enthält
+  Then wird ebenso maskiert wie bei den vier benannten Werkzeugen — es gibt keine Positivliste,
+  die ein Werkzeug ausnimmt.
+  - Test: synthetisches Ergebnis mit einem frei erfundenen `tool_name` (z.B. `"AnyMcpTool"`) und
+    einem generischen Textfeld, das das Geheimnis enthält — Maskierung greift trotzdem.
+
+- **AC-11:** Alles außer dem Geheimnis bleibt unversehrt.
+  Given ein Werkzeug-Ergebnis enthält ein Geheimnis **und** übrigen Inhalt (weiterer Text vor und
+  nach dem Wert, sowie weitere Felder im Ergebnis)
+  When der Wächter maskiert
+  Then ist ausschließlich der Geheimniswert ersetzt — jeder andere Text und jedes andere Feld
+  kommt unverändert bei Claude an.
+  - Test: Ergebnis mit Text vor und nach dem Wert sowie mit weiteren Feldern (`stderr`,
+    `interrupted`) — geprüft wird die Anwesenheit **beider** Textteile und aller übrigen Felder.
+    Ohne diese AC bestünde eine Umsetzung, die das gesamte Ergebnis durch einen Platzhalter
+    ersetzt, die ACs 2–6 vollständig — der Wert wäre weg, aber auch jede nutzbare Ausgabe.
+
+- **AC-12:** Mehrfaches Vorkommen wird vollständig maskiert.
+  Given derselbe Geheimniswert steht **mehrfach** in einem Werkzeug-Ergebnis, und zusätzlich
+  stehen **zwei verschiedene** Geheimnisse darin
+  When der Wächter maskiert
+  Then ist kein einziges Vorkommen mehr im Klartext lesbar — weder ein weiteres Vorkommen
+  desselben Werts noch das zweite Geheimnis.
+  - Test: Ergebnis mit demselben Wert an drei Stellen und einem zweiten Geheimnis an einer
+    vierten. Verhindert eine Umsetzung, die nur den ersten Treffer ersetzt.
+
+- **AC-13:** Der Ersatz hat die Gestalt, die die Plattform tatsächlich annimmt.
+  Given der Wächter hat ein Geheimnis gefunden und erzeugt einen Ersatz für ein
+  Werkzeug-Ergebnis, das als Objekt vorlag
+  When der Ersatz an die Plattform übergeben wird
+  Then trägt er **jeden** Schlüssel des ursprünglichen Ergebnisses — kein Schlüssel fehlt, und
+  der Ersatz ist kein blosser Text.
+  - Test: Ergebnis mit den fünf gemessenen Bash-Schlüsseln (`stdout`, `stderr`, `interrupted`,
+    `isImage`, `noOutputExpected`) hineingeben; die Schlüsselmenge des Ersatzes muss die
+    ursprüngliche vollständig enthalten, und der Ersatz darf kein String sein.
+  - **Warum diese eine AC den Mechanismus nennt:** Gemessen wurde, dass die Plattform einen
+    String oder ein unvollständiges Objekt **stillschweigend verwirft** — ohne Fehler, ohne
+    Hinweis, mit Exit 0. Ein Wächter mit falscher Gestalt sieht in jedem anderen Test wie ein
+    funktionierender aus. Ohne AC-13 wären die ACs 2–6 und 10–12 alle mit einem Wächter grün, der
+    nachweislich nichts bewirkt.
+
+## Bekannte Grenzen
+
+- **`PostToolUse` kann nicht blockieren.** Laut Hook-Vertrag hat das Werkzeug zu diesem
+  Zeitpunkt bereits ausgeführt; eine Sperre (wie bei Scheibe 1) ist hier technisch nicht
+  möglich. Der Wächter kann nur das Ergebnis **vor der Anzeige an Claude** verändern.
+- **Ein falsch geformter Ersatzwert ist lautlos wirkungslos** (siehe Messung im Zuschnitt).
+  Deshalb genügt es NICHT, in einem Test die Ausgabe des Wächters zu prüfen — ein Wächter, der
+  einen String ausgibt, bestünde eine solche Prüfung und täte nichts. **AC-13 bewacht genau
+  das.** Diese Zusicherung nennt bewusst den Mechanismus: sie bildet den gemessenen Vertrag der
+  Plattform ab, ohne den jede Wirkungszusicherung unbeweisbar bliebe.
+- **Kein `.env`-Cache**, wie bei Scheibe 1 — sonst greift der Wächter nach einer Rotation ins
+  Leere.
+- **Wirkt erst ab der nächsten Sitzung.** `.claude/settings.json` wird beim Sitzungsstart
+  eingelesen; eine Änderung während der laufenden Sitzung wird erst beim nächsten Start
+  wirksam.
+- **`.claude/settings.json` ist orchestrator-geschützt.** Die Verdrahtung braucht eine
+  ausdrücklich **getippte** Freigabe des Product Owners (`override`, TTL 1 Stunde) — sie kann
+  nicht ohne PO-Eingriff erfolgen.
+- **Ein Geheimnis als Schlüsselname auf der obersten Ebene erreicht Claude im Klartext**
+  (F001, behoben-mit-Rest 2026-08-08). Schlüssel **unterhalb** der obersten Ebene werden
+  maskiert. Auf der obersten Ebene von `tool_response` wird **bewusst nicht** umbenannt: Fehlt
+  dort ein Originalschlüssel, verwirft die Plattform den **gesamten** Ersatz — dann bliebe auch
+  jeder Wert unmaskiert. Die Wahl lautet also „laute Teillücke statt stiller Totalausfall".
+  Der Wächter meldet diesen Fall auf stderr, mit **maskiertem** Schlüsselnamen.
+  ⚠️ Sonderfall der Meldungsregel: Wenn der Schlüssel *selbst* das Geheimnis ist, wäre „nenne
+  den Schlüsselnamen, nie den Wert" widersprüchlich — deshalb wird auch der Name maskiert
+  dargestellt (`token_***GZ_…***_ende`).
+- **Verschachtelungstiefe: nirgends mehr Rekursion, Obergrenze 9997** (F002/F003/F005, behoben
+  2026-08-08). Traversierung **und** Tiefenkopie laufen iterativ über einen Stapel; die feste
+  Grenze von 25 Ebenen samt ihrer stderr-Meldung ist ersatzlos gefallen, `copy.deepcopy` ist
+  durch `_tiefe_kopie` ersetzt.
+  **Warum das mehr war als eine Randnotiz:** Die frühere Formulierung an dieser Stelle
+  („greift fail-open — Ergebnis unverändert, Exit 0, stumm") klang neutral, bedeutete aber
+  wörtlich, dass der Geheimniswert **im Klartext sichtbar bleibt**. `copy.deepcopy` warf ab
+  Tiefe 498 einen `RecursionError`, den der Notfall-Handler auffing — **bevor** irgendeine
+  Ausgabe entstand. Von außen war das nicht von „geprüft, nichts gefunden" zu unterscheiden,
+  während die Plattform das Ergebnis unverändert weiterreichte. Ein stiller Totalausfall ist
+  der schwerste Fehler, den ein Wächter dieser Art haben kann.
+  **Neue Grenze, gemessen** (2026-08-08, Python 3.12, `recursionlimit` 1000): `json.loads`
+  **und** `json.dumps` schaffen Tiefe **9997**, ab 9998 werfen beide einen `RecursionError` —
+  rund das Zwanzigfache der alten Schranke. Jenseits davon kann nichts mehr *unbemerkt*
+  schiefgehen, und zwar aus drei Gründen: (1) Einlesen und Ausgeben haben **dieselbe** Grenze,
+  (2) die Maskierung erhöht die Tiefe nicht — was durch `json.loads` kam, geht auch durch
+  `json.dumps` — und (3) scheitert das Einlesen doch, **meldet** der Wächter das jetzt auf
+  stderr, statt zu schweigen.
+- **Fail-open heißt nicht mehr lautlos** (F005, 2026-08-08). Bricht die Prüfung mit einer
+  Ausnahme ab, bleibt es bei Exit 0 und unverändertem Ergebnis — aber es entsteht eine
+  stderr-Zeile, dass **nicht zu Ende geprüft** wurde. Präzisierung zu AC-1, kein Widerspruch:
+  AC-1 regelt „geprüft, kein Fund", nicht „konnte nicht prüfen". Die Meldung nennt
+  ausschließlich den Ausnahme-**Typ** (`type(e).__name__`), nie deren Text — eine
+  Fehlermeldung kann Bruchstücke der Nutzlast tragen, und eine kaputte Nutzlast ist der
+  wahrscheinlichste Ort dafür.
+  **Ausgenommen bleibt der Fall „Plugin fehlt":** Das ist ein Dauerzustand, kein Zwischenfall —
+  der Wächter weiß von Anfang an, dass er nicht arbeiten kann, und eine Zeile nach *jedem*
+  Werkzeugaufruf wäre Lärm. Gemeldet wird, wer **unerwartet mitten in der Arbeit** scheitert.
+- ⚠️ **Ein Geheimnis im WERKZEUGNAMEN erscheint im Klartext in den Meldungen des Wächters**
+  (F008, Adversary-Runde 6, **bewusst nicht behoben**). Der Name aus `tool_name` wird
+  ungeprüft in jede Meldung gedruckt — er kommt aus der Nutzlast, nicht aus dem Ergebnis, und
+  läuft deshalb an der Maskierung vorbei. Trägt er einen Geheimniswert, steht dieser
+  ausgeschrieben da, **direkt neben dem Satz „Wert bewusst nicht angezeigt"**. Reproduziert auf
+  beiden Pfaden — Erfolgsfall und Notfall-Handler:
+  `[secret_output_gate] Zugangsdaten im Ergebnis von mcp__dienst_<WERT> maskiert: … (Wert
+  bewusst nicht angezeigt).` Das verletzt AC-9, die schärfste Zusicherung dieses Bauteils.
+  **Warum trotzdem so ausgeliefert:** praktisch nicht auslösbar. `tool_name` ist bei den
+  eingebauten Werkzeugen ein fester Plattform-String (`Bash`, `Read`, `Edit`, …) und bei
+  MCP-Werkzeugen ein statischer Server-Bezeichner; keiner davon trägt jemals einen `.env`-Wert.
+  **Die Behebung ist bekannt und scheitert nicht an der Technik**, sondern ist aus
+  Aufwandsgründen vertagt: ein Modul-Feld `_PAARE` (`None` = Erkennung noch nicht geladen) plus
+  eine Funktion `_werkzeug_sicher()`, die alle Druckstellen benutzen — sie maskiert den Namen,
+  sobald die Erkennung geladen ist, und **hält ihn zurück**, solange sie es nicht ist. Letzteres
+  ist nötig, weil auf dem Notfallpfad gerade das Laden der Erkennung die Fehlerquelle sein kann;
+  ein Maskieren „einmal beim Setzen von `_WERKZEUG`" liefe dort ins Leere. Der Nutzen dieser
+  Form: eine künftige fünfte Druckstelle kann die Maskierung nicht vergessen. Folge-Ticket:
+  **#1617** (enthält Lösungsskizze, Reproduktion beider Pfade und den Grund, warum der
+  naheliegende Ansatz nicht trägt).
+- **Die Schlüssel-REIHENFOLGE ist ein erhaltener Nebeneffekt, keine belegte Anforderung**
+  (F009). Gemessen (neun Läufe) ist ausschließlich die Schlüssel-**Menge**: fehlt dem Ersatz
+  ein Schlüssel des Originals, verwirft die Plattform den gesamten Ersatz stillschweigend. Ob
+  die Reihenfolge zählt, wurde **nie gemessen**. `_tiefe_kopie` erhält sie (sie kostet nichts
+  und ist die naheliegendere Gestalt), und `test_replacement_keeps_the_original_key_order`
+  bewacht sie — aber der Docstring der Funktion führt sie weiterhin als
+  „Plattform-Anforderung", was so nicht belegt ist. Diese Zeile hier ist die maßgebliche
+  Fassung; der Docstring konnte nicht nachgezogen werden (geschützte Datei, keine Freigabe).
+- **Keine Sperre gegen Werte, die nicht über ein Claude-Code-Werkzeugergebnis laufen** (z.B.
+  ein Prozess, der direkt in eine vom Nutzer geöffnete Datei schreibt, ohne dass ein
+  `PostToolUse`-Hook dazwischen sitzt). Das ist außerhalb der Reichweite jedes Hooks dieser
+  Art.
+
+## Nicht in dieser Scheibe
+
+- **Stufe A** (Werte, die zur Laufzeit von der `.env` in eine andere Datei wandern, ohne im
+  Werkzeugaufruf selbst zu stehen) — eigener, nachfolgender Workflow.
+- **Ein Melder für fehlgeschlagene Aufrufe** (`PostToolUseFailure`): Er könnte einen Fund
+  **erkennen und melden** — ersetzen kann er nichts (siehe AC-3). Wert hätte das trotzdem: Man
+  erführe, dass gerade ein Geheimnis ausgetreten ist, und könnte erneuern. Als eigene Scheibe
+  dem PO vorzulegen, nicht hier mitzunehmen.
+- **F008/F009** (Nebenbefunde an Scheibe 1: `cd`-Erkennung ignoriert Heredoc-Inhalte;
+  Testlücke bei kaputten Anführungszeichen) — eigener Workflow.
+- **Die Erneuerung der drei noch kompromittierten Zugangsdaten** (`GZ_SMTP_PASS`,
+  `GZ_TEST_SMTP_PASS`, `GZ_TEST_IMAP_PASS`) — läuft außerhalb dieses Workflows (PO: Resend,
+  `infra`: Stalwart-Postfach), ist kein Code.
+- **Der eigentliche Fix zu #1535** (Test druckt Bot-Zugang bei Fehlschlag) bleibt im Test
+  selbst — Zusicherung auf Schlüsselnamen statt Wert umstellen. Dieser Wächter ist das Netz,
+  nicht der Ersatz dafür.
+- **Eine Plugin-Änderung** an `secret_egress_guard.py` selbst — das Plugin ist auf allen sechs
+  Claude-Instanzen dieses Servers aktiv; ein projektspezifischer Fix gehört nicht dorthin.
+
+## Regel-Budget
+
+Dieser Wächter schließt einen Weg, über den in #1535 nachweislich ein aktiver Zugang
+ausgetreten ist (aktiv ausgenutzte Sicherheitslücke, analog Scheibe 1) — er schaltet sich
+deshalb **nicht** automatisch nach einem Prüfdatum ab. Wirksamkeits-Prüfung
+(Regel-Budget-Ledger): **2026-11-05**.
+
+## Umfang
+
+| Datei | Art | Zeilen (geschätzt) |
+|---|---|---|
+| `.claude/hooks/secret_output_gate.py` | ANLEGEN | ~150–200 |
+| `tests/unit/test_secret_output_gate.py` | ANLEGEN | ~150 |
+| `.claude/settings.json` | ÄNDERN | ~8 |
+
+**`.claude/hooks/` und `.claude/settings.json` sind geschützt** — das Anlegen des Wächters und
+die Verdrahtung brauchen die getippte PO-Freigabe (`override`, TTL 1 Stunde), gebunden an den
+aktiven Workflow `fix-1537-s2-laufzeit-lecks`.
+
+Risiko **HOCH** (Analyse A4): der Wächter läuft nach jedem Werkzeugaufruf in jeder Sitzung.
+Ein Fehler verfälscht nicht ein Feature, sondern potenziell jedes Werkzeug-Ergebnis. AC-1
+(stumm im Normalfall) und AC-8 (fail-open) sind deshalb nicht verhandelbar.
+
+Vor der eigentlichen Umsetzung steht ein Wegwerf-Experiment (Marker-String statt echtem
+Geheimnis, eigenes Scratchpad-Projekt), das klärt, ob `updatedToolOutput` in dieser
+Claude-Code-Fassung überhaupt trägt — ohne diesen Nachweis wäre die Implementierung auf einer
+Vermutung gebaut.
+
+## Implementation Details
+
+- **Erkennung wiederverwenden:** `collect_secrets`, `_is_secret_key`, `_is_secret_value` aus
+  `core/hooks/secret_egress_guard.py` des Plugins `agent-os-openspec` per `importlib` laden —
+  derselbe Ladeweg wie in `.claude/hooks/hook_utils.py` (dort für `hook_utils.py` des Plugins),
+  nur mit anderem Zieldateipfad. Zwei getrennte `try`-Blöcke (Vorbild
+  `secret_in_repo_gate.py:96-123`): fehlt das Modul komplett → fail-open mit Meldung; fehlt nur
+  eine der privaten Funktionen (ältere Plugin-Fassung) → ebenfalls fail-open, nicht abstürzen.
+- **Verdrahtung:** neue `PostToolUse`-Gruppe in `.claude/settings.json`, geschützte Form
+  `if [ -f "${CLAUDE_PROJECT_DIR}/.claude/hooks/secret_output_gate.py" ]; then python3
+  "${CLAUDE_PROJECT_DIR}/.claude/hooks/secret_output_gate.py"; fi` (Vorbild: jede bestehende
+  Gruppe, kein `&&`/`|| exit 0`). Da Stufe B **alle** Werkzeuge treffen soll (Zuschnitt), ist
+  in der Implementierung zu bestätigen, mit welcher `matcher`-Angabe eine `PostToolUse`-Gruppe
+  tatsächlich jedes Werkzeug abdeckt (die einzige bestehende Gruppe im Projekt,
+  `auto_restart_server.py`, ist bewusst auf `Bash` eingeschränkt und damit kein direktes
+  Vorbild für „alle Werkzeuge"). **Geklärt 2026-08-07:** Laut Matcher-Tabelle treffen `"*"`,
+  `""` und das Weglassen des Feldes gleichermaßen alle Werkzeuge. Gewählt wird `"matcher": "*"`
+  — explizit, weil `test_issue_384_hook_fail_open.py:181` je Gruppe ausschließlich die Schlüssel
+  `matcher` und `hooks` zulässt und eine ausgeschriebene Angabe im Bestand lesbarer ist.
+- **Fehlgeschlagene Werkzeugaufrufe sind nicht erreichbar** (siehe AC-3). Eine Verdrahtung auf
+  `PostToolUseFailure` würde den Wächter zwar aufrufen, könnte das Ergebnis aber nicht ersetzen.
+- **Ausgabeform:** `{"hookSpecificOutput": {"hookEventName": "PostToolUse",
+  "updatedToolOutput": <maskiertes Ergebnis>}}` — Struktur (String vs. Beibehaltung der
+  ursprünglichen dict-Form) wird im Vorab-Experiment geklärt, bevor der Wächter final gebaut
+  wird.
+- **Zeitbudget klein** (Vorbild Plugin-Egress-Wächter: 5 s), damit kein Werkzeugaufruf spürbar
+  gebremst wird.
+- **Kein Werkzeugname-Filter** — Umsetzung des Zuschnitts „alle Werkzeuge, kein Ausschluss".
+
+## Test Plan
+
+Kern-Schicht, deterministisch, Vorbild `tests/unit/test_secret_in_repo_gate.py`: der Wächter
+läuft als **echter Subprozess** mit stdin-JSON (`tool_name`, `tool_input`, `tool_response`),
+gegen eine **synthetische** `.env` in `tmp_path` (nie die echte Projekt-`.env`) — kein Mock,
+kein `patch()`. Prüflingspfad per `GZ_SECRET_GATE_PATH`-Umgebungsvariable austauschbar (analog
+`GZ_SECRET_GATE_PATH` aus Scheibe 1), damit die spätere Mutations-Gegenprobe auf einer Kopie im
+Scratchpad läuft und `.claude/**` unangetastet bleibt. Eine Plugin-Sonde am Modulkopf
+überspringt die Suite sauber (`pytest.skip`), falls das Plugin nicht installiert ist, statt
+strukturell rot zu werden.
+
+Geplante Tests (mindestens einer je AC, mehrere ACs brauchen eine Gegenprobe):
+
+1. `test_gate_silent_when_no_secret_found` (AC-1)
+2. `test_gate_masks_secret_in_bash_success_stdout` (AC-2)
+3. `test_gate_masks_secret_in_bash_failure_string_result` (AC-3)
+4. `test_gate_masks_secret_in_read_nested_file_content` (AC-4)
+5. `test_gate_masks_secret_in_write_content` (AC-5)
+6. `test_gate_masks_secret_in_edit_old_string` (AC-6)
+7. `test_gate_masks_secret_in_edit_new_string` (AC-6)
+8. `test_gate_masks_secret_in_edit_original_file` (AC-6)
+9. `test_gate_ignores_short_values` (AC-7)
+10. `test_gate_ignores_known_placeholder_values` (AC-7)
+11. `test_gate_fail_open_when_plugin_missing` (AC-8)
+12. `test_gate_fail_open_on_malformed_stdin_json` (AC-8)
+13. `test_gate_fail_open_on_unexpected_tool_response_type` (AC-8)
+14. `test_masking_message_never_contains_the_secret_value` (AC-9)
+15. `test_gate_masks_regardless_of_tool_name` (AC-10)
+16. `test_gate_preserves_surrounding_text_and_other_fields` (AC-11)
+17. `test_gate_masks_every_occurrence_and_multiple_secrets` (AC-12)
+18. `test_replacement_keeps_every_original_key_and_is_not_a_string` (AC-13)
+
+Geplant: **18 Verhaltenstests** in `tests/unit/test_secret_output_gate.py`.
+
+**Pflicht-Mutationen für die Gegenprobe** (der Adversary muss belegen, dass jede davon
+mindestens einen Test rot macht — bleibt eine grün, ist das ein Befund):
+
+| Mutation | erwartet rot |
+|---|---|
+| Maskierung ganz entfernen (Ergebnis unverändert durchreichen) | 2–6, 10–12 |
+| nur das erste Vorkommen ersetzen | 17 |
+| gesamtes Ergebnis durch Platzhalter ersetzen statt nur den Wert | 16 |
+| nur `stdout` betrachten (verschachtelte und String-Formen ignorieren) | 3, 4, 5, 6 |
+| Schlüsselname durch den **Wert** in der Ersatzform tauschen | 14 |
+| fail-open → fail-closed (Störung blockiert) | 11, 12, 13 |
+| Ausgabe auch ohne Fund erzeugen | 1 |
+| Ersatz als **String** statt als Objekt zurückgeben | 18 |
+| beim Ersatz einen Originalschlüssel weglassen | 18 |
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Der Wächter setzt eine bereits bestehende, im Plugin dokumentierte
+  Geheimnis-Definition mechanisch auf einen bisher ungeschützten Weg (Werkzeug-Ausgaben) an —
+  er trifft keine neue Architekturentscheidung und führt keinen neuen Geheimnis-Begriff ein
+  (siehe „Zuschnitt").
+
+## Changelog
+
+- 2026-08-07: Initial spec created
+- 2026-08-08: F003 behoben — Tiefengrenze (`_MAX_TIEFE = 25`) samt ihrer stderr-Meldung
+  ersatzlos entfernt, Traversierung iterativ. AC-1 (stumm im Normalfall) gilt damit auch für
+  tief verschachtelte harmlose Ergebnisse; der blinde Fleck aus F002 entfällt ganz.
+- 2026-08-08: F005/F006/F007 behoben. `copy.deepcopy` durch die iterative `_tiefe_kopie`
+  ersetzt (Obergrenze 497 → **9997**, Schlüsselreihenfolge erhalten); der Notfall-Handler
+  meldet einen Abbruch jetzt auf stderr (nur Ausnahme-Typ), statt lautlos ein ungeprüftes
+  Ergebnis durchzulassen; zwei Testlücken geschlossen (Geheimnis als reiner Listeneintrag,
+  echter Auslöser für den äußeren Notfall-Pfad). 23 → 27 Tests.
+- 2026-08-08: Adversary-Runde 6. **F008 bewusst nicht behoben** und als bekannte Grenze
+  dokumentiert (Geheimnis im Werkzeugnamen erscheint im Klartext in den Meldungen; praktisch
+  nicht auslösbar, Behebung bekannt und vertagt). **F009** geklärt: die Schlüsselreihenfolge
+  ist ein erhaltener Nebeneffekt ohne belegte Plattform-Anforderung — gemessen ist nur die
+  Schlüsselmenge; neuer Test `test_replacement_keeps_the_original_key_order` hält sie fest.
+  28 → 29 Tests. Der Wächter selbst bleibt unverändert (`4fc65709…`).

--- a/tests/unit/test_secret_output_gate.py
+++ b/tests/unit/test_secret_output_gate.py
@@ -1,0 +1,839 @@
+"""Verhaltensnachweis fuer den Ausgabe-Waechter „Secret-Output-Sperre" (Stufe B).
+
+Ein `PostToolUse`-Waechter durchsucht das ERGEBNIS jedes Werkzeugaufrufs nach dem
+ausgeschriebenen Wert eines Geheimnisses aus der lokalen `.env` und ersetzt jeden Treffer
+durch `***<SCHLUESSELNAME>***`, bevor Claude das Ergebnis sieht. Kein Fund heisst: Ergebnis
+unveraendert und keinerlei Ausgabe. Jede eigene Stoerung heisst: Ergebnis unveraendert,
+Exit 0 (durchgehend fail-open — der Waechter laeuft nach JEDEM Werkzeugaufruf in JEDER
+Sitzung, ein Irrtum darf nie ein Ergebnis zerstoeren).
+
+Kern-Schicht, deterministisch: jeder Fall baut ein eigenes Wegwerf-Projekt mit einer
+SYNTHETISCHEN `.env` in `tmp_path` (nie die echte Projekt-`.env`) und ruft den Waechter als
+echten Unterprozess mit stdin-JSON auf — kein Mock, kein patch(), kein Netz. `HOME` und
+`CLAUDE_PROJECT_DIR` werden dabei bewusst auf Wegwerf-Pfade gezogen, damit die Suite unter
+keinen Umstaenden gegen echte Zugangsdaten laeuft.
+
+Pfadregel #1409: Der Pruefling wird relativ zu DIESER Datei aufgeloest, damit der Test aus
+einem Worktree den Worktree-Stand prueft und nicht die Hauptrepo-Kopie.
+"""
+from __future__ import annotations
+
+import importlib.util as _gz_ilu
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+HOOKS = REPO / ".claude" / "hooks"
+# Ueberschreibbar fuer die Mutations-Gegenprobe: der Adversary mutiert eine EXTERNE Kopie im
+# Scratchpad statt der geschuetzten Originaldatei — dafuer muss der Pruefling-Pfad umstellbar
+# sein (Muster GZ_SECRET_GATE_PATH aus Scheibe 1). Ohne die Variable unveraendertes Verhalten.
+GATE = Path(os.environ["GZ_SECRET_OUTPUT_GATE_PATH"]) \
+    if os.environ.get("GZ_SECRET_OUTPUT_GATE_PATH") else HOOKS / "secret_output_gate.py"
+
+# ------------------------------------------------------------------- Plugin-Sonde
+# Der Waechter leiht sich die Geheimnis-Erkennung (collect_secrets, _is_secret_key,
+# _is_secret_value) aus `core/hooks/secret_egress_guard.py` des Plugins agent-os-openspec.
+# Ohne Plugin geht er fail-open — die Masking-Tests waeren dann strukturell rot. Sauber
+# ueberspringen statt rot; auf dem Server (Plugin vorhanden) laeuft die Suite vollstaendig.
+try:
+    _gz_spec = _gz_ilu.spec_from_file_location("_gz_hook_utils_probe", HOOKS / "hook_utils.py")
+    _gz_mod = _gz_ilu.module_from_spec(_gz_spec)
+    _gz_spec.loader.exec_module(_gz_mod)
+except ImportError as _gz_exc:
+    pytest.skip(
+        f"agent-os-openspec-Plugin fehlt ({_gz_exc}) — Hook-Suite braucht die "
+        "installierten Server-Hooks (#1196)",
+        allow_module_level=True,
+    )
+
+
+def _plugin_wurzel() -> Path | None:
+    """Installationspfad des Plugins (gleicher Weg wie der Shim: die Registry)."""
+    try:
+        with open(os.path.expanduser("~/.claude/plugins/installed_plugins.json")) as fh:
+            daten = json.load(fh)
+        for schluessel, eintraege in daten.get("plugins", {}).items():
+            if schluessel.startswith("agent-os-openspec@"):
+                eintrag = next((e for e in eintraege if e.get("scope") == "user"), eintraege[0])
+                return Path(eintrag.get("installPath", ""))
+    except Exception:
+        return None
+    return None
+
+
+_gz_wurzel = _plugin_wurzel()
+if _gz_wurzel is None or not (_gz_wurzel / "core" / "hooks" / "secret_egress_guard.py").is_file():
+    pytest.skip(
+        "Plugin-Modul secret_egress_guard.py nicht auffindbar — der Waechter geht dann "
+        "fail-open, die Masking-Faelle waeren strukturell rot",
+        allow_module_level=True,
+    )
+
+# ------------------------------------------------------- synthetische Geheimnisse
+# Frei erfunden, bewusst NICHT aus der echten Projekt-.env. Schluessel-Endung passt zur
+# Erkennung, Wert lang genug (>= 8) und kein Platzhalter.
+SCHLUESSEL = "GZ_FAKE_TEST_PASS"
+WERT = "Zk8mQr2vLp9wXt4nBs6y"
+ZWEITER_SCHLUESSEL = "GZ_FAKE_OTHER_TOKEN"
+ZWEITER_WERT = "Hd3jWn7cVq1zRy5tKm8p"
+KURZER_SCHLUESSEL = "GZ_FAKE_SHORT_KEY"
+KURZER_WERT = "ab12cd"          # < 8 Zeichen -> nie ein Geheimnis
+PLATZHALTER_SCHLUESSEL = "GZ_FAKE_DEMO_SECRET"
+PLATZHALTER_WERT = "changeme"   # vom Platzhalter-Filter des Plugins erfasst
+
+ERSATZ = f"***{SCHLUESSEL}***"
+ZWEITER_ERSATZ = f"***{ZWEITER_SCHLUESSEL}***"
+
+
+def _env_text() -> str:
+    return (
+        f"{SCHLUESSEL}={WERT}\n"
+        f"{ZWEITER_SCHLUESSEL}={ZWEITER_WERT}\n"
+        f"{KURZER_SCHLUESSEL}={KURZER_WERT}\n"
+        f"{PLATZHALTER_SCHLUESSEL}={PLATZHALTER_WERT}\n"
+    )
+
+
+def _projekt(tmp_path: Path, mit_env: bool = True, zusatz_env: str = "") -> Path:
+    ordner = tmp_path / "projekt"
+    ordner.mkdir(exist_ok=True)
+    if mit_env:
+        (ordner / ".env").write_text(_env_text() + zusatz_env)
+    return ordner
+
+
+def _hook(tmp_path: Path, tool_name: str = "Bash", tool_response=None,
+          tool_input: dict | None = None, roh_stdin: str | None = None,
+          ohne_plugin: bool = False, zusatz_env: str = "") -> subprocess.CompletedProcess:
+    """Ruft den Waechter wie die Hook-Schicht auf: stdin-JSON, cwd = Wegwerf-Projekt."""
+    ordner = _projekt(tmp_path, zusatz_env=zusatz_env)
+    eingabe = roh_stdin if roh_stdin is not None else json.dumps({
+        "session_id": "wegwerf",
+        "tool_name": tool_name,
+        "tool_input": tool_input if tool_input is not None else {"command": "echo hallo"},
+        "tool_response": tool_response,
+    })
+    env = dict(os.environ)
+    # Der Waechter loest die .env ueber CLAUDE_PROJECT_DIR bzw. cwd auf — beide zeigen auf
+    # das Wegwerf-Projekt, damit die echte Projekt-.env garantiert nie gelesen wird.
+    env["CLAUDE_PROJECT_DIR"] = str(ordner)
+    env.pop("CLAUDE_TOOL_INPUT", None)
+    env.pop("CLAUDE_TOOL_NAME", None)
+    if ohne_plugin:
+        # Kein Mock: ein leeres HOME laesst die Plugin-Registry ins Leere laufen, der
+        # importlib-Ladeweg scheitert echt.
+        leeres_home = tmp_path / "leeres_home"
+        leeres_home.mkdir(exist_ok=True)
+        env["HOME"] = str(leeres_home)
+    return subprocess.run(
+        [sys.executable, str(GATE)], input=eingabe, cwd=str(ordner),
+        capture_output=True, text=True, timeout=30, env=env,
+    )
+
+
+def _als_text(wert) -> str:
+    return wert if isinstance(wert, str) else json.dumps(wert, ensure_ascii=False)
+
+
+def _wirksames_ergebnis(r: subprocess.CompletedProcess, urspruenglich) -> str:
+    """Das Ergebnis, das Claude NACH dem Waechter sieht — als Text.
+
+    Die Ausgabeform steht in der RED-Phase noch nicht endgueltig fest (String vs.
+    Originalstruktur unter `updatedToolOutput`; wird im Vorab-Experiment der
+    Implementierungsphase geklaert). Dieser Leser ist deshalb bewusst tolerant und DARF
+    in der Implementierungsphase nachgezogen werden — keine einzige Zusicherung der Tests
+    aendert sich dadurch, weil hier nur "was sieht Claude am Ende" bestimmt wird.
+    """
+    roh = r.stdout.strip()
+    if not roh:
+        return _als_text(urspruenglich)   # keine Ausgabe = Ergebnis unveraendert
+    try:
+        daten = json.loads(roh)
+    except json.JSONDecodeError:
+        return roh
+    if isinstance(daten, dict):
+        hso = daten.get("hookSpecificOutput")
+        if isinstance(hso, dict) and "updatedToolOutput" in hso:
+            return _als_text(hso["updatedToolOutput"])
+        for schluessel in ("updatedToolOutput", "tool_response", "toolOutput"):
+            if schluessel in daten:
+                return _als_text(daten[schluessel])
+    return roh
+
+
+def _gesamtausgabe(r: subprocess.CompletedProcess) -> str:
+    return r.stdout + r.stderr
+
+
+def _bash_erfolg(stdout: str) -> dict:
+    """Gemessene Gestalt eines erfolgreichen Bash-Ergebnisses (33.681 Faelle)."""
+    return {"stdout": stdout, "stderr": "", "interrupted": False,
+            "isImage": False, "noOutputExpected": False}
+
+
+# ------------------------------------------------------------------------ Faelle
+
+
+def test_gate_silent_when_no_secret_found(tmp_path):
+    """(AC-1) Kein Fund -> Ergebnis unveraendert und KEINERLEI Ausgabe."""
+    antwort = _bash_erfolg("alles ganz normal, kein Geheimnis weit und breit\n")
+    r = _hook(tmp_path, "Bash", antwort)
+    assert r.returncode == 0, f"Ohne Fund darf nie etwas anderes als Exit 0 kommen: {_gesamtausgabe(r)}"
+    assert r.stdout == "", f"Ohne Fund darf es keinerlei stdout geben, bekam: {r.stdout!r}"
+    assert r.stderr == "", f"Ohne Fund darf es keinerlei stderr geben, bekam: {r.stderr!r}"
+
+
+def test_gate_masks_secret_in_bash_success_stdout(tmp_path):
+    """(AC-2) Geheimnis im stdout eines erfolgreichen Bash-Ergebnisses -> maskiert."""
+    antwort = _bash_erfolg(f"SMTP-Login: {WERT}\n")
+    r = _hook(tmp_path, "Bash", antwort)
+    wirksam = _wirksames_ergebnis(r, antwort)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {_gesamtausgabe(r)}"
+    assert WERT not in wirksam, f"Geheimniswert steht weiterhin im Klartext im Ergebnis: {wirksam!r}"
+    assert ERSATZ in wirksam, f"Ersatzform {ERSATZ} fehlt im Ergebnis: {wirksam!r}"
+
+
+def test_gate_masks_secret_in_bash_failure_string_result(tmp_path):
+    """(AC-3) Fehlschlag-Ergebnis kommt als REINER STRING zurueck (2.576 gemessene Faelle)."""
+    antwort = f"Error: Exit code 1\nauth failed with password {WERT}\n"
+    r = _hook(tmp_path, "Bash", antwort)
+    wirksam = _wirksames_ergebnis(r, antwort)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {_gesamtausgabe(r)}"
+    assert WERT not in wirksam, f"String-Form (Fehlschlag) wurde nicht maskiert: {wirksam!r}"
+    assert ERSATZ in wirksam, f"Ersatzform {ERSATZ} fehlt: {wirksam!r}"
+    assert "Error: Exit code 1" in wirksam, f"Fehlertext ging verloren: {wirksam!r}"
+
+
+def test_gate_masks_secret_in_read_nested_file_content(tmp_path):
+    """(AC-4) Read: Inhalt liegt VERSCHACHTELT unter `file.content` — der wahrscheinlichste
+    Austrittsweg ueberhaupt (jede Datei, die ein Geheimnis im Klartext traegt)."""
+    antwort = {"type": "text", "file": {
+        "filePath": "/wegwerf/altes_skript.sh",
+        "content": f"#!/bin/sh\nexport SMTP_PASS={WERT}\n",
+        "numLines": 2, "startLine": 1, "totalLines": 2}}
+    r = _hook(tmp_path, "Read", antwort, tool_input={"file_path": "/wegwerf/altes_skript.sh"})
+    wirksam = _wirksames_ergebnis(r, antwort)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {_gesamtausgabe(r)}"
+    assert WERT not in wirksam, f"Verschachtelter Read-Inhalt wurde nicht maskiert: {wirksam!r}"
+    assert ERSATZ in wirksam, f"Ersatzform {ERSATZ} fehlt: {wirksam!r}"
+
+
+def test_gate_masks_secret_in_write_content(tmp_path):
+    """(AC-5) Write: Inhalt liegt auf OBERSTER Ebene unter `content`."""
+    antwort = {"type": "create", "filePath": "/wegwerf/neu.txt",
+               "content": f"passwort = {WERT}\n", "structuredPatch": []}
+    r = _hook(tmp_path, "Write", antwort,
+              tool_input={"file_path": "/wegwerf/neu.txt", "content": "..."})
+    wirksam = _wirksames_ergebnis(r, antwort)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {_gesamtausgabe(r)}"
+    assert WERT not in wirksam, f"Write-content wurde nicht maskiert: {wirksam!r}"
+    assert ERSATZ in wirksam, f"Ersatzform {ERSATZ} fehlt: {wirksam!r}"
+
+
+def _edit_antwort(feld: str) -> dict:
+    """Gemessene Edit-Gestalt: oldString/newString/originalFile, KEIN stdout/content."""
+    antwort = {"filePath": "/wegwerf/datei.py", "oldString": "alt", "newString": "neu",
+               "originalFile": "unveraenderter Rest\n", "structuredPatch": [],
+               "userModified": False, "replaceAll": False}
+    antwort[feld] = f"zeile davor\n{WERT}\nzeile danach\n"
+    return antwort
+
+
+def test_gate_masks_secret_in_edit_old_string(tmp_path):
+    """(AC-6) Geheimnis in `oldString` — einzeln geprueft, damit kein Feld durchrutscht."""
+    antwort = _edit_antwort("oldString")
+    r = _hook(tmp_path, "Edit", antwort)
+    wirksam = _wirksames_ergebnis(r, antwort)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {_gesamtausgabe(r)}"
+    assert WERT not in wirksam, f"Edit.oldString wurde nicht maskiert: {wirksam!r}"
+    assert ERSATZ in wirksam, f"Ersatzform {ERSATZ} fehlt: {wirksam!r}"
+
+
+def test_gate_masks_secret_in_edit_new_string(tmp_path):
+    """(AC-6) Geheimnis in `newString`."""
+    antwort = _edit_antwort("newString")
+    r = _hook(tmp_path, "Edit", antwort)
+    wirksam = _wirksames_ergebnis(r, antwort)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {_gesamtausgabe(r)}"
+    assert WERT not in wirksam, f"Edit.newString wurde nicht maskiert: {wirksam!r}"
+    assert ERSATZ in wirksam, f"Ersatzform {ERSATZ} fehlt: {wirksam!r}"
+
+
+def test_gate_masks_secret_in_edit_original_file(tmp_path):
+    """(AC-6) Geheimnis in `originalFile` — traegt den GESAMTEN Dateiinhalt vor der
+    Aenderung und ist damit der ergiebigste der drei Edit-Wege."""
+    antwort = _edit_antwort("originalFile")
+    r = _hook(tmp_path, "Edit", antwort)
+    wirksam = _wirksames_ergebnis(r, antwort)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {_gesamtausgabe(r)}"
+    assert WERT not in wirksam, f"Edit.originalFile wurde nicht maskiert: {wirksam!r}"
+    assert ERSATZ in wirksam, f"Ersatzform {ERSATZ} fehlt: {wirksam!r}"
+
+
+def test_gate_ignores_short_values(tmp_path):
+    """(AC-7) Ein zu kurzer .env-Wert ist KEIN Geheimnis — sonst traefe der Waechter
+    staendig harmlosen Text."""
+    antwort = _bash_erfolg(f"kurzwert={KURZER_WERT} — voellig harmlos\n")
+    r = _hook(tmp_path, "Bash", antwort)
+    assert r.returncode == 0, f"Kurzer Wert haette nichts ausloesen duerfen: {_gesamtausgabe(r)}"
+    assert r.stdout == "" and r.stderr == "", (
+        f"Kurzer Wert hat eine Maskierung/Meldung ausgeloest: {_gesamtausgabe(r)!r}"
+    )
+
+
+def test_gate_ignores_known_placeholder_values(tmp_path):
+    """(AC-7) Bekannter Platzhalterwert (`changeme`) ist KEIN Geheimnis."""
+    antwort = _bash_erfolg(f"password={PLATZHALTER_WERT} (Beispielkonfiguration)\n")
+    r = _hook(tmp_path, "Bash", antwort)
+    assert r.returncode == 0, f"Platzhalter haette nichts ausloesen duerfen: {_gesamtausgabe(r)}"
+    assert r.stdout == "" and r.stderr == "", (
+        f"Platzhalterwert hat eine Maskierung/Meldung ausgeloest: {_gesamtausgabe(r)!r}"
+    )
+
+
+def test_gate_fail_open_when_plugin_missing(tmp_path):
+    """(AC-8) Plugin nicht ladbar -> Ergebnis unveraendert durchgereicht, Exit 0.
+
+    Der Waechter laeuft nach JEDEM Werkzeugaufruf: eine eigene Stoerung darf niemals ein
+    Ergebnis zerstoeren oder eine Sitzung blockieren.
+    """
+    antwort = _bash_erfolg(f"SMTP-Login: {WERT}\n")
+    r = _hook(tmp_path, "Bash", antwort, ohne_plugin=True)
+    wirksam = _wirksames_ergebnis(r, antwort)
+    assert r.returncode == 0, f"Eigene Stoerung haette nie blockieren duerfen: {_gesamtausgabe(r)}"
+    assert "Traceback" not in r.stderr, f"Der Waechter ist abgestuerzt: {r.stderr}"
+    assert WERT in wirksam, (
+        "Ohne Erkennung muss das Ergebnis UNVERAENDERT durchgereicht werden — "
+        f"der Waechter hat es angetastet: {wirksam!r}"
+    )
+    assert ERSATZ not in wirksam, f"Ohne Plugin kann es keine echte Maskierung geben: {wirksam!r}"
+
+
+def test_gate_fail_open_on_malformed_stdin_json(tmp_path):
+    """(AC-8) Kaputtes JSON auf stdin -> Exit 0, kein veraendertes Ergebnis, kein Absturz.
+
+    Seit F005 gehoert dazu die zweite Haelfte: fail-open heisst nicht mehr lautlos. Eine
+    unlesbare Nutzlast bedeutet NICHT geprueft — und ungeprueft durchgereicht sieht sonst
+    genauso aus wie geprueft und sauber. Der Wert im Kaputt-Text ist bewusst ein echtes
+    Geheimnis: eine kaputte Nutzlast ist der wahrscheinlichste Ort, an dem ein Geheimnis in
+    einen Fehlertext geraet, und der Waechter darf ihn deshalb nie mit ausgeben.
+    """
+    r = _hook(tmp_path, roh_stdin=f'{{ "tool_name": "Bash", {WERT} kein JSON')
+    assert r.returncode == 0, f"Kaputtes stdin haette nie blockieren duerfen: {_gesamtausgabe(r)}"
+    assert "Traceback" not in r.stderr, f"Der Waechter ist abgestuerzt: {r.stderr}"
+    assert "updatedToolOutput" not in r.stdout, (
+        f"Ohne lesbare Nutzlast darf kein Ersatz-Ergebnis erzeugt werden: {r.stdout!r}"
+    )
+    assert r.stderr.strip() != "", (
+        "Eine unlesbare Nutzlast wurde NICHT geprueft — das darf nicht lautlos aussehen wie "
+        "'geprueft, nichts gefunden'"
+    )
+    assert WERT not in _gesamtausgabe(r), (
+        "Der Waechter hat den Geheimniswert aus der kaputten Nutzlast in seine eigene "
+        f"Meldung geschrieben: {_gesamtausgabe(r)!r}"
+    )
+
+
+def test_gate_fail_open_on_unexpected_tool_response_type(tmp_path):
+    """(AC-8) `tool_response` von unerwartetem Typ (null, Zahl, Liste) -> Exit 0, kein Absturz."""
+    for antwort in (None, 42, [1, 2, 3], True):
+        r = _hook(tmp_path, "Bash", antwort)
+        assert r.returncode == 0, (
+            f"tool_response={antwort!r} haette nie blockieren duerfen: {_gesamtausgabe(r)}"
+        )
+        assert "Traceback" not in r.stderr, (
+            f"tool_response={antwort!r} hat den Waechter abstuerzen lassen: {r.stderr}"
+        )
+
+
+def test_masking_message_never_contains_the_secret_value(tmp_path):
+    """(AC-9) Wichtigste Einzelzusicherung: in KEINER Ausgabe des Waechters (stdout wie
+    stderr) darf der rohe Wert auftauchen — nur der Schluesselname."""
+    antwort = _bash_erfolg(f"login ok mit {WERT}\n")
+    r = _hook(tmp_path, "Bash", antwort)
+    gesamt = _gesamtausgabe(r)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {gesamt}"
+    assert gesamt.strip() != "", "Ein echter Fund muss ueberhaupt eine Wirkung erzeugen"
+    assert WERT not in gesamt, (
+        "Der Geheimniswert selbst ist in der Ausgabe des Waechters aufgetaucht — das ist "
+        f"die wichtigste verbotene Wirkung dieses Gates: {gesamt!r}"
+    )
+    assert SCHLUESSEL in gesamt, f"Der Schluesselname fehlt in der Ausgabe: {gesamt!r}"
+
+
+def test_gate_masks_regardless_of_tool_name(tmp_path):
+    """(AC-10) Es gibt keine Positivliste: auch ein unbekanntes (MCP-)Werkzeug wird maskiert."""
+    antwort = {"result": f"Antwort des Dienstes: token={WERT}", "status": "ok"}
+    r = _hook(tmp_path, "AnyMcpTool", antwort, tool_input={"frage": "irgendwas"})
+    wirksam = _wirksames_ergebnis(r, antwort)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {_gesamtausgabe(r)}"
+    assert WERT not in wirksam, f"Unbekanntes Werkzeug wurde ausgenommen: {wirksam!r}"
+    assert ERSATZ in wirksam, f"Ersatzform {ERSATZ} fehlt: {wirksam!r}"
+
+
+def test_gate_preserves_surrounding_text_and_other_fields(tmp_path):
+    """(AC-11) Ausschliesslich der Wert wird ersetzt — alles andere kommt unversehrt an.
+
+    Der einzige Test, der eine Umsetzung faengt, die das GESAMTE Ergebnis durch einen
+    Platzhalter ersetzt: der Wert waere dann weg (ACs 2-6 gruen), aber auch jede nutzbare
+    Ausgabe. Deshalb wird hier POSITIV geprueft: Text davor, Text danach und die uebrigen
+    Felder muessen vorhanden sein.
+    """
+    davor = "zeile-davor-marker-4711: Verbindung wird aufgebaut"
+    danach = "zeile-danach-marker-4712: Verbindung geschlossen"
+    stderr_marker = "hinweis-marker-4713: nur ein Warnhinweis"
+    antwort = {"stdout": f"{davor}\npass={WERT}\n{danach}\n", "stderr": stderr_marker,
+               "interrupted": False, "isImage": False}
+    r = _hook(tmp_path, "Bash", antwort)
+    wirksam = _wirksames_ergebnis(r, antwort)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {_gesamtausgabe(r)}"
+    assert WERT not in wirksam, f"Wert nicht maskiert: {wirksam!r}"
+    assert ERSATZ in wirksam, f"Ersatzform {ERSATZ} fehlt: {wirksam!r}"
+    assert davor in wirksam, f"Text VOR dem Wert ging verloren: {wirksam!r}"
+    assert danach in wirksam, f"Text NACH dem Wert ging verloren: {wirksam!r}"
+    assert stderr_marker in wirksam, f"Feld `stderr` ging verloren: {wirksam!r}"
+    assert "interrupted" in wirksam, f"Feld `interrupted` ging verloren: {wirksam!r}"
+
+
+def test_gate_masks_every_occurrence_and_multiple_secrets(tmp_path):
+    """(AC-12) Derselbe Wert an DREI Stellen plus ein ZWEITES Geheimnis an einer vierten —
+    kein einziges Vorkommen darf uebrig bleiben (faengt "nur der erste Treffer")."""
+    antwort = {
+        "stdout": f"erster: {WERT}\nzweiter: {WERT}\n",
+        "stderr": f"dritter: {WERT}\n",
+        "interrupted": False,
+        "details": {"weiteres_geheimnis": f"vierter: {ZWEITER_WERT}"},
+    }
+    r = _hook(tmp_path, "Bash", antwort)
+    wirksam = _wirksames_ergebnis(r, antwort)
+    gesamt = _gesamtausgabe(r)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {gesamt}"
+    assert WERT not in wirksam, f"Nicht jedes Vorkommen wurde ersetzt: {wirksam!r}"
+    assert ZWEITER_WERT not in wirksam, f"Das zweite Geheimnis blieb im Klartext: {wirksam!r}"
+    assert wirksam.count(ERSATZ) >= 3, (
+        f"Erwartet 3 Ersetzungen von {SCHLUESSEL}, gefunden {wirksam.count(ERSATZ)}: {wirksam!r}"
+    )
+    assert ZWEITER_ERSATZ in wirksam, f"Ersatzform {ZWEITER_ERSATZ} fehlt: {wirksam!r}"
+    assert WERT not in gesamt and ZWEITER_WERT not in gesamt, (
+        f"Ein Geheimniswert steht in der Gesamtausgabe des Waechters: {gesamt!r}"
+    )
+
+
+def test_replacement_keeps_every_original_key_and_is_not_a_string(tmp_path):
+    """(AC-13) Der Ersatz hat die Gestalt, die die Plattform tatsaechlich annimmt.
+
+    Gemessen (2026-08-07, neun Laeufe einer eigenstaendigen Sitzung mit Zufallsmarker):
+    ein String oder ein unvollstaendiges Objekt als `updatedToolOutput` wird von der
+    Plattform STILLSCHWEIGEND VERWORFEN — kein Fehler, kein Hinweis, Hook-Exit 0, auch
+    unter `--debug hooks` keine Diagnosezeile. Ein Waechter mit falscher Gestalt ist von
+    einem funktionierenden nicht unterscheidbar und waere in JEDEM anderen Test hier
+    gruen, waehrend er nachweislich nichts bewirkt.
+
+    Deshalb wird hier nicht der Inhalt geprueft (das tun die ACs 2-6, 10-12), sondern die
+    GESTALT: der Ersatz traegt jeden Schluessel des urspruenglichen Ergebnisses und ist
+    kein blosser Text.
+    """
+    antwort = _bash_erfolg(f"login ok mit {WERT}\n")   # die fuenf gemessenen Bash-Schluessel
+    r = _hook(tmp_path, "Bash", antwort)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {_gesamtausgabe(r)}"
+    roh = r.stdout.strip()
+    assert roh != "", "Ein echter Fund muss ueberhaupt einen Ersatz erzeugen"
+
+    daten = json.loads(roh)
+    hso = daten.get("hookSpecificOutput")
+    assert isinstance(hso, dict), f"`hookSpecificOutput` fehlt oder ist kein Objekt: {roh!r}"
+    assert hso.get("hookEventName") == "PostToolUse", (
+        f"Falscher hookEventName — die Plattform ordnet den Ersatz sonst nicht zu: {roh!r}"
+    )
+    assert "updatedToolOutput" in hso, f"`updatedToolOutput` fehlt: {roh!r}"
+
+    ersatz = hso["updatedToolOutput"]
+    assert not isinstance(ersatz, str), (
+        "Der Ersatz ist ein String — gemessen: die Plattform verwirft das lautlos, der "
+        f"Waechter waere wirkungslos: {ersatz!r}"
+    )
+    assert isinstance(ersatz, dict), (
+        f"Ein Objekt-Ergebnis muss als Objekt ersetzt werden, bekam {type(ersatz).__name__}"
+    )
+    fehlend = set(antwort) - set(ersatz)
+    assert not fehlend, (
+        f"Dem Ersatz fehlen Schluessel des Originals {sorted(fehlend)} — gemessen: ein "
+        f"unvollstaendiges Objekt wird lautlos verworfen. Ersatz-Schluessel: {sorted(ersatz)}"
+    )
+
+
+# ------------------------------------- Schluesselnamen und Verschachtelungstiefe
+# Befunde der Adversary-Runden, alle scheiterten LAUTLOS — genau die Fehlerart, gegen die
+# dieser Waechter ueberhaupt existiert:
+#   F001: geprueft wurden nur dict-WERTE, nie dict-SCHLUESSEL.
+#   F002/F003: die feste Tiefengrenze (`_MAX_TIEFE = 25`) liess tiefere Ebenen ungeprueft.
+#     Die Meldung dieser Grenze verletzte zugleich AC-1 (stumm im Normalfall): sie erschien
+#     auch bei voellig harmlosen tiefen Nutzlasten. Die Grenze ist deshalb ersatzlos
+#     gefallen — die Traversierung laeuft iterativ, es gibt nichts mehr zu melden.
+
+
+def test_gate_masks_secret_used_as_nested_key(tmp_path):
+    """(F001) Ein Geheimnis als SCHLUESSELNAME unterhalb der obersten Ebene wird maskiert.
+
+    Unterhalb der obersten Ebene prueft die Plattform die Schluesselmenge nicht — dort
+    darf (und muss) umbenannt werden. Die uebrigen Felder bleiben dabei erhalten.
+    """
+    nachbar_marker = "nachbar-marker-4714"
+    antwort = {
+        "stdout": "Konfiguration geladen\n",
+        "stderr": "",
+        "interrupted": False,
+        "details": {f"token_{WERT}": "gehoert zu diesem Dienst", "nachbar": nachbar_marker},
+    }
+    r = _hook(tmp_path, "Bash", antwort)
+    wirksam = _wirksames_ergebnis(r, antwort)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {_gesamtausgabe(r)}"
+    assert WERT not in wirksam, (
+        f"Geheimnis als verschachtelter SCHLUESSELNAME blieb im Klartext: {wirksam!r}"
+    )
+    assert ERSATZ in wirksam, f"Ersatzform {ERSATZ} fehlt im Schluesselnamen: {wirksam!r}"
+    assert nachbar_marker in wirksam, (
+        f"Nachbarfeld ging beim Umbenennen des Schluessels verloren: {wirksam!r}"
+    )
+    daten = json.loads(r.stdout.strip())
+    ersatz = daten["hookSpecificOutput"]["updatedToolOutput"]
+    assert set(ersatz) == set(antwort), (
+        "Die OBERSTE Schluesselmenge muss unangetastet bleiben (AC-13), auch wenn weiter "
+        f"unten umbenannt wird. Original {sorted(antwort)}, Ersatz {sorted(ersatz)}"
+    )
+    assert set(ersatz["details"]) != set(antwort["details"]), (
+        "Unterhalb der obersten Ebene wurde der Schluessel NICHT umbenannt: "
+        f"{sorted(ersatz['details'])}"
+    )
+
+
+def test_gate_reports_secret_in_top_level_key_without_renaming_it(tmp_path):
+    """(F001) Auf der OBERSTEN Ebene wird ein Geheimnis im Schluesselnamen gemeldet, aber
+    nicht umbenannt.
+
+    Gemessen (AC-13): fehlt dem Ersatz ein Schluessel des Originals, verwirft die Plattform
+    den GESAMTEN Ersatz stillschweigend — dann blieben auch alle WERTE unmaskiert. Aus einer
+    Teilluecke wuerde ein Totalausfall. Also: Schluesselmenge unveraendert lassen UND laut
+    melden. Die Meldung nennt den Schluessel in MASKIERTER Form, nie den rohen Wert.
+    """
+    schluessel_mit_geheimnis = f"token_{WERT}_ende"
+    antwort = {
+        "stdout": f"login ok mit {ZWEITER_WERT}\n",
+        "stderr": "",
+        "interrupted": False,
+        schluessel_mit_geheimnis: "harmloser Begleitwert",
+    }
+    r = _hook(tmp_path, "Bash", antwort)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {_gesamtausgabe(r)}"
+
+    daten = json.loads(r.stdout.strip())
+    ersatz = daten["hookSpecificOutput"]["updatedToolOutput"]
+    assert set(ersatz) == set(antwort), (
+        "Die Schluesselmenge auf oberster Ebene wurde veraendert — gemessen: die Plattform "
+        f"verwirft den Ersatz dann komplett. Original {sorted(antwort)}, Ersatz {sorted(ersatz)}"
+    )
+    assert ZWEITER_WERT not in json.dumps(ersatz), (
+        "Die Werte-Maskierung muss trotz des Sonderfalls unveraendert weiterlaufen"
+    )
+
+    assert r.stderr.strip() != "", (
+        "Ein Geheimnis im obersten Schluesselnamen darf NICHT lautlos durchgehen"
+    )
+    assert f"token_{ERSATZ}_ende" in r.stderr, (
+        f"Die Meldung nennt den (maskierten) Schluesselnamen nicht: {r.stderr!r}"
+    )
+    assert WERT not in r.stderr, (
+        f"Der rohe Geheimniswert steht in der Meldung des Waechters: {r.stderr!r}"
+    )
+    assert "Bash" in r.stderr, f"Die Meldung nennt das Werkzeug nicht: {r.stderr!r}"
+
+
+def _tief_verschachtelt(ebenen: int, blatt: str) -> dict:
+    knoten: dict = {"ebene": "blatt", "inhalt": blatt}
+    for i in range(ebenen):
+        knoten = {"ebene": f"e{i}", "tiefer": knoten}
+    return knoten
+
+
+def test_gate_stays_silent_on_deeply_nested_harmless_payload(tmp_path):
+    """(F003, AC-1) Eine tief verschachtelte, voellig HARMLOSE Nutzlast erzeugt keinerlei
+    Ausgabe.
+
+    Bauvorgabe 1 ist unbedingt: kein Fund heisst keinerlei stdout UND keinerlei stderr. Eine
+    Meldung ueber die eigene Pruefgrenze verletzt das — sie erschien auch dann, wenn im
+    gesamten Ergebnis kein einziger Geheimniswert steckt, und machte den Normalfall laut.
+    """
+    antwort = {"stdout": "nichts auffaelliges\n", "stderr": "", "interrupted": False,
+               "details": _tief_verschachtelt(30, "voellig harmlos")}
+    r = _hook(tmp_path, "Bash", antwort)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {_gesamtausgabe(r)}"
+    assert "Traceback" not in r.stderr, f"Der Waechter ist abgestuerzt: {r.stderr}"
+    assert r.stdout == "", (
+        f"Ohne Fund darf es keinerlei stdout geben, bekam: {r.stdout!r}"
+    )
+    assert r.stderr == "", (
+        "Ohne Fund darf es keinerlei stderr geben — auch nicht ueber die eigene "
+        f"Pruefgrenze, bekam: {r.stderr!r}"
+    )
+
+
+def test_gate_main_runs_to_completion_without_swallowed_error(tmp_path):
+    """Kein VERSCHLUCKTER Fehler in `main()` — von aussen sonst unsichtbar.
+
+    Der Waechter faengt am Modulende JEDE Ausnahme ab (Bauvorgabe 2, fail-open) und endet
+    dann mit Exit 0 und leerem stderr — also exakt so wie ein sauberer Durchlauf. Jeder
+    andere Test hier kann deshalb gruen sein, waehrend `main()` in Wahrheit auf halber
+    Strecke abbricht: gemessen am 2026-08-08, als ein Zugriff auf eine entfernte Notiz einen
+    `KeyError` warf und die volle Suite trotzdem gruen blieb.
+
+    Deshalb hier derselbe Aufruf OHNE den auffangenden `__main__`-Block: `runpy.run_path`
+    laedt das Modul unter einem anderen Namen, `main()` wird direkt gerufen. Eine Ausnahme
+    schlaegt dann als echter Traceback mit Exit != 0 durch. Kein Mock — echter Unterprozess,
+    echtes stdin, Wegwerf-Projekt wie in `_hook`.
+    """
+    ordner = _projekt(tmp_path)
+    eingabe = json.dumps({
+        "session_id": "wegwerf", "tool_name": "Bash", "tool_input": {"command": "echo hallo"},
+        # Gewoehnliches dict-Ergebnis ohne jeden Geheimniswert: der Normalfall, der bis ans
+        # Ende von main() laeuft (ein frueher Rueckgabewert wuerde nichts beweisen).
+        "tool_response": _bash_erfolg("alles ganz normal\n"),
+    })
+    ohne_auffang = (
+        "import runpy, sys;"
+        f"m = runpy.run_path({str(GATE)!r}, run_name='_probe_ohne_auffang');"
+        "sys.exit(m['main']())"
+    )
+    env = dict(os.environ)
+    env["CLAUDE_PROJECT_DIR"] = str(ordner)
+    r = subprocess.run([sys.executable, "-c", ohne_auffang], input=eingabe, cwd=str(ordner),
+                       capture_output=True, text=True, timeout=30, env=env)
+    assert "Traceback" not in r.stderr, (
+        f"Eine Ausnahme lief in main() bis nach oben — im echten Lauf verschluckt sie der "
+        f"auffangende __main__-Block lautlos: {r.stderr}"
+    )
+    assert r.returncode == 0, f"main() endete nicht mit 0: {r.returncode}, {r.stderr!r}"
+    assert r.stdout == "" and r.stderr == "", (
+        f"Der Normalfall muss stumm bleiben: stdout={r.stdout!r} stderr={r.stderr!r}"
+    )
+
+
+def test_gate_masks_secret_far_below_former_depth_limit(tmp_path):
+    """(F002/F003) Ein Geheimnis 40 Ebenen tief wird maskiert — es gibt keine eigene
+    Tiefengrenze mehr.
+
+    Frueher brach die Pruefung bei Ebene 25 ab: der Wert unterhalb blieb im Klartext und der
+    Waechter kuendigte seinen eigenen blinden Fleck an. Beides faellt weg — die Traversierung
+    laeuft iterativ ueber einen Stapel und erreicht jedes Blatt.
+    """
+    antwort = {"stdout": "nichts auffaelliges\n", "stderr": "", "interrupted": False,
+               "details": _tief_verschachtelt(40, f"pass={WERT}")}
+    r = _hook(tmp_path, "Bash", antwort)
+    wirksam = _wirksames_ergebnis(r, antwort)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {_gesamtausgabe(r)}"
+    assert "Traceback" not in r.stderr, f"Der Waechter ist abgestuerzt: {r.stderr}"
+    assert WERT not in wirksam, (
+        f"Geheimnis 40 Ebenen tief blieb im Klartext — die Pruefung bricht ab: {wirksam!r}"
+    )
+    assert ERSATZ in wirksam, f"Ersatzform {ERSATZ} fehlt: {wirksam!r}"
+    meldung = r.stderr.lower()
+    assert not ("tief" in meldung and "nicht mehr" in meldung), (
+        f"Es darf keine Meldung ueber eine Tiefengrenze mehr geben: {r.stderr!r}"
+    )
+    assert WERT not in _gesamtausgabe(r), (
+        f"Der rohe Geheimniswert steht in der Ausgabe des Waechters: {_gesamtausgabe(r)!r}"
+    )
+
+
+# ------------------------------------ Kopiergrenze, Listen und der Notfall-Pfad
+# Drei Befunde der Adversary-Runde 3. Der erste ist der schwerste, den dieser Waechter
+# ueberhaupt haben kann: er scheiterte STILL und liess dabei den Wert im Klartext stehen.
+#   F005: `copy.deepcopy` warf ab Tiefe ~497 einen RecursionError. Der Notfall-Handler fing
+#         ihn ab, bevor `main()` irgendetwas ausgegeben hatte -> von "kein Fund" nicht
+#         unterscheidbar, waehrend die Plattform das Ergebnis MIT Geheimnis weiterreichte.
+#   F006: kein Test legte je ein Geheimnis als blossen LISTENEINTRAG ab.
+#   F007: den aeusseren Notfall-Handler loeste kein einziger Test je aus.
+
+
+def test_gate_masks_secret_deeper_than_the_copy_recursion_limit(tmp_path):
+    """(F005) Ein Geheimnis unterhalb der frueheren Kopier-Grenze (~497) wird maskiert.
+
+    Der schwerste denkbare Fehler dieses Waechters: er bricht ab, BEVOR er etwas ausgegeben
+    hat, und schweigt dabei — die Plattform reicht das Ergebnis dann unveraendert und mit dem
+    Wert im Klartext weiter. Von aussen sieht das exakt aus wie "geprueft, nichts gefunden".
+    """
+    antwort = {"stdout": "nichts auffaelliges\n", "stderr": "", "interrupted": False,
+               "details": _tief_verschachtelt(600, f"pass={WERT}")}
+    r = _hook(tmp_path, "Bash", antwort)
+    wirksam = _wirksames_ergebnis(r, antwort)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {_gesamtausgabe(r)}"
+    assert "Traceback" not in r.stderr, f"Der Waechter ist abgestuerzt: {r.stderr}"
+    assert WERT not in wirksam, (
+        "Geheimnis 600 Ebenen tief blieb im Klartext — die Kopie bricht ab und der Waechter "
+        f"schweigt dazu: stdout={r.stdout[:120]!r} stderr={r.stderr!r}"
+    )
+    assert ERSATZ in wirksam, f"Ersatzform {ERSATZ} fehlt: {wirksam!r}"
+    assert WERT not in _gesamtausgabe(r), (
+        f"Der rohe Geheimniswert steht in der Ausgabe des Waechters: {_gesamtausgabe(r)!r}"
+    )
+
+
+def test_gate_masks_secret_as_plain_list_element(tmp_path):
+    """(F006) Ein Geheimnis als blosser LISTENEINTRAG — nicht als dict-Wert.
+
+    Gemischte Form (Liste in dict in Liste), weil genau diese Kombination bisher von keinem
+    Test beruehrt wurde: eine abgeschaltete Listen-Traversierung machte 0 von 23 Tests rot.
+    Die Nachbareintraege muessen dabei an ihrer Stelle bleiben.
+    """
+    antwort = {
+        "stdout": "Konfiguration geladen\n",
+        "stderr": "",
+        "interrupted": False,
+        "eintraege": ["harmlos-vorher", {"weitere": [f"pass={WERT}", "harmlos-nachher"]}],
+    }
+    r = _hook(tmp_path, "Bash", antwort)
+    wirksam = _wirksames_ergebnis(r, antwort)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {_gesamtausgabe(r)}"
+    assert WERT not in wirksam, (
+        f"Geheimnis als reiner Listeneintrag blieb im Klartext: {wirksam!r}"
+    )
+    assert ERSATZ in wirksam, f"Ersatzform {ERSATZ} fehlt: {wirksam!r}"
+    daten = json.loads(r.stdout.strip())
+    ersatz = daten["hookSpecificOutput"]["updatedToolOutput"]
+    assert ersatz["eintraege"][0] == "harmlos-vorher", (
+        f"Der Eintrag VOR dem Treffer wurde veraendert: {ersatz['eintraege'][0]!r}"
+    )
+    assert ersatz["eintraege"][1]["weitere"][1] == "harmlos-nachher", (
+        f"Der Eintrag NACH dem Treffer ging verloren: {ersatz['eintraege'][1]!r}"
+    )
+    assert ersatz["eintraege"][1]["weitere"][0] == f"pass={ERSATZ}", (
+        f"Der Listeneintrag wurde nicht an Ort und Stelle ersetzt: {ersatz['eintraege'][1]!r}"
+    )
+
+
+# `extra_key_patterns` des Plugins wird zur Laufzeit als regulaerer Ausdruck ausgewertet
+# (`_is_secret_key`). Ein unvollstaendiger Ausdruck laesst die Erkennung MITTEN im Lauf
+# scheitern — ein echter, ohne Mock herstellbarer Ausloeser fuer den Notfall-Pfad.
+KAPUTTE_KONFIG = 'secret_egress_guard:\n  extra_key_patterns:\n    - "("\n'
+# Schluessel, den KEIN eingebautes Muster trifft — sonst greift `any()` schon vorher und der
+# kaputte Ausdruck wird nie ausgewertet.
+UNVERDAECHTIGE_ZEILE = "GZ_FAKE_NOTIZ=beliebiger_text\n"
+
+
+def test_gate_reports_when_the_inspection_could_not_finish(tmp_path):
+    """(F005 Teil 2 / F007) Bricht die Pruefung mit einem Fehler ab, SAGT der Waechter das.
+
+    Bis hierher galt: jede eigene Stoerung endet lautlos mit Exit 0. Fuer eine Stoerung VOR
+    der Maskierung heisst das aber, dass das Ergebnis MIT dem Geheimnis weitergereicht wird —
+    und niemand erfaehrt davon. Fail-open bleibt (Exit 0, Ergebnis unangetastet), aber nicht
+    mehr stumm. Ab jetzt gilt: stumm ist der Waechter nur, wenn er vollstaendig geprueft und
+    nichts gefunden hat.
+
+    Die Meldung darf ausschliesslich den Ausnahme-TYP nennen, nie deren Text: eine
+    Fehlermeldung kann Bruchstuecke der Nutzlast tragen.
+    """
+    antwort = _bash_erfolg(f"SMTP-Login: {WERT}\n")
+    ordner = tmp_path / "projekt"
+    ordner.mkdir(exist_ok=True)
+    (ordner / "openspec.yaml").write_text(KAPUTTE_KONFIG)
+    r = _hook(tmp_path, "Bash", antwort, zusatz_env=UNVERDAECHTIGE_ZEILE)
+    wirksam = _wirksames_ergebnis(r, antwort)
+
+    assert r.returncode == 0, f"Eine eigene Stoerung darf nie blockieren: {_gesamtausgabe(r)}"
+    assert "Traceback" not in r.stderr, f"Der Waechter ist abgestuerzt: {r.stderr}"
+    assert WERT in wirksam, (
+        "Fail-open heisst: das Ergebnis wird UNVERAENDERT durchgereicht — der Waechter hat "
+        f"es angetastet: {wirksam!r}"
+    )
+    assert r.stderr.strip() != "", (
+        "Eine abgebrochene Pruefung darf NICHT lautlos bleiben — sonst ist sie von "
+        "'geprueft, nichts gefunden' nicht zu unterscheiden, waehrend der Wert sichtbar bleibt"
+    )
+    assert "Bash" in r.stderr, f"Die Meldung nennt das Werkzeug nicht: {r.stderr!r}"
+    assert "unterminated subpattern" not in r.stderr, (
+        "Der TEXT der Ausnahme steht in der Meldung — er kann Bruchstuecke der Nutzlast "
+        f"tragen. Erlaubt ist nur der Typ: {r.stderr!r}"
+    )
+    assert WERT not in _gesamtausgabe(r), (
+        f"Der rohe Geheimniswert steht in der Ausgabe des Waechters: {_gesamtausgabe(r)!r}"
+    )
+
+
+def test_gate_masks_secret_close_to_the_parse_limit(tmp_path):
+    """(F005) Auch dicht UNTER der neuen Obergrenze wird noch maskiert.
+
+    Tiefe 600 (Test oben) beweist nur, dass die alte `deepcopy`-Schranke weg ist — nicht,
+    dass wirklich nirgends mehr Rekursion steckt. Hier laeuft die volle Kette (Einlesen,
+    Kopieren, Traversieren, Ausgeben) knapp unterhalb der gemessenen Grenze von 9997.
+    """
+    antwort = {"stdout": "nichts auffaelliges\n", "stderr": "", "interrupted": False,
+               "details": _tief_verschachtelt(9_900, f"pass={WERT}")}
+    r = _hook(tmp_path, "Bash", antwort)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {r.stderr[:300]}"
+    assert "Traceback" not in r.stderr, f"Der Waechter ist abgestuerzt: {r.stderr[:300]}"
+    assert ERSATZ in r.stdout, (
+        f"Knapp unter der Obergrenze wurde nicht maskiert: stderr={r.stderr[:300]!r}"
+    )
+    assert WERT not in _gesamtausgabe(r), (
+        "Der rohe Geheimniswert steht in der Ausgabe des Waechters"
+    )
+
+
+def test_gate_reports_when_the_payload_cannot_be_parsed(tmp_path):
+    """(F005 Teil 2) Dasselbe an der NEUEN Obergrenze: unlesbare Nutzlast wird gemeldet.
+
+    Nach dem Wegfall von `copy.deepcopy` liegt die Grenze bei `json.loads` (gemessen: Tiefe
+    9997 geht, 9998 wirft `RecursionError`). Bliebe der Waechter dort stumm, waere derselbe
+    Fehler nur um vier Groessenordnungen verschoben: Wert sichtbar, niemand erfaehrt es.
+    """
+    tiefe = 10_000
+    nutzlast = ('{"tool_name": "Bash", "tool_response": '
+                + '{"a": ' * tiefe + f'"pass={WERT}"' + "}" * tiefe + "}")
+    r = _hook(tmp_path, roh_stdin=nutzlast)
+    assert r.returncode == 0, f"Eine eigene Stoerung darf nie blockieren: {_gesamtausgabe(r)}"
+    assert "Traceback" not in r.stderr, f"Der Waechter ist abgestuerzt: {r.stderr}"
+    assert "updatedToolOutput" not in r.stdout, (
+        f"Ohne lesbare Nutzlast darf kein Ersatz-Ergebnis erzeugt werden: {r.stdout[:200]!r}"
+    )
+    assert r.stderr.strip() != "", (
+        "Eine nicht lesbare Nutzlast bedeutet: NICHT geprueft. Das darf nicht lautlos "
+        "aussehen wie 'geprueft, nichts gefunden'"
+    )
+    assert WERT not in _gesamtausgabe(r), (
+        f"Der rohe Geheimniswert steht in der Ausgabe des Waechters: {_gesamtausgabe(r)!r}"
+    )
+
+
+# ------------------------------------------------------ Schluesselreihenfolge
+# F009 (Runde 6): der Docstring von `_tiefe_kopie` sagte die Reihenfolge als
+# Plattform-Anforderung zu, ohne dass ein Test sie hielt (Mutation: 0 von 27 rot).
+#
+# F008 aus derselben Runde ist BEWUSST NICHT behoben und hat deshalb hier auch keinen Test:
+# der Werkzeugname aus `tool_name` wird ungeprueft in die Meldungen gedruckt. Die Luecke
+# steht als bekannte Grenze in der Spec, nicht als dauerhaft roter Test im Korpus.
+
+
+def test_replacement_keeps_the_original_key_order(tmp_path):
+    """(F009) Die Schluesselreihenfolge des Originals bleibt erhalten — auch verschachtelt.
+
+    Belegt ist als Plattform-Anforderung nur die Schluessel-MENGE (fehlt einer, wird der
+    gesamte Ersatz verworfen; neun gemessene Laeufe). Ob die REIHENFOLGE zaehlt, ist nie
+    gemessen worden. Sie kostet nichts, ist im Zweifel die naeherliegende Gestalt — und eine
+    Zusage im Code, die kein Test haelt, ist genau das, was hier mehrfach schiefging.
+    """
+    antwort = {"zuerst": "eins", "stdout": f"pass={WERT}\n", "dann": "zwei",
+               "interrupted": False, "zuletzt": {"b": "B", "a": "A", "c": "C"}}
+    r = _hook(tmp_path, "Bash", antwort)
+    assert r.returncode == 0, f"Der Waechter darf nie blockieren: {_gesamtausgabe(r)}"
+    daten = json.loads(r.stdout.strip())
+    ersatz = daten["hookSpecificOutput"]["updatedToolOutput"]
+    assert list(ersatz) == list(antwort), (
+        f"Die Schluesselreihenfolge auf oberster Ebene wurde veraendert: {list(ersatz)}"
+    )
+    assert list(ersatz["zuletzt"]) == list(antwort["zuletzt"]), (
+        f"Die Schluesselreihenfolge weiter unten wurde veraendert: {list(ersatz['zuletzt'])}"
+    )


### PR DESCRIPTION
Schliesst #1537 Scheibe 2 Stufe B. Ein `PostToolUse`-Waechter durchsucht das **Ergebnis** jedes Werkzeugaufrufs nach ausgeschriebenen Werten aus der lokalen `.env` und ersetzt Treffer durch `***<SCHLUESSELNAME>***`, bevor Claude sie sieht.

Damit ist der dritte Austrittsweg abgedeckt: Scheibe 1 schuetzt vorgemerkte Dateien beim Commit, der Egress-Waechter (#1380) ausgehende **Eingaben** — ein Wert, der in der **Ausgabe** zurueckkommt, obwohl er im Aufruf nie stand, lief bisher an beiden vorbei.

## Was drin ist

- `.claude/hooks/secret_output_gate.py` (neu, 375 Zeilen) — Erkennung aus dem Plugin geliehen (`collect_secrets`, `_is_secret_key`, `_is_secret_value`), kein dritter Geheimnis-Begriff. Durchgehend fail-open, kein `.env`-Cache, kein Werkzeugname-Filter.
- `tests/unit/test_secret_output_gate.py` (neu, 29 Tests) — echter Subprozess gegen synthetische `.env` in `tmp_path`, keine Mocks.
- `.claude/settings.json` — `PostToolUse`-Gruppe mit `matcher: "*"`, geschuetzte `if [ -f … ]`-Huelle, Zeitbudget 5 s.
- Spec und Kontext-Dokument.

## Drei Adversary-Runden

Jede Runde fand etwas Echtes; zweimal hat die Behebung eines Befundes einen neuen erzeugt.

| Befund | Was | Stand |
|---|---|---|
| F001 | Geheimnis als **Schluesselname** wurde nicht geprueft | behoben |
| F002 | Tiefengrenze brach **wortlos** ab | behoben |
| F003 | die Meldung dazu war dann **zu laut** (feuerte ohne jeden Fund) | behoben, Grenze ersatzlos entfernt |
| F004 | Wirkungsnachweis gegen eine **aeltere Datei** gefuehrt | behoben, dreimal neu gefuehrt |
| **F005** | `copy.deepcopy` scheiterte ab Tiefe 498 **still** — Ergebnis lief unmaskiert durch | behoben |
| F006/F007 | zwei Pflicht-Mutationen, die **kein Test** fing | bewacht |
| F008 | Werkzeugname wird ungeprueft in die Meldung gedruckt | **vertagt** -> #1617 |

**F005 war der schwerste** und stammte aus der allerersten Fassung (per erhaltener Kopie sha256 `9c08375a…` byte-genau belegt) — zwei Pruefrunden waren daran vorbeigelaufen. Sichtbar wurde er erst, als die Tiefengrenze fiel.

**Leitregel, die daraus im Waechter steht:** gemeldet wird, wer **unerwartet mitten in der Arbeit** scheitert — nicht, wer von vornherein weiss, dass er nicht arbeiten kann ("Plugin fehlt" bleibt deshalb bewusst still). Stumm ist der Waechter nur noch, wenn er **vollstaendig geprueft und nichts gefunden** hat.

## Nachweise

- **Wirkungsnachweis in echter Sitzung** gegen den ausgelieferten Stand (sha256 `4fc65709…`, Byte-Gleichheit belegt): Bash maskiert, `Read` verschachtelt maskiert **mit vollstaendig erhaltener Gestalt**, Normalfall unveraendert, Wert im Sitzungsprotokoll null Treffer bei greifenden Positivkontrollen. Das ist der einzige Beleg, dass die Plattform den Ersatz **annimmt** — ein falsch geformter Ersatz wird stillschweigend verworfen und waere von einem funktionierenden Waechter nicht unterscheidbar.
- **Mutations-Gegenprobe:** 10 von 11 Pflicht-Mutationen werden von Tests gefangen; die letzte Luecke (dict-Schluesselreihenfolge) ist seitdem bewacht.
- Obergrenze **9997** gemessen (Grenze von `json.loads`/`json.dumps`) statt vorher 497; im Test bei Tiefe 9.900 am Verhalten festgenagelt. Groesste real gemessene Tiefe ueber 5.093 echte Werkzeug-Ergebnisse: **5**.

## Bekannte Grenzen (in der Spec, nicht verschwiegen)

- **Fehlgeschlagene Werkzeugaufrufe sind unerreichbar** — bei Exit != 0 ruft die Plattform `PostToolUse` gar nicht auf. Der Anlassfall #1535 ist ein fehlschlagender Test; **dieser Waechter verhindert ihn nicht.** Sein Fix gehoert in den Test selbst.
- **F008** (#1617) — eng ausloesbar, Behebung bekannt und dort skizziert.
- Ein Geheimnis als Schluesselname auf oberster Ebene wird gemeldet, aber nicht umbenannt (sonst verwirft die Plattform den gesamten Ersatz).

## Kein Staging/Prod noetig

Reine Werkzeug- und Testaenderung — kein Code in `src/`, `api/`, `internal/`, `frontend/`, `cmd/`. Der Waechter wirkt erst ab der naechsten Claude-Code-Sitzung.

Refs #1537, #1617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrcoPY7GGBPNV2L1phL47J