### PR TITLE
fix(#1614): Doppelversand amtlicher Warnungen stoppen, GELB-Kontrast anheben

### DIFF
--- a/docs/context/fix-1614-briefing-warnfenster.md
+++ b/docs/context/fix-1614-briefing-warnfenster.md
@@ -1,0 +1,236 @@
+# Context: fix-1614-briefing-warnfenster
+
+## Request Summary
+**KORRIGIERT nach Forensik am echten Vorfall (siehe unten) — die ursprüngliche
+Issue-Prämisse ("Warnung fehlte im Briefing wegen zu engem Zeitfenster") ist
+widerlegt.** Der tatsächliche Umfang, PO-bestätigt 2026-08-08, vier Teile:
+
+1. **Doppelversand:** Eine amtliche Warnung, die bereits korrekt im Briefing
+   erscheint, wird bis zu 15 Minuten später vom unabhängigen Alarm-Checker
+   NOCHMAL als eigene, redundante Nachricht verschickt — weil der
+   Briefing-Pfad das Melde-Gedächtnis nie beschreibt.
+2. **GELB-Kontrast in der E-Mail:** Die Warnfarbe für Stufe 2 (`G_ALERT_L2`)
+   hat nachweislich 4,11:1 Kontrast — unter der von CLAUDE.md geforderten
+   WCAG-AA-Grenze (4,5:1). Deshalb wird die Warnung leicht übersehen.
+3. **Fehlende Verdrahtung (#1461 S3b-2a):** Der Briefing-Versand ruft die
+   bereits gebaute Kanal-Schwellen-Funktion (`min_official_level_for_threshold`)
+   nie auf — GELB-Warnungen erreichen SMS/Telegram im Briefing deshalb nie,
+   obwohl genau das am 2026-08-05 als PO-Entscheidung bereits beschlossen und
+   für den separaten Alarm-Weg bereits umgesetzt wurde. Gilt für Trip UND
+   Ortsvergleich (dort als offener Teilschritt S3b-2b bereits bekannt).
+4. **"!"-Kennzeichnung:** Neue, bisher nicht existierende Kennzeichnung für
+   amtliche Warnungen, die den SMS-Kanal erreichen.
+
+## 🔴 Forensik-Befund (2026-08-08, entscheidend für den Zuschnitt)
+
+Die ursprüngliche Issue-Behauptung ("Warnung fehlte in SMS/E-Mail des
+16:01-Uhr-Briefings") wurde direkt an der **tatsächlich verschickten Mail**
+geprüft (Resend-Read-API, `RESEND_READ_API_KEY` aus
+`/home/hem/henemm-infra/.env`, `GET https://api.resend.com/emails/<id>`,
+User-Agent-Header nötig sonst Cloudflare-403). Ergebnis: Mail-ID `86918bc7`
+(2026-08-08 16:01:33 UTC, Betreff „[KHW 403] Etappe 2 … — Abend") enthielt
+die Warnung korrekt:
+```
+━━ Amtliche Warnungen ━━
+  ⚠️ Amtliche Warnung: Yellow Thunderstorm Warning (So 09.08. · 14:00 – Mo 10.08. 01:59)
+```
+Die 14 Minuten später verschickte Mail-ID `7d0bbfd6` (16:15:01, Betreff
+„[KHW 403] Segment 4 · GELB Gewitter (So)") ist **dieselbe** Warnung
+(Region „Trentino Alto Adige", identischer Zeitraum, Stufe GELB) — als
+eigene, redundante Alarm-Mail. Auch die reine Zeitfenster-Rechnung mit den
+echten historischen Werten (Snapshot `weather_snapshots/5f534011_2026-08-09.json`,
+Segment „Ziel" 46.706056/12.406271, Fenster 06:00–18:00 UTC alt vs. Warnung
+12:00–23:59 UTC) bestätigt das: die Warnung überschneidet sich mit dem ALTEN
+Fenster bereits — `filter_alerts_to_window()` direkt mit den echten Werten
+aufgerufen liefert 1 Treffer. **Die Fenster-Theorie war falsch, das Symptom
+war ein Doppelversand, keine fehlende Warnung.**
+
+## Related Files
+
+### Teil 1 — Doppelversand
+| File | Relevance |
+|------|-----------|
+| `src/services/trip_alert.py:1061-1151` (`check_official_alert_triggers`) | Unabhängiger 15-Min-Checker, deckt die GESAMTE Restroute ab (#1460 P4) — findet Warnungen, die das Briefing bereits gezeigt hat, erneut und meldet sie separat, weil er nicht weiß, dass sie schon gezeigt wurden. |
+| `src/services/trip_alert.py:1153-1167` (`_record_official_alert_state`) | Schreibt NACH erfolgreichem Alarm-Versand den Melde-Stand (`official_alert:`-Namensraum, `AlertStateService`). Der Briefing-Pfad ruft das nirgends auf — genau diese Lücke erzeugt den Doppelversand. |
+| `src/services/trip_report_scheduler.py` (nahe `:1028`, vor `write_anchor_and_reset_memory`, `_send_trip_report_outcome`) | Hier fehlt der Aufruf, der die im Briefing gezeigten `sw.official_alerts` als „gemeldet" vermerkt. |
+| `src/services/trip_report_scheduler.py:1180-1187` (`_reset_alert_state_after_briefing`) | Löscht nur den Änderungs-Raum; der `official_alert:`-Raum bleibt bewusst erhalten (#1460 P2) — passt zur Lösung, muss nicht geändert werden. |
+| `src/services/alert_briefing_anchor.py` | Geteilter Baustein (#1467 S2 AG5) für Anker+Reset zwischen Trip und Ortsvergleich — Vorbild/Zielort für die neue geteilte "als gemeldet vermerken"-Funktion (PO-Linie: "zwingend derselbe Code"). |
+| `src/output/renderers/alert/official_alerts.py:407` (`official_alert_state_key`) | Kanonische Schlüsselbildung, MUSS von der neuen Record-Funktion verwendet werden (Präfix-Kopplungstest existiert bereits, `test_official_alert_state_key_praefix_stimmt_mit_dem_reset_filter_ueberein`). |
+
+### Teil 2 — GELB-Kontrast
+| File | Relevance |
+|------|-----------|
+| `src/output/renderers/email/design_tokens.py:32` | `G_ALERT_L2 = '#9a6f00'` — Kommentar im Code selbst: „4,11:1 auf G_PAPER" — unter der CLAUDE.md-Mindestgrenze 4,5:1 (WCAG-AA). |
+| `src/output/renderers/alert/official_alerts.py:1330,1335,1408,207,1222` | Alle Stellen, die `G_ALERT_L2/L3/L4` als `level_colors`-Mapping verwenden (Warn-Block, Standalone-HTML, Compact-Badges) — Farbwert wird zentral aus `design_tokens.py` bezogen, EINE Änderung wirkt überall. |
+| `src/output/renderers/email/compare_html.py:107` | Compare-Pendant nutzt denselben Token `G_ALERT_L2` (mit eigenem Hintergrund-Ton `#f2e4b0`) — Kontrast dort separat zu prüfen, da Text/Hintergrund-Kombination abweicht. |
+
+### Teil 3 — Fehlende Kanal-Schwellen-Verdrahtung (#1461 S3b-2a/S3b-2b)
+| File | Relevance |
+|------|-----------|
+| `src/services/alert_urgency.py:71-80` (`min_official_level_for_threshold`) | Fertige Funktion: Kanal-Schwelle ('LOW'/'MODERATE'/'HIGH') → niedrigste amtliche Stufe, die den Kanal erreichen darf. Bereits gebaut, PO-Entscheidung 2026-08-05 bereits getroffen — **wird vom Trip-Briefing nie aufgerufen** (verifiziert: `grep` auf `trip_report_scheduler.py` findet keinen Treffer). |
+| `src/output/tokens/hazard_symbols.py:32-37` | `MIN_SMS_LEVEL = 3` (alte, feste Grenze) — bleibt als Fallback-Default bestehen, wird aber pro Aufruf durch `sms_alert_min_level` überschrieben, WENN der Aufrufer ihn setzt. |
+| `src/output/renderers/sms_trip.py:143-178,381,413-458` (`_official_alert_entries`, `sms_alert_min_level`-Parameter) | Die Parameter-Durchreichung existiert bereits bis zum Renderer — nur der EINE Aufruf-Ort im Scheduler übergibt nie einen aus `trip.alert_channel_thresholds` abgeleiteten Wert. |
+| `src/services/trip_report_scheduler.py` | Baustelle: hier muss `alert_urgency.min_official_level_for_threshold(trip.alert_channel_thresholds.get('sms', 'LOW'))` (und analog fürs Telegram-Pendant) berechnet und durchgereicht werden. |
+| `src/services/comparison_engine.py:704,869` (laut `project_1461_s3b2a_kanal_schwelle`-Memory) | Compare-Pendant derselben Lücke (S3b-2b, bereits als offen dokumentiert) — Teilungsregel verlangt denselben Fix hier. |
+| `frontend/.../shared/alarme-tab/alertChannelState.ts` | Der Bedienort, den der PO meint: Reiter „Alarme", `AlertChannelThresholdState` (LOW/MODERATE/HIGH je Kanal, Default LOW). Muss NICHT geändert werden — ist bereits der richtige, geteilte Bedienweg; nur das Backend liest ihn im Briefing-Pfad nicht aus. |
+
+### Teil 4 — „!"-Kennzeichnung
+| File | Relevance |
+|------|-----------|
+| `src/output/renderers/alert/official_alerts.py:368-404` (`official_alerts_to_sms_entries`) | Erzeugt die `(Kürzel, Stufenbuchstabe, Stunde)`-Tripel, die in die SMS-Kurzform einfließen — hier oder an der Stelle, die diese Tripel zu Text zusammensetzt, muss die „!"-Kennzeichnung ergänzt werden. Existiert heute nirgends im Code (verifiziert per grep). |
+
+## Existing Patterns
+- **#1460 P2** (`AlertStateService.reset()`, `services/alert_state.py`) trennt
+  bereits zwei Namensräume: Änderungs-Raum (wird beim Briefing zurückgesetzt)
+  vs. `official_alert:`-Raum (überlebt den Reset). Die fehlende Schreibung in
+  diesen Raum aus dem Briefing-Pfad ist die Lücke, die Teil 1 schließt.
+- **#1467 S2 AG5** hat "beide Pfade müssen sich gleich verhalten" bereits für
+  Anker+Reset als EINEN geteilten Baustein etabliert — Vorlage für die neue
+  geteilte "record"-Funktion statt einer Zweitfassung von
+  `_record_official_alert_state`.
+- **#1461 S3a/S3b-2a** hat die komplette Dringlichkeits-/Kanal-Schwellen-
+  Architektur bereits gebaut und für den Alarm-Pfad verdrahtet (`alert_urgency.py`,
+  `alert_channel_threshold.py`, Frontend-Reiter „Alarme"). Teil 3 ist reines
+  Nachziehen der bereits getroffenen PO-Entscheidung ("Bericht zeigt künftig
+  mehr, auch gelb", 2026-08-05) für den Briefing-Pfad — keine neue Entscheidung,
+  keine neue Architektur.
+- **Design-Tokens zentral** (`design_tokens.py`) — EIN Ort für alle
+  Warnstufen-Farben, von mehreren Renderern konsumiert (Teil 2 ändert nur
+  den Token-Wert, keine Konsumenten-Logik).
+
+## Dependencies
+- **Upstream:** `services.official_alerts.get_official_alerts_with_status` /
+  `.base.filter_alerts_to_window` (Zeitfenster-Filterung); `AlertStateService`
+  (Melde-Gedächtnis, Datei je Nutzer/Trip).
+- **Downstream:** E-Mail-/SMS-/Telegram-Renderer, die `sw.official_alerts`
+  konsumieren (Format unverändert); `trip_alert.py`s 15-Min-Checker, der
+  `AlertStateService` liest.
+
+## Existing Specs
+- `docs/specs/modules/rework_1460_t1_relevanzfilter.md` — P2 Gedächtnis, P4
+  Ort+Zeit-Kopplung (AC-20..AC-33). Direkte fachliche Nachbarschaft.
+- `docs/specs/modules/rework_1467_s2_aenderungsalarm.md` — AG5 geteilter
+  Baustein Anker+Reset.
+- `docs/specs/modules/feat_1461_s3b1_briefing_sichtbarkeit.md` —
+  Sichtbarkeits-Regeln im Briefing.
+
+## Vorhandene Tests als Vorbild
+- `tests/tdd/test_official_alert_time_window.py` — P4-Fenster-Semantik des
+  Alarm-Checkers (Pro-Segment-Fenster, Dedup-Schlüssel).
+- `tests/tdd/test_alert_state_briefing_reset.py` — AC-20..23, inkl. echtem
+  `_reset_alert_state_after_briefing()`-Aufrufpfad über eine echte
+  `TripReportSchedulerService`-Instanz. AC-22/22b sind exakt das Muster
+  "Briefing hat stattgefunden → Checker meldet danach nicht erneut / meldet
+  bei echter Verschärfung doch" — das Gegenstück zu dem, was #1614 fürs
+  Briefing selbst braucht.
+- `tests/tdd/test_official_alert_dedup_timespan.py`,
+  `test_issue_1088_official_alert_triggers.py` — weitere Nachbarn.
+
+## Risks & Considerations
+- **Doppelversand-Gefahr bleibt bei reiner Fenster-Erweiterung:** Wird nur das
+  Abfragefenster geweitet, ohne das Melde-Gedächtnis aus dem Briefing-Pfad zu
+  beschreiben, verschiebt sich der Bug nur — die Warnung erscheint dann im
+  Briefing UND weiterhin separat ~15 Min später, weil der Checker sie
+  weiterhin für "neu" hält. Die Spec muss beide Teile explizit als AC fassen.
+- **Fachliche Entscheidung Fensterdefinition:** "ab jetzt bis Ende Zieletappe"
+  (im Issue vorgeschlagen) vs. Alternativen — für PO-Freigabe in der Spec
+  explizit machen.
+- **Test-Politik:** `AlertStateService`/`get_official_alerts_with_status` sind
+  reine Dateizugriffe ohne Netz/Live-Dienst → Kern-Schicht (deterministisch),
+  passend zu den bestehenden Nachbartests, kein Live-E2E nötig für den
+  Kern-Nachweis.
+- **Mandantentrennung:** `AlertStateService(user_id=...)` durchgängig; mit
+  zwei Nutzern testen (CLAUDE.md-Pflicht).
+- **Kein Compare-Pendant nötig:** siehe `comparison_engine.py` oben — dort
+  existiert das enge Fenster gar nicht, also keine Teilungs-Verletzung durch
+  diesen Fix. Pendant-Gate (#1481 B) greift ohnehin nur bei `frontend/`- und
+  `compare_*`/`trip_*`-präfigierten Renderer-Neuanlagen, nicht bei
+  `services/`-Änderungen.
+- **Laufende Parallel-Arbeit:** Worktree `intake-1555` (#1467 S3, Workflow
+  `rework-1467-s3-nowcast`, Phase Validation, kein Live-Lock) ändert
+  `trip_alert.py` im Bereich ~658-970 (Nowcast-Tagesobergrenze). Die für
+  #1614 relevanten Zeilen (~1061-1225) sind davon nicht direkt berührt;
+  spätere Rebase-Reibung beim Merge ist möglich, aber kein Blocker.
+
+## Offene Frage für /20-analyse
+Soll die neue "als im Briefing gemeldet vermerken"-Logik als eigenständige
+Funktion neben `_record_official_alert_state` in `trip_alert.py` liegen, per
+Extraktion in `alert_briefing_anchor.py` geteilt werden, oder direkt
+`TripAlertService._record_official_alert_state` aus dem Scheduler heraus
+aufrufen? Analyse-Phase soll entscheiden, welcher Weg der etablierten
+Teilungs-Konvention (#1467 S2 AG5) am ehesten entspricht.
+
+→ **Beantwortet, siehe Analysis-Sektion unten.**
+
+## Analysis
+
+### Type
+Bug (Teil 1, 3) + kleine Design-Korrektur (Teil 2) + neues, kleines Feature
+(Teil 4). Zuschnitt PO-bestätigt 2026-08-08, nach Forensik-Korrektur (s.o.)
+und mehreren Rückfragen im Chat. **Kein Fenster-/Zeitproblem mehr Teil des
+Zuschnitts** — die ursprüngliche Issue-Hypothese ist widerlegt.
+
+### Affected Files (with changes)
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `src/services/alert_briefing_anchor.py` | MODIFY (neue Funktion) | `record_official_alerts_reported(*, user_id, entity_id, alerts)` — State-Schreib-Body aus `trip_alert.py:1153-1167` übernommen. |
+| `src/services/trip_alert.py:1153-1167` | MODIFY (Refactor) | `_record_official_alert_state` wird dünner Wrapper um die neue geteilte Funktion. |
+| `src/services/trip_report_scheduler.py` (nahe `:1028`) | MODIFY | Nach erfolgreichem, nicht-Ad-hoc-Versand: gezeigte `sw.official_alerts` als „gemeldet" vermerken (Teil 1). |
+| `src/services/trip_report_scheduler.py` (SMS/Telegram-Request-Aufbau) | MODIFY | `sms_alert_min_level` aus `trip.alert_channel_thresholds` ableiten und durchreichen; analoge Telegram-Schwelle (Teil 3). |
+| `src/services/comparison_engine.py:704,869`-Umfeld | MODIFY | Dieselbe Verdrahtung für Ortsvergleich (Teil 3, S3b-2b). |
+| `src/output/renderers/email/design_tokens.py:32` | MODIFY | `G_ALERT_L2` auf einen Wert mit ≥4,5:1 Kontrast anheben (Teil 2). |
+| `src/output/renderers/alert/official_alerts.py:368-404` (`official_alerts_to_sms_entries`) bzw. Konsument in `sms_trip.py` | MODIFY | „!"-Präfix für amtliche Warnungen, die den SMS-Kanal erreichen (Teil 4). |
+| Tests | MODIFY/CREATE | `test_alert_state_briefing_reset.py` (Teil 1), neuer/erweiterter Test für Kanal-Schwelle im Briefing-Pfad (Teil 3), Kontrast-Wächter oder Snapshot-Vergleich (Teil 2), SMS-Format-Test (Teil 4). |
+
+### Scope Assessment
+- Files: ~8 Produktivdateien (davon 1 neue Funktion, 2 Wiring-Ergänzungen, 1 Refactor, 1 Konstante, 1 Renderer-Ergänzung), mehrere Testdateien erweitert.
+- Estimated LoC: +70–100 Produktivcode, +200–300 Tests (deutlich größer als der ursprüngliche Zuschnitt, weil drei zusätzliche, PO-bestätigte Teilthemen dazukamen).
+- Risk Level: **MEDIUM–HIGH** (sicherheitsrelevanter Warnpfad, vier unabhängige Änderungsflächen, Renderer-Commit-Gate #811 greift wegen `official_alerts.py`/`sms_trip.py`/`design_tokens.py`-Änderungen — `briefing_mail_validator.py` UND `email_spec_validator.py` können beide betroffen sein).
+
+### Technical Approach
+
+**Teil 1 — Doppelversand-Schutz** (unverändert gegenüber der ersten Analyse,
+nur ohne die Fenster-Änderung): neue geteilte Funktion
+`record_official_alerts_reported()` in `alert_briefing_anchor.py`, aufgerufen
+im Scheduler nach erfolgreichem, nicht-Ad-hoc-Versand, VOR
+`write_anchor_and_reset_memory`. `_record_official_alert_state` in
+`trip_alert.py` wird Wrapper darauf.
+
+**Teil 2 — GELB-Kontrast:** `G_ALERT_L2` in `design_tokens.py` auf einen
+dunkleren Ocker-/Gelbton anheben, der ≥4,5:1 gegen `G_PAPER` UND gegen
+`G_CARD` (weiß) erreicht — beide Hintergründe kommen je nach Einbettung vor
+(Trip-Warn-Block sitzt auf der Seite, Compare-Badges evtl. auf Karte).
+Reiner Token-Wert-Wechsel, keine Konsumenten-Logik ändert sich.
+
+**Teil 3 — Kanal-Schwelle verdrahten:** Im Scheduler (Trip) und in
+`comparison_engine.py` (Compare) den bereits fertigen
+`alert_urgency.min_official_level_for_threshold(threshold)` aufrufen, mit
+`trip.alert_channel_thresholds.get("sms", "LOW")` bzw. dem Telegram-Pendant,
+und das Ergebnis als `sms_alert_min_level` (SMS) sowie an der äquivalenten
+Telegram-Stelle durchreichen. Kein neuer Mechanismus — nur der fehlende aus
+#1461 S3b-2a nachgezogene Aufruf. Compare-Pendant folgt der Teilungsregel
+(dieselbe Funktion, keine Zweitfassung).
+
+**Teil 4 — „!"-Kennzeichnung:** Amtliche Warnungen, die den SMS-Kanal
+erreichen (nach Teil-3-Schwelle), bekommen ein „!"-Präfix in der SMS-Kurzform.
+Exakte Platzierung (vor dem Kürzel? vor dem ganzen Block?) und ob Telegram
+dieselbe Kennzeichnung bekommt, ist eine offene Frage für die Spec-ACs.
+
+### Dependencies
+- `services/alert_state.py` (`AlertStateService`, `OFFICIAL_ALERT_KEY_PREFIX`) — Teil 1, unverändert wiederverwendet.
+- `output/renderers/alert/official_alerts.py:407` (`official_alert_state_key`) — Teil 1, MUSS verwendet werden.
+- `services/alert_urgency.py` (`min_official_level_for_threshold`, bereits vorhanden) — Teil 3, MUSS verwendet werden, keine zweite Schwellen-Logik.
+- `output/renderers/email/design_tokens.py` — Teil 2, zentraler Farb-Token.
+- Renderer-Commit-Gate #811 (`renderer_mail_gate.py`) — betrifft Teil 1 (trip_report_scheduler.py-Umfeld zählt nicht direkt, aber `official_alerts.py`/`sms_trip.py` sind explizit gelistet) UND Teil 3/4. Vor Commit: `tests/tdd/test_issue_811_mode_matrix.py` + `briefing_mail_validator.py` grün.
+
+### Risiken (gegengeprüft)
+- **Teil 1:** Kaltstart unkritisch (`state.get(key)` liefert `None`); Reset (`_reset_alert_state_after_briefing`) schont den `official_alert:`-Namensraum bereits strukturell; echte Eskalation meldet weiterhin korrekt (State vergleicht `level`).
+- **Teil 2:** Kontrast-Fix darf die zweite Verwendung (`compare_html.py:107`, eigener Hintergrund `#f2e4b0`) nicht verschlechtern — dort separat nachrechnen, nicht blind denselben Hex übernehmen falls der Hintergrund abweicht.
+- **Teil 3:** Mehr SMS-Traffic als bisher (GELB erreicht jetzt SMS, sofern Nutzer die Schwelle nicht selbst hochgesetzt hat) — das ist die **bereits getroffene** PO-Entscheidung von #1461 S3b-2a, kein neues Risiko, aber sollte in der Spec explizit als bewusste Verhaltensänderung stehen, nicht als Nebeneffekt.
+- **Teil 4:** SMS-Zeichenbudget (160 Zeichen) — ein zusätzliches „!" pro Warnung ist minimal, aber bei mehreren gleichzeitigen Warnungen in Summe zu prüfen.
+- **Test-Politik:** Teile 1/3 sind reine Dateizugriffe/Funktionsaufrufe (Kern-Schicht). Teil 2 (Kontrast) und Teil 4 (SMS-Text) sind Renderer-Änderungen — Pflicht-Validatoren (`briefing_mail_validator.py`) laufen vor „E2E bestanden".
+
+### Open Questions
+- [ ] Teil 4: „!" nur bei SMS, oder auch bei Telegram? (Telegram hat bereits Emoji-Kennzeichnung `⚠️`/`🔴` — evtl. redundant.)
+- [ ] Teil 3: exakter GELB-Grenzfall — reicht `LOW` als Default wirklich bis Stufe 2 runter, oder soll die Spec das als eigenes AC mit Beispiel-Level fixieren (Mehrdeutigkeit vermeiden)?
+- [ ] Teil 2: konkreter neuer Hex-Wert für `G_ALERT_L2` — muss vor Implementierung berechnet/geprüft werden (Kontrast-Rechner gegen G_PAPER `#f6f4ee` UND G_CARD `#ffffff`).

--- a/docs/specs/modules/fix_1614_briefing_warnfenster.md
+++ b/docs/specs/modules/fix_1614_briefing_warnfenster.md
@@ -1,0 +1,426 @@
+---
+entity_id: fix_1614_briefing_warnfenster
+type: bugfix
+created: 2026-08-08
+updated: 2026-08-08
+status: draft
+workflow: fix-1614-briefing-warnfenster
+---
+
+# Fix #1614: Amtliche Warnungen im Trip-Briefing — Doppelversand-Schutz, GELB-Kontrast, Kanal-Schwelle- und SMS-Kennzeichnungs-Verifikation
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Vier PO-bestätigte Teilthemen rund um amtliche Warnungen im Trip-Briefing (2026-08-08,
+nach Forensik-Korrektur der ursprünglichen Fenster-Theorie — siehe
+`docs/context/fix-1614-briefing-warnfenster.md`). **Wichtiger Befund dieser Spec-Phase:**
+von den vier Teilen sind nur **Teil 1** (Doppelversand) und **Teil 2** (GELB-Kontrast)
+tatsächlich offene Produktivcode-Arbeit. Teil 3 (Kanal-Schwelle) und Teil 4
+(„!"-Kennzeichnung) sind **bereits vollständig implementiert** (Issues #1318, #1461
+S3a/S3b-2a/S3b-2b, alle live/geschlossen) — belegt per direkter Code-Lesung unten. Diese
+Spec führt Teil 3/4 trotzdem mit eigenen ACs, aber als **Regressionsschutz für bereits
+bestehendes Verhalten**, nicht als neue Wiring-Arbeit. Siehe „🔴 Kritischer Befund"
+weiter unten für die Details und Belegstellen.
+
+1. **Doppelversand (Teil 1, echte Arbeit):** Eine amtliche Warnung, die bereits korrekt
+   im Trip-Briefing erscheint, wird bis zu 15 Minuten später vom unabhängigen
+   15-Minuten-Alarm-Checker NOCHMAL als eigene, redundante Nachricht verschickt — weil
+   der Briefing-Pfad das Melde-Gedächtnis nie beschreibt.
+2. **GELB-Kontrast in der E-Mail (Teil 2, echte Arbeit):** `G_ALERT_L2` hat 4,11:1
+   Kontrast auf `G_PAPER` — unter der CLAUDE.md-Mindestgrenze WCAG-AA (4,5:1).
+3. **Kanal-Schwellen-Verdrahtung (Teil 3, bereits erledigt):** Trip-SMS
+   (`trip_report.py:337-357`) und Trip-Telegram (`narrow.py:414-421`) lesen bereits
+   `trip.alert_channel_thresholds` und rufen `alert_urgency.min_official_level_for_threshold()`
+   auf (#1461 S3b-2a). Der Ortsvergleichs-Bericht hält die Schwelle bewusst konstant auf
+   „gering" (#1461 S3b-2b, PO-dokumentiert als „Zwei Wirkungsorte" — Bericht und
+   Alarm-Versand sind absichtlich getrennt). Beides zusammen erfüllt bereits exakt das
+   im Issue gewünschte Verhalten: GELB erreicht SMS/Telegram, solange der Nutzer die
+   Schwelle nicht selbst hochsetzt.
+4. **„!"-Kennzeichnung (Teil 4, bereits erledigt):** Trip-SMS setzt bereits ein
+   führendes „!" vor den amtlichen Warnblock (`output/tokens/render.py:21-26`, Issue
+   #1318). Compare-SMS hat denselben Marker bereits über eine eigene Funktion
+   (`comparison.py:835-855`, Issue #1332). Telegram hat bewusst KEIN „!" (Emoji-
+   Kennzeichnung stattdessen) — das entspricht bereits der im Issue gewünschten
+   Abgrenzung.
+
+## 🔴 Kritischer Befund (Spec-Phase, 2026-08-08) — Teil 3/4 sind kein offener Umfang
+
+Der Auftrag für diese Spec beschrieb Teil 3 als fehlende Verdrahtung im
+Trip-Briefing-Scheduler und Teil 4 als „existiert nirgends im Code". Beide Aussagen
+stützten sich auf einen `grep` ausschließlich gegen `trip_report_scheduler.py` bzw.
+gegen `official_alerts.py`/`sms_trip.py` — nicht gegen die tatsächlichen Renderer, die
+der Scheduler über `notification_service.py` aufruft. Direkte Code-Lesung in dieser
+Spec-Phase zeigt:
+
+| Behauptung im Auftrag | Tatsächlicher Code-Stand |
+|---|---|
+| „Trip-Briefing-Scheduler ruft `min_official_level_for_threshold` nirgends auf" | Wahr für `trip_report_scheduler.py` selbst, falsch für den Renderer-Pfad: `trip_report.py:337-342` (SMS) und `narrow.py:414-415` (Telegram) lesen `trip.alert_channel_thresholds` und rufen die Funktion bereits auf — Kommentar dort verweist explizit auf „#1461 S3b-2a". Der Scheduler baut die `TripReport`-Instanz über `notification_service.send_trip_report()`, das intern `TripReportFormatter` (= `trip_report.py`) nutzt; der fehlende Treffer im Scheduler selbst ist deshalb kein Gap. |
+| „!"-Kennzeichnung existiert nirgends im Code" | Falsch: `output/tokens/render.py:15-26` (`_fuse()`) setzt bereits `prefix = "!" if warn_marker_pending else ""` für Tokens der Kategorie `official_alert` — Kommentar „Issue #1318: der `!`-Marker leitet den Warn-Block genau einmal ein." Compare hat einen eigenen, aber ebenfalls bereits fertigen Marker: `comparison.py:835-855` (`_official_alert_sms_marker`), verwendet in `_sms_location_part` (`:910-914`), Issue #1332. |
+| „Compare-Pendant S3b-2b noch offen" | Falsch: `docs/specs/modules/feat_1461_s3b2b_compare_kanal_schwelle.md` ist **approved, v1.3, PO-„go" 2026-08-06**, Memory bestätigt „✅ LIVE seit 2026-08-06, #1461 vollständig geschlossen", PR #1543, Prod-Commit `7469126b`. |
+
+**Wie sich Compare vom Trip unterscheidet (bewusst, dokumentiert, kein Fix-Bedarf):**
+Compare hält den Berichts-Schwellenwert für SMS/Telegram bewusst konstant auf
+`alert_urgency.min_official_level_for_threshold("LOW")` — unabhängig davon, was der
+Nutzer als Alarm-Kanal-Schwelle eingestellt hat (`comparison.py:734-740`,
+Kommentar: „Kein Compare-Kanal-Schwellenparameter hier: der Bericht bleibt beim
+Startwert, unabhängig von einer je Kanal eingestellten Alarm-Schwelle (Spec 'Zwei
+Wirkungsorte' — Bericht und Alarm-Versand sind getrennt)."). Der Trip-Bericht liest
+dagegen die tatsächlich konfigurierte Schwelle. Diese Asymmetrie ist eine bereits in
+`feat_1461_s3b2b_compare_kanal_schwelle.md` (Abschnitt „Zwei Wirkungsorte") getroffene,
+PO-genehmigte Architekturentscheidung — **kein Nebenbefund dieser Spec, keine
+Trip/Compare-Teilungsverletzung** (der Compare-Bericht ist bewusst permissiver, nicht
+weniger fähig). Diese Spec ändert daran nichts.
+
+**Konsequenz für diese Spec:** Teil 3 und Teil 4 werden unten mit eigenen ACs geführt,
+aber ausschließlich als **Regressionstests, die den bereits bestehenden, korrekten
+Zustand festnageln** — kein neuer Produktivcode. Sollte die Implementierungsphase einen
+echten, hier nicht erfassten Gap finden (z.B. einen dritten Aufrufpfad ohne
+Schwellen-Verdrahtung), ist das eine Abweichung von dieser Spec und braucht vor der
+Umsetzung eine kurze Rückmeldung an den Orchestrator/PO statt stillschweigender
+Scope-Erweiterung.
+
+## Source
+
+- **File:** `src/services/trip_report_scheduler.py`
+- **Identifier:** `TripReportSchedulerService._send_trip_report_outcome` (Teil 1, nahe
+  Zeile 958/1028); `src/output/renderers/email/design_tokens.py` (Teil 2, Zeile 32);
+  `src/output/renderers/trip_report.py:337-357` + `src/output/renderers/narrow.py:387-433`
+  (Teil 3, bereits implementiert); `src/output/tokens/render.py:15-37` +
+  `src/output/renderers/comparison.py:835-914` (Teil 4, bereits implementiert)
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `services.alert_state.AlertStateService` | class | Melde-Gedächtnis (Datei je Nutzer/Trip), Namensraum `official_alert:` überlebt den Briefing-Reset bereits (#1460 P2) — Teil 1 |
+| `services.alert_briefing_anchor` | module | Geteilter Baustein (#1467 S2 AG5) für Anker+Reset zwischen Trip und Ortsvergleich; Ort der neuen `record_official_alerts_reported()`-Funktion — Teil 1 |
+| `services.trip_alert.TripAlertService._record_official_alert_state` | method | Wird zum Wrapper um die neue geteilte Funktion — Teil 1 |
+| `output.renderers.alert.official_alerts.official_alert_state_key` | function | Kanonische Schlüsselbildung fürs Melde-Gedächtnis; MUSS von jeder neuen State-Schreibung verwendet werden — Teil 1 |
+| `output.renderers.email.design_tokens.G_ALERT_L2` | constant | Wird auf `#8a6300` angehoben — Teil 2 |
+| `services.alert_urgency.min_official_level_for_threshold` | function | Bereits fertig und bereits an allen relevanten Stellen verdrahtet (Trip-SMS, Trip-Telegram, Compare-SMS, Compare-Telegram) — Teil 3, nur Verifikation |
+| `output.tokens.render._fuse` | function | Bereits bestehender „!"-Marker-Mechanismus für Trip-SMS — Teil 4, nur Verifikation |
+| `output.renderers.comparison._official_alert_sms_marker` | function | Bereits bestehender „!"-Marker für Compare-SMS — Teil 4, nur Verifikation |
+
+## Scope
+
+### Affected Files
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `src/services/alert_briefing_anchor.py` | MODIFY (neue Funktion) | `record_official_alerts_reported(*, user_id, entity_id, alerts)` — State-Schreib-Body aus `trip_alert.py:1153-1167` übernommen (Teil 1) |
+| `src/services/trip_alert.py` (~1153-1167, `_record_official_alert_state`) | MODIFY (Refactor) | Wird dünner Wrapper um die neue geteilte Funktion, Verhalten unverändert (Teil 1) |
+| `src/services/trip_report_scheduler.py` (nahe Zeile 958-996, vor dem `write_anchor_and_reset_memory`-Aufruf bei ~1028) | MODIFY | Nach `result = self._notification_service.send_trip_report(request)`, wenn `result.sent and not on_demand`: gesammelte `sw.official_alerts` über die neue Funktion als „gemeldet" vermerken (Teil 1) |
+| `src/output/renderers/email/design_tokens.py:32` | MODIFY | `G_ALERT_L2` von `'#9a6f00'` auf `'#8a6300'` (Teil 2) |
+| `tests/tdd/test_alert_state_briefing_reset.py` | MODIFY | Erweitert um Doppelversand-Regressionsfälle (Teil 1) |
+| Neue/erweiterte Kontrast-Testdatei (Namensregel: nach Verhalten, z.B. `tests/tdd/test_official_alert_color_contrast.py`) | CREATE/MODIFY | Kontrast-Nachweis für `G_ALERT_L2` gegen `G_PAPER`/`G_CARD` (Teil 2) |
+| `tests/tdd/test_official_alert_channel_threshold.py` (neu, Regressionsschutz) oder Erweiterung einer Nachbardatei | CREATE | Pin des bereits bestehenden Schwellen-Verhaltens Trip-SMS/Telegram + Compare-SMS/Telegram (Teil 3, **kein Produktivcode**) |
+| `tests/tdd/test_official_alert_sms_marker.py` (neu, Regressionsschutz) oder Erweiterung einer Nachbardatei | CREATE | Pin des bereits bestehenden „!"-Markers Trip-SMS + Compare-SMS, Nicht-Ziel-Nachweis Telegram (Teil 4, **kein Produktivcode**) |
+
+**Kein Compare-Pendant für Teil 1:** `comparison_engine.py:302-303` übergibt kein
+Zeitfenster an `get_official_alerts_with_status` — hat das Doppelversand-Problem
+strukturell nicht (in der Analyse-Phase bereits geprüft und ausgeschlossen).
+
+### Estimated Changes
+
+- Files: 4 Produktivdateien (Teil 1: 3, Teil 2: 1), 4 Testdateien (2 neu/erweitert je
+  Teil 1/2, 2 neu als reiner Regressionsschutz für Teil 3/4)
+- LoC: +45/-10 Produktivcode (Teil 1) + 1 Zeile (Teil 2) = ~+46/-10 Produktivcode
+  gesamt; +250/-0 Tests (deutlich mehr Tests als Produktivcode, weil Teil 3/4
+  ausschließlich aus Regressionstests ohne begleitende Produktivänderung bestehen)
+
+## Implementation Details
+
+### Teil 1 — Doppelversand-Schutz
+
+Neue Funktion in `src/services/alert_briefing_anchor.py` (Vorbild `reset_alert_memory()`
+in derselben Datei):
+
+```python
+def record_official_alerts_reported(
+    *, user_id: str, entity_id: str, alerts: list,
+) -> None:
+    """Vermerkt amtliche Warnungen als 'im Briefing gemeldet' — DIE geteilte
+    Schreib-Logik fürs Melde-Gedächtnis (official_alert:-Namensraum)."""
+```
+
+Übernimmt den State-Schreib-Body aus `trip_alert.py:1153-1167`
+(`_record_official_alert_state`): `AlertStateService(user_id=...).load(entity_id)`, je
+Alert `official_alert_state_key(a)` als Schlüssel mit
+`{"last_reported_value": float(a.level), "reported_at": now_iso}` setzen,
+`state_svc.save(entity_id, state)`. Fail-soft bei leerer `alerts`-Liste (No-Op).
+
+`TripAlertService._record_official_alert_state()` wird zum Wrapper, der an
+`record_official_alerts_reported()` delegiert (`alerts=[a for a, _seg_ids in
+official_notices]`) — Verhalten unverändert, siehe Test 6/AC-5.
+
+Im Scheduler wird nach `result = self._notification_service.send_trip_report(request)`
+(Zeile ~958) und VOR dem bestehenden `write_anchor_and_reset_memory`-Aufruf (Zeile
+~1028) folgende Bedingung ergänzt:
+
+```python
+if result.sent and not on_demand:
+    all_official_alerts = [a for sw in segment_weather for a in (sw.official_alerts or [])]
+    if all_official_alerts:
+        from services.alert_briefing_anchor import record_official_alerts_reported
+        record_official_alerts_reported(
+            user_id=self._user_id, entity_id=trip.id, alerts=all_official_alerts,
+        )
+```
+
+Reihenfolge bewusst VOR `write_anchor_and_reset_memory`, damit ein Exception-Pfad dort
+das Record nicht verschluckt. `on_demand`-Gate ist zwingend — Ad-hoc-Abruf (#1007)
+bleibt read-only gegenüber dem Melde-Gedächtnis. `result.sent` ist zwingend, damit ein
+fehlgeschlagener oder kanalloser Versand keine Warnung fälschlich als „gemeldet"
+markiert (sonst würde eine Warnung, die NIE zugestellt wurde, trotzdem vom
+Alarm-Checker unterdrückt).
+
+### Teil 2 — GELB-Kontrast
+
+`design_tokens.py:32`: `G_ALERT_L2` von `'#9a6f00'` (4,11:1 auf `G_PAPER`) auf
+`'#8a6300'` ändern. Nachgerechnet in dieser Spec-Phase (WCAG-2.1-relative-Luminanz):
+
+- gegen `G_PAPER` (`#f6f4ee`): **4,94:1** (≥ 4,5:1 ✅)
+- gegen `G_CARD` (`#ffffff`): **5,43:1** (≥ 4,5:1 ✅)
+- gegen den Compare-Badge-Hintergrund `compare_html.py:107` (`#f2e4b0`): **~4,27:1**
+  (< 4,5:1 ❌ — siehe „Known Limitations", nicht Teil dieses Fixes)
+
+Reiner Token-Wert-Wechsel, keine Konsumenten-Logik ändert sich — alle Verwender
+(`official_alerts.py:1330,1335,1408,207,1222`) beziehen den Wert bereits zentral aus
+`design_tokens.py`.
+
+### Teil 3 — Kanal-Schwellen-Verdrahtung (bereits implementiert, nur verifizieren)
+
+**Kein Produktivcode-Änderung.** Bereits vorhanden:
+
+- Trip-SMS: `trip_report.py:337-342` liest `trip.alert_channel_thresholds.get("sms")`,
+  ruft `alert_urgency.min_official_level_for_threshold(_sms_threshold or "LOW")` auf,
+  übergibt das Ergebnis als `sms_alert_min_level` an `SMSTripFormatter.format_sms()`
+  (`:357`).
+- Trip-Telegram: `narrow.py:414-415` (`_official_alert_bubble`) liest
+  `trip.alert_channel_thresholds.get("telegram")`, ruft dieselbe Funktion auf, filtert
+  Segmente danach (`:417-422`).
+- Compare-SMS/Telegram: `comparison.py:740` und `:912` rufen
+  `alert_urgency.min_official_level_for_threshold("LOW")` — bewusst konstant „gering",
+  siehe „🔴 Kritischer Befund" oben.
+
+Diese Spec verlangt für Teil 3 ausschließlich neue Regressionstests, die dieses bereits
+korrekte Verhalten aus Nutzersicht (erzeugte SMS-/Telegram-Texte, nicht interne
+Funktionsaufrufe) festnageln.
+
+### Teil 4 — „!"-Kennzeichnung (bereits implementiert, nur verifizieren)
+
+**Kein Produktivcode-Änderung.** Bereits vorhanden:
+
+- Trip-SMS: `output/tokens/render.py:15-26` (`_fuse()`) — für den ersten Token der
+  Kategorie `official_alert` in der TokenLine wird `"!"` vorangestellt
+  (`warn_marker_pending`-Flag, genau einmal pro Warnblock, Issue #1318).
+- Compare-SMS: `comparison.py:835-855` (`_official_alert_sms_marker`), verwendet in
+  `_sms_location_part()` (`:910-914`), Issue #1332.
+- Telegram (Trip UND Compare): bewusst KEIN „!" — beide nutzen stattdessen die
+  bestehende Emoji-Kennzeichnung pro Warnstufe
+  (`render_official_alert_telegram`/`_LEVEL_WORDS` in `official_alerts.py`); die
+  Compare-Telegram-Fassung hatte laut Code-Kommentar (`comparison.py:723-725`) sogar
+  explizit einen früheren „!"-Marker per PO-Korrektur 2026-07-23 wieder entfernt
+  bekommen, um Redundanz mit dem Emoji zu vermeiden — diese Spec bestätigt diesen
+  Zustand als gewollt, ändert nichts daran.
+
+Diese Spec verlangt für Teil 4 ausschließlich neue Regressionstests, die den
+bestehenden Marker (Position, genau einmal pro Block) und die Telegram-Abwesenheit aus
+Nutzersicht (erzeugter Text) festnageln.
+
+## Test Plan
+
+### Test-Schicht
+
+Kern-Schicht (deterministisch): kein Netz, keine Live-Dienste. `AlertStateService`,
+`design_tokens`-Werte und die Renderer-Funktionen sind reine Dateizugriffe/reine
+Funktionen. Kein Mock-Theater, kein Dateiinhalt-Check als alleiniger
+Verhaltensnachweis (Ausnahme: Teil-2-Kontrasttest rechnet direkt gegen die
+Hex-Konstanten, das ist reine Mathematik, kein String-Match-Ersatz für Verhalten).
+Testdatei-Namensregel: nach Verhalten benennen (`test_naming_gate.py` blockt
+`test_issue_1614_*.py`).
+
+### Renderer-Commit-Gate #811
+
+`design_tokens.py` gehört zu den Mail-Inhalts-Dateien des Gates — vor Commit müssen
+`uv run pytest tests/tdd/test_issue_811_mode_matrix.py` grün UND ein erfolgreicher
+`uv run python3 .claude/hooks/briefing_mail_validator.py`-Lauf vorliegen. Teil 3/4
+berühren `sms_trip.py`/`official_alerts.py`/`comparison.py` nur, falls die
+Regressionstests dort neue Test-Imports/Fixtures brauchen, die selbst Produktivdateien
+NICHT verändern — der Gate-Trigger ist Staging der Datei, nicht des Diffs; im Zweifel
+Gate-Lauf einplanen.
+
+### Automated Tests (TDD RED)
+
+- [ ] **Test 1** (`test_alert_state_briefing_reset.py`, Teil 1): GIVEN ein
+  Trip-Briefing wurde erfolgreich mit einer amtlichen Warnung X versendet (echter
+  `_send_trip_report_outcome()`-Aufrufpfad), WHEN danach
+  `TripAlertService.check_official_alert_triggers()` für denselben Trip mit
+  unveränderter Warnung X (gleiches Level) läuft, THEN liefert der Checker X NICHT als
+  neu/eskaliert zurück (kein Doppelversand — heutiges Verhalten: X wird erneut
+  gemeldet).
+
+- [ ] **Test 2** (Eskalations-Gegenprobe, Teil 1): GIVEN dasselbe Vorbriefing wie Test
+  1, WHEN die Warnung X danach auf ein höheres Level eskaliert, THEN meldet
+  `check_official_alert_triggers()` die eskalierte Warnung weiterhin.
+
+- [ ] **Test 3** (Ad-hoc-Ausnahme, Teil 1): GIVEN ein On-Demand-Abruf
+  (`on_demand=True`, #1007) liefert dieselbe amtliche Warnung, WHEN der Abruf
+  abgeschlossen ist, THEN bleibt das Melde-Gedächtnis unverändert.
+
+- [ ] **Test 4** (Fehlgeschlagener Versand, Teil 1, neuer Fall gegenüber dem
+  Vorgänger-Entwurf): GIVEN `result.sent` ist `False` (z.B. kein Kanal erreichbar),
+  WHEN `_send_trip_report_outcome()` durchläuft, THEN wird die neue Record-Funktion
+  NICHT aufgerufen — eine nie zugestellte Warnung darf den Alarm-Checker nicht stumm
+  schalten.
+
+- [ ] **Test 5** (Wrapper-Regression, Teil 1): GIVEN dieselben Eingaben (`trip_id`,
+  `official_notices`) wie vor dem Refactor, WHEN
+  `TripAlertService._record_official_alert_state()` nach dem Umbau zum Wrapper
+  aufgerufen wird, THEN entsteht exakt derselbe State-Eintrag wie vorher.
+
+- [ ] **Test 6** (Kaltstart, Teil 1): GIVEN ein Trip ohne jeden vorherigen
+  `official_alert:`-State-Eintrag, WHEN das Briefing mit einer amtlichen Warnung
+  versendet wird, THEN läuft `record_official_alerts_reported()` fehlerfrei durch.
+
+- [ ] **Test 7** (Mandantentrennung, CLAUDE.md-Pflicht, Teil 1): GIVEN zwei
+  verschiedene `user_id`s mit je einem Trip und je einer identischen amtlichen
+  Warnung, WHEN für Nutzer A das Briefing versendet wird, THEN bleibt das
+  Melde-Gedächtnis von Nutzer B unverändert.
+
+- [ ] **Test 8** (Kontrast, Teil 2): GIVEN der neue `G_ALERT_L2`-Wert `#8a6300`, WHEN
+  der Kontrast gegen `G_PAPER` (`#f6f4ee`) und `G_CARD` (`#ffffff`) berechnet wird
+  (echte WCAG-2.1-Formel, kein String-Vergleich), THEN liegt beides bei ≥ 4,5:1.
+
+- [ ] **Test 9** (Renderer-Durchgriff, Teil 2): GIVEN eine amtliche Warnung Stufe 2
+  (GELB) wird gerendert (E-Mail-HTML), WHEN der Renderer läuft, THEN enthält die
+  erzeugte Ausgabe den neuen Hex-Wert `#8a6300` statt des alten `#9a6f00` — belegt,
+  dass der Token-Wechsel tatsächlich bis zur Ausgabe durchschlägt (nicht nur die
+  Konstante geändert wurde).
+
+- [ ] **Test 10** (Regressionsschutz Trip-SMS-Schwelle, Teil 3, bereits bestehendes
+  Verhalten): GIVEN ein Trip hat für den SMS-Kanal keine eigene Schwelle gesetzt
+  (Startwert „gering"), WHEN die Trip-SMS für eine amtliche Warnung Stufe 2 (GELB)
+  erzeugt wird, THEN enthält der SMS-Text die Warnung.
+
+- [ ] **Test 11** (Regressionsschutz Trip-SMS-Schwelle hochgesetzt, Teil 3): GIVEN
+  derselbe Trip hat für den SMS-Kanal die Schwelle explizit auf „hoch" gesetzt, WHEN
+  dieselbe GELB-Warnung gerendert wird, THEN fehlt sie im SMS-Text.
+
+- [ ] **Test 12** (Regressionsschutz Trip-Telegram-Schwelle, Teil 3, analog Test
+  10/11 für den Telegram-Kanal): GIVEN Trip-Telegram-Schwelle „gering" bzw. „hoch",
+  WHEN die Telegram-Bubble für dieselbe GELB-Warnung gerendert wird, THEN erscheint
+  sie im ersten Fall und fehlt im zweiten.
+
+- [ ] **Test 13** (Regressionsschutz Compare-Bericht, Teil 3): GIVEN ein
+  Ortsvergleich hat für einen Kanal eine erhöhte Alarm-Kanal-Schwelle gesetzt, WHEN
+  der reguläre Kurznachrichten-Bericht (SMS und Telegram) für eine GELB-Warnung
+  erzeugt wird, THEN erscheint die Warnung trotzdem (Bericht bleibt bewusst
+  unabhängig von der Alarm-Schwelle, „Zwei Wirkungsorte").
+
+- [ ] **Test 14** (Regressionsschutz „!"-Marker Trip-SMS, Teil 4): GIVEN eine
+  amtliche Warnung erreicht den SMS-Kanal, WHEN die Trip-SMS-Kurzform erzeugt wird,
+  THEN steht genau ein führendes „!" unmittelbar vor dem ersten Token des amtlichen
+  Warnblocks, kein weiteres „!" vor folgenden Tokens desselben Blocks.
+
+- [ ] **Test 15** (Regressionsschutz „!"-Marker Compare-SMS, Teil 4): GIVEN dieselbe
+  Ausgangslage für einen Ortsvergleichs-Ort, WHEN die Compare-SMS-Kurzform erzeugt
+  wird, THEN trägt der Ortsblock denselben „!"-Marker.
+
+- [ ] **Test 16** (Nicht-Ziel-Nachweis Telegram, Teil 4): GIVEN dieselbe amtliche
+  Warnung erreicht Trip-Telegram bzw. Compare-Telegram, WHEN die jeweilige Bubble
+  gerendert wird, THEN enthält der Text KEIN „!"-Präfix vor der Warnung (stattdessen
+  die bestehende Emoji-Kennzeichnung).
+
+## Acceptance Criteria
+
+- **AC-1:** Given dieselbe Warnung wurde bereits erfolgreich im Trip-Briefing gemeldet (Melde-Gedächtnis geschrieben), When der unabhängige 15-Minuten-Alarm-Checker danach mit unverändertem Level läuft, Then meldet der Checker diese Warnung NICHT erneut als separate Nachricht.
+  - Test: Test 1 — Kern-Regressionsschutz gegen den forensisch belegten Doppelversand (Mail-Paar `86918bc7`/`7d0bbfd6`).
+
+- **AC-2:** Given dieselbe Ausgangslage wie AC-1, When die Warnung nach dem Briefing tatsächlich auf ein höheres Level eskaliert, Then meldet der Alarm-Checker die eskalierte Warnung weiterhin als neuen Trigger.
+  - Test: Test 2 — verhindert stille Unterdrückung echter Verschärfung durch den neuen Doppelversand-Schutz.
+
+- **AC-3:** Given ein Ad-hoc-/On-Demand-Abruf (`on_demand=True`, #1007) liefert dieselbe amtliche Warnung, When der Abruf abgeschlossen ist, Then bleibt das Melde-Gedächtnis unverändert — kein neuer Eintrag im `official_alert:`-Namensraum.
+  - Test: Test 3 — bestehende Read-only-Garantie darf durch die neue Schreiblogik nicht verletzt werden.
+
+- **AC-4:** Given der Versand eines Trip-Briefings ist fehlgeschlagen oder kein Kanal war erreichbar (`result.sent` ist falsch), When `_send_trip_report_outcome()` durchläuft, Then wird keine Warnung als „gemeldet" vermerkt — eine nie zugestellte Warnung bleibt für den Alarm-Checker weiterhin meldepflichtig.
+  - Test: Test 4 — verhindert einen neuen, subtileren Bug (stumme Warnung nach fehlgeschlagenem Versand).
+
+- **AC-5:** Given identische Eingaben vor und nach dem Wrapper-Refactor von `_record_official_alert_state`, When die Methode aufgerufen wird, Then entsteht in beiden Fällen exakt derselbe State-Eintrag (gleicher Schlüssel, gleiches Level, Zeitstempel-Feld vorhanden).
+  - Test: Test 5 — verhindert Verhaltensänderung durch das Refactoring selbst.
+
+- **AC-6:** Given ein Trip ohne jeden vorherigen `official_alert:`-Eintrag (Kaltstart, erstes Briefing), When das Briefing mit einer amtlichen Warnung erfolgreich versendet wird, Then läuft die neue Record-Funktion fehlerfrei durch und legt einen gültigen Eintrag an.
+  - Test: Test 6 — verhindert Absturz bei Bestandsnutzern ohne Historie.
+
+- **AC-7:** Given zwei verschiedene Nutzer mit je einem Trip und je einer identischen amtlichen Warnung, When für Nutzer A das Briefing versendet wird, Then bleibt das Melde-Gedächtnis von Nutzer B davon unberührt.
+  - Test: Test 7 — Mandantentrennung, CLAUDE.md-Pflicht bei jedem nutzerbezogenen Datenpfad.
+
+- **AC-8:** Given der neue Farbwert `#8a6300` für `G_ALERT_L2`, When der Kontrast gegen die Hintergründe `G_PAPER` (`#f6f4ee`) und `G_CARD` (`#ffffff`) nach WCAG-2.1 berechnet wird, Then liegt beides bei mindestens 4,5:1 (WCAG-AA).
+  - Test: Test 8 — direkte Umsetzung der CLAUDE.md-Kontrastregel.
+
+- **AC-9:** Given eine amtliche Warnung der Stufe 2 (GELB) wird als E-Mail-HTML gerendert, When die Ausgabe erzeugt wird, Then enthält sie den neuen Farbwert `#8a6300`, nicht mehr den alten `#9a6f00`.
+  - Test: Test 9 — Nachweis, dass der Token-Wechsel bis zur tatsächlichen Ausgabe durchschlägt.
+
+- **AC-10:** Given ein Trip hat für den SMS-Kanal keine eigene Schwelle gesetzt (Startwert „gering"), When eine amtliche Warnung der Stufe 2 (GELB) im Trip-SMS-Text erzeugt wird, Then erscheint sie dort — bereits bestehendes Verhalten seit #1461 S3b-2a, hier als Regressionsschutz gepinnt.
+  - Test: Test 10.
+
+- **AC-11:** Given derselbe Trip hat die SMS-Kanal-Schwelle explizit auf „hoch" gesetzt, When dieselbe GELB-Warnung gerendert wird, Then fehlt sie im SMS-Text.
+  - Test: Test 11 — Gegenprobe zu AC-10, verhindert Regress auf „immer alles anzeigen".
+
+- **AC-12:** Given ein Trip hat für den Telegram-Kanal keine eigene Schwelle bzw. eine hochgesetzte Schwelle, When die Telegram-Bubble für eine GELB-Warnung gerendert wird, Then verhält sie sich analog AC-10/AC-11 für den Telegram-Kanal.
+  - Test: Test 12.
+
+- **AC-13:** Given ein Ortsvergleich hat für einen Kanal eine erhöhte Alarm-Kanal-Schwelle gesetzt, When der reguläre Kurznachrichten-Bericht (SMS und Telegram) für eine GELB-Warnung erzeugt wird, Then erscheint die Warnung trotzdem — der Bericht bleibt bewusst unabhängig von der Alarm-Schwelle (dokumentierte PO-Entscheidung „Zwei Wirkungsorte", #1461 S3b-2b).
+  - Test: Test 13 — pin des bewusst abweichenden Compare-Verhaltens gegenüber Trip.
+
+- **AC-14:** Given eine amtliche Warnung erreicht den SMS-Kanal (Trip oder Ortsvergleich), When die jeweilige SMS-Kurzform erzeugt wird, Then steht genau ein führendes „!" unmittelbar vor dem ersten Token des amtlichen Warnblocks, kein zusätzliches „!" vor folgenden Tokens desselben Blocks.
+  - Test: Test 14/15 — bereits bestehendes Verhalten (#1318 Trip, #1332 Compare), hier als Regressionsschutz gepinnt.
+
+- **AC-15:** Given dieselbe amtliche Warnung erreicht Trip-Telegram oder Compare-Telegram, When die jeweilige Bubble gerendert wird, Then enthält der Text KEIN „!"-Präfix — Telegram nutzt stattdessen ausschließlich die bestehende Emoji-Kennzeichnung.
+  - Test: Test 16 — explizite Nicht-Ziel-Absicherung, verhindert versehentliche Telegram-Änderung in der Implementierungsphase.
+
+## Known Limitations
+
+- **Compare-Badge-Kontrast bleibt unter 4,5:1.** Der neue `G_ALERT_L2`-Wert (`#8a6300`)
+  erreicht auf dem Compare-Badge-Hintergrund `compare_html.py:107` (`#f2e4b0`) nur
+  **~4,27:1** (in dieser Spec-Phase nachgerechnet) — unter der WCAG-AA-Grenze. Der
+  Auftrag für diese Spec begrenzt Teil 2 explizit auf `design_tokens.py`; eine Behebung
+  des Compare-Badge-Kontrasts bräuchte einen eigenen Hintergrund-Ton oder eine eigene
+  Farbe für diese eine Kombination und ist eigene Arbeit, kein Teil dieses Fixes.
+- **Teil 3/4 sind Regressionstests ohne Produktivcode.** Sollte eine spätere Prüfung
+  (Adversary, manuelle Staging-Verifikation) einen ECHTEN, hier nicht erfassten Gap
+  finden — z.B. einen dritten Aufrufpfad, der die Schwelle nicht liest — ist das eine
+  Abweichung von dieser Spec, kein stiller Nacharbeits-Auftrag; vor Erweiterung des
+  Umfangs ist eine kurze Rückmeldung fällig.
+- **Compare-Bericht bleibt bewusst unabhängig von der Alarm-Kanal-Schwelle.** Das ist
+  eine bereits getroffene, dokumentierte PO-Entscheidung (`feat_1461_s3b2b_compare_
+  kanal_schwelle.md`, Abschnitt „Zwei Wirkungsorte") — keine Inkonsistenz, die diese
+  Spec beheben soll.
+- **Kein Compare-Pendant für Teil 1.** `comparison_engine.py` hat das
+  Doppelversand-Problem strukturell nicht (kein Zeitfenster-Parameter an der
+  betroffenen Stelle).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Teil 1 ist ein chirurgischer Bugfix innerhalb bestehender, bereits
+  dokumentierter Architektur (#1460 P2 Zwei-Namensräume-Melde-Gedächtnis, #1467 S2 AG5
+  geteilter Baustein-Ansatz). Teil 2 ist ein reiner Token-Wert-Wechsel. Teil 3/4
+  ändern per Befund dieser Spec-Phase keinen Produktivcode, sondern pinnen bereits
+  über ADR-0046 (Alarm-Kanal-Schwelle) und die #1318/#1332-Historie abgedecktes
+  Verhalten fest — keine neue Grundsatzentscheidung, kein neues ADR.
+
+## Changelog
+
+- 2026-08-08: Initial spec created (Fenster-Theorie, inzwischen widerlegt).
+- 2026-08-08: Vollständige Neufassung (v2) nach PO-bestätigtem Vier-Teile-Zuschnitt und
+  direkter Code-Verifikation in der Spec-Phase. Fenster-Theorie entfernt (Doppelversand
+  statt fehlender Warnung, Resend-Forensik-Beleg). Kritischer Befund ergänzt: Teil 3
+  (Kanal-Schwelle) und Teil 4 („!"-Kennzeichnung) sind bereits vollständig implementiert
+  (#1318, #1461 S3a/S3b-2a/S3b-2b) — beide werden nur noch mit Regressionstests geführt,
+  kein neuer Produktivcode. Neuer Kontrast-Nachrechnung für Teil 2 inkl. Known-Limitation
+  zum Compare-Badge-Hintergrund.

--- a/src/output/renderers/email/design_tokens.py
+++ b/src/output/renderers/email/design_tokens.py
@@ -29,7 +29,7 @@ G_INFO = '#2a6cb3'             # Compact-Summary-Akzent
 G_WX_THUNDER = '#c43a2a'       # Gewitterwarnung — Gefahr-Rot, konsistent mit G_DANGER (#b33a2a)
 
 # --- Amtliche-Warnung-Stufenskala (Issue #1056 v2.0, additiv) ---
-G_ALERT_L2 = '#9a6f00'         # Stufe 2 gelb (4,11:1 auf G_PAPER)
+G_ALERT_L2 = '#8a6300'         # Stufe 2 gelb (4,94:1 auf G_PAPER, #1614 WCAG-AA)
 G_ALERT_L3 = '#c8482a'         # Stufe 3 orange->rot (4,32:1)
 G_ALERT_L4 = '#6d28d9'         # Stufe 4 violett = hoechste Stufe (6,46:1)
 

--- a/src/services/alert_briefing_anchor.py
+++ b/src/services/alert_briefing_anchor.py
@@ -169,6 +169,36 @@ def write_anchor_and_reset_memory(
             reset_alert_memory(user_id=user_id, entity_id=entity_id)
 
 
+def record_official_alerts_reported(
+    *, user_id: str, entity_id: str, alerts: list,
+) -> None:
+    """Vermerkt amtliche Warnungen als 'im Briefing gemeldet' — DIE geteilte
+    Schreib-Logik fürs Melde-Gedächtnis (`official_alert:`-Namensraum).
+
+    Issue #1614 Teil 1: verhindert, dass eine bereits im Trip-Briefing
+    gezeigte, unveränderte amtliche Warnung bis zu 15 Minuten später vom
+    unabhängigen Alarm-Checker nochmal als eigene Nachricht verschickt wird.
+
+    Übernommen aus `TripAlertService._record_official_alert_state` — DIE
+    geteilte Fassung, `_record_official_alert_state` delegiert seit dem
+    Refactor hierher (Verhalten unverändert, siehe AC-5).
+
+    Fail-soft bei leerer `alerts`-Liste: No-Op.
+    """
+    if not alerts:
+        return
+    from output.renderers.alert.official_alerts import official_alert_state_key
+    from services.alert_state import AlertStateService
+
+    state_svc = AlertStateService(user_id=user_id)
+    state = state_svc.load(entity_id)
+    now_iso = datetime.now(timezone.utc).isoformat()
+    for a in alerts:
+        key = official_alert_state_key(a)
+        state[key] = {"last_reported_value": float(a.level), "reported_at": now_iso}
+    state_svc.save(entity_id, state)
+
+
 def reset_alert_memory(*, user_id: str, entity_id: str) -> None:
     """DER Reset-Weg für das Melde-Gedächtnis — Trip UND Ortsvergleich.
 

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -1193,19 +1193,20 @@ class TripAlertService:
 
     def _record_official_alert_state(self, trip_id: str, official_notices: list) -> None:
         """Issue #1088/#1200: alert_state nach erfolgreichem Versand fortschreiben
-        (Dedupe). `official_notices` sind `(OfficialAlert, segment_ids)`-Tupel."""
+        (Dedupe). `official_notices` sind `(OfficialAlert, segment_ids)`-Tupel.
+
+        Issue #1614 Teil 1: dünner Wrapper um die geteilte Schreib-Logik in
+        `services.alert_briefing_anchor.record_official_alerts_reported` —
+        Verhalten unverändert (AC-5), Segment-IDs werden hier nicht gebraucht.
+        """
         if not official_notices:
             return
-        from output.renderers.alert.official_alerts import official_alert_state_key
-        from services.alert_state import AlertStateService
+        from services.alert_briefing_anchor import record_official_alerts_reported
 
-        state_svc = AlertStateService(user_id=self._user_id)
-        state = state_svc.load(trip_id)
-        now_iso = datetime.now(timezone.utc).isoformat()
-        for a, _segment_ids in official_notices:
-            key = official_alert_state_key(a)
-            state[key] = {"last_reported_value": float(a.level), "reported_at": now_iso}
-        state_svc.save(trip_id, state)
+        record_official_alerts_reported(
+            user_id=self._user_id, entity_id=trip_id,
+            alerts=[a for a, _segment_ids in official_notices],
+        )
 
     def _send_official_alert_only(self, trip: "Trip", official_notices: list) -> bool:
         """Issue #1088: Standalone-Versand einer amtlichen Warnung ohne Wetter-Delta.

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -1025,6 +1025,24 @@ class TripReportSchedulerService:
             except Exception as e:
                 logger.warning(f"Failed to save weather snapshot for {trip.id}: {e}")
 
+        # Issue #1614 Teil 1: eine amtliche Warnung, die bereits erfolgreich im
+        # Trip-Briefing gemeldet wurde, darf der unabhaengige 15-Minuten-
+        # Alarm-Checker nicht bis zu 15 Minuten spaeter nochmal als eigene,
+        # redundante Nachricht verschicken. Beide Bedingungen sind zwingend:
+        # result.sent (sonst waere eine NIE zugestellte Warnung faelschlich
+        # als "gemeldet" markiert, AC-4) UND not on_demand (Ad-hoc-Abruf
+        # bleibt read-only, #1007, AC-3). VOR write_anchor_and_reset_memory,
+        # damit ein Exception-Pfad dort das Record nicht verschluckt.
+        if result.sent and not on_demand:
+            all_official_alerts = [
+                a for sw in segment_weather for a in (sw.official_alerts or [])
+            ]
+            if all_official_alerts:
+                from services.alert_briefing_anchor import record_official_alerts_reported
+                record_official_alerts_reported(
+                    user_id=self._user_id, entity_id=trip.id, alerts=all_official_alerts,
+                )
+
         write_anchor_and_reset_memory(
             user_id=self._user_id,
             entity_ids=[trip.id],
@@ -1200,6 +1218,10 @@ class TripReportSchedulerService:
             "sent_at": datetime.now(tz=timezone.utc).isoformat(),
             "channels": channels,
         })
+        # Issue #1614: ein frischer Nutzer ohne jedes vorherige Datenverzeichnis
+        # (kein Trip-Snapshot, kein Alert-State) hatte hier noch kein
+        # Zielverzeichnis — path.write_text() scheiterte mit FileNotFoundError.
+        path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(data, indent=2))
 
     def _convert_trip_to_segments(

--- a/tests/tdd/test_alert_state_briefing_reset.py
+++ b/tests/tdd/test_alert_state_briefing_reset.py
@@ -514,3 +514,441 @@ def test_official_alert_state_key_praefix_stimmt_mit_dem_reset_filter_ueberein()
         )
     finally:
         _clean_user(user_id)
+
+
+# ══════════════ Issue #1614 Teil 1 — Doppelversand-Schutz (Tests 1-7) ════════
+#
+# SPEC: docs/specs/modules/fix_1614_briefing_warnfenster.md (AC-1 .. AC-7)
+#
+# RED-Ursache (heute, vor der Implementierung):
+# - `services.alert_briefing_anchor.record_official_alerts_reported()`
+#   existiert noch nicht -> ImportError/AttributeError in den betroffenen
+#   Tests (5, 6, 7 direkter Import; 3, 4 Patch-Versuch auf das nicht
+#   vorhandene Modul-Attribut).
+# - Der Scheduler-Pfad `_send_trip_report_outcome()` schreibt das
+#   Melde-Gedaechtnis der amtlichen Warnungen nirgends -> der unabhaengige
+#   Alarm-Checker haelt eine bereits im Briefing gezeigte, unveraenderte
+#   Warnung weiterhin fuer "neu" (Test 1/2 -> AssertionError).
+#
+# Testpolitik: keine Mocks. Die E-Mail-Transportgrenze (`EmailOutput.send`)
+# wird per `monkeypatch.setattr` durch eine echte, aufzeichnende Funktion
+# ersetzt (Muster `tests/tdd/test_starkregen_kurzfristhinweis.py::
+# _install_fake_email_send`) -- kein Netz, kein Objekt-Double.
+
+# Muster `tests/helpers/alert_log_fixtures.py::settings_email_only()`: die
+# Trip-Fixtures dieser Datei (`_trip()`) haben `send_email=True` per Default
+# -- `can_send_email()` muss also True liefern, sonst wirft
+# `EmailOutput.__init__` VOR dem gefakten `send()` (Konstruktions-Check laesst
+# sich nicht durch das Patchen von `.send` umgehen). Telegram/SMS bleiben
+# unkonfiguriert, weil `_trip()` diese Kanaele nicht aktiviert.
+_NO_TRANSPORT_FIELDS_1614: dict = {
+    "smtp_host": "dummy.invalid", "smtp_user": "dummy", "smtp_pass": "dummy",
+    "mail_to": "dummy@example.com",
+    "telegram_bot_token": "", "telegram_chat_id": "",
+    "telegram_test_bot_token": "", "telegram_test_chat_id": "",
+    "sms_gateway_url": "", "seven_api_key": "", "sms_to": "",
+}
+
+
+def _settings_no_transport_1614():
+    from app.config import Settings
+
+    return Settings(**_NO_TRANSPORT_FIELDS_1614)
+
+
+def _fixture_scheduler_class_1614():
+    """Echte Unterklasse (kein Mock): liefert das Wetter aus der Fixture statt
+    vom Provider -- Muster test_ac23/test_trip_briefing_anchor_unchanged.py."""
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    class _FixtureScheduler(TripReportSchedulerService):
+        def _fetch_weather(self, segments, provider=None):
+            return [_data(s.segment_id, gust_max_kmh=20.0) for s in segments]
+
+    return _FixtureScheduler
+
+
+def _install_fake_email_send_1614(monkeypatch) -> list:
+    """Ersetzt den Transport-Rand `EmailOutput.send` -- echte Funktion, kein
+    Netz, kein Objekt-Double. Liefert die Liste der 'gesendeten'
+    (subject, body)-Paare."""
+    from output.channels.email import EmailOutput
+
+    sent: list = []
+
+    def _fake_send(self, *, subject, body, **kwargs):
+        sent.append((subject, body))
+
+    monkeypatch.setattr(EmailOutput, "send", _fake_send)
+    return sent
+
+
+def _official_alert_1614(hazard: str, level: int, *, region: str = "Gailtal"):
+    from services.official_alerts import OfficialAlert
+
+    now = datetime.now(timezone.utc)
+    return OfficialAlert(
+        source="tdd-1614", hazard=hazard, level=level,
+        label=f"{hazard}-Warnung (#1614)", region_label=region,
+        valid_from=now - timedelta(hours=1), valid_to=now + timedelta(hours=8),
+    )
+
+
+def test_briefing_meldet_unveraenderte_amtliche_warnung_danach_nicht_erneut(monkeypatch):
+    """Test 1 / AC-1.
+
+    GIVEN ein Trip-Briefing wurde erfolgreich mit einer amtlichen Warnung X
+          versendet (echter `_send_trip_report_outcome()`-Aufrufpfad)
+    WHEN  danach `TripAlertService.check_official_alert_triggers()` fuer
+          denselben Trip mit unveraenderter Warnung X (gleiches Level) laeuft
+    THEN  liefert der Checker X NICHT als neu/eskaliert zurueck (kein
+          Doppelversand -- Mail-Paar `86918bc7`/`7d0bbfd6` aus der Forensik).
+
+    RED (heute): der Briefing-Pfad schreibt das Melde-Gedaechtnis nirgends,
+    der Checker haelt X weiterhin fuer neu -> `again` ist nicht leer.
+    """
+    from services.official_alerts import register_official_alert_source
+    from services.trip_alert import TripAlertService
+
+    user_id = _fresh_user("t1614-1")
+    _clean_user(user_id)
+    b, backup = _sources_backup()
+    b._REGISTERED_SOURCES.clear()
+    try:
+        trip = _trip("trip-1614-t1")
+        sent = _install_fake_email_send_1614(monkeypatch)
+        alert = _official_alert_1614("thunderstorm", 2)
+        register_official_alert_source(_FixedOfficialAlertSource(LAT, LON, alert))
+
+        scheduler = _fixture_scheduler_class_1614()(
+            settings=_settings_no_transport_1614(), user_id=user_id,
+        )
+        outcome = scheduler._send_trip_report_outcome(trip, "morning", on_demand=False)
+        assert outcome == "sent", f"Vorbedingung: der Versand muss gelingen ({outcome!r})"
+        assert sent, "Vorbedingung: die Briefing-Mail wurde tatsaechlich gerendert"
+
+        again = TripAlertService(user_id=user_id).check_official_alert_triggers(trip)
+        assert again == [], (
+            "Dieselbe amtliche Warnung darf nach einem erfolgreichen Briefing nicht "
+            f"erneut als neu gemeldet werden (Doppelversand #1614), erhalten: {again!r}"
+        )
+    finally:
+        b._REGISTERED_SOURCES.clear()
+        b._REGISTERED_SOURCES.extend(backup)
+        _clean_user(user_id)
+
+
+def test_eskalierte_warnung_wird_trotz_bereits_gemeldeter_unveraenderter_warnung_weiterhin_gemeldet(
+    monkeypatch,
+):
+    """Test 2 / AC-2 (Eskalations-Gegenprobe).
+
+    GIVEN dasselbe Vorbriefing wie Test 1 -- ZWEI amtliche Warnungen
+          (unveraendert: thunderstorm Stufe 2; spaeter eskalierend: flood)
+          wurden erfolgreich im Briefing gemeldet
+    WHEN  danach NUR "flood" auf Stufe 3 eskaliert
+    THEN  meldet der Checker AUSSCHLIESSLICH die eskalierte Warnung ("flood")
+          -- NICHT die unveraenderte ("thunderstorm").
+
+    RED (heute): ohne Doppelversand-Schutz erscheint "thunderstorm" (die
+    unveraenderte Warnung) ebenfalls wieder -> die Menge der gemeldeten
+    Gefahren ist nicht `{"flood"}`, sondern `{"flood", "thunderstorm"}`.
+    """
+    from services.official_alerts import register_official_alert_source
+    from services.trip_alert import TripAlertService
+
+    user_id = _fresh_user("t1614-2")
+    _clean_user(user_id)
+    b, backup = _sources_backup()
+    b._REGISTERED_SOURCES.clear()
+    try:
+        trip = _trip("trip-1614-t2")
+        _install_fake_email_send_1614(monkeypatch)
+
+        unchanged = _official_alert_1614("thunderstorm", 2)
+        register_official_alert_source(_FixedOfficialAlertSource(LAT, LON, unchanged))
+        escalating_source = _FixedOfficialAlertSource(LAT, LON, _official_alert_1614("flood", 2))
+        register_official_alert_source(escalating_source)
+
+        scheduler = _fixture_scheduler_class_1614()(
+            settings=_settings_no_transport_1614(), user_id=user_id,
+        )
+        outcome = scheduler._send_trip_report_outcome(trip, "morning", on_demand=False)
+        assert outcome == "sent", f"Vorbedingung: der Versand muss gelingen ({outcome!r})"
+
+        escalating_source._alert = _official_alert_1614("flood", 3)
+
+        triggered = TripAlertService(user_id=user_id).check_official_alert_triggers(trip)
+        hazards = {a.hazard for a, _seg in triggered}
+        assert hazards == {"flood"}, (
+            "Eine echte Verschaerfung ('flood') muss weiterhin gemeldet werden, eine "
+            "unveraenderte Warnung ('thunderstorm') darf NICHT erneut auftauchen "
+            f"(Doppelversand #1614): {triggered!r}"
+        )
+        (flood_entry,) = [a for a, _seg in triggered if a.hazard == "flood"]
+        assert flood_entry.level == 3
+    finally:
+        b._REGISTERED_SOURCES.clear()
+        b._REGISTERED_SOURCES.extend(backup)
+        _clean_user(user_id)
+
+
+def test_ad_hoc_abruf_schreibt_das_melde_gedaechtnis_amtlicher_warnungen_nicht(monkeypatch):
+    """Test 3 / AC-3 (Ad-hoc-Ausnahme, #1007).
+
+    GIVEN ein On-Demand-Abruf (`on_demand=True`) liefert dieselbe amtliche
+          Warnung
+    WHEN  der Abruf abgeschlossen ist
+    THEN  bleibt das Melde-Gedaechtnis unveraendert -- die neue
+          Record-Funktion wird kein einziges Mal aufgerufen.
+
+    RED (heute): `record_official_alerts_reported` existiert noch nicht auf
+    `services.alert_briefing_anchor` -> `monkeypatch.setattr(..., raising=True)`
+    wirft AttributeError.
+    """
+    import services.alert_briefing_anchor as anchor_mod_1614
+    from services.alert_state import AlertStateService
+    from services.official_alerts import register_official_alert_source
+
+    user_id = _fresh_user("t1614-3")
+    _clean_user(user_id)
+    b, backup = _sources_backup()
+    b._REGISTERED_SOURCES.clear()
+    try:
+        trip = _trip("trip-1614-t3")
+        _install_fake_email_send_1614(monkeypatch)
+        register_official_alert_source(
+            _FixedOfficialAlertSource(LAT, LON, _official_alert_1614("thunderstorm", 2))
+        )
+
+        calls: list = []
+
+        def _fake_record(*, user_id, entity_id, alerts):
+            calls.append((user_id, entity_id, alerts))
+
+        monkeypatch.setattr(anchor_mod_1614, "record_official_alerts_reported", _fake_record)
+
+        before = AlertStateService(user_id=user_id).load(trip.id)
+
+        scheduler = _fixture_scheduler_class_1614()(
+            settings=_settings_no_transport_1614(), user_id=user_id,
+        )
+        outcome = scheduler._send_trip_report_outcome(trip, "morning", on_demand=True)
+        assert outcome in ("sent", "no_channels", "channels_unreachable"), (
+            f"Der Ad-hoc-Lauf ist vorzeitig abgebrochen: {outcome!r}"
+        )
+
+        assert calls == [], (
+            f"Der Ad-hoc-Abruf (#1007) darf die neue Record-Funktion nicht aufrufen: {calls!r}"
+        )
+        after = AlertStateService(user_id=user_id).load(trip.id)
+        assert after == before, "Das Melde-Gedaechtnis darf sich durch einen Ad-hoc-Abruf nicht aendern"
+    finally:
+        b._REGISTERED_SOURCES.clear()
+        b._REGISTERED_SOURCES.extend(backup)
+        _clean_user(user_id)
+
+
+def test_fehlgeschlagener_versand_schreibt_das_melde_gedaechtnis_nicht(monkeypatch):
+    """Test 4 / AC-4 (fehlgeschlagener Versand, neuer Fall).
+
+    GIVEN `result.sent` ist `False` (Telegram konfiguriert, aber garantiert
+          scheiternd -- `is_test_mode`-Guard von `TelegramOutput`, kein
+          Live-Netz -- E-Mail bewusst deaktiviert)
+    WHEN  `_send_trip_report_outcome()` durchlaeuft
+    THEN  wird die neue Record-Funktion NICHT aufgerufen -- eine nie
+          zugestellte Warnung darf den Alarm-Checker nicht stumm schalten.
+
+    RED (heute): `record_official_alerts_reported` existiert noch nicht ->
+    `monkeypatch.setattr(..., raising=True)` wirft AttributeError.
+    """
+    import services.alert_briefing_anchor as anchor_mod_1614
+    from services.official_alerts import register_official_alert_source
+    from tests.helpers.alert_log_fixtures import settings_email_and_failing_telegram
+
+    user_id = _fresh_user("t1614-4")
+    _clean_user(user_id)
+    b, backup = _sources_backup()
+    b._REGISTERED_SOURCES.clear()
+    try:
+        trip = _trip("trip-1614-t4")
+        trip.report_config = TripReportConfig(
+            trip_id=trip.id, send_email=False, send_telegram=True, send_sms=False,
+        )
+        register_official_alert_source(
+            _FixedOfficialAlertSource(LAT, LON, _official_alert_1614("thunderstorm", 2))
+        )
+
+        calls: list = []
+
+        def _fake_record(*, user_id, entity_id, alerts):
+            calls.append((user_id, entity_id, alerts))
+
+        monkeypatch.setattr(anchor_mod_1614, "record_official_alerts_reported", _fake_record)
+
+        scheduler = _fixture_scheduler_class_1614()(
+            settings=settings_email_and_failing_telegram(), user_id=user_id,
+        )
+        outcome = scheduler._send_trip_report_outcome(trip, "morning", on_demand=False)
+        assert outcome == "channels_unreachable", (
+            f"Vorbedingung: der Versand muss ehrlich als nicht zugestellt gelten ({outcome!r})"
+        )
+        assert calls == [], (
+            f"Ein fehlgeschlagener Versand darf die Warnung nicht als 'gemeldet' vermerken: {calls!r}"
+        )
+    finally:
+        b._REGISTERED_SOURCES.clear()
+        b._REGISTERED_SOURCES.extend(backup)
+        _clean_user(user_id)
+
+
+def test_record_official_alert_state_wrapper_liefert_denselben_eintrag_wie_die_neue_funktion():
+    """Test 5 / AC-5 (Wrapper-Regression).
+
+    GIVEN identische Eingaben (Alert, Trip-Kennung)
+    WHEN  einmal ueber den ALTEN Weg (`TripAlertService._record_official_
+          alert_state`, wird nach dem Refactor zum duennen Wrapper) und
+          einmal ueber die NEUE geteilte Funktion
+          (`record_official_alerts_reported`) geschrieben wird
+    THEN  entsteht in beiden Faellen exakt derselbe Schluessel mit demselben
+          Level -- der Wrapper darf das Verhalten nicht veraendern.
+
+    RED (heute): `record_official_alerts_reported` existiert noch nicht in
+    `services.alert_briefing_anchor` -> ImportError.
+    """
+    from services.alert_briefing_anchor import record_official_alerts_reported
+    from services.alert_state import AlertStateService
+    from services.trip_alert import TripAlertService
+
+    user_a = _fresh_user("t1614-5a")
+    user_b = _fresh_user("t1614-5b")
+    _clean_user(user_a)
+    _clean_user(user_b)
+    try:
+        trip_id = "trip-1614-t5"
+        alert = _official_alert_1614("thunderstorm", 2)
+        official_notices = [(alert, ["1"])]
+
+        TripAlertService(user_id=user_a)._record_official_alert_state(trip_id, official_notices)
+        via_wrapper = AlertStateService(user_id=user_a).load(trip_id)
+
+        record_official_alerts_reported(user_id=user_b, entity_id=trip_id, alerts=[alert])
+        via_new_function = AlertStateService(user_id=user_b).load(trip_id)
+
+        assert set(via_wrapper) == set(via_new_function), (
+            "Wrapper und neue Funktion muessen dieselben Schluessel erzeugen: "
+            f"{sorted(via_wrapper)!r} vs {sorted(via_new_function)!r}"
+        )
+        for key, value in via_wrapper.items():
+            assert value["last_reported_value"] == via_new_function[key]["last_reported_value"], (
+                f"Unterschiedlicher Level fuer {key!r}: {value!r} vs {via_new_function[key]!r}"
+            )
+            assert "reported_at" in via_new_function[key]
+    finally:
+        _clean_user(user_a)
+        _clean_user(user_b)
+
+
+def test_record_official_alerts_reported_laeuft_bei_kaltstart_fehlerfrei_durch():
+    """Test 6 / AC-6 (Kaltstart).
+
+    GIVEN ein Trip ohne jeden vorherigen `official_alert:`-State-Eintrag
+    WHEN  `record_official_alerts_reported()` mit einer amtlichen Warnung
+          aufgerufen wird
+    THEN  laeuft der Aufruf fehlerfrei durch und legt einen gueltigen
+          Eintrag an.
+
+    RED (heute): `record_official_alerts_reported` existiert noch nicht ->
+    ImportError.
+    """
+    from services.alert_briefing_anchor import record_official_alerts_reported
+    from services.alert_state import AlertStateService
+
+    user_id = _fresh_user("t1614-6")
+    _clean_user(user_id)
+    try:
+        trip_id = "trip-1614-t6"
+        assert AlertStateService(user_id=user_id).load(trip_id) == {}, (
+            "Vorbedingung: kein vorheriger Eintrag"
+        )
+        alert = _official_alert_1614("thunderstorm", 2)
+
+        record_official_alerts_reported(user_id=user_id, entity_id=trip_id, alerts=[alert])
+
+        after = AlertStateService(user_id=user_id).load(trip_id)
+        assert len(after) == 1, f"Erwartet genau einen neuen Eintrag: {after!r}"
+        (entry,) = after.values()
+        assert entry["last_reported_value"] == 2.0
+        assert "reported_at" in entry
+    finally:
+        _clean_user(user_id)
+
+
+def test_record_official_alerts_reported_beruehrt_nur_den_eigenen_nutzer():
+    """Test 7 / AC-7 (Mandantentrennung, CLAUDE.md-Pflicht).
+
+    GIVEN zwei verschiedene `user_id`s mit je einem Trip und je einer
+          identischen amtlichen Warnung
+    WHEN  fuer Nutzer A `record_official_alerts_reported()` aufgerufen wird
+    THEN  bleibt das Melde-Gedaechtnis von Nutzer B unveraendert.
+
+    RED (heute): `record_official_alerts_reported` existiert noch nicht ->
+    ImportError.
+    """
+    from services.alert_briefing_anchor import record_official_alerts_reported
+    from services.alert_state import AlertStateService
+
+    user_a = _fresh_user("t1614-7a")
+    user_b = _fresh_user("t1614-7b")
+    _clean_user(user_a)
+    _clean_user(user_b)
+    try:
+        trip_id = "trip-1614-t7"
+        alert = _official_alert_1614("thunderstorm", 2)
+
+        record_official_alerts_reported(user_id=user_a, entity_id=trip_id, alerts=[alert])
+
+        assert AlertStateService(user_id=user_a).load(trip_id) != {}
+        assert AlertStateService(user_id=user_b).load(trip_id) == {}, (
+            "Nutzer B darf durch das Melde-Gedaechtnis von Nutzer A nicht beruehrt werden"
+        )
+    finally:
+        _clean_user(user_a)
+        _clean_user(user_b)
+
+
+def test_record_official_alerts_reported_mit_leerer_liste_ist_ein_no_op():
+    """F001 (Adversary-Mutations-Fund, #1614). GIVEN kein vorheriger State,
+    WHEN record_official_alerts_reported() mit leerer alerts-Liste aufgerufen
+    wird, THEN wird keine State-Datei angelegt/veraendert (No-Op-Vertrag).
+
+    RED-Nachweis (Mutations-Gegenprobe): der Fail-soft-Guard `if not alerts:
+    return` in `record_official_alerts_reported()` wurde entfernt -- alle
+    bestehenden Tests dieser Datei blieben gruen, weil keiner die Funktion
+    mit einer leeren Liste aufruft. Dieser Test prueft nicht nur den
+    Rueckgabewert von `load()` (leeres dict), sondern dass die Datei
+    ueberhaupt nicht existiert -- das ist der eigentliche No-Op-Vertrag
+    laut Docstring, nicht bloss ein zufaellig leerer State.
+    """
+    from services.alert_briefing_anchor import record_official_alerts_reported
+    from services.alert_state import AlertStateService
+
+    user_id = _fresh_user("t1614-f001")
+    _clean_user(user_id)
+    try:
+        trip_id = "trip-1614-f001"
+        svc = AlertStateService(user_id=user_id)
+        state_path = svc._path(trip_id)
+        assert not state_path.exists(), "Vorbedingung: keine State-Datei vorhanden"
+
+        record_official_alerts_reported(user_id=user_id, entity_id=trip_id, alerts=[])
+
+        assert AlertStateService(user_id=user_id).load(trip_id) == {}, (
+            "Bei leerer alerts-Liste darf kein State entstehen"
+        )
+        assert not state_path.exists(), (
+            "No-Op-Vertrag verletzt: record_official_alerts_reported() hat trotz leerer "
+            f"alerts-Liste eine State-Datei angelegt ({state_path!r})"
+        )
+    finally:
+        _clean_user(user_id)

--- a/tests/tdd/test_email_design_tokens.py
+++ b/tests/tdd/test_email_design_tokens.py
@@ -56,7 +56,7 @@ def test_ac4_alert_level_tokens_present_issue_1056():
     from src.output.renderers.email.design_tokens import (
         G_ALERT_L2, G_ALERT_L3, G_ALERT_L4,
     )
-    assert G_ALERT_L2 == "#9a6f00"
+    assert G_ALERT_L2 == "#8a6300"  # #1614 WCAG-AA-Anhebung
     assert G_ALERT_L3 == "#c8482a"
     assert G_ALERT_L4 == "#6d28d9"
 

--- a/tests/tdd/test_official_alert_badge_color.py
+++ b/tests/tdd/test_official_alert_badge_color.py
@@ -23,7 +23,7 @@ from services.official_alerts.models import OfficialAlert
 
 # Amtstreue 4-Stufen-Palette (Spec #1056 v2.0)
 GREEN = "#3a7d44"        # Stufe 1 (= G_SUCCESS, unverändert)
-YELLOW = "#9a6f00"       # Stufe 2 (neu G_ALERT_L2)
+YELLOW = "#8a6300"       # Stufe 2 (G_ALERT_L2, #1614 WCAG-AA-Anhebung)
 ORANGE_RED = "#c8482a"   # Stufe 3 (neu G_ALERT_L3)
 VIOLET = "#6d28d9"       # Stufe 4 (neu G_ALERT_L4)
 

--- a/tests/tdd/test_official_alert_channel_threshold.py
+++ b/tests/tdd/test_official_alert_channel_threshold.py
@@ -1,0 +1,167 @@
+"""Regressionsschutz — Issue #1614 Teil 3: Kanal-Schwellen-Verdrahtung.
+
+SPEC: docs/specs/modules/fix_1614_briefing_warnfenster.md (AC-10 .. AC-13)
+
+Kritischer Befund der Spec-Phase: Teil 3 ist BEREITS vollstaendig
+implementiert (#1461 S3b-2a Trip, S3b-2b Compare) -- diese Tests sind reiner
+Regressionsschutz und laufen schon HEUTE gruen, kein TDD im engeren Sinn.
+Kein Produktivcode wird durch diese Datei ausgeloest.
+
+Testpolitik: kein Mock-Theater, echte Renderer-Aufrufe (Kern-Schicht, kein
+Netz). Geprueft wird die erzeugte Ausgabe (SMS-/Telegram-Text), nicht interne
+Funktionsaufrufe.
+
+Pfadregel #1409: reine Modul-Importe, kein fester Hauptrepo-Pfad noetig.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+from app.trip import Stage, Trip, Waypoint
+from services.official_alerts import OfficialAlert
+from tests.unit.test_renderers_email import _make_segment_weather
+
+LAT, LON = 42.20, 9.05
+
+
+def _gelb_alert() -> OfficialAlert:
+    # Hazard "flood" (Kuerzel "FL") statt "thunderstorm" ("TH"): das
+    # Trip-SMS-Format traegt bereits ein IMMER vorhandenes Gewitter-
+    # Vorhersage-Token mit demselben Symbol "TH:" (SMS_MULTI_SYMBOLS_BY_METRIC
+    # "thunder" -> ("TH:", "TH+:")) -- ein Substring-Check auf "TH:" waere
+    # unabhaengig vom amtlichen Warnblock immer wahr und bewiese nichts.
+    now = datetime.now(timezone.utc)
+    return OfficialAlert(
+        source="tdd-1614-t10", hazard="flood", level=2,
+        label="Hochwasserwarnung Stufe 2 (#1614)", region_label="Region",
+        valid_from=now - timedelta(hours=1), valid_to=now + timedelta(hours=8),
+    )
+
+
+def _segment_with_alert(alert: OfficialAlert):
+    sw = _make_segment_weather()
+    sw.official_alerts = [alert]
+    return sw
+
+
+def _trip(threshold: dict | None) -> Trip:
+    stage = Stage(
+        id="T1", name="Tag 1", date=date.today(),
+        waypoints=[
+            Waypoint(id="G1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0),
+            Waypoint(id="G2", name="Ziel", lat=LAT + 0.05, lon=LON + 0.05, elevation_m=1200.0),
+        ],
+    )
+    return Trip(
+        id="trip-1614-schwelle", name="Schwellen-Trip", stages=[stage],
+        alert_channel_thresholds=threshold,
+    )
+
+
+def test_trip_sms_zeigt_gelbe_warnung_bei_startwert_schwelle():
+    """Test 10 / AC-10.
+
+    GIVEN ein Trip hat fuer den SMS-Kanal keine eigene Schwelle gesetzt
+          (Startwert "gering")
+    WHEN  die Trip-SMS fuer eine amtliche Warnung Stufe 2 (GELB) erzeugt wird
+    THEN  enthaelt der SMS-Text die Warnung.
+    """
+    from output.renderers.trip_report import TripReportFormatter
+
+    trip = _trip(None)
+    seg = _segment_with_alert(_gelb_alert())
+
+    report = TripReportFormatter().format_email(
+        segments=[seg], trip_name=trip.name, report_type="evening",
+        trip=trip, tz=ZoneInfo("UTC"),
+    )
+    assert "FL:" in report.sms_text, (
+        f"Die GELB-Warnung muss bei Startwert-Schwelle im SMS-Text erscheinen: "
+        f"{report.sms_text!r}"
+    )
+
+
+def test_trip_sms_verbirgt_gelbe_warnung_bei_hochgesetzter_schwelle():
+    """Test 11 / AC-11 (Gegenprobe zu AC-10).
+
+    GIVEN derselbe Trip hat die SMS-Kanal-Schwelle explizit auf "hoch"
+          gesetzt
+    WHEN  dieselbe GELB-Warnung gerendert wird
+    THEN  fehlt sie im SMS-Text.
+    """
+    from output.renderers.trip_report import TripReportFormatter
+
+    trip = _trip({"sms": "HIGH"})
+    seg = _segment_with_alert(_gelb_alert())
+
+    report = TripReportFormatter().format_email(
+        segments=[seg], trip_name=trip.name, report_type="evening",
+        trip=trip, tz=ZoneInfo("UTC"),
+    )
+    assert "FL:" not in report.sms_text, (
+        f"Die GELB-Warnung darf bei hochgesetzter SMS-Schwelle nicht erscheinen: "
+        f"{report.sms_text!r}"
+    )
+
+
+def test_trip_telegram_bubble_folgt_derselben_kanal_schwelle():
+    """Test 12 / AC-12 (analog Test 10/11 fuer Telegram).
+
+    GIVEN ein Trip hat fuer den Telegram-Kanal keine eigene Schwelle bzw.
+          eine hochgesetzte Schwelle
+    WHEN  die Telegram-Bubble fuer dieselbe GELB-Warnung gerendert wird
+    THEN  erscheint sie im ersten Fall und fehlt im zweiten.
+    """
+    from output.renderers.narrow import _official_alert_bubble
+
+    seg = _segment_with_alert(_gelb_alert())
+
+    bubble_low = _official_alert_bubble([seg], ZoneInfo("UTC"), trip=_trip(None))
+    assert bubble_low is not None and "Amtliche Warnung" in bubble_low.text, (
+        f"Bei Startwert-Schwelle muss die GELB-Warnung in der Telegram-Bubble "
+        f"erscheinen: {bubble_low!r}"
+    )
+
+    bubble_high = _official_alert_bubble(
+        [seg], ZoneInfo("UTC"), trip=_trip({"telegram": "HIGH"}),
+    )
+    assert bubble_high is None, (
+        f"Bei hochgesetzter Telegram-Schwelle darf keine Bubble entstehen: {bubble_high!r}"
+    )
+
+
+def test_compare_bericht_zeigt_gelbe_warnung_unabhaengig_von_der_alarm_schwelle():
+    """Test 13 / AC-13 (Regressionsschutz Compare-Bericht, "Zwei Wirkungsorte").
+
+    GIVEN ein Ortsvergleich-Ort traegt eine amtliche Warnung Stufe 2 (GELB) --
+          `render_compare_sms`/`render_compare_telegram` kennen strukturell
+          KEINEN Alarm-Kanal-Schwellenparameter (#1461 S3b-2b, PO-dokumentiert)
+    WHEN  der reguläre Kurznachrichten-Bericht (SMS und Telegram) erzeugt wird
+    THEN  erscheint die Warnung trotzdem -- der Bericht bleibt bewusst
+          unabhaengig von einer je Kanal eingestellten Alarm-Schwelle.
+    """
+    from app.user import ComparisonResult, LocationResult, SavedLocation
+    from output.renderers.comparison import render_compare_sms, render_compare_telegram
+
+    location = SavedLocation(id="loc-1614", name="Testort", lat=LAT, lon=LON, elevation_m=1000)
+    loc_result = LocationResult(location=location, official_alerts=[_gelb_alert()])
+    result = ComparisonResult(
+        locations=[loc_result], time_window=(0, 23), target_date=date.today(),
+    )
+
+    sms = render_compare_sms(result)
+    telegram = render_compare_telegram(result)
+
+    assert "!FL" in sms, (
+        "Der Compare-SMS-Bericht muss eine GELB-Warnung unabhaengig von einer "
+        f"Alarm-Kanal-Schwelle zeigen (Zwei Wirkungsorte, #1461 S3b-2b): {sms!r}"
+    )
+    # Compare-Telegram traegt keinen "Amtliche Warnung"-Praefix (der Praefix
+    # ist dort der Ortsname, s. comparison.py:748) -- "Warnstufe" ist der
+    # zuverlaessige Marker, dass ueberhaupt eine amtliche Warnung im Block
+    # gerendert wurde (render_official_alert_telegram()).
+    assert "Warnstufe" in telegram, (
+        "Der Compare-Telegram-Bericht muss eine GELB-Warnung unabhaengig von "
+        f"einer Alarm-Kanal-Schwelle zeigen: {telegram!r}"
+    )

--- a/tests/tdd/test_official_alert_color_contrast.py
+++ b/tests/tdd/test_official_alert_color_contrast.py
@@ -1,0 +1,98 @@
+"""TDD RED — Issue #1614 Teil 2: GELB-Kontrast (`G_ALERT_L2`) auf WCAG-AA.
+
+SPEC: docs/specs/modules/fix_1614_briefing_warnfenster.md (AC-8, AC-9)
+
+RED-Ursache (heute): `G_ALERT_L2` steht noch auf dem alten Wert `#9a6f00`
+(4,11:1 gegen `G_PAPER`, unter der von CLAUDE.md geforderten WCAG-AA-
+Mindestgrenze 4,5:1). Der neue Wert `#8a6300` erreicht laut Spec-Rechnung
+4,94:1 (G_PAPER) bzw. 5,43:1 (weisser Kartenhintergrund).
+
+Testpolitik (CLAUDE.md "Test-Politik: Zwei Schichten"): reine Mathematik
+gegen die Hex-Konstanten -- WCAG-2.1-relative-Luminanz-Formel aus dem
+bestehenden Mess-Werkzeug `scripts/contrast_audit.py` (keine zweite Formel-
+Implementierung). Kein Mock-Theater. Test 9 prueft die tatsaechlich
+gerenderte HTML-Ausgabe (Wirkung, nicht nur die Konstante).
+
+Pfadregel #1409: `_REPO_ROOT` wird relativ zu DIESER Datei aufgeloest.
+"""
+from __future__ import annotations
+
+import importlib.util
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_NEW_G_ALERT_L2 = "#8a6300"
+_OLD_G_ALERT_L2 = "#9a6f00"
+_G_PAPER = "#f6f4ee"
+# design_tokens.py definiert keine eigene "G_CARD"-Konstante -- der
+# Warn-Block sitzt teils direkt auf weissem Kartenhintergrund (Spec-Rechnung
+# "gegen G_CARD (#ffffff)").
+_G_CARD = "#ffffff"
+
+
+def _load_contrast_audit():
+    """Laedt das bestehende Mess-Werkzeug als Modul (kein Formel-Duplikat)."""
+    spec = importlib.util.spec_from_file_location(
+        "contrast_audit_1614", _REPO_ROOT / "scripts" / "contrast_audit.py",
+    )
+    if spec is None or spec.loader is None:
+        raise FileNotFoundError("scripts/contrast_audit.py nicht ladbar")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_g_alert_l2_neuer_wert_erreicht_wcag_aa_gegen_paper_und_card():
+    """Test 8 / AC-8.
+
+    GIVEN der neue `G_ALERT_L2`-Wert `#8a6300`
+    WHEN  der Kontrast gegen `G_PAPER` (`#f6f4ee`) und den weissen
+          Kartenhintergrund (`#ffffff`) nach WCAG-2.1 berechnet wird
+    THEN  liegt beides bei mindestens 4,5:1 (WCAG-AA).
+    """
+    from output.renderers.email.design_tokens import G_ALERT_L2
+
+    assert G_ALERT_L2 == _NEW_G_ALERT_L2, (
+        f"G_ALERT_L2 muss auf den kontrastreicheren Wert {_NEW_G_ALERT_L2!r} "
+        f"angehoben werden, aktuell: {G_ALERT_L2!r}"
+    )
+    cab = _load_contrast_audit()
+    ratio_paper = cab.contrast_ratio(G_ALERT_L2, _G_PAPER)
+    ratio_card = cab.contrast_ratio(G_ALERT_L2, _G_CARD)
+    assert ratio_paper >= 4.5, (
+        f"G_ALERT_L2 ({G_ALERT_L2!r}) gegen G_PAPER unter WCAG-AA: {ratio_paper:.2f}:1"
+    )
+    assert ratio_card >= 4.5, (
+        f"G_ALERT_L2 ({G_ALERT_L2!r}) gegen G_CARD unter WCAG-AA: {ratio_card:.2f}:1"
+    )
+
+
+def test_renderer_gibt_den_neuen_farbwert_fuer_eine_gelbe_warnung_aus():
+    """Test 9 / AC-9 (Renderer-Durchgriff).
+
+    GIVEN eine amtliche Warnung der Stufe 2 (GELB)
+    WHEN  sie als E-Mail-HTML gerendert wird (`render_official_alerts_html`)
+    THEN  enthaelt die erzeugte Ausgabe den neuen Hex-Wert `#8a6300`, nicht
+          mehr den alten `#9a6f00` -- belegt, dass der Token-Wechsel bis zur
+          tatsaechlichen Ausgabe durchschlaegt.
+    """
+    from output.renderers.alert.official_alerts import render_official_alerts_html
+    from services.official_alerts import OfficialAlert
+
+    now = datetime.now(timezone.utc)
+    alert = OfficialAlert(
+        source="tdd-1614-t9", hazard="thunderstorm", level=2,
+        label="Gewitterwarnung Stufe 2 (#1614 Test 9)", region_label="Gailtal",
+        valid_from=now - timedelta(hours=1), valid_to=now + timedelta(hours=8),
+    )
+    html = render_official_alerts_html([("Gailtal", [alert])])
+
+    assert _NEW_G_ALERT_L2 in html, (
+        f"Der neue Farbwert {_NEW_G_ALERT_L2!r} muss im gerenderten HTML einer "
+        f"Stufe-2-Warnung erscheinen: {html!r}"
+    )
+    assert _OLD_G_ALERT_L2 not in html, (
+        f"Der alte Farbwert darf nach dem Token-Wechsel nicht mehr erscheinen: {html!r}"
+    )

--- a/tests/tdd/test_official_alert_sms_marker.py
+++ b/tests/tdd/test_official_alert_sms_marker.py
@@ -1,0 +1,152 @@
+"""Regressionsschutz — Issue #1614 Teil 4: "!"-Kennzeichnung amtlicher Warnungen.
+
+SPEC: docs/specs/modules/fix_1614_briefing_warnfenster.md (AC-14, AC-15, AC-16)
+
+Kritischer Befund der Spec-Phase: Teil 4 ist BEREITS vollstaendig
+implementiert (Trip-SMS Issue #1318 `output/tokens/render.py::_fuse`,
+Compare-SMS Issue #1332 `comparison.py::_official_alert_sms_marker`) --
+diese Tests sind reiner Regressionsschutz und laufen schon HEUTE gruen, kein
+TDD im engeren Sinn. Kein Produktivcode wird durch diese Datei ausgeloest.
+
+Testpolitik: kein Mock-Theater, echte Renderer-Aufrufe (Kern-Schicht, kein
+Netz). Geprueft wird die erzeugte Ausgabe (SMS-/Telegram-Text).
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+from app.trip import Stage, Trip, Waypoint
+from app.user import ComparisonResult, LocationResult, SavedLocation
+from services.official_alerts import OfficialAlert
+from tests.unit.test_renderers_email import _make_segment_weather
+
+LAT, LON = 42.20, 9.05
+
+
+def _two_official_alerts() -> tuple[OfficialAlert, OfficialAlert]:
+    """Zwei verschiedene Gefahren, beide Stufe 3 (orange, ueber jeder
+    Kanal-Schwelle) -- fuer den Nachweis "genau EIN fuehrendes '!' vor dem
+    GESAMTEN Block, nicht vor jedem einzelnen Token"."""
+    now = datetime.now(timezone.utc)
+    thunder = OfficialAlert(
+        source="tdd-1614-t14", hazard="thunderstorm", level=3,
+        label="Gewitterwarnung (#1614)", region_label="Region",
+        valid_from=now - timedelta(hours=1), valid_to=now + timedelta(hours=8),
+    )
+    flood = OfficialAlert(
+        source="tdd-1614-t14", hazard="flood", level=3,
+        label="Hochwasserwarnung (#1614)", region_label="Region",
+        valid_from=now - timedelta(hours=1), valid_to=now + timedelta(hours=8),
+    )
+    return thunder, flood
+
+
+def _segment_with_alerts(alerts: list[OfficialAlert]):
+    sw = _make_segment_weather()
+    sw.official_alerts = list(alerts)
+    return sw
+
+
+def _trip() -> Trip:
+    stage = Stage(
+        id="T1", name="Tag 1", date=date.today(),
+        waypoints=[
+            Waypoint(id="G1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0),
+            Waypoint(id="G2", name="Ziel", lat=LAT + 0.05, lon=LON + 0.05, elevation_m=1200.0),
+        ],
+    )
+    return Trip(id="trip-1614-marker", name="Marker-Trip", stages=[stage])
+
+
+def test_trip_sms_traegt_genau_ein_fuehrendes_ausrufezeichen_vor_dem_warnblock():
+    """Test 14 / AC-14 (Trip-SMS).
+
+    GIVEN eine amtliche Warnung erreicht den SMS-Kanal (Stufe 3, orange)
+    WHEN  die Trip-SMS-Kurzform erzeugt wird
+    THEN  steht genau ein fuehrendes "!" unmittelbar vor dem ersten Token des
+          amtlichen Warnblocks, kein weiteres "!" vor folgenden Tokens
+          desselben Blocks (Issue #1318).
+    """
+    from output.renderers.trip_report import TripReportFormatter
+
+    thunder, flood = _two_official_alerts()
+    seg = _segment_with_alerts([thunder, flood])
+    trip = _trip()
+
+    report = TripReportFormatter().format_email(
+        segments=[seg], trip_name=trip.name, report_type="evening",
+        trip=trip, tz=ZoneInfo("UTC"),
+    )
+    sms = report.sms_text
+    assert sms.count("!") == 1, (
+        f"Erwartet genau EIN '!' im gesamten SMS-Text, gefunden {sms.count('!')}: {sms!r}"
+    )
+    assert "!TH:" in sms, f"Das '!' muss unmittelbar vor dem ersten Warnblock-Token stehen: {sms!r}"
+    assert "FL:" in sms and "!FL:" not in sms, (
+        f"Das zweite Token desselben Blocks darf KEIN eigenes '!' tragen: {sms!r}"
+    )
+
+
+def test_compare_sms_traegt_denselben_ausrufezeichen_marker():
+    """Test 15 / AC-14 (Compare-SMS, Regressionsschutz #1332).
+
+    GIVEN dieselbe Ausgangslage fuer einen Ortsvergleichs-Ort
+    WHEN  die Compare-SMS-Kurzform erzeugt wird
+    THEN  traegt der Ortsblock denselben "!"-Marker (genau einmal, vor dem
+          ersten Token).
+    """
+    from output.renderers.comparison import render_compare_sms
+
+    thunder, flood = _two_official_alerts()
+    location = SavedLocation(id="loc-1614", name="Testort", lat=LAT, lon=LON, elevation_m=1000)
+    loc_result = LocationResult(location=location, official_alerts=[thunder, flood])
+    result = ComparisonResult(
+        locations=[loc_result], time_window=(0, 23), target_date=date.today(),
+    )
+
+    sms = render_compare_sms(result)
+    assert sms.count("!") == 1, (
+        f"Erwartet genau EIN '!' im gesamten Compare-SMS-Text, gefunden "
+        f"{sms.count('!')}: {sms!r}"
+    )
+    assert "!TH:" in sms, f"Das '!' muss unmittelbar vor dem ersten Warnblock-Token stehen: {sms!r}"
+    assert "FL:" in sms and "!FL:" not in sms, (
+        f"Das zweite Token desselben Blocks darf KEIN eigenes '!' tragen: {sms!r}"
+    )
+
+
+def test_telegram_zeigt_amtliche_warnung_ohne_ausrufezeichen_praefix():
+    """Test 16 / AC-15 (Nicht-Ziel-Nachweis Telegram, Trip UND Compare).
+
+    GIVEN dieselbe amtliche Warnung erreicht Trip-Telegram bzw.
+          Compare-Telegram
+    WHEN  die jeweilige Bubble/Nachricht gerendert wird
+    THEN  enthaelt der Text KEIN "!"-Praefix -- Telegram nutzt stattdessen
+          ausschliesslich die bestehende Emoji-Kennzeichnung (Trip UND
+          Compare bewusst kein Marker, PO-Korrektur 2026-07-23,
+          `comparison.py:723-725`).
+    """
+    from output.renderers.comparison import render_compare_telegram
+    from output.renderers.narrow import _official_alert_bubble
+
+    thunder, flood = _two_official_alerts()
+
+    trip_seg = _segment_with_alerts([thunder, flood])
+    trip_bubble = _official_alert_bubble([trip_seg], ZoneInfo("UTC"), trip=_trip())
+    assert trip_bubble is not None, "Vorbedingung: die Trip-Telegram-Bubble muss entstehen"
+    assert "!" not in trip_bubble.text, (
+        f"Trip-Telegram darf keinen '!'-Marker zeigen (Emoji-Kennzeichnung "
+        f"stattdessen): {trip_bubble.text!r}"
+    )
+
+    location = SavedLocation(id="loc-1614b", name="Testort", lat=LAT, lon=LON, elevation_m=1000)
+    loc_result = LocationResult(location=location, official_alerts=[thunder, flood])
+    result = ComparisonResult(
+        locations=[loc_result], time_window=(0, 23), target_date=date.today(),
+    )
+    compare_telegram = render_compare_telegram(result)
+    assert "!" not in compare_telegram, (
+        f"Compare-Telegram darf keinen '!'-Marker zeigen (Emoji-Kennzeichnung "
+        f"stattdessen): {compare_telegram!r}"
+    )

--- a/tests/tdd/test_official_alert_standalone_render.py
+++ b/tests/tdd/test_official_alert_standalone_render.py
@@ -44,7 +44,7 @@ SA_ORANGE_TO = datetime(2026, 7, 11, 20, 0, tzinfo=UTC)
 
 # Bestands-Code-Tokens (design_tokens.py G_ALERT_L2/L3/L4) — DIESE müssen im
 # Output stehen (AC-13).
-TOKEN_L2, TOKEN_L3, TOKEN_L4 = "#9a6f00", "#c8482a", "#6d28d9"
+TOKEN_L2, TOKEN_L3, TOKEN_L4 = "#8a6300", "#c8482a", "#6d28d9"  # #1614 WCAG-AA
 # Design-Vorlage-Hex (`.stufe`/`.meter`/`.dot`-Klassen) — DIESE dürfen NICHT im
 # Output erscheinen (AC-13).
 DESIGN_HEX_GELB, DESIGN_HEX_ORANGE, DESIGN_HEX_ROT = "#e8b81f", "#e07a1e", "#c43030"

--- a/tests/tdd/test_warn_block_render.py
+++ b/tests/tdd/test_warn_block_render.py
@@ -29,7 +29,7 @@ SA_ORANGE_TO = datetime(2026, 7, 11, 20, 0, tzinfo=UTC)
 # Design-Vorlage-Hex (`.wb`-Klassen) — DIESE dürfen NICHT im Output erscheinen.
 DESIGN_HEX = ("#e8b81f", "#e07a1e", "#c43030")
 # Bestands-Code-Tokens (design_tokens.py) — DIESE tragen die Severity-Farbe.
-TOKEN_L2, TOKEN_L3, TOKEN_L4 = "#9a6f00", "#c8482a", "#6d28d9"
+TOKEN_L2, TOKEN_L3, TOKEN_L4 = "#8a6300", "#c8482a", "#6d28d9"  # #1614 WCAG-AA
 
 
 def _alert(level: int, hazard: str, label: str, vf, vt, region="Hermagor", url=None):


### PR DESCRIPTION
Eine amtliche Warnung, die bereits im Trip-Briefing erscheint, wurde bis zu
15 Minuten spaeter vom unabhaengigen Alarm-Checker nochmal als eigene,
redundante Nachricht verschickt (belegt per Resend-Forensik am realen
Mail-Paar). Der Briefing-Pfad schreibt das Melde-Gedaechtnis jetzt ueber die
geteilte Funktion record_official_alerts_reported() mit, analog dem
Alarm-Checker-Muster aus #1467 S2 AG5.

Zusaetzlich: G_ALERT_L2 (Warnfarbe Stufe GELB) von #9a6f00 auf #8a6300
angehoben, da 4,11:1 Kontrast unter der WCAG-AA-Mindestgrenze (4,5:1) lag.

Kanal-Schwellen-Verdrahtung (#1461 S3b-2a/S3b-2b) und die "!"-Kennzeichnung
in der SMS (#1318/#1332) waren bereits korrekt implementiert -- dafuer nur
Regressionstests ergaenzt, kein neuer Produktivcode.

Adversary VERIFIED (4 Mutationen, alle gefangen inkl. Nachfass-Runde F001).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GeicPrxDfsCcpPrjyV4igJ
