### PR TITLE
fix(#1517): RegisterHandler prueft Existenz vor E-Mail-Pflicht

### DIFF
--- a/docs/context/fix-1517-validator-register-order.md
+++ b/docs/context/fix-1517-validator-register-order.md
@@ -1,0 +1,85 @@
+# Context: fix-1517-validator-register-order
+
+## Request Summary
+
+Issue #1517: Der Staging-Validator-Nutzer (`data/users/validator-issue110/user.json`) hatte
+weder `id` noch `password_hash` — Login strukturell unmöglich, `scripts/setup-validator-user.sh`
+scheitert seit #1226 still. Ursache lokalisiert: `RegisterHandler` prüft das seit #1226
+pflichtige `email`-Feld VOR der Existenz-Prüfung des Usernamens. Ein idempotenter
+Register-Aufruf ohne `email` gegen einen bereits existierenden Nutzer liefert dadurch
+**400 "validation failed"** statt der von `setup-validator-user.sh` erwarteten **409 "user
+already exists"** — der Login-Verifikationspfad des Scripts wird nie erreicht.
+
+Scope dieses Workflows: NUR der `gregor_zwanzig`-Anteil (Reihenfolge-Fix + Regressionstest).
+Der zweite Issue-Punkt (`henemm-infra/scripts/sync-staging-validator-creds.sh` fehlt
+App-Layer-Passwort-Sync) liegt in einem anderen Repo/Zuständigkeitsbereich — per MQ an die
+`infra`-Instanz gemeldet (Nachricht 61815), nicht Teil dieses Workflows.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `internal/handler/auth.go` | `RegisterHandler` (Zeile 30-107): Validierungsreihenfolge — `email`-Pflichtprüfung (Zeile 64-70, #1226) sitzt vor `s.UserExists` (Zeile 76) |
+| `internal/handler/auth_test.go` | Bestehende Tests zu `RegisterHandler`; `TestRegisterHandlerDuplicateUser` (Zeile 82) sendet immer ein `email`-Feld — die Lücke (existierender User OHNE email) ist unbelegt |
+| `scripts/setup-validator-user.sh` | Sendet beim Register-Call nie `email` (Zeile 20-22) — bewusst so belassen (Script ist reiner Konsument, Reihenfolge-Fix reicht) |
+
+## Existing Patterns
+
+- Alle anderen 400-Validierungen in `RegisterHandler` (Username-Länge, Regex, Passwort-Länge,
+  Zeile 39-59) laufen ebenfalls VOR der Existenz-Prüfung — die #1226-E-Mail-Prüfung reiht sich
+  nur unglücklich in dieselbe Reihenfolge ein. Die Korrektur ist NICHT „alle Validierungen nach
+  hinten schieben" (würde User-Enumeration über Fehlercode-Timing/-Text ermöglichen, siehe
+  Risks), sondern gezielt die Existenz-Prüfung VOR die E-Mail-Pflichtprüfung ziehen.
+- `s.UserExists(req.Username)` (Zeile 76) ist bereits die kanonische Existenzprüfung, die
+  reine Format-Validierungen (Username-Länge/-Regex, Passwort-Länge) nutzt sie aktuell NICHT
+  vorgeschaltet — nur E-Mail soll das betreffen, weil das der einzige Fall ist, der einen
+  belegten Idempotenz-Bruch verursacht (#1517).
+
+## Dependencies
+
+- `store.Store.UserExists` — unverändert, wird nur früher aufgerufen
+- Keine Migration nötig (reine Handler-Logik, kein Datenmodell-Wechsel)
+
+## Risks & Considerations
+
+- **User-Enumeration:** Existenzprüfung vor Format-Validierung heißt: ein Angreifer kann durch
+  Weglassen der E-Mail herausfinden, ob ein Username existiert (409 statt 400). Das ist bereits
+  heute der Fall für gültige, vollständige Requests (409 bei Duplikat ist ohnehin sichtbar) —
+  die Änderung verschiebt die Grenze nur für den E-Mail-Check, kein neues Informationsleck
+  gegenüber dem Status quo (Username-Länge/-Regex/Passwort-Länge bleiben VOR der
+  Existenzprüfung, dort ist das Verhalten unverändert).
+- **Reihenfolge NICHT einfach umdrehen (alle Checks nach UserExists):** würde
+  `TestRegisterHandlerShortUsername`/`TestRegisterHandlerShortPassword` (400 erwartet)
+  brechen, wenn zufällig ein bereits vergebener Username mit ungültigem Passwort kommt — bewusst
+  NICHT im Scope, nur die E-Mail-Prüfung wandert.
+- Bug-Nachweis-Pflicht (Testpolitik): Kern-Test reproduziert das Symptom aus Nutzersicht
+  (Register ohne email gegen existierenden User → muss 409 sein, nicht 400) — rot vor Fix, grün
+  danach.
+
+## Analysis
+
+### Type
+Bug
+
+### Affected Files (with changes)
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `internal/handler/auth.go` | MODIFY | `s.UserExists`-Prüfung (aktuell Zeile 76) vor die E-Mail-Pflichtprüfung (aktuell Zeile 64-70) ziehen; bei Treffer weiterhin 409 |
+| `internal/handler/auth_test.go` | MODIFY | Neuer Test: existierender User, Register-Request OHNE `email` → 409 (nicht 400) |
+
+### Scope Assessment
+- Files: 2
+- Estimated LoC: ~10 (Produktivcode, reine Umstellung) + ~25 (Test)
+- Risk Level: LOW (lokale Reihenfolgeänderung in einem Handler, keine neuen Abhängigkeiten, kein Datenmodell-Wechsel)
+
+### Technical Approach
+In `RegisterHandler` die `s.UserExists(req.Username)`-Prüfung direkt nach den reinen
+Format-Validierungen (Username-Länge/-Regex, Passwort-Länge) und VOR die E-Mail-Pflichtprüfung
+ziehen. Bei existierendem User weiterhin 409 zurückgeben, sonst wie bisher weiter zur
+E-Mail-Prüfung. Kein Eingriff an `dispatchVerificationMail`, `s.SaveUser`, `s.ProvisionUserDirs`.
+
+### Dependencies
+Keine neuen. `store.Store.UserExists` bleibt unverändert (nur früherer Aufrufzeitpunkt).
+
+### Open Questions
+Keine.

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -2371,15 +2371,18 @@ User registration with username + password + email (HTTP 201 on success, 409 if 
 - `password`: ≥8 characters
 - `email`: required (Issue #1226), minimal format check (`strings.Contains(email, "@")` — no `net/mail` parsing, no uniqueness check)
 
+**Check order (Issue #1517):** format checks (username length/regex, password length) → existence check (`s.UserExists`) → email presence/format. The existence check runs **before** the email checks, so a request for an already-registered username returns 409 regardless of whether `email` is set — previously a missing `email` on an existing username produced a misleading 400 `validation failed`.
+
 **Error Responses:**
 
 | Status | Body | Scenario |
 |--------|------|----------|
 | 400 | `{"error":"invalid request"}` | JSON malformed (`internal/handler/auth.go:36`) |
-| 400 | `{"error":"validation failed"}` | username/password/email missing or too short (auth.go:43-67) |
-| 400 | `{"error":"invalid_email"}` | `email` present but without `@` (auth.go:73) |
-| 409 | `{"error":"user already exists"}` | User with this ID already registered (auth.go:80 — Klartext mit Leerzeichen, KEIN snake_case) |
-| 500 | `{"error":"internal error"}` / `{"error":"store_error"}` | Hashing-/Persistenz-Fehler (auth.go:88,101) |
+| 400 | `{"error":"validation failed"}` | username/password missing, too short, or wrong format (auth.go:43-56) |
+| 409 | `{"error":"user already exists"}` | User with this ID already registered (auth.go:62-67 — Klartext mit Leerzeichen, KEIN snake_case; checked before email validation) |
+| 400 | `{"error":"validation failed"}` | `email` missing (auth.go:75-79) |
+| 400 | `{"error":"invalid_email"}` | `email` present but without `@` (auth.go:81-85) |
+| 500 | `{"error":"internal error"}` / `{"error":"store_error"}` | Hashing-/Persistenz-Fehler (auth.go:88-93,102-106) |
 
 Since Issue #1226, a valid `email` also triggers the existing `dispatchVerificationMail` helper (from #1219) after account creation — same Double-Opt-In flow as profile email changes. Google-OAuth account creation (`createOAuthUser`) and passkey-public account creation (`PasskeyRegisterPublicFinishHandler`) trigger the same dispatch on first-time account creation (not on existing-user login).
 
@@ -3395,6 +3398,14 @@ function corridorInside(value, min, max) {
 
 ## Changelog
 
+- 2026-08-09: Issue #1517 — `POST /api/auth/register` prüft die Existenz des Usernamens
+  (`s.UserExists`) jetzt VOR der #1226-E-Mail-Pflichtprüfung; Reihenfolge der reinen
+  Format-Validierungen (Username-Länge/-Regex, Passwort-Länge) bleibt unverändert davor.
+  Bug: ein Register-Aufruf ohne `email`-Feld gegen einen bereits existierenden Username
+  lieferte fälschlich 400 `validation failed` statt 409 `user already exists` — brach u.a.
+  `scripts/setup-validator-user.sh`, das nie ein `email`-Feld sendet. Kein neues Feld, keine
+  DTO-Änderung, nur Prüfreihenfolge in `internal/handler/auth.go`. Siehe
+  `docs/specs/modules/fix_1517_validator_register_order.md`.
 - 2026-08-07: Issue #1552 — `GET /api/metrics` liefert je Größe zusätzlich
   `trip_default_enabled` (bool), gesetzt aus dem neuen Registerfeld
   `trip_default_rank` (`src/app/metric_catalog.py`). Es markiert die

--- a/docs/specs/modules/fix_1517_validator_register_order.md
+++ b/docs/specs/modules/fix_1517_validator_register_order.md
@@ -1,0 +1,151 @@
+---
+entity_id: fix_1517_validator_register_order
+type: module
+created: 2026-08-09
+updated: 2026-08-09
+status: draft
+version: "1.0"
+tags: [auth, go-api, bugfix]
+---
+
+# RegisterHandler — Existenzprüfung vor E-Mail-Pflichtprüfung
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`RegisterHandler` prüft aktuell das seit #1226 pflichtige `email`-Feld VOR der
+Existenzprüfung des Usernamens (`s.UserExists`). Ein idempotenter Register-Aufruf
+ohne `email` gegen einen bereits existierenden Nutzer liefert dadurch fälschlich
+`400 "validation failed"` statt `409 "user already exists"`. Das bricht
+`scripts/setup-validator-user.sh` (sendet nie ein `email`-Feld) und war Ursache
+dafür, dass der Staging-Validator-Nutzer ohne `password_hash` blieb (#1517).
+
+## Source
+
+- **File:** `internal/handler/auth.go`
+- **Identifier:** `RegisterHandler`
+
+## Estimated Scope
+
+- **LoC:** ~10 (Produktivcode, reine Umstellung) + ~25 (Test)
+- **Files:** 2
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `store.Store.UserExists` | Go-Methode | Existenzprüfung des Usernamens — unverändert, wird nur früher im Ablauf aufgerufen |
+
+## Implementation Details
+
+In `RegisterHandler` (`internal/handler/auth.go`) den Block
+
+```go
+if s.UserExists(req.Username) {
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(409)
+    w.Write([]byte(`{"error":"user already exists"}`))
+    return
+}
+```
+
+(aktuell nach der E-Mail-Prüfung, Zeile 77-82) VOR den Block
+
+```go
+if req.Email == "" {
+    ...
+}
+if !strings.Contains(req.Email, "@") {
+    ...
+}
+```
+
+(aktuell Zeile 64-75) ziehen.
+
+Die Reihenfolge der reinen Format-Validierungen (Username-Länge Zeile 40-45,
+Username-Regex Zeile 46-51, Passwort-Länge Zeile 52-57) bleibt **unverändert vor**
+`s.UserExists` — nur die E-Mail-Pflichtprüfung wandert hinter die Existenzprüfung.
+Kein Eingriff an `dispatchVerificationMail`, `s.SaveUser`, `s.ProvisionUserDirs`.
+
+Resultierende Reihenfolge in `RegisterHandler`:
+1. JSON-Decode
+2. Username-Länge (400)
+3. Username-Regex (400)
+4. Passwort-Länge (400)
+5. **`s.UserExists` (409)** ← vorgezogen
+6. E-Mail leer (400)
+7. E-Mail-Format (400 `invalid_email`)
+8. bcrypt, SaveUser, ProvisionUserDirs, dispatchVerificationMail, 201
+
+## Expected Behavior
+
+- **Input:** `POST /api/auth/register` mit `username`, `password`, optional `email`
+- **Output:** Bei existierendem Username **409** unabhängig davon, ob `email`
+  gesetzt ist. Bei neuem Username ohne `email` weiterhin **400
+  "validation failed"**. Bei neuem Username mit ungültigem Username/Passwort
+  weiterhin **400** (Reihenfolge davor unverändert).
+- **Side effects:** Keine neuen. Kein Konto wird bei 409 oder 400 angelegt (wie
+  zuvor).
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Username existiert bereits im Store / When `POST
+  /api/auth/register` mit diesem Username und **ohne** `email`-Feld aufgerufen
+  wird / Then antwortet der Handler mit **409 "user already exists"** (nicht 400).
+  - Test: Neuer Test in `internal/handler/auth_test.go` — Store mit existierendem
+    User vorbereiten (analog `TestRegisterHandlerDuplicateUser`), Request-Body
+    ohne `email`-Feld senden, `w.Code == 409` und Fehlertext `"user already
+    exists"` prüfen. Dies ist der Kern-Regressionstest für den Bug aus #1517
+    (rot vor dem Fix, grün danach).
+
+- **AC-2:** Given ein Username existiert bereits im Store / When `POST
+  /api/auth/register` mit diesem Username und **gesetztem** `email`-Feld
+  aufgerufen wird / Then antwortet der Handler weiterhin mit **409 "user
+  already exists"**.
+  - Test: Bestehender Test `TestRegisterHandlerDuplicateUser`
+    (`internal/handler/auth_test.go:82`) bleibt unverändert grün — belegt, dass
+    der Fix das bestehende Duplikat-Verhalten mit E-Mail nicht verändert.
+
+- **AC-3:** Given ein Username existiert **nicht** im Store / When `POST
+  /api/auth/register` mit diesem (neuen) Username und **ohne** `email`-Feld
+  aufgerufen wird / Then antwortet der Handler weiterhin mit **400 "validation
+  failed"**.
+  - Test: Bestehender Test `TestRegisterHandler_MissingEmail_AC1`
+    (`internal/handler/auth_test.go:136`) bleibt unverändert grün — belegt, dass
+    die E-Mail-Pflichtprüfung für neue User (#1226) durch das Vorziehen von
+    `s.UserExists` nicht ausgehebelt wird.
+
+- **AC-4:** Given ein Username existiert **nicht** im Store / When `POST
+  /api/auth/register` mit zu kurzem Username (< 3 Zeichen) oder zu kurzem
+  Passwort (< 8 Zeichen) aufgerufen wird / Then antwortet der Handler weiterhin
+  mit **400** (nicht 409, nicht 500).
+  - Test: Bestehende Tests `TestRegisterHandlerShortUsername`
+    (`internal/handler/auth_test.go:103`) und `TestRegisterHandlerShortPassword`
+    (`internal/handler/auth_test.go:117`) bleiben unverändert grün — belegt,
+    dass die Reihenfolge der Format-Validierungen VOR `s.UserExists` nicht
+    angetastet wurde.
+
+## Known Limitations
+
+- **User-Enumeration:** Die Existenzprüfung liegt jetzt vor der E-Mail-Pflicht-
+  prüfung — ein Angreifer kann durch Weglassen von `email` herausfinden, ob ein
+  Username existiert (409 statt 400), ohne eine gültige E-Mail angeben zu
+  müssen. Das ist kein neues Informationsleck gegenüber dem Status quo: bei
+  vollständigen, formal gültigen Requests war der 409 bei Duplikat schon vorher
+  sichtbar. Username-Länge/-Regex und Passwort-Länge bleiben unverändert VOR der
+  Existenzprüfung, dort ändert sich am Enumeration-Verhalten nichts.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine lokale Reihenfolgeänderung innerhalb eines bestehenden
+  Handlers, kein neues Datenmodell, kein neuer Kanal, keine neue Abhängigkeit —
+  berührt keine der in `docs/adr/README.md` gelisteten Entscheidungsflächen.
+
+## Changelog
+
+- 2026-08-09: Initial spec created

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -55,6 +55,17 @@ func RegisterHandler(s *store.Store, bcryptCost int, cfg config.Config) http.Han
 			w.Write([]byte(`{"error":"validation failed"}`))
 			return
 		}
+		// Issue #1517: Existenzprüfung wandert VOR die E-Mail-Pflichtprüfung —
+		// ein Register-Aufruf ohne email gegen einen bereits existierenden User
+		// muss 409 liefern, nicht fälschlich 400 (bricht sonst
+		// scripts/setup-validator-user.sh, das nie ein email-Feld sendet).
+		if s.UserExists(req.Username) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(409)
+			w.Write([]byte(`{"error":"user already exists"}`))
+			return
+		}
+
 		// Issue #1226: E-Mail ist ab jetzt Pflichtfeld — nur mit gesetzter,
 		// formal gültiger Adresse kann der Verifikations-Dispatch (Double-Opt-In)
 		// überhaupt greifen. Leeres Feld → generischer "validation failed"; Feld
@@ -71,13 +82,6 @@ func RegisterHandler(s *store.Store, bcryptCost int, cfg config.Config) http.Han
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(400)
 			w.Write([]byte(`{"error":"invalid_email"}`))
-			return
-		}
-
-		if s.UserExists(req.Username) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(409)
-			w.Write([]byte(`{"error":"user already exists"}`))
 			return
 		}
 

--- a/internal/handler/auth_test.go
+++ b/internal/handler/auth_test.go
@@ -100,6 +100,116 @@ func TestRegisterHandlerDuplicateUser(t *testing.T) {
 	}
 }
 
+// TDD Regression — Issue #1517: RegisterHandler prüfte die E-Mail-Pflicht
+// (#1226) VOR der Existenzprüfung. Ein Register-Aufruf ohne email gegen
+// einen bereits existierenden User lieferte dadurch 400 statt der
+// erwarteten 409 — bricht scripts/setup-validator-user.sh (sendet nie ein
+// email-Feld). SPEC: docs/specs/modules/fix_1517_validator_register_order.md AC-1
+func TestRegisterHandler_ExistingUserWithoutEmail_Returns409_AC1(t *testing.T) {
+	s := newTestStore(t)
+	dir := filepath.Join(s.DataDir, "users", "alice")
+	os.MkdirAll(dir, 0755)
+	os.WriteFile(filepath.Join(dir, "user.json"), []byte(`{"id":"alice"}`), 0644)
+
+	h := RegisterHandler(s, bcrypt.MinCost, testRegisterCfg())
+
+	// WHEN: Registering same username WITHOUT email (wie
+	// scripts/setup-validator-user.sh es tut)
+	body := `{"username":"alice","password":"geheim123"}`
+	req := httptest.NewRequest("POST", "/api/auth/register", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	// THEN: 409 Conflict (nicht 400 "validation failed")
+	if w.Code != 409 {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["error"] != "user already exists" {
+		t.Errorf("expected error 'user already exists', got %q", resp["error"])
+	}
+}
+
+// TDD Regression — Issue #1517 Adversary F001: Format-Validierungen
+// (Username-Länge/-Regex, Passwort-Länge) müssen VOR s.UserExists bleiben,
+// sonst würde ein zu kurzes Passwort gegen einen existierenden Username
+// fälschlich 409 liefern und damit die Existenz preisgeben (Enumeration-Leak,
+// den die Spec unter "Known Limitations" bewusst begrenzt sehen will). Die
+// bestehenden AC-4-Tests nutzen einen leeren Store, in dem UserExists
+// ohnehin immer false liefert — dieser Test prüft die Reihenfolge dort, wo
+// sie beobachtbar wird: mit einem bereits existierenden User.
+// SPEC: docs/specs/modules/fix_1517_validator_register_order.md AC-4
+func TestRegisterHandler_ExistingUserShortPassword_Returns400NotEnumeration(t *testing.T) {
+	s := newTestStore(t)
+	dir := filepath.Join(s.DataDir, "users", "alice")
+	os.MkdirAll(dir, 0755)
+	os.WriteFile(filepath.Join(dir, "user.json"), []byte(`{"id":"alice"}`), 0644)
+
+	h := RegisterHandler(s, bcrypt.MinCost, testRegisterCfg())
+
+	// WHEN: Registering same username with a too-short password
+	body := `{"username":"alice","password":"short","email":"alice@beispiel.de"}`
+	req := httptest.NewRequest("POST", "/api/auth/register", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	// THEN: 400 "validation failed" (NICHT 409 — das wäre der Enumeration-Leak)
+	if w.Code != 400 {
+		t.Fatalf("expected 400 for short password against existing user, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["error"] != "validation failed" {
+		t.Errorf("expected error 'validation failed', got %q", resp["error"])
+	}
+}
+
+// TDD Regression — Issue #1517 Adversary F002: strukturell identisch zu F001,
+// aber für Username-Länge und Username-Regex statt Passwort-Länge. Der
+// existierende Store-Eintrag wird bewusst direkt als Datei geschrieben (statt
+// über den Handler angelegt) — genau dieser Bypass ermöglicht einen
+// gespeicherten Username, der die aktuellen Format-Regeln verletzt, und macht
+// so die Reihenfolge beobachtbar: bliebe s.UserExists vor den
+// Format-Validierungen, würde ein Request mit exakt diesem (ungültigen)
+// Username fälschlich 409 statt 400 liefern.
+// SPEC: docs/specs/modules/fix_1517_validator_register_order.md AC-4
+func TestRegisterHandler_ExistingUserInvalidUsernameFormat_Returns400NotEnumeration(t *testing.T) {
+	cases := []struct {
+		name     string
+		username string
+	}{
+		{"too short (< 3 chars)", "ab"},
+		{"invalid characters", "ali$ce"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+			dir := filepath.Join(s.DataDir, "users", tc.username)
+			os.MkdirAll(dir, 0755)
+			os.WriteFile(filepath.Join(dir, "user.json"), []byte(`{"id":"`+tc.username+`"}`), 0644)
+
+			h := RegisterHandler(s, bcrypt.MinCost, testRegisterCfg())
+
+			body := `{"username":"` + tc.username + `","password":"geheim123","email":"user@beispiel.de"}`
+			req := httptest.NewRequest("POST", "/api/auth/register", strings.NewReader(body))
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+
+			// THEN: 400 "validation failed" (NICHT 409 — das wäre der Enumeration-Leak)
+			if w.Code != 400 {
+				t.Fatalf("expected 400 for invalid username against existing user, got %d: %s", w.Code, w.Body.String())
+			}
+			var resp map[string]string
+			json.Unmarshal(w.Body.Bytes(), &resp)
+			if resp["error"] != "validation failed" {
+				t.Errorf("expected error 'validation failed', got %q", resp["error"])
+			}
+		})
+	}
+}
+
 func TestRegisterHandlerShortUsername(t *testing.T) {
 	s := newTestStore(t)
 	h := RegisterHandler(s, bcrypt.MinCost, testRegisterCfg())


### PR DESCRIPTION
## Summary
- `RegisterHandler` prüfte die seit #1226 pflichtige E-Mail-Adresse VOR der Existenzprüfung des Usernamens -- ein idempotenter Register-Aufruf ohne `email` gegen einen bereits existierenden Nutzer lieferte dadurch faelschlich 400 statt 409
- Genau das brach `scripts/setup-validator-user.sh` (sendet nie ein `email`-Feld) und war Ursache dafür, dass der Staging-Validator-Nutzer ohne `password_hash` blieb
- Fix: `s.UserExists()` vor die E-Mail-Pflichtprüfung gezogen; Format-Validierungen (Username-Länge/-Regex, Passwort-Länge) bleiben unverändert davor (Enumeration-Schutz)
- `docs/reference/api_contract.md` korrigiert (spiegelte den Bug wider)

## Test plan
- [x] `go test -race -count=1 -v ./internal/handler/...` -- 499/499 grün
- [x] Adversary VERIFIED (3 Runden, 2 Fix-Loops: F001 Passwort-Boundary, F002 Username-Format-Boundary, beide behoben und testabgesichert)
- [x] Alle 4 Acceptance Criteria + beide Adversary-Nachträge mit Test belegt
- [x] Scope: 2 Code-Dateien, +121 LoC (Limit 250)
- [x] Reiner Backend-Fix, kein Frontend -- Staging-Browser-Gate entfällt

Refs: #1517