### PR TITLE
fix(#1676): seven.io liefert die Nachrichten-id als Zeichenkette

### DIFF
--- a/docs/specs/modules/feat_1676_s1_premium_sms_rueckkanal.md
+++ b/docs/specs/modules/feat_1676_s1_premium_sms_rueckkanal.md
@@ -4,7 +4,7 @@ type: module
 created: 2026-08-10
 updated: 2026-08-10
 status: draft
-version: "1.3"
+version: "1.5"
 tags: [sms, inbound, premium, garmin, seven-io, dual-stack]
 ---
 
@@ -59,6 +59,8 @@ Frontend (folgt in S2/S3).
 | `internal/store/store.go::ListUserIDs/LoadUser/SaveUser` | module | Nutzer-Iteration + Read-Modify-Write mit Merge (Go bleibt einziger Schreiber von `user.json`) |
 | `internal/handler/telegram_connect.go` | Vorbild | localhost-only-Sperre, Handler-Aufbau |
 | `internal/handler/localhost_guard.go` | NEU (v1.4) | `requireLocalOnly()` — wirksame Loopback-Sperre, s.u. |
+| `GZ_SKIP_FRONTEND_BROWSER_GATE` (Konvention, `staging_gate.py`) | Vorbild | lauter, exakter Env-Var-Schalter mit stderr-Meldung — Muster für `GZ_PREMIUM_SMS_POLL_DRYRUN` |
+| `docs/adr/0015-dual-stack-zielarchitektur.md` | ADR | Zuständigkeitsgrenze Python-Core (Fachlogik, Polling) vs. Go-API (Persistenz, `user.json`) |
 
 > **Sicherheitsnachtrag v1.4 (2026-08-10, bei der Staging-Verifikation gemessen):** Die vom Vorbild
 > uebernommene „localhost-only"-Sperre prueft nur `r.RemoteAddr` und **wirkt nicht** — nginx laeuft
@@ -71,8 +73,6 @@ Frontend (folgt in S2/S3).
 > Proxy-Kopfzeile (`X-Forwarded-For`/`X-Real-IP`/`X-Forwarded-Proto`) anliegt — die setzt nginx bei
 > jeder Durchleitung, der lokale Python-Kern keine. Gilt auch fuer `telegram_connect.go` (dieselbe
 > Luecke, aelter). Eine Sperre auf nginx-Ebene ist zusaetzlich bei `henemm-infra` angefragt.
-| `GZ_SKIP_FRONTEND_BROWSER_GATE` (Konvention, `staging_gate.py`) | Vorbild | lauter, exakter Env-Var-Schalter mit stderr-Meldung — Muster für `GZ_PREMIUM_SMS_POLL_DRYRUN` |
-| `docs/adr/0015-dual-stack-zielarchitektur.md` | ADR | Zuständigkeitsgrenze Python-Core (Fachlogik, Polling) vs. Go-API (Persistenz, `user.json`) |
 
 ## Implementation Details
 
@@ -87,8 +87,16 @@ Frontend (folgt in S2/S3).
 2. seven_api_key fehlt -> return 0.
 3. last_seen_id aus diagnostics/premium_sms_inbound.json laden (Default 0).
 4. GET journal/inbound?limit=100, Header X-Api-Key (kein date_from, s.u.).
+   **Die Antwort liefert `id` als ZEICHENKETTE** (z.B. `"5283665"`), nicht
+   als Zahl (gemessen 2026-08-10, s. Fix F004 unten) -- diese Annahme war in
+   v1.0-v1.4 falsch und liess den Cron-Job produktiv alle 5 Minuten mit
+   `TypeError` abbrechen.
 5. Fehler (HTTP/Netzwerk) -> loggen, return 0, last_seen_id unveraendert.
 6. Nachrichten mit id > last_seen_id aufsteigend sortieren (aeltest zuerst).
+   `id` wird dafuer je Eintrag robust nach `int` umgewandelt (Fix F004); ein
+   Eintrag, dessen `id` sich nicht umwandeln laesst, wird uebersprungen (mit
+   Warnung) statt den ganzen Journal-Lauf abzubrechen -- Fail-soft je
+   Eintrag, nicht Fail-hard fuer das Fenster.
 7. Je Nachricht ohne Garmin-Kennzeichen: last_seen_id-Kandidat auf
    max(bisher, msg.id) anheben (sonst Dauer-Reevaluation). Fuer eine
    Nachricht MIT Kennzeichen entscheidet Schritt 9 ueber das Anheben --
@@ -148,6 +156,30 @@ AC-5 — abschliessende Entscheidung, Zeiger wandert weiter, sonst warnt das
 System alle 5 Minuten ueber etwas, das sich von selbst nicht aendert). Die
 ACs bleiben woertlich unveraendert; betroffen ist ausschliesslich das interne
 Ablaufdetail in Schritt 7/9/11 und der Trigger-Endpoint.
+
+**Fix F004 (v1.5, Produktionsfehler #1676, gemessen 2026-08-10):** v1.0-v1.4
+nahmen an, `id` im Journal-Eintrag sei eine Zahl (Fixtures verwendeten
+`3001` usw.) — die echte seven.io-API liefert `id` jedoch als ZEICHENKETTE
+(`"5283665"`, gemessene Antwort s.u.). Der Vergleich `id > last_seen_id`
+brach deshalb produktiv alle 5 Minuten mit `TypeError: '>' not supported
+between instances of 'str' and 'int'` ab, ohne dass ein Test das fing — die
+Fixtures bildeten eine erfundene, nicht die gemessene Wirklichkeit ab. Die
+Korrektur wandelt `id` robust nach `int` um (Schritt 6); eine einzelne nicht
+umwandelbare `id` überspringt NUR diesen Eintrag statt den ganzen Lauf
+abzubrechen. Gemessene Journal-Antwort (Rufnummern maskiert, Struktur
+original):
+
+```json
+[{"id":"5283665","from":"49150000000x","to":"4916092172595","text":"...",
+  "timestamp":"2026-08-10 09:19:31","reply_to_message_id":null,"price":0.01}]
+```
+
+Von den übrigen Feldern liest der Reader nur `text` und `from` — beide sind
+in Fixtures wie gemessener Antwort bereits korrekt als Zeichenkette
+typisiert. `timestamp`, `reply_to_message_id` und `price` werden vom Reader
+nicht gelesen (s. „Zeitstempel"-Punkt unter Known Limitations), ihr Typ ist
+für diese Scheibe irrelevant. Die ACs bleiben wörtlich unverändert; betroffen
+ist ausschließlich die interne Typumwandlung in Schritt 6.
 
 Schritt 1 kennt — anders als `sms.py`s Sandbox-Guard — keinen
 Sandbox-Key-Sonderfall: der Journal-**Lesepfad** ist gemessen NICHT isoliert
@@ -243,10 +275,13 @@ unverändert mit leerem Wert).
 
 Analog `forecast_budget.py:44-50` (Verzeichnis `diagnostics/` unter
 `get_data_root()`, NICHT `data/last_sms_id.txt` wie im veralteten
-Vorlagecode). Fail-open beim Lesen (kaputte/fehlende Datei -> 0), atomarer
-Write beim Schreiben. Der Zeiger wird auch im Dry-Run fortgeschrieben —
-er ist globaler Diagnose-State, kein Nutzerdatensatz, und verhindert, dass
-derselbe Dry-Run jeden Poll dieselben Nachrichten erneut protokolliert.
+Vorlagecode). Fail-open beim Lesen (kaputte/fehlende Datei ODER nicht
+umwandelbarer `last_seen_id`-Wert -> 0, Fix F004), atomarer Write beim
+Schreiben — die Zeigerdatei selbst speichert `last_seen_id` weiterhin als
+Zahl (der Reader wandelt beim Lesen um). Der Zeiger wird auch im Dry-Run
+fortgeschrieben — er ist globaler Diagnose-State, kein Nutzerdatensatz, und
+verhindert, dass derselbe Dry-Run jeden Poll dieselben Nachrichten erneut
+protokolliert.
 
 ## Expected Behavior
 
@@ -306,6 +341,8 @@ derselbe Dry-Run jeden Poll dieselben Nachrichten erneut protokolliert.
   - `test_dryrun_switch_polls_journal_but_writes_nothing` (AC-10)
   - `test_dryrun_switch_warns_loudly_on_stderr` (Vorbild `GZ_SKIP_FRONTEND_BROWSER_GATE`)
   - `test_fetch_uses_x_api_key_header_and_limit_param` (Abruf-Vertrag: `X-Api-Key`, `limit`, kein `date_from`)
+  - `test_string_ids_are_processed_and_deduplicated_across_runs` (Fix F004: Zeichenketten-`id` wie die echte API, Dedup über Läufe hinweg)
+  - `test_unparseable_id_is_skipped_without_aborting_the_run` (Fix F004: nicht umwandelbare `id` überspringt nur den Eintrag)
 - `internal/handler/premium_sms_connect_test.go` (Go, mit echtem Store gegen temporäres Testverzeichnis, zwei Nutzer wie von CLAUDE.md für datenbewegende Endpoints gefordert):
   - `TestLearnSetsReplyAddressForSoleUnambiguousPremiumUser` (AC-4)
   - `TestLearnRejectsWhenTwoPremiumUsersAndNoStoredMatch` (AC-5, kein Cross-User-Leck)
@@ -350,3 +387,15 @@ derselbe Dry-Run jeden Poll dieselben Nachrichten erneut protokolliert.
   `recordRun()`, sichtbar in `/api/scheduler/status`.
   `triggerGlobalEndpoint()` selbst bleibt unangetastet (daran hängen
   `inbound_command_poll` u. a.). ACs wörtlich unverändert.
+- 2026-08-10: v1.5 — Fix F004 (Produktionsfehler, live gemessen): die echte
+  seven.io-API liefert `id` im Journal-Eintrag als ZEICHENKETTE, nicht als
+  Zahl, wie v1.0–v1.4 fälschlich annahmen (Fixtures verwendeten erfundene
+  Zahlen-IDs statt der gemessenen Wirklichkeit). Der Vergleich
+  `id > last_seen_id` brach dadurch produktiv alle 5 Minuten mit `TypeError`
+  ab (`/api/scheduler/status` meldete `premium_sms_poll` dauerhaft als HTTP
+  500). Schritt 4/6 und die Dedup-Zeiger-Sektion korrigiert: `id` wird robust
+  nach `int` umgewandelt, eine einzelne nicht umwandelbare `id` überspringt
+  nur diesen Eintrag statt den ganzen Journal-Lauf abzubrechen. Fixtures in
+  `tests/unit/test_inbound_sms_reply_learning.py` liefern `id` jetzt als
+  Zeichenkette, exakt wie die gemessene API-Antwort. ACs wörtlich
+  unverändert.

--- a/src/services/inbound_sms_reader.py
+++ b/src/services/inbound_sms_reader.py
@@ -26,7 +26,15 @@ Rueckadressen, AC-7-Vertrag unveraendert); die Fehlschlagzahl liegt danach im
 Instanzfeld `last_failed_count` fuer den Trigger-Endpunkt (Team-Lead-Entscheid
 #1676 S1 Fix-Loop, s. `api/routers/scheduler.py::trigger_inbound_sms`).
 
-SPEC: docs/specs/modules/feat_1676_s1_premium_sms_rueckkanal.md v1.2
+Fix F004 (Produktionsfehler, gemessen 2026-08-10): die echte seven.io-API
+liefert `id` im Journal-Eintrag als ZEICHENKETTE (`"5283665"`), nicht als
+Zahl -- der Vergleich `id > last_seen_id` brach deshalb mit `TypeError` ab
+und legte den Cron-Job alle 5 Minuten lahm. `_coerce_message_id()` wandelt
+jede `id` robust in eine ganze Zahl um; eine einzelne nicht umwandelbare `id`
+ueberspringt NUR diese Nachricht (mit Warnung), bricht aber nicht den ganzen
+Lauf ab -- Fail-soft je Eintrag, nicht Fail-hard fuer das ganze Journal.
+
+SPEC: docs/specs/modules/feat_1676_s1_premium_sms_rueckkanal.md v1.5
 """
 from __future__ import annotations
 
@@ -130,16 +138,26 @@ class InboundSmsReader:
         if messages is None:
             return 0, 0  # Netz-/HTTP-Fehler -- last_seen_id bleibt unveraendert
 
-        new_messages = sorted(
-            (m for m in messages if m.get("id", 0) > last_seen_id),
-            key=lambda m: m.get("id", 0),
-        )
+        parsed: list[tuple[int, dict]] = []
+        for m in messages:
+            raw_id = m.get("id", 0)
+            msg_id = _coerce_message_id(raw_id)
+            if msg_id is None:
+                logger.warning(
+                    "journal/inbound Eintrag mit nicht umwandelbarer id %r "
+                    "wird uebersprungen (Fix F004), Rest des Journal-Fensters "
+                    "wird weiterverarbeitet.", raw_id,
+                )
+                continue
+            if msg_id > last_seen_id:
+                parsed.append((msg_id, m))
+
+        new_messages = sorted(parsed, key=lambda pair: pair[0])
 
         learned = 0
         failed = 0
         max_seen = last_seen_id
-        for message in new_messages:
-            msg_id = message.get("id", 0)
+        for msg_id, message in new_messages:
             text = message.get("text", "") or ""
             if GARMIN_MARKER not in text:
                 max_seen = max(max_seen, msg_id)
@@ -214,13 +232,14 @@ class InboundSmsReader:
             return None
 
     def _load_last_seen_id(self, data_root: Path) -> int:
-        """Fail-open: kaputte/fehlende Zeigerdatei -> 0."""
+        """Fail-open: kaputte/fehlende Zeigerdatei ODER nicht umwandelbarer
+        `last_seen_id`-Wert -> 0 (Fix F004)."""
         path = data_root / "diagnostics" / _DEDUP_POINTER_NAME
         try:
             data = json.loads(path.read_text())
-            return int(data.get("last_seen_id", 0))
         except Exception:
             return 0
+        return _coerce_message_id(data.get("last_seen_id", 0)) or 0
 
     def _save_last_seen_id(self, data_root: Path, last_seen_id: int) -> None:
         """Atomarer Write (tempfile + os.rename), auch im Dry-Run (Spec:
@@ -239,6 +258,18 @@ class InboundSmsReader:
                 os.remove(tmp_path)
             except OSError:
                 pass
+
+
+def _coerce_message_id(raw) -> int | None:
+    """Wandelt eine Journal-`id` robust in eine ganze Zahl um (Fix F004): die
+    echte seven.io-API liefert `id` als Zeichenkette (`"5283665"`), unsere
+    aeltesten Fixtures nahmen faelschlich eine Zahl an. `None` bei jedem Wert,
+    der sich nicht umwandeln laesst -- der Aufrufer ueberspringt dann NUR
+    diesen einen Eintrag, statt den ganzen Journal-Lauf abzubrechen."""
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
 
 
 def _mask(number: str) -> str:

--- a/tests/unit/test_inbound_sms_reply_learning.py
+++ b/tests/unit/test_inbound_sms_reply_learning.py
@@ -25,7 +25,13 @@ verfaelschte R3-Regel im Fake liess KEINEN Python-Test rot werden). Der
 Alle Rufnummern sind erfunden (`491700000000x`), einzige echte Nummer ist die
 im Issue oeffentliche Dienst-Nummer `4916092172595` als `to`-Feld.
 
-SPEC: docs/specs/modules/feat_1676_s1_premium_sms_rueckkanal.md v1.1
+Fix F004 (Produktionsfehler, gemessen 2026-08-10): die echte seven.io-API
+liefert `id` als ZEICHENKETTE (`"5283665"`), nicht als Zahl. Die
+Fixture-Helfer unten geben `id` deshalb als `str(msg_id)` weiter, exakt wie
+die gemessene Antwort -- Zahlen-IDs in Fixtures haetten den Fehler nicht
+gefangen (Team-Lead-Befund: kein Test bewachte den echten Datentyp).
+
+SPEC: docs/specs/modules/feat_1676_s1_premium_sms_rueckkanal.md v1.5
 """
 from __future__ import annotations
 
@@ -45,7 +51,7 @@ class AssertedNetworkTouch(Exception):
 
 def _garmin_message(msg_id: int, sender: str, text_suffix: str = "g-0Ab1Cd2Ef") -> dict:
     return {
-        "id": msg_id,
+        "id": str(msg_id),  # Fix F004: echte API liefert id als Zeichenkette
         "from": sender,
         "to": SERVICE_NUMBER,
         "text": f"Test ueber App inreachlink.com/{text_suffix}... (51.9956, 7.7136)",
@@ -57,7 +63,7 @@ def _garmin_message(msg_id: int, sender: str, text_suffix: str = "g-0Ab1Cd2Ef") 
 
 def _private_message(msg_id: int, sender: str) -> dict:
     return {
-        "id": msg_id,
+        "id": str(msg_id),  # Fix F004: echte API liefert id als Zeichenkette
         "from": sender,
         "to": SERVICE_NUMBER,
         "text": "Hallo, bist du morgen da?",
@@ -593,3 +599,83 @@ def test_router_reports_partial_when_learn_failures_occurred(monkeypatch):
         f"ein Fehlschlag darf NICHT als 'ok' gemeldet werden, bekam {response!r}"
     )
     assert response["failed"] == 1
+
+
+# =============================================================================
+# Fix F004 (Produktionsfehler, gemessen 2026-08-10): die echte seven.io-API
+# liefert `id` als Zeichenkette -- der Vergleich `id > last_seen_id` brach
+# deshalb mit TypeError ab und legte den Cron-Job alle 5 Minuten lahm.
+# =============================================================================
+
+def test_string_ids_are_processed_and_deduplicated_across_runs(monkeypatch):
+    """Fix F004: Given das Journal liefert `id` als Zeichenkette (exakt wie
+    die echte seven.io-API) / When der Poll zweimal laeuft (zweiter Lauf mit
+    derselben plus einer neuen, hoeheren id) / Then wird die Nachricht im
+    ersten Lauf korrekt verarbeitet, der Dedup-Zeiger wandert ueber
+    Laeufe hinweg weiter, und der zweite Lauf verarbeitet NUR die neue id --
+    ohne diesen Fix bricht bereits der erste Lauf mit TypeError ab."""
+    import services.inbound_sms_reader as reader_mod
+
+    _fake_production_origin(monkeypatch, reader_mod)
+
+    fake_post = _LearnCallRecorder()
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    # Lauf 1: einzige Nachricht mit String-id "9001" (wie die echte API).
+    fake_get_1 = _FakeJournalEndpoint([[_garmin_message(9001, GARMIN_FROM_A)]])
+    monkeypatch.setattr(httpx, "get", fake_get_1)
+    reader = reader_mod.InboundSmsReader()
+    result_1 = reader.poll_and_process(_settings())
+    assert result_1 == 1, f"erwartet 1 gelernte Rueckadresse, bekam {result_1!r}"
+    assert len(fake_post.calls) == 1
+    assert fake_post.calls[0]["json"]["from"] == GARMIN_FROM_A
+
+    # Lauf 2: dieselbe Nachricht (id "9001") plus eine neue (id "9002").
+    fake_get_2 = _FakeJournalEndpoint(
+        [[_garmin_message(9001, GARMIN_FROM_A), _garmin_message(9002, GARMIN_FROM_B)]]
+    )
+    monkeypatch.setattr(httpx, "get", fake_get_2)
+    result_2 = reader.poll_and_process(_settings())
+    assert result_2 == 1, (
+        f"Lauf 2 darf NUR die neue id \"9002\" lernen, bekam {result_2!r}"
+    )
+    assert len(fake_post.calls) == 2, (
+        f"Fix F004: id \"9001\" darf im Lauf 2 NICHT erneut gelernt werden "
+        f"(Dedup ueber Zeichenketten-IDs hinweg), gesehen: {fake_post.calls!r}"
+    )
+    assert fake_post.calls[1]["json"]["from"] == GARMIN_FROM_B
+
+
+def test_unparseable_id_is_skipped_without_aborting_the_run(monkeypatch):
+    """Fix F004: Given das Journal-Fenster enthaelt einen Eintrag mit
+    NICHT umwandelbarer `id` (`"abc"`) zwischen zwei gueltigen Garmin-
+    Nachrichten / When der Poll laeuft / Then werden die beiden gueltigen
+    Nachrichten trotzdem verarbeitet -- der kaputte Eintrag wird
+    uebersprungen, der Lauf bricht NICHT ab."""
+    import services.inbound_sms_reader as reader_mod
+
+    _fake_production_origin(monkeypatch, reader_mod)
+
+    broken_entry = _garmin_message(0, GARMIN_FROM_A)
+    broken_entry["id"] = "abc"
+    journal = [
+        _garmin_message(9101, GARMIN_FROM_A),
+        broken_entry,
+        _garmin_message(9102, GARMIN_FROM_B),
+    ]
+    fake_get = _FakeJournalEndpoint([journal])
+    fake_post = _LearnCallRecorder()
+    monkeypatch.setattr(httpx, "get", fake_get)
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    reader = reader_mod.InboundSmsReader()
+    result = reader.poll_and_process(_settings())
+
+    assert result == 2, (
+        f"beide gueltigen Nachrichten muessen trotz kaputter id verarbeitet "
+        f"werden, bekam {result!r}"
+    )
+    assert len(fake_post.calls) == 2, (
+        f"der kaputte Eintrag darf den Lauf NICHT abbrechen, gesehen: {fake_post.calls!r}"
+    )
+    assert {c["json"]["from"] for c in fake_post.calls} == {GARMIN_FROM_A, GARMIN_FROM_B}


### PR DESCRIPTION
fix(#1676): seven.io liefert die Nachrichten-id als Zeichenkette

Produktivfehler seit dem S1-Rollout: der Cron-Job `premium_sms_poll`
scheiterte alle 5 Minuten mit

  TypeError: '>' not supported between instances of 'str' and 'int'
  src/services/inbound_sms_reader.py:134

Die echte Journal-Antwort liefert `id` als Zeichenkette (`"5283665"`), der
Reader verglich sie gegen einen Zahl-Zeiger. Die Rueckadresse wurde dadurch
nie gelernt.

Der eigentliche Befund ist nicht der Vergleich, sondern die Fixtures: sie
verwendeten Zahlen-ids und bildeten damit eine erfundene Wirklichkeit ab,
obwohl die gemessene Antwort vorlag. Alle Tests blieben gruen, weil sie die
erfundene Variante prueften. Fixtures sind jetzt an die gemessene Form
angeglichen (id als Zeichenkette).

- `_coerce_message_id()` wandelt robust nach int; ein Eintrag mit
  unbrauchbarer id wird uebersprungen statt den ganzen Lauf abzubrechen
  (Fail-soft je Eintrag). Gilt auch beim Laden des gespeicherten Zeigers.
- Neuer Reproduktions-Test ueber zwei Laeufe mit Zeichenketten-ids; die
  Gegenprobe belegt, dass er ohne den Fix mit exakt dem gemeldeten
  TypeError rot wird.
- Neuer Test: unbrauchbare id zwischen zwei gueltigen Nachrichten -> beide
  gueltigen werden verarbeitet, kein Abbruch.
- Typ-Durchsicht der uebrigen Journal-Felder: der Reader liest nur `id`,
  `text` und `from`; `price`/`timestamp`/`reply_to_message_id` werden nicht
  gelesen. Kein weiterer Fund.

Spec auf v1.5: die Zeichenketten-id ist jetzt ausdruecklich festgehalten,
mit dem Hinweis, dass die Annahme in v1.0-v1.4 falsch war. Nebenbei die
Tabellenformatierung des v1.4-Nachtrags repariert.

Sichtbar wurde der Fehler nur, weil der Job seinen Fehlschlag seit v1.2/v1.3
in den Scheduler-Status meldet statt bedingungslos Erfolg zu behaupten.

Refs #1676

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X9SjbKBjrAnEAifJYciPRg
