### PR TITLE
feat(#1660 A): Tages-Tief/Hoch/Nacht getrennt wählbar, gemessen und gefühlt

### DIFF
--- a/docs/context/fix-1660-a-temp-trennung.md
+++ b/docs/context/fix-1660-a-temp-trennung.md
@@ -1,0 +1,87 @@
+# Context: fix-1660-a-temp-trennung
+
+## Request Summary
+
+Issue #1660 Slice A (PO-beauftragt 2026-08-09): Tages-Tief, Tages-Hoch und
+Nacht-Tief sollen — jeweils für gemessene UND gefühlte Temperatur — unabhängig
+voneinander wählbar sein und in allen Kanälen (SMS zuerst, konsistent auch
+Mail/Telegram) wirken. Vorbild: #1484 hat exakt das für die gemessene
+Nacht-Tiefsttemperatur (`temperature_night`, Token `N`) geliefert; die
+gefühlte Nacht (`FN`) wurde dort als Folgeschnitt ausdrücklich abgegrenzt
+(`feat_1484_night_temp_metric.md`, Abgrenzung 1).
+
+## Zwei Mechanismen, keine neuen UI-Flächen
+
+1. **Nacht-Abspaltung gefühlt (`FN`):** neuer Katalogeintrag analog
+   `temperature_night` — Muster 1:1 aus #1484 übertragbar.
+2. **Tages-Tief ↔ Tages-Hoch (`K`↔`D`, `FK`↔`FD`):** über die BESTEHENDE
+   Aggregations-Auswahl (`MetricConfig.aggregations`, UI seit #1357:
+   `frontend/.../weather-metrics-tab/aggregationSelection.ts`). Die
+   E-Mail-Pfade lesen sie seit #1357 (`email/compact.py:174`,
+   `email/plain.py:203`, `email/html.py:1430`) — die SMS-Kette liest sie
+   NICHT. PO-Vorgabe aus #1660: keine neue Editor-Fläche bauen; die
+   Pro-Kanal-Kaskade (#429/#434) liefert `MetricConfig` inkl. `aggregations`
+   bereits kanalgenau (`models.py::get_metrics_for_channel`, von
+   `trip_report.py:291` für SMS gelesen).
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `src/app/metric_catalog.py:139-150` | Vorbild `temperature_night`; neuer Eintrag `wind_chill_night` daneben |
+| `src/output/renderers/sms_trip.py:118-123` | `SMS_MULTI_SYMBOLS_BY_METRIC`: `wind_chill: (FN,FK,FD,WC)` aufteilen |
+| `src/output/renderers/trip_report.py:285-333` | SMS-Spec-Aufbau aus Kanal-Kaskade; hier muss die Aggregations-Gate-Logik für K/D/FK/FD rein |
+| `src/output/tokens/builder.py:262-304` | Sechs Temperatur-Token; je Symbol eigene `MetricSpec` — Schichtgrenze: importiert nichts aus `src/app/` |
+| `src/services/segment_weather.py:395-407` | `night_weather_needed()`: um `wind_chill_night` erweitern (#1484 AC-8-Analogon) |
+| `src/output/renderers/compact_summary.py:195-198,338-347` | Gefühlte Nacht-Untergrenze hängt an `wind_chill` → auf `wind_chill_night` umbinden |
+| `src/output/renderers/narrow.py:501-522` | Telegram-Abendübersicht: Nachtwert für `wind_chill` → an neue Größe binden |
+| `src/output/renderers/trip_metric_ids.py` | Bestandsdaten-Ableitung (#1484-Muster `derived=True`) — `wind_chill_night` ergänzen |
+| `frontend/.../weather-metrics-tab/aggregationSelection.ts` | Bestehende min/max-Auswahl — KEINE Änderung erwartet, nur Verifikation |
+| `internal/model/alert_metric_mapping.generated.json` | Paritätstest bedienen (kein `alert_metrics` am neuen Eintrag → kein Mapping-Eintrag) |
+
+## Existing Patterns
+
+- **#1484 komplett als Blaupause:** Katalogeintrag ohne `summary_fields`/
+  `alert_metrics`, Bestandsableitung beim Lesen (aktiviert gdw. Elternmetrik
+  aktiv, `derived=True`, nie serialisiert), `night_weather_needed()` teilt
+  Versand/Vorschau, Abend-Gate bleibt in `builder.py` (`evening_only`).
+- **Aggregations-Lesen:** `{mc.metric_id: mc.aggregations for mc in ...}` —
+  Muster aus `email/html.py:1430`; für SMS analog aus
+  `get_metrics_for_channel("sms", report_type)` ableitbar.
+- **Kürzel-Ratsche:** `tests/unit/test_sms_token_symbol_register_ratchet.py`
+  sichert Register↔`tokens/`-Literale; `builder.py` bleibt literal.
+
+## Dependencies
+
+- Upstream: Kanal-Kaskade (#429/#434/#1575), Nachtfenster-Berechnung
+  (`day_window.night_wind_chill_min_c`), Aggregations-Persistenz (#1357).
+- Downstream: SMS-Fidelity-Vorschau (`carried_ids`, vgl. #923b), Telegram-
+  Kurzform (= SMS-Prüfweg), `briefing_mail_validator` (Mail-Pfad),
+  Golden-E-Mail-Tests (dürfen bit-identisch bleiben, solange Default-
+  Aggregationen unverändert).
+
+## Existing Specs
+
+- `docs/specs/modules/feat_1484_night_temp_metric.md` — Vorbild + Abgrenzung 1
+- `docs/specs/modules/night_temp_evening_only.md` — Abend-Gate (DEC-1/DEC-2)
+- `docs/specs/modules/sms_daywindow_aggregation.md` — Tagesfenster-Werte
+- `docs/specs/modules/sms_format.md` — Token-Grammatik v2.x
+
+## Risks & Considerations
+
+- **WC (Wintersport-Tageskennzahl)** hängt mit an `wind_chill` — bei der
+  Aufteilung entscheiden, ob WC bei `wind_chill` bleibt (empfohlen: ja, es
+  ist ein Tageswert) — sonst Regression #1450.
+- **Default-Aggregationen:** `temperature`/`wind_chill` haben heute
+  `("min","max")` als Default → Bestands-Trips zeigen K+D/FK+FD weiter beide;
+  nur eine BEWUSSTE Abwahl im Editor darf ein Token entfernen (kein stiller
+  Verlust, Analogie #1484 AC-6/AC-7).
+- **`aggregations` enthält ggf. auch "avg"** (Temperatur-Default war mal
+  min/max/avg) — Gate darf nur min→K, max→D abbilden, avg ignorieren.
+- **Kanal-Konsistenz:** Die Aggregations-Abwahl wirkt in Mail seit #1357 —
+  nach diesem Schnitt zusätzlich in SMS; Telegram-Kurzform folgt dem SMS-Weg.
+  Prüfen, dass narrow/compact_summary (eigene Untergrenzen-Logik) nicht
+  widersprechen.
+- **Schichtgrenze `output/tokens/`:** keine Register-Importe; Steuerung
+  ausschließlich über `MetricSpec.enabled` je Symbol (bestehender Weg über
+  `disabled_specs` in `trip_report.py`).

--- a/docs/reference/sms_briefing_overview.md
+++ b/docs/reference/sms_briefing_overview.md
@@ -56,7 +56,7 @@ Feste Reihenfolge (POSITIONAL, `sms_format.md:44`):
 | `N` | Nacht-Tief-Temperatur °C am Schlafplatz | `N8`, `N-12` | nur abends (Issue #1319 Scheibe D) — im Morgenbriefing entfällt der Token komplett |
 | `K` | Tiefst-Temperatur °C **unterwegs** (kälteste Gehzeit-Stunde) — beantwortet eine andere Frage als `N` | `K6`, `K-12`, `K-` | ja (Issue #1410, morgens **und** abends) |
 | `D` | Tag-/Höchst-Temperatur °C | `D24`, `D-` | ja |
-| `FN` | **Gefühlte** Nacht-Tief-Temperatur °C am Schlafplatz | `FN6`, `FN-` | nur abends, nur wenn die Wettergröße „Gefühlte Temperatur" im Trip aktiviert ist (Issue #1410) |
+| `FN` | **Gefühlte** Nacht-Tief-Temperatur °C am Schlafplatz | `FN6`, `FN-` | nur abends, nur wenn die eigene Wettergröße „Gefühlte Nacht-Tiefsttemperatur" im Trip aktiviert ist (`wind_chill_night`, Issue #1660; vorher an „Gefühlte Temperatur" gekoppelt, Issue #1410) |
 | `FK` | **Gefühlte** Tiefst-Temperatur °C unterwegs | `FK4`, `FK-` | nur wenn „Gefühlte Temperatur" aktiviert ist |
 | `FD` | **Gefühlte** Höchst-Temperatur °C | `FD13`, `FD-` | nur wenn „Gefühlte Temperatur" aktiviert ist |
 | `R` | Regen (mm) | `R0.2@6(1.4@16)` / `R-` | ja |

--- a/docs/reference/sms_format.md
+++ b/docs/reference/sms_format.md
@@ -1,10 +1,10 @@
 ---
 entity_id: sms_format
 type: reference
-version: "2.18"
+version: "2.21"
 status: active
 created: 2025-12-27
-updated: 2026-08-05
+updated: 2026-08-09
 tags: [sms, compact, tokens, single-source-of-truth]
 ---
 
@@ -13,7 +13,7 @@ tags: [sms, compact, tokens, single-source-of-truth]
 - [x] Approved (v2.0 am 2026-04-25)
 - [x] Implementiert in SMS-Adapter via `src/output/renderers/sms/` (β3, 2026-04-28)
 
-# SMS / Kompakt-Format Specification (v2.18)
+# SMS / Kompakt-Format Specification (v2.21)
 
 **Single Source of Truth** für die kompakte Token-Zeile, die in allen Channels (SMS, Satellit, E-Mail-Header, Push) identisch verwendet wird. Alle anderen Repräsentationen (E-Mail-Body, Tabellen, Push-Titel) leiten sich aus dieser Token-Zeile ab.
 
@@ -50,7 +50,7 @@ Diese Spec ersetzt v1.0 und integriert das Format aus dem Vorgänger-Projekt (`w
 | Header | `{Name}:` | immer |
 | Forecast (Nacht) | `N` | **nur Abendbriefing** (Issue #1319 Scheibe D) — im Morgenbriefing entfällt der Token komplett, nicht als `N-` — UND nur bei aktivierter Metrik „Nacht-Tiefsttemperatur“ (`temperature_night`, Issue #1484; bis dahin an „Temperatur“ gekoppelt, Issue #1415) |
 | Forecast (Tiefst unterwegs) | `K` | Morgen + Abend (Issue #1410) — kälteste Gehzeit-Stunde, von `N` unterschieden — nur bei aktivierter Metrik „Temperatur“ (Issue #1415) |
-| Forecast (gefühlt, Nacht) | `FN` | **nur Abendbriefing** UND nur bei aktivierter Metrik „Gefühlte Temperatur“ |
+| Forecast (gefühlt, Nacht) | `FN` | **nur Abendbriefing** UND nur bei aktivierter Metrik „Gefühlte Nacht-Tiefsttemperatur“ (`wind_chill_night`, Issue #1660; bis dahin an „Gefühlte Temperatur“ gekoppelt, Issue #1410) |
 | Forecast (gefühlt) | `FK FD` | Morgen + Abend, aber nur bei aktivierter Metrik „Gefühlte Temperatur“ |
 | Forecast (Höchst) | `D` | Morgen + Abend, nur bei aktivierter Metrik „Temperatur“ (Issue #1415) |
 | Forecast | `R PR W G TH:` | nur bei aktivierter Metrik (bei `-` als Null-Wert) |
@@ -67,7 +67,7 @@ Diese Spec ersetzt v1.0 und integriert das Format aus dem Vorgänger-Projekt (`w
 
 **Hinweis zu `N` (Issue #1319 Scheibe D, 2026-07-23):** Im Abendbriefing ist `N` das erste Forecast-Token wie oben dargestellt. Im Morgenbriefing entfällt `N` vollständig aus der Zeile (nicht `N-`) — die Reihenfolge rutscht entsprechend nach: `{Name}: K D FK FD R PR W G TH: TH+: ...`.
 
-**Hinweis zu `K`/`FK`/`FD`/`FN` (Issue #1410, 2026-07-28):** `K` ist die Tiefsttemperatur **unterwegs** (kälteste Gehzeit-Stunde) und steht unabhängig neben `N` (Nacht am Schlafplatz) — beide erscheinen abends gemeinsam (`N` seit Issue #1484 nur bei gewählter eigener Metrik „Nacht-Tiefsttemperatur“), morgens nur `K`. Das `F`-Präfix bezeichnet die **gefühlte** Temperatur (`FN`/`FK`/`FD` als Parität zu `N`/`K`/`D`); diese drei erscheinen ausschliesslich, wenn die Metrik „Gefühlte Temperatur“ (`wind_chill`) im Trip aktiviert ist.
+**Hinweis zu `K`/`FK`/`FD`/`FN` (Issue #1410, 2026-07-28; Kürzel-Bindung nachgezogen durch Issue #1660, 2026-08-09):** `K` ist die Tiefsttemperatur **unterwegs** (kälteste Gehzeit-Stunde) und steht unabhängig neben `N` (Nacht am Schlafplatz) — beide erscheinen abends gemeinsam (`N` seit Issue #1484 nur bei gewählter eigener Metrik „Nacht-Tiefsttemperatur“), morgens nur `K`. Das `F`-Präfix bezeichnet die **gefühlte** Temperatur (`FN`/`FK`/`FD` als Parität zu `N`/`K`/`D`). `FN` folgt seit Issue #1660 — wie `N` seit #1484 — der eigenen wählbaren Metrik „Gefühlte Nacht-Tiefsttemperatur“ (`wind_chill_night`), statt wie zuvor an „Gefühlte Temperatur“ zu hängen. `FK`/`FD` bleiben an „Gefühlte Temperatur“ (`wind_chill`) gekoppelt und folgen seit #1660 zusätzlich der dortigen Auswertungswahl (#1357): nur bei gewähltem „Tiefstwert“ erscheint `FK`, nur bei gewähltem „Höchstwert“ `FD`. Für `K`/`D` bei der Metrik „Temperatur“ gilt seither dieselbe Regel (min→`K`, max→`D`).
 
 **Grundregel „gewählt / nicht gewählt” (PO-Entscheidung 2026-08-03, Issue #1415):** Für **jedes** Vorhersage-Kürzel gilt: geprüft, aber nichts über der Schwelle bzw. kein Wert ⇒ Null-Form (`R-`, `K-`); Metrik im Trip **abgewählt** ⇒ das Kürzel entfällt vollständig, auch die Null-Form. Eine dritte Stufe „Wert nicht abrufbar / Datenlücke im Fenster ⇒ `R?`” (#1328) gibt es bei den Schwellwert-Kürzeln `R`/`PR`/`W`/`G`/`TH:`/`TH+:` (`TH+:` seit Fix #1482, 2026-08-04) **und** seit Fix #1483 (2026-08-05, s. „Bekannte Ist-Abweichungen”) auch bei den Temperatur-Kürzeln `N`/`K`/`D`/`FN`/`FK`/`FD` (s. §4). Es gibt damit **keine unbedingten Vorhersage-Token** mehr: `N`/`K`/`D` (Metrik „Temperatur”) verhalten sich seit #1415 exakt wie `FN`/`FK`/`FD` (Metrik „Gefühlte Temperatur”), und `TH+:` verhält sich seit #1482 exakt wie `TH:`. Die Bindung Kürzel→Metrik liegt an genau einer Stelle: `SMS_MULTI_SYMBOLS_BY_METRIC` (mehrere Kürzel je Metrik) bzw. `SMS_SYMBOL_BY_METRIC` (1:1) in `src/output/renderers/sms_trip.py`, ausgewertet in `trip_report.py` (`disabled_specs` → `output/tokens/builder.py::_visible()`).
 
@@ -109,7 +109,7 @@ Diese Spec ersetzt v1.0 und integriert das Format aus dem Vorgänger-Projekt (`w
 | `N{temp}` / `N-` (**nur Abendbriefing**, nur bei aktivierter Metrik „Nacht-Tiefsttemperatur“, Issue #1484) | Nacht-Tiefsttemperatur °C am Schlafplatz, ganzzahlig — Fenster Ankunft→06:00 Folgetag am Etappenziel, NICHT das Tagessegment-Minimum. Im Morgenbriefing entfällt der Token komplett (kein `N-`). | `night_temp_min_c()` aus `night_weather` (Fallback: Tagessegment-`temp_min_c`, wenn `night_weather` fehlt/leer) | `N9` |
 | `K{temp}` / `K-` (nur bei aktivierter Metrik „Temperatur“) | Tiefsttemperatur **unterwegs** °C, ganzzahlig — kälteste Stunde der Gehzeit. Erscheint in BEIDEN Report-Typen und ist von `N` (Nacht am Schlafplatz) zu unterscheiden. | `day_window.collect_hiking_window_points()` → `hiking_field_min_max("t2m_c")`, MIN (Issue #1417) | `K3` |
 | `D{temp}` / `D-` (nur bei aktivierter Metrik „Temperatur“) | Tag-Max °C, ganzzahlig — genauer: Höchstwert **während der Gehzeit**, nicht der Kalendertag (s. Hinweis unter der Tabelle) | dieselbe Quelle wie `K`, MAX | `D24` |
-| `FN{temp}` / `FN-` (**nur Abendbriefing**, nur bei aktivierter Metrik) | **Gefühlte** Nacht-Tiefsttemperatur °C am Schlafplatz — Parität zu `N`, gleiches Fenster Ankunft→06:00 Folgetag. | `night_wind_chill_min_c()` aus `night_weather` (Fallback: Gehzeit-`wind_chill_min_c`) | `FN6` |
+| `FN{temp}` / `FN-` (**nur Abendbriefing**, nur bei aktivierter Metrik „Gefühlte Nacht-Tiefsttemperatur“, `wind_chill_night`, Issue #1660) | **Gefühlte** Nacht-Tiefsttemperatur °C am Schlafplatz — Parität zu `N`, gleiches Fenster Ankunft→06:00 Folgetag. | `night_wind_chill_min_c()` aus `night_weather` (Fallback: Gehzeit-`wind_chill_min_c`) | `FN6` |
 | `FK{temp}` / `FK-` (nur bei aktivierter Metrik) | **Gefühlte** Tiefsttemperatur unterwegs °C — Parität zu `K`, identisches Gehzeit-Fenster. | dieselbe Quelle wie `K`, aber `hiking_field_min_max("wind_chill_c")`, MIN | `FK1` |
 | `FD{temp}` / `FD-` (nur bei aktivierter Metrik) | **Gefühlte** Höchsttemperatur während der Gehzeit °C — Parität zu `D`. | dieselbe Quelle wie `FK`, MAX | `FD18` |
 | `R{mm}@{h}({max}@{h})` / `R-` | Regen Threshold@Stunde + Peak | Hourly `precip_1h_mm`, Threshold aus `config.rain_amount_threshold` | `R0.2@6(1.4@16)` |
@@ -341,7 +341,8 @@ Nur in Dry-Run / Debug-Modus angehängt, ansonsten weggelassen.
 | `N` (nur Abend) | `N-` | Bei fehlender Nacht-Temperatur — **nur im Abendbriefing**; im Morgenbriefing fehlt der Token komplett (kein `N-`). **Nur** bei aktivierter Metrik „Nacht-Tiefsttemperatur“ (Issue #1484, vorher „Temperatur“ per #1415) — zur zusätzlichen `?`-Form bei Datenlücke s. Hinweis unten |
 | `K` | `K-` | Bei fehlender Gehzeit-Tiefsttemperatur — **nur** bei aktivierter Metrik „Temperatur“ (Issue #1415) — zur zusätzlichen `?`-Form bei Datenlücke s. Hinweis unten |
 | `D` | `D-` | Bei fehlender Tag-Temperatur — **nur** bei aktivierter Metrik „Temperatur“ (Issue #1415) — zur zusätzlichen `?`-Form bei Datenlücke s. Hinweis unten |
-| `FN` / `FK` / `FD` | `FN-` / `FK-` / `FD-` | **Nur** bei aktivierter Metrik „Gefühlte Temperatur“, wenn lediglich die Daten fehlen. Ist die Metrik nicht gewählt, erscheint gar nichts — auch keine Null-Form (Issue #1410) — zur zusätzlichen `?`-Form bei Datenlücke s. Hinweis unten |
+| `FN` | `FN-` | **Nur** bei aktivierter Metrik „Gefühlte Nacht-Tiefsttemperatur“ (`wind_chill_night`, Issue #1660; vorher „Gefühlte Temperatur“, Issue #1410), wenn lediglich die Daten fehlen. Ist die Metrik nicht gewählt, erscheint gar nichts — auch keine Null-Form — zur zusätzlichen `?`-Form bei Datenlücke s. Hinweis unten |
+| `FK` / `FD` | `FK-` / `FD-` | **Nur** bei aktivierter Metrik „Gefühlte Temperatur“ UND passender Auswertungswahl (min→`FK`, max→`FD`, Issue #1660), wenn lediglich die Daten fehlen. Ist die Metrik nicht gewählt oder die Auswertungswahl passt nicht, erscheint gar nichts — auch keine Null-Form (Issue #1410) — zur zusätzlichen `?`-Form bei Datenlücke s. Hinweis unten |
 | `R` / `PR` | `R-` / `PR-` | Bei fehlendem oder Sub-Threshold-Niederschlag |
 | `W` / `G` | `W-` / `G-` | Bei fehlendem oder Sub-Threshold-Wind |
 | `TH` / `TH+` | `TH:-` / `TH+:-` | Bei fehlendem oder Sub-Threshold-Gewitter — zur zusätzlichen `?`-Form bei Datenlücke s. Hinweis unten |
@@ -542,6 +543,7 @@ Implementationen, die SMS-Text und E-Mail-Subject getrennt erzeugen, sind als **
 | 2.18 | 2026-08-05 | Temperatur-Kürzel zeigen jetzt `?` bei Datenlücke (Fix #1483) — löst die in v2.15 unter §2 vermerkte Ist-Abweichung auf: `N`/`K`/`D`/`FN`/`FK`/`FD` zeigten bei einer Datenlücke im ausgewerteten Fenster bislang fälschlich `-` statt `?`, obwohl die Schwellwert-Kürzel `R`/`PR`/`W`/`G`/`TH:`/`TH+:` diesen Fall längst über dieselbe Regel signalisierten. Umsetzung: neuer gemeinsamer Helfer `_gap_or()` (`builder.py:120-130`), extrahiert aus der bisherigen Inline-Zeile in `_mk_metric()` (Zeile 150) und zusätzlich von der Temperatur-Schleife in `build_token_line()` (Zeile 299) genutzt — reines Verhaltens-Angleichen, keine neue Bedingung. `_wintersport()` bleibt bewusst unverändert und zeigt weiterhin nie `?` (kein gemeinsamer Aufrufpfad mit `_gap_or()`). Betrifft §2 (Grundregel-Absatz, Bekannte Ist-Abweichungen), §4 (Null-Repräsentation, `?`-Form-Hinweis). Spec: `docs/specs/modules/fix_1483_temp_gap_marker.md`. |
 | 2.19 | 2026-08-05 | Der `!`-Warn-Block-Filter (§3.4c) ist für **Trips** keine feste Grenze mehr — Issue #1461 S3b-2a lässt die bisher fest verdrahtete `MIN_SMS_LEVEL`-Schwelle (orange) in der neuen, je Alarm-Kanal einstellbaren Kanal-Schwelle (`Trip.alert_channel_thresholds`) aufgehen. Startwert **gering** je Kanal ⇒ der Trip-Briefing-SMS-/Telegram-Text zeigt künftig auch **gelbe** (Stufe 2) amtliche Warnungen, die vorher nie erschienen; die alte feste Grenze bleibt nur erhalten, wenn der Nutzer die Schwelle bewusst auf „mittel“ oder höher setzt. Der Alarm-**Versand** (`render_official_alert_sms`) war schon vorher ungefiltert und bleibt unverändert. Der **Ortsvergleich** (`comparison.py`) behält den festen Vorgabewert, bis Folgescheibe S3b-2b ihn nachzieht. §2 (Token-Tabelle) und §3.4c entsprechend präzisiert. ADR-0046, Spec: `docs/specs/modules/feat_1461_s3b2a_kanal_schwelle.md`. |
 | 2.20 | 2026-08-06 | Folgescheibe S3b-2b: der `!`-Warn-Block-Filter des **Ortsvergleichs** (`comparison.py`) geht ebenfalls auf die Startschwelle „gering" über — `render_compare_sms`/`render_compare_telegram` rufen den geteilten Kern jetzt mit `min_official_level_for_threshold("LOW")` statt des vormals festen `MIN_SMS_LEVEL` (orange). Der Compare-SMS-/Telegram-Bericht zeigt künftig auch **gelbe** (Stufe 2) amtliche Warnungen, die vorher nie erschienen. Anders als beim Trip gibt es dafür keinen eigenen, je Kanal einstellbaren Bericht-Parameter — die neue Alarm-Kanal-Schwelle des Ortsvergleichs (`ComparePreset.alert_channel_thresholds`) regelt ausschließlich den Alarm-**Versand**, nicht diesen Bericht (derselbe Zielkonflikt wie beim Trip, gleiche Auflösung). §2 (Token-Tabelle) und §3.4c entsprechend präzisiert. ADR-0046, Spec: `docs/specs/modules/feat_1461_s3b2b_compare_kanal_schwelle.md`. |
+| 2.21 | 2026-08-09 | Temperatur-Trennung Scheibe A (Issue #1660): (1) `FN` hängt nicht mehr an „Gefühlte Temperatur" (`wind_chill`), sondern an der neuen eigenen wählbaren Metrik „Gefühlte Nacht-Tiefsttemperatur" (`wind_chill_night`) — exakt analog zu `N`/`temperature_night` seit #1484; `FK`/`FD`/`WC` bleiben bei `wind_chill`. (2) Die seit #1357 vorhandene Auswertungswahl (Spanne/Tiefstwert/Höchstwert/Mittelwert je Metrik) wirkt jetzt auch in der SMS: `K` nur bei gewähltem „Tiefstwert", `D` nur bei „Höchstwert" (Metrik „Temperatur"); `FK`/`FD` analog bei „Gefühlte Temperatur"; „Nur Mittelwert" entfernt beide Token der jeweiligen Größe ersatzlos, kein Rückfall auf die Spanne. `N`/`FN` sind von der Auswertungswahl unberührt (eigene Metriken ohne Auswertungswahl). Betrifft §2 (Token-Reihenfolge-Tabelle, Hinweis zu `K`/`FK`/`FD`/`FN`), §3.2 (`FN`-Zeile), §4 (Null-Repräsentation). Spec: `docs/specs/modules/fix_1660a_temp_trennung.md`. |
 
 **Quellen für v2.0:**
 - Vorgänger-Repo `henemm/weather_email_autobot`:

--- a/docs/specs/modules/fix_1660a_temp_trennung.md
+++ b/docs/specs/modules/fix_1660a_temp_trennung.md
@@ -1,0 +1,401 @@
+---
+entity_id: fix_1660a_temp_trennung
+type: module
+created: 2026-08-09
+updated: 2026-08-09
+status: draft
+version: "1.0"
+tags: [metrics, sms, briefing, editor, aggregation]
+---
+
+<!-- Issue #1660 Scheibe A — Tages-Tief/Hoch/Nacht getrennt waehlbar,
+     gemessen UND gefuehlt (Folge aus #1484) -->
+
+# Temperatur-Trennung: Tages-Tief, Tages-Hoch und Nacht getrennt wählbar
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Nach #1484 ist die **gemessene** Nacht-Tiefsttemperatur (`N`) eine eigene
+wählbare Größe; Tages-Tief und Tages-Hoch (`K`/`D`) hängen dagegen weiterhin
+gemeinsam an „Temperatur", und die **gefühlte** Seite (`FN`/`FK`/`FD`/`WC`)
+hängt komplett an „Gefühlte Temperatur". PO-Auftrag #1660 (2026-08-09): alle
+drei Zeitbezüge — Tages-Tief, Tages-Hoch, Nacht-Tief — sollen für gemessene
+und gefühlte Temperatur unabhängig voneinander wählbar sein und in allen
+Kanälen konsistent wirken.
+
+Diese Scheibe erreicht das mit **zwei Mechanismen und ohne eine einzige neue
+Bedienfläche**:
+
+1. **Nacht-Abspaltung gefühlt:** neuer Katalogeintrag `wind_chill_night`,
+   exakt nach dem Muster von `temperature_night` (#1484). Das Kürzel `FN`
+   wandert von `wind_chill` zur neuen Größe; `WC` bleibt bei `wind_chill`.
+2. **Tages-Tief ↔ Tages-Hoch über die bestehende Auswertungswahl:** die seit
+   #1357 vorhandene Einzelwahl je Größe (`Spanne` / `Nur Tiefstwert` /
+   `Nur Höchstwert` / `Nur Mittelwert`, gespeichert als
+   `MetricConfig.aggregations`) wirkt bisher nur in der E-Mail-Kachelzeile.
+   Die SMS-/Kurzform-Kette liest sie nicht und zeigt deshalb immer beide
+   Token. Nach dieser Scheibe gilt: `min` gewählt ⇒ `K`, `max` gewählt ⇒ `D`;
+   für die gefühlte Seite `FK`/`FD` analog.
+
+## Source
+
+### 1. Neuer Katalogeintrag `wind_chill_night`
+
+- **File:** `src/app/metric_catalog.py` — neuer `MetricDefinition` direkt
+  hinter `wind_chill` (heute Zeilen 151–173), gebaut **exakt** nach
+  `temperature_night` (Zeilen 139–150):
+  - `id="wind_chill_night"`, `label_de="Gefühlte Nacht-Tiefsttemperatur"`,
+    `unit="°C"`, `dp_field="wind_chill_c"`, `category="temperature"`
+  - `default_aggregations=("min",)` — dadurch liefert
+    `available_aggregations()` genau eine Möglichkeit, und
+    `showsAggregationChoice()` (Frontend) blendet die Auswertungswahl für
+    diese Größe von selbst aus. **Keine** neue UI-Regel nötig.
+  - **KEINE** `summary_fields` (⇒ keine Auswertungs-Pill, keine
+    Tabellenspalte), **KEINE** `alert_metrics`/`risk_thresholds`/
+    `sms_threshold`, **KEIN** `cmp`/`alert_label` — der Kälte-Alarm bleibt
+    vollständig bei `temperature_cold` (#914), der `wind_chill`-Risikowert
+    (`risk_thresholds={"high_lt": -20.0}`) bleibt bei `wind_chill`.
+  - `compact_label="TFN"` (Telegram-Kurzübersicht-Zeile, Pendant zu `TN`)
+  - `sms_code="FN"` — **kollisionsfrei geprüft** gegen alle 26 heutigen
+    `sms_code`-Werte (`D N TN TF HU DP W G WD R PR TH CP SL PT CT CL CM CH
+    VS SU UV HP NL SD NS`); `FN` kommt dort nicht vor. Grund für genau
+    diesen Wert: er ist identisch mit dem SMS-Token-Symbol, das die Größe
+    trägt — damit ist der Eintrag registerkonform im Sinne von #1435 E3b
+    (bei `temperature_night` war `N` durch `temperature_cold` belegt,
+    deshalb dort das Ersatzkürzel `TN`). Er wird für `carried_ids` der
+    SMS-Fidelity-Vorschau gebraucht (#923b AC-4).
+
+### 2. Kürzel-Bindung SMS
+
+- **File:** `src/output/renderers/sms_trip.py:119-124` —
+  `SMS_MULTI_SYMBOLS_BY_METRIC` aufteilen:
+  `"wind_chill": ("FK", "FD", "WC")` und `"wind_chill_night": ("FN",)`.
+  `"temperature": ("K","D")` und `"temperature_night": ("N",)` bleiben.
+- **File:** `src/output/tokens/builder.py:262-304` — **unverändert**. Die
+  Symbolliste (`N K D FN FK FD`), das Abend-Gate (`evening_only` für
+  `N`/`FN`) und die Null-Form-Regel bleiben wie sie sind; gesteuert wird
+  ausschließlich über `MetricSpec.enabled` je Symbol. Die Schichtgrenze
+  (`output/tokens/` importiert nichts aus `src/app/`) bleibt gewahrt.
+- **File:** `tests/unit/test_sms_token_symbol_register_ratchet.py:60-64` —
+  die Ausnahme-Begründung `"WC: vier Kuerzel fuer eine Groesse (Register:
+  TF)"` wird sachlich falsch (es sind nach der Aufteilung drei). Der
+  Kommentar ist mitzuziehen; die Ausnahme selbst bleibt bestehen.
+
+### 3. Bestandsdaten-Ableitung beim Lesen
+
+- **File:** `src/app/loader.py:800-816` — **hier** sitzt die #1484-Ableitung
+  (NICHT in `trip_metric_ids.py`; das Kontext-Dokument nennt die falsche
+  Datei). Zweiter, baugleicher Block für `wind_chill_night`:
+  fehlt der Eintrag in `display_config.metrics[]`, wird er mit
+  `enabled=<Zustand von wind_chill>`, `aggregations=[]`, `bucket="secondary"`,
+  `derived=True` ergänzt — und **nur dann**, wenn überhaupt ein
+  `wind_chill`-Eintrag existiert (leere Liste = Altbestand Fall A, bleibt
+  leer; Roundtrip-Invarianz).
+- **File:** `src/app/models.py` — `MetricConfig.derived` existiert bereits
+  (#1484), keine Modelländerung nötig. Der Filter, der abgeleitete Einträge
+  vom Zurückschreiben ausnimmt (`loader.py:1302` und `:1507`,
+  `getattr(mc, "derived", False)`), ist **generisch** und greift für den
+  neuen Eintrag automatisch — hier ist nichts zu ergänzen, aber AC-8 muss
+  es messen statt es anzunehmen.
+
+### 4. Nacht-Datenbeschaffung
+
+- **File:** `src/services/segment_weather.py:395-407` —
+  `night_weather_needed(dc)` zusätzlich um
+  `dc.is_metric_enabled("wind_chill_night")` erweitern. Sonst zeigt die
+  Vorschau ein `FN`, das still auf den Gehzeit-Tiefstwert zurückfällt
+  (`sms_trip.py:249-252`), während der Versand den echten Nachtwert trägt.
+
+### 5. Abend-Untergrenze E-Mail-Kurzzusammenfassung und Telegram
+
+- **File:** `src/output/renderers/compact_summary.py:171-203` — heute hängt
+  der gefühlte Teil ausschließlich an `"wind_chill" in enabled` und reicht
+  `night_wind_chill_min_c` unbedingt durch. Nach dem Muster der gemessenen
+  Seite (Zeilen 172-190): `felt_night_selected = "wind_chill_night" in
+  enabled`; Nachtwert nur dann durchreichen; ist **nur** die Nachtgröße
+  gewählt, entsteht die Einzelangabe über denselben Formatierer ohne
+  Tages-Aggregat (`elif`-Zweig analog Zeile 183-190).
+- **File:** `src/output/renderers/narrow.py:501-522` und `:714-735` — zwei
+  Stellen: (a) `_overview_line()` bindet die Abend-Untergrenze für
+  `metric_id == "wind_chill"` an `night_wind_chill_min_c`; das muss vom
+  Gewähltsein von `wind_chill_night` abhängen. (b) Die Schleife ab Zeile 720
+  braucht einen zweiten Zweig wie den für `temperature_night`: ist
+  `wind_chill` abgewählt und `wind_chill_night` gewählt, entsteht abends eine
+  eigene Zeile mit `compact_label` + Wert.
+
+### 6. Aggregations-Gate für K/D und FK/FD (SMS-Kette)
+
+- **File:** `src/output/renderers/trip_report.py:285-333` — die Menge der
+  SMS-Metriken kommt weiter aus der Kanal-Kaskade
+  (`_dc_uncollapsed.get_metrics_for_channel("sms", report_type)`, #1575
+  Scheibe 3). Die **Auswertungswahl** wird — wie schon `sms_threshold`
+  zwei Zeilen darüber (KL-4 aus #1575) — aus der **globalen** Metrikliste
+  `_global_metrics = {mc.metric_id: mc for mc in _dc_uncollapsed.metrics}`
+  gelesen, nicht aus dem Kanal-Layout. Siehe DEC-2.
+  Die bestehende Zeile
+  `MetricSpec(symbol=sym, enabled=metric_id in active_metric_ids)` bekommt
+  einen zweiten Faktor: für die vier Tages-Symbole zusätzlich das
+  Aggregations-Gate, für `N`/`FN` nicht (eigene Metriken, eigene Auswahl).
+- **File:** `src/output/renderers/email/html.py:1428-1431` — Referenzmuster
+  für das Lesen (`{mc.metric_id: mc.aggregations for mc in dc.metrics if
+  mc.enabled}`); **unverändert**, nur als Vorbild zitiert.
+
+### 7. Vier Stellen mit `temperature_night`-Sonderbehandlung (mitzuziehen)
+
+Der neue Eintrag ist wie `temperature_night` ein **Nachtfenster-Skalar**, kein
+Stundenwert. Ohne diese vier Ergänzungen erscheint eine Tabellenspalte
+„Gefühlte Nacht" mit Stundenwerten, die es gar nicht gibt:
+
+| File | Was |
+|------|-----|
+| `src/output/renderers/channel_layout.py:88` | Filter `!= "temperature_night"` → Menge `{"temperature_night","wind_chill_night"}` |
+| `src/output/renderers/email/helpers.py:97` | `NO_HOURLY_COLUMN_METRIC_IDS` um `wind_chill_night` |
+| `src/output/renderers/compare_hourly_metric_ids.py:59` | `HOURLY_EXCLUDED_METRIC_IDS` um `wind_chill_night` |
+| `src/output/renderers/compare_hourly_metric_ids.py:70-73` | `HOURLY_EXCLUSION_REASON` — Begründungstext für die Bedienfläche |
+
+### 8. Parität / Frontend
+
+- **Frontend:** KEINE neue Komponente, KEINE Änderung an
+  `frontend/src/lib/components/shared/weather-metrics-tab/aggregationSelection.ts`.
+  `WeatherMetricsTab` lädt den Katalog aus `GET /api/metrics`; der neue
+  Eintrag erscheint automatisch als Ankreuzfeld in der Temperatur-Kategorie.
+  Die Ausschlussliste `corridorEditorState.ts` braucht keinen Eintrag —
+  ohne `alert_metrics` taucht die Größe im Alarm-Mapping gar nicht auf
+  (bei #1484 vom Adversary belegt).
+- **File:** `internal/model/alert_metric_mapping.generated.json` — kein
+  `alert_metrics` ⇒ **kein** neuer Eintrag; der Paritätstest
+  (`test_alert_metric_mapping_parity.py`) muss ohne Regenerierung grün
+  bleiben. Läuft er rot, ist am Katalogeintrag zu viel deklariert.
+
+## Estimated Scope
+
+- **LoC:** ~100–140 produktiv über zwei Mechanismen (Katalogeintrag ~18,
+  Kürzel-Tabelle 3, Bestandsableitung ~13, `night_weather_needed` 3,
+  `compact_summary` ~14, `narrow` zwei Stellen ~20, vier
+  Sonderbehandlungs-Listen ~10, Aggregations-Gate `trip_report` ~20,
+  Ratschen-Kommentar 3)
+- **Files:** ~11 produktiv
+- **Effort:** medium–high
+
+> **⚠️ LoC-Limit:** Produktiv bleibt der Schnitt unter 250. **Mit den Tests
+> zu 14 Akzeptanzkriterien** (zwei Kanalseiten, beide Ableitungsrichtungen,
+> Zwei-Nutzer-Fall, Golden-Mail) ist das Gesamt-Delta realistisch bei
+> **300–400 LoC**. Ein `workflow.py set-field loc_limit_override 500` wird
+> voraussichtlich gebraucht — er ist **vorab beim PO einzuholen**
+> (CLAUDE.md: kein LoC-Override ohne Erlaubnis), nicht erst bei der
+> Blockade. Alternative, falls der PO den Schnitt kleiner will: Mechanismus 1
+> (gefühlte Nacht) und Mechanismus 2 (Aggregations-Gate) als zwei getrennte
+> Workflows fahren — sie sind technisch unabhängig.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `feat_1484_night_temp_metric` | Spec | Blaupause; hebt dort Abgrenzung 1 auf |
+| `night_temp_evening_only` | Spec | Abend-Gate (DEC-1/DEC-2) bleibt unverändert |
+| `trip_aggregation_selection` (#1357) | Spec | Quelle der Auswertungswahl (UI + Persistenz) |
+| Kanal-Kaskade #429/#434/#1575 | Feature | liefert die SMS-Metrikmenge |
+| `day_window.night_wind_chill_min_c` | Funktion | Wertquelle für `FN` |
+| `sms_format` | Spec | Token-Grammatik v2.x |
+
+## Entscheidungen (DEC)
+
+### DEC-1 — „Nur Mittelwert" entfernt in der SMS beide Tages-Token
+
+Die Auswertungswahl ist seit #1357 eine **Einzelwahl** (PO 2026-07-28: „Es
+gibt kein zusätzlich: entweder oder"). Für „Temperatur" ist `Nur Mittelwert`
+(`aggregations=["avg"]`) wählbar — die SMS kennt aber kein Mittelwert-Token.
+
+**Entscheidung:** `avg` wird ignoriert; sind weder `min` noch `max` gewählt,
+entfallen `K` **und** `D`. Wer ausdrücklich nur den Mittelwert will, will
+weder Tief noch Hoch — die E-Mail zeigt in dem Fall genau den Mittelwert-Pill,
+die SMS zeigt für diese Größe nichts. **Kein** Rückfall auf die Spanne: ein
+Rückfall würde die bewusste Wahl stillschweigend überstimmen.
+
+*Für „Gefühlte Temperatur" stellt sich die Frage nicht — der Katalog führt
+dort kein `avg`, also bietet die Oberfläche „Nur Mittelwert" gar nicht an.*
+
+### DEC-2 — Die Auswertungswahl ist eine globale Größe, kein Kanal-Layout-Feld
+
+`get_metrics_for_channel("sms", …)` kann `MetricConfig`-Objekte aus einem
+gespeicherten SMS-Kanal-Layout liefern. Kanal-Layouts führen **keine**
+Auswertungswahl; ihre `aggregations` fallen beim Laden auf den Default
+`["min","max"]` zurück (`loader.py:841/874`). Läse das Gate aus der Kaskade,
+wäre die Abwahl bei jedem Trip mit SMS-Kanal-Layout **wirkungslos** — ein
+lautloser Fehlschlag.
+
+**Entscheidung:** Menge der Metriken aus der Kaskade, Auswertungswahl aus der
+globalen Liste `_dc_uncollapsed.metrics`. Das ist exakt das Muster, das
+`sms_threshold` in derselben Funktion bereits verwendet (KL-4, #1575), und es
+hält SMS und E-Mail auf **derselben** Quelle (`html.py:1428` liest ebenfalls
+`dc.metrics`).
+
+## Bestandsdaten (PFLICHT-Regel aus CLAUDE.md)
+
+Zwei getrennte Bestandsfragen, beide **ohne Migrationslauf, ohne Replace**:
+
+1. **`wind_chill_night` fehlt im gespeicherten Config** ⇒ die Größe gilt als
+   aktiviert **genau dann, wenn `wind_chill` aktiviert ist**. Das heutige
+   Verhalten (`FN` hängt an der gefühlten Temperatur) bleibt für Altbestand
+   exakt erhalten. Erst ein bewusster Editor-Save materialisiert den
+   expliziten Eintrag — über den bestehenden Merge-Pfad
+   (`weather_config.go: mergeConfigMap`).
+2. **`aggregations` fehlt im gespeicherten Config** ⇒ `["min","max"]`
+   (`loader.py:787`) ⇒ `K`+`D` bzw. `FK`+`FD` erscheinen weiter beide.
+   Auch der Migrationspfad `loader.py:957` schreibt die Katalog-Vorgabe
+   (`temperature`: `min,max,avg`), enthält also min und max. **Kein
+   Bestands-Trip verliert durch diesen Schnitt ein Token** — nur eine
+   bewusste Abwahl im Editor entfernt eines.
+
+Trips ganz ohne `display_config` brauchen keine Sonderbehandlung: sie erhalten
+`build_default_display_config[_for_profile]`, das den neuen Eintrag über den
+Katalog-Default (`default_enabled=True`) mitführt.
+
+## Abgrenzungen (bewusst NICHT in dieser Scheibe)
+
+1. **`WC` bleibt bei `wind_chill`.** Die Wintersport-Kennzahl ist ein
+   Tageswert; ein Umhängen an die Nachtgröße wäre Regression #1450.
+2. **Keine Alarm-/Grenzwert-Funktion für `wind_chill_night`** — keine
+   `alert_metrics`, kein `sms_threshold`, kein `risk_thresholds`, nicht im
+   Korridor-Editor. Der Kältealarm bleibt bei `temperature_cold` (#914), der
+   gefühlte Risikowert bei `wind_chill`.
+3. **E-Mail-Nacht-Stundentabelle bleibt an `show_night_block`.** Sie ist eine
+   Tabellensektion mit eigenem Bedienelement, keine Metrik-Spalte.
+4. **Ortsvergleich: keine Sonderbehandlung** außer dem Stundenverlauf-
+   Ausschluss (Punkt 7 oben). Gleichziehen ist #1463.
+5. **Teil B von #1660 (fehlende Token) ist NICHT enthalten** — das ist ein
+   eigener Schnitt.
+6. **Keine neue Bedienfläche.** Weder eine Tief/Hoch-Auswahl neben der
+   Metrik-Auswahl noch eine Änderung an `aggregationSelection.ts`. Wird im
+   Verlauf der Umsetzung eine neue UI-Fläche nötig, ist das ein Stopp-Grund
+   und keine Erweiterung des Schnitts (PO-Vorgabe #1660).
+7. **Die `?`-/Null-Form-Logik aus #1415/#1483 bleibt unverändert**
+   (Datenlücke bei gewählter Größe ⇒ `FN-` bzw. `?`, abgewählt ⇒ Token
+   entfällt ganz).
+
+## Expected Behavior
+
+- **Input:** Metrik-Auswahl (Reiter Wertebereiche) für „Temperatur",
+  „Nacht-Tiefsttemperatur", „Gefühlte Temperatur", „Gefühlte
+  Nacht-Tiefsttemperatur" — jeweils an/aus; dazu die Auswertungswahl je
+  Tagesgröße (Spanne / nur Tiefstwert / nur Höchstwert / nur Mittelwert).
+- **Output:** Sechs Temperatur-Token der SMS/Telegram-Kurzform erscheinen
+  unabhängig voneinander: `N` an `temperature_night`, `FN` an
+  `wind_chill_night`, `K`/`D` an `temperature` **und** deren
+  Auswertungswahl, `FK`/`FD` an `wind_chill` **und** deren Auswertungswahl.
+  E-Mail-Kurzzusammenfassung und Telegram-Abendübersicht folgen derselben
+  Auswahl.
+- **Side effects:** Nacht-Wetterabruf wird auch dann ausgelöst, wenn nur
+  `wind_chill_night` (ohne `show_night_block`) gewählt ist.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip mit gewählter „Gefühlter Temperatur" und abgewählter „Gefühlter Nacht-Tiefsttemperatur" / When das Abend-Briefing als SMS erzeugt wird / Then enthält die SMS `FK`, `FD` und `WC`, aber kein `FN`-Token.
+  - Test: SMS-Rendering mit realistischem Forecast-Fixture (Nachtwert ≠ Tageswert), Assertion auf die Token-Menge.
+
+- **AC-2:** Given ein Trip mit gewählter „Gefühlter Nacht-Tiefsttemperatur" und abgewählter „Gefühlter Temperatur" / When das Abend-Briefing als SMS erzeugt wird / Then enthält die SMS `FN` mit dem Wert aus dem Nachtfenster (Ankunft→06:00), aber weder `FK` noch `FD` noch `WC`.
+  - Test: wie AC-1, umgekehrte Auswahl; der geprüfte Zahlenwert stammt aus dem Nachtfenster, nicht aus dem Gehzeit-Aggregat.
+
+- **AC-3:** Given ein Trip mit gewählter „Gefühlter Nacht-Tiefsttemperatur" / When das Morgen-Briefing erzeugt wird / Then erscheint kein `FN` — das bestehende Nur-Abends-Gate wirkt unverändert weiter.
+  - Test: Morgen-Rendering, Assertion auf Abwesenheit von `FN`; die bestehende Suite zum Abend-Gate bleibt grün.
+
+- **AC-4:** Given ein Trip mit gewählter „Temperatur" und der Auswertungswahl „Nur Höchstwert" / When das Briefing als SMS erzeugt wird / Then enthält die SMS `D`, aber kein `K` — und ein zusätzlich gewähltes `N` bleibt davon unberührt sichtbar.
+  - Test: SMS-Rendering mit `aggregations=["max"]` auf `temperature`, Assertion auf `D` vorhanden / `K` abwesend / `N` vorhanden (Abend).
+
+- **AC-5:** Given ein Trip mit gewählter „Gefühlter Temperatur" und der Auswertungswahl „Nur Tiefstwert" / When das Briefing als SMS erzeugt wird / Then enthält die SMS `FK`, aber kein `FD` — und ein zusätzlich gewähltes `FN` bleibt unberührt sichtbar.
+  - Test: SMS-Rendering mit `aggregations=["min"]` auf `wind_chill`, Assertion auf alle drei Symbole einzeln.
+
+- **AC-6:** Given ein Trip mit der Auswertungswahl „Nur Höchstwert" für „Temperatur" **und** einem gespeicherten SMS-Kanal-Layout (`channel_layouts.sms`) / When das Briefing als SMS erzeugt wird / Then wirkt die Abwahl trotzdem: die SMS enthält `D`, aber kein `K`.
+  - Test: Trip-Fixture mit befülltem `channel_layouts.sms` (dessen Einträge tragen keine `aggregations`), Rendering, Assertion auf `K` abwesend. *Dieser Test ist der Wächter für DEC-2 — ohne ihn wäre das Gate bei jedem kanal-konfigurierten Trip wirkungslos, ohne dass irgendetwas rot würde.*
+
+- **AC-7:** Given ein Trip mit gewählter „Temperatur" und der Auswertungswahl „Nur Mittelwert" / When das Briefing als SMS erzeugt wird / Then enthält die SMS weder `K` noch `D`; die Abend-E-Mail zeigt für diese Größe weiterhin den Mittelwert.
+  - Test: SMS-Rendering mit `aggregations=["avg"]`, Assertion auf beide Symbole abwesend; dazu ein E-Mail-Rendering, das den Mittelwert-Pill weiterhin nachweist (DEC-1, kein stiller Totalverlust der Größe über alle Kanäle).
+
+- **AC-8:** Given ein gespeicherter Bestands-Trip mit aktivierter „Gefühlter Temperatur" und **ohne** `wind_chill_night`-Eintrag / When der Trip geladen und das Abend-Briefing erzeugt wird / Then erscheint `FN` genau wie vor der Änderung, und ein anschließender Config-Save erhält alle übrigen `display_config`-Felder (Merge, kein Replace, kein Zurückschreiben des abgeleiteten Eintrags).
+  - Test: Roundtrip mit echtem Bestands-JSON-Fixture (Format wie `data/users/<uid>/trips/*.json`); geprüft wird sowohl das gerenderte Token als auch die gespeicherte Datei nach dem Save.
+
+- **AC-9:** Given ein gespeicherter Bestands-Trip mit **deaktivierter** „Gefühlter Temperatur" / When der Trip geladen wird / Then ist „Gefühlte Nacht-Tiefsttemperatur" abgeleitet AUS — es taucht kein neues Token unangefordert im Briefing auf.
+  - Test: Ableitung beide Richtungen, zusätzlich der Fall „Metrikliste komplett leer" (Altbestand ohne `display_config`) — dort wird **kein** Eintrag erfunden.
+
+- **AC-10:** Given „Gefühlte Nacht-Tiefsttemperatur" abgewählt und „Gefühlte Temperatur" gewählt / When die Abend-E-Mail-Kurzzusammenfassung und die Telegram-Abendübersicht erzeugt werden / Then erscheint dort keine gefühlte Nacht-Untergrenze, sondern der Gehzeit-Tiefstwert; bei umgekehrter Auswahl erscheint abends eine eigene Zeile mit dem Nachtwert — in beiden Kanälen.
+  - Test: `compact_summary`- und `narrow`-Rendering, beide Auswahlrichtungen, Vergleich der Zahlenwerte (Nachtwert ≠ Gehzeit-Tiefstwert im Fixture, sonst beweist der Test nichts).
+
+- **AC-11:** Given „Gefühlte Nacht-Tiefsttemperatur" gewählt und die Nacht-Stundentabelle (`show_night_block`) ausgeschaltet / When das Abend-Briefing über den Vorschau-Pfad erzeugt wird / Then zeigt `FN` das echte Nacht-Minimum, nicht still den Gehzeit-Tiefstwert.
+  - Test: Vorschau-/Scheduler-Pfad mit `show_night_block=False`, Fixture mit deutlich abweichendem Nachtwert, Assertion auf den Nachtwert.
+
+- **AC-12:** Given der Metrik-Katalog / When `GET /api/metrics` abgerufen wird / Then enthält die Antwort „Gefühlte Nacht-Tiefsttemperatur" als wählbare Größe der Temperatur-Kategorie; sie erscheint in **keiner** Stundentabelle (Trip-E-Mail wie Ortsvergleich), in **keinem** Kanal-Spaltenlayout und in **keinem** Alarm-Mapping.
+  - Test: API-Test gegen den Router (FastAPI TestClient) plus je eine Assertion gegen `render_for_channel()`, den Trip-Zeilenbauer und `internal/model/alert_metric_mapping.generated.json` (Paritätstest bleibt ohne Regenerierung grün).
+
+- **AC-13:** Given ein Trip mit unveränderten Vorgabe-Auswertungen (`min`+`max`) und ohne explizite Nacht-Einträge / When Trip-Briefing-E-Mail und SMS erzeugt werden / Then sind sie **zeichengleich** zum Stand vor dieser Änderung.
+  - Test: bestehende Golden-Mail-Tests bleiben bit-identisch grün; zusätzlich ein SMS-Vergleich gegen den erwarteten Token-String. *Das ist der Bestandsschutz-Nachweis: der Schnitt ändert nur, was jemand bewusst abwählt.*
+
+- **AC-14:** Given zwei verschiedene Nutzer mit entgegengesetzter Auswahl (Nutzer A: nur gefühlte Nacht, Auswertungswahl „Nur Höchstwert"; Nutzer B: nur gefühlter Tag, Auswertungswahl „Spanne") / When beide ihr Abend-Briefing erzeugen / Then wirkt jeweils nur die eigene Auswahl — keine Vermischung über `user_id`-Grenzen.
+  - Test: zwei User-Verzeichnisse unter `data/users/<uid>/`, zwei Renderings im selben Prozess, gegenläufige Assertions auf allen sechs Temperatur-Token.
+
+## Known Limitations
+
+- Die SMS kann keinen Tages-Mittelwert darstellen; „Nur Mittelwert" ist dort
+  gleichbedeutend mit „kein Temperatur-Token" (DEC-1). Wer das anders will,
+  braucht ein neues Token — außerhalb dieses Schnitts.
+- Die Auswertungswahl bleibt eine **globale** Größe je Metrik (DEC-2). Eine
+  pro-Kanal unterschiedliche Auswertung ist damit weiterhin nicht möglich.
+- `compact_label="TFN"` ist drei Zeichen lang; die Katalogkonvention nennt
+  „1–2 Großbuchstaben" für `sms_code` (dort: `FN`, zwei Zeichen), nicht für
+  `compact_label`. Falls ein bestehender Test die Länge des `compact_label`
+  prüft, ist `TF-N` **keine** Ausweichlösung — dann ist die Konvention im
+  Katalog zu klären, nicht der Wert zu verbiegen.
+- Die Kürzel-Ratsche behält ihre `wind_chill_c`-Ausnahme; sie bewacht die
+  vier bzw. drei Kürzel dieser Größe weiterhin nicht gegen das Register.
+
+## Prüfhinweis für den Adversary
+
+Leitfrage aus CLAUDE.md: **Ist die Zusicherung dort geprüft, wo sie WIRKT —
+oder nur dort, wo der Code steht?** Die vier Stellen, an denen hier ein
+grüner Testlauf ohne Wirkung entstehen kann:
+
+1. **AC-6 / DEC-2 (Quelle der Auswertungswahl).** Ein Test ohne
+   `channel_layouts.sms` im Fixture ist grün, egal ob das Gate aus der
+   Kaskade oder aus der globalen Liste liest. Erst das befüllte Kanal-Layout
+   trennt richtig von falsch.
+2. **AC-11 (Datenbeschaffung).** Ein Fixture, in dem Nachtwert und
+   Gehzeit-Tiefstwert zufällig gleich sind, beweist nichts.
+3. **AC-8/AC-9 (Ableitung beim Lesen).** Prüfen, dass die Ableitung im
+   **Ladepfad** (`loader.py`) wirkt und nicht nur im Katalog-Default —
+   ein Test, der `MetricConfig` von Hand baut, umgeht genau die Stelle.
+4. **AC-13 (Bestandsschutz).** Golden-Vergleiche müssen den **gerenderten
+   Text** vergleichen, nicht die Konfiguration.
+
+**Mutations-Gegenproben (Pflicht, per String-Ersetzung mit externer
+Sicherungskopie — nie `git checkout/stash/reset`):**
+
+- `SMS_MULTI_SYMBOLS_BY_METRIC["wind_chill"]` zurück auf
+  `("FN","FK","FD","WC")` drehen und den `wind_chill_night`-Eintrag
+  entfernen — welcher Test wird rot?
+- Im Aggregations-Gate `"min"` und `"max"` vertauschen (K an max, D an min)
+  — fängt das ein Test, oder prüfen alle nur „ein Token weniger"?
+- Die Aggregations-Quelle von `_dc_uncollapsed.metrics` auf die
+  Kanal-Kaskade umstellen — bleibt alles grün? Dann fehlt AC-6.
+- Das Gate zusätzlich auf `N`/`FN` anwenden (die abgeleiteten Nacht-Einträge
+  tragen `aggregations=[]`) — die Nacht-Token müssten verschwinden; fängt
+  das ein Test?
+- `night_weather_needed()` auf den Stand vor der Änderung zurücksetzen —
+  wird AC-11 rot, oder fällt `FN` still auf den Tageswert?
+- In `channel_layout.py` den `wind_chill_night`-Filter entfernen — entsteht
+  eine Geisterspalte, die kein Test bemerkt?
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Der Schnitt folgt zwei bereits getroffenen Entscheidungen
+  (#1484 Nacht-Abspaltung, #1357 Auswertungswahl) und schafft keine neue
+  Entscheidungsfläche. Er hebt lediglich Abgrenzung 1 aus
+  `feat_1484_night_temp_metric.md` planmäßig auf — dort ausdrücklich als
+  Folgeschnitt vorgesehen.
+
+## Changelog
+
+- 2026-08-09: Initial spec created (Issue #1660 Scheibe A)

--- a/src/app/loader.py
+++ b/src/app/loader.py
@@ -815,6 +815,21 @@ def _parse_display_config(data: Dict[str, Any]) -> "UnifiedWeatherDisplayConfig"
                 derived=True,
             ))
 
+    # Issue #1660 Scheibe A: baugleicher Ableitungsblock fuer die gefuehlte
+    # Seite -- fehlt "wind_chill_night" im gespeicherten Config, erbt sie den
+    # Zustand von "wind_chill". Abgeleitet wird NUR, wenn ein
+    # "wind_chill"-Eintrag existiert (Roundtrip-Invarianz).
+    if not any(mc.metric_id == "wind_chill_night" for mc in metrics):
+        _felt_entries = [mc for mc in metrics if mc.metric_id == "wind_chill"]
+        if _felt_entries:
+            metrics.append(MetricConfig(
+                metric_id="wind_chill_night",
+                enabled=any(mc.enabled for mc in _felt_entries),
+                aggregations=[],
+                bucket="secondary",
+                derived=True,
+            ))
+
     # Issue #429/#1394 (T4): kanal-spezifische Layouts laden (optional,
     # backward-compat). Wenn channel_layouts fehlt → None, damit
     # get_metrics_for_channel auf die globale Liste zurückfällt. Eine

--- a/src/app/metric_catalog.py
+++ b/src/app/metric_catalog.py
@@ -171,6 +171,29 @@ _METRICS: list[MetricDefinition] = [
         # neue Abkuerzungsregel, s. Spec compare_kanal_metriken.md Punkt 3).
         sms_code="TF",
     ),
+    # Issue #1660 Scheibe A: gefuehlte Nacht-Tiefsttemperatur am Etappenziel
+    # als EIGENE waehlbare Groesse, getrennt von "wind_chill" (FK/FD).
+    # Exakt nach dem Muster von "temperature_night" (#1484, s.o.) -- nur auf
+    # der gefuehlten Seite. Traegt das FN-Kuerzel der Trip-SMS (Bindung:
+    # sms_trip.SMS_MULTI_SYMBOLS_BY_METRIC), erscheint nur im Abend-Briefing.
+    # Der Wert entsteht im Nachtfenster (day_window.night_wind_chill_min_c),
+    # nicht aus einem Etappen-Aggregat -- deshalb keine summary_fields (=
+    # keine Auswertungs-Pill, keine Tabellenspalte) und keine
+    # Alarm-Deklaration (Kaeltealarm bleibt temperature_cold, der gefuehlte
+    # Risikowert bleibt bei "wind_chill"). "WC" (Wintersport-Tageskennzahl)
+    # bleibt bewusst bei "wind_chill" (Regression #1450, Spec-Abgrenzung 1).
+    MetricDefinition(
+        id="wind_chill_night", label_de="Gefühlte Nacht-Tiefsttemperatur",
+        unit="°C", dp_field="wind_chill_c", category="temperature",
+        default_aggregations=("min",),
+        compact_label="TFN", col_key="felt_night", col_label="NachtF",
+        providers={"openmeteo": True, "geosphere": True},
+        # sms_code = "FN": identisch mit dem SMS-Token-Symbol, das die
+        # Groesse traegt (#1435 E3b Registerkonformitaet) -- kollisionsfrei
+        # geprueft gegen alle heutigen sms_code-Werte des Katalogs.
+        sms_code="FN",
+        decimals=0,
+    ),
     MetricDefinition(
         id="humidity", label_de="Luftfeuchtigkeit", unit="%",
         dp_field="humidity_pct", category="temperature",

--- a/src/output/renderers/channel_layout.py
+++ b/src/output/renderers/channel_layout.py
@@ -82,10 +82,11 @@ def render_for_channel(
     Liste (Fallback) liefert.
     """
     enabled = dc.get_metrics_for_channel(channel, report_type)
-    # #1484: Nachtfenster-Skalar — nie eine Tabellenspalte/Detail-Zeile;
-    # den Wert tragen SMS-Token bzw. die Abend-Untergrenzen der
+    # #1484/#1660 Scheibe A: Nachtfenster-Skalare — nie eine Tabellenspalte/
+    # Detail-Zeile; den Wert tragen SMS-Token bzw. die Abend-Untergrenzen der
     # Kurzzusammenfassung/Telegram-Kurzuebersicht.
-    enabled = [m for m in enabled if m.metric_id != "temperature_night"]
+    _NIGHT_SCALAR_IDS = {"temperature_night", "wind_chill_night"}
+    enabled = [m for m in enabled if m.metric_id not in _NIGHT_SCALAR_IDS]
     primary = sorted(
         [m for m in enabled if m.bucket == "primary"], key=lambda m: m.order,
     )

--- a/src/output/renderers/compact_summary.py
+++ b/src/output/renderers/compact_summary.py
@@ -192,12 +192,27 @@ class CompactSummaryFormatter:
 
         # Issue #1410 (F2): der gefuehlte Temperaturteil steht direkt neben dem
         # gemessenen -- nur wenn die Metrik im Trip aktiviert ist.
+        # Issue #1660 Scheibe A: die gefuehlte Nacht-Untergrenze folgt der
+        # EIGENEN Groesse "wind_chill_night", nicht mehr unbedingt
+        # "wind_chill" (Muster der gemessenen Seite, Zeile 172-191).
+        felt_night_selected = "wind_chill_night" in enabled
         if "wind_chill" in enabled:
             ft = self._format_felt_temperature(
                 summary, report_type=report_type,
-                night_wind_chill_min_c=night_wind_chill_min_c,
+                night_wind_chill_min_c=(
+                    night_wind_chill_min_c if felt_night_selected else None
+                ),
                 hiking_felt_min_c=hiking_felt_min_c,
                 hiking_felt_max_c=hiking_felt_max_c,
+            )
+            if ft:
+                parts.append(ft)
+        elif felt_night_selected:
+            # Nur die gefuehlte Nachtgroesse gewaehlt: abends ihr Wert als
+            # Einzelangabe (derselbe Formatierer, ohne Tages-Aggregat).
+            ft = self._format_felt_temperature(
+                None, report_type=report_type,
+                night_wind_chill_min_c=night_wind_chill_min_c,
             )
             if ft:
                 parts.append(ft)

--- a/src/output/renderers/compare_hourly_metric_ids.py
+++ b/src/output/renderers/compare_hourly_metric_ids.py
@@ -56,7 +56,9 @@ for _legacy, _metric_id in FRONTEND_TO_HOURLY_METRIC_ID.items():
 # AC-11 (PO-Entscheid 2026-08-01): ausdruecklich vom Stundenverlauf
 # ausgenommene Groessen. BENANNTE Menge statt stillem Fehlen -- Bedienflaeche,
 # Aufloeser und Tests geben so dieselbe Auskunft.
-HOURLY_EXCLUDED_METRIC_IDS: frozenset[str] = frozenset({"sunshine", "temperature_night"})
+HOURLY_EXCLUDED_METRIC_IDS: frozenset[str] = frozenset(
+    {"sunshine", "temperature_night", "wind_chill_night"}
+)
 
 # Begruendung, die die Bedienflaeche anzeigt (ueber die Katalogantwort, s.
 # compare_metric_catalog.get_compare_metric_catalog). Nennt den Grund UND die
@@ -70,6 +72,10 @@ HOURLY_EXCLUSION_REASON: dict[str, str] = {
     "temperature_night": (
         "Nachtfenster-Skalar (#1484), kein Stundenwert — stuendlich "
         "beantwortet die Temperatur dieselbe Frage."
+    ),
+    "wind_chill_night": (
+        "Nachtfenster-Skalar (#1660), kein Stundenwert — stuendlich "
+        "beantwortet die gefuehlte Temperatur dieselbe Frage."
     ),
 }
 

--- a/src/output/renderers/email/helpers.py
+++ b/src/output/renderers/email/helpers.py
@@ -90,11 +90,13 @@ def should_merge_wind_dir(dc: UnifiedWeatherDisplayConfig) -> bool:
 # Row extraction (per-segment hourly + per-night-block aggregation)
 # ----------------------------------------------------------------------
 
-# Issue #1484: Groessen ohne Stundenspalten-Semantik — der Nachtfenster-
-# Skalar erscheint als SMS-Token bzw. Abend-Untergrenze, nie als Spalte.
-# EINE Quelle fuer alle Trip-Zeilen-Bauer (Pendant der Compare-Seite:
-# compare_hourly_metric_ids.HOURLY_EXCLUDED_METRIC_IDS).
-NO_HOURLY_COLUMN_METRIC_IDS: frozenset[str] = frozenset({"temperature_night"})
+# Issue #1484/#1660 Scheibe A: Groessen ohne Stundenspalten-Semantik — die
+# Nachtfenster-Skalare erscheinen als SMS-Token bzw. Abend-Untergrenze, nie
+# als Spalte. EINE Quelle fuer alle Trip-Zeilen-Bauer (Pendant der
+# Compare-Seite: compare_hourly_metric_ids.HOURLY_EXCLUDED_METRIC_IDS).
+NO_HOURLY_COLUMN_METRIC_IDS: frozenset[str] = frozenset(
+    {"temperature_night", "wind_chill_night"}
+)
 
 
 def dp_to_row(dp: ForecastDataPoint, dc: UnifiedWeatherDisplayConfig,

--- a/src/output/renderers/narrow.py
+++ b/src/output/renderers/narrow.py
@@ -717,6 +717,10 @@ def render_telegram_bubbles(
     # abends eine eigene Zeile mit dem Register-Kuerzel (TN).
     _enabled_ids = set(dc.get_enabled_metric_ids())
     _night_selected = "temperature_night" in _enabled_ids
+    # Issue #1660 Scheibe A: dieselbe Abspaltung jetzt auch fuer die
+    # gefuehlte Nacht-Untergrenze -- "wind_chill_night" statt unbedingt
+    # "wind_chill".
+    _felt_night_selected = "wind_chill_night" in _enabled_ids
     for mid in dc.get_enabled_metric_ids():
         if mid == "temperature_night":
             if ("temperature" in _enabled_ids or report_type != "evening"
@@ -727,10 +731,21 @@ def render_telegram_bubbles(
                 f"{get_metric('temperature_night').compact_label} "
                 f"{_night_min_c:.1f}"), _TG_PROSE_WIDTH))
             continue
+        if mid == "wind_chill_night":
+            if ("wind_chill" in _enabled_ids or report_type != "evening"
+                    or _night_felt_min_c is None):
+                continue
+            from app.metric_catalog import get_metric
+            overview_lines.extend(_wrap(_esc(
+                f"{get_metric('wind_chill_night').compact_label} "
+                f"{_night_felt_min_c:.1f}"), _TG_PROSE_WIDTH))
+            continue
         overview_lines.extend(_wrap(_esc(_overview_line(
             mid, seg_tables, fkeys, report_type=report_type,
             night_min_c=_night_min_c if _night_selected else None,
-            night_wind_chill_min_c=_night_felt_min_c,
+            night_wind_chill_min_c=(
+                _night_felt_min_c if _felt_night_selected else None
+            ),
             hiking_temp_extrema=_hiking_temp,
             hiking_felt_extrema=_hiking_felt,
             has_gap=has_gap,

--- a/src/output/renderers/sms_trip.py
+++ b/src/output/renderers/sms_trip.py
@@ -113,12 +113,16 @@ SMS_SYMBOL_BY_METRIC: dict[str, str] = {
 # (#624) -- ein zweiter Eintrag dort wuerde das Schwellwert-Dict verfaelschen.
 # Fix #1484 (PO-Entscheidung 2026-08-03): 'N' wandert von "temperature" zur
 # eigenen waehlbaren Groesse "temperature_night" -- Tages- und Nachttemperatur
-# sind zwei unabhaengige Auswahl-Entscheidungen (Zelt vs. Huette). 'FN' bleibt
-# bewusst bei "wind_chill" (Spec-Abgrenzung 1, feat_1484_night_temp_metric.md).
+# sind zwei unabhaengige Auswahl-Entscheidungen (Zelt vs. Huette).
+# Fix #1660 Scheibe A: dieselbe Trennung jetzt auch auf der gefuehlten Seite --
+# 'FN' wandert von "wind_chill" zur eigenen waehlbaren Groesse
+# "wind_chill_night". 'WC' (Wintersport-Tageskennzahl) bleibt bewusst bei
+# "wind_chill" (Regression #1450, Spec-Abgrenzung 1).
 SMS_MULTI_SYMBOLS_BY_METRIC: dict[str, tuple[str, ...]] = {
     "temperature": ("K", "D"),
     "temperature_night": ("N",),
-    "wind_chill": ("FN", "FK", "FD", "WC"),
+    "wind_chill": ("FK", "FD", "WC"),
+    "wind_chill_night": ("FN",),
     "thunder": ("TH:", "TH+:"),
 }
 

--- a/src/output/renderers/trip_report.py
+++ b/src/output/renderers/trip_report.py
@@ -331,6 +331,29 @@ class TripReportFormatter:
             for metric_id, syms in SMS_MULTI_SYMBOLS_BY_METRIC.items()
             for sym in syms
         ]
+        # Issue #1660 Scheibe A Mechanismus 2: die seit #1357 bestehende
+        # Auswertungswahl (MetricConfig.aggregations) gated zusaetzlich K/D
+        # bzw. FK/FD -- bisher las die SMS-Kette sie gar nicht (nur die
+        # E-Mail-Kachelzeile, email/html.py:1430). DEC-2: Quelle ist die
+        # GLOBALE Metrikliste (_global_metrics), NICHT die Kanal-Kaskade --
+        # gespeicherte Kanal-Layouts fuehren keine eigene Auswertungswahl und
+        # fallen beim Laden auf min+max zurueck (loader.py:841/874); laese
+        # das Gate aus der Kaskade, waere eine Abwahl bei jedem kanal-
+        # konfigurierten Trip wirkungslos (AC-6). DEC-1: 'avg' kennt die SMS
+        # nicht -- weder 'min' noch 'max' gewaehlt heisst BEIDE Token
+        # entfallen (nicht in _AGG_GATE_SYMBOLS aufgefuehrt: N/FN -- eigene
+        # Groessen ohne Auswertungswahl, #1484/#1660).
+        _AGG_GATE_SYMBOLS: dict[str, tuple[str, str]] = {
+            "K": ("temperature", "min"), "D": ("temperature", "max"),
+            "FK": ("wind_chill", "min"), "FD": ("wind_chill", "max"),
+        }
+        _disabled_sms_specs += [
+            MetricSpec(symbol=sym, enabled=False)
+            for sym, (metric_id, agg_key) in _AGG_GATE_SYMBOLS.items()
+            if metric_id in active_metric_ids
+            and metric_id in _global_metrics
+            and agg_key not in _global_metrics[metric_id].aggregations
+        ]
         # Issue #1461 S3b-2a: SMS-Kanal-Schwelle des Trips -> niedrigste
         # amtliche Warnstufe fuer den Kurznachrichten-Bericht (Startwert
         # 'gering', s. SMSTripFormatter.format_sms Docstring).

--- a/src/services/segment_weather.py
+++ b/src/services/segment_weather.py
@@ -396,10 +396,11 @@ def night_weather_needed(dc) -> bool:
     """Braucht dieser Trip Nachtdaten? (#1484 AC-8)
 
     Ja bei aktiver Nacht-Stundentabelle (``show_night_block``, bisheriges
-    Kriterium) ODER gewaehlter Nacht-Tiefsttemperatur — sonst zeigt die
-    Vorschau ein ``N``, das still auf den Tageswert zurueckfaellt, waehrend
-    der Versand den echten Nachtwert traegt. Geteilte Entscheidung fuer
-    preview_service; der Versand-Scheduler beschafft ohnehin immer.
+    Kriterium) ODER gewaehlter Nacht-Tiefsttemperatur (gemessen ODER
+    gefuehlt, #1660 Scheibe A) — sonst zeigt die Vorschau ein ``N``/``FN``,
+    das still auf den Tageswert zurueckfaellt, waehrend der Versand den
+    echten Nachtwert traegt. Geteilte Entscheidung fuer preview_service; der
+    Versand-Scheduler beschafft ohnehin immer.
 
     Issue #1651: ODER aktive Gewitter-Metrik — ab dieser Scheibe speisen die
     Nachtdaten zusaetzlich den Nacht-Zusatz des Vorschau-Satzes („nachts
@@ -415,6 +416,7 @@ def night_weather_needed(dc) -> bool:
         return False
     return bool(
         dc.is_metric_enabled("temperature_night")
+        or dc.is_metric_enabled("wind_chill_night")
         or dc.is_metric_enabled("thunder")
     )
 

--- a/tests/fixtures/shared_metric_format_parity/format_value_severity_grid.tsv
+++ b/tests/fixtures/shared_metric_format_parity/format_value_severity_grid.tsv
@@ -214,6 +214,15 @@ wind_chill	42	42°C	42	red
 wind_chill	137.0	137°C	137	red
 wind_chill	1013.0	1013°C	1013	red
 wind_chill	20000	20000°C	20000	red
+wind_chill_night	None	–	–	None
+wind_chill_night	-12.5	-12°C	-12	None
+wind_chill_night	0	0°C	0	None
+wind_chill_night	0.4	0°C	0	None
+wind_chill_night	7.5	8°C	8	None
+wind_chill_night	42	42°C	42	None
+wind_chill_night	137.0	137°C	137	None
+wind_chill_night	1013.0	1013°C	1013	None
+wind_chill_night	20000	20000°C	20000	None
 wind_direction	None	–	–	None
 wind_direction	-12.5	-12 °	-12	None
 wind_direction	0	0 °	0	None

--- a/tests/tdd/test_compact_summary_hiking_min_and_felt.py
+++ b/tests/tdd/test_compact_summary_hiking_min_and_felt.py
@@ -21,9 +21,13 @@ _DASH = "–"  # En-Dash, wie in der bestehenden Abend-Spanne
 
 def _summary(report_type: str, *, felt_enabled: bool = False, with_night: bool = True) -> str:
     # #1484: die Abend-Untergrenze (Nachtwert) braucht die eigene Nachtgroesse.
+    # #1660 Scheibe A: dieselbe Eigenstaendigkeit jetzt auch auf der
+    # gefuehlten Seite ("wind_chill_night") — ohne expliziten Eintrag bleibt
+    # die gefuehlte Abend-Untergrenze beim Gehzeit-Tiefstwert (F.dc() baut
+    # MetricConfig direkt, ohne die Bestandsableitung des Ladepfads).
     metrics = (
-        ("temperature", "temperature_night", "wind_chill") if felt_enabled
-        else ("temperature", "temperature_night")
+        ("temperature", "temperature_night", "wind_chill", "wind_chill_night")
+        if felt_enabled else ("temperature", "temperature_night")
     )
     return CompactSummaryFormatter().format_stage_summary(
         [F.segment()],

--- a/tests/tdd/test_felt_night_catalog_exclusions.py
+++ b/tests/tdd/test_felt_night_catalog_exclusions.py
@@ -1,0 +1,150 @@
+"""Katalogeintrag ``wind_chill_night`` (#1660 Scheibe A) -- waehlbar in der
+Temperatur-Kategorie, aber in KEINER Stundentabelle, KEINEM
+Kanal-Spaltenlayout und KEINEM Alarm-Mapping.
+
+Spec: docs/specs/modules/fix_1660a_temp_trennung.md — AC-12, Source Punkt 1
+(Katalogeintrag) und Punkt 7 (vier Sonderbehandlungs-Stellen, Muster
+``temperature_night``/#1484).
+
+Kern-Schicht, deterministisch: kein Mock, kein Netz. ``metrics_client``-
+Fixture 1:1 aus ``test_night_temp_own_metric_selection.py`` (Vorbild #1484)
+uebernommen.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.models import MetricConfig, UnifiedWeatherDisplayConfig
+
+NIGHT_METRIC = "wind_chill_night"
+
+
+@pytest.fixture
+def metrics_client() -> TestClient:
+    from api.routers import config
+
+    app = FastAPI()
+    app.include_router(config.router, prefix="/api")
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# AC-12 — Katalog & API
+# ---------------------------------------------------------------------------
+
+class TestCatalogAndApi:
+
+    def test_catalog_offers_felt_night_metric_as_selectable(self):
+        from app.metric_catalog import get_all_metrics
+
+        ids = {m.id for m in get_all_metrics()}
+        assert NIGHT_METRIC in ids, (
+            "„Gefuehlte Nacht-Tiefsttemperatur“ fehlt im waehlbaren Katalog."
+        )
+
+    def test_api_metrics_exposes_felt_night_next_to_wind_chill(self, metrics_client):
+        resp = metrics_client.get("/api/metrics")
+        assert resp.status_code == 200
+        catalog = resp.json()
+
+        by_id = {m["id"]: (cat, m) for cat, ms in catalog.items() for m in ms}
+        assert NIGHT_METRIC in by_id, (
+            f"GET /api/metrics liefert {sorted(by_id)} — die gefuehlte "
+            f"Nachtgroesse fehlt."
+        )
+        night_cat, night = by_id[NIGHT_METRIC]
+        wc_cat, _ = by_id["wind_chill"]
+        assert night_cat == wc_cat, (
+            f"Die gefuehlte Nachtgroesse steht in Kategorie {night_cat!r}, "
+            f"„Gefuehlte Temperatur“ in {wc_cat!r} — beide gehoeren zusammen."
+        )
+        assert "Nacht" in night["label"], (
+            f"Editor-Beschriftung muss den Nachtbezug tragen: {night['label']!r}"
+        )
+
+    def test_felt_night_metric_has_no_alert_declaration(self):
+        """Der Kaeltealarm bleibt bei ``temperature_cold`` (#914), der
+        gefuehlte Risikowert bei ``wind_chill`` -- der neue Eintrag deklariert
+        keine eigene Alarm-Identitaet (sonst regeneriert
+        ``alert_metric_mapping.generated.json`` einen unerwuenschten
+        Eintrag, s. Spec Punkt 8)."""
+        from app.metric_catalog import get_metric
+
+        metric = get_metric(NIGHT_METRIC)  # raises KeyError, solange fehlend
+        assert not metric.alert_metrics, (
+            f"„Gefuehlte Nacht-Tiefsttemperatur“ darf keine alert_metrics "
+            f"deklarieren: {metric.alert_metrics!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-12 — Nachtfenster-Skalar: keine Stundenspalte, kein Alarm-Mapping
+# ---------------------------------------------------------------------------
+
+class TestFeltNightIsNeverAnHourlyColumn:
+
+    def test_trip_channel_layout_excludes_felt_night_from_columns(self):
+        """Trip-Mail-Seite: ``NO_HOURLY_COLUMN_METRIC_IDS`` (email/helpers.py)
+        muss den neuen Eintrag fuehren -- sonst erscheint eine
+        Tabellenspalte „Gefuehlte Nacht“ mit Stundenwerten, die es gar
+        nicht gibt."""
+        from output.renderers.email.helpers import NO_HOURLY_COLUMN_METRIC_IDS
+
+        assert NIGHT_METRIC in NO_HOURLY_COLUMN_METRIC_IDS, (
+            f"{NIGHT_METRIC!r} fehlt in NO_HOURLY_COLUMN_METRIC_IDS "
+            f"({sorted(NO_HOURLY_COLUMN_METRIC_IDS)})."
+        )
+
+    def test_render_for_channel_never_places_felt_night_in_a_bucket(self):
+        """Wirkungs-Nachweis (nicht nur Konfiguration): ein Trip mit
+        aktivierter ``wind_chill_night`` darf im E-Mail-Layout weder eine
+        primary- noch eine secondary-Spalte fuer die Groesse erzeugen --
+        analog zum Filter, den ``render_for_channel`` heute schon fuer
+        ``temperature_night`` anwendet (channel_layout.py:88)."""
+        from output.renderers.channel_layout import render_for_channel
+
+        dc = UnifiedWeatherDisplayConfig(
+            trip_id="i1660a-hourly",
+            metrics=[
+                MetricConfig(metric_id=NIGHT_METRIC, enabled=True,
+                             bucket="secondary"),
+                MetricConfig(metric_id="precipitation", enabled=True),
+            ],
+        )
+        layout = render_for_channel("email", dc, "evening")
+
+        assert NIGHT_METRIC not in layout.table_columns, (
+            f"{NIGHT_METRIC!r} erscheint als Tabellenspalte: "
+            f"{layout.table_columns!r}"
+        )
+        assert NIGHT_METRIC not in layout.detail_metrics, (
+            f"{NIGHT_METRIC!r} erscheint als Detail-Zeile: "
+            f"{layout.detail_metrics!r} -- channel_layout.py:88 filtert "
+            f"bisher nur „temperature_night“ aus der Menge heraus."
+        )
+
+    def test_compare_hourly_excludes_felt_night_with_reason(self):
+        """Ortsvergleich-Seite: ``HOURLY_EXCLUDED_METRIC_IDS`` +
+        ``HOURLY_EXCLUSION_REASON`` (compare_hourly_metric_ids.py:59/70-73)
+        muessen den neuen Eintrag ebenfalls fuehren -- sonst zeigt der
+        Vergleichs-Stundenverlauf eine Geisterspalte, die kein Test
+        bemerkt."""
+        from output.renderers.compare_hourly_metric_ids import (
+            HOURLY_EXCLUDED_METRIC_IDS, HOURLY_EXCLUSION_REASON,
+        )
+
+        assert NIGHT_METRIC in HOURLY_EXCLUDED_METRIC_IDS, (
+            f"{NIGHT_METRIC!r} fehlt in HOURLY_EXCLUDED_METRIC_IDS "
+            f"({sorted(HOURLY_EXCLUDED_METRIC_IDS)})."
+        )
+        reason = HOURLY_EXCLUSION_REASON.get(NIGHT_METRIC)
+        assert reason and len(reason) >= 15, (
+            f"HOURLY_EXCLUSION_REASON fuehrt keine (oder eine zu kurze) "
+            f"Begruendung fuer {NIGHT_METRIC!r}: {reason!r}"
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/tdd/test_felt_night_own_metric_selection.py
+++ b/tests/tdd/test_felt_night_own_metric_selection.py
@@ -1,0 +1,456 @@
+"""Die GEFUEHLTE Nacht-Tiefsttemperatur folgt ihrer EIGENEN Metrik-Auswahl.
+
+Issue: #1660 Scheibe A — Folge aus #1484 (dort nur die GEMESSENE Nachtgroesse
+"temperature_night", Kuerzel N; "gefuehlte Nacht" FN blieb ausdruecklich als
+Folgeschnitt an "wind_chill" gekoppelt, s. feat_1484_night_temp_metric.md
+Abgrenzung 1).
+
+Spec: docs/specs/modules/fix_1660a_temp_trennung.md — Mechanismus 1
+(Katalogeintrag ``wind_chill_night``, Kuerzel-Trennung ``FN`` von
+``wind_chill``, Bestandsableitung im Ladepfad, Nachtdaten-Bedarf,
+Abend-Untergrenze in Kurzzusammenfassung/Telegram).
+
+Struktur/Fixture-Stil 1:1 aus ``test_night_temp_own_metric_selection.py``
+(Vorbild #1484) uebernommen, nur auf die GEFUEHLTE Seite gespiegelt.
+
+Gemessen wird der echte Weg von der Nutzereinstellung bis zum gerenderten
+Kanaltext (SMS, E-Mail-Kurzzusammenfassung, Telegram-Kurzuebersicht) bzw.
+durch den echten Lade-Pfad (``loader._parse_display_config``) und den echten
+API-Endpoint (``GET /api/metrics``). Keine Mocks, kein Netz, keine
+Dateiinhalt-Pruefungen.
+
+Abgrenzung laut Spec: ``WC`` (Wintersport-Tageskennzahl) bleibt bei
+"wind_chill" (Regression #1450 waere sonst die Folge). Die E-Mail-Nacht-
+Stundentabelle bleibt an ``show_night_block``.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from output.renderers.compact_summary import CompactSummaryFormatter
+from output.renderers.trip_report import TripReportFormatter
+
+from tests.tdd import _min_temp_felt_fixtures as F
+
+NIGHT_METRIC = "wind_chill_night"
+_SAVE_TEST_USER = "tdd-1660a-save"
+_FELT = ("FN", "FK", "FD")
+_FELT_WITH_WC = ("FN", "FK", "FD", "WC")
+_DASH = "–"  # En-Dash der Kurzzusammenfassungs-Spannen
+
+
+def _report(report_type: str, *metric_ids: str, segment=None, night=...):
+    """Echt gerenderter TripReport mit genau den genannten aktiven Metriken."""
+    return TripReportFormatter().format_email(
+        [segment if segment is not None else F.segment()],
+        trip_name="I1660aFeltNight",
+        report_type=report_type,
+        night_weather=F.night_weather() if night is ... else night,
+        display_config=F.dc(*metric_ids),
+        stage_name=F.STAGE_NAME,
+        tz=F.TZ,
+    )
+
+
+def _sms(report_type: str, *metric_ids: str, **kw) -> str:
+    return _report(report_type, *metric_ids, **kw).sms_text
+
+
+def _compact(report_type: str, *metric_ids: str) -> str:
+    return CompactSummaryFormatter().format_stage_summary(
+        [F.segment()], F.STAGE_NAME, F.dc(*metric_ids), F.night_weather(),
+        tz=F.TZ, report_type=report_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-1 / AC-2 / AC-3 — SMS-Token folgen der eigenen Auswahl
+# ---------------------------------------------------------------------------
+
+class TestSmsFeltNightTokenFollowsOwnSelection:
+
+    def test_day_tokens_present_without_night_metric(self):
+        """AC-1: Gefuehlte Temperatur AN, gefuehlte Nachtgroesse AUS ->
+        FK/FD/WC ja, FN nein."""
+        sms = _sms("evening", "wind_chill", "precipitation")
+
+        present = F.present_symbols(sms, _FELT_WITH_WC)
+        assert present == {"FK", "FD", "WC"}, (
+            f"Erwartet nur FK/FD/WC bei abgewaehlter gefuehlter "
+            f"Nachtgroesse, gefunden {sorted(present)} — FN haengt offenbar "
+            f"weiter an „Gefuehlte Temperatur“.\nSMS: {sms}"
+        )
+
+    def test_night_token_present_without_day_metric(self):
+        """AC-2: gefuehlte Nachtgroesse AN, gefuehlte Temperatur AUS ->
+        FN ja (Nachtfenster-Wert), FK/FD/WC nein."""
+        sms = _sms("evening", NIGHT_METRIC, "precipitation")
+
+        assert F.sms_token_value(sms, "FN") == str(int(F.FELT_NIGHT_MIN_C)), (
+            f"FN fehlt oder traegt den falschen Wert, obwohl die gefuehlte "
+            f"Nachtgroesse gewaehlt ist (erwartet FN{int(F.FELT_NIGHT_MIN_C)})"
+            f".\nSMS: {sms}"
+        )
+        leaked = F.present_symbols(sms, ("FK", "FD", "WC"))
+        assert not leaked, (
+            f"FK/FD/WC erscheinen {sorted(leaked)}, obwohl „Gefuehlte "
+            f"Temperatur“ abgewaehlt ist.\nSMS: {sms}"
+        )
+
+    def test_both_selected_keeps_all_four_tokens(self):
+        """Nichtregression: beide AN -> FN/FK/FD/WC wie vor dem Schnitt."""
+        sms = _sms("evening", "wind_chill", NIGHT_METRIC, "precipitation")
+
+        assert F.present_symbols(sms, _FELT_WITH_WC) == {"FN", "FK", "FD", "WC"}, (
+            f"Beide Groessen gewaehlt — alle vier Kuerzel erwartet.\nSMS: {sms}"
+        )
+        assert F.sms_token_value(sms, "FN") == str(int(F.FELT_NIGHT_MIN_C))
+        assert F.sms_token_value(sms, "FK") == str(int(F.FELT_HIKE_MIN_C))
+        assert F.sms_token_value(sms, "FD") == str(int(F.FELT_HIKE_MAX_C))
+
+    def test_morning_never_shows_felt_night_token(self):
+        """AC-3: das bestehende Nur-Abends-Gate (builder.py, evening_only)
+        wirkt unveraendert weiter, auch mit gewaehlter Nachtgroesse."""
+        sms = _sms("morning", "wind_chill", NIGHT_METRIC, "precipitation")
+
+        assert F.sms_token_value(sms, "FN") is None, (
+            f"FN erscheint im Morgen-Briefing.\nSMS: {sms}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-8 / AC-9 — Bestands-Trips ueber den echten Lade-Pfad
+# ---------------------------------------------------------------------------
+
+class TestLegacyTripsDeriveFeltNightFromWindChill:
+    """Ableitungsregel beim Lesen: fehlt ``wind_chill_night`` im gespeicherten
+    ``display_config``, gilt die Groesse als aktiviert genau dann, wenn
+    „Gefuehlte Temperatur" aktiviert ist — niemand wird ueberrascht.
+
+    Adversary-Hinweis der Spec: das muss ueber den LADEPFAD gemessen werden,
+    nicht ueber von Hand gebautes ``MetricConfig`` — sonst wird genau die
+    Stelle umgangen, die dieser Schnitt aendert.
+    """
+
+    @staticmethod
+    def _dc_from_stored(metrics: list[dict]):
+        from app.loader import _parse_display_config
+
+        return _parse_display_config({"metrics": metrics, "show_night_block": True})
+
+    def _evening_sms(self, dc) -> str:
+        return TripReportFormatter().format_email(
+            [F.segment()], trip_name="I1660aFeltNight", report_type="evening",
+            night_weather=F.night_weather(), display_config=dc,
+            stage_name=F.STAGE_NAME, tz=F.TZ,
+        ).sms_text
+
+    def test_stored_trip_with_wind_chill_derives_felt_night_enabled(self):
+        """AC-8: Bestands-Trip (Gefuehlte Temperatur AN, kein Nacht-Eintrag)
+        -- die Nachtgroesse muss beim LADEN als abgeleitet AKTIVIERT gelten.
+
+        RED direkt am Ladepfad: ``loader.py`` fuehrt heute noch keinen
+        Ableitungs-Block fuer ``wind_chill_night`` (nur fuer
+        ``temperature_night``, #1484) -- ohne expliziten Eintrag bleibt
+        ``is_metric_enabled`` auf dem Default ``False``.
+        """
+        dc = self._dc_from_stored([
+            {"metric_id": "wind_chill", "enabled": True},
+            {"metric_id": "precipitation", "enabled": True},
+        ])
+
+        assert dc.is_metric_enabled(NIGHT_METRIC), (
+            "Bestands-Trip mit aktivierter „Gefuehlter Temperatur“ und ohne "
+            "expliziten wind_chill_night-Eintrag muss die Nachtgroesse als "
+            "abgeleitet AKTIVIERT fuehren -- die #1484-Ableitung in "
+            "loader.py deckt bisher nur „temperature_night“ ab."
+        )
+        sms = self._evening_sms(dc)
+        assert F.sms_token_value(sms, "FN") == str(int(F.FELT_NIGHT_MIN_C)), (
+            f"FN fehlt trotz Ableitung ueber die aktive Elternmetrik.\n"
+            f"SMS: {sms}"
+        )
+
+    def test_stored_trip_without_wind_chill_stays_night_free(self):
+        """AC-9: Gefuehlte Temperatur AUS -> Nachtgroesse startet AUS.
+
+        Charakterisierung: schon heute gruen (kein Eintrag -> Default
+        ``False``) -- der Wert liegt in der Mutations-Gegenprobe (Ableitung
+        darf das nicht versehentlich auf True drehen)."""
+        dc = self._dc_from_stored([
+            {"metric_id": "wind_chill", "enabled": False},
+            {"metric_id": "precipitation", "enabled": True},
+        ])
+
+        assert not dc.is_metric_enabled(NIGHT_METRIC), (
+            "Bestands-Trip ohne aktivierte „Gefuehlte Temperatur“ zeigt "
+            "eine abgeleitet aktivierte Nachtgroesse."
+        )
+        sms = self._evening_sms(dc)
+        assert F.sms_token_value(sms, "FN") is None, (
+            f"FN erscheint trotz deaktivierter Elternmetrik.\nSMS: {sms}"
+        )
+
+    def test_empty_metrics_list_does_not_invent_felt_night(self):
+        """AC-9 (Roundtrip-Invarianz): Altbestand ganz ohne
+        ``display_config``-Metrikliste erfindet KEINEN Eintrag.
+
+        Charakterisierung: schon heute gruen (kein Code erzeugt aus einer
+        leeren Liste einen Eintrag) -- Regressionsschutz fuer die neue
+        Ableitung, die NUR bei vorhandenem "wind_chill"-Eintrag greifen darf.
+        """
+        dc = self._dc_from_stored([])
+
+        assert not any(mc.metric_id == NIGHT_METRIC for mc in dc.metrics), (
+            "Eine leere Metrikliste (Altbestand Fall A) darf keinen "
+            "wind_chill_night-Eintrag erfinden."
+        )
+
+    def test_explicit_disabled_entry_overrides_derivation(self):
+        """Ein gespeicherter expliziter Nacht-Eintrag schlaegt die
+        Ableitung -- auch wenn „Gefuehlte Temperatur“ selbst aktiv ist."""
+        dc = self._dc_from_stored([
+            {"metric_id": "wind_chill", "enabled": True},
+            {"metric_id": NIGHT_METRIC, "enabled": False},
+            {"metric_id": "precipitation", "enabled": True},
+        ])
+
+        sms = self._evening_sms(dc)
+        assert F.sms_token_value(sms, "FN") is None, (
+            f"Explizit abgewaehlter wind_chill_night-Eintrag muss die "
+            f"Ableitung ueberstimmen.\nSMS: {sms}"
+        )
+        present = F.present_symbols(sms, ("FK", "FD", "WC"))
+        assert present == {"FK", "FD", "WC"}, (
+            f"Die Tagesgroesse bleibt von der expliziten Nacht-Abwahl "
+            f"unberuehrt — erwartet FK/FD/WC, gefunden {sorted(present)}."
+            f"\nSMS: {sms}"
+        )
+
+    def test_explicit_enabled_entry_overrides_parent_deselection(self):
+        """Umgekehrt: Nachtgroesse explizit AN, obwohl „Gefuehlte
+        Temperatur“ selbst AUS ist."""
+        dc = self._dc_from_stored([
+            {"metric_id": "wind_chill", "enabled": False},
+            {"metric_id": NIGHT_METRIC, "enabled": True},
+            {"metric_id": "precipitation", "enabled": True},
+        ])
+
+        sms = self._evening_sms(dc)
+        assert F.sms_token_value(sms, "FN") == str(int(F.FELT_NIGHT_MIN_C)), (
+            f"Explizit aktivierter wind_chill_night-Eintrag muss FN zeigen, "
+            f"auch bei abgewaehlter Elternmetrik.\nSMS: {sms}"
+        )
+        leaked = F.present_symbols(sms, ("FK", "FD", "WC"))
+        assert not leaked, (
+            f"FK/FD/WC erscheinen {sorted(leaked)}, obwohl „Gefuehlte "
+            f"Temperatur“ abgewaehlt ist.\nSMS: {sms}"
+        )
+
+    def test_save_after_derivation_does_not_write_back_and_preserves_other_fields(
+        self, tmp_path,
+    ):
+        """AC-8 (Save-Haelfte): der ueber die Elternmetrik abgeleitete
+        Eintrag wird NICHT zurueckgeschrieben (loader.py: generischer
+        ``getattr(mc, "derived", False)``-Filter vor ``_trip_to_dict()``) --
+        sonst wuerde ein spaeterer Ladevorgang ihn als EXPLIZIT lesen und die
+        Ableitungsregel fuer neue Aenderungen an „wind_chill“ nicht mehr
+        greifen. Zusaetzlich Read-Modify-Write-Nachweis (CLAUDE.md-Pflicht):
+        alle uebrigen ``display_config``-Felder ueberleben Speichern +
+        Neuladen unveraendert."""
+        from app.loader import load_trip, load_trip_from_dict, save_trip
+
+        trip_dict = {
+            "id": "trip-1660a-save",
+            "name": "AC-8 Save-Nachweis",
+            "stages": [
+                {
+                    "id": "stage-1",
+                    "name": "Etappe 1",
+                    "date": "2026-08-09",
+                    "waypoints": [
+                        {"id": "wp-1", "name": "Start", "lat": 42.13,
+                         "lon": 9.13, "elevation_m": 400},
+                        {"id": "wp-2", "name": "Ziel", "lat": 42.10,
+                         "lon": 9.18, "elevation_m": 1200},
+                    ],
+                },
+            ],
+            "aggregation": {"profile": "allgemein"},
+            "display_config": {
+                "metrics": [
+                    {"metric_id": "wind_chill", "enabled": True},
+                    {"metric_id": "precipitation", "enabled": True},
+                ],
+                "show_night_block": False,
+                "night_interval_hours": 3,
+                "sms_metrics": ["temperature"],
+            },
+        }
+
+        trip = load_trip_from_dict(trip_dict)
+        assert trip.display_config.is_metric_enabled(NIGHT_METRIC), (
+            "Vorbedingung verletzt: die Nachtgroesse muss ueber die "
+            "Ableitung bereits aktiviert sein, sonst prueft dieser Test "
+            "nichts."
+        )
+
+        path = save_trip(trip, user_id=_SAVE_TEST_USER, data_dir=tmp_path)
+        raw = json.loads(Path(path).read_text(encoding="utf-8"))
+        saved_ids = {m["metric_id"] for m in raw["display_config"]["metrics"]}
+        assert NIGHT_METRIC not in saved_ids, (
+            f"Der abgeleitete {NIGHT_METRIC}-Eintrag wurde zurueckgeschrieben "
+            f"({sorted(saved_ids)}) -- ein spaeterer Ladevorgang wuerde ihn "
+            f"als EXPLIZIT lesen und die Ableitungsregel fuer neue "
+            f"Aenderungen an „wind_chill“ nicht mehr greifen lassen."
+        )
+        assert raw["display_config"]["show_night_block"] is False, (
+            "show_night_block wurde beim Speichern nicht erhalten "
+            "(Read-Modify-Write-Pflicht, CLAUDE.md)."
+        )
+        assert raw["display_config"]["night_interval_hours"] == 3, (
+            "night_interval_hours wurde beim Speichern nicht erhalten."
+        )
+        assert raw["display_config"]["sms_metrics"] == ["temperature"], (
+            "sms_metrics wurde beim Speichern nicht erhalten."
+        )
+
+        reloaded = load_trip(trip.id, data_dir=tmp_path, user_id=_SAVE_TEST_USER)
+        assert reloaded.display_config.is_metric_enabled(NIGHT_METRIC), (
+            "Nach dem Neuladen ist die Nachtgroesse verschwunden -- die "
+            "Ableitung muss bei jedem Laden erneut greifen, solange kein "
+            "expliziter Eintrag gespeichert wurde."
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-10 — E-Mail-Kurzzusammenfassung
+# ---------------------------------------------------------------------------
+
+class TestCompactSummaryFeltNightBound:
+
+    def test_evening_shows_hiking_range_when_night_deselected(self):
+        text = _compact("evening", "wind_chill", "precipitation")
+        parts = F.compact_parts(text)
+
+        expected = (
+            f"gef. {int(F.FELT_HIKE_MIN_C)}{_DASH}{int(F.FELT_HIKE_MAX_C)}°C"
+        )
+        assert expected in parts, (
+            f"Abend-Untergrenze muss ohne gefuehlte Nachtgroesse die "
+            f"kaelteste Gehzeit-Stunde sein ({expected!r}), gefunden "
+            f"{parts!r} — die gefuehlte Nacht-Untergrenze haengt offenbar "
+            f"weiter unbedingt an „Gefuehlte Temperatur“.\nSatz: {text!r}"
+        )
+
+    def test_evening_night_bound_when_both_selected(self):
+        """Nichtregression: beide AN -> gefuehlte Nacht-Untergrenze wie
+        bisher."""
+        text = _compact("evening", "wind_chill", NIGHT_METRIC, "precipitation")
+        parts = F.compact_parts(text)
+
+        expected = (
+            f"gef. {int(F.FELT_NIGHT_MIN_C)}{_DASH}{int(F.FELT_HIKE_MAX_C)}°C"
+        )
+        assert expected in parts, (
+            f"Beide Groessen gewaehlt — {expected!r} erwartet, gefunden "
+            f"{parts!r}.\nSatz: {text!r}"
+        )
+
+    def test_evening_night_value_alone_when_only_night_selected(self):
+        text = _compact("evening", NIGHT_METRIC)
+        parts = F.compact_parts(text)
+
+        expected = f"gef. {int(F.FELT_NIGHT_MIN_C)}°C"
+        assert expected in parts, (
+            f"Nur die gefuehlte Nachtgroesse ist gewaehlt — ihr Wert "
+            f"({expected!r}) muss im Satz stehen (eigener Zweig analog "
+            f"„temperature“, s. compact_summary.py Zeile 183-190). "
+            f"Gefunden: {parts!r}\nSatz: {text!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-10 — Telegram-Kurzuebersicht
+# ---------------------------------------------------------------------------
+
+class TestTelegramOverviewFeltNightBound:
+
+    def test_evening_tf_line_without_night_substitution(self):
+        report = _report("evening", "wind_chill", "precipitation")
+        tfline = F.overview_line(report, "TF")
+
+        assert tfline, (
+            "Die TF-Zeile der Kurzuebersicht fehlt komplett — Vorbedingung "
+            "des Nachweises verletzt."
+        )
+        assert f"{F.FELT_NIGHT_MIN_C:.1f}" not in tfline, (
+            f"Die Abend-TF-Zeile zeigt die gefuehlte Nacht-Untergrenze, "
+            f"obwohl die gefuehlte Nachtgroesse abgewaehlt ist.\n"
+            f"Zeile: {tfline!r}"
+        )
+
+    def test_evening_tf_line_with_night_substitution_when_selected(self):
+        """Nichtregression: beide AN -> gefuehlte Nacht-Untergrenze in der
+        TF-Zeile."""
+        report = _report("evening", "wind_chill", NIGHT_METRIC, "precipitation")
+        tfline = F.overview_line(report, "TF")
+
+        assert f"{F.FELT_NIGHT_MIN_C:.1f}" in tfline, (
+            f"Beide Groessen gewaehlt — die Abend-TF-Zeile muss die "
+            f"gefuehlte Nacht-Untergrenze zeigen.\nZeile: {tfline!r}"
+        )
+
+    def test_evening_night_value_visible_when_only_night_selected(self):
+        report = _report("evening", NIGHT_METRIC)
+        bubble = F.overview_bubble(report)
+        value_lines = [ln for ln in bubble.splitlines()[1:] if ln.strip()]
+
+        assert any(str(int(F.FELT_NIGHT_MIN_C)) in ln for ln in value_lines), (
+            f"Nur die gefuehlte Nachtgroesse ist gewaehlt — ihr Wert muss "
+            f"in der Kurzuebersicht erscheinen (eigener Zweig analog "
+            f"„temperature_night“, s. narrow.py Zeile ~717-722).\n"
+            f"Bubble: {bubble!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-11 — Nacht-Datenbeschaffung haengt an der Auswahl, nicht nur an der
+# Nacht-Stundentabelle
+# ---------------------------------------------------------------------------
+
+class TestFeltNightFetchFollowsMetricSelection:
+    """Vorschau-/Scheduler-Pfad (``segment_weather.night_weather_needed``)
+    muss auch bei gewaehlter ``wind_chill_night`` Nachtdaten anfordern --
+    sonst zeigt die Vorschau ein FN, das still auf den Gehzeit-Tiefstwert
+    zurueckfaellt, waehrend der Versand den echten Nachtwert traegt
+    (#1484-Analogon fuer die gefuehlte Seite)."""
+
+    def test_needed_when_felt_night_metric_selected_without_table(self):
+        from services.segment_weather import night_weather_needed
+
+        dc = F.dc(NIGHT_METRIC, "precipitation")
+        dc.show_night_block = False
+        assert night_weather_needed(dc), (
+            "Gewaehlte gefuehlte Nachtgroesse braucht Nachtdaten — auch "
+            "ohne Nacht-Stundentabelle."
+        )
+
+    def test_not_needed_when_neither(self):
+        from services.segment_weather import night_weather_needed
+
+        dc = F.dc("wind_chill")
+        dc.show_night_block = False
+        assert not night_weather_needed(dc), (
+            "Weder Tabelle noch gefuehlte Nachtgroesse — kein Grund fuer "
+            "einen Nacht-Abruf in der Vorschau."
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/tdd/test_felt_night_own_metric_selection.py
+++ b/tests/tdd/test_felt_night_own_metric_selection.py
@@ -29,8 +29,6 @@ import json
 from pathlib import Path
 
 import pytest
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
 
 from output.renderers.compact_summary import CompactSummaryFormatter
 from output.renderers.trip_report import TripReportFormatter

--- a/tests/tdd/test_hiking_window_parity.py
+++ b/tests/tdd/test_hiking_window_parity.py
@@ -38,7 +38,10 @@ from tests.tdd import _hiking_window_fixtures as F
 
 # #1484: temperature_night mit dabei — der AC-7-Nachtwert haengt an der
 # eigenen Groesse; fuer die uebrigen (Morgen-/ohne-Nacht-)Faelle ist sie inert.
-_FELT = ("temperature", "temperature_night", "wind_chill")
+# #1660 Scheibe A: dieselbe Eigenstaendigkeit jetzt auch fuer die gefuehlte
+# Nachtgroesse ("wind_chill_night") -- sonst faellt der AC-7-Nachwert der
+# gefuehlten Seite still auf den Gehzeit-Tiefstwert zurueck.
+_FELT = ("temperature", "temperature_night", "wind_chill", "wind_chill_night")
 _NUMBER = re.compile(r"-?\d+(?:\.\d+)?")
 
 

--- a/tests/tdd/test_sms_snow_symbols.py
+++ b/tests/tdd/test_sms_snow_symbols.py
@@ -601,6 +601,11 @@ def test_ac8_sms_symbols_endpoint_keeps_official_snow_hazard():
 def test_ac1_wind_chill_reports_all_four_symbols():
     """AC-1: wind_chill fehlt heute strukturell -- nach dem Fix liefert der
     Endpoint alle vier Kuerzel in der dokumentierten Reihenfolge.
+
+    Issue #1660 Scheibe A: 'FN' ist zur eigenen waehlbaren Groesse
+    "wind_chill_night" gewandert (SMS_MULTI_SYMBOLS_BY_METRIC-Aufteilung) --
+    "wind_chill" liefert seitdem drei statt vier Kuerzel, 'FN' erscheint
+    unter eigenem metric_id-Eintrag.
     """
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
@@ -616,9 +621,19 @@ def test_ac1_wind_chill_reports_all_four_symbols():
         f"AC-1: erwarte genau einen wind_chill-Eintrag, gefunden {len(entries)}: "
         f"{entries!r}"
     )
-    assert entries[0]["sms_symbols"] == ["FN", "FK", "FD", "WC"], (
+    assert entries[0]["sms_symbols"] == ["FK", "FD", "WC"], (
         "AC-1: wind_chill liefert "
-        f"{entries[0]['sms_symbols']!r}, erwartet ['FN','FK','FD','WC']"
+        f"{entries[0]['sms_symbols']!r}, erwartet ['FK','FD','WC']"
+    )
+
+    night_entries = [m for m in metrics if m["metric_id"] == "wind_chill_night"]
+    assert len(night_entries) == 1, (
+        f"AC-1/#1660: erwarte genau einen wind_chill_night-Eintrag, "
+        f"gefunden {len(night_entries)}: {night_entries!r}"
+    )
+    assert night_entries[0]["sms_symbols"] == ["FN"], (
+        "AC-1/#1660: wind_chill_night liefert "
+        f"{night_entries[0]['sms_symbols']!r}, erwartet ['FN']"
     )
 
 
@@ -680,9 +695,14 @@ def test_ac3_single_symbol_metrics_unchanged_in_array_format():
 
 
 def test_ac6_endpoint_reports_eleven_metrics_total():
-    """AC-6/Regression: 8 Register-Metriken + 3 neue (temperature,
-    temperature_night, wind_chill) = 11 Eintraege, kein Wertverlust durch
-    die Typumstellung string -> string[].
+    """AC-6/Regression: 8 Register-Metriken + 4 neue (temperature,
+    temperature_night, wind_chill, wind_chill_night) = 12 Eintraege, kein
+    Wertverlust durch die Typumstellung string -> string[].
+
+    Issue #1660 Scheibe A: "wind_chill_night" ist eine vierte neue,
+    eigenstaendig waehlbare Groesse (SMS_MULTI_SYMBOLS_BY_METRIC-Aufteilung)
+    -- Zaehlung von 11 auf 12 erhoeht (Testname bleibt aus Historiengruenden
+    stehen, s. AC-6-Zaehlweise in der Docstring).
     """
     from fastapi import FastAPI
     from fastapi.testclient import TestClient
@@ -693,8 +713,8 @@ def test_ac6_endpoint_reports_eleven_metrics_total():
     app.include_router(config_router.router)
     metrics = TestClient(app).get("/sms-symbols").json()["metrics"]
 
-    assert len(metrics) == 11, (
-        f"AC-6: erwarte 11 Metrik-Eintraege (8 Register + 3 neue, thunder "
+    assert len(metrics) == 12, (
+        f"AC-6: erwarte 12 Metrik-Eintraege (8 Register + 4 neue, thunder "
         f"nur einmal gezaehlt), gefunden {len(metrics)}: {metrics!r}"
     )
     by_metric = {m["metric_id"]: m["sms_symbols"] for m in metrics}

--- a/tests/tdd/test_sms_temp_aggregation_gate.py
+++ b/tests/tdd/test_sms_temp_aggregation_gate.py
@@ -1,0 +1,277 @@
+"""Die SMS-Kette liest die bestehende Auswertungswahl (min/max/avg,
+``MetricConfig.aggregations``, seit #1357) fuer Tages-Tief/Hoch, K/D bzw.
+FK/FD -- bisher zeigt die SMS bei aktiver Groesse immer BEIDE Token,
+unabhaengig davon, was im Editor (Reiter Wertebereiche) fuer diese Groesse
+gewaehlt wurde.
+
+Issue: #1660 Scheibe A. Spec: docs/specs/modules/fix_1660a_temp_trennung.md
+— Mechanismus 2 (Aggregations-Gate) + DEC-1 (Mittelwert entfernt beide
+Tages-Token) + DEC-2 (Auswertungswahl ist eine GLOBALE Groesse, kein
+Kanal-Layout-Feld -- ``trip_report.py`` liest sie aus
+``_dc_uncollapsed.metrics``, NICHT aus der Kanal-Kaskade).
+
+Kern-Schicht, deterministisch: kein Mock, kein Netz, kein ``patch()``.
+Gemessen wird der echte Weg ``TripReportFormatter.format_email()`` ->
+``report.sms_text`` sowie (fuer AC-7 den Bestandsschutz der E-Mail-Seite)
+``build_metrics_summary_pills()`` -- dieselbe Funktion, die die
+E-Mail-Kachelzeile seit #1357 bereits bedient.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.models import MetricConfig, UnifiedWeatherDisplayConfig
+from output.renderers.trip_report import TripReportFormatter
+
+from tests.tdd import _min_temp_felt_fixtures as F
+
+TRIP_ID = "i1660a-agg"
+
+
+def _dc(
+    *,
+    temperature_aggs: list[str] | None = None,
+    wind_chill_aggs: list[str] | None = None,
+    extra: tuple[str, ...] = (),
+    channel_layouts: dict | None = None,
+) -> UnifiedWeatherDisplayConfig:
+    """Displaykonfiguration mit optionaler Auswertungswahl je Tagesgroesse."""
+    metrics: list[MetricConfig] = []
+    if temperature_aggs is not None:
+        metrics.append(MetricConfig(
+            metric_id="temperature", enabled=True, aggregations=temperature_aggs,
+        ))
+    if wind_chill_aggs is not None:
+        metrics.append(MetricConfig(
+            metric_id="wind_chill", enabled=True, aggregations=wind_chill_aggs,
+        ))
+    for mid in extra:
+        metrics.append(MetricConfig(metric_id=mid, enabled=True))
+    return UnifiedWeatherDisplayConfig(
+        trip_id=TRIP_ID, metrics=metrics, per_channel_layouts=channel_layouts,
+    )
+
+
+def _sms(dc: UnifiedWeatherDisplayConfig, report_type: str = "evening") -> str:
+    return TripReportFormatter().format_email(
+        [F.segment()], trip_name="I1660aAgg", report_type=report_type,
+        night_weather=F.night_weather(), display_config=dc,
+        stage_name=F.STAGE_NAME, tz=F.TZ,
+    ).sms_text
+
+
+# ---------------------------------------------------------------------------
+# AC-4 / AC-5 — Einzelwahl (Nur Tiefstwert / Nur Hoechstwert) wirkt in der SMS
+# ---------------------------------------------------------------------------
+
+class TestSingleChoiceGatesSmsTokens:
+
+    def test_max_only_shows_d_hides_k_keeps_night_unaffected(self):
+        """AC-4: „Nur Hoechstwert" bei „Temperatur" -> D ja, K nein; ein
+        zusaetzlich gewaehltes N bleibt unberuehrt sichtbar."""
+        dc = _dc(temperature_aggs=["max"], extra=("temperature_night",))
+        sms = _sms(dc)
+
+        assert F.sms_token_value(sms, "D") == str(int(F.HIKE_MAX_C)), (
+            f"D fehlt oder falscher Wert bei „Nur Hoechstwert“.\nSMS: {sms}"
+        )
+        assert F.sms_token_value(sms, "K") is None, (
+            f"K erscheint trotz „Nur Hoechstwert“ -- die SMS-Kette liest "
+            f"die Auswertungswahl noch nicht.\nSMS: {sms}"
+        )
+        assert F.sms_token_value(sms, "N") == str(int(F.NIGHT_MIN_C)), (
+            f"N (eigene Groesse, #1484) darf vom Aggregations-Gate der "
+            f"Tagesgroesse nicht beruehrt werden.\nSMS: {sms}"
+        )
+
+    def test_min_only_shows_fk_hides_fd_keeps_night_unaffected(self):
+        """AC-5: „Nur Tiefstwert" bei „Gefuehlte Temperatur" -> FK ja, FD
+        nein; ein zusaetzlich gewaehltes FN bleibt unberuehrt sichtbar."""
+        dc = _dc(wind_chill_aggs=["min"], extra=("wind_chill_night",))
+        sms = _sms(dc)
+
+        assert F.sms_token_value(sms, "FK") == str(int(F.FELT_HIKE_MIN_C)), (
+            f"FK fehlt oder falscher Wert bei „Nur Tiefstwert“.\nSMS: {sms}"
+        )
+        assert F.sms_token_value(sms, "FD") is None, (
+            f"FD erscheint trotz „Nur Tiefstwert“.\nSMS: {sms}"
+        )
+        assert F.sms_token_value(sms, "FN") == str(int(F.FELT_NIGHT_MIN_C)), (
+            f"FN (eigene Groesse, #1660a Mechanismus 1) darf vom "
+            f"Aggregations-Gate der Tagesgroesse nicht beruehrt werden.\n"
+            f"SMS: {sms}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-6 — DEC-2: die Auswertungswahl kommt aus der GLOBALEN Liste, nicht aus
+# einem gespeicherten SMS-Kanal-Layout
+# ---------------------------------------------------------------------------
+
+class TestAggregationSourceIsGlobalNotChannelLayout:
+
+    def test_channel_layout_defaults_do_not_override_global_gate(self):
+        """AC-6: ein gespeichertes SMS-Kanal-Layout (dessen Eintraege KEINE
+        Auswertungswahl tragen, Default beim Laden ist min+max,
+        ``loader.py:841/874``) darf die globale Abwahl nicht aushebeln.
+
+        Wächter fuer DEC-2 laut Spec-Pruefhinweis: ohne befuelltes
+        ``per_channel_layouts["sms"]`` waere dieser Test grün, egal ob das
+        Gate aus der Kaskade oder aus der globalen Liste liest.
+        """
+        channel_sms = [
+            MetricConfig(metric_id="temperature", enabled=True),
+            MetricConfig(metric_id="precipitation", enabled=True),
+        ]
+        dc = _dc(
+            temperature_aggs=["max"], extra=("precipitation",),
+            channel_layouts={"sms": channel_sms},
+        )
+        sms = _sms(dc)
+
+        assert F.sms_token_value(sms, "D") == str(int(F.HIKE_MAX_C)), (
+            f"D fehlt trotz kanal-konfiguriertem Trip.\nSMS: {sms}"
+        )
+        assert F.sms_token_value(sms, "K") is None, (
+            f"DEC-2 verletzt: K erscheint, obwohl „Temperatur“ global auf "
+            f"„Nur Hoechstwert“ steht — das Gate liest offenbar aus "
+            f"channel_layouts.sms (Default min+max) statt aus der "
+            f"globalen Metrikliste, die Abwahl waere damit bei JEDEM "
+            f"kanal-konfigurierten Trip wirkungslos.\nSMS: {sms}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-7 — DEC-1: „Nur Mittelwert" entfernt in der SMS beide Tages-Token, die
+# E-Mail zeigt weiterhin den Mittelwert-Pill
+# ---------------------------------------------------------------------------
+
+class TestAvgOnlyRemovesSmsTokensButKeepsEmailPill:
+
+    def test_avg_only_removes_both_sms_tokens(self):
+        dc = _dc(temperature_aggs=["avg"])
+        sms = _sms(dc)
+
+        assert F.sms_token_value(sms, "K") is None, (
+            f"K erscheint trotz „Nur Mittelwert“ -- die SMS kennt kein "
+            f"Mittelwert-Token, DEC-1 verlangt den Totalverlust NUR fuer "
+            f"die SMS.\nSMS: {sms}"
+        )
+        assert F.sms_token_value(sms, "D") is None, (
+            f"D erscheint trotz „Nur Mittelwert“.\nSMS: {sms}"
+        )
+
+    def test_avg_only_email_pill_still_shows_the_mean(self):
+        """Bestandsschutz-Gegenprobe zu DEC-1: die E-Mail-Kachelzeile bleibt
+        unberuehrt (Muster: ``test_trip_aggregation_single_choice.py``,
+        ``pill_text == "Ø 22°C"``) -- kein stiller Totalverlust der Groesse
+        ueber ALLE Kanaele."""
+        from output.renderers.email.helpers import build_metrics_summary_pills
+
+        pills = build_metrics_summary_pills(
+            [F.segment()], ["temperature"], {}, tz=F.TZ,
+            metric_aggregations={"temperature": ["avg"]},
+        )
+        texts = [text for text, _tone in pills]
+        assert any(t.startswith("Ø ") for t in texts), (
+            f"Die E-Mail-Kachelzeile fuer „Temperatur“ fehlt oder zeigt "
+            f"keinen Mittelwert -- DEC-1 gilt NUR fuer die SMS.\n"
+            f"Kacheln: {texts!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-13 — Bestandsschutz: unveraenderte Vorgabe-Auswertungen bleiben
+# zeichengleich
+# ---------------------------------------------------------------------------
+
+class TestDefaultAggregationStaysBitIdentical:
+
+    def test_default_min_max_selection_keeps_all_temperature_tokens(self):
+        """Charakterisierung, heute bereits gruen: die Vorgabe (min+max)
+        darf das neue Gate nicht veraendern -- kein stiller Bestandsbruch.
+        Wert liegt in der Mutations-Gegenprobe (Gate faelschlich auch auf
+        min+max anwenden waere hier rot)."""
+        dc = _dc(
+            temperature_aggs=["min", "max"], wind_chill_aggs=["min", "max"],
+            extra=("temperature_night", "precipitation"),
+        )
+        sms = _sms(dc)
+
+        expected = {
+            "K": int(F.HIKE_MIN_C), "D": int(F.HIKE_MAX_C),
+            "N": int(F.NIGHT_MIN_C),
+            "FK": int(F.FELT_HIKE_MIN_C), "FD": int(F.FELT_HIKE_MAX_C),
+        }
+        for sym, val in expected.items():
+            assert F.sms_token_value(sms, sym) == str(val), (
+                f"Bestandsschutz gebrochen: {sym} erwartet {val}, "
+                f"gefunden {F.sms_token_value(sms, sym)!r}.\nSMS: {sms}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# AC-14 — Zwei Nutzer mit entgegengesetzter Auswahl, keine Vermischung
+# ---------------------------------------------------------------------------
+
+class TestTwoUsersOppositeSelectionDoNotBleed:
+
+    @staticmethod
+    def _dc_from_specs(specs: list[tuple[str, bool, list[str] | None]],
+                        trip_id: str) -> UnifiedWeatherDisplayConfig:
+        metrics = []
+        for mid, enabled, aggs in specs:
+            kwargs = {"metric_id": mid, "enabled": enabled}
+            if aggs is not None:
+                kwargs["aggregations"] = aggs
+            metrics.append(MetricConfig(**kwargs))
+        return UnifiedWeatherDisplayConfig(trip_id=trip_id, metrics=metrics)
+
+    def test_opposite_configs_render_independently(self):
+        """AC-14: Nutzer A waehlt nur die gefuehlte Nacht (+ Temperatur „Nur
+        Hoechstwert"), Nutzer B waehlt nur die gefuehlte Tagesgroesse (+
+        Temperatur komplett aus) -- beide Renderings im selben Prozess
+        duerfen sich nicht gegenseitig faerben."""
+        dc_a = self._dc_from_specs([
+            ("wind_chill_night", True, None),
+            ("wind_chill", False, None),
+            ("temperature", True, ["max"]),
+            ("temperature_night", False, None),
+            ("precipitation", True, None),
+        ], trip_id="i1660a-usera")
+        dc_b = self._dc_from_specs([
+            ("wind_chill", True, ["min", "max"]),
+            ("wind_chill_night", False, None),
+            ("temperature", False, None),
+            ("temperature_night", False, None),
+            ("precipitation", True, None),
+        ], trip_id="i1660a-userb")
+
+        sms_a = _sms(dc_a)
+        sms_b = _sms(dc_b)
+
+        assert F.present_symbols(sms_a, ("FN", "FK", "FD")) == {"FN"}, (
+            f"Nutzer A (nur gefuehlte Nacht) zeigt "
+            f"{sorted(F.present_symbols(sms_a, ('FN', 'FK', 'FD')))} statt "
+            f"nur FN.\nSMS A: {sms_a}"
+        )
+        assert F.present_symbols(sms_a, ("K", "D")) == {"D"}, (
+            f"Nutzer A („Nur Hoechstwert“) zeigt "
+            f"{sorted(F.present_symbols(sms_a, ('K', 'D')))} statt nur D.\n"
+            f"SMS A: {sms_a}"
+        )
+
+        assert F.present_symbols(sms_b, ("FN", "FK", "FD")) == {"FK", "FD"}, (
+            f"Nutzer B (nur gefuehlte Tagesgroesse, Spanne) zeigt "
+            f"{sorted(F.present_symbols(sms_b, ('FN', 'FK', 'FD')))} statt "
+            f"FK/FD — die Auswahl von Nutzer A faerbt offenbar ab.\n"
+            f"SMS B: {sms_b}"
+        )
+        assert F.present_symbols(sms_b, ("K", "D")) == set(), (
+            f"Nutzer B (Temperatur komplett abgewaehlt) zeigt "
+            f"{sorted(F.present_symbols(sms_b, ('K', 'D')))}.\nSMS B: {sms_b}"
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/tdd/test_sms_trip_felt_temp_tokens.py
+++ b/tests/tdd/test_sms_trip_felt_temp_tokens.py
@@ -26,9 +26,13 @@ def _sms(report_type: str, *, felt_enabled: bool) -> str:
     """Echt gerenderte Trip-SMS — mit bzw. ohne aktivierte gefuehlte Temperatur."""
     # #1484: die Nachtgroesse ist eigenstaendig waehlbar — hier aktiv, damit
     # die N-Assertions (Parallelitaet gemessen/gefuehlt) aussagekraeftig bleiben.
+    # #1660 Scheibe A: dieselbe Eigenstaendigkeit jetzt auch auf der
+    # gefuehlten Seite ("wind_chill_night") — ohne expliziten Eintrag bleibt
+    # FN abgewaehlt (F.dc() baut MetricConfig direkt, ohne die
+    # Bestandsableitung des Ladepfads).
     metrics = (
-        ("temperature", "temperature_night", "wind_chill") if felt_enabled
-        else ("temperature", "temperature_night")
+        ("temperature", "temperature_night", "wind_chill", "wind_chill_night")
+        if felt_enabled else ("temperature", "temperature_night")
     )
     report = TripReportFormatter().format_email(
         [F.segment()],

--- a/tests/tdd/test_telegram_felt_temperature_overview.py
+++ b/tests/tdd/test_telegram_felt_temperature_overview.py
@@ -29,12 +29,16 @@ _NUMBER = re.compile(r"-?\d+(?:\.\d+)?")
 
 
 def _report(report_type: str):
+    # #1660 Scheibe A: die abendliche Untergrenze der TF-Zeile haengt jetzt
+    # an der eigenen Groesse "wind_chill_night" -- ohne sie faellt sie still
+    # auf den Gehzeit-Tiefstwert zurueck (F.dc() baut MetricConfig direkt,
+    # ohne die Bestandsableitung des Ladepfads).
     return TripReportFormatter().format_email(
         [F.segment()],
         trip_name="Issue1410",
         report_type=report_type,
         night_weather=F.night_weather(),
-        display_config=F.dc("temperature", "wind_chill"),
+        display_config=F.dc("temperature", "wind_chill", "wind_chill_night"),
         stage_name=F.STAGE_NAME,
         tz=F.TZ,
     )

--- a/tests/unit/test_compare_catalog_derives_from_central_catalog.py
+++ b/tests/unit/test_compare_catalog_derives_from_central_catalog.py
@@ -47,6 +47,12 @@ CENTRAL_METRICS_COVERED_ELSEWHERE: dict[str, str] = {
     # Tages-Minimum dieselbe Aussage -- Eintrag `temp_min_c`
     # (temperature/min) deckt sie ab.
     "temperature_night": "#1484 — deckungsgleich mit temp_min_c (temperature/min)",
+    # #1660 Scheibe A: dieselbe Begruendung fuer die gefuehlte Seite --
+    # gefuehlte Nacht-Tiefsttemperatur am Etappenziel ist im Ortsvergleich
+    # (ganze Tage am festen Ort) dieselbe Aussage wie das Tages-Minimum der
+    # gefuehlten Temperatur -- Eintrag `wind_chill_min_c` (wind_chill/min)
+    # deckt sie ab (Spec-Abgrenzung 4: keine Ortsvergleich-Sonderbehandlung).
+    "wind_chill_night": "#1660 — deckungsgleich mit wind_chill_min_c (wind_chill/min)",
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_preview_night_block.py
+++ b/tests/unit/test_preview_night_block.py
@@ -296,9 +296,13 @@ def test_preview_skips_night_fetch_when_neither_selected(monkeypatch):
 
     target = date.today()
     trip = _demo_trip_single_stage(target, show_night_block=False)
+    # Issue #1660 Scheibe A: "wind_chill_night" ist ein eigener, per Default
+    # aktivierter Katalogeintrag (analog "temperature_night") -- fuer die
+    # "keiner der Gruende"-Gegenprobe muss auch sie abgewaehlt sein.
     trip.display_config.metrics = [
         dataclasses.replace(mc, enabled=False)
-        if mc.metric_id in ("temperature_night", "thunder") else mc
+        if mc.metric_id in ("temperature_night", "thunder", "wind_chill_night")
+        else mc
         for mc in trip.display_config.metrics
     ]
 
@@ -306,5 +310,6 @@ def test_preview_skips_night_fetch_when_neither_selected(monkeypatch):
 
     assert calls == [], (
         "Die Vorschau beschafft Nachtdaten, obwohl weder Nacht-Tabelle noch "
-        "Nacht-Tiefsttemperatur noch Gewitter-Metrik gewaehlt sind."
+        "Nacht-Tiefsttemperatur (gemessen/gefuehlt) noch Gewitter-Metrik "
+        "gewaehlt sind."
     )

--- a/tests/unit/test_sms_fidelity_preview.py
+++ b/tests/unit/test_sms_fidelity_preview.py
@@ -42,21 +42,24 @@ from output.tokens.render import render_line
 # (output.renderers.sms_trip) ein eigenes SMS-Token-Symbol tragen.
 # Issue #1484: "N" (Nacht-Tiefsttemperatur) hängt jetzt an der eigenen
 # metric_id "temperature_night", nicht mehr an "temperature".
+# Issue #1660 Scheibe A: dieselbe Trennung jetzt auch auf der gefuehlten
+# Seite -- "FN" haengt an der eigenen metric_id "wind_chill_night".
 ALL_SMS_METRIC_IDS = [
-    "temperature", "temperature_night", "wind_chill", "precipitation",
-    "rain_probability", "wind", "gust", "thunder", "snow_depth",
-    "snowfall_limit", "fresh_snow",
+    "temperature", "temperature_night", "wind_chill", "wind_chill_night",
+    "precipitation", "rain_probability", "wind", "gust", "thunder",
+    "snow_depth", "snowfall_limit", "fresh_snow",
 ]
 
 # metric_id -> SMS-Symbol(e), die bei Auswahl im gerenderten Text vorkommen
 # müssen. Gespiegelt aus output.renderers.sms_trip.SMS_SYMBOL_BY_METRIC /
-# SMS_MULTI_SYMBOLS_BY_METRIC (§624/§1410/§1435/§1484). Bewusst hier
+# SMS_MULTI_SYMBOLS_BY_METRIC (§624/§1410/§1435/§1484/§1660). Bewusst hier
 # dupliziert (nicht importiert), damit der Test unabhängig von der internen
 # Ableitung bleibt und wirklich das SICHTBARE Symbol im Rendertext prüft.
 METRIC_TO_SYMBOLS = {
     "temperature": ("K", "D"),
     "temperature_night": ("N",),
-    "wind_chill": ("FN", "FK", "FD", "WC"),
+    "wind_chill": ("FK", "FD", "WC"),
+    "wind_chill_night": ("FN",),
     "precipitation": ("R",),
     "rain_probability": ("PR",),
     "wind": ("W",),

--- a/tests/unit/test_sms_token_symbol_register_ratchet.py
+++ b/tests/unit/test_sms_token_symbol_register_ratchet.py
@@ -55,10 +55,12 @@ EXEMPT_FORECAST_FIELDS: dict[str, str] = {
     # Groesse (keine Katalog-Metrik), also gibt es kein Soll-Kuerzel.
     "avalanche_level": "AV: Lawinenstufe, kein Registereintrag",
     # 'WC' — gefuehlte Temperatur. Eine Groesse (Register: 'TF') traegt im
-    # SMS-Format VIER Kuerzel (WC/FN/FK/FD, Nacht/Tiefst/Hoechst +
-    # Zusammenfassung) und ist damit strukturell nicht aus einem einzelnen
-    # sms_code-Feld ableitbar. Bewusster Sonderfall, s. Known Limitations.
-    "wind_chill_c": "WC: vier Kuerzel fuer eine Groesse (Register: TF)",
+    # SMS-Format DREI Kuerzel (WC/FK/FD, Tageskennzahl/Tiefst/Hoechst) und
+    # ist damit strukturell nicht aus einem einzelnen sms_code-Feld
+    # ableitbar. Bewusster Sonderfall, s. Known Limitations. Fix #1660
+    # Scheibe A: 'FN' (Nacht) ist zur eigenen Groesse "wind_chill_night"
+    # gewandert (vorher vier Kuerzel).
+    "wind_chill_c": "WC: drei Kuerzel fuer eine Groesse (Register: TF)",
 }
 
 # metric_id -> Begruendung. Ausnahmen der Register-Herrschaft ueber


### PR DESCRIPTION
## Summary
- **Gefühlte Nacht-Tiefsttemperatur** (`FN`) wird eigene wählbare Wettergröße `wind_chill_night` — exakt nach dem #1484-Muster (`temperature_night`): Katalogeintrag, Kürzel-Bindung, Bestandsableitung beim Laden, Nacht-Datenbeschaffung, Telegram/Kurzzusammenfassungs-Bindung, Stundentabellen-Ausschlüsse.
- **Auswertungswahl wirkt in der SMS** (#1357-Nachzug): `K` nur bei „min", `D` nur bei „max" (Temperatur); `FK`/`FD` analog (Gefühlte Temperatur). „Nur Mittelwert" entfernt beide SMS-Token (DEC-1); Quelle ist die globale Metrikliste, nicht das Kanal-Layout (DEC-2 — sonst wäre die Abwahl bei Kanal-konfigurierten Trips wirkungslos).
- Bestands-Trips unverändert: Ableitung beim Lesen (`derived=True`, nie serialisiert), Golden-Mails bit-identisch, TSV-Fixture rein additiv (9 neue Zeilen).
- Doku nachgezogen: `sms_format.md` (v2.21), `sms_briefing_overview.md`.

## Qualitätsnachweise
- Spec `docs/specs/modules/fix_1660a_temp_trennung.md` (14 ACs, PO-approved)
- TDD: 21 rote Tests vor Implementierung, danach 30/30 grün; Adversary-Fix-Runde +Save-Roundtrip-Test
- Adversary: 3 Runden, 6 Pflicht-Mutationen alle gefangen, F001–F003 behoben und unabhängig nachgemessen, **VERIFIED**
- Regressionsläufe: 261 passed (34 Dateien) + 426/426 (40 abhängige Dateien nach Compare-Katalog-Fix) + #1651-Nachbar-Suiten grün nach Rebase
- Mail-Gates: `briefing_mail_validator` + `email_spec_validator` gegen echt zugestellte Mails (Exit 0)

Part of #1660 (Teil B — fehlende SMS-Token für 14 Metriken — folgt als eigene Scheibe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFziB15Kn8aDEZYe8CoQ31