### PR TITLE
fix(#1505): Orts-Vergleich-Ausblick benennt seinen Zustand statt zu schweigen

### DIFF
--- a/docs/context/fix-1505-compare-ausblick-zustand.md
+++ b/docs/context/fix-1505-compare-ausblick-zustand.md
@@ -1,0 +1,110 @@
+# Context: Fix #1505 — Orts-Vergleich, Ausblick-Zeile verschwindet still
+
+## Request Summary
+
+Der 3-Tages-Ausblick im Orts-Vergleich verschwindet heute wortlos, wenn ein Fehler vorlag oder
+Daten fehlen — für den Empfänger ununterscheidbar vom Normalfall (Trend vorhanden, aber leer).
+Compare-Pendant zu #1486 (Trip-Pfad, bereits geliefert), mit strukturell anderem Datenpfad.
+
+## Related Files
+
+| File | Relevanz |
+|------|----------|
+| `src/output/renderers/email/compare_html.py:1115-1147` (`_render_location_outlook`) | HTML-Renderer, **zwei** stille Ausstiege: `loc.error is not None or not loc.outlook_hourly_data` (Z.1128) UND `if not rows: return ""` (Z.1131, nach `_build_location_outlook_rows`) — im Issue-Text wird nur der erste genannt |
+| `src/output/renderers/comparison.py:260-335` (`render_comparison_text`/`render_comparison_plain`) | **Klartext-Pendant**, eigene, unabhängige stille Bedingung: `outlook_rows = [...] if outlook_enabled and loc_result.outlook_hourly_data else []` (Z.280-284) — bei leer/Fehler entfällt der Block hier ebenso lautlos, UND bei `not have_hourly and not outlook_rows` fällt der ganze Ort aus der Mail (Z.284/`continue`) |
+| `src/services/comparison_engine.py:127-169` | Datenerzeugung: `loc.error` bei Fetch-Fehler (Z.135, Z.352 Exception) ODER `outlook_hourly_data = []`, wenn `_outlook_days` (Tage nach `_last_detail_day` innerhalb der 96h-Fetch-Antwort) leer bleibt |
+| `src/app/user.py:117-` (`LocationResult`) | Datenklasse mit `error: Optional[str]`, `outlook_hourly_data: list` — kein eigenes Zustandsfeld, das Grund von Leere unterscheidet |
+| `src/output/renderers/email/outlook_state_hint.py` | Fertiger, geteilter Baustein aus #1486: `OutlookState`-Enum (`FOUND/NO_STAGES/BEYOND_HORIZON/UNAVAILABLE`), `outlook_state_text/should_warn/render_*_html/render_*_plain` — bewusst generisch (keine Trip-Typen in Signatur), für Compare vorgesehen |
+| `src/app/models.py:780-810` | `OutlookState`(Enum)/`TrendResult`(Dataclass) — Domänenschicht, hier liegt die eigentliche Zustandslogik |
+| `src/output/renderers/email/outlook.py` | GETEILTER Tabellen-Renderer (`build_outlook_row`, `render_outlook_table`, `render_outlook_plain`) — bleibt unverändert, Paritäts-Golden (`tests/tdd/test_trip_outlook_parity.py`) |
+| `tests/tdd/test_outlook_state_named_not_silent.py`, `tests/tdd/test_outlook_state_visible_in_channels.py` | Bestehende Tests für den Trip-Pfad — Vorbild für Compare-Äquivalent, NICHT verändern (Trip-Verhalten fixiert) |
+
+## Existing Patterns
+
+- **#1486 (Trip-Pfad, geliefert 2026-08-05):** `_build_stage_trend()` gibt `TrendResult(rows, state, horizon_days)` zurück; vier Renderer (HTML/Plain/Compact/Telegram) prüfen `if multi_day_trend: <Tabelle> elif outlook_state not in (None, FOUND): <Zustandstext>`. Styling: `NO_STAGES`/`BEYOND_HORIZON` = neutraler Fließtext (`G_INK_MUTED`, kein Rahmen), `UNAVAILABLE` = Danger-Box/`⚠️`.
+- **Compare hat NUR E-Mail (HTML + Klartext) für den Ausblick** — geprüft: `render_compare_telegram()` und `render_compare_sms()` (`comparison.py:651-`, `942-`) haben KEINE `outlook_*`-Parameter. Der Ausblick existiert im Compare-Pfad nur in der E-Mail (zwei Fassungen). Kleinerer Blast Radius als #1486 (4 Kanäle).
+- **`undelivered_hint.py`** wird bereits von `compare_html.py` als geteilter, kanal-neutraler Hinweisbaustein genutzt (Z.1563-1569) — Präzedenzfall für „Hinweisbaustein rein, Compare bindet ein".
+
+## Dependencies
+
+- **Upstream:** `comparison_engine.py::ComparisonEngine.run()` — einzige Quelle für `LocationResult.error`/`outlook_hourly_data`. `target_date` ist bei Scheduler-Versand `date.today()` (Compare hat kein „Tour zu Ende"-Konzept wie Trip-Etappen); nur im interaktiven Preview-Pfad (`compare_preview_service.py`) frei wählbar — dort könnte ein weit in der Zukunft liegendes `target_date` faktisch den Vorhersagehorizont überschreiten.
+- **Downstream:** Renderer-Commit-Gate #811 greift auf `compare_html.py`. `email_spec_validator.py` (Marker `X-GZ-Mail-Type: compare`) ist der Pflicht-Validator vor „E2E bestanden" — validiert nur den HTML-Body (Klartext ist blinder Fleck, s. `reference_compare_mail_plaintext_blind_spot`).
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1486_outlook_silent_exit.md` (v1.0, Trip-Pfad) — Abschnitt „Known Limitations" benennt den Compare-Bug ausdrücklich als eigenständig, NICHT 1:1 übertragbar.
+- `docs/specs/modules/multi_day_trend.md` (v5.0) — Trip-Ausblick-Spec, referenziert nicht den Compare-Pfad.
+- Kein bestehendes Spec-Modul für den Compare-Ausblick-Zustand.
+
+## Risks & Considerations
+
+1. **Drei stille Ausstiege, nicht zwei.** Das Issue nennt nur `loc.error is not None or not loc.outlook_hourly_data` (Z.1128). Gemessen existiert ein dritter, unabhängiger Ausstieg: `if not rows: return ""` nach `_build_location_outlook_rows()` (Z.1131) — auch wenn `outlook_hourly_data` nicht leer ist, kann die Zeilenbildung leer zurückkommen (z.B. Metrik-Filterung). Muss im Zustandsmodell mitgedacht werden.
+2. **Klartext-Pfad ist eigenständig fehlerhaft, nicht nur ein zweiter Aufrufer.** `comparison.py` hat eine eigene Bedingung, die NICHT von einer Zustandskorrektur in `compare_html.py` mitgefixt wird. Beide Dateien müssen geändert werden. Zusätzliche Falle: fehlt sowohl Stundenverlauf als auch Ausblick, fällt der Ort im Klartext-Pfad komplett aus der Mail (Z.284), im HTML-Pfad nicht (dort bleibt nur der Ausblick-Block leer) — dieses Auseinanderlaufen ist bereits vorhanden und nicht Teil des Ausblick-Bugs, aber beim Umbau sichtbar.
+3. **„Leer ≠ unbekannt" (Lehre aus #1492 S2b):** `outlook_hourly_data = []` kann heißen „Horizont/Fetch-Fenster erschöpft" (analog Klasse B) ODER „Fetch fehlgeschlagen, aber `error` aus irgendeinem Grund nicht gesetzt" — die beiden Fälle sind im aktuellen Datenmodell nicht scharf getrennt. Muss in der Spec-Phase geklärt werden, ob Compare eine eigene, kleinere Zustands-Taxonomie braucht (kein Trip-Äquivalent zu `NO_STAGES`, da Compare kein „Tour zu Ende" kennt) oder ob nur `UNAVAILABLE` + `FOUND` reichen.
+4. **Kein Compare-Äquivalent zu `NO_STAGES`.** Trip kennt „Tour ist zu Ende" als normalen, nicht-warnungswürdigen Grund. Compare hat kein Etappen-Konzept — die Frage, ob es hier überhaupt einen „harmlosen Leer"-Zustand gibt (oder ob leer bei Compare IMMER auf Fehler/Datenlücke hindeutet, weil das 96h-Fenster normalerweise ausreicht), ist eine Analyse-Entscheidung mit Konsequenz für Logging (WARNING ja/nein) und Text.
+5. **Pendant-Sperre (#1481 B):** Neue Dateien in `compare_html.py`-Nähe oder in `comparison.py` sind okay (Bestandsdateien, keine Neuanlage), aber ein etwaiger neuer Compare-spezifischer Hilfsbaustein braucht entweder Ablage unter `shared/`-Äquivalent (hier: `outlook_state_hint.py` direkt wiederverwenden, keine Kopie) oder eine `gz-eigenstaendig`-Begründung.
+6. **Renderer-Commit-Gate #811 + Mail-Validator-Pflicht** vor jedem Commit, der `compare_html.py` staged.
+7. **`OutlookState`/`TrendResult` liegen in `app/models.py`** (Domänenschicht) — falls Compare eine eigene, kleinere Enum-Teilmenge braucht, ist zu klären: neue Werte im bestehenden Enum ergänzen oder eigenen State für Compare definieren (Architekturfrage für die Spec-Phase).
+
+## Scope-Abgrenzung (aus Issue #1505 + Known-Limitations #1486)
+
+**In Scope:** `compare_html.py::_render_location_outlook()`, `comparison.py` (Klartext-Ausblick-Block),
+ggf. `comparison_engine.py` (nur falls Fehler-vs-leer schärfer unterschieden werden muss),
+Wiederverwendung von `outlook_state_hint.py` (kein Nachbau).
+
+**Explizit NICHT in Scope:** `render_compare_telegram`/`render_compare_sms` (kein Ausblick dort),
+`outlook.py` (geteilter Tabellen-Renderer, unverändert), #1563 (Vertretungshinweis — anderer Bug,
+selbe Datei, andere Zeilen).
+
+**PO-Entscheidung 2026-08-08 (eng vs. breit):** Fix bleibt auf die Ausblick-Zeile begrenzt.
+`comparison.py:275` (`if loc_result.error is not None: continue` — lässt bei Fehler den GESAMTEN
+Orts-Block inkl. Stundenverlauf aus dem Klartext verschwinden, nicht nur den Ausblick) bleibt
+UNVERÄNDERT. Das ist breiter als der Ausblick-Bug (betrifft auch Stundenverlauf) und geht als
+Nebenbefund nach #1199, kein eigenes Issue, kein Teil dieses Fixes.
+
+## Analysis
+
+### Type
+Bug (nutzersichtbares Fehlverhalten, Compare-Pendant zu #1486).
+
+### Affected Files (with changes)
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `src/output/renderers/email/compare_html.py` | MODIFY | `_render_location_outlook()`: die drei stillen `return ""`-Ausstiege (Z.1128 `loc.error`/`not outlook_hourly_data`, Z.1131 `not rows`) werden zu einem einzigen Zustands-Check zusammengeführt, der bei „nichts zu zeigen" `render_outlook_state_html(OutlookState.UNAVAILABLE)` aus dem bestehenden `outlook_state_hint.py` rendert statt `""` |
+| `src/output/renderers/comparison.py` | MODIFY | `render_comparison_text`/Klartext-Ausblick-Block (Z.280-284): dieselbe Zusammenführung für den Fall `loc_result.error is None` (der Fehlerfall bleibt bei Z.275 unverändert, s.o. PO-Entscheidung); nutzt `render_outlook_state_plain(OutlookState.UNAVAILABLE)` |
+| `src/services/comparison_engine.py` | MODIFY | Zwei bisher fehlende `logger.warning(...)`-Aufrufe: (a) wenn `raw_result.get("error")`/Exception zu `LocationResult(error=...)` führt (Z.~135, Z.~352 — aktuell komplett unprotokolliert), (b) wenn `outlook_hourly_data` nach erfolgreichem Fetch leer bleibt (Z.~167) |
+| `tests/tdd/test_compare_outlook_state_named_not_silent.py` (neu) | CREATE | Analog zu `tests/tdd/test_outlook_state_named_not_silent.py` (Trip-Pfad) — HTML + Klartext, alle Ursachen (`error`, leeres `outlook_hourly_data`, leere `rows`), inkl. `caplog`-Prüfung |
+| `docs/specs/modules/fix_1505_compare_outlook_silent_exit.md` (neu) | CREATE | Spec-Modul, referenziert `fix_1486_outlook_silent_exit.md` als Vorbild |
+
+Kein neues Produktivmodul nötig — `outlook_state_hint.py` wird unverändert wiederverwendet
+(keine neuen `OutlookState`-Werte, keine Compare-eigene Kopie, Pendant-Sperre #1481 B bleibt
+unberührt weil keine neue Datei in einem einseitigen Verzeichnis entsteht).
+
+### Scope Assessment
+- Files: 3 Produktiv-Änderungen (kein neues Produktivmodul) + 1 neue Testdatei + 1 neue Spec
+- Estimated LoC: ~60-100 (Produktivcode ~30-50, Tests ~40-60) — innerhalb des 250-LoC-Budgets,
+  kein `loc_limit_override` nötig
+- Risk Level: MEDIUM (Renderer-Commit-Gate #811 greift auf `compare_html.py`; Mail-Validator-Pflicht
+  vor „E2E bestanden"; zwei unabhängige Renderer müssen konsistent geändert werden)
+
+### Technical Approach
+
+**Zwei-Zustands-Modell statt Trips Vier-Zustands-Modell (bewusste Vereinfachung, kein Bug):**
+Compare hat kein „Tour zu Ende"-Konzept (kein `NO_STAGES`-Äquivalent) und `target_date` ist bei
+Scheduler-Versand `date.today()` mit festem 96h-Fetch-Fenster — ein `BEYOND_HORIZON`-Fall ist im
+Regelbetrieb praktisch ausgeschlossen. Alle drei bestehenden stillen Ursachen (`loc.error`,
+leeres `outlook_hourly_data`, leere `rows`) werden deshalb einheitlich als
+`OutlookState.UNAVAILABLE` behandelt — Wiederverwendung des bestehenden Enum-Werts aus #1486, keine
+neue Taxonomie nötig.
+
+**Single-Source-Logging:** Die neuen WARNING-Logs kommen in `comparison_engine.py::run()` (Datenschicht,
+läuft genau einmal pro Ort und Vergleichslauf) — NICHT in den Renderern, weil `render_compare_email()`
+(`comparison.py:410-`) HTML- und Klartext-Renderer für dasselbe `ComparisonResult` in einem Aufruf
+verkettet; ein Log in beiden Renderern hätte doppelt geloggt.
+
+### Dependencies
+Siehe „Related Files"/„Dependencies" oben — keine neuen Abhängigkeiten, nur Wiederverwendung.
+
+### Open Questions
+- [x] Klartext-Fehlerfall (Z.275) eng oder breit? → PO-Entscheidung: eng, Nebenbefund #1199.

--- a/docs/specs/modules/fix_1486_outlook_silent_exit.md
+++ b/docs/specs/modules/fix_1486_outlook_silent_exit.md
@@ -282,6 +282,8 @@ Changelog dort).
   wiederverwendbar — `comparison_engine.py`/`compare_html.py` werden in DIESEM Workflow jedoch
   NICHT angefasst (Scope-Treue zu #1486, LoC-Budget). Der Compare-Bug ist nutzersichtbares
   Fehlverhalten und bekommt laut Nebenbefund-Triage ein eigenes Issue — nicht Teil dieses Fixes.
+  **Nachtrag (2026-08-08):** Der Compare-Pfad ist inzwischen in #1505 behoben —
+  `docs/specs/modules/fix_1505_compare_outlook_silent_exit.md`.
 - **`tests/test_output_timezone_guard.py:517-518`:** Nennt `_build_stage_trend` mit
   Zeilennummern-Historie in Ausnahme-Schlüsseln. Die Rückgabetyp-Änderung selbst berührt diesen
   Wächter nicht (er prüft Zeitzonen-Handling, nicht den Rückgabetyp), aber die

--- a/docs/specs/modules/fix_1505_compare_outlook_silent_exit.md
+++ b/docs/specs/modules/fix_1505_compare_outlook_silent_exit.md
@@ -1,0 +1,294 @@
+---
+entity_id: fix_1505_compare_outlook_silent_exit
+type: module
+created: 2026-08-08
+updated: 2026-08-08
+status: implemented
+version: "1.0"
+tags: [compare, email-rendering, outlook, logging, bugfix]
+extends: fix_1486_outlook_silent_exit, outlook_state_hint, comparison_engine
+---
+
+# Fix #1505: Orts-Vergleich, Ausblick-Zeile verschwindet still
+
+## Approval
+
+- [x] Approved
+
+## Purpose
+
+Der 3-Tages-Ausblick im Orts-Vergleich verschwindet heute an drei unabhängigen Stellen wortlos
+(`_render_location_outlook()` in `compare_html.py`, der Klartext-Ausblick-Block in `comparison.py`)
+— für den Empfänger ist ein Fehler, fehlende Rohdaten und eine leere Zeilenbildung nach Filterung
+ununterscheidbar von einer normalen leeren Stelle. Dieser Fix ersetzt das stille Verwerfen im
+HTML- und Klartext-Ausblick durch einen sichtbaren Zustandstext (Wiederverwendung von
+`OutlookState.UNAVAILABLE` aus #1486) und protokolliert die zugrundeliegenden Ursachen in
+`comparison_engine.py` als WARNING, wo sie bisher unprotokolliert blieben. Compare-Pendant zu
+#1486 (Trip-Pfad, bereits geliefert) mit strukturell anderem Datenpfad und bewusst vereinfachtem
+Zwei-Zustands-Modell statt Trips Vier-Zustands-Modell.
+
+## Source
+
+- **File:** `src/output/renderers/email/compare_html.py`
+- **Identifier:** `_render_location_outlook` (Zeilen 1115-1147)
+
+> Python-Core (`src/output/renderers/`, `src/services/`) — Domain-Backend, nicht Go/Frontend.
+
+## Estimated Scope
+
+- **LoC:** ~60-100 (Produktivcode ~30-50, Tests ~40-60) — innerhalb des 250-LoC-Budgets, kein
+  `loc_limit_override` nötig.
+- **Files:** 3 Produktiv-Änderungen (kein neues Produktivmodul) + 1 neue Testdatei + 1 neue Spec.
+- **Effort:** medium (zwei unabhängige Renderer müssen konsistent geändert werden;
+  Renderer-Commit-Gate #811 greift auf `compare_html.py`).
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/output/renderers/email/outlook_state_hint.py` | module (unverändert, aus #1486) | `OutlookState`-Enum, `render_outlook_state_html`/`render_outlook_state_plain`, `outlook_state_should_warn` — bewusst generisch gehalten, für Compare vorgesehen, keine Compare-eigene Kopie |
+| `src/app/models.py` | module | `OutlookState`(Enum) — Domänenschicht, hier liegt die Zustandslogik, wird von `outlook_state_hint.py` re-exportiert |
+| `src/services/comparison_engine.py` | module | einzige Quelle für `LocationResult.error`/`outlook_hourly_data`; hier kommen die neuen WARNING-Logs hinzu |
+| `src/output/renderers/comparison.py` | module | Klartext-Renderer (`render_comparison_text`), `render_compare_email()` als gemeinsamer Einstiegspunkt für HTML+Klartext |
+| `docs/specs/modules/fix_1486_outlook_silent_exit.md` | spec (v1.0, Trip-Pfad) | Vorbild-Spec, Known Limitations dort benennen den Compare-Bug bereits ausdrücklich als eigenständig |
+| `.claude/hooks/email_spec_validator.py` | tool (Marker `X-GZ-Mail-Type: compare`) | Pflicht-Validator vor „E2E bestanden" — prüft NUR den HTML-Body |
+| Renderer-Commit-Gate #811 | gate | greift auf `compare_html.py`, verlangt vor Commit `email_spec_validator.py` grün |
+| Pendant-Sperre #1481 B | gate | keine neue Datei in `frontend/.../compare*` bzw. Renderer mit `compare_`-Präfix nötig — Wiederverwendung von `outlook_state_hint.py`, kein Nachbau |
+
+## Implementation Details
+
+### 1. Zwei-Zustands-Modell statt Trips Vier-Zustands-Modell (bewusste Vereinfachung)
+
+Compare hat kein „Tour zu Ende"-Konzept (kein `NO_STAGES`-Äquivalent aus #1486) und `target_date`
+ist bei Scheduler-Versand `date.today()` mit festem 96h-Fetch-Fenster (`COMPARE_FORECAST_HOURS`,
+`comparison_engine.py:40`) — ein `BEYOND_HORIZON`-Fall ist im Regelbetrieb praktisch ausgeschlossen
+(nur im interaktiven Preview-Pfad mit frei wählbarem `target_date` theoretisch möglich, dort aber
+nicht Teil dieses Fixes). Alle drei bestehenden stillen Ursachen werden deshalb einheitlich als
+`OutlookState.UNAVAILABLE` behandelt:
+
+1. `loc.error is not None` (Fetch-Fehler oder Exception in `comparison_engine.py`).
+2. `not loc.outlook_hourly_data` (Fetch erfolgreich, aber kein Datenpunkt in den drei
+   Ausblick-Kalendertagen — z.B. Vorhersagehorizont erschöpft).
+3. `not rows` nach `_build_location_outlook_rows()` (Rohdaten vorhanden, aber Zeilenbildung liefert
+   nichts — z.B. Metrik-Filterung, `compare_html.py:1095-1096`).
+
+**KEINE neuen `OutlookState`-Werte, KEIN neues Produktivmodul, KEINE Compare-eigene Kopie von
+`outlook_state_hint.py`** (Pendant-Sperre #1481 B: Wiederverwendung ist der Ausweg, keine neue
+Datei in einem einseitigen Verzeichnis).
+
+### 2. `compare_html.py::_render_location_outlook()` (Zeilen 1115-1147)
+
+Die zwei bestehenden stillen `return ""`-Ausstiege werden zu einem Zustands-Check
+zusammengeführt:
+
+```python
+if loc.error is not None or not loc.outlook_hourly_data:
+    return _render_outlook_unavailable(index, with_location, loc)
+rows = _build_location_outlook_rows(loc, outlook_metrics)
+if not rows:
+    return _render_outlook_unavailable(index, with_location, loc)
+```
+
+Der Zustandstext ersetzt `""` und nutzt `render_outlook_state_html(OutlookState.UNAVAILABLE)` aus
+`outlook_state_hint.py`, eingebettet in denselben Block-Wrapper (`padding`-`div`), den die
+Erfolgstabelle heute verwendet, damit die Danger-Box denselben Sektionsrahmen bekommt wie die
+Tabelle. Ob der Ortsname bei `with_location=True` vor dem Zustandstext erscheint (analog zum
+Erfolgsfall) ist eine Implementierungs-Detailfrage, keine AC-relevante Entscheidung — Konsistenz
+mit dem `header`-Aufbau der Erfolgstabelle ist der Leitfaden.
+
+### 3. `comparison.py::render_comparison_text()` — Klartext-Ausblick-Block (Zeilen 280-284)
+
+Dieselbe Zusammenführung, ABER NUR für den Fall `loc_result.error is None` — Zeile 275
+(`if loc_result.error is not None: continue`) bleibt UNVERÄNDERT (s. „Known Limitations" und
+PO-Scope-Entscheidung unten):
+
+```python
+if loc_result.error is None:
+    if outlook_enabled:
+        outlook_rows = (
+            _build_location_outlook_rows(loc_result, outlook_metrics)
+            if loc_result.outlook_hourly_data else []
+        )
+        if not outlook_rows:
+            # UNAVAILABLE: weder outlook_hourly_data noch rows vorhanden
+            outlook_state_text = render_outlook_state_plain(OutlookState.UNAVAILABLE)
+        else:
+            outlook_state_text = None
+    else:
+        outlook_rows, outlook_state_text = [], None
+```
+
+Der `if not have_hourly and not outlook_rows: continue`-Ausstieg (Zeile 284) muss angepasst werden,
+damit ein Ort mit `outlook_state_text` gesetzt (aber leerem `outlook_rows`) NICHT übersprungen wird
+— sonst würde der neue Zustandstext nie erscheinen, weil der Ort vorher aus der Mail fällt.
+`outlook_state_text` wird analog zu `outlook_rows` in `section_lines` geschrieben (Zeile ~324-334,
+im `if outlook_rows:`-Zweig ergänzt um einen `elif outlook_state_text:`-Zweig).
+
+### 4. `comparison_engine.py::run()` — zwei neue WARNING-Logs
+
+Logger existiert bereits: `logger = logging.getLogger("comparison_engine")` (Zeile 32).
+
+- **(a) Fehlerfall** — aktuell komplett unprotokolliert an zwei Stellen:
+  - Zeile 132-137 (`raw_result.get("error")` → `LocationResult(error=...)`, Fetch liefert
+    strukturierten Fehler statt Exception).
+  - Zeile 349-353 (`except Exception as e` → `LocationResult(error=str(e))`).
+
+  Beide bekommen `logger.warning("Ort %s: Ausblick nicht verfügbar (Fetch-Fehler: %s)", loc.name, ...)`
+  unmittelbar vor bzw. beim Anhängen des fehlerhaften `LocationResult`.
+
+- **(b) Leere `outlook_hourly_data` nach erfolgreichem Fetch** — Zeile 167-169
+  (`outlook_hourly_data = [dp for dp, d in _by_local_day if d in _outlook_days]`): wenn das
+  Ergebnis leer ist, `logger.warning("Ort %s: kein Ausblick — keine Daten in den naechsten 3 Tagen", loc.name)`.
+
+**WICHTIG — Single-Source-Logging:** Die Logs kommen NUR hierher (Datenschicht, läuft genau
+einmal pro Ort und Vergleichslauf), NICHT in die Renderer. `render_compare_email()`
+(`comparison.py:375-`) ruft HTML- und Klartext-Renderer für dasselbe `ComparisonResult` in einem
+Aufruf (Zeile 410 ff.) — ein Log in beiden Renderern würde pro Lauf doppelt loggen.
+
+### 5. Fall „`rows` leer trotz vorhandenem `outlook_hourly_data`" — kein Log in `comparison_engine.py`
+
+Dieser dritte Ausstieg (Zeilenbildung nach Metrik-Filterung liefert nichts,
+`compare_html.py:1131`/`comparison.py:_build_location_outlook_rows`) entsteht erst im
+Renderer, NICHT in `comparison_engine.py` — `comparison_engine.py` kennt zu diesem Zeitpunkt
+weder `outlook_metrics` noch das Filterungsergebnis. Für diesen Fall gibt es bewusst KEIN
+WARNING-Log (Renderer sollen laut Punkt 4 nicht loggen); der sichtbare Zustandstext im
+HTML/Klartext ist hier der einzige Nutzer-Hinweis. Das ist eine Abweichung von AC-2/AC-3 in
+#1486 (dort loggt der Scheduler auch die Zeilenbau-Leere) — dort läuft die Zeilenbildung
+VOR der Rückgabe aus `_build_stage_trend()`, hier ist sie strukturell in den Renderern
+verortet.
+
+## Expected Behavior
+
+- **Input:** Ein Orts-Vergleich mit 1-N Orten, je Ort mit/ohne Fetch-Fehler, mit/ohne
+  Ausblicks-Rohdaten (`outlook_hourly_data`), mit/ohne nach Metrik-Filterung übrig bleibende Zeilen.
+- **Output:** HTML- UND Klartext-Ausblick zeigen JE ORT entweder die Ausblick-Tabelle (Daten
+  vorhanden) ODER den Zustandstext „Vorhersage derzeit nicht abrufbar." — nie mehr eine unerklärte
+  Leerstelle, sofern der Ort im jeweiligen Kanal überhaupt erscheint (Klartext-Fehlerfall bleibt
+  Ausnahme, s. Known Limitations).
+- **Side effects:** WARNING-Log-Einträge in `comparison_engine.py` für Fehlerfälle und leere
+  `outlook_hourly_data` (vorher keine); kein zusätzliches Logging in den Renderern.
+
+## Acceptance Criteria
+
+- **AC-1 (HTML — Fehlerfall):** Given ein Ort mit `LocationResult.error != None` / When
+  `render_compare_html()` den Ausblick-Block für diesen Ort rendert / Then erscheint der
+  Zustandstext „Vorhersage derzeit nicht abrufbar." (Danger-Styling, analog #1486 `UNAVAILABLE`)
+  statt eines leeren Strings, UND `comparison_engine.py::run()` erzeugt für diesen Ort GENAU EINEN
+  WARNING-Log-Eintrag.
+  - Test: `ComparisonEngine.run()` mit einer gemockten Fetch-Antwort, die `error` setzt bzw. eine
+    Exception wirft; prüfe den gerenderten HTML-Ausblick-Block auf den Zustandstext UND per
+    `caplog` auf genau einen WARNING-Eintrag mit Ortsbezug.
+
+- **AC-2 (HTML — leeres `outlook_hourly_data`):** Given ein Ort mit erfolgreichem Fetch, aber
+  `outlook_hourly_data == []` (z.B. Vorhersagehorizont innerhalb der 96h-Fetch-Antwort ohne
+  Datenpunkte in den drei Ausblickstagen) / When der HTML-Ausblick-Block gerendert wird / Then
+  erscheint derselbe Zustandstext, UND ein WARNING-Log-Eintrag entsteht.
+  - Test: Fixture mit `raw_data`, deren Zeitstempel alle innerhalb von `_last_detail_day` liegen
+    (keine Tage danach); prüfe gerenderten HTML-Block auf Zustandstext UND `caplog` auf WARNING.
+
+- **AC-3 (HTML — leere `rows` trotz vorhandenem `outlook_hourly_data`):** Given ein Ort mit
+  nicht-leerem `outlook_hourly_data`, aber `_build_location_outlook_rows()` liefert eine leere
+  Liste (z.B. durch eine leere `outlook_metrics`-Auswahl, Issue #1361/#1368-Pfad,
+  `compare_html.py:1095-1096`) / When der HTML-Ausblick-Block gerendert wird / Then erscheint
+  derselbe Zustandstext wie in AC-1/AC-2 (kein separater Text nötig — es ist derselbe
+  UNAVAILABLE-Zustand), UND es entsteht KEIN zusätzliches WARNING-Log in `comparison_engine.py`
+  (s. Implementation Details §5 — dieser Pfad ist Renderer-intern).
+  - Test: Ruft `_render_location_outlook()` direkt mit einem `LocationResult`, dessen
+    `outlook_hourly_data` gesetzt ist, aber `outlook_metrics=[]` übergeben wird; prüft den
+    Rückgabewert auf den Zustandstext UND per `caplog`, dass `comparison_engine` NICHT geloggt hat
+    (dieser Testfall ruft `comparison_engine.run()` gar nicht auf).
+
+- **AC-4 (Klartext — dieselben zwei Ursachen, Fehlerfall ausgenommen):** Given ein Ort mit
+  `loc_result.error is None`, aber leerem `outlook_hourly_data` ODER leeren `outlook_rows` nach
+  Filterung / When `render_comparison_text()` den Klartext-Ausblick für diesen Ort rendert / Then
+  erscheint der Zustandstext im Klartext-Ausblick-Abschnitt statt eines fehlenden Abschnitts, UND
+  der Ort bleibt in der Mail sichtbar (nicht `continue`-übersprungen).
+  - Test: `render_comparison_text()` mit einem `ComparisonResult`, dessen einziger Ort `error=None`
+    und `outlook_hourly_data=[]` hat; prüft den Klartext-Body auf Vorhandensein des Ortsnamens UND
+    des Zustandstexts.
+
+- **AC-5 (Normalfall unverändert — Regressionstest):** Given ein Ort mit erfolgreichem Fetch,
+  nicht-leerem `outlook_hourly_data` und nicht-leeren `rows` / When HTML UND Klartext gerendert
+  werden / Then erscheint unverändert die Ausblick-Tabelle (kein neuer Zustandstext), UND es
+  entsteht KEIN WARNING-Log-Eintrag für diesen Ort.
+  - Test: Bestehende Golden-Fixture mit vollständigen Ausblicksdaten durch beide Renderer laufen
+    lassen; prüft Tabellen-Marker (z.B. `OUTLOOK_HEADING` im Output) UND per `caplog`, dass kein
+    WARNING mit Ortsbezug für den Ausblick entsteht.
+
+- **AC-6 (kein Doppel-Logging):** Given ein Vergleichslauf mit einem Ort, dessen Fetch fehlschlägt
+  / When `ComparisonEngine.run()` einmal aufgerufen und anschließend
+  `render_compare_email()` (HTML + Klartext in einem Aufruf) auf dem Ergebnis ausgeführt wird /
+  Then entsteht GENAU EIN WARNING-Log-Eintrag für diesen Ort — nicht zwei, obwohl beide Renderer
+  über den Zustand entscheiden.
+  - Test: `caplog`-Zähler auf WARNING-Records mit dem betroffenen Ortsnamen nach dem vollständigen
+    Lauf (`run()` gefolgt von `render_compare_email()`), Assertion `== 1`. Test hängt direkt an
+    `comparison_engine.py`, nicht an den Renderern (Log entsteht dort, nicht in ihnen).
+
+- **AC-7 (Mehrort-Fall — keine falsche Ganz-Auslassung im HTML):** Given ein Vergleich mit 3 Orten:
+  Ort A (`FOUND`, Ausblick vorhanden), Ort B (`error != None`), Ort C (`error=None`, leeres
+  `outlook_hourly_data`) / When `render_compare_html()` gerendert wird / Then erscheinen alle drei
+  Orte mit ihrem jeweils korrekten Zustand (A: Tabelle, B und C: Zustandstext) — kein Ort
+  verschwindet komplett aus der HTML-Mail. Im Klartext fällt Ort B (Fehlerfall) laut Scope-Grenze
+  weiterhin aus dem Stundenverlauf-/Ausblick-Abschnitt heraus (Zeile 275, s. Known Limitations,
+  Korrektur 2026-08-08) — der Ortsname selbst bleibt dort im vorbestehenden Übersichtsblock mit
+  eigener Fehlerzeile sichtbar (`comparison.py:216-222`, unverändert); A und C erscheinen im
+  Stundenverlauf-/Ausblick-Abschnitt mit Tabelle bzw. Zustandstext.
+  - Test: `ComparisonResult` mit drei `LocationResult`-Einträgen wie beschrieben; prüft im
+    gerenderten HTML alle drei Ortsnamen UND je Ort den korrekten Ausblick-Zustand; prüft im
+    Klartext, dass Ort A und C erscheinen und dass im Stundenverlauf-/Ausblick-Abschnitt (nicht im
+    gesamten Mail-Body) weder Tabelle noch Zustandstext für Ort B vorkommen.
+
+## Known Limitations
+
+- **Scope-Grenze Klartext-Fehlerfall (PO-Entscheidung 2026-08-08, bewusst NICHT Teil dieses
+  Fixes; Formulierung präzisiert 2026-08-08 nach Befund aus der Implementierung):**
+  `comparison.py:275` (`if loc_result.error is not None: continue`) bleibt unverändert. Ein Ort,
+  der komplett fehlschlägt, fällt im Klartext-Teil weiterhin GANZ aus dem
+  Stundenverlauf-/Ausblick-Abschnitt heraus (weder Tabelle noch Zustandstext, für keinen der
+  beiden Bausteine). **Korrektur:** anders als ursprünglich hier formuliert verschwindet der Ort
+  dadurch NICHT aus der gesamten Mail — sein Name bleibt im vorbestehenden Übersichtsblock
+  (`comparison.py:216-222`, unverändert, jeder Ort inkl. Fehlerzeile) sichtbar; nur der
+  Stundenverlauf-/Ausblick-Teil fehlt ihm. Das ist breiter als der Ausblick-Bug dieses Fixes und
+  geht als Nebenbefund-Eintrag nach #1199 (Laufender Sammel-Issue,
+  kein eigenes Issue laut Nebenbefund-Triage) statt hier mitgefixt zu werden.
+- **Kein Compare-Äquivalent zu `NO_STAGES`/`BEYOND_HORIZON`:** Anders als #1486 (Trip, vier
+  Zustände) verwendet dieser Fix nur `FOUND`/`UNAVAILABLE`. Ein theoretischer
+  `BEYOND_HORIZON`-Fall im interaktiven Preview-Pfad (frei wählbares `target_date`, s.
+  `compare_preview_service.py`) wird NICHT gesondert behandelt — er fällt unter `UNAVAILABLE` mit
+  identischem Text. Das ist als bewusste Vereinfachung dokumentiert, keine übersehene Lücke.
+- **`_build_location_outlook_rows()`-Leere (dritte Ursache) erzeugt kein Log in
+  `comparison_engine.py`:** Dieser Pfad ist strukturell im Renderer verortet (Metrik-Filterung
+  findet erst dort statt, `comparison_engine.py` kennt `outlook_metrics` nicht). Der sichtbare
+  Zustandstext ist hier der einzige Nutzer-Hinweis, kein WARNING-Log begleitet ihn — Abweichung
+  vom Trip-Pfad (#1486), wo derselbe Fall noch im Scheduler geloggt wird, weil dort die
+  Zeilenbildung vor dem Rückgabewert von `_build_stage_trend()` liegt.
+- **Klartext-Validator-Blindfleck:** `email_spec_validator.py` (Pflicht-Validator, Marker
+  `X-GZ-Mail-Type: compare`) liest NUR den HTML-Body. Der Klartext-Nachweis (AC-4, AC-7 Klartext-
+  Teil) muss zusätzlich manuell bzw. testseitig geführt werden — bekannter, vorbestehender
+  blinder Fleck (s. Memory `reference_compare_mail_plaintext_blind_spot`), nicht Teil dieses Fixes.
+- **`render_compare_telegram`/`render_compare_sms` unverändert:** Kein Ausblick-Feature in diesen
+  Kanälen (geprüft: keine `outlook_*`-Parameter vorhanden) — dieser Fix betrifft ausschließlich
+  die E-Mail (HTML + Klartext).
+- **#1563 (Vertretungshinweis fehlt) ist ein anderer Bug** in derselben Datei
+  (`compare_html.py`), andere Zeilen — nicht Teil dieses Fixes.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine.
+- **Rationale:** Dieser Fix führt keine neue Systementscheidung ein, sondern wendet das in #1486
+  etablierte Muster (`OutlookState`, geteilter Rendering-Baustein `outlook_state_hint.py`) additiv
+  auf einen zweiten, bereits vorgesehenen Konsumenten an (`outlook_state_hint.py` war laut #1486
+  „bewusst generisch gehalten... damit derselbe Baustein später auch der Ortsvergleich nutzen
+  kann"). Die Reduktion auf zwei statt vier Zustände ist eine lokale, auf Compare beschränkte
+  Design-Wahl (kein `NO_STAGES`-Äquivalent, `BEYOND_HORIZON` praktisch ausgeschlossen im
+  Regelbetrieb) ohne Rückwirkung auf den Trip-Pfad oder andere Konsumenten von `OutlookState`.
+
+## Changelog
+
+- 2026-08-08: Initial spec created (Fix #1505, Compare-Pendant zu #1486; PO-Scope-Entscheidung zur
+  Ausklammerung von `comparison.py:275` dokumentiert).
+- 2026-08-08: TDD-GREEN-Befund eingearbeitet (AC-7, Known Limitations): die ursprüngliche
+  Formulierung „Ort verschwindet GANZ aus der Mail" war unpräzise — gemessen am unveränderten
+  Basis-Stand bleibt der Ortsname eines Fehler-Orts im Klartext-Übersichtsblock
+  (`comparison.py:216-222`) sichtbar; die Scope-Grenze betrifft nur den
+  Stundenverlauf-/Ausblick-Abschnitt. Keine Scope-Änderung, nur Präzisierung der Beschreibung.

--- a/src/output/renderers/comparison.py
+++ b/src/output/renderers/comparison.py
@@ -34,6 +34,9 @@ from output.renderers.email.compare_html import (
     _units_legend_text, _visible_hour_metrics, derive_row_labels,
     loc_hail_flag, location_render_order,
 )
+from output.renderers.email.outlook_state_hint import (
+    OutlookState, render_outlook_state_plain,
+)
 from output.renderers.email.undelivered_hint import (
     has_undelivered, render_undelivered_plain,
 )
@@ -281,7 +284,16 @@ def render_comparison_text(
             _build_location_outlook_rows(loc_result, outlook_metrics)
             if outlook_enabled and loc_result.outlook_hourly_data else []
         )
-        if not have_hourly and not outlook_rows:
+        # Fix #1505 (AC-4): bei eingeschaltetem Ausblick ohne Zeilen (weder
+        # Rohdaten noch etwas nach der Metrik-Filterung) stand hier bisher
+        # NICHTS -- der Ort fiel unten sogar ganz aus dem Abschnitt. Jetzt
+        # tritt derselbe benannte Zustand an die Stelle wie im HTML-Teil
+        # (geteilter Baustein aus #1486, keine zweite Formulierung).
+        outlook_state_text = (
+            render_outlook_state_plain(OutlookState.UNAVAILABLE)
+            if outlook_enabled and not outlook_rows else None
+        )
+        if not have_hourly and not outlook_rows and not outlook_state_text:
             continue
         # Issue #1378 (AC-3): dieselbe Ortszeit-Auflösung wie im HTML-Pfad --
         # der Pflicht-Validator liest nur HTML, der Klartext braucht die
@@ -295,9 +307,12 @@ def render_comparison_text(
         # abgeschaltetem Stundenverlauf also der des Ausblicks, nicht der
         # ungenutzten `hourly_data` (seit #1366/9ae845d8 ein realer Fall).
         _points = loc_result.hourly_data if have_hourly else loc_result.outlook_hourly_data
-        _ref = _points[0].ts
+        # Fix #1505: ohne jeden Datenpunkt (nur Zustandstext) gibt es keinen
+        # Referenzzeitpunkt -- dann steht der Ortsname ohne angeschriebene
+        # Zeitbasis da, statt eine erfundene zu behaupten (oder zu crashen).
         section_lines.append(
-            f"{loc_result.location.name} ({tz_abbrev(_ref, tz)})"
+            f"{loc_result.location.name} ({tz_abbrev(_points[0].ts, tz)})"
+            if _points else loc_result.location.name
         )
         if have_hourly:
             for dp in loc_result.hourly_data:
@@ -332,6 +347,11 @@ def render_comparison_text(
                 outlook_rows, show_acc=False, metrics=outlook_metrics,
                 heading=OUTLOOK_HEADING, show_name=False,
             ).strip("\n"))
+        elif outlook_state_text:
+            # Fix #1505 (AC-4): benannter Zustand an derselben Stelle wie
+            # sonst die Ausblick-Tabelle, unter derselben Ueberschrift.
+            section_lines.append(OUTLOOK_HEADING)
+            section_lines.append(f"   {outlook_state_text}")
         section_lines.append("")
 
     if section_lines:

--- a/src/output/renderers/email/compare_html.py
+++ b/src/output/renderers/email/compare_html.py
@@ -1112,6 +1112,35 @@ def _build_location_outlook_rows(
 OUTLOOK_HEADING = "3-Tages-Ausblick"
 
 
+def _render_outlook_unavailable(
+    loc: LocationResult, index: int, with_location: bool = False,
+) -> str:
+    """Fix #1505: benannter Ausblick-Zustand statt stillem ``""``.
+
+    Derselbe Block-Rahmen wie die Erfolgstabelle (Padding-`div` + Kopf mit
+    Eyebrow "AUSBLICK"), damit der Zustandstext an genau der Stelle steht, an
+    der sonst die Tabelle stuende. Der Zustandstext selbst kommt aus dem
+    geteilten Baustein ``outlook_state_hint`` (#1486) -- keine
+    Compare-eigene Kopie, keine neuen ``OutlookState``-Werte.
+
+    Kein Referenzzeitpunkt (``ref_ts=None``): ohne Datenpunkte gibt es keine
+    Zeitbasis, die man ehrlich anschreiben koennte."""
+    from output.renderers.email.outlook_state_hint import (
+        OutlookState, render_outlook_state_html,
+    )
+
+    title = (
+        f"{loc.location.name} · {OUTLOOK_HEADING}" if with_location
+        else OUTLOOK_HEADING
+    )
+    header = _location_heading(loc, None, eyebrow="AUSBLICK", title=title)
+    hint = render_outlook_state_html(OutlookState.UNAVAILABLE)
+    return (
+        f'<div style="padding:{20 if index else 14}px 24px 0;">'
+        f'{header}{hint}</div>'
+    )
+
+
 def _render_location_outlook(
     loc: LocationResult, index: int,
     outlook_metrics: list[dict] | None = None,
@@ -1124,12 +1153,18 @@ def _render_location_outlook(
     Issue #1368: eigene Ueberschrift "3-Tages-Ausblick" statt des ein
     zweites Mal wiederholten Ortsnamens. ``with_location=True`` stellt den
     Ortsnamen voran -- noetig, wenn der Stundenblock desselben Ortes (der
-    ihn sonst nennt) nicht gerendert wird."""
+    ihn sonst nennt) nicht gerendert wird.
+
+    Fix #1505: die drei stillen Ausstiege (Fehler, leere Rohdaten, leere
+    Zeilen nach Metrik-Filterung) sahen fuer den Empfaenger alle gleich aus
+    -- eine unerklaerte Leerstelle. Sie liefern jetzt alle denselben
+    benannten Zustand (``OutlookState.UNAVAILABLE``) ueber den geteilten
+    Baustein aus #1486 (kein Compare-eigener Nachbau)."""
     if loc.error is not None or not loc.outlook_hourly_data:
-        return ""
+        return _render_outlook_unavailable(loc, index, with_location)
     rows = _build_location_outlook_rows(loc, outlook_metrics)
     if not rows:
-        return ""
+        return _render_outlook_unavailable(loc, index, with_location)
     # Issue #1378: dieselbe angeschriebene Zeitbasis wie beim Stundenblock
     # (geteilter Kopfbau, kein zweiter) — auch die Ausblick-Tageszeilen
     # und ihre @-Stunden-Tokens stehen in dieser Zeitbasis.

--- a/src/services/comparison_engine.py
+++ b/src/services/comparison_engine.py
@@ -130,6 +130,16 @@ class ComparisonEngine:
                 raw_result = fetch_forecast_for_location(loc, forecast_hours)
 
                 if raw_result.get("error"):
+                    # Fix #1505 (AC-1): der Fetch-Fehler blieb bisher komplett
+                    # unprotokolliert -- der Ausblick des Ortes verschwand in
+                    # der Mail wortlos UND im Log stand nichts davon. Genau
+                    # EINE Meldung je Ort und Lauf: sie entsteht hier in der
+                    # Datenschicht, NICHT in den Renderern (die laufen fuer
+                    # dieselbe Mail zweimal, HTML + Klartext -- Spec §4).
+                    logger.warning(
+                        "Ort %s: Ausblick nicht verfuegbar (Fetch-Fehler: %s)",
+                        loc.name, raw_result["error"],
+                    )
                     results.append(LocationResult(
                         location=loc,
                         error=raw_result["error"],
@@ -167,6 +177,16 @@ class ComparisonEngine:
                 outlook_hourly_data = [
                     dp for dp, d in _by_local_day if d in _outlook_days
                 ]
+                if not outlook_hourly_data:
+                    # Fix #1505 (AC-2): erfolgreicher Fetch, aber kein
+                    # Datenpunkt in den drei Ausblickstagen (z.B. erschoepfter
+                    # Vorhersagehorizont). Bisher fiel der Ausblick des Ortes
+                    # dafuer wortlos aus der Mail; der Empfaenger sah eine
+                    # unerklaerte Leerstelle, das Log gar nichts.
+                    logger.warning(
+                        "Ort %s: kein Ausblick — keine Daten in den naechsten "
+                        "3 Tagen", loc.name,
+                    )
 
                 # Filter by target date and time window (Issue #1361/#1372
                 # S1b: inkl. Mitternachts-Uebergang, AC-3).
@@ -347,6 +367,14 @@ class ComparisonEngine:
                 ))
 
             except Exception as e:
+                # Fix #1505 (AC-1): zweiter, bisher ebenfalls unprotokollierter
+                # Weg zu `LocationResult(error=...)` -- gleiche Meldung wie beim
+                # strukturierten Fetch-Fehler, damit beide Ursachen im Log
+                # gleich aussehen.
+                logger.warning(
+                    "Ort %s: Ausblick nicht verfuegbar (Fetch-Fehler: %s)",
+                    loc.name, e,
+                )
                 results.append(LocationResult(
                     location=loc,
                     error=str(e),

--- a/tests/tdd/test_compare_outlook_state_named_not_silent.py
+++ b/tests/tdd/test_compare_outlook_state_named_not_silent.py
@@ -1,0 +1,454 @@
+"""Fix #1505 (TDD RED) — Orts-Vergleich: Ausblick-Zeile verschwindet still.
+
+Spec: docs/specs/modules/fix_1505_compare_outlook_silent_exit.md (AC-1..AC-7)
+Kontext: docs/context/fix-1505-compare-ausblick-zustand.md
+
+RED heute: `_render_location_outlook()` (compare_html.py) gibt bei Fehler,
+leeren Rohdaten und leeren Zeilen nach Filterung jeweils `""` zurueck; der
+Klartext-Ausblick-Block (comparison.py) laesst den Ort bei leerem Ausblick
+ganz aus der Mail entfallen. `comparison_engine.py` protokolliert weder den
+Fehlerfall noch leere Ausblicksdaten. Alle drei Ursachen sind fuer den
+Empfaenger identisch: eine unerklaerte Leerstelle bzw. ein fehlender Ort.
+
+KEINE Mocks: echte LocationResult-/ComparisonResult-/SavedLocation-DTOs,
+echte Renderer. Einzige Netz-Grenze (`fetch_forecast_for_location`) per
+Attribut-Rebind ersetzt (Muster
+`tests/tdd/test_comparison_engine_midnight_window.py`), in `finally`
+restauriert.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta, timezone
+
+_ENGINE_LOGGER = "comparison_engine"
+_STATE_TEXT = "Vorhersage derzeit nicht abrufbar."
+
+
+# ---------------------------------------------------------------------------
+# Helpers — echte Domaenen-Objekte
+# ---------------------------------------------------------------------------
+
+def _location(name="Innsbruck", loc_id="innsbruck"):
+    from app.user import SavedLocation
+
+    return SavedLocation(id=loc_id, name=name, lat=47.27, lon=11.39,
+                          elevation_m=574, timezone="UTC")
+
+
+def _day_points(day: date, temp: float = 10.0):
+    from app.models import ForecastDataPoint, ThunderLevel
+
+    return [
+        ForecastDataPoint(
+            ts=datetime(day.year, day.month, day.day, h, 0, tzinfo=timezone.utc),
+            t2m_c=temp, wind10m_kmh=10.0, gust_kmh=15.0,
+            precip_1h_mm=0.0, pop_pct=10, cloud_total_pct=30,
+            thunder_level=ThunderLevel.NONE, visibility_m=20000,
+        )
+        for h in (2, 8, 14, 20)
+    ]
+
+
+def _run_engine_with_fetch(locations, fetch_fn, *, time_window=(9, 16),
+                            target_date=None):
+    """Echte ComparisonEngine; einzige Netz-Grenze per Attribut-Rebind
+    ersetzt (kein Mock), in `finally` restauriert."""
+    import services.comparison_engine as ce_mod
+
+    target_date = target_date or date.today()
+    original = ce_mod.fetch_forecast_for_location
+    ce_mod.fetch_forecast_for_location = fetch_fn
+    try:
+        return ce_mod.ComparisonEngine.run(
+            locations=locations, time_window=time_window,
+            target_date=target_date, official_alerts_enabled=False,
+        )
+    finally:
+        ce_mod.fetch_forecast_for_location = original
+
+
+def _error_fetch(location, hours=96, settings=None):
+    return {"location": location, "error": "Kontingent erschoepft",
+            "forecast_hours": hours, "snow_source": None, "raw_data": []}
+
+
+def _raising_fetch(location, hours=96, settings=None):
+    """Zweiter Weg zu `LocationResult(error=...)`: eine Exception statt eines
+    strukturierten `error`-Feldes (Adversary F002 — dieser Zweig war
+    ungetestet, sein WARNING liess sich spurlos entfernen)."""
+    raise RuntimeError("Netzwerkfehler")
+
+
+def _today_only_fetch(location, hours=96, settings=None):
+    """Erfolgreicher Fetch, aber alle Punkte liegen am Detailtag selbst —
+    kein Datenpunkt jenseits davon, `outlook_hourly_data` bleibt leer."""
+    return {"location": location, "error": None, "forecast_hours": hours,
+            "snow_source": None, "raw_data": _day_points(date.today())}
+
+
+def _multi_day_fetch(location, hours=96, settings=None):
+    """Erfolgreicher Fetch mit Detailtag + 3 Folgetagen (Normalfall)."""
+    today = date.today()
+    points = list(_day_points(today))
+    for offset in (1, 2, 3):
+        points.extend(_day_points(today + timedelta(days=offset)))
+    return {"location": location, "error": None, "forecast_hours": hours,
+            "snow_source": None, "raw_data": points}
+
+
+def _loc_result_direct(*, error=None, outlook_hourly_data=None,
+                        hourly_data=None, name="Innsbruck"):
+    from app.user import LocationResult
+
+    return LocationResult(
+        location=_location(name, name.lower()),
+        error=error,
+        hourly_data=hourly_data or [],
+        outlook_hourly_data=outlook_hourly_data or [],
+    )
+
+
+def _comparison_result(locations):
+    from app.user import ComparisonResult
+
+    return ComparisonResult(
+        locations=locations, time_window=(9, 16), target_date=date.today(),
+        created_at=datetime.now(),
+    )
+
+
+def _engine_warnings(caplog, name=None):
+    """WARNINGs, die AUS `comparison_engine` stammen (Namensfilter)."""
+    recs = [r for r in caplog.records
+            if r.levelno >= logging.WARNING and r.name == _ENGINE_LOGGER]
+    if name:
+        recs = [r for r in recs if name in r.getMessage()]
+    return recs
+
+
+def _all_warnings(caplog, name=None):
+    """WARNINGs aus JEDEM Logger — ohne Namensfilter (Adversary F001).
+
+    `_engine_warnings()` beantwortet nur "wie oft hat die Engine geloggt?".
+    Spec §4 verlangt aber mehr: der Zustand darf ueberhaupt nur EINMAL je
+    Ort und Lauf protokolliert werden, egal aus welchem Modul — ein
+    zusaetzliches `logger.warning(...)` in einem der beiden Renderer unter
+    EIGENEM Loggernamen (`compare_html`, `comparison`) ist genau der
+    Doppel-Log, den AC-6 verbietet, und rutschte am Namensfilter vorbei.
+    Renderer-Logs propagieren zum Root-Logger und landen damit in `caplog`.
+    """
+    recs = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    if name:
+        recs = [r for r in recs if name in r.getMessage()]
+    return recs
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — HTML: Fehlerfall
+# ---------------------------------------------------------------------------
+
+def test_ac1_html_error_location_shows_state_text_and_logs_warning(caplog):
+    """AC-1: Given ein Ort mit Fetch-Fehler / When der HTML-Ausblick-Block
+    gerendert wird / Then erscheint der Zustandstext statt einer Leerstelle,
+    UND `comparison_engine.py` erzeugt genau einen WARNING-Log-Eintrag."""
+    from output.renderers.email.compare_html import render_compare_html
+
+    with caplog.at_level(logging.DEBUG, logger=_ENGINE_LOGGER):
+        result = _run_engine_with_fetch([_location()], _error_fetch)
+
+    loc_result = result.locations[0]
+    assert loc_result.error is not None, "Vorbedingung: Fetch muss fehlschlagen"
+
+    html = render_compare_html(result, outlook_enabled=True)
+    assert _STATE_TEXT in html, (
+        "Bei einem Fehler muss der Ausblick-Block einen Zustandstext zeigen "
+        f"statt zu verschwinden. HTML-Ausschnitt: ...{html[-400:]}"
+    )
+    warnings = _engine_warnings(caplog, "Innsbruck")
+    assert len(warnings) == 1, (
+        f"Erwartete genau 1 WARNING fuer den Fehler-Ort, sah "
+        f"{len(warnings)}: {[r.getMessage() for r in warnings]}"
+    )
+
+
+def test_ac1b_html_exception_during_fetch_shows_state_text_and_logs_warning(caplog):
+    """AC-1, zweiter Codepfad (Adversary F002): Given ein Ort, dessen Abruf
+    mit einer EXCEPTION abbricht (statt ein `error`-Feld zu liefern) / When
+    der HTML-Ausblick-Block gerendert wird / Then erscheint derselbe
+    Zustandstext, UND es entsteht genau ein WARNING mit Ortsbezug.
+
+    Ohne diesen Fall bewachte die Suite nur die `raw_result["error"]`-Stelle;
+    das WARNING in der `except`-Klausel liess sich ersatzlos loeschen, ohne
+    dass ein Test rot wurde."""
+    from output.renderers.email.compare_html import render_compare_html
+
+    with caplog.at_level(logging.DEBUG, logger=_ENGINE_LOGGER):
+        result = _run_engine_with_fetch([_location()], _raising_fetch)
+
+    loc_result = result.locations[0]
+    assert loc_result.error is not None, (
+        "Vorbedingung: die Exception muss zu einem Fehler-Ergebnis werden"
+    )
+    assert "Netzwerkfehler" in loc_result.error, (
+        f"Vorbedingung: der Exception-Text traegt den Fehler, war: "
+        f"{loc_result.error!r}"
+    )
+
+    html = render_compare_html(result, outlook_enabled=True)
+    assert _STATE_TEXT in html, (
+        "Auch ein Abbruch per Exception muss den Zustandstext zeigen statt "
+        f"zu verschwinden. HTML-Ausschnitt: ...{html[-400:]}"
+    )
+    warnings = _all_warnings(caplog, "Innsbruck")
+    assert len(warnings) == 1, (
+        f"Erwartete genau 1 WARNING fuer den abgebrochenen Abruf, sah "
+        f"{len(warnings)}: {[(r.name, r.getMessage()) for r in warnings]}"
+    )
+    assert "Netzwerkfehler" in warnings[0].getMessage(), (
+        "Die Meldung muss den Grund nennen, sonst ist sie im Betrieb "
+        f"wertlos: {warnings[0].getMessage()!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — HTML: leeres outlook_hourly_data nach erfolgreichem Fetch
+# ---------------------------------------------------------------------------
+
+def test_ac2_html_empty_outlook_data_shows_state_text_and_logs_warning(caplog):
+    """AC-2: Given ein Ort mit erfolgreichem Fetch, aber leerem
+    `outlook_hourly_data` / When der HTML-Ausblick-Block gerendert wird /
+    Then erscheint derselbe Zustandstext, UND ein WARNING-Log entsteht."""
+    from output.renderers.email.compare_html import render_compare_html
+
+    with caplog.at_level(logging.DEBUG, logger=_ENGINE_LOGGER):
+        result = _run_engine_with_fetch([_location()], _today_only_fetch)
+
+    loc_result = result.locations[0]
+    assert loc_result.error is None, "Vorbedingung: Fetch war erfolgreich"
+    assert loc_result.outlook_hourly_data == [], (
+        f"Vorbedingung: outlook_hourly_data muss leer sein, war: "
+        f"{loc_result.outlook_hourly_data}"
+    )
+
+    html = render_compare_html(result, outlook_enabled=True)
+    assert _STATE_TEXT in html, (
+        "Bei leeren Ausblicksdaten muss ein Zustandstext erscheinen statt "
+        f"einer Leerstelle. HTML-Ausschnitt: ...{html[-400:]}"
+    )
+    warnings = _engine_warnings(caplog, "Innsbruck")
+    assert len(warnings) == 1, (
+        f"Erwartete genau 1 WARNING fuer leere Ausblicksdaten, sah "
+        f"{len(warnings)}: {[r.getMessage() for r in warnings]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3 — HTML: leere rows trotz vorhandenem outlook_hourly_data
+# ---------------------------------------------------------------------------
+
+def test_ac3_html_empty_rows_after_filtering_shows_state_text_no_engine_log(caplog):
+    """AC-3: Given ein Ort mit nicht-leerem `outlook_hourly_data`, aber
+    `_build_location_outlook_rows()` liefert (durch eine geleerte
+    Metrik-Auswahl) keine Zeile / When der HTML-Ausblick-Block gerendert
+    wird / Then erscheint derselbe Zustandstext wie in AC-1/AC-2, UND es
+    entsteht KEIN zusaetzliches WARNING in `comparison_engine.py` (dieser
+    Pfad ist Renderer-intern, die Engine wird gar nicht aufgerufen)."""
+    from output.renderers.email.compare_html import _render_location_outlook
+
+    loc = _loc_result_direct(
+        outlook_hourly_data=_day_points(date.today() + timedelta(days=1)),
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=_ENGINE_LOGGER):
+        html = _render_location_outlook(loc, 0, outlook_metrics=[])
+
+    assert _STATE_TEXT in html, (
+        "Eine durch Metrik-Filterung leere Zeilenliste muss trotz "
+        f"vorhandener Rohdaten den Zustandstext zeigen. Ergebnis: {html!r}"
+    )
+    assert _engine_warnings(caplog) == [], (
+        "Dieser Pfad ist Renderer-intern (comparison_engine wurde gar nicht "
+        f"aufgerufen) und darf keine Engine-WARNINGs erzeugen: "
+        f"{[r.getMessage() for r in _engine_warnings(caplog)]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 — Klartext: dieselben zwei Ursachen, Fehlerfall ausgenommen
+# ---------------------------------------------------------------------------
+
+def test_ac4_plain_empty_outlook_no_error_shows_state_text_location_stays():
+    """AC-4: Given ein Ort mit `error is None`, aber leerem
+    `outlook_hourly_data` / When `render_comparison_text()` rendert / Then
+    erscheint der Zustandstext im Klartext-Ausblick-Abschnitt, UND der Ort
+    bleibt in der Mail sichtbar (nicht `continue`-uebersprungen)."""
+    from output.renderers.comparison import render_comparison_text
+
+    loc = _loc_result_direct(error=None, outlook_hourly_data=[],
+                              name="Alphaville")
+    result = _comparison_result([loc])
+
+    text = render_comparison_text(result, outlook_enabled=True)
+
+    assert "Alphaville" in text, (
+        "Ein fehlerfreier Ort mit leerem Ausblick darf im Klartext NICHT "
+        f"komplett verschwinden. Text: {text!r}"
+    )
+    assert _STATE_TEXT in text, (
+        "Der Klartext muss den Zustandstext zeigen statt eines fehlenden "
+        f"Ausblick-Abschnitts. Text: {text!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — Normalfall unveraendert (Regressionstest)
+# ---------------------------------------------------------------------------
+
+def test_ac5_found_state_unchanged_no_state_text_no_warning(caplog):
+    """AC-5: Given ein Ort mit erfolgreichem Fetch und Daten fuer 3
+    Folgetage / When HTML UND Klartext gerendert werden / Then erscheint
+    unveraendert die Ausblick-Tabelle (kein neuer Zustandstext), UND es
+    entsteht KEIN WARNING fuer diesen Ort."""
+    from output.renderers.comparison import render_comparison_text
+    from output.renderers.email.compare_html import (
+        OUTLOOK_HEADING, render_compare_html,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=_ENGINE_LOGGER):
+        result = _run_engine_with_fetch([_location()], _multi_day_fetch)
+
+    loc_result = result.locations[0]
+    assert loc_result.error is None
+    assert loc_result.outlook_hourly_data, (
+        "Vorbedingung: outlook_hourly_data darf fuer den Normalfall nicht "
+        "leer sein"
+    )
+
+    html = render_compare_html(result, outlook_enabled=True)
+    text = render_comparison_text(result, outlook_enabled=True)
+
+    assert OUTLOOK_HEADING in html, (
+        f"Normalfall muss die Ausblick-Tabelle zeigen. HTML-Ausschnitt: "
+        f"...{html[-400:]}"
+    )
+    assert _STATE_TEXT not in html, (
+        "Im Normalfall darf KEIN Zustandstext erscheinen — Daten sind "
+        f"vorhanden. HTML enthaelt faelschlich: {_STATE_TEXT!r}"
+    )
+    assert _STATE_TEXT not in text, (
+        "Im Normalfall darf KEIN Zustandstext im Klartext erscheinen — "
+        f"Daten sind vorhanden. Text: {text!r}"
+    )
+    warnings = _engine_warnings(caplog, "Innsbruck")
+    assert warnings == [], (
+        f"Der Normalfall ist kein Stoerfall und darf NICHT protokolliert "
+        f"werden: {[r.getMessage() for r in warnings]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-6 — kein Doppel-Logging (HTML + Klartext in einem Mail-Aufbau)
+# ---------------------------------------------------------------------------
+
+def test_ac6_no_duplicate_warning_across_html_and_plain_render(caplog):
+    """AC-6: Given ein Vergleichslauf mit einem Fehler-Ort / When
+    `ComparisonEngine.run()` einmal laeuft und anschliessend
+    `render_compare_email()` (HTML + Klartext in einem Aufruf) auf dem
+    Ergebnis ausgefuehrt wird / Then entsteht GENAU EIN WARNING-Log-Eintrag
+    fuer diesen Ort — nicht zwei, obwohl beide Renderer ueber den Zustand
+    entscheiden."""
+    from output.renderers.comparison import render_compare_email
+
+    with caplog.at_level(logging.DEBUG, logger=_ENGINE_LOGGER):
+        result = _run_engine_with_fetch([_location()], _error_fetch)
+        render_compare_email(result, outlook_enabled=True)
+
+    # Adversary F001: OHNE Logger-Namensfilter. Der frueher hier benutzte
+    # `_engine_warnings()` haette einen zweiten Log-Aufruf aus einem der
+    # Renderer (eigener Loggername) nicht gesehen — die Mutation "zusaetzliches
+    # logger.warning('compare_html') in `_render_outlook_unavailable`" liess
+    # alle sieben Tests gruen. Geprueft wird jetzt die Zusicherung selbst:
+    # genau EINE Meldung zu diesem Ort im gesamten Lauf, aus welchem Modul
+    # auch immer.
+    warnings = _all_warnings(caplog, "Innsbruck")
+    assert len(warnings) == 1, (
+        f"Erwartete GENAU 1 WARNING (ueber ALLE Logger) trotz HTML+Klartext "
+        f"im selben Mail-Aufbau, sah {len(warnings)}: "
+        f"{[(r.name, r.getMessage()) for r in warnings]}"
+    )
+    assert warnings[0].name == _ENGINE_LOGGER, (
+        "Die eine Meldung muss aus der Datenschicht kommen "
+        f"({_ENGINE_LOGGER}), nicht aus einem Renderer — sah "
+        f"{warnings[0].name!r}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-7 — Mehrort-Fall: keine falsche Ganz-Auslassung im HTML
+# ---------------------------------------------------------------------------
+
+def test_ac7_multi_location_html_shows_all_three_with_correct_state():
+    """AC-7: Given ein Vergleich mit 3 Orten (A: FOUND, B: error != None,
+    C: error=None mit leerem outlook_hourly_data) / When
+    `render_compare_html()` gerendert wird / Then erscheinen alle drei Orte
+    mit ihrem jeweils korrekten Zustand — kein Ort verschwindet komplett aus
+    der HTML-Mail. Im Klartext verschwindet Ort B (Fehlerfall) laut
+    Scope-Grenze weiterhin GANZ (comparison.py:275, PO-Entscheidung
+    2026-08-08); A und C erscheinen."""
+    from output.renderers.comparison import render_comparison_text
+    from output.renderers.email.compare_html import render_compare_html
+
+    loc_a = _loc_result_direct(
+        error=None,
+        outlook_hourly_data=_day_points(date.today() + timedelta(days=1)),
+        hourly_data=_day_points(date.today()),
+        name="OrtA",
+    )
+    loc_b = _loc_result_direct(error="Kontingent erschoepft", name="OrtB")
+    loc_c = _loc_result_direct(error=None, outlook_hourly_data=[], name="OrtC")
+    result = _comparison_result([loc_a, loc_b, loc_c])
+
+    html = render_compare_html(result, outlook_enabled=True)
+    for name in ("OrtA", "OrtB", "OrtC"):
+        assert name in html, (
+            f"Ort {name} muss in der HTML-Mail erscheinen — kein Ort darf "
+            f"komplett fehlen. HTML-Laenge: {len(html)}"
+        )
+    assert html.count(_STATE_TEXT) == 2, (
+        "Erwartete den Zustandstext genau bei den zwei betroffenen Orten "
+        f"(B, C), fand ihn {html.count(_STATE_TEXT)}x. "
+        f"HTML-Ausschnitt: ...{html[-600:]}"
+    )
+
+    text = render_comparison_text(result, outlook_enabled=True)
+    assert "OrtA" in text and "OrtC" in text, (
+        f"Orte A und C muessen im Klartext erscheinen. Text: {text!r}"
+    )
+    # Scope-Grenze (comparison.py:275, PO-Entscheidung 2026-08-08): der
+    # Fehler-Ort faellt aus dem Stundenverlauf-/Ausblick-Abschnitt heraus --
+    # dort bekommt er weder Tabelle noch Zustandstext.
+    #
+    # GEMESSEN am Basis-Commit (vor diesem Fix): der Ortsname erscheint im
+    # Klartext trotzdem, naemlich im Uebersichtsblock DARUEBER, mit eigener
+    # Fehlerzeile ("OrtB / Fehler: Kontingent erschoepft",
+    # comparison.py:216-222). Die urspruengliche Fassung dieser Zeile
+    # (`"OrtB" not in text`) war deshalb schon vor der Implementierung
+    # unerfuellbar und haette nur durch eine Aenderung ausserhalb dieses
+    # Fixes gruen werden koennen. Geprueft wird jetzt der Abschnitt, den die
+    # Scope-Grenze tatsaechlich betrifft.
+    section = text[text.index("STUNDENVERLAUF"):]
+    assert "OrtB" not in section, (
+        "Ort B (Fehlerfall) muss laut Scope-Grenze (comparison.py:275) "
+        f"aus dem Stundenverlauf-/Ausblick-Abschnitt entfallen. "
+        f"Abschnitt: {section!r}"
+    )
+    assert section.count(_STATE_TEXT) == 1, (
+        "Im Klartext-Abschnitt darf NUR Ort C den Zustandstext tragen (Ort B "
+        f"entfaellt dort ganz), fand ihn {section.count(_STATE_TEXT)}x. "
+        f"Abschnitt: {section!r}"
+    )
+    assert "Fehler: Kontingent erschoepft" in text, (
+        "Der Fehler von Ort B bleibt im Uebersichtsblock sichtbar "
+        f"(Bestandsverhalten, unveraendert). Text: {text!r}"
+    )


### PR DESCRIPTION
Der 3-Tages-Ausblick verschwindet bei Fehler, leeren Ausblicksdaten oder
leeren Zeilen nach Metrik-Filterung nicht mehr wortlos aus HTML- und
Klartext-Mail, sondern zeigt "Vorhersage derzeit nicht abrufbar." — Wieder-
verwendung von OutlookState.UNAVAILABLE aus #1486 (outlook_state_hint.py,
unveraendert). comparison_engine.py protokolliert Fehlerfaelle und leere
Ausblicksdaten jetzt als WARNING (vorher unprotokolliert).

Adversary-Verdict: VERIFIED (2 Runden, 8 ACs, 12 Checklisten-Punkte).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Boo9S4srN3ZYLRiuhipci7
