### PR TITLE
fix(#1535): os.environ-Zusicherung maskiert Werte statt sie zu drucken

### DIFF
--- a/docs/specs/fast/fix-1535-env-snapshot-maskieren.md
+++ b/docs/specs/fast/fix-1535-env-snapshot-maskieren.md
@@ -1,0 +1,81 @@
+# Mini-Spec: #1535 — Umgebungs-Abbild in Zusicherung maskieren
+
+**Issue:** https://github.com/henemm/gregor_zwanzig/issues/1535
+**Track:** Fast Track · **Betroffen:** `tests/tdd/test_issue_1014_live_optin.py`
+
+## Ausgangslage (gemessen, nicht vermutet)
+
+`tests/tdd/test_issue_1014_live_optin.py:86-90` vergleicht zwei Abbilder von `os.environ`
+(gefiltert auf `GZ_TELEGRAM_*`) mit **echten Werten** gegen `{}`. Wird die Zusicherung
+verletzt, druckt pytest den Diff — und damit den Wert von `GZ_TELEGRAM_TEST_BOT_TOKEN`,
+einen aktiven Bot-Zugang, im Klartext.
+
+Einziger Fall im Testbestand: 34 Treffer für `dict(os.environ)`/`os.environ.copy()` in
+`tests/`, davon alle übrigen reine Subprocess-Umgebungs-Vorbereitung; die 13 weiteren
+`os.environ`-Zusicherungen vergleichen gegen eingespielte Fantasiewerte.
+
+Der Austrittsweg „Claude-Sitzungsprotokoll" ist seit #1537 Scheibe 2 B durch
+`secret_output_gate.py` bereits maskiert. Offen bleiben die Wege ohne Hook:
+menschliches Terminal, `pytest > logfile`, angehängte Protokolle, Artefaktablagen.
+
+## Was ändert sich
+
+- **Teil A wird eine eigene Testfunktion** `test_live_telegram_enabled_does_not_touch_environ`
+  (bisher erste Hälfte von `test_without_optin_all_live_tests_skip_and_env_unchanged`).
+  Grund: der Nachweis-Test unten muss sie einzeln aufrufen können, ohne den 240-Sekunden-
+  Subprocess-Lauf aus Teil B mitzuziehen.
+- **Die Zusicherung vergleicht maskierte Abbilder:** Schlüsselname + SHA-256-Kurz-Hash
+  (12 Zeichen) statt Wert. Ein Diff bleibt aussagekräftig (er nennt den geänderten
+  Schlüssel und zeigt, dass sich der Wert geändert hat), enthält aber keinen Zugang.
+- **`== {}` fällt weg, `before == after` bleibt.** Die Aussage von AC-1 aus
+  `docs/specs/modules/issue_1014_telegram_live_optin.md` lautet „`os.environ` bleibt
+  unverändert" — das ist `before == after`. Das zusätzliche `== {}` prüft nicht die
+  Funktion, sondern den Zufallszustand der Umgebung: es wird rot, sobald irgendeine
+  `GZ_TELEGRAM_*`-Variable gesetzt ist, die mit dem Opt-in nichts zu tun hat
+  (`GZ_TELEGRAM_TEST_BOT_TOKEN`). Genau dieses Übermaß ist die Ursache dafür, dass der
+  Test auf dem Server rot wird und dabei den Zugang druckt.
+- **Der prüfrelevante Teil von `== {}` bleibt erhalten:** eine eigene Zusicherung, dass
+  keiner der vier **opt-in-relevanten** Schlüssel (`GZ_TELEGRAM_LIVE`,
+  `GZ_TELEGRAM_BOT_TOKEN`, `GZ_TELEGRAM_CHAT_ID`, `GZ_TELEGRAM_TEST_CHAT_ID`) gesetzt ist —
+  geprüft über **Schlüsselnamen**, nie über Werte.
+
+## Was darf sich nicht ändern
+
+- Teil B (isolierter Subprocess-pytest-Lauf über die Live-Dateien, Proxy-Blockade,
+  `_clean_subprocess_env`) bleibt inhaltlich unangetastet.
+- AC-1 von #1014 bleibt vollständig gedeckt: „ohne `GZ_TELEGRAM_LIVE` werden alle
+  Live-Tests übersprungen und `os.environ` bleibt unverändert."
+- Kein Produktivcode wird angefasst — die Änderung liegt ausschließlich in `tests/`.
+- Es entsteht **kein** neues Gate und keine neue Pflicht-Regel (PO-Entscheid Intake
+  2026-08-10: nur die Stelle fixen, kein Ratschen-Test — Regel-Budget).
+
+## Nachweis-Test (rot vor Fix, grün nach Fix)
+
+Neue Datei `tests/unit/test_env_snapshot_assertions_mask_secrets.py` (nach Verhalten
+benannt, nicht nach Issue-Nummer):
+
+Ein Subprocess-pytest-Lauf **nur auf den Teil-A-Testknoten**, mit
+`GZ_TELEGRAM_TEST_BOT_TOKEN=<Kennwert>` in der Umgebung. Zwei Zusicherungen:
+
+1. Der Lauf endet mit Exit-Code 0 (die gesetzte Test-Bot-Variable darf den Test nicht
+   rot machen — sie sagt nichts über das Opt-in aus).
+2. Der **Kennwert taucht in der gesamten Ausgabe nicht auf** — weder bei Erfolg noch
+   in einem Fehlerdiff.
+
+Vor dem Fix scheitert beides: `== {}` wird durch die gesetzte Variable verletzt, und
+der Diff druckt den Kennwert. Nach dem Fix greift keine der beiden Bedingungen.
+
+Der Kennwert ist ein frei erfundener Zeichenstring, kein echter Zugang.
+
+## Manuelle Test-Schritte
+
+1. `GZ_TELEGRAM_TEST_BOT_TOKEN=KENNWERT-XYZ uv run pytest tests/tdd/test_issue_1014_live_optin.py::test_live_telegram_enabled_does_not_touch_environ -q`
+   → grün, Ausgabe enthält `KENNWERT-XYZ` nicht.
+2. `uv run pytest tests/unit/test_env_snapshot_assertions_mask_secrets.py -q` → grün.
+3. `uv run pytest tests/tdd/test_issue_1014_live_optin.py -q` → unverändertes Verhalten
+   für Teil B (Subprocess-Lauf über die Live-Dateien).
+
+## Inline-Test (wird während der Implementierung geschrieben)
+
+- [ ] `tests/unit/test_env_snapshot_assertions_mask_secrets.py` — Kennwert erscheint
+      nicht in der Ausgabe, Lauf ist grün trotz gesetzter Test-Bot-Variable

--- a/tests/tdd/test_issue_1014_live_optin.py
+++ b/tests/tdd/test_issue_1014_live_optin.py
@@ -25,6 +25,7 @@ Subprocess-Start, bis die Fixture-Funktionen implementiert sind.
 """
 from __future__ import annotations
 
+import hashlib
 import os
 import subprocess
 import sys
@@ -78,18 +79,50 @@ def _clean_subprocess_env() -> dict:
 # ---------------------------------------------------------------------------
 
 
-def test_without_optin_all_live_tests_skip_and_env_unchanged(monkeypatch):
+# Opt-in-relevante Schluessel — die einzigen, deren blosse Anwesenheit etwas
+# ueber ein (unbeabsichtigtes) Opt-in aussagt. Andere GZ_TELEGRAM_*-Variablen
+# (z.B. GZ_TELEGRAM_TEST_BOT_TOKEN) duerfen gesetzt sein, ohne den Test rot zu
+# machen — #1535.
+_OPT_IN_RELEVANT_KEYS = (
+    "GZ_TELEGRAM_LIVE",
+    "GZ_TELEGRAM_BOT_TOKEN",
+    "GZ_TELEGRAM_CHAT_ID",
+    "GZ_TELEGRAM_TEST_CHAT_ID",
+)
+
+
+def _masked_telegram_env_snapshot() -> dict:
+    """Maskiertes Abbild von os.environ (GZ_TELEGRAM_*): Schluesselname +
+    SHA-256-Kurz-Hash (12 Zeichen) statt Wert. Ein Diff bleibt aussagekraeftig,
+    druckt aber nie einen echten Zugang (#1535)."""
+    return {
+        k: hashlib.sha256(v.encode()).hexdigest()[:12]
+        for k, v in os.environ.items()
+        if k.startswith("GZ_TELEGRAM_")
+    }
+
+
+def test_live_telegram_enabled_does_not_touch_environ(monkeypatch):
     # -- Teil A: direkter In-Process-Beweis für live_telegram_enabled() --
     for key in ("GZ_TELEGRAM_LIVE", "GZ_TELEGRAM_BOT_TOKEN", "GZ_TELEGRAM_TEST_CHAT_ID", "GZ_TELEGRAM_CHAT_ID"):
         monkeypatch.delenv(key, raising=False)
 
-    before = {k: v for k, v in os.environ.items() if k.startswith("GZ_TELEGRAM_")}
+    before = _masked_telegram_env_snapshot()
     assert live_telegram_enabled() is False
-    after = {k: v for k, v in os.environ.items() if k.startswith("GZ_TELEGRAM_")}
-    assert before == after == {}, (
-        "live_telegram_enabled() darf ohne GZ_TELEGRAM_LIVE=1 os.environ nicht veraendern"
+    after = _masked_telegram_env_snapshot()
+    assert before == after, (
+        "live_telegram_enabled() darf ohne GZ_TELEGRAM_LIVE=1 os.environ nicht "
+        "veraendern (maskiertes Abbild: Schluesselname + SHA-256-Kurz-Hash, kein Wert)"
     )
 
+    set_opt_in_keys = [k for k in _OPT_IN_RELEVANT_KEYS if k in os.environ]
+    assert not set_opt_in_keys, (
+        "Opt-in-relevante Schluessel duerfen ohne bewusstes Opt-in nicht gesetzt "
+        f"sein: {set_opt_in_keys}"
+    )
+
+
+def test_without_optin_all_live_tests_skip_and_env_unchanged():
     # -- Teil B: isolierter Subprocess-pytest-Lauf ueber alle 6 Live-Dateien --
     env = _clean_subprocess_env()
     result = subprocess.run(

--- a/tests/unit/test_env_snapshot_assertions_mask_secrets.py
+++ b/tests/unit/test_env_snapshot_assertions_mask_secrets.py
@@ -1,0 +1,132 @@
+"""
+Nachweis-Test fuer #1535: `os.environ`-Zusicherungen in
+`tests/tdd/test_issue_1014_live_optin.py` duerfen bei einer Verletzung keinen
+echten Zugang im Diff drucken.
+
+Vor dem Fix vergleicht die AC-1-Zusicherung ein echtes `os.environ`-Abbild
+(gefiltert auf `GZ_TELEGRAM_*`) gegen `{}`. Ist `GZ_TELEGRAM_TEST_BOT_TOKEN`
+gesetzt (z.B. auf dem Server, sourced aus einer .env), wird die Zusicherung
+verletzt und pytest druckt den Wert im Fehlerdiff.
+
+Dieser Test simuliert genau diese Server-Situation ueber einen isolierten
+Subprocess-pytest-Lauf **nur auf dem Teil-A-Testknoten** (nicht die ganze
+Datei — Teil B startet einen bis zu 240s langen Subprocess-Lauf ueber 6
+Live-Dateien und ist hier irrelevant).
+
+Der Kennwert ist ein frei erfundener Zeichenstring, kein echter Zugang.
+
+Spec: docs/specs/fast/fix-1535-env-snapshot-maskieren.md
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_FAKE_TOKEN = "fake-kennwert-1535-nicht-echt-xyz"
+
+_TARGET_NODE_ID = (
+    "tests/tdd/test_issue_1014_live_optin.py::"
+    "test_live_telegram_enabled_does_not_touch_environ"
+)
+
+
+def test_masked_snapshot_assertion_survives_set_test_bot_token_and_hides_value():
+    env = os.environ.copy()
+    env["GZ_TELEGRAM_TEST_BOT_TOKEN"] = _FAKE_TOKEN
+    for key in ("GZ_TELEGRAM_LIVE", "GZ_TELEGRAM_BOT_TOKEN", "GZ_TELEGRAM_CHAT_ID", "GZ_TELEGRAM_TEST_CHAT_ID"):
+        env.pop(key, None)
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    parts = [str(_REPO_ROOT), str(_REPO_ROOT / "src")]
+    if existing_pythonpath:
+        parts.append(existing_pythonpath)
+    env["PYTHONPATH"] = os.pathsep.join(parts)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", _TARGET_NODE_ID, "-v"],
+        cwd=str(_REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    combined = result.stdout + result.stderr
+
+    assert result.returncode == 0, (
+        "Eine gesetzte GZ_TELEGRAM_TEST_BOT_TOKEN-Variable darf den Opt-in-Test "
+        "nicht rot machen — sie sagt nichts ueber das Opt-in aus:\n"
+        + combined[-4000:]
+    )
+    assert _FAKE_TOKEN not in combined, (
+        "Der Kennwert erscheint in der Testausgabe — die os.environ-Zusicherung "
+        "druckt den echten Wert statt eines maskierten Abbilds:\n" + combined[-4000:]
+    )
+
+
+def test_masked_snapshot_diff_names_key_but_hides_value(tmp_path):
+    """Nachweis am Wirkort: erzwingt einen Fehlschlag der maskierten
+    Zusicherung selbst (statt nur den Erfolgsfall zu beobachten) und prueft,
+    dass der Diff den Schluesselnamen nennt, aber keinen der beiden Werte."""
+    before_value = "fake-kennwert-1535-before-abc"
+    after_value = "fake-kennwert-1535-after-xyz-anders"
+
+    # WICHTIG: die Werte stehen NIRGENDS als Literal im Quelltext der
+    # Reprodatei — sonst echot pytest sie beim Fehlschlag ueber den
+    # Quellcode-Kontext, unabhaengig vom eigentlichen Diff. Sie werden zur
+    # Laufzeit ausschliesslich ueber Umgebungsvariablen (mit neutralen
+    # Namen, NICHT GZ_TELEGRAM_*) eingespeist.
+    repro_file = tmp_path / "test_repro_masked_diff.py"
+    repro_file.write_text(
+        "import os\n"
+        "from tests.tdd.test_issue_1014_live_optin import _masked_telegram_env_snapshot\n"
+        "\n"
+        "def test_forced_mismatch():\n"
+        "    os.environ['GZ_TELEGRAM_TEST_BOT_TOKEN'] = os.environ['REPRO_BEFORE_VALUE']\n"
+        "    before = _masked_telegram_env_snapshot()\n"
+        "    os.environ['GZ_TELEGRAM_TEST_BOT_TOKEN'] = os.environ['REPRO_AFTER_VALUE']\n"
+        "    after = _masked_telegram_env_snapshot()\n"
+        "    assert before == after\n"
+    )
+
+    env = os.environ.copy()
+    for key in (
+        "GZ_TELEGRAM_LIVE",
+        "GZ_TELEGRAM_BOT_TOKEN",
+        "GZ_TELEGRAM_CHAT_ID",
+        "GZ_TELEGRAM_TEST_CHAT_ID",
+        "GZ_TELEGRAM_TEST_BOT_TOKEN",
+    ):
+        env.pop(key, None)
+    env["REPRO_BEFORE_VALUE"] = before_value
+    env["REPRO_AFTER_VALUE"] = after_value
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    parts = [str(_REPO_ROOT), str(_REPO_ROOT / "src")]
+    if existing_pythonpath:
+        parts.append(existing_pythonpath)
+    env["PYTHONPATH"] = os.pathsep.join(parts)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(repro_file), "-v"],
+        cwd=str(_REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    combined = result.stdout + result.stderr
+
+    assert result.returncode != 0, (
+        "Der erzwungene Mismatch haette die maskierte Zusicherung rot machen "
+        "muessen — sonst prueft dieser Test gar nichts am Wirkort:\n" + combined[-4000:]
+    )
+    assert "GZ_TELEGRAM_TEST_BOT_TOKEN" in combined, (
+        "Der Diff soll den Schluesselnamen nennen — ein Diff ohne Schluesselnamen "
+        "waere nicht mehr aussagekraeftig:\n" + combined[-4000:]
+    )
+    assert before_value not in combined and after_value not in combined, (
+        "Der Diff druckt einen echten Wert statt nur Schluesselname + Hash:\n"
+        + combined[-4000:]
+    )


### PR DESCRIPTION
## Problem

`tests/tdd/test_issue_1014_live_optin.py` verglich zwei `os.environ`-Abbilder mit **echten Werten** gegen `{}`. Schlug die Zusicherung fehl, druckte pytest den Wert von `GZ_TELEGRAM_TEST_BOT_TOKEN` im Klartext — ein aktiver Bot-Zugang in Terminal, Logdatei, Artefaktablage und Fehlerbericht.

Belegt per A/B gegen den unveraenderten Stand (Kennwert erfunden):

```
E   AssertionError: live_telegram_enabled() darf ohne GZ_TELEGRAM_LIVE=1 ...
E   {'GZ_TELEGRAM_TEST_BOT_TOKEN': 'fake-kennwert-1535-nicht-echt-xyz'}
```

## Loesung

- Abbilder tragen **Schluesselname + SHA-256-Kurz-Hash** statt Wert. Der Fehlerdiff bleibt aussagekraeftig, nennt aber keinen Zugang.
- Das zusaetzliche `== {}` faellt weg. Es prueft nicht die Funktion, sondern den Zufallszustand der Umgebung und wird rot, sobald irgendeine `GZ_TELEGRAM_*`-Variable gesetzt ist, die mit dem Opt-in nichts zu tun hat — genau dieses Uebermass loeste den Fehlschlag aus, der den Wert druckte. `before == after` bleibt.
- Der pruefrelevante Teil bleibt als eigene Zusicherung: keiner der vier **opt-in-relevanten** Schluessel darf gesetzt sein — geprueft ueber Namen, nie ueber Werte.
- Teil A wurde dafuer in `test_live_telegram_enabled_does_not_touch_environ` aufgeteilt; Teil B bleibt inhaltlich unveraendert.

## Nachweis

`tests/unit/test_env_snapshot_assertions_mask_secrets.py` erzwingt einen Fehlschlag der maskierten Zusicherung **am Wirkort** und prueft: Lauf rot · Schluesselname im Diff · Wert nicht im Diff.

**Mutations-Gegenprobe:** Maskierung per String-Ersetzung auf Klartext zurueckgedreht → der Nachweis-Test wird rot. Er bewacht die Maskierung also tatsaechlich.

## Umfang

Nur `tests/` — kein Produktivcode, kein neues Gate. Punkt 2 des Issues (Suche nach weiteren Tests, die Geheimnis-Variablen in Zusicherungen vergleichen) wurde gemessen: von 34 `os.environ`-Abbildern im Testbestand ist dies der **einzige**, der mit echten Werten in eine Zusicherung laeuft; die uebrigen sind Subprocess-Umgebungs-Vorbereitung oder vergleichen gegen Fantasiewerte.

Punkt 3 (Rotation des Test-Bot-Zugangs) hat der PO am 2026-08-05 abgelehnt — nicht Teil dieses PR.

Refs #1535

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7zsUokLQtHAGVUaryUDzR