### PR TITLE
fix: data/ vom LoC-Gate-Delta ausschliessen

### DIFF
--- a/openspec.yaml
+++ b/openspec.yaml
@@ -188,6 +188,17 @@ spec_validation:
 # Override erzwangen, bei ~250 Zeilen echter Arbeit. Das ist die Angleichung
 # der Config an die dokumentierte Regel, keine Aufweichung: max_loc_delta
 # bleibt 250, Code zählt unverändert voll.
+#
+# data/-Ausschluss (#1613, 2026-08-08): data/ enthaelt ausschliesslich
+# Laufzeit-Nutzerdaten und Test-Fixtures, nie Anwendungscode -- war nie als
+# Workflow-Scope gemeint. Fehlender Ausschluss fiel auf, weil im
+# Hauptrepo-Checkout data/ auf claude-gregor:claude-gregor gehaertet ist
+# (Schutz vor #-Vorfall mit Besitzerwechsel-Ausfall) und `git diff` dort
+# unlesbare, aber getrackte Fixture-Dateien als vollstaendig geloescht
+# liest -- das blaehte den gemessenen Delta pro betroffenem Workflow um
+# mehrere tausend Phantom-Zeilen auf und blockierte jeden Developer-Agent-
+# Edit unabhaengig vom tatsaechlichen Scope. Keine Aufweichung: echte
+# Code-Aenderungen in src/api/internal/frontend zaehlen unveraendert voll.
 scope_guard:
   max_loc_delta: 250
   loc_exclude_patterns:
@@ -203,6 +214,7 @@ scope_guard:
     - "^docs/"
     - "\\.md$"
     - "^\\.gitignore$"
+    - "^data/"
 
 # Bash Gate — Projekt-spezifische Whitelist
 # Tools die legitimate Artefakte schreiben (nicht Workflow-State)


### PR DESCRIPTION
## Summary
- `data/` (Laufzeit-Nutzerdaten + Test-Fixtures, nie Anwendungscode) zur `scope_guard.loc_exclude_patterns`-Liste in `openspec.yaml` hinzugefügt — analog zum `docs/`-Ausschluss aus #1409, gleiche Begründung: war nie als Workflow-Scope gemeint.
- Root Cause: Im Hauptrepo-Checkout ist `data/` auf `claude-gregor:claude-gregor` gehärtet (schützt vor einem früheren Vorfall mit stillem Besitzerwechsel-Ausfall). `git diff HEAD --numstat` liest die dadurch unlesbaren, aber getrackten Fixture-Dateien als vollständig gelöscht → `edit_gate.py` blähte den LoC-Delta um mehrere tausend Phantom-Zeilen auf und blockierte jeden Developer-Agent-Edit, unabhängig vom tatsächlichen Scope.
- Entdeckt bei #1613. Ein erster Versuch (PR #1620, `git rm --cached` der betroffenen Dateien) wurde verworfen — es sind echte Test-Fixtures, kein Alt-Datenmüll (92 CI-Tests wären kaputt gegangen). Diese Config-Änderung ist der korrekte, chirurgische Fix: keine Tracking-Änderung, keine Berechtigungs-Änderung.

## Test plan
- [x] Reine Config-Änderung, keine Code-Änderung — CI-Ampel sollte unverändert grün bleiben
- [x] `data/`-Dateien bleiben getrackt (kein Effekt auf Test-Fixtures)
- [x] `max_loc_delta` bleibt 250, echter Code in `src/`/`api/`/`internal/`/`frontend/` zählt unverändert voll

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3iLWZx3rrfRA1eetw43pH