### PR TITLE
fix(#1638): Monitor-Tool dauerhaft in permissions.allow freigeben

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,8 @@
     "allow": [
       "Bash",
       "WebSearch",
-      "WebFetch"
+      "WebFetch",
+      "Monitor"
     ],
     "deny": [],
     "ask": []

--- a/docs/specs/fast/fix-1638-monitor-permission.md
+++ b/docs/specs/fast/fix-1638-monitor-permission.md
@@ -1,0 +1,16 @@
+# Mini-Spec: Monitor (CI) immer genehmigen
+
+## Was ändert sich
+- `.claude/settings.json` (Projekt-Settings, eingecheckt): `permissions.allow` bekommt den Eintrag `"Monitor"` dazu.
+- Dadurch fragt keine Session mehr einzeln nach, wenn sie das Monitor-Tool (Beobachtung von Hintergrundprozessen/CI-Läufen) nutzt.
+
+## Was darf sich nicht ändern
+- Keine anderen Einträge in `permissions.allow`/`deny`/`ask` werden verändert.
+- Keine Ausweitung auf andere Tools — nur `Monitor`.
+
+## Manuelle Test-Schritte
+1. `.claude/settings.json` öffnen, prüfen dass `"Monitor"` unter `permissions.allow` steht (Diff-Review).
+2. In einer neuen Session/einem neuen Worktree das Monitor-Tool aufrufen (z.B. während ein Background-Task läuft) und beobachten, dass keine Genehmigungs-Abfrage mehr erscheint.
+
+## Inline-Test (wird während Implementierung geschrieben)
+- [ ] Kein automatisierter Test nötig — reine Permissions-Konfiguration ohne Programmlogik. Verifikation erfolgt manuell (s.o.) + Diff-Review.


### PR DESCRIPTION
## Summary
- `.claude/settings.json`: `Monitor`-Tool zu `permissions.allow` hinzugefügt — Sessions fragen nicht mehr bei jeder CI-/Hintergrundprozess-Beobachtung nach Genehmigung.
- Mini-Spec: `docs/specs/fast/fix-1638-monitor-permission.md`

## Test plan
- [x] JSON-Validität geprüft (`python3 -m json.tool`)
- [x] Diff-Review: nur ein Eintrag ergänzt, sonst nichts verändert
- [ ] Keine automatisierte Prüfung nötig (reine Permissions-Konfiguration)

Fixes #1638

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFziB15Kn8aDEZYe8CoQ31