### PR TITLE
test(#1703): Scheibe 3 -- get_all_metrics()-vs-_METRICS-Blindstelle schliessen

### DIFF
--- a/docs/context/feat-1703-s3-selectable-metrics.md
+++ b/docs/context/feat-1703-s3-selectable-metrics.md
@@ -1,0 +1,120 @@
+# Context: #1703 Scheibe 3 — Nicht-wählbare Register-Metriken
+
+## Request Summary
+
+Epic #1703 (Folgearbeit aus #1514) baut den Matrix-Wächter `tests/tdd/test_channel_metric_matrix.py`
+(#1677 B) achsenweise aus. Scheibe 3 muss laut PO-Reihenfolge **zuerst** laufen: die
+`get_all_metrics()`-Blindstelle (`src/app/metric_catalog.py:693`) filtert `selectable=False`-
+Metriken aus JEDER Vollständigkeitsprüfung, die auf ihr aufbaut — Scheiben 1/2/4/5 würden sie
+sonst erben. Ziel: ein Wächter, der für jede nicht-wählbare Register-Metrik mit Ausgabefeld
+(`sms_code`, `alert_label`, `summary_fields`, …) prüft, dass sie dort ankommt (oder dokumentiert
+NICHT ankommt), wo das Feld sie hinschickt.
+
+## Ausgangslage: DREI nicht-wählbare Metriken, DREI verschiedene Sollzustände
+
+`grep "selectable=False" src/app/metric_catalog.py` (Stand 2026-08-10):
+
+| Metrik | Ausgabefelder | PO-Regel / Soll |
+|---|---|---|
+| `confidence` (#710/#715, final) | keine (`sms_code`/`alert_label` fehlen) | NUR 3 erlaubte Orte: E-Mail-Textblock (`build_confidence_hint`), SMS-Token, interne Aggregation. NIE als Spalte/Metrik-Auswahl |
+| `temperature_cold` (#914) | `sms_code="N"`, `alert_label="Temp"`, `summary_fields={"min": "temp_min_c"}` | Kältealarm MUSS ankommen (Alarm-Renderer, Compare-Aktivierung); Mail-Spalte fällt bewusst in den `remaining`-Fallback (Bestand, s.u.) |
+| `cape` (#1585, PO-Regel final) | `sms_code="CP"`, `alert_label="CAPE"` | Darf **nirgends** sichtbar sein — nur interne Berechnung (`thunder_level_from_signals`, CAPE-Delta-Alarm #1592) |
+
+Ein naiver Wächter „nicht-wählbar + hat `sms_code` ⇒ muss ankommen" würde für `cape` das exakte
+Gegenteil der PO-Entscheidung festschreiben. Die drei Fälle brauchen **je eigene** Zusicherung,
+keine gemeinsame Formel.
+
+## Bereits vorhandene Infrastruktur (NICHT neu erfinden)
+
+- **`_is_selectable()` + `_SELECTABLE_GATE_EXEMPT`** (`src/app/models.py:613-650`, #1585): zentraler
+  Choke-Point, den `_filter_metrics_by_report_type()` (models.py:653, speist E-Mail+SMS+Telegram)
+  nutzt. Exemption-Liste ist klein, benannt, darf nur schrumpfen — aktuell nur `temperature_cold`.
+- **`is_alert_metric_active()`** (`src/services/weather_change_detection.py:181-236`, #1585):
+  prüft das `_ALERT_METRIC_TO_CATALOG_ID`-Tupel als Ganzes (nicht Glied-für-Glied) — verhindert,
+  dass ein Filter auf `temperature_cold` den `TEMPERATURE_MIN`-Alarm stumm schaltet.
+- **Bestehende Charakterisierungstests je Metrik** (nicht Gegenstand dieser Scheibe, aber Referenz):
+  `tests/tdd/test_cape_not_selectable.py` (AC-3/AC-9, Choke-Points `_filter_metrics_by_report_type`
+  + `is_alert_metric_active`), `tests/tdd/test_issue_715_confidence_not_selectable.py`,
+  `tests/unit/test_metric_catalog.py::test_ac4_temperature_cold_bleibt_unveraendert_n`.
+
+## Gemessene Lücke: weitere `.selectable`-Stellen OHNE Exemption-Bewusstsein
+
+`grep "\.selectable\b" src/` findet **8 weitere** Stellen, die den rohen Katalog-Flag prüfen,
+NICHT über `_is_selectable()` (die die Exemption-Liste kennt):
+
+| Datei:Zeile | Kontext | Bewertung |
+|---|---|---|
+| `output/renderers/email/helpers.py:311` (`resolve_metric_col_order`) | Spaltenreihenfolge E-Mail/Plain | **Bewusste Ausnahme, dokumentiert** (models.py:619-625): `temperature_cold` fällt hier raus, landet aber über den `remaining`-Zweig (`email/html.py:681`) hinten in der Tabelle — bestehender, testgehaltener Zustand (`test_mail_column_order.py::test_legacy_config_without_order_keeps_catalog_order`) |
+| `output/renderers/email/helpers.py:120`, `:177` (`dp_to_row` Stundentabelle) | Stundenverlauf Trip | Kein Kommentar zu `temperature_cold`/Exemption — muss geprüft werden, ob das Fehlen dort Bestand oder Lücke ist |
+| `output/renderers/email/helpers.py:288` (`get_hourly_metric_ids` neuer Pfad) | Stundenverlauf-Spaltenauswahl | dito |
+| `output/renderers/compare_metric_catalog.py:284` | Compare-Katalog-Label-Auflösung | Kommentiert als Issue #1585/CAPE-Fall — `temperature_cold` nicht erwähnt, aber `temperature_cold` ist nie Teil von `COMPARE_METRIC_CATALOG` (nur Trip-Alarm-Pseudogröße), also strukturell nicht betroffen — verifizieren |
+| `output/renderers/compare_metric_ids.py:140` (`_non_selectable_keys`) | Compare gespeicherte Auswahl | Analog, generisch aus Katalog abgeleitet |
+| `app/metric_catalog.py:615/661/869/945` | katalog-intern (`get_metric`-Familien, Template-Filter) | Katalog-eigene Konsistenz, kein externer Ausgabeort |
+
+**Kernbefund:** Es gibt zwei parallele "ist die Größe wählbar?"-Prüfungen im Code — die
+exemption-bewusste `_is_selectable()` und die rohe `mdef.selectable`-Prüfung an mehreren Stellen.
+Das ist laut Code-Kommentar für `resolve_metric_col_order` **bewusst** (mit kompensierendem
+Fallback). Für die beiden Stundentabellen-Stellen (`dp_to_row`, `get_hourly_metric_ids`) ist nicht
+dokumentiert, ob ein künftiges `temperature_cold`-Vorkommen dort ebenfalls einen Fallback hätte
+oder einfach lautlos verschwindet — das ist eine der beiden Fragen, die die Spec-Phase klären muss.
+
+## Related Files
+
+| File | Relevance |
+|---|---|
+| `src/app/metric_catalog.py` | Katalog, `get_all_metrics()` (Blindstelle), 3 `selectable=False`-Definitionen |
+| `src/app/models.py:613-686` | `_SELECTABLE_GATE_EXEMPT`, `_is_selectable()`, `_filter_metrics_by_report_type()` |
+| `src/services/weather_change_detection.py:181-236` | `is_alert_metric_active()`, Tupel-weise Prüfung |
+| `src/output/renderers/email/helpers.py:100-320` | 4 Stellen mit rohem `.selectable`-Check |
+| `src/output/renderers/compare_metric_catalog.py`, `compare_metric_ids.py` | Compare-seitige `.selectable`-Checks |
+| `src/services/compare_alert.py:59` | `_SUMMARY_KEY_TO_CATALOG_ID` mappt `temp_min_c` → `temperature_cold` (Compare-Aktivierungssignal) |
+| `tests/tdd/test_channel_metric_matrix.py` | Ziel-Datei für die neue Achse (Option C, kein neues Gate) |
+| `tests/tdd/test_cape_not_selectable.py` | Bestehende Charakterisierung CAPE (Referenzmuster für Scheibe-3-Assertions) |
+| `tests/tdd/test_issue_715_confidence_not_selectable.py` | Bestehende Charakterisierung confidence |
+| `docs/reference/metric_output_matrix.md` §6 Scheibe 3 | Auftragsbeschreibung, Definition of Done (Doku-Zelle umtragen) |
+
+## Existing Specs
+
+- `docs/specs/modules/feat_1585_cape_selectable_false.md` — Vorgänger-Spec, gleiches Muster
+- `docs/specs/modules/fix_1677_sms_reihenfolge.md` — AC-13/14/15, definiert den bestehenden
+  Matrix-Test, den Scheibe 3 erweitert (Option C: kein neuer Test, neue Achse in derselben Datei)
+- `docs/specs/modules/konzept_1514_metrik_ausgabeorte.md` — Ursprungskonzept, Herkunft von #1703
+
+## Risks & Considerations
+
+- **Kollateralschaden-Muster (#1585, memory `reference_selectable_gate_collateral_damage_pattern`):**
+  ein neuer generischer Filter kann eine ANDERE, bereits etablierte Ausnahme treffen. Vor jeder
+  Code-Änderung: alle 3 non-selectable Metriken einzeln durchspielen (bereits oben getan) — gilt
+  für neue Testerwartungen genauso wie für Produktivcode.
+- **KORREKTUR (2026-08-10, per echtem Rendering widerlegt — vormals hier als „empirisch geklärt"
+  behauptet):** `temperature_cold` erscheint SEHR WOHL als eigene Stundenspalte „TmpMin" in der
+  Trip-Mail, mit identischem Wert zu „Temp" in jeder Stunde (echte Dublette, per
+  `TripReportFormatter().format_email()`-Rendering nachgemessen). Der Fehler in der ursprünglichen
+  Analyse: `email/helpers.py::dp_to_row()`/`get_hourly_metric_ids()` (dort sitzt der geprüfte
+  `.selectable`-Check) hat **keinen einzigen Produktions-Aufrufer** in `src/` — der tatsächliche
+  Trip-Mail-Pfad läuft über `TripReportFormatter._dp_to_row()`/`_aggregate_night_block()`
+  (`trip_report.py:627`/`534`), eine ZWEITE, gleichnamige Implementierung OHNE eigenen
+  `.selectable`-Check. Sie verlässt sich vollständig auf die vorgelagerte, exemption-bewusste
+  Kollabierung `dc.get_metrics_for_channel("email", report_type)` (`trip_report.py:135-138` →
+  `_is_selectable()`) — und die lässt `temperature_cold` (Exemption) durch, unverändert `enabled=True`,
+  bis in die Zeilen-Builder. Zwei Lehren: (1) „Prüfort = Wirkort" gilt auch für den eigenen
+  Analyseschritt, nicht nur für Tests — ein gleichnamiger Funktionsname beweist nicht denselben
+  Wirkort; (2) die ~13 Testdateien, die `email/helpers.py::dp_to_row()` isoliert aufrufen (u.a.
+  `test_cape_not_selectable.py`, `test_issue_715_confidence_not_selectable.py`), prüfen für den
+  Trip-Mail-Aspekt eine produktiv tote Funktion — für `cape`/`confidence` zufällig folgenlos (beide
+  werden schon VOR `_dp_to_row()` aus `dc.metrics` entfernt), aber strukturell die falsche Stelle.
+  `temperature_cold` kommt weiterhin in `COMPARE_METRIC_CATALOG` nicht vor (grep bestätigt leer) —
+  die Compare-seitigen `.selectable`-Checks bleiben für sie gegenstandslos, relevant nur für
+  `cape`/`confidence`.
+- **Scope-Grenze:** Scheibe 3 soll laut Doku „klein" sein — die Recherche bestätigt das jetzt: kein
+  Produktivcode-Fix nötig, nur ein Wächter, der die oben hergeleiteten Fakten in Tests gießt.
+- **Kein neues Pflicht-Gate:** Erweiterung des bestehenden budgetierten Gates #1677 B — Regel-Budget
+  beachten (kein Ersatz nötig, ist Erweiterung eines bestehenden Gates).
+- **Definition of Done laut Epic:** nach Abschluss die „unbewacht"-Zelle in
+  `docs/reference/metric_output_matrix.md` §4 auf den neuen Wächter umtragen.
+
+## Next Step
+
+`/20-analyse` (bzw. direkt in Spec-Phase, da Standard Track Context+Analyse kombiniert) — die
+offene Frage aus „Risks" (Stundentabellen-Verhalten für `temperature_cold`) muss vor der Spec
+per Messung (kleiner Testlauf) beantwortet werden.

--- a/docs/reference/metric_output_matrix.md
+++ b/docs/reference/metric_output_matrix.md
@@ -161,6 +161,17 @@ Ausgaben erscheint. Das ist keine Lücke in einem Test, sondern eine Blindstelle
 `get_all_metrics()`) und die Wirkung strukturell: sie repariert die Aussagekraft
 jeder künftigen Achse mit.*
 
+**✅ Erledigt (2026-08-10, Epic #1703 Scheibe 3):** Wächter in
+`tests/tdd/test_channel_metric_matrix.py` (`test_ac1_confidence_absent_from_mail_telegram_compare`
+bis `test_ac8_non_selectable_metrics_stay_out_unless_exempt`) — parametrisiert über `_METRICS` +
+`_SELECTABLE_GATE_EXEMPT`, deckt `confidence`/`cape`/`temperature_cold` einzeln ab plus generisch
+jede künftige `selectable=False`-Metrik mit Ausgabefeld. Spec:
+`docs/specs/modules/fix_1703_s3_selectable_metrics.md`. Adversary VERIFIED (Finding F001 zu AC-3
+korrigiert — der Kältealarm bleibt nicht wegen der Exemption aktiv, sondern über den OR-Tupel-
+Mechanismus in `is_alert_metric_active()`, s. Spec-Korrekturabschnitt). Nebenbefund (kein Fix
+dieser Scheibe): `temperature_cold` erscheint als echte Dublette „TmpMin"/„Temp" in der
+Stundentabelle (AC-6, Charakterisierung).
+
 ### 4.2 Priorität 2 und 3
 
 | # | Unbewachte Fläche | Ort | Prio | Bemerkung |
@@ -261,7 +272,7 @@ beiden Mail-Pfaden (`email/outlook.py:149`, `:343`, `:522`).
 *Risiko: mittel. Größe: mittel–groß — zwei Produktflächen, eine geteilte
 Spaltenquelle, deshalb eine Assertion-Familie für beide.* Deckt Fläche 2.
 
-### Scheibe 3 — Nicht-wählbare Register-Metriken
+### Scheibe 3 — Nicht-wählbare Register-Metriken ✅ ERLEDIGT (2026-08-10)
 
 Ein kleiner Test, der über `_METRICS` statt `get_all_metrics()`
 (`metric_catalog.py:695`) iteriert und für jede nicht-wählbare Metrik mit
@@ -269,6 +280,11 @@ Ausgabefeldern (`sms_code`, `alert_label`, …) prüft, dass sie dort ankommt, w
 das Feld sie hinschickt — heute betrifft das `temperature_cold`.
 *Risiko: niedrig. Größe: klein.* **Sollte zuerst laufen** — sie repariert die
 Aussagekraft aller anderen Achsen mit. Deckt Fläche 3.
+
+Umgesetzt als 8 ACs (AC-1 bis AC-8) in `tests/tdd/test_channel_metric_matrix.py`, gemessen
+gegen den echten Renderpfad (`TripReportFormatter().format_email()`, nicht die produktiv
+ungenutzte `email/helpers.py::dp_to_row()`). Details, Sollzustand je Metrik, Mutations-
+Gegenprobe: `docs/specs/modules/fix_1703_s3_selectable_metrics.md`.
 
 ### Scheibe 4 — Kurzform-Mail, Kompaktzeilen, Kompakt-Zusammenfassung, Telegram-Kurzform
 

--- a/docs/specs/modules/fix_1703_s3_selectable_metrics.md
+++ b/docs/specs/modules/fix_1703_s3_selectable_metrics.md
@@ -1,0 +1,459 @@
+---
+entity_id: fix_1703_s3_selectable_metrics
+type: module
+created: 2026-08-10
+updated: 2026-08-10
+status: draft
+version: "1.0"
+tags: [metrics, selectable, matrix-test, epic-1703, non-selectable]
+---
+
+<!-- Epic #1703 (Folgearbeit aus #1514), Scheibe 3 -- PO-Reihenfolge: MUSS
+     zuerst laufen. Schliesst Flaeche 3 aus docs/reference/metric_output_matrix.md
+     §4.1: get_all_metrics() filtert selectable=False heraus, jeder
+     Vollstaendigkeitstest, der ueber get_all_metrics() iteriert (Scheiben
+     1/2/4/5), erbt strukturell diese Blindstelle. -->
+
+# Nicht-wählbare Register-Metriken: die `get_all_metrics()`-Blindstelle schließen (#1703 Scheibe 3)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`get_all_metrics()` (`src/app/metric_catalog.py:693-701`) liefert
+`[m for m in _METRICS if m.selectable]` — jeder Vollständigkeitstest, der
+über diese Funktion iteriert (das werden die Scheiben 1/2/4/5 in
+`tests/tdd/test_channel_metric_matrix.py` tun), kann `selectable=False`-
+Metriken strukturell nie sehen. Das ist keine Lücke in einem einzelnen
+Test, sondern eine Blindstelle **aller** künftigen Matrix-Achsen gleichzeitig
+(`docs/reference/metric_output_matrix.md` §4.1, "Fläche 3"). Diese Scheibe
+schließt sie mit einem kleinen, generischen Wächter, der stattdessen über
+`_METRICS` iteriert und für jede nicht-wählbare Register-Metrik mit
+Ausgabefeldern (`sms_code`, `alert_label`, `summary_fields`, …) prüft, dass
+sie GENAU dort ankommt (oder GENAU dort NICHT ankommt), wo ihr dokumentierter
+Sollzustand es vorschreibt — heute drei Fälle (`confidence`, `cape`,
+`temperature_cold`), je mit eigenem Sollzustand, keiner gemeinsamen Formel.
+
+**Kein Produktivcode-Fix ist Auftrag dieser Scheibe.** Ziel ist ausschließlich
+ein neuer, zukunftssichernder Wächter in einer bestehenden, bereits
+budgetierten Testdatei (#1677 B, Option C aus `metric_output_matrix.md` §5 —
+Matrix-Test achsenweise erweitern, kein zweites Register, kein neues
+Pflicht-Gate).
+
+### Korrektur gegenüber dem Kontext-Dokument (gemessen 2026-08-10)
+
+`docs/context/feat-1703-s3-selectable-metrics.md` behauptet unter „Risks",
+die Stundentabellen-Frage sei „EMPIRISCH GEKLÄRT": `temperature_cold`
+erscheine **nicht** als eigene Stundenspalte, weil `dp_field="t2m_c"`
+identisch mit der Spalte „Temp" sei und eine Dublette wäre — „korrekt und
+braucht keinen Fallback". Ein direkter Render-Test gegen
+`TripReportFormatter().format_email(...)` mit `build_default_display_config()`
+widerlegt das:
+
+```
+row = fmt._dp_to_row(data[0], config)
+# {'time': '00', 'temp': 12.0, 'temp_cold': 12.0, 'felt': 8.0, ...}
+```
+
+Die Spalte **erscheint** — als „TmpMin" am Ende der Kopfzeile (`['Time',
+'Temp', 'Feels', 'Wind', 'Gust', 'Rain', 'Thdr', 'SnowL', 'Cloud', 'Sun',
+'TmpMin', 'Risk']`), mit **identischem Zahlenwert** zu „Temp" in jeder
+Stunde. Grund: `TripReportFormatter._dp_to_row()`/`_aggregate_night_block()`
+(`trip_report.py:627`/`534`) — die tatsächlich produktiv aufgerufenen
+Zeilen-Baumethoden — haben **keinen** eigenen `.selectable`-Check; sie
+verlassen sich vollständig auf die vorgelagerte Kollabierung
+`dc.get_metrics_for_channel("email", report_type)` (`trip_report.py:135-138`),
+und die IST exemption-bewusst (`_is_selectable()`, `models.py:629`) —
+`temperature_cold` übersteht sie also und erreicht die Zeilen-Builder
+unverändert `enabled=True`. Der im Kontext-Dokument (und im ursprünglichen
+Auftragstext dieser Scheibe) zitierte `.selectable`-Check in
+`email/helpers.py::dp_to_row()`/`aggregate_night_block()` (Zeile 120/177) ist
+eine **zweite, produktiv ungenutzte** Implementierung gleichen Namens — kein
+Aufrufer in `src/` erreicht sie über den Trip-Mail-Pfad (nur die
+modul-eigene, selbst nirgends aufgerufene `extract_hourly_rows()` und ~13
+Testdateien, die sie isoliert aufrufen). Details, Einordnung und
+Scope-Entscheidung: s. „Known Limitations".
+
+**Konsequenz für diese Spec:** AC-6 unten hält den **gemessenen** Ist-Zustand
+fest (Charakterisierung: die Dublette existiert), nicht die im
+Kontext-Dokument angenommene Abwesenheit. Ob die Dublette selbst ein
+Nebenbefund für #1199 ist, entscheidet der PO/Team-Lead bei Spec-Freigabe —
+diese Spec fixt sie nicht (kein Produktivcode-Auftrag, s. Purpose oben).
+
+## Source
+
+> **Schicht-Hinweis:** ausschließlich Python-Core, ausschließlich Testcode.
+> Kein Frontend, keine Go-Beteiligung.
+
+- **File:** `tests/tdd/test_channel_metric_matrix.py`
+- **Identifier:** neue parametrisierte Testfunktionen, die den bestehenden
+  AC-13/14/15-Block (#1677 B) um eine vierte Achse ergänzen. Iterationsbasis
+  ist `app.metric_catalog._METRICS` (Modul-Liste, Zeilen 92-593), NICHT
+  `get_all_metrics()` — genau das ist die zu schließende Blindstelle.
+
+**Ausdrücklich UNVERÄNDERT (reine Prüfziele, kein Edit):**
+
+- `src/app/metric_catalog.py` — `_METRICS`/`_METRICS_BY_ID` (Z. 92-593/593),
+  `get_all_metrics()` (Z. 693-701, die Blindstelle selbst — bleibt bewusst
+  bestehen, sie ist für ihre eigentlichen Aufrufer `/api/metrics` und
+  Trip-Editor korrekt; nur Vollständigkeitstests dürfen sie nicht mehr als
+  einzige Iterationsbasis nutzen), drei `selectable=False`-Definitionen:
+  `temperature_cold` (Z. 120-129), `confidence` (Z. 322-331), `cape`
+  (Z. 351-383)
+- `src/app/models.py` — `_SELECTABLE_GATE_EXEMPT` (Z. 626, aktuell
+  `frozenset({"temperature_cold"})`), `_is_selectable()` (Z. 629-650),
+  `_filter_metrics_by_report_type()` (Z. 653-686), gemeinsamer Choke-Point für
+  `get_metrics_for_channel()`/`get_metrics_for_report_type()` (Z. 797-842)
+- `src/output/renderers/trip_report.py` — `TripReportFormatter.format_email()`
+  Kollabierungsschritt `dc.get_metrics_for_channel("email", report_type)`
+  (Z. 135-138, DER eigentliche Choke-Point für Trip-Mail+Stundentabelle),
+  `_dp_to_row()` (Z. 627-662), `_aggregate_night_block()` (Z. 534),
+  `_visible_cols()` (Z. 668-673)
+- `src/output/renderers/email/helpers.py` — `resolve_metric_col_order()`
+  (Z. 302-315, raw `.selectable`-Check ohne Exemption, dokumentierte
+  Ausnahme via `remaining`-Fallback), `dp_to_row()`/`aggregate_night_block()`/
+  `visible_cols()` neuer Pfad (Z. 103-137/157-235/253-293 — **nicht** Ziel
+  dieser Scheibe, s. Known Limitations)
+- `src/output/renderers/email/html.py` — `remaining`-Fallback-Zweig
+  (Z. 678-682), `_col_order = resolve_metric_col_order(dc)` (Z. 1021)
+- `src/services/weather_change_detection.py` — `is_alert_metric_active()`
+  (Z. 181-238), `_ALERT_METRIC_TO_CATALOG_ID[AlertMetric.TEMPERATURE_MIN] =
+  ("temperature_cold", "temperature")` (Z. 85)
+- `src/services/compare_alert.py` — `_SUMMARY_KEY_TO_CATALOG_ID["temp_min_c"]
+  = "temperature_cold"` (Z. 59), `_display_config_from_active_metrics()`
+  (Z. 475-524)
+- `src/output/renderers/compare_metric_catalog.py::get_compare_metric_catalog()`
+  (Z. 284, raw `.selectable`-Check)
+- `src/output/renderers/compare_metric_ids.py::_non_selectable_keys()`
+  (Z. 140, raw `.selectable`-Check, `resolve_enabled_metrics()`)
+
+## Estimated Scope
+
+- **LoC:** ~110-170 Testcode (8 ACs, davon 3 mit echtem Mehrfach-Render
+  gegen die tatsächliche Produktionspipeline — `TripReportFormatter().format_email()`,
+  Telegram-rich, Compare —, 1 generischer Parametrisierungs-Block über
+  `_METRICS`). Kein Produktivcode-Delta.
+- **Files:** 1 (`tests/tdd/test_channel_metric_matrix.py`, Erweiterung —
+  kein neues Modul, s. Test-Namensregel CLAUDE.md).
+- **Effort:** low. Doku selbst nennt „klein" (`metric_output_matrix.md` §6
+  Scheibe 3: „Risiko: niedrig. Größe: klein."); die Recherche bestätigt das —
+  einzige Komplexität ist das korrekte Anzapfen der ECHTEN Produktionspfade
+  (s. Korrektur oben), nicht die Testmenge selbst.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `tests/tdd/test_cape_not_selectable.py` | REFERENZ (Teststil, Regression-Baseline) | `TestAlertEngineExcludesCape` (AC-9-Muster: Größe + Kollateralschaden-Wächter) ist Vorbild für AC-2/AC-8 unten. `TestEmailTableExcludesCapeColumn::test_dp_to_row_excludes_cape_col_key` testet **nicht** den produktiven Trip-Mail-Pfad (s. Known Limitations) — bleibt unangetastet, wird hier nicht als Beleg für AC-2/AC-6 herangezogen |
+| `tests/tdd/test_issue_715_confidence_not_selectable.py` | REFERENZ (Teststil) | Vorbild für AC-1 (API-Exclusion, `/api/metrics`) |
+| `tests/tdd/test_compare_alert_metric_gating.py::test_f002_guard_temp_min_active_min_temp_delta_fires` | REFERENZ (Bestand, bleibt grün) | Deckt AC-4 (Compare-Aktivierung `temperature_cold`) bereits ab — kein redundanter Test, nur generische Mitabsicherung über AC-8 |
+| `tests/unit/test_mail_column_order.py::test_legacy_config_without_order_keeps_catalog_order` | REFERENZ (Bestand, bleibt grün) | Hält bereits fest, dass „TmpMin" am Ende der Spaltenreihenfolge steht (`remaining`-Fallback) — Vorbild für AC-5, Beleg für die Korrektur oben |
+| `src/app/models.py::_SELECTABLE_GATE_EXEMPT` | UNVERÄNDERT | Klein, benannt, darf nur schrumpfen (#1585-Kommentar) — AC-8 spiegelt exakt diese Menge, keine eigene Kopie |
+| `docs/reference/metric_output_matrix.md` §4.1/§6 | WIRD AKTUALISIERT (Doku-Nachtrag) | Definition of Done: „Fläche 3"/„Scheibe 3" auf „erledigt, Wächter: …" umtragen (s. u.) |
+| `docs/adr/0005-confidence-not-selectable-metric.md` | REFERENZ | Grundsatz-ADR `selectable=False`, unverändert |
+
+## Implementation Details
+
+Neue Testachse in `tests/tdd/test_channel_metric_matrix.py`, parametrisiert
+über `[m for m in _METRICS if not m.selectable]` (heute exakt 3 Einträge)
+statt über das bestehende `_ALL_METRIC_IDS = [m.id for m in get_all_metrics()]`.
+Zwei Gruppen von Assertions, je nachdem ob die Metrik in
+`_SELECTABLE_GATE_EXEMPT` steht:
+
+**Gruppe A — nicht exemptiert (heute: `confidence`, `cape`):** MUSS an
+KEINEM der geprüften Choke-Points erscheinen:
+1. Trip-Mail-Spaltenreihenfolge (`resolve_metric_col_order()` UND — Prüfort
+   = Wirkort — der tatsächlich gerenderte `<thead>` von
+   `TripReportFormatter().format_email()`)
+2. Compare-Katalog (`get_compare_metric_catalog()`, per `metric_id`)
+3. Compare-Auswahlauflösung (`resolve_enabled_metrics()`, per `key`)
+4. Alarm-Aktivität (`is_alert_metric_active()`), NUR falls die Metrik einen
+   `alert_metrics`-Eintrag trägt (bei `confidence`: keiner — dieser Punkt
+   entfällt dann strukturell, nicht durch eine leere Assertion)
+
+**Gruppe B — exemptiert (heute: `temperature_cold`):** die generische
+„muss überall fehlen"-Regel gilt NICHT — stattdessen verweist der Test auf
+die spezifischen AC-3 bis AC-7 unten (Kältealarm MUSS aktiv sein,
+Compare-Aktivierung MUSS wirken, Mail-Spalte MUSS über den
+`remaining`-Fallback erscheinen, Stundenspalte erscheint HEUTE als
+Dublette, Compare-Katalog bleibt strukturell leer).
+
+Diese Zweiteilung spiegelt exakt die Bedingung, die `_is_selectable()`
+(`models.py:644`) selbst prüft — der Test dupliziert damit keine eigene,
+zweite Definition von „ist wählbar", sondern liest `_SELECTABLE_GATE_EXEMPT`
+direkt aus `app.models` (wie es der Produktivcode auch tut).
+
+## Expected Behavior
+
+- **Input:** der zentrale Metrik-Katalog `_METRICS` (unverändert), drei
+  synthetische Fixtures (ein Trip mit `confidence`/`cape`/`temperature_cold`
+  jeweils `enabled=True`; ein Compare-Preset mit `temp_min_c` in
+  `active_metrics`), keine echten PO-Daten.
+- **Output:** ein neuer, grüner Testblock in
+  `tests/tdd/test_channel_metric_matrix.py`, der die drei heutigen
+  `selectable=False`-Fälle UND jede künftige `selectable=False`-Metrik ohne
+  Testcode-Änderung gegen dieselbe Grundregel prüft.
+- **Side effects:** keine. Kein Produktivcode-Edit, keine neue Persistenz,
+  kein neues Pflicht-Gate (Erweiterung des bestehenden #1677-B-Gates).
+
+## Acceptance Criteria
+
+- **AC-1 (confidence — nirgends, trotz `summary_fields`):** Given
+  `confidence.selectable=False`, `default_enabled=False`, KEIN `sms_code`,
+  KEIN `alert_label`, aber `summary_fields={"min": "confidence_pct_min"}` /
+  When ein Trip mit `MetricConfig(metric_id="confidence", enabled=True)`
+  über `TripReportFormatter().format_email()` (Mail-Spaltenreihenfolge),
+  `render_for_channel("telegram", ...)` (Telegram-rich) und
+  `get_compare_metric_catalog()` (Compare-Katalog) geprüft wird / Then
+  erscheint `confidence`/„Sicherheit" an KEINER dieser drei Stellen — die
+  drei erlaubten Erscheinungsorte (E-Mail-Textblock `build_confidence_hint()`,
+  SMS-Symbol `C+/C~/C?`, interne Aggregation/`confidence_pct_min` in
+  `risk_engine.py`/`outlook.py`) bleiben von dieser Prüfung unberührt und
+  unverändert.
+  - Test: echtes Rendering wie AC-13/14 im selben File; Regression-Baseline
+    gegen `test_issue_715_confidence_not_selectable.py` (API-Exclusion bleibt
+    dort, wird hier nicht dupliziert).
+
+- **AC-2 (cape — nirgends, TROTZ `sms_code="CP"`/`alert_label="CAPE"`,
+  Mutations-Gegenprobe-Ziel):** Given `cape.selectable=False`,
+  `default_enabled=False`, MIT `sms_code="CP"` UND `alert_label="CAPE"` /
+  When dieselben drei Stellen wie AC-1 geprüft werden UND zusätzlich
+  `is_alert_metric_active(AlertMetric.CAPE, dc)` mit `cape.enabled=True` /
+  Then erscheint CAPE nirgends — kein „CP"-Token in der Mail-Spaltenliste,
+  kein Compare-Katalog-Eintrag, UND `is_alert_metric_active()` liefert
+  `False` trotz `enabled=True`.
+  - Test: wie AC-1, plus direkter `is_alert_metric_active`-Aufruf (Vorbild
+    `test_cape_not_selectable.py::TestAlertEngineExcludesCape`). **Dies ist
+    der explizite Mutations-Gegenprobe-Fall:** würde `_SELECTABLE_GATE_EXEMPT`
+    versehentlich um `"cape"` erweitert, MUSS mindestens die
+    Mail-Spaltenreihenfolge-Assertion dieses AC rot werden (s. „Prüfhinweis
+    für den Adversary").
+
+- **AC-3 (temperature_cold — Kältealarm MUSS aktiv bleiben, Trip-Pfad):**
+  Given ein Trip mit `temperature_cold` in Default-Konfiguration (Dataclass-
+  Default `enabled=True`, kein `default_enabled` gesetzt — s.
+  `build_default_display_config()`) / When
+  `is_alert_metric_active(AlertMetric.TEMPERATURE_MIN, dc)` geprüft wird /
+  Then liefert es `True` — der Kältealarm bleibt funktional, obwohl
+  `temperature_cold.selectable=False` ist.
+  - **Korrektur gegenüber dem ursprünglichen Auftragstext (Adversary-Finding
+    F001, 2026-08-10):** Ursache ist NICHT die Exemption in
+    `_SELECTABLE_GATE_EXEMPT`. `is_alert_metric_active()`
+    (`src/services/weather_change_detection.py:224-234`) liest
+    `_SELECTABLE_GATE_EXEMPT` an keiner Stelle — der eigentliche Grund ist
+    die OR-Tupel-Abbildung `_ALERT_METRIC_TO_CATALOG_ID[TEMPERATURE_MIN] =
+    ("temperature_cold", "temperature")`
+    (`src/services/weather_change_detection.py:85`): das mitgemappte, selbst
+    `selectable=True`/`enabled=True` Glied `"temperature"` trägt das
+    Ergebnis per `any(...)` über beide Katalog-IDs. Mutations-Gegenprobe
+    (`_SELECTABLE_GATE_EXEMPT` komplett geleert) lässt AC-3 fälschlich GRÜN
+    — die Exemption-Wirkung für `temperature_cold` wird stattdessen von
+    AC-5 bewiesen (Mail-Spalte über den `remaining`-Fallback — dort IST die
+    Exemption die entscheidende Variable). AC-3 bleibt als
+    Regression-Baseline für den Kältealarm bestehen (schützt gegen den
+    historisch dokumentierten Tupel-OR-Abbau, `weather_change_detection.py:
+    210-218`), beweist aber NICHT die Exemption-Wirkung.
+  - Test: direkter `is_alert_metric_active`-Aufruf mit einem
+    `UnifiedWeatherDisplayConfig`, das explizit
+    `MetricConfig(metric_id="temperature_cold", enabled=True)` trägt (Vorbild
+    Assertion-Stil `test_cape_not_selectable.py::TestAlertEngineExcludesCape`,
+    hier der positive Gegenfall). Kein neuer Redundanz-Test nötig, falls beim
+    Implementieren ein bereits bestehender Test exakt diese Zusicherung hält
+    (zu verifizieren: `tests/tdd/test_issue_914_slice1_foundation.py`,
+    `tests/unit/test_issue_222_alert_rules_detection.py` grep-geprüft, aber
+    keiner der Treffer ruft `is_alert_metric_active(TEMPERATURE_MIN, ...)`
+    mit `temperature_cold` direkt auf — nach heutigem Stand ist dies ein
+    echt neuer Test).
+
+- **AC-4 (temperature_cold — Compare-Aktivierung MUSS wirken, Regression-
+  Baseline):** Given ein Compare-Preset mit `active_metrics` enthält
+  `"temp_min_c"` / When `compare_alert.py::_display_config_from_active_metrics()`
+  daraus eine `display_config` baut und `is_alert_metric_active(
+  AlertMetric.TEMPERATURE_MIN, ...)` sie auswertet / Then gilt die Min-
+  Temperatur als aktiv.
+  - Test: bereits Bestand, bleibt grün —
+    `tests/tdd/test_compare_alert_metric_gating.py::test_f002_guard_temp_min_active_min_temp_delta_fires`.
+    Diese Scheibe fügt keinen zweiten, redundanten Test hinzu; die generische
+    Parametrisierung (AC-8) verankert denselben Choke-Point zusätzlich
+    zukunftssichernd (falls `_SELECTABLE_GATE_EXEMPT` künftig um eine zweite
+    ID wächst, deckt AC-8 automatisch mit ab, ob deren Compare-Aktivierung
+    ebenfalls funktioniert).
+
+- **AC-5 (temperature_cold — Mail-Spaltenreihenfolge über den
+  `remaining`-Fallback, Prüfort = Wirkort):** Given ein Trip mit Default-
+  Konfiguration (`temperature_cold.enabled=True`, keine eigene `order`) /
+  When die Trip-Mail über `TripReportFormatter().format_email()` gerendert
+  wird — NICHT nur `resolve_metric_col_order()` isoliert aufgerufen / Then
+  erscheint die Spalte „TmpMin" im tatsächlichen `<thead>` der HTML-Tabelle,
+  an letzter Position (`remaining`-Fallback, `email/html.py:678-682`),
+  OBWOHL `resolve_metric_col_order(dc)` selbst `"temp_cold"` NICHT in seiner
+  Rückgabeliste führt (dokumentierte Bestands-Abweichung,
+  `models.py:619-625`).
+  - Test: wie `test_mail_column_order.py::_mail_columns` (Regex gegen den
+    echten `<thead>`, kein isolierter Funktionsaufruf) — Regression-
+    Baseline gegen `test_legacy_config_without_order_keeps_catalog_order`.
+
+- **AC-6 (temperature_cold — Stundentabelle: GEMESSENE Dublette, KEINE
+  Fixierung dieser Scheibe):** Given derselbe Default-Trip / When die
+  Stundenzeilen der Trip-Mail gerendert werden
+  (`TripReportFormatter._dp_to_row()`/`_aggregate_night_block()`,
+  `trip_report.py` — nicht die gleichnamigen, produktiv ungenutzten
+  Funktionen in `email/helpers.py`, s. Known Limitations) / Then erscheint
+  HEUTE (gemessen 2026-08-10) eine eigene Stundenspalte „TmpMin" NEBEN
+  „Temp", mit für dieselbe Stunde IDENTISCHEM Zahlenwert (beide lesen
+  `dp_field="t2m_c"`) — eine echte Dublette. Dies widerspricht der im
+  Kontext-Dokument als „empirisch geklärt" bezeichneten Annahme (s.
+  Purpose/Korrektur oben); dieser AC hält den Ist-Zustand als
+  Charakterisierung fest, ohne ihn zu bewerten oder zu fixen.
+  - Test: wie AC-5, Assertion auf Anwesenheit BEIDER Spalten („Temp" und
+    „TmpMin") im `<thead>` UND auf identischen Zellwert für dieselbe Stunde
+    (kein Bug-Fix-Test, reine Charakterisierung des heutigen Verhaltens —
+    Vorbild AC-2 in `fix_1677_sms_reihenfolge.md`, dort für Byte-Identität).
+
+- **AC-7 (temperature_cold — Compare-Katalog bleibt strukturell leer):**
+  Given `get_compare_metric_catalog()`/das rohe `COMPARE_METRIC_CATALOG` /
+  When beide auf `metric_id=="temperature_cold"` geprüft werden / Then
+  taucht kein Eintrag auf — nicht weil ein `.selectable`-Filter ihn
+  entfernt, sondern weil `COMPARE_METRIC_CATALOG` ihn nie enthalten hat
+  (`temperature_cold` ist eine reine Trip-Alarm-Pseudogröße ohne
+  Compare-Entsprechung).
+  - Test: `"temperature_cold" not in {e["metric_id"] for e in
+    COMPARE_METRIC_CATALOG}` — Charakterisierung, aber zukunftssichernd
+    (würde jemand ihn versehentlich ergänzen, wird dieser Test rot, bevor
+    ein `.selectable`-Filter ihn stillschweigend wieder herausfiltert).
+
+- **AC-8 (generisch, zukunftssichernd — die eigentliche Blindstellen-
+  Reparatur):** Given `[m for m in _METRICS if not m.selectable]` (heute:
+  `confidence`, `cape`, `temperature_cold` — NICHT hartkodiert, sondern aus
+  dem Katalog abgeleitet) / When pro Metrik geprüft wird, ob ihre `id` in
+  `_SELECTABLE_GATE_EXEMPT` steht / Then gilt für JEDE NICHT gelistete
+  Metrik dieselbe Grundregel aus AC-1/AC-2 (erscheint an keinem der
+  ID-verankerten Choke-Points: `resolve_metric_col_order()`-Rückgabe,
+  `get_compare_metric_catalog()`-Metrik-IDs, `resolve_enabled_metrics()`-
+  Ergebnis; UND, sofern ein `alert_metrics`-Eintrag existiert, gilt sie über
+  `is_alert_metric_active()` nie als aktiv) — für JEDE gelistete Metrik wird
+  stattdessen auf die spezifischen ACs 3-7 verwiesen, die Regel wird NICHT
+  generisch erzwungen (die Exemption macht eine pauschale „muss fehlen"-
+  Aussage dort falsch).
+  - Test: EIN parametrisierter Testlauf über `_METRICS` (gefiltert auf
+    `selectable=False`, heute 3 Fälle, mit `_SELECTABLE_GATE_EXEMPT`-
+    Verzweigung direkt aus `app.models` importiert, keine zweite Kopie der
+    Ausnahmeliste). Deckt automatisch eine künftige vierte
+    `selectable=False`-Metrik ab, ohne dass diese Testdatei erneut
+    angefasst werden muss — das ist der strukturelle Reparaturanteil dieser
+    Scheibe (`metric_output_matrix.md` §4.1: „die Wirkung ist strukturell:
+    sie repariert die Aussagekraft jeder künftigen Achse mit").
+
+## Known Limitations
+
+1. **`email/helpers.py::dp_to_row()`/`aggregate_night_block()`/`visible_cols()`
+   (neuer Pfad, Horizon-Filter) sind produktiv ungenutzt für den Trip-Mail-
+   Pfad, werden aber von ~13 Testdateien isoliert aufgerufen** (u. a.
+   `test_cape_not_selectable.py`, `test_issue_715_confidence_not_selectable.py`,
+   `test_trip_mail_corridor_mark.py`, `test_issue_911_mail_details.py`).
+   Der echte Produktionspfad läuft über `TripReportFormatter._dp_to_row()`/
+   `_aggregate_night_block()`/`_visible_cols()` (`trip_report.py`), die KEINEN
+   eigenen `.selectable`-Check tragen und sich vollständig auf die
+   vorgelagerte, exemption-bewusste Kollabierung (`get_metrics_for_channel`,
+   `trip_report.py:135-138`) verlassen. Für `confidence`/`cape` ist das Ist-
+   Verhalten heute trotzdem korrekt (beide werden bereits VOR `_dp_to_row()`
+   aus `dc.metrics` entfernt, weil sie nicht exemptiert sind) — die
+   ~13 Tests prüfen also eine funktional äquivalente, aber strukturell
+   andere (und produktiv tote) Funktion. Das ist eine „Prüfort ≠ Wirkort"-
+   Lücke bei GRÜNEN, nicht ROTEN Tests — kein aktueller Fehlbetrieb, aber ein
+   Befund im Sinne von CLAUDE.md („Ist die Zusicherung dort geprüft, wo sie
+   WIRKT?"). **Nicht Gegenstand dieser Scheibe** (Scope ist ausschließlich
+   Fläche 3, die `get_all_metrics()`-vs-`_METRICS`-Blindstelle) — Empfehlung:
+   Sammel-Eintrag in #1199, kein eigenes Issue (keine aktuell falsche
+   Auslieferung, reine Testarchitektur-Präzisierung).
+2. **Die gemessene `temperature_cold`-Stundenspalten-Dublette (AC-6) wird
+   NICHT gefixt.** Diese Scheibe hält sie als Charakterisierung fest; ob sie
+   ein eigener Nebenbefund (#1199) oder ein Issue wird (nutzersichtbar: eine
+   real ausgelieferte Mail zeigt zwei Spalten mit identischen Zahlen), ist
+   PO-/Team-Lead-Entscheidung bei Spec-Freigabe, keine Vorentscheidung
+   dieser Spec.
+3. **Nicht Gegenstand dieser Scheibe (Epic-Vorgabe):** die Alarm-Renderer-
+   Matrix (Scheibe 1, Fläche 1: `alert/render.py`), die Ausblick-Tabelle
+   (Scheibe 2, Fläche 2: `outlook_columns()`), und die übrigen 7 unbewachten
+   Flächen aus `metric_output_matrix.md` §4.2 (Compare-Zellwert, Reihenfolge
+   jenseits E-Mail/Telegram-rich, Kurzform-/Kompakt-Varianten, Telegram-
+   Kurzform, Einheiten, Frontend-Register, Trip-SMS-Kaskade) — nur Fläche 3
+   (die `get_all_metrics()`-vs-`_METRICS`-Blindstelle selbst) ist Ziel.
+4. **`app/metric_catalog.py:615/661/869/945`** (katalog-interne
+   `.selectable`-Checks, z. B. `get_metric`-Familien, Template-Filter) sind
+   KEIN externer Ausgabeort (Bestand, bereits so im Kontext-Dokument
+   eingeordnet) — kein AC prüft sie gezielt.
+5. **`get_all_metrics()` selbst bleibt unverändert.** Sie ist für ihre
+   eigentlichen Aufrufer (`/api/metrics`, Trip-Editor-Metrikauswahl) korrekt
+   — das Ziel ist, dass VOLLSTÄNDIGKEITSTESTS sie nicht mehr als einzige
+   Iterationsbasis verwenden, nicht ihre Filterlogik zu ändern.
+
+## Definition of Done
+
+Nach grünem Testlauf **zusätzlich zum Code-Merge** (Epic-Vorgabe, nicht
+optional): `docs/reference/metric_output_matrix.md` §4.1 „Fläche 3" und §6
+„Scheibe 3" aktualisieren — den Absatz von einer offenen Beschreibung („kann
+… nicht sehen") auf einen Verweis auf den neuen Wächter umstellen (Testdatei
++ die neuen AC-Nummern in `tests/tdd/test_channel_metric_matrix.py`), analog
+wie andere geschlossene Punkte im Dokument markiert werden.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine.
+- **Rationale:** reine Testerweiterung eines bereits etablierten,
+  budgetierten Gates (#1677 B); keine neue Entscheidungsfläche (kein Kanal,
+  kein Provider, kein Datenmodell-, Auth- oder Editor-Paradigma-Wechsel).
+  ADR-0005 (`selectable=False`-Grundsatz) bleibt unverändert gültig — diese
+  Scheibe testet ihn nur an einer bisher unbewachten Stelle nach.
+
+## Prüfhinweis für den Adversary
+
+Leitfrage aus CLAUDE.md: **Ist die Zusicherung dort geprüft, wo sie WIRKT —
+oder nur dort, wo der Code steht?** Konkret für diese Spec: mehrere ACs
+wurden bewusst gegen den ECHTEN Renderpfad (`TripReportFormatter().format_email()`)
+statt gegen isolierte Hilfsfunktionen formuliert — genau weil eine isolierte
+Prüfung hier nachweislich (s. Korrektur oben) die falsche Funktion getroffen
+hätte.
+
+**Mutations-Gegenproben (Pflicht, per String-Ersetzung mit externer
+Sicherungskopie — nie `git checkout/stash/reset`):**
+
+- **Primärfall (explizit im Auftrag):** `_SELECTABLE_GATE_EXEMPT` um
+  `"cape"` erweitern (`models.py:626`) — welcher Test wird rot? MUSS
+  mindestens AC-2 sein (Mail-Spaltenreihenfolge UND/ODER
+  `is_alert_metric_active(CAPE, ...)` kippt auf `True`). Bleibt der Testlauf
+  grün, prüft AC-2 nicht die tatsächliche Exemption-Bedingung, sondern nur
+  eine hartkodierte `"cape"`-Zeichenkette.
+- Denselben Mutationstest mit `"confidence"` statt `"cape"` wiederholen —
+  fängt AC-1/AC-8 das ebenfalls, obwohl `confidence` keinen `sms_code`/
+  `alert_label` trägt (die ID-verankerten Choke-Points müssen unabhängig
+  von Feld-Existenz greifen)?
+- `_SELECTABLE_GATE_EXEMPT` komplett leeren (`frozenset()`) — MUSS AC-5
+  (Mail-Spalten-Fallback für `temperature_cold`) rot werden lassen. **Korrektur
+  (Adversary-Finding F001, 2026-08-10):** AC-3 (Kältealarm) bleibt bei dieser
+  Mutation erwartungsgemäß GRÜN — `is_alert_metric_active()` liest
+  `_SELECTABLE_GATE_EXEMPT` nicht (s. Korrektur-Hinweis bei AC-3 oben); AC-3
+  ist kein Fang für diese Mutation. Der zu AC-3 gehörige Mutationsfall ist
+  stattdessen die Tupel-OR-Ersetzung weiter unten.
+- Den `remaining`-Fallback in `email/html.py:678-682` entfernen (nur
+  `ordered`, kein `+ remaining`) — fängt AC-5 das (temperature_cold
+  verschwindet komplett statt nur die Position zu ändern)?
+- In `is_alert_metric_active()` die Tupel-OR-Prüfung (Z. 231-234) durch eine
+  Glied-für-Glied-Prüfung ersetzen (jedes Element einzeln statt `any(...)`)
+  — fängt AC-3 das (der historisch dokumentierte Beinahe-Fehler aus dem
+  Code-Kommentar `weather_change_detection.py:210-218`)?
+
+## Changelog
+
+- 2026-08-10: Initial spec created (Epic #1703, Scheibe 3). Implementation-
+  Details-Ansatz gegen den aktuellen Code verifiziert, nicht unbesehen aus
+  dem Kontext-Dokument übernommen: die dortige Behauptung, die
+  Stundentabellen-Frage für `temperature_cold` sei „empirisch geklärt"
+  (Abwesenheit = korrekt), erwies sich bei direktem Rendering-Test als
+  widerlegt (Dublette „TmpMin"/„Temp" mit identischem Wert) — Ursache ist
+  eine zweite, produktiv ungenutzte `dp_to_row()`-Implementierung in
+  `email/helpers.py`, die der Kontext-Doku fälschlich als der reale
+  Choke-Point galt. AC-6 und die „Known Limitations" wurden entsprechend
+  korrigiert, s. Abschnitt „Korrektur gegenüber dem Kontext-Dokument".

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -23,6 +23,15 @@ AC-Zuordnung:
 E-Mail/Telegram sind bewusste GRUEN-Ausnahmen (Bestandsfunktion, hier nur
 strukturell abgesichert) -- der SMS-Kurzform-Reihenfolge-Teil ist der
 einzige neue, heute rote Anteil dieser Datei.
+
+Epic #1703 Scheibe 3 (AC-1 bis AC-8, unten): schliesst die
+get_all_metrics()-vs-_METRICS-Blindstelle (docs/reference/metric_output_matrix.md
+Flaeche 3) -- Vollstaendigkeitstests wie AC-13/14/15 oben iterieren ueber
+get_all_metrics() und koennen selectable=False-Groessen (confidence, cape,
+temperature_cold) daher strukturell nie sehen. SPEC:
+docs/specs/modules/fix_1703_s3_selectable_metrics.md. Kein Produktivcode-Fix
+-- Charakterisierungstest fuer bereits korrektes, bisher unbewachtes
+Verhalten (alle 8 ACs laufen heute bereits GRUEN).
 """
 from __future__ import annotations
 
@@ -31,12 +40,15 @@ import re
 
 import pytest
 
-from app.metric_catalog import get_all_metrics, get_metric
-from app.models import MetricConfig, UnifiedWeatherDisplayConfig
+from app.metric_catalog import _METRICS, build_default_display_config, get_all_metrics, get_metric
+from app.models import AlertMetric, MetricConfig, UnifiedWeatherDisplayConfig, _SELECTABLE_GATE_EXEMPT
 from output.renderers.channel_layout import render_for_channel
+from output.renderers.compare_metric_catalog import COMPARE_METRIC_CATALOG, get_compare_metric_catalog
+from output.renderers.compare_metric_ids import FRONTEND_TO_RENDERER_METRIC_ID, resolve_enabled_metrics
 from output.renderers.email.helpers import resolve_metric_col_order
 from output.renderers.sms_trip import SMS_SYMBOL_BY_METRIC, SMS_MULTI_SYMBOLS_BY_METRIC
 from output.renderers.trip_report import TripReportFormatter
+from services.weather_change_detection import is_alert_metric_active
 
 from tests.tdd import _min_temp_felt_fixtures as F
 
@@ -242,3 +254,311 @@ def test_ac15_sms_kurzform_selection_deselection_and_order(metric_id):
     # bleibt der Bezugspunkt, kein RED.
     sms_default = _render_sms(_two_metric_dc(metric_id, partner_id))
     assert _first_index_starting_with(sms_default, symbol) is not None
+
+
+# ---------------------------------------------------------------------------
+# Epic #1703 Scheibe 3 (AC-1 bis AC-8): die get_all_metrics()-vs-_METRICS-
+# Blindstelle schliessen (docs/reference/metric_output_matrix.md Flaeche 3).
+# SPEC: docs/specs/modules/fix_1703_s3_selectable_metrics.md.
+#
+# Kein Produktivcode-Fix -- Charakterisierungstest fuer bereits korrektes,
+# bisher unbewachtes Verhalten. Iterationsbasis fuer AC-8 ist _METRICS
+# (NICHT get_all_metrics()) + _SELECTABLE_GATE_EXEMPT direkt aus app.models
+# -- keine zweite Kopie der Ausnahmeliste.
+# ---------------------------------------------------------------------------
+
+
+def _mail_table(
+    dc: UnifiedWeatherDisplayConfig, report_type: str = "evening",
+) -> tuple[list[str], list[list[str]]]:
+    """Kopfzeile + Datenzeilen der ECHTEN Trip-Mail-Stundentabelle (Pruefort =
+    Wirkort -- s. Korrektur-Abschnitt der Spec: eine isolierte Pruefung von
+    resolve_metric_col_order() haette hier nachweislich die falsche Funktion
+    getroffen, s. AC-2/AC-5)."""
+    report = TripReportFormatter().format_email(
+        [_matrix_segment()], trip_name="Issue1703Matrix", report_type=report_type,
+        night_weather=F.night_weather(), display_config=dc,
+        stage_name=F.STAGE_NAME, tz=F.TZ,
+    )
+    head = re.search(r"<thead><tr>(.*?)</tr></thead>", report.email_html, re.S)
+    assert head, "Stundentabelle ohne Kopfzeile gerendert"
+    headers = [
+        re.sub(r"<[^>]+>", "", th).strip()
+        for th in re.findall(r"<th[^>]*>.*?</th>", head.group(1), re.S)
+    ]
+    body = re.search(r"<tbody>(.*?)</tbody>", report.email_html, re.S)
+    assert body, "Stundentabelle ohne Datenzeilen gerendert"
+    rows = [
+        [
+            re.sub(r"<[^>]+>", "", td).strip()
+            for td in re.findall(r"<td[^>]*>.*?</td>", tr, re.S)
+        ]
+        for tr in re.findall(r"<tr>(.*?)</tr>", body.group(1), re.S)
+    ]
+    return headers, rows
+
+
+def _row_by_time(headers: list[str], rows: list[list[str]], time_label: str) -> dict[str, str]:
+    time_idx = headers.index("Time")
+    for row in rows:
+        if row[time_idx] == time_label:
+            return dict(zip(headers, row))
+    raise AssertionError(f"keine Zeile mit Time={time_label!r} gefunden: {rows}")
+
+
+# --- AC-1: confidence -- nirgends, trotz summary_fields --------------------
+
+
+def test_ac1_confidence_absent_from_mail_telegram_compare():
+    """AC-1: confidence (selectable=False, default_enabled=False, KEIN
+    sms_code, KEIN alert_label, aber summary_fields={'min':
+    'confidence_pct_min'}) erscheint an keiner der drei Choke-Points -- die
+    drei erlaubten Erscheinungsorte (E-Mail-Textblock build_confidence_hint(),
+    SMS-Symbol C+/C~/C?, interne Aggregation confidence_pct_min) sind NICHT
+    Gegenstand dieses Tests, bleiben unberuehrt."""
+    metric = get_metric("confidence")
+    assert metric.selectable is False
+    assert metric.sms_code == "" and metric.alert_label == ""
+    assert metric.summary_fields == {"min": "confidence_pct_min"}
+
+    partner_id = _partner_of("confidence")
+    dc = _two_metric_dc("confidence", partner_id)
+
+    headers, _ = _mail_table(dc)
+    assert metric.col_label not in headers, (
+        f"AC-1: 'confidence' (Spaltenlabel {metric.col_label!r}) erscheint in "
+        f"der echten Trip-Mail-Kopfzeile: {headers}"
+    )
+    assert get_metric(partner_id).col_label in headers, (
+        "AC-1: Partner-Groesse muss trotzdem erscheinen (kein Kollateralschaden)"
+    )
+
+    cells = _telegram_cells(dc)
+    assert "confidence" not in cells, (
+        f"AC-1: 'confidence' erscheint in der Telegram-rich Tabelle/Detailzeile: {cells}"
+    )
+    assert partner_id in cells, "AC-1: Partner-Groesse muss in Telegram-rich erscheinen"
+
+    compare_ids = {e["metric_id"] for e in get_compare_metric_catalog()}
+    assert "confidence" not in compare_ids, (
+        f"AC-1: 'confidence' erscheint im Compare-Katalog: {compare_ids}"
+    )
+
+
+# --- AC-2: cape -- nirgends, TROTZ sms_code="CP"/alert_label="CAPE" --------
+# (Mutations-Gegenprobe-Ziel, s. "Pruefhinweis fuer den Adversary")
+
+
+def test_ac2_cape_absent_from_mail_telegram_compare_and_alert():
+    """AC-2: cape (selectable=False, default_enabled=False, MIT sms_code='CP'
+    UND alert_label='CAPE') erscheint an denselben drei Stellen wie AC-1
+    NICHT, UND is_alert_metric_active(CAPE, ...) bleibt False trotz
+    enabled=True.
+
+    Mutations-Gegenprobe-Ziel: die Mail-Header-Assertion prueft den ECHTEN
+    <thead> (nicht nur resolve_metric_col_order() isoliert) -- wuerde
+    _SELECTABLE_GATE_EXEMPT versehentlich um 'cape' erweitert, ueberlebt cape
+    die Kanal-Kollabierung (trip_report.py:135) und erschiene ueber den
+    remaining-Fallback (email/html.py:678-682) am Tabellenende, OBWOHL
+    resolve_metric_col_order() selbst (roher .selectable-Check, KEINE
+    Exemption-Kenntnis) unveraendert bliebe -- dasselbe Pruefort=Wirkort-Muster
+    wie bei AC-5/AC-6."""
+    metric = get_metric("cape")
+    assert metric.selectable is False
+    assert metric.sms_code == "CP" and metric.alert_label == "CAPE"
+
+    partner_id = _partner_of("cape")
+    dc = _two_metric_dc("cape", partner_id)
+
+    headers, _ = _mail_table(dc)
+    assert metric.col_label not in headers, (
+        f"AC-2: 'CAPE' erscheint in der echten Trip-Mail-Kopfzeile: {headers}"
+    )
+    assert "cape" not in resolve_metric_col_order(dc), (
+        "AC-2: 'cape' col_key erscheint in resolve_metric_col_order()"
+    )
+
+    cells = _telegram_cells(dc)
+    assert "cape" not in cells, (
+        f"AC-2: 'cape' erscheint in der Telegram-rich Tabelle/Detailzeile: {cells}"
+    )
+
+    compare_ids = {e["metric_id"] for e in get_compare_metric_catalog()}
+    assert "cape" not in compare_ids, (
+        f"AC-2: 'cape' erscheint im Compare-Katalog: {compare_ids}"
+    )
+
+    cape_dc = _single_metric_dc("cape", enabled=True)
+    assert is_alert_metric_active(AlertMetric.CAPE, cape_dc) is False, (
+        "AC-2: is_alert_metric_active(CAPE, ...) liefert True trotz "
+        "enabled=True -- CAPE darf trotz Bestandskonfiguration nie "
+        "alarmfaehig gelten"
+    )
+
+
+# --- AC-3: temperature_cold -- Kaeltealarm MUSS aktiv bleiben (Trip-Pfad) --
+
+
+def test_ac3_temperature_cold_cold_alarm_stays_active():
+    """AC-3: ein Trip mit temperature_cold in Default-Konfiguration
+    (Dataclass-Default enabled=True, kein explizites default_enabled gesetzt
+    -- s. build_default_display_config()) haelt den Kaeltealarm aktiv, obwohl
+    temperature_cold.selectable=False ist. Korrektur (Adversary-Finding F001,
+    2026-08-10): NICHT die Exemption in _SELECTABLE_GATE_EXEMPT bewirkt das --
+    is_alert_metric_active() liest _SELECTABLE_GATE_EXEMPT an keiner Stelle.
+    Ursache ist die OR-Tupel-Abbildung _ALERT_METRIC_TO_CATALOG_ID[TEMPERATURE_MIN]
+    = ("temperature_cold", "temperature") (weather_change_detection.py:85):
+    das mitgemappte, selbst selectable=True/enabled=True Glied "temperature"
+    traegt das Ergebnis per any(...) (weather_change_detection.py:224-234).
+    Die Exemption-Wirkung fuer temperature_cold wird stattdessen von AC-5
+    bewiesen (Mail-Spalte ueber den remaining-Fallback -- dort IST die
+    Exemption die entscheidende Variable, per Mutation bestaetigt)."""
+    dc = build_default_display_config()
+    assert dc.is_metric_enabled("temperature_cold") is True, (
+        "Vorbedingung verletzt: temperature_cold muss in der Default-"
+        "Konfiguration enabled=True sein (Dataclass-Default, kein "
+        "explizites default_enabled)"
+    )
+    assert is_alert_metric_active(AlertMetric.TEMPERATURE_MIN, dc) is True, (
+        "AC-3: Kaeltealarm (TEMPERATURE_MIN) darf trotz "
+        "temperature_cold.selectable=False nicht inaktiv sein -- Ursache ist "
+        "die OR-Tupel-Abbildung auf die mitgemappte, selbst waehlbare Groesse "
+        "'temperature' (_ALERT_METRIC_TO_CATALOG_ID), NICHT die Exemption in "
+        "_SELECTABLE_GATE_EXEMPT (die wird hier nicht gelesen, s. AC-5 fuer "
+        "den Test, der die Exemption-Wirkung tatsaechlich belegt)"
+    )
+
+
+# --- AC-4 (Regression-Baseline, KEIN neuer Test): temperature_cold --------
+# Compare-Aktivierung MUSS wirken. Bereits gedeckt von
+# tests/tdd/test_compare_alert_metric_gating.py::
+# test_f002_guard_temp_min_active_min_temp_delta_fires (bleibt gruen, kein
+# redundanter Test). Die generische Parametrisierung in AC-8 verankert
+# denselben Choke-Point zusaetzlich zukunftssichernd.
+
+
+# --- AC-5: temperature_cold -- Mail-Spaltenreihenfolge ueber den ----------
+# remaining-Fallback (Pruefort = Wirkort)
+
+
+def test_ac5_temperature_cold_mail_column_via_remaining_fallback():
+    """AC-5: ein Trip mit Default-Konfiguration (temperature_cold.enabled=True,
+    keine eigene order) zeigt die Spalte 'TmpMin' im ECHTEN <thead> an
+    letzter Position (remaining-Fallback, email/html.py:678-682), OBWOHL
+    resolve_metric_col_order(dc) selbst 'temp_cold' NICHT fuehrt
+    (dokumentierte Bestands-Abweichung, models.py:619-625)."""
+    dc = build_default_display_config()
+
+    assert "temp_cold" not in resolve_metric_col_order(dc), (
+        "Vorbedingung: resolve_metric_col_order() fuehrt 'temp_cold' bewusst "
+        "NICHT (Bestand, s. models.py _SELECTABLE_GATE_EXEMPT-Kommentar)"
+    )
+
+    headers, _ = _mail_table(dc)
+    metric_cols = [h for h in headers if h not in {"Time", "Risk"}]
+    assert "TmpMin" in metric_cols, (
+        f"AC-5: 'TmpMin' fehlt in der echten Trip-Mail-Kopfzeile: {headers}"
+    )
+    assert metric_cols[-1] == "TmpMin", (
+        f"AC-5: 'TmpMin' muss ueber den remaining-Fallback an letzter "
+        f"Position stehen: {metric_cols}"
+    )
+
+
+# --- AC-6: temperature_cold -- Stundentabelle: GEMESSENE Dublette ---------
+# (Charakterisierung, KEINE Fixierung dieser Scheibe -- s. Known
+# Limitations Punkt 2 der Spec)
+
+
+def test_ac6_temperature_cold_hourly_duplicate_characterization():
+    """AC-6: die Stundenzeilen der Trip-Mail zeigen HEUTE (gemessen
+    2026-08-10) eine eigene Spalte 'TmpMin' NEBEN 'Temp', mit fuer dieselbe
+    Stunde IDENTISCHEM Zahlenwert (beide lesen dp_field='t2m_c') -- eine
+    echte Dublette. Reine Charakterisierung, kein Bug-Fix-Test."""
+    dc = build_default_display_config()
+    headers, rows = _mail_table(dc)
+    assert "Temp" in headers and "TmpMin" in headers
+
+    row = _row_by_time(headers, rows, f"{F.COLD_HOUR:02d}")
+    assert row["Temp"] == row["TmpMin"], (
+        f"AC-6 (Charakterisierung): 'Temp' und 'TmpMin' sollten fuer "
+        f"dieselbe Stunde identisch gerendert sein (Dublette) -- gemessen "
+        f"Temp={row['Temp']!r} TmpMin={row['TmpMin']!r}"
+    )
+
+
+# --- AC-7: temperature_cold -- Compare-Katalog bleibt strukturell leer ----
+
+
+def test_ac7_temperature_cold_absent_from_compare_catalog():
+    """AC-7: weder das rohe COMPARE_METRIC_CATALOG noch
+    get_compare_metric_catalog() fuehren einen Eintrag mit
+    metric_id=='temperature_cold' -- nicht weil ein .selectable-Filter ihn
+    entfernt, sondern weil COMPARE_METRIC_CATALOG ihn nie enthalten hat
+    (reine Trip-Alarm-Pseudogroesse ohne Compare-Entsprechung)."""
+    raw_ids = {e["metric_id"] for e in COMPARE_METRIC_CATALOG}
+    filtered_ids = {e["metric_id"] for e in get_compare_metric_catalog()}
+    assert "temperature_cold" not in raw_ids, (
+        f"AC-7: 'temperature_cold' erscheint im rohen COMPARE_METRIC_CATALOG: {raw_ids}"
+    )
+    assert "temperature_cold" not in filtered_ids, (
+        f"AC-7: 'temperature_cold' erscheint in get_compare_metric_catalog(): {filtered_ids}"
+    )
+
+
+# --- AC-8 (generisch, zukunftssichernd): die eigentliche Blindstellen- ----
+# Reparatur. Iterationsbasis ist _METRICS (NICHT get_all_metrics()),
+# Verzweigung ueber _SELECTABLE_GATE_EXEMPT direkt aus app.models -- keine
+# zweite Kopie der Ausnahmeliste.
+
+_NON_SELECTABLE_METRIC_IDS = [m.id for m in _METRICS if not m.selectable]
+
+
+@pytest.mark.parametrize("metric_id", _NON_SELECTABLE_METRIC_IDS)
+def test_ac8_non_selectable_metrics_stay_out_unless_exempt(metric_id):
+    """AC-8: fuer JEDE NICHT in _SELECTABLE_GATE_EXEMPT gelistete
+    selectable=False-Groesse gilt dieselbe Grundregel aus AC-1/AC-2 an den
+    ID-verankerten Choke-Points (resolve_metric_col_order()-Rueckgabe,
+    get_compare_metric_catalog()-Metrik-IDs, resolve_enabled_metrics()-
+    Ergebnis sofern ein Compare-Katalog-Eintrag existiert, is_alert_metric_
+    active() sofern ein alert_metrics-Eintrag existiert). Fuer eine gelistete
+    Groesse (heute: temperature_cold) gilt die Regel NICHT -- s. AC-3 bis
+    AC-7."""
+    if metric_id in _SELECTABLE_GATE_EXEMPT:
+        pytest.skip(
+            f"{metric_id!r} ist ueber _SELECTABLE_GATE_EXEMPT ausgenommen -- "
+            "der Sollzustand steht in AC-3 bis AC-7, nicht in dieser "
+            "generischen Regel"
+        )
+
+    metric = get_metric(metric_id)
+    dc = _single_metric_dc(metric_id, enabled=True)
+
+    col_order = resolve_metric_col_order(dc)
+    assert metric.col_key not in col_order, (
+        f"AC-8: {metric_id!r} (col_key {metric.col_key!r}) erscheint in "
+        f"resolve_metric_col_order(): {col_order}"
+    )
+
+    compare_ids = {e["metric_id"] for e in get_compare_metric_catalog()}
+    assert metric_id not in compare_ids, (
+        f"AC-8: {metric_id!r} erscheint im Compare-Katalog: {compare_ids}"
+    )
+
+    for entry in COMPARE_METRIC_CATALOG:
+        if entry["metric_id"] != metric_id:
+            continue
+        resolved = resolve_enabled_metrics([entry["key"]]) or []
+        renderer_id = FRONTEND_TO_RENDERER_METRIC_ID.get(entry["key"])
+        assert renderer_id not in resolved, (
+            f"AC-8: {metric_id!r} (Compare-Key {entry['key']!r}) erscheint "
+            f"im Ergebnis von resolve_enabled_metrics(): {resolved}"
+        )
+
+    for alert_value in metric.alert_metrics.values():
+        alert_metric = AlertMetric(alert_value)
+        assert is_alert_metric_active(alert_metric, dc) is False, (
+            f"AC-8: is_alert_metric_active({alert_metric!r}, ...) liefert "
+            f"True fuer die nicht waehlbare Groesse {metric_id!r}, obwohl "
+            "enabled=True"
+        )


### PR DESCRIPTION
## Summary
- Neue Achse in `tests/tdd/test_channel_metric_matrix.py` (AC-1..AC-8, Option C aus der Epic-Doku: bestehendes Matrix-Gate #1677 B erweitert, kein neues Pflicht-Gate)
- Parametrisiert ueber `app.metric_catalog._METRICS` + `app.models._SELECTABLE_GATE_EXEMPT` statt `get_all_metrics()` -- schliesst die Blindstelle, die alle kuenftigen Vollstaendigkeitstests (Scheiben 1/2/4/5) sonst geerbt haetten
- Sichert je einzeln ab: `confidence` (nirgends, keine Ausgabefelder), `cape` (nirgends TROTZ Feldern), `temperature_cold` (Alarm+Compare-Aktivierung bleiben aktiv, Mail-Spalte nur ueber dokumentierten Fallback, nicht im Ortsvergleich) -- plus ein generischer, zukunftssichernder Test fuer jede kuenftige nicht-waehlbare Metrik
- **Kein Produktivcode geaendert** -- reiner Charakterisierungs-Waechter fuer bereits korrektes, bisher unbewachtes Verhalten (83 passed, 1 skipped)
- Adversary-Runde (VERIFIED nach Fix-Loop) fand einen echten Fehler in der urspruenglichen Spec-Formulierung: AC-3 behauptete faelschlich, der Kaeltealarm bleibe wegen `_SELECTABLE_GATE_EXEMPT` aktiv -- tatsaechlich ist die Ursache die OR-Tupel-Abbildung in `is_alert_metric_active()`. Docstring/Assertion/Spec korrigiert (reine Textkorrektur, kein Verhaltenswechsel)
- `docs/reference/metric_output_matrix.md` als Definition-of-Done aktualisiert (Flaeche 3 + Scheibe 3 auf erledigt markiert)

## Test plan
- [x] `uv run pytest tests/tdd/test_channel_metric_matrix.py -v` -- 83 passed, 1 skipped
- [x] Mit `--disable-socket` erneut verifiziert -- identisch
- [x] `pytest tests/tdd/ --collect-only --disable-socket` -- keine Kollisionen durch neue Imports
- [x] Mutations-Gegenprobe (Adversary): `_SELECTABLE_GATE_EXEMPT` um `cape`/`confidence` erweitert bzw. komplett geleert -- jeweils erwartete Tests werden rot, saubere Ruecktellung verifiziert
- [x] Scope-Check: nur Testdatei + Doku geaendert, keine `src/`/`api/`-Datei im Diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nZGZ9MYWc33osdoqZ9zuW