### PR TITLE
test(#1667 S1): Fixtures wanduhrunabhaengig + dauerhafter Waechter

### DIFF
--- a/docs/context/fix-1667-arrival-midnight-wrap.md
+++ b/docs/context/fix-1667-arrival-midnight-wrap.md
@@ -1,0 +1,264 @@
+# Context: fix-1667-arrival-midnight-wrap
+
+**Issue:** [#1667](https://github.com/henemm/gregor_zwanzig/issues/1667) — „Ankunftszeit-Berechnung ignoriert Mitternachts-Wrap"
+**Workflow:** `fix-1667-arrival-midnight-wrap` (Full Process, Intake-Score 5)
+**Erstellt:** 2026-08-10 · Basis-HEAD `5ea233a4`
+
+## Request Summary
+
+Rund 20 Tests schlagen reproduzierbar zwischen ~22:00 und 00:00 UTC fehl, weil Test-Fixtures ein Stage-Datum von `now.date()` mit Ankunftszeiten aus `(now + N h).strftime("%H:%M")` kombinieren. Zu klären ist, ob derselbe Musterfehler auch im Produktionscode existiert — dort wäre er sicherheitsrelevant, weil ein noch unterwegs befindlicher Wanderer Wetterwarnungen verlieren könnte.
+
+## 🔴 Die Issue-Prämisse ist überholt — die wahre Ursache ist eine andere
+
+Das Issue nennt als Ursachenkette: Ankunft nach Mitternacht → wird als Vergangenheit gelesen → löst die #1584-Unterdrückung („Alarme schalten 2h nach Ankunft ab") aus. **Beide Glieder dieser Kette treffen nicht zu.**
+
+1. **Die 2h-Regel existiert nicht mehr.** Commit `dcabda4a` (PR #1590, gemerged als `e69017c8`, 2026-08-08) hat sie durch das ortszeit-aufgelöste Tagesfenster ersetzt. `grep -rn "arrival_time + timedelta" src/` findet nur noch den 1h-Mindestfenster-Fallback aus #1584 selbst (`src/services/trip_segments.py:288`). Die Fehlschläge wurden am 2026-08-10 beobachtet, also *nach* diesem Merge.
+
+2. **`arrival_calculated` kann gar keine Zeit nach Mitternacht tragen.** `_format_hhmm()` klemmt auf `23:59` — dreifach identisch in `src/core/naismith.py:54-60`, `internal/model/naismith.go:88-96` und `frontend/src/lib/utils/naismith.ts:63-68`. Nur ein manuell gesetzter `arrival_override` trägt eine Zeit wie `"00:30"`.
+
+### Die tatsächliche Ursache: `wp_days[0]` kann strukturell nie 1 werden
+
+`src/services/trip_segments.py:149-158`:
+
+```python
+day = 0
+prev = None
+wp_days: List[int] = []
+for t in wp_times:
+    if t is not None and prev is not None and t < prev:  # strikt fallend = Tagesgrenze
+        day += 1
+    wp_days.append(day)
+    if t is not None:
+        prev = t
+```
+
+`prev` ist beim ersten Durchlauf `None` ⇒ **`wp_days[0]` ist immer 0.** Der Rollover aus #1098 erkennt eine Tagesgrenze nur *zwischen* zwei Wegpunkten. Eine Etappe, deren **erster** Wegpunkt bereits auf den Folgetag gehört, ist im Datenmodell nicht darstellbar.
+
+Damit ist die Uhrzeit-Abhängigkeit exakt rechenbar (Beispiel `_save_radar_trip`, Versätze +1h/+4h):
+
+| Laufzeit UTC | wp0 (+1h) | wp1 (+4h) | `wp_days` | Ergebnis |
+|---|---|---|---|---|
+| 12:00 | 13:00 | 16:00 | [0,0] | Segment heute 13–16 Uhr, aktiv → **grün** |
+| 20:00–22:59 | 21:00 | 00:00 | [0,**1**] | strikt fallend ⇒ Rollover greift **korrekt** → **grün** |
+| **ab 23:00** | **00:00** | **03:00** | **[0,0]** | steigend ⇒ kein Rollover ⇒ Segment liegt **23 h in der Vergangenheit** ⇒ „alle Segmente vorbei" ⇒ `check_radar_alerts()` liefert 0 → **rot** |
+
+Bei den +2h/+4h-Fixtures verschiebt sich die Kippkante auf 22:00 UTC. Das erklärt die Feldbeobachtung „~20 Tests, 23:00–00:00 UTC" ohne Rest.
+
+**Zweiter, seltenerer Mechanismus:** Baut die Fixture um 23:59:59 und läuft der Check um 00:00:01, ist `date_type.today()` (`src/services/trip_alert.py:739`) bereits der Folgetag, das Stage-Datum aber der Vortag ⇒ `get_stage_for_date()` findet nichts ⇒ leere Segmentliste.
+
+## Related Files
+
+### Produktionscode — Schreibpfad Ankunftszeit
+| Datei:Zeile | Relevanz |
+|---|---|
+| `src/core/naismith.py:54-60` | `_format_hhmm()` — **die 23:59-Klemme**; einzige Erzeugungsstelle der Ankunftszeit |
+| `src/core/naismith.py:75-114` | Naismith-Rechnung je Wegpunkt |
+| `internal/model/naismith.go:88-121` | Go-Spiegel der Klemme (`ComputeStageArrivals`) |
+| `frontend/src/lib/utils/naismith.ts:63-68` | TS-Spiegel der Klemme |
+| `src/app/loader.py:1684-1688` | Compute-on-Save (Python) |
+| `internal/store/trip.go:228-241` | Compute-on-Save (Go) |
+| `src/app/trip.py:77` | Felddefinition: `Optional[str]`, `"HH:MM"` |
+
+### Produktionscode — Lesepfad / Segmentbau
+| Datei:Zeile | Relevanz |
+|---|---|
+| `src/services/trip_segments.py:149-158` | **`wp_days`-Offsetvektor — der Kern des Befunds** |
+| `src/services/trip_segments.py:181-192` | Kombination `target_date + wp_days[i]` + `HH:MM` → `datetime` |
+| `src/services/trip_segments.py:86-90` | Interpolation mit `+ timedelta(days=1)` (#1091) |
+| `src/services/trip_segments.py:194-205` | Kollaps-Guard „Mitternachts-Klemme" |
+| `src/services/trip_segments.py:239-292` | Ziel-Segment (#1584 nach PR #1590): Tagesfenster, `arrival_local_date` aus Ortszeit |
+| `src/services/trip_forecast.py:185-198` | ⚠️ **Zweiter Befund** — kombiniert stur `stage.date` + `HH:MM`; Rollover wird vom `end <= start`-Guard stumm auf `start + 2h` eingeebnet, entgegen dem Kommentar direkt darüber |
+| `src/services/segment_weather.py:453-457` | ⚠️ Nacht-Zeitreihe über **UTC**-Tag ⇒ bei Ankunft nach UTC-Mitternacht ~29 h lang |
+
+### Produktionscode — die fünf „Segment ist vorbei"-Guards
+| Datei:Zeile | Was unterdrückt wird |
+|---|---|
+| `src/services/trip_alert.py:749-763` | Radar-/NowCast-Alarm entfällt komplett |
+| `src/services/trip_alert.py:1005-1010` | Kein Frisch-Abruf ⇒ keine Wetteränderungs-Erkennung |
+| `src/services/trip_alert.py:1156-1158` | Segment fällt aus der Gruppierung amtlicher Warnungen |
+| `src/services/trip_report_scheduler.py:1183-1191` | Kein Nowcast-Call im Briefing-Pfad |
+| `src/services/corridor_threshold.py:86` | Korridor-/Schwellen-Treffer unterdrückt |
+
+⚠️ `trip_alert.py:749-763` und `trip_report_scheduler.py:1183-1191` sind **getrennte Kopien derselben Auswahl-Logik** — ein Fix an einer Stelle greift nicht an der anderen.
+
+### Testcode — betroffene Fixtures (12 Dateien, ~29–31 Testfunktionen)
+| Datei:Zeile | Helfer | Versätze |
+|---|---|---|
+| `tests/tdd/test_alert_log_metrics.py:115` | `_save_radar_trip()` (Ursprung) | +1h/+4h |
+| `tests/tdd/test_alert_urgency.py:175` | `_save_radar_trip()` (bitidentische Kopie) | +1h/+4h |
+| `tests/tdd/test_issue_827_radar_throttle_recording.py:38` | `_make_trip()` | +2h/+4h |
+| `tests/tdd/test_issue_1070_daily_alert_limit.py:227` | `_make_trip()` | +2h/+4h |
+| `tests/tdd/test_alert_channel_threshold.py:214` | `_radar_trip()` | +2h/+4h |
+| `tests/tdd/test_issue_883_acute_danger_override.py:76` | `_make_active_trip()` | −1h/+2h |
+| `tests/tdd/test_alert_quiet_hours_robustness.py:224` | `_save_trip_direct()` | −1h/+2h |
+| `tests/tdd/test_issue_822_radar_nowcast_segment.py:169,713,800` | inline (3×) | diverse |
+| `tests/tdd/test_bundle_791_847_844_alerts.py:196` | inline | −1h/+3h |
+| `tests/tdd/test_issue_995_scheduler_pause.py:183` | inline | −1h/+2h |
+| `tests/tdd/test_issue_818_radar_briefing_integration.py:400` | **`pytest.skip` vor 04:00 UTC** | — |
+| `tests/unit/test_alarm_zeitfenster_ziel.py:349` | **`pytest.skip` in den ersten 3 Min des UTC-Tages** | — |
+
+Das Issue nennt 4 Dateien — es sind **mindestens 12**.
+
+## Existing Patterns
+
+### Vorbild für den Fixture-Fix (im Repo zweimal erprobt)
+`tests/tdd/test_952_onset_alert_fidelity.py:135-147` und `tests/tdd/test_issue_1069_tier_channel_gating.py:438-450` klemmen das Ankunftsfenster auf **02:00–22:00 Ortszeit**. Das erfüllt genau die Bedingung aus der Ursachenanalyse: Wegpunkt-Zeiten steigen monoton innerhalb desselben Kalendertags, `wp_days` bleibt `[0,0]`, das Segment landet nie in der Vergangenheit.
+
+⚠️ **Die scheinbar sauberere Alternative — Stage-Datum aus dem Ankunfts-`datetime` ableiten — löst das Problem nicht**, weil `wp_days[0]` trotzdem 0 bleibt.
+
+### Wrap-Muster aus #399 — nur bedingt als Vorbild geeignet
+`hour_in_window()` (`src/app/day_window.py:134-146`) ist der geteilte Baustein, hat aber nur **3 Aufrufer** gegen mindestens **4 wortgleiche Inline-Kopien** (`trip_report.py:422`, `email/helpers.py:149`, `renderers/day_window.py:127`, plus eigene Varianten in `comparison_engine.py`, `compare_official_alert.py`). In `docs/reference/` und `docs/adr/` kommt der Helfer **nicht ein einziges Mal** vor — keine dokumentierte Hauskonvention.
+
+⚠️ **#1334 hat genau dieses Wrap-Muster an einer Aggregationsstelle als Bug-Ursache wieder ENTFERNT** (`src/services/segment_weather.py:226-262`): der reine Stunden-Wraparound „zog fälschlich gleiche Uhrzeiten von JEDEM Tag der Zeitreihe". Reine Stundenzahl-Wraps sind richtig beim Einordnen einer einzelnen Stunde (Anzeige/Filter) und falsch beim Aggregieren über eine mehrtägige Zeitreihe.
+
+### Test-Uhr: existiert nicht als Werkzeug
+- **`freezegun` ist nicht im Projekt** (`tests/tdd/test_compare_alert_day_window.py:48` sagt das ausdrücklich).
+- Punktuelle DI-Uhren existieren: `src/services/radar_service.py:127` (`_now_fn`) — **der Radar-Dienst hat den Haken bereits, keine der betroffenen Fixtures nutzt ihn**; dazu `meteoalarm.py:75`, `dpc.py:53`, `warn_egress.py:185`.
+- Der Workflow `fix-1656-testuhr` führt im Namen in die Irre: Commit `a0ae1d0d` (PR #1659) sagt wörtlich „KEIN Produktivcode angefasst"; es wurde **eine** Datei umgebaut, keine allgemeine Testuhr. Der Nachweis lief über ein **Wegwerf-pytest-Plugin zur Tageszeit-Verschiebung**, das **nicht eingecheckt** ist — für #1667 der naheliegende Nachweisweg.
+
+## Dependencies
+
+- **Upstream:** `naismith.py` (Ankunftsberechnung) → `loader.py`/`trip.go` (Compute-on-Save) → `trip_segments.py` (Segmentbau)
+- **Downstream:** alle fünf „Segment vorbei"-Guards, Radar-/NowCast-Alarme, Wetteränderungs-Erkennung, amtliche Warnungen, Briefing-Nowcast, Korridor-Schwellen
+
+## Existing Specs & ADRs
+
+| Dokument | Kernaussage | Stand (nachgemessen) |
+|---|---|---|
+| `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` | **Akzeptiert.** Kalendertage folgen der Ortszeit. „Ein Ortstag hat nicht immer 24 Stunden — jedes Tagesfenster muss seine Länge **berechnen** statt sie zu setzen." Rechenfalle: gleiches `tzinfo`-Objekt ⇒ Python rechnet auf Wanduhr-Werten. **Offene Restliste:** vier Stellen in `trip_command_processor.py` folgen der Regel noch nicht | gültig |
+| `docs/adr/0035-ein-tagesfenster-fuer-trip-und-ortsvergleich.md` | **Akzeptiert.** Ein Auflöser `resolve_configured_window()`, Default 4–19 Uhr. Fenster über Mitternacht sind zulässig; am Zielsegment aber nicht abgebildet (PO 2026-08-08) | gültig |
+| `docs/specs/modules/fix_1584_alarm_zeitfenster.md` | Ziel-Segment endet am Tagesfenster statt 2h nach Ankunft | **umgesetzt** (PR #1590) |
+| `docs/specs/_archive/modules/issue_1098_midnight_rollover_segments.md` | `wp_days`-Vektor | **umgesetzt** (`trip_segments.py:151-157`) |
+| `docs/specs/_archive/modules/issue_1004_startzeit_ssot.md:81,227` | Nennt die Klemme ausdrücklich: „**Ursache der Mitternachts-Klemme**" und „bleibt Grenzverhalten (nur abgesichert, nicht neu designt)" | **bewusste Altlast** |
+| `docs/specs/modules/daywindow_gap_and_midnight_fix.md` | #1334 — Wrap-Muster in `segment_weather.py` ersatzlos entfernt | **umgesetzt** |
+| `docs/specs/_archive/modules/bug_397_output_localtime.md` | Ursprung des Wrap-Musters (#397/#398/#399) | historisch |
+| `docs/reference/api_contract.md:905,917,933` | `arrival_calculated` = reiner `HH:MM`-String ohne Datum; Prioritätskette `arrival_override` > `stage.start_time` > `arrival_calculated` > 08:00. **Zu Etappen über Mitternacht steht dort NICHTS** | Lücke |
+
+### 🔴 Wichtige Abgrenzung zur PO-Entscheidung vom 2026-08-08
+`fix_1584_alarm_zeitfenster.md:310-323` schließt **Mitternachts-Tagesfenster** (`start_hour > end_hour`, z. B. 22–2 Uhr) am Zielsegment bewusst aus — weil ein einzelnes Intervall das entstehende Loch nicht darstellen kann.
+
+**Das ist NICHT derselbe Fall wie #1667.** Dort geht es um eine *Etappe mit Ankunft nach Mitternacht*, hier um ein *konfiguriertes Fenster über Mitternacht*. Beide laufen zufällig über denselben `window_end <= arrival_time`-Guard. Für Spätankünfte ist die Behandlung ausdrücklich **gewollt und per AC abgenommen** (AC-3: „der Trip fällt durch die Spätankunft NICHT stillschweigend aus der Überwachung"). Wer #1667 auf „ist doch schon entschieden" zuschneidet, verwechselt die beiden Fälle.
+
+## Bestehende Wächter
+
+- **`tests/test_output_timezone_guard.py`** (#1402) — AST-Ratsche mit `KNOWN_VIOLATIONS`, die nur schrumpfen darf. Flaggt rohes `.astimezone()` und stille Zonen-Rückfälle; bewacht zusätzlich die Aufrufseite in `src/`/`api/`.
+- `tests/unit/test_alarm_zeitfenster_ziel.py` — AC-1…AC-6 aus #1584, inkl. `test_mitternachtsfenster_22_2_klemmt_auf_mindestfenster` und `test_ac4b_westzone_spaete_ankunft_fenster_endet_am_ortstag`
+- `tests/tdd/test_issue_1004_startzeit_ssot.py:431,448,481` — Über-Mitternacht-Interpolation (#1091), Ziel-Ankunft am Folgetag (#1098)
+- Weitere Wrap-Tests: `test_comparison_engine_midnight_window.py:87`, `test_thunder_forecast_day_window.py:226`, `test_drilldown_day_window_local_date.py:273,483`, `test_compare_local_time_basis.py:485`, `test_compare_outlook_day_boundary.py:116`
+
+**Nicht bewacht:** kein Test prüft die 23:59-Klemme als Fehlverhalten; **keiner der drei Klemm-Orte (Python/Go/TS) hat einen Paritätstest** gegen die anderen beiden.
+
+## Datenmodell — Ist-Stand nachgemessen
+
+- `arrival_calculated`/`arrival_override` kommen in **keiner** JSON-Datei des Repos vor (`grep -rn "arrival_calculated" --include=*.json .` → 0 Treffer). Die Felder sind `omitempty`, die Ankunft wird bei jedem Lauf frisch gerechnet.
+- `start_time` ist in **keiner** der 9 Trip-Fixtures gesetzt — überall greift der Default 08:00.
+- **Keine einzige Etappe in den Bestandsdaten hat eine Ankunft nach Mitternacht.** Die einzigen Zeitangaben sind GPX-`time_window`-Artefakte (08:00–13:33), die seit #1004 keine Autorität mehr haben.
+
+## Risks & Considerations
+
+1. **🔴 Der Fixture-Fix beweist nichts über die Produktionsfrage — und entfernt zugleich den einzigen vorhandenen Frühwarn-Effekt** (abendlich rote Tests). Nach der Ursachenanalyse ist die Produktionsfrage jetzt präzise formulierbar: *Kann ein realer Trip eine Etappe haben, deren erster Wegpunkt erst nach Mitternacht erreicht wird — und was macht `wp_days[0] == 0` dann?*
+2. **Der `trip_forecast.py`-Befund ist eigenständig** und vom Issue nicht erfasst: Kommentar und Verhalten widersprechen sich dort nachweislich. Zuschnitt-Entscheidung nötig — eigene Scheibe oder mitnehmen.
+3. **Zwei Kopien der „Segment vorbei"-Logik** (`trip_alert.py` / `trip_report_scheduler.py`) — jeder Fix muss beide treffen oder die Teilung ausdrücklich begründen.
+4. **Drei Kopien der 23:59-Klemme ohne Paritätstest** (Python/Go/TS) — wer eine ändert, hat kein Netz. Änderung an der Klemme berührt außerdem eine per #1004 bewusst stehen gelassene Entscheidung ⇒ PO-Rückfrage nötig, keine stille Korrektur.
+5. **Das Wrap-Muster aus #399 ist kein Universalrezept** — #1334 hat es an einer Aggregationsstelle als Bug-Ursache entfernt.
+6. **LoC-Limit 250:** `tests/` zählt mit. Ehrlicher Fixture-Scope ~80–120 LoC, Vollausbau mit Helfer + Skip-Rückbau ~140 LoC — im Rahmen, aber ohne Puffer für Produktionscode-Arbeit im selben Workflow.
+7. **DST:** ADR-0044 verlangt, Fensterlängen zu *berechnen*. `trip_segments.py` nutzt `datetime.combine(...).replace(tzinfo=dest_tz)` — genau das Muster, vor dem ADR-0044 warnt. **Kein Test deckt die beiden Wechseltage hier ab.**
+8. **Ruhezeiten:** `deviation_alert_engine.py:78-106` rechnet fest in `Europe/Vienna` statt in der Ortszeit des Ziels — von #1584 als offener Sonderfall benannt, Zusammenwirken mit Nacht-Ankunft ungeprüft.
+
+## Analysis (Phase 2 — alles am laufenden Code gemessen)
+
+### Type
+**Bug** — mit einer realen, sicherheitsrelevanten Produktwirkung, die das Issue richtig befürchtet, aber falsch begründet.
+
+### 🔴 Die Sicherheitslücke — gemessen, nicht hergeleitet
+
+**Bedingung:** `stage.start_time + Naismith-Gehzeit > 24:00`. Erreichbar ohne Trick — ein Abendstart 18:00 mit 10 h Gehzeit genügt; die Startzeit ist im Editor frei eingebbar (`StageTimeField.svelte:34`, kein `min`/`max`).
+
+Gemessene Kette (`start_time=22:00`, 4 Wegpunkte, Korsika):
+
+| Messpunkt | Ergebnis |
+|---|---|
+| `arrival_calculated` | `['22:00','23:59','23:59','23:59']` — 3 von 4 auf die Klemme |
+| Segmente | **2 statt 4** — Kollaps-Guard verwirft 15,6 km / 1800 Hm samt Überwachung |
+| Ziel-Segment | 1h-Mindestfenster statt Tagesfenster (Log-Zeile wörtlich) |
+| Überwachungsende | **immer 00:59 Ortszeit**, sobald die Bedingung zutrifft |
+| Reale Restgehzeit | **11 h 50 min ohne Radar-/NowCast-Alarm** |
+| Ab UTC-Mitternacht | `get_stage_for_date()` liefert nichts mehr — Etappe unauffindbar |
+
+**Ursache ist die 23:59-Klemme** (`src/core/naismith.py:54-60`), nicht die 2h-Regel (seit PR #1590 weg) und nicht `wp_days` (dort nur Symptom). Die Klemme zerstört das Signal, an dem der `wp_days`-Rollover den Tageswechsel erkennt: `23:59 == 23:59` ist nicht *strikt fallend*.
+
+### Testfehlschlag — andere Ursache, punktgenau reproduziert
+
+`wp_days[0]` ist strukturell 0. Die Fixtures schreiben `arrival_calculated` direkt als `now + N h` und umgehen Naismith komplett. Mit einem Zeit-Verschiebungs-Plugin belegt: `test_alert_urgency.py::test_convective_radar_logs_high` grün bis 22:59 UTC, **rot ab exakt 23:00 UTC** (`check_radar_alerts() == 0`).
+
+🔴 **Ein Fix an `wp_days` allein macht die ~30 Tests grün und ändert an der Sicherheitslücke nichts.**
+
+### Zwei Messungen, die den Zuschnitt bestimmen
+
+**M1 — Modulo-Wrap statt Klemme löst die Lücke und ist im Normalfall bit-identisch:**
+
+| Start | Klemme (heute) | `total_min % (24*60)` |
+|---|---|---|
+| 08:00 | `['08:00','12:23','14:58','19:21']` → 4 Segmente | **bit-identisch** |
+| 18:00 | `['18:00','22:23','23:59','23:59']` → **3** Segmente | `[…,'00:58','05:21']` → **4** Segmente |
+| 22:00 | `['22:00','23:59','23:59','23:59']` → **2** Segmente | `['22:00','02:23','04:58','09:21']` → **4** Segmente |
+
+**M2 — 🔴 Der Modulo allein schließt die Lücke NICHT.** `trip_alert.py:745` fragt nur `convert_trip_to_segments(trip, today)`. Um 02:00 UTC am Folgetag, Wanderer real unterwegs:
+- **Ein-Etappen-Trip:** `[]` → `continue` → **null Alarme**, trotz korrekt gebauter Segmente.
+- **Zwei-Etappen-Trip:** die Schleife greift das erste Segment der **nächsten** Etappe ⇒ **stille Falsch-Ortung** (Radar für `(42.42, 9.02)`, Wanderer bei `(42.34, 8.94)`). Besteht heute schon.
+
+### Scheiben-Zuschnitt
+
+| Scheibe | Inhalt | Wirkung | LoC |
+|---|---|---|---|
+| **S1** | Fixtures entschärfen (12 Dateien, Klemmen auf 02:00–22:00 Ortszeit nach `test_952_onset_alert_fidelity.py:135-147`) + 2 `pytest.skip` zurückbauen + `freezegun` als Dev-Dependency | keine Produktwirkung; räumt die abendliche Blockade weg | ~110–140 |
+| **S2** | Klemme → Modulo in **drei** Sprachen (`naismith.py:59`, `naismith.go:91-97`, `naismith.ts:63-68`) + **Paritätstest**, den heute keiner der drei Orte hat | macht Nacht-Ankünfte *darstellbar* | ~95–115 |
+| **S3** | Tagesübergreifende Segment-Auswahl als **additiver Fallback** + DI-Uhr `_now_fn` | macht sie *erreichbar*; behebt auch die Falsch-Ortung | ~120–130 |
+
+**Grenzen begründet:** S1 teilt kein Codestück mit S2/S3 — zusammen hieße das, einen grünen Testlauf als Beleg für den Produktivfix auszugeben. S2 ist nachweislich inert (Normalfall bit-identisch, kein Bestands-Trip hat `start_time`); S3 greift in den heißen Alarmpfad und braucht eine eigene Adversary-Runde. S3 hängt an S2. **S2+S3 zusammen (~230 LoC) passten formal — das ist die Falle:** kein Puffer für Fix-Loops, und der Adversary müsste zwei verschiedene Wirkketten in einem Durchgang brechen.
+
+🔴 **Auflage: S1 schließt #1667 nicht.** Der Issue bleibt bis S3 offen — sonst wird aus „Tests grün" stillschweigend „Lücke zu". Genau diese Verwechslung war der Ausgangspunkt des Tickets.
+
+### Warum Modulo und nicht „Klemme heben"
+
+Der Datenkontrakt bleibt **unangetastet**: Die Go-Begründung der Klemme (`naismith.go:86-88`) lautet, die Python-Gegenseite `_parse_hhmm` könne Stunden > 23 nicht konsumieren. Der Modulo liefert weiterhin nur `00:00`–`23:59` — die Bedingung ist **erfüllt, nicht umgangen**; `api_contract.md:917` bleibt wortgleich gültig. Ein echtes Anheben (`"25:30"`) bräche `time.fromisoformat`, ließe Go-`Sscanf` auf 08:00 zurückfallen und die TS-Regex auf den Default — drei stille, divergente Rückfälle ohne Paritätstest dazwischen.
+
+### Tests, die heute das Gegenteil festschreiben (müssen mit S2 umgeschrieben werden)
+
+- `tests/tdd/test_issue_802_fahrrad_segment_zeit.py:28` — erwartet `["08:00","23:59"]`
+- `internal/model/naismith_802_test.go:77-82` — dieselbe Erwartung auf Go-Seite
+- `internal/model/naismith_test.go:161-182` — expliziter Klemm-Test **mit der Begründung im Kommentar**; **umschreiben, nicht löschen**, sonst geht die einzige Dokumentation der ursprünglichen Überlegung verloren
+- `tests/tdd/test_issue_1004_startzeit_ssot.py` — AC-5-Zusicherungen
+- `frontend/src/lib/utils/naismith.test.ts`, `naismith_674.test.ts`
+
+Der Kollaps-Guard `trip_segments.py:194-205` **bleibt** (fängt weiter `==`-Zeiten aus der Interpolation); nur sein Kommentar wird falsch.
+
+### S3 — das eine ernste Risiko: Doppel-Aktivierung
+Nach S2 läuft das Ziel-Segment von Etappe 08-12 bis 17:00 UTC am 08-13, während Etappe 08-13 ab 06:00 UTC läuft. Zwei Segmente gleichzeitig „aktiv"; heute entschiede allein Listenreihenfolge + `break`. **Deshalb reiner Fallback:** heute gewinnt immer, gestern kommt nur zum Zug, wenn heute nichts liefert. Gehört als eigenes AC in die Spec.
+
+**Die PO-Entscheidung vom 2026-08-08 bleibt unberührt** — sie sitzt im `window_end <= arrival_time`-Guard; S3 fasst nur die Etappen*auswahl* an, S2 nur die Ankunfts*berechnung*. `test_mitternachtsfenster_22_2_klemmt_auf_mindestfenster` muss grün bleiben und gehört als Regressionsbeleg in beide Scheiben.
+
+### Nachweisstrategie
+- **Test-Uhr: `freezegun` als Dev-Dependency**, kein Eigenbau — Hauskonvention analog pytest-socket („das fertige Standardwerkzeug"). Erst damit ist S1 beweisbar: derselbe Test unter `freeze_time("…23:30Z")` heute rot, nach S1 grün. *Regel-Budget: an S1 gekoppelt, Prüfdatum +90 Tage.*
+- **S2 Kern:** Paritäts-Fixture über alle drei Sprachen an 23:59/24:00/24:01/47:59 + Regression 22:00-Start → 4 statt 2 Segmente. **Staging:** Test-Trip `start_time=22:00`, Trip-Detail im echten Browser — vier verschiedene Uhrzeiten statt dreimal „23:59".
+- **S3 Kern:** über `_now_fn` um 02:00 UTC prüfen, dass **die Koordinaten des tatsächlich begangenen Segments** abgefragt werden — nicht bloß, dass irgendein Alarm entsteht. Ein Test auf `count > 0` hätte die Falsch-Ortung nie gefunden.
+- **Mutations-Gegenprobe (Pflicht):** Modulo → Klemme zurückdrehen ⇒ Segment-Zähltest muss rot werden. Fallback deaktivieren ⇒ Koordinaten-Test muss rot werden.
+
+### Nebenbefunde — Triage-Entscheidung
+
+| Befund | Entscheidung | Begründung |
+|---|---|---|
+| `trip_forecast.py:185-198` (24 h Versatz, Kommentar behauptet das Gegenteil) | **#1199-Sammeleintrag** | Nur über `src/app/cli.py:222` erreichbar (Legacy-Debug) ⇒ weder (a) noch (b) noch (c). Eintrag muss den **falschen Kommentar** nennen — er ist die Falle für den Nächsten |
+| `segment_weather.py:453-457` (30 h Nachtfenster) | **#1199 + Pflicht-Nachmessung in der S2-Adversary-Runde** | Heute selten erreichbar, keine belegbare Falschzahl in zugestellter Mail. **Nach S2 ändert sich die Lage** — Nacht-Ankünfte werden erstmals real gebaut |
+| `hour_in_window`-Inline-Kopien | **gar nichts** | Berührt #1667 nicht; #1334 hat das Muster andernorts als Bug-Ursache entfernt |
+| `wp_days[0]` bei manuellem Override nach Mitternacht | **Known Limitation in der Spec** | Nach S2 kommt wp[0] garantiert aus `start_time`; konstruiert, nicht beobachtet |
+| DST-Wechseltage (`.replace(tzinfo=...)`) | **#1199** | Echte ADR-0044-Abweichung, aber weder Ursache noch Folge von #1667 |
+
+### PO-Entscheidungen — getroffen 2026-08-10
+
+| Frage | Entscheidung |
+|---|---|
+| **Überwachungsdauer nach Mitternachts-Ankunft** | **Bis Tagesfenster-Ende** (wie bei Tagesankunft, Standard 19 Uhr). Keine zweite Zeitrechnung neben #1584. Mehr Wetterabrufe werden in Kauf genommen |
+| **Editor-Anzeige bei Wegpunkt nach Mitternacht** | **Nur die korrekte Uhrzeit** („02:23"). Die Folgetags-Kennzeichnung „(+1)" kommt als **eigene kleine Arbeit danach** — nicht Teil von S2 |
+| **Nacht-Etappen grundsätzlich** | **Erlaubt lassen.** Nachtstarts sind gängige Bergpraxis; keine Sperre, kein Warnhinweis |
+| **Reihenfolge** | **S1 zuerst**, dann S2, dann S3. 🔴 **Auflage: #1667 bleibt bis S3 offen** — S1 schließt den Issue nicht |

--- a/docs/specs/modules/fix_1667_s1_fixture_wanduhr.md
+++ b/docs/specs/modules/fix_1667_s1_fixture_wanduhr.md
@@ -1,0 +1,377 @@
+---
+entity_id: fix_1667_s1_fixture_wanduhr
+type: bugfix
+created: 2026-08-10
+updated: 2026-08-10
+status: draft
+workflow: fix-1667-arrival-midnight-wrap
+version: "1.0"
+tags: [issue-1667, tests, fixtures, day-window, freezegun, radar-alerts]
+---
+
+# S1 — Zeitfensterabhängige Test-Fixtures entschärfen (Mitternachts-Wanduhr)
+
+## Approval
+
+- [x] Approved — PO „freigabe" 2026-08-10
+
+## 🔴 Diese Scheibe schließt Issue #1667 NICHT
+
+**S1 hat keine Produktwirkung und keinen Produktivcode-Eingriff.** Sie
+entschärft ausschließlich Test-Fixtures, die zwischen ~22:00 und 00:00 UTC
+reproduzierbar rot werden. Die zugrundeliegende Sicherheitslücke — ein
+Wanderer, der nach Mitternacht ankommt, verliert bis zu 11 h 50 min
+Radar-/NowCast-Überwachung ohne jeden Alarm (gemessen in Phase 2, s.
+`docs/context/fix-1667-arrival-midnight-wrap.md`, Abschnitt „Die
+Sicherheitslücke — gemessen, nicht hergeleitet") — bleibt nach S1
+**unverändert offen**. Sie wird erst durch S2 (Klemme → Modulo in
+Naismith, drei Sprachen) und S3 (tagesübergreifende Segment-Auswahl)
+adressiert. **Aus „die ~30 Tests sind wieder grün" darf nicht geschlossen
+werden, dass die Lücke geschlossen ist** — genau diese Verwechslung war der
+Auslöser des Tickets: Das Issue benannte als Ursache eine 2h-Regel, die seit
+PR #1590 gar nicht mehr existiert, und übersah die tatsächliche,
+sicherheitsrelevante 23:59-Klemme in `naismith.py`, weil die sichtbaren
+Symptome — abendlich rote Tests — einer anderen, harmlosen Ursache
+entspringen (`wp_days[0]` ist strukturell immer 0, s. u.).
+
+**Issue #1667 bleibt nach S1 explizit offen** (PO-Entscheidung
+2026-08-10). Schließen erst nach S3.
+
+## Purpose
+
+Zwölf Testdateien mit ~29–31 Testfunktionen bauen ihre Trip-Fixturen, indem
+sie `arrival_calculated` direkt als `(now + N h).strftime("%H:%M")` bei
+Stage-Datum `now.date()` schreiben — sie umgehen die Naismith-Berechnung
+komplett und damit auch deren 23:59-Klemme. Das kollidiert mit einer
+zweiten, unabhängigen Eigenschaft des Segmentbaus:
+`src/services/trip_segments.py:151-159` erkennt einen Tageswechsel
+zwischen zwei Wegpunkten nur bei **strikt fallender** Uhrzeit
+(`t < prev`); der **erste** Wegpunkt (`wp_days[0]`) ist dadurch strukturell
+immer 0 — ein Rollover *vor* dem ersten Wegpunkt ist im Datenmodell nicht
+darstellbar.
+
+Ab 23:00 UTC erzeugt eine `+1h/+4h`-Fixture die Folge `wp0=00:00,
+wp1=03:00` — **steigend statt fallend**, also kein erkannter Rollover. Das
+Segment wird mit `target_date + wp_days[0]=0` kombiniert und landet damit
+23 Stunden in der Vergangenheit; der Guard „alle Segmente vorbei"
+(`src/services/trip_alert.py:749-763`) greift, `check_radar_alerts()`
+liefert 0 Treffer statt der erwarteten 1. Punktgenau reproduziert:
+`tests/tdd/test_alert_urgency.py::test_convective_radar_logs_high` läuft
+grün bis 22:59 UTC und rot ab exakt 23:00 UTC (`assert 0 == 1`); bei
+`+2h/+4h`-Fixturen liegt die Kippkante bei 22:00 UTC. Ein zweiter,
+seltenerer Mechanismus greift um 23:59:59→00:00:01: `date_type.today()`
+(`src/services/trip_alert.py:739`) springt bereits auf den Folgetag,
+während das Stage-Datum der Fixture beim Vortag bleibt —
+`get_stage_for_date()` findet dann nichts mehr.
+
+**🔴 Alternative, geprüft und verworfen:** Naheliegend wäre, das
+Stage-Datum aus dem Ankunfts-`datetime` abzuleiten, statt `now.date()` zu
+nehmen. **Das löst das Problem nicht.** `wp_days[0]` bleibt strukturell 0,
+weil es für den ersten Wegpunkt keinen Vorgänger gibt, an dem eine
+fallende Uhrzeit erkannt werden könnte (`prev is None` beim ersten
+Durchlauf, `trip_segments.py:151-159`). Ein Rollover *vor* dem ersten
+Wegpunkt ist im Datenmodell nicht darstellbar — gleich, welches Datum die
+Fixture setzt. Dieser Absatz steht hier, damit die Alternative nicht
+erneut versucht wird.
+
+Diese Scheibe ersetzt die Uhrzeit-Arithmetik in allen zwölf Fixturen durch
+ein Ankunftsfenster, das **innerhalb desselben Kalendertags monoton
+steigt** (02:00–22:00 Ortszeit) — ein im Repo bereits zweimal erprobtes
+Muster (`test_952_onset_alert_fidelity.py:125-147`,
+`test_issue_1069_tier_channel_gating.py:430-450`). Damit bleibt
+`wp_days` immer `[0, 0, …]`, das Segment landet nie in der Vergangenheit,
+und die Tests werden von der Wanduhr unabhängig.
+
+## Source
+
+- **Files:** zwölf Testdateien unter `tests/tdd/` und `tests/unit/` (s.
+  „Affected Files"), neuer gemeinsamer Helfer unter `tests/helpers/`
+- **Identifier:** `_save_radar_trip()`, `_make_trip()`, `_radar_trip()`,
+  `_make_active_trip()`, `_save_trip_direct()`, drei Inline-Stellen in
+  `test_issue_822_radar_nowcast_segment.py`, zwei `pytest.skip`-Guards
+
+> **Schicht-Hinweis:** Ausschließlich Python-Testcode
+> (`tests/tdd/`, `tests/unit/`, `tests/helpers/`) und
+> `pyproject.toml` (Dev-Dependency `freezegun`). **Kein** Eingriff in
+> `src/`, `api/`, `internal/`, `frontend/`, `cmd/` — das ist die zentrale
+> Nicht-Wirkungs-Zusicherung dieser Scheibe (s. AC-6).
+
+## Affected Files
+
+| Datei:Zeile | Helfer | Heutiger Versatz |
+|---|---|---|
+| `tests/tdd/test_alert_log_metrics.py:115` | `_save_radar_trip()` (Ursprung) | +1h/+4h |
+| `tests/tdd/test_alert_urgency.py:175` | `_save_radar_trip()` (bitidentische Kopie) | +1h/+4h |
+| `tests/tdd/test_issue_827_radar_throttle_recording.py:38` | `_make_trip()` | +2h/+4h |
+| `tests/tdd/test_issue_1070_daily_alert_limit.py:227` | `_make_trip()` | +2h/+4h |
+| `tests/tdd/test_alert_channel_threshold.py:214` | `_radar_trip()` | +2h/+4h |
+| `tests/tdd/test_issue_883_acute_danger_override.py:76` | `_make_active_trip()` | −1h/+2h |
+| `tests/tdd/test_alert_quiet_hours_robustness.py:224` | `_save_trip_direct()` | −1h/+2h |
+| `tests/tdd/test_issue_822_radar_nowcast_segment.py:169,713,800` | inline (3×, ohne benannten Helfer) | diverse (−4h/−2h/+2h; −1h/+1h; −1h/+1h) |
+| `tests/tdd/test_bundle_791_847_844_alerts.py:196` | inline | −1h/+3h |
+| `tests/tdd/test_issue_995_scheduler_pause.py:183-184` | inline (`arr1`/`arr2`) | −1h/+2h |
+| `tests/tdd/test_issue_818_radar_briefing_integration.py:401` | `pytest.skip` vor 04:00 UTC (in `test_ac5_past_segment_no_alert_guard_test`, Zeile 386) — zurückbauen | — |
+| `tests/unit/test_alarm_zeitfenster_ziel.py:350` | `pytest.skip` in den ersten 3 Min des UTC-Tages — zurückbauen | — |
+
+Alle Zeilenangaben am HEAD `5ea233a4` nachgemessen (Bash `grep -n`/`sed
+-n`); zwei Zeilennummern aus dem Briefing waren um 1 verschoben
+(`test_issue_818…:401` statt 400, `test_alarm_zeitfenster_ziel.py:350`
+statt 349) — hier korrigiert.
+
+## Estimated Scope
+
+- **LoC:** ~110–140 (neuer Helfer `tests/helpers/arrival_window_fixtures.py`
+  ~35–45 LoC; zehn Aufrufstellen schrumpfen von je ~6–10 Zeilen
+  Uhrzeit-Arithmetik auf 1–3 Zeilen Aufruf, macht die drei Inline-Stellen in
+  `test_issue_822_…` und die Umbau-Differenz an den übrigen neun Stellen
+  netto positiv aber klein; zwei `pytest.skip`-Rückbauten je ~5-10 Zeilen
+  löschen/anpassen; `pyproject.toml` +1 Zeile)
+- **Files:** 13 (12 Testdateien + 1 neuer Helfer) + `pyproject.toml`
+- **Effort:** medium — reine Mechanik an vielen Stellen, aber mit
+  eigenem Zeit-Nahweis-Nachweis (freezegun) pro Fixture zu verifizieren
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `tests/tdd/test_952_onset_alert_fidelity.py::_active_window` (Zeile 125-147) | pattern | Vorbild für die 02:00–22:00-Ortszeit-Klemmung — im Repo bereits erprobt |
+| `tests/tdd/test_issue_1069_tier_channel_gating.py::_active_window_now` (Zeile 430-450) | pattern | Zweites, bitidentisches Vorbild — bestätigt, dass das Muster kein Einzelfall ist |
+| `src/services/trip_segments.py::convert_trip_to_segments` (Zeile 151-159, `wp_days`) | module | Die Eigenschaft, gegen die entschärft wird — NICHT geändert, nur an ihr Verhalten angepasst |
+| `tests/helpers/nowcast_gate_fixtures.py` | module | Bestehender Helfer-Baustein derselben Fixture-Familie (Issue #1467 S3); neuer Helfer fügt sich stilistisch ein (echte Trips/Waypoints, kein Mock), baut aber KEINE gemeinsame Funktion mit ihm, da dessen `make_trip()` bewusst einen ganztägigen 00:00–23:59-Bereich nutzt, nicht das hier gebrauchte Ankunfts-Offset-Muster |
+| `freezegun` (neu, Dev-Dependency) | tool | Test-Uhr für den Vorher/Nachher-Nachweis (AC-1); ohne sie ist S1 nur um 23:xx UTC live beweisbar |
+| `pytest-socket` (bestehend) | tool | Analogie für die Hauskonvention „fertiges Standardwerkzeug statt Eigenbau", auf die sich die Aufnahme von `freezegun` beruft |
+
+## Implementation Details
+
+**1. Neuer gemeinsamer Helfer `tests/helpers/arrival_window_fixtures.py`**
+
+Enthält eine Funktion (Arbeitsname `active_window_offsets(lat, lon,
+start_offset_min, end_offset_min)`), die exakt das Muster aus
+`test_952_onset_alert_fidelity.py::_active_window` /
+`test_issue_1069_tier_channel_gating.py::_active_window_now` kapselt:
+Ortszeit-Fenster um `datetime.now(tz)` herum, auf `02:00–22:00 Ortszeit`
+geklemmt, `HH:MM`-Strings für Start/Ende zurückgegeben. Die zehn
+namentlich benannten Aufrufstellen (alle außer den drei Inline-Stellen in
+`test_issue_822_…`, die einen dritten Wegpunkt und abweichende
+Zeitzonen/Muster verwenden und deshalb nicht ohne Signaturänderung passen)
+rufen den Helfer auf, statt die Uhrzeit-Arithmetik lokal zu wiederholen.
+
+```
+def active_window_offsets(lat: float, lon: float,
+                           start_offset_min: int, end_offset_min: int
+                           ) -> tuple[str, str]:
+    """Ankunftszeiten fuer zwei Wegpunkte, geklemmt auf 02:00-22:00
+    Ortszeit — verhindert den Mitternachts-Rollover-Verlust aus
+    trip_segments.py:151-159 (wp_days[0] ist strukturell immer 0).
+    Vorbild: test_952_onset_alert_fidelity.py::_active_window."""
+    tz = tz_for_coords(lat, lon)
+    now_local = datetime.now(tz)
+    start = now_local + timedelta(minutes=start_offset_min)
+    end = now_local + timedelta(minutes=end_offset_min)
+    day_start = now_local.replace(hour=2, minute=0, second=0, microsecond=0)
+    day_end = now_local.replace(hour=22, minute=0, second=0, microsecond=0)
+    if start < day_start:
+        start = day_start
+    if end > day_end:
+        end = day_end
+    if end <= start:
+        end = start + timedelta(hours=1)
+    return start.strftime("%H:%M"), end.strftime("%H:%M")
+```
+
+Aufruf an den zehn Stellen z. B. `test_alert_urgency.py::_save_radar_trip`:
+
+```
+arr0, arr1 = active_window_offsets(LAT, LON, 60, 240)  # statt now+1h/+4h
+```
+
+Die drei Inline-Stellen in `test_issue_822_radar_nowcast_segment.py` (Zeile
+169, 713, 800) rufen dieselbe Funktion mit ihren jeweiligen
+Offset-Paaren auf; wo drei Wegpunkte gebraucht werden (Zeile 169:
+−4h/−2h/+2h), wird der Helfer zweimal aufgerufen (Start/Mitte,
+Mitte/Ende) oder — falls das die Monotonie verletzt — die Fixture bleibt
+mit begründetem Kommentar bei lokal geklemmter Arithmetik. **Diese
+Entscheidung fällt in der Implementierung, nicht in dieser Spec** —
+Leitplanke ist: `wp_days` muss `[0, 0, 0]` bleiben, geprüft durch AC-1/AC-2.
+
+**2. Zwei `pytest.skip`-Rückbauten**
+
+- `test_issue_818_radar_briefing_integration.py:401` — Guard `if
+  now.hour < 4: pytest.skip(...)` entfällt; die Fixture in derselben
+  Funktion (baut auf `wp1 = now-2h`) wird auf den Helfer umgestellt, womit
+  der Zeitumbruch-Grund für den Skip entfällt.
+- `tests/unit/test_alarm_zeitfenster_ziel.py:350` — Guard `if
+  arrival.date() != date.today(): pytest.skip(...)` entfällt; die Fixture
+  (Ankunft `now - 3min`) verliert ihre Abhängigkeit von der UTC-Tagesgrenze,
+  weil `arrival` nicht mehr direkt mit `date.today()` verglichen werden
+  muss — die Konstruktion nutzt stattdessen ebenfalls ein Wanduhr-robustes
+  Muster (Details in der Implementierung, kein neuer AC nötig: AC-4 deckt
+  das Ergebnis „kein `pytest.skip` mehr zeitabhängig" bereits ab).
+
+**3. `freezegun` als Dev-Dependency**
+
+`pyproject.toml`, Abschnitt `[dependency-groups].dev` (Zeile 82-88):
+Zeile `"freezegun>=1.5.0",` ergänzen, analog zur bestehenden Zeile
+`"pytest-socket>=0.8.0",` — Hauskonvention „fertiges Standardwerkzeug statt
+Eigenbau" (`freezegun` ist ausdrücklich als Werkzeug für S1 markiert,
+Regel-Budget-Prüfdatum s. u.).
+
+## Expected Behavior
+
+- **Input:** Testlauf zu beliebiger Wanduhrzeit, inklusive 22:00–00:00 UTC
+  und der Sekunde 23:59:59→00:00:01.
+- **Output:** Alle betroffenen ~29-31 Testfunktionen sind zu jeder
+  Wanduhrzeit grün (nachgewiesen für die Kippkanten via `freeze_time`,
+  s. AC-1/AC-2). Kein `pytest.skip` greift mehr zeitabhängig (AC-4).
+- **Side effects:** keine Produktwirkung — `git diff --stat` zeigt null
+  Zeilen in `src/`, `api/`, `internal/`, `frontend/` (AC-6).
+
+## Acceptance Criteria
+
+- **AC-1:** Given der Test `test_alert_urgency.py::test_convective_radar_logs_high`
+  läuft mit der ursprünglichen (unveränderten) Fixture unter `freeze_time`
+  auf `2026-08-10T23:30:00+00:00` / When der Test in diesem Zustand
+  ausgeführt wird / Then schlägt er fehl (`assert 0 == 1`) — das ist der
+  Vorher-Nachweis der Kippkante bei 23:00 UTC.
+  - Test: `freezegun.freeze_time` auf die genannte Uhrzeit setzen, den
+    unveränderten Test (vor dem Fixture-Umbau, z. B. am Commit vor dieser
+    Änderung oder über eine temporär zurückgesetzte Kopie der Fixture)
+    ausführen und den `AssertionError` beobachten. Dieser AC ist der
+    Vorher-Teil des Vorher/Nachher-Paars mit AC-2.
+
+- **AC-2:** Given dieselbe Testfunktion nach dem Fixture-Umbau dieser
+  Scheibe, wieder unter `freeze_time` auf `2026-08-10T23:30:00+00:00` /
+  When der Test ausgeführt wird / Then ist er grün — der Nachweis über die
+  gestellte Uhr ist der Kern der Abnahme dieser Scheibe: derselbe Test,
+  dieselbe simulierte Zeit, vorher rot, nachher grün.
+  - Test: `freezegun.freeze_time("2026-08-10T23:30:00+00:00")` um den
+    Testlauf von `test_alert_urgency.py::test_convective_radar_logs_high`
+    (nach dem Fixture-Umbau); Assert Exit 0 bzw. `check_radar_alerts()`
+    liefert wieder 1 Treffer.
+
+- **AC-3 (Kippkanten):** Given dieselben umgebauten Fixturen aus
+  `test_alert_log_metrics.py`/`test_alert_urgency.py` (+1h/+4h-Familie),
+  `test_issue_827_radar_throttle_recording.py`/`test_issue_1070_daily_alert_limit.py`/
+  `test_alert_channel_threshold.py` (+2h/+4h-Familie) und die
+  Datumssprung-Sekunde / When je ein Testlauf unter `freeze_time` auf
+  22:59:59 UTC, 23:00:00 UTC (bzw. 21:59:59/22:00:00 für die
+  +2h/+4h-Familie) sowie 23:59:59 UTC und 00:00:01 UTC des Folgetags läuft
+  / Then bleiben alle vier Zeitpunkte grün — die Kippkanten sind
+  abgedeckt, nicht nur ein Einzelzeitpunkt.
+  - Test: pro genannter Kippkante ein `freeze_time`-Lauf über mindestens
+    eine Fixture aus jeder betroffenen Versatz-Familie (+1h/+4h,
+    +2h/+4h, −1h/+2h) sowie eine 23:59:59→00:00:01-Probe über eine der
+    beiden vormals überspringenden Dateien (`test_issue_818_…`,
+    `test_alarm_zeitfenster_ziel.py`); Assert jeweils Exit 0 ohne Skip.
+  - 🔴 **Die drei Familien kippen NICHT aus demselben Grund** — wer das
+    übersieht, prüft bei `−1h/+2h` eine Grenze, die es dort nicht gibt:
+    - `+1h/+4h` und `+2h/+4h`: **Rollover-Kippkante** bei 23:00 bzw.
+      22:00 UTC. Ab dort ist die Folge *steigend* (z.B. `00:00 → 03:00`),
+      der Tageswechsel wird nicht erkannt, `wp_days` bleibt `[0,0]`, das
+      Segment landet in der Vergangenheit.
+    - `−1h/+2h`: **keine Rollover-Kippkante.** Der erste Wegpunkt liegt
+      stets vor `now`, die Folge ist damit immer *fallend* (z.B.
+      `21:00 → 00:00`), der Rollover greift korrekt und `wp_days` wird
+      richtig `[0,1]`. Für diese Familie ist **allein die
+      Mitternachtsgrenze 00:00:01 UTC** relevant: `date_type.today()`
+      springt auf den neuen Tag, während das Stage-Datum der Fixture beim
+      Vortag bleibt ⇒ `get_stage_for_date()` findet nichts ⇒ leere
+      Segmentliste. Ein Test dieser Familie an 22:00/23:00 UTC wäre
+      **grün aus dem falschen Grund** und bewiese nichts.
+
+- **AC-4 (keine zeitabhängigen Skips mehr):** Given
+  `test_issue_818_radar_briefing_integration.py::test_ac5_past_segment_no_alert_guard_test`
+  und `test_alarm_zeitfenster_ziel.py` (die Testfunktion um Zeile 350) /
+  When beide unter `freeze_time` auf eine Uhrzeit laufen, die vorher den
+  jeweiligen `pytest.skip` ausgelöst hätte (z. B. 02:00 UTC bzw. 00:00:30
+  UTC) / Then wird kein `pytest.skip` mehr aufgerufen und der Test läuft
+  bis zu einem echten Pass/Fail durch.
+  - Test: `freeze_time` auf die genannten vormals überspringenden
+    Zeitpunkte setzen, `pytest -rs` (zeigt Skip-Gründe) auf beide
+    Testfunktionen; Assert keine Zeile mit `SKIPPED` für diese Tests.
+
+- **AC-5 (Mutations-Gegenprobe):** Given der Helfer
+  `active_window_offsets()` wird in der 02:00–22:00-Klemmung deaktiviert
+  (z. B. `day_start`/`day_end`-Klemmung durch eine No-Op ersetzt, sodass er
+  wieder rohe `now + N h`-Werte ohne Tagesgrenze liefert) / When
+  `test_alert_urgency.py::test_convective_radar_logs_high` unter
+  `freeze_time` auf 23:30 UTC läuft / Then wird der Test wieder rot — die
+  Klemmung ist die Zusicherung, die den Fund tatsächlich verhindert, und
+  ohne sie fängt kein anderer Test dieselbe Regression.
+  - Test: Mutation per Textersetzung (nach CLAUDE.md-Vorgabe: externe
+    Sicherungskopie, keine `git checkout/stash/reset`) an
+    `active_window_offsets()`, dann `freeze_time("...23:30:00+00:00")` +
+    Testlauf; Assert `AssertionError`. Mutation danach zurückspielen.
+
+- **AC-6 (Nicht-Wirkung, Produktivcode unangetastet):** Given der
+  vollständige Diff dieser Scheibe / When `git diff --stat
+  origin/main...HEAD -- src/ api/ internal/ frontend/ cmd/` ausgeführt wird
+  / Then ist die Ausgabe leer (null geänderte Zeilen in Produktivcode) —
+  die Scheibe belegt damit selbst, dass sie keine Produktwirkung
+  beansprucht.
+  - Test: `git diff --stat` gegen den Merge-Basis-Commit über exakt diese
+    fünf Verzeichnisse laufen lassen; Assert leere Ausgabe. (Kann als
+    manueller Nachweis im PR oder als CI-Schritt erfolgen — kein neuer
+    Pytest-Test nötig, da es sich um eine repo-strukturelle Prüfung
+    handelt, keine Verhaltensprüfung von Anwendungscode.)
+
+## Known Limitations
+
+- **Die gesamte Produktionslücke bleibt offen.** S1 löst nichts an der
+  23:59-Klemme (`naismith.py:54-60`) oder an `wp_days[0]` — beide sind
+  Gegenstand von S2/S3. Ein realer Wanderer mit Abendstart verliert
+  weiterhin bis zu ~12 h Überwachung ohne Alarm.
+- **Nicht alle zehn Fixture-Kopien werden zu EINER Funktion
+  zusammengeführt.** Die drei Inline-Stellen in
+  `test_issue_822_radar_nowcast_segment.py` behalten möglicherweise lokale
+  Arithmetik, wenn der Drei-Wegpunkte-Fall nicht sauber auf den
+  Zwei-Wegpunkte-Helfer passt (Entscheidung fällt in der Implementierung).
+- **Fixtures außerhalb der Alarm-/Radar-Ecke sind nicht Teil dieser
+  Scheibe.** Andere Tests, die `arrival_calculated` mit ähnlicher
+  Wanduhr-Abhängigkeit setzen, aber nicht in der Liste der zwölf Dateien
+  stehen, wurden nicht durchsucht und bleiben unverändert.
+- **`test_issue_822_radar_nowcast_segment.py` behält teils andere
+  Zeitzonen/Muster** (Island UTC+0, London UTC+0) — der Helfer wird dort
+  ggf. mit anderen Koordinaten aufgerufen, ändert aber nichts an der
+  grundsätzlichen 02:00–22:00-Ortszeit-Klemmung.
+
+## Risiko
+
+**Der Fixture-Fix entfernt den einzigen derzeit vorhandenen
+Frühwarn-Effekt** für die echte Sicherheitslücke: die abendlich roten
+Tests waren bislang das einzige Signal, das überhaupt auf eine
+Uhrzeit-Abhängigkeit im Alarm-Pfad hinwies — auch wenn dieses Signal aus
+einem harmlosen Testfixture-Artefakt stammte (`wp_days[0]`), nicht aus der
+tatsächlichen 23:59-Klemme. Nach S1 gibt es **kein automatisches Signal
+mehr**, das auf die verbleibende Lücke hinweist, bis S2/S3 sie mit eigenen,
+gezielten Tests abdecken. Dieses Risiko wird bewusst in Kauf genommen,
+weil die roten Tests aktuell ein Fixture-Artefakt bewachen und keine
+verlässliche Aussage über die echte Lücke treffen — ein rotes Ergebnis um
+23:00 UTC beweist nichts über eine Ankunft nach Mitternacht, weil die
+Fixture diesen Fall (Ankunft > 23:59 real, geklemmt auf 23:59) gar nicht
+konstruiert.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reiner Testinfrastruktur-Umbau ohne neue
+  Architekturentscheidung — keine neue Zeitquelle, kein neuer
+  Auflöser, kein Produktivcode-Konsument. `freezegun` als Dev-Dependency
+  ist ein Werkzeug-Zusatz, kein Architekturentscheid; das Regel-Budget dazu
+  (Prüfdatum 2026-11-08, s. u.) ersetzt kein bestehendes ADR und begründet
+  keines.
+
+## Regel-Budget
+
+`freezegun` als Dev-Dependency ist an diese Scheibe gekoppelt.
+**Prüfdatum: 2026-11-08 (+90 Tage).** Fang-Beleg bei Einführung: ohne
+Test-Uhr ist der Vorher/Nachher-Nachweis aus AC-1/AC-2 nur zwischen ~22:00
+und 00:00 UTC live erbringbar — jede andere Verifikation müsste auf die
+passende Uhrzeit warten. Am Prüfdatum: hat `freezegun` außerhalb dieser
+Scheibe (S2/S3, andere Zeit-abhängige Tests) einen zweiten, unabhängigen
+Fang belegt? Kein Fang → Rückbau prüfen (die punktuellen DI-Uhren
+`_now_fn` bleiben als Alternative bestehen).
+
+## Changelog
+
+- 2026-08-10: Initial spec created

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,4 +86,5 @@ dev = [
     "ruff>=0.8.0",
     "playwright>=1.57.0",
     "pytest-socket>=0.8.0",
+    "freezegun>=1.5.0",
 ]

--- a/tests/fixtures/ratchet_cases/wallclock_arrival_faelle.py.txt
+++ b/tests/fixtures/ratchet_cases/wallclock_arrival_faelle.py.txt
@@ -1,0 +1,231 @@
+# Fixture-Quelltexte fuer tests/tdd/test_fixture_wallclock_ratchet.py.
+#
+# Bewusst KEINE .py-Endung: der Waechter scannt tests/**/*.py, und diese Datei
+# enthaelt absichtlich echte Verstoesse. Laege sie als .py hier, meldete der
+# Waechter seine eigenen Fixtures. Vorbild fuer Form und Begruendung:
+# tests/fixtures/ratchet_cases/faelle.py.txt (#1409 Lieferung B).
+#
+# Format: `# === <fall> ===` trennt die Faelle. Der Text bis zum naechsten
+# Trenner wird 1:1 als Testdatei nach tmp_path geschrieben.
+
+# === roh-unclamped ===
+from datetime import datetime, timedelta, timezone
+
+
+def _save_radar_trip(user_id, trip_id):
+    now = datetime.now(timezone.utc)
+    stage = {
+        "date": now.date().isoformat(),
+        "waypoints": [
+            {"id": "W0", "arrival_calculated": (now + timedelta(hours=1)).strftime("%H:%M")},
+            {"id": "W1", "arrival_calculated": (now + timedelta(hours=4)).strftime("%H:%M")},
+        ],
+    }
+    return stage
+
+# === sauber-geklemmt ===
+from datetime import datetime, timedelta, timezone
+
+
+def _active_window(tz):
+    """Vorbild aus tests/tdd/test_952_onset_alert_fidelity.py — auf 02:00-22:00
+    Ortszeit geklemmt, deshalb steigt die Folge innerhalb EINES Kalendertags."""
+    now_local = datetime.now(tz)
+    start = now_local + timedelta(hours=1)
+    end = now_local + timedelta(hours=4)
+    tag_start = now_local.replace(hour=2, minute=0, second=0, microsecond=0)
+    tag_ende = now_local.replace(hour=22, minute=0, second=0, microsecond=0)
+    if start < tag_start:
+        start = tag_start
+    if end > tag_ende:
+        end = tag_ende
+    return start.strftime("%H:%M"), end.strftime("%H:%M")
+
+
+def _save_radar_trip(user_id, trip_id):
+    now = datetime.now(timezone.utc)
+    arr0, arr1 = _active_window(timezone.utc)
+    return {
+        "date": now.date().isoformat(),
+        "waypoints": [
+            {"id": "W0", "arrival_calculated": arr0},
+            {"id": "W1", "arrival_calculated": arr1},
+        ],
+    }
+
+# === nur-uhrzeit-ohne-datum ===
+from datetime import datetime, timedelta, timezone
+
+
+def _quiet_window_now():
+    """Ruhezeitfenster um jetzt herum — KEIN Etappen-Datum im Spiel, also auch
+    kein Mitternachts-Rollover eines Segments. Muster aus
+    tests/helpers/nowcast_gate_fixtures.py::quiet_window_now."""
+    now = datetime.now(timezone.utc)
+    return (
+        (now - timedelta(minutes=30)).strftime("%H:%M"),
+        (now + timedelta(minutes=30)).strftime("%H:%M"),
+    )
+
+# === astimezone-dazwischen ===
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+
+def test_ac1_radar_alert_onset_in_local_time():
+    tz = ZoneInfo("Europe/Paris")
+    now_utc = datetime.now(timezone.utc)
+    stage = {
+        "date": now_utc.date().isoformat(),
+        "waypoints": [
+            {"arrival_calculated": (now_utc - timedelta(hours=1)).astimezone(tz).strftime("%H:%M")},
+            {"arrival_calculated": (now_utc + timedelta(hours=3)).astimezone(tz).strftime("%H:%M")},
+        ],
+    }
+    assert stage
+
+# === bypass-zwischenvariable ===
+from datetime import datetime, timedelta, timezone
+
+
+def _save_radar_trip(user_id, trip_id):
+    """Der generische Bypass (Adversary-Finding F004 zu #1667 S1): identisches
+    Anti-Muster, aber die Rechnung steht in einer Zwischenvariablen. Bis zur
+    Namensaufloesung meldete der Scanner hier NULL Funde — ein trivialer,
+    voellig plausibler Refactoring-Schritt haette die Ratsche entwertet."""
+    now = datetime.now(timezone.utc)
+    ankunft_start = now + timedelta(hours=1)
+    ankunft_ziel = now + timedelta(hours=4)
+    return {
+        "date": now.date().isoformat(),
+        "waypoints": [
+            {"id": "W0", "arrival_calculated": ankunft_start.strftime("%H:%M")},
+            {"id": "W1", "arrival_calculated": ankunft_ziel.strftime("%H:%M")},
+        ],
+    }
+
+# === bypass-zwischenvariable-mit-astimezone ===
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+
+def _save_radar_trip(user_id, trip_id):
+    """Zweistufige Kette: rohe Rechnung -> Name -> .astimezone(...) -> Name.
+    Das Muster aus tests/unit/test_alarm_zeitfenster_ziel.py, das die Spec als
+    "strukturell nicht erfassbar" beschrieb."""
+    now = datetime.now(timezone.utc)
+    ankunft = now - timedelta(minutes=3)
+    ankunft_lokal = ankunft.astimezone(ZoneInfo("Atlantic/Reykjavik"))
+    return {
+        "date": now.date().isoformat(),
+        "waypoints": [
+            {"id": "W0", "arrival_calculated": ankunft_lokal.strftime("%H:%M")},
+        ],
+    }
+
+# === bypass-liste ===
+from datetime import datetime, timedelta, timezone
+
+
+def _save_radar_trip(user_id, trip_id):
+    """Adversary-Finding F007: die Uhrzeiten landen in einer LISTE statt direkt
+    in einem dict-Wert oder Aufruf-Argument. Die erste Fassung der
+    Fluss-Erkennung zaehlte nur dict und Call auf und schwieg hier."""
+    now = datetime.now(timezone.utc)
+    zeiten = [
+        (now + timedelta(hours=1)).strftime("%H:%M"),
+        (now + timedelta(hours=4)).strftime("%H:%M"),
+    ]
+    return {
+        "date": now.date().isoformat(),
+        "waypoints": [{"arrival_calculated": z} for z in zeiten],
+    }
+
+# === bypass-tupel-rueckgabe ===
+from datetime import date, datetime, timedelta, timezone
+
+
+def _fenster():
+    """Adversary-Finding F007, zweite Form: Rueckgabe als Tupel. Weder dict
+    noch Aufruf-Argument — und trotzdem dasselbe Anti-Muster."""
+    now = datetime.now(timezone.utc)
+    ankunft_start = now + timedelta(hours=2)
+    return date.today(), (
+        ankunft_start.strftime("%H:%M"),
+        (now + timedelta(hours=4)).strftime("%H:%M"),
+    )
+
+# === erwartungswert-nur-verglichen ===
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+
+def test_onset_wird_in_ortszeit_gerendert():
+    """Gegenprobe zur Fluss-Erkennung: eine wanduhr-abgeleitete Uhrzeit, die
+    NUR verglichen wird — das Muster aus
+    tests/tdd/test_bundle_791_847_844_alerts.py. Kein Wegpunkt, kein Fund.
+
+    Ohne diese Unterscheidung erzwaenge die Ratsche Aenderungen an voellig
+    gesunden Tests."""
+    tz = ZoneInfo("Europe/Paris")
+    now_utc = datetime.now(timezone.utc)
+    onset_utc = now_utc + timedelta(minutes=5)
+    expected_local_hhmm = onset_utc.astimezone(tz).strftime("%H:%M")
+    utc_hhmm = onset_utc.strftime("%H:%M")
+    body = _irgendeine_mail(date_hint=now_utc.date().isoformat())
+    assert expected_local_hhmm in body
+    assert utc_hhmm not in body, f"UTC-Zeit {utc_hhmm} darf nicht erscheinen"
+
+
+def _irgendeine_mail(date_hint):
+    return date_hint
+
+# === sauber-geklemmt-ueber-namen ===
+from datetime import datetime, timedelta, timezone
+
+
+def _active_window(tz):
+    """Dasselbe Gegenmuster wie `sauber-geklemmt`, aber der Aufrufer legt die
+    Rueckgabe in eigene Namen und ruft strftime erst dort auf.
+
+    Der Scanner muss hier schweigen, obwohl am strftime ein Name steht: `start`
+    wird in den Klemm-Zweigen NEU gebunden, ist also nicht ausschliesslich aus
+    roher Wanduhr-Arithmetik gebunden. Ohne diesen Beleg waere unklar, ob die
+    Namensaufloesung das erprobte Muster mitfaengt und die Ratsche
+    unpassierbar macht — genau der Zielkonflikt, an dem der RED-Agent die
+    Namensaufloesung verworfen hatte."""
+    now_local = datetime.now(tz)
+    start = now_local + timedelta(hours=1)
+    end = now_local + timedelta(hours=4)
+    tag_start = now_local.replace(hour=2, minute=0, second=0, microsecond=0)
+    tag_ende = now_local.replace(hour=22, minute=0, second=0, microsecond=0)
+    if start < tag_start:
+        start = tag_start
+    if end > tag_ende:
+        end = tag_ende
+    return start, end
+
+
+def _save_radar_trip(user_id, trip_id):
+    now = datetime.now(timezone.utc)
+    start, end = _active_window(timezone.utc)
+    return {
+        "date": now.date().isoformat(),
+        "waypoints": [
+            {"id": "W0", "arrival_calculated": start.strftime("%H:%M")},
+            {"id": "W1", "arrival_calculated": end.strftime("%H:%M")},
+        ],
+    }
+
+# === datum-aus-date-today ===
+from datetime import date, datetime, timedelta, timezone
+
+
+def _make_trip():
+    now_utc = datetime.now(timezone.utc)
+    return {
+        "date": date.today().isoformat(),
+        "waypoints": [
+            {"arrival_calculated": (now_utc + timedelta(hours=2)).strftime("%H:%M")},
+        ],
+    }

--- a/tests/helpers/arrival_window_fixtures.py
+++ b/tests/helpers/arrival_window_fixtures.py
@@ -1,0 +1,267 @@
+"""Wanduhr-robuste Ankunftszeiten fuer Trip-Fixturen (Issue #1667 Scheibe S1).
+
+SPEC: docs/specs/modules/fix_1667_s1_fixture_wanduhr.md
+
+Das Problem
+-----------
+Rund dreissig Alarm-/Radar-Tests bauten ihre Etappen-Wegpunkte als
+``(now +/- timedelta(...)).strftime("%H:%M")`` bei Etappendatum
+``now.date()``. Ab einer bestimmten Wanduhrzeit lief die Uhrzeit-Folge ueber
+Mitternacht und wurde dadurch *steigend* (``00:00 -> 03:00``) statt
+*fallend*. ``convert_trip_to_segments`` (``src/services/trip_segments.py``,
+``wp_days``) erkennt eine Tagesgrenze aber nur bei **strikt fallender**
+Uhrzeit; das Segment landete 23 Stunden in der Vergangenheit, der Guard
+„alle Segmente vorbei" (``src/services/trip_alert.py``) griff, und
+``check_radar_alerts()`` lieferte 0 statt 1.
+
+Warum die naheliegende „02:00-22:00 Ortszeit"-Klemmung NICHT reicht
+--------------------------------------------------------------------
+Nachgemessen (nicht hergeleitet) unter ``freeze_time`` fuer Korsika
+(UTC+2), Etappendatum ``date.today()``:
+
+======================  =====================  =========================
+Wanduhr (UTC)           Fenster laut Klemmung  Segment in UTC
+======================  =====================  =========================
+2026-08-10 21:59:59     00:59 -> 01:59         08-09 22:59 .. 23:59  VORBEI
+2026-08-10 23:30:00     02:30 -> 05:30         08-10 00:30 .. 03:30  VORBEI
+======================  =====================  =========================
+
+Der Grund ist **nicht** die vom Spec-Entwurf vermutete undichte obere
+Klemme, sondern ein Bezugstag-Bruch: das Fenster wird um ``now_local``
+gebaut, das Segment aber auf ``date.today()`` gesetzt. Sobald Ortszeit und
+Systemtag auseinanderlaufen — bei UTC+2 ab 22:00 UTC — zeigt ``now_local``
+schon auf den Folgetag, das Etappendatum noch auf den Vortag, und jede
+Ortszeit-Uhrzeit wird beim Segmentbau einen ganzen Tag zu frueh eingesetzt.
+Die Klemmung verschiebt die Kippkante damit von 23:00 auf 22:00 UTC, statt
+sie zu beseitigen.
+
+Zweite gemessene Einsicht: ``wp_days == [0, 0]`` ist als Leitplanke ab
+~22:00 UTC **unerfuellbar**. Auf dem Etappentag ist die spaeteste
+darstellbare Ortszeit 23:59; bei UTC+2 sind das 21:59 UTC. Wer ``now_utc``
+danach noch erreichen will, MUSS ueber den Rollover gehen — die richtige
+Antwort ist also eine *fallende* Folge (``wp_days == [0, 1]``), nicht eine
+steigende.
+
+Wie dieser Helfer es loest
+---------------------------
+Er rechnet in **Minuten seit Ortszeit-Mitternacht des Etappentags** — also
+in genau der Groesse, die ``convert_trip_to_segments`` beim Zusammensetzen
+wieder auseinandernimmt — und klemmt dort:
+
+* Der erste Wegpunkt liegt zwingend im Bereich ``[0, 1439]``: ``wp_days[0]``
+  ist strukturell immer 0, ein Rollover *vor* dem ersten Wegpunkt ist im
+  Datenmodell nicht darstellbar.
+* Jeder Folge-Wegpunkt liegt ``1..1439`` Minuten nach seinem Vorgaenger.
+  Die untere Grenze haelt die Folge streng monoton (sonst kollabiert das
+  Segment am ``end_dt <= start_dt``-Guard), die obere Grenze garantiert,
+  dass ein Tageswechsel sich als *fallende* Uhrzeit zeigt und deshalb von
+  ``wp_days`` erkannt wird. Ein Abstand von genau 1440 Minuten wuerde
+  dieselbe Uhrzeit erzeugen und den Rollover verschlucken.
+
+Damit ist das Ergebnis zu jeder Wanduhrzeit entweder aktiv oder in der
+Zukunft — beides laesst ``check_radar_alerts()`` ein Segment waehlen — und
+nie „vorbei".
+
+Bezugstag
+---------
+``stage_date()`` liefert dieselbe Quelle, die ``trip_alert.py`` fuer
+``convert_trip_to_segments`` benutzt (``date.today()``). Fixturen sollten das
+Etappendatum daraus nehmen statt aus ``datetime.now(timezone.utc).date()``:
+laeuft die Systemzeitzone nicht auf UTC (oder faellt der Testlauf genau auf
+den Datumssprung), zeigen die beiden sonst auf verschiedene Tage und
+``get_stage_for_date()`` findet nichts.
+
+Kein Mock: die Funktionen rechnen mit echten Zeitzonen ueber
+``utils.timezone.tz_for_coords`` und geben dieselben ``HH:MM``-Strings
+zurueck, die auch die Anwendung schreibt.
+
+Pfadregel #1409: keine Pfadaufloesung noetig — dieser Helfer liest nichts von
+der Platte.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta, timezone
+
+from utils.timezone import tz_for_coords
+
+__all__ = [
+    "MINUTEN_PRO_TAG",
+    "active_window_offsets",
+    "fenster_minuten",
+    "past_window_offsets",
+    "stage_date",
+]
+
+MINUTEN_PRO_TAG = 24 * 60
+
+
+def fenster_minuten(minuten_jetzt: int, *offsets_min: int) -> tuple[int, ...]:
+    """Die tragende Rechnung von :func:`active_window_offsets`, OHNE Uhr.
+
+    Eingabe ist die Minute seit Ortszeit-Mitternacht des Etappentags, in der
+    *jetzt* liegt (darf negativ sein: der lokale Tag hat noch nicht begonnen;
+    darf ueber 1439 liegen: er ist schon vorbei). Ausgabe sind die
+    Wegpunkt-Minuten desselben Bezugs.
+
+    Bewusst als reine Funktion herausgezogen, damit die drei Zusicherungen
+    unten ueber ALLE Minuten eines Tages deterministisch pruefbar sind — ohne
+    gestellte Uhr, ohne Zeitzonendaten, in jedem CI-Lauf. Vorher hingen sie an
+    einmaligen ``freeze_time``-Handlaeufen, deren Ergebnis nur als Text in
+    einem Artefakt lag; eine Verfaelschung der Monotonie-Untergrenze oder der
+    oberen Klemme blieb im gesamten committeten Testbestand unbemerkt
+    (Adversary-Findings F002/F003 zu #1667 S1).
+
+    Zusicherungen — jede einzeln in
+    ``tests/unit/test_arrival_window_fixtures.py`` bewacht:
+
+    1. ``0 <= ergebnis[0] <= 1439`` — der erste Wegpunkt liegt auf dem
+       Etappentag. ``wp_days[0]`` ist in ``convert_trip_to_segments``
+       strukturell immer 0; ein Rollover VOR dem ersten Wegpunkt ist im
+       Datenmodell nicht darstellbar.
+    2. Streng monoton steigend. Zwei gleiche Zeiten kollabieren das Segment am
+       ``end_dt <= start_dt``-Guard.
+    3. Jeder Abstand hoechstens ``MINUTEN_PRO_TAG - 1``. Bei genau 1440 waere
+       die Uhrzeit identisch und der Tageswechsel wuerde verschluckt — die
+       Rollover-Erkennung in ``convert_trip_to_segments`` greift nur bei
+       STRIKT fallender Uhrzeit.
+    """
+    if len(offsets_min) < 2:
+        raise ValueError(
+            "Ein Segment braucht mindestens zwei Wegpunkte — "
+            f"erhalten: {offsets_min!r}"
+        )
+
+    roh = [int(minuten_jetzt) + int(v) for v in offsets_min]
+
+    # Hat der lokale Etappentag noch gar nicht begonnen (westliche Zeitzonen
+    # kurz nach UTC-Mitternacht), wird das GANZE Fenster nach vorne geschoben
+    # statt nur sein Anfang — sonst bliebe ein Segment von einer Minute Laenge
+    # uebrig. Nach hinten wird NICHT geschoben: das nimmt den spaeteren
+    # Wegpunkten ihre Reichweite in die Zukunft und laesst das Segment
+    # oestlich von UTC (nachgemessen: Neuseeland ab 22:00 UTC) doch wieder in
+    # der Vergangenheit landen.
+    verschiebung = max(0, -roh[0])
+    roh = [r + verschiebung for r in roh]
+
+    # Zusicherung 1.
+    minuten: list[int] = [min(roh[0], MINUTEN_PRO_TAG - 1)]
+    for r in roh[1:]:
+        vorher = minuten[-1]
+        # Zusicherungen 2 und 3.
+        minuten.append(min(max(r, vorher + 1), vorher + MINUTEN_PRO_TAG - 1))
+    return tuple(minuten)
+
+
+def stage_date() -> date:
+    """Etappendatum, das zur Segmentauswahl in ``trip_alert.py`` passt.
+
+    Dort steht ``today = date_type.today()``; ``convert_trip_to_segments``
+    sucht die Etappe ueber ``get_stage_for_date(today)``. Eine Fixture, die
+    ihr Etappendatum aus ``datetime.now(timezone.utc).date()`` nimmt, trifft
+    das nur, solange die Systemzeitzone UTC ist.
+    """
+    return date.today()
+
+
+def active_window_offsets(lat: float, lon: float, *offsets_min: int) -> tuple[str, ...]:
+    """Ankunftszeiten (``HH:MM`` Ortszeit) fuer zwei oder mehr Wegpunkte.
+
+    ``offsets_min`` sind die gewuenschten Abstaende zu *jetzt* in Minuten,
+    aufsteigend gemeint (z.B. ``60, 240`` fuer das alte ``now+1h`` /
+    ``now+4h``). Zurueck kommt ein Tupel gleicher Laenge, das mit dem
+    Etappendatum aus :func:`stage_date` ein Segment ergibt, das zu jeder
+    Wanduhrzeit aktiv oder zukuenftig ist — nie „vorbei".
+
+    Die gewuenschten Abstaende werden dabei nur so weit veraendert, wie die
+    Tagesgrenzen es erzwingen; in der Tagesmitte kommen sie unveraendert
+    heraus.
+
+    🔴 **Das Vorzeichen eines Versatzes ist keine Zusicherung.** Nahe der
+    Ortszeit-Mitternacht ist "zwei Stunden vor jetzt" auf dem Etappentag nicht
+    darstellbar; der Wegpunkt rutscht dann nach vorne und kann NACH *jetzt*
+    liegen. Ein Test, der ein bereits VERGANGENES erstes Segment braucht (z.B.
+    "der Nowcast muss die Koordinaten des ZWEITEN Segments nehmen"), darf sich
+    darauf nicht verlassen — er braucht Koordinaten weit oestlich von
+    Greenwich, damit der Etappentag am Ort immer weit genug fortgeschritten
+    ist. Nachgemessen an
+    ``test_issue_822_radar_nowcast_segment.py::test_ac3_...``: in Ligurien
+    (UTC+1) war das erste Segment um 00:00:01 UTC noch aktiv und der Test
+    fiel auf die Wegpunkt-0-Koordinaten zurueck.
+    """
+    tagesbeginn, minuten_jetzt = _tagesbezug(lat, lon)
+    return tuple(
+        (tagesbeginn + timedelta(minutes=m)).strftime("%H:%M")
+        for m in fenster_minuten(minuten_jetzt, *offsets_min)
+    )
+
+
+def _tagesbezug(lat: float, lon: float) -> tuple[datetime, int]:
+    """Ortszeit-Mitternacht des Etappentags und die Minute, in der *jetzt* liegt.
+
+    Genau dieser Bezug wird in ``convert_trip_to_segments`` wieder aufgebaut
+    (``datetime.combine(target_date, wp_time).replace(tzinfo=seg_tz)``).
+    """
+    tz = tz_for_coords(lat, lon)
+    tagesbeginn = datetime.combine(stage_date(), time(0, 0)).replace(tzinfo=tz)
+    jetzt = datetime.now(timezone.utc)
+    return tagesbeginn, int((jetzt - tagesbeginn).total_seconds() // 60)
+
+
+def past_window_offsets(lat: float, lon: float, *offsets_min: int) -> tuple[str, ...]:
+    """Ankunftszeiten fuer ein Segment, das garantiert schon VORBEI ist.
+
+    Gegenstueck zu :func:`active_window_offsets` fuer die Regressionswaechter
+    des „alle Segmente vorbei"-Guards. Alle Wegpunkte liegen auf dem
+    Etappentag und mindestens eine Minute vor *jetzt*.
+
+    🔴 **Das allein genuegt nicht, damit ein Trip als „vorbei" gilt.** Seit
+    Issue #1584 endet das Ziel-Segment nicht mehr bei „Ankunft + 2 h", sondern
+    am Ende des konfigurierten Tagesfensters (Default 4-19 Uhr Ortszeit,
+    ``src/services/trip_segments.py``). Eine Fixture, die nur die Wegpunkte in
+    die Vergangenheit legt, haelt das Ziel-Segment trotzdem bis 19:00 Ortszeit
+    offen. Aufrufer muessen deshalb zusaetzlich ein Tagesfenster setzen, dessen
+    Ende vor der Ankunft liegt — dann faellt das Ziel-Segment auf das minimale
+    Fenster von einer Stunde nach Ankunft zurueck.
+
+    Reicht der Platz auf dem Etappentag nicht fuer die gewuenschten Abstaende
+    (fruehe Ortszeit), wird das Fenster gestaucht statt zu scheitern; ist gar
+    kein Platz mehr, wird :class:`ValueError` geworfen — laut scheitern statt
+    still ein Fenster liefern, das die Zusicherung nicht traegt.
+    """
+    if len(offsets_min) < 2:
+        raise ValueError(
+            "Ein Segment braucht mindestens zwei Wegpunkte — "
+            f"erhalten: {offsets_min!r}"
+        )
+
+    tz = tz_for_coords(lat, lon)
+    tag = stage_date()
+    tagesbeginn = datetime.combine(tag, time(0, 0)).replace(tzinfo=tz)
+    jetzt = datetime.now(timezone.utc)
+    minuten_jetzt = int((jetzt - tagesbeginn).total_seconds() // 60)
+
+    anzahl = len(offsets_min)
+    obergrenze = min(MINUTEN_PRO_TAG - 1, minuten_jetzt - 1)
+    if obergrenze < anzahl - 1:
+        raise ValueError(
+            f"Auf dem Etappentag {tag} ist an dieser Ortszeit noch kein "
+            f"vergangenes Fenster mit {anzahl} Wegpunkten darstellbar "
+            f"(Platz: {obergrenze + 1} Minuten). Die Fixture braucht eine "
+            "Zeitzone, deren Etappentag weiter fortgeschritten ist."
+        )
+
+    roh = [minuten_jetzt + int(v) for v in offsets_min]
+    for i in range(1, anzahl):
+        roh[i] = max(roh[i], roh[i - 1] + 1)
+    # Das ganze Fenster so weit nach hinten schieben, dass der letzte Wegpunkt
+    # vor jetzt liegt (nach vorne wird nicht geschoben — das machte es spaeter).
+    verschiebung = min(0, obergrenze - roh[-1])
+    roh = [r + verschiebung for r in roh]
+    if roh[0] < 0:
+        # Passt die gewuenschte Spanne nicht mehr auf den bisher vergangenen
+        # Teil des Etappentags: gleichmaessig auf [0, obergrenze] stauchen.
+        roh = [round(obergrenze * i / (anzahl - 1)) for i in range(anzahl)]
+        for i in range(1, anzahl):
+            roh[i] = max(roh[i], roh[i - 1] + 1)
+
+    return tuple((tagesbeginn + timedelta(minutes=m)).strftime("%H:%M") for m in roh)

--- a/tests/tdd/test_alert_channel_threshold.py
+++ b/tests/tdd/test_alert_channel_threshold.py
@@ -66,6 +66,7 @@ from tests.helpers.alert_log_fixtures import (
     read_log,
     weather,
 )
+from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
 
 # ═══════════════════════════ Telegram-Stub (echtes 127.0.0.1) ═════════════
 #
@@ -214,17 +215,18 @@ def _ac4_trip(trip_id: str) -> Trip:
 def _radar_trip(trip_id: str) -> Trip:
     """Tour im aktiven Segmentfenster JETZT — Vorbild
     ``test_issue_827_radar_throttle_recording.py::_make_trip``."""
-    today = date.today()
-    now_utc = datetime.now(timezone.utc)
+    # #1667 S1: wanduhr-robustes Ankunftsfenster statt roher now+Nh-Arithmetik
+    # (ab 22:00 UTC lief die +2h/+4h-Folge steigend ueber Mitternacht).
+    arr0, arr1 = active_window_offsets(LAT, LON, 120, 240)
     wp0 = Waypoint(
         id="WP0", name="Start", lat=LAT, lon=LON, elevation_m=500.0,
-        arrival_calculated=(now_utc + timedelta(hours=2)).strftime("%H:%M"),
+        arrival_calculated=arr0,
     )
     wp1 = Waypoint(
         id="WP1", name="Ziel", lat=LAT + 0.1, lon=LON + 0.1, elevation_m=600.0,
-        arrival_calculated=(now_utc + timedelta(hours=4)).strftime("%H:%M"),
+        arrival_calculated=arr1,
     )
-    stage = Stage(id="S1", name="Tag 1", date=today, waypoints=[wp0, wp1])
+    stage = Stage(id="S1", name="Tag 1", date=stage_date(), waypoints=[wp0, wp1])
     trip = Trip(id=trip_id, name="AC3 Radar-Trip", stages=[stage])
     trip.report_config = TripReportConfig(
         trip_id=trip_id, send_email=True, send_telegram=True, send_sms=False,

--- a/tests/tdd/test_alert_log_metrics.py
+++ b/tests/tdd/test_alert_log_metrics.py
@@ -23,6 +23,8 @@ from datetime import datetime, timedelta, timezone
 from app.loader import get_briefings_dir, get_data_dir
 from app.models import Corridor, ThunderLevel
 
+from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
+
 from tests.helpers.alert_log_fixtures import (
     LAT, LON, fresh_user, gust_alert_trip, read_log, settings_email_only, weather,
 )
@@ -115,18 +117,22 @@ def test_ac2_beide_korridor_namensraeume_liefern_dasselbe_register_paar():
 def _save_radar_trip(user_id: str, trip_id: str) -> None:
     briefings = get_briefings_dir(user_id)
     briefings.mkdir(parents=True, exist_ok=True)
-    now = datetime.now(timezone.utc)
+    # #1667 S1: Ankunftszeiten aus dem wanduhr-robusten Helfer statt aus roher
+    # now+Nh-Arithmetik — sonst laeuft die Folge ab 23:00 UTC steigend ueber
+    # Mitternacht, der Rollover wird nicht erkannt und das Segment landet
+    # 23 h in der Vergangenheit ("alle Segmente vorbei" -> 0 Alarme).
+    arr0, arr1 = active_window_offsets(LAT, LON, 60, 240)
     (briefings / f"{trip_id}.json").write_text(json.dumps({
         "id": trip_id, "name": "Radar-Trip",
         "stages": [{
-            "id": "S1", "name": "Tag 1", "date": now.date().isoformat(),
+            "id": "S1", "name": "Tag 1", "date": stage_date().isoformat(),
             "waypoints": [
                 {"id": "W0", "name": "Start", "lat": LAT, "lon": LON,
                  "elevation_m": 1000.0,
-                 "arrival_calculated": (now + timedelta(hours=1)).strftime("%H:%M")},
+                 "arrival_calculated": arr0},
                 {"id": "W1", "name": "Ziel", "lat": LAT + 0.1, "lon": LON + 0.1,
                  "elevation_m": 1500.0,
-                 "arrival_calculated": (now + timedelta(hours=4)).strftime("%H:%M")},
+                 "arrival_calculated": arr1},
             ],
         }],
         "report_config": {"trip_id": trip_id, "send_email": True, "send_telegram": False},

--- a/tests/tdd/test_alert_quiet_hours_robustness.py
+++ b/tests/tdd/test_alert_quiet_hours_robustness.py
@@ -78,6 +78,7 @@ from app.config import Settings
 from app.loader import get_briefings_dir, save_location
 from app.user import SavedLocation
 
+from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
 from tests.helpers.compare_briefings import write_compare_briefings
 
 _REPO = Path(__file__).resolve().parents[2]
@@ -234,21 +235,23 @@ def _save_trip_direct(
     ``get_briefings_dir()`` folgt dem pytest-isolierten Daten-Wurzelpfad
     (#1133) — demselben Pfad, aus dem ``load_all_trips()`` liest.
     """
-    now = datetime.now(timezone.utc)
     briefings = get_briefings_dir(user_id)
     briefings.mkdir(parents=True, exist_ok=True)
+    # #1667 S1: wanduhr-robustes Ankunftsfenster (Helfer) statt roher
+    # now-1h/now+2h-Arithmetik mit Etappendatum aus der Wanduhr.
+    arr0, arr1 = active_window_offsets(lat, lon, -60, 120)
     data: dict = {
         "id": trip_id,
         "name": name,
         "stages": [{
-            "id": "S1", "name": "Tag 1", "date": now.date().isoformat(),
+            "id": "S1", "name": "Tag 1", "date": stage_date().isoformat(),
             "waypoints": [
                 {"id": "WP0", "name": "Start", "lat": lat, "lon": lon,
                  "elevation_m": 100.0,
-                 "arrival_calculated": (now - timedelta(hours=1)).strftime("%H:%M")},
+                 "arrival_calculated": arr0},
                 {"id": "WP1", "name": "Ziel", "lat": lat + 0.05,
                  "lon": lon + 0.05, "elevation_m": 200.0,
-                 "arrival_calculated": (now + timedelta(hours=2)).strftime("%H:%M")},
+                 "arrival_calculated": arr1},
             ],
         }],
         "report_config": {

--- a/tests/tdd/test_alert_urgency.py
+++ b/tests/tdd/test_alert_urgency.py
@@ -42,6 +42,7 @@ from tests.helpers.alert_log_fixtures import (
     LAT, LON, clean_compare_user, compare_data_root, fresh_user, gust_alert_trip,
     read_log, settings_email_only, weather,
 )
+from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
 from tests.helpers.compare_briefings import write_compare_briefings
 
 _GUST_STANDARD_THRESHOLD_KMH = 20.0
@@ -176,18 +177,21 @@ def _save_radar_trip(user_id: str, trip_id: str) -> None:
     """1:1 Muster aus tests/tdd/test_alert_log_metrics.py::_save_radar_trip."""
     briefings = get_briefings_dir(user_id)
     briefings.mkdir(parents=True, exist_ok=True)
-    now = datetime.now(timezone.utc)
+    # #1667 S1: Ankunftszeiten aus dem wanduhr-robusten Helfer statt aus roher
+    # now+Nh-Arithmetik — genau diese Fixture kippte ab 23:00 UTC nach
+    # "alle Segmente vorbei" und liess check_radar_alerts() 0 statt 1 liefern.
+    arr0, arr1 = active_window_offsets(LAT, LON, 60, 240)
     (briefings / f"{trip_id}.json").write_text(json.dumps({
         "id": trip_id, "name": "Radar-Trip",
         "stages": [{
-            "id": "S1", "name": "Tag 1", "date": now.date().isoformat(),
+            "id": "S1", "name": "Tag 1", "date": stage_date().isoformat(),
             "waypoints": [
                 {"id": "W0", "name": "Start", "lat": LAT, "lon": LON,
                  "elevation_m": 1000.0,
-                 "arrival_calculated": (now + timedelta(hours=1)).strftime("%H:%M")},
+                 "arrival_calculated": arr0},
                 {"id": "W1", "name": "Ziel", "lat": LAT + 0.1, "lon": LON + 0.1,
                  "elevation_m": 1500.0,
-                 "arrival_calculated": (now + timedelta(hours=4)).strftime("%H:%M")},
+                 "arrival_calculated": arr1},
             ],
         }],
         "report_config": {"trip_id": trip_id, "send_email": True, "send_telegram": False},

--- a/tests/tdd/test_bundle_791_847_844_alerts.py
+++ b/tests/tdd/test_bundle_791_847_844_alerts.py
@@ -34,6 +34,8 @@ from app.models import (
 )
 from app.trip import Stage, Trip, Waypoint
 
+from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
+
 DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
 
 
@@ -191,12 +193,13 @@ def test_ac1_radar_alert_onset_in_local_time():
     _clean_user(uid)
     _ensure_real_user_dir(uid)
     try:
-        today = now_utc.date()
-        wp0 = _make_waypoint("WP0", lat, lon,
-                             (now_utc - timedelta(hours=1)).astimezone(tz).strftime("%H:%M"))
-        wp1 = _make_waypoint("WP1", lat + 0.1, lon + 0.1,
-                             (now_utc + timedelta(hours=3)).astimezone(tz).strftime("%H:%M"))
-        stage = Stage(id="S1", name="Etappe 1", date=today, waypoints=[wp0, wp1])
+        # #1667 S1: wanduhr-robustes Ankunftsfenster (Helfer) statt roher
+        # now-1h/now+3h-Arithmetik. Der Helfer liefert bereits Ortszeit,
+        # das frueher noetige .astimezone(tz) entfaellt damit.
+        arr0, arr1 = active_window_offsets(lat, lon, -60, 180)
+        wp0 = _make_waypoint("WP0", lat, lon, arr0)
+        wp1 = _make_waypoint("WP1", lat + 0.1, lon + 0.1, arr1)
+        stage = Stage(id="S1", name="Etappe 1", date=stage_date(), waypoints=[wp0, wp1])
         trip_id = f"tdd-791-trip-{uuid.uuid4().hex[:6]}"
         trip = Trip(id=trip_id, name="GR20 Test", stages=[stage])
         trip.report_config = TripReportConfig(

--- a/tests/tdd/test_fixture_wallclock_ratchet.py
+++ b/tests/tdd/test_fixture_wallclock_ratchet.py
@@ -1,0 +1,672 @@
+"""Waechter (#1667 S1): keine Trip-Fixture baut Ankunftszeiten aus der rohen
+Wanduhr, ohne sie auf einen Tagesbereich zu klemmen.
+
+Das Anti-Muster
+---------------
+Eine Fixture setzt das Etappen-Datum aus der Wanduhr (``now.date()`` /
+``date.today()``) und die Ankunftszeit ihrer Wegpunkte direkt aus
+``(now +/- timedelta(...)).strftime("%H:%M")``. Ab einer bestimmten
+Wanduhrzeit — bei ``+1h/+4h`` ab 23:00 UTC, bei ``+2h/+4h`` ab 22:00 UTC —
+laeuft die Uhrzeit-Folge ueber Mitternacht und wird dadurch *steigend*
+(``00:00 -> 03:00``) statt *fallend*. ``convert_trip_to_segments``
+(``src/services/trip_segments.py:151-159``) erkennt eine Tagesgrenze aber nur
+bei strikt fallender Uhrzeit, und ``wp_days[0]`` ist strukturell immer 0 —
+ein Rollover VOR dem ersten Wegpunkt ist im Datenmodell nicht darstellbar.
+Das Segment landet damit 23 Stunden in der Vergangenheit, der Guard „alle
+Segmente vorbei" (``src/services/trip_alert.py:749-763``) greift, und
+``check_radar_alerts()`` liefert 0 statt 1.
+
+Gemessen, nicht hergeleitet: ``test_alert_urgency.py::
+test_convective_radar_logs_high`` ist unter ``freeze_time`` auf
+``2026-08-10T12:00:00+00:00`` gruen und unter ``2026-08-10T23:30:00+00:00``
+rot (``assert 0 == 1``). Beide Laeufe liegen als Artefakt unter
+``docs/artifacts/fix-1667-arrival-midnight-wrap/``.
+
+🔴 **Diese Ratsche bewacht die TESTS, nicht das Produkt.** Sie sagt nichts
+ueber die eigentliche Sicherheitsluecke aus #1667 (23:59-Klemme in
+``src/core/naismith.py:54-60``, bis zu 11 h 50 min ohne Radar-Alarm fuer
+einen Wanderer mit Spaetankunft). Diese wird erst von S2/S3 adressiert. Wer
+aus „diese Datei ist gruen" schliesst, die Luecke sei zu, wiederholt genau
+den Denkfehler, der #1667 ausgeloest hat.
+
+Was der Scanner meldet
+----------------------
+``scan_wallclock_arrival_fixtures(tests_root)`` durchsucht ``tests_root``
+rekursiv nach ``*.py`` und meldet jede Funktion, in der BEIDE Merkmale
+zugleich auftreten:
+
+1. **Wanduhr-Etappendatum** — ein Aufruf ``<jetzt>.date()`` (Empfaenger ist
+   ein Name, der mit ``now``/``jetzt``/``heute`` beginnt, oder direkt ein
+   ``datetime.now(...)``/``utcnow()``/``today()``-Aufruf) oder
+   ``date.today()`` / ``datetime.today()`` / ``date_type.today()``.
+2. **Ungeklemmte Ankunftszeit** — ein Aufruf ``X.strftime("%H:%M")``, bei dem
+   ``X`` (ggf. ueber ein zwischengeschaltetes ``.astimezone(...)``) ein
+   ``BinOp`` ist, in dem ein ``timedelta(...)`` vorkommt. Gemeldet wird die
+   Zeile des ``strftime``-Aufrufs.
+
+Gemeldet wird nur die Kombination. Ein Ruhezeitfenster ohne Etappendatum
+(``tests/helpers/nowcast_gate_fixtures.py::quiet_window_now``,
+``tests/tdd/test_compare_radar_alert.py::_quiet_hours_window_now``) ist
+deshalb kein Fund — dort gibt es kein Segment, das in die Vergangenheit
+rutschen koennte.
+
+Namensaufloesung — und warum sie das Gegenmuster nicht mitfaengt
+----------------------------------------------------------------
+Bis 2026-08-10 sah der Scanner nur den direkten Rechenausdruck am
+``strftime``. Eine einzige Zwischenvariable genuegte, um ihn zu umgehen —
+``ankunft = now + timedelta(hours=1)`` … ``ankunft.strftime("%H:%M")`` ergab
+NULL Funde bei identischem Anti-Muster. Das war keine schmale, dateispezifische
+Ausnahme, sondern eine generische Bypass-Technik und machte den bleibenden
+Schutz weitgehend wertlos (Adversary-Finding F004 zu #1667 S1).
+
+Der Scanner loest Namen deshalb auf. Der Zielkonflikt, an dem die
+Namensaufloesung urspruenglich verworfen wurde — das erprobte Gegenmuster
+(``test_952_onset_alert_fidelity.py::_active_window``) hat am ``strftime``
+ebenfalls nur einen Namen stehen — loest sich ueber die Frage **"ist der Name
+AUSSCHLIESSLICH aus roher Wanduhr-Arithmetik gebunden?"**:
+
+* Gegenmuster: ``start`` wird zuerst aus ``now_local + timedelta(...)``
+  gebunden, in den Klemm-Zweigen aber ERNEUT aus ``tag_start``/``tag_ende``.
+  Nicht alle Zuweisungen sind rohe Rechnungen ⇒ geklemmt ⇒ kein Fund. Genau
+  die Klemmung, die den Namen sicher macht, ist das Merkmal, an dem er
+  freigesprochen wird.
+* Bypass: einzige Zuweisung, rohe Rechnung, nie neu gebunden ⇒ Fund.
+
+Ketten ueber Zwischenschritte (``x = roh``; ``y = x.astimezone(tz)``;
+``y.strftime(...)``) werden mitverfolgt. Belegt durch
+``test_scanner_erkennt_den_bypass_ueber_eine_zwischenvariable``,
+``test_scanner_erkennt_die_kette_ueber_astimezone_und_namen`` und die
+Gegenprobe ``test_scanner_schweigt_bei_geklemmtem_namen``.
+
+Grenzen, ehrlich benannt
+-------------------------
+Der Scanner arbeitet rein syntaktisch und **innerhalb einer Funktion**. Er
+sieht nicht:
+
+* Namen, die aus einer ANDEREN Funktion stammen (Rueckgabewerte werden nicht
+  verfolgt) — deshalb schweigt er beim Gegenmuster auch dann, wenn der
+  Aufrufer die geklemmten Werte weiterreicht;
+* Uhrzeiten, die ueber eine Sammlung laufen (Liste, dict, Tupel-Entpackung):
+  dort ist die Herkunft nicht mehr eindeutig einem Namen zuzuordnen, und der
+  Scanner meldet im Zweifel NICHT — lieber ein uebersehener Fall als ein
+  Falsch-Positiv, das die Ratsche unpassierbar macht;
+* ob eine Klemmung fachlich RICHTIG ist. Er prueft nur, DASS der Name
+  irgendwo anders gebunden wird.
+
+Zwei Stellen im Bestand brauchen das Anti-Muster strukturell und stehen
+deshalb begruendet in ``KNOWN_VIOLATIONS`` (Begruendung dort, nicht hier —
+sie gehoert an den Eintrag).
+
+Regel-Budget
+------------
+``EXPIRY`` (2026-11-08, +90 Tage) — Vorbild ``EXPIRY`` in
+``.claude/hooks/test_naming_gate.py`` und
+``tests/tdd/test_repo_path_hardcoding_ratchet.py``. Am Pruefdatum: hat die
+Ratsche einen echten Rueckfall verhindert? Kein Fang => Rueckbau.
+
+Spec: ``docs/specs/modules/fix_1667_s1_fixture_wanduhr.md``.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+# Wurzel DIESES Checkouts (Worktree) — bewusst nicht das Hauptrepo (#1409):
+# der Waechter muss den Baum pruefen, in dem gerade gearbeitet wird.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TESTS_ROOT = REPO_ROOT / "tests"
+
+# Fixture-Quelltexte liegen AUSSERHALB der Scanflaeche `tests/**/*.py`
+# (Endung .py.txt) — sonst meldete der Waechter seine eigenen Fixtures.
+_FAELLE_DATEI = REPO_ROOT / "tests/fixtures/ratchet_cases/wallclock_arrival_faelle.py.txt"
+
+# Pruefdatum des Regel-Budgets: 2026-11-08
+EXPIRY = date(2026, 11, 8)
+
+_HHMM = "%H:%M"
+_WANDUHR_NAMEN = ("now", "jetzt", "heute")
+_HEUTE_TRAEGER = {"date", "datetime", "date_type", "datetime_type"}
+
+# 🔴 Diese Liste darf nur SCHRUMPFEN, nie wachsen — und sie darf NICHT gefuellt
+# werden, um den Waechter gruen zu bekommen. Ein Eintrag ist nur zulaessig, wenn
+# die Fixture das Anti-Muster STRUKTURELL braucht: wenn es keine Wegpunktzeit
+# gibt, die die Pruefaussage traegt UND auf dem Etappentag darstellbar ist.
+# „Umstellen waere aufwendig" ist kein Grund.
+#
+# Die beiden Eintraege unten entstanden, als die Namensaufloesung eingebaut
+# wurde (Adversary-Finding F004): sie legte zwei Stellen frei, die der Scanner
+# vorher gar nicht sehen konnte. Beide sind geprueft und begruendet:
+#
+# 1) test_alarm_zeitfenster_ziel.py::_radar_mails_fuer_spaetankunft
+#    Baut die Ankunft aus `jetzt - 3 min` und braucht das auch: die Fixture
+#    beweist den Randfall-Guard fuer eine SPAETANKUNFT relativ zum
+#    Tagesfenster, und `day_window_end_hour` wird aus der Ortsstunde ebendieser
+#    Ankunft abgeleitet. Ein geklemmtes Fenster wuerde die Ankunft verschieben
+#    und damit die Pruefaussage zerstoeren. Statt der Klemmung kompensiert die
+#    Fixture ueber die ORTSWAHL (Reykjavik, sonst Auckland), sodass Ortsdatum
+#    == Etappendatum und Ortsstunde >= 1 gilt. Diese Kompensation ist der
+#    einzige Fix im ganzen Slice, der ueber ALLE 1440 Minuten eines Tages
+#    deterministisch bewacht wird —
+#    `test_radar_fixture_ist_zu_jeder_tageszeit_kein_mitternachtsfenster`
+#    iteriert 1440+3 synthetische Zeitpunkte, ohne gestellte Uhr. Der Schutz
+#    ist hier also NICHT schwaecher als die Ratsche, sondern staerker.
+#
+# 2) test_starkregen_kurzfristhinweis.py::_trip_with_segment_offset
+#    Die Pruefaussage IST die exakte Vorlaufzeit: 90 Minuten (jenseits von
+#    NOWCAST_HORIZON_MIN=60) darf keinen Nowcast-Abruf ausloesen, 30 Minuten
+#    schon. Jede Klemmung wuerde 90 auf weniger stauchen und den Test ins
+#    Gegenteil verkehren. „Segmentbeginn exakt +90 min, auf dem Etappentag" ist
+#    aber unrepraesentierbar, sobald weniger als 90 Minuten des lokalen Tages
+#    uebrig sind — der erste Wegpunkt MUSS auf dem Etappentag liegen
+#    (`wp_days[0]` ist strukturell 0), und ein Etappendatum ist genau ein
+#    Kalendertag. Keine Zeitzone loest das: sie verschiebt das Fenster nur.
+#    Die Datei erkennt das selbst und ueberspringt an der Grenze laut
+#    (`pytest.skip`) — sie ist dort also nicht still falsch, sondern
+#    hoerbar abwesend. Ein echter Fix braeuchte tagesuebergreifende Etappen,
+#    also Produktivcode — Gegenstand von #1667 S3, nicht von S1.
+#
+# 🔴 Der Shrink-Waechter unten faengt nur VERALTETE Eintraege, nicht neue
+# unbegruendete: eine Ausnahmeliste kann sich strukturell nicht selbst gegen
+# Zuwachs schuetzen, und Code kann das nicht loesen. Jeder neue Eintrag ist
+# deshalb review-pflichtig und braucht die Begruendung hier im Klartext —
+# wer einen hinzufuegt, ohne dass ein Reviewer sie geprueft hat, hebelt den
+# Waechter aus (Adversary-Finding F008 zu #1667 S1).
+#
+# Format je Eintrag: (repo-relativer Pfad, Funktionsname)
+KNOWN_VIOLATIONS: frozenset[tuple[str, str]] = frozenset({
+    ("tests/unit/test_alarm_zeitfenster_ziel.py", "_radar_mails_fuer_spaetankunft"),
+    ("tests/tdd/test_starkregen_kurzfristhinweis.py", "_trip_with_segment_offset"),
+})
+
+
+@dataclass(frozen=True)
+class Finding:
+    """Eine Fundstelle: Datei, Funktion, Zeile des ``strftime``-Aufrufs."""
+
+    path: Path
+    function: str
+    line: int
+
+    @property
+    def ref(self) -> str:
+        return f"{self.path}:{self.line} ({self.function})"
+
+
+def _ist_timedelta(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    f = node.func
+    if isinstance(f, ast.Name) and f.id == "timedelta":
+        return True
+    return isinstance(f, ast.Attribute) and f.attr == "timedelta"
+
+
+def _ist_wanduhr_traeger(node: ast.AST) -> bool:
+    """Traegt ``node`` die aktuelle Wanduhr? (Empfaenger eines ``.date()``)."""
+    if isinstance(node, ast.Name):
+        # Fuehrende Unterstriche abstreifen: ``_now`` traegt die Wanduhr genauso
+        # wie ``now``. Ohne das genuegte ein Unterstrich, um den Waechter zu
+        # umgehen — gemessen an einer Mutation, die genau daran vorbeilief.
+        return node.id.lstrip("_").lower().startswith(_WANDUHR_NAMEN)
+    if isinstance(node, ast.Call):
+        f = node.func
+        if isinstance(f, ast.Attribute) and f.attr in {"now", "utcnow", "today"}:
+            return True
+        if isinstance(f, ast.Name) and f.id in {"now", "utcnow"}:
+            return True
+    return False
+
+
+def _ist_wanduhr_datum(node: ast.AST) -> bool:
+    """``now.date()``, ``date.today()``, ``datetime.today()``,
+    ``date_type.today()`` — und ``stage_date()``.
+
+    ``stage_date()`` gehoert dazu, weil es genau ``date.today()`` zurueckgibt.
+    Ohne diesen Zweig entstuende ausgerechnet durch S1 eine neue Luecke: die
+    zwoelf umgestellten Fixturen holen ihr Etappendatum jetzt aus
+    ``stage_date()`` statt aus ``now.date()``. Faellt eine von ihnen spaeter auf
+    rohe Ankunftszeiten zurueck, laege wieder dieselbe Kombination vor — der
+    Scanner haette sie aber nicht mehr gesehen, weil er nur die alte
+    Datums-Schreibweise kannte. Nachgemessen: mit dem Rueckfall auf rohe
+    Wanduhr-Arithmetik in ``test_alert_urgency.py::_save_radar_trip`` blieb die
+    Ratsche gruen, bis dieser Zweig dazukam.
+    """
+    if not isinstance(node, ast.Call):
+        return False
+    if isinstance(node.func, ast.Name) and node.func.id == "stage_date":
+        return True
+    if not isinstance(node.func, ast.Attribute):
+        return False
+    attr = node.func.attr
+    if attr == "stage_date":
+        return True
+    if attr == "date":
+        return _ist_wanduhr_traeger(node.func.value)
+    if attr in {"today", "utcnow"}:
+        v = node.func.value
+        return isinstance(v, ast.Name) and v.id in _HEUTE_TRAEGER
+    return False
+
+
+def _ohne_astimezone(node: ast.AST) -> ast.AST:
+    """``x.astimezone(tz)`` -> ``x`` (beliebig oft geschachtelt)."""
+    while (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+           and node.func.attr == "astimezone"):
+        node = node.func.value
+    return node
+
+
+def _ist_rohe_rechnung(node: ast.AST, zuweisungen=None, gesehen=frozenset()) -> bool:
+    """Ein Ausdruck, der DIE WANDUHR um einen ``timedelta`` verschiebt.
+
+    Beide Haelften zaehlen: es muss ein ``timedelta`` vorkommen UND der andere
+    Operand muss die Wanduhr tragen. Ohne die zweite Bedingung meldete der
+    Scanner auch ``tagesbeginn + timedelta(minutes=m)`` — also ausgerechnet
+    die geklemmte Rechnung im Helfer, der das Anti-Muster beseitigt. Ein
+    Waechter, der seine eigene Loesung anzeigt, ist unbrauchbar.
+    """
+    node = _ohne_astimezone(node)
+    if not isinstance(node, ast.BinOp):
+        return False
+    if not any(_ist_timedelta(n) for n in ast.walk(node)):
+        return False
+    for seite in (node.left, node.right):
+        seite = _ohne_astimezone(seite)
+        if _ist_wanduhr_traeger(seite):
+            return True
+        if (isinstance(seite, ast.Name) and zuweisungen is not None
+                and _ist_roher_name(seite.id, zuweisungen, gesehen)):
+            return True
+        if isinstance(seite, ast.BinOp) and _ist_rohe_rechnung(seite, zuweisungen, gesehen):
+            return True
+    return False
+
+
+def _fliesst_in_eine_datenstruktur(strftime_knoten: ast.AST,
+                                   funktion: ast.AST,
+                                   zuweisungen: dict[str, list[ast.AST]]) -> bool:
+    """Wird die formatierte Uhrzeit WEITERGEGEBEN — oder nur verglichen?
+
+    Eine Ankunftszeit landet immer in einer Datenstruktur oder einem Aufruf:
+    ``{"arrival_calculated": ...}``, ``Waypoint(arrival_calculated=...)``,
+    ``_make_waypoint(id, lat, lon, ...)``. Ein ERWARTUNGSWERT dagegen wird
+    einer Variablen zugewiesen und danach nur noch verglichen — z.B.
+    ``expected_local_hhmm = onset_utc.astimezone(tz).strftime("%H:%M")`` in
+    ``test_bundle_791_847_844_alerts.py``, das den gerenderten Onset in der
+    Mail prueft und mit Wegpunkten nichts zu tun hat.
+
+    Ohne diese Unterscheidung meldete die Namensaufloesung solche
+    Erwartungswerte mit — und haette Aenderungen an voellig gesunden Tests
+    erzwungen.
+
+    Die erste Fassung zaehlte konkrete Knotenarten auf (dict-Werte und
+    Aufruf-Argumente). Damit war die demonstrierte FORM behoben, nicht die
+    KLASSE: eine Liste (``zeiten = [ankunft.strftime("%H:%M"), ...]``) und eine
+    Tupel-Rueckgabe (``return heute, (ankunft.strftime("%H:%M"), ...)``)
+    umgingen sie vollstaendig (Adversary-Finding F007). Statt der Aufzaehlung
+    entscheidet jetzt die ELTERNKETTE: die Uhrzeit fliesst, wenn sie —
+    unmittelbar oder durch beliebig geschachtelte Sammlungen hindurch — in
+    einem Aufruf oder einem ``return`` landet. Eine Sammlung ist dabei selbst
+    schon ein Ziel: eine Liste von Uhrzeiten IST eine Datenstruktur.
+
+    Nicht als Fluss zaehlt die reine BINDUNG (``x = ...``, auch parallel als
+    ``a, b = ...``): dort entscheidet der gebundene Name weiter, nicht der
+    Ausdruck. Ebenso wenig zaehlen Vergleiche und f-Strings — das ist die
+    Signatur des Erwartungswerts.
+    """
+    eltern: dict[int, ast.AST] = {}
+    for k in ast.walk(funktion):
+        for kind in ast.iter_child_nodes(k):
+            eltern[id(kind)] = k
+
+    def _fliesst(knoten: ast.AST) -> bool:
+        aktuell = knoten
+        while True:
+            elter = eltern.get(id(aktuell))
+            if elter is None:
+                return False
+            if isinstance(elter, (ast.Return, ast.Yield, ast.YieldFrom)):
+                return True
+            if isinstance(elter, ast.keyword):
+                return True
+            if isinstance(elter, ast.Call):
+                # Der Empfaenger eines Methodenaufrufs (``x.strftime()``) ist
+                # kein Fluss — sonst floesse jede Uhrzeit in sich selbst.
+                return aktuell is not elter.func
+            if isinstance(elter, ast.Dict):
+                return aktuell in elter.values
+            if isinstance(elter, (ast.List, ast.Set)):
+                return True
+            if isinstance(elter, ast.Tuple):
+                grosselter = eltern.get(id(elter))
+                if (isinstance(grosselter, ast.Assign)
+                        and any(isinstance(z, ast.Tuple) for z in grosselter.targets)):
+                    # Parallele Bindung ``a, b = x, y`` — keine Datenstruktur,
+                    # sondern zwei Zuweisungen. Weiter ueber die Namen.
+                    return False
+                aktuell = elter
+                continue
+            if isinstance(elter, (ast.Starred, ast.comprehension, ast.GeneratorExp,
+                                  ast.ListComp, ast.SetComp, ast.DictComp)):
+                aktuell = elter
+                continue
+            return False
+
+    namen_mit_uhrzeit: set[str] = set()
+    for k in ast.walk(funktion):
+        if not isinstance(k, ast.Assign):
+            continue
+        werte = (k.value.elts if isinstance(k.value, ast.Tuple) else [k.value])
+        if strftime_knoten not in werte:
+            continue
+        for ziel in k.targets:
+            teile = ziel.elts if isinstance(ziel, ast.Tuple) else [ziel]
+            if isinstance(ziel, ast.Tuple) and isinstance(k.value, ast.Tuple):
+                # Elementweise paaren: nur der Name, der WIRKLICH diese
+                # Uhrzeit bekommt, gilt als Traeger.
+                for t, w in zip(teile, k.value.elts):
+                    if w is strftime_knoten and isinstance(t, ast.Name):
+                        namen_mit_uhrzeit.add(t.id)
+            else:
+                for t in teile:
+                    if isinstance(t, ast.Name):
+                        namen_mit_uhrzeit.add(t.id)
+
+    if _fliesst(strftime_knoten):
+        return True
+    for k in ast.walk(funktion):
+        if (isinstance(k, ast.Name) and k.id in namen_mit_uhrzeit
+                and isinstance(k.ctx, ast.Load) and _fliesst(k)):
+            return True
+    return False
+
+
+def _zuweisungen(funktion: ast.AST) -> dict[str, list[ast.AST]]:
+    """Alle Zuweisungen an einfache Namen INNERHALB dieser Funktion.
+
+    Bewusst alle, nicht nur die erste: ob ein Name eine ungeklemmte Uhrzeit
+    traegt, entscheidet sich erst, wenn man SAEMTLICHE Zuweisungen kennt (s.
+    ``_ist_roher_name``)."""
+    gefunden: dict[str, list[ast.AST]] = {}
+    for k in ast.walk(funktion):
+        ziele: list[ast.AST] = []
+        if isinstance(k, ast.Assign):
+            ziele = list(k.targets)
+        elif isinstance(k, (ast.AnnAssign, ast.AugAssign)):
+            ziele = [k.target]
+        if not ziele or getattr(k, "value", None) is None:
+            continue
+        for z in ziele:
+            if isinstance(z, ast.Name):
+                gefunden.setdefault(z.id, []).append(k.value)
+            else:
+                # Tupel-Entpackung o.ae.: die Herkunft ist nicht mehr
+                # eindeutig einem Namen zuzuordnen. Alle darin gebundenen
+                # Namen werden als "nicht roh" behandelt (s. Docstring oben:
+                # im Zweifel NICHT melden, um Falsch-Positive zu vermeiden).
+                for t in ast.walk(z):
+                    if isinstance(t, ast.Name):
+                        gefunden.setdefault(t.id, []).append(ast.Constant(value=None))
+    return gefunden
+
+
+def _ist_roher_name(name: str, zuweisungen: dict[str, list[ast.AST]],
+                    gesehen: frozenset[str] = frozenset()) -> bool:
+    """Traegt ``name`` garantiert eine UNGEKLEMMTE Wanduhr-Uhrzeit?
+
+    Der RED-Agent hatte die Namensaufloesung verworfen, weil sie das erprobte
+    Gegenmuster mitfinge: dort steht am ``strftime`` ebenfalls nur ein Name.
+    Der Zielkonflikt loest sich ueber die Frage „ist der Name AUSSCHLIESSLICH
+    aus roher Wanduhr-Arithmetik gebunden?":
+
+    * Gegenmuster (``test_952_onset_alert_fidelity.py::_active_window``):
+      ``start`` wird zuerst aus ``now_local + timedelta(...)`` gebunden, danach
+      in den Klemm-Zweigen erneut aus ``tag_start``/``tag_ende``. Eine dieser
+      Zuweisungen ist KEINE rohe Rechnung => der Name gilt als geklemmt =>
+      kein Fund. Genau die Klemmung, die den Namen sicher macht, ist also das
+      Merkmal, an dem der Scanner ihn freispricht.
+    * Bypass (``arrival = now + timedelta(hours=1)`` ... ``arrival.strftime``):
+      einzige Zuweisung, rohe Rechnung, nie neu gebunden => Fund.
+
+    Ketten ueber Zwischenschritte werden mitverfolgt
+    (``arrival_local = arrival.astimezone(tz)``), mit Zyklusschutz.
+    """
+    if name in gesehen or name not in zuweisungen:
+        return False
+    gesehen = gesehen | {name}
+    werte = zuweisungen[name]
+    if not werte:
+        return False
+    for wert in werte:
+        if _ist_rohe_rechnung(wert, zuweisungen, gesehen):
+            continue
+        kern = _ohne_astimezone(wert)
+        if isinstance(kern, ast.Name) and _ist_roher_name(kern.id, zuweisungen, gesehen):
+            continue
+        return False
+    return True
+
+
+def _ist_ungeklemmte_uhrzeit(node: ast.AST,
+                             zuweisungen: dict[str, list[ast.AST]] | None = None) -> bool:
+    """``<rohe Wanduhr>.strftime("%H:%M")`` — direkt als Rechenausdruck ODER
+    ueber eine Zwischenvariable, die nur aus roher Wanduhr-Arithmetik gebunden
+    ist. Ein geklemmter Name (irgendwo anders zugewiesen) ist kein Fund."""
+    if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+        return False
+    if node.func.attr != "strftime":
+        return False
+    if not (node.args and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value == _HHMM):
+        return False
+    ziel = _ohne_astimezone(node.func.value)
+    if isinstance(ziel, ast.BinOp):
+        return _ist_rohe_rechnung(ziel, zuweisungen)
+    if isinstance(ziel, ast.Name) and zuweisungen is not None:
+        return _ist_roher_name(ziel.id, zuweisungen)
+    return False
+
+
+def scan_wallclock_arrival_fixtures(tests_root: Path) -> list[Finding]:
+    """Alle Funktionen unter ``tests_root``, die ein Wanduhr-Etappendatum mit
+    einer ungeklemmten Ankunftszeit kombinieren."""
+    funde: list[Finding] = []
+    for datei in sorted(tests_root.rglob("*.py")):
+        try:
+            baum = ast.parse(datei.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for knoten in ast.walk(baum):
+            if not isinstance(knoten, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            zuw = _zuweisungen(knoten)
+            uhrzeiten = [n for n in ast.walk(knoten)
+                         if _ist_ungeklemmte_uhrzeit(n, zuw)
+                         and _fliesst_in_eine_datenstruktur(n, knoten, zuw)]
+            if not uhrzeiten:
+                continue
+            if not any(_ist_wanduhr_datum(n) for n in ast.walk(knoten)):
+                continue
+            for treffer in uhrzeiten:
+                funde.append(Finding(path=datei, function=knoten.name,
+                                     line=treffer.lineno))
+    return funde
+
+
+def _relativ(f: Finding) -> str:
+    try:
+        return str(f.path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(f.path)
+
+
+def _fall(name: str) -> str:
+    """Fixture-Quelltext ``name`` aus der externen Vorlagendatei holen."""
+    abschnitte = re.split(r"^# === (\S+) ===$\n",
+                          _FAELLE_DATEI.read_text("utf-8"), flags=re.M)
+    vorrat = dict(zip(abschnitte[1::2], abschnitte[2::2]))
+    assert name in vorrat, f"Fall {name!r} fehlt in {_FAELLE_DATEI}: {sorted(vorrat)}"
+    return vorrat[name]
+
+
+def _attrappe(tmp_path: Path, quelltext: str) -> Path:
+    """Echte Testdatei-Attrappe auf die Platte schreiben (kein Mock)."""
+    f = tmp_path / "test_attrappe.py"
+    f.write_text(quelltext, encoding="utf-8")
+    return f
+
+
+# ══════════════ Die Ratsche selbst (heute ROT, gruen nach S1) ══════════════
+
+def test_keine_fixture_baut_ankunft_aus_der_rohen_wanduhr():
+    """#1667 S1: keine Trip-Fixture kombiniert ein Wanduhr-Etappendatum mit
+    einer ungeklemmten ``(now +/- timedelta).strftime("%H:%M")``-Ankunft."""
+    funde = scan_wallclock_arrival_fixtures(TESTS_ROOT)
+    offen = [f for f in funde if (_relativ(f), f.function) not in KNOWN_VIOLATIONS]
+    zeilen = "\n".join(f"  - {_relativ(f)}:{f.line} in {f.function}()" for f in offen)
+    dateien = sorted({_relativ(f) for f in offen})
+    assert not offen, (
+        f"{len(offen)} Fundstellen in {len(dateien)} Dateien bauen die "
+        f"Ankunftszeit aus der rohen Wanduhr und werden dadurch zwischen "
+        f"~22:00 und 00:00 UTC reproduzierbar rot:\n"
+        f"{zeilen}\n\n"
+        f"Abhilfe: das erprobte, auf 02:00-22:00 Ortszeit geklemmte Fenster "
+        f"aus tests/tdd/test_952_onset_alert_fidelity.py::_active_window "
+        f"verwenden (S1 zieht es nach tests/helpers/). KNOWN_VIOLATIONS zu "
+        f"fuellen ist KEINE Abhilfe."
+    )
+
+
+def test_known_violations_enthaelt_keine_veralteten_eintraege():
+    """Die Ausnahmeliste darf nur schrumpfen: was der Scanner nicht mehr
+    findet, muss raus — sonst schleppt sie tote Ausnahmen mit."""
+    aktuell = {(_relativ(f), f.function)
+               for f in scan_wallclock_arrival_fixtures(TESTS_ROOT)}
+    veraltet = sorted(KNOWN_VIOLATIONS - aktuell)
+    assert not veraltet, (
+        "Diese KNOWN_VIOLATIONS-Eintraege werden nicht mehr gefunden und "
+        f"muessen entfernt werden: {veraltet}"
+    )
+
+
+# ══════════ Kann dieser Waechter ueberhaupt scheitern? (Selbstbeleg) ══════════
+
+def test_scanner_meldet_das_antimuster(tmp_path):
+    """Echte Lage: Wanduhr-Datum + ungeklemmte Ankunft => Fund."""
+    _attrappe(tmp_path, _fall("roh-unclamped"))
+    funde = scan_wallclock_arrival_fixtures(tmp_path)
+    assert len(funde) == 2, f"erwartet 2 Funde, bekommen: {[f.ref for f in funde]}"
+    assert all(f.function == "_save_radar_trip" for f in funde)
+
+
+def test_scanner_schweigt_bei_geklemmtem_muster(tmp_path):
+    """Kuenstlich saubere Eingabe: dasselbe Fixture-Ziel, aber auf
+    02:00-22:00 Ortszeit geklemmt (das Muster, das S1 einfuehrt) => 0 Funde.
+
+    Ohne diesen Beleg waere unklar, ob der Waechter ueberhaupt zwischen
+    krank und gesund unterscheidet — und ob S1 ihn gruen bekommen KANN."""
+    _attrappe(tmp_path, _fall("sauber-geklemmt"))
+    funde = scan_wallclock_arrival_fixtures(tmp_path)
+    assert funde == [], f"Falsch-Positiv am geklemmten Muster: {[f.ref for f in funde]}"
+
+
+def test_scanner_schweigt_ohne_etappendatum(tmp_path):
+    """Ruhezeitfenster aus der Wanduhr ohne Etappendatum ist kein Fund —
+    dort gibt es kein Segment, das in die Vergangenheit rutschen koennte."""
+    _attrappe(tmp_path, _fall("nur-uhrzeit-ohne-datum"))
+    assert scan_wallclock_arrival_fixtures(tmp_path) == []
+
+
+def test_scanner_erkennt_astimezone_zwischenschritt(tmp_path):
+    """``(now +/- timedelta).astimezone(tz).strftime("%H:%M")`` — die Form aus
+    tests/tdd/test_bundle_791_847_844_alerts.py:196 — wird ebenfalls gefunden."""
+    _attrappe(tmp_path, _fall("astimezone-dazwischen"))
+    funde = scan_wallclock_arrival_fixtures(tmp_path)
+    assert len(funde) == 2, f"erwartet 2 Funde, bekommen: {[f.ref for f in funde]}"
+
+
+def test_scanner_erkennt_den_bypass_ueber_eine_zwischenvariable(tmp_path):
+    """Adversary-Finding F004: EINE Zwischenvariable vor dem ``strftime``
+    genuegte, um den Waechter zu umgehen — bei identischem Anti-Muster meldete
+    er 0 Funde. Das war keine schmale Ausnahme, sondern eine generische
+    Umgehung; damit war der bleibende Schutz weitgehend wertlos."""
+    _attrappe(tmp_path, _fall("bypass-zwischenvariable"))
+    funde = scan_wallclock_arrival_fixtures(tmp_path)
+    assert len(funde) == 2, f"erwartet 2 Funde, bekommen: {[f.ref for f in funde]}"
+    assert all(f.function == "_save_radar_trip" for f in funde)
+
+
+def test_scanner_erkennt_die_kette_ueber_astimezone_und_namen(tmp_path):
+    """Zweistufige Kette (rohe Rechnung -> Name -> ``.astimezone`` -> Name).
+    Die Spec hatte dieses Muster als strukturell unerfassbar beschrieben."""
+    _attrappe(tmp_path, _fall("bypass-zwischenvariable-mit-astimezone"))
+    funde = scan_wallclock_arrival_fixtures(tmp_path)
+    assert len(funde) == 1, f"erwartet 1 Fund, bekommen: {[f.ref for f in funde]}"
+
+
+def test_scanner_erkennt_uhrzeiten_in_einer_liste(tmp_path):
+    """Adversary-Finding F007: die Uhrzeiten landen in einer LISTE statt direkt
+    in einem dict-Wert. Die erste Fassung der Fluss-Erkennung zaehlte nur dict
+    und Call auf — damit war die demonstrierte FORM behoben, nicht die KLASSE."""
+    _attrappe(tmp_path, _fall("bypass-liste"))
+    funde = scan_wallclock_arrival_fixtures(tmp_path)
+    assert len(funde) == 2, f"erwartet 2 Funde, bekommen: {[f.ref for f in funde]}"
+    assert all(f.function == "_save_radar_trip" for f in funde)
+
+
+def test_scanner_erkennt_uhrzeiten_in_einer_tupel_rueckgabe(tmp_path):
+    """Zweite Form aus F007: ``return heute, (…strftime(…), …)``. Weder dict
+    noch Aufruf-Argument — der Fluss laeuft ueber geschachtelte Tupel in ein
+    ``return``."""
+    _attrappe(tmp_path, _fall("bypass-tupel-rueckgabe"))
+    funde = scan_wallclock_arrival_fixtures(tmp_path)
+    assert len(funde) == 2, f"erwartet 2 Funde, bekommen: {[f.ref for f in funde]}"
+    assert all(f.function == "_fenster" for f in funde)
+
+
+def test_scanner_schweigt_bei_einem_nur_verglichenen_erwartungswert(tmp_path):
+    """Die Kehrseite der Fluss-Erkennung: eine wanduhr-abgeleitete Uhrzeit, die
+    nur verglichen wird, ist kein Wegpunkt und kein Fund.
+
+    Ohne diese Unterscheidung meldete die Namensaufloesung den Onset-Vergleich
+    in ``test_bundle_791_847_844_alerts.py`` mit und erzwaenge Aenderungen an
+    einem voellig gesunden Test."""
+    _attrappe(tmp_path, _fall("erwartungswert-nur-verglichen"))
+    funde = scan_wallclock_arrival_fixtures(tmp_path)
+    assert funde == [], f"Falsch-Positiv am Erwartungswert: {[f.ref for f in funde]}"
+
+
+def test_scanner_schweigt_bei_geklemmtem_namen(tmp_path):
+    """Die Kehrseite der Namensaufloesung: ein Name, der in einem Klemm-Zweig
+    NEU gebunden wird, ist kein Fund.
+
+    Ohne diesen Beleg waere die Ratsche moeglicherweise unpassierbar — genau
+    der Zielkonflikt, an dem der RED-Agent die Namensaufloesung verworfen
+    hatte. Er loest sich, weil die Klemmung selbst das Merkmal ist."""
+    _attrappe(tmp_path, _fall("sauber-geklemmt-ueber-namen"))
+    funde = scan_wallclock_arrival_fixtures(tmp_path)
+    assert funde == [], f"Falsch-Positiv am geklemmten Namen: {[f.ref for f in funde]}"
+
+
+def test_scanner_erkennt_date_today_als_etappendatum(tmp_path):
+    """Nicht nur ``now.date()``, auch ``date.today()`` ist ein Wanduhr-Datum."""
+    _attrappe(tmp_path, _fall("datum-aus-date-today"))
+    assert len(scan_wallclock_arrival_fixtures(tmp_path)) == 1
+
+
+# ═══════════════════════════ Regel-Budget ═══════════════════════════
+
+def test_regel_budget_pruefdatum_steht_als_text_in_der_datei():
+    assert EXPIRY == date(2026, 11, 8), (
+        "Pruefdatum des Regel-Budgets (+90 Tage), Vorbild EXPIRY in "
+        ".claude/hooks/test_naming_gate.py"
+    )
+    text = Path(__file__).read_text(encoding="utf-8").splitlines()
+    assert [n for n, z in enumerate(text, 1) if EXPIRY.isoformat() in z], (
+        "Das ISO-Pruefdatum muss als Text in dieser Datei stehen, damit das "
+        "Gate-Audit es per grep findet."
+    )

--- a/tests/tdd/test_issue_1070_daily_alert_limit.py
+++ b/tests/tdd/test_issue_1070_daily_alert_limit.py
@@ -60,6 +60,8 @@ from app.models import (
 from app.loader import get_data_dir
 from app.trip import Stage, Trip, Waypoint
 
+from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
+
 # Koordinaten im GR20-Gebiet (Korsika) — identisch zu test_issue_827
 LAT, LON = 42.20, 9.10
 
@@ -225,14 +227,14 @@ def _wet_frames(lat: float, lon: float) -> list:
 
 
 def _make_trip(trip_id: str, send_email: bool, send_telegram: bool) -> Trip:
-    today = date_type.today()
-    now_utc = datetime.now(timezone.utc)
-    arrival_now = (now_utc + timedelta(hours=2)).strftime("%H:%M")
+    # #1667 S1: wanduhr-robustes Ankunftsfenster statt roher now+Nh-Arithmetik
+    # (ab 22:00 UTC lief die +2h/+4h-Folge steigend ueber Mitternacht).
+    arr0, arr1 = active_window_offsets(LAT, LON, 120, 240)
     wp0 = Waypoint(id="WP0", name="Start", lat=LAT, lon=LON, elevation_m=500.0,
-                   arrival_calculated=arrival_now)
+                   arrival_calculated=arr0)
     wp1 = Waypoint(id="WP1", name="End", lat=LAT + 0.1, lon=LON + 0.1, elevation_m=600.0,
-                   arrival_calculated=(now_utc + timedelta(hours=4)).strftime("%H:%M"))
-    stage = Stage(id="S1", name="Tag 1", date=today, waypoints=[wp0, wp1])
+                   arrival_calculated=arr1)
+    stage = Stage(id="S1", name="Tag 1", date=stage_date(), waypoints=[wp0, wp1])
     trip = Trip(id=trip_id, name="1070 Test", stages=[stage])
     trip.report_config = TripReportConfig(
         trip_id=trip_id,

--- a/tests/tdd/test_issue_818_radar_briefing_integration.py
+++ b/tests/tdd/test_issue_818_radar_briefing_integration.py
@@ -34,6 +34,8 @@ import pytest
 from app.models import TripReportConfig
 from app.trip import Stage, Trip, Waypoint
 
+from tests.helpers.arrival_window_fixtures import past_window_offsets, stage_date
+
 def _data_root_users() -> Path:
     """Nutzer-Wurzel der Compare-Preset-Ablage — Funktion statt Konstante
     (#1595): ``get_data_root()`` liefert erst zur Laufzeit die von der
@@ -121,6 +123,15 @@ def _save_trip_direct(trip: Trip, user_id: str) -> None:
             "trip_id": trip.id, "send_email": True, "send_telegram": False,
         },
     }
+    # #1667 S1: Das Tagesfenster muss mit auf die Platte. Es wurde bisher
+    # stillschweigend verworfen — ein Trip, dessen Fixture ein eigenes Fenster
+    # setzt, las nach dem Neuladen wieder den Default 4-19 Uhr. Seit #1584
+    # entscheidet genau dieses Fenster, wann das Ziel-Segment endet.
+    _rc = getattr(trip, "report_config", None)
+    for _feld in ("day_window_start_hour", "day_window_end_hour"):
+        _wert = getattr(_rc, _feld, None) if _rc else None
+        if _wert is not None:
+            data["report_config"][_feld] = _wert
     (trips_dir / f"{trip.id}.json").write_text(json.dumps(data, indent=2))
 
 
@@ -142,22 +153,30 @@ def _write_snapshot(user_id: str, trip_id: str, segment_id, hourly_precip: dict)
     snapshots_dir.mkdir(parents=True, exist_ok=True)
     now_utc = datetime.now(timezone.utc)
 
+    # #1667 S1: Die Stundenraster laufen ueber ZWEI Tage, nicht ueber einen.
+    # Die Aufrufer schluesseln nach der UTC-Stunde des Onsets (``now + 5 min``);
+    # in den letzten fuenf Minuten des UTC-Tages ist das Stunde 0 des FOLGE-
+    # tages, waehrend hier nur der heutige Tag geschrieben wurde. Der Snapshot
+    # traf den Onset-Zeitpunkt dann nicht mehr und die Tests
+    # ``test_ac1_...``/``test_ac4_...`` wurden zwischen 23:55 und 24:00 UTC
+    # reproduzierbar rot (nachgemessen unter freeze_time: gruen bis 23:54:59,
+    # rot ab 23:55:00). Der Kommentar am Aufruf ("onset_h statt now_h vermeidet
+    # Race Condition bei XX:55-XX:59") beschrieb die Absicht, die Ablage hier
+    # zog aber nicht mit.
+    tagesbeginn = now_utc.replace(hour=0, minute=0, second=0, microsecond=0,
+                                  tzinfo=None)
     hourly = []
-    for h in range(24):
+    for stunde in range(48):
         # Naive UTC-Zeitstempel (kein tzinfo) — so serialisiert WeatherSnapshotService
-        ts_naive = now_utc.replace(hour=h, minute=0, second=0, microsecond=0, tzinfo=None)
+        ts_naive = tagesbeginn + timedelta(hours=stunde)
         hourly.append({
             "ts": ts_naive.strftime("%Y-%m-%dT%H:%M:%S"),
-            "precip_1h_mm": float(hourly_precip.get(h, 0.0)),
+            "precip_1h_mm": float(hourly_precip.get(ts_naive.hour, 0.0)),
         })
 
-    snapshot = {
-        "trip_id": trip_id,
-        "target_date": today.isoformat(),
-        "snapshot_at": now_utc.isoformat(),
-        "provider": "openmeteo",
-        "segments": [{
-            "segment_id": segment_id,
+    def _segment_eintrag(sid) -> dict:
+        return {
+            "segment_id": sid,
             "start_time": (now_utc - timedelta(hours=1)).isoformat(),
             "end_time": (now_utc + timedelta(hours=2)).isoformat(),
             "start_lat": LAT,
@@ -174,7 +193,21 @@ def _write_snapshot(user_id: str, trip_id: str, segment_id, hourly_precip: dict)
             "duration_hours": 3.0,
             "aggregated": {"t2m_c_max": 20.0, "t2m_c_min": 15.0},
             "hourly": hourly,
-        }],
+        }
+
+    # #1667 S1: Der Snapshot deckt zusaetzlich das ZIEL-Segment ab. Die
+    # Etappe von `_make_active_trip` laeuft bis 23:59 Ortszeit; danach ist
+    # nicht mehr Segment 1 aktiv, sondern das Ziel-Segment (segment_id
+    # "Ziel", vergeben in src/services/trip_segments.py). Der Snapshot kannte
+    # nur segment_id=1, die Regen-Ankuendigung wurde dort nicht gefunden und
+    # der Alarm feuerte trotzdem — nachgemessen: gruen um 23:59:00, rot ab
+    # 23:59:30. Eigene Ursache, unabhaengig vom Stundenraster oben.
+    snapshot = {
+        "trip_id": trip_id,
+        "target_date": today.isoformat(),
+        "snapshot_at": now_utc.isoformat(),
+        "provider": "openmeteo",
+        "segments": [_segment_eintrag(segment_id), _segment_eintrag("Ziel")],
     }
     filepath = snapshots_dir / f"{trip_id}_{today.isoformat()}.json"
     filepath.write_text(json.dumps(snapshot, indent=2))
@@ -386,40 +419,62 @@ def test_ac4_double_alert_guard_suppresses_radar_when_forecast_recent():
 def test_ac5_past_segment_no_alert_guard_test():
     """AC-5: REGRESSION-GUARD aus #822 — alle Segmente vorbei → kein Alert.
 
-    Nachweis-Test für bereits implementierten Filter in check_radar_alerts Z. 616-631.
-    Kann vor Implementierung bereits grün sein.
+    Nachweis-Test für bereits implementierten Filter in check_radar_alerts.
 
-    Setup: wp1 = now-2h → Destination-Segment end = now-2h+2h = now (Vergangenheit
-    bei Ausführung nach einem Bruchteil der Setup-Zeit, analog zu 822 AC-2(c)).
-    Mindestens 4 Stunden nach Mitternacht erforderlich (kein Mitternachts-Wrap).
+    #1667 S1 — zwei Dinge am Setup mussten sich ändern, damit der Test zu
+    JEDER Wanduhrzeit trägt (vorher stand hier ein
+    ``pytest.skip`` für die ersten vier Stunden des UTC-Tages):
+
+    1. **Die Ankunftszeiten kommen aus** ``past_window_offsets`` statt aus
+       roher ``now - N h``-Arithmetik. Sonst rutschte die Uhrzeit-Folge über
+       Mitternacht und das Etappendatum passte nicht mehr zur Segmentauswahl.
+    2. **Der Trip bekommt ein eigenes Tagesfenster** (0–1 Uhr Ortszeit) und
+       Wegpunkte weit östlich von Greenwich. Grund: seit Issue #1584 endet das
+       Ziel-Segment nicht mehr bei „Ankunft + 2 h", sondern am Ende des
+       konfigurierten Tagesfensters (Default 19:00 Ortszeit). Mit dem Default
+       wäre das Ziel-Segment bis 19:00 Ortszeit offen — der Trip wäre bis dahin
+       eben NICHT „vorbei", und der Test prüfte gar nicht mehr, was seine
+       Überschrift behauptet. Die im Docstring bis 2026-08-10 behauptete
+       Rechnung „Destination-End = now-2h+2h = now" beschreibt den Stand vor
+       #1584. Mit einem Fensterende vor der Ankunft greift der Randfall-Guard
+       in ``trip_segments.py`` und das Ziel-Segment endet eine Stunde nach
+       Ankunft — erst damit ist „alle Segmente vorbei" überhaupt herstellbar.
+
+    Die östliche Zeitzone ist nötig, weil der Etappentag am Ort schon weit
+    fortgeschritten sein muss, damit überhaupt Platz für ein vergangenes
+    Fenster ist; die Prüfaussage (``count == 0``) hängt nicht am Ort.
     """
     from services.trip_alert import TripAlertService
     from services.radar_service import RadarNowcastService
 
-    now = datetime.now(timezone.utc)
-    if now.hour < 4:
-        pytest.skip("AC-5 benötigt >=4h nach Mitternacht (UTC) um Zeitumbruch zu vermeiden")
+    # Neuseeland (UTC+12): der lokale Etappentag liegt zu jeder UTC-Uhrzeit
+    # mindestens zwölf Stunden zurück, es ist also immer Platz fuer ein
+    # vergangenes Fenster.
+    past_lat, past_lon = -41.29, 174.78
 
     uid = f"tdd-818-ac5-{uuid.uuid4().hex[:6]}"
     _clean_user(uid)
     _ensure_real_user_dir(uid)
     try:
-        # wp1 = now-2h → alle Segmente zeitlich vorbei (Destination-End ≈ now)
-        # Analog zu test_issue_822 AC-2(c) — dort getestet und grün.
+        arr0, arr1 = past_window_offsets(past_lat, past_lon, -240, -120)
         wp0 = Waypoint(
-            id="WP0", name="Start", lat=LAT, lon=LON, elevation_m=100.0,
-            arrival_calculated=(now - timedelta(hours=4)).strftime("%H:%M"),
+            id="WP0", name="Start", lat=past_lat, lon=past_lon, elevation_m=100.0,
+            arrival_calculated=arr0,
         )
         wp1 = Waypoint(
-            id="WP1", name="Ziel", lat=LAT + 0.05, lon=LON + 0.05, elevation_m=200.0,
-            arrival_calculated=(now - timedelta(hours=2)).strftime("%H:%M"),
+            id="WP1", name="Ziel", lat=past_lat + 0.05, lon=past_lon + 0.05,
+            elevation_m=200.0,
+            arrival_calculated=arr1,
         )
-        stage = Stage(id="S1", name="Tag 1", date=now.date(), waypoints=[wp0, wp1])
+        stage = Stage(id="S1", name="Tag 1", date=stage_date(), waypoints=[wp0, wp1])
         trip_id = f"tdd-818-ac5-{uuid.uuid4().hex[:6]}"
         trip = Trip(id=trip_id, name="AC5 Past Trip", stages=[stage])
         trip.report_config = TripReportConfig(
             trip_id=trip_id, send_email=True, send_telegram=False,
             alert_on_changes=False,
+            # s. Punkt 2 im Docstring: Fensterende VOR der Ankunft, damit das
+            # Ziel-Segment eine Stunde nach Ankunft schliesst.
+            day_window_start_hour=0, day_window_end_hour=1,
         )
         _save_trip_direct(trip, uid)
 

--- a/tests/tdd/test_issue_822_radar_nowcast_segment.py
+++ b/tests/tdd/test_issue_822_radar_nowcast_segment.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import shutil
 import uuid
-from datetime import date as date_type
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from zoneinfo import ZoneInfo
@@ -35,14 +34,30 @@ import pytest
 from app.models import TripReportConfig
 from app.trip import Stage, Trip, Waypoint
 
+from tests.helpers.arrival_window_fixtures import (
+    active_window_offsets,
+    past_window_offsets,
+    stage_date,
+)
+
 DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
 
 # Zwei klar voneinander abweichende Koordinatenpaare.
 # WP0: waypoints[0] (alter Ist-Code-Pfad in check_radar_alerts).
 # SEG: start_point des aktiven Segments (Ziel-Zustand nach #822).
-WP0_LAT, WP0_LON = 44.10, 9.10    # Ligurien — waypoints[0] (alter Pfad)
-SEG_LAT, SEG_LON = 44.20, 9.25    # Start-Punkt aktives Segment (neuer Pfad)
-SEG_END_LAT, SEG_END_LON = 44.30, 9.40
+#
+# #1667 S1: Die Koordinaten lagen bis 2026-08-10 in Ligurien (UTC+1/+2). Sie
+# sind nach Neuseeland (UTC+12) gewandert, weil test_ac3 ein Segment braucht,
+# das JETZT SCHON VORBEI ist (wp0 = jetzt-2h). Alle Wegpunktzeiten liegen als
+# Ortszeit auf dem Etappentag; westlich von der Datumsgrenze ist "zwei Stunden
+# vor jetzt" kurz nach Ortszeit-Mitternacht schlicht nicht darstellbar, das
+# geklemmte Fenster rutschte nach vorn und Segment 1 war noch aktiv. In
+# UTC+12 liegt der Etappentag zu JEDER UTC-Uhrzeit mindestens zwoelf Stunden
+# zurueck. Die Pruefaussage haengt nicht am Ort, nur an der Verschiedenheit
+# der drei Punkte.
+WP0_LAT, WP0_LON = -41.29, 174.78   # Wellington — waypoints[0] (alter Pfad)
+SEG_LAT, SEG_LON = -41.19, 174.93   # Start-Punkt aktives Segment (neuer Pfad)
+SEG_END_LAT, SEG_END_LON = -41.09, 175.08
 
 
 # --------------------------------------------------------------------------
@@ -167,21 +182,24 @@ def test_ac1_segment_helper_roundtrip_bit_identical():
     from app.config import Settings
 
     # Trip mit 3 Waypoints und arrival_calculated (Innsbruck-Region)
-    now_utc = datetime.now(timezone.utc)
+    # #1667 S1: die drei Ankunftszeiten kommen aus dem wanduhr-robusten Helfer
+    # (er nimmt beliebig viele Versaetze), statt roh ueber Mitternacht zu
+    # rechnen. Die Bit-Identitaets-Aussage dieses Tests haengt nicht an
+    # konkreten Uhrzeiten, sehr wohl aber an monoton steigenden Zeiten:
+    # kollabierte Segmente wuerden auf beiden Seiten uebersprungen und der
+    # Vergleich waere leer gegen leer.
     lat, lon = 47.05, 11.40
-    wp0 = _make_waypoint("WP0", lat, lon,
-                         (now_utc - timedelta(hours=4)).strftime("%H:%M"))
-    wp1 = _make_waypoint("WP1", lat + 0.1, lon + 0.1,
-                         (now_utc - timedelta(hours=2)).strftime("%H:%M"))
-    wp2 = _make_waypoint("WP2", lat + 0.2, lon + 0.2,
-                         (now_utc + timedelta(hours=2)).strftime("%H:%M"))
+    arr0, arr1, arr2 = active_window_offsets(lat, lon, -240, -120, 120)
+    wp0 = _make_waypoint("WP0", lat, lon, arr0)
+    wp1 = _make_waypoint("WP1", lat + 0.1, lon + 0.1, arr1)
+    wp2 = _make_waypoint("WP2", lat + 0.2, lon + 0.2, arr2)
     stage = Stage(
         id="S1", name="Tag 1",
-        date=now_utc.date(),
+        date=stage_date(),
         waypoints=[wp0, wp1, wp2],
     )
     trip = Trip(id="tdd-822-ac1-trip", name="AC1 Trip", stages=[stage])
-    target_date = now_utc.date()
+    target_date = stage_date()
 
     svc = TripReportSchedulerService(settings=Settings())
     expected = svc._convert_trip_to_segments(trip, target_date)
@@ -230,22 +248,16 @@ def test_ac2_segment_selection_by_time():
     from services.trip_alert import TripAlertService
     from services.radar_service import RadarNowcastService
 
-    today = date_type.today()
-    now = datetime.now(timezone.utc)
+    today = stage_date()
     lat_base, lon_base = 51.50, 0.00  # lon=0 → Europe/London, BST=UTC+1 in summer
 
-    # Ermittle echten UTC-Offset für lat_base/lon_base via tz_for_coords.
-    from utils.timezone import tz_for_coords as _tz_fc
-    tz_loc = _tz_fc(lat_base, lon_base)
-    now_local_tz = now.astimezone(tz_loc)
-    tz_off = now_local_tz.utcoffset()  # e.g. timedelta(hours=1) für BST
-
     # --- Fall (a): aktives Segment ---
-    # Lokale Zeiten so berechnen, dass nach UTC-Konvertierung gilt:
-    # Seg 1: [now-2h, now-1h] UTC → vorbei; Seg 2: [now-1h, now+1h] UTC → aktiv
-    local_minus2h = (now - timedelta(hours=2) + tz_off).strftime("%H:%M")
-    local_minus1h = (now - timedelta(hours=1) + tz_off).strftime("%H:%M")
-    local_plus1h = (now + timedelta(hours=1) + tz_off).strftime("%H:%M")
+    # Seg 1: [now-2h, now-1h] → vorbei; Seg 2: [now-1h, now+1h] → aktiv.
+    # #1667 S1: der Helfer rechnet die Ortszeit selbst (der frühere manuelle
+    # utcoffset-Aufschlag entfällt) und klemmt das Fenster auf den Etappentag.
+    local_minus2h, local_minus1h, local_plus1h = active_window_offsets(
+        lat_base, lon_base, -120, -60, 60
+    )
 
     wp0 = _make_waypoint("WP0", lat_base, lon_base, local_minus2h)
     wp1 = _make_waypoint("WP1", lat_base + 0.10, lon_base + 0.10, local_minus1h)
@@ -299,8 +311,22 @@ def test_ac2_segment_selection_by_time():
         )
 
         # --- Fall (c): alle Segmente bereits vorbei → kein Alert ---
-        local_minus4h = (now - timedelta(hours=4) + tz_off).strftime("%H:%M")
-        local_minus2h_c = (now - timedelta(hours=2) + tz_off).strftime("%H:%M")
+        # #1667 S1: Wegpunkte aus dem Vergangenheits-Helfer statt aus roher
+        # now-Nh-Arithmetik.
+        # ⚠️ Diese Fixture legt NUR die Wegpunkte in die Vergangenheit. Seit
+        # Issue #1584 endet das Ziel-Segment am Tagesfenster-Ende (19:00
+        # Ortszeit), nicht mehr bei "Ankunft + 2 h" — der Trip ist damit
+        # tagsüber gar nicht "vorbei". Dass die Zusicherung trotzdem hält,
+        # liegt an send_email=False/send_telegram=False unten: ohne offenen
+        # Kanal zählt check_radar_alerts() nach #827 ohnehin nichts. Der Fall
+        # prüft hier also nicht, was seine Überschrift behauptet; das ist ein
+        # Altbefund, den S1 nicht repariert (S1 ändert keinen Produktivcode
+        # und keine Zusicherung). Das saubere Gegenstück steht in
+        # test_issue_818_radar_briefing_integration.py::
+        # test_ac5_past_segment_no_alert_guard_test.
+        local_minus4h, local_minus2h_c = past_window_offsets(
+            lat_base, lon_base, -240, -120
+        )
         wp_p0 = _make_waypoint("P0", lat_base, lon_base, local_minus4h)
         wp_p1 = _make_waypoint("P1", lat_base + 0.05, lon_base + 0.05, local_minus2h_c)
         stage_past = Stage(id="S1", name="Tag 1", date=today,
@@ -357,9 +383,9 @@ def test_ac3_nowcast_called_at_segment_coordinates():
     Nachweis: recorded_coords[0] muss (SEG_LAT, SEG_LON) sein, NICHT (WP0_LAT, WP0_LON).
     Genau 1 get_nowcast-Call pro Trip-Lauf.
 
-    Hinweis: _save_trip_direct umgeht Naismith Compute-on-Save (Issue #802),
-    WP0_LAT/WP0_LON liegen in Ligurien (lon≈9) → tz_for_coords gibt Europe/Rome (CEST=UTC+2).
-    Lokale Zeiten = UTC+2, daher +2h auf UTC-Zeiten addieren.
+    Hinweis: _save_trip_direct umgeht Naismith Compute-on-Save (Issue #802).
+    Die Ortszeit-Umrechnung macht seit #1667 S1 der Helfer; die Koordinaten
+    liegen seither in Neuseeland (Begründung an der Konstanten-Definition).
     """
     from services.trip_alert import TripAlertService
     from services.radar_service import RadarNowcastService
@@ -368,21 +394,16 @@ def test_ac3_nowcast_called_at_segment_coordinates():
     _clean_user(uid)
     _ensure_real_user_dir(uid)
     try:
-        now = datetime.now(timezone.utc)
-        today = now.date()
+        today = stage_date()
 
-        # Ermittle echten UTC-Offset für WP0 via tz_for_coords (kann Etc/GMT-N sein).
-        from utils.timezone import tz_for_coords as _tz_fc
-        tz_wp0 = _tz_fc(WP0_LAT, WP0_LON)
-        now_local = now.astimezone(tz_wp0)
-        tz_offset = now_local.utcoffset()  # e.g. timedelta(hours=1) für Etc/GMT-1
-
-        # Lokale Ankunftszeiten so berechnen, dass nach UTC-Rückkonvertierung gilt:
-        # Seg 1: [now-2h, now-30m] UTC → nur sicher wenn now.hour >= 2
-        # Seg 2: [now-30m, now+90m] UTC → aktiv
-        local_minus2h = (now - timedelta(hours=2) + tz_offset).strftime("%H:%M")
-        local_minus30m = (now - timedelta(minutes=30) + tz_offset).strftime("%H:%M")
-        local_plus90m = (now + timedelta(hours=1, minutes=30) + tz_offset).strftime("%H:%M")
+        # Seg 1: [now-2h, now-30m] → vorbei; Seg 2: [now-30m, now+90m] → aktiv.
+        # #1667 S1: der Helfer rechnet die Ortszeit selbst (der frühere manuelle
+        # utcoffset-Aufschlag entfällt) und klemmt das Fenster auf den
+        # Etappentag — damit entfällt auch die alte Einschränkung "nur sicher
+        # wenn now.hour >= 2".
+        local_minus2h, local_minus30m, local_plus90m = active_window_offsets(
+            WP0_LAT, WP0_LON, -120, -30, 90
+        )
 
         wp0 = _make_waypoint("WP0", WP0_LAT, WP0_LON, local_minus2h)
         wp1 = _make_waypoint("WP1", SEG_LAT, SEG_LON, local_minus30m)
@@ -460,8 +481,8 @@ def test_ac4_mail_body_contains_segment_label_and_cooldown():
         today = now.date()
         lat, lon = 51.50, 0.00  # lon=0 → tz_for_coords returns Europe/London (BST in summer)
         lat1, lon1 = lat + 0.10, lon + 0.10
-        from utils.timezone import tz_for_coords as _tz_fc4
-        tz_off4 = now.astimezone(_tz_fc4(lat, lon)).utcoffset()
+        # #1667 S1: Ortszeit-Umrechnung und Tagesgrenzen-Klemmung im Helfer.
+        arr0, arr1 = active_window_offsets(lat, lon, -60, 60)
 
         # Haversine-Distanz WP0→WP1 (für km-Plausibilitäts-Check)
         R = 6371.0
@@ -470,10 +491,8 @@ def test_ac4_mail_body_contains_segment_label_and_cooldown():
         a = math.sin(dlat / 2) ** 2 + math.cos(math.radians(lat)) * math.cos(math.radians(lat1)) * math.sin(dlon / 2) ** 2
         expected_km = R * 2 * math.asin(math.sqrt(a))  # ≈ 13.1 km
 
-        wp0 = _make_waypoint("WP0", lat, lon,
-                             (now - timedelta(hours=1) + tz_off4).strftime("%H:%M"))
-        wp1 = _make_waypoint("WP1", lat1, lon1,
-                             (now + timedelta(hours=1) + tz_off4).strftime("%H:%M"))
+        wp0 = _make_waypoint("WP0", lat, lon, arr0)
+        wp1 = _make_waypoint("WP1", lat1, lon1, arr1)
         stage = Stage(id="S1", name="Tag 1", date=today, waypoints=[wp0, wp1])
         trip_id = f"tdd-822-ac4-trip-{uuid.uuid4().hex[:6]}"
         trip = Trip(id=trip_id, name="AC4 Trip", stages=[stage])
@@ -597,17 +616,14 @@ def test_ac6_cooldown_display_reflects_trip_setting():
     from services.trip_alert import TripAlertService
     from services.radar_service import RadarNowcastService
 
-    now = datetime.now(timezone.utc)
-    today = now.date()
+    today = stage_date()
     lat, lon = 51.50, 0.00  # lon=0 → tz_for_coords returns e.g. Europe/London
-    from utils.timezone import tz_for_coords as _tz_fc6
-    tz_off6 = now.astimezone(_tz_fc6(lat, lon)).utcoffset()
+    # #1667 S1: Ortszeit-Umrechnung und Tagesgrenzen-Klemmung im Helfer.
+    arr0, arr1 = active_window_offsets(lat, lon, -60, 60)
 
     def _make_active_trip(trip_id: str, cooldown: int | None) -> Trip:
-        wp0 = _make_waypoint("WP0", lat, lon,
-                             (now - timedelta(hours=1) + tz_off6).strftime("%H:%M"))
-        wp1 = _make_waypoint("WP1", lat + 0.10, lon + 0.10,
-                             (now + timedelta(hours=1) + tz_off6).strftime("%H:%M"))
+        wp0 = _make_waypoint("WP0", lat, lon, arr0)
+        wp1 = _make_waypoint("WP1", lat + 0.10, lon + 0.10, arr1)
         stage = Stage(id="S1", name="Tag 1", date=today, waypoints=[wp0, wp1])
         t = Trip(id=trip_id, name="AC6 Trip", stages=[stage])
         if cooldown is not None:
@@ -701,19 +717,17 @@ def test_ac7_throttle_recording_unchanged():
     _clean_user(uid)
     _ensure_real_user_dir(uid)
     try:
-        now = datetime.now(timezone.utc)
-        today = now.date()
+        today = stage_date()
 
         # Aktives Segment: [now-1h, now+1h]
-        # Island (lat=64, lon=-22): UTC+0 ganzjährig (kein DST) → arrival_calculated
-        # als UTC-String direkt korrekt, kein Offset-Versatz.
+        # Island (lat=64, lon=-22): UTC+0 ganzjährig (kein DST).
         # _save_trip_direct nötig: save_trip recomputes arrival_calculated via Naismith
         # und würde die Zeiten überschreiben.
+        # #1667 S1: Zeiten aus dem wanduhr-robusten Helfer.
         lat, lon = 64.0, -22.0
-        wp0 = _make_waypoint("WP0", lat, lon,
-                             (now - timedelta(hours=1)).strftime("%H:%M"))
-        wp1 = _make_waypoint("WP1", lat + 0.05, lon + 0.05,
-                             (now + timedelta(hours=1)).strftime("%H:%M"))
+        arr0, arr1 = active_window_offsets(lat, lon, -60, 60)
+        wp0 = _make_waypoint("WP0", lat, lon, arr0)
+        wp1 = _make_waypoint("WP1", lat + 0.05, lon + 0.05, arr1)
         stage = Stage(id="S1", name="Tag 1", date=today, waypoints=[wp0, wp1])
         trip_id = "tdd-822-ac7-trip"
         trip = Trip(id=trip_id, name="AC7 Trip", stages=[stage])
@@ -792,15 +806,14 @@ def test_ac8_mandantentrennung_isolated():
     _clean_user(uid_b)
     _ensure_real_user_dir(uid_b)
     try:
-        now = datetime.now(timezone.utc)
-        today = now.date()
+        today = stage_date()
         lat, lon = 51.5, 0.0  # UTC-Zone
+        # #1667 S1: Zeiten aus dem wanduhr-robusten Helfer.
+        arr0, arr1 = active_window_offsets(lat, lon, -60, 60)
 
         def _make_trip_for(uid: str, trip_id: str) -> Trip:
-            wp0 = _make_waypoint("WP0", lat, lon,
-                                 (now - timedelta(hours=1)).strftime("%H:%M"))
-            wp1 = _make_waypoint("WP1", lat + 0.05, lon + 0.05,
-                                 (now + timedelta(hours=1)).strftime("%H:%M"))
+            wp0 = _make_waypoint("WP0", lat, lon, arr0)
+            wp1 = _make_waypoint("WP1", lat + 0.05, lon + 0.05, arr1)
             s = Stage(id="S1", name="Tag 1", date=today, waypoints=[wp0, wp1])
             t = Trip(id=trip_id, name=f"AC8 {uid}", stages=[s])
             t.report_config = TripReportConfig(

--- a/tests/tdd/test_issue_827_radar_throttle_recording.py
+++ b/tests/tdd/test_issue_827_radar_throttle_recording.py
@@ -10,14 +10,14 @@ from __future__ import annotations
 import json
 import shutil
 import uuid
-from datetime import date as date_type
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-
 
 from app.config import Settings
 from app.models import TripReportConfig
 from app.trip import Stage, Trip, Waypoint
+
+from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
 
 DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
 
@@ -36,15 +36,17 @@ def _wet_frames(lat: float, lon: float) -> list:
 
 
 def _make_trip(trip_id: str, send_email: bool, send_telegram: bool) -> Trip:
-    today = date_type.today()
-    now_utc = datetime.now(timezone.utc)
-    # Waypoints so dass aktives Segment jetzt liegt
-    arrival_now = (now_utc + timedelta(hours=2)).strftime("%H:%M")
+    # Waypoints so dass das Segment jetzt aktiv (oder noch zukuenftig) ist.
+    # #1667 S1: der Helfer klemmt das Fenster auf den Etappentag, statt roh
+    # ueber Mitternacht zu rechnen — ab 22:00 UTC lief die +2h/+4h-Folge sonst
+    # steigend ueber den Tageswechsel und das Segment landete in der
+    # Vergangenheit.
+    arr0, arr1 = active_window_offsets(LAT, LON, 120, 240)
     wp0 = Waypoint(id="WP0", name="Start", lat=LAT, lon=LON, elevation_m=500.0,
-                   arrival_calculated=arrival_now)
+                   arrival_calculated=arr0)
     wp1 = Waypoint(id="WP1", name="End", lat=LAT + 0.1, lon=LON + 0.1, elevation_m=600.0,
-                   arrival_calculated=(now_utc + timedelta(hours=4)).strftime("%H:%M"))
-    stage = Stage(id="S1", name="Tag 1", date=today, waypoints=[wp0, wp1])
+                   arrival_calculated=arr1)
+    stage = Stage(id="S1", name="Tag 1", date=stage_date(), waypoints=[wp0, wp1])
     trip = Trip(id=trip_id, name="827 Test", stages=[stage])
     trip.report_config = TripReportConfig(
         trip_id=trip_id,

--- a/tests/tdd/test_issue_883_acute_danger_override.py
+++ b/tests/tdd/test_issue_883_acute_danger_override.py
@@ -39,6 +39,8 @@ import pytest
 from app.models import TripReportConfig
 from app.trip import Stage, Trip, Waypoint
 
+from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
+
 DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
 
 # Island: UTC+0 ganzjährig (kein DST) → arrival_calculated-Zeiten = UTC-Zeiten.
@@ -74,17 +76,23 @@ def _nonconvective_frames(lat: float, lon: float) -> list:
 # --------------------------------------------------------------------------
 
 def _make_active_trip(trip_id: str, quiet_from: str | None = None, quiet_to: str | None = None) -> Trip:
-    """2-Waypoint-Trip mit aktivem Segment (now-1h … now+2h), UTC+0 (Island)."""
-    now = datetime.now(timezone.utc)
+    """2-Waypoint-Trip mit aktivem Segment (now-1h … now+2h), UTC+0 (Island).
+
+    #1667 S1: die Zeiten kommen aus dem wanduhr-robusten Helfer. Diese
+    -1h/+2h-Familie hat keine Rollover-Kippkante (die Folge faellt), wohl aber
+    ein Datumsproblem an der UTC-Mitternacht: das Etappendatum muss aus
+    derselben Quelle stammen wie die Segmentauswahl in trip_alert.py.
+    """
+    arr0, arr1 = active_window_offsets(LAT, LON, -60, 120)
     wp0 = Waypoint(
         id="WP0", name="Start", lat=LAT, lon=LON, elevation_m=100.0,
-        arrival_calculated=(now - timedelta(hours=1)).strftime("%H:%M"),
+        arrival_calculated=arr0,
     )
     wp1 = Waypoint(
         id="WP1", name="Ziel", lat=LAT + 0.05, lon=LON + 0.05, elevation_m=200.0,
-        arrival_calculated=(now + timedelta(hours=2)).strftime("%H:%M"),
+        arrival_calculated=arr1,
     )
-    stage = Stage(id="S1", name="Tag 1", date=now.date(), waypoints=[wp0, wp1])
+    stage = Stage(id="S1", name="Tag 1", date=stage_date(), waypoints=[wp0, wp1])
     trip = Trip(id=trip_id, name=f"Test {trip_id}", stages=[stage])
     trip.alert_quiet_from = quiet_from
     trip.alert_quiet_to = quiet_to
@@ -146,12 +154,22 @@ def _write_snapshot(user_id: str, trip_id: str, segment_id, hourly_precip: dict)
     snapshots_dir.mkdir(parents=True, exist_ok=True)
     now_utc = datetime.now(timezone.utc)
 
+    # #1667 S1: Stundenraster ueber ZWEI Tage. Die Aufrufer schluesseln nach
+    # ``_onset_hour()`` (``jetzt + 5 min``); in den letzten fuenf Minuten des
+    # UTC-Tages ist das Stunde 0 des FOLGEtages, waehrend hier nur der heutige
+    # Tag geschrieben wurde. Nachgemessen (A/B gegen den Fixture-Stand vor
+    # dieser Scheibe, beide Seiten identisch): ``test_ac2_...`` und
+    # ``test_ac4_...`` waren zwischen 23:55:00 und 24:00:00 UTC rot, um
+    # 23:54:00 gruen — der Befund ist aelter als S1 und hat mit den
+    # Ankunftszeiten nichts zu tun.
+    tagesbeginn = now_utc.replace(hour=0, minute=0, second=0, microsecond=0,
+                                  tzinfo=None)
     hourly = []
-    for h in range(24):
-        ts_naive = now_utc.replace(hour=h, minute=0, second=0, microsecond=0, tzinfo=None)
+    for stunde in range(48):
+        ts_naive = tagesbeginn + timedelta(hours=stunde)
         hourly.append({
             "ts": ts_naive.strftime("%Y-%m-%dT%H:%M:%S"),
-            "precip_1h_mm": float(hourly_precip.get(h, 0.0)),
+            "precip_1h_mm": float(hourly_precip.get(ts_naive.hour, 0.0)),
         })
 
     snapshot = {

--- a/tests/tdd/test_issue_995_scheduler_pause.py
+++ b/tests/tdd/test_issue_995_scheduler_pause.py
@@ -27,6 +27,8 @@ from app.models import (
 )
 from app.trip import Stage, Trip, Waypoint
 
+from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
+
 _USER_A = "tdd-995-usera"
 _USER_B = "tdd-995-userb"
 _USER_AC8 = "tdd-995-ac8"
@@ -174,21 +176,21 @@ class TestAC9AlertDispatchUnaffected:
         from services.trip_alert import TripAlertService
         from services.radar_service import RadarNowcastService
         from providers.brightsky import RadarFrame
-        from utils.timezone import tz_for_coords
 
         trip_id = "ac9-paused-trip"
         now = datetime.now(timezone.utc)
         lat, lon = 47.0, 11.0
-        offset = now.astimezone(tz_for_coords(lat, lon)).utcoffset()
-        arr1 = (now - timedelta(hours=1) + offset).strftime("%H:%M")
-        arr2 = (now + timedelta(hours=2) + offset).strftime("%H:%M")
+        # #1667 S1: der Helfer rechnet die Ortszeit selbst aus (der frühere
+        # manuelle utcoffset-Aufschlag entfällt) und klemmt das Fenster auf den
+        # Etappentag, statt roh über Mitternacht zu laufen.
+        arr1, arr2 = active_window_offsets(lat, lon, -60, 120)
 
         trips_dir = get_briefings_dir(_USER_AC9)
         trips_dir.mkdir(parents=True, exist_ok=True)
         data = {
             "id": trip_id, "name": "AC9 Trip",
             "stages": [{
-                "id": "S1", "name": "Tag 1", "date": now.date().isoformat(),
+                "id": "S1", "name": "Tag 1", "date": stage_date().isoformat(),
                 "waypoints": [
                     {"id": "WP0", "name": "WP0", "lat": lat, "lon": lon, "elevation_m": 1000,
                      "arrival_calculated": arr1},

--- a/tests/unit/test_alarm_zeitfenster_ziel.py
+++ b/tests/unit/test_alarm_zeitfenster_ziel.py
@@ -283,7 +283,7 @@ def _persist_trip(trip, user_id: str) -> None:
     (briefings / f"{trip.id}.json").write_text(json.dumps(payload, indent=2))
 
 
-def radar_fixture_window(arrival_utc: datetime) -> tuple[int, int]:
+def radar_fixture_window(arrival_utc: datetime, heute: date | None = None) -> tuple[int, int]:
     """Tagesfenster-Grenzen fuer die Radar-Fixture — REINE Funktion, damit die
     Tageszeit-Unabhaengigkeit deterministisch pruefbar ist (s.
     ``test_radar_fixture_ist_zu_jeder_tageszeit_kein_mitternachtsfenster``).
@@ -301,31 +301,54 @@ def radar_fixture_window(arrival_utc: datetime) -> tuple[int, int]:
     nicht wrappen; noetig ist dann nur noch ``end_hour >= 1``, worum sich
     ``radar_fixture_ort()`` kuemmert.
     """
-    return 0, arrival_utc.astimezone(radar_fixture_tz(arrival_utc)).hour
+    return 0, arrival_utc.astimezone(radar_fixture_tz(arrival_utc, heute)).hour
 
 
-def radar_fixture_tz(arrival_utc: datetime):
+def _island_taugt(arrival_utc: datetime, heute: date) -> bool:
+    """Traegt Reykjavik diese Ankunft — oder muss die Fixture ausweichen?
+
+    Zwei Bedingungen, beide zwingend (s. ``radar_fixture_ort``):
+    Ortsstunde >= 1 und Ortsdatum == ``heute``.
+    """
+    from zoneinfo import ZoneInfo
+
+    lokal = arrival_utc.astimezone(ZoneInfo("Atlantic/Reykjavik"))
+    return lokal.hour >= 1 and lokal.date() == heute
+
+
+def radar_fixture_tz(arrival_utc: datetime, heute: date | None = None):
     """Zeitzone des Zielorts fuer die Radar-Fixture — s. ``radar_fixture_ort``."""
     from zoneinfo import ZoneInfo
 
-    if arrival_utc.hour >= 1:
+    heute = heute if heute is not None else date.today()
+    if _island_taugt(arrival_utc, heute):
         return ZoneInfo("Atlantic/Reykjavik")
     return ZoneInfo("Pacific/Auckland")
 
 
-def radar_fixture_ort(arrival_utc: datetime) -> tuple[float, float]:
+def radar_fixture_ort(arrival_utc: datetime, heute: date | None = None) -> tuple[float, float]:
     """Zielkoordinate der Radar-Fixture — REINE Funktion (s. Invarianten-Test).
 
     Standard ist Reykjavik (``Atlantic/Reykjavik``, ganzjaehrig UTC+0 OHNE
     Sommerzeit): Ortszeit == UTC, keine Offset-Rechnung, kein DST-Flattern.
     Die Ortsstunde ist dort gleich der UTC-Stunde — und muss >= 1 sein, damit
-    ``start_hour = 0`` echt kleiner als ``end_hour`` ist. Verletzt ist das nur
-    in der UTC-Stunde 0; dann weicht die Fixture nach Auckland (UTC+12/+13)
-    aus, wo dieselbe UTC-Zeit auf 12:xx bzw. 13:xx Ortszeit faellt — und wo
-    das Ortsdatum in dieser UTC-Stunde weiterhin dem UTC-Datum entspricht
-    (fuer ``date.today()`` in ``check_radar_alerts()`` zwingend).
+    ``start_hour = 0`` echt kleiner als ``end_hour`` ist.
+
+    Ausgewichen wird nach Auckland (UTC+12/+13), wenn eine der beiden
+    Bedingungen verletzt ist:
+
+    * **Ortsstunde 0** — dann waere ``end_hour == 0`` und ``start_hour = 0``
+      nicht mehr echt kleiner.
+    * **Ortsdatum != ``heute``** — ``check_radar_alerts()`` sucht die Etappe
+      ueber ``date.today()``; liegt die Ankunft (``jetzt`` minus drei Minuten)
+      noch vor UTC-Mitternacht, waehrend ``date.today()`` schon auf dem neuen
+      Tag steht, faende es die Etappe nicht. #1667 S1: genau dafuer stand hier
+      bis 2026-08-10 ein ``pytest.skip`` fuer die ersten drei Minuten des
+      UTC-Tages. In Auckland faellt dieselbe absolute Zeit auf 11:5x bzw.
+      12:5x Ortszeit DES NEUEN TAGES — Datum und Stunde stimmen also beide.
     """
-    if arrival_utc.hour >= 1:
+    heute = heute if heute is not None else date.today()
+    if _island_taugt(arrival_utc, heute):
         return ISLAND_LAT, ISLAND_LON
     return AUCKLAND_LAT, AUCKLAND_LON
 
@@ -346,17 +369,15 @@ def _radar_mails_fuer_spaetankunft() -> list:
 
     now = datetime.now(timezone.utc)
     arrival = now - timedelta(minutes=3)
-    if arrival.date() != date.today():
-        pytest.skip(
-            "Fixture nicht konstruierbar: 'jetzt minus 3 Minuten' liegt vor "
-            "UTC-Mitternacht, waehrend check_radar_alerts() bereits den neuen "
-            "date.today() verwendet. Betrifft nur die ersten 3 Minuten des "
-            "UTC-Tages."
-        )
-
-    dest_lat, dest_lon = radar_fixture_ort(arrival)
-    dest_tz = radar_fixture_tz(arrival)
-    start_hour, end_hour = radar_fixture_window(arrival)
+    # #1667 S1: Der frueher hier stehende ``pytest.skip`` fuer die ersten drei
+    # Minuten des UTC-Tages ist entfallen. Die Ortswahl bekommt jetzt
+    # ``date.today()`` uebergeben und weicht selbst nach Auckland aus, wenn die
+    # Ankunft noch vor UTC-Mitternacht liegt — dann stimmt das ORTSdatum
+    # wieder mit dem Etappendatum ueberein (s. ``radar_fixture_ort``).
+    heute = date.today()
+    dest_lat, dest_lon = radar_fixture_ort(arrival, heute)
+    dest_tz = radar_fixture_tz(arrival, heute)
+    start_hour, end_hour = radar_fixture_window(arrival, heute)
     arrival_local = arrival.astimezone(dest_tz)
     start_local = (arrival - timedelta(hours=4)).astimezone(dest_tz)
 
@@ -463,14 +484,25 @@ def test_radar_fixture_ist_zu_jeder_tageszeit_kein_mitternachtsfenster():
       2. ``end_hour`` == Ortsstunde der Ankunft -> das Fensterende (HH:00)
          liegt vor der Ankunft (HH:MM), der Randfall-Guard greift
 
-    Zusaetzlich wird geprueft, dass das Ortsdatum dem UTC-Datum entspricht —
-    ``check_radar_alerts()`` sucht die Etappe ueber ``date.today()`` (UTC).
+    Zusaetzlich wird geprueft, dass das Ortsdatum dem ETAPPENdatum entspricht —
+    ``check_radar_alerts()`` sucht die Etappe ueber ``date.today()``.
+
+    #1667 S1: Der Durchlauf deckt jetzt auch die drei Minuten VOR
+    UTC-Mitternacht ab, in denen die Ankunft (``jetzt`` minus drei Minuten)
+    noch auf dem Vortag liegt, waehrend ``date.today()`` schon auf dem neuen
+    Tag steht. Fuer sie stand hier bis 2026-08-10 ein ``pytest.skip``; sie sind
+    der Grund, warum das Etappendatum als Parameter hereinkommt statt aus
+    ``arrival.date()`` abgeleitet zu werden.
     """
     basis = datetime(2026, 8, 8, tzinfo=timezone.utc)
-    for minute in range(24 * 60):
-        arrival = basis + timedelta(minutes=minute)
-        tz = radar_fixture_tz(arrival)
-        start_hour, end_hour = radar_fixture_window(arrival)
+    faelle = [(basis + timedelta(minutes=m), (basis + timedelta(minutes=m)).date())
+              for m in range(24 * 60)]
+    # Ankunft kurz vor UTC-Mitternacht, Etappendatum bereits der Folgetag.
+    faelle += [(basis - timedelta(minutes=m), basis.date()) for m in (1, 2, 3)]
+
+    for arrival, heute in faelle:
+        tz = radar_fixture_tz(arrival, heute)
+        start_hour, end_hour = radar_fixture_window(arrival, heute)
         lokal = arrival.astimezone(tz)
 
         assert start_hour < end_hour, (
@@ -485,10 +517,10 @@ def test_radar_fixture_ist_zu_jeder_tageszeit_kein_mitternachtsfenster():
             f"{lokal.hour} bei {arrival.isoformat()} — das Fensterende laege "
             "nicht vor der Ankunft und der Randfall-Guard griefe nicht."
         )
-        assert lokal.date() == arrival.date(), (
-            f"F004: Ortsdatum {lokal.date()} != UTC-Datum {arrival.date()} bei "
+        assert lokal.date() == heute, (
+            f"F004: Ortsdatum {lokal.date()} != Etappendatum {heute} bei "
             f"{arrival.isoformat()} ({tz}) — check_radar_alerts() sucht die "
-            "Etappe ueber date.today() in UTC und faende sie nicht."
+            "Etappe ueber date.today() und faende sie nicht."
         )
 
 

--- a/tests/unit/test_arrival_window_fixtures.py
+++ b/tests/unit/test_arrival_window_fixtures.py
@@ -1,0 +1,320 @@
+"""Waechter fuer die tragenden Zusicherungen von ``arrival_window_fixtures``.
+
+Warum es diese Datei gibt
+-------------------------
+Der Fixture-Helfer aus #1667 S1 traegt drei Zusicherungen, ohne die die zwoelf
+umgestellten Alarm-/Radar-Testdateien zwischen ~22:00 und 00:00 UTC wieder rot
+werden. Bis 2026-08-10 waren sie NUR durch einmalige, von Hand gestartete
+``freeze_time``-Laeufe belegt, deren Ausgabe als Text in einem Artefakt lag.
+
+Die Adversary-Gegenprobe hat gezeigt, was das wert war: zwei Verfaelschungen
+von Zusicherungen, die der Helfer-Docstring selbst „tragend" nennt, blieben im
+gesamten committeten Testbestand unbemerkt —
+
+* Monotonie-Untergrenze entfernt (``max(r, vorher + 1)`` -> ``r``): voller
+  Suitenlauf gruen, auch an allen vier Kippkanten unter gestellter Uhr (F002).
+* Obere Klemme ``1439`` -> ``1440``: voller Suitenlauf gruen, nur ein gezielter
+  Handlauf fing es (F003).
+
+Das ist derselbe Fehler, den S1 beheben sollte, eine Ebene hoeher: der Schutz
+existierte als Bericht, nicht als Mechanismus. Diese Datei macht ihn zum
+Mechanismus.
+
+Zwei Schichten, mit Absicht
+---------------------------
+1. ``fenster_minuten()`` ist eine REINE Funktion (Minute seit
+   Ortszeit-Mitternacht rein, Wegpunkt-Minuten raus). Sie wird hier ueber ALLE
+   1440 Minuten eines Tages plus die Raender davor und danach geprueft —
+   deterministisch, ohne Uhr, ohne Zeitzonendaten, in jedem CI-Lauf.
+2. Der Wirkort ist aber nicht die Rechnung, sondern das fertige Segment. Die
+   Wirkungs-Tests unten stellen deshalb die Uhr auf die Kippkanten und lassen
+   den ECHTEN ``convert_trip_to_segments`` ueber einen ECHTEN Trip laufen —
+   „ist die Zusicherung dort geprueft, wo sie WIRKT?" Damit wird ``freezegun``
+   auch tatsaechlich benutzt statt nur in ``pyproject.toml`` zu stehen (F001).
+
+Kein Netz, kein Mock: Schicht 1 ist Arithmetik, Schicht 2 baut echte
+Trip-/Waypoint-Objekte und ruft den echten Produktivcode.
+
+Pfadregel #1409: der Pruefling wird ueber den Paketpfad importiert, den
+``tests/conftest.py`` relativ zu DIESER Datei aufsetzt — kein fester
+Hauptrepo-Pfad.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta, timezone
+
+import pytest
+from freezegun import freeze_time
+
+from app.models import TripReportConfig
+from app.trip import Stage, Trip, Waypoint
+from services.trip_segments import convert_trip_to_segments
+from utils.timezone import tz_for_coords
+
+from tests.helpers.arrival_window_fixtures import (
+    MINUTEN_PRO_TAG,
+    active_window_offsets,
+    fenster_minuten,
+    stage_date,
+)
+
+# Die Versatz-Familien, die in den zwoelf umgestellten Dateien wirklich
+# vorkommen, plus zwei Grenzfaelle (gleiche Versaetze, Abstand ueber einen
+# ganzen Tag), die die Zusicherungen 2 und 3 ueberhaupt erst ansprechen.
+FAMILIEN: list[tuple[int, ...]] = [
+    (60, 240),          # test_alert_log_metrics, test_alert_urgency
+    (120, 240),         # test_issue_827, test_issue_1070, test_alert_channel_threshold
+    (-60, 120),         # test_issue_883, test_alert_quiet_hours_robustness, #995
+    (-60, 180),         # test_bundle_791_847_844
+    (-240, -120, 120),  # test_issue_822 AC-1
+    (-120, -30, 90),    # test_issue_822 AC-3
+]
+
+# Nord/Sued und weit oestlich/westlich von Greenwich, plus die Zonen, die in
+# den Fixturen wirklich benutzt werden.
+ORTE: list[tuple[str, float, float]] = [
+    ("Korsika UTC+2", 42.20, 9.10),
+    ("Island UTC+0", 64.00, -22.00),
+    ("London UTC+1", 51.50, 0.00),
+    ("Neuseeland UTC+12", -41.29, 174.78),
+    ("Denver UTC-6", 39.74, -104.99),
+]
+
+# Ein voller lokaler Tag plus die Raender: minuten_jetzt darf negativ sein (der
+# lokale Etappentag hat noch nicht begonnen) und ueber 1439 liegen (er ist
+# schon vorbei) — beides kommt bei realen Zeitzonen vor.
+ALLE_MINUTEN = range(-MINUTEN_PRO_TAG, 2 * MINUTEN_PRO_TAG)
+
+
+# ══════════ Schicht 1: die reine Rechnung, ueber den ganzen Tag ══════════
+
+def test_erster_wegpunkt_liegt_immer_auf_dem_etappentag():
+    """Zusicherung 1: ``0 <= ergebnis[0] <= 1439``.
+
+    ``wp_days[0]`` ist in ``convert_trip_to_segments`` strukturell immer 0.
+    Faellt der erste Wegpunkt aus dem Etappentag, wird er beim Zusammensetzen
+    trotzdem auf diesen Tag gelegt — das Segment landet einen ganzen Tag
+    daneben.
+    """
+    verletzt = [
+        (m, versaetze, fenster_minuten(m, *versaetze)[0])
+        for m in ALLE_MINUTEN
+        for versaetze in FAMILIEN
+        if not 0 <= fenster_minuten(m, *versaetze)[0] <= MINUTEN_PRO_TAG - 1
+    ]
+    assert not verletzt, (
+        f"{len(verletzt)} Faelle legen den ersten Wegpunkt neben den "
+        f"Etappentag, z.B. {verletzt[:3]}"
+    )
+
+
+def test_wegpunkte_sind_immer_streng_monoton():
+    """Zusicherung 2: streng steigend.
+
+    Zwei gleiche Zeiten lassen das Segment am ``end_dt <= start_dt``-Guard in
+    ``convert_trip_to_segments`` kollabieren; es wird dann geloggt
+    uebersprungen und die Etappe verliert stillschweigend ein Segment.
+    """
+    verletzt = []
+    for m in ALLE_MINUTEN:
+        for versaetze in FAMILIEN:
+            werte = fenster_minuten(m, *versaetze)
+            if any(werte[i] >= werte[i + 1] for i in range(len(werte) - 1)):
+                verletzt.append((m, versaetze, werte))
+    assert not verletzt, (
+        f"{len(verletzt)} Faelle sind nicht streng monoton, z.B. {verletzt[:3]}"
+    )
+
+
+def test_abstand_bleibt_unter_einem_ganzen_tag():
+    """Zusicherung 3: jeder Abstand hoechstens 1439 Minuten.
+
+    Bei genau 1440 waere die Uhrzeit des Folgepunkts IDENTISCH mit der seines
+    Vorgaengers. Die Rollover-Erkennung in ``convert_trip_to_segments`` greift
+    nur bei STRIKT fallender Uhrzeit — der Tageswechsel wuerde verschluckt und
+    das Segment kollabierte.
+    """
+    verletzt = []
+    for m in ALLE_MINUTEN:
+        for versaetze in FAMILIEN:
+            werte = fenster_minuten(m, *versaetze)
+            for i in range(len(werte) - 1):
+                if werte[i + 1] - werte[i] > MINUTEN_PRO_TAG - 1:
+                    verletzt.append((m, versaetze, werte[i], werte[i + 1]))
+    assert not verletzt, (
+        f"{len(verletzt)} Abstaende erreichen oder ueberschreiten einen ganzen "
+        f"Tag, z.B. {verletzt[:3]}"
+    )
+
+
+@pytest.mark.parametrize("versaetze", [(60, 60), (120, 120, 120), (240, 0)])
+def test_gleiche_oder_fallende_versaetze_bleiben_streng_monoton(versaetze):
+    """Die Untergrenze ``vorher + 1`` ist die einzige Zusicherung, die diesen
+    Fall traegt — bei streng steigenden Versaetzen greift sie nie.
+
+    Genau deshalb blieb ihre Entfernung in der Adversary-Gegenprobe unbemerkt:
+    alle zwoelf Aufrufstellen uebergeben steigende Versaetze. Der Helfer sagt
+    aber „streng monoton" ohne Vorbehalt zu — hier wird diese Zusage geprueft,
+    nicht die zufaellige Aufrufpraxis.
+    """
+    for m in (0, 1, 719, 1438, 1439, -1, 1440, 2000):
+        werte = fenster_minuten(m, *versaetze)
+        assert all(werte[i] < werte[i + 1] for i in range(len(werte) - 1)), (
+            f"minuten_jetzt={m}, Versaetze={versaetze} -> {werte} ist nicht "
+            "streng monoton; die Untergrenze vorher+1 fehlt oder greift nicht"
+        )
+
+
+@pytest.mark.parametrize("abstand", [MINUTEN_PRO_TAG, MINUTEN_PRO_TAG + 1, 5000])
+def test_grosser_abstand_wird_unter_einen_tag_geklemmt(abstand):
+    """Ein Versatz-Paar, das ueber einen ganzen Tag auseinanderliegt, MUSS auf
+    hoechstens 1439 Minuten zusammengezogen werden.
+
+    Das ist der Fall, den die obere Klemme allein traegt. Waere sie 1440,
+    kaeme beim Abstand 1440 dieselbe Uhrzeit heraus — hier direkt geprueft:
+    die Minuten modulo Tag muessen sich unterscheiden.
+    """
+    for m in (0, 300, 900, 1439):
+        a, b = fenster_minuten(m, 0, abstand)
+        assert b - a <= MINUTEN_PRO_TAG - 1, (
+            f"minuten_jetzt={m}, Abstand={abstand} -> {a}/{b}: Abstand "
+            f"{b - a} erreicht einen ganzen Tag"
+        )
+        assert a % MINUTEN_PRO_TAG != b % MINUTEN_PRO_TAG, (
+            f"minuten_jetzt={m}, Abstand={abstand} -> {a}/{b}: beide Wegpunkte "
+            "tragen dieselbe Uhrzeit; der Tageswechsel waere fuer "
+            "convert_trip_to_segments unsichtbar"
+        )
+
+
+def test_versaetze_in_der_tagesmitte_bleiben_unveraendert():
+    """Gegenprobe zur Klemmung: mitten am Tag darf der Helfer NICHTS tun.
+
+    Ohne diesen Test koennte die Klemmung beliebig scharf werden (z.B. alles
+    auf eine Minute stauchen) und die drei Tests oben blieben gruen.
+    """
+    mitte = 12 * 60
+    for versaetze in FAMILIEN:
+        assert fenster_minuten(mitte, *versaetze) == tuple(
+            mitte + v for v in versaetze
+        ), f"Versaetze {versaetze} wurden in der Tagesmitte veraendert"
+
+
+def test_zu_wenige_wegpunkte_scheitern_laut():
+    """Ein Segment braucht zwei Wegpunkte — ein einzelner ist ein Programm-
+    fehler des Aufrufers und darf nicht still ein Ein-Punkt-Fenster liefern."""
+    with pytest.raises(ValueError):
+        fenster_minuten(600, 60)
+
+
+# ══════════ Schicht 2: die Wirkung am echten Segmentbau ══════════
+
+# Die Kippkanten aus AC-3 der Spec, plus die Mitternachtssekunden. Bis
+# 2026-08-10 wurden genau diese Zeitpunkte NUR von Hand geprueft.
+KIPPKANTEN = [
+    "2026-08-10T12:00:00+00:00",
+    "2026-08-10T21:59:59+00:00",
+    "2026-08-10T22:00:00+00:00",
+    "2026-08-10T22:59:59+00:00",
+    "2026-08-10T23:00:00+00:00",
+    "2026-08-10T23:30:00+00:00",
+    "2026-08-10T23:59:59+00:00",
+    "2026-08-11T00:00:01+00:00",
+    "2026-08-11T02:00:00+00:00",
+]
+
+
+def _trip_aus_helfer(lat: float, lon: float, versaetze: tuple[int, ...]) -> Trip:
+    """Echter Trip, dessen Ankunftszeiten aus dem Helfer stammen — genau so,
+    wie es die zwoelf umgestellten Fixturen tun."""
+    zeiten = active_window_offsets(lat, lon, *versaetze)
+    waypoints = [
+        Waypoint(id=f"WP{i}", name=f"WP{i}", lat=lat + i * 0.05,
+                 lon=lon + i * 0.05, elevation_m=1000.0, arrival_calculated=z)
+        for i, z in enumerate(zeiten)
+    ]
+    stage = Stage(id="S1", name="Tag 1", date=stage_date(), waypoints=waypoints)
+    trip = Trip(id="wanduhr-probe", name="Wanduhr-Probe", stages=[stage])
+    trip.report_config = TripReportConfig(trip_id="wanduhr-probe", send_email=False)
+    return trip
+
+
+@pytest.mark.parametrize("zeitpunkt", KIPPKANTEN)
+@pytest.mark.parametrize("ortsname,lat,lon", ORTE)
+def test_segment_liegt_nie_vollstaendig_in_der_vergangenheit(
+    zeitpunkt, ortsname, lat, lon
+):
+    """DIE Wirkung, um die es in #1667 S1 geht — am Wirkort geprueft.
+
+    ``check_radar_alerts()`` bricht mit „alle Segmente vorbei" ab, sobald
+    ``now_utc`` hinter dem Ende des letzten Segments liegt; genau das liess die
+    Fixturen ab 22:00/23:00 UTC 0 statt 1 Alarm liefern. Geprueft wird hier
+    nicht die Rechnung des Helfers, sondern das Ergebnis des ECHTEN
+    ``convert_trip_to_segments`` — inklusive Rollover-Erkennung und
+    Ziel-Segment.
+    """
+    with freeze_time(zeitpunkt):
+        jetzt = datetime.now(timezone.utc)
+        for versaetze in FAMILIEN:
+            trip = _trip_aus_helfer(lat, lon, versaetze)
+            segmente = convert_trip_to_segments(trip, stage_date())
+            assert segmente, (
+                f"{ortsname} @ {zeitpunkt}, Versaetze {versaetze}: leere "
+                "Segmentliste — die Etappe wurde gar nicht gefunden oder alle "
+                "Segmente sind am end_dt<=start_dt-Guard kollabiert"
+            )
+            letztes_ende = max(s.end_time for s in segmente)
+            assert letztes_ende >= jetzt, (
+                f"{ortsname} @ {zeitpunkt}, Versaetze {versaetze}: alle "
+                f"Segmente vorbei (letztes Ende {letztes_ende.isoformat()} < "
+                f"jetzt {jetzt.isoformat()}) — check_radar_alerts() liefert "
+                "hier 0 statt 1, genau der Fund aus #1667 S1"
+            )
+
+
+@pytest.mark.parametrize("zeitpunkt", KIPPKANTEN)
+def test_wegpunktzeiten_ergeben_echt_wachsende_segmentgrenzen(zeitpunkt):
+    """Kein Segment darf still verschwinden.
+
+    ``convert_trip_to_segments`` ueberspringt ein Segment mit
+    ``end_dt <= start_dt`` und loggt nur eine Warnung. Ein solcher Verlust
+    faellt in den Fixturen sonst nicht auf: der Test bekommt einfach ein
+    Segment weniger und laeuft weiter.
+    """
+    with freeze_time(zeitpunkt):
+        for ortsname, lat, lon in ORTE:
+            for versaetze in FAMILIEN:
+                trip = _trip_aus_helfer(lat, lon, versaetze)
+                segmente = convert_trip_to_segments(trip, stage_date())
+                # Wegpunkte minus 1 Verbindungssegmente, plus das Ziel-Segment.
+                erwartet = len(versaetze)
+                assert len(segmente) == erwartet, (
+                    f"{ortsname} @ {zeitpunkt}, Versaetze {versaetze}: "
+                    f"{len(segmente)} statt {erwartet} Segmenten — mindestens "
+                    "eines ist am end_dt<=start_dt-Guard kollabiert"
+                )
+                for s in segmente:
+                    assert s.end_time > s.start_time, (
+                        f"{ortsname} @ {zeitpunkt}: Segment {s.segment_id} "
+                        "endet nicht nach seinem Anfang"
+                    )
+
+
+def test_freeze_time_stellt_die_uhr_wirklich():
+    """Selbstbeleg: wenn ``freeze_time`` hier nicht wirkte, waeren alle
+    Wirkungs-Tests oben stumm — sie liefen dann immer zur realen Wanduhrzeit
+    und pruefen die Kippkanten nie.
+
+    Genau diese Frage („prueft der Test, was er behauptet?") war der Kern des
+    Adversary-Findings F001.
+    """
+    with freeze_time("2026-08-10T23:30:00+00:00"):
+        assert datetime.now(timezone.utc) == datetime(
+            2026, 8, 10, 23, 30, tzinfo=timezone.utc
+        )
+        assert date.today() == date(2026, 8, 10)
+        tz = tz_for_coords(42.20, 9.10)
+        tagesbeginn = datetime.combine(date(2026, 8, 10), time(0, 0)).replace(tzinfo=tz)
+        # Korsika liegt im Sommer auf UTC+2: der Etappentag begann um 22:00 UTC
+        # des Vortages, "jetzt" ist also Minute 1530 dieses lokalen Tages.
+        assert (datetime.now(timezone.utc) - tagesbeginn) == timedelta(minutes=1530)

--- a/uv.lock
+++ b/uv.lock
@@ -242,6 +242,18 @@ wheels = [
 ]
 
 [[package]]
+name = "freezegun"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/dd/23e2f4e357f8fd3bdff613c1fe4466d21bfb00a6177f238079b17f7b1c84/freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a", size = 35914, upload-time = "2025-08-09T10:39:08.338Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/2e/b41d8a1a917d6581fc27a35d05561037b048e47df50f27f8ac9c7e27a710/freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2", size = 19266, upload-time = "2025-08-09T10:39:06.636Z" },
+]
+
+[[package]]
 name = "gpxpy"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -315,6 +327,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "freezegun" },
     { name = "jsonschema" },
     { name = "playwright" },
     { name = "pytest" },
@@ -343,6 +356,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "freezegun", specifier = ">=1.5.0" },
     { name = "jsonschema" },
     { name = "playwright", specifier = ">=1.57.0" },
     { name = "pytest", specifier = ">=8.4.1" },
@@ -902,6 +916,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1199,6 +1225,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/1c/d7b67ab43f30013b47c12b42d1acd354c195351a3f7a1d67f59e54227ede/ruff-0.14.10-py3-none-win32.whl", hash = "sha256:104c49fc7ab73f3f3a758039adea978869a918f31b73280db175b43a2d9b51d6", size = 13196187, upload-time = "2025-12-18T19:29:19.006Z" },
     { url = "https://files.pythonhosted.org/packages/fb/9c/896c862e13886fae2af961bef3e6312db9ebc6adc2b156fe95e615dee8c1/ruff-0.14.10-py3-none-win_amd64.whl", hash = "sha256:466297bd73638c6bdf06485683e812db1c00c7ac96d4ddd0294a338c62fdc154", size = 14661283, upload-time = "2025-12-18T19:29:30.16Z" },
     { url = "https://files.pythonhosted.org/packages/74/31/b0e29d572670dca3674eeee78e418f20bdf97fa8aa9ea71380885e175ca0/ruff-0.14.10-py3-none-win_arm64.whl", hash = "sha256:e51d046cf6dda98a4633b8a8a771451107413b0f07183b2bef03f075599e44e6", size = 13729839, upload-time = "2025-12-18T19:28:48.636Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Was das behebt

~30 Testfunktionen in 12 Dateien wurden zwischen 22:00 und 00:00 UTC reproduzierbar rot und blockierten abends jedes Commit-Gate.

**Die im Issue vermutete Ursache trifft nicht zu.** Dort steht, die #1584-Regel „Alarme schalten 2 h nach Ankunft ab" werde fälschlich ausgelöst. Diese Regel existiert seit PR #1590 (2026-08-08) nicht mehr; die Fehlschläge traten danach auf.

**Die tatsächliche Ursache:** `trip_segments.py:151-159` erkennt einen Tageswechsel nur *zwischen* zwei Wegpunkten und nur bei **strikt fallender** Uhrzeit — `wp_days[0]` ist strukturell immer 0. Ab 23:00 UTC erzeugt eine `+1h/+4h`-Fixture die Folge `00:00 → 03:00`: **steigend**, also kein Rollover. Das Segment landet 23 h in der Vergangenheit, der Guard „alle Segmente vorbei" (`trip_alert.py:749-763`) greift, `check_radar_alerts()` liefert 0 statt 1.

Punktgenau reproduziert: grün bis 22:59 UTC, rot ab exakt 23:00 UTC.

## Kein Produktivcode

`git diff --stat` **und** `git status --short` über `src/ api/ internal/ frontend/ cmd/` sind beide leer (AC-6). Diese Scheibe fasst ausschließlich `tests/` und `pyproject.toml` an.

## Die Spec-Skizze war falsch — nachgemessen, nicht vermutet

Die freigegebene Spec skizzierte eine Klemmung auf 02:00–22:00 Ortszeit. Gemessen verschiebt sie die Kippkante lediglich von 23:00 auf 22:00 UTC und macht 21:59:59 **zusätzlich** rot — eine Verschlechterung. Grund ist ein Bezugstag-Bruch: Das Fenster wird um `now_local` gebaut, das Segment aber auf `stage.date` gesetzt; ab 22:00 UTC zeigen beide auf verschiedene Tage.

Umgesetzt ist stattdessen eine Rechnung in **Minuten seit Ortszeit-Mitternacht des Etappentags** — genau die Größe, die `convert_trip_to_segments` beim Zusammensetzen wieder auseinandernimmt.

## Zwei Wächter, beide eingecheckt und wanduhrunabhängig

| Datei | Was er bewacht |
|---|---|
| `tests/unit/test_arrival_window_fixtures.py` | Die tragende Rechnung als reine Funktion: `range(-1440, 2880)` × 6 Versatz-Familien **ohne Uhr**; dazu 9 Kippkanten × 5 Zeitzonen gegen den echten `convert_trip_to_segments` |
| `tests/tdd/test_fixture_wallclock_ratchet.py` | AST-Ratsche gegen das Anti-Muster, Fluss-Analyse über die Elternkette statt Typ-Aufzählung |

## Adversary: VERIFIED nach drei Runden (2× BROKEN)

Die Befunde trugen und haben den PR substanziell verändert:

- **F001 (CRITICAL):** `freezegun` war installiert, aber **in keiner Testdatei importiert** — alle Nachweise waren einmalige Handläufe, deren Ergebnis nur als Text existierte. Sie wären nie wieder gelaufen, auch nicht in CI.
- **F002/F003 (CRITICAL/HIGH):** Monotonie-Untergrenze und obere Klemme `1439` — beide vom eigenen Docstring als „tragend" bezeichnet — waren von **keinem** Test bewacht. Gezielte Verfälschungen blieben komplett stumm.
- **F004/F007 (HIGH):** Die Ratsche ließ sich über eine Zwischenvariable, eine Liste oder einen Tupel-Rückgabewert vollständig umgehen. Behoben an der Wurzel: Die fehleranfällige Typ-Aufzählung ist ersetzt durch eine Fluss-Analyse.

**Jede dieser Verfälschungen macht jetzt einen eingecheckten Test rot** — belegt mit externer Sicherungskopie und md5-Rückspielung.

## Nebenbefunde

**Die Härtung legte eine 13. betroffene Datei frei**, die auf keiner Liste stand (`test_starkregen_kurzfristhinweis.py`) — die Umgehungslücke hatte sie verdeckt.

**Außerdem korrigiert:** `test_issue_818::test_ac5` war seit PR #1590 rund **19 Stunden täglich rot** — unbemerkt, weil die Datei in `.github/ci_tdd_excludes.txt` steht. Sein Docstring beschrieb bis heute den Stand *vor* #1584. Der `pytest.skip` „now.hour < 4" hat nie bewacht, wofür er dastand: Bei Island (UTC±0) lag die Kante bei 19:00, nicht bei 04:00.

`KNOWN_VIOLATIONS` enthält zwei **begründete** Einträge: Beide Fixturen brauchen ihre exakte Zeitlage als Prüfaussage; eine Klemmung würde sie zerstören. `test_starkregen` ist erst mit S3 (tagesübergreifende Etappen) sauber lösbar.

Fünf weitere Nebenbefunde sind in #1199 gebucht.

## Testlage

- **278 Tests grün**, 0 übersprungen, `ruff` sauber
- **Vollsuite:** 4 rot, alle vorbestehend — 2× Telegram-Konfiguration im Arbeitsordner, 2× auf der CI-Ausnahmeliste. Isoliert **ohne** die neuen Dateien reproduziert, also keine Regression.
- Nach dem Rebase auf 17 neue Commits erneut vollständig grün.

## 🔴 Dieser PR schließt #1667 nicht

Die eigentliche Sicherheitslücke bleibt offen: Ein Wanderer mit Abendstart verliert bis zu **11 h 50 min** Radar-/NowCast-Überwachung, weil `naismith.py:54-60` jede Ankunft auf `23:59` klemmt. Gemessen an `start_time=22:00`: 2 statt 4 Segmente, 15,6 km und 1800 Hm ohne jede Wetterüberwachung, Überwachungsende hart um 00:59 Ortszeit.

Das behebt **S2** (Klemme → Modulo in drei Sprachen) und **S3** (tagesübergreifende Segment-Auswahl). Bis dahin bleibt das Issue offen.

Refs #1667

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Auw6wfip4rmBknYvxQHTCq
