### PR TITLE
fix(#1478 Teil 1): broad_test_run_gate erkennt pytest nur noch in Kommando-Position

### DIFF
--- a/.claude/hooks/broad_test_run_gate.py
+++ b/.claude/hooks/broad_test_run_gate.py
@@ -128,20 +128,96 @@ def _tokens(command: str) -> list[str] | None:
         return None
 
 
+_SEGMENT_SEPARATORS = {"&&", "||", ";", "|", "&"}
+_TEXT_MATCH_COMMANDS = {
+    "grep", "egrep", "fgrep", "rgrep", "zgrep", "pgrep", "rg", "ag", "ack",
+}
+_LAUNCHER_COMMANDS = {
+    "env", "nice", "nohup", "sudo", "doas", "setsid", "timeout", "xargs",
+    "time", "ionice", "chrt",
+}
+_PYTHON_LAUNCHER_RE = re.compile(r"^python3?(\.\d+)?$")
+
+
+def _basename(token: str) -> str:
+    """Letztes Pfadsegment -- 'pytest'-Erkennung soll pfad-qualifizierte
+    Launcher (/usr/bin/python3, .venv/bin/python3) genauso treffen wie
+    nackte Namen (Issue #1478 Teil 1, Adversary-Runde 3, Finding F007)."""
+    return token.rsplit("/", 1)[-1]
+
+
+def _nearest_non_flag_predecessor(tokens: list[str], index: int) -> "str | None":
+    """Naechstes Token VOR `index` im selben Segment, das keine Flag
+    (fuehrendes '-') ist. None am Segmentanfang (Trenner erreicht oder
+    Listenanfang) -- dann gibt es kein Kommando, das 'pytest' als
+    Suchmuster konsumiert haben koennte."""
+    j = index - 1
+    while j >= 0:
+        tok = tokens[j]
+        if tok in _SEGMENT_SEPARATORS:
+            return None
+        if not tok.startswith("-"):
+            return tok
+        j -= 1
+    return None
+
+
 def _pytest_invocations(tokens: list[str]) -> list[int]:
-    """Indizes, an denen ein pytest-Lauf beginnt."""
-    hits = []
+    """Indizes, an denen ein pytest-Lauf beginnt.
+
+    Default: JEDES 'pytest'-/'*/pytest'-Token zaehlt als Aufrufbeginn.
+    Zwei Faelle:
+
+    1. Unmittelbar vorangehendes Flag-Token (fuehrendes '-'): der Vorgaenger
+       HINTER ALLEN Flags wird ermittelt (`_nearest_non_flag_predecessor`
+       ueberspringt beliebig viele Flags). Ist dieser Vorgaenger ein
+       bekannter Prozess-Launcher (`_LAUNCHER_COMMANDS`) oder ein
+       Python-Interpreter (`_PYTHON_LAUNCHER_RE` auf den Basename) ->
+       'pytest' IST ein Aufruf, egal wie viele Flags dazwischen liegen
+       (Issue #1478 Teil 1, Adversary-Runde 3, Finding F006: 'sudo -E
+       pytest', 'nice -n10 pytest', 'xargs -I{} pytest' MUESSEN weiterhin
+       blockiert werden). Sonst (Vorgaenger ist ein gewoehnliches Wort wie
+       'commit', 'log', 'grep') ist 'pytest' dessen Freitext-Flag-Wert,
+       kein eigener Aufruf (Finding F005: 'git commit -m pytest', 'git log
+       --grep pytest', 'grep -m pytest').
+    2. Kein vorangehendes Flag: der naechste Nicht-Flag-Vorgaenger im
+       selben Segment wird direkt gegen `_TEXT_MATCH_COMMANDS` geprueft
+       (Basename) -- 'pytest' ist dessen Suchmuster (grep -n "pytest"
+       datei, pgrep -af "pytest"), sonst Default "ist ein Aufruf" (z.B.
+       jeder bare Launcher: 'sudo pytest tests/', F001/AC-6).
+    """
+    hits: list[int] = []
     for i, tok in enumerate(tokens):
-        if tok == "pytest" or tok.endswith("/pytest"):
-            hits.append(i)
-        elif tok == "-m" and i + 1 < len(tokens) and tokens[i + 1] == "pytest":
-            hits.append(i + 1)
+        if tok != "pytest" and not tok.endswith("/pytest"):
+            continue
+        if i > 0 and tokens[i - 1].startswith("-"):
+            launcher = _nearest_non_flag_predecessor(tokens, i)
+            launcher_base = _basename(launcher) if launcher is not None else None
+            if launcher_base in _LAUNCHER_COMMANDS or (
+                launcher_base is not None and _PYTHON_LAUNCHER_RE.match(launcher_base)
+            ):
+                hits.append(i)
+            continue
+        predecessor = _nearest_non_flag_predecessor(tokens, i)
+        predecessor_base = _basename(predecessor) if predecessor is not None else None
+        if predecessor_base in _TEXT_MATCH_COMMANDS:
+            continue
+        hits.append(i)
     return hits
 
 
 def _args_after(tokens: list[str], start: int) -> list[str]:
-    """Argumente nach dem pytest-Token bis zum naechsten Kommando-Trenner."""
-    stop = {"&&", "||", ";", "|", ">", ">>"}
+    """Argumente nach dem pytest-Token bis zum naechsten Kommando-Trenner.
+
+    Nutzt dieselbe Trenner-Menge wie `_nearest_non_flag_predecessor()`
+    (`_SEGMENT_SEPARATORS`, seit Runde 2 inkl. '&') statt eines eigenen,
+    unsynchronisierten Sets -- sonst erkennt `_pytest_invocations()` einen
+    Aufruf korrekt an einer Segmentgrenze, aber `_args_after()` sammelt
+    Tokens ueber genau diese Grenze hinweg ein (Issue #1478 Teil 1,
+    Adversary-Runde 4, Finding F-ADV1: 'pytest tests/ & x.py' lief
+    unblockiert durch, weil 'x.py' aus dem NAECHSTEN Segment faelschlich
+    als benannte Testdatei des ERSTEN Aufrufs galt)."""
+    stop = _SEGMENT_SEPARATORS | {">", ">>"}
     out = []
     for tok in tokens[start + 1:]:
         if tok in stop:

--- a/.github/ci_tdd_excludes.txt
+++ b/.github/ci_tdd_excludes.txt
@@ -86,3 +86,12 @@ tests/tdd/test_telegram_kurzstil_parse_mode.py
 tests/tdd/test_telegram_kurzstil_trip_alert.py
 tests/tdd/test_telegram_kurzstil_trip_briefing.py
 tests/tdd/test_trip_report_test_send_past_stage_clamp.py
+# Issue #1478 Teil 1 (2026-08-09): Modul importiert broad_test_run_gate.py,
+# das transitiv hook_utils.py laedt -- ein Shim, der das echte Modul aus dem
+# INSTALLIERTEN agent-os-openspec-Plugin nachlaedt (~/.claude/plugins/
+# installed_plugins.json). Der CI-Runner installiert dieses Plugin nicht
+# (nur "uv sync --dev") -- reiner Umgebungsartefakt, kein funktionaler
+# Defekt. Lokal/im Adversary-Verfahren 5 Runden lang verifiziert (42 Tests,
+# VERDICT HOLDS). Entfernbar, sobald hook_utils.py einen CI-tauglichen
+# Fallback bekommt (separate, breitere Aenderung, ausserhalb dieses Scopes).
+tests/tdd/test_broad_test_run_gate_pytest_word_position.py

--- a/.github/ci_tdd_excludes.txt
+++ b/.github/ci_tdd_excludes.txt
@@ -86,12 +86,3 @@ tests/tdd/test_telegram_kurzstil_parse_mode.py
 tests/tdd/test_telegram_kurzstil_trip_alert.py
 tests/tdd/test_telegram_kurzstil_trip_briefing.py
 tests/tdd/test_trip_report_test_send_past_stage_clamp.py
-# Issue #1478 Teil 1 (2026-08-09): Modul importiert broad_test_run_gate.py,
-# das transitiv hook_utils.py laedt -- ein Shim, der das echte Modul aus dem
-# INSTALLIERTEN agent-os-openspec-Plugin nachlaedt (~/.claude/plugins/
-# installed_plugins.json). Der CI-Runner installiert dieses Plugin nicht
-# (nur "uv sync --dev") -- reiner Umgebungsartefakt, kein funktionaler
-# Defekt. Lokal/im Adversary-Verfahren 5 Runden lang verifiziert (42 Tests,
-# VERDICT HOLDS). Entfernbar, sobald hook_utils.py einen CI-tauglichen
-# Fallback bekommt (separate, breitere Aenderung, ausserhalb dieses Scopes).
-tests/tdd/test_broad_test_run_gate_pytest_word_position.py

--- a/docs/context/fix-1478-teil1-gate-fehlalarme.md
+++ b/docs/context/fix-1478-teil1-gate-fehlalarme.md
@@ -1,0 +1,79 @@
+# Context: fix-1478-teil1-gate-fehlalarme
+
+## Request Summary
+
+`broad_test_run_gate.py` blockiert reine Lesebefehle, die zufällig das Wort
+"pytest" als Argumentwert enthalten (z.B. `grep -n "pytest" .github/workflows/*.yml`,
+`pgrep -af "pytest"`), weil `_pytest_invocations()` jedes Token mit dem
+Wortlaut "pytest" für einen echten Aufrufbeginn hält — unabhängig von seiner
+Position im Kommando. Belegt von einer Peer-Session am 2026-08-09, Issue
+#1478 (Teil 1, dritter Fall derselben Fehlalarm-Familie neben den bereits im
+Plugin-Repo behobenen `bash_gate.py`-Fällen).
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `.claude/hooks/broad_test_run_gate.py` | `_pytest_invocations()` (Zeile 131-138): prüft nur `tok == "pytest"`, keine Positionsprüfung |
+
+## Existing Patterns
+
+- Bereits tokenbasiert (`shlex.split` via `_tokens()`), nicht naiver
+  Teilstring-Scan über den ganzen String — die Grundstruktur ist richtig,
+  nur die Positionsprüfung fehlt.
+- Vorbild für "nicht fragen ob ich einen Aufruf erkenne, sondern ob ich
+  sicher bin, dass keiner drinsteckt": `hook_utils.is_git_subcommand`
+  (agent-os-openspec, Issue #1431 dort).
+- Real genutztes Aufrufmuster in diesem Projekt (CLAUDE.md): ausschließlich
+  `uv run pytest ...` — kein bares `pytest`, kein `python -m pytest` in der
+  dokumentierten Konvention (aber `-m pytest` wird vom bestehenden Code
+  bereits gesondert behandelt, Zeile 137, bleibt unverändert).
+
+## Dependencies
+
+- `hook_utils.find_project_root`, `hook_utils.get_active_workflow_name` —
+  unverändert, nicht betroffen
+- Keine Tests existieren bisher für diesen Hook (`grep -rl broad_test_run_gate`
+  über `tests/` liefert nichts) — neue Testdatei nötig
+
+## Risks & Considerations
+
+- **Sicherheitsrelevant in die andere Richtung:** die Korrektur darf einen
+  ECHTEN breiten Testlauf nicht durchrutschen lassen (Grund des Gates:
+  2026-08-03, echte Telegram-Nachrichten an Prod, #1477). Die Fix-Richtung
+  ("nur an Kommando-Position zählt als Aufruf") verengt die Fehlalarm-Fläche,
+  lockert aber nicht die eigentliche Schutzwirkung — ein echter
+  `pytest`/`uv run pytest`-Aufruf ohne benannte Dateien bleibt an
+  Kommando-Position und wird weiterhin erkannt.
+- Muss `uv run pytest` (das im Projekt tatsächlich verwendete Muster)
+  weiterhin als Aufruf erkennen — nicht nur bares `pytest` am Segmentanfang.
+- Shell-Trenner (`&&`, `||`, `;`, `|`) müssen als neue Segmentanfänge zählen,
+  damit `cmd1 && pytest tests/` weiterhin erkannt wird.
+
+## Analysis
+
+### Type
+Bug (Gate-Fehlalarm, blockiert legitime Lesebefehle)
+
+### Affected Files (with changes)
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `.claude/hooks/broad_test_run_gate.py` | MODIFY | `_pytest_invocations()`: Positionsprüfung ergänzen (Segmentanfang oder nach `run`) |
+| `tests/unit/test_broad_test_run_gate_pytest_word_position.py` | CREATE | Neue Testdatei (keine bestehende vorhanden) |
+
+### Scope Assessment
+- Files: 2 (1 Produktivdatei, 1 neue Testdatei)
+- Estimated LoC: ~20 (Produktivcode) + ~60 (Tests)
+- Risk Level: LOW-MEDIUM (projektweiter Commit-Gate, aber additive Verengung ohne Schutzlockerung)
+
+### Technical Approach
+`_pytest_invocations()` erweitern: ein "pytest"-Token (oder `*/pytest`) zählt
+nur als Aufrufbeginn, wenn es (a) am Anfang der Token-Liste steht, (b) direkt
+nach einem Shell-Trenner (`&&`, `||`, `;`, `|`) steht, oder (c) direkt nach
+`run` steht (deckt `uv run pytest`). Die bestehende `-m pytest`-Regel bleibt
+unverändert als eigener Zweig. Kein Eingriff an `_tokens()`, `_args_after()`,
+`_names_concrete_test_files()`, `_has_safe_flag()` — die Positionsprüfung ist
+lokal auf `_pytest_invocations()` begrenzt.
+
+### Open Questions
+Keine.

--- a/docs/specs/modules/fix_1478_teil1_gate_fehlalarme.md
+++ b/docs/specs/modules/fix_1478_teil1_gate_fehlalarme.md
@@ -1,0 +1,373 @@
+---
+entity_id: fix_1478_teil1_gate_fehlalarme
+type: module
+created: 2026-08-09
+updated: 2026-08-09
+status: draft
+version: "1.0"
+tags: [gates, tooling, issue-1478]
+---
+
+# Fix: broad_test_run_gate erkennt "pytest" nur noch in Kommando-Position
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`broad_test_run_gate.py` soll breite `pytest`-Läufe ohne benannte Testdateien
+blockieren (Schutz gegen den Vorfall vom 2026-08-03, echte Telegram-
+Nachrichten an Prod). Aktuell hält `_pytest_invocations()` JEDES Token mit
+dem Wortlaut "pytest" für einen Aufrufbeginn — auch wenn es nur ein
+Argumentwert eines ANDEREN Kommandos ist (`grep -n "pytest" datei`,
+`pgrep -af "pytest"`). Das blockiert reine Lesebefehle fälschlich. Dieses
+Modul beschränkt die Erkennung auf echte Kommando-Position.
+
+## Source
+
+- **File:** `.claude/hooks/broad_test_run_gate.py`
+- **Identifier:** `def _pytest_invocations`, `def _args_after` (seit Runde 5)
+
+Python-Core / Tooling (`.claude/hooks/`) — kein Frontend-, Go-API- oder
+Domain-Backend-Code betroffen.
+
+## Estimated Scope
+
+- **LoC:** ~25 (Produktivcode) + ~75 (Tests)
+- **Files:** 2 (1 Produktivdatei, 1 neue Testdatei)
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `_tokens()` | function (unverändert) | shlex-Tokenisierung, liefert die Eingabe für `_pytest_invocations` |
+| `_args_after()` | function (**geändert Runde 5**, siehe F-ADV1) | begrenzt die Argumentliste eines erkannten Aufrufs; nutzte bis Runde 5 ein eigenes, unsynchronisiertes Trenner-Set |
+
+## Implementation Details
+
+**Runde 1 → BROKEN (F001/F002):** Positions-Allowlist (Segmentanfang / nach
+`run`) erkannte Launcher-Präfixe (`env`, `nice`, `timeout N`, `sudo`,
+`xargs`) nicht als Kommando-Position — Regression. Siehe
+`docs/artifacts/fix-1478-teil1-gate-fehlalarme/adversary-dialog-round1-broken.md`.
+
+**Runde 2 → BROKEN (F005, siehe Session-Verlauf des Orchestrators):** die
+daraufhin gebaute Fail-safe-Fassung (Default "ist ein Aufruf", Ausnahme nur
+bei bekanntem Text-Suchkommando als nächstem Nicht-Flag-Vorgänger) hatte
+einen eigenen, unconditionellen `-m`-Sonderzweig, der JEDES `<kommando> -m
+pytest` als Aufruf registrierte — unabhängig davon, ob `<kommando>`
+überhaupt Python ist. Live reproduziert: `git commit -m pytest`, `git log
+--grep pytest`, `grep -m pytest file` wurden fälschlich blockiert. Gerade
+`git commit -m` ist im eigenen PR-Liefer-Workflow dieses Projekts
+allgegenwärtig — ein deutlich breiterer, häufigerer Fehlalarm als die
+ursprünglich gemeldeten Fälle.
+
+**Runde 3 → BROKEN (F006/F007, siehe Session-Verlauf des Orchestrators):**
+"jedes Flag vor pytest schliesst aus, ausser -m+Python" war selbst zu
+pauschal — EIN Flag zwischen einem echten Launcher und `pytest` (z.B.
+`sudo -E pytest tests/`, `nice -n10 pytest tests/`, `xargs -I{} pytest {}`,
+`env -S pytest tests/`) hebelte die AC-6-Erkennung wieder aus (F006, dieselbe
+Bug-Klasse wie F001, nur eine Flag-Stufe tiefer). Zusaetzlich matchte
+`_PYTHON_LAUNCHER_RE` nur den nackten Interpreter-Namen, nicht
+pfad-qualifizierte Formen wie `/usr/bin/python3`/`.venv/bin/python3` (F007).
+
+**Runde 4 (aktuell):** Prioritaet umgedreht (Vorschlag des Adversary-Agenten
+uebernommen). Statt "Flag davor -> ausgenommen, ausser -m+Python" gilt jetzt:
+"Flag davor -> Launcher-Erkennung PRUEFEN (Vorgaenger hinter allen Flags),
+ausgenommen NUR wenn der Launcher weder ein bekannter Prozess-Launcher noch
+ein Python-Interpreter ist". Die Launcher-/Python-Erkennung arbeitet auf dem
+**Basename** (`rsplit("/", 1)[-1]`), damit pfad-qualifizierte Formen
+(`/usr/bin/python3`) erkannt werden. Text-Suchkommando-Ausnahme (Runde 2)
+bleibt fuer den flag-losen Fall unveraendert bestehen.
+
+```python
+_SEGMENT_SEPARATORS = {"&&", "||", ";", "|", "&"}
+_TEXT_MATCH_COMMANDS = {
+    "grep", "egrep", "fgrep", "rgrep", "zgrep", "pgrep", "rg", "ag", "ack",
+}
+_LAUNCHER_COMMANDS = {
+    "env", "nice", "nohup", "sudo", "doas", "setsid", "timeout", "xargs",
+    "time", "ionice", "chrt",
+}
+_PYTHON_LAUNCHER_RE = re.compile(r"^python3?(\.\d+)?$")
+
+
+def _basename(token: str) -> str:
+    """Letztes Pfadsegment -- 'pytest'-Erkennung soll pfad-qualifizierte
+    Launcher (/usr/bin/python3, .venv/bin/python3) genauso treffen wie
+    nackte Namen (Issue #1478 Teil 1, Adversary-Runde 3, Finding F007)."""
+    return token.rsplit("/", 1)[-1]
+
+
+def _nearest_non_flag_predecessor(tokens: list[str], index: int) -> "str | None":
+    """Naechstes Token VOR `index` im selben Segment, das keine Flag
+    (fuehrendes '-') ist. None am Segmentanfang (Trenner erreicht oder
+    Listenanfang)."""
+    j = index - 1
+    while j >= 0:
+        tok = tokens[j]
+        if tok in _SEGMENT_SEPARATORS:
+            return None
+        if not tok.startswith("-"):
+            return tok
+        j -= 1
+    return None
+
+
+def _pytest_invocations(tokens: list[str]) -> list[int]:
+    """Indizes, an denen ein pytest-Lauf beginnt.
+
+    Default: JEDES 'pytest'-/'*/pytest'-Token zaehlt als Aufrufbeginn.
+    Zwei Faelle:
+
+    1. Unmittelbar vorangehendes Flag-Token (fuehrendes '-'): der Vorgaenger
+       HINTER ALLEN Flags wird ermittelt (`_nearest_non_flag_predecessor`
+       ueberspringt beliebig viele Flags). Ist dieser Vorgaenger ein
+       bekannter Prozess-Launcher (`_LAUNCHER_COMMANDS`) oder ein
+       Python-Interpreter (`_PYTHON_LAUNCHER_RE` auf den Basename) ->
+       'pytest' IST ein Aufruf, egal wie viele Flags dazwischen liegen
+       (Issue #1478 Teil 1, Adversary-Runde 3, Finding F006: 'sudo -E
+       pytest', 'nice -n10 pytest', 'xargs -I{} pytest' MUESSEN weiterhin
+       blockiert werden). Sonst (Vorgaenger ist ein gewoehnliches Wort wie
+       'commit', 'log', 'grep') ist 'pytest' dessen Freitext-Flag-Wert,
+       kein eigener Aufruf (Finding F005: 'git commit -m pytest', 'git log
+       --grep pytest', 'grep -m pytest').
+    2. Kein vorangehendes Flag: der naechste Nicht-Flag-Vorgaenger im
+       selben Segment wird direkt gegen `_TEXT_MATCH_COMMANDS` geprueft
+       (Basename) -- 'pytest' ist dessen Suchmuster (grep -n "pytest"
+       datei, pgrep -af "pytest"), sonst Default "ist ein Aufruf" (z.B.
+       jeder bare Launcher: 'sudo pytest tests/', F001/AC-6).
+    """
+    hits: list[int] = []
+    for i, tok in enumerate(tokens):
+        if tok != "pytest" and not tok.endswith("/pytest"):
+            continue
+        if i > 0 and tokens[i - 1].startswith("-"):
+            launcher = _nearest_non_flag_predecessor(tokens, i)
+            launcher_base = _basename(launcher) if launcher is not None else None
+            if launcher_base in _LAUNCHER_COMMANDS or (
+                launcher_base is not None and _PYTHON_LAUNCHER_RE.match(launcher_base)
+            ):
+                hits.append(i)
+            continue
+        predecessor = _nearest_non_flag_predecessor(tokens, i)
+        predecessor_base = _basename(predecessor) if predecessor is not None else None
+        if predecessor_base in _TEXT_MATCH_COMMANDS:
+            continue
+        hits.append(i)
+    return hits
+```
+
+`re` ist bereits am Dateianfang von `broad_test_run_gate.py` importiert
+(`import re`) — kein neuer Import nötig.
+
+**Runde 5 (aktuell) → Fund F-ADV1 (Adversary-Runde 4, außerhalb von
+`_pytest_invocations()`):** `_args_after()` begrenzt die Argumentliste eines
+erkannten Aufrufs mit einem EIGENEN, nie synchronisierten Trenner-Set
+(`{"&&", "||", ";", "|", ">", ">>"}`), dem das einfache `&` fehlt — obwohl
+`_SEGMENT_SEPARATORS` es seit Runde 2/AC-7 enthält. Erkennung
+(`_pytest_invocations`) und Begrenzung (`_args_after`) nutzten dadurch zwei
+verschiedene Vorstellungen von "Segmentende". Live reproduziert:
+`pytest tests/ & x.py` — `_pytest_invocations` erkennt den Aufruf an
+Index 0 korrekt, aber `_args_after` sammelt Tokens ÜBER den `&`-Trenner
+hinweg ein, findet `x.py` aus dem NÄCHSTEN, unabhängigen Segment und hält
+den Aufruf fälschlich für "konkrete Datei benannt" — ein voller,
+ungemarkerter Testlauf (der 2026-08-03-Vorfall) läuft unblockiert durch.
+
+Fix: `_args_after()` verwendet dieselbe Trenner-Menge wie
+`_nearest_non_flag_predecessor()`, ergänzt um die Redirect-Operatoren
+`>`/`>>`, die dort keine Rolle spielen (schließen aber ihrerseits die
+Argumentliste ab — unverändertes Bestandsverhalten):
+
+```python
+def _args_after(tokens: list[str], start: int) -> list[str]:
+    """Argumente nach dem pytest-Token bis zum naechsten Kommando-Trenner.
+
+    Nutzt dieselbe Trenner-Menge wie `_nearest_non_flag_predecessor()`
+    (`_SEGMENT_SEPARATORS`, seit Runde 2 inkl. '&') statt eines eigenen,
+    unsynchronisierten Sets -- sonst erkennt `_pytest_invocations()` einen
+    Aufruf korrekt an einer Segmentgrenze, aber `_args_after()` sammelt
+    Tokens ueber genau diese Grenze hinweg ein (Issue #1478 Teil 1,
+    Adversary-Runde 4, Finding F-ADV1: 'pytest tests/ & x.py' lief
+    unblockiert durch, weil 'x.py' aus dem NAECHSTEN Segment faelschlich
+    als benannte Testdatei des ERSTEN Aufrufs galt)."""
+    stop = _SEGMENT_SEPARATORS | {">", ">>"}
+    out = []
+    for tok in tokens[start + 1:]:
+        if tok in stop:
+            break
+        out.append(tok)
+    return out
+```
+
+## Expected Behavior
+
+- **Input:** Bash-Kommandozeile (roher String, bereits durch `_tokens()`
+  tokenisiert)
+- **Output:** Liste der Token-Indizes, an denen ein ECHTER pytest-Aufruf
+  beginnt (leer, wenn keiner)
+- **Side effects:** keine (reine Berechnung)
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Kommando `uv run pytest tests/tdd/x.py` / When
+  `_pytest_invocations()` aufgerufen wird / Then der Index des `pytest`-Tokens
+  wird erkannt (unverändertes Verhalten für das im Projekt tatsächlich
+  genutzte Aufrufmuster).
+  - Test: bestätigt anhand des bestehenden, im Projekt üblichen Musters.
+
+- **AC-2:** Given ein reiner Lesebefehl `grep -n "pytest" .github/workflows/*.yml`
+  / When `_pytest_invocations()` aufgerufen wird / Then die Liste ist leer
+  (kein Fehlalarm) — der reale, im Issue gemeldete Fall.
+  - Test: `broad_test_run_gate`-Hauptfunktion (End-to-End über Payload)
+    blockiert diesen Befehl NICHT mehr.
+
+- **AC-3:** Given `pgrep -af "pytest"` / When geprüft wird / Then kein
+  Fehlalarm — der zweite im Issue gemeldete Fall.
+  - Test: analog AC-2.
+
+- **AC-4:** Given `cmd1 && pytest tests/tdd/x.py` / When geprüft wird / Then
+  der pytest-Aufruf NACH dem Trenner `&&` wird weiterhin erkannt
+  (Regressionswächter: Segmentanfang nach Shell-Trenner bleibt gültige
+  Kommando-Position).
+  - Test: `_pytest_invocations()` direkt.
+
+- **AC-5:** Given `pytest tests/` (echter breiter Lauf ohne benannte Datei,
+  bares Kommando) / When das volle Gate geprüft wird / Then bleibt der
+  Befehl BLOCKIERT — die eigentliche Schutzwirkung darf nicht schwächer
+  werden.
+  - Test: End-to-End über Payload, `BLOCKED` in stderr.
+
+- **AC-6 (Adversary-Fund F001, PFLICHT):** Given ein breiter Lauf hinter
+  einem Launcher-Präfix (`env`, `nice`, `timeout 60`, `sudo`, `xargs`,
+  jeweils gefolgt von `pytest tests/` ohne benannte Datei) / When das volle
+  Gate geprüft wird / Then bleibt der Befehl BLOCKIERT für JEDEN dieser
+  Launcher — vor dieser Korrektur erkannte der Alt-Code jeden davon
+  positionsunabhängig, die erste Fix-Fassung (Positions-Allowlist) erkannte
+  KEINEN davon mehr (Regression).
+  - Test: End-to-End über Payload, je Launcher-Variante, `BLOCKED` in stderr.
+
+- **AC-7 (Adversary-Fund F002):** Given `sleep 1 & pytest tests/`
+  (Hintergrund-Trenner `&`, kein `&&`) / When geprüft wird / Then bleibt der
+  Befehl BLOCKIERT.
+  - Test: End-to-End über Payload.
+  - **Korrigierte Ursache (Entwickler-Agent-Nebenbefund, Fix-Loop Runde 2):**
+    `&` wurde zwar zu `_SEGMENT_SEPARATORS` hinzugefügt, ist dort aber
+    faktisch wirkungslos — `_nearest_non_flag_predecessor()` gibt für ein
+    Trenner-Token entweder `None` zurück (mit Trenner-Prüfung) oder das
+    Trenner-Token selbst als gewöhnlichen Vorgänger (ohne Prüfung); beide
+    Fälle sind ausserhalb von `_TEXT_MATCH_COMMANDS` und führen zum
+    identischen Ergebnis. AC-7 besteht durch den Fail-safe-Default ("ist
+    ein Aufruf, ausser ein bekanntes Suchkommando steht direkt davor") —
+    nicht durch `_SEGMENT_SEPARATORS`. Die Konstante bleibt als
+    dokumentierte Segment-Grenze für `_nearest_non_flag_predecessor()`
+    bestehen (Invariante "nur innerhalb desselben Segments suchen"), auch
+    wenn sie unter der aktuellen `_TEXT_MATCH_COMMANDS`-Liste keinen
+    beobachtbaren Unterschied macht.
+
+- **AC-8 (Adversary-Fund F005, Runde 2, PFLICHT):** Given ein Kommando, bei
+  dem "pytest" unmittelbar hinter einem Freitext-Flag eines NICHT-Python-
+  Kommandos steht (`git commit -m pytest`, `git log --grep pytest`,
+  `grep -m pytest datei`) / When das volle Gate geprüft wird / Then wird
+  der Befehl NICHT blockiert — "pytest" ist erkennbar der Flag-Wert, kein
+  eigener Aufruf. Live am unmutierten Runde-2-Code reproduziert (RC=2 statt
+  0 für alle drei Beispiele).
+  - Test: End-to-End über Payload, je Beispiel.
+
+- **AC-9 (Regressionswächter zu AC-8):** Given `python3 -m pytest
+  tests/tdd/x.py` (der einzige legitime `-m`-Fall) / When geprüft wird /
+  Then bleibt der Aufruf weiterhin erkannt — die AC-8-Korrektur darf
+  `python -m pytest` nicht mit ausschließen.
+  - Test: `_pytest_invocations()` direkt + End-to-End.
+
+- **AC-10 (Adversary-Fund F006, Runde 3, PFLICHT):** Given ein bekannter
+  Prozess-Launcher mit EINEM Flag zwischen ihm und `pytest`
+  (`sudo -E pytest tests/`, `nice -n10 pytest tests/`,
+  `xargs -I{} pytest {} tests/`, `xargs -n1 pytest tests/`,
+  `env -S pytest tests/`) / When das volle Gate geprüft wird / Then bleibt
+  der Befehl BLOCKIERT — ein einzelnes Flag zwischen Launcher und `pytest`
+  darf die AC-6-Erkennung nicht aushebeln. Live am unmutierten Runde-3-Code
+  reproduziert (RC=0 statt 2 für alle fünf Beispiele).
+  - Test: End-to-End über Payload, je Beispiel.
+
+- **AC-11 (Adversary-Fund F007, Runde 3):** Given ein pfad-qualifizierter
+  Python-Interpreter (`/usr/bin/python3 -m pytest tests/`,
+  `.venv/bin/python3 -m pytest tests/`, `/usr/bin/python3.12 -m pytest
+  tests/`) / When geprüft wird / Then bleibt der Befehl BLOCKIERT — die
+  Python-Erkennung muss auf dem Basename arbeiten, nicht nur auf dem
+  nackten Namen.
+  - Test: End-to-End über Payload, je Beispiel + Unit gegen
+    `_pytest_invocations()`.
+
+- **AC-12 (Adversary-Fund F-ADV1, Runde 4, KRITISCH, PFLICHT):** Given ein
+  erkannter breiter pytest-Aufruf, gefolgt von einem Hintergrund-Trenner
+  `&` und einem beliebigen weiteren Token mit `.py`-Endung
+  (`pytest tests/ & x.py`, `pytest tests/ & echo x.py`) / When das volle
+  Gate geprüft wird / Then bleibt der Befehl BLOCKIERT — das `.py`-Token
+  aus dem NÄCHSTEN Segment darf nicht als benannte Testdatei des ERSTEN
+  Aufrufs zählen. Live am unmutierten Runde-4-Code reproduziert (RC=0 statt
+  2). Kontrollprobe mit `&&` statt `&` an derselben Stelle: RC=2 (isoliert
+  die Ursache eindeutig auf `_args_after()`s fehlendes `&`).
+  - Test: End-to-End über Payload, je Beispiel.
+
+## Known Limitations
+
+- **Bewusst nicht behoben (Formprüfung ist bodenlos, vgl. Projekt-Prinzip
+  "invertiere die Frage statt jeden Fall aufzuzählen"):** ein Launcher mit
+  MEHREREN Flags, von denen eines einen eigenen Wert-Token traegt UND
+  dieser Wert-Token unmittelbar vor `pytest` steht, wird falsch eingeordnet
+  — z.B. `sudo -u root -E pytest tests/`: der Rueckwaerts-Scan haelt
+  `root` (den Wert von `-u`) faelschlich fuer den Launcher-Namen, da er
+  keine Flag-Aritaet pro Kommando kennt (unbeschraenkt komplex, siehe
+  `reference_command_parsing_is_bottomless_invert_the_question`). Bewusste
+  Grenze dieser schmalen Korrektur — vollstaendige Argument-Semantik pro
+  Launcher ist nicht das Ziel. `sudo -E pytest` (EIN wertloses Flag,
+  AC-10) bleibt dagegen korrekt erkannt.
+- **Bekannt, akzeptiert, kein Fix (Adversary-Runde 4, F-ADV2, LOW,
+  Überblockierungs-Richtung):** `sudo -u pytest whoami` (ein System-User
+  namens "pytest" als Flag-Wert von `-u`) wird fälschlich BLOCKIERT, weil
+  der Rückwärts-Scan "pytest" selbst für den Vorgänger hält, bevor er
+  "sudo" erreicht. Sicherheitsrichtung stimmt (fail-safe blockiert lieber
+  einmal zu viel), kein reales Sicherheitsrisiko — Sammel-Eintrag statt
+  eigener Korrektur (PO-Konvention Nebenbefund-Triage).
+- **Bekannt, akzeptiert, kein Fix (Adversary-Runde 4, F-ADV3, LOW,
+  Struktur-Hinweis):** `_TEXT_MATCH_COMMANDS` wird im Flag-Zweig von
+  `_pytest_invocations()` nie konsultiert (strukturell unerreichbar, da der
+  Zweig-Default "kein Launcher erkannt → nicht blockiert" für
+  Text-Suchkommandos ohnehin dasselbe Ergebnis liefert) — mutations-belegt
+  (Prioritäts-Umkehr fängt kein Test). Kein Verhaltensfehler, laut
+  Docstring beabsichtigte Trennung der beiden Zweige.
+- **Bekannt, akzeptiert, kein Fix (Adversary-Runde 5, F-ADV4, LOW,
+  Überblockierungs-Richtung):** `_nearest_non_flag_predecessor()` kennt
+  `>`/`>>` nicht als Segmentgrenze (im Unterschied zu `_args_after()`, das
+  sie seit Runde 5 explizit berücksichtigt) — ein Redirect-Ziel, das
+  zufällig `pytest` heißt (`echo x > pytest`), wird dadurch fälschlich als
+  Aufruf-Kandidat gewertet. Kein AC verletzt, kein Fall gefunden, in dem
+  ein ECHTER breiter Aufruf dadurch durchrutscht (`>` unmittelbar vor
+  einem echten Aufruf-Token ist in gültiger Bash-Syntax nicht möglich —
+  ein Redirect-Ziel ist per Definition ein Dateiname, kein Kommandostart).
+  Sammel-Eintrag statt eigener Korrektur (PO-Konvention
+  Nebenbefund-Triage).
+- Ein text-suchendes Kommando außerhalb der festen Liste
+  `_TEXT_MATCH_COMMANDS` (z.B. `find . -name "pytest"`, `awk`, `sed -n`)
+  kann weiterhin einen Fehlalarm auslösen, wenn "pytest" darin als reiner
+  Text vorkommt — nicht behoben, da nicht belegt (nur die tatsächlich
+  gemeldeten Fälle `grep`/`pgrep`-Familie sind in der Liste). Eine
+  vollständige Kommando-Semantik-Erkennung ist außerhalb des Scopes dieser
+  schmalen Korrektur.
+- Ändert nichts an `_tokens()`s Fallback-Verhalten bei verschachtelter
+  Shell (`sh -c`, `eval`) — dort liefert `_tokens()` bereits `None` und das
+  Gate greift über einen anderen, unveränderten Pfad.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Korrektur einer bestehenden Erkennungsfunktion, keine
+  neue Architektur-Entscheidung nötig. Folgt demselben Prinzip wie die
+  bereits im Plugin-Repo behobenen `bash_gate.py`-Fälle (Issue #1478,
+  PR henemm/agent-os-openspec#92).
+
+## Changelog
+
+- 2026-08-09: Initial spec created

--- a/tests/tdd/test_broad_test_run_gate_pytest_word_position.py
+++ b/tests/tdd/test_broad_test_run_gate_pytest_word_position.py
@@ -1,0 +1,324 @@
+"""TDD RED -- Issue #1478 Teil 1: `broad_test_run_gate.py` haelt jedes Token
+mit dem Wortlaut "pytest" fuer einen Aufrufbeginn, unabhaengig von seiner
+Position im Kommando. Das blockiert reine Lesebefehle, die "pytest" nur als
+Argumentwert eines ANDEREN Kommandos enthalten (`grep -n "pytest" datei`,
+`pgrep -af "pytest"`), faelschlich.
+
+SPEC: docs/specs/modules/fix_1478_teil1_gate_fehlalarme.md (AC-1 bis AC-12)
+
+Kein Mock-Theater: `_pytest_invocations()` wird direkt mit echten Token-Listen
+geprueft (Unit-Ebene), der volle Gate-Pfad ueber einen echten Subprozess mit
+JSON-Payload auf stdin (End-to-End-Ebene, identisches Muster wie
+tests/tdd/test_fix_853_842_837_tooling_gates.py).
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT / ".claude" / "hooks"))
+
+import broad_test_run_gate as gate  # noqa: E402
+
+
+def _run_gate(command: str) -> subprocess.CompletedProcess:
+    """Fuehrt den echten Hook als Subprozess aus (kein In-Process-Aufruf --
+    main() ruft sys.exit(), das wuerde den Testprozess beenden)."""
+    payload = json.dumps({"tool_input": {"command": command}})
+    return subprocess.run(
+        [sys.executable, str(ROOT / ".claude" / "hooks" / "broad_test_run_gate.py")],
+        input=payload,
+        capture_output=True,
+        text=True,
+        cwd=str(ROOT),
+    )
+
+
+class TestPytestInvocationsUnit:
+    """Direkte Pruefung von `_pytest_invocations()` gegen bereits
+    tokenisierte Kommandos (kein Subprozess noetig)."""
+
+    def test_ac1_uv_run_pytest_recognized(self):
+        tokens = ["uv", "run", "pytest", "tests/tdd/x.py"]
+        assert gate._pytest_invocations(tokens) == [2]
+
+    def test_ac2_pytest_as_grep_pattern_not_recognized(self):
+        tokens = ["grep", "-n", "pytest", ".github/workflows/ci.yml"]
+        assert gate._pytest_invocations(tokens) == []
+
+    def test_ac3_pytest_as_pgrep_pattern_not_recognized(self):
+        tokens = ["pgrep", "-af", "pytest"]
+        assert gate._pytest_invocations(tokens) == []
+
+    def test_ac4_pytest_after_separator_recognized(self):
+        tokens = ["echo", "x", "&&", "pytest", "tests/tdd/x.py"]
+        assert gate._pytest_invocations(tokens) == [3]
+
+    def test_bare_pytest_at_segment_start_still_recognized(self):
+        tokens = ["pytest", "tests/"]
+        assert gate._pytest_invocations(tokens) == [0]
+
+    def test_python_dash_m_pytest_still_recognized(self):
+        tokens = ["python3", "-m", "pytest", "tests/tdd/x.py"]
+        assert gate._pytest_invocations(tokens) == [2]
+
+    def test_semicolon_separator_recognized(self):
+        tokens = ["cmd1", ";", "pytest", "tests/tdd/x.py"]
+        assert gate._pytest_invocations(tokens) == [2]
+
+    def test_pipe_separator_recognized(self):
+        tokens = ["echo", "x", "|", "pytest", "tests/tdd/x.py"]
+        assert gate._pytest_invocations(tokens) == [3]
+
+
+class TestGateEndToEnd:
+    """Voller Hook-Pfad ueber Subprozess -- belegt die tatsaechliche
+    Blockier-/Freigabe-Wirkung, nicht nur die Hilfsfunktion."""
+
+    def test_ac2_grep_for_pytest_not_blocked(self):
+        result = _run_gate('grep -n "pytest" .github/workflows/ci.yml')
+        assert result.returncode == 0, result.stderr
+
+    def test_ac3_pgrep_for_pytest_not_blocked(self):
+        result = _run_gate('pgrep -af "pytest"')
+        assert result.returncode == 0, result.stderr
+
+    def test_ac5_bare_broad_pytest_still_blocked(self):
+        result = _run_gate("pytest tests/")
+        assert result.returncode == 2, (
+            f"Echter breiter Testlauf MUSS weiterhin blockiert werden, "
+            f"war returncode={result.returncode}, stderr={result.stderr!r}"
+        )
+        assert "BLOCKED" in result.stderr
+
+    def test_uv_run_pytest_broad_still_blocked(self):
+        result = _run_gate("uv run pytest tests/")
+        assert result.returncode == 2
+        assert "BLOCKED" in result.stderr
+
+    def test_uv_run_pytest_named_file_still_allowed(self):
+        result = _run_gate("uv run pytest tests/tdd/test_x.py")
+        assert result.returncode == 0, result.stderr
+
+
+class TestAC6LauncherPrefixesStillBlocked:
+    """Adversary-Fund F001 (Runde 1, BROKEN): die erste Fix-Fassung nutzte
+    eine Positions-Allowlist (Segmentanfang / nach 'run'), die reale
+    Launcher-Praefixe NICHT als Kommando-Position erkannte -- ein breiter
+    Lauf dahinter wurde faelschlich NICHT blockiert (Regression gegenueber
+    dem Alt-Code, der jedes 'pytest'-Token positionsunabhaengig matchte).
+    Diese Tests belegen je einen der von der Adversary-Session real
+    reproduzierten Faelle (exit=0 statt exit=2 mit der ersten Fix-Fassung)."""
+
+    def test_env_prefix_still_blocked(self):
+        result = _run_gate("env pytest tests/")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+    def test_nice_prefix_still_blocked(self):
+        result = _run_gate("nice pytest tests/")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+    def test_timeout_prefix_still_blocked(self):
+        result = _run_gate("timeout 60 pytest tests/")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+    def test_sudo_prefix_still_blocked(self):
+        result = _run_gate("sudo pytest tests/")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+    def test_xargs_prefix_still_blocked(self):
+        result = _run_gate("xargs pytest tests/")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+
+class TestAC7AmpersandSeparatorRecognized:
+    """Adversary-Fund F002: '&' (einfacher Hintergrund-Trenner, nicht '&&')
+    fehlte in _SEGMENT_SEPARATORS -- ein pytest-Aufruf im Hintergrund-Segment
+    wurde nicht als eigenes Segment erkannt und lief unblockiert durch."""
+
+    def test_background_ampersand_segment_still_blocked(self):
+        result = _run_gate("sleep 1 & pytest tests/")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+
+class TestF003F004BoundaryHardening:
+    """Adversary-Runde 2 (VERIFIED, 2 MEDIUM-Findings aus der Mutationsprobe):
+    der ausgelieferte Code ist in beiden Faellen bereits korrekt -- diese
+    Tests sichern die Boundary-Bedingungen gegen kuenftige Regression ab.
+
+    F003: `_nearest_non_flag_predecessor` bricht bei einem Trenner-Token
+    (hier '&&') sofort ab und liefert None -- ein Suchkommando OHNE
+    Argumente direkt vor dem Trenner darf 'pytest' im NAECHSTEN Segment
+    nicht als sein Suchmuster vereinnahmen.
+
+    F004: der Vorgaenger-Suchradius ist bewusst genau 1 Token -- ein
+    Suchkommando MIT einem Wortargument direkt vor 'pytest' (kein Trenner
+    dazwischen) darf 'pytest' ebenfalls nicht vereinnahmen, weil der
+    unmittelbare Vorgaenger ('foo') kein bekanntes Suchkommando ist.
+    """
+
+    def test_f003_grep_before_separator_does_not_swallow_next_segment(self):
+        tokens = ["grep", "&&", "pytest", "tests/"]
+        assert gate._pytest_invocations(tokens) == [2]
+
+        result = _run_gate("grep && pytest tests/")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+    def test_f004_grep_with_word_arg_before_pytest_does_not_swallow(self):
+        tokens = ["grep", "foo", "pytest", "tests/"]
+        assert gate._pytest_invocations(tokens) == [2]
+
+        result = _run_gate("grep foo pytest tests/")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+
+class TestAC8F005FlagValueNotInvocation:
+    """Adversary-Fund F005 (Runde 2, BROKEN): der unconditionelle '-m'-Zweig
+    registrierte JEDES '<kommando> -m pytest' als Aufruf, unabhaengig davon,
+    ob <kommando> ueberhaupt Python ist. Live am unmutierten Code
+    reproduziert: git commit -m pytest / git log --grep pytest /
+    grep -m pytest datei wurden faelschlich blockiert -- 'pytest' ist in
+    allen drei Faellen erkennbar der Freitext-Wert eines Flags, kein
+    eigener Aufruf. Gerade 'git commit -m' ist im PR-Liefer-Workflow dieses
+    Projekts allgegenwaertig."""
+
+    def test_git_commit_dash_m_pytest_message_not_blocked(self):
+        result = _run_gate('git commit -m "pytest"')
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_git_log_grep_pytest_not_blocked(self):
+        result = _run_gate("git log --grep pytest")
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_grep_dash_m_pytest_not_blocked(self):
+        result = _run_gate("grep -m pytest datei.txt")
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_unit_git_commit_dash_m_pytest_not_recognized(self):
+        tokens = ["git", "commit", "-m", "pytest"]
+        assert gate._pytest_invocations(tokens) == []
+
+    def test_unit_grep_dash_m_pytest_not_recognized(self):
+        tokens = ["grep", "-m", "pytest", "datei.txt"]
+        assert gate._pytest_invocations(tokens) == []
+
+
+class TestAC9PythonDashMStillRecognized:
+    """Regressionswaechter zu AC-8: die Flag-Wert-Ausnahme darf den
+    einzigen legitimen '-m'-Fall (python -m pytest) nicht mit ausschliessen."""
+
+    def test_python3_dash_m_pytest_still_recognized(self):
+        tokens = ["python3", "-m", "pytest", "tests/tdd/x.py"]
+        assert gate._pytest_invocations(tokens) == [2]
+
+        result = _run_gate("python3 -m pytest tests/tdd/x.py")
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_bare_python_dash_m_pytest_broad_still_blocked(self):
+        result = _run_gate("python3 -m pytest tests/")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+
+class TestAC10F006LauncherWithFlagStillBlocked:
+    """Adversary-Fund F006 (Runde 3, BROKEN): 'jedes Flag vor pytest schliesst
+    aus, ausser -m+Python' war selbst zu pauschal -- ein einzelnes Flag
+    zwischen einem echten Launcher und 'pytest' hebelte die AC-6-Erkennung
+    wieder aus. Live am unmutierten Runde-3-Code reproduziert (RC=0 statt 2
+    fuer alle fuenf Beispiele)."""
+
+    def test_sudo_with_flag_still_blocked(self):
+        result = _run_gate("sudo -E pytest tests/")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+    def test_nice_with_flag_still_blocked(self):
+        result = _run_gate("nice -n10 pytest tests/")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+    def test_xargs_with_braces_flag_still_blocked(self):
+        result = _run_gate("xargs -I{} pytest {} tests/")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+    def test_xargs_with_n_flag_still_blocked(self):
+        result = _run_gate("xargs -n1 pytest tests/")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+    def test_env_with_flag_still_blocked(self):
+        result = _run_gate("env -S pytest tests/")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+    def test_unit_sudo_with_flag_recognized(self):
+        tokens = ["sudo", "-E", "pytest", "tests/"]
+        assert gate._pytest_invocations(tokens) == [2]
+
+
+class TestAC11F007PathQualifiedPythonRecognized:
+    """Adversary-Fund F007 (Runde 3): _PYTHON_LAUNCHER_RE matchte nur den
+    nackten Interpreter-Namen, nicht pfad-qualifizierte Formen -- realistisch
+    haeufig (Skripte/Cron/systemd/venv-relative Pfade)."""
+
+    def test_absolute_path_python3_dash_m_pytest_still_blocked(self):
+        result = _run_gate("/usr/bin/python3 -m pytest tests/")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+    def test_venv_relative_python3_dash_m_pytest_still_blocked(self):
+        result = _run_gate(".venv/bin/python3 -m pytest tests/")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+    def test_absolute_path_versioned_python_still_blocked(self):
+        result = _run_gate("/usr/bin/python3.12 -m pytest tests/")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+    def test_unit_absolute_path_python_recognized(self):
+        tokens = ["/usr/bin/python3", "-m", "pytest", "tests/"]
+        assert gate._pytest_invocations(tokens) == [2]
+
+
+class TestAC12FAdv1ArgsAfterAmpersandBoundary:
+    """Adversary-Fund F-ADV1 (Runde 4, BROKEN, CRITICAL): _args_after() hatte
+    ein eigenes, nie mit _SEGMENT_SEPARATORS synchronisiertes Trenner-Set
+    ohne '&'. _pytest_invocations() erkannte einen breiten Aufruf VOR einem
+    '&'-Hintergrund-Trenner zwar korrekt, aber _args_after() sammelte
+    Tokens ueber die Grenze hinweg ein und hielt ein '.py'-Token aus dem
+    NAECHSTEN, unabhaengigen Segment faelschlich fuer eine benannte
+    Testdatei des ERSTEN Aufrufs -- genau der 2026-08-03-Vorfall (voller,
+    ungemarkerter Testlauf laeuft durch)."""
+
+    def test_broad_pytest_before_ampersand_with_py_token_after_still_blocked(self):
+        result = _run_gate("pytest tests/ & x.py")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+    def test_broad_pytest_before_ampersand_with_echo_py_after_still_blocked(self):
+        result = _run_gate("pytest tests/ & echo x.py")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+    def test_control_double_ampersand_still_blocked(self):
+        # Kontrollprobe: mit '&&' (bereits vor Runde 5 im stop-Set) war es
+        # schon immer korrekt -- isoliert den Fund eindeutig auf '&'.
+        result = _run_gate("pytest tests/ && echo x.py")
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+    def test_unit_args_after_stops_at_ampersand(self):
+        tokens = ["pytest", "tests/", "&", "x.py"]
+        assert gate._args_after(tokens, 0) == ["tests/"]

--- a/tests/tdd/test_broad_test_run_gate_pytest_word_position.py
+++ b/tests/tdd/test_broad_test_run_gate_pytest_word_position.py
@@ -10,6 +10,18 @@ Kein Mock-Theater: `_pytest_invocations()` wird direkt mit echten Token-Listen
 geprueft (Unit-Ebene), der volle Gate-Pfad ueber einen echten Subprozess mit
 JSON-Payload auf stdin (End-to-End-Ebene, identisches Muster wie
 tests/tdd/test_fix_853_842_837_tooling_gates.py).
+
+Modul-Import ueber `pytest.importorskip` statt eines harten `import`: der
+Hook laedt transitiv `hook_utils.py`, einen Shim, der das echte Modul aus dem
+INSTALLIERTEN agent-os-openspec-Plugin nachlaedt. Auf CI-Runnern (kein
+Plugin installiert) waere ein hartes `import` ein COLLECTION-FEHLER, kein
+sauberer Skip -- das bricht `tests/tdd/test_pytest_collection_and_timeout_
+safety.py`s interne `pytest --collect-only`-Subprozesse (laufen OHNE die
+`.github/ci_tdd_excludes.txt`-Ausschluesse), die eine fehlerfreie Voll-
+Collection erwarten (Issue #1478 Teil 1, gemessen: CI-Lauf mit hartem Import
+riss 21 Tests in voellig unabhaengigen Dateien mit). `importorskip` macht
+denselben Zustand zu einem sauberen SKIP (kein Collection-Fehler), lokal mit
+installiertem Plugin laeuft die Datei unveraendert durch.
 """
 
 import json
@@ -17,10 +29,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(ROOT / ".claude" / "hooks"))
 
-import broad_test_run_gate as gate  # noqa: E402
+gate = pytest.importorskip("broad_test_run_gate")
 
 
 def _run_gate(command: str) -> subprocess.CompletedProcess:


### PR DESCRIPTION
## Summary
- `_pytest_invocations()` erkannte den Wortlaut "pytest" bisher an JEDER Position im Kommando als Aufruf — auch als Suchmuster eines anderen Kommandos (`grep -n "pytest" datei`, `pgrep -af "pytest"`). Erkennung jetzt auf echte Kommando-Position beschränkt (Segmentanfang, nach bekannten Prozess-Launchern env/nice/nohup/sudo/doas/setsid/timeout/xargs/time/ionice/chrt, nach Python-Interpretern — auch pfad-qualifiziert wie `/usr/bin/python3`)
- Flag-Werte anderer Kommandos (`git commit -m pytest`, `git log --grep pytest`) werden nicht mehr fälschlich als Aufruf gewertet
- `_args_after()` nutzt jetzt dieselbe Trenner-Menge wie die Erkennung selbst (vorher: eigenes, unsynchronisiertes Set ohne `&` — ein breiter Lauf vor `&` ließ sich durch ein folgendes `.py`-Token durchschleusen)

Fünf Fix-Loop-Runden mit Adversary-Verifikation (4× BROKEN mit echten, live reproduzierten Funden, final HOLDS) — jede Runde fand einen realen Fehlalarm oder eine reale Sicherheitsregression, keine wurde übersprungen. Details: `docs/specs/modules/fix_1478_teil1_gate_fehlalarme.md`.

Teil 2 (workflow.py finish-Alias) bereits via PR #91 im Plugin-Repo gemergt. Die zwei ursprünglichen Fälle aus dem Issue (`bash_gate.py` `->`/`json.dumps`, `tdd_enforcement.py` Worktree-Artefaktpfad) sind ebenfalls bereits gemergt (henemm/agent-os-openspec#92).

## Test plan
- [x] 42 Tests, TDD RED→GREEN über 5 Runden dokumentiert
- [x] Adversary: 4× BROKEN (F001/F002 Launcher-Bypass, F005 Flag-Wert-Fehlklassifizierung, F006/F007 Launcher+Flag-Bypass + Pfad-Interpreter, F-ADV1 `_args_after`-Segmentgrenze), final HOLDS — 12/12 AC bewiesen, Mutationsgegenprobe wirksam
- [x] Kein externer Caller der geänderten Funktionen (Regressionsrisiko ausgeschlossen)
- [ ] CI-Ampel grün abwarten

Bezieht sich auf #1478 (Issue wird NICHT automatisch geschlossen — manuelles Close erst nach vollständiger Prüfung)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SruqXq4DU8Eweoj3Sa7HWL