### PR TITLE
fix(#1426): Sammelversand-Ersatzweg behandelt Empfaenger einzeln

### DIFF
--- a/docs/context/fix-1426-sammelversand-ersatzweg.md
+++ b/docs/context/fix-1426-sammelversand-ersatzweg.md
@@ -1,0 +1,282 @@
+# Context: fix-1426-sammelversand-ersatzweg
+
+## Request Summary
+Sammelversand an mehrere Empfänger (erreichbar über Ortsvergleich-Presets) hat zwei
+zusammenhängende Defekte in `EmailOutput`: (A) die beiden Ersatz-Postausgänge brechen
+beim ersten abgelehnten Empfänger komplett ab, statt wie der Primärweg jeden Empfänger
+einzeln zu behandeln; (B) lehnt der Mailserver *alle* Empfänger ab, meldet `send()`
+trotzdem Erfolg, weil jede Ablehnung nur geloggt wird und kein Erfolgs-Check existiert.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `src/output/channels/email.py` | Kernstück. `_dial_and_send()` (:456) ist seit #1412 S3a der EINE Transport-Ort für Primär- und beide Ersatzwege. Docstring dort verweist bereits explizit auf #1426 als offen. `send()` (:596-975) orchestriert Retry/Ersatzweg-Auswahl. |
+| `tests/test_mail_recipient_parity.py` | Bestehender Struktur-Test (`_finde_guard_if`) sucht die Empfänger-Guard-`If`-Anweisung als **oberste Ebene** von `send()` — kein `ast.walk`. Bei Umbau von `send()` prüfen, ob dieser Test noch die richtige Region trifft (siehe Memory-Falle unten). |
+| `tests/tdd/test_telegram_test_mode_guard.py:278-303` | Vorbild-Testmuster laut Issue: Sink am Transportrand, der je Empfänger gezielt ablehnt. |
+| `src/services/notification_service.py` | Aufrufer von `EmailOutput(...).send(...)` — u. a. Zeile 736/762 (Compare-Mehrempfänger-Pfad), 469, 835, 974, 1198, 1311, 1466/1502 (überwiegend Einzelempfänger). |
+| `src/services/scheduler_dispatch_service.py:333` | Ortsvergleich-Preset liefert Feld `empfaenger` (Fallback `mail_to` bei leer, `:338`) — Einstiegspunkt für Mehrempfänger-Versand. |
+| `src/services/radar_alert_service.py:96` | Weiterer direkter `EmailOutput(...).send(...)`-Aufrufer, ebenfalls betroffen falls Mehrempfänger. |
+
+## Existing Patterns
+
+- **`isolate_per_recipient`-Parameter** (`_dial_and_send`, :465) steuert bereits die
+  Asymmetrie: Primärweg (`True`, aufgerufen `:836`) fasst jeden `sendmail()`-Call in
+  `try/except smtplib.SMTPException` (:501-522) und loggt nur; beide Ersatzwege
+  (`False`, aufgerufen `:586` und `:900`) tun das nicht — ein `SMTPException` bei
+  einem Empfänger reißt die restliche Schleife (:523-524) mit.
+- Primärweg-Loop endet ohne Rückgabewert/Erfolgs-Tracking; `send()` interpretiert
+  jedes normale Return von `_dial_and_send()` als vollen Erfolg (`:843`).
+- `smtplib.SMTPServerDisconnected` wird VOR dem generischen `SMTPException`-Zweig
+  behandelt (:503-518) — bei einer Erweiterung um Erfolgs-Tracking darf dieser
+  Vorrang nicht verändert werden (Transportabbruch ≠ Empfänger-Ablehnung).
+- Guard-Reihenfolge in `send()` (Herkunftssperre #1476, Allowlist #1219) bleibt
+  unverändert vor der Dial-Schleife — dieser Fix betrifft nur, was *nach* dem Dial
+  passiert.
+
+## Dependencies
+
+- **Upstream (was `_dial_and_send`/`send` nutzt):** `smtplib.SMTP`, `_phase_timeout_or_raise()`
+  (#1448 S1 Zeitbudget), `_fallback_recipients_blocked()` (#1412 S1 Guard vor Ersatzweg).
+- **Downstream (was von `send()`/`EmailOutput` abhängt):** `notification_service.py`
+  (Trip- und Compare-Versand), `radar_alert_service.py` (Alarme). Ein geänderter
+  Fehlerfall (`OutputError` bei Totalablehnung) muss von diesen Aufrufern bereits
+  behandelbar sein — sie fangen `OutputError` schon heute für andere Fehlerarten ab.
+
+## Existing Specs
+- `docs/specs/bugfix/email_retry_mechanism_spec.md` v1.0 — Retry-Mechanismus (Referenz in `send()`-Docstring)
+- `docs/context/fix-1412-s3-transport-kapselung.md` — Analyse zu `_dial_and_send`, Abschnitt „Antwort auf Frage 1" (Ursprung der #1426-Erfassung)
+
+## Risks & Considerations
+
+- **Renderer-Commit-Gate (#811):** `src/output/channels/email.py` steht auf der
+  geschützten Liste (`.claude/hooks/renderer_mail_gate.py:45`). Commit blockiert,
+  bis im aktiven Workflow beide frisch vorliegen: `tests/tdd/test_issue_811_mode_matrix.py`
+  grün UND ein erfolgreicher `briefing_mail_validator.py`-Lauf.
+- **Struktur-Test-Falle (#1412-Memory):** `test_mail_recipient_parity.py::_finde_guard_if`
+  sucht die Guard-`If` nur auf der obersten Ebene von `send()`. Falls die Änderung
+  Logik in eine Hilfsmethode auslagert, könnte dieser Test „Region verloren" melden,
+  ohne dass die Guard-Prüfung selbst kaputt ist — vor Eingriff an `send()` gegenprüfen,
+  Fixture-Wert (`verzweigungen_python`) nicht blind nachziehen.
+- **Kombinierter Fix zwingend:** Issue betont ausdrücklich, A und B nur getrennt zu
+  fixen würde B auf die Ersatzwege ausbreiten (Einfassung ohne Erfolgs-Check).
+- **Kern-Schicht genügt:** Laut Issue kein Staging-Nachweis nötig — der Ersatzweg ist
+  im Betrieb praktisch nicht gezielt provozierbar, ein Sink-Test am Transportrand
+  (Vorbild `test_telegram_test_mode_guard.py`) ist der tragfähige Nachweis.
+- **`radar_alert_service.py:96`** ist ein weiterer direkter Aufrufer — prüfen, ob er
+  ebenfalls Mehrempfänger-Listen übergibt (bisher nicht verifiziert, nur Blast-Radius-Hinweis).
+
+## Bug Report (Intake-Phase Verifizierung)
+
+### Reproduktionspfad aus Nutzersicht
+
+**Szenario A — Ersatzweg bricht beim ersten abgelehnten Empfänger ab (Defekt A):**
+
+1. **Ausgangslage:** Ortsvergleich-Preset mit zwei oder mehr Empfängern (die Mehrempfänger-Unterstützung wird bereits vom Compare-Versand erwartet, s.u.)
+2. **Versandreihenfolge:** 
+   - `notification_service.py:835` → `EmailOutput(...).send(..., to=recipients, compare_hourly_enabled=..., mail_type="compare")`
+   - `email.py:597-843` Primärweg mit `isolate_per_recipient=True` (Zeile 836)
+   - Der Primärweg wird mit `smtplib.SMTP` verbunden (z.B. Resend)
+3. **Fehlerfall Primärweg-Rejection:**
+   - Primärserver lehnt den ersten oder einen mittleren Empfänger ab (z.B. `SMTPRecipientsRefused` auf ein lokales Testpostfach `gregor-test@henemm.com` mit 452-Quota-Limit)
+   - Die `try/except`-Einfassung (Zeile 501-522) fängt das auf, loggt nur (:520-522), Schleife läuft weiter
+   - Die übrigen Empfänger werden versendet
+4. **Fehlerfall Ersatzweg (isolate_per_recipient=False, Zeile 586):**
+   - Primärweg schlägt mit `OSError`/Timeout/Netz komplett fehl (nicht Empfänger-Einzelablehnung)
+   - `_handle_transient_dial_failure()` wird aufgerufen (Zeile 814 oder :882), versucht Ersatzweg (Zeile 578)
+   - Ersatzweg wird mit `isolate_per_recipient=False` aufgerufen (Zeile 586)
+   - **Defekt:** Zeile 524 hat KEINEN try/except für das zweite und folgende `sendmail()`-Aufrufe
+   - Erster Empfänger wird versendet, zweiter Empfänger wird ABGELEHNT → **`SMTPException` wird nicht gefangen**, Schleife bricht ab
+   - Alle Empfänger 3+ bekommen nichts, **obwohl sie vielleicht akzeptabel wären** (z.B. andere Provider, andere Quota)
+
+**Szenario B — Totalablehnung meldet Erfolg (Defekt B):**
+
+1. **Ausgangslage:** Ortsvergleich mit zwei Empfängern, beide von derselben Quota-Grenze betroffen
+2. **Versandablauf Primärweg:**
+   - Server antwortet auf BEIDE `sendmail()`-Aufrufe mit `SMTPRecipientsRefused` (z.B. 452 "Quota exceeded")
+   - Beide Fehler werden in der `try/except` (Zeile 501-522) abgefangen und nur geloggt
+   - Schleife endet normal, `_dial_and_send()` kehrt nach Zeile 524 zurück (kein return-Statement, implizites `None`)
+3. **Erfolgs-Check in send():**
+   - Nach der `_dial_and_send()`-Rückkehr (Zeile 838) prüft der Code NICHT, ob überhaupt ein Empfänger erreicht wurde
+   - Zeile 843: einfach `return` — gibt dem Aufrufer (notification_service.py:835) den Eindruck, die Mail wurde versendet
+   - **Defekt:** Beide Empfänger wurden abgelehnt, aber `notification_service.py` sieht keinen Fehler, `mail_type="compare"` wird im Nutzer-Notifikations-State als Erfolg gebucht
+
+### Betroffene Code-Stellen
+
+| Datei | Zeilen | Defekt | Beschreibung |
+|-------|--------|--------|-------------|
+| `src/output/channels/email.py` | 500–524 | A | `if isolate_per_recipient:` → try/except nur bei `True`; bei `False` (Ersatzweg) kein Schutz |
+| `src/output/channels/email.py` | 523–524 | A | Ersatzweg-Zeile ohne try/except: `server.sendmail(from_addr, [recipient], msg.as_string())` |
+| `src/output/channels/email.py` | 836 | — | Primärweg-Aufruf mit `isolate_per_recipient=True` (korrekt) |
+| `src/output/channels/email.py` | 586 | — | Ersatzweg-Aufruf mit `isolate_per_recipient=False` (hier sitzt Defekt A) |
+| `src/output/channels/email.py` | 838–843 | B | Nach `_dial_and_send()` kein Erfolgs-Check; einfach `return` ohne zu prüfen, ob ein Empfänger erreicht wurde |
+| `src/services/notification_service.py` | 835–842 | — | Compare-Report-Versand mit `to=recipients` (mehrere möglich); ruft `EmailOutput(...).send()` ohne try/except auf (propagiert Fehler korrekt, aber Defekt B sorgt dafür, dass kein Fehler kommt) |
+
+### Reproduktionsmechanismus (Sink-Test-Vorbild)
+
+Nach Vorbild von `tests/tdd/test_telegram_test_mode_guard.py:278-303`:
+- Mock-Sink auf dem Primärweg: antwortet normal auf Empfänger 1, wirft `smtplib.SMTPRecipientsRefused` auf Empfänger 2+
+- Ersatzweg ausgewogen verfügbar (kein Netzfehler)
+- **Defekt A:** Ersatzweg-Loop bricht nach Empfänger 1 ab → Empfänger 2 wird nicht versendet
+- **Defekt B:** Primärweg-Loop mit zwei Empfängern, BEIDE Ablehnung → `send()` kehrt mit Code 0 (Erfolg) zurück
+
+### Offene Fragen zur Spec
+
+1. **Erfolgs-Semantik:** Was ist ein „erfolgreicher Versand" bei Mehrempfänger? Mindestens einer? Alle? Oder wird erwartet, dass der Aufrufer (notification_service.py) selbst `recipients` aufteilt und pro Empfänger einzeln aufruft?
+   - Aktueller Stand: `send()` dokumentiert kein Verhalten für Mehrempfänger-Totalablehnung (Defekt B)
+   
+2. **Ersatzweg-Fehlsammelstrategie:** Soll der Ersatzweg wie der Primärweg `isolate_per_recipient=True` nutzen und damit komplett asymmetrisch werden, oder bleibt die Asymmetrie bewusst?
+   - Laut Docstring (Zeile 474-478): die Asymmetrie ist bewusst konserviert als „heute noch so", wird aber als #1426 behoben — keine Aussage zur Zielform
+
+3. **Renderer-Commit-Gate #811:** `email.py` steht auf geschützter Liste. Tests `tests/tdd/test_issue_811_mode_matrix.py` und Validator `briefing_mail_validator.py` prüfen Mail-Inhalte, nicht Versand-Logik. Müssen bei dieser Änderung neue Tests hinzukommen (Mehrempfänger-Ablehnung), oder Bestands-Tests aktualisiert?
+   - Derzeit kein Bestandstest für Mehrempfänger-Fehlerfall bekannt
+
+### Zusammenfassung (< 300 Worte)
+
+**Root Cause:** Zwei zusammenhängende Implementierungsfehler im Sammelversand (`email.py:456-843`):
+- **(A) Ersatzweg-Abbruch:** Parameter `isolate_per_recipient` ist nur beim Primärweg `True` (mit try/except pro Empfänger), bei Ersatzwegen `False` (ohne Einfassung). Ein abgelehnter Empfänger (z.B. Quota 452 auf Ersatzserver) reißt die restliche Schleife mit.
+- **(B) Totalablehnung still:** Nach `_dial_and_send()` (Zeile 838) prüft `send()` nicht, ob überhaupt ein Empfänger erreicht wurde. Lehnt der Server alle Empfänger ab, kehrt `send()` normal zurück → `notification_service.py:835` sieht keinen Fehler.
+
+**Reproduktionspfad:** Ortsvergleich-Versand mit mehreren Empfängern via `notification_service.py:835` (`to=recipients`). Primärweg schlägt mit Netzfehler fehl oder ein Empfänger wird auf Primärweg abgelehnt, Ersatzweg wird versucht. Defekt A: Ersatzweg bricht ab. Defekt B: Primärweg lehnt alle ab, send() kehrt erfolgreich zurück.
+
+**Betroffene Dateien:** `src/output/channels/email.py` (Versand-Logik), `src/services/notification_service.py` (Compare-Aufrufer).
+
+**Offene Punkte:** (1) Sollte Erfolg = mindestens ein Empfänger erreicht oder alle? (2) Soll Ersatzweg auch `isolate_per_recipient=True` nutzen (symmetrisch)? (3) Welche neuen Testfälle für Mehrempfänger-Fehler nötig?
+
+## Strategische Bewertung
+
+### 1. Technischer Ansatz
+
+**Erfolgs-Semantik (Antwort auf offene Frage 1):** *Mindestens ein* Empfänger
+erreicht = Erfolg. Das ist konsistent mit dem bestehenden
+`isolate_per_recipient`-Zweck ("ein abgelehnter Empfänger reißt die übrigen
+nicht mit") und mit dem Fail-soft-Muster, das der Compare-Versand bereits für
+Telegram/SMS fährt (`notification_service.py`, AC-5 dort: "Telegram-/SMS-Fehler
+werden geloggt, reissen aber die anderen Kanaele nicht mit"). Nur *Total*-
+Ablehnung (0 von N zugestellt) ist ein Fehler.
+
+**Asymmetrie auflösen (Antwort auf offene Frage 2):** `isolate_per_recipient`
+als Parameter entfällt ersatzlos — beide Ersatzwege bekommen dieselbe
+try/except-Einfassung wie heute nur der Primärweg (Zeile 500–522). Eine
+Variante, die den Parameter behält und beide Aufrufer auf `True` umstellt,
+wäre funktional identisch, ließe aber einen toten Parameter mit falscher
+Suggestion ("hier gibt es noch eine Wahl") zurück — schlechter für die
+nächste Person, die den Code liest.
+
+**Erfolgs-Check-Ort:** *In* `_dial_and_send()`, nicht im Aufrufer. Es gibt
+drei Aufrufstellen (:828 Primärweg, :578 und :892 beide Ersatzwege) — den
+Zähl-und-Prüf-Code an einer Stelle zu halten vermeidet dreifache Duplikation.
+Konkret: eine lokale Liste `fehler: list[tuple[str, Exception]]` sammelt
+abgelehnte Empfänger in der bestehenden Schleife; nach der Schleife, wenn
+`len(fehler) == len(recipients)` (und `len(recipients) > 1` — der
+Ein-Empfänger-Fast-Path in Zeile 494–496 bleibt unverändert, dort propagiert
+eine Ablehnung schon heute korrekt als Exception), wird
+`raise OutputError("email", f"Alle {len(recipients)} Empfänger abgelehnt: …")`
+geworfen. Die drei Aufrufer brauchen dafür KEINE Änderung: der Primärweg-Call
+(:828) liegt in `send()`s eigenem try-Block, aber `OutputError` matcht keinen
+der nachfolgenden `except`-Zweige (alle smtplib-/OSError-spezifisch) und
+propagiert damit unverändert aus `send()` — exakt das gewünschte Verhalten
+(Totalablehnung ist ein permanenter Fehler, kein Retry-Kandidat). Die beiden
+Ersatzweg-Calls stehen bereits in einem `except Exception as fb_err: raise
+OutputError(..., f"fallback also failed: {fb_err}")`-Wrapper — eine dort
+geworfene `OutputError` läuft automatisch durch diesen Pfad und liefert die
+richtige, bereits vorhandene Fehlermeldungsform.
+
+**`SMTPServerDisconnected`-Vorrang bleibt unangetastet:** Der Fix ändert
+nichts an Reihenfolge oder Verhalten dieses Zweigs (Zeile 503–518) — er wird
+weiterhin VOR dem generischen `SMTPException`-Zweig geprüft und weiterhin
+sofort durchgereicht (kein Sammeln, kein Weitermachen), weil ein toter Socket
+kein Empfänger-Problem ist. Nur der bisher `else`-Zweig (Zeile 523–524, heute
+ungeschützt) bekommt dieselbe dreiteilige Struktur wie der `if`-Zweig.
+
+**Nettoeffekt am Code:** die `if isolate_per_recipient: … else: …`-Verzweigung
+in der Schleife entfällt zugunsten EINES Pfads; Signatur und alle drei
+Aufrufer verlieren das `isolate_per_recipient=`-Argument; nach der Schleife
+kommt der Fehler-Check.
+
+### 2. Risiko-Bewertung
+
+- **`test_mail_recipient_parity.py::_finde_guard_if` (Struktur-Test-Falle):**
+  KEIN Risiko bei diesem Zuschnitt. Der Guard-`If` mit dem Literal `"resend"`
+  liegt in `send()` bei Zeile 669 — weit VOR der Retry-Schleife (819ff.) und
+  strukturell unberührt von Änderungen in `_dial_and_send()`. Solange die
+  Änderung sich auf `_dial_and_send()`/`_handle_transient_dial_failure()` und
+  die drei Call-Sites beschränkt (kein Umbau von `send()`s Kontrollfluss vor
+  der Schleife), bleibt sowohl die Region-Findung als auch die
+  Verzweigungszahl (`verzweigungen_python`-Fixture) unverändert.
+- **Gate #811 (Renderer-Commit-Gate):** `email.py` steht auf der geschützten
+  Liste — normaler Ablauf, kein Sonderrisiko: `tests/tdd/test_issue_811_mode_matrix.py`
+  grün und ein frischer `briefing_mail_validator.py`-Lauf müssen vor dem
+  Commit vorliegen. Da dieser Fix reine Versand-*Logik* ändert (nicht
+  Mail-*Inhalt*/Rendering), sollte der Mode-Matrix-Test unberührt bleiben —
+  trotzdem Pflichtlauf vor Commit, nicht überspringbar.
+- **Ein Bestandstest zementiert aktuell genau Defekt A als Sollverhalten:**
+  `tests/tdd/test_mail_transport_dial_behaviour.py::test_ac3_ersatzweg_bricht_beim_ersten_abgelehnten_empfaenger_ab`
+  (Zeile 243–268, parametrisiert über beide Ersatzwege) erwartet explizit
+  `pytest.raises(OutputError)` nach genau zwei von drei Zustellversuchen und
+  kommentiert "nach dem abgelehnten Empfaenger darf kein weiterer folgen".
+  Dieser Test ist NICHT in `.github/ci_tdd_excludes.txt` gelistet, läuft
+  also heute grün in CI und wird durch den Fix zwangsläufig rot — er MUSS im
+  selben PR umgeschrieben werden (Vorbild: die direkt benachbarte
+  `test_ac2_primaerweg_stellt_trotz_einer_ablehnung_an_die_uebrigen_zu`,
+  Zeile 197–228, die dieselbe Erwartung für den Primärweg schon heute
+  korrekt formuliert — Ersatzweg-Pendant analog bauen, inkl. neuem Test für
+  Totalablehnung = Defekt B). Das ist der zentrale TDD-Umbaupunkt dieser
+  Schebe, kein Nebenbefund.
+- **Aufrufer (`notification_service.py:835`, Compare-Pfad):** kein
+  Nachzug nötig. Der Aufruf steht bereits ohne try/except (Docstring
+  Zeile 813–818: "Der E-Mail-Pfad propagiert Fehler unveraendert … damit ein
+  SMTP-Ausfall weiterhin als Fehler des Preset-Versands sichtbar bleibt") —
+  eine neu geworfene `OutputError` bei Totalablehnung fällt in denselben,
+  bereits vorgesehenen Pfad wie jeder andere SMTP-Fehler heute.
+- **`radar_alert_service.py:96`:** verifiziert — sendet praktisch immer an
+  genau einen Empfänger (`mail_settings.mail_to` oder `to`-Override, beides
+  einzelne Strings), trifft also den Ein-Empfänger-Fast-Path (Zeile 494–496),
+  der von diesem Fix unverändert bleibt. Kein Nachzugsbedarf.
+- **Verhaltensänderung für bestehende Fallback-Aufrufer, die heute (fälschlich)
+  einen Fehler sehen:** Fälle, in denen der Ersatzweg heute wegen Defekt A
+  einen `OutputError` wirft, obwohl tatsächlich ≥1 Empfänger zustellbar wäre,
+  werden nach dem Fix zu Erfolg (mit Log-Zeile pro abgelehntem Empfänger)  —
+  das ist die beabsichtigte Korrektur, aber jede Monitoring-/Alerting-Logik,
+  die sich auf die heutige Fehlerrate verlässt, sieht danach weniger
+  `OutputError`s aus diesem Pfad. Kein bekannter Konsument tut das; nur zur
+  Vollständigkeit genannt.
+
+### 3. Scope-Schätzung
+
+| Datei | Art | ~LoC |
+|---|---|---|
+| `src/output/channels/email.py` | `_dial_and_send()`-Schleife vereinheitlichen + Erfolgs-Check, Signatur + Docstring, 3 Call-Sites (Parameter entfernen) | ~40–60 (netto eher −10 bis +30, da die `if/else`-Verzweigung entfällt) |
+| `tests/tdd/test_mail_transport_dial_behaviour.py` | AC-3 umschreiben (Ersatzweg liefert trotz Ablehnung zu), neuer AC für Totalablehnung (Defekt B, beide Wege) | ~60–90 (neue/umgeschriebene Testfunktionen + ggf. neue Helper-Fixtures für "alle Empfänger abgelehnt") |
+| `docs/context/…`/Spec | Spec-Dokument für die Scheibe (Pflicht laut Workflow) | separat, zählt nicht gegen das 250-LoC-Limit |
+
+Gesamt: **klar innerhalb des 250-LoC-Budgets**, realistisch 100–150 LoC
+Code+Test zusammen. Kein Bedarf für `loc_limit_override`.
+
+### 4. Abhängigkeiten und Reihenfolge
+
+1. Spec schreiben (AC-N-Format), insbesondere die Erfolgs-Semantik
+   ("mindestens ein Empfänger") explizit als AC festhalten — das ist die
+   einzige echte Design-Entscheidung, der Rest ist mechanisch.
+2. TDD RED: `test_ac3_…` umschreiben (rot, weil Ersatzweg heute noch abbricht)
+   + neuer Test für Defekt B (Primärweg UND Ersatzweg total abgelehnt → `send()`
+   wirft) — beide VOR der Implementierung rot bekommen.
+3. Implementierung in `_dial_and_send()` + 3 Call-Sites (GREEN).
+4. Gate #811 (Mode-Matrix-Test + `briefing_mail_validator.py`) — unabhängig
+   von 1–3, muss vor Commit grün sein, keine Reihenfolgeabhängigkeit zu den
+   übrigen Schritten außer "vor Commit".
+5. Kein Staging-Nachweis nötig (Issue-Aussage: Ersatzweg im Betrieb praktisch
+   nicht gezielt provozierbar) — Kern-Schicht-Sink-Test genügt als Nachweis.
+
+### 5. Empfehlung
+
+**Ersatzwege auf dieselbe Try/Except-Einfassung wie der Primärweg heben
+(Parameter `isolate_per_recipient` ersatzlos entfernen), Erfolgs-Check
+zentral in `_dial_and_send()` nach der Schleife (`raise OutputError` nur bei
+0 von N zugestellt), Erfolgs-Semantik = mindestens ein Empfänger.** Das löst
+A und B mit einer einzigen, in sich konsistenten Änderung an einer Stelle,
+statt den Check dreimal an den Aufrufstellen zu duplizieren. Größtes
+praktisches Risiko ist nicht der Code selbst, sondern der vorhandene Test
+`test_ac3_ersatzweg_bricht_beim_ersten_abgelehnten_empfaenger_ab`, der die
+heutige Fehlfunktion als Sollverhalten festschreibt — der muss im selben PR
+umgedreht werden, sonst bleibt CI nach dem Fix zuverlässig rot.

--- a/docs/specs/bugfix/collect_send_recipient_isolation.md
+++ b/docs/specs/bugfix/collect_send_recipient_isolation.md
@@ -1,0 +1,191 @@
+---
+entity_id: collect_send_recipient_isolation
+type: bugfix
+created: 2026-08-09
+updated: 2026-08-09
+status: done
+version: "1.0"
+workflow: "fix-1426-sammelversand-ersatzweg"
+tags: [email, sammelversand, smtp, ersatzweg, fehlerbehandlung]
+---
+
+# Collect-Send Recipient Isolation
+
+## Approval
+
+- [x] Approved
+
+## Purpose
+
+Sammelversand an mehrere Empfänger (Ortsvergleich-Presets) hat zwei zusammenhängende
+Defekte in `EmailOutput._dial_and_send()`: (A) beide Ersatz-Postausgänge brechen beim
+ersten abgelehnten Empfänger komplett ab, statt wie der Primärweg jeden Empfänger
+einzeln zu behandeln; (B) lehnt der Server *alle* Empfänger ab, meldet `send()`
+trotzdem Erfolg, weil kein Erfolgs-Check existiert. Diese Spec vereinheitlicht die
+Empfänger-Einfassung für alle drei Versandwege und ergänzt einen zentralen
+Erfolgs-Check.
+
+## Source
+
+- **File:** `src/output/channels/email.py`
+- **Identifier:** `EmailOutput._dial_and_send()`, `EmailOutput.send()`
+
+## Estimated Scope
+
+- **LoC:** ~100–150 (Code ~40–60, Tests ~60–90)
+- **Files:** 2 (`src/output/channels/email.py`, `tests/tdd/test_mail_transport_dial_behaviour.py`)
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/services/notification_service.py` | Aufrufer | Compare-Mehrempfänger-Versand (`to=recipients`, Zeile ~835); propagiert `OutputError` bereits unverändert |
+| `src/services/radar_alert_service.py` | Aufrufer | Sendet praktisch immer an genau einen Empfänger — trifft den Ein-Empfänger-Fast-Path, bleibt unverändert |
+| `.claude/hooks/renderer_mail_gate.py` (#811) | Commit-Gate | Greift bei jedem Commit, der `email.py` staged — `tests/tdd/test_issue_811_mode_matrix.py` grün + `briefing_mail_validator.py`-Lauf sind Pflichtlauf vor Commit |
+| `tests/test_mail_recipient_parity.py` | Struktur-Test | Sucht die Empfänger-Guard-`If` in `send()` als oberste Ebene — liegt VOR der Retry-Schleife, von dieser Änderung unberührt, solange `send()`s Kontrollfluss vor der Schleife unangetastet bleibt |
+
+## Implementation Details
+
+```
+_dial_and_send(..., deadline_at) -> None:
+    # Parameter `isolate_per_recipient` entfaellt ersatzlos.
+    with smtplib.SMTP(...) as server:
+        ...
+        if len(recipients) == 1:
+            server.sendmail(from_addr, recipients, msg.as_string())
+            return
+        fehler: list[tuple[str, Exception]] = []
+        for recipient in recipients:
+            try:
+                server.sendmail(from_addr, [recipient], msg.as_string())
+            except smtplib.SMTPServerDisconnected:
+                raise  # unveraendert: Transportabbruch sofort durchreichen,
+                       # VOR dem generischen SMTPException-Zweig
+            except smtplib.SMTPException as exc:
+                logger.error("SMTP-Fehler fuer Empfaenger %s: %s", recipient, exc)
+                fehler.append((recipient, exc))
+        if len(fehler) == len(recipients):
+            raise OutputError(
+                "email",
+                f"Alle {len(recipients)} Empfaenger abgelehnt: "
+                f"{[str(e) for _, e in fehler]}",
+            )
+```
+
+- Die `if isolate_per_recipient: … else: …`-Verzweigung in der Schleife entfällt zugunsten
+  eines einzigen Pfads (der heutigen `True`-Variante). Alle drei Aufrufstellen
+  (`send()` Primärweg, `_handle_transient_dial_failure()` beide Ersatzwege) verlieren
+  das `isolate_per_recipient=`-Argument.
+- `smtplib.SMTPServerDisconnected` bleibt VOR dem generischen `SMTPException`-Zweig und
+  wird weiterhin sofort durchgereicht (kein Sammeln) — ein toter Socket ist kein
+  Empfänger-Problem.
+- Der Erfolgs-Check sitzt zentral am Ende der Schleife in `_dial_and_send()`, nicht an
+  den drei Aufrufstellen: nur bei `len(fehler) == len(recipients)` (Totalablehnung)
+  wird `OutputError` geworfen. Der Ein-Empfänger-Fast-Path (`len(recipients) == 1`)
+  bleibt unverändert — dort propagiert eine Ablehnung schon heute korrekt als Exception.
+- Der Primärweg-Aufruf (`send()`, im eigenen try-Block) lässt eine dort geworfene
+  `OutputError` unverändert durchlaufen, da kein nachfolgender `except`-Zweig
+  `OutputError` matcht (alle sind smtplib-/OSError-spezifisch). Beide Ersatzweg-Aufrufe
+  stehen bereits in `except Exception as fb_err: raise OutputError(..., f"fallback also
+  failed: {fb_err}")`-Wrappern — eine dort geworfene `OutputError` läuft automatisch
+  durch diesen bestehenden Pfad.
+
+## Expected Behavior
+
+- **Input:** `send(..., to=[a, b, c])` mit mehreren Empfängern, einer der drei
+  Versandwege (Primär- oder einer der beiden Ersatzwege) aktiv.
+- **Output:** Wird mindestens ein Empfänger zugestellt, kehrt `send()` normal zurück
+  (kein Fehler) — unabhängig davon, ob der Versand über den Primär- oder einen
+  Ersatzweg lief. Werden alle Empfänger abgelehnt, wirft `send()` `OutputError`.
+- **Side effects:** Jede einzelne Empfänger-Ablehnung wird weiterhin per
+  `logger.error()` geloggt (unverändert). Ein Transportabbruch
+  (`SMTPServerDisconnected`) landet weiterhin in `send()`s eigenem Retry-/
+  Ersatzweg-Zweig, nicht in der neuen Sammel-Logik.
+
+## Acceptance Criteria
+
+- **AC-1:** Given drei Empfänger, Primärweg schlägt viermal mit `SMTPResponseException`
+  (452) fehl, Ersatzweg 1 (4xx-Auslöser) ist konfiguriert und lehnt genau den zweiten
+  Empfänger mit `SMTPException` ab / When `send()` aufgerufen wird / Then werden
+  Empfänger 1 und 3 auf dem Ersatzweg zugestellt und `send()` wirft NICHT.
+  - Test: umgeschriebene Variante von
+    `test_ac3_ersatzweg_bricht_beim_ersten_abgelehnten_empfaenger_ab` (Fall
+    `ersatzweg-1-4xx`) — statt `pytest.raises(OutputError)` wird jetzt Zustellung an
+    Empfänger 0 und 2 sowie normale Rückkehr von `send()` geprüft.
+
+- **AC-2:** Given dieselbe Ausgangslage wie AC-1, aber Primärweg scheitert mit
+  `OSError` (Netzfehler) statt 4xx, Ersatzweg 2 (Netzfehler-Auslöser) ist konfiguriert
+  und lehnt genau den zweiten Empfänger ab / When `send()` aufgerufen wird / Then
+  werden Empfänger 1 und 3 auf dem Ersatzweg zugestellt und `send()` wirft NICHT.
+  - Test: umgeschriebene Variante von
+    `test_ac3_ersatzweg_bricht_beim_ersten_abgelehnten_empfaenger_ab` (Fall
+    `ersatzweg-2-netzfehler`), analog zu AC-1.
+
+- **AC-3:** Given drei Empfänger, Primärweg lehnt ALLE drei mit `SMTPException` ab,
+  kein Ersatzweg konfiguriert / When `send()` aufgerufen wird / Then wirft `send()`
+  `OutputError`, dessen Meldung alle drei Empfänger-Ablehnungen erkennbar macht.
+  - Test: neuer Test (z. B. `test_ac10_primaerweg_totalablehnung_wirft`) — bisher kehrte
+    `send()` hier normal zurück (Defekt B), obwohl kein Empfänger erreicht wurde.
+
+- **AC-4:** Given Primärweg scheitert komplett mit Netzfehler, Ersatzweg ist
+  konfiguriert, lehnt dort aber ALLE drei Empfänger mit `SMTPException` ab / When
+  `send()` aufgerufen wird / Then wirft `send()` `OutputError` mit einer Meldung, die
+  den gescheiterten Ersatzweg erkennbar macht (bestehendes
+  "fallback also failed"-Format).
+  - Test: neuer Test (z. B. `test_ac11_ersatzweg_totalablehnung_wirft`) — bisher gab es
+    für diesen Fall keinen Test, `_dial_and_send()` kehrte implizit mit `None` zurück
+    und der Ersatzweg-Aufruf in `_handle_transient_dial_failure()` meldete fälschlich
+    Erfolg (`return True`).
+
+- **AC-5:** Given ein Transportabbruch (`SMTPServerDisconnected`) während `sendmail()`
+  für den zweiten von drei Empfängern auf dem Primärweg / When `send()` aufgerufen
+  wird / Then wird für den dritten Empfänger auf DERSELBEN Verbindung kein
+  Zustellversuch mehr unternommen, und der Abbruch landet weiterhin in `send()`s
+  eigenem `SMTPServerDisconnected`-Zweig (Retry/Ersatzweg) statt in der neuen
+  Sammel-/Erfolgs-Logik verschluckt zu werden.
+  - Test: bestehender
+    `test_f001_primaerweg_reicht_transportabbruch_durch_statt_ihn_zu_verschlucken`
+    bleibt unverändert grün (Regressionsnachweis, keine Anpassung nötig).
+
+- **AC-6:** Given die sieben bestehenden Fehlerfälle (Auth-Fehler, 5xx dauerhaft,
+  4xx ohne/mit gescheitertem Ersatzweg, sonstiger SMTP-Fehler, Netzfehler ohne/mit
+  gescheitertem Ersatzweg) / When `send()` jeweils aufgerufen wird / Then bleiben die
+  gemeldeten Fehlertexte wortgleich zum Stand vor diesem Fix.
+  - Test: bestehender `test_ac9_fehlermeldungen_bleiben_wortgleich` läuft nach dem Fix
+    unverändert grün, ohne dass die erwarteten Meldungs-Strings angepasst werden.
+
+- **AC-7:** Given genau ein Empfänger (Ein-Empfänger-Fast-Path, z. B.
+  `radar_alert_service.py`) / When `send()` aufgerufen wird / Then bleibt das
+  Verhalten unverändert — eine Ablehnung propagiert weiterhin direkt als Exception,
+  ohne durch die neue Sammel-/Erfolgs-Logik zu laufen.
+  - Test: bestehender
+    `test_ac1_primaerweg_verbindet_mit_konfiguriertem_ziel_in_fester_reihenfolge` bleibt
+    unverändert grün.
+
+## Known Limitations
+
+- Kein Staging-Nachweis nötig (Issue-Aussage: der Ersatzweg ist im Betrieb praktisch
+  nicht gezielt provozierbar) — die Kern-Schicht-Sink-Tests oben gelten als
+  hinreichender Nachweis.
+- `radar_alert_service.py` sendet nach heutigem Stand ausschließlich an genau einen
+  Empfänger (`mail_settings.mail_to` oder ein einzelner `to`-Override) — nur
+  Blast-Radius-Hinweis, kein Anpassungsbedarf in dieser Scheibe.
+- Fälle, in denen der Ersatzweg heute wegen Defekt A fälschlich `OutputError` wirft,
+  obwohl tatsächlich ≥1 Empfänger zustellbar wäre, werden nach dem Fix zu Erfolg (mit
+  Log-Zeile pro abgelehntem Empfänger) — das ist die beabsichtigte Korrektur, senkt
+  aber die beobachtbare Fehlerrate aus diesem Pfad für jede Monitoring-Logik, die sich
+  darauf verlässt (kein bekannter Konsument tut das).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Fehlerbehandlungs-Symmetrisierung innerhalb einer bereits
+  bestehenden, einzigen Transport-Funktion (`_dial_and_send()`, seit #1412 S3a der
+  eine Ort für alle drei Versandwege) — keine neue Entscheidungsfläche (Kanäle,
+  Provider, Datenmodell, Auth), daher kein eigenes ADR nötig.
+
+## Changelog
+
+- 2026-08-09: Initial spec created (Issue #1426)
+- 2026-08-09: Implementation completed — `EmailOutput._dial_and_send()` unified recipient handling across all three fallback paths; central success check added for total rejection detection. Status: done

--- a/docs/specs/modules/fix_1412_s3a_transport_kapselung_mail.md
+++ b/docs/specs/modules/fix_1412_s3a_transport_kapselung_mail.md
@@ -333,7 +333,8 @@ ausschließlich innerhalb von `EmailOutput._dial_and_send`.
   Primär- und Ersatzweg wird **bewusst nicht** vorgenommen (Entscheidung
   E2) — der zusammengesetzte Defekt (Ersatzweg alles-oder-nichts plus
   stiller Erfolg bei Totalablehnung am Primärweg) ist als **#1426** erfasst
-  und wird erst nach dieser Scheibe behoben.
+  worden und wurde nach dieser Scheibe behoben (Status: `done`; siehe
+  `docs/specs/bugfix/collect_send_recipient_isolation.md`).
 - Die Guard-Prüfung wird durch S3a **nicht** in den Transport verlegt
   (Entscheidung, R-A/R-B in der Analyse) — die strengere Form (Prüfung
   immer im gemeinsamen Weg) ist Sache von S4, wo der Empfängervertrag über

--- a/src/output/channels/email.py
+++ b/src/output/channels/email.py
@@ -462,7 +462,6 @@ class EmailOutput:
         recipients: list[str],
         msg,
         from_addr: str,
-        isolate_per_recipient: bool,
         deadline_at: float,
     ) -> None:
         """Issue #1412 S3a: der EINE Ort, an dem eine SMTP-Verbindung entsteht.
@@ -471,11 +470,11 @@ class EmailOutput:
         Retry-Schleife (Spec, Entscheidung E1: `_dial_and_send` hat genau
         einen Aufrufer-Kontext, der bereits einmal prüft).
 
-        `isolate_per_recipient` konserviert die heutige Asymmetrie zwischen
-        Primär- und Ersatzweg (Spec, Entscheidung E2): nur der Primärweg fasst
-        jeden Empfänger einzeln ein, beide Ersatzwege brechen beim ersten
-        abgelehnten Empfänger ab. Der zusammengesetzte Defekt dahinter ist als
-        #1426 erfasst und wird NACH dieser Scheibe behoben.
+        Issue #1426: alle drei Versandwege (Primärweg und beide Ersatzwege)
+        fassen jeden Empfänger einzeln ein — die frühere Asymmetrie
+        (`isolate_per_recipient`, #1412 S3a E2) ist damit aufgelöst. Lehnt der
+        Postausgang ALLE Empfänger ab, wird `OutputError` geworfen; vorher
+        meldete `send()` in diesem Fall fälschlich Erfolg.
 
         Issue #1448 S1: `deadline_at` (`time.monotonic()`-Zeitpunkt) begrenzt
         jede Phase -- Verbindungsaufbau samt Begrüßung, `starttls()`,
@@ -495,33 +494,38 @@ class EmailOutput:
                 server.sock.settimeout(_phase_timeout_or_raise(deadline_at))
                 server.sendmail(from_addr, recipients, msg.as_string())
             else:
+                fehler: list[tuple[str, Exception]] = []
                 for recipient in recipients:
                     server.sock.settimeout(_phase_timeout_or_raise(deadline_at))
-                    if isolate_per_recipient:
-                        try:
-                            server.sendmail(from_addr, [recipient], msg.as_string())
-                        except smtplib.SMTPServerDisconnected:
-                            # Adversary-Fund F001 zu #1448 S1: ein
-                            # Transportabbruch (z.B. weil die neue
-                            # Zeitgrenze waehrend DIESES sendmail()
-                            # zuschlaegt, s. `_phase_timeout_or_raise()`)
-                            # ist KEIN empfaengerspezifisches Problem wie
-                            # `SMTPRecipientsRefused` -- der Socket ist tot,
-                            # ein weiterer Versuch beim naechsten Empfaenger
-                            # waere sinnlos und wuerde denselben Fehler
-                            # erneut (still) verschlucken. Deshalb NICHT wie
-                            # eine Empfaenger-Ablehnung schlucken, sondern
-                            # durchreichen -- landet in send()s eigenem
-                            # `SMTPServerDisconnected`-Zweig (Retry +
-                            # Ersatzweg, s.u.). Muss VOR dem generischen
-                            # `SMTPException`-Zweig stehen (dessen Oberklasse).
-                            raise
-                        except smtplib.SMTPException as exc:
-                            logger.error(
-                                "SMTP-Fehler für Empfänger %s: %s", recipient, exc
-                            )
-                    else:
+                    try:
                         server.sendmail(from_addr, [recipient], msg.as_string())
+                    except smtplib.SMTPServerDisconnected:
+                        # Adversary-Fund F001 zu #1448 S1: ein
+                        # Transportabbruch (z.B. weil die neue
+                        # Zeitgrenze waehrend DIESES sendmail()
+                        # zuschlaegt, s. `_phase_timeout_or_raise()`)
+                        # ist KEIN empfaengerspezifisches Problem wie
+                        # `SMTPRecipientsRefused` -- der Socket ist tot,
+                        # ein weiterer Versuch beim naechsten Empfaenger
+                        # waere sinnlos und wuerde denselben Fehler
+                        # erneut (still) verschlucken. Deshalb NICHT wie
+                        # eine Empfaenger-Ablehnung schlucken, sondern
+                        # durchreichen -- landet in send()s eigenem
+                        # `SMTPServerDisconnected`-Zweig (Retry +
+                        # Ersatzweg, s.u.). Muss VOR dem generischen
+                        # `SMTPException`-Zweig stehen (dessen Oberklasse).
+                        raise
+                    except smtplib.SMTPException as exc:
+                        logger.error(
+                            "SMTP-Fehler für Empfänger %s: %s", recipient, exc
+                        )
+                        fehler.append((recipient, exc))
+                if len(fehler) == len(recipients):
+                    raise OutputError(
+                        "email",
+                        f"Alle {len(recipients)} Empfaenger abgelehnt: "
+                        f"{[str(e) for _, e in fehler]}",
+                    )
 
     def _handle_transient_dial_failure(
         self,
@@ -583,7 +587,6 @@ class EmailOutput:
                     recipients,
                     msg,
                     from_addr,
-                    isolate_per_recipient=False,
                     # Issue #1448 S1: eigene, garantierte Deadline statt des
                     # (evtl. bereits aufgebrauchten) Rests des Primärbudgets.
                     deadline_at=time.monotonic() + FALLBACK_RESERVE_SECONDS,
@@ -833,7 +836,6 @@ class EmailOutput:
                     recipients,
                     msg,
                     from_addr,
-                    isolate_per_recipient=True,
                     deadline_at=primaer_deadline,
                 )
 
@@ -897,7 +899,6 @@ class EmailOutput:
                                 recipients,
                                 msg,
                                 from_addr,
-                                isolate_per_recipient=False,
                                 # Issue #1448 S1: eigene, garantierte Deadline
                                 # statt des (evtl. bereits aufgebrauchten)
                                 # Rests des Primärbudgets.

--- a/tests/tdd/test_mail_transport_dial_behaviour.py
+++ b/tests/tdd/test_mail_transport_dial_behaviour.py
@@ -1,7 +1,11 @@
-"""Charakterisierung des E-Mail-Transports (#1412 Scheibe S3a).
+"""Charakterisierung des E-Mail-Transports (#1412 Scheibe S3a) und ab #1426
+zugleich Verhaltensnachweis fuer die vereinheitlichte Empfaenger-Isolierung.
 
 Spec: docs/specs/modules/fix_1412_s3a_transport_kapselung_mail.md
-      (AC-1, AC-2, AC-3, AC-9)
+      (AC-1, AC-2, AC-9)
+Spec: docs/specs/bugfix/collect_send_recipient_isolation.md
+      (AC-1, AC-2, AC-3, AC-4 -- vormals hier als "AC-3" (S3a-Spec) das
+      GEGENTEIL festgehalten, s. Historie unten)
 
 S3a ist verhaltensneutral: die drei abgeschriebenen Verbindungsbloecke in
 `EmailOutput.send()` (email.py:589 Primaerweg, :638/:682 Ersatzwege) werden zu
@@ -10,12 +14,15 @@ Verhalten am Transportrand fest, damit der Umbau beweisbar nichts verschiebt --
 sie ist deshalb schon VOR dem Umbau gruen und wuerde rot, wenn er etwas
 veraendert. Das ist ihr ganzer Zweck.
 
-Ausdruecklich mitgeschrieben wird die ASYMMETRIE (Analyse, Befund 1): nur der
-Primaerweg fasst jeden Empfaenger einzeln ein (`isolate_per_recipient=True`),
-beide Ersatzwege brechen beim ersten abgelehnten Empfaenger ab. Der
-zusammengesetzte Defekt dahinter ist als #1426 erfasst und wird NACH S3a
-behoben -- diese Datei schreibt bis dahin den Ist-Zustand fest, nicht den
-Wunschzustand.
+**Historie der Asymmetrie (Analyse, Befund 1, S3a):** nur der Primaerweg fasste
+jeden Empfaenger einzeln ein (`isolate_per_recipient=True`), beide Ersatzwege
+brachen beim ersten abgelehnten Empfaenger ab. Der zusammengesetzte Defekt
+dahinter war als #1426 erfasst -- diese Datei hielt bis zum #1426-Fix den
+damaligen Ist-Zustand fest (nicht den Wunschzustand). Mit #1426 entfaellt
+`isolate_per_recipient` ersatzlos: alle drei Versandwege behandeln Empfaenger
+jetzt einheitlich einzeln, UND ein zentraler Erfolgs-Check wirft `OutputError`,
+wenn kein einziger Empfaenger zugestellt wurde (vorher: stiller Erfolg bei
+Totalablehnung, Defekt B).
 
 Nachweisform: echte Attrappe am Transportrand (kein Mock, kein MagicMock), die
 jeden Schritt in der Reihenfolge aufzeichnet und gezielt ablehnen kann.
@@ -88,6 +95,18 @@ def _installiere_transport(
     `verbindungsfehler` wirft beim Verbindungsaufbau zum jeweiligen Host,
     `sendefehler` bei der Zustellung an den jeweiligen Empfaenger -- jeweils
     eine FRISCHE Ausnahme je Versuch (die Retry-Schleife laeuft bis zu 4x).
+
+    RED-Fund (#1426, unabhaengig vom eigentlichen Fix): `running_origin()`
+    (Herkunftssperre #1476) klassifiziert JEDEN Checkout, der nicht exakt
+    PROD_ROOT/STAGING_ROOT ist -- also auch diesen Worktree -- als "test" und
+    ersetzt in `send()` alle Empfaenger durch eine einzelne feste Adresse,
+    BEVOR `_dial_and_send()` sie sieht. Diese Datei prueft den Transport mit
+    den EMPFAENGER-Adressen als Identitaet (Reihenfolge, welcher abgelehnt
+    wird) -- ohne Neutralisierung wuerden alle adress-basierten Assertions
+    hier unabhaengig vom eigentlichen Testfall fehlschlagen. Betrifft auch
+    die bereits bestehenden AC-1/AC-2/F001-Tests (nicht nur die #1426-neuen)
+    -- vermutlich unbemerkt seit #1476, weil diese ganze Datei per
+    `pytest.mark.email` von der Standard-Kernschicht ausgenommen ist.
     """
     verlauf: list[tuple] = []
     verbindungsfehler = dict(verbindungsfehler or {})
@@ -149,6 +168,11 @@ def _installiere_transport(
     # es wird nichts weggeprueft, nur die Wanduhr.
     wartezeiten: list[float] = []
     monkeypatch.setattr(email_module.time, "sleep", wartezeiten.append)
+    # s. Docstring oben: Herkunftssperre (#1476) neutralisieren, damit die
+    # EMPFAENGER-Adressen unveraendert am Transport ankommen -- gemessen wird
+    # hier der Transport, nicht die Herkunftssperre (dafuer gibt es eigene
+    # Tests, z.B. tests/tdd/test_telegram_origin_guard.py).
+    monkeypatch.setattr(email_module, "running_origin", lambda _module_file: "production")
     return verlauf
 
 
@@ -229,7 +253,8 @@ def test_ac2_primaerweg_stellt_trotz_einer_ablehnung_an_die_uebrigen_zu(
 
 
 # -----------------------------------------------------------------------
-# AC-3 -- Ersatzwege brechen beim ersten abgelehnten Empfaenger ab
+# #1426 AC-1/AC-2 -- Ersatzwege stellen trotz einer Ablehnung an die
+# uebrigen Empfaenger zu (bis hierher galt das GEGENTEIL, s. Datei-Historie)
 # -----------------------------------------------------------------------
 
 
@@ -240,18 +265,94 @@ def test_ac2_primaerweg_stellt_trotz_einer_ablehnung_an_die_uebrigen_zu(
         ("ersatzweg-2-netzfehler", lambda: OSError("Namensaufloesung fehlgeschlagen")),
     ],
 )
-def test_ac3_ersatzweg_bricht_beim_ersten_abgelehnten_empfaenger_ab(
+def test_ersatzweg_stellt_trotz_einer_ablehnung_an_die_uebrigen_zu(
     monkeypatch, weg, primaerfehler
 ):
-    """AC-3: drei Empfaenger auf dem Ersatzweg, genau einer wird abgelehnt --
-    kein Zustellversuch nach dem gescheiterten, und send() wirft. Beide
-    Ersatzwege (nach 4xx bzw. nach Netzfehler) sind getrennter Code und werden
-    getrennt geprueft."""
+    """#1426 AC-1/AC-2 (docs/specs/bugfix/collect_send_recipient_isolation.md):
+    drei Empfaenger auf dem Ersatzweg, genau einer wird abgelehnt -- die
+    beiden anderen bekommen die Mail trotzdem zugestellt, und send() wirft
+    NICHT. Beide Ersatzwege (nach 4xx bzw. nach Netzfehler) sind getrennter
+    Code und werden getrennt geprueft.
+
+    Bis zum #1426-Fix galt hier das Gegenteil (Defekt A): ein abgelehnter
+    Empfaenger riss die restliche Ersatzweg-Schleife mit, die uebrigen
+    Empfaenger bekamen nichts."""
     verlauf = _installiere_transport(
         monkeypatch,
         verbindungsfehler={PRIMAER_HOST: primaerfehler},
         sendefehler={
             EMPFAENGER[1]: lambda: smtplib.SMTPException("Ersatzweg lehnt ab")
+        },
+    )
+
+    _sende(_postausgang(fallback_host=ERSATZ_HOST), EMPFAENGER)
+
+    assert _zustellungen(verlauf, ERSATZ_HOST) == [
+        (EMPFAENGER[0],),
+        (EMPFAENGER[1],),
+        (EMPFAENGER[2],),
+    ], f"{weg}: alle drei Empfaenger werden einzeln versucht, auch nach der Ablehnung"
+    zugestellt = [
+        e[2][0]
+        for e in verlauf
+        if e[0] == "sendmail" and e[1] == ERSATZ_HOST and e[3] == "zugestellt"
+    ]
+    assert zugestellt == [EMPFAENGER[0], EMPFAENGER[2]], (
+        f"{weg}: Empfaenger 1 und 3 werden trotz Ablehnung von Empfaenger 2 zugestellt"
+    )
+    assert ("dial", ERSATZ_HOST, ERSATZ_PORT) in verlauf
+    assert len([e for e in verlauf if e[0] == "dial" and e[1] == PRIMAER_HOST]) == 4, (
+        f"{weg}: der Ersatzweg ist erst nach vier gescheiterten Versuchen dran"
+    )
+
+
+# -----------------------------------------------------------------------
+# #1426 AC-3/AC-4 -- Totalablehnung wirft OutputError statt stillen Erfolg
+# zu melden (Defekt B)
+# -----------------------------------------------------------------------
+
+
+def test_primaerweg_totalablehnung_wirft_outputerror(monkeypatch):
+    """#1426 AC-3: lehnt der Primaerweg ALLE Empfaenger ab, muss send()
+    OutputError werfen statt normal zurueckzukehren. Vorher wurde jede
+    Ablehnung nur geloggt, ohne Pruefung ob ueberhaupt ein Empfaenger
+    erreicht wurde -- send() meldete faelschlich Erfolg."""
+    verlauf = _installiere_transport(
+        monkeypatch,
+        sendefehler={
+            e: (lambda e=e: smtplib.SMTPException(f"{e} abgelehnt"))
+            for e in EMPFAENGER
+        },
+    )
+
+    with pytest.raises(OutputError):
+        _sende(_postausgang(), EMPFAENGER)
+
+    assert _zustellungen(verlauf, PRIMAER_HOST) == [
+        (EMPFAENGER[0],),
+        (EMPFAENGER[1],),
+        (EMPFAENGER[2],),
+    ], "jeder Empfaenger wird einzeln versucht, auch wenn am Ende alle abgelehnt werden"
+    assert [e for e in verlauf if e[0] == "dial"] == [
+        ("dial", PRIMAER_HOST, PRIMAER_PORT)
+    ], "eine Totalablehnung ist kein Transportfehler -- kein Neuversuch, kein Ersatzweg"
+
+
+def test_ersatzweg_totalablehnung_wirft_outputerror(monkeypatch):
+    """#1426 AC-4: schlaegt der Primaerweg komplett fehl (Netzfehler) und
+    lehnt der Ersatzweg anschliessend ALLE Empfaenger ab, muss send()
+    OutputError werfen. Vorher kehrte `_dial_and_send()` fuer den Ersatzweg
+    implizit mit None zurueck, und der Ersatzweg-Aufruf in
+    `_handle_transient_dial_failure()` meldete faelschlich Erfolg
+    (`return True`)."""
+    verlauf = _installiere_transport(
+        monkeypatch,
+        verbindungsfehler={
+            PRIMAER_HOST: lambda: OSError("Namensaufloesung fehlgeschlagen")
+        },
+        sendefehler={
+            e: (lambda e=e: smtplib.SMTPException(f"{e} abgelehnt"))
+            for e in EMPFAENGER
         },
     )
 
@@ -261,11 +362,8 @@ def test_ac3_ersatzweg_bricht_beim_ersten_abgelehnten_empfaenger_ab(
     assert _zustellungen(verlauf, ERSATZ_HOST) == [
         (EMPFAENGER[0],),
         (EMPFAENGER[1],),
-    ], f"{weg}: nach dem abgelehnten Empfaenger darf kein weiterer folgen"
-    assert ("dial", ERSATZ_HOST, ERSATZ_PORT) in verlauf
-    assert len([e for e in verlauf if e[0] == "dial" and e[1] == PRIMAER_HOST]) == 4, (
-        f"{weg}: der Ersatzweg ist erst nach vier gescheiterten Versuchen dran"
-    )
+        (EMPFAENGER[2],),
+    ], "auch auf dem Ersatzweg wird jeder Empfaenger einzeln versucht, bevor Totalablehnung gemeldet wird"
 
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Ersatz-Postausgänge (nach 4xx-Fehler bzw. Netzfehler) fassen Empfänger jetzt einzeln ein wie der Primärweg — ein abgelehnter Empfänger stoppt nicht mehr die restliche Zustellung.
- Lehnt ein Versandweg ALLE Empfänger ab, wirft `send()` jetzt `OutputError` statt fälschlich Erfolg zu melden.
- `isolate_per_recipient`-Parameter ersatzlos aus `EmailOutput._dial_and_send()` entfernt.

## Test plan
- [x] TDD RED→GREEN: `tests/tdd/test_mail_transport_dial_behaviour.py` (14/14 grün)
- [x] Adversary-Dialog VERIFIED (7/7 ACs bewiesen, Mutationsgegenprobe 2/3 gefangen)
- [x] Regressionslauf (1255 Tests über alle EmailOutput-Referenzen): keine Regression, 13 vorbestehende Fehlschläge sind umgebungsbedingt (blockierter echter Netzzugriff)
- [x] Renderer-Commit-Gate #811: Matrix-Test + `briefing_mail_validator.py` grün

Bezieht sich auf #1426 — Issue wird manuell nach bestandenem Post-Deploy-Selftest geschlossen, nicht automatisch bei diesem Merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPhBZF1eJDAosL3E6h1nYi