### PR TITLE
fix(#1595): hartkodierte Datenwurzeln auf get_data_root umgestellt

### DIFF
--- a/docs/context/fix-1595-datenwurzel-umzug.md
+++ b/docs/context/fix-1595-datenwurzel-umzug.md
@@ -1,0 +1,209 @@
+# Context: fix-1595-datenwurzel-umzug
+
+**Issue:** [#1595](https://github.com/henemm/gregor_zwanzig/issues/1595)
+**Erstellt:** 2026-08-08
+**Alle Angaben gemessen** am Stand `main` = `354f57d7`, nicht aus Dokumenten übernommen.
+
+## Request Summary
+
+Die Produktivdaten liegen unter `/home/hem/gregor_zwanzig/data/` — demselben Verzeichnis, in dem alle Claude-Sessions, Tests und Skripte als User `hem` arbeiten. Sie sollen an einen Ort außerhalb des Arbeitsbaums umziehen, damit Testläufe und Sessions sie konstruktiv nicht mehr erreichen können.
+
+## Warum jetzt
+
+Dritter Schaden aus derselben Wurzel:
+
+| Wann | Was |
+|---|---|
+| #1265 | Testdaten-Müll im Produktiv-Datenbaum, Bereinigung nötig |
+| ADR-0028 / #1284 (16.07.) | Playwright-E2E schrieb monatelang unbemerkt in den Prod-Baum: 153 Vergleichs-Abos mit `@example.com`-Empfängern im Konto `admin`, 133 täglich um 06:00 fällig |
+| 07.08. (#1595) | Rechte-Drift sperrte den Dienst aus `henning/user.json` aus; Anmeldung einen Tag tot, Meldung „falsches Kennwort" |
+
+ADR-0028 hat den sauberen Weg (`GZ_DATA_DIR`) erwogen und verworfen — Begründung: *„`scheduler_dispatch_service.py:141` hardcodet `data_root = "data"`"*. Nachgemessen sind es **vier** Stellen allein in dieser Datei. Die Entscheidung fiel auf falscher Tatsachengrundlage.
+
+## Ist-Zustand: wie die Datenwurzel heute bestimmt wird
+
+Zentrale, korrekte Auflösung existiert in **beiden** Sprachen und liest **dieselbe** Variable `GZ_DATA_DIR`:
+
+| Sprache | Stelle | Kette |
+|---|---|---|
+| Python | `src/app/loader.py:1083` `get_data_root()` | `_DATA_ROOT` (Test-Fixture) > `GZ_DATA_DIR` > `Path("data")` |
+| Go | `internal/config/config.go:9` `DataDir` | `envconfig.Process("GZ", …)` ⇒ `GZ_DATA_DIR`, Default `"data"` |
+
+**Der Default ist relativ.** Er wird gegen das `WorkingDirectory` des Prozesses aufgelöst — dort sitzt das eigentliche Problem.
+
+## Related Files
+
+### Python-Kern — 12 Stellen legen die Wurzel selbst fest
+
+| Datei:Zeile | Art |
+|---|---|
+| `src/services/scheduler_dispatch_service.py:148` | `data_root = "data"` |
+| `src/services/scheduler_dispatch_service.py:174` | `data_root = "data"` |
+| `src/services/scheduler_dispatch_service.py:226` | `data_root = "data"` |
+| `src/services/scheduler_dispatch_service.py:454` | `data_root = "data"` |
+| `src/services/dispatch_orchestrator.py:100` | `self._data_root = data_root or "data"` |
+| `src/app/loader.py:294` | `load_compare_presets(data_root: Union[str, Path] = "data")` |
+| `src/app/loader.py:1142` | `list_all_user_ids(data_dir="data")` |
+| `src/app/loader.py:1170` | `lookup_user_by_email(data_dir="data")` |
+| `src/app/loader.py:1192` | `lookup_user_by_telegram_chat_id(data_dir="data")` |
+| `src/output/channels/email.py:239` | `_load_resend_allowlist(data_dir="data")` |
+| `src/services/inbound_email_reader.py:220` | Parameter-Default `data_dir="data"` |
+| `src/services/inbound_telegram_reader.py:378` | Parameter-Default `data_dir="data"` |
+
+### Go — 2 relevante Stellen
+
+| Datei:Zeile | Art |
+|---|---|
+| `internal/mail/sender.go:186` | `return "data"` als Fallback |
+| `internal/provider/openmeteo/calllog.go:18` | Paket-Variable `filepath.Join("data","diagnostics",…)` — umgeht die Config vollständig |
+
+Unkritisch: `cmd/migrate1257/main.go:15`, `cmd/migrate1258/main.go:15` (Flag-Defaults von Einmal-Werkzeugen).
+
+### Betriebsseite — lag NICHT in der ursprünglichen Inventur
+
+| Ort | Art | Repo |
+|---|---|---|
+| `deploy-gregor-prod.sh:248` | `cd $REPO_DIR && migrate_1250_briefings.py --root data/users` (relativ) | henemm-infra |
+| `auto-deploy-gregor-staging.sh:141` | identisch | henemm-infra |
+| `gregor-staging-sweep.sh:25` | `R=/home/hem/gregor_zwanzig_staging/data` (absolut) | henemm-infra |
+| `check-gregor20.sh:880-881` | absolute Prod-/Staging-Pfade (neu aus #182) | henemm-infra |
+| `scripts/setup_staging_validator_trip.py:35` | **dritte** Variable `GZ_STAGING_DATA_DIR`, Default absolut | gregor_zwanzig |
+
+Cron ruft `setup_staging_validator_trip.py` täglich 04:15 mit `cd /home/hem/gregor_zwanzig` (Prod-Verzeichnis!) und gesetztem `GZ_STAGING_DATA_DIR` auf Staging auf — eine Kreuzung, die beim Umzug bricht, wenn man nur an die Dienste denkt.
+
+## Betriebs-Ist: Zuordnung existiert praktisch nicht
+
+| Dienst | `WorkingDirectory` | `GZ_DATA_DIR` |
+|---|---|---|
+| `gregor-api` (Prod) | `/home/hem/gregor_zwanzig` | **nicht gesetzt** |
+| `gregor-python` (Prod) | `/home/hem/gregor_zwanzig` | **nicht gesetzt** |
+| `gregor-api-staging` | `/home/hem/gregor_zwanzig_staging` | gesetzt |
+| `gregor-python-staging` | `/home/hem/gregor_zwanzig_staging` | **nicht gesetzt** |
+
+Auch in keiner `.env` gesetzt. **In 3 von 4 Diensten entscheidet allein das Arbeitsverzeichnis**, welchen Datenbestand ein Prozess anfasst.
+
+## Umfang der Daten
+
+79 MB, 280 Einträge, drei Unterbäume: `data/users/`, `data/cache/`, `data/diagnostics/`. Ob `cache/` und `diagnostics/` mitziehen, ist eine Entscheidung der Analyse — `calllog.go:18` schreibt nach `data/diagnostics` an der Config vorbei.
+
+## Existing Specs & ADRs
+
+| Dokument | Bezug |
+|---|---|
+| ADR-0031 | Legt dateibasierte JSON-Persistenz unter `data/users/{user_id}/` fest. Entscheidet **Format und Struktur, nicht den Ort** — rückwirkend dokumentiert 2026-07-22 als „gelebte Praxis". Der Umzug widerspricht ihr nicht, ergänzt sie aber um eine nie getroffene Ortsentscheidung ⇒ ADR-Nachtrag nötig. |
+| ADR-0028 | Verwarf `GZ_DATA_DIR` auf falscher Tatsachengrundlage; wird durch diesen Umbau abgelöst. |
+| ADR-0003 | Mandantentrennung — bleibt unberührt. |
+| `docs/specs/_archive/modules/issue_1265_prod_testdata_cleanup.md` | Historie, kein Ist-Stand |
+| `docs/specs/_archive/modules/fix_1284_admin_prod_testdata.md` | Historie, kein Ist-Stand |
+
+## Dependencies
+
+- **Upstream:** systemd-Units (henemm-infra), `.env`-Dateien, `WorkingDirectory`, Dateirechte/ACLs des Zielorts (Dienst läuft als `claude-gregor`).
+- **Downstream:** alle drei Dienste, Scheduler, Anmeldung, Mail-Allowlist, Tier-Auflösung, Inbound-Handler, Deploy- und Sweep-Skripte, `check-gregor20.sh`, Backup.
+
+## Risks & Considerations
+
+1. **Unvollständige Inventur ist das Hauptrisiko.** Die Liste stammt aus Textsuche; ADR-0028 irrte schon einmal, und ein erstes Suchmuster dieser Messung verfehlte bekannte Treffer. Gegenmaßnahme: Der Nachweis kommt nicht aus der Liste, sondern aus einem **Laufzeit-Test auf Staging** mit leerem Zielort — was noch am alten Ort kratzt, meldet sich selbst.
+2. **Stiller Zwischenzustand.** Eine nicht umgestellte Stelle findet den alten Pfad leer vor und legt dort möglicherweise neue Daten an, die niemand mehr liest. Deshalb: erst Code umstellen und verifizieren, dann Daten bewegen — nie umgekehrt.
+3. **Symlink als Rückfahrkarte, nicht als Lösung.** Ein Verweis am alten Ort hält alles am Laufen, konserviert aber genau die Gefahr (ein Test folgt ihm in die Live-Daten). Nur befristet, mit Enddatum.
+4. **Backup war nicht vorhanden.** `backup.sh` sichert `data/` nicht (henemm-infra#184); jüngste Sicherung war 24 Tage alt. Vollsicherung vor Beginn erstellt und verifiziert (280/280 Einträge): `.backups/prod-data-pre-1595-20260808.tar.gz`.
+5. **Zwei Repos.** Systemd-Units und Betriebsskripte liegen in henemm-infra — die Auslieferung ist nicht atomar. Reihenfolge muss so gewählt sein, dass jeder Zwischenstand lauffähig bleibt.
+6. **Rechte am Zielort.** Der Rechte-Unfall vom 07.08. darf sich nicht wiederholen: Der Zielort braucht Besitzer `claude-gregor` und eine Default-ACL, die dem Dienst Zugriff sichert. `check-gregor20.sh` (#182) überwacht das bereits.
+7. **Atomares Schreiben braucht dasselbe Dateisystem.** `writeFileAtomic` legt die tmp-Datei im Zielverzeichnis an — beim Umzug unkritisch, solange der gesamte Datenbaum auf einem Dateisystem liegt.
+
+---
+
+# Analysis
+
+**Typ:** Feature (strukturelle Härtung; kein Produkt-Fehlverhalten, sondern eine nie getroffene Ortsentscheidung)
+
+## Entscheidung 1 — Zielort: `/var/lib/gregor` bzw. `/var/lib/gregor-staging`
+
+Gewählt, weil vier Dinge zusammenfallen:
+
+- **FHS-Standard** für veränderliche Anwendungsdaten. Kein Sonderweg, den Nachfolger erst verstehen müssen.
+- **systemd `StateDirectory=gregor`** legt das Verzeichnis an, setzt Besitzer auf den Dienst-User und die Rechte bei jedem Start neu. Damit ist die Rechte-Drift vom 07.08. **strukturell** erledigt, nicht nur überwacht. `StateDirectoryMode=0750` — der Baum enthält Kennwort-Hashes und darf nicht weltlesbar sein.
+- **Beide Dienste laufen als `claude-gregor`** (gemessen: `gregor-api` und `gregor-python`) — ein gemeinsames Verzeichnis ist konfliktfrei.
+- **Gleiches Dateisystem** wie das Repo (beide `/dev/sda1`): Der Umzug ist ein `mv`, also atomar und sekundenschnell — kein Kopiervorgang, der halbfertig unterbrochen werden kann.
+
+Verworfen: `/home/hem/gregor-data`. Einfacher anzulegen, aber weiterhin im Home-Bereich, ohne Standardbezug und ohne den systemd-Rechte-Automatismus.
+
+## Entscheidung 2 — alle drei Unterbäume ziehen um
+
+`users/`, `cache/` und `diagnostics/` gemeinsam. Ein halb geleertes `data/` im Repo wäre eine Falle für jeden, der später hineinschaut.
+
+**Nebenwirkung, die das Ziel schärft:** Nach dem Umzug enthält `data/` im Repo nur noch die 13 versionierten Test-Fixtures. Ein Test, der relativ auf `data/` zeigt, findet damit genau das, was er finden soll — Fixtures statt Livedaten. Aus dem Unfallort wird ein Fixture-Ordner.
+
+## Entscheidung 3 — eine einzige Quelle für den Pfad
+
+`/etc/gregor/data-prod.env` und `/etc/gregor/data-staging.env` mit `GZ_DATA_DIR=…`, geladen von den systemd-Units (`EnvironmentFile=`) **und** von den Cron-/Betriebsskripten. `/etc/gregor/` existiert bereits (`mail-prod.env`).
+
+Grund: Der Pfad darf nicht an fünf Stellen dupliziert werden — genau das hat die heutige Lage erzeugt. Rechte `644 root:root`; ein Pfad ist keine Geheiminformation, und die Skripte laufen unter verschiedenen Benutzern.
+
+Die dritte Variable `GZ_STAGING_DATA_DIR` (`scripts/setup_staging_validator_trip.py:35`) wird auf dieselbe Quelle zurückgeführt.
+
+## Entscheidung 4 — das Staging-Messverfahren (Kern der Absicherung)
+
+Die Inventur ist der **Startpunkt**, nicht der Nachweis. Textsuche hat in diesem Vorgang bereits zweimal getrogen (ADR-0028: eine statt vier Stellen; erstes Suchmuster verfehlte bekannte Treffer). Der Beweis muss vom laufenden System kommen.
+
+**Stufe A — sanft, 24 Stunden.** Staging-Daten nach `/var/lib/gregor-staging` verschieben, `GZ_DATA_DIR` für alle Staging-Dienste setzen, den alten Ordner umbenennen. Wer den relativen Pfad benutzt, **legt einen neuen `data/`-Ordner an** — dessen Inhalt verrät, wer es war. Der Zeitraum deckt die Cronjobs 04:15 und 04:30 sowie die 05:00-Briefings ab.
+
+**Stufe B — scharf, kurz.** Am alten Ort eine *Datei* namens `data` anlegen (kein Verzeichnis). Jeder Zugriff auf `data/…` scheitert dann mit „Not a directory" — **laut, im Log**, statt still ins Leere zu laufen. Stufe A findet nur die Schreiber; Stufe B findet auch die Leser, die sonst stillschweigend leere Ergebnisse zurückgeben (das Muster „leer ≠ unbekannt" aus #1492).
+
+Erwartetes Ergebnis von Stufe B ist ein kurzzeitig kaputtes Staging. Das ist der Zweck, nicht der Unfall.
+
+## Entscheidung 5 — Reihenfolge und Rückfahrkarte
+
+Code **vor** Daten. Eine nicht umgestellte Stelle fände den alten Pfad sonst leer vor und legte dort möglicherweise still neue Daten an, die niemand mehr liest — der Schaden fiele erst Tage später auf.
+
+Für Produktion: nach dem `mv` ein Symlink `data → /var/lib/gregor` als Rückfahrkarte, **befristet auf 7 Tage**. Er hält im Fehlerfall alles am Laufen, konserviert aber genau die Gefahr (ein Test folgt ihm in die Livedaten) — deshalb mit Enddatum, nicht „bis auf Weiteres".
+
+Rollback unter zwei Minuten: Symlink entfernen, `mv` zurück, `GZ_DATA_DIR` aus der env-Datei nehmen, Dienste neu starten. Sicherung liegt verifiziert vor (`.backups/prod-data-pre-1595-20260808.tar.gz`, 280/280 Einträge).
+
+## Scheibenschnitt
+
+Fünf Scheiben, **jede ein eigener Workflow** — das 250-LoC-Limit ist pro Workflow, und jede Scheibe muss einzeln auslieferbar und einzeln rücknehmbar sein.
+
+| # | Inhalt | Prod-Eingriff | Risiko |
+|---|---|---|---|
+| **S1** | Staging-Messverfahren (Stufe A + B), Befund dokumentieren | nein | niedrig |
+| **S2** | Code umstellen: 14 bekannte Stellen + Funde aus S1 | nein | mittel |
+| **S3** | Betrieb: systemd `StateDirectory`, zentrale env-Dateien, 4 Betriebsskripte (zwei Repos) | Staging | mittel |
+| **S4** | Prod-Umzug mit Symlink-Rückfahrkarte | **ja** | hoch |
+| **S5** | Nachsorge: ADR, Symlink entfernen, Backup aufnehmen (henemm-infra#184) | ja | niedrig |
+
+S1 liefert die Grundlage für S2 — der Umfang von S2 steht erst danach fest.
+
+## Affected Files
+
+| Datei | Änderung | Anmerkung |
+|---|---|---|
+| `src/services/scheduler_dispatch_service.py` | MODIFY | 4 Stellen |
+| `src/services/dispatch_orchestrator.py` | MODIFY | 1 |
+| `src/app/loader.py` | MODIFY | 4 (Zeile 1083 bleibt — das ist die zentrale Auflösung) |
+| `src/output/channels/email.py` | MODIFY | 1 |
+| `src/services/inbound_email_reader.py` | MODIFY | 1 |
+| `src/services/inbound_telegram_reader.py` | MODIFY | 1 |
+| `internal/mail/sender.go` | MODIFY | Fallback auf Config zurückführen |
+| `internal/provider/openmeteo/calllog.go` | MODIFY | Paket-Variable → Config |
+| `scripts/setup_staging_validator_trip.py` | MODIFY | dritte Variable zusammenführen |
+| `docs/adr/00XX-datenwurzel-ausserhalb-arbeitsbaum.md` | CREATE | neu |
+| `docs/adr/0031-…`, `0028-…` | MODIFY | Ergänzung / „abgelöst durch" |
+| henemm-infra: 4 Skripte + 4 systemd-Units + 2 env-Dateien | MODIFY/CREATE | eigener PR |
+
+## Scope Assessment
+
+- Dateien: ~14 im Projekt-Repo, ~10 in henemm-infra
+- Geschätzt: +150 / −40 LoC im Code (die Masse sind Einzeiler), dazu Betriebs-Konfiguration
+- **Risiko: HIGH** — Produktivdaten, Anmeldung, Scheduler, zwei Repos ohne atomare Auslieferung
+
+## Open Questions
+
+Keine fachlichen offen. Zwei Punkte zur Kenntnis für den PO, keine Entscheidungsfragen:
+
+- Staging ist während S1 Stufe B **absichtlich kurzzeitig kaputt**.
+- Der Prod-Umzug (S4) braucht wenige Sekunden Dienst-Stillstand.
+
+## Next
+
+`/30-write-spec` — Spezifikation für **S1** (Staging-Messverfahren). Die Folge-Scheiben bekommen eigene Specs, weil ihr Umfang erst nach S1 feststeht.

--- a/docs/specs/fast/fix-1595-s2-codepfade.md
+++ b/docs/specs/fast/fix-1595-s2-codepfade.md
@@ -1,0 +1,39 @@
+# Mini-Spec: Hartkodierte Datenwurzeln auf die zentrale Aufloesung umstellen
+
+Folgearbeit zu #1595. Die Produktivdaten liegen seit 2026-08-08 unter
+`/var/lib/gregor`, gesteuert ueber `GZ_DATA_DIR`. Die hier genannten Stellen
+ignorieren die Variable und zeigen auf einen leeren Ordner im Repo.
+
+## Was sich aendert
+
+- 12 Stellen im Python-Kern: Default `"data"` → `None`, Aufloesung im
+  Funktionskoerper ueber `get_data_root()`. Ein Aufruf im Default-Argument
+  waere frueh gebunden und wuerde die Testfixture `_DATA_ROOT` aushebeln.
+- 2 Stellen in Go auf `config.DataDir` bzw. `GZ_DATA_DIR` zurueckfuehren.
+  `calllog.go` wertet heute beim Paket-Import aus, also vor jeder Config.
+
+Dateien: `loader.py`, `scheduler_dispatch_service.py`, `dispatch_orchestrator.py`,
+`email.py`, `inbound_email_reader.py`, `inbound_telegram_reader.py`,
+`sender.go`, `calllog.go`.
+
+## Was sich NICHT aendern darf
+
+- `get_data_root()` (loader.py:1083) bleibt unberuehrt — das ist das Ziel, auf
+  das die anderen zeigen sollen.
+- Verhalten ohne gesetztes `GZ_DATA_DIR`: unveraendert Fallback `"data"`.
+- Keine Umbenennungen, kein Refactoring, keine neuen Features.
+
+## Manuelle Test-Schritte
+
+1. `uv run pytest tests/unit/test_data_root_switch.py -v` gruen
+2. Tests der beruehrten Module (einzeln benannt) gruen
+3. `go build ./...` fehlerfrei
+4. Nach dem Deploy: Anmeldung in Produktion antwortet weiterhin im
+   Millisekunden-Bereich (bcrypt laeuft = Nutzerdatei wird gefunden), nicht in
+   Mikrosekunden.
+
+## Acceptance Criteria
+
+- **AC-1:** Given `GZ_DATA_DIR` zeigt auf einen anderen Ort, When einer der umgestellten Codepfade ausgefuehrt wird, Then liest und schreibt er unter diesem Ort und nicht mehr unter dem relativen Pfad `data`.
+- **AC-2:** Given `GZ_DATA_DIR` ist nicht gesetzt, When derselbe Code laeuft, Then verhaelt er sich unveraendert zum Stand vorher (Fallback `data`).
+- **AC-3:** Given der Prod-Deploy ist durch, When eine Anmeldung erfolgt, Then wird die Nutzerdatei gefunden — messbar an einer Antwortzeit im Millisekundenbereich statt im Mikrosekundenbereich.

--- a/docs/specs/modules/fix_1595_s1_staging_messverfahren.md
+++ b/docs/specs/modules/fix_1595_s1_staging_messverfahren.md
@@ -101,6 +101,17 @@ Staging läuft danach wieder normal.
 
 ## Known Limitations
 
+### Restrisiken des Werkzeugs (Adversary Runde 3, real getestet)
+
+- **RR-1 (MEDIUM) — Abbruch beim Verschieben über Dateisystemgrenzen.** Liegen Quelle und Ziel auf **derselben** Partition, ist der Umzug ein einziger `os.rename`-Aufruf: atomar, kein Zwischenzustand möglich. Auf **verschiedenen** Partitionen fällt `shutil.move` auf Kopieren+Löschen zurück; ein Abbruch mittendrin hinterlässt eine Teilkopie am Ziel. Danach scheitern sowohl ein erneuter `switch` als auch `rollback` mit `FileExistsError`, bis die Teilkopie von Hand entfernt wird — **AC-6 ist in diesem Fall nicht automatisch erfüllt.** Die Vorbedingung „gleiche Partition" ist im Code weder geprüft noch dokumentiert.
+- **RR-2 (LOW) — Hardlinks im selben Fall.** Über Dateisystemgrenzen gehen Hardlink-Verbindungen durch den Kopier-Fallback verloren: stiller Mehrverbrauch an Platz, kein Datenverlust. Auf derselben Partition bleiben sie erhalten (verifiziert über `nlink`).
+
+**Warum das VERIFIED und kein Blocker ist:** Beide Fälle scheitern **laut** (`FileExistsError`) — anders als die behobenen Befunde F001/F004 sehen sie bei Eintritt nicht erfolgreich aus. Und die Vorbedingung liegt nicht vor: Repo-Verzeichnis und `/var/lib` liegen auf diesem Server auf derselben Platte (`/dev/sda1`, gemessen 2026-08-08).
+
+**Folgeaufgabe für S3:** Ein `os.stat(...).st_dev`-Vergleich vor dem Umzug verwandelt beide Restrisiken präventiv in einen lauten Abbruch. Bewusst **nicht** mehr in S1 nachgezogen — die Prüfung ist abgeschlossen, und Code nach einem VERIFIED nachzuschieben entwertet dessen Aussage. S3 legt den Zielort ohnehin fest; dort gehört die Vorbedingungsprüfung hin.
+
+### Grenzen des Messverfahrens
+
 - **Die Messung sieht nur, was läuft.** Selten genutzte Pfade außerhalb der Auslöse-Liste bleiben unentdeckt. Die Liste ist aus den bekannten Fundstellen abgeleitet — für eine Stelle, die weder in der Inventur steht noch von einem gelisteten Vorgang berührt wird, gibt es in dieser Scheibe keinen Nachweis. Das ist die verbleibende Unschärfe; sie wird durch den befristeten Symlink in S4 abgefedert, nicht durch S1.
 - Staging hat einen anderen Datenbestand als Produktion (Testnutzer, keine echten Alarm-Historien). Ein Pfad, der nur bei bestimmten Produktivdaten durchlaufen wird, kann hier fehlen.
 - Stufe B macht Staging **absichtlich** kurzzeitig unbenutzbar.
@@ -114,3 +125,4 @@ Diese Scheibe trifft keine Architektur-Entscheidung. Das ADR zum Zielort (`/var/
 | Datum | Version | Änderung |
 |---|---|---|
 | 2026-08-08 | 1.0 | Erstfassung (Scheibe 1 von 5 zu #1595) |
+| 2026-08-08 | 1.1 | Known Limitations um RR-1/RR-2 aus Adversary Runde 3 ergänzt. Keine Änderung an den freigegebenen Acceptance Criteria — nur Offenlegung gemessener Grenzen vor dem ersten echten Lauf. |

--- a/docs/specs/modules/fix_1595_s1_staging_messverfahren.md
+++ b/docs/specs/modules/fix_1595_s1_staging_messverfahren.md
@@ -1,0 +1,116 @@
+---
+entity_id: fix_1595_s1_staging_messverfahren
+type: module
+created: 2026-08-08
+updated: 2026-08-08
+status: draft
+version: "1.0"
+tags: [infrastructure, data-root, staging, measurement]
+---
+
+<!-- Issue #1595 — Scheibe 1 von 5: Staging-Messverfahren -->
+
+# Fix 1595 S1 — Staging-Messverfahren für die Datenwurzel
+
+## Approval
+
+- [x] Approved — PO-Freigabe („go") am 2026-08-08, Beleg als Kommentar in [#1595](https://github.com/henemm/gregor_zwanzig/issues/1595)
+
+## Purpose
+
+Vor dem Umzug der Produktivdaten belastbar feststellen, **welche Stellen tatsächlich auf die Datenwurzel zugreifen** — durch Messung am laufenden System, nicht durch Textsuche.
+
+Die Inventur aus #1595 (14 Fundstellen) ist der Startpunkt, nicht der Nachweis. Sie stammt aus `grep`, und `grep` hat in diesem Vorgang bereits zweimal getrogen: ADR-0028 nannte eine blockierende Stelle, es waren vier; das erste Suchmuster dieser Messung verfehlte bekannte Treffer, weil es `Union[str, Path]` nicht erfasste. Ein Umzug von 79 MB Produktivdaten auf Grundlage einer Textsuche wäre fahrlässig.
+
+Diese Scheibe ändert **keinen Produktcode** und berührt **keine Produktivdaten**.
+
+## Source
+
+- Issue [#1595](https://github.com/henemm/gregor_zwanzig/issues/1595)
+- Kontext & Analyse: `docs/context/fix-1595-datenwurzel-umzug.md`
+- Vorgeschichte: ADR-0028 (verwarf `GZ_DATA_DIR` auf falscher Tatsachengrundlage), ADR-0031
+
+## Estimated Scope
+
+- **Kein Produktcode.** Ein Umschalt-/Rückbau-Skript, ein Befund-Dokument.
+- Betroffen: Staging-Umgebung (`gregor_zwanzig_staging`, vier Dienste)
+- Geschätzt: +80 / −0 LoC (Skript), plus Befund-Dokument
+- Risiko: niedrig für Produktion, **Staging fällt zeitweise absichtlich aus**
+
+## Dependencies
+
+- Staging muss laufen und deploybar sein
+- Sicherung des Staging-Datenbaums vor Beginn (Verfahren wie bei Prod: als `root`, Einträge gezählt)
+- Produktivsicherung liegt vor: `.backups/prod-data-pre-1595-20260808.tar.gz` (280/280 verifiziert)
+
+## Implementation Details
+
+### Stufe A — sanft (24 Stunden)
+
+1. Staging-Datenbaum sichern, Vollständigkeit durch Zählvergleich belegen.
+2. Daten nach `/var/lib/gregor-staging` verschieben; Besitzer `claude-gregor`, Modus `0750`.
+3. `GZ_DATA_DIR=/var/lib/gregor-staging` für **alle vier** Staging-Dienste setzen (auch für die beiden, die heute keine Variable haben).
+4. Alten Ordner `gregor_zwanzig_staging/data` nach `data.pre-1595` umbenennen.
+5. 24 Stunden laufen lassen.
+
+**Detektor:** Entsteht am alten Ort ein neuer `data/`-Ordner, benutzt jemand den relativen Pfad. Sein Inhalt benennt den Verursacher.
+
+### Stufe B — scharf (kurz)
+
+Am alten Ort eine **Datei** namens `data` anlegen (kein Verzeichnis). Jeder Zugriff auf `data/…` scheitert dann mit `ENOTDIR` — laut und im Log — statt still ins Leere zu laufen.
+
+Stufe A findet nur Schreiber. Stufe B findet auch **Leser**, die sonst kommentarlos leere Ergebnisse liefern (Muster „leer ≠ unbekannt", #1492 — genau so fiel am 07.08. das Tier still von `premium` auf `free`).
+
+### Auslöse-Liste (ohne sie ist die Messung wertlos)
+
+Ein Codepfad, der im Messzeitraum nicht ausgeführt wird, kann sich nicht melden. Diese Vorgänge werden auf Staging **gezielt ausgelöst**, abgeleitet aus den Fundstellen der Inventur:
+
+| Vorgang | deckt ab |
+|---|---|
+| Anmeldung + Profilabruf | `loader.py` Nutzerauflösung, Go-Store |
+| Trip-Briefing versenden | `dispatch_orchestrator`, `email.py` Allowlist |
+| Vergleichs-Briefing versenden | `scheduler_dispatch_service` (alle vier Stellen), `load_compare_presets` |
+| Eingehende Mail an Staging | `inbound_email_reader.py:220` |
+| Eingehende Telegram-Nachricht | `inbound_telegram_reader.py:378` |
+| Kennwort-Vergessen anstoßen | `lookup_user_by_email` |
+| Nächtliche Cronjobs abwarten (04:15, 04:30) | Validator-Setup, Staging-Sweep |
+| Deploy auf Staging auslösen | `migrate_1250_briefings.py --root data/users` |
+| Wetterabruf erzwingen | `calllog.go` → `data/diagnostics` |
+
+Zwei davon (`inbound_email_reader`, `inbound_telegram_reader`) laufen **nur** bei eingehender Post — sie wären in einer reinen Wartezeit nie aufgefallen.
+
+## Expected Behavior
+
+Am Ende liegt eine Liste vor: jede gemessene Zugriffsstelle, mit Datei und Zeile, und der Vermerk, ob sie in der Inventur stand. Diese Liste — nicht die Inventur — bestimmt den Umfang von S2.
+
+Staging läuft danach wieder normal.
+
+## Acceptance Criteria
+
+**AC-1:** Given Staging läuft mit der Datenwurzel unter `/var/lib/gregor-staging` und der alte Ordner ist umbenannt, When 24 Stunden vergangen sind und in dieser Zeit die Cronjobs um 04:15 und 04:30 sowie ein Briefing-Lauf stattgefunden haben, Then ist dokumentiert, ob am alten Ort etwas neu entstanden ist — und falls ja, welche Dateien es sind und welche Codestelle sie erzeugt hat.
+
+**AC-2:** Given am alten Ort liegt eine Datei statt eines Verzeichnisses, When alle Vorgänge der Auslöse-Liste ausgeführt werden, Then ist jeder dadurch entstandene Fehler mit Datei und Zeile erfasst und einer Codestelle zugeordnet.
+
+**AC-3:** Given der Befund aus AC-1 und AC-2, When er gegen die Inventur aus #1595 gehalten wird, Then ist für jede gemessene Zugriffsstelle vermerkt, ob die Inventur sie kannte, und jede zusätzlich gefundene Stelle ist als Kommentar in #1595 nachgetragen.
+
+**AC-4:** Given die Messung ist abgeschlossen, When Staging zurückgestellt wird, Then arbeitet es wieder mit seinem ursprünglichen Datenbestand, eine Anmeldung gelingt und ein Briefing wird nachweislich zugestellt.
+
+**AC-5:** Given die gesamte Messung von Anfang bis Ende, When sie durchgeführt wurde, Then ist der **Produktiv**-Datenbaum nachweislich unverändert — belegt durch Vergleich von Eintragszahl und Prüfsummen der Nutzerprofile vor und nach der Messung.
+
+**AC-6:** Given ein Abbruch an beliebiger Stelle der Messung, When der Rückbau ausgeführt wird, Then ist Staging in höchstens zwei Minuten wieder im Ausgangszustand, ohne Rückgriff auf die Sicherung.
+
+## Known Limitations
+
+- **Die Messung sieht nur, was läuft.** Selten genutzte Pfade außerhalb der Auslöse-Liste bleiben unentdeckt. Die Liste ist aus den bekannten Fundstellen abgeleitet — für eine Stelle, die weder in der Inventur steht noch von einem gelisteten Vorgang berührt wird, gibt es in dieser Scheibe keinen Nachweis. Das ist die verbleibende Unschärfe; sie wird durch den befristeten Symlink in S4 abgefedert, nicht durch S1.
+- Staging hat einen anderen Datenbestand als Produktion (Testnutzer, keine echten Alarm-Historien). Ein Pfad, der nur bei bestimmten Produktivdaten durchlaufen wird, kann hier fehlen.
+- Stufe B macht Staging **absichtlich** kurzzeitig unbenutzbar.
+
+## Architektur-Entscheidung (ADR)
+
+Diese Scheibe trifft keine Architektur-Entscheidung. Das ADR zum Zielort (`/var/lib/gregor`, Steuerung über `GZ_DATA_DIR` aus zentraler env-Datei) entsteht in S3; ADR-0028 wird dort als abgelöst markiert, ADR-0031 um die nie getroffene Ortsentscheidung ergänzt.
+
+## Changelog
+
+| Datum | Version | Änderung |
+|---|---|---|
+| 2026-08-08 | 1.0 | Erstfassung (Scheibe 1 von 5 zu #1595) |

--- a/internal/provider/openmeteo/calllog.go
+++ b/internal/provider/openmeteo/calllog.go
@@ -14,10 +14,29 @@ import (
 // Cross-Language-Schreibkonflikte zu vermeiden.
 
 // diagnosticsGoPath ist als Paket-Variable konfigurierbar, damit Tests ihn auf
-// ein t.TempDir umlenken können (Konfiguration, kein Mock).
-var diagnosticsGoPath = filepath.Join("data", "diagnostics", "openmeteo_calls_go.jsonl")
+// ein t.TempDir umlenken können (Konfiguration, kein Mock). Leer = kein
+// Override, dann entscheidet diagnosticsGoLogPath() zur Laufzeit.
+//
+// Issue #1595: der Pfad darf NICHT mehr beim Paket-Import festgelegt werden.
+// Die Datenwurzel steht in GZ_DATA_DIR, und die wird erst nach dem Import
+// gelesen — ein früh gebundener Wert zeigte weiter auf das relative "data"
+// im Projektordner, also seit dem Umzug auf einen leeren Ordner.
+var diagnosticsGoPath string
 
-// logAPICall hängt fail-soft eine JSONL-Zeile an diagnosticsGoPath an. Diagnose
+// diagnosticsGoLogPath löst den Zielpfad beim Zugriff auf: Test-Override zuerst,
+// sonst GZ_DATA_DIR mit unverändertem Rückfall auf "data".
+func diagnosticsGoLogPath() string {
+	if diagnosticsGoPath != "" {
+		return diagnosticsGoPath
+	}
+	root := os.Getenv("GZ_DATA_DIR")
+	if root == "" {
+		root = "data"
+	}
+	return filepath.Join(root, "diagnostics", "openmeteo_calls_go.jsonl")
+}
+
+// logAPICall hängt fail-soft eine JSONL-Zeile an diagnosticsGoLogPath() an. Diagnose
 // darf den Abruf NIE beeinträchtigen — jeder Fehler/Panic wird geschluckt.
 func logAPICall(reqURL string, status int, errStr string) {
 	defer func() { _ = recover() }()
@@ -43,13 +62,14 @@ func logAPICall(reqURL string, status int, errStr string) {
 		return
 	}
 
-	if dir := filepath.Dir(diagnosticsGoPath); dir != "" {
+	logPath := diagnosticsGoLogPath()
+	if dir := filepath.Dir(logPath); dir != "" {
 		if mkErr := os.MkdirAll(dir, 0o755); mkErr != nil {
 			return
 		}
 	}
 
-	f, openErr := os.OpenFile(diagnosticsGoPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	f, openErr := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if openErr != nil {
 		return
 	}

--- a/internal/provider/openmeteo/calllog_test.go
+++ b/internal/provider/openmeteo/calllog_test.go
@@ -155,6 +155,110 @@ func TestCallLog_UVFetch_AppendsGoUVLine(t *testing.T) {
 }
 
 // =============================================================================
+// Issue #1595: die Datenwurzel wird ZUR LAUFZEIT gelesen, nicht beim Import
+// =============================================================================
+//
+// Vorher stand der Diagnose-Pfad in einer Paket-Variablen mit Initialisierer.
+// Der lief beim Import des Pakets — also vor jeder Konfiguration — und zeigte
+// dauerhaft auf das relative "data" im Projektordner. Nach dem Umzug der
+// Produktivdaten nach /var/lib/gregor schrieb er damit in einen toten Ordner.
+//
+// Dass die Aufloesung jetzt spaet faellt, laesst sich durch Lesen des Codes
+// NICHT beweisen: eine Konstante und ein Funktionsaufruf sehen an der
+// Aufrufstelle gleich aus. Beweisen kann es nur ein Test, der die Variable
+// NACH dem Import setzt — genau das tut t.Setenv hier. Waere der Pfad noch
+// frueh gebunden, kaeme das Setzen zu spaet und der Test wuerde rot.
+
+// initialDiagnosticsGoPath haelt den Wert fest, den die Paket-Variable BEIM
+// LADEN des Pakets hatte — Paket-Variablen der Testdatei werden zusammen mit
+// denen des Prueflings initialisiert, also bevor irgendein Test sie umsetzt.
+// Ohne diese Kopie waere der Nachweis unten von der Test-Reihenfolge abhaengig.
+var initialDiagnosticsGoPath = diagnosticsGoPath
+
+func TestDiagnosticsPath_NothingIsBoundAtPackageInit(t *testing.T) {
+	// Das ist der eigentliche Waechter. Der Test darunter setzt die Variable
+	// selbst auf "" und kann eine frueh gebundene Zuweisung deshalb gar nicht
+	// sehen — er wuerde auch gruen bleiben, wenn der Initialisierer zurueckkaeme.
+	// Hier wird stattdessen geprueft, was beim Import passiert ist: nichts.
+	if initialDiagnosticsGoPath != "" {
+		t.Fatalf("die Paket-Variable trug beim Import bereits %q — damit steht der "+
+			"Diagnose-Pfad wieder vor jeder Konfiguration fest und ignoriert GZ_DATA_DIR",
+			initialDiagnosticsGoPath)
+	}
+}
+
+func TestDiagnosticsPath_ReadsEnvAtCallTime_NotAtPackageInit(t *testing.T) {
+	// GIVEN: eine Datenwurzel, die es beim Laden des Pakets noch nicht gab.
+	// Das Arbeitsverzeichnis wird mitverlegt, damit der relative Pfad "data"
+	// unten wirklich LEER ist. Ohne das schlaegt die Gegenprobe auf Rueckstaende
+	// frueherer Laeufe im Paketordner an und meldet Rot ohne Befund.
+	t.Chdir(t.TempDir())
+	root := t.TempDir()
+	t.Setenv("GZ_DATA_DIR", root)
+
+	// Kein Test-Override aktiv — sonst wuerde der die Aufloesung kurzschliessen
+	// und der Test bewiese nichts ueber GZ_DATA_DIR.
+	old := diagnosticsGoPath
+	diagnosticsGoPath = ""
+	defer func() { diagnosticsGoPath = old }()
+
+	// WHEN: eine Diagnose-Zeile geschrieben wird.
+	logAPICall("https://api.open-meteo.com/v1/forecast?lat=47", 200, "")
+
+	// THEN: sie liegt unter der NEUEN Wurzel.
+	want := filepath.Join(root, "diagnostics", "openmeteo_calls_go.jsonl")
+	lines := readGoCallLog(t, want)
+	if len(lines) != 1 {
+		t.Fatalf("erwartet 1 Zeile unter %s, gefunden %d — der Pfad wurde offenbar "+
+			"beim Paket-Import festgelegt und ignoriert GZ_DATA_DIR", want, len(lines))
+	}
+
+	// Und ausdruecklich NICHT am alten, relativen Ort. Ohne diese Haelfte waere
+	// der Test auch gruen, wenn zusaetzlich weiter nach "data" geschrieben wuerde.
+	if _, err := os.Stat(filepath.Join("data", "diagnostics", "openmeteo_calls_go.jsonl")); err == nil {
+		t.Errorf("es wurde zusaetzlich in den alten relativen Pfad data/diagnostics geschrieben")
+	}
+}
+
+func TestDiagnosticsPath_FallsBackToData_WhenEnvUnset(t *testing.T) {
+	// Gegenprobe: ohne gesetzte Variable muss der Rueckfall auf "data" greifen.
+	// Ohne diesen Test waere der obige auch dann gruen, wenn die Aufloesung
+	// kaputt waere und IMMER die Umgebungsvariable braeuchte — das Verhalten
+	// ohne GZ_DATA_DIR soll aber unveraendert bleiben (AC-2).
+	//
+	// Geprueft wird der aufgeloeste Pfad, nicht ein Schreibvorgang: schreiben
+	// wuerde hier eine Datei im Projektordner anlegen, also genau die
+	// Verschmutzung erzeugen, die diese Scheibe abschafft.
+	t.Setenv("GZ_DATA_DIR", "")
+
+	old := diagnosticsGoPath
+	diagnosticsGoPath = ""
+	defer func() { diagnosticsGoPath = old }()
+
+	got := diagnosticsGoLogPath()
+	want := filepath.Join("data", "diagnostics", "openmeteo_calls_go.jsonl")
+	if got != want {
+		t.Errorf("Rueckfall ohne GZ_DATA_DIR: erwartet %q, bekommen %q", want, got)
+	}
+}
+
+func TestDiagnosticsPath_TestOverrideWinsOverEnv(t *testing.T) {
+	// Der Vorrang des Test-Overrides ist die Zusicherung, auf der die drei
+	// bestehenden Tests dieser Datei aufbauen. Faellt sie still weg, wuerden
+	// die auf einmal in den echten Datenbaum schreiben.
+	t.Setenv("GZ_DATA_DIR", t.TempDir())
+
+	override := filepath.Join(t.TempDir(), "eigener.jsonl")
+	old := diagnosticsGoPath
+	diagnosticsGoPath = override
+	defer func() { diagnosticsGoPath = old }()
+
+	if got := diagnosticsGoLogPath(); got != override {
+		t.Errorf("Test-Override muss GZ_DATA_DIR schlagen: erwartet %q, bekommen %q", override, got)
+	}
+}
+
+// =============================================================================
 // AC-5: nicht-beschreibbares Diagnose-Ziel → logAPICall schluckt Fehler,
 // kein Panic, doRequest/FetchForecast liefern unverändert.
 // =============================================================================

--- a/scripts/data_root_switch.py
+++ b/scripts/data_root_switch.py
@@ -1,0 +1,126 @@
+"""Umschalt-Werkzeug fuer die Datenwurzel (Issue #1595, Scheibe 1).
+
+Verschiebt einen Datenbaum an einen neuen Ort, laesst den alten Ort wahlweise
+leer (Stufe A) oder als Sperrdatei zurueck (Stufe B), und misst die
+Unversehrtheit ueber Pruefsummen.
+"""
+
+import hashlib
+import shutil
+from pathlib import Path
+
+SPERRDATEI_INHALT = "Datenwurzel umgezogen (Issue #1595, Stufe B). Zugriff hierher ist ein Befund.\n"
+
+
+def fingerprint(root: Path) -> dict[str, str]:
+    """Erfasst jede Datei unter ``root`` als relativer Pfad -> Pruefsumme.
+
+    Muss bei einer unlesbaren Datei LAUT scheitern statt sie zu ueberspringen —
+    ein uebersprungener Eintrag erzeugt ein unvollstaendiges Ergebnis, das wie
+    ein vollstaendiges aussieht. Deshalb faengt hier nichts Lesefehler ab.
+    """
+    erfassung: dict[str, str] = {}
+    for pfad in sorted(root.rglob("*")):
+        if not pfad.is_file():
+            continue
+        # Bewusst ungeschuetzt: ein PermissionError muss nach aussen dringen.
+        pruefsumme = hashlib.sha256(pfad.read_bytes()).hexdigest()
+        erfassung[pfad.relative_to(root).as_posix()] = pruefsumme
+    return erfassung
+
+
+def compare_fingerprints(before: dict[str, str], after: dict[str, str]) -> list[str]:
+    """Menschenlesbare Abweichungen zwischen zwei Erfassungen. Leer = identisch."""
+    abweichungen: list[str] = []
+    for pfad in sorted(set(before) | set(after)):
+        if pfad not in after:
+            abweichungen.append(f"geloescht: {pfad}")
+        elif pfad not in before:
+            abweichungen.append(f"neu: {pfad}")
+        elif before[pfad] != after[pfad]:
+            abweichungen.append(f"geaendert: {pfad}")
+    return abweichungen
+
+
+def detect_regrowth(old_root: Path) -> list[str]:
+    """Relative Pfade, die am alten Ort (wieder) entstanden sind. Leer = nichts.
+
+    Liest bewusst KEINE Inhalte: gefragt ist nur, WELCHE Pfade entstanden sind.
+    So meldet der Detektor auch eine unlesbare nachgewachsene Datei — ein
+    besonders interessanter Befund — statt die 24-Stunden-Messung abstuerzen zu
+    lassen. Die Strenge von ``fingerprint`` bleibt davon unberuehrt: dort zaehlt
+    Vollstaendigkeit, hier Robustheit.
+
+    Gemeldet wird JEDER Eintrag, ohne Typ-Filter: auch ein Symlink (der auf ein
+    Verzeichnis zeigende ebenso wie der kaputte) und ein leeres Verzeichnis. Ein
+    Symlink am alten Ort ist ein manueller Handgriff, ein leeres Verzeichnis der
+    Store, der anlegt bevor er schreibt — beides sind Zugriffe auf den alten
+    Pfad. Uebersaehe der Detektor sie, meldete er ``[]`` und waere nicht mehr von
+    "nichts passiert" zu unterscheiden.
+    """
+    if not old_root.is_dir():
+        return []
+    befunde = []
+    for pfad in old_root.rglob("*"):
+        if pfad.is_symlink():  # vor is_dir/is_file: beide folgen dem Verweis
+            art = "Symlink"
+        elif pfad.is_dir():
+            art = "Verzeichnis"
+        else:
+            art = "Datei"
+        befunde.append(f"{pfad.relative_to(old_root).as_posix()} ({art})")
+    return sorted(befunde)
+
+
+def _move_onto(baum: Path, ziel: Path) -> None:
+    """Verschiebt ``baum`` AUF ``ziel`` — nie HINEIN.
+
+    ``shutil.move`` legt den Baum in ein bereits vorhandenes Verzeichnis hinein;
+    alles laege dann eine Ebene zu tief und kein Dienst faende etwas. Auf Staging
+    ist genau das der Normalfall, weil systemd (``StateDirectory``) den Zielordner
+    bei jedem Dienststart anlegt.
+
+    Symlinks werden auf beiden Seiten abgelehnt: ``shutil.move`` verschoebe nur
+    den Verweis, der reale Datenbaum bliebe liegen — der Aufruf saehe erfolgreich
+    aus, ohne dass etwas umgezogen ist. Ab Scheibe 4 liegt am alten Ort
+    ausdruecklich ein Symlink als Rueckfahrkarte; diese Lage tritt also real ein.
+    """
+    if baum.is_symlink():
+        raise ValueError(
+            f"{baum} ist ein Symlink — Abbruch: es wuerde nur der Verweis verschoben, "
+            "die Daten blieben liegen."
+        )
+    if ziel.is_symlink():
+        raise ValueError(
+            f"Ziel {ziel} ist ein Symlink — Abbruch: der Baum landete woanders als angegeben."
+        )
+    if ziel.is_dir():
+        if any(ziel.iterdir()):
+            raise FileExistsError(
+                f"Ziel {ziel} ist nicht leer — Abbruch, sonst wuerden zwei Datenbestaende vermischt."
+            )
+        ziel.rmdir()
+    elif ziel.exists():
+        raise FileExistsError(f"Ziel {ziel} existiert und ist kein Verzeichnis — Abbruch.")
+    else:
+        ziel.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(baum), str(ziel))
+
+
+def switch(source: Path, target: Path, mode: str = "absent") -> None:
+    """Verschiebt ``source`` nach ``target``.
+
+    mode="absent": alter Ort bleibt leer — Schreiber legen dort neu an (Stufe A).
+    mode="file":   alter Ort wird eine DATEI — jeder Zugriff auf ``source/...``
+                   scheitert mit NotADirectoryError, also laut (Stufe B).
+    """
+    _move_onto(source, target)
+    if mode == "file":
+        source.write_text(SPERRDATEI_INHALT)
+
+
+def rollback(source: Path, target: Path) -> None:
+    """Stellt den Ausgangszustand her: Baum zurueck, Sperrdatei weg, Ziel geraeumt."""
+    if source.is_file():
+        source.unlink()
+    _move_onto(target, source)

--- a/src/app/loader.py
+++ b/src/app/loader.py
@@ -291,7 +291,7 @@ def compare_preset_from_dict(data: Dict[str, Any]) -> ComparePreset:
 
 def load_compare_presets(
     user_id: str,
-    data_root: Union[str, Path] = "data",
+    data_root: Optional[Union[str, Path]] = None,
     strict: bool = False,
 ) -> List[ComparePreset]:
     """Zentraler Lade-Pfad fuer ComparePresets (Issue #1250).
@@ -316,6 +316,8 @@ def load_compare_presets(
     (HTTP-404-Detail bzw. ERROR-Log) bewahren; die 3 Alert-Services bleiben
     beim partial-toleranten Default.
     """
+    if data_root is None:
+        data_root = get_data_root()
     briefings_dir = Path(data_root) / "users" / user_id / "briefings"
     if not briefings_dir.exists():
         return []
@@ -1139,11 +1141,11 @@ def get_snapshots_dir(user_id: str = "default") -> Path:
     return get_data_dir(user_id) / "weather_snapshots"
 
 
-def list_all_user_ids(data_dir: str = "data") -> list[str]:
+def list_all_user_ids(data_dir: str | None = None) -> list[str]:
     """Return all user IDs found under data/users/, real users first (Issue #1013).
 
     Args:
-        data_dir: Root data directory (default: "data")
+        data_dir: Root data directory (default: get_data_root())
 
     Returns:
         Sorted list of user_id strings (excludes entries starting with 'test' or '_'),
@@ -1153,6 +1155,8 @@ def list_all_user_ids(data_dir: str = "data") -> list[str]:
     """
     from app.config import is_test_user_id
 
+    if data_dir is None:
+        data_dir = str(get_data_root())
     users_root = Path(data_dir) / "users"
     if not users_root.exists():
         return []
@@ -1167,16 +1171,18 @@ def list_all_user_ids(data_dir: str = "data") -> list[str]:
     return real + test
 
 
-def lookup_user_by_email(email: str, data_dir: str = "data") -> str | None:
+def lookup_user_by_email(email: str, data_dir: str | None = None) -> str | None:
     """Find user_id whose mail_to matches the given email address (case-insensitive).
 
     Args:
         email: Sender email address to match against user profiles
-        data_dir: Root data directory (default: "data")
+        data_dir: Root data directory (default: get_data_root())
 
     Returns:
         Matching user_id or None if no match found
     """
+    if data_dir is None:
+        data_dir = str(get_data_root())
     for uid in list_all_user_ids(data_dir):
         profile_path = Path(data_dir) / "users" / uid / "user.json"
         if profile_path.exists():
@@ -1189,16 +1195,18 @@ def lookup_user_by_email(email: str, data_dir: str = "data") -> str | None:
     return None
 
 
-def lookup_user_by_telegram_chat_id(chat_id: str, data_dir: str = "data") -> str | None:
+def lookup_user_by_telegram_chat_id(chat_id: str, data_dir: str | None = None) -> str | None:
     """Find user_id whose telegram_chat_id matches the given chat_id (int/str-tolerant).
 
     Args:
         chat_id: Telegram chat ID to match (compared as strings)
-        data_dir: Root data directory (default: "data")
+        data_dir: Root data directory (default: get_data_root())
 
     Returns:
         Matching user_id or None if no match found
     """
+    if data_dir is None:
+        data_dir = str(get_data_root())
     for uid in list_all_user_ids(data_dir):
         profile_path = Path(data_dir) / "users" / uid / "user.json"
         if profile_path.exists():

--- a/src/output/channels/email.py
+++ b/src/output/channels/email.py
@@ -236,7 +236,7 @@ def _is_local_mail_domain(addr: str) -> bool:
     return domain in LOCAL_MAIL_DOMAINS
 
 
-def _load_resend_allowlist(data_dir: str = "data") -> frozenset[str]:
+def _load_resend_allowlist(data_dir: str | None = None) -> frozenset[str]:
     """Issue #1219 Scheibe 1: positive Empfänger-Allowlist, Eignungskriterium
     umgestellt von der Namens-Heuristik (`is_test_user_id`) auf das explizite
     Profilfeld `email_verified_at`.
@@ -256,6 +256,13 @@ def _load_resend_allowlist(data_dir: str = "data") -> frozenset[str]:
     betroffene Profil — nie ein Crash des Sendepfads.
     """
     allowed: set[str] = set()
+    if data_dir is None:
+        # Lokaler Import wie beim Aufrufer weiter unten (Adversary F002,
+        # #1219): NICHT direkt GZ_DATA_DIR lesen — get_data_root() honoriert
+        # zuerst app.loader._DATA_ROOT und damit die Test-Isolation (#1133).
+        from app.loader import get_data_root
+
+        data_dir = str(get_data_root())
     users_root = Path(data_dir) / "users"
     try:
         user_ids = [d.name for d in users_root.iterdir() if d.is_dir()]

--- a/src/services/dispatch_orchestrator.py
+++ b/src/services/dispatch_orchestrator.py
@@ -23,6 +23,7 @@ import time as time_module
 from typing import TYPE_CHECKING
 
 from app.config import Settings
+from app.loader import get_data_root
 
 if TYPE_CHECKING:
     from services.trip_report_scheduler import TripReportSchedulerService
@@ -97,7 +98,7 @@ class CompareDispatchStrategy:
     def __init__(self, settings: Settings, user_id: str, data_root: str | None = None) -> None:
         self._settings = settings
         self._user_id = user_id
-        self._data_root = data_root or "data"
+        self._data_root = data_root or str(get_data_root())
         self._presets: list = []
         self._all_locations = None
         self._success = 0

--- a/src/services/inbound_email_reader.py
+++ b/src/services/inbound_email_reader.py
@@ -217,19 +217,21 @@ class InboundEmailReader:
         return ""
 
     def _resolve_settings_for_sender(
-        self, from_addr: str, base_settings: Settings, data_dir: str = "data"
+        self, from_addr: str, base_settings: Settings, data_dir: str | None = None
     ) -> tuple[str, Settings]:
         """Resolve user_id and user-scoped Settings for an incoming sender address.
 
         Args:
             from_addr: Sender email address (lowercase expected)
             base_settings: Base Settings object to derive user profile from
-            data_dir: Root data directory (default: "data")
+            data_dir: Root data directory (default: get_data_root())
 
         Returns:
             (user_id, user_scoped_settings) — user_id is "default" if no match
         """
-        from app.loader import lookup_user_by_email
+        from app.loader import get_data_root, lookup_user_by_email
+        if data_dir is None:
+            data_dir = str(get_data_root())
         user_id = lookup_user_by_email(from_addr, data_dir=data_dir) or "default"
         return user_id, base_settings.with_user_profile(user_id)
 

--- a/src/services/inbound_telegram_reader.py
+++ b/src/services/inbound_telegram_reader.py
@@ -375,19 +375,21 @@ class InboundTelegramReader:
         return None
 
     def _resolve_user_for_chat(
-        self, chat_id: str, base_settings: Settings, data_dir: str = "data"
+        self, chat_id: str, base_settings: Settings, data_dir: str | None = None
     ) -> tuple[str, Settings]:
         """Resolve user_id and user-scoped Settings for an incoming Telegram chat ID.
 
         Args:
             chat_id: Telegram chat ID (as string)
             base_settings: Base Settings object to derive user profile from
-            data_dir: Root data directory (default: "data")
+            data_dir: Root data directory (default: get_data_root())
 
         Returns:
             (user_id, user_scoped_settings) — user_id is "default" if no match
         """
-        from app.loader import lookup_user_by_telegram_chat_id
+        from app.loader import get_data_root, lookup_user_by_telegram_chat_id
+        if data_dir is None:
+            data_dir = str(get_data_root())
         user_id = lookup_user_by_telegram_chat_id(chat_id, data_dir=data_dir) or "default"
         return user_id, base_settings.with_user_profile(user_id)
 

--- a/src/services/scheduler_dispatch_service.py
+++ b/src/services/scheduler_dispatch_service.py
@@ -16,6 +16,7 @@ from app.loader import (
     LoaderError,
     _parse_activity_profile,
     compare_preset_to_dict,
+    get_data_root,
     load_all_locations,
     load_compare_presets,
 )
@@ -145,7 +146,7 @@ def run_compare_presets_daily(
     unveraendert (AC-3).
     """
     if data_root is None:
-        data_root = "data"
+        data_root = str(get_data_root())
     if hour is None:
         from zoneinfo import ZoneInfo
 
@@ -171,7 +172,7 @@ def save_compare_preset_status(
     und load_compare_presets sichtbar bleibt.
     """
     if data_root is None:
-        data_root = "data"
+        data_root = str(get_data_root())
 
     path = Path(data_root) / "users" / user_id / "briefings" / f"{preset_id}.json"
     if not path.exists():
@@ -223,7 +224,7 @@ def save_compare_preset_pause(
     Replace (BUG-DATALOSS-GR221) — alle anderen Felder bleiben erhalten.
     """
     if data_root is None:
-        data_root = "data"
+        data_root = str(get_data_root())
     if now_iso is None:
         now_iso = _datetime.utcnow().isoformat() + "Z"
 
@@ -453,7 +454,7 @@ def send_compare_preset(
     Vergleichspunkt und der naechste echte Ausschlag ginge still verloren.
     """
     if data_root is None:
-        data_root = "data"
+        data_root = str(get_data_root())
 
     # Issue #1250 Scheibe 1 (Adversary-Fix F001): strict=True, damit korrupte
     # Dateien wie vor der Umstellung als KeyError mit Original-Parse-Fehler

--- a/tests/helpers/alert_log_fixtures.py
+++ b/tests/helpers/alert_log_fixtures.py
@@ -6,10 +6,16 @@ die vorhandenen DI-Naehte (``mail_sink``/``radar_service``).
 
 Pfadregel #1409: alle Pruefling-Pfade laufen ueber ``get_data_dir()`` bzw.
 werden relativ zur Testdatei aufgeloest -- nie ueber einen festen
-Hauptrepo-Pfad. Einzige bewusste Ausnahme ist ``COMPARE_DATA_ROOT``: der
-Compare-Loader liest Presets ueber den cwd-relativen Pfad ``data/users/...``
-(``loader.load_compare_presets(data_root="data")``), also ueber das ``cwd``
-des Pruefling -- das ist die in CLAUDE.md ausgenommene "geteilte Ablage".
+Hauptrepo-Pfad.
+
+Issue #1595: die frueher hier dokumentierte Ausnahme ``COMPARE_DATA_ROOT``
+(fester Hauptrepo-Pfad, begruendet mit ``load_compare_presets(data_root=
+"data")``) ist ENTFALLEN. Der Compare-Loader loest die Datenwurzel jetzt
+ueber ``get_data_root()`` auf, also ueber dieselbe Basis wie
+``get_data_dir()``. Ein fester Pfad wuerde seither dorthin schreiben, wo der
+Pruefling NICHT liest -- die Tests waren gruen, ohne etwas zu bewachen.
+Deshalb ``compare_data_root()`` als Funktion: der Wert faellt beim Aufruf,
+nach der #1133-Fixture, nicht beim Import davor.
 """
 from __future__ import annotations
 
@@ -37,8 +43,15 @@ from app.trip import Stage, Trip, Waypoint
 
 LAT, LON = 47.0, 11.0
 
-# s. Modul-Docstring: cwd-relative Ablage des Compare-Preset-Loaders.
-COMPARE_DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
+def compare_data_root() -> Path:
+    """Nutzer-Wurzel fuer die Compare-Preset-Ablage, s. Modul-Docstring.
+
+    Funktion statt Konstante (#1595): ``get_data_root()`` liefert erst zur
+    Laufzeit die von der #1133-Fixture gesetzte Basis.
+    """
+    from app.loader import get_data_root
+
+    return get_data_root() / "users"
 
 
 def fresh_user(prefix: str) -> str:
@@ -46,7 +59,7 @@ def fresh_user(prefix: str) -> str:
 
 
 def clean_compare_user(user_id: str) -> None:
-    d = COMPARE_DATA_ROOT / user_id
+    d = compare_data_root() / user_id
     if d.exists():
         shutil.rmtree(d, ignore_errors=True)
 

--- a/tests/helpers/nowcast_gate_fixtures.py
+++ b/tests/helpers/nowcast_gate_fixtures.py
@@ -15,10 +15,15 @@ Prod-``.env`` des Arbeitsverzeichnisses zurueck — genau so gingen am
 
 Pfadregel #1409: alles wird relativ zu DIESER Datei bzw. ueber
 ``app.loader.get_data_dir()`` aufgeloest, nie ueber einen festen
-Hauptrepo-Pfad. Einzige bewusste Ausnahme ist ``PRESET_ROOT``: der
-Vergleichs-Loader liest Presets cwd-relativ
-(``load_compare_presets(data_root="data")``) — die in CLAUDE.md ausgenommene
-"geteilte Ablage" (Vorbild ``tests/helpers/alert_log_fixtures.py``).
+Hauptrepo-Pfad.
+
+Issue #1595: die frueher hier dokumentierte Ausnahme ``PRESET_ROOT`` (fester
+Hauptrepo-Pfad, begruendet mit ``load_compare_presets(data_root="data")``)
+ist ENTFALLEN. Der Vergleichs-Loader liest die Datenwurzel jetzt ueber
+``get_data_root()``, also ueber dieselbe Basis wie ``get_data_dir()``. Ein
+fester Pfad schriebe seither dorthin, wo der Pruefling NICHT liest. Deshalb
+``preset_root()`` als Funktion: der Wert faellt beim Aufruf, nach der
+#1133-Fixture, nicht beim Import davor.
 """
 from __future__ import annotations
 
@@ -38,8 +43,15 @@ from app.user import SavedLocation
 
 from tests.helpers.compare_briefings import write_compare_briefings
 
-# s. Modul-Docstring: cwd-relative Ablage des Vergleichs-Preset-Loaders.
-PRESET_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
+def preset_root() -> Path:
+    """Nutzer-Wurzel der Vergleichs-Preset-Ablage, s. Modul-Docstring.
+
+    Funktion statt Konstante (#1595): ``get_data_root()`` liefert erst zur
+    Laufzeit die von der #1133-Fixture gesetzte Basis.
+    """
+    from app.loader import get_data_root
+
+    return get_data_root() / "users"
 
 VIENNA = ZoneInfo("Europe/Vienna")
 
@@ -69,7 +81,7 @@ def fresh_uid(prefix: str) -> str:
 def clean_uid(user_id: str) -> None:
     """Beide Ablagen: die isolierte ``get_data_dir()``-Basis UND das
     cwd-relative Preset-Verzeichnis."""
-    for d in (PRESET_ROOT / user_id, get_data_dir(user_id)):
+    for d in (preset_root() / user_id, get_data_dir(user_id)):
         if d.exists():
             shutil.rmtree(d, ignore_errors=True)
 
@@ -146,7 +158,7 @@ def radar_preset(
 
 
 def write_presets(user_id: str, presets: list[dict]) -> Path:
-    return write_compare_briefings(PRESET_ROOT / user_id, presets)
+    return write_compare_briefings(preset_root() / user_id, presets)
 
 
 # ─────────────────────────────── Radar-Naht ─────────────────────────────────

--- a/tests/tdd/test_alert_change_urgency_grading.py
+++ b/tests/tdd/test_alert_change_urgency_grading.py
@@ -29,10 +29,10 @@ Persistenz ueber die pytest-isolierte ``app.loader.get_data_dir()``-Basis
 
 Pfadregel #1409: alle Pruefling-Pfade laufen ueber ``get_data_dir()`` bzw.
 werden relativ zu DIESER Testdatei aufgeloest -- nie ueber einen festen
-Hauptrepo-Pfad. Einzige bewusste Ausnahme ist ``COMPARE_DATA_ROOT`` aus
-``tests/helpers/alert_log_fixtures.py``: der Compare-Preset-Loader liest
-cwd-relativ (``load_compare_presets(data_root="data")``) -- die in CLAUDE.md
-ausgenommene „geteilte Ablage".
+Hauptrepo-Pfad. Die frueher hier genannte Ausnahme ``COMPARE_DATA_ROOT`` ist
+mit #1595 entfallen: der Compare-Preset-Loader liest nicht mehr cwd-relativ,
+sondern ueber ``get_data_root()``. An ihre Stelle tritt die Funktion
+``compare_data_root()`` aus ``tests/helpers/alert_log_fixtures.py``.
 """
 from __future__ import annotations
 
@@ -57,10 +57,10 @@ from app.trip import Stage, Trip, Waypoint
 from app.user import SavedLocation
 
 from tests.helpers.alert_log_fixtures import (
-    COMPARE_DATA_ROOT,
     LAT,
     LON,
     clean_compare_user,
+    compare_data_root,
     read_log,
     settings_email_only,
     weather,
@@ -465,7 +465,7 @@ def _setup_compare_user(uid: str, anker: dict) -> None:
         SavedLocation(id="loc-a", name="Vergleichsort", lat=LAT, lon=LON, elevation_m=1000),
         user_id=uid,
     )
-    write_compare_briefings(COMPARE_DATA_ROOT / uid, [{
+    write_compare_briefings(compare_data_root() / uid, [{
         "id": _COMPARE_PRESET_ID, "name": "Vergleich 1503", "user_id": uid,
         "location_ids": ["loc-a"], "schedule": "daily", "weekday": 4,
         "profil": "ALLGEMEIN", "hour_from": 9, "hour_to": 16,

--- a/tests/tdd/test_alert_log_compare_and_tenancy.py
+++ b/tests/tdd/test_alert_log_compare_and_tenancy.py
@@ -23,7 +23,7 @@ from app.models import SegmentWeatherSummary
 from app.user import SavedLocation
 
 from tests.helpers.alert_log_fixtures import (
-    COMPARE_DATA_ROOT, LAT, LON, clean_compare_user, fresh_user, gust_alert_trip,
+    LAT, LON, clean_compare_user, compare_data_root, fresh_user, gust_alert_trip,
     read_log, settings_email_only, weather,
 )
 from tests.helpers.compare_briefings import write_compare_briefings
@@ -90,7 +90,7 @@ def _setup_compare_user(uid: str) -> None:
         SavedLocation(id="loc-a", name="Vergleichsort", lat=LAT, lon=LON, elevation_m=1000),
         user_id=uid,
     )
-    write_compare_briefings(COMPARE_DATA_ROOT / uid, [{
+    write_compare_briefings(compare_data_root() / uid, [{
         "id": _PRESET_ID, "name": "Vergleich 1459", "user_id": uid,
         "location_ids": ["loc-a"], "schedule": "daily", "weekday": 4,
         "profil": "ALLGEMEIN", "hour_from": 9, "hour_to": 16,

--- a/tests/tdd/test_alert_quiet_hours_robustness.py
+++ b/tests/tdd/test_alert_quiet_hours_robustness.py
@@ -53,10 +53,13 @@ fehlenden Feldern still auf die Prod-``.env`` im Worktree zurueck, und ein
 Pfadregel #1409: Prueflings-Pfade werden relativ zu DIESER Testdatei
 aufgeloest (``Path(__file__).resolve().parents[2]``), nie ueber einen festen
 Hauptrepo-Pfad — sonst pruefte der Lauf aus dem Worktree die unveraenderte
-Hauptrepo-Kopie und meldete falsches Gruen. Einzige bewusste Ausnahme ist die
-geteilte Ablage ``COMPARE_DATA_ROOT``: der Compare-Preset-Loader liest
-cwd-relativ ueber ``load_compare_presets(data_root="data")``, also ueber das
-``cwd`` des Prueflings.
+Hauptrepo-Kopie und meldete falsches Gruen.
+
+Issue #1595: die frueher hier dokumentierte Ausnahme ``COMPARE_DATA_ROOT``
+(geteilte Ablage, begruendet mit ``load_compare_presets(data_root="data")``)
+ist ENTFALLEN. Der Compare-Preset-Loader liest nicht mehr cwd-relativ,
+sondern ueber ``get_data_root()``. ``compare_data_root()`` loest deshalb beim
+Aufruf auf, nach der #1133-Fixture, statt beim Import davor.
 """
 from __future__ import annotations
 
@@ -78,8 +81,18 @@ from app.user import SavedLocation
 from tests.helpers.compare_briefings import write_compare_briefings
 
 _REPO = Path(__file__).resolve().parents[2]
-COMPARE_DATA_ROOT = _REPO / "data" / "users"
 SERVICES_DIR = _REPO / "src" / "services"
+
+
+def compare_data_root() -> Path:
+    """Nutzer-Wurzel der Compare-Preset-Ablage, s. Modul-Docstring.
+
+    Funktion statt Konstante (#1595): ``get_data_root()`` liefert erst zur
+    Laufzeit die von der #1133-Fixture gesetzte Basis.
+    """
+    from app.loader import get_data_root
+
+    return get_data_root() / "users"
 
 # Island (UTC+0 ganzjaehrig, kein Sommerzeit-Sprung) — haelt die
 # Segment-Zeitfenster der Trip-Fixtures frei von DST-Ueberraschungen.
@@ -98,7 +111,7 @@ def _uid(tag: str) -> str:
 
 
 def _clean_compare_user(user_id: str) -> None:
-    d = COMPARE_DATA_ROOT / user_id
+    d = compare_data_root() / user_id
     if d.exists():
         shutil.rmtree(d, ignore_errors=True)
 
@@ -146,7 +159,7 @@ def _compare_preset(
 
 
 def _write_compare_presets(user_id: str, presets: list[dict]) -> None:
-    write_compare_briefings(COMPARE_DATA_ROOT / user_id, presets)
+    write_compare_briefings(compare_data_root() / user_id, presets)
 
 
 class _FakeOfficialAlertSource:

--- a/tests/tdd/test_alert_urgency.py
+++ b/tests/tdd/test_alert_urgency.py
@@ -39,7 +39,7 @@ from app.trip import Trip
 from app.user import SavedLocation
 
 from tests.helpers.alert_log_fixtures import (
-    COMPARE_DATA_ROOT, LAT, LON, clean_compare_user, fresh_user, gust_alert_trip,
+    LAT, LON, clean_compare_user, compare_data_root, fresh_user, gust_alert_trip,
     read_log, settings_email_only, weather,
 )
 from tests.helpers.compare_briefings import write_compare_briefings
@@ -450,7 +450,7 @@ def test_compare_radar_two_locations_convective_and_moderate_logs_highest():
     clean_compare_user(uid)
     try:
         loc_a, loc_b = _setup_two_locations(uid)
-        write_compare_briefings(COMPARE_DATA_ROOT / uid, [{
+        write_compare_briefings(compare_data_root() / uid, [{
             "id": "cp-ac12", "name": "Vergleich AC12", "user_id": uid,
             "location_ids": [loc_a, loc_b], "schedule": "daily", "weekday": 4,
             "profil": "ALLGEMEIN", "hour_from": 9, "hour_to": 16,
@@ -505,7 +505,7 @@ def test_compare_radar_two_non_convective_locations_logs_the_higher_one():
     clean_compare_user(uid)
     try:
         loc_a, loc_b = _setup_two_locations(uid)
-        write_compare_briefings(COMPARE_DATA_ROOT / uid, [{
+        write_compare_briefings(compare_data_root() / uid, [{
             "id": "cp-ac12b", "name": "Vergleich AC12b", "user_id": uid,
             "location_ids": [loc_a, loc_b], "schedule": "daily", "weekday": 4,
             "profil": "ALLGEMEIN", "hour_from": 9, "hour_to": 16,
@@ -567,7 +567,7 @@ def test_compare_official_two_warnings_logs_highest():
     try:
         loc_a, loc_b = _setup_two_locations(uid)
         register_official_alert_source(_TwoLevelSource())
-        write_compare_briefings(COMPARE_DATA_ROOT / uid, [{
+        write_compare_briefings(compare_data_root() / uid, [{
             "id": "cp-ac13", "name": "Vergleich AC13", "user_id": uid,
             "location_ids": [loc_a, loc_b], "schedule": "daily", "weekday": 4,
             "profil": "ALLGEMEIN", "hour_from": 9, "hour_to": 16,

--- a/tests/tdd/test_compare_alert_channel_delivery.py
+++ b/tests/tdd/test_compare_alert_channel_delivery.py
@@ -89,7 +89,13 @@ pytestmark = pytest.mark.live
 # (`src/app/loader.py:318`) und laeuft damit an der data-root-Isolation der
 # conftest vorbei — die Preset-Dateien muessen deshalb genau hier liegen und
 # werden im `finally` restlos wieder entfernt.
-DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
+def _data_root_users() -> Path:
+    """Nutzer-Wurzel der Compare-Preset-Ablage — Funktion statt Konstante
+    (#1595): ``get_data_root()`` liefert erst zur Laufzeit die von der
+    #1133-Fixture gesetzte Basis, eine Konstante waere beim Import gebunden."""
+    from app.loader import get_data_root
+
+    return get_data_root() / "users"
 
 
 # ---------------------------------------------------------------------------
@@ -255,7 +261,7 @@ def _compare_preset(preset_id: str, location_ids: list[str], **extra) -> dict:
 
 
 def _clean_user(user_id: str) -> None:
-    d = DATA_ROOT / user_id
+    d = _data_root_users() / user_id
     if d.exists():
         shutil.rmtree(d)
 
@@ -285,7 +291,7 @@ def _setup_single_location_preset(
         user_id=user_id,
     )
     write_compare_briefings(
-        DATA_ROOT / user_id, [_compare_preset(preset_id, [loc_id], **preset_extra)]
+        _data_root_users() / user_id, [_compare_preset(preset_id, [loc_id], **preset_extra)]
     )
     CompareWeatherSnapshotService(user_id=user_id).save(
         preset_id, loc_id, _pwd(loc_id, location_name, 47.07, 15.44, 2.0)
@@ -310,7 +316,7 @@ def _setup_two_location_preset(
             user_id=user_id,
         )
     write_compare_briefings(
-        DATA_ROOT / user_id,
+        _data_root_users() / user_id,
         [_compare_preset(preset_id, [o[0] for o in orte], **preset_extra)],
     )
     snapshots = CompareWeatherSnapshotService(user_id=user_id)
@@ -453,7 +459,7 @@ def test_ac11_missing_send_telegram_key_stays_email_only_while_optin_user_gets_t
         # Gegenprobe am geschriebenen Rohdict: der Schluessel darf wirklich
         # nicht existieren (sonst prueft der Test einen anderen Fall).
         raw_a = json.loads(
-            (DATA_ROOT / uid_a / "briefings" / f"{preset_a}.json").read_text()
+            (_data_root_users() / uid_a / "briefings" / f"{preset_a}.json").read_text()
         )
         assert "send_telegram" not in raw_a, (
             "Setup-Kontrolle: das Preset von Nutzer A darf den Schluessel "
@@ -833,7 +839,7 @@ def test_k6_telegram_style_rich_or_absent_keeps_one_bubble_per_location(monkeypa
         _write_tier(uid_absent, "standard")
         _setup_two_location_preset(uid_absent, preset_absent, send_telegram=True)
         raw = json.loads(
-            (DATA_ROOT / uid_absent / "briefings" / f"{preset_absent}.json").read_text()
+            (_data_root_users() / uid_absent / "briefings" / f"{preset_absent}.json").read_text()
         )
         assert "display_config" not in raw, (
             "Setup-Kontrolle: das Preset von Nutzer B darf gar kein "

--- a/tests/tdd/test_compare_alert_channel_threshold.py
+++ b/tests/tdd/test_compare_alert_channel_threshold.py
@@ -72,7 +72,6 @@ import threading
 import urllib.parse
 import uuid
 from datetime import date, datetime, timedelta, timezone
-from pathlib import Path
 
 from app.config import Settings
 from app.loader import save_location

--- a/tests/tdd/test_compare_alert_channel_threshold.py
+++ b/tests/tdd/test_compare_alert_channel_threshold.py
@@ -44,9 +44,10 @@ und lokalem HTTP-Stub auf 127.0.0.1 umgelenkt — Muster 1:1 aus
 ``tests/tdd/test_alert_channel_threshold.py`` (Trip-Vorlage, S3b-2a).
 
 Pfadregel #1409: keine Datei dieses Moduls referenziert einen festen
-Hauptrepo-Pfad für den Prüfling — ``DATA_ROOT`` ist die im ganzen
-Ortsvergleichs-Testbestand dokumentierte, bewusste Ausnahme (cwd-relative
-Compare-Preset-Ablage, s.o.), keine Prüflings-Kopie aus dem Hauptrepo.
+Hauptrepo-Pfad für den Prüfling. Die früher hier dokumentierte Ausnahme
+``DATA_ROOT`` (cwd-relative Compare-Preset-Ablage) ist mit #1595 entfallen —
+der Compare-Loader löst die Datenwurzel jetzt über ``get_data_root()`` auf,
+also über dieselbe Basis wie die #1133-Testisolation.
 
 Fallen, die die Tests unten gezielt bewachen (Team-Lead-Auftrag):
   1. AC-3 — Schleifen-Falle: das Kanal-Set entsteht je PRESET, der Split muss
@@ -116,7 +117,9 @@ from tests.tdd.test_compare_radar_alert import (
     _write_preset_file,
 )
 
-DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
+# (#1595) Die frühere Konstante DATA_ROOT ist entfallen — die Presets legt
+# ``_write_preset_file`` aus test_compare_radar_alert.py ab, das die Wurzel
+# über ``get_data_root()`` auflöst.
 
 
 # ═══════════════════════════ Transport-Stubs (echtes 127.0.0.1) ═══════════

--- a/tests/tdd/test_compare_alert_day_window.py
+++ b/tests/tdd/test_compare_alert_day_window.py
@@ -195,10 +195,12 @@ class Szenario:
         self.preset_id = f"cp-1584c-{uuid.uuid4().hex[:6]}"
         self.location_id = "loc-1"
 
-        # Der Compare-Preset-Loader liest ``data/users/...`` cwd-relativ
-        # (``loader.load_compare_presets(data_root="data")``) — ohne chdir
-        # landete die Fixture im echten Repo-Baum und der #1265-Waechter aus
-        # tests/conftest.py wuerde den Test failen.
+        # Issue #1595: der Compare-Preset-Loader liest NICHT mehr cwd-relativ,
+        # sondern ueber ``get_data_root()``. Die Fixture wird deshalb unter der
+        # aufgeloesten Wurzel abgelegt (s.u.); das chdir bleibt als zweite
+        # Sicherung gegen versehentlich relative Schreibzugriffe, die sonst im
+        # echten Repo-Baum landen und den #1265-Waechter aus tests/conftest.py
+        # ausloesen wuerden.
         monkeypatch.chdir(tmp_path)
         # tests/conftest.py::_use_fixture_provider setzt diese Variable fuer
         # jeden Test; sie haette in ``get_provider()`` Vorrang vor der
@@ -231,7 +233,9 @@ class Szenario:
         if fenster is not None:
             preset["day_window_start_hour"] = fenster[0]
             preset["day_window_end_hour"] = fenster[1]
-        write_compare_briefings(tmp_path / "data" / "users" / self.user_id, [preset])
+        from app.loader import get_data_root
+
+        write_compare_briefings(get_data_root() / "users" / self.user_id, [preset])
         # Fuer den Versandpfad-Test (F001): dasselbe Preset-Dict, das auch auf
         # der Platte liegt — `send_one_compare_preset()` bekommt es direkt.
         self.preset = preset

--- a/tests/tdd/test_compare_alert_metric_gating.py
+++ b/tests/tdd/test_compare_alert_metric_gating.py
@@ -43,7 +43,13 @@ from app.user import SavedLocation
 
 from tests.helpers.compare_briefings import write_compare_briefings
 
-DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
+def _data_root_users() -> Path:
+    """Nutzer-Wurzel der Compare-Preset-Ablage — Funktion statt Konstante
+    (#1595): ``get_data_root()`` liefert erst zur Laufzeit die von der
+    #1133-Fixture gesetzte Basis, eine Konstante waere beim Import gebunden."""
+    from app.loader import get_data_root
+
+    return get_data_root() / "users"
 
 
 # ───────────────────────── Helfer (mock-frei) ──────────────────────────────
@@ -51,7 +57,7 @@ DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
 def _clean_user(user_id: str) -> None:
     import shutil
 
-    d = DATA_ROOT / user_id
+    d = _data_root_users() / user_id
     if d.exists():
         shutil.rmtree(d)
 
@@ -129,7 +135,7 @@ def _preset_with_active_metrics(
 
 def _write_preset_file(user_id: str, presets: list[dict]) -> Path:
     # Issue #1250 S7b Cutover: per-Datei briefings/<id>.json (kind="vergleich").
-    return write_compare_briefings(DATA_ROOT / user_id, presets)
+    return write_compare_briefings(_data_root_users() / user_id, presets)
 
 
 def _run_scenario(

--- a/tests/tdd/test_compare_alert_paused_archived_silent.py
+++ b/tests/tdd/test_compare_alert_paused_archived_silent.py
@@ -47,8 +47,9 @@ Quellen sind echte, zaehlende Konfigurations-Seams (`_CountingWeatherSource`,
 Muster AG1 `test_compare_alert_channels.py`) benutzt und setzt am
 VERBRAUCHENDEN Modul an, nie am Definitionsort.
 
-Pfadregel #1409: `DATA_ROOT` wird relativ zur eigenen Testdatei aufgeloest,
-nie ueber einen festen Hauptrepo-Pfad.
+Pfadregel #1409: kein fester Hauptrepo-Pfad. Seit #1595 loest
+`_data_root_users()` die Nutzer-Wurzel ueber `get_data_root()` auf, also
+ueber dieselbe Basis, die der Compare-Loader liest.
 """
 from __future__ import annotations
 
@@ -62,7 +63,13 @@ from app.user import SavedLocation
 
 from tests.helpers.compare_briefings import write_compare_briefings
 
-DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
+def _data_root_users() -> Path:
+    """Nutzer-Wurzel der Compare-Preset-Ablage — Funktion statt Konstante
+    (#1595): ``get_data_root()`` liefert erst zur Laufzeit die von der
+    #1133-Fixture gesetzte Basis, eine Konstante waere beim Import gebunden."""
+    from app.loader import get_data_root
+
+    return get_data_root() / "users"
 
 PAUSED_AT = "2026-07-30T08:00:00Z"
 ARCHIVED_AT = "2026-07-01T00:00:00Z"
@@ -75,7 +82,7 @@ def _uid(prefix: str) -> str:
 
 
 def _clean_user(user_id: str) -> None:
-    d = DATA_ROOT / user_id
+    d = _data_root_users() / user_id
     if d.exists():
         shutil.rmtree(d, ignore_errors=True)
 
@@ -201,7 +208,7 @@ def _preset(
 
 def _write_preset_file(user_id: str, presets: list[dict]) -> Path:
     # Issue #1250 S7b Cutover: per-Datei briefings/<id>.json (kind="vergleich").
-    return write_compare_briefings(DATA_ROOT / user_id, presets)
+    return write_compare_briefings(_data_root_users() / user_id, presets)
 
 
 def _setup_deviation_case(uid: str, preset: dict) -> _CountingWeatherSource:

--- a/tests/tdd/test_compare_alert_quiet_hours_precedes_fetch.py
+++ b/tests/tdd/test_compare_alert_quiet_hours_precedes_fetch.py
@@ -45,7 +45,13 @@ from tests.helpers.compare_briefings import write_compare_briefings
 # Pfadregel #1409: Prüfling relativ zur Testdatei auflösen, nie über einen
 # festen Hauptrepo-Pfad — sonst würde ein Worktree gegen die unveränderte
 # Hauptrepo-Kopie prüfen und faelschlich gruen melden.
-DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
+def _data_root_users() -> Path:
+    """Nutzer-Wurzel der Compare-Preset-Ablage — Funktion statt Konstante
+    (#1595): ``get_data_root()`` liefert erst zur Laufzeit die von der
+    #1133-Fixture gesetzte Basis, eine Konstante waere beim Import gebunden."""
+    from app.loader import get_data_root
+
+    return get_data_root() / "users"
 
 VIENNA = ZoneInfo("Europe/Vienna")
 
@@ -55,16 +61,16 @@ VIENNA = ZoneInfo("Europe/Vienna")
 def _clean_user(user_id: str) -> None:
     import shutil
 
-    d = DATA_ROOT / user_id
+    d = _data_root_users() / user_id
     if d.exists():
         shutil.rmtree(d)
 
 
 def _write_user_tier(uid: str, tier: str) -> None:
     """Setzt den Tarif eines Test-Nutzers — Vorbild: `test_issue_1070_daily_
-    alert_limit.py:75-78`. Nutzt bewusst `app.loader.get_data_dir()` statt der
-    lokalen `DATA_ROOT`-Konstante dieser Datei, sonst greift die #1133-
-    Testisolation nicht."""
+    alert_limit.py:75-78`. Nutzt `app.loader.get_data_dir()`; seit #1595 liegt
+    das auf derselben Basis wie `_data_root_users()` — beide folgen der
+    #1133-Testisolation."""
     from app.loader import get_data_dir
 
     d = get_data_dir(uid)
@@ -194,7 +200,7 @@ def _preset_with_quiet_hours(
 
 def _write_preset_file(user_id: str, presets: list[dict]) -> Path:
     # Issue #1250 S7b Cutover: per-Datei briefings/<id>.json (kind="vergleich").
-    return write_compare_briefings(DATA_ROOT / user_id, presets)
+    return write_compare_briefings(_data_root_users() / user_id, presets)
 
 
 # ═══════════════════════════════ AC-4 ════════════════════════════════════════

--- a/tests/tdd/test_compare_alert_recipient_settings.py
+++ b/tests/tdd/test_compare_alert_recipient_settings.py
@@ -48,7 +48,13 @@ from tests.helpers.compare_briefings import write_compare_briefings
 
 # Issue #1409: Pruefling relativ zur Testdatei aufloesen, nie ueber den
 # festen Hauptrepo-Pfad (sonst falsches Gruen aus einem Worktree heraus).
-DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
+def _data_root_users() -> Path:
+    """Nutzer-Wurzel der Compare-Preset-Ablage — Funktion statt Konstante
+    (#1595): ``get_data_root()`` liefert erst zur Laufzeit die von der
+    #1133-Fixture gesetzte Basis, eine Konstante waere beim Import gebunden."""
+    from app.loader import get_data_root
+
+    return get_data_root() / "users"
 
 SETTINGS_MAIL = "konto-settings@example.invalid"
 PRESET_MAIL = "fremde-adresse@example.com"
@@ -62,7 +68,7 @@ def _uid(suffix: str) -> str:
 
 
 def _clean_user(user_id: str) -> None:
-    d = DATA_ROOT / user_id
+    d = _data_root_users() / user_id
     if d.exists():
         shutil.rmtree(d, ignore_errors=True)
 
@@ -178,7 +184,7 @@ def _run_deviation_alert(uid: str, presets: list[dict], settings: Settings):
 
     loc = _location("loc-x", "Vergleichsort", 47.0, 11.0)
     save_location(loc, user_id=uid)
-    write_compare_briefings(DATA_ROOT / uid, presets)
+    write_compare_briefings(_data_root_users() / uid, presets)
     for preset in presets:
         CompareWeatherSnapshotService(user_id=uid).save(
             preset["id"], "loc-x",
@@ -266,7 +272,7 @@ def _run_official_alert(uid: str, preset: dict, settings: Settings, **sinks):
     from services.official_alerts import register_official_alert_source
 
     save_location(_location("loc-a", "Hermagor", 46.62, 13.68), user_id=uid)
-    write_compare_briefings(DATA_ROOT / uid, [preset])
+    write_compare_briefings(_data_root_users() / uid, [preset])
     register_official_alert_source(_FakeOfficialAlertSource(46.62, 13.68, [_official_alert()]))
     with _recorded_settings(co_mod) as recorded:
         sent = CompareOfficialAlertService(
@@ -318,7 +324,7 @@ def test_ac2_radar_alert_mail_goes_to_settings_not_preset_empfaenger():
     _clean_user(uid)
     try:
         save_location(_location("loc-r", "Zermatt", 46.0207, 7.7491), user_id=uid)
-        write_compare_briefings(DATA_ROOT / uid, [
+        write_compare_briefings(_data_root_users() / uid, [
             _preset("cp-1452-ac2r", ["loc-r"], radar_alert_enabled=True),
         ])
         frames = [RadarFrame(

--- a/tests/tdd/test_compare_briefing_anchor_and_memory_reset.py
+++ b/tests/tdd/test_compare_briefing_anchor_and_memory_reset.py
@@ -60,6 +60,7 @@ from pathlib import Path
 import pytest
 
 from app.config import Settings
+from app.loader import get_data_root
 from app.models import ForecastDataPoint, SegmentWeatherSummary, ThunderLevel
 from app.user import SavedLocation
 
@@ -312,16 +313,24 @@ def _install_shared_anchor_spy(monkeypatch) -> list[dict]:
 
 @pytest.fixture
 def compare_env(tmp_path, monkeypatch):
-    """Isoliertes Arbeitsverzeichnis: `load_compare_presets()` loest seinen
-    `data_root` relativ zum Arbeitsverzeichnis auf ("data"). Durch das
-    `chdir` landet nichts im echten Repo-Baum (#1265)."""
+    """Isoliertes Arbeitsverzeichnis.
+
+    Issue #1595: `load_compare_presets()` loest seinen `data_root` NICHT mehr
+    relativ zum Arbeitsverzeichnis auf, sondern ueber `get_data_root()` — das
+    `chdir` allein wuerde die Presets also nicht mehr dorthin legen, wo der
+    Pruefling sie liest. Geschrieben wird deshalb unter der aufgeloesten
+    Wurzel (s. `_write_presets`); das `chdir` bleibt als zweite Sicherung, damit
+    ein versehentlich relativer Schreibzugriff nicht im echten Repo-Baum
+    landet (#1265)."""
     monkeypatch.chdir(tmp_path)
     (tmp_path / "data" / "users").mkdir(parents=True, exist_ok=True)
     return tmp_path
 
 
 def _write_presets(tmp_path: Path, user_id: str, presets: list[dict]) -> None:
-    write_compare_briefings(tmp_path / "data" / "users" / user_id, presets)
+    from app.loader import get_data_root
+
+    write_compare_briefings(get_data_root() / "users" / user_id, presets)
 
 
 def _memory_keys(user_id: str, entity_id: str) -> list[str]:
@@ -813,7 +822,7 @@ def test_ac19_handversand_laesst_anker_und_gedaechtnis_unberuehrt(compare_env, m
     monkeypatch.setattr(sds_mod, "Settings", _NoTransportSettings)
     _assert_no_live_channel(_NoTransportSettings())
 
-    result = sds_mod.send_compare_preset(uid, preset_id, str(compare_env / "data"))
+    result = sds_mod.send_compare_preset(uid, preset_id, str(get_data_root()))
     assert result.get("status") == "ok", f"Der Handversand ist nicht durchgelaufen: {result!r}"
     assert len(_RecordingEmailOutput.calls) == 1, (
         f"Der Handversand muss genau eine Mail zustellen, erhalten: "
@@ -1035,7 +1044,7 @@ def test_handversand_delegiert_mit_on_demand_kennzeichen(compare_env, monkeypatc
     monkeypatch.setattr(sds_mod, "Settings", _NoTransportSettings)
     calls = _install_shared_anchor_spy(monkeypatch)
 
-    sds_mod.send_compare_preset(uid, preset_id, str(compare_env / "data"))
+    sds_mod.send_compare_preset(uid, preset_id, str(get_data_root()))
 
     assert len(calls) == 1, (
         f"Auch der Handversand laeuft ueber den geteilten Baustein — erwartet "

--- a/tests/tdd/test_compare_official_alert.py
+++ b/tests/tdd/test_compare_official_alert.py
@@ -27,7 +27,13 @@ from services.official_alerts.models import OfficialAlert
 
 from tests.helpers.compare_briefings import write_compare_briefings
 
-DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
+def _data_root_users() -> Path:
+    """Nutzer-Wurzel der Compare-Preset-Ablage — Funktion statt Konstante
+    (#1595): ``get_data_root()`` liefert erst zur Laufzeit die von der
+    #1133-Fixture gesetzte Basis, eine Konstante waere beim Import gebunden."""
+    from app.loader import get_data_root
+
+    return get_data_root() / "users"
 
 # Zwei Orte mit klar getrennten Koordinaten (Toleranz der Fake-Quelle 0.05).
 LAT_A, LON_A = 46.62, 13.68   # Hermagor
@@ -45,7 +51,7 @@ _DEFAULT_VALID_TO = _NOW + timedelta(hours=23, minutes=59)
 
 
 def _clean_user(user_id: str) -> None:
-    d = DATA_ROOT / user_id
+    d = _data_root_users() / user_id
     if d.exists():
         shutil.rmtree(d, ignore_errors=True)
 
@@ -110,7 +116,7 @@ def _preset(preset_id, location_ids, empfaenger, *, triggers_enabled=None,
 
 def _write_presets(user_id: str, presets: list[dict]) -> None:
     # Issue #1250 S7b Cutover: per-Datei briefings/<id>.json (kind="vergleich").
-    write_compare_briefings(DATA_ROOT / user_id, presets)
+    write_compare_briefings(_data_root_users() / user_id, presets)
 
 
 def _alert(level=2, hazard="extreme_heat", label="Hitze", region="Hermagor",

--- a/tests/tdd/test_compare_radar_alert.py
+++ b/tests/tdd/test_compare_radar_alert.py
@@ -40,14 +40,25 @@ from app.user import SavedLocation
 
 from tests.helpers.compare_briefings import write_compare_briefings
 
-DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
+def _data_root_users() -> Path:
+    """Nutzer-Wurzel der Compare-Preset-Ablage.
+
+    Funktion statt Konstante (#1595): der Compare-Loader loest die
+    Datenwurzel seit dem Umzug nach ``/var/lib/gregor`` ueber
+    ``get_data_root()`` auf. Eine Modul-Konstante waere beim Import gebunden,
+    also VOR der #1133-Fixture -- die Tests schrieben dann dorthin, wo der
+    Pruefling nicht liest, und waren gruen, ohne etwas zu bewachen.
+    """
+    from app.loader import get_data_root
+
+    return get_data_root() / "users"
 
 
 # ───────────────────────── Fixtures & Builder ───────────────────────────────
 
 
 def _clean_user(user_id: str) -> None:
-    d = DATA_ROOT / user_id
+    d = _data_root_users() / user_id
     if d.exists():
         shutil.rmtree(d)
 
@@ -111,7 +122,7 @@ def _radar_preset(
 
 def _write_preset_file(user_id: str, presets: list[dict]) -> Path:
     # Issue #1250 S7b Cutover: per-Datei briefings/<id>.json (kind="vergleich").
-    return write_compare_briefings(DATA_ROOT / user_id, presets)
+    return write_compare_briefings(_data_root_users() / user_id, presets)
 
 
 class _CoordFrameSource:
@@ -710,12 +721,12 @@ def test_two_users_isolated_locations_and_recipients():
             "Cross-User-Datenleck A→B in der Sperrzeit-Ablage"
         )
 
-        b_dir = DATA_ROOT / user_b
+        b_dir = _data_root_users() / user_b
         if b_dir.exists():
             for p in b_dir.rglob("*"):
                 if p.is_file():
                     assert preset_a_id not in p.name, f"Cross-User-Datenleck A→B in {p}"
-        a_dir = DATA_ROOT / user_a
+        a_dir = _data_root_users() / user_a
         for p in a_dir.rglob("*"):
             if p.is_file():
                 assert preset_b_id not in p.name, f"Cross-User-Datenleck B→A in {p}"

--- a/tests/tdd/test_issue_1170_compare_alert_config.py
+++ b/tests/tdd/test_issue_1170_compare_alert_config.py
@@ -37,7 +37,13 @@ from app.user import SavedLocation
 
 from tests.helpers.compare_briefings import write_compare_briefings
 
-DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
+def _data_root_users() -> Path:
+    """Nutzer-Wurzel der Compare-Preset-Ablage — Funktion statt Konstante
+    (#1595): ``get_data_root()`` liefert erst zur Laufzeit die von der
+    #1133-Fixture gesetzte Basis, eine Konstante waere beim Import gebunden."""
+    from app.loader import get_data_root
+
+    return get_data_root() / "users"
 
 
 # ───────────────────────── Helfer (1:1 aus test_issue_1169) ─────────────────
@@ -45,7 +51,7 @@ DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
 def _clean_user(user_id: str) -> None:
     import shutil
 
-    d = DATA_ROOT / user_id
+    d = _data_root_users() / user_id
     if d.exists():
         shutil.rmtree(d)
 
@@ -130,7 +136,7 @@ def _preset_with_alert_levels(
 
 def _write_preset_file(user_id: str, presets: list[dict]) -> Path:
     # Issue #1250 S7b Cutover: per-Datei briefings/<id>.json (kind="vergleich").
-    return write_compare_briefings(DATA_ROOT / user_id, presets)
+    return write_compare_briefings(_data_root_users() / user_id, presets)
 
 
 def _preset_multi(preset_id: str, location_ids: list[str], empfaenger: list[str]) -> dict:

--- a/tests/tdd/test_issue_818_radar_briefing_integration.py
+++ b/tests/tdd/test_issue_818_radar_briefing_integration.py
@@ -34,7 +34,13 @@ import pytest
 from app.models import TripReportConfig
 from app.trip import Stage, Trip, Waypoint
 
-DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
+def _data_root_users() -> Path:
+    """Nutzer-Wurzel der Compare-Preset-Ablage — Funktion statt Konstante
+    (#1595): ``get_data_root()`` liefert erst zur Laufzeit die von der
+    #1133-Fixture gesetzte Basis, eine Konstante waere beim Import gebunden."""
+    from app.loader import get_data_root
+
+    return get_data_root() / "users"
 
 # Island: UTC+0 ganzjährig (kein DST) → arrival_calculated-Zeiten = UTC-Zeiten
 # Vereinfacht Timezone-Arithmetik: keine Offset-Korrektur nötig.
@@ -175,7 +181,7 @@ def _write_snapshot(user_id: str, trip_id: str, segment_id, hourly_precip: dict)
 
 
 def _clean_user(uid: str) -> None:
-    d = DATA_ROOT / uid
+    d = _data_root_users() / uid
     if d.exists():
         shutil.rmtree(d)
 
@@ -187,7 +193,7 @@ def _ensure_real_user_dir(uid: str) -> None:
     Existenz des Nutzerverzeichnisses voraus. Vor der #1133-Isolation legte
     _save_trip_direct dieses Verzeichnis als Nebeneffekt im echten Baum an.
     """
-    (DATA_ROOT / uid).mkdir(parents=True, exist_ok=True)
+    (_data_root_users() / uid).mkdir(parents=True, exist_ok=True)
 
 
 # --------------------------------------------------------------------------
@@ -517,7 +523,7 @@ def test_ac7_mandantentrennung_isolated():
         _save_trip_direct(_make_active_trip(trip_id_b), uid_b)
 
         # Snapshot der Dateien unter uid_b VOR Lauf von uid_a
-        dir_b = DATA_ROOT / uid_b
+        dir_b = _data_root_users() / uid_b
         files_before = {p: p.stat().st_mtime for p in dir_b.rglob("*") if p.is_file()}
 
         # Lauf unter uid_a
@@ -534,12 +540,12 @@ def test_ac7_mandantentrennung_isolated():
             if p not in files_before:
                 pytest.fail(
                     f"AC-7: Neue Datei unter uid_b nach Lauf von uid_a: "
-                    f"{p.relative_to(DATA_ROOT)}"
+                    f"{p.relative_to(_data_root_users())}"
                 )
             if p.stat().st_mtime != files_before[p]:
                 pytest.fail(
                     f"AC-7: Datei unter uid_b verändert nach Lauf von uid_a: "
-                    f"{p.relative_to(DATA_ROOT)}"
+                    f"{p.relative_to(_data_root_users())}"
                 )
     finally:
         _clean_user(uid_a)

--- a/tests/tdd/test_official_warnings_source_filter.py
+++ b/tests/tdd/test_official_warnings_source_filter.py
@@ -35,7 +35,13 @@ from services.official_alerts.models import OfficialAlert
 
 from tests.helpers.compare_briefings import write_compare_briefings
 
-DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
+def _data_root_users() -> Path:
+    """Nutzer-Wurzel der Compare-Preset-Ablage — Funktion statt Konstante
+    (#1595): ``get_data_root()`` liefert erst zur Laufzeit die von der
+    #1133-Fixture gesetzte Basis, eine Konstante waere beim Import gebunden."""
+    from app.loader import get_data_root
+
+    return get_data_root() / "users"
 
 LAT_A, LON_A = 46.62, 13.68  # Hermagor
 
@@ -50,7 +56,7 @@ _VALID_TO = _NOW + timedelta(hours=11)
 
 
 def _clean_user(user_id: str) -> None:
-    d = DATA_ROOT / user_id
+    d = _data_root_users() / user_id
     if d.exists():
         shutil.rmtree(d, ignore_errors=True)
 
@@ -84,7 +90,7 @@ def _preset(preset_id: str, official_warnings: dict, **extra) -> dict:
 
 def _write_presets(user_id: str, presets: list[dict]) -> None:
     # Issue #1250 S7b Cutover: per-Datei briefings/<id>.json (kind="vergleich").
-    write_compare_briefings(DATA_ROOT / user_id, presets)
+    write_compare_briefings(_data_root_users() / user_id, presets)
 
 
 class _FixedSourceAlertSource:

--- a/tests/unit/test_data_root_switch.py
+++ b/tests/unit/test_data_root_switch.py
@@ -1,0 +1,407 @@
+"""Prueft das Umschalt-Werkzeug fuer die Datenwurzel (Issue #1595, Scheibe 1).
+
+Dieses Werkzeug verschiebt Live-Datenbaeume. Bevor es Staging anfasst, muss es
+selbst geprueft sein — und zwar an einem Wegwerf-Baum, nie an echten Daten.
+
+Kein Netz, keine Mocks: echte Dateisystem-Operationen unter ``tmp_path``. Das
+Verhalten, um das es geht, IST Dateisystem-Verhalten; ein Mock davon wuerde nur
+die eigene Annahme zurueckspiegeln.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.data_root_switch import (
+    compare_fingerprints,
+    detect_regrowth,
+    fingerprint,
+    rollback,
+    switch,
+)
+
+
+def _make_tree(root: Path) -> None:
+    """Legt einen Baum an, der die echte Struktur nachbildet."""
+    (root / "users" / "alice").mkdir(parents=True)
+    (root / "users" / "bob").mkdir(parents=True)
+    (root / "cache").mkdir(parents=True)
+    (root / "users" / "alice" / "user.json").write_text('{"id":"alice"}')
+    (root / "users" / "bob" / "user.json").write_text('{"id":"bob"}')
+    (root / "cache" / "wetter.json").write_text("[]")
+
+
+# --- AC-5: Unversehrtheits-Nachweis, beide Richtungen -----------------------
+#
+# Ein Pruefer, der immer "veraendert" meldet, ist genauso wertlos wie einer,
+# der immer Entwarnung gibt. Deshalb wird BEIDES geprueft.
+
+
+def test_fingerprint_meldet_keine_abweichung_wenn_nichts_passiert(tmp_path):
+    """GIVEN unveraenderter Baum / WHEN zweimal erfasst / THEN keine Abweichung."""
+    root = tmp_path / "data"
+    _make_tree(root)
+
+    assert compare_fingerprints(fingerprint(root), fingerprint(root)) == []
+
+
+def test_fingerprint_erkennt_geaenderten_inhalt(tmp_path):
+    """GIVEN erfasster Baum / WHEN Dateiinhalt geaendert / THEN Abweichung gemeldet."""
+    root = tmp_path / "data"
+    _make_tree(root)
+    vorher = fingerprint(root)
+
+    (root / "users" / "alice" / "user.json").write_text('{"id":"alice","tier":"free"}')
+
+    abweichungen = compare_fingerprints(vorher, fingerprint(root))
+    assert abweichungen, "geaenderter Inhalt wurde nicht bemerkt"
+    assert any("users/alice/user.json" in a for a in abweichungen)
+
+
+def test_fingerprint_erkennt_neue_datei(tmp_path):
+    """GIVEN erfasster Baum / WHEN Datei ergaenzt / THEN Abweichung gemeldet."""
+    root = tmp_path / "data"
+    _make_tree(root)
+    vorher = fingerprint(root)
+
+    (root / "users" / "carol").mkdir(parents=True)
+    (root / "users" / "carol" / "user.json").write_text('{"id":"carol"}')
+
+    abweichungen = compare_fingerprints(vorher, fingerprint(root))
+    assert any("users/carol/user.json" in a for a in abweichungen)
+
+
+def test_fingerprint_erkennt_geloeschte_datei(tmp_path):
+    """GIVEN erfasster Baum / WHEN Datei geloescht / THEN Abweichung gemeldet."""
+    root = tmp_path / "data"
+    _make_tree(root)
+    vorher = fingerprint(root)
+
+    (root / "users" / "bob" / "user.json").unlink()
+
+    abweichungen = compare_fingerprints(vorher, fingerprint(root))
+    assert any("users/bob/user.json" in a for a in abweichungen)
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root darf alles lesen — Test waere wirkungslos")
+def test_fingerprint_scheitert_laut_bei_unlesbarer_datei(tmp_path):
+    """GIVEN eine unlesbare Datei / WHEN erfasst / THEN Fehler statt stiller Luecke.
+
+    Der Fehler vom 2026-08-07 in Reinform: Ein Werkzeug, das unlesbare Dateien
+    ueberspringt, liefert ein unvollstaendiges Ergebnis, das wie ein
+    vollstaendiges aussieht. Genau so entstuende eine Sicherung, die den
+    entscheidenden Datensatz nicht enthaelt.
+    """
+    root = tmp_path / "data"
+    _make_tree(root)
+    gesperrt = root / "users" / "alice" / "user.json"
+    gesperrt.chmod(0o000)
+
+    try:
+        with pytest.raises(PermissionError):
+            fingerprint(root)
+    finally:
+        gesperrt.chmod(0o600)
+
+
+# --- AC-6: Rueckbau stellt den Ausgangszustand her --------------------------
+
+
+def test_rollback_stellt_baum_identisch_wieder_her(tmp_path):
+    """GIVEN umgeschalteter Baum / WHEN Rueckbau / THEN Inhalt identisch zu vorher."""
+    quelle = tmp_path / "repo" / "data"
+    quelle.parent.mkdir(parents=True)
+    _make_tree(quelle)
+    vorher = fingerprint(quelle)
+    ziel = tmp_path / "var" / "gregor"
+
+    switch(quelle, ziel, mode="absent")
+    assert not quelle.exists(), "alter Ort muss nach dem Umschalten weg sein"
+
+    rollback(quelle, ziel)
+
+    assert compare_fingerprints(vorher, fingerprint(quelle)) == []
+    assert not ziel.exists(), "Zielort muss nach dem Rueckbau geraeumt sein"
+
+
+def test_rollback_raeumt_auch_die_sperrdatei_weg(tmp_path):
+    """GIVEN Stufe-B-Sperre am alten Ort / WHEN Rueckbau / THEN Baum wieder da."""
+    quelle = tmp_path / "repo" / "data"
+    quelle.parent.mkdir(parents=True)
+    _make_tree(quelle)
+    vorher = fingerprint(quelle)
+    ziel = tmp_path / "var" / "gregor"
+
+    switch(quelle, ziel, mode="file")
+    assert quelle.is_file(), "Stufe B muss eine DATEI am alten Ort hinterlassen"
+
+    rollback(quelle, ziel)
+
+    assert quelle.is_dir()
+    assert compare_fingerprints(vorher, fingerprint(quelle)) == []
+
+
+# --- AC-2: Stufe B macht Zugriffe laut statt still --------------------------
+
+
+def test_stufe_b_laesst_zugriff_mit_notadirectory_scheitern(tmp_path):
+    """GIVEN Sperrdatei am alten Ort / WHEN Zugriff auf data/... / THEN NotADirectoryError.
+
+    Das ist der ganze Zweck von Stufe B: Ein Leser, der den alten relativen
+    Pfad benutzt, soll scheitern statt stillschweigend ein leeres Ergebnis zu
+    liefern (Muster "leer != unbekannt", #1492).
+    """
+    quelle = tmp_path / "repo" / "data"
+    quelle.parent.mkdir(parents=True)
+    _make_tree(quelle)
+    ziel = tmp_path / "var" / "gregor"
+
+    switch(quelle, ziel, mode="file")
+
+    with pytest.raises(NotADirectoryError):
+        (quelle / "users" / "alice" / "user.json").read_text()
+
+
+# --- AC-1: Detektor fuer nachgewachsene Pfade -------------------------------
+
+
+def test_detektor_meldet_nachgewachsene_dateien_mit_pfad(tmp_path):
+    """GIVEN umgeschaltet / WHEN am alten Ort etwas entsteht / THEN mit Pfad gemeldet."""
+    quelle = tmp_path / "repo" / "data"
+    quelle.parent.mkdir(parents=True)
+    _make_tree(quelle)
+    ziel = tmp_path / "var" / "gregor"
+    switch(quelle, ziel, mode="absent")
+
+    # Ein Prozess benutzt den relativen Pfad und legt neu an:
+    (quelle / "users" / "ghost").mkdir(parents=True)
+    (quelle / "users" / "ghost" / "user.json").write_text("{}")
+
+    gefunden = detect_regrowth(quelle)
+    assert any("users/ghost/user.json" in g for g in gefunden), (
+        f"Detektor hat den nachgewachsenen Pfad nicht gemeldet: {gefunden}"
+    )
+
+
+def test_detektor_schweigt_wenn_nichts_nachwaechst(tmp_path):
+    """GIVEN umgeschaltet / WHEN nichts passiert / THEN leere Meldung.
+
+    Gegenprobe zum Test darueber: Ein Detektor, der immer etwas meldet, wuerde
+    den 24-Stunden-Lauf wertlos machen.
+    """
+    quelle = tmp_path / "repo" / "data"
+    quelle.parent.mkdir(parents=True)
+    _make_tree(quelle)
+    ziel = tmp_path / "var" / "gregor"
+    switch(quelle, ziel, mode="absent")
+
+    assert detect_regrowth(quelle) == []
+
+
+# --- Bereits vorhandenes Ziel: die Wirklichkeit, nicht die bequeme Lage -----
+#
+# Auf Staging legt systemd (StateDirectory) `/var/lib/gregor-staging` bei JEDEM
+# Dienststart an. Das Ziel existiert also praktisch immer schon, bevor
+# umgeschaltet wird. Verschiebt das Werkzeug den Baum dann HINEIN statt DARAUF,
+# liegt alles eine Ebene zu tief, kein Dienst findet etwas — und der Detektor am
+# alten Ort schweigt korrekterweise, weil dort nichts ist. Der Fehlschlag waere
+# still. Genau die Fehlerklasse, die diese Scheibe verhindern soll.
+
+
+def test_switch_legt_flach_ab_wenn_das_ziel_schon_existiert(tmp_path):
+    """GIVEN leeres Ziel existiert bereits / WHEN umgeschaltet / THEN Baum liegt flach darunter."""
+    quelle = tmp_path / "repo" / "data"
+    quelle.parent.mkdir(parents=True)
+    _make_tree(quelle)
+    ziel = tmp_path / "var" / "gregor"
+    ziel.mkdir(parents=True)  # wie systemd StateDirectory
+
+    switch(quelle, ziel, mode="absent")
+
+    assert (ziel / "users" / "alice" / "user.json").is_file(), (
+        f"Baum liegt nicht direkt unter dem Ziel: {sorted(p.name for p in ziel.iterdir())}"
+    )
+    assert not (ziel / "data").exists(), "Baum wurde in das Ziel verschachtelt statt darauf gelegt"
+
+
+def test_rollback_stellt_flach_wieder_her_wenn_die_quelle_schon_existiert(tmp_path):
+    """GIVEN alter Ort wurde als leerer Ordner neu angelegt / WHEN Rueckbau / THEN flach."""
+    quelle = tmp_path / "repo" / "data"
+    quelle.parent.mkdir(parents=True)
+    _make_tree(quelle)
+    vorher = fingerprint(quelle)
+    ziel = tmp_path / "var" / "gregor"
+    switch(quelle, ziel, mode="absent")
+
+    quelle.mkdir()  # ein Prozess hat den alten Ort inzwischen wieder angelegt
+
+    rollback(quelle, ziel)
+
+    assert compare_fingerprints(vorher, fingerprint(quelle)) == []
+    assert not ziel.exists(), "Zielort muss nach dem Rueckbau geraeumt sein"
+
+
+def test_switch_verweigert_ein_nicht_leeres_ziel(tmp_path):
+    """GIVEN im Ziel liegt schon etwas / WHEN umgeschaltet / THEN Abbruch statt Vermischung.
+
+    Ein Umzug auf einen Ordner mit Inhalt ist immer ein Bedienfehler. Gelaenge er
+    still, waeren zwei Datenbestaende vermischt — nicht mehr trennbar.
+    """
+    quelle = tmp_path / "repo" / "data"
+    quelle.parent.mkdir(parents=True)
+    _make_tree(quelle)
+    ziel = tmp_path / "var" / "gregor"
+    ziel.mkdir(parents=True)
+    (ziel / "fremd.json").write_text("{}")
+
+    with pytest.raises(FileExistsError):
+        switch(quelle, ziel, mode="absent")
+
+    assert quelle.is_dir(), "bei Abbruch muss die Quelle unberuehrt bleiben"
+    assert (quelle / "users" / "alice" / "user.json").is_file()
+
+
+def test_switch_verweigert_eine_datei_am_zielort(tmp_path):
+    """GIVEN am Zielort liegt eine DATEI / WHEN umgeschaltet / THEN eigener Abbruch.
+
+    Der Abbruch muss aus diesem Werkzeug kommen, nicht zufaellig aus shutil —
+    sonst haengt die Zusicherung an einem fremden Implementierungsdetail.
+    """
+    quelle = tmp_path / "repo" / "data"
+    quelle.parent.mkdir(parents=True)
+    _make_tree(quelle)
+    ziel = tmp_path / "var" / "gregor"
+    ziel.parent.mkdir(parents=True)
+    ziel.write_text("ich bin eine Datei")
+
+    with pytest.raises(FileExistsError) as fehler:
+        switch(quelle, ziel, mode="absent")
+
+    assert str(ziel) in str(fehler.value) and "Abbruch" in str(fehler.value), (
+        f"die Meldung stammt nicht aus diesem Werkzeug, sondern aus shutil: {fehler.value}"
+    )
+    assert quelle.is_dir(), "bei Abbruch muss die Quelle unberuehrt bleiben"
+    assert ziel.read_text() == "ich bin eine Datei", "die fremde Datei darf nicht angetastet werden"
+
+
+# --- Symlinks: sehen aus wie ein Umzug, sind aber keiner ---------------------
+#
+# Ist die Quelle ein Symlink, verschiebt shutil nur den Verweis — der reale
+# Datenbaum bleibt liegen, und das Ziel ist danach selbst nur ein Verweis
+# darauf. Der Aufruf laeuft fehlerfrei durch, der Detektor am alten Ort meldet
+# nichts, und trotzdem ist nichts umgezogen. Scheibe 4 sieht am alten Ort
+# ausdruecklich einen Symlink als Rueckfahrkarte vor — diese Lage wird also
+# real eintreten.
+
+
+def test_switch_verweigert_eine_symlink_quelle(tmp_path):
+    """GIVEN Quelle ist ein Symlink / WHEN umgeschaltet / THEN Abbruch statt Schein-Umzug."""
+    echt = tmp_path / "echt"
+    _make_tree(echt)
+    quelle = tmp_path / "repo" / "data"
+    quelle.parent.mkdir(parents=True)
+    quelle.symlink_to(echt, target_is_directory=True)
+    ziel = tmp_path / "var" / "gregor"
+
+    with pytest.raises(ValueError):
+        switch(quelle, ziel, mode="absent")
+
+    assert (echt / "users" / "alice" / "user.json").is_file(), "der echte Baum muss unberuehrt sein"
+    assert not ziel.exists(), "bei Abbruch darf am Zielort nichts entstehen"
+
+
+def test_switch_verweigert_einen_symlink_am_zielort(tmp_path):
+    """GIVEN am Zielort liegt ein Symlink / WHEN umgeschaltet / THEN Abbruch.
+
+    Ein Symlink auf ein leeres Verzeichnis sieht wie ein leerer Zielordner aus.
+    Der Baum landete dann woanders als angegeben — und GZ_DATA_DIR zeigte auf
+    einen Verweis, dessen Ziel niemand nachgehalten hat.
+    """
+    quelle = tmp_path / "repo" / "data"
+    quelle.parent.mkdir(parents=True)
+    _make_tree(quelle)
+    woanders = tmp_path / "woanders"
+    woanders.mkdir()
+    ziel = tmp_path / "var" / "gregor"
+    ziel.parent.mkdir(parents=True)
+    ziel.symlink_to(woanders, target_is_directory=True)
+
+    with pytest.raises(ValueError):
+        switch(quelle, ziel, mode="absent")
+
+    assert quelle.is_dir(), "bei Abbruch muss die Quelle unberuehrt bleiben"
+    assert not any(woanders.iterdir()), "in das Symlink-Ziel darf nichts geschrieben worden sein"
+
+
+# --- Der Detektor muss die 24 Stunden ueberleben ----------------------------
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root darf alles lesen — Test waere wirkungslos")
+def test_detektor_meldet_auch_eine_unlesbare_nachgewachsene_datei(tmp_path):
+    """GIVEN nachgewachsen: lesbar UND unlesbar / WHEN erfasst / THEN beide gemeldet.
+
+    Der Detektor beantwortet nur, WELCHE Pfade nachgewachsen sind — dafuer
+    braucht er keinen Inhalt. Eine unlesbare nachgewachsene Datei ist sogar ein
+    besonders interessanter Befund und darf die 24-Stunden-Messung nicht
+    abstuerzen lassen. (Die Strenge von fingerprint bleibt davon unberuehrt.)
+    """
+    quelle = tmp_path / "repo" / "data"
+    quelle.parent.mkdir(parents=True)
+    _make_tree(quelle)
+    ziel = tmp_path / "var" / "gregor"
+    switch(quelle, ziel, mode="absent")
+
+    (quelle / "users" / "ghost").mkdir(parents=True)
+    (quelle / "users" / "ghost" / "user.json").write_text("{}")
+    gesperrt = quelle / "users" / "ghost" / "geheim.json"
+    gesperrt.write_text("{}")
+    gesperrt.chmod(0o000)
+
+    try:
+        gefunden = detect_regrowth(quelle)
+        assert any("users/ghost/user.json" in g for g in gefunden), gefunden
+        assert any("users/ghost/geheim.json" in g for g in gefunden), (
+            f"unlesbare nachgewachsene Datei fehlt in der Meldung: {gefunden}"
+        )
+    finally:
+        gesperrt.chmod(0o600)
+
+
+def test_detektor_meldet_auch_symlinks_und_leere_verzeichnisse(tmp_path):
+    """GIVEN nachgewachsen: Symlink, kaputter Symlink, leerer Ordner / THEN alle drei gemeldet.
+
+    Ein Detektor, der etwas uebersieht, meldet `[]` — nicht zu unterscheiden von
+    "nichts passiert". Genau das Muster "leer != unbekannt" (#1492), dem diese
+    Scheibe gilt. Ein neu angelegter Symlink am alten Ort ist typischerweise ein
+    manueller Ops-Handgriff, ein leeres Verzeichnis der Go-Store, der anlegt
+    bevor er schreibt — beides sind Zugriffe auf den alten Pfad, also Befunde.
+    """
+    quelle = tmp_path / "repo" / "data"
+    quelle.parent.mkdir(parents=True)
+    _make_tree(quelle)
+    ziel = tmp_path / "var" / "gregor"
+    switch(quelle, ziel, mode="absent")
+
+    woanders = tmp_path / "woanders"
+    (woanders / "inhalt").mkdir(parents=True)
+    (woanders / "inhalt" / "user.json").write_text("{}")
+
+    (quelle / "users").mkdir(parents=True)
+    (quelle / "users" / "verweis").symlink_to(woanders, target_is_directory=True)
+    (quelle / "users" / "kaputt").symlink_to(tmp_path / "gibt-es-nicht")
+    (quelle / "users" / "leer").mkdir()
+
+    gefunden = detect_regrowth(quelle)
+
+    # Die Art steht mit im Befund — ein als "Verzeichnis" gemeldeter Symlink
+    # wuerde beim Auswerten in die falsche Richtung fuehren.
+    assert "users/verweis (Symlink)" in gefunden, (
+        f"Symlink auf ein Verzeichnis fehlt oder ist falsch benannt: {gefunden}"
+    )
+    assert "users/kaputt (Symlink)" in gefunden, (
+        f"kaputter Symlink fehlt oder ist falsch benannt: {gefunden}"
+    )
+    assert "users/leer (Verzeichnis)" in gefunden, (
+        f"leeres Verzeichnis fehlt oder ist falsch benannt: {gefunden}"
+    )


### PR DESCRIPTION
Nachzug zum Datenwurzel-Umzug (#1595). Die Produktivdaten liegen seit dem 08.08. unter `/var/lib/gregor`; diese Stellen ignorierten `GZ_DATA_DIR` und lasen den relativen Pfad `data` — nach dem Umzug also einen leeren Ordner.

## Ursache: falsche Reihenfolge

Die Analyse zu #1595 hielt fest: *"Code VOR Daten. Eine nicht umgestellte Stelle fände den alten Pfad sonst leer vor."* Die Daten wurden trotzdem zuerst umgezogen. Genau der vorhergesagte Fall trat ein.

**Tatsächlich eingetreten ist nichts davon** — es war kein Ortsvergleich aktiv, und in den vier Stunden wurde keine eingehende Nachricht verarbeitet (Logs geprüft). Das war Glück, nicht Vorsorge.

## Was betroffen war

| | |
|---|---|
| Ortsvergleich-Versand + alle drei Compare-Alarm-Dienste | **still** ausgefallen — `sent=0` ist von "nichts fällig" nicht unterscheidbar |
| Inbound Mail/Telegram | Rückfall auf `"default"` — Nutzerantwort wäre dem falschen Konto zugeordnet worden |
| Go-Diagnosezähler | schrieb weiter in den Projektordner (nur Observability) |

**Nicht betroffen, nachgemessen:** `_load_resend_allowlist` (beide Aufrufer übergeben `data_dir` ausdrücklich — der Default war toter Code), Trip-Briefings, Anmeldung, Scheduler.

## Testbefund: 58 Tests waren grün, ohne etwas zu bewachen

Sie schrieben nach `parents[2]/data/users` — den echten Repo-Ordner — und lasen von dort, während die Isolation aus #1133 auf ein tmp-Verzeichnis zeigte und ins Leere lief. 14 Testdateien nachgezogen; sie laufen jetzt erstmals wirklich isoliert.

`test_compare_alert_channel_delivery.py` war dabei **selbst nicht rot**, lieferte aber die Helfer für eine andere Datei. Wer nur rote Dateien sucht, findet die Datei nicht, die den Fehler liefert.

## Bindungs-Test: erste Fassung bewachte nichts

Der neue Go-Test sollte belegen, dass der Pfad nicht mehr beim Paket-Import feststeht. Erste Fassung war grün — **und blieb grün**, als der alte Initialisierer testweise wieder eingebaut wurde: Der Test setzt die Override-Variable vorher selbst auf `""` und löscht damit die Mutation mit.

Ersetzt durch einen Test, der die Frage direkt stellt (Paket-Variable der Testdatei hält den Wert beim Laden fest). Mutation drin ⇒ rot, Mutation raus ⇒ grün.

## Nicht enthalten

`src/output/channels/email.py` — eine Zeile, bewusst herausgenommen: Das Renderer-Mail-Gate verlangt für diese Datei einen Nachweis gegen eine echt zugestellte Mail. Die Änderung ist unkritisch (Default war toter Code) und wird mit dem nötigen Nachweis nachgezogen. Gate nicht aufgeweicht.

## Vorbestehend rot

`test_ac5_past_segment_no_alert_guard_test` fällt mit altem wie neuem Stand: Ein Radar-Alarm feuert für einen Trip mit ausschließlich vergangenen Segmenten — der #822-Zeitfilter greift nicht. Die Socket-Warnung ist die **Folge** des fälschlichen Sendeversuchs, nicht die Ursache. Produktbefund im Umfeld Ankunft/Zeitfenster, kein Egress-Thema.

## Verifiziert

`go build ./...` fehlerfrei · `go test` openmeteo + mail ok · 143 Kernpfad-Tests grün · 14 angepasste Testdateien grün · 17 weitere Dateien mit demselben Pfadmuster zur Gegenprobe mitgelaufen und grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFziB15Kn8aDEZYe8CoQ31