### PR TITLE
fix(#1685): amtliche Warnung bei reiner Fenster-Revision nicht erneut melden

### DIFF
--- a/docs/context/fix-1685-warnfenster-revision.md
+++ b/docs/context/fix-1685-warnfenster-revision.md
@@ -1,0 +1,217 @@
+# Kontext: #1685 — Alarm trotz Nennung im Morgenbriefing
+
+**Issue:** https://github.com/henemm/gregor_zwanzig/issues/1685 (`priority:high`, `type:bug`, `area:alerts`, `session:alarm`)
+**Workflow:** `fix-1685-warnfenster-revision` · Track: Full Process
+**Erstellt:** 2026-08-10
+
+---
+
+## 1. Der Vorfall (aus Nutzersicht)
+
+Am 10.08.2026 um **07:01 CEST** enthielt das Morgen-Briefing des Trips *KHW 403* (Etappe 3/13,
+Sillianer Hütte → Obstansersee-Hütte) den Warnblock:
+
+> AMTLICHE WARNUNG · 1 aktiv · Stufe GELB (1/3) · GeoSphere Austria
+> **Gewitter** Mo 10.08. · 14:00–22:00 · Ziel · Kartitsch
+
+Rund **3,5 Stunden später** (10:30 CEST) kam als eigenständige Nachricht:
+
+> 1 AMTLICHE WARNUNG · **Gewitter gemeldet.** · WARNSTUFE GELB (niedrigste von drei)
+> Gewitter · Gültig: Mo 10.08. · **18:00 — Di 11.08. 03:00** · Route: Ziel
+> Quelle: GeoSphere Austria — Kartitsch.
+
+Gleicher Ort, gleiche Gefahr, gleiche Warnstufe, gleiche Quelle. Einziger Unterschied: die Behörde
+hat das Gültigkeitsfenster revidiert (Beginn 14:00 → 18:00, Ende 22:00 → 03:00).
+
+**PO-Bewertung im Issue:** *„Ja, die Zeit ist etwas erweitert aber das ist für den Wandernden nicht
+relevant. Schaffst du es, das in eine Regel zu kippen OHNE DASS ES ZU KOMPLEX wird?"*
+
+---
+
+## 2. Am Live-System nachgemessen (2026-08-10)
+
+### 2.1 Melde-Gedächtnis der Produktion
+
+`/var/lib/gregor/users/henning/alert_state/5f534011.json` (Trip KHW 403), gelesen als `claude-gregor`:
+
+```
+official_alert:region:Kartitsch:thunderstorm:2026-08-10T12:00:00+00:00:2026-08-10T20:00:00+00:00
+    -> {"last_reported_value": 2.0, "reported_at": "2026-08-10T05:01:19Z"}   # = 07:01 CEST, Briefing
+official_alert:region:Kartitsch:thunderstorm:2026-08-10T16:00:00+00:00:2026-08-11T01:00:00+00:00
+    -> {"last_reported_value": 2.0, "reported_at": "2026-08-10T08:30:10Z"}   # = 10:30 CEST, Alarm
+```
+
+12:00–20:00 UTC = 14:00–22:00 CEST (Briefing) · 16:00–01:00 UTC = 18:00–03:00 CEST (Alarm).
+**Beide Fenster überlappen** (16:00–20:00 UTC gemeinsam), Stufe in beiden Fällen `2.0` (GELB).
+
+### 2.2 Der Versand ist protokolliert
+
+`/var/lib/gregor/users/henning/alert_log.json`:
+
+```
+{"entity_id":"5f534011","sent_at":"2026-08-10T08:30:10Z","changes_count":1,"severity":"LOW",
+ "hazards":["thunderstorm"],"reason":"official_alert",
+ "channels_sent":["email","telegram"],
+ "channels_not_sent":[{"channel":"sms","reason":"below_channel_threshold"}]}
+```
+
+### 2.3 Kein Einzelfall — zweiter Beleg, andere Quelle, anderer Tag
+
+Im selben Melde-Gedächtnis, einen Tag früher, über **MeteoAlarm Italien**:
+
+```
+official_alert:region:Trentino Alto Adige:thunderstorm:2026-08-09T14:00:00+02:00:2026-08-10T01:59:00+02:00
+    -> reported_at 2026-08-08T16:15:02Z
+official_alert:region:Trentino Alto Adige:thunderstorm:2026-08-09T10:00:00+02:00:2026-08-10T01:59:00+02:00
+    -> reported_at 2026-08-09T09:30:14Z
+```
+
+Gleiches Ende, Beginn **um 4 h vorverlegt** (14:00 → 10:00), gleiche Stufe. Auch dieser Doppel-Versand
+steht im `alert_log` (`2026-08-09T09:30:14Z`). Der Defekt ist also **quellenübergreifend**, nicht
+GeoSphere-spezifisch.
+
+### 2.4 Gegenprobe: echte Folgeperioden werden korrekt getrennt
+
+Im selben Melde-Gedächtnis stehen Hitzewarnungen aufeinanderfolgender Tage:
+
+```
+Dellach/Kirchbach extreme_heat  2026-08-03T22:00 – 2026-08-04T21:59
+Kirchbach         extreme_heat  2026-08-04T22:00 – 2026-08-05T21:59
+Friuli            extreme_heat  2026-08-04T10:00 – 2026-08-06T01:59  (+02:00)
+Friuli            extreme_heat  2026-08-06T08:00 – 2026-08-06T19:59  (+02:00)
+```
+
+Diese Paare **überlappen nicht** (21:59 endet, 22:00 beginnt; 01:59 endet, 08:00 beginnt). Eine
+Überlappungs-Regel würde sie unverändert als getrennte, echte Warnungen behandeln. Das ist am
+echten Datenbestand geprüft, nicht angenommen.
+
+---
+
+## 3. Ursache im Code
+
+`official_alert_state_key()` — `src/output/renderers/alert/official_alerts.py:407-423`:
+
+```python
+if alert.dedup_id:       ident = f"id:{alert.dedup_id}"
+elif alert.region_label: ident = f"region:{alert.region_label}"
+else:                    ident = f"label:{alert.label}"
+vf = alert.valid_from.isoformat() if alert.valid_from else "none"
+vt = alert.valid_to.isoformat() if alert.valid_to else "none"
+return f"official_alert:{ident}:{alert.hazard}:{vf}:{vt}"
+```
+
+Das Gültigkeitsfenster ist **Bestandteil der Identität**. Der Trigger vergleicht per exaktem
+Schlüssel-Treffer (`src/services/trip_alert.py:1378-1384`):
+
+```python
+prev = state.get(key)
+if prev is None or a.level > prev.get("last_reported_value", 0):
+    new_or_escalated.append((a, segment_ids))
+```
+
+Ändert die Behörde das Fenster, entsteht ein **neuer Schlüssel** → `prev is None` → die Warnung gilt
+als neu → eigenständiger Alarm. Identisch im Ortsvergleich (`src/services/compare_official_alert.py:226,230`).
+
+**Das war Absicht** (#1245, PO-Entscheidung 2026-07-15): zwei *echte* Warnperioden derselben Region
+und Gefahr sollen getrennt bleiben. Die Absicht ist richtig — sie unterscheidet nur nicht zwischen
+„zweite Periode" und „dieselbe Periode, korrigiertes Fenster".
+
+---
+
+## 4. Warum keine stabile Kennung der Behörde hilft
+
+Naheliegender „sauberer" Weg wäre, die von der Quelle gelieferte Warn-ID als `dedup_id` zu
+übernehmen. **Am Live-Endpunkt nachgemessen** (`GET warnungen.zamg.at/wsapp/api/getWarningsForCoords`
+für Kartitsch, 2026-08-10):
+
+| Warnung | `warnid` | `chgid` | `verlaufid` | Fenster |
+|---|---|---|---|---|
+| Gewitter (redaktionell) | 4838 | 1 | 3 | 10.08. 18:00 – 11.08. 03:00 |
+| Gewitter (Kurzwarnung) | **5** | 0 | 0 | 09.08. 23:00 – 00:00 |
+| Gewitter (Kurzwarnung) | **5** | 0 | 0 | 10.08. 00:00 – 01:00 |
+| Gewitter (Kurzwarnung) | **5** | 0 | 0 | 10.08. 20:00 – 21:00 |
+| Hitze | 10 | 202608100 | 21 / 31 / 41 / 51 | 11.–14.08., je ein Tag |
+
+`warnid` ist **nicht eindeutig**: bei automatischen Kurzwarnungen ist es ein Typ-Code (`5`), der über
+viele verschiedene Warnungen hinweg gleich bleibt. Als `dedup_id` verwendet, würden diese echten,
+verschiedenen Warnungen zu einer kollabieren. Zudem setzen **fünf von sechs Quellen** überhaupt kein
+`dedup_id` (einziger Produzent: `massif_closure.py:67-70`).
+
+⇒ Eine quellenübergreifende Regel auf Basis von **Identität + Gefahr + Zeitüberlappung** ist der
+tragfähige Weg; sie funktioniert für GeoSphere und MeteoAlarm gleichermaßen (beide Belege oben).
+
+---
+
+## 5. Bestehende Zusicherungen, die nicht brechen dürfen
+
+| Quelle | Zusicherung | Berührt? |
+|---|---|---|
+| #1245 AC-1 | Zwei Perioden gleicher Region+Gefahr bleiben in `dedupe_official_alerts` **zwei Einträge** | **Nein** — Fix betrifft nur die Melde-Entprellung, nicht die Anzeige |
+| #1245 Known Limitation | „Kein Interval-Merging (PO 2026-07-15): überlappende Perioden werden NICHT zu einem Gesamtzeitraum verschmolzen" | **Nein** — es wird nichts verschmolzen, nur nicht erneut *gemeldet* |
+| #1245 AC-4 | Neue Periode T2 ≠ T1 erzeugt eigenen Zustands-Key ohne A zu überschreiben | **Ja, präzisierungsbedürftig** → „T2 **überlappt T1 nicht**". Der bewachende Test (`test_official_alert_dedup_timespan.py:271`) nutzt aneinandergrenzende, **nicht überlappende** Perioden (Mo 04:00–22:00 / Mo 22:00–Di 22:00) und bleibt damit grün |
+| #1245 AC-2/AC-3 | Eskalation am selben Zeitraum bzw. bei Massiv-Sperren kollabiert auf Maximum | **Nein** |
+| #1460 AC-20/AC-22 | `official_alert:`-Einträge überleben den Briefing-Reset | **Nein** |
+| #1614 AC-1/AC-2 | Im Briefing gemeldete Warnung feuert nicht erneut; Eskalation feuert weiterhin | **Nein** — wird erweitert, nicht ersetzt |
+| #1086 / F001 | Cross-Source-Kollaps minütlich abweichender Zeiträume | **Nein** — Anzeige-Ebene |
+| ADR-0040 | „gemeldet wird eine gerissene Grenze **einmal**; erneut erst bei Verschärfung" | Bestätigt die Richtung |
+
+Kein ADR regelt die Identität amtlicher Warnungen; #1245 notiert selbst, dass eines langfristig
+naheliegt.
+
+---
+
+## 6. PO-Entscheidung (2026-08-10, im Dialog eingeholt)
+
+Gewählt: **stumm bei Überlappung, AUSSER die Warnung beginnt ≥ 2 h früher.**
+
+| Zuvor gemeldet | Neu geliefert | Verhalten |
+|---|---|---|
+| Gewitter Kartitsch 14:00–22:00 GELB | 18:00–03:00 GELB | **still** (später, überlappt) |
+| " | 14:00–02:00 GELB | **still** (nur verlängert) |
+| " | 12:00–20:00 GELB | **melden** (2 h früher) |
+| " | 10:00–18:00 GELB | **melden** (4 h früher) |
+| " | 18:00–03:00 ORANGE | **melden** (Stufe gestiegen) |
+| " | morgen 14:00–22:00 GELB | **melden** (kein Zeit-Überlapp) |
+
+Begründung für die Asymmetrie: Ein Ereignis, das **früher** eintritt, zwingt zum Umplanen — der
+Wanderer ist dann eventuell schon im Gelände. Das ist derselbe Gedanke, den der PO in #1468 wörtlich
+als *„höchstrelevant"* bezeichnet hat (dort für die Vorhersage, hier für amtliche Warnungen).
+Der am 09.08. gemessene Trentino-Fall (Vorverlegung um 4 h) bleibt damit bewusst ein Alarm.
+
+---
+
+## 7. Betroffene Stellen
+
+**Lesepfad (Entscheidung „melden ja/nein"):**
+- `src/services/trip_alert.py:1378-1384`
+- `src/services/compare_official_alert.py:224-234`
+
+**Schreibpfad (Melde-Gedächtnis):**
+- `src/services/alert_briefing_anchor.py:305-333` (`record_official_alerts_reported`) — geteilte Fassung
+- `src/services/trip_alert.py:1387-1402` (Wrapper) · Aufrufer `:1279`, `:1456`
+- `src/services/trip_report_scheduler.py:1218-1226` (Trip-Briefing vermerkt, was es gezeigt hat)
+- `src/services/compare_official_alert.py:264-273` (**eigene Inline-Kopie** `_record_state`)
+
+**Schlüsselbildung:** `src/output/renderers/alert/official_alerts.py:407-423`
+**Präfix-Konstante / Reset:** `src/services/alert_state.py:36`, `:73-101`
+**Taktung:** beide Prüfer laufen `*/15` (`internal/scheduler/scheduler.go:145`, `:156`)
+
+---
+
+## 8. Nebenbefund — eigener Defekt, NICHT Teil dieser Scheibe
+
+**Das Ortsvergleich-Briefing vermerkt gezeigte amtliche Warnungen überhaupt nicht.**
+`scheduler_dispatch_service.py:453-464` schreibt nur Anker + Reset; ein Gegenstück zu
+`trip_report_scheduler.py:1218-1226` fehlt. Der Compare-Prüfer (`*/15`) kennt die im
+Vergleichs-Briefing gezeigten Warnungen daher nicht als „gemeldet" und schickt sie erneut als
+eigenständigen Alarm. #1614 hat diese Lücke nur auf der Trip-Seite geschlossen.
+
+Nutzersichtbares Fehlverhalten ⇒ eigenes Issue (Triage-Kriterium a), nicht Sammel-Eintrag.
+
+Weitere, geringere Befunde für #1199:
+- `trip_alert.py:434` liest im Vorfilter nur das Legacy-Feld `official_alert_triggers_enabled`,
+  nicht `official_warnings.enabled` (der eigentliche Prüfer `:1307` liest beide).
+- Trip-Prüfer wertet `official_warnings.sources` nicht aus; der Compare-Prüfer (`:130`, `:213-215`) schon.
+- Briefing und Prüfer holen mit **verschiedenen Fenstern**; `get_official_alerts_with_status`
+  (`official_alerts/base.py:163-186`) kann dadurch je Lauf eine andere „beste Quelle" wählen und
+  damit einen anderen Schlüssel erzeugen.

--- a/docs/specs/modules/fix_1685_warnfenster_revision.md
+++ b/docs/specs/modules/fix_1685_warnfenster_revision.md
@@ -1,0 +1,301 @@
+---
+entity_id: fix_1685_warnfenster_revision
+type: bugfix
+created: 2026-08-11
+updated: 2026-08-11
+status: draft
+workflow: fix-1685-warnfenster-revision
+---
+
+# Fix #1685: Amtliche Warnung wird bei reiner Fenster-Revision nicht erneut gemeldet
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Eine amtliche Warnung, deren Behörde nur das Gültigkeitsfenster nachträglich korrigiert
+(gleiche Region/Gefahr/Stufe, überlappender Zeitraum), löst heute einen zweiten,
+redundanten Alarm aus — weil `official_alert_state_key()` den Zeitraum als Teil der
+Identität behandelt und jede Fenster-Änderung dadurch wie eine neue Warnung wirkt. Am
+Live-System zweifach belegt (GeoSphere Kartitsch 10.08., MeteoAlarm Trentino 09.08.,
+`docs/context/fix-1685-warnfenster-revision.md` Abschnitt 2). Diese Spec ergänzt die
+Melde-Entscheidung um eine Überlappungs-Prüfung: eine Revision desselben
+Identität+Gefahr-Eintrags bleibt still, außer die Stufe ist gestiegen oder der Beginn
+liegt ≥2h früher — PO-Entscheidung 2026-08-10 (Kontext-Doc Abschnitt 6).
+
+## Source
+
+- **File:** `src/output/renderers/alert/official_alerts.py` (neue geteilte Entscheidungsfunktion, neben `official_alert_state_key`)
+- **Identifier:** `official_alert_state_key` (Zeile 407-423, unverändert) — daneben neu: `official_alert_revision_verdict` (Entscheidung) und `official_alert_state_entry` (Schema-Builder für Melde-Gedächtnis-Einträge)
+- **Weitere Lesepfad-Dateien:** `src/services/trip_alert.py:1378-1384`, `src/services/compare_official_alert.py:224-234` (Methode `_detect`)
+- **Weitere Schreibpfad-Dateien:** `src/services/alert_briefing_anchor.py:305-333` (`record_official_alerts_reported`), `src/services/compare_official_alert.py:264-273` (`_record_state`)
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `output.renderers.alert.official_alerts.official_alert_state_key` | function | Kanonische Schlüsselbildung (Identität+Hazard+Zeitraum), unverändert — die neue Funktion baut darauf auf, ersetzt sie nicht |
+| `output.renderers.alert.official_alerts.dedupe_official_alerts` | function | Anzeige-Ebene, bewusst NICHT verändert — arbeitet weiter mit dem exakten `(ident, hazard, valid_from, valid_to)`-Tupel (Zeile 339), zeigt zwei Perioden also unverändert getrennt |
+| `services.alert_state.AlertStateService` | class | Melde-Gedächtnis, Datei je Nutzer/Entität; `load()`/`save()` werden vom neuen Fortschreibungs-Zweig direkt im Lesepfad aufgerufen (Vertragsänderung, s. „Implementation Details") |
+| `services.alert_state.OFFICIAL_ALERT_KEY_PREFIX` | constant | `"official_alert:"` — Fortschreibungs-Einträge bleiben in diesem Namensraum, überleben Briefing-Resets (#1460 P2) unverändert |
+| `services.trip_alert.TripAlertService.check_official_alert_triggers` | method | Trip-Lesepfad, Zeile 1283-1385; nutzt ab dieser Spec die geteilte Entscheidungsfunktion statt des rohen `state.get(key)`-Vergleichs |
+| `services.compare_official_alert.CompareOfficialAlertService._detect` | method | Ortsvergleich-Lesepfad, Zeile 182-235; identische Umstellung, pro Ort eigenes `AlertStateService` |
+| `services.alert_briefing_anchor.record_official_alerts_reported` | function | Trip-Schreibpfad (Briefing + Standalone-Alarm); erweitert um `valid_from`/`valid_to` im Eintrag |
+| `services.compare_official_alert.CompareOfficialAlertService._record_state` | method | Compare-Schreibpfad; identisch erweitert (eigene, bisher unabhängige Inline-Kopie) |
+| #1245 (PO 2026-07-15) | decision | Ursprung der Zeitraum-in-Identität-Regel; diese Spec präzisiert AC-4, hebt sie nicht auf |
+| ADR-0040 | decision | „Eine gerissene Grenze wird einmal gemeldet, erneut erst bei Verschärfung" — bestätigt die Richtung dieser Spec |
+| #1614 | spec | Direkter Vorgänger, identische Codestellen (Doppelversand zwischen Briefing und 15-Min-Checker); dort ungelöst blieb die Revision-INNERHALB des Checkers selbst — das ist genau diese Spec |
+
+## Scope
+
+### Affected Files
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `src/output/renderers/alert/official_alerts.py` | MODIFY | Neue Funktionen `official_alert_revision_verdict(alert, state)` und `official_alert_state_entry(alert, reported_at_iso)` direkt unterhalb von `official_alert_state_key` (Zeile ~424) |
+| `src/services/trip_alert.py` (Lesepfad `check_official_alert_triggers`, ~1378-1384) | MODIFY | Ersetzt den rohen Schlüssel-Vergleich durch `official_alert_revision_verdict`; führt bei stiller Revision die Fortschreibung inkl. `state_svc.save()` sofort aus |
+| `src/services/compare_official_alert.py` (Lesepfad `_detect`, ~224-234) | MODIFY | Identische Umstellung, pro `loc_id` eigenes `AlertStateService` |
+| `src/services/compare_official_alert.py` (Schreibpfad `_record_state`, ~264-273) | MODIFY | Nutzt `official_alert_state_entry` statt eigenem Inline-Dict — Read-Modify-Write-Merge, `valid_from`/`valid_to` künftig persistiert |
+| `src/services/alert_briefing_anchor.py` (`record_official_alerts_reported`, ~305-333) | MODIFY | Nutzt `official_alert_state_entry` statt eigenem Inline-Dict — identische Erweiterung für den Trip-Schreibpfad |
+| `tests/tdd/test_official_alert_revision_dedup.py` | CREATE | Neue, nach Verhalten benannte Testdatei (Namensregel #1196) — alle 14 Tests dieser Spec |
+
+**Nicht angefasst (bewusst):** `src/services/trip_report_scheduler.py:1219-1227` — delegiert bereits an
+`record_official_alerts_reported()` und erbt die Erweiterung automatisch, keine eigene Änderung nötig.
+
+### Estimated Changes
+
+- Files: 5 Produktivdateien, 1 neue Testdatei
+- LoC: +90/-20 Produktivcode (neue Entscheidungs- und Entry-Builder-Funktion, zwei Lesepfad-Umstellungen, zwei Schreibpfad-Umstellungen); +200/-0 Tests
+
+## Implementation Details
+
+### Identität+Hazard-Präfix statt Zeitstempel-Parsing
+
+`official_alert_state_key()` bleibt unverändert. Neu: ein Präfix ohne Zeitraum, gebildet
+mit derselben Präzedenz (`dedup_id` > `region_label` > `label`):
+
+```python
+def _identity_hazard_prefix(alert: "OfficialAlert") -> str:
+    if alert.dedup_id:       ident = f"id:{alert.dedup_id}"
+    elif alert.region_label: ident = f"region:{alert.region_label}"
+    else:                    ident = f"label:{alert.label}"
+    return f"official_alert:{ident}:{alert.hazard}:"
+```
+
+Damit lassen sich alle Bestandsschlüssel derselben Identität+Gefahr per `str.startswith`
+finden — **ohne** die ISO-Zeitstempel aus dem Schlüssel-String zu parsen (der Grund, warum
+das heute fragil wäre, s. Kontext-Doc Abschnitt „Technische Vorgaben"). Der Zeitraum wird
+stattdessen aus dem **Eintrags-Wert** gelesen (neue Felder, s.u.), nicht aus dem Schlüssel.
+
+### Neue Entscheidungsfunktion `official_alert_revision_verdict`
+
+```python
+def official_alert_revision_verdict(alert, state: dict):
+    """Liefert (should_report: bool, stale_key: str|None, merged_entry: dict|None).
+    should_report=True: melden (Kern-Vergleich `state.get(key)`, wie bisher,
+    ODER Eskalation/Vorverlegung >=2h innerhalb einer echten Überlappung).
+    should_report=False + merged_entry gesetzt: stille Revision -- Aufrufer
+    MUSS stale_key entfernen, merged_entry unter dem NEUEN Schluessel
+    speichern und sofort persistieren (state_svc.save)."""
+```
+
+Ablauf: (1) `key = official_alert_state_key(alert)`, `prev = state.get(key)`. Fehlt
+`alert.valid_from`/`valid_to`, entscheidet ausschließlich dieser exakte Treffer — wie
+heute (fail-soft, kein Rateverhalten bei zeitlosen Warnungen). (2) Sonst: alle
+Bestandsschlüssel mit `_identity_hazard_prefix(alert)` sammeln, deren **Eintrag** eigene
+`valid_from`/`valid_to`-Felder trägt (fehlen sie — Alt-Eintrag vor diesem Fix —, wird der
+Schlüssel bei diesem Schritt ignoriert, verhält sich weiter wie heute über den exakten
+Treffer aus Schritt 1). (3) Unter den verbleibenden Kandidaten den mit **echter**
+Überlappung wählen (`alert.valid_from < kandidat.valid_to and kandidat.valid_from <
+alert.valid_to`; bei mehreren Treffern: höchster `last_reported_value`, bei Gleichstand
+spätester `reported_at`). (4) Kein überlappender Kandidat → zurück zu Schritt 1
+(unverändertes Ist-Verhalten, deckt #1245 AC-4 und die Hitzewarnungs-Gegenprobe ab).
+(5) Überlappender Kandidat gefunden: `melden`, wenn `alert.level > kandidat.level` ODER
+`kandidat.valid_from - alert.valid_from >= 2h`; sonst `still` mit
+`merged_entry = {"last_reported_value": max(kandidat.level, alert.level), "reported_at":
+kandidat.reported_at (UNVERÄNDERT), "valid_from": alert.valid_from, "valid_to":
+alert.valid_to}` und `stale_key = kandidat-Schlüssel`.
+
+### Vertragsänderung: Lesepfad wird zum Schreibpfad (nur im Still-Zweig)
+
+`check_official_alert_triggers()` dokumentiert heute explizit „Schreibt KEINEN
+alert_state" (Zeile 1294-1295). Diese Spec ändert das für genau den Still-Zweig: ohne
+sofortige Fortschreibung würde der DRITTE Fall einer Revisionskette gegen das veraltete,
+erste Fenster verglichen und fälschlich erneut gemeldet (Kontext-Doc Abschnitt
+„Fortschreibung statt Wachstum", Beispiel 14–22 → 18–03 → 22–06). Der Melden-Zweig bleibt
+unverändert reiner Lesepfad — die eigentliche Schreibung nach erfolgreichem Versand läuft
+weiterhin über `record_official_alerts_reported`/`_record_state` (unverändertes Gate:
+`result.sent`, #1614 AC-4). Beide Aufrufer (`trip_alert.py`, `compare_official_alert.py`)
+rufen bei `should_report=False and merged_entry is not None` sofort `del
+state[stale_key]`, `state[key] = merged_entry`, `state_svc.save(entity_id, state)` — mit
+demselben `AlertStateService`/`entity_id`, das sie für den Lesezugriff schon geladen haben.
+
+### Schema-Erweiterung im Melde-Gedächtnis (Read-Modify-Write mit Merge)
+
+Neue Funktion `official_alert_state_entry(alert, reported_at_iso) -> dict`:
+
+```python
+def official_alert_state_entry(alert, reported_at_iso: str) -> dict:
+    return {
+        "last_reported_value": float(alert.level),
+        "reported_at": reported_at_iso,
+        "valid_from": alert.valid_from.isoformat() if alert.valid_from else None,
+        "valid_to": alert.valid_to.isoformat() if alert.valid_to else None,
+    }
+```
+
+Ersetzt die bisher **zwei unabhängig duplizierten** Inline-Dicts in
+`record_official_alerts_reported` und `_record_state` (Compare). Bestandseinträge ohne
+`valid_from`/`valid_to` werden beim nächsten Laden unverändert übernommen (kein Migrations-
+Lauf nötig) — sie bekommen die Felder automatisch, sobald für ihre Identität+Gefahr
+erneut geschrieben wird; bis dahin bleiben sie über den exakten Schlüsseltreffer gültig
+(Read-Modify-Write mit Merge, CLAUDE.md „Daten-Schema-Reworks").
+
+## Test Plan
+
+### Test-Schicht
+
+Kern-Schicht (deterministisch): `AlertStateService` ist reiner Dateizugriff (kein Netz),
+die neue Entscheidungsfunktion ist eine reine Funktion über `dict`/`OfficialAlert`. Kein
+Mock-Theater. Testdatei nach Verhalten benannt (`test_naming_gate.py`).
+
+### Automated Tests (TDD RED)
+
+- [ ] **Test 1** (später, überlappt): GIVEN im Melde-Gedächtnis steht Warnung X (Kartitsch, Gewitter, GELB, 14:00–22:00 UTC lokal), WHEN dieselbe Identität+Gefahr mit Fenster 18:00–03:00 GELB geprüft wird, THEN meldet der Checker sie NICHT (still, echte Überlappung 18:00–22:00).
+
+- [ ] **Test 2** (nur verlängert): GIVEN dieselbe Vorlage wie Test 1, WHEN das neue Fenster 14:00–02:00 GELB liefert (gleicher Start, verlängertes Ende), THEN bleibt der Checker still.
+
+- [ ] **Test 3** (2h früher, exakte Grenze): GIVEN dieselbe Vorlage wie Test 1, WHEN das neue Fenster exakt 2 Stunden früher beginnt (12:00–20:00 GELB), THEN meldet der Checker die Warnung erneut.
+
+- [ ] **Test 4** (4h früher): GIVEN dieselbe Vorlage wie Test 1, WHEN das neue Fenster 10:00–18:00 GELB liefert, THEN meldet der Checker die Warnung erneut.
+
+- [ ] **Test 5** (Stufe gestiegen): GIVEN dieselbe Vorlage wie Test 1, WHEN das neue Fenster 18:00–03:00 ORANGE liefert (später, aber höhere Stufe), THEN meldet der Checker die Warnung trotz späterem Beginn erneut.
+
+- [ ] **Test 6** (kein Zeit-Überlapp): GIVEN dieselbe Vorlage wie Test 1, WHEN am Folgetag dasselbe Fenster 14:00–22:00 GELB erneut auftritt, THEN meldet der Checker sie als eigenständige, neue Warnung.
+
+- [ ] **Test 7** (Ortsvergleich identisch): GIVEN dieselbe Ausgangslage wie Test 1 und Test 3, aber im Ortsvergleichs-Melde-Gedächtnis eines Orts (`CompareOfficialAlertService._detect`), WHEN dieselben zwei Revisionen geprüft werden, THEN verhält sich der Ortsvergleichs-Pfad identisch zum Trip-Pfad (still bei Test-1-Fenster, melden bei Test-3-Fenster).
+
+- [ ] **Test 8** (keine Zeitangabe, unverändert): GIVEN eine Warnung ohne `valid_from`/`valid_to` steht mit Level 2 im Melde-Gedächtnis, WHEN dieselbe zeitlose Warnung mit unverändertem Level erneut geprüft wird, THEN bleibt der Checker still — wie vor dieser Spec, ohne jede Überlappungsprüfung.
+
+- [ ] **Test 9** (Alt-Eintrag ohne neue Felder bleibt lesbar): GIVEN im Melde-Gedächtnis liegt ein Eintrag im alten Schema (nur `last_reported_value`/`reported_at`, ohne `valid_from`/`valid_to` — Bestandsdaten vor diesem Fix), WHEN eine Warnung mit geändertem, überlappendem Fenster geprüft wird, THEN stürzt der Checker nicht ab und behandelt sie wie heute (exakter Schlüsseltreffer entscheidet, kein Interval-Vergleich gegen den Alt-Eintrag).
+
+- [ ] **Test 10** (Kette aus drei Revisionen): GIVEN Warnung X wird mit Fenster 14:00–22:00 GELB gemeldet, WHEN sie danach zu 18:00–03:00 GELB (still, Fortschreibung) und anschließend zu 22:00–06:00 GELB revidiert wird, THEN meldet der Checker nur beim ersten Fenster, beide Folgefenster bleiben still (Fortschreibung verhindert das Falsch-Melden am dritten Glied).
+
+- [ ] **Test 11** (aneinandergrenzende Fenster bleiben getrennt): GIVEN Warnung A endet 22:00 GELB, WHEN Warnung B (gleiche Identität+Gefahr, gleiche Stufe) exakt um 22:00 beginnt, THEN meldet der Checker B als eigenständige, neue Warnung (keine echte Überlappung, Gegenprobe zu #1245 AC-4).
+
+- [ ] **Test 12** (Anzeige unverändert): GIVEN dieselben zwei aneinandergrenzenden oder überlappenden Perioden wie Test 1/Test 11, WHEN `dedupe_official_alerts` für die Anzeige aufgerufen wird, THEN liefert sie weiterhin zwei getrennte Einträge — die neue Regel wirkt ausschließlich im Melde-Gedächtnis.
+
+- [ ] **Test 13** (Mandantentrennung): GIVEN zwei Nutzer mit je einem Trip und je derselben Warnungs-Revision (Fenster wie Test 1), WHEN für Nutzer A die Fortschreibung greift, THEN bleibt das Melde-Gedächtnis von Nutzer B unverändert.
+
+- [ ] **Test 14** (Compare-Orts-Isolation): GIVEN ein Ortsvergleichs-Preset mit zwei Orten, an Ort A liegt bereits Warnung X mit Fenster 14:00–22:00 GELB im Melde-Gedächtnis, WHEN an Ort B dieselbe Warnungs-Identität mit unverändertem Fenster zum ersten Mal auftritt, THEN wird sie für Ort B als neu gemeldet (kein Cross-Talk über die location-id-basierte Trennung, F005/F006).
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine amtliche Warnung mit Fenster 14:00–22:00 GELB steht im Melde-Gedächtnis, When dieselbe Identität+Gefahr mit Fenster 18:00–03:00 GELB (später, echte Überlappung) geprüft wird, Then meldet der Checker sie NICHT erneut.
+  - Test: Test 1.
+
+- **AC-2:** Given dieselbe Ausgangslage wie AC-1, When das neue Fenster 14:00–02:00 GELB liefert (gleicher Start, nur verlängertes Ende), Then bleibt der Checker still.
+  - Test: Test 2.
+
+- **AC-3:** Given dieselbe Ausgangslage wie AC-1, When das neue Fenster exakt 2 Stunden früher beginnt (12:00–20:00 GELB), Then meldet der Checker die Warnung erneut als Alarm.
+  - Test: Test 3.
+
+- **AC-4:** Given dieselbe Ausgangslage wie AC-1, When das neue Fenster 10:00–18:00 GELB liefert (4 Stunden früher), Then meldet der Checker die Warnung erneut als Alarm.
+  - Test: Test 4.
+
+- **AC-5:** Given dieselbe Ausgangslage wie AC-1, When das neue Fenster 18:00–03:00 ORANGE liefert (Stufe gestiegen, trotz späterem Beginn), Then meldet der Checker die Warnung erneut als Alarm.
+  - Test: Test 5.
+
+- **AC-6:** Given dieselbe Ausgangslage wie AC-1, When am Folgetag dasselbe Fenster 14:00–22:00 GELB erneut auftritt (kein Zeit-Überlapp mit dem Vortag), Then meldet der Checker sie als eigenständige, neue Warnung.
+  - Test: Test 6.
+
+- **AC-7:** Given dieselben Revisions-Fälle wie AC-1 und AC-3, im Melde-Gedächtnis eines Ortsvergleichs-Orts statt eines Trips, When der Ortsvergleichs-Checker (`_detect`) sie prüft, Then verhält er sich identisch zum Trip-Pfad — still bei AC-1, melden bei AC-3.
+  - Test: Test 7.
+
+- **AC-8:** Given eine Warnung ohne `valid_from`/`valid_to` steht mit unverändertem Level im Melde-Gedächtnis, When dieselbe zeitlose Warnung erneut geprüft wird, Then entscheidet ausschließlich der exakte Schlüsseltreffer wie vor dieser Spec — keine Überlappungsprüfung greift.
+  - Test: Test 8.
+
+- **AC-9:** Given ein Bestandseintrag im Melde-Gedächtnis ohne die neuen Felder `valid_from`/`valid_to` (Datenstand vor diesem Fix), When eine Warnung mit geändertem, überlappendem Fenster gegen diesen Eintrag geprüft wird, Then bleibt der Eintrag gültig und lesbar, kein Absturz, Verhalten entspricht dem heutigen exakten Schlüsseltreffer.
+  - Test: Test 9.
+
+- **AC-10:** Given eine Warnungs-Revisionskette über drei Glieder (14:00–22:00 → 18:00–03:00 → 22:00–06:00, jedes Glied überlappt sein Vorgänger-Fenster, gleiche Stufe), When alle drei Glieder nacheinander geprüft werden, Then meldet der Checker nur beim ersten Glied, die beiden Folgeglieder bleiben still.
+  - Test: Test 10.
+
+- **AC-11:** Given zwei aneinandergrenzende, NICHT überlappende Fenster derselben Identität+Gefahr+Stufe (A endet 22:00, B beginnt exakt 22:00), When B geprüft wird, Then meldet der Checker B als eigenständige, neue Warnung — Präzisierung von #1245 AC-4 zu „T2 überlappt T1 nicht".
+  - Test: Test 11.
+
+- **AC-12:** Given zwei getrennt gemeldete Perioden derselben Identität+Gefahr (überlappend oder aneinandergrenzend), When die Anzeige-Funktion `dedupe_official_alerts` läuft, Then zeigt sie weiterhin beide Perioden getrennt — die neue Regel wirkt ausschließlich im Melde-Gedächtnis, nicht in der Anzeige.
+  - Test: Test 12.
+
+## Non-Regression
+
+Diese Änderung darf keine der folgenden bestehenden Zusicherungen brechen
+(Kontext-Doc Abschnitt 5, Live-Nachmessung 2026-08-10):
+
+| Quelle | Zusicherung | Auswirkung dieser Spec |
+|---|---|---|
+| #1245 AC-1 | Zwei Perioden gleicher Region+Gefahr bleiben in `dedupe_official_alerts` **zwei Einträge** | Unverändert — AC-12 sichert das explizit ab, die Anzeige-Funktion wird nicht angefasst |
+| #1245 Known Limitation | Kein Interval-Merging: überlappende Perioden werden NICHT zu einem Gesamtzeitraum verschmolzen | Unverändert — die Fortschreibung ersetzt nur den State-EINTRAG (Melde-Gedächtnis), sie verschmilzt keine angezeigten Zeiträume |
+| **#1245 AC-4 — PRÄZISIERT** | Bisher: „Neue Periode T2 ≠ T1 erzeugt eigenen Zustands-Key ohne A zu überschreiben." Neu: „T2 **überlappt T1 nicht**" — nur dann bleiben beide State-Keys unabhängig; überlappt T2 T1 (ohne Eskalation/≥2h-Vorverlegung), wird T1 durch die Fortschreibung ersetzt. Der bewachende Test `tests/tdd/test_official_alert_dedup_timespan.py:271` (`TestAC4TriggerNewPeriodFiresIndependently`) nutzt Perioden, die exakt aneinandergrenzen (Periode B beginnt exakt dort, wo Periode A endet — `period_b_from = period_a_to`) und bleibt damit ohne Änderung grün, weil aneinandergrenzende Fenster nach dieser Spec (AC-11) weiterhin KEINE echte Überlappung sind. |
+| #1245 AC-2/AC-3 | Eskalation am selben Zeitraum bzw. Massiv-Sperren kollabieren auf Maximum | Unverändert — betrifft `dedupe_official_alerts`, nicht die neue Melde-Entscheidung |
+| #1460 AC-20/AC-22 | `official_alert:`-Einträge überleben den Briefing-Reset | Unverändert — Fortschreibungs-Einträge tragen weiterhin denselben Präfix, `AlertStateService.reset()` behandelt sie identisch |
+| #1614 AC-1/AC-2 | Im Briefing gemeldete Warnung feuert im Alarm-Checker nicht erneut; Eskalation feuert weiterhin | Erweitert, nicht ersetzt — #1614 deckte den Doppelversand zwischen Briefing-Schreibpfad und Checker-Lesepfad ab, diese Spec deckt die Revision-Erkennung INNERHALB des Checkers selbst ab |
+| #1086 / F001 | Cross-Source-Kollaps minütlich abweichender Zeiträume | Unverändert — Anzeige-Ebene, nicht berührt |
+| ADR-0040 | „Eine gerissene Grenze wird einmal gemeldet, erneut erst bei Verschärfung" | Bestätigt — diese Spec setzt das für Fenster-Revisionen explizit um |
+
+## Nicht in dieser Scheibe
+
+- **Ortsvergleich-Briefing vermerkt gezeigte amtliche Warnungen nicht** (Kontext-Doc
+  Abschnitt 8): `scheduler_dispatch_service.py:453-464` hat kein Gegenstück zu
+  `trip_report_scheduler.py:1219-1227`. Der Compare-Checker (`*/15`) kennt im
+  Vergleichs-Briefing gezeigte Warnungen daher nicht als „gemeldet" und würde sie über
+  den in dieser Spec beschriebenen Mechanismus erst ab dem eigenen 15-Minuten-Lauf
+  verfolgen, nicht ab dem Briefing-Zeitpunkt. Nutzersichtbares Fehlverhalten
+  (Triage-Kriterium a) → **eigenes Issue**, nicht Teil dieser Scheibe.
+- Drei kleinere Befunde aus derselben Live-Analyse (Kontext-Doc Abschnitt 8, Ende) →
+  Sammel-Issue #1199, keine eigenen Issues:
+  - `trip_alert.py:434` liest im Vorfilter nur `official_alert_triggers_enabled`, nicht
+    `official_warnings.enabled` (der eigentliche Prüfer liest beide).
+  - Trip-Prüfer wertet `official_warnings.sources` nicht aus (Compare-Prüfer schon).
+  - Briefing und Prüfer holen mit verschiedenen Zeitfenstern, können dadurch je Lauf
+    eine andere „beste Quelle" wählen und einen anderen Schlüssel erzeugen.
+
+## Known Limitations
+
+- **`max(alt, neu)` bei der Stufe ist bewusst asymmetrisch gegen Deeskalation.** Ein
+  Zurückpendeln GELB→ORANGE→GELB→ORANGE meldet nach dieser Spec nur den ersten
+  Stufenanstieg, nicht jeden Wechsel — sonst würde ein Flackern der Quelle wiederholt
+  Alarme auslösen. Trade-off, PO-seitig mit der „ohne dass es zu komplex wird"-Vorgabe
+  akzeptiert, keine Deeskalations-Meldung vorgesehen.
+- **Verwaiste State-Einträge nach Eskalation/Vorverlegung.** Wird eine Revision GEMELDET
+  (Eskalation oder ≥2h früherer Beginn), bleibt der ALTE Schlüssel unverändert im
+  Melde-Gedächtnis stehen (nur der Still-Zweig entfernt `stale_key`). Das ist bewusst
+  konsistent mit #1245 (getrennte Perioden behalten getrennte Keys) und harmlos: ein
+  späteres drittes Glied vergleicht gegen ALLE Kandidaten mit echter Überlappung und
+  wählt den mit dem höchsten `last_reported_value` (bei Gleichstand: spätestem
+  `reported_at`) — der frisch gemeldete Eintrag gewinnt diese Auswahl im Regelfall.
+- **Mehrere gleichzeitig überlappende Kandidaten sind ein Theoretischer Randfall.** Die
+  deterministische Tie-Break-Regel (höchste Stufe, dann spätester `reported_at`) ist nicht
+  über den Kern-Testplan hinaus exhaustiv geprüft — kann bei ungewöhnlicher
+  Bestandsanhäufung (mehrere Alt-Einträge derselben Identität vor diesem Fix) auftreten.
+- **Lesepfad wird für den Still-Zweig zum Schreibpfad.** `check_official_alert_triggers()`
+  und `CompareOfficialAlertService._detect()` waren bisher rein lesend (das dokumentierte
+  #1614-Prinzip „Schreiben erst nach erfolgreichem Versand" gilt weiter für den
+  Melden-Zweig). Für den Still-Zweig ist eine sofortige Fortschreibung technisch
+  notwendig (s. „Implementation Details" — sonst Kettenbug am dritten Glied); das ist eine
+  bewusste, hier dokumentierte Abweichung vom bisherigen Vertrag, kein Seiteneffekt.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Chirurgische Ergänzung der bestehenden #1245-Architektur (Zeitraum als
+  Teil der State-Identität) um eine Überlappungs-Prüfung an der Melde-Entscheidung.
+  ADR-0040 deckt die Grundrichtung („eine gerissene Grenze wird einmal gemeldet") bereits
+  ab; diese Spec präzisiert eine Detailregel (#1245 AC-4), erzeugt aber keine neue
+  Grundsatzentscheidung zu Kanälen, Provider, Datenmodell, Auth oder Editor-Paradigma.
+
+## Changelog
+
+- 2026-08-11: Initial spec created (Issue #1685, PO-Entscheidung 2026-08-10 aus dem Dialog übernommen).

--- a/src/output/renderers/alert/official_alerts.py
+++ b/src/output/renderers/alert/official_alerts.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import html as _html
 import re
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Optional
 from zoneinfo import ZoneInfo
 
@@ -421,6 +421,141 @@ def official_alert_state_key(alert: "OfficialAlert") -> str:
     vf = alert.valid_from.isoformat() if alert.valid_from else "none"
     vt = alert.valid_to.isoformat() if alert.valid_to else "none"
     return f"official_alert:{ident}:{alert.hazard}:{vf}:{vt}"
+
+
+def _identity_hazard_prefix(alert: "OfficialAlert") -> str:
+    """Issue #1685: Praefix OHNE Zeitraum, gleiche Praezedenz wie
+    `official_alert_state_key` (`dedup_id` > `region_label` > `label`).
+    Damit lassen sich alle Bestandsschluessel derselben Identitaet+Gefahr per
+    `str.startswith` finden, ohne die ISO-Zeitstempel aus dem Schluessel-
+    String zu parsen (der Zeitraum wird stattdessen aus dem Eintrags-Wert
+    gelesen, s. `official_alert_state_entry`).
+
+    Adversary F003 (#1685 Fix-Loop, LOW, widerlegt): das `:`-Trennzeichen ist
+    NICHT maskiert -- theoretisch koennte ein eingebetteter Doppelpunkt in
+    `region_label`/`label` (z.B. "Kartitsch:" vs. "Kartitsch" mit Suffix
+    "Sued") zwei verschiedene Identitaeten auf denselben Praefix kollabieren
+    lassen. Unter realen Quelldaten nicht konstruierbar: der Vermutungsfall
+    "Kartitsch" vs. "Kartitsch Sued" traegt vor dem `:`-Trenner ein
+    Leerzeichen, das den Praefix-Treffer bereits verhindert -- eine Kollision
+    braucht einen eingebetteten Doppelpunkt, der exakt auf einen der festen
+    `hazard`-Werte trifft."""
+    if alert.dedup_id:
+        ident = f"id:{alert.dedup_id}"
+    elif alert.region_label:
+        ident = f"region:{alert.region_label}"
+    else:
+        ident = f"label:{alert.label}"
+    return f"official_alert:{ident}:{alert.hazard}:"
+
+
+def official_alert_revision_verdict(
+    alert: "OfficialAlert", state: dict,
+) -> tuple[bool, Optional[str], Optional[dict]]:
+    """Issue #1685: Melde-Entscheidung fuer eine amtliche Warnung, die eine
+    reine Fenster-Revision einer bereits gemeldeten Warnung derselben
+    Identitaet+Gefahr sein kann (PO-Entscheidung 2026-08-10).
+
+    Liefert `(should_report, stale_key, merged_entry)`.
+    - `should_report=True`: melden -- entweder der klassische exakte
+      Schluessel-Treffer (Ist-Verhalten #1245) oder eine Eskalation/
+      Vorverlegung >=2h innerhalb einer echten Ueberlappung. `stale_key` und
+      `merged_entry` sind dann `None`.
+    - `should_report=False` mit gesetztem `merged_entry`: stille Revision --
+      der Aufrufer MUSS `stale_key` aus dem State entfernen, `merged_entry`
+      unter dem NEUEN Schluessel (`official_alert_state_key(alert)`)
+      ablegen und sofort persistieren (`state_svc.save`).
+
+    Fail-soft: fehlt `alert.valid_from`/`valid_to`, oder traegt kein
+    Bestandseintrag der gleichen Identitaet+Gefahr eigene `valid_from`/
+    `valid_to`-Felder (Alt-Eintrag vor diesem Fix), entscheidet ausschliesslich
+    der exakte Schluesseltreffer -- wie vor dieser Spec, kein Interval-
+    Vergleich.
+
+    Adversary F001 (#1685 Fix-Loop, CRITICAL): manche Quellen liefern naive
+    (tz-lose) `valid_from`/`valid_to` (vigilance/meteoalarm, s.
+    `services.official_alerts.base._as_aware_utc`). Ein Vergleich naiv-vs-
+    aware wirft sonst `TypeError` -- und der Aufrufer `check_official_alert_
+    triggers` faengt das NICHT ab, sodass der Trip fuer den Lauf ALLE amtlichen
+    Warnungen verliert. Deshalb werden hier ALLE verglichenen Zeitpunkte --
+    Kandidat UND `alert` selbst -- vor jedem Vergleich normalisiert, und der
+    Vergleich steht im selben geschuetzten Block wie das Parsen."""
+    from services.official_alerts.base import _as_aware_utc
+
+    key = official_alert_state_key(alert)
+    prev = state.get(key)
+
+    def _exact_match_verdict() -> tuple[bool, Optional[str], Optional[dict]]:
+        should_report = prev is None or alert.level > prev.get("last_reported_value", 0)
+        return should_report, None, None
+
+    if alert.valid_from is None or alert.valid_to is None:
+        return _exact_match_verdict()
+
+    alert_vf = _as_aware_utc(alert.valid_from)
+    alert_vt = _as_aware_utc(alert.valid_to)
+
+    prefix = _identity_hazard_prefix(alert)
+    candidates: list[tuple[str, dict, datetime]] = []
+    for cand_key, entry in state.items():
+        if not cand_key.startswith(prefix):
+            continue
+        vf_raw, vt_raw = entry.get("valid_from"), entry.get("valid_to")
+        if vf_raw is None or vt_raw is None:
+            continue
+        try:
+            cand_vf = _as_aware_utc(datetime.fromisoformat(vf_raw))
+            cand_vt = _as_aware_utc(datetime.fromisoformat(vt_raw))
+            if alert_vf < cand_vt and cand_vf < alert_vt:
+                candidates.append((cand_key, entry, cand_vf))
+        except (TypeError, ValueError):
+            continue
+
+    if not candidates:
+        return _exact_match_verdict()
+
+    stale_key, kandidat, kandidat_vf = max(
+        candidates,
+        key=lambda c: (c[1].get("last_reported_value", 0), c[1].get("reported_at") or ""),
+    )
+    kandidat_level = kandidat.get("last_reported_value", 0)
+    if alert.level > kandidat_level or (kandidat_vf - alert_vf) >= timedelta(hours=2):
+        return True, None, None
+
+    merged_entry = {
+        "last_reported_value": max(kandidat_level, float(alert.level)),
+        # Adversary F002 (#1685 Fix-Loop, HIGH): `.get(..., "")` griff nur bei
+        # fehlendem Schluessel, nicht bei explizit gespeichertem `None` -- ein
+        # zweiter gleichrangiger Kandidat mit `reported_at: null` liess den
+        # Tie-Break oben `None` mit `str` vergleichen (TypeError). Ausserdem
+        # darf nie wieder ein `None` ins Melde-Gedaechtnis geschrieben werden.
+        # Adversary F007 (#1685 Fix-Loop Runde 2, MEDIUM): der Ersatzwert darf
+        # NICHT `datetime.now(...)` sein -- `reported_at` ist genau das
+        # Tie-Break-Kriterium oben (Zeile 519, "bei Gleichstand: spaetester
+        # reported_at gewinnt"). Ein erfundenes "jetzt" gewinnt damit
+        # systematisch gegen echte, aeltere Zeitstempel und verzerrt kuenftige
+        # Tie-Breaks. `""` ist konsistent mit der Lese-Normalisierung
+        # `.get("reported_at") or ""` in Zeile 519 und verliert -- statt zu
+        # gewinnen.
+        "reported_at": kandidat.get("reported_at") or "",
+        "valid_from": alert.valid_from.isoformat(),
+        "valid_to": alert.valid_to.isoformat(),
+    }
+    return False, stale_key, merged_entry
+
+
+def official_alert_state_entry(alert: "OfficialAlert", reported_at_iso: str) -> dict:
+    """Issue #1685: Schema-Builder fuer Melde-Gedaechtnis-Eintraege -- ersetzt
+    die bisher zwei unabhaengig duplizierten Inline-Dicts in
+    `record_official_alerts_reported` und `CompareOfficialAlertService.
+    _record_state`. Neu ggue. dem Ist-Zustand: `valid_from`/`valid_to`, damit
+    `official_alert_revision_verdict` spaeter echte Ueberlappung pruefen kann."""
+    return {
+        "last_reported_value": float(alert.level),
+        "reported_at": reported_at_iso,
+        "valid_from": alert.valid_from.isoformat() if alert.valid_from else None,
+        "valid_to": alert.valid_to.isoformat() if alert.valid_to else None,
+    }
 
 
 def _bundle_by_hazard_level(

--- a/src/services/alert_briefing_anchor.py
+++ b/src/services/alert_briefing_anchor.py
@@ -320,7 +320,10 @@ def record_official_alerts_reported(
     """
     if not alerts:
         return
-    from output.renderers.alert.official_alerts import official_alert_state_key
+    from output.renderers.alert.official_alerts import (
+        official_alert_state_entry,
+        official_alert_state_key,
+    )
     from services.alert_state import AlertStateService
 
     state_svc = AlertStateService(user_id=user_id)
@@ -328,7 +331,7 @@ def record_official_alerts_reported(
     now_iso = datetime.now(timezone.utc).isoformat()
     for a in alerts:
         key = official_alert_state_key(a)
-        state[key] = {"last_reported_value": float(a.level), "reported_at": now_iso}
+        state[key] = official_alert_state_entry(a, now_iso)
     state_svc.save(entity_id, state)
 
 

--- a/src/services/compare_official_alert.py
+++ b/src/services/compare_official_alert.py
@@ -28,6 +28,8 @@ from app.config import Settings
 from app.loader import compare_preset_to_dict, load_all_locations, load_compare_presets
 from output.renderers.alert.official_alerts import (
     dedupe_official_alerts,
+    official_alert_revision_verdict,
+    official_alert_state_entry,
     official_alert_state_key,
 )
 from services import alert_channel_threshold, alert_daily_limit, alert_log
@@ -215,23 +217,33 @@ class CompareOfficialAlertService:
             raw = [(alert, loc_ids) for alert, loc_ids in raw if alert.source in sources]
         deduped = dedupe_official_alerts(raw)
 
+        state_svc_by_loc = {loc.id: AlertStateService(user_id=self._user_id) for loc in locs}
         state_by_loc = {
-            loc.id: AlertStateService(user_id=self._user_id).load(f"{preset_id}:{loc.id}")
-            for loc in locs
+            loc_id: svc.load(f"{preset_id}:{loc_id}") for loc_id, svc in state_svc_by_loc.items()
         }
 
         new_or_escalated: list = []
         per_location_new: dict = {}
+        changed_locs: set = set()
         for alert, loc_ids in deduped:
-            key = official_alert_state_key(alert)
             is_new = False
             for loc_id in loc_ids:
-                prev = state_by_loc[loc_id].get(key)
-                if prev is None or alert.level > prev.get("last_reported_value", 0):
+                should_report, stale_key, merged_entry = official_alert_revision_verdict(
+                    alert, state_by_loc[loc_id]
+                )
+                if should_report:
                     is_new = True
                     per_location_new.setdefault(loc_id, []).append(alert)
+                elif merged_entry is not None:
+                    # Issue #1685: stille Fenster-Revision -- Fortschreibung
+                    # sofort, identisch zum Trip-Pfad (check_official_alert_triggers).
+                    del state_by_loc[loc_id][stale_key]
+                    state_by_loc[loc_id][official_alert_state_key(alert)] = merged_entry
+                    changed_locs.add(loc_id)
             if is_new:
                 new_or_escalated.append((alert, loc_ids))
+        for loc_id in changed_locs:
+            state_svc_by_loc[loc_id].save(f"{preset_id}:{loc_id}", state_by_loc[loc_id])
         return new_or_escalated, per_location_new
 
     def _day_window_end(self, preset_id: str, loc, now: datetime) -> datetime:
@@ -269,7 +281,7 @@ class CompareOfficialAlertService:
             state = state_svc.load(entity_id)
             for alert in alerts:
                 key = official_alert_state_key(alert)
-                state[key] = {"last_reported_value": float(alert.level), "reported_at": now_iso}
+                state[key] = official_alert_state_entry(alert, now_iso)
             state_svc.save(entity_id, state)
 
     def _effective_channels(self, preset: dict) -> set[str]:

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -1291,8 +1291,13 @@ class TripAlertService:
         in der Standalone-Alert-Mail).
         Fail-soft: Toggle-Gate zuerst, Quellenfehler werden bereits von
         get_official_alerts_for_location() pro Quelle abgefangen. Schreibt
-        KEINEN alert_state — das übernimmt der Aufrufer erst nach
-        erfolgreichem Versand (Konsistenz mit dem Wetter-Delta-Pfad).
+        nach erfolgreichem Versand KEINEN alert_state selbst — das übernimmt
+        der Aufrufer (Konsistenz mit dem Wetter-Delta-Pfad). Ausnahme (Issue
+        #1685): bei einer stillen Fenster-Revision (Warnung derselben
+        Identität+Gefahr, echte Überlappung, keine Eskalation/Vorverlegung
+        ≥2h) schreibt diese Methode das Melde-Gedächtnis SOFORT fort — sonst
+        vergleicht ein drittes Kettenglied gegen das veraltete, erste Fenster
+        und meldet fälschlich erneut.
 
         Issue #1697: `now_utc` reicht die "Jetzt"-Sekunde des Laufs an
         `_get_cached_weather` durch (Default: echte Wanduhr, s. dortiger
@@ -1372,16 +1377,27 @@ class TripAlertService:
         from output.renderers.alert.official_alerts import (
             dedupe_official_alerts,
             official_alert_state_key,
+            official_alert_revision_verdict,
         )
         tagged_alerts = dedupe_official_alerts(tagged_alerts)
 
-        state = AlertStateService(user_id=self._user_id).load(trip.id)
+        state_svc = AlertStateService(user_id=self._user_id)
+        state = state_svc.load(trip.id)
         new_or_escalated = []
+        state_changed = False
         for a, segment_ids in tagged_alerts:
-            key = official_alert_state_key(a)
-            prev = state.get(key)
-            if prev is None or a.level > prev.get("last_reported_value", 0):
+            should_report, stale_key, merged_entry = official_alert_revision_verdict(a, state)
+            if should_report:
                 new_or_escalated.append((a, segment_ids))
+            elif merged_entry is not None:
+                # Issue #1685: stille Fenster-Revision -- Fortschreibung sofort,
+                # sonst vergleicht ein drittes Kettenglied gegen das veraltete,
+                # erste Fenster und meldet faelschlich erneut.
+                del state[stale_key]
+                state[official_alert_state_key(a)] = merged_entry
+                state_changed = True
+        if state_changed:
+            state_svc.save(trip.id, state)
         return new_or_escalated
 
     def _record_official_alert_state(self, trip_id: str, official_notices: list) -> None:

--- a/tests/tdd/test_official_alert_revision_dedup.py
+++ b/tests/tdd/test_official_alert_revision_dedup.py
@@ -1,0 +1,653 @@
+"""Amtliche Warnung: reine Fenster-Revision loest keinen redundanten Alarm aus.
+
+SPEC: docs/specs/modules/fix_1685_warnfenster_revision.md (AC-1..AC-12)
+KONTEXT: docs/context/fix-1685-warnfenster-revision.md
+
+RED: `official_alert_revision_verdict()` existiert noch nicht -> ImportError
+im parametrisierten Test 1-6/AC-1..AC-6 und in Test 8/9. Der echte Einstieg
+`TripAlertService.check_official_alert_triggers()` meldet heute jede
+Fenster-Revision erneut (Test 1/AC-1, Test 10/AC-10 rot);
+`CompareOfficialAlertService._detect()` identisch (Test 7/AC-7). Der
+"melden"-Zweig von AC-3/AC-7/AC-11/AC-12 ist bereits unter dem heutigen
+Verhalten gruen (Non-Regression, analog test_official_alert_dedup_timespan.py).
+
+Mock-frei: echte OfficialAlert-DTOs, echte Quellen (Protocol-Subtyping),
+echte alert_state-Persistenz unter data/users/<frischer-user>/.
+"""
+from __future__ import annotations
+
+import shutil
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from app.models import (
+    ForecastMeta,
+    GPXPoint,
+    NormalizedTimeseries,
+    Provider,
+    SegmentWeatherData,
+    SegmentWeatherSummary,
+    TripReportConfig,
+    TripSegment,
+)
+from app.trip import Stage, Trip, Waypoint
+from app.user import SavedLocation
+from output.renderers.alert.official_alerts import dedupe_official_alerts, official_alert_state_key
+from services.official_alerts.models import OfficialAlert
+
+DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
+LAT, LON = 47.0, 11.0
+
+
+def _clean_user(uid: str) -> None:
+    d = DATA_ROOT / uid
+    if d.exists():
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def _fresh_user(prefix: str) -> str:
+    return f"tdd-1685-{prefix}-{uuid.uuid4().hex[:6]}"
+
+
+def _registered_sources_backup():
+    import services.official_alerts.base as oa_base
+
+    return oa_base, list(oa_base._REGISTERED_SOURCES)
+
+
+def _minimal_trip(trip_id: str) -> Trip:
+    stage = Stage(
+        id="T1", name="Tag 1", date=date(2026, 7, 8),
+        waypoints=[Waypoint(id="G1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0)],
+    )
+    trip = Trip(id=trip_id, name="Revision-Trip", stages=[stage], official_warnings=None)
+    trip.report_config = TripReportConfig(trip_id=trip_id, send_email=True)
+    return trip
+
+
+def _save_cached(user_id: str, trip_id: str) -> None:
+    # Segment jetzt-2h..jetzt+48h -- deckt alle Revisions-Fenster dieser Datei ab.
+    from services.weather_snapshot import WeatherSnapshotService
+
+    now = datetime.now(timezone.utc)
+    segment = TripSegment(
+        segment_id=1,
+        start_point=GPXPoint(lat=LAT, lon=LON, elevation_m=1000, distance_from_start_km=0.0),
+        end_point=GPXPoint(lat=LAT + 0.1, lon=LON + 0.1, elevation_m=1500, distance_from_start_km=8.0),
+        start_time=now - timedelta(hours=2), end_time=now + timedelta(hours=48),
+        duration_hours=4.0, distance_km=8.0, ascent_m=500, descent_m=0,
+    )
+    data = SegmentWeatherData(
+        segment=segment,
+        timeseries=NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="test", grid_res_km=1.0), data=[],
+        ),
+        aggregated=SegmentWeatherSummary(precip_sum_mm=2.0),
+        fetched_at=now, provider="openmeteo",
+    )
+    WeatherSnapshotService(user_id=user_id).save_dated(trip_id, date.today(), [data])
+
+
+def _mk_alert(vf: datetime, vt: datetime, level: int, *, hazard: str = "thunderstorm",
+              region: str = "Kartitsch-1685") -> OfficialAlert:
+    return OfficialAlert(source="test-1685", hazard=hazard, level=level,
+                          label="Gewitter (#1685)", region_label=region, valid_from=vf, valid_to=vt)
+
+
+class _RevisableOfficialAlertSource:
+    """Echte Quelle (kein Mock), austauschbares `.alert` -- Behoerde revidiert Fenster/Level."""
+
+    def __init__(self, lat: float, lon: float, alert: OfficialAlert) -> None:
+        self._lat, self._lon, self.alert = lat, lon, alert
+
+    @property
+    def name(self) -> str:
+        return "test-1685-revision"
+
+    def covers(self, lat: float, lon: float) -> bool:
+        return abs(lat - self._lat) < 0.05 and abs(lon - self._lon) < 0.05
+
+    def fetch(self, lat: float, lon: float):
+        return [self.alert]
+
+
+def _freeze_compare_now(monkeypatch, frozen: datetime) -> None:
+    # Muster test_compare_official_alert.py -- sonst variiert das lokale
+    # ADR-0035-Tagesfenster mit der Testzeit.
+    import services.compare_official_alert as coa_mod
+
+    class _Frozen(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return frozen.astimezone(tz) if tz else frozen.replace(tzinfo=None)
+
+    monkeypatch.setattr(coa_mod, "datetime", _Frozen)
+
+
+def _run_trip_chain(uid_prefix: str, shifts: list[tuple[float, float, int]]) -> list[list]:
+    # Echter check_official_alert_triggers()-Lauf je (start_h, end_h, level);
+    # nach jeder nicht-leeren Runde wird -- wie am echten Sende-Erfolgspfad -- fortgeschrieben.
+    from services.official_alerts import register_official_alert_source
+    from services.trip_alert import TripAlertService
+
+    user_id = _fresh_user(uid_prefix)
+    _clean_user(user_id)
+    oa_base, backup = _registered_sources_backup()
+    oa_base._REGISTERED_SOURCES.clear()
+    try:
+        trip = _minimal_trip(f"trip-1685-{uid_prefix}")
+        _save_cached(user_id, trip.id)
+        base_from = datetime.now(timezone.utc) - timedelta(hours=1)
+        base_to = base_from + timedelta(hours=8)
+        source = _RevisableOfficialAlertSource(LAT, LON, _mk_alert(base_from, base_to, shifts[0][2]))
+        register_official_alert_source(source)
+        svc = TripAlertService(user_id=user_id)
+        rounds = []
+        for start_h, end_h, level in shifts:
+            source.alert = _mk_alert(base_from + timedelta(hours=start_h), base_to + timedelta(hours=end_h), level)
+            result = svc.check_official_alert_triggers(trip)
+            rounds.append(result)
+            if result:
+                svc._record_official_alert_state(trip.id, result)
+        return rounds
+    finally:
+        oa_base._REGISTERED_SOURCES.clear()
+        oa_base._REGISTERED_SOURCES.extend(backup)
+        _clean_user(user_id)
+
+
+def _run_compare_chain(monkeypatch, uid_prefix: str, shifts: list[tuple[float, float, int]]) -> list[list]:
+    # Wie _run_trip_chain, ueber den Ortsvergleichs-Einstieg _detect() (AC-7).
+    from app.config import Settings
+    from services.compare_official_alert import CompareOfficialAlertService
+    from services.official_alerts import register_official_alert_source
+
+    user_id = _fresh_user(uid_prefix)
+    _clean_user(user_id)
+    oa_base, backup = _registered_sources_backup()
+    oa_base._REGISTERED_SOURCES.clear()
+    try:
+        frozen = datetime(2026, 8, 11, 6, 0, tzinfo=timezone.utc)
+        _freeze_compare_now(monkeypatch, frozen)
+        base_from = frozen - timedelta(hours=1)
+        base_to = base_from + timedelta(hours=8)
+        loc = SavedLocation(id="loc-1685", name="Kartitsch-1685", lat=LAT, lon=LON, elevation_m=1000)
+        source = _RevisableOfficialAlertSource(LAT, LON, _mk_alert(base_from, base_to, shifts[0][2]))
+        register_official_alert_source(source)
+        settings = Settings(smtp_host="dummy.invalid", smtp_user="dummy", smtp_pass="dummy",
+                             mail_to="dummy@example.com")
+        svc = CompareOfficialAlertService(settings=settings, user_id=user_id, mail_sink=lambda *a: None)
+        preset_id = "preset-1685"
+        rounds = []
+        for start_h, end_h, level in shifts:
+            source.alert = _mk_alert(base_from + timedelta(hours=start_h), base_to + timedelta(hours=end_h), level)
+            new_or_escalated, per_loc = svc._detect(preset_id, [loc])
+            rounds.append(new_or_escalated)
+            if new_or_escalated:
+                svc._record_state(preset_id, per_loc)
+        return rounds
+    finally:
+        oa_base._REGISTERED_SOURCES.clear()
+        oa_base._REGISTERED_SOURCES.extend(backup)
+        _clean_user(user_id)
+
+
+# ---- Test 1-6 / AC-1..AC-6 -- parametrisierte Melde-Entscheidung ----
+# (Verschiebung Beginn h, Verschiebung Ende h, Stufen-Delta, erwartetes Melden)
+REVISION_CASES = [
+    pytest.param(4, 5, 0, False, id="ac1-spaeter-ueberlappend-still"),
+    pytest.param(0, 4, 0, False, id="ac2-nur-verlaengert-still"),
+    pytest.param(-2, -2, 0, True, id="ac3-exakt-2h-frueher-meldet"),
+    pytest.param(-4, -4, 0, True, id="ac4-4h-frueher-meldet"),
+    pytest.param(4, 5, 1, True, id="ac5-stufe-gestiegen-meldet"),
+    pytest.param(24, 24, 0, True, id="ac6-kein-zeit-ueberlapp-meldet"),
+]
+
+
+@pytest.mark.parametrize("start_shift_h,end_shift_h,level_delta,expect_report", REVISION_CASES)
+def test_revision_verdict_matches_po_regel(start_shift_h, end_shift_h, level_delta, expect_report):
+    # Test 1-6/AC-1..AC-6 (RED): official_alert_revision_verdict fehlt noch.
+    # Zeitgrenzen aus der PO-Tabelle (Kontext-Doc Abschnitt 6).
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    base_from = datetime.now(timezone.utc) - timedelta(hours=1)
+    base_to = base_from + timedelta(hours=8)
+    prev_alert = _mk_alert(base_from, base_to, 2)
+    prev_key = official_alert_state_key(prev_alert)
+    state = {prev_key: {
+        "last_reported_value": 2.0, "reported_at": "2026-08-10T05:01:19+00:00",
+        "valid_from": base_from.isoformat(), "valid_to": base_to.isoformat(),
+    }}
+    new_alert = _mk_alert(
+        base_from + timedelta(hours=start_shift_h), base_to + timedelta(hours=end_shift_h), 2 + level_delta,
+    )
+
+    should_report, stale_key, merged_entry = official_alert_revision_verdict(new_alert, state)
+
+    assert should_report is expect_report, (
+        f"shift={start_shift_h}/{end_shift_h} delta={level_delta}: erwartet {expect_report}, erhalten {should_report}"
+    )
+    if expect_report:
+        assert merged_entry is None, f"Melden darf keinen merged_entry liefern: {merged_entry!r}"
+    else:
+        assert stale_key == prev_key, f"Stille Revision muss den alten Schluessel markieren: {stale_key!r}"
+        assert merged_entry["last_reported_value"] == max(2, 2 + level_delta), merged_entry
+        assert merged_entry["valid_from"] == new_alert.valid_from.isoformat()
+        assert merged_entry["valid_to"] == new_alert.valid_to.isoformat()
+        assert merged_entry["reported_at"] == "2026-08-10T05:01:19+00:00", (
+            "Fortschreibung darf den urspruenglichen reported_at NICHT veraendern"
+        )
+
+
+# ---- AC-8/AC-9/AC-12 -- Fail-soft (keine Interval-Logik) & Anzeige unveraendert
+
+def test_ac8_ac9_fail_soft_ohne_interval_logik():
+    """Test 8/AC-8 (RED, zeitlose Warnung entscheidet nur ueber den exakten
+    Schluesseltreffer) + Test 9/AC-9 (RED, ein Alt-Eintrag ohne valid_from/
+    valid_to wird bei der Kandidatensuche ignoriert -- kein Absturz)."""
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    timeless = OfficialAlert(source="test-1685", hazard="wildfire", level=2,
+                              label="Waldbrand-Gefahr Stufe 2 (#1685 AC-8)", region_label="Var-1685")
+    state = {official_alert_state_key(timeless): {
+        "last_reported_value": 2.0, "reported_at": "2026-08-10T05:01:19+00:00",
+    }}
+    should_report, stale_key, merged_entry = official_alert_revision_verdict(timeless, state)
+    assert should_report is False, "Unveraenderte zeitlose Warnung darf nicht erneut melden"
+    assert stale_key is None and merged_entry is None, f"stale_key={stale_key!r} merged_entry={merged_entry!r}"
+
+    old_from = datetime.now(timezone.utc) - timedelta(hours=1)
+    old_to = old_from + timedelta(hours=8)
+    legacy_key = official_alert_state_key(_mk_alert(old_from, old_to, 2))
+    legacy_state = {legacy_key: {"last_reported_value": 2.0, "reported_at": "2026-08-09T07:00:00+00:00"}}
+    revised = _mk_alert(old_from + timedelta(hours=4), old_to + timedelta(hours=5), 2)
+    should_report2, stale_key2, merged_entry2 = official_alert_revision_verdict(revised, legacy_state)
+    assert should_report2 is True, f"Alt-Eintrag darf die Interval-Logik nicht ausloesen: {should_report2!r}"
+    assert stale_key2 is None and merged_entry2 is None
+
+
+def test_f001_naiver_alert_gegen_tz_bewussten_bestandseintrag_und_umgekehrt():
+    """Adversary F001 (#1685 Fix-Loop, CRITICAL): manche Quellen (vigilance,
+    meteoalarm) liefern naive Zeitstempel. Ein Vergleich naiv-vs-aware wirft
+    ohne Normalisierung `TypeError` -- und der echte Einstieg
+    `TripAlertService.check_official_alert_triggers` faengt das NICHT ab,
+    der Trip verliert damit fuer den Lauf ALLE amtlichen Warnungen. Beide
+    Richtungen ueber den echten Einstieg, nicht nur an der Hilfsfunktion."""
+    from services.official_alerts import register_official_alert_source
+    from services.trip_alert import TripAlertService
+
+    # Richtung 1: Bestandseintrag tz-bewusst, neue Warnung liefert naiven Zeitstempel.
+    user_naive = _fresh_user("f001-naive")
+    _clean_user(user_naive)
+    oa_base, backup = _registered_sources_backup()
+    oa_base._REGISTERED_SOURCES.clear()
+    try:
+        trip = _minimal_trip("trip-1685-f001-naive")
+        _save_cached(user_naive, trip.id)
+        base_from_aware = datetime.now(timezone.utc) - timedelta(hours=1)
+        base_to_aware = base_from_aware + timedelta(hours=8)
+        source = _RevisableOfficialAlertSource(
+            LAT, LON, _mk_alert(base_from_aware, base_to_aware, 2, region="Kartitsch-f001"),
+        )
+        register_official_alert_source(source)
+        svc = TripAlertService(user_id=user_naive)
+        first = svc.check_official_alert_triggers(trip)
+        assert len(first) == 1, f"Vorbedingung: Erstmeldung muss neu sein: {first!r}"
+        svc._record_official_alert_state(trip.id, first)
+
+        # Revision liefert NAIVE (tz-lose) Zeitstempel -- reale Quellenlage.
+        naive_from = (base_from_aware + timedelta(hours=4)).replace(tzinfo=None)
+        naive_to = (base_to_aware + timedelta(hours=5)).replace(tzinfo=None)
+        source.alert = _mk_alert(naive_from, naive_to, 2, region="Kartitsch-f001")
+        second = svc.check_official_alert_triggers(trip)  # darf NICHT werfen
+        assert second == [], f"Ueberlappende Revision (naiv) muss still bleiben: {second!r}"
+    finally:
+        oa_base._REGISTERED_SOURCES.clear()
+        oa_base._REGISTERED_SOURCES.extend(backup)
+        _clean_user(user_naive)
+
+    # Richtung 2: Bestandseintrag naiv (Alt-Fassung), neue Warnung tz-bewusst.
+    user_aware = _fresh_user("f001-aware")
+    _clean_user(user_aware)
+    oa_base, backup = _registered_sources_backup()
+    oa_base._REGISTERED_SOURCES.clear()
+    try:
+        trip = _minimal_trip("trip-1685-f001-aware")
+        _save_cached(user_aware, trip.id)
+        base_from_aware = datetime.now(timezone.utc) - timedelta(hours=1)
+        base_to_aware = base_from_aware + timedelta(hours=8)
+        naive_from = base_from_aware.replace(tzinfo=None)
+        naive_to = base_to_aware.replace(tzinfo=None)
+        source = _RevisableOfficialAlertSource(
+            LAT, LON, _mk_alert(naive_from, naive_to, 2, region="Kartitsch-f001b"),
+        )
+        register_official_alert_source(source)
+        svc = TripAlertService(user_id=user_aware)
+        first = svc.check_official_alert_triggers(trip)
+        assert len(first) == 1, f"Vorbedingung: Erstmeldung muss neu sein: {first!r}"
+        svc._record_official_alert_state(trip.id, first)
+
+        # Revision liefert TZ-BEWUSSTE Zeitstempel gegen einen naiv gespeicherten Bestand.
+        source.alert = _mk_alert(
+            base_from_aware + timedelta(hours=4), base_to_aware + timedelta(hours=5), 2,
+            region="Kartitsch-f001b",
+        )
+        second = svc.check_official_alert_triggers(trip)  # darf NICHT werfen
+        assert second == [], f"Ueberlappende Revision (aware) muss still bleiben: {second!r}"
+    finally:
+        oa_base._REGISTERED_SOURCES.clear()
+        oa_base._REGISTERED_SOURCES.extend(backup)
+        _clean_user(user_aware)
+
+
+def test_f002_tie_break_und_merge_ueberleben_reported_at_null():
+    """Adversary F002 (#1685 Fix-Loop, HIGH): `.get("reported_at", "")` griff
+    nur bei fehlendem Schluessel, nicht bei explizit gespeichertem `None`.
+    Zwei echt ueberlappende, gleichrangige Kandidaten -- einer mit
+    `reported_at: null`, der andere mit echtem String -- duerfen beim
+    Tie-Break nicht werfen (sonst `None < str`, TypeError). Gleicher Rang UND
+    unterschiedlicher `reported_at`-Typ ist die Bedingung, unter der der Bug
+    tatsaechlich greift (zwei identische `None` vergleichen sich klaglos)."""
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    base_from = datetime.now(timezone.utc) - timedelta(hours=2)
+    base_to = base_from + timedelta(hours=10)
+    cand_a = _mk_alert(base_from, base_from + timedelta(hours=8), 2)
+    cand_b = _mk_alert(base_from + timedelta(hours=1), base_from + timedelta(hours=9), 2)
+    key_a, key_b = official_alert_state_key(cand_a), official_alert_state_key(cand_b)
+    state = {
+        key_a: {
+            "last_reported_value": 2.0, "reported_at": None,
+            "valid_from": cand_a.valid_from.isoformat(), "valid_to": cand_a.valid_to.isoformat(),
+        },
+        key_b: {
+            "last_reported_value": 2.0, "reported_at": "2026-08-10T05:01:19+00:00",
+            "valid_from": cand_b.valid_from.isoformat(), "valid_to": cand_b.valid_to.isoformat(),
+        },
+    }
+    new_alert = _mk_alert(base_from + timedelta(hours=2), base_from + timedelta(hours=10), 2)
+
+    should_report, stale_key, merged_entry = official_alert_revision_verdict(new_alert, state)  # darf NICHT werfen
+
+    assert should_report is False, f"Ueberlappung ohne Eskalation muss still bleiben: {should_report!r}"
+    assert merged_entry["reported_at"] is not None, (
+        f"Melde-Gedaechtnis darf kein None mehr speichern: {merged_entry!r}"
+    )
+    assert isinstance(merged_entry["reported_at"], str) and merged_entry["reported_at"] != ""
+
+    # Zweiter Teil (Zeile 502): der GEWINNENDE Kandidat selbst traegt
+    # `reported_at: null` (eindeutig hoehere Stufe, kein Tie-Break noetig) --
+    # deckt die Fortschreibungs-Zeile isoliert ab, unabhaengig vom Tie-Break.
+    # Adversary F007 (#1685 Fix-Loop Runde 2, MEDIUM): der Ersatzwert ist seit
+    # der Korrektur der leere String, NICHT mehr `datetime.now()` (das
+    # verzerrte kuenftige Tie-Breaks, s. test_f007_... unten) -- die
+    # Assertion prueft deshalb den EXAKTEN Wert, nicht nur "nicht None".
+    winner_key = official_alert_state_key(cand_a)
+    winner_state = {winner_key: {
+        "last_reported_value": 3.0, "reported_at": None,
+        "valid_from": cand_a.valid_from.isoformat(), "valid_to": cand_a.valid_to.isoformat(),
+    }}
+    lower_level_alert = _mk_alert(base_from + timedelta(hours=2), base_from + timedelta(hours=10), 2)
+    _, _, merged_entry2 = official_alert_revision_verdict(lower_level_alert, winner_state)
+    assert merged_entry2["reported_at"] == "", (
+        f"Fortschreibung darf ein None-reported_at des Gewinner-Kandidaten nur durch den "
+        f"leeren String ersetzen (F007), nicht durch ein erfundenes 'jetzt': {merged_entry2!r}"
+    )
+
+
+def test_f007_erfundener_jetzt_wert_verzerrt_kuenftigen_tie_break():
+    """Adversary F007 (#1685 Fix-Loop Runde 2, MEDIUM): `official_alerts.py:534`
+    schrieb bei fehlendem `reported_at` bisher `datetime.now(...)` statt des
+    leeren Strings. `reported_at` ist genau das Tie-Break-Kriterium (Zeile
+    519) -- ein erfundenes "jetzt" ist chronologisch IMMER groesser als jeder
+    echte, aeltere Zeitstempel und wuerde einen Kandidaten OHNE eigenen
+    reported_at in einer SPAETEREN Runde systematisch gegen einen echten,
+    datierten Kandidaten gleicher Stufe gewinnen lassen. Zwei Runden: Runde 1
+    erzeugt den Ersatzwert ueber die echte Verdict-Funktion (wie er auch
+    tatsaechlich persistiert wuerde), Runde 2 stellt ihn gegen einen echten,
+    datierten Kandidaten gleicher Stufe -- der echte MUSS gewinnen."""
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    t0 = datetime.now(timezone.utc)
+    region = "Kartitsch-f007"
+
+    # Runde 1: Kandidat OHNE eigenen reported_at (Alt-Zustand) -> stille
+    # Revision, die F007-Zeile erzeugt den Ersatzwert.
+    cand_none = _mk_alert(t0, t0 + timedelta(hours=8), 2, region=region)
+    key_none = official_alert_state_key(cand_none)
+    state_r1 = {key_none: {
+        "last_reported_value": 2.0, "reported_at": None,
+        "valid_from": cand_none.valid_from.isoformat(), "valid_to": cand_none.valid_to.isoformat(),
+    }}
+    revised_r1 = _mk_alert(t0 + timedelta(hours=4), t0 + timedelta(hours=13), 2, region=region)
+    _, _, merged_r1 = official_alert_revision_verdict(revised_r1, state_r1)
+    assert merged_r1["reported_at"] == "", f"F007: Ersatzwert muss '' sein, nicht 'jetzt': {merged_r1!r}"
+
+    # Runde 2: der aus Runde 1 fortgeschriebene Eintrag (reported_at exakt wie
+    # tatsaechlich geschrieben) tritt gegen einen ECHTEN, datierten,
+    # gleichrangigen Kandidaten an.
+    key_r1 = official_alert_state_key(revised_r1)
+    cand_real = _mk_alert(t0 + timedelta(hours=3), t0 + timedelta(hours=11), 2, region=region)
+    key_real = official_alert_state_key(cand_real)
+    state_r2 = {
+        key_r1: merged_r1,
+        key_real: {
+            "last_reported_value": 2.0, "reported_at": "2020-01-01T00:00:00+00:00",
+            "valid_from": cand_real.valid_from.isoformat(), "valid_to": cand_real.valid_to.isoformat(),
+        },
+    }
+    revised_r2 = _mk_alert(t0 + timedelta(hours=6), t0 + timedelta(hours=9), 2, region=region)
+    should_report_r2, stale_key_r2, merged_r2 = official_alert_revision_verdict(revised_r2, state_r2)
+
+    assert should_report_r2 is False
+    assert stale_key_r2 == key_real, (
+        f"Echter, datierter Kandidat muss den Tie-Break gewinnen, nicht der Runde-1-Ersatzwert "
+        f"(sonst haette ein erfundenes 'jetzt' den Vorrang): stale_key={stale_key_r2!r}"
+    )
+    assert merged_r2["reported_at"] == "2020-01-01T00:00:00+00:00"
+
+
+def test_f004_sinkende_stufe_im_still_zweig_senkt_last_reported_value_nicht():
+    """Adversary F004 (#1685 Fix-Loop, MEDIUM): REVISION_CASES deckte nie ein
+    sinkendes Level im Still-Zweig ab -- die Mutation `max(kandidat_level,
+    float(alert.level))` -> `float(alert.level)` blieb dadurch ungefangen
+    (alle 65 Tests grün). Ueberlappend, nicht vorverlegt, Stufe faellt:
+    `last_reported_value` darf NICHT sinken."""
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    base_from = datetime.now(timezone.utc) - timedelta(hours=1)
+    base_to = base_from + timedelta(hours=8)
+    prev_alert = _mk_alert(base_from, base_to, 3)  # ORANGE bereits gemeldet
+    prev_key = official_alert_state_key(prev_alert)
+    state = {prev_key: {
+        "last_reported_value": 3.0, "reported_at": "2026-08-10T05:01:19+00:00",
+        "valid_from": base_from.isoformat(), "valid_to": base_to.isoformat(),
+    }}
+    # Stufe faellt auf GELB(2), Fenster ueberlappt (spaeter, nicht vorverlegt).
+    new_alert = _mk_alert(base_from + timedelta(hours=4), base_to + timedelta(hours=5), 2)
+
+    should_report, stale_key, merged_entry = official_alert_revision_verdict(new_alert, state)
+
+    assert should_report is False, "Sinkende Stufe bei echter Ueberlappung darf nicht erneut melden"
+    assert merged_entry["last_reported_value"] == 3.0, (
+        f"last_reported_value darf bei sinkender Stufe NICHT absinken: {merged_entry!r}"
+    )
+
+
+def test_f005_unparsebarer_bestandswert_faellt_auf_exakten_treffer_zurueck():
+    """Adversary F005 (#1685 Fix-Loop, MEDIUM): AC-9 deckte nur KOMPLETT
+    fehlende valid_from/valid_to ab (Guard vor dem try, Zeile 480) -- nie
+    einen VORHANDENEN, aber unparsebaren Wert, der den try/except tatsaechlich
+    erreicht. Ohne try/except wirft `datetime.fromisoformat('not-a-date')`
+    `ValueError` -> Absturz statt Fallback auf den exakten Schluesseltreffer."""
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    base_from = datetime.now(timezone.utc) - timedelta(hours=1)
+    base_to = base_from + timedelta(hours=8)
+    key = official_alert_state_key(_mk_alert(base_from, base_to, 2))
+    state = {key: {
+        "last_reported_value": 2.0, "reported_at": "2026-08-10T05:01:19+00:00",
+        "valid_from": "not-a-date", "valid_to": base_to.isoformat(),
+    }}
+    revised = _mk_alert(base_from + timedelta(hours=4), base_to + timedelta(hours=5), 2)
+
+    should_report, stale_key, merged_entry = official_alert_revision_verdict(revised, state)  # darf NICHT werfen
+
+    assert should_report is True, (
+        f"Unparsebarer Bestandswert muss auf den exakten Schluesseltreffer zurueckfallen "
+        f"(neuer Schluessel != alter -> melden), nicht abstuerzen: {should_report!r}"
+    )
+    assert stale_key is None and merged_entry is None
+
+
+def test_ac12_anzeige_bleibt_getrennt_trotz_ueberlappung():
+    """Test 12/AC-12 (Non-Regression, MUSS GRUEN bleiben): ueberlappende
+    Perioden bleiben in `dedupe_official_alerts` zwei Eintraege."""
+    base_from = datetime.now(timezone.utc) - timedelta(hours=1)
+    base_to = base_from + timedelta(hours=8)
+    alert_a = _mk_alert(base_from, base_to, 2)
+    alert_b = _mk_alert(base_from + timedelta(hours=4), base_to + timedelta(hours=5), 2)
+
+    result = dedupe_official_alerts([(alert_a, []), (alert_b, [])])
+
+    assert len(result) == 2, f"Anzeige muss beide Perioden getrennt zeigen: {result!r}"
+
+
+# ---- AC-1/AC-3/AC-10/AC-11 -- echter Einstieg (Trip) ----
+
+def test_ac1_ac3_ac10_ac11_trip_checker_real_entry():
+    # Test 1/AC-1 (RED, still) + Test 3/AC-3 (Non-Regression, melden 2h frueher)
+    # + Test 10/AC-10 (RED, Kette 14-22->18-03->22-06, nur Glied 1 meldet)
+    # + Test 11/AC-11 (Non-Regression, angrenzend meldet neu, #1245 AC-4) --
+    # alle vier ueber den echten Einstieg check_official_alert_triggers().
+    still = _run_trip_chain("ac1", [(0, 0, 2), (4, 5, 2)])
+    assert len(still[0]) == 1, f"Vorbedingung: Erstmeldung muss neu sein: {still[0]!r}"
+    assert still[1] == [], f"AC-1: spaeter/ueberlappend darf nicht erneut melden: {still[1]!r}"
+
+    reports = _run_trip_chain("ac3", [(0, 0, 2), (-2, -2, 2)])
+    assert len(reports[0]) == 1
+    assert len(reports[1]) == 1, f"AC-3: 2h frueherer Beginn muss erneut gemeldet werden: {reports[1]!r}"
+
+    chain = _run_trip_chain("ac10", [(0, 0, 2), (4, 5, 2), (8, 8, 2)])
+    assert len(chain[0]) == 1, f"Erstmeldung muss neu sein: {chain[0]!r}"
+    assert chain[1] == [], f"Zweites Glied muss still bleiben: {chain[1]!r}"
+    assert chain[2] == [], f"Drittes Glied muss (Fortschreibung) still bleiben: {chain[2]!r}"
+
+    adjacent = _run_trip_chain("ac11", [(0, 0, 2), (8, 8, 2)])
+    assert len(adjacent[0]) == 1
+    assert len(adjacent[1]) == 1, f"AC-11: angrenzend/nicht-ueberlappend muss neu gemeldet werden: {adjacent[1]!r}"
+
+
+def test_ac13_mandantentrennung_fortschreibung_beruehrt_nur_den_eigenen_nutzer():
+    # Test 13 (Mandantentrennung, CLAUDE.md-Pflicht): Nutzer B's Melde-Gedaechtnis
+    # bleibt unberuehrt von Nutzer A's stiller Fortschreibung.
+    from services.alert_state import AlertStateService
+    from services.official_alerts import register_official_alert_source
+    from services.trip_alert import TripAlertService
+
+    user_a, user_b = _fresh_user("t13a"), _fresh_user("t13b")
+    _clean_user(user_a)
+    _clean_user(user_b)
+    oa_base, backup = _registered_sources_backup()
+    oa_base._REGISTERED_SOURCES.clear()
+    try:
+        trip_a, trip_b = _minimal_trip("trip-1685-t13a"), _minimal_trip("trip-1685-t13b")
+        _save_cached(user_a, trip_a.id)
+        _save_cached(user_b, trip_b.id)
+        base_from = datetime.now(timezone.utc) - timedelta(hours=1)
+        base_to = base_from + timedelta(hours=8)
+        source = _RevisableOfficialAlertSource(LAT, LON, _mk_alert(base_from, base_to, 2))
+        register_official_alert_source(source)
+
+        svc_a, svc_b = TripAlertService(user_id=user_a), TripAlertService(user_id=user_b)
+        svc_a._record_official_alert_state(trip_a.id, svc_a.check_official_alert_triggers(trip_a))
+        svc_b._record_official_alert_state(trip_b.id, svc_b.check_official_alert_triggers(trip_b))
+        state_b_before = AlertStateService(user_id=user_b).load(trip_b.id)
+
+        source.alert = _mk_alert(base_from + timedelta(hours=4), base_to + timedelta(hours=5), 2)
+        second_a = svc_a.check_official_alert_triggers(trip_a)
+        assert second_a == [], f"Vorbedingung AC-1: Nutzer A muss still bleiben: {second_a!r}"
+
+        state_b_after = AlertStateService(user_id=user_b).load(trip_b.id)
+        assert state_b_after == state_b_before, (
+            f"Fortschreibung von Nutzer A darf Nutzer B nicht beruehren:\n"
+            f"vorher={state_b_before!r}\nnachher={state_b_after!r}"
+        )
+    finally:
+        oa_base._REGISTERED_SOURCES.clear()
+        oa_base._REGISTERED_SOURCES.extend(backup)
+        _clean_user(user_a)
+        _clean_user(user_b)
+
+
+# ---- AC-7/Test 14 -- echter Einstieg (Ortsvergleich) ----
+
+def test_ac7_compare_detect_real_entry(monkeypatch):
+    # Test 7/AC-7 (RED still-Fall + Non-Regression melden-Fall): echter Einstieg
+    # CompareOfficialAlertService._detect verhaelt sich wie der Trip-Pfad.
+    still = _run_compare_chain(monkeypatch, "ac7a", [(0, 0, 2), (4, 5, 2)])
+    assert len(still[0]) == 1, f"Vorbedingung: Erstmeldung muss neu sein: {still[0]!r}"
+    assert still[1] == [], f"AC-7 (still): Compare-Pfad muss wie Trip-Pfad still bleiben: {still[1]!r}"
+
+    reports = _run_compare_chain(monkeypatch, "ac7b", [(0, 0, 2), (-2, -2, 2)])
+    assert len(reports[0]) == 1
+    assert len(reports[1]) == 1, f"AC-7 (melden): erwartet erneute Meldung: {reports[1]!r}"
+
+
+def test_f006_compare_detect_self_persistence_of_silent_revision(monkeypatch):
+    """Adversary F006 (#1685 Fix-Loop Runde 2, MEDIUM): der Compare-Lesepfad
+    (`CompareOfficialAlertService._detect`, Zeile 245-246) schreibt die
+    stille Fensterrevision sofort selbst fort -- analog zum Trip-Zwilling
+    (`trip_alert.py:1399-1400`, bewacht durch Test 10/AC-10 oben). Entfernt
+    man die `save()`-Zeile im Compare-Pfad, blieben ohne diesen Test alle 69
+    Tests gruen (Testluecke): ein drittes Kettenglied vergliche sonst gegen
+    das veraltete, ERSTE Fenster und meldete faelschlich erneut. Kette wie
+    Test 10, ueber den Compare-Einstieg `_detect()`."""
+    chain = _run_compare_chain(monkeypatch, "f006", [(0, 0, 2), (4, 5, 2), (8, 8, 2)])
+    assert len(chain[0]) == 1, f"Erstmeldung muss neu sein: {chain[0]!r}"
+    assert chain[1] == [], f"Zweites Glied muss still bleiben: {chain[1]!r}"
+    assert chain[2] == [], f"Drittes Glied muss (Fortschreibung) still bleiben: {chain[2]!r}"
+
+
+def test_ac14_compare_orts_isolation_keine_fortschreibung_ueber_die_location_id_hinweg(monkeypatch):
+    # Test 14 (Compare-Orts-Isolation, F005/F006): Ort A traegt Warnung X bereits
+    # im Melde-Gedaechtnis, Ort B sieht dieselbe Identitaet mit unveraendertem
+    # Fenster zum ersten Mal -- kein Cross-Talk ueber die location-id-Trennung.
+    from app.config import Settings
+    from services.compare_official_alert import CompareOfficialAlertService
+    from services.official_alerts import register_official_alert_source
+
+    user_id = _fresh_user("t14")
+    _clean_user(user_id)
+    oa_base, backup = _registered_sources_backup()
+    oa_base._REGISTERED_SOURCES.clear()
+    try:
+        frozen = datetime(2026, 8, 11, 6, 0, tzinfo=timezone.utc)
+        _freeze_compare_now(monkeypatch, frozen)
+        base_from = frozen - timedelta(hours=1)
+        base_to = base_from + timedelta(hours=8)
+        loc_a = SavedLocation(id="loc-a-1685", name="Ort A", lat=LAT, lon=LON, elevation_m=1000)
+        loc_b = SavedLocation(id="loc-b-1685", name="Ort B", lat=LAT + 2.0, lon=LON + 2.0, elevation_m=1000)
+        register_official_alert_source(_RevisableOfficialAlertSource(LAT, LON, _mk_alert(base_from, base_to, 2)))
+        register_official_alert_source(
+            _RevisableOfficialAlertSource(LAT + 2.0, LON + 2.0, _mk_alert(base_from, base_to, 2))
+        )
+        settings = Settings(smtp_host="dummy.invalid", smtp_user="dummy", smtp_pass="dummy",
+                             mail_to="dummy@example.com")
+        svc = CompareOfficialAlertService(settings=settings, user_id=user_id, mail_sink=lambda *a: None)
+        preset_id = "preset-1685-iso"
+
+        first, per_loc_first = svc._detect(preset_id, [loc_a])
+        assert len(first) == 1, f"Vorbedingung: Ort A meldet neu: {first!r}"
+        svc._record_state(preset_id, per_loc_first)
+
+        _, per_loc_second = svc._detect(preset_id, [loc_a, loc_b])
+        assert "loc-b-1685" in per_loc_second, f"Ort B muss trotz identischem Fenster neu gelten: {per_loc_second!r}"
+        assert "loc-a-1685" not in per_loc_second, f"Ort A darf nicht erneut als neu gelten: {per_loc_second!r}"
+    finally:
+        oa_base._REGISTERED_SOURCES.clear()
+        oa_base._REGISTERED_SOURCES.extend(backup)
+        _clean_user(user_id)


### PR DESCRIPTION
Behebt #1685 — Issue-Close erst nach bestandenem Prod-Selftest (kein Auto-Close-Schlüsselwort).

## Der Fehler, am Live-System belegt

Korrigiert eine Behörde nur das Gültigkeitsfenster einer bereits gemeldeten Warnung, galt sie bisher als neu — das Fenster ist Teil des Melde-Schlüssels (#1245).

Aus `alert_state/5f534011.json` (Produktion, 10.08.):
```
official_alert:region:Kartitsch:thunderstorm:...T12:00:00+00:00:...T20:00:00+00:00  reported_at 05:01Z  (Morgenbriefing)
official_alert:region:Kartitsch:thunderstorm:...T16:00:00+00:00:...T01:00:00+00:00  reported_at 08:30Z  (Alarm, 3,5 h später)
```
Beide Stufe 2.0 (GELB), Fenster überlappen. Der Doppelversand steht im `alert_log`.

**Kein Einzelfall:** dasselbe Muster einen Tag zuvor über MeteoAlarm Italien (Trentino Alto Adige, Beginn 14:00 → 10:00 vorverlegt, Doppelversand 09.08. 09:30Z). Quellenübergreifend.

**Gegenprobe am selben Datenbestand:** echte Folgeperioden (Hitze 03.→04.08., 04.→05.08., Friuli) überlappen **nicht** — die neue Regel trennt sie unverändert korrekt.

**Verworfene Alternative:** die Warn-Nummer der Behörde als stabile Kennung. Live gemessen (`getWarningsForCoords`, Kartitsch): `warnid` ist bei automatischen Kurzwarnungen ein Typ-Code (`5`), der über viele verschiedene Warnungen gleich bleibt — als Kennung würde er echte Warnungen zusammenwerfen. Fünf von sechs Quellen setzen ohnehin kein `dedup_id`.

## Die Regel (PO-Entscheidung 2026-08-10)

Überlappt das neue Fenster ein bereits gemeldetes derselben Identität + Gefahr, bleibt es **still** — außer die Stufe ist gestiegen **oder** der Beginn liegt ≥ 2 h früher.

| Gemeldet war | Neu geliefert | Verhalten |
|---|---|---|
| Kartitsch 14:00–22:00 GELB | 18:00–03:00 GELB | still (später, überlappt) |
| " | 14:00–02:00 GELB | still (nur verlängert) |
| " | 12:00–20:00 GELB | **melden** (2 h früher) |
| " | 10:00–18:00 GELB | **melden** (4 h früher) |
| " | 18:00–03:00 ORANGE | **melden** (Stufe gestiegen) |
| " | morgen 14:00–22:00 GELB | **melden** (kein Überlapp) |

Die Asymmetrie ist Absicht: ein Ereignis, das früher eintritt, zwingt zum Umplanen — der in #1468 wörtlich als „höchstrelevant" bezeichnete Fall bleibt ein Alarm.

## Umsetzung

- Neue geteilte Funktion `official_alert_revision_verdict` neben `official_alert_state_key`; **Trip und Ortsvergleich nutzen dieselbe** (Teilungs-Invariante).
- Bei stiller Revision wird der Zustand fortgeschrieben (alter Schlüssel entfällt) — sonst meldet das dritte Glied einer Revisionskette fälschlich erneut.
- Melde-Gedächtnis-Einträge tragen jetzt `valid_from`/`valid_to`. Read-Modify-Write mit Merge; Bestandsdaten ohne die Felder bleiben gültig und verhalten sich wie bisher.
- **Anzeige unberührt:** `dedupe_official_alerts` ist unverändert, beide Perioden bleiben in der Mail sichtbar.

**Spec-Präzisierung:** #1245 AC-4 lautet künftig „T2 überlappt T1 nicht" statt „T2 ≠ T1". Der bewachende Test `test_official_alert_dedup_timespan.py::TestAC4TriggerNewPeriodFiresIndependently` arbeitet mit aneinandergrenzenden Perioden (`period_b_from = period_a_to`) und bleibt unverändert grün — nachgemessen, nicht angenommen.

## Prüfung

Adversary drei Runden, erste Fassung **BROKEN**:

- **F001 CRITICAL** — der Zeitvergleich lag außerhalb des `try/except`. Ein naiver Zeitstempel (vigilance/meteoalarm liefern solche, dokumentiert in `official_alerts/base.py:47-56`) gegen einen zeitzonenbehafteten Bestandseintrag warf `TypeError`. Über den fail-soft-Zweig in `trip_alert.py:459-462` hätte das **alle** amtlichen Warnungen des Trips für den Lauf verschluckt — schlimmer als der Ursprungsbug.
- **F002 HIGH** — `.get("reported_at", "")` liefert `None` bei explizit gespeichertem `None`; der Tie-Break warf `TypeError`.
- **F004/F005** — zwei bewusst eingebaute Schutzmechanismen (Anti-Deeskalation, unparsebarer Zeitstempel) waren durch keinen Test bewacht; ihre Entfernung ließ alle Tests grün.
- **F006** — die Selbstpersistenz im **Vergleichs**-Pfad war ungeprüft, während der Trip-Zwilling bewacht war.
- **F007** — bei fehlendem `reported_at` wurde ein erfundener Jetzt-Zeitstempel geschrieben, der künftige Tie-Breaks systematisch gegen echte, ältere Werte gewonnen hätte.

Alle behoben, jeder Fix per Mutation belegt. Protokoll: `docs/artifacts/fix-1685-warnfenster-revision/adversary-dialog.md` (nicht eingecheckt, `docs/artifacts` ist gitignored).

**Tests:** 71 grün (18 neue + 53 Non-Regression). Voller Lauf mit `--disable-socket` zeigt keine Regression in den berührten Dateien. `ruff` sauber.

**Mail-Gates:** `test_issue_811_mode_matrix.py` 41 grün · `briefing_mail_validator.py` Exit 0 · `official_alert_mail_validator.py` Exit 0 (gegen echt zugestellte Staging-Mail).

## Nebenbefund, getrennt gebucht

#1714 — das **Ortsvergleich**-Briefing vermerkt gezeigte amtliche Warnungen überhaupt nicht; der Prüfer schickt sie 15 Minuten später erneut. #1614 hat diese Lücke nur auf der Trip-Seite geschlossen. Unabhängig von diesem PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
