### PR TITLE
fix(#1613): SMS-Kürzel-Legende deckt Mehrfach-Symbol-Metriken ab

### DIFF
--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -40,13 +40,27 @@ def get_sms_symbols():
     `sms_trip.py` (Metriken) — das Frontend fuehrt keine zweite Liste.
     """
     from output.renderers.alert.official_alerts import _HAZARD_LABELS
-    from output.renderers.sms_trip import SMS_SYMBOL_BY_METRIC
+    from output.renderers.sms_trip import (
+        SMS_MULTI_SYMBOLS_BY_METRIC, SMS_SYMBOL_BY_METRIC,
+    )
     from output.tokens.hazard_symbols import HAZARD_SMS_SYMBOLS
+
+    def _symbols_for(metric_id: str) -> list[str]:
+        # SMS_MULTI_SYMBOLS_BY_METRIC hat Vorrang (deckt z.B. "thunder"
+        # bereits vollstaendig ab -> kein Duplikat-Eintrag aus
+        # SMS_SYMBOL_BY_METRIC). Fix #1613.
+        if metric_id in SMS_MULTI_SYMBOLS_BY_METRIC:
+            return [s.rstrip(":") for s in SMS_MULTI_SYMBOLS_BY_METRIC[metric_id]]
+        return [SMS_SYMBOL_BY_METRIC[metric_id].rstrip(":")]
+
+    all_metric_ids = list(SMS_SYMBOL_BY_METRIC.keys()) + [
+        mid for mid in SMS_MULTI_SYMBOLS_BY_METRIC if mid not in SMS_SYMBOL_BY_METRIC
+    ]
 
     return {
         "metrics": [
-            {"metric_id": mid, "sms_symbol": sym.rstrip(":")}
-            for mid, sym in SMS_SYMBOL_BY_METRIC.items()
+            {"metric_id": mid, "sms_symbols": _symbols_for(mid)}
+            for mid in all_metric_ids
         ],
         "hazards": [
             {"hazard": h, "sms_symbol": sym, "label": _HAZARD_LABELS.get(h, h)}

--- a/docs/context/fix-1613-sms-multi-symbols.md
+++ b/docs/context/fix-1613-sms-multi-symbols.md
@@ -1,0 +1,83 @@
+# Context: fix-1613-sms-multi-symbols
+
+## Request Summary
+`/api/sms-symbols` liefert nur Metriken mit genau EINEM SMS-Kürzel (`SMS_SYMBOL_BY_METRIC`). Metriken mit MEHREREN Kürzeln (`SMS_MULTI_SYMBOLS_BY_METRIC`: `wind_chill` → FN/FK/FD/WC, `temperature` → K/D, `temperature_night` → N, `thunder` → zusätzlich TH+:) fehlen strukturell in der Antwort und damit in jeder Legende/Anzeige, die sich auf den Endpoint stützt. PO hat konkret `WC` als fehlend im Trip-Editor bestätigt.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `api/routers/config.py:30-53` | `GET /api/sms-symbols` — Root Cause: serialisiert nur `SMS_SYMBOL_BY_METRIC.items()`, liest `SMS_MULTI_SYMBOLS_BY_METRIC` nie |
+| `src/output/renderers/sms_trip.py:64-90` | `_SMS_SYMBOL_METRIC_IDS` (1:1) → `SMS_SYMBOL_BY_METRIC`, aus `metric_catalog.sms_code` abgeleitet (#1435 E3b) |
+| `src/output/renderers/sms_trip.py:118-123` | `SMS_MULTI_SYMBOLS_BY_METRIC` — die fehlende Quelle: `temperature`→(K,D), `temperature_night`→(N,), `wind_chill`→(FN,FK,FD,WC), `thunder`→(TH:,TH+:) |
+| `frontend/src/lib/components/shared/WeatherMetricsTab.svelte:106-165` | `SmsSymbolCatalog`/`SmsSymbolEntry`-Typen, `smsSymbols` State, `metricSymbols`-Derived (Lookup metric_id → Symbol) |
+| `frontend/src/lib/components/shared/WeatherMetricsTab.svelte:1350-1459` (Sektion „04 — Schwellwerte") | Einzige Stelle, die `metricSymbols[...]` tatsächlich anzeigt — als Badge in `ThresholdMetricRow`, für genau die 8 `SMS_SYMBOL_BY_METRIC`-Metriken (wind, gust, precipitation, rain_probability, thunder, snow_depth, snowfall_limit; `fresh_snow` fehlt hier ebenfalls, aber unstrittig — kein Bestandteil dieses Issues) |
+| `frontend/src/lib/components/shared/weather-metrics-tab/ThresholdMetricRow.svelte` | Zeigt `smsSymbol` als `<code class="sms-symbol">`-Badge neben dem Label — bisheriges alleiniges Anzeige-Muster, ABER an `levels` (Segmented-Control Sensibel/Standard/Robust) gekoppelt |
+| `frontend/src/lib/components/shared/WeatherMetricsTab.svelte:996-1024` (`officialAlertsToggle`-Snippet) | Die tatsächliche „Kürzel-Legende" (`official-alerts-symbol-legend`) — zeigt aber nur `smsSymbols.hazards` (9 Gefahrenarten), NICHT `smsSymbols.metrics`. Kein Ort, an dem Metrik-Kürzel als Fließtext-Legende erscheinen |
+| `frontend/src/lib/components/shared/weather-metrics-tab/WeatherV2Grundauswahl.svelte` | Metrik-Checkbox-Grundauswahl (Sektion 02) — generisch aus `catalog`, zeigt aktuell KEIN Symbol pro Metrik |
+| `frontend/src/lib/components/trip-detail/ActiveMetricRow.svelte` | Zeigt `Kürzel <span>{short}</span>` — ANDERES Konzept (`short`/`metricById`, ein Register-Kürzel für Layout/Spalten-Editor), nicht die SMS-Multi-Symbol-Frage. Nicht Teil dieses Bugs |
+| `tests/unit/test_sms_fidelity_preview.py:36-64` | `ALL_SMS_METRIC_IDS`/`METRIC_TO_SYMBOLS` — unabhängige, absichtlich dupliziert gehaltene Referenzliste für die SMS-Fidelity-Vorschau (#923); bestätigt exakt dieselben Symbol-Zuordnungen wie `sms_trip.py`, nutzt sie aber über einen anderen Endpoint (`/api/_validator/sms-fidelity-preview`) |
+| `docs/reference/api_contract.md:166` | Endpoint-Liste, nur Pfad+Methode, kein Schema — keine Änderung nötig |
+
+## Existing Patterns
+
+- **Ableitung statt Handpflege (#1435 E3b):** `SMS_SYMBOL_BY_METRIC` wird aus `metric_catalog.get_sms_code()` abgeleitet, nicht mehr handgepflegt. `SMS_MULTI_SYMBOLS_BY_METRIC` bleibt bewusst eine eigene Handliste (Kommentar in `sms_trip.py:87-91`: mehrere Symbole pro Metrik, `SMS_SYMBOL_BY_METRIC` wird zusätzlich für Schwellwerte gelesen — Vermischung würde falsche Schwellwert-Einträge erzeugen).
+- **Endpoint-Kommentar bekräftigt die Absicht** (`config.py:31-40`, Issue #1318 AC-9): „die Legende nicht von der tatsächlich versendeten SMS abweichen kann" — genau diese Zusicherung ist durch die Typ-Lücke gebrochen.
+- **Anzeige-Muster bislang 1:1 an Schwellwert-Konfiguration gekoppelt:** Die einzige existierende Stelle, die ein Symbol tatsächlich rendert (`ThresholdMetricRow`), setzt zwingend `levels` (Segmented-Control) voraus. `wind_chill`/`temperature`/`temperature_night` sind aber KEINE Schwellwert-Metriken (keine konfigurierbaren Sensibel/Standard/Robust-Stufen) — für sie existiert **keine** analoge Zeilen-Komponente. Ein reines „Endpoint erweitern" behebt die Backend-Lücke, aber die Frontend-Seite braucht einen neuen Anzeigeort, kein Copy-Paste eines bestehenden.
+
+## Dependencies
+
+- **Upstream:** `metric_catalog.get_sms_code()` (Register), `_SMS_SYMBOL_GRAMMAR` (Ausnahmen TH:/NS24+), `SMS_MULTI_SYMBOLS_BY_METRIC`-Handliste selbst — beide sind bereits korrekt, nur der Endpoint liest die zweite nicht.
+- **Downstream:** `frontend/src/lib/components/shared/WeatherMetricsTab.svelte` (`smsSymbols`/`metricSymbols`) ist der einzige bekannte Konsument von `/api/sms-symbols` im Trip- UND Vergleich-Kontext (`context === 'vergleich'` lädt denselben Endpoint, Zeile 506). Eine additive Erweiterung der Response (`metrics`-Array um weitere Einträge) bricht nichts Bestehendes.
+
+## Existing Specs
+- Kein dediziertes Spec-Dokument zu `/api/sms-symbols` selbst; Herkunft verteilt über `docs/specs/modules/` zu #1318 (AC-9, Endpoint-Einführung), #1410 (Mehrfach-Kürzel-Tabelle), #1450/#1482/#1484 (einzelne Symbol-Nachträge in `sms_trip.py`) — keine davon aktualisiert bislang den Endpoint für Mehrfach-Kürzel.
+
+## Risks & Considerations
+
+- **Offene Design-Frage für `/20-analyse`/`/30-write-spec`:** WO im Frontend sollen die neuen Mehrfach-Symbol-Einträge sichtbar werden? Es gibt noch KEINEN Anzeigeort für `wind_chill`/`temperature`/`temperature_night`-Symbole — weder Schwellwerte-Sektion (keine Levels) noch die Fließtext-Legende (nur Hazards) noch die Grundauswahl (kein Symbol-Slot). PO-Formulierung „Zeile mit Kürzel WC muss sichtbar sein" deutet auf eine NEUE Zeile analog zu `ThresholdMetricRow`, aber ohne Segmented-Control — das ist eine eigene Kompotenten-Entscheidung, nicht bloß eine Endpoint-Erweiterung.
+- **`thunder`'s zweites Kürzel `TH+:`** kollidiert im Antwortformat: `thunder` steht bereits in `SMS_SYMBOL_BY_METRIC` (mit `TH:`) UND in `SMS_MULTI_SYMBOLS_BY_METRIC` (mit `TH:`, `TH+:`) — Response-Struktur muss klären, ob eine Metrik-ID mehrfach im `metrics`-Array erscheinen darf oder ob pro Metrik ein Array von Symbolen zurückkommt (Breaking Change für `SmsSymbolEntry`/`metricSymbols`-Lookup, das aktuell `metric_id → einzelnes sms_symbol` ist).
+- **Bestandsschutz:** `SmsSymbolEntry`-Interface (Frontend, `sms_symbol: string`) müsste ggf. auf `sms_symbol: string | string[]` erweitert werden oder auf mehrere Einträge pro `metric_id` — beides berührt `metricSymbols`-Derived (aktuell `Map<metric_id, string>`, letzter Eintrag gewinnt bei Duplikaten).
+- **Test-Politik:** Kern-Layer, kein Netz nötig — `TestClient(app).get("/sms-symbols")`-Pattern existiert bereits in `tests/tdd/test_sms_snow_symbols.py:539-577` als Vorbild für Backend-AC-Tests.
+
+## Verwandtes Issue
+- **#1435 E3b** — dort bereits als bekannte Lücke vermerkt („`wind_chill` (vier Kürzel) ... bleiben außerhalb"), nie zu eigenem Ticket gemacht. Root Cause und betroffene Zeilen sind identisch mit dieser Analyse.
+
+## Analysis
+
+### Type
+Bug (Label `bug`, `[triage:a] nutzersichtbares Fehlverhalten`).
+
+**Hinweis zum Investigations-Ablauf:** Der dispatchte `bug-intake`-Agent meldete sich zweimal `idle` ohne inhaltlichen Bericht (kein Write/Edit-Tool, konnte nichts hinterlassen — bekanntes Agenten-Muster, siehe Memory `feedback_developer_agents_go_idle_without_report`). Die Bug-Analyse unten stammt daher aus der eigenen Code-Recherche (Context-Phase) + einem `Plan/Sonnet`-Agenten für die strategische Bewertung; beide zentralen Design-Entscheidungen wurden stichprobenartig gegen den Code verifiziert (`buckets.off`-Gate bestätigt an den Zeilen 293/1357-1441).
+
+### Root Cause (bestätigt)
+`GET /api/sms-symbols` (`api/routers/config.py:43-50`) liest ausschließlich `SMS_SYMBOL_BY_METRIC` (1:1), nie `SMS_MULTI_SYMBOLS_BY_METRIC` (`sms_trip.py:118-123`). Frontend hat dadurch für `wind_chill`/`temperature`/`temperature_night` **keine** Symbol-Daten und (bestätigt per Grep) aktuell auch **keinen Anzeigeort** für diese Metriken — die einzige existierende Symbol-Anzeige (`ThresholdMetricRow.svelte`) ist zwingend an eine Schwellwert-Konfiguration gekoppelt, die für diese drei Metriken nicht existiert.
+
+### Design-Entscheidungen (aus Plan-Agent, verifiziert)
+1. **Response-Format:** `/api/sms-symbols` liefert pro `metric_id` künftig `sms_symbols: string[]` statt `sms_symbol: string`. `SMS_MULTI_SYMBOLS_BY_METRIC` hat Vorrang (deckt `thunder` bereits vollständig als `["TH:", "TH+:"]` ab, kein Duplikat mehr), die restlichen 7 `SMS_SYMBOL_BY_METRIC`-Metriken liefern ein Array mit einem Element.
+2. **Neuer Anzeigeort:** Neue, schlanke Komponente (Arbeitstitel `MultiSymbolMetricRow.svelte`, im selben Ordner wie `ThresholdMetricRow.svelte`) — Label + Badge-Liste, **kein** Segmented-Control. Gated über `!buckets.off.includes('wind_chill')` etc. — exakt dasselbe, bereits verifizierte Gate-Muster wie die 7 bestehenden Schwellwert-Zeilen (Zeilen 1357-1441) und Sektion 05 (Zeile 293). Platzierung: Sektion 04 bzw. eigener Unterabschnitt „04b", da inhaltlich verwandt (SMS-Kürzel) aber ohne Schwellwert-Konfiguration.
+
+### Affected Files (with changes)
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `api/routers/config.py` | MODIFY | `/api/sms-symbols`: `metrics`-Array liefert `sms_symbols: string[]`, Merge mit Vorrang für `SMS_MULTI_SYMBOLS_BY_METRIC` |
+| `tests/tdd/test_sms_snow_symbols.py` oder neue Testdatei (Namensregel beachten, nicht issue-nummeriert) | CREATE/MODIFY | AC-Test: `wind_chill` → `["FN","FK","FD","WC"]`, `thunder` → genau `["TH:","TH+:"]` (kein Duplikat), bestehende 1:1-Metriken weiterhin 1-elementige Arrays |
+| `frontend/src/lib/components/shared/WeatherMetricsTab.svelte` | MODIFY | `SmsSymbolEntry`/`SmsSymbolCatalog`-Typen, `metricSymbols`-Derived auf `Record<string, string[]>`, bestehende `ThresholdMetricRow`-Aufrufe auf `metricSymbols['wind']?.[0]` umstellen, neue Zeilen für wind_chill/temperature/temperature_night verdrahten |
+| `frontend/src/lib/components/shared/weather-metrics-tab/MultiSymbolMetricRow.svelte` (Name in Spec final) | CREATE | Label + Badge-Liste, kein Segmented-Control |
+| ggf. `frontend/src/lib/components/shared/weather-metrics-tab/ThresholdMetricRow.svelte` | KEINE ÄNDERUNG | Prop-Signatur (`smsSymbol?: string`) bleibt, Call-Sites liefern weiterhin Einzelwert |
+
+### Scope Assessment
+- Files: 4-5 (2-3 Backend/Test, 2 Frontend)
+- Estimated LoC: ~150-200 (unter dem 250-LoC-Workflow-Limit, kein Override nötig)
+- Risk Level: MEDIUM (Response-Format-Änderung ist technisch breaking, aber `WeatherMetricsTab.svelte` ist der einzige bekannte Konsument — Trip- und Vergleich-Kontext laufen durch dieselbe Instanz, Änderung bleibt kontrolliert)
+
+### Technical Approach
+Test-first im Kern-Layer (kein Netz nötig, `TestClient`-Muster aus `tests/tdd/test_sms_snow_symbols.py:539-577`). Reihenfolge: (1) roter Backend-Test für neues Array-Format inkl. `thunder`-Dedup, (2) Endpoint-Implementierung, (3) Frontend-Typen + Derived, (4) neue Anzeige-Komponente, (5) Wiring in `WeatherMetricsTab.svelte`. Eine Scheibe, kein Split nötig.
+
+### Dependencies
+- Kein bekannter zweiter Konsument von `/api/sms-symbols` außer `WeatherMetricsTab.svelte` (Trip + Vergleich-Kontext).
+- Gates: Renderer-Commit-Gate (#811) greift nicht (`config.py` nicht in der gated Dateiliste). Pendant-Gate (#1481B) greift nicht (neue Komponente liegt in `shared/`). Frontend-Browser-Gate (#1558) greift automatisch beim Deploy, da Scope `frontend-only`/`full-stack` wird — keine Sonderbehandlung nötig.
+
+### Open Questions
+- [ ] Exakter finaler Name der neuen Komponente (Spec-Phase) — `MultiSymbolMetricRow.svelte` ist Arbeitstitel, keine PO-Entscheidung nötig (rein technisch).
+- [ ] Reihenfolge/Platzierung der neuen Zeilen relativ zu den bestehenden 7 Schwellwert-Zeilen — visuell in Spec klären (z.B. als eigener Unterblock nach den Schwellwerten).

--- a/docs/specs/modules/fix_1613_sms_multi_symbols.md
+++ b/docs/specs/modules/fix_1613_sms_multi_symbols.md
@@ -1,0 +1,218 @@
+---
+entity_id: fix_1613_sms_multi_symbols
+type: module
+created: 2026-08-08
+updated: 2026-08-08
+status: draft
+version: "1.0"
+tags: [bug, sms, frontend, api]
+---
+
+# Fix #1613 — SMS-Kürzel für Mehrfach-Symbol-Metriken fehlen im Endpoint und im Frontend
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`GET /api/sms-symbols` liefert bislang nur die acht Metriken aus `SMS_SYMBOL_BY_METRIC`
+(genau ein Kürzel je Metrik). Die drei Metriken `wind_chill` (FN/FK/FD/WC),
+`temperature` (K/D) und `temperature_night` (N) tragen jeweils MEHRERE Kürzel
+(`SMS_MULTI_SYMBOLS_BY_METRIC`) und fehlen dadurch strukturell in der Antwort —
+und damit auch in jeder Anzeige, die sich auf den Endpoint stützt. Der PO hat
+konkret bestätigt, dass `WC` (Gefühlte Temperatur) im Trip-Editor sichtbar
+fehlt. Diese Spec behebt die Backend-Lücke und schafft den bislang nicht
+existierenden Frontend-Anzeigeort für diese drei Metriken.
+
+## Source
+
+- **File:** `api/routers/config.py`
+- **Identifier:** `get_sms_symbols()` (Zeilen 30-55)
+
+> **Schicht-Hinweis:** Diese Spec berührt drei Schichten — Python-Core
+> (`api/routers/config.py`, liest `src/output/renderers/sms_trip.py`),
+> Frontend (`frontend/src/lib/components/shared/`) und einen Kern-Test
+> (`tests/tdd/`). Go-API/`internal/` ist NICHT betroffen.
+
+## Affected Files
+
+| File | Change Type | Beschreibung |
+|------|-------------|--------------|
+| `api/routers/config.py` | MODIFY | `/api/sms-symbols`: `metrics`-Array liefert künftig `sms_symbols: string[]` statt `sms_symbol: string`; Merge mit Vorrang für `SMS_MULTI_SYMBOLS_BY_METRIC` |
+| `tests/tdd/test_sms_snow_symbols.py` | MODIFY | Bestehende AC-8-Tests (`test_ac8_sms_symbols_endpoint_serves_register_symbols`, `test_ac8_sms_symbols_endpoint_keeps_official_snow_hazard`) lesen `e["sms_symbol"]` (Singular) — MUSS auf `e["sms_symbols"][0]` bzw. das neue Array-Format umgestellt werden, sonst brechen sie strukturell. Neue AC-Tests für dieses Issue ergänzen (Namensregel: nicht issue-nummeriert, im selben Modul-Testfile oder in `tests/unit/test_sms_symbols_endpoint.py`, falls thematisch sauberer trennbar) |
+| `frontend/src/lib/components/shared/WeatherMetricsTab.svelte` | MODIFY | `SmsSymbolEntry`/`SmsSymbolCatalog`-Typen auf `sms_symbols: string[]`; `metricSymbols`-Derived auf `Record<string, string[]>`; 7 bestehende `ThresholdMetricRow`-Aufrufe auf `metricSymbols[id]?.[0]` umstellen; 3 neue Zeilen für `temperature`/`temperature_night`/`wind_chill` verdrahten, gegated über `!buckets.off.includes(...)` |
+| `frontend/src/lib/components/shared/weather-metrics-tab/MultiSymbolMetricRow.svelte` | CREATE | Neue, schlanke Zeilen-Komponente: Label + Badge-Liste, KEIN Segmented-Control (analog, aber unabhängig von `ThresholdMetricRow.svelte`) |
+| `frontend/src/lib/components/shared/weather-metrics-tab/__tests__/multiSymbolMetricRowWiring.test.ts` | CREATE | Source-inspizierender Kern-Test (Präzedenz `day_window_card.test.ts`/`weatherMetricsTabDayWindowSave.test.ts`: kein Rendering-Harness für Svelte-5-Runen in `node:test`) — prüft Wiring, Gate und Prop-Übergabe im Quelltext |
+
+## Estimated Scope
+
+- **LoC:** ~150-200
+- **Files:** 5 (2 Backend/Test, 3 Frontend/Test)
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `metric_catalog.get_sms_code()` (Register) | Upstream | Quelle für `SMS_SYMBOL_BY_METRIC` (unverändert) |
+| `SMS_MULTI_SYMBOLS_BY_METRIC` (`src/output/renderers/sms_trip.py:118-123`) | Upstream | Bereits korrekte Handliste — bisher vom Endpoint nie gelesen, das ist die Root Cause |
+| `frontend/src/lib/components/shared/WeatherMetricsTab.svelte` | Downstream | Einziger bekannter Konsument von `/api/sms-symbols`, Trip- UND Vergleich-Kontext (dieselbe Komponenten-Instanz, `context === 'vergleich'` lädt denselben Endpoint) |
+| `ThresholdMetricRow.svelte` | Downstream (unverändert) | Prop-Signatur `smsSymbol?: string` bleibt bestehen; Call-Sites liefern künftig `metricSymbols[id]?.[0]` |
+
+## Implementation Details
+
+```
+# api/routers/config.py — get_sms_symbols()
+
+from output.renderers.sms_trip import SMS_MULTI_SYMBOLS_BY_METRIC, SMS_SYMBOL_BY_METRIC
+
+def _symbols_for(metric_id: str) -> list[str]:
+    # SMS_MULTI_SYMBOLS_BY_METRIC hat Vorrang (deckt z.B. "thunder" bereits
+    # vollstaendig ab -> kein Duplikat-Eintrag mit SMS_SYMBOL_BY_METRIC).
+    if metric_id in SMS_MULTI_SYMBOLS_BY_METRIC:
+        return [s.rstrip(":") for s in SMS_MULTI_SYMBOLS_BY_METRIC[metric_id]]
+    return [SMS_SYMBOL_BY_METRIC[metric_id].rstrip(":")]
+
+all_metric_ids = list(SMS_SYMBOL_BY_METRIC.keys()) + [
+    mid for mid in SMS_MULTI_SYMBOLS_BY_METRIC if mid not in SMS_SYMBOL_BY_METRIC
+]
+# -> 8 + 3 (temperature, temperature_night, wind_chill) = 11 Eintraege,
+#    "thunder" erscheint genau einmal mit 2 Symbolen.
+
+"metrics": [
+    {"metric_id": mid, "sms_symbols": _symbols_for(mid)}
+    for mid in all_metric_ids
+]
+```
+
+```
+# WeatherMetricsTab.svelte
+
+interface SmsSymbolEntry {
+    metric_id: string;
+    sms_symbols: string[];   // vorher: sms_symbol: string
+}
+const metricSymbols = $derived(
+    Object.fromEntries(
+        (smsSymbols?.metrics ?? []).map((m) => [m.metric_id, m.sms_symbols])
+    )
+);
+// bestehende ThresholdMetricRow-Aufrufe:
+//   smsSymbol={metricSymbols['wind']?.[0]}   (statt metricSymbols['wind'])
+// neue Zeilen (Beispiel wind_chill), Gate identisch zum bestehenden Muster:
+{#if !buckets.off.includes('wind_chill')}
+<MultiSymbolMetricRow
+    metricId="wind_chill"
+    label={metricById['wind_chill']?.label ?? 'Gefühlte Temperatur'}
+    symbols={metricSymbols['wind_chill'] ?? []}
+/>
+{/if}
+```
+
+`MultiSymbolMetricRow.svelte` (Props): `metricId: string; label: string; symbols: string[]`.
+Rendert `data-testid="sms-multi-symbol-row-{metricId}"`, je Symbol
+`data-testid="sms-symbol-badge-{metricId}-{symbol}"` als `<code>`-Badge —
+analog zur `.sms-symbol`-Badge-Optik aus `ThresholdMetricRow.svelte`, aber
+ohne Segmented-Control/Schwellwert-Spalte.
+
+## Expected Behavior
+
+- **Input:** `GET /api/sms-symbols` (keine Parameter); Frontend lädt den
+  Endpoint beim Öffnen des Trip- oder Vergleich-Editors (Sektion „04 —
+  Schwellwerte").
+- **Output:** `metrics`-Array mit 11 Einträgen (vorher 8), jeder Eintrag
+  `{"metric_id": str, "sms_symbols": string[]}`; `thunder` einmalig mit
+  `["TH", "TH+"]`; `wind_chill` mit `["FN","FK","FD","WC"]`; `temperature`
+  mit `["K","D"]`; `temperature_night` mit `["N"]`. Frontend zeigt für jede
+  nicht abgewählte Metrik aus diesen 11 eine Zeile mit Label + Kürzel-Badges.
+- **Side effects:** keine (Read-only-Endpoint, keine Persistenz-Änderung).
+
+## Acceptance Criteria
+
+- **AC-1:** Given der Endpoint `/api/sms-symbols` wird aufgerufen / When die
+  Antwort für `metric_id == "wind_chill"` gelesen wird / Then enthält
+  `sms_symbols` genau `["FN","FK","FD","WC"]` (vorher fehlte der Eintrag
+  strukturell — das ist der Bug-Nachweis, rot vor Fix, grün nach Fix).
+  - Test: `TestClient(app).get("/sms-symbols")`-Pattern aus
+    `tests/tdd/test_sms_snow_symbols.py:539-577`, Assertion auf das
+    vollständige Array statt auf String-Presence.
+
+- **AC-2:** Given `thunder` trägt laut `SMS_MULTI_SYMBOLS_BY_METRIC` zwei
+  Kürzel (`TH:`, `TH+:`) / When `/api/sms-symbols` aufgerufen wird / Then
+  erscheint `thunder` genau EINMAL im `metrics`-Array mit
+  `sms_symbols == ["TH", "TH+"]` — kein Duplikat-Eintrag aus
+  `SMS_SYMBOL_BY_METRIC`.
+  - Test: Zählt Einträge mit `metric_id == "thunder"` (muss genau 1 sein) und
+    prüft den vollständigen Array-Inhalt.
+
+- **AC-3:** Given die sieben Nicht-thunder-Metriken aus
+  `SMS_SYMBOL_BY_METRIC` (precipitation, rain_probability, wind, gust,
+  snow_depth, snowfall_limit, fresh_snow) / When `/api/sms-symbols`
+  aufgerufen wird / Then liefert jede davon ein einelementiges Array mit
+  demselben Kürzel wie vor dieser Änderung (Regressionsschutz, u.a. gegen
+  das bestehende AC-8 aus #1435 E3b für `snow_depth`→`SD`,
+  `snowfall_limit`→`SL`).
+  - Test: bestehende `test_ac8_sms_symbols_endpoint_serves_register_symbols`
+    auf das neue Array-Format umgestellt, Werte unverändert erwartet.
+
+- **AC-4:** Given ein Trip-Editor mit aktivierter Metrik „Gefühlte
+  Temperatur" (`wind_chill` nicht in `buckets.off`) / When die
+  Schwellwerte-Sektion im Quelltext auf ihr Wiring geprüft wird / Then ist
+  eine `MultiSymbolMetricRow` mit `metricId="wind_chill"` und
+  `symbols={metricSymbols['wind_chill']}` (nicht leer, nicht hartcodiert)
+  im `!buckets.off.includes('wind_chill')`-Zweig verdrahtet — die
+  Sichtbarkeit von Kürzel `WC`, nicht nur, dass der Endpoint es liefert.
+  - Test: source-inspizierender Frontend-Test (Präzedenz
+    `weatherMetricsTabDayWindowSave.test.ts`: kein Rendering-Harness für
+    Svelte-5-Runen in `node:test`) extrahiert den `wind_chill`-Block und
+    prüft Komponente, Prop-Bindung und Gate-Bedingung im Quelltext. Die
+    tatsächliche Pixel-Sichtbarkeit von „WC" wird zusätzlich bei der
+    Staging-Validierung vor dem Prod-Deploy (Liefer-Workflow Schritt 3,
+    echter Browser) bestätigt — Kern-Layer kann das laut Projekt-Präzedenz
+    nicht rendern.
+
+- **AC-5:** Given `wind_chill` ist abgewählt (`buckets.off` enthält
+  `'wind_chill'`) / When die Schwellwerte-Sektion rendert / Then erscheint
+  KEINE `MultiSymbolMetricRow` für `wind_chill` — exakt dasselbe Gate-Muster
+  wie die sieben bestehenden Schwellwert-Zeilen.
+  - Test: derselbe source-inspizierende Test wie AC-4 prüft, dass der Block
+    in ein `{#if !buckets.off.includes('wind_chill')}` eingebettet ist.
+
+- **AC-6:** Given die sieben bestehenden `ThresholdMetricRow`-Aufrufe lesen
+  künftig `metricSymbols[id]?.[0]` statt `metricSymbols[id]` (Typwechsel
+  `string` → `string[]`) / When der Katalog geladen ist / Then zeigt z.B.
+  die Wind-Zeile weiterhin exakt das Kürzel, das vor dieser Änderung
+  angezeigt wurde — kein Wertverlust durch die Typumstellung.
+  - Test: Backend-Test bestätigt `sms_symbols[0]` für `wind` unverändert;
+    Frontend-Test prüft, dass alle 7 Call-Sites auf `?.[0]` umgestellt sind
+    (kein verbliebener direkter String-Zugriff).
+
+## Known Limitations
+
+- Kein Rendering-Harness für Svelte-5-Runen in diesem `node:test`-Setup
+  (`@testing-library/svelte` nicht installiert) — der Frontend-Kern-Test
+  bleibt source-inspizierend (Präzedenz `day_window_card.test.ts`). Die
+  echte Browser-Sichtbarkeit wird final bei der Staging-Validierung vor dem
+  Prod-Deploy geprüft, nicht im Kern-Layer.
+- Response-Format-Änderung (`sms_symbol: string` → `sms_symbols: string[]`)
+  ist technisch ein Breaking Change, kein additiver — kontrolliert, da
+  `WeatherMetricsTab.svelte` der einzige bekannte Konsument ist (Trip- und
+  Vergleich-Kontext laufen durch dieselbe Instanz).
+- `fresh_snow` fehlt weiterhin in der Schwellwerte-Sektion (kein Bestandteil
+  dieses Issues, laut Kontext-Analyse unstrittig).
+- Reihenfolge der drei neuen Zeilen (`temperature`, `temperature_night`,
+  `wind_chill`) folgt der Reihenfolge in `SMS_MULTI_SYMBOLS_BY_METRIC` — keine
+  gesonderte PO-Vorgabe dazu bekannt.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Keine Entscheidungsfläche im Sinne von `docs/adr/README.md`
+  (kein neuer Kanal, Provider, Datenmodell/Persistenz, Auth oder
+  Editor-Paradigma) — reine Bugfix-Erweiterung eines bestehenden Read-only-
+  Endpoints und eine neue, geteilte Anzeige-Komponente im etablierten Muster.
+
+## Changelog
+
+- 2026-08-08: Initial spec created (Issue #1613)

--- a/frontend/src/lib/components/shared/WeatherMetricsTab.svelte
+++ b/frontend/src/lib/components/shared/WeatherMetricsTab.svelte
@@ -38,6 +38,9 @@
 		type ChannelOverride,
 	} from './weather-metrics-tab/channelMetricLayouts.ts';
 	import ThresholdMetricRow from './weather-metrics-tab/ThresholdMetricRow.svelte';
+	// Fix #1613: Mehrfach-Symbol-Metriken (temperature/temperature_night/wind_chill)
+	// haben keinen Schwellwert -- eigene, schlanke Zeile ohne Segmented-Control.
+	import MultiSymbolMetricRow from './weather-metrics-tab/MultiSymbolMetricRow.svelte';
 	// Issue #1357: Auswertungswahl je Wettergroesse (Mail-Kachelzeile).
 	import AggregationMetricRow from './weather-metrics-tab/AggregationMetricRow.svelte';
 	import {
@@ -105,7 +108,7 @@
 
 	interface SmsSymbolEntry {
 		metric_id: string;
-		sms_symbol: string;
+		sms_symbols: string[];
 	}
 	interface SmsSymbolCatalog {
 		metrics: SmsSymbolEntry[];
@@ -162,7 +165,7 @@
 	let smsSymbols = $state<SmsSymbolCatalog | null>(null);
 	const metricSymbols = $derived(
 		Object.fromEntries(
-			(smsSymbols?.metrics ?? []).map((m: SmsSymbolEntry) => [m.metric_id, m.sms_symbol])
+			(smsSymbols?.metrics ?? []).map((m: SmsSymbolEntry) => [m.metric_id, m.sms_symbols])
 		)
 	);
 	let templates: Template[] = $state([]);
@@ -1357,7 +1360,7 @@
 								{#if !buckets.off.includes('wind')}
 								<ThresholdMetricRow
 									metricId="wind"
-									smsSymbol={metricSymbols['wind']}
+									smsSymbol={metricSymbols['wind']?.[0]}
 									label="Wind (km/h)"
 									levels={[
 										{ id: 'sensibel', label: 'Sensibel', float: 15 },
@@ -1371,7 +1374,7 @@
 								{#if !buckets.off.includes('gust')}
 								<ThresholdMetricRow
 									metricId="gust"
-									smsSymbol={metricSymbols['gust']}
+									smsSymbol={metricSymbols['gust']?.[0]}
 									label="Böen (km/h)"
 									levels={[
 										{ id: 'sensibel', label: 'Sensibel', float: 30 },
@@ -1385,7 +1388,7 @@
 								{#if !buckets.off.includes('precipitation')}
 								<ThresholdMetricRow
 									metricId="precipitation"
-									smsSymbol={metricSymbols['precipitation']}
+									smsSymbol={metricSymbols['precipitation']?.[0]}
 									label="Niederschlag (mm)"
 									levels={[
 										{ id: 'sensibel', label: 'Sensibel', float: 0.3 },
@@ -1399,7 +1402,7 @@
 								{#if !buckets.off.includes('rain_probability')}
 								<ThresholdMetricRow
 									metricId="rain_probability"
-									smsSymbol={metricSymbols['rain_probability']}
+									smsSymbol={metricSymbols['rain_probability']?.[0]}
 									label="Regenwahrsch. (%)"
 									levels={[
 										{ id: 'sensibel', label: 'Sensibel', float: 25 },
@@ -1413,7 +1416,7 @@
 								{#if !buckets.off.includes('thunder')}
 								<ThresholdMetricRow
 									metricId="thunder"
-									smsSymbol={metricSymbols['thunder']}
+									smsSymbol={metricSymbols['thunder']?.[0]}
 									label="Gewitter"
 									levels={[
 										{ id: 'leicht', label: 'Leicht', float: 1.0 },
@@ -1427,7 +1430,7 @@
 								{#if !buckets.off.includes('snow_depth')}
 								<ThresholdMetricRow
 									metricId="snow_depth"
-									smsSymbol={metricSymbols['snow_depth']}
+									smsSymbol={metricSymbols['snow_depth']?.[0]}
 									label="Schneehöhe (cm)"
 									levels={[
 										{ id: 'sensibel', label: 'Sensibel', float: 5 },
@@ -1441,7 +1444,7 @@
 								{#if !buckets.off.includes('snowfall_limit')}
 								<ThresholdMetricRow
 									metricId="snowfall_limit"
-									smsSymbol={metricSymbols['snowfall_limit']}
+									smsSymbol={metricSymbols['snowfall_limit']?.[0]}
 									label="Schneefallgrenze (m)"
 									levels={[
 										{ id: 'sensibel', label: 'Sensibel', float: 2000 },
@@ -1450,6 +1453,28 @@
 									]}
 									currentFloat={smsThresholds['snowfall_limit'] !== undefined && smsThresholds['snowfall_limit'] !== '' ? parseFloat(smsThresholds['snowfall_limit']) : null}
 									onChange={(id, f) => { userTouched = true; smsThresholds = { ...smsThresholds, ['snowfall_limit']: String(f) }; scheduleAutoSave(); }}
+								/>
+								{/if}
+								<!-- Fix #1613: Mehrfach-Symbol-Metriken ohne Schwellwert (kein onChange/levels). -->
+								{#if !buckets.off.includes('temperature')}
+								<MultiSymbolMetricRow
+									metricId="temperature"
+									label={metricById['temperature']?.label ?? 'Temperatur'}
+									symbols={metricSymbols['temperature'] ?? []}
+								/>
+								{/if}
+								{#if !buckets.off.includes('temperature_night')}
+								<MultiSymbolMetricRow
+									metricId="temperature_night"
+									label={metricById['temperature_night']?.label ?? 'Nacht-Tiefsttemperatur'}
+									symbols={metricSymbols['temperature_night'] ?? []}
+								/>
+								{/if}
+								{#if !buckets.off.includes('wind_chill')}
+								<MultiSymbolMetricRow
+									metricId="wind_chill"
+									label={metricById['wind_chill']?.label ?? 'Gefühlte Temperatur'}
+									symbols={metricSymbols['wind_chill'] ?? []}
 								/>
 								{/if}
 							</tbody>

--- a/frontend/src/lib/components/shared/weather-metrics-tab/MultiSymbolMetricRow.svelte
+++ b/frontend/src/lib/components/shared/weather-metrics-tab/MultiSymbolMetricRow.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	// Fix #1613 — Anzeigezeile fuer Metriken mit MEHREREN SMS-Kuerzeln
+	// (wind_chill: FN/FK/FD/WC, temperature: K/D, temperature_night: N).
+	// Analog ThresholdMetricRow.svelte, aber ohne Segmented-Control/Schwellwert
+	// -- diese Metriken haben keinen konfigurierbaren SMS-Schwellwert.
+	// Spec: docs/specs/modules/fix_1613_sms_multi_symbols.md
+
+	interface Props {
+		metricId: string;
+		label: string;
+		symbols: string[];
+	}
+
+	let { metricId, label, symbols }: Props = $props();
+</script>
+
+<tr data-testid="sms-multi-symbol-row-{metricId}" data-metric={metricId}>
+	<td class="metric-label" colspan="3">
+		{label}
+		{#each symbols as symbol (symbol)}
+			<code class="sms-symbol" data-testid="sms-symbol-badge-{metricId}-{symbol}">{symbol}</code>
+		{/each}
+	</td>
+</tr>
+
+<style>
+	.metric-label {
+		padding: 8px;
+		font-size: 14px;
+		color: var(--g-ink);
+	}
+
+	.sms-symbol {
+		font-family: var(--g-font-mono, monospace);
+		font-size: 12px;
+		color: var(--g-ink-2, #555);
+		margin-left: 4px;
+	}
+
+	@media (max-width: 899px) {
+		tr {
+			display: block;
+			margin-bottom: 12px;
+			border-bottom: 1px solid var(--g-rule-soft, #eee);
+			padding-bottom: 8px;
+		}
+
+		td {
+			display: block;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/shared/weather-metrics-tab/__tests__/multiSymbolMetricRowWiring.test.ts
+++ b/frontend/src/lib/components/shared/weather-metrics-tab/__tests__/multiSymbolMetricRowWiring.test.ts
@@ -1,0 +1,137 @@
+// Fix #1613 — SMS-Kuerzel fuer Mehrfach-Symbol-Metriken fehlen im Frontend.
+// Spec: docs/specs/modules/fix_1613_sms_multi_symbols.md § AC-4/AC-5/AC-6
+//
+// `wind_chill` (Gefuehlte Temperatur, FN/FK/FD/WC) hat bislang KEINEN
+// Anzeigeort in der Schwellwerte-Sektion — der PO hat konkret bestaetigt,
+// dass 'WC' im Trip-Editor sichtbar fehlt. Diese Tests pruefen das Wiring
+// der neuen `MultiSymbolMetricRow` fuer `wind_chill` im Quelltext.
+//
+// Kein Rendering-Harness fuer Svelte-5-Runen im node:test-Setup (kein
+// @testing-library/svelte) — daher source-inspizierende Tests
+// (Praezedenz: weatherMetricsTabDayWindowSave.test.ts, day_window_card.test.ts).
+// Die tatsaechliche Pixel-Sichtbarkeit von "WC" wird zusaetzlich bei der
+// Staging-Validierung vor dem Prod-Deploy bestaetigt.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const WEATHER_METRICS_TAB = join(here, '..', '..', 'WeatherMetricsTab.svelte');
+const src = readFileSync(WEATHER_METRICS_TAB, 'utf-8');
+
+/** Isoliert den `{#if !buckets.off.includes('wind_chill')}...{/if}`-Block
+ * um den erwarteten `<MultiSymbolMetricRow metricId="wind_chill" .../>`-Aufruf
+ * (analog dem bestehenden Gate-Muster der sieben ThresholdMetricRow-Zeilen). */
+function windChillGateBlock(): string {
+	const gateRe = /\{#if !buckets\.off\.includes\('wind_chill'\)\}/;
+	const gateMatch = gateRe.exec(src);
+	assert.ok(
+		gateMatch,
+		"AC-5: kein {#if !buckets.off.includes('wind_chill')}-Gate im Quelltext gefunden — " +
+			'wind_chill hat noch keinen Schwellwerte-Anzeigeort'
+	);
+	const start = gateMatch!.index;
+	const end = src.indexOf('{/if}', start);
+	assert.ok(end > start, 'AC-5: schliessendes {/if} zum wind_chill-Gate nicht gefunden');
+	return src.slice(start, end + '{/if}'.length);
+}
+
+describe('AC-4: MultiSymbolMetricRow ist fuer wind_chill verdrahtet (Kuerzel WC bislang strukturell unsichtbar)', () => {
+	test('WeatherMetricsTab.svelte importiert MultiSymbolMetricRow', () => {
+		assert.match(
+			src,
+			/import MultiSymbolMetricRow from '\.\/weather-metrics-tab\/MultiSymbolMetricRow\.svelte'/,
+			'AC-4: Import von MultiSymbolMetricRow fehlt'
+		);
+	});
+
+	test('der wind_chill-Gate-Block enthaelt genau einen <MultiSymbolMetricRow>-Aufruf', () => {
+		const block = windChillGateBlock();
+		const matches = block.match(/<MultiSymbolMetricRow/g) ?? [];
+		assert.equal(
+			matches.length,
+			1,
+			`AC-4: erwarte genau einen <MultiSymbolMetricRow>-Aufruf im wind_chill-Gate, gefunden ${matches.length}`
+		);
+	});
+
+	test('der Aufruf setzt metricId="wind_chill"', () => {
+		const block = windChillGateBlock();
+		assert.match(
+			block,
+			/<MultiSymbolMetricRow[\s\S]*?metricId="wind_chill"/,
+			'AC-4: metricId="wind_chill" fehlt am MultiSymbolMetricRow-Aufruf'
+		);
+	});
+
+	test("die symbols-Prop bindet an metricSymbols['wind_chill'] -- NICHT hartcodiert", () => {
+		const block = windChillGateBlock();
+		const callMatch = block.match(/<MultiSymbolMetricRow[\s\S]*?\/>/);
+		assert.ok(callMatch, 'AC-4: MultiSymbolMetricRow-Aufruf (selbstschliessendes Tag) nicht gefunden');
+		const call = callMatch![0];
+		assert.match(
+			call,
+			/symbols=\{metricSymbols\['wind_chill'\][^}]*\}/,
+			`AC-4: symbols-Prop muss an metricSymbols['wind_chill'] gebunden sein (nicht hartcodiert), gefunden:\n${call}`
+		);
+		assert.ok(
+			!/symbols=\{\s*\[\s*['"]/.test(call),
+			`AC-4: symbols-Prop darf kein hartcodiertes Array sein (z.B. symbols={['FN','FK','FD','WC']}):\n${call}`
+		);
+	});
+});
+
+describe("AC-5: dasselbe Gate-Muster wie die sieben bestehenden Schwellwert-Zeilen -- Abwahl blendet aus", () => {
+	test("MultiSymbolMetricRow(wind_chill) steht INNERHALB von {#if !buckets.off.includes('wind_chill')} ... {/if}", () => {
+		// windChillGateBlock() wirft bereits, wenn Gate-Start oder -Ende fehlen --
+		// hier zusaetzlich sicherstellen, dass der Row-Aufruf tatsaechlich
+		// ZWISCHEN Gate-Start und {/if} liegt (nicht nur zufaellig irgendwo im Text).
+		const block = windChillGateBlock();
+		const rowIdx = block.indexOf('<MultiSymbolMetricRow');
+		const closeIdx = block.lastIndexOf('{/if}');
+		assert.ok(
+			rowIdx >= 0 && rowIdx < closeIdx,
+			'AC-5: <MultiSymbolMetricRow> fuer wind_chill muss zwischen Gate-Oeffnung und {/if} liegen'
+		);
+	});
+
+	test('exakt dasselbe Gate-Textmuster wie bei den bestehenden ThresholdMetricRow-Zeilen (z.B. wind)', () => {
+		const existingGate = /\{#if !buckets\.off\.includes\('wind'\)\}/;
+		assert.match(src, existingGate, 'Referenz-Gate-Muster (wind) nicht gefunden -- Vergleichsbasis fehlt');
+		assert.match(
+			src,
+			/\{#if !buckets\.off\.includes\('wind_chill'\)\}/,
+			"AC-5: wind_chill muss exakt demselben Gate-Muster folgen: {#if !buckets.off.includes('wind_chill')}"
+		);
+	});
+});
+
+describe('AC-6: bestehende sieben ThresholdMetricRow-Aufrufe lesen metricSymbols[id]?.[0] statt metricSymbols[id] (Typwechsel string -> string[])', () => {
+	const existingIds = [
+		'wind', 'gust', 'precipitation', 'rain_probability', 'thunder', 'snow_depth', 'snowfall_limit',
+	];
+
+	for (const id of existingIds) {
+		test(`smsSymbol-Prop fuer '${id}' verwendet ?.[0], kein direkter String-Zugriff`, () => {
+			const re = new RegExp(`smsSymbol=\\{metricSymbols\\['${id}'\\][^}]*\\}`);
+			const match = src.match(re);
+			assert.ok(match, `AC-6: smsSymbol-Prop fuer '${id}' nicht gefunden (Muster: smsSymbol={metricSymbols['${id}']...})`);
+			assert.match(
+				match![0],
+				/\?\.\[0\]/,
+				`AC-6: '${id}' muss metricSymbols['${id}']?.[0] lesen (Array-Zugriff nach der Typumstellung), gefunden: ${match![0]}`
+			);
+		});
+	}
+
+	test('SmsSymbolEntry-Typ traegt sms_symbols: string[] (nicht mehr sms_symbol: string)', () => {
+		assert.match(
+			src,
+			/interface SmsSymbolEntry\s*\{[\s\S]*?sms_symbols:\s*string\[\][\s\S]*?\}/,
+			'AC-6: SmsSymbolEntry.sms_symbols: string[] fehlt (oder noch als sms_symbol: string typisiert)'
+		);
+	});
+});

--- a/tests/tdd/test_sms_snow_symbols.py
+++ b/tests/tdd/test_sms_snow_symbols.py
@@ -540,7 +540,11 @@ def test_ac7_official_snow_warning_is_the_only_sn_token():
 # ---------------------------------------------------------------------------
 
 def test_ac8_sms_symbols_endpoint_serves_register_symbols():
-    """AC-8: das Frontend zieht die Kuerzel zur Laufzeit -> SD/SL."""
+    """AC-8: das Frontend zieht die Kuerzel zur Laufzeit -> SD/SL.
+
+    Fix #1613: der Endpoint liefert je Metrik jetzt ein Array `sms_symbols`
+    statt eines einzelnen `sms_symbol`-Strings (Mehrfach-Kuerzel-Metriken).
+    """
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
 
@@ -551,7 +555,7 @@ def test_ac8_sms_symbols_endpoint_serves_register_symbols():
     resp = TestClient(app).get("/sms-symbols")
     assert resp.status_code == 200, resp.text
 
-    by_metric = {e["metric_id"]: e["sms_symbol"] for e in resp.json()["metrics"]}
+    by_metric = {e["metric_id"]: e["sms_symbols"][0] for e in resp.json()["metrics"]}
 
     assert by_metric.get("snow_depth") == "SD", (
         "AC-8: /api/sms-symbols liefert fuer snow_depth "
@@ -566,7 +570,13 @@ def test_ac8_sms_symbols_endpoint_serves_register_symbols():
 
 
 def test_ac8_sms_symbols_endpoint_keeps_official_snow_hazard():
-    """AC-8/AC-7: der Gefahren-Teil derselben Antwort behaelt 'SN'."""
+    """AC-8/AC-7: der Gefahren-Teil derselben Antwort behaelt 'SN'.
+
+    Fix #1613 aendert nur das `metrics`-Array-Format, NICHT `hazards` (dort
+    bleibt `sms_symbol` ein einzelner String -- keine Metrik traegt in
+    HAZARD_SMS_SYMBOLS mehrere Kuerzel). Dieser Test bleibt unveraendert
+    gruen als Regressionsschutz gegen das Gegenteil.
+    """
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
 
@@ -580,6 +590,126 @@ def test_ac8_sms_symbols_endpoint_keeps_official_snow_hazard():
     assert by_hazard.get("snow") == "SN", (
         "AC-8: die amtliche Schneewarnung muss 'SN' bleiben, gefunden "
         f"{by_hazard.get('snow')!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix #1613 — Mehrfach-Symbol-Metriken (wind_chill/temperature/temperature_night)
+# fehlen strukturell im /api/sms-symbols-Endpoint
+# ---------------------------------------------------------------------------
+
+def test_ac1_wind_chill_reports_all_four_symbols():
+    """AC-1: wind_chill fehlt heute strukturell -- nach dem Fix liefert der
+    Endpoint alle vier Kuerzel in der dokumentierten Reihenfolge.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from api.routers import config as config_router
+
+    app = FastAPI()
+    app.include_router(config_router.router)
+    metrics = TestClient(app).get("/sms-symbols").json()["metrics"]
+
+    entries = [m for m in metrics if m["metric_id"] == "wind_chill"]
+    assert len(entries) == 1, (
+        f"AC-1: erwarte genau einen wind_chill-Eintrag, gefunden {len(entries)}: "
+        f"{entries!r}"
+    )
+    assert entries[0]["sms_symbols"] == ["FN", "FK", "FD", "WC"], (
+        "AC-1: wind_chill liefert "
+        f"{entries[0]['sms_symbols']!r}, erwartet ['FN','FK','FD','WC']"
+    )
+
+
+def test_ac2_thunder_appears_once_with_two_symbols_no_duplicate():
+    """AC-2: thunder steht in SMS_SYMBOL_BY_METRIC UND
+    SMS_MULTI_SYMBOLS_BY_METRIC -- der Merge darf keinen Duplikat-Eintrag
+    aus SMS_SYMBOL_BY_METRIC erzeugen.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from api.routers import config as config_router
+
+    app = FastAPI()
+    app.include_router(config_router.router)
+    metrics = TestClient(app).get("/sms-symbols").json()["metrics"]
+
+    thunder_entries = [m for m in metrics if m["metric_id"] == "thunder"]
+    assert len(thunder_entries) == 1, (
+        "AC-2: 'thunder' darf nur EINMAL im metrics-Array stehen (kein "
+        f"Duplikat aus SMS_SYMBOL_BY_METRIC), gefunden {len(thunder_entries)}: "
+        f"{thunder_entries!r}"
+    )
+    assert thunder_entries[0]["sms_symbols"] == ["TH", "TH+"], (
+        "AC-2: thunder liefert "
+        f"{thunder_entries[0]['sms_symbols']!r}, erwartet ['TH','TH+']"
+    )
+
+
+def test_ac3_single_symbol_metrics_unchanged_in_array_format():
+    """AC-3: die sieben Nicht-thunder-Metriken aus SMS_SYMBOL_BY_METRIC
+    liefern weiterhin genau dasselbe Kuerzel wie vor der Umstellung --
+    jetzt als einelementiges Array (Regressionsschutz, u.a. #1435 E3b).
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from api.routers import config as config_router
+
+    app = FastAPI()
+    app.include_router(config_router.router)
+    metrics = TestClient(app).get("/sms-symbols").json()["metrics"]
+    by_metric = {m["metric_id"]: m["sms_symbols"] for m in metrics}
+
+    expected = {
+        "precipitation": ["R"],
+        "rain_probability": ["PR"],
+        "wind": ["W"],
+        "gust": ["G"],
+        "snow_depth": ["SD"],
+        "snowfall_limit": ["SL"],
+        "fresh_snow": ["NS24+"],
+    }
+    for metric_id, expected_symbols in expected.items():
+        assert by_metric.get(metric_id) == expected_symbols, (
+            f"AC-3: {metric_id} liefert {by_metric.get(metric_id)!r}, "
+            f"erwartet {expected_symbols!r}"
+        )
+
+
+def test_ac6_endpoint_reports_eleven_metrics_total():
+    """AC-6/Regression: 8 Register-Metriken + 3 neue (temperature,
+    temperature_night, wind_chill) = 11 Eintraege, kein Wertverlust durch
+    die Typumstellung string -> string[].
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from api.routers import config as config_router
+
+    app = FastAPI()
+    app.include_router(config_router.router)
+    metrics = TestClient(app).get("/sms-symbols").json()["metrics"]
+
+    assert len(metrics) == 11, (
+        f"AC-6: erwarte 11 Metrik-Eintraege (8 Register + 3 neue, thunder "
+        f"nur einmal gezaehlt), gefunden {len(metrics)}: {metrics!r}"
+    )
+    by_metric = {m["metric_id"]: m["sms_symbols"] for m in metrics}
+    assert by_metric.get("temperature") == ["K", "D"], (
+        f"AC-6: temperature liefert {by_metric.get('temperature')!r}, "
+        "erwartet ['K','D']"
+    )
+    assert by_metric.get("temperature_night") == ["N"], (
+        f"AC-6: temperature_night liefert {by_metric.get('temperature_night')!r}, "
+        "erwartet ['N']"
+    )
+    assert by_metric.get("wind") == ["W"], (
+        "AC-6: 'wind' (bestehende ThresholdMetricRow-Call-Site) muss nach "
+        f"der Typumstellung weiterhin ['W'] liefern, gefunden "
+        f"{by_metric.get('wind')!r} -- kein Wertverlust durch metricSymbols[id]?.[0]"
     )
 
 


### PR DESCRIPTION
## Summary
- `GET /api/sms-symbols` las bislang nur `SMS_SYMBOL_BY_METRIC` (1:1-Kürzel), nie `SMS_MULTI_SYMBOLS_BY_METRIC` — dadurch fehlten `WC` (Gefühlte Temperatur), `K`/`D` (Temperatur), `N` (Nacht-Tiefsttemperatur) und `TH+` (Gewitter-Folgetag) strukturell in jeder Legende/Anzeige. PO hatte `WC` als sichtbar fehlend bestätigt.
- Endpoint liefert jetzt `sms_symbols: string[]` pro Metrik (11 statt 8 Einträge), `thunder` erscheint einmalig mit beiden Kürzeln (kein Duplikat).
- Neue, schlanke Frontend-Komponente `MultiSymbolMetricRow.svelte` zeigt Label + Kürzel-Badges für die drei bisher nicht anzeigbaren Metriken — ohne die bestehende `ThresholdMetricRow` anzufassen.
- Wiederholung eines in #1435 E3b bereits vermerkten, nie umgesetzten Befunds.

## Test plan
- [x] Backend: 24/24 Tests grün (`tests/tdd/test_sms_snow_symbols.py`)
- [x] Frontend: 14/14 Tests grün (source-inspizierend, kein Rendering-Harness für Svelte-5-Runen)
- [x] Gezielte Regression: 105/109 abhängige Backend-Tests grün (4 dokumentiert-vorbestehende Skips, themenfremd), 13/13 Frontend
- [x] Adversary VERIFIED (Mutations-Gegenprobe: 3/4 gefangen, 1 LOW-Finding F001 nicht blockierend, dokumentiert in #1199)
- [ ] Staging-Validierung (folgt via `/e2e-verify`)

Closes #1613

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3iLWZx3rrfRA1eetw43pH