### PR TITLE
fix(#1689): Attestation-Findings mit gemeinsamem Typkontrakt absichern

### DIFF
--- a/.claude/hooks/_e2e_paths.py
+++ b/.claude/hooks/_e2e_paths.py
@@ -15,6 +15,31 @@ from pathlib import Path
 STALE_HOURS = 24
 
 
+def partition_findings(raw) -> "tuple[list, list]":
+    """Trennt ein aus JSON geladenes Findings-Array in (gueltige, unverwertbare).
+
+    Fix #1689: einziger Ort, der die Form eines Findings kennt — sowohl
+    staging_gate.py (Schreibseite, hart) als auch prod_selftest.py (Leseseite,
+    weich) rufen ausschließlich diese Funktion auf, statt je eigene
+    isinstance-Prüfungen zu bauen (das war bereits der fünfte reaktive Guard
+    an demselben Objektgraphen).
+
+    ``raw`` ist ein beliebiger, bereits aus JSON geladener Wert. Ist ``raw``
+    selbst keine Liste (z.B. ein Objekt/dict, eine Zahl oder ``None``), gilt
+    der GESAMTE Wert als unverwertbar: ``gueltige`` bleibt leer, ``raw``
+    landet als einziger Eintrag in ``unverwertbare``. Ist ``raw`` eine Liste,
+    wird elementweise nach ``isinstance(f, dict)`` getrennt — beide
+    Teillisten behalten die ursprüngliche Reihenfolge.
+
+    Reine Funktion: keine Seiteneffekte, kein Zugriff auf Dateisystem/Zeit.
+    """
+    if not isinstance(raw, list):
+        return [], [raw]
+    gueltige = [f for f in raw if isinstance(f, dict)]
+    unverwertbare = [f for f in raw if not isinstance(f, dict)]
+    return gueltige, unverwertbare
+
+
 def last_gate_scope_path(repo_dir) -> Path:
     """Marker-Pfad für die Gate-Scope-Basis (Issue #916):
     <repo_dir>/.claude/last_gate_scope.json.

--- a/.claude/hooks/prod_selftest.py
+++ b/.claude/hooks/prod_selftest.py
@@ -437,7 +437,8 @@ def _render_fail_health(workflow: str, head: str, health_msg: str) -> str:
 
 
 def _render_full_report(
-    workflow: str, head: str, health_msg: str, verdict: str, probes: list[dict]
+    workflow: str, head: str, health_msg: str, verdict: str, probes: list[dict],
+    unusable_findings: list | None = None,
 ) -> str:
     lines = [
         f"# Prod-Selftest — {workflow}",
@@ -461,6 +462,17 @@ def _render_full_report(
         lines.append(
             f"| {ac} | {staging} | {prod_url} | {prod_http} | {prod_status} |"
         )
+
+    # Fix #1689 (AC-5/AC-6): unverwertbare (Nicht-Dict-)Findings sichtbar
+    # ausweisen statt sie stillschweigend zu verwerfen.
+    if unusable_findings:
+        lines += ["", "## Unverwertbare Findings", ""]
+        lines.append(
+            f"{len(unusable_findings)} Eintrag/Einträge im findings-Array waren "
+            "keine Dicts und konnten nicht geprobt werden:"
+        )
+        for f in unusable_findings:
+            lines.append(f"- `{f!r}`")
 
     lines += ["", "## Fazit", ""]
     if verdict == "PASS":
@@ -492,6 +504,12 @@ def _render_full_report(
     elif verdict == "FAIL":
         lines.append(
             "FAIL: Regression in Produktion (Bot-Menü oder AC). Issue NICHT schließen."
+        )
+    elif verdict == "FAIL_UNUSABLE_FINDINGS":
+        lines.append(
+            "FAIL: Das findings-Array enthielt ausschließlich unverwertbare "
+            "(Nicht-Dict-)Einträge — kein einziger Nachweis konnte geprobt "
+            "werden. Issue NICHT schließen."
         )
     else:  # PARTIAL
         fails = [p for p in probes if p.get("status") == "PASS" and p.get("prod_status") == "FAIL"]
@@ -686,7 +704,10 @@ def run_selftest(
             _log(f"FEHLER: Nachweis-Datei {e2e_path} nicht lesbar: {exc}", stream=sys.stderr)
             return 1
 
-    if exact_data is not None and exact_data.get("verified_commit") == head:
+    # Fix #1689 (AC-10): valides, aber NICHT-Dict Top-Level-JSON wird wie "kein
+    # exakter Treffer" behandelt -- die bestehende Ancestor-Suche greift
+    # automatisch, statt mit AttributeError abzustuerzen (weich, Leseseite).
+    if isinstance(exact_data, dict) and exact_data.get("verified_commit") == head:
         verified = exact_data
         verdict = verified.get("staging_verdict", "")
         if not verdict.startswith("VERIFIED"):
@@ -745,9 +766,18 @@ def run_selftest(
         return 1
 
     # Phase 3: AC-Attestation (concurrent)
-    findings = verified.get("findings", [])
-    if not findings:
-        # Leer → als PASS werten (durch staging_gate eigentlich blockiert)
+    raw_findings = verified.get("findings", [])
+    # Fix #1689 (AC-5/AC-6): vor pool.map partitionieren -- ab hier fliessen in
+    # pool.map/_derive_verdict/_render_full_report garantiert nur noch Dicts.
+    # Ein findings-Feld, das selbst keine Liste ist, wird vollstaendig als
+    # unverwertbar behandelt (_e2e_paths.partition_findings).
+    findings, unusable_findings = _e2e_paths.partition_findings(raw_findings)
+    if not raw_findings:
+        # Leer (und OHNE unverwertbare Eintraege) → als PASS werten (durch
+        # staging_gate eigentlich blockiert). Greift NUR bei einer von Anfang
+        # an leeren rohen Liste -- eine nach der Partitionierung leere
+        # Probe-Liste bei vorhandenen unverwertbaren Eintraegen faellt NICHT
+        # hierher (siehe AC-7-Regel unten).
         _write_report(
             report_path,
             _render_full_report(workflow, head, health_msg, "PASS", []),
@@ -758,7 +788,15 @@ def run_selftest(
     with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
         probes = list(pool.map(_probe_ac, findings))
 
-    verdict = _derive_verdict(probes)
+    # Fix #1689 (AC-7, Kern): waren unverwertbare Eintraege vorhanden und blieb
+    # KEIN einziges gueltiges Finding uebrig, ist das Ergebnis ausdruecklich
+    # KEIN Erfolg -- unabhaengig davon, dass _derive_verdict([]) fuer eine
+    # leere Probe-Liste sonst PASS liefern wuerde (Z. 553-556). Kein stiller
+    # Erfolg fuer einen unbrauchbaren Nachweis.
+    if unusable_findings and not probes:
+        verdict = "FAIL_UNUSABLE_FINDINGS"
+    else:
+        verdict = _derive_verdict(probes)
 
     # Phase 4: Bot-Menü-Check (additiv, gated)
     menu_finding = _check_bot_menu_prod()
@@ -769,7 +807,9 @@ def run_selftest(
     if menu_finding["status"] == "FAIL":
         verdict = "FAIL"
 
-    report_content = _render_full_report(workflow, head, health_msg, verdict, probes) + menu_line
+    report_content = _render_full_report(
+        workflow, head, health_msg, verdict, probes, unusable_findings
+    ) + menu_line
     _write_report(report_path, report_content)
 
     _log(f"Verdict={verdict} (Bericht: {report_path})")

--- a/.claude/hooks/staging_gate.py
+++ b/.claude/hooks/staging_gate.py
@@ -355,9 +355,32 @@ def write_verdict(verdict: str, findings_path: Path, e2e_path: Path | None = Non
         return 1
 
     try:
-        findings = json.loads(findings_path.read_text()) if findings_path.exists() else []
+        raw_findings = json.loads(findings_path.read_text()) if findings_path.exists() else []
     except (json.JSONDecodeError, OSError) as exc:
         _log(f"Findings-Datei nicht lesbar: {exc}", stream=sys.stderr)
+        return 1
+
+    # Fix #1689 (AC-2/AC-3): hart pruefen, BEVOR irgendein Artefakt entsteht —
+    # analog zur Verdict-Praefix-Pruefung oben (#1327). --findings-json muss
+    # eine Liste sein, und jedes Element ein Dict; sonst kein Artefakt.
+    if not isinstance(raw_findings, list):
+        _log(
+            f"--findings-json muss eine JSON-Liste sein, gefunden: "
+            f"{type(raw_findings).__name__} statt list. Attestation unveraendert "
+            "(kein Artefakt geschrieben).",
+            stream=sys.stderr,
+        )
+        return 1
+    findings, unusable_findings = _e2e_paths.partition_findings(raw_findings)
+    if unusable_findings:
+        first_idx = next(i for i, f in enumerate(raw_findings) if not isinstance(f, dict))
+        _log(
+            f"--findings-json enthaelt unverwertbare (Nicht-Dict-)Elemente: Index "
+            f"{first_idx} hat Typ {type(raw_findings[first_idx]).__name__} statt dict "
+            f"({len(unusable_findings)} von {len(raw_findings)} Elementen betroffen). "
+            "Attestation unveraendert (kein Artefakt geschrieben).",
+            stream=sys.stderr,
+        )
         return 1
 
     # Issue #1327 (AC-3): Findings tragen ihren Urheber-Workflow, damit der
@@ -367,10 +390,7 @@ def write_verdict(verdict: str, findings_path: Path, e2e_path: Path | None = Non
         or os.environ.get("GZ_ACTIVE_WORKFLOW")
         or "unknown"
     ).strip() or "unknown"
-    findings = [
-        {**f, "workflow": workflow} if isinstance(f, dict) else f
-        for f in findings
-    ]
+    findings = [{**f, "workflow": workflow} for f in findings]
 
     scope = scope_override or _detect_committed_scope(head=sha)
     # Issue #1558: NACH der Scope-Berechnung — nicht oben beim Telegram-Gate,
@@ -407,8 +427,22 @@ def write_verdict(verdict: str, findings_path: Path, e2e_path: Path | None = Non
             existing = json.loads(e2e_path.read_text())
         except (json.JSONDecodeError, OSError):
             existing = None
-        if existing is not None and existing.get("verified_commit") == sha:
+        # Fix #1689 (AC-8): ein valides, aber NICHT-Dict Top-Level-JSON wird wie
+        # eine kaputte Attestation behandelt (isinstance-Guard VOR .get()) —
+        # kein AttributeError, regulaeres Ueberschreiben bleibt moeglich.
+        if isinstance(existing, dict) and existing.get("verified_commit") == sha:
             existing_findings = existing.get("findings") or []
+            # Fix #1689 (AC-4): Nicht-Dict-Altlasten (z.B. aus einer frueheren
+            # Objekt-statt-Liste-Fehlform, #1653/#1677) werden VOR dem
+            # Workflow-Filter verworfen — jeder reguläre Folge-Schreibvorgang
+            # heilt damit ein bereits verschmutztes Artefakt.
+            existing_findings, existing_unusable = _e2e_paths.partition_findings(existing_findings)
+            if existing_unusable:
+                _log(
+                    f"{len(existing_unusable)} unverwertbare (Nicht-Dict-)Altlast-"
+                    "Eintraege beim Merge verworfen.",
+                    stream=sys.stderr,
+                )
             # Issue #1327 (AC-4): Einträge DIESES Workflows werden ersetzt statt
             # additiv angehängt — sonst überleben korrigierte Fassungen neben den
             # fehlerhaften und erzeugen dauerhaft False-FAILs. Fremde Workflows
@@ -547,6 +581,19 @@ def gate_check(e2e_path: Path | None, scope_override: str | None,
         except (json.JSONDecodeError, OSError) as exc:
             _log(f"FEHLER: Nachweis-Datei {e2e_path} nicht lesbar: {exc}", stream=sys.stderr)
             return 1
+
+    # Fix #1689 (AC-9): valides, aber NICHT-Dict Top-Level-JSON wird FAIL-CLOSED
+    # geblockt — anders als der Merge-Lesepfad (weich), weil dies der
+    # Exakt-Match-Zweig des echten Prod-Deploy-Gates ist. NICHT wie `data is
+    # None` behandeln (das würde in die Ancestor-Relaxierung rutschen).
+    if data is not None and not isinstance(data, dict):
+        _log(
+            f"FEHLER: Nachweis-Datei {e2e_path} enthält kein Dict auf oberster "
+            f"Ebene (gefundener Typ: {type(data).__name__}) — Gate fail-closed "
+            "blockiert.",
+            stream=sys.stderr,
+        )
+        return 1
 
     verified_commit = data.get("verified_commit", "") if data is not None else ""
 

--- a/docs/context/fix-1689-attestation-robustheit.md
+++ b/docs/context/fix-1689-attestation-robustheit.md
@@ -1,0 +1,204 @@
+# Context: fix-1689-attestation-robustheit
+
+Issue: [#1689](https://github.com/henemm/gregor_zwanzig/issues/1689) · `bug`, `priority:medium`, triage:c
+(fälschlich blockierendes/crashendes Gate)
+
+## Request Summary
+
+Der Pflicht-Post-Deploy-Selftest stürzt ab, wenn das `findings`-Array einer Attestation
+Nicht-Dict-Einträge (Bare-Strings) enthält — und `staging_gate.py` lässt genau solche Einträge
+still hinein, sobald der Prüf-Agent statt einer JSON-**Liste** ein JSON-**Objekt** an
+`--findings-json` übergibt. Zweimal am 2026-08-10 in zwei unabhängigen Sessions aufgetreten
+(#1653, #1677); beide Male verzögerte sich der Deploy-Abschluss.
+
+## Befund am Code (selbst nachgeprüft, nicht aus dem Issue übernommen)
+
+### Schreibseite — `.claude/hooks/staging_gate.py`
+
+| Zeile | Beobachtung |
+|---|---|
+| 358 | `findings = json.loads(findings_path.read_text())` — **kein Typ-Check**. Ein JSON-Objekt wird zu einem `dict`. |
+| 370–373 | `[{**f, "workflow": w} if isinstance(f, dict) else f for f in findings]` — die Iteration über ein `dict` liefert dessen **Schlüssel** (Strings); der `else f`-Zweig reicht sie unverändert durch. Exit 0, keine Meldung. |
+| 411–447 | Merge: `kept` filtert nur über `isinstance(f, dict) and f.get("workflow")`. Nicht-Dict-Altlasten fallen in keinen Filter und werden bei **jedem** Folgeschreiben unverändert mitgeschleppt. |
+
+Zusätzlich (über den Issue-Text hinaus): ein **Skalar** in der Findings-Datei (`5`, `true`)
+lässt `for f in findings` mit `TypeError` abbrechen — unbehandelter Traceback statt Meldung.
+
+### Leseseite — `.claude/hooks/prod_selftest.py`
+
+| Zeile | Beobachtung |
+|---|---|
+| 748 | `findings = verified.get("findings", [])` — kein Typ-Check auf das Feld selbst. |
+| 759 | `pool.map(_probe_ac, findings)` — die Exception aus dem Worker schlägt beim Einsammeln durch. |
+| 239–244 | `_probe_ac`: `finding.get("status")` → `AttributeError: 'str' object has no attribute 'get'`. |
+| 547–577 | `_derive_verdict`: filtert ebenfalls über `p.get("status")` — würde an Nicht-Dicts genauso scheitern. |
+| 455–463 | `_render_full_report(..., probes)` — dritte Stelle, die Dicts voraussetzt. |
+
+**Präzisierung nach Gegenprobe (Challenger):** Es sind **eine akute + zwei latente**
+Absturzstellen, nicht drei aktuelle. `_probe_ac` läuft als erstes und reißt den Lauf über
+`pool.map` sofort ab — `_derive_verdict` und `_render_full_report` werden in diesem Durchlauf
+nie erreicht. Latent werden sie genau dann, wenn man `_probe_ac` isoliert absichert (z. B. per
+`try/except`, das den rohen String durchreicht). Konsequenz unverändert: Die Reparatur gehört
+**vor** das `pool.map` — dort erledigt sie alle drei auf einmal.
+
+### 🔴 Falle bei der naheliegenden Umsetzung
+
+`_derive_verdict` liefert bei „keine PASS-Findings" **PASS** (Zeile 553–556), und Zeile 748–753
+werten ein leeres `findings` als PASS mit Exit 0. Ein reines „Nicht-Dicts wegfiltern und
+weitermachen" würde bei einer Attestation, die **nur** aus Bare-Strings besteht, einen stummen
+Gesamt-PASS erzeugen — also aus einem lauten Crash ein leises Falsch-Grün machen. Das ist die
+bekannte Klasse „Gate bestand mit Foto der Anmeldemaske". Muss in den ACs abgedeckt sein.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `.claude/hooks/staging_gate.py` | `write_verdict()` (Z. 330–452) — Eingangsvalidierung + Merge |
+| `.claude/hooks/prod_selftest.py` | `_probe_ac` (239), Hauptlauf (748–776), `_derive_verdict` (547) |
+| `.claude/hooks/_e2e_paths.py` | Auflösung `.claude/e2e_verified/<sha>.json` (unverändert) |
+| `.claude/agents/staging-validator.md:88` | erzeugt die Findings-Datei — Aufrufer, der den Fehler produziert hat |
+| `.claude/commands/e2e-verify.md:148` | zweiter Aufrufer |
+| `tests/tdd/test_staging_gate.py` | Muster Subprozess-Aufruf `_run_gate`, `--e2e-path` in `tmp_path` |
+| `tests/tdd/test_staging_gate_verdict_merge.py` | Muster Merge-Tests (#1197) |
+| `tests/tdd/test_prod_selftest_internal_url_skip.py` | **Vorlage für den Regressionstest**: lädt `prod_selftest.py` per `importlib` aus der Worktree-Kopie, kein Netz |
+
+## Existing Patterns
+
+- **Fail-loud auf der Schreibseite, fail-soft auf der Leseseite.** Präzedenz: `write_verdict`
+  lehnt seit #1327 Verdict-Texte ohne `VERIFIED`/`AMBIGUOUS`-Präfix mit Exit 1 ab (Z. 347–352) —
+  exakt die Bauform, die `--findings-json` fehlt.
+- **Skip-Status statt FAIL** auf der Leseseite: `SKIPPED_NO_URL`, `SKIPPED_PREVIEW_TEST_TRIP`,
+  `SKIPPED_NOT_MAPPABLE` (#788/#1197) — ein neuer Status für unbrauchbare Einträge fügt sich ein.
+- **Testpfad-Regel #1409:** Prüfling relativ zur Testdatei auflösen
+  (`Path(__file__).resolve().parents[2]`), sonst prüft der Test die unveränderte Hauptrepo-Kopie.
+- **Testnamensregel:** nach Verhalten benennen, nicht nach Issue-Nummer.
+
+## Dependencies
+
+- **Upstream** (erzeugen die Eingabe): `staging-validator`-Agent, `/e2e-verify`-Command — beide
+  schreiben eine Findings-JSON nach `/tmp` und übergeben den Pfad.
+- **Downstream** (lesen das Artefakt): `prod_selftest.py` (Findings als HTTP-Proben),
+  `staging_gate.py --check` (nur `verified_commit`/`staging_verdict`/`scope`, **nicht** die
+  Findings), `deploy-gregor-prod.sh` (ruft `--check` auf, liest die Findings nicht selbst).
+  ⇒ Der Deploy-Block hängt nicht an den Findings; betroffen ist der **Issue-Close** hinter
+  Schritt 4b.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1197_staging_gate_verdict_merge.md` — die Merge-Mechanik, die hier
+  erweitert wird
+- `docs/specs/modules/fix_1197_prod_selftest_internal_url_skip.md` — Vorbild für einen neuen
+  Skip-/Meldestatus
+- `docs/specs/modules/fix_1382_deploy_gate_evidence.md` — Nachweis-Ablage pro Stand
+- `docs/specs/_archive/modules/issue_521_staging_validator.md` — Ursprungs-Kontrakt von Mode A
+
+## Risks & Considerations
+
+1. **Falsch-Grün statt Crash** (s. o.) — die Hauptgefahr der Umsetzung.
+2. **Bestehende Attestationen** dürfen durch eine strengere Leseseite nicht plötzlich blockieren;
+   alle `.claude/e2e_verified/*.json` mit sauberen Dict-Findings müssen unverändert PASS liefern.
+3. **Verschärfung der Schreibseite** darf keinen gültigen Lauf abweisen — die bestehenden
+   `test_staging_gate.py`-Fälle (leere Liste, Liste von Dicts) müssen grün bleiben.
+4. **Merge-Bereinigung**: Nicht-Dict-Altlasten beim Folgeschreiben zu verwerfen ändert eine
+   bestehende Datei. Das ist gewollt („laut sagen"), berührt aber den Marker-Schutz — die
+   Bereinigung darf **nur** durch das Werkzeug selbst passieren, nie per Hand/Bash.
+5. **Exit-Code-Messung**: Der ursprüngliche Crash wurde als PASS fehlgelesen, weil
+   `… | tail; echo $?` den Exit der Pipe meldet. Für die Verifikation gilt: Exit direkt messen
+   (`cmd > datei; echo $?`), nie durch eine Pipe.
+6. **Kein Netz im Regressionstest** — Kern-Schicht, Muster aus `test_prod_selftest_internal_url_skip.py`.
+
+## Analysis
+
+### Type
+
+**Bug** — fälschlich crashendes Gate (triage:c). Kein Verhalten der Anwendung betroffen,
+ausschließlich die Nachweis-Kette der Auslieferung.
+
+### Technical Approach (Empfehlung)
+
+**Zwei Verteidigungslinien mit unterschiedlicher Härte** — das ist die Kernentscheidung:
+
+| Seite | Verhalten | Begründung |
+|---|---|---|
+| **Schreibseite** `staging_gate.py` | **hart: Exit ≠ 0**, kein Artefakt | Der Prüf-Agent steht noch am Werkzeug und kann seine Datei sofort korrigieren. Ein kaputtes Artefakt entsteht gar nicht erst. Präzedenz im selben File: Verdict-Präfix-Prüfung (#1327, Z. 347–352). |
+| **Leseseite** `prod_selftest.py` | **weich: überspringen + melden** | Läuft nach dem Deploy und trifft nur noch Altlasten. Ein kaputtes Artefakt darf den Wächter nicht abschießen — es soll als „Nachweis nicht sauber" **im Bericht stehen**. |
+
+Konkret:
+
+1. `staging_gate.py::write_verdict` — vor Z. 370 eine Eingangsprüfung: die geladene JSON muss
+   eine **Liste** sein, und **jedes** Element ein **Dict**. Sonst Exit 1 mit einer Meldung, die
+   den tatsächlichen Typ nennt und auf die erwartete Form hinweist. Deckt auch den
+   Skalar-Fall ab (`TypeError` beim Iterieren).
+2. `staging_gate.py` Merge (Z. 411–447) — Nicht-Dict-Einträge aus `existing_findings`
+   **verwerfen** und die Zahl der verworfenen Einträge auf stderr melden. Damit heilt jedes
+   reguläre Folgeschreiben ein bereits verschmutztes Artefakt, ohne Hand-Edit (Marker-Schutz
+   bleibt gewahrt).
+3. `prod_selftest.py` — **vor** dem `pool.map` (Z. 759) die Findings in verwertbar/unverwertbar
+   trennen. Unverwertbare erscheinen als eigener Abschnitt im Bericht. Damit sind alle drei
+   Absturzstellen (`_probe_ac`, `_derive_verdict`, `_render_full_report`) auf einen Schlag
+   erledigt, weil ab dort garantiert nur noch Dicts fließen. Ebenso abgesichert: ein
+   `findings`-Feld, das gar keine Liste ist (Z. 748).
+4. **Gegen das Falsch-Grün:** Waren unverwertbare Einträge dabei und bleibt **kein einziger**
+   verwertbarer übrig, ist das Ergebnis ausdrücklich **nicht PASS** — der Nachweis beweist
+   dann nichts. Exit ≠ 0 mit klarer Meldung. Bei Mischung (einige unverwertbar, andere gültig)
+   entscheidet wie bisher die Bewertung der gültigen Findings; die unverwertbaren stehen
+   sichtbar im Bericht.
+
+### Affected Files
+
+| Datei | Change | Beschreibung |
+|---|---|---|
+| `.claude/hooks/_e2e_paths.py` | MODIFY | **neue gemeinsame Funktion** `partition_findings(raw)` → `(gültige, unverwertbare)`; einziger Ort, der die Form der Findings kennt |
+| `.claude/hooks/staging_gate.py` | MODIFY | Eingangsprüfung `--findings-json` (hart, Exit 1); Merge verwirft Nicht-Dict-Altlasten laut |
+| `.claude/hooks/prod_selftest.py` | MODIFY | Partitionierung vor `pool.map`; Bericht-Abschnitt; Verdict-Regel „alles unverwertbar" |
+| `tests/tdd/test_attestation_findings_typsicher.py` | CREATE | Regressionstests beider Seiten, kein Netz, Fixture in der **realen** Objektform |
+
+### Scope Assessment
+
+- Dateien: 4 (3 MODIFY, 1 CREATE)
+- Geschätzte LoC: ~+90 Code, ~+130 Test → **~220**, unter dem Limit 250, aber ohne viel Luft
+- Risk Level: **MEDIUM** — kleiner, gut umgrenzter Eingriff, aber in den Wächtern selbst
+
+### Dependencies / Reihenfolge
+
+Schreib- und Leseseite sind unabhängig; die Leseseite ist die dringendere (sie crasht). Beides
+in einer Scheibe, weil die Regressionstests dieselbe Fixture-Form teilen.
+
+### Gegenprobe durch `analysis-challenger` (Verdict: NEEDS REVIEW) — eingearbeitet
+
+1. **🔴 Der Bug liegt scharf im Repo, nicht nur in der Vergangenheit.**
+   `.claude/e2e_verified/1001273d00382645824a11c96855a2ed9878fc51.json` trägt **heute**
+   `"findings": ["issue", "commit", "steps", "cleanup", "skipped", "notes"]` — sechs nackte
+   Strings. `verified_commit` passt zum Dateinamen, `staging_verdict` beginnt mit `VERIFIED`,
+   `verified_at` = 2026-08-10T08:42:28Z. Die Datei besteht damit **jede** Metadaten-Prüfung in
+   `gate_check()` und `_nearest_verified_ancestor()` und würde, sobald sie als exakter Treffer
+   oder nächster Vorfahre gewählt wird, den Selftest zum Absturz bringen. Sie liegt innerhalb
+   des Retention-Fensters (`ATTESTATION_RETENTION=20`, `staging_gate.py:62`), ist nach mtime
+   ca. die achtälteste und überlebt noch mehrere Schreibvorgänge. Die 19 anderen Attestationen
+   sind sauber — der Fehler ist selten, aber real.
+   **Nicht anfassen** (Marker-Schutz, Regel „Gate-State-Dateien nie per Hand"): der Fix macht
+   sie harmlos, und sie ist der beste Live-Beleg für die Wirkung.
+2. **🔴 Die reale Fehlform ist nicht „Liste vergessen".** Die Schlüssel `issue/commit/steps/
+   cleanup/skipped/notes` sehen nach einer **Report-/Changelog-Struktur** aus, nicht nach dem
+   AC-Schema `ac/status/url/evidence` (`.claude/agents/staging-validator.md:60–91`). Eine
+   Fixture, die nur „leeres Objekt statt Liste" simuliert, träfe den echten Fall womöglich
+   nicht. Die Regressionstests bilden **genau diese Objektform** nach.
+3. **Strukturell statt punktuell.** `staging_gate.py` trägt 40, `prod_selftest.py` 24
+   Issue-Referenzen in Kommentaren — beide Dateien wurden wieder und wieder gegen dieselbe
+   Klasse (kaputte/fehlende/veraltete Attestation-Daten) einzeln nachgerüstet, ohne dass es je
+   **eine** Stelle für die Form der Findings gab. Deshalb: die Prüf-/Normalisierungsfunktion
+   nach **`_e2e_paths.py`** — beide Hooks laden dieses Modul ohnehin schon per `importlib`
+   (`staging_gate.py:47–52`, `prod_selftest.py:47–51`), teilen dann **einen** Typkontrakt und
+   die nächste Konsumstelle erbt ihn automatisch.
+4. **Reichweite (4) bestätigt, jetzt am Original.** `gate_check()` (`staging_gate.py:461–654`)
+   und `_nearest_verified_ancestor()` (`_e2e_paths.py:292–359`) lesen nur
+   `verified_commit`/`staging_verdict`/`verified_at`. `deploy-gregor-prod.sh` (Z. 174, 210) ruft
+   ausschließlich `staging_gate.py --check` auf und liest die Findings nirgends selbst —
+   nachgelesen im Originalskript, nicht aus der Doku abgeleitet.
+5. **Kein heute grüner Test bricht.** Weder `test_staging_gate.py` noch
+   `test_staging_gate_verdict_merge.py` übergeben Nicht-Dict-Findings oder ein JSON-Objekt.
+
+### Open Questions
+
+- [ ] Keine blockierenden. Die einzige echte Entscheidung — hart schreiben / weich lesen, und
+      „alles unverwertbar ⇒ nicht PASS" — geht als AC in die Spec und wird dort freigegeben.

--- a/docs/specs/modules/fix_1689_attestation_findings_typkontrakt.md
+++ b/docs/specs/modules/fix_1689_attestation_findings_typkontrakt.md
@@ -1,0 +1,488 @@
+---
+entity_id: fix_1689_attestation_findings_typkontrakt
+type: bugfix
+created: 2026-08-10
+updated: 2026-08-10
+status: draft
+version: "1.2"
+tags: [gate, attestation, staging-gate, prod-selftest]
+---
+
+# Attestation-Findings: gemeinsamer Typkontrakt (hart schreiben, weich lesen)
+
+## Approval
+
+- [x] Approved — PO-Freigabe 2026-08-10 („auf 500 anheben, go"), inkl.
+      `loc_limit_override = 500` für diesen Workflow
+
+## Purpose
+
+Der Pflicht-Post-Deploy-Selftest (`prod_selftest.py`) stürzt ab, wenn das
+`findings`-Array einer Attestation Nicht-Dict-Einträge (Bare-Strings) enthält —
+und `staging_gate.py` lässt genau solche Einträge still hinein, sobald der
+Prüf-Agent statt einer JSON-**Liste** ein JSON-**Objekt** an `--findings-json`
+übergibt. Zweimal am 2026-08-10 in zwei unabhängigen Sessions aufgetreten
+(#1653, #1677), beide Male verzögerte sich der Deploy-Abschluss. Eine zweite
+Gegenprobe fand dieselbe Fehlerklasse eine Ebene höher: auch das **Top-Level**
+der Attestation selbst (nicht nur das `findings`-Array) wird an drei Stellen
+per `.get()` verwendet, ohne zu prüfen, ob überhaupt ein Dict geladen wurde.
+Diese Spec führt einen **gemeinsamen Typkontrakt für Attestation-Daten** ein
+(Top-Level-Dict UND Findings-Array) und macht die Schreib- und
+Deploy-Gate-Seite hart, die reinen Lese-/Report-Seiten weich, aber nicht
+blind (überspringen + sichtbar melden statt Absturz oder stilles Falsch-Grün).
+
+## Source
+
+- **File:** `.claude/hooks/_e2e_paths.py`
+- **Identifier:** `partition_findings(raw)` (neu) — von `staging_gate.py` und
+  `prod_selftest.py` per `importlib` geladen (bereits bestehendes Muster,
+  `staging_gate.py:47–52`, `prod_selftest.py:47–51`)
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `.claude/hooks/_e2e_paths.py` | module | Ort des neuen gemeinsamen Typkontrakts `partition_findings()`; wird von beiden Hooks bereits per `importlib.util.spec_from_file_location` geladen |
+| `.claude/hooks/staging_gate.py::write_verdict` | function | Schreibseite (Mode A) — Eingangsprüfung + Merge-Bereinigung, `write_verdict` Z. 330–458; Merge-Lesepfad Z. 410 |
+| `.claude/hooks/staging_gate.py::gate_check` | function | Deploy-Gate (Mode B) — Exakt-Match-Zweig Z. 551, aufgerufen von `deploy-gregor-prod.sh:174,210` im echten Prod-Deploy |
+| `.claude/hooks/prod_selftest.py` | module | Leseseite — `_probe_ac` (Z. 239), `_derive_verdict` (Z. 547), `_render_full_report` (Z. 439), Exakt-Match-Zweig (Z. 689), Hauptlauf (Z. 748–776) |
+| `.claude/agents/staging-validator.md` | agent | Erzeugt die `--findings-json`-Datei (Aufrufer, der den Fehler in #1653/#1677 produziert hat) |
+| `.claude/commands/e2e-verify.md` | command | Zweiter Aufrufer von `staging_gate.py --write-verdict` |
+| `docs/specs/modules/fix_1197_prod_selftest_internal_url_skip.md` | spec | Vorbild für einen neuen Skip-/Meldestatus auf der Leseseite |
+| `docs/specs/modules/fix_1197_staging_gate_verdict_merge.md` | spec | Merge-Mechanik, die hier um die Bereinigung von Nicht-Dict-Altlasten erweitert wird |
+
+## Scope
+
+### Affected Files
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `.claude/hooks/_e2e_paths.py` | MODIFY | Neue Funktion `partition_findings(raw)` → `(gueltige: list[dict], unverwertbare: list)`; einziger Ort, der die Form eines Findings kennt |
+| `.claude/hooks/staging_gate.py` | MODIFY | `write_verdict`: Eingangsprüfung der geladenen `--findings-json` (hart, Exit ≠ 0 bei Nicht-Liste oder Nicht-Dict-Element); Merge (Z. 411–447) verwirft Nicht-Dict-Altlasten aus `existing_findings` und meldet die Anzahl; Merge-Lesepfad (Z. 410) behandelt ein Top-Level-Nicht-Dict wie eine kaputte Datei; `gate_check` (Z. 551) blockiert fail-closed bei Top-Level-Nicht-Dict |
+| `.claude/hooks/prod_selftest.py` | MODIFY | Partitionierung der `findings` **vor** `pool.map` (Z. 758–759) über `_e2e_paths.partition_findings`; unverwertbare Einträge als eigener Bericht-Abschnitt (`_render_full_report`); neue Verdict-Regel „alles unverwertbar ⇒ nicht PASS"; Exakt-Match-Zweig (Z. 689) fällt bei Top-Level-Nicht-Dict auf die Ancestor-Suche zurück |
+| `tests/tdd/test_attestation_findings_typsicher.py` | CREATE | Regressionstests aller drei Ebenen (Findings-Array, Top-Level-Merge-Lesepfad, Top-Level-Gate-Check/Selftest-Exaktmatch) + der gemeinsamen Funktion, kein Netz, Fixtures in den real vorgefundenen Fehlformen |
+
+### Estimated Changes
+
+- Files: 4 (3 MODIFY, 1 CREATE)
+- LoC: ~+105 Code (Findings-Guard + 3 Top-Level-Guards), ~+150 Test (11 Testfälle inkl. Subprozess- und Boundary-Seam-Muster) → ~255 gesamt — **liegt über dem Workflow-Limit von 250**. Ein `loc_limit_override` ist vor der Implementierung beim PO einzuholen, nicht eigenmächtig zu setzen.
+- Effort: medium — kleiner, gut umgrenzter Eingriff, aber in den Wächtern selbst (Sorgfaltspflicht hoch, einer der drei neuen Guards sitzt im echten Prod-Deploy-Pfad)
+
+## Implementation Details
+
+### Warum zentral
+
+Dies ist bereits der **sechste** reaktiv nachgerüstete `isinstance(dict)`-Guard
+an demselben Objektgraphen — vorherige fünf: `_e2e_paths.py:54, :72, :139,
+:344` und `staging_gate.py:371/419/430/439`, entstanden aus #916, #1084,
+#1130, #1382, #1327. `prod_selftest.py` hat dagegen bis heute **null** solche
+Guards — genau dort liegt die akute Absturzstelle dieser Spec. Ausgerechnet
+der Ancestor-Pfad (`_e2e_paths.py:344`) ist geschützt, der häufiger benutzte
+Exakt-Match-Pfad in `staging_gate.py:551` und `prod_selftest.py:689` ist es
+nicht — eine Asymmetrie, die nur auffällt, wenn man beide Pfade nebeneinander
+liest. Genau das begründet, warum die neue Prüffunktion nach `_e2e_paths.py`
+gehört statt zum siebten Einzelflicken an einer der beiden Aufrufer-Dateien
+zu werden: beide Hooks laden das Modul bereits per `importlib`
+(`staging_gate.py:47–52`, `prod_selftest.py:47–51`), es entsteht kein neues
+Modul und kein neuer Import-Pfad.
+
+1. **`_e2e_paths.py` — `partition_findings(raw)`:** Erwartet `raw` als
+   beliebigen aus JSON geladenen Wert. Ist `raw` keine Liste, ist das gesamte
+   Ergebnis unverwertbar (leere `gueltige`, `raw` selbst als einziger Eintrag
+   in `unverwertbare`, oder eine äquivalente Markierung „kein Listentyp").
+   Ist `raw` eine Liste, wird elementweise nach `isinstance(f, dict)`
+   getrennt; die Reihenfolge bleibt erhalten. Reine Funktion, keine
+   Seiteneffekte, kein Zugriff auf Dateisystem/Zeit.
+
+2. **Schreibseite `staging_gate.py::write_verdict`** (vor der heutigen Z. 370,
+   `[{**f, "workflow": w} if isinstance(f, dict) else f for f in findings]`):
+   Nach dem Laden der `--findings-json` (Z. 357–361) wird `partition_findings`
+   aufgerufen. Bleibt auch nur ein unverwertbarer Eintrag übrig oder war die
+   Wurzel selbst keine Liste, bricht der Aufruf mit Exit ≠ 0 ab, **bevor**
+   irgendein Artefakt geschrieben wird — analog zur bestehenden
+   Verdict-Präfix-Prüfung im selben File (#1327, Z. 347–352: erst prüfen,
+   dann erst der `_telegram_live_gate()`-Aufruf und das Schreiben). Die
+   Meldung nennt den tatsächlich vorgefundenen Typ (z. B. `dict` statt
+   `list`) bzw. bei einer Liste den Index und Typ des ersten unverwertbaren
+   Elements. Ein Skalar (`5`, `true`, `null`) in der Datei fällt ebenfalls
+   unter „keine Liste" und erzeugt keinen unbehandelten `TypeError` mehr.
+
+3. **Merge-Bereinigung** (heutige Z. 411–447): `existing_findings` wird vor
+   dem `kept = [...]`-Filter durch `partition_findings` geschickt; nur die
+   `gueltige`-Hälfte fließt in den weiteren Merge (`kept`, `seen`, `merged`)
+   ein. Die Anzahl verworfener Einträge wird auf stderr gemeldet (Muster wie
+   `_log(...)` an anderen Stellen derselben Funktion). Damit heilt **jeder**
+   reguläre Folgeschreibvorgang für denselben `verified_commit` ein bereits
+   verschmutztes Artefakt — ohne Hand-Edit an der Gate-Datei (Marker-Schutz
+   bleibt gewahrt, die Bereinigung passiert ausschließlich durch das
+   Werkzeug selbst).
+
+4. **Top-Level-Guard im Merge-Lesepfad** (`staging_gate.py:410`,
+   `if existing is not None and existing.get("verified_commit") == sha:`):
+   Vor dem `.get()`-Aufruf zusätzlich `isinstance(existing, dict)` prüfen.
+   Trifft das nicht zu, wird die Datei wie eine kaputte/fehlende Attestation
+   behandelt — regulär überschrieben, konsistent mit dem bestehenden
+   Kommentar „Bei abweichendem/fehlendem/kaputtem verified_commit bleibt das
+   reguläre Überschreiben" (Z. 404). Kein Exit-Abbruch an dieser Stelle, weil
+   der reguläre Schreibvorgang selbst dadurch nicht verhindert werden darf.
+
+5. **Top-Level-Guard im Gate-Check** (`staging_gate.py:551`,
+   `verified_commit = data.get("verified_commit", "") if data is not None
+   else ""`): **Fail-closed.** Ist `data` geladen, aber kein Dict, wird das
+   NICHT wie `data is None` (→ kein Treffer, Ancestor-Relaxierung möglich)
+   behandelt, sondern blockiert den Deploy sofort mit Exit ≠ 0 und einer
+   eindeutigen Meldung, die den vorgefundenen Typ nennt. Dies ist der
+   Exakt-Match-Zweig des echten Prod-Deploy-Gates
+   (`deploy-gregor-prod.sh:174,210`) — hier gilt dieselbe Härte wie bei der
+   Verdict-Präfix-Prüfung, weil ein Deploy sonst auf einer unlesbaren
+   Attestation basieren könnte, ohne dass irgendjemand es bemerkt.
+
+6. **Top-Level-Guard im Selftest-Exaktmatch** (`prod_selftest.py:689`,
+   `if exact_data is not None and exact_data.get("verified_commit") ==
+   head:`): Zusätzlich `isinstance(exact_data, dict)` prüfen. Trifft das
+   nicht zu, wird wie „kein exakter Treffer" verfahren — die bestehende
+   Ancestor-Suche (dieselbe geteilte `_e2e_paths._nearest_verified_ancestor`,
+   die bereits an Z. 344 durch ihren eigenen Guard geschützt ist) greift
+   automatisch, statt mit `AttributeError` abzustürzen. Analog zur
+   Leseseite bei den Findings: weich, weil dies nach dem Deploy läuft und
+   nur noch Altlasten trifft.
+
+7. **Leseseite `prod_selftest.py`** (vor der heutigen Z. 758–759,
+   `probes = list(pool.map(_probe_ac, findings))`): `findings = verified.get(
+   "findings", [])` (Z. 748) wird durch `partition_findings` geschickt, statt
+   direkt an `pool.map` übergeben zu werden. Die `unverwertbare`-Liste
+   erscheint als eigener, sichtbarer Abschnitt im Bericht (`_render_full_report`,
+   Z. 439 ff.) — z. B. eine zusätzliche Überschrift „## Unverwertbare Findings"
+   mit den rohen Einträgen. Ab dieser Stelle fließen in `pool.map`,
+   `_derive_verdict` (Z. 547) und `_render_full_report` garantiert nur noch
+   Dicts — damit sind alle drei bekannten Absturzstellen (`_probe_ac`
+   akut über `pool.map`; `_derive_verdict`/`_render_full_report` latent,
+   sobald `_probe_ac` isoliert abgesichert würde) auf einen Schlag erledigt.
+   Ein `findings`-Feld, das selbst gar keine Liste ist, wird von
+   `partition_findings` identisch wie „alles unverwertbar" behandelt.
+
+8. **🔴 Verdict-Regel gegen Falsch-Grün — am WIRKORT prüfen, nicht am
+   Kurzschluss.** Waren unverwertbare Einträge dabei und bleibt nach dem
+   Partitionieren **kein einziger** verwertbarer übrig, liefert der Selftest
+   ausdrücklich **nicht** `PASS` (auch nicht `SKIPPED_ALL` o. ä.) und
+   Exit ≠ 0. **Wichtig:** Diese Regel darf sich nicht allein auf die heutige
+   Sonderbehandlung „leere Findings ⇒ PASS" (Z. 749–756) stützen, denn
+   `_derive_verdict([])` liefert **selbst** PASS zurück, unabhängig davon,
+   wo vorher gefiltert wurde: Z. 551 (`if probes and len(skipped_probes) ==
+   len(probes)`) ist bei leerer Liste falsch, Z. 553
+   (`if not pass_probes: return "PASS"`) trifft dann zu. Jede
+   Fix-Variante, die am Ende `_derive_verdict` mit einer nach Partitionierung
+   leeren Probe-Liste aufruft, tappt sonst in dieselbe Falle. Die Zusicherung
+   muss deshalb am **Ergebnis des vollständigen Laufs** hängen (finaler
+   Verdict-String + Prozess-Exit-Code), nicht an der Stelle, an der gefiltert
+   wird: konkret muss vor dem Aufruf von `_derive_verdict` (oder als erste
+   Prüfung darin) festgestellt werden „rohe Findings waren nicht leer UND
+   unverwertbare waren vorhanden UND gueltige ist leer" ⇒ eigener
+   Nicht-PASS-Pfad, unabhängig vom sonstigen `_derive_verdict`-Verhalten.
+   Eine leere **rohe** Findings-Liste (kein unverwertbarer Eintrag vorhanden)
+   bleibt PASS wie bisher. Bei Mischung (einige unverwertbar, andere gültig)
+   entscheidet unverändert die Bewertung der gültigen Findings; die
+   unverwertbaren stehen zusätzlich sichtbar im Bericht.
+
+## Expected Behavior
+
+- **Input (Schreibseite):** `--findings-json` zeigt auf eine Datei mit
+  beliebigem JSON-Inhalt.
+- **Output (Schreibseite):** Nur bei einer JSON-Liste aus ausschließlich
+  Dict-Elementen wird die Attestation geschrieben (Exit 0 bei
+  VERIFIED/AMBIGUOUS-Präfix, unverändert). Bei jeder anderen Form: Exit ≠ 0,
+  kein Artefakt, Meldung mit dem vorgefundenen Typ auf stderr.
+- **Input (Merge-Lesepfad / Gate-Check / Selftest-Exaktmatch):** eine
+  bestehende `.claude/e2e_verified/<sha>.json`, deren Top-Level-JSON valide,
+  aber kein Dict ist.
+- **Output:** Merge-Lesepfad behandelt dies wie eine kaputte Datei (regulär
+  überschreiben); Gate-Check blockiert fail-closed (Exit ≠ 0, Deploy-relevant);
+  Selftest-Exaktmatch fällt weich auf die Ancestor-Suche zurück.
+- **Input (Leseseite Findings):** `verified.get("findings", [])` aus einer
+  bestehenden `.claude/e2e_verified/<sha>.json`.
+- **Output (Leseseite Findings):** Kein Absturz unabhängig vom Inhalt.
+  Gemischte Findings liefern ein Verdict nur aus den gültigen Einträgen,
+  unverwertbare erscheinen im Bericht. Ausschließlich unverwertbare Findings
+  liefern ein explizites Nicht-PASS mit Exit ≠ 0.
+- **Side effects:** Merge-Bereinigung verändert bestehende
+  `.claude/e2e_verified/<sha>.json`-Dateien beim nächsten regulären Schreiben
+  desselben `verified_commit` (gewollt, siehe Punkt 3 oben). Kein
+  Hand-Edit, keine Bash-Manipulation der Gate-Datei.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine gemischte Rohliste aus Findings (Dict- und
+  Nicht-Dict-Einträgen in beliebiger Reihenfolge), When
+  `_e2e_paths.partition_findings(raw)` aufgerufen wird, Then liefert sie ein
+  Tupel `(gueltige, unverwertbare)`, in dem `gueltige` ausschließlich die
+  Dict-Einträge und `unverwertbare` ausschließlich die Nicht-Dict-Einträge
+  enthält, jeweils in ursprünglicher Reihenfolge.
+  - Test: Direkter Aufruf der reinen Funktion mit einer Liste, die Dicts,
+    Strings und eine Zahl mischt — kein Dateiinhalt-Check, echtes
+    Funktionsverhalten.
+
+- **AC-2:** Given eine `--findings-json`-Datei mit validem JSON, das aber
+  KEINE Liste ist (z. B. ein Objekt `{"issue": "...", "commit": "..."}"`,
+  eine Zahl oder `null`), When `staging_gate.py --write-verdict "VERIFIED: …"
+  --findings-json <datei>` aufgerufen wird, Then bricht der Prozess mit
+  Exit-Code ≠ 0 ab, es wird KEINE `.claude/e2e_verified/<sha>.json`
+  geschrieben, und die stderr-Meldung nennt den tatsächlich vorgefundenen
+  Typ (z. B. „dict" statt „list").
+  - Test: Subprozess-Aufruf von `staging_gate.py` (Muster
+    `test_staging_gate.py::_run_gate`) mit `--e2e-path` in `tmp_path`;
+    Assertion auf Exit-Code, Nicht-Existenz der Zieldatei und Meldungsinhalt.
+
+- **AC-3:** Given eine `--findings-json`-Datei mit einer JSON-Liste, die
+  mindestens ein Nicht-Dict-Element enthält (z. B. `["issue", "commit",
+  "steps", "cleanup", "skipped", "notes"]` — die reale Fehlform aus
+  `.claude/e2e_verified/1001273d00382645824a11c96855a2ed9878fc51.json`), When
+  `--write-verdict` aufgerufen wird, Then bricht der Prozess mit Exit-Code
+  ≠ 0 ab, es wird kein Artefakt geschrieben, und die Meldung weist auf
+  unverwertbare Elemente in der Liste hin.
+  - Test: Subprozess-Aufruf wie AC-2, Fixture ist exakt die reale Fehlform.
+
+- **AC-4:** Given eine bestehende Attestation für denselben `verified_commit`,
+  deren `findings`-Array bereits Nicht-Dict-Altlasten enthält, When ein
+  weiterer regulärer `--write-verdict`-Aufruf mit gültigen (Dict-)Findings
+  für denselben Commit erfolgt, Then enthält die geschriebene Datei im
+  `findings`-Array KEINE Nicht-Dict-Einträge mehr, und die Anzahl der
+  verworfenen Einträge wird auf stderr gemeldet.
+  - Test: Zwei aufeinanderfolgende `_run_gate`-Aufrufe auf dieselbe
+    `tmp_path`-Attestation (Muster `test_staging_gate_verdict_merge.py`):
+    erster Aufruf legt eine Attestation mit Bare-String-Findings direkt per
+    `json.dump` an (simuliert Altlast), zweiter Aufruf ist ein regulärer
+    `--write-verdict` mit sauberen Findings.
+
+- **AC-5:** Given eine Attestation, deren `findings`-Array eine Mischung aus
+  gültigen Dict-Findings und unverwertbaren Nicht-Dict-Einträgen enthält,
+  When `prod_selftest.py` sie verarbeitet, Then löst dies weder
+  `AttributeError` noch `TypeError` aus, die unverwertbaren Einträge
+  erscheinen als eigener sichtbarer Abschnitt im erzeugten Bericht, und der
+  Verdict richtet sich ausschließlich nach den gültigen Findings.
+  - Test: Modul per `importlib` aus der Worktree-Kopie laden (Muster
+    `test_prod_selftest_internal_url_skip.py`), `_e2e_verified_data` mit
+    gemischten Findings präparieren. Der Health-Check wird als ehrlicher
+    Boundary-Seam an der Netzgrenze ersetzt (Muster
+    `test_prod_selftest_internal_url_skip.py`: `_http_get` per monkeypatch
+    durch einen Recorder, der NIE die zu testende Logik zurückspiegelt) —
+    ausschließlich um die Netzgrenze zu kontrollieren, kein Mock der
+    Findings-Verarbeitung selbst. Bericht-Text auf den neuen Abschnitt
+    prüfen.
+
+- **AC-6:** Given eine Attestation, deren `findings`-Feld selbst gar keine
+  Liste ist (z. B. ein Objekt statt einer Liste), When `prod_selftest.py`
+  sie verarbeitet, Then löst dies keinen Absturz aus, sondern das Feld wird
+  vollständig als unverwertbar behandelt und im Bericht entsprechend
+  ausgewiesen.
+  - Test: wie AC-5, aber `findings` im präparierten Attestation-Dict durch
+    ein Objekt ersetzt.
+
+- **AC-7:** Given eine Attestation, deren `findings`-Array ausschließlich
+  aus unverwertbaren Nicht-Dict-Einträgen besteht (reale Fehlform:
+  `["issue", "commit", "steps", "cleanup", "skipped", "notes"]`), When
+  `prod_selftest.py` den **vollständigen Lauf** verarbeitet (nicht nur der
+  Kurzschluss bei leerer Roh-Liste, sondern der reguläre Pfad bis
+  `_derive_verdict`), Then ist das ENDGÜLTIGE Ergebnis AUSDRÜCKLICH NICHT
+  PASS (weder `PASS` noch `SKIPPED_ALL` noch ein anderer Erfolgs-Status) und
+  der Prozess-Exit-Code ist ≠ 0 — kein stiller Erfolg für einen unbrauchbaren
+  Nachweis, auch nicht auf dem Umweg über eine nach Partitionierung leere
+  Probe-Liste, die `_derive_verdict([])` sonst als PASS werten würde
+  (`prod_selftest.py:553–556`).
+  - Test: wie AC-5, `findings` exakt auf die reale Fehlform gesetzt;
+    Assertion auf den **von der Hauptlauf-Funktion tatsächlich
+    zurückgegebenen/geschriebenen** Verdict-String UND den Prozess-Exit-Code
+    (nicht auf einen internen Zwischenwert oder nur auf einen der beiden —
+    genau die Verwechslung, die den Bug erst unentdeckt ließ, #1689 Risk 5:
+    „… | tail; echo $?" maskiert den echten Exit-Code). Der Test MUSS
+    `_derive_verdict` mit dem tatsächlich partitionierten (leeren)
+    Probe-Ergebnis durchlaufen lassen — der Kurzschluss darf nicht künstlich
+    vorgezogen werden, sonst prüft der Test am eigentlichen Bugpfad vorbei.
+
+- **AC-8:** Given eine bestehende Attestation-Datei für denselben
+  `verified_commit`, deren Top-Level-JSON valide, aber KEIN Dict ist (z. B.
+  eine Liste oder ein String), When `write_verdict` seinen Merge-Lesepfad
+  durchläuft (`staging_gate.py:410`), Then wird die Datei wie eine kaputte
+  Attestation behandelt und regulär überschrieben — kein `AttributeError`,
+  kein Abbruch des regulären Schreibvorgangs.
+  - Test: `--e2e-path` zeigt in `tmp_path` auf eine vorab per `json.dump`
+    angelegte Datei mit Top-Level-Liste statt Dict; anschließender regulärer
+    `--write-verdict`-Aufruf; Assertion, dass die Datei danach ein sauberes
+    Dict mit den neuen Findings enthält.
+
+- **AC-9:** Given eine Attestation-Datei, deren Dateiname exakt zum
+  Ziel-Commit passt, deren Top-Level-JSON aber KEIN Dict ist, When
+  `staging_gate.py --check` den Exakt-Match-Zweig durchläuft
+  (`staging_gate.py:551`, aufgerufen von `deploy-gregor-prod.sh:174,210` im
+  echten Prod-Deploy), Then blockiert der Gate-Check FAIL-CLOSED mit
+  Exit-Code ≠ 0 und einer Meldung, die den vorgefundenen Typ nennt —
+  niemals mit stillem Durchlassen (Exit 0) oder unbehandeltem Absturz.
+  - Test: `_run_gate(["--check", ...])` mit `--e2e-path` auf eine
+    vorbereitete Top-Level-Nicht-Dict-Datei; Assertion auf Exit-Code ≠ 0.
+
+- **AC-10:** Given eine Attestation-Datei, deren Dateiname exakt zum
+  Ziel-Commit (HEAD) passt, deren Top-Level-JSON aber KEIN Dict ist, When
+  `prod_selftest.py` seinen Exakt-Match-Zweig durchläuft
+  (`prod_selftest.py:689`), Then wird dies wie „kein exakter Treffer"
+  behandelt, sodass die bestehende Ancestor-Suche
+  (`_e2e_paths._nearest_verified_ancestor`) greift, statt mit
+  `AttributeError` abzustürzen.
+  - Test: wie AC-5/AC-9-Muster — exakt benannte Attestation-Datei mit
+    Top-Level-Liste vorbereiten, optional einen gültigen Ancestor daneben
+    anlegen; Assertion auf kein `AttributeError` und erwartetes
+    Ancestor-Verhalten (PASS über Ancestor bzw. definierte Fail-Meldung,
+    wenn kein Ancestor existiert).
+
+## Invarianten / Was sich nicht ändern darf
+
+- Alle heute grünen Fälle in `tests/tdd/test_staging_gate.py` bleiben grün:
+  eine leere Findings-Liste und eine Liste ausschließlich aus Dicts sind
+  weiterhin gültige Eingaben für `--write-verdict`.
+- Alle heute grünen Fälle in `tests/tdd/test_staging_gate_verdict_merge.py`
+  bleiben grün: der bestehende Merge/Dedup-Mechanismus für saubere
+  Dict-Findings (Workflow-Tagging, Content-Dedup) ändert sich nicht.
+- Bestehende, saubere Attestationen (`.claude/e2e_verified/*.json` mit
+  Top-Level-Dict und ausschließlich Dict-Findings) liefern in
+  `staging_gate.py --check` und `prod_selftest.py` unverändert dasselbe
+  Verdict wie vor dieser Änderung.
+- `_nearest_verified_ancestor()` (`_e2e_paths.py:292–359`) wird NICHT
+  angefasst — ihr Guard (Z. 344) existiert bereits und bleibt Vorbild für
+  die drei neu abgesicherten Stellen.
+
+## Bestätigte Nicht-Risiken
+
+- Stichprobe von 11 echten Attestationen im Repo: ausnahmslos saubere
+  Top-Level-Dicts mit sauberen Dict-Findings. Eine strengere Eingangsprüfung
+  hätte keine davon abgewiesen.
+- `tests/tdd/conftest.py::_make_e2e_verified()` nutzt ebenfalls saubere
+  Top-Level-Dicts mit Dict-Findings — kein bestehender Test wird durch
+  diese Spec rot.
+
+## Nicht in dieser Scheibe
+
+- **Die real korrumpierte Datei
+  `.claude/e2e_verified/1001273d00382645824a11c96855a2ed9878fc51.json` wird
+  NICHT von Hand bereinigt.** Gate-State-Dateien werden nie per Hand/Bash
+  verändert (Marker-Schutz). Der Fix macht die Datei harmlos (AC-4 greift
+  beim nächsten regulären Schreiben desselben Commits; bis dahin verhindert
+  AC-5/AC-7 einen Absturz oder ein Falsch-Grün beim Lesen). Sie bleibt
+  bewusst als Live-Beleg liegen.
+- **Kein Schema-Zwang auf die Feldnamen INNERHALB eines Findings oder einer
+  Attestation.** Geprüft wird ausschließlich der Typ „Dict" (bzw. „Liste"
+  für das Findings-Array) — keine Pflicht auf `ac`/`status`/`url`/`evidence`
+  oder auf bestimmte Top-Level-Schlüssel. Ein zu strenger Feld-Zwang würde
+  gültige Altbestände mit abweichenden, aber funktionierenden
+  Feldkombinationen abweisen.
+- **Keine Änderung an der Ancestor-Relaxierung selbst oder am übrigen
+  Deploy-Block.** Der Prod-Deploy (`deploy-gregor-prod.sh:174,210`) ruft
+  ausschließlich `staging_gate.py --check` auf; betroffen von dieser Spec
+  ist der Exakt-Match-Zweig innerhalb von `gate_check` (AC-9) sowie die
+  Nachweis-Kette bis zum Issue-Close (Schritt 4b/5, AC-2–AC-8/AC-10), nicht
+  die Ancestor-Logik oder der restliche Deploy-Ablauf.
+- **Randnotiz — anderer Fehlermodus, kein Teil dieser Scheibe:**
+  `Path.write_text()` in `write_verdict` (Z. 449) ist nicht atomar. Bei
+  echter Parallelität entstünde dadurch potenziell invalides JSON (bereits
+  über den bestehenden `json.JSONDecodeError`-Fang sauber abgefangen), nicht
+  valides JSON mit falschem Typ — ein anderer Fehlermodus als der hier
+  behandelte.
+
+## Test Plan
+
+Neue Datei `tests/tdd/test_attestation_findings_typsicher.py` (Name nach
+Verhalten, nicht nach Issue-Nummer). Kern-Schicht, kein Netz. Prüflinge
+relativ zur Testdatei auflösen (`Path(__file__).resolve().parents[2]`,
+Muster `test_prod_selftest_internal_url_skip.py` / `test_staging_gate.py`).
+
+### Automated Tests (TDD RED)
+
+- [ ] `test_partition_findings_splits_dicts_and_non_dicts` — AC-1: reine
+      Funktion, gemischte Liste rein, korrekt getrenntes Tupel raus.
+- [ ] `test_partition_findings_non_list_root_is_fully_unusable` — AC-1
+      (Ergänzung): `raw` selbst kein Listentyp → alles landet in
+      `unverwertbare`, `gueltige` ist leer.
+- [ ] `test_write_verdict_rejects_object_instead_of_list` — AC-2: JSON-Objekt
+      statt Liste, Exit ≠ 0, kein Artefakt, Meldung nennt Typ „dict".
+- [ ] `test_write_verdict_rejects_list_with_bare_string_entries` — AC-3:
+      reale Fehlform (6 Bare-Strings) als Liste, Exit ≠ 0, kein Artefakt.
+- [ ] `test_write_verdict_merge_drops_non_dict_legacy_entries` — AC-4: Altlast
+      in bestehender Attestation wird beim nächsten sauberen Schreiben
+      entfernt, Anzahl auf stderr gemeldet.
+- [ ] `test_prod_selftest_survives_mixed_findings_without_crash` — AC-5: kein
+      Absturz, unverwertbare Einträge im Bericht sichtbar, Verdict nur aus
+      gültigen Findings.
+- [ ] `test_prod_selftest_survives_non_list_findings_field` — AC-6:
+      `findings`-Feld selbst kein Listentyp, kein Absturz.
+- [ ] `test_prod_selftest_all_unusable_findings_is_not_pass` — AC-7: reale
+      Fehlform als vollständiger `findings`-Inhalt, Verdict explizit nicht
+      PASS/SKIPPED_ALL, Exit-Code ≠ 0, Assertion läuft über den vollständigen
+      Lauf bis `_derive_verdict`, nicht über einen künstlich vorgezogenen
+      Kurzschluss.
+- [ ] `test_write_verdict_merge_survives_non_dict_top_level_existing` — AC-8:
+      bestehende Attestation mit Top-Level-Liste statt Dict, regulärer
+      Folge-Schreibvorgang überschreibt sauber statt abzustürzen.
+- [ ] `test_gate_check_fails_closed_on_non_dict_top_level` — AC-9: exakt
+      benannte Attestation mit Top-Level-Nicht-Dict, `--check` liefert
+      Exit-Code ≠ 0.
+- [ ] `test_prod_selftest_falls_back_to_ancestor_on_non_dict_exact_match` —
+      AC-10: exakt benannte Attestation mit Top-Level-Nicht-Dict, kein
+      Absturz, Ancestor-Pfad greift.
+
+## Mutations-Gegenprobe
+
+Vier konkrete Verfälschungen, die je mindestens einen der obigen Tests rot
+machen MÜSSEN (String-Ersetzung mit externer Sicherungskopie, kein
+`git checkout/stash/reset`):
+
+1. **Typprüfung auf der Schreibseite entfernen** — den neuen
+   `partition_findings`-Aufruf in `write_verdict` durch die heutige Zeile
+   `findings = json.loads(...)` ohne Prüfung ersetzen. Muss AC-2 und AC-3
+   rot machen (Attestation würde trotz Objekt/Bare-Strings geschrieben).
+2. **Partitionierung auf der Leseseite entfernen** — vor `pool.map` wieder
+   direkt `findings = verified.get("findings", [])` ohne
+   `partition_findings`-Aufruf verwenden. Muss AC-5 und AC-6 rot machen
+   (Absturz statt Bericht-Abschnitt).
+3. **„Alles unverwertbar ⇒ nicht PASS"-Regel entfernen** — die neue Regel
+   weglassen, sodass ein vollständig unverwertbares `findings`-Array wie
+   „leer" behandelt wird und `_derive_verdict([])` unverändert PASS mit
+   Exit 0 zurückgibt. Muss AC-7 rot machen (Verdict wäre PASS statt
+   explizit nicht-PASS) — UND zeigt, ob der Test den echten Pfad prüft: ein
+   Test, der den Kurzschluss bei leerer Roh-Liste künstlich auslöst statt
+   den vollständigen Lauf zu durchlaufen, bliebe an dieser Mutation
+   fälschlich grün.
+4. **Fail-closed-Guard im Gate-Check entfernen** — den neuen
+   `isinstance(data, dict)`-Guard vor `staging_gate.py:551` weglassen, sodass
+   `data.get(...)` bei einer Top-Level-Liste wieder mit `AttributeError`
+   abstürzt (oder, falls stattdessen `data is None` genutzt würde, fälschlich
+   in die Ancestor-Relaxierung des Deploy-Gates rutscht). Muss AC-9 rot
+   machen.
+
+## Known Limitations
+
+- Method-bewusstes Proben (GET vs. POST) und Feldnamen-Schema innerhalb
+  eines Findings oder einer Attestation bleiben unverändert außerhalb dieser
+  Spec (siehe „Nicht in dieser Scheibe").
+- Die Merge-Korrektur (AC-4) wirkt erst ab dem nächsten regulären
+  `--write-verdict`-Lauf auf denselben `verified_commit`; bis dahin verlässt
+  sich die Sicherheit gegen Absturz/Falsch-Grün ausschließlich auf die
+  Leseseiten-Guards (AC-5/AC-6/AC-7/AC-10).
+- Nicht-atomares Schreiben (`Path.write_text`) bleibt bestehen — siehe
+  Randnotiz unter „Nicht in dieser Scheibe".
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reiner Bugfix an bestehenden Gate-Skripten, keine neue
+  Entscheidungsfläche (kein neuer Kanal, Provider, Datenmodell oder
+  Auth-Mechanismus betroffen). Die Entscheidung „hart schreiben, weich
+  lesen" ist in dieser Spec begründet und braucht kein eigenes ADR.
+
+## Changelog
+
+- 2026-08-10: Initial spec created
+- 2026-08-10: Nachtrag zweite Gegenprobe — Top-Level-Typkontrakt (AC-8/AC-9/
+  AC-10), Präzisierung AC-7 auf den vollständigen Lauf/`_derive_verdict`,
+  Abschnitt „Warum zentral" und „Bestätigte Nicht-Risiken" ergänzt
+- 2026-08-10: Revision v1.2 — Testbeschreibungen (AC-5/AC-7, Testplan,
+  Mutation 3) von „gemockt"/„mocken" auf ehrlichen Boundary-Seam-Wortlaut
+  umformuliert (Mock-Theater-Verbot); LoC-Schätzung auf ~255 korrigiert
+  (über dem 250-Limit — `loc_limit_override` vor Umsetzung beim PO
+  einzuholen)

--- a/tests/tdd/test_attestation_findings_typsicher.py
+++ b/tests/tdd/test_attestation_findings_typsicher.py
@@ -1,0 +1,582 @@
+"""
+TDD RED — Attestation-Findings: gemeinsamer Typkontrakt (hart schreiben, weich lesen).
+
+Spec: docs/specs/modules/fix_1689_attestation_findings_typkontrakt.md (AC-1..AC-10)
+Kontext: #1653, #1677, #1689 — sobald der Pruef-Agent statt einer JSON-**Liste**
+ein JSON-**Objekt** an `--findings-json` uebergibt, iteriert write_verdict()
+heute lautlos ueber dessen SCHLUESSEL statt seine Elemente zu pruefen — genau
+so entstand die real vorgefundene Fehlform
+`.claude/e2e_verified/1001273d00382645824a11c96855a2ed9878fc51.json`:
+`"findings": ["issue", "commit", "steps", "cleanup", "skipped", "notes"]`
+(exakt die sechs Top-Level-Schluessel eines Findings-Objekts). Auf der
+Leseseite laesst genau diese Fehlform prod_selftest.py mit AttributeError
+abstuerzen (`_probe_ac` ruft `finding.get(...)` auf einem bloßen String auf).
+Eine zweite, unabhaengige Fehlerklasse betrifft das TOP-LEVEL der Attestation
+selbst (nicht nur das findings-Array): an drei Stellen wird `.get()` auf einem
+geladenen JSON-Wert aufgerufen, ohne zu pruefen, ob ueberhaupt ein Dict
+geladen wurde.
+
+Kein Netz (Kern-Schicht):
+- Die vier prod_selftest.py-Tests (AC-5/AC-6/AC-7/AC-10) rufen `run_selftest()`
+  direkt auf; der Health-Check/die HTTP-Proben laufen ueber einen ehrlichen
+  Boundary-Seam (`_http_get` per monkeypatch, Muster
+  test_prod_selftest_internal_url_skip.py::_HttpGetRecorder) — der Seam
+  spiegelt NIE die zu testende Findings-Logik zurueck, sondern liefert einen
+  fest verdrahteten Status.
+- Die staging_gate.py-Tests (AC-2/AC-3/AC-4/AC-8/AC-9) laufen als Subprozess
+  gegen ein HERMETISCHES Ein-Commit-Git-Repo (Muster
+  test_staging_gate.py::_setup_repo). e2e_telegram_live.py wird bewusst NICHT
+  mitkopiert: write_verdict() ruft ueber _telegram_live_gate() IMMER einen
+  echten `git diff HEAD~1..HEAD` auf (unabhaengig vom --scope-Override); in
+  einem Ein-Commit-Repo scheitert HEAD~1, was _telegram_live_gate() ohne
+  GZ_TELEGRAM_TEST_CHAT_ID sonst zum Blocken bringen wuerde. Das Fehlen der
+  Datei loest denselben fail-soft-Pfad aus, den test_staging_gate.py::_setup_repo
+  bereits nutzt (Import-Fehler abgefangen, Gate uebersprungen) — keine
+  Netzabhaengigkeit, kein Mock der eigentlich getesteten Logik.
+
+Pfadregel (#1409): Pruefling wird relativ zur Testdatei aufgeloest
+(Path(__file__).resolve().parents[2] -> .claude/hooks/...), NIE ueber einen
+festen Hauptrepo-Pfad — auch das hermetische Ein-Commit-Repo kopiert seine
+.claude/hooks aus genau dieser Worktree-Ablage, kein Bezug zum beweglichen
+Hauptrepo.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tests.tdd.conftest import _init_evidence_free_repo, _load_prod_selftest_module
+
+WORKTREE_DIR = Path(__file__).resolve().parents[2]
+HOOKS_DIR = WORKTREE_DIR / ".claude" / "hooks"
+
+
+# ---------------------------------------------------------------------------
+# Gemeinsame Helfer
+# ---------------------------------------------------------------------------
+
+def _load_e2e_paths_module():
+    """Laedt _e2e_paths.py frisch per importlib aus der Worktree-Kopie
+    (Muster test_staging_gate_verdict_merge.py::_load_module)."""
+    spec = importlib.util.spec_from_file_location(
+        "_e2e_paths_typsicher", str(HOOKS_DIR / "_e2e_paths.py")
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_e2e_paths_mod = _load_e2e_paths_module()
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    )
+
+
+def _setup_isolated_repo(tmp_path: Path) -> Path:
+    """Hermetisches Ein-Commit-Git-Repo mit eigener .claude/hooks-Kopie
+    (Muster test_staging_gate.py::_setup_repo) -- isoliert vom beweglichen
+    Hauptrepo. e2e_telegram_live.py wird bewusst NICHT mitkopiert (s.
+    Modul-Docstring)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "t@t.de")
+    _git(repo, "config", "user.name", "Test")
+
+    hooks = repo / ".claude" / "hooks"
+    hooks.mkdir(parents=True)
+    for name in ("staging_gate.py", "prod_selftest.py", "_e2e_paths.py"):
+        shutil.copy(HOOKS_DIR / name, hooks / name)
+
+    (repo / "README.md").write_text("# baseline\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "baseline")
+    return repo
+
+
+def _repo_head_sha(repo: Path) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def _run_gate_in(repo: Path, args: list[str]) -> tuple[int, str, str]:
+    env = os.environ.copy()
+    env["GZ_ACTIVE_WORKFLOW"] = "fix-1689-attestation-robustheit"
+    result = subprocess.run(
+        [sys.executable, str(repo / ".claude" / "hooks" / "staging_gate.py")] + args,
+        capture_output=True, text=True, cwd=str(repo), env=env,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def _add_commit(root: Path, relpath: str, content: str, message: str) -> str:
+    path = root / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    subprocess.run(["git", "add", "-A"], cwd=root, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-q", "-m", message], cwd=root, check=True, capture_output=True)
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=root, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+class _HealthOkRecorder:
+    """Ehrlicher Boundary-Seam an der Netzgrenze (Muster
+    test_prod_selftest_internal_url_skip.py::_HttpGetRecorder): liefert IMMER
+    einen erfolgreichen Health-Check und einen generischen 200 fuer jede
+    andere geprobte URL -- fest verdrahtet, spiegelt NIE die
+    Findings-Partitionierung zurueck."""
+
+    def __init__(self, mod):
+        self._health_url = mod.HEALTH_URL
+        self.calls: list[str] = []
+
+    def __call__(self, url: str, follow_redirects: bool = False):
+        self.calls.append(url)
+        if url == self._health_url:
+            return 200, b'{"status": "ok"}', ""
+        return 200, b"", ""
+
+
+# Reale Fehlform aus .claude/e2e_verified/1001273d00382645824a11c96855a2ed9878fc51.json
+REAL_FEHLFORM = ["issue", "commit", "steps", "cleanup", "skipped", "notes"]
+
+
+# ---------------------------------------------------------------------------
+# AC-1: _e2e_paths.partition_findings() — reine Funktion, kein Netz, kein Seam
+# ---------------------------------------------------------------------------
+
+def test_partition_findings_splits_dicts_and_non_dicts():
+    """AC-1: gemischte Liste aus Dict- und Nicht-Dict-Eintraegen rein, korrekt
+    getrenntes Tupel (gueltige, unverwertbare) raus, jeweils in Reihenfolge."""
+    dict_a = {"ac": "AC-1", "status": "PASS"}
+    dict_b = {"ac": "AC-2", "status": "PASS"}
+    raw = [dict_a, "issue", 42, dict_b, None, "commit"]
+
+    gueltige, unverwertbare = _e2e_paths_mod.partition_findings(raw)
+
+    assert gueltige == [dict_a, dict_b], (
+        f"gueltige soll ausschliesslich die Dict-Eintraege in Reihenfolge enthalten: {gueltige}"
+    )
+    assert unverwertbare == ["issue", 42, None, "commit"], (
+        f"unverwertbare soll ausschliesslich die Nicht-Dict-Eintraege in Reihenfolge enthalten: {unverwertbare}"
+    )
+
+
+def test_partition_findings_non_list_root_is_fully_unusable():
+    """AC-1 (Ergaenzung): raw selbst ist keine Liste (ein JSON-Objekt) ->
+    gueltige ist leer, unverwertbare traegt den gesamten Wert."""
+    raw = {
+        "issue": "#1653",
+        "commit": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        "steps": "1) Playwright-Lauf 2) Screenshots",
+        "cleanup": "keine",
+        "skipped": "keine",
+        "notes": "Objekt statt Liste",
+    }
+
+    gueltige, unverwertbare = _e2e_paths_mod.partition_findings(raw)
+
+    assert gueltige == [], f"Bei Nicht-Listen-Root darf 'gueltige' nicht befuellt sein: {gueltige}"
+    assert unverwertbare == [raw], (
+        f"Bei Nicht-Listen-Root soll 'unverwertbare' den Rohwert als einzigen Eintrag tragen: {unverwertbare}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2/AC-3: staging_gate.py write_verdict — Eingangspruefung Findings-JSON
+# ---------------------------------------------------------------------------
+
+def test_write_verdict_rejects_object_instead_of_list(tmp_path):
+    """AC-2: --findings-json zeigt auf ein JSON-OBJEKT statt einer Liste (der
+    reale Ausloeser von #1653/#1677) -> Exit != 0, KEIN Artefakt geschrieben,
+    Meldung nennt den vorgefundenen Typ 'dict'."""
+    repo = _setup_isolated_repo(tmp_path)
+    findings_path = tmp_path / "findings.json"
+    findings_path.write_text(json.dumps({
+        "issue": "#1653",
+        "commit": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        "steps": "1) Playwright-Lauf 2) Screenshots",
+        "cleanup": "keine",
+        "skipped": "keine",
+        "notes": "Objekt statt Liste an --findings-json uebergeben (echte Ursache von #1653/#1677)",
+    }))
+    out_path = tmp_path / "e2e_verified.json"
+
+    rc, out, err = _run_gate_in(repo, [
+        "--write-verdict", "VERIFIED: sollte abgelehnt werden",
+        "--findings-json", str(findings_path),
+        "--e2e-path", str(out_path),
+        "--scope=backend",
+    ])
+
+    combined = out + err
+    assert rc != 0, f"JSON-Objekt statt Liste muss Exit != 0 liefern, bekam {rc}.\n{combined}"
+    assert not out_path.exists(), (
+        f"Trotz Objekt statt Liste wurde eine Attestation geschrieben: {out_path}"
+    )
+    # F001-Haertung (Adversary): ein unbehandelter Absturz darf NIE als
+    # kontrollierte Meldung durchgehen. Ohne diese Zeile erfuellt bereits der
+    # Substring 'dict' aus der Traceback-Zeile 'return write_verdict(...)'
+    # (aus main()) die naechste Assertion, obwohl gar keine echte
+    # Typ-Meldung vorliegt -- z.B. wenn nur die isinstance(list)-Pruefung
+    # entfernt wird, aber die nachgelagerte partition_findings-Auswertung
+    # (die eine Liste voraussetzt) an einem Nicht-Listen-Wert mit
+    # KeyError/TypeError abstuerzt.
+    assert "Traceback" not in err, (
+        f"write_verdict ist mit einem unbehandelten Python-Traceback abgestuerzt "
+        f"statt kontrolliert mit einer eigenen Typ-Meldung abzulehnen:\n{err}"
+    )
+    assert "dict" in combined.lower(), (
+        f"Meldung soll den vorgefundenen Typ 'dict' nennen, bekam: {combined}"
+    )
+    assert "muss eine json-liste sein" in combined.lower(), (
+        f"Meldung soll die echte Typkontrakt-Meldung enthalten (nicht nur "
+        f"zufaellig 'dict' aus einer Traceback-Zeile), bekam: {combined}"
+    )
+
+
+def test_write_verdict_rejects_list_with_bare_string_entries(tmp_path):
+    """AC-3: --findings-json ist eine Liste mit Nicht-Dict-Elementen (die
+    reale Fehlform, sechs Bare-Strings) -> Exit != 0, KEIN Artefakt
+    geschrieben, Meldung weist auf unverwertbare Elemente hin."""
+    repo = _setup_isolated_repo(tmp_path)
+    findings_path = tmp_path / "findings.json"
+    findings_path.write_text(json.dumps(REAL_FEHLFORM))
+    out_path = tmp_path / "e2e_verified.json"
+
+    rc, out, err = _run_gate_in(repo, [
+        "--write-verdict", "VERIFIED: sollte abgelehnt werden",
+        "--findings-json", str(findings_path),
+        "--e2e-path", str(out_path),
+        "--scope=backend",
+    ])
+
+    combined = out + err
+    assert rc != 0, f"Liste mit Bare-String-Elementen muss Exit != 0 liefern, bekam {rc}.\n{combined}"
+    assert not out_path.exists(), (
+        f"Trotz Bare-String-Elementen wurde eine Attestation geschrieben: {out_path}"
+    )
+    assert any(kw in combined.lower() for kw in ["unverwertbar", "kein dict", "nicht dict", "index"]), (
+        f"Meldung soll auf unverwertbare Listenelemente hinweisen, bekam: {combined}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4: staging_gate.py write_verdict — Merge-Bereinigung von Findings-Altlast
+# ---------------------------------------------------------------------------
+
+def test_write_verdict_merge_drops_non_dict_legacy_entries(tmp_path):
+    """AC-4: eine bestehende Attestation fuer denselben verified_commit
+    traegt bereits Nicht-Dict-Altlasten im findings-Array (reale Fehlform);
+    ein weiterer regulaerer --write-verdict mit sauberen Findings muss diese
+    Altlast beim Merge entfernen und die Anzahl auf stderr melden."""
+    repo = _setup_isolated_repo(tmp_path)
+    head = _repo_head_sha(repo)
+    e2e_path = tmp_path / "e2e_verified.json"
+    e2e_path.write_text(json.dumps({
+        "verified_commit": head,
+        "staging_verdict": "VERIFIED: Altlast (reale Fehlform #1653/#1677)",
+        "findings": list(REAL_FEHLFORM),
+        "verified_at": datetime.now(timezone.utc).isoformat(),
+        "scope": "backend",
+        "environment": "staging",
+    }, indent=2))
+
+    clean_finding = {
+        "ac": "AC-1",
+        "status": "PASS",
+        "url": "https://staging.gregor20.henemm.com/trips:AC-1",
+        "evidence": "sauberer Folge-Lauf",
+    }
+    findings_path = tmp_path / "findings.json"
+    findings_path.write_text(json.dumps([clean_finding]))
+
+    rc, out, err = _run_gate_in(repo, [
+        "--write-verdict", "VERIFIED: sauberer Folge-Lauf",
+        "--findings-json", str(findings_path),
+        "--e2e-path", str(e2e_path),
+        "--scope=backend",
+    ])
+
+    assert rc == 0, (
+        f"Regulaerer Folge-Schreibvorgang mit sauberen Findings muss gelingen, "
+        f"bekam Exit {rc}.\nstdout: {out}\nstderr: {err}"
+    )
+    result = json.loads(e2e_path.read_text())
+    findings = result.get("findings", [])
+    assert all(isinstance(f, dict) for f in findings), (
+        f"Nicht-Dict-Altlast wurde beim Merge NICHT entfernt: {findings}"
+    )
+    assert any(
+        f.get("ac") == "AC-1" and f.get("evidence") == "sauberer Folge-Lauf" for f in findings
+    ), f"Neues sauberes Finding fehlt nach dem Merge: {findings}"
+    combined = out + err
+    assert any(kw in combined.lower() for kw in ["verworfen", "entfernt", "discard"]), (
+        f"Anzahl der verworfenen Altlast-Eintraege soll auf stderr gemeldet werden, bekam: {combined}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-8/AC-9: Top-Level-Typkontrakt (Merge-Lesepfad + Gate-Check)
+# ---------------------------------------------------------------------------
+
+def test_write_verdict_merge_survives_non_dict_top_level_existing(tmp_path):
+    """AC-8: die BESTEHENDE Attestation-Datei fuer denselben verified_commit
+    hat ein valides, aber NICHT-Dict Top-Level-JSON (eine Liste) -> der
+    Merge-Lesepfad behandelt dies wie eine kaputte Datei und ueberschreibt
+    regulaer -- kein AttributeError, kein Abbruch des Schreibvorgangs."""
+    repo = _setup_isolated_repo(tmp_path)
+    e2e_path = tmp_path / "e2e_verified.json"
+    e2e_path.write_text(json.dumps(["kaputt", "kein", "dict"]))
+
+    clean_finding = {
+        "ac": "AC-1",
+        "status": "PASS",
+        "url": "https://staging.gregor20.henemm.com/trips:AC-1",
+        "evidence": "regulaerer Schreibvorgang nach kaputter Bestandsdatei",
+    }
+    findings_path = tmp_path / "findings.json"
+    findings_path.write_text(json.dumps([clean_finding]))
+
+    rc, out, err = _run_gate_in(repo, [
+        "--write-verdict", "VERIFIED: ueberschrieben nach kaputtem Bestand",
+        "--findings-json", str(findings_path),
+        "--e2e-path", str(e2e_path),
+        "--scope=backend",
+    ])
+
+    assert rc == 0, (
+        f"Top-Level-Nicht-Dict-Bestandsdatei muss wie eine kaputte Attestation behandelt "
+        f"und regulaer ueberschrieben werden, bekam Exit {rc}.\nstdout: {out}\nstderr: {err}"
+    )
+    result = json.loads(e2e_path.read_text())
+    assert isinstance(result, dict), f"Ergebnis muss ein sauberes Dict sein, war: {result!r}"
+    assert any(
+        f.get("ac") == "AC-1" and f.get("evidence") == clean_finding["evidence"]
+        for f in result.get("findings", [])
+    ), f"Neues Finding fehlt nach dem Ueberschreiben: {result.get('findings')}"
+
+
+def test_gate_check_fails_closed_on_non_dict_top_level(tmp_path):
+    """AC-9: eine exakt zum Ziel-Commit passende Attestation-Datei hat ein
+    valides, aber NICHT-Dict Top-Level-JSON -> `--check` (Exakt-Match-Zweig,
+    aufgerufen vom echten Prod-Deploy) blockt FAIL-CLOSED mit einer eigenen
+    Meldung -- niemals stilles Durchlassen (Exit 0) UND niemals ein
+    unbehandelter Python-Absturz (Traceback), der nur zufaellig denselben
+    Exit-Code liefert."""
+    repo = _setup_isolated_repo(tmp_path)
+    e2e_path = tmp_path / "broken_top_level.json"
+    e2e_path.write_text(json.dumps(["not", "a", "dict"]))
+
+    rc, out, err = _run_gate_in(repo, ["--check", f"--e2e-path={e2e_path}", "--scope=backend"])
+
+    combined = out + err
+    assert rc != 0, f"Erwartet Exit != 0 bei Top-Level-Nicht-Dict, bekam {rc}.\n{combined}"
+    assert "Traceback" not in err, (
+        "gate_check ist mit einem unbehandelten Python-Traceback abgestuerzt statt "
+        f"kontrolliert fail-closed mit einer eigenen Meldung zu blocken:\n{err}"
+    )
+    assert any(kw in combined.lower() for kw in ["list", "kein dict", "nicht dict", "typ"]), (
+        f"Meldung soll den vorgefundenen Typ nennen, bekam: {combined}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5/AC-6/AC-7: prod_selftest.py — Findings-Partitionierung vor pool.map
+# ---------------------------------------------------------------------------
+
+def test_prod_selftest_survives_mixed_findings_without_crash(tmp_path, monkeypatch):
+    """AC-5: das findings-Array einer Attestation mischt gueltige Dict-
+    Findings mit unverwertbaren Nicht-Dict-Eintraegen -> kein AttributeError/
+    TypeError, die unverwertbaren Eintraege erscheinen als eigener sichtbarer
+    Abschnitt im Bericht, das Verdict richtet sich ausschliesslich nach den
+    gueltigen Findings."""
+    mod = _load_prod_selftest_module()
+    root = tmp_path / "repo"
+    head = _init_evidence_free_repo(root)
+    monkeypatch.setattr(mod, "REPO_DIR", root)
+    recorder = _HealthOkRecorder(mod)
+    monkeypatch.setattr(mod, "_http_get", recorder)
+
+    valid_finding = {
+        "ac": "AC-1",
+        "status": "PASS",
+        "url": "https://staging.gregor20.henemm.com/trips:AC-1",
+        "evidence": "gueltiges Finding",
+    }
+    mixed_findings = [valid_finding, "issue", 42, None]
+    e2e_path = tmp_path / "e2e_verified.json"
+    e2e_path.write_text(json.dumps({
+        "verified_commit": head,
+        "staging_verdict": "VERIFIED: gemischte Findings",
+        "findings": mixed_findings,
+        "verified_at": datetime.now(timezone.utc).isoformat(),
+        "scope": "backend",
+        "environment": "staging",
+    }))
+
+    workflow_name = "fix-1689-ac5-mixed-findings"
+    report_path = root / "docs" / "artifacts" / workflow_name / "prod-selftest.md"
+
+    rc = mod.run_selftest(e2e_path, workflow_name, scope="backend", explicit_path=True)
+
+    assert rc == 0, f"Erwartet Exit 0 (einziges gueltiges Finding PASS), bekam {rc}"
+    assert report_path.exists(), "Bericht wurde nicht geschrieben"
+    content = report_path.read_text()
+    assert "unverwertbar" in content.lower(), (
+        f"Bericht muss einen sichtbaren Abschnitt fuer unverwertbare Findings enthalten:\n{content}"
+    )
+    assert "AC-1" in content, f"Gueltiges Finding fehlt im Bericht:\n{content}"
+
+
+def test_prod_selftest_survives_non_list_findings_field(tmp_path, monkeypatch):
+    """AC-6: das findings-Feld selbst ist gar keine Liste (ein JSON-Objekt)
+    -> kein Absturz, das gesamte Feld wird als unverwertbar behandelt und im
+    Bericht entsprechend ausgewiesen."""
+    mod = _load_prod_selftest_module()
+    root = tmp_path / "repo"
+    head = _init_evidence_free_repo(root)
+    monkeypatch.setattr(mod, "REPO_DIR", root)
+    recorder = _HealthOkRecorder(mod)
+    monkeypatch.setattr(mod, "_http_get", recorder)
+
+    e2e_path = tmp_path / "e2e_verified.json"
+    e2e_path.write_text(json.dumps({
+        "verified_commit": head,
+        "staging_verdict": "VERIFIED: findings ist ein Objekt statt einer Liste",
+        "findings": {"issue": "#1653", "commit": "deadbeef"},
+        "verified_at": datetime.now(timezone.utc).isoformat(),
+        "scope": "backend",
+        "environment": "staging",
+    }))
+
+    workflow_name = "fix-1689-ac6-findings-not-a-list"
+    report_path = root / "docs" / "artifacts" / workflow_name / "prod-selftest.md"
+
+    mod.run_selftest(e2e_path, workflow_name, scope="backend", explicit_path=True)
+
+    assert report_path.exists(), "Bericht wurde trotz Nicht-Listen-findings nicht geschrieben"
+    content = report_path.read_text()
+    assert "unverwertbar" in content.lower(), (
+        f"Ein findings-Feld ohne Listentyp muss vollstaendig als unverwertbar "
+        f"ausgewiesen werden:\n{content}"
+    )
+
+
+def test_prod_selftest_all_unusable_findings_is_not_pass(tmp_path, monkeypatch):
+    """AC-7 (Kern): das findings-Array besteht AUSSCHLIESSLICH aus
+    unverwertbaren Nicht-Dict-Eintraegen (die reale Fehlform). Die Assertion
+    laeuft ueber den VOLLSTAENDIGEN Lauf von run_selftest() bis
+    _derive_verdict -- nicht ueber einen kuenstlich vorgezogenen Kurzschluss
+    -- und prueft das ENDGUELTIGE, tatsaechlich zurueckgegebene Ergebnis
+    (Verdict-String + Exit-Code), nicht einen internen Zwischenwert. Ohne die
+    neue 'alles unverwertbar => nicht PASS'-Regel wuerde eine nach
+    Partitionierung leere Probe-Liste ueber _derive_verdict([]) faelschlich
+    PASS liefern (prod_selftest.py:553-556)."""
+    mod = _load_prod_selftest_module()
+    root = tmp_path / "repo"
+    head = _init_evidence_free_repo(root)
+    monkeypatch.setattr(mod, "REPO_DIR", root)
+    recorder = _HealthOkRecorder(mod)
+    monkeypatch.setattr(mod, "_http_get", recorder)
+
+    e2e_path = tmp_path / "e2e_verified.json"
+    e2e_path.write_text(json.dumps({
+        "verified_commit": head,
+        "staging_verdict": "VERIFIED: reale Fehlform #1653/#1677",
+        "findings": list(REAL_FEHLFORM),
+        "verified_at": datetime.now(timezone.utc).isoformat(),
+        "scope": "backend",
+        "environment": "staging",
+    }))
+
+    workflow_name = "fix-1689-ac7-all-unusable-not-pass"
+    report_path = root / "docs" / "artifacts" / workflow_name / "prod-selftest.md"
+
+    rc = mod.run_selftest(e2e_path, workflow_name, scope="backend", explicit_path=True)
+
+    assert rc != 0, (
+        f"Ausschliesslich unverwertbare Findings duerfen NIE als Erfolg (Exit 0) "
+        f"gewertet werden (kein stiller Erfolg fuer einen unbrauchbaren Nachweis), "
+        f"bekam Exit {rc}"
+    )
+    assert report_path.exists(), "Bericht fehlt trotz vollstaendig unverwertbarer Findings"
+    content = report_path.read_text()
+    match = re.search(r"\*\*Verdict:\s*([A-Za-z_]+)\*\*", content)
+    assert match, f"Verdict-Zeile fehlt im Bericht:\n{content}"
+    verdict_str = match.group(1)
+    assert verdict_str not in ("PASS", "SKIPPED_ALL", "SKIPPED_AUTH_REDIRECT", "SKIPPED_AUTH"), (
+        f"Verdict darf bei ausschliesslich unverwertbaren Findings kein Erfolgs-Status sein "
+        f"(Kurzschluss ueber _derive_verdict([]) waere PASS gewesen), war: {verdict_str}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-10: prod_selftest.py — Top-Level-Guard im Exakt-Match-Zweig
+# ---------------------------------------------------------------------------
+
+def test_prod_selftest_falls_back_to_ancestor_on_non_dict_exact_match(tmp_path, monkeypatch):
+    """AC-10: die exakt zum HEAD passende Attestation-Datei hat ein valides,
+    aber NICHT-Dict Top-Level-JSON -> dies wird wie 'kein exakter Treffer'
+    behandelt, sodass die bestehende Ancestor-Suche
+    (_e2e_paths._nearest_verified_ancestor) greift statt mit AttributeError
+    abzustuerzen. Die Ancestor-Suche selbst (unveraendert) zaehlt den
+    Ziel-Commit als ERSTEN Kandidaten mit -- trifft sie dort bereits auf eine
+    (wenn auch kaputte) Attestation, bricht sie fail-closed ab (Fix #1382
+    Scheibe 2, _e2e_paths.py:344, wird von dieser Spec NICHT angefasst). Das
+    erwartbare Ergebnis ist deshalb KEIN AttributeError und eine definierte
+    FAIL-Meldung ('kein Nachweis') -- nicht PASS ueber einen gueltigen
+    Vorgaenger, der wegen genau dieser Vorrangregel nie erreicht wird."""
+    mod = _load_prod_selftest_module()
+    root = tmp_path / "repo"
+    parent_sha = _init_evidence_free_repo(root)
+    monkeypatch.setattr(mod, "REPO_DIR", root)
+    recorder = _HealthOkRecorder(mod)
+    monkeypatch.setattr(mod, "_http_get", recorder)
+
+    att_dir = root / ".claude" / "e2e_verified"
+    att_dir.mkdir(parents=True, exist_ok=True)
+    (att_dir / f"{parent_sha}.json").write_text(json.dumps({
+        "verified_commit": parent_sha,
+        "staging_verdict": "VERIFIED: gueltiger Vorgaenger",
+        "findings": [],
+        "verified_at": datetime.now(timezone.utc).isoformat(),
+        "scope": "backend",
+        "environment": "staging",
+    }))
+
+    head_sha = _add_commit(root, "src/b.py", "b = 2\n", "head mit kaputter Exakt-Attestation")
+    (att_dir / f"{head_sha}.json").write_text(json.dumps(["kaputt", "kein", "dict"]))
+
+    workflow_name = "fix-1689-ac10-non-dict-exact-match"
+    report_path = root / "docs" / "artifacts" / workflow_name / "prod-selftest.md"
+    e2e_path = mod._commit_e2e_path()
+
+    rc = mod.run_selftest(e2e_path, workflow_name, scope="backend", explicit_path=False)
+
+    assert rc == 1, (
+        f"Kaputte Exakt-Attestation muss kontrolliert blocken (Ancestor-Suche greift, "
+        f"scheitert aber an ihrer eigenen Vorrangregel fuer den ersten -- kaputten -- "
+        f"gefundenen Kandidaten) statt abzustuerzen oder still PASS zu liefern. "
+        f"Bekam Exit {rc}."
+    )
+    assert report_path.exists(), "Bericht fehlt trotz kontrolliertem FAIL"
+    content = report_path.read_text()
+    assert any(kw in content.lower() for kw in ["kein nachweis", "keine attestation"]), (
+        f"Bericht muss erklaeren, dass kein (nutzbarer) Nachweis vorlag:\n{content}"
+    )


### PR DESCRIPTION
Behebt #1689 (Issue wird erst nach bestandenem Post-Deploy-Selftest geschlossen, deshalb kein Auto-Close-Schluesselwort).

## Problem

Der Pflicht-Post-Deploy-Selftest stuerzte mit `AttributeError` ab, wenn das `findings`-Array einer Attestation Nicht-Dict-Eintraege enthielt — und `staging_gate.py` liess genau solche Eintraege still hinein: uebergab der Pruef-Agent an `--findings-json` ein JSON-**Objekt** statt einer **Liste**, iterierte die Schleife ueber dessen Schluessel und schrieb die Bare-Strings ins Artefakt. Exit 0, keine Meldung. Zweimal am 2026-08-10 aufgetreten (#1653, #1677).

Im Repo lag ein **realer** Fall: `.claude/e2e_verified/1001273d…json` mit `["issue","commit","steps","cleanup","skipped","notes"]` — passierte jede bestehende Pruefung.

## Loesung

**Ein gemeinsamer Typkontrakt** statt des siebten Einzelflickens: `partition_findings()` in `_e2e_paths.py`, das beide Hooks ohnehin per importlib laden. Dieselbe Fehlerklasse wurde bisher fuenfmal einzeln nachgeruestet (#916, #1084, #1130, #1382, #1327), waehrend `prod_selftest.py` gar keinen solchen Guard hatte.

**Schreibseite hart, Leseseite weich:**
- `staging_gate.py` bricht bei falscher Form mit Exit != 0 ab und schreibt **kein** Artefakt — der Pruef-Agent steht noch am Werkzeug und kann korrigieren.
- `prod_selftest.py` sortiert unverwertbare Eintraege **vor** dem `pool.map` aus und weist sie im Bericht aus, statt abzustuerzen.

**Kein Falsch-Gruen:** Bleibt nach dem Aussortieren kein verwertbarer Eintrag uebrig, ist das Ergebnis ausdruecklich nicht PASS (Exit != 0). Ohne diese Regel waere aus dem lauten Absturz ein leises „bestanden" geworden, weil `_derive_verdict([])` von sich aus PASS liefert.

**Derselbe Kontrakt eine Ebene hoeher:** Drei Stellen riefen `.get()` auf frisch geladenem JSON auf, ohne den Dict-Typ zu pruefen. Eine davon (`gate_check`, Exakt-Match) laeuft im echten Prod-Deploy und blockt jetzt fail-closed statt mit unbehandeltem Traceback.

**Selbstheilung:** Der Merge verwirft Nicht-Dict-Altlasten und meldet die Anzahl — jedes regulaere Folgeschreiben bereinigt ein verschmutztes Artefakt, ohne Hand-Edit an der Gate-Datei.

## Nachweis

- 11 neue Tests (AC-1..AC-10), Fixture in der **real gefundenen** Fehlform
- Adversary **VERIFIED**: alle 7 Mutationen von jeweils einem Test gefangen
- Ein Befund behoben: der AC-2-Test war nur zufaellig gruen, weil `dict` auch im Traceback steht — er prueft jetzt zusaetzlich auf die echte Meldung und die Abwesenheit eines Tracebacks
- Regression: **292 Tests** ueber alle 42 Dateien, die die drei Hooks beruehren — gruen

Spec: `docs/specs/modules/fix_1689_attestation_findings_typkontrakt.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)