### PR TITLE
fix(#1592): CAPE-Änderungsalarme in die jeweilige Modellwelt umrechnen (Scheibe C3)

### DIFF
--- a/docs/adr/0048-modellabhaengige-schwellen-statt-einer-zahl.md
+++ b/docs/adr/0048-modellabhaengige-schwellen-statt-einer-zahl.md
@@ -95,6 +95,43 @@ Ereignis** und eskaliert nie über `LOW`. Die Schwelle wird variabel, die Deckel
   - Die Herkunft muss auf jedem Weg mitlaufen, auf dem sie gebraucht wird. Ortsvergleich
     (`model="aggregate"`) und Schnappschuss-Reload (`model="snapshot"`) haben sie strukturell
     nicht; dort abstiniert CAPE dauerhaft, bis ein Folgeticket sie durchreicht.
-  - Die Familien RiskEngine (C2) und Δ-Alarme (C3) sind in dieser Scheibe **noch nicht**
-    umgestellt und verwenden weiterhin die feste Zahl. Sie folgen in eigenen Scheiben unter
-    demselben Issue.
+  - Die Familien RiskEngine (C2) und Δ-Alarme (C3) waren in dieser Scheibe **noch nicht**
+    umgestellt und verwendeten zunächst weiterhin die feste Zahl. Sie folgten in eigenen
+    Scheiben unter demselben Issue — Stand siehe **Vollzugsvermerk** unten.
+
+## Vollzugsvermerk
+
+Die Entscheidung selbst bleibt unverändert — dieser Vermerk hält nur fest, dass ihr
+Geltungsbereich inzwischen vollständig umgesetzt ist. Betroffen waren vier Stellen, an denen
+CAPE ursprünglich gegen die feste, unbelegte 1000 (bzw. abgeleitet 500/1200/600/200) geprüft
+wurde:
+
+- **Familie 1 (Fusion, `thunder_level_from_signals`):** umgestellt mit dieser Scheibe selbst
+  (B0+C0+C1, 2026-08-08) — die im Titel benannte Entscheidung.
+- **Familie 2 (RiskEngine, `risk_engine.py`):** geschlossen mit Scheibe C2
+  (`ac1343e1`, 2026-08-08, Spec `fix_1592_c2_cape_riskengine.md`). Die zweite, ungedeckelte
+  CAPE-Zählung in `_check_catalog_metric()` entfällt ersatzlos — `_check_thunder` trägt die in
+  dieser ADR zugesicherte Deckelung auf `LOW` jetzt allein, ohne dass eine parallele Regel sie
+  unterläuft. C2 schließt zugleich die eine offene Eichlücke `("icon_d2", "FR")`: das Gebiet FR
+  bekommt einen zweiten, geordneten Referenzpunkt (französische Alpen, 45,00/6,50), den das
+  Eichskript befragt, wenn der erste (Korsika) keine Werte liefert — Regel 4 dieser ADR
+  ("Eichung vermisst genau die Reihe, die der Produktivcode bezieht") bleibt dabei unverändert
+  in Kraft, nur die Punktwahl je Gebiet wird von einem Einzelpunkt zu einer geordneten Liste.
+- **Familie 3 (Δ-Alarme, `weather_change_detection.py`/`alert_preset.py`):** geschlossen mit
+  Scheibe C3 (Spec `fix_1592_c3_cape_delta_alarme.md`, PO-„Go" 2026-08-08). Anders als Familie 1
+  bekommt Familie 3 **keine eigene Eichung** — sie **rechnet** die bestehende
+  Empfindlichkeitsleiter (1200/600/200, ADR-0043, unverändert der einzige Regler) in die
+  Modellwelt des liefernden Modells um: `wirksame Δ-Schwelle = nominale Stufe ×
+  cape_threshold_jkg(modell, gebiet) / 1000`. Die 1000 im Nenner ist die Referenzwelt, für die
+  die Leiter ursprünglich geschrieben wurde — dieselbe Zahl, die vor Scheibe C1 überall galt,
+  jetzt als benannte Konstante `CAPE_REFERENZ_NIVEAU_JKG`. Regel 5 dieser ADR gilt unverändert:
+  fehlt die Eichung für Modell × Gebiet, entsteht **kein** Alarm, nicht „unauffällig".
+- **Familie 4 (Anzeige/Metrik-Auswahl):** entfällt ersatzlos mit #1585 — CAPE ist seither
+  `selectable=false`, es gibt keine per-Etappe wählbare CAPE-Spalte mehr, die eine Schwelle
+  anzeigen müsste. Diese ADR musste dafür nichts umsetzen.
+
+Damit prüft keine Stelle im Produktivcode mehr eine feste, modellübergreifende CAPE-Zahl als
+Auslöseschwelle. Die einzige verbliebene feste Zahl ist die nominale Empfindlichkeitsleiter
+selbst (1200/600/200) — die bleibt laut ADR-0043 bewusst die Einstellung, nicht die wirksame
+Schwelle, und wird von Familie 1–3 vor der Prüfung jeweils in die passende Modellwelt
+übersetzt.

--- a/docs/context/fix-1592-c3-cape-delta-alarme.md
+++ b/docs/context/fix-1592-c3-cape-delta-alarme.md
@@ -1,0 +1,265 @@
+# Context: #1592 Scheibe C3 — CAPE-Δ-Alarme (Schwellenfamilie 3)
+
+**Workflow:** `fix-1592-c3-cape-delta-alarme` · **Issue:** #1592 · **Basis:** `origin/main` `0461ed63`
+**Vorgänger live:** B0+C0+C1 (PR #1611), C2 (PR #1612, `ac1343e1`)
+
+## Request Summary
+
+Die letzte noch modellblinde CAPE-Schwellenfamilie sind die **Änderungsalarme** (Δ): ein
+Sprung von 500 J/kg (Katalog-Default) bzw. 1200/600/200 (Empfindlichkeitsstufen) löst
+unabhängig davon aus, aus welchem Wettermodell der Wert stammt. Bei AROME ist dieser Sprung
+praktisch unerreichbar, bei ECMWF beiläufig.
+
+## Zentrale Feststellung dieser Phase: der Zuschnitt von gestern greift zu kurz
+
+Das Vorgänger-Kontextdokument (`docs/context/fix-1592-cape-modellschwelle.md:258`) schneidet
+C3 auf **„nur Beleg-Gate"** zu: kein Alarm, wenn die Modell-Herkunft unbekannt ist. Dasselbe
+Dokument benennt zwei Zeilen weiter oben (`:27`) den eigentlichen Fehler aber anders:
+
+> Ein Änderungsbetrag von 500 J/kg ist bei AROME (gemessenes Maximum 840) praktisch
+> unerreichbar und bei ECMWF (Maximum 3670) beiläufig.
+
+Diese beiden Aussagen passen nicht zusammen. Bei AROME **ist** die Herkunft bekannt
+(`meteofrance_arome`) — ein Beleg-Gate lässt den Fall durch und die 500/600 bleiben stehen.
+Der benannte Fehler wäre nach C3 unverändert vorhanden.
+
+### Gemessen (2026-08-08, offline, dieser Worktree)
+
+Der Zuschnitt „nur Gate" stützte sich auf die Annahme, im Ortsvergleich und nach einem
+Schnappschuss-Reload gebe es keine Herkunft. **Beides trifft für den Alarmpfad nicht zu:**
+
+```
+ALARM-PFAD    cape_model_id = 'icon_d2'   (echte Provider-Meta)
+ANZEIGE-PFAD  cape_model_id = None        (summarize_points, model="aggregate")
+SERIALISIERT  cape_model_id -> icon_d2
+DESERIALISIERT cape_model_id = 'icon_d2'
+```
+
+- **Ortsvergleich:** Es gibt **zwei** Compare-Pipelines. Die *Anzeige*-Pipeline aggregiert über
+  Orte (`weather_metrics.py:1093`, `model="aggregate"`) und hat keine Herkunft. Die
+  *Alarm*-Pipeline holt je Ort einen einzelnen Provider-Abruf
+  (`compare_location_weather_source.py:103-119` → `segment_weather.py:280-281` →
+  `weather_metrics.py:802`) und trägt die **echte** Herkunft. Die im Vorgängerdokument
+  (`:276-279`) als „dauerhafte Lücke, bewusst" notierte Verstummung des Ortsvergleichs
+  existiert im Alarmpfad **nicht**.
+- **Schnappschuss:** `_serialize_summary`/`_deserialize_summary`
+  (`weather_snapshot.py`, geteilt mit `compare_weather_snapshot.py:25-29`) reichen
+  `cape_model_id` unverändert durch. Nur die separat rekonstruierte Stundenreihe bekommt
+  `meta.model="snapshot"` (`weather_snapshot.py:281`) — ein anderes Objekt. Der Feldkommentar
+  in `app/models.py:447-454`, der „Schnappschuss-Reload" als `None`-Fall nennt, beschreibt
+  damit den Lesepfad falsch.
+
+**Folge:** Ein reines Beleg-Gate würde in beiden Alarmpfaden fast nie greifen. Es bewachte
+nur noch den Restfall „unbekanntes Modell" — und ließe den Fehler, wegen dessen das Issue
+existiert, unangetastet.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/weather_change_detection.py:598-658` | **Die** Vergleichsstelle: `triggered = abs(delta) > threshold` (`:632`) |
+| `src/services/weather_change_detection.py:820-850` | `_classify_severity` — `delta/schwelle`, ≥1,5 MODERATE, ≥2,0 MAJOR |
+| `src/services/weather_change_detection.py:628-630` | Präzedenz: `_ordinal_levels`-Sonderpfad je Metrik (#1460) |
+| `src/services/weather_change_detection.py:51` | `_ALERT_METRIC_TO_SUMMARY_FIELD[CAPE] = "cape_max_jkg"` |
+| `src/services/weather_change_detection.py:456-560` | `from_alert_rules()` — füllt `_thresholds` **pro Trip**, nicht pro Segment |
+| `src/app/metric_catalog.py:337` | `default_change_threshold=500.0` |
+| `src/app/metric_catalog.py:807-828` | `get_change_detection_map()` |
+| `src/services/alert_preset.py:62` | `(AlertMetric.CAPE, DELTA, 1200, 600, 200)` |
+| `src/services/compare_alert.py:44,447-457` | Ortsvergleich: alle Metriken hart auf `"standard"` → CAPE Δ 600 |
+| `src/services/deviation_alert_engine.py:172-198,283-284` | Detektor-Auswahl, generischer Wrapper (keine CAPE-Logik) |
+| `src/services/trip_alert.py:335-350,604-636` | Trip-Seite derselben Kette |
+| `src/app/model_registry.py:120-142` | `CAPE_THRESHOLDS_JKG` (11 Einträge), `cape_threshold_jkg()` |
+| `src/providers/thunder_routing.py:64-85` | `thunder_region_for(lat, lon)` → `FR`/`DE_ALPEN`/`EU_REST` |
+| `src/app/models.py:454` | `SegmentWeatherSummary.cape_model_id` |
+| `src/app/models.py:324-329,371-384,472-489` | Koordinaten am Vergleichspunkt: `segment.start_point.lat/lon` |
+| `scripts/eichung_cape_schwelle.py` | Eichlauf B0 (Historical Forecast API) |
+| `frontend/src/lib/generated/alertPresetThresholds.generated.json:2-7` | `cape: {entspannt:1200, standard:600, sensibel:200, kind:"delta"}` |
+| `frontend/src/lib/components/alerts-tab/alertMetricTable.ts:50-55,231-242` | `levelToThreshold()` rendert **eine Zahl**: `Δ ≥ 600 J/kg` |
+| `scripts/generate_alert_preset_table.py` · `tests/tdd/test_alert_preset_table_parity.py` | Generator + Frische-Ratsche |
+
+## Existing Patterns
+
+- **Abstain-Muster (C1/C2, kanonisch):** `providers/thunder_enrichment.py:172-187` löst
+  `cape_threshold_jkg(effective_cape_model_id(meta), thunder_region_for(lat, lon))` auf; ist
+  das Ergebnis `None`, trägt CAPE **kein** Signal bei — „keine Aussage", nicht „unauffällig".
+  Abgesichert syntaktisch durch einen keyword-only Parameter **ohne Default**
+  (`output/metric_format.py:315-372`), damit ein vergessener Aufruf hart bricht statt still
+  zurückzufallen.
+- **Sonderpfad je Metrik im Δ-Loop:** `_ordinal_levels` (#1460) behandelt Gewitterstufen
+  bereits abweichend von `abs(delta) > threshold` — die Bauform für einen CAPE-Sonderpfad
+  existiert an derselben Stelle.
+- **Aggregationsregel `"agreement"`** (`weather_metrics.py:837,1196-1203`): uneinige Herkunft
+  über Segmente → `None`, nie ein zufälliger Erstwert.
+- **Eichverfahren (dokumentiert, PO-Recherche):** Quantil-Mapping über eine Konvektionssaison
+  (April–September), `x aus A → F_B⁻¹(F_A(x))`; praktisch „Perzentil des jeweiligen Modells"
+  statt Absolutwert. Historische Läufe aus Open-Meteos Historical Forecast API.
+
+## Dependencies
+
+- **Upstream:** `model_registry` (Eichtabelle, Normalisierung), `thunder_routing` (Gebiet),
+  `SegmentWeatherSummary.cape_model_id` (Herkunft), `alert_preset._PRESET_TABLE` (Ladder).
+- **Downstream:** Trip-Alarmzeilen (Mail/SMS/Telegram), Ortsvergleichs-Alarme,
+  `WeatherChange.threshold` (wird im Alarmtext mitgeführt), Frontend-Anzeige der
+  Empfindlichkeitsstufen, `alertPresetThresholds.generated.json` + Parität-Ratsche.
+
+## Existing Specs & ADRs
+
+- `docs/specs/modules/fix_1592_s1_cape_modellschwelle.md` (B0+C0+C1) — Abstain-Regel `:137-140`,
+  Familie 3 ausdrücklich ausgeklammert `:32-38`.
+- `docs/specs/modules/fix_1592_c2_cape_riskengine.md` (C2) — Familie 3 ausgeklammert `:29-33`.
+- `docs/context/fix-1592-cape-modellschwelle.md` — Vorgänger-Kontext; C3-Zuschnitt `:245,258`.
+- **ADR-0048** „Modellabhängige Schwellen statt einer Zahl" — Grundsatz: *feste Schwellen nie
+  über Modellgrenzen tragen*; hält fest, dass Δ-Alarme (C3) noch nicht umgestellt sind.
+- **ADR-0009** Alerts sind Δ-Wächter gegen den letzten Briefing-Stand.
+- **ADR-0043** Die Empfindlichkeitsstufe ist der **einzige** Alarm-Regler — eine
+  modellabhängige Zahl darf keinen zweiten Regler einführen, sondern muss dieselbe Stufe
+  gebietsweise gleich *bedeuten* lassen.
+
+## Belegte und unbelegte Zahlen
+
+Für die Δ-Werte **1200/600/200** und den Katalog-Default **500** gibt es **keine dokumentierte
+Quelle** — weder im Repo (`docs/specs/_archive/modules/issue_846_alert_preset.md:87`,
+`docs/specs/modules/feat_864_859_alert_presets.md:128` führen sie ohne Herleitung) noch
+veröffentlicht. Auch das eigene Gedächtnis kennt eine veröffentlichte Eichung nur für CAPE-
+**Niveaus**, nicht für Sprungbeträge.
+
+Auffällig: Die vier Zahlen sind glatte Vielfache der alten, modellblinden Niveau-Schwelle von
+1000 J/kg — 1,2 / 0,6 / 0,2 bzw. 0,5. Das ist eine **Rekonstruktion, keine Fundstelle**; sie
+ist plausibel, aber nirgends belegt.
+
+## Wege zu einer modellabhängigen Δ-Schwelle (für die Analysephase)
+
+1. **Anteil der geeichten Niveau-Schwelle** — Δ-Schwelle = Faktor × `cape_threshold_jkg(modell,
+   gebiet)`, Faktoren 1,2/0,6/0,2 aus der heutigen Leiter. Kein neuer Messlauf; verhält sich
+   dort, wo die geeichte Schwelle 1000 beträgt, exakt wie heute. Schwäche: der Anker 1000 ist
+   selbst unbelegt.
+2. **Eigener Δ-Eichlauf** — `scripts/eichung_cape_schwelle.py` erweitern: die API-Antwort
+   enthält `hourly.time` bereits, das Skript liest es nur nicht aus (`:169-179`). Tagesmaxima
+   bilden, Differenzen, 95. Perzentil. **Keine neuen Abrufe** (~13 Abrufe gesamt, Antwort in
+   Sekunden), gleiche Saison, gleiche Referenzpunkte.
+3. **Nur Beleg-Gate** (Zuschnitt von gestern) — behebt den benannten Fehler nicht, s.o.
+
+## Risks & Considerations
+
+- **Die Schwelle steuert auch die Eskalation.** `_classify_severity` rechnet
+  `delta/schwelle`; MAJOR ab Faktor 2. Unter AROME ist Faktor 2 bei 500 rechnerisch kaum
+  erreichbar, unter ECMWF beiläufig — der Modellfehler wirkt doppelt: beim Auslösen **und**
+  bei der Dringlichkeit.
+- **Die Schwelle wird pro Trip aufgelöst, gebraucht wird sie pro Segment.** `_thresholds` ist
+  ein Dict pro Service-Instanz; Modell und Gebiet variieren je Segment. Die Auflösung muss
+  deshalb **in** `detect_changes()` erfolgen, nicht bei der Konstruktion.
+- **Frontend zeigt eine feste Zahl.** `levelToThreshold()` rendert `Δ ≥ 600 J/kg`; der Typ
+  erzwingt `number`. Wird die wirksame Schwelle gebietsabhängig, ist die Anzeige nicht mehr
+  wörtlich wahr. Zu entscheiden: Anzeige unverändert lassen (nominale Leiter) oder umformulieren.
+- **ADR-0043-Konflikt vermeiden:** Eine modellabhängige Zahl darf nicht als zweiter Regler
+  auftreten. Sie ist die *Umrechnung* derselben Empfindlichkeitsstufe in die jeweilige
+  Modellwelt — das ist genau der Zweck von ADR-0048.
+- **Empfindlichkeit steigt.** Die geeichten Niveau-Schwellen liegen überwiegend unter 1000
+  (FR/AROME 300, DE_ALPEN/ICON-EU 360). Weg 1 senkt die Δ-Schwellen dort deutlich →
+  **mehr** Alarme als heute. Das ist der beabsichtigte Effekt („in Frankreich löst nie aus"),
+  muss aber vor der Freigabe beziffert werden.
+- **Abgrenzung #1601:** Ob Anker und frischer Wert aus **derselben** Quelle stammen, prüft
+  weiterhin niemand. Gemessen: der Anker trägt eine echte, eingefrorene `cape_model_id`, der
+  frische Wert eine aktuelle — sie können abweichen. Bleibt eigenes Ticket, direkt nach C3.
+
+## Analysis
+
+### Type
+Bug (Schwellenfehler mit nutzersichtbarer Wirkung im Alarmpfad)
+
+### Entscheidung: Umrechnung statt Messreihe (PO 2026-08-08)
+
+Auf die Frage nach der Δ-Eichung: **„was ist ein pragmatischer Weg? Du bist schon wieder
+dabei daraus ein Forschungsprojekt zu machen."** Der eigene Δ-Messlauf entfällt damit.
+
+Gewählt: **Weg 1 — die bestehende Leiter in die jeweilige Modellwelt umrechnen.**
+
+```
+wirksame Δ-Schwelle = Preset-Zahl × cape_threshold_jkg(modell, gebiet) / 1000
+```
+
+Die 1000 ist kein neu gesetzter Wert, sondern die bis Scheibe C1 überall gültige
+CAPE-Schwelle — genau die Welt, für die die Leiter 1200/600/200 geschrieben wurde. Wo die
+geeichte Schwelle 1000 beträgt, ändert sich nichts. Keine neue Tabelle, kein Abruf, keine
+erfundene Zahl.
+
+### Gemessene Wirkung (alle 11 geeichten Kombinationen)
+
+| Modell × Gebiet | geeicht | entspannt | standard | sensibel | Faktor |
+|---|---|---|---|---|---|
+| meteofrance_arome × FR | 300 | 1200 → 360 | 600 → **180** | 200 → 60 | 0,30 |
+| icon_d2 × FR | 300 | 1200 → 360 | 600 → 180 | 200 → 60 | 0,30 |
+| icon_eu × EU_REST | 300 | 1200 → 360 | 600 → 180 | 200 → 60 | 0,30 |
+| meteofrance_arome × EU_REST | 310 | 1200 → 372 | 600 → 186 | 200 → 62 | 0,31 |
+| icon_d2 × DE_ALPEN | 300 | 1200 → 360 | 600 → 180 | 200 → 60 | 0,30 |
+| icon_eu × DE_ALPEN | 360 | 1200 → 432 | 600 → 216 | 200 → 72 | 0,36 |
+| meteofrance_arome × DE_ALPEN | 380 | 1200 → 456 | 600 → 228 | 200 → 76 | 0,38 |
+| ecmwf_ifs04 × EU_REST | 420 | 1200 → 504 | 600 → 252 | 200 → 84 | 0,42 |
+| ecmwf_ifs04 × DE_ALPEN | 650 | 1200 → 780 | 600 → 390 | 200 → 130 | 0,65 |
+| ecmwf_ifs04 × FR | 710 | 1200 → 852 | 600 → 426 | 200 → 142 | 0,71 |
+| icon_eu × FR | 850 | 1200 → 1020 | 600 → 510 | 200 → 170 | 0,85 |
+
+🔴 **Alle Faktoren liegen unter 1 — die Δ-Schwellen sinken überall, nicht nur in Frankreich.**
+Das ist die ehrliche Folge davon, dass die alte 600 an nichts geeicht war: an keinem der
+Referenzpunkte erreicht das 95. Perzentil der Modellklimatologie 1000 J/kg. Es bedeutet
+**mehr CAPE-Änderungsalarme als heute**, am stärksten unter AROME und ICON-D2 (Faktor 0,30).
+Diese Zahl gehört vor die Freigabe.
+
+**Eine untere Grenze ist bereits eingebaut** und muss nicht erfunden werden: die Eichtabelle
+selbst hat den Boden `MIN_THRESHOLD_JKG = 300` (`scripts/eichung_cape_schwelle.py:70`).
+Der Umrechnungsfaktor kann deshalb nicht unter 0,30 fallen.
+
+### Technischer Ansatz
+
+1. **Auflösung in `detect_changes()`**, nicht bei der Konstruktion — Modell und Gebiet
+   variieren je Segment, `_thresholds` ist aber ein Dict pro Service-Instanz. Andockpunkt ist
+   der bestehende Sonderpfad je Metrik (`weather_change_detection.py:628-630`, `_ordinal_levels`).
+2. **Ein Nachschlag, zwei Wirkungen:** `cape_threshold_jkg(...)` liefert `None` → **kein
+   Alarm** (Abstain, identisch zu C1/C2, deckt den ursprünglich geplanten Beleg-Gate-Fall ab);
+   liefert eine Zahl → Umrechnung.
+3. **Die wirksame Schwelle muss ins Ereignis.** `WeatherChange.threshold` wird nicht nur im
+   Alarmtext genannt (`output/renderers/alert/render.py:494`), sondern dort **nachgeprüft**
+   (`output/renderers/alert/model.py:97-104`, `over_thr`) und zur Sortierung benutzt
+   (`render.py:725`). Trüge das Ereignis die nominale Zahl, während mit der umgerechneten
+   ausgelöst wurde, stünde im Alarm „unter Schwelle" — und die Reihenfolge wäre falsch.
+4. **Referenzwert benannt ablegen**, nicht als nackte 1000 im Code: Konstante in
+   `model_registry.py` mit Begründung (die vor #1592 universelle Schwelle).
+5. **Anzeige** (PO: in dieser Scheibe mitmachen): `levelToThreshold()` gibt für CAPE heute
+   `Δ ≥ 600 J/kg` zurück — eine Zahl, die so nirgends mehr wirkt. Sie wird als Richtwert
+   gekennzeichnet und um den Hinweis auf die Umrechnung ergänzt. Die generierte Datei und
+   ihr Typ (`number`) bleiben unverändert, damit Generator und Frische-Ratsche nicht brechen.
+
+### Affected Files
+
+| Datei | Art | Beschreibung |
+|---|---|---|
+| `src/app/model_registry.py` | MODIFY | Referenzniveau-Konstante + Umrechnungsfunktion |
+| `src/services/weather_change_detection.py` | MODIFY | CAPE-Sonderpfad in `detect_changes()`: Abstain + Umrechnung + wirksame Schwelle ins Ereignis |
+| `frontend/src/lib/components/alerts-tab/alertMetricTable.ts` | MODIFY | CAPE-Schwellentext als Richtwert kennzeichnen |
+| `frontend/src/lib/components/alerts-tab/issue_864_alert_metric_levels.test.ts` | MODIFY | Erwartung für CAPE nachziehen (`:75`) |
+| `tests/tdd/test_cape_delta_modellschwelle.py` | CREATE | Verhaltenstests (Umrechnung, Abstain, Ereignis-Schwelle, Eskalationsstufe) |
+
+**Nicht angefasst:** `alert_preset.py` (die Leiter bleibt die nominale Empfindlichkeitsstufe —
+ADR-0043: ein Regler), `metric_catalog.py`, `compare_alert.py` (erbt die Wirkung über
+dieselbe `detect_changes()`), Generator und generierte Datei.
+
+### Scope Assessment
+- Dateien: 3 Produktiv (2 Python, 1 TypeScript) + 2 Test
+- Geschätzt: ~55 Produktiv / ~90 Test
+- Risiko: **MEDIUM** — schmaler Eingriff, aber nutzersichtbar in Alarmmenge und -text
+- Scope-Art: **full-stack** (Frontend berührt ⇒ Browser-Gate beim Ausliefern greift)
+
+### Offene Punkte für die Spec
+- Wortlaut des Anzeige-Hinweises (PO entscheidet über die ACs)
+- Ob der Alarmtext die Umrechnung erwähnt oder nur die wirksame Zahl nennt
+
+## Testlage
+
+Kein einziger bestehender Test verbindet `cape_model_id`/Gebiet mit dem Δ-Alarmpfad — dieser
+Bereich ist heute testfrei. Betroffene Bestandstests:
+
+- `tests/unit/test_change_detection.py:417,490-505` (Katalog-Default 500 für `cape_max_jkg`)
+- `tests/tdd/test_issue_846_alert_preset.py:237-243` (`test_ac6_entspannt_cape_threshold_1200_delta`)
+- `tests/tdd/test_alert_preset_table_parity.py` (Frische-Ratsche Generat)
+- `tests/unit/test_alert_metric_identity_delivery.py:73,80,112,120,260-282`
+- `tests/tdd/test_compare_alert_metric_gating.py`

--- a/docs/features/gewitter-gesamtkonzept.md
+++ b/docs/features/gewitter-gesamtkonzept.md
@@ -223,10 +223,13 @@ tragen.**
 > gelassen. Die Zuordnung Endpunkt → Variante ist deshalb empirisch ermittelt (Wert-für-Wert-
 > Vergleich) und im Eichskript dokumentiert. **Wer neu eicht, prüft sie zuerst nach.**
 >
-> ⚠️ **Nur die Fusion.** Der RiskEngine-Pfad und die Δ-Alarm-Schwellen prüfen weiterhin gegen
-> die feste, unbelegte Zahl — Scheiben C2 und C3 unter #1592. Ortsvergleich und
-> Schnappschuss-Reload führen strukturell keine Modell-Herkunft, dort trägt CAPE dauerhaft
-> nicht bei.
+> ✅ **Auch RiskEngine und Δ-Alarme sind inzwischen umgestellt** (Scheiben C2/C3 unter #1592,
+> Vollzugsvermerk in ADR-0048). Der RiskEngine-Pfad zählte CAPE bis C2 ein zweites Mal gegen
+> die feste 1000/2000 — obendrauf zur bereits gedeckelten Fusion; diese zweite Regel ist
+> gestrichen. Die Δ-Alarm-Schwellen rechneten bis C3 die nominale Empfindlichkeitsstufe
+> (1200/600/200) unverändert gegen jedes Modell; sie übersetzen die Stufe seither in dieselbe
+> Modellwelt wie die Fusion. Ortsvergleich und Schnappschuss-Reload führen weiterhin strukturell
+> keine Modell-Herkunft, dort trägt CAPE dauerhaft nicht bei — das bleibt unverändert.
 
 ### 3.5 Die CAPE-Deckelung ist belegt ersetzbar (Recherche 2026-08-08)
 
@@ -737,7 +740,7 @@ CAPE-Deckelung zu ersetzen. #1531 ist damit **nicht** eine spätere Scheibe, son
 
 | Rang | Scheibe | Warum hier | Stand |
 |---|---|---|---|
-| **0** | ✅ **CAPE-Schwelle modellabhängig gemacht** (3.4b, **#1592**, ADR-0048) | **Fusion erledigt und live seit 2026-08-08**: Schwelle je Modell × Gebiet, geeicht am 95. Perzentil der Modellklimatologie (mind. 300 J/kg). Auf dem GR20 gilt jetzt 300 statt 1000 — CAPE trägt dort erstmals bei. **Offen: C2** (RiskEngine, dort noch ungedeckelt bis `HIGH` gegen die feste 1000) **und C3** (Δ-Alarme) | teils erledigt |
+| **0** | ✅ **CAPE-Schwelle modellabhängig gemacht** (3.4b, **#1592**, ADR-0048) | **Fusion, RiskEngine und Δ-Alarme erledigt und live**: Schwelle je Modell × Gebiet, geeicht am 95. Perzentil der Modellklimatologie (mind. 300 J/kg). Auf dem GR20 gilt jetzt 300 statt 1000 — CAPE trägt dort erstmals bei. RiskEngine zählt CAPE nicht mehr doppelt (C2), Δ-Alarme rechnen die Empfindlichkeitsstufe in dieselbe Modellwelt um (C3). Vollzugsvermerk: ADR-0048 | ✅ erledigt |
 | **1** | **Fehlende DWD-Größen abrufen** (#1531) — Felder befüllen, **nicht** einstufen | Liefert `lpi_max` (gleiche Statistik) und `cin_ml` (ersetzt die Deckelung). **CIN gibt es bei Open-Meteo nicht für ICON/AROME** — der Direktabruf ist der einzige Weg. Spec liegt fertig vor | Spec fertig, Freigabe offen |
 | **2** | **Belegte Leitern übernehmen**: LPI **1/30/50** statt 5/**20**/50 · CAPE **1000/2500/4000** statt binär · CIN-Paarung **−25/−50/−100/−200** statt Deckelung | Beseitigt eine der beiden erfundenen Zahlen und macht CAPE zu einem vollwertigen Signal. Alles belegt (3.5, 3.5b) | ✅ E1 |
 | **3** | **Gleiche Statistik**: `lpi_max` statt `lpi` gegen `lpi_con_max` | Nimmt allein **Faktor 5** aus dem Gebietsbruch — ohne jede Kalibrierung | ✅ E1 |

--- a/docs/reference/decision_matrix.md
+++ b/docs/reference/decision_matrix.md
@@ -100,10 +100,15 @@ Mixed-Layer, Météo-France Most-Unstable, GFS Surface-Based. Die frühere feste
 dauerhaft der Ortsvergleich (`model="aggregate"`) und der Schnappschuss-Reload
 (`model="snapshot"`), die strukturell keine Herkunft führen.
 
-⚠️ **Nur die Fusion ist umgestellt.** Der RiskEngine-Pfad (`risk_engine.py`, CAPE →
-`Risk(THUNDERSTORM, MODERATE|HIGH)`, dort **ungedeckelt**) und die Δ-Alarm-Schwellen
-(`alert_preset.py`) prüfen weiterhin gegen die feste, unbelegte 1000 bzw. 500/1200/600/200.
-Scheiben C2 und C3 unter #1592.
+✅ **Fusion, RiskEngine und Δ-Alarme sind inzwischen alle umgestellt** (Vollzugsvermerk in
+ADR-0048). Der RiskEngine-Pfad (`risk_engine.py`) zählte CAPE bis Scheibe C2 ein zweites Mal
+gegen die feste, unbelegte 1000/2000 — obendrauf zur bereits gedeckelten Fusion; diese zweite
+Regel ist gestrichen, die Deckelung auf „leicht" wirkt jetzt ungestört. Die Δ-Alarm-Schwellen
+(`weather_change_detection.py`, `alert_preset.py`) rechneten bis Scheibe C3 die nominale
+Empfindlichkeitsstufe (1200/600/200, ADR-0043) unverändert gegen jedes Modell; sie übersetzen
+die Stufe seither in dieselbe Modellwelt wie die Fusion
+(`wirksame Δ-Schwelle = nominale Stufe × cape_threshold_jkg(modell, gebiet) / 1000`). Beide
+Scheiben unter #1592.
 
 **Für jede weitere Quelle (z. B. Hagel, S5/#1475):** Eine neue Größe dockt mit **einer
 Tabellenzeile** an — Provider füllt nur Felder, die Einstufung liest nur Felder (Konzept

--- a/docs/specs/modules/fix_1592_c3_cape_delta_alarme.md
+++ b/docs/specs/modules/fix_1592_c3_cape_delta_alarme.md
@@ -1,0 +1,235 @@
+---
+entity_id: fix_1592_c3_cape_delta_alarme
+type: module
+created: 2026-08-08
+updated: 2026-08-08
+status: draft
+version: "1.0"
+tags: [cape, alarme, delta, modellschwelle, issue-1592]
+---
+
+# #1592 Scheibe C3 — CAPE-Änderungsalarme in die jeweilige Modellwelt umrechnen
+
+## Approval
+
+- [x] Approved — PO-„Go" 2026-08-08, neun ACs auf Deutsch vorgelegt und freigegeben
+
+## Purpose
+
+Die letzte modellblinde CAPE-Schwellenfamilie sind die **Änderungsalarme**. Ein Sprung von
+600 J/kg (Empfindlichkeitsstufe „standard") löst heute unabhängig davon aus, aus welchem
+Wettermodell der Wert stammt — bei AROME praktisch nie, bei ECMWF beiläufig. Diese Scheibe
+rechnet die bestehende Empfindlichkeitsleiter mit der bereits geeichten Schwelle aus B0 in
+die jeweilige Modellwelt um, sodass dieselbe Stufe überall dasselbe bedeutet.
+
+## Source
+
+- **File:** `src/services/weather_change_detection.py` — `WeatherChangeDetectionService.detect_changes()`
+- **File:** `src/app/model_registry.py` — Umrechnung + Referenzniveau
+- **File:** `frontend/src/lib/components/alerts-tab/alertMetricTable.ts` — `levelToThreshold()`
+
+Schicht: **Python-Core** (`src/services/`, `src/app/`) + **Frontend** (SvelteKit). Keine
+Go-Seite berührt.
+
+## Estimated Scope
+
+- **LoC:** ~55 Produktiv / ~90 Test
+- **Files:** 3 Produktiv (2 Python, 1 TypeScript), 2 Test
+- **Effort:** medium
+- **Scope-Art:** full-stack (Frontend berührt ⇒ Browser-Gate beim Ausliefern greift)
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `app.model_registry.CAPE_THRESHOLDS_JKG` | vorhanden (B0) | Geeichte Niveau-Schwelle je Modell × Gebiet |
+| `app.model_registry.cape_threshold_jkg()` | vorhanden (B0) | Nachschlag mit „nicht belegt" = `None` |
+| `providers.thunder_routing.thunder_region_for()` | vorhanden | Koordinaten → `FR`/`DE_ALPEN`/`EU_REST` |
+| `app.models.SegmentWeatherSummary.cape_model_id` | vorhanden (C0) | Herkunft am Vergleichspunkt |
+| `services.alert_preset._PRESET_TABLE` | unverändert | Nominale Empfindlichkeitsleiter |
+
+## Die Regel
+
+```
+wirksame Δ-Schwelle = nominale Preset-Zahl × cape_threshold_jkg(modell, gebiet) / 1000
+```
+
+Die **1000** ist kein neu gesetzter Wert, sondern die bis Scheibe C1 überall gültige
+CAPE-Schwelle — genau die Welt, für die die Leiter 1200/600/200 geschrieben wurde. Sie wird
+als benannte Konstante mit dieser Begründung abgelegt, nicht als nackte Zahl im Code.
+
+**Keine neue Eichung, kein neuer Messlauf, keine erfundene Zahl** — die vorhandene Eichung
+wird nur weitergetragen. Damit bleibt auch ADR-0043 gewahrt: die Empfindlichkeitsstufe ist
+weiterhin der **einzige** Regler; Modell und Gebiet ändern nicht die Einstellung, sondern nur
+ihre Übersetzung in die Skala des liefernden Modells.
+
+### Gemessene Wirkung (alle 11 geeichten Kombinationen, Stufe „standard")
+
+| Modell × Gebiet | geeicht | heute | neu | Faktor |
+|---|---|---|---|---|
+| meteofrance_arome × FR (GR20) | 300 | 600 | **180** | 0,30 |
+| icon_d2 × FR | 300 | 600 | 180 | 0,30 |
+| icon_d2 × DE_ALPEN | 300 | 600 | 180 | 0,30 |
+| icon_eu × EU_REST | 300 | 600 | 180 | 0,30 |
+| meteofrance_arome × EU_REST | 310 | 600 | 186 | 0,31 |
+| icon_eu × DE_ALPEN | 360 | 600 | 216 | 0,36 |
+| meteofrance_arome × DE_ALPEN | 380 | 600 | 228 | 0,38 |
+| ecmwf_ifs04 × EU_REST | 420 | 600 | 252 | 0,42 |
+| ecmwf_ifs04 × DE_ALPEN | 650 | 600 | 390 | 0,65 |
+| ecmwf_ifs04 × FR | 710 | 600 | 426 | 0,71 |
+| icon_eu × FR | 850 | 600 | 510 | 0,85 |
+
+🔴 **Alle Faktoren liegen unter 1 — die Schwellen sinken überall, nicht nur in Frankreich.**
+An keinem Referenzpunkt erreicht das 95. Perzentil der Modellklimatologie 1000 J/kg. Folge:
+**mehr CAPE-Änderungsalarme als heute**, am stärksten unter AROME und ICON-D2. Das ist die
+beabsichtigte Korrektur — die alte 600 war an nichts geeicht —, aber es ist eine spürbare
+Produktänderung und gehört ausdrücklich in diese Freigabe.
+
+Eine untere Grenze ist bereits eingebaut und wird **nicht** zusätzlich erfunden: die
+Eichtabelle hat den Boden 300 J/kg (`scripts/eichung_cape_schwelle.py:70`), der
+Umrechnungsfaktor kann deshalb nicht unter 0,30 fallen.
+
+## Implementation Details
+
+```
+In detect_changes(), am bestehenden Sonderpfad je Metrik (weather_change_detection.py:628-630,
+Vorbild _ordinal_levels aus #1460):
+
+  wenn Feld == "cape_max_jkg":
+      geeicht = cape_threshold_jkg(
+          new_summary.cape_model_id,
+          thunder_region_for(new_data.segment.start_point.lat,
+                             new_data.segment.start_point.lon),
+      )
+      wenn geeicht is None:
+          weiter                       # Abstain: keine Aussage, kein Alarm
+      schwelle = nominale_schwelle * geeicht / CAPE_REFERENZ_NIVEAU_JKG
+
+Die so bestimmte `schwelle` ist ab hier die EINE Wahrheit — sie entscheidet über
+`triggered`, über `_classify_severity(...)` UND wird als `WeatherChange.threshold`
+mitgegeben.
+```
+
+**Warum die wirksame Schwelle ins Ereignis muss:** `WeatherChange.threshold` wird nicht nur
+im Alarmtext genannt (`src/output/renderers/alert/render.py:494`), sondern dort **nachgeprüft**
+(`src/output/renderers/alert/model.py:97-104`, `over_thr()` → „über"/„unter") und zur
+Sortierung der Alarmzeilen benutzt (`render.py:725`). Trüge das Ereignis die nominale 600,
+während mit 180 ausgelöst wurde, stünde im Alarm „unter Schwelle" und die Reihenfolge wäre
+falsch.
+
+**Warum in `detect_changes()` und nicht bei der Konstruktion:** `_thresholds` ist ein Dict pro
+Service-Instanz (ein Trip), Modell und Gebiet variieren aber je Segment.
+
+**Der Ortsvergleich erbt die Wirkung**, ohne eigenen Code: `CompareAlertService` läuft über
+denselben `DeviationAlertEngine` → dieselbe `detect_changes()`. Gemessen: der
+Ortsvergleichs-**Alarm**pfad trägt eine echte Herkunft (`compare_location_weather_source.py:103-119`
+→ `segment_weather.py:280-281` → `weather_metrics.py:802`); nur der *Anzeige*-Pfad
+(`summarize_points`, `model="aggregate"`) hat keine — der löst aber keine Alarme aus.
+
+## Expected Behavior
+
+- **Input:** Zwei `SegmentWeatherData` (Δ-Anker und frischer Stand) mit `cape_max_jkg` und
+  `cape_model_id`, plus Segment-Koordinaten.
+- **Output:** `WeatherChange` für `cape_max_jkg` genau dann, wenn der Sprung die **umgerechnete**
+  Schwelle überschreitet — mit dieser Schwelle im Ereignis; sonst kein Ereignis.
+- **Side effects:** Keine Persistenz-Änderung, kein neues Feld, keine Abrufe zur Laufzeit.
+
+## Acceptance Criteria
+
+- **AC-1 (Der Kernfall: CAPE-Alarme erreichen Frankreich):** Given eine Etappe auf Korsika
+  (42.22/9.05, Gebiet FR) mit Herkunft `meteofrance_arome` und Empfindlichkeitsstufe
+  „standard" / When das CAPE-Tagesmaximum gegenüber dem Δ-Anker um 250 J/kg steigt / Then
+  entsteht eine CAPE-Alarmzeile (umgerechnete Schwelle 180), während heute keine entsteht
+  (nominale Schwelle 600).
+  - Test: Aufruf über `detect_changes()` mit echten `SegmentWeatherData`; geprüft wird die
+    Existenz des `WeatherChange` für `cape_max_jkg`, nicht ein Zwischenwert.
+
+- **AC-2 (Gegenprobe — die Schwelle verschwindet nicht):** Given dieselbe Etappe und Stufe /
+  When das CAPE-Maximum um nur 150 J/kg steigt / Then entsteht **keine** CAPE-Alarmzeile
+  (150 < 180).
+  - Test: derselbe Aufruf, leere Ergebnisliste für `cape_max_jkg`. Ohne diesen Fall wäre
+    AC-1 auch von einer Implementierung erfüllt, die immer auslöst.
+
+- **AC-3 (Unbekannte Herkunft schweigt, statt zu behaupten):** Given eine Etappe, deren
+  `cape_model_id` `None` ist (unbekanntes Modell oder Herkunft über Segmentgrenzen uneinig) /
+  When das CAPE-Maximum um 5000 J/kg springt / Then entsteht **keine** CAPE-Alarmzeile —
+  „keine Aussage", nicht „unauffällig".
+  - Test: `detect_changes()` liefert kein `cape_max_jkg`-Ereignis; Gegenprobe mit gesetzter
+    Herkunft liefert eines.
+
+- **AC-4 (Kein Gebiet, keine Aussage):** Given eine Etappe mit bekannter Herkunft, aber
+  Koordinaten außerhalb jedes geeichten Gebiets bzw. einer Kombination ohne Eichwert / When
+  ein beliebig großer CAPE-Sprung auftritt / Then entsteht **keine** CAPE-Alarmzeile.
+  - Test: über `detect_changes()` mit einer nachweislich nicht in `CAPE_THRESHOLDS_JKG`
+    enthaltenen Kombination.
+
+- **AC-5 (Der Alarmtext nennt die Schwelle, die wirklich galt):** Given der Alarm aus AC-1 /
+  When die Alarmzeile gerendert wird / Then nennt sie 180 J/kg als Schwelle und stuft das
+  Ereignis als „über Schwelle" ein — nicht 600 und nicht „unter Schwelle".
+  - Test: `WeatherChange.threshold == 180.0` **und** `over_thr()` des Renderer-Modells
+    liefert `True` für das daraus gebaute Ereignis. Prüfort ist der Renderer, nicht nur das
+    Ereignis.
+
+- **AC-6 (Die Dringlichkeit folgt der umgerechneten Schwelle):** Given die Etappe aus AC-1 /
+  When das CAPE-Maximum um 400 J/kg steigt / Then ist die Alarmstufe MAJOR (400/180 = 2,2 ≥ 2,0),
+  während heute überhaupt kein Alarm entstünde (400 < 600).
+  - Test: `WeatherChange.severity is ChangeSeverity.MAJOR`.
+
+- **AC-7 (Der Ortsvergleich erbt die Wirkung, ohne eigenen Code):** Given ein Ortsvergleich
+  mit einem Ort in Frankreich, Herkunft `meteofrance_arome`, Stufe „standard" / When das
+  CAPE-Maximum dieses Ortes um 250 J/kg steigt / Then entsteht eine Abweichungsmeldung für
+  diesen Ort.
+  - Test: über den Compare-Auswertungspfad (`DeviationAlertEngine`), nicht über eine
+    Trip-Attrappe — beweist die geteilte Wirkung.
+
+- **AC-8 (Keine andere Metrik ändert ihr Verhalten):** Given identische Eingaben für
+  Windböen, Niederschlag, Frischschnee und Nullgradgrenze / When `detect_changes()` vor und
+  nach der Änderung läuft / Then sind Auslösung, Schwelle und Alarmstufe dieser Metriken
+  byte-identisch.
+  - Test: A/B-Vergleich gegen den Basis-Commit für die nicht betroffenen Metriken.
+
+- **AC-9 (Die Anzeige behauptet keine Zahl, die nirgends wirkt):** Given der Alarme-Reiter im
+  Trip-Editor mit CAPE auf „standard" / When der Nutzer die Schwellenspalte liest / Then ist
+  erkennbar, dass 600 J/kg ein Richtwert ist, der je Wettermodell und Gebiet umgerechnet wird
+  — bei allen anderen Metriken bleibt die Anzeige unverändert.
+  - Test: `levelToThreshold('cape', 'standard')` trägt die Kennzeichnung; `levelToThreshold`
+    für Windböen/Sicht/Nullgradgrenze liefert unveränderte Zeichenketten. `thresholdTitle('cape')`
+    liefert die Umrechnungs-Erklärung, für alle anderen Metriken `undefined`; ein SSR-Render-Test
+    (`AlertMetricLevelRow.svelte` via `svelte/server`) prüft das `title`-Attribut UND den
+    Zellentext am tatsächlich erzeugten HTML. Zusätzlich im echten Browser gegen Staging
+    geprüft (Frontend-Browser-Gate).
+
+## Nicht in dieser Scheibe
+
+- **#1601** (Modellwechsel zwischen Δ-Anker und frischem Wert löst allein einen Alarm aus).
+  Gemessen bestätigt: der Anker trägt eine eingefrorene `cape_model_id`, der frische Wert
+  eine aktuelle; abweichen können sie. Eigenes Ticket, direkt im Anschluss.
+- **Die nominale Leiter 1200/600/200 selbst.** Sie bleibt unverändert die
+  Empfindlichkeitseinstellung (ADR-0043). Dass für sie keine Quelle existiert, ist notiert
+  (`docs/context/fix-1592-c3-cape-delta-alarme.md`), aber kein Gegenstand dieser Scheibe.
+- **Feinere Gebiete als `FR`/`DE_ALPEN`/`EU_REST`.** Ein Perzentil je Ort wäre genauer, kostet
+  aber Abrufe je Ort — in B0 bereits als spätere Verfeinerung zurückgestellt.
+- **Der Katalog-Default `default_change_threshold=500`** (`metric_catalog.py:337`) bleibt
+  stehen; er ist der nominale Ausgangswert für Trips ohne Empfindlichkeitsstufen und läuft
+  durch dieselbe Umrechnung.
+
+## ADR
+
+**Kein neues ADR.** ADR-0048 („Modellabhängige Schwellen statt einer Zahl") gilt unverändert
+und benennt die Δ-Alarme ausdrücklich als noch nicht umgestellt — diese Scheibe schließt
+genau diese Lücke. ADR-0048 bekommt dazu einen Vollzugsvermerk.
+
+## Changelog
+
+- 2026-08-08: Erstfassung. Zuschnitt gegenüber dem Vorgänger-Kontextdokument erweitert
+  (Umrechnung statt reinem Beleg-Gate), nachdem die Annahme „Ortsvergleich und Schnappschuss
+  haben keine Modell-Herkunft" offline widerlegt wurde. Δ-Eichung per eigenem Messlauf nach
+  PO-Einwand verworfen zugunsten der Umrechnung der vorhandenen Eichung.
+
+## Korrektur am Vorgänger-Kontextdokument
+
+`docs/context/fix-1592-cape-modellschwelle.md:258,276-279` schnitt C3 auf „nur Beleg-Gate" zu
+und nahm an, Ortsvergleich und Schnappschuss-Reload hätten nie eine Modell-Herkunft. Beides
+wurde am 2026-08-08 offline nachgemessen und trifft für den Alarmpfad **nicht** zu (Herkunft
+`icon_d2` vorhanden, überlebt den Schnappschuss-Roundtrip). Ein reines Beleg-Gate hätte fast
+nichts bewacht und den im Issue benannten Fehler unangetastet gelassen.

--- a/frontend/src/lib/components/alerts-tab/AlertMetricLevelRow.svelte
+++ b/frontend/src/lib/components/alerts-tab/AlertMetricLevelRow.svelte
@@ -2,7 +2,7 @@
 	// Issue #864/#859 — Eine Metrik-Zeile im Alerts-Tab: Segmented-Control (4 Stufen)
 	// + Schwellwert-Anzeige. Spec: docs/specs/modules/feat_864_859_alert_presets.md
 	import type { AlertMetric, SensLevel } from '$lib/types';
-	import { levelToThreshold } from './alertMetricTable.ts';
+	import { levelToThreshold, thresholdTitle } from './alertMetricTable.ts';
 
 	interface Props {
 		metric: AlertMetric;
@@ -28,6 +28,9 @@
 	};
 
 	const threshold = $derived(levelToThreshold(metric, level));
+	// Issue #1592 Scheibe C3 (AC-9): Erklärung fuer den Richtwert-Hinweis
+	// (aktuell nur CAPE) -- sitzt im `title`, nicht im knappen Zellentext.
+	const title = $derived(thresholdTitle(metric));
 	const isDimmed = $derived(level === 'off');
 </script>
 
@@ -52,7 +55,7 @@
 			</button>
 		{/each}
 	</td>
-	<td class="threshold" data-testid="alert-threshold-{metric}">{threshold ?? '—'}</td>
+	<td class="threshold" data-testid="alert-threshold-{metric}" title={title}>{threshold ?? '—'}</td>
 </tr>
 
 <style>

--- a/frontend/src/lib/components/alerts-tab/__tests__/alertMetricLevelRowTitleRender.test.ts
+++ b/frontend/src/lib/components/alerts-tab/__tests__/alertMetricLevelRowTitleRender.test.ts
@@ -1,0 +1,102 @@
+// #1592 Scheibe C3, Adversary-Runde 2 Finding F001 (HIGH): das `title`-
+// Attribut der CAPE-Schwellenzelle (`AlertMetricLevelRow.svelte`) wurde von
+// KEINEM Test bewacht — `thresholdTitle()` war nur an der FUNKTION geprüft,
+// nicht an der Stelle, wo sie tatsächlich wirkt (Prüfort ≠ Wirkort). Dieser
+// Test rendert die echte Svelte-Komponente serverseitig (svelte/server
+// `render()`, Hooks: frontend/test-svelte-ssr-hooks.mjs — Vorbild:
+// shared/versand-tab/__tests__/channel_checkbox_dedupe_render.test.ts) und
+// prüft am erzeugten HTML.
+//
+// Spec: docs/specs/modules/fix_1592_c3_cape_delta_alarme.md (AC-9)
+//
+// Pfadregel #1409: alle Pfade relativ zu DIESER Datei.
+//
+// Ausführung:
+//   cd frontend && node --experimental-strip-types --test \
+//     src/lib/components/alerts-tab/__tests__/alertMetricLevelRowTitleRender.test.ts
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { register } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// __tests__ -> alerts-tab -> components -> lib -> src -> frontend
+const FRONTEND = path.resolve(HERE, '../../../../..');
+
+register(
+	pathToFileURL(path.join(FRONTEND, 'test-svelte-ssr-hooks.mjs')).href,
+	pathToFileURL(FRONTEND + '/').href
+);
+
+const { render } = await import('svelte/server');
+const AlertMetricLevelRow = (
+	await import(
+		pathToFileURL(path.join(FRONTEND, 'src/lib/components/alerts-tab/AlertMetricLevelRow.svelte')).href
+	)
+).default;
+
+function renderRow(metric: string, label: string, level: string): string {
+	return render(AlertMetricLevelRow, {
+		props: { metric, label, level, onChange: () => {} }
+	}).body;
+}
+
+/** Öffnendes `<td ...>`-Tag UND sichtbarer Zellentext der Schwellenzelle
+ * dieser Metrik — robust gegen Attributreihenfolge/umgebendes Markup. */
+function thresholdCell(html: string, metric: string): { openTag: string; text: string } {
+	const marker = `data-testid="alert-threshold-${metric}"`;
+	const markerIdx = html.indexOf(marker);
+	assert.notEqual(markerIdx, -1, `Testid "alert-threshold-${metric}" nicht im gerenderten HTML gefunden.`);
+	const tagStart = html.lastIndexOf('<td', markerIdx);
+	assert.notEqual(tagStart, -1, `Kein <td> vor dem Testid "alert-threshold-${metric}" gefunden.`);
+	const tagEnd = html.indexOf('>', markerIdx);
+	const openTag = html.slice(tagStart, tagEnd + 1);
+	const cellEnd = html.indexOf('</td>', tagEnd);
+	assert.notEqual(cellEnd, -1, `Kein schliessendes </td> fuer "alert-threshold-${metric}" gefunden.`);
+	const text = html
+		.slice(tagEnd + 1, cellEnd)
+		.replace(/<!--[\s\S]*?-->/g, '')
+		.trim();
+	return { openTag, text };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// F001: CAPE-Zeile trägt das `title`-Attribut mit der Umrechnungs-Erklärung,
+// UND der Zellentext behält das führende "Δ ≥" (das war der Fehler der
+// vorigen Fassung, s. capeRichtwertAnzeige.test.ts).
+// ─────────────────────────────────────────────────────────────────────────
+
+test('CAPE-Schwellenzelle traegt title="Richtwert — wird je Wettermodell und Gebiet umgerechnet" (F001)', () => {
+	const html = renderRow('cape', 'CAPE', 'standard');
+	const { openTag, text } = thresholdCell(html, 'cape');
+
+	assert.match(
+		openTag,
+		/title="Richtwert — wird je Wettermodell und Gebiet umgerechnet"/,
+		`CAPE-Zelle muss das erklärende title-Attribut tragen — gerendertes Tag: ${openTag}`
+	);
+	assert.equal(
+		text,
+		'Δ ≥ ~600 J/kg',
+		'CAPE-Zellentext muss weiterhin mit "Δ ≥" beginnen (Änderungsschwelle, kein absoluter Grenzwert).'
+	);
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Gegenprobe: eine andere Metrik bekommt KEIN title-Attribut — auch kein
+// leeres title="".
+// ─────────────────────────────────────────────────────────────────────────
+
+test('wind_gust-Schwellenzelle traegt KEIN title-Attribut (Gegenprobe F001)', () => {
+	const html = renderRow('wind_gust', 'Windböen', 'standard');
+	const { openTag, text } = thresholdCell(html, 'wind_gust');
+
+	assert.doesNotMatch(
+		openTag,
+		/\btitle=/,
+		`wind_gust-Zelle darf kein title-Attribut tragen (auch kein title="") — gerendertes Tag: ${openTag}`
+	);
+	assert.equal(text, 'Δ ≥ 20 km/h', 'wind_gust-Zellentext muss unverändert bleiben.');
+});

--- a/frontend/src/lib/components/alerts-tab/__tests__/capeRichtwertAnzeige.test.ts
+++ b/frontend/src/lib/components/alerts-tab/__tests__/capeRichtwertAnzeige.test.ts
@@ -1,0 +1,80 @@
+// #1592 Scheibe C3 AC-9: die CAPE-Schwellenanzeige behauptet keine Zahl, die
+// nirgends wirkt — UND bleibt als Änderungsschwelle ("Δ ≥") erkennbar, nicht
+// als absoluter Grenzwert (Adversary-Nachbesserung, Team-Lead 2026-08-09).
+//
+// Spec: docs/specs/modules/fix_1592_c3_cape_delta_alarme.md (AC-9)
+//
+// `levelToThreshold('cape', 'standard')` liefert jetzt "Δ ≥ ~600 J/kg" —
+// die Tilde markiert die Näherung, das "Δ ≥" bleibt erhalten (sonst würde
+// CAPE optisch wie eine THRESHOLD_CROSSING-Metrik, z. B. Sicht "< 1000 m",
+// wirken, obwohl es weiterhin eine ÄNDERUNGSschwelle ist). Die Erklärung
+// ("wird je Wettermodell und Gebiet umgerechnet") sitzt NICHT im knappen
+// Zellentext, sondern im `title`-Attribut der Zelle
+// (`thresholdTitle()` → `AlertMetricLevelRow.svelte`).
+//
+// Ausfuehrung:
+//   cd frontend && node --import ./test-lib-loader.mjs --experimental-strip-types \
+//     --test src/lib/components/alerts-tab/__tests__/capeRichtwertAnzeige.test.ts
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { levelToThreshold, thresholdTitle } from '../alertMetricTable.ts';
+
+// ─────────────────────────────────────────────────────────────────────────
+// AC-9: CAPE/standard trägt weiterhin die Zahl 600, die Einheit J/kg UND
+// das "Δ ≥" (Änderungsschwelle, kein absoluter Grenzwert) — zusätzlich
+// markiert als Näherung (Tilde).
+// ─────────────────────────────────────────────────────────────────────────
+
+test('cape > standard liefert exakt "Δ ≥ ~600 J/kg" (AC-9, Δ bleibt erhalten)', () => {
+	const text = levelToThreshold('cape', 'standard');
+	assert.equal(
+		text,
+		'Δ ≥ ~600 J/kg',
+		'CAPE bleibt eine Δ-Schwelle (nicht "< 600 J/kg" wie ein absoluter Grenzwert) — ' +
+			'die Tilde markiert die Näherung, "Δ ≥" darf nicht verschwinden.',
+	);
+});
+
+test('cape > standard behält das führende "Δ ≥" (Regressions-Wächter gegen die letzte Fassung)', () => {
+	// Genau der Fehler der vorigen Fassung ("~600 J/kg (Modell)"): das "Δ ≥"
+	// fehlte, CAPE sah wie ein absoluter Grenzwert aus. Dieser Test faengt
+	// jede kuenftige Aenderung ab, die das "Δ ≥" wieder verliert.
+	const text = levelToThreshold('cape', 'standard') as string;
+	assert.match(text, /^Δ ≥ /, 'muss mit "Δ ≥ " beginnen');
+	assert.match(text, /~600/, 'die Näherung (Tilde) vor der Zahl muss erhalten bleiben');
+	assert.match(text, /J\/kg/, 'muss weiterhin die Einheit J/kg zeigen');
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// AC-9: die Erklärung sitzt im `title`, nicht im Zellentext -- nur für CAPE.
+// ─────────────────────────────────────────────────────────────────────────
+
+test('thresholdTitle("cape") erklärt die Umrechnung je Modell/Gebiet (AC-9)', () => {
+	assert.equal(
+		thresholdTitle('cape'),
+		'Richtwert — wird je Wettermodell und Gebiet umgerechnet',
+	);
+});
+
+test('thresholdTitle > alle anderen Metriken liefern kein title (Gegenprobe AC-9)', () => {
+	assert.equal(thresholdTitle('wind_gust'), undefined);
+	assert.equal(thresholdTitle('visibility'), undefined);
+	assert.equal(thresholdTitle('precipitation_sum'), undefined);
+	assert.equal(thresholdTitle('freezing_level'), undefined);
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Gegenprobe (AC-9: "bei allen anderen Metriken bleibt die Anzeige
+// unverändert") — Windböen und Sicht dürfen durch die CAPE-Änderung nicht
+// mitverändert werden.
+// ─────────────────────────────────────────────────────────────────────────
+
+test('wind_gust > standard bleibt unverändert "Δ ≥ 20 km/h" (Gegenprobe AC-9)', () => {
+	assert.equal(levelToThreshold('wind_gust', 'standard'), 'Δ ≥ 20 km/h');
+});
+
+test('visibility > standard bleibt unverändert "< 1000 m" (Gegenprobe AC-9)', () => {
+	assert.equal(levelToThreshold('visibility', 'standard'), '< 1000 m');
+});

--- a/frontend/src/lib/components/alerts-tab/alertMetricTable.ts
+++ b/frontend/src/lib/components/alerts-tab/alertMetricTable.ts
@@ -238,7 +238,31 @@ export function levelToThreshold(metric: AlertMetric, level: SensLevel): string 
 	if (THRESHOLD_CROSSING_METRICS.has(metric)) {
 		return unit ? `< ${value} ${unit}` : `< ${value}`;
 	}
+	// Issue #1592 Scheibe C3 (AC-9): die CAPE-Delta-Schwelle wird seit C3
+	// modell-/gebietsabhängig umgerechnet (Backend:
+	// `app.model_registry.cape_delta_threshold_jkg`) -- die Zahl bleibt aber
+	// eine ÄNDERUNGSschwelle ("Δ ≥"), kein absoluter Grenzwert (das würde sie
+	// optisch mit THRESHOLD_CROSSING-Metriken wie Sicht verwechselbar machen).
+	// Die Tilde markiert die Näherung; die Erklärung sitzt im `title`-Attribut
+	// der Zelle (s. `thresholdTitle()`), nicht im knappen Zellentext selbst.
+	// Nur CAPE, alle anderen Metriken unverändert.
+	if (metric === 'cape') {
+		return unit ? `Δ ≥ ~${value} ${unit}` : `Δ ≥ ~${value}`;
+	}
 	return unit ? `Δ ≥ ${value} ${unit}` : `Δ ≥ ${value}`;
+}
+
+/**
+ * Erklärender `title`-Hinweis für die Schwellenzelle -- aktuell nur für CAPE
+ * (Issue #1592 Scheibe C3, AC-9): die angezeigte Zahl ist ein Richtwert, der
+ * je Wettermodell und Gebiet umgerechnet wird. Alle anderen Metriken haben
+ * KEIN `title` (Regressions-Invariante, s. AlertMetricLevelRow.svelte).
+ */
+export function thresholdTitle(metric: AlertMetric): string | undefined {
+	if (metric === 'cape') {
+		return 'Richtwert — wird je Wettermodell und Gebiet umgerechnet';
+	}
+	return undefined;
 }
 
 /**

--- a/frontend/src/lib/components/alerts-tab/issue_864_alert_metric_levels.test.ts
+++ b/frontend/src/lib/components/alerts-tab/issue_864_alert_metric_levels.test.ts
@@ -72,9 +72,9 @@ test('levelToThreshold > precipitation_sum standard → "Δ ≥ 10 mm"', () => {
 	assert.equal(result, 'Δ ≥ 10 mm');
 });
 
-test('levelToThreshold > cape standard → "Δ ≥ 600 J/kg"', () => {
+test('levelToThreshold > cape standard → "Δ ≥ ~600 J/kg" (Richtwert seit #1592 C3, Δ bleibt erhalten)', () => {
 	const result = levelToThreshold('cape' as AlertMetric, 'standard');
-	assert.equal(result, 'Δ ≥ 600 J/kg');
+	assert.equal(result, 'Δ ≥ ~600 J/kg');
 });
 
 // ─── AC-3: THRESHOLD_CROSSING_METRICS ─────────────────────────────────────

--- a/src/app/model_registry.py
+++ b/src/app/model_registry.py
@@ -140,3 +140,30 @@ def cape_threshold_jkg(model_id: Optional[str], region: Optional[str]) -> Option
     if model_id is None or region is None:
         return None
     return CAPE_THRESHOLDS_JKG.get((model_id, region))
+
+
+# Issue #1592 Scheibe C3: kein neu gesetzter Wert -- die bis Scheibe C1
+# ueberall gueltige, modellblinde CAPE-Schwelle. Genau fuer DIESE Welt wurde
+# die Empfindlichkeitsleiter der CAPE-Aenderungsalarme (1200/600/200,
+# `services.alert_preset._PRESET_TABLE`) geschrieben. Als benannte Konstante
+# abgelegt, damit sie nirgends als nackte 1000 im Code auftaucht.
+CAPE_REFERENZ_NIVEAU_JKG = 1000.0
+
+
+def cape_delta_threshold_jkg(
+    nominal: float, model_id: Optional[str], region: Optional[str]
+) -> Optional[float]:
+    """Rechnet eine nominale Delta-Schwelle (aus der Empfindlichkeitsleiter)
+    in die Modellwelt von (``model_id``, ``region``) um:
+
+        wirksame Schwelle = nominal * cape_threshold_jkg(model_id, region)
+                             / CAPE_REFERENZ_NIVEAU_JKG
+
+    ``None``, wenn ``cape_threshold_jkg()`` ``None`` liefert (unbekannte
+    Herkunft ODER Kombination ohne Eichwert) -- "nicht belegt" heisst hier
+    identisch zu jedem anderen Nachschlag in diesem Modul (Spec Abschnitt
+    2/3). Kein Rueckfall auf ``nominal``."""
+    geeicht = cape_threshold_jkg(model_id, region)
+    if geeicht is None:
+        return None
+    return nominal * geeicht / CAPE_REFERENZ_NIVEAU_JKG

--- a/src/services/deviation_alert_engine.py
+++ b/src/services/deviation_alert_engine.py
@@ -22,7 +22,7 @@ from datetime import datetime, time as time_type, timedelta, timezone
 from typing import List, Optional, Set
 from zoneinfo import ZoneInfo
 
-from app.models import ChangeSeverity, WeatherChange
+from app.models import ChangeSeverity, GPXPoint, WeatherChange
 from services.point_weather import AlertEvaluationConfig, PointWeatherData
 from services.weather_change_detection import WeatherChangeDetectionService
 
@@ -45,18 +45,24 @@ class EvaluationResult:
 class _SegmentIdShim:
     """Interner Adapter: gibt `WeatherChangeDetectionService.detect_changes()`
     (unverändert, liest `.segment.segment_id`/`.start_time`/`.end_time` für
-    `_peak_occurred_at()`) etwas mit diesem Attribut-Shape, ohne
-    `PointWeatherData` selbst an `TripSegment` zu koppeln. `start_time`/
-    `end_time` werden aus der Zeitreihe selbst abgeleitet (erster/letzter
-    Zeitstempel) — das reproduziert den bestehenden Peak-Zeit-Fensterfilter
-    ohne echtes `TripSegment`."""
+    `_peak_occurred_at()`, seit Issue #1592 Scheibe C3 zusaetzlich
+    `.start_point.lat`/`.lon` fuer die CAPE-Gebietsbestimmung) etwas mit
+    diesem Attribut-Shape, ohne `PointWeatherData` selbst an `TripSegment` zu
+    koppeln. `start_time`/`end_time` werden aus der Zeitreihe selbst
+    abgeleitet (erster/letzter Zeitstempel) — das reproduziert den
+    bestehenden Peak-Zeit-Fensterfilter ohne echtes `TripSegment`.
+    `start_point` ist ein echtes `GPXPoint` mit den Punkt-Koordinaten
+    (`PointWeatherData.lat`/`.lon`) -- derselbe Typ, den `TripSegment`
+    traegt, damit `detect_changes()` beide Aufrufer-Formen ohne
+    Fallunterscheidung bedient."""
 
-    __slots__ = ("segment_id", "start_time", "end_time")
+    __slots__ = ("segment_id", "start_time", "end_time", "start_point")
 
     def __init__(self, point: PointWeatherData) -> None:
         self.segment_id = point.id
         ts_values = [dp.ts for dp in point.timeseries.data] if point.timeseries else []
         self.start_time = ts_values[0] if ts_values else None
+        self.start_point = GPXPoint(lat=point.lat, lon=point.lon)
         self.end_time = ts_values[-1] if ts_values else None
 
 

--- a/src/services/weather_change_detection.py
+++ b/src/services/weather_change_detection.py
@@ -610,6 +610,29 @@ class WeatherChangeDetectionService:
             if old_value is None or new_value is None:
                 continue
 
+            # Issue #1592 Scheibe C3: CAPE-Aenderungsalarme rechnen die
+            # nominale Empfindlichkeitsstufe (`threshold`) in die Modellwelt
+            # des liefernden Modells um -- Sonderpfad analog `_ordinal_levels`
+            # oben. `cape_delta_threshold_jkg()` liefert None bei unbekannter
+            # Herkunft ODER einer Modell x Gebiet-Kombination ohne Eichwert:
+            # "keine Aussage", kein Alarm (Abstain, wie C1/C2). Die so
+            # bestimmte Schwelle ist ab hier die EINE Wahrheit -- sie
+            # entscheidet ueber `triggered`, geht in `_classify_severity()`
+            # und wird unten als `WeatherChange.threshold` mitgegeben.
+            if metric == "cape_max_jkg":
+                from app.model_registry import cape_delta_threshold_jkg
+                from providers.thunder_routing import thunder_region_for
+                region = thunder_region_for(
+                    new_data.segment.start_point.lat,
+                    new_data.segment.start_point.lon,
+                )
+                effective_threshold = cape_delta_threshold_jkg(
+                    threshold, new_summary.cape_model_id, region,
+                )
+                if effective_threshold is None:
+                    continue
+                threshold = effective_threshold
+
             # Convert enum values to ordinals for delta calculation.
             # Issue #1214 Scheibe 6: kanonische Ordnungsquelle statt lokalem Dict.
             if isinstance(old_value, Enum):

--- a/tests/integration/test_friendly_format_email_and_alerts.py
+++ b/tests/integration/test_friendly_format_email_and_alerts.py
@@ -43,11 +43,11 @@ from app.models import (
 _NOW = datetime(2026, 3, 15, 10, 0, tzinfo=timezone.utc)
 
 
-def _make_segment(segment_id: int = 1) -> TripSegment:
+def _make_segment(segment_id: int = 1, lat: float = 47.0, lon: float = 11.0) -> TripSegment:
     return TripSegment(
         segment_id=segment_id,
-        start_point=GPXPoint(lat=47.0, lon=11.0, elevation_m=1000.0),
-        end_point=GPXPoint(lat=47.1, lon=11.1, elevation_m=1200.0),
+        start_point=GPXPoint(lat=lat, lon=lon, elevation_m=1000.0),
+        end_point=GPXPoint(lat=lat + 0.1, lon=lon + 0.1, elevation_m=1200.0),
         start_time=_NOW,
         end_time=_NOW + timedelta(hours=2),
         duration_hours=2.0,
@@ -120,6 +120,7 @@ def _make_summary(
     uv_index_max: float | None = None,
     freezing_level: float = 2500.0,
     snow_depth: float = 0.0,
+    cape_model_id: str | None = None,
 ) -> SegmentWeatherSummary:
     return SegmentWeatherSummary(
         temp_min_c=temp_max - 5,
@@ -130,6 +131,11 @@ def _make_summary(
         precip_sum_mm=precip_sum,
         cloud_avg_pct=cloud_avg,
         cape_max_jkg=cape_max,
+        # Issue #1592 Scheibe C3: Default bleibt None (keine Herkunft) --
+        # bestehende Aufrufer, die CAPE nicht ausdrücklich prüfen, bleiben
+        # unverändert. Tests, die einen CAPE-Δ-Alarm erwarten, müssen seit
+        # C3 eine echte Herkunft übergeben (sonst greift der AC-3-Abstain).
+        cape_model_id=cape_model_id,
         visibility_min_m=visibility_min,
         thunder_level_max=thunder_max,
         humidity_avg_pct=humidity_avg,
@@ -147,8 +153,10 @@ def _make_segment_weather(
     segment_id: int = 1,
     summary: SegmentWeatherSummary | None = None,
     dp_kwargs: dict | None = None,
+    lat: float = 47.0,
+    lon: float = 11.0,
 ) -> SegmentWeatherData:
-    seg = _make_segment(segment_id)
+    seg = _make_segment(segment_id, lat=lat, lon=lon)
     dp = _make_dp(**(dp_kwargs or {}))
     ts = NormalizedTimeseries(meta=_make_meta(), data=[dp])
     agg = summary or _make_summary()
@@ -620,21 +628,40 @@ class TestAlertChangeDetectionSimulated:
         assert changes[0].severity == ChangeSeverity.MAJOR
 
     def test_cape_change_detected_with_custom_threshold(self):
-        """CAPE change with custom lower threshold → detected."""
+        """CAPE change with custom lower threshold → detected.
+
+        Issue #1592 Scheibe C3: `_make_summary()`/`_make_segment_weather()`
+        setzen standardmäßig KEINE Modell-Herkunft (`cape_model_id=None`) und
+        liegen im Gebiet DE_ALPEN (47.0/11.0) -- ohne Herkunft greift der
+        AC-3-Abstain (kein Alarm bei unbekannter Herkunft), die alte, jetzt
+        modellblinde Erwartung wäre also nicht mehr gültig. Dieser Test
+        setzt deshalb ausdrücklich eine echte Herkunft (meteofrance_arome)
+        und ein geeichtes Gebiet (Korsika/FR): Faktor 0.30
+        (`app.model_registry.CAPE_THRESHOLDS_JKG[("meteofrance_arome","FR")]
+        == 300.0`) -- nominal 200 -> wirksam 60. Der Sprung (+400) bleibt
+        weit darüber.
+        """
         from services.weather_change_detection import WeatherChangeDetectionService
 
         cached = _make_segment_weather(
-            summary=_make_summary(cape_max=200.0))
+            summary=_make_summary(cape_max=200.0, cape_model_id="meteofrance_arome"),
+            lat=42.22, lon=9.05)
         fresh = _make_segment_weather(
-            summary=_make_summary(cape_max=600.0))  # +400
+            summary=_make_summary(cape_max=600.0, cape_model_id="meteofrance_arome"),  # +400
+            lat=42.22, lon=9.05)
 
-        # Custom threshold: 200 (instead of catalog default 500)
+        # Custom threshold: 200 (instead of catalog default 500) -> umgerechnet
+        # (Faktor 0.30, meteofrance_arome x FR) auf 60.
         service = WeatherChangeDetectionService(
             thresholds={"cape_max_jkg": 200.0})
         changes = service.detect_changes(cached, fresh)
 
         assert len(changes) == 1
         assert changes[0].metric == "cape_max_jkg"
+        assert changes[0].threshold == pytest.approx(60.0), (
+            "Wirksame Schwelle muss die auf meteofrance_arome x FR umgerechnete "
+            "Zahl sein (200 * 300/1000 = 60), nicht die nominale 200."
+        )
 
     def test_uv_index_change_detected(self):
         """UV-Index change from 2 to 8 (threshold 3.0) → detected."""
@@ -909,6 +936,12 @@ class TestAlertFlowWithSimulatedData:
         """
         Simulate approaching storm: temp drops, wind spikes, precipitation
         increases, CAPE rises, thunder appears. All at once.
+
+        Issue #1592 Scheibe C3: CAPE braucht seit dieser Scheibe eine echte
+        Modell-Herkunft, sonst greift der AC-3-Abstain (kein Alarm bei
+        unbekannter Herkunft) -- die Segmente liegen deshalb ausdrücklich auf
+        Korsika/FR mit Herkunft meteofrance_arome (Faktor 0.30, s.
+        `app.model_registry.CAPE_THRESHOLDS_JKG`).
         """
         from services.weather_change_detection import WeatherChangeDetectionService
 
@@ -918,16 +951,18 @@ class TestAlertFlowWithSimulatedData:
             gust_max=25.0,
             precip_sum=0.0,
             cape_max=100.0,
+            cape_model_id="meteofrance_arome",
             thunder_max=ThunderLevel.NONE,
-        ))
+        ), lat=42.22, lon=9.05)
         fresh = _make_segment_weather(summary=_make_summary(
             temp_max=14.0,      # -8 → detected
             wind_max=45.0,      # +30 → detected
             gust_max=70.0,      # +45 → detected
             precip_sum=20.0,    # +20 → detected
-            cape_max=1800.0,    # +1700 → detected
+            cape_max=1800.0,    # +1700 → detected (wirksame Schwelle 150, s.u.)
+            cape_model_id="meteofrance_arome",
             thunder_max=ThunderLevel.HIGH,  # 0→2 → detected
-        ))
+        ), lat=42.22, lon=9.05)
 
         service = WeatherChangeDetectionService(thresholds={
             "temp_max_c": 5.0,

--- a/tests/tdd/test_cape_delta_modellschwelle.py
+++ b/tests/tdd/test_cape_delta_modellschwelle.py
@@ -1,0 +1,458 @@
+"""TDD RED — #1592 Scheibe C3: CAPE-Änderungsalarme rechnen die bestehende
+Empfindlichkeitsleiter (1200/600/200) in die jeweilige Modellwelt um.
+
+Spec: docs/specs/modules/fix_1592_c3_cape_delta_alarme.md
+Context: docs/context/fix-1592-c3-cape-delta-alarme.md
+
+Regel:
+    wirksame Δ-Schwelle = nominale Preset-Zahl × cape_threshold_jkg(modell, gebiet) / 1000
+
+Andockpunkt (noch nicht implementiert): `WeatherChangeDetectionService.detect_changes()`
+(`src/services/weather_change_detection.py:598-658`), Sonderpfad je Metrik analog
+`_ordinal_levels` (#1460).
+
+Mock-frei: alle Aufrufe laufen durch die echte `WeatherChangeDetectionService`
+(bzw. für AC-7 durch die echte `DeviationAlertEngine`) mit echten DTOs
+(`SegmentWeatherData`/`SegmentWeatherSummary`/`PointWeatherData`) — kein
+`Mock()`/`patch()`/`MagicMock`.
+
+Gemessene Fakten (nicht neu hergeleitet, s. Team-Lead-Briefing):
+    cape_threshold_jkg('meteofrance_arome', 'FR') == 300.0  →  Faktor 0.30
+    thunder_region_for(42.22, 9.05) == 'FR'                 (Korsika)
+    Preset "standard" für CAPE (Δ) == 600  →  wirksame Schwelle 600*0.30 == 180.0
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.model_registry import cape_threshold_jkg
+from app.models import (
+    ChangeSeverity,
+    GPXPoint,
+    SegmentWeatherData,
+    SegmentWeatherSummary,
+    TripSegment,
+)
+from providers.thunder_routing import thunder_region_for
+from services.weather_change_detection import WeatherChangeDetectionService
+
+# ─────────────────────────────────────────────────────────────────────────
+# Sanity-Checks der in dieser Datei benutzten geografischen/Eich-Annahmen —
+# laufen bei jedem Testlauf mit, damit ein künftiger Registry-/Routing-Umbau
+# diese Testdatei nicht lautlos auf falschen Annahmen sitzen lässt.
+# ─────────────────────────────────────────────────────────────────────────
+
+CORSICA_LAT, CORSICA_LON = 42.22, 9.05
+assert thunder_region_for(CORSICA_LAT, CORSICA_LON) == "FR", (
+    "Testannahme verletzt: Korsika-Koordinaten müssen ins Gebiet FR routen "
+    "(sonst prüfen AC-1/2/3/5/6 den falschen Fall)."
+)
+assert cape_threshold_jkg("meteofrance_arome", "FR") == 300.0, (
+    "Testannahme verletzt: die B0-Eichung für meteofrance_arome×FR hat sich "
+    "geändert (erwartet 300.0) — die hartcodierten Erwartungswerte 180.0 in "
+    "AC-1/2/5/6 dieser Datei sind davon abgeleitet und müssen nachgezogen werden."
+)
+
+# EU_REST-Koordinaten, die NICHT in FR (lat 41.3-51.1 / lon -5.2-9.7) und
+# NICHT in DE_ALPEN (lat 43.17-58.09 / lon -3.95-20.35) fallen — Ostsee-Raum.
+EU_REST_LAT, EU_REST_LON = 60.0, 25.0
+assert thunder_region_for(EU_REST_LAT, EU_REST_LON) == "EU_REST"
+# icon_d2×EU_REST ist nachweislich NICHT in der Eichtabelle enthalten (nur
+# icon_d2×FR und icon_d2×DE_ALPEN sind geeicht, s. model_registry.py:120-132)
+# — die Kombination steht daher für AC-4 ("Kein Gebiet, keine Aussage").
+assert cape_threshold_jkg("icon_d2", "EU_REST") is None, (
+    "Testannahme verletzt: icon_d2×EU_REST müsste unbelegt sein (AC-4 braucht "
+    "genau eine nachweislich fehlende Kombination)."
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Helfer (mock-frei) — bauen echte SegmentWeatherData-Paare.
+# ─────────────────────────────────────────────────────────────────────────
+
+def _segment(lat: float, lon: float) -> TripSegment:
+    now = datetime(2026, 8, 8, 10, 0, tzinfo=timezone.utc)
+    return TripSegment(
+        segment_id=1,
+        start_point=GPXPoint(lat=lat, lon=lon, elevation_m=800, distance_from_start_km=0.0),
+        end_point=GPXPoint(lat=lat + 0.05, lon=lon + 0.05, elevation_m=1200, distance_from_start_km=5.0),
+        start_time=now,
+        end_time=now,
+        duration_hours=2.0,
+        distance_km=5.0,
+        ascent_m=400,
+        descent_m=0,
+    )
+
+
+def _cape_pair(
+    *, old_cape: float, new_cape: float, cape_model_id, lat: float, lon: float
+) -> tuple[SegmentWeatherData, SegmentWeatherData]:
+    """Baut ein (old_data, new_data)-Paar mit ausschließlich CAPE + Herkunft
+    belegt — alle anderen Felder bleiben None (werden vom Detektor übersprungen,
+    s. `detect_changes()`: `old_value is None or new_value is None` → `continue`)."""
+    segment = _segment(lat, lon)
+    fetched_at = datetime(2026, 8, 8, 6, 0, tzinfo=timezone.utc)
+    old_data = SegmentWeatherData(
+        segment=segment,
+        timeseries=None,
+        aggregated=SegmentWeatherSummary(cape_max_jkg=old_cape, cape_model_id=cape_model_id),
+        fetched_at=fetched_at,
+        provider="test-scripted",
+    )
+    new_data = SegmentWeatherData(
+        segment=segment,
+        timeseries=None,
+        aggregated=SegmentWeatherSummary(cape_max_jkg=new_cape, cape_model_id=cape_model_id),
+        fetched_at=fetched_at,
+        provider="test-scripted",
+    )
+    return old_data, new_data
+
+
+def _cape_changes(changes) -> list:
+    return [c for c in changes if c.metric == "cape_max_jkg"]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# AC-1: Der Kernfall — CAPE-Alarme erreichen Frankreich.
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_ac1_arome_fr_standard_250_jump_triggers_alarm():
+    """
+    GIVEN Korsika (FR), Herkunft meteofrance_arome, Stufe "standard"
+          (nominale Δ-Schwelle 600, umgerechnet 600*0.30 = 180)
+    WHEN  CAPE-Tagesmaximum springt um 250 J/kg (500 -> 750)
+    THEN  entsteht ein WeatherChange für cape_max_jkg.
+
+    RED heute: der Detektor kennt noch keine Modell-/Gebiets-Umrechnung und
+    vergleicht stur gegen die nominale 600 -> 250 < 600 -> KEIN Ereignis.
+    """
+    old_data, new_data = _cape_pair(
+        old_cape=500.0, new_cape=750.0,
+        cape_model_id="meteofrance_arome", lat=CORSICA_LAT, lon=CORSICA_LON,
+    )
+    service = WeatherChangeDetectionService(thresholds={"cape_max_jkg": 600.0})
+    changes = service.detect_changes(old_data, new_data)
+
+    cape_changes = _cape_changes(changes)
+    assert cape_changes, (
+        "AC-1: erwartetes CAPE-Ereignis fehlt. Heute vergleicht der Detektor "
+        "gegen die nominale Schwelle 600 (250 < 600 -> kein Alarm); nach C3 "
+        "muss er gegen die umgerechnete Schwelle 180 vergleichen (250 > 180 "
+        "-> Alarm)."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# AC-2: Gegenprobe — die Schwelle verschwindet nicht (darf JETZT schon grün
+# sein: 150 < 600 (nominal, heute) UND 150 < 180 (umgerechnet, nach C3) —
+# in BEIDEN Welten kein Ereignis).
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_ac2_arome_fr_standard_150_jump_stays_silent():
+    """
+    GIVEN dieselbe Etappe/Stufe wie AC-1
+    WHEN  CAPE-Maximum springt nur um 150 J/kg (500 -> 650)
+    THEN  entsteht KEIN CAPE-Ereignis (150 < 180).
+
+    Dieser Test ist die Gegenprobe zu AC-1 und darf schon HEUTE grün sein
+    (150 liegt sowohl unter der nominalen 600 als auch unter der künftigen
+    umgerechneten 180) — ohne ihn wäre AC-1 auch von einer Implementierung
+    erfüllt, die immer auslöst.
+    """
+    old_data, new_data = _cape_pair(
+        old_cape=500.0, new_cape=650.0,
+        cape_model_id="meteofrance_arome", lat=CORSICA_LAT, lon=CORSICA_LON,
+    )
+    service = WeatherChangeDetectionService(thresholds={"cape_max_jkg": 600.0})
+    changes = service.detect_changes(old_data, new_data)
+
+    assert _cape_changes(changes) == []
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# AC-3: Unbekannte Herkunft schweigt, statt zu behaupten.
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_ac3_unknown_model_id_abstains_even_on_huge_jump():
+    """
+    GIVEN Etappe mit cape_model_id=None (unbekanntes Modell)
+    WHEN  CAPE-Maximum springt um 5000 J/kg
+    THEN  entsteht KEIN CAPE-Ereignis ("keine Aussage", nicht "unauffällig").
+
+    RED heute: der Detektor kennt cape_model_id noch gar nicht und feuert
+    stur bei abs(delta) > 600 -> 5000 > 600 -> Ereignis entsteht (fälschlich).
+    """
+    old_data, new_data = _cape_pair(
+        old_cape=100.0, new_cape=5100.0,
+        cape_model_id=None, lat=CORSICA_LAT, lon=CORSICA_LON,
+    )
+    service = WeatherChangeDetectionService(thresholds={"cape_max_jkg": 600.0})
+    changes = service.detect_changes(old_data, new_data)
+
+    assert _cape_changes(changes) == [], (
+        "AC-3: unbekannte Modell-Herkunft (cape_model_id=None) darf auch bei "
+        "einem riesigen Sprung KEIN CAPE-Ereignis erzeugen — Abstain, nicht "
+        "Alarm."
+    )
+
+
+def test_ac3_gegenprobe_known_model_id_fires_on_same_jump():
+    """Gegenprobe zu AC-3: dieselbe Konstellation, aber mit gesetzter
+    Herkunft, liefert sehr wohl ein Ereignis — das Abstain-Verhalten aus
+    AC-3 hängt wirklich an `cape_model_id`, nicht an sonst etwas."""
+    old_data, new_data = _cape_pair(
+        old_cape=100.0, new_cape=5100.0,
+        cape_model_id="meteofrance_arome", lat=CORSICA_LAT, lon=CORSICA_LON,
+    )
+    service = WeatherChangeDetectionService(thresholds={"cape_max_jkg": 600.0})
+    changes = service.detect_changes(old_data, new_data)
+
+    assert _cape_changes(changes), (
+        "Gegenprobe zu AC-3: mit bekannter Herkunft muss derselbe Sprung ein "
+        "CAPE-Ereignis erzeugen (heute schon der Fall, da 5000 > 600 ohnehin "
+        "auslöst — bleibt nach C3 mit umgerechneter Schwelle 180 ebenso "
+        "wahr)."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# AC-4: Kein Gebiet / keine Eichung, keine Aussage.
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_ac4_known_model_but_uncalibrated_region_abstains():
+    """
+    GIVEN Etappe mit bekannter Herkunft (icon_d2), aber Koordinaten im
+          Gebiet EU_REST — für icon_d2×EU_REST existiert KEIN Eichwert
+          (nur icon_d2×FR und icon_d2×DE_ALPEN sind in CAPE_THRESHOLDS_JKG,
+          s. model_registry.py:120-132)
+    WHEN  CAPE-Maximum springt um 5000 J/kg
+    THEN  entsteht KEIN CAPE-Ereignis.
+
+    RED heute: der Detektor prüft die Kombination noch nicht gegen die
+    Eichtabelle und feuert stur bei abs(delta) > 600.
+    """
+    old_data, new_data = _cape_pair(
+        old_cape=100.0, new_cape=5100.0,
+        cape_model_id="icon_d2", lat=EU_REST_LAT, lon=EU_REST_LON,
+    )
+    service = WeatherChangeDetectionService(thresholds={"cape_max_jkg": 600.0})
+    changes = service.detect_changes(old_data, new_data)
+
+    assert _cape_changes(changes) == [], (
+        "AC-4: icon_d2xEU_REST hat keinen Eichwert -> auch ein riesiger "
+        "Sprung darf KEIN CAPE-Ereignis erzeugen."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# AC-5: Der Alarmtext nennt die Schwelle, die wirklich galt — Prüfort ist
+# der RENDERER (over_thr()), nicht nur das WeatherChange-Objekt.
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_ac5_event_carries_effective_threshold_and_renderer_sees_over_thr():
+    """
+    GIVEN der Alarm aus AC-1 (250-J/kg-Sprung, meteofrance_arome, FR)
+    WHEN  die Alarmzeile über den echten Konverter `to_alert_message()`
+          gerendert wird
+    THEN  WeatherChange.threshold == 180.0 UND das daraus gebaute
+          AlertEvent liefert `over_thr(event) is True` — nicht 600 und
+          nicht "unter Schwelle".
+
+    Baut das AlertEvent über den echten Projektions-Weg
+    (`output.renderers.alert.project.to_alert_message`), nicht von Hand
+    zusammengestückelt.
+
+    RED heute: AC-1 liefert noch KEIN Ereignis (250 < nominale 600) — diese
+    Kette bricht deshalb bereits an der ersten Assertion.
+    """
+    from output.renderers.alert.model import over_thr
+    from output.renderers.alert.project import to_alert_message
+
+    old_data, new_data = _cape_pair(
+        old_cape=500.0, new_cape=750.0,
+        cape_model_id="meteofrance_arome", lat=CORSICA_LAT, lon=CORSICA_LON,
+    )
+    service = WeatherChangeDetectionService(thresholds={"cape_max_jkg": 600.0})
+    changes = service.detect_changes(old_data, new_data)
+    cape_changes = _cape_changes(changes)
+    assert cape_changes, "AC-5 setzt das AC-1-Ereignis voraus — s. AC-1 für die Begründung."
+
+    change = cape_changes[0]
+    assert change.threshold == 180.0, (
+        f"AC-5: WeatherChange.threshold muss die umgerechnete Schwelle 180.0 "
+        f"tragen, nicht die nominale 600 — war {change.threshold!r}."
+    )
+
+    message = to_alert_message(
+        [change], [new_data], "GR20-Test", tz=timezone.utc, stand_at="12:00",
+    )
+    assert len(message.events) == 1
+    event = message.events[0]
+    assert over_thr(event) is True, (
+        "AC-5: der Renderer muss das Ereignis als 'über Schwelle' einstufen "
+        "(over_thr() aus output.renderers.alert.model) — sonst stünde im "
+        "Alarmtext 'unter Schwelle', obwohl er ausgelöst hat."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# AC-6: Die Dringlichkeit folgt der umgerechneten Schwelle.
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_ac6_400_jump_is_major_under_converted_threshold():
+    """
+    GIVEN Etappe aus AC-1 (meteofrance_arome, FR, Stufe "standard")
+    WHEN  CAPE-Maximum springt um 400 J/kg
+    THEN  ChangeSeverity.MAJOR (400 / 180 = 2.22 >= 2.0), während heute
+          ÜBERHAUPT KEIN Alarm entstünde (400 < nominale 600).
+
+    RED heute: kein Ereignis (400 < 600) -> die Severity-Prüfung kann gar
+    nicht erst stattfinden.
+    """
+    old_data, new_data = _cape_pair(
+        old_cape=500.0, new_cape=900.0,
+        cape_model_id="meteofrance_arome", lat=CORSICA_LAT, lon=CORSICA_LON,
+    )
+    service = WeatherChangeDetectionService(thresholds={"cape_max_jkg": 600.0})
+    changes = service.detect_changes(old_data, new_data)
+    cape_changes = _cape_changes(changes)
+    assert cape_changes, (
+        "AC-6 setzt voraus, dass ein CAPE-Ereignis entsteht (heute: 400 < "
+        "600 -> kein Alarm; nach C3: 400 > 180 -> Alarm mit MAJOR)."
+    )
+    assert cape_changes[0].severity is ChangeSeverity.MAJOR, (
+        f"AC-6: Severity muss MAJOR sein (400/180=2.22>=2.0) — war "
+        f"{cape_changes[0].severity!r}."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# AC-7: Der Ortsvergleich erbt die Wirkung, ohne eigenen Code — geprüft über
+# den echten Compare-Auswertungskern `DeviationAlertEngine`, NICHT über eine
+# Trip-Attrappe. `DeviationAlertEngine` ist location-generisch (kennt kein
+# `Trip`) und ist exakt der Kern, den `CompareAlertService` UND
+# `TripAlertService` gemeinsam nutzen (services/deviation_alert_engine.py) —
+# das ist die tiefste Ebene, die noch echter (geteilter) Compare-Code ist,
+# ohne dass ein voller `CompareAlertService`-Lauf Netz/Dateisystem-Fixtures
+# braucht.
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_ac7_compare_path_via_deviation_alert_engine_inherits_conversion():
+    """
+    GIVEN ein Ortsvergleichs-Punkt in Frankreich, Herkunft meteofrance_arome,
+          Stufe "standard" (per `metric_alert_levels={"cape": "standard"}`,
+          exakt der Weg, über den `CompareAlertService` seine Regeln baut,
+          s. `expand_per_metric_levels()` in `services/alert_preset.py`)
+    WHEN  CAPE-Maximum dieses Ortes um 250 J/kg steigt
+    THEN  entsteht eine Abweichungsmeldung (EvaluationResult.triggered=True)
+          mit einem cape_max_jkg-Change bei Schwelle 180.0.
+
+    RED heute: die Engine baut die Regel mit der nominalen Schwelle 600 ->
+    250 < 600 -> `triggered=False` ("no_significant_changes").
+    """
+    from services.deviation_alert_engine import DeviationAlertEngine
+    from services.point_weather import AlertEvaluationConfig, PointWeatherData
+
+    fetched_at = datetime(2026, 8, 8, 6, 0, tzinfo=timezone.utc)
+    old_point = PointWeatherData(
+        id="corse-test", name="Korsika-Testort", lat=CORSICA_LAT, lon=CORSICA_LON,
+        timeseries=None,
+        aggregated=SegmentWeatherSummary(cape_max_jkg=500.0, cape_model_id="meteofrance_arome"),
+        fetched_at=fetched_at, provider="test-scripted",
+    )
+    fresh_point = PointWeatherData(
+        id="corse-test", name="Korsika-Testort", lat=CORSICA_LAT, lon=CORSICA_LON,
+        timeseries=None,
+        aggregated=SegmentWeatherSummary(cape_max_jkg=750.0, cape_model_id="meteofrance_arome"),
+        fetched_at=fetched_at, provider="test-scripted",
+    )
+    config = AlertEvaluationConfig(
+        cooldown_minutes=0, quiet_from=None, quiet_to=None,
+        metric_alert_levels={"cape": "standard"}, channels={"email"},
+    )
+    engine = DeviationAlertEngine()
+    result = engine.evaluate(
+        [old_point], [fresh_point], config, alert_state={},
+        now=datetime(2026, 8, 8, 10, 0, tzinfo=timezone.utc),
+    )
+
+    assert result.triggered is True, (
+        f"AC-7: der Ortsvergleichs-Auswertungskern muss bei 250 J/kg Sprung "
+        f"gegen FR/meteofrance_arome auslösen (umgerechnete Schwelle 180) — "
+        f"war triggered={result.triggered!r} suppressed_reason="
+        f"{result.suppressed_reason!r}."
+    )
+    cape_changes = _cape_changes(result.changes)
+    assert cape_changes, "AC-7: erwartetes cape_max_jkg-Ereignis fehlt im Compare-Pfad."
+    assert cape_changes[0].threshold == 180.0
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# AC-8: Regressionsschutz — vier NICHT betroffene Metriken bleiben
+# byte-identisch (Auslösung, Schwelle, Severity) zu den heutigen
+# `_PRESET_TABLE`-Werten (Stufe "standard": WIND_GUST 20, PRECIPITATION_SUM
+# 10, FRESH_SNOW 8, FREEZING_LEVEL 400). Alle vier Deltas sind bewusst exakt
+# das 2.5-fache ihrer Schwelle -> eindeutig MAJOR (>=2.0), keine
+# Rundungs-/Grenzfall-Ambiguität.
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_ac8_untouched_metrics_stay_byte_identical():
+    """
+    GIVEN identische Eingaben für gust_max_kmh, precip_sum_mm,
+          snow_new_sum_cm, freezing_level_m (Stufe "standard"-Schwellen aus
+          `_PRESET_TABLE`, unverändert von dieser Scheibe)
+    WHEN  detect_changes() läuft
+    THEN  Auslösung, Schwelle und Severity dieser vier Metriken bleiben exakt
+          wie heute (2.5x Schwelle -> MAJOR).
+
+    Darf JETZT schon grün sein — dient als Regressionsschutz gegen die
+    CAPE-Änderung dieser Scheibe (die vier Felder sind vom neuen
+    CAPE-Sonderpfad nicht berührt).
+    """
+    segment = _segment(47.0, 11.0)
+    fetched_at = datetime(2026, 8, 8, 6, 0, tzinfo=timezone.utc)
+    old_summary = SegmentWeatherSummary(
+        gust_max_kmh=20.0, precip_sum_mm=10.0, snow_new_sum_cm=5.0, freezing_level_m=2000,
+    )
+    new_summary = SegmentWeatherSummary(
+        gust_max_kmh=70.0,   # +50 (Schwelle 20 -> 2.5x)
+        precip_sum_mm=35.0,  # +25 (Schwelle 10 -> 2.5x)
+        snow_new_sum_cm=25.0,  # +20 (Schwelle 8 -> 2.5x)
+        freezing_level_m=3000,  # +1000 (Schwelle 400 -> 2.5x)
+    )
+    old_data = SegmentWeatherData(
+        segment=segment, timeseries=None, aggregated=old_summary,
+        fetched_at=fetched_at, provider="test-scripted",
+    )
+    new_data = SegmentWeatherData(
+        segment=segment, timeseries=None, aggregated=new_summary,
+        fetched_at=fetched_at, provider="test-scripted",
+    )
+    service = WeatherChangeDetectionService(thresholds={
+        "gust_max_kmh": 20.0,
+        "precip_sum_mm": 10.0,
+        "snow_new_sum_cm": 8.0,
+        "freezing_level_m": 400.0,
+    })
+    changes = service.detect_changes(old_data, new_data)
+    by_field = {c.metric: c for c in changes}
+
+    assert set(by_field) == {"gust_max_kmh", "precip_sum_mm", "snow_new_sum_cm", "freezing_level_m"}
+    expected_thresholds = {
+        "gust_max_kmh": 20.0,
+        "precip_sum_mm": 10.0,
+        "snow_new_sum_cm": 8.0,
+        "freezing_level_m": 400.0,
+    }
+    for field, expected_threshold in expected_thresholds.items():
+        change = by_field[field]
+        assert change.threshold == expected_threshold, (
+            f"AC-8 Regression: {field}.threshold muss unverändert "
+            f"{expected_threshold} bleiben — war {change.threshold!r}."
+        )
+        assert change.severity is ChangeSeverity.MAJOR, (
+            f"AC-8 Regression: {field}.severity muss unverändert MAJOR "
+            f"bleiben (2.5x Schwelle) — war {change.severity!r}."
+        )


### PR DESCRIPTION
Schließt Scheibe C3 von #1592 — die letzte modellblinde CAPE-Schwellenfamilie.

## Das Problem

Ein CAPE-Sprung von 600 J/kg (Empfindlichkeitsstufe „standard") löste bisher unabhängig davon
aus, aus welchem Wettermodell der Wert stammt. Bei AROME — dem Modell für Frankreich und
Korsika, wo die Zielgruppe wandert — liegt das gemessene Maximum bei 840 J/kg; die Schwelle
war dort praktisch unerreichbar. Bei ECMWF (Maximum 3670) ist derselbe Sprung beiläufig.
Dieselbe Empfindlichkeitsstufe bedeutete je Gebiet etwas anderes, und zwar im Alarmpfad, der
bis MAJOR eskaliert.

## Die Lösung

Die bestehende Leiter wird mit der in Scheibe B0 geeichten Schwelle umgerechnet:

```
wirksame Schwelle = nominale Zahl × cape_threshold_jkg(modell, gebiet) / 1000
```

Die 1000 ist kein neu gesetzter Wert, sondern die bis Scheibe C1 überall gültige Schwelle —
genau die Welt, für die die Leiter 1200/600/200 geschrieben wurde. **Keine neue Eichung, kein
Messlauf, keine erfundene Zahl.** ADR-0043 bleibt gewahrt: die Empfindlichkeitsstufe ist
weiterhin der einzige Regler; Modell und Gebiet ändern nicht die Einstellung, sondern nur
ihre Übersetzung in die Skala des liefernden Modells.

Fehlt eine Eichung — unbekannte Herkunft oder eine Kombination ohne Eichwert — entsteht **kein**
Alarm. „Keine Aussage", nicht „unauffällig", wie in C1 und C2.

## 🔴 Wirkung, die man kennen muss

Alle elf geeichten Schwellen liegen unter 1000. Die Änderungsschwellen sinken deshalb
**überall**, nicht nur in Frankreich — Faktor 0,30 (AROME/ICON-D2) bis 0,85 (ICON-EU in FR).
Das bedeutet **mehr CAPE-Änderungsalarme als bisher**. Das ist die beabsichtigte Korrektur, denn
die alte 600 war an nichts geeicht; dem PO wurde die Wirkungstabelle vor der Freigabe beziffert
vorgelegt. Nach unten begrenzt der Eichboden von 300 J/kg den Faktor auf 0,30.

## Geändert

| Datei | Änderung |
|---|---|
| `src/app/model_registry.py` | `CAPE_REFERENZ_NIVEAU_JKG` (benannt, mit Begründung) + `cape_delta_threshold_jkg()`, `None` bei fehlender Eichung — kein Rückfall |
| `src/services/weather_change_detection.py` | CAPE-Sonderpfad in `detect_changes()`, gebaut wie der vorhandene `_ordinal_levels`-Sonderfall (#1460) |
| `src/services/deviation_alert_engine.py` | `_SegmentIdShim` trägt jetzt `start_point` |
| `frontend/.../alertMetricTable.ts`, `AlertMetricLevelRow.svelte` | `Δ ≥ ~600 J/kg` + Tooltip „Richtwert — wird je Wettermodell und Gebiet umgerechnet" |
| `docs/adr/0048-…` | Vollzugsvermerk (Entscheidung unverändert, kein neues ADR) |

Die umgerechnete Schwelle wandert auch **ins Ereignis**. Das ist keine Kosmetik: der Renderer
prüft sie nach (`output/renderers/alert/model.py::over_thr`) und sortiert danach
(`render.py:725`) — mit der nominalen Zahl stünde im Alarm „unter Schwelle".

## Zwei Funde, die der Plan nicht vorhergesehen hatte

1. **Der Ortsvergleich wäre abgestürzt.** `_SegmentIdShim` hatte `__slots__` ohne Koordinaten.
   Die Spec-Regel 1:1 umgesetzt hätte einen `AttributeError` geworfen — und der hätte den
   **gesamten** Alarmlauf lahmgelegt, nicht nur CAPE. In der RED-Phase gefunden.
2. **Zwei Bestandstests schrieben das alte Verhalten fest**
   (`tests/integration/test_friendly_format_email_and_alerts.py`; der Helfer `_make_summary()`
   setzt keine Modell-Herkunft). Weder Analyse noch Adversary hatten die Datei auf dem Schirm —
   erst der breite Lauf zeigte sie. Dasselbe Muster wie in Scheibe C2. Nachgezogen, eine
   Zusicherung dabei **verschärft**: sie prüft jetzt den konkreten umgerechneten Schwellenwert
   statt nur die Existenz des Alarms.

## Nachweis

- **Adversary VERIFIED**, drei Runden, **13 Mutationen, 12 gefangen** — die eine ungefangene ist
  nachweislich bedeutungsgleich.
- Runde 2 stand auf AMBIGUOUS wegen **F001**: die Mutation „Tooltip-Durchreichung entfernen"
  blieb bei 28/28 grün — Wirkung vorhanden, aber unbewacht („Prüfort ≠ Wirkort"). Geschlossen
  durch einen echten SSR-Render-Test mit Gegenprobe.
- **Vollsuite mit exakter CI-Konfiguration: 7170 grün.**
- 9 Akzeptanzkriterien, alle durch je einen Test belegt.

Nicht in dieser Scheibe: #1601 (Modellwechsel zwischen Δ-Anker und frischem Wert löst allein
einen Alarm aus) — direkt im Anschluss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxyuCgpKtbf16da3Cx88zy
