### PR TITLE
fix(#1660 B): Null-Form erreicht den Produktionspfad

### DIFF
--- a/src/output/renderers/sms_trip.py
+++ b/src/output/renderers/sms_trip.py
@@ -63,18 +63,14 @@ if TYPE_CHECKING:
 # app-freie Formatschicht `output/tokens/` darf es nicht und führt die Kürzel
 # dort weiterhin als Literale (Schichtgrenze, abgesichert durch die Ratsche
 # tests/unit/test_sms_token_symbol_register_ratchet.py).
-_SMS_SYMBOL_METRIC_IDS: tuple[str, ...] = (
-    "precipitation",
-    "rain_probability",
-    "wind",
-    "gust",
-    "thunder",
-    "snow_depth",
-    "snowfall_limit",
-    "fresh_snow",
-    # Issue #1660 Scheibe B: 14 waehlbare Metriken, bisher ohne SMS-Token.
-    # Alle 1:1 (kein Kuerzel-Mehrfach wie wind_chill) -> gehoeren in diese
-    # Register-Ableitung, NICHT in SMS_MULTI_SYMBOLS_BY_METRIC (DEC-1).
+# Issue #1660 Scheibe B Fix-Loop (Muster #1410, DEC-1): die 14 waehlbaren
+# Metriken als eigene, benannte Konstante -- Single Source fuer
+# _SMS_SYMBOL_METRIC_IDS UNTEN und fuer build_extended_metric_specs() (s.
+# dort). Vorher standen dieselben 14 Ids literal in _SMS_SYMBOL_METRIC_IDS
+# UND in trip_report.py's disabled-only-Schleife -- das Auseinanderdriften
+# war genau die Ursache des Fix-Loop-Bugs (Root-Cause: aktive Metriken
+# bekamen NIE eine MetricSpec, nur abgewaehlte).
+SMS_NULLFORM_METRIC_IDS: tuple[str, ...] = (
     "humidity",
     "dewpoint",
     "wind_direction",
@@ -89,6 +85,21 @@ _SMS_SYMBOL_METRIC_IDS: tuple[str, ...] = (
     "uv_index",
     "pressure",
     "freezing_level",
+)
+
+_SMS_SYMBOL_METRIC_IDS: tuple[str, ...] = (
+    "precipitation",
+    "rain_probability",
+    "wind",
+    "gust",
+    "thunder",
+    "snow_depth",
+    "snowfall_limit",
+    "fresh_snow",
+    # Issue #1660 Scheibe B: 14 waehlbare Metriken, bisher ohne SMS-Token.
+    # Alle 1:1 (kein Kuerzel-Mehrfach wie wind_chill) -> gehoeren in diese
+    # Register-Ableitung, NICHT in SMS_MULTI_SYMBOLS_BY_METRIC (DEC-1).
+    *SMS_NULLFORM_METRIC_IDS,
 )
 
 # Benannte Ausnahme von der Register-Ableitung: 'TH:' ist Grammatikform (der
@@ -106,6 +117,25 @@ SMS_SYMBOL_BY_METRIC: dict[str, str] = {
     metric_id: _SMS_SYMBOL_GRAMMAR.get(metric_id) or get_sms_code(metric_id)
     for metric_id in _SMS_SYMBOL_METRIC_IDS
 }
+
+
+def build_extended_metric_specs(active_metric_ids: set[str]) -> list[MetricSpec]:
+    """#1660 B Fix-Loop: MetricSpecs fuer die 14 erweiterten Metriken in BEIDEN
+    Faellen (Muster #1410, wie schon SMS_MULTI_SYMBOLS_BY_METRIC unten fuer
+    die Temperatur-Trios) -- nur so erreicht die Null-Form (§9 der Spec) den
+    Produktionspfad. Root-Cause des Fix-Loop-Bugs: trip_report.py fuehrte die
+    14 bisher ausschliesslich in der disabled-only-Schleife (Bug #944), eine
+    aktive Metrik ohne Daten bekam dadurch NIE eine Spec und builder.py's
+    `if spec is None and not samples: continue`-Gate liess sie komplett
+    entfallen statt '{symbol}-' zu rendern."""
+    return [
+        MetricSpec(
+            symbol=SMS_SYMBOL_BY_METRIC[metric_id],
+            enabled=metric_id in active_metric_ids,
+        )
+        for metric_id in SMS_NULLFORM_METRIC_IDS
+    ]
+
 
 # Issue #1410: metric_id -> MEHRERE SMS-Kuerzel derselben Metrik. Eigene
 # Zuordnung, weil eine Metrik hier mehrere Symbole traegt (Nacht/Tiefst/

--- a/src/output/renderers/trip_report.py
+++ b/src/output/renderers/trip_report.py
@@ -280,7 +280,8 @@ class TripReportFormatter:
         )
 
         from output.renderers.sms_trip import (
-            SMSTripFormatter, SMS_MULTI_SYMBOLS_BY_METRIC, SMS_SYMBOL_BY_METRIC,
+            SMSTripFormatter, SMS_MULTI_SYMBOLS_BY_METRIC, SMS_NULLFORM_METRIC_IDS,
+            SMS_SYMBOL_BY_METRIC, build_extended_metric_specs,
         )
         # Issue #1575 Scheibe 3: die MENGE der SMS-Metriken kommt aus der
         # SMS-eigenen Kaskade (per_report > per_channel > global), der
@@ -317,7 +318,18 @@ class TripReportFormatter:
             MetricSpec(symbol=sym, enabled=False)
             for metric_id, sym in SMS_SYMBOL_BY_METRIC.items()
             if metric_id not in active_metric_ids
+            # Fix-Loop #1660 B: die 14 erweiterten Metriken sind hier
+            # AUSGENOMMEN -- sie bekommen unten ueber build_extended_metric_
+            # specs() eine Spec in BEIDEN Faellen (aktiv UND abgewaehlt), nicht
+            # nur bei Abwahl. Ohne diese Ausnahme entstuenden doppelte Specs
+            # fuer dasselbe Symbol.
+            and metric_id not in SMS_NULLFORM_METRIC_IDS
         ]
+        # Root-Cause-Fix (Adversary/Staging-E2E #1660 B, Prod-Bug): vorher
+        # bekamen aktive der 14 Metriken KEINE Spec -> builder.py's
+        # `if spec is None and not samples: continue` liess sie bei fehlenden
+        # Daten komplett entfallen statt die Null-Form (§9) zu rendern.
+        _disabled_sms_specs += build_extended_metric_specs(active_metric_ids)
         # Issue #1410 §6: die Temperatur-Token erscheinen NUR bei aktivierter
         # Metrik -- dasselbe Pruefmuster wie oben fuer SD/SL. Anders als dort
         # wird die Spec in BEIDEN Faellen mitgegeben: nur so kann der Builder

--- a/tests/tdd/test_sms_extended_null_forms.py
+++ b/tests/tdd/test_sms_extended_null_forms.py
@@ -1,0 +1,217 @@
+"""TDD RED->GREEN: Fix-Loop #1660 B -- Null-Form fuer aktive Metriken ohne Daten.
+
+Bug (Staging-E2E, Verdict BROKEN): "Metrik gewaehlt, keine Daten im Fenster"
+zeigte KEINE Null-Form (z.B. 'PT-') -- der Token fehlte VOLLSTAENDIG. Ursache:
+trip_report.py fuehrte die 14 erweiterten Metriken (#1660 Scheibe B) nur in
+der disabled-only-Schleife (Bug-#944-Muster) -- eine AKTIVE Metrik bekam
+dadurch nie eine MetricSpec und builder.py's
+`if spec is None and not samples: continue`-Gate liess sie ganz entfallen.
+
+Diese Tests laufen bewusst ueber den ECHTEN Produktionshelfer
+`build_extended_metric_specs()` (nicht ueber eine an Ort und Stelle
+konstruierte MetricSpec wie der bestehende AC-10-Test) -- Prueforte muss dem
+Wirkort entsprechen (Muster aus mehreren Vorfaellen, s. CLAUDE.md).
+
+SPEC: docs/specs/modules/fix_1660b_sms_token_wiring.md DEC-3/§9, AC-10.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from app.models import (
+    ForecastDataPoint,
+    ForecastMeta,
+    GPXPoint,
+    NormalizedTimeseries,
+    Provider,
+    SegmentWeatherData,
+    SegmentWeatherSummary,
+    ThunderLevel,
+    TripSegment,
+)
+from output.renderers.sms_trip import SMSTripFormatter, build_extended_metric_specs
+
+_TZ = ZoneInfo("UTC")
+
+
+def _meta() -> ForecastMeta:
+    return ForecastMeta(
+        provider=Provider.OPENMETEO, model="test",
+        run=datetime(2026, 8, 10, 0, 0, tzinfo=timezone.utc),
+        grid_res_km=1.0, interp="point_grid",
+    )
+
+
+def _dp(hour: int, *, day: int = 10, **overrides) -> ForecastDataPoint:
+    """Datenpunkt OHNE die zu testenden Klassen-c/a/b-Felder -- Default laesst
+    precip_type/visibility_m unbesetzt (None); cloud_total_pct wird bei Bedarf
+    per Override auf None gesetzt (Basis-Default ist 50)."""
+    base = dict(
+        ts=datetime(2026, 8, day, hour, 0, tzinfo=timezone.utc),
+        t2m_c=15.0, wind10m_kmh=5.0, gust_kmh=5.0, precip_1h_mm=0.0,
+        pop_pct=0, cloud_total_pct=50, thunder_level=ThunderLevel.NONE,
+        humidity_pct=55,
+    )
+    base.update(overrides)
+    return ForecastDataPoint(**base)
+
+
+def _single_day_segment(points: list[ForecastDataPoint]) -> SegmentWeatherData:
+    seg = TripSegment(
+        segment_id=1,
+        start_point=GPXPoint(lat=47.0, lon=11.0, elevation_m=1500),
+        end_point=GPXPoint(lat=47.1, lon=11.1, elevation_m=1800),
+        start_time=datetime(2026, 8, 10, 4, 0, tzinfo=timezone.utc),
+        end_time=datetime(2026, 8, 10, 19, 0, tzinfo=timezone.utc),
+        duration_hours=15.0, distance_km=20.0, ascent_m=800, descent_m=400,
+    )
+    ts = NormalizedTimeseries(meta=_meta(), data=points)
+    return SegmentWeatherData(
+        segment=seg, timeseries=ts,
+        aggregated=SegmentWeatherSummary(temp_min_c=10.0, temp_max_c=20.0),
+        fetched_at=datetime(2026, 8, 10, 3, 0, tzinfo=timezone.utc),
+        provider="openmeteo",
+    )
+
+
+def test_precip_type_null_form_when_active_without_data():
+    """Klasse (c), Wirkort-Test: nur precip_type aktiv, KEIN Datenpunkt traegt
+    precip_type -> 'PT-' MUSS in der SMS stehen (nicht: Token fehlt ganz)."""
+    points = [_dp(h) for h in range(4, 20)]
+    segments = [_single_day_segment(points)]
+
+    sms = SMSTripFormatter().format_sms(
+        segments, stage_name="Etappe1", report_type="evening", tz=_TZ,
+        disabled_specs=build_extended_metric_specs({"precip_type"}),
+    )
+    assert "PT-" in sms, f"PT-Null-Form fehlt (Bug: Token entfaellt komplett): {sms!r}"
+
+
+def test_cloud_total_null_and_gap_form_when_active_without_data():
+    """Klasse (a): nur cloud_total aktiv, keine Wolkendaten -> 'CT-'; mit
+    Datenluecke (has_gap=True) -> 'CT?'."""
+    points = [_dp(h, cloud_total_pct=None) for h in range(4, 20)]
+    segments = [_single_day_segment(points)]
+
+    sms = SMSTripFormatter().format_sms(
+        segments, stage_name="Etappe1", report_type="evening", tz=_TZ,
+        disabled_specs=build_extended_metric_specs({"cloud_total"}),
+    )
+    assert "CT-" in sms, f"CT-Null-Form fehlt: {sms!r}"
+
+    sms_gap = SMSTripFormatter().format_sms(
+        segments, stage_name="Etappe1", report_type="evening", tz=_TZ,
+        disabled_specs=build_extended_metric_specs({"cloud_total"}),
+        has_gap=True,
+    )
+    assert "CT?" in sms_gap, f"CT-Gap-Form fehlt: {sms_gap!r}"
+    assert "CT-" not in sms_gap, f"bei Gap darf keine '-'-Form mehr stehen: {sms_gap!r}"
+
+
+def test_visibility_null_form_when_active_without_data():
+    """Klasse (b): nur visibility aktiv, keine Sichtwerte -> 'VS-'."""
+    points = [_dp(h) for h in range(4, 20)]
+    segments = [_single_day_segment(points)]
+
+    sms = SMSTripFormatter().format_sms(
+        segments, stage_name="Etappe1", report_type="evening", tz=_TZ,
+        disabled_specs=build_extended_metric_specs({"visibility"}),
+    )
+    assert "VS-" in sms, f"VS-Null-Form fehlt: {sms!r}"
+
+
+def test_empty_active_set_matches_all_disabled_byte_identical():
+    """Negativ-Kontrolle: build_extended_metric_specs(set()) (keine der 14
+    gewaehlt, aber Daten LIEGEN VOR) muss zeichengleich zum alten
+    disabled-only-Muster sein (Bug #944, s. trip_report.py's fruehere
+    1:1-Schleife) -- die vollstaendige Abwahl darf durch den Helfer weder ein
+    Geistertoken (z.B. 'PT-' aus der Null-Form) noch einen echten Wert
+    (z.B. 'HU55@4') erzeugen."""
+    from output.renderers.sms_trip import SMS_NULLFORM_METRIC_IDS, SMS_SYMBOL_BY_METRIC
+    from output.tokens.dto import MetricSpec
+
+    points = [_dp(h) for h in range(4, 20)]
+    segments = [_single_day_segment(points)]
+
+    sms_via_helper = SMSTripFormatter().format_sms(
+        segments, stage_name="Etappe1", report_type="evening", tz=_TZ,
+        disabled_specs=build_extended_metric_specs(set()),
+    )
+    old_style_all_disabled = [
+        MetricSpec(symbol=SMS_SYMBOL_BY_METRIC[mid], enabled=False)
+        for mid in SMS_NULLFORM_METRIC_IDS
+    ]
+    sms_via_old_pattern = SMSTripFormatter().format_sms(
+        segments, stage_name="Etappe1", report_type="evening", tz=_TZ,
+        disabled_specs=old_style_all_disabled,
+    )
+    assert sms_via_helper == sms_via_old_pattern, (
+        f"leeres active-Set muss zeichengleich zum alten disabled-only-Muster sein:\n"
+        f"  Helfer: {sms_via_helper!r}\n"
+        f"  alt:    {sms_via_old_pattern!r}"
+    )
+    assert "PT-" not in sms_via_helper and "HU55" not in sms_via_helper, (
+        f"kein Geistertoken/Wert der 14 bei vollstaendiger Abwahl erwartet: {sms_via_helper!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Adversary-Runde 3 (VERDRAHTUNG): die Tests oben rufen build_extended_
+# metric_specs() SELBST auf und reichen das Ergebnis von Hand an format_sms()
+# -- das prueft die Helfer-Grammatik, nicht die Verdrahtung in trip_report.py
+# (Zeile "_disabled_sms_specs += build_extended_metric_specs(active_metric_ids)").
+# Mutation "diese Zeile entfernen" = exakt der urspruengliche Staging-Bug --
+# und macht KEINEN der obigen Tests rot (Prüfort != Wirkort).
+#
+# Die folgenden Tests fahren deshalb den ECHTEN Produktionspfad
+# TripReportFormatter().format_email() -> report.sms_text (Vorbild:
+# tests/tdd/test_sms_thunder_from_hourly_timeseries.py, dort fuer TH:).
+# Nur hier wirkt die Metrik-Auswahl (UnifiedWeatherDisplayConfig) tatsaechlich
+# ueber sms_metric_ids -> active_metric_ids -> build_extended_metric_specs().
+# ---------------------------------------------------------------------------
+
+from output.renderers.trip_report import TripReportFormatter
+from tests.tdd import _min_temp_felt_fixtures as F
+
+
+def test_precip_type_null_form_reaches_production_wiring():
+    """AKTIV, ohne precip_type-Daten im Fenster -> 'PT-' MUSS in der ECHTEN
+    Trip-SMS stehen (TripReportFormatter().format_email() -> sms_text).
+
+    F.segment()/F.night_weather() tragen nie precip_type (Feld bleibt in der
+    Fixture unbesetzt) -- "gewaehlt, aber kein Wert" ist damit automatisch
+    gegeben, ohne die Zeitreihe extra zu verstuemmeln."""
+    report = TripReportFormatter().format_email(
+        [F.segment()],
+        trip_name="Issue1660B",
+        report_type="evening",
+        night_weather=F.night_weather(),
+        display_config=F.dc("precip_type"),
+        stage_name=F.STAGE_NAME,
+        tz=F.TZ,
+    )
+    sms = report.sms_text
+    assert F.sms_token_value(sms, "PT") == "-", (
+        f"'PT-' erwartet (Metrik gewaehlt, keine Daten) -- Bug: der Token "
+        f"entfaellt komplett, wenn die Verdrahtung in trip_report.py fehlt.\n"
+        f"SMS: {sms!r}"
+    )
+
+
+def test_precip_type_absent_via_production_wiring_when_deselected():
+    """Negativfall ueber denselben Produktionspfad: precip_type NICHT
+    gewaehlt -> kein 'PT'-Token in der SMS (weder Wert noch Null-Form)."""
+    report = TripReportFormatter().format_email(
+        [F.segment()],
+        trip_name="Issue1660B",
+        report_type="evening",
+        night_weather=F.night_weather(),
+        display_config=F.dc("precipitation"),
+        stage_name=F.STAGE_NAME,
+        tz=F.TZ,
+    )
+    sms = report.sms_text
+    assert F.sms_token_value(sms, "PT") is None, (
+        f"'PT' darf bei Abwahl gar nicht vorkommen: {sms!r}"
+    )


### PR DESCRIPTION
## #1660 Teil B Fix-Loop: Null-Form erreicht den Produktionspfad

Nachbesserung zu PR #1672 (NICHT automatisch schließen — Issue-Close erst nach Prod-Selftest).

**Staging-Befund (external-validator, Verdict BROKEN):** Bei „Metrik gewählt, aber kein Wert im Fenster" fehlte das Token vollständig statt der spec-geforderten Null-Form — bei nur `precip_type` aktiv war die Kurzform-Zeile komplett leer.

**Root Cause:** `trip_report.py` übergab `MetricSpec`s nur für **abgewählte** Metriken (#944-Muster); für aktive der 14 kam beim Builder keine Spec an → `spec is None and keine Daten` ⇒ gar kein Token. Der bisherige AC-10-Test prüfte am Builder mit einer Spec, die Produktion nie übergibt (Prüfort ≠ Wirkort).

**Fix (Muster #1410, Both-Cases-Specs):**
- `sms_trip.py`: Konstante `SMS_NULLFORM_METRIC_IDS` + geteilter Helfer `build_extended_metric_specs(active_metric_ids)`
- `trip_report.py`: die 14 aus der disabled-only-Schleife ausgenommen, Helfer-Aufruf ergänzt
- Neue Wirkort-Tests fahren den echten `TripReportFormatter().format_email()`-Pfad (`report.sms_text`) — mutations-belegt: Verdrahtungszeile entfernt ⇒ Test rot (exakt der Staging-Bug)

**Qualität:** Adversary Runde 3 fand die Testlücke (M3 ungefangen, CRITICAL), Runde 4 bestätigt geschlossen — Gesamt-Verdict **VERIFIED** über 4 Runden. 172 benannte Tests grün, AC-11-Byte-Identitäts-Golden unverändert grün, ruff clean, Renderer-Gate #811 frisch (811-Matrix + briefing_mail_validator Exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFziB15Kn8aDEZYe8CoQ31
