### PR TITLE
fix(#1666): setup-validator-user.sh sendet nginx-Basicauth-Header

### DIFF
--- a/docs/specs/fast/fix-1666-validator-basicauth.md
+++ b/docs/specs/fast/fix-1666-validator-basicauth.md
@@ -1,0 +1,16 @@
+# Mini-Spec: fix-1666-validator-basicauth
+
+## Was ändert sich
+- `scripts/setup-validator-user.sh`: Beiden `curl`-Aufrufen (Register Zeile 20-22, Login-Verifikation Zeile 30-33) wird `-u "$USER:$PASS"` hinzugefügt, damit die nginx-Basicauth vor Staging (`GZ_VALIDATOR_USER`/`GZ_VALIDATOR_PASS` aus `.claude/validator.env`) passiert wird.
+
+## Was darf sich nicht ändern
+- Die bestehende HTTP-Status-Logik (201/409/429/Fehlerfall) und die JSON-Payloads der beiden Requests bleiben unverändert — nur der zusätzliche Basicauth-Header wird ergänzt.
+- Kein Verhalten für lokale/nicht-Staging-Ziele ändert sich (Basicauth-Header ist idempotent, falls nicht erforderlich).
+
+## Manuelle Test-Schritte
+1. `bash scripts/setup-validator-user.sh` gegen Staging ausführen.
+2. Erwartung: kein HTTP 401 (nginx-Basicauth-Seite) mehr — stattdessen reguläre App-Antwort (201, 409 oder 429 je nach Vorzustand).
+3. Bei 409/429: Login-Verifikationszweig durchläuft ebenfalls ohne 401.
+
+## Inline-Test (wird während Implementierung geschrieben)
+- [ ] Kein automatisierter Test möglich ohne Live-Staging-Zugriff (reines Shell-Script, keine Unit-Test-Infrastruktur vorhanden) — Verifikation erfolgt manuell gegen Staging gemäß obigen Schritten.

--- a/scripts/setup-validator-user.sh
+++ b/scripts/setup-validator-user.sh
@@ -18,6 +18,7 @@ USER="${GZ_VALIDATOR_USER:?GZ_VALIDATOR_USER muss gesetzt sein}"
 PASS="${GZ_VALIDATOR_PASS:?GZ_VALIDATOR_PASS muss gesetzt sein}"
 
 HTTP_CODE=$(curl -s -o /tmp/validator-setup.out -w "%{http_code}" -X POST "$URL/api/auth/register" \
+    -u "$USER:$PASS" \
     -H "Content-Type: application/json" \
     -d "{\"username\":\"$USER\",\"password\":\"$PASS\"}")
 
@@ -29,6 +30,7 @@ case "$HTTP_CODE" in
         echo "Test-User '$USER' existiert bereits auf $URL (HTTP $HTTP_CODE) — Login wird verifiziert..."
         LOGIN_CODE=$(curl -s -o /tmp/validator-login.json -w "%{http_code}" \
             -X POST "$URL/api/auth/login" \
+            -u "$USER:$PASS" \
             -H "Content-Type: application/json" \
             -d "{\"username\":\"$USER\",\"password\":\"$PASS\"}")
         if [ "$LOGIN_CODE" = "200" ]; then


### PR DESCRIPTION
## Summary
- `scripts/setup-validator-user.sh` scheiterte strukturell gegen Staging (HTTP 401 von nginx-Basicauth, keine App-Antwort), weil beiden `curl`-Aufrufen (Register + Login-Verifikation) der `-u`-Header fehlte
- Beide Aufrufe bekommen jetzt `-u "$GZ_VALIDATOR_USER:$GZ_VALIDATOR_PASS"`
- Sonst keine Verhaltensänderung (HTTP-Status-Logik, Payloads, Fehlermeldungen unverändert)

## Test plan
- [x] `bash -n scripts/setup-validator-user.sh` fehlerfrei
- [x] Diff auf reine `-u`-Ergänzung geprüft, kein Scope-Creep
- [ ] Manueller Lauf gegen Staging nach Merge (Register/Login ohne 401)

Refs #1666

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxSo9P8EyxyX138FHsk1Kw