### PR TITLE
feat(#1677): Nutzer-Reihenfolge wirkt in der Trip-Kurzform + Kanal-Metrik-Matrix

### DIFF
--- a/api/routers/validator.py
+++ b/api/routers/validator.py
@@ -148,16 +148,15 @@ def _determine_cascade_source(
     Ermittelt welche Kaskadenstufe aktiv ist: per_report → per_channel → global.
     Eine leere Liste auf Stufe 1/2 ist expliziter User-Wunsch — kein Fallback
     auf die nächste Stufe. Spec: docs/specs/modules/issue_448_validator_metrics_for_channel.md.
+
+    Issue #1677 AC-9: delegiert an ``UnifiedWeatherDisplayConfig.
+    cascade_source_for_channel()`` -- dem models.py-Helfer, den auch das
+    Aktivierungs-Gate der Trip-Kurzform (trip_report.py) nutzt. Kein zweiter,
+    unabhaengig gepflegter Ableitungsweg mehr.
     """
     if dc is None:
         return "global"
-    per_report = (dc.per_report_layouts or {}).get(report_type, {})
-    if channel in per_report:
-        return "per_report"
-    per_channel = dc.per_channel_layouts or {}
-    if channel in per_channel:
-        return "per_channel"
-    return "global"
+    return dc.cascade_source_for_channel(channel, report_type)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/context/fix-1677-sms-reihenfolge.md
+++ b/docs/context/fix-1677-sms-reihenfolge.md
@@ -1,0 +1,75 @@
+# Context: fix-1677-sms-reihenfolge (#1677)
+
+## Request Summary
+
+PO-Auftrag (2026-08-10): Die im Editor per Drag & Drop gezogene Metrik-Reihenfolge
+muss auch in der Trip-Kurzform (SMS/Telegram-Kurzform) wirken — „Der User ist
+Experte, er wird nicht bevormundet." Dazu Vollständigkeits-Tests Kanal × Metrik
+(Scheibe B), damit die Fehlerklasse „Bedienelement ohne Wirkung" strukturell
+bewacht ist (#1450, #1362, #1660 A+B, #1677).
+
+## Gemessener Ist-Zustand (3 Explore-Reports, 2026-08-10)
+
+### Frontend (exp-frontend)
+- Trip-Editor: **Reihenfolge JE KANAL** — `channelBuckets[email|telegram|sms]`
+  (WeatherMetricsTab, Fallback auf globale `buckets`), gespeichert via
+  `PUT /api/trips/{id}/weather-config` als `channel_layouts: {email:[…], telegram:[…], sms:[…]}`.
+  **Es gibt einen eigenen SMS-Tab mit Drag & Drop — dessen Sortierung ist heute wirkungslos.**
+- Compare-Editor: EINE globale Reihenfolge (`wiz.activeMetricKeys`), keine Kanal-Tabs.
+- UI-Beschriftung nennt den Kanal nur über den aktiven Tab („Reihenfolge = von links nach rechts").
+
+### Kanal-Verhalten (exp-channels)
+- **Respektieren die Reihenfolge bereits:** E-Mail (`trip_report.py:135-138` → `dc.metrics`
+  sortiert → `html.py:1021 _col_order`), Telegram rich (`narrow.py:644 render_for_channel`),
+  Ortsvergleich Mail+Kurzform (`comparison.py:668/936-937/1017`, ordnungserhaltendes Dedup).
+- **Lücke NUR Trip-Kurzform:** `trip_report.py:290-293` kollabiert die sortierte Liste aus
+  `get_metrics_for_channel("sms", …)` in ein **Set** (`sms_metric_ids = {…}`); danach sortiert
+  `builder.py::build_token_line` final nach fester `POSITIONAL`-Tabelle (Z. ~465-468).
+- Sortier-Semantik überall: `models.py:647 _sorted_by_layout` — Bucket (primary vor secondary),
+  darin `order`; auf JEDER Kaskaden-Ebene (#1575). SMS hat `max_table_cols=0`
+  (`channel_layout.py:90-95`) — für die flache Zeile zählt effektiv die Gesamt-Listenreihenfolge.
+
+### Pipeline-Bruchstellen bei Umstellung (exp-pipeline)
+- **Bricht:** `builder.py` finale `tokens.sort(POS_INDEX)` (der zentrale Schalter);
+  `render.py::_fuse()` Z.22-44 fusioniert `HR:`+`TH:` (Vigilance) nur bei ADJAZENZ —
+  Format-Pflicht laut `sms_format.md` §3.3.
+- **Bricht (Tests, ~7 Dateien):** `tests/golden/test_sms_golden.py` (5 Goldens +
+  `_assert_positional_order_v2`), `tests/unit/test_token_builder.py`
+  (`test_token_order_positional_per_sms_format_v2`), Goldstrings in
+  `test_sms_official_alert_tokens.py`, `test_sms_unknown_on_missing_data.py` —
+  **nur wenn sich die DEFAULT-Reihenfolge ändert; bleibt der Default POSITIONAL, bleiben sie grün.**
+- **Unabhängig:** Kürzung (`_truncate`/`DROP_ORDER` nach Symbol, `_strip_peaks` nach Kategorie),
+  Alert-SMS (`alert/render.py`, eigene Baustrecke), Compare-Text (`_ordered_rows`, keine
+  Token-Pipeline), `filter_for_subject` (Stub).
+- Doku: `sms_format.md` §2 dokumentiert POSITIONAL als fix → muss versioniert erweitert werden;
+  §3.3 HR:/TH:-Adjazenz bleibt Pflicht.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `src/output/renderers/trip_report.py:289-293` | Set-Kollaps — hier geht die Reihenfolge verloren |
+| `src/output/renderers/sms_trip.py` | `format_sms(…)`-Signatur; Spec-Zusammenbau (Threshold/Disabled/Nullform-Specs) |
+| `src/output/tokens/builder.py` | finale Sortierung `POS_INDEX`; `MetricSpec`-Verbrauch; Schichtgrenze (kein app-Import) |
+| `src/output/tokens/dto.py` | `MetricSpec` (Kandidat für additives `position`-Feld) |
+| `src/output/tokens/render.py` | `_fuse()` (Vigilance-Adjazenz), Kürzung (unabhängig) |
+| `src/app/models.py:647,735-775` | `_sorted_by_layout`, Kanal-Kaskade — Quelle der Ordnung |
+| `docs/reference/sms_format.md` | §2 POSITIONAL (SSoT, Versionierung), §3.3 Adjazenz-Pflicht |
+| `tests/golden/test_sms_golden.py` + `tests/golden/sms/*.txt` | Byte-Identitäts-Wachen des Defaults |
+
+## Risks & Considerations
+
+1. **Drahtformat-Kontrakt:** POSITIONAL ist dokumentierte Format-Zusicherung — Änderung nur als
+   versionierte Erweiterung mit klarem Default (ohne Nutzer-Sortierung: exakt heutige Reihenfolge,
+   byte-identisch — sonst brechen 5 Goldens + Bestandsnutzer-Erwartung).
+2. **System-Blöcke nicht sortierbar:** Vigilance (HR:/TH:-Fusion!), amtlicher Warn-Block (`!`-Marker,
+   sicherheitsrelevant ganz hinten/fix), Fire, `W?`, DBG — Nutzer-Reihenfolge gilt nur für
+   Vorhersage-/Wintersport-Token wählbarer Metriken.
+3. **Mehrfach-Symbole:** temperature→(K,D), wind_chill→(FK,FD,WC), thunder→(TH:,TH+:) — EIN
+   Metrik-Anker, interne Reihenfolge fest; Position folgt der Metrik.
+4. **Schichtgrenze:** `output/tokens/` darf `models.py` nicht lesen — Position muss über
+   `MetricSpec` (additives Feld) oder geordnete Config transportiert werden.
+5. **Kürzungs-Priorität bleibt sicherheitsbasiert** (Anzeige-Reihenfolge ≠ Überlebensrang) —
+   sonst kürzt sich der Experte versehentlich die Gewitterwarnung weg.
+6. **Compare-Kurzform** respektiert Reihenfolge bereits — nicht anfassen (Regressionsgefahr).
+7. **LoC:** Scheibe A moderat; Scheibe B (Matrix-Tests) treibt das Gate-Delta — Override früh ansprechen.

--- a/docs/reference/sms_format.md
+++ b/docs/reference/sms_format.md
@@ -1,7 +1,7 @@
 ---
 entity_id: sms_format
 type: reference
-version: "2.22"
+version: "2.23"
 status: active
 created: 2025-12-27
 updated: 2026-08-10
@@ -13,7 +13,7 @@ tags: [sms, compact, tokens, single-source-of-truth]
 - [x] Approved (v2.0 am 2026-04-25)
 - [x] Implementiert in SMS-Adapter via `src/output/renderers/sms/` (β3, 2026-04-28)
 
-# SMS / Kompakt-Format Specification (v2.22)
+# SMS / Kompakt-Format Specification (v2.23)
 
 **Single Source of Truth** für die kompakte Token-Zeile, die in allen Channels (SMS, Satellit, E-Mail-Header, Push) identisch verwendet wird. Alle anderen Repräsentationen (E-Mail-Body, Tabellen, Push-Titel) leiten sich aus dieser Token-Zeile ab.
 
@@ -77,6 +77,8 @@ Diese Spec ersetzt v1.0 und integriert das Format aus dem Vorgänger-Projekt (`w
 > **Fix #1482 (2026-08-04):** Bis hierhin galten zwei zusätzliche Ist-Abweichungen bei `TH+:` — beide behoben. (a) `TH+:` hing an keinem Eintrag der Metrik-Bindung und erschien deshalb auch bei abgewählter Metrik „Gewitter”; es folgt jetzt derselben Bindung wie `TH:` über `SMS_MULTI_SYMBOLS_BY_METRIC[“thunder”]` (s. Zeile „Forecast (Gewitter Folge-Etappe)” oben). (b) `TH+:` konnte bei einer echten Datenlücke der Folge-Etappe nie `?` werden und zeigte stattdessen fälschlich die Entwarnung `TH+:-`; es zeigt jetzt `TH+:?`, wenn die Folge-Etappe existiert, ihre Gewitterdaten aber nicht beschaffbar waren. Unverändert bleibt `TH+:-`, wenn schlicht kein Folgetag existiert (letzte Etappe des Trips) — diese beiden Fälle dürfen nicht verwechselt werden (s. §3.2 und §4). `TH+:` nutzt außerdem denselben konfigurierten Gewitter-Schwellwert wie `TH:` (vorher hartkodierter Default). Details: `docs/specs/modules/fix_1482_th_plus_metrik_luecke.md`.
 
 > **Fix #1483 (2026-08-05):** Bis hierhin gab es die `?`-Form nur für die Schwellwert-Kürzel `R`/`PR`/`W`/`G`/`TH:`/`TH+:`. Die Temperatur-Kürzel `N`/`K`/`D`/`FN`/`FK`/`FD` durchliefen stattdessen `render_temperature()`, das ausschliesslich Zahl oder `-` lieferte — eine Datenlücke erschien dort folglich als `K-` und war von „geprüft, kein Wert” nicht unterscheidbar. Jetzt nutzen beide Pfade denselben gemeinsamen Helfer `_gap_or()` (`builder.py:120-130`): `_mk_metric()` (Zeile 150, Schwellwert-Kürzel) UND die Temperatur-Schleife in `build_token_line()` (Zeile 299). `_wintersport()` (Schneehöhe/Neuschnee/Schneefallgrenze/Lawinenstufe/Windchill) bleibt bewusst unverändert und zeigt weiterhin nie `?` — es ruft `render_int()` über einen eigenen Pfad auf, der mit `_gap_or()` nichts zu tun hat. Details: `docs/specs/modules/fix_1483_temp_gap_marker.md`.
+
+> **Fix #1677 (2026-08-10, v2.23):** Die in §2 gezeigte Token-Reihenfolge ist ab jetzt der **Default** — sie gilt unverändert, solange für den Kanal `sms` keine kanal-eigene Kaskadenebene aktiv ist (weder `per_report_layouts[report_type].sms` noch `per_channel_layouts.sms`, geprüft über `UnifiedWeatherDisplayConfig.cascade_source_for_channel("sms", report_type)`). Ist eine dieser beiden Ebenen gesetzt, bestimmt die dort im SMS-Kanal-Tab des Trip-Editors per Drag&Drop gezogene Reihenfolge die Anzeigefolge der **Vorhersage-** (`R PR W G TH: TH+: HU DP WD CP PT CT CL CM CH VS SU UV HP NL K D FK FD N FN`) und **Wintersport-Token** (`SD NS24+ SL AV WC`) — jede Metrik ist dabei EIN Anker: bei Mehrfach-Symbol-Metriken (`temperature`→`K D`, `temperature_night`→`N`, `wind_chill`→`FK FD WC`, `wind_chill_night`→`FN`, `thunder`→`TH: TH+:`) erben alle zugehörigen Symbole dieselbe Nutzer-Position, ihre interne Reihenfolge (z.B. `K` vor `D`) bleibt fix. **Unverändert fix, unabhängig von jeder Nutzer-Reihenfolge:** die Vigilance-Adjazenz `HR:TH:` (§3.3, ohne Leerzeichen), der amtliche Warn-Block, Fire (`Z: M:`), `W?` und `DBG` — diese System-Blöcke stehen immer hinter dem sortierbaren Block, in ihrer bisherigen relativen Reihenfolge (sie sind nicht Teil der wählbaren Metrik-Kaskade). Die Kürzung bei Überlänge (§6) bleibt unverändert prioritätsbasiert — die Anzeige-Position beeinflusst NICHT, welches Token zuerst fällt. Details: `docs/specs/modules/fix_1677_sms_reihenfolge.md`.
 
 ---
 

--- a/docs/specs/modules/fix_1677_sms_reihenfolge.md
+++ b/docs/specs/modules/fix_1677_sms_reihenfolge.md
@@ -1,0 +1,325 @@
+---
+entity_id: fix_1677_sms_reihenfolge
+type: module
+created: 2026-08-10
+updated: 2026-08-10
+status: draft
+version: "1.0"
+tags: [metrics, sms, telegram, tokens, briefing, ordering]
+---
+
+<!-- Issue #1677 — Drag&Drop-Reihenfolge des SMS-Kanal-Tabs muss in der
+     zugestellten Trip-Kurzform wirken (PO-Auftrag 2026-08-10: "Der User ist
+     Experte, er wird nicht bevormundet"). Scheibe B: Vollstaendigkeits-Matrix
+     Kanal x Metrik gegen die Fehlerklasse "Bedienelement ohne Wirkung". -->
+
+# SMS-Kurzform: Nutzer-Reihenfolge aus dem SMS-Tab wirkt
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Der Trip-Editor bietet für den SMS-Kanal einen eigenen Tab mit Drag&Drop-
+Metrik-Reihenfolge (`WeatherMetricsTab`, `channel_layouts.sms`) — diese
+Sortierung wird bereits gespeichert und wirkt in E-Mail-Spalten, Telegram-
+rich und dem Ortsvergleich, aber NICHT in der Trip-Kurzform (SMS/Telegram-
+Kurzform): `trip_report.py` kollabiert die sortierte Kaskaden-Liste in ein
+Set, bevor sie `output/tokens/builder.py` erreicht, das anschließend eine
+feste `POSITIONAL`-Tabelle anwendet. PO-Auftrag #1677: die im SMS-Tab
+gezogene Reihenfolge muss dieselbe Wirkung entfalten wie in den anderen
+Kanälen — ohne neue Bedienfläche, denn die Auswahlmechanik existiert
+bereits (Muster von #1660 A/B). Zusätzlich verlangt der PO eine
+Vollständigkeits-Matrix über Metrik-Katalog × Kanal, damit die Fehlerklasse
+„Bedienelement ohne Wirkung" (#1450, #1362, #1660 A/B) strukturell bewacht
+ist statt fallweise entdeckt zu werden.
+
+## Source
+
+> **Schicht-Hinweis:** Änderungen liegen ausschließlich im Python-Core.
+> Quelle der Reihenfolge: `src/app/models.py` (`UnifiedWeatherDisplayConfig`,
+> bereits vorhandene Kaskade). Transport + Sortierung: `src/output/tokens/`
+> (bleibt frei von `src/app/`-Importen — Schichtgrenze). Verdrahtung:
+> `src/output/renderers/trip_report.py`. Doku: `docs/reference/sms_format.md`.
+
+### 1. Quelle der Reihenfolge (`src/app/models.py`) — kein neuer Ableitungsweg
+
+`UnifiedWeatherDisplayConfig.get_metrics_for_channel("sms", report_type)`
+liefert bereits eine nach Editor-Position sortierte **Liste**
+(`_sorted_by_layout`, Issue #1575) über die dreistufige Kaskade
+(per_report > per_channel > global). Diese Scheibe ändert an der Kaskade
+selbst nichts — sie sorgt nur dafür, dass die Listen-**Reihenfolge**, statt
+nur die Listen-**Menge**, den Renderer erreicht.
+
+Neu: eine Methode `UnifiedWeatherDisplayConfig.cascade_source_for_channel(
+channel: str, report_type: str) -> Literal["per_report", "per_channel",
+"global"]`, die exakt dieselben drei Bedingungen wie
+`get_metrics_for_channel` prüft (Ebene 1: `per_report_layouts[report_type]`
+enthält `channel`; Ebene 2: `per_channel_layouts` enthält `channel`; sonst
+`"global"`). `get_metrics_for_channel` und die neue Methode teilen sich die
+Bedingungsprüfung (ein privater Helfer, keine zweite Kopie der drei
+if-Zweige). `api/routers/validator.py::_determine_cascade_source` — bisher
+laut eigenem Docstring ein bewusster **Spiegel** von
+`get_metrics_for_channel` — wird auf einen Aufruf dieser neuen Methode
+umgestellt; damit gibt es für „auf welcher Kaskadenebene antwortet der
+SMS-Kanal?" nur noch EINEN Ableitungsweg, den Produktionscode und
+Validator-Endpoint gemeinsam nutzen (Test-Referenz:
+`tests/integration/test_issue_448_validator_metrics_for_channel.py` bleibt
+grün, da sich das beobachtbare Verhalten des Endpoints nicht ändert).
+
+### 2. Verdrahtung (`src/output/renderers/trip_report.py`)
+
+- Zeile ~290-293 (Set-Kollaps) wird durch die **Liste** ersetzt:
+  `sms_metrics_ordered = _dc_uncollapsed.get_metrics_for_channel("sms",
+  report_type)`. Aus dieser Liste wird weiterhin `sms_metric_ids` (als Menge,
+  für die bestehenden Abwahl-/Schwellwert-Ableitungen darunter unverändert)
+  UND zusätzlich eine `position`-Zuordnung `metric_id -> index` abgeleitet.
+- Aktivierungs-Gate (DEC-2): `position` wird NUR dann an die erzeugten
+  `MetricSpec`-Objekte durchgereicht, wenn
+  `_dc_uncollapsed.cascade_source_for_channel("sms", report_type)` `"per_report"`
+  oder `"per_channel"` ist. Bei `"global"` bleibt `position=None` für ALLE
+  Specs — der Builder fällt dann vollständig auf die bisherige
+  `POSITIONAL`-Sortierung zurück (Byte-Identität, s. DEC-2).
+- Für Mehrfach-Symbol-Metriken (`SMS_MULTI_SYMBOLS_BY_METRIC`: temperature,
+  temperature_night, wind_chill, wind_chill_night, thunder) erhalten
+  **alle** zugehörigen Symbole dieselbe `position` wie ihre Metrik (DEC-5) —
+  die vorhandenen Erzeugungsstellen der jeweiligen `MetricSpec`-Objekte
+  (`_disabled_sms_specs`-Aufbau, `build_extended_metric_specs`) werden um
+  das additive `position`-Feld ergänzt, ohne ihre bestehende
+  enabled/disabled-Logik zu verändern.
+
+### 3. Transport (`src/output/tokens/dto.py`)
+
+`MetricSpec` bekommt ein additives Feld `position: Optional[int] = None`
+(frozen dataclass, Muster #1410/#1660 B — Default hält jeden
+Bestandsaufrufer byte-identisch).
+
+### 4. Sortierung (`src/output/tokens/builder.py::build_token_line`)
+
+Die finale Sortierung (Zeile ~465-468) wird um eine erste Sortierstufe
+erweitert: für jeden Token wird über `by_sym` die zugehörige `MetricSpec`
+nachgeschlagen; trägt sie ein `position`, sortiert der Token danach
+(Bucket 0); alle übrigen Token (kein Symbol-Spec, Spec ohne `position`,
+oder Kategorien, die grundsätzlich nicht sortierbar sind — Vigilance,
+amtliche Warnungen, Fire, `W?`, `DBG`) fallen in Bucket 1 und behalten dort
+exakt die bisherige `POS_INDEX`-Reihenfolge als zweite Sortierstufe. Die
+zweistufige Sortierung `(Bucket, Rang-innerhalb-Bucket)` ist stabil
+(`list.sort`) und garantiert automatisch DEC-4 (System-Blöcke IMMER hinter
+dem sortierbaren Block) — **nicht** durch explizites Verschieben der
+System-Blöcke, sondern weil im Aktiv-Zustand alle sortierbaren Metriken
+durchgehend `position` tragen und alle System-Blöcke nie eine `position`
+haben. Im Default-Zustand (kein `position` bei irgendeinem Token) fallen
+ausnahmslos alle Token in Bucket 1 — die Sortierung ist dann identisch zur
+heutigen einstufigen `POS_INDEX`-Sortierung (Byte-Identität).
+
+Die Kategorien `official_alert` (eigener `OFFICIAL_ALERT_POS`) bleiben von
+dieser Änderung unberührt — amtliche Warnungen sind nicht Teil des
+Metrik-Katalogs und tragen nie eine `position`.
+
+### 5. Kürzung (`src/output/tokens/render.py`) — keine Änderung
+
+`DROP_ORDER`, `PRIORITY` (builder.py) und `_strip_peaks`/`_truncate`
+bleiben unverändert symbol-/prioritätsbasiert (DEC-6). Die
+Anzeige-Reihenfolge (neu: Nutzer-Position) beeinflusst NICHT, welches Token
+beim Kürzen zuerst fällt.
+
+### 6. Doku (`docs/reference/sms_format.md`)
+
+§2 wird versioniert erweitert (v2.23): Klarstellung, dass die in §2
+gezeigte Reihenfolge der **Default** ist (kein SMS-Kanal-Layout aktiv);
+ist eine SMS-spezifische Kaskadenebene (per_report/per_channel) für den
+Trip gesetzt, bestimmt sie die Reihenfolge der Vorhersage-/
+Wintersport-Token, während Vigilance-Adjazenz (§3.3), amtlicher Warn-Block,
+Fire und die Blockstruktur unverändert fix bleiben.
+
+## Estimated Scope
+
+- **LoC:** ~90-140 produktiv (models.py Methode + Helfer-Extraktion ~25,
+  trip_report.py Verdrahtung ~30-40, dto.py 1 Feld, builder.py
+  Sortierschlüssel ~15, validator.py Umstellung auf den Helfer ~10). Scheibe
+  B (Matrix-Tests über den Katalog × 3 Kanäle) treibt das Test-LoC-Delta
+  deutlich über das 250-LoC-Grundlimit.
+- **Files:** ~5 produktiv (`models.py`, `dto.py`, `builder.py`,
+  `trip_report.py`, `api/routers/validator.py`) + 1 Referenz-Doku.
+- **Effort:** medium (Mechanik ist additiv und folgt einem bereits
+  etablierten Muster; die Matrix-Tests sind der größere Aufwandstreiber).
+
+> **⚠️ LoC-Limit:** Mit den parametrisierten Matrix-Tests aus Scheibe B
+> (Katalog × {E-Mail, Telegram-rich, SMS-Kurzform} × {Auswahl, Abwahl,
+> Reihenfolge}) liegt das Gesamt-Delta voraussichtlich über dem
+> 250-LoC-Grundlimit. `workflow.py set-field loc_limit_override` vorab beim
+> PO einholen (CLAUDE.md), nicht erst bei der Blockade.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `fix_1660a_temp_trennung` | Spec | Vorbild-Mechanik (Kanal-Kaskade, DEC-Stil, Kürzel-Bindung) |
+| `fix_1660b_sms_token_wiring` | Spec | 14 erweiterte Metriken, `PRIORITY`/`POSITIONAL`/`DROP_ORDER`-Verdrahtung, die hier NICHT erneut geändert wird |
+| `issue_448_validator_metrics_for_channel` (Archiv) | Spec | Vorhandener `_determine_cascade_source`-Spiegel, wird auf den neuen models.py-Helfer umgestellt |
+| Kanal-Kaskade #429/#434/#1575 (`fix_1575_channel_metric_selection`) | Spec/Feature | Liefert die bereits sortierte SMS-Metrikliste, die diese Scheibe nutzt statt neu zu bauen |
+| `sms_format` | Spec | Token-Grammatik v2.22, wird auf v2.23 fortgeschrieben |
+| `metric_catalog.py` | Modul | Katalog-Reihenfolge als Default-Fallback (unverändert) |
+
+## Implementation Details
+
+Kernänderung in einem Satz: die SMS-Kaskade liefert bereits eine sortierte
+LISTE (`get_metrics_for_channel`), aber `trip_report.py` faltet sie vor der
+Weitergabe in ein Set zusammen — dieser eine Kollaps ist die Bruchstelle.
+Der Fix ersetzt den Kollaps durch eine `position`-Annotation je `MetricSpec`
+(additiv, Default `None`), aktiv nur wenn eine SMS-spezifische Kaskadenebene
+antwortet (sonst bleibt alles beim Alten). `build_token_line` sortiert
+zweistufig: positionierte Token zuerst nach `position`, alle übrigen
+(inkl. sämtlicher System-Blöcke) danach unverändert nach `POS_INDEX`.
+
+## Expected Behavior
+
+- **Input:** Metrik-Reihenfolge aus dem SMS-Kanal-Tab des Trip-Editors
+  (`per_channel_layouts.sms` oder `per_report_layouts[rt].sms`), gespeichert
+  über die bestehende `PUT /api/trips/{id}/weather-config`-Route.
+- **Output:** Trip-Kurzform (SMS-Text und Telegram-Kurzform-Zeile, identische
+  `TokenLine`-Quelle) zeigt die gewählten Vorhersage-/Wintersport-Token in
+  genau der vom Nutzer gezogenen Reihenfolge; System-Blöcke (Vigilance,
+  amtliche Warnungen, Fire, `W?`, `DBG`) bleiben unverändert dahinter in
+  ihrer bisherigen relativen Reihenfolge. Ohne SMS-spezifisches Layout:
+  zeichengleiche Ausgabe zum Vorzustand.
+- **Side effects:** keine neuen Datenabrufe, keine Schema-/Persistenz-
+  Änderung (die Kaskaden-Struktur existiert bereits seit #429/#434); die
+  Kürzungs-Rangfolge bei Überlänge bleibt unverändert sicherheitsbasiert.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip mit SMS-Kanal-Layout (`per_channel_layouts.sms`), in dem die Metriken in der Reihenfolge Böen (`gust`), Wind (`wind`), Niederschlag (`precipitation`) gezogen wurden (Default-Reihenfolge wäre Niederschlag, Wind, Böen) / When das Abendbriefing als SMS erzeugt wird / Then erscheinen die Token in der SMS in der Reihenfolge `G... W... R...` (Böen vor Wind vor Niederschlag), nicht in der Default-Reihenfolge `R... W... G...`.
+  - Test: SMS-Rendering mit realistischem Forecast-Fixture, Assertion auf die exakte Token-Reihenfolge im gerenderten String (Regex-Positionsvergleich, kein bloßer `in`-Check).
+
+- **AC-2:** Given ein Trip OHNE SMS-Kanal-Layout (weder `per_channel_layouts.sms` noch `per_report_layouts[rt].sms` gesetzt, nur eine globale Metrikliste) / When Abend- und Morgenbriefing als SMS gerendert werden / Then ist die Token-Reihenfolge exakt die heutige `POSITIONAL`-Reihenfolge — alle 5 Goldens in `tests/golden/sms/*.txt` bleiben unverändert grün, und ein zusätzlicher Zeichen-für-Zeichen-Vergleich gegen den Stand vor dieser Änderung bestätigt Byte-Identität für ein realistisches Nicht-Golden-Fixture.
+  - Test: bestehende Golden-Suite läuft unverändert; zusätzlicher expliziter String-Vergleich für ein Fixture mit mehreren aktiven Metriken ohne SMS-Layout.
+
+- **AC-3:** Given ein Trip mit `per_channel_layouts.sms` = Reihenfolge A (z.B. Wind, Regen, Böen) UND zusätzlich `per_report_layouts["evening"].sms` = Reihenfolge B (z.B. Böen, Wind, Regen) / When das Abendbriefing gerendert wird / Then folgt die SMS-Token-Reihenfolge B (per_report schlägt per_channel); wird stattdessen das Morgenbriefing gerendert (kein `per_report_layouts["morning"].sms` gesetzt) / Then folgt die SMS-Token-Reihenfolge A (per_channel greift als Fallback).
+  - Test: zwei Renderings desselben Trips (`report_type="morning"`/`"evening"`), Assertion auf jeweils unterschiedliche, korrekt zugeordnete Token-Reihenfolge.
+
+- **AC-4:** Given ein Trip mit SMS-Layout, das Gewitter (`thunder`) an erster Position führt, während zusätzlich echte Vigilance-Daten (`HR:`/`TH:`, französischer Provider) für dieselbe Etappe vorliegen / When die SMS gerendert wird / Then steht das Vorhersage-Gewitter-Token `TH:` (Kategorie `forecast`, Nutzer-Position 0) VOR dem Vigilance-Block, und `HR:`/`TH:` (Kategorie `vigilance`) bleiben unmittelbar aneinander fusioniert (`HR:...TH:...` ohne Leerzeichen dazwischen, §3.3) — unabhängig von der gewählten Nutzer-Reihenfolge.
+  - Test: SMS-Rendering mit Vigilance-Fixture UND aktivem SMS-Layout, Assertion sowohl auf Block-Reihenfolge (forecast vor vigilance) als auch auf die ununterbrochene `HR:...TH:...`-Fusion (Regex ohne Leerzeichen).
+
+- **AC-5:** Given ein Trip mit SMS-Layout, in dem „Temperatur" (`temperature`) an Position 2 und „Gefühlte Temperatur" (`wind_chill`) an Position 0 steht / When die SMS gerendert wird / Then erscheinen `FK`/`FD` (Windchill-Symbole) VOR `K`/`D` (Temperatur-Symbole), und innerhalb jedes Metrik-Ankers bleibt die interne Reihenfolge unverändert (`K` vor `D`, `FK` vor `FD`) — die Nutzer-Position gilt pro Metrik, nicht pro Symbol.
+  - Test: SMS-Rendering mit beiden Metriken aktiv, Assertion auf Block-Reihenfolge (FK/FD-Paar vor K/D-Paar) UND auf die unveränderte interne Paar-Reihenfolge.
+
+- **AC-6:** Given ein Trip mit SMS-Layout, das eine der 14 erweiterten Metriken (z.B. CAPE, `cape`) an erste Position setzt, kombiniert mit einem Fixture, das eine Zeilenlänge >160 Zeichen erzwingt (mehrere Wintersport- und Sicherheitsgrößen aktiv) / When die SMS gerendert und gekürzt wird / Then fällt `CP` trotz Position 0 als eines der ERSTEN Token weg (unverändert nach `DROP_ORDER`, direkt nach `DBG`), bevor auch nur ein Wintersport- oder Sicherheitstoken (`R`/`PR`/`W`/`G`/`TH:`) entfernt wird.
+  - Test: konstruiertes Überlängen-Fixture mit aktivem SMS-Layout, Assertion auf die Reihenfolge des Wegfalls (welche Symbole zuerst verschwinden), nicht nur auf die Endlänge — Gegenprobe: Anzeige-Position ≠ Überlebensrang.
+
+- **AC-7:** Given ein Trip mit SMS-Layout und einer Auswahl aus mindestens zwei Wintersport-Metriken (z.B. `snow_depth`, `avalanche_risk`) UND mindestens einer Vorhersage-Metrik, alle in einer vom Nutzer definierten Reihenfolge, die eine Wintersport-Metrik vor eine Vorhersage-Metrik setzt / When die SMS gerendert wird / Then folgt der Wintersport-Token (z.B. `SD`) direkt der Nutzer-Reihenfolge (erscheint vor dem später positionierten Vorhersage-Token), UND beide stehen trotzdem vor den nicht-sortierbaren System-Blöcken (Vigilance/Fire/`W?`/`DBG`).
+  - Test: SMS-Rendering mit gemischter forecast+wintersport-Reihenfolge, Assertion auf die konkrete Token-Abfolge inkl. der System-Block-Grenze.
+
+- **AC-8:** Given ein Ortsvergleich mit eigener globaler Metrik-Reihenfolge (`comparison.py`) UND ein Trip mit aktiver amtlicher Alarm-Konfiguration (`alert/render.py`, eigene Baustrecke) / When Compare-Kurzform bzw. Alert-SMS gerendert werden / Then bleibt ihre Token-Reihenfolge unverändert zum Stand vor dieser Änderung — bestehende Tests für `comparison.py` und `alert/render.py` laufen ohne Anpassung grün, kein Code in diesen beiden Pfaden wird berührt.
+  - Test: bestehende Compare-SMS- und Alert-SMS-Testsuiten laufen unverändert grün (Regressionsnachweis, kein neuer Testcode nötig, sofern kein Code dort geändert wurde).
+
+- **AC-9:** Given ein Trip mit `cascade_source_for_channel("sms", report_type)` == `"per_channel"` / When derselbe Zustand über `GET /api/_validator/metrics-for-channel?channel=sms&...` abgefragt wird / Then meldet der Validator-Endpoint `source: "per_channel"` — Produktionscode (Aktivierungs-Gate in `trip_report.py`) und Validator-Endpoint verwenden denselben models.py-Helfer, keine zweite, unabhängig gepflegte Bedingungsprüfung.
+  - Test: ein Trip-Fixture wird sowohl über den Validator-Endpoint abgefragt als auch direkt gerendert; Assertion, dass der gemeldete `source`-Wert exakt dann `"per_report"`/`"per_channel"` ist, wenn die Nutzer-Reihenfolge in der SMS tatsächlich wirkt (Kopplung von Meldung und Wirkung).
+
+- **AC-10:** Given ein Trip mit gewählten Metriken aus dem gesamten wählbaren Katalog (forecast + wintersport + die 14 erweiterten Metriken), einmal mit SMS-Layout A und einmal mit SMS-Layout B (zwei disjunkte Permutationen derselben Metrik-Menge) / When die SMS für beide Layouts gerendert wird / Then unterscheiden sich beide Ausgaben AUSSCHLIESSLICH in der Token-Reihenfolge — dieselbe Menge an Symbolen mit denselben Werten, aber zwei nachweisbar verschiedene Reihenfolgen.
+  - Test: zwei Renderings desselben Fixtures mit vertauschtem Layout, Assertion auf identische Symbol-**Menge** UND verschiedene Symbol-**Reihenfolge** (Permutations-Nachweis).
+
+- **AC-11:** Given ein Trip mit SMS-Layout und einer gewählten Metrik aus allen drei Grammatik-Klassen von #1660 B (z.B. `humidity`, `visibility`, `wind_direction`) in einer definierten Nutzer-Reihenfolge / When SMS-Text und Telegram-Kurzform-Zeile für dieselbe Etappe erzeugt werden / Then sind beide Token-Zeilen zeichengleich inklusive der Nutzer-Reihenfolge (gemeinsame `TokenLine`-Quelle, kein zweiter Rendering- oder Sortier-Pfad für Telegram).
+  - Test: Rendering über beide Aufrufer (`SMSTripFormatter`/Telegram-Kurzform-Renderer), String-Vergleich der kompletten Zeile.
+
+- **AC-12:** Given ein Trip mit allen 14 erweiterten Metriken plus mehreren Kern-Metriken in einer vom Nutzer definierten SMS-Reihenfolge, real gegen Staging zugestellt (Test-SMS bzw. E-Mail-Kurzform-Kopfzeile über das Test-Postfach, `GZ_TEST_IMAP_*`) / When die zugestellte Nachricht per IMAP abgerufen und geprüft wird / Then enthält der tatsächlich zugestellte Text die Token in der konfigurierten Nutzer-Reihenfolge — nicht nur eine Zwischenstufe im Renderer-Unit-Test (Prüfort = Wirkort, CLAUDE.md).
+  - Test: `GET /api/preview/<trip>/sms` gegen Staging PLUS eine tatsächlich zugestellte Kurzform-Mail, Muster wie in `fix_1660b_sms_token_wiring` AC-15.
+
+- **AC-13 (Matrix, Scheibe B — E-Mail):** Given jede wählbare Metrik des Katalogs einzeln aktiviert bzw. deaktiviert wird UND in zwei unterschiedlichen Kanal-Reihenfolgen konfiguriert wird / When das E-Mail-Briefing gerendert wird (`format_email`-HTML, Spaltenreihenfolge) / Then wirkt (a) die Aktivierung — die Metrik-Spalte erscheint —, (b) die Deaktivierung — die Spalte verschwindet —, (c) die Reihenfolge — zwei verschiedene Konfigurationen erzeugen zwei nachweisbar verschiedene Spaltenreihenfolgen, jeweils parametrisiert über den vollständigen Metrik-Katalog.
+  - Test: parametrisierter Test über `metric_catalog`-Einträge × {aktiv, inaktiv, Reihenfolge A, Reihenfolge B}, Assertion an der gerenderten HTML-Spaltenstruktur (`_col_order`), nicht an der Konfiguration.
+
+- **AC-14 (Matrix, Scheibe B — Telegram-rich):** Given dieselbe Parametrisierung wie AC-13, aber für das Telegram-rich-Layout (`narrow.py::render_for_channel`) / When das Telegram-Briefing gerendert wird / Then wirken Auswahl, Abwahl und Reihenfolge analog zu AC-13 im narrow-Layout.
+  - Test: parametrisierter Test über den Katalog, Assertion an der gerenderten Telegram-Struktur (Reihenfolge der Bubbles/Zeilen).
+
+- **AC-15 (Matrix, Scheibe B — SMS-Kurzform):** Given dieselbe Parametrisierung wie AC-13, jetzt für die SMS-Kurzform (`report.sms_text`) / When das Briefing als SMS gerendert wird / Then wirken (a) Auswahl, (b) Abwahl, (c) Reihenfolge wie in AC-1, UND zusätzlich (d) ohne gesetztes SMS-Layout ist die Ausgabe für jede Katalog-Metrik byte-identisch zum Stand vor dieser Änderung.
+  - Test: parametrisierter Test über den vollständigen Metrik-Katalog × {aktiv/inaktiv, Reihenfolge A/B, mit/ohne SMS-Layout}, Assertion am gerenderten SMS-String — Ziel: die Fehlerklasse „Bedienelement ohne Wirkung" ist strukturell bewacht statt fallweise entdeckt.
+
+## Known Limitations
+
+1. **Compare-Editor bekommt keine Kanal-Tabs.** Der Ortsvergleich hat eine
+   EINE globale Metrik-Reihenfolge (`wiz.activeMetricKeys`), keine
+   SMS-spezifische Kaskadenebene — die Compare-Kurzform respektiert bereits
+   diese globale Reihenfolge (unverändert, DEC-7). Dass Trip und Compare
+   damit strukturell unterschiedliche Editor-Eingaben für „Reihenfolge"
+   haben, ist ein bekannter Architektur-Mismatch, der hier nur dokumentiert,
+   nicht behoben wird (kein neuer Kanal-Tab für Compare in dieser Scheibe).
+2. **Keine Umsortierung der System-Blöcke.** Vigilance, amtlicher Warn-Block,
+   Fire, `W?`, `DBG` bleiben in ihrer heutigen relativen Reihenfolge und
+   Position (hinter dem sortierbaren Block) — sie sind nicht Teil der
+   wählbaren Metrik-Kaskade und bekommen nie eine `position`.
+3. **Kein neues UI.** Der SMS-Tab mit Drag&Drop existiert bereits; diese
+   Scheibe verdrahtet ausschließlich seine bisher wirkungslose Ausgabe.
+4. **`filter_for_subject` bleibt Stub** (wie in `fix_1660b_sms_token_wiring`
+   dokumentiert) — außerhalb des Scopes dieser Scheibe.
+5. **Keine Reihenfolge-Wirkung in Alert-SMS.** Die alarmgetriebene SMS
+   (`alert/render.py`) nutzt eine eigene Baustrecke ohne `MetricSpec`/
+   `TokenLine`-Kaskade und wird von dieser Scheibe nicht angefasst (DEC-7);
+   eine Nutzer-Reihenfolge für Alarm-Token ist fachlich auch nicht sinnvoll
+   (Alarme sind nach Dringlichkeit, nicht nach Vorliebe sortiert).
+6. **`WC` (Windchill-Wintersport-Token) bleibt praktisch unerreichbar.**
+   Wie in `sms_format.md` §3.6 dokumentiert, entsteht `WC` im Produktivpfad
+   nie (nur Legacy-CLI `profile="wintersport"`) — die Mehrfach-Symbol-Bindung
+   `wind_chill → (FK, FD, WC)` erhält trotzdem dieselbe `position`-Regel wie
+   die übrigen Anker, ohne dass dies über den Trip-Versandweg beobachtbar
+   wäre.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Der Schnitt schließt eine bestehende Lücke in einer bereits
+  etablierten Kaskade (#429/#434/#1575) und einer bereits etablierten
+  Token-Sortier-Infrastruktur (`POSITIONAL`/`POS_INDEX`, zuletzt erweitert
+  durch #1660 A/B) um ein additives Sortierkriterium. Keine neue
+  Persistenz-, Auth- oder Provider-Entscheidungsfläche.
+
+## Prüfhinweis für den Adversary
+
+Leitfrage aus CLAUDE.md: **Ist die Zusicherung dort geprüft, wo sie WIRKT —
+oder nur dort, wo der Code steht?**
+
+1. **AC-2 (Byte-Identität).** Golden-Vergleiche müssen den **gerenderten
+   Text** vergleichen, nicht nur, dass die Tests „grün" sind — ein Test, der
+   nur prüft, dass keine Exception fliegt, deckt eine verschobene
+   Reihenfolge nicht auf.
+2. **AC-4 (System-Block-Grenze / HR:TH:-Fusion).** Ein Test ohne echte
+   Vigilance-Daten kann die Adjazenz-Regel nicht brechen — es braucht ein
+   Fixture, das `HR:`/`TH:` tatsächlich erzeugt, UND ein aktives SMS-Layout,
+   das eine sortierbare Metrik VOR den Vigilance-Block schiebt.
+3. **AC-6 (Kürzung).** Ein Fixture ohne echten Kürzungsdruck (<160 Zeichen)
+   beweist nichts über die Drop-Reihenfolge, egal welche `position` gesetzt
+   ist.
+4. **AC-9 (kein zweiter Ableitungsweg).** Ein Test, der nur den
+   Validator-Endpoint ODER nur den Renderer prüft, deckt ein Auseinanderlaufen
+   beider Pfade nicht auf — es braucht den gekoppelten Vergleich.
+
+**Mutations-Gegenproben (Pflicht, per String-Ersetzung mit externer
+Sicherungskopie — nie `git checkout/stash/reset`):**
+
+- Den Set-Kollaps in `trip_report.py` wieder einführen (`{m.metric_id for m
+  in ...}` statt der Liste) — welcher Test wird rot? (Muss AC-1 sein, nicht
+  nur ein Existenz-Check.)
+- Das Aktivierungs-Gate (DEC-2) entfernen, sodass `position` IMMER gesetzt
+  wird, auch ohne SMS-spezifisches Layout — werden die 5 Goldens
+  (`tests/golden/sms/*.txt`) rot? (Muss der Fall sein, sonst prüft AC-2
+  nichts.)
+- Das `position`-Feld in `build_token_line` ignorieren (Sortierschlüssel
+  bleibt einstufig `POS_INDEX`) — welcher Test bemerkt, dass die
+  Nutzer-Reihenfolge wirkungslos bleibt? (Muss AC-1/AC-7/AC-10 sein.)
+- Bei Mehrfach-Symbol-Metriken nur EINEM der zugehörigen Symbole die
+  `position` zuweisen (z.B. nur `K`, nicht `D`) — fängt AC-5 den
+  auseinanderlaufenden Anker?
+- Den geteilten `cascade_source_for_channel`-Helfer in `trip_report.py`
+  durch eine eigene, unabhängig geschriebene Bedingungsprüfung ersetzen
+  (zweiter Ableitungsweg) und in `api/routers/validator.py` gezielt eine
+  abweichende Formulierung derselben Bedingung belassen — fängt AC-9 das
+  Auseinanderdriften, wenn eine der beiden Stellen künftig geändert wird,
+  ohne die andere nachzuziehen?
+- `DROP_ORDER` unverändert lassen, aber die Kürzungs-Reihenfolge testweise
+  an der `position` statt an `PRIORITY`/`DROP_ORDER` ausrichten — wird AC-6
+  rot? (Belegt, dass Anzeige-Reihenfolge und Überlebensrang tatsächlich
+  entkoppelt geprüft sind.)
+
+## Changelog
+
+- 2026-08-10: Initial spec created (Issue #1677)

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -643,6 +643,33 @@ def _filter_metrics_by_report_type(
 # Issue #1575: Bucket-Rangfolge fuer die Spalten-/Zeilenreihenfolge.
 _BUCKET_RANK = {"primary": 0, "secondary": 1}
 
+CascadeSource = Literal["per_report", "per_channel", "global"]
+
+
+def _cascade_source_for_channel(
+    per_report_layouts: Optional[dict[str, dict[str, list["MetricConfig"]]]],
+    per_channel_layouts: Optional[dict[str, list["MetricConfig"]]],
+    channel: str,
+    report_type: str,
+) -> CascadeSource:
+    """Issue #1677 DEC-2/AC-9: geteilte Bedingungsprüfung, welche Kaskaden-
+    ebene für ``channel``/``report_type`` antwortet -- EXAKT dieselben drei
+    Bedingungen wie ``UnifiedWeatherDisplayConfig.get_metrics_for_channel()``.
+    Genutzt von ``UnifiedWeatherDisplayConfig.cascade_source_for_channel()``
+    UND (indirekt) von ``api/routers/validator.py::_determine_cascade_source``
+    -- damit gibt es fuer diese Frage nur EINEN Ableitungsweg, keine zweite,
+    unabhaengig gepflegte Kopie der drei if-Zweige.
+    """
+    if (
+        per_report_layouts is not None
+        and report_type in per_report_layouts
+        and channel in per_report_layouts[report_type]
+    ):
+        return "per_report"
+    if per_channel_layouts is not None and channel in per_channel_layouts:
+        return "per_channel"
+    return "global"
+
 
 def _sorted_by_layout(metrics: list["MetricConfig"]) -> list["MetricConfig"]:
     """Sortiert nach der im Editor eingestellten Position (Issue #1575).
@@ -745,26 +772,24 @@ class UnifiedWeatherDisplayConfig:
         Issue #1575: JEDE Ebene laeuft durch dieselbe Sortierung nach der im
         Editor eingestellten Position — sonst verhielte sich ein Trip mit
         kanal-eigenen Listen anders als einer ohne.
+
+        Issue #1677 DEC-2: die Ebenen-ERKENNUNG teilt sich mit
+        ``cascade_source_for_channel()`` den Helfer ``_cascade_source_for_
+        channel()`` -- kein zweiter Ableitungsweg fuer dieselbe Frage.
         """
-        # Ebene 1 (#434): per_report_layouts[report_type][channel]
-        if (
-            self.per_report_layouts is not None
-            and report_type in self.per_report_layouts
-            and channel in self.per_report_layouts[report_type]
-        ):
-            report_channel_metrics = self.per_report_layouts[report_type][channel]
+        source = _cascade_source_for_channel(
+            self.per_report_layouts, self.per_channel_layouts, channel, report_type,
+        )
+        if source == "per_report":
+            report_channel_metrics = self.per_report_layouts[report_type][channel]  # type: ignore[index]
             if len(report_channel_metrics) == 0:
                 return []
             return _sorted_by_layout(
                 _filter_metrics_by_report_type(report_channel_metrics, report_type),
             )
 
-        # Ebene 2 (#429): per_channel_layouts[channel]
-        if (
-            self.per_channel_layouts is not None
-            and channel in self.per_channel_layouts
-        ):
-            channel_metrics = self.per_channel_layouts[channel]
+        if source == "per_channel":
+            channel_metrics = self.per_channel_layouts[channel]  # type: ignore[index]
             if len(channel_metrics) == 0:
                 return []
             return _sorted_by_layout(
@@ -773,6 +798,20 @@ class UnifiedWeatherDisplayConfig:
 
         # Ebene 3: globaler Fallback
         return _sorted_by_layout(self.get_metrics_for_report_type(report_type))
+
+    def cascade_source_for_channel(self, channel: str, report_type: str) -> CascadeSource:
+        """Issue #1677 AC-9: auf welcher Kaskadenebene antwortet
+        ``get_metrics_for_channel()`` fuer diesen Kanal/Report-Typ?
+
+        Teilt sich die Bedingungsprüfung mit ``get_metrics_for_channel()``
+        (``_cascade_source_for_channel()``) -- der Validator-Spiegel
+        ``api/routers/validator.py::_determine_cascade_source`` ruft diese
+        Methode ebenfalls auf, statt eine eigene Kopie der drei if-Zweige zu
+        pflegen.
+        """
+        return _cascade_source_for_channel(
+            self.per_report_layouts, self.per_channel_layouts, channel, report_type,
+        )
 
 
 # --- Ausblick-Zustand (Fix #1486) ---

--- a/src/output/renderers/sms_trip.py
+++ b/src/output/renderers/sms_trip.py
@@ -119,7 +119,10 @@ SMS_SYMBOL_BY_METRIC: dict[str, str] = {
 }
 
 
-def build_extended_metric_specs(active_metric_ids: set[str]) -> list[MetricSpec]:
+def build_extended_metric_specs(
+    active_metric_ids: set[str],
+    position_by_metric: Optional[dict[str, int]] = None,
+) -> list[MetricSpec]:
     """#1660 B Fix-Loop: MetricSpecs fuer die 14 erweiterten Metriken in BEIDEN
     Faellen (Muster #1410, wie schon SMS_MULTI_SYMBOLS_BY_METRIC unten fuer
     die Temperatur-Trios) -- nur so erreicht die Null-Form (§9 der Spec) den
@@ -127,11 +130,18 @@ def build_extended_metric_specs(active_metric_ids: set[str]) -> list[MetricSpec]
     14 bisher ausschliesslich in der disabled-only-Schleife (Bug #944), eine
     aktive Metrik ohne Daten bekam dadurch NIE eine Spec und builder.py's
     `if spec is None and not samples: continue`-Gate liess sie komplett
-    entfallen statt '{symbol}-' zu rendern."""
+    entfallen statt '{symbol}-' zu rendern.
+
+    Issue #1677 DEC-2: ``position_by_metric`` ist additiv (Default None ->
+    leeres Dict, jedes Symbol bekommt ``position=None``, byte-identisch zum
+    Vorzustand). Der Aufrufer (trip_report.py) uebergibt nur dann Werte,
+    wenn eine SMS-spezifische Kaskadenebene aktiv ist (Aktivierungs-Gate)."""
+    position_by_metric = position_by_metric or {}
     return [
         MetricSpec(
             symbol=SMS_SYMBOL_BY_METRIC[metric_id],
             enabled=metric_id in active_metric_ids,
+            position=position_by_metric.get(metric_id),
         )
         for metric_id in SMS_NULLFORM_METRIC_IDS
     ]
@@ -740,8 +750,31 @@ class SMSTripFormatter:
         # regulär wie jeder andere Metrik-Block -- ohne diesen Eintrag würden
         # sie bei vorhandenen Schneedaten erscheinen. _visible(spec_with_
         # enabled_false) -> False unterdrückt sie genau wie jede andere Metrik.
+        # Issue #1677 Fix-Loop F001 (Adversary CRITICAL): `disabled_specs`
+        # traegt seit #1677 auch die Nutzer-`position` fuer AKTIVE Kern-/
+        # Wintersport-Symbole (trip_report.py). Ein Symbol mit konfiguriertem
+        # `sms_threshold` (#624) belegt sein Symbol aber bereits VORHER in
+        # `config` (Schleife oben) -- OHNE position. Der reine "nur wenn
+        # Symbol fehlt"-Filter (`s.symbol not in existing_syms`) verwarf die
+        # positionstragende Spec aus `disabled_specs` dadurch STILL, sobald
+        # beide Features (#624 + #1677) fuer dieselbe Metrik kombiniert
+        # wurden. Jetzt wird bei Symbol-Kollision `position` NACHGETRAGEN
+        # (Feld-Merge, exakt wie der bestehende threshold-Merge oben) statt
+        # die zweite Spec zu verwerfen -- EIN Config-Eintrag pro Symbol
+        # bleibt Invariante, aber keines seiner additiven Felder geht mehr
+        # verloren.
         if disabled_specs:
             existing_syms = {s.symbol for s in config}
+            position_by_sym = {
+                s.symbol: s.position for s in disabled_specs if s.position is not None
+            }
+            if position_by_sym:
+                config = [
+                    replace(s, position=position_by_sym[s.symbol])
+                    if s.symbol in position_by_sym and s.position is None
+                    else s
+                    for s in config
+                ]
             config.extend(s for s in disabled_specs if s.symbol not in existing_syms)
 
         token_line = build_token_line(

--- a/src/output/renderers/trip_report.py
+++ b/src/output/renderers/trip_report.py
@@ -287,10 +287,23 @@ class TripReportFormatter:
         # SMS-eigenen Kaskade (per_report > per_channel > global), der
         # SCHWELLWERT je Metrik bleibt eine globale Groesse (KL-4) -- die vom
         # Editor geschriebenen Kanal-Layouts fuehren kein ``sms_threshold``.
-        sms_metric_ids = {
-            m.metric_id
-            for m in _dc_uncollapsed.get_metrics_for_channel("sms", report_type)
-        }
+        # Issue #1677: die Kaskade liefert eine bereits sortierte LISTE
+        # (nicht laenger sofort in ein Set kollabiert) -- daraus wird
+        # weiterhin die Menge (sms_metric_ids, fuer die Abwahl-/Schwellwert-
+        # Ableitungen darunter unveraendert) UND zusaetzlich eine
+        # metric_id -> Index-Zuordnung fuer die Nutzer-Position abgeleitet.
+        _sms_metrics_ordered = _dc_uncollapsed.get_metrics_for_channel("sms", report_type)
+        sms_metric_ids = {m.metric_id for m in _sms_metrics_ordered}
+        # Aktivierungs-Gate (DEC-2): position wird NUR gesetzt, wenn eine
+        # SMS-spezifische Kaskadenebene antwortet -- bei 'global' bleibt
+        # jede Spec ohne position, der Builder faellt vollstaendig auf die
+        # bisherige POSITIONAL-Sortierung zurueck (Byte-Identitaet, AC-2).
+        _sms_cascade_source = _dc_uncollapsed.cascade_source_for_channel("sms", report_type)
+        _sms_position_by_metric: dict[str, int] = (
+            {m.metric_id: i for i, m in enumerate(_sms_metrics_ordered)}
+            if _sms_cascade_source in ("per_report", "per_channel")
+            else {}
+        )
         _global_metrics = {m.metric_id: m for m in _dc_uncollapsed.metrics}
         # Issue #624: konfigurierte Schwellwerte aus MetricConfig ableiten.
         _sms_thr = {
@@ -313,23 +326,40 @@ class TripReportFormatter:
         # Bug #944: SMS-Symbole ohne aktive Metrik als deaktivierte Specs führen,
         # damit SD/SL nicht erscheinen, wenn die Metrik im Trip nicht gewählt ist —
         # unabhängig davon, ob Schneedaten in der Vorhersage vorhanden sind.
+        # Issue #1677: die Schleife deckt jetzt BEIDE Faelle ab (aktiv UND
+        # abgewaehlt), nicht mehr nur die Abwahl -- vorher entstand fuer
+        # AKTIVE Kern-/Wintersport-Symbole (R/PR/W/G/SD/SL/NS24+) gar keine
+        # Spec (Builder nutzte den spec=None-Default-Zweig), also auch keine
+        # Stelle, an der eine Nutzer-Position haengen konnte. enabled/disabled
+        # bleibt dabei exakt die bisherige Bug-#944-Logik.
         active_metric_ids = sms_metric_ids
         _disabled_sms_specs = [
-            MetricSpec(symbol=sym, enabled=False)
+            MetricSpec(
+                symbol=sym,
+                enabled=metric_id in active_metric_ids,
+                position=_sms_position_by_metric.get(metric_id),
+            )
             for metric_id, sym in SMS_SYMBOL_BY_METRIC.items()
-            if metric_id not in active_metric_ids
-            # Fix-Loop #1660 B: die 14 erweiterten Metriken sind hier
-            # AUSGENOMMEN -- sie bekommen unten ueber build_extended_metric_
-            # specs() eine Spec in BEIDEN Faellen (aktiv UND abgewaehlt), nicht
-            # nur bei Abwahl. Ohne diese Ausnahme entstuenden doppelte Specs
-            # fuer dasselbe Symbol.
-            and metric_id not in SMS_NULLFORM_METRIC_IDS
+            if (
+                # Fix-Loop #1660 B: die 14 erweiterten Metriken sind hier
+                # AUSGENOMMEN -- sie bekommen unten ueber build_extended_metric_
+                # specs() eine Spec in BEIDEN Faellen (aktiv UND abgewaehlt), nicht
+                # nur bei Abwahl. Ohne diese Ausnahme entstuenden doppelte Specs
+                # fuer dasselbe Symbol.
+                metric_id not in SMS_NULLFORM_METRIC_IDS
+                # 'thunder' bekommt seine Spec(s) ausschliesslich ueber die
+                # SMS_MULTI_SYMBOLS_BY_METRIC-Schleife unten (TH:/TH+:) --
+                # sonst entstuende ein zweiter, konkurrierender 'TH:'-Eintrag.
+                and metric_id != "thunder"
+            )
         ]
         # Root-Cause-Fix (Adversary/Staging-E2E #1660 B, Prod-Bug): vorher
         # bekamen aktive der 14 Metriken KEINE Spec -> builder.py's
         # `if spec is None and not samples: continue` liess sie bei fehlenden
         # Daten komplett entfallen statt die Null-Form (§9) zu rendern.
-        _disabled_sms_specs += build_extended_metric_specs(active_metric_ids)
+        _disabled_sms_specs += build_extended_metric_specs(
+            active_metric_ids, _sms_position_by_metric,
+        )
         # Issue #1410 §6: die Temperatur-Token erscheinen NUR bei aktivierter
         # Metrik -- dasselbe Pruefmuster wie oben fuer SD/SL. Anders als dort
         # wird die Spec in BEIDEN Faellen mitgegeben: nur so kann der Builder
@@ -338,8 +368,14 @@ class TripReportFormatter:
         # Issue #1415: gilt jetzt auch fuer die GEMESSENE Temperatur (N/K/D);
         # sie war bis dahin unbedingt und blieb als einzige Groesse auch nach
         # Abwahl in der SMS stehen.
+        # Issue #1677 DEC-5: alle Symbole EINER Mehrfach-Symbol-Metrik
+        # erben dieselbe position (EIN Metrik-Anker, kein Pro-Symbol-Drift).
         _disabled_sms_specs += [
-            MetricSpec(symbol=sym, enabled=metric_id in active_metric_ids)
+            MetricSpec(
+                symbol=sym,
+                enabled=metric_id in active_metric_ids,
+                position=_sms_position_by_metric.get(metric_id),
+            )
             for metric_id, syms in SMS_MULTI_SYMBOLS_BY_METRIC.items()
             for sym in syms
         ]

--- a/src/output/tokens/builder.py
+++ b/src/output/tokens/builder.py
@@ -102,6 +102,13 @@ POS_INDEX = {key: i for i, key in enumerate(POSITIONAL)}
 OFFICIAL_ALERT_POS = POS_INDEX[(VIGI_TH, "vigilance")] + 0.5
 STD_SYMBOLS = {s for s, _ in POSITIONAL}
 
+# Issue #1677 DEC-4/Known Limitation 2: nur diese beiden Kategorien gehoeren
+# zur waehlbaren Metrik-Kaskade und duerfen ueber MetricSpec.position sortiert
+# werden. Vigilance teilt sich das Symbol 'TH:' mit 'forecast' (Adversary-
+# Hinweis 2, AC-4) -- die Kategorie-Pruefung verhindert, dass eine
+# Vorhersage-Position auf den Vigilance-Token durchschlaegt.
+_POSITION_SORTABLE_CATEGORIES = {"forecast", "wintersport"}
+
 DEFAULTS = {"R": 0.2, "PR": 20.0, "W": 10.0, "G": 20.0,
             FORECAST_TH: 1.0, FORECAST_THP: 1.0}
 
@@ -462,10 +469,26 @@ def build_token_line(
             "debug", PRIORITY["DBG"],
         ))
 
-    tokens.sort(key=lambda t: (
-        OFFICIAL_ALERT_POS if t.category == "official_alert"
-        else POS_INDEX.get((t.symbol, t.category), 99)
-    ))
+    # Issue #1677: zweistufige Sortierung. Bucket 0 = Token, deren MetricSpec
+    # eine Nutzer-Position traegt (nur 'forecast'/'wintersport' -- die
+    # waehlbare Metrik-Kaskade; Vigilance/amtliche Warnungen/Fire/W?/DBG
+    # sind strukturell nicht sortierbar, DEC-4/Known Limitation 2), sortiert
+    # nach dieser Position. Bucket 1 = alle uebrigen Token, unveraendert nach
+    # der bisherigen POS_INDEX-Reihenfolge. Ohne jede Position (kein
+    # SMS-Kanal-Layout aktiv) fallen ausnahmslos alle Token in Bucket 1 --
+    # die Sortierung ist dann identisch zur bisherigen einstufigen
+    # POS_INDEX-Sortierung (Byte-Identitaet, AC-2).
+    def _sort_key(t: Token) -> tuple[int, float]:
+        spec = by_sym.get(t.symbol) if t.category in _POSITION_SORTABLE_CATEGORIES else None
+        if spec is not None and spec.position is not None:
+            return (0, spec.position)
+        fallback = (
+            OFFICIAL_ALERT_POS if t.category == "official_alert"
+            else POS_INDEX.get((t.symbol, t.category), 99)
+        )
+        return (1, fallback)
+
+    tokens.sort(key=_sort_key)
     return TokenLine(
         stage_name=_sanitize_stage_name(stage_name), report_type=report_type,
         tokens=tuple(tokens), truncated=False, full_length=0,

--- a/src/output/tokens/dto.py
+++ b/src/output/tokens/dto.py
@@ -109,6 +109,10 @@ class MetricSpec:
     # When set to "symbol" or "scale", the builder emits a friendly token
     # bit-identical to legacy use_friendly_format=True (Backward-Compat).
     format_mode: Optional[str] = None
+    # Issue #1677: additive Nutzer-Anzeigeposition (SMS-Kanal-Layout-Index).
+    # None (Default) -> Bestandsaufrufer bleiben byte-identisch, builder.py
+    # sortiert dann ausschliesslich nach der bisherigen POSITIONAL-Tabelle.
+    position: Optional[int] = None
 
 
 @dataclass(frozen=True)

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -1,0 +1,244 @@
+"""TDD RED: Issue #1677 Scheibe B -- Vollstaendigkeits-Matrix Metrik-Katalog x
+Kanal, damit die Fehlerklasse "Bedienelement ohne Wirkung" (#1450, #1362,
+#1660 A/B, #1677) strukturell bewacht ist statt fallweise entdeckt zu werden.
+
+SPEC: docs/specs/modules/fix_1677_sms_reihenfolge.md AC-13/AC-14/AC-15.
+
+Parametrisiert ueber ``app.metric_catalog.get_all_metrics()`` (26
+waehlbare Metriken). Pro Kanal wird gegen die Funktion getestet, die der
+jeweilige Produktivpfad TATSAECHLICH aufruft (kein Duplikat-Rendering):
+- E-Mail:        ``resolve_metric_col_order`` (email/html.py:1021 ``_col_order``)
+- Telegram-rich: ``render_for_channel`` (narrow.py:644)
+- SMS-Kurzform:  ``TripReportFormatter().format_email() -> report.sms_text``
+  (derselbe Wirkort wie test_sms_user_metric_order.py)
+
+AC-Zuordnung:
+- AC-13 (E-Mail):        test_ac13_email_column_selection_and_order       -> GRUEN (Bestand, #1575)
+- AC-14 (Telegram-rich):  test_ac14_telegram_rich_selection_and_order      -> GRUEN (Bestand, #429/#1575)
+- AC-15 (SMS-Kurzform):   test_ac15_sms_kurzform_selection_deselection_and_order
+    - (a)/(b) Auswahl/Abwahl -> GRUEN (Bestand, Bug-#944-Muster + #1415/#1660B)
+    - (c) Nutzer-Reihenfolge -> RED (exakt die Luecke aus #1677)
+    - (d) ohne SMS-Layout   -> GRUEN (Charakterisierung, wie AC-2)
+
+E-Mail/Telegram sind bewusste GRUEN-Ausnahmen (Bestandsfunktion, hier nur
+strukturell abgesichert) -- der SMS-Kurzform-Reihenfolge-Teil ist der
+einzige neue, heute rote Anteil dieser Datei.
+"""
+from __future__ import annotations
+
+import dataclasses
+import re
+
+import pytest
+
+from app.metric_catalog import get_all_metrics, get_metric
+from app.models import MetricConfig, UnifiedWeatherDisplayConfig
+from output.renderers.channel_layout import render_for_channel
+from output.renderers.email.helpers import resolve_metric_col_order
+from output.renderers.sms_trip import SMS_SYMBOL_BY_METRIC, SMS_MULTI_SYMBOLS_BY_METRIC
+from output.renderers.trip_report import TripReportFormatter
+
+from tests.tdd import _min_temp_felt_fixtures as F
+
+_ALL_METRIC_IDS = [m.id for m in get_all_metrics()]
+
+# #1484/#1660 A: Nachtfenster-Skalare sind bewusst NIE eine Telegram-rich-
+# Tabellen-/Detailzelle (channel_layout.py:85-89 ``_NIGHT_SCALAR_IDS``) --
+# strukturelle Ausnahme, kein Auswahl-Bug.
+_TELEGRAM_NIGHT_SCALAR_EXCEPTIONS = {"temperature_night", "wind_chill_night"}
+
+
+def _partner_of(metric_id: str) -> str:
+    """Sichere Partner-Metrik ohne Symbol-Praefix-Kollision (K ist bei
+    keinem anderen Katalog-Kuerzel Praefix, s. Kollisionsanalyse im Kontext-
+    Dokument der Spec)."""
+    return "wind" if metric_id == "temperature" else "temperature"
+
+
+def _single_metric_dc(metric_id: str, *, enabled: bool, order: int = 0) -> UnifiedWeatherDisplayConfig:
+    return UnifiedWeatherDisplayConfig(
+        trip_id="x1677",
+        metrics=[MetricConfig(metric_id=metric_id, enabled=enabled, order=order)],
+    )
+
+
+def _two_metric_dc(first: str, second: str) -> UnifiedWeatherDisplayConfig:
+    return UnifiedWeatherDisplayConfig(
+        trip_id="x1677",
+        metrics=[
+            MetricConfig(metric_id=first, enabled=True, order=0),
+            MetricConfig(metric_id=second, enabled=True, order=1),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-13: E-Mail -- resolve_metric_col_order(dc), Bestand (#1575)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("metric_id", _ALL_METRIC_IDS)
+def test_ac13_email_column_selection_and_order(metric_id):
+    col_key = get_metric(metric_id).col_key
+    other_id = _partner_of(metric_id)
+    other_key = get_metric(other_id).col_key
+
+    assert col_key in resolve_metric_col_order(_single_metric_dc(metric_id, enabled=True)), (
+        f"(a) {metric_id} aktiv -> Spalte {col_key!r} muss erscheinen"
+    )
+    assert col_key not in resolve_metric_col_order(_single_metric_dc(metric_id, enabled=False)), (
+        f"(b) {metric_id} inaktiv -> Spalte {col_key!r} darf nicht erscheinen"
+    )
+
+    order_a = resolve_metric_col_order(_two_metric_dc(metric_id, other_id))
+    order_b = resolve_metric_col_order(_two_metric_dc(other_id, metric_id))
+    assert order_a.index(col_key) < order_a.index(other_key), (
+        f"(c) Reihenfolge A ({metric_id} vor {other_id}): {order_a}"
+    )
+    assert order_b.index(other_key) < order_b.index(col_key), (
+        f"(c) Reihenfolge B ({other_id} vor {metric_id}): {order_b}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-14: Telegram-rich -- render_for_channel("telegram", ...), Bestand (#429/#1575)
+# ---------------------------------------------------------------------------
+
+
+def _telegram_cells(dc: UnifiedWeatherDisplayConfig) -> list[str]:
+    layout = render_for_channel("telegram", dc, "evening")
+    return layout.table_columns + layout.detail_metrics
+
+
+@pytest.mark.parametrize("metric_id", _ALL_METRIC_IDS)
+def test_ac14_telegram_rich_selection_and_order(metric_id):
+    if metric_id in _TELEGRAM_NIGHT_SCALAR_EXCEPTIONS:
+        assert metric_id not in _telegram_cells(_single_metric_dc(metric_id, enabled=True))
+        assert metric_id not in _telegram_cells(_single_metric_dc(metric_id, enabled=False))
+        return
+
+    other_id = _partner_of(metric_id)
+    assert metric_id in _telegram_cells(_single_metric_dc(metric_id, enabled=True)), (
+        f"(a) {metric_id} aktiv -> muss in Telegram-rich Tabelle/Detail erscheinen"
+    )
+    assert metric_id not in _telegram_cells(_single_metric_dc(metric_id, enabled=False)), (
+        f"(b) {metric_id} inaktiv -> darf nicht erscheinen"
+    )
+
+    cells_a = _telegram_cells(_two_metric_dc(metric_id, other_id))
+    cells_b = _telegram_cells(_two_metric_dc(other_id, metric_id))
+    assert cells_a.index(metric_id) < cells_a.index(other_id), (
+        f"(c) Reihenfolge A ({metric_id} vor {other_id}): {cells_a}"
+    )
+    assert cells_b.index(other_id) < cells_b.index(metric_id), (
+        f"(c) Reihenfolge B ({other_id} vor {metric_id}): {cells_b}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-15: SMS-Kurzform -- report.sms_text, EINZIGER roter Anteil dieser Datei
+# ---------------------------------------------------------------------------
+
+
+def _matrix_segment():
+    """EIN Trip-Fixture (Spec-Vorgabe "effizient halten"): F.segment() plus
+    reale (nicht-None) Wintersport-Aggregate -- ohne das haben snow_depth/
+    snowfall_limit/fresh_snow KEINE Null-Form (anders als die 14 erweiterten
+    Metriken aus #1660 B) und wuerden bei F.segment() pur gar keinen Token
+    erzeugen, unabhaengig von der Auswahl -- das waere ein Messfehler, kein
+    Befund zu #1677."""
+    seg = F.segment()
+    agg = dataclasses.replace(
+        seg.aggregated, snow_depth_cm=20.0, snowfall_limit_m=1800.0, snow_new_sum_cm=3.0,
+    )
+    return dataclasses.replace(seg, aggregated=agg)
+
+
+def _render_sms(dc: UnifiedWeatherDisplayConfig) -> str:
+    report = TripReportFormatter().format_email(
+        [_matrix_segment()], trip_name="Issue1677Matrix", report_type="evening",
+        night_weather=F.night_weather(), display_config=dc,
+        stage_name=F.STAGE_NAME, tz=F.TZ,
+    )
+    return report.sms_text
+
+
+def _representative_symbol(metric_id: str) -> str:
+    if metric_id in SMS_MULTI_SYMBOLS_BY_METRIC:
+        return SMS_MULTI_SYMBOLS_BY_METRIC[metric_id][0]
+    return SMS_SYMBOL_BY_METRIC[metric_id]
+
+
+# sms_format.md §5: der Threshold+Peak-Block traegt '(' ')' und '%'
+# (Prozent-Schreibweise, "Wahrscheinlichkeit (%)"), und TH:/TH+: sind
+# is_level (builder.py LEVELS = {0:'-',1:'L',2:'M',3:'H'}) -- ohne diese
+# Zeichen/Buchstaben fand die urspruengliche Grammatik weder die
+# Kern-Vorhersage-Token (R/PR/W/G, die ueber render_threshold_peak_value()
+# mit Default-Schwellwert IMMER den Peak-Block tragen) noch das Gewitter-
+# Stufen-Token 'TH:M@11' (Testfehler gegen sms_format.md §5/§3, Erwartung
+# unveraendert). Die Stufen-Buchstaben stehen bewusst nur unmittelbar vor
+# '@'/Ende/Klammer-Ende (Praefix-Kollisionsschutz z.B. 'N' vs. 'NL-'
+# unveraendert, s. test_sms_user_metric_order.py::_VALUE_GRAMMAR).
+_GRAMMAR_SUFFIX = re.compile(
+    r"(?:(?:\d+(?:\.\d+)?%?|[LMH])(?:@\d+(?:\((?:\d+(?:\.\d+)?%?|[LMH])@\d+\))?)?|-|\?)$"
+)
+
+
+def _first_index_starting_with(sms: str, symbol: str) -> int | None:
+    """Index des ersten Tokens, der mit ``symbol`` beginnt und danach nur aus
+    Wert-Grammatik-Zeichen besteht (Praefix-Kollisionen sind fuer die hier
+    verwendeten Partner-Paare ausgeschlossen, s. ``_partner_of``)."""
+    body = sms.split(": ", 1)[1] if ": " in sms else sms
+    for i, tok in enumerate(body.split(" ")):
+        if tok.startswith(symbol) and _GRAMMAR_SUFFIX.fullmatch(tok[len(symbol):]):
+            return i
+    return None
+
+
+def _sms_order_dc(order: list[str]) -> UnifiedWeatherDisplayConfig:
+    metrics = [MetricConfig(metric_id=m, enabled=True) for m in order]
+    sms_layout = [
+        MetricConfig(metric_id=m, enabled=True, bucket="primary", order=i)
+        for i, m in enumerate(order)
+    ]
+    return UnifiedWeatherDisplayConfig(
+        trip_id="x1677", metrics=metrics, per_channel_layouts={"sms": sms_layout},
+    )
+
+
+@pytest.mark.parametrize("metric_id", _ALL_METRIC_IDS)
+def test_ac15_sms_kurzform_selection_deselection_and_order(metric_id):
+    symbol = _representative_symbol(metric_id)
+    partner_id = _partner_of(metric_id)
+    partner_symbol = _representative_symbol(partner_id)
+
+    # (a)/(b) Auswahl/Abwahl -- heute bereits GRUEN (Bug-#944-Muster +
+    # #1415/#1660 B bewachen das schon).
+    sms_on = _render_sms(_two_metric_dc(metric_id, partner_id))
+    sms_off = _render_sms(_single_metric_dc(partner_id, enabled=True))
+    assert _first_index_starting_with(sms_on, symbol) is not None, (
+        f"(a) {metric_id} aktiv -> Symbol {symbol!r} muss erscheinen: {sms_on!r}"
+    )
+    assert _first_index_starting_with(sms_off, symbol) is None, (
+        f"(b) {metric_id} nicht gewaehlt -> kein {symbol!r}-Token: {sms_off!r}"
+    )
+
+    # (c) Nutzer-Reihenfolge -- DER rote Anteil: heute wird jede SMS-Kanal-
+    # Layout-Reihenfolge auf dieselbe feste POSITIONAL-Tabelle abgebildet.
+    sms_a = _render_sms(_sms_order_dc([metric_id, partner_id]))
+    sms_b = _render_sms(_sms_order_dc([partner_id, metric_id]))
+    ia_m = _first_index_starting_with(sms_a, symbol)
+    ia_p = _first_index_starting_with(sms_a, partner_symbol)
+    ib_m = _first_index_starting_with(sms_b, symbol)
+    ib_p = _first_index_starting_with(sms_b, partner_symbol)
+    assert ia_m is not None and ia_p is not None and ia_m < ia_p, (
+        f"(c) Reihenfolge A ({metric_id} vor {partner_id}) nicht umgesetzt: {sms_a!r}"
+    )
+    assert ib_m is not None and ib_p is not None and ib_p < ib_m, (
+        f"(c) Reihenfolge B ({partner_id} vor {metric_id}) nicht umgesetzt: {sms_b!r}"
+    )
+
+    # (d) ohne SMS-Layout -- Charakterisierung wie AC-2: heutiges Verhalten
+    # bleibt der Bezugspunkt, kein RED.
+    sms_default = _render_sms(_two_metric_dc(metric_id, partner_id))
+    assert _first_index_starting_with(sms_default, symbol) is not None

--- a/tests/tdd/test_sms_user_metric_order.py
+++ b/tests/tdd/test_sms_user_metric_order.py
@@ -1,0 +1,554 @@
+"""TDD RED: Issue #1677 -- die im SMS-Kanal-Tab gezogene Metrik-Reihenfolge
+muss in der zugestellten Trip-Kurzform (SMS/Telegram-Kurzform) wirken.
+
+SPEC: docs/specs/modules/fix_1677_sms_reihenfolge.md (AC-1..AC-11).
+
+Wirkort-Prinzip (CLAUDE.md "Pruefort = Wirkort", Muster
+tests/tdd/test_sms_extended_null_forms.py): fast alle Tests hier fahren den
+ECHTEN Produktionspfad ``TripReportFormatter().format_email() -> report.
+sms_text`` -- keine an Ort und Stelle konstruierten ``MetricSpec``-Objekte.
+
+Ausnahme AC-4: Vigilance-Daten (``provider="meteofrance"``,
+``vigilance_hr_level``/``vigilance_th_level``) erreichen den Trip-SMS-Pfad
+strukturell NICHT -- ``SMSTripFormatter._build_normalized_forecast()`` setzt
+weder ``provider`` noch die Vigilance-Felder (Grep-Beleg 2026-08-10: nur
+Direktaufrufe in ``tests/unit/test_token_builder.py``,
+``tests/golden/test_sms_golden.py``, ``tests/unit/test_renderers_sms.py``
+bauen echte Vigilance-Fixtures). Der Wirkort der NEUEN Sortierung ist ohnehin
+``output/tokens/builder.py::build_token_line`` (Implementation Details
+Punkt 4 der Spec) -- AC-4 faehrt deshalb genau diese Ebene direkt.
+
+AC-Zuordnung (Kopf-Kommentar UND Rueckmeldung):
+- AC-1: test_ac1_sms_channel_layout_order_wins_over_default            -> RED
+- AC-2: test_ac2_default_order_byte_identical_without_sms_layout       -> GRUEN (Charakterisierung, Bestand)
+- AC-3: test_ac3_per_report_layout_overrides_per_channel_layout        -> RED
+- AC-4: test_ac4_vigilance_block_stays_behind_forecast_and_fused       -> RED (TypeError: MetricSpec.position fehlt)
+- AC-5: test_ac5_position_applies_per_metric_anchor_not_per_symbol     -> RED
+- AC-6: test_ac6_drop_order_ignores_display_position_...               -> RED
+- AC-7: test_ac7_wintersport_metric_can_precede_forecast_metric_...    -> RED
+- AC-8: siehe Kopf-Kommentar unten (kein neuer Testcode -- Bestand deckt ab)
+- AC-9: test_ac9_cascade_source_helper_matches_validator_...           -> RED (AttributeError: cascade_source_for_channel fehlt)
+- AC-10: test_ac10_two_permutations_same_metric_set_different_order    -> RED
+- AC-11: test_ac11_sms_and_telegram_kurzform_share_one_token_line      -> RED
+
+AC-8 (Compare-Kurzform-Regression): ``tests/unit/test_compare_metric_order.py
+::TestAC10SmsFollowsUserOrder`` deckt ``render_compare_sms`` bereits mit
+einem Ordnungs-Assert ab (``test_sms_shows_all_four_metrics_of_order_a``,
+``test_sms_selection_flips_with_reversed_order``) -- kein neuer Testcode
+noetig (Spec: "NUR falls dort keiner existiert"). Alert-SMS
+(``alert/render.py``) hat keine Nutzer-Reihenfolge (Known Limitation 5 der
+Spec, Alarme sind dringlichkeitssortiert) -- kein Test noetig, da kein Code
+dort geaendert wird.
+
+Keine Mocks, kein Netz -- reine Datenmodell-Objekte + Renderer-Aufrufe
+(CLAUDE.md Test-Politik, Schicht "Kern").
+"""
+from __future__ import annotations
+
+import dataclasses
+import re
+
+from app.models import MetricConfig, UnifiedWeatherDisplayConfig
+from output.renderers.trip_report import TripReportFormatter
+from output.tokens.dto import DailyForecast, HourlyValue, MetricSpec, NormalizedForecast
+from output.tokens.builder import build_token_line
+from api.routers.validator import _determine_cascade_source
+
+from tests.tdd import _min_temp_felt_fixtures as F
+
+# ---------------------------------------------------------------------------
+# Fixtures/Helfer
+# ---------------------------------------------------------------------------
+
+
+def _sms_layout_dc(
+    order: list[str], *, per_report_evening: list[str] | None = None,
+) -> UnifiedWeatherDisplayConfig:
+    """UnifiedWeatherDisplayConfig mit globaler Metrikliste (Katalog-Default-
+    Reihenfolge) UND ``per_channel_layouts['sms']`` in der Nutzer-Reihenfolge
+    ``order``. ``per_report_evening`` setzt zusaetzlich die hoechste
+    Kaskadenebene (#434) nur fuer 'evening' (AC-3)."""
+    global_metrics = [MetricConfig(metric_id=m, enabled=True) for m in order]
+    sms_layout = [
+        MetricConfig(metric_id=m, enabled=True, bucket="primary", order=i)
+        for i, m in enumerate(order)
+    ]
+    kwargs: dict = dict(
+        trip_id="i1677", metrics=global_metrics,
+        per_channel_layouts={"sms": sms_layout},
+    )
+    if per_report_evening is not None:
+        kwargs["per_report_layouts"] = {"evening": {"sms": [
+            MetricConfig(metric_id=m, enabled=True, bucket="primary", order=i)
+            for i, m in enumerate(per_report_evening)
+        ]}}
+    return UnifiedWeatherDisplayConfig(**kwargs)
+
+
+def _render_sms(dc: UnifiedWeatherDisplayConfig, report_type: str = "evening") -> str:
+    report = TripReportFormatter().format_email(
+        [F.segment()], trip_name="Issue1677", report_type=report_type,
+        night_weather=F.night_weather(), display_config=dc,
+        stage_name=F.STAGE_NAME, tz=F.TZ,
+    )
+    return report.sms_text
+
+
+# sms_format.md §5: Wert-Grammatik ist NICHT nur eine nackte Zahl -- der
+# Threshold+Peak-Block ("{val}@{h}({peak}@{h})", §5 "Threshold == Max-
+# Optimierung"), die Prozent-Schreibweise (§5 "Wahrscheinlichkeit (%)") UND
+# die Stufen-Label-Werte L/M/H (§3, TH:/TH+: sind is_level, builder.py
+# LEVELS = {0:'-',1:'L',2:'M',3:'H'}) sind Pflichtbestandteile des Formats.
+# Die urspruengliche Grammatik hier kannte weder '@' noch '(' ')' noch '%'
+# noch die Stufen-Buchstaben -- fand dadurch KEINEN der Kern-Vorhersage-Token
+# (R/PR/W/G/TH:), die ueber render_threshold_peak_value() ausnahmslos mit
+# Default-Schwellwert (builder.py DEFAULTS) gerendert werden und deshalb
+# strukturell den Peak-Block tragen (Testfehler gegen sms_format.md §5,
+# nicht gegen die Spec dieser Scheibe -- Erwartung unveraendert, nur die
+# Symbol-Erkennung repariert). Die Buchstaben sind bewusst ENG gefasst (nur
+# unmittelbar vor '@'/Ende/Klammer-Ende) -- ein Praefix-Kollisionstest
+# ('L' nach Symbol 'N' fuer den Token 'NL-') bestaetigt, dass 'N' weiterhin
+# NICHT faelschlich in 'NL-' matcht.
+_VALUE_GRAMMAR = re.compile(
+    r"(?:(?:\d+(?:\.\d+)?%?|[LMH])(?:@\d+(?:\((?:\d+(?:\.\d+)?%?|[LMH])@\d+\))?)?|-|\?)$"
+)
+
+
+def _token_index(sms: str, symbol: str) -> int:
+    """Index des Tokens mit exakt diesem Symbol (fullmatch auf Symbol+Wert,
+    schliesst Praefix-Verwechslungen strukturell aus, Muster F.sms_token_value)."""
+    body = sms.split(": ", 1)[1] if ": " in sms else sms
+    pattern = re.compile(rf"{re.escape(symbol)}(?:{_VALUE_GRAMMAR.pattern})")
+    for i, tok in enumerate(body.split(" ")):
+        if pattern.fullmatch(tok):
+            return i
+    raise AssertionError(f"Symbol {symbol!r} nicht gefunden in SMS: {sms!r}")
+
+
+def _present(sms: str, symbol: str) -> bool:
+    """Bool-Wrapper um ``_token_index()`` (Symbol-Praesenz, unabhaengig vom
+    konkreten Wert-Format). AC-10 braucht eine Praesenz-Pruefung ueber die
+    volle Peak-Grammatik (s. ``_VALUE_GRAMMAR``) -- der geteilte Fixture-
+    Helfer ``F.sms_token_value()`` (``tests/tdd/_min_temp_felt_fixtures.py``)
+    ist bewusst auf reine Temperatur-Token ohne Peak-Block eingegrenzt (dort
+    NICHT geaendert, um dessen Praefix-Kollisionsschutz fuer andere Tests
+    nicht zu verwaessern) -- deshalb hier ein lokaler, auf die volle Grammatik
+    passender Wrapper statt einer Aufweichung der geteilten Fixture."""
+    try:
+        _token_index(sms, symbol)
+        return True
+    except AssertionError:
+        return False
+
+
+def _exact_token_index(sms: str, literal: str) -> int:
+    """Index eines Tokens, der EXAKT dem literalen String entspricht (fuer
+    wertlose System-Marker wie 'W?', deren Symbol bereits den vollen Text
+    traegt)."""
+    body = sms.split(": ", 1)[1] if ": " in sms else sms
+    for i, tok in enumerate(body.split(" ")):
+        if tok == literal:
+            return i
+    raise AssertionError(f"Token {literal!r} nicht gefunden in SMS: {sms!r}")
+
+
+# ---------------------------------------------------------------------------
+# AC-1
+# ---------------------------------------------------------------------------
+
+
+def test_ac1_sms_channel_layout_order_wins_over_default():
+    """SMS-Kanal-Layout [gust, wind, precipitation] -> G vor W vor R, NICHT
+    die Default-Reihenfolge R vor W vor G (POSITIONAL)."""
+    dc = _sms_layout_dc(["gust", "wind", "precipitation"])
+    sms = _render_sms(dc)
+    i_g, i_w, i_r = _token_index(sms, "G"), _token_index(sms, "W"), _token_index(sms, "R")
+    assert i_g < i_w < i_r, (
+        f"Erwartete Reihenfolge G < W < R (SMS-Kanal-Layout), aber Indizes "
+        f"G={i_g} W={i_w} R={i_r}. SMS: {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 -- GRUEN (Bestand-Charakterisierung, dokumentierte Ausnahme)
+# ---------------------------------------------------------------------------
+
+
+def test_ac2_default_order_byte_identical_without_sms_layout():
+    """Ohne SMS-Kanal-Layout (nur globale Auswahl) bleibt die Reihenfolge
+    exakt die heutige POSITIONAL-Reihenfolge -- fuer morning UND evening.
+    Referenzstring am 2026-08-10 empirisch vom UNVERAENDERTEN Code
+    abgenommen (uv run python3 -c "..." gegen HEAD 21da0d50) und eingefroren.
+    Diese Ausnahme ist bewusst GRUEN: der Test beweist Byte-Identitaet des
+    Ist-Zustands, nicht das neue Verhalten."""
+    dc = F.dc("gust", "wind", "precipitation")
+    expected = "E7: R0.5@5(8.4@11) W12@4(45@10) G22@4(70@10)"
+    assert _render_sms(dc, "evening") == expected, "Abend-SMS weicht vom eingefrorenen Referenzstring ab"
+    assert _render_sms(dc, "morning") == expected, "Morgen-SMS weicht vom eingefrorenen Referenzstring ab"
+
+
+# ---------------------------------------------------------------------------
+# AC-3
+# ---------------------------------------------------------------------------
+
+
+def test_ac3_per_report_layout_overrides_per_channel_layout():
+    """per_report_layouts['evening']['sms'] (Ebene 1) schlaegt
+    per_channel_layouts['sms'] (Ebene 2); fuer 'morning' (kein per_report-
+    Eintrag) greift per_channel_layouts als Fallback."""
+    dc = _sms_layout_dc(
+        ["wind", "precipitation", "gust"],           # Ebene 2 (A)
+        per_report_evening=["gust", "wind", "precipitation"],  # Ebene 1 (B), nur evening
+    )
+    evening = _render_sms(dc, "evening")
+    morning = _render_sms(dc, "morning")
+
+    assert _token_index(evening, "G") < _token_index(evening, "W") < _token_index(evening, "R"), (
+        f"Abend muss Reihenfolge B (per_report: G,W,R) folgen: {evening!r}"
+    )
+    assert _token_index(morning, "W") < _token_index(morning, "R") < _token_index(morning, "G"), (
+        f"Morgen muss auf Reihenfolge A (per_channel: W,R,G) zurueckfallen: {morning!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 -- builder.py-Ebene (Begruendung s. Modul-Docstring)
+# ---------------------------------------------------------------------------
+
+
+def test_ac4_vigilance_block_stays_behind_forecast_and_fused():
+    """Vorhersage-Gewitter (TH:, category='forecast') an Nutzer-Position 0
+    steht VOR dem Vigilance-Block, waehrend HR:/TH: (category='vigilance')
+    unveraendert fusioniert bleiben -- die Symbol-Kollision (beide Kategorien
+    teilen sich das Zeichen 'TH:') darf die Vigilance-Adjazenz nicht brechen
+    (Implementation Details Punkt 4 + Adversary-Hinweis 2).
+
+    RED heute: ``MetricSpec`` kennt noch kein ``position``-Feld (dto.py) ->
+    TypeError. Das IST der RED-Beleg fuer diese Scheibe."""
+    today = DailyForecast(
+        temp_min_c=3.0, temp_max_c=12.0, night_temp_min_c=3.0,
+        wind_hourly=(HourlyValue(10, 25.0),),
+        thunder_hourly=(HourlyValue(11, 2.0),),
+    )
+    forecast = NormalizedForecast(
+        days=(today,), provider="meteofrance", country="FR",
+        vigilance_hr_level="M", vigilance_hr_hour=14,
+        vigilance_th_level="H", vigilance_th_hour=17,
+    )
+    specs = [
+        MetricSpec(symbol="TH:", enabled=True, position=0),  # type: ignore[call-arg]
+    ]
+    line = build_token_line(forecast, specs, report_type="evening", stage_name="E7")
+    body = line.render(160).split(": ", 1)[1]
+
+    i_th_forecast = body.index("TH:M@11")
+    i_w = body.index("W25@10")
+    i_vigi = body.index("HR:M@14TH:H@17")
+    assert i_th_forecast < i_w < i_vigi, (
+        f"Erwartet: Vorhersage-TH: (Position 0) vor W vor dem fusionierten "
+        f"Vigilance-Block: {body!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5
+# ---------------------------------------------------------------------------
+
+
+def test_ac5_position_applies_per_metric_anchor_not_per_symbol():
+    """wind_chill (FK/FD) an Position 0, temperature (K/D) an Position 1 ->
+    FK/FD-Paar VOR K/D-Paar, interne Paar-Reihenfolge bleibt (FK<FD, K<D)."""
+    dc = _sms_layout_dc(["wind_chill", "temperature"])
+    sms = _render_sms(dc)
+    i_fk, i_fd = _token_index(sms, "FK"), _token_index(sms, "FD")
+    i_k, i_d = _token_index(sms, "K"), _token_index(sms, "D")
+    assert i_fk < i_k and i_fd < i_k, (
+        f"Gefuehltes Paar (Nutzer-Position 0) muss vor dem gemessenen Paar "
+        f"(Position 1) stehen: {sms!r}"
+    )
+    assert i_fk < i_fd, f"Interne Reihenfolge FK vor FD muss erhalten bleiben: {sms!r}"
+    assert i_k < i_d, f"Interne Reihenfolge K vor D muss erhalten bleiben: {sms!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC-6
+# ---------------------------------------------------------------------------
+
+
+def test_ac6_drop_order_ignores_display_position():
+    """CAPE (CP) an Nutzer-Position 0 faellt bei Ueberlaenge trotzdem VOR den
+    sicherheitsrelevanten Vorhersage-Token weg (DROP_ORDER-Prioritaet 2,
+    unveraendert) -- Anzeige-Position != Ueberlebensrang. Die ueberlebenden
+    Kern-Token behalten dabei die vom Nutzer gesetzte Reihenfolge (G vor W
+    vor R, NICHT Default R/W/G) -- das macht die Zusicherung erst
+    RED-faehig, sonst waere sie schon heute (ohne jede Aenderung) erfuellt."""
+    order = [
+        "cape", "gust", "wind", "precipitation", "rain_probability", "thunder",
+        "snow_depth", "snowfall_limit", "fresh_snow",
+        "temperature", "temperature_night", "wind_chill", "wind_chill_night",
+        "humidity", "dewpoint", "wind_direction", "precip_type", "cloud_total",
+        "cloud_low", "cloud_mid", "cloud_high", "visibility", "sunshine",
+        "uv_index", "pressure", "freezing_level",
+    ]
+    dc_full = _sms_layout_dc(order)
+    # Testfehler gegen die eigene AC-6-Praemisse ("Fixture, das eine
+    # Zeilenlaenge >160 Zeichen erzwingt"): F.segment() pur (ohne
+    # Wintersport-Aggregate) erreichte hoechstens 157 Zeichen -- der Drop
+    # wurde nie ausgeloest, die Kern-Zusicherung (CP faellt VOR den
+    # ueberlebenden Kern-Token) blieb ungeprueft. Muster wie
+    # test_ac7_...: reale Schneedaten via dataclasses.replace (dieselbe
+    # Datenquelle, die _segments_to_normalized_forecast fuer SD/SL/NS24+
+    # aggregiert) heben die Zeile ueber die Schwelle.
+    seg = F.segment()
+    agg = dataclasses.replace(
+        seg.aggregated, snow_depth_cm=25.0, snowfall_limit_m=1800.0, snow_new_sum_cm=5.0,
+    )
+    seg = dataclasses.replace(seg, aggregated=agg)
+    report = TripReportFormatter().format_email(
+        [seg], trip_name="Issue1677", report_type="evening",
+        night_weather=F.night_weather(), display_config=dc_full,
+        stage_name=F.STAGE_NAME, tz=F.TZ,
+    )
+    sms_full = report.sms_text
+    assert len(sms_full) <= 160
+    assert F.sms_token_value(sms_full, "CP") is None, (
+        f"CP muss bei Ueberlaenge weichen (DROP_ORDER-Prioritaet 2), "
+        f"unabhaengig von Position 0: {sms_full!r}"
+    )
+    i_g, i_w, i_r = _token_index(sms_full, "G"), _token_index(sms_full, "W"), _token_index(sms_full, "R")
+    assert i_g < i_w < i_r, (
+        f"Ueberlebende Kern-Token muessen die Nutzer-Reihenfolge G<W<R "
+        f"behalten, nicht die Default-Reihenfolge: {sms_full!r}"
+    )
+
+    # Gegenprobe: ohne Kuerzungsdruck bleibt CP stehen (CP ist generell
+    # wirksam verdrahtet, nicht grundsaetzlich unterdrueckt).
+    dc_small = _sms_layout_dc(["cape", "gust"])
+    sms_small = _render_sms(dc_small)
+    assert F.sms_token_value(sms_small, "CP") is not None, (
+        f"Ohne Kuerzungsdruck muss CP (Position 0) stehen: {sms_small!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-7
+# ---------------------------------------------------------------------------
+
+
+def test_ac7_wintersport_metric_can_precede_forecast_metric_but_stays_before_system_blocks():
+    """Wintersport-Metrik (snow_depth, Nutzer-Position 0) vor
+    Vorhersage-Metrik (gust, Position 2) -- beide bleiben trotzdem vor dem
+    nicht-sortierbaren System-Block (hier: 'W?', amtliche-Warnungen-nicht-
+    abrufbar-Marker)."""
+    order = ["snow_depth", "snowfall_limit", "gust"]
+    dc = _sms_layout_dc(order)
+    seg = F.segment()
+    agg = dataclasses.replace(seg.aggregated, snow_depth_cm=25.0, snowfall_limit_m=1700.0)
+    seg = dataclasses.replace(seg, aggregated=agg, official_alerts_unavailable=True)
+
+    report = TripReportFormatter().format_email(
+        [seg], trip_name="Issue1677", report_type="evening",
+        night_weather=F.night_weather(), display_config=dc,
+        stage_name=F.STAGE_NAME, tz=F.TZ,
+    )
+    sms = report.sms_text
+    i_sd = _token_index(sms, "SD")
+    i_g = _token_index(sms, "G")
+    i_marker = _exact_token_index(sms, "W?")
+    assert i_sd < i_g, (
+        f"SD (Wintersport, Nutzer-Position 0) muss vor G (Vorhersage, "
+        f"Position 2) stehen: {sms!r}"
+    )
+    assert i_g < i_marker, (
+        f"Systemblock 'W?' muss auch bei umsortierten Fachtoken dahinter "
+        f"bleiben: {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-9
+# ---------------------------------------------------------------------------
+
+
+def test_ac9_cascade_source_helper_matches_validator_and_couples_to_order_effect():
+    """``UnifiedWeatherDisplayConfig.cascade_source_for_channel()`` (models.py,
+    noch nicht existent -> AttributeError = RED) muss dieselbe Antwort geben
+    wie der Validator-Spiegel ``_determine_cascade_source`` UND diese
+    Antwort muss mit der tatsaechlichen Reihenfolge-Wirkung gekoppelt sein
+    (Adversary-Hinweis 4: kein Test, der nur EINEN der beiden Pfade prueft)."""
+    dc_layout = _sms_layout_dc(["gust", "wind", "precipitation"])
+    dc_global = F.dc("gust", "wind", "precipitation")
+
+    for dc, expected_order_effect in ((dc_layout, True), (dc_global, False)):
+        validator_source = _determine_cascade_source(dc, "sms", "evening")
+        model_source = dc.cascade_source_for_channel("sms", "evening")  # type: ignore[attr-defined]
+        assert model_source == validator_source, (
+            f"models.py-Helfer und Validator-Spiegel laufen auseinander: "
+            f"{model_source!r} != {validator_source!r}"
+        )
+        sms = _render_sms(dc)
+        order_matches_user = (
+            _token_index(sms, "G") < _token_index(sms, "W") < _token_index(sms, "R")
+        )
+        assert order_matches_user == expected_order_effect, (
+            f"Kopplung von Meldung ({model_source!r}) und Wirkung gebrochen: "
+            f"order_matches_user={order_matches_user}, erwartet="
+            f"{expected_order_effect}. SMS: {sms!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-10
+# ---------------------------------------------------------------------------
+
+
+def test_ac10_two_permutations_same_metric_set_different_order():
+    """Zwei disjunkte Permutationen derselben Metrik-MENGE -> dieselbe
+    Symbol-Menge, aber zwei nachweisbar verschiedene Reihenfolgen."""
+    metric_ids = ["gust", "wind", "precipitation", "cape", "humidity"]
+    symbols = ["G", "W", "R", "CP", "HU"]
+    order_a = metric_ids
+    order_b = list(reversed(metric_ids))
+
+    sms_a = _render_sms(_sms_layout_dc(order_a))
+    sms_b = _render_sms(_sms_layout_dc(order_b))
+
+    present_a = {s for s in symbols if _present(sms_a, s)}
+    present_b = {s for s in symbols if _present(sms_b, s)}
+    assert present_a == present_b == set(symbols), (
+        f"Beide Permutationen muessen dieselbe Symbol-Menge zeigen: "
+        f"A={present_a} B={present_b}\nA={sms_a!r}\nB={sms_b!r}"
+    )
+
+    appearance_a = sorted(symbols, key=lambda s: _token_index(sms_a, s))
+    appearance_b = sorted(symbols, key=lambda s: _token_index(sms_b, s))
+    assert appearance_a == ["G", "W", "R", "CP", "HU"], f"Reihenfolge A falsch: {sms_a!r}"
+    assert appearance_b == ["HU", "CP", "R", "W", "G"], f"Reihenfolge B falsch: {sms_b!r}"
+    assert appearance_a != appearance_b, (
+        f"Dieselbe Menge in zwei Reihenfolgen muss zwei verschiedene "
+        f"Token-Folgen ergeben, ergab aber beide Male {appearance_a}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-11
+# ---------------------------------------------------------------------------
+
+
+def test_ac11_sms_and_telegram_kurzform_share_one_token_line():
+    """SMS und Telegram-Kurzform sind KEIN zweiter Renderer-/Sortier-Pfad,
+    sondern EIN Objekt: ``services/notification_service.py`` uebergibt
+    ``body=report.sms_text or report.email_plain`` fuer BEIDE Kanaele
+    unveraendert (Zeilen 364/381, Grep-Beleg 2026-08-10 -- begruendeter
+    Verweis statt zweitem Testaufruf, #1660 B dokumentiert dasselbe Muster).
+    Der Beleg hier ist die konkrete Nutzer-Reihenfolge auf GENAU diesem
+    Objekt, ueber alle drei #1660-B-Grammatikklassen hinweg (a: humidity,
+    b: visibility, c: wind_direction)."""
+    order = ["wind_direction", "visibility", "humidity"]  # Klasse c, b, a
+    dc = _sms_layout_dc(order)
+    sms = _render_sms(dc)
+    i_wd, i_vs, i_hu = _token_index(sms, "WD"), _token_index(sms, "VS"), _token_index(sms, "HU")
+    assert i_wd < i_vs < i_hu, (
+        f"Nutzer-Reihenfolge WD < VS < HU muss auf report.sms_text gelten, "
+        f"dem Objekt, das notification_service.py fuer SMS UND "
+        f"Telegram-Kurzform sendet: {sms!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix-Loop (Adversary BROKEN-Verdict, 2026-08-10): F001 + F002
+# ---------------------------------------------------------------------------
+
+
+def test_fixloop_f001_threshold_and_position_combine():
+    """Adversary Fix-Loop F001 (CRITICAL): eine Metrik mit KONFIGURIERTEM
+    ``sms_threshold`` (Issue #624) UND SMS-Kanal-Position (#1677) darf ihre
+    Position nicht verlieren.
+
+    Root Cause vor dem Fix: ``sms_trip.py::format_sms()`` baut zuerst aus
+    ``thresholds`` (Zeilen ~725-746) eine threshold-tragende ``MetricSpec``
+    ohne ``position`` und belegt damit das Symbol in ``config``. Der
+    anschliessende ``disabled_specs``-Merge (Zeilen ~753-755,
+    ``config.extend(s for s in disabled_specs if s.symbol not in
+    existing_syms)``) verwirft die positionstragende Spec aus
+    ``disabled_specs`` daraufhin STILL, weil das Symbol schon "existiert" --
+    die Nutzer-Reihenfolge verpufft genau dann, wenn beide Features
+    kombiniert werden. Repro des Adversary: gust auf Position 0 OHNE
+    Schwelle wirkt (G vor W vor R), MIT ``sms_threshold=15.0`` auf gust
+    faellt G wieder an die Default-Position."""
+    global_metrics = [
+        MetricConfig(metric_id="gust", enabled=True, sms_threshold=15.0),
+        MetricConfig(metric_id="wind", enabled=True),
+        MetricConfig(metric_id="precipitation", enabled=True),
+    ]
+    sms_layout = [
+        MetricConfig(metric_id=m, enabled=True, bucket="primary", order=i)
+        for i, m in enumerate(["gust", "wind", "precipitation"])
+    ]
+    dc = UnifiedWeatherDisplayConfig(
+        trip_id="i1677fixloopf001", metrics=global_metrics,
+        per_channel_layouts={"sms": sms_layout},
+    )
+    sms = _render_sms(dc)
+    i_g, i_w, i_r = _token_index(sms, "G"), _token_index(sms, "W"), _token_index(sms, "R")
+    assert i_g < i_w < i_r, (
+        f"SMS-Kanal-Position (gust zuerst) muss auch bei konfiguriertem "
+        f"Schwellwert (sms_threshold=15.0 auf gust) wirken -- G vor W vor "
+        f"R erwartet, unabhaengig vom Schwellwert-Merge: {sms!r}"
+    )
+
+
+def test_fixloop_f002_last_resort_priority_ignores_display_position():
+    """Adversary Fix-Loop F002 (MEDIUM): der Last-Resort-Kuerzungszweig
+    (``render.py`` Zeilen ~100-114, sortiert Kern-Vorhersage-Token
+    ausschliesslich nach dem sicherheitsbasierten ``Token.priority``) darf
+    NIEMALS von der Nutzer-Anzeigeposition (``MetricSpec.position``)
+    beeinflusst werden (DEC-6/sms_format.md §6). Kein bisheriger Test
+    erreicht diesen Zweig fuer KERN-Vorhersage-Token (R/W/G/TH:) mit
+    gleichzeitig aktiver Nutzer-Position -- die AC-6-Kuerzungs-Tests bleiben
+    im DROP_ORDER-Zweig stecken (DROP_ORDER fasst R/W/G/TH: nie an), und
+    keiner davon nutzt einen so kleinen ``max_length``, dass ueberhaupt das
+    Last-Resort-Kernstueck aktiv wird.
+
+    Direkter ``build_token_line()`` + ``render(N)``-Aufruf (Muster des
+    AC-4-Tests oben, s. Modul-Docstring): ``TripReportFormatter``/
+    ``SMSTripFormatter`` haerten ``max_length=160`` fest
+    (``trip_report.py`` Zeile ~394 ``format_sms(..., max_length=160, ...)``)
+    -- ohne einen extrem kleinen, direkt an ``TokenLine.render()``
+    uebergebenen ``max_length`` wird der Last-Resort-Zweig fuer Kern-Token
+    strukturell NIE erreicht (DROP_ORDER/PR/K-D-N-Drops reichen bei jeder
+    ueber den Produktivpfad erreichbaren SMS-Laenge aus).
+
+    Gewitter (``TH:``) traegt Nutzer-Position 0 (die "beste" Anzeigeposition)
+    UND die hoechste ``PRIORITY`` (10) -- unmutiert ueberlebt es das
+    Last-Resort-Kuerzen als letztes Kern-Token trotz Position 0 (die
+    Position darf die Ueberlebens-Reihenfolge nicht steuern). Bei der
+    Mutation "Token.priority aus spec.position ableiten" wuerde ``TH:``
+    (Position 0 = niedrigster Wert) stattdessen als ERSTES Kern-Token
+    entfernt -- exakt die DEC-6-Verletzung, die dieser Test fangen muss."""
+    today = DailyForecast(
+        rain_hourly=(HourlyValue(5, 3.0),),
+        wind_hourly=(HourlyValue(4, 12.0),),
+        gust_hourly=(HourlyValue(4, 22.0),),
+        thunder_hourly=(HourlyValue(11, 2.0),),
+    )
+    forecast = NormalizedForecast(days=(today,))
+    specs = [
+        MetricSpec(symbol="TH:", position=0),
+        MetricSpec(symbol="W", position=1),
+        MetricSpec(symbol="G", position=2),
+        MetricSpec(symbol="R", position=3),
+    ]
+    line = build_token_line(forecast, specs, report_type="evening", stage_name="E7")
+    rendered = line.render(25)
+    assert _present(rendered, "TH:"), (
+        f"Gewitter (hoechste PRIORITY=10, unabhaengig von Anzeigeposition 0) "
+        f"muss den Last-Resort-Zweig als Kern-Token ueberleben: {rendered!r}"
+    )
+    assert _present(rendered, "W"), f"W (PRIORITY 8) muss ueberleben: {rendered!r}"
+    assert _present(rendered, "G"), f"G (PRIORITY 8) muss ueberleben: {rendered!r}"
+    assert not _present(rendered, "R"), (
+        f"R (niedrigste PRIORITY=7 unter den vier Kern-Token) muss als "
+        f"ERSTES Kern-Token weichen, trotz Nutzer-Position 3 (letzte "
+        f"Anzeigeposition) -- Anzeige-Position != Ueberlebensrang: {rendered!r}"
+    )


### PR DESCRIPTION
## #1677: Nutzer-Reihenfolge wirkt in der Trip-Kurzform + Kanal×Metrik-Matrix-Tests

Teil von #1677 (NICHT automatisch schließen — Issue-Close erst nach Prod-Selftest).

**Was:** Die Drag&Drop-Sortierung aus dem SMS-Tab des Editors (existierte, war wirkungslos) bestimmt jetzt die Token-Reihenfolge der Kurzform (SMS + Telegram-Kurzform). PO: „Der User ist Experte, er wird nicht bevormundet."

**Wie:**
- `trip_report.py` behält die geordnete Kanal-Kaskaden-Liste (kein Set-Kollaps mehr); Positionen nur bei SMS-spezifischem Layout (`cascade_source_for_channel != "global"`) — ohne SMS-Sortierung **byte-identisch** (5 Goldens unverändert grün)
- `MetricSpec.position` (additiv), Builder sortiert zweistufig: positionierte Metrik-Token (forecast + wintersport) zuerst, Rest im POSITIONAL-Fallback; System-Blöcke (Vigilance mit HR:TH:-Fusion, amtliche Warnungen, Fire, W?, DBG) bleiben fix dahinter
- Mehrfach-Symbole wandern als Anker (K+D, FK+FD+WC, TH:+TH+:), Kürzung bleibt prioritätsbasiert (Anzeigeposition ≠ Überlebensrang — sonst kürzt man sich die Gewitterwarnung weg)
- Kaskaden-Quelle als EINE geteilte Methode (`cascade_source_for_channel`), Validator-Endpoint delegiert
- `sms_format.md` v2.23

**Fix-Loop (Adversary Runde 2, CRITICAL):** Position verpuffte still bei kombiniertem `sms_threshold` (#624) — Merge verwarf die Positions-Spec. Behoben (symbol-präziser `dataclasses.replace()`-Merge), mutations-belegt in Runde 3.

**Scheibe B:** Matrix-Tests `tests/tdd/test_channel_metric_matrix.py` — 26 Katalog-Metriken × E-Mail/Telegram-rich/Kurzform: Auswahl, Abwahl, Reihenfolge am Wirkort. Fehlerklasse „Bedienelement ohne Wirkung" (#1450/#1362/#1660/#1677) jetzt strukturell bewacht.

**Qualität:** Spec 15 ACs (PO-approved, spec-validator VALID) · TDD 35 RED → GREEN · Adversary VERIFIED über 3 Runden (10 Mutationen, alle gefangen bzw. Findings behoben) · 300 benannte Tests grün · ruff clean · Renderer-Gate #811 frisch (Validator Exit 0) · LoC-Override 1600 PO-genehmigt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFziB15Kn8aDEZYe8CoQ31
