### PR TITLE
fix(#1676): interne Endpunkte waren aus dem Internet erreichbar

### DIFF
--- a/docs/specs/modules/feat_1676_s1_premium_sms_rueckkanal.md
+++ b/docs/specs/modules/feat_1676_s1_premium_sms_rueckkanal.md
@@ -58,6 +58,19 @@ Frontend (folgt in S2/S3).
 | `internal/model/tier.go::EffectiveTier` | module | Premium-Kandidaten-Filter, serverseitige zweite Verteidigungslinie (R3) |
 | `internal/store/store.go::ListUserIDs/LoadUser/SaveUser` | module | Nutzer-Iteration + Read-Modify-Write mit Merge (Go bleibt einziger Schreiber von `user.json`) |
 | `internal/handler/telegram_connect.go` | Vorbild | localhost-only-Sperre, Handler-Aufbau |
+| `internal/handler/localhost_guard.go` | NEU (v1.4) | `requireLocalOnly()` — wirksame Loopback-Sperre, s.u. |
+
+> **Sicherheitsnachtrag v1.4 (2026-08-10, bei der Staging-Verifikation gemessen):** Die vom Vorbild
+> uebernommene „localhost-only"-Sperre prueft nur `r.RemoteAddr` und **wirkt nicht** — nginx laeuft
+> auf demselben Host, also ist `RemoteAddr` bei jeder aus dem Internet hereingeholten Anfrage
+> `127.0.0.1`. Beleg: ein Aufruf von aussen gegen Staging erreichte die Fachlogik (HTTP 409 aus der
+> Mehrdeutigkeitsregel, nicht 403 aus der Sperre); auf Produktion antwortete der Geschwister-Endpunkt
+> `/api/internal/telegram-connect` mit 422 statt 403. Bei genau einem Premium-Nutzer haette ein
+> unauthentifizierter Aufrufer damit die Garmin-Rueckadresse auf eine fremde Nummer setzen koennen.
+> Behoben durch `requireLocalOnly()`: zusaetzlich zur Loopback-Pruefung wird abgelehnt, sobald eine
+> Proxy-Kopfzeile (`X-Forwarded-For`/`X-Real-IP`/`X-Forwarded-Proto`) anliegt — die setzt nginx bei
+> jeder Durchleitung, der lokale Python-Kern keine. Gilt auch fuer `telegram_connect.go` (dieselbe
+> Luecke, aelter). Eine Sperre auf nginx-Ebene ist zusaetzlich bei `henemm-infra` angefragt.
 | `GZ_SKIP_FRONTEND_BROWSER_GATE` (Konvention, `staging_gate.py`) | Vorbild | lauter, exakter Env-Var-Schalter mit stderr-Meldung — Muster für `GZ_PREMIUM_SMS_POLL_DRYRUN` |
 | `docs/adr/0015-dual-stack-zielarchitektur.md` | ADR | Zuständigkeitsgrenze Python-Core (Fachlogik, Polling) vs. Go-API (Persistenz, `user.json`) |
 

--- a/internal/handler/localhost_guard.go
+++ b/internal/handler/localhost_guard.go
@@ -1,0 +1,46 @@
+package handler
+
+// Sicherheitsfix (Team-Lead-Befund, 2026-08-10): die frueherer localhost-Sperre
+// auf den internen Endpoints (PostPremiumSmsLearnHandler,
+// PostTelegramConnectHandler) pruefte nur r.RemoteAddr. Das wirkt NICHT:
+// nginx laeuft auf demselben Host und proxyt nach 127.0.0.1, also ist
+// r.RemoteAddr bei JEDER ueber nginx hereingeholten Anfrage -- egal von
+// welcher externen IP -- "127.0.0.1:<port>", ununterscheidbar von einem
+// direkten Aufruf des lokalen Python-Core. Gemessen: Staging von aussen
+// erreichte den Endpoint bis zur Fachlogik (409 statt 403).
+//
+// Fix kehrt die Frage um: nicht "sieht das nach einem externen Aufrufer
+// aus?", sondern "bin ich SICHER, dass dieser Aufruf lokal ist?" -- im
+// Zweifel ablehnen. nginx setzt fuer JEDE durchgeleitete Anfrage mindestens
+// einen der Proxy-Header (X-Forwarded-For/X-Real-IP/X-Forwarded-Proto,
+// siehe /etc/nginx/sites-enabled/*gregor*). Der lokale Python-Core ruft
+// direkt per net/http auf localhost:8090 und setzt keinen dieser Header.
+// Traegt eine Anfrage einen davon, ist sie zwangslaeufig durch nginx
+// gelaufen, egal was RemoteAddr behauptet.
+
+import (
+	"net/http"
+	"strings"
+)
+
+// isProxiedRequest meldet, ob r einen der Header traegt, die nginx jeder von
+// aussen hereingeholten Anfrage aufpraegt.
+func isProxiedRequest(r *http.Request) bool {
+	return r.Header.Get("X-Forwarded-For") != "" ||
+		r.Header.Get("X-Real-IP") != "" ||
+		r.Header.Get("X-Forwarded-Proto") != ""
+}
+
+// requireLocalOnly erzwingt, dass eine Anfrage ein echter Loopback-Aufruf
+// eines lokalen Prozesses ist -- nicht einer, der ueber nginx aus dem
+// Internet hereingeholt wurde. Schreibt bei Ablehnung 403 und liefert false;
+// Aufrufer MUESSEN bei false sofort zurueckkehren, ohne weiterzuarbeiten.
+func requireLocalOnly(w http.ResponseWriter, r *http.Request) bool {
+	remoteHost := r.RemoteAddr
+	isLoopback := strings.HasPrefix(remoteHost, "127.0.0.1:") || strings.HasPrefix(remoteHost, "[::1]:")
+	if !isLoopback || isProxiedRequest(r) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return false
+	}
+	return true
+}

--- a/internal/handler/premium_sms_connect.go
+++ b/internal/handler/premium_sms_connect.go
@@ -30,9 +30,7 @@ import (
 // PostPremiumSmsLearnHandler baut den Handler mit injiziertem Store.
 func PostPremiumSmsLearnHandler(s *store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		remoteHost := r.RemoteAddr
-		if !strings.HasPrefix(remoteHost, "127.0.0.1:") && !strings.HasPrefix(remoteHost, "[::1]:") {
-			http.Error(w, "forbidden", http.StatusForbidden)
+		if !requireLocalOnly(w, r) {
 			return
 		}
 

--- a/internal/handler/premium_sms_connect_test.go
+++ b/internal/handler/premium_sms_connect_test.go
@@ -72,6 +72,12 @@ func newLearnRequest(remoteAddr string, body map[string]any) *http.Request {
 	return req
 }
 
+func newLearnRequestWithHeader(remoteAddr, headerName, headerValue string, body map[string]any) *http.Request {
+	req := newLearnRequest(remoteAddr, body)
+	req.Header.Set(headerName, headerValue)
+	return req
+}
+
 // ---------------------------------------------------------------------------
 // AC-4 UND AC-1 (Persistenz-Haelfte): genau ein Premium-Kandidat ohne
 // gespeicherten Treffer -> lernt tatsaechlich am persistierten user.json.
@@ -245,6 +251,60 @@ func TestLearnRejectsNonLocalhostCaller(t *testing.T) {
 	premium := mustLoadUser(t, s, "premium-user")
 	if premium.PremiumSmsReplyTo != "" {
 		t.Error("Nicht-Localhost-Aufruf darf NIE etwas persistieren")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Sicherheitsfix (Team-Lead-Befund, 2026-08-10): RemoteAddr allein reicht
+// nicht -- nginx proxyt auf denselben Host, RemoteAddr ist dann IMMER
+// 127.0.0.1. Eine Anfrage mit Proxy-Header ist zwangslaeufig durch nginx
+// gelaufen und muss abgelehnt werden, auch wenn RemoteAddr Loopback vortaeuscht.
+// ---------------------------------------------------------------------------
+
+func TestLearnRejectsRequestWithForwardedForHeaderEvenWithUniqueCandidate(t *testing.T) {
+	s := learnTestStore(t)
+	mustSaveUser(t, s, model.User{ID: "premium-user", Tier: "premium"})
+
+	h := PostPremiumSmsLearnHandler(s)
+	// Genau EIN Premium-Kandidat -- ohne den Proxy-Header waere das ein
+	// eindeutiger Treffer (AC-4). Der Header allein muss trotzdem ablehnen:
+	// die Mehrdeutigkeitsregel darf nicht die einzige Schutzschicht sein.
+	req := newLearnRequestWithHeader("127.0.0.1:54321", "X-Forwarded-For", "203.0.113.5",
+		map[string]any{"from": garminFromA})
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("erwartet 403 bei X-Forwarded-For trotz eindeutigem Kandidaten, bekam %d, body=%s",
+			rr.Code, rr.Body.String())
+	}
+
+	premium := mustLoadUser(t, s, "premium-user")
+	if premium.PremiumSmsReplyTo != "" {
+		t.Error("proxierte Anfrage darf NIE etwas persistieren, auch nicht bei eindeutigem Kandidaten")
+	}
+}
+
+func TestLearnRejectsRequestWithRealIPOrForwardedProtoHeader(t *testing.T) {
+	for _, headerName := range []string{"X-Real-IP", "X-Forwarded-Proto"} {
+		t.Run(headerName, func(t *testing.T) {
+			s := learnTestStore(t)
+			mustSaveUser(t, s, model.User{ID: "premium-user", Tier: "premium"})
+
+			h := PostPremiumSmsLearnHandler(s)
+			req := newLearnRequestWithHeader("127.0.0.1:54321", headerName, "https",
+				map[string]any{"from": garminFromA})
+			rr := httptest.NewRecorder()
+			h(rr, req)
+
+			if rr.Code != http.StatusForbidden {
+				t.Fatalf("erwartet 403 bei %s, bekam %d, body=%s", headerName, rr.Code, rr.Body.String())
+			}
+			premium := mustLoadUser(t, s, "premium-user")
+			if premium.PremiumSmsReplyTo != "" {
+				t.Errorf("proxierte Anfrage (%s) darf NIE etwas persistieren", headerName)
+			}
+		})
 	}
 }
 

--- a/internal/handler/telegram_connect.go
+++ b/internal/handler/telegram_connect.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -171,9 +170,7 @@ func GetTelegramStatusHandler(s *store.Store) http.HandlerFunc {
 // Resolves the one-time token to a user_id and saves the chat_id.
 func PostTelegramConnectHandler(s *store.Store, ts *TelegramTokenStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		remoteHost := r.RemoteAddr
-		if !strings.HasPrefix(remoteHost, "127.0.0.1:") && !strings.HasPrefix(remoteHost, "[::1]:") {
-			http.Error(w, "forbidden", http.StatusForbidden)
+		if !requireLocalOnly(w, r) {
 			return
 		}
 

--- a/internal/handler/telegram_connect_localhost_guard_test.go
+++ b/internal/handler/telegram_connect_localhost_guard_test.go
@@ -1,0 +1,91 @@
+package handler
+
+// Sicherheitsfix (Team-Lead-Befund, 2026-08-10): PostTelegramConnectHandler
+// hatte dieselbe wirkungslose localhost-Sperre wie
+// PostPremiumSmsLearnHandler -- r.RemoteAddr ist bei jeder ueber nginx
+// hereingeholten Anfrage "127.0.0.1:<port>", egal welche externe IP den
+// Request abgeschickt hat. Diese Tests pruefen die WIRKUNG des Fixes
+// (requireLocalOnly, internal/handler/localhost_guard.go) an diesem
+// Endpoint: eine Anfrage mit Proxy-Header wird abgelehnt und veraendert
+// keinen Nutzerdatensatz; ein echter lokaler Aufruf (kein Proxy-Header)
+// funktioniert weiter wie zuvor.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/henemm/gregor-api/internal/model"
+	"github.com/henemm/gregor-api/internal/store"
+)
+
+func telegramConnectTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	return store.New(t.TempDir(), "default")
+}
+
+func newTelegramConnectRequest(remoteAddr string, headers map[string]string, body map[string]any) *http.Request {
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/internal/telegram-connect", bytes.NewReader(b))
+	req.RemoteAddr = remoteAddr
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	return req
+}
+
+// Anfrage traegt X-Forwarded-For, RemoteAddr taeuscht Loopback vor (wie es
+// eine ueber nginx durchgeleitete Anfrage tut) -> 403, kein Schreibzugriff.
+func TestTelegramConnectRejectsRequestWithForwardedForHeader(t *testing.T) {
+	s := telegramConnectTestStore(t)
+	ts := NewTelegramTokenStore(t.TempDir())
+	mustSaveUser(t, s, model.User{ID: "victim-user"})
+	token := ts.CreateToken("victim-user")
+
+	h := PostTelegramConnectHandler(s, ts)
+	req := newTelegramConnectRequest(
+		"127.0.0.1:54321",
+		map[string]string{"X-Forwarded-For": "203.0.113.5"},
+		map[string]any{"token": token, "chat_id": "attacker-chat-id"},
+	)
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("erwartet 403 bei X-Forwarded-For, bekam %d, body=%s", rr.Code, rr.Body.String())
+	}
+
+	victim := mustLoadUser(t, s, "victim-user")
+	if victim.TelegramChatID != "" {
+		t.Errorf("proxierte Anfrage darf TelegramChatID NICHT setzen, hat aber %q", victim.TelegramChatID)
+	}
+}
+
+// Anfrage ohne Proxy-Header von echtem Loopback -> funktioniert weiter wie
+// vor dem Fix.
+func TestTelegramConnectWorksForGenuineLocalCallWithoutProxyHeaders(t *testing.T) {
+	s := telegramConnectTestStore(t)
+	ts := NewTelegramTokenStore(t.TempDir())
+	mustSaveUser(t, s, model.User{ID: "victim-user"})
+	token := ts.CreateToken("victim-user")
+
+	h := PostTelegramConnectHandler(s, ts)
+	req := newTelegramConnectRequest(
+		"127.0.0.1:54321",
+		nil,
+		map[string]any{"token": token, "chat_id": "real-chat-id"},
+	)
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("erwartet 200 fuer echten lokalen Aufruf, bekam %d, body=%s", rr.Code, rr.Body.String())
+	}
+
+	victim := mustLoadUser(t, s, "victim-user")
+	if victim.TelegramChatID != "real-chat-id" {
+		t.Errorf("erwartet TelegramChatID=%q, bekam %q", "real-chat-id", victim.TelegramChatID)
+	}
+}


### PR DESCRIPTION
fix(#1676): interne Endpunkte waren aus dem Internet erreichbar

Die "localhost-only"-Sperre auf /api/internal/* prueft nur `r.RemoteAddr`.
Das wirkt nicht: nginx laeuft auf demselben Host und proxyt nach 127.0.0.1,
also ist `RemoteAddr` bei JEDER aus dem Internet hereingeholten Anfrage
Loopback — ununterscheidbar vom lokalen Python-Kern.

Gemessen bei der Staging-Verifikation von #1676 S1:
- Staging von aussen, `POST /api/internal/premium-sms-learn` mit
  `dry_run:false` -> HTTP 409 `no_unique_premium_candidate`. Die Anfrage hat
  die Fachlogik erreicht; abgelehnt hat sie die Mehrdeutigkeitsregel, nicht
  die Sperre.
- Produktion, `POST /api/internal/telegram-connect` -> HTTP 422, nicht 403.
- nginx blockt /api/internal nicht.

Auf Produktion existiert genau ein Premium-Nutzer. Dort haette derselbe
Aufruf 200 ergeben und die Garmin-Rueckadresse auf eine fremde Nummer
gesetzt — unauthentifiziert. Briefings waeren dann zum Premium-Tarif an den
Angreifer gegangen. Der Prod-Deploy von S1 wurde deshalb gestoppt.

Fix kehrt die Frage um: nicht "sieht das nach einem externen Aufrufer aus?",
sondern "bin ich sicher, dass dieser Aufruf lokal ist?" — im Zweifel 403.
`requireLocalOnly()` lehnt zusaetzlich zur Loopback-Pruefung ab, sobald eine
Proxy-Kopfzeile anliegt (X-Forwarded-For/X-Real-IP/X-Forwarded-Proto); die
setzt nginx bei jeder Durchleitung, der lokale Python-Kern keine.

Gilt auch fuer telegram_connect.go — dieselbe Luecke, aelter und nicht aus
dieser Arbeit, aber nach dem Fund nicht offen zu lassen.

Vier neue Tests pruefen die Wirkung, u.a. dass ein Aufruf mit
X-Forwarded-For auch bei genau einem Premium-Kandidaten 403 bekommt und
nichts schreibt — die Mehrdeutigkeitsregel darf nicht die einzige
Schutzschicht sein. Gegenprobe belegt: ohne die Proxy-Pruefung werden genau
diese vier rot (403 erwartet, 200 bekommen).

Eine zusaetzliche Sperre auf nginx-Ebene ist bei henemm-infra angefragt
(Verteidigung in der Tiefe — die Anwendungspruefung war schon einmal
unbemerkt wirkungslos).

Refs #1676

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X9SjbKBjrAnEAifJYciPRg
