### PR TITLE
docs(#1661): Die zwei neuen briefing_health-Felder im API-Vertrag nachgetragen

### DIFF
--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -1121,7 +1121,9 @@ Returns current scheduler state with per-job metadata (next_run, last_run).
     "provider_error_streak_since": "2026-08-09T14:32:00Z",
     "provider_errors_recent_count": 1,
     "briefing_dispatch_error_streak_since": "2026-08-10T09:00:00Z",
-    "briefing_dispatch_errors_recent_count": 2
+    "briefing_dispatch_errors_recent_count": 2,
+    "alert_anchor_rejected_streak_since": "2026-08-10T11:15:00Z",
+    "alert_anchor_rejected_recent_count": 4
   },
   "tier_request_health": {
     "open_count": 1,
@@ -1147,11 +1149,13 @@ Returns current scheduler state with per-job metadata (next_run, last_run).
 | jobs[].overlap | object \| null (Issue #1447 S2a) | Present **only** when at least one tick has been skipped since the last executed run of this job, because the previous run of the same job ID was still in progress (`sync.Mutex.TryLock()` in `recordRun`). Absent field means no overlap is occurring — never an error signal. |
 | jobs[].overlap.skipped_since_last_run | int | Number of consecutive ticks skipped since the last executed run; resets to 0 (and the `overlap` field disappears) the next time the job actually runs, regardless of outcome |
 | jobs[].overlap.last_skipped_at | datetime | ISO-8601 UTC timestamp of the most recently skipped tick |
-| briefing_health | object (Issues #1115, #1421, #1629) | Health metrics for scheduler services (provider/weather and briefing dispatch). Privacy-safe aggregate across all users — only numeric, no `user_id`/`trip_id` appears here. |
+| briefing_health | object (Issues #1115, #1421, #1629, #1661) | Health metrics for scheduler services (provider/weather, briefing dispatch, deviation-alert anchors). Privacy-safe aggregate across all users — only numeric and timestamps, no `user_id`/`trip_id`/reason appears here. |
 | briefing_health.provider_error_streak_since | string \| null (Issue #1115, ADR-0018) | ISO-8601 UTC timestamp when the current unbroken series of provider (weather/forecast API) errors started, or `null` if no error streak is active. External monitor calculates `now - provider_error_streak_since` to escalate with outage duration. Gap threshold (for streak detection): 2 hours. |
 | briefing_health.provider_errors_recent_count | int (Issue #1115, ADR-0018) | Count of provider errors in the last 24 hours. Used to distinguish temporary transients from persistent outages. |
 | briefing_health.briefing_dispatch_error_streak_since | string \| null (Issue #1629) | ISO-8601 UTC timestamp when the current unbroken series of trip/compare briefing dispatch (send) errors started, or `null` if no dispatch error streak is active. Tracks send failures separately from weather data availability. Gap threshold: 26 hours (briefings run 1–2 times daily per user, so a 2-hour threshold would mask single failures). |
 | briefing_health.briefing_dispatch_errors_recent_count | int (Issue #1629) | Count of briefing dispatch errors in the last 24 hours (recorded in `users/<uid>/diagnostics/briefing_dispatch_failures.jsonl`). |
+| briefing_health.alert_anchor_rejected_streak_since | string \| null (Issue #1661) | ISO-8601 UTC timestamp when the current unbroken series of **rejected deviation-alert anchors** started, or `null` if no streak is active. An anchor is rejected when it describes a different calendar day than today (`wrong_day`), is older than the 26 h fallback limit (`too_old`), or is missing entirely while the trip is already running (`missing`) — in each case the deviation guard has no valid comparison point and stays silent. Gap threshold: **60 minutes** (the alert check runs every 15 minutes, so an hour without a further rejection ends the series; the 26 h threshold used for briefings would keep the same fault invisible for days). |
+| briefing_health.alert_anchor_rejected_recent_count | int (Issue #1661) | Count of rejected deviation-alert anchors in the last 24 hours (recorded in `users/<uid>/diagnostics/alert_anchor_rejected.jsonl`). Only the timestamp is decoded on the Go side — neither the trip id nor the rejection reason leaves the Python core (#252). |
 | tier_request_health | object (Issue #1555) | Privacy-safe aggregate of open tier-change requests (`POST /api/auth/tier-change-request`, Issue #1071) across ALL users. Purely numeric — the endpoint is public, so no `user_id`, `display_name` or e-mail ever appears here (#252). A request counts as **done** when `requested_tier` is empty OR equals the effective `tier`; only otherwise it is **open**. |
 | tier_request_health.open_count | int | Number of currently open tier-change requests across all users. `0` when none are pending. |
 | tier_request_health.oldest_open_age_hours | float | Age in hours of the **oldest** open request (from its `requested_at`); `0.0` when `open_count` is 0 or no open request carries a `requested_at`. Raw hours only — the 7-day overdue threshold is evaluated by the external monitor (`check-gregor20.sh`), not here. |


### PR DESCRIPTION
Nachtrag zu #1661 (PR #1694, live seit 2026-08-10).

`alert_anchor_rejected_streak_since` und `alert_anchor_rejected_recent_count` sind an `/api/scheduler/status` live, standen aber nicht in `docs/reference/api_contract.md` — obwohl dort beide Vorgaengerfelder dokumentiert sind (#1115 Provider, #1629 Versand) und die Datei laut CLAUDE.md die **Single Source of Truth fuer DTOs und Datenformate** ist.

Ergaenzt:
- Beispielblock der Statusantwort
- Feldtabelle mit Bedeutung der drei Ablehnungsgruende (`wrong_day`, `too_old`, `missing`)
- Begruendung der **60-Minuten**-Luecke: der Alarm-Check laeuft alle 15 Minuten, die 26 h der Briefing-Diagnose liessen denselben Fehler tagelang unsichtbar
- Privacy-Zusicherung (#252): nur der Zeitstempel wird auf der Go-Seite dekodiert, weder Trip-Kennung noch Ablehnungsgrund verlassen den Python-Kern
- `briefing_health`-Sammelzeile um #1661 erweitert

Reine Doku-Aenderung, kein Code. `tests/test_api_contract_drift.py` gruen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRLKfjLxYAg8fSTeNRWM6r