### PR TITLE
fix(#1601): Modellwechsel allein loest keinen CAPE-Aenderungsalarm mehr aus

### DIFF
--- a/docs/adr/0048-modellabhaengige-schwellen-statt-einer-zahl.md
+++ b/docs/adr/0048-modellabhaengige-schwellen-statt-einer-zahl.md
@@ -126,6 +126,14 @@ wurde:
   die Leiter ursprünglich geschrieben wurde — dieselbe Zahl, die vor Scheibe C1 überall galt,
   jetzt als benannte Konstante `CAPE_REFERENZ_NIVEAU_JKG`. Regel 5 dieser ADR gilt unverändert:
   fehlt die Eichung für Modell × Gebiet, entsteht **kein** Alarm, nicht „unauffällig".
+  **Ergänzt mit #1601 (2026-08-09):** Die Umrechnung in die Modellwelt setzt voraus, dass Alt-
+  und Neu-Wert überhaupt aus derselben Modellwelt stammen. Wechselt zwischen zwei Läufen das
+  liefernde Modell (`old_summary.cape_model_id != new_summary.cape_model_id` in
+  `weather_change_detection.py`), entsteht **kein** CAPE-Änderungsalarm — der Sprung wäre sonst
+  allein dem Modellwechsel zuzuschreiben, nicht dem Wetter. `None` auf der Alt-Seite zählt dabei
+  als Abweichung (Regel a der zugehörigen Spec), konsistent mit Regel 5: unbelegte Herkunft ist
+  „keine Aussage", nicht „unauffällig". Wirkt auf beide Alarmwege (Trip, Ortsvergleich), weil
+  beide dieselbe `DeviationAlertEngine` nutzen.
 - **Familie 4 (Anzeige/Metrik-Auswahl):** entfällt ersatzlos mit #1585 — CAPE ist seither
   `selectable=false`, es gibt keine per-Etappe wählbare CAPE-Spalte mehr, die eine Schwelle
   anzeigen müsste. Diese ADR musste dafür nichts umsetzen.

--- a/docs/context/fix-1601-modellwechsel-alarm.md
+++ b/docs/context/fix-1601-modellwechsel-alarm.md
@@ -1,0 +1,210 @@
+# Context: fix-1601-modellwechsel-alarm
+
+Issue #1601 · Standard Track · Basis `origin/main` = `4725c3f3` · erstellt 2026-08-09
+
+## Request Summary
+
+Der Änderungs-Alarm vergleicht den gespeicherten CAPE-Wert mit dem frisch abgerufenen, ohne
+zu prüfen, ob beide vom selben Wettermodell stammen. Wechselt zwischen zwei Läufen das
+liefernde Modell, springt die Zahl allein deshalb — und löst einen Alarm aus, obwohl sich das
+Wetter nicht geändert hat.
+
+## Was seit #1592 bereits steht (gemessen, nicht aus dem Ticket gelesen)
+
+Das Issue schreibt: „das konkrete Modell steht im Schnappschuss gar nicht erst". **Das gilt
+nicht mehr.** Scheibe C0 hat `SegmentWeatherSummary.cape_model_id` eingeführt
+(`src/app/models.py:454`); der Serialisierer schreibt alle nicht-leeren Felder generisch mit
+(`weather_snapshot.py:201-215`, `vars()`-basiert), der Leser holt sie generisch zurück
+(`:218-234`, `dataclasses.fields`-basiert). Das Feld musste dafür nirgends eigens angemeldet
+werden.
+
+**Beleg am laufenden Produktivsystem**, nicht am Code:
+`/var/lib/gregor/users/henning/weather_snapshots/5f534011_2026-08-09.json`, geschrieben
+2026-08-09 05:00 UTC — jede Etappe trägt `"cape_model_id": "icon_d2"` neben ihrem
+`cape_max_jkg`.
+
+Die Hartcodierung `model="snapshot"` beim Laden (`weather_snapshot.py:281`) betrifft **nur**
+die rekonstruierte Stunden-Zeitreihe (`NormalizedTimeseries.meta`), nicht das Aggregat. Das
+Aggregat wird getrennt über `_deserialize_summary(data["aggregated"])` gelesen. Die Herkunft
+im Schnappschuss überlebt das Laden also unverändert.
+
+**Zu bauen bleibt allein der Vergleich.** Heute liest der Δ-Pfad ausschließlich die Herkunft
+des **frischen** Werts (`weather_change_detection.py:630` — `new_summary.cape_model_id`);
+`old_summary.cape_model_id` wird an keiner Stelle gelesen.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/weather_change_detection.py:598-694` | Δ-Zweig; der CAPE-Sonderpfad `:622-634` ist der Andockpunkt des Guards |
+| `src/services/deviation_alert_engine.py:207-221` | **Einziger** live erreichbarer Aufrufer von `detect_changes()` |
+| `src/services/trip_alert.py:265` | Trip-Alarm → `DeviationAlertEngine.evaluate()` |
+| `src/services/compare_alert.py:371-374` | Ortsvergleich-Alarm → dieselbe Engine |
+| `src/app/model_registry.py:64-72,148-169` | `effective_cape_model_id()`, `cape_delta_threshold_jkg()` — das bestehende Abstain-Muster |
+| `src/app/models.py:454` | `cape_model_id` am Etappen-Aggregat |
+| `src/services/weather_metrics.py:802` | Befüllung: `cape_model_id=effective_cape_model_id(timeseries.meta)` |
+| `src/services/weather_snapshot.py:201-234` | Generische Serialisierung beider Richtungen |
+| `src/services/compare_weather_snapshot.py:63,93` | Ortsvergleich benutzt **denselben** Serialisierer |
+| `src/providers/openmeteo.py:1030` | Log-Zeile des Modellwechsels (`Model fallback: … → next endpoint`) |
+| `tests/tdd/test_cape_delta_modellschwelle.py` | 9 Tests zum CAPE-Δ-Sonderpfad — fachlicher Ort für den Regressionstest |
+
+## Existing Patterns
+
+- **Abstain statt Rateschätzung:** „unbekannte Herkunft" und „Kombination ohne Eichwert"
+  heißen im `model_registry` an jedem Nachschlagort identisch `None`, und `None` führt im
+  Δ-Pfad zu `continue` — kein Alarm, kein Ersatzwert. Der Guard aus #1601 ist derselbe
+  Gedanke, eine Ebene früher: nicht „welcher Wert", sondern „vergleichbar überhaupt?".
+- **Sonderpfad vor der Delta-Berechnung:** Der Ordinal-Sonderfall (`_ordinal_levels`) und der
+  CAPE-Sonderfall sitzen beide **vor** `delta = new - old`. Dort gehört auch der Guard hin.
+- **Kein Default an der Signaturgrenze:** #1592 hat bewusst Parameter ohne Default gesetzt,
+  damit ein vergessener Aufruf hart bricht statt still zu raten.
+
+## Dependencies
+
+- **Upstream:** `model_registry` (Normalisierung + Eichung), `thunder_routing.thunder_region_for`
+  (Gebietsbestimmung), Aggregation in `weather_metrics`.
+- **Downstream:** beide Alarmwege (Trip, Ortsvergleich) — sie teilen sich `DeviationAlertEngine`.
+  Ein Guard hier wirkt auf beide gleichzeitig; das ist gewollt und entspricht der
+  Trip/Compare-Teilungsregel.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1592_c3_cape_delta_alarme.md` — die Scheibe, auf der #1601 aufsetzt
+- `docs/specs/modules/fix_1592_s1_cape_modellschwelle.md` — Befund A/B, Scheibenfolge
+- `docs/context/fix-1592-cape-modellschwelle.md` Abschnitt „Befund B" — die Erstbeschreibung
+- ADR-0009 (Vergleichsanker), ADR-0025 (Einstiegsfunktion als Prüfort)
+
+## Realitätsbeleg: tritt der Fall überhaupt auf?
+
+Ja, gemessen in den Produktivlogs (`journalctl -u gregor-python`):
+
+| Zeitraum | Modellwechsel |
+|---|---|
+| letzte 14 Tage | 2 (28.07. `meteofrance_arome`, 30.07. `icon_d2`, beide „transient") |
+| letzte 60 Tage | 10+, darunter am 08.07. vier 503-bedingte Wechsel binnen einer Sekunde |
+
+Bemerkenswert: **kein einziger CAPE-Lückenfüller-Fallback** in 14 Tagen (0 Treffer auf
+`Fallback … filled` mit `cape`). Der Modellwechsel passiert also nicht über
+`meta.fallback_model`, sondern über den Endpunkt-Wechsel des Primärmodells — genau der Weg,
+den `effective_cape_model_id()` über `meta.model` abbildet.
+
+Weil der Rückfall **transient** ist, wirkt er doppelt: Lauf N schreibt den Anker mit AROME,
+Lauf N+1 vergleicht mit ICON (Falschalarm), Lauf N+2 ist wieder AROME (zweiter Falschalarm in
+Gegenrichtung).
+
+## Risks & Considerations
+
+1. **Der Guard unterdrückt — das ist die eigentliche Gefahr.** Zu weit gefasst, verschwinden
+   echte Gewitter-Änderungsalarme lautlos. Dieses Fehlerbild hatten wir schon zweimal (#1584:
+   Regel konnte strukturell nie auslösen; #1555: Alarme wurden system-weit nie zugestellt).
+   Der Adversary-Lauf muss gezielt prüfen, ob bei **gleichem** Modell noch alles feuert.
+2. **Altbestand ohne Herkunft.** Anker von vor dem 08.08. tragen `cape_model_id: None`. Fasst
+   der Guard „None vs. icon_d2" als Modellwechsel auf, schweigen die Alarme, bis der Anker
+   einmal neu geschrieben ist. Für Trips ist das harmlos (täglicher Report überschreibt), für
+   den Ortsvergleich siehe Punkt 3. Die Alternative — „None heißt egal" — wäre die
+   gefährlichere Wahl, weil sie genau den unbelegten Fall durchwinkt.
+3. **OFFEN, nicht gemessen: trägt der Ortsvergleich die Herkunft wirklich?** Die Code-Kette
+   spricht dafür (`CompareLocationWeatherSource.fetch` → `SegmentWeatherService` →
+   `WeatherMetricsService:802`, also derselbe Weg wie beim Trip). **Ein Beleg am laufenden
+   System fehlt aber:** alle 13 Compare-Anker in Produktion stammen vom 31.07. und tragen das
+   Feld nicht — seither wurde kein Compare-Report versendet, und #1584 Scheibe C verwirft
+   Anker älter als 26 h ohnehin. Die Aussage bleibt damit hergeleitet. Nachweis gehört in die
+   Spec (Staging: Compare-Report auslösen, geschriebenen Anker aufmachen).
+4. **Reichweite der Regel.** Herkunft gibt es nur für CAPE. Andere Metriken (Wind,
+   Niederschlag) streuen zwischen Modellen ebenfalls, tragen aber keine Herkunftsangabe — ein
+   Guard für sie wäre nicht baubar, ohne das Fundament zu verbreitern. Spec-Entscheidung:
+   Scheibe bleibt auf CAPE.
+5. **Toter Code als Falle.** `trip_alert.py:604-632` enthält ein zweites, unerreichbares
+   `_detect_all_changes` (seit #1168 ersetzt). Wer den Guard dort einbaut, härtet einen Pfad,
+   den niemand geht — bekanntes Muster aus dem Memory („Adversary härtet ggf. den falschen
+   Pfad"). Der Prüfort ist `DeviationAlertEngine`.
+
+## Analysis
+
+### Type
+
+Bug. Fehlende Prüfung im Δ-Pfad, kein neues Verhalten.
+
+### Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/services/weather_change_detection.py` | MODIFY | Guard nach `threshold = effective_threshold` (:634): `old_summary.cape_model_id != new_summary.cape_model_id` ⇒ `continue` |
+| `tests/tdd/test_cape_delta_modellschwelle.py` | MODIFY | 3 Testfälle + Helfer mit getrennter Alt-/Neu-Herkunft (der bestehende `_cape_pair`, :88-111, kennt nur EINEN gemeinsamen Wert) |
+
+### Scope Assessment
+
+- Produktivcode: 1 Datei, 3-6 LoC · Test: 1 Datei, 50-90 LoC · **Summe ~55-95 LoC** (Limit 250)
+- Risiko: MEDIUM — winziger Eingriff, aber im unbeaufsichtigten Alarm-Pfad
+
+### Technical Approach
+
+Der Guard sitzt **nach** dem bestehenden Schwellen-Abstain, nicht davor. Das ist keine
+Stilfrage: `cape_delta_threshold_jkg()` bricht bereits ab, wenn die Herkunft des **frischen**
+Werts unbelegt ist. Nach dieser Zeile ist `new_summary.cape_model_id` also garantiert belegt —
+der Vergleich prüft damit faktisch nur noch die Alt-Seite und kann bei gleichem Modell
+strukturell nicht fälschlich unterdrücken. Stünde der Guard davor, meldete er „Modellwechsel",
+wo in Wahrheit gar kein zweites Modell im Spiel ist, sondern schlicht keine Eichung vorliegt.
+
+### Entscheidung: `None` zählt als Abweichung (Regel a)
+
+Von drei denkbaren Regeln ist nur diese konsistent zum bestehenden Code:
+
+- **(a) `alt != neu` ⇒ kein Alarm, `None` zählt mit** ← gewählt
+- (b) nur bei zwei belegten, verschiedenen Werten ⇒ kein Alarm: behandelt „unbekannt" auf der
+  Alt-Seite als alarmwürdig, während dieselbe Unbekanntheit auf der Neu-Seite seit C3 zum
+  Abstain führt. Widersprüchlich — und erzeugt beim ersten Lauf nach jedem Anker-Neuaufbau
+  genau den Fehlalarm, den #1601 beseitigen soll.
+- (c) wie (a), aber mit eigenem Grund „nicht belegt": verhaltensgleich, verlangt aber
+  Begründungs-Infrastruktur pro Metrik, die es nicht gibt (`detect_changes` kennt kein
+  Reason-Tracking; `EvaluationResult.suppressed_reason` sitzt eine Ebene höher und kennt drei
+  feste Werte). Aufwand ohne Abnehmer.
+
+### Gegenangriff auf diese Analyse (analysis-challenger, VERDICT CONFIRMED)
+
+Alle vier Kernbehauptungen halten am Code stand — insbesondere zwei, die ich nur hergeleitet
+hatte: Das Aggregat wird auf dem gesamten Weg vom geladenen Vergleichspunkt bis zur
+Vergleichsstelle **nirgends neu gebaut** (`point_weather.py:96-110` und
+`deviation_alert_engine.py:74-77` reichen dasselbe Objekt durch), und die Log-Zeile
+„Model fallback" bedeutet tatsächlich einen Wechsel der Modellwelt: die fünf Einträge in
+`REGIONAL_MODELS` sind disjunkt und bilden 1:1 auf sich selbst ab, der erfolgreiche Kandidat
+landet über `_parse_response()` in `meta.model`. Kein Endpunktwechsel innerhalb derselben Welt.
+
+### Zwei Befunde aus dem Gegenangriff
+
+**1. Gemischte Etappen sind kein Altbestands-, sondern ein Dauerfall.** Die Aggregation setzt
+`cape_model_id` nur, wenn alle Segmente einer Etappe dasselbe Modell tragen — sonst `None`
+(`weather_metrics.py:837,1196-1203`, Regel `agreement`). Eine Etappe an einer Modell-Gitter-
+grenze liefert damit **jeden Tag** `None`. Wichtig für die Einordnung: dort greift schon heute
+der C3-Abstain (Neu-Seite unbelegt), CAPE-Änderungsalarme feuern dort also bereits seit
+gestern nie — **das ist Erbe von #1592 C3, nicht Folge dieses Guards.** Der Guard fügt genau
+einen Fall hinzu: Alt gemischt (`None`), Neu einheitlich ⇒ kein Alarm. Das ist fachlich
+richtig, weil ein Mischwert und ein Einzelmodellwert nicht vergleichbar sind.
+Gemessen: der heutige Produktiv-Trip hat 5 von 5 Etappen einheitlich `icon_d2`, also keinen
+Mischfall. Für Grenzrouten (Korsika/Festland) liegt **keine Messung** vor.
+
+**2. Ein zugestellter Falschalarm durch Modellwechsel ist NICHT belegt.** Der Mechanismus ist
+belegt (10+ Modellwechsel in 60 Tagen), die Auswirkung nicht. Im Alarm-Log aller drei Nutzer
+stehen genau **2 CAPE-Änderungsalarme** (05.08. LOW, 06.08. MODERATE, beide
+`reason: forecast_change`) — an beiden Tagen gab es keinen Modellwechsel. Die Begründung für
+#1601 bleibt damit: der Weg ist offen und wird begangen, ein Schaden ist noch nicht
+nachgewiesen. Das ist ein Argument für den Fix, aber keins für Eile.
+(Messhinweis: die Alarm-Logs haben je Nutzer zwei Formate — Liste bzw. Objekt mit `entries`.
+Wer die falsche Ebene liest, zählt 0 statt 2.)
+
+### Open Questions (für die Spec)
+
+- [ ] Nachweis, dass der Ortsvergleich die Herkunft wirklich mitschreibt — am laufenden System,
+      nicht am Code. In Produktion gibt es keinen frischen Compare-Vergleichspunkt.
+- [ ] Soll ein Grenzrouten-Dauerschweigen (Befund 1) als eigener Befund gegen #1592 C3
+      gebucht werden? Betrifft nicht diese Scheibe.
+
+## Testabdeckung heute
+
+18 Testdateien fassen `detect_changes` an; die einzige, die den CAPE-Sonderpfad direkt prüft,
+ist `tests/tdd/test_cape_delta_modellschwelle.py` (9 Tests, inkl. `test_ac7_…`, das bewusst
+über `DeviationAlertEngine` — also den Live-Pfad — geht).
+
+**Kein einziger Test prüft Herkunfts-Identität zwischen alter und neuer Basis.** Der Helper
+`_seg(...)` (Zeile 89-106) setzt für alt und neu immer denselben Modellschlüssel; ein
+Modellwechsel kommt in keinem Testfall vor. Die Lücke aus dem Issue ist damit bestätigt.

--- a/docs/features/gewitter-gesamtkonzept.md
+++ b/docs/features/gewitter-gesamtkonzept.md
@@ -230,6 +230,12 @@ tragen.**
 > (1200/600/200) unverändert gegen jedes Modell; sie übersetzen die Stufe seither in dieselbe
 > Modellwelt wie die Fusion. Ortsvergleich und Schnappschuss-Reload führen weiterhin strukturell
 > keine Modell-Herkunft, dort trägt CAPE dauerhaft nicht bei — das bleibt unverändert.
+>
+> ✅ **#1601 (2026-08-09): Modellwechsel zwischen zwei Läufen löst keinen CAPE-Änderungsalarm
+> mehr aus.** Wechselt das liefernde Modell zwischen dem gespeicherten Anker und dem frischen
+> Wert (`cape_model_id` alt ≠ neu, `None` zählt als Abweichung), unterbleibt der Alarm — die
+> Modellwelt-Umrechnung aus C3 gilt nur innerhalb derselben Modellwelt. Betrifft beide
+> Alarmwege (Trip, Ortsvergleich) über die geteilte `DeviationAlertEngine`.
 
 ### 3.5 Die CAPE-Deckelung ist belegt ersetzbar (Recherche 2026-08-08)
 

--- a/docs/reference/decision_matrix.md
+++ b/docs/reference/decision_matrix.md
@@ -110,6 +110,14 @@ die Stufe seither in dieselbe Modellwelt wie die Fusion
 (`wirksame Δ-Schwelle = nominale Stufe × cape_threshold_jkg(modell, gebiet) / 1000`). Beide
 Scheiben unter #1592.
 
+✅ **Modellwechsel zwischen zwei Läufen unterdrückt den CAPE-Änderungsalarm (#1601).** Die
+Modellwelt-Umrechnung oben setzt voraus, dass Alt- und Neu-Wert aus derselben Modellwelt
+stammen. Stimmen `cape_model_id` von altem und neuem Stand nicht überein (`None` auf der
+Alt-Seite zählt als Abweichung), entsteht **kein** Alarm — sonst würde ein reiner
+Modellwechsel (z. B. AROME→ICON beim Open-Meteo-Fallback) als Wetteränderung gemeldet, obwohl
+sich am Wetter nichts geändert hat. Guard sitzt in `weather_change_detection.py`, wirkt über
+`DeviationAlertEngine` auf Trip- und Ortsvergleich-Alarme gleichermaßen.
+
 **Für jede weitere Quelle (z. B. Hagel, S5/#1475):** Eine neue Größe dockt mit **einer
 Tabellenzeile** an — Provider füllt nur Felder, die Einstufung liest nur Felder (Konzept
 #1419 Abschnitt 5), wie beim Blitzpotenzial in #1474c geschehen. **Keine eigene

--- a/docs/specs/modules/fix_1601_modellwechsel_alarm.md
+++ b/docs/specs/modules/fix_1601_modellwechsel_alarm.md
@@ -1,0 +1,195 @@
+---
+entity_id: fix_1601_modellwechsel_alarm
+type: bugfix
+created: 2026-08-09
+updated: 2026-08-09
+status: draft
+version: "1.0"
+tags: [cape, alarme, delta, modellwechsel, issue-1601]
+---
+
+# #1601 — Modellwechsel zwischen Δ-Anker und frischem Wert löst allein einen Alarm aus
+
+## Approval
+
+- [x] Approved — PO-go 2026-08-09 (alle 6 ACs unverändert freigegeben)
+
+## Purpose
+
+Der CAPE-Änderungsalarm vergleicht den gespeicherten Δ-Anker mit dem frisch abgerufenen Wert,
+ohne zu prüfen, ob beide vom selben Wettermodell stammen. Wechselt zwischen zwei Läufen das
+liefernde Modell (z.B. `meteofrance_arome` → `icon_d2`), springt die Zahl allein durch den
+Modellwechsel — und kann einen Alarm auslösen, obwohl sich das Wetter nicht geändert hat.
+Diese Scheibe fügt einen Herkunfts-Vergleich in den bestehenden CAPE-Sonderpfad ein: stimmen
+Alt- und Neu-Herkunft nicht überein, entsteht kein Änderungs-Alarm.
+
+## Source
+
+- **File:** `src/services/weather_change_detection.py`
+- **Identifier:** `WeatherChangeDetectionService.detect_changes()`, CAPE-Sonderpfad, direkt
+  nach `threshold = effective_threshold` (aktuell Zeile 634)
+
+Schicht: **Python-Core** (`src/services/`). Kein Go-, kein Frontend-Code betroffen.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `app.models.SegmentWeatherSummary.cape_model_id` | vorhanden (#1592 C0) | Herkunft am Δ-Anker (`old_summary`) und am frischen Wert (`new_summary`) |
+| `app.model_registry.cape_delta_threshold_jkg()` | vorhanden (#1592 C3) | Bestehender Abstain-Nachschlag; läuft unverändert vor dem neuen Guard |
+| `providers.thunder_routing.thunder_region_for()` | vorhanden | Gebietsbestimmung für die Schwellenumrechnung, unverändert |
+| `services.deviation_alert_engine.DeviationAlertEngine.evaluate()` | vorhanden | Einziger live erreichbarer Aufrufer von `detect_changes()`; Prüfort für AC-5 |
+| `services.compare_location_weather_source` → `services.segment_weather` → `services.weather_metrics` | vorhanden | Schreibt `cape_model_id` auch für Ortsvergleichs-Anker; Nachweis am laufenden System in AC-6 |
+
+## Scope
+
+### Affected Files
+| File | Change Type | Description |
+|---|---|---|
+| `src/services/weather_change_detection.py` | MODIFY | Guard nach `threshold = effective_threshold` (:634): `old_summary.cape_model_id != new_summary.cape_model_id` ⇒ `continue` |
+| `tests/tdd/test_cape_delta_modellschwelle.py` | MODIFY | Testfälle zur Modell-Identität + Erweiterung des bestehenden Helfers `_cape_pair` (:88-111), der aktuell nur EINEN gemeinsamen `cape_model_id`-Wert für Alt und Neu kennt und für getrennte Alt-/Neu-Herkunft erweitert werden muss |
+
+### Estimated Changes
+- Files: 2 (1 Produktiv, 1 Test)
+- LoC: Produktivcode ~3-6 / Test ~50-90 (Summe ~55-95, Limit 250)
+
+## Implementation Details
+
+Der Guard sitzt **nach** dem bestehenden Schwellen-Abstain, nicht davor: `cape_delta_threshold_jkg()`
+bricht bereits ab, wenn die Herkunft des **frischen** Werts unbelegt ist. Nach dieser Zeile ist
+`new_summary.cape_model_id` garantiert belegt — der neue Vergleich prüft damit faktisch nur noch,
+ob die Alt-Seite mit der (belegten) Neu-Seite übereinstimmt.
+
+```
+if metric == "cape_max_jkg":
+    ... (bestehender Abstain-Block, unverändert bis :634)
+    threshold = effective_threshold
+    if old_summary.cape_model_id != new_summary.cape_model_id:
+        continue
+```
+
+`None` zählt als Abweichung (Regel a, siehe Vorgänger-Kontextdokument
+`docs/context/fix-1601-modellwechsel-alarm.md` Abschnitt „Entscheidung: `None` zählt als
+Abweichung"): ein Δ-Anker ohne Herkunft (Altbestand vor #1592 C0, oder eine gemischte Etappe,
+die nach der Aggregationsregel `agreement` keine einheitliche Herkunft trägt) ist mit einem
+belegten frischen Wert nicht vergleichbar. Konsistent zum bestehenden Muster: „unbekannte
+Herkunft" führt im Δ-Pfad an jeder Stelle zu Abstain, nicht zu einem Ersatzwert.
+
+Der Sonderpfad wirkt für beide Alarmwege identisch, weil beide dieselbe
+`DeviationAlertEngine.evaluate()` → `detect_changes()`-Kette durchlaufen (Trip über
+`trip_alert.py:265`, Ortsvergleich über `compare_alert.py:371-374`).
+
+## Test Plan
+
+### Automated Tests (TDD RED)
+
+- [ ] Test 1 (Modellwechsel unterdrückt): GIVEN ein CAPE-Δ-Paar mit `old_summary.cape_model_id
+  = "meteofrance_arome"`, `new_summary.cape_model_id = "icon_d2"` und einem Sprung weit über
+  die wirksame Schwelle WHEN `detect_changes()` läuft THEN entsteht kein `WeatherChange` für
+  `cape_max_jkg`.
+- [ ] Test 2 (Vergleichspunkt ohne Herkunft): GIVEN `old_summary.cape_model_id = None`
+  (Zustand vor #1592 C0) und `new_summary.cape_model_id` belegt, großer Sprung WHEN
+  `detect_changes()` läuft THEN entsteht kein `WeatherChange` für `cape_max_jkg`.
+- [ ] Test 3 (Gegenprobe gleiches Modell): GIVEN Alt- und Neu-Herkunft identisch belegt
+  (z.B. beide `icon_d2`), Sprung über der wirksamen Schwelle WHEN `detect_changes()` läuft
+  THEN entsteht weiterhin ein `WeatherChange` für `cape_max_jkg` — der Guard unterdrückt nicht
+  mehr als beabsichtigt.
+- [ ] Test 4 (Normalfall): GIVEN Alt- und Neu-Herkunft identisch belegt, Sprung UNTER der
+  wirksamen Schwelle WHEN `detect_changes()` läuft THEN entsteht kein `WeatherChange` —
+  unverändert zu heute, kein Nebeneffekt des neuen Guards.
+- [ ] Test 5 (Wirkort, Modellwechsel über die Engine): GIVEN dieselbe Modellwechsel-Situation
+  wie Test 1, aber aufgerufen über `DeviationAlertEngine.evaluate()`
+  (`src/services/deviation_alert_engine.py:264`, den einzigen live erreichbaren Aufrufer) WHEN
+  die Auswertung läuft THEN ist `EvaluationResult.triggered is False` — ein Nachweis nur über
+  den direkten Aufruf von `detect_changes()` genügt nicht, weil der Alarmpfad in Produktion
+  ausschließlich über die Engine läuft.
+- [ ] Test 6 (Wirkort, Gegenprobe über die Engine): GIVEN dieselbe Situation wie Test 3, aber
+  aufgerufen über `DeviationAlertEngine.evaluate()` WHEN die Auswertung läuft THEN ist
+  `EvaluationResult.triggered is True` mit einem `cape_max_jkg`-Change — bestätigt, dass der
+  Guard den bestehenden, gewollten Alarmweg nicht mitunterdrückt.
+
+## Acceptance Criteria
+
+- **AC-1 (Modellwechsel unterdrückt):** Given ein CAPE-Δ-Vergleich, bei dem der Δ-Anker Modell
+  `meteofrance_arome` trägt und der frisch abgerufene Wert Modell `icon_d2`, mit einem Sprung
+  weit über die für das frische Modell wirksame Schwelle / When `detect_changes()` diesen
+  Vergleich auswertet / Then entsteht kein Änderungs-Alarm für `cape_max_jkg`, obwohl der
+  Sprung nominell alarmwürdig wäre.
+
+- **AC-2 (Vergleichspunkt ohne Herkunft):** Given ein Δ-Anker mit `cape_model_id = None` (Stand
+  vor #1592 C0 oder eine Etappe mit uneiniger Modellherkunft über ihre Segmente) und ein
+  frischer Wert mit belegtem Modell, mit einem großen CAPE-Sprung / When `detect_changes()`
+  diesen Vergleich auswertet / Then entsteht kein Änderungs-Alarm für `cape_max_jkg`, weil
+  `None` als Abweichung zählt und Alt- und Neu-Seite nicht vergleichbar sind.
+
+- **AC-3 (Gegenprobe gleiches Modell — die wichtigste):** Given ein Δ-Anker und ein frischer
+  Wert mit identischem, belegtem Modell (z.B. beide `icon_d2`), mit einem Sprung über der für
+  dieses Modell wirksamen Schwelle / When `detect_changes()` diesen Vergleich auswertet / Then
+  entsteht weiterhin ein Änderungs-Alarm für `cape_max_jkg` — der Guard darf den bestehenden,
+  gewollten Alarmweg nicht mitunterdrücken.
+
+- **AC-4 (Normalfall):** Given ein Δ-Anker und ein frischer Wert mit identischem, belegtem
+  Modell, mit einem Sprung unter der wirksamen Schwelle / When `detect_changes()` diesen
+  Vergleich auswertet / Then entsteht kein Änderungs-Alarm für `cape_max_jkg` — unverändert
+  zum heutigen Verhalten, kein Nebeneffekt des neuen Guards.
+
+- **AC-5 (Wirkort statt Codeort):** Given dieselben zwei Situationen aus AC-1 (Modellwechsel)
+  und AC-3 (gleiches Modell), aber aufgerufen über `DeviationAlertEngine.evaluate()`
+  (`src/services/deviation_alert_engine.py:264`) statt direkt über `detect_changes()` / When
+  die Auswertung läuft / Then bleibt `EvaluationResult.triggered` bei AC-1 `False` und bei AC-3
+  `True` — `DeviationAlertEngine.evaluate()` ist der einzige live erreichbare Aufrufer von
+  `detect_changes()` (Trip über `trip_alert.py:265`, Ortsvergleich über
+  `compare_alert.py:371-374`); ein Nachweis nur über den direkten Aufruf von `detect_changes()`
+  würde den toten, seit #1168 unerreichbaren Pfad in `trip_alert.py:604-632` genauso grün
+  zeigen wie den echten, ohne dass der Guard dort wirkt.
+
+- **AC-6 (Nachweis am laufenden System für den Ortsvergleich):** Given ein auf Staging frisch
+  ausgelöster Ortsvergleichs-Report für einen Ort mit bekanntem CAPE-Modell / When der Report
+  läuft und der dabei geschriebene Compare-Vergleichspunkt geöffnet wird / Then enthält dessen
+  gespeicherter Datensatz das Feld `cape_model_id` mit einem nicht-leeren Wert — bislang ist
+  diese Aussage nur aus dem Code hergeleitet, weil alle Compare-Anker in Produktion vom 31.07.
+  stammen und das Feld nicht tragen (seither kein Compare-Versand, und #1584 Scheibe C verwirft
+  Anker älter als 26 h ohnehin). Vorgehen: Compare-Report auf Staging für einen Testort
+  auslösen, die geschriebene Snapshot-Datei öffnen, `cape_model_id` am Aggregat prüfen.
+
+## Nicht in dieser Scheibe
+
+- **Andere Metriken als CAPE.** Nur CAPE trägt eine Herkunftsangabe (`cape_model_id`); ein
+  analoger Guard für Wind, Niederschlag o.ä. wäre ohne eigenes Fundament nicht baubar.
+- **Der tote Pfad `src/services/trip_alert.py:604-632`.** Ein zweites, seit #1168
+  unerreichbares `_detect_all_changes` — wird nicht angefasst, der Prüfort bleibt
+  `DeviationAlertEngine`.
+- **Das Dauerschweigen auf Etappen mit gemischter Modellherkunft.** Etappen an einer
+  Modell-Gitter-Grenze liefern jeden Tag `cape_model_id = None` (Aggregationsregel
+  `agreement`, `weather_metrics.py:837,1196-1203`) — dort greift schon heute der #1592-C3-
+  Abstain auf der Neu-Seite, CAPE-Änderungsalarme feuern dort also bereits seit dieser Scheibe
+  nie. Das ist Erbe von #1592 C3, nicht Folge des hier gebauten Guards, und wird hier nicht
+  korrigiert.
+- **Kein Reason-/Begründungs-Tracking pro Metrik.** `detect_changes()` kennt kein
+  Reason-Tracking, `EvaluationResult.suppressed_reason` kennt nur drei feste Werte auf einer
+  höheren Ebene — Begründungs-Infrastruktur für „unterdrückt wegen Modellwechsel" wird hier
+  nicht gebaut.
+
+## Risiko
+
+Ein zugestellter Falschalarm durch Modellwechsel ist bislang **nicht belegt**: im
+Alarm-Log aller drei Nutzer stehen in Produktion genau 2 CAPE-Änderungsalarme (05.08. und
+06.08.), beide an Tagen ohne gemessenen Modellwechsel. Der Mechanismus, der zu einem
+Falschalarm führen könnte, ist dagegen belegt: 10+ Modellwechsel binnen 60 Tagen in den
+Produktivlogs, davon mehrere transient (Lauf N liefert Modell A, Lauf N+1 Modell B, Lauf N+2
+wieder A) — jeder transiente Wechsel wirkt doppelt, da er einen Δ-Vergleich in beide
+Richtungen verfälscht. Der Weg ist offen und wird begangen, ein Schaden ist noch nicht
+nachgewiesen. Das rechtfertigt den Fix, nicht Eile — und die Gegenprobe (AC-3/AC-4) ist wegen
+der Gefahr eines zu weit gefassten Guards (vgl. #1584, #1555: Alarme, die strukturell nie
+bzw. nie zugestellt auslösen konnten) der wichtigste Testfall dieser Scheibe.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Kein neues ADR nötig — die Scheibe ergänzt einen bestehenden Sonderpfad um
+  einen zusätzlichen Abstain-Grund, ohne das Eichungs- oder Schwellenmodell aus ADR-0043/
+  ADR-0048 zu ändern.
+
+## Changelog
+
+- 2026-08-09: Initial spec created. Bezug: Issue #1601, Vorgänger #1592 (C0/C3), Epic #1419.

--- a/src/services/weather_change_detection.py
+++ b/src/services/weather_change_detection.py
@@ -633,6 +633,28 @@ class WeatherChangeDetectionService:
                     continue
                 threshold = effective_threshold
 
+                # Issue #1601: Der Delta-Anker und der frische Wert muessen aus
+                # DERSELBEN Modellwelt stammen -- sonst springt die Zahl allein
+                # durch den Modellwechsel, ohne dass sich das Wetter geaendert
+                # hat. `None` auf der Alt-Seite zaehlt als Abweichung: ein
+                # Vergleichspunkt ohne Herkunft ist mit einem belegten frischen
+                # Wert nicht vergleichbar (Abstain, wie ueberall im Delta-Pfad).
+                #
+                # Platzierung NACH dem Abstain oben ist heute verhaltensneutral:
+                # `detect_changes()` hat kein Begruendungs-Tracking pro Metrik,
+                # beide Reihenfolgen erzeugen byte-identische Ausgabe -- per
+                # Mutation gemessen (Adversary F001, kein Test wird rot, wenn
+                # der Guard vor den Abstain-Block wandert). Die Reihenfolge ist
+                # trotzdem sachlich richtig: nach dem Abstain ist
+                # `new_summary.cape_model_id` garantiert belegt, der Vergleich
+                # hier prueft also nur noch die Alt-Seite -- genau der Fall,
+                # den dieser Guard beschreiben will. Wer je eine
+                # Begruendungs-Ausgabe ergaenzt ("unterdrueckt wegen X"), muss
+                # diese Reihenfolge beibehalten -- dann wird sie
+                # verhaltensrelevant.
+                if old_summary.cape_model_id != new_summary.cape_model_id:
+                    continue
+
             # Convert enum values to ordinals for delta calculation.
             # Issue #1214 Scheibe 6: kanonische Ordnungsquelle statt lokalem Dict.
             if isinstance(old_value, Enum):

--- a/tests/tdd/test_cape_delta_modellschwelle.py
+++ b/tests/tdd/test_cape_delta_modellschwelle.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from app.model_registry import cape_threshold_jkg
+from app.model_registry import cape_delta_threshold_jkg, cape_threshold_jkg
 from app.models import (
     ChangeSeverity,
     GPXPoint,
@@ -52,6 +52,17 @@ assert cape_threshold_jkg("meteofrance_arome", "FR") == 300.0, (
     "geändert (erwartet 300.0) — die hartcodierten Erwartungswerte 180.0 in "
     "AC-1/2/5/6 dieser Datei sind davon abgeleitet und müssen nachgezogen werden."
 )
+# Issue #1601 braucht ein ZWEITES, ebenfalls für FR geeichtes Modell, damit ein
+# Modellwechsel geprüft werden kann, ohne dass der C3-Abstain (unbelegte
+# Kombination) die Aussage überdeckt. icon_d2xFR ist geeicht und ergibt — wie
+# meteofrance_arome x FR — die wirksame Schwelle 600*300/1000 = 180.0.
+assert cape_threshold_jkg("icon_d2", "FR") == 300.0, (
+    "Testannahme verletzt: icon_d2xFR muss geeicht sein (erwartet 300.0) — "
+    "sonst greift bei den #1601-Fällen der C3-Abstain statt des "
+    "Herkunfts-Vergleichs, und sie würden aus dem falschen Grund grün."
+)
+assert cape_delta_threshold_jkg(600.0, "icon_d2", "FR") == 180.0
+assert cape_delta_threshold_jkg(600.0, "meteofrance_arome", "FR") == 180.0
 
 # EU_REST-Koordinaten, die NICHT in FR (lat 41.3-51.1 / lon -5.2-9.7) und
 # NICHT in DE_ALPEN (lat 43.17-58.09 / lon -3.95-20.35) fallen — Ostsee-Raum.
@@ -85,25 +96,54 @@ def _segment(lat: float, lon: float) -> TripSegment:
     )
 
 
+_UNSET = object()  # unterscheidet "nicht angegeben" von der gültigen Angabe None
+
+
 def _cape_pair(
-    *, old_cape: float, new_cape: float, cape_model_id, lat: float, lon: float
+    *,
+    old_cape: float,
+    new_cape: float,
+    cape_model_id=_UNSET,
+    lat: float,
+    lon: float,
+    old_model_id=_UNSET,
+    new_model_id=_UNSET,
 ) -> tuple[SegmentWeatherData, SegmentWeatherData]:
     """Baut ein (old_data, new_data)-Paar mit ausschließlich CAPE + Herkunft
     belegt — alle anderen Felder bleiben None (werden vom Detektor übersprungen,
-    s. `detect_changes()`: `old_value is None or new_value is None` → `continue`)."""
+    s. `detect_changes()`: `old_value is None or new_value is None` → `continue`).
+
+    Issue #1601: Alt- und Neu-Seite können jetzt UNTERSCHIEDLICHE Herkunft
+    tragen (`old_model_id`/`new_model_id`). Bewusst der bestehende Helfer
+    erweitert statt eines zweiten daneben: die #1592-C3-Fälle und die
+    #1601-Fälle müssen ihre DTOs auf demselben Weg bauen, sonst kann ein
+    künftiger Umbau die eine Bauart ändern und die andere unbemerkt zurück-
+    lassen — dann prüften beide Testgruppen verschiedene Objekte. `_UNSET`
+    hält die 9 bestehenden Aufrufstellen (`cape_model_id=...`, inkl.
+    `cape_model_id=None` in AC-3) unverändert gültig.
+    """
+    if old_model_id is _UNSET:
+        old_model_id = cape_model_id
+    if new_model_id is _UNSET:
+        new_model_id = cape_model_id
+    if old_model_id is _UNSET or new_model_id is _UNSET:
+        raise TypeError(
+            "_cape_pair: entweder `cape_model_id` (beide Seiten) oder "
+            "`old_model_id`+`new_model_id` angeben."
+        )
     segment = _segment(lat, lon)
     fetched_at = datetime(2026, 8, 8, 6, 0, tzinfo=timezone.utc)
     old_data = SegmentWeatherData(
         segment=segment,
         timeseries=None,
-        aggregated=SegmentWeatherSummary(cape_max_jkg=old_cape, cape_model_id=cape_model_id),
+        aggregated=SegmentWeatherSummary(cape_max_jkg=old_cape, cape_model_id=old_model_id),
         fetched_at=fetched_at,
         provider="test-scripted",
     )
     new_data = SegmentWeatherData(
         segment=segment,
         timeseries=None,
-        aggregated=SegmentWeatherSummary(cape_max_jkg=new_cape, cape_model_id=cape_model_id),
+        aggregated=SegmentWeatherSummary(cape_max_jkg=new_cape, cape_model_id=new_model_id),
         fetched_at=fetched_at,
         provider="test-scripted",
     )
@@ -456,3 +496,231 @@ def test_ac8_untouched_metrics_stay_byte_identical():
             f"AC-8 Regression: {field}.severity muss unverändert MAJOR "
             f"bleiben (2.5x Schwelle) — war {change.severity!r}."
         )
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Issue #1601 — Modellwechsel zwischen Δ-Anker und frischem Wert darf allein
+# KEINEN Änderungsalarm auslösen.
+#
+# Spec: docs/specs/modules/fix_1601_modellwechsel_alarm.md
+#
+# Wirksame Schwelle in allen Fällen unten: Preset "standard" (nominal 600)
+# × cape_threshold_jkg(<modell>, "FR") 300 / 1000 = 180.0 J/kg (oben per
+# Sanity-Assert festgenagelt, für BEIDE beteiligten Modelle identisch — der
+# Sprung ist also nicht durch eine andere Schwelle erklärbar, sondern nur
+# durch die Herkunft).
+# ═════════════════════════════════════════════════════════════════════════
+
+
+def _cape_point_pair(
+    *, old_cape: float, new_cape: float, old_model_id, new_model_id
+):
+    """Wie `_cape_pair`, aber für den Engine-Pfad: `DeviationAlertEngine`
+    arbeitet auf `PointWeatherData` (kein `TripSegment`), deshalb ein
+    eigener Bauweg — nicht aus Bequemlichkeit, sondern weil der DTO-Typ ein
+    anderer ist. Muster übernommen aus
+    `test_ac7_compare_path_via_deviation_alert_engine_inherits_conversion`."""
+    from services.point_weather import PointWeatherData
+
+    fetched_at = datetime(2026, 8, 8, 6, 0, tzinfo=timezone.utc)
+    old_point = PointWeatherData(
+        id="corse-test", name="Korsika-Testort", lat=CORSICA_LAT, lon=CORSICA_LON,
+        timeseries=None,
+        aggregated=SegmentWeatherSummary(cape_max_jkg=old_cape, cape_model_id=old_model_id),
+        fetched_at=fetched_at, provider="test-scripted",
+    )
+    fresh_point = PointWeatherData(
+        id="corse-test", name="Korsika-Testort", lat=CORSICA_LAT, lon=CORSICA_LON,
+        timeseries=None,
+        aggregated=SegmentWeatherSummary(cape_max_jkg=new_cape, cape_model_id=new_model_id),
+        fetched_at=fetched_at, provider="test-scripted",
+    )
+    return old_point, fresh_point
+
+
+def test_modellwechsel_unterdrueckt_cape_aenderungsalarm():
+    """
+    GIVEN ein CAPE-Δ-Paar auf Korsika (FR), Δ-Anker vom Modell
+          `meteofrance_arome`, frischer Wert vom Modell `icon_d2`
+    WHEN  das CAPE-Maximum um 1000 J/kg springt (500 -> 1500) — weit über
+          der wirksamen Schwelle 180 (und sogar über der nominalen 600)
+    THEN  entsteht KEIN WeatherChange für cape_max_jkg, weil der Sprung
+          allein durch den Modellwechsel erklärbar ist.
+
+    RED heute: `detect_changes()` vergleicht die Herkunft der beiden Seiten
+    nicht und feuert (1000 > 180) -> Alarm, obwohl sich das Wetter nicht
+    geändert haben muss. (AC-1)
+    """
+    old_data, new_data = _cape_pair(
+        old_cape=500.0, new_cape=1500.0,
+        old_model_id="meteofrance_arome", new_model_id="icon_d2",
+        lat=CORSICA_LAT, lon=CORSICA_LON,
+    )
+    service = WeatherChangeDetectionService(thresholds={"cape_max_jkg": 600.0})
+    changes = service.detect_changes(old_data, new_data)
+
+    assert _cape_changes(changes) == [], (
+        "AC-1: Δ-Anker (meteofrance_arome) und frischer Wert (icon_d2) "
+        "stammen aus verschiedenen Modellwelten — der Sprung ist allein "
+        "dadurch erklärbar und darf KEIN cape_max_jkg-Ereignis erzeugen."
+    )
+
+
+def test_anker_ohne_modellherkunft_unterdrueckt_cape_aenderungsalarm():
+    """
+    GIVEN ein Δ-Anker ohne Herkunft (`cape_model_id=None` — Altbestand vor
+          #1592 C0 oder eine Etappe mit uneiniger Modellherkunft) und ein
+          frischer Wert mit belegter Herkunft (`icon_d2`)
+    WHEN  das CAPE-Maximum um 1000 J/kg springt (500 -> 1500)
+    THEN  entsteht KEIN WeatherChange für cape_max_jkg — `None` zählt als
+          Abweichung, die beiden Seiten sind nicht vergleichbar.
+
+    RED heute: der C3-Abstain schaut nur auf die NEU-Seite (dort belegt),
+    die Alt-Seite bleibt ungeprüft -> Alarm entsteht. (AC-2)
+    """
+    old_data, new_data = _cape_pair(
+        old_cape=500.0, new_cape=1500.0,
+        old_model_id=None, new_model_id="icon_d2",
+        lat=CORSICA_LAT, lon=CORSICA_LON,
+    )
+    service = WeatherChangeDetectionService(thresholds={"cape_max_jkg": 600.0})
+    changes = service.detect_changes(old_data, new_data)
+
+    assert _cape_changes(changes) == [], (
+        "AC-2: ein Δ-Anker ohne Herkunft (None) ist mit einem belegten "
+        "frischen Wert nicht vergleichbar — kein cape_max_jkg-Ereignis."
+    )
+
+
+def test_gleiches_modell_ueber_schwelle_loest_weiterhin_aus():
+    """
+    GIVEN Δ-Anker und frischer Wert mit IDENTISCHER, belegter Herkunft
+          (beide `icon_d2`, Korsika/FR, wirksame Schwelle 180)
+    WHEN  das CAPE-Maximum um 250 J/kg springt (500 -> 750)
+    THEN  entsteht weiterhin ein WeatherChange für cape_max_jkg mit
+          threshold 180.0.
+
+    Diese Gegenprobe ist der wichtigste Testfall der Scheibe: sie ist HEUTE
+    schon grün und bewacht, dass der kommende Herkunfts-Guard nicht mehr
+    unterdrückt als vorgesehen. Der Sprung liegt bewusst zwischen der
+    umgerechneten (180) und der nominalen (600) Schwelle — er kann also nur
+    dann grün sein, wenn die C3-Umrechnung weiter greift. (AC-3)
+    """
+    old_data, new_data = _cape_pair(
+        old_cape=500.0, new_cape=750.0,
+        cape_model_id="icon_d2", lat=CORSICA_LAT, lon=CORSICA_LON,
+    )
+    service = WeatherChangeDetectionService(thresholds={"cape_max_jkg": 600.0})
+    changes = service.detect_changes(old_data, new_data)
+
+    cape_changes = _cape_changes(changes)
+    assert cape_changes, (
+        "AC-3: bei identischer Herkunft (beide icon_d2) muss ein Sprung von "
+        "250 J/kg über der wirksamen Schwelle 180 weiterhin ein "
+        "cape_max_jkg-Ereignis erzeugen — der Herkunfts-Guard darf den "
+        "gewollten Alarmweg nicht mitunterdrücken."
+    )
+    assert cape_changes[0].threshold == 180.0
+
+
+def test_gleiches_modell_unter_schwelle_bleibt_still():
+    """
+    GIVEN Δ-Anker und frischer Wert mit identischer, belegter Herkunft
+          (beide `icon_d2`, Korsika/FR, wirksame Schwelle 180)
+    WHEN  das CAPE-Maximum nur um 150 J/kg springt (500 -> 650)
+    THEN  entsteht KEIN WeatherChange für cape_max_jkg.
+
+    Normalfall, heute schon grün — belegt, dass ein Schweigen in den Fällen
+    AC-1/AC-2 nicht einfach das Schweigen aller kleinen Sprünge ist. (AC-4)
+    """
+    old_data, new_data = _cape_pair(
+        old_cape=500.0, new_cape=650.0,
+        cape_model_id="icon_d2", lat=CORSICA_LAT, lon=CORSICA_LON,
+    )
+    service = WeatherChangeDetectionService(thresholds={"cape_max_jkg": 600.0})
+    changes = service.detect_changes(old_data, new_data)
+
+    assert _cape_changes(changes) == [], (
+        "AC-4: 150 J/kg liegen unter der wirksamen Schwelle 180 — "
+        "unverändert kein Ereignis."
+    )
+
+
+def test_engine_modellwechsel_ergibt_kein_ausgeloestes_ergebnis():
+    """
+    GIVEN dieselbe Modellwechsel-Situation wie AC-1 (`meteofrance_arome` ->
+          `icon_d2`, Sprung 1000 J/kg), aber ausgewertet über den einzigen
+          live erreichbaren Aufrufer `DeviationAlertEngine.evaluate()`
+          (Trip über trip_alert.py:265, Ortsvergleich über
+          compare_alert.py:371-374)
+    WHEN  die Auswertung läuft
+    THEN  ist `EvaluationResult.triggered is False`.
+
+    Prüfort = Wirkort: ein Nachweis nur über den direkten `detect_changes()`-
+    Aufruf würde den seit #1168 toten Pfad genauso grün zeigen wie den
+    echten. RED heute: die Engine meldet triggered=True. (AC-5)
+    """
+    from services.deviation_alert_engine import DeviationAlertEngine
+    from services.point_weather import AlertEvaluationConfig
+
+    old_point, fresh_point = _cape_point_pair(
+        old_cape=500.0, new_cape=1500.0,
+        old_model_id="meteofrance_arome", new_model_id="icon_d2",
+    )
+    config = AlertEvaluationConfig(
+        cooldown_minutes=0, quiet_from=None, quiet_to=None,
+        metric_alert_levels={"cape": "standard"}, channels={"email"},
+    )
+    engine = DeviationAlertEngine()
+    result = engine.evaluate(
+        [old_point], [fresh_point], config, alert_state={},
+        now=datetime(2026, 8, 8, 10, 0, tzinfo=timezone.utc),
+    )
+
+    assert result.triggered is False, (
+        f"AC-5: am Wirkort (DeviationAlertEngine.evaluate) darf ein reiner "
+        f"Modellwechsel meteofrance_arome -> icon_d2 keinen Alarm auslösen — "
+        f"war triggered={result.triggered!r} mit changes="
+        f"{[(c.metric, c.delta, c.threshold) for c in result.changes]!r}."
+    )
+    assert _cape_changes(result.changes) == []
+
+
+def test_engine_gleiches_modell_loest_weiterhin_aus():
+    """
+    GIVEN dieselbe Situation wie AC-3 (beide Seiten `icon_d2`, Sprung
+          250 J/kg über der wirksamen Schwelle 180), ausgewertet über
+          `DeviationAlertEngine.evaluate()`
+    WHEN  die Auswertung läuft
+    THEN  ist `EvaluationResult.triggered is True` mit einem
+          cape_max_jkg-Change.
+
+    Gegenprobe am Wirkort, heute schon grün — bewacht, dass der Guard den
+    bestehenden, gewollten Alarmweg auch über die Engine nicht
+    mitunterdrückt. (AC-5, zweite Hälfte)
+    """
+    from services.deviation_alert_engine import DeviationAlertEngine
+    from services.point_weather import AlertEvaluationConfig
+
+    old_point, fresh_point = _cape_point_pair(
+        old_cape=500.0, new_cape=750.0,
+        old_model_id="icon_d2", new_model_id="icon_d2",
+    )
+    config = AlertEvaluationConfig(
+        cooldown_minutes=0, quiet_from=None, quiet_to=None,
+        metric_alert_levels={"cape": "standard"}, channels={"email"},
+    )
+    engine = DeviationAlertEngine()
+    result = engine.evaluate(
+        [old_point], [fresh_point], config, alert_state={},
+        now=datetime(2026, 8, 8, 10, 0, tzinfo=timezone.utc),
+    )
+
+    assert result.triggered is True, (
+        f"AC-5 Gegenprobe: bei identischer Herkunft muss die Engine weiter "
+        f"auslösen — war triggered={result.triggered!r} suppressed_reason="
+        f"{result.suppressed_reason!r}."
+    )
+    cape_changes = _cape_changes(result.changes)
+    assert cape_changes, "AC-5 Gegenprobe: cape_max_jkg-Ereignis fehlt im Engine-Pfad."
+    assert cape_changes[0].threshold == 180.0


### PR DESCRIPTION
Behebt #1601 (Issue wird erst nach bestandenem Prod-Selftest geschlossen).

## Problem

Der Δ-Pfad verglich den gespeicherten CAPE-Wert mit dem frisch abgerufenen, **ohne zu prüfen, ob beide vom selben Wettermodell stammen**. Wechselt zwischen zwei Läufen das liefernde Modell, springt die Zahl allein dadurch — bis hin zur schwersten Alarmstufe, ohne dass sich das Wetter geändert hat.

Belegt in Produktion: 10+ Modellwechsel in 60 Tagen (`Model fallback: … → next endpoint`), davon mehrere transient — Lauf N liefert AROME, Lauf N+1 ICON, Lauf N+2 wieder AROME. Jeder transiente Wechsel verfälscht den Vergleich **in beide Richtungen**.

Ehrliche Einordnung: ein tatsächlich **zugestellter** Falschalarm ist nicht nachgewiesen. Im Alarm-Log aller drei Nutzer stehen genau 2 CAPE-Änderungsalarme (05.08., 06.08.), beide an Tagen ohne Modellwechsel. Belegt ist der offene Weg, nicht der eingetretene Schaden.

## Lösung

Guard im CAPE-Sonderpfad, **nach** dem bestehenden Schwellen-Abstain (`weather_change_detection.py`): stimmen alte und neue Herkunft nicht überein, entsteht kein Alarm. `None` auf der Alt-Seite zählt als Abweichung. Wirkt über die geteilte `DeviationAlertEngine` auf **beide** Alarmwege.

Zwei wirksame Zeilen. Das Fundament stand bereits aus #1592 C0 — entgegen der Annahme im Ticket: der Prod-Schnappschuss von heute 05:00 UTC trägt `cape_model_id: icon_d2` an jeder Etappe.

## Nachweis

- 6 Tests, **3 davon vor dem Fix rot** — inklusive Nachweis über die Engine als einzigem live erreichbaren Aufrufer (der zweite Pfad in `trip_alert.py:604` ist seit #1168 tot)
- Adversary **VERIFIED**: von 5 Mutationen fangen die Tests 4. Die unbewachte fünfte (Reihenfolge des Guards) ist nachweislich verhaltensneutral — der zuvor irreführende Kommentar wurde daraufhin korrigiert
- Vollsuite 7201 grün; die 2 Roten in `test_issue_1014_live_optin.py` laufen isoliert grün und sind mit dem neueren `tests/conftest.py` aus `main` auch dort grün
- Doku ergänzt: ADR-0048, `decision_matrix.md`, `gewitter-gesamtkonzept.md` §3.4b beschrieben den Δ-Mechanismus bisher unvollständig

## Offen bis Staging

**AC-6** — Nachweis am laufenden System, dass der Ortsvergleich `cape_model_id` mitschreibt. Bisher nur aus dem Code hergeleitet; in Produktion existiert kein frischer Compare-Anker (alle vom 31.07.).

Umfang 300 Zeilen (Grenze für diesen Vorgang auf 350 angehoben, PO-Entscheid — 278 Zeilen davon sind Tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxyuCgpKtbf16da3Cx88zy
