### PR TITLE
fix(#1651): Nachtgewitter wird in der Vorschau genannt, mit Stufe und Uhrzeit

### DIFF
--- a/docs/context/fix-1651-vorschau-tagesentwarnung.md
+++ b/docs/context/fix-1651-vorschau-tagesentwarnung.md
@@ -1,0 +1,136 @@
+# Kontext — #1651: Gewitter außerhalb des Tagesfensters in der Mail nennen
+
+Stand: 2026-08-09, Basis `bcc4aeaf`. Alle Angaben unten sind **gemessen**, nicht hergeleitet;
+wo etwas ungeprüft ist, steht es ausdrücklich dabei.
+
+## Ausgangslage
+
+Entstanden aus der Staging-Funktionsprobe zu #1498. Beide dort gemeldeten Widersprüche sind
+behoben und belegt (A/B gegen die Elterncommits). Übrig blieb ein Widerspruch derselben
+Familie in **umgekehrter Richtung**, gemessen an einer echt zugestellten Mail:
+
+| Stelle in derselben Mail | Aussage zum 10.08.2026 |
+|---|---|
+| ⚡ Gewitter-Vorschau | `Kein Gewitter erwartet` |
+| 🌙 Nacht am Ziel, Zeile `00` | roter Punkt `#b91c1c` = `ThunderLevel.HIGH` |
+
+Beide Sätze sind für sich korrekt — das Gewitter lag um 00:00, außerhalb des Tagesfensters
+04–19. Die Vorschau nennt ihr Fenster aber nicht.
+
+**PO-Entscheidung 2026-08-09:** Nicht das Fenster beschriften, sondern das Nachtgewitter
+**nennen, mit exakter Uhrzeit** — in E-Mail und Telegram. SMS zeigt es weiterhin nicht.
+
+## Relevante Dateien
+
+### Wo der Vorschau-Satz entsteht (genau zwei Stellen, wortgleich)
+
+| Stelle | Datei:Zeile |
+|---|---|
+| Trend-Weg | `src/services/trip_report_scheduler.py:1838-1848` (`_thunder_entry_from_trend_row`) |
+| Fetch-Weg | `src/services/trip_report_scheduler.py:2034-2041` (`_build_thunder_forecast`) |
+| Orchestrierung beider | `trip_report_scheduler.py:1670` (`_build_thunder_forecast_from_trend_or_fetch`) |
+
+Beide haben das aufgelöste Fenster bereits als lokale Variable (`resolve_configured_window`,
+Zeile 1799 bzw. 2005). Die Klemmung sitzt in `:1789-1793` bzw. `outlook.py:353-360`.
+
+### Wer den Eintrag liest
+
+| Leser | Datei:Zeile | Gelesene Felder |
+|---|---|---|
+| Mail HTML | `src/output/renderers/email/html.py:1323` | `level`, `date`, `text`, `hail` |
+| Mail Klartext | `src/output/renderers/email/plain.py:328` | dieselben |
+| SMS | `src/output/renderers/sms_trip.py:461-483` | **nur** `level`, `hour`, `hail` — und nur `"+1"` |
+| Telegram rich | — | liest den Eintrag **gar nicht** |
+
+HTML und Klartext bekommen dasselbe Objekt (`email/__init__.py:150` und `:187`) — eine
+Änderung an der Quelle erreicht beide.
+
+### Die zweite Mail-Stelle: der Mehrtages-Ausblick
+
+`outlook_active = show_outlook and bool(multi_day_trend)` (`email/html.py:1307-1312`,
+`plain.py:308-309`). Ist er aktiv, **entfällt die Gewitter-Vorschau komplett**.
+`multi_day_trend_reports` hat den Vorgabewert `["evening"]` (`app/loader.py:897`).
+
+⇒ Morgen-Mail zeigt die Vorschau, Abend-Mail den Ausblick. Beide verschweigen das
+Nachtgewitter, an verschiedenen Codestellen.
+
+## 🔴 Gemessen: Mail und Telegram widersprechen sich heute schon
+
+Eigene Messung mit identischen Eingangsdaten (Gewitter `HIGH` um 02:00 Ortszeit, Gehzeit
+08–17, `metrics=None` = Trip-Standard):
+
+```
+row['thunder']        = NONE
+row['hourly_thunder'] = [(2, 3.0)]
+
+format_trend_tokens(row):
+  thunder_word  = 'kein'
+  thunder_token = 'hoch@2'
+
+render_outlook_plain([row])   ->  "Mo  15–25°C  –  10  ⚡–"
+narrow._outlook_lines([row])  ->  "Mo  15–25°C  R–  10  ⚡hoch@2"
+```
+
+Beide Zellen entstehen aus derselben Zeile und derselben Funktion. **Die Mail rendert das
+Wort, Telegram das Token.** Telegram erfüllt die PO-Vorgabe damit bereits; zu bauen ist sie
+nur in der E-Mail.
+
+## Datenlage: kein neuer Netzabruf nötig
+
+- `outlook.py:380-396` baut `hourly_thunder` **ungefiltert** über alle Punkte.
+- `segment_weather.py:236-238` hält die Rohzeitreihe ungefiltert („OpenMeteo returns
+  full-day (24h) data"); nur `.aggregated` wird auf die Gehzeit geklemmt.
+- `openmeteo.py:993-1000` fragt nach Kalendertagen, nicht nach Stunden.
+
+⇒ Die vollen 24 Stunden liegen an allen Bauwegen bereits vor, für `+1` und `+2`.
+
+## 🔴 Das Rückfallrisiko in #1498
+
+`night_weather` deckt Ankunft **heute** bis **06:00 des Folgetags** ab
+(`segment_weather.py:436-441`), gebaut einmal pro Report aus `segment_weather[-1]`
+(`trip_report_scheduler.py:876-878`, `preview_service.py:219-220`).
+
+Die `+1`-Vorschau-Daten stammen aus einem **anderen** Abruf (`_build_stage_trend` bzw.
+`_collect_future_stage_weather`). Für die Stunden **00:00–06:00 des Folgetags** behaupten
+damit zwei Quellen etwas über dieselbe Stunde — exakt die Konstellation, die den
+ursprünglichen #1498-Fehler erzeugte („ab 02:00" gegen „kein").
+
+Beide laufen zwar über denselben Roh-Cache (`weather_cache.py:253-255`), ein Treffer ist
+aber an Koordinate, Modell, Fensterabdeckung und TTL gebunden — **keine Garantie**.
+*Nicht verifiziert:* ob im Ist-Zustand tatsächlich ein Cache-Treffer eintritt.
+
+Für den Abend von `+1` (20:00–23:00) und für ganz `+2` gibt es keine Gegenquelle — dort kann
+nichts widersprechen, aber auch nichts bestätigen.
+
+## Bestehende Muster, die wiederverwendet werden
+
+- **Additive Schlüssel im Eintrags-Dict:** `hail` (#1475) und `_gap_offsets` (#1482) sind
+  Vorbilder für Felder, die die SMS ignoriert.
+- **Fenster-Auflösung an einer Stelle:** `app/day_window.py:20-50`
+  (`resolve_configured_window`, wrap-fähig seit #1361/#1372) und `:52-63` (`hour_in_window`).
+- **Höchstes Level ermitteln:** `metric_format.max_thunder` / `thunder_ordinal` — nacktes
+  `max()` wäre alphabetisch falsch.
+
+## Was es NICHT gibt
+
+Eine Notation, die ein Zeitfenster als Text benennt, existiert im ganzen Code nicht.
+`⚡ möglich 4:00–19:00` (`compact_summary.py:578-586`) sieht so aus, ist aber die Spanne der
+tatsächlichen Gewitterstunden (`min`/`max`) — **nicht** das Fenster. Verwechslungsgefahr.
+
+## Angrenzende Befunde (nicht in dieser Scheibe)
+
+- **„Metriken-Überblick"-Pille** (`email/helpers.py:1686-1730`): meldet
+  `Gewitter ab 04:00 · stärkste 04:00`, während **keine** Tabelle der Mail eine Stunde vor
+  08:00 zeigt. Ursache ist kein Klemmfehler, sondern die bewusste Absenkung der Untergrenze
+  für das erste Segment (`day_window.py:117-129`, Absicht seit #1317/#1319). Eigener
+  Sachverhalt, noch nicht verbucht.
+- **Gewitter-Spalte fehlt bei einem neu angelegten Trip per Vorgabe** — Altbefund aus einem
+  #1498-Kommentar, nie verbucht.
+
+## Betroffene Tests
+
+`tests/unit/test_thunder_forecast_day_window.py` (Zeilen 95,112,146,161,198,214),
+`tests/tdd/test_thunder_forecast_low_level.py`, `tests/tdd/test_briefing_parity_night_thunder.py:55`,
+`tests/tdd/test_bug_874_th_plus_sms.py`, `tests/unit/test_trip_report_formatter_v2.py:266`,
+Golden-Snapshots `tests/golden/email/corsica-vigilance-{html,plain}.txt` und
+`gr20-spring-morning-{html,plain}.txt`.

--- a/docs/specs/modules/fix_1651_vorschau_zeitfenster.md
+++ b/docs/specs/modules/fix_1651_vorschau_zeitfenster.md
@@ -1,0 +1,453 @@
+---
+entity_id: fix_1651_vorschau_zeitfenster
+type: bugfix
+created: 2026-08-09
+updated: 2026-08-09
+status: draft
+version: "2.0"
+tags: [gewitter, vorschau, zeitfenster, issue-1651]
+---
+
+<!-- Version 2.0 ersetzt die Fassung vom selben Tag vollstaendig. PO-Entscheidung
+2026-08-09 (siehe Kommentar 2 an Issue #1651): nicht das Fenster BESCHRIFTEN,
+sondern das Nachtgewitter tatsaechlich NENNEN — mit exakter Uhrzeit. Die alte
+Fassung (Suffix " (Fenster 04-19 Uhr)") ist damit ueberholt und wird NICHT
+uebernommen. -->
+
+# #1651 — Gewitter außerhalb des Tagesfensters wird in der Mail genannt, mit Uhrzeit
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Ein Gewitter **außerhalb** des konfigurierten Tagesfensters (Default 04–19 Uhr
+Ortszeit) soll in der Trip-Mail **genannt werden, mit exakter Uhrzeit** — statt
+wie heute verschwiegen zu werden. Betroffen sind zwei Stellen derselben Mail:
+die morgendliche „⚡ Gewitter-Vorschau" (Fließtext-Satz) und die abendliche
+„Mehrtages-Ausblick"-Tabelle (Spalte „Gew"). SMS zeigt die Angabe weiterhin
+nicht (Platzgrund, PO-Vorgabe); Telegram (rich) erfüllt die Vorgabe bereits
+und bleibt unverändert.
+
+PO-Wortlaut (Kommentar 2 an Issue #1651, 2026-08-09):
+
+> „Bei der SMS wird's einfach nicht angezeigt. Bei E-Mail und Telegram darf
+> das Gewitter außerhalb des ‚Tagesfensters' natürlich schon erwähnt werden:
+> In der Zusammenfassung z.B. mit Gewitter mit exakter Uhrzeit."
+
+Die zentrale Zusicherung dieser Scheibe: der ursprüngliche #1498-Fehler darf
+nicht in umgekehrter Form zurückkommen. Der Fehler war nicht „die Vorschau
+erwähnt die Nacht", sondern: zwei verschiedene Datenquellen sagten für
+**dieselbe Stunde** derselben Mail Widersprüchliches. Diese Scheibe stellt
+sicher, dass die neue Nacht-Angabe für die Stunden, die auch die
+„Nacht am Ziel"-Tabelle derselben Mail zeigt, aus **derselben** Quelle stammt.
+
+## Source
+
+- **File:** `src/app/day_window.py` — neue Funktion für die Nacht-Angabe
+  (Fenster-Zugehörigkeit und Zusammenführung zweier Stundenquellen)
+- **File:** `src/services/trip_report_scheduler.py` —
+  `_thunder_entry_from_trend_row()`, `_build_thunder_forecast()`,
+  `_build_thunder_forecast_from_trend_or_fetch()`, `_build_stage_trend()`,
+  Hauptablauf (`generate_and_send`, Zeile ~875–902)
+- **File:** `src/services/preview_service.py` — Reihenfolge der
+  Nachtwetter-Beschaffung
+- **File:** `src/output/renderers/email/outlook.py` —
+  `render_outlook_table()`, `render_outlook_plain()`
+
+Schicht: **Python-Core** (`src/app/`, `src/services/`,
+`src/output/renderers/`). Kein Go-, kein Frontend-Code betroffen.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `app.day_window.resolve_configured_window()` / `hour_in_window()` | vorhanden | Fenster-Grenzen und Zugehörigkeits-Prüfung — dieselbe Quelle, auf der auch die bestehende Tagesfenster-Klemmung (#1498 Fall 2) beruht |
+| `services.segment_weather.fetch_night_weather()` | vorhanden | Liefert die Nacht-Zeitreihe (Ankunft heute → 06:00 Folgetag) — dieselbe Funktion, die auch die „Nacht am Ziel"-Tabelle speist; keine zweite Quelle |
+| `TripReportSchedulerService._build_thunder_forecast_from_trend_or_fetch()` | vorhanden | Einziger Weg, über den sowohl Versand als auch Vorschau-Endpunkt den Vorschau-Eintrag beziehen — trägt die Parität aus AC-9 strukturell |
+| `services.preview_service.py` | vorhanden | Bezieht Vorschau-Eintrag und Ausblick-Tabelle über dieselben Scheduler-Methoden wie der Versandpfad |
+| `output/renderers/email/html.py:1323`, `plain.py:328` | vorhanden | Lesen ausschließlich `fc['text']` — keine Änderung nötig, die neue Nacht-Angabe erreicht beide automatisch, weil sie in `text` eingebaut wird |
+| `output/renderers/sms_trip.py:473–483` | vorhanden | Liest nur `entry["level"]`/`entry["hour"]`, nicht `entry["text"]` — SMS bleibt strukturell unberührt |
+| `output/renderers/narrow.py:571–586` (`_outlook_lines`, Telegram rich) | vorhanden | Liest `thunder_token` aus der **ungefilterten** `hourly_thunder`-Reihe der Etappe — zeigt Nachtgewitter bereits heute; wird von dieser Scheibe nicht angefasst |
+
+## Scope
+
+### Affected Files
+
+| File | Change Type | Description |
+|---|---|---|
+| `src/app/day_window.py` | MODIFY | Neue Funktion, die aus zwei Stundenreihen (eigene Etappen-Zeitreihe + optional Nacht-Zeitreihe) die außerhalb des Fensters liegenden Stunden bestimmt und daraus Level+früheste Stunde ableitet (Implementation Details) |
+| `src/services/trip_report_scheduler.py` | MODIFY | Neuer optionaler `night_weather`-Parameter an `_build_thunder_forecast_from_trend_or_fetch()`, `_thunder_entry_from_trend_row()`, `_build_thunder_forecast()`; Suffix-Anhängen an `text`; `_build_stage_trend()` bekommt denselben optionalen Parameter und setzt `row["night_thunder"]`; Hauptablauf reicht das bereits vorhandene `night_weather` an beide Aufrufe durch |
+| `src/services/preview_service.py` | MODIFY | Nachtwetter-Beschaffung (aktuell nach dem Trend-/Vorschau-Aufbau) nach vorne verschoben, analog zum Versandpfad, damit sie beim Bau von Trend und Vorschau bereits vorliegt |
+| `src/output/renderers/email/outlook.py` | MODIFY | `render_outlook_table()`/`render_outlook_plain()` hängen die Nacht-Angabe an die „Gew"-Zelle an, wenn `stage.get("night_thunder")` gesetzt ist |
+| `tests/unit/test_thunder_forecast_day_window.py` | MODIFY | Bestehende Tests zur Fenster-Klemmung um die neue Nacht-Angabe ergänzen |
+| `tests/tdd/test_thunder_forecast_low_level.py` | MODIFY | dito für die LOW-Stufe |
+| `tests/tdd/test_briefing_parity_night_thunder.py` | MODIFY | Bereits vorhandene Fixtures (`_thunder_forecast()`, `_night_weather()`, `_night_dp()`) sind direkt wiederverwendbar — neue Tests für die Kombination Vorschau + Nacht-Tabelle in derselben Mail |
+| `tests/tdd/test_bug_874_th_plus_sms.py` | MODIFY | Regressionsnachweis: SMS-Token unverändert trotz Nacht-Angabe im `text`-Feld |
+| `tests/unit/test_trip_report_formatter_v2.py` | MODIFY | Erwarteter Vorschau-Text ggf. anpassen, falls dort ein Nachtgewitter-Fixture verwendet wird |
+| `tests/golden/email/corsica-vigilance-html.txt`, `corsica-vigilance-plain.txt`, `gr20-spring-morning-html.txt`, `gr20-spring-morning-plain.txt` | MODIFY | Golden-Snapshots neu ziehen, sofern der Fixture-Trip ein Nachtgewitter zeigt |
+| neue Testdatei (Name nach Verhalten, z.B. `tests/unit/test_thunder_night_addendum.py`) | CREATE | Gezielte Tests für die neue Helper-Funktion in `app/day_window.py` (Merge-Logik, Mehrere-Nachtstunden-Regel, +2 ohne Nacht-Tabelle) |
+
+### Estimated Changes
+
+Siehe Abschnitt „Umfang" — die ehrliche Schätzung liegt über dem
+250-Zeilen-Workflow-Limit.
+
+## Implementation Details
+
+### 1. Wo die zwei Quellen für dieselbe Stunde herkommen (gemessen)
+
+`night_weather` (Nacht-Tabelle) deckt Ankunft **heute** bis **06:00 des
+Folgetags** ab (`segment_weather.py::fetch_night_weather`, Zeile 410–460).
+Der Vorschau-Eintrag für „+1" (morgen) stammt aus einem **anderen** Abruf —
+entweder der bereits gebauten `multi_day_trend`-Zeile (Trend-Weg,
+`_thunder_entry_from_trend_row`) oder einem eigenen Fallback-Fetch
+(`_build_thunder_forecast`). Für die Stunden **00:00–06:00 des Folgetags**
+behaupten damit zwei verschiedene Quellen etwas über dieselbe Stunde — genau
+die Konstellation, die den ursprünglichen #1498-Fehler erzeugt hat.
+
+**Auflösung (Regel dieser Scheibe):** Für Stunden, die `night_weather`
+abdeckt (00:00–06:00 des Folgetags), ist `night_weather` die maßgebliche
+Quelle — sie ist dieselbe Quelle, welche die „Nacht am Ziel"-Tabelle direkt
+neben der Vorschau zeigt. Für alle anderen außerhalb des Fensters liegenden
+Stunden (z.B. 20:00–23:00 desselben Folgetags, und der gesamte Folge-Tag
+„+2", den `night_weather` nicht erreicht) gilt die **eigene**, bereits
+vorliegende Zeitreihe der jeweiligen Etappe — dieselbe Reihe, aus der auch
+die Telegram-„Ausblick"-Bubble ihr `thunder_token` bezieht
+(`narrow.py::_outlook_lines`, liest bereits ungefiltert). Kein neuer
+Netzabruf nötig: beide Reihen liegen an allen drei Bauwegen bereits vor.
+
+### 2. Neue Helper-Funktion (`app/day_window.py`)
+
+```python
+def night_addendum(
+    own_hourly: list[tuple[int, "ThunderLevel"]],
+    night_hourly: list[tuple[int, "ThunderLevel"]] | None,
+    win_start: int,
+    win_end: int,
+) -> tuple["ThunderLevel", int] | None:
+    """Level + fruehste Stunde des schlimmsten Gewitters AUSSERHALB des
+    Fensters. `night_hourly` (falls gegeben) ueberschreibt `own_hourly` fuer
+    Stunden, die es abdeckt (Autoritaet der Nacht-Tabellen-Quelle)."""
+```
+
+`own_hourly`/`night_hourly` sind `(Ortszeit-Stunde, ThunderLevel)`-Paare aus
+den jeweils bereits vorhandenen, ungefilterten Zeitreihen. Die Funktion:
+merged beide (Nacht-Quelle gewinnt bei überlappender Stunde), filtert auf
+`not hour_in_window(hour, win_start, win_end)`, ermittelt das Maximum-Level
+über `thunder_ordinal()` und davon die früheste Stunde — spiegelbildlich zur
+bestehenden Innerhalb-Fenster-Logik in `_thunder_entry_from_trend_row`. Kein
+Level (nur `NONE` außerhalb) → `None` (kein Zusatz).
+
+### 3. Integration Vorschau-Satz (Morgen-Default, Fetch-Weg + Trend-Weg)
+
+`_build_thunder_forecast_from_trend_or_fetch()` bekommt einen neuen
+optionalen Parameter `night_weather: Optional[NormalizedTimeseries] = None`
+und reicht ihn an `_thunder_entry_from_trend_row()` bzw.
+`_build_thunder_forecast()` durch (nur für den „+1"-Eintrag relevant, „+2"
+bekommt `night_hourly=None`). Beide Methoden rufen `night_addendum()` auf
+und hängen bei einem Treffer
+`f", nachts {STUFE} ab {hour:02d}:00"` an den bestehenden `text` an — der
+bisherige Text (inkl. Fenster-Klemmung) bleibt unverändert, das ist ein
+reiner Anhang.
+
+**Die Stufe wird genannt (PO-Entscheidung 2026-08-09).** Wortschatz:
+
+| Level | Nacht-Zusatz |
+|---|---|
+| LOW | `, nachts leichtes Gewitter ab HH:MM` |
+| MED | `, nachts mittleres Gewitter ab HH:MM` |
+| HIGH | `, nachts starkes Gewitter ab HH:MM` |
+
+Bewusste Abweichung vom Tagestext: dort trägt MED **kein** Adjektiv
+(„Gewitter möglich ab HH:MM"). Der Nacht-Zusatz nennt alle drei Stufen, weil
+er als angehängter Halbsatz für sich lesbar sein muss — ein „nachts Gewitter"
+ohne Adjektiv wäre von „Stufe unbekannt" nicht unterscheidbar.
+
+Beispiele:
+- gemessenes #1651-Szenario (kein Gewitter im Fenster, HIGH um 00:00):
+  `"Kein Gewitter erwartet, nachts starkes Gewitter ab 00:00"`
+- Tag und Nacht gemeinsam (angehängt, nicht ersetzt):
+  `"Starkes Gewitter erwartet ab 14:00, nachts mittleres Gewitter ab 22:00"`
+
+Hauptablauf (`generate_and_send`): `night_weather` ist an Zeile ~876–878
+bereits vorhanden — wird unverändert an `_build_thunder_forecast_from_trend_or_fetch()`
+(Zeile ~900) sowie an `_build_stage_trend()` (Zeile ~889, s.u.) durchgereicht.
+
+### 4. Integration Ausblick-Tabelle (Abend-Default)
+
+`_build_stage_trend()` bekommt denselben optionalen `night_weather`-Parameter.
+Nach dem Bau jeder Zeile über `build_outlook_row()` (die bereits ungefilterte
+`hourly_thunder`-Samples liefert) wird geprüft, ob `row["date"] ==
+target_date + 1 Tag` — nur dann wird `night_weather` als zweite Quelle an
+`night_addendum()` übergeben, sonst nur die eigene Reihe. Bei einem Treffer
+bekommt die Zeile ein neues additives Feld `row["night_thunder"] = (level,
+hour)`.
+
+`render_outlook_table()` (HTML) und `render_outlook_plain()` (Klartext)
+lesen `stage.get("night_thunder")` und hängen an die bestehende „Gew"-Zelle
+an: ist die Zelle bislang „–"/„⚡–" (kein Tages-Gewitter), wird sie durch
+`"nachts {STUFE} HH:MM"` (HTML) bzw. `"⚡ nachts {STUFE} HH:MM"` (Klartext,
+Symbol-Konvention aus `_THUNDER_MAP` übernommen) **ersetzt** statt ergänzt —
+ein Bindestrich gefolgt von einer Uhrzeit wäre irreführend. Zeigt die Zelle
+bereits ein Tages-Gewitter, wird `" nachts {STUFE} HH:MM"` angehängt.
+
+`{STUFE}` in der Tabelle nutzt den **kurzen** Wortschatz, den die Spalte
+bereits führt (`THUNDER_LABEL_DE`: `leicht`/`mittel`/`hoch`) — nicht die
+langen Adjektive des Fließtexts. Beispiel: `⚡ nachts hoch 00:00`.
+
+### 5. Reihenfolge UND Bedingung in `preview_service.py`
+
+**5a — Reihenfolge.** Der Vorschau-Pfad beschafft `night_weather` aktuell
+**nach** dem Bau von Trend und Vorschau-Eintrag (Zeile 218–220 vs. 198–202;
+nachgemessen 2026-08-09). Damit die neue Nacht-Angabe auch im
+Vorschau-Endpunkt erscheint (AC-9, Parität), wird die Beschaffung vor die
+Aufrufe von `_build_stage_trend()`/
+`_build_thunder_forecast_from_trend_or_fetch()` verschoben — reine
+Umstellung, kein neuer Netzabruf.
+
+**5b — 🔴 Die Bedingungen der beiden Pfade sind NICHT gleich (nachgemessen).**
+Reihenfolge allein genügt nicht:
+
+| Pfad | Bedingung für den Nachtwetter-Abruf |
+|---|---|
+| Versand, `trip_report_scheduler.py:875-877` | `if segment_weather:` — praktisch immer |
+| Vorschau, `preview_service.py:219` | zusätzlich `night_weather_needed(trip.display_config)` |
+
+`night_weather_needed()` (`segment_weather.py`) liefert heute nur dann `True`,
+wenn die **Nacht-Stundentabelle** (`show_night_block`) oder die
+**Nacht-Tiefsttemperatur** (`temperature_night`) aktiv ist. Für einen Trip
+**ohne** Nacht-Tabelle hätte der Versand also die Nacht-Zeitreihe, die
+Vorschau nicht — beide bildeten die Nacht-Angabe aus **verschiedenen**
+Quellen, und AC-9 bräche genau dort.
+
+Besonders tückisch: Testfixtures mit aktiver Nacht-Tabelle bleiben dabei
+grün; der Fehler zeigt sich nur im echten Pfad. Das ist die Fehlerklasse
+„Prüfort ≠ Wirkort".
+
+**Auflösung:** `night_weather_needed()` wird um die Bedingung erweitert, dass
+auch eine aktive **Gewitter-Metrik** Nachtdaten nötig macht — denn ab dieser
+Scheibe speisen sie zusätzlich die Nacht-Angabe. Die Funktion bleibt damit
+die **eine geteilte Entscheidung** für beide Pfade (so ist sie ausdrücklich
+gedacht, siehe ihr Docstring), statt dass der Vorschau-Pfad eine eigene
+Sonderregel bekommt.
+
+**Folge fürs Kontingent, bewusst in Kauf genommen:** Trips mit
+Gewitter-Metrik, aber ohne Nacht-Tabelle, holen im Vorschau-Pfad künftig
+zusätzlich die Nacht-Zeitreihe. Der Versand tat das ohnehin schon; es
+entsteht kein neuer Abruf im Versand, nur eine Angleichung der Vorschau.
+
+### Offene Punkte — hiermit entschieden
+
+1. **Spaltenbreite:** Die „Gew"-Spalte ist eine Tabellenzelle ohne feste
+   Zeichenbreite (HTML: `<td>` mit `padding`, kein `white-space:nowrap`;
+   Klartext-Ausblick fügt ohnehin keine feste Spaltenbreite durch, s.
+   `render_outlook_plain`). „nachts 02:00" passt ohne Layoutbruch.
+2. **Mehrere Nachtstunden:** früheste Stunde des **erreichten
+   Höchst-Levels** über alle außerhalb liegenden Stunden hinweg (00:00–03:59
+   UND 20:00–23:59 zusammen als ein Pool) — spiegelbildlich zur
+   bestehenden Innerhalb-Fenster-Regel. Beispiel: MED um 02:00 UND HIGH um
+   22:00 → „nachts starkes Gewitter ab 22:00" (HIGH gewinnt, dessen früheste
+   Stunde).
+3. **Level-Angabe: MIT Stufen-Wort** — PO-Entscheidung 2026-08-09, nachdem
+   auffiel, dass ohne Stufe zusammen mit Regel 2 beide Informationen
+   verlorengehen (bei MED um 02:00 und HIGH um 22:00 bliebe nur „nachts
+   Gewitter ab 22:00" — weder die Schwere noch das frühere Ereignis wären
+   erkennbar). Wörtlich: `", nachts starkes Gewitter ab HH:MM"` (Fließtext,
+   Adjektive `leichtes`/`mittleres`/`starkes`) bzw. `"nachts hoch HH:MM"`
+   (Ausblick-Tabelle, Kurzwortschatz `leicht`/`mittel`/`hoch`).
+4. **„+2" ohne Nacht-Tabellen-Gegenquelle:** die Angabe erscheint dort
+   trotzdem (PO will die Information generell zeigen, nicht nur dort, wo ein
+   Widerspruchsrisiko besteht) — Quelle ist ausschließlich die eigene,
+   bereits vorliegende Zeitreihe der „+2"-Etappe.
+
+## Test Plan
+
+### Automated Tests (TDD RED)
+
+- [ ] Test 1 (Kernszenario Morgen, GIVEN Default-Fenster, kein Gewitter im
+  Fenster, HIGH um 00:00 in `night_weather` WHEN der Vorschau-Eintrag gebaut
+  wird THEN lautet `entry["text"]` „Kein Gewitter erwartet, nachts starkes
+  Gewitter ab 00:00").
+- [ ] Test 2 (Kernszenario Abend, GIVEN derselbe Fall WHEN die
+  Ausblick-Tabelle für denselben Tag gebaut wird THEN zeigt die
+  „Gew"-Zelle „nachts hoch 00:00" statt „–"/„⚡–").
+- [ ] Test 3 (Konsistenz mit Nacht-Tabelle, GIVEN dieselbe zugestellte Mail
+  WHEN sowohl die Nacht-Tabellen-Zeile 00:00 als auch die neue Nacht-Angabe
+  gelesen werden THEN nennen beide dieselbe Stunde und dasselbe Level).
+- [ ] Test 4 (Tag + Nacht kombiniert, GIVEN HIGH ab 14:00 im Fenster UND MED
+  um 22:00 außerhalb WHEN der Eintrag gebaut wird THEN lautet der Text
+  „Starkes Gewitter erwartet ab 14:00, nachts mittleres Gewitter ab 22:00").
+- [ ] Test 5 (Keine Änderung ohne Nachtgewitter, GIVEN ruhige Nacht UND
+  ruhiger Tag WHEN der Eintrag gebaut wird THEN bleibt der Text „Kein
+  Gewitter erwartet" ohne Zusatz).
+- [ ] Test 6 (+2 ohne Gegenquelle, GIVEN Gewitter außerhalb des Fensters am
+  übernächsten Tag WHEN der Eintrag für „+2" gebaut wird THEN erscheint die
+  Nacht-Angabe trotzdem, aus der eigenen Zeitreihe).
+- [ ] Test 7 (Mehrere Nachtstunden, GIVEN MED um 02:00 UND HIGH um 22:00
+  WHEN der Eintrag gebaut wird THEN wird ausschließlich „nachts starkes Gewitter ab 22:00" genannt).
+- [ ] Test 8 (SMS unverändert, GIVEN ein Eintrag mit gesetzter Nacht-Angabe
+  im `text`-Feld WHEN der SMS-Renderer das TH+-Token baut THEN bleibt das
+  Token unverändert — liest weiterhin nur `level`/`hour`).
+- [ ] Test 9 (Parität Vorschau-Endpunkt ↔ zugestellte Mail, GIVEN derselbe
+  Trip und Zieltag WHEN der Eintrag einmal über `preview_service.py` und
+  einmal über den Versandpfad gebaut wird THEN ist `entry["text"]"
+  zeichengleich).
+
+## Acceptance Criteria
+
+- **AC-1 (Kernszenario Morgen — das gemessene #1651-Szenario):** Given ein
+  Trip mit Default-Tagesfenster (04–19 Uhr), am Folgetag kein Gewitter
+  innerhalb dieses Fensters, aber ein Gewitter der Stufe „hoch" um 00:00 Uhr
+  (dieselbe Stunde, die auch die Nacht-Tabelle derselben Mail zeigt) / When
+  die morgendliche Trip-Mail erzeugt wird / Then steht in der Gewitter-
+  Vorschau-Zeile für diesen Tag der Satz „Kein Gewitter erwartet, nachts
+  starkes Gewitter ab 00:00" statt der bisherigen reinen Entwarnung ohne
+  Nacht-Hinweis.
+
+- **AC-2 (Kernszenario Abend):** Given derselbe Trip und Tag wie AC-1 / When
+  die abendliche Trip-Mail mit aktivem Mehrtages-Ausblick erzeugt wird /
+  Then zeigt die Spalte „Gew" für diesen Tag „nachts hoch 00:00" (HTML) bzw.
+  „⚡ nachts hoch 00:00" (Klartext) statt der bisherigen Entwarnung „–"/„⚡–" —
+  in beiden Mail-Teilen (HTML und Klartext) derselben Mail.
+
+- **AC-3 (Konsistenz mit der Nacht-Tabelle — zentrale #1498-Zusicherung):**
+  Given ein Trip, dessen „Nacht am Ziel"-Tabelle für 00:00 des Folgetags ein
+  Gewitter der Stufe „hoch" zeigt / When dieselbe Mail sowohl die
+  Nacht-Tabelle als auch die neue Vorschau- bzw. Ausblick-Nacht-Angabe
+  enthält / Then nennen beide Stellen exakt dieselbe Stunde und dasselbe
+  Level — es entsteht keine widersprüchliche Aussage über dieselbe Stunde
+  in derselben Mail.
+
+- **AC-4 (Tages- und Nachtgewitter gemeinsam):** Given ein Trip mit
+  Gewitter der Stufe „hoch" ab 14:00 Uhr innerhalb des Fensters UND
+  zusätzlich Gewitter der Stufe „mittel" um 22:00 Uhr außerhalb des
+  Fensters am selben Tag / When die Trip-Mail erzeugt wird / Then nennt der
+  Satz beide Ereignisse: „Starkes Gewitter erwartet ab 14:00, nachts
+  mittleres Gewitter ab 22:00" — die Tages-Aussage bleibt unverändert, die
+  Nacht-Angabe wird angehängt und nennt ihre eigene Stufe.
+
+- **AC-5 (Keine Änderung ohne Nachtgewitter — Regressionsschutz):** Given
+  ein Trip ohne jedes Gewitter (weder im Fenster noch außerhalb) am
+  Folgetag / When die Trip-Mail erzeugt wird / Then bleibt der Text „Kein
+  Gewitter erwartet" unverändert, ohne angehängte Nacht-Angabe.
+
+- **AC-6 (Übernächster Tag ohne Nacht-Tabellen-Gegenquelle):** Given ein
+  Trip mit Gewitter außerhalb des Fensters am übernächsten Tag („+2", für
+  den es keine „Nacht am Ziel"-Tabelle in derselben Mail gibt) / When die
+  Trip-Mail erzeugt wird / Then erscheint die Nacht-Angabe für „+2"
+  trotzdem, aus der für diesen Tag ohnehin bereits beschafften Zeitreihe —
+  kein neuer Netzabruf.
+
+- **AC-7 (Mehrere Nachtstunden — früheste Stunde des Höchst-Levels):**
+  Given Gewitter der Stufe „mittel" um 02:00 Uhr UND der Stufe „hoch" um
+  22:00 Uhr, beide außerhalb des Fensters am selben Tag / When der Satz
+  gebaut wird / Then wird ausschließlich das höhere Level mit seiner
+  frühesten Stunde genannt: „nachts starkes Gewitter ab 22:00" — nicht
+  02:00, und die genannte Stufe ist die höhere („starkes"), nicht die des
+  früheren Ereignisses.
+
+- **AC-8 (SMS und Telegram-Kurzform bleiben unverändert —
+  Regressionsschutz):** Given ein Trip-Report mit einer neu angehängten
+  Nacht-Angabe im Vorschau-Text / When der Report für SMS oder die
+  Telegram-Kurzform gerendert wird / Then bleibt das TH+-Token unverändert
+  gegenüber dem Stand vor dieser Scheibe — es liest weiterhin
+  ausschließlich `level`/`hour`, nie den Fließtext.
+
+- **AC-9 (Parität Vorschau-Endpunkt ↔ zugestellte Mail):** Given derselbe
+  Trip und derselbe Zieltag / When der Vorschau-Satz einmal über den
+  Vorschau-Endpunkt (`preview_service.py`) und einmal über die tatsächlich
+  zugestellte Trip-Mail erzeugt wird / Then ist der Satz an beiden Stellen
+  zeichengleich, weil beide Wege dieselbe Scheduler-Methode durchlaufen und
+  `night_weather` an beiden Stellen in derselben Reihenfolge vorliegt.
+
+- **AC-11 (Parität auch ohne Nacht-Tabelle — die Falle aus 5b):** Given ein
+  Trip, dessen Gewitter-Metrik aktiv ist, der aber **keine** Nacht-Tabelle
+  anzeigt (`show_night_block` aus, Nacht-Tiefsttemperatur nicht gewählt),
+  und der am Folgetag ein Gewitter außerhalb des Tagesfensters hat / When
+  derselbe Tag einmal über den Vorschau-Endpunkt und einmal über die
+  zugestellte Mail erzeugt wird / Then nennen beide dieselbe Nachtstunde —
+  der Vorschau-Pfad greift auf dieselbe Nacht-Zeitreihe zu wie der Versand,
+  statt still auf eine andere Quelle auszuweichen.
+
+- **AC-10 (Telegram rich bleibt unverändert):** Given ein Trip mit
+  Nachtgewitter außerhalb des Fensters / When die Telegram-„Ausblick"-Bubble
+  gerendert wird / Then bleibt ihre Darstellung (z.B. „⚡H@2") gegenüber
+  dem Stand vor dieser Scheibe unverändert — sie zeigt Nachtgewitter bereits
+  heute über ihre eigene, ungefilterte Quelle.
+
+## Umfang
+
+**Die ehrliche Schätzung überschreitet das 250-Zeilen-Workflow-Limit.**
+
+- Produktivcode: `app/day_window.py` (~35 LoC neue Funktion) +
+  `trip_report_scheduler.py` (~100 LoC: vier Methoden-Signaturen erweitert,
+  Merge-Aufruf, Suffix-Bau, Zeilen-Augmentierung) +
+  `preview_service.py` (~20 LoC Umstellung) + `outlook.py` (~30 LoC) ≈
+  **~185 LoC**.
+- Tests: zehn ACs über mindestens sieben bestehende Testdateien plus eine
+  neue gezielte Testdatei für die Helper-Funktion, plus vier
+  Golden-Snapshot-Aktualisierungen (zählen laut CLAUDE.md nicht mit) ≈
+  geschätzt **~150–220 LoC**.
+- **Gesamt geschätzt: ~335–405 LoC.**
+
+✅ **PO-Entscheidung 2026-08-09: Limit auf 500 angehoben, Lieferung in einem
+Zug.** `loc_limit_override = 500` ist im Workflow gesetzt. Die unten
+skizzierte Zweiteilung wird damit **nicht** gefahren und ist nur noch als
+Rückfalloption dokumentiert.
+
+**Sauberste Trennung in zwei Scheiben** (nicht gewählt, nur als Rückfall):
+
+| Scheibe | Inhalt | Enthält |
+|---|---|---|
+| **A — Vorschau-Satz (Morgen)** | AC-1, AC-3 (Teilaspekt Vorschau), AC-4, AC-5, AC-6, AC-7, AC-8, AC-9 | `app/day_window.py`-Helper (geteilte Grundlage für beide Scheiben), `trip_report_scheduler.py`-Forecast-Methoden, `preview_service.py`-Umstellung |
+| **B — Ausblick-Tabelle (Abend)** | AC-2, AC-3 (Teilaspekt Tabelle), AC-10 | `_build_stage_trend()`-Zeilen-Augmentierung (baut auf Scheibe A's Helper auf), `outlook.py`-Rendering |
+
+Scheibe A trägt den Helper und ist damit die natürliche erste Scheibe;
+Scheibe B ist ohne A nicht sinnvoll umsetzbar (gemeinsame Funktion).
+
+## Nicht in dieser Scheibe
+
+- **Die „Metriken-Überblick"-Pille** (`helpers.py:1686-1730`, „Gewitter ab
+  HH:MM · stärkste HH:MM") — dieselbe Fensterlosigkeit, aber ein eigener
+  Sachverhalt, wird getrennt verbucht.
+- **Hagel-Zusatz für die Nacht-Angabe** — der bestehende Hagel-Hinweis
+  (`format_hail_note`) bleibt ausschließlich an das Tagesfenster-Ergebnis
+  gekoppelt; die neue Nacht-Angabe trägt keinen eigenen Hagel-Zusatz (Scope-
+  Begrenzung, kein fachlicher Verlust — Hagel ist ein Zusatzhinweis, kein
+  Kernwert).
+- **Die Tagesfenster-Klemmung selbst** — der Fix aus #1530 (Tages-Text
+  behauptet keine Nachtstunden mehr) bleibt unverändert bestehen; diese
+  Scheibe ergänzt nur additiv.
+- **Die dokumentierte Restgrenze 04–06 Uhr aus #1530** — bleibt unverändert
+  bestehen, wird durch die `night_weather`-Autorität für 00:00–06:00 in
+  dieser Scheibe implizit mit erledigt (dieselbe Quelle wie die
+  Nacht-Tabelle), aber nicht gesondert nachgewiesen.
+
+## Risiko
+
+Die Änderung ist additiv (neues Suffix, neues Zeilen-Feld) und rührt weder
+an der Level-Berechnung innerhalb des Fensters noch an Alarm-/Versandlogik —
+kein neuer Alarm entsteht, keiner entfällt. Das Hauptrisiko liegt in der
+Reihenfolge-Änderung in `preview_service.py` (Nachtwetter-Beschaffung nach
+vorne verschoben) — ein Fehler dort würde sich als fehlende oder doppelte
+Nacht-Beschaffung zeigen, nicht als falscher Text; Test 9 (Parität) deckt
+das ab.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Erweiterung einer bestehenden Formatierungs-/Aggregations-
+  stelle um eine zusätzliche, additive Quellen-Zusammenführung. Berührt
+  keine Entscheidungsfläche (Kanäle, Provider, Datenmodell, Auth,
+  Editor-Paradigma, Test-/Deploy-Strategie) im Sinne von `docs/adr/README.md`.
+
+## Changelog
+
+- 2026-08-09: Version 2.0 — vollständige Neufassung nach PO-Entscheidung
+  (Kommentar 2 an Issue #1651): Nachtgewitter wird GENANNT statt das
+  Zeitfenster nur beschriftet. Ersetzt Version 1.0 (Suffix-Ansatz)
+  vollständig.
+- 2026-08-09: Initial spec created (Version 1.0, überholt). Bezug: Issue
+  #1651, Vorgänger #1530/#1498.

--- a/docs/specs/modules/fix_1651_vorschau_zeitfenster.md
+++ b/docs/specs/modules/fix_1651_vorschau_zeitfenster.md
@@ -94,15 +94,17 @@ Schicht: **Python-Core** (`src/app/`, `src/services/`,
 | File | Change Type | Description |
 |---|---|---|
 | `src/app/day_window.py` | MODIFY | Neue Funktion, die aus zwei Stundenreihen (eigene Etappen-Zeitreihe + optional Nacht-Zeitreihe) die außerhalb des Fensters liegenden Stunden bestimmt und daraus Level+früheste Stunde ableitet (Implementation Details) |
-| `src/services/trip_report_scheduler.py` | MODIFY | Neuer optionaler `night_weather`-Parameter an `_build_thunder_forecast_from_trend_or_fetch()`, `_thunder_entry_from_trend_row()`, `_build_thunder_forecast()`; Suffix-Anhängen an `text`; `_build_stage_trend()` bekommt denselben optionalen Parameter und setzt `row["night_thunder"]`; Hauptablauf reicht das bereits vorhandene `night_weather` an beide Aufrufe durch |
+| `src/services/trip_report_scheduler.py` | MODIFY | Neuer optionaler `night_weather`-Parameter an `_build_thunder_forecast_from_trend_or_fetch()`, `_thunder_entry_from_trend_row()`, `_build_thunder_forecast()`; Suffix-Anhängen an `text`; Hauptablauf reicht das bereits vorhandene `night_weather` durch. **Umsetzungs-Abweichung 2026-08-09:** `_build_stage_trend()` bleibt unangetastet — der Parameter hätte in dieser Scheibe keinen Leser, `row["night_thunder"]` braucht nur die nach #1653 herausgelöste Ausblick-Tabelle. Ein Parameter ohne Leser ist ein Versprechen ohne Deckung. |
 | `src/services/preview_service.py` | MODIFY | Nachtwetter-Beschaffung (aktuell nach dem Trend-/Vorschau-Aufbau) nach vorne verschoben, analog zum Versandpfad, damit sie beim Bau von Trend und Vorschau bereits vorliegt |
 | ~~`src/output/renderers/email/outlook.py`~~ | — | **verschoben nach #1653** |
+| `src/services/segment_weather.py` | MODIFY | `night_weather_needed()` liefert auch bei aktiver Gewitter-Metrik `True` — die geteilte Entscheidung beider Pfade (AC-11, Spec §5b) |
 | `tests/unit/test_thunder_forecast_day_window.py` | MODIFY | Bestehende Tests zur Fenster-Klemmung um die neue Nacht-Angabe ergänzen |
 | `tests/tdd/test_thunder_forecast_low_level.py` | MODIFY | dito für die LOW-Stufe |
 | `tests/tdd/test_briefing_parity_night_thunder.py` | MODIFY | Bereits vorhandene Fixtures (`_thunder_forecast()`, `_night_weather()`, `_night_dp()`) sind direkt wiederverwendbar — neue Tests für die Kombination Vorschau + Nacht-Tabelle in derselben Mail |
 | `tests/tdd/test_bug_874_th_plus_sms.py` | MODIFY | Regressionsnachweis: SMS-Token unverändert trotz Nacht-Angabe im `text`-Feld |
 | `tests/unit/test_trip_report_formatter_v2.py` | MODIFY | Erwarteter Vorschau-Text ggf. anpassen, falls dort ein Nachtgewitter-Fixture verwendet wird |
-| `tests/golden/email/corsica-vigilance-html.txt`, `corsica-vigilance-plain.txt`, `gr20-spring-morning-html.txt`, `gr20-spring-morning-plain.txt` | MODIFY | Golden-Snapshots neu ziehen, sofern der Fixture-Trip ein Nachtgewitter zeigt |
+| ~~`tests/golden/email/*`~~ | — | **nicht nötig, gemessen:** die Fixture-Trips haben kein Gewitter außerhalb des Fensters, `test_email_html_golden.py` bleibt grün |
+| `tests/unit/test_preview_night_block.py` | MODIFY | **nachträglich ergänzt:** `test_preview_skips_night_fetch_when_neither_selected` wurde durch AC-11 rot (Fixture ließ `thunder` aktiv). Gegenprobe nachgezogen statt entwertet — schaltet jetzt auch `thunder` ab und bewacht weiter, dass kein pauschaler Zusatzabruf entsteht |
 | neue Testdatei (Name nach Verhalten, z.B. `tests/unit/test_thunder_night_addendum.py`) | CREATE | Gezielte Tests für die neue Helper-Funktion in `app/day_window.py` (Merge-Logik, Mehrere-Nachtstunden-Regel, +2 ohne Nacht-Tabelle) |
 
 ### Estimated Changes

--- a/docs/specs/modules/fix_1651_vorschau_zeitfenster.md
+++ b/docs/specs/modules/fix_1651_vorschau_zeitfenster.md
@@ -16,6 +16,22 @@ uebernommen. -->
 
 # #1651 — Gewitter außerhalb des Tagesfensters wird in der Mail genannt, mit Uhrzeit
 
+> **Scheiben-Schnitt, PO-Entscheidung 2026-08-09 (nach dem TDD-RED).** Diese Spec
+> deckt nur noch die **morgendliche „⚡ Gewitter-Vorschau"** ab. Der abendliche
+> **Mehrtages-Ausblick** ist herausgelöst nach **#1653**, weil seine Gewitter-Zelle
+> erst drei eigene, gemessene Fehler loswerden muss (Wort und Uhrzeit aus
+> verschiedenen Zeiträumen; Tag oder Nacht verschwindet; rohe Programmnamen),
+> bevor eine Nacht-Angabe sinnvoll darauf passt. Die rohen Programmnamen
+> (`⚡MED`/`⚡HIGH` statt „mittel"/„hoch") laufen als eigene kleine Lieferung
+> unter **#1654**. **AC-2 und AC-10 sind damit hierher nicht mehr anwendbar** —
+> sie stehen unten als verschoben markiert und werden in #1653 neu gefasst.
+>
+> **Korrektur zu einer Annahme dieser Spec:** Der Satz „Telegram (rich) erfüllt die
+> Vorgabe bereits" gilt **nicht allgemein**. Gemessen: Telegram zeigt den stärksten
+> Wert über 24 Stunden mit dessen Uhrzeit und verschweigt dabei den jeweils
+> schwächeren — bei Tag „mittel" 14:00 + Nacht „hoch" 00:00 erscheint `⚡hoch@0`,
+> das Tagesgewitter fehlt. Behandelt in #1653.
+
 ## Approval
 
 - [ ] Approved
@@ -24,11 +40,11 @@ uebernommen. -->
 
 Ein Gewitter **außerhalb** des konfigurierten Tagesfensters (Default 04–19 Uhr
 Ortszeit) soll in der Trip-Mail **genannt werden, mit exakter Uhrzeit** — statt
-wie heute verschwiegen zu werden. Betroffen sind zwei Stellen derselben Mail:
-die morgendliche „⚡ Gewitter-Vorschau" (Fließtext-Satz) und die abendliche
-„Mehrtages-Ausblick"-Tabelle (Spalte „Gew"). SMS zeigt die Angabe weiterhin
-nicht (Platzgrund, PO-Vorgabe); Telegram (rich) erfüllt die Vorgabe bereits
-und bleibt unverändert.
+wie heute verschwiegen zu werden. Betroffen ist in dieser Scheibe **eine** Stelle:
+die morgendliche „⚡ Gewitter-Vorschau" (Fließtext-Satz), sichtbar in HTML **und**
+Klartext. SMS zeigt die Angabe weiterhin nicht (Platzgrund, PO-Vorgabe).
+Die abendliche „Mehrtages-Ausblick"-Tabelle und Telegram sind nach **#1653**
+herausgelöst.
 
 PO-Wortlaut (Kommentar 2 an Issue #1651, 2026-08-09):
 
@@ -53,8 +69,8 @@ sicher, dass die neue Nacht-Angabe für die Stunden, die auch die
   Hauptablauf (`generate_and_send`, Zeile ~875–902)
 - **File:** `src/services/preview_service.py` — Reihenfolge der
   Nachtwetter-Beschaffung
-- **File:** `src/output/renderers/email/outlook.py` —
-  `render_outlook_table()`, `render_outlook_plain()`
+(`src/output/renderers/email/outlook.py` war in Version 2.0 vorgesehen und ist
+mit dem Scheiben-Schnitt nach #1653 herausgelöst.)
 
 Schicht: **Python-Core** (`src/app/`, `src/services/`,
 `src/output/renderers/`). Kein Go-, kein Frontend-Code betroffen.
@@ -80,7 +96,7 @@ Schicht: **Python-Core** (`src/app/`, `src/services/`,
 | `src/app/day_window.py` | MODIFY | Neue Funktion, die aus zwei Stundenreihen (eigene Etappen-Zeitreihe + optional Nacht-Zeitreihe) die außerhalb des Fensters liegenden Stunden bestimmt und daraus Level+früheste Stunde ableitet (Implementation Details) |
 | `src/services/trip_report_scheduler.py` | MODIFY | Neuer optionaler `night_weather`-Parameter an `_build_thunder_forecast_from_trend_or_fetch()`, `_thunder_entry_from_trend_row()`, `_build_thunder_forecast()`; Suffix-Anhängen an `text`; `_build_stage_trend()` bekommt denselben optionalen Parameter und setzt `row["night_thunder"]`; Hauptablauf reicht das bereits vorhandene `night_weather` an beide Aufrufe durch |
 | `src/services/preview_service.py` | MODIFY | Nachtwetter-Beschaffung (aktuell nach dem Trend-/Vorschau-Aufbau) nach vorne verschoben, analog zum Versandpfad, damit sie beim Bau von Trend und Vorschau bereits vorliegt |
-| `src/output/renderers/email/outlook.py` | MODIFY | `render_outlook_table()`/`render_outlook_plain()` hängen die Nacht-Angabe an die „Gew"-Zelle an, wenn `stage.get("night_thunder")` gesetzt ist |
+| ~~`src/output/renderers/email/outlook.py`~~ | — | **verschoben nach #1653** |
 | `tests/unit/test_thunder_forecast_day_window.py` | MODIFY | Bestehende Tests zur Fenster-Klemmung um die neue Nacht-Angabe ergänzen |
 | `tests/tdd/test_thunder_forecast_low_level.py` | MODIFY | dito für die LOW-Stufe |
 | `tests/tdd/test_briefing_parity_night_thunder.py` | MODIFY | Bereits vorhandene Fixtures (`_thunder_forecast()`, `_night_weather()`, `_night_dp()`) sind direkt wiederverwendbar — neue Tests für die Kombination Vorschau + Nacht-Tabelle in derselben Mail |
@@ -175,7 +191,11 @@ Hauptablauf (`generate_and_send`): `night_weather` ist an Zeile ~876–878
 bereits vorhanden — wird unverändert an `_build_thunder_forecast_from_trend_or_fetch()`
 (Zeile ~900) sowie an `_build_stage_trend()` (Zeile ~889, s.u.) durchgereicht.
 
-### 4. Integration Ausblick-Tabelle (Abend-Default)
+### 4. Integration Ausblick-Tabelle (Abend-Default) — VERSCHOBEN NACH #1653
+
+Der folgende Abschnitt ist mit dem Scheiben-Schnitt vom 2026-08-09 nicht mehr
+Teil dieser Spec. Er bleibt als Vorarbeit stehen, ist aber in #1653 neu zu
+fassen — die dort gemessenen Altfehler der Zelle ändern den Entwurf.
 
 `_build_stage_trend()` bekommt denselben optionalen `night_weather`-Parameter.
 Nach dem Bau jeder Zeile über `build_outlook_row()` (die bereits ungefilterte
@@ -270,9 +290,10 @@ entsteht kein neuer Abruf im Versand, nur eine Angleichung der Vorschau.
   Fenster, HIGH um 00:00 in `night_weather` WHEN der Vorschau-Eintrag gebaut
   wird THEN lautet `entry["text"]` „Kein Gewitter erwartet, nachts starkes
   Gewitter ab 00:00").
-- [ ] Test 2 (Kernszenario Abend, GIVEN derselbe Fall WHEN die
+- [x] ~~Test 2 (Kernszenario Abend)~~ — **verschoben nach #1653**.
+  ~~(GIVEN derselbe Fall WHEN die
   Ausblick-Tabelle für denselben Tag gebaut wird THEN zeigt die
-  „Gew"-Zelle „nachts hoch 00:00" statt „–"/„⚡–").
+  „Gew"-Zelle „nachts hoch 00:00" statt „–"/„⚡–".)~~
 - [ ] Test 3 (Konsistenz mit Nacht-Tabelle, GIVEN dieselbe zugestellte Mail
   WHEN sowohl die Nacht-Tabellen-Zeile 00:00 als auch die neue Nacht-Angabe
   gelesen werden THEN nennen beide dieselbe Stunde und dasselbe Level).
@@ -306,11 +327,12 @@ entsteht kein neuer Abruf im Versand, nur eine Angleichung der Vorschau.
   starkes Gewitter ab 00:00" statt der bisherigen reinen Entwarnung ohne
   Nacht-Hinweis.
 
-- **AC-2 (Kernszenario Abend):** Given derselbe Trip und Tag wie AC-1 / When
+- **AC-2 — VERSCHOBEN NACH #1653, in dieser Scheibe nicht anwendbar.**
+  ~~Given derselbe Trip und Tag wie AC-1 / When
   die abendliche Trip-Mail mit aktivem Mehrtages-Ausblick erzeugt wird /
   Then zeigt die Spalte „Gew" für diesen Tag „nachts hoch 00:00" (HTML) bzw.
   „⚡ nachts hoch 00:00" (Klartext) statt der bisherigen Entwarnung „–"/„⚡–" —
-  in beiden Mail-Teilen (HTML und Klartext) derselben Mail.
+  in beiden Mail-Teilen (HTML und Klartext) derselben Mail.~~
 
 - **AC-3 (Konsistenz mit der Nacht-Tabelle — zentrale #1498-Zusicherung):**
   Given ein Trip, dessen „Nacht am Ziel"-Tabelle für 00:00 des Folgetags ein
@@ -371,41 +393,40 @@ entsteht kein neuer Abruf im Versand, nur eine Angleichung der Vorschau.
   der Vorschau-Pfad greift auf dieselbe Nacht-Zeitreihe zu wie der Versand,
   statt still auf eine andere Quelle auszuweichen.
 
-- **AC-10 (Telegram rich bleibt unverändert):** Given ein Trip mit
+- **AC-10 — VERSCHOBEN NACH #1653, in dieser Scheibe nicht anwendbar.**
+  Die Annahme dahinter ist zudem widerlegt: Telegram zeigt den 24-Stunden-
+  Höchstwert und verschweigt den jeweils schwächeren von Tag und Nacht.
+  ~~Given ein Trip mit
   Nachtgewitter außerhalb des Fensters / When die Telegram-„Ausblick"-Bubble
   gerendert wird / Then bleibt ihre Darstellung (z.B. „⚡H@2") gegenüber
   dem Stand vor dieser Scheibe unverändert — sie zeigt Nachtgewitter bereits
-  heute über ihre eigene, ungefilterte Quelle.
+  heute über ihre eigene, ungefilterte Quelle.~~
 
 ## Umfang
 
-**Die ehrliche Schätzung überschreitet das 250-Zeilen-Workflow-Limit.**
+**Neu bemessen nach dem TDD-RED und dem Scheiben-Schnitt vom 2026-08-09.**
 
-- Produktivcode: `app/day_window.py` (~35 LoC neue Funktion) +
-  `trip_report_scheduler.py` (~100 LoC: vier Methoden-Signaturen erweitert,
-  Merge-Aufruf, Suffix-Bau, Zeilen-Augmentierung) +
-  `preview_service.py` (~20 LoC Umstellung) + `outlook.py` (~30 LoC) ≈
-  **~185 LoC**.
-- Tests: zehn ACs über mindestens sieben bestehende Testdateien plus eine
-  neue gezielte Testdatei für die Helper-Funktion, plus vier
-  Golden-Snapshot-Aktualisierungen (zählen laut CLAUDE.md nicht mit) ≈
-  geschätzt **~150–220 LoC**.
-- **Gesamt geschätzt: ~335–405 LoC.**
+Die Schätzung der Version 2.0 (~335–405 Zeilen) war um etwa das Dreifache zu
+niedrig: der Entwickler brauchte für die elf Kriterien **994 Zeilen Testcode**,
+weil die beiden Paritäts-Prüfungen (AC-9, AC-11) den echten Versand- **und** den
+echten Vorschau-Pfad fahren statt einen nachgebauten. Zusammen mit dem
+Produktivcode lag der Workflow bei rund **1180 Zeilen** — weit über den vom PO
+freigegebenen 500.
 
-✅ **PO-Entscheidung 2026-08-09: Limit auf 500 angehoben, Lieferung in einem
-Zug.** `loc_limit_override = 500` ist im Workflow gesetzt. Die unten
-skizzierte Zweiteilung wird damit **nicht** gefahren und ist nur noch als
-Rückfalloption dokumentiert.
+**Folge (PO-Entscheidung):** Der Abend-Teil ist nach #1653 herausgelöst, die
+rohen Programmnamen nach #1654. In dieser Scheibe verbleiben:
 
-**Sauberste Trennung in zwei Scheiben** (nicht gewählt, nur als Rückfall):
+| Teil | geschätzt |
+|---|---|
+| Produktivcode (`day_window.py`, `trip_report_scheduler.py`, `preview_service.py`) | ~150 |
+| Tests: `test_thunder_night_addendum.py` + `test_thunder_night_addendum_parity.py` | ~713 |
+| entfällt: `test_outlook_night_thunder_cell.py` (281 Z.) | → #1653 |
 
-| Scheibe | Inhalt | Enthält |
-|---|---|---|
-| **A — Vorschau-Satz (Morgen)** | AC-1, AC-3 (Teilaspekt Vorschau), AC-4, AC-5, AC-6, AC-7, AC-8, AC-9 | `app/day_window.py`-Helper (geteilte Grundlage für beide Scheiben), `trip_report_scheduler.py`-Forecast-Methoden, `preview_service.py`-Umstellung |
-| **B — Ausblick-Tabelle (Abend)** | AC-2, AC-3 (Teilaspekt Tabelle), AC-10 | `_build_stage_trend()`-Zeilen-Augmentierung (baut auf Scheibe A's Helper auf), `outlook.py`-Rendering |
-
-Scheibe A trägt den Helper und ist damit die natürliche erste Scheibe;
-Scheibe B ist ohne A nicht sinnvoll umsetzbar (gemeinsame Funktion).
+Damit bleibt der Workflow weiterhin über 250, aber innerhalb der bereits
+gesetzten Grenze von 500 nur bei den Produktivzeilen — der Testanteil überschreitet
+sie. **Das ist bewusst so und vom PO getragen:** die Paritäts-Prüfungen sind der
+eigentliche Schutz gegen einen Rückfall in #1498 und werden nicht gekürzt.
+Reicht das Limit beim Commit nicht, wird es angehoben, nicht der Test gekürzt.
 
 ## Nicht in dieser Scheibe
 

--- a/src/app/day_window.py
+++ b/src/app/day_window.py
@@ -50,6 +50,87 @@ def resolve_configured_window(
     return day_window_start_hour, day_window_end_hour
 
 
+def night_addendum(
+    own_hourly,
+    night_hourly,
+    win_start: int,
+    win_end: int,
+):
+    """Level + fruehste Stunde des schlimmsten Gewitters AUSSERHALB des
+    Fensters (#1651).
+
+    ``own_hourly``/``night_hourly`` sind Folgen von
+    ``(Ortszeit-Stunde, ThunderLevel)`` aus den jeweils bereits vorliegenden,
+    UNGEFILTERTEN Zeitreihen -- kein neuer Netzabruf.
+
+    ``night_hourly`` (falls gegeben) ueberschreibt ``own_hourly`` fuer die
+    Stunden, die es abdeckt (00:00-06:00 des Folgetags): es ist dieselbe
+    Quelle, welche die „Nacht am Ziel"-Tabelle direkt neben der Vorschau
+    zeigt. Genau daran scheiterte #1498 -- zwei Quellen sagten fuer DIESELBE
+    Stunde derselben Mail Widerspruechliches.
+
+    Mehrere Stunden ausserhalb bilden EINEN Pool (z. B. 00-03 und 20-23
+    zusammen): es gewinnt das hoechste Level, davon die frueheste Stunde --
+    spiegelbildlich zur Innerhalb-Fenster-Regel in
+    ``_thunder_entry_from_trend_row``.
+
+    Rueckgabe ``None``, wenn ausserhalb des Fensters kein Gewitter liegt
+    (dann entsteht kein Zusatz).
+    """
+    from app.models import ThunderLevel
+    from app.thunder_scale import thunder_ordinal
+
+    def _peak_per_hour(pairs) -> dict:
+        peaks: dict = {}
+        for hour, level in pairs or ():
+            if level is None:
+                continue
+            h = int(hour)
+            prev = peaks.get(h)
+            if prev is None or thunder_ordinal(level) > thunder_ordinal(prev):
+                peaks[h] = level
+        return peaks
+
+    merged = _peak_per_hour(own_hourly)
+    merged.update(_peak_per_hour(night_hourly))
+
+    outside = [
+        (hour, level)
+        for hour, level in merged.items()
+        if level != ThunderLevel.NONE
+        and not hour_in_window(hour, win_start, win_end)
+    ]
+    if not outside:
+        return None
+    level = max((lv for _h, lv in outside), key=thunder_ordinal)
+    hour = min(h for h, lv in outside if lv == level)
+    return level, hour
+
+
+# Wortschatz des Nacht-Zusatzes (#1651). Bewusste Abweichung vom Tagestext,
+# wo MED kein Adjektiv traegt („Gewitter moeglich ab HH:MM"): der Halbsatz
+# muss fuer sich lesbar sein -- ein „nachts Gewitter" ohne Stufe waere von
+# „Stufe unbekannt" nicht unterscheidbar.
+_NIGHT_ADDENDUM_WORD = {
+    "LOW": "leichtes",
+    "MED": "mittleres",
+    "HIGH": "starkes",
+}
+
+
+def format_night_addendum(level, hour: int) -> str:
+    """Der angehaengte Halbsatz zu einem ``night_addendum()``-Treffer.
+
+    EINE Stelle fuer den Wortlaut: beide Bauwege des Vorschau-Satzes
+    (Trend-Weg und Fetch-Weg) sind wortgleich, aber unabhaengiger Code --
+    eine zweite Kopie wuerde driften.
+    """
+    word = _NIGHT_ADDENDUM_WORD.get(getattr(level, "name", str(level)))
+    if word is None:
+        return ""
+    return f", nachts {word} Gewitter ab {int(hour):02d}:00"
+
+
 def hour_in_window(hour: int, start_hour: int, end_hour: int) -> bool:
     """Liegt die Ortszeit-Stunde im Fenster? Beide Grenzen einschliesslich.
 

--- a/src/services/preview_service.py
+++ b/src/services/preview_service.py
@@ -191,18 +191,6 @@ class PreviewService:
         # (trip_report_scheduler.py:878-887) — `.rows` bleibt der bisherige
         # Wert, `.state`/`.horizon_days` werden zusaetzlich durchgereicht.
         # Jede Abweichung hier liesse die Vorschau wieder divergieren (AC-6).
-        multi_day_trend = None
-        outlook_state = None
-        outlook_horizon_days = None
-        if segment_weather and render_options.show_multi_day_trend:
-            trend_result = scheduler._build_stage_trend(trip, target, tz=trip_tz)
-            multi_day_trend = trend_result.rows
-            outlook_state = trend_result.state
-            outlook_horizon_days = trend_result.horizon_days
-        thunder_forecast = scheduler._build_thunder_forecast_from_trend_or_fetch(
-            trip, target, tz=trip_tz, multi_day_trend=multi_day_trend,
-        )
-
         # Issue #1315: Nacht-Wetter fuer BEIDE report_types (#1313-Semantik),
         # ueber dieselbe geteilte Funktion wie der Versand (kein Duplikat).
         # Nur beschaffen, wenn der Trip die Sektion ueberhaupt zeigen wuerde
@@ -214,10 +202,27 @@ class PreviewService:
         # Issue #1484 AC-8: auch die gewaehlte Nacht-Tiefsttemperatur
         # braucht Nachtdaten, nicht nur die Nacht-Stundentabelle — geteilte
         # Entscheidung night_weather_needed (Paritaet zum Versand).
+        # Issue #1651: die Beschaffung steht VOR dem Bau von Trend und
+        # Vorschau-Eintrag (vorher danach) — sonst faehrt der Vorschau-Pfad
+        # den Vorschau-Satz ohne die Nacht-Reihe und divergiert vom Versand
+        # (AC-9). Reine Umstellung, kein zusaetzlicher Abruf.
         from services.segment_weather import fetch_night_weather, night_weather_needed
         night_weather = None
         if segment_weather and night_weather_needed(trip.display_config):
             night_weather = fetch_night_weather(segment_weather[-1], provider=provider)
+
+        multi_day_trend = None
+        outlook_state = None
+        outlook_horizon_days = None
+        if segment_weather and render_options.show_multi_day_trend:
+            trend_result = scheduler._build_stage_trend(trip, target, tz=trip_tz)
+            multi_day_trend = trend_result.rows
+            outlook_state = trend_result.state
+            outlook_horizon_days = trend_result.horizon_days
+        thunder_forecast = scheduler._build_thunder_forecast_from_trend_or_fetch(
+            trip, target, tz=trip_tz, multi_day_trend=multi_day_trend,
+            night_weather=night_weather,
+        )
 
         # Issue #474: F12 Wetterlage-Label vor format_email berechnen.
         try:

--- a/src/services/segment_weather.py
+++ b/src/services/segment_weather.py
@@ -400,10 +400,22 @@ def night_weather_needed(dc) -> bool:
     Vorschau ein ``N``, das still auf den Tageswert zurueckfaellt, waehrend
     der Versand den echten Nachtwert traegt. Geteilte Entscheidung fuer
     preview_service; der Versand-Scheduler beschafft ohnehin immer.
+
+    Issue #1651: ODER aktive Gewitter-Metrik — ab dieser Scheibe speisen die
+    Nachtdaten zusaetzlich den Nacht-Zusatz des Vorschau-Satzes („nachts
+    starkes Gewitter ab HH:MM"). Ohne diese Bedingung haette ein Trip OHNE
+    Nacht-Tabelle im Versand die Nacht-Reihe und in der Vorschau nicht —
+    beide bildeten den Satz aus verschiedenen Quellen (AC-11). Die eine
+    geteilte Entscheidung waechst mit, statt dass der Vorschau-Pfad eine
+    eigene Sonderregel bekommt.
     """
+    if getattr(dc, "show_night_block", False):
+        return True
+    if dc is None:
+        return False
     return bool(
-        getattr(dc, "show_night_block", False)
-        or (dc is not None and dc.is_metric_enabled("temperature_night"))
+        dc.is_metric_enabled("temperature_night")
+        or dc.is_metric_enabled("thunder")
     )
 
 

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -90,6 +90,26 @@ def _trend_note(thunder: str, precip_mm: float, wind_kmh: int) -> str | None:
     return " · ".join(notes) if notes else None
 
 
+def _night_thunder_hours(night_weather, fc_date: date, to_local):
+    """``night_weather`` -> ``(Ortszeit-Stunde, ThunderLevel)`` fuer EINEN Tag.
+
+    Issue #1651: die Nacht-Zeitreihe (Ankunft heute -> 06:00 morgen) ist fuer
+    die Stunden, die sie abdeckt, die massgebliche Quelle des Nacht-Zusatzes
+    -- dieselbe, aus der auch die „Nacht am Ziel"-Tabelle derselben Mail
+    entsteht. ``None`` (keine Reihe, keine Punkte am Zieltag) heisst: keine
+    Gegenquelle, es gilt allein die eigene Etappen-Reihe.
+    """
+    data = getattr(night_weather, "data", None)
+    if not data:
+        return None
+    hours = [
+        (to_local(dp.ts).hour, dp.thunder_level)
+        for dp in data
+        if dp.thunder_level is not None and to_local(dp.ts).date() == fc_date
+    ]
+    return hours or None
+
+
 def _parse_hhmm(value: str) -> Optional[time]:
     """Parse 'HH:MM' to a time; returns None on malformed input.
 
@@ -897,8 +917,12 @@ class TripReportSchedulerService:
         #    (evening default) its rows are REUSED — no second weather fetch.
         #    Only offsets not covered by the trend fall back to a dedicated
         #    single-stage fetch (typically morning, where the trend is off).
+        #    Issue #1651: `night_weather` (Schritt 4, oben) wird durchgereicht,
+        #    damit der Satz ein Gewitter ausserhalb des Tagesfensters nennt --
+        #    aus DERSELBEN Reihe, die daneben als Nacht-Tabelle steht.
         thunder_forecast = self._build_thunder_forecast_from_trend_or_fetch(
             trip, target_date, tz=trip_tz, multi_day_trend=multi_day_trend,
+            night_weather=night_weather,
         )
 
         # 7b. Vortag-Vergleich (Issue #750): gestrigen Snapshot laden + Deltas
@@ -1673,6 +1697,7 @@ class TripReportSchedulerService:
         target_date: date,
         tz: Optional[ZoneInfo],
         multi_day_trend=None,
+        night_weather=None,
     ) -> Optional[dict]:
         """Issue #1275: derive the +1/+2 thunder forecast from the SAME data as
         the E-Mail-Outlook table.
@@ -1698,8 +1723,20 @@ class TripReportSchedulerService:
         Aussagen widersprachen sich an einer echt zugestellten Staging-Mail.
         Die Vorschau ist eine TAGES-Aussage und nutzt dasselbe Fenster wie
         SMS/Telegram/Fusszeile (ADR-0025).
+
+        Issue #1651: ``night_weather`` (dieselbe Reihe, die auch die
+        „Nacht am Ziel"-Tabelle speist) laesst den Satz ein Gewitter
+        AUSSERHALB des Fensters zusaetzlich nennen -- angehaengt an ``text``,
+        die Tages-Aussage (``level``/``hour``) bleibt geklemmt. Beide
+        Aufrufer (Versand und Vorschau) reichen sie durch; genau das traegt
+        die Paritaet aus AC-9/AC-11.
         """
         from app.day_window import resolve_configured_window
+
+        def _local(dt):
+            # #1402: nie .astimezone(tz) auf einem naiven ts -- local_dt geht
+            # ueber den zentralen Naiv-Guard (Hausnorm "naiv = UTC", #1345).
+            return local_dt(dt, tz) if tz else dt
 
         _rc = getattr(trip, "report_config", None)
         win_start, win_end = resolve_configured_window(
@@ -1719,6 +1756,12 @@ class TripReportSchedulerService:
             if row is not None:
                 forecast[key] = self._thunder_entry_from_trend_row(
                     row, fc_date, window_start=win_start, window_end=win_end,
+                    # "+2" liegt jenseits der Nacht-Reihe (endet 06:00 morgen)
+                    # -- dort gibt es keine Gegenquelle (Spec, Punkt 4).
+                    night_hourly=(
+                        _night_thunder_hours(night_weather, fc_date, _local)
+                        if offset == 1 else None
+                    ),
                 )
             else:
                 missing_dates.add(fc_date)
@@ -1731,6 +1774,7 @@ class TripReportSchedulerService:
                 self._build_thunder_forecast(
                     fetched, target_date, tz=tz,
                     window_start=win_start, window_end=win_end,
+                    night_weather=night_weather,
                 )
                 if fetched else None
             ) or {}
@@ -1767,6 +1811,7 @@ class TripReportSchedulerService:
         *,
         window_start: Optional[int] = None,
         window_end: Optional[int] = None,
+        night_hourly=None,
     ) -> dict:
         """Map one ``multi_day_trend`` row to a thunder_forecast entry (#1275).
 
@@ -1791,24 +1836,35 @@ class TripReportSchedulerService:
         Skala (auch ``hourly_thunder`` selbst wird darüber gebaut, s.
         ``outlook.py::build_outlook_row``), also bleibt der Werte-Vergleich
         konsistent statt einer zweiten, driftenden Kopie.
+
+        Issue #1651: ``night_hourly`` (optional, ``(Stunde, ThunderLevel)``-
+        Paare aus ``night_weather``) laesst den Satz ein Gewitter AUSSERHALB
+        des Fensters zusaetzlich NENNEN. Rein additiv -- ``level``/``hour``
+        (die Tages-Aussage, aus der SMS und Ampel lesen) bleiben geklemmt,
+        nur ``text`` waechst um den Halbsatz.
         """
-        from app.day_window import hour_in_window, resolve_configured_window
+        from app.day_window import (
+            format_night_addendum, hour_in_window, night_addendum,
+            resolve_configured_window,
+        )
         from app.models import ThunderLevel
         from app.thunder_scale import thunder_label_value, thunder_ordinal
 
         win_start, win_end = resolve_configured_window(window_start, window_end)
+        # Rueckabbildung Sample-Wert -> Level ueber die geteilte Render-Skala
+        # selbst (#1474: keine Handkopie).
+        _value_to_level = {thunder_label_value(lv): lv for lv in ThunderLevel}
+        all_hourly = tuple(row.get("hourly_thunder") or ())
         windowed = [
-            hv for hv in (row.get("hourly_thunder") or ())
+            hv for hv in all_hourly
             if hour_in_window(int(hv.hour), win_start, win_end)
         ]
         if windowed:
             # Issue #1498 (Fall 2): Level aus den Stundenproben IM Fenster,
             # nicht aus dem Kalendertags-Maximum `row["thunder"]` — sonst
             # setzt ein reines Nachtgewitter (02:00) die Tages-Vorschau.
-            # Rueckabbildung Sample-Wert -> Level ueber die geteilte
-            # Render-Skala selbst (#1474: keine Handkopie), Sortierung ueber
-            # thunder_ordinal (ADR-0025, Entscheidung 3: Skalen getrennt).
-            _value_to_level = {thunder_label_value(lv): lv for lv in ThunderLevel}
+            # Sortierung ueber thunder_ordinal (ADR-0025, Entscheidung 3:
+            # Skalen getrennt).
             level = max(
                 (
                     _value_to_level.get(int(hv.value), ThunderLevel.NONE)
@@ -1846,6 +1902,17 @@ class TripReportSchedulerService:
                 f"Starkes Gewitter erwartet ab {when}"
                 if when else "Starkes Gewitter erwartet"
             )
+        # Issue #1651: das Gewitter AUSSERHALB des Fensters wird angehaengt
+        # genannt. Quelle sind dieselben, ohnehin vorliegenden Stundenproben
+        # der Zeile -- fuer 00:00-06:00 des Folgetags schlaegt `night_hourly`
+        # sie, weil dieselbe Reihe daneben als Nacht-Tabelle steht.
+        own_hourly = [
+            (int(hv.hour), _value_to_level.get(int(hv.value), ThunderLevel.NONE))
+            for hv in all_hourly
+        ]
+        add = night_addendum(own_hourly, night_hourly, win_start, win_end)
+        if add:
+            text += format_night_addendum(*add)
         return {
             "date": fc_date.strftime("%d.%m.%Y"),
             "level": level,
@@ -1936,6 +2003,7 @@ class TripReportSchedulerService:
         *,
         window_start: Optional[int] = None,
         window_end: Optional[int] = None,
+        night_weather=None,
     ) -> Optional[dict]:
         """
         Build thunder forecast for +1 and +2 days.
@@ -2001,19 +2069,29 @@ class TripReportSchedulerService:
         # Nacht-Tabelle. Liegt im Fenster gar kein Datenpunkt, entsteht KEIN
         # Eintrag — das greift in `_gap_offsets` (#1482) als ehrliche
         # Datenluecke ("?") statt einer blinden Entwarnung (#1331-Lehre).
-        from app.day_window import hour_in_window, resolve_configured_window
+        from app.day_window import (
+            format_night_addendum, hour_in_window, night_addendum,
+            resolve_configured_window,
+        )
         win_start, win_end = resolve_configured_window(window_start, window_end)
 
         forecast = {}
         for offset, key in [(1, "+1"), (2, "+2")]:
             fc_date = target_date + timedelta(days=offset)
-            thunder_dps = [
+            # Issue #1651: der volle Kalendertag wird zuerst gesammelt, damit
+            # die Stunden AUSSERHALB des Fensters fuer den Nacht-Zusatz zur
+            # Verfuegung stehen. `thunder_dps` -- die Tages-Aussage -- bleibt
+            # unveraendert auf das Fenster geklemmt (#1498 Fall 2).
+            day_dps = [
                 dp
                 for sw in segments
                 if sw.timeseries and sw.timeseries.data
                 for dp in sw.timeseries.data
                 if _local(dp.ts).date() == fc_date and dp.thunder_level
-                and hour_in_window(_local(dp.ts).hour, win_start, win_end)
+            ]
+            thunder_dps = [
+                dp for dp in day_dps
+                if hour_in_window(_local(dp.ts).hour, win_start, win_end)
             ]
             if not thunder_dps:
                 continue
@@ -2039,6 +2117,18 @@ class TripReportSchedulerService:
                 text = f"Gewitter möglich ab {when}"
             else:
                 text = f"Starkes Gewitter erwartet ab {when}"
+            # Issue #1651: Nacht-Zusatz, wortgleich zum Trend-Weg (eine
+            # Wortlaut-Quelle: format_night_addendum). `night_weather` reicht
+            # nur bis 06:00 des Folgetags und ist deshalb allein fuer "+1"
+            # eine Gegenquelle; "+2" traegt ausschliesslich seine eigene Reihe.
+            add = night_addendum(
+                [(_local(dp.ts).hour, dp.thunder_level) for dp in day_dps],
+                _night_thunder_hours(night_weather, fc_date, _local)
+                if offset == 1 else None,
+                win_start, win_end,
+            )
+            if add:
+                text += format_night_addendum(*add)
             forecast[key] = {
                 "date": fc_date.strftime("%d.%m.%Y"),
                 "level": level,

--- a/tests/unit/test_preview_night_block.py
+++ b/tests/unit/test_preview_night_block.py
@@ -272,9 +272,17 @@ def test_preview_night_fetch_follows_night_metric_selection(monkeypatch):
 
 
 def test_preview_skips_night_fetch_when_neither_selected(monkeypatch):
-    """Gegenprobe zu AC-8: weder Nacht-Stundentabelle noch Nachtgroesse
-    gewaehlt -> die Vorschau beschafft keine Nachtdaten (kein unnoetiger
-    Provider-Aufruf)."""
+    """Gegenprobe zu AC-8: ist KEINER der Gruende gegeben, die Nachtdaten
+    noetig machen -> die Vorschau beschafft keine (kein unnoetiger
+    Provider-Aufruf).
+
+    #1651 hat die Liste dieser Gruende um die Gewitter-Metrik erweitert: ab
+    dieser Scheibe speisen Nachtdaten auch den Nacht-Zusatz des
+    Vorschau-Satzes ("nachts starkes Gewitter ab HH:MM"), und ohne sie
+    divergierte die Vorschau vom Versand (AC-11). Der Test schaltet sie
+    deshalb mit ab -- er bewacht weiterhin, dass kein PAUSCHALER Zusatz-Abruf
+    fuer jeden Trip entsteht, jetzt gegen den vollstaendigen Bedingungssatz.
+    """
     import services.segment_weather as sw
 
     calls: list[int] = []
@@ -290,13 +298,13 @@ def test_preview_skips_night_fetch_when_neither_selected(monkeypatch):
     trip = _demo_trip_single_stage(target, show_night_block=False)
     trip.display_config.metrics = [
         dataclasses.replace(mc, enabled=False)
-        if mc.metric_id == "temperature_night" else mc
+        if mc.metric_id in ("temperature_night", "thunder") else mc
         for mc in trip.display_config.metrics
     ]
 
     PreviewService()._build_report(trip, target, "evening", demo=True)
 
     assert calls == [], (
-        "Die Vorschau beschafft Nachtdaten, obwohl weder Tabelle noch "
-        "Nachtgroesse gewaehlt sind."
+        "Die Vorschau beschafft Nachtdaten, obwohl weder Nacht-Tabelle noch "
+        "Nacht-Tiefsttemperatur noch Gewitter-Metrik gewaehlt sind."
     )

--- a/tests/unit/test_thunder_forecast_day_window.py
+++ b/tests/unit/test_thunder_forecast_day_window.py
@@ -13,6 +13,13 @@ das geteilte Tagesfenster (Default 04-19, pro Trip konfigurierbar,
 Fusszeile, ADR-0025). Nachtstunden gehoeren der Nacht-Tabelle; die beiden
 Aussagen ueberlappen sich nicht mehr.
 
+#1651 (additiv): dieselbe TAGES-Aussage (``level``/``hour``) bleibt
+geklemmt, der Fliesstext nennt das Gewitter ausserhalb des Fensters aber
+seit dieser Scheibe zusaetzlich mit Uhrzeit — verschwiegen wird es nicht
+mehr. Die Erwartungstexte unten tragen den angehaengten Halbsatz deshalb
+mit; die eigentliche #1498-Zusicherung sitzt unveraendert in den
+``level``/``hour``-Aussagen.
+
 KEINE Mocks: reale Model-Objekte, echte Scheduler-Methoden. Der Stub-Trip
 in den Konfigurations-Tests ist ein einfaches Datenobjekt (echte Attribute,
 kein Mock()/patch()).
@@ -92,7 +99,12 @@ def test_fallback_nachtgewitter_ausserhalb_fenster_ist_entwarnung():
     assert entry["level"] == ThunderLevel.NONE, (
         f"Nacht-LOW (02:00) darf die Tages-Vorschau nicht setzen: {entry!r}"
     )
-    assert entry["text"] == "Kein Gewitter erwartet", entry["text"]
+    assert entry["hour"] is None, entry
+    # #1651: die TAGES-Aussage bleibt die Entwarnung, das Nachtgewitter wird
+    # nun aber angehaengt genannt statt verschwiegen.
+    assert entry["text"] == (
+        "Kein Gewitter erwartet, nachts leichtes Gewitter ab 02:00"
+    ), entry["text"]
 
 
 def test_fallback_ab_stunde_kommt_aus_dem_fenster():
@@ -109,7 +121,11 @@ def test_fallback_ab_stunde_kommt_aus_dem_fenster():
     entry = (fc or {}).get("+1")
     assert entry is not None
     assert entry["level"] == ThunderLevel.LOW
-    assert entry["text"] == "Leichtes Gewitter möglich ab 04:00", entry["text"]
+    # #1651: "ab 04:00" ist und bleibt die Tages-Aussage; die 02:00 erscheinen
+    # ausschliesslich im angehaengten Nacht-Halbsatz.
+    assert entry["text"] == (
+        "Leichtes Gewitter möglich ab 04:00, nachts leichtes Gewitter ab 02:00"
+    ), entry["text"]
     assert entry["hour"] == 4, entry
 
 
@@ -143,7 +159,10 @@ def test_trend_nachtgewitter_ausserhalb_fenster_ist_entwarnung():
     assert entry["level"] == ThunderLevel.NONE, (
         f"Nacht-LOW (02:00) darf die Tages-Vorschau nicht setzen: {entry!r}"
     )
-    assert entry["text"] == "Kein Gewitter erwartet", entry["text"]
+    assert entry["hour"] is None, entry
+    assert entry["text"] == (
+        "Kein Gewitter erwartet, nachts leichtes Gewitter ab 02:00"
+    ), entry["text"]
 
 
 def test_trend_ab_stunde_kommt_aus_dem_fenster():
@@ -158,7 +177,9 @@ def test_trend_ab_stunde_kommt_aus_dem_fenster():
     entry = (fc or {}).get("+1")
     assert entry is not None
     assert entry["level"] == ThunderLevel.LOW
-    assert entry["text"] == "Leichtes Gewitter möglich ab 19:00", entry["text"]
+    assert entry["text"] == (
+        "Leichtes Gewitter möglich ab 19:00, nachts leichtes Gewitter ab 02:00"
+    ), entry["text"]
 
 
 # ===========================================================================
@@ -195,7 +216,11 @@ def test_konfiguriertes_fenster_wird_beachtet():
     entry = (fc or {}).get("+1")
     assert entry is not None
     assert entry["level"] == ThunderLevel.NONE, entry
-    assert entry["text"] == "Kein Gewitter erwartet", entry["text"]
+    # #1651: das KONFIGURIERTE Fenster bestimmt auch, was "ausserhalb" ist --
+    # 05:00 liegt vor Fensterbeginn 06:00 und wird deshalb angehaengt genannt.
+    assert entry["text"] == (
+        "Kein Gewitter erwartet, nachts leichtes Gewitter ab 05:00"
+    ), entry["text"]
 
 
 def test_mitternachts_fenster_wrap_zaehlt_nachtstunden():

--- a/tests/unit/test_thunder_night_addendum.py
+++ b/tests/unit/test_thunder_night_addendum.py
@@ -1,0 +1,331 @@
+"""#1651: Gewitter AUSSERHALB des Tagesfensters wird in der Mail genannt.
+
+Spec: docs/specs/modules/fix_1651_vorschau_zeitfenster.md (Version 2.0)
+Kontext: docs/context/fix-1651-vorschau-tagesentwarnung.md
+
+Ausgangslage (echt zugestellte Staging-Mail): die "⚡ Gewitter-Vorschau"
+sagte fuer den 10.08.2026 "Kein Gewitter erwartet", waehrend die
+"Nacht am Ziel"-Tabelle DERSELBEN Mail fuer 00:00 "hoch" zeigte -- das
+Gewitter lag ausserhalb des Tagesfensters 04-19 (Klemmung aus
+#1498/#1530) und wurde dadurch verschwiegen.
+
+Diese Datei prueft die Fliesstext-Seite: der Satz nennt das Nachtgewitter
+angehaengt, mit exakter Uhrzeit UND Stufe; die Tages-Aussage bleibt
+unveraendert (rein additiv). Geprueft werden BEIDE Bauwege -- Trend-Weg
+(trip_report_scheduler.py:1838-1848) und Fetch-Weg (:2034-2041); sie sind
+wortgleich, aber unabhaengiger Code.
+
+KEINE Mocks: reale Model-Objekte, echte Scheduler-Methoden. Die Fixtures
+``_dp``/``_segment`` kommen aus tests/unit/test_thunder_forecast_day_window.py
+-- derselbe Pruefling, dieselben Daten, EINE Quelle statt einer Kopie.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+from app.models import ThunderLevel
+from tests.unit.test_thunder_forecast_day_window import _dp, _segment
+
+_UTC = ZoneInfo("UTC")
+_TODAY = date(2026, 7, 3)
+_TOMORROW = date(2026, 7, 4)
+_DAY_AFTER = date(2026, 7, 5)
+
+# Wortschatz des Nacht-Zusatzes (Spec, Implementation Details 3). Bewusste
+# Abweichung vom Tagestext: MED traegt hier ein Adjektiv, weil der Halbsatz
+# fuer sich lesbar sein muss.
+_ADD_LOW = ", nachts leichtes Gewitter ab "
+_ADD_MED = ", nachts mittleres Gewitter ab "
+_ADD_HIGH = ", nachts starkes Gewitter ab "
+
+
+def _day_points(day: date, thunder_by_hour):
+    """Voller Kalendertag, Gewitter nur in den genannten Stunden."""
+    return [
+        _dp(day, h, thunder_by_hour.get(h, ThunderLevel.NONE))
+        for h in range(0, 24)
+    ]
+
+
+def _trend_row(thunder_by_hour, level_max, fc_date: date = _TOMORROW):
+    """Eine echte ``multi_day_trend``-Zeile ueber den geteilten Baustein
+    ``build_outlook_row`` -- kein handgeschriebenes Dict."""
+    from output.renderers.email.outlook import build_outlook_row
+
+    points = _day_points(fc_date, thunder_by_hour)
+    seg = _segment(points, thunder_level_max=level_max)
+    row = build_outlook_row(seg.aggregated, points, "Sa", _UTC)
+    row["date"] = fc_date
+    return row
+
+
+def _night_series(thunder_by_hour, night_of: date = _TOMORROW):
+    """``night_weather`` wie ``segment_weather.fetch_night_weather()`` es
+    liefert: Ankunft am Vortag 15:00 bis 06:00 des ``night_of``-Tages.
+
+    ``thunder_by_hour`` bezieht sich auf die Stunden NACH Mitternacht, also
+    auf ``night_of`` selbst -- genau die Stunden, fuer die auch die
+    "Nacht am Ziel"-Tabelle derselben Mail zustaendig ist.
+    """
+    from app.models import ForecastMeta, NormalizedTimeseries, Provider
+
+    arrival_day = night_of - timedelta(days=1)
+    data = [_dp(arrival_day, h) for h in range(15, 24)]
+    data += [
+        _dp(night_of, h, thunder_by_hour.get(h, ThunderLevel.NONE))
+        for h in range(0, 7)
+    ]
+    meta = ForecastMeta(
+        provider=Provider.OPENMETEO, model="icon_d2",
+        run=datetime(_TODAY.year, _TODAY.month, _TODAY.day, 0, 0, tzinfo=timezone.utc),
+        grid_res_km=2.0,
+    )
+    return NormalizedTimeseries(meta=meta, data=data)
+
+
+def _entry_from_trend(row, *, night_weather=None, key="+1"):
+    """Vorschau-Eintrag ueber den PRIMAEREN Bauweg (Trend-Zeile)."""
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    kwargs = {}
+    if night_weather is not None:
+        kwargs["night_weather"] = night_weather
+    fc = TripReportSchedulerService()._build_thunder_forecast_from_trend_or_fetch(
+        None, _TODAY, _UTC, multi_day_trend=[row], **kwargs,
+    )
+    return (fc or {}).get(key)
+
+
+# ===========================================================================
+# AC-1 — Kernszenario Morgen: das gemessene #1651-Szenario
+# ===========================================================================
+
+
+def test_ac1_trend_nachtgewitter_wird_mit_uhrzeit_genannt():
+    """AC-1 (Trend-Weg): Given Default-Fenster 04-19, morgen KEIN Gewitter im
+    Fenster, aber HIGH um 00:00 in derselben Nacht-Zeitreihe, die auch die
+    "Nacht am Ziel"-Tabelle speist / When der Vorschau-Eintrag gebaut wird /
+    Then lautet der Satz "Kein Gewitter erwartet, nachts starkes Gewitter ab
+    00:00" statt der bisherigen reinen Entwarnung.
+    """
+    row = _trend_row({}, ThunderLevel.NONE)
+    entry = _entry_from_trend(
+        row, night_weather=_night_series({0: ThunderLevel.HIGH}),
+    )
+    assert entry is not None, "Vorschau-Eintrag fuer morgen fehlt ganz"
+    assert entry["text"] == "Kein Gewitter erwartet, nachts starkes Gewitter ab 00:00", (
+        f"Der Vorschau-Satz verschweigt das Nachtgewitter um 00:00: {entry['text']!r}"
+    )
+
+
+def test_ac1_fetch_nachtgewitter_wird_mit_uhrzeit_genannt():
+    """AC-1 (Fetch-Weg, Morgen-Default ohne Trend): derselbe Satz entsteht am
+    zweiten, unabhaengigen Bauweg -- er ist wortgleich, aber eigener Code
+    (trip_report_scheduler.py:2034-2041)."""
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    seg = _segment(_day_points(_TOMORROW, {}), thunder_level_max=ThunderLevel.NONE)
+    fc = TripReportSchedulerService()._build_thunder_forecast(
+        seg, _TODAY, tz=_UTC,
+        night_weather=_night_series({0: ThunderLevel.HIGH}),
+    )
+    entry = (fc or {}).get("+1")
+    assert entry is not None, "Vorschau-Eintrag fuer morgen fehlt ganz"
+    assert entry["text"] == "Kein Gewitter erwartet, nachts starkes Gewitter ab 00:00", (
+        f"Fetch-Weg verschweigt das Nachtgewitter um 00:00: {entry['text']!r}"
+    )
+
+
+def test_ac1_die_tagesklemmung_aus_1498_bleibt_bestehen():
+    """AC-1 Gegenprobe: der Zusatz ist ADDITIV. `level`/`hour` -- die Felder,
+    aus denen SMS und Ampel die TAGES-Aussage ableiten -- bleiben auf der
+    Entwarnung stehen; nur der Fliesstext waechst.
+
+    Ohne diese Pruefung koennte der Fix das Nachtgewitter in die Tages-Aussage
+    hochziehen und damit #1498 in der urspruenglichen Richtung wieder
+    aufreissen.
+    """
+    row = _trend_row({}, ThunderLevel.NONE)
+    entry = _entry_from_trend(
+        row, night_weather=_night_series({0: ThunderLevel.HIGH}),
+    )
+    assert entry["level"] == ThunderLevel.NONE, (
+        f"Nachtgewitter hebt das TAGES-Level an -- #1498 waere zurueck: {entry!r}"
+    )
+    assert entry["hour"] is None, (
+        f"Nachtgewitter setzt die TAGES-Stunde -- #1498 waere zurueck: {entry!r}"
+    )
+
+
+# ===========================================================================
+# AC-4 — Tages- und Nachtgewitter gemeinsam
+# ===========================================================================
+
+
+def test_ac4_tag_und_nacht_werden_beide_genannt():
+    """AC-4: Given HIGH ab 14:00 INNERHALB und MED um 22:00 AUSSERHALB des
+    Fensters am selben Tag / When der Eintrag gebaut wird / Then nennt der
+    Satz beide Ereignisse -- die Tages-Aussage unveraendert, die Nacht-Angabe
+    angehaengt mit eigener Stufe.
+
+    Quelle der 22:00-Stunde ist die eigene Zeitreihe der Etappe (die
+    Nacht-Tabelle reicht nur bis 06:00 und deckt 22:00 des Folgetags nicht ab).
+    """
+    row = _trend_row(
+        {14: ThunderLevel.HIGH, 22: ThunderLevel.MED}, ThunderLevel.HIGH,
+    )
+    entry = _entry_from_trend(row)
+    assert entry is not None
+    assert entry["text"] == (
+        "Starkes Gewitter erwartet ab 14:00, nachts mittleres Gewitter ab 22:00"
+    ), f"Tages- und Nachtgewitter werden nicht beide genannt: {entry['text']!r}"
+    assert entry["level"] == ThunderLevel.HIGH, entry
+    assert entry["hour"] == 14, entry
+
+
+# ===========================================================================
+# AC-5 — Keine Aenderung ohne Nachtgewitter (Regressionsschutz)
+# ===========================================================================
+
+
+def test_ac5_ohne_nachtgewitter_bleibt_der_satz_unveraendert():
+    """AC-5 (Regressionsschutz -- VOR und NACH dem Fix gruen): Given weder im
+    Fenster noch ausserhalb ein Gewitter / When der Eintrag gebaut wird /
+    Then bleibt "Kein Gewitter erwartet" ohne jeden Zusatz."""
+    row = _trend_row({}, ThunderLevel.NONE)
+    entry = _entry_from_trend(row)
+    assert entry["text"] == "Kein Gewitter erwartet", (
+        f"Ohne jedes Gewitter darf kein Nacht-Zusatz entstehen: {entry['text']!r}"
+    )
+
+
+def test_ac5_tagesgewitter_ohne_nachtgewitter_bleibt_unveraendert():
+    """AC-5 (Regressionsschutz -- VOR und NACH dem Fix gruen): auch ein reines
+    TAGES-Gewitter bekommt keinen Zusatz, sonst haette der Fix jede bestehende
+    Vorschau-Zeile veraendert."""
+    row = _trend_row({14: ThunderLevel.HIGH}, ThunderLevel.HIGH)
+    entry = _entry_from_trend(row)
+    assert entry["text"] == "Starkes Gewitter erwartet ab 14:00", (
+        f"Reines Tagesgewitter bekam einen Nacht-Zusatz: {entry['text']!r}"
+    )
+
+
+def test_ac5_ruhige_nachtquelle_fuegt_nichts_hinzu():
+    """AC-5 an der Merge-Naht: liegt eine Nacht-Zeitreihe vor, die KEIN
+    Gewitter meldet, darf sie den Satz nicht veraendern -- der Zusatz haengt
+    an gemessenem Gewitter, nicht am blossen Vorhandensein der Quelle."""
+    row = _trend_row({}, ThunderLevel.NONE)
+    entry = _entry_from_trend(row, night_weather=_night_series({}))
+    assert entry["text"] == "Kein Gewitter erwartet", (
+        f"Eine ruhige Nacht-Quelle erzeugte einen Zusatz: {entry['text']!r}"
+    )
+
+
+# ===========================================================================
+# AC-6 — Uebernaechster Tag ("+2") ohne Nacht-Tabellen-Gegenquelle
+# ===========================================================================
+
+
+def test_ac6_plus2_nennt_nachtgewitter_aus_der_eigenen_zeitreihe():
+    """AC-6: Given Gewitter ausserhalb des Fensters am UEBERNAECHSTEN Tag --
+    fuer den es in derselben Mail keine "Nacht am Ziel"-Tabelle gibt / When
+    der "+2"-Eintrag gebaut wird / Then erscheint die Nacht-Angabe trotzdem,
+    aus der fuer diesen Tag ohnehin schon beschafften Zeitreihe.
+
+    Kein `night_weather` im Spiel: die Zeile traegt ihre eigenen, bereits
+    ungefilterten Stundenproben -- kein zusaetzlicher Abruf noetig.
+    """
+    row = _trend_row({23: ThunderLevel.LOW}, ThunderLevel.LOW, fc_date=_DAY_AFTER)
+    entry = _entry_from_trend(row, key="+2")
+    assert entry is not None, "Vorschau-Eintrag fuer uebermorgen fehlt ganz"
+    assert entry["text"] == "Kein Gewitter erwartet, nachts leichtes Gewitter ab 23:00", (
+        f'"+2" verschweigt das Gewitter ausserhalb des Fensters: {entry["text"]!r}'
+    )
+
+
+# ===========================================================================
+# AC-7 — Mehrere Nachtstunden: frueheste Stunde des HOECHST-Levels
+# ===========================================================================
+
+
+def test_ac7_hoechstes_level_gewinnt_nicht_das_fruehere_ereignis():
+    """AC-7: Given MED um 02:00 UND HIGH um 22:00, beide ausserhalb des
+    Fensters am selben Tag / When der Satz gebaut wird / Then wird
+    ausschliesslich "nachts starkes Gewitter ab 22:00" genannt -- nicht
+    02:00, und die Stufe ist die hoehere, nicht die des fruehereren
+    Ereignisses.
+
+    Beide Stunden bilden EINEN Pool (00:00-03:59 und 20:00-23:59 zusammen),
+    spiegelbildlich zur bestehenden Innerhalb-Fenster-Regel.
+    """
+    row = _trend_row(
+        {2: ThunderLevel.MED, 22: ThunderLevel.HIGH}, ThunderLevel.HIGH,
+    )
+    entry = _entry_from_trend(row)
+    assert entry is not None
+    assert entry["text"] == "Kein Gewitter erwartet, nachts starkes Gewitter ab 22:00", (
+        f"Nicht das hoechste Level mit seiner fruehesten Stunde: {entry['text']!r}"
+    )
+    assert "02:00" not in entry["text"], (
+        f"Die fruehere, aber schwaechere Stunde wird genannt: {entry['text']!r}"
+    )
+
+
+def test_ac7_nachtquelle_hat_vorrang_vor_der_eigenen_reihe():
+    """AC-7 / zentrale #1498-Zusicherung an der Merge-Naht: fuer eine Stunde,
+    die BEIDE Quellen abdecken (00:00-06:00 des Folgetags), gewinnt die
+    Nacht-Zeitreihe -- sie ist dieselbe Quelle, welche die Nacht-Tabelle
+    direkt neben der Vorschau zeigt.
+
+    Hier behauptet die eigene Etappen-Reihe LOW um 02:00, die Nacht-Reihe
+    HIGH um 02:00. Genannt werden muss "starkes", sonst widerspraeche der
+    Satz der Tabelle in derselben Mail.
+    """
+    row = _trend_row({2: ThunderLevel.LOW}, ThunderLevel.LOW)
+    entry = _entry_from_trend(
+        row, night_weather=_night_series({2: ThunderLevel.HIGH}),
+    )
+    assert entry is not None
+    assert entry["text"] == "Kein Gewitter erwartet, nachts starkes Gewitter ab 02:00", (
+        "Die Vorschau folgt der eigenen Etappen-Reihe statt der Nacht-Quelle -- "
+        f"sie widerspricht damit der Nacht-Tabelle derselben Mail: {entry['text']!r}"
+    )
+
+
+# ===========================================================================
+# AC-8 — SMS-Token bleibt unberuehrt
+# ===========================================================================
+
+
+def test_ac8_sms_token_ignoriert_die_nacht_angabe():
+    """AC-8: Given ein Vorschau-Eintrag, dessen `text` die neue Nacht-Angabe
+    traegt / When der SMS-Renderer das TH+-Token baut / Then bleibt das Token
+    die Entwarnung "TH+:-" -- der SMS-Pfad liest ausschliesslich
+    `level`/`hour`, nie den Fliesstext (Platzgrund, PO-Vorgabe: SMS zeigt die
+    Angabe nicht).
+
+    RED-Mechanik: die Vorbedingung (Nacht-Angabe steht im `text`) ist heute
+    nicht erfuellt -- ohne sie prueft die eigentliche Zusicherung nichts.
+    """
+    from output.renderers.sms_trip import SMSTripFormatter
+
+    row = _trend_row({22: ThunderLevel.HIGH}, ThunderLevel.HIGH)
+    entry = _entry_from_trend(row)
+    assert _ADD_HIGH in entry["text"], (
+        "Vorbedingung: der Eintrag muss die Nacht-Angabe tragen, sonst prueft "
+        f"dieser Test nichts: {entry['text']!r}"
+    )
+
+    sms = SMSTripFormatter().format_sms(
+        [_segment(_day_points(_TODAY, {}))],
+        report_type="morning",
+        thunder_forecast={"+1": entry},
+    )
+    assert "TH+:-" in sms, (
+        "Die Nacht-Angabe ist in die Kurznachricht durchgeschlagen -- die SMS "
+        f"soll sie nicht zeigen: {sms!r}"
+    )
+    assert "nachts" not in sms, (
+        f"Der Fliesstext der Vorschau steht in der Kurznachricht: {sms!r}"
+    )

--- a/tests/unit/test_thunder_night_addendum.py
+++ b/tests/unit/test_thunder_night_addendum.py
@@ -60,18 +60,27 @@ def _trend_row(thunder_by_hour, level_max, fc_date: date = _TOMORROW):
     return row
 
 
-def _night_series(thunder_by_hour, night_of: date = _TOMORROW):
+def _night_series(thunder_by_hour, night_of: date = _TOMORROW, evening_by_hour=None):
     """``night_weather`` wie ``segment_weather.fetch_night_weather()`` es
     liefert: Ankunft am Vortag 15:00 bis 06:00 des ``night_of``-Tages.
 
     ``thunder_by_hour`` bezieht sich auf die Stunden NACH Mitternacht, also
     auf ``night_of`` selbst -- genau die Stunden, fuer die auch die
     "Nacht am Ziel"-Tabelle derselben Mail zustaendig ist.
+
+    ``evening_by_hour`` (optional) belegt dagegen die Abendstunden des
+    ANKUNFTSTAGS (15:00-23:00, also den Tag VOR ``night_of``). Die Reihe
+    deckt beide Kalendertage ab -- wer sie ohne Datumsbezug auswertet,
+    verwechselt sie (siehe ``test_nachtquelle_vom_ankunftstag_...``).
     """
     from app.models import ForecastMeta, NormalizedTimeseries, Provider
 
+    evening_by_hour = evening_by_hour or {}
     arrival_day = night_of - timedelta(days=1)
-    data = [_dp(arrival_day, h) for h in range(15, 24)]
+    data = [
+        _dp(arrival_day, h, evening_by_hour.get(h, ThunderLevel.NONE))
+        for h in range(15, 24)
+    ]
     data += [
         _dp(night_of, h, thunder_by_hour.get(h, ThunderLevel.NONE))
         for h in range(0, 7)
@@ -290,6 +299,118 @@ def test_ac7_nachtquelle_hat_vorrang_vor_der_eigenen_reihe():
     assert entry["text"] == "Kein Gewitter erwartet, nachts starkes Gewitter ab 02:00", (
         "Die Vorschau folgt der eigenen Etappen-Reihe statt der Nacht-Quelle -- "
         f"sie widerspricht damit der Nacht-Tabelle derselben Mail: {entry['text']!r}"
+    )
+
+
+def test_ac7_nachtquelle_hat_vorrang_auch_wenn_sie_ENTWARNT():
+    """AC-7/AC-3, Gegenrichtung zum Test darueber (Adversary F001): die
+    Nacht-Quelle gewinnt BEDINGUNGSLOS, nicht nur wenn sie das hoehere Level
+    meldet.
+
+    Hier behauptet die eigene Etappen-Reihe HIGH um 02:00 (z. B. aus einem
+    aelteren Modelllauf), die maessgebliche Nacht-Reihe dagegen LOW. Genannt
+    werden muss "leichtes" -- denn genau diese Nacht-Reihe steht als
+    "Nacht am Ziel"-Tabelle daneben in derselben Mail und zeigt dort LOW.
+
+    Ohne diesen Test bliebe die Autoritaetsregel halb bewacht: ein
+    Maximum-Merge (Nacht gewinnt nur bei >=) liesse alle uebrigen Tests
+    gruen und wuerde die Vorschau der Tabelle widersprechen lassen -- der
+    #1498-Fehler, in der Richtung, die diese Scheibe verhindern soll.
+    """
+    row = _trend_row({2: ThunderLevel.HIGH}, ThunderLevel.HIGH)
+    entry = _entry_from_trend(
+        row, night_weather=_night_series({2: ThunderLevel.LOW}),
+    )
+    assert entry is not None
+    assert entry["text"] == "Kein Gewitter erwartet, nachts leichtes Gewitter ab 02:00", (
+        "Die eigene Etappen-Reihe ueberstimmt die Nacht-Quelle nach OBEN -- "
+        "die Vorschau behauptet ein staerkeres Gewitter, als die "
+        f"Nacht-Tabelle derselben Mail zeigt: {entry['text']!r}"
+    )
+    assert "starkes" not in entry["text"], entry["text"]
+
+
+# ===========================================================================
+# Datums-Zuordnung der Nacht-Quelle (Adversary F002/F003)
+# ===========================================================================
+
+
+def test_nachtquelle_vom_ankunftstag_gilt_nicht_fuer_morgen():
+    """Adversary F002: die Nacht-Reihe deckt ZWEI Kalendertage ab (Ankunft
+    heute 15:00 bis 06:00 morgen). Ein Gewitter am ANKUNFTSABEND (heute
+    20:00) gehoert zu HEUTE und darf im Vorschau-Satz fuer MORGEN nicht
+    auftauchen.
+
+    Wird die Reihe nur nach Stunde-des-Tages statt nach Datum ausgewertet,
+    wandert das heutige Abendgewitter in die morgige Vorschau -- eine
+    Aussage ueber einen Tag aus den Daten eines anderen. Das ist exakt die
+    Fehlerklasse aus #1498, in genau der Funktion, die sie verhindern soll.
+
+    Alles andere ist hier bewusst ruhig: morgen weder im noch ausserhalb des
+    Fensters ein Gewitter, die Nachtstunden 00-06 ebenfalls nicht. Ein
+    Zusatz KANN damit nur aus der falsch zugeordneten Stunde stammen.
+    """
+    row = _trend_row({}, ThunderLevel.NONE)
+    entry = _entry_from_trend(
+        row,
+        night_weather=_night_series({}, evening_by_hour={20: ThunderLevel.HIGH}),
+    )
+    assert entry is not None
+    assert entry["text"] == "Kein Gewitter erwartet", (
+        "Das Gewitter vom HEUTIGEN Abend (20:00) erscheint im Vorschau-Satz "
+        f"fuer MORGEN: {entry['text']!r}"
+    )
+
+
+def test_trend_plus2_ignoriert_die_nachtquelle():
+    """Adversary F003 (Trend-Weg): fuer "+2" ist die eigene Zeitreihe die
+    ALLEINIGE Quelle -- die Nacht-Reihe gilt dort nicht.
+
+    Begruendung aus der Spec (Punkt 4): zu "+2" gibt es in derselben Mail
+    keine "Nacht am Ziel"-Tabelle, also auch keine Gegenquelle, der zu
+    folgen waere. Hier traegt die Nacht-Reihe (hypothetisch bis in den
+    uebernaechsten Tag reichend) HIGH um 00:00, die eigene "+2"-Reihe LOW um
+    23:00. Genannt werden muss die eigene Angabe.
+
+    Ohne diesen Test ist der ``offset == 1``-Waechter unbewacht: in allen
+    uebrigen Fixtures endet die Nacht-Reihe vor "+2", der Datumsfilter
+    maskiert ihn also.
+    """
+    row = _trend_row({23: ThunderLevel.LOW}, ThunderLevel.LOW, fc_date=_DAY_AFTER)
+    entry = _entry_from_trend(
+        row,
+        night_weather=_night_series({0: ThunderLevel.HIGH}, night_of=_DAY_AFTER),
+        key="+2",
+    )
+    assert entry is not None, "Vorschau-Eintrag fuer uebermorgen fehlt ganz"
+    assert entry["text"] == "Kein Gewitter erwartet, nachts leichtes Gewitter ab 23:00", (
+        'Die Nacht-Reihe wurde auch fuer "+2" herangezogen, obwohl es dort '
+        f"keine Nacht-Tabelle als Gegenquelle gibt: {entry['text']!r}"
+    )
+
+
+def test_fetch_plus2_ignoriert_die_nachtquelle():
+    """Adversary F003 (Fetch-Weg): derselbe Waechter am zweiten Bauweg.
+
+    Der ``offset == 1``-Vorbehalt steht in BEIDEN Bauwegen als eigene Zeile
+    (trip_report_scheduler.py) -- eine Kopie, die getrennt brechen kann. Ein
+    Test auf nur einem der beiden Wege liesse die andere Zeile unbewacht.
+    """
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    seg = _segment(
+        _day_points(_DAY_AFTER, {23: ThunderLevel.LOW}),
+        thunder_level_max=ThunderLevel.LOW,
+    )
+    fc = TripReportSchedulerService()._build_thunder_forecast(
+        seg, _TODAY, tz=_UTC,
+        night_weather=_night_series({0: ThunderLevel.HIGH}, night_of=_DAY_AFTER),
+    )
+    entry = (fc or {}).get("+2")
+    assert entry is not None, "Vorschau-Eintrag fuer uebermorgen fehlt ganz"
+    assert entry["text"] == "Kein Gewitter erwartet, nachts leichtes Gewitter ab 23:00", (
+        'Fetch-Weg: die Nacht-Reihe wurde auch fuer "+2" herangezogen: '
+        f"{entry['text']!r}"
     )
 
 

--- a/tests/unit/test_thunder_night_addendum_parity.py
+++ b/tests/unit/test_thunder_night_addendum_parity.py
@@ -1,0 +1,434 @@
+"""#1651: die Nacht-Angabe stammt aus DERSELBEN Quelle wie die Nacht-Tabelle
+-- und der Vorschau-Endpunkt sagt dasselbe wie die zugestellte Mail.
+
+Spec: docs/specs/modules/fix_1651_vorschau_zeitfenster.md (AC-3, AC-9, AC-11)
+Kontext: docs/context/fix-1651-vorschau-tagesentwarnung.md
+
+Die zentrale Zusicherung dieser Scheibe ist NICHT "die Vorschau erwaehnt die
+Nacht", sondern: fuer dieselbe Stunde derselben Mail darf es keine zwei
+widersprechenden Quellen geben -- genau daran scheiterte #1498 in der
+umgekehrten Richtung. Fuer 00:00-06:00 des Folgetags ist ``night_weather``
+massgeblich, dieselbe Reihe, die direkt daneben als "Nacht am Ziel"-Tabelle
+steht.
+
+AC-9/AC-11 sind Paritaets-Aussagen und laufen deshalb ueber BEIDE echten
+Pfade -- ``_send_trip_report_outcome()`` (Versand) UND
+``PreviewService._build_report()`` (Vorschau) -- statt einen Pfad zweimal zu
+fahren: ein Nachbau des Versandwegs wuerde die Uebergabe, um die es geht,
+selbst mitliefern und nichts pruefen.
+
+Die Falle aus Spec 5b: beide Pfade beschaffen Nachtdaten unter
+VERSCHIEDENEN Bedingungen (Versand praktisch immer, Vorschau nur bei
+``night_weather_needed()``). Ein Trip ohne Nacht-Tabelle faellt genau dort
+auseinander -- und Fixtures MIT Nacht-Tabelle bleiben dabei gruen. AC-11
+prueft deshalb ausdruecklich den Trip OHNE Nacht-Tabelle.
+
+DETERMINISMUS (Kern-Schicht, KEIN Netz): die Wetterdaten kommen ueber den
+projekteigenen Offline-Schalter ``GZ_TEST_FIXTURE_DIR``
+(providers/base.py::get_provider, Issue #346) aus selbst geschriebenen
+Fixture-Dateien -- der Produktivpfad bleibt unveraendert, getauscht ist nur
+die Datenquelle. KEIN echter Versand: alle drei Kanaele sind abgeschaltet,
+der Versandlauf endet mit "no_channels".
+"""
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, time, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+from app.models import ThunderLevel
+
+_UTC = ZoneInfo("UTC")
+_TODAY = date.today()
+_TOMORROW = _TODAY + timedelta(days=1)
+
+# FixtureProvider verankert seine 72 Punkte am aktuellen UTC-Tag.
+_IDX_TOMORROW_00 = 24
+
+# Zwei WEIT auseinanderliegende Orte, damit der FixtureProvider fuer die
+# Nachtquelle (Ankunft heute, Innsbruck) und die Folgeetappe (Zillertal)
+# VERSCHIEDENE Dateien waehlt (providers/fixture.py::_nearest). Nur so ist
+# unterscheidbar, aus welcher Quelle die Nacht-Angabe stammt.
+_TODAY_COORDS = [(47.2692, 11.4041), (47.2700, 11.4100)]      # -> innsbruck.json
+_TOMORROW_COORDS = [(47.2190, 11.8767), (47.2200, 11.8800)]   # -> zillertal.json
+
+_EXPECTED_ADDENDUM = ", nachts starkes Gewitter ab 00:00"
+
+
+def _fixture_points(thunder_by_index: dict) -> list[dict]:
+    """72 Stundenpunkte im Go-Fixture-Format (Issue #263)."""
+    return [
+        {
+            "t2m_c": 15.0, "wind10m_kmh": 10.0, "gust_kmh": 20.0,
+            "precip_1h_mm": 0.0, "cloud_total_pct": 30, "pop_pct": 10,
+            "thunder_level": thunder_by_index.get(i, "NONE"),
+        }
+        for i in range(72)
+    ]
+
+
+def _write_split_fixture_dir(tmp_path):
+    """Nachtquelle mit Gewitter, Folgeetappe ohne.
+
+    innsbruck  -- Ankunftsort von HEUTE, also die Quelle von
+                  ``fetch_night_weather``: Stufe "hoch" um 00:00 morgen.
+    zillertal  -- die Etappe von MORGEN: durchgehend gewitterfrei.
+
+    Damit kann die Nacht-Angabe ausschliesslich aus der Nacht-Zeitreihe
+    stammen. Holt ein Pfad sie nicht, fehlt sie ihm -- die Divergenz wird
+    sichtbar, statt sich hinter einer zweiten, zufaellig gleichen Quelle zu
+    verstecken.
+    """
+    fixture_dir = tmp_path / "openmeteo"
+    fixture_dir.mkdir(parents=True, exist_ok=True)
+    (fixture_dir / "innsbruck.json").write_text(
+        json.dumps({"data": _fixture_points({_IDX_TOMORROW_00: "HIGH"})})
+    )
+    for name in ("zillertal.json", "stubai.json"):
+        (fixture_dir / name).write_text(json.dumps({"data": _fixture_points({})}))
+    return fixture_dir
+
+
+def _trip(*, show_night_block: bool):
+    """Trip mit heutiger Etappe (Innsbruck) + Folgeetappe (Zillertal), alle
+    Kanaele abgeschaltet.
+
+    Gewitter-Metrik aktiv, Nacht-Tiefsttemperatur NICHT gewaehlt: bei
+    ``show_night_block=False`` liefert ``night_weather_needed()`` heute damit
+    False -- genau die Bedingung aus Spec 5b.
+    """
+    from app.models import MetricConfig, TripReportConfig, UnifiedWeatherDisplayConfig
+    from app.trip import Stage, TimeWindow, Trip, Waypoint
+
+    def _stage(sid, name, day, coords):
+        wps = [
+            Waypoint(
+                id=f"{sid}-{i}", name="Start" if i == 0 else "Ziel",
+                lat=lat, lon=lon, elevation_m=600,
+                time_window=TimeWindow(
+                    start=time(9, 0) if i == 0 else time(15, 0),
+                    end=time(9, 0) if i == 0 else time(15, 0),
+                ),
+            )
+            for i, (lat, lon) in enumerate(coords)
+        ]
+        return Stage(id=sid, name=name, date=day, start_time=time(9, 0), waypoints=wps)
+
+    display_config = UnifiedWeatherDisplayConfig(
+        trip_id="tdd-1651-paritaet",
+        metrics=[
+            MetricConfig(metric_id="temperature", enabled=True, bucket="primary", order=0),
+            MetricConfig(metric_id="thunder", enabled=True, bucket="primary", order=1),
+        ],
+        updated_at=datetime.now(timezone.utc),
+        show_night_block=show_night_block,
+    )
+    trip = Trip(
+        id="tdd-1651-paritaet",
+        name="TDD 1651 Paritaet",
+        stages=[
+            _stage("S1", "Heute", _TODAY, _TODAY_COORDS),
+            _stage("S2", "Morgen", _TOMORROW, _TOMORROW_COORDS),
+        ],
+        display_config=display_config,
+        report_config=TripReportConfig(
+            trip_id="tdd-1651-paritaet",
+            multi_day_trend_reports=["evening"],
+            send_email=False, send_sms=False, send_telegram=False,
+        ),
+    )
+    # Kein Netzabruf fuer amtliche Warnungen im Versandlauf.
+    trip.official_alerts_enabled = False
+    return trip
+
+
+class _ForecastRecorder:
+    """Nimmt den Vorschau-Eintrag ab, den die GETEILTE Scheduler-Methode
+    liefert -- die echte Methode laeuft dabei unveraendert durch (kein
+    ersetzter Rueckgabewert, kein Mock)."""
+
+    def __init__(self, monkeypatch):
+        from services.trip_report_scheduler import TripReportSchedulerService
+
+        self._cls = TripReportSchedulerService
+        self._real = TripReportSchedulerService._build_thunder_forecast_from_trend_or_fetch
+        self.captured: dict = {}
+        recorder = self
+
+        def _wrapped(inner_self, *args, **kwargs):
+            result = recorder._real(inner_self, *args, **kwargs)
+            recorder.captured[recorder.label] = result
+            return result
+
+        self.label = "?"
+        monkeypatch.setattr(
+            TripReportSchedulerService,
+            "_build_thunder_forecast_from_trend_or_fetch",
+            _wrapped,
+        )
+
+    def entry(self, label: str):
+        fc = self.captured.get(label) or {}
+        return fc.get("+1")
+
+
+def _run_both_paths(monkeypatch, tmp_path, *, show_night_block: bool):
+    """Faehrt Versand UND Vorschau fuer denselben Trip und Zieltag und gibt
+    die beiden ``+1``-Eintraege zurueck."""
+    from services.preview_service import PreviewService
+    from services.trip_report_scheduler import TripReportSchedulerService
+    from services.weather_cache import reset_shared_weather_cache_for_tests
+
+    fixture_dir = _write_split_fixture_dir(tmp_path)
+    monkeypatch.setenv("GZ_TEST_FIXTURE_DIR", str(fixture_dir))
+    reset_shared_weather_cache_for_tests()
+
+    recorder = _ForecastRecorder(monkeypatch)
+
+    # "morning": Zieltag ist HEUTE, in beiden Pfaden identisch, und der
+    # Mehrtages-Ausblick ist aus (multi_day_trend_reports=["evening"]) --
+    # damit greift in beiden Pfaden derselbe Bauweg.
+    scheduler = TripReportSchedulerService()
+    assert scheduler._get_target_date("morning") == _TODAY, (
+        "Fixture-Fehler: Versand und Vorschau muessen denselben Zieltag bauen"
+    )
+
+    recorder.label = "versand"
+    outcome = scheduler._send_trip_report_outcome(_trip(show_night_block=show_night_block), "morning")
+    assert outcome == "no_channels", (
+        f"Der Versandlauf nahm einen anderen Ausgang als erwartet: {outcome!r} "
+        "(alle Kanaele sind abgeschaltet, es darf nichts hinausgehen)"
+    )
+
+    recorder.label = "vorschau"
+    PreviewService()._build_report(
+        _trip(show_night_block=show_night_block), _TODAY, "morning",
+    )
+
+    return recorder.entry("versand"), recorder.entry("vorschau")
+
+
+# ===========================================================================
+# AC-3 — Konsistenz mit der Nacht-Tabelle in DERSELBEN Mail
+# ===========================================================================
+
+
+def _night_series_with_high_at_midnight():
+    """``night_weather`` wie ``fetch_night_weather`` es liefert: Ankunft
+    11.07. 12:00 bis 12.07. 06:00, Gewitter "hoch" um 00:00.
+
+    Passend zu ``tests.unit.test_renderers_email._make_segment_weather()``
+    (Ankunft 11.07.2026 12:00 UTC) -- dieselbe Fixture-Basis wie
+    tests/tdd/test_briefing_parity_night_thunder.py.
+    """
+    from app.models import (
+        ForecastDataPoint, ForecastMeta, NormalizedTimeseries, Provider,
+    )
+
+    def _dp(day: int, hour: int, thunder=ThunderLevel.NONE):
+        return ForecastDataPoint(
+            ts=datetime(2026, 7, day, hour, 0, tzinfo=timezone.utc),
+            t2m_c=9.0, wind10m_kmh=8.0, gust_kmh=15.0, pop_pct=10,
+            precip_1h_mm=0.0, cloud_total_pct=40, thunder_level=thunder,
+            humidity_pct=60,
+        )
+
+    meta = ForecastMeta(
+        provider=Provider.OPENMETEO, model="icon_d2",
+        run=datetime(2026, 7, 11, 0, 0, tzinfo=timezone.utc),
+        grid_res_km=2.0, interp="nearest",
+    )
+    data = [_dp(11, h) for h in range(12, 24)]
+    data += [
+        _dp(12, h, ThunderLevel.HIGH if h == 0 else ThunderLevel.NONE)
+        for h in range(0, 7)
+    ]
+    return NormalizedTimeseries(meta=meta, data=data)
+
+
+def test_ac3_nacht_angabe_und_nacht_tabelle_nennen_dieselbe_stunde():
+    """AC-3: Given eine Mail, deren "Nacht am Ziel"-Tabelle fuer 00:00 des
+    Folgetags "hoch" zeigt / When dieselbe Mail auch die Vorschau-Zeile
+    enthaelt / Then nennen beide Stellen dieselbe Stunde und dieselbe Stufe.
+
+    Das ist der gemessene #1651-Widerspruch in einem einzigen gerenderten
+    Dokument: heute steht daneben "Kein Gewitter erwartet".
+
+    Der Teilaspekt "Ausblick-Tabelle" von AC-3 ist mit dem Scheiben-Schnitt
+    vom 2026-08-09 nach #1653 herausgeloest; geprueft wird hier ausschliesslich
+    die Vorschau-Zeile gegen die Nacht-Tabelle.
+
+    Kein Netz: ``night_weather`` ist ein konstruiertes, echtes
+    ``NormalizedTimeseries``; der Vorschau-Eintrag wird ueber die ECHTE
+    Scheduler-Methode aus GENAU DIESER Reihe abgeleitet -- also nicht
+    unabhaengig behauptet, sondern aus derselben Quelle gezogen.
+    """
+    from output.renderers.trip_report import TripReportFormatter
+    from services.trip_report_scheduler import TripReportSchedulerService
+    from tests.unit.test_renderers_email import _make_segment_weather
+
+    night = _night_series_with_high_at_midnight()
+    target = date(2026, 7, 11)
+
+    from app.models import ForecastDataPoint, SegmentWeatherSummary
+    from output.renderers.email.outlook import build_outlook_row
+
+    # Die Etappe von morgen ist tagsueber gewitterfrei -- der Hinweis kann
+    # ausschliesslich aus der Nacht-Reihe kommen.
+    quiet_points = [
+        ForecastDataPoint(
+            ts=datetime(2026, 7, 12, h, 0, tzinfo=timezone.utc),
+            thunder_level=ThunderLevel.NONE,
+        )
+        for h in range(0, 24)
+    ]
+    summary = SegmentWeatherSummary(
+        temp_min_c=10.0, temp_max_c=20.0, wind_max_kmh=10.0,
+        precip_sum_mm=0.0, thunder_level_max=ThunderLevel.NONE,
+    )
+    row = build_outlook_row(summary, quiet_points, "So", _UTC)
+    row["date"] = date(2026, 7, 12)
+
+    forecast = TripReportSchedulerService()._build_thunder_forecast_from_trend_or_fetch(
+        None, target, _UTC, multi_day_trend=[row], night_weather=night,
+    )
+
+    report = TripReportFormatter().format_email(
+        segments=[_make_segment_weather()],
+        trip_name="GR20",
+        report_type="morning",
+        night_weather=night,
+        thunder_forecast=forecast,
+        stage_name="GR20 E3",
+        tz=_UTC,
+    )
+    plain = report.email_plain
+
+    # Vorbedingung: die Nacht-Tabelle DIESER Mail nennt 00:00 als "hoch".
+    night_rows = [
+        ln for ln in plain.splitlines() if ln.strip().startswith("00 ")
+    ]
+    assert night_rows and "hoch" in night_rows[0], (
+        "Fixture-Fehler: die Nacht-Tabelle muss fuer 00:00 'hoch' zeigen, "
+        f"sonst prueft dieser Test nichts: {night_rows!r}"
+    )
+
+    # AC-3: die Vorschau derselben Mail nennt exakt dieselbe Stunde/Stufe.
+    assert "Kein Gewitter erwartet, nachts starkes Gewitter ab 00:00" in plain, (
+        "Vorschau und Nacht-Tabelle derselben Mail widersprechen sich fuer "
+        "00:00 -- die Vorschau entwarnt, die Tabelle zeigt 'hoch'.\n"
+        f"{plain}"
+    )
+
+
+# ===========================================================================
+# AC-9 / AC-11 — Paritaet Vorschau-Endpunkt <-> zugestellte Mail
+# ===========================================================================
+
+
+def test_ac9_vorschau_und_versand_nennen_denselben_satz(monkeypatch, tmp_path):
+    """AC-9: Given derselbe Trip und Zieltag, Nachtgewitter "hoch" um 00:00 /
+    When der Vorschau-Satz einmal ueber den Vorschau-Endpunkt und einmal ueber
+    den Versandpfad entsteht / Then ist er zeichengleich -- und beide nennen
+    das Nachtgewitter.
+
+    Beide Pfade laufen hier wirklich; die Nacht-Zeitreihe muss in beiden VOR
+    dem Bau des Vorschau-Eintrags vorliegen (Spec 5a). Liegt sie in einem der
+    beiden erst danach vor, fehlt dort der Halbsatz -- und die Gleichheit
+    faellt.
+    """
+    versand, vorschau = _run_both_paths(monkeypatch, tmp_path, show_night_block=True)
+
+    assert versand is not None and vorschau is not None, (
+        f"Fixture-Fehler: kein '+1'-Eintrag gebaut ({versand!r} / {vorschau!r})"
+    )
+    assert _EXPECTED_ADDENDUM in versand["text"], (
+        "Der VERSANDPFAD verschweigt das Nachtgewitter um 00:00: "
+        f"{versand['text']!r}"
+    )
+    assert _EXPECTED_ADDENDUM in vorschau["text"], (
+        "Der VORSCHAU-PFAD verschweigt das Nachtgewitter um 00:00: "
+        f"{vorschau['text']!r}"
+    )
+    assert versand["text"] == vorschau["text"], (
+        "Vorschau-Endpunkt und zugestellte Mail nennen verschiedene Saetze:\n"
+        f"  Versand:  {versand['text']!r}\n"
+        f"  Vorschau: {vorschau['text']!r}"
+    )
+
+
+def test_ac11_paritaet_auch_ohne_nacht_tabelle(monkeypatch, tmp_path):
+    """AC-11 (die Falle aus Spec 5b): Given ein Trip mit aktiver
+    Gewitter-Metrik, aber OHNE Nacht-Tabelle und ohne gewaehlte
+    Nacht-Tiefsttemperatur / When derselbe Tag einmal ueber den
+    Vorschau-Endpunkt und einmal ueber den Versand entsteht / Then nennen
+    beide dieselbe Nachtstunde.
+
+    Heute beschafft der Vorschau-Pfad hier ueberhaupt keine Nachtdaten
+    (``night_weather_needed()`` prueft nur Nacht-Tabelle und
+    Nacht-Tiefsttemperatur), waehrend der Versand sie immer holt. Eine
+    Reihenfolge-Korrektur allein reicht deshalb nicht -- die geteilte
+    Entscheidung selbst muss die Gewitter-Metrik kennen.
+    """
+    versand, vorschau = _run_both_paths(monkeypatch, tmp_path, show_night_block=False)
+
+    assert versand is not None and vorschau is not None, (
+        f"Fixture-Fehler: kein '+1'-Eintrag gebaut ({versand!r} / {vorschau!r})"
+    )
+    assert _EXPECTED_ADDENDUM in versand["text"], (
+        f"Der VERSANDPFAD verschweigt das Nachtgewitter: {versand['text']!r}"
+    )
+    assert _EXPECTED_ADDENDUM in vorschau["text"], (
+        "Der VORSCHAU-PFAD nennt das Nachtgewitter nicht -- er greift auf eine "
+        "andere Quelle zu als der Versand (Spec 5b): "
+        f"{vorschau['text']!r}"
+    )
+    assert versand["text"] == vorschau["text"], (
+        "Ohne Nacht-Tabelle divergieren Vorschau und Versand:\n"
+        f"  Versand:  {versand['text']!r}\n"
+        f"  Vorschau: {vorschau['text']!r}"
+    )
+
+
+def test_ac11_geteilte_entscheidung_kennt_die_gewitter_metrik():
+    """AC-11 an der geteilten Entscheidung selbst: ``night_weather_needed()``
+    ist laut eigenem Docstring die EINE Entscheidung fuer beide Pfade. Ab
+    dieser Scheibe speisen Nachtdaten auch die Nacht-Angabe -- eine aktive
+    Gewitter-Metrik macht sie damit noetig, auch ohne Nacht-Tabelle.
+
+    Gegenprobe im selben Test: ohne Gewitter-Metrik (und ohne die beiden
+    bisherigen Gruende) bleibt die Antwort Nein -- es entsteht kein
+    pauschaler Zusatz-Abruf fuer jeden Trip.
+    """
+    import dataclasses
+
+    from app.metric_catalog import build_default_display_config
+    from services.segment_weather import night_weather_needed
+
+    base = build_default_display_config(trip_id="tdd-1651-needed")
+    without_night = dataclasses.replace(
+        base,
+        show_night_block=False,
+        metrics=[
+            dataclasses.replace(mc, enabled=(mc.metric_id == "thunder"))
+            for mc in base.metrics
+        ],
+    )
+    assert without_night.is_metric_enabled("thunder"), "Fixture-Fehler"
+    assert not without_night.is_metric_enabled("temperature_night"), "Fixture-Fehler"
+
+    assert night_weather_needed(without_night) is True, (
+        "Die geteilte Entscheidung haelt Nachtdaten fuer entbehrlich, obwohl "
+        "die Gewitter-Metrik aktiv ist -- der Vorschau-Pfad bekaeme dann eine "
+        "andere Quelle als der Versand (Spec 5b)"
+    )
+
+    nothing_enabled = dataclasses.replace(
+        base,
+        show_night_block=False,
+        metrics=[dataclasses.replace(mc, enabled=False) for mc in base.metrics],
+    )
+    assert night_weather_needed(nothing_enabled) is False, (
+        "Ohne Nacht-Tabelle, ohne Nacht-Tiefsttemperatur und ohne "
+        "Gewitter-Metrik darf kein Nachtabruf entstehen"
+    )

--- a/tests/unit/test_thunder_night_addendum_parity.py
+++ b/tests/unit/test_thunder_night_addendum_parity.py
@@ -42,9 +42,6 @@ _UTC = ZoneInfo("UTC")
 _TODAY = date.today()
 _TOMORROW = _TODAY + timedelta(days=1)
 
-# FixtureProvider verankert seine 72 Punkte am aktuellen UTC-Tag.
-_IDX_TOMORROW_00 = 24
-
 # Zwei WEIT auseinanderliegende Orte, damit der FixtureProvider fuer die
 # Nachtquelle (Ankunft heute, Innsbruck) und die Folgeetappe (Zillertal)
 # VERSCHIEDENE Dateien waehlt (providers/fixture.py::_nearest). Nur so ist
@@ -53,6 +50,30 @@ _TODAY_COORDS = [(47.2692, 11.4041), (47.2700, 11.4100)]      # -> innsbruck.jso
 _TOMORROW_COORDS = [(47.2190, 11.8767), (47.2200, 11.8800)]   # -> zillertal.json
 
 _EXPECTED_ADDENDUM = ", nachts starkes Gewitter ab 00:00"
+
+
+def _idx_tomorrow_local_midnight() -> int:
+    """Fixture-Index der Stunde "morgen 00:00 ORTSZEIT" am Ankunftsort.
+
+    Der FixtureProvider verankert seine 72 Punkte am aktuellen **UTC**-Tag
+    (``providers/fixture.py``), der Pruefling rechnet dagegen in der aus den
+    Koordinaten aufgeloesten Ortszeit. Ein fest verdrahteter Index 24 traefe
+    in Innsbruck 02:00 Ortszeit -- der Test pruefte dann ein anderes Szenario
+    als das gemessene aus #1651 (Gewitter um MITTERNACHT, dieselbe Stunde,
+    die auch die Nacht-Tabelle zeigt). Der Offset wird deshalb gemessen statt
+    angenommen; das haelt den Test auch ueber den Sommerzeit-Wechsel hinweg.
+    """
+    from utils.timezone import tz_for_coords
+
+    base = datetime.now(timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    tz = tz_for_coords(*_TODAY_COORDS[-1])
+    for i in range(24, 0, -1):
+        local = (base + timedelta(hours=i)).astimezone(tz)
+        if local.date() == _TOMORROW and local.hour == 0:
+            return i
+    raise AssertionError("Fixture-Fehler: keine Stunde 'morgen 00:00 Ortszeit'")
 
 
 def _fixture_points(thunder_by_index: dict) -> list[dict]:
@@ -82,7 +103,9 @@ def _write_split_fixture_dir(tmp_path):
     fixture_dir = tmp_path / "openmeteo"
     fixture_dir.mkdir(parents=True, exist_ok=True)
     (fixture_dir / "innsbruck.json").write_text(
-        json.dumps({"data": _fixture_points({_IDX_TOMORROW_00: "HIGH"})})
+        json.dumps({
+            "data": _fixture_points({_idx_tomorrow_local_midnight(): "HIGH"})
+        })
     )
     for name in ("zillertal.json", "stubai.json"):
         (fixture_dir / name).write_text(json.dumps({"data": _fixture_points({})}))


### PR DESCRIPTION
Behebt **#1651** (Issue wird erst nach dem Produktions-Selbsttest geschlossen, deshalb kein `Closes`-Stichwort).

## Worum es geht

Ein Gewitter **außerhalb** des Tagesfensters (Default 04–19 Ortszeit) wurde seit #1530 verschwiegen. Gemessen an einer echt zugestellten Staging-Mail:

| Stelle in DERSELBEN Mail | Aussage zum 10.08.2026 |
|---|---|
| ⚡ Gewitter-Vorschau | `Kein Gewitter erwartet` |
| 🌙 Nacht am Ziel, Zeile `00` | roter Punkt = `ThunderLevel.HIGH` |

Beide Sätze waren für sich korrekt — das Gewitter lag um 00:00, außerhalb des Fensters. Die Vorschau nannte ihr Fenster aber nicht, also las sich die Entwarnung als Aussage über den ganzen Tag.

**PO-Entscheidung:** nicht das Fenster beschriften, sondern das Gewitter **nennen**. Jetzt: `Kein Gewitter erwartet, nachts starkes Gewitter ab 00:00`.

## Die zentrale Zusicherung

Für Stunden, die auch die „Nacht am Ziel"-Tabelle zeigt (00:00–06:00 des Folgetags), ist **deren** Quelle maßgeblich. Damit können die beiden Stellen derselben Mail nicht mehr über dieselbe Stunde Widersprüchliches sagen — genau der Fehler aus #1498, den diese Änderung nicht zurückholen darf.

## Was sich NICHT ändert

- **Kurznachricht:** `entry["level"]`/`["hour"]` bleiben tagesfenster-geklemmt, der Zusatz steht nur im Fließtext. SMS und Telegram-Kurzform schweigen weiter (PO-Vorgabe).
- **Telegram rich** nicht angefasst.
- **Kein neuer Netzabruf** — die vollen 24 Stunden lagen bereits vor, nur ein Filterschritt warf sie weg.
- Die Tagesfenster-Klemmung aus #1530 bleibt; der Zusatz kommt additiv dazu.

`night_weather_needed()` berücksichtigt jetzt auch die Gewitter-Metrik. Ohne das hätte der Versand die Nacht-Reihe und die Vorschau nicht — die Parität wäre bei Trips **ohne** Nacht-Tabelle gebrochen, und zwar unbemerkt, weil Fixtures mit aktiver Nacht-Tabelle grün geblieben wären (AC-11, vorab gemessen).

## Adversary: drei Runden, zwischendurch BROKEN

Runde 2 ergab **BROKEN** — nicht wegen der Umsetzung, sondern weil zwei zentrale Zusicherungen **unbewacht** waren. Beide Verfälschungen ließen alle 27 Tests grün:

- **F001:** Die Regel „Nacht-Quelle gewinnt" war nur in einer Richtung geprüft. Als Maximum-Vergleich mutiert, hätte die Mail ein stärkeres Gewitter behauptet, als die Nacht-Tabelle daneben zeigt.
- **F002:** Der Datumsfilter war gar nicht geprüft. Entfernt, wäre ein Gewitter von **heute Abend** als „nachts ab 20:00" für **morgen** erschienen — dieselbe Fehlerklasse wie #1498, in der Funktion, die sie verhindern soll.
- **F003:** Der `offset == 1`-Vorbehalt existiert als zwei unabhängige Kopien; beide waren ungeprüft.

Vier Wächter ergänzt, **jeder einzeln per Mutation als scharf belegt** (rot mit Verfälschung, grün nach Rücknahme, Ausgangsstand per Prüfsumme bestätigt). Für F003 waren zwei Tests nötig, weil die beiden Kopien getrennt brechen können — gemessen, nicht angenommen. Runde 3: **VERIFIED**.

**F005** (Runde 3, LOW, kein Blocker): Schwächt man den Datumsvergleich von `==` auf `>=`, bleibt alles grün. Praktisch folgenlos, weil `fetch_night_weather()` die Anfrage selbst hart begrenzt — dokumentiert statt verschwiegen.

## Umfang

| | netto |
|---|---|
| Produktivcode | +188 |
| Tests | +177 |

31 Tests in den vier berührten Dateien grün, 84 Tests in den Nachbarsuiten grün. LoC-Limit vom PO auf 500 angehoben.

## Bewusst nicht in dieser Scheibe

- **#1653** — Mehrtages-Ausblick der Abend-Mail: seine Gewitter-Zelle vermischt Zeiträume, verschluckt Tag oder Nacht und betrifft auch Telegram. Muss erst saniert werden, bevor eine Nacht-Angabe darauf passt.
- **#1654** — rohe Programmnamen `⚡MED`/`⚡HIGH` statt „mittel"/„hoch".
- **Offene Produktfrage:** Das Wort „nachts" hängt am Zeitfenster, nicht an der Tageszeit. Bei einem Trip mit abweichendem Fenster (z.B. 06–18) hieße es „nachts … ab 05:00". Mit der Standardeinstellung tritt das nicht auf; liegt beim PO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxyuCgpKtbf16da3Cx88zy
