### PR TITLE
fix(#1348): Warn-Kompensation statt STRENGE Einzelquellen-Regel

### DIFF
--- a/docs/context/fix-1348-warn-kompensation.md
+++ b/docs/context/fix-1348-warn-kompensation.md
@@ -1,0 +1,82 @@
+# Context: fix-1348-warn-kompensation
+
+## Request Summary
+
+PO-Korrektur vom 2026-07-30 zu Issue #1348 umsetzen: Der Briefing-Hinweis
+"amtliche Warnungen aktuell nicht abrufbar" soll für einen Ort nur noch
+erscheinen, wenn **keine** für diesen Ort zuständige Warn-Quelle erfolgreich
+geantwortet hat. Kompensation durch eine andere erfolgreiche, ebenfalls
+zuständige Quelle zählt. Die aktuelle Formel in
+`src/services/official_alerts/base.py:146` (`unavailable = covering > 0 and
+failed >= 1`) ist die davor gültige, jetzt abgelöste STRENGE Regel vom
+2026-07-23 und erzeugt Fehlalarme (Beleg: PO-Meldung Trip "KHW 403",
+30.07., GeoSphere lieferte 54× erfolgreich, nur MeteoAlarm war gesperrt,
+Hinweis erschien trotzdem für AT-Etappen).
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `src/services/official_alerts/base.py` | Kernlogik: `get_official_alerts_with_status()` (Zeile 90-176), Formel in Zeile 146 muss geändert werden; Docstring Zeile 98-116 referenziert die alte STRENGE Regel |
+| `tests/tdd/test_official_alerts_unavailable_hint.py` | `TestUnavailableSignal` (Zeile 105-239) — `test_mischfall_streng_one_fail_one_empty_is_unavailable` (Zeile 165-194) fixiert exakt das alte Verhalten und muss auf die neue Kompensationsregel umgestellt werden; Moduldocstring (Zeile 20-22) referenziert ebenfalls die alte Regel |
+| `src/services/trip_report_scheduler.py` | Aufrufer 1 (Zeile 802-818): setzt `sw.official_alerts_unavailable` je Segment für Trip-E-Mail/SMS — **kein Codeänderung nötig**, profitiert automatisch von der Formel-Korrektur in `base.py` |
+| `src/services/comparison_engine.py` | Aufrufer 2 (Zeile 322-341): setzt `official_alerts_unavailable` je Ort für Compare — **kein Codeänderung nötig**, gleicher Grund |
+| `docs/specs/modules/warn_unavailable_hint.md` | Ursprungs-Spec (status: draft, nie approved) dokumentiert die jetzt abgelöste STRENGE Formel als Implementierungsdetail — braucht Update oder Verweis auf neue Spec |
+
+## Existing Patterns
+
+- **Ein zentraler Signalgeber, viele Konsumenten:** `get_official_alerts_with_status()` ist die einzige Stelle, die `covering`/`failed` zählt; Trip-Scheduler und Compare-Engine rufen sie beide auf und reichen das Boolean nur weiter. Die Korrektur an einer Stelle wirkt für beide Kanäle — passt zur Projektvorgabe "möglichst viel Code zwischen Trip und Ortsvergleich teilen".
+- **Fail-soft ohne Exception:** echte Quellen (`GeoSphereWarnSource` etc.) werfen nie, sondern liefern bei Egress-Block/429 intern `[]` über `warn_egress.observe_fetch_failure()`. Das bestehende Testmuster unterscheidet daher "wirft" (`_AllCoveringFailSource`) von "fail-soft leer, aber real ausgefallen" (echte `GeoSphereWarnSource` + Egress-Block).
+- **Kein Mock-Theater:** Testquellen sind echte Objekte, die das `OfficialAlertSource`-Protocol strukturell erfüllen (`covers`/`fetch`/`name`), keine `Mock()`/`patch()`.
+
+## Dependencies
+
+- **Upstream:** `services.official_alerts.warn_egress` (Fail-Signal je Quelle), `services.official_alerts._REGISTERED_SOURCES` (Registry aller 5 amtlichen Quellen: MeteoAlarm, GeoSphere-Warn, Vigilance, Météo-Forêts, Massif-Closure)
+- **Downstream:** `trip_report_scheduler.py` → `SegmentWeatherData.official_alerts_unavailable` → E-Mail-Renderer (full/compact) + SMS-Renderer; `comparison_engine.py` → `LocationResult.official_alerts_unavailable` → Compare-HTML-Renderer. Keiner dieser Renderer muss geändert werden — sie konsumieren nur das Boolean.
+
+## Existing Specs
+
+- `docs/specs/modules/warn_unavailable_hint.md` (draft, nicht approved) — dokumentiert die ursprüngliche STRENGE Formel vom 2026-07-23 als Bestandteil der Implementierung. Braucht in `/30-write-spec` eine Korrektur der Formel-Beschreibung (nicht zwingend eine neue Datei, da `warn_unavailable_hint` bereits das richtige Modul referenziert).
+- `docs/specs/modules/feat_1349_compare_unavailable.md`, `feat_1349_sms_unavailable.md`, `feat_1349_telegram_unavailable.md` — Folge-Specs für die Anzeige des Flags in weiteren Kanälen; unverändert betroffen, da sie nur das Boolean konsumieren.
+
+## Risks & Considerations
+
+- **Sicherheitsrelevant:** eine zu lockere Formel darf keine echte Lücke verschlucken. `failed >= covering` (ALLE zuständigen Quellen ausgefallen) statt `failed >= 1` ist die korrekte Übersetzung der PO-Korrektur — bei nur einer zuständigen Quelle bleibt das Verhalten unverändert streng (`covering=1, failed=1` -> weiterhin `unavailable=True`).
+- **PO-Aussage zu Südtirol ist zwischenzeitlich überholt (wichtig fuer die Spec!):** Die PO-Korrektur vom 2026-07-30 nennt als Beispiel "Fuer die Suedtirol-Etappen ist MeteoAlarm die einzige Quelle, dort bleibt der Hinweis korrekt". Das stimmte am 2026-07-30, ist aber seit **2026-07-31** (`23118c36`, #1427 S2) nicht mehr aktuell: `DpcSource` deckt seither denselben IT-Bbox-Bereich (lat 36.0-47.5, lon 6.5-19.0) zusätzlich ab — Südtirol liegt darin. Seit **2026-08-01** (`9c20f482`, #1445 S1+S3) laeuft AT+IT zudem ueber `MeteoAlarmFeedSource(country)` statt der alten `MeteoAlarmSource` (EDR-Index, jetzt ruhend/unregistriert). Registrierte Quellen heute (`services/official_alerts/__init__.py:36-42`): `VigilanceSource, MeteoForetsSource, MassifClosureSource, GeoSphereWarnSource, MeteoAlarmFeedSource("IT"), MeteoAlarmFeedSource("AT"), DpcSource`. **Fuer einen Suedtirol-Punkt decken heute ZWEI Quellen ab** (`MeteoAlarmFeedSource("IT")` + `DpcSource`), nicht mehr eine. Ob der Hinweis dort bei einem MeteoAlarm-Ausfall weiterhin erscheinen soll, haengt jetzt vom DpcSource-Status ab, nicht mehr automatisch von "es gibt nur eine Quelle". **Offene Frage fuer die Spec:** AC so formulieren, dass sie die reale Quellenlage von heute prueft, nicht das veraltete Einzelquellen-Beispiel des PO-Kommentars.
+- **Regressionsgefahr:** `test_mischfall_streng_one_fail_one_empty_is_unavailable` erwartet aktuell `unavailable is True` für den Kompensationsfall — dieser Test MUSS mit umgedreht werden (neuer Name + neue Assertion), sonst bleibt die alte Regel grün eingefroren.
+- **Realpfad-Nachweis explizit vom PO gefordert:** "ein Test, der genau die heutige Prod-Lage abbildet ... vor dem Fix rot." Die im PO-Kommentar genannten Quellen (`GeoSphere` + `MeteoAlarm`) muessen fuer den echten Regressionstest durch die AKTUELL registrierten Klassen ersetzt werden: `GeoSphereWarnSource` + `MeteoAlarmFeedSource("AT")` fuer den AT-Kompensationsfall; fuer den IT-Fall entweder zwei echte IT-Quellen (`MeteoAlarmFeedSource("IT")` + `DpcSource`) mit EINER ausgefallenen (weiterhin `unavailable=False`, kompensiert) ODER — falls die Spec bewusst den strengeren Alt-Fall erhalten will — eine isolierte Registry mit nur einer IT-Quelle.
+- **Docstrings synchron halten:** sowohl `base.py:98-116` als auch der Moduldocstring von `test_official_alerts_unavailable_hint.py` referenzieren wörtlich die "STRENGE" 2026-07-23-Regel — beide müssen auf die 2026-07-30-Korrektur aktualisiert werden, sonst widerspricht die Doku dem Code (bekanntes Muster aus früheren Findings in diesem Projekt).
+
+## Analysis
+
+### Type
+Bug (Korrektur: aktuelles Verhalten entspricht nicht mehr der gültigen PO-Entscheidung vom 2026-07-30)
+
+### Affected Files (with changes)
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/services/official_alerts/base.py` | MODIFY | Zeile 146: `unavailable = covering > 0 and failed >= 1` → `unavailable = covering > 0 and failed >= covering`; Docstring Zeile 98-116 auf Kompensationsregel umschreiben |
+| `tests/tdd/test_official_alerts_unavailable_hint.py` | MODIFY | Mischfall-Test umdrehen (neue Assertion + neuer Name), Moduldocstring-Referenz korrigieren, neuen Realpfad-Test mit aktuell registrierten Quellen (`GeoSphereWarnSource`, `MeteoAlarmFeedSource`, `DpcSource`) ergänzen |
+| `docs/specs/modules/warn_unavailable_hint.md` | MODIFY | Formel-Beschreibung in "Implementation Details" auf Kompensationsregel korrigieren (war nie approved, kann direkt korrigiert werden) |
+
+Keine Änderung nötig an: `trip_report_scheduler.py`, `comparison_engine.py` (konsumieren nur das Boolean), allen Renderern (E-Mail/SMS/Compare).
+
+### Scope Assessment
+- Files: 3 (1 Produktivdatei, 1 Testdatei, 1 Spec-Korrektur)
+- Estimated LoC: ~10 (base.py) + ~40-60 (Testdatei: 1 Test umgeschrieben, 1 neuer Realpfad-Test) + Spec-Text
+- Risk Level: LOW — zentrale, gut isolierte Funktion; alle Aufrufer bereits über Tests abgesichert; keine Renderer-Änderung
+
+### Technical Approach
+1. Formel in `base.py:146` ändern: `covering > 0 and failed >= covering` (statt `failed >= 1`). Bei genau einer zuständigen Quelle bleibt das Verhalten identisch streng — nur bei ≥2 zuständigen Quellen wirkt jetzt Kompensation.
+2. Docstrings (Code + Test) von "STRENG, eine Quelle genügt" auf "nur wenn ALLE zuständigen Quellen ausgefallen sind" umstellen, Referenz auf PO-Entscheid 2026-07-30 statt 2026-07-23.
+3. Bestehenden Mischfall-Test umdrehen: gleiches Setup (`_AllCoveringFailSource` + `_SuccessEmptySource`), aber `unavailable is False` erwarten (kompensiert).
+4. Neuen Realpfad-Test mit den HEUTE registrierten Quellklassen ergänzen, der die tatsächliche Prod-Quellenlage abbildet (nicht die veraltete "MeteoAlarm einzige IT-Quelle"-Annahme) — echter Nachweis ohne Mock-Theater, analog zum bestehenden `test_real_failsoft_empty_from_blocked_source_is_unavailable`-Muster.
+5. Spec-Datei `warn_unavailable_hint.md` Formel-Abschnitt korrigieren.
+
+### Dependencies
+- `services.official_alerts.__init__` — Registry-Liste, für den Realpfad-Test relevant (welche Quellen sind heute aktiv)
+- `services.official_alerts.warn_egress` — Fail-Signal-Mechanik bleibt unverändert
+- Keine neuen externen Abhängigkeiten
+
+### Open Questions
+- [x] Soll die Spec das PO-Beispiel "Südtirol = nur eine Quelle" wörtlich reproduzieren, oder die reale heutige Zwei-Quellen-Lage als Grundlage nehmen? **PO-Entscheid (2026-08-09): reale heutige Lage.** Der Realpfad-Test nutzt `MeteoAlarmFeedSource("IT")` + `DpcSource` für Südtirol-Punkte; fällt nur eine der beiden aus, greift jetzt auch dort die Kompensation (kein Hinweis mehr). Der strenge Alt-Fall (nur eine zuständige Quelle) bleibt trotzdem über `test_all_covering_fail_is_unavailable` / `test_real_failsoft_empty_from_blocked_source_is_unavailable` (Innsbruck, nur GeoSphere in isolierter Registry) abgedeckt.

--- a/docs/specs/modules/fix_1348_warn_kompensation.md
+++ b/docs/specs/modules/fix_1348_warn_kompensation.md
@@ -1,0 +1,167 @@
+---
+entity_id: fix_1348_warn_kompensation
+type: module
+created: 2026-08-09
+updated: 2026-08-09
+status: draft
+version: "1.0"
+tags: [official-alerts, safety, issue-1348]
+---
+
+# Fix: Amtliche-Warnungen-Hinweis nur bei echter Lücke (Kompensation zählt)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Der Briefing-Hinweis "amtliche Warnungen aktuell nicht abrufbar" wird heute
+schon dann gesetzt, wenn EINE von mehreren für einen Ort zuständigen
+Warn-Quellen ausfällt — auch wenn eine andere zuständige Quelle erfolgreich
+geantwortet hat. Das erzeugt Fehlalarme (belegt: Trip "KHW 403", 30.07.,
+GeoSphere lieferte durchgehend erfolgreich, nur MeteoAlarm war gesperrt,
+Hinweis erschien trotzdem). Ein Sicherheitshinweis, der auch ohne echte
+Lücke erscheint, wird überlesen. Dieses Modul stellt die PO-Korrektur vom
+2026-07-30 her: der Hinweis erscheint nur noch, wenn KEINE für den Ort
+zuständige Quelle erfolgreich geantwortet hat.
+
+## Source
+
+- **File:** `src/services/official_alerts/base.py`
+- **Identifier:** `def get_official_alerts_with_status`, Formelzeile (aktuell `unavailable = covering > 0 and failed >= 1`)
+
+Python-Core / Domain-Backend (`src/services/`) — keine andere Schicht betroffen.
+
+## Estimated Scope
+
+- **LoC:** ~60-80
+- **Files:** 3 (1 Produktivdatei, 1 Testdatei, 1 bestehende Spec-Korrektur)
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `services.official_alerts.base.OfficialAlertSource` | Protocol | Quellen-Interface (`covers`, `fetch`, `name`) |
+| `services.official_alerts.base._REGISTERED_SOURCES` | module-state | Registry aller amtlichen Quellen, wird iteriert |
+| `services.official_alerts.warn_egress.observe_fetch_failure` | context manager | erkennt fail-soft-Ausfälle ohne Exception (Real-Pfad) |
+| `services.official_alerts.__init__` | registry | heute registriert: `VigilanceSource, MeteoForetsSource, MassifClosureSource, GeoSphereWarnSource, MeteoAlarmFeedSource("IT"), MeteoAlarmFeedSource("AT"), DpcSource` |
+| `services.trip_report_scheduler.TripReportScheduler` | service | Konsument, keine Codeänderung |
+| `services.comparison_engine` | service | Konsument, keine Codeänderung |
+| ADR-0018 | decision | "Provider-Fallback ohne Kaschieren" — dieselbe Leitidee: Ausweichen erlaubt, solange keine echte Lücke entsteht |
+
+## Implementation Details
+
+Formel in `get_official_alerts_with_status()` ändern:
+
+```
+# Vorher (PO-Entscheid 2026-07-23, STRENG — abgelöst):
+unavailable = covering > 0 and failed >= 1
+
+# Nachher (PO-Entscheid 2026-07-30 — Kompensation zählt):
+unavailable = covering > 0 and failed >= covering
+```
+
+`covering` und `failed` werden unverändert gezählt (kein Änderungsbedarf an
+der Zähl-Logik selbst, nur an der Ableitung des Booleans daraus). Bei genau
+einer zuständigen Quelle ist `failed >= covering` äquivalent zu `failed >= 1`
+— das strenge Verhalten für Orte mit nur einer zuständigen Quelle bleibt
+unverändert. Erst ab zwei oder mehr zuständigen Quellen wirkt Kompensation:
+eine erfolgreiche zuständige Quelle genügt, um `unavailable=False` zu halten.
+
+Docstring der Funktion (aktuell Zeile 98-116) wird auf die neue Regel
+umgeschrieben; ebenso der Moduldocstring von
+`tests/tdd/test_official_alerts_unavailable_hint.py` (referenziert aktuell
+wörtlich "PO-Entscheid 2026-07-23, STRENG").
+
+## Expected Behavior
+
+- **Input:** Koordinaten eines Orts; Zustand der registrierten amtlichen
+  Warn-Quellen (deckt ab ja/nein, Fetch erfolgreich/ausgefallen)
+- **Output:** `(alerts: list[OfficialAlert], unavailable: bool)` — Signatur
+  unverändert
+- **Side effects:** keine (reine Berechnung, kein neuer Zustand)
+
+## Acceptance Criteria
+
+- **AC-1:** Given zwei für einen Ort zuständige Quellen, eine fällt beim
+  Fetch aus (wirft), die andere liefert erfolgreich (auch leer) / When
+  `get_official_alerts_with_status()` aufgerufen wird / Then
+  `unavailable=False` (Kompensation greift — Kern der PO-Korrektur).
+  - Test: bestehenden Test `test_mischfall_streng_one_fail_one_empty_is_unavailable`
+    umbenennen (`test_mischfall_kompensiert_one_fail_one_success_is_available`)
+    und Assertion auf `unavailable is False` umdrehen.
+
+- **AC-2:** Given zwei für einen Ort zuständige Quellen, BEIDE fallen beim
+  Fetch aus / When der Status berechnet wird / Then `unavailable=True`
+  (keine Kompensation möglich, wenn nichts übrig bleibt, das kompensieren
+  könnte).
+  - Test: neuer Test mit zwei `_AllCoveringFailSource`-artigen Quellen (oder
+    einer zweiten Fail-Quelle zusätzlich zur bestehenden), erwartet
+    `unavailable is True`.
+
+- **AC-3:** Given genau EINE für einen Ort zuständige Quelle, diese fällt
+  aus / When der Status berechnet wird / Then `unavailable=True`
+  (Regressionswächter: bei nur einer Quelle bleibt das Verhalten so streng
+  wie zuvor — keine Kompensation ohne Kompensationspartner).
+  - Test: bestehender Test `test_all_covering_fail_is_unavailable` bleibt
+    unverändert grün (dient als Regressionsnachweis für diesen Fall).
+
+- **AC-4:** Given keine für den Ort zuständige Quelle / When der Status
+  berechnet wird / Then `unavailable=False` (unverändert, kein
+  Fehlalarm ohne Zuständigkeit).
+  - Test: bestehender Test `test_non_covering_is_available` bleibt
+    unverändert grün.
+
+- **AC-5 (Realpfad AT, PO-Vorfall):** Given die heute registrierten
+  AT-Quellen `GeoSphereWarnSource` (liefert erfolgreich, echter Objekt-Pfad)
+  und `MeteoAlarmFeedSource("AT")` (Egress-Block simuliert real-blockiert,
+  fail-soft `[]` ohne Exception) für einen österreichischen Punkt / When der
+  Status berechnet wird / Then `unavailable=False` — genau der am 30.07.
+  gemeldete Fehlalarm-Fall ist jetzt korrekt.
+  - Test: neuer Realpfad-Test mit den ECHTEN, heute registrierten Klassen
+    (kein Double), analog zum bestehenden Muster mit
+    `GeoSphereWarnSource`/Egress-Guard.
+
+- **AC-6 (Realpfad IT/Südtirol, reale heutige Quellenlage):** Given die
+  heute registrierten IT-Quellen `MeteoAlarmFeedSource("IT")`
+  (real-blockiert, fail-soft `[]`) und `DpcSource` (liefert erfolgreich,
+  auch leer) für einen Südtirol-Punkt / When der Status berechnet wird /
+  Then `unavailable=False` — reflektiert die REALE heutige Zwei-Quellen-Lage
+  für Südtirol (nicht das am 2026-07-30 noch gültige, seit `DpcSource`
+  (2026-07-31) überholte Einzelquellen-Beispiel aus dem PO-Kommentar).
+  - Test: neuer Realpfad-Test, echte Klassen, PO-Entscheid 2026-08-09
+    (reale Lage statt Alt-Beispiel).
+
+- **AC-7 (Regression, unverändert bestehender Realpfad-Test):** Given eine
+  einzelne, im Egress-Wächter blockierte Quelle (`GeoSphereWarnSource`,
+  isolierte Registry mit nur dieser einen Quelle) / When der Status
+  berechnet wird / Then `unavailable=True` — bleibt der bestehende
+  Regressionswächter `test_real_failsoft_empty_from_blocked_source_is_unavailable`
+  unverändert grün.
+
+## Known Limitations
+
+- Der Warn-Lücken-Hinweis existiert weiterhin nur im E-Mail-Trip-Briefing
+  (full+compact); SMS/Telegram/Compare-Mail sind laut #1348-Kommentar
+  bewusste Folge-Scheiben, kein Blocker dieser Korrektur.
+- `DpcSource` hat eigene bekannte Grenzen (Zonen-Drift, #1434) — diese
+  Korrektur ändert nichts an der Zuverlässigkeit einzelner Quellen, nur an
+  der Ableitung von `unavailable` aus dem kombinierten Quellenstatus.
+- Coverage-Grenzen einzelner Quellen (z.B. INCA-Bbox reicht über
+  Österreich hinaus, #1397) bleiben wie dokumentiert unverändert bestehen —
+  außerhalb des Scopes dieser Korrektur.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine (neue)
+- **Rationale:** Setzt ADR-0018 ("Provider-Fallback ohne Kaschieren") konsequent
+  um — Ausweichen auf eine kompensierende Quelle ist erlaubt, solange keine
+  echte Lücke entsteht; fällt die letzte zuständige Quelle auch aus, wird das
+  weiterhin laut gemeldet, nicht kaschiert. Kein neuer Architektur-Entscheid
+  nötig, nur eine Formel-Korrektur innerhalb der bestehenden Entscheidung.
+
+## Changelog
+
+- 2026-08-09: Initial spec created (Korrektur der PO-Entscheidung 2026-07-30 zu #1348)

--- a/docs/specs/modules/warn_unavailable_hint.md
+++ b/docs/specs/modules/warn_unavailable_hint.md
@@ -76,10 +76,22 @@ for source in _REGISTERED_SOURCES:
         results.extend(source.fetch(lat, lon))
     except Exception:
         logger.warning(...); failed += 1
-unavailable = covering > 0 and failed >= 1   # PO-Entscheid 2026-07-23: STRENG —
-# schon EINE ausgefallene abdeckende Quelle genügt (eine ausgefallene Quelle
-# hätte eine Warnung tragen können, die die anderen nicht abdecken).
+unavailable = covering > 0 and failed >= covering   # PO-Entscheid 2026-07-30:
+# KOMPENSATION — der Hinweis erscheint nur bei einer ECHTEN Lücke, also wenn
+# ALLE zuständigen Quellen ausgefallen sind. Eine erfolgreiche zuständige
+# Quelle (auch leer) kompensiert die ausgefallenen.
 ```
+
+> **Korrektur (PO-Entscheid 2026-07-30, umgesetzt 2026-08-09):** Die
+> ursprünglich hier stehende STRENGE Formel `unavailable = covering > 0 and
+> failed >= 1` (PO-Entscheid 2026-07-23) ist **abgelöst**. Sie erzeugte
+> Fehlalarme, sobald EINE von mehreren zuständigen Quellen ausfiel, obwohl
+> eine andere erfolgreich antwortete (Beleg: Trip „KHW 403", 30.07. —
+> GeoSphere lieferte durchgehend, nur MeteoAlarm war gesperrt, der Hinweis
+> erschien trotzdem). Bei genau EINER zuständigen Quelle ist
+> `failed >= covering` äquivalent zu `failed >= 1`, das strenge Verhalten
+> bleibt dort unverändert. Maßgebliche Spec der Korrektur:
+> `docs/specs/modules/fix_1348_warn_kompensation.md`.
 
 `get_official_alerts_for_location()` wird zum duennen Wrapper
 (`alerts, _ = get_official_alerts_with_status(...); return alerts`) — Vertrag
@@ -217,13 +229,13 @@ echte Objekte statt Mock/patch):
 - **Orts-Vergleich (Compare-Mail) ist NICHT Teil dieser Scheibe.**
   `PointWeatherData`/`compare_html.py`/`comparison.py` bekommen das
   `unavailable`-Flag hier nicht — Folge-Issue, falls PO das priorisiert.
-- **Partial-Failure gilt als "unavailable" (PO-Entscheid 2026-07-23, STRENG):**
-  schon EINE ausgefallene abdeckende Quelle löst den Hinweis aus — auch wenn
-  eine andere abdeckende Quelle für denselben Ort gleichzeitig erfolgreich
-  (auch leer) antwortet. Begründung: die ausgefallene Quelle hätte eine
-  Warnung tragen können, die die andere nicht abdeckt; „konnten wir nicht
-  prüfen" ist die sichere Aussage. Nur wenn ALLE abdeckenden Quellen erfolgreich
-  antworten, erscheint kein Hinweis.
+- **Partial-Failure-Formel korrigiert (PO-Entscheid 2026-07-30, umgesetzt
+  2026-08-09):** die Ableitung von "unavailable" aus den Quellenstatus ist
+  nicht mehr Teil dieser Spec, sondern maßgeblich in
+  `docs/specs/modules/fix_1348_warn_kompensation.md` dokumentiert
+  (Kompensation: eine erfolgreiche zuständige Quelle kompensiert eine
+  ausgefallene; der Hinweis erscheint nur, wenn ALLE zuständigen Quellen
+  ausgefallen sind).
 - **Segment-Dedup-Verhalten unveraendert:** `trip_report_scheduler.py` fetcht
   amtliche Warnungen nur einmal je eindeutiger Segment-Koordinate
   (`seen_coords`); das neue Flag wird nur auf dem zuerst gefetchten Segment
@@ -244,3 +256,6 @@ echte Objekte statt Mock/patch):
 ## Changelog
 
 - 2026-07-23: Initial spec created
+- 2026-08-09: Known-Limitations-Absatz zur Partial-Failure-Formel korrigiert
+  (Verweis auf `fix_1348_warn_kompensation.md` statt veraltete STRENGE Regel
+  als aktuell darzustellen)

--- a/src/services/official_alerts/base.py
+++ b/src/services/official_alerts/base.py
@@ -98,11 +98,22 @@ def get_official_alerts_with_status(
     """Wie ``get_official_alerts_for_location``, liefert zusaetzlich einen
     ``unavailable``-Status (Issue #1348).
 
-    ``unavailable = covering > 0 and failed >= 1`` (PO-Entscheid 2026-07-23,
-    STRENG): schon EINE abdeckende, beim Fetch ausgefallene Quelle genuegt —
-    sie haette eine Warnung tragen koennen, die die anderen Quellen nicht
-    abdecken. Fehlt Coverage ganz (``covering == 0``) oder liefern ALLE
-    abdeckenden Quellen erfolgreich (auch leer), ist ``unavailable = False``.
+    ``unavailable = covering > 0 and failed >= covering`` (PO-Entscheid
+    2026-07-30, KOMPENSATION — loest die STRENGE Regel vom 2026-07-23 ab):
+    der Hinweis entsteht nur bei einer ECHTEN Luecke, also wenn ALLE fuer den
+    Punkt zustaendigen Quellen ausgefallen sind. Antwortet auch nur EINE
+    zustaendige Quelle erfolgreich (auch leer), kompensiert sie die
+    ausgefallenen -> ``unavailable = False``. Fehlt Coverage ganz
+    (``covering == 0``), ist ``unavailable = False`` (kein Fehlalarm ohne
+    Zustaendigkeit).
+
+    Bei GENAU EINER zustaendigen Quelle ist ``failed >= covering`` aequivalent
+    zu ``failed >= 1`` — dort bleibt das Verhalten unveraendert streng, es gibt
+    keinen Kompensationspartner. Erst ab zwei zustaendigen Quellen wirkt die
+    Kompensation. Grund der Korrektur: ein Sicherheitshinweis, der auch ohne
+    echte Luecke erscheint, wird ueberlesen (Beleg: Trip "KHW 403", 30.07.,
+    GeoSphere lieferte durchgehend erfolgreich, nur MeteoAlarm war gesperrt,
+    der Hinweis erschien trotzdem).
 
     "Ausgefallen" umfasst ZWEI Faelle (Issue #1348 Fix-Loop): (a) ``fetch()``
     wirft eine Exception; (b) ``fetch()`` liefert fail-soft ``[]``, obwohl ein
@@ -143,7 +154,7 @@ def get_official_alerts_with_status(
         # die Quelle lieferte fail-soft [], war aber real nicht abrufbar.
         if fetch_status["failed"]:
             failed += 1
-    unavailable = covering > 0 and failed >= 1
+    unavailable = covering > 0 and failed >= covering
 
     if now is None:
         now = datetime.now(timezone.utc)

--- a/tests/tdd/test_official_alerts_unavailable_hint.py
+++ b/tests/tdd/test_official_alerts_unavailable_hint.py
@@ -1,6 +1,7 @@
 """TDD RED — Issue #1348-Rest: Briefing-Hinweis "amtliche Warnungen nicht abrufbar".
 
 SPEC: docs/specs/modules/warn_unavailable_hint.md (AC-1 … AC-6)
+SPEC: docs/specs/modules/fix_1348_warn_kompensation.md (AC-1 … AC-7, Klasse TestUnavailableSignal)
 
 Diese Tests schlagen JETZT absichtlich fehl — das Feature existiert noch nicht:
 - `services.official_alerts.base.get_official_alerts_with_status` -> AttributeError
@@ -17,9 +18,16 @@ Codepfad laufen. Kein `Mock()`/`patch()`/`MagicMock`. Kein Live-Netz — die
 
 Vorbild-Muster: tests/tdd/test_issue_1034_official_alerts_foundation.py.
 
-PO-Entscheid 2026-07-23 (STRENG): `unavailable = (es gibt abdeckende Quellen)
-AND (mindestens EINE davon ist beim Fetch fehlgeschlagen)` — NICHT "alle
-fehlgeschlagen". Der Mischfall-Test unten ist der Kern dieser Entscheidung.
+PO-Entscheid 2026-07-30 (loest die STRENGE Regel vom 2026-07-23 ab, Issue
+#1348 Restpunkt): `unavailable = (es gibt abdeckende Quellen) AND (ALLE
+davon sind beim Fetch fehlgeschlagen)`. Kompensation durch eine andere
+erfolgreiche, ebenfalls zustaendige Quelle zaehlt -- ein Sicherheitshinweis,
+der auch ohne echte Luecke erscheint, wird ueberlesen (Beleg: Trip "KHW 403",
+30.07., GeoSphere lieferte durchgehend erfolgreich, nur MeteoAlarm war
+gesperrt, der Hinweis erschien trotzdem). Bei GENAU EINER zustaendigen
+Quelle bleibt das Verhalten unveraendert streng (`failed >= covering` ist
+dort aequivalent zu `failed >= 1`). Der Mischfall-Test unten ist der Kern
+dieser Entscheidung.
 """
 from __future__ import annotations
 
@@ -162,14 +170,17 @@ class TestUnavailableSignal:
             oa_base._REGISTERED_SOURCES.clear()
             oa_base._REGISTERED_SOURCES.extend(backup)
 
-    def test_mischfall_streng_one_fail_one_empty_is_unavailable(self):
-        """KERN DER PO-ENTSCHEIDUNG (STRENG): eine deckende Quelle wirft, eine
-        deckende Quelle liefert erfolgreich [] -> unavailable=True.
+    def test_mischfall_kompensiert_one_fail_one_success_is_available(self):
+        """KERN DER PO-KORREKTUR (2026-07-30): eine deckende Quelle wirft, eine
+        andere deckende Quelle liefert erfolgreich [] -> unavailable=False.
 
-        Schon EINE ausgefallene abdeckende Quelle genuegt — sie haette eine
-        Warnung tragen koennen, die die andere Quelle nicht abdeckt. Die frueher
-        diskutierte "alle muessen fehlschlagen"-Variante wuerde hier faelschlich
-        unavailable=False liefern; genau das schliesst dieser Test aus.
+        Die erfolgreiche zustaendige Quelle KOMPENSIERT die ausgefallene --
+        genau der am 30.07. gemeldete Fehlalarm-Fall (GeoSphere ok, nur
+        MeteoAlarm gesperrt, Hinweis erschien trotzdem faelschlich). Die
+        fruehere STRENGE Variante ("eine ausgefallene Quelle genuegt") ist
+        damit abgeloest; dieser Test war vor der Korrektur GRUEN mit
+        `unavailable is True` und wird durch den Formel-Fix (`failed >=
+        covering` statt `failed >= 1`) auf `unavailable is False` umgedreht.
         """
         import services.official_alerts.base as oa_base
         from services.official_alerts.base import get_official_alerts_with_status
@@ -184,14 +195,226 @@ class TestUnavailableSignal:
                 f"Nur die (werfende) Fail-Quelle deckt ab; die Empty-Quelle liefert "
                 f"[] -> Gesamt-Alertliste leer, war {alerts!r}"
             )
-            assert unavailable is True, (
-                "STRENG (PO-Entscheid 2026-07-23): eine ausgefallene abdeckende "
-                "Quelle genuegt fuer unavailable=True, auch wenn eine andere "
-                "abdeckende Quelle erfolgreich [] liefert."
+            assert unavailable is False, (
+                "PO-Entscheid 2026-07-30: eine erfolgreiche zustaendige Quelle "
+                "kompensiert eine ausgefallene zustaendige Quelle am selben Ort "
+                "-> unavailable=False, kein Fehlalarm mehr."
             )
         finally:
             oa_base._REGISTERED_SOURCES.clear()
             oa_base._REGISTERED_SOURCES.extend(backup)
+
+    def test_beide_covering_quellen_fallen_aus_is_unavailable(self):
+        """AC-2: zwei zustaendige Quellen, BEIDE fallen beim Fetch aus ->
+        unavailable=True. Keine Kompensation moeglich, wenn nichts uebrig
+        bleibt, das kompensieren koennte -- Gegenprobe zu AC-1, damit die
+        Formel nicht versehentlich auf 'irgendeine Quelle deckt ab' entartet."""
+        import services.official_alerts.base as oa_base
+        from services.official_alerts.base import get_official_alerts_with_status
+
+        class _SecondCoveringFailSource:
+            @property
+            def name(self) -> str:
+                return "test-covering-fail-2"
+
+            def covers(self, lat: float, lon: float) -> bool:
+                return True
+
+            def fetch(self, lat: float, lon: float):
+                raise RuntimeError("zweite simulierte Quelle faellt ebenfalls aus")
+
+        backup = list(oa_base._REGISTERED_SOURCES)
+        oa_base._REGISTERED_SOURCES.clear()
+        try:
+            oa_base._REGISTERED_SOURCES.append(_AllCoveringFailSource())
+            oa_base._REGISTERED_SOURCES.append(_SecondCoveringFailSource())
+            alerts, unavailable = get_official_alerts_with_status(_LAT, _LON)
+            assert alerts == []
+            assert unavailable is True, (
+                "Fallen ALLE zustaendigen Quellen aus, bleibt kein Kompensations-"
+                "Partner uebrig -> unavailable=True bleibt bestehen."
+            )
+        finally:
+            oa_base._REGISTERED_SOURCES.clear()
+            oa_base._REGISTERED_SOURCES.extend(backup)
+
+    def test_realpath_at_geosphere_erfolg_kompensiert_meteoalarm_blockiert(self):
+        """AC-5 REAL-PFAD (PO-Vorfall 30.07., Trip "KHW 403"): die HEUTE in
+        Prod registrierten AT-Quellen `GeoSphereWarnSource` (erfolgreich,
+        via genuinem Cache-Treffer -- kein Live-Netz) und
+        `MeteoAlarmFeedSource("AT")` (real geblockt, `feeds.meteoalarm.org`
+        steht im Egress-Waechter auf BLOCKED) fuer einen oesterreichischen
+        Punkt -> unavailable=False. Genau der Fehlalarm, den die PO-Korrektur
+        beheben sollte, jetzt mit den ECHTEN Quellklassen nachgestellt.
+
+        Kein Mock-Theater, kein Live-Netz: `GeoSphereWarnSource` bekommt einen
+        echten, aber MANUELL VORGEFUELLTEN Cache-Treffer (identisches Muster
+        zu `tests/tdd/test_warn_services_rest.py::test_cache_hit_kein_call`)
+        -- ihr `fetch()` laeuft dadurch ueber den echten Cache-Hit-Zweig von
+        `warn_egress.cached_fetch()`, ohne jemals `request_fn()` aufzurufen.
+        `MeteoAlarmFeedSource("AT")` faellt ueber den bereits bestehenden,
+        real geblockten Host aus (identischer Mechanismus wie im
+        Regressionswaechter oben)."""
+        import time as time_module
+
+        import services.official_alerts.base as oa_base
+        from services.official_alerts.base import get_official_alerts_with_status
+        from services.official_alerts.geosphere_warn import (
+            GeoSphereWarnSource, _cache as _geosphere_cache, _round_coord,
+            CACHE_TTL as _GEOSPHERE_CACHE_TTL,
+        )
+        from services.official_alerts.meteoalarm_feed import (
+            MeteoAlarmFeedSource, _cache as _meteoalarm_feed_cache,
+        )
+
+        # Innsbruck -- in der GeoSphere-/INCA-Bbox (covers=True fuer beide Quellen).
+        at_lat, at_lon = 47.26, 11.39
+
+        backup = list(oa_base._REGISTERED_SOURCES)
+        oa_base._REGISTERED_SOURCES.clear()
+        _geosphere_cache.clear()
+        _meteoalarm_feed_cache.clear()
+        try:
+            geosphere = GeoSphereWarnSource()
+            meteoalarm_at = MeteoAlarmFeedSource("AT")
+            assert geosphere.covers(at_lat, at_lon) is True
+            assert meteoalarm_at.covers(at_lat, at_lon) is True
+
+            # Echter Cache-Treffer: GeoSphere "hat gerade erfolgreich leer
+            # geantwortet" -- keine Warnungen fuer Innsbruck, ohne Netz.
+            # WICHTIG: ``gemeindenr`` MUSS gesetzt sein (formgueltig, laut
+            # ``_ist_auswertbare_gemeindenr``) -- ``_zone_for_point_at()``
+            # liest dasselbe GeoSphere-Cache-Objekt weiter, um die AT-EMMA-
+            # Zone aufzuloesen. OHNE ``gemeindenr`` waere die Zone ``None``
+            # ("nicht zustaendig", Fall 1) und ``MeteoAlarmFeedSource("AT")``
+            # wuerde ``_get_cached_feed("AT")`` NIE aufrufen -- der geblockte
+            # Host bliebe unerreicht, der Test wuerde faelschlich SCHON VOR
+            # dem Fix gruen sein (genau dieser Fehler flog beim ersten
+            # Testlauf auf: 0 statt 1 ausgefallene Quelle).
+            _geosphere_cache[_round_coord(at_lat, at_lon)] = {
+                "data": {
+                    "properties": {
+                        "location": {
+                            "properties": {
+                                "name": "Innsbruck (Test)",
+                                "gemeindenr": "70101",
+                            }
+                        },
+                        "warnings": [],
+                    }
+                },
+                "fetched_at": time_module.monotonic(),
+                "ttl": _GEOSPHERE_CACHE_TTL,
+            }
+
+            oa_base._REGISTERED_SOURCES.append(geosphere)
+            oa_base._REGISTERED_SOURCES.append(meteoalarm_at)
+
+            alerts, unavailable = get_official_alerts_with_status(at_lat, at_lon)
+            assert alerts == [], (
+                f"Beide Quellen liefern keine aktiven Warnungen, war {alerts!r}"
+            )
+            assert unavailable is False, (
+                "GeoSphere liefert erfolgreich (auch leer), MeteoAlarm ist "
+                "geblockt -> die erfolgreiche Quelle kompensiert -> "
+                "unavailable=False. Der 30.07.-Fehlalarm ist damit behoben."
+            )
+        finally:
+            oa_base._REGISTERED_SOURCES.clear()
+            oa_base._REGISTERED_SOURCES.extend(backup)
+            _geosphere_cache.clear()
+            _meteoalarm_feed_cache.clear()
+
+    def test_realpath_suedtirol_dpc_erfolg_kompensiert_meteoalarm_blockiert(self):
+        """AC-6 REAL-PFAD (reale heutige Quellenlage, PO-Entscheid 2026-08-09):
+        das im urspruenglichen PO-Kommentar (30.07.) genannte Beispiel
+        "fuer Suedtirol ist MeteoAlarm die einzige Quelle" ist seit
+        `DpcSource` (2026-07-31, #1427 S2) ueberholt -- ein Suedtirol-Punkt
+        wird HEUTE von ZWEI Quellen abgedeckt: `MeteoAlarmFeedSource("IT")`
+        und `DpcSource`. Faellt nur MeteoAlarm aus (real geblockter Host),
+        kompensiert DpcSource -> unavailable=False.
+
+        Kein Mock-Theater, kein Live-Netz: der DPC-Zonencode fuer den
+        Testpunkt wird ueber die ECHTE Zonen-Geometrie (`_zone_at`)
+        ermittelt (kein geratener/hartkodierter Code), der Bulletin-Cache
+        wird mit einem minimalen, aber vollstaendig REALISTISCH GEFORMTEN
+        "NESSUNA ALLERTA"-Datensatz fuer genau diese Zone vorgefuellt
+        (identisches Zeilenformat wie `tests/fixtures/dpc`-Fixtures) --
+        `DpcSource.fetch()` laeuft dadurch ueber den echten Cache-Hit-Zweig,
+        ohne Netz. `MeteoAlarmFeedSource("IT")` faellt ueber den bereits
+        bestehenden, real geblockten `feeds.meteoalarm.org`-Host aus."""
+        import time as time_module
+        from datetime import datetime, timezone
+
+        import services.official_alerts.base as oa_base
+        from services.official_alerts.base import get_official_alerts_with_status
+        from services.official_alerts.dpc import (
+            DpcSource, _cache as _dpc_cache, _CACHE_KEY as _DPC_CACHE_KEY,
+            _zone_at, CACHE_TTL as _DPC_CACHE_TTL,
+        )
+        from services.official_alerts.meteoalarm_feed import (
+            MeteoAlarmFeedSource, _cache as _meteoalarm_feed_cache,
+        )
+
+        # Bozen/Bolzano -- Suedtirol, sicher innerhalb der DPC-Bbox.
+        st_lat, st_lon = 46.4983, 11.3548
+
+        backup = list(oa_base._REGISTERED_SOURCES)
+        oa_base._REGISTERED_SOURCES.clear()
+        _dpc_cache.clear()
+        _meteoalarm_feed_cache.clear()
+        try:
+            dpc = DpcSource()
+            meteoalarm_it = MeteoAlarmFeedSource("IT")
+            assert dpc.covers(st_lat, st_lon) is True
+            assert meteoalarm_it.covers(st_lat, st_lon) is True
+
+            zone_code = _zone_at(st_lat, st_lon)
+            assert zone_code is not None, (
+                "Suedtirol muss ueber die echte DPC-Zonen-Geometrie eine "
+                "zustaendige Zone finden -- sonst deckt DpcSource den Punkt "
+                "gar nicht ab und der Testaufbau ist falsch."
+            )
+
+            today = datetime.now(timezone.utc).date()
+            _dpc_cache[_DPC_CACHE_KEY] = {
+                "data": {
+                    "bulletin_date": today,
+                    "by_day": {
+                        "today": {
+                            zone_code: {
+                                "Zona_all": zone_code,
+                                "Nome_zona": "Test-Zone (Suedtirol)",
+                                "Temporali": "1/NESSUNA ALLERTA",
+                                "Idrogeo": "1/NESSUNA ALLERTA",
+                                "Idraulico": "1/NESSUNA ALLERTA",
+                            }
+                        }
+                    },
+                },
+                "fetched_at": time_module.monotonic(),
+                "ttl": _DPC_CACHE_TTL,
+            }
+
+            oa_base._REGISTERED_SOURCES.append(dpc)
+            oa_base._REGISTERED_SOURCES.append(meteoalarm_it)
+
+            alerts, unavailable = get_official_alerts_with_status(st_lat, st_lon)
+            assert alerts == [], (
+                f"Beide Quellen liefern keine aktiven Warnungen, war {alerts!r}"
+            )
+            assert unavailable is False, (
+                "DpcSource liefert erfolgreich (auch leer), MeteoAlarm ist "
+                "geblockt -> DpcSource kompensiert -> unavailable=False. "
+                "Reflektiert die REALE heutige Zwei-Quellen-Lage fuer "
+                "Suedtirol, nicht das seit 2026-07-31 ueberholte "
+                "Einzelquellen-Beispiel aus dem PO-Kommentar vom 30.07."
+            )
+        finally:
+            oa_base._REGISTERED_SOURCES.clear()
+            oa_base._REGISTERED_SOURCES.extend(backup)
+            _dpc_cache.clear()
+            _meteoalarm_feed_cache.clear()
 
     def test_real_failsoft_empty_from_blocked_source_is_unavailable(self):
         """REAL-PFAD-REGRESSIONSWAECHTER (Issue #1348 Fix-Loop, der eigentliche


### PR DESCRIPTION
## Summary
- Der Briefing-Hinweis "amtliche Warnungen aktuell nicht abrufbar" erschien bisher schon, wenn EINE von mehreren zuständigen Warn-Quellen ausfiel — auch wenn eine andere erfolgreich antwortete (PO-Meldung 30.07., Trip "KHW 403": GeoSphere lieferte durchgehend, nur MeteoAlarm war gesperrt, der Hinweis erschien trotzdem)
- Setzt die PO-Korrektur vom 2026-07-30 um: `unavailable=True` nur noch, wenn ALLE zuständigen Quellen ausgefallen sind — eine erfolgreiche zuständige Quelle kompensiert eine ausgefallene
- Bei genau einer zuständigen Quelle bleibt das Verhalten unverändert streng (kein Kompensationspartner)
- Zwei Realpfad-Tests mit den heute tatsächlich in Prod registrierten Quellklassen (AT: GeoSphere + MeteoAlarm, Südtirol: DPC + MeteoAlarm) — netzfrei über gezielt vorbefüllte Modul-Caches, kein Mock

## Test plan
- [x] `tests/tdd/test_official_alerts_unavailable_hint.py` — 16 passed (TDD RED→GREEN dokumentiert)
- [x] Regressionsradius (34 verwandte Testdateien) — 291 passed, 0 failed
- [x] Adversary VERIFIED — 7/7 AC bewiesen, Mutationsgegenprobe 2/2 gefangen (alte strenge Formel + Off-by-one)
- [ ] CI-Ampel grün abwarten
- [ ] Staging-Verifikation nach Merge

Bezieht sich auf #1348 (Issue wird NICHT automatisch geschlossen — manuelles Close erst nach bestandenem Post-Deploy-Selftest, Projektregel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SruqXq4DU8Eweoj3Sa7HWL