### PR TITLE
feat(#1676): Premium-SMS als vierter Versandkanal fuer das Trip-Briefing (S2a)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,8 @@
 
 - **Zielgruppe:** Weitwanderer (z.B. GR20), eingeschraenkte Konnektivitaet
 - **Stack:** Python, uv, pytest
-- **Channels:** E-Mail (MVP), Telegram, SMS. (Signal 2026-06-06 app-weit entfernt, Issue #610 — s.u.)
+- **Channels:** E-Mail, Telegram, SMS, **Premium-SMS** (Garmin inReach, #1676 — seit 2026-08-10 im Trip-Briefing, ADR-0049). (Signal 2026-06-06 app-weit entfernt, Issue #610 — s.u.)
+- **🔴 Alle vier Kanäle sind gleichrangig relevant — kein Kanal ersetzt einen anderen.** PO-Vorgabe, mehrfach bekräftigt (zuletzt 2026-08-10): Auf dem Karnischen Höhenweg gibt es **auf der Hütte nur Satellit** — und das ist genau die Zeit, zu der Briefings verschickt werden, weshalb dort **nur Premium-SMS** ankommt. **Auf dem Pass gibt es normalen Handyempfang, dort sind E-Mail und Telegram relevant** und werden gelesen. Wer daraus „E-Mail/Telegram sind für die Tour nachrangig" folgert, liegt falsch — dieser Fehlschluss stand bereits einmal in einer Notiz und musste vom PO korrigiert werden. Alarme müssen **alle** Kanäle erreichen (#1701).
 - **Multi-User-Produkt:** Gregor Zwanzig ist **mandantenfähig** — jeder Nutzer hat eigene Trips, Orte, Orts-Vergleiche, Empfänger und Settings. Persistenz pro Nutzer unter `data/users/<user_id>/`. Isolation **konsequent** über `s.WithUser(middleware.UserIDFromContext(r.Context()))` (Go) bzw. `user_id`-Parameter (Python). **PFLICHT bei jedem nutzerbezogenen Endpoint:** echte `user_id` aus Auth-Kontext durchreichen, **niemals** auf `"default"` zurückfallen — das ist ein Cross-User-Datenleck. Jeder neue datenbewegende Endpoint MUSS mit **zwei verschiedenen Nutzern** getestet werden. Es gibt kein systemseitiges „an mich" — „senden" heißt immer „an die konfigurierten Empfänger dieses Nutzers".
 
 ## Workflow
@@ -306,7 +307,9 @@ Beide Wächter lassen bei **eigener** Störung immer durch und sagen es — ein 
 
 ## Signal als Channel — ENTFERNT (2026-06-06, Issue #610)
 
-Kanäle sind nur noch **E-Mail · Telegram · SMS**. Kein `SignalOutput`/`signal_text`/`send_signal`, kein `/api/preview/{trip}/signal`. Wiedereinführung müsste neu spezifiziert werden. (Callmebot bleibt serverseitig für andere Dienste.)
+Signal ist entfernt: kein `SignalOutput`/`signal_text`/`send_signal`, kein `/api/preview/{trip}/signal`. Wiedereinführung müsste neu spezifiziert werden. (Callmebot bleibt serverseitig für andere Dienste.)
+
+**Die Kanal-Liste lautet seit 2026-08-10 vier, nicht drei:** E-Mail · Telegram · SMS · Premium-SMS. Hier stand bis dahin „Kanäle sind nur noch E-Mail · Telegram · SMS" — das war nach der Signal-Entfernung richtig und ist seit #1676 S2a (ADR-0049, schreibt ADR-0004 fort) überholt. Premium-SMS ist heute nur im **Trip-Briefing** verdrahtet; Alarm- und Vergleichspfad folgen mit #1701, die Oberfläche mit S3. Zur Gleichrangigkeit der vier Kanäle siehe „Projekt-Ueberblick" oben.
 
 ## Confidence (Vorhersage-Verlässlichkeit) — NICHT wählbar als Metrik (2026-06-10, Issue #710)
 

--- a/docs/adr/0049-premium-sms-vierter-kanal.md
+++ b/docs/adr/0049-premium-sms-vierter-kanal.md
@@ -1,0 +1,123 @@
+# ADR-0049: Premium-SMS (Garmin inReach) ist ein vierter, eigenständiger Kanal `premium_sms` — kein SMS-Sonderfall (schreibt ADR-0004 fort)
+
+- **Status:** Akzeptiert (PO-„freigabe" 2026-08-10)
+- **Datum:** 2026-08-10
+- **Bezug:** Issue #1676 (Scheibe S2a), Spec
+  `docs/specs/modules/feat_1676_s2a_premium_sms_versand.md`; **schreibt
+  ADR-0004 fort** („Die unterstützten Kanäle sind nur noch E-Mail · Telegram ·
+  SMS"), ohne es zu widerrufen; folgt ADR-0015 (Kanal-Transporte gehören in
+  den Python-Kern)
+
+## Kontext
+
+ADR-0004 hat die Kanalliste 2026-06-06 bewusst auf drei Kanäle verengt und
+Signal entfernt — mit der ausdrücklichen Folgepflicht: „Neue Features dürfen
+Signal nicht als Briefing-Kanal annehmen. Eine Reaktivierung erfordert ein
+neues ADR." Dieselbe Folgepflicht trifft jeden **anderen** vierten Kanal: die
+Zahl „drei" stand dort nicht als Zufall, sondern als Wartungsgrenze.
+
+Issue #1676 bringt einen Fall, den ADR-0004 nicht kannte. Auf einer
+Weitwanderung ist das Satellitengerät (Garmin inReach) unterwegs oft der
+einzige erreichbare Empfangsweg — E-Mail und Telegram brauchen Netz, das
+genau dort fehlt, wo das Briefing gebraucht wird. Technisch läuft der Versand
+über denselben Dienstleister wie die normale SMS (seven.io), fachlich ist es
+aber **kein** SMS-Sonderfall:
+
+| | SMS | Premium-SMS (Garmin inReach) |
+|---|---|---|
+| Absender | frei konfigurierbar (`sms_from`, oft leer) | **fest** unsere Dienstnummer `4916092172595` — nur an sie kann das Gerät antworten |
+| Empfänger | vom Nutzer eingetragene Rufnummer (`sms_to`) | **gelernte, veränderliche** Rückadresse aus `user.json`, die Garmin je Gespräch neu vergibt (S1, #1676) |
+| Fehlt das Ziel | Kanal gilt als nicht konfiguriert, es passiert schlicht nichts | **muss sichtbar scheitern** — eine Nummer, die Garmin inzwischen einem fremden Gerät zugeteilt hat, kostet Geld und geht an einen Fremden |
+| Berechtigung | Tier `standard` **und** `premium` | ausschließlich Tier `premium` |
+
+Die naheliegende Abkürzung wäre gewesen, das als Variante von `SMSOutput` zu
+bauen („derselbe Dienstleister, nur ein anderes `from`"). Genau das ist der
+Fehler, den dieses ADR ausschließt: die vier Zeilen oben sind vier
+unterschiedliche fachliche Regeln. Eine Variante hätte sie in Bedingungen
+innerhalb eines Kanals versteckt, wo niemand sie als Kanal-Eigenschaft
+wiederfindet — und die Rechte-Ausweitung (`standard` darf plötzlich das
+teure Gerät ansprechen) wäre ein stiller Nebeneffekt statt einer
+Entscheidung.
+
+## Entscheidung
+
+**Premium-SMS ist ein vierter, eigenständiger Kanal mit dem verbindlichen
+Namen `premium_sms`.** Die Kanalliste des Produkts lautet damit:
+**E-Mail · Telegram · SMS · Premium-SMS**.
+
+Verbindlich festgelegt:
+
+1. **Der Kanalname ist `premium_sms`** — überall gleich: Klassenname
+   `PremiumSmsOutput.name`, Trip-Feld `send_premium_sms`, Schlüssel in
+   `NotificationResult.sent_channels`/`blocked_channels`, Eintrag in
+   `CHANNEL_LIMITS`, künftige Vorschau-/Alarm-Pfade. Der Name wurde **vor**
+   dem Code festgeschrieben, damit er nicht mitten in der Umsetzung wandert.
+2. **Fester Absender.** `4916092172595` ist Kanal-Eigenschaft, nicht
+   Konfiguration. `sms_from` hat auf diesen Kanal keine Wirkung — das Gerät
+   antwortet nur an die Nummer, von der es angesprochen wurde.
+3. **Der Empfänger kommt ausschließlich aus der gelernten Rückadresse**
+   (`user.json`, geschrieben von S1). `sms_to` wird für diesen Kanal nie
+   gelesen; ein Überschreiben per Umgebungsvariable ist gesperrt (Code-Sperre,
+   nicht Betriebsdisziplin).
+4. **Fail-closed mit sichtbarem Grund.** Fehlt die gelernte Rückadresse oder
+   ist sie älter als 30 Tage, geht **keine** Nachricht hinaus, und der Grund
+   steht als auswertbares Ergebnisfeld (`blocked_channels`) beim Aufrufer —
+   nicht nur in einer Logzeile. Begründung der 30 Tage: eine von Garmin
+   inzwischen neu vergebene Nummer nimmt die SMS mit HTTP 200 an, der
+   Scheinerfolg wäre von einem echten nicht zu unterscheiden.
+5. **Eigenes Tier-Gate.** `premium_sms_allowed()` prüft ausschließlich
+   `premium`. Eine Wiederverwendung von `sms_allowed()` (das `standard`
+   durchlässt) wäre eine stille Rechte-Ausweitung.
+6. **Ein gemeinsamer Transport, zwei Kanäle.** Beide seven.io-Kanäle erben
+   Sicherheitssperren und HTTP-Transport aus einer gemeinsamen Basis
+   (`SevenIoChannelBase`), statt sie zu kopieren.
+
+## Verworfene Alternativen
+
+- **Variante von `SMSOutput`** (Parameter/Flag „premium"). Technisch am
+  dichtesten, verworfen: die vier fachlichen Unterschiede oben würden zu
+  `if`-Zweigen im SMS-Kanal, das strengere Tier-Gate wäre nicht mehr als
+  Kanal-Eigenschaft erkennbar, und „Absender fest" stünde neben „Absender
+  konfigurierbar" in derselben Klasse. PO-Vorgabe war ausdrücklich „eigener
+  Kanal, keine Variante".
+- **Kopie von `sms.py`** mit angepassten Feldern. Verworfen: die beiden
+  Sicherheitssperren (Test-Modus-Sandbox-Key #1336, Herkunftssperre #1476)
+  existierten dann zweimal. Der bestehende Paritätstest prüft sie **namentlich
+  je Klasse** — eine in der Kopie vergessene Sperre wäre der Testsuite nicht
+  aufgefallen. Eine Kopie hätte also genau die Vergessbarkeit verdoppelt, die
+  die Sperren verhindern sollen.
+- **Rückadresse zusätzlich per `.env`/Konfiguration setzbar** („als
+  Notausgang"). Verworfen: eine per Umgebungsvariable auffrischbare
+  Verfallsfrist ist keine Frist, und ein per `.env` gesetzter Empfänger
+  umgeht die einzige Datenquelle, die weiß, welches Gerät gerade antwortet.
+- **ADR-0004 ändern statt fortschreiben.** Verworfen: die Historie soll
+  nachvollziehbar bleiben (Regel „das alte ADR nicht löschen"). ADR-0004
+  gilt unverändert für **Signal**; nur seine Zahl „drei" wird hier auf vier
+  fortgeschrieben.
+
+## Konsequenzen
+
+- **Positiv:** Der einzige Kanal, der unterwegs ohne Netz funktioniert, wird
+  regulär bedienbar. Die vier Sonderregeln stehen an einer auffindbaren Stelle
+  (Kanal-Klasse) statt als Bedingungen im SMS-Pfad. Die Sicherheitssperren
+  gelten für beide seven.io-Kanäle aus einer Quelle.
+- **Negativ / Preis:** Jede Stelle, die heute eine harte Dreier-Kanalliste
+  führt, ist ab jetzt unvollständig — bekannt und benannt:
+  `alert_log.py::_ALL_CHANNELS`, die zweite Kopie in `trip_alert.py`, die
+  Kanal-Schwellen aus ADR-0046, `AlertChannelsConfig` in Go und
+  `api_contract.md`. S2a rührt sie **nicht** an (nur Trip-Briefing); sie sind
+  die Liefer-Position von S2b (#1701). Bis dahin ist Premium-SMS
+  ausdrücklich **kein** Alarm-Kanal.
+- **Negativ / Preis:** Ein vierter Kanal kostet dauerhaft Pflege — genau der
+  Grund, aus dem ADR-0004 die Liste verengt hat. Der Unterschied zu Signal:
+  dieser Kanal ist für die Zielgruppe der einzige Weg ohne Netz, nicht der
+  vierte Weg mit Netz.
+- **Folgepflicht:** Wer eine neue Stelle baut, die ein Kanal-Set auflöst, muss
+  `premium_sms` mitführen oder begründen, warum nicht (ADR-0046 hat dieselbe
+  Folgepflicht für die Kanal-Schwelle). Kosten-/Kontingentzählung je Kanal
+  existiert im Bestand nirgends und ist eigene Arbeit (#1702).
+- **Nicht bewiesen durch S2a:** dass eine Premium-SMS tatsächlich auf dem
+  Gerät ankommt. Die Herkunftssperre (#1476) erzwingt außerhalb der
+  Produktions-Wurzel den Sandbox-Key („sendet nie, kostet nie"), Staging ist
+  zusätzlich sandboxiert. Dieser Nachweis gehört zu #1533 und ist bis dahin
+  als **offen** auszuweisen, nicht als bestanden.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -111,3 +111,4 @@ bzw. in den Specs unter `docs/specs/`.
 | [0046](0046-alarm-kanal-schwelle.md) | Kanal-Schwelle regelt AUF WELCHEM WEG eine Meldung ankommt — nicht OB (ergänzt 0043, Issue #1461 S3b-2a) | Akzeptiert |
 | [0047](0047-gewitter-vertretung-zwischen-direktquellen.md) | Gewitter-Vertretung zwischen Direktquellen bei echtem Dienstausfall — dehnt 0018 auf die Gewitter-Domäne aus, grenzt sich von 0025 ab (Issue #1492 Scheibe 2a) | Akzeptiert |
 | [0048](0048-modellabhaengige-schwellen-statt-einer-zahl.md) | Feste Schwellen werden nie über Modellgrenzen getragen — CAPE-Schwelle je Modell × Gebiet, geeicht am 95. Perzentil der Modellklimatologie (mind. 300 J/kg); unbekannte Herkunft heißt „keine Aussage" (Issue #1592 Scheiben B0+C0+C1) | Akzeptiert |
+| [0049](0049-premium-sms-vierter-kanal.md) | Premium-SMS (Garmin inReach) ist ein vierter, eigenständiger Kanal `premium_sms` — kein SMS-Sonderfall (schreibt 0004 fort, Issue #1676 S2a) | Akzeptiert |

--- a/docs/context/feat-1676-s2-premium-sms-kanal.md
+++ b/docs/context/feat-1676-s2-premium-sms-kanal.md
@@ -1,0 +1,243 @@
+# Context: feat-1676-s2-premium-sms-kanal
+
+**Issue:** #1676 S2 — Premium-SMS als vierter Versandkanal (Backend-Hälfte)
+**Vorgänger:** S1 (Rückkanal + gelernte Rückadresse) ist live auf `597ea84f`
+**Nachfolger:** S3 (Oberfläche), S4 = #1533 (Generalprobe auf dem Gerät, Frist 20.8.)
+**Basis:** `origin/main` = `e76c99d6`
+
+## Request Summary
+
+Premium-SMS (Garmin inReach, seven.io-Nummer `4916092172595`) soll ein vollwertiger vierter
+Versandkanal werden — Absender fest unsere Rufnummer, Empfänger die von S1 gelernte,
+veränderliche Rückadresse, bei leer/veraltet **kein** Versand. S1 lernt die Adresse bereits;
+ohne S2 geht nichts an das Gerät.
+
+## Related Files
+
+### Python — Versandweg
+
+| Datei | Relevanz |
+|---|---|
+| `src/output/channels/sms.py` | **Vorbild für den neuen Kanal.** 102 Zeilen: `SMSOutput.send()` (`:77-102`) POSTet an seven.io mit `X-Api-Key`; `from` wird nur gesetzt, wenn `sms_from` gefüllt ist (`:85-86`). Zwei Sperren davor: `_guard_test_mode_sandbox_key()` (`:34-51`), `_guard_code_origin()` (`:53-75`). |
+| `src/output/channels/base.py` | `Protocol OutputChannel` (`:16-49`): nur `name` + `send(subject, body)`. Fabrik `get_channel()` (`:66-102`) mit `if/elif`-Kette über Kanalnamen — **wird aber nur von der CLI benutzt** (`src/app/cli.py:256/258/280/282`), nicht vom Versandpfad. |
+| `src/services/notification_service.py` | 1537 Zeilen, **die Hauptarbeit**. Fünf Versand-Anlässe, jeder mit eigener harter `if "email"/"telegram"/"sms"`-Kette. Für S2 zentral: `send_trip_report()` (`:275-460`), SMS-Zweig `:369-377`. Kanäle kommen dort aus drei Bool-Flags `send_email`/`send_sms`/`send_telegram` (`:87-89`), nicht aus `effective_channels`. |
+| `src/services/alert_log.py:59` | `_ALL_CHANNELS = ("email", "telegram", "sms")` — harte Aufzählung, treibt `channels_not_sent` im Alarm-Protokoll. Nur für den Alarm-Pfad relevant. |
+| `src/services/trip_alert.py:1446` | **Zweite, unabhängige Kopie** derselben Dreier-Liste, inline. Drift-Risiko. |
+| `src/output/renderers/channel_layout.py:45-49` | `CHANNEL_LIMITS` — drei Einträge (`sms`: 153 Zeichen). `:97` fällt bei unbekanntem Kanal still auf **Telegram**-Limits zurück (4096 Zeichen). ⚠️ **Nachgemessen und eingegrenzt (Phase 2):** Dieser Rückfall betrifft den Briefing-Pfad **nicht** — `CHANNEL_LIMITS` wird ausschließlich von `comparison.py` und `compare_preview_service.py` gelesen, der Briefing-SMS-Text bekommt `max_length=160` fest übergeben (`src/output/renderers/trip_report.py:420`). Die Falle bleibt nur für den Vergleichs-Pfad und für S3 relevant. |
+| `src/app/config.py` | `sms_to`/`sms_from`/`sms_gateway_url`/`seven_api_key`/`seven_sandbox_key` (`:155-162`). `with_user_profile()` (`:278-318`) übernimmt heute genau drei Profilfelder: `mail_to`, `telegram_chat_id`, `sms_to` (`:308-313`). |
+| `src/app/loader.py:1081-1125` | `get_data_root()`/`get_data_dir()` — Datenwurzel per Modul-Override (Test-Isolation) > ENV `GZ_DATA_DIR` > `data/`. Jeder Lesezugriff auf `user.json` MUSS hierüber laufen. |
+| `src/app/origin_guard.py:22-46` | Herkunftssperre. Vergleicht die Checkout-Wurzel **exakt** mit `/home/hem/gregor_zwanzig` bzw. `…_staging` — ein Worktree gilt deshalb als `"test"`. |
+| `src/services/inbound_sms_reader.py` | S1-Gegenstück (nicht ändern). Konstanten: `GARMIN_MARKER = "inreachlink.com"` (`:58`), `LEARN_ENDPOINT` localhost:8090 (`:57`). |
+| `src/services/user_tier.py:17-31` | `daily_alert_limit()` — free 2 / standard 4 / premium unbegrenzt. Premium-SMS ist laut `docs/specs/modules/epic_user_tiers_overview.md:29` ein **Premium-Tier**-Merkmal mit 15-Minuten-Mindestabstand. |
+
+### Go — Modell, Persistenz, Auslösung
+
+| Datei | Relevanz |
+|---|---|
+| `internal/model/user.go:37-38` | **S1-Bestand, nicht ändern:** `PremiumSmsReplyTo string` / `PremiumSmsReplyAt *time.Time`. Einziger Schreiber `internal/handler/premium_sms_connect.go:108-109`. **Heute liest sie außer dem Schreiber niemand** — S2 ist der erste Leser. |
+| `internal/model/trip.go:161-163` | `SendEmail`/`SendSms`/`SendTelegram *bool` — nicht autoritativ, bei jedem Load/Save aus `ReportConfig` abgeleitet (`internal/store/trip.go:57-92`). |
+| `internal/model/trip.go:187-206` | `AlertChannelsConfig` (Email/Telegram/Sms bool) und `AlertChannelThresholdsConfig` (drei `*string`). Nur Alarm-Pfad. |
+| `internal/store/trip.go:214-255`, `store/user.go:67-79` | `SaveTrip`/`SaveUser` schreiben das **komplette** Struct neu. Da `Trip`/`User` typisierte Structs sind, verwirft `json.Unmarshal` unbekannte JSON-Felder — sie gehen beim nächsten Speichern **verloren**. Merge passiert nicht im Store, sondern im Handler (`internal/handler/trip.go:256-402`, freie Maps über `config_merge.go:11-22`). |
+| `internal/router/router.go:169-175` | Vorschau-Routen mit Kanalname als **festes Literal** beim Registrieren. Keine Allowlist erlaubter Kanalnamen — `preview_proxy.go:76` baut die Python-URL aus dem festen String. |
+| `internal/scheduler/scheduler.go:271-304, 545-584` | Go löst den echten Versand aus: `POST {python}/api/scheduler/trip-reports?user_id=…`, **ohne Body und ohne Kanalliste**. Python liest die Kanalauswahl selbst aus der Persistenz. Das heißt: **S2 braucht keine neue Go→Python-Leitung für den Versand.** |
+
+## Existing Patterns
+
+- **Kein Kanal-Register im Versandpfad.** `notification_service.py` konstruiert `EmailOutput`/`SMSOutput`/`TelegramOutput` direkt an jeder Sendestelle. `get_channel()` ist *nicht* die Naht — es bedient nur die CLI. Ein vierter Kanal muss entweder an jeder Stelle einzeln verdrahtet werden, oder der Briefing-Zweig wird auf eine Auflösung umgestellt.
+- **Guards sind Handarbeit, nicht erzwungen.** `tests/tdd/test_channel_origin_guard_parity.py:85-155` prüft die Herkunftssperre namentlich nur für `EmailOutput` und `SMSOutput` — kein Scan über `src/output/channels/`. Ein neuer Kanal ohne Guards fällt der Testsuite **nicht** auf.
+- **Test-Nähte: Sinks nur teilweise vorhanden.** `mail_sink`/`sms_sink`/`telegram_sink` (Docstring `notification_service.py:853-854`) existieren für amtliche Warnung und Vergleichs-Briefing. **`send_trip_report()` und `_dispatch_alert_message()` haben keinen `sms_sink`** — dort wird direkt gesendet. Für den Briefing-Pfad ist die belastbare Naht deshalb ein **echter lokaler HTTP-Stub** nach Vorbild `tests/tdd/test_issue_936_sms_stub.py` (kein Mock).
+- **Read-Modify-Write im Handler, nicht im Store** (siehe oben) — Pflicht bei jedem neuen Persistenz-Feld.
+
+## Dependencies
+
+- **Upstream:** seven.io Gateway (`gateway.seven.io`, bereits `TEST_ACCESS` in `src/app/egress_guard.py:52`, deckungsgleich mit `internal/egress/inventory.go` — kein neuer Allowlist-Eintrag nötig) · gelernte Rückadresse aus `users/<id>/user.json` (S1) · `sms_trip`-Renderer für den Nachrichtentext.
+- **Downstream:** S3 (Oberfläche) zeigt Kanal + Rückadresse · #1533 Generalprobe · `alert_log.json`-Protokoll, sobald der Kanal alarmfähig wird.
+
+## Existing Specs
+
+- `docs/specs/modules/feat_1676_s1_premium_sms_rueckkanal.md` — S1, v1.5. **Schließt Versand ausdrücklich aus** (Z. 29: „Nur Empfangen, Erkennen, Lernen, Speichern … kein Versandkanal (folgt in S2/S3)"). Enthält R1 (nur Nachrichten mit `inreachlink.com` lernen), R3 (Zuordnung über gespeicherte Nummer, sonst genau ein Premium-Nutzer, sonst 409).
+- `docs/specs/modules/egress_guard_sms.md` — seven.io-Sandbox-Isolation.
+- `docs/specs/modules/epic_user_tiers_overview.md:29,107` — Premium-SMS als Premium-Tier-Merkmal, „existiert als Kanal noch nicht".
+- `docs/reference/sms_format.md` — SMS-Token-Grammatik v2.23, wird unverändert weiterverwendet.
+- **Für S2 existiert keine Spec** — sie ist in Phase 3 zu schreiben.
+
+## Verpflichtungen aus ADRs
+
+| ADR | Konsequenz für S2 |
+|---|---|
+| `0004-signal-channel-removed.md` | Legt fest: „Die unterstützten Kanäle sind **nur noch** E-Mail · Telegram · SMS" (Z. 16-17). Ein vierter Kanal weicht davon ab → nach CLAUDE.md („Abweichung ⇒ neues ADR") braucht S2 ein **neues ADR**, das ADR-0004 in diesem Punkt fortschreibt. Das ist eine Liefer-Position, kein Nebensatz. |
+| `0015-dual-stack-zielarchitektur.md` | Alle Kanal-Renderer und -Transporte gehören in den Python-Kern. Der neue Kanal gehört also nach `src/output/channels/`, nicht nach Go. |
+| `0017-output-paket-konsolidierung.md` | Z. 56-65: Gate-Pfadmuster müssen im selben Commit nachgezogen werden, sonst „stiller Schutzverlust". |
+| `0046-alarm-kanal-schwelle.md` | Z. 101-105: jede neue Stelle, die ein Kanal-Set auflöst, muss die Kanal-Schwelle anwenden. Greift erst, wenn Premium-SMS alarmfähig wird. |
+| `docs/reference/api_contract.md:740-806` | `AlertChannelsConfig`/`AlertChannelThresholdsConfig` sind dort als „alle drei Felder" dokumentiert — nachzuziehen, sobald der Kanal in diesen Structs auftaucht. |
+
+## Wächter, die anschlagen werden
+
+| Wächter | Bedingung | Betrifft welchen Schnitt |
+|---|---|---|
+| `tests/test_success_status_guard.py:1547-1586, 1792-1794` | Ratsche mit **exakter Erwartung 3** je Funktion, indexbasiert (`::0`/`::1`/`::2`) für `send_official_alert` und `_dispatch_alert_message`. Ein vierter `sent_channels.append()` dort erzeugt einen ungelisteten Fund → `test_no_unlisted_success_status_findings` rot. Anheben nur mit Nachzug in Spec `waechter_1405_erfolg_wirkung.md`. | **Nur Alarm-Pfad.** `send_trip_report` ist Z. 774 ausdrücklich „belegt verschont" — ein Briefing-Schnitt löst diese Ratsche **nicht** aus. Selbst nachgemessen. |
+| `src/output/renderers/channel_layout.py:97` | Stiller Rückfall auf Telegram-Limits bei unbekanntem Kanal — kein Fehler, nur eine viel zu lange SMS. | Jeder Schnitt. Muss ein Eintrag in `CHANNEL_LIMITS` werden, und der Rückfall gehört bei einem SMS-artigen Kanal geprüft. |
+| `.claude/hooks/data_schema_backup.py:25-31` | Präfix `internal/model/` — jede Änderung dort löst vor dem Edit ein `data/users/`-Backup aus. | Jeder Schnitt mit Go-Modell-Feld. |
+| `.claude/hooks/touched_tests_gate.py:37` | Jede `.py` unter `src/`/`api/`; sucht Tests in `tests/unit/`. `tests/tdd/` zählt dort **nicht** mit → Meldung „UNGEPRUEFT" statt Blockade. | Jeder Schnitt. |
+| `.claude/hooks/renderer_mail_gate.py:42-48` | Erfasst von `src/output/channels/` **nur** `email.py`. Eine neue `channels/premium_sms.py` löst es nicht aus; eine Änderung an `renderers/sms_trip.py` oder `renderers/email/helpers.py` schon. | Nur bei Renderer-Berührung. |
+| `.claude/hooks/pendant_gate.py:54,160-164` | Nur `src/output/renderers` mit `compare_`/`trip_`-Präfix. `src/output/channels/` fällt nicht darunter. | Nur bei neuem präfigierten Renderer. |
+| `tests/test_egress_inventory_drift.py:72-89` | Deckungsgleichheit Python↔Go-Inventar. `gateway.seven.io` ist beidseitig vorhanden → **kein Handlungsbedarf**, solange kein neuer Host dazukommt. | — |
+
+## Risks & Considerations
+
+1. **Der Nachweis ist teurer als die Änderung.** Deterministisch beweisbar: Nutzlast (`from` = `4916092172595`), Empfängerauflösung aus `premium_sms_reply_to`, fail-closed bei leer/veraltet, Zeichen-Limit. **Nicht** beweisbar vor S4: dass die SMS auf dem Gerät ankommt. Gründe, gemessen: der Staging-Scheduler führt keinen Job aus (alle zehn `last_run: null`), und die Herkunftssperre stuft jeden Worktree als `"test"` ein und erzwingt dort den Sandbox-Key, der laut seven.io „nie sendet, nie kostet". Echter Versand ist strukturell nur mit Produktions-Herkunft möglich → gehört in #1533, und zwar als SKIPPED ausgewiesen, nicht als bestanden behauptet.
+2. **`extra="ignore"` in den Settings verschluckt neue Felder still** (`config.py:90`). Ein `premium_sms_reply_to`, das nur in `with_user_profile` ergänzt wird, ohne auf der `Settings`-Klasse deklariert zu sein, verschwindet lautlos. Prüfort muss die *Wirkung* sein (kommt der Wert im POST-Body an?), nicht die Existenz des Zweigs.
+3. **`force_test` bei Staging** (`config.py:292-293`) schaltet auf `for_testing()` um — auf Staging ist der Premium-Versand also grundsätzlich sandboxiert. Das ist gewollt, macht aber jede Staging-„Zustellung" zum Nicht-Beweis.
+4. **Zwei unabhängige Dreier-Listen** (`alert_log.py:59`, `trip_alert.py:1446`) werden bei einem alarmfähigen Kanal beide gebraucht — eine zu vergessen erzeugt ein stilles Loch im Protokoll, keinen Testfehler.
+5. **Kostenstelle hat kein Vorbild.** Gemessen: keine Kosten-, Kontingent- oder Versandzähler-Erfassung je Kanal im Produktivcode. Das einzige Mengengerüst ist das Tier-Tageslimit für Alarme (`user_tier.py:17-31`). Eine „eigene Kostenstelle" ist damit ein eigenes Feature, nicht ein Feld.
+6. **`api/routers/notify.py:15` kennt SMS gar nicht** — der Testversand-Endpunkt unterstützt nur `email`/`telegram` (`channel_test_service.py:30-41`). Ein Premium-SMS-Testversand über diesen Weg existiert nicht und müsste neu gebaut werden.
+7. **Go-Persistenz verliert unbekannte Felder** (typisierte Structs, voller Rewrite). Jedes neue Kanal-Flag braucht explizites Struct-Feld **und** expliziten Merge-Zweig im Handler.
+
+## Empfohlener Schnitt (Begründung für Phase 2/3)
+
+Der im Issue beschriebene S2-Umfang (vierter Kanal überall, Alarme, Vergleich, Kostenstelle) ist
+für einen Workflow zu groß und stellt das Dringendste hinten an. Vorschlag:
+
+- **S2a — Trip-Briefing als Premium-SMS.** Neuer Kanal, Absender fest, Empfänger = gelernte
+  Rückadresse, fail-closed bei leer/veraltet, SMS-Zeichenlimit, Premium-Tier-Gate, Go-Flag mit
+  Merge, Guards nach SMS-Vorbild, neues ADR. Damit wird #1533 durchführbar — das ist die Frist.
+- **S2b — Alarm- und Vergleichspfad.** `_ALL_CHANNELS`, `trip_alert.py:1446`, Kanal-Schwellen,
+  Erfolgs-Ratsche anheben (mit Spec-Nachzug), `api_contract.md`.
+- **S2c — Kostenstelle.** Eigenes Feature ohne Vorbild im Bestand.
+
+Der Schnitt ist auch technisch begründet, nicht nur zeitlich: S2a umgeht die Erfolgs-Ratsche
+vollständig (`send_trip_report` ist verschont), S2b läuft zwangsläufig hinein.
+
+---
+
+# Analysis (Phase 2)
+
+## Type
+
+**Feature** — es fehlt Funktionalität, die es nie gab. Kein Fehlverhalten.
+
+## Der Versandweg, lückenlos verfolgt
+
+Go löst aus (`internal/scheduler/scheduler.go:279` → `POST /api/scheduler/trip-reports?user_id=…`,
+ohne Body und ohne Kanalliste) → `api/routers/scheduler.py:26` →
+`trip_report_scheduler.py:299 send_reports_for_hour()` →
+`dispatch_orchestrator.py:165 run_briefing_dispatch()` →
+`trip_report_scheduler.py:825 _send_trip_report_outcome()` →
+`trip_report_scheduler.py:1067 _build_trip_report_request()` →
+`notification_service.py:275 send_trip_report()`.
+
+**Entscheidend: es gibt genau ZWEI Stellen, an denen S2a ansetzen muss.**
+
+1. **Kanal-Entscheidung:** `trip_report_scheduler.py:1303` — die einzige maßgebliche Stelle:
+   `send_sms=config is not None and config.send_sms and sms_allowed(self._user_id)`.
+   Tier-Gate und Nutzerwunsch sitzen in derselben Zeile. (Strukturgleiche Zweitkopie in
+   `:965`, aber nur für den „keine Wetterdaten"-Hinweis.)
+2. **Sendezweig:** `notification_service.py:369-377`.
+
+Ausdrücklich **nicht** beteiligt, gegen die Vermutung geprüft: `report_config_resolver.py`
+(klassifiziert die Kanal-Flags als `RENDER_NEUTRAL`, `:63-66`), `scheduler_dispatch_service.py`
+(Vergleichs-Pfad), `trip_alert.py::_briefing_channels()` (nur Vererbungs-Default für Alarme).
+
+Der Zeitplan ist **kanal-gemeinsam** (`trip_report_scheduler.py:345-360, 591-601`): ein
+Morgen-/Abend-Paar je Trip, kein kanalspezifischer Slot.
+
+## Korrekturen an Phase 1 (selbst nachgemessen)
+
+| Phase-1-Annahme | Messung | Folge |
+|---|---|---|
+| Premium-SMS braucht 153 Zeichen aus `CHANNEL_LIMITS`, sonst greift der stille Telegram-Rückfall | Der Briefing-Pfad liest `CHANNEL_LIMITS` **nie**. `trip_report.py:420` übergibt `max_length=160` fest. 153 ist die Segmentgrenze **verketteter** SMS, 160 die einer einzelnen. | **Premium-SMS übernimmt `report.sms_text` unverändert.** Kein zweiter Render-Pfad, kein `premium_sms_text`-Feld, kein `renderer_mail_gate`-Auslöser. Spart Aufwand *und* hält „komplette Kopie von SMS" wörtlich ein. |
+| Go verliert unbekannte Felder → Struct-Änderung nötig | `Trip.ReportConfig` ist `map[string]interface{}` (`trip.go:112`), Merge feldweise über `config_merge.go:11-22`. Der Verlust trifft nur die abgeleiteten Flach-Felder `SendEmail/SendSms/SendTelegram` (`trip.go:161-163`). | **Keine Go-Änderung in S2a.** Der Schlüssel `send_premium_sms` lebt in `report_config` und übersteht Speichern/Laden. Das Flach-Feld ist reine Frontend-Bequemlichkeit → S3. Damit entfällt auch der `data_schema_backup.py`-Auslöser. |
+
+## Neuer Fund: die Vorgabe „niemals aus `.env`" ist nicht von selbst erfüllt
+
+`SettingsConfigDict(env_prefix="GZ_")` (`config.py:87`) gilt uniform für **jedes** deklarierte
+Feld. Sobald `premium_sms_reply_to` ein reguläres Settings-Feld ist — und das muss es sein, weil
+`extra="ignore"` (`config.py:90`) undeklarierte Werte lautlos verschluckt — wäre
+`GZ_PREMIUM_SMS_REPLY_TO` ein funktionierender Override. Bei `sms_to`/`mail_to` ist dieselbe Lücke
+bis heute nur betrieblich geschlossen (keine solche Zeile in `.env`). Da die Vorgabe hier
+ausdrücklich „niemals" sagt, braucht es eine Code-Sperre, Vorbild `_resend_default_deny`
+(`config.py:194-217`).
+
+**Gegenprobe zur Nicht-Editierbarkeit:** `UpdateProfileHandler` (`internal/handler/auth.go:530-586`)
+dekodiert in ein lokales Struct ohne dieses Feld, Go verwirft unbekannte JSON-Schlüssel. Die
+Nutzer-API kann die Rückadresse also heute nicht setzen — für S2a ist nichts zu tun, aber dieses
+Struct darf das Feld nie aufnehmen (Leitplanke für S3).
+
+## Design-Entscheidungen
+
+| # | Entscheidung | Begründung |
+|---|---|---|
+| **D1** | Gemeinsame Basisklasse `src/output/channels/seven_io_base.py`; `SMSOutput` und `PremiumSmsOutput` erben `send()` als Template-Method und füllen nur `_resolve_recipient()`/`_resolve_sender()`. `sms.py` wird im **selben** Commit umgestellt. | Die beiden Sicherheits-Sperren existieren dann genau einmal statt zweimal. Eine Kopie hätte die Vergessbarkeit verdoppelt, die sie vermeiden soll — und `test_channel_origin_guard_parity.py:85-155` prüft nur namentlich genannte Klassen, würde eine vergessene Sperre also nicht bemerken. Ein Varianten-Parameter an `SMSOutput` wäre technisch am dichtesten, verstößt aber gegen die PO-Vorgabe „eigener Kanal". |
+| **D2** | Zwei deklarierte Settings-Felder `premium_sms_reply_to` / `premium_sms_reply_at`, gefüllt in `with_user_profile()` im Muster der bestehenden drei Zeilen — **plus** Validator-Sperre gegen `GZ_`-Override. | Einziger bestehender Profil→Settings-Übersetzer; ein zweiter Auflöser-Dienst würde die `get_data_dir()`-Lesung duplizieren und bei Test-Isolation abweichen können. |
+| **D3** | Die Fail-closed-Prüfung sitzt **in** der Kanal-Klasse (`_resolve_recipient()` wirft `OutputConfigError`), nicht als `if` am Aufrufort. | Der bestehende SMS-Zweig prüft `can_send_sms()` **vor** dem `try` — ist das falsch, passiert schlicht nichts: kein Log, kein Ergebnisfeld. Für SMS tolerierbar, für Premium-SMS durch die Vorgabe „kein stiller Fehlschlag" verboten. |
+| **D4** | Neues Feld `NotificationResult.blocked_channels: dict[str, str]` (Kanal → Grund). | Macht „nicht gesendet, weil …" **messbar** statt nur protokolliert. Ohne das wäre die Zusicherung nur an einer Logzeile prüfbar — und eine Logzeile ist kein Nachweis. |
+| **D5** | `report.sms_text` unverändert wiederverwenden (160 Zeichen). | Siehe Korrektur oben. Ein eigener Render-Pfad würde Inhalt zwischen SMS und Premium-SMS auseinanderlaufen lassen. |
+| **D6** | Verfallsfrist als Modul-Konstante. **Vorschlag: 30 Tage.** | Beide Fehlermodi sind asymmetrisch schlimm: zu kurz ⇒ selbstverschuldeter Briefing-Ausfall mitten auf der Tour (das Gerät meldet sich im Wesentlichen einmal zu Tourbeginn); zu lang ⇒ kostenpflichtige SMS an eine Nummer, die Garmin inzwischen einem fremden Gerät zugeteilt hat, mit HTTP 200 als Scheinerfolg. 30 Tage deckt mehrwöchige Touren und begrenzt die Fremdnummer-Aussetzung auf einen Monat. **Gestützt** auf die Annahme, dass Touren Tage bis wenige Wochen dauern; **widerlegt** durch reale Touren > 30 Tage (dann trip-gebunden statt fix) oder durch einen Messwert, dass seven.io/Garmin die Nummer schneller neu vergibt. Kein gemessener Wert → PO-Entscheidung. |
+| **D7** | Neue Funktion `premium_sms_allowed(user_id)` — nur `premium`. | `sms_allowed()` lässt `standard` **und** `premium` durch (`user_tier.py:6-14`). Premium-SMS ist laut `epic_user_tiers_overview.md:29` Premium-Merkmal. Das Gate wiederzuverwenden wäre ein stiller Rechte-Ausweitung. |
+| **D8** | Keine Go-Änderung in S2a. | Siehe Korrektur oben. |
+| **D9** | Kanalname verbindlich `premium_sms`, festgelegt in einem neuen ADR, das ADR-0004 fortschreibt. | ADR-0004 sagt „nur noch drei Kanäle"; die Projektregel verlangt bei Abweichung ein neues ADR. Zuerst schreiben, damit der Name nicht mitten in der Umsetzung wandert. |
+
+## Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `docs/adr/00XX-premium-sms-vierter-kanal.md` | CREATE | Schreibt ADR-0004 fort, legt `premium_sms` fest |
+| `docs/specs/modules/feat_1676_s2a_premium_sms_versand.md` | CREATE | Spec mit ACs (Phase 3) |
+| `src/output/channels/seven_io_base.py` | CREATE | Guards + HTTP-Transport, Template-Method |
+| `src/output/channels/premium_sms.py` | CREATE | Absender fest, Empfänger gelernt, Frische-Prüfung |
+| `src/output/channels/sms.py` | MODIFY | Auf Basisklasse umstellen (schrumpft) |
+| `src/output/channels/base.py` | MODIFY | `get_channel("premium_sms")` für CLI-Parität |
+| `src/app/config.py` | MODIFY | 2 Felder, `with_user_profile()`, `can_send_premium_sms()`, ENV-Sperre |
+| `src/services/notification_service.py` | MODIFY | Sendezweig in `send_trip_report()`, `blocked_channels` |
+| `src/services/trip_report_scheduler.py` | MODIFY | `send_premium_sms` in beiden Aufrufstellen (`:965`, `:1303`) |
+| `src/services/user_tier.py` | MODIFY | `premium_sms_allowed()` |
+| `src/app/models.py` | MODIFY | `TripReportConfig.send_premium_sms` |
+| `src/app/loader.py` | MODIFY | Feld beim Trip-Laden übernehmen |
+| `src/output/renderers/channel_layout.py` | MODIFY | Defensiver `CHANNEL_LIMITS`-Eintrag (1 Zeile, Vorsorge für S3) |
+| `tests/unit/test_premium_sms_versand.py` | CREATE | HTTP-Stub: Nutzlast, fail-closed, TTL-Kante, Guard-Parität |
+| `tests/unit/test_config_premium_sms.py` | CREATE | Settings, Profil-Übernahme, ENV-Sperre |
+| `tests/unit/test_user_tier.py` | MODIFY | `premium_sms_allowed` |
+| `tests/tdd/test_channel_origin_guard_parity.py` | MODIFY | `PremiumSmsOutput` in die Parität aufnehmen |
+
+Testdateien liegen bewusst unter `tests/unit/` — `touched_tests_gate.py:37` sucht nur dort;
+in `tests/tdd/` gälte der Commit als „UNGEPRUEFT". Namen nach Verhalten, nicht nach Issue-Nummer.
+
+## Scope Assessment
+
+- **Dateien:** 4 CREATE (2 Code, 2 Test) + 2 CREATE Doku + 11 MODIFY
+- **LoC:** Python netto ≈ **+150** (Basisklasse +80, Premium-Kanal +50, `sms.py` schrumpft ≈ −60, Rest +80) · Tests ≈ **+400** · Doku zählt nicht mit → erwartet **≈ +550**, LoC-Override nötig (PO-Erlaubnis liegt vor)
+- **Risiko:** **MEDIUM.** Kein Bestandsverhalten wird verändert außer dem `sms.py`-Refactor — und der ist durch die bestehende SMS-Testsuite abgedeckt. Der Rest ist additiv.
+
+## Nachweis-Plan
+
+Naht: **echter lokaler HTTP-Stub** (`http.server` auf `127.0.0.1`), Vorbild
+`tests/tdd/test_issue_936_sms_stub.py` und `test_issue_1069_tier_channel_gating.py` — kein Mock,
+keine `patch()`. Messbar:
+
+1. `payload["from"] == "4916092172595"`, auch wenn `sms_from`/`GZ_SMS_FROM` bewusst abweichend gesetzt ist
+2. `payload["to"]` stammt aus der Fixture-`user.json`, **nicht** aus `Settings.sms_to` (Test setzt `GZ_SMS_TO` abweichend)
+3. Rückadresse leer → **null** POSTs beim Stub **und** `blocked_channels["premium_sms"]` gesetzt
+4. TTL-Kante beidseitig: Frist − 1 s sendet, Frist + 1 s sendet nicht
+5. Text bitidentisch zu `report.sms_text`, Länge ≤ 160 unter Extremwetter-Fixture
+6. Guard-Parität: Testlauf-Herkunft erzwingt Sandbox-Key bzw. bricht ohne ihn hart ab
+7. `premium_sms_allowed("standard")` ist `False` — obwohl `sms_allowed("standard")` `True` ist
+8. ENV-Sperre: `GZ_PREMIUM_SMS_REPLY_TO` im Prozess-Environment führt zum lauten Abbruch, nicht zum Override
+
+**Mit keiner Naht beweisbar → #1533:** dass die SMS auf dem Gerät ankommt und dort lesbar ist.
+Gemessene Gründe: die Herkunftssperre stuft jeden Pfad außer `/home/hem/gregor_zwanzig` als
+Testlauf ein und erzwingt den Sandbox-Key („sendet nie, kostet nie"); `force_test` sandboxiert
+Staging zusätzlich (`config.py:292`); der Staging-Scheduler führt ohnehin keinen Job aus. Das ist
+als **SKIPPED** auszuweisen, nicht als bestanden.
+
+## Reihenfolge
+
+1. **ADR** — legt den Namen fest, bevor Code ihn trägt
+2. **Settings-Datenebene** — isoliert prüfbar, noch ohne Kanal
+3. **Kanal-Code** (Basisklasse + Premium + `sms.py`-Umstellung, ein Commit) — hier liegt der Kern-Nachweis
+4. **Verdrahtung** (`notification_service`, beide Scheduler-Stellen, Tier-Gate, Modell/Loader) — Ende-zu-Ende gegen den Stub
+5. **Defensiver `CHANNEL_LIMITS`-Eintrag** — letzter, kleinster Schritt
+
+## Open Questions (für die Spec-Freigabe)
+
+- [ ] **Verfallsfrist:** 30 Tage wie vorgeschlagen (D6)? Der Wert ist begründet, aber nicht gemessen.
+- [ ] **Schnitt:** S2a jetzt (Briefing), S2b (Alarme/Vergleich) und S2c (Kostenstelle) danach?

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -1,6 +1,6 @@
 # Architektur – Gregor Zwanzig
 
-**Updated:** 2026-08-10 (Issue #1676 Scheibe S1 — neuer Premium-SMS-Rückkanal: `InboundSmsReader` pollt das seven.io-Journal auf Garmin-inReach-Antworten und lernt die Rückadresse über den neuen internen Go-Endpoint `POST /api/internal/premium-sms-learn`; kein Trip-Befehlskanal, kein Frontend); 2026-08-03 (Issue #1460 Teil 1, ADR-0043 löst ADR-0040 ab — Wertebereich (`corridors[].notify`) fällt als Alarm-Auslöser weg, Empfindlichkeitsstufe bleibt einziger Regler und wirkt bei Gewitter über das erreichte Niveau statt die Sprunggröße, symmetrisch für Verschärfung und Entwarnung; Melde-Gedächtnis-Reset löscht beim Briefing nur noch den Änderungs-Raum, der amtliche Raum bleibt erhalten); 2026-07-21 (Doku-Audit #1341 — Frontend-Sektionen auf Ist-Stand: Wizards entfernt, Organisms-Barrel korrigiert, /api/subscriptions → /api/compare/presets + /api/briefings); 2026-07-03 (Issue #1001 — Telegram-Ausgabe neu gebaut: `render_telegram_bubbles()` ersetzt `render_narrow()` für den Telegram-Kanal, Multi-Bubble-Versand statt Prosa-Nachricht, echte Monospace-Segment-Tabellen, Inline-Keyboard-Aktionen-Bubble); 2026-06-30 (Issue #919 — Radar-Alert auf kanonischen Renderer migriert: `OnsetEvent`-Datenklasse + `cooldown_display` in `model.py`, Onset-Zweige in alle vier `render_*`-Funktionen, `check_radar_alerts` baut jetzt `AlertMessage(OnsetEvent(...))`, `src/outputs/radar_alert.py` gelöscht); 2026-06-26 (Issue #887 — SMS/Telegram Report-Konsistenz: SMS `pop_hourly` aus `agg.pop_max_pct`, Telegram Detail-Zeile mit config-gesteuerten Metriken; Issue #884 — HTML-Mail Fidelity: 8-Sektion-Layout mit zweispaltigem Header + Stats-Grid, Ziel-Sektion, Ausblick mit Risk-Dot, Kommandos-Sektion, zweigeteilt Footer); 2026-06-15 (Issue #822 — Radar-/Regen-Nowcast-Alert segmentbewusst: gemeinsamer Segment-Helfer, aktives/nächstes Segment nach Tageszeit, Ort-Label via build_segment_label, Tour-TZ via tz_for_coords, dynamischer Cooldown-Text); 2026-06-14 (Issue #816 — Alert-Abweichungs-Kern: read-only Snapshot, alert_state Melde-Gedächtnis, knapper Render-Pfad); 2026-06-12 (Issue #758 — Einheitlicher Speicher-Status-Indikator + Trip-Editor Auto-Save; #733 Briefing-Mail-Validator Marker-Header); 2026-06-11 (Issue #749 — Day Comparison Renderer: render_day_comparison_html/plain für Vortag-Vergleich-Sektion); 2026-06-09 (Issue #675 — Etappen-Startzeiten Editor-Widget; Issue #671 — Bot-Menü automatisch beim Service-Start + Live-Selftest); 2026-06-08 (Issue #655 — Telegram callback_query + editMessageText Zoom-Navigation); 2026-06-07 (Issue #637 — Telegram Webhook Migration); 2026-06-03 (Issue #572 — Inbound-Handler Multi-User Routing); 2026-05-31 (Issue #483 — Demo-Modus im Vorschau-Tab; Issue #495 — MapCanvas Leaflet-Karte; Issue #475 — OutputLayoutEditor zu Organisms)
+**Updated:** 2026-08-10 (Issue #1676 Scheibe S2a — Premium-SMS wird vierter Versandkanal `premium_sms`, ausschließlich fürs Trip-Briefing: fester Absender `4916092172595`, Empfänger die in S1 gelernte Rückadresse aus `user.json`, Verfall nach 30 Tagen ohne Nachlernen, fail-closed mit auswertbarem Grund statt stillem Ausbleiben, eigenes Tier-Gate nur `premium`; ADR-0049 schreibt ADR-0004 fort — Kanalliste jetzt E-Mail · Telegram · SMS · Premium-SMS; Alarm-/Vergleichspfad und Oberfläche folgen erst mit S2b/#1701 bzw. S3); 2026-08-10 (Issue #1676 Scheibe S1 — neuer Premium-SMS-Rückkanal: `InboundSmsReader` pollt das seven.io-Journal auf Garmin-inReach-Antworten und lernt die Rückadresse über den neuen internen Go-Endpoint `POST /api/internal/premium-sms-learn`; kein Trip-Befehlskanal, kein Frontend); 2026-08-03 (Issue #1460 Teil 1, ADR-0043 löst ADR-0040 ab — Wertebereich (`corridors[].notify`) fällt als Alarm-Auslöser weg, Empfindlichkeitsstufe bleibt einziger Regler und wirkt bei Gewitter über das erreichte Niveau statt die Sprunggröße, symmetrisch für Verschärfung und Entwarnung; Melde-Gedächtnis-Reset löscht beim Briefing nur noch den Änderungs-Raum, der amtliche Raum bleibt erhalten); 2026-07-21 (Doku-Audit #1341 — Frontend-Sektionen auf Ist-Stand: Wizards entfernt, Organisms-Barrel korrigiert, /api/subscriptions → /api/compare/presets + /api/briefings); 2026-07-03 (Issue #1001 — Telegram-Ausgabe neu gebaut: `render_telegram_bubbles()` ersetzt `render_narrow()` für den Telegram-Kanal, Multi-Bubble-Versand statt Prosa-Nachricht, echte Monospace-Segment-Tabellen, Inline-Keyboard-Aktionen-Bubble); 2026-06-30 (Issue #919 — Radar-Alert auf kanonischen Renderer migriert: `OnsetEvent`-Datenklasse + `cooldown_display` in `model.py`, Onset-Zweige in alle vier `render_*`-Funktionen, `check_radar_alerts` baut jetzt `AlertMessage(OnsetEvent(...))`, `src/outputs/radar_alert.py` gelöscht); 2026-06-26 (Issue #887 — SMS/Telegram Report-Konsistenz: SMS `pop_hourly` aus `agg.pop_max_pct`, Telegram Detail-Zeile mit config-gesteuerten Metriken; Issue #884 — HTML-Mail Fidelity: 8-Sektion-Layout mit zweispaltigem Header + Stats-Grid, Ziel-Sektion, Ausblick mit Risk-Dot, Kommandos-Sektion, zweigeteilt Footer); 2026-06-15 (Issue #822 — Radar-/Regen-Nowcast-Alert segmentbewusst: gemeinsamer Segment-Helfer, aktives/nächstes Segment nach Tageszeit, Ort-Label via build_segment_label, Tour-TZ via tz_for_coords, dynamischer Cooldown-Text); 2026-06-14 (Issue #816 — Alert-Abweichungs-Kern: read-only Snapshot, alert_state Melde-Gedächtnis, knapper Render-Pfad); 2026-06-12 (Issue #758 — Einheitlicher Speicher-Status-Indikator + Trip-Editor Auto-Save; #733 Briefing-Mail-Validator Marker-Header); 2026-06-11 (Issue #749 — Day Comparison Renderer: render_day_comparison_html/plain für Vortag-Vergleich-Sektion); 2026-06-09 (Issue #675 — Etappen-Startzeiten Editor-Widget; Issue #671 — Bot-Menü automatisch beim Service-Start + Live-Selftest); 2026-06-08 (Issue #655 — Telegram callback_query + editMessageText Zoom-Navigation); 2026-06-07 (Issue #637 — Telegram Webhook Migration); 2026-06-03 (Issue #572 — Inbound-Handler Multi-User Routing); 2026-05-31 (Issue #483 — Demo-Modus im Vorschau-Tab; Issue #495 — MapCanvas Leaflet-Karte; Issue #475 — OutputLayoutEditor zu Organisms)
 
 ## Überblick
 Gregor Zwanzig ist ein verteiltes System mit separatem Frontend (SvelteKit) und einem Dual-Stack-Backend (Go + Python):
@@ -8,7 +8,9 @@ Gregor Zwanzig ist ein verteiltes System mit separatem Frontend (SvelteKit) und 
 - **Go-API:** REST-API (Port 8090), Auth/Sessions, Mandantentrennung, Persistenz/Store, Proxy zum Python-Core
 - **Python-Core:** Wetter-Domäne (Provider, Risk Engine, Aggregation), alle Kanal-Renderer und -Transporte, Scheduler, Alerts, Inbound-Handler (FastAPI, Port 8000)
 - **Frontend:** SvelteKit Web-UI für Trip-Management, Konfiguration und Orts-Vergleiche
-- **Channels:** E-Mail (SMTP), Telegram, SMS (seven.io)
+- **Channels:** E-Mail (SMTP), Telegram, SMS (seven.io), Premium-SMS (seven.io, Garmin
+  inReach — seit Issue #1676 S2a **nur im Trip-Briefing** verdrahtet, nicht im Alarmpfad und
+  nicht im Ortsvergleich; siehe ADR-0049)
 - **Abo-Objekte:** Briefing-Subscriptions für Trips (ADR-0023) und Compare-Presets für Orts-Vergleiche — getrennte Domänenobjekte, keine gemeinsame „Subscription“-Abstraktion mehr
 
 Siehe `docs/adr/0015-dual-stack-zielarchitektur.md` für die verbindliche Zuständigkeitsgrenze.
@@ -71,6 +73,17 @@ Die folgenden Komponenten leben im Python-Core:
      den öffentlichen Methoden; `_post` wertet keine Statuscodes aus.
      Spec: `docs/specs/modules/telegram_send_pacing.md`.
    - **SMS** (`src/output/channels/sms.py`) – SMS-Versand via seven.io
+   - **Premium-SMS** (`src/output/channels/premium_sms.py`, `PremiumSmsOutput`,
+     `name == "premium_sms"`, seit Issue #1676 S2a) – **nur Trip-Briefing**, kein Alarm-
+     und kein Ortsvergleich-Pfad (folgt frühestens mit #1701). Fester Absender
+     `4916092172595` (unabhängig von `sms_from`), Empfänger ausschließlich die in S1
+     gelernte Rückadresse aus `user.json` (nie `sms_to`), Fail-Closed bei fehlender oder
+     >30 Tage alter Rückadresse mit auswertbarem Grund in `NotificationResult.blocked_channels`,
+     eigenes Tier-Gate (`premium_sms_allowed()`, ausschließlich Tier `premium`). Teilt sich
+     mit `SMSOutput` die Basisklasse `SevenIoChannelBase` (Sicherheitssperren + HTTP-Transport
+     genau einmal statt zweimal). Kein eigener Render-Pfad — Text kommt unverändert aus
+     `report.sms_text`. Kein Frontend-Schalter (folgt mit S3). Details: ADR-0049,
+     `docs/specs/modules/feat_1676_s2a_premium_sms_versand.md`.
 
 ### Datenfluss (Produktiv)
 
@@ -96,7 +109,7 @@ Channel Renderers
   ├─→ render_sms() → Wire-Format ≤160 Zeichen
   └─→ DebugBuffer
   ↓
-Channel (E-Mail / Telegram / SMS / Console)
+Channel (E-Mail / Telegram / SMS / Premium-SMS [nur Trip-Briefing] / Console)
 ```
 
 **Report-Config-Resolver (Issue #1208, Scheibe A):** Für Trip-Briefings löst
@@ -180,7 +193,17 @@ Reader nicht (Sandbox-Key liefert auf dem Lesepfad dasselbe Produktiv-Journal
 wie der Prod-Key — siehe `docs/specs/modules/egress_guard_sms.md` → Known
 Limitations), außer der Trockenlauf-Schalter `GZ_PREMIUM_SMS_POLL_DRYRUN=1`
 ist gesetzt. Details: `docs/specs/modules/feat_1676_s1_premium_sms_rueckkanal.md`.
-Kein Frontend, keine Befehlsausführung, kein Versandkanal (folgt in S2/S3).
+Kein Frontend, keine Befehlsausführung. Der Versand über diese gelernte
+Rückadresse ist seit Scheibe S2a live (s. u.) — **nur fürs Trip-Briefing**.
+
+### Premium-SMS als Versandkanal (Issue #1676, Scheibe S2a — nur Trip-Briefing)
+
+Aufbauend auf der gelernten Rückadresse aus S1 ist Premium-SMS seit S2a ein
+vierter, eigenständiger Versandkanal `premium_sms` (s. „Channels" oben und
+ADR-0049). Bewusst **nicht** verdrahtet: Alarmpfad und Ortsvergleich (folgen
+frühestens mit #1701), Oberfläche (folgt mit S3). `send_premium_sms` ist bis
+dahin nur über den freien `report_config`-Schlüssel setzbar, noch kein
+Go-Flach-Feld analog `send_sms`/`send_telegram`.
 
 ### Telegram Bot-Menü (Automatisches Setup)
 

--- a/docs/features/scope.md
+++ b/docs/features/scope.md
@@ -1,13 +1,16 @@
 # Gregor Zwanzig – Scope & Vision
 
-> Stand: 2026-07-21 (Doku-Audit #1341). Ersetzt die MVP-/CLI-Ära-Fassung
-> (Git-Historie). Offene Arbeit steht ausschließlich in GitHub Issues.
+> Stand: 2026-07-21 (Doku-Audit #1341), 2026-08-10 (Issue #1676 S2a — Premium-SMS
+> ergänzt). Ersetzt die MVP-/CLI-Ära-Fassung (Git-Historie). Offene Arbeit steht
+> ausschließlich in GitHub Issues.
 
 ## Produkt
 
 Wetter-Risiko-Briefings für Weitwanderungen und Orts-Vergleiche — als
 Multi-User-Webprodukt (SvelteKit-Frontend) mit automatischem Versand über
-E-Mail, Telegram und SMS (seven.io). Signal wurde entfernt (#610).
+E-Mail, Telegram und SMS (seven.io), seit Issue #1676 S2a zusätzlich
+Premium-SMS (Garmin inReach, ADR-0049) — **ausschließlich fürs Trip-Briefing**,
+nicht für Alarme oder Orts-Vergleiche. Signal wurde entfernt (#610).
 
 ## Nutzer & Kontext
 
@@ -28,7 +31,9 @@ tauglich, unterwegs steuerbar (Inbound-Kommandos), kontextbezogen (Profil).
 ## Was das Produkt heute leistet
 
 - **Trip-Briefings:** Abend-/Morgen-Briefings pro Etappe (E-Mail full/compact,
-  Telegram-Bubbles, SMS ≤160 Zeichen), Zeitpläne pro Nutzer.
+  Telegram-Bubbles, SMS ≤160 Zeichen, seit #1676 S2a zusätzlich Premium-SMS
+  für Garmin-inReach-Nutzer mit Premium-Tier, kein UI bislang), Zeitpläne pro
+  Nutzer.
 - **Orts-Vergleich:** Vergleichsmatrix über ≥2 Orte mit Idealbereichen,
   Winner-Logik, eigenem Mail-Template, Zeitplan-Versand.
 - **Alerts als Abweichungs-Wächter:** Nowcast/aktueller Forecast vs. letztes

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -576,6 +576,7 @@ Lawinenlagebericht als eigenstaendiges Datenobjekt (nicht Teil von NormalizedTim
 | timezone                        | str         | Zeitzone (default: "Europe/Vienna")                    |
 | send_email                      | bool        | E-Mail senden? (default: true)                         |
 | send_sms                        | bool        | SMS senden? (default: false)                           |
+| send_premium_sms                | bool        | Premium-SMS (Garmin inReach) senden? (default: false, Issue #1676 S2a) — eigenständiger vierter Kanal `premium_sms`, **nur Trip-Briefing** (Alarmpfad/Ortsvergleich erst mit #1701, s. ADR-0049); Empfänger ist ausschließlich die in Scheibe S1 gelernte Rückadresse aus `user.json`, nie `sms_to`. Lebt aktuell nur im freien `report_config`-Schlüssel (kein eigenes Go-Struct-Feld analog `send_sms`/`send_telegram`, folgt erst mit S3). |
 | alert_on_changes                | bool        | Alerts bei Änderungen? (default: true)                 |
 | change_threshold_temp_c         | float       | Temp-Änderungs-Schwelle [°C] (default: 5.0)            |
 | change_threshold_wind_kmh       | float       | Wind-Änderungs-Schwelle [km/h] (default: 20.0)         |
@@ -3415,6 +3416,15 @@ function corridorInside(value, min, max) {
 
 ## Changelog
 
+- 2026-08-10: Issue #1676 Scheibe S2a (ADR-0049) — `TripReportConfig.send_premium_sms`
+  (bool, default `false`) macht Premium-SMS (Garmin inReach) zum vierten, eigenständigen
+  Versandkanal `premium_sms` — **ausschließlich fürs Trip-Briefing**. Fester Absender
+  `4916092172595` (unabhängig von `sms_from`), Empfänger ausschließlich die in Scheibe S1
+  gelernte Rückadresse aus `user.json` (nie `sms_to`), Verfall nach 30 Tagen, fail-closed mit
+  auswertbarem Grund. Lebt bislang nur im freien `report_config`-Schlüssel, kein eigenes
+  Go-Struct-Feld analog `send_sms`/`send_telegram` (folgt erst mit S3). **Ausdrücklich nicht
+  betroffen:** `AlertChannelsConfig`/`AlertChannelThresholdsConfig` — Premium-SMS ist bis
+  #1701 kein Alarm-Kanal.
 - 2026-08-09: Issue #1517 — `POST /api/auth/register` prüft die Existenz des Usernamens
   (`s.UserExists`) jetzt VOR der #1226-E-Mail-Pflichtprüfung; Reihenfolge der reinen
   Format-Validierungen (Username-Länge/-Regex, Passwort-Länge) bleibt unverändert davor.

--- a/docs/specs/modules/feat_1676_s2a_premium_sms_versand.md
+++ b/docs/specs/modules/feat_1676_s2a_premium_sms_versand.md
@@ -1,0 +1,472 @@
+---
+entity_id: feat_1676_s2a_premium_sms_versand
+type: module
+created: 2026-08-10
+updated: 2026-08-10
+status: draft
+version: "1.0"
+tags: [sms, premium, garmin, seven-io, channel, dual-stack]
+---
+
+<!-- Issue #1676 (Scheibe S2a) -- Premium-SMS als vierter Versandkanal,
+     nur Trip-Briefing. Vorgaenger: S1 (feat_1676_s1_premium_sms_rueckkanal.md,
+     live). Nachfolger: S2b/#1701 (Alarme/Vergleich), S2c/#1702 (Kostenstelle),
+     S3 (Oberflaeche), S4/#1533 (Generalprobe auf dem Geraet). -->
+
+# Premium-SMS als vierter Versandkanal — S2a: Trip-Briefing
+
+## Approval
+
+- [x] Approved — PO-Freigabe 2026-08-10 ("freigabe"), inkl. 30-Tage-Frist (D6)
+      und Schnitt S2a (S2b → #1701, S2c → #1702)
+
+## Purpose
+
+Premium-SMS (Garmin inReach) wird ein vollwertiger, eigenständiger vierter
+Versandkanal `premium_sms` — ausschließlich für das Trip-Briefing. Fester
+Absender (unsere seven.io-Dienstnummer), Empfänger ausschließlich die in S1
+gelernte, veränderliche Rückadresse aus `user.json`. Bei fehlender oder älter
+als 30 Tage alter Rückadresse geht **keine** SMS hinaus — mit einem sichtbaren,
+auswertbaren Grund statt einem stillen Ausbleiben. S1 lernt die Rückadresse
+bereits; ohne diese Scheibe geht nichts an das Gerät.
+
+## Abgrenzung (nicht in dieser Scheibe)
+
+- **S2b — Alarm- und Vergleichspfad (#1701):** `_ALL_CHANNELS`
+  (`alert_log.py:59`), die zweite unabhängige Dreier-Liste
+  (`trip_alert.py:1446`), Kanal-Schwellen (ADR-0046), die Erfolgs-Ratsche
+  `test_success_status_guard.py`, `api_contract.md`-Nachzug für
+  `AlertChannelsConfig`/`AlertChannelThresholdsConfig`. Diese Scheibe rührt
+  den Alarm-Pfad nicht an — `send_trip_report()` ist von der Erfolgs-Ratsche
+  ausdrücklich verschont (nachgemessen), ein reiner Briefing-Schnitt löst sie
+  nicht aus.
+- **S2c — Kostenstelle (#1702):** Kosten-/Kontingent-/Versandzähler je Kanal
+  existieren im Bestand nirgends (nur das Tier-Tageslimit für Alarme,
+  `user_tier.py:17-31`). Eigenes Feature ohne Vorbild, nicht Teil dieser
+  Scheibe.
+- **S3 — Oberfläche:** Kanal-Auswahl und gelernte Rückadresse im Frontend
+  sichtbar/schaltbar. Diese Scheibe bleibt reines Backend; `send_premium_sms`
+  ist in S2a nur über den freien `report_config`-Schlüssel setzbar, noch
+  nicht über ein UI-Kontrollelement.
+- **#1533 — Generalprobe auf dem Gerät (Frist 20.8.):** der einzige Nachweis,
+  dass eine Premium-SMS tatsächlich am Garmin-Gerät ankommt. Siehe
+  „Nachweisgrenzen" unten.
+
+## Source
+
+- **File:** `src/output/channels/seven_io_base.py` (NEU, ~80 LoC) — gemeinsame
+  Basisklasse `SevenIoChannelBase`: beide Sicherheitssperren
+  (`_guard_test_mode_sandbox_key`, `_guard_code_origin`, Vorbild
+  `sms.py:34-75`) und der HTTP-Transport (Vorbild `sms.py:77-102`) als
+  Template-Method, genau einmal statt zweimal.
+- **File:** `src/output/channels/premium_sms.py` (NEU, ~50 LoC) —
+  `PremiumSmsOutput`, `name == "premium_sms"`, fester Absender
+  `4916092172595`, `_resolve_recipient()` prüft leer/veraltet fail-closed.
+- **File:** `src/output/channels/sms.py` (MODIFY, ≈−60 LoC) — auf die
+  Basisklasse umgestellt, Verhalten unverändert. Selber Commit wie die neue
+  Basisklasse (D1) — sonst wären die Sicherheitssperren zwischenzeitlich
+  dupliziert statt vereinheitlicht.
+- **File:** `src/output/channels/base.py` (MODIFY, +~40 LoC) —
+  `get_channel("premium_sms")` für CLI-Parität (Vorbild `:93-95`), **plus**
+  `ChannelBlockedError(OutputConfigError)` mit Pflichtfeld `reason_code`
+  (Nachtrag 2026-08-10, s. D10).
+- **File:** `src/app/config.py` (MODIFY) — zwei Felder
+  `premium_sms_reply_to`/`premium_sms_reply_at`, Übernahme in
+  `with_user_profile()` (Muster `:307-313`), ENV-Sperre gegen
+  `GZ_PREMIUM_SMS_REPLY_TO` **und** `GZ_PREMIUM_SMS_REPLY_AT`.
+  **Korrektur nach Adversary-Runde 1 (F003):** ein zunächst gebautes
+  `can_send_premium_sms()` ist wieder **entfernt**. Eine vorgeschaltete
+  Bereitschaftsfrage im Versandzweig würde die Fail-closed-Prüfung im Kanal
+  *abschirmen* — die Mutations-Gegenprobe zu AC-3 (Prüfung im Kanal entfernt)
+  wäre dann grün geblieben. An ihrer Stelle steht eine Begründung im Code plus
+  ein Wächter-Test, der ihre Rückkehr rot macht.
+- **File:** `src/services/notification_service.py` (MODIFY, +~25 LoC) —
+  Sendezweig in `send_trip_report()` neben dem bestehenden SMS-Zweig
+  (`:369-377`), neues Feld `NotificationResult.blocked_channels`.
+- **File:** `src/services/trip_report_scheduler.py` (MODIFY, +~10 LoC) —
+  `send_premium_sms=config is not None and config.send_premium_sms and
+  premium_sms_allowed(self._user_id)` an beiden Kanal-Entscheidungsstellen
+  (`:965`, `:1303`).
+- **File:** `src/services/user_tier.py` (MODIFY, +~10 LoC) —
+  `premium_sms_allowed(user_id)`, ausschließlich Tier `premium`.
+- **File:** `src/app/models.py` (MODIFY, +1 LoC) —
+  `TripReportConfig.send_premium_sms: bool = False` (Muster `:924-926`).
+- **File:** `src/app/loader.py` (MODIFY) — Feld an **zwei** Stellen mitziehen:
+  Lesen in `_parse_trip` (`:574-579`) und Schreiben in `_trip_to_dict`
+  (`:1600-1605`), beide auf der `report_config`-Ebene.
+  **Korrektur 2026-08-10:** eine frühere Fassung dieser Zeile nannte fünf
+  Stellen. Die drei weiteren gehören zum flachen Dual-Read-Mechanismus
+  (`trip.send_sms`/`send_telegram`, #1250 Scheibe 4) — dort ist **kein**
+  `send_premium_sms`-Pendant angelegt und auch keines nötig: der Sendepfad
+  liest ausschließlich `trip.report_config.send_premium_sms`
+  (`trip_report_scheduler.py:971`, `:1315`). Die Parität zum flachen Feld wird
+  erst mit S3 relevant. Die alte Zeile behauptete Umfang, den der Code nicht
+  einlöst.
+- **File:** `src/output/renderers/channel_layout.py` (MODIFY, +1 Zeile) —
+  defensiver `CHANNEL_LIMITS["premium_sms"]`-Eintrag; verhindert den stillen
+  Telegram-Rückfall (`:97`), falls ein künftiger Aufrufer (S3) den Kanal dort
+  nachschlägt. Der Briefing-Pfad selbst liest `CHANNEL_LIMITS` nicht (s.
+  Implementation Details) — reine Vorsorge, kein funktionaler Bestandteil
+  dieser Scheibe.
+- **File:** `docs/adr/0049-premium-sms-vierter-kanal.md` (NEU) — schreibt
+  ADR-0004 fort, legt den Kanalnamen `premium_sms` verbindlich fest, VOR dem
+  Code.
+- **File:** `tests/unit/test_premium_sms_versand.py` (NEU, ~250 LoC) —
+  HTTP-Stub gegen `PremiumSmsOutput`/`send_trip_report()`.
+- **File:** `tests/unit/test_config_premium_sms.py` (NEU, ~80 LoC) —
+  Settings-Felder, Profil-Übernahme, ENV-Sperre.
+- **File:** `tests/unit/test_user_tier.py` (**CREATE**, ~70 LoC) —
+  `premium_sms_allowed()`. Korrektur 2026-08-10: die Spec nahm diese Datei
+  als Bestand an, sie existierte nicht. `sms_allowed()` wird heute nur
+  beiläufig in `tests/tdd/`-Dateien mitgeprüft (u. a.
+  `test_issue_1069_tier_channel_gating.py`), es gibt keinen eigenen
+  Tier-Test unter `tests/unit/`. Die Datei enthält deshalb zusätzlich einen
+  Bestandsnachweis für `sms_allowed()` als Kontrast zu AC-8.
+- **File:** `tests/tdd/test_channel_origin_guard_parity.py` (MODIFY,
+  +~30 LoC) — `PremiumSmsOutput` in die bestehende Guard-Parität
+  aufgenommen (dort heute nur `EmailOutput`/`SMSOutput` namentlich geprüft).
+
+## Estimated Scope
+
+- **LoC (Produktivcode):** ≈ +150 netto (Basisklasse +80, Premium-Kanal +50,
+  `sms.py` schrumpft ≈ −60, Rest +80).
+- **LoC (Tests):** geschätzt ≈ +400, **gemessen nach RED: +874**
+  (`test_premium_sms_versand.py` 539, `test_config_premium_sms.py` 156,
+  `test_user_tier.py` 69, `test_channel_origin_guard_parity.py` +110).
+  Die Schätzung war um mehr als das Doppelte zu niedrig. Gründe, benannt statt
+  weggerundet: der echte lokale HTTP-Server samt Trip-Fixtures ist Aufbau vor
+  der ersten Zusicherung; AC-10 prüft vier Schaltkombinationen; AC-4/AC-5 sind
+  ein Kantenpaar mit je eigener Fixture; AC-7 wird am eingegangenen Request
+  gemessen statt am Transport-Sink der Bestandstests.
+- **Gesamt erwartet:** ≈ +1024 (874 Tests + ≈ 150 Produktivcode) — LoC-Override
+  auf 1200 gesetzt. Doku zählt nicht mit.
+- **Files:** 5 CREATE (2 Code, 2 Test, 1 ADR) + 10 MODIFY.
+- **Effort:** medium.
+- **Risiko:** MEDIUM. Kein Bestandsverhalten ändert sich außer dem
+  `sms.py`-Refactor — der ist durch die bestehende SMS-Testsuite abgedeckt.
+  Der Rest ist additiv.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `docs/specs/modules/feat_1676_s1_premium_sms_rueckkanal.md` | Vorgänger-Spec | liefert `premium_sms_reply_to`/`premium_sms_reply_at` in `user.json` — alleinige Datenquelle dieser Scheibe |
+| `src/output/channels/sms.py` | Vorbild/Umbau | Template-Method-Basis, Guards, HTTP-Transport (D1) |
+| `src/app/config.py::with_user_profile` | module | einziger Profil→Settings-Übersetzer (D2), einzige Stelle, die `get_data_dir()`-Isolation respektiert |
+| `src/services/user_tier.py::sms_allowed` | Vorbild, NICHT wiederverwendet | Struktur für `premium_sms_allowed` — `sms_allowed` lässt `standard` durch, das darf Premium-SMS nicht (D7) |
+| `src/services/notification_service.py::send_trip_report` | module | Sendezweig-Integrationspunkt, einzige maßgebliche Stelle im Briefing-Pfad |
+| `src/services/trip_report_scheduler.py` | module | beide Kanal-Entscheidungsstellen (`:965`, `:1303`) |
+| `docs/adr/0004-signal-channel-removed.md` | ADR | wird fortgeschrieben (D9), nicht widerrufen |
+| `tests/tdd/test_issue_936_sms_stub.py` | Test-Vorbild | lokaler HTTP-Stub-Aufbau (kein Mock) |
+| `tests/tdd/test_channel_origin_guard_parity.py` | Test-Vorbild, MODIFY | Guard-Parität-Muster, wird um `PremiumSmsOutput` erweitert |
+| `src/app/egress_guard.py` | module | `gateway.seven.io` bereits `TEST_ACCESS` (`:52`) — kein neuer Eintrag nötig |
+
+## Implementation Details
+
+### Kanal-Klasse: Template-Method über eine gemeinsame Basis (D1)
+
+`seven_io_base.py` trägt beide Sicherheitssperren und den HTTP-Transport
+genau einmal. `SMSOutput` und `PremiumSmsOutput` überschreiben nur
+Empfänger-/Absender-Auflösung (Skizze, nicht wörtlicher Endstand):
+
+```python
+class SMSOutput(SevenIoChannelBase):
+    name = "sms"
+    def _resolve_sender(self) -> str | None:
+        return self._settings.sms_from or None
+    def _resolve_recipient(self) -> str:
+        return self._settings.sms_to
+
+class PremiumSmsOutput(SevenIoChannelBase):
+    name = "premium_sms"
+    PREMIUM_SMS_SENDER = "4916092172595"
+    def _resolve_sender(self) -> str:
+        return self.PREMIUM_SMS_SENDER
+    def _resolve_recipient(self) -> str:
+        reply_to = self._settings.premium_sms_reply_to
+        reply_at = self._settings.premium_sms_reply_at
+        if not reply_to or not reply_at:
+            raise OutputConfigError("premium_sms", "keine gelernte Rueckadresse")
+        if _now() - reply_at > PREMIUM_SMS_REPLY_TTL:
+            raise OutputConfigError("premium_sms", "Rueckadresse veraltet (>30 Tage)")
+        return reply_to
+```
+
+Eine Kopie statt einer gemeinsamen Basis hätte die Vergessbarkeit der beiden
+Sperren verdoppelt — genau das, was sie verhindern sollen. Ein
+Varianten-Parameter an `SMSOutput` wäre technisch dichter, verstößt aber
+gegen die PO-Vorgabe „eigener Kanal, keine Variante".
+
+### Fail-Closed sitzt in der Kanal-Klasse, nicht am Aufrufort (D3)
+
+`_resolve_recipient()` wirft `OutputConfigError`; `send()` in der Basisklasse
+ruft sie vor jedem HTTP-Call auf. Der bestehende SMS-Zweig prüft
+`can_send_sms()` vorher (`notification_service.py:369`) — das reicht bei
+Premium-SMS nicht: „leer" und „veraltet" sind erst zur Sendezeit final
+bekannt, und die Vorgabe verlangt einen sichtbaren, keinen stillen
+Fehlschlag.
+
+### Sichtbarkeit des Fehlschlags: `blocked_channels` (D4)
+
+`NotificationResult` bekommt ein neues Feld `blocked_channels: dict[str,
+str]` (Kanal → Grund). Der Sendezweig in `send_trip_report()` fängt
+`OutputConfigError`/`OutputError` von `PremiumSmsOutput` ab und trägt den
+Grund dort ein, statt ihn nur zu loggen — eine Logzeile ist kein Nachweis.
+
+### Maschinenlesbarer Sperrgrund (D10, Nachtrag 2026-08-10, PO-freigegeben)
+
+Der Wert in `blocked_channels` ist deutscher Klartext — als Diagnose brauchbar, als Quelle für
+das Alarm-Protokoll nicht: `alert_log.py:40-52` führt stabile Kurzschlüssel
+(`channel_disabled`, `delivery_failed`, `below_channel_threshold`). Die Session, die S2b
+(#1701) baut, hätte auf deutschen Prosatext vergleichen müssen, um die zwei Sperrfälle zu
+unterscheiden — eine Kopplung, die beim ersten Umformulieren still bricht.
+
+Deshalb trägt die Ursache eine **maschinenlesbare Kennung**:
+`ChannelBlockedError(OutputConfigError)` in `base.py` mit Pflichtfeld `reason_code`, Werte
+`premium_sms_no_reply_address` und `premium_sms_reply_address_stale` (als Konstanten
+`BLOCK_REASON_*` aus `premium_sms.py` importierbar).
+
+Warum eine Unterklasse und nicht ein Attribut an `OutputError`: der Alarmpfad sieht **nur die
+Ausnahme** des Kanals, nicht `NotificationResult` — ein zweites Ergebnisfeld hätte ihn
+strukturell nie erreicht. Die Basisklasse anzufassen hätte den von E-Mail, Telegram und SMS
+geteilten Vertrag verändert, ohne etwas zu gewinnen: im generischen `except` braucht der
+Aufrufer ohnehin `getattr(exc, "reason_code", None)`, weil es Ausnahmen ohne Kennung gibt
+(HTTP-Störung, SMTP-Fehler). Der Klartext bleibt unverändert daneben stehen.
+
+**Diese Ergänzung geht über die ursprünglich freigegebene Spec hinaus** und wurde am
+2026-08-10 gesondert freigegeben. Auslöser war ein Hinweis der S2b-Session, nicht ein eigener
+Fund — festgehalten, damit die Herkunft der Entscheidung nachvollziehbar bleibt.
+
+**Nachtrag aus Adversary-Runde 1 (F002):** Die Kennung liegt zusätzlich als Ergebnisfeld
+`NotificationResult.blocked_reason_codes` vor, gefüllt an **beiden** Sperrstellen (Briefing und
+Wetterausfall-Hinweis). Bewusst **ohne Ersatzwert**: ein fehlender Eintrag *ist* die Aussage
+„das war keine bewusste Sperre, sondern ein Fehler". Genau daran unterscheidet die AC-3-Prüfung
+jetzt einen Zufallsabsturz von einer Sperre — vorher akzeptierte sie jede nicht-leere
+Fehlermeldung als Grund, und der Adversary hat das mit einer Mutation ausgenutzt.
+
+### Text unverändert aus `report.sms_text` (D5)
+
+Kein eigener Render-Pfad, kein `premium_sms_text`-Feld. `PremiumSmsOutput`
+bekommt denselben `body=report.sms_text or report.email_plain` wie der
+bestehende SMS-Zweig (`notification_service.py:373`). Der Briefing-Pfad
+liest `CHANNEL_LIMITS` (`channel_layout.py:45-49`) nicht — `trip_report.py:420`
+übergibt `max_length=160` fest; die 153 dort sind die Segmentgrenze
+**verketteter** SMS, hier irrelevant.
+
+### Verfallsfrist als Modul-Konstante (D6, PO-Entscheid 2026-08-10)
+
+`PREMIUM_SMS_REPLY_TTL = timedelta(days=30)` in `premium_sms.py`. Begründung
+und Widerlegungsbedingungen: siehe Known Limitations.
+
+### Eigenes Tier-Gate (D7)
+
+`premium_sms_allowed(user_id)` prüft ausschließlich `tier == "premium"` —
+keine Wiederverwendung von `sms_allowed()`, das `standard` **und** `premium`
+durchlässt (`user_tier.py:6-14`). Wiederverwendung wäre eine stille
+Rechte-Ausweitung.
+
+### Kein Go-*Produktivcode* in S2a (D8)
+
+**Präzisierung 2026-08-10:** Diese Entscheidung hieß zuerst „keine Go-Änderung". Wörtlich trifft
+das nicht mehr zu — `internal/handler/fix_go_rmw_merge_1082_1103_test.go` hat **zwölf Zeilen**
+bekommen (der neue Schlüssel im bestehenden Merge-Regressionstest). Das ist ein **Test**, kein
+Struct und kein Handler; die Substanz der Entscheidung — kein neues Go-Feld, kein
+`data_schema_backup.py`-Auslöser — bleibt unberührt. Der Test entstand als Beleg für die
+Ganzobjekt-Frage (s. u.), nicht als Funktionsänderung.
+
+`send_premium_sms` lebt als freier Schlüssel in `Trip.ReportConfig`
+(`map[string]interface{}`, `trip.go:112`), überlebt Speichern/Laden über den
+bestehenden feldweisen Merge (`config_merge.go:11-22`) ohne neues
+Go-Struct-Feld. Ein Flach-Feld analog `SendSms`/`SendEmail`
+(`trip.go:161-163`) ist reine Frontend-Bequemlichkeit und folgt erst mit S3.
+Damit entfällt auch der `data_schema_backup.py`-Auslöser für diese Scheibe.
+
+### Neuer Kanalname im ADR, vor dem Code (D9)
+
+Reihenfolge laut Kontextdokument: (1) ADR — legt `premium_sms` fest, (2)
+Settings-Datenebene, (3) Kanal-Code (Basisklasse + Premium + `sms.py`-Umbau,
+ein Commit), (4) Verdrahtung (Scheduler, Tier-Gate, Modell/Loader), (5)
+defensiver `CHANNEL_LIMITS`-Eintrag.
+
+### ENV-Sperre gegen `GZ_PREMIUM_SMS_REPLY_TO`
+
+`SettingsConfigDict(env_prefix="GZ_")` (`config.py:87`) gilt uniform für
+jedes deklarierte Feld; `extra="ignore"` (`config.py:90`) verschluckt
+undeklarierte Werte lautlos — `premium_sms_reply_to` muss aber deklariert
+sein, sonst verschwindet der Profilwert selbst lautlos. Ein
+`model_validator(mode="after")` prüft, ob `GZ_PREMIUM_SMS_REPLY_TO` im
+Prozess-Environment gesetzt ist, und bricht dann die Konstruktion mit
+`ValueError` ab — anders als `_resend_default_deny` (`:194-217`, stille
+Umlenkung), weil die Vorgabe „niemals editierbar" strenger ist als die
+Resend-Regel: ein stiller Reroute wäre hier selbst ein Verstoß gegen
+„niemals".
+
+## Expected Behavior
+
+- **Input:** Trip-Briefing-Auslösung wie bisher (`Go-Scheduler →
+  send_trip_report()`), kein neuer Trigger, kein neuer HTTP-Eingang.
+- **Output:** bei aktivem `send_premium_sms`, Premium-Tier und einer
+  gültigen, frischen (≤ 30 Tage) Rückadresse: ein POST an
+  `gateway.seven.io` mit `from=4916092172595`, `to=<gelernte Adresse>`,
+  `text=<report.sms_text>`. Sonst kein POST;
+  `blocked_channels["premium_sms"]` trägt den Grund.
+- **Side effects:** keine neue Persistenz, kein Schreiben irgendwo, keine
+  Änderung an S1s Lernpfad. `sent_channels`/`blocked_channels` im
+  `NotificationResult` sind die einzigen neuen beobachtbaren Zustände.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Premium-Nutzer hat eine gültige, frische gelernte Rückadresse UND `sms_from`/`GZ_SMS_FROM` sind bewusst auf eine andere Nummer gesetzt / When das Trip-Briefing über Premium-SMS versendet wird / Then trägt die tatsächlich abgesendete Nachricht als Absender ausnahmslos die feste Nummer `4916092172595` — die abweichende `sms_from`-Einstellung hat keinerlei Wirkung auf den Premium-Kanal.
+  - Prüfort: `payload["from"]` am lokalen HTTP-Stub (Vorbild `tests/tdd/test_issue_936_sms_stub.py`), NICHT das Settings-Objekt — die Zusicherung wirkt am ausgehenden POST, nicht am Konstruktor.
+  - Test: `tests/unit/test_premium_sms_versand.py::test_sender_is_fixed_number_regardless_of_sms_from`
+
+- **AC-2:** Given die gelernte Rückadresse eines Premium-Nutzers steht in dessen `user.json` UND `Settings.sms_to`/`GZ_SMS_TO` sind im selben Testlauf auf eine andere Nummer gesetzt / When das Briefing über Premium-SMS versendet wird / Then geht die Nachricht ausschließlich an die gelernte Rückadresse — `sms_to` wird für diesen Kanal an keiner Stelle gelesen.
+  - Prüfort: `payload["to"]` am HTTP-Stub, mit `GZ_SMS_TO` im Prozess-Environment bewusst widersprüchlich gesetzt.
+  - Test: `tests/unit/test_premium_sms_versand.py::test_recipient_comes_from_learned_reply_to_not_sms_to`
+
+- **AC-3:** Given ein Premium-Nutzer hat noch keine gelernte Rückadresse (`premium_sms_reply_to` leer) / When das Trip-Briefing versendet wird / Then geht keine Premium-SMS hinaus, kein HTTP-Aufruf findet statt, und der Grund ist im Versandergebnis unter dem Kanalnamen `premium_sms` als auswertbarer Text hinterlegt — nicht nur in einer Logzeile.
+  - Prüfort: doppelt gemessen — (a) der HTTP-Stub bleibt komplett unbenutzt (`stub.received == []`), (b) `NotificationResult.blocked_channels["premium_sms"]` ist gesetzt. Nur beide Messpunkte zusammen beweisen „ausbleibender Versand UND sichtbarer Grund".
+  - Test: `tests/unit/test_premium_sms_versand.py::test_empty_reply_to_blocks_send_with_visible_reason`
+
+- **AC-4:** Given ein Premium-Nutzer hat eine gelernte Rückadresse, deren Zeitstempel exakt eine Sekunde über der 30-Tage-Frist liegt / When das Briefing versendet wird / Then geht keine Premium-SMS hinaus und der Grund benennt die veraltete Rückadresse — unabhängig davon, dass die Nummer selbst syntaktisch gültig aussieht.
+  - Prüfort: wie AC-3, mit einer Fixture-`user.json`, deren `premium_sms_reply_at` bewusst auf `jetzt − 30 Tage − 1 Sekunde` gesetzt ist.
+  - Test: `tests/unit/test_premium_sms_versand.py::test_reply_to_older_than_ttl_blocks_send`
+
+- **AC-5:** Given ein Premium-Nutzer hat eine gelernte Rückadresse, deren Zeitstempel exakt eine Sekunde unter der 30-Tage-Frist liegt / When das Briefing versendet wird / Then geht die Premium-SMS regulär hinaus — die Frist blockiert nicht vorsorglich früher als spezifiziert.
+  - Prüfort: derselbe Stub, Fixture mit `premium_sms_reply_at = jetzt − 30 Tage + 1 Sekunde`. Zusammen mit AC-4 beweist dieser Kantentest, dass die Frist exakt bei 30 Tagen liegt, nicht ungefähr.
+  - Test: `tests/unit/test_premium_sms_versand.py::test_reply_to_just_within_ttl_still_sends`
+
+- **AC-6:** Given ein Trip-Briefing mit einer Extremwetter-Fixture (viele Warnungen/Token im SMS-Text) wird für einen Premium-Nutzer mit gültiger Rückadresse gerendert / When es über Premium-SMS versendet wird / Then ist der tatsächlich abgesendete Text bitidentisch mit `report.sms_text` und nicht länger als 160 Zeichen.
+  - Prüfort: `payload["text"]` am HTTP-Stub, verglichen mit dem von `TripReportFormatter.format_email()` tatsächlich erzeugten `report.sms_text` derselben Fixture — nicht mit einer im Test hart codierten Erwartungskonstante, sonst bliebe ein gemeinsamer Kopierfehler in Renderer und Test unentdeckt.
+  - Test: `tests/unit/test_premium_sms_versand.py::test_text_matches_sms_text_verbatim_under_extreme_weather`
+
+- **AC-7:** Given der Testcode läuft — wie jeder pytest-Lauf in einem Arbeitsordner — aus einer Testlauf-Herkunft (die Herkunftssperre vergleicht die Checkout-Wurzel **exakt** mit `/home/hem/gregor_zwanzig`, ein Worktree darunter gilt deshalb als Testlauf) / When Premium-SMS gesendet wird / Then wird ausschließlich der Sandbox-Key verwendet, und ist kein Sandbox-Key konfiguriert, bricht der Versand laut ab, bevor ein HTTP-Aufruf stattfindet — exakt wie beim bestehenden SMS-Kanal.
+  - Prüfort: `X-Api-Key`-Header am HTTP-Stub (Sandbox-Fall) bzw. `OutputConfigError` vor jedem Stub-Aufruf (Fehlerfall) — Vorbild `tests/tdd/test_channel_origin_guard_parity.py:131-144`, dort um `PremiumSmsOutput` erweitert.
+  - Test: `tests/tdd/test_channel_origin_guard_parity.py::test_premium_sms_test_origin_switches_to_sandbox_key`, `::test_premium_sms_test_origin_without_sandbox_key_hard_aborts`
+
+- **AC-8:** Given ein Nutzer hat Tier `standard` (nicht `premium`) UND `send_premium_sms` ist in seinem Trip aktiviert / When das Briefing-Versandfenster prüft, ob Premium-SMS gesendet werden darf / Then wird keine Premium-SMS versendet, obwohl derselbe Nutzer für den normalen SMS-Kanal (`sms_allowed`) als berechtigt gilt.
+  - Prüfort: End-zu-Ende gegen den HTTP-Stub mit einer `standard`-Tier-Fixture — der Stub darf keinen Request erhalten; zusätzlich eine reine Funktionsprüfung von `premium_sms_allowed("standard") is False` als zweiter, günstigerer Messpunkt.
+  - Test: `tests/unit/test_user_tier.py::test_premium_sms_allowed_excludes_standard_tier`, `tests/unit/test_premium_sms_versand.py::test_standard_tier_never_triggers_premium_sms_send`
+
+- **AC-9:** Given im Prozess-Environment ist `GZ_PREMIUM_SMS_REPLY_TO` **oder** `GZ_PREMIUM_SMS_REPLY_AT` gesetzt (Versuch, die gelernte Rückadresse oder deren Alter per Umgebungsvariable zu überschreiben) / When `Settings()` konstruiert wird / Then schlägt die Konstruktion laut fehl, statt den Wert stillschweigend zu übernehmen — die gelernte Rückadresse und ihr Zeitstempel bleiben ausschließlich über `user.json` erreichbar.
+  - Prüfort: die `Settings(...)`-Konstruktion selbst, je Variable ein eigener Fall — der Prüfort ist der Konstruktionszeitpunkt, nicht ein späterer Sendeversuch, weil ein still akzeptierter Wert sonst erst beim nächsten Versand sichtbar würde.
+  - **Beide Variablen, nicht nur der Empfänger:** Ein Override des Zeitstempels würde die 30-Tage-Frist künstlich auffrischen und damit den Versand an eine längst veraltete Nummer freigeben. Die Nummer wäre dabei formal korrekt, die Sperre aus AC-4 aber wirkungslos — eine Sperre, die man mit einer Umgebungsvariable abschalten kann, ist keine.
+  - Test: `tests/unit/test_config_premium_sms.py::test_env_override_for_reply_to_is_rejected_loudly`, `::test_env_override_for_reply_at_is_rejected_loudly`
+
+- **AC-10:** Given ein Nutzer hat `send_sms=false` und `send_premium_sms=true` (oder umgekehrt) / When das Briefing versendet wird / Then wird ausschließlich der jeweils aktivierte Kanal tatsächlich angesprochen — Premium-SMS ist vom bestehenden SMS-Kanal vollständig unabhängig schaltbar, keiner setzt den anderen voraus oder schließt ihn ein.
+  - Prüfort: HTTP-Stub gegen `send_trip_report()` mit allen vier Kombinationen aus `send_sms`/`send_premium_sms`, unterschieden am `to`-Wert der eingegangenen Requests (beide Kanäle senden an dieselbe seven.io-URL).
+  - Test: `tests/unit/test_premium_sms_versand.py::test_premium_sms_and_sms_are_independently_switchable`
+
+## Nachweisgrenzen — was diese Scheibe NICHT beweist
+
+Dass die Premium-SMS tatsächlich auf dem Garmin-Gerät ankommt und dort lesbar
+ist, ist mit den Mitteln dieser Scheibe **strukturell nicht** beweisbar:
+
+- Die Herkunftssperre (`origin_guard.running_origin()`) stuft jeden Pfad
+  außer `/home/hem/gregor_zwanzig` als Testlauf ein und erzwingt dann den
+  Sandbox-Key, der laut seven.io-Dokumentation nie eine echte SMS sendet und
+  nie kostet (AC-7 prüft genau diesen Mechanismus, nicht seine Umgehung).
+- `force_test` (`config.py:292-293`) sandboxiert Staging zusätzlich — jede
+  „Zustellung" dort ist folglich kein Beweis.
+- Der Staging-Scheduler führt derzeit keinen einzigen Job aus (`last_run:
+  null` für alle zehn Jobs, gemessen) — selbst ein scharf geschalteter
+  Versand würde auf Staging nie automatisch ausgelöst.
+- Ein bestandener Testlauf dieser Spec bedeutet ausschließlich: Nutzlast
+  korrekt, Empfänger korrekt aufgelöst, Fail-Closed wirksam, Guards greifen —
+  **nicht** „kommt auf dem Gerät an".
+
+Dieser Nachweis ist ausdrücklich als **SKIPPED** auszuweisen (nicht als
+bestanden zu behaupten) und gehört in **#1533** (Generalprobe, Frist 20.8.).
+
+## Mutations-Gegenprobe
+
+Pflicht laut Projektregel — je AC eine gezielte Verfälschung, die mindestens
+einen Test rot machen MUSS:
+
+| AC | Gezielte Verfälschung | Test, der dadurch rot werden MUSS |
+|---|---|---|
+| AC-1 | `_resolve_sender()` liefert `self._settings.sms_from` statt der festen Nummer | `test_sender_is_fixed_number_regardless_of_sms_from` |
+| AC-2 | `_resolve_recipient()` liest `self._settings.sms_to` statt `premium_sms_reply_to` | `test_recipient_comes_from_learned_reply_to_not_sms_to` |
+| AC-3 | Fail-Closed-Prüfung in `_resolve_recipient()` entfernt (leerer String wird durchgereicht) | `test_empty_reply_to_blocks_send_with_visible_reason` — Stub bekommt plötzlich einen Request |
+| AC-4/5 | `PREMIUM_SMS_REPLY_TTL` von 30 auf z. B. 300 Tage geändert | `test_reply_to_older_than_ttl_blocks_send` schlägt fehl, weil jetzt trotzdem gesendet wird — der Kantentest deckt genau diese Verschiebung auf |
+| AC-6 | Sendezweig übergibt `report.email_plain` statt `report.sms_text` | `test_text_matches_sms_text_verbatim_under_extreme_weather` |
+| AC-7 | `PremiumSmsOutput.send()` ruft `_guard_code_origin()` beim Erben nicht auf (Copy-Paste-Fehler) | `test_premium_sms_test_origin_without_sandbox_key_hard_aborts` |
+| AC-8 | `premium_sms_allowed()` delegiert an `sms_allowed()` statt eigener Tier-Prüfung | `test_premium_sms_allowed_excludes_standard_tier` |
+| AC-9 | ENV-Sperre-Validator entfernt/deaktiviert | `test_env_override_for_reply_to_is_rejected_loudly` |
+| AC-10 | Sendezweig prüft `request.send_sms or request.send_premium_sms` (ODER statt unabhängig) | `test_premium_sms_and_sms_are_independently_switchable` |
+
+## Known Limitations
+
+- **Die 30-Tage-Frist ist eine begründete Setzung, kein Messwert (D6).**
+  Widerlegt durch: (a) reale Touren länger als 30 Tage — dann müsste die
+  Frist trip-gebunden statt fix sein; (b) ein Messwert, dass seven.io/Garmin
+  die Rufnummer schneller (oder deutlich langsamer) neu vergibt als
+  angenommen. Ohne eine solche Messung bleibt 30 Tage der PO-entschiedene
+  Wert (2026-08-10).
+- **Der `sms.py`-Refactor auf die gemeinsame Basisklasse ist das einzige
+  Bestandsrisiko dieser Scheibe** — er berührt den produktiven
+  SMS-Versandweg. Abgesichert durch die bestehende SMS-Testsuite (u. a.
+  `test_channel_origin_guard_parity.py`), die unverändert grün bleiben muss;
+  `SMSOutput.send()` darf sich im Verhalten nicht ändern, nur in der
+  internen Struktur.
+- **Die ENV-Sperre deckt beide Felder ab** (`GZ_PREMIUM_SMS_REPLY_TO` und
+  `GZ_PREMIUM_SMS_REPLY_AT`, AC-9). Sie wurde beim Schreiben der Spec
+  bewusst über die wörtliche PO-Vorgabe („Empfänger niemals aus der
+  Konfiguration") hinaus auf den Zeitstempel ausgedehnt, weil eine
+  Verfallsfrist, die per Umgebungsvariable auffrischbar ist, keine Sperre
+  wäre. Nicht abgedeckt bleibt der Fall, dass jemand die Datei `user.json`
+  direkt bearbeitet — das ist Dateisystem-Zugriff auf dem Server und liegt
+  außerhalb dessen, was ein Anwendungs-Wächter leisten kann.
+- **Kein Frontend, keine Sichtbarkeit für den Nutzer.** `send_premium_sms`
+  ist in dieser Scheibe nirgends im UI schaltbar (folgt in S3).
+- **Go bleibt unverändert (D8).** `send_premium_sms` lebt ausschließlich im
+  freien `report_config`-Feld, noch kein eigenes Struct-Feld.
+- **Der `CHANNEL_LIMITS`-Eintrag ist reine Vorsorge.** Der Briefing-Pfad
+  liest ihn nicht (s. Implementation Details) — relevant erst, sobald ein
+  künftiger Aufrufer (S3, Vergleichspfad) den Kanal dort nachschlägt.
+- **Der S1-Lern-/Rückkanal-Mechanismus ist unverändert** und wird von dieser
+  Scheibe nicht erneut geprüft — die dortigen ACs bleiben die alleinige
+  Grundlage für „gelernte Rückadresse korrekt".
+
+## Test Coverage
+
+- `tests/unit/test_premium_sms_versand.py` — echter lokaler HTTP-Stub
+  (`http.server` auf `127.0.0.1`, Vorbild `test_issue_936_sms_stub.py`), kein
+  Mock, kein `patch()`:
+  - `test_sender_is_fixed_number_regardless_of_sms_from` (AC-1)
+  - `test_recipient_comes_from_learned_reply_to_not_sms_to` (AC-2)
+  - `test_empty_reply_to_blocks_send_with_visible_reason` (AC-3)
+  - `test_reply_to_older_than_ttl_blocks_send` (AC-4)
+  - `test_reply_to_just_within_ttl_still_sends` (AC-5)
+  - `test_text_matches_sms_text_verbatim_under_extreme_weather` (AC-6)
+  - `test_standard_tier_never_triggers_premium_sms_send` (AC-8)
+  - `test_premium_sms_and_sms_are_independently_switchable` (AC-10)
+- `tests/unit/test_config_premium_sms.py`:
+  - `test_env_override_for_reply_to_is_rejected_loudly` (AC-9)
+  - Settings-Feld-Deklaration, `with_user_profile()`-Übernahme
+- `tests/unit/test_user_tier.py` (MODIFY):
+  - `test_premium_sms_allowed_excludes_standard_tier` (AC-8)
+- `tests/tdd/test_channel_origin_guard_parity.py` (MODIFY):
+  - `test_premium_sms_test_origin_switches_to_sandbox_key` (AC-7)
+  - `test_premium_sms_test_origin_without_sandbox_key_hard_aborts` (AC-7)
+
+Testdateien liegen bewusst unter `tests/unit/` (Ausnahme: die Erweiterung
+der bestehenden `tests/tdd/test_channel_origin_guard_parity.py`) —
+`touched_tests_gate.py:37` sucht nur unter `tests/unit/`. Namen nach
+Verhalten, nicht nach Issue-Nummer.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** **0049** — `docs/adr/0049-premium-sms-vierter-kanal.md`
+  (nächste freie Nummer, gemessen: höchster Bestand ist 0048).
+- **Rationale:** ADR-0004 legt fest: „Die unterstützten Kanäle sind nur noch
+  E-Mail · Telegram · SMS." Die PO-Vorgabe verlangt Premium-SMS als eigenen,
+  vierten Kanal `premium_sms` — nach CLAUDE.md-Regel „Abweichung ⇒ neues
+  ADR" schreibt das neue ADR ADR-0004 in diesem Punkt fort, statt es
+  stillschweigend zu unterlaufen. Es legt den Kanalnamen fest, **bevor** der
+  Code ihn trägt (Reihenfolge-Punkt 1).
+
+## Changelog
+
+- 2026-08-10: Initial spec erstellt — Issue #1676, Scheibe S2a
+  (Trip-Briefing als Premium-SMS)

--- a/internal/handler/fix_go_rmw_merge_1082_1103_test.go
+++ b/internal/handler/fix_go_rmw_merge_1082_1103_test.go
@@ -86,6 +86,13 @@ func TestUpdateTrip_PartialReportConfig_MergesFields(t *testing.T) {
 			"enabled":      true,
 			"email_format": "full",
 			"send_email":   true,
+			// Issue #1676 S2a: der vierte Kanal liegt als FREIER Schluessel in
+			// report_config (kein Struct-Feld). Die heutige Oberflaeche sendet
+			// ihn beim Speichern nicht mit — dann darf er auch nicht
+			// verschwinden. Gegenstueck: alert_channels wird als Ganzobjekt
+			// ersetzt (trip.go, AlertChannels), dort waere genau das ein
+			// stiller Kanal-Abschalter.
+			"send_premium_sms": true,
 		},
 	}
 	if err := s.SaveTrip(&trip); err != nil {
@@ -119,6 +126,11 @@ func TestUpdateTrip_PartialReportConfig_MergesFields(t *testing.T) {
 	}
 	if got.ReportConfig["send_email"] != true {
 		t.Errorf("report_config.send_email lost/changed: got %v", got.ReportConfig["send_email"])
+	}
+	if got.ReportConfig["send_premium_sms"] != true {
+		t.Errorf("report_config.send_premium_sms lost/changed: got %v — ein "+
+			"Speichervorgang ohne das Flag hat den kostenpflichtigen Kanal "+
+			"still abgeschaltet", got.ReportConfig["send_premium_sms"])
 	}
 }
 

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -13,18 +13,44 @@ import logging
 import os
 import sys
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
 
+# Issue #1676 S2a (ADR-0049): die gelernte Premium-SMS-Rueckadresse und ihr
+# Zeitstempel duerfen NIE aus der Umgebung kommen -- nur aus user.json.
+_PREMIUM_SMS_ENV_VARS = ("GZ_PREMIUM_SMS_REPLY_TO", "GZ_PREMIUM_SMS_REPLY_AT")
+_PREMIUM_SMS_FIELDS = ("premium_sms_reply_to", "premium_sms_reply_at")
+
 
 def _in_pytest() -> bool:
     """True, wenn der aktuelle Prozess ein pytest-Lauf ist (Issue #1122)."""
     return "PYTEST_CURRENT_TEST" in os.environ or "pytest" in sys.modules
+
+
+def _parse_learned_timestamp(raw: Any) -> Optional[datetime]:
+    """RFC3339-Zeitstempel aus `user.json` als zeitzonenbehaftetes datetime.
+
+    Der Go-Schreiber (`internal/handler/premium_sms_connect.go`) legt UTC mit
+    `Z`-Endung ab, das `fromisoformat` aelterer Python-Versionen kennt nur
+    `+00:00`. Ohne Zeitzone gelesene Werte gelten als UTC — ein naiver
+    Zeitstempel wuerde beim Fristvergleich je nach Serverzeit um Stunden
+    verrutschen. Unlesbares ergibt `None` (fail-closed beim Aufrufer).
+    """
+    if isinstance(raw, datetime):
+        return raw if raw.tzinfo else raw.replace(tzinfo=timezone.utc)
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
 
 
 def is_test_user_id(user_id: str, data_dir: str = "data") -> bool:
@@ -161,6 +187,21 @@ class Settings(BaseSettings):
     sms_from: Optional[str] = Field(default=None, description="SMS sender ID or number")
     sms_to: Optional[str] = Field(default=None, description="SMS recipient phone number")
 
+    # Premium-SMS (Garmin inReach, Issue #1676 S2a, ADR-0049): die von S1
+    # gelernte Rueckadresse des Geraets und der Zeitpunkt, zu dem sie gelernt
+    # wurde. Einzige Quelle ist user.json (with_user_profile); als Settings-
+    # Feld deklariert, weil extra="ignore" undeklarierte Werte lautlos
+    # verschluckt -- der Profilwert waere sonst spurlos verschwunden. Ein
+    # GZ_-Override ist per _premium_sms_reply_env_deny gesperrt.
+    premium_sms_reply_to: Optional[str] = Field(
+        default=None,
+        description="Gelernte Garmin-Rueckadresse — NUR aus user.json (nie GZ_*)",
+    )
+    premium_sms_reply_at: Optional[datetime] = Field(
+        default=None,
+        description="Zeitpunkt, zu dem die Rueckadresse gelernt wurde (30-Tage-Frist)",
+    )
+
     # Telegram settings (for telegram channel via Bot API)
     telegram_bot_token: str = Field(default="", description="Telegram Bot API token from @BotFather")
     telegram_chat_id: str = Field(default="", description="Telegram chat ID of recipient")
@@ -190,6 +231,42 @@ class Settings(BaseSettings):
                     "Wartezeit vor dem einen Wiederholversuch "
                     "(env: GZ_TELEGRAM_RETRY_AFTER_CAP_SECONDS)",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _premium_sms_reply_env_deny(cls, data: Any) -> Any:
+        """Issue #1676 S2a (AC-9, ADR-0049): die gelernte Rueckadresse und ihr
+        Alter sind per Umgebungsvariable NICHT setzbar.
+
+        Abbruch statt Umlenkung (anders als `_resend_default_deny` darunter):
+        die Vorgabe lautet „niemals editierbar" — ein stiller Reroute waere
+        hier selbst der Verstoss. Ein Override von
+        `GZ_PREMIUM_SMS_REPLY_AT` wuerde ausserdem die 30-Tage-Frist
+        kuenstlich auffrischen und damit den Versand an eine laengst neu
+        vergebene Fremdnummer freigeben; eine Frist, die man mit einer
+        Umgebungsvariable abschalten kann, ist keine.
+
+        `mode="before"` statt `mode="after"`, gemessen und nicht geraten:
+        pydantic haengt an eine im Validator geworfene `ValueError` den
+        Eingabewert an (`input_value={...}`). In einem `after`-Validator ist
+        das die Quell-Zuordnung MIT der injizierten Rufnummer — die
+        Fehlermeldung wuerde die Nummer unmaskiert ausplaudern (S1: nur
+        maskiert protokollieren). Hier werden die beiden Werte deshalb VOR dem
+        Abbruch aus der Zuordnung entfernt; die Meldung nennt nur die
+        verbotene Variable.
+        """
+        offenders = [name for name in _PREMIUM_SMS_ENV_VARS if os.environ.get(name)]
+        if not offenders:
+            return data
+        if isinstance(data, dict):
+            for field_name in _PREMIUM_SMS_FIELDS:
+                data.pop(field_name, None)
+        raise ValueError(
+            "Premium-SMS-Rueckadresse ist nicht konfigurierbar (Issue #1676, "
+            f"ADR-0049): {', '.join(offenders)} im Prozess-Environment gesetzt. "
+            "Die gelernte Rueckadresse und ihr Zeitstempel kommen "
+            "ausschliesslich aus user.json — Variable entfernen.",
+        )
 
     @model_validator(mode="after")
     def _resend_default_deny(self) -> "Settings":
@@ -311,6 +388,16 @@ class Settings(BaseSettings):
             overrides["telegram_chat_id"] = profile["telegram_chat_id"]
         if profile.get("sms_to"):
             overrides["sms_to"] = profile["sms_to"]
+        # Issue #1676 S2a: gelernte Premium-SMS-Rueckadresse (S1 schreibt sie
+        # hier hinein). Der Zeitstempel wird zu einem zeitzonenbehafteten
+        # datetime aufgeloest — model_copy() unten umgeht die Feld-Validierung,
+        # ein roher Text kaeme sonst beim Fristvergleich an. Laesst er sich
+        # nicht lesen, bleibt das Feld leer und der Kanal blockt fail-closed.
+        if profile.get("premium_sms_reply_to"):
+            overrides["premium_sms_reply_to"] = profile["premium_sms_reply_to"]
+        reply_at = _parse_learned_timestamp(profile.get("premium_sms_reply_at"))
+        if reply_at is not None:
+            overrides["premium_sms_reply_at"] = reply_at
 
         if not overrides:
             return base
@@ -325,6 +412,15 @@ class Settings(BaseSettings):
             self.sms_to,
         ])
 
+    # Issue #1676 S2a, Adversary-Fund F003: hier stand ein
+    # `can_send_premium_sms()`. Es ist ENTFERNT und kommt nicht zurueck, solange
+    # es keinen Wirkort hat: Die Sendebereitschaft des Premium-Kanals
+    # entscheidet ausschliesslich `PremiumSmsOutput._resolve_recipient()` zur
+    # Sendezeit (Spec D3) — nur dort ist die 30-Tage-Frist pruefbar und nur von
+    # dort kommt der sichtbare Grund (Spec D4). Eine zweite, namentlich an
+    # `can_send_sms()`/`can_send_telegram()` erinnernde Bereitschaftsfrage
+    # (die im Versandzweig SEHR WOHL vorgeschaltet sind) laedt dazu ein, sie
+    # fuer den wirksamen Schutz zu halten und den echten zu entfernen.
     def can_send_telegram(self) -> bool:
         """Check if Telegram configuration is complete."""
         return bool(self.telegram_bot_token and self.telegram_chat_id)
@@ -332,6 +428,9 @@ class Settings(BaseSettings):
     _SENSITIVE_FIELDS = {
         "smtp_pass", "imap_pass", "test_smtp_pass", "test_imap_pass",
         "seven_api_key", "telegram_bot_token",
+        # Issue #1676: die gelernte Geraete-Rufnummer gehoert nach S1-Vorgabe
+        # nur maskiert in Protokolle — repr(settings) landet in Logzeilen.
+        "premium_sms_reply_to",
     }
 
     def __repr__(self) -> str:

--- a/src/app/loader.py
+++ b/src/app/loader.py
@@ -574,6 +574,9 @@ def _parse_trip(data: Dict[str, Any]) -> Trip:
             send_email=rc_data.get("send_email", True),
             send_sms=rc_data.get("send_sms", False),
             send_telegram=rc_data.get("send_telegram", False),
+            # Issue #1676 S2a (Spec D8): der Go-Handler legt das Flag als
+            # freien Schluessel in `report_config` ab — hier wird es gelesen.
+            send_premium_sms=rc_data.get("send_premium_sms", False),
             alert_on_changes=rc_data.get("alert_on_changes", True),
             change_threshold_temp_c=rc_data.get("change_threshold_temp_c", 5.0),
             change_threshold_wind_kmh=rc_data.get("change_threshold_wind_kmh", 20.0),
@@ -1597,6 +1600,9 @@ def _trip_to_dict(trip: Trip) -> Dict[str, Any]:
             "send_email": trip.report_config.send_email,
             "send_sms": trip.report_config.send_sms,
             "send_telegram": trip.report_config.send_telegram,
+            # Issue #1676 S2a: mitgeschrieben, damit ein per Go gesetztes Flag
+            # den Python-Schreibweg ueberlebt (Read-Modify-Write, kein Replace).
+            "send_premium_sms": trip.report_config.send_premium_sms,
             "alert_on_changes": trip.report_config.alert_on_changes,
             "change_threshold_temp_c": trip.report_config.change_threshold_temp_c,
             "change_threshold_wind_kmh": trip.report_config.change_threshold_wind_kmh,

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -970,6 +970,9 @@ class TripReportConfig:
     send_email: bool = True
     send_sms: bool = False
     send_telegram: bool = False
+    # Issue #1676 S2a (ADR-0049): vierter Kanal, unabhaengig von send_sms
+    # schaltbar. Startwert AUS — der Kanal kostet und braucht Premium-Tier.
+    send_premium_sms: bool = False
 
     # Alerts
     alert_on_changes: bool = True

--- a/src/output/channels/base.py
+++ b/src/output/channels/base.py
@@ -63,6 +63,36 @@ class OutputConfigError(OutputError):
     pass
 
 
+class ChannelBlockedError(OutputConfigError):
+    """Sperre mit maschinenlesbarem Grund: Prosatext UND stabiler Kurzschluessel.
+
+    Warum an der Ausnahme und nicht als weiteres Ergebnisfeld beim Aufrufer:
+    ein Aufrufer, der den Sperrgrund WEITERBUCHEN muss — das Alarm-Protokoll
+    (`services/alert_log.py`, `channels_not_sent`) — sieht ausschliesslich die
+    Ausnahme des Kanals; ein Feld an `NotificationResult` erreicht ihn nie.
+    Und er darf den Fall nicht am deutschen Prosatext erkennen muessen: ein
+    solcher Vergleich bricht still beim ersten Umformulieren.
+
+    `reason_code` ist deshalb PFLICHT (keyword-only, ohne Vorgabewert) — eine
+    Sperre ohne Kurzschluessel soll beim Erzeugen auffallen, nicht spaeter
+    beim Auswerten leer sein. Die Werte folgen dem Vokabular der bestehenden
+    Kurzschluessel in `alert_log.py` (`channel_disabled`, `delivery_failed`,
+    `below_channel_threshold`) und stehen als Konstanten beim jeweiligen Kanal.
+
+    `OutputError`/`OutputConfigError` bleiben unveraendert: bestehende
+    `except OutputConfigError`-Zweige fangen diese Unterklasse mit, `str(exc)`
+    liefert weiter den Prosatext, und Kanaele ohne Kurzschluessel aendern sich
+    nicht. Auslesen deshalb einheitlich und gefahrlos auch fuer Ausnahmen
+    ohne Kurzschluessel:
+
+        >>> code = getattr(exc, "reason_code", None)
+    """
+
+    def __init__(self, channel: str, message: str, *, reason_code: str) -> None:
+        self.reason_code = reason_code
+        super().__init__(channel, message)
+
+
 def get_channel(name: str, settings: "Settings") -> OutputChannel:
     """
     Factory function to create output channel instances.
@@ -93,6 +123,11 @@ def get_channel(name: str, settings: "Settings") -> OutputChannel:
     elif name == "sms":
         from output.channels.sms import SMSOutput
         return SMSOutput(settings)
+    elif name == "premium_sms":
+        # Issue #1676 S2a (ADR-0049): vierter Kanal, damit die CLI ihn
+        # genauso ansprechen kann wie die drei bestehenden.
+        from output.channels.premium_sms import PremiumSmsOutput
+        return PremiumSmsOutput(settings)
     elif name == "telegram":
         from output.channels.telegram import TelegramOutput
         return TelegramOutput(settings)

--- a/src/output/channels/premium_sms.py
+++ b/src/output/channels/premium_sms.py
@@ -1,0 +1,107 @@
+"""Premium-SMS (Garmin inReach) — vierter Versandkanal, Issue #1676 S2a.
+
+ADR-0049 legt den Kanalnamen `premium_sms` und die vier Eigenheiten fest, die
+ihn vom normalen SMS-Kanal unterscheiden:
+
+* **Absender fest.** Nur an unsere Dienstnummer kann das Satellitengeraet
+  antworten — `sms_from` hat auf diesen Kanal keine Wirkung.
+* **Empfaenger ausschliesslich die gelernte Rueckadresse** aus `user.json`
+  (S1 lernt sie beim Empfang). `sms_to` wird hier nie gelesen.
+* **Fail-closed mit Grund.** Fehlt die Rueckadresse oder ist sie zu alt, geht
+  keine Nachricht hinaus. Der Grund verlaesst den Kanal als
+  `ChannelBlockedError` — Prosatext fuer den Menschen PLUS Kurzschluessel
+  (`reason_code`) fuer den Aufrufer — und landet beim Briefing-Aufrufer in
+  `NotificationResult.blocked_channels`; ein stilles Ausbleiben ist bei
+  diesem Kanal ausdruecklich verboten (Spec D3/D4).
+* **Berechtigung nur `premium`** — das prueft `services.user_tier.
+  premium_sms_allowed()` am Aufrufort, nicht dieser Kanal.
+
+Der Nachrichtentext ist unveraendert `report.sms_text` (Spec D5): kein
+eigener Renderer, damit SMS und Premium-SMS inhaltlich nicht auseinander
+laufen.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from app.origin_guard import running_origin
+from output.channels.base import ChannelBlockedError
+from output.channels.seven_io_base import SevenIoChannelBase
+
+#: Unsere feste seven.io-Dienstnummer. Kanal-Eigenschaft, keine Einstellung.
+PREMIUM_SMS_SENDER = "4916092172595"
+
+# Kurzschluessel der beiden Sperrfaelle. Sie stehen NEBEN dem Prosatext, nicht
+# an seiner Stelle: der Text sagt einem Menschen, was los ist, der
+# Kurzschluessel laesst sich buchen und vergleichen. Vokabular und Schreibweise
+# wie die bestehenden Gruende in `services/alert_log.py` (`channel_disabled`,
+# `delivery_failed`, `below_channel_threshold`), damit der Alarmpfad sie
+# unveraendert nach `channels_not_sent` schreiben kann.
+BLOCK_REASON_NO_REPLY_ADDRESS = "premium_sms_no_reply_address"
+BLOCK_REASON_REPLY_ADDRESS_STALE = "premium_sms_reply_address_stale"
+
+#: Verfallsfrist der gelernten Rueckadresse (Spec D6, PO-Entscheid 2026-08-10).
+#: Begruendete Setzung, kein Messwert: zu kurz heisst Briefing-Ausfall mitten
+#: auf der Tour, zu lang heisst kostenpflichtige SMS an eine Nummer, die Garmin
+#: inzwischen einem fremden Geraet zugeteilt hat — mit HTTP 200 als
+#: Scheinerfolg. Widerlegungsbedingungen: Spec „Known Limitations".
+PREMIUM_SMS_REPLY_TTL = timedelta(days=30)
+
+
+class PremiumSmsOutput(SevenIoChannelBase):
+    """Sendet das Trip-Briefing als Premium-SMS an das Garmin-Geraet."""
+
+    CHANNEL_NAME = "premium_sms"
+
+    def _origin(self) -> str:
+        """Herkunft DIESES Moduls — siehe `SevenIoChannelBase._origin`."""
+        return running_origin(Path(__file__))
+
+    def _resolve_sender(self) -> str:
+        return PREMIUM_SMS_SENDER
+
+    def _resolve_recipient(self) -> str:
+        """Die gelernte Rueckadresse — oder ein benannter Abbruch.
+
+        Beide Faelle sind erst zur Sendezeit final bekannt und deshalb hier
+        geprueft, nicht am Aufrufort (Spec D3). Jeder Abbruch traegt seinen
+        Kurzschluessel mit, damit ein Aufrufer die zwei Faelle ohne
+        Textvergleich unterscheiden kann.
+        """
+        reply_to = self._settings.premium_sms_reply_to
+        reply_at = self._settings.premium_sms_reply_at
+        if not reply_to or reply_at is None:
+            raise ChannelBlockedError(
+                self.name,
+                "keine gelernte Rueckadresse vorhanden — das Geraet hat sich "
+                "noch nie gemeldet (Rueckkanal, Issue #1676 S1); ohne sie ist "
+                "kein Empfaenger bekannt.",
+                reason_code=BLOCK_REASON_NO_REPLY_ADDRESS,
+            )
+        age = _now() - _as_aware(reply_at)
+        if age > PREMIUM_SMS_REPLY_TTL:
+            raise ChannelBlockedError(
+                self.name,
+                "gelernte Rueckadresse ist veraltet: zuletzt vor "
+                f"{age.days} Tagen gelernt, erlaubt sind "
+                f"{PREMIUM_SMS_REPLY_TTL.days} Tage. Garmin kann die Nummer "
+                "inzwischen einem fremden Geraet zugeteilt haben — Versand "
+                "abgebrochen, bis sich das Geraet wieder meldet.",
+                reason_code=BLOCK_REASON_REPLY_ADDRESS_STALE,
+            )
+        return reply_to
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _as_aware(stamp: datetime) -> datetime:
+    """Zeitstempel ohne Zeitzone gilt als UTC (so legt Go ihn ab).
+
+    Ohne diese Umschreibung wuerde der Fristvergleich mit einem naiven
+    Zeitstempel abbrechen, statt zu blocken — ein Absturz statt einer
+    Entscheidung.
+    """
+    return stamp if stamp.tzinfo else stamp.replace(tzinfo=timezone.utc)

--- a/src/output/channels/seven_io_base.py
+++ b/src/output/channels/seven_io_base.py
@@ -1,0 +1,187 @@
+"""Gemeinsame Basis der beiden seven.io-Kanaele: SMS und Premium-SMS.
+
+Issue #1676 S2a (ADR-0049, Spec D1). Beide Kanaele sprechen dasselbe
+Gateway, unterscheiden sich aber fachlich in Absender, Empfaenger,
+Fehlverhalten und Berechtigung. Gemeinsam bleiben genau zwei Dinge, und die
+liegen deshalb HIER, ein einziges Mal:
+
+* die beiden Sicherheitssperren — Test-Modus-Sandbox-Key (#1336) und
+  Herkunftssperre (#1476),
+* der HTTP-Transport samt Antwort-Auswertung.
+
+Warum eine gemeinsame Basis und keine Kopie: der Paritaetstest
+`tests/tdd/test_channel_origin_guard_parity.py` prueft die Sperren
+**namentlich je Klasse** — eine in einer Kopie vergessene Sperre faellt der
+Testsuite nicht auf. Eine Kopie haette also genau die Vergessbarkeit
+verdoppelt, die die Sperren verhindern sollen.
+
+Die Unterklassen fuellen nur `_resolve_sender()` / `_resolve_recipient()`
+(und bei Bedarf `_validate_config()`).
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import httpx
+
+from app.config import Settings
+from app.origin_guard import running_origin
+from output.channels.base import OutputConfigError, OutputError
+
+logger = logging.getLogger(__name__)
+
+
+def mask_number(number: Optional[str]) -> str:
+    """Rufnummer fuer Protokolle: nur die letzten drei Stellen.
+
+    Die gelernte Garmin-Rueckadresse darf nach S1-Vorgabe nur maskiert in
+    Logzeilen erscheinen; fuer die normale SMS-Nummer gilt dasselbe Mass.
+    """
+    if not number:
+        return "<leer>"
+    return f"…{number[-3:]}" if len(number) > 3 else "…"
+
+
+class SevenIoChannelBase:
+    """Template-Method fuer Kanaele, die ueber das seven.io-Gateway senden.
+
+    Implementiert das OutputChannel-Protokoll: `send(subject, body)`.
+    `subject` wird ignoriert — eine SMS hat kein Betreff-Feld.
+    Zeitgrenze 10 s; ein Fehlschlag wirft `OutputError`.
+    """
+
+    #: Kanalname (`OutputChannel.name`) — von jeder Unterklasse zu setzen.
+    CHANNEL_NAME = "seven_io"
+
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+        self._validate_config()
+
+    @property
+    def name(self) -> str:
+        return self.CHANNEL_NAME
+
+    # ------------------------------------------------------------------
+    # Von den Kanaelen zu fuellen
+    # ------------------------------------------------------------------
+
+    def _validate_config(self) -> None:
+        """Transport-Voraussetzungen. Unterklassen verscharfen das.
+
+        Bewusst NUR Gateway und Schluessel: ob ein Ziel vorliegt, entscheidet
+        `_resolve_recipient()` zur Sendezeit — bei Premium-SMS ist das erst
+        dort final bekannt (Spec D3).
+        """
+        if not (self._settings.sms_gateway_url and self._settings.seven_api_key):
+            raise OutputConfigError(
+                self.name,
+                "seven.io nicht konfiguriert: sms_gateway_url und seven_api_key "
+                "sind Pflichtfelder",
+            )
+
+    def _resolve_sender(self) -> Optional[str]:
+        """Absender; `None` laesst das Gateway seinen Standard verwenden."""
+        raise NotImplementedError
+
+    def _resolve_recipient(self) -> str:
+        """Empfaenger. Wirft `OutputConfigError`, wenn kein Versand erlaubt ist."""
+        raise NotImplementedError
+
+    def _origin(self) -> str:
+        """Herkunft DIESES Kanal-Moduls (Issue #1476).
+
+        Die Unterklassen ueberschreiben das mit `running_origin(Path(__file__))`
+        aus ihrem EIGENEN Modul. Zwei Gruende, beide inhaltlich: die Sperre
+        fragt nach der Herkunft des Kanal-Codes, nicht nach der dieser
+        Basisdatei — und Tests, die eine Prod-Herkunft vortaeuschen muessen
+        (`monkeypatch.setattr(sms_mod, "running_origin", …)`), setzen genau
+        dort an.
+        """
+        return running_origin(Path(__file__))
+
+    # ------------------------------------------------------------------
+    # Sicherheitssperren — gelten fuer JEDEN seven.io-Kanal
+    # ------------------------------------------------------------------
+
+    def _guard_test_mode_sandbox_key(self) -> None:
+        """Bedingungsloser Guard (Issue #1336, Vorbild telegram.py #1288): im
+        Test-Modus (is_test_mode=True) ist AUSSCHLIESSLICH der konfigurierte
+        seven.io-Sandbox-Key erlaubt. Faengt die Fallback-Luecke aus
+        config.py::for_testing() ab: fehlt seven_sandbox_key, bleibt
+        seven_api_key sonst unveraendert der Prod-Key.
+        """
+        if not self._settings.is_test_mode:
+            return
+        sandbox_key = self._settings.seven_sandbox_key
+        active = self._settings.seven_api_key
+        if not sandbox_key or active != sandbox_key:
+            raise OutputConfigError(
+                self.name,
+                "Test-Modus aktiv, aber seven_api_key ist nicht der "
+                "Sandbox-Zugang (GZ_SEVEN_SANDBOX_KEY) — Versand blockiert "
+                "(Issue #1336).",
+            )
+
+    def _guard_code_origin(self) -> str:
+        """Herkunftssperre (Issue #1476, AC-6 — Vorbild
+        telegram.py::_guard_code_origin): bei Testlauf-Herkunft ist der
+        Prod-API-Key unzulaessig. Der Sandbox-Key sendet laut seven.io-Doku
+        NIE eine echte SMS ("sendet nie, kostet nie") und ist damit der
+        sichere Ersatz -- keine Rufnummer muss umgeschaltet werden.
+        """
+        if self._origin() != "test":
+            return self._settings.seven_api_key
+        sandbox_key = self._settings.seven_sandbox_key
+        if not sandbox_key:
+            raise OutputConfigError(
+                self.name,
+                "Herkunftssperre (Issue #1476): Code laeuft aus einem "
+                "Testlauf-Verzeichnis, aber kein Sandbox-Key konfiguriert "
+                "(GZ_SEVEN_SANDBOX_KEY) -- Versand abgebrochen.",
+            )
+        if self._settings.seven_api_key != sandbox_key:
+            logger.warning(
+                "Herkunftssperre (Issue #1476): Testlauf-Herkunft erkannt "
+                "-- SMS-Key auf den Sandbox-Key umgeschaltet.",
+            )
+        return sandbox_key
+
+    # ------------------------------------------------------------------
+    # Transport
+    # ------------------------------------------------------------------
+
+    def send(self, subject: str, body: str) -> None:
+        """Sende `body` ueber das seven.io-Gateway. `subject` wird ignoriert.
+
+        Reihenfolge ist Teil der Zusicherung: beide Sperren laufen
+        BEDINGUNGSLOS und VOR jeder Ziel-Auflosung, damit kein Kanal am
+        Sandbox-Zwang vorbeikommt.
+        """
+        self._guard_test_mode_sandbox_key()
+        api_key = self._guard_code_origin()
+        recipient = self._resolve_recipient()
+        sender = self._resolve_sender()
+
+        payload: dict[str, str] = {"to": recipient, "text": body}
+        if sender:
+            payload["from"] = sender
+
+        response = httpx.post(
+            self._settings.sms_gateway_url,
+            headers={"X-Api-Key": api_key},
+            data=payload,
+            timeout=10,
+        )
+        if response.status_code != 200:
+            raise OutputError(
+                self.name,
+                f"seven.io HTTP {response.status_code}: {response.text[:200]}",
+            )
+        status_code = response.text.strip()
+        if status_code != "100":
+            raise OutputError(self.name, f"seven.io Fehler-Code: {status_code!r}")
+        logger.info(
+            "%s an %s ueber seven.io gesendet", self.name, mask_number(recipient),
+        )

--- a/src/output/channels/sms.py
+++ b/src/output/channels/sms.py
@@ -1,102 +1,42 @@
 """SMS output channel via seven.io HTTP API."""
-import logging
 from pathlib import Path
+from typing import Optional
 
-import httpx
-
-from app.config import Settings
 from app.origin_guard import running_origin
-from output.channels.base import OutputConfigError, OutputError
+from output.channels.base import OutputConfigError
+from output.channels.seven_io_base import SevenIoChannelBase
 
-logger = logging.getLogger(__name__)
 
-
-class SMSOutput:
+class SMSOutput(SevenIoChannelBase):
     """Sends SMS via seven.io REST API.
 
     Implements the OutputChannel protocol: send(subject, body).
     subject is ignored — SMS has no subject field.
     Uses a 10s timeout; on failure raises OutputError.
+
+    Issue #1676 S2a: Sicherheitssperren und HTTP-Transport liegen jetzt in
+    `SevenIoChannelBase` — dieselbe Basis traegt den vierten Kanal
+    (`premium_sms`), damit die beiden Sperren genau einmal existieren
+    (ADR-0049). Das Verhalten dieses Kanals ist dadurch unveraendert: Ziel
+    bleibt `sms_to`, `from` wird weiterhin nur gesetzt, wenn `sms_from`
+    gefuellt ist.
     """
 
-    def __init__(self, settings: Settings) -> None:
-        if not settings.can_send_sms():
+    CHANNEL_NAME = "sms"
+
+    def _validate_config(self) -> None:
+        if not self._settings.can_send_sms():
             raise OutputConfigError(
                 "sms",
                 "SMS nicht konfiguriert: sms_api_key und sms_to sind Pflichtfelder",
             )
-        self._settings = settings
 
-    @property
-    def name(self) -> str:
-        return "sms"
+    def _origin(self) -> str:
+        """Herkunft DIESES Moduls — siehe `SevenIoChannelBase._origin`."""
+        return running_origin(Path(__file__))
 
-    def _guard_test_mode_sandbox_key(self) -> None:
-        """Bedingungsloser Guard (Issue #1336, Vorbild telegram.py #1288): im
-        Test-Modus (is_test_mode=True) ist AUSSCHLIESSLICH der konfigurierte
-        seven.io-Sandbox-Key erlaubt. Faengt die Fallback-Luecke aus
-        config.py::for_testing() ab: fehlt seven_sandbox_key, bleibt
-        seven_api_key sonst unveraendert der Prod-Key.
-        """
-        if not self._settings.is_test_mode:
-            return
-        sandbox_key = self._settings.seven_sandbox_key
-        active = self._settings.seven_api_key
-        if not sandbox_key or active != sandbox_key:
-            raise OutputConfigError(
-                "sms",
-                "Test-Modus aktiv, aber seven_api_key ist nicht der "
-                "Sandbox-Zugang (GZ_SEVEN_SANDBOX_KEY) — Versand blockiert "
-                "(Issue #1336).",
-            )
+    def _resolve_sender(self) -> Optional[str]:
+        return self._settings.sms_from or None
 
-    def _guard_code_origin(self) -> str:
-        """Herkunftssperre (Issue #1476, AC-6 — Vorbild
-        telegram.py::_guard_code_origin): bei Testlauf-Herkunft ist der
-        Prod-API-Key unzulaessig. Der Sandbox-Key sendet laut seven.io-Doku
-        NIE eine echte SMS ("sendet nie, kostet nie") und ist damit der
-        sichere Ersatz -- keine Rufnummer muss umgeschaltet werden.
-        """
-        if running_origin(Path(__file__)) != "test":
-            return self._settings.seven_api_key
-        sandbox_key = self._settings.seven_sandbox_key
-        if not sandbox_key:
-            raise OutputConfigError(
-                "sms",
-                "Herkunftssperre (Issue #1476): Code laeuft aus einem "
-                "Testlauf-Verzeichnis, aber kein Sandbox-Key konfiguriert "
-                "(GZ_SEVEN_SANDBOX_KEY) -- Versand abgebrochen.",
-            )
-        if self._settings.seven_api_key != sandbox_key:
-            logger.warning(
-                "Herkunftssperre (Issue #1476): Testlauf-Herkunft erkannt "
-                "-- SMS-Key auf den Sandbox-Key umgeschaltet.",
-            )
-        return sandbox_key
-
-    def send(self, subject: str, body: str) -> None:
-        """Send body as SMS via seven.io. subject is ignored."""
-        self._guard_test_mode_sandbox_key()
-        api_key = self._guard_code_origin()
-        payload: dict[str, str] = {
-            "to": self._settings.sms_to,
-            "text": body,
-        }
-        if self._settings.sms_from:
-            payload["from"] = self._settings.sms_from
-
-        response = httpx.post(
-            self._settings.sms_gateway_url,
-            headers={"X-Api-Key": api_key},
-            data=payload,
-            timeout=10,
-        )
-        if response.status_code != 200:
-            raise OutputError(
-                "sms",
-                f"seven.io HTTP {response.status_code}: {response.text[:200]}",
-            )
-        status_code = response.text.strip()
-        if status_code != "100":
-            raise OutputError("sms", f"seven.io Fehler-Code: {status_code!r}")
-        logger.info("SMS sent to %s via seven.io", self._settings.sms_to)
+    def _resolve_recipient(self) -> str:
+        return self._settings.sms_to

--- a/src/output/renderers/channel_layout.py
+++ b/src/output/renderers/channel_layout.py
@@ -46,6 +46,12 @@ CHANNEL_LIMITS = {
     "email":    {"max_table_cols": None, "max_chars": None},   # unbegrenzt
     "telegram": {"max_table_cols": 8,    "max_chars": 4096},
     "sms":      {"max_table_cols": 0,    "max_chars": 153},
+    # Issue #1676 S2a (ADR-0049): Vorsorge, kein Bestandteil des
+    # Briefing-Pfads — der uebergibt `max_length=160` fest (trip_report.py).
+    # Ohne diesen Eintrag fiele ein kuenftiger Aufrufer (S3, Vergleichspfad)
+    # unten still auf die TELEGRAM-Grenzen zurueck: 4096 Zeichen und eine
+    # Tabelle in einer Satelliten-SMS.
+    "premium_sms": {"max_table_cols": 0, "max_chars": 153},
 }
 
 

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -30,6 +30,7 @@ from output.renderers.email.design_tokens import (
 )
 from output.channels.base import OutputConfigError
 from output.channels.email import EmailOutput
+from output.channels.premium_sms import PremiumSmsOutput
 from output.channels.sms import SMSOutput
 from output.channels.telegram import TelegramOutput
 from services.trip_command_processor import CommandResult
@@ -87,6 +88,8 @@ class TripReportRequest:
     send_email: bool = True
     send_sms: bool = False
     send_telegram: bool = False
+    # Issue #1676 S2a (ADR-0049): vierter Kanal, unabhaengig von send_sms.
+    send_premium_sms: bool = False
     # Hinweise / Präfixe
     test_prefix: bool = False
     on_demand_prefix: bool = False
@@ -120,11 +123,42 @@ class NotificationResult:
     # `failed_channels` haelt zusaetzlich fest, welche davon technisch NICHT
     # angekommen sind, ohne diese bewusste Semantik zu veraendern.
     failed_channels: list[str] = field(default_factory=list)
+    # Issue #1676 S2a (Spec D4): Kanal -> Grund, warum NICHTS hinausging.
+    # `failed_channels` haelt gescheiterte Transporte fest; hier steht der
+    # Fall davor — der Kanal wurde bewusst nicht betreten (z.B. keine oder
+    # veraltete gelernte Rueckadresse). Ein Ergebnisfeld statt einer
+    # Logzeile, weil eine Logzeile kein Nachweis ist.
+    blocked_channels: dict[str, str] = field(default_factory=dict)
+    # Issue #1676 S2a (Spec D10), Adversary-Fund F002: derselbe Sperrfall
+    # zusaetzlich als maschinenlesbare Kennung (`ChannelBlockedError.
+    # reason_code`). Der Prosatext oben ist fuer Menschen; wer Faelle
+    # unterscheiden oder buchen will, vergleicht die Kennung. Ein FEHLENDER
+    # Eintrag heisst: das war keine bewusste Sperre, sondern ein Transport-
+    # oder Programmfehler. Genau diese Unterscheidung ist am Prosatext allein
+    # nicht moeglich — ein Absturztext sieht dort aus wie eine Sperrmeldung.
+    blocked_reason_codes: dict[str, str] = field(default_factory=dict)
 
     @property
     def delivered_channels(self) -> list[str]:
         """Kanaele, die den Versand ohne Fehler abgeschlossen haben."""
         return [c for c in self.sent_channels if c not in self.failed_channels]
+
+
+def _record_block_reason_code(
+    codes: dict[str, str], channel: str, exc: BaseException,
+) -> None:
+    """Traegt die Kennung einer BEWUSSTEN Sperre ein — sonst nichts.
+
+    Issue #1676 S2a (Spec D10). Bewusst per ``getattr``: der umgebende
+    ``except`` faengt jede Ausnahme (Kanalunabhaengigkeit, #1662), also auch
+    Transport- und Programmfehler. Die tragen keinen ``reason_code`` und
+    bekommen hier auch keinen erfunden — ihr Fehlen IST die Aussage
+    „das war keine Sperre". Ein Ersatzwert wuerde genau die Unterscheidung
+    zerstoeren, um die es geht.
+    """
+    code = getattr(exc, "reason_code", None)
+    if isinstance(code, str) and code.strip():
+        codes[channel] = code
 
 
 @dataclass
@@ -346,9 +380,14 @@ class NotificationService:
             not request.send_email
             and not request.send_sms
             and not request.send_telegram
+            # Issue #1676 S2a: ein Trip, der NUR Premium-SMS bekommt, ist
+            # konfiguriert — sonst gaelte der Lauf als "kein Kanal".
+            and not request.send_premium_sms
         )
 
         sent_channels: list[str] = []
+        blocked_channels: dict[str, str] = {}
+        blocked_reason_codes: dict[str, str] = {}
 
         # E-Mail — Issue #1662 (Punkt 8): Zustellbilanz statt Kanalreihenfolge.
         # Bisher war E-Mail der einzige Kanal ohne `try`; ein SMTP-/Guard-Fehler
@@ -375,6 +414,26 @@ class NotificationService:
                 sent_channels.append("sms")
             except Exception as e:
                 logger.error(f"SMS send failed for {request.trip.name}: {e}")
+
+        # Premium-SMS (Garmin inReach, Issue #1676 S2a, ADR-0049).
+        # Bewusst OHNE vorgeschaltete `can_send_*`-Bedingung: ob eine gelernte
+        # Rueckadresse vorliegt und frisch genug ist, entscheidet der Kanal
+        # selbst (Spec D3) und liefert den Grund als Ausnahme zurueck. Eine
+        # Bedingung davor wuerde dieselbe Pruefung doppeln und den Grund
+        # verschlucken — genau das, was `blocked_channels` verhindert.
+        if request.send_premium_sms:
+            try:
+                PremiumSmsOutput(self._settings).send(
+                    subject=report.email_subject,
+                    body=report.sms_text or report.email_plain,
+                )
+                sent_channels.append("premium_sms")
+            except Exception as e:  # noqa: BLE001 — Grund wird Ergebnisfeld
+                blocked_channels["premium_sms"] = str(e)
+                _record_block_reason_code(blocked_reason_codes, "premium_sms", e)
+                logger.error(
+                    f"Premium-SMS nicht versendet für {request.trip.name}: {e}"
+                )
 
         # Telegram
         if request.send_telegram and self._settings.can_send_telegram():
@@ -457,6 +516,8 @@ class NotificationService:
             sent_channels=sent_channels,
             telegram_fully_sent=telegram_fully_sent,
             no_channel_configured=no_channel_configured,
+            blocked_channels=blocked_channels,
+            blocked_reason_codes=blocked_reason_codes,
         )
 
     def _send_telegram_incomplete_hint(self, report, missing_count: int) -> None:
@@ -485,14 +546,24 @@ class NotificationService:
         send_email: bool = True,
         send_sms: bool = False,
         send_telegram: bool = False,
+        send_premium_sms: bool = False,
     ) -> NotificationResult:
-        """Kurzer Hinweis bei komplettem Wetterdaten-Ausfall (Issue #1012)."""
+        """Kurzer Hinweis bei komplettem Wetterdaten-Ausfall (Issue #1012).
+
+        Issue #1676 S2a: `send_premium_sms` ist hier kein Beiwerk — der
+        Scheduler entscheidet den Kanal an derselben Stelle wie fuer das
+        Briefing. Ein Flag, das ankommt und nichts tut, waere ein stilles
+        Loch: der Nutzer haette den Kanal gewaehlt und nie erfahren, dass er
+        die Ausfallmeldung nicht bekommt.
+        """
         subject = f"[{trip.name}] Wetterdaten nicht verfügbar"
         text = (
             "Wetterdienst aktuell nicht erreichbar — wir versuchen es weiter "
             "und liefern das Briefing nach, sobald Daten verfügbar sind."
         )
         sent_channels: list[str] = []
+        blocked_channels: dict[str, str] = {}
+        blocked_reason_codes: dict[str, str] = {}
 
         if send_email:
             try:
@@ -508,6 +579,15 @@ class NotificationService:
             except Exception as e:
                 logger.error(f"No-data hint SMS failed for {trip.name}: {e}")
 
+        if send_premium_sms:
+            try:
+                PremiumSmsOutput(self._settings).send(subject=subject, body=text)
+                sent_channels.append("premium_sms")
+            except Exception as e:  # noqa: BLE001 — Grund wird Ergebnisfeld
+                blocked_channels["premium_sms"] = str(e)
+                _record_block_reason_code(blocked_reason_codes, "premium_sms", e)
+                logger.error(f"No-data hint Premium-SMS blockiert für {trip.name}: {e}")
+
         if send_telegram and self._settings.can_send_telegram():
             try:
                 TelegramOutput(self._settings).send(subject=subject, body=text)
@@ -515,7 +595,12 @@ class NotificationService:
             except Exception as e:
                 logger.error(f"No-data hint Telegram failed for {trip.name}: {e}")
 
-        return NotificationResult(sent=bool(sent_channels), sent_channels=sent_channels)
+        return NotificationResult(
+            sent=bool(sent_channels),
+            sent_channels=sent_channels,
+            blocked_channels=blocked_channels,
+            blocked_reason_codes=blocked_reason_codes,
+        )
 
     def send_deviation_alert(
         self,

--- a/src/services/report_config_resolver.py
+++ b/src/services/report_config_resolver.py
@@ -64,6 +64,9 @@ RENDER_NEUTRAL: dict[str, str] = {
     "send_email": "Steuert WELCHER Kanal versendet wird, nicht den Mail-Inhalt.",
     "send_sms": "Steuert WELCHER Kanal versendet wird, nicht den Mail-Inhalt.",
     "send_telegram": "Steuert WELCHER Kanal versendet wird, nicht den Mail-Inhalt.",
+    # Issue #1676 S2a (ADR-0049): vierter Kanal, gleiche Begruendung wie die
+    # drei darueber — der Premium-SMS-Text ist unveraendert `report.sms_text`.
+    "send_premium_sms": "Steuert WELCHER Kanal versendet wird, nicht den Mail-Inhalt.",
     # Alert-Pfad
     "alert_on_changes": "Gehoert zum separaten Alert-/Deviation-Pfad, nicht zum Briefing-Rendering.",
     "change_threshold_temp_c": "Gehoert zum separaten Alert-/Deviation-Pfad, nicht zum Briefing-Rendering.",

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -38,7 +38,7 @@ from services.alert_briefing_anchor import (
 )
 from services.day_comparison import DayComparison
 from services.notification_service import NotificationService, TripReportRequest
-from services.user_tier import sms_allowed
+from services.user_tier import premium_sms_allowed, sms_allowed
 from utils.geo import haversine_km
 from utils.timezone import local_dt, tz_for_coords
 
@@ -964,6 +964,13 @@ class TripReportSchedulerService:
                     send_email=not config or config.send_email,
                     send_sms=config is not None and config.send_sms and sms_allowed(self._user_id),
                     send_telegram=config is not None and config.send_telegram,
+                    # Issue #1676 S2a: eigenes Tier-Gate (nur premium), NICHT
+                    # sms_allowed() -- das laesst standard durch (Spec D7).
+                    send_premium_sms=(
+                        config is not None
+                        and config.send_premium_sms
+                        and premium_sms_allowed(self._user_id)
+                    ),
                 )
                 self._write_pending_marker(
                     trip, report_type, target_date,
@@ -1301,6 +1308,13 @@ class TripReportSchedulerService:
             trip_url=f"https://gregor20.henemm.com/trips/{trip.id}",
             send_email=not config or config.send_email,
             send_sms=config is not None and config.send_sms and sms_allowed(self._user_id),
+            # Issue #1676 S2a: eigenes Tier-Gate (nur premium), NICHT
+            # sms_allowed() -- das laesst standard durch (Spec D7).
+            send_premium_sms=(
+                config is not None
+                and config.send_premium_sms
+                and premium_sms_allowed(self._user_id)
+            ),
             send_telegram=config is not None and config.send_telegram,
             test_prefix=allow_test_fallback,
             on_demand_prefix=on_demand,

--- a/src/services/user_tier.py
+++ b/src/services/user_tier.py
@@ -14,6 +14,25 @@ def sms_allowed(user_id: str) -> bool:
     return profile.get("tier", "free") in ("standard", "premium")
 
 
+def premium_sms_allowed(user_id: str) -> bool:
+    """Issue #1676 S2a (AC-8/D7): Premium-SMS ist ein Premium-Merkmal.
+
+    BEWUSST keine Delegation an `sms_allowed()` — das laesst `standard`
+    durch. Der Premium-SMS-Kanal spricht ein Satellitengeraet an, jede
+    Nachricht kostet; eine Wiederverwendung waere eine stille
+    Rechte-Ausweitung. Fehlendes `tier`-Feld, fehlende oder kaputte
+    `user.json` verhalten sich wie `free` — fail-closed.
+    """
+    profile_path = get_data_dir(user_id) / "user.json"
+    if not profile_path.exists():
+        return False
+    try:
+        profile = json.loads(profile_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return False
+    return profile.get("tier", "free") == "premium"
+
+
 def daily_alert_limit(user_id: str) -> int | None:
     """Issue #1070: Tages-Obergrenze proaktiver Alerts nach Nutzerlevel.
 

--- a/tests/tdd/test_channel_origin_guard_parity.py
+++ b/tests/tdd/test_channel_origin_guard_parity.py
@@ -16,7 +16,12 @@ Spec: docs/specs/fast/fix-1476-telegram-herkunftssperre.md
 """
 from __future__ import annotations
 
+import http.server
 import smtplib
+import socket
+import threading
+import urllib.parse
+from datetime import datetime, timezone
 
 import httpx
 import pytest
@@ -152,3 +157,108 @@ def test_sms_production_origin_delivers_unchanged(sms_httpx_sink, monkeypatch):
     SMSOutput(_prod_style_sms_settings()).send("x", "Text")
 
     assert sms_httpx_sink.calls[0]["headers"]["X-Api-Key"] == "prod-key"
+
+
+# ---------------------------------------------------------------------------
+# Issue #1676 S2a, AC-7 — dieselbe Herkunftssperre fuer den VIERTEN Kanal
+# (Premium-SMS/Garmin inReach). Diese Datei prueft die Sperre bis heute nur
+# namentlich fuer EmailOutput/SMSOutput; ein neuer Kanal ohne Guards faellt der
+# Suite sonst nicht auf (gemessener Befund, Kontextdokument "Existing Patterns").
+#
+# Gemessen wird hier am ECHTEN lokalen HTTP-Server statt am httpx-Sink oben:
+# der `X-Api-Key` ist damit am tatsaechlich EINGEGANGENEN Request nachgewiesen,
+# und "kein Aufruf" heisst "kein Byte auf der Leitung". Die bestehenden
+# E-Mail-/SMS-Faelle bleiben unveraendert auf ihren Boundary-Sinks.
+# ---------------------------------------------------------------------------
+
+PREMIUM_REPLY_TO = "+4915799912345"
+
+
+class _SevenIoStub:
+    """Lokaler HTTP-Server (127.0.0.1), der die seven.io-POSTs entgegennimmt."""
+
+    def __init__(self) -> None:
+        self.received: list[dict] = []
+        received = self.received
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                data = urllib.parse.parse_qs(self.rfile.read(length).decode())
+                received.append({
+                    "api_key": self.headers.get("X-Api-Key"),
+                    "payload": {k: v[0] for k, v in data.items()},
+                })
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"100")
+
+            def log_message(self, *args):
+                pass
+
+        probe = socket.socket()
+        probe.bind(("", 0))
+        self.port = probe.getsockname()[1]
+        probe.close()
+        self._server = http.server.HTTPServer(("127.0.0.1", self.port), Handler)
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+
+    def stop(self) -> None:
+        self._server.shutdown()
+
+
+@pytest.fixture()
+def premium_sms_stub():
+    stub = _SevenIoStub()
+    yield stub
+    stub.stop()
+
+
+def _prod_style_premium_sms_settings(port: int, **overrides) -> Settings:
+    defaults = dict(
+        seven_api_key="prod-key",
+        sms_gateway_url=f"http://127.0.0.1:{port}/api/sms",
+        premium_sms_reply_to=PREMIUM_REPLY_TO,
+        premium_sms_reply_at=datetime.now(timezone.utc),
+    )
+    defaults.update(overrides)
+    settings = Settings(**defaults)
+    assert settings.is_test_mode is False
+    assert settings.env == "production"
+    return settings
+
+
+def test_premium_sms_test_origin_switches_to_sandbox_key(premium_sms_stub):
+    """AC-7 (Premium-SMS): Testlauf-Herkunft — jeder pytest-Lauf in einem
+    Arbeitsordner ist eine — erzwingt den Sandbox-Key, der laut seven.io-Doku
+    nie eine echte SMS sendet."""
+    from output.channels.premium_sms import PremiumSmsOutput
+
+    settings = _prod_style_premium_sms_settings(
+        premium_sms_stub.port, seven_sandbox_key="sandbox-key",
+    )
+    PremiumSmsOutput(settings).send("x", "Text")
+
+    assert len(premium_sms_stub.received) == 1, (
+        f"Erwartet genau EINEN POST, bekommen: {premium_sms_stub.received!r}"
+    )
+    assert premium_sms_stub.received[0]["api_key"] == "sandbox-key", (
+        "Premium-SMS ging mit dem Prod-Key hinaus: "
+        f"{premium_sms_stub.received[0]['api_key']!r}"
+    )
+
+
+def test_premium_sms_test_origin_without_sandbox_key_hard_aborts(premium_sms_stub):
+    """AC-7 (Premium-SMS): kein Sandbox-Key konfiguriert -> harter Abbruch,
+    BEVOR ein HTTP-Aufruf stattfindet."""
+    from output.channels.premium_sms import PremiumSmsOutput
+
+    settings = _prod_style_premium_sms_settings(
+        premium_sms_stub.port, seven_sandbox_key=None,
+    )
+    with pytest.raises(OutputConfigError, match="1476"):
+        PremiumSmsOutput(settings).send("x", "Text")
+
+    assert premium_sms_stub.received == [], (
+        f"Trotz Abbruch ging etwas hinaus: {premium_sms_stub.received!r}"
+    )

--- a/tests/test_trip_flat_fields_dual_read.py
+++ b/tests/test_trip_flat_fields_dual_read.py
@@ -62,6 +62,14 @@ def _trip_dict(**stage_overrides) -> dict:
             "send_email": True,
             "send_sms": True,
             "send_telegram": False,
+            # Issue #1676 S2a: vierter Kanal. Steht hier, weil dieses Fixture
+            # laut Docstring VOLLSTAENDIG ist — `send_premium_sms` wird wie
+            # seine drei Geschwister immer serialisiert (bewusst kein
+            # omitempty, sonst bliebe beim Datei-Merge ein alter Plattenwert
+            # stehen, #1250 Scheibe 4 F002). Fehlte der Schluessel hier, waere
+            # er ein "hinzugekommener Schluessel mit echtem Wert" und der
+            # Roundtrip-Test unten rot, ohne dass etwas verloren geht.
+            "send_premium_sms": False,
             "alert_on_changes": True,
             "change_threshold_temp_c": 5.0,
             "change_threshold_wind_kmh": 20.0,

--- a/tests/unit/test_config_premium_sms.py
+++ b/tests/unit/test_config_premium_sms.py
@@ -1,0 +1,173 @@
+"""Premium-SMS: Rueckadresse kommt ausschliesslich aus ``user.json``.
+
+Spec: docs/specs/modules/feat_1676_s2a_premium_sms_versand.md — AC-9 sowie die
+beiden Traeger dieser Zusicherung (Feld-Deklaration, Profil-Uebernahme).
+
+Prueforte:
+
+- **AC-9** ist die ``Settings(...)``-Konstruktion selbst. Ein still akzeptierter
+  ``GZ_``-Wert wuerde erst beim naechsten Versand sichtbar — dann ist die SMS
+  schon draussen (und kostenpflichtig). Je Variable ein eigener Fall: ein
+  Override von ``premium_sms_reply_at`` frischt die 30-Tage-Frist kuenstlich auf
+  und gibt damit den Versand an eine langst veraltete Nummer frei; eine Sperre,
+  die man mit einer Umgebungsvariable abschalten kann, ist keine.
+- **Feld-Deklaration:** ``extra="ignore"`` (``config.py``) verschluckt
+  undeklarierte Werte lautlos — ein nur in ``with_user_profile()`` ergaenztes
+  Feld verschwindet also spurlos. Geprueft wird deshalb, dass ein uebergebener
+  Wert am Objekt ANKOMMT, nicht bloss, dass irgendwo eine Zeile steht.
+- **Profil-Uebernahme:** echte ``user.json`` in der (per conftest isolierten)
+  Datenwurzel, gelesen ueber den einzigen Profil->Settings-Uebersetzer.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.config import Settings
+from app.loader import get_data_dir
+
+LEARNED_REPLY_TO = "+4915799912345"
+ENV_INJECTED_NUMBER = "+4915700000000"
+
+
+def _write_profile(user_id: str, *, with_premium_fields: bool) -> datetime | None:
+    """Schreibt ``user.json`` wie der einzige Schreiber (Go-Handler, S1) es tut."""
+    path = get_data_dir(user_id)
+    path.mkdir(parents=True, exist_ok=True)
+    profile: dict = {"id": user_id, "tier": "premium"}
+    stamp = None
+    if with_premium_fields:
+        stamp = (datetime.now(timezone.utc) - timedelta(hours=3)).replace(microsecond=0)
+        profile["premium_sms_reply_to"] = LEARNED_REPLY_TO
+        profile["premium_sms_reply_at"] = stamp.isoformat().replace("+00:00", "Z")
+    (path / "user.json").write_text(json.dumps(profile), encoding="utf-8")
+    return stamp
+
+
+# ---------------------------------------------------------------------------
+# AC-9: ENV-Sperre, je Variable ein Fall
+# ---------------------------------------------------------------------------
+
+def test_env_override_for_reply_to_is_rejected_loudly(monkeypatch) -> None:
+    """AC-9: Given ``GZ_PREMIUM_SMS_REPLY_TO`` steht im Prozess-Environment /
+    When ``Settings()`` konstruiert wird / Then schlaegt die Konstruktion laut
+    fehl, statt den Wert stillschweigend zu uebernehmen."""
+    monkeypatch.delenv("GZ_PREMIUM_SMS_REPLY_TO", raising=False)
+    assert Settings() is not None, (
+        "Gegenprobe: ohne die Umgebungsvariable muss Settings() normal bauen — "
+        "sonst prueft dieser Test nur ein generell kaputtes Settings."
+    )
+
+    monkeypatch.setenv("GZ_PREMIUM_SMS_REPLY_TO", ENV_INJECTED_NUMBER)
+    with pytest.raises(ValueError) as excinfo:
+        Settings()
+
+    message = str(excinfo.value)
+    assert "GZ_PREMIUM_SMS_REPLY_TO" in message.upper(), (
+        f"Die Fehlermeldung benennt die verbotene Variable nicht: {message!r}"
+    )
+    assert ENV_INJECTED_NUMBER not in message, (
+        "Rufnummern gehoeren nicht unmaskiert in Fehlermeldungen "
+        f"(Spec S1: nur maskiert protokollieren): {message!r}"
+    )
+
+
+def test_env_override_for_reply_at_is_rejected_loudly(monkeypatch) -> None:
+    """AC-9: dasselbe fuer ``GZ_PREMIUM_SMS_REPLY_AT`` — ein aufgefrischter
+    Zeitstempel wuerde die 30-Tage-Frist (AC-4) wirkungslos machen, bei formal
+    korrekter Rufnummer."""
+    monkeypatch.delenv("GZ_PREMIUM_SMS_REPLY_AT", raising=False)
+    assert Settings() is not None, "Gegenprobe: ohne die Variable muss Settings() bauen"
+
+    monkeypatch.setenv(
+        "GZ_PREMIUM_SMS_REPLY_AT", datetime.now(timezone.utc).isoformat(),
+    )
+    with pytest.raises(ValueError) as excinfo:
+        Settings()
+
+    assert "GZ_PREMIUM_SMS_REPLY_AT" in str(excinfo.value).upper(), (
+        f"Die Fehlermeldung benennt die verbotene Variable nicht: {excinfo.value!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Traeger 1: die Felder muessen deklariert sein, sonst frisst extra="ignore" sie
+# ---------------------------------------------------------------------------
+
+def test_declared_premium_sms_fields_survive_construction() -> None:
+    """Given ``Settings`` wird mit gelernter Rueckadresse und Zeitstempel gebaut
+    / When die Werte gelesen werden / Then stehen sie am Objekt — ein
+    undeklariertes Feld waere von ``extra="ignore"`` lautlos verschluckt
+    worden, und die Rueckadresse waere nie beim Versand angekommen."""
+    stamp = datetime.now(timezone.utc).replace(microsecond=0)
+
+    settings = Settings(premium_sms_reply_to=LEARNED_REPLY_TO, premium_sms_reply_at=stamp)
+
+    assert settings.premium_sms_reply_to == LEARNED_REPLY_TO
+    assert settings.premium_sms_reply_at == stamp
+    assert Settings().premium_sms_reply_to in (None, ""), (
+        "Ohne Profil darf keine Rueckadresse vorbelegt sein — fail-closed."
+    )
+    assert Settings().premium_sms_reply_at is None
+
+
+# ---------------------------------------------------------------------------
+# Traeger 2: with_user_profile() ist der einzige Weg an die gelernten Werte
+# ---------------------------------------------------------------------------
+
+def test_with_user_profile_takes_over_learned_reply_address() -> None:
+    """Given ``user.json`` traegt die gelernte Rueckadresse und ihren
+    Zeitstempel / When ``Settings().with_user_profile()`` laeuft / Then stehen
+    beide Werte an den Settings — sonst kann kein Versandzweig sie sehen."""
+    user_id = "tdd-1676-cfg-profile"
+    stamp = _write_profile(user_id, with_premium_fields=True)
+
+    settings = Settings().with_user_profile(user_id)
+
+    assert settings.premium_sms_reply_to == LEARNED_REPLY_TO, (
+        f"Gelernte Rueckadresse nicht uebernommen: {settings.premium_sms_reply_to!r}"
+    )
+    reply_at = settings.premium_sms_reply_at
+    assert reply_at is not None, "Zeitstempel nicht uebernommen — die 30-Tage-Frist waere blind"
+    if isinstance(reply_at, str):
+        reply_at = datetime.fromisoformat(reply_at.replace("Z", "+00:00"))
+    assert reply_at.tzinfo is not None, (
+        f"Zeitstempel ohne Zeitzone ({reply_at!r}) — ein Vergleich mit 'jetzt' "
+        "waere je nach Serverzeit um Stunden verschoben."
+    )
+    assert abs((reply_at - stamp).total_seconds()) < 2, (
+        f"Zeitstempel weicht ab: {reply_at!r} != {stamp!r}"
+    )
+
+
+def test_no_second_readiness_question_for_premium_sms() -> None:
+    """Adversary-Fund F003: Given jemand baut eine
+    ``Settings.can_send_premium_sms()``-Bereitschaftsfrage (wieder) ein / When
+    diese Datei laeuft / Then schlaegt sie fehl — die Sendebereitschaft des
+    Premium-Kanals entscheidet allein der Kanal zur Sendezeit (Spec D3), und
+    eine zweite, vorgeschaltete Frage wuerde die Fail-Closed-Pruefung dort
+    abschirmen: sie liesse sich entfernen, ohne dass ein Test rot wird.
+
+    Prueft die Zusicherung an ihrem Wirkort — am Objekt, das der Versandzweig
+    benutzt, nicht am Dateitext (eine Kommentarzeile im Code waere kein
+    Schutz). Die zwei EXISTIERENDEN Geschwister werden mitgeprueft: fiele die
+    Namensfamilie ganz weg, waere dieser Test sonst still gegenstandslos.
+    """
+    settings = Settings(
+        premium_sms_reply_to=LEARNED_REPLY_TO,
+        premium_sms_reply_at=datetime.now(timezone.utc),
+    )
+
+    assert not hasattr(settings, "can_send_premium_sms"), (
+        "`Settings.can_send_premium_sms()` ist wieder da. Entweder hat sie "
+        "jetzt einen echten Wirkort — dann muss ein Test genau diesen Wirkort "
+        "bewachen und dieser hier weichen — oder sie ist erneut toter Code, "
+        "der Vertrauen in einen Schutz vortaeuscht, den nur "
+        "`PremiumSmsOutput._resolve_recipient()` leistet."
+    )
+    assert callable(settings.can_send_sms) and callable(settings.can_send_telegram), (
+        "Gegenprobe: die Bereitschaftsfragen der anderen Kanaele muessen "
+        "existieren — sonst prueft dieser Test nur ein leeres Settings-Objekt."
+    )

--- a/tests/unit/test_premium_sms_versand.py
+++ b/tests/unit/test_premium_sms_versand.py
@@ -1,0 +1,860 @@
+"""Premium-SMS (Garmin inReach) als vierter Versandkanal — Nachweis am POST.
+
+Spec: docs/specs/modules/feat_1676_s2a_premium_sms_versand.md
+Abgedeckt: AC-1, AC-2, AC-3, AC-4, AC-5, AC-6, AC-8, AC-10.
+
+Naht ist ein ECHTER lokaler HTTP-Server auf 127.0.0.1, der die POSTs an das
+seven.io-Gateway entgegennimmt (Vorbild ``tests/tdd/test_issue_936_sms_stub.py``
+und ``tests/tdd/test_issue_1069_tier_channel_gating.py``) — kein Mock, kein
+``patch()``. Gemessen wird die tatsaechlich abgesendete Nutzlast (``from``,
+``to``, ``text`` aus dem eingegangenen Request), nicht das Settings-Objekt:
+die Zusicherungen wirken am ausgehenden POST, nicht am Konstruktor.
+
+Der Weg ist der produktive:
+
+    gelernte Rueckadresse in ``user.json`` (S1 schreibt sie dort)
+      -> ``Settings.with_user_profile()``
+      -> ``TripReportSchedulerService._build_trip_report_request()``  (Tier-Gate
+         + Kanalwunsch)
+      -> ``NotificationService.send_trip_report()``
+      -> Kanal -> POST an das Gateway
+
+Das Kanal-Flag ``send_premium_sms`` wird bewusst NICHT am Modell-Konstruktor
+vorbeigeschoben, sondern als freier Schluessel in ``report_config`` der
+gespeicherten Briefing-Datei abgelegt — genau dort, wo der Go-Handler es
+ablegt (Spec D8) — und ueber ``load_trip()`` zurueckgelesen. So messen diese
+Tests die ganze Kette inklusive Persistenz-Uebernahme, und ein fehlgeschlagener
+Test benennt den ausgebliebenen Versand statt eines fehlenden Schlagworts.
+"""
+from __future__ import annotations
+
+import http.server
+import json
+import re
+import socket
+import threading
+import urllib.parse
+from datetime import date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.config import Settings
+from app.loader import get_data_dir, load_trip, save_trip
+from output.renderers.trip_report import TripReportFormatter
+
+# Unsere feste seven.io-Dienstnummer (Spec AC-1) — der Premium-Absender.
+PREMIUM_SMS_SENDER = "4916092172595"
+# Von Garmin je Gespraech neu vergebene Rueckadresse, die S1 gelernt hat.
+LEARNED_REPLY_TO = "+4915799912345"
+# Settings.sms_to / Settings.sms_from — duerfen den Premium-Kanal nie erreichen.
+CONFIG_SMS_TO = "+49000000111"
+CONFIG_SMS_FROM = "+49000000222"
+# Spec D6: 30 Tage. Absichtlich hier ausgeschrieben statt aus dem Produktivmodul
+# gelesen — ein aus dem Code importierter Wert wuerde jede Fristverschiebung
+# stillschweigend mitziehen und die Kantentests (AC-4/AC-5) entwerten.
+REPLY_TTL = timedelta(days=30)
+# Kurzschluessel der zwei Sperrfaelle — aus demselben Grund ausgeschrieben:
+# ein importierter Wert wuerde ein Vertauschen der beiden Kennungen
+# stillschweigend mitziehen, und genau dieses Vertauschen wuerde der Alarmpfad
+# (#1701) als falschen Grund ins Protokoll buchen.
+EXPECTED_CODE_NO_REPLY = "premium_sms_no_reply_address"
+EXPECTED_CODE_STALE = "premium_sms_reply_address_stale"
+
+_KEEP = object()  # Sentinel: Settings-Feld absichtlich NICHT ueberschreiben
+
+
+# ---------------------------------------------------------------------------
+# Lokaler seven.io-Stub (echter HTTP-Server, kein Mock)
+# ---------------------------------------------------------------------------
+
+class _SevenIoStub:
+    """Nimmt die echten POSTs von SMSOutput/PremiumSmsOutput entgegen."""
+
+    def __init__(self) -> None:
+        self.received: list[dict] = []
+        received = self.received
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(length)
+                data = urllib.parse.parse_qs(body.decode())
+                entry = {k: v[0] for k, v in data.items()}
+                entry["_api_key"] = self.headers.get("X-Api-Key")
+                received.append(entry)
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"100")
+
+            def log_message(self, *args):
+                pass
+
+        probe = socket.socket()
+        probe.bind(("", 0))
+        self.port = probe.getsockname()[1]
+        probe.close()
+        self._server = http.server.HTTPServer(("127.0.0.1", self.port), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._server.shutdown()
+
+    def recipients(self) -> list[str | None]:
+        return [entry.get("to") for entry in self.received]
+
+    def to(self, number: str) -> list[dict]:
+        return [entry for entry in self.received if entry.get("to") == number]
+
+
+@pytest.fixture()
+def stub():
+    s = _SevenIoStub()
+    yield s
+    s.stop()
+
+
+class _CapturingFormatter(TripReportFormatter):
+    """Echter Renderer, der die erzeugten Reports zusaetzlich festhaelt.
+
+    Kein Fake: ``format_email`` laeuft unveraendert durch die Produktivlogik,
+    der Rueckgabewert wird nur mitgeschrieben. So kann AC-6 den abgesendeten
+    Text gegen den TATSAECHLICH gerenderten ``report.sms_text`` derselben
+    Fixture vergleichen, statt gegen eine Konstante im Test (die einen
+    gemeinsamen Kopierfehler in Renderer und Test nicht aufdecken wuerde).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.reports: list = []
+
+    def format_email(self, *args, **kwargs):
+        report = super().format_email(*args, **kwargs)
+        self.reports.append(report)
+        return report
+
+
+# ---------------------------------------------------------------------------
+# Fixture-Daten
+# ---------------------------------------------------------------------------
+
+def _write_profile(
+    user_id: str,
+    *,
+    tier: str,
+    reply_to: str | None = None,
+    reply_age: timedelta = timedelta(minutes=5),
+) -> None:
+    """Schreibt ``user.json`` in die (per conftest isolierte) Datenwurzel.
+
+    Feldnamen exakt wie der einzige Schreiber sie ablegt
+    (``internal/handler/premium_sms_connect.go`` -> ``internal/model/user.go``:
+    ``premium_sms_reply_to`` / ``premium_sms_reply_at`` als RFC3339-UTC).
+    """
+    path = get_data_dir(user_id)
+    path.mkdir(parents=True, exist_ok=True)
+    profile: dict = {"id": user_id, "tier": tier}
+    if reply_to is not None:
+        stamp = datetime.now(timezone.utc) - reply_age
+        profile["premium_sms_reply_to"] = reply_to
+        profile["premium_sms_reply_at"] = stamp.isoformat().replace("+00:00", "Z")
+    (path / "user.json").write_text(json.dumps(profile), encoding="utf-8")
+
+
+def _stub_settings(port: int, user_id: str, *, sms_from=None, sms_to=CONFIG_SMS_TO) -> Settings:
+    update = {
+        "sms_gateway_url": f"http://127.0.0.1:{port}/api/sms",
+        "seven_api_key": "test-stub-key",
+        "seven_sandbox_key": "test-stub-key",
+        "sms_from": sms_from,
+    }
+    if sms_to is not _KEEP:
+        update["sms_to"] = sms_to
+    return Settings().with_user_profile(user_id).model_copy(update=update)
+
+
+def _make_segment_data(*, extreme: bool = False):
+    from app.models import (
+        ForecastDataPoint, ForecastMeta, GPXPoint, NormalizedTimeseries,
+        Provider, SegmentWeatherData, SegmentWeatherSummary, ThunderLevel,
+        TripSegment,
+    )
+
+    if extreme:
+        points = [
+            ForecastDataPoint(
+                ts=datetime(2026, 5, 1, 9 + h, 0, tzinfo=timezone.utc),
+                t2m_c=-38.0 + h * 15, wind10m_kmh=99.0 + h, gust_kmh=165.0 + h,
+                pop_pct=100, precip_1h_mm=120.9, wind_chill_c=-55.0,
+                cloud_total_pct=100, visibility_m=50, snow_depth_cm=420.0,
+                snow_new_24h_cm=95.0, thunder_level=ThunderLevel.HIGH,
+            )
+            for h in range(6)
+        ]
+        agg = SegmentWeatherSummary(
+            temp_min_c=-38.0, temp_max_c=47.0, temp_avg_c=4.5,
+            wind_max_kmh=104.0, gust_max_kmh=170.0, precip_sum_mm=725.4,
+            cloud_avg_pct=100,
+        )
+    else:
+        points = [
+            ForecastDataPoint(
+                ts=datetime(2026, 5, 1, 9 + h, 0, tzinfo=timezone.utc),
+                t2m_c=15.0 + h, wind10m_kmh=10.0 + h, gust_kmh=22.0 + h,
+                pop_pct=40, precip_1h_mm=0.4, wind_chill_c=12.0 + h,
+                cloud_total_pct=55,
+            )
+            for h in range(6)
+        ]
+        agg = SegmentWeatherSummary(
+            temp_min_c=15.0, temp_max_c=20.0, temp_avg_c=17.5,
+            wind_max_kmh=16.0, gust_max_kmh=28.0, precip_sum_mm=2.4,
+            cloud_avg_pct=55,
+        )
+
+    meta = ForecastMeta(
+        provider=Provider.OPENMETEO, model="icon_d2",
+        run=datetime(2026, 5, 1, 0, 0, tzinfo=timezone.utc),
+        grid_res_km=2.0, interp="point_grid",
+    )
+    seg = TripSegment(
+        segment_id=1,
+        start_point=GPXPoint(lat=42.2, lon=9.05, elevation_m=400.0),
+        end_point=GPXPoint(lat=42.25, lon=9.09, elevation_m=1200.0),
+        start_time=datetime(2026, 5, 1, 9, 0, tzinfo=timezone.utc),
+        end_time=datetime(2026, 5, 1, 13, 0, tzinfo=timezone.utc),
+        duration_hours=4.0, distance_km=8.0, ascent_m=800.0, descent_m=0.0,
+    )
+    return SegmentWeatherData(
+        segment=seg, timeseries=NormalizedTimeseries(meta=meta, data=points),
+        aggregated=agg, fetched_at=datetime.now(timezone.utc), provider="openmeteo",
+    )
+
+
+def _persisted_trip(user_id: str, *, send_sms: bool, send_premium_sms: bool):
+    """Speichert einen Trip und liest ihn zurueck — inklusive Kanal-Flag.
+
+    ``send_premium_sms`` wird als freier Schluessel in die gespeicherte
+    ``report_config`` geschrieben (Spec D8: genau so legt der Go-Handler es ab)
+    und muss von ``load_trip()`` uebernommen werden.
+    """
+    from app.models import TripReportConfig
+    from app.trip import Stage, Trip, Waypoint
+
+    trip_id = f"trip-{user_id}"
+    stage = Stage(
+        id="S1", name="Etappe 1", date=date.today() + timedelta(days=1),
+        waypoints=[
+            Waypoint(id="W1", name="Start", lat=42.2, lon=9.05, elevation_m=400),
+            Waypoint(id="W2", name="Ziel", lat=42.25, lon=9.09, elevation_m=1200),
+        ],
+    )
+    trip = Trip(
+        id=trip_id, name=f"Premium-SMS {user_id}", stages=[stage],
+        report_config=TripReportConfig(
+            trip_id=trip_id, send_email=False, send_sms=send_sms, send_telegram=False,
+        ),
+    )
+    path = save_trip(trip, user_id=user_id)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["report_config"]["send_premium_sms"] = send_premium_sms
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+    loaded = load_trip(path, user_id=user_id)
+    assert loaded is not None, "Trip liess sich nicht zurueckladen"
+    return loaded
+
+
+def _dispatch(
+    user_id: str,
+    stub: _SevenIoStub,
+    *,
+    send_sms: bool,
+    send_premium_sms: bool,
+    extreme: bool = False,
+    settings: Settings | None = None,
+):
+    """Faehrt den echten Briefing-Versandweg und gibt (request, result, reports)."""
+    from services.notification_service import NotificationService
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    settings = settings if settings is not None else _stub_settings(stub.port, user_id)
+    trip = _persisted_trip(user_id, send_sms=send_sms, send_premium_sms=send_premium_sms)
+    scheduler = TripReportSchedulerService(settings=settings, user_id=user_id)
+    request = scheduler._build_trip_report_request(
+        trip=trip,
+        report_type="evening",
+        segment_weather=[_make_segment_data(extreme=extreme)],
+        trip_tz=ZoneInfo("Europe/Vienna"),
+        stage_name=None,
+        stage_stats=None,
+        night_weather=None,
+        thunder_forecast=None,
+        multi_day_trend=None,
+        stability_result=None,
+        day_comparison=None,
+        exposed_sections=[],
+        allow_test_fallback=False,
+        on_demand=False,
+        catchup_prefix=None,
+    )
+    notifier = NotificationService(settings=settings, user_id=user_id)
+    formatter = _CapturingFormatter()
+    notifier._formatter = formatter
+    result = notifier.send_trip_report(request)
+    return request, result, formatter.reports
+
+
+def _blocked_reason(result, *, expected_code: str) -> str:
+    """``blocked_channels``/``blocked_reason_codes`` sind Spec D4/D10 —
+    Ergebnisfelder, keine Logzeilen.
+
+    ``expected_code`` ist PFLICHT (keyword-only, ohne Vorgabewert): vorher
+    genuegte hier irgendein nicht-leerer Text, und damit war eine BEWUSSTE
+    Sperre von einem unfreiwilligen Absturz nicht mehr zu unterscheiden — ein
+    ``AttributeError`` aus einer verfaelschten Fail-Closed-Pruefung landet ueber
+    denselben ``except``-Zweig in ``blocked_channels`` und liest sich dort wie
+    eine Sperrmeldung. Die Kennung entsteht ausschliesslich dort, wo der Kanal
+    bewusst abbricht (``ChannelBlockedError``), und trennt beides.
+    """
+    blocked = getattr(result, "blocked_channels", None)
+    assert blocked is not None, (
+        "NotificationResult hat kein Feld `blocked_channels` — der ausgebliebene "
+        "Premium-SMS-Versand ist damit nur in einer Logzeile sichtbar, und eine "
+        "Logzeile ist kein Nachweis (Spec D4)."
+    )
+    assert "premium_sms" in blocked, (
+        f"Kein Grund unter dem Kanalnamen 'premium_sms' hinterlegt: {blocked!r}"
+    )
+    reason = blocked["premium_sms"]
+    assert isinstance(reason, str) and reason.strip(), (
+        f"Grund ist kein auswertbarer Text: {reason!r}"
+    )
+    codes = getattr(result, "blocked_reason_codes", None)
+    assert codes is not None, (
+        "NotificationResult hat kein Feld `blocked_reason_codes` — dann ist der "
+        "deutsche Prosatext die einzige Quelle des Sperrgrunds, und ein "
+        "Absturztext ist darin von einer bewussten Sperre nicht zu "
+        "unterscheiden (Spec D10)."
+    )
+    assert codes.get("premium_sms") == expected_code, (
+        f"Sperrgrund traegt die Kennung {codes.get('premium_sms')!r}, erwartet "
+        f"{expected_code!r}. Hinterlegter Prosatext: {reason!r} — der allein "
+        "beweist nichts: ein unfreiwilliger Absturz in der Fail-Closed-Pruefung "
+        "kommt ueber denselben except-Zweig hier an und sieht genauso aus."
+    )
+    return reason
+
+
+# ---------------------------------------------------------------------------
+# AC-1: Absender ist ausnahmslos die feste Dienstnummer
+# ---------------------------------------------------------------------------
+
+def test_sender_is_fixed_number_regardless_of_sms_from(stub) -> None:
+    """AC-1: Given Premium-Nutzer mit frischer Rueckadresse UND abweichend
+    gesetztem ``sms_from`` / When das Briefing per Premium-SMS geht / Then
+    traegt der abgesendete POST als ``from`` die feste Nummer 4916092172595."""
+    user_id = "tdd-1676-sender"
+    _write_profile(user_id, tier="premium", reply_to=LEARNED_REPLY_TO)
+    settings = _stub_settings(stub.port, user_id, sms_from=CONFIG_SMS_FROM)
+    assert settings.sms_from == CONFIG_SMS_FROM, "Widerspruch nicht wirksam gesetzt"
+
+    _, result, _ = _dispatch(
+        user_id, stub, send_sms=False, send_premium_sms=True, settings=settings,
+    )
+
+    assert len(stub.received) == 1, (
+        f"Erwartet genau EIN Premium-SMS-POST, bekommen: {stub.received!r} — "
+        "der Premium-Kanal erreicht den seven.io-Transport nicht."
+    )
+    # Dieser Trip hat NUR den Premium-Kanal — er ist damit konfiguriert.
+    # Faellt das Flag aus der `no_channel_configured`-Rechnung heraus, geht die
+    # SMS weiter hinaus, aber der Scheduler bucht den Lauf als `no_channels`,
+    # schreibt keinen briefing_log-Eintrag und die Cockpit-Kachel zeigt keinen
+    # Versand (trip_report_scheduler.py:1188/1238-1241). Deshalb hier
+    # mitgemessen: die Wirkung ist unsichtbar am POST allein.
+    assert result.no_channel_configured is False, (
+        "Ein Trip, der ausschliesslich Premium-SMS bekommt, gilt als 'kein "
+        "Kanal konfiguriert' — der nachweislich abgesendete Versand wuerde im "
+        "Protokoll und im Cockpit als 'nicht vorgesehen' erscheinen."
+    )
+    assert stub.received[0].get("from") == PREMIUM_SMS_SENDER, (
+        f"Absender falsch: {stub.received[0].get('from')!r} — erwartet die feste "
+        f"Dienstnummer {PREMIUM_SMS_SENDER!r}; sms_from ({CONFIG_SMS_FROM}) darf "
+        "auf den Premium-Kanal keinerlei Wirkung haben."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Empfaenger ist die gelernte Rueckadresse, nie sms_to
+# ---------------------------------------------------------------------------
+
+def test_recipient_comes_from_learned_reply_to_not_sms_to(stub, monkeypatch) -> None:
+    """AC-2: Given ``GZ_SMS_TO`` steht bewusst widersprüchlich im Prozess-
+    Environment / When das Briefing per Premium-SMS geht / Then geht der POST
+    ausschliesslich an die gelernte Rueckadresse."""
+    user_id = "tdd-1676-recipient"
+    contradicting = "+49111111111"
+    monkeypatch.setenv("GZ_SMS_TO", contradicting)
+    _write_profile(user_id, tier="premium", reply_to=LEARNED_REPLY_TO)
+    settings = _stub_settings(stub.port, user_id, sms_to=_KEEP)
+    assert settings.sms_to == contradicting, (
+        f"GZ_SMS_TO wurde nicht wirksam ({settings.sms_to!r}) — der Widerspruch, "
+        "den dieser Test braucht, liegt nicht vor."
+    )
+
+    _dispatch(user_id, stub, send_sms=False, send_premium_sms=True, settings=settings)
+
+    assert len(stub.received) == 1, (
+        f"Erwartet genau EIN Premium-SMS-POST, bekommen: {stub.received!r}"
+    )
+    assert stub.received[0].get("to") == LEARNED_REPLY_TO, (
+        f"Empfaenger falsch: {stub.received[0].get('to')!r} — erwartet die gelernte "
+        f"Rueckadresse {LEARNED_REPLY_TO!r} aus user.json, nie sms_to."
+    )
+    assert contradicting not in stub.recipients(), (
+        "sms_to wurde fuer den Premium-Kanal gelesen — verboten (AC-2)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3: keine gelernte Rueckadresse -> kein Versand, sichtbarer Grund
+# ---------------------------------------------------------------------------
+
+def test_empty_reply_to_blocks_send_with_visible_reason(stub) -> None:
+    """AC-3: Given Premium-Nutzer ohne gelernte Rueckadresse / When das
+    Briefing versendet wird / Then kein HTTP-Aufruf UND ein auswertbarer Grund
+    unter ``blocked_channels['premium_sms']``."""
+    user_id = "tdd-1676-noreply"
+    _write_profile(user_id, tier="premium", reply_to=None)
+
+    _, result, _ = _dispatch(user_id, stub, send_sms=False, send_premium_sms=True)
+
+    assert stub.received == [], (
+        f"Ohne gelernte Rueckadresse darf KEIN POST hinausgehen, bekommen: "
+        f"{stub.received!r}"
+    )
+    _blocked_reason(result, expected_code=EXPECTED_CODE_NO_REPLY)
+    assert "premium_sms" not in result.sent_channels, (
+        f"Kanal als gesendet vermerkt, obwohl nichts hinausging: {result.sent_channels!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 / AC-5: die 30-Tage-Frist, beidseitig auf die Sekunde
+# ---------------------------------------------------------------------------
+
+def test_reply_to_older_than_ttl_blocks_send(stub) -> None:
+    """AC-4: Given Zeitstempel exakt eine Sekunde UEBER der 30-Tage-Frist /
+    When das Briefing versendet wird / Then kein Versand, Grund benennt die
+    veraltete Rueckadresse."""
+    user_id = "tdd-1676-stale"
+    _write_profile(
+        user_id, tier="premium", reply_to=LEARNED_REPLY_TO,
+        reply_age=REPLY_TTL + timedelta(seconds=1),
+    )
+
+    _, result, _ = _dispatch(user_id, stub, send_sms=False, send_premium_sms=True)
+
+    assert stub.received == [], (
+        "Rueckadresse ist 30 Tage + 1 Sekunde alt — es darf KEIN POST hinausgehen "
+        f"(die Nummer sieht syntaktisch gueltig aus), bekommen: {stub.received!r}"
+    )
+    reason = _blocked_reason(result, expected_code=EXPECTED_CODE_STALE).lower()
+    assert any(word in reason for word in ("veralt", "alt", "abgelaufen", "30")), (
+        f"Grund benennt die veraltete Rueckadresse nicht: {reason!r}"
+    )
+
+
+def test_reply_to_just_within_ttl_still_sends(stub) -> None:
+    """AC-5: Given Zeitstempel exakt eine Sekunde UNTER der 30-Tage-Frist /
+    When das Briefing versendet wird / Then geht die Premium-SMS regulaer
+    hinaus — die Frist blockiert nicht vorsorglich frueher."""
+    user_id = "tdd-1676-fresh-edge"
+    _write_profile(
+        user_id, tier="premium", reply_to=LEARNED_REPLY_TO,
+        reply_age=REPLY_TTL - timedelta(seconds=1),
+    )
+
+    _, result, _ = _dispatch(user_id, stub, send_sms=False, send_premium_sms=True)
+
+    assert len(stub.received) == 1, (
+        "Rueckadresse ist 30 Tage - 1 Sekunde alt und damit noch gueltig — genau "
+        f"EIN POST erwartet, bekommen: {stub.received!r} "
+        f"(blocked: {getattr(result, 'blocked_channels', None)!r})"
+    )
+    assert stub.received[0].get("to") == LEARNED_REPLY_TO
+
+
+# ---------------------------------------------------------------------------
+# AC-6: Text bitidentisch mit report.sms_text, <= 160 Zeichen
+# ---------------------------------------------------------------------------
+
+def test_text_matches_sms_text_verbatim_under_extreme_weather(stub) -> None:
+    """AC-6: Given Extremwetter-Fixture / When per Premium-SMS versendet wird /
+    Then ist der abgesendete Text bitidentisch mit dem tatsaechlich gerenderten
+    ``report.sms_text`` und nicht laenger als 160 Zeichen."""
+    user_id = "tdd-1676-text"
+    _write_profile(user_id, tier="premium", reply_to=LEARNED_REPLY_TO)
+
+    _, _, reports = _dispatch(
+        user_id, stub, send_sms=False, send_premium_sms=True, extreme=True,
+    )
+
+    assert len(reports) == 1, f"Erwartet genau EINEN gerenderten Report, bekommen {len(reports)}"
+    report = reports[0]
+    assert len(stub.received) == 1, (
+        f"Erwartet genau EIN Premium-SMS-POST, bekommen: {stub.received!r}"
+    )
+    sent_text = stub.received[0].get("text")
+    assert report.sms_text, "Renderer hat keinen SMS-Text erzeugt"
+    assert report.sms_text != report.email_plain, (
+        "Fixture unbrauchbar: sms_text und email_plain sind identisch — dann "
+        "koennte dieser Test einen Griff zum falschen Feld nicht unterscheiden."
+    )
+    assert sent_text == report.sms_text, (
+        "Abgesendeter Text weicht vom gerenderten report.sms_text ab.\n"
+        f"  gesendet: {sent_text!r}\n  gerendert: {report.sms_text!r}"
+    )
+    assert len(sent_text) <= 160, f"SMS-Text zu lang: {len(sent_text)} Zeichen"
+
+
+# ---------------------------------------------------------------------------
+# AC-8: standard-Tier loest nie einen Premium-SMS-Versand aus
+# ---------------------------------------------------------------------------
+
+def test_standard_tier_never_triggers_premium_sms_send(stub) -> None:
+    """AC-8: Given Tier ``standard`` mit aktiviertem ``send_premium_sms`` UND
+    gueltiger Rueckadresse / When das Versandfenster prueft / Then keine
+    Premium-SMS — obwohl derselbe Nutzer fuer den normalen SMS-Kanal
+    berechtigt ist."""
+    from services.user_tier import sms_allowed
+
+    user_id = "tdd-1676-standard"
+    _write_profile(user_id, tier="standard", reply_to=LEARNED_REPLY_TO)
+    assert sms_allowed(user_id) is True, (
+        "Voraussetzung des Tests: standard darf normale SMS — sonst prueft er "
+        "nur eine Generalsperre."
+    )
+
+    request, _, _ = _dispatch(user_id, stub, send_sms=True, send_premium_sms=True)
+
+    assert getattr(request, "send_premium_sms", None) is False, (
+        "Das Versandfenster hat Premium-SMS fuer einen standard-Nutzer "
+        f"freigegeben: {getattr(request, 'send_premium_sms', '<Feld fehlt>')!r}"
+    )
+    assert stub.to(LEARNED_REPLY_TO) == [], (
+        f"Premium-SMS an die gelernte Rueckadresse trotz Tier 'standard': "
+        f"{stub.to(LEARNED_REPLY_TO)!r}"
+    )
+    assert stub.to(CONFIG_SMS_TO), (
+        "Der normale SMS-Kanal muss weiter funktionieren (keine Generalsperre) — "
+        f"empfangen: {stub.received!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-8 am ZWEITEN Wirkort: der Wetterausfall-Hinweis
+# (Adversary-Fund F001, 2026-08-10)
+# ---------------------------------------------------------------------------
+
+def _outage_scheduler_class():
+    """Echter Scheduler, dessen Wetterquelle einen Totalausfall zurueckgibt.
+
+    Kein Mock: der Rueckgabewert ist bitgleich der Platzhalter, den
+    ``_fetch_weather()`` bei Provider-Fehlern selbst erzeugt (WEATHER-04,
+    ``trip_report_scheduler.py`` „Error-Placeholder statt auslassen") — nur ihr
+    ANTEIL (>75 %, ``OUTAGE_WITHHOLD_RATIO``) entscheidet ueber den
+    Ausfall-Pfad. Der zu pruefende Code, die Kanalentscheidung in diesem Pfad,
+    laeuft unveraendert; ein echter Provider-Ausfall waere hier nur langsamer
+    und wetterabhaengig, nicht aussagekraeftiger.
+    """
+    from app.models import SegmentWeatherData, SegmentWeatherSummary
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    class _OutageScheduler(TripReportSchedulerService):
+        def _fetch_weather(self, segments, provider=None):
+            return [
+                SegmentWeatherData(
+                    segment=segment,
+                    timeseries=None,
+                    aggregated=SegmentWeatherSummary(),
+                    fetched_at=datetime.now(timezone.utc),
+                    provider="unknown",
+                    has_error=True,
+                    error_message="Wetterdienst nicht erreichbar (aufgezeichneter Ausfall)",
+                )
+                for segment in segments
+            ]
+
+    return _OutageScheduler
+
+
+def test_standard_tier_gets_no_premium_sms_when_weather_data_fails(stub) -> None:
+    """AC-8 am zweiten Wirkort: Given Tier ``standard`` mit aktiviertem
+    ``send_premium_sms`` und gueltiger Rueckadresse UND der Wetterdienst faellt
+    komplett aus / When der Scheduler den Wetterausfall-Hinweis verschickt /
+    Then geht KEINE Premium-SMS hinaus, obwohl derselbe Lauf den normalen
+    SMS-Hinweis zustellt.
+
+    Das Tarif-Gate steht im Scheduler an ZWEI Kanal-Entscheidungsstellen —
+    Briefing und Ausfall-Hinweis. Entfernt man es an dieser zweiten, bleiben
+    alle uebrigen Tests dieser Datei gruen, weil sie nur die erste fahren
+    (nachgemessen, Adversary-Fund F001). Geprueft wird deshalb die WIRKUNG im
+    Ausfall-Pfad: was am Gateway ankommt.
+    """
+    from services.user_tier import sms_allowed
+
+    user_id = "tdd-1676-outage-standard"
+    _write_profile(user_id, tier="standard", reply_to=LEARNED_REPLY_TO)
+    assert sms_allowed(user_id) is True, (
+        "Voraussetzung des Tests: standard darf normale SMS — sonst prueft er "
+        "nur eine Generalsperre."
+    )
+    settings = _stub_settings(stub.port, user_id)
+    trip = _persisted_trip(user_id, send_sms=True, send_premium_sms=True)
+
+    scheduler = _outage_scheduler_class()(settings=settings, user_id=user_id)
+    outcome = scheduler._send_trip_report_outcome(trip, "evening")
+
+    assert outcome == "no_weather", (
+        f"Der Lauf hat den Wetterausfall-Pfad nicht genommen (outcome={outcome!r}) "
+        "— dann sagt dieser Test ueber die zweite Kanal-Entscheidungsstelle "
+        "nichts aus."
+    )
+    assert stub.to(CONFIG_SMS_TO), (
+        "Der Ausfall-Hinweis ist ueberhaupt nicht verschickt worden (kein "
+        f"SMS-POST): {stub.received!r}. Ohne ihn ist das Ausbleiben der "
+        "Premium-SMS kein Nachweis, sondern nur ein stiller Pfad."
+    )
+    assert stub.to(LEARNED_REPLY_TO) == [], (
+        "Premium-SMS an die gelernte Rueckadresse trotz Tier 'standard': "
+        f"{stub.to(LEARNED_REPLY_TO)!r} — am Wetterausfall-Hinweis fehlt das "
+        "Tarif-Gate; die SMS ist kostenpflichtig und geht an ein Geraet, fuer "
+        "das der Nutzer nicht bezahlt hat."
+    )
+
+
+def test_outage_hint_names_the_reason_when_premium_sms_is_blocked(stub) -> None:
+    """AC-3/D4 am zweiten Wirkort: Given ein Premium-Nutzer ohne gelernte
+    Rueckadresse / When der Wetterausfall-Hinweis verschickt wird / Then geht
+    keine Premium-SMS hinaus und der Grund steht im Ergebnis DIESES Versands.
+
+    ``blocked_channels`` wird an zwei Stellen gefuellt (Briefing und
+    Ausfall-Hinweis); bewacht war nur die erste. Ohne diesen Test koennte der
+    Ausfall-Hinweis den Grund verschlucken, ohne dass etwas rot wird.
+    """
+    from services.notification_service import NotificationService
+
+    user_id = "tdd-1676-outage-noreply"
+    _write_profile(user_id, tier="premium", reply_to=None)
+    settings = _stub_settings(stub.port, user_id)
+    trip = _persisted_trip(user_id, send_sms=False, send_premium_sms=True)
+
+    result = NotificationService(settings=settings, user_id=user_id).send_no_data_hint(
+        trip, "evening",
+        send_email=False, send_sms=False, send_telegram=False, send_premium_sms=True,
+    )
+
+    assert stub.received == [], (
+        f"Ohne gelernte Rueckadresse darf auch der Ausfall-Hinweis KEINEN POST "
+        f"absetzen, bekommen: {stub.received!r}"
+    )
+    _blocked_reason(result, expected_code=EXPECTED_CODE_NO_REPLY)
+    assert "premium_sms" not in result.sent_channels, (
+        f"Kanal als gesendet vermerkt, obwohl nichts hinausging: "
+        f"{result.sent_channels!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Persistenz: ein Speichervorgang ohne das Flag darf es nicht zuruecksetzen
+# ---------------------------------------------------------------------------
+
+def test_saving_a_trip_without_the_flag_keeps_a_stored_true() -> None:
+    """Given ein Trip mit gespeichertem ``send_premium_sms: true`` / When ein
+    Schreibvorgang laeuft, der das Flag NICHT mitsendet (der Weg der
+    Inbound-Kommandos ``/skip``/``/pause``: ``dataclasses.replace`` +
+    ``save_trip``) / Then steht das Flag danach unveraendert in der Datei.
+
+    Hintergrund: beim Kanal-Set ``alert_channels`` wird das GANZE Objekt
+    ersetzt (``internal/handler/trip.go`` — „gesetzt = ersetzt", all-or-nothing);
+    ein neues Feld, das die Oberflaeche nicht mitsendet, faellt dort still auf
+    ``false``. Fuer ``send_premium_sms`` traegt der Python-Schreibweg das Risiko,
+    weil er ein VOLLSTAENDIGES ``report_config``-Objekt aus dem Modell
+    serialisiert: liest der Ladeweg das Flag nicht, ueberschreibt der
+    Vorgabewert ``False`` den gespeicherten Wert — stiller Kanal-Abschalter
+    ohne Zutun des Nutzers.
+    """
+    import dataclasses
+
+    from app.loader import get_briefings_dir, load_trip, save_trip
+
+    user_id = "tdd-1676-persist"
+    trip = _persisted_trip(user_id, send_sms=False, send_premium_sms=True)
+    # Vorbedingung ist die DATEI, nicht das Modell: dass der Ladeweg den Wert
+    # uebernimmt, ist Teil des Prueflings — waere es die Vorbedingung, wuerde
+    # ausgerechnet der Verlustfall als "Vorbedingung nicht hergestellt"
+    # gemeldet und der eigentliche Befund verdeckt.
+    path = get_briefings_dir(user_id) / f"{trip.id}.json"
+    stored_before = json.loads(path.read_text(encoding="utf-8"))["report_config"]
+    assert stored_before.get("send_premium_sms") is True, (
+        "Vorbedingung nicht hergestellt — in der Datei steht gar nicht true: "
+        f"{stored_before.get('send_premium_sms')!r}"
+    )
+
+    # Ein Schreibvorgang, der NUR ein anderes Feld anfasst.
+    changed = dataclasses.replace(
+        trip,
+        report_config=dataclasses.replace(trip.report_config, skip_next=True),
+    )
+    written = save_trip(changed, user_id=user_id)
+    assert written == path, f"Unerwarteter Schreibpfad: {written} != {path}"
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    assert raw["report_config"].get("send_premium_sms") is True, (
+        "Das Flag ist beim Speichern verloren gegangen bzw. auf false "
+        f"zurueckgedreht: {raw['report_config'].get('send_premium_sms')!r} — der "
+        "Nutzer hat den Kanal gewaehlt und bekommt ihn ohne Vorwarnung nicht mehr."
+    )
+    reloaded = load_trip(path, user_id=user_id)
+    assert reloaded is not None and reloaded.report_config.send_premium_sms is True, (
+        "Nach dem Zuruecklesen ist der Kanal aus: "
+        f"{getattr(reloaded and reloaded.report_config, 'send_premium_sms', None)!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-10: Premium-SMS und SMS sind unabhaengig schaltbar
+# ---------------------------------------------------------------------------
+
+@pytest.mark.timeout(120)
+def test_premium_sms_and_sms_are_independently_switchable(stub) -> None:
+    """AC-10: Given alle vier Kombinationen aus ``send_sms``/
+    ``send_premium_sms`` / When das Briefing versendet wird / Then wird genau
+    der jeweils aktivierte Kanal angesprochen — unterschieden am ``to``-Wert."""
+    combos = [(False, False), (True, False), (False, True), (True, True)]
+    for index, (send_sms, send_premium_sms) in enumerate(combos):
+        user_id = f"tdd-1676-combo{index}"
+        _write_profile(user_id, tier="premium", reply_to=LEARNED_REPLY_TO)
+        before_sms = len(stub.to(CONFIG_SMS_TO))
+        before_premium = len(stub.to(LEARNED_REPLY_TO))
+
+        _dispatch(user_id, stub, send_sms=send_sms, send_premium_sms=send_premium_sms)
+
+        got_sms = len(stub.to(CONFIG_SMS_TO)) - before_sms
+        got_premium = len(stub.to(LEARNED_REPLY_TO)) - before_premium
+        assert (got_sms, got_premium) == (int(send_sms), int(send_premium_sms)), (
+            f"Kombination send_sms={send_sms}, send_premium_sms={send_premium_sms}: "
+            f"erwartet ({int(send_sms)} SMS, {int(send_premium_sms)} Premium-SMS), "
+            f"bekommen ({got_sms}, {got_premium}) — die Kanaele sind nicht "
+            "unabhaengig schaltbar."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Die zwei Sperrfaelle sind OHNE Textvergleich unterscheidbar
+# (Nachziehung 2026-08-10, Vorarbeit fuer den Alarmpfad #1701)
+# ---------------------------------------------------------------------------
+
+def _block_case(user_id: str, stub: _SevenIoStub, *, reply_to, reply_age) -> tuple:
+    """Faehrt den Kanal bis zur Sperre; gibt (Kurzschluessel, Prosatext).
+
+    Prüfort ist der Kanal selbst, weil GENAU DORT der Alarmpfad (#1701) den
+    Grund abgreift: er sieht die Ausnahme des Kanals, kein Ergebnisfeld des
+    Briefing-Aufrufers. Gefragt wird per ``getattr`` — genauso, wie ein
+    Aufrufer fragen muss, der auch Ausnahmen ohne Kurzschluessel faengt.
+    """
+    from output.channels.base import OutputConfigError
+    from output.channels.premium_sms import PremiumSmsOutput
+
+    _write_profile(user_id, tier="premium", reply_to=reply_to, reply_age=reply_age)
+    settings = _stub_settings(stub.port, user_id)
+    with pytest.raises(OutputConfigError) as caught:
+        PremiumSmsOutput(settings).send(subject="egal", body="egal")
+    code = getattr(caught.value, "reason_code", None)
+    assert isinstance(code, str) and code.strip(), (
+        f"Die Sperre traegt keinen maschinenlesbaren Grund (reason_code={code!r}) "
+        "— dann bleibt dem Alarmpfad nur der deutsche Prosatext, und ein "
+        "Vergleich darauf bricht beim ersten Umformulieren still."
+    )
+    return code, str(caught.value)
+
+
+def test_channel_name_premium_sms_resolves_to_the_premium_channel(stub) -> None:
+    """Given der Kanalname ``premium_sms`` wird ueber die zentrale Kanal-Fabrik
+    aufgeloest (der Weg der CLI, ``get_channel``) / When ohne gelernte
+    Rueckadresse gesendet wird / Then blockt derselbe Fail-Closed-Grund wie beim
+    direkt gebauten Kanal, und es geht KEIN POST hinaus.
+
+    Gemessen wird das Verhalten, nicht der Typ: waere der Name dort auf den
+    normalen SMS-Kanal verdrahtet, ginge hier eine kostenpflichtige SMS an
+    ``sms_to`` ab — mit falschem Absender und falschem Empfaenger — statt zu
+    blocken. Die Registrierung war bis hierhin von keinem Test beruehrt.
+    """
+    from output.channels.base import OutputConfigError, get_channel
+
+    user_id = "tdd-1676-factory"
+    _write_profile(user_id, tier="premium", reply_to=None)
+    settings = _stub_settings(stub.port, user_id)
+
+    with pytest.raises(OutputConfigError) as caught:
+        get_channel("premium_sms", settings).send(subject="egal", body="egal")
+
+    assert getattr(caught.value, "reason_code", None) == EXPECTED_CODE_NO_REPLY, (
+        f"Kanalname 'premium_sms' fuehrt nicht auf den Premium-Kanal: der "
+        f"Abbruch traegt {getattr(caught.value, 'reason_code', None)!r} statt "
+        f"{EXPECTED_CODE_NO_REPLY!r}."
+    )
+    assert stub.received == [], (
+        f"Trotz fehlender Rueckadresse ging ein POST hinaus: {stub.received!r}"
+    )
+
+
+def test_the_two_block_cases_carry_distinct_machine_codes(stub) -> None:
+    """Given die beiden Sperrfaelle (keine Rueckadresse / Rueckadresse aelter
+    als die Frist) / When der Premium-Kanal jeweils blockt / Then tragen die
+    Ausnahmen VERSCHIEDENE, stabile Kurzschluessel — ein Aufrufer unterscheidet
+    die Faelle, ohne deutschen Prosatext zu vergleichen — und der Prosatext
+    bleibt daneben erhalten."""
+    no_reply_code, no_reply_text = _block_case(
+        "tdd-1676-code-empty", stub, reply_to=None, reply_age=timedelta(minutes=5),
+    )
+    stale_code, stale_text = _block_case(
+        "tdd-1676-code-stale", stub, reply_to=LEARNED_REPLY_TO,
+        reply_age=REPLY_TTL + timedelta(seconds=1),
+    )
+
+    assert stub.received == [], (
+        f"Beide Faelle muessen VOR dem POST blocken, bekommen: {stub.received!r}"
+    )
+    assert no_reply_code != stale_code, (
+        f"Beide Sperrfaelle tragen denselben Kurzschluessel ({no_reply_code!r}) "
+        "— dann ist der deutsche Prosatext das einzige Unterscheidungsmerkmal, "
+        "und genau das soll er nicht sein."
+    )
+    # Zuordnung Fall -> Kennung, gegen ausgeschriebene Werte: ein Vertauschen
+    # der beiden Kennungen wuerde den Alarmpfad den falschen Grund buchen
+    # lassen, und ein Vergleich gegen die importierten Konstanten wuerde das
+    # Vertauschen mitziehen.
+    assert no_reply_code == EXPECTED_CODE_NO_REPLY, (
+        f"Fall 'keine gelernte Rueckadresse' meldet {no_reply_code!r}, erwartet "
+        f"{EXPECTED_CODE_NO_REPLY!r}."
+    )
+    assert stale_code == EXPECTED_CODE_STALE, (
+        f"Fall 'Rueckadresse veraltet' meldet {stale_code!r}, erwartet "
+        f"{EXPECTED_CODE_STALE!r}."
+    )
+    for code in (no_reply_code, stale_code):
+        assert re.fullmatch(r"[a-z][a-z0-9_]*", code), (
+            f"Kurzschluessel {code!r} ist kein stabiler Schluessel im Stil von "
+            "`alert_log.py` (channel_disabled, delivery_failed), sondern sieht "
+            "wie Prosatext aus — er wandert dann bei jeder Umformulierung mit."
+        )
+    for label, text in (("keine Rueckadresse", no_reply_text), ("veraltet", stale_text)):
+        assert len(text) > 60, (
+            f"Fall {label}: der menschenlesbare Grund ist auf {text!r} "
+            "geschrumpft — die Kennung kommt ZUSAETZLICH, sie ersetzt den "
+            "Prosatext nicht (Spec D4)."
+        )

--- a/tests/unit/test_user_tier.py
+++ b/tests/unit/test_user_tier.py
@@ -1,0 +1,69 @@
+"""Nutzerlevel-Gates (``src/services/user_tier.py``) — dateibasiert, ohne Netz.
+
+Bestand: ``sms_allowed()`` laesst ``standard`` UND ``premium`` durch (Epic
+#1067/#1069). Neu mit #1676 S2a: ``premium_sms_allowed()`` fuer den vierten
+Kanal — ausschliesslich ``premium``.
+
+Spec: docs/specs/modules/feat_1676_s2a_premium_sms_versand.md (AC-8, D7)
+
+``premium_sms_allowed`` wird ABSICHTLICH erst in der Testfunktion importiert:
+ein Import auf Modulebene wuerde die Datei beim Fehlen der Funktion komplett
+abbrechen und damit auch den Bestandsnachweis unten mitreissen.
+"""
+from __future__ import annotations
+
+import json
+
+from app.loader import get_data_dir
+from services.user_tier import sms_allowed
+
+
+def _profile(user_id: str, tier: str | None) -> str:
+    """Legt ``user.json`` in der (per conftest isolierten) Datenwurzel an."""
+    path = get_data_dir(user_id)
+    path.mkdir(parents=True, exist_ok=True)
+    data: dict = {"id": user_id}
+    if tier is not None:
+        data["tier"] = tier
+    (path / "user.json").write_text(json.dumps(data), encoding="utf-8")
+    return user_id
+
+
+def test_sms_allowed_matches_tier_table() -> None:
+    """Bestandsverhalten (Regressionsschutz): free nein, standard/premium ja,
+    fehlende Datei nein."""
+    assert sms_allowed(_profile("tdd-1676-tier-free", "free")) is False
+    assert sms_allowed(_profile("tdd-1676-tier-std", "standard")) is True
+    assert sms_allowed(_profile("tdd-1676-tier-prem", "premium")) is True
+    assert sms_allowed("tdd-1676-tier-nofile") is False
+
+
+def test_premium_sms_allowed_excludes_standard_tier() -> None:
+    """AC-8/D7: Given Tier ``standard`` / When die Premium-SMS-Berechtigung
+    geprueft wird / Then False — obwohl derselbe Nutzer fuer den normalen
+    SMS-Kanal berechtigt ist. Eine Delegation an ``sms_allowed()`` waere eine
+    stille Rechte-Ausweitung."""
+    from services.user_tier import premium_sms_allowed
+
+    std = _profile("tdd-1676-psms-std", "standard")
+    free = _profile("tdd-1676-psms-free", "free")
+    prem = _profile("tdd-1676-psms-prem", "premium")
+    no_tier = _profile("tdd-1676-psms-notier", None)
+
+    assert sms_allowed(std) is True, (
+        "Voraussetzung: standard darf normale SMS — sonst zeigt der Vergleich unten nichts."
+    )
+    assert premium_sms_allowed(std) is False, (
+        "standard-Tier darf KEINE Premium-SMS ausloesen (Premium-Merkmal, D7)."
+    )
+    assert premium_sms_allowed(free) is False
+    assert premium_sms_allowed(no_tier) is False, (
+        "Bestandsnutzer ohne tier-Feld verhaelt sich wie free — kein impliziter "
+        "Premium-Zugriff durch ein fehlendes Feld."
+    )
+    assert premium_sms_allowed("tdd-1676-psms-nofile") is False, (
+        "Fehlende user.json darf Premium-SMS nicht versehentlich erlauben."
+    )
+    assert premium_sms_allowed(prem) is True, (
+        "premium-Tier muss Premium-SMS erlauben — sonst ist der Kanal generell tot."
+    )


### PR DESCRIPTION
## Was diese Scheibe leistet

Das Trip-Briefing kann als **Premium-SMS** an ein Garmin inReach gehen. Scheibe S1 lernt die
Rückadresse des Geräts bereits — ohne diese Scheibe ging damit nichts hinaus.

Drei Unterschiede zum normalen SMS-Kanal:

| | SMS | Premium-SMS |
|---|---|---|
| Absender | Konto-Standard (ein **Name**, auf 11 Zeichen gekürzt) | fest die gemietete Dienstnummer |
| Empfänger | Handynummer aus dem Nutzerprofil | die von S1 **gelernte** Rückadresse, nicht editierbar |
| Tarif | `standard` **und** `premium` | ausschließlich `premium` |

Bei fehlender oder über **30 Tage** alter Rückadresse geht nichts hinaus — mit auswertbarem Grund,
nicht als stiller Fehlschlag. Die 30 Tage sind eine PO-Entscheidung (2026-08-10), kein Messwert;
die Widerlegungsbedingungen stehen in der Spec unter D6.

## Bauentscheidungen, die eine Begründung brauchen

**Gemeinsame Basisklasse statt Kopie.** `SevenIoChannelBase` trägt die zwei Sicherheitssperren
(Test-Modus-Sandbox, Herkunftssperre) und den HTTP-Transport genau einmal. Eine Kopie von `sms.py`
hätte sie verdoppelt — und `test_channel_origin_guard_parity.py` prüft nur **namentlich genannte**
Klassen, hätte eine vergessene Sperre also nicht bemerkt.

**`_origin()` bleibt je Kanal-Modul auflösbar**, nicht in der Basisklasse. Drei Bestandstests
patchen `running_origin` im `sms`-Modul; hätte die Basisklasse es selbst aufgelöst, wären diese
Patches wirkungslos geworden und die Tests **still falsch grün**.

**Die Fail-closed-Prüfung sitzt IN der Kanal-Klasse, nicht am Aufrufort.** Der bestehende
SMS-Zweig prüft `can_send_sms()` vor dem `try` — ist das falsch, passiert schlicht nichts, ohne Log
und ohne Ergebnisfeld. Für SMS tolerierbar, für einen kostenpflichtigen Kanal nicht.

**Ein zunächst gebautes `can_send_premium_sms()` wurde wieder entfernt** (Adversary-Befund F003):
eine vorgeschaltete Bereitschaftsfrage hätte die Fail-closed-Prüfung im Kanal *abgeschirmt* und die
Mutations-Gegenprobe entwertet. An ihrer Stelle steht eine Begründung im Code plus ein Wächter, der
ihre Rückkehr rot macht.

**ENV-Sperre für Rückadresse UND Zeitstempel.** `env_prefix="GZ_"` gilt für jedes deklarierte
Settings-Feld; deklariert werden muss es aber, weil `extra="ignore"` undeklarierte Werte lautlos
verschluckt. Der Zeitstempel ist mitgesperrt, weil eine Frist, die per Umgebungsvariable
auffrischbar ist, keine Frist wäre.

**Kein eigener Render-Pfad.** `report.sms_text` wird unverändert übernommen (160 Zeichen). Die 153
aus `CHANNEL_LIMITS` sind die Segmentgrenze **verketteter** SMS und werden vom Briefing-Pfad nie
gelesen — eine ursprüngliche Annahme, die beim Nachmessen fiel.

**Kein Go-Produktivcode.** `send_premium_sms` lebt im freien `report_config`-Map und übersteht
Speichern/Laden über den bestehenden feldweisen Merge. Belegt durch einen Mutationstest, nicht
behauptet.

**ADR-0049** schreibt ADR-0004 („nur noch drei Kanäle") fort, statt es still zu unterlaufen.

## Nachweis

- **27 gezielte Tests** gegen einen **echten lokalen HTTP-Server**, kein Mock, kein `patch()` als
  Verhaltensnachweis.
- **Adversary VERIFIED** nach zwei Runden. Die erste endete **BROKEN** mit drei Befunden, alle
  behoben. Der schwerste (F001, HIGH) war *Prüfort ≠ Wirkort*: die Tarifsperre stand korrekt an
  **beiden** Entscheidungsstellen, aber nur eine war testbewacht — das Entfernen an der zweiten
  ließ alle Tests grün. In der zweiten Runde wurden 7 von 7 Mutationen gefangen.
- **Vollsuite 7725 grün, 2 rot** — beide vorbestehend und fremd: die bekannte Zeitabhängigkeit der
  Alarm-/Anker-Familie und `test_issue_1014_live_optin` (Worktree-`.env`).

## Nicht in dieser Scheibe

- **#1701** — Alarm- und Vergleichspfad. Wird parallel gebaut; der Sperrgrund trägt deshalb eine
  maschinenlesbare Kennung, damit dort nicht auf deutschen Prosatext verglichen werden muss.
- **#1702** — eigene Kostenstelle.
- **S3** — Oberfläche. `send_premium_sms` ist bislang nur über `report_config` setzbar.

## Ausdrücklich NICHT bewiesen

Dass die SMS **auf dem Gerät ankommt**. Die Herkunftssperre erzwingt außerhalb der
Produktionswurzel den Sandbox-Key, der laut seven.io nie sendet; `force_test` sandboxiert Staging
zusätzlich. Ein grüner Testlauf hier heißt: Nutzlast richtig, Empfänger richtig aufgelöst, Sperre
wirksam, Guards greifen — **nicht** „angekommen". Das ist die Generalprobe **#1533** (Frist 20.8.).

## Hinweis zur Ampel

Es ist Abend UTC. In diesem Repo werden zu dieser Tageszeit Tests der Alarm-/Anker-Familie von
selbst rot (Etappendaten auf `date.today()`, Ankunftszeiten ohne Tagesüberlauf). Rote Fälle aus
dieser Familie sind kein Befund dieses PR — entscheidbar ist das nur per `gh run rerun` auf
demselben Commit zu anderer Uhrzeit, nicht per zweitem Diff.

Refs #1676

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZgT7vzYTtQRQBwnjyP9pg
