### PR TITLE
docs(#1676): ADR-Nummer in der S2a-Spec zitierfaehig schreiben

### DIFF
--- a/docs/specs/modules/feat_1676_s2a_premium_sms_versand.md
+++ b/docs/specs/modules/feat_1676_s2a_premium_sms_versand.md
@@ -457,8 +457,8 @@ Verhalten, nicht nach Issue-Nummer.
 
 ## Architektur-Entscheidung (ADR)
 
-- **ADR-Nr.:** **0049** — `docs/adr/0049-premium-sms-vierter-kanal.md`
-  (nächste freie Nummer, gemessen: höchster Bestand ist 0048).
+- **ADR-Nr.:** ADR-0049 — `docs/adr/0049-premium-sms-vierter-kanal.md`
+  (nächste freie Nummer, gemessen: höchster Bestand war 0048).
 - **Rationale:** ADR-0004 legt fest: „Die unterstützten Kanäle sind nur noch
   E-Mail · Telegram · SMS." Die PO-Vorgabe verlangt Premium-SMS als eigenen,
   vierten Kanal `premium_sms` — nach CLAUDE.md-Regel „Abweichung ⇒ neues


### PR DESCRIPTION
Ein Wort. Das ADR-Feld der S2a-Spec nannte die Nummer nur als Pfad (`docs/adr/0049-…`); der Spec-Waechter verlangt sie als `ADR-0049` und blockte deshalb den Workflow-Abschluss — zu Recht, denn ein Pfad ist nicht greppbar, eine ADR-Nummer ist es.

Reine Doku, kein Verhalten. **Die Auslieferung von #1676 S2a ist bereits abgeschlossen** (Prod `3af745f2`, Staging VERIFIED, Post-Deploy-Selftest PASS) — dieser PR aendert daran nichts und braucht keine erneute Staging-Verifikation.

Refs #1676

🤖 Generated with [Claude Code](https://claude.com/claude-code)