### PR TITLE
feat(#1701): Premium-SMS im Alarm- und Vergleichspfad (#1676 S2b)

### DIFF
--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -752,51 +752,56 @@ type OfficialWarningsConfig struct {
 }
 
 // AlertChannelsConfig — Issue #1258 Scheibe S3, additives Trip-Kanal-Set fuer
-// die Alert-Zustellung. All-or-nothing: Client sendet immer alle drei Felder.
+// die Alert-Zustellung. Seit Issue #1701 (S2b, D3) VIER Felder, alle *bool
+// mit Feld-Level-Merge (die fruehere All-or-nothing-Praemisse ist abgeloest —
+// ein PUT ohne ein Feld laesst dessen Bestandswert unangetastet).
 type AlertChannelsConfig struct {
-    Email    bool `json:"email"`
-    Telegram bool `json:"telegram"`
-    Sms      bool `json:"sms"`
+    Email      *bool `json:"email,omitempty"`
+    Telegram   *bool `json:"telegram,omitempty"`
+    Sms        *bool `json:"sms,omitempty"`
+    PremiumSms *bool `json:"premium_sms,omitempty"` // Issue #1701 S2b
 }
 
 // AlertChannelThresholdsConfig — Issue #1461 S3b-2a, additives Geschwister-
 // feld zu AlertChannelsConfig (NICHT darin). Je Kanal die Dringlichkeits-
 // Schwelle als String-Pointer, damit "Kanal fehlt im Body" (Feld-Level-Merge
 // bewahrt den Bestandswert) von "Kanal explizit gesetzt" unterscheidbar bleibt.
+// PremiumSms (Issue #1701 S2b, D6) ist das vierte Geschwisterfeld.
 type AlertChannelThresholdsConfig struct {
-    Email    *string `json:"email,omitempty"`    // "LOW"|"MODERATE"|"HIGH"
-    Telegram *string `json:"telegram,omitempty"`
-    Sms      *string `json:"sms,omitempty"`
+    Email      *string `json:"email,omitempty"`    // "LOW"|"MODERATE"|"HIGH"
+    Telegram   *string `json:"telegram,omitempty"`
+    Sms        *string `json:"sms,omitempty"`
+    PremiumSms *string `json:"premium_sms,omitempty"`
 }
 ```
 
-### alert_channels (Issue #1258)
+### alert_channels (Issue #1258, seit #1701 S2b vier Kanäle)
 
 Trip-weites Kanal-Set für den Alert-Versand (Abweichungs-Alerts und amtliche Sofort-Alerts), Pointer-Feld analog `official_warnings`:
 
 ```json
-{"alert_channels": {"email": true, "telegram": false, "sms": false}}
+{"alert_channels": {"email": true, "telegram": false, "sms": false, "premium_sms": true}}
 ```
 
 | Feld | Typ | Semantik |
 |------|-----|----------|
-| `alert_channels` | Objekt \| `null`/nicht gesetzt | **`null`/fehlend (Legacy-Verhalten):** Alert-Kanäle erben die aktiven Briefing-Kanäle aus `report_config` (`send_email`/`send_telegram`/`send_sms`) — kein Verhaltenswechsel für Bestand. **Gesetzt:** ersetzt beim Alert-Versand den geerbten Briefing-Anteil (all-or-nothing, alle drei Felder explizit) |
-| `alert_channels.email`/`.telegram`/`.sms` | bool | einzelne Kanal-Flags |
+| `alert_channels` | Objekt \| `null`/nicht gesetzt | **`null`/fehlend (Legacy-Verhalten):** Alert-Kanäle erben die aktiven Briefing-Kanäle aus `report_config` (`send_email`/`send_telegram`/`send_sms`/`send_premium_sms`) — kein Verhaltenswechsel für Bestand. **Gesetzt:** ersetzt beim Alert-Versand den geerbten Briefing-Anteil, seit #1701 (D3) mit **Feld-Level-Merge**: ein PUT, das ein Feld nicht mitschickt (z. B. ein älterer Frontend-Build ohne `premium_sms`), lässt dessen Bestandswert unverändert statt ihn auf `false` zurückzusetzen |
+| `alert_channels.email`/`.telegram`/`.sms`/`.premium_sms` | bool | einzelne Kanal-Flags; `premium_sms` gated zusätzlich über `premium_sms_allowed()` (Tier-Gate, NICHT `sms_allowed()`) |
 
-Präzedenz unverändert: per-Regel-`channels`-Overrides (Issue #638, s. „Versand-Logik (Kanal pro Alert)" oben) gewinnen weiterhin über den geerbten/gesetzten Trip-Anteil; das SMS-Tier-Gate bleibt in jedem Fall aktiv. Quelle: `internal/model/trip.go` (`AlertChannelsConfig`), Spec `docs/specs/_archive/modules/issue_1258_alarme_tab_official_warnings.md` Abschnitt 9.
+Präzedenz unverändert: per-Regel-`channels`-Overrides (Issue #638, s. „Versand-Logik (Kanal pro Alert)" oben) gewinnen weiterhin über den geerbten/gesetzten Trip-Anteil; das SMS-/Premium-SMS-Tier-Gate bleibt in jedem Fall aktiv. Quelle: `internal/model/trip.go` (`AlertChannelsConfig`), Spec `docs/specs/_archive/modules/issue_1258_alarme_tab_official_warnings.md` Abschnitt 9, Spec `docs/specs/modules/feat_1701_alarm_premium_sms.md` (vierter Kanal, D3).
 
-### alert_channel_thresholds (Issue #1461 S3b-2a Trip · S3b-2b Ortsvergleich)
+### alert_channel_thresholds (Issue #1461 S3b-2a Trip · S3b-2b Ortsvergleich · #1701 S2b vierter Kanal)
 
-Additives Geschwisterfeld zu `alert_channels`/`send_telegram`+`send_sms` (bewusst **nicht** darin — der Kanal-Schalter wird beim Speichern als Ganzes ersetzt, all-or-nothing; ein Client ohne Kenntnis der Schwelle würde sie sonst still löschen): je Alarm-Kanal die Dringlichkeitsstufe, ab der eine ausgelöste Alarm-Meldung diesen Kanal erreichen darf. Identischer Vertrag auf `Trip` **und** `ComparePreset` — derselbe Go-Typ (`AlertChannelThresholdsConfig`), kein zweiter.
+Additives Geschwisterfeld zu `alert_channels`/`send_telegram`+`send_sms`+`send_premium_sms`: je Alarm-Kanal die Dringlichkeitsstufe, ab der eine ausgelöste Alarm-Meldung diesen Kanal erreichen darf. Identischer Vertrag auf `Trip` **und** `ComparePreset` — derselbe Go-Typ (`AlertChannelThresholdsConfig`), kein zweiter.
 
 ```json
-{"alert_channel_thresholds": {"email": "LOW", "telegram": "HIGH", "sms": "MODERATE"}}
+{"alert_channel_thresholds": {"email": "LOW", "telegram": "HIGH", "sms": "MODERATE", "premium_sms": "HIGH"}}
 ```
 
 | Feld | Typ | Semantik |
 |------|-----|----------|
 | `alert_channel_thresholds` | Objekt \| `null`/nicht gesetzt | **`null`/fehlend:** kein Kanal hat eine Schwelle gesetzt — Startwert `"LOW"` je Kanal (Python-Vorgabewert, nicht persistiert). **Gesetzt:** je Kanal maßgeblich für den Versand-Filter |
-| `alert_channel_thresholds.email`/`.telegram`/`.sms` | `"LOW"`\|`"MODERATE"`\|`"HIGH"` \| fehlend | fehlender Kanal-Key im PUT-Body → **Feld-Level-Merge** bewahrt den Bestandswert (AC-7 Trip / AC-10 Compare); ein GANZ fehlendes `alert_channel_thresholds` im Body bewahrt das ganze Unterobjekt (Top-Level-`nil`-Erbe, AC-6 Trip / AC-9 Compare) |
+| `alert_channel_thresholds.email`/`.telegram`/`.sms`/`.premium_sms` | `"LOW"`\|`"MODERATE"`\|`"HIGH"` \| fehlend | fehlender Kanal-Key im PUT-Body → **Feld-Level-Merge** bewahrt den Bestandswert (AC-7 Trip / AC-10 Compare); ein GANZ fehlendes `alert_channel_thresholds` im Body bewahrt das ganze Unterobjekt (Top-Level-`nil`-Erbe, AC-6 Trip / AC-9 Compare) |
 
 Wirkung: eine ausgelöste Meldung erreicht einen eingeschalteten Kanal nur, wenn ihre Dringlichkeit (`services.alert_urgency`, `LOW`/`MODERATE`/`HIGH`) die dort eingestellte Schwelle erreicht oder übertrifft (`services.alert_channel_threshold.split_by_threshold()`). Das an das Alarm-Protokoll übergebene Kanal-Set bleibt dabei das **rohe**, unveränderte Opt-in — nur der tatsächliche Versand wird gefiltert (ADR-0046). Vollständig unterdrückte Meldungen erscheinen im nächsten Briefing als nicht zugestellt (Grund `below_channel_threshold`, S3b-1-Sichtbarkeit).
 
@@ -1848,6 +1853,7 @@ type ComparePreset struct {
     AlertQuietTo         *string                `json:"alert_quiet_to,omitempty"`              // Issue #1170
     SendTelegram         *bool                  `json:"send_telegram,omitempty"`               // Issue #1216 Slice 2b: Alarm-Kanal-Opt-in (Default falsy = E-Mail-only)
     SendSms              *bool                  `json:"send_sms,omitempty"`                    // Issue #1216 Slice 2b
+    SendPremiumSms       *bool                  `json:"send_premium_sms,omitempty"`            // Issue #1701 S2b (D8): eigenes Feld statt alert_channels-Sub-Objekt (Ortsvergleich hat keins)
     Kind                 string                 `json:"kind,omitempty"`                        // ADR-0023-Diskriminator ("vergleich"); nur Migration schreibt ihn
     CreatedAt            time.Time              `json:"created_at"`
 }
@@ -3416,6 +3422,19 @@ function corridorInside(value, min, max) {
 
 ## Changelog
 
+- 2026-08-11: Issue #1701 Scheibe S2b — Premium-SMS wird vierter Kanal im
+  Alarm- UND Ortsvergleich-Pfad (Vorgänger: S2a #1676, ausschließlich
+  Trip-Briefing). `AlertChannelsConfig` bekommt `PremiumSms *bool` — dabei
+  entfällt die frühere „All-or-nothing"-Prämisse: alle vier Felder (Email/
+  Telegram/Sms/PremiumSms) sind jetzt `*bool` mit **Feld-Level-Merge**
+  (Vorbild `AlertChannelThresholdsConfig`), ein PUT ohne ein Feld lässt
+  dessen Bestandswert unangetastet statt ihn auf `false` zurückzusetzen.
+  `AlertChannelThresholdsConfig` bekommt `PremiumSms *string` als viertes
+  Geschwisterfeld (ADR-0046-Pflicht). `ComparePreset.SendPremiumSms *bool`
+  neu (eigenes Feld, kein `alert_channels`-Sub-Objekt im Ortsvergleich).
+  Tier-Gate `premium_sms_allowed()` (NICHT `sms_allowed()`) an allen drei
+  Alarmpfaden (Änderung/Radar/amtlich) und beiden Kontexten (Trip/Compare).
+  Siehe `docs/specs/modules/feat_1701_alarm_premium_sms.md`.
 - 2026-08-10: Issue #1676 Scheibe S2a (ADR-0049) — `TripReportConfig.send_premium_sms`
   (bool, default `false`) macht Premium-SMS (Garmin inReach) zum vierten, eigenständigen
   Versandkanal `premium_sms` — **ausschließlich fürs Trip-Briefing**. Fester Absender

--- a/docs/specs/modules/feat_1701_alarm_premium_sms.md
+++ b/docs/specs/modules/feat_1701_alarm_premium_sms.md
@@ -75,7 +75,7 @@ der drei Alarmpfade den Kanal heute strukturell nicht kennt.
     SMS-Zweig (`:1405-1411`), `_log_error()` (`:1299-1305`) Label-Dict gehärtet.
   - `send_official_alert()` (`:794-899`): vierter Kanal-Zweig nach dem SMS-Zweig
     (`:881-894`).
-  - `send_compare_official_alert()` (`:995-1081`) + neue Hilfsfunktion
+  - `send_multi_location_official_alert()` (`:995-1081`) + neue Hilfsfunktion
     `_dispatch_compare_official_premium_sms()` (Vorbild `_dispatch_compare_official_sms`,
     `:1140-1157`).
   - Alle sechs `alert_log.append_entry(...)`-Aufrufstellen (s.u.) reichen zusätzlich
@@ -114,7 +114,7 @@ der drei Alarmpfade den Kanal heute strukturell nicht kennt.
   indexbasierte Ratsche für `send_official_alert` (`:1547-1554`, `:1792`) und
   `_dispatch_alert_message` (`:1579-1586`, `:1794`) wird von **3** auf **4** angehoben
   (D7), plus ein Nachzug-Eintrag für die neue Fundstelle
-  `send_compare_official_alert::3` (falls der Scanner sie dort listet — am Bestand
+  `send_multi_location_official_alert::3` (falls der Scanner sie dort listet — am Bestand
   nachzumessen, s. „Known Limitations").
 - **File:** `docs/specs/modules/waechter_1405_erfolg_wirkung.md` (MODIFY, Doku) —
   Pflicht-Nachzug der neuen Ratschen-Zahlen (dort wörtlich verlangt).
@@ -259,7 +259,7 @@ Optional[dict[str, str]] = None` (Kanal → `reason_code`, z.B.
 `premium_sms_no_reply_address`). `_channels_not_sent()` prüft ihn VOR den bisherigen drei
 Fällen: hat ein nicht zugestellter Kanal einen Eintrag in `blocked_reason_codes`, wird dessen
 Wert als Grund übernommen statt `REASON_DELIVERY_FAILED`. Alle drei Alarm-Dispatcher
-(`_dispatch_alert_message`, `send_official_alert`, `send_compare_official_alert`) füllen
+(`_dispatch_alert_message`, `send_official_alert`, `send_multi_location_official_alert`) füllen
 `NotificationResult.blocked_reason_codes` für Premium-SMS über `_record_block_reason_code()`
 (bereits aus S2a vorhanden, unverändert wiederverwendet) — für die drei Bestandskanäle bleibt
 das Feld leer, ihr Verhalten ändert sich nicht.
@@ -288,7 +288,7 @@ zerstören. Richtiger Zug: die erwartete Zahl in `test_success_status_guard.py` 
 anheben, mit Pflicht-Nachzug in `docs/specs/modules/waechter_1405_erfolg_wirkung.md`
 (dort steht wörtlich, Ratschen-Zahlen würden „IN DER SPEC beschlossen und dort nachgezogen").
 
-**Offen für die Implementierung:** ob `send_compare_official_alert()` (die neue
+**Offen für die Implementierung:** ob `send_multi_location_official_alert()` (die neue
 `_dispatch_compare_official_premium_sms`-Erweiterung) vom selben Scanner überhaupt als
 Fundstelle erkannt wird — die Funktion `sent_channels.append("email")` UNBEDINGT vor dem
 `if not self._dispatch_compare_official_email(...)`-Aufruf ist strukturell dieselbe Klasse,
@@ -332,7 +332,7 @@ Nachbarfelder (`handler/compare_preset.go:407-411`).
   - Test: `tests/unit/test_alert_channel_premium_sms.py::test_official_trip_alert_reaches_premium_sms`
 
 - **AC-4:** Given ein Ortsvergleich-Preset hat `send_premium_sms=true` (Nutzer ist Premium-Tier) / When ein Änderungs-, Regenradar- oder amtlicher Alarm für einen betroffenen Vergleichsort ausgelöst wird / Then wird der Ort in allen drei Fällen zusätzlich per Premium-SMS gemeldet — nicht nur bei E-Mail/Telegram/SMS, wie es heute für alle drei Ortsvergleichs-Alarmpfade gilt.
-  - Prüfort: HTTP-Stub gegen `compare_alert.py`, `compare_radar_alert.py`, `compare_official_alert.py` (bzw. `send_compare_official_alert()` direkt), je ein Fall pro Alarmart.
+  - Prüfort: HTTP-Stub gegen `compare_alert.py`, `compare_radar_alert.py`, `compare_official_alert.py` (bzw. `send_multi_location_official_alert()` direkt), je ein Fall pro Alarmart.
   - Test: `tests/unit/test_compare_alert_premium_sms.py::test_compare_deviation_alert_reaches_premium_sms`, `::test_compare_radar_alert_reaches_premium_sms`, `::test_compare_official_alert_reaches_premium_sms`
 
 - **AC-5:** Given ein Nutzer mit Tier `standard` hat (fälschlich oder testweise) `alert_channels.premium_sms=true` bzw. `send_premium_sms=true` im Ortsvergleich gesetzt / When ein Alarm für Trip oder Ortsvergleich ausgelöst wird / Then bleibt der Premium-SMS-Kanal in allen drei Alarmpfaden inaktiv — dasselbe strenge Tier-Gate (`premium_sms_allowed`) wie im Trip-Briefing, nicht das schwächere `sms_allowed`, das `standard` durchlässt.
@@ -363,7 +363,7 @@ Nachbarfelder (`handler/compare_preset.go:407-411`).
 
 - Die drei bestehenden Kanäle (E-Mail, Telegram, SMS) verhalten sich in allen drei
   Alarm-Dispatchern (`_dispatch_alert_message`, `send_official_alert`,
-  `send_compare_official_alert`) byte-identisch zu vorher — keine der bestehenden
+  `send_multi_location_official_alert`) byte-identisch zu vorher — keine der bestehenden
   Testsuiten für diese Kanäle darf sich ändern müssen.
 - `alert_log.append_entry()` bleibt für alle Bestandsaufrufe ohne `blocked_reason_codes`
   (Default `None`) exakt beim heutigen Verhalten: generischer `delivery_failed`.
@@ -414,9 +414,53 @@ Implementierung zu messen, nicht anzunehmen.
 | AC-9 | `_channels_not_sent()`: `blocked_reason_codes`-Vorrang entfernt | `test_blocked_premium_sms_reason_is_specific_not_generic` |
 | AC-10 | Ratschen-Zahl nicht angehoben (bleibt 3) ODER Buchung hinter `try` verschoben | `test_success_status_guard.py`-Ratschentests selbst (rot bzw. — bei verschobener Buchung — eine der Alarm-Tests, die `sent_channels` vs. `reachable_channels` unterscheiden) |
 
+## Nachtrag 2026-08-11 (RED-Phase): die ACHTE Stelle — der Radar-Bereitschafts-Guard
+
+**Gefunden vom Developer in der RED-Phase, vom Orchestrierer am Bestand nachgemessen.**
+Diese Spec kannte sieben Ansatzstellen. Es sind acht.
+
+`src/services/trip_alert.py:1043-1049` (`check_radar_alerts`) bricht den Radar-Alarm ab,
+**bevor** irgendein Kanal-Set aufgelöst wird:
+
+```python
+can_email = self._settings.can_send_email()
+can_telegram = self._settings.can_send_telegram()
+can_sms = self._settings.can_send_sms()
+if not can_email and not can_telegram and not can_sms:
+    continue   # "No channel configured; skipping radar alert"
+```
+
+**Warum das genau den PO-Fall trifft:** `can_send_sms()` verlangt `sms_gateway_url` UND
+`seven_api_key` UND **`sms_to`** (`src/app/config.py:407-413`). Premium-SMS hat aber
+konstruktionsbedingt **keine feste Empfängernummer** — die Rückadresse wird gelernt
+(ADR-0049, [[reference_garmin_inreach_hat_keine_feste_nummer]]). Ein Nutzer, der auf der
+Hütte **nur** Satellit hat und deshalb ausschließlich Premium-SMS konfiguriert, hat kein
+`sms_to` ⇒ `can_send_sms()` ist `False` ⇒ **der Radar-Alarm wird verworfen, obwohl ein
+funktionsfähiger Kanal konfiguriert ist.** Alle übrigen sieben Stellen wären dann korrekt
+umgesetzt und der Alarm käme trotzdem nie an.
+
+**Das ist kein Nebenbefund für #1199.** Ohne diese Stelle ist das freigegebene **AC-1**
+(„Abweichungs- **oder Regenradar**-Alarm geht an das Gerät") für die reale Konfiguration
+nicht erfüllt. Es wird in dieser Scheibe mitgelöst — die ACs ändern sich dadurch nicht.
+
+**Richtung für die Umsetzung:** Den Guard NICHT um eine vierte
+`can_send_*()`-Bereitschaftsfrage erweitern — ein `can_send_premium_sms()` wurde in S2a
+bewusst entfernt (Adversary-Fund F003) und darf nicht zurückkehren. Stattdessen den Guard
+gegen das **bereits daneben liegende effektive Kanal-Set** führen
+(`_radar_effective_channels(trip)` leer ⇒ Abbruch). Das ist die Quelle, die ohnehin
+maßgeblich ist, und beseitigt die Doppelung, statt sie zu vergrößern.
+
+**🔴 Prüfort = Wirkort, Pflicht für den Nachweis:** Die RED-Tests der Radar-ACs setzen
+derzeit `sms_gateway_url`/`sms_to` mit, damit `can_send_sms()` zufällig `True` wird — sie
+laufen also **am Guard vorbei** und würden diesen Defekt nicht bemerken. Es braucht
+mindestens einen Test mit einem Trip, der **ausschließlich** Premium-SMS konfiguriert hat
+(keine SMS-, keine Telegram-, keine E-Mail-Konfiguration), der beweist, dass der
+Radar-Alarm trotzdem hinausgeht. Ohne diesen Test ist AC-1 formal grün und praktisch
+wirkungslos — dieselbe Falle, die in diesem Projekt bereits dreimal zugeschlagen hat.
+
 ## Known Limitations
 
-- **Ratschen-Reichweite für `send_compare_official_alert` ungeklärt (D7).** Ob der
+- **Ratschen-Reichweite für `send_multi_location_official_alert` ungeklärt (D7).** Ob der
   Scanner diese Funktion als eigene B14a-artige Fundstelle listet, ist vor der
   Implementierung zu messen (aktuell nur `send_compare_preset` als B12 gelistet, ein
   strukturell anderes Muster). Fällt sie darunter, braucht auch sie eine

--- a/docs/specs/modules/feat_1701_alarm_premium_sms.md
+++ b/docs/specs/modules/feat_1701_alarm_premium_sms.md
@@ -1,0 +1,467 @@
+---
+entity_id: feat_1701_alarm_premium_sms
+type: module
+created: 2026-08-11
+updated: 2026-08-11
+status: draft
+version: "1.0"
+tags: [sms, premium, garmin, alarm, ortsvergleich, kanal-schwelle, alert-log]
+---
+
+<!-- Issue #1701 (Scheibe S2b von #1676) -- Premium-SMS wird vierter Kanal im
+     Alarm- UND Ortsvergleich-Pfad. Vorgaenger: S2a (Trip-Briefing, gemergt,
+     ADR-0049). Nachfolger: S2c (#1702, Kostenstelle), S3 (Oberflaeche). -->
+
+# Premium-SMS als vierter Alarm-/Vergleichs-Kanal — S2b
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Premium-SMS (Garmin inReach) ist seit S2a ein vollwertiger vierter Versandkanal — aber
+ausschließlich für das planmäßige Trip-Briefing. Diese Scheibe zieht ihn durch den
+**Alarm-Pfad** (Trip-Änderungs-/Regenradar-Alarme, amtliche Trip-Warnungen) und den
+**Ortsvergleich-Pfad** (dieselben drei Alarmarten für gespeicherte Vergleichs-Orte) nach —
+inklusive der zugehörigen Kanal-Schwelle (ADR-0046) und der maschinenlesbaren Sperrgrund-
+Buchung im Alarm-Protokoll. Ohne diese Scheibe erreicht ein Nutzer, der auf einer Hütte
+ausschließlich per Satellit erreichbar ist (Karnischer Höhenweg, PO-Fall ab 20.08.), zwar
+weiterhin sein Briefing per Premium-SMS — aber **keinen einzigen Gewitteralarm**, weil jeder
+der drei Alarmpfade den Kanal heute strukturell nicht kennt.
+
+## Abgrenzung (nicht in dieser Scheibe)
+
+- **S2a — Trip-Briefing (#1676, gemergt):** liefert den Kanal selbst
+  (`PremiumSmsOutput`, Tier-Gate, Fail-Closed, ADR-0049) und die geteilte Infrastruktur
+  (`NotificationResult.blocked_channels`/`blocked_reason_codes`, `_record_block_reason_code`),
+  auf der diese Scheibe additiv aufbaut. Nicht neu zu bauen.
+- **S2c — Kostenstelle (#1702):** Kosten-/Kontingent-/Versandzähler je Kanal existieren im
+  Bestand nirgends (nur das Tier-Tageslimit für Alarme, `user_tier.py:17-31`). Eigenes
+  Feature ohne Vorbild, nicht Teil dieser Scheibe.
+- **S3 — Oberfläche:** die Kanal-Auswahl `alert_channels.premium_sms` bzw.
+  `send_premium_sms` im Ortsvergleich-Preset wird in dieser Scheibe ausschließlich über die
+  API setzbar (Go-Feld, Merge, Persistenz) — noch kein UI-Kontrollelement. Auch die
+  Premium-SMS-Kanal-Schwelle bleibt ohne Bedienelement.
+- **#1533 — Generalprobe auf dem Gerät:** dass ein Alarm tatsächlich am Garmin-Gerät
+  ankommt, ist mit den Mitteln dieser Scheibe strukturell nicht beweisbar (gleiche
+  Sandbox-Einschränkung wie in S2a, siehe „Nachweisgrenzen").
+
+## Source
+
+> **Schicht-Hinweis:** Python-Core (`src/services/`) für den Versand-/Protokoll-Teil,
+> Go-API (`internal/model/`, `internal/handler/`) für Persistenz/Merge des vierten Kanal-Flags.
+
+- **File:** `src/services/alert_log.py` (MODIFY, ~15 LoC) — `_ALL_CHANNELS` (`:59`) um
+  `"premium_sms"` erweitert; `append_entry()` (`:130-221`) und `_channels_not_sent()`
+  (`:113-132`) bekommen einen neuen optionalen Parameter `blocked_reason_codes`, der für
+  einen Kanal mit Eintrag den generischen `REASON_DELIVERY_FAILED` durch die spezifische
+  Kennung ersetzt (D5).
+- **File:** `src/services/trip_alert.py` (MODIFY, ~20 LoC) —
+  `_effective_alert_channels()` (`:1461-1513`), zwei Stellen: die scharfe
+  `alert_channels`-Ableitung (`:1492-1494`, Tupel `("email","telegram","sms")` → `+ "premium_sms"`)
+  und `_briefing_channels()` (`:1515-1527`, neuer `if getattr(config, "send_premium_sms", False)`-Zweig).
+  `_radar_effective_channels()` (`:825-846`) bekommt denselben vierten Zweig, gegated über
+  `premium_sms_allowed(self._user_id)` (NICHT `sms_allowed`, D2). Import
+  `from services.user_tier import sms_allowed, premium_sms_allowed` (`:33`).
+- **File:** `src/services/compare_alert_channels.py` (MODIFY, ~6 LoC) —
+  `effective_compare_channels()` (`:28-36`) bekommt einen vierten Zweig
+  `if preset.get("send_premium_sms") and premium_sms_allowed(user_id): channels.add("premium_sms")`
+  — bewusst OHNE `settings.can_send_premium_sms()` (D2: diese Methode wurde in S2a
+  absichtlich entfernt, s.u.).
+- **File:** `src/services/notification_service.py` (MODIFY, ~90 LoC) — vier separate
+  Stellen, siehe „Implementation Details":
+  - `_dispatch_alert_message()` (`:1200-1417`): vierter Kanal-Zweig nach dem
+    SMS-Zweig (`:1405-1411`), `_log_error()` (`:1299-1305`) Label-Dict gehärtet.
+  - `send_official_alert()` (`:794-899`): vierter Kanal-Zweig nach dem SMS-Zweig
+    (`:881-894`).
+  - `send_compare_official_alert()` (`:995-1081`) + neue Hilfsfunktion
+    `_dispatch_compare_official_premium_sms()` (Vorbild `_dispatch_compare_official_sms`,
+    `:1140-1157`).
+  - Alle sechs `alert_log.append_entry(...)`-Aufrufstellen (s.u.) reichen zusätzlich
+    `blocked_reason_codes=result.blocked_reason_codes` durch.
+- **File:** `src/services/trip_alert.py` (dieselbe Datei, bereits oben gezählt) — zwei
+  `alert_log.append_entry(...)`-Aufrufstellen (`:316`, `:1097`, `:1404` laut Messung des
+  Kontextdokuments — drei, nicht zwei; korrigiert) bekommen `blocked_reason_codes=`.
+- **File:** `src/services/compare_alert.py` (MODIFY, 1 Zeile) — `append_entry`-Aufruf
+  (`:256`) bekommt `blocked_reason_codes=`.
+- **File:** `src/services/compare_radar_alert.py` (MODIFY, 1 Zeile) — `append_entry`-Aufruf
+  (`:202`) bekommt `blocked_reason_codes=`.
+- **File:** `src/services/compare_official_alert.py` (MODIFY, 1 Zeile) — `append_entry`-Aufruf
+  (`:171`) bekommt `blocked_reason_codes=`.
+- **File:** `internal/model/trip.go` (MODIFY, ~20 LoC) —
+  `AlertChannelsConfig` (`:187-191`) von `bool`-Feldern auf `*bool` umgestellt (Email,
+  Telegram, Sms) **plus** neues Feld `PremiumSms *bool`; Docstring-Prämisse „All-or-nothing"
+  (`:185-186`) entfällt (D3). `AlertChannelThresholdsConfig` (`:202-206`) bekommt
+  `PremiumSms *string` als viertes Geschwisterfeld (ADR-0046-Pflicht, D6) — dieser Typ ist
+  identisch für Trip und Ortsvergleich, also automatisch auf beiden Seiten wirksam.
+- **File:** `internal/handler/trip.go` (MODIFY, ~20 LoC) — der bisherige
+  Ganzobjekt-Ersatz `if req.AlertChannels != nil { existing.AlertChannels = req.AlertChannels }`
+  (`:367-369`) wird durch Feld-Level-Merge ersetzt (Vorbild `AlertChannelThresholds`,
+  `:375-386`, D3). Der bestehende Threshold-Merge-Block (`:375-386`) bekommt einen vierten
+  `if req.AlertChannelThresholds.PremiumSms == nil ...`-Zweig.
+- **File:** `internal/model/compare_preset.go` (MODIFY, ~4 LoC) — neues Feld
+  `SendPremiumSms *bool` (Vorbild `SendTelegram`/`SendSms`, `:91-92`).
+- **File:** `internal/handler/compare_preset.go` (MODIFY, ~8 LoC) — Merge-Block
+  `:407-411` bekommt einen dritten `if updated.SendPremiumSms == nil { ... }`-Zweig;
+  der Threshold-Merge-Block (`:419-429`) bekommt den vierten `PremiumSms`-Zweig
+  (identisches Muster wie im Trip-Handler).
+- **File:** `docs/reference/api_contract.md` (MODIFY, Doku, zählt nicht zum LoC-Budget) —
+  `AlertChannelsConfig`/`AlertChannelThresholdsConfig`-Codeblöcke (`:740-770`) und die
+  zugehörige Prosa (`:773-807`) auf vier Kanäle nachziehen; „all-or-nothing" für
+  `AlertChannelsConfig` entfällt.
+- **File:** `tests/test_success_status_guard.py` (MODIFY, ~10 LoC) — die
+  indexbasierte Ratsche für `send_official_alert` (`:1547-1554`, `:1792`) und
+  `_dispatch_alert_message` (`:1579-1586`, `:1794`) wird von **3** auf **4** angehoben
+  (D7), plus ein Nachzug-Eintrag für die neue Fundstelle
+  `send_compare_official_alert::3` (falls der Scanner sie dort listet — am Bestand
+  nachzumessen, s. „Known Limitations").
+- **File:** `docs/specs/modules/waechter_1405_erfolg_wirkung.md` (MODIFY, Doku) —
+  Pflicht-Nachzug der neuen Ratschen-Zahlen (dort wörtlich verlangt).
+- **File:** `tests/unit/test_alert_channel_premium_sms.py` (CREATE, ~180 LoC) —
+  echter lokaler HTTP-Stub, Trip-Änderungs-/Radar-Alarm + amtlicher Trip-Alarm über
+  Premium-SMS, Tier-Gate, Totalausfall-Schutz.
+- **File:** `tests/unit/test_compare_alert_premium_sms.py` (CREATE, ~120 LoC) —
+  dieselben drei Alarmarten für den Ortsvergleich.
+- **File:** `tests/unit/test_alert_log_premium_sms_channel.py` (CREATE, ~80 LoC) —
+  `_ALL_CHANNELS`, `blocked_reason_codes`-Weiterreichung, kein stilles Loch im Protokoll.
+- **File:** `tests/unit/test_alert_channel_threshold_premium_sms.py` (CREATE, ~60 LoC) —
+  Kanal-Schwelle greift für Premium-SMS wie für die drei Bestandskanäle.
+- **File:** `internal/handler/trip_alert_channels_test.go` (MODIFY, ~40 LoC) —
+  Feld-Level-Merge-Fälle für `PremiumSms`, Bestandsdaten-Erhalt bei fehlendem vierten Feld.
+- **File:** `internal/handler/trip_alert_channel_thresholds_test.go` (MODIFY, ~15 LoC) —
+  vierter Schwellenwert-Fall.
+- **File:** `internal/handler/compare_preset_official_alerts_test.go` (MODIFY, ~15 LoC) —
+  `SendPremiumSms`-Merge-Fall.
+- **File:** `internal/handler/compare_preset_alert_channel_thresholds_test.go`
+  (MODIFY, ~15 LoC) — vierter Schwellenwert-Fall für den Ortsvergleich.
+
+## Estimated Scope
+
+- **LoC (Produktivcode, Python + Go):** ≈ +180 (alert_log +15, trip_alert +20,
+  compare_alert_channels +6, notification_service +90, sechs `append_entry`-Aufrufstellen
+  +6, Go-Modell +24, Go-Handler +28, Ratsche +10 — Doku zählt nicht mit).
+- **LoC (Tests):** geschätzt ≈ +450 (vier neue Python-Testdateien ≈ 440, vier Go-Test-
+  Ergänzungen ≈ 85 — **konservativ geschätzt**, S2a lag beim tatsächlichen RED-Stand um mehr
+  als das Doppelte über der Schätzung, weil echte HTTP-Stub-Fixtures und Kantenfälle teurer
+  sind als vermutet).
+- **Gesamt erwartet:** ≈ +630, realistisch eher **800–1200** nach S2a-Erfahrung.
+  **Das im Workflow gesetzte LoC-Budget von 400 reicht nicht** — ein Override auf
+  mindestens **1200** ist vor der Implementierung einzuholen, nicht erst wenn das Limit
+  reißt. Begründung: diese Scheibe berührt DREI unabhängige Versand-Dispatcher in
+  `notification_service.py` (nicht einen wie in S2a), zwei Go-Structs mit Merge-Pflicht
+  statt keinem, und die Ratschen-Nachzugpflicht.
+- **Files:** 4 CREATE (Tests) + 20 MODIFY (13 Python/Doku, 7 Go/Go-Tests).
+- **Effort:** high.
+- **Risiko:** MEDIUM-HOCH. Kein bestehendes Verhalten der drei etablierten Kanäle
+  ändert sich (rein additiv), aber die Zahl der Ansatzpunkte ist hoch — ein vergessener
+  Ansatzpunkt erzeugt keinen Testfehler, sondern ein stilles Loch (Präzedenzfall:
+  `_ALL_CHANNELS` in `alert_log.py` liefert bei Vergessen einfach kein Protokoll-Feld für
+  `premium_sms`, kein Crash).
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `docs/specs/modules/feat_1676_s2a_premium_sms_versand.md` | Vorgänger-Spec | liefert `PremiumSmsOutput`, `premium_sms_allowed()`, `NotificationResult.blocked_channels`/`blocked_reason_codes`, `_record_block_reason_code()` — alles wiederverwendet, nichts neu gebaut |
+| `docs/adr/0049-premium-sms-vierter-kanal.md` | ADR | legt den Kanalnamen bereits fest; diese Scheibe braucht **kein neues ADR** |
+| `docs/adr/0046-alarm-kanal-schwelle.md` | ADR | verpflichtet: jede neue Stelle, die ein Kanal-Set auflöst, muss die Kanal-Schwelle anwenden — hier eingelöst (AC-8) |
+| `src/services/user_tier.py::premium_sms_allowed` | module | Tier-Gate, NICHT `sms_allowed` (lässt `standard` durch) |
+| `src/services/alert_channel_threshold.py::split_by_threshold` | module | kanal-agnostisch (Default `LOW`), kein Code-Eingriff nötig — nur das Go-Feld zum Setzen fehlt |
+| `internal/model/trip.go::AlertChannelThresholdsConfig` | Vorbild | Pointer-Feld-Merge-Muster, das `AlertChannelsConfig` jetzt übernimmt (D3) |
+| `internal/handler/compare_preset.go` Merge-Block `:407-429` | Vorbild | identisches Muster bereits für Telegram/Sms/Thresholds vorhanden |
+| `tests/test_success_status_guard.py` | Wächter | Erfolgs-Ratsche, MUSS angehoben werden (D7), NICHT umgangen |
+
+## Implementation Details
+
+### D1 — Fünf plus zwei: die tatsächliche Zahl der Enumerationen
+
+Der ursprüngliche Befund nannte fünf hart verdrahtete Kanal-Aufzählungen. Beim Nachmessen für
+diese Spec kamen zwei weitere hinzu, die dieselbe Struktur haben, aber nicht in der
+ursprünglichen Liste standen:
+
+1. `alert_log.py:59` `_ALL_CHANNELS`
+2. `trip_alert.py:1492-1494` (`_effective_alert_channels`, scharfes Set)
+3. `trip_alert.py:1515-1527` (`_briefing_channels`, Vererbung)
+4. `trip_alert.py:825-846` (`_radar_effective_channels`, bewusst getrennt seit #1467 S3)
+5. `compare_alert_channels.py:28-36` (`effective_compare_channels`)
+6. **NEU gemessen:** `notification_service.py:794-899` (`send_official_alert`, drei
+   `if "<kanal>" in effective_channels`-Zweige)
+7. **NEU gemessen:** `notification_service.py:995-1081` +
+   `_dispatch_compare_official_{email,telegram,sms}` (`:1083-1157`) — der
+   Ortsvergleich-Pendant zu (6), strukturell identisch, aber eine eigene Funktionsfamilie.
+
+`_dispatch_alert_message()` (`:1200-1417`) ist KEINE eigene Enumeration im selben Sinn wie
+(6)/(7) — sie liest `effective_channels` bereits als aufgelöstes Set (aus (2)/(3)/(4)/(5))
+und muss nur um einen vierten `if "premium_sms" in effective_channels:`-Zweig ergänzt werden.
+Trotzdem ist sie eine eigene Ansatzstelle, weil sie den Versand selbst auslöst
+(`PremiumSmsOutput(...).send(...)`), nicht nur das Set berechnet.
+
+### D2 — Kein `settings.can_send_premium_sms()` im Alarm-Pfad
+
+S2a hat genau diese Methode nach einem Adversary-Fund (F003) **entfernt**: eine
+vorgeschaltete Bereitschaftsfrage im Sendezweig hätte die Fail-Closed-Prüfung in
+`PremiumSmsOutput._resolve_recipient()` *abgeschirmt* — bei einem Bug in der Vorprüfung
+wäre die eigentliche Sperre nie erreicht worden, und der Test dafür wäre grün geblieben.
+Diese Scheibe **darf diese Methode nicht wieder einführen**, auch nicht implizit über eine
+andere Bereitschaftsfrage mit ähnlichem Namen. Folge: `effective_compare_channels()` und
+`_radar_effective_channels()` gaten Premium-SMS ausschließlich über Opt-in (`preset.get(...)`
+bzw. `config.send_premium_sms`) und Tier (`premium_sms_allowed`) — genau wie die drei anderen
+Kanäle NICHT über `can_send_sms()`/`can_send_telegram()` im Alarm-Pfad geprüft werden
+(diese Methoden gaten dort schon heute nur die technische Konfiguration, nicht die
+Empfänger-Frische — bei Premium-SMS gibt es aber gar keine technische Konfiguration zu
+prüfen, nur die Rückadresse, und die prüft ausschließlich der Kanal selbst).
+
+### D3 — Go-Merge: das vierte Feld darf kein fünftes Datenverlust-Muster werden
+
+`AlertChannelsConfig` trägt heute die explizite Prämisse „All-or-nothing: alle drei Felder
+werden vom Client immer explizit gesendet". Diese Prämisse ist mit einem vierten Feld, das
+die Oberfläche (S3) noch gar nicht kennt, sofort falsch: ein PUT eines alten Frontend-Builds
+schickt weiterhin nur drei Felder, Go dekodiert das fehlende vierte als Zero-Value `false`,
+und der bisherige Ganzobjekt-Ersatz (`existing.AlertChannels = req.AlertChannels`) würde
+einen bereits aktivierten Premium-Alarmkanal bei **jedem** Speichern eines Trips über die
+alte Oberfläche stillschweigend abschalten — ein Muster wie BUG-DATALOSS-GR221 (#102).
+
+Lösung: `Email`/`Telegram`/`Sms`/`PremiumSms` werden `*bool`, und der Handler übernimmt das
+Feld-Level-Merge-Muster, das für `AlertChannelThresholdsConfig` direkt daneben bereits
+etabliert ist (`trip.go:202-206`, `handler/trip.go:375-386`): fehlt ein Feld im Body (`nil`),
+bleibt der Bestandswert erhalten; ist es explizit gesetzt (auch `false`), gewinnt der neue
+Wert. Damit verhält sich `AlertChannelsConfig` konsistent mit seinem direkten
+Geschwisterfeld, statt zwei unterschiedliche Merge-Philosophien nebeneinander zu pflegen.
+
+### D4 — Der Totalausfall-Fund: `_log_error()` stürzt heute ab
+
+`notification_service.py:1301` — `label = {"email": "Email", "telegram": "Telegram",
+"sms": "SMS"}[channel]` ist ein direkter Dict-Zugriff ohne Rückfall, in einem
+Exception-Handler. Sobald `_dispatch_alert_message()` einen `"premium_sms"`-Zweig bekommt
+und der Versand fehlschlägt, wirft dieser Zugriff selbst einen `KeyError` — **innerhalb**
+der Fehlerbehandlung des ursprünglichen Fehlers. Python propagiert diesen zweiten Fehler
+nach oben, `_dispatch_alert_message()` bricht komplett ab, und alle Kanäle, die in der
+Aufrufreihenfolge NACH Premium-SMS liegen, erhalten ihren Alarm ebenfalls nicht — aus einem
+Teilausfall wird ein Totalausfall.
+
+Fix: `label = {"email": "Email", "telegram": "Telegram", "sms": "SMS",
+"premium_sms": "Premium-SMS"}.get(channel, channel)` — das `.get()` mit Fallback macht die
+Stelle zusätzlich robust gegen einen fünften, künftigen Kanal, der denselben Fehler sonst
+wiederholen würde.
+
+### D5 — Sperrgrund im Alarm-Protokoll: maschinenlesbar statt generisch
+
+Heute kennt `alert_log._channels_not_sent()` genau drei Gründe für „nicht zugestellt":
+`channel_disabled` (Kanal aus), `below_channel_threshold` (#1461) und `delivery_failed`
+(Sammelbecken für alles andere). Ein blockierter Premium-SMS-Versand (leere/veraltete
+Rückadresse) landet damit ununterscheidbar von einem echten Transportfehler im selben
+Sammelbecken — genau die Kopplung, die S2a mit `ChannelBlockedError.reason_code` bereits für
+das Briefing gelöst hat.
+
+`append_entry()` bekommt einen neuen optionalen Parameter `blocked_reason_codes:
+Optional[dict[str, str]] = None` (Kanal → `reason_code`, z.B.
+`premium_sms_no_reply_address`). `_channels_not_sent()` prüft ihn VOR den bisherigen drei
+Fällen: hat ein nicht zugestellter Kanal einen Eintrag in `blocked_reason_codes`, wird dessen
+Wert als Grund übernommen statt `REASON_DELIVERY_FAILED`. Alle drei Alarm-Dispatcher
+(`_dispatch_alert_message`, `send_official_alert`, `send_compare_official_alert`) füllen
+`NotificationResult.blocked_reason_codes` für Premium-SMS über `_record_block_reason_code()`
+(bereits aus S2a vorhanden, unverändert wiederverwendet) — für die drei Bestandskanäle bleibt
+das Feld leer, ihr Verhalten ändert sich nicht.
+
+### D6 — Kanal-Schwelle: nur das Go-Feld fehlt
+
+`alert_channel_threshold.split_by_threshold()` ist bereits kanal-agnostisch (iteriert über
+das übergebene Kanal-Set, Default `"LOW"` für unbekannte Kanäle) — hier ist **kein**
+Python-Code-Eingriff nötig. Die ADR-0046-Pflicht „jede Stelle, die ein Kanal-Set auflöst,
+muss die Schwelle anwenden" ist für Premium-SMS damit automatisch erfüllt, sobald der Kanal
+im aufgelösten Set auftaucht — vorausgesetzt, der Nutzer kann die Schwelle überhaupt SETZEN.
+Das fehlende Stück ist ausschließlich `AlertChannelThresholdsConfig.PremiumSms *string` in Go
+plus der zugehörige Merge-Zweig (Vorbild: die drei bestehenden Zweige direkt daneben).
+
+### D7 — Erfolgs-Ratsche anheben, nicht umgehen
+
+`tests/test_success_status_guard.py` erwartet für `send_official_alert` und
+`_dispatch_alert_message` exakt drei `sent_channels.append()`-Aufrufe vor dem jeweiligen
+`try` (B14a/B14c, dokumentierter Mangel: „Marker vor der Tat"). Mit dem vierten Kanal wird
+daraus vier. **Der naheliegende Schluss — die Buchung hinter den `try` ziehen, damit die
+Ratsche bei 0 bleibt — ist FALSCH** (zwei frühere Sitzungen sind unabhängig darauf
+hereingefallen, s. Memory): `alert_log.append_entry()` nimmt bewusst ZWEI getrennte Listen
+(`sent_channels`=„versucht", `reachable_channels`=„erreichbar") entgegen, und alle sechs
+Aufrufstellen übergeben beide. Eine Verschiebung der Buchung würde diese Unterscheidung
+zerstören. Richtiger Zug: die erwartete Zahl in `test_success_status_guard.py` von 3 auf 4
+anheben, mit Pflicht-Nachzug in `docs/specs/modules/waechter_1405_erfolg_wirkung.md`
+(dort steht wörtlich, Ratschen-Zahlen würden „IN DER SPEC beschlossen und dort nachgezogen").
+
+**Offen für die Implementierung:** ob `send_compare_official_alert()` (die neue
+`_dispatch_compare_official_premium_sms`-Erweiterung) vom selben Scanner überhaupt als
+Fundstelle erkannt wird — die Funktion `sent_channels.append("email")` UNBEDINGT vor dem
+`if not self._dispatch_compare_official_email(...)`-Aufruf ist strukturell dieselbe Klasse,
+aber in der aktuellen Ratschen-Liste nicht als eigene Zeile geführt (nur `send_compare_preset`
+ist als B12 gelistet, ein anderes Muster). Vor dem Anheben ist am Bestand zu messen, ob der
+Scanner hier überhaupt reagiert — siehe „Known Limitations".
+
+### D8 — Ortsvergleich: `SendPremiumSms` als eigenes Go-Feld, kein Wiederverwenden
+
+`ComparePreset` hat heute `SendTelegram`/`SendSms *bool` (`compare_preset.go:91-92`) als
+Kanal-Opt-in — kein Pendant zu `Trip.AlertChannels` (der Ortsvergleich hat kein
+`alert_channels`-Sub-Objekt, die Kanäle sind flache Top-Level-Felder). Premium-SMS bekommt
+konsequent ein eigenes `SendPremiumSms *bool`, Merge nach demselben Muster wie die beiden
+Nachbarfelder (`handler/compare_preset.go:407-411`).
+
+## Expected Behavior
+
+- **Input:** ein ausgelöster Alarm (Abweichung, Regenradar-Onset, amtliche Warnung) für
+  einen Trip oder Ortsvergleich, dessen effektives Kanal-Set `"premium_sms"` enthält.
+- **Output:** ein POST an `gateway.seven.io` mit fester Absendernummer und der gelernten
+  Rückadresse als Empfänger (identisch zu S2a) — der Alarmtext statt des Briefing-Texts.
+  Bei blockiertem/gescheitertem Versand: die anderen effektiven Kanäle werden trotzdem
+  bedient, und `alert_log.json` trägt einen auswertbaren Grund für `premium_sms`.
+- **Side effects:** keine neue Persistenz außer dem einen neuen Go-Feld je betroffenem
+  Struct (`AlertChannelsConfig.PremiumSms`, `AlertChannelThresholdsConfig.PremiumSms`,
+  `ComparePreset.SendPremiumSms`). Bestandsdaten aller drei bestehenden Felder bleiben beim
+  Speichern unverändert erhalten (Read-Modify-Write, kein Replace).
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Premium-Tier-Nutzer hat in seinem Trip `alert_channels.premium_sms = true` UND eine gültige, frische gelernte Rückadresse / When ein Abweichungs- oder Regenradar-Alarm für diesen Trip ausgelöst wird / Then geht eine Premium-SMS mit dem Alarmtext an das Gerät hinaus — genauso zuverlässig wie bei gleicher Konfiguration für E-Mail, Telegram oder SMS.
+  - Prüfort: `payload["to"]`/`payload["text"]` am lokalen HTTP-Stub, ausgelöst über `TripAlertService._send_alert()` bzw. `check_radar_alerts()`.
+  - Test: `tests/unit/test_alert_channel_premium_sms.py::test_deviation_alert_reaches_premium_sms_when_opted_in`, `::test_radar_alert_reaches_premium_sms_when_opted_in`
+
+- **AC-2:** Given ein Trip hat kein scharfes `alert_channels`-Set (`None`) UND im Trip-Briefing ist `send_premium_sms=true` aktiv / When ein Alarm für diesen Trip ausgelöst wird / Then erbt der Alarmpfad den Premium-SMS-Kanal automatisch mit — kein Trip verliert den vierten Kanal nur deshalb, weil er nie ein scharfes Alarm-Kanal-Set gesetzt hat, genau wie es heute für die drei bestehenden Kanäle gilt.
+  - Prüfort: `_briefing_channels()`-Rückgabe UND End-zu-Ende am HTTP-Stub mit einer Fixture, deren `trip.alert_channels is None`.
+  - Test: `tests/unit/test_alert_channel_premium_sms.py::test_legacy_trip_inherits_premium_sms_from_briefing_config`
+
+- **AC-3:** Given Premium-SMS ist im effektiven Kanal-Set eines Trips für amtliche Warnungen enthalten / When eine amtliche Warnung für diesen Trip eintrifft / Then wird auch dafür eine Premium-SMS mit dem amtlichen Kurztext versendet — der amtliche Warnpfad (`send_official_alert`) ist eine von `_dispatch_alert_message` unabhängige Funktion und wäre sonst der stille vierte blinde Fleck.
+  - Prüfort: HTTP-Stub gegen `NotificationService.send_official_alert()` direkt, mit `effective_channels={"email","premium_sms"}`.
+  - Test: `tests/unit/test_alert_channel_premium_sms.py::test_official_trip_alert_reaches_premium_sms`
+
+- **AC-4:** Given ein Ortsvergleich-Preset hat `send_premium_sms=true` (Nutzer ist Premium-Tier) / When ein Änderungs-, Regenradar- oder amtlicher Alarm für einen betroffenen Vergleichsort ausgelöst wird / Then wird der Ort in allen drei Fällen zusätzlich per Premium-SMS gemeldet — nicht nur bei E-Mail/Telegram/SMS, wie es heute für alle drei Ortsvergleichs-Alarmpfade gilt.
+  - Prüfort: HTTP-Stub gegen `compare_alert.py`, `compare_radar_alert.py`, `compare_official_alert.py` (bzw. `send_compare_official_alert()` direkt), je ein Fall pro Alarmart.
+  - Test: `tests/unit/test_compare_alert_premium_sms.py::test_compare_deviation_alert_reaches_premium_sms`, `::test_compare_radar_alert_reaches_premium_sms`, `::test_compare_official_alert_reaches_premium_sms`
+
+- **AC-5:** Given ein Nutzer mit Tier `standard` hat (fälschlich oder testweise) `alert_channels.premium_sms=true` bzw. `send_premium_sms=true` im Ortsvergleich gesetzt / When ein Alarm für Trip oder Ortsvergleich ausgelöst wird / Then bleibt der Premium-SMS-Kanal in allen drei Alarmpfaden inaktiv — dasselbe strenge Tier-Gate (`premium_sms_allowed`) wie im Trip-Briefing, nicht das schwächere `sms_allowed`, das `standard` durchlässt.
+  - Prüfort: HTTP-Stub bleibt leer (`stub.received == []`) für den Premium-Kanal bei einer `standard`-Tier-Fixture, in allen drei Dispatchern.
+  - Test: `tests/unit/test_alert_channel_premium_sms.py::test_standard_tier_never_reaches_premium_sms_via_alerts`, `tests/unit/test_compare_alert_premium_sms.py::test_standard_tier_never_reaches_premium_sms_via_compare_alerts`
+
+- **AC-6:** Given ein Alarm geht an mehrere Kanäle gleichzeitig, darunter Premium-SMS, UND der Premium-Versand schlägt fehl (z.B. keine gelernte Rückadresse) / When der Alarm verarbeitet wird / Then erreichen die übrigen konfigurierten Kanäle (E-Mail/Telegram/SMS) den Nutzer trotzdem, unbeeinträchtigt vom Premium-Fehlschlag.
+  - Prüfort: Fixture mit vier aktiven Kanälen, Premium-SMS gezielt blockiert (leere Rückadresse) — die anderen drei POSTs kommen am jeweiligen Stub an, KEIN unbehandelter `KeyError`/Absturz in `_log_error()`.
+  - Test: `tests/unit/test_alert_channel_premium_sms.py::test_failed_premium_sms_does_not_abort_remaining_channels`
+
+- **AC-7:** Given ein bestehender Trip hat bereits `alert_channels` mit gesetzten Werten für E-Mail/Telegram/SMS gespeichert / When der Nutzer über die API ein PUT ohne das vierte Feld `premium_sms` schickt (z.B. eine ältere Frontend-Version) / Then bleiben die drei bestehenden Kanal-Einstellungen unverändert erhalten UND ein zuvor gesetzter Premium-SMS-Wert wird NICHT auf `false` zurückgesetzt.
+  - Prüfort: Go-Handler-Test, zwei aufeinanderfolgende PUTs — erster setzt alle vier Felder, zweiter schickt nur drei; danach wird der volle gespeicherte Trip gelesen und das vierte Feld geprüft.
+  - Test: `internal/handler/trip_alert_channels_test.go::TestAlertChannels_FourthFieldMissingInBody_PreservesExistingValue`
+
+- **AC-8:** Given ein Nutzer hat für Premium-SMS eine Dringlichkeits-Schwelle „HIGH" eingestellt UND ein ausgelöster Alarm hat die Dringlichkeit „MODERATE" / When der Alarm verarbeitet wird / Then bleibt die Premium-SMS diesmal aus (unter der Schwelle), exakt wie es heute für die drei bestehenden Kanäle gilt — Premium-SMS ist von der Kanal-Schwelle nicht ausgenommen.
+  - Prüfort: `alert_channel_threshold.split_by_threshold()` mit einem Kanal-Set, das `"premium_sms"` enthält, und einer Trip-Fixture mit `alert_channel_thresholds.premium_sms="HIGH"`.
+  - Test: `tests/unit/test_alert_channel_threshold_premium_sms.py::test_premium_sms_suppressed_below_configured_threshold`
+
+- **AC-9:** Given eine Alarm-Meldung sollte per Premium-SMS gehen, aber die gelernte Rückadresse ist leer oder älter als 30 Tage / When der Alarm-Lauf abgeschlossen ist / Then zeigt das Alarm-Protokoll (`alert_log.json`) den Kanal `premium_sms` unter `channels_not_sent` mit dem spezifischen Grund (`premium_sms_no_reply_address` bzw. `premium_sms_reply_address_stale`) — nicht mit dem generischen „technisch gescheitert" und nicht als spurloses Fehlen im Protokoll.
+  - Prüfort: `alert_log.json` nach dem Testlauf gelesen (kein Mock des Protokolls selbst), `channels_not_sent`-Eintrag für `premium_sms` mit dem erwarteten `reason`-Wert.
+  - Test: `tests/unit/test_alert_log_premium_sms_channel.py::test_blocked_premium_sms_reason_is_specific_not_generic`
+
+- **AC-10:** Given der Adversary verfälscht die neue Verdrahtung so, dass ein Kanal als „versucht" (`sent_channels`) gebucht wird, obwohl `PremiumSmsOutput.send()` nie aufgerufen wurde (oder umgekehrt: der Aufruf erfolgt, ohne dass er gebucht wird) / When die Ratschen-Testsuite (`test_success_status_guard.py`) läuft / Then schlägt genau der dafür benannte Test fehl — die Erfolgs-Ratsche wurde bewusst von 3 auf 4 angehoben, nicht deaktiviert, umgangen oder durch Verschieben der Buchung hinter den `try` unterlaufen.
+  - Prüfort: `test_no_unlisted_success_status_findings` bzw. der spezifische Index-Test für `send_official_alert`/`_dispatch_alert_message`.
+  - Test: `tests/test_success_status_guard.py` (MODIFY, erwartete Zahl 3→4 je Funktion)
+
+## Was sich NICHT ändern darf (Invarianten)
+
+- Die drei bestehenden Kanäle (E-Mail, Telegram, SMS) verhalten sich in allen drei
+  Alarm-Dispatchern (`_dispatch_alert_message`, `send_official_alert`,
+  `send_compare_official_alert`) byte-identisch zu vorher — keine der bestehenden
+  Testsuiten für diese Kanäle darf sich ändern müssen.
+- `alert_log.append_entry()` bleibt für alle Bestandsaufrufe ohne `blocked_reason_codes`
+  (Default `None`) exakt beim heutigen Verhalten: generischer `delivery_failed`.
+- Die Unterscheidung `sent_channels` („betreten/versucht") vs. `reachable_channels`
+  („erreichbar") bleibt bestehen — die Ratschen-Anhebung (D7) verschiebt keine Buchung
+  zwischen diesen beiden Ebenen.
+- `settings.can_send_premium_sms()` wird NICHT wieder eingeführt (D2) — auch nicht unter
+  anderem Namen mit gleicher Wirkung (vorgeschaltete Bereitschaftsfrage, die die
+  Fail-Closed-Prüfung im Kanal abschirmt).
+- Bestandsdaten aller drei bereits gespeicherten `AlertChannelsConfig`-Felder und aller drei
+  `AlertChannelThresholdsConfig`-Felder bleiben bei jedem PUT ohne das vierte Feld
+  unverändert erhalten (Read-Modify-Write, niemals Replace) — AC-7.
+
+## Bewusst nicht in dieser Scheibe
+
+- Kein UI-Kontrollelement für `alert_channels.premium_sms`, `send_premium_sms` (Compare)
+  oder die Premium-SMS-Kanal-Schwelle (folgt S3).
+- Kein neues ADR — ADR-0049 legt den Kanalnamen bereits fest, ADR-0046 verpflichtet bereits
+  zur Schwellenanwendung; diese Scheibe löst beide Verpflichtungen ein, ohne sie zu ändern.
+- Keine Kostenstelle/kein Kontingent für Premium-SMS-Alarme (S2c/#1702).
+- Kein Eingriff in `alert_channel_threshold.split_by_threshold()` selbst — die Funktion ist
+  bereits kanal-agnostisch.
+
+## Nachweisgrenzen — was diese Scheibe NICHT beweist
+
+Wie in S2a strukturell nicht beweisbar: dass eine Alarm-Premium-SMS tatsächlich auf dem
+Garmin-Gerät ankommt. Dieselben Gründe wie in S2a (Herkunftssperre erzwingt Sandbox-Key,
+`force_test` sandboxiert Staging zusätzlich, Staging-Scheduler führt keinen Job aus) gelten
+unverändert. Dieser Nachweis ist als **SKIPPED** auszuweisen und gehört in **#1533**.
+
+Zusätzlich in dieser Scheibe strukturell offen: ob der Ratschen-Scanner
+(`test_success_status_guard.py`) die neue `_dispatch_compare_official_premium_sms`-Erweiterung
+überhaupt als eigene Fundstelle erkennt (D7, „Known Limitations"). Das ist am Bestand vor der
+Implementierung zu messen, nicht anzunehmen.
+
+## Mutations-Gegenprobe
+
+| AC | Gezielte Verfälschung | Test, der dadurch rot werden MUSS |
+|---|---|---|
+| AC-1 | `_dispatch_alert_message()`: Premium-Zweig fehlt / prüft falschen Kanalnamen | `test_deviation_alert_reaches_premium_sms_when_opted_in` |
+| AC-2 | `_briefing_channels()`: `send_premium_sms`-Zweig entfernt | `test_legacy_trip_inherits_premium_sms_from_briefing_config` |
+| AC-3 | `send_official_alert()`: Premium-Zweig liest `config.send_sms` statt eigenem Flag / fehlt ganz | `test_official_trip_alert_reaches_premium_sms` |
+| AC-4 | `effective_compare_channels()`: `send_premium_sms`-Zweig entfernt | alle drei Compare-Tests in `test_compare_alert_premium_sms.py` |
+| AC-5 | `premium_sms_allowed()`-Aufruf durch `sms_allowed()` ersetzt (an einer der drei Gate-Stellen) | jeweiliger `test_standard_tier_never_reaches_premium_sms_via_*`-Test |
+| AC-6 | `_log_error()`-Label-Dict-Fix zurückgenommen (harter `[channel]`-Zugriff) | `test_failed_premium_sms_does_not_abort_remaining_channels` — die anderen Kanäle bekämen keinen Request mehr |
+| AC-7 | `handler/trip.go`: Feld-Level-Merge durch Ganzobjekt-Ersatz zurückgetauscht | `TestAlertChannels_FourthFieldMissingInBody_PreservesExistingValue` |
+| AC-8 | `AlertChannelThresholdsConfig.PremiumSms` beim Auflösen ignoriert (Default `"LOW"` immer verwendet) | `test_premium_sms_suppressed_below_configured_threshold` |
+| AC-9 | `_channels_not_sent()`: `blocked_reason_codes`-Vorrang entfernt | `test_blocked_premium_sms_reason_is_specific_not_generic` |
+| AC-10 | Ratschen-Zahl nicht angehoben (bleibt 3) ODER Buchung hinter `try` verschoben | `test_success_status_guard.py`-Ratschentests selbst (rot bzw. — bei verschobener Buchung — eine der Alarm-Tests, die `sent_channels` vs. `reachable_channels` unterscheiden) |
+
+## Known Limitations
+
+- **Ratschen-Reichweite für `send_compare_official_alert` ungeklärt (D7).** Ob der
+  Scanner diese Funktion als eigene B14a-artige Fundstelle listet, ist vor der
+  Implementierung zu messen (aktuell nur `send_compare_preset` als B12 gelistet, ein
+  strukturell anderes Muster). Fällt sie darunter, braucht auch sie eine
+  Zahlen-Anhebung; fällt sie nicht darunter, ist nichts zu tun. Diese Spec trifft die
+  Entscheidung nicht vorab, weil eine falsche Annahme hier entweder unnötigen Code oder
+  eine übersehene Ratschen-Lücke erzeugen würde.
+- **Kein Frontend, keine Sichtbarkeit für den Nutzer** — wie in S2a, folgt in S3.
+- **`AlertChannelsConfig` verliert die „All-or-nothing"-Garantie (D3).** Das ist
+  beabsichtigt (Voraussetzung für Bestandsschutz), bedeutet aber: ein Client, der künftig
+  gezielt einen Kanal auf `false` setzen will, muss ihn jetzt explizit im Body mitschicken —
+  das war vorher implizit durch „immer alle drei" gegeben. Für S3 zu beachten, nicht Teil
+  dieser Scheibe.
+- **Kanal-Schwelle bleibt ohne Bedienelement** — ein per API gesetzter Wert wirkt, ist aber
+  bis S3 nur über direkte API-Aufrufe erreichbar.
+- **Nachweis am Gerät bleibt #1533**, unverändert zu S2a.
+
+## Test Coverage
+
+- `tests/unit/test_alert_channel_premium_sms.py` (CREATE) — Trip-Alarmpfade (AC-1, AC-2,
+  AC-3, AC-5 Trip-Teil, AC-6).
+- `tests/unit/test_compare_alert_premium_sms.py` (CREATE) — Ortsvergleich-Alarmpfade
+  (AC-4, AC-5 Compare-Teil).
+- `tests/unit/test_alert_log_premium_sms_channel.py` (CREATE) — Protokoll-Verhalten (AC-9),
+  `_ALL_CHANNELS`-Erweiterung ohne stilles Loch.
+- `tests/unit/test_alert_channel_threshold_premium_sms.py` (CREATE) — Kanal-Schwelle (AC-8).
+- `internal/handler/trip_alert_channels_test.go` (MODIFY) — Feld-Level-Merge Trip (AC-7).
+- `internal/handler/trip_alert_channel_thresholds_test.go` (MODIFY) — vierte Schwelle Trip.
+- `internal/handler/compare_preset_official_alerts_test.go` (MODIFY) — `SendPremiumSms`-Merge
+  Ortsvergleich.
+- `internal/handler/compare_preset_alert_channel_thresholds_test.go` (MODIFY) — vierte
+  Schwelle Ortsvergleich.
+- `tests/test_success_status_guard.py` (MODIFY) — Ratsche (AC-10).
+
+Testdateien liegen unter `tests/unit/` (`touched_tests_gate.py:37`) bzw. `internal/handler/`
+(Go-Testkonvention). Namen nach Verhalten, nicht nach Issue-Nummer.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine (neue).
+- **Rationale:** ADR-0049 legt den Kanalnamen `premium_sms` bereits verbindlich fest —
+  diese Scheibe erweitert seine Reichweite auf zwei weitere Versandanlässe, ohne die
+  Entscheidung selbst zu ändern. ADR-0046 verpflichtet bereits zur Anwendung der
+  Kanal-Schwelle an jeder neuen Kanal-Set-Auflösungsstelle; diese Scheibe löst diese
+  Verpflichtung für Premium-SMS ein (AC-8), statt sie zu widerrufen oder zu erweitern.
+
+## Changelog
+
+- 2026-08-11: Initial spec erstellt — Issue #1701, Scheibe S2b von #1676

--- a/docs/specs/modules/waechter_1405_erfolg_wirkung.md
+++ b/docs/specs/modules/waechter_1405_erfolg_wirkung.md
@@ -477,8 +477,8 @@ Scan-Ergebnis):
 | `src/services/compare_official_alert.py::check_all_compare_presets` | 1 |
 | `src/services/scheduler_dispatch_service.py::send_compare_preset` | 1 |
 | `api/routers/scheduler.py::_ping_heartbeat_compare` | 1 |
-| `src/services/notification_service.py::send_official_alert` | **3** |
-| `src/services/notification_service.py::_dispatch_alert_message` | **3** |
+| `src/services/notification_service.py::send_official_alert` | **4** |
+| `src/services/notification_service.py::_dispatch_alert_message` | **4** |
 | `src/services/notification_service.py::_dispatch_compare_official_email` | 1 |
 | `src/services/notification_service.py::_dispatch_compare_official_telegram` | 1 |
 | `src/services/notification_service.py::_dispatch_compare_official_sms` | 1 |
@@ -793,3 +793,9 @@ B15–B17-Aufnahme trotz totem Code).
   AC-18) — 20 ACs statt 16. Größenschätzung auf 2400–2800 LoC angehoben
   (vorher 1600–2200) — Freigabe erneut beim PO einzuholen. Approval
   zurückgesetzt.
+- 2026-08-11 (Nachzug Issue #1701, S2b): Premium-SMS wird vierter
+  Versandkanal in `send_official_alert` (B14a) und `_dispatch_alert_message`
+  (B14c) — die Mindest-Trefferzahl beider Funktionsschlüssel steigt von 3
+  auf 4 (Tabelle oben), `SPEC_LISTED_FINDINGS`-Summe von 40 auf 42.
+  Funktionsschlüssel-Zahl (33) unverändert. Dies ist genau die in „Offene
+  Punkte" 2 vorgesehene, hier beschlossene Korrektur.

--- a/internal/handler/compare_preset.go
+++ b/internal/handler/compare_preset.go
@@ -410,12 +410,18 @@ func UpdateComparePresetHandler(s *store.Store) http.HandlerFunc {
 		if updated.SendSms == nil {
 			updated.SendSms = original.SendSms
 		}
+		// Issue #1701 (S2b, D8): drittes Kanal-Opt-in-Feld, identisches
+		// Muster wie SendTelegram/SendSms daneben.
+		if updated.SendPremiumSms == nil {
+			updated.SendPremiumSms = original.SendPremiumSms
+		}
 		// Issue #1461 S3b-2b: alert_channel_thresholds erhalten wenn Body es
 		// nicht traegt (nil nach Decode = Feld fehlte im Request), analog
 		// OfficialWarnings -- PLUS Feld-Level-Merge innerhalb des
 		// Unterobjekts (Muster OfficialWarnings.Sources, Fix-Loop F002 dort):
 		// ein PUT, das nur EINEN Kanal mitschickt, darf die anderen,
-		// unangetasteten Kanaele nicht loeschen.
+		// unangetasteten Kanaele nicht loeschen. PremiumSms (Issue #1701
+		// S2b): viertes Geschwisterfeld, identisches Muster.
 		if updated.AlertChannelThresholds == nil {
 			updated.AlertChannelThresholds = original.AlertChannelThresholds
 		} else if original.AlertChannelThresholds != nil {
@@ -427,6 +433,9 @@ func UpdateComparePresetHandler(s *store.Store) http.HandlerFunc {
 			}
 			if updated.AlertChannelThresholds.Sms == nil {
 				updated.AlertChannelThresholds.Sms = original.AlertChannelThresholds.Sms
+			}
+			if updated.AlertChannelThresholds.PremiumSms == nil {
+				updated.AlertChannelThresholds.PremiumSms = original.AlertChannelThresholds.PremiumSms
 			}
 		}
 		// Issue #764: forecast_hours erhalten wenn Body es nicht trägt (0 = Feld fehlte im Body).

--- a/internal/handler/compare_preset_alert_channel_thresholds_test.go
+++ b/internal/handler/compare_preset_alert_channel_thresholds_test.go
@@ -188,6 +188,75 @@ func TestUpdateComparePreset_AlertChannelThresholdsFieldLevelMergePreservesUntou
 	}
 }
 
+// Issue #1701 (S2b, D6): vierter Schwellenwert-Fall fuer den Ortsvergleich
+// -- identisches Feld-Level-Merge-Muster wie oben, jetzt fuer PremiumSms.
+func TestUpdateComparePreset_AlertChannelThresholdsPremiumSmsFieldLevelMerge(t *testing.T) {
+	s := newTestStore(t)
+
+	original := model.ComparePreset{
+		ID:          "cp-1701-thr-premium",
+		Name:        "PremiumSms-Threshold-Test",
+		UserID:      "user1",
+		LocationIDs: []string{"loc-a"},
+		Schedule:    "manual",
+		Profil:      "SUMMER_TREKKING",
+		HourFrom:    8,
+		HourTo:      17,
+		Empfaenger:  []string{"a@example.com"},
+		AlertChannelThresholds: &model.AlertChannelThresholdsConfig{
+			Email:      alertThresholdStrPtr("MODERATE"),
+			PremiumSms: alertThresholdStrPtr("HIGH"),
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := s.WithUser("user1").SaveComparePresets([]model.ComparePreset{original}); err != nil {
+		t.Fatalf("SaveComparePresets: %v", err)
+	}
+
+	// PUT aendert NUR email, premium_sms fehlt im Unterobjekt komplett.
+	body := map[string]interface{}{
+		"name":         "PremiumSms-Threshold-Test",
+		"schedule":     "manual",
+		"profil":       "SUMMER_TREKKING",
+		"hour_from":    8,
+		"hour_to":      17,
+		"location_ids": []string{"loc-a"},
+		"empfaenger":   []string{"a@example.com"},
+		"alert_channel_thresholds": map[string]interface{}{
+			"email": "LOW",
+		},
+	}
+	buf, _ := json.Marshal(body)
+
+	r := chi.NewRouter()
+	r.Put("/api/compare/presets/{id}", UpdateComparePresetHandler(s))
+	req := httptest.NewRequest(http.MethodPut, "/api/compare/presets/cp-1701-thr-premium", bytes.NewReader(buf))
+	req.Header.Set("Content-Type", "application/json")
+	req = addUserToContext(req, "user1")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	loaded, err := s.WithUser("user1").LoadComparePresets()
+	if err != nil {
+		t.Fatalf("LoadComparePresets: %v", err)
+	}
+	p := loaded[0]
+	if p.AlertChannelThresholds == nil || p.AlertChannelThresholds.Email == nil ||
+		*p.AlertChannelThresholds.Email != "LOW" {
+		t.Fatalf("expected email=LOW applied, got %+v", p.AlertChannelThresholds)
+	}
+	if p.AlertChannelThresholds.PremiumSms == nil || *p.AlertChannelThresholds.PremiumSms != "HIGH" {
+		t.Errorf(
+			"premium_sms erased by email-only PUT, expected HIGH (unangetastet), got %+v",
+			p.AlertChannelThresholds.PremiumSms,
+		)
+	}
+}
+
 // F002 (Adversary HIGH, Fix-Loop 1): der bestehende AC-10-Test oben deckt nur
 // eine Merge-Richtung ab (Body traegt telegram, prueft dass email erhalten
 // bleibt) — Email und Sms als Preserve-Zeilen (compare_preset.go:425-430)

--- a/internal/handler/compare_preset_official_alerts_test.go
+++ b/internal/handler/compare_preset_official_alerts_test.go
@@ -448,6 +448,87 @@ func TestUpdateComparePreset_ChannelTogglesRoundtrip(t *testing.T) {
 	}
 }
 
+// Issue #1701 (S2b, D8): send_premium_sms ist ein neues, eigenes Kanal-Opt-
+// in-Feld (kein alert_channels-Sub-Objekt im Ortsvergleich) — Roundtrip UND
+// RMW-Erhalt, wenn ein spaeterer PUT das Feld nicht mitschickt.
+func TestUpdateComparePreset_SendPremiumSmsRoundtripAndPreserved(t *testing.T) {
+	s := newTestStore(t)
+
+	original := model.ComparePreset{
+		ID:          "cp-premium-sms-1",
+		Name:        "PremiumSms-Test",
+		UserID:      "user1",
+		LocationIDs: []string{"loc-a"},
+		Schedule:    "manual",
+		Profil:      "SUMMER_TREKKING",
+		HourFrom:    8,
+		HourTo:      17,
+		Empfaenger:  []string{"a@example.com"},
+		CreatedAt:   time.Now().UTC(),
+	}
+	if err := s.WithUser("user1").SaveComparePresets([]model.ComparePreset{original}); err != nil {
+		t.Fatalf("SaveComparePresets: %v", err)
+	}
+
+	// Erster PUT: send_premium_sms explizit gesetzt.
+	firstBody := map[string]interface{}{
+		"name": "PremiumSms-Test", "schedule": "manual", "profil": "SUMMER_TREKKING",
+		"hour_from": 8, "hour_to": 17, "location_ids": []string{"loc-a"},
+		"empfaenger": []string{"a@example.com"}, "send_premium_sms": true,
+	}
+	firstBuf, _ := json.Marshal(firstBody)
+
+	r := chi.NewRouter()
+	r.Put("/api/compare/presets/{id}", UpdateComparePresetHandler(s))
+	firstReq := httptest.NewRequest(http.MethodPut, "/api/compare/presets/cp-premium-sms-1", bytes.NewReader(firstBuf))
+	firstReq.Header.Set("Content-Type", "application/json")
+	firstReq = addUserToContext(firstReq, "user1")
+	firstW := httptest.NewRecorder()
+	r.ServeHTTP(firstW, firstReq)
+	if firstW.Code != http.StatusOK {
+		t.Fatalf("expected 200 on first PUT, got %d: %s", firstW.Code, firstW.Body.String())
+	}
+
+	afterFirst, err := s.WithUser("user1").LoadComparePresets()
+	if err != nil {
+		t.Fatalf("LoadComparePresets after first PUT: %v", err)
+	}
+	if afterFirst[0].SendPremiumSms == nil || *afterFirst[0].SendPremiumSms != true {
+		t.Fatalf("expected send_premium_sms=true persisted, got %v", afterFirst[0].SendPremiumSms)
+	}
+
+	// Zweiter PUT: send_premium_sms fehlt im Body -- der Bestandswert (true)
+	// muss erhalten bleiben (RMW-Kontrakt, kein Replace).
+	secondBody := map[string]interface{}{
+		"name": "PremiumSms-Test (umbenannt)", "schedule": "manual", "profil": "SUMMER_TREKKING",
+		"hour_from": 8, "hour_to": 17, "location_ids": []string{"loc-a"},
+		"empfaenger": []string{"a@example.com"},
+	}
+	secondBuf, _ := json.Marshal(secondBody)
+	secondReq := httptest.NewRequest(http.MethodPut, "/api/compare/presets/cp-premium-sms-1", bytes.NewReader(secondBuf))
+	secondReq.Header.Set("Content-Type", "application/json")
+	secondReq = addUserToContext(secondReq, "user1")
+	secondW := httptest.NewRecorder()
+	r.ServeHTTP(secondW, secondReq)
+	if secondW.Code != http.StatusOK {
+		t.Fatalf("expected 200 on second PUT, got %d: %s", secondW.Code, secondW.Body.String())
+	}
+
+	loaded, err := s.WithUser("user1").LoadComparePresets()
+	if err != nil {
+		t.Fatalf("LoadComparePresets after second PUT: %v", err)
+	}
+	if loaded[0].SendPremiumSms == nil || *loaded[0].SendPremiumSms != true {
+		t.Errorf(
+			"RMW leak: send_premium_sms erased by a PUT that omitted the field, "+
+				"expected true (unangetastet), got %v", loaded[0].SendPremiumSms,
+		)
+	}
+	if loaded[0].Name != "PremiumSms-Test (umbenannt)" {
+		t.Errorf("expected name updated, got %q", loaded[0].Name)
+	}
+}
+
 // AC-5 (T3): Partieller PUT (nur official_alert_triggers_enabled) erhaelt
 // alert_cooldown_minutes UND die beiden anderen neuen Felder (RMW-Merge).
 func TestUpdateComparePreset_PartialPutPreservesTriggerAndChannelsAndCooldown(t *testing.T) {

--- a/internal/handler/trip.go
+++ b/internal/handler/trip.go
@@ -219,8 +219,10 @@ type tripUpdateRequest struct {
 	OfficialWarnings *model.OfficialWarningsConfig `json:"official_warnings,omitempty"`
 	// AlertChannels — Issue #1258 Scheibe S3 (D2), RMW-Kontrakt analog
 	// OfficialWarnings (nil = im Body nicht gesendet -> bestehender Wert
-	// bleibt erhalten). All-or-nothing: kein Feld-Level-Merge noetig, der
-	// Client sendet immer alle drei Kanaele explizit.
+	// bleibt erhalten) PLUS Feld-Level-Merge innerhalb des Unterobjekts seit
+	// Issue #1701 (S2b, D3) -- die fruehere All-or-nothing-Praemisse ist mit
+	// dem vierten Feld PremiumSms abgeloest (fehlt ein Feld im Body, bleibt
+	// dessen Bestandswert erhalten statt geloescht zu werden).
 	AlertChannels *model.AlertChannelsConfig `json:"alert_channels,omitempty"`
 	// AlertChannelThresholds — Issue #1461 S3b-2a, RMW-Kontrakt analog
 	// OfficialWarnings (nil = im Body nicht gesendet -> bestehender Wert
@@ -360,18 +362,34 @@ func UpdateTripHandler(s *store.Store) http.HandlerFunc {
 			}
 			existing.OfficialWarnings = req.OfficialWarnings
 		}
-		// Issue #1258 Scheibe S3 (D2) — RMW-Merge analog OfficialWarnings.
-		// All-or-nothing: der Client sendet immer alle drei Kanaele explizit,
-		// daher genuegt der Pointer-Ersatz (kein Feld-Level-Merge wie bei
-		// OfficialWarnings.Sources noetig).
+		// Issue #1258 Scheibe S3 (D2), Issue #1701 (S2b, D3) — RMW-Merge
+		// analog OfficialWarnings. Die fruehere All-or-nothing-Praemisse
+		// entfaellt mit dem vierten Feld PremiumSms: Feld-Level-Merge
+		// INNERHALB des Unterobjekts (Muster AlertChannelThresholds direkt
+		// darunter) -- fehlt im Body ein Feld, bleibt dessen Bestandswert
+		// erhalten statt dass das ganze Unterobjekt ersetzt wird (AC-7).
 		if req.AlertChannels != nil {
+			if req.AlertChannels.Email == nil && existing.AlertChannels != nil {
+				req.AlertChannels.Email = existing.AlertChannels.Email
+			}
+			if req.AlertChannels.Telegram == nil && existing.AlertChannels != nil {
+				req.AlertChannels.Telegram = existing.AlertChannels.Telegram
+			}
+			if req.AlertChannels.Sms == nil && existing.AlertChannels != nil {
+				req.AlertChannels.Sms = existing.AlertChannels.Sms
+			}
+			if req.AlertChannels.PremiumSms == nil && existing.AlertChannels != nil {
+				req.AlertChannels.PremiumSms = existing.AlertChannels.PremiumSms
+			}
 			existing.AlertChannels = req.AlertChannels
 		}
 		// Issue #1461 S3b-2a — ZWEI Ebenen Datenverlustschutz (Pflicht, kein
 		// Kann): Top-Level-nil-Erbe (dieses if) UND Feld-Level-Merge INNERHALB
-		// des Unterobjekts (die drei folgenden ifs, Muster OfficialWarnings.
+		// des Unterobjekts (die vier folgenden ifs, Muster OfficialWarnings.
 		// Sources F002) -- fehlt im Body nur ein Kanal, bleibt dessen
 		// Bestandswert erhalten statt dass das ganze Unterobjekt ersetzt wird.
+		// PremiumSms (Issue #1701 S2b, D6): viertes Geschwisterfeld,
+		// identisches Muster.
 		if req.AlertChannelThresholds != nil {
 			if req.AlertChannelThresholds.Email == nil && existing.AlertChannelThresholds != nil {
 				req.AlertChannelThresholds.Email = existing.AlertChannelThresholds.Email
@@ -381,6 +399,9 @@ func UpdateTripHandler(s *store.Store) http.HandlerFunc {
 			}
 			if req.AlertChannelThresholds.Sms == nil && existing.AlertChannelThresholds != nil {
 				req.AlertChannelThresholds.Sms = existing.AlertChannelThresholds.Sms
+			}
+			if req.AlertChannelThresholds.PremiumSms == nil && existing.AlertChannelThresholds != nil {
+				req.AlertChannelThresholds.PremiumSms = existing.AlertChannelThresholds.PremiumSms
 			}
 			existing.AlertChannelThresholds = req.AlertChannelThresholds
 		}

--- a/internal/handler/trip_alert_channel_thresholds_test.go
+++ b/internal/handler/trip_alert_channel_thresholds_test.go
@@ -130,6 +130,62 @@ func TestUpdateTripHandler_AlertChannelThresholdsFieldLevelMergePreservesUntouch
 	}
 }
 
+// AC-7 fuer Premium-SMS (#1701 S2b, D6): vierter Schwellenwert-Fall,
+// identisches Muster wie TestUpdateTripHandler_AlertChannelThresholdsField
+// LevelMergePreservesUntouchedChannel oben, nur fuer das neue Geschwister-
+// feld PremiumSms statt Email/Telegram/Sms.
+func TestUpdateTripHandler_AlertChannelThresholdsPremiumSmsFieldLevelMerge(t *testing.T) {
+	s := newTestStore(t)
+	trip := model.Trip{
+		ID:   "trip-1701-thr-premium",
+		Name: "PremiumSms-Threshold-Test",
+		Stages: []model.Stage{{
+			ID: "S1", Name: "D1", Date: "2026-07-15",
+			Waypoints: []model.Waypoint{{ID: "W1", Name: "P", Lat: 47.0, Lon: 11.0, ElevationM: 500}},
+		}},
+		AlertChannelThresholds: &model.AlertChannelThresholdsConfig{
+			Email: strPtr("MODERATE"), PremiumSms: strPtr("HIGH"),
+		},
+	}
+	if err := s.SaveTrip(&trip); err != nil {
+		t.Fatalf("SaveTrip: %v", err)
+	}
+
+	// PUT aendert NUR email, premium_sms fehlt im Unterobjekt komplett.
+	body := map[string]interface{}{
+		"alert_channel_thresholds": map[string]interface{}{"email": "LOW"},
+	}
+	buf, _ := json.Marshal(body)
+
+	r := chi.NewRouter()
+	r.Put("/api/trips/{id}", UpdateTripHandler(s))
+	req := httptest.NewRequest(http.MethodPut, "/api/trips/trip-1701-thr-premium", bytes.NewReader(buf))
+	req.Header.Set("Content-Type", "application/json")
+	req = addUserToContext(req, "test")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	loaded, err := s.LoadTrip("trip-1701-thr-premium")
+	if err != nil {
+		t.Fatalf("LoadTrip: %v", err)
+	}
+	if loaded.AlertChannelThresholds == nil || loaded.AlertChannelThresholds.Email == nil ||
+		*loaded.AlertChannelThresholds.Email != "LOW" {
+		t.Fatalf("expected email=LOW applied, got %+v", loaded.AlertChannelThresholds)
+	}
+	if loaded.AlertChannelThresholds.PremiumSms == nil ||
+		*loaded.AlertChannelThresholds.PremiumSms != "HIGH" {
+		t.Errorf(
+			"premium_sms erased by email-only PUT, expected HIGH (unangetastet), got %+v",
+			loaded.AlertChannelThresholds.PremiumSms,
+		)
+	}
+}
+
 // Gegenprobe: ein neu angelegter Trip ohne alert_channel_thresholds bleibt
 // nil (Startwert "LOW" je Kanal wird von Python code-seitig angenommen,
 // nicht hier persistiert).

--- a/internal/handler/trip_alert_channels_test.go
+++ b/internal/handler/trip_alert_channels_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/henemm/gregor-api/internal/model"
 )
 
+func boolPtr(b bool) *bool { return &b }
+
 // AC-26: PUT nur mit alert_channels persistiert das Feld UND laesst uebrige
 // Trip-Felder (Name, Stages, ReportConfig, Corridors) unangetastet.
 func TestUpdateTripHandler_AlertChannelsRMW(t *testing.T) {
@@ -62,9 +64,9 @@ func TestUpdateTripHandler_AlertChannelsRMW(t *testing.T) {
 	}
 
 	if loaded.AlertChannels == nil ||
-		loaded.AlertChannels.Email != false ||
-		loaded.AlertChannels.Telegram != true ||
-		loaded.AlertChannels.Sms != false {
+		loaded.AlertChannels.Email == nil || *loaded.AlertChannels.Email != false ||
+		loaded.AlertChannels.Telegram == nil || *loaded.AlertChannels.Telegram != true ||
+		loaded.AlertChannels.Sms == nil || *loaded.AlertChannels.Sms != false {
 		t.Fatalf("expected alert_channels={email:false,telegram:true,sms:false}, got %+v", loaded.AlertChannels)
 	}
 
@@ -94,7 +96,9 @@ func TestUpdateTripHandler_AlertChannelsPreservedWhenBodyOmitsIt(t *testing.T) {
 			ID: "S1", Name: "D1", Date: "2026-07-15",
 			Waypoints: []model.Waypoint{{ID: "W1", Name: "P", Lat: 47.0, Lon: 11.0, ElevationM: 500}},
 		}},
-		AlertChannels: &model.AlertChannelsConfig{Email: false, Telegram: true, Sms: false},
+		AlertChannels: &model.AlertChannelsConfig{
+			Email: boolPtr(false), Telegram: boolPtr(true), Sms: boolPtr(false),
+		},
 	}
 	if err := s.SaveTrip(&trip); err != nil {
 		t.Fatalf("SaveTrip: %v", err)
@@ -119,11 +123,99 @@ func TestUpdateTripHandler_AlertChannelsPreservedWhenBodyOmitsIt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadTrip: %v", err)
 	}
-	if loaded.AlertChannels == nil || loaded.AlertChannels.Email != false ||
-		loaded.AlertChannels.Telegram != true || loaded.AlertChannels.Sms != false {
+	if loaded.AlertChannels == nil ||
+		loaded.AlertChannels.Email == nil || *loaded.AlertChannels.Email != false ||
+		loaded.AlertChannels.Telegram == nil || *loaded.AlertChannels.Telegram != true ||
+		loaded.AlertChannels.Sms == nil || *loaded.AlertChannels.Sms != false {
 		t.Errorf("alert_channels erased by PUT without field: expected {email:false,telegram:true,sms:false}, got %+v", loaded.AlertChannels)
 	}
 	if loaded.Name != "AlertChannels-Preserve-Test (umbenannt)" {
 		t.Errorf("expected name updated, got %q", loaded.Name)
+	}
+}
+
+// AC-7 (#1701 S2b): PUT eines aelteren Frontend-Builds ohne das vierte Feld
+// "premium_sms" darf einen zuvor gesetzten Premium-SMS-Wert NICHT auf false
+// zuruecksetzen -- Feld-Level-Merge INNERHALB von AlertChannelsConfig
+// (Muster AlertChannelThresholds, D3 der Spec). Zwei aufeinanderfolgende
+// PUTs: der erste setzt alle vier Felder, der zweite schickt nur drei.
+func TestUpdateTripHandler_AlertChannels_FourthFieldMissingInBody_PreservesExistingValue(t *testing.T) {
+	s := newTestStore(t)
+	trip := model.Trip{
+		ID:   "trip-1701-ac7",
+		Name: "AC7-1701-Test",
+		Stages: []model.Stage{{
+			ID: "S1", Name: "D1", Date: "2026-07-15",
+			Waypoints: []model.Waypoint{{ID: "W1", Name: "P", Lat: 47.0, Lon: 11.0, ElevationM: 500}},
+		}},
+	}
+	if err := s.SaveTrip(&trip); err != nil {
+		t.Fatalf("SaveTrip: %v", err)
+	}
+
+	r := chi.NewRouter()
+	r.Put("/api/trips/{id}", UpdateTripHandler(s))
+
+	// Erster PUT: alle vier Felder explizit gesetzt, inkl. premium_sms=true.
+	firstBody := map[string]interface{}{
+		"alert_channels": map[string]interface{}{
+			"email": true, "telegram": false, "sms": true, "premium_sms": true,
+		},
+	}
+	firstBuf, _ := json.Marshal(firstBody)
+	firstReq := httptest.NewRequest(http.MethodPut, "/api/trips/trip-1701-ac7", bytes.NewReader(firstBuf))
+	firstReq.Header.Set("Content-Type", "application/json")
+	firstReq = addUserToContext(firstReq, "test")
+	firstW := httptest.NewRecorder()
+	r.ServeHTTP(firstW, firstReq)
+	if firstW.Code != http.StatusOK {
+		t.Fatalf("expected 200 on first PUT, got %d: %s", firstW.Code, firstW.Body.String())
+	}
+
+	afterFirst, err := s.LoadTrip("trip-1701-ac7")
+	if err != nil {
+		t.Fatalf("LoadTrip after first PUT: %v", err)
+	}
+	if afterFirst.AlertChannels == nil || afterFirst.AlertChannels.PremiumSms == nil ||
+		*afterFirst.AlertChannels.PremiumSms != true {
+		t.Fatalf("expected premium_sms=true after first PUT, got %+v", afterFirst.AlertChannels)
+	}
+
+	// Zweiter PUT: wie ein aelteres Frontend-Build — nur drei Felder, kein
+	// premium_sms im Body.
+	secondBody := map[string]interface{}{
+		"alert_channels": map[string]interface{}{
+			"email": false, "telegram": true, "sms": false,
+		},
+	}
+	secondBuf, _ := json.Marshal(secondBody)
+	secondReq := httptest.NewRequest(http.MethodPut, "/api/trips/trip-1701-ac7", bytes.NewReader(secondBuf))
+	secondReq.Header.Set("Content-Type", "application/json")
+	secondReq = addUserToContext(secondReq, "test")
+	secondW := httptest.NewRecorder()
+	r.ServeHTTP(secondW, secondReq)
+	if secondW.Code != http.StatusOK {
+		t.Fatalf("expected 200 on second PUT, got %d: %s", secondW.Code, secondW.Body.String())
+	}
+
+	loaded, err := s.LoadTrip("trip-1701-ac7")
+	if err != nil {
+		t.Fatalf("LoadTrip after second PUT: %v", err)
+	}
+	// Die drei explizit gesendeten Felder wurden uebernommen.
+	if loaded.AlertChannels == nil ||
+		loaded.AlertChannels.Email == nil || *loaded.AlertChannels.Email != false ||
+		loaded.AlertChannels.Telegram == nil || *loaded.AlertChannels.Telegram != true ||
+		loaded.AlertChannels.Sms == nil || *loaded.AlertChannels.Sms != false {
+		t.Fatalf("expected the three explicitly sent fields applied, got %+v", loaded.AlertChannels)
+	}
+	// AC-7: premium_sms fehlte im zweiten Body -- der Bestandswert (true)
+	// MUSS erhalten bleiben, NICHT still auf false zurueckgesetzt werden.
+	if loaded.AlertChannels.PremiumSms == nil || *loaded.AlertChannels.PremiumSms != true {
+		t.Errorf(
+			"AC-7: premium_sms erased by a PUT that omitted the fourth field "+
+				"(simulating an older frontend build) -- expected true (unangetastet), got %+v",
+			loaded.AlertChannels.PremiumSms,
+		)
 	}
 }

--- a/internal/model/compare_preset.go
+++ b/internal/model/compare_preset.go
@@ -90,6 +90,11 @@ type ComparePreset struct {
 	OfficialWarnings *OfficialWarningsConfig `json:"official_warnings,omitempty"`
 	SendTelegram     *bool                   `json:"send_telegram,omitempty"`
 	SendSms          *bool                   `json:"send_sms,omitempty"`
+	// SendPremiumSms — Issue #1701 (S2b, D8): Premium-SMS-Kanal-Opt-in fuer
+	// den Ortsvergleich, eigenes Feld statt Wiederverwendung (der Ortsvergleich
+	// hat kein alert_channels-Sub-Objekt wie der Trip, die Kanaele sind flache
+	// Top-Level-Felder). Pointer-Pattern wie SendTelegram/SendSms daneben.
+	SendPremiumSms *bool `json:"send_premium_sms,omitempty"`
 	// AlertChannelThresholds — Issue #1461 S3b-2b, additives Geschwisterfeld
 	// (bewusst NICHT in AlertChannels/OfficialWarnings) fuer die je Kanal
 	// eingestellte Dringlichkeits-Schwelle. Bestehender Typ, selbes Package

--- a/internal/model/trip.go
+++ b/internal/model/trip.go
@@ -182,27 +182,35 @@ type OfficialWarningsConfig struct {
 
 // AlertChannelsConfig — Issue #1258 Scheibe S3 (D2), additives Trip-Kanal-
 // Set fuer die Alert-Zustellung (Pointer-Feld-Pattern analog
-// OfficialWarningsConfig). All-or-nothing: alle drei Felder werden vom
-// Client immer explizit gesendet (kein Feld-Level-Merge noetig).
+// OfficialWarningsConfig).
+//
+// Issue #1701 (S2b, D3): die fruehere "All-or-nothing"-Praemisse ("alle drei
+// Felder werden vom Client immer explizit gesendet, kein Feld-Level-Merge
+// noetig") entfaellt mit dem VIERTEN Feld PremiumSms -- die Oberflaeche
+// (S3) kennt es noch gar nicht, ein PUT eines alten Frontend-Builds wuerde
+// es sonst bei JEDEM Speichern als Zero-Value stillschweigend abschalten
+// (Muster BUG-DATALOSS-GR221, #102). Alle vier Felder sind deshalb `*bool`
+// und werden im Handler feld-weise gemergt (Vorbild
+// AlertChannelThresholdsConfig direkt darunter, internal/handler/trip.go).
 type AlertChannelsConfig struct {
-	Email    bool `json:"email"`
-	Telegram bool `json:"telegram"`
-	Sms      bool `json:"sms"`
+	Email      *bool `json:"email,omitempty"`
+	Telegram   *bool `json:"telegram,omitempty"`
+	Sms        *bool `json:"sms,omitempty"`
+	PremiumSms *bool `json:"premium_sms,omitempty"`
 }
 
 // AlertChannelThresholdsConfig — Issue #1461 S3b-2a, additives Geschwister-
-// feld zu AlertChannelsConfig (bewusst NICHT darin -- AlertChannelsConfig
-// wird beim Speichern heute als Ganzes ersetzt, "all-or-nothing"; ein Client
-// ohne Kenntnis der Schwelle wuerde sie sonst bei jedem Speichern still
-// loeschen). Je Kanal die Dringlichkeits-Schwelle als String-Pointer
-// ("LOW"|"MODERATE"|"HIGH"), NICHT bool wie AlertChannelsConfig -- Pointer
-// statt Wert, damit "Kanal fehlt im Body" (nil, Feld-Level-Merge bewahrt den
-// Bestandswert) von "Kanal explizit auf einen Wert gesetzt" unterscheidbar
-// bleibt (internal/handler/trip.go).
+// feld zu AlertChannelsConfig. Je Kanal die Dringlichkeits-Schwelle als
+// String-Pointer ("LOW"|"MODERATE"|"HIGH") -- Pointer statt Wert, damit
+// "Kanal fehlt im Body" (nil, Feld-Level-Merge bewahrt den Bestandswert)
+// von "Kanal explizit auf einen Wert gesetzt" unterscheidbar bleibt
+// (internal/handler/trip.go). PremiumSms (Issue #1701 S2b, ADR-0046-
+// Pflicht D6): viertes Geschwisterfeld, identisches Merge-Muster.
 type AlertChannelThresholdsConfig struct {
-	Email    *string `json:"email,omitempty"`
-	Telegram *string `json:"telegram,omitempty"`
-	Sms      *string `json:"sms,omitempty"`
+	Email      *string `json:"email,omitempty"`
+	Telegram   *string `json:"telegram,omitempty"`
+	Sms        *string `json:"sms,omitempty"`
+	PremiumSms *string `json:"premium_sms,omitempty"`
 }
 
 // AlertableMetrics are metrics that can receive an alert rule (delta-based since #817).

--- a/src/services/alert_log.py
+++ b/src/services/alert_log.py
@@ -56,7 +56,7 @@ REASON_FORECAST_CHANGE = "forecast_change"
 REASON_NOWCAST = "nowcast"
 REASON_OFFICIAL_ALERT = "official_alert"
 
-_ALL_CHANNELS = ("email", "telegram", "sms")
+_ALL_CHANNELS = ("email", "telegram", "sms", "premium_sms")
 
 
 def _norm_pairs(pairs: Iterable) -> list[tuple[str, str]]:
@@ -112,17 +112,22 @@ def hazards_from_official_alerts(alerts) -> list[str]:
 
 def _channels_not_sent(
     effective: set[str], delivered: list[str], below_threshold: "set[str] | None" = None,
+    blocked_reason_codes: "dict[str, str] | None" = None,
 ) -> list[dict]:
-    """Je nicht zugestelltem Kanal ein Grund: unter der Kanal-Schwelle (#1461
-    S3b-2a) geht VOR technisch gescheitert, sonst wie bisher: eingeschaltet
+    """Je nicht zugestelltem Kanal ein Grund: ein spezifischer, gebuchter
+    Sperrgrund (D5, #1701) geht VOR der Kanal-Schwelle (#1461 S3b-2a), die
+    wiederum VOR technisch gescheitert geht, sonst wie bisher: eingeschaltet
     und weder below-threshold noch zugestellt -> technisch gescheitert; war
     er aus, hat der Nutzer ihn abgeschaltet."""
     below_threshold = below_threshold or set()
+    blocked_reason_codes = blocked_reason_codes or {}
     result = []
     for channel in _ALL_CHANNELS:
         if channel in delivered:
             continue
-        if channel in below_threshold:
+        if channel in blocked_reason_codes:
+            reason = blocked_reason_codes[channel]
+        elif channel in below_threshold:
             reason = REASON_BELOW_THRESHOLD
         elif channel in effective:
             reason = REASON_DELIVERY_FAILED
@@ -146,6 +151,7 @@ def append_entry(
     sent_channels: Iterable[str],
     reachable_channels: Optional[Iterable[str]] = None,
     below_threshold_channels: Optional[Iterable[str]] = None,
+    blocked_reason_codes: Optional[dict[str, str]] = None,
 ) -> None:
     """Haengt GENAU EINEN Eintrag an das Alarm-Protokoll des Nutzers an.
 
@@ -182,6 +188,13 @@ def append_entry(
     des Nutzers -- die Schwelle filtert nur den tatsaechlichen Versand
     (Aufrufer), nie das, was hier protokolliert wird (rote Linie #638).
 
+    `blocked_reason_codes` (D5, #1701): Kanal -> spezifische Sperr-Kennung
+    (z.B. `premium_sms_no_reply_address`), aus
+    `NotificationResult.blocked_reason_codes` durchgereicht. Ersetzt fuer den
+    betroffenen Kanal den generischen `REASON_DELIVERY_FAILED` in
+    `channels_not_sent` -- ein Kanal OHNE eigenen Eintrag bleibt unveraendert
+    beim generischen Grund (Bestandsinvariante).
+
     Read-Modify-Write ueber die volle Datei: Alt-Eintraege ohne die neuen
     Felder bleiben unveraendert erhalten (AC-14). `metrics` und `hazards`
     werden IMMER beide serialisiert (leer, wenn nicht zutreffend) -- ein
@@ -215,6 +228,7 @@ def append_entry(
         "channels_sent": delivered,
         "channels_not_sent": _channels_not_sent(
             effective, delivered, set(below_threshold_channels or ()),
+            blocked_reason_codes,
         ),
     }
 

--- a/src/services/compare_alert.py
+++ b/src/services/compare_alert.py
@@ -237,6 +237,9 @@ class CompareAlertService:
 
             delivered_all: set[str] = set()
             reachable_all: set[str] = set()
+            # Issue #1701 (S2b, D5): ueber alle Dringlichkeits-Gruppen hinweg
+            # gesammelt, analog `delivered_all`/`reachable_all`.
+            blocked_reason_codes_all: dict[str, str] = {}
             any_sent = False
             finalized_ids: set[str] = set()
             for ids_key, channels in groups_by_ids.items():
@@ -255,6 +258,7 @@ class CompareAlertService:
                 )
                 delivered_all |= set(notif_result.delivered_channels)
                 reachable_all |= set(notif_result.sent_channels)
+                blocked_reason_codes_all.update(notif_result.blocked_reason_codes)
                 if notif_result.sent:
                     any_sent = True
                     finalized_ids |= set(ids_key)
@@ -279,6 +283,7 @@ class CompareAlertService:
                 sent_channels=sorted(delivered_all),
                 reachable_channels=sorted(reachable_all),
                 below_threshold_channels=below_threshold_all,
+                blocked_reason_codes=blocked_reason_codes_all,
             )
             if not any_sent:
                 continue

--- a/src/services/compare_alert_channels.py
+++ b/src/services/compare_alert_channels.py
@@ -22,17 +22,27 @@ nur noch ein duenner Wrapper auf diese Funktion.
 from __future__ import annotations
 
 from app.config import Settings
-from services.user_tier import sms_allowed
+from services.user_tier import premium_sms_allowed, sms_allowed
 
 
 def effective_compare_channels(preset: dict, settings: Settings, user_id: str) -> set[str]:
     """E-Mail immer; Telegram/SMS nur bei Preset-Opt-in UND globaler
-    User-Faehigkeit (bei SMS zusaetzlich Tier-Gate ueber `sms_allowed`)."""
+    User-Faehigkeit (bei SMS zusaetzlich Tier-Gate ueber `sms_allowed`).
+
+    Issue #1701 (S2b, D2): Premium-SMS bewusst OHNE
+    `settings.can_send_premium_sms()` — diese Methode wurde in S2a nach
+    Adversary-Fund F003 entfernt und darf nicht zurueckkehren. Nur Opt-in
+    (`send_premium_sms`) UND Tier-Gate (`premium_sms_allowed`) entscheiden;
+    die Sendebereitschaft selbst prueft ausschliesslich der Kanal zur
+    Sendezeit (Spec D3 der Vorgaenger-Scheibe).
+    """
     channels = {"email"}
     if preset.get("send_telegram") and settings.can_send_telegram():
         channels.add("telegram")
     if preset.get("send_sms") and settings.can_send_sms() and sms_allowed(user_id):
         channels.add("sms")
+    if preset.get("send_premium_sms") and premium_sms_allowed(user_id):
+        channels.add("premium_sms")
     return channels
 
 

--- a/src/services/compare_official_alert.py
+++ b/src/services/compare_official_alert.py
@@ -171,6 +171,7 @@ class CompareOfficialAlertService:
             sent_channels=result.delivered_channels,
             reachable_channels=result.sent_channels,
             below_threshold_channels=suppressed,
+            blocked_reason_codes=result.blocked_reason_codes,
         )
         if not result.sent:
             return False

--- a/src/services/compare_radar_alert.py
+++ b/src/services/compare_radar_alert.py
@@ -202,6 +202,7 @@ class CompareRadarAlertService:
             sent_channels=notif_result.delivered_channels,
             reachable_channels=notif_result.sent_channels,
             below_threshold_channels=suppressed,
+            blocked_reason_codes=notif_result.blocked_reason_codes,
         )
         if not notif_result.sent:
             return False

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -841,6 +841,9 @@ class NotificationService:
 
         sent_channels: list[str] = []
         failed_channels: list[str] = []  # Issue #1459: Alarm-Protokoll
+        # Issue #1701 (S2b, D5): analog `_dispatch_alert_message`.
+        blocked_channels: dict[str, str] = {}
+        blocked_reason_codes: dict[str, str] = {}
 
         if "email" in effective_channels and self._settings.can_send_email():
             sent_channels.append("email")
@@ -893,9 +896,29 @@ class NotificationService:
                 failed_channels.append("sms")
                 logger.error(f"Official alert sms failed for {trip.name}: {e}")
 
+        # Premium-SMS (Garmin inReach, Issue #1701 S2b) — bewusst OHNE
+        # can_send_*()-Bereitschaftsfrage (D2), Sperrgrund geht nach
+        # `blocked_channels`/`blocked_reason_codes` statt `failed_channels`
+        # (kein Transportfehler, s. `_dispatch_alert_message`).
+        if "premium_sms" in effective_channels:
+            sent_channels.append("premium_sms")
+            try:
+                sms_prefix = trip.name.replace(" ", "")
+                premium_text = render_official_alert_sms(
+                    dto_notices, sms_prefix=sms_prefix, tz=alert_tz,
+                )
+                PremiumSmsOutput(self._settings).send(subject="", body=premium_text)
+            except Exception as e:  # noqa: BLE001 — Grund wird Ergebnisfeld
+                blocked_channels["premium_sms"] = str(e)
+                _record_block_reason_code(blocked_reason_codes, "premium_sms", e)
+                failed_channels.append("premium_sms")
+                logger.error(f"Official alert premium-sms failed for {trip.name}: {e}")
+
         return NotificationResult(
             sent=bool(sent_channels), sent_channels=sent_channels,
             failed_channels=failed_channels,
+            blocked_channels=blocked_channels,
+            blocked_reason_codes=blocked_reason_codes,
         )
 
     # TODO(#1207): wird durch den Versand-Orchestrator generalisiert
@@ -1055,6 +1078,9 @@ class NotificationService:
 
         sent_channels: list[str] = []
         failed_channels: list[str] = []  # Issue #1459: Alarm-Protokoll
+        # Issue #1701 (S2b, D5): analog `_dispatch_alert_message`.
+        blocked_channels: dict[str, str] = {}
+        blocked_reason_codes: dict[str, str] = {}
         if "email" in effective_channels and self._settings.can_send_email():
             if not self._dispatch_compare_official_email(
                 preset_name, subject, html, mail_sink
@@ -1074,10 +1100,24 @@ class NotificationService:
             ):
                 failed_channels.append("sms")
             sent_channels.append("sms")
+        # Premium-SMS (Garmin inReach, Issue #1701 S2b) — bewusst OHNE
+        # can_send_*()-Bereitschaftsfrage (D2), Sperrgrund geht nach
+        # `blocked_channels`/`blocked_reason_codes` statt `failed_channels`.
+        # Append NACH dem Helfer-Aufruf (wie bei email/telegram/sms in dieser
+        # Funktion) — der Erfolgsmarker steht erst, nachdem die Tat versucht
+        # wurde, nicht davor (Klasse 1c, s. `test_success_status_guard.py`).
+        if "premium_sms" in effective_channels:
+            if not self._dispatch_compare_official_premium_sms(
+                preset_name, dto_notices, alert_tz, blocked_channels, blocked_reason_codes,
+            ):
+                failed_channels.append("premium_sms")
+            sent_channels.append("premium_sms")
 
         return NotificationResult(
             sent=bool(sent_channels), sent_channels=sent_channels,
             failed_channels=failed_channels,
+            blocked_channels=blocked_channels,
+            blocked_reason_codes=blocked_reason_codes,
         )
 
     def _dispatch_compare_official_email(
@@ -1153,6 +1193,30 @@ class NotificationService:
                 SMSOutput(self._settings).send(subject="", body=sms_text)
         except Exception as e:
             logger.error(f"Compare official alert sms failed for {preset_name}: {e}")
+            return False
+        return True
+
+    def _dispatch_compare_official_premium_sms(
+        self, preset_name: str, dto_notices: list, alert_tz: ZoneInfo,
+        blocked_channels: dict[str, str], blocked_reason_codes: dict[str, str],
+    ) -> bool:
+        """Issue #1701 (S2b, Vorbild `_dispatch_compare_official_sms`):
+        `True`, wenn der Transport ohne Fehler durchlief. Eine bewusste
+        Sperre (keine/veraltete Rueckadresse) landet zusaetzlich in
+        `blocked_channels`/`blocked_reason_codes` (D5) — kein
+        Transportfehler."""
+        from output.renderers.alert.official_alerts import render_official_alert_sms
+
+        try:
+            sms_prefix = preset_name.replace(" ", "")
+            premium_text = render_official_alert_sms(
+                dto_notices, sms_prefix=sms_prefix, tz=alert_tz,
+            )
+            PremiumSmsOutput(self._settings).send(subject="", body=premium_text)
+        except Exception as e:  # noqa: BLE001 — Grund wird Ergebnisfeld
+            blocked_channels["premium_sms"] = str(e)
+            _record_block_reason_code(blocked_reason_codes, "premium_sms", e)
+            logger.error(f"Compare official alert premium-sms failed for {preset_name}: {e}")
             return False
         return True
 
@@ -1291,6 +1355,12 @@ class NotificationService:
 
         sent_channels: list[str] = []
         failed_channels: list[str] = []
+        # Issue #1701 (S2b, D5): Kanal -> Grund, warum Premium-SMS NICHT
+        # zugestellt wurde (bewusste Sperre, nicht Transportfehler) — an den
+        # Aufrufer durchgereicht, der es an `alert_log.append_entry()`
+        # weiterreicht (D5).
+        blocked_channels: dict[str, str] = {}
+        blocked_reason_codes: dict[str, str] = {}
         # Issue #1467 S2 AG3a: bleibt True fuer alle Aufrufer ohne
         # `telegram_groups` (unveraendertes Verhalten). Nur der Fan-out-Zweig
         # unten setzt ihn bei einer Teilzustellung auf False (AC-25c).
@@ -1298,7 +1368,16 @@ class NotificationService:
 
         def _log_error(channel: str, e: Exception) -> None:
             failed_channels.append(channel)  # Issue #1459: Alarm-Protokoll
-            label = {"email": "Email", "telegram": "Telegram", "sms": "SMS"}[channel]
+            # D4-Fund (#1701): harter Dict-Zugriff ohne Rueckfall stuerzte
+            # bei einem gescheiterten Premium-SMS-Versand INNERHALB der
+            # Fehlerbehandlung selbst ab (KeyError) und riss alle NACH
+            # Premium-SMS liegenden Kanaele mit -- aus einem Teilausfall
+            # wurde ein Totalausfall. `.get()` mit Fallback haertet die
+            # Stelle zusaetzlich gegen jeden kuenftigen fuenften Kanal.
+            label = {
+                "email": "Email", "telegram": "Telegram", "sms": "SMS",
+                "premium_sms": "Premium-SMS",
+            }.get(channel, channel)
             if radar_mode:
                 logger.error(f"Radar alert {channel} failed for {target_name}: {e}")
             else:
@@ -1410,10 +1489,28 @@ class NotificationService:
             except Exception as e:
                 _log_error("sms", e)
 
+        # Premium-SMS (Garmin inReach, Issue #1701 S2b) — bewusst OHNE
+        # vorgeschaltete can_send_*()-Bereitschaftsfrage (D2): die
+        # Sendebereitschaft entscheidet ausschliesslich
+        # `PremiumSmsOutput._resolve_recipient()` zur Sendezeit; eine
+        # bewusste Sperre (keine/veraltete Rueckadresse) landet in
+        # `blocked_channels`/`blocked_reason_codes` statt in
+        # `failed_channels` — sie ist kein Transportfehler.
+        if "premium_sms" in effective_channels:
+            sent_channels.append("premium_sms")
+            try:
+                PremiumSmsOutput(self._settings).send(subject=subject, body=sms_body)
+            except Exception as e:  # noqa: BLE001 — Grund wird Ergebnisfeld
+                blocked_channels["premium_sms"] = str(e)
+                _record_block_reason_code(blocked_reason_codes, "premium_sms", e)
+                _log_error("premium_sms", e)
+
         return NotificationResult(
             sent=bool(sent_channels), sent_channels=sent_channels,
             failed_channels=failed_channels,
             telegram_fully_sent=telegram_fully_sent,
+            blocked_channels=blocked_channels,
+            blocked_reason_codes=blocked_reason_codes,
         )
 
     # ------------------------------------------------------------------

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -30,7 +30,7 @@ from services.point_weather import AlertEvaluationConfig, TripSegmentWeatherAdap
 from services.corridor_threshold import CorridorHit
 from services.throttle_store import ThrottleStore
 from services.trip_day import trip_local_today
-from services.user_tier import sms_allowed
+from services.user_tier import premium_sms_allowed, sms_allowed
 from services.weather_change_detection import WeatherChangeDetectionService
 from utils.timezone import tz_for_coords
 
@@ -317,6 +317,7 @@ class TripAlertService:
             sent_channels=notif_result.delivered_channels,
             reachable_channels=notif_result.sent_channels,
             below_threshold_channels=self._last_below_threshold_channels,
+            blocked_reason_codes=notif_result.blocked_reason_codes,
         )
         delivered = notif_result.sent
         if not delivered:
@@ -843,6 +844,15 @@ class TripAlertService:
             and getattr(config, "send_sms", False) and sms_allowed(self._user_id)
         ):
             channels.add("sms")
+        if (
+            config and getattr(config, "send_premium_sms", False)
+            and premium_sms_allowed(self._user_id)
+        ):
+            # Bewusst OHNE can_send_*()-Bereitschaftsfrage (D2/Spec-Nachtrag
+            # 2026-08-11): Premium-SMS hat keine feste Rufnummer, die
+            # Sendebereitschaft entscheidet ausschliesslich
+            # `PremiumSmsOutput._resolve_recipient()` zur Sendezeit.
+            channels.add("premium_sms")
         return channels
 
     def _briefing_precip_for_onset(
@@ -1040,11 +1050,13 @@ class TripAlertService:
                 logger.debug(f"Radar alert suppressed by double-alert guard for {trip.id}")
                 continue
 
-            # Kein Kanal konfiguriert → kein Alert (nichts zu recorden)
-            can_email = self._settings.can_send_email()
-            can_telegram = self._settings.can_send_telegram()
-            can_sms = self._settings.can_send_sms()
-            if not can_email and not can_telegram and not can_sms:
+            # Kein Kanal konfiguriert → kein Alert (nichts zu recorden).
+            # Spec-Nachtrag 2026-08-11 (#1701, "die achte Stelle"): bewusst
+            # gegen das effektive Kanal-Set gefuehrt statt gegen eine vierte
+            # can_send_*()-Bereitschaftsfrage -- ein Trip mit ausschliesslich
+            # Premium-SMS hat kein `sms_to`, `can_send_sms()` waere False,
+            # obwohl ein funktionsfaehiger Kanal konfiguriert ist.
+            if not self._radar_effective_channels(trip):
                 logger.warning(f"No channel configured; skipping radar alert for {trip.id}")
                 continue
 
@@ -1136,6 +1148,7 @@ class TripAlertService:
                 sent_channels=result.delivered_channels,
                 reachable_channels=result.sent_channels,
                 below_threshold_channels=_radar_suppressed,
+                blocked_reason_codes=result.blocked_reason_codes,
             )
             delivered = result.sent
             if not delivered:
@@ -1451,6 +1464,7 @@ class TripAlertService:
             sent_channels=result.delivered_channels,
             reachable_channels=result.sent_channels,
             below_threshold_channels=_official_suppressed,
+            blocked_reason_codes=result.blocked_reason_codes,
         )
         if result.sent:
             self._record_official_alert_state(trip.id, official_notices)
@@ -1490,7 +1504,8 @@ class TripAlertService:
             # (auch wenn alle drei Kanäle aus sind — bewusst kein {"email"}-Default,
             # der Nutzer hat explizit konfiguriert).
             inherited = {
-                ch for ch in ("email", "telegram", "sms") if trip.alert_channels.get(ch)
+                ch for ch in ("email", "telegram", "sms", "premium_sms")
+                if trip.alert_channels.get(ch)
             }
         else:
             # Legacy-Pfad: E-Mail-Default gilt NUR wenn report_config None ist
@@ -1510,6 +1525,8 @@ class TripAlertService:
 
         if "sms" in channels and not sms_allowed(self._user_id):
             channels = channels - {"sms"}
+        if "premium_sms" in channels and not premium_sms_allowed(self._user_id):
+            channels = channels - {"premium_sms"}
         return channels
 
     @staticmethod
@@ -1524,4 +1541,6 @@ class TripAlertService:
             channels.add("telegram")
         if getattr(config, "send_sms", False):
             channels.add("sms")
+        if getattr(config, "send_premium_sms", False):
+            channels.add("premium_sms")
         return channels

--- a/tests/test_success_status_guard.py
+++ b/tests/test_success_status_guard.py
@@ -1553,6 +1553,14 @@ KNOWN_VIOLATIONS: dict[str, str] = {
     "src/services/notification_service.py::send_official_alert::2": (
         "B14a (#1405/#684) — send_official_alert: dito, SMS."
     ),
+    # Issue #1701 (S2b, D7): vierter Kanal Premium-SMS (Garmin inReach) --
+    # bewusste Ratschen-Anhebung 3->4, NICHT die Buchung hinter den `try`
+    # verschoben (s. Spec D7). `sent_channels`="versucht" bleibt getrennt von
+    # `reachable_channels`="erreichbar" -- dieselbe Marker-vor-der-Tat-Semantik
+    # wie die drei Bestandskanaele.
+    "src/services/notification_service.py::send_official_alert::3": (
+        "B14a (#1405/#684, #1701 D7) — send_official_alert: dito, Premium-SMS."
+    ),
     # --- B14b ENTFERNT (#1459, 2026-08-02): die drei Compare-Versandhelfer
     # _dispatch_compare_official_{email,telegram,sms} hatten keine Rückmeldung —
     # der Aufrufer buchte den Erfolg auf den bloßen Umstand, dass er sie
@@ -1584,6 +1592,11 @@ KNOWN_VIOLATIONS: dict[str, str] = {
     ),
     "src/services/notification_service.py::_dispatch_alert_message::2": (
         "B14c (#1405/#684) — _dispatch_alert_message: dito, SMS."
+    ),
+    # Issue #1701 (S2b, D7): vierter Kanal Premium-SMS, dieselbe Begruendung
+    # wie bei send_official_alert::3 oben.
+    "src/services/notification_service.py::_dispatch_alert_message::3": (
+        "B14c (#1405/#684, #1701 D7) — _dispatch_alert_message: dito, Premium-SMS."
     ),
     "src/services/notification_service.py::send_command_reply_email::0": (
         "B21 (#1405) — send_command_reply_email: EmailOutput, keine Rückmeldung."
@@ -1788,10 +1801,15 @@ SPEC_LISTED_FINDINGS: dict[str, int] = {
     "src/services/scheduler_dispatch_service.py::send_compare_preset": 1,
     # B13 entfernt (#1407) — toter Compare-Heartbeat wurde geloescht statt
     # angeschlossen, der Scanner findet dort nichts mehr.
-    # B14a — sent_channels.append() vor dem try, DREI Kanäle (email/telegram/sms)
-    "src/services/notification_service.py::send_official_alert": 3,
-    # B14c — dito, DREI Kanäle; genutzt von Änderungs-, Radar- und amtlichen Alarmen
-    "src/services/notification_service.py::_dispatch_alert_message": 3,
+    # B14a — sent_channels.append() vor dem try, jetzt VIER Kanäle
+    # (email/telegram/sms/premium_sms). Issue #1701 (S2b, D7): von 3 auf 4
+    # angehoben, NICHT die Buchung hinter den `try` verschoben — die Spec
+    # trifft diese Entscheidung ausdrücklich (Nachzugpflicht dieses
+    # Kommentars).
+    "src/services/notification_service.py::send_official_alert": 4,
+    # B14c — dito, jetzt VIER Kanäle; genutzt von Änderungs-, Radar- und
+    # amtlichen Alarmen. Issue #1701 (S2b, D7).
+    "src/services/notification_service.py::_dispatch_alert_message": 4,
     # B14b entfernt (#1459, 2026-08-02) — die drei Helfer
     # _dispatch_compare_official_{email,telegram,sms} liefern jetzt `bool`, und
     # send_compare_official_alert() WERTET den Rueckgabewert aus (fuellt daraus
@@ -1878,15 +1896,21 @@ def test_scanner_finds_every_spec_listed_finding():
     WHEN der Wächter über die Scanfläche läuft
     THEN schlägt er in JEDER der 33 zugehörigen Funktionen mindestens so oft
     an wie in der Mindestzahl-Tabelle festgelegt (30 Funktionen mit 1, 2
-    Funktionen mit 3, 1 Funktion mit 4), Summe 40.
+    Funktionen mit 4, 1 Funktion mit 4), Summe 42.
+
+    Issue #1701 (S2b, D7): der vierte Versandkanal Premium-SMS hebt die
+    beiden Kanal-Vorkommen in ``send_official_alert`` und
+    ``_dispatch_alert_message`` von je drei auf je vier Treffer an (die
+    Spec-Nachzugpflicht aus Version 1.2 dieses Dokuments) — Summe damit 42
+    statt 40, Funktionsschlüssel-Zahl unverändert 33.
 
     Gemessen an SPEC_LISTED_FINDINGS — einer fest verdrahteten Erwartung aus
     der Spec (``pfad::funktion`` → Mindest-Trefferzahl), NICHT aus
     KNOWN_VIOLATIONS abgeleitet (AC-1 und AC-3 dürfen nicht dieselbe Quelle
     benutzen, sonst prüft der Wächter sich selbst). Gezählt wird im ROHEN
-    Scan-Ergebnis, wo der Zeilenbezug noch vorhanden ist: die drei
+    Scan-Ergebnis, wo der Zeilenbezug noch vorhanden ist: die vier
     Kanal-Vorkommen in ``send_official_alert`` und ``_dispatch_alert_message``
-    sind je drei Treffer, die vier Zweige in ``_handle_query`` je vier — eine
+    sind je vier Treffer, die vier Zweige in ``_handle_query`` je vier — eine
     reine Mengenprüfung bliebe grün, wenn der Scanner davon welche verlöre.
 
     **AC-17 (B18, dateiweites Muster) und AC-18 (B19/B20, Inbound-Reader)
@@ -1903,10 +1927,11 @@ def test_scanner_finds_every_spec_listed_finding():
     # gekürzte Tabelle würde sonst hinter einem grünen Scan verschwinden,
     # und genau das ist der Weg, auf dem Wächter still ihre Schärfe
     # verlieren (Test-Politik: Schwellen nie anpassen, damit etwas grün wird).
-    assert len(SPEC_LISTED_FINDINGS) == 33 and sum(SPEC_LISTED_FINDINGS.values()) == 40, (
+    assert len(SPEC_LISTED_FINDINGS) == 33 and sum(SPEC_LISTED_FINDINGS.values()) == 42, (
         "SPEC_LISTED_FINDINGS weicht von der Spec-Tabelle ab (erwartet 33 "
-        "Funktionsschlüssel, Summe 40 — Version 1.2 minus B13, #1407, minus "
-        "B2, #1447, minus B14b (drei Schlüssel), #1459). Ist: "
+        "Funktionsschlüssel, Summe 42 — Version 1.2 minus B13, #1407, minus "
+        "B2, #1447, minus B14b (drei Schlüssel), #1459, plus zweimal +1 fuer "
+        "den vierten Kanal Premium-SMS, #1701 D7). Ist: "
         f"{len(SPEC_LISTED_FINDINGS)} Schlüssel, Summe "
         f"{sum(SPEC_LISTED_FINDINGS.values())}"
     )

--- a/tests/unit/test_alert_channel_premium_sms.py
+++ b/tests/unit/test_alert_channel_premium_sms.py
@@ -285,6 +285,86 @@ def _official_alert() -> OfficialAlert:
     )
 
 
+# ═══════════════════ Schritt 0: der Radar-Bereitschafts-Guard ═════════════
+# Spec-Nachtrag 2026-08-11 (RED-Phase) -- die ACHTE Ansatzstelle. Die drei
+# AC-1/AC-5-Radar-Tests unten setzen ``sms_gateway_url``/``sms_to`` immer
+# mit und laufen deshalb AM GUARD VORBEI (``can_send_sms()`` wird zufaellig
+# ``True``). Dieser Test ist der einzige in der Datei, der ALLE drei
+# Bestandskanaele technisch unerreichbar macht -- genau der PO-Fall
+# (Huette = nur Satellit, #1667/#1701).
+
+
+def _settings_premium_sms_only(port: int, user_id: str) -> Settings:
+    """Settings mit ALLEN drei Bestandskanaelen technisch unerreichbar --
+    kein SMTP, kein Telegram-Bot, kein ``sms_to`` -- NUR Premium-SMS
+    (geteiltes ``sms_gateway_url``) ist konfiguriert. Jedes Feld ausdruecklich
+    gesetzt (#1477), kein stiller Ruecksprung auf die Prod-.env."""
+    update = {
+        "smtp_host": None, "smtp_user": None, "smtp_pass": None, "mail_to": None,
+        "telegram_bot_token": None, "telegram_chat_id": None,
+        "sms_to": None,
+        "sms_gateway_url": f"http://127.0.0.1:{port}/api/sms",
+        "seven_api_key": "test-stub-key",
+        "seven_sandbox_key": "test-stub-key",
+        "sms_from": None,
+    }
+    return Settings().with_user_profile(user_id).model_copy(update=update)
+
+
+def test_radar_alert_reaches_premium_sms_when_no_other_channel_configured(monkeypatch):
+    """Schritt 0 (Spec-Nachtrag): Given ein Trip hat AUSSCHLIESSLICH
+    Premium-SMS konfiguriert -- keine SMS- (``sms_to`` leer), keine
+    Telegram-, keine E-Mail-Konfiguration / When ein Regenradar-Alarm
+    ausgeloest wird / Then geht der Alarm trotzdem per Premium-SMS hinaus --
+    der Radar-Bereitschafts-Guard darf einen funktionsfaehigen Kanal nicht
+    verwerfen, nur weil die DREI ANDEREN Kanaele technisch unerreichbar sind.
+
+    ROT-Grund (gemessen, ``trip_alert.py:1043-1049``):
+    ``check_radar_alerts()`` prueft VOR jeder Kanal-Set-Aufloesung
+    ``can_send_email() or can_send_telegram() or can_send_sms()`` -- alle
+    drei sind hier bewusst False (kein `sms_to`, kein Telegram-Bot, kein
+    SMTP). Der Alarm wird mit ``continue`` verworfen, BEVOR
+    ``_radar_effective_channels()`` (das den Premium-Zweig kennen wird)
+    ueberhaupt aufgerufen wird -- unabhaengig davon, wie vollstaendig die
+    uebrigen sieben Ansatzstellen umgesetzt sind.
+    """
+    import app.loader as loader
+    from services.radar_service import RadarNowcastService
+    from services.trip_alert import TripAlertService
+
+    uid = _uid("step0-radar-only")
+    _write_profile(uid, tier="premium", reply_to=LEARNED_REPLY_TO)
+    trip = _radar_trip(f"trip-step0-{uuid.uuid4().hex[:6]}", send_premium_sms=True)
+    monkeypatch.setattr(loader, "load_all_trips", lambda **kw: [trip])
+
+    stub = _SevenIoStub()
+    try:
+        settings = _settings_premium_sms_only(stub.port, uid)
+        assert not settings.can_send_email(), "Testvoraussetzung: E-Mail unerreichbar"
+        assert not settings.can_send_telegram(), "Testvoraussetzung: Telegram unerreichbar"
+        assert not settings.can_send_sms(), "Testvoraussetzung: SMS unerreichbar"
+
+        svc = TripAlertService(
+            settings=settings, user_id=uid, throttle_hours=0,
+            radar_service=RadarNowcastService(frame_source=_light_wet_frames),
+            mail_sink=lambda subject, body: None,
+        )
+        sent = svc.check_radar_alerts()
+    finally:
+        stub.stop()
+
+    assert sent >= 1, (
+        f"Schritt 0: der Radar-Alarm muss trotz drei unerreichbarer "
+        f"Bestandskanaele ausgeloest werden, sent={sent}"
+    )
+    hits = stub.to(LEARNED_REPLY_TO)
+    assert len(hits) == 1, (
+        "Schritt 0: erwartet GENAU EINE Premium-SMS an die gelernte "
+        f"Rueckadresse trotz technisch unerreichbarer E-Mail/Telegram/SMS, "
+        f"erhalten: {hits!r} (voller Stub: {stub.received!r})"
+    )
+
+
 # ═══════════════════════════════ AC-1 ═════════════════════════════════════
 
 def test_deviation_alert_reaches_premium_sms_when_opted_in():

--- a/tests/unit/test_alert_channel_premium_sms.py
+++ b/tests/unit/test_alert_channel_premium_sms.py
@@ -1,0 +1,610 @@
+"""RED — Issue #1701 (#1676 Scheibe S2b): Premium-SMS im Trip-Alarmpfad.
+
+Spec: docs/specs/modules/feat_1701_alarm_premium_sms.md
+Abgedeckt: AC-1, AC-2, AC-3, AC-5 (Trip-Teil), AC-6.
+
+TESTPOLITIK (CLAUDE.md "Test-Politik: Zwei Schichten", Kern-Schicht): kein
+Mock-Theater -- kein ``Mock()``/``patch()``/``MagicMock``. Der Versandweg
+wird gegen einen ECHTEN lokalen HTTP-Server geprueft (Vorbild
+``tests/unit/test_premium_sms_versand.py::_SevenIoStub``), kein Test-Double
+der Transport-Klasse. SMS und Premium-SMS teilen sich denselben lokalen
+Stub -- beide Kanaele lesen dieselbe ``sms_gateway_url``
+(``SevenIoChannelBase``, Spec D1 der Vorgaenger-Scheibe S2a) und werden ueber
+den ``to``-Empfaenger unterschieden.
+
+PRUEFORT = WIRKORT (CLAUDE.md): AC-1/AC-2 pruefen sowohl die Rueckgabe der
+Aufloesungsfunktion (``_effective_alert_channels``/``_briefing_channels``)
+ALS AUCH die End-zu-Ende-Zustellung am Stub -- ein Test, der nur eine Seite
+trifft, laesst die andere Haelfte unbewacht (genau der in mehreren Issues
+wiederholte Fehler, den die Spec ausdruecklich benennt).
+
+Pfadregel #1409: kein fester Hauptrepo-Pfad -- alle Zugriffe laufen ueber
+``get_data_dir()`` (pytest-isolierte Datenwurzel, #1133).
+"""
+from __future__ import annotations
+
+import http.server
+import json
+import socket
+import threading
+import urllib.parse
+import uuid
+from datetime import date, datetime, timedelta, timezone
+
+from app.config import Settings
+from app.models import (
+    ChangeSeverity,
+    ForecastMeta,
+    GPXPoint,
+    NormalizedTimeseries,
+    Provider,
+    SegmentWeatherData,
+    SegmentWeatherSummary,
+    TripReportConfig,
+    TripSegment,
+    WeatherChange,
+)
+from app.trip import Stage, Trip, Waypoint
+from services.official_alerts import OfficialAlert
+
+from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
+
+# Feste seven.io-Dienstnummer (S2a, ADR-0049) -- der Premium-Absender.
+PREMIUM_SMS_SENDER = "4916092172595"
+# Von Garmin gelernte Rueckadresse (S1).
+LEARNED_REPLY_TO = "+4915799912345"
+# Settings.sms_to -- darf den Premium-Kanal nie erreichen.
+CONFIG_SMS_TO = "+49000000111"
+LAT, LON = 47.0, 11.0
+
+
+# ---------------------------------------------------------------------------
+# Lokaler seven.io-Stub (echter HTTP-Server, kein Mock) -- bedient SMS UND
+# Premium-SMS, weil beide Kanaele dieselbe `sms_gateway_url` lesen.
+# ---------------------------------------------------------------------------
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class _SevenIoStub:
+    def __init__(self) -> None:
+        self.received: list[dict] = []
+        received = self.received
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(length)
+                data = urllib.parse.parse_qs(body.decode())
+                received.append({k: v[0] for k, v in data.items()})
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"100")
+
+            def log_message(self, *args):  # noqa: D401
+                pass
+
+        self.port = _free_port()
+        self._server = http.server.HTTPServer(("127.0.0.1", self.port), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._server.shutdown()
+
+    def to(self, number: str) -> list[dict]:
+        return [e for e in self.received if e.get("to") == number]
+
+
+class _TelegramStub:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        sent = self.sent
+        counter = {"mid": 6000}
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(length)
+                try:
+                    payload = json.loads(body.decode())
+                except ValueError:
+                    payload = {}
+                sent.append(payload)
+                counter["mid"] += 1
+                resp = json.dumps(
+                    {"ok": True, "result": {"message_id": counter["mid"]}}
+                ).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(resp)
+
+            def log_message(self, *args):  # noqa: D401
+                pass
+
+        self.port = _free_port()
+        self._server = http.server.HTTPServer(("127.0.0.1", self.port), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def stop(self) -> None:
+        self._server.shutdown()
+
+
+def _pin_telegram_stub(monkeypatch, stub: "_TelegramStub") -> None:
+    """Herkunftssperre (#1476) auf 'production' pinnen -- Vorbild
+    ``tests/tdd/test_alert_channel_threshold.py::_pin_telegram_stub``."""
+    import output.channels.telegram as tg_module
+
+    monkeypatch.setattr(tg_module, "running_origin", lambda module_file: "production")
+    monkeypatch.setattr(tg_module, "TELEGRAM_API_BASE", stub.base_url)
+
+
+# ---------------------------------------------------------------------------
+# Fixture-Bausteine
+# ---------------------------------------------------------------------------
+
+def _uid(prefix: str) -> str:
+    return f"tdd-1701-{prefix}-{uuid.uuid4().hex[:6]}"
+
+
+def _write_profile(
+    user_id: str, *, tier: str, reply_to: str | None = None,
+    reply_age: timedelta = timedelta(minutes=5),
+) -> None:
+    """Echtes ``user.json`` -- Feldnamen wie S1 sie ablegt
+    (``premium_sms_reply_to``/``premium_sms_reply_at``, RFC3339-UTC)."""
+    from app.loader import get_data_dir
+
+    path = get_data_dir(user_id)
+    path.mkdir(parents=True, exist_ok=True)
+    profile: dict = {"id": user_id, "tier": tier}
+    if reply_to is not None:
+        stamp = datetime.now(timezone.utc) - reply_age
+        profile["premium_sms_reply_to"] = reply_to
+        profile["premium_sms_reply_at"] = stamp.isoformat().replace("+00:00", "Z")
+    (path / "user.json").write_text(json.dumps(profile), encoding="utf-8")
+
+
+def _settings(port: int, user_id: str, *, telegram_port: int | None = None) -> Settings:
+    """JEDES versandrelevante Feld ausdruecklich gesetzt (#1477) -- kein
+    stiller Ruecksprung auf die Prod-.env des Worktrees."""
+    update = {
+        "sms_gateway_url": f"http://127.0.0.1:{port}/api/sms",
+        "seven_api_key": "test-stub-key",
+        "seven_sandbox_key": "test-stub-key",
+        "sms_to": CONFIG_SMS_TO,
+        "sms_from": None,
+    }
+    if telegram_port is not None:
+        # Test-Modus-Guards (#1288/#1363): im Test-Modus (via tdd-Praefix in
+        # with_user_profile() erzwungen) ist NUR der konfigurierte
+        # Test-Bot-Token/-Chat erlaubt -- Prod- und Test-Wert identisch
+        # gesetzt, analog dem Sandbox-Key-Muster fuer seven.io oben.
+        update["telegram_bot_token"] = "tdd-1701-bot-token"
+        update["telegram_test_bot_token"] = "tdd-1701-bot-token"
+        update["telegram_chat_id"] = "4711"
+        update["telegram_test_chat_id"] = "4711"
+    base = Settings().with_user_profile(user_id)
+    return base.model_copy(update=update)
+
+
+def _weather_segment(segment_id: int | str = 1, **summary_kwargs) -> SegmentWeatherData:
+    now = datetime.now(timezone.utc)
+    seg = TripSegment(
+        segment_id=segment_id,
+        start_point=GPXPoint(lat=LAT, lon=LON, elevation_m=1000),
+        end_point=GPXPoint(lat=LAT + 0.1, lon=LON + 0.1, elevation_m=1500),
+        start_time=now - timedelta(hours=1), end_time=now + timedelta(hours=3),
+        duration_hours=4.0, distance_km=6.0, ascent_m=500, descent_m=0,
+    )
+    return SegmentWeatherData(
+        segment=seg,
+        timeseries=NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="test", grid_res_km=1.0),
+            data=[],
+        ),
+        aggregated=SegmentWeatherSummary(**summary_kwargs),
+        fetched_at=now, provider="openmeteo",
+    )
+
+
+def _change() -> WeatherChange:
+    return WeatherChange(
+        metric="gust_max_kmh", old_value=20.0, new_value=45.0, delta=25.0,
+        threshold=20.0, severity=ChangeSeverity.MODERATE, direction="increase",
+        segment_id="1",
+    )
+
+
+def _base_trip(trip_id: str, *, alert_channels: dict | None = None,
+                report_config: TripReportConfig | None = None) -> Trip:
+    stage = Stage(
+        id="T1", name="Tag 1", date=date.today(),
+        waypoints=[Waypoint(id="W1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0)],
+    )
+    trip = Trip(id=trip_id, name="Premium-Alarm-Trip", stages=[stage], official_warnings=None)
+    trip.report_config = report_config or TripReportConfig(
+        trip_id=trip_id, send_email=False, alert_on_changes=True,
+    )
+    trip.alert_cooldown_minutes = 0
+    trip.official_alert_triggers_enabled = False
+    if alert_channels is not None:
+        trip.alert_channels = alert_channels
+    return trip
+
+
+def _radar_trip(trip_id: str, *, send_premium_sms: bool) -> Trip:
+    arr0, arr1 = active_window_offsets(LAT, LON, -60, 120)
+    wp0 = Waypoint(
+        id="WP0", name="Start", lat=LAT, lon=LON, elevation_m=500.0, arrival_calculated=arr0,
+    )
+    wp1 = Waypoint(
+        id="WP1", name="Ziel", lat=LAT + 0.1, lon=LON + 0.1, elevation_m=600.0,
+        arrival_calculated=arr1,
+    )
+    stage = Stage(id="S1", name="Tag 1", date=stage_date(LAT, LON), waypoints=[wp0, wp1])
+    trip = Trip(id=trip_id, name="AC-1 Radar-Trip", stages=[stage])
+    trip.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=False, send_sms=False, send_telegram=False,
+        send_premium_sms=send_premium_sms,
+    )
+    trip.alert_cooldown_minutes = 0
+    return trip
+
+
+def _light_wet_frames(lat, lon):
+    """DI-Seam (RadarNowcastService.frame_source): leichter, nicht
+    konvektiver Regen mit Onset in 5 Minuten (Vorbild
+    ``tests/tdd/test_alert_channel_threshold.py::_light_wet_frames``)."""
+    from providers.brightsky import RadarFrame
+
+    now = datetime.now(timezone.utc)
+    return [
+        RadarFrame(timestamp=now + timedelta(minutes=5), precip_mm_h=0.5),
+        RadarFrame(timestamp=now + timedelta(minutes=15), precip_mm_h=0.6),
+    ]
+
+
+def _official_alert() -> OfficialAlert:
+    return OfficialAlert(
+        source="test-vigilance", hazard="thunderstorm", level=3,
+        label="Gewitter", valid_from=datetime.now(timezone.utc),
+        valid_to=datetime.now(timezone.utc) + timedelta(hours=6),
+        region_label="Testregion",
+    )
+
+
+# ═══════════════════════════════ AC-1 ═════════════════════════════════════
+
+def test_deviation_alert_reaches_premium_sms_when_opted_in():
+    """AC-1: Given ein Premium-Tier-Nutzer hat ``alert_channels.premium_sms
+    = true`` UND eine gueltige, frische gelernte Rueckadresse / When ein
+    Abweichungsalarm fuer diesen Trip ausgeloest wird / Then geht eine
+    Premium-SMS mit dem Alarmtext an das Geraet hinaus.
+
+    ROT-Grund (gemessen): ``_effective_alert_channels()`` kennt nur das
+    Kanal-Tupel ``("email", "telegram", "sms")`` (``trip_alert.py:1492-1494``)
+    -- ``alert_channels.premium_sms`` wird komplett ignoriert, das
+    Kanal-Set bleibt leer, der Stub bekommt nie einen POST.
+    """
+    from services.trip_alert import TripAlertService
+
+    uid = _uid("ac1-dev")
+    _write_profile(uid, tier="premium", reply_to=LEARNED_REPLY_TO)
+    trip = _base_trip(
+        f"trip-ac1-dev-{uuid.uuid4().hex[:6]}", alert_channels={"premium_sms": True},
+    )
+
+    stub = _SevenIoStub()
+    try:
+        svc = TripAlertService(
+            settings=_settings(stub.port, uid), user_id=uid, throttle_hours=0,
+            mail_sink=lambda subject, body: None,
+        )
+        result = svc._send_alert(trip, [_weather_segment(1)], [_change()])
+    finally:
+        stub.stop()
+
+    hits = stub.to(LEARNED_REPLY_TO)
+    assert len(hits) == 1, (
+        "AC-1: erwartet GENAU EINE Premium-SMS an die gelernte Rueckadresse, "
+        f"erhalten: {hits!r} (voller Stub: {stub.received!r})"
+    )
+    assert hits[0].get("from") == PREMIUM_SMS_SENDER, (
+        f"Absender falsch: {hits[0].get('from')!r}, erwartet {PREMIUM_SMS_SENDER!r}"
+    )
+    assert hits[0].get("text"), "Alarmtext darf nicht leer sein"
+    assert "premium_sms" in result.delivered_channels, (
+        f"'premium_sms' fehlt in delivered_channels: {result.delivered_channels!r}"
+    )
+
+
+def test_radar_alert_reaches_premium_sms_when_opted_in(monkeypatch):
+    """AC-1 (Radar): Given ein Premium-Tier-Nutzer hat im Trip-Briefing
+    ``send_premium_sms=true`` aktiv UND eine frische gelernte Rueckadresse /
+    When ein Regenradar-Alarm ausgeloest wird / Then geht ebenfalls eine
+    Premium-SMS hinaus -- derselbe Kanal, ein STRUKTURELL getrennter
+    Ansatzpunkt (Issue #1467 S3, ``trip_alert.py:825-846``).
+
+    ROT-Grund (gemessen): ``_radar_effective_channels()`` hat keinen
+    ``premium_sms``-Zweig -- die Inline-Kopie kennt nur email/telegram/sms.
+    """
+    import app.loader as loader
+    from services.radar_service import RadarNowcastService
+    from services.trip_alert import TripAlertService
+
+    uid = _uid("ac1-radar")
+    _write_profile(uid, tier="premium", reply_to=LEARNED_REPLY_TO)
+    trip = _radar_trip(f"trip-ac1-radar-{uuid.uuid4().hex[:6]}", send_premium_sms=True)
+    monkeypatch.setattr(loader, "load_all_trips", lambda **kw: [trip])
+
+    stub = _SevenIoStub()
+    try:
+        svc = TripAlertService(
+            settings=_settings(stub.port, uid), user_id=uid, throttle_hours=0,
+            radar_service=RadarNowcastService(frame_source=_light_wet_frames),
+            mail_sink=lambda subject, body: None,
+        )
+        sent = svc.check_radar_alerts()
+    finally:
+        stub.stop()
+
+    assert sent >= 1, f"Voraussetzung: der Radar-Alarm muss ausgeloest sein, sent={sent}"
+    hits = stub.to(LEARNED_REPLY_TO)
+    assert len(hits) == 1, (
+        f"AC-1 (Radar): erwartet GENAU EINE Premium-SMS, erhalten: {hits!r} "
+        f"(voller Stub: {stub.received!r})"
+    )
+
+
+# ═══════════════════════════════ AC-2 ═════════════════════════════════════
+
+def test_legacy_trip_inherits_premium_sms_from_briefing_config():
+    """AC-2: Given ein Trip hat KEIN scharfes ``alert_channels``-Set (None)
+    UND im Trip-Briefing ist ``send_premium_sms=true`` aktiv / When ein
+    Alarm ausgeloest wird / Then erbt der Alarmpfad den Premium-SMS-Kanal
+    automatisch mit -- genauso wie es heute fuer die drei bestehenden
+    Kanaele gilt.
+
+    ROT-Grund (gemessen): ``_briefing_channels()`` liest nur send_email/
+    send_telegram/send_sms -- ``send_premium_sms`` wird nicht abgefragt.
+    """
+    from services.trip_alert import TripAlertService
+
+    uid = _uid("ac2")
+    _write_profile(uid, tier="premium", reply_to=LEARNED_REPLY_TO)
+    trip_id = f"trip-ac2-{uuid.uuid4().hex[:6]}"
+    trip = _base_trip(
+        trip_id,
+        report_config=TripReportConfig(
+            trip_id=trip_id, send_email=False, send_telegram=False, send_sms=False,
+            send_premium_sms=True, alert_on_changes=True,
+        ),
+    )
+    assert trip.alert_channels is None, "Voraussetzung: kein scharfes Kanal-Set gesetzt"
+
+    stub = _SevenIoStub()
+    try:
+        svc = TripAlertService(
+            settings=_settings(stub.port, uid), user_id=uid, throttle_hours=0,
+            mail_sink=lambda subject, body: None,
+        )
+        briefing_channels = svc._briefing_channels(trip.report_config)
+        result = svc._send_alert(trip, [_weather_segment(1)], [_change()])
+    finally:
+        stub.stop()
+
+    assert "premium_sms" in briefing_channels, (
+        f"_briefing_channels() vererbt 'premium_sms' nicht: {briefing_channels!r}"
+    )
+    hits = stub.to(LEARNED_REPLY_TO)
+    assert len(hits) == 1, (
+        f"AC-2: die Vererbung muss End-zu-Ende wirken, erhalten: {hits!r}"
+    )
+    assert "premium_sms" in result.delivered_channels, (
+        f"'premium_sms' fehlt in delivered_channels: {result.delivered_channels!r}"
+    )
+
+
+# ═══════════════════════════════ AC-3 ═════════════════════════════════════
+
+def test_official_trip_alert_reaches_premium_sms():
+    """AC-3: Given Premium-SMS ist im effektiven Kanal-Set eines Trips fuer
+    amtliche Warnungen enthalten / When eine amtliche Warnung eintrifft /
+    Then wird auch dafuer eine Premium-SMS mit dem amtlichen Kurztext
+    versendet -- ``send_official_alert()`` ist eine von
+    ``_dispatch_alert_message`` UNABHAENGIGE Funktion und waere sonst der
+    stille vierte blinde Fleck.
+
+    ROT-Grund (gemessen): ``send_official_alert()`` hat nur drei
+    Kanal-Zweige (email/telegram/sms, ``notification_service.py:845-894``).
+    """
+    from services.notification_service import NotificationService
+
+    uid = _uid("ac3")
+    _write_profile(uid, tier="premium", reply_to=LEARNED_REPLY_TO)
+    trip = _base_trip(f"trip-ac3-{uuid.uuid4().hex[:6]}")
+
+    stub = _SevenIoStub()
+    try:
+        svc = NotificationService(settings=_settings(stub.port, uid), user_id=uid)
+        result = svc.send_official_alert(
+            trip=trip, notices=[(_official_alert(), ["1"])],
+            effective_channels={"email", "premium_sms"},
+            mail_sink=lambda subject, body: None,
+        )
+    finally:
+        stub.stop()
+
+    hits = stub.to(LEARNED_REPLY_TO)
+    assert len(hits) == 1, (
+        f"AC-3: die amtliche Warnung muss auch per Premium-SMS gehen, "
+        f"erhalten: {hits!r} (voller Stub: {stub.received!r})"
+    )
+    assert "premium_sms" in result.sent_channels, (
+        f"'premium_sms' fehlt in sent_channels: {result.sent_channels!r}"
+    )
+
+
+# ═══════════════════════════════ AC-5 (Trip) ══════════════════════════════
+
+_CONTROL_REPLY_TO = "+4915799954321"
+
+
+def test_standard_tier_never_reaches_premium_sms_via_alerts(monkeypatch):
+    """AC-5 (Trip): Given ZWEI Nutzer mit identisch konfiguriertem
+    Premium-SMS-Opt-in in allen drei Alarmpfaden (Abweichung, Radar,
+    amtlich) -- Nutzer A hat Tier ``standard``, Nutzer B (Kontrolle) hat
+    Tier ``premium`` / When bei BEIDEN dieselben drei Alarmpfade ausgeloest
+    werden / Then bleibt Premium-SMS bei Nutzer A in JEDEM der drei Pfade
+    inaktiv, waehrend Nutzer B sie in mindestens einem Pfad bekommt --
+    ``premium_sms_allowed()`` (NICHT ``sms_allowed()``, das ``standard``
+    durchlaesst) entscheidet an jeder Ansatzstelle.
+
+    Warum beide Seiten in EINEM Test stehen (Projektregel, s.
+    ``tests/tdd/test_compare_alert_channel_delivery.py`` Moduldocstring):
+    die stumme Seite (Nutzer A) ist bereits HEUTE gruen, weil Premium-SMS
+    noch NIRGENDS verdrahtet ist (AC-1/AC-2/AC-3 sind rot) -- ein Test nur
+    mit Nutzer A wuerde die Nicht-Implementierung feiern statt das Tier-Gate
+    zu pruefen. Erst die Kontroll-Seite (Nutzer B, MUSS mindestens einmal
+    ankommen) macht den Test scharf und damit heute ROT.
+    """
+    import app.loader as loader
+    from services.trip_alert import TripAlertService
+    from services.user_tier import premium_sms_allowed, sms_allowed
+
+    uid = _uid("ac5-trip")
+    uid_control = _uid("ac5-trip-control")
+    _write_profile(uid, tier="standard", reply_to=LEARNED_REPLY_TO)
+    _write_profile(uid_control, tier="premium", reply_to=_CONTROL_REPLY_TO)
+    assert sms_allowed(uid) is True and premium_sms_allowed(uid) is False, (
+        "Testvoraussetzung: 'standard' darf normale SMS, aber NICHT Premium-SMS"
+    )
+    assert premium_sms_allowed(uid_control) is True, (
+        "Testvoraussetzung Kontrolle: 'premium' darf Premium-SMS"
+    )
+
+    stub = _SevenIoStub()
+    try:
+        settings = _settings(stub.port, uid)
+        settings_control = _settings(stub.port, uid_control)
+
+        for user_id, current_settings in ((uid, settings), (uid_control, settings_control)):
+            trip_dev = _base_trip(
+                f"trip-ac5-dev-{user_id}-{uuid.uuid4().hex[:6]}",
+                alert_channels={"premium_sms": True},
+            )
+            TripAlertService(
+                settings=current_settings, user_id=user_id, throttle_hours=0,
+                mail_sink=lambda subject, body: None,
+            )._send_alert(trip_dev, [_weather_segment(1)], [_change()])
+
+            trip_off = _base_trip(
+                f"trip-ac5-off-{user_id}-{uuid.uuid4().hex[:6]}",
+                alert_channels={"premium_sms": True},
+            )
+            TripAlertService(
+                settings=current_settings, user_id=user_id, throttle_hours=0,
+                mail_sink=lambda subject, body: None,
+            )._send_official_alert_only(trip_off, [(_official_alert(), ["1"])])
+    finally:
+        stub.stop()
+
+    hits_standard = stub.to(LEARNED_REPLY_TO)
+    hits_control = stub.to(_CONTROL_REPLY_TO)
+    assert hits_standard == [], (
+        "AC-5: ein Nutzer mit Tier 'standard' darf in KEINEM der Alarmpfade "
+        f"eine Premium-SMS bekommen, erhalten: {hits_standard!r}"
+    )
+    assert len(hits_control) >= 1, (
+        "AC-5 (Kontrolle): ein Nutzer mit Tier 'premium' MUSS bei identischer "
+        "Konfiguration Premium-SMS bekommen -- sonst beweist die stumme Seite "
+        "oben nur, dass Premium-SMS ueberhaupt nicht verdrahtet ist, nicht "
+        f"dass das Tier-Gate entscheidet. Erhalten: {hits_control!r} "
+        f"(voller Stub: {stub.received!r})"
+    )
+
+
+# ═══════════════════════════════ AC-6 ═════════════════════════════════════
+
+def test_failed_premium_sms_does_not_abort_remaining_channels(monkeypatch):
+    """AC-6: Given ein Alarm geht an mehrere Kanaele gleichzeitig, darunter
+    Premium-SMS, UND der Premium-Versand schlaegt fehl (keine gelernte
+    Rueckadresse) / When der Alarm verarbeitet wird / Then erreichen die
+    uebrigen konfigurierten Kanaele (E-Mail/Telegram/SMS) den Nutzer
+    trotzdem UND der Aufruf selbst bricht NICHT mit einer unbehandelten
+    Ausnahme ab.
+
+    D4-Fund: ``_log_error()`` (``notification_service.py:1301``) indiziert
+    hart in ein Label-Dict ohne 'premium_sms'-Eintrag -- ein gescheiterter
+    Premium-Versand loest dort einen ``KeyError`` INNERHALB der
+    Fehlerbehandlung des ersten Fehlers aus, der Aufruf bricht komplett ab
+    und das Ergebnis (inkl. Protokollierung durch den Aufrufer) geht
+    verloren -- aus einem Teilausfall wird ein Totalausfall.
+
+    ROT-Grund heute (vor JEDER Implementierung): ``_dispatch_alert_message()``
+    kennt 'premium_sms' in effective_channels ueberhaupt nicht -- der Kanal
+    wird nie in ``blocked_channels``/``blocked_reason_codes`` gefuehrt, weil
+    er nie versucht wird. Nach der Implementierung mit zurueckgenommenem
+    D4-Fix wuerde stattdessen die Ausnahme selbst dieses Testergebnis
+    hervorbringen (Mutations-Gegenprobe).
+    """
+    from services.notification_service import NotificationService
+
+    uid = _uid("ac6")
+    _write_profile(uid, tier="premium", reply_to=None)  # keine Rueckadresse -> Sperre
+
+    stub = _SevenIoStub()
+    tg_stub = _TelegramStub()
+    try:
+        _pin_telegram_stub(monkeypatch, tg_stub)
+        settings = _settings(stub.port, uid, telegram_port=tg_stub.port)
+        svc = NotificationService(settings=settings, user_id=uid)
+        trip = _base_trip(f"trip-ac6-{uuid.uuid4().hex[:6]}")
+        mails: list[tuple[str, str]] = []
+
+        try:
+            result = svc.send_deviation_alert(
+                trip=trip, weather=[_weather_segment(1)], changes=[_change()],
+                effective_channels={"email", "telegram", "sms", "premium_sms"},
+                mail_sink=lambda subject, body: mails.append((subject, body)),
+            )
+        except Exception as e:  # noqa: BLE001 -- genau das ist der D4-Befund
+            import pytest
+
+            pytest.fail(
+                "AC-6: der Versandaufruf darf bei einem gescheiterten "
+                "Premium-SMS-Versand NICHT mit einer unbehandelten Ausnahme "
+                f"abbrechen (Totalausfall-Risiko, Spec D4) -- erhalten: "
+                f"{type(e).__name__}: {e}"
+            )
+    finally:
+        stub.stop()
+        tg_stub.stop()
+
+    assert mails, "AC-6: E-Mail muss trotz gescheitertem Premium-Versand ankommen"
+    assert tg_stub.sent, "AC-6: Telegram muss trotz gescheitertem Premium-Versand ankommen"
+    assert stub.to(CONFIG_SMS_TO), (
+        "AC-6: SMS muss trotz gescheitertem Premium-Versand ankommen"
+    )
+    assert stub.to(LEARNED_REPLY_TO) == [], (
+        "AC-6 Voraussetzung: ohne gelernte Rueckadresse darf KEIN "
+        f"Premium-SMS-POST hinausgehen, erhalten: {stub.to(LEARNED_REPLY_TO)!r}"
+    )
+    assert result.blocked_channels.get("premium_sms"), (
+        "AC-6: der gescheiterte Premium-Versand muss als Grund in "
+        f"blocked_channels stehen, gefunden: {result.blocked_channels!r} -- "
+        "heute wird 'premium_sms' in effective_channels ueberhaupt nicht "
+        "erkannt, deshalb bleibt das Feld leer."
+    )

--- a/tests/unit/test_alert_channel_premium_sms.py
+++ b/tests/unit/test_alert_channel_premium_sms.py
@@ -178,13 +178,23 @@ def _write_profile(
 
 def _settings(port: int, user_id: str, *, telegram_port: int | None = None) -> Settings:
     """JEDES versandrelevante Feld ausdruecklich gesetzt (#1477) -- kein
-    stiller Ruecksprung auf die Prod-.env des Worktrees."""
+    stiller Ruecksprung auf die Prod-.env des Worktrees.
+
+    E-Mail-Felder sind dummy, aber gesetzt (Vorbild
+    ``_settings_email_and_premium_sms`` unten): NIE tatsaechlich kontaktiert,
+    weil jeder Aufrufer hier ``mail_sink`` uebergibt -- ohne ``smtp_host``/
+    ``mail_to`` liefert ``can_send_email()`` lokal (echte ``.env`` im
+    Worktree) etwas anderes als auf dem CI-Runner (keine ``.env``), und
+    genau diese Diskrepanz liess AC-6 lokal gruen und auf CI rot laufen.
+    """
     update = {
         "sms_gateway_url": f"http://127.0.0.1:{port}/api/sms",
         "seven_api_key": "test-stub-key",
         "seven_sandbox_key": "test-stub-key",
         "sms_to": CONFIG_SMS_TO,
         "sms_from": None,
+        "smtp_host": "dummy.invalid", "smtp_user": "dummy", "smtp_pass": "dummy",
+        "mail_to": "dummy@example.com",
     }
     if telegram_port is not None:
         # Test-Modus-Guards (#1288/#1363): im Test-Modus (via tdd-Praefix in
@@ -560,7 +570,6 @@ def test_standard_tier_never_reaches_premium_sms_via_alerts(monkeypatch):
     zu pruefen. Erst die Kontroll-Seite (Nutzer B, MUSS mindestens einmal
     ankommen) macht den Test scharf und damit heute ROT.
     """
-    import app.loader as loader
     from services.trip_alert import TripAlertService
     from services.user_tier import premium_sms_allowed, sms_allowed
 

--- a/tests/unit/test_alert_channel_premium_sms.py
+++ b/tests/unit/test_alert_channel_premium_sms.py
@@ -616,6 +616,83 @@ def test_standard_tier_never_reaches_premium_sms_via_alerts(monkeypatch):
     )
 
 
+# ═══════════════════ Adversary F001 (#1701, trip_alert.py:847-850) ═══════
+
+def test_standard_tier_never_reaches_premium_sms_via_radar_path(monkeypatch):
+    """F001 (HIGH, Adversary-Fund #1701): Given ZWEI Nutzer haben identisch
+    konfiguriertes Premium-SMS-Opt-in im Regenradar-Pfad -- Nutzer A Tier
+    'standard', Nutzer B (Kontrolle) Tier 'premium' / When bei BEIDEN
+    derselbe Regenradar-Alarm ausgeloest wird / Then bleibt Premium-SMS bei
+    Nutzer A inaktiv, waehrend Nutzer B sie bekommt --
+    ``premium_sms_allowed()`` (NICHT ``sms_allowed()``, das 'standard'
+    durchlaesst) muss auch am RADAR-Ansatzpunkt (``_radar_effective_
+    channels()``, trip_alert.py:844) entscheiden.
+
+    Deckungsluecke des vorhandenen AC-5-Tests: der deckt nur den
+    Abweichungs- und den amtlichen Pfad ab -- der Radar-Pfad
+    (``check_radar_alerts()``) hatte bislang KEINE Abdeckung mit einem
+    'standard'-Tarif-Nutzer. Tauscht man ``premium_sms_allowed()`` gegen
+    ``sms_allowed()`` aus, wurde bisher KEIN Test rot (Mutations-
+    Gegenprobe, s. Fix-Loop-Bericht).
+    """
+    import app.loader as loader
+    from services.radar_service import RadarNowcastService
+    from services.trip_alert import TripAlertService
+    from services.user_tier import premium_sms_allowed, sms_allowed
+
+    uid = _uid("f001-radar")
+    uid_control = _uid("f001-radar-control")
+    _write_profile(uid, tier="standard", reply_to=LEARNED_REPLY_TO)
+    _write_profile(uid_control, tier="premium", reply_to=_CONTROL_REPLY_TO)
+    assert sms_allowed(uid) is True and premium_sms_allowed(uid) is False, (
+        "Testvoraussetzung: 'standard' darf normale SMS, aber NICHT Premium-SMS"
+    )
+    assert premium_sms_allowed(uid_control) is True, (
+        "Testvoraussetzung Kontrolle: 'premium' darf Premium-SMS"
+    )
+
+    trip = _radar_trip(f"trip-f001-radar-{uuid.uuid4().hex[:6]}", send_premium_sms=True)
+    trip_control = _radar_trip(
+        f"trip-f001-radar-control-{uuid.uuid4().hex[:6]}", send_premium_sms=True,
+    )
+    trips_by_user = {uid: [trip], uid_control: [trip_control]}
+    monkeypatch.setattr(
+        loader, "load_all_trips", lambda **kw: trips_by_user.get(kw.get("user_id"), []),
+    )
+
+    stub = _SevenIoStub()
+    try:
+        svc = TripAlertService(
+            settings=_settings(stub.port, uid), user_id=uid, throttle_hours=0,
+            radar_service=RadarNowcastService(frame_source=_light_wet_frames),
+            mail_sink=lambda subject, body: None,
+        )
+        svc.check_radar_alerts()
+
+        svc_control = TripAlertService(
+            settings=_settings(stub.port, uid_control), user_id=uid_control, throttle_hours=0,
+            radar_service=RadarNowcastService(frame_source=_light_wet_frames),
+            mail_sink=lambda subject, body: None,
+        )
+        svc_control.check_radar_alerts()
+    finally:
+        stub.stop()
+
+    hits_standard = stub.to(LEARNED_REPLY_TO)
+    hits_control = stub.to(_CONTROL_REPLY_TO)
+    assert hits_standard == [], (
+        "F001: ein Nutzer mit Tier 'standard' darf im Radar-Pfad KEINE "
+        f"Premium-SMS bekommen, erhalten: {hits_standard!r}"
+    )
+    assert len(hits_control) >= 1, (
+        "F001 (Kontrolle): ein Nutzer mit Tier 'premium' MUSS im identisch "
+        "konfigurierten Radar-Pfad Premium-SMS bekommen -- sonst beweist die "
+        "stumme Seite oben nur, dass Premium-SMS im Radar-Pfad ueberhaupt "
+        f"nicht verdrahtet ist. Erhalten: {hits_control!r} "
+        f"(voller Stub: {stub.received!r})"
+    )
+
+
 # ═══════════════════════════════ AC-6 ═════════════════════════════════════
 
 def test_failed_premium_sms_does_not_abort_remaining_channels(monkeypatch):
@@ -687,4 +764,119 @@ def test_failed_premium_sms_does_not_abort_remaining_channels(monkeypatch):
         f"blocked_channels stehen, gefunden: {result.blocked_channels!r} -- "
         "heute wird 'premium_sms' in effective_channels ueberhaupt nicht "
         "erkannt, deshalb bleibt das Feld leer."
+    )
+
+
+# ═══════════════ Adversary F002 (#1701, trip_alert.py:320 + :1151) ════════
+#
+# Beide Stellen reichen `blocked_reason_codes=notif_result.blocked_reason_
+# codes` bzw. `result.blocked_reason_codes` an `alert_log.append_entry()`
+# weiter. Der bestehende AC-9-Test (`test_alert_log_channels.py`) ruft
+# `append_entry()` DIREKT mit einem selbstgebauten Dict auf -- er prueft die
+# Funktion, nicht die Verdrahtung, die ein echter Alarmlauf benutzt. Die
+# beiden Tests hier gehen bewusst ueber die ECHTEN Dispatcher
+# (`check_and_send_alerts()` / `check_radar_alerts()`) und lesen danach das
+# tatsaechlich geschriebene `alert_log.json`.
+
+def _settings_email_and_premium_sms(uid: str) -> Settings:
+    """E-Mail echt konfigurierbar (dummy-SMTP, NIE tatsaechlich kontaktiert
+    -- der Versand laeuft ueber ``mail_sink``), Premium-SMS technisch
+    erreichbar aber ohne gelernte Rueckadresse gesperrt. Jedes
+    versandrelevante Feld ausdruecklich gesetzt (#1477), kein stiller
+    Ruecksprung auf die Prod-.env des Worktrees."""
+    from app.config import Settings as _Settings
+
+    update = {
+        "smtp_host": "dummy.invalid", "smtp_user": "dummy", "smtp_pass": "dummy",
+        "mail_to": "dummy@example.com",
+        "telegram_bot_token": "", "telegram_chat_id": "",
+        "sms_to": None,
+        # Nie tatsaechlich kontaktiert: die Sperre (keine Rueckadresse)
+        # greift in PremiumSmsOutput._resolve_recipient() VOR jedem
+        # Netzzugriff (s. Modul-Docstring premium_sms.py).
+        "sms_gateway_url": "http://127.0.0.1:1/api/sms",
+        "seven_api_key": "test-stub-key", "seven_sandbox_key": "test-stub-key",
+        "sms_from": None,
+    }
+    return _Settings().with_user_profile(uid).model_copy(update=update)
+
+
+def test_deviation_alarm_run_logs_specific_premium_sms_block_reason():
+    """F002 (MEDIUM-HIGH, Abweichungspfad, trip_alert.py:320): Ein
+    VOLLSTAENDIGER Alarmlauf ueber ``check_and_send_alerts()`` -- der echte
+    Dispatcher, kein direkter Aufruf von ``alert_log.append_entry()`` --
+    protokolliert bei fehlender gelernter Rueckadresse den SPEZIFISCHEN
+    Sperrgrund ``premium_sms_no_reply_address`` statt des generischen
+    ``delivery_failed``.
+
+    Entfernt man an der Aufrufstelle ``blocked_reason_codes=notif_result.
+    blocked_reason_codes``, wird bisher KEIN Test rot (Mutations-Gegenprobe,
+    s. Fix-Loop-Bericht).
+    """
+    from services.trip_alert import TripAlertService
+    from tests.helpers.alert_log_fixtures import gust_alert_trip, read_log, reason_for_channel, weather
+
+    uid = _uid("f002-dev")
+    _write_profile(uid, tier="premium", reply_to=None)  # keine Rueckadresse -> Sperre
+    trip_id = f"trip-f002-dev-{uuid.uuid4().hex[:6]}"
+    trip = gust_alert_trip(trip_id, alert_channels={"email": True, "premium_sms": True})
+
+    mails: list = []
+    svc = TripAlertService(
+        settings=_settings_email_and_premium_sms(uid), user_id=uid, throttle_hours=0,
+        mail_sink=lambda subject, body: mails.append((subject, body)),
+    )
+    sent = svc.check_and_send_alerts(
+        trip, [weather(1, gust_max_kmh=20.0)], fresh_weather=[weather(1, gust_max_kmh=60.0)],
+    )
+
+    assert sent is True, f"Voraussetzung: der Boeen-Alarm muss ausgeloest worden sein, sent={sent}"
+    assert mails, "Voraussetzung: E-Mail muss trotz gesperrtem Premium-Versand ankommen"
+    log = read_log(uid)
+    entries = [e for e in log["entries"] if e.get("entity_id") == trip_id]
+    assert len(entries) == 1, f"Erwartet genau einen Eintrag fuer {trip_id!r}: {log!r}"
+    entry = entries[0]
+    assert reason_for_channel(entry, "premium_sms") == "premium_sms_no_reply_address", (
+        "F002: der spezifische Sperrgrund muss aus der echten Verdrahtung "
+        "(check_and_send_alerts -> append_entry) im Protokoll stehen, "
+        f"erhalten: {reason_for_channel(entry, 'premium_sms')!r} (Eintrag: {entry!r})"
+    )
+
+
+def test_radar_alarm_run_logs_specific_premium_sms_block_reason(monkeypatch):
+    """F002 (MEDIUM-HIGH, Radar-Pfad, trip_alert.py:1151): derselbe
+    Nachweis fuer den strukturell getrennten Radar-Dispatcher
+    (``check_radar_alerts()``).
+
+    Entfernt man an der Aufrufstelle ``blocked_reason_codes=result.
+    blocked_reason_codes``, wird bisher KEIN Test rot (Mutations-Gegenprobe,
+    s. Fix-Loop-Bericht).
+    """
+    import app.loader as loader
+    from services.radar_service import RadarNowcastService
+    from services.trip_alert import TripAlertService
+    from tests.helpers.alert_log_fixtures import read_log, reason_for_channel
+
+    uid = _uid("f002-radar")
+    _write_profile(uid, tier="premium", reply_to=None)  # keine Rueckadresse -> Sperre
+    trip_id = f"trip-f002-radar-{uuid.uuid4().hex[:6]}"
+    trip = _radar_trip(trip_id, send_premium_sms=True)
+    monkeypatch.setattr(loader, "load_all_trips", lambda **kw: [trip])
+
+    svc = TripAlertService(
+        settings=_settings_email_and_premium_sms(uid), user_id=uid, throttle_hours=0,
+        radar_service=RadarNowcastService(frame_source=_light_wet_frames),
+        mail_sink=lambda subject, body: None,
+    )
+    sent = svc.check_radar_alerts()
+
+    assert sent >= 1, f"Voraussetzung: der Radar-Alarm muss ausgeloest worden sein, sent={sent}"
+    log = read_log(uid)
+    entries = [e for e in log["entries"] if e.get("entity_id") == trip_id]
+    assert len(entries) == 1, f"Erwartet genau einen Eintrag fuer {trip_id!r}: {log!r}"
+    entry = entries[0]
+    assert reason_for_channel(entry, "premium_sms") == "premium_sms_no_reply_address", (
+        "F002: der spezifische Sperrgrund muss aus der echten Verdrahtung "
+        "(check_radar_alerts -> append_entry) im Protokoll stehen, "
+        f"erhalten: {reason_for_channel(entry, 'premium_sms')!r} (Eintrag: {entry!r})"
     )

--- a/tests/unit/test_alert_channel_threshold_premium_sms.py
+++ b/tests/unit/test_alert_channel_threshold_premium_sms.py
@@ -1,0 +1,233 @@
+"""RED — Issue #1701 (#1676 Scheibe S2b): Kanal-Schwelle (ADR-0046) fuer
+Premium-SMS.
+
+Spec: docs/specs/modules/feat_1701_alarm_premium_sms.md
+Abgedeckt: AC-8.
+
+WICHTIGER BEFUND BEIM SCHREIBEN DIESES TESTS (D6 der Spec): ``services.
+alert_channel_threshold.split_by_threshold()`` ist BEREITS kanal-agnostisch
+-- ein reiner Aufruf mit ``channels={"premium_sms"}`` ist schon HEUTE
+korrekt und damit KEIN legitimer RED-Treiber (ein isolierter Funktionstest
+waere bereits gruen, siehe Kontrollmessung unten). Die tatsaechlich fehlende
+Funktionalitaet liegt bei ``_effective_alert_channels()``
+(``trip_alert.py:1492-1494``): Premium-SMS wird dort HEUTE ueberhaupt nicht
+als Kanal erkannt, unabhaengig von jeder Schwelle. Der RED-Nachweis muss
+deshalb END-ZU-ENDE laufen und BEIDE Seiten zeigen (Vorbild: die uebrige
+Testsuite dieses Projekts verlangt fuer genau diese Faelle immer die
+Gegenprobe, s. ``tests/tdd/test_compare_alert_channel_delivery.py``
+Modul-Docstring): die HIGH-Schwelle unterdrueckt (heute trivial gruen, weil
+der Kanal noch gar nicht existiert) UND die Gegenprobe ohne Schwelle liefert
+tatsaechlich zu (heute ROT, weil der Kanal fehlt). Erst das Paar beweist,
+dass die SCHWELLE entscheidet -- nicht die (noch fehlende)
+Kanal-Erkennung selbst.
+
+TESTPOLITIK (CLAUDE.md "Test-Politik: Zwei Schichten", Kern-Schicht): kein
+Mock-Theater, echter lokaler HTTP-Stub (Vorbild
+``tests/unit/test_alert_channel_premium_sms.py``).
+"""
+from __future__ import annotations
+
+import http.server
+import socket
+import threading
+import urllib.parse
+import uuid
+from datetime import date, datetime, timedelta, timezone
+
+from app.config import Settings
+from app.models import (
+    ChangeSeverity,
+    ForecastMeta,
+    GPXPoint,
+    NormalizedTimeseries,
+    Provider,
+    SegmentWeatherData,
+    SegmentWeatherSummary,
+    TripReportConfig,
+    TripSegment,
+    WeatherChange,
+)
+from app.trip import Stage, Trip, Waypoint
+from services import alert_channel_threshold
+
+LEARNED_REPLY_TO = "+4915799912345"
+LAT, LON = 47.0, 11.0
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class _SevenIoStub:
+    def __init__(self) -> None:
+        self.received: list[dict] = []
+        received = self.received
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(length)
+                data = urllib.parse.parse_qs(body.decode())
+                received.append({k: v[0] for k, v in data.items()})
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"100")
+
+            def log_message(self, *args):  # noqa: D401
+                pass
+
+        self.port = _free_port()
+        self._server = http.server.HTTPServer(("127.0.0.1", self.port), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._server.shutdown()
+
+    def to(self, number: str) -> list[dict]:
+        return [e for e in self.received if e.get("to") == number]
+
+
+def _uid(prefix: str) -> str:
+    return f"tdd-1701-thr-{prefix}-{uuid.uuid4().hex[:6]}"
+
+
+def _write_profile(user_id: str, *, tier: str, reply_to: str) -> None:
+    import json
+
+    from app.loader import get_data_dir
+
+    path = get_data_dir(user_id)
+    path.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc) - timedelta(minutes=5)
+    profile = {
+        "id": user_id, "tier": tier,
+        "premium_sms_reply_to": reply_to,
+        "premium_sms_reply_at": stamp.isoformat().replace("+00:00", "Z"),
+    }
+    (path / "user.json").write_text(json.dumps(profile), encoding="utf-8")
+
+
+def _settings(port: int, user_id: str) -> Settings:
+    update = {
+        "sms_gateway_url": f"http://127.0.0.1:{port}/api/sms",
+        "seven_api_key": "test-stub-key",
+        "seven_sandbox_key": "test-stub-key",
+        "sms_to": "+49000000111",
+        "sms_from": None,
+    }
+    return Settings().with_user_profile(user_id).model_copy(update=update)
+
+
+def _weather_segment(segment_id: int | str = 1, **summary_kwargs) -> SegmentWeatherData:
+    now = datetime.now(timezone.utc)
+    seg = TripSegment(
+        segment_id=segment_id,
+        start_point=GPXPoint(lat=LAT, lon=LON, elevation_m=1000),
+        end_point=GPXPoint(lat=LAT + 0.1, lon=LON + 0.1, elevation_m=1500),
+        start_time=now - timedelta(hours=1), end_time=now + timedelta(hours=3),
+        duration_hours=4.0, distance_km=6.0, ascent_m=500, descent_m=0,
+    )
+    return SegmentWeatherData(
+        segment=seg,
+        timeseries=NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="test", grid_res_km=1.0),
+            data=[],
+        ),
+        aggregated=SegmentWeatherSummary(**summary_kwargs),
+        fetched_at=now, provider="openmeteo",
+    )
+
+
+def _low_urgency_change() -> WeatherChange:
+    """MINOR -> Dringlichkeit 'LOW' (``alert_urgency.urgency_from_changes``)."""
+    return WeatherChange(
+        metric="gust_max_kmh", old_value=20.0, new_value=45.0, delta=25.0,
+        threshold=20.0, severity=ChangeSeverity.MINOR, direction="increase",
+        segment_id="1",
+    )
+
+
+def _trip(trip_id: str, *, threshold: str | None) -> Trip:
+    stage = Stage(
+        id="T1", name="Tag 1", date=date.today(),
+        waypoints=[Waypoint(id="W1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0)],
+    )
+    trip = Trip(id=trip_id, name="Schwellen-Trip", stages=[stage], official_warnings=None)
+    trip.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=False, alert_on_changes=True,
+    )
+    trip.alert_channels = {"premium_sms": True}
+    trip.alert_cooldown_minutes = 0
+    trip.official_alert_triggers_enabled = False
+    if threshold is not None:
+        trip.alert_channel_thresholds = {"premium_sms": threshold}
+    return trip
+
+
+# ═══════════════════════════════ AC-8 ═════════════════════════════════════
+
+def test_premium_sms_suppressed_below_configured_threshold():
+    """AC-8: Given ein Nutzer hat fuer Premium-SMS die Schwelle 'HIGH'
+    eingestellt UND ein ausgeloester Alarm hat die Dringlichkeit 'LOW' /
+    When der Alarm verarbeitet wird / Then bleibt die Premium-SMS aus --
+    UND die Gegenprobe OHNE gesetzte Schwelle (Startwert 'LOW') liefert
+    denselben Alarm regulaer zu. Nur das Paar beweist, dass die SCHWELLE
+    entscheidet.
+
+    Kontrollmessung (kein RED-Treiber, s. Moduldocstring): der reine
+    Funktionsaufruf ist schon heute korrekt.
+    """
+    allowed, suppressed = alert_channel_threshold.split_by_threshold(
+        {"premium_sms"}, "MODERATE", {"premium_sms": "HIGH"},
+    )
+    assert suppressed == {"premium_sms"} and allowed == set(), (
+        "Kontrollmessung: split_by_threshold() ist bereits kanal-agnostisch "
+        f"korrekt (D6) -- gefunden allowed={allowed!r}, suppressed={suppressed!r}"
+    )
+
+    from services.trip_alert import TripAlertService
+
+    uid = _uid("ac8")
+    _write_profile(uid, tier="premium", reply_to=LEARNED_REPLY_TO)
+
+    stub = _SevenIoStub()
+    try:
+        settings = _settings(stub.port, uid)
+
+        # -- HIGH-Schwelle: die gering-dringliche Meldung bleibt aus --
+        trip_high = _trip(f"trip-ac8-high-{uuid.uuid4().hex[:6]}", threshold="HIGH")
+        TripAlertService(
+            settings=settings, user_id=uid, throttle_hours=0,
+            mail_sink=lambda subject, body: None,
+        )._send_alert(trip_high, [_weather_segment(1)], [_low_urgency_change()])
+
+        assert stub.to(LEARNED_REPLY_TO) == [], (
+            "AC-8: bei HIGH-Schwelle und geringer Dringlichkeit darf KEINE "
+            f"Premium-SMS gehen, erhalten: {stub.to(LEARNED_REPLY_TO)!r}"
+        )
+
+        # -- Gegenprobe: keine gesetzte Schwelle (Startwert 'LOW') -> liefert --
+        trip_low = _trip(f"trip-ac8-low-{uuid.uuid4().hex[:6]}", threshold=None)
+        assert trip_low.alert_channel_thresholds is None, (
+            "Voraussetzung der Gegenprobe: keine Schwelle gesetzt"
+        )
+        TripAlertService(
+            settings=settings, user_id=uid, throttle_hours=0,
+            mail_sink=lambda subject, body: None,
+        )._send_alert(trip_low, [_weather_segment(1)], [_low_urgency_change()])
+    finally:
+        stub.stop()
+
+    hits = stub.to(LEARNED_REPLY_TO)
+    assert len(hits) == 1, (
+        "AC-8 (Gegenprobe): OHNE gesetzte Schwelle (Startwert 'LOW') muss "
+        "eine gering-dringliche Meldung Premium-SMS erreichen -- sonst "
+        "beweist der erste Teil dieses Tests nur, dass Premium-SMS ueberhaupt "
+        f"nicht verdrahtet ist, nicht dass die SCHWELLE entscheidet. "
+        f"Erhalten: {hits!r} (voller Stub: {stub.received!r})"
+    )

--- a/tests/unit/test_alert_log_premium_sms_channel.py
+++ b/tests/unit/test_alert_log_premium_sms_channel.py
@@ -1,0 +1,167 @@
+"""RED — Issue #1701 (#1676 Scheibe S2b): Premium-SMS im Alarm-Protokoll.
+
+Spec: docs/specs/modules/feat_1701_alarm_premium_sms.md
+Abgedeckt: AC-9, plus die ``_ALL_CHANNELS``-Erweiterung (Test Coverage:
+"kein stilles Loch").
+
+TESTPOLITIK (CLAUDE.md "Test-Politik: Zwei Schichten", Kern-Schicht): kein
+Mock-Theater, kein Mock des Protokolls selbst -- ``append_entry()`` wird
+direkt aufgerufen (echter Baustein, geteilt von allen sechs Aufrufstellen)
+und ``alert_log.json`` danach als echte Datei gelesen (Vorbild
+``tests/helpers/alert_log_fixtures.py::read_log``).
+
+Pfadregel #1409: ``get_data_dir()`` respektiert die pytest-isolierte
+Datenwurzel (#1133) -- kein fester Hauptrepo-Pfad.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+
+from services import alert_log
+
+
+def _uid(prefix: str) -> str:
+    return f"tdd-1701-log-{prefix}-{uuid.uuid4().hex[:6]}"
+
+
+def _read_log(user_id: str) -> dict:
+    from app.loader import get_data_dir
+
+    path = get_data_dir(user_id) / "alert_log.json"
+    if not path.exists():
+        return {"entries": [], "not_delivered": []}
+    data = json.loads(path.read_text())
+    data.setdefault("entries", [])
+    data.setdefault("not_delivered", [])
+    return data
+
+
+def _not_sent(entry: dict, channel: str) -> dict | None:
+    for item in entry.get("channels_not_sent") or []:
+        if isinstance(item, dict) and item.get("channel") == channel:
+            return item
+    return None
+
+
+# ═══════════════════════════════ AC-9 ═════════════════════════════════════
+
+def test_blocked_premium_sms_reason_is_specific_not_generic():
+    """AC-9: Given eine Alarm-Meldung sollte per Premium-SMS gehen, aber die
+    gelernte Rueckadresse ist leer oder veraltet / When der Alarm-Lauf
+    abgeschlossen ist / Then zeigt ``alert_log.json`` den Kanal
+    ``premium_sms`` unter ``channels_not_sent`` mit dem SPEZIFISCHEN Grund
+    (``premium_sms_no_reply_address``) -- nicht mit dem generischen
+    ``delivery_failed`` und nicht als spurloses Fehlen.
+
+    ROT-Grund (gemessen): ``append_entry()`` kennt den Parameter
+    ``blocked_reason_codes`` heute nicht (``alert_log.py:135-149``) -- der
+    Aufruf unten scheitert mit ``TypeError: unexpected keyword argument``.
+    Selbst wenn der Parameter existierte: ``_channels_not_sent()`` iteriert
+    nur ``_ALL_CHANNELS = ("email", "telegram", "sms")`` -- "premium_sms"
+    kann in ``channels_not_sent`` heute UEBERHAUPT NICHT erscheinen (stilles
+    Loch, D5).
+    """
+    uid = _uid("ac9")
+    alert_log.append_entry(
+        uid, entity_id="trip-ac9", entity_type="trip",
+        changes_count=1, severity="MODERATE",
+        reason=alert_log.REASON_FORECAST_CHANGE,
+        effective_channels={"email", "premium_sms"},
+        sent_channels=["email"],
+        reachable_channels=["email"],
+        blocked_reason_codes={"premium_sms": "premium_sms_no_reply_address"},
+    )
+
+    log = _read_log(uid)
+    assert len(log["entries"]) == 1, (
+        f"Voraussetzung: genau EIN Protokolleintrag erwartet, gefunden: {log!r}"
+    )
+    entry = log["entries"][0]
+    item = _not_sent(entry, "premium_sms")
+    assert item is not None, (
+        "AC-9: 'premium_sms' fehlt komplett unter 'channels_not_sent' -- "
+        f"stilles Loch statt eines auswertbaren Grundes: {entry!r}"
+    )
+    assert item.get("reason") == "premium_sms_no_reply_address", (
+        "AC-9: der Grund muss die SPEZIFISCHE Kennung tragen, nicht den "
+        f"generischen Sammelbegriff. Gefunden: {item.get('reason')!r}"
+    )
+    assert item.get("reason") != alert_log.REASON_DELIVERY_FAILED, (
+        f"AC-9: der generische Grund {alert_log.REASON_DELIVERY_FAILED!r} "
+        "verdeckt die eigentliche Ursache (fehlende Rueckadresse) -- genau "
+        "die Ununterscheidbarkeit, die D5 beseitigen soll."
+    )
+
+
+def test_email_reason_stays_generic_when_no_blocked_reason_code_given():
+    """AC-9 Gegenprobe: Given ein E-Mail-Versand scheitert OHNE
+    ``blocked_reason_codes``-Eintrag (Bestandsverhalten, Invariante der
+    Spec) / When der Alarm-Lauf abgeschlossen ist / Then bleibt der Grund
+    fuer E-Mail unveraendert der generische ``delivery_failed`` -- die neue
+    Vorrangregel (D5) darf nur GEFUELLTE Eintraege ersetzen, nie Kanaele
+    ohne eigene Kennung."""
+    uid = _uid("ac9-invariant")
+    alert_log.append_entry(
+        uid, entity_id="trip-ac9-inv", entity_type="trip",
+        changes_count=1, severity="MODERATE",
+        reason=alert_log.REASON_FORECAST_CHANGE,
+        effective_channels={"email", "premium_sms"},
+        sent_channels=[],
+        reachable_channels=[],
+        blocked_reason_codes={"premium_sms": "premium_sms_no_reply_address"},
+    )
+
+    log = _read_log(uid)
+    entry = log["entries"][0] if log["entries"] else log["not_delivered"][0]
+    email_item = _not_sent(entry, "email")
+    assert email_item is not None, f"'email' fehlt unter 'channels_not_sent': {entry!r}"
+    assert email_item.get("reason") == alert_log.REASON_DELIVERY_FAILED, (
+        "Invariante verletzt: ein Kanal OHNE eigenen blocked_reason_codes-"
+        f"Eintrag muss beim generischen Grund bleiben, gefunden: "
+        f"{email_item.get('reason')!r}"
+    )
+
+
+# ══════════════ _ALL_CHANNELS-Erweiterung (Test Coverage, kein Mock) ═══════
+
+def test_premium_sms_missing_delivery_appears_in_protocol_no_silent_hole():
+    """Given Premium-SMS ist im effektiven Kanal-Set enthalten UND wurde
+    NICHT zugestellt (kein ``blocked_reason_codes``-Eintrag, z.B. ein
+    technischer Transportfehler) / When der Protokoll-Eintrag geschrieben
+    wird / Then erscheint 'premium_sms' TROTZDEM unter 'channels_not_sent'
+    (generischer Grund) -- statt spurlos zu fehlen.
+
+    ROT-Grund (gemessen): ``_ALL_CHANNELS = ("email", "telegram", "sms")``
+    (``alert_log.py:59``) -- ``_channels_not_sent()`` iteriert nur diese drei
+    Namen, ein vierter Kanal kann im Ergebnis strukturell nicht auftauchen,
+    unabhaengig davon was uebergeben wird.
+    """
+    uid = _uid("all-channels")
+    alert_log.append_entry(
+        uid, entity_id="trip-all-channels", entity_type="trip",
+        changes_count=1, severity="MODERATE",
+        reason=alert_log.REASON_FORECAST_CHANGE,
+        effective_channels={"premium_sms"},
+        sent_channels=[],
+        reachable_channels=[],
+    )
+
+    log = _read_log(uid)
+    assert log["entries"] == [], (
+        "Voraussetzung: kein erreichbarer Kanal -> Eintrag landet unter "
+        f"'not_delivered', gefunden unter 'entries': {log['entries']!r}"
+    )
+    assert len(log["not_delivered"]) == 1, (
+        f"Voraussetzung: genau EIN Eintrag unter 'not_delivered', gefunden: {log!r}"
+    )
+    entry = log["not_delivered"][0]
+    item = _not_sent(entry, "premium_sms")
+    assert item is not None, (
+        "'premium_sms' fehlt komplett unter 'channels_not_sent' -- stilles "
+        f"Loch statt eines Protokoll-Eintrags: {entry!r}"
+    )
+    assert item.get("reason") == alert_log.REASON_DELIVERY_FAILED, (
+        f"Ohne eigene Kennung muss der generische Grund stehen, gefunden: "
+        f"{item.get('reason')!r}"
+    )

--- a/tests/unit/test_compare_alert_premium_sms.py
+++ b/tests/unit/test_compare_alert_premium_sms.py
@@ -1,0 +1,496 @@
+"""RED — Issue #1701 (#1676 Scheibe S2b): Premium-SMS im Ortsvergleich-
+Alarmpfad.
+
+Spec: docs/specs/modules/feat_1701_alarm_premium_sms.md
+Abgedeckt: AC-4, AC-5 (Compare-Teil).
+
+TESTPOLITIK (CLAUDE.md "Test-Politik: Zwei Schichten", Kern-Schicht): kein
+Mock-Theater. Der Ortsvergleich kennt drei STRUKTURELL getrennte
+Alarm-Dispatcher (Aenderung/Radar/amtlich); je einer wird hier ueber seinen
+echten Service-Pfad ausgeloest. E-Mail laeuft ueber ``mail_sink`` (DI-Seam,
+kein SMTP), Premium-SMS geht ueber einen ECHTEN lokalen HTTP-Stub, weil
+weder ``send_multi_location_deviation_alert()`` noch
+``send_multi_location_radar_alert()`` einen SMS-Sink kennen (nur
+``mail_sink``) -- Telegram/SMS werden deshalb in diesen Presets bewusst NICHT
+aktiviert, um den Stub sauber auf Premium-SMS zu beschraenken.
+
+Pfadregel #1409: kein fester Hauptrepo-Pfad -- alle Zugriffe laufen ueber
+``get_data_dir()``/``get_data_root()`` (pytest-isolierte Datenwurzel, #1133).
+"""
+from __future__ import annotations
+
+import http.server
+import json
+import shutil
+import socket
+import threading
+import urllib.parse
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from app.config import Settings
+from app.loader import save_location
+from app.user import SavedLocation
+from services.official_alerts import OfficialAlert
+
+from tests.helpers.compare_briefings import write_compare_briefings
+
+LEARNED_REPLY_TO = "+4915799912345"
+PREMIUM_SMS_SENDER = "4916092172595"
+LAT, LON = 47.07, 15.44
+
+
+def _data_root_users() -> Path:
+    """Nutzer-Wurzel der Compare-Preset-Ablage -- Funktion statt Konstante
+    (#1595), s. ``tests/tdd/test_compare_alert_channel_delivery.py``."""
+    from app.loader import get_data_root
+
+    return get_data_root() / "users"
+
+
+# ---------------------------------------------------------------------------
+# Lokaler seven.io-Stub -- bedient SMS UND Premium-SMS (geteilte
+# ``sms_gateway_url``, SevenIoChannelBase).
+# ---------------------------------------------------------------------------
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class _SevenIoStub:
+    def __init__(self) -> None:
+        self.received: list[dict] = []
+        received = self.received
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(length)
+                data = urllib.parse.parse_qs(body.decode())
+                received.append({k: v[0] for k, v in data.items()})
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"100")
+
+            def log_message(self, *args):  # noqa: D401
+                pass
+
+        self.port = _free_port()
+        self._server = http.server.HTTPServer(("127.0.0.1", self.port), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._server.shutdown()
+
+    def to(self, number: str) -> list[dict]:
+        return [e for e in self.received if e.get("to") == number]
+
+
+# ---------------------------------------------------------------------------
+# Fixture-Bausteine
+# ---------------------------------------------------------------------------
+
+def _uid(prefix: str) -> str:
+    return f"tdd-1701-cmp-{prefix}-{uuid.uuid4().hex[:6]}"
+
+
+def _clean_user(user_id: str) -> None:
+    d = _data_root_users() / user_id
+    if d.exists():
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def _write_profile(
+    user_id: str, *, tier: str, reply_to: str | None = None,
+    reply_age: timedelta = timedelta(minutes=5),
+) -> None:
+    from app.loader import get_data_dir
+
+    path = get_data_dir(user_id)
+    path.mkdir(parents=True, exist_ok=True)
+    profile: dict = {"id": user_id, "tier": tier}
+    if reply_to is not None:
+        stamp = datetime.now(timezone.utc) - reply_age
+        profile["premium_sms_reply_to"] = reply_to
+        profile["premium_sms_reply_at"] = stamp.isoformat().replace("+00:00", "Z")
+    (path / "user.json").write_text(json.dumps(profile), encoding="utf-8")
+
+
+def _settings(port: int, user_id: str) -> Settings:
+    update = {
+        "sms_gateway_url": f"http://127.0.0.1:{port}/api/sms",
+        "seven_api_key": "test-stub-key",
+        "seven_sandbox_key": "test-stub-key",
+        "sms_to": "+49000000111",
+        "sms_from": None,
+    }
+    return Settings().with_user_profile(user_id).model_copy(update=update)
+
+
+def _compare_preset(preset_id: str, location_ids: list[str], **extra) -> dict:
+    """Compare-Preset-Rohdict -- ``**extra`` setzt NUR ausdruecklich
+    uebergebene Schluessel (Vorbild
+    ``tests/tdd/test_compare_alert_channel_delivery.py::_compare_preset``)."""
+    preset = {
+        "id": preset_id, "name": preset_id, "user_id": "unused",
+        "location_ids": list(location_ids), "schedule": "daily", "weekday": 4,
+        "profil": "ALLGEMEIN", "hour_from": 9, "hour_to": 16,
+        "empfaenger": [], "letzter_versand": None, "top_ort_letzter_versand": None,
+        "created_at": "2026-08-11T00:00:00Z",
+    }
+    preset.update(extra)
+    return preset
+
+
+def _write_presets(user_id: str, presets: list[dict]) -> None:
+    write_compare_briefings(_data_root_users() / user_id, presets)
+
+
+def _pwd(point_id: str, name: str, lat: float, lon: float, precip_sum_mm: float):
+    from app.models import SegmentWeatherSummary
+    from services.point_weather import PointWeatherData
+
+    return PointWeatherData(
+        id=point_id, name=name, lat=lat, lon=lon, timeseries=None,
+        aggregated=SegmentWeatherSummary(precip_sum_mm=precip_sum_mm),
+        fetched_at=datetime.now(timezone.utc), provider="test-scripted",
+    )
+
+
+class _ScriptedWeatherSource:
+    """Deterministische ``LocationWeatherSource`` (kein Mock): liefert echte
+    ``PointWeatherData`` ohne Netz."""
+
+    def __init__(self, values: dict[str, float]) -> None:
+        self._values = dict(values)
+
+    def fetch(self, point_id, lat, lon, start_hour=None, end_hour=None):
+        return _pwd(point_id, point_id, lat, lon, self._values.get(point_id, 0.0))
+
+
+class _CoordFrameSource:
+    """Echter ``frame_source``-Doppelgaenger fuer ``RadarNowcastService`` --
+    liefert je Koordinate einen vorab festgelegten, echten ``RadarFrame``-Satz
+    (Vorbild ``tests/tdd/test_compare_radar_alert.py::_CoordFrameSource``)."""
+
+    def __init__(self, by_coord: dict[tuple[float, float], list]) -> None:
+        self._by_coord = by_coord
+
+    def __call__(self, lat: float, lon: float) -> list:
+        return self._by_coord.get((round(lat, 4), round(lon, 4)), [])
+
+
+def _wet_frame(onset_minutes: int) -> list:
+    from providers.brightsky import RadarFrame
+
+    ts = datetime.now(timezone.utc) + timedelta(minutes=onset_minutes)
+    return [RadarFrame(timestamp=ts, precip_mm_h=0.6, is_convective=False)]
+
+
+class _FakeOfficialAlertSource:
+    """Echte Quelle (kein Mock): zustaendig fuer einen Punkt, liefert
+    steuerbare Alerts (Vorbild ``tests/tdd/test_compare_official_alert.py``)."""
+
+    def __init__(self, lat, lon, alerts):
+        self._lat, self._lon, self._alerts = lat, lon, alerts
+
+    @property
+    def name(self) -> str:
+        return "tdd-1701-source"
+
+    def covers(self, lat, lon) -> bool:
+        return abs(lat - self._lat) < 0.05 and abs(lon - self._lon) < 0.05
+
+    def fetch(self, lat, lon):
+        return list(self._alerts)
+
+
+def _official_alert() -> OfficialAlert:
+    now = datetime.now(timezone.utc)
+    return OfficialAlert(
+        source="tdd-1701-source", hazard="thunderstorm", level=3, label="Gewitter",
+        valid_from=now - timedelta(hours=1), valid_to=now + timedelta(hours=23),
+        region_label="Testregion",
+    )
+
+
+def _sources_backup():
+    import services.official_alerts.base as b
+
+    return b, list(b._REGISTERED_SOURCES)
+
+
+# ═══════════════════════════════ AC-4 ═════════════════════════════════════
+
+def test_compare_deviation_alert_reaches_premium_sms():
+    """AC-4 (Aenderungsalarm): Given ein Ortsvergleich-Preset hat
+    ``send_premium_sms=true`` (Nutzer ist Premium-Tier) / When ein
+    Aenderungsalarm fuer einen betroffenen Vergleichsort ausgeloest wird /
+    Then wird der Ort zusaetzlich per Premium-SMS gemeldet.
+
+    ROT-Grund (gemessen): ``effective_compare_channels()`` hat keinen
+    ``premium_sms``-Zweig (``compare_alert_channels.py:28-36``).
+    """
+    from services.compare_alert import CompareAlertService
+    from services.compare_weather_snapshot import CompareWeatherSnapshotService
+
+    uid = _uid("ac4-dev")
+    _clean_user(uid)
+    try:
+        _write_profile(uid, tier="premium", reply_to=LEARNED_REPLY_TO)
+        preset_id = f"cp-ac4-dev-{uuid.uuid4().hex[:6]}"
+        loc_id = "loc-1"
+        save_location(
+            SavedLocation(id=loc_id, name="Testort", lat=LAT, lon=LON, elevation_m=353),
+            user_id=uid,
+        )
+        _write_presets(uid, [_compare_preset(preset_id, [loc_id], send_premium_sms=True)])
+        CompareWeatherSnapshotService(user_id=uid).save(
+            preset_id, loc_id, _pwd(loc_id, "Testort", LAT, LON, 2.0),
+        )
+
+        stub = _SevenIoStub()
+        try:
+            mails: list = []
+            svc = CompareAlertService(
+                settings=_settings(stub.port, uid), user_id=uid,
+                weather_source=_ScriptedWeatherSource({loc_id: 30.0}),
+                mail_sink=lambda subject, body: mails.append((subject, body)),
+            )
+            svc.check_all_compare_presets()
+        finally:
+            stub.stop()
+
+        hits = stub.to(LEARNED_REPLY_TO)
+        assert len(hits) == 1, (
+            f"AC-4 (Aenderungsalarm): erwartet GENAU EINE Premium-SMS, "
+            f"erhalten: {hits!r} (voller Stub: {stub.received!r})"
+        )
+        assert hits[0].get("from") == PREMIUM_SMS_SENDER
+        assert mails, "E-Mail muss weiterhin zugestellt werden (E-Mail immer aktiv)"
+    finally:
+        _clean_user(uid)
+
+
+def test_compare_radar_alert_reaches_premium_sms():
+    """AC-4 (Regenradar): Given dasselbe Opt-in / When ein Regenradar-Onset
+    fuer einen Vergleichsort ausgeloest wird / Then wird auch dafuer per
+    Premium-SMS gemeldet -- eigener, strukturell getrennter Dispatcher
+    (``compare_radar_alert.py``).
+
+    ROT-Grund (gemessen): derselbe fehlende ``premium_sms``-Zweig in
+    ``effective_compare_channels()``, hier ueber den Radar-Pfad erreicht.
+    """
+    from services.compare_radar_alert import CompareRadarAlertService
+    from services.radar_service import RadarNowcastService
+
+    uid = _uid("ac4-radar")
+    _clean_user(uid)
+    try:
+        _write_profile(uid, tier="premium", reply_to=LEARNED_REPLY_TO)
+        preset_id = f"cp-ac4-radar-{uuid.uuid4().hex[:6]}"
+        loc_id = "loc-1"
+        save_location(
+            SavedLocation(id=loc_id, name="Testort", lat=LAT, lon=LON, elevation_m=353),
+            user_id=uid,
+        )
+        _write_presets(uid, [_compare_preset(
+            preset_id, [loc_id], send_premium_sms=True, radar_alert_enabled=True,
+        )])
+
+        stub = _SevenIoStub()
+        try:
+            mails: list = []
+            frame_source = _CoordFrameSource({(LAT, LON): _wet_frame(8)})
+            svc = CompareRadarAlertService(
+                settings=_settings(stub.port, uid), user_id=uid,
+                radar_service=RadarNowcastService(frame_source=frame_source),
+                mail_sink=lambda subject, body: mails.append((subject, body)),
+            )
+            sent = svc.check_all_compare_presets()
+        finally:
+            stub.stop()
+
+        assert sent == 1, f"Voraussetzung: Radar-Alarm muss ausgeloest sein, sent={sent}"
+        hits = stub.to(LEARNED_REPLY_TO)
+        assert len(hits) == 1, (
+            f"AC-4 (Radar): erwartet GENAU EINE Premium-SMS, erhalten: {hits!r} "
+            f"(voller Stub: {stub.received!r})"
+        )
+    finally:
+        _clean_user(uid)
+
+
+def test_compare_official_alert_reaches_premium_sms():
+    """AC-4 (amtliche Warnung): Given dasselbe Opt-in / When eine amtliche
+    Warnung fuer einen Vergleichsort eintrifft / Then wird auch dafuer per
+    Premium-SMS gemeldet -- dritter, strukturell getrennter Dispatcher
+    (``send_multi_location_official_alert``, in der Spec als
+    "send_compare_official_alert" bezeichnet).
+
+    ROT-Grund (gemessen): weder ``effective_compare_channels()`` noch
+    ``send_multi_location_official_alert()`` kennen ``premium_sms``.
+    """
+    from services.compare_official_alert import CompareOfficialAlertService
+    from services.official_alerts import register_official_alert_source
+
+    uid = _uid("ac4-off")
+    _clean_user(uid)
+    b, backup = _sources_backup()
+    b._REGISTERED_SOURCES.clear()
+    try:
+        _write_profile(uid, tier="premium", reply_to=LEARNED_REPLY_TO)
+        preset_id = f"cp-ac4-off-{uuid.uuid4().hex[:6]}"
+        loc_id = "loc-a"
+        save_location(
+            SavedLocation(id=loc_id, name="Testort", lat=LAT, lon=LON, elevation_m=353),
+            user_id=uid,
+        )
+        _write_presets(uid, [_compare_preset(preset_id, [loc_id], send_premium_sms=True)])
+        register_official_alert_source(_FakeOfficialAlertSource(LAT, LON, [_official_alert()]))
+
+        stub = _SevenIoStub()
+        try:
+            mails: list = []
+            svc = CompareOfficialAlertService(
+                settings=_settings(stub.port, uid), user_id=uid,
+                mail_sink=lambda subject, body: mails.append((subject, body)),
+            )
+            svc.check_all_compare_presets()
+        finally:
+            stub.stop()
+
+        hits = stub.to(LEARNED_REPLY_TO)
+        assert len(hits) == 1, (
+            f"AC-4 (Amtlich): erwartet GENAU EINE Premium-SMS, erhalten: {hits!r} "
+            f"(voller Stub: {stub.received!r})"
+        )
+    finally:
+        b._REGISTERED_SOURCES.clear()
+        b._REGISTERED_SOURCES.extend(backup)
+        _clean_user(uid)
+
+
+# ═══════════════════════════════ AC-5 (Compare) ═══════════════════════════
+
+_CONTROL_REPLY_TO = "+4915799954321"
+
+
+def _run_three_compare_dispatchers(uid: str, reply_to: str, stub: "_SevenIoStub") -> None:
+    """Legt Orte/Presets fuer alle drei Ortsvergleichs-Alarmarten an und
+    loest sie aus -- gemeinsamer Baustein fuer die Standard- UND die
+    Kontroll-Seite von AC-5, damit beide Seiten identisch konfiguriert sind
+    bis auf das Tarif der jeweiligen ``user_id``."""
+    from services.compare_alert import CompareAlertService
+    from services.compare_official_alert import CompareOfficialAlertService
+    from services.compare_radar_alert import CompareRadarAlertService
+    from services.compare_weather_snapshot import CompareWeatherSnapshotService
+    from services.official_alerts import register_official_alert_source
+    from services.radar_service import RadarNowcastService
+
+    loc_dev, loc_radar, loc_off = f"{uid}-dev", f"{uid}-radar", f"{uid}-off"
+    for loc_id in (loc_dev, loc_radar, loc_off):
+        save_location(
+            SavedLocation(id=loc_id, name=loc_id, lat=LAT, lon=LON, elevation_m=353),
+            user_id=uid,
+        )
+    preset_dev = f"cp-{uid}-dev"
+    preset_radar = f"cp-{uid}-radar"
+    preset_off = f"cp-{uid}-off"
+    _write_presets(uid, [
+        _compare_preset(preset_dev, [loc_dev], send_premium_sms=True),
+        _compare_preset(preset_radar, [loc_radar], send_premium_sms=True, radar_alert_enabled=True),
+        _compare_preset(preset_off, [loc_off], send_premium_sms=True),
+    ])
+    CompareWeatherSnapshotService(user_id=uid).save(
+        preset_dev, loc_dev, _pwd(loc_dev, loc_dev, LAT, LON, 2.0),
+    )
+    register_official_alert_source(_FakeOfficialAlertSource(LAT, LON, [_official_alert()]))
+
+    settings = _settings(stub.port, uid)
+
+    CompareAlertService(
+        settings=settings, user_id=uid,
+        weather_source=_ScriptedWeatherSource({loc_dev: 30.0}),
+        mail_sink=lambda subject, body: None,
+    ).check_all_compare_presets()
+
+    frame_source = _CoordFrameSource({(LAT, LON): _wet_frame(8)})
+    CompareRadarAlertService(
+        settings=settings, user_id=uid,
+        radar_service=RadarNowcastService(frame_source=frame_source),
+        mail_sink=lambda subject, body: None,
+    ).check_all_compare_presets()
+
+    CompareOfficialAlertService(
+        settings=settings, user_id=uid,
+        mail_sink=lambda subject, body: None,
+    ).check_all_compare_presets()
+
+
+def test_standard_tier_never_reaches_premium_sms_via_compare_alerts():
+    """AC-5 (Compare): Given ZWEI Nutzer mit identisch konfiguriertem
+    ``send_premium_sms=true`` in Presets fuer alle drei Alarmarten -- Nutzer
+    A hat Tier ``standard``, Nutzer B (Kontrolle) hat Tier ``premium`` /
+    When bei BEIDEN dieselben drei Ortsvergleichs-Alarmpfade ausgeloest
+    werden / Then bleibt Premium-SMS bei Nutzer A in JEDEM der drei Pfade
+    inaktiv, waehrend Nutzer B sie in mindestens einem Pfad bekommt --
+    ``premium_sms_allowed()`` (NICHT ``sms_allowed()``) entscheidet.
+
+    Warum beide Seiten in EINEM Test stehen: die stumme Seite (Nutzer A)
+    ist bereits HEUTE gruen, weil Premium-SMS im Ortsvergleich noch
+    NIRGENDS verdrahtet ist (AC-4-Tests derselben Datei sind rot). Erst die
+    Kontroll-Seite (Nutzer B, MUSS mindestens einmal ankommen) macht den
+    Test scharf und damit heute ROT.
+    """
+    from services.user_tier import premium_sms_allowed, sms_allowed
+
+    uid = _uid("ac5")
+    uid_control = _uid("ac5-control")
+    _clean_user(uid)
+    _clean_user(uid_control)
+    b, backup = _sources_backup()
+    b._REGISTERED_SOURCES.clear()
+    try:
+        _write_profile(uid, tier="standard", reply_to=LEARNED_REPLY_TO)
+        _write_profile(uid_control, tier="premium", reply_to=_CONTROL_REPLY_TO)
+        assert sms_allowed(uid) is True and premium_sms_allowed(uid) is False, (
+            "Testvoraussetzung: 'standard' darf normale SMS, aber NICHT Premium-SMS"
+        )
+        assert premium_sms_allowed(uid_control) is True, (
+            "Testvoraussetzung Kontrolle: 'premium' darf Premium-SMS"
+        )
+
+        stub = _SevenIoStub()
+        try:
+            _run_three_compare_dispatchers(uid, LEARNED_REPLY_TO, stub)
+            _run_three_compare_dispatchers(uid_control, _CONTROL_REPLY_TO, stub)
+        finally:
+            stub.stop()
+
+        hits_standard = stub.to(LEARNED_REPLY_TO)
+        hits_control = stub.to(_CONTROL_REPLY_TO)
+        assert hits_standard == [], (
+            "AC-5: ein Nutzer mit Tier 'standard' darf in KEINEM der drei "
+            f"Ortsvergleichs-Alarmpfade eine Premium-SMS bekommen, erhalten: "
+            f"{hits_standard!r}"
+        )
+        assert len(hits_control) >= 1, (
+            "AC-5 (Kontrolle): ein Nutzer mit Tier 'premium' MUSS bei "
+            "identischer Konfiguration Premium-SMS bekommen -- sonst beweist "
+            "die stumme Seite oben nur, dass Premium-SMS im Ortsvergleich "
+            "ueberhaupt nicht verdrahtet ist, nicht dass das Tier-Gate "
+            f"entscheidet. Erhalten: {hits_control!r} (voller Stub: "
+            f"{stub.received!r})"
+        )
+    finally:
+        b._REGISTERED_SOURCES.clear()
+        b._REGISTERED_SOURCES.extend(backup)
+        _clean_user(uid)
+        _clean_user(uid_control)

--- a/tests/unit/test_compare_alert_premium_sms.py
+++ b/tests/unit/test_compare_alert_premium_sms.py
@@ -123,12 +123,20 @@ def _write_profile(
 
 
 def _settings(port: int, user_id: str) -> Settings:
+    """JEDES versandrelevante Feld ausdruecklich gesetzt (#1477) -- kein
+    stiller Ruecksprung auf die Prod-.env des Worktrees. E-Mail-Felder
+    sind dummy, aber gesetzt: NIE tatsaechlich kontaktiert, weil jeder
+    Aufrufer hier ``mail_sink`` uebergibt -- ohne ``smtp_host``/``mail_to``
+    liefert ``can_send_email()`` lokal (echte ``.env`` im Worktree) etwas
+    anderes als auf dem CI-Runner (keine ``.env``)."""
     update = {
         "sms_gateway_url": f"http://127.0.0.1:{port}/api/sms",
         "seven_api_key": "test-stub-key",
         "seven_sandbox_key": "test-stub-key",
         "sms_to": "+49000000111",
         "sms_from": None,
+        "smtp_host": "dummy.invalid", "smtp_user": "dummy", "smtp_pass": "dummy",
+        "mail_to": "dummy@example.com",
     }
     return Settings().with_user_profile(user_id).model_copy(update=update)
 


### PR DESCRIPTION
Scheibe **S2b** von #1676: Premium-SMS (Garmin inReach, Satellit) wirkt jetzt auch im
**Alarm- und Vergleichspfad**, nicht nur im Trip-Briefing (S2a, PR #1706).

Ohne diese Scheibe käme auf dem Karnischen Höhenweg zweimal täglich ein Briefing auf dem
Gerät an — aber **kein Gewitteralarm**.

## Der Umfang war größer als das Ticket

Das Ticket nannte **zwei** hart verdrahtete Kanal-Aufzählungen. Umgesetzt sind **acht**
Ansatzstellen. Die achte fand erst die RED-Phase, und sie allein hätte die Scheibe
wirkungslos gemacht:

`check_radar_alerts()` bricht ab, **bevor** ein Kanal-Set aufgelöst wird, wenn
`can_send_email/telegram/sms` alle falsch sind. `can_send_sms()` verlangt `sms_to` —
Premium-SMS hat konstruktionsbedingt **keine feste Nummer**. Ein Trip mit ausschließlich
Premium-SMS (genau die Hütten-Konfiguration) hätte damit **jeden Radar-Alarm verloren**,
bei sonst vollständiger Umsetzung und grünen Tests. Der Guard führt jetzt gegen
`_radar_effective_channels()` statt gegen vier Bereitschaftsfragen.

## Zwei scharfe Kanten mit erledigt

- **Totalausfall statt Teilausfall** (`_log_error`): ein harter Index in ein Label-Dict im
  Exception-Handler ließ einen gescheiterten Premium-Versand den ganzen Dispatch-Lauf
  abbrechen — die danach liegenden Kanäle verloren ihren Alarm mit. Behoben und bewacht.
- **Stiller Datenverlust** (`AlertChannelsConfig`): das Ganzobjekt-Ersetzen hätte bei jedem
  Speichern den vierten Kanal auf `false` gesetzt, solange die Oberfläche ihn nicht kennt
  (bis S3). Jetzt `*bool` + Feld-Level-Merge nach dem Vorbild von
  `AlertChannelThresholdsConfig` daneben.

## Nachweis

- 38 Kern-Tests grün, Go-Tests grün, `go build`/`go vet` sauber, keine Regression in 17
  bestehenden Alarm-Kanal-Testdateien.
- **Adversary VERIFIED nach Fix-Loop.** Runde 1 (AMBIGUOUS): 14 Mutationen, 11 gefangen,
  **3 nicht** — Tarifsperre im Radar-Pfad und die `blocked_reason_codes`-Verdrahtung an den
  echten Aufrufstellen waren unbewacht (der AC-9-Test rief `append_entry()` direkt auf statt
  über den Dispatcher). Beide Lücken mit Tests geschlossen, **ohne** Produktivcode zu ändern —
  die Zusicherungen waren korrekt, nur ungeschützt. Runde 3: der Adversary hat alle drei
  Mutationen **selbst** nachgefahren statt dem Bericht zu glauben.
- **Erfolgs-Ratsche** korrekt von 3 auf 4 angehoben (mit Spec-Nachzug), **nicht** durch
  Verschieben der Buchung hinter den `try` unterlaufen — das hätte die Unterscheidung
  „versucht" vs. „erreicht" im Alarm-Protokoll kollabieren lassen.

## Nicht in dieser Scheibe

Kein Bedienelement (S3) · keine Kostenstelle (S2c/#1702) · **kein Nachweis am Gerät** —
der braucht echte Scheduler-Läufe und gehört zu #1533.

Refs #1701, #1676

🤖 Generated with [Claude Code](https://claude.com/claude-code)
