### PR TITLE
docs(#1478): Aufrufstellen auf workflow.py finish umgestellt

### DIFF
--- a/.claude/commands/70-deploy.md
+++ b/.claude/commands/70-deploy.md
@@ -88,7 +88,7 @@ ActiveEnterTimestamp`, `/api/health`.
 
 ## Schritt 5 — Abschluss
 
-1. `workflow.py write-log success`, dann `workflow.py complete`
+1. `workflow.py write-log success`, dann `workflow.py finish`
 2. Ergebnis-Kommentar ans Issue: was live ist, was nachgewiesen wurde, **was offen blieb**,
    abgeleitete Meldungen
 3. `gh issue close <N>` — **nur** wenn 4b Exit 0 lieferte **und** wirklich alles erledigt ist.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ OpenSpec-Workflow mit Adversary Verification (Commands sind zweistellig; Einstie
 | Was | Befehl / Pflicht |
 |-----|------------------|
 | **AC-N-Format in Specs** | Jede Spec `created >= 2026-05-11` braucht `## Acceptance Criteria` mit `**AC-1:** Given.../When.../Then...` (>=30 Zeichen). Vorbild: `docs/specs/modules/epic_191_state_migration.md`. Ohne AC-N blockt `workflow_gate` Phase 6. |
-| **Execution-Log vor `complete`** | `python3 .claude/hooks/workflow.py write-log success` schreibt YAML (Phasen, Laufzeiten, Token-Verbrauch, Issue #829) nach `.claude/workflows/_log/`, dann `workflow.py complete`. Ohne Log blockt der Hook. |
+| **Execution-Log vor `finish`** | `python3 .claude/hooks/workflow.py write-log success` schreibt YAML (Phasen, Laufzeiten, Token-Verbrauch, Issue #829) nach `.claude/workflows/_log/`, dann `workflow.py finish`. Ohne Log blockt der Hook. |
 | **Token-Tracking (#829)** | Stop-Hook `track_token_usage.py` summiert Transcript-Tokens ins Workflow-State, kumulativ über Sessions. Kein `GZ_ACTIVE_WORKFLOW` → fail-safe. |
 | **LoC-Limit 250/Workflow** | `workflow.py status` zeigt `LoC-Delta: +N/250`. Überschritten → `workflow.py set-field loc_limit_override 500`. Generierte Dateien + `docs/`/`*.md`/`.gitignore` zählen nicht. |
 | **Adversary-Verdict Gating** | Nach phase6b: `AMBIGUOUS` → `workflow.py override-ambiguous "<Grund>"` (TTL 1h); `None`/`BROKEN` → `qa_gate.py` aufrufen. Commit blockt ohne Verdict. |

--- a/docs/context/fix-1478-abschluss-alias.md
+++ b/docs/context/fix-1478-abschluss-alias.md
@@ -1,0 +1,169 @@
+# Context: fix-1478-abschluss-alias
+
+## Request Summary
+
+Der letzte Buchungsschritt eines Workflows (`workflow.py complete`) ist aus einer
+worktree-isolierten Sitzung heraus nicht ausführbar — und praktisch jede Sitzung ist
+worktree-isoliert. Ziel: ein zweiter, gleichwertiger Name für denselben Unterbefehl,
+der den Fehlalarm nicht auslöst. Teil 2 von Issue #1478.
+
+## Befund (gemessen 2026-08-08, Worktree `pw-forensik`)
+
+```
+echo complete
+  → BLOCKIERT: "runs a string through complete, which can't be verified
+    to stay inside the worktree"
+```
+
+**Es ist ausschließlich das Wort, nicht `workflow.py`.** Schon ein nacktes `echo` mit
+diesem Argument wird abgewiesen. `complete` ist ein bash-Builtin (programmierbare
+Vervollständigung, nimmt ein Kommando als Argument); der Worktree-Wächter des
+Claude-Code-Harness liest es als eval-artiges Konstrukt und hält den Rest der Zeile für
+ein durchgereichtes, unprüfbares Kommando.
+
+Das erklärt lückenlos die frühere Beobachtung, dass **alle anderen Unterbefehle** über
+denselben absoluten Pfad problemlos laufen: `start`, `switch`, `status`, `phase`,
+`set-field`, `add-artifact`, `write-log`. In dieser Sitzung erneut bestätigt — `start`
+lief, `complete` nicht.
+
+Gegenprobe für Kandidatennamen: `echo finish`, `echo close`, `echo wrapup` laufen alle
+durch. `done` scheidet aus (Shell-Keyword in `for`/`while`-Schleifen).
+
+## Zuständigkeit — Korrektur der bisherigen Lagebeurteilung
+
+Im Issue-Kommentar vom 2026-08-08 12:29 steht „in diesem Repo ist er nicht behebbar".
+Das ist richtig für `gregor_zwanzig` und für den *Wächter* — aber der **Name des
+Unterbefehls** gehört uns: er steht in `henemm/agent-os-openspec`, einem eigenen Repo
+des PO. Der Fehlalarm ist damit abräumbar, ohne den Wächter anzufassen.
+
+**Präzedenz im selben Repo:** CHANGELOG 3.10.2 (Issue #87) behandelt exakt dieselbe
+Konstellation — „Root Cause liegt im Claude-Code-Harness und ist nicht im Framework
+korrigierbar. Mitigation innerhalb des Frameworks: …". Das ist das etablierte Muster.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `agent-os-openspec/core/hooks/workflow.py:1172-1191` | `COMMANDS`-Dict — hier entsteht der Alias (1 Zeile) |
+| `agent-os-openspec/core/commands/80-workflow.md:96` | Aufrufzeile |
+| `agent-os-openspec/core/commands/00-bug.md:111` | Aufrufzeile |
+| `agent-os-openspec/core/commands/99-reset.md:21` | Aufrufzeile |
+| `agent-os-openspec/setup.py:566, 602` | erzeugt die Aufrufzeile in **neu generierten** Projekt-CLAUDE.md |
+| `agent-os-openspec/.claude-plugin/plugin.json` | Version (aktuell 3.10.2) — Release-Konvention |
+| `agent-os-openspec/CHANGELOG.md` | Pflicht-Eintrag je Release |
+| `gregor_zwanzig/.claude/commands/70-deploy.md:91` | Aufrufzeile Schritt 5 — der real blockierte Pfad |
+| `gregor_zwanzig/CLAUDE.md:41` | Tabellenzeile „Execution-Log vor `complete`" |
+| `gregor_zwanzig/docs/project/agent-os-improvement-bundle.md:200` | nur Beschreibung, kein Aufruf (Archiv) |
+
+Reine Doku im Plugin-Repo, nachzuziehen: `README.md`, `CLAUDE.md`,
+`docs/WORKFLOW_GUIDE.md`, `docs/specs/bug-fix-fast-track.md`.
+
+## Existing Patterns
+
+- **Unterbefehl mit Tests:** `tests/test_workflow_abandon_82.py` ist das Vorbild —
+  hermetischer Subprozess-Test (`CLAUDE_PROJECT_DIR=tmp_path`, `cwd=tmp_path`), ruft
+  `workflow.py` mit Argumentliste auf. Das Wort im Python-Quelltext ist unkritisch;
+  nur Bash-Zeilen lösen den Wächter aus.
+- **Harness-Fehler mildern statt beheben:** CHANGELOG 3.10.2 / Issue #87.
+- **Release:** Version-Bump in `plugin.json` + CHANGELOG-Eintrag, SemVer. Ein neuer
+  Unterbefehlsname ist additiv → MINOR (3.11.0).
+
+## Dependencies
+
+- **Upstream:** `cmd_complete` bleibt unverändert; der Alias zeigt auf dieselbe Funktion.
+- **Downstream:** Jede Claude-Instanz auf diesem Server (`infra`, `n8n`, `website`,
+  `gregor`, `nightjet`, `security`) nutzt dasselbe Plugin. Deshalb ist
+  **Rückwärtskompatibilität Pflicht**: der alte Name muss gültig bleiben, sonst brechen
+  laufende Sitzungen und fremde Projekt-Dokus.
+
+## Risks & Considerations
+
+1. **Wirkort ≠ Quellort.** Das aktive Plugin wird über
+   `~/.claude/plugins/installed_plugins.json` auf
+   `~/.claude/plugins/cache/henemm-private/agent-os-openspec/3.10.2` aufgelöst — eine
+   **echte Kopie**, kein Symlink (inhaltlich derzeit identisch mit dem Repo, nur `.pyc`
+   weichen ab). Der Marketplace `henemm-private` ist vom Typ `directory` mit
+   `installLocation = /home/hem/agent-os-openspec`, weshalb Skills aus dem Repo geladen
+   werden. Welcher Pfad im Ernstfall gewinnt, ist **nicht abgeleitet, sondern zu
+   messen** — sonst ändern wir eine Datei, die niemand ausführt.
+2. **Gemeinsam genutzter Checkout.** `/home/hem/agent-os-openspec` steht auf `main` und
+   wird von allen Instanzen live gelesen. Dort einen Branch auszuchecken verändert das
+   Verhalten **jeder laufenden Sitzung**. Arbeit gehört in einen isolierten Klon; im
+   gemeinsamen Checkout liegen zudem fremde uncommittete Dateien
+   (`.claude/pending_validation_*.json`), die unangetastet bleiben.
+3. **Der Beweis muss aus einer worktree-isolierten Sitzung kommen.** Ein grüner
+   Unit-Test im Plugin zeigt nur, dass der Alias denselben State schreibt — er zeigt
+   **nicht**, dass der Wächter die neue Aufrufzeile durchlässt. Das ist genau der
+   Prüfort-≠-Wirkort-Fehler, der in diesem Projekt mehrfach zu falschem Grün geführt hat.
+   Abnahmekriterium ist der reale Aufruf, nicht die Testsuite.
+4. **Keine Gate-Aufweichung.** Der Wächter soll verhindern, dass eine isolierte Sitzung
+   außerhalb ihres Worktrees schreibt. `workflow.py finish` ist für ihn genauso prüfbar
+   wie das erlaubte `workflow.py status` — es gibt kein Schutzziel, das der neue Name
+   aushebelt. Abzugrenzen von der verbotenen Alternative: Aufrufformen durchprobieren,
+   bis eine durchrutscht.
+5. **Zwei Repos, zwei PRs.** Plugin-Fix und Projekt-Doku hängen zusammen, laufen aber
+   über getrennte Liefer-Wege.
+6. **Teil 1 von #1478** (RED-Artefakt wird im Hauptrepo statt im Worktree gesucht) ist
+   nicht Gegenstand dieses Workflows und bleibt offen.
+
+## Existing Specs
+
+Keine Spec im Projekt betroffen. Im Plugin-Repo ist `docs/specs/bug-fix-fast-track.md`
+nur als Doku-Fundstelle berührt.
+
+## Analysis
+
+### Type
+Bug (Harness-Fehlalarm) mit additivem Fix im eigenen Framework-Repo — kein Feature.
+
+### Affected Files (with changes)
+
+| File | Change Type | Description |
+|---|---|---|
+| `agent-os-openspec/core/hooks/workflow.py` | MODIFY | `"finish": cmd_complete` zusätzlich in `COMMANDS`-Dict (~1 Zeile) |
+| `agent-os-openspec/tests/test_workflow_finish_alias.py` | CREATE | Subprozess-Test nach Vorbild `test_workflow_abandon_82.py`: `finish` schreibt identischen End-State wie `complete`; Altname bleibt funktionsfähig |
+| `agent-os-openspec/core/commands/80-workflow.md` | MODIFY | Aufrufzeile auf `finish` |
+| `agent-os-openspec/core/commands/00-bug.md` | MODIFY | Aufrufzeile auf `finish` |
+| `agent-os-openspec/core/commands/99-reset.md` | MODIFY | Aufrufzeile auf `finish` |
+| `agent-os-openspec/setup.py` | MODIFY | zwei Stellen (Tabelle Zeile 566, generierte Aufrufzeile 602) — wirkt in künftig neu generierte Projekt-CLAUDE.md |
+| `agent-os-openspec/README.md`, `CLAUDE.md`, `docs/WORKFLOW_GUIDE.md`, `docs/specs/bug-fix-fast-track.md` | MODIFY | Doku-Erwähnungen von `workflow.py complete` |
+| `agent-os-openspec/.claude-plugin/plugin.json` | MODIFY | Version 3.10.2 → 3.11.0 (additiv, SemVer MINOR) |
+| `agent-os-openspec/CHANGELOG.md` | MODIFY | neuer Eintrag, Muster CHANGELOG 3.10.2 (#87) |
+| `gregor_zwanzig/.claude/commands/70-deploy.md:91` | MODIFY | `workflow.py complete` → `workflow.py finish` |
+| `gregor_zwanzig/CLAUDE.md:41` | MODIFY | Tabellenzeile auf `finish` |
+
+`gregor_zwanzig/docs/project/agent-os-improvement-bundle.md:200` bleibt unverändert
+(Archiv-Doku, beschreibt nur das historische Verhalten).
+
+### Scope Assessment
+- Dateien: ~13 (1 Code, 1 Test, 11 Doku/Aufrufzeilen in 2 Repos)
+- Geschätztes LoC: +~40/-~10 (überwiegend Test + Dict-Eintrag; Doku zählt laut Projekt-Konvention nicht gegen das LoC-Limit)
+- Risk Level: **LOW** — additiv, alter Name bleibt gültig, keine bestehende Funktion wird verändert
+
+### Technical Approach
+1. `COMMANDS["finish"] = cmd_complete` in `workflow.py` — reiner Alias, keine Logikänderung.
+2. Test nach Vorbild `test_workflow_abandon_82.py`: hermetischer Subprozess-Aufruf mit
+   `finish`, Vergleich des resultierenden State-JSON gegen einen Referenzlauf mit
+   `complete`.
+3. **Abnahme zusätzlich zum Unit-Test:** realer Aufruf `echo finish` und
+   `python3 .../workflow.py finish` aus dieser worktree-isolierten Sitzung heraus —
+   das ist der eigentliche Beweis, der Unit-Test allein reicht nicht (Risiko 3 im
+   Context-Dokument).
+4. Alle Aufrufstellen in Skills/Doku auf `finish` umstellen; `complete` nirgends
+   entfernen.
+5. Release: Version-Bump + CHANGELOG-Eintrag im Plugin-Repo, danach PR.
+6. Im Projekt-Repo (`gregor_zwanzig`) zweiter, kleiner PR für die zwei Doku-Stellen —
+   erst nachdem der Plugin-PR gemerged UND der Cache-Sync (automatisch, s.o.) bestätigt ist.
+
+### Dependencies
+- Upstream: keine — `cmd_complete` unverändert.
+- Downstream: alle sechs Claude-Instanzen des Servers nutzen dasselbe Plugin
+  (`infra`, `n8n`, `website`, `gregor`, `nightjet`, `security`) — Rückwärtskompatibilität
+  ist deshalb Pflicht, nicht optional.
+
+### Open Questions
+Keine blockierenden. Einzig zu beobachten: ob der automatische Cache-Sync (Marketplace
+`directory`-Quelle) den neuen Namen ohne manuellen Eingriff in
+`~/.claude/plugins/cache/henemm-private/agent-os-openspec/3.10.2` verfügbar macht —
+wird in der Implementierungs-/Adversary-Phase empirisch geprüft (siehe Technical Approach
+Punkt 3), nicht vorab angenommen.

--- a/docs/specs/modules/fix_1478_workflow_finish_alias.md
+++ b/docs/specs/modules/fix_1478_workflow_finish_alias.md
@@ -1,0 +1,167 @@
+---
+entity_id: fix_1478_workflow_finish_alias
+type: module
+created: 2026-08-09
+updated: 2026-08-09
+status: draft
+version: "1.0"
+tags: [workflow-engine, harness-fehlalarm, plugin]
+---
+
+# workflow.py: Alias `finish` für `complete`
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`workflow.py complete` — der letzte Buchungsschritt eines Workflows — ist aus jeder
+worktree-isolierten Session heraus nicht ausführbar: der Worktree-Wächter des
+Claude-Code-Harness liest das Wort `complete` als bash-Builtin (programmierbare
+Vervollständigung) und blockiert die gesamte Kommandozeile, unabhängig vom
+vorangestellten Pfad. Ein zusätzlicher, gleichwertiger Unterbefehlsname räumt den
+Fehlalarm ab, ohne den Wächter anzufassen. Issue #1478 (Teil 2 von 2 — Teil 1, das
+RED-Artefakt-Suchpfadproblem, ist nicht Gegenstand dieser Spec).
+
+## Source
+
+**Schicht-Hinweis (abweichend vom Standardfall):** Diese Änderung betrifft nicht
+Frontend/Go-API/Python-Core von `gregor_zwanzig`, sondern das externe Framework-Repo
+`henemm/agent-os-openspec` (Marketplace `henemm-private`, Directory-Quelle
+`/home/hem/agent-os-openspec`), das von allen sechs Claude-Instanzen des Servers
+gemeinsam genutzt wird. `gregor_zwanzig` selbst besitzt kein eigenes
+`.claude/hooks/workflow.py` — nur zwei Doku-Zeilen verweisen auf den Unterbefehl.
+
+- **File:** `agent-os-openspec/core/hooks/workflow.py` (Repo:
+  `/home/hem/agent-os-openspec`, nicht Teil dieses Projekt-Checkouts)
+- **Identifier:** `COMMANDS`-Dict, Zeile ~1185
+
+## Estimated Scope
+
+- **LoC:** ~40 (überwiegend Test; Doku zählt nicht gegen das Projekt-LoC-Limit und
+  betrifft ohnehin ein anderes Repo)
+- **Files:** ~13 (1 Code, 1 Test, ~11 Doku-/Aufrufzeilen über zwei Repos)
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `cmd_complete` (workflow.py) | upstream, unverändert | Zielfunktion, auf die der neue Name zeigt |
+| Plugin-Marketplace-Sync (`directory`-Quelle) | Infrastruktur | überträgt Source-Repo-Änderungen automatisch in `~/.claude/plugins/cache/henemm-private/agent-os-openspec/3.10.2` — empirisch bestätigt (Cache-Kopie zeitlich neuer, inhaltlich identisch zum Source) |
+| `gregor_zwanzig/.claude/commands/70-deploy.md`, `CLAUDE.md` | downstream | zwei Aufrufstellen im Projekt-Repo, eigener Folge-PR |
+
+## Implementation Details
+
+```python
+# agent-os-openspec/core/hooks/workflow.py — COMMANDS-Dict
+COMMANDS = {
+    "start": cmd_start,
+    ...
+    "complete": cmd_complete,
+    "finish": cmd_complete,   # NEU — Alias, siehe Issue #1478
+    "abandon": cmd_abandon,
+    ...
+}
+```
+
+Kein Logikcode ändert sich — `cmd_complete` bleibt unverändert und wird unter zwei
+Namen erreichbar. `complete` bleibt dauerhaft gültig (Rückwärtskompatibilität für
+laufende Sitzungen und fremde Projekt-Dokus, die den alten Namen noch verwenden).
+
+Aufrufstellen, die auf den neuen Namen umgestellt werden (alle im Plugin-Repo, plus
+zwei im Projekt-Repo):
+
+- `agent-os-openspec/core/commands/80-workflow.md:96`
+- `agent-os-openspec/core/commands/00-bug.md:111`
+- `agent-os-openspec/core/commands/99-reset.md:21`
+- `agent-os-openspec/setup.py:566,602`
+- `agent-os-openspec/README.md`, `CLAUDE.md`, `docs/WORKFLOW_GUIDE.md`,
+  `docs/specs/bug-fix-fast-track.md`
+- `agent-os-openspec/.claude-plugin/plugin.json` (Version 3.10.2 → 3.11.0)
+- `agent-os-openspec/CHANGELOG.md` (neuer Eintrag)
+- `gregor_zwanzig/.claude/commands/70-deploy.md:91`
+- `gregor_zwanzig/CLAUDE.md:41`
+
+## Expected Behavior
+
+- **Input:** `python3 <pfad>/workflow.py finish` (aus einer worktree-isolierten Sitzung
+  heraus, mit vorher gesetztem `phase8_complete` und geschriebenem Execution-Log)
+- **Output:** identischer End-State wie bisher `complete` — Workflow-JSON wandert nach
+  `_archive/`, Statusmeldung wie beim Altnamen
+- **Side effects:** keine neuen. `complete` bleibt unverändert nutzbar (getestet, nicht
+  nur behauptet — siehe AC-2)
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Workflow in `phase8_complete` mit geschriebenem Execution-Log,
+  When `workflow.py finish` aufgerufen wird, Then ist der End-State (archiviertes
+  JSON, Statusausgabe) inhaltlich identisch zu einem Referenzlauf mit
+  `workflow.py complete` auf demselben Ausgangszustand.
+  - Test: Subprozess-Test (Muster `tests/test_workflow_abandon_82.py`, hermetisch via
+    `CLAUDE_PROJECT_DIR=tmp_path`) — zwei identisch präparierte Workflow-Fixtures, einer
+    mit `complete` beendet, einer mit `finish`; beide resultierenden `_archive/`-JSONs
+    werden bis auf Zeitstempelfelder verglichen.
+
+- **AC-2:** Given derselbe Zustand, When `workflow.py complete` weiterhin aufgerufen
+  wird, Then funktioniert der Altname unverändert (keine Regression durch die
+  Alias-Einführung).
+  - Test: derselbe Subprozess-Test ruft explizit auch `complete` auf und prüft Exit 0 +
+    unveränderten Output gegenüber einem vor der Änderung aufgezeichneten Referenzlauf.
+
+- **AC-3:** Given eine worktree-isolierte Claude-Code-Sitzung (echter Wächter aktiv,
+  kein Unit-Test-Mock), When `finish` als Bash-Kommando ausgeführt wird (mit
+  vorangestelltem Pfad, wie es die Skills tatsächlich tun), Then blockiert der
+  Worktree-Wächter NICHT — im Unterschied zu `complete`, das nachweislich blockiert.
+  - Test: **Kein automatisierter Test möglich** (der Wächter ist Harness-Infrastruktur,
+    nicht Teil der Codebasis). Manueller Nachweis während Implementierung/Adversary:
+    realer `echo finish` und realer `workflow.py finish`-Aufruf aus dieser Sitzung,
+    Ergebnis im Adversary-Protokoll festgehalten. Das ist der eigentliche Beweis der
+    Spec — AC-1/AC-2 allein würden einen funktionslosen Alias nicht von diesem
+    unterscheiden.
+
+- **AC-4:** Given der Marketplace `henemm-private` ist vom Typ `directory`, When das
+  Source-Repo verändert und diese Sitzung eine Skill-Instruktion neu lädt, Then
+  spiegelt die aufgelöste Cache-Kopie (`~/.claude/plugins/cache/henemm-private/
+  agent-os-openspec/<version>`) den neuen Stand — ohne manuellen Cache-Eingriff.
+  - Test: nach der Code-Änderung `diff` zwischen Source- und Cache-Kopie von
+    `workflow.py`; muss nach einer neuen Skill-Ladung identisch sein (Fortsetzung der
+    bereits in der Analysephase gemessenen Beobachtung, dass beide Kopien synchron
+    bleiben).
+
+## Known Limitations
+
+- Löst **nur** Teil 2 von #1478. Teil 1 (RED-Artefakt-Suche im Hauptrepo statt
+  Worktree, `tdd_enforcement.py`) bleibt offen, eigene Scheibe.
+- Der Wächter selbst (Harness) bleibt unverändert — künftige, noch unentdeckte
+  Bash-Builtin-Kollisionen (`test`, `type`, `read` u.ä. als Unterbefehlsnamen) sind mit
+  diesem Fix nicht pauschal ausgeschlossen, nur der konkret gemeldete Fall.
+- Rückwärtskompatibilität ist Pflicht, aber nicht ewig geplant: `complete` wird nicht
+  aktiv abgekündigt; ein künftiges Aufräumen wäre ein separates Ticket mit eigener
+  Migrationsfrist über alle sechs Instanzen hinweg.
+- **AC-4 nachträglich als Harness-Grenze eingestuft (PO-Entscheidung 2026-08-09,
+  gemessen im Adversary-Lauf):** Der Fix ist gemergt auf `origin/main` von
+  `agent-os-openspec` (PR #91, Commit `e07e01d`) und der gemeinsam genutzte Checkout
+  `/home/hem/agent-os-openspec` ist per Fast-Forward aktuell. Der **versionierte
+  Plugin-Cache** (`~/.claude/plugins/cache/henemm-private/agent-os-openspec/3.10.2`,
+  von `installed_plugins.json` referenziert) zieht das **nicht automatisch** nach —
+  bestätigt: `CLAUDE_PLUGIN_ROOT` ist in dieser Sitzung nicht gesetzt, die
+  Skill-eigene Pfadauflösung fällt auf den stehengebliebenen Cache-Eintrag zurück.
+  Das ist ein bereits dokumentiertes Merkmal der Plugin-Cache-Architektur
+  (`~/.claude/plugins/cache/.../` hinkt der `directory`-Quelle nach Fremd-Releases
+  grundsätzlich hinterher), keine neue Lücke dieses Fixes. Ob/wann ein Session-Neustart
+  oder ein Plugin-Update den Cache auffrischt, liegt außerhalb dessen, was aus einer
+  laufenden Sitzung heraus ohne Hand-Eingriff in Harness-Zustand geprüft oder erzwungen
+  werden kann — bewusst nicht versucht.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** additiver Alias auf Werkzeug-Ebene (nicht Produktarchitektur von
+  `gregor_zwanzig`), betrifft kein Entscheidungsfeld aus `docs/adr/`. Präzedenz für
+  „Harness-Fehlalarm im Framework mildern" bereits etabliert: CHANGELOG 3.10.2, Issue #87.
+
+## Changelog
+
+- 2026-08-09: Initial spec created


### PR DESCRIPTION
Folgeaenderung zum gemergten Plugin-Fix (agent-os-openspec#91): die beiden
verbliebenen "workflow.py complete"-Erwaehnungen in diesem Repo zeigen jetzt
auf den neuen, additiven Alias "finish" -- Ursache des ganzen Fixes war ein
Wortkonflikt mit dem bash-Builtin "complete", das der Worktree-Waechter des
Harness als Kommando liest und blockiert.

Context/Spec-Dokumente ebenfalls beigefuegt.

Refs: #1478 (Teil 2 von 2, Plugin-Seite bereits gemergt)
