### PR TITLE
fix(#1697): Alarm-Pfad folgt dem Ortstag der Tour statt der Serveruhr

### DIFF
--- a/docs/context/fix-1667-s3-tagesuebergreifende-segmente.md
+++ b/docs/context/fix-1667-s3-tagesuebergreifende-segmente.md
@@ -1,0 +1,365 @@
+# Context: fix-1667-s3-tagesuebergreifende-segmente
+
+**Issue:** [#1667](https://github.com/henemm/gregor_zwanzig/issues/1667) — Scheibe **S3**
+**Workflow:** `fix-1667-s3-tagesuebergreifende-segmente` (Full Process, Intake-Score 4)
+**Erstellt:** 2026-08-10 · Basis-HEAD `ffb82a40` (enthält S1 `db14acd3` und S2 `8d36dc8c`)
+**Vorgänger-Kontext:** `docs/context/fix-1667-arrival-midnight-wrap.md` (S1/S2 — gilt weiter, wird hier nicht wiederholt)
+
+## Request Summary
+
+Nach S2 werden Segmente einer Etappe mit Ankunft nach Mitternacht **korrekt gebaut** — die
+Alarm-Pipeline **findet sie aber nicht**, weil sie ausschließlich den heutigen Kalendertag
+abfragt. S3 soll die Etappenauswahl tagesübergreifend machen, damit ein Wanderer mit
+Abendstart seine Radar-/NowCast-Überwachung behält (heute: bis zu 11 h 50 min Verlust) und
+damit bei Mehr-Etappen-Trips nicht still der falsche Ort abgefragt wird.
+
+## Ist-Stand, am Code gemessen
+
+### Die eine Zeile, an der alles hängt
+
+`src/services/trip_alert.py:739,745`:
+
+```python
+today = date_type.today()          # 739
+...
+segments = convert_trip_to_segments(trip, today)   # 745
+if not segments:
+    continue
+```
+
+`convert_trip_to_segments` löst über `Trip.get_stage_for_date` (`src/app/trip.py:268-272`)
+per **striktem `==`** auf und liefert `[]`, wenn keine Etappe genau dieses Datum trägt.
+Eine gestrige Etappe, deren Segmente real bis heute Mittag laufen, ist damit unauffindbar.
+
+Zwei gemessene Folgen um 02:00 UTC am Folgetag:
+
+| Trip-Form | Verhalten heute | Wirkung |
+|---|---|---|
+| **Ein-Etappen-Trip** | `[]` → `continue` | **null Alarme**, obwohl die Segmente korrekt gebaut würden |
+| **Mehr-Etappen-Trip** | heutige Etappe liefert Segmente, aber keines ist aktiv ⇒ `now_utc < segments[0].start_time` ⇒ `active = segments[0]` | **stille Falsch-Ortung**: Radar für den Startpunkt der *nächsten* Etappe (gemessen: Wanderer `(42.34, 8.94)`, Abfrage `(42.42, 9.02)`) |
+
+### Was S2 bereits richtig macht — S3 muss hier nichts nachrechnen
+
+Der PO-Beschluss „Überwachung bis Tagesfenster-Ende" ist im Ziel-Segment
+(`src/services/trip_segments.py:264-290`) **bereits erfüllt**: `arrival_local_date` leitet
+sich aus der Ankunfts-**Ortszeit** ab, bei 22:00-Start also aus dem Folgetag; `window_end`
+liegt dann auf Folgetag 19:00 Ortszeit. Die Segmente von gestern reichen real bis in den
+heutigen Nachmittag. S3 ist deshalb reine **Auswahl**, keine neue Zeitrechnung.
+
+## Related Files
+
+### Die drei Kopien der Aktiv-Segment-Auswahl (nicht zwei)
+
+| Datei:Zeile | Funktion | Verhalten wenn nichts aktiv |
+|---|---|---|
+| `src/services/trip_alert.py:749-764` | `check_radar_alerts` | `now < segments[0].start_time` → `segments[0]`; sonst `continue` (**S3-Kern**) |
+| `src/services/trip_report_scheduler.py:1341-1350` | `_build_starkregen_hint` | identische Logik, dann `return None` |
+| `api/routers/debug.py:76-83` | Staging-Debug-Seam | **kein** Vergangenheits-Abbruch, fällt immer auf `segments[0]` |
+
+⚠️ Der Docstring bei `trip_report_scheduler.py:1333` verweist auf „trip_alert.py:730-745" —
+**veraltet**, die Stelle sitzt bei 745-764. Beim Anfassen mitziehen.
+
+⚠️ **Wichtiger Unterschied zwischen den beiden Produktivkopien:** `check_radar_alerts` ist
+eine **Now-Schleife über alle Trips** und löst das Datum selbst auf.
+`_build_starkregen_hint` bekommt die Segmentliste dagegen **von außen** gereicht
+(`trip_report_scheduler.py:1060-1062`), gebaut zum Briefing-`target_date`
+(`_get_target_date`: morgens `today`, abends `today+1`). Die Datumsauflösung sitzt dort
+also gar nicht in der Kopie — „beide Kopien fixen" ist deshalb **nicht** dasselbe wie
+„zweimal dieselbe Zeile ändern". Das ist eine Analyse-Frage, keine Implementierungsfrage.
+
+### Die fünf „Segment vorbei"-Guards — mit Scope-Bewertung
+
+| Datei:Zeile | Was unterdrückt wird | S3-relevant? |
+|---|---|---|
+| `src/services/trip_alert.py:756-764` | Radar-/NowCast-Alarm komplett | **ja — Kern** |
+| `src/services/trip_alert.py:1005-1010` | `_fetch_fresh_weather`: `end_time < now_utc` → skip; `start_time.date() > today_utc` → skip | **zu prüfen** — arbeitet auf gecachten Segmenten, nicht auf der Datumsauflösung |
+| `src/services/trip_alert.py:1155-1158` | `check_official_alert_triggers`: `end_time < now_utc` → skip | **zu prüfen** — dito |
+| `src/services/trip_report_scheduler.py:1346-1350` | Kein Nowcast-Call im Briefing-Pfad | **ja**, aber s. o. (Datum kommt vom Aufrufer) |
+| `src/services/corridor_threshold.py:84-87` | Korridor-/Schwellentreffer | **nein** — `evaluate_corridor_thresholds` hat **keinen Produktions-Aufrufer**, nur Tests (`tests/tdd/test_corridor_threshold_evaluation.py:79`, `tests/tdd/test_alert_log_metrics.py:97`). Anfassen wäre Scope ohne Nutzerwirkung |
+
+Nur eine Debug-Warnung, **kein** Skip: `src/services/segment_weather.py:386-392`.
+
+### Alle Aufrufer der Segmentbildung (Datum-Argument je Stelle)
+
+| Datei:Zeile | Funktion | Datum |
+|---|---|---|
+| `src/services/trip_alert.py:745` | `check_radar_alerts` | `date.today()` |
+| `src/services/trip_report_scheduler.py:424` | `_process_pending_markers` | Marker-Datum |
+| `src/services/trip_report_scheduler.py:858` | `_send_trip_report_outcome` | `_get_target_date()` |
+| `src/services/trip_report_scheduler.py:868` | `_send_trip_report_outcome` | `select_test_stage().date` |
+| `src/services/trip_report_scheduler.py:1761` | `_build_stage_trend` | `stage.date` |
+| `src/services/trip_report_scheduler.py:2153` | `_collect_future_stage_weather` | `stage.date` |
+| `src/services/trip_command_processor.py:296-297` | `_ensure_fresh_snapshot` | **`today` UND `tomorrow`**, Ergebnis addiert |
+| `src/services/preview_service.py:143` | Preview | `target` |
+| `src/services/stage_weather.py:49` | `_segments_for_stage` | `stage.date` (Scoped Trip) |
+| `api/routers/debug.py:63,70` | Debug-Seam | `today`, dann Fallback über **alle** Stages |
+| `tools/weather_validation.py:99` | Validierungswerkzeug | `_get_target_date()` |
+
+## Existing Patterns
+
+### Es gibt bereits zwei Präzedenzfälle für „mehr als ein Tag"
+
+1. **`trip_command_processor.py:296-297`** — `segments + segments_tomorrow`, also schlichte
+   Addition zweier Tage. Vorbild für die *Form* eines additiven Fallbacks; Richtung ist
+   allerdings vorwärts, nicht rückwärts.
+2. **`api/routers/debug.py:70`** — Fallback-Schleife über alle Stages, nimmt die erste, die
+   Segmente liefert. Nur Staging-Debug, aber der einzige existierende „Datum-egal"-Pfad.
+
+**Kein** Produktivpfad löst heute die Etappe des **Vortags** auf. Tagesübergreifende
+Segmente entstehen ausschließlich intern über den `wp_days`-Offset
+(`trip_segments.py:150-158`, #1091/#1098).
+
+### Gegenrichtung — nicht verwechseln
+
+`trip_report_scheduler.py:1422-1444` (`_clamp_segments_to_today`, #1325) verschiebt
+vergangene Segmentzeiten **vorwärts auf heute** — reiner Test-Fallback
+(`allow_test_fallback`). Das ist die Umkehrung dessen, was S3 tut, und darf nicht
+angefasst oder als Vorbild genommen werden.
+
+### Test-Uhr: zwei Hausmuster, beide vorhanden
+
+| Muster | Produktivnaht | Testbeispiel |
+|---|---|---|
+| **`now_fn`-Fabrik im Konstruktor** | `src/services/radar_service.py:127` — `self._now_fn = now_fn or (lambda: datetime.now(timezone.utc))` | `tests/unit/test_radar_nowcast_cache_sharing.py:126-128` |
+| **`now=`-Parameter** durchgereicht | `alert_gate`, Budget-Gates, `check_nowcast_gate` | `tests/tdd/test_alert_gate.py:108`, `tests/unit/test_forecast_budget_gate.py:326` |
+| **`freeze_time`** (seit S1 Dev-Dependency) | — | `tests/unit/test_arrival_window_fixtures.py:256-261` |
+
+`TripAlertService.check_radar_alerts` hat **keine** von beiden — `now_utc` und `today`
+kommen roh aus der Wanduhr. Die Wahl zwischen `_now_fn` und `freeze_time` ist eine
+Analyse-Entscheidung; beide sind Hauskonvention, `freeze_time` ist seit S1 verfügbar und
+bräuchte **keine** Produktivcode-Naht.
+
+## Dependencies
+
+- **Upstream:** `naismith.py` (Ankunft, seit S2 mit Modulo-Wrap) → `trip_segments.py`
+  (Segmentbau inkl. `wp_days`-Rollover und Ziel-Segment nach #1584) → `Trip.get_stage_for_date`
+- **Downstream:** Radar-/NowCast-Alarme (`check_radar_alerts`), Briefing-Starkregenhinweis
+  (`_build_starkregen_hint`), und über den geteilten Freigabe-Baustein `check_nowcast_gate`
+  (#1467 S3) die Ruhezeit-/Sperrzeit-/Tagesgrenzen-Kette (`alert_daily_limit`, `ThrottleStore`)
+
+## Existing Specs & ADRs
+
+| Dokument | Kernaussage für S3 |
+|---|---|
+| `docs/specs/modules/fix_1667_s2_naismith_wrap.md:362-367` | Known Limitation formuliert die S3-Aufgabe wörtlich: „`trip_alert.py:745` fragt weiterhin nur den heutigen Tag ab. Behoben erst durch S3." |
+| `docs/specs/modules/fix_1584_alarm_zeitfenster.md:310-323` | 🔴 **Abgrenzung:** Ein *konfiguriertes Tagesfenster über Mitternacht* (22–2 Uhr) ist am Zielsegment bewusst ausgeschlossen. Das ist **nicht** derselbe Fall wie eine *Etappe mit Ankunft nach Mitternacht*. `test_mitternachtsfenster_22_2_klemmt_auf_mindestfenster` muss grün bleiben |
+| `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` | Kalendertage folgen der Ortszeit — relevant, weil `trip_alert.py:739` `date.today()` (Server-Lokalzeit) nutzt, nicht die Ortszeit der Etappe |
+| `docs/adr/0035-ein-tagesfenster-fuer-trip-und-ortsvergleich.md` | Ein Auflöser `resolve_configured_window()`, Default 4–19 |
+| `docs/reference/api_contract.md:905,917,933` | `arrival_calculated` bleibt reiner `HH:MM`-String — von S3 unberührt |
+
+## Bestehende Wächter — was nicht brechen darf
+
+| Test | Zusichert | Läuft in CI? |
+|---|---|---|
+| `tests/tdd/test_issue_822_radar_nowcast_segment.py:232` (`test_ac2_segment_selection_by_time`, Fall a) | aktives Segment wird gewählt | **nein** (`ci_tdd_excludes.txt`) |
+| `tests/tdd/test_issue_822_radar_nowcast_segment.py:313` (Fall c) | **alle Segmente vorbei ⇒ kein Alarm** | **nein** |
+| `tests/tdd/test_issue_818_radar_briefing_integration.py:419` (`test_ac5_past_segment_no_alert_guard_test`) | dasselbe, NZ-Zone, Fenster 0–1 | **nein** |
+| `tests/unit/test_alarm_zeitfenster_ziel.py:527` (`test_radarpfad_spaetankunft_faellt_nicht_in_alle_segmente_vorbei`) | Umkehrrichtung: Spätankunft darf **nicht** in „alle vorbei" fallen | **ja** |
+| `tests/unit/test_alarm_zeitfenster_ziel.py:605` (`test_mitternachtsfenster_22_2_klemmt_auf_mindestfenster`) | PO-Entscheidung 2026-08-08 | **ja** |
+| `tests/unit/test_alarm_zeitfenster_ziel.py:420-724` (12 Tests, AC-1…AC-6 aus #1584) | Tagesfenster am Ziel | **ja** |
+| `tests/unit/test_arrival_window_fixtures.py` (10 Tests) | S1-Helfer + Segmentbau unter `freeze_time` nie „alle vorbei" | **ja** |
+| `tests/tdd/test_fixture_wallclock_ratchet.py` (13 Tests) | S1-Ratsche gegen Wanduhr-Fixtures | **ja** |
+| `tests/tdd/test_naismith_midnight_wrap_segments.py`, `test_naismith_hhmm_wrap_parity.py` | S2 | **ja** |
+| `tests/tdd/test_starkregen_kurzfristhinweis.py:277-626` (AC-1…AC-8) | Briefing-Starkregenhinweis; **kein** eigener Test für den Zweig „alle vorbei → `return None`" | **ja** |
+
+🔴 **Der wichtigste Befund aus der Testkartierung:** Genau die beiden Tests, die die von S3
+zu ändernde Zusicherung („alle Segmente vorbei ⇒ kein Alarm") ausdrücklich festschreiben,
+stehen **beide** in `.github/ci_tdd_excludes.txt` und laufen nicht in CI. Ein S3, das sie
+anpasst und nur lokal grün prüft, ändert eine Zusicherung, die in CI von **niemandem**
+bewacht wird. Der neue Nachweis muss CI-laufend sein.
+
+## Risks & Considerations
+
+1. 🔴 **Die Vorrangregel ist die eigentliche Designentscheidung — und die naive Fassung
+   greift zu kurz.** „Heute gewinnt, gestern nur wenn heute nichts liefert" behebt den
+   Ein-Etappen-Fall, **nicht** die Falsch-Ortung: Beim Mehr-Etappen-Trip *liefert* heute
+   sehr wohl Segmente (die Etappe ab 08:00), es ist nur keines aktiv, und die
+   Vorstart-Regel (`now < segments[0].start_time → segments[0]`) greift zu. Der Fallback
+   muss also **vor** der Vorstart-Regel ausgewertet werden. Formulierung, die beides trifft:
+   *ein aktives Segment von heute gewinnt; erst danach ein aktives Segment von gestern; erst
+   danach die Vorschau auf heute.* Gehört als eigenes AC in die Spec.
+2. **Doppel-Aktivierung.** Nach S2 überlappen Ziel-Segment von gestern (bis ~19:00 Ortszeit)
+   und Etappe von heute (ab 08:00) real. Was passiert zwischen 08:00 und 19:00, wenn beide
+   aktiv sind? Regel muss deterministisch und begründet sein, nicht Listenreihenfolge + `break`.
+3. **Zwei Kopien, aber nicht symmetrisch.** Die Datumsauflösung sitzt nur in
+   `check_radar_alerts`; im Scheduler kommt sie vom Aufrufer (`_get_target_date`). Ob der
+   Briefing-Pfad überhaupt einen Vortags-Fallback *will* (das Briefing gilt einem Zieltag),
+   ist offen — abends baut er sogar `today+1`.
+4. **Alarm-Häufigkeit / Kontingent.** Ein zusätzlich gefundenes aktives Segment heißt
+   zusätzliche Radar-/NowCast-Abrufe. `check_nowcast_gate` (#1467 S3) drosselt per
+   `trip.id` — ein zweites Segment desselben Trips erzeugt keinen zweiten Alarm, aber
+   möglicherweise Abrufe. Gegen `alert_daily_limit` und `ThrottleStore` zu prüfen.
+5. **`date.today()` ist Server-Lokalzeit, nicht Ortszeit** (`trip_alert.py:739`). Server
+   läuft auf `Etc/UTC`, deshalb heute deckungsgleich mit UTC — aber es ist eine
+   undokumentierte Kopplung und steht quer zu ADR-0044. Ob S3 das mitzieht oder als
+   Known Limitation benennt, ist eine Zuschnitt-Entscheidung.
+6. **Kein Nachweis ohne Uhr.** Der Kernbeweis („um 02:00 UTC werden die Koordinaten des
+   tatsächlich begangenen Segments abgefragt") braucht eine gestellte Uhr. `freeze_time`
+   ist seit S1 verfügbar und bräuchte keine Produktivnaht; `_now_fn` wäre die
+   explizitere, aber invasivere Variante.
+7. **Ein Test auf „Alarm entsteht" hätte die Falsch-Ortung nie gefunden.** Der Nachweis
+   muss auf die **Koordinaten** des gewählten Segments zielen, nicht auf einen Zähler.
+8. **`corridor_threshold.py` nicht anfassen** — kein Produktions-Aufrufer. Ein Fix dort
+   wäre unbelegbare Arbeit.
+9. **LoC-Limit 250**, `tests/` zählt mit. Geschätzt ~120–130 Produktiv+Test; der
+   CI-laufende Ersatznachweis für die zwei ausgeschlossenen Tests kommt obendrauf.
+10. **Rückwärts-Suche darf nicht unbegrenzt sein.** „Gestern" heißt genau ein Tag;
+    ein Trip mit Lücken oder eine mehrtägige Rückwärtssuche wäre neuer Scope.
+
+---
+
+## Analysis (Phase 2)
+
+### Type
+**Bug.** Sicherheitsrelevant: Verlust der Radar-/NowCast-Überwachung. Kein neues Verhalten,
+sondern die Wiederherstellung einer Zusicherung, die #822 bereits gegeben hat.
+
+### Was die Gegenprüfung bestätigt hat
+
+| Behauptung | Ergebnis |
+|---|---|
+| Ein-Etappen-Trip 02:00 UTC ⇒ null Radar-Alarme | **hält** — `get_stage_for_date` strikt `==` (`src/app/trip.py:268-272`) |
+| Mehr-Etappen-Trip ⇒ echter Radar-Abruf für den falschen Ort | **hält** — zwischen Auswahl (`trip_alert.py:749-758`) und `get_nowcast` (`:812-819`) liegt **kein** Horizont-/Näheguard. `NOWCAST_HORIZON_MIN` kommt in `trip_alert.py` nicht vor; der Guard sitzt nur in der Schwesterfunktion `trip_report_scheduler.py:1352-1357` |
+| Ziel-Segment von gestern läuft real bis ~19:00 Ortszeit heute | **hält für den Normalfall** — `arrival_local_date` = Folgetag, `09:21 < 19:00` ⇒ regulärer Zweig, kein Mindestfenster (`trip_segments.py:275-297`). **Nicht** für Etappen, deren Ankunft nach dem Folgetags-Fensterende liegt (Gehzeit > 21 h ab 22:00-Start) — dort greift weiter das 1-h-Mindestfenster |
+| `corridor_threshold.py` ohne Produktions-Aufrufer | **hält** — nur Definition + 2 Tests; `trip_alert.py:29` importiert nur das Dataclass `CorridorHit`, passend zu `trip_alert.py:52-56` („#1460 P1a: KEIN Alarm-Auslöser mehr"). Dokumentiert in `docs/specs/modules/rework_1460_t1_relevanzfilter.md:45` |
+| Die zwei „alle Segmente vorbei"-Wächter laufen nicht in CI | **hält** — `.github/ci_tdd_excludes.txt:77-78`. Kein CI-laufender Ersatz gefunden: `test_alarm_zeitfenster_ziel.py` und `test_arrival_window_fixtures.py` konstruieren ihre Fixtures bewusst so, dass Ortsdatum == Etappendatum bleibt, prüfen den datumsübergreifenden Fall also gerade nicht |
+
+### 🔴 Nachgemessen: `date.today()` bricht auch ohne Nacht-Etappe — in beide Richtungen
+
+`trip_alert.py:739` nutzt `date.today()` (Serverzeit = UTC), die Etappe trägt aber ein
+**Ortsdatum**. Für eine völlig gewöhnliche Etappe 08:00–19:00 Ortszeit gemessen:
+
+| Zone | Etappe läuft in UTC | `date.today()` trifft die Etappe |
+|---|---|---|
+| Europe/Paris (UTC+2) | 06:00–17:00 desselben Tages | **immer** |
+| America/Los_Angeles (UTC−7) | 15:00 bis 02:00 des Folgetags | **die letzten 2 h nicht** — dort ist die Etappe *gestern* ⇒ **vom Vortags-Fallback mitgeheilt** |
+| Pacific/Auckland (UTC+12) | **20:00 des Vortags** bis 07:00 | **die ersten 4 h nicht** — dort ist die Etappe *morgen* ⇒ **ein Vortags-Fallback hilft nicht** |
+
+Ein Wanderer in Neuseeland verliert damit die ersten ~4 von 11 Stunden **jedes** Etappentags
+— ohne jede Nacht-Etappe, bei ganz normalem 08:00-Start. Vorbestehend, von S3 weder erzeugt
+noch (in der Rückwärts-Variante) behoben. Ob S3 den Vorwärts-Zweig mitnimmt, ist eine
+Zuschnitt-Entscheidung des PO (s. Open Questions).
+
+### Technischer Ansatz
+
+Zwei Funktionen in `src/services/trip_segments.py`, getrennt entlang der Asymmetrie der Aufrufer:
+
+```python
+select_active_segment(segments, now_utc) -> Optional[TripSegment]
+resolve_current_segment(trip, now_utc, today) -> Optional[tuple[TripSegment, date]]
+```
+
+- **`select_active_segment`** ist die heutige Regel 1:1 (aktiv → `segments[0]` wenn `now <
+  segments[0].start_time` → `None`). Ersetzt beide Kopien verhaltensidentisch.
+- **`resolve_current_segment`** löst zusätzlich das Datum auf und trägt die Vorrangkette.
+  Nur `check_radar_alerts` braucht sie.
+- **Segment statt Segmentliste, und mit Datum.** Eine zusammengeführte Liste
+  (`gestern + heute`) degradiert die Vorrangregel zu „Listenreihenfolge + `break`" — in der
+  Überlappung stünde das Ziel-Segment von gestern vorn und gewönne. Die Liste kann die Regel
+  also gar nicht tragen.
+- **Vortagsbau lazy** — nur wenn heute kein aktives Segment liefert.
+
+**Vorrangkette:** (1) aktives Segment von heute → (2) aktives Segment von gestern →
+(3) Vorschau `heute[0]` → (4) nichts. Aus gestern wird **nie** eine Vorschau genommen.
+
+**Begründung für „heute gewinnt bei echter Überlappung"** (der Punkt, den die Analyse vorher
+nur behauptet hat):
+1. *Fachlich:* Das Ziel-Segment von gestern ist ein **ortsfestes** Fenster an der Unterkunft
+   (`trip_segments.py:264-290` — Startkoordinate = Ankunftspunkt). Läuft heute ein Segment,
+   ist der Wanderer in Bewegung; diese Koordinate ist die informativere.
+2. *Technisch:* Solange heute ein aktives Segment existiert, ist das Ergebnis **bitgleich**
+   zum Ist-Zustand. Genau das macht die Änderung nachweisbar additiv.
+
+### 🔴 Der nicht offensichtliche Teil: das Schnappschuss-Datum muss mitwandern
+
+`trip_alert.py:829` lädt `WeatherSnapshotService(...).load_dated(trip.id, today)` und
+`_briefing_precip_for_onset` (`:690-717`) matcht auf `segment_id`. Stammt das gewählte
+Segment von gestern, trifft der Vergleich auf den **gleichnamigen** Eintrag des heutigen
+Schnappschusses (`segment_id="Ziel"` bzw. `1,2,3…`) und kann den gerade erst gewonnenen
+Alarm still unterdrücken (`_briefing_announced and not result.is_convective` → `continue`).
+**Ohne diese Mitnahme wäre S3 in genau dem Fall wirkungslos, für den es gebaut wird.**
+Gleiche Klasse, aber nur ein Cooldown-Fenster weit: der Doppel-Alarm-Guard-Schlüssel
+`precip:{segment_id}` (`trip_alert.py:846`) — als Known Limitation benennen, nicht reparieren.
+
+### Test-Uhr: `freeze_time`, keine Produktivnaht
+
+`_now_fn` auf `TripAlertService` wäre eine **halbe** Uhr: die Wanduhr wird in diesem Pfad an
+mindestens vier Stellen gelesen (`trip_alert.py:739,740,850` plus
+`RadarNowcastService._now_fn`, `radar_service.py:127`) — eine Naht nur im Alarmdienst ließe
+Radar-Service und Cache auf der echten Uhr. `freeze_time` ersetzt `datetime`/`date` global,
+ist seit S1 Dev-Dependency und friert in `tests/unit/test_arrival_window_fixtures.py:256,284`
+bereits denselben Code ein. Koordinaten-Nachweis über `CountingFrameSource`
+(`tests/helpers/nowcast_gate_fixtures.py:175-190`, protokolliert `(lat, lon)`).
+
+**Auflage:** Radar-Cache ist Prozess-Singleton mit TTL 300 s (`radar_cache.py:106-120`) —
+unter eingefrorener Uhr läuft er nie ab; pro Test `reset_radar_cache()`.
+**Nicht anfassen:** `_radar_mails_fuer_spaetankunft` (`test_alarm_zeitfenster_ziel.py:356-417`)
+ist absichtlich wanduhrgebunden und von der S1-Ratsche bewacht.
+
+### Affected Files
+
+| Datei | Art | Beschreibung |
+|---|---|---|
+| `src/services/trip_segments.py` | MODIFY | `select_active_segment` + `resolve_current_segment` |
+| `src/services/trip_alert.py` | MODIFY | `:739-764` auf den Baustein; `:829` Schnappschuss-Datum mitziehen |
+| `src/services/trip_report_scheduler.py` | MODIFY | `:1341-1350` auf den Selektor; veralteten Docstring `:1332-1333` korrigieren |
+| `tests/unit/test_tagesuebergreifende_segmentauswahl.py` | CREATE | CI-laufender Nachweis mit `freeze_time` + Koordinaten-Assertion |
+
+Ablage in `tests/unit/` ist **Absicht**: `tests/tdd/` läuft grundsätzlich in CI, aber genau
+die beiden einschlägigen Altwächter stehen auf der Ausnahmeliste.
+
+### Scope Assessment
+- Dateien: 3 MODIFY + 1 CREATE
+- LoC: ~60 netto Produktivcode, ~130 Tests ⇒ **~190 netto** (Limit 250)
+- Risiko: **MEDIUM** — heißer Alarmpfad, aber bitgleich, solange heute ein aktives Segment existiert
+
+### Risiken, die in die Spec gehören
+- **Tagesbudget-Konkurrenz:** Ein Wrap-Trip, der bisher gar nichts verbrauchte, kann jetzt
+  das Tagesbudget des Nutzers belegen (`alert_daily_limit.py:61-74`) und andere Trips
+  verdrängen. Gewollte Wirkung, aber zu benennen.
+- **Provider-Last:** weiterhin **ein** `get_nowcast` pro Trip pro Lauf
+  (`trip_alert.py:801-806`); Mehrlast nur bei Trips, die bisher `continue` nahmen
+  (≤ 1 Abruf je 15-Min-Zyklus). Gedämpft durch Radar-Cache und `ForecastBudgetGate`
+  (`priority="polling"`).
+- **Die zwölf #1584-Tests:** elf bekommen ihre Segmente vom Test selbst
+  (`test_alarm_zeitfenster_ziel.py:200-207`) und sind strukturell unberührt.
+  `test_mitternachtsfenster_22_2_klemmt_auf_mindestfenster` hängt allein an der
+  Ziel-Segment-Rechnung, die S3 **nicht** anfasst — Voraussetzung: S3 führt nirgends
+  „Fensterende auf den Folgetag schieben" ein, sondern nimmt Segmente, wie sie gebaut wurden.
+
+### Known Limitations (Entwurf für die Spec)
+- **Ostzonen-Spiegelbild** (s. Messung oben) — je nach PO-Entscheidung offen oder mit erledigt.
+- **Sehr lange Nacht-Etappen** (Ankunft nach dem Folgetags-Fensterende) behalten das
+  1-h-Mindestfenster. Das ist die von #1584 AC-3 ausdrücklich abgenommene Spätankunfts-
+  Behandlung, kein neuer Mangel — aber im S3-Kontext bisher nirgends benannt.
+- **Deviations-/Schnappschuss-Pfad** (`_get_cached_weather`, `trip_alert.py:484-492`) lädt
+  ebenfalls nur den heutigen Schnappschuss. Gleiche Fehlerklasse, anderer Pfad, nicht S3.
+- **Doppel-Alarm-Guard-Schlüssel** `precip:{segment_id}` kollidiert über den Tageswechsel.
+
+### PO-Entscheidung 2026-08-10 — S3 zurückgestellt hinter #1697
+
+Die Frage „nur rückwärts oder symmetrisch (auch morgen)?" ist **anders beantwortet worden
+als gestellt**, und zu Recht: Ein Vorwärts-Zweig wäre Herumbauen um eine falsch gestellte
+Frage gewesen. Der Ostzonen-Befund ist kein Zuschnitt-Detail von S3, sondern ein eigener
+Fehler mit eigener Ursache — `date.today()` ist die **Serveruhr**, die Etappe trägt ein
+**Ortsdatum**. Er ist als **[#1697](https://github.com/henemm/gregor_zwanzig/issues/1697)**
+gebucht und wird **vor** S3 behoben.
+
+Die Messung, die die beiden trennt:
+
+| Fall | Server-Datum trifft | Ortsdatum trifft |
+|---|---|---|
+| Neuseeland, normale Etappe 08–19 | 2/4 | **4/4** |
+| Kalifornien, normale Etappe 08–19 | 3/4 | **4/4** |
+| Paris, Nacht-Etappe 22:00→10:00 (**der S3-Fall**) | 2/5 | **1/5 — schlechter** |
+
+Fehler A (Zeitzone) wird durch die richtige Datumsauflösung **vollständig** behoben.
+Fehler B (Etappe überlebt ihren Kalendertag) wird durch **kein** Datum behoben — dafür ist
+der Vortags-Rückgriff da, und nur dafür.
+
+**Für S3 ändert sich inhaltlich nichts.** Ein Vortags-Rückgriff rechnet relativ zu „heute",
+unabhängig davon, wie „heute" bestimmt wird. Diese Analyse bleibt vollständig gültig und wird
+nach #1697 unverändert aufgenommen. Kein Rework, keine Abhängigkeit außer der Reihenfolge.
+
+### Open Questions
+*(keine offenen — S3 ist analysiert und wartet auf #1697)*

--- a/docs/context/fix-1697-ortstag-statt-servertag.md
+++ b/docs/context/fix-1697-ortstag-statt-servertag.md
@@ -1,0 +1,224 @@
+# Context & Analysis: fix-1697-ortstag-statt-servertag
+
+**Issue:** [#1697](https://github.com/henemm/gregor_zwanzig/issues/1697)
+**Workflow:** `fix-1697-ortstag-statt-servertag` (Standard Track, Intake-Score 3)
+**Erstellt:** 2026-08-10 · Basis-HEAD `dc100be9`
+**Reihenfolge:** vor [#1667 S3](fix-1667-s3-tagesuebergreifende-segmente.md) (PO 2026-08-10)
+
+## Request Summary
+
+Der Alarm- und Briefing-Pfad bestimmt „welcher Tag der Tour ist jetzt" über `date.today()` —
+das Datum der **Serveruhr** (`Etc/UTC`). Eine Etappe trägt aber ein **Ortsdatum**. Fallen
+beide auseinander, wird die Etappe nicht gefunden und der Trip stillschweigend übersprungen.
+Gemessen: Neuseeland verliert die ersten ~4 von 11 Stunden **jedes** Etappentags, Kalifornien
+die letzten ~2 — bei ganz normaler Tagesetappe, ohne Nacht-Etappe.
+
+## Type
+**Bug.** Verstoß gegen eine bereits getroffene Grundsatzentscheidung (ADR-0044), nicht
+gegen eine offene Frage.
+
+## 🔴 Die Entwurfsfrage ist bereits entschieden — nicht neu aufmachen
+
+`docs/adr/0044-kalendertage-folgen-der-ortszeit.md` (**Akzeptiert**, PO 2026-08-03) legt fest:
+
+> **Kalendertage — „heute", „morgen" — bestimmen sich nach der Ortszeit der Tour.**
+> Die Zone wird aus den Koordinaten des Wegpunkts aufgelöst, mit dreistufigem Rückfall:
+> Etappe des Weltzeit-Tages → erste Etappe mit Wegpunkten → importierte UTC-Konstante.
+
+Die dortige Restliste nennt vier Stellen in `trip_command_processor.py` als „bewusst
+ausgegrenzt, nicht vergessen". **`trip_alert.py` und `trip_report_scheduler.py` stehen dort
+nicht** — sie sind schlicht übersehen worden, und sie wiegen schwerer als die genannten
+(Alarme statt Anzeige).
+
+### Das Muster existiert bereits, erprobt und gehärtet
+
+`docs/specs/modules/fix_1470_drilldown_ortszeit.md` (#1470, PO-freigegeben 2026-08-03) löst
+exakt dieselbe Frage inklusive der **Henne-Ei-Falle**: Man braucht ein Datum, um die Zone zu
+bestimmen, und die Zone, um das Datum zu bestimmen.
+
+Auflösung in zwei Schritten (`trip_command_processor.py:783-824`):
+
+```python
+def _trip_tz(self, trip):                      # :794 — Rückfall 2
+    stage = next((s for s in trip.stages if s.waypoints), None)
+    if stage is None:
+        return UTC                             # Rückfall 3
+    wp = stage.waypoints[0]
+    return tz_for_coords(wp.lat, wp.lon)
+
+def _display_tz(self, trip, day_date):         # :809 — Rückfall 1
+    stage = trip.get_stage_for_date(day_date)
+    if stage is None or not stage.waypoints:
+        return self._trip_tz(trip)
+    wp = stage.waypoints[0]
+    return tz_for_coords(wp.lat, wp.lon)
+
+# :783 — _anchor_tz: Zone der Etappe des WELTZEIT-Tages, weil dieser Tag
+# höchstens einen Tag daneben liegt und damit praktisch immer die richtige
+# Etappe findet, OHNE selbst schon von der Zone abzuhängen.
+```
+
+Der Adversary hat diese Fassung erzwungen: die erste ankerte an der **ersten Etappe der
+Tour** und lag bei einer Tour Neuseeland → Korsika **zehn Stunden** daneben.
+
+**Die drei Methoden sind heute privat auf `TripCommandProcessor`** — für #1697 müssen sie
+in einen geteilten Baustein wandern. Eine benannte Funktion „heutiges Datum am Ort X"
+existiert im ganzen Repo **nicht**; es gibt nur Inline-Ableitungen
+(`compare_location_weather_source.py:116`, `trip_segments.py:275`).
+
+### Mehr-Zonen-Touren: bewusst kein Thema (PO 2026-08-10)
+
+ADR-0044 stuft den Restfehler bereits ab: „Wechselt der Wanderer **an genau diesem Tag** die
+Zone, … Der Fehler ist dann die Differenz zweier benachbarter Etappen — in aller Regel null."
+Der PO hat das am 2026-08-10 bestätigt: nicht bauen, als bekannte Grenze dokumentieren.
+
+## 🔴 Der Fund, der den Zuschnitt bestimmt: Schreiber und Leser hängen aneinander
+
+`date.today()` ist nicht nur der Etappen-Anker, sondern auch der **Schlüssel des
+Wetter-Schnappschusses**:
+
+| Rolle | Stelle | Datum |
+|---|---|---|
+| **schreibt** | `trip_report_scheduler.py:1109` `save_dated(trip.id, target_date, …)` | `_get_target_date()` → `date.today()` (morgens) / `+1` (abends), `:653-667` |
+| **liest** | `trip_alert.py:570` `load_dated(trip.id, today)` | `date.today()` |
+| **liest** | `trip_alert.py:971` `load_dated(trip.id, today)` | `date.today()` |
+| **prüft** | `trip_alert.py:592` `anchor_date == today` | `date.today()` — **neu seit #1661** (`edef0523`, parallele Sitzung) |
+
+Heute ist die Kette **in sich konsistent falsch**: Schreiber und Leser irren gleich, deshalb
+passt es zusammen. Wird **nur** die Etappenauswahl (`trip_alert.py:881`) auf Ortszeit
+umgestellt, entsteht ein **neuer** Bruch — die gewählte Etappe stammt vom Ortstag, der
+Schnappschuss vom Serverdatum. Folgen: `_briefing_precip_for_onset` (`:838-865`) matcht auf
+`segment_id` und vergleicht dann gegen die Daten einer **anderen** Etappe; die seit #1661
+scharfe Frischeprüfung `anchor_date == today` könnte einen gültigen Anker verwerfen und
+`_report_missing_anchor` auslösen.
+
+**Daraus folgt die Zuschnitt-Regel: „welcher Tag der Tour ist jetzt" muss einmal aufgelöst
+und in der ganzen Kette gleich verwendet werden.** Eine Einzelzeile zu ändern ist hier nicht
+der kleine, sondern der gefährliche Schnitt.
+
+## Related Files — 17 Stellen, nach Wirkung sortiert
+
+### Kette A — wählt die Etappe für Alarm/Briefing (der Kern)
+
+| Datei:Zeile | Funktion | Wirkung bei falschem Tag |
+|---|---|---|
+| `src/services/trip_alert.py:881` | Radar-/NowCast-Schleife | **kein Alarm** (`continue`) |
+| `src/services/trip_alert.py:569` | `_get_cached_weather` | Anker nicht gefunden / verworfen |
+| `src/services/trip_alert.py:971` | Briefing-Vergleich im Radar-Alarm | Vergleich gegen falsche Etappe |
+| `src/services/trip_report_scheduler.py:663` | `_get_target_date` | **Briefing für den falschen Tag** |
+| `src/services/trip_report_scheduler.py:617` | `_get_active_trips` | Trip gilt als nicht aktiv ⇒ **kein Briefing** |
+| `src/services/trip_report_scheduler.py:857` | `_send_trip_report` | Segmente der falschen Etappe |
+| `src/services/trip_report_scheduler.py:1109` | `save_dated` | Schnappschuss unter falschem Schlüssel |
+| `src/services/trip_alert.py:386` | `check_all_trips` | Trip-Filter `end_date < today` — Randtag |
+
+### Kette B — Anzeige, Vorschau, Werkzeuge (eigener Schnitt)
+
+`trip_command_processor.py:1276` (`/jetzt`), `:1125` (`/status`), `:498` (`_handle_query`,
+**löst Versand aus**), `:428` (`command_date`) — die vier von ADR-0044 bereits benannten ·
+`inbound_telegram_reader.py:358` · `preview_service.py:94` · `api/routers/debug.py:61` ·
+`trip_report_scheduler.py:719,883,1434,1749,2142` · `tools/weather_validation.py:94,226`
+
+### Bewusst NICHT betroffen (feste Zone ist dort Absicht, nicht Fehler)
+
+`forecast_budget._today_utc:124` und `meteoalarm_budget._today_utc:170` (Kontingent-
+Tageswechsel bewusst UTC) · `alert_daily_limit.py:32` und `deviation_alert_engine.py:112`
+(Tageszähler/Ruhezeit fest `Europe/Vienna`) · `scheduler_dispatch_service.py:164` (Slot-Stunde)
+
+## Bestehende Wächter
+
+`tests/test_output_timezone_guard.py` (#1402) ist eine **AST-Ratsche** mit schrumpfender
+`KNOWN_VIOLATIONS`-Liste: sie flaggt rohes `.astimezone()`, stille Zonen-Rückfälle und
+verlangt, dass Produktiv-Aufrufer `tz` **explizit** übergeben
+(`test_production_callsites_pass_tz_explicitly`). Neuer Code muss deshalb `local_dt(dt, UTC)`
+aus `src/utils/timezone.py` benutzen, **nicht** `dt.astimezone(UTC)`.
+
+Elf weitere Zeitzonen-Wächter (`test_drilldown_day_window_local_date.py`,
+`test_compare_local_time_basis.py`, `test_bug_397_output_localtime.py`,
+`test_alert_quiet_hours_localtime.py`, `test_alert_event_time_uses_local_timezone.py` u.a.).
+**Keiner** von ihnen steht in `.github/ci_tdd_excludes.txt` — anders als bei #1667 S3 laufen
+hier alle einschlägigen Wächter in CI.
+
+**Nicht bewacht:** kein Test prüft, dass die **Etappenauswahl** dem Ortstag folgt. Genau
+diese Lücke hat den Fehler getragen.
+
+## Technischer Ansatz
+
+1. **Geteilter Baustein** — die drei privaten Methoden aus `TripCommandProcessor` in ein
+   gemeinsames Modul heben (Kandidat: `src/utils/timezone.py`, wo `tz_for_coords`/`local_dt`
+   schon liegen, oder ein neues `src/services/trip_day.py`) und um die eigentliche
+   Zielfunktion ergänzen:
+   `trip_local_today(trip, now_utc) -> date` — zweistufig nach dem #1470-Muster.
+   `TripCommandProcessor` ruft anschließend den geteilten Baustein, statt eine vierte Kopie
+   entstehen zu lassen.
+2. **Kette A geschlossen umstellen**, damit Schreiber und Leser gekoppelt bleiben.
+3. **Kette B unverändert lassen** und als Folge-Issue buchen — inklusive der vier Stellen,
+   die ADR-0044 schon kennt.
+
+**Sommerzeit ist Pflicht, nicht Kür.** ADR-0044 schreibt vor: „**Immer beide Wechseltage
+testen**", und warnt vor der Rechenfalle — gleiche `tzinfo` ⇒ Python rechnet auf Wanduhr-
+Werten und liefert an jedem Tag 24,0 Stunden. Für eine reine *Datums*bestimmung ist das
+weniger scharf als für Fensterlängen, muss aber belegt werden statt angenommen.
+
+## Scope Assessment
+- Dateien: 1 CREATE (Baustein) + 3–4 MODIFY + 1 CREATE (Tests)
+- LoC: ~50 Baustein, ~30 Aufrufstellen, ~120–150 Tests (drei Zonen × Kippkanten + zwei
+  Sommerzeit-Wechseltage) ⇒ **~200–230**, Limit 250 — machbar, aber ohne Puffer
+- Risiko: **MEDIUM-HIGH** — die Änderung betrifft *jeden* Trip, auch jeden europäischen (s. u.).
+
+## 🔴 Nachgemessen und korrigiert: „in Europa ändert sich nichts" ist FALSCH
+
+Diese Analyse hat zunächst angenommen, der Fix sei für Mitteleuropa bitgleich und nur für
+ferne Zonen wirksam. **Nachgemessen stimmt das nicht:**
+
+| Zone | Ortsdatum ≠ Serverdatum | Fenster |
+|---|---|---|
+| Europe/Paris, Europe/Vienna | **2,00 h/Tag** | 22:00–00:00 UTC (= 00:00–02:00 Ortszeit) |
+| America/Los_Angeles | 7,00 h/Tag | 00:00–07:00 UTC |
+| Pacific/Auckland | 12,00 h/Tag | 12:00–00:00 UTC |
+
+**Auch ein Korsika-Trip ist jede Nacht zwei Stunden lang betroffen.** Was in diesem Fenster
+passiert, ändert sich substanziell:
+
+| | heute | nach dem Fix |
+|---|---|---|
+| Serverdatum 22:30 UTC | Tag D | Tag D |
+| Ortsdatum (00:30 Ortszeit) | — | **Tag D+1** |
+| gewählte Etappe | D — deren Segmente endeten 19:00 Ortszeit ⇒ **alle vorbei** ⇒ `continue` | **D+1** — alle Segmente in der Zukunft ⇒ `now < segments[0].start_time` ⇒ `active = segments[0]` |
+| Radar-Abfrage | **keine** | **eine, am Startpunkt der morgigen Etappe** |
+
+Fachlich ist die neue Auswahl **richtig** — um 00:30 Ortszeit ist lokal tatsächlich der
+Folgetag, und die Vorschau-Regel („aktives *oder nächstes* Segment", #822) ist Absicht.
+
+**Aber sie deckt eine vorbestehende Schwäche auf:** `check_radar_alerts` hat **keinen**
+Horizont-Guard — `NOWCAST_HORIZON_MIN` kommt in `trip_alert.py` nicht vor. Die
+Schwesterfunktion `_build_starkregen_hint` hat ihn (`trip_report_scheduler.py:1352-1357`).
+Nach dem Fix würde also jede Nacht ein Radar-**Nowcast** (Horizont ~60 min) für ein Segment
+abgerufen, das erst in 7,5 Stunden beginnt — fachlich sinnlos und reine Kontingent-Last.
+
+Gemildert, aber nicht beseitigt: `check_nowcast_gate` läuft **vor** `get_nowcast`
+(`trip_alert.py` — Gate, dann Abruf), die Ruhezeit unterdrückt also bei konfiguriertem
+`alert_quiet_from/to` auch den Abruf. Ruhezeiten sind aber **optional pro Trip**.
+
+**Konsequenz für die Spec:** Der fehlende Horizont-Guard gehört als eigenes AC mit in diese
+Scheibe. Ihn wegzulassen hieße, einen Fix auszuliefern, der bei jedem europäischen Trip
+nächtliche Fehlabrufe erzeugt — und das wäre keine Nebenwirkung, sondern ein neuer Fehler.
+Die beiden Kopien sollen ohnehin dieselbe Regel tragen.
+
+## Nachweis-Strategie
+- **Der wichtigste Test ist das Verhalten im 22:00–00:00-UTC-Fenster eines Korsika-Trips**,
+  nicht Neuseeland. Genau dort ändert sich etwas für den Bestand, und genau dort hätte eine
+  unbelegte „bitgleich"-Behauptung den Fehler durchgelassen.
+- **Außerhalb dieses Fensters** muss der gewählte Tag für einen Korsika-Trip über alle
+  24 Stunden unverändert sein.
+- **Wirkung** über die **Koordinaten** des abgefragten Segments, nicht über einen
+  Alarm-Zähler — ein Zähler hätte die Falsch-Ortung nie bemerkt.
+- **Uhr:** `freeze_time` (seit #1667 S1 Dev-Dependency); der Alarm-Pfad liest die Wanduhr an
+  mehreren Stellen, eine einzelne DI-Naht wäre eine halbe Uhr.
+- **Mutations-Gegenprobe:** Baustein auf `date.today()` zurückdrehen ⇒ der Neuseeland-Test
+  muss rot werden.
+
+## Open Questions
+- [ ] **Gehört `_get_target_date` (Briefing) in dieselbe Scheibe wie der Alarm-Pfad?**
+      Dafür: Schreiber/Leser-Kopplung (s. o.) — getrennt entsteht ein neuer Bruch.
+      Dagegen: LoC-Limit und ein zweiter Wirkbereich (Briefing-Versand) in einer
+      Adversary-Runde. **Mit dem Horizont-Guard als Pflicht-AC ist das Budget knapp.**

--- a/docs/specs/modules/fix_1697_ortstag_statt_servertag.md
+++ b/docs/specs/modules/fix_1697_ortstag_statt_servertag.md
@@ -1,0 +1,618 @@
+---
+entity_id: fix_1697_ortstag_statt_servertag
+type: bugfix
+created: 2026-08-10
+updated: 2026-08-10
+status: draft
+workflow: fix-1697-ortstag-statt-servertag
+version: "1.0"
+tags: [issue-1697, timezone, adr-0044, trip-alert, radar-alert, calendar-day]
+---
+
+# Fix #1697 — Alarm-Pfad folgt dem Ortstag der Tour, nicht der Serveruhr
+
+## Approval
+
+- [x] Approved — **PO Henning, 2026-08-10, wörtlich: „Freigabe auf 500."**
+  Freigegeben wurden zugleich die neun Akzeptanzkriterien und der erweiterte
+  LoC-Rahmen (`loc_limit_override 500` statt 250). Begründung für den Rahmen:
+  der „Zweite Fund" (geteilte Testfixture `stage_date`, zwölf Testdateien) ist
+  kein Komfort-Zusatz, sondern verhindert, dass diese Spec dieselbe
+  Fehlerklasse im Testbestand neu erzeugt.
+
+**Vorausgegangene PO-Entscheidungen zu diesem Zuschnitt (2026-08-10):**
+
+- **Das Zeitzonen-Problem wird als Zeitzonen-Problem gelöst**, nicht durch
+  Absuchen von Nachbartagen. Ein zunächst vorgeschlagener Zuschnitt (#1667 S3
+  sucht zusätzlich einen Tag vorwärts) wurde vom PO mit genau dieser
+  Begründung verworfen — er hätte um eine falsch gestellte Frage herumgebaut.
+- **#1697 vor #1667 S3.** Die Sicherheitslücke aus #1667 bleibt so lange offen;
+  bewusst in Kauf genommen, um auf sauberer Grundlage aufzusetzen.
+- **Touren über mehrere Zeitzonen werden nicht gebaut** — als bekannte Grenze
+  dokumentiert (deckt sich mit ADR-0044, das den Restfehler als „in aller
+  Regel null" einstuft).
+
+## Purpose
+
+`src/services/trip_alert.py` bestimmt „welcher Tag der Tour ist jetzt" an vier
+Stellen über `date.today()` — das Datum der **Serveruhr** (`Etc/UTC`). Eine
+Etappe trägt aber ein **Ortsdatum**. Fallen beide auseinander, findet
+`Trip.get_stage_for_date` (striktes `==`) keine Etappe mehr, und der Trip wird
+per `continue` stillschweigend übersprungen: kein Alarm, keine Meldung.
+
+Gemessen (Kontext-Dokument, Basis-HEAD `dc100be9`), Abweichung Ortsdatum vs.
+Serverdatum:
+
+| Zone | Abweichung | Fenster |
+|---|---|---|
+| Europe/Paris, Europe/Vienna | 2,00 h/Tag | 22:00–00:00 UTC (= 00:00–02:00 Ortszeit) |
+| America/Los_Angeles | 7,00 h/Tag | 00:00–07:00 UTC |
+| Pacific/Auckland | 12,00 h/Tag | 12:00–00:00 UTC |
+
+Trefferquote bei einer normalen Etappe 08:00–19:00 Ortszeit, vier
+Stichproben über den Tag:
+
+| Zone | Serverdatum trifft | Ortsdatum trifft |
+|---|---|---|
+| Europe/Paris | 4/4 | 4/4 |
+| America/Los_Angeles | 3/4 | 4/4 |
+| Pacific/Auckland | 2/4 | 4/4 |
+
+Nutzerwirkung: Ein Neuseeland-Trip verliert die ersten ~4 von 11 Stunden
+**jedes** Etappentags, ein Kalifornien-Trip die letzten ~2 — ohne jede
+Nacht-Etappe.
+
+## Die Entwurfsfrage ist entschieden — nicht neu aufmachen
+
+`docs/adr/0044-kalendertage-folgen-der-ortszeit.md` (**Akzeptiert**, PO
+2026-08-03): „Kalendertage bestimmen sich nach der Ortszeit der Tour. Die Zone
+wird aus den Koordinaten des Wegpunkts aufgelöst, mit dreistufigem Rückfall:
+Etappe des Weltzeit-Tages → erste Etappe mit Wegpunkten → importierte
+UTC-Konstante."
+
+Die Henne-Ei-Falle — man braucht ein Datum, um die Zone zu bestimmen, und die
+Zone, um das Datum zu bestimmen — ist in `docs/specs/modules/fix_1470_drilldown_ortszeit.md`
+Abschnitt „Die Reihenfolge-Falle" gelöst und vom Adversary gehärtet. Diese
+Spec **übernimmt die dortige Auflösung wörtlich**, sie wird hier nicht neu
+erfunden:
+
+1. **Welcher Kalendertag?** entscheidet die Zone der Etappe des
+   **Weltzeit-Tages**. Der liegt höchstens einen Tag daneben, trifft also
+   praktisch immer die Etappe, auf der der Nutzer gerade steht.
+2. **Der eigentliche Ortstag** ergibt sich dann aus derselben Zone, angewendet
+   auf `now_utc`.
+
+Bestehender Code (unverändert übernommen, nur verschoben — s. Implementation
+Details): `src/services/trip_command_processor.py:775-824`
+(`_anchor_tz`/`_trip_tz`/`_display_tz`).
+
+### 🔴 Verworfene Alternative: Zone der ersten Etappe der Tour
+
+Die ERSTE Fassung von #1470 ankerte an der ersten Etappe der Tour. Der
+Adversary hat mit einer Tour Neuseeland → Korsika **zehn Stunden** Abweichung
+nachgewiesen (12:00–22:00 UTC meldete bereits den Folgetag, während es am Ort
+erst 14:00–23:00 war). Diese Alternative ist verworfen und wird durch diese
+Spec nicht erneut erwogen.
+
+## Source
+
+- **Files:** `src/services/trip_alert.py` (Wirkort), `src/services/trip_command_processor.py`
+  (verliert drei private Methoden an den neuen Baustein),
+  `src/services/trip_day.py` (neu, geteilter Baustein), sowie
+  `tests/helpers/arrival_window_fixtures.py` (geteilte Testfixture, s.
+  „🔴 Zweiter Fund" unten)
+- **Identifier:** `TripAlertService.check_all_trips` (`:363`),
+  `TripAlertService._get_cached_weather` (`:509`),
+  `TripAlertService.check_radar_alerts` (`:862`),
+  `TripAlertService.check_official_alert_triggers` (`:1244`)
+
+> **Schicht-Hinweis:** Reines Python-Core / Domain-Backend
+> (`src/services/`). Kein Go-, kein Frontend-Anteil. `trip_day.py` liegt
+> bewusst in `src/services/`, nicht in `src/utils/timezone.py` — letzteres
+> kennt weder `Trip` noch `Stage` und bleibt eine generische
+> Koordinaten/Zeitzonen-Bibliothek ohne Domänenwissen (s. Implementation
+> Details, Abschnitt „Warum ein neues Modul").
+
+## 🔴 Zweiter Fund: die geteilte Testfixture muss mitgehen
+
+Zwölf Alarm-/Radar-Testdateien bauen ihre Etappen über den Helfer
+`tests/helpers/arrival_window_fixtures.py` (#1667 S1). Dessen Funktion
+`stage_date()` ist **niladisch** und liefert wörtlich `date.today()` — mit der
+Begründung im eigenen Docstring: „Dort steht `today = date_type.today()`;
+`convert_trip_to_segments` sucht die Etappe über `get_stage_for_date(today)`."
+Das ist exakt der Code, den diese Spec an `trip_alert.py:881` ändert.
+
+**Ohne Anpassung entsteht durch diese Spec selbst eine neue, tägliche
+Zeitfenster-Lücke — diesmal im Testbestand statt in Produktion.** Nach der
+Umstellung sucht `check_radar_alerts` die Etappe über
+`trip_local_today(trip, now_utc)`; die Fixture würde ihre Stage aber
+weiterhin unter `date.today()` (Serverdatum) ablegen. In der
+22:00–00:00-UTC-Randzeit (oder dem Äquivalent der jeweiligen Testkoordinaten)
+laufen beide dann auf verschiedene Tage — exakt dieselbe Fehlerklasse, die
+diese Spec beheben soll, nur eine Ebene höher. Zwölf Testdateien würden damit
+**zeitabhängig neu flakig**, ausgerechnet in den Randfenstern, die AC-2/AC-3
+absichern sollen.
+
+Betroffen (per Grep verifiziert, echte Aufrufe von `stage_date()`, keine
+Namenskollisionen):
+
+`tests/tdd/test_issue_818_radar_briefing_integration.py`,
+`tests/tdd/test_issue_822_radar_nowcast_segment.py` (6 Aufrufe),
+`tests/tdd/test_bundle_791_847_844_alerts.py`,
+`tests/tdd/test_issue_827_radar_throttle_recording.py`,
+`tests/tdd/test_alert_urgency.py`,
+`tests/tdd/test_issue_1070_daily_alert_limit.py`,
+`tests/tdd/test_issue_995_scheduler_pause.py`,
+`tests/tdd/test_alert_channel_threshold.py`,
+`tests/tdd/test_issue_883_acute_danger_override.py`,
+`tests/tdd/test_alert_quiet_hours_robustness.py`,
+`tests/tdd/test_alert_log_metrics.py`,
+`tests/unit/test_arrival_window_fixtures.py` (der Guard selbst).
+
+**Warum genau zwölf und nicht dreizehn:** `grep -rln "arrival_window_fixtures
+import" tests/` liefert exakt diese zwölf Dateien. Ein reiner Textgriff nach
+`stage_date` trifft zusätzlich `tests/tdd/test_gpx_proxy.py` — dort ist
+`stage_date` ein **Query-Parameter** des GPX-Endpunkts, kein Aufruf dieses
+Helfers. Diese Datei wird **nicht** angefasst.
+
+**Konsequenz für den Zuschnitt:** Diese Korrektur gehört zwingend **in diese
+Scheibe**, aus demselben Grund, aus dem der Horizont-Guard zwingend ist —
+sie ist keine Erweiterung, sondern die Vermeidung eines neuen, durch diese
+Spec selbst verursachten Fehlers. Sie treibt den LoC-Umfang über das
+250er-Limit (s. Estimated Scope).
+
+`_tagesbezug(lat, lon)` in derselben Datei kennt `lat`/`lon` bereits (für
+`tz_for_coords`) — nur `stage_date()` selbst ist koordinatenblind. Die
+Korrektur macht `stage_date(lat, lon)` **PFLICHT-parametrisiert** (kein
+Default, analog zum bestehenden `tagesgleicher_anker_noetig`-Muster in
+`_get_cached_weather`): jeder der zwölf Aufrufer muss bewusst dieselben
+Koordinaten übergeben, die er auch für `active_window_offsets(lat, lon, …)`
+benutzt. Die Formel selbst ist **kein** Aufruf von
+`services.trip_day.trip_local_today` — die Fixture kennt ihre Koordinaten
+bereits direkt (keine Henne-Ei-Falle, kein Trip zum Nachschlagen nötig) und
+bleibt bei der einfacheren `local_dt(datetime.now(timezone.utc),
+tz_for_coords(lat, lon)).date()`, die bereits mit den in dieser Datei
+importierten Bausteinen (`tz_for_coords`, aus `utils.timezone` zu ergänzen:
+`local_dt`) auskommt.
+
+## Affected Files
+
+| Datei:Zeile | Änderung |
+|---|---|
+| `src/services/trip_day.py` (NEU) | `trip_tz`, `display_tz`, `anchor_tz` — verschoben aus `trip_command_processor.py`; neue Funktion `trip_local_today(trip, now_utc) -> date` |
+| `src/services/trip_command_processor.py:775-824` | `_anchor_tz`/`_trip_tz`/`_display_tz` entfernt (nach `trip_day.py` verschoben, Verhalten bit-identisch) |
+| `src/services/trip_command_processor.py:735-773` | `_day_window` ruft `trip_day.trip_local_today`/`trip_day.display_tz`/`trip_day.anchor_tz` statt `self._…` — AC-8 |
+| `src/services/trip_alert.py:9-34` | Import `from services.trip_day import trip_local_today` ergänzt |
+| `src/services/trip_alert.py:382-394` | `check_all_trips`: `today = date_type.today()` → `now_utc = datetime.now(timezone.utc)`; `today` je Trip **innerhalb** der Schleife über `trip_local_today(trip, now_utc)` |
+| `src/services/trip_alert.py:441` | End-Date-Filter (`trip.end_date < today`) nutzt den je-Trip aufgelösten `today` |
+| `src/services/trip_alert.py:446,452` | `_get_cached_weather`-Aufruf bekommt `now_utc=now_utc`; `check_official_alert_triggers`-Aufruf bekommt `now_utc` |
+| `src/services/trip_alert.py:509-570` | `_get_cached_weather`: neuer optionaler Parameter `now_utc: Optional[datetime] = None` (Begründung für den Default s. u.); `today = date.today()` → `today = trip_local_today(trip, now_utc or datetime.now(timezone.utc))` |
+| `src/services/trip_alert.py:1244-1274` | `check_official_alert_triggers`: neuer optionaler Parameter `now_utc: Optional[datetime] = None`, durchgereicht an `_get_cached_weather` |
+| `src/services/trip_alert.py:877-887` | `check_radar_alerts`: `today = date_type.today()` (vor der Schleife) entfernt; je Trip `today = trip_local_today(trip, now_utc)` vor `convert_trip_to_segments(trip, today)` |
+| `src/services/trip_alert.py:906-908` (neu) | Horizont-Guard vor dem Nowcast-Gate: `active.start_time > now_utc` + `NOWCAST_HORIZON_MIN`-Vergleich → `continue` |
+| `src/services/trip_alert.py:971` | `load_dated(trip.id, today)` — unverändert im Code, profitiert vom korrigierten `today` (AC-5) |
+| `tests/helpers/arrival_window_fixtures.py:155-207` | `stage_date()` → `stage_date(lat, lon)` (Pflicht-Parameter); `_tagesbezug`/`past_window_offsets` rufen die neue Signatur |
+| 12 bestehende Testdateien (Liste oben, „Zweiter Fund") | Aufrufe von `stage_date()` → `stage_date(lat, lon)` mit denselben Koordinaten wie das jeweils benutzte `active_window_offsets`/`past_window_offsets` |
+| `tests/unit/test_arrival_window_fixtures.py` | neue Zusicherung: `stage_date(lat, lon)` weicht für eine Ost-Zone (Korsika) und eine West-Zone (Kalifornien) unter gestellter Uhr korrekt vom Serverdatum ab — Regressionsschutz für die Korrektur oben |
+| `tests/unit/test_trip_local_today.py` (NEU) | Reine Funktionstests von `trip_day.py`: Rückfallkette (AC-6), Sommerzeit (AC-7) |
+| `tests/tdd/test_radar_alert_follows_ortstag.py` (NEU) | Wirkungstests gegen `TripAlertService`: Auckland-Koordinatennachweis (AC-1), Korsika-Bestandsschutz (AC-2), Korsika-Randfenster (AC-3), Horizont-Guard (AC-4), Schnappschuss-Konsistenz (AC-5), Delegation (AC-8), Mutations-Gegenprobe |
+
+**Nicht angefasst (bewusst, DRAUSSEN):** `trip_report_scheduler.py:663`
+(`_get_target_date`), `:617` (`_get_active_trips`), `:857`, `:1109`
+(`save_dated`) — Briefing-Schreiber bleibt auf Serverdatum, eigene Scheibe.
+Kette B (`trip_command_processor.py` `/jetzt`, `/status`, `_handle_query`,
+`command_date`; `inbound_telegram_reader.py`; `preview_service.py`;
+`api/routers/debug.py`; `tools/weather_validation.py`) — eigenes Folge-Issue.
+Mehr-Zonen-Touren — bewusst nicht gebaut (PO 2026-08-10, s. Known
+Limitations). `corridor_threshold.py` — kein Produktions-Aufrufer.
+`forecast_budget._today_utc`, `meteoalarm_budget._today_utc`,
+`alert_daily_limit.py:32`, `deviation_alert_engine.py:112` — feste Zone ist
+dort Absicht, nicht Fehler.
+
+## Estimated Scope
+
+- **LoC:** ~300–330 — deutlich über dem 250er-Limit. Aufschlüsselung:
+  `trip_day.py` ~70 (Baustein, inkl. Docstrings im Detailgrad des
+  Vorbilds), `trip_command_processor.py` ~‑35 (drei Methoden entfernt,
+  `_day_window` leicht umgebaut — netto Rückgang), `trip_alert.py` ~50 (vier
+  Aufrufstellen + Horizont-Guard + zwei optionale Parameter),
+  `arrival_window_fixtures.py` ~15, zwölf Testdateien × ~2 Zeilen
+  (Koordinaten-Argument ergänzen) ~24, `test_arrival_window_fixtures.py`
+  ~20 (neue Zusicherung), zwei neue Testdateien ~170–200 (drei Zonen ×
+  Kippkante, zwei Sommerzeit-Wechseltage, Horizont-Guard mit
+  Aufruf-Zähler, Mutations-Gegenprobe).
+  **Empfehlung:** `workflow.py set-field loc_limit_override 500` vor der
+  Implementierung setzen — der Zweite Fund (geteilte Testfixture) ist kein
+  Komfort-Zusatz, sondern notwendig, um AC-2/AC-3 überhaupt ohne neue
+  Nacht-Flakiness abzusichern.
+- **Files:** 3 neu (`trip_day.py`, zwei Testdateien), 16 geändert
+  (`trip_command_processor.py`, `trip_alert.py`,
+  `arrival_window_fixtures.py`, `test_arrival_window_fixtures.py`, 12
+  bestehende Testdateien) = 19.
+- **Effort:** medium-high — die Kernänderung ist klein (vier Aufrufstellen +
+  ein Guard), der Aufwand liegt im Sommerzeit-Nachweis, im
+  Horizont-Guard-Test und im sauberen Nachziehen der geteilten Testfixture.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` | ADR | Bereits akzeptierte Grundsatzentscheidung — diese Spec setzt sie für Kette A um, öffnet sie nicht neu |
+| `docs/specs/modules/fix_1470_drilldown_ortszeit.md` | spec | Henne-Ei-Auflösung (Weltzeit-Tag-Anker) wörtlich übernommen |
+| `src/services/trip_command_processor.py::_anchor_tz/_trip_tz/_display_tz` (`:775-824`) | module | Quellcode der Auflösung, wird nach `trip_day.py` verschoben |
+| `src/utils/timezone.py::tz_for_coords`, `local_dt`, `UTC` | module | Bausteine, aus denen `trip_day.py` UND die korrigierte Testfixture bestehen — keine dritte Kopie |
+| `src/services/radar_service.py::NOWCAST_HORIZON_MIN` | constant | Schwellwert des neuen Horizont-Guards, identisch zum Vorbild |
+| `src/services/trip_report_scheduler.py::_build_starkregen_hint` (`:1352-1357`) | pattern | Vorbild für die Horizont-Guard-Formel (`minutes_until_start > NOWCAST_HORIZON_MIN`) |
+| `tests/tdd/test_starkregen_kurzfristhinweis.py::test_ac2_zeitfenster_guard_kein_fetch_ausserhalb_horizon` (`:330`) | pattern | Vorbild für den Horizont-Guard-Test: echte `RadarNowcastService.get_nowcast`-Ersetzung mit Aufruf-Liste, Nah/Fern-Gegenprobe im selben Test |
+| `tests/helpers/arrival_window_fixtures.py` (#1667 S1) | fixture | Geteilte Testfixture für ~30 Alarm-/Radar-Tests; zwölf davon rufen `stage_date()` direkt und müssen mit dieser Spec mitgehen (s. „Zweiter Fund") |
+| `tests/tdd/test_fixture_wallclock_ratchet.py` | guard | AST-Ratsche gegen rohe Wanduhr-Arithmetik in Testdateien; behandelt `stage_date()`-Aufrufe bereits als „wanduhr-getragen" — bleibt durch die Signaturänderung unberührt (prüft Aufruf-Muster, nicht die Formel dahinter) |
+| `src/services/weather_snapshot.py::load_dated/load/load_target_date` | module | Ziel der Lesungen an `:570`/`:971` — unverändert im Code, das übergebene `today` ändert sich |
+
+## Implementation Details
+
+### Warum ein neues Modul (`src/services/trip_day.py`) statt `utils/timezone.py`
+
+`src/utils/timezone.py` ist eine generische Koordinaten-/Zeitzonen-Bibliothek
+ohne Domänenwissen (`tz_for_coords`, `local_dt`, `UTC` — keine Kenntnis von
+`Trip`/`Stage`). Die drei Methoden aus #1470 kennen dagegen `Trip.stages` und
+`Trip.get_stage_for_date`. Sie gehören in die Domänen-Schicht
+(`src/services/`), analog dazu, wie sie heute schon auf
+`TripCommandProcessor` (auch `services/`) liegen. `trip_day.py` importiert
+`Trip` nur unter `TYPE_CHECKING` (wie `trip_alert.py` es bereits tut) — kein
+Kreislaufimport-Risiko, da `app/trip.py` selbst nichts aus `services/`
+importiert.
+
+### Der geteilte Baustein
+
+```python
+# src/services/trip_day.py
+def trip_tz(trip: "Trip") -> ZoneInfo:
+    """Ortszone der Tour OHNE Tagesbezug — erste Etappe mit Wegpunkten."""
+    stage = next((s for s in trip.stages if s.waypoints), None)
+    return tz_for_coords(stage.waypoints[0].lat, stage.waypoints[0].lon) \
+        if stage else UTC
+
+def display_tz(trip: "Trip", day_date: date) -> ZoneInfo:
+    """Ortszone der Etappe an ``day_date`` — Rückfall auf ``trip_tz``."""
+    stage = trip.get_stage_for_date(day_date)
+    if stage is None or not stage.waypoints:
+        return trip_tz(trip)
+    wp = stage.waypoints[0]
+    return tz_for_coords(wp.lat, wp.lon)
+```
+
+```python
+def anchor_tz(trip: "Trip", now_utc: datetime) -> ZoneInfo:
+    """Zone der Etappe des WELTZEIT-Tages (#1470 F003) — entscheidet, WELCHER
+    Kalendertag gerade ist, ohne selbst schon vom Ortstag abzuhängen."""
+    return display_tz(trip, local_dt(now_utc, UTC).date())
+
+def trip_local_today(trip: "Trip", now_utc: datetime) -> date:
+    """Der Kalendertag „heute", gemessen an der Ortszeit der Tour (ADR-0044)."""
+    return local_dt(now_utc, anchor_tz(trip, now_utc)).date()
+```
+
+`trip_tz`/`display_tz`/`anchor_tz` sind unveränderte Verschiebungen der
+#1470-Methoden (nur `self.` entfernt); `trip_local_today` ist neu und fasst
+exakt zusammen, was `TripCommandProcessor._day_window`'s „today"-Zweig heute
+schon inline tut (`local_dt(received_at, self._anchor_tz(...)).date()`).
+
+### Kette A — vier Aufrufstellen
+
+Alle vier Stellen bekommen denselben `now_utc`, damit ein Lauf konsistent
+bleibt (kein Trip sieht eine andere „Jetzt"-Sekunde als der nächste):
+
+- `check_all_trips`: `now_utc = datetime.now(timezone.utc)` einmal zu
+  Laufbeginn; `today = trip_local_today(trip, now_utc)` **je Trip** innerhalb
+  der Schleife (nicht mehr davor — die Zone hängt vom Trip ab).
+- `check_radar_alerts`: `now_utc` bleibt an seiner bisherigen Stelle
+  (`:882`); `today` wandert von vor die Schleife in die Schleife.
+- `_get_cached_weather`/`check_official_alert_triggers`: bekommen `now_utc`
+  als **optionalen** Parameter (`Optional[datetime] = None`, Default
+  `datetime.now(timezone.utc)`), NICHT als Pflicht-Parameter ohne Default.
+
+### 🔴 Bewusste Abweichung vom „kein Default"-Muster
+
+`_get_cached_weather`s bestehender Parameter `tagesgleicher_anker_noetig` hat
+explizit **keinen** Default — eine neue Aufrufstelle muss sich bewusst
+entscheiden. `now_utc` bekommt dagegen einen Default. Grund: Es handelt sich
+um zwei verschiedene Fragen. `tagesgleicher_anker_noetig` ist eine
+**Verhaltensentscheidung** (welcher Alarmpfad, welche Semantik) — ein
+falscher Default wäre gefährlich still falsch. `now_utc` ist dagegen „wie
+spät ist es" — ein Default auf die echte Wanduhr ist exakt das, was jeder
+der 34 bestehenden direkten Aufrufe von `check_official_alert_triggers(trip)`
+(8 Testdateien) und der beiden direkten Aufrufe von `_get_cached_weather`
+(`tests/tdd/test_alert_anchor_day_guard.py`,
+`tests/tdd/test_issue_823_snapshot_date_guard.py`) heute bereits implizit
+tun. Ein Pflicht-Parameter hätte alle 10 Dateien zum Nacharbeiten gezwungen
+— eine Scope-Explosion ohne fachlichen Gewinn, da keine dieser Testdateien
+zonenübergreifende Trips baut. `check_all_trips` reicht ihren einen
+`now_utc`-Wert explizit durch und ist damit in sich konsistent; alle anderen
+Aufrufer erhalten unverändert das Verhalten von heute.
+
+### Horizont-Guard in `check_radar_alerts`
+
+Direkt nach der Segmentauswahl (vor der Throttle-/Ruhezeit-Prüfung, analog
+zur Reihenfolge in `_build_starkregen_hint`):
+
+```python
+if active.start_time > now_utc:
+    from services.radar_service import NOWCAST_HORIZON_MIN
+    minutes_until_start = (active.start_time - now_utc).total_seconds() / 60.0
+    if minutes_until_start > NOWCAST_HORIZON_MIN:
+        logger.debug(
+            f"Radar alert skipped: Segment beginnt erst in "
+            f"{minutes_until_start:.0f} min (>{NOWCAST_HORIZON_MIN} min "
+            f"Horizont) fuer {trip.id}"
+        )
+        continue
+```
+
+Kein `alert_log`-Eintrag — analog zu den bestehenden Zweigen „keine
+Segmente"/„alle Segmente vorbei" ein paar Zeilen darüber, die ebenfalls ohne
+Protokolleintrag `continue`n. Ein Protokolleintrag ist dem
+Throttle-/Ruhezeit-Zweig vorbehalten, der einen sonst *fälligen* Alarm
+unterdrückt — hier ist der Alarm schlicht noch nicht fällig.
+
+### Zweiter Fund: `stage_date(lat, lon)`
+
+```python
+def stage_date(lat: float, lon: float) -> date:
+    """Ortstag am Wegpunkt — dieselbe Formel wie in Produktion, nicht
+    dieselbe Funktion: hier ist die Zone schon bekannt, keine Henne-Ei-Falle."""
+    return local_dt(datetime.now(timezone.utc), tz_for_coords(lat, lon)).date()
+```
+
+`_tagesbezug` ruft `stage_date(lat, lon)` statt `stage_date()`;
+`past_window_offsets` ebenso. Die zwölf Aufrufer übergeben dieselben
+Koordinaten, die sie bereits für `active_window_offsets`/`past_window_offsets`
+verwenden — eine mechanische, nicht-fachliche Änderung je Datei.
+
+## Expected Behavior
+
+- **Input:** Ein Lauf von `check_all_trips` oder `check_radar_alerts` zu
+  einem beliebigen Zeitpunkt `now_utc`.
+- **Output:** Jeder Trip wird anhand des **Ortstags seiner aktuellen Etappe**
+  bewertet, nicht anhand des Serverdatums. Radar-Nowcast-Abrufe erfolgen nur
+  für Segmente, die innerhalb von `NOWCAST_HORIZON_MIN` beginnen.
+- **Side effects:** Für Trips, deren Zone während des gesamten Laufzeitraums
+  mit dem Serverdatum übereinstimmt (die meisten Tests, alle Trips außerhalb
+  der jeweiligen Randfenster), ist das Verhalten bit-identisch zu heute.
+
+## LoC-Rahmen — nachgemessen und angehoben (PO 2026-08-10)
+
+Die RED-Phase hat ergeben, dass der **Nachweis** ~742 LoC braucht statt der geschätzten
+170–200. Nachgemessen, nicht geschätzt; auf ausdrückliche Ansage wurde **kein Test
+weggekürzt**, um eine Zahl zu treffen. Zusammen mit ~300–330 LoC Produktivcode liegt die
+Scheibe bei **~1070**.
+
+Der PO hat entschieden: **eine Scheibe, Rahmen auf 1100** (statt der ebenfalls vorgelegten
+Teilung in zwei Scheiben). Alle neun Akzeptanzkriterien bleiben in **einem** Änderungssatz.
+
+**Zweite Anhebung auf 1400 (PO 2026-08-10), nach zwei Adversary-Fix-Schleifen.** Endstand
+gemessen: **+1313/−123** in `src/` und `tests/`, netto **+1190** — davon **152 Zeilen
+Produktivcode**. Der gesamte Zuwachs gegenüber 1100 sind Wächter, die der Adversary
+erzwungen hat:
+
+| Fund | Wirkort | Was ohne den Wächter passiert wäre |
+|---|---|---|
+| **F001** (CRITICAL) | `trip_alert.py:584` (`_get_cached_weather`, Δ-Anker-Pfad) | Die Korrektur ließ sich auf `date.today()` zurückdrehen, **ohne dass einer von 218 Tests rot wurde** |
+| **F002** (HIGH) | `trip_alert.py:404` (`check_all_trips`, Filter `end_date < today`) | Dasselbe bei **266 Tests**. Wirkung: bei negativem UTC-Versatz (Los Angeles) gilt die Tour am letzten Ortstag zu früh als abgelaufen ⇒ übersprungen ⇒ keine Alarme — das ursprüngliche Fehlerbild an neuer Stelle |
+| Nachbesserung AC-8 | `trip_day.py:71` (`anchor_tz`) | Der Anker ließ sich auf die bei #1470 mit zehn Stunden Abweichung verworfene Fassung zurückdrehen; gefangen hätte es nur die **geerbte** #1470-Suite, nicht der eigene Bestand |
+
+**Die Lehre, die über diese Scheibe hinausgeht:** Dreimal in Folge war der Produktivcode
+**korrekt** und trotzdem unbewacht. Jede Aufrufstelle rechnet ihren eigenen Ortstag und
+braucht ihren eigenen Wächter — ein grüner Testlauf über alle neun Kriterien hat das
+dreimal nicht bemerkt. Gemessen und abgeschlossen: `trip_alert.py` enthält genau **drei**
+unabhängige `today = trip_local_today(...)`-Zuweisungen (`:404`, `:584`, `:901`), alle drei
+sind jetzt einzeln durch eine Mutations-Gegenprobe belegt.
+
+Das ist zugleich der Beleg für die Hausregel, den Aufwand des **Nachweises**
+mitzuschätzen: die Verhaltensänderung ist klein (vier Aufrufstellen plus ein Guard), der
+Nachweis das Achtfache davon.
+
+Das ist ein Beleg für die Hausregel, den Aufwand des **Nachweises** mitzuschätzen und nicht
+nur den des Fixes: die Kernänderung ist klein (vier Aufrufstellen plus ein Guard), der
+Nachweis ist das Vielfache davon — drei Zeitzonen, zwei Sommerzeit-Wechseltage, ein
+22-Stichproben-Bestandsschutz und ein Koordinaten-Nachweis, der eine stille Falsch-Ortung
+sichtbar macht.
+
+## Acceptance Criteria
+
+- **AC-1 (Wirkung — Koordinatennachweis, nicht Alarm-Zähler):** Given ein
+  Trip mit Etappe in Pacific/Auckland und Ortsdatum D, die Uhr steht auf
+  einen Zeitpunkt innerhalb des Etappenfensters, an dem das Serverdatum noch
+  D-1 ist / When der Scheduler `check_radar_alerts` über alle Trips dieses
+  Nutzers laufen lässt / Then erfolgt der
+  Nowcast-Abruf an den Koordinaten des tatsächlich begangenen Segments von
+  Ortsdatum D — nicht an denen einer Etappe von D-1 oder gar keiner.
+  - Test: `tests/tdd/test_radar_alert_follows_ortstag.py`,
+    Ersetzung von `RadarNowcastService.get_nowcast` durch eine echte
+    Funktion, die `(lat, lon)` protokolliert (Muster
+    `test_starkregen_kurzfristhinweis.py::_install_fake_nowcast`); Assert
+    protokollierte Koordinaten == Wegpunkt der D-Etappe.
+
+- **AC-2 (Bestandsschutz):** Given ein Trip auf Korsika (Europe/Paris,
+  UTC+2) mit einer gewöhnlichen Tagesetappe 08:00–19:00 Ortszeit / When
+  `check_radar_alerts` zu allen 24 vollen Stunden eines Tages läuft / Then
+  ist außerhalb des Fensters 22:00–00:00 UTC die ausgewählte Etappe an jeder
+  geprüften Stunde identisch zum Verhalten vor dieser Änderung.
+  - Test: parametrisierter Lauf über 22 Stichproben (jede volle Stunde
+    außer 22 und 23 Uhr UTC) unter `freeze_time`; Assert gewähltes Segment
+    unverändert gegenüber der alten `date.today()`-Formel als lokal
+    hinterlegte Referenz.
+
+- **AC-3 (das ehrliche Fenster):** Given derselbe Korsika-Trip aus AC-2, der
+  zusätzlich eine Etappe am Folgetag trägt / When die Uhr
+  auf 22:30 UTC steht (= 00:30 Ortszeit des Folgetags) / Then wählt
+  `check_radar_alerts` die Etappe des
+  Folgetags statt in `continue` zu enden — dies ist fachlich beabsichtigt,
+  nicht ein Fehlerbild.
+  - Test: `freeze_time("…T22:30:00Z")`, Assert gewähltes Segment gehört zur
+    Folgetags-Etappe, Assert kein `continue` ohne jede Segmentwahl.
+
+- **AC-4 (Horizont-Guard, mit Gegenprobe im selben Test):** Given zwei
+  ansonsten gleiche Läufe, bei denen das gewählte Segment einmal später als
+  `NOWCAST_HORIZON_MIN` in der Zukunft beginnt und einmal innerhalb dieses
+  Horizonts / When `check_radar_alerts` in beiden Läufen die Segmentwahl
+  durchlaufen hat und vor dem Nowcast-Abruf steht / Then unterbleibt der
+  `get_nowcast`-Aufruf im Fern-Fall vollständig, während er im Nah-Fall
+  genau einmal erfolgt — die Zahl der protokollierten Abrufe ist 0
+  beziehungsweise 1.
+  - Test: `tests/tdd/test_radar_alert_follows_ortstag.py`, Muster
+    `test_starkregen_kurzfristhinweis.py::test_ac2_zeitfenster_guard_kein_fetch_ausserhalb_horizon`
+    — echte Funktions-Ersetzung mit Aufruf-Liste, Fern-Fall (>60 min) und
+    Nah-Fall (≤60 min) im selben Test.
+
+- **AC-5 (kein neuer interner Bruch innerhalb von Kette A):** Given ein Trip,
+  dessen Ortstag D vom Serverdatum D-1 abweicht, und ein Wetter-Schnappschuss,
+  der **ausschließlich** unter dem Ortstag D abgelegt ist und für die
+  Einsetzstunde des gewählten Segments angekündigten, nicht-konvektiven Regen
+  ≥ 0,5 mm enthält / When `check_radar_alerts` läuft und der Radar für dieses
+  Segment nicht-konvektiven Regen meldet / Then wird der Alarm **unterdrückt**
+  („Briefing hatte das schon angekündigt") — was beweist, dass die
+  Schnappschuss-Lesung unter **demselben** Ortstag nachgeschlagen hat wie die
+  Segmentwahl.
+  - **Gegenprobe im selben Test (die diskriminierende Hälfte):** derselbe
+    Schnappschuss stattdessen **ausschließlich** unter dem Serverdatum D-1
+    abgelegt / Then wird er **nicht** gefunden und der Alarm **feuert**.
+    Genau dieser zweite Fall ist heute das Verhalten und wäre bei einer
+    halbierten Umstellung (Segmentwahl auf Ortstag, Schnappschuss weiter auf
+    Serverdatum) das Fehlerbild.
+  - Test: `tests/tdd/test_radar_alert_follows_ortstag.py`, zwei Läufe unter
+    derselben gestellten Uhr, Assert auf die Zahl zugestellter Alarme
+    (0 bzw. 1). **Kein** Codereview-Assert, keine Struktur-Zusicherung — die
+    Kopplung wird über ihre Wirkung gemessen, nicht über den Fundort im Code.
+  - **Grenze dieses AC, ausdrücklich benannt:** AC-5 misst die *Kopplung*
+    zwischen Segmentwahl und Schnappschuss-Lesung, nicht die Richtigkeit der
+    Segmentwahl selbst — eine Wahl unter dem falschen Tag, die zufällig
+    dieselben Koordinaten trifft, bliebe hier unbemerkt. Das deckt **AC-1**
+    ab (Koordinatennachweis). Die beiden gehören zusammen; keines von beiden
+    genügt allein.
+
+- **AC-6 (Rückfallkette):** Given zwei Touren, von denen die eine keine
+  Etappe am aufgelösten Tag hat, aber andere Etappen mit Wegpunkten trägt,
+  und die andere überhaupt keine Etappe mit Wegpunkten besitzt / When
+  `trip_local_today` für beide Touren die Zeitzone bestimmen muss, um daraus
+  den Ortstag abzuleiten / Then fällt die erste auf die Zone der ersten
+  Etappe mit Wegpunkten zurück und die zweite auf die aus
+  `src/utils/timezone.py` importierte UTC-Konstante — an keiner Stelle auf
+  ein hartverdrahtetes `ZoneInfo("UTC")`.
+  - Test: `tests/unit/test_trip_local_today.py`, drei Fälle (Treffer,
+    Rückfall 1, Rückfall 2) gegen `trip_day.trip_local_today`.
+
+- **AC-7 (Sommerzeit, ADR-0044-Pflicht):** Given eine europäische Zone an
+  beiden Umstellungstagen eines Jahres (Vorstellung und Rückstellung) / When
+  `trip_local_today` für Zeitpunkte kurz vor und kurz nach der Umstellung
+  ausgewertet wird / Then liefert sie an beiden Tagen den korrekten Ortstag —
+  ohne die Rechenfalle „gleiche tzinfo ⇒ 24,0 Stunden an jedem Tag"
+  (ADR-0044).
+  - Test: `tests/unit/test_trip_local_today.py`, `freeze_time` auf beide
+    Wechseltage 2026, Assert Ortstag korrekt vor/nach der Umstellungsstunde.
+
+- **AC-8 (keine vierte Kopie):** Given der Umbau ist abgeschlossen / When
+  `TripCommandProcessor` inspiziert wird / Then trägt die Klasse **nicht**
+  mehr die Methoden `_trip_tz`/`_display_tz`/`_anchor_tz` als eigene
+  Implementierung — sie ruft `trip_day` auf; im Repo existiert danach eine
+  Auflösung, nicht zwei.
+  - Test: `assert not hasattr(TripCommandProcessor, "_trip_tz")` (und
+    Geschwister) in `tests/unit/test_trip_local_today.py`; zusätzlich bleibt
+    die bestehende #1470-Suite
+    (`tests/tdd/test_drilldown_day_window_local_date.py`) unverändert grün —
+    Verhaltensnachweis, dass die Verschiebung nichts gebrochen hat.
+
+- **AC-9 (geteilte Testfixture bleibt synchron — „Zweiter Fund"):** Given
+  `tests/helpers/arrival_window_fixtures.py::stage_date(lat, lon)` wird für
+  eine Korsika-Koordinate und für eine UTC-neutrale Koordinate unter
+  identischer gestellter Uhr in der 22:00–00:00-UTC-Randzeit aufgerufen /
+  When beide Ergebnisse verglichen werden / Then weicht die Korsika-Koordinate
+  vom Serverdatum ab (Folgetag), während die UTC-neutrale Koordinate beim
+  Serverdatum bleibt — die Fixture folgt derselben Formel wie
+  `trip_alert.py`, nicht mehr der alten `date.today()`-Konstante.
+  - Test: `tests/unit/test_arrival_window_fixtures.py`, neue Zusicherung
+    unter `freeze_time` auf `…T22:30:00Z`.
+
+## Known Limitations
+
+- **Mehr-Zonen-Touren.** Wechselt der Wanderer an genau dem aufgelösten Tag
+  die Zeitzone, kann die Etappe des Weltzeit-Tages eine andere Zone tragen
+  als die des Ortstages. Der Restfehler ist die Differenz zweier
+  benachbarter Etappen — **warum genau zwei:** der Anker nimmt die Etappe des
+  Weltzeit-Tages (`anchor_tz`), der Ortstag höchstens die des Nachbartags;
+  weiter als einen Tag können die beiden nie auseinanderliegen, weil kein
+  UTC-Offset 24 h überschreitet. ADR-0044 stuft das als „in aller Regel null"
+  ein. Bewusst nicht gebaut (PO-Entscheidung 2026-08-10).
+- **Briefing-Schreiber bleibt auf Serverdatum.** `trip_report_scheduler.py`
+  schreibt Schnappschüsse weiterhin unter `date.today()`/`+1`
+  (`_get_target_date`, `:653-667`; Schreibstelle `save_dated`, `:1109`). Für
+  positive UTC-Offsets (Europe, Auckland) bleibt
+  das mit dem neuen Leser kompatibel, **weil** der Abend-Lauf bereits heute
+  pauschal `+1 Tag` schreibt (`trip_report_scheduler.py:667`:
+  `return today + timedelta(days=1)`), unabhängig von der tatsächlichen
+  Ortszeit
+  seines Laufzeitpunkts — dieser Vorgriff deckt sich mit dem Ortstag, den der
+  Leser in der Randzeit sucht. Für negative Offsets (America/Los_Angeles)
+  löst dieser Fix exakt die Lücke, die Messung 2 zeigt (3/4 → 4/4 Treffer),
+  weil der Morgen-Lauf ohnehin unter dem für den lokalen Tag richtigen
+  Serverdatum schreibt.
+  **Verbleibende, nicht einmalige Lücke:** In der Randzeit selbst
+  (22:00–00:00 UTC bzw. Zonen-Äquivalent) kann der Abend-Lauf zum
+  Prüfzeitpunkt noch nicht gelaufen sein — dann findet `:971`
+  (`_briefing_precip_for_onset`) **keinen** Schnappschuss unter dem neuen
+  Ortstags-Schlüssel. Das ist **fail-soft, nicht einmalig**: `kein Schnappschuss
+  ⇒ keine briefing-basierte Unterdrückung ⇒ der Radar-Alarm feuert trotzdem`
+  (sichere Richtung — ein möglicher Zusatz-Alarm, kein verschluckter).
+  **Belegt, nicht gefolgert:** `_briefing_precip_for_onset`
+  (`src/services/trip_alert.py:838-865`) gibt bei `snapshot is None` sofort
+  `None` zurück; die Unterdrückung an `:975` verlangt
+  `_briefing_precip is not None and _briefing_precip >= 0.5`. Fehlender
+  Schnappschuss kann also nur zu *weniger* Unterdrückung führen. **Die
+  Gegenprobe zu AC-5 misst genau diesen Zweig** (Schnappschuss unter dem
+  falschen Schlüssel ⇒ Alarm feuert) — die Limitation ist damit von einem
+  laufenden Test gedeckt, nicht nur von einem Absatz. Das
+  kann an jedem Tag in diesem 2-Stunden-Fenster erneut auftreten, abhängig
+  vom konfigurierten `evening_time` des jeweiligen Trips, nicht nur einmalig
+  bei der Umstellung.
+- **Kette B unverändert.** `/jetzt`, `/status`, `_handle_query`,
+  `command_date`, `inbound_telegram_reader.py`, `preview_service.py`,
+  `api/routers/debug.py`, `tools/weather_validation.py` bleiben auf
+  Serverzeit-Logik — eigenes Folge-Issue.
+- **`_get_cached_weather`s Datums-Treffer bleibt ungeprüft frisch.** Der
+  Fast-Path bei exaktem Schlüsseltreffer (`:571`) prüft nur die
+  Datumsgleichheit, keine zusätzliche Alters-/Frische-Prüfung — unverändertes
+  Verhalten von vor dieser Spec, nicht neu eingeführt.
+
+## Nachweis-Strategie
+
+- **Der wichtigste Test ist das Verhalten im 22:00–00:00-UTC-Fenster eines
+  Korsika-Trips**, nicht Neuseeland — genau dort ändert sich etwas für den
+  Bestand (AC-2/AC-3), und genau dort hätte eine unbelegte
+  „bitgleich"-Behauptung den Fehler durchgelassen (Kontext-Dokument, Abschnitt
+  „Nachgemessen und korrigiert").
+- **Wirkung** wird über **Koordinaten** des abgefragten Segments
+  nachgewiesen, nicht über einen Alarm-Zähler — ein Zähler hätte die
+  Falsch-Ortung (falsches Segment, richtiger Alarm) nie bemerkt.
+- **Uhr:** `freeze_time` (seit #1667 S1 Dev-Dependency). Keine DI-Naht: der
+  Alarm-Pfad liest die Wanduhr an mehreren Stellen (`check_all_trips`,
+  `check_radar_alerts`, der Testfixture selbst) — eine einzelne Naht wäre
+  eine halbe Uhr.
+- **Mutations-Gegenprobe (Pflicht, per Textersetzung + externer
+  Sicherungskopie, kein `git checkout/stash/reset`):**
+  1. `trip_local_today` in `trip_day.py` auf `date.today()` zurückgedreht ⇒
+     der Auckland-Koordinatentest (AC-1) muss rot werden.
+  2. Horizont-Guard aus `check_radar_alerts` entfernt ⇒ der AC-4-Fern-Fall
+     muss rot werden (Aufruf-Liste nicht mehr leer).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** ADR-0044 (bereits akzeptiert, keine neue ADR nötig)
+- **Rationale:** Diese Spec setzt eine bereits getroffene Grundsatzentscheidung
+  für Kette A (Alarm-/Radar-Pfad) um, statt eine neue zu treffen. Sie ändert
+  weder die Auflösungsregel noch den Rückfallmechanismus aus ADR-0044 — sie
+  überträgt sie unverändert von `TripCommandProcessor` (#1470, Kette
+  Drilldown) auf `TripAlertService` (Kette A, Alarm/Radar) und behebt einen
+  dadurch aufgedeckten Nebenbefund in der geteilten Testfixture.
+
+## Changelog
+
+- 2026-08-10: Initial spec created

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -29,6 +29,7 @@ from services.notification_service import (
 from services.point_weather import AlertEvaluationConfig, TripSegmentWeatherAdapter
 from services.corridor_threshold import CorridorHit
 from services.throttle_store import ThrottleStore
+from services.trip_day import trip_local_today
 from services.user_tier import sms_allowed
 from services.weather_change_detection import WeatherChangeDetectionService
 from utils.timezone import tz_for_coords
@@ -379,11 +380,13 @@ class TripAlertService:
             und uebersprungenen Touren, Gesamtlaufzeit und ob die
             Zeitobergrenze den Lauf beendet hat.
         """
-        from datetime import date as date_type
-
         from app.loader import load_all_trips
 
-        today = date_type.today()
+        # Issue #1697: "heute" bestimmt sich je Trip aus der ORTSzeit der
+        # Tour, nicht der Serveruhr (ADR-0044). now_utc bleibt fuer den
+        # gesamten Lauf gleich, damit kein Trip eine andere "Jetzt"-Sekunde
+        # sieht als der naechste.
+        now_utc = datetime.now(timezone.utc)
         alerts_sent = 0
         checked = 0
         hit_deadline = False
@@ -396,6 +399,9 @@ class TripAlertService:
                 hit_deadline = True
                 break
             checked += 1
+            # Issue #1697: Ortstag dieses Trips — die Zone haengt vom Trip ab,
+            # deshalb erst HIER (je Trip), nicht einmal vor der Schleife.
+            today = trip_local_today(trip, now_utc)
             # Issue #222 W1: Trips with active alert_rules must be checked even if
             # report_config is missing or alert_on_changes=False — alert_rules is the
             # new source-of-truth (disable via rule.enabled=False).
@@ -443,13 +449,15 @@ class TripAlertService:
                 continue
 
             # Δ-Anker: hier ist ein Anker DESSELBEN Tages Pflicht (#1661).
-            cached = self._get_cached_weather(trip, tagesgleicher_anker_noetig=True)
+            cached = self._get_cached_weather(
+                trip, tagesgleicher_anker_noetig=True, now_utc=now_utc,
+            )
 
             # Issue #1088: amtliche Warnungen zusätzlich zum Wetter-Delta prüfen —
             # fail-soft, darf den Zyklus für andere Trips nicht abbrechen.
             official_notices: list = []
             try:
-                official_notices = self.check_official_alert_triggers(trip)
+                official_notices = self.check_official_alert_triggers(trip, now_utc=now_utc)
             except Exception as e:
                 logger.error(f"Official alert trigger check failed for trip {trip.id}: {e}")
 
@@ -507,7 +515,8 @@ class TripAlertService:
         )
 
     def _get_cached_weather(
-        self, trip: "Trip", *, tagesgleicher_anker_noetig: bool
+        self, trip: "Trip", *, tagesgleicher_anker_noetig: bool,
+        now_utc: Optional[datetime] = None,
     ) -> Optional[List[SegmentWeatherData]]:
         """
         Get cached weather data for a trip from the weather snapshot.
@@ -558,6 +567,12 @@ class TripAlertService:
         Args:
             trip: Trip to get cached weather for
             tagesgleicher_anker_noetig: True nur fuer den Abweichungs-Alarm.
+            now_utc: Issue #1697 — "Jetzt" fuer die Ortstag-Aufloesung
+                (`trip_local_today`). Optional mit Default auf die echte
+                Wanduhr: anders als `tagesgleicher_anker_noetig` ist das
+                eine reine "wie spaet ist es"-Frage, kein Verhaltensschalter
+                (Begruendung: Spec-Abschnitt "Bewusste Abweichung vom
+                'kein Default'-Muster").
 
         Returns:
             Cached weather data or None if not available/not trustworthy
@@ -566,7 +581,7 @@ class TripAlertService:
             from services.weather_snapshot import WeatherSnapshotService
 
             svc = WeatherSnapshotService(user_id=self._user_id)
-            today = date.today()
+            today = trip_local_today(trip, now_utc or datetime.now(timezone.utc))
             dated = svc.load_dated(trip.id, today)
             if dated is not None:
                 return dated
@@ -874,15 +889,16 @@ class TripAlertService:
 
         Returns the number of radar alerts triggered.
         """
-        from datetime import date as date_type
         from app.loader import load_all_trips
         from services.trip_segments import convert_trip_to_segments
 
-        today = date_type.today()
         now_utc = datetime.now(timezone.utc)
         sent = 0
 
         for trip in load_all_trips(user_id=self._user_id):
+            # Issue #1697: Ortstag dieses Trips statt Serverdatum (ADR-0044) —
+            # je Trip, die Zone haengt vom Trip ab.
+            today = trip_local_today(trip, now_utc)
             # Segment-Auswahl (Issue #822 — ersetzt stage.waypoints[0])
             segments = convert_trip_to_segments(trip, today)
             if not segments:
@@ -902,6 +918,29 @@ class TripAlertService:
                     # Alle Segmente zeitlich vorbei → kein Alert (Option Y der Spec)
                     logger.debug(
                         f"Radar alert skipped: alle Segmente vorbei fuer {trip.id}"
+                    )
+                    continue
+
+            # Issue #1697 AC-4: Horizont-Guard — Vorbild
+            # `trip_report_scheduler.py::_build_starkregen_hint`. Ein Segment,
+            # das erst weit in der Zukunft beginnt, loest keinen Nowcast-Abruf
+            # aus (Horizont ~60 min); ohne diesen Guard riefe die neue
+            # Ortstag-Etappenwahl in der 22:00-00:00-UTC-Randzeit jede Nacht
+            # einen fachlich sinnlosen Nowcast fuer die morgige Etappe ab.
+            if active.start_time > now_utc:
+                from services.radar_service import NOWCAST_HORIZON_MIN
+
+                minutes_until_start = (active.start_time - now_utc).total_seconds() / 60.0
+                if minutes_until_start > NOWCAST_HORIZON_MIN:
+                    # #1405-Linie: WAS uebersprungen wird, wird benannt, nicht
+                    # nur DASS uebersprungen wird — der Startzeitpunkt macht
+                    # die Meldung zu einer Aussage ueber das Segment selbst
+                    # (pruefbar, betrieblich brauchbar), statt nur ueber die
+                    # Distanz in Minuten.
+                    logger.debug(
+                        f"Radar alert skipped: Segment beginnt erst in "
+                        f"{minutes_until_start:.0f} min (>{NOWCAST_HORIZON_MIN} min "
+                        f"Horizont, Start={active.start_time.isoformat()}) fuer {trip.id}"
                     )
                     continue
 
@@ -1241,7 +1280,9 @@ class TripAlertService:
 
         return result
 
-    def check_official_alert_triggers(self, trip: "Trip") -> list:
+    def check_official_alert_triggers(
+        self, trip: "Trip", now_utc: Optional[datetime] = None,
+    ) -> list:
         """Issue #1088/#1200: liefert amtliche Warnungen, die NEU sind oder deren
 
         Level gestiegen ist ggü. dem letzten gemeldeten Stand (alert_state),
@@ -1252,6 +1293,10 @@ class TripAlertService:
         get_official_alerts_for_location() pro Quelle abgefangen. Schreibt
         KEINEN alert_state — das übernimmt der Aufrufer erst nach
         erfolgreichem Versand (Konsistenz mit dem Wetter-Delta-Pfad).
+
+        Issue #1697: `now_utc` reicht die "Jetzt"-Sekunde des Laufs an
+        `_get_cached_weather` durch (Default: echte Wanduhr, s. dortiger
+        Docstring).
         """
         # Issue #1258: official_warnings.enabled loest das Legacy-Feld ab.
         # official_warnings is None -> Trip noch nicht migriert -> Fallback auf
@@ -1271,7 +1316,9 @@ class TripAlertService:
         # `cached` dient hier nur als Routen-Geometrie mit absoluten Zeiten; der
         # feinere Zeitfilter pro Etappe steht unten (`end_time < now_utc`).
         # Begruendung ausfuehrlich im Docstring von `_get_cached_weather`.
-        cached = self._get_cached_weather(trip, tagesgleicher_anker_noetig=False)
+        cached = self._get_cached_weather(
+            trip, tagesgleicher_anker_noetig=False, now_utc=now_utc,
+        )
         if not cached:
             return []
 

--- a/src/services/trip_command_processor.py
+++ b/src/services/trip_command_processor.py
@@ -20,7 +20,8 @@ from typing import Optional
 
 from app.loader import get_data_dir, get_snapshots_dir, load_all_trips, save_trip
 from app.trip import Stage, Trip
-from utils.timezone import UTC, local_dt, local_fmt, local_hour, tz_for_coords
+from services.trip_day import anchor_tz, display_tz
+from utils.timezone import UTC, local_dt, local_fmt, local_hour
 
 logger = logging.getLogger(__name__)
 
@@ -750,78 +751,28 @@ class TripCommandProcessor:
         kurz vor Mitternacht still auf Minuten zusammenschrumpfen — eine
         Produktaenderung, die niemand bestellt hat.
 
-        Reihenfolge-Falle: ``_display_tz(trip, day_date)`` braucht den Tag,
+        Reihenfolge-Falle: ``display_tz(trip, day_date)`` braucht den Tag,
         aber welcher Tag "heute" ist, entscheidet erst die Zone. Aufgeloest in
-        zwei Schritten — die Zone des WELTZEIT-Tages (``_anchor_tz``) bestimmt
-        den Kalendertag, die etappengenaue Zone genau dieses Tages danach
-        Fensterbeginn UND Beschriftung. ``tz`` wird ZURUECKGEGEBEN und vom
-        Aufrufer durchgereicht, nicht dort ein zweites Mal geholt: so koennen
-        Fenstergrenze und Uhrzeitspalte konstruktiv nicht auseinanderlaufen
-        (AC-4).
+        zwei Schritten (``services.trip_day``, #1697 — verschoben aus #1470,
+        Verhalten bit-identisch) — die Zone des WELTZEIT-Tages (``anchor_tz``)
+        bestimmt den Kalendertag, die etappengenaue Zone genau dieses Tages
+        danach Fensterbeginn UND Beschriftung. ``tz`` wird ZURUECKGEGEBEN und
+        vom Aufrufer durchgereicht, nicht dort ein zweites Mal geholt: so
+        koennen Fenstergrenze und Uhrzeitspalte konstruktiv nicht
+        auseinanderlaufen (AC-4).
 
         Rueckgabe: ``(from_time, hours, day_date, tz)``.
         """
-        local_now = local_dt(received_at, self._anchor_tz(trip, received_at))
+        local_now = local_dt(received_at, anchor_tz(trip, received_at))
         if day_token == "today":
             day_date = local_now.date()
-            return received_at, 12, day_date, self._display_tz(trip, day_date)
+            return received_at, 12, day_date, display_tz(trip, day_date)
         day_date = (local_now + timedelta(days=1)).date()
         next_date = day_date + timedelta(days=1)
-        tz = self._display_tz(trip, day_date)
+        tz = display_tz(trip, day_date)
         from_time = _local_midnight(day_date, tz)
         hours = _hours_between(from_time, _local_midnight(next_date, tz))
         return from_time, hours, day_date, tz
-
-    def _anchor_tz(self, trip: Trip, received_at: datetime):
-        """Zone, die entscheidet WELCHER Kalendertag gerade ist (#1470 F003).
-
-        Genommen wird die Etappe des WELTZEIT-Tages. Der liegt hoechstens
-        einen Tag neben dem Ortstag, trifft also praktisch immer die Etappe,
-        auf der der Nutzer gerade steht. Der frueher benutzte Anker "erste
-        Etappe der Tour" war bei einer Tour ueber mehrere Zonen grob daneben:
-        gemessen an einer Tour Neuseeland -> Korsika lag der Tageswechsel
-        ZEHN Stunden falsch (12:00-22:00 UTC meldete bereits den Folgetag,
-        waehrend es am Ort erst 14:00-23:00 war). Mit diesem Anker bleibt als
-        Restfehler nur die Zonendifferenz zweier BENACHBARTER Etappen — null,
-        ausser der Wanderer wechselt an genau diesem Tag die Zone.
-
-        ``local_dt(..., UTC)`` statt ``received_at.date()``: der Weltzeit-Tag
-        soll aus der Weltzeit kommen, auch wenn ein Aufrufer den Zeitstempel
-        einmal in einer anderen Zone hereinreicht.
-        """
-        return self._display_tz(trip, local_dt(received_at, UTC).date())
-
-    def _trip_tz(self, trip: Trip):
-        """Ortszone der Tour OHNE Tagesbezug — erste Etappe, die Wegpunkte hat.
-
-        Beantwortet allein die Frage "welcher Kalendertag ist gerade?"
-        (#1470). Es ist derselbe Weg, den ``_display_tz`` schon als Rueckfall
-        geht, nur ohne das Tagesargument — keine zweite Aufloesung. Ohne
-        Wegpunkt bleibt die importierte UTC-Konstante (Hausnorm #1345), nie
-        ein hartverdrahtetes ``ZoneInfo("UTC")``.
-        """
-        stage = next((s for s in trip.stages if s.waypoints), None)
-        if stage is None:
-            return UTC
-        wp = stage.waypoints[0]
-        return tz_for_coords(wp.lat, wp.lon)
-
-    def _display_tz(self, trip: Trip, day_date: date):
-        """Anzeige-Zeitzone = ORTSzeit des Wegpunkts, nicht Prozess-Zeitzone.
-
-        Issue #1402: ein naiver Zeitstempel ist per Hausnorm (#1345) UTC. Ein
-        argumentloses ``.astimezone()`` deutet ihn als PROZESS-Zeitzone — auf
-        dem UTC-Server zufaellig unauffaellig, auf jedem anderen Host falsch.
-        Deshalb dieselbe Aufloesung wie im ``/jetzt``-Pfad weiter unten:
-        Koordinaten des Wegpunkts -> Zone. Ohne Wegpunkt bleibt nur UTC (die
-        Zeitstempel SIND UTC) — dann stimmt die Anzeige wenigstens mit den
-        Daten ueberein, statt die Serverzone zu raten.
-        """
-        stage = trip.get_stage_for_date(day_date)
-        if stage is None or not stage.waypoints:
-            return self._trip_tz(trip)
-        wp = stage.waypoints[0]
-        return tz_for_coords(wp.lat, wp.lon)
 
     def _format_drilldown(
         self, res, header: str, fmt, tz, with_emoji: bool = True,

--- a/src/services/trip_day.py
+++ b/src/services/trip_day.py
@@ -1,0 +1,81 @@
+"""Geteilter Baustein: "welcher Kalendertag ist gerade, an der Ortszeit der
+Tour?" (ADR-0044, Issue #1697).
+
+Verschoben aus ``services.trip_command_processor`` (#1470,
+``_trip_tz``/``_display_tz``/``_anchor_tz``) — bit-identisches Verhalten,
+nur ``self.`` entfernt. Neu ist ausschliesslich :func:`trip_local_today`.
+
+SPEC: docs/specs/modules/fix_1697_ortstag_statt_servertag.md
+
+Warum ein eigenes Modul statt ``utils/timezone.py``: letzteres ist eine
+generische Koordinaten-/Zeitzonen-Bibliothek ohne Domaenenwissen
+(``tz_for_coords``, ``local_dt``, ``UTC``) — kennt weder ``Trip`` noch
+``Stage``. Diese Funktionen kennen ``Trip.stages``/``Trip.get_stage_for_date``
+und gehoeren deshalb in die Domaenen-Schicht (``src/services/``).
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import TYPE_CHECKING
+
+from utils.timezone import UTC, local_dt, tz_for_coords
+
+if TYPE_CHECKING:
+    from zoneinfo import ZoneInfo
+
+    from app.trip import Trip
+
+
+def trip_tz(trip: "Trip") -> "ZoneInfo":
+    """Ortszone der Tour OHNE Tagesbezug — erste Etappe, die Wegpunkte hat.
+
+    Beantwortet allein die Frage "welcher Kalendertag ist gerade?" (#1470).
+    Es ist derselbe Weg, den :func:`display_tz` schon als Rueckfall geht, nur
+    ohne das Tagesargument — keine zweite Aufloesung. Ohne Wegpunkt bleibt
+    die importierte UTC-Konstante (Hausnorm #1345), nie ein hartverdrahtetes
+    ``ZoneInfo("UTC")``.
+    """
+    stage = next((s for s in trip.stages if s.waypoints), None)
+    if stage is None:
+        return UTC
+    wp = stage.waypoints[0]
+    return tz_for_coords(wp.lat, wp.lon)
+
+
+def display_tz(trip: "Trip", day_date: date) -> "ZoneInfo":
+    """Anzeige-Zeitzone = ORTSzeit des Wegpunkts an ``day_date`` — Rueckfall
+    auf :func:`trip_tz`, wenn diese Etappe keine Wegpunkte traegt."""
+    stage = trip.get_stage_for_date(day_date)
+    if stage is None or not stage.waypoints:
+        return trip_tz(trip)
+    wp = stage.waypoints[0]
+    return tz_for_coords(wp.lat, wp.lon)
+
+
+def anchor_tz(trip: "Trip", now_utc: datetime) -> "ZoneInfo":
+    """Zone, die entscheidet WELCHER Kalendertag gerade ist (#1470 F003).
+
+    Genommen wird die Etappe des WELTZEIT-Tages. Der liegt hoechstens einen
+    Tag neben dem Ortstag, trifft also praktisch immer die Etappe, auf der
+    der Nutzer gerade steht. Der frueher benutzte Anker "erste Etappe der
+    Tour" war bei einer Tour ueber mehrere Zonen grob daneben: gemessen an
+    einer Tour Neuseeland -> Korsika lag der Tageswechsel ZEHN Stunden
+    falsch. Mit diesem Anker bleibt als Restfehler nur die Zonendifferenz
+    zweier BENACHBARTER Etappen — null, ausser der Wanderer wechselt an
+    genau diesem Tag die Zone (Known Limitation, PO 2026-08-10).
+
+    ``local_dt(..., UTC)`` statt ``now_utc.date()``: der Weltzeit-Tag soll
+    aus der Weltzeit kommen, auch wenn ein Aufrufer den Zeitstempel einmal
+    in einer anderen Zone hereinreicht.
+    """
+    return display_tz(trip, local_dt(now_utc, UTC).date())
+
+
+def trip_local_today(trip: "Trip", now_utc: datetime) -> date:
+    """Der Kalendertag "heute", gemessen an der Ortszeit der Tour (ADR-0044).
+
+    Henne-Ei-Aufloesung in zwei Schritten (#1470): :func:`anchor_tz`
+    bestimmt zuerst WELCHER Kalendertag gerade ist (ueber die Etappe des
+    Weltzeit-Tages), dann liefert dieselbe Zone den eigentlichen Ortstag.
+    """
+    return local_dt(now_utc, anchor_tz(trip, now_utc)).date()

--- a/tests/helpers/arrival_window_fixtures.py
+++ b/tests/helpers/arrival_window_fixtures.py
@@ -64,11 +64,12 @@ nie „vorbei".
 
 Bezugstag
 ---------
-``stage_date()`` liefert dieselbe Quelle, die ``trip_alert.py`` fuer
-``convert_trip_to_segments`` benutzt (``date.today()``). Fixturen sollten das
-Etappendatum daraus nehmen statt aus ``datetime.now(timezone.utc).date()``:
-laeuft die Systemzeitzone nicht auf UTC (oder faellt der Testlauf genau auf
-den Datumssprung), zeigen die beiden sonst auf verschiedene Tage und
+``stage_date(lat, lon)`` liefert dieselbe Formel, die ``trip_alert.py`` seit
+Issue #1697 fuer ``convert_trip_to_segments`` benutzt (Ortstag der Tour ueber
+``trip_local_today``, ADR-0044, nicht mehr ``date.today()``). Fixturen
+nehmen das Etappendatum daraus statt aus
+``datetime.now(timezone.utc).date()``: sonst zeigen Etappendatum und
+Ankunftszeiten in der 22:00-00:00-UTC-Randzeit auf verschiedene Tage und
 ``get_stage_for_date()`` findet nichts.
 
 Kein Mock: die Funktionen rechnen mit echten Zeitzonen ueber
@@ -82,7 +83,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta, timezone
 
-from utils.timezone import tz_for_coords
+from utils.timezone import local_dt, tz_for_coords
 
 __all__ = [
     "MINUTEN_PRO_TAG",
@@ -152,15 +153,24 @@ def fenster_minuten(minuten_jetzt: int, *offsets_min: int) -> tuple[int, ...]:
     return tuple(minuten)
 
 
-def stage_date() -> date:
+def stage_date(lat: float, lon: float) -> date:
     """Etappendatum, das zur Segmentauswahl in ``trip_alert.py`` passt.
 
-    Dort steht ``today = date_type.today()``; ``convert_trip_to_segments``
-    sucht die Etappe ueber ``get_stage_for_date(today)``. Eine Fixture, die
-    ihr Etappendatum aus ``datetime.now(timezone.utc).date()`` nimmt, trifft
-    das nur, solange die Systemzeitzone UTC ist.
+    Issue #1697: ``check_radar_alerts()`` sucht die Etappe seither ueber
+    ``trip_local_today(trip, now_utc)`` (Ortstag der Tour, ADR-0044) statt
+    ueber ``date.today()`` (Serverdatum). ``lat``/``lon`` sind deshalb
+    PFLICHT (kein Default) — jeder Aufrufer muss bewusst dieselben
+    Koordinaten uebergeben, die er auch fuer
+    ``active_window_offsets``/``past_window_offsets`` benutzt, sonst laufen
+    Etappendatum und Ankunftszeiten in der 22:00-00:00-UTC-Randzeit
+    auseinander (exakt die Fehlerklasse, die #1697 in Produktion behebt).
+
+    Bewusst NICHT ``services.trip_day.trip_local_today`` — die Fixture kennt
+    ihre Koordinaten bereits direkt (keine Henne-Ei-Falle, kein Trip zum
+    Nachschlagen), sie bleibt bei der einfacheren Formel mit den bereits
+    importierten Bausteinen.
     """
-    return date.today()
+    return local_dt(datetime.now(timezone.utc), tz_for_coords(lat, lon)).date()
 
 
 def active_window_offsets(lat: float, lon: float, *offsets_min: int) -> tuple[str, ...]:
@@ -202,7 +212,7 @@ def _tagesbezug(lat: float, lon: float) -> tuple[datetime, int]:
     (``datetime.combine(target_date, wp_time).replace(tzinfo=seg_tz)``).
     """
     tz = tz_for_coords(lat, lon)
-    tagesbeginn = datetime.combine(stage_date(), time(0, 0)).replace(tzinfo=tz)
+    tagesbeginn = datetime.combine(stage_date(lat, lon), time(0, 0)).replace(tzinfo=tz)
     jetzt = datetime.now(timezone.utc)
     return tagesbeginn, int((jetzt - tagesbeginn).total_seconds() // 60)
 
@@ -235,7 +245,7 @@ def past_window_offsets(lat: float, lon: float, *offsets_min: int) -> tuple[str,
         )
 
     tz = tz_for_coords(lat, lon)
-    tag = stage_date()
+    tag = stage_date(lat, lon)
     tagesbeginn = datetime.combine(tag, time(0, 0)).replace(tzinfo=tz)
     jetzt = datetime.now(timezone.utc)
     minuten_jetzt = int((jetzt - tagesbeginn).total_seconds() // 60)

--- a/tests/helpers/nowcast_gate_fixtures.py
+++ b/tests/helpers/nowcast_gate_fixtures.py
@@ -335,30 +335,64 @@ def entries_for(user_id: str, entity_id: str, *, bucket: str) -> list[dict]:
 # ─────────────────────────────── Trip-Bausteine ─────────────────────────────
 
 
+def trip_stage(
+    stage_id: str, day: date_type, lat: float, lon: float,
+    *, arrival_start: str = "00:00", arrival_end: str = "23:59",
+    wp_prefix: str = "WP",
+) -> Stage:
+    """Zwei-Wegpunkt-Etappe (Start/Ende) — der Baustein, aus dem
+    :func:`make_trip` seine Etappe baut. Additiv exportiert (Issue #1697),
+    damit Aufrufer, die eine ZWEITE Etappe (z.B. Folgetag) brauchen, sie
+    NICHT selbst aus ``Stage``/``Waypoint`` zusammensetzen — Teilungsregel
+    statt Nachbau.
+    """
+    wp0 = Waypoint(
+        id=f"{wp_prefix}0", name="Start", lat=lat, lon=lon, elevation_m=500.0,
+        arrival_calculated=arrival_start,
+    )
+    wp1 = Waypoint(
+        id=f"{wp_prefix}1", name="Ende", lat=lat + 0.1, lon=lon + 0.1, elevation_m=600.0,
+        arrival_calculated=arrival_end,
+    )
+    return Stage(id=stage_id, name="Tag 1", date=day, waypoints=[wp0, wp1])
+
+
 def make_trip(
     trip_id: str,
     *,
     cooldown_minutes: int = 120,
     quiet_from: str | None = None,
     quiet_to: str | None = None,
+    stage_date: date_type | None = None,
+    lat: float = TRIP_LAT,
+    lon: float = TRIP_LON,
+    arrival_start: str = "00:00",
+    arrival_end: str = "23:59",
+    extra_stages: list[Stage] | None = None,
 ) -> Trip:
     """Trip mit einer heute aktiven Etappe (Segment-Auswahl in
     ``check_radar_alerts()`` braucht ``arrival_calculated``).
 
-    Die Etappe spannt bewusst den GANZEN Tag (00:00–23:59 Ortszeit = UTC, s.
-    ``TRIP_LAT``): so ist zu jeder Tageszeit ein Segment aktiv und der Test
-    misst die Freigabe-Stufen, nicht die Segment-Auswahl.
+    Die Etappe spannt standardmaessig den GANZEN Tag (00:00–23:59 Ortszeit =
+    UTC, s. ``TRIP_LAT``): so ist zu jeder Tageszeit ein Segment aktiv und
+    der Test misst die Freigabe-Stufen, nicht die Segment-Auswahl.
+
+    Issue #1697: ``stage_date``/``lat``/``lon``/``arrival_start``/
+    ``arrival_end``/``extra_stages`` sind ADDITIV — alle Defaults sind
+    bit-identisch zum bisherigen Verhalten (``date.today()``,
+    ``TRIP_LAT``/``TRIP_LON``, 00:00–23:59, keine zweite Etappe). Bestehende
+    Aufrufer (``test_nowcast_suppression_logging.py``,
+    ``test_trip_radar_nowcast_gate_migration.py``) bleiben unveraendert
+    gruen (belegt per Testlauf, s. Commit-Historie). Die neuen Parameter
+    dienen Faellen, die eine ANDERE Etappe/einen zweiten Tag brauchen (z.B.
+    #1697 AC-1/AC-3/AC-5: Ortsdatum weicht vom Serverdatum ab).
     """
-    wp0 = Waypoint(
-        id="WP0", name="Start", lat=TRIP_LAT, lon=TRIP_LON, elevation_m=500.0,
-        arrival_calculated="00:00",
+    day = stage_date if stage_date is not None else date_type.today()
+    stage = trip_stage(
+        "S1", day, lat, lon, arrival_start=arrival_start, arrival_end=arrival_end,
     )
-    wp1 = Waypoint(
-        id="WP1", name="Ende", lat=TRIP_LAT + 0.1, lon=TRIP_LON + 0.1, elevation_m=600.0,
-        arrival_calculated="23:59",
-    )
-    stage = Stage(id="S1", name="Tag 1", date=date_type.today(), waypoints=[wp0, wp1])
-    trip = Trip(id=trip_id, name="S3 Nowcast-Trip", stages=[stage])
+    stages = [stage] + list(extra_stages or [])
+    trip = Trip(id=trip_id, name="S3 Nowcast-Trip", stages=stages)
     trip.report_config = TripReportConfig(
         trip_id=trip_id, send_email=True, send_telegram=False,
     )

--- a/tests/tdd/test_alert_channel_threshold.py
+++ b/tests/tdd/test_alert_channel_threshold.py
@@ -217,7 +217,11 @@ def _radar_trip(trip_id: str) -> Trip:
     ``test_issue_827_radar_throttle_recording.py::_make_trip``."""
     # #1667 S1: wanduhr-robustes Ankunftsfenster statt roher now+Nh-Arithmetik
     # (ab 22:00 UTC lief die +2h/+4h-Folge steigend ueber Mitternacht).
-    arr0, arr1 = active_window_offsets(LAT, LON, 120, 240)
+    # #1697 AC-4: Segment muss JETZT aktiv sein (nicht erst in 2h beginnen,
+    # s. Docstring oben "im aktiven Segmentfenster JETZT"), sonst greift der
+    # neue Horizont-Guard (NOWCAST_HORIZON_MIN=60) und unterdrueckt den
+    # Nowcast-Abruf, den dieser Test misst.
+    arr0, arr1 = active_window_offsets(LAT, LON, -60, 120)
     wp0 = Waypoint(
         id="WP0", name="Start", lat=LAT, lon=LON, elevation_m=500.0,
         arrival_calculated=arr0,
@@ -226,7 +230,7 @@ def _radar_trip(trip_id: str) -> Trip:
         id="WP1", name="Ziel", lat=LAT + 0.1, lon=LON + 0.1, elevation_m=600.0,
         arrival_calculated=arr1,
     )
-    stage = Stage(id="S1", name="Tag 1", date=stage_date(), waypoints=[wp0, wp1])
+    stage = Stage(id="S1", name="Tag 1", date=stage_date(LAT, LON), waypoints=[wp0, wp1])
     trip = Trip(id=trip_id, name="AC3 Radar-Trip", stages=[stage])
     trip.report_config = TripReportConfig(
         trip_id=trip_id, send_email=True, send_telegram=True, send_sms=False,

--- a/tests/tdd/test_alert_log_metrics.py
+++ b/tests/tdd/test_alert_log_metrics.py
@@ -125,7 +125,7 @@ def _save_radar_trip(user_id: str, trip_id: str) -> None:
     (briefings / f"{trip_id}.json").write_text(json.dumps({
         "id": trip_id, "name": "Radar-Trip",
         "stages": [{
-            "id": "S1", "name": "Tag 1", "date": stage_date().isoformat(),
+            "id": "S1", "name": "Tag 1", "date": stage_date(LAT, LON).isoformat(),
             "waypoints": [
                 {"id": "W0", "name": "Start", "lat": LAT, "lon": LON,
                  "elevation_m": 1000.0,

--- a/tests/tdd/test_alert_quiet_hours_robustness.py
+++ b/tests/tdd/test_alert_quiet_hours_robustness.py
@@ -244,7 +244,7 @@ def _save_trip_direct(
         "id": trip_id,
         "name": name,
         "stages": [{
-            "id": "S1", "name": "Tag 1", "date": stage_date().isoformat(),
+            "id": "S1", "name": "Tag 1", "date": stage_date(lat, lon).isoformat(),
             "waypoints": [
                 {"id": "WP0", "name": "Start", "lat": lat, "lon": lon,
                  "elevation_m": 100.0,

--- a/tests/tdd/test_alert_urgency.py
+++ b/tests/tdd/test_alert_urgency.py
@@ -184,7 +184,7 @@ def _save_radar_trip(user_id: str, trip_id: str) -> None:
     (briefings / f"{trip_id}.json").write_text(json.dumps({
         "id": trip_id, "name": "Radar-Trip",
         "stages": [{
-            "id": "S1", "name": "Tag 1", "date": stage_date().isoformat(),
+            "id": "S1", "name": "Tag 1", "date": stage_date(LAT, LON).isoformat(),
             "waypoints": [
                 {"id": "W0", "name": "Start", "lat": LAT, "lon": LON,
                  "elevation_m": 1000.0,

--- a/tests/tdd/test_briefing_anchor_survives_dispatch_failure.py
+++ b/tests/tdd/test_briefing_anchor_survives_dispatch_failure.py
@@ -72,13 +72,14 @@ from app.models import (
     UnifiedWeatherDisplayConfig,
 )
 from app.trip import Stage, Trip, Waypoint
+from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
 
 # Pfadregel #1409: Pruefling relativ zur Testdatei aufloesen, nie ueber einen
 # festen Hauptrepo-Pfad — sonst pruefte dieser Test aus dem Worktree die
 # unveraenderte Hauptrepo-Kopie und meldete falsches Gruen.
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-LAT, LON = 47.0, 11.0
+LAT, LON = 64.13, -21.90
 
 # Alle Transport-Felder ausdruecklich unbrauchbar: `Settings()` faellt bei
 # fehlenden Feldern still auf die Prod-`.env` im Worktree zurueck (#1477).
@@ -173,13 +174,20 @@ def _trip(trip_id: str, *, with_levels: bool = False,
     ein Vermerk mit gestrigem Zieltag pruefen, ohne dass er schon an der
     bestehenden "keine Segmente"-Regel (`:392-395`) verfaellt.
     """
+    # #1667 S1 / #1697: wanduhr-robuste Ankunftszeit + Ortstag statt roher
+    # date.today() ohne arrival_calculated — sonst greift ab ~17:00 UTC der
+    # Naismith-Default 08:00 und das Ziel-Segment endet am Tagesfenster-Ende
+    # (19:00 Ortszeit) VOR dem Testlauf.
+    heute = stage_date(LAT, LON)
+    arr0, arr1 = active_window_offsets(LAT, LON, -60, 120)
     stages = [
         Stage(
-            id=f"T{i + 1}", name=f"Tag {i + 1}", date=date.today() + timedelta(days=off),
+            id=f"T{i + 1}", name=f"Tag {i + 1}", date=heute + timedelta(days=off),
             waypoints=[
-                Waypoint(id=f"G{i}1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0),
+                Waypoint(id=f"G{i}1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0,
+                         arrival_calculated=arr0),
                 Waypoint(id=f"G{i}2", name="Ziel", lat=LAT + 0.1, lon=LON + 0.1,
-                         elevation_m=1500.0),
+                         elevation_m=1500.0, arrival_calculated=arr1),
             ],
         )
         for i, off in enumerate(stage_offsets)

--- a/tests/tdd/test_bundle_791_847_844_alerts.py
+++ b/tests/tdd/test_bundle_791_847_844_alerts.py
@@ -199,7 +199,7 @@ def test_ac1_radar_alert_onset_in_local_time():
         arr0, arr1 = active_window_offsets(lat, lon, -60, 180)
         wp0 = _make_waypoint("WP0", lat, lon, arr0)
         wp1 = _make_waypoint("WP1", lat + 0.1, lon + 0.1, arr1)
-        stage = Stage(id="S1", name="Etappe 1", date=stage_date(), waypoints=[wp0, wp1])
+        stage = Stage(id="S1", name="Etappe 1", date=stage_date(lat, lon), waypoints=[wp0, wp1])
         trip_id = f"tdd-791-trip-{uuid.uuid4().hex[:6]}"
         trip = Trip(id=trip_id, name="GR20 Test", stages=[stage])
         trip.report_config = TripReportConfig(

--- a/tests/tdd/test_issue_1070_daily_alert_limit.py
+++ b/tests/tdd/test_issue_1070_daily_alert_limit.py
@@ -229,12 +229,15 @@ def _wet_frames(lat: float, lon: float) -> list:
 def _make_trip(trip_id: str, send_email: bool, send_telegram: bool) -> Trip:
     # #1667 S1: wanduhr-robustes Ankunftsfenster statt roher now+Nh-Arithmetik
     # (ab 22:00 UTC lief die +2h/+4h-Folge steigend ueber Mitternacht).
-    arr0, arr1 = active_window_offsets(LAT, LON, 120, 240)
+    # #1697 AC-4: Segment muss JETZT aktiv sein (nicht erst in 2h beginnen),
+    # sonst greift der neue Horizont-Guard (NOWCAST_HORIZON_MIN=60) und
+    # unterdrueckt den Nowcast-Abruf, den diese Tests messen wollen.
+    arr0, arr1 = active_window_offsets(LAT, LON, -60, 120)
     wp0 = Waypoint(id="WP0", name="Start", lat=LAT, lon=LON, elevation_m=500.0,
                    arrival_calculated=arr0)
     wp1 = Waypoint(id="WP1", name="End", lat=LAT + 0.1, lon=LON + 0.1, elevation_m=600.0,
                    arrival_calculated=arr1)
-    stage = Stage(id="S1", name="Tag 1", date=stage_date(), waypoints=[wp0, wp1])
+    stage = Stage(id="S1", name="Tag 1", date=stage_date(LAT, LON), waypoints=[wp0, wp1])
     trip = Trip(id=trip_id, name="1070 Test", stages=[stage])
     trip.report_config = TripReportConfig(
         trip_id=trip_id,

--- a/tests/tdd/test_issue_818_radar_briefing_integration.py
+++ b/tests/tdd/test_issue_818_radar_briefing_integration.py
@@ -466,7 +466,7 @@ def test_ac5_past_segment_no_alert_guard_test():
             elevation_m=200.0,
             arrival_calculated=arr1,
         )
-        stage = Stage(id="S1", name="Tag 1", date=stage_date(), waypoints=[wp0, wp1])
+        stage = Stage(id="S1", name="Tag 1", date=stage_date(past_lat, past_lon), waypoints=[wp0, wp1])
         trip_id = f"tdd-818-ac5-{uuid.uuid4().hex[:6]}"
         trip = Trip(id=trip_id, name="AC5 Past Trip", stages=[stage])
         trip.report_config = TripReportConfig(

--- a/tests/tdd/test_issue_822_radar_nowcast_segment.py
+++ b/tests/tdd/test_issue_822_radar_nowcast_segment.py
@@ -195,11 +195,11 @@ def test_ac1_segment_helper_roundtrip_bit_identical():
     wp2 = _make_waypoint("WP2", lat + 0.2, lon + 0.2, arr2)
     stage = Stage(
         id="S1", name="Tag 1",
-        date=stage_date(),
+        date=stage_date(lat, lon),
         waypoints=[wp0, wp1, wp2],
     )
     trip = Trip(id="tdd-822-ac1-trip", name="AC1 Trip", stages=[stage])
-    target_date = stage_date()
+    target_date = stage_date(lat, lon)
 
     svc = TripReportSchedulerService(settings=Settings())
     expected = svc._convert_trip_to_segments(trip, target_date)
@@ -248,8 +248,8 @@ def test_ac2_segment_selection_by_time():
     from services.trip_alert import TripAlertService
     from services.radar_service import RadarNowcastService
 
-    today = stage_date()
     lat_base, lon_base = 51.50, 0.00  # lon=0 → Europe/London, BST=UTC+1 in summer
+    today = stage_date(lat_base, lon_base)
 
     # --- Fall (a): aktives Segment ---
     # Seg 1: [now-2h, now-1h] → vorbei; Seg 2: [now-1h, now+1h] → aktiv.
@@ -394,7 +394,7 @@ def test_ac3_nowcast_called_at_segment_coordinates():
     _clean_user(uid)
     _ensure_real_user_dir(uid)
     try:
-        today = stage_date()
+        today = stage_date(WP0_LAT, WP0_LON)
 
         # Seg 1: [now-2h, now-30m] → vorbei; Seg 2: [now-30m, now+90m] → aktiv.
         # #1667 S1: der Helfer rechnet die Ortszeit selbst (der frühere manuelle
@@ -616,8 +616,8 @@ def test_ac6_cooldown_display_reflects_trip_setting():
     from services.trip_alert import TripAlertService
     from services.radar_service import RadarNowcastService
 
-    today = stage_date()
     lat, lon = 51.50, 0.00  # lon=0 → tz_for_coords returns e.g. Europe/London
+    today = stage_date(lat, lon)
     # #1667 S1: Ortszeit-Umrechnung und Tagesgrenzen-Klemmung im Helfer.
     arr0, arr1 = active_window_offsets(lat, lon, -60, 60)
 
@@ -717,14 +717,13 @@ def test_ac7_throttle_recording_unchanged():
     _clean_user(uid)
     _ensure_real_user_dir(uid)
     try:
-        today = stage_date()
-
         # Aktives Segment: [now-1h, now+1h]
         # Island (lat=64, lon=-22): UTC+0 ganzjährig (kein DST).
         # _save_trip_direct nötig: save_trip recomputes arrival_calculated via Naismith
         # und würde die Zeiten überschreiben.
         # #1667 S1: Zeiten aus dem wanduhr-robusten Helfer.
         lat, lon = 64.0, -22.0
+        today = stage_date(lat, lon)
         arr0, arr1 = active_window_offsets(lat, lon, -60, 60)
         wp0 = _make_waypoint("WP0", lat, lon, arr0)
         wp1 = _make_waypoint("WP1", lat + 0.05, lon + 0.05, arr1)
@@ -806,8 +805,8 @@ def test_ac8_mandantentrennung_isolated():
     _clean_user(uid_b)
     _ensure_real_user_dir(uid_b)
     try:
-        today = stage_date()
         lat, lon = 51.5, 0.0  # UTC-Zone
+        today = stage_date(lat, lon)
         # #1667 S1: Zeiten aus dem wanduhr-robusten Helfer.
         arr0, arr1 = active_window_offsets(lat, lon, -60, 60)
 

--- a/tests/tdd/test_issue_827_radar_throttle_recording.py
+++ b/tests/tdd/test_issue_827_radar_throttle_recording.py
@@ -41,12 +41,15 @@ def _make_trip(trip_id: str, send_email: bool, send_telegram: bool) -> Trip:
     # ueber Mitternacht zu rechnen — ab 22:00 UTC lief die +2h/+4h-Folge sonst
     # steigend ueber den Tageswechsel und das Segment landete in der
     # Vergangenheit.
-    arr0, arr1 = active_window_offsets(LAT, LON, 120, 240)
+    # #1697 AC-4: Segment muss JETZT aktiv sein (nicht erst in 2h beginnen),
+    # sonst greift der neue Horizont-Guard (NOWCAST_HORIZON_MIN=60) und
+    # unterdrueckt den Nowcast-Abruf, den dieser Test misst.
+    arr0, arr1 = active_window_offsets(LAT, LON, -60, 120)
     wp0 = Waypoint(id="WP0", name="Start", lat=LAT, lon=LON, elevation_m=500.0,
                    arrival_calculated=arr0)
     wp1 = Waypoint(id="WP1", name="End", lat=LAT + 0.1, lon=LON + 0.1, elevation_m=600.0,
                    arrival_calculated=arr1)
-    stage = Stage(id="S1", name="Tag 1", date=stage_date(), waypoints=[wp0, wp1])
+    stage = Stage(id="S1", name="Tag 1", date=stage_date(LAT, LON), waypoints=[wp0, wp1])
     trip = Trip(id=trip_id, name="827 Test", stages=[stage])
     trip.report_config = TripReportConfig(
         trip_id=trip_id,

--- a/tests/tdd/test_issue_883_acute_danger_override.py
+++ b/tests/tdd/test_issue_883_acute_danger_override.py
@@ -92,7 +92,7 @@ def _make_active_trip(trip_id: str, quiet_from: str | None = None, quiet_to: str
         id="WP1", name="Ziel", lat=LAT + 0.05, lon=LON + 0.05, elevation_m=200.0,
         arrival_calculated=arr1,
     )
-    stage = Stage(id="S1", name="Tag 1", date=stage_date(), waypoints=[wp0, wp1])
+    stage = Stage(id="S1", name="Tag 1", date=stage_date(LAT, LON), waypoints=[wp0, wp1])
     trip = Trip(id=trip_id, name=f"Test {trip_id}", stages=[stage])
     trip.alert_quiet_from = quiet_from
     trip.alert_quiet_to = quiet_to

--- a/tests/tdd/test_issue_995_scheduler_pause.py
+++ b/tests/tdd/test_issue_995_scheduler_pause.py
@@ -190,7 +190,7 @@ class TestAC9AlertDispatchUnaffected:
         data = {
             "id": trip_id, "name": "AC9 Trip",
             "stages": [{
-                "id": "S1", "name": "Tag 1", "date": stage_date().isoformat(),
+                "id": "S1", "name": "Tag 1", "date": stage_date(lat, lon).isoformat(),
                 "waypoints": [
                     {"id": "WP0", "name": "WP0", "lat": lat, "lon": lon, "elevation_m": 1000,
                      "arrival_calculated": arr1},

--- a/tests/tdd/test_radar_alert_follows_ortstag.py
+++ b/tests/tdd/test_radar_alert_follows_ortstag.py
@@ -1,0 +1,755 @@
+"""TDD RED — Issue #1697: Alarm-Pfad folgt dem Ortstag der Tour, nicht der
+Serveruhr (Kette A, ``TripAlertService.check_radar_alerts``).
+
+SPEC: docs/specs/modules/fix_1697_ortstag_statt_servertag.md (AC-1 … AC-5)
+
+RED-Grund heute (gemessen):
+- ``check_radar_alerts()`` bestimmt "welcher Tag ist heute" ueber
+  ``date_type.today()`` (Serveruhr) statt ueber die Ortszeit der Tour
+  (``services.trip_day.trip_local_today`` — Modul existiert noch nicht).
+  Weicht Ortsdatum und Serverdatum voneinander ab, findet
+  ``convert_trip_to_segments()`` keine Etappe -> leere Segmentliste ->
+  ``continue`` -> 0 Nowcast-Abrufe (AC-1/AC-3/AC-5-Symptom).
+- ``check_radar_alerts()`` hat KEINEN Horizont-Guard vor dem Nowcast-Abruf
+  (``NOWCAST_HORIZON_MIN`` kommt in ``trip_alert.py`` nicht vor) -> ein
+  Segment, das erst in > 60 Minuten beginnt, loest trotzdem einen Abruf aus
+  (AC-4-Symptom).
+
+AC-2 ist ein Bestandsschutz-Test (analog #818 AC-3/AC-5/AC-7 — "Guard-Tests,
+vor Implementierung bereits gruen"): ausserhalb der 22:00-00:00-UTC-Randzeit
+liefern alte und neue Formel fuer Korsika (UTC+2) dasselbe Ergebnis, der
+Test ist also schon heute gruen und bleibt es nach der Umstellung.
+
+Teilungsregel: Trip-Bau, Persistenz und die Nowcast-DI-Naht kommen aus dem
+BESTEHENDEN geteilten Helfer ``tests/helpers/nowcast_gate_fixtures.py``
+(``make_trip``/``trip_stage``/``save_trip``/``fresh_uid``/
+``CountingFrameSource``/``radar_service``/``reset_radar_cache``/
+``settings_email_only``) statt lokal nachgebaut zu werden — ``make_trip``
+wurde fuer #1697 additiv um Etappen-Datum/Koordinaten/Ankunftszeiten/eine
+zweite Etappe erweitert (Defaults bit-identisch zum bisherigen Verhalten,
+belegt per Testlauf der bestehenden Aufrufer, s. Commit-Historie). Nur der
+Briefing-Schnappschuss-Schreiber (``_write_briefing_snapshot``) ist neu und
+bleibt lokal — kein Pendant im geteilten Helfer.
+
+Testpolitik (CLAUDE.md "Test-Politik: Zwei Schichten"):
+- Kein Mock-Theater: kein ``Mock()``/``patch()``/``MagicMock``. Der
+  Nowcast-Abruf laeuft ueber die ECHTE DI-Naht
+  ``RadarNowcastService(frame_source=...)`` (Konstruktor-Parameter
+  ``TripAlertService(radar_service=...)``); ``CountingFrameSource``
+  protokolliert jeden Aufruf mit echten Koordinaten und liefert echte
+  ``RadarFrame``-Objekte (``wet_frames()``) — kein Live-Netz, kein
+  monkeypatch auf Klassenebene.
+- Wirkung ueber Koordinaten, nicht ueber einen Alarm-Zaehler (Nachweis-
+  Strategie der Spec): ein Zaehler haette eine Falsch-Ortung (falsches
+  Segment, richtiger Alarm) nie bemerkt.
+- 🔴 Radar-Cache ist Prozess-Singleton mit TTL 300 s — unter gestellter Uhr
+  laeuft er nie ab. Jeder Test, der ueber die DI-Naht Aufrufe zaehlt, ruft
+  deshalb ``reset_radar_cache()`` VOR dem Aufbau seiner eigenen
+  ``CountingFrameSource``, sonst misst ein zweiter Test an denselben
+  Koordinaten einen Cache-Treffer statt der Segmentwahl.
+- Trip-Persistenz per ``save_trip()`` (aus dem geteilten Helfer), NICHT
+  ``Trip(...).save()`` — ``save_trip()`` umgeht Naismith-Compute-on-Save
+  (#802), das die exakt gesetzten ``arrival_calculated``-Werte
+  ueberschreiben wuerde.
+- Uhr: ``freeze_time`` (freezegun). Isolation: ``tests/conftest.py::
+  _isolate_data_root`` (autouse, #1133) — keine manuelle Aufraeumung noetig.
+
+Ausfuehrung:
+    uv run pytest tests/tdd/test_radar_alert_follows_ortstag.py -v \
+        --disable-socket --allow-hosts=127.0.0.1
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import date as date_type
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from freezegun import freeze_time
+
+from services.trip_alert import TripAlertService
+from services.trip_segments import convert_trip_to_segments
+
+from tests.helpers.nowcast_gate_fixtures import (
+    CountingFrameSource,
+    fresh_uid,
+    make_trip,
+    radar_service,
+    reset_radar_cache,
+    save_trip,
+    settings_email_only,
+    trip_stage,
+)
+
+# Pacific/Auckland (UTC+12 im August, keine Sommerzeit dort im Winter) —
+# AC-1/AC-5: Ortsdatum weicht vom Serverdatum ab.
+AUCKLAND_LAT, AUCKLAND_LON = -36.8485, 174.7633
+# Europe/Paris (UTC+2 im Sommer) — AC-2/AC-3: die 22:00-00:00-UTC-Randzeit.
+CORSICA_LAT, CORSICA_LON = 42.20, 9.10
+# Atlantic/Reykjavik (UTC+0 ganzjaehrig) — AC-4: Horizont-Guard ohne
+# Zeitzonen-Rechnung, DI-Naht ueber exakte Minutenabstaende.
+REYKJAVIK_LAT, REYKJAVIK_LON = 64.1466, -21.9426
+# America/Los_Angeles (UTC-7 im August) — F002: NEGATIVER Versatz, das
+# Serverdatum laeuft dem Ortstag VORAUS (date.today() = Ortstag D + 1) —
+# genau die Richtung, in der die Ueberwachung etwas VERLIERT (Tour gilt
+# faelschlich als abgelaufen).
+LOS_ANGELES_LAT, LOS_ANGELES_LON = 34.0522, -118.2437
+
+
+def _write_briefing_snapshot(
+    user_id: str, trip_id: str, target_date: date_type, segment_id,
+    onset_hour_naive: datetime, precip_mm: float,
+) -> None:
+    """Minimaler Briefing-Snapshot mit EINER Regen-Stunde am Onset — Format
+    entspricht ``WeatherSnapshotService.save_dated()`` (naive UTC-Zeitstempel,
+    Muster ``tests/tdd/test_issue_818_radar_briefing_integration.py::
+    _write_snapshot``, hier mit explizitem ``target_date``-Parameter statt
+    ``date_type.today()`` — genau das ist der Streitpunkt von AC-5). Neu,
+    kein Pendant im geteilten Helfer (der kennt keine Briefing-Snapshots)."""
+    from app.loader import get_snapshots_dir
+
+    snapshots_dir = get_snapshots_dir(user_id)
+    snapshots_dir.mkdir(parents=True, exist_ok=True)
+    hourly = [
+        {
+            "ts": (onset_hour_naive + timedelta(hours=h)).strftime("%Y-%m-%dT%H:%M:%S"),
+            "precip_1h_mm": precip_mm if h == 0 else 0.0,
+        }
+        for h in range(-2, 3)
+    ]
+    segment_entry = {
+        "segment_id": segment_id,
+        "start_time": (onset_hour_naive - timedelta(hours=1)).isoformat(),
+        "end_time": (onset_hour_naive + timedelta(hours=2)).isoformat(),
+        "start_lat": 0.0, "start_lon": 0.0, "start_elevation_m": 0.0,
+        "start_distance_from_start_km": 0.0,
+        "end_lat": 0.0, "end_lon": 0.0, "end_elevation_m": 0.0,
+        "end_distance_from_start_km": 0.0,
+        "distance_km": 0.0, "ascent_m": 0.0, "descent_m": 0.0,
+        "duration_hours": 3.0,
+        "aggregated": {},
+        "hourly": hourly,
+    }
+    snapshot = {
+        "trip_id": trip_id,
+        "target_date": target_date.isoformat(),
+        "snapshot_at": datetime.now(timezone.utc).isoformat(),
+        "provider": "openmeteo",
+        "segments": [segment_entry],
+    }
+    path = snapshots_dir / f"{trip_id}_{target_date.isoformat()}.json"
+    path.write_text(json.dumps(snapshot, indent=2))
+
+
+def _aktives_segment(segments, now_utc):
+    """Spiegelt die Segment-Auswahl aus ``check_radar_alerts()`` 1:1 (aktives
+    ODER naechstes Segment, #822) — als lokal hinterlegte Referenz fuer
+    AC-2, unabhaengig vom Pruefling aufgebaut."""
+    for seg in segments:
+        if seg.start_time <= now_utc <= seg.end_time:
+            return seg
+    if segments and now_utc < segments[0].start_time:
+        return segments[0]
+    return None
+
+
+# ══════════════════════════════════ AC-1 ══════════════════════════════════
+
+
+def test_ac1_auckland_koordinatennachweis():
+    """AC-1: Ortsdatum D (Auckland) weicht vom Serverdatum SD ab — der
+    Nowcast-Abruf muss an den Koordinaten der D-Etappe erfolgen.
+
+    RED-Symptom heute: ``today = date.today()`` = SD findet die D-Etappe
+    nicht, ``convert_trip_to_segments()`` liefert ``[]``, der Trip wird per
+    ``continue`` uebersprungen — 0 Aufrufe statt der D-Koordinaten.
+    """
+    from zoneinfo import ZoneInfo
+
+    reset_radar_cache()
+    frame_source = CountingFrameSource(onset_minutes=10)
+
+    uid = fresh_uid("ac1")
+    trip_id = f"trip-ac1-{uuid.uuid4().hex[:8]}"
+    with freeze_time("2026-08-10T13:00:00+00:00"):
+        now_utc = datetime.now(timezone.utc)
+        sd = date_type.today()
+        d_ort = now_utc.astimezone(ZoneInfo("Pacific/Auckland")).date()
+        assert d_ort != sd, "Testvoraussetzung: Ortsdatum muss vom Serverdatum abweichen"
+
+        trip = make_trip(trip_id, stage_date=d_ort, lat=AUCKLAND_LAT, lon=AUCKLAND_LON)
+        save_trip(trip, uid)
+
+        svc = TripAlertService(
+            settings=settings_email_only(), user_id=uid, throttle_hours=2,
+            radar_service=radar_service(frame_source),
+        )
+        svc.check_radar_alerts()
+
+    assert frame_source.calls, (
+        f"AC-1: Am Ortsdatum {d_ort} (Serverdatum {sd}) haette der Nowcast-"
+        f"Abruf an den Koordinaten der D-Etappe erfolgen muessen — "
+        f"calls={frame_source.calls!r}. RED: `today = date.today()` findet "
+        "die D-Etappe nicht, der Trip wird uebersprungen."
+    )
+    lat, lon = frame_source.calls[0]
+    assert lat == pytest.approx(AUCKLAND_LAT) and lon == pytest.approx(AUCKLAND_LON), (
+        f"AC-1: Abruf-Koordinaten {frame_source.calls[0]!r} passen nicht zur "
+        f"D-Etappe ({AUCKLAND_LAT}, {AUCKLAND_LON})"
+    )
+
+
+# ══════════════════════════════════ AC-2 ══════════════════════════════════
+
+
+@pytest.mark.parametrize("hour_utc", list(range(0, 22)))
+def test_ac2_bestandsschutz_korsika_ausserhalb_der_randzeit(hour_utc):
+    """AC-2 (Bestandsschutz): Ausserhalb 22:00-00:00 UTC muss das gewaehlte
+    Segment eines Korsika-Trips identisch zur ALTEN ``date.today()``-Formel
+    bleiben — Korsika (UTC+2) wechselt den Ortstag nur in dieser Randzeit.
+
+    Dieser Test ist — wie AC-3/AC-5/AC-7 in #818 — bereits VOR der
+    Implementierung gruen (Guard-Test): fuer diese 22 Stichproben stimmen
+    alte und neue Formel ueberein.
+
+    Bewusst die GANZTAGS-Etappe (``make_trip``-Default 00:00-23:59), nicht
+    die realistische 08:00-16:00-Etappe aus AC-3: nur so ist bei JEDER der
+    22 Stichproben (auch morgens vor 08:00 und abends nach 16:00) ueberhaupt
+    ein Segment aktiv oder "als naechstes" waehlbar — die realistische
+    Etappe waere z. B. um 20:00 UTC schon laengst "alle Segmente vorbei" und
+    der Bestandsschutz-Vergleich liefe ins Leere (``erwartet is None``).
+    """
+    reset_radar_cache()
+    frame_source = CountingFrameSource(onset_minutes=10)
+
+    uid = fresh_uid(f"ac2-{hour_utc:02d}")
+    trip_id = f"trip-ac2-{uuid.uuid4().hex[:8]}"
+    zeitpunkt = f"2026-08-10T{hour_utc:02d}:00:00+00:00"
+    with freeze_time(zeitpunkt):
+        now_utc = datetime.now(timezone.utc)
+        alte_formel_heute = date_type.today()
+
+        trip = make_trip(trip_id, stage_date=alte_formel_heute, lat=CORSICA_LAT, lon=CORSICA_LON)
+        save_trip(trip, uid)
+
+        referenz_segmente = convert_trip_to_segments(trip, alte_formel_heute)
+        erwartet = _aktives_segment(referenz_segmente, now_utc)
+        assert erwartet is not None, (
+            f"Testvoraussetzung bei {zeitpunkt}: die alte Formel muss ein "
+            "aktives Segment liefern"
+        )
+
+        svc = TripAlertService(
+            settings=settings_email_only(), user_id=uid, throttle_hours=2,
+            radar_service=radar_service(frame_source),
+        )
+        svc.check_radar_alerts()
+
+    assert frame_source.calls, (
+        f"AC-2 bei {zeitpunkt}: kein Nowcast-Abruf erfolgt, erwartet war ein "
+        f"aktives Segment an ({erwartet.start_point.lat}, {erwartet.start_point.lon})"
+    )
+    lat, lon = frame_source.calls[0]
+    assert lat == pytest.approx(erwartet.start_point.lat) and lon == pytest.approx(erwartet.start_point.lon), (
+        f"AC-2 bei {zeitpunkt}: Abruf-Koordinaten {frame_source.calls[0]!r} "
+        f"weichen von der alten Formel ({erwartet.start_point.lat}, "
+        f"{erwartet.start_point.lon}) ab — Bestandsschutz verletzt"
+    )
+
+
+# ══════════════════════════════════ AC-3 ══════════════════════════════════
+
+
+def test_ac3_das_ehrliche_fenster_waehlt_die_folgetags_etappe(caplog):
+    """AC-3 (Spec-Wortlaut): 22:30 UTC = 00:30 Ortszeit des FOLGETAGS auf
+    Korsika. Die Etappe des Folgetags muss gewaehlt werden — fachlich
+    gewollt (#822 "aktives ODER naechstes Segment"), kein Fehlerbild.
+
+    REALISTISCHE Etappe (Start 08:00, Ankunft 16:00 Ortszeit) statt der
+    Ganztags-Fixture aus AC-2: mit 00:00-23:59 wuerde der #1584-Randfall-
+    Guard das Ziel-Segment des AKTUELLEN Tages bis 22:59 UTC verlaengern
+    (Ankunft 23:59 Ortszeit liegt nach dem Tagesfenster-Ende -> minimales
+    Fenster "Ankunft + 1 h") — um 22:30 UTC waere dann noch etwas vom
+    HEUTIGEN Tag aktiv und der Test praeft die falsche Verzweigung (nicht
+    "continue", sondern eine andere Etappenwahl). Nachgemessen: mit
+    08:00-16:00 endet auch das Ziel-Segment des heutigen Tages um 17:00 UTC
+    (Tagesfenster-Ende 19:00 Ortszeit = 17:00 UTC liegt NACH der Ankunft,
+    der Randfall-Guard greift nicht) — um 22:30 UTC ist die heutige Etappe
+    dann wirklich vollstaendig vorbei, genau wie das AC woertlich beschreibt.
+
+    🔴 GREEN-Phase-Korrektur (#1697, PO-Feedback nach erster GREEN-Runde):
+    die urspruengliche RED-Fassung prüfte den Etappenwechsel ueber
+    ``frame_source.calls`` (ein TATSAECHLICHER Nowcast-Abruf). Das
+    kollidiert nachweislich mit AC-4 (Horizont-Guard, aus DERSELBEN Spec):
+    das gewaehlte Folgetags-Segment beginnt hier um 06:00 UTC — von
+    22:30 UTC aus 7,5 h in der Zukunft, weit ausserhalb
+    ``NOWCAST_HORIZON_MIN`` (60 min). Genau dieses Muster (samt der exakten
+    "7,5 Stunden") nennt die Spec selbst als Beleg FUER AC-4 (Kontext-
+    Dokument, Abschnitt "Nachgemessen und korrigiert": "...ein Segment
+    abgerufen, das erst in 7,5 Stunden beginnt — fachlich sinnlos"). Ein
+    Nowcast-Abruf DARF hier also nicht erfolgen; die urspruengliche
+    Zusicherung war falsch, nicht bloss unguenstig formuliert.
+
+    Positiver Beleg statt Negativ-Check: eine leere Segmentliste allein zu
+    verneinen ("alle Segmente vorbei" nicht im Log) beweist nicht, DASS die
+    Folgetags-Etappe gewaehlt wurde — nur, dass irgendein Segment gefunden
+    wurde. Der Horizont-Guard (``check_radar_alerts()``,
+    ``src/services/trip_alert.py``) nennt seit #1697 im Debug-Log den
+    Startzeitpunkt des uebersprungenen Segments (#1405-Linie: was
+    uebersprungen wird, wird benannt). Dieser Test extrahiert ihn aus dem
+    ECHTEN Log von ``check_radar_alerts()`` und vergleicht ihn gegen den
+    Start der Folgetags-Etappe — die Zusicherung sitzt damit an der Stelle,
+    an der die Auswahl WIRKT (der SUT-Aufruf selbst), nicht an einer
+    Nachrechnung daneben. Die separate Referenzrechnung
+    (``trip_local_today`` + ``convert_trip_to_segments``) bleibt reine
+    Testvoraussetzung (zeigt, was die Fixture ueberhaupt hergibt) und traegt
+    keine Zusicherung ueber das Verhalten von ``check_radar_alerts()`` mehr.
+
+    RED heute: ``today = date.today()`` bleibt auf dem AKTUELLEN Server-Tag;
+    dessen Segmente sind um 22:30 UTC alle vorbei -> ``continue``
+    ("alle Segmente vorbei" im Log), statt die Folgetags-Etappe zu waehlen
+    (kein Log-Eintrag mit dem Start der Folgetags-Etappe).
+    """
+    import logging
+    import re
+
+    from services.trip_day import trip_local_today
+    from services.trip_segments import convert_trip_to_segments
+
+    reset_radar_cache()
+    frame_source = CountingFrameSource(onset_minutes=10)
+
+    uid = fresh_uid("ac3")
+    trip_id = f"trip-ac3-{uuid.uuid4().hex[:8]}"
+    with freeze_time("2026-08-10T22:30:00+00:00"):
+        heute = date_type.today()
+        folgetag = heute + timedelta(days=1)
+
+        trip = make_trip(
+            trip_id, stage_date=heute, lat=CORSICA_LAT, lon=CORSICA_LON,
+            arrival_start="08:00", arrival_end="16:00",
+            extra_stages=[
+                trip_stage(
+                    "S2", folgetag, CORSICA_LAT + 0.5, CORSICA_LON + 0.5,
+                    arrival_start="08:00", arrival_end="16:00", wp_prefix="S2WP",
+                ),
+            ],
+        )
+        save_trip(trip, uid)
+
+        # Nur TESTVORAUSSETZUNG: zeigt, was die Fixture hergibt (dieselben
+        # Bausteine wie check_radar_alerts() intern, aber separat
+        # aufgerufen) — trägt selbst KEINE Zusicherung über das Verhalten
+        # des SUT (s. Docstring "Positiver Beleg statt Negativ-Check").
+        now_utc = datetime.now(timezone.utc)
+        referenz_tag = trip_local_today(trip, now_utc)
+        assert referenz_tag == folgetag, (
+            f"Testvoraussetzung: trip_local_today() haette {folgetag} "
+            f"liefern muessen, war {referenz_tag}"
+        )
+        referenz_segmente = convert_trip_to_segments(trip, referenz_tag)
+        assert referenz_segmente, "Testvoraussetzung: Folgetags-Etappe muss Segmente liefern"
+        assert referenz_segmente[0].start_point.lat == pytest.approx(CORSICA_LAT + 0.5), (
+            "Testvoraussetzung: erstes Segment der Folgetags-Etappe muss an "
+            "den S2-Koordinaten liegen"
+        )
+        erwarteter_start = referenz_segmente[0].start_time
+
+        svc = TripAlertService(
+            settings=settings_email_only(), user_id=uid, throttle_hours=2,
+            radar_service=radar_service(frame_source),
+        )
+        with caplog.at_level(logging.DEBUG, logger="trip_alert"):
+            svc.check_radar_alerts()
+
+    # Positiver Beleg (am SUT-Aufruf selbst, nicht an der Referenz daneben):
+    # der Horizont-Guard-Log nennt den Start des uebersprungenen Segments —
+    # der muss der Start der FOLGETAGS-Etappe sein, nicht "irgendein"
+    # Segment und nicht die Abwesenheit von "alle Segmente vorbei".
+    treffer = re.search(r"Start=(\S+)\)", caplog.text)
+    assert treffer, (
+        "AC-3: der Horizont-Guard-Log haette den Start des uebersprungenen "
+        "Segments nennen muessen (kein Treffer fuer 'Start=...'). Entweder "
+        "wurde ueberhaupt kein Segment gewaehlt (RED: `date.today()` findet "
+        f"die Folgetags-Etappe nicht) oder der Log fehlt.\nLog:\n{caplog.text}"
+    )
+    geloggter_start = datetime.fromisoformat(treffer.group(1))
+    assert geloggter_start == erwarteter_start, (
+        f"AC-3: der Horizont-Guard uebersprang ein Segment mit Start "
+        f"{geloggter_start.isoformat()}, erwartet war der Start der "
+        f"Folgetags-Etappe {erwarteter_start.isoformat()} — vermutlich wurde "
+        f"noch die Etappe von {heute} gewaehlt oder gar keine."
+    )
+    # AC-4 (Horizont-Guard) unterdrueckt hier zu Recht den tatsaechlichen
+    # Nowcast-Abruf — das Segment beginnt 7,5 h in der Zukunft, weit
+    # ausserhalb NOWCAST_HORIZON_MIN. Das ist AC-4s Aufgabe, kein AC-3-Fund.
+    assert not frame_source.calls, (
+        "AC-3 (Kopplung zu AC-4): das Folgetags-Segment liegt weit ausserhalb "
+        "des Nowcast-Horizonts — ein tatsaechlicher Abruf waere eine "
+        f"AC-4-Regression. calls={frame_source.calls!r}"
+    )
+
+
+# ══════════════════════════════════ AC-4 ══════════════════════════════════
+
+
+def test_ac4_horizont_guard_fern_kein_abruf_nah_ein_abruf():
+    """AC-4: Segment > ``NOWCAST_HORIZON_MIN`` (60 min) entfernt -> KEIN
+    Nowcast-Abruf; Segment innerhalb -> genau EIN Abruf (Gegenprobe im
+    selben Test — der Nah-Fall allein waere nicht diskriminierend, weil
+    er auch ohne jeden Guard schon einen Abruf ausloest).
+
+    RED heute: ``check_radar_alerts()`` hat KEINEN Horizont-Guard — der
+    Fern-Fall ruft ``get_nowcast()`` trotzdem auf.
+    """
+    from services.radar_service import NOWCAST_HORIZON_MIN
+
+    assert NOWCAST_HORIZON_MIN == 60, (
+        f"Testvoraussetzung: NOWCAST_HORIZON_MIN muss 60 sein, war {NOWCAST_HORIZON_MIN!r}"
+    )
+
+    with freeze_time("2026-08-10T10:00:00+00:00"):
+        heute = date_type.today()
+
+        # Fern: Segment beginnt in 90 Minuten (> 60) -> kein Abruf.
+        reset_radar_cache()
+        frame_source_fern = CountingFrameSource(onset_minutes=10)
+        uid_fern = fresh_uid("ac4-fern")
+        trip_fern_id = f"trip-ac4-fern-{uuid.uuid4().hex[:8]}"
+        trip_fern = make_trip(
+            trip_fern_id, stage_date=heute, lat=REYKJAVIK_LAT, lon=REYKJAVIK_LON,
+            arrival_start="11:30", arrival_end="15:00",
+        )
+        save_trip(trip_fern, uid_fern)
+        TripAlertService(
+            settings=settings_email_only(), user_id=uid_fern, throttle_hours=2,
+            radar_service=radar_service(frame_source_fern),
+        ).check_radar_alerts()
+
+        assert frame_source_fern.calls == [], (
+            "AC-4: Segment beginnt erst in 90 Minuten (> NOWCAST_HORIZON_MIN=60) "
+            f"— get_nowcast() darf NICHT aufgerufen werden, war "
+            f"{frame_source_fern.calls!r}. RED: check_radar_alerts() hat noch "
+            "keinen Horizont-Guard."
+        )
+
+        # Nah (Gegenprobe): Segment beginnt in 30 Minuten (<= 60) -> Abruf MUSS erfolgen.
+        reset_radar_cache()
+        frame_source_nah = CountingFrameSource(onset_minutes=10)
+        uid_nah = fresh_uid("ac4-nah")
+        trip_nah_id = f"trip-ac4-nah-{uuid.uuid4().hex[:8]}"
+        trip_nah = make_trip(
+            trip_nah_id, stage_date=heute, lat=REYKJAVIK_LAT, lon=REYKJAVIK_LON,
+            arrival_start="10:30", arrival_end="15:00",
+        )
+        save_trip(trip_nah, uid_nah)
+        TripAlertService(
+            settings=settings_email_only(), user_id=uid_nah, throttle_hours=2,
+            radar_service=radar_service(frame_source_nah),
+        ).check_radar_alerts()
+
+        assert len(frame_source_nah.calls) >= 1, (
+            "AC-4 (Gegenprobe): Segment beginnt in 30 Minuten (<= Horizont) — "
+            f"get_nowcast() MUSS aufgerufen werden, war {frame_source_nah.calls!r}."
+        )
+
+
+# ══════════════════════════════════ AC-5 ══════════════════════════════════
+
+
+def test_ac5_segmentwahl_und_schnappschuss_lesen_denselben_ortstag():
+    """AC-5: Ortstag D (Auckland) weicht vom Serverdatum SD ab. Ein
+    Briefing-Schnappschuss NUR unter D unterdrueckt den Alarm (Regen war
+    angekuendigt); derselbe Schnappschuss NUR unter SD wird nicht gefunden,
+    der Alarm feuert. Beweist, dass Segmentwahl UND Schnappschuss-Lesung
+    denselben ``today`` benutzen (kein halbierter Umbau).
+
+    RED heute in BEIDEN Haelften: ``today = date.today()`` = SD findet die
+    D-Etappe gar nicht -> 0 Aufrufe, egal wo der Schnappschuss liegt. Die
+    Unterdrueckungs-Erwartung (count == 0) ist damit heute schon zufaellig
+    erfuellt (wie die Bestandsschutz-Haelfte in AC-2); die Gegenprobe
+    (count >= 1) ist es NICHT und macht diesen Test rot.
+    """
+    from zoneinfo import ZoneInfo
+
+    def _run(*, snapshot_under_ortsdatum: bool) -> int:
+        reset_radar_cache()
+        frame_source = CountingFrameSource(onset_minutes=10)
+        mails: list = []
+
+        uid = fresh_uid("ac5-supp" if snapshot_under_ortsdatum else "ac5-gegen")
+        trip_id = f"trip-ac5-{uuid.uuid4().hex[:8]}"
+        with freeze_time("2026-08-10T13:00:00+00:00"):
+            now_utc = datetime.now(timezone.utc)
+            sd = date_type.today()
+            d_ort = now_utc.astimezone(ZoneInfo("Pacific/Auckland")).date()
+            assert d_ort != sd, "Testvoraussetzung: Ortsdatum muss vom Serverdatum abweichen"
+
+            trip = make_trip(trip_id, stage_date=d_ort, lat=AUCKLAND_LAT, lon=AUCKLAND_LON)
+            save_trip(trip, uid)
+
+            onset_hour_naive = (now_utc + timedelta(minutes=10)).replace(
+                minute=0, second=0, microsecond=0, tzinfo=None,
+            )
+            snapshot_datum = d_ort if snapshot_under_ortsdatum else sd
+            _write_briefing_snapshot(
+                uid, trip_id, snapshot_datum, segment_id=1,
+                onset_hour_naive=onset_hour_naive, precip_mm=1.2,
+            )
+
+            svc = TripAlertService(
+                settings=settings_email_only(), user_id=uid, throttle_hours=2,
+                radar_service=radar_service(frame_source),
+                mail_sink=lambda subject, body: mails.append((subject, body)),
+            )
+            count = svc.check_radar_alerts()
+        return count
+
+    unterdrueckt = _run(snapshot_under_ortsdatum=True)
+    assert unterdrueckt == 0, (
+        "AC-5: Schnappschuss liegt unter dem ORTSTAG D mit angekuendigtem "
+        f"Regen (1.2 mm) — der Alarm haette unterdrueckt werden muessen, "
+        f"war count={unterdrueckt}"
+    )
+
+    feuert = _run(snapshot_under_ortsdatum=False)
+    assert feuert >= 1, (
+        "AC-5 (Gegenprobe): derselbe Schnappschuss liegt NUR unter dem "
+        "SERVERDATUM SD — er darf dort NICHT gefunden werden (Segmentwahl "
+        "und Schnappschuss-Lesung muessen denselben Ortstag D verwenden), "
+        f"der Alarm haette feuern muessen, war count={feuert}. "
+        "RED: heute wird ueberhaupt keine Etappe gefunden (Ortsdatum D "
+        "fehlt der alten `date.today()`-Formel), der Alarm feuert nicht."
+    )
+
+
+# ═══════════════════ Fix-Loop F001 (Adversary, CRITICAL) ═══════════════════
+#
+# Der Adversary hat ``_get_cached_weather()`` (``trip_alert.py:584``, der
+# DELTA-Alarm-Pfad ueber ``check_all_trips() -> _get_cached_weather() ->
+# load_dated()``) unbewacht gefunden: eine Mutation, die genau diese Zeile
+# von ``today = trip_local_today(trip, now_utc or datetime.now(timezone.utc))``
+# auf ``today = date.today()`` zurueckdreht, liess ALLE 218 bis dahin
+# gelaufenen Tests gruen (u.a. alle 26 in dieser Datei, `test_alert_anchor_
+# day_guard.py`, `test_issue_823_snapshot_date_guard.py`,
+# `test_issue_1088_official_alert_triggers.py`, `test_success_status_guard.py`).
+# Grund: AC-5 hier oben sichert ausschliesslich ``check_radar_alerts()`` ab,
+# das SEINE EIGENE ``today``-Variable benutzt (``trip_alert.py:901``) — eine
+# von ZWEI unabhaengigen Aufrufstellen von ``trip_local_today()`` in Kette A.
+# Die andere (der Delta-Pfad) hatte keinen Test.
+#
+# Wirkort ist deshalb bewusst ``_get_cached_weather()`` SELBST — nicht
+# ``check_all_trips()`` mit echtem Fresh-Fetch (der braeuchte Live-Netz) —,
+# analog zum bestehenden Muster ``test_alert_anchor_day_guard.py::
+# cached_weather()``, das exakt dieselbe Methode fuer #1661 direkt aufruft.
+# Diese Wahl beruehrt NUR den DATIERTEN Zweig (``dated = svc.load_dated(...)``
+# wird sofort zurueckgegeben, wenn nicht ``None``) — der undatierte
+# Rueckfall-Zweig mit ``anchor_date == today`` (#1661, ``trip_alert.py:607``)
+# wird von diesem Test NICHT beruehrt: es existiert keine undatierte Datei,
+# der Fund-Fall greift bereits bei ``load_dated()``. Keine Kopplungs-
+# Ueberraschung zu #1661 aufgetreten.
+
+
+def _wetter_mit_boe(boe_kmh: float, segment_id: str = "1"):
+    """Minimaler Δ-Anker mit erkennbarem, sonst voellig beliebigem
+    Boeenwert — Muster ``test_alert_anchor_day_guard.py::_wetter``. Der
+    Delta-Pfad (``_get_cached_weather``) braucht nur eine ladbare
+    ``SegmentWeatherData``-Liste, keine zur Trip-Etappe passende Segment-
+    Geometrie (die Kopplung Segmentwahl<->Schnappschuss ist AC-5s Aufgabe,
+    nicht diese hier)."""
+    from app.models import (
+        ForecastDataPoint,
+        ForecastMeta,
+        GPXPoint,
+        NormalizedTimeseries,
+        Provider,
+        SegmentWeatherData,
+        SegmentWeatherSummary,
+        TripSegment,
+    )
+
+    stunde = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+    punkte = [
+        ForecastDataPoint(
+            ts=stunde + timedelta(hours=h), t2m_c=12.0 + h,
+            wind10m_kmh=boe_kmh / 2, gust_kmh=boe_kmh, precip_1h_mm=0.0,
+        )
+        for h in range(4)
+    ]
+    segment = TripSegment(
+        segment_id=segment_id,
+        start_point=GPXPoint(lat=AUCKLAND_LAT, lon=AUCKLAND_LON, elevation_m=500.0,
+                             distance_from_start_km=0.0),
+        end_point=GPXPoint(lat=AUCKLAND_LAT + 0.1, lon=AUCKLAND_LON + 0.1,
+                           elevation_m=600.0, distance_from_start_km=6.0),
+        start_time=stunde, end_time=stunde + timedelta(hours=4),
+        duration_hours=4.0, distance_km=6.0, ascent_m=100.0, descent_m=0.0,
+    )
+    return SegmentWeatherData(
+        segment=segment,
+        timeseries=NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="test", grid_res_km=1.0),
+            data=punkte,
+        ),
+        aggregated=SegmentWeatherSummary(
+            gust_max_kmh=boe_kmh, wind_max_kmh=boe_kmh / 2,
+            temp_max_c=15.0, temp_min_c=8.0, precip_sum_mm=0.0,
+        ),
+        fetched_at=datetime.now(timezone.utc),
+        provider="openmeteo",
+    )
+
+
+def test_f001_delta_anker_wird_unter_ortstag_gesucht_nicht_servertag():
+    """F001-Fix: ``_get_cached_weather()`` (Delta-Alarm-Pfad) sucht den
+    DATIERTEN Anker unter dem ORTSTAG D der Tour, nicht dem Serverdatum SD.
+
+    Aufbau wie AC-1/AC-5 (Auckland, Ortsdatum D weicht vom Serverdatum SD
+    ab, ``freeze_time("2026-08-10T13:00:00+00:00")``): Schnappschuss NUR
+    unter D abgelegt -> muss gefunden werden. Gegenprobe im selben Test:
+    derselbe Schnappschuss NUR unter SD -> darf NICHT gefunden werden
+    (genau das waere das Verhalten der Mutation ``today = date.today()``).
+    """
+    from zoneinfo import ZoneInfo
+
+    from services.weather_snapshot import WeatherSnapshotService
+
+    def _pruefen(*, snapshot_unter_ortstag: bool):
+        uid = fresh_uid("f001-anker" if snapshot_unter_ortstag else "f001-gegen")
+        trip_id = f"trip-f001-{uuid.uuid4().hex[:8]}"
+        with freeze_time("2026-08-10T13:00:00+00:00"):
+            now_utc = datetime.now(timezone.utc)
+            sd = date_type.today()
+            d_ort = now_utc.astimezone(ZoneInfo("Pacific/Auckland")).date()
+            assert d_ort != sd, "Testvoraussetzung: Ortsdatum muss vom Serverdatum abweichen"
+
+            trip = make_trip(trip_id, stage_date=d_ort, lat=AUCKLAND_LAT, lon=AUCKLAND_LON)
+            save_trip(trip, uid)
+
+            snapshot_datum = d_ort if snapshot_unter_ortstag else sd
+            WeatherSnapshotService(uid).save_dated(
+                trip_id, snapshot_datum, [_wetter_mit_boe(200.0)],
+            )
+
+            svc = TripAlertService(
+                settings=settings_email_only(), user_id=uid, throttle_hours=2,
+            )
+            ergebnis = svc._get_cached_weather(
+                trip, tagesgleicher_anker_noetig=True, now_utc=now_utc,
+            )
+        return ergebnis
+
+    gefunden = _pruefen(snapshot_unter_ortstag=True)
+    assert gefunden, (
+        "F001: Schnappschuss liegt unter dem ORTSTAG D — "
+        "_get_cached_weather() haette ihn finden muessen. RED bei Mutation "
+        "`today = date.today()`: der Anker wird unter dem SERVERDATUM SD "
+        "gesucht und nicht gefunden."
+    )
+    assert gefunden[0].aggregated.gust_max_kmh == pytest.approx(200.0), (
+        f"F001: gefundener Anker traegt den falschen Boeenwert: "
+        f"{gefunden[0].aggregated.gust_max_kmh!r}"
+    )
+
+    nicht_gefunden = _pruefen(snapshot_unter_ortstag=False)
+    assert nicht_gefunden is None, (
+        "F001 (Gegenprobe): derselbe Schnappschuss liegt NUR unter dem "
+        "SERVERDATUM SD — er darf unter dem korrekt aufgeloesten Ortstag D "
+        f"NICHT gefunden werden. Zurueckgekommen: {nicht_gefunden!r}. Das "
+        "waere genau das Verhalten der Mutation `today = date.today()`."
+    )
+
+
+# ═══════════════════ Fix-Loop F002 (Adversary, HIGH) ═══════════════════
+#
+# Der Adversary hat ``check_all_trips()`` (``trip_alert.py:404`` — eigene
+# ``today``-Zuweisung je Trip; einziger Verbraucher ``:447`` der Ablauf-
+# Filter ``trip.end_date < today``) unbewacht gefunden: die Mutation
+# ``today = trip_local_today(trip, now_utc)`` -> ``today = date.today()``
+# an DIESER Stelle liess den gesamten bisherigen #1697-Bestand (266 Tests,
+# inkl. F001) gruen — F001 sichert nur ``_get_cached_weather()``s EIGENE
+# ``today``-Berechnung ab (``trip_alert.py:584``), nicht die von
+# ``check_all_trips()`` unabhaengig berechnete.
+#
+# Hauptfall bewusst NEGATIVER Versatz (Los Angeles, UTC-7): das ist die
+# gefaehrliche Richtung — das Serverdatum laeuft dem Ortstag VORAUS
+# (``date.today()`` = Ortstag D + 1), die Tour gilt an ihrem LETZTEN
+# Ortstag D deshalb faelschlich schon als abgelaufen und wird nie wieder
+# geprueft (Original-Fehlerbild).
+#
+# Wirkort: der positive Beleg kommt NICHT aus einem vollen Alarm-Versand
+# (bräuchte Live-Fresh-Fetch/amtliche Quellen, kein Netz im Testlauf) —
+# sondern aus dem bestehenden Produktions-Signal
+# ``_report_missing_anchor()``: ein "laufender" Trip (``start_date <= today
+# <= end_date``) OHNE jeden Schnappschuss protokolliert eine ECHTE WARNUNG
+# mit Trip-Kennung (``trip_alert.py:662-666``). Diese WARNUNG erscheint nur,
+# wenn der Trip den Ablauf-Filter ueberhaupt passiert — sie ist damit ein
+# direktes Signal DAFUER, dass ``check_all_trips()`` den Trip an diesem Tag
+# noch prueft, nicht dafuer uebersprungen zu haben.
+
+
+def test_f002_ablauf_filter_prueft_den_letzten_ortstag_noch(caplog):
+    """F002-Fix: ``check_all_trips()`` filtert abgelaufene Touren ueber den
+    ORTSTAG der Tour, nicht das Serverdatum.
+
+    Hauptfall: Trip mit ``end_date == D`` (Ortstag, Los Angeles) unter einer
+    gestellten Uhr, zu der ``date.today()`` bereits ``D+1`` waere -> der
+    Trip MUSS an D noch geprueft werden (WARNUNG "obwohl die Tour laeuft"
+    erscheint, statt eines stillen Ablauf-Skips).
+
+    Gegenprobe im selben Test: ein Trip, dessen ``end_date`` D-1 ist (nach
+    Ortstag TATSAECHLICH abgelaufen), erzeugt KEINE solche WARNUNG — sonst
+    prueft der Test nur "irgendetwas passiert", nicht den Filter selbst.
+
+    RED bei Mutation ``today = date.today()`` an ``trip_alert.py:404``: SD
+    (Serverdatum) = D+1, der Hauptfall-Trip mit ``end_date=D`` faellt durch
+    ``trip.end_date < today`` (``D < D+1``) und wird VOR
+    ``_get_cached_weather()`` per ``continue`` uebersprungen — keine
+    WARNUNG.
+    """
+    import logging
+    from zoneinfo import ZoneInfo
+
+    def _lauf(*, end_date_ist_heute: bool):
+        uid = fresh_uid("f002-heute" if end_date_ist_heute else "f002-abgelaufen")
+        trip_id = f"trip-f002-{uuid.uuid4().hex[:8]}"
+        with freeze_time("2026-08-11T05:00:00+00:00"):
+            now_utc = datetime.now(timezone.utc)
+            sd = date_type.today()
+            d_ort = now_utc.astimezone(ZoneInfo("America/Los_Angeles")).date()
+            assert d_ort == sd - timedelta(days=1), (
+                "Testvoraussetzung: Serverdatum muss dem LA-Ortstag genau "
+                "einen Tag vorauslaufen"
+            )
+
+            stage_datum = d_ort if end_date_ist_heute else d_ort - timedelta(days=1)
+            trip = make_trip(
+                trip_id, stage_date=stage_datum,
+                lat=LOS_ANGELES_LAT, lon=LOS_ANGELES_LON,
+            )
+            assert trip.end_date == stage_datum, (
+                "Testvoraussetzung: end_date muss dem einzigen Etappentag "
+                "entsprechen"
+            )
+            save_trip(trip, uid)
+
+            svc = TripAlertService(settings=settings_email_only(), user_id=uid)
+            with caplog.at_level(logging.DEBUG, logger="trip_alert"):
+                svc.check_all_trips()
+        return caplog.text
+
+    log_heute = _lauf(end_date_ist_heute=True)
+    assert "obwohl die Tour laeuft" in log_heute, (
+        "F002: Trip mit end_date == Ortstag D haette den Ablauf-Filter "
+        "passieren muessen (WARNUNG 'obwohl die Tour laeuft' erwartet). "
+        f"Log:\n{log_heute}"
+    )
+    caplog.clear()
+
+    log_abgelaufen = _lauf(end_date_ist_heute=False)
+    assert "obwohl die Tour laeuft" not in log_abgelaufen, (
+        "F002 (Gegenprobe): ein tatsaechlich abgelaufener Trip (end_date == "
+        "D-1) darf NICHT als 'laufend' behandelt werden — sonst ist der "
+        f"Ablauf-Filter selbst wirkungslos. Log:\n{log_abgelaufen}"
+    )

--- a/tests/unit/test_arrival_window_fixtures.py
+++ b/tests/unit/test_arrival_window_fixtures.py
@@ -233,7 +233,7 @@ def _trip_aus_helfer(lat: float, lon: float, versaetze: tuple[int, ...]) -> Trip
                  lon=lon + i * 0.05, elevation_m=1000.0, arrival_calculated=z)
         for i, z in enumerate(zeiten)
     ]
-    stage = Stage(id="S1", name="Tag 1", date=stage_date(), waypoints=waypoints)
+    stage = Stage(id="S1", name="Tag 1", date=stage_date(lat, lon), waypoints=waypoints)
     trip = Trip(id="wanduhr-probe", name="Wanduhr-Probe", stages=[stage])
     trip.report_config = TripReportConfig(trip_id="wanduhr-probe", send_email=False)
     return trip
@@ -257,7 +257,7 @@ def test_segment_liegt_nie_vollstaendig_in_der_vergangenheit(
         jetzt = datetime.now(timezone.utc)
         for versaetze in FAMILIEN:
             trip = _trip_aus_helfer(lat, lon, versaetze)
-            segmente = convert_trip_to_segments(trip, stage_date())
+            segmente = convert_trip_to_segments(trip, stage_date(lat, lon))
             assert segmente, (
                 f"{ortsname} @ {zeitpunkt}, Versaetze {versaetze}: leere "
                 "Segmentliste — die Etappe wurde gar nicht gefunden oder alle "
@@ -285,7 +285,7 @@ def test_wegpunktzeiten_ergeben_echt_wachsende_segmentgrenzen(zeitpunkt):
         for ortsname, lat, lon in ORTE:
             for versaetze in FAMILIEN:
                 trip = _trip_aus_helfer(lat, lon, versaetze)
-                segmente = convert_trip_to_segments(trip, stage_date())
+                segmente = convert_trip_to_segments(trip, stage_date(lat, lon))
                 # Wegpunkte minus 1 Verbindungssegmente, plus das Ziel-Segment.
                 erwartet = len(versaetze)
                 assert len(segmente) == erwartet, (
@@ -298,6 +298,47 @@ def test_wegpunktzeiten_ergeben_echt_wachsende_segmentgrenzen(zeitpunkt):
                         f"{ortsname} @ {zeitpunkt}: Segment {s.segment_id} "
                         "endet nicht nach seinem Anfang"
                     )
+
+
+# ══════════ AC-9 (#1697): stage_date() folgt der Ortszeit, nicht dem Serverdatum ══════════
+
+# Atlantic/Reykjavik: UTC+0 ganzjaehrig — "UTC-neutrale" Koordinate, deren
+# Ortsdatum in der Randzeit 22:00-00:00 UTC NIE vom Serverdatum abweicht.
+ISLAND_STAGE_DATE_LAT, ISLAND_STAGE_DATE_LON = 64.1466, -21.9426
+# Korsika (Europe/Paris, UTC+2 im Sommer) — weicht in genau diesem Fenster ab.
+KORSIKA_STAGE_DATE_LAT, KORSIKA_STAGE_DATE_LON = 42.20, 9.10
+
+
+def test_ac9_stage_date_folgt_der_ortszeit_in_der_randzeit():
+    """#1697 AC-9 ("Zweiter Fund"): ``stage_date()`` ist heute NILADISCH und
+    liefert wörtlich ``date.today()`` (Serverdatum) — unabhängig von jeder
+    Koordinate. Nach der Umstellung auf ``stage_date(lat, lon)`` MUSS eine
+    Korsika-Koordinate um 22:30 UTC den FOLGETAG liefern (Ortszeit 00:30),
+    waehrend eine UTC-neutrale Koordinate beim Serverdatum bleibt — dieselbe
+    Formel, die ``trip_alert.py`` nach #1697 fuer die Etappenauswahl benutzt.
+
+    RED heute: ``stage_date()`` nimmt keine Argumente entgegen ->
+    ``TypeError`` bei ``stage_date(lat, lon)``.
+    """
+    with freeze_time("2026-08-10T22:30:00+00:00"):
+        serverdatum = date(2026, 8, 10)
+        folgetag = date(2026, 8, 11)
+
+        korsika_datum = stage_date(KORSIKA_STAGE_DATE_LAT, KORSIKA_STAGE_DATE_LON)
+        island_datum = stage_date(ISLAND_STAGE_DATE_LAT, ISLAND_STAGE_DATE_LON)
+
+    assert korsika_datum == folgetag, (
+        f"AC-9: stage_date(Korsika) lieferte {korsika_datum}, erwartet "
+        f"{folgetag} (00:30 Ortszeit des Folgetags um 22:30 UTC)"
+    )
+    assert island_datum == serverdatum, (
+        f"AC-9: stage_date(Island) lieferte {island_datum}, erwartet "
+        f"{serverdatum} (UTC-neutrale Koordinate — Ortsdatum == Serverdatum)"
+    )
+    assert korsika_datum != island_datum, (
+        "AC-9: Korsika- und Island-Ortsdatum muessen in dieser Randzeit "
+        "auseinanderlaufen, sonst ist der Test nicht diskriminierend"
+    )
 
 
 def test_freeze_time_stellt_die_uhr_wirklich():

--- a/tests/unit/test_trip_local_today.py
+++ b/tests/unit/test_trip_local_today.py
@@ -1,0 +1,262 @@
+"""TDD RED — Issue #1697: geteilter Baustein ``services.trip_day``.
+
+SPEC: docs/specs/modules/fix_1697_ortstag_statt_servertag.md (AC-6, AC-7, AC-8)
+
+RED-Grund heute (gemessen): ``src/services/trip_day.py`` existiert noch
+nicht — jeder Import in dieser Datei scheitert mit ``ModuleNotFoundError``.
+``TripCommandProcessor`` traegt die drei Methoden (``_trip_tz``/
+``_display_tz``/``_anchor_tz``) noch selbst (#1470), AC-8 ist also ebenfalls
+rot.
+
+Testpolitik (CLAUDE.md "Test-Politik: Zwei Schichten"): Kern-Schicht, kein
+Netz, kein Mock — reine Funktionstests gegen echte ``Trip``/``Stage``/
+``Waypoint``-Objekte und echte Zeitzonenaufloesung (``utils.timezone``).
+Uhr: ``freeze_time`` (freezegun) fuer AC-7.
+
+Pfadregel #1409: keine Pfadaufloesung noetig — diese Datei liest nichts von
+der Platte, sie ruft nur echten Produktivcode gegen In-Memory-Objekte auf.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from zoneinfo import ZoneInfo
+
+from freezegun import freeze_time
+
+from app.trip import Stage, Trip, Waypoint
+
+AUCKLAND_LAT, AUCKLAND_LON = -36.8485, 174.7633
+LOS_ANGELES_LAT, LOS_ANGELES_LON = 34.0522, -118.2437
+VIENNA_LAT, VIENNA_LON = 48.2082, 16.3738
+
+
+def _wp(id_: str, lat: float, lon: float) -> Waypoint:
+    return Waypoint(id=id_, name=id_, lat=lat, lon=lon, elevation_m=500.0,
+                     arrival_calculated="12:00")
+
+
+# ══════════════════════════════ AC-6: Rueckfallkette ══════════════════════════════
+
+
+def test_ac6_direkter_treffer_nutzt_die_etappe_des_weltzeit_tages():
+    """Treffer-Fall: die Etappe des Weltzeit-Tages tragt Wegpunkte -> ihre
+    Zone bestimmt den Ortstag direkt, ohne Rueckfall.
+
+    Nachgemessen (nicht angenommen): Auckland (UTC+12 im August) und der
+    Weltzeit-Tag als Stage-Datum liefern einen ANDEREN Ortstag als das
+    UTC-Datum — das beweist, dass die Berechnung wirklich die Zone des
+    Wegpunkts benutzt, nicht bloss ``now_utc.date()`` durchreicht.
+    """
+    from services.trip_day import trip_local_today
+
+    with freeze_time("2026-08-10T23:00:00+00:00"):
+        now_utc = datetime.now(timezone.utc)
+        weltzeit_tag = now_utc.date()  # 2026-08-10
+        trip = Trip(
+            id="ac6-treffer", name="Treffer",
+            stages=[Stage(id="S1", name="S1", date=weltzeit_tag,
+                          waypoints=[_wp("W0", AUCKLAND_LAT, AUCKLAND_LON)])],
+        )
+        erwartet = now_utc.astimezone(ZoneInfo("Pacific/Auckland")).date()
+        assert erwartet != weltzeit_tag, (
+            "Testvoraussetzung: Auckland-Ortstag muss vom Weltzeit-Tag abweichen"
+        )
+        result = trip_local_today(trip, now_utc)
+
+    assert result == erwartet, (
+        f"AC-6 (Treffer): trip_local_today() lieferte {result}, erwartet "
+        f"{erwartet} (Auckland-Ortstag zum Zeitpunkt {now_utc.isoformat()})"
+    )
+
+
+def test_ac6_rueckfall_1_erste_etappe_mit_wegpunkten():
+    """Rueckfall 1: keine Etappe traegt das Datum des Weltzeit-Tages, aber
+    eine SPAETERE Etappe im ``stages``-Array hat Wegpunkte -> deren Zone
+    wird benutzt (die ERSTE mit Wegpunkten, nicht irgendeine).
+
+    Zwei Kandidatenzonen (Auckland zuerst, Los Angeles danach) stellen
+    sicher, dass wirklich die ERSTE mit Wegpunkten gewinnt — beide Zonen
+    liefern am selben ``now_utc`` unterschiedliche Kalendertage.
+    """
+    from services.trip_day import trip_local_today
+
+    with freeze_time("2026-08-10T23:00:00+00:00"):
+        now_utc = datetime.now(timezone.utc)
+        trip = Trip(
+            id="ac6-rueckfall1", name="Rueckfall1",
+            stages=[
+                Stage(id="S0", name="S0", date=date(2026, 1, 1), waypoints=[]),
+                Stage(id="S1", name="S1", date=date(2026, 2, 1),
+                      waypoints=[_wp("W1", AUCKLAND_LAT, AUCKLAND_LON)]),
+                Stage(id="S2", name="S2", date=date(2026, 3, 1),
+                      waypoints=[_wp("W2", LOS_ANGELES_LAT, LOS_ANGELES_LON)]),
+            ],
+        )
+        assert trip.get_stage_for_date(now_utc.date()) is None, (
+            "Testvoraussetzung: keine Etappe darf auf den Weltzeit-Tag treffen"
+        )
+        erwartet_auckland = now_utc.astimezone(ZoneInfo("Pacific/Auckland")).date()
+        erwartet_la = now_utc.astimezone(ZoneInfo("America/Los_Angeles")).date()
+        assert erwartet_auckland != erwartet_la, (
+            "Testvoraussetzung: Auckland- und LA-Ortstag muessen sich "
+            "unterscheiden, sonst ist der Test nicht diskriminierend"
+        )
+        result = trip_local_today(trip, now_utc)
+
+    assert result == erwartet_auckland, (
+        f"AC-6 (Rueckfall 1): trip_local_today() lieferte {result}, erwartet "
+        f"{erwartet_auckland} (Zone der ERSTEN Etappe mit Wegpunkten = "
+        "Auckland, S1 — nicht S2/Los Angeles)"
+    )
+
+
+def test_ac6_rueckfall_2_utc_konstante_ohne_wegpunkte():
+    """Rueckfall 2: KEINE Etappe der Tour hat Wegpunkte -> die aus
+    ``utils.timezone`` importierte UTC-Konstante greift, nicht ein
+    hartverdrahtetes ``ZoneInfo("UTC")``."""
+    from services.trip_day import anchor_tz, trip_local_today
+    from utils.timezone import UTC
+
+    with freeze_time("2026-08-10T23:00:00+00:00"):
+        now_utc = datetime.now(timezone.utc)
+        trip = Trip(
+            id="ac6-rueckfall2", name="Rueckfall2",
+            stages=[
+                Stage(id="S0", name="S0", date=date(2026, 1, 1), waypoints=[]),
+                Stage(id="S1", name="S1", date=date(2026, 2, 1), waypoints=[]),
+            ],
+        )
+        result = trip_local_today(trip, now_utc)
+        used_tz = anchor_tz(trip, now_utc)
+
+    assert used_tz == UTC, (
+        f"AC-6 (Rueckfall 2): anchor_tz() lieferte {used_tz!r}, erwartet die "
+        "importierte UTC-Konstante aus utils.timezone"
+    )
+    assert result == now_utc.date(), (
+        f"AC-6 (Rueckfall 2): trip_local_today() lieferte {result}, erwartet "
+        f"{now_utc.date()} (UTC-Datum, da keine Etappe Wegpunkte traegt)"
+    )
+
+
+# ══════════════════════════════ AC-7: Sommerzeit ══════════════════════════════
+
+
+def test_ac7_sommerzeit_fruehjahrs_umstellung_2026():
+    """Europe/Vienna, Fruehjahrs-Umstellung 2026-03-29 (02:00 -> 03:00
+    Ortszeit, nachgemessen: UTC-Sprung bei 01:00 UTC, Offset +1 -> +2).
+    Der Ortstag muss kurz vor UND kurz nach der Umstellungsstunde korrekt
+    2026-03-29 lauten — keine Rechenfalle "24,0 Stunden an jedem Tag"."""
+    from services.trip_day import trip_local_today
+
+    tag = date(2026, 3, 29)
+    trip = Trip(
+        id="ac7-fruehjahr", name="Fruehjahr",
+        stages=[Stage(id="S1", name="S1", date=tag,
+                      waypoints=[_wp("W0", VIENNA_LAT, VIENNA_LON)])],
+    )
+
+    with freeze_time("2026-03-29T00:59:00+00:00"):
+        vor = trip_local_today(trip, datetime.now(timezone.utc))
+    with freeze_time("2026-03-29T01:01:00+00:00"):
+        nach = trip_local_today(trip, datetime.now(timezone.utc))
+
+    assert vor == tag, (
+        f"AC-7 (Fruehjahr, kurz vor Umstellung): trip_local_today() lieferte "
+        f"{vor}, erwartet {tag}"
+    )
+    assert nach == tag, (
+        f"AC-7 (Fruehjahr, kurz nach Umstellung): trip_local_today() lieferte "
+        f"{nach}, erwartet {tag}"
+    )
+
+
+def test_ac7_sommerzeit_herbst_umstellung_2026():
+    """Europe/Vienna, Herbst-Umstellung 2026-10-25 (03:00 -> 02:00
+    Ortszeit, nachgemessen: UTC-Sprung bei 01:00 UTC, Offset +2 -> +1).
+    Derselbe Ortstag muss vor UND nach der Umstellungsstunde stehen."""
+    from services.trip_day import trip_local_today
+
+    tag = date(2026, 10, 25)
+    trip = Trip(
+        id="ac7-herbst", name="Herbst",
+        stages=[Stage(id="S1", name="S1", date=tag,
+                      waypoints=[_wp("W0", VIENNA_LAT, VIENNA_LON)])],
+    )
+
+    with freeze_time("2026-10-25T00:59:00+00:00"):
+        vor = trip_local_today(trip, datetime.now(timezone.utc))
+    with freeze_time("2026-10-25T01:01:00+00:00"):
+        nach = trip_local_today(trip, datetime.now(timezone.utc))
+
+    assert vor == tag, (
+        f"AC-7 (Herbst, kurz vor Umstellung): trip_local_today() lieferte "
+        f"{vor}, erwartet {tag}"
+    )
+    assert nach == tag, (
+        f"AC-7 (Herbst, kurz nach Umstellung): trip_local_today() lieferte "
+        f"{nach}, erwartet {tag}"
+    )
+
+
+# ══════════════════════════════ AC-8: keine vierte Kopie ══════════════════════════════
+
+
+def test_ac8_trip_command_processor_verliert_die_privaten_methoden():
+    """Nach dem Umbau traegt ``TripCommandProcessor`` ``_trip_tz``/
+    ``_display_tz``/``_anchor_tz`` NICHT mehr als eigene Implementierung —
+    die Aufloesung existiert im Repo genau einmal, in ``trip_day.py``."""
+    from services.trip_command_processor import TripCommandProcessor
+
+    for methodenname in ("_trip_tz", "_display_tz", "_anchor_tz"):
+        assert not hasattr(TripCommandProcessor, methodenname), (
+            f"AC-8: TripCommandProcessor traegt noch '{methodenname}' als "
+            "eigene Implementierung — sie muss nach services/trip_day.py "
+            "verschoben sein (keine vierte Kopie)"
+        )
+
+
+def test_ac8_anchor_folgt_der_heutigen_etappe_nicht_der_ersten_der_tour():
+    """Adversary-Hinweis (kein CRITICAL-Finding, Bestandsschutz): eine Tour
+    ueber ZWEI Zonen — erste Etappe Auckland, die Etappe des HEUTIGEN
+    Weltzeit-Tages Wien — muss ``anchor_tz()`` aus der Zone der HEUTIGEN
+    Etappe ziehen (``display_tz(trip, weltzeit_tag)``), NICHT aus der
+    ERSTEN Etappe der Tour (``trip_tz``) — genau das war die von #1470 mit
+    der Neuseeland->Korsika-Tour als "zehn Stunden daneben" VERWORFENE
+    Alternative. AC-8 verlangt diesen Bestandsschutz; die geerbte
+    #1470-Suite (``test_drilldown_day_window_local_date.py``) deckt ihn nur
+    indirekt ueber ``TripCommandProcessor`` ab — hier direkt gegen
+    ``services.trip_day``."""
+    from services.trip_day import anchor_tz, trip_tz
+    from utils.timezone import tz_for_coords
+
+    with freeze_time("2026-08-10T12:00:00+00:00"):
+        now_utc = datetime.now(timezone.utc)
+        heute = now_utc.date()
+        trip = Trip(
+            id="ac8-zwei-zonen", name="ZweiZonen",
+            stages=[
+                Stage(id="S0", name="S0", date=date(2026, 1, 1),
+                      waypoints=[_wp("W0", AUCKLAND_LAT, AUCKLAND_LON)]),
+                Stage(id="S1", name="S1", date=heute,
+                      waypoints=[_wp("W1", VIENNA_LAT, VIENNA_LON)]),
+            ],
+        )
+        auckland_zone = tz_for_coords(AUCKLAND_LAT, AUCKLAND_LON)
+        vienna_zone = tz_for_coords(VIENNA_LAT, VIENNA_LON)
+        assert auckland_zone != vienna_zone, (
+            "Testvoraussetzung: Auckland- und Wien-Zone muessen sich "
+            "unterscheiden, sonst ist der Test nicht diskriminierend"
+        )
+        assert trip_tz(trip) == auckland_zone, (
+            "Testvoraussetzung: trip_tz() (erste Etappe MIT Wegpunkten) "
+            "muss Auckland liefern"
+        )
+
+        result = anchor_tz(trip, now_utc)
+
+    assert result == vienna_zone, (
+        f"AC-8: anchor_tz() lieferte {result!r}, erwartet die Zone der "
+        f"HEUTIGEN Etappe (Wien) {vienna_zone!r} — nicht die der ERSTEN "
+        "Etappe der Tour (Auckland, #1470 verworfene Alternative)"
+    )


### PR DESCRIPTION
Refs #1697 (bleibt offen bis zur Folgescheibe fuer den Briefing-Pfad).

## Das Problem, gemessen

Der Alarm-Pfad bestimmte den zu ueberwachenden Tag ueber `date.today()` — das Datum der **Serveruhr** (Etc/UTC). Eine Etappe traegt aber ein **Ortsdatum**, und `get_stage_for_date` vergleicht strikt. Fallen beide auseinander, wird der Trip still uebersprungen.

Gemessen an einer gewoehnlichen Etappe 08:00–19:00 Ortszeit:

| Zone | Serverdatum trifft | Ortsdatum trifft |
|---|---|---|
| Europe/Paris | 4 von 4 | 4 von 4 |
| America/Los_Angeles | 3 von 4 | 4 von 4 |
| Pacific/Auckland | **2 von 4** | 4 von 4 |

Neuseeland verlor die ersten ~4 von 11 Stunden **jedes** Etappentags, Kalifornien die letzten ~2. **Auch Mitteleuropa ist betroffen** — jede Nacht zwei Stunden (22:00–00:00 UTC). Die urspruengliche Annahme „in Europa aendert sich nichts" wurde nachgemessen und ist falsch; genau daraus folgt der Horizont-Guard (s.u.).

## Was geaendert wurde

**Neu `src/services/trip_day.py`** — geteilter Baustein. `trip_tz`/`display_tz`/`anchor_tz` sind aus `TripCommandProcessor` hierher verschoben (dort privat), neu ist `trip_local_today()`. Die Henne-Ei-Aufloesung (man braucht ein Datum fuer die Zone und die Zone fuer das Datum) stammt unveraendert aus #1470/ADR-0044 und ist dort bereits vom Adversary gehaertet worden.

**Horizont-Guard in `check_radar_alerts`** — ohne ihn wuerde die korrigierte Etappenwahl in der naechtlichen Randzone jede Nacht einen Nowcast (Horizont ~60 min) fuer ein Segment abrufen, das erst in 7,5 Stunden beginnt. Die Schwesterfunktion im Scheduler hatte diesen Guard laengst.

**`stage_date()` im geteilten Test-Helfer nimmt jetzt Koordinaten** — sein eigener Docstring sagte, er bilde genau die geaenderte Zeile nach. Ohne Nachziehen waeren zwoelf Alarm-Testdateien nachts flakig geworden.

Produktivcode: **+152/−73** in drei Dateien. Der Rest ist Nachweis.

## Adversary: VERIFIED nach vier Runden, sieben Mutationen, zweimal BROKEN

Beide Befunde betrafen **nicht den Code**, sondern fehlende Waechter:

| Fund | Wirkort | Ohne Waechter |
|---|---|---|
| **F001** (CRITICAL) | `trip_alert.py:584` | Korrektur liess sich zuruecknehmen, ohne dass einer von **218** Tests rot wurde |
| **F002** (HIGH) | `trip_alert.py:404` | Dasselbe bei **266** Tests. Wirkung: in Kalifornien gilt die Tour am letzten Ortstag zu frueh als abgelaufen ⇒ uebersprungen ⇒ keine Alarme — das urspruengliche Fehlerbild an neuer Stelle |

Dreimal in Folge war der Produktivcode korrekt und trotzdem unbewacht. Gemessen und abgeschlossen: `trip_alert.py` hat genau **drei** unabhaengige Ortstag-Zuweisungen (`:404`, `:584`, `:901`), alle drei sind jetzt einzeln durch eine Mutations-Gegenprobe belegt.

Der Adversary hat ausserdem die Begruendung des Entwicklers zu einer vierten, nicht gebauten Absicherung **teilweise widerlegt** — F003 (MEDIUM, kein Blocker) ist in #1199 gebucht, mit dem Hinweis, dass die Begruendung nicht als Blaupause taugt.

## Nicht in dieser Scheibe

Briefing-Pfad (`_get_target_date`, `_get_active_trips`, `save_dated`) und die weiteren zwoelf Fundstellen — gleiche Ursache, andere Nutzerwirkung, eigener Nachweis. Touren ueber **mehrere** Zeitzonen bleiben bewusst ungeloest (PO-Entscheidung 2026-08-10, deckt sich mit ADR-0044, das den Restfehler als „in aller Regel null" einstuft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Auw6wfip4rmBknYvxQHTCq