### PR TITLE
fix: LoC-Gate data-Ausschluss auch fuer Dateinamen mit Sonderzeichen

### DIFF
--- a/openspec.yaml
+++ b/openspec.yaml
@@ -199,6 +199,12 @@ spec_validation:
 # mehrere tausend Phantom-Zeilen auf und blockierte jeden Developer-Agent-
 # Edit unabhaengig vom tatsaechlichen Scope. Keine Aufweichung: echte
 # Code-Aenderungen in src/api/internal/frontend zaehlen unveraendert voll.
+#
+# Quoting-Nachtrag (#1613, 2026-08-08): `git diff --numstat` setzt bei
+# Dateinamen mit Sonderzeichen (z.B. Umlauten) ein fuehrendes `"` samt
+# Oktal-Escapes. Der Anker `^data/` griff dadurch bei genau diesen
+# Dateien nicht -- `^"?data/` toleriert das optionale Anfuehrungszeichen,
+# bleibt aber praezise (matcht NICHT `not_data/subdir/data/foo`).
 scope_guard:
   max_loc_delta: 250
   loc_exclude_patterns:
@@ -214,7 +220,7 @@ scope_guard:
     - "^docs/"
     - "\\.md$"
     - "^\\.gitignore$"
-    - "^data/"
+    - '^"?data/'
 
 # Bash Gate — Projekt-spezifische Whitelist
 # Tools die legitimate Artefakte schreiben (nicht Workflow-State)


### PR DESCRIPTION
Folge-Fix zu PR #1621. git diff --numstat quotet Dateinamen mit Sonderzeichen (Umlaute) in doppelte Anfuehrungszeichen samt Oktal-Escapes -- der Anker ^data/ griff dadurch bei genau diesen Dateien nicht (Restdelta 6823 Zeilen). Neues Pattern toleriert das optionale fuehrende Anfuehrungszeichen, bleibt aber praezise verankert (kein Match auf z.B. andere-daten/data/foo). Gefunden vom developer-Agent in Issue 1613 waehrend der GREEN-Phase, verifiziert per Python-Regex-Test gegen alle vier Fallgruppen.

Generated with Claude Code
https://claude.ai/code/session_01J3iLWZx3rrfRA1eetw43pH