### PR TITLE
test(#1703) Scheibe 1: Alarm-Renderer × alle alarmfähigen Metriken

### DIFF
--- a/docs/context/feat-1703-s1-alarm-renderer-matrix.md
+++ b/docs/context/feat-1703-s1-alarm-renderer-matrix.md
@@ -1,0 +1,306 @@
+# Context: #1703 Scheibe 1 — Alarm-Renderer × alle `_METRICS`
+
+<!-- Epic #1703 (Folgearbeit aus #1514), Scheibe 1. Deckt Fläche 1 aus
+     docs/reference/metric_output_matrix.md §4.1. Scheibe 3 (Blindstelle
+     get_all_metrics()-vs-_METRICS) ist Voraussetzung und seit PR #1710
+     erledigt — diese Scheibe baut darauf auf. -->
+
+## Request Summary
+
+Die vier Alarm-Renderer (`render_subject`/`render_email`/`render_telegram`/`render_sms`
+in `src/output/renderers/alert/render.py`) bekommen eine Matrix-Achse im bestehenden,
+bereits budgetierten Wächter `tests/tdd/test_channel_metric_matrix.py` (#1677 B,
+Option C aus `metric_output_matrix.md` §5). Zusätzlich soll erzwungen werden, dass keine
+alarmfähige Metrik unbenannt in den `_HANDLED_UNITS`-Ersatzpfad (`render.py:35/49`) fällt.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/output/renderers/alert/render.py` | Prüfling: die vier Renderer + `_val`/`_num`/`_unit_display`/`_code`/`_HANDLED_UNITS` |
+| `src/output/renderers/alert/model.py` | `AlertEvent:11`, `OnsetEvent:30`, `CorridorEvent:48` — die drei Ereignistypen |
+| `src/app/metric_catalog.py` | `_METRICS:92-590` (28 Einträge), `format_metric_value:1004`, `get_alert_label:988`, `get_sms_code:959`, `get_decimals:968` |
+| `src/services/weather_change_detection.py:82-99` | `_ALERT_METRIC_TO_CATALOG_ID` — 13 Keys, zwei OR-Tupel |
+| `src/app/models.py:1040-1060` | `AlertMetric`-Enum, 14 Werte |
+| `tests/tdd/test_channel_metric_matrix.py` | **Zieldatei** — hier kommt die neue Achse hinein (Bestand: AC-13/14/15 aus #1677 B, AC-1..AC-8 aus Scheibe 3) |
+| `tests/helpers/hourly_columns.py` | **Vorbild** für „Soll aus dem Katalog rechnen, Ausnahmen aus dem Produktivmodul lesen" |
+| `docs/reference/metric_output_matrix.md` | Fläche 1 (§4.1) + Scheibenbeschreibung (§6); Definition of Done: Zelle umtragen |
+
+### Produktive Aufrufer der vier Renderer (gemessen, außerhalb Tests)
+
+| Aufrufer | Renderer |
+|---|---|
+| `src/services/notification_service.py:1166-1171` (`_dispatch_alert_message`, ab `:1116`) | alle vier; zusätzlich `render_alert_telegram(single_msg)` bei `:1289` (Mehrort-Fan-out) |
+| `src/services/radar_alert_service.py:93-94` | `render_subject`, `render_email` |
+| `src/services/validator_render_service.py:138-141` | alle vier (Validator-Vorschau) |
+
+## Existing Patterns
+
+**Wie eine Metrik in die vier Renderer gelangt** (gemessen): `AlertEvent.metric_id`
+(`model.py:14`) → lokale Helfer → Katalogfunktionen. Kein Renderer ruft die
+Katalogfunktionen direkt auf, mit **einer** Ausnahme: `_datablock_single`
+(`render.py:365`) liest `get_metric(e.metric_id).unit` direkt und umgeht damit
+`_unit_display()` — der `thunder`-Sonderfall (`render.py:84-85`, `unit=""` → `"%"`)
+greift dort **nicht**.
+
+**Welcher Renderer welchen Helfer nutzt** (das ist die entscheidende Asymmetrie):
+
+| Helfer | `render_subject` | `render_email` | `render_telegram` | `render_sms` |
+|---|---|---|---|---|
+| `_val()` (Einheit, `_HANDLED_UNITS`) | ja (`:308`) | ja (`:355`, `:370`, `:374`) | ja (via `_email_line:338`) | **nein** |
+| `_num()`/`_unit_display()` (Multi-Zeile, #978) | ja (`:320`) | ja (`:481-505`) | ja (`:574-578`) | **nein** |
+| `_code()` → `get_sms_code()` | nein | nein | nein | **nur hier** (`:597`, `:136`) |
+| `_label()` → `get_alert_label()` | ja | ja | ja | nein |
+
+→ **`render_sms` ist strukturell ein anderer Prüffall** als die drei übrigen: es kennt
+weder Einheit noch Alarm-Kürzel, nur `sms_code`. Eine Assertion-Familie „für alle vier
+gleich" wäre falsch.
+
+**Soll-Mengen rechnen statt tippen** (`tests/helpers/hourly_columns.py:100-158`): Soll =
+Katalog minus benannte Ausnahmen, die per `getattr` **aus dem Produktivmodul** gelesen
+werden (`hourly_excluded_metric_ids():41-61` bricht mit `pytest.fail()` ab, wenn das
+Produktivmodul keine benannte Ausnahmekonstante führt), plus Vakuum-Schutz
+(`assert_soll_menge_ist_plausibel():130-158` prüft Katalog-Mindestgröße und
+Nicht-Leerheit). Das ist das Muster, das die neue Achse übernehmen muss.
+
+**Zwei Bauwege für Alarm-Nachrichten** koexistieren in den Bestandstests, ohne geteilte
+Fixture: (a) direkte Dataclass-Instanziierung (`AlertEvent(metric_id=…)`), (b) der echte
+Projektionsweg `to_alert_message()` über `WeatherChange`
+(`test_issue_917_alert_renderer.py:70-95`, `test_alert_renderer_format_bugs.py:30-59`,
+`test_issue_919_radar_alert_canonical.py:199-222`).
+
+## Dependencies
+
+- **Upstream:** `app.metric_catalog` (Label, Kürzel, Einheit, Nachkommastellen),
+  `output.renderers.email.design_tokens`, `utils.ascii_fold`, `alert.model`
+- **Downstream:** die drei Aufrufer oben — d.h. jede Änderung am Renderer wirkt auf
+  Wetter-Alarm-Versand, Radar-Alarm und Validator-Vorschau gleichzeitig
+
+## Gemessener Ist-Stand: Katalog × Alarmfähigkeit
+
+`_METRICS` hat **28** Einträge; **15** sind alarmfähig (nicht-leeres `alert_metrics`
+**oder** nicht-leeres `alert_label`): `temperature`, `temperature_cold`, `humidity`,
+`wind`, `gust`, `precipitation`, `rain_probability`, `thunder`, `cape`, `snowfall_limit`,
+`visibility`, `uv_index`, `freezing_level`, `snow_depth`, `fresh_snow`.
+
+**Die fünf alarmfähigen Metriken, deren Einheit NICHT in `_HANDLED_UNITS` steht** — sie
+laufen heute in den Ersatzpfad `render.py:51-52`:
+
+| metric_id | unit | decimals | über `AlertMetric` erreichbar? |
+|---|---|---|---|
+| `thunder` | `""` | 0 | ja (`THUNDER_LEVEL`) |
+| `cape` | `"J/kg"` | 0 | Enum-Wert existiert, aber `selectable=False` → s. offene Frage 1 |
+| `uv_index` | `""` | 0 | `alert_metrics={}` — nur `alert_label`, kein Enum-Wert |
+| `snow_depth` | `"cm"` | 0 | `alert_metrics={}` — nur `alert_label`, kein Enum-Wert |
+| `fresh_snow` | `"cm"` | 0 | ja (`FRESH_SNOW`) |
+
+**Der eigentliche Konstruktionsfehler** (gemessen, nicht vermutet): `_HANDLED_UNITS`
+(`render.py:35`) ist eine **wortgleiche Kopie** der sieben Einheiten, die
+`format_metric_value()` (`metric_catalog.py:1016-1024`) tatsächlich mit Suffix
+formatiert — `m`, `km`, `hPa`, `%`, `km/h`, `°C`, `mm`. Der `else`-Zweig dort
+(`:1025-1026`) liefert `str(value)` **ohne Einheit**; der Ersatzpfad in `_val()` ist
+also eine bewusste Reparatur, kein Defekt. Fragil ist die **Doppelung**: wird
+`format_metric_value()` um eine Einheit erweitert, ohne `_HANDLED_UNITS` mitzuziehen,
+bleibt der Alarm-Renderer still im Ersatzpfad — und verliert dort die deutsche
+Zahlformatierung (kein Tausenderpunkt, Dezimalpunkt statt Komma).
+
+`AlertMetric` (`models.py:1040-1060`) hat 14 Werte, `_ALERT_METRIC_TO_CATALOG_ID` 13 Keys.
+`HUMIDITY` ist ein bewusst toter Eintrag (Kommentar `models.py:1057-1060`:
+Deserialisierbarkeit alt-persistierter `AlertRules`). Zwei OR-Tupel:
+`TEMPERATURE_MIN → ("temperature_cold", "temperature")`,
+`SNOW_LINE → ("snowfall_limit", "freezing_level")`. Kein `alert_metrics`-Wert im Katalog
+zeigt ins Leere. `SNOW_LINE` wird von keiner Katalog-Metrik selbst deklariert — es
+existiert nur als Rückwärtsabbildung.
+
+## Gemessener Ist-Stand: Testabdeckung (= die unbewachte Fläche)
+
+18 Testdateien rufen die vier Renderer auf. **Keine einzige** parametrisiert über
+`_METRICS` oder `get_all_metrics()`. Über alle Alarm-Renderer-Tests hinweg kommen
+insgesamt **8 verschiedene** `metric_id`-Werte vor: `gust`, `temperature_cold`,
+`precipitation`, `cape`, `thunder`, `rain_probability`, `visibility`, `freezing_level`
+— von 15 alarmfähigen Katalogeinträgen. **Sieben alarmfähige Metriken werden in keinem
+Alarm-Renderer-Test je gerendert.**
+
+Das Nächstliegende ist `test_issue_919_radar_alert_canonical.py:234-247`
+(`test_ac8_deviation_all_four_renderers_run`) — ruft alle vier Renderer nacheinander
+auf, aber nur für `gust`, und nur als Nicht-Leer-Smoketest.
+
+**`_HANDLED_UNITS` wird in keinem Test als Bezeichner gelesen**
+(`grep -rln "_HANDLED_UNITS" tests/ src/` trifft nur `render.py` selbst). Der Ersatzpfad
+ist ausschließlich für `cape`/`J/kg` geprüft:
+`test_952_alert_mail_design_fidelity.py:51-62` testet `_val()` direkt
+(`assert _val(event, 1230.0) == "1230 J/kg"`), `test_957_alert_mail_literal_structure.py:149-156`
+prüft `"500 J/kg" in html`. Für `cm` (`snow_depth`, `fresh_snow`), `""` (`thunder`,
+`uv_index`), `°` (`wind_direction`), `h` (`sunshine`) existiert **keine** Prüfung des
+Ersatzpfads.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1703_s3_selectable_metrics.md` — Vorgänger-Scheibe, liefert
+  `_METRICS`-statt-`get_all_metrics()`-Iterationsbasis und das Spec-Format
+- `docs/specs/modules/fix_1677_sms_reihenfolge.md` — AC-13/14/15, das budgetierte Gate,
+  in das die neue Achse eingehängt wird
+- `docs/reference/metric_output_matrix.md` §4.1 „Fläche 1", §6 „Scheibe 1"
+
+## Risks & Considerations
+
+1. **`render_sms` gehört strukturell nicht in dieselbe Assertion-Familie.** Es kennt
+   weder Einheit noch `alert_label`, nur `sms_code`. Wer „alle vier gleich" prüft, prüft
+   `render_sms` gegen eine Zusicherung, die dort nicht gilt.
+2. **Prüfort = Wirkort.** `_val()` direkt zu testen (wie
+   `test_952_alert_mail_design_fidelity.py:51-62`) prüft die Hilfsfunktion, nicht die
+   Verdrahtung. Die Zusicherung „keine alarmfähige Metrik fällt unbenannt in den
+   Ersatzpfad" wirkt in `render_subject`/`render_email`/`render_telegram` — dort muss
+   sie gemessen werden. (Memory: `reference_pruefort_muss_dem_wirkort_entsprechen`)
+3. **`temperature_cold`/`TEMPERATURE_MIN` hat zwei verwechselbare Schutzmechanismen.**
+   `is_alert_metric_active()` trägt das Ergebnis über das OR-Tupel (`temperature`),
+   **nicht** über `_SELECTABLE_GATE_EXEMPT` — die Exemption wird dort nie gelesen. Genau
+   diese Verwechslung war Adversary-Finding F001 in Scheibe 3. Eine Behauptung „X wirkt
+   wegen der Exemption" auf dem Alarmpfad ist ein Verdachtsfall.
+   (Memory: `reference_selectable_gate_collateral_damage_pattern`)
+4. **Ein Wächter über den Ersatzpfad darf nicht zur Schwellen-Manipulation verleiten.**
+   Der Ersatzpfad ist heute inhaltlich korrekt (er hängt die Einheit an, was
+   `format_metric_value()` unterlassen würde). Der Wächter muss die **Doppelung**
+   bewachen, nicht den Ersatzpfad verbieten.
+5. **Keine geteilte Alarm-Fixture vorhanden.** Eine neue, katalogweit parametrisierte
+   Achse braucht einen Fixture-Bauweg — Entscheidung „direkte Dataclass" vs.
+   „Projektionsweg `to_alert_message()`" steht in der Analyse an und hat direkte
+   Auswirkung darauf, was der Test überhaupt beweisen kann.
+6. **Pfadfehler im Epic-Issue und im Matrix-Dokument:** beide nennen
+   `tests/tdd/test_compare_hourly_catalog_columns.py:122` als Vorbild. Die Datei liegt
+   unter `tests/unit/test_compare_hourly_catalog_columns.py`; das eigentliche Muster
+   steckt in `tests/helpers/hourly_columns.py`.
+
+## Analysis
+
+### Type
+
+Feature (Wächter-Ausbau) — kein Bug-Fix-Auftrag. Wie Scheibe 3: neue Achse in einer
+bestehenden, budgetierten Testdatei. Die Analyse hat allerdings drei Widersprüche im
+Prüfling **gemessen**, die den Zuschnitt berühren (s. „Gemessene Widersprüche").
+
+### Die Soll-Menge, gerechnet statt getippt
+
+Drei Kandidatenmengen, gemessen unterschiedlich groß:
+
+| Menge | Größe | Inhalt |
+|---|---|---|
+| `alert_label != ""` **oder** `alert_metrics != {}` | 15 | die 15 aus dem Kontext-Abschnitt |
+| in `_ALERT_METRIC_TO_CATALOG_ID` erreichbar | **11** | ohne `humidity`, `rain_probability`, `uv_index`, `snow_depth` |
+| davon produktiv im Trip-Alarm erzeugbar | **10** | zusätzlich ohne `cape` |
+
+Gemessen, warum die vier wegfallen: `humidity` und `rain_probability` sind
+`is_precursor=True` (Katalog-Docstring: „ignoriert von `from_display_config`/
+`from_alert_rules`"); `uv_index` und `snow_depth` haben weder `alert_metrics` noch
+einen Eintrag in `_ALERT_METRIC_TO_CATALOG_ID` (`weather_change_detection.py:82-99`).
+
+→ **Die Soll-Menge ist rechenbar** (`alert_metrics`/`is_precursor` aus dem Katalog +
+`_ALERT_METRIC_TO_CATALOG_ID` aus dem Produktivmodul), ganz ohne getippte Liste. Die
+vier Ausschlüsse tragen ihre Begründung im Produktivcode — das `hourly_columns.py`-
+Muster ist also anwendbar, ohne eine neue Ausnahme-Konstante erfinden zu müssen.
+
+### Renderer-Zuschnitt: drei plus eins, nicht vier gleich
+
+`render_subject`/`render_email`/`render_telegram` teilen `_val()`/`_label()`
+(`get_alert_label`). `render_sms` teilt davon **nichts** — nur `_code()`
+(`get_sms_code`). Zwei Assertion-Familien, nicht eine.
+
+`OnsetEvent` gehört **nicht** in die Matrix: die Dataclass hat kein `metric_id`-Feld
+(`model.py:30-46`), alle drei produktiven Konstruktoraufrufe
+(`radar_alert_service.py:59-68`, `notification_service.py:1085-1094`,
+`validator_render_service.py:102-110`) setzen keinen Katalogbezug, und der Renderer
+verzweigt binär über `is_convective` mit hartcodierten Literalen (`render.py:146/225/276/285`).
+Strukturell metrik-los.
+
+`CorridorEvent` trägt zwar `metric_id` (`model.py:54`), ist aber ein **toter Pfad**:
+`evaluate_corridor_thresholds()` (`corridor_threshold.py:68`) hat keinen Aufrufer in
+`src/`/`api/`, und der einzige produktive `_send_alert()` (`trip_alert.py:296`) übergibt
+`corridor_hits` nicht — Default `None` → `[]` (`trip_alert.py:1225/1271`). Entsprechend
+baut **keine einzige** Testdatei im Repo je ein `CorridorEvent`
+(`grep -rln "CorridorEvent" tests/` → 0). Gehört mangels Wirkung nicht in diese Scheibe.
+
+### Gemessene Widersprüche im Prüfling
+
+Alle drei sind **gemessen** (echte Renderer-Aufrufe), nicht aus Code geschlossen:
+
+1. **Gewitter erscheint im Bündel-Alarm als Prozent, im Einzel-Alarm ohne Einheit.**
+   Einzel: `Gewitter: 10→20`; Bündel: `Gewitter 10→20%`. Ursache: der Einzelpfad liest
+   `get_metric().unit` (`""`) direkt (`render.py:47`, `:365`), der Bündelpfad nutzt
+   `_unit_display()`, das für `thunder` hart `"%"` liefert (`render.py:84-85`).
+   **Das `%` widerspricht der PO-Entscheidung #1585** (2026-08-07): `thunder` ist die
+   **Stärke** (`kein·leicht·mittel·hoch`), die Prozent-Achse wäre `thunder_probability`.
+   `alert_metrics={"max": "thunder_level"}` (`metric_catalog.py:340`) bestätigt: der
+   Alarmwert ist eine Stufe. „Stufe 3" als „3 %" auszugeben ist nutzersichtbar falsch,
+   und Gewitter ist die sicherheitskritischste Größe des Produkts.
+   Der Code-Kommentar (`render.py:78-83`) beruft sich auf eine Design-Vorlage aus #978 —
+   also auf einen Stand **vor** der PO-Entscheidung. Fachlich verwandt: #1480
+   („Wächter gegen lokale Kopien der Gewitter-Stufenskala"), zurückgestellt hinter #1488.
+
+2. **Zwei Metrikpaare sind in drei von vier Kanälen byte-identisch.**
+   `temperature`/`temperature_cold` teilen `alert_label="Temp"`,
+   `snow_depth`/`fresh_snow` teilen `alert_label="Schnee"`. Betreff, E-Mail und Telegram
+   sind für die Paare **byte-identisch**; nur der SMS-Code trennt sie (`D`/`N` bzw.
+   `SD`/`NS`). Produktiv entsteht daraus heute keine Verwechslung (`snow_depth` erreicht
+   den Alarmpfad nicht; bei `temperature_cold`/`temperature` meinen beide denselben
+   Min-Temperatur-Alarm, s. OR-Tupel). **Für den Wächter ist es dennoch entscheidend:**
+   eine Mutation, die `metric_id` zwischen den Paaren vertauscht, bliebe in drei von
+   vier Kanälen grün. Die Mutations-Gegenprobe muss das wissen.
+
+3. **Tausenderpunkt fehlt im Ersatzpfad.** `_val()` liefert `1500 J/kg`, `_num()` für
+   denselben Wert `1.500` (`render.py:51` hat keine Tausenderlogik, `:66-72` schon).
+   Betrifft alle fünf Ersatzpfad-Metriken ab Wert 1000. Produktiv praktisch
+   unerreichbar: `cape` erreicht den Trip-Alarm nicht, `thunder` läuft auf Stufe 0–3,
+   `uv_index`/`snow_depth` erreichen den Alarmpfad nie, `fresh_snow` bräuchte 10 m
+   Neuschnee.
+
+**Zusätzlich gemessen — `cape` ist nicht überall blockiert:** Im Trip-Pfad ja
+(`display_config` und `metric_alert_levels` sind gekoppelt, `trip_alert.py:265-274`).
+Im **Compare-Pfad** nicht: `_display_config_from_active_metrics()` gibt für
+nicht-migrierte Alt-Presets `None` zurück (`compare_alert.py:500-501`), und
+`alert_preset.py:278` ruft den `is_alert_metric_active`-Filter **nur bei gesetztem**
+`display_config` auf — `_STANDARD_METRIC_LEVELS` enthält `cape` (`compare_alert.py:44`).
+Ob ein solcher Alt-Preset produktiv existiert, ist **nicht gemessen** (lokal keine
+`kind="vergleich"`-Datei vorhanden). Der Validator-Vorschau-Endpoint
+(`POST /api/trips/{id}/alert-preview`) ist ungefiltert, aber kein Nutzer-Versandweg.
+
+### Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `tests/tdd/test_channel_metric_matrix.py` | MODIFY | neue Achse: Alarm-Renderer × rechenbare Soll-Menge |
+| `docs/reference/metric_output_matrix.md` | MODIFY | Fläche 1 auf den neuen Wächter umtragen (Definition of Done) |
+| `docs/specs/modules/fix_1703_s1_alert_renderer_matrix.md` | CREATE | Spec |
+| `src/output/renderers/alert/render.py` | MODIFY *(nur bei Scope-Variante B)* | `_unit_display()`-Sonderfall `thunder` |
+
+### Scope Assessment
+
+- Dateien: 3 (Variante A) bzw. 4 (Variante B)
+- Geschätzte LoC: +180/-0 (A) bzw. +195/-3 (B) — unter dem 250er-Limit
+- Risiko: **MITTEL**. Der Wächter selbst ist risikoarm (Testdatei). Variante B fasst den
+  Alarm-Renderer an, der von drei Diensten geteilt wird.
+
+### Technical Approach
+
+Neue Achse in `test_channel_metric_matrix.py`, parametrisiert über die **gerechnete**
+Soll-Menge. Zwei Assertion-Familien: (a) Betreff/E-Mail/Telegram gegen
+`get_alert_label()`, (b) SMS gegen `get_sms_code()` mit token-grenzen-bewusstem Match
+(die Präfix-Kollision `N` ⊂ `NL`/`NS` macht eine reine Teilstring-Prüfung unbrauchbar —
+im Bestand ist der einzige kollisionssichere Alarm-SMS-Test die Vollstring-Gleichheit
+`test_alert_sms_location_positions.py:454`). Zusätzlich ein Wächter gegen die
+**Doppelung** `_HANDLED_UNITS` ↔ `format_metric_value()`: für jede Einheit prüfen, ob
+die Whitelist mit dem tatsächlichen Formatierungsverhalten übereinstimmt — das ist
+maschinell prüfbar und fängt genau den lautlosen Drift, den das Epic beschreibt.
+
+Ausnahmen folgen dem `_NIGHT_SCALAR_IDS`-Muster (`channel_layout.py:85-89` ↔
+`test_channel_metric_matrix.py:57-60`): **kein `pytest.skip`**, sondern ein invertierter
+Assertion-Zweig in derselben parametrisierten Funktion.
+
+### Open Questions
+
+- [x] **Scope-Entscheidung PO (2026-08-11): Variante B — Gewitter-Prozent wird in dieser
+      Scheibe mitrepariert.** `_unit_display()`s `thunder`-Sonderfall (`render.py:84-85`)
+      fällt; der Bestandstest aus #978, der `"Gewitter 10→20%"` erwartet
+      (`test_978_deviation_line_readability.py:232`, ebenso `:218` im Betreff), prüft
+      damit veraltetes Verhalten und wird auf den Sollzustand nachgezogen — nicht
+      gelöscht, weil er die Bündel-Zeile im Übrigen weiter bewacht. Maßgeblich ist die
+      spätere Entscheidung #1585 (2026-08-07) gegen die frühere Design-Vorlage #978.

--- a/docs/reference/metric_output_matrix.md
+++ b/docs/reference/metric_output_matrix.md
@@ -145,6 +145,42 @@ fremder Einheit **still** auf einen Ersatzpfad aus — das Ergebnis ist eine
 plausibel aussehende, inhaltlich falsche Alarmmeldung statt eines Fehlers.
 *Priorität 1, weil Alarme sicherheitsrelevant sind und der Fehlermodus lautlos ist.*
 
+**✅ Erledigt (2026-08-11, Epic #1703 Scheibe 1):** Wächter in
+`tests/tdd/test_channel_metric_matrix.py` (`test_ac_s1_1_alarm_beschriftung_in_betreff_mail_telegram`,
+`test_ac_s1_2_sms_kuerzel_als_eigenstaendiger_token` + `…_sms_praefix_gegenprobe`,
+`test_ac_s1_3_soll_menge_wird_gerechnet_und_ist_plausibel`,
+`test_ac_s1_4_handled_units_deckt_sich_mit_der_katalog_formatierung`,
+`test_ac_s1_5_gewitter_allein_/_gebuendelt_ohne_prozentzeichen`,
+`test_ac_s1_6_uebrige_groessen_behalten_ihre_katalog_einheit` + `…_prozentzeichen_bleibt_wo_die_einheit_es_verlangt`,
+`test_ac_s1_7_doppeldeutige_beschriftung_ist_benannt` + `…_gleichnamige_groessen_trennt_nur_die_kurznachricht`).
+Parametrisiert über die **gemessene Soll-Menge von 11** alarmfähigen Katalog-Kennungen —
+gerechnet aus dem Produktivmodul (`_ALERT_METRIC_TO_CATALOG_ID`,
+`weather_change_detection.py:82-99`), nie im Test aufgezählt: `cape`, `freezing_level`,
+`fresh_snow`, `gust`, `precipitation`, `snowfall_limit`, `temperature`, `temperature_cold`,
+`thunder`, `visibility`, `wind`. Auch die `_HANDLED_UNITS`-Whitelist ist jetzt gegen das
+tatsächliche Formatierungsverhalten des Katalogs gehalten (beide Richtungen, 12 Fälle über
+die Vereinigung aus Katalog-Einheiten und Whitelist-Einträgen). Mitrepariert: der
+Gewitter-Sonderfall in `_unit_display()` hängte im **gebündelten** Alarm ein Prozentzeichen
+an eine Stufe (0–3) — ersatzlos entfernt, PO-Entscheidung #1585 löst die ältere
+#978-Design-Vorlage ab; die drei Bestands-Assertions in
+`tests/tdd/test_978_deviation_line_readability.py` (:218, :232, :350) und der dortige
+Modul-Docstring sind nachgezogen. Spec:
+`docs/specs/modules/fix_1703_s1_alert_renderer_matrix.md`.
+
+**Grenzen dieses Wächters (benannt, nicht behoben):**
+- `CorridorEvent` (Wertebereichs-Alarm) bleibt unbewacht — toter Pfad:
+  `evaluate_corridor_thresholds()` (`corridor_threshold.py:68`) hat keinen Aufrufer in
+  `src/`/`api/`, und der produktive `_send_alert()` (`trip_alert.py:296`) übergibt
+  `corridor_hits` nicht.
+- `OnsetEvent` (Radar-Beginn) bleibt unbewacht — strukturell metrik-los: die
+  Datenstruktur hat kein `metric_id`-Feld (`alert/model.py:30-46`), der Renderer
+  verzweigt binär über `is_convective` mit festen Wörtern.
+- Für `snowfall_limit`, `temperature_cold` und `wind` kann **kein** Test bemerken, wenn
+  sie aus der Rückwärts-Abbildung entfernt werden: sie deklarieren im Katalog kein
+  `alert_metrics` und hängen allein an `_ALERT_METRIC_TO_CATALOG_ID`. Die
+  Größenschranke des Vakuum-Schutzes (≥ 8) fängt eine einzelne Entfernung nicht
+  (11 − 1 = 10).
+
 **Fläche 2 — Alle Metriken × Ausblick-Tabelle.** `outlook_columns()`
 (`compare_outlook_metric_ids.py:78`), genutzt von Trip-Mail **und** Compare-Mail
 (`email/outlook.py:149`, `:343`, `:522`).
@@ -256,7 +292,7 @@ entscheidende Unterschied zu Option B und der Grund für die Empfehlung.
 Acht issue-fähige Einträge. **Keiner davon ist in dem Workflow umgesetzt, der
 dieses Dokument erzeugt hat** — er hat ausschließlich diese Datei angelegt.
 
-### Scheibe 1 — Alarm-Renderer × alle `_METRICS`
+### Scheibe 1 — Alarm-Renderer × alle `_METRICS` ✅ ERLEDIGT (2026-08-11)
 
 Matrix-Achse für `render_subject`/`render_email`/`render_telegram`/`render_sms`
 (`alert/render.py:292/448/549/617`) über das volle `_METRICS`. Der Test muss
@@ -264,6 +300,16 @@ zusätzlich erzwingen, dass keine alarmfähige Metrik in den `_HANDLED_UNITS`-
 Ersatzpfad (`alert/render.py:49`) fällt, ohne dort namentlich als Ausnahme zu stehen.
 *Risiko: hoch (sicherheitsrelevant, lautloser Fehlermodus). Größe: mittel — vier
 Renderer, aber gleichförmige Assertions.* Deckt Fläche 1.
+
+Umgesetzt als 7 ACs (AC-S1-1 bis AC-S1-7) in `tests/tdd/test_channel_metric_matrix.py`,
+parametrisiert über die gemessene Soll-Menge von **11** alarmfähigen Kennungen — gerechnet
+aus `_ALERT_METRIC_TO_CATALOG_ID`, nicht über `_METRICS` iteriert: die vier Metriken mit
+`alert_label`, aber ohne produktiven Alarmweg (`humidity`/`rain_probability` als
+Vorboten-Größen, `uv_index`/`snow_depth` ohne Mapping-Eintrag) müssten sonst sofort
+wieder ausgenommen werden. Gemessen an den vier echten Renderern, nicht an
+`_val()`/`_unit_display()` isoliert. Mitrepariert: Gewitter-Prozentzeichen im gebündelten
+Alarm (PO-Entscheidung #1585 löst die #978-Vorlage ab). Details, Soll-Menge, Grenzen und
+Mutations-Gegenprobe: `docs/specs/modules/fix_1703_s1_alert_renderer_matrix.md`.
 
 ### Scheibe 2 — Ausblick-Tabelle Trip + Compare
 

--- a/docs/specs/modules/fix_1703_s1_alert_renderer_matrix.md
+++ b/docs/specs/modules/fix_1703_s1_alert_renderer_matrix.md
@@ -1,0 +1,236 @@
+---
+entity_id: fix_1703_s1_alert_renderer_matrix
+type: module
+created: 2026-08-11
+updated: 2026-08-11
+status: draft
+version: "1.0"
+tags: [metrics, alert-renderer, matrix-test, epic-1703, thunder, units]
+---
+
+<!-- Epic #1703 (Folgearbeit aus #1514), Scheibe 1. Deckt Flaeche 1 aus
+     docs/reference/metric_output_matrix.md §4.1. Voraussetzung Scheibe 3
+     (PR #1710) ist erledigt -- die Iterationsbasis _METRICS statt
+     get_all_metrics() steht damit bereits. -->
+
+# Alarm-Renderer × alle alarmfähigen Metriken (#1703 Scheibe 1)
+
+## Approval
+
+- [x] Approved — PO-Freigabe 2026-08-11 („go"), ACs auf Deutsch vorgelegt und bestätigt.
+  Enthaltene Scope-Entscheidung: Gewitter-Prozentzeichen wird in dieser Scheibe
+  mitrepariert (Variante B, s. AC-5).
+
+## Purpose
+
+Die vier Alarm-Renderer (`render_subject`/`render_email`/`render_telegram`/`render_sms`)
+sind heute für **8 von 11** produktiv erreichbaren Alarm-Metriken ungeprüft: kein
+einziger Test iteriert über den Katalog, und ein alarmfähiger Katalogeintrag ohne
+Alarm-Ausgabe fällt nirgends auf. Diese Scheibe hängt eine Matrix-Achse in den
+bestehenden, budgetierten Wächter `tests/tdd/test_channel_metric_matrix.py` (#1677 B) —
+und repariert dabei einen gemessenen Widerspruch, der die sicherheitskritischste Größe
+des Produkts betrifft (PO-Entscheidung 2026-08-11, s. AC-5).
+
+## Source
+
+- **File:** `src/output/renderers/alert/render.py` (Prüfling), `tests/tdd/test_channel_metric_matrix.py` (Wächter)
+- **Identifier:** `render_subject:292` · `render_email:448` · `render_telegram:549` · `render_sms:617` · `_unit_display:75` · `_HANDLED_UNITS:35`
+
+Schicht: **Python-Core** (`src/output/renderers/`, `src/services/`). Keine Go-, keine
+Frontend-Berührung.
+
+## Estimated Scope
+
+- **LoC:** ~195 (+192 Test/Doku, −3 Produktivcode)
+- **Files:** 4
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `src/app/metric_catalog.py` | Katalog | `get_alert_label()`, `get_sms_code()`, `format_metric_value()`, `_METRICS` |
+| `src/services/weather_change_detection.py:82-99` | Produktivmodul | `_ALERT_METRIC_TO_CATALOG_ID` — **die Soll-Mengen-Quelle** |
+| `src/output/renderers/alert/model.py` | Datentypen | `AlertEvent`, `AlertMessage` |
+| `tests/tdd/test_channel_metric_matrix.py` | Wächter (Bestand) | Zieldatei, wird erweitert |
+| `tests/helpers/hourly_columns.py` | Vorbild | Muster „Soll rechnen, nicht tippen" |
+
+## Implementation Details
+
+### Die Soll-Menge (gemessen 2026-08-11, nicht getippt)
+
+```python
+# Quelle: das Produktivmodul selbst, nicht der Test.
+from services.weather_change_detection import _ALERT_METRIC_TO_CATALOG_ID
+soll = {cid for ids in _ALERT_METRIC_TO_CATALOG_ID.values() for cid in ids}
+# -> 11 IDs: cape, freezing_level, fresh_snow, gust, precipitation,
+#            snowfall_limit, temperature, temperature_cold, thunder,
+#            visibility, wind
+```
+
+Warum **11** und nicht die 15 Metriken mit `alert_label`/`alert_metrics`: `humidity` und
+`rain_probability` sind `is_precursor=True` (Vorboten-Größen, laut Katalog-Docstring von
+`from_display_config`/`from_alert_rules` ignoriert); `uv_index` und `snow_depth` tragen
+zwar ein `alert_label`, haben aber weder `alert_metrics` noch einen Eintrag im Mapping —
+sie können strukturell nie ein `AlertEvent` erzeugen. Ein Wächter, der sie mitprüfte,
+müsste sie sofort wieder ausnehmen; ein Wächter, der über `_ALERT_METRIC_TO_CATALOG_ID`
+rechnet, braucht **gar keine Ausnahmeliste**.
+
+### Der Gewitter-Fix (AC-5)
+
+```python
+# render.py:75-86 -- ENTFAELLT ersatzlos:
+def _unit_display(e: AlertEvent) -> str:
+    if e.metric_id == "thunder":
+        return "%"          # <- diese zwei Zeilen fallen
+    return get_metric(e.metric_id).unit
+```
+
+`thunder` trägt `alert_metrics={"max": "thunder_level"}` (`metric_catalog.py:340`) — der
+Alarmwert ist eine **Stufe** (0–3), keine Prozentzahl. Der Sonderfall stammt aus einer
+Design-Vorlage zu #978 und wurde von PO-Entscheidung #1585 (2026-08-07, „genau zwei
+Gewitter-Metriken: `thunder` = Stärke, `thunder_probability` = Wahrscheinlichkeit")
+überholt. Nach dem Wegfall liefert `_unit_display()` für `thunder` `""` — identisch zu
+dem, was der Einzel-Event-Pfad (`render.py:47`, `:365`) ohnehin schon liest.
+
+### Zwei Assertion-Familien, nicht eine
+
+`render_subject`/`render_email`/`render_telegram` beziehen die Beschriftung aus
+`get_alert_label()`. `render_sms` kennt weder Beschriftung noch Einheit, nur
+`get_sms_code()`. Die SMS-Prüfung braucht einen **token-grenzen-bewussten** Vergleich:
+`N` (temperature_cold) ist Wortanfang von `NL` (freezing_level) und `NS` (fresh_snow) —
+eine reine Teilstring-Suche schlüge falsch an. Vorbild für die Token-Grammatik:
+`test_channel_metric_matrix.py:194-207`; das Token-Format des Alarm-Pfads ist
+`{vorzeichen}{kürzel}{wert}[@HH]` (`render.py:596-597`).
+
+### Ausnahme-Muster
+
+Nach `_NIGHT_SCALAR_IDS` (`channel_layout.py:85-89` ↔ `test_channel_metric_matrix.py:57-60`):
+**kein `pytest.skip`**, sondern ein invertierter Assertion-Zweig in derselben
+parametrisierten Funktion.
+
+## Expected Behavior
+
+- **Input:** ein `AlertMessage` mit genau einem `AlertEvent` je Katalog-Metrik aus der
+  gerechneten Soll-Menge (bzw. zwei Events für die Bündel-Prüfung)
+- **Output:** in Betreff, E-Mail und Telegram erscheint die Beschriftung der Größe; in
+  der Kurznachricht ihr Kürzel als abgegrenzter Token
+- **Side effects:** keine. Der Wächter rendert nur, er versendet nichts.
+
+## Acceptance Criteria
+
+- **AC-1:** Gegeben ein Alarm zu genau einer der 11 alarmfähigen Wettergrößen, wenn
+  Betreff, E-Mail und Telegram-Nachricht erzeugt werden, dann nennt **jede** der drei
+  Ausgaben die Größe mit der Beschriftung, die der Katalog für sie führt.
+  - Test: parametrisiert über die gerechnete Soll-Menge; je Größe werden die drei echten
+    Renderer aufgerufen und auf die Katalog-Beschriftung geprüft — die Beschriftung wird
+    aus `get_alert_label()` gelesen, nie im Test getippt.
+
+- **AC-2:** Gegeben derselbe Alarm, wenn die Kurznachricht erzeugt wird, dann enthält
+  sie das Kürzel dieser Größe als eigenständigen Token — und **nicht** bloß als
+  zufälligen Wortanfang eines fremden Kürzels.
+  - Test: parametrisiert über dieselbe Soll-Menge, mit Token-Grammatik statt
+    Teilstring-Suche. Gegenprobe: für das Kürzel `N` darf ein Alarm, der nur
+    Nullgradgrenze (`NL`) oder Neuschnee (`NS`) enthält, **keinen** Treffer liefern.
+
+- **AC-3:** Gegeben der Wächter läuft, wenn die Menge der zu prüfenden Größen bestimmt
+  wird, dann stammt sie ausschließlich aus dem Produktivmodul
+  (`_ALERT_METRIC_TO_CATALOG_ID`) und ist niemals im Test aufgezählt.
+  - Test: die Soll-Menge wird im Test aus dem Produktivmodul gelesen; ein
+    Plausibilitäts-Wächter schlägt fehl, wenn sie leer ist oder unter 8 Einträge fällt
+    (Vakuum-Schutz nach dem Muster `hourly_columns.py:130-158`) — ein Wächter, der über
+    eine leere Menge iteriert, ist immer grün und bewacht nichts.
+
+- **AC-4:** Gegeben die Einheiten-Liste des Alarm-Renderers (`_HANDLED_UNITS`), wenn sie
+  gegen das tatsächliche Formatierungsverhalten des Katalogs gehalten wird, dann stimmen
+  beide für jede im Katalog vorkommende Einheit überein.
+  - Test: für jede Katalog-Einheit wird gemessen, ob die Katalog-Formatierung die
+    Einheit tatsächlich anhängt; das Ergebnis muss der Zugehörigkeit zur Liste
+    entsprechen — in beide Richtungen. Damit fällt auf, wenn eine der beiden Listen
+    erweitert wird und die andere zurückbleibt (heute gemessen deckungsgleich).
+
+- **AC-5:** Gegeben ein Gewitter-Alarm, wenn irgendeine der vier Ausgaben erzeugt wird,
+  dann erscheint der Gewitter-Wert **ohne** Prozentzeichen — und zwar unabhängig davon,
+  ob der Alarm allein oder gebündelt mit anderen Größen auftritt.
+  - Test: Gewitter-Alarm einzeln **und** gebündelt mit einer zweiten Größe rendern; in
+    beiden Fällen darf an den Gewitter-Wert kein Prozentzeichen angehängt sein. Heute
+    schlägt der Bündel-Fall fehl (gemessen: `Gewitter 10→20%`) — das ist der einzige
+    rote Anteil dieser Scheibe.
+
+- **AC-6:** Gegeben der Gewitter-Fix ist eingespielt, wenn Alarme zu den übrigen zehn
+  Größen erzeugt werden, dann bleiben ihre Ausgaben unverändert.
+  - Test: die Einheiten-Darstellung der anderen zehn Größen wird im gebündelten Fall
+    geprüft (Prozentzeichen bleibt bei Feuchte/Regenwahrscheinlichkeit erhalten, wo es
+    hingehört) — der Fix darf nicht über sein Ziel hinausschießen.
+
+- **AC-7:** Gegeben zwei Größen teilen sich dieselbe Beschriftung, wenn der Wächter über
+  sie läuft, dann ist diese Doppeldeutigkeit im Wächter ausdrücklich benannt statt
+  stillschweigend übergangen.
+  - Test: für `temperature` und `temperature_cold` (beide „Temp") greift ein eigener,
+    umgekehrter Prüfzweig, der festhält, dass Betreff/E-Mail/Telegram die beiden **nicht**
+    unterscheiden können und allein das Kurznachrichten-Kürzel (`D` gegen `N`) sie trennt.
+    Kein Überspringen — der Zweig prüft, was dort tatsächlich gilt.
+
+## Known Limitations
+
+1. **Der Wertebereichs-Alarm (`CorridorEvent`) bleibt außen vor.** Er trägt zwar eine
+   Metrik-Kennung, ist aber ein toter Pfad: `evaluate_corridor_thresholds()`
+   (`corridor_threshold.py:68`) hat keinen Aufrufer in `src/`/`api/`, und der einzige
+   produktive `_send_alert()` (`trip_alert.py:296`) übergibt `corridor_hits` nicht.
+   Entsprechend baut keine Testdatei im Repo je ein solches Ereignis. Ein Wächter über
+   einen toten Pfad bewacht nichts.
+2. **Der Radar-Beginn-Alarm (`OnsetEvent`) ist strukturell metrik-los.** Die Datenstruktur
+   hat kein `metric_id`-Feld (`model.py:30-46`), alle drei produktiven Erzeuger setzen
+   keinen Katalogbezug, und der Renderer verzweigt binär über `is_convective` mit festen
+   Wörtern (`render.py:146/225/276/285`). Er ist kein Punkt in einer Metrik×Kanal-Matrix.
+3. **Die Tausenderpunkt-Abweichung wird nicht repariert.** Gemessen liefert der
+   Einzel-Alarm `1500 J/kg`, der Bündel-Alarm `1.500` für denselben Wert
+   (`render.py:51` hat keine Tausenderlogik, `:66-72` schon). Produktiv praktisch
+   unerreichbar: die betroffenen Größen erreichen entweder den Alarmweg nicht
+   (`cape` im Trip-Pfad, `uv_index`, `snow_depth`) oder haben nie Werte über 1000
+   (`thunder` = Stufe 0–3, `fresh_snow` bräuchte 10 m Neuschnee). → Sammel-Eintrag #1199.
+4. **`cape` ist nur im Trip-Pfad sicher blockiert.** Im Ortsvergleich gibt
+   `_display_config_from_active_metrics()` für nicht-migrierte Alt-Vorlagen `None`
+   zurück (`compare_alert.py:500-501`), und der Aktivitäts-Filter läuft nur bei
+   gesetzter Konfiguration (`alert_preset.py:278`); `_STANDARD_METRIC_LEVELS` enthält
+   `cape` (`compare_alert.py:44`). Ob eine solche Alt-Vorlage produktiv existiert, ist
+   **nicht gemessen** — lokal liegt keine Vergleichs-Datei vor. → Sammel-Eintrag #1199,
+   getrennt von dieser Scheibe.
+5. **Der Wächter prüft Anwesenheit, nicht Richtigkeit des Werts.** Dass die Beschriftung
+   erscheint, beweist nicht, dass der Zahlenwert stimmt. Zellwert-Vollständigkeit ist
+   ausdrücklich Scheibe 5 des Epics.
+
+## Prüfhinweis für den Adversary
+
+**Die Mutations-Gegenprobe hat hier eine bekannte blinde Stelle.** `temperature` und
+`temperature_cold` tragen dieselbe Beschriftung („Temp"). Eine Mutation, die die
+Metrik-Kennung zwischen diesen beiden vertauscht, lässt Betreff, E-Mail und Telegram
+**byte-identisch** — nur die Kurznachricht ändert sich (`D` gegen `N`). Wer nur die drei
+erstgenannten Kanäle mutiert und grün bleibt, hat **nicht** bewiesen, dass der Wächter
+wirkt. Belastbare Mutationen für diese Scheibe:
+
+- `_unit_display()`s `thunder`-Zweig wieder einsetzen → AC-5 muss rot werden
+- eine ID aus der Soll-Menge entfernen → AC-3s Vakuum-Schutz muss anschlagen
+- eine Einheit zu `_HANDLED_UNITS` hinzufügen, die der Katalog nicht anhängt (z. B. `cm`)
+  → AC-4 muss rot werden
+- in der SMS-Prüfung die Token-Grammatik durch eine reine Teilstring-Suche ersetzen →
+  AC-2s Gegenprobe (`N` gegen `NL`/`NS`) muss rot werden
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Kein neues Register, kein neues Pflicht-Gate — die Achse erweitert das
+  bereits budgetierte Gate #1677 B (Option C aus `metric_output_matrix.md` §5). Der
+  Gewitter-Fix vollzieht eine bestehende PO-Entscheidung (#1585) nach, statt eine neue
+  zu treffen.
+
+## Definition of Done
+
+Zusätzlich zu den ACs: die Zelle „Fläche 1" in `docs/reference/metric_output_matrix.md`
+§4.1 wird von „unbewacht" auf den neuen Wächter umgetragen, und §6 „Scheibe 1" auf
+erledigt gesetzt — das Dokument ist laut Epic-Leitplanke Teil der Definition of Done
+jeder Scheibe.
+
+## Changelog
+
+- 2026-08-11: Initial spec created (Epic #1703 Scheibe 1)

--- a/docs/specs/modules/fix_1703_s1_alert_renderer_matrix.md
+++ b/docs/specs/modules/fix_1703_s1_alert_renderer_matrix.md
@@ -41,9 +41,16 @@ Frontend-Berührung.
 
 ## Estimated Scope
 
-- **LoC:** ~195 (+192 Test/Doku, −3 Produktivcode)
+- **LoC:** ~531 (+529 Test, −2 Produktivcode; `docs/` zählt nicht ins Limit)
 - **Files:** 4
 - **Effort:** medium
+
+> **Korrigiert 2026-08-11 nach der RED-Phase.** Die ursprüngliche Schätzung (~195) lag um
+> Faktor 2,75 daneben: die Prüftiefe wuchs durch die drei Korrekturen (s. Abschnitt
+> „Korrekturen aus der RED-Phase") — gerechnete Soll-Menge mit zwei zusätzlichen
+> Absicherungen, Vereinigungs-Prüfung bei den Einheiten, Präfix-Gegenprobe bei den
+> Kurznachrichten. Der **Produktiv**-Zähler bleibt bei 0/250; ausschließlich Testzeilen.
+> PO-Freigabe für `test_loc_limit_override 600` am 2026-08-11 eingeholt.
 
 ## Dependencies
 
@@ -171,6 +178,46 @@ parametrisierten Funktion.
     unterscheiden können und allein das Kurznachrichten-Kürzel (`D` gegen `N`) sie trennt.
     Kein Überspringen — der Zweig prüft, was dort tatsächlich gilt.
 
+## Korrekturen aus der RED-Phase (2026-08-11, gemessen)
+
+Drei Zusagen dieser Spec trugen in der ursprünglichen Fassung nicht. Gefunden beim
+Schreiben der Tests, hier nachgezogen — die ACs bleiben inhaltlich unverändert, die
+Prüfungen werden strenger.
+
+1. **AC-3s Vakuum-Schutz allein hätte nicht angeschlagen.** Der Prüfhinweis unten nannte
+   „eine ID aus der Soll-Menge entfernen → Vakuum-Schutz muss anschlagen". Gemessen
+   falsch: 11 minus 1 ergibt 10, die Größenschranke (≥ 8) feuert nicht. AC-3 prüft
+   deshalb zusätzlich (i) die parametrisierte Konstante gegen eine frische Ableitung aus
+   dem Produktivmodul (fängt eine Mutation im Test) und (ii) dass
+   `{m.id for m in _METRICS if m.alert_metrics and not m.is_precursor}` Teilmenge der
+   Soll-Menge ist (fängt eine Entfernung auf Produktivseite). **Restlücke, im Test
+   benannt:** `snowfall_limit`, `temperature_cold` und `wind` deklarieren im Katalog kein
+   `alert_metrics` und hängen allein an der Rückwärts-Abbildung — für diese drei kann
+   kein Test eine Entfernung aus dem Mapping bemerken.
+
+2. **Der Gewitter-Fix bricht DREI Bestands-Assertions, nicht zwei.** Neben
+   `test_978_deviation_line_readability.py:218` und `:232` auch `:350`
+   (`"Böen 80, Gewitter 55%, Regen% 55%"`). Die Datei steht **nicht** in
+   `.github/ci_tdd_excludes.txt`, läuft also auf CI — ohne Nachzug kippt der `test`-Job.
+   **Zusätzlich mitzuziehen:** der Modul-Docstring derselben Datei (Zeilen 25–32) hält
+   den Widerspruch als bewusste #978-Entscheidung fest („die GREEN-Phase muss diesen
+   Katalog/Vorlage-Widerspruch auflösen, z. B. Sonderfall für `metric_id=='thunder'`").
+   Diese Begründung ist mit #1585 überholt; bleibt sie stehen, widerspricht die
+   Dokumentation hinterher dem Code. Der Sonderfall war also eine dokumentierte
+   Entscheidung, keine Nachlässigkeit — er wird bewusst abgelöst, nicht still entfernt.
+
+3. **AC-4 wörtlich genommen hätte einen Listeneintrag ungeprüft gelassen.** „Für jede im
+   Katalog vorkommende Einheit" erfasst `km` nicht — `km` steht in `_HANDLED_UNITS`, ist
+   aber keine Katalog-`unit` (nur `display_unit` von `visibility`). Geprüft wird deshalb
+   die **Vereinigung** aus Katalog-Einheiten und Whitelist-Einträgen (12 Fälle, heute
+   deckungsgleich).
+
+Ebenfalls gemessen und in den Tests berücksichtigt: Eine pauschale Prozentzeichen-Prüfung
+wäre unehrlich, weil der Renderer legitim eine Änderungs-Prozentzahl („+100 %") aus
+`delta_pct()` ausgibt. Die Gewitter-Fixture nutzt deshalb `0.0 → 2.0` (Stufe 0–3, für die
+`delta_pct()` definitionsgemäß `None` liefert) — jedes verbleibende `%` ist dann
+zwangsläufig eine Einheit.
+
 ## Known Limitations
 
 1. **Der Wertebereichs-Alarm (`CorridorEvent`) bleibt außen vor.** Er trägt zwar eine
@@ -200,6 +247,20 @@ parametrisierten Funktion.
    erscheint, beweist nicht, dass der Zahlenwert stimmt. Zellwert-Vollständigkeit ist
    ausdrücklich Scheibe 5 des Epics.
 
+6. **Ein katalogbasierter Wächter kann Katalogfehler prinzipiell nicht sehen**
+   (Adversary-Finding F001, MEDIUM, gemessen 2026-08-11). Der von dieser Spec
+   vorgeschriebene Grundsatz „Soll aus dem Katalog rechnen, nie im Test tippen" (AC-3)
+   hat eine strukturelle Kehrseite: Prüfling und Maßstab lesen dieselbe Quelle. Vertauscht
+   jemand die SMS-Kürzel `D` und `N` **im Katalog selbst**, wandern Soll und Ist gemeinsam
+   mit der Mutation, und **kein** Test dieser Scheibe wird rot. Gefangen wird der Fall
+   allein von `tests/tdd/test_issue_917_alert_renderer.py::TestAC6CatalogSmsCodes` — einem
+   vorbestehenden Test aus #917, der die Literale `"D"`/`"N"` bewusst hart schreibt.
+   Diese Abhängigkeit ist im Test von AC-7 als Kommentar vermerkt, damit sie bei einer
+   künftigen Löschung jener Datei nicht unbemerkt verlorengeht. **Verallgemeinert:** Wo
+   ein Wächter sein Soll aus derselben Quelle bezieht wie der Prüfling, braucht die
+   *Korrektheit* dieser Quelle einen zweiten, bewusst redundanten Wächter mit getippten
+   Werten — „nie tippen" gilt für die Soll-*Menge*, nicht für die Soll-*Zuordnung*.
+
 ## Prüfhinweis für den Adversary
 
 **Die Mutations-Gegenprobe hat hier eine bekannte blinde Stelle.** `temperature` und
@@ -210,7 +271,10 @@ erstgenannten Kanäle mutiert und grün bleibt, hat **nicht** bewiesen, dass der
 wirkt. Belastbare Mutationen für diese Scheibe:
 
 - `_unit_display()`s `thunder`-Zweig wieder einsetzen → AC-5 muss rot werden
-- eine ID aus der Soll-Menge entfernen → AC-3s Vakuum-Schutz muss anschlagen
+- eine ID aus der Soll-Menge entfernen → **nicht** der Größen-Vakuumschutz fängt das
+  (11−1 = 10 liegt über der Schranke, s. Korrektur 1), sondern der Abgleich gegen die
+  frische Ableitung bzw. die Teilmengen-Prüfung. Für `snowfall_limit`,
+  `temperature_cold` und `wind` fängt es **gar nichts** — bekannte, benannte Restlücke.
 - eine Einheit zu `_HANDLED_UNITS` hinzufügen, die der Katalog nicht anhängt (z. B. `cm`)
   → AC-4 muss rot werden
 - in der SMS-Prüfung die Token-Grammatik durch eine reine Teilstring-Suche ersetzen →

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -73,16 +73,18 @@ def _num(e: AlertEvent, value: float) -> str:
 
 
 def _unit_display(e: AlertEvent) -> str:
-    """Einheit fuer die Multi-Metrik-Zeile (Issue #978).
+    """Einheit fuer die Multi-Metrik-Zeile (Issue #978) -- immer aus dem Katalog.
 
-    Sonderfall thunder: Katalog fuehrt die Metrik mit unit="" (historisch
-    level-basiert), die Design-Vorlage zeigt Gewitter-Werte aber als
-    Prozent (Vorschlaege.html:208/220-233/281). Lokaler Sonderfall statt
-    Katalog-Aenderung, da eine Katalog-Anpassung ein geteilter Eingriff
-    ausserhalb des Scopes dieses Fixes waere.
+    Frueher hing hier ein Sonderfall fuer 'thunder', der ein '%' anhaengte
+    (Design-Vorlage zu #978, Vorschlaege.html:208/220-233/281). Er ist mit
+    Issue #1703 Scheibe 1 ersatzlos entfallen: 'thunder' traegt
+    alert_metrics={"max": "thunder_level"} (metric_catalog.py:340), der
+    Alarmwert ist also eine STUFE (0-3), keine Prozentzahl. PO-Entscheidung
+    #1585 (2026-08-07, genau zwei Gewitter-Metriken: 'thunder' = Staerke,
+    'thunder_probability' = Wahrscheinlichkeit) hat die Vorlage abgeloest;
+    die Abloesung wurde am 2026-08-11 vom PO bestaetigt. Der Einzel-Event-Pfad
+    (:47, :365) las ohnehin schon die Katalog-Einheit ("").
     """
-    if e.metric_id == "thunder":
-        return "%"
     return get_metric(e.metric_id).unit
 
 

--- a/tests/tdd/test_978_deviation_line_readability.py
+++ b/tests/tdd/test_978_deviation_line_readability.py
@@ -22,14 +22,17 @@ tests/tdd/test_952_alert_mail_design_fidelity.py,
 tests/tdd/test_952_onset_alert_fidelity.py::TestAC8RendererParity,
 tests/tdd/test_957_alert_mail_literal_structure.py::TestSingleEventVerdictAndDatablock.
 
-Bekannte Katalog-Randbedingung (nicht Teil dieser RED-Tests, aber
-GREEN-relevant): `metric_catalog.get_metric("thunder").unit == ""` (nicht
-"%"), obwohl die Design-Vorlage Gewitter-Werte mit "%" zeigt
-(Zeilen 208/220-233/281). AC-3/AC-4 unten prüfen daher exakt die von der
-Spec vorgegebenen Literale inkl. "Gewitter 55%" — die GREEN-Phase muss diesen
-Katalog/Vorlage-Widerspruch auflösen (z.B. Sonderfall für metric_id=="thunder"
-im neuen `_num()`-Helper), da ein reiner `unit=="%"`-Check laut aktuellem
-Katalogstand nicht greift.
+Katalog-Randbedingung, seit 2026-08-11 aufgelöst: `get_metric("thunder").unit`
+ist "" (nicht "%"). Die Design-Vorlage zu #978 zeigte Gewitter-Werte mit "%"
+(Zeilen 208/220-233/281), weshalb `_unit_display()` fuer "thunder" hart ein
+"%" anhaengte und AC-3/AC-4 dieses "%" als SOLL festschrieben. Diese
+Entscheidung ist mit PO-Entscheidung #1585 (2026-08-07: genau zwei
+Gewitter-Metriken — "thunder" = Staerke, "thunder_probability" =
+Wahrscheinlichkeit) ueberholt: der Alarmwert von "thunder" ist eine STUFE
+(0-3, alert_metrics={"max": "thunder_level"}), keine Prozentzahl. Issue #1703
+Scheibe 1 hat den Sonderfall ersatzlos entfernt; die Literale unten fuehren
+Gewitter-Werte deshalb OHNE "%". Das "%" bei "Regen%" bleibt — das ist der
+Name der Metrik rain_probability, ihre Einheit ist tatsaechlich Prozent.
 """
 import sys
 
@@ -215,7 +218,7 @@ class TestAC2RoundingNoiseAndThousandSeparator:
 class TestAC3SubjectTop3JustNumbers:
     def test_subject_top3_exact_literal(self):
         subject = render_subject(_multi_msg())
-        assert "Niedersch 30, Gewitter 90%, Böen 80" in subject, (
+        assert "Niedersch 30, Gewitter 90, Böen 80" in subject, (
             f"Betreff-Top3 nicht im SOLL-Format (PO-Nachtrag 2026-07-02: "
             f"kritischster zuerst, severity-absteigend): {subject!r}"
         )
@@ -229,7 +232,7 @@ class TestAC3SubjectTop3JustNumbers:
 class TestAC4TelegramMultiLineNoUnitsExceptPercent:
     def test_telegram_multiline_exact_literal(self):
         tg = render_telegram(_multi_msg())
-        assert "Niedersch 2→30 · Gewitter 20→90% · Böen 20→80" in tg, (
+        assert "Niedersch 2→30 · Gewitter 20→90 · Böen 20→80" in tg, (
             f"Telegram-Multi-Zeile nicht im SOLL-Format (PO-Nachtrag "
             f"2026-07-02: kritischster zuerst, severity-absteigend): {tg!r}"
         )
@@ -347,7 +350,7 @@ class TestMixedOverUnderOrdering:
 
     def test_subject_top3_excludes_under_threshold_event(self):
         subject = render_subject(_mixed_over_under_msg())
-        assert "Böen 80, Gewitter 55%, Regen% 55%" in subject, (
+        assert "Böen 80, Gewitter 55, Regen% 55%" in subject, (
             f"Top-3 muss die drei über-Schwelle-Events severity-absteigend "
             f"zeigen: {subject!r}"
         )

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -32,6 +32,13 @@ temperature_cold) daher strukturell nie sehen. SPEC:
 docs/specs/modules/fix_1703_s3_selectable_metrics.md. Kein Produktivcode-Fix
 -- Charakterisierungstest fuer bereits korrektes, bisher unbewachtes
 Verhalten (alle 8 ACs laufen heute bereits GRUEN).
+
+Epic #1703 Scheibe 1 (AC-S1-1 bis AC-S1-7, ganz unten): Alarm-Renderer x alle
+alarmfaehigen Metriken (docs/reference/metric_output_matrix.md Flaeche 1) --
+die vier Alarm-Renderer waren fuer 8 von 11 produktiv erreichbaren
+Alarm-Groessen ungeprueft. SPEC:
+docs/specs/modules/fix_1703_s1_alert_renderer_matrix.md. EINZIGER roter
+Anteil dieser Achse: AC-S1-5 im gebuendelten Fall (Gewitter-Prozentzeichen).
 """
 from __future__ import annotations
 
@@ -43,15 +50,22 @@ from pathlib import Path
 import pytest
 
 from app.loader import _parse_display_config
-from app.metric_catalog import _METRICS, build_default_display_config, get_all_metrics, get_metric
+from app.metric_catalog import (
+    _METRICS, build_default_display_config, format_metric_value, get_all_metrics,
+    get_alert_label, get_cmp, get_metric, get_sms_code,
+)
 from app.models import AlertMetric, MetricConfig, UnifiedWeatherDisplayConfig, _SELECTABLE_GATE_EXEMPT
+from output.renderers.alert.model import AlertEvent, AlertMessage, side_label
+from output.renderers.alert.render import (
+    _HANDLED_UNITS, render_email, render_sms, render_subject, render_telegram,
+)
 from output.renderers.channel_layout import render_for_channel
 from output.renderers.compare_metric_catalog import COMPARE_METRIC_CATALOG, get_compare_metric_catalog
 from output.renderers.compare_metric_ids import FRONTEND_TO_RENDERER_METRIC_ID, resolve_enabled_metrics
 from output.renderers.email.helpers import resolve_metric_col_order
 from output.renderers.sms_trip import SMS_SYMBOL_BY_METRIC, SMS_MULTI_SYMBOLS_BY_METRIC
 from output.renderers.trip_report import TripReportFormatter
-from services.weather_change_detection import is_alert_metric_active
+from services.weather_change_detection import _ALERT_METRIC_TO_CATALOG_ID, is_alert_metric_active
 
 from tests.tdd import _min_temp_felt_fixtures as F
 
@@ -1023,4 +1037,532 @@ def test_kaskade_ac12_sms_order_is_applied_not_positional():
     )
     assert ib_first is not None and ib_second is not None and ib_second < ib_first, (
         f"AC-12: Reihenfolge B ({second_id} vor {first_id}) nicht umgesetzt: {sms_ba!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Epic #1703 Scheibe 1 (AC-S1-1 bis AC-S1-7): Alarm-Renderer x alle
+# alarmfaehigen Metriken (docs/reference/metric_output_matrix.md Flaeche 1).
+# SPEC: docs/specs/modules/fix_1703_s1_alert_renderer_matrix.md.
+#
+# Eigene AC-Nummerierung (AC-S1-n), damit sie weder mit AC-13/14/15 (#1677 B)
+# noch mit AC-1..AC-8 (Scheibe 3) kollidiert.
+#
+# EINZIGER roter Anteil: AC-S1-5 im gebuendelten Fall. _unit_display()
+# (render.py:75-86) haengt fuer 'thunder' hart ein '%' an, obwohl der
+# Alarmwert eine STUFE ist (alert_metrics={'max': 'thunder_level'},
+# metric_catalog.py:340) -- PO-Entscheidung #1585 (genau zwei
+# Gewitter-Metriken: 'thunder' = Staerke, 'thunder_probability' =
+# Wahrscheinlichkeit) loest die aeltere Design-Vorlage aus #978 ab.
+#
+# ZWEI Assertion-Familien statt einer (Kontext-Dokument, Tabelle "Welcher
+# Renderer welchen Helfer nutzt"): Betreff/E-Mail/Telegram beziehen die
+# Beschriftung ueber _label() -> get_alert_label(); render_sms kennt weder
+# Beschriftung noch Einheit, nur _code() -> get_sms_code(). Geprueft wird
+# ausschliesslich an den vier ECHTEN Renderern (Pruefort = Wirkort) -- nie an
+# _val()/_unit_display() isoliert, denn das pruefte den Helfer statt die
+# Verdrahtung (s. Korrektur-Abschnitt der Scheibe-3-Spec).
+# ---------------------------------------------------------------------------
+
+
+def _alarm_soll_ids() -> set[str]:
+    """Die alarmfaehigen Katalog-Kennungen -- GERECHNET aus dem Produktivmodul
+    (``_ALERT_METRIC_TO_CATALOG_ID``, weather_change_detection.py:82-99), nie
+    im Test aufgezaehlt (AC-S1-3). Wer ueber diese Menge iteriert, braucht
+    keine Ausnahmeliste: humidity/rain_probability (is_precursor) und
+    uv_index/snow_depth (kein Mapping-Eintrag) fallen strukturell heraus."""
+    return {cid for ids in _ALERT_METRIC_TO_CATALOG_ID.values() for cid in ids}
+
+
+_ALARM_SOLL_IDS = sorted(_alarm_soll_ids())
+
+# Vakuum-Schutz-Untergrenze (Muster tests/helpers/hourly_columns.py:130-158):
+# ein Waechter, der ueber eine leere oder stark geschrumpfte Menge iteriert,
+# ist immer gruen und bewacht nichts. Gemessen 2026-08-11: 11 Kennungen.
+_ALARM_SOLL_MINDESTGROESSE = 8
+
+# Gewitter-Kennung aus dem Produktivmodul gelesen statt getippt.
+_GEWITTER_ID = _ALERT_METRIC_TO_CATALOG_ID[AlertMetric.THUNDER_LEVEL][0]
+
+_UNIT_PROBE_VALUE = 12.0
+_EINHEITEN_UNTER_BEOBACHTUNG = sorted({m.unit for m in _METRICS} | set(_HANDLED_UNITS))
+
+# Alarm-SMS-Tokengrammatik (render.py:596-601 ``_sms_token``,
+# render.py:136-137 ``_sms_corridor_token``): {Vorzeichen}{Kuerzel}{Wert}[@HH],
+# optional mit vorangestellter Ortsposition "{n}:". Eine reine Teilstring-Suche
+# waere hier unbrauchbar -- 'N' (temperature_cold) ist Wortanfang von 'NL'
+# (freezing_level) und 'NS' (fresh_snow), s. AC-S1-2-Gegenprobe.
+_ALERT_SMS_TOKEN = re.compile(r"^(?:\d+:)?[+\-!]([A-Za-z][A-Za-z/]*)-?\d+(?:@\d+)?$")
+
+
+def _alert_sms_codes(sms: str) -> list[str]:
+    """Die Kuerzel einer Alarm-Kurznachricht in Token-Reihenfolge -- Token fuer
+    Token zerlegt, nie per Teilstring gesucht."""
+    body = sms.split(": ", 1)[1] if ": " in sms else sms
+    codes = []
+    for token in body.split(" "):
+        hit = _ALERT_SMS_TOKEN.match(token)
+        if hit:
+            codes.append(hit.group(1))
+    return codes
+
+
+def _alarm_kontroll_id(metric_id: str) -> str:
+    """Fremd-Groesse fuer die Verwechslungs-Gegenprobe: ihre Beschriftung darf
+    in der Ausgabe NICHT vorkommen. 'Wind'/'Boeen' sind mit keiner anderen
+    Alarm-Beschriftung teilstring-verwandt; dass beide zur Soll-Menge gehoeren,
+    prueft AC-S1-3."""
+    return "wind" if metric_id != "wind" else "gust"
+
+
+def _alert_event(
+    metric_id: str, *, value_from: float = 10.0, value_to: float = 20.0,
+    threshold: float = 5.0,
+) -> AlertEvent:
+    """Ein Abweichungs-Ereignis. ``cmp`` kommt aus dem Katalog (get_cmp), damit
+    der Test die Richtung nicht erfindet."""
+    return AlertEvent(
+        metric_id=metric_id, value_from=value_from, value_to=value_to,
+        threshold=threshold, cmp=get_cmp(metric_id), occurred_at="09:00",
+        km_from=0.0, km_to=5.0,
+    )
+
+
+def _alert_message(*events: AlertEvent) -> AlertMessage:
+    return AlertMessage(trip_short="T1703S1", stand_at="08:00", events=tuple(events))
+
+
+def _label_kanaele(msg: AlertMessage) -> dict[str, str]:
+    """Die drei Ausgaben, die die Beschriftung fuehren -- ECHTE Renderer.
+    Der sichtbare HTML-Text entsteht durch Entfernen der Tags: Auszeichnung wie
+    ``width="100%"`` ist keine Ausgabe (relevant fuer AC-S1-5)."""
+    html, plain = render_email(msg)
+    return {
+        "Betreff": render_subject(msg),
+        "E-Mail (Klartext)": plain,
+        "E-Mail (HTML-Text)": re.sub(r"<[^>]+>", "", html),
+        "Telegram": render_telegram(msg),
+    }
+
+
+# --- AC-S1-1: Beschriftung in Betreff/E-Mail/Telegram ---------------------
+
+
+@pytest.mark.parametrize("metric_id", _ALARM_SOLL_IDS)
+def test_ac_s1_1_alarm_beschriftung_in_betreff_mail_telegram(metric_id):
+    """AC-S1-1: ein Alarm zu genau einer alarmfaehigen Groesse nennt sie in
+    Betreff, E-Mail UND Telegram mit der Katalog-Beschriftung -- gelesen aus
+    get_alert_label(), nie im Test getippt. Die Gegenprobe (Beschriftung einer
+    fremden Groesse darf NICHT erscheinen) macht die Zusicherung
+    mutationsempfindlich; fuer das gleichnamige Paar temperature/
+    temperature_cold gilt sie nur eingeschraenkt -- das haelt AC-S1-7 fest."""
+    label = get_alert_label(metric_id)
+    kontroll_label = get_alert_label(_alarm_kontroll_id(metric_id))
+    ausgaben = _label_kanaele(_alert_message(_alert_event(metric_id)))
+
+    for kanal, text in ausgaben.items():
+        assert label in text, (
+            f"AC-S1-1: {kanal} nennt die Groesse {metric_id!r} nicht mit ihrer "
+            f"Katalog-Beschriftung {label!r}: {text!r}"
+        )
+        assert kontroll_label not in text, (
+            f"AC-S1-1 (Gegenprobe): {kanal} traegt die Beschriftung "
+            f"{kontroll_label!r} einer gar nicht alarmierten Groesse: {text!r}"
+        )
+
+
+# --- AC-S1-2: SMS-Kuerzel als abgegrenzter Token --------------------------
+
+
+@pytest.mark.parametrize("metric_id", _ALARM_SOLL_IDS)
+def test_ac_s1_2_sms_kuerzel_als_eigenstaendiger_token(metric_id):
+    """AC-S1-2: die Kurznachricht traegt das Kuerzel der Groesse als
+    eigenstaendigen Token. Geprueft wird mit Token-Grammatik statt
+    Teilstring-Suche, und es darf KEIN fremdes Kuerzel mitgelesen werden."""
+    code = get_sms_code(metric_id)
+    assert code, (
+        f"Vorbedingung: {metric_id!r} hat kein sms_code -- _code() fiele auf "
+        "die metric_id zurueck (render.py:89-90), der Test pruefte dann etwas "
+        "anderes als das Kuerzel"
+    )
+    sms = render_sms(_alert_message(_alert_event(metric_id)))
+    codes = _alert_sms_codes(sms)
+
+    assert code in codes, (
+        f"AC-S1-2: Kurznachricht fuehrt fuer {metric_id!r} keinen Token mit "
+        f"dem Kuerzel {code!r}: {sms!r} (erkannte Kuerzel: {codes})"
+    )
+    fremde = {get_sms_code(other) for other in _ALARM_SOLL_IDS if other != metric_id}
+    mitgelesen = sorted(fremde & set(codes) - {code})
+    assert not mitgelesen, (
+        f"AC-S1-2: Kurznachricht zu {metric_id!r} fuehrt zusaetzlich fremde "
+        f"Kuerzel {mitgelesen}: {sms!r}"
+    )
+
+
+def _sms_praefix_kollisionen() -> list[tuple[str, str]]:
+    """Paare (kurz, lang) aus der Soll-Menge, bei denen ein Kuerzel echter
+    Wortanfang eines anderen ist -- gerechnet, nicht getippt. Gemessen
+    2026-08-11: N/NL (temperature_cold vs. freezing_level) und N/NS
+    (temperature_cold vs. fresh_snow)."""
+    return [
+        (kurz_id, lang_id)
+        for kurz_id in _ALARM_SOLL_IDS
+        for lang_id in _ALARM_SOLL_IDS
+        if get_sms_code(kurz_id)
+        and get_sms_code(lang_id)
+        and get_sms_code(kurz_id) != get_sms_code(lang_id)
+        and get_sms_code(lang_id).startswith(get_sms_code(kurz_id))
+    ]
+
+
+_SMS_PRAEFIX_KOLLISIONEN = _sms_praefix_kollisionen()
+
+
+@pytest.mark.parametrize("kurz_id,lang_id", _SMS_PRAEFIX_KOLLISIONEN)
+def test_ac_s1_2_sms_praefix_gegenprobe(kurz_id, lang_id):
+    """AC-S1-2 (Pflicht-Gegenprobe): ein Alarm, der NUR die Groesse mit dem
+    laengeren Kuerzel traegt, darf fuer das kuerzere KEINEN Treffer liefern.
+    Genau hier schluege eine Teilstring-Suche falsch an -- ersetzt man die
+    Token-Grammatik in ``_alert_sms_codes()`` durch ``code in sms``, muss
+    dieser Test rot werden."""
+    kurz, lang = get_sms_code(kurz_id), get_sms_code(lang_id)
+    sms = render_sms(_alert_message(_alert_event(lang_id)))
+    codes = _alert_sms_codes(sms)
+
+    assert lang in codes, (
+        f"Vorbedingung: {lang_id!r} muss sein eigenes Kuerzel {lang!r} tragen "
+        f"(sonst prueft die Gegenprobe ins Leere): {sms!r}"
+    )
+    assert kurz not in codes, (
+        f"AC-S1-2 (Gegenprobe): das Kuerzel {kurz!r} ({kurz_id!r}) wird in "
+        f"einer Kurznachricht mitgelesen, die nur {lang_id!r} ({lang!r}) "
+        f"enthaelt: {sms!r}"
+    )
+
+
+# --- AC-S1-3: Soll-Menge stammt aus dem Produktivmodul (Vakuum-Schutz) ----
+
+
+def test_ac_s1_3_soll_menge_wird_gerechnet_und_ist_plausibel():
+    """AC-S1-3: die geprueften Groessen stammen ausschliesslich aus
+    ``_ALERT_METRIC_TO_CATALOG_ID``. Der Plausibilitaets-Waechter schlaegt an,
+    wenn die Menge leer ist, unter die Mindestgroesse faellt oder von der
+    parametrisierten Konstante abweicht -- die Konstante ist der Mutations-Ort
+    (sie speist alle parametrize-Achsen), die Neuberechnung hier ist der
+    unabhaengige Pruefort."""
+    frisch = {cid for ids in _ALERT_METRIC_TO_CATALOG_ID.values() for cid in ids}
+
+    assert frisch, (
+        "Vakuum: das Produktivmodul fuehrt keine einzige alarmfaehige "
+        "Katalog-Kennung -- jede Achse dieser Scheibe liefe ueber null Faelle"
+    )
+    assert len(frisch) >= _ALARM_SOLL_MINDESTGROESSE, (
+        f"Vakuum-Schutz: nur {len(frisch)} alarmfaehige Kennungen "
+        f"({sorted(frisch)}) -- erwartet mindestens "
+        f"{_ALARM_SOLL_MINDESTGROESSE}. Entweder ist das Mapping geschrumpft "
+        "oder die Soll-Rechnung greift daneben."
+    )
+    assert set(_ALARM_SOLL_IDS) == frisch, (
+        f"Die parametrisierte Soll-Menge {sorted(_ALARM_SOLL_IDS)} weicht vom "
+        f"Produktivmodul {sorted(frisch)} ab -- eine im Test aufgezaehlte oder "
+        "gekuerzte Liste ist genau das, was AC-S1-3 verbietet"
+    )
+
+    katalog_ids = {m.id for m in _METRICS}
+    assert frisch <= katalog_ids, (
+        f"Kennungen ohne Katalog-Eintrag: {sorted(frisch - katalog_ids)}"
+    )
+    # Unabhaengige Gegenrichtung: der Katalog kennt die Alarmfaehigkeit selbst
+    # (alert_metrics, ohne die is_precursor-Vorboten). Faellt eine solche
+    # Groesse aus dem Mapping, schrumpfen sonst BEIDE Seiten gemeinsam und
+    # keine Assertion oben wuerde anschlagen. Grenze, bewusst: die drei
+    # Groessen, die nur ueber die Rueckwaerts-Abbildung erreichbar sind
+    # (snowfall_limit/temperature_cold via OR-Tupel, wind via WIND_CHANGE),
+    # deklarieren im Katalog kein alert_metrics und sind so nicht abgedeckt.
+    katalog_alarmfaehig = {
+        m.id for m in _METRICS if m.alert_metrics and not m.is_precursor
+    }
+    assert katalog_alarmfaehig <= frisch, (
+        f"Der Katalog fuehrt {sorted(katalog_alarmfaehig - frisch)} als "
+        "alarmfaehig (alert_metrics gesetzt, kein Vorbote), das Produktivmodul "
+        "_ALERT_METRIC_TO_CATALOG_ID kennt die Kennung(en) aber nicht -- "
+        "entweder ist das Mapping geschrumpft oder der Katalog ist gewachsen, "
+        "ohne dass die Alarm-Renderer-Achse davon erfaehrt"
+    )
+    ohne_kuerzel = sorted(cid for cid in frisch if not get_sms_code(cid))
+    assert not ohne_kuerzel, (
+        f"Alarmfaehige Groessen ohne sms_code: {ohne_kuerzel} -- _code() faellt "
+        "dort auf die metric_id zurueck, AC-S1-2 pruefte dann das Falsche"
+    )
+    ohne_beschriftung = sorted(cid for cid in frisch if get_alert_label(cid) == cid)
+    assert not ohne_beschriftung, (
+        f"Alarmfaehige Groessen ohne Katalog-Beschriftung: {ohne_beschriftung} "
+        "-- get_alert_label() gibt dort die Kennung selbst zurueck"
+    )
+
+    kontroll_ids = {_alarm_kontroll_id(cid) for cid in _ALARM_SOLL_IDS}
+    assert kontroll_ids <= frisch, (
+        f"Kontroll-Groessen ausserhalb der Soll-Menge: "
+        f"{sorted(kontroll_ids - frisch)} -- die Gegenprobe in AC-S1-1 haette "
+        "keine Grundlage"
+    )
+    assert _SMS_PRAEFIX_KOLLISIONEN, (
+        "Keine Praefix-Kollision mehr unter den Kuerzeln -- dann laeuft die "
+        "AC-S1-2-Gegenprobe ueber null Faelle und bewacht nichts"
+    )
+    assert _GEWITTER_ID in frisch, (
+        f"Die Gewitter-Kennung {_GEWITTER_ID!r} steht nicht in der Soll-Menge "
+        "-- AC-S1-5/AC-S1-6 haetten keinen Gegenstand"
+    )
+    assert _HANDLED_UNITS and len(_EINHEITEN_UNTER_BEOBACHTUNG) >= 8, (
+        f"Vakuum-Schutz AC-S1-4: {len(_EINHEITEN_UNTER_BEOBACHTUNG)} Einheiten "
+        f"unter Beobachtung, _HANDLED_UNITS={_HANDLED_UNITS}"
+    )
+
+
+# --- AC-S1-4: _HANDLED_UNITS deckt sich mit der Katalog-Formatierung ------
+
+
+def _katalog_haengt_einheit_an(unit: str) -> bool:
+    """Gemessen statt behauptet: haengt ``format_metric_value()`` diese Einheit
+    tatsaechlich an den Wert an? Der else-Zweig (metric_catalog.py:1025-1026)
+    liefert ``str(value)`` ganz ohne Einheit."""
+    if not unit:
+        return False
+    return format_metric_value(unit, _UNIT_PROBE_VALUE).endswith(" " + unit)
+
+
+@pytest.mark.parametrize(
+    "unit", _EINHEITEN_UNTER_BEOBACHTUNG, ids=lambda u: u or "ohne-einheit",
+)
+def test_ac_s1_4_handled_units_deckt_sich_mit_der_katalog_formatierung(unit):
+    """AC-S1-4: ``_HANDLED_UNITS`` (render.py:35) ist eine wortgleiche Kopie
+    der Einheiten, die ``format_metric_value()`` mit Suffix formatiert. Diese
+    Doppelung driftet lautlos: waechst die eine Liste ohne die andere, faellt
+    der Alarm-Renderer still in den Ersatzpfad (render.py:51-52) und verliert
+    dort die deutsche Zahlformatierung. Geprueft wird in BEIDE Richtungen --
+    Katalog-Einheiten und Listen-Einheiten stehen gemeinsam in der Achse."""
+    haengt_an = _katalog_haengt_einheit_an(unit)
+    gelistet = unit in _HANDLED_UNITS
+    assert haengt_an == gelistet, (
+        f"AC-S1-4: Einheit {unit!r} -- Katalog haengt sie "
+        f"{'an' if haengt_an else 'NICHT an'} "
+        f"(format_metric_value({unit!r}, {_UNIT_PROBE_VALUE}) = "
+        f"{format_metric_value(unit, _UNIT_PROBE_VALUE)!r}), _HANDLED_UNITS "
+        f"fuehrt sie {'' if gelistet else 'NICHT '}-- die beiden Listen sind "
+        "auseinandergelaufen"
+    )
+
+
+# --- AC-S1-5: Gewitter ohne Prozentzeichen (DER rote Anteil) --------------
+
+
+def _gewitter_event() -> AlertEvent:
+    """value_from=0.0 -> ``delta_pct()`` ist definitionsgemaess None
+    (model.py:92-96), die Ausgabe traegt also KEINE Aenderungs-Prozentzahl.
+    Jedes verbleibende '%' ist damit zwangslaeufig eine EINHEIT -- genau das
+    misst AC-S1-5. Werte 0->2 bilden die Gewitter-STUFE ab (0-3)."""
+    return _alert_event(_GEWITTER_ID, value_from=0.0, value_to=2.0, threshold=1.0)
+
+
+def _alle_vier_ausgaben(msg: AlertMessage) -> dict[str, str]:
+    ausgaben = _label_kanaele(msg)
+    ausgaben["Kurznachricht"] = render_sms(msg)
+    return ausgaben
+
+
+def test_ac_s1_5_gewitter_allein_ohne_prozentzeichen():
+    """AC-S1-5 (Einzel-Alarm): heute bereits gruen -- der Einzelpfad liest
+    ``get_metric().unit`` direkt (render.py:47, :365) und umgeht damit den
+    ``_unit_display()``-Sonderfall."""
+    assert get_metric(_GEWITTER_ID).unit == "", (
+        f"Vorbedingung: der Katalog fuehrt {_GEWITTER_ID!r} ohne Einheit "
+        "(Stufe 0-3, metric_catalog.py:333) -- sonst waere ein Einheiten-"
+        "Suffix keine Fehlanzeige"
+    )
+    msg = _alert_message(_gewitter_event())
+    ausgaben = _alle_vier_ausgaben(msg)
+
+    assert get_alert_label(_GEWITTER_ID) in ausgaben["Betreff"], (
+        "Vorbedingung: der Betreff muss den Gewitter-Alarm ueberhaupt nennen"
+    )
+    assert get_sms_code(_GEWITTER_ID) in _alert_sms_codes(ausgaben["Kurznachricht"]), (
+        "Vorbedingung: die Kurznachricht muss den Gewitter-Token tragen"
+    )
+    for kanal, text in ausgaben.items():
+        assert "%" not in text, (
+            f"AC-S1-5: {kanal} haengt an den Gewitter-Wert ein Prozentzeichen "
+            f"an -- Gewitter ist eine STUFE (alert_metrics="
+            "{'max': 'thunder_level'}), die Prozent-Achse waere "
+            f"'thunder_probability' (PO-Entscheidung #1585): {text!r}"
+        )
+
+
+def test_ac_s1_5_gewitter_gebuendelt_ohne_prozentzeichen():
+    """AC-S1-5 (Buendel-Alarm): DER rote Anteil dieser Scheibe. Der
+    Mehr-Metrik-Pfad nutzt ``_unit_display()`` (render.py:75-86), das fuer
+    'thunder' hart '%' liefert -- gemessen 2026-08-11: 'Gewitter 10->20%'."""
+    partner_id = _alarm_kontroll_id(_GEWITTER_ID)
+    assert get_metric(partner_id).unit != "%", (
+        f"Vorbedingung: die Partner-Groesse {partner_id!r} darf selbst keine "
+        "Prozent-Einheit tragen -- sonst waere nicht zuzuordnen, woher ein "
+        "'%' stammt"
+    )
+    msg = _alert_message(
+        _gewitter_event(),
+        _alert_event(partner_id, value_from=0.0, value_to=30.0, threshold=10.0),
+    )
+    ausgaben = _alle_vier_ausgaben(msg)
+
+    assert get_alert_label(_GEWITTER_ID) in ausgaben["Betreff"], (
+        "Vorbedingung: der Betreff muss den Gewitter-Alarm ueberhaupt nennen"
+    )
+    for kanal, text in ausgaben.items():
+        assert "%" not in text, (
+            f"AC-S1-5: {kanal} haengt im gebuendelten Alarm an den "
+            "Gewitter-Wert ein Prozentzeichen an -- Gewitter ist eine STUFE, "
+            "keine Prozentzahl (PO-Entscheidung #1585; der Sonderfall in "
+            f"_unit_display() stammt aus der aelteren #978-Vorlage): {text!r}"
+        )
+
+
+# --- AC-S1-6: der Fix schiesst nicht ueber sein Ziel hinaus ---------------
+
+
+def _buendel_zeile(plain: str, label: str) -> str:
+    zeilen = [z for z in plain.splitlines() if z.startswith(f"{label} · ")]
+    assert len(zeilen) == 1, (
+        f"Erwartet genau eine Datenzeile zur Beschriftung {label!r}, gefunden "
+        f"{len(zeilen)}: {zeilen}"
+    )
+    return zeilen[0]
+
+
+@pytest.mark.parametrize("metric_id", _ALARM_SOLL_IDS)
+def test_ac_s1_6_uebrige_groessen_behalten_ihre_katalog_einheit(metric_id):
+    """AC-S1-6: im gebuendelten Alarm traegt jede uebrige Groesse weiterhin
+    genau ihre Katalog-Einheit -- der Gewitter-Fix darf sie nicht mitreissen.
+    Fuer Gewitter selbst greift ein umgekehrter Zweig (kein pytest.skip,
+    Muster ``_TELEGRAM_NIGHT_SCALAR_EXCEPTIONS`` weiter oben): dort gilt die
+    Regel dieses Tests gerade NICHT, der Sollzustand steht in AC-S1-5."""
+    if metric_id == _GEWITTER_ID:
+        assert get_metric(metric_id).unit == "", (
+            f"Umgekehrter Zweig: {metric_id!r} traegt im Katalog bewusst keine "
+            "Einheit -- daraus folgt der Sollzustand aus AC-S1-5 (keine "
+            "Prozent-Ausgabe). Traegt der Katalog hier ploetzlich eine "
+            "Einheit, ist die Grundlage beider ACs weg."
+        )
+        return
+
+    unit = get_metric(metric_id).unit
+    ereignis = _alert_event(metric_id, value_from=0.0, value_to=20.0)
+    _, plain = render_email(_alert_message(ereignis, _gewitter_event()))
+    zeile = _buendel_zeile(plain, get_alert_label(metric_id))
+    erwartetes_ende = f"{unit} {side_label(ereignis)}"
+
+    assert zeile.endswith(erwartetes_ende), (
+        f"AC-S1-6: die Datenzeile zu {metric_id!r} endet nicht auf ihre "
+        f"Katalog-Einheit ({erwartetes_ende!r}): {zeile!r}"
+    )
+
+
+def test_ac_s1_6_prozentzeichen_bleibt_wo_die_einheit_es_verlangt():
+    """AC-S1-6: Groessen, deren Katalog-Einheit tatsaechlich '%' ist (Feuchte
+    und Regenwahrscheinlichkeit -- beide is_precursor und daher NICHT in der
+    Soll-Menge, als AlertEvent aber sehr wohl renderbar), behalten ihr
+    Prozentzeichen. Ein Fix, der ``_unit_display()`` pauschal entschaerft
+    statt nur den thunder-Sonderfall zu entfernen, wird hier rot."""
+    prozent_ids = [m.id for m in _METRICS if m.unit == "%" and m.alert_label]
+    assert prozent_ids, (
+        "Vakuum: der Katalog fuehrt keine Prozent-Groesse mit Alarm-"
+        "Beschriftung -- dieser Test bewachte nichts"
+    )
+    partner_id = _alarm_kontroll_id(_GEWITTER_ID)
+
+    for metric_id in prozent_ids:
+        ereignis = _alert_event(metric_id, value_from=0.0, value_to=80.0, threshold=20.0)
+        _, plain = render_email(_alert_message(
+            ereignis,
+            _alert_event(partner_id, value_from=0.0, value_to=30.0, threshold=10.0),
+        ))
+        zeile = _buendel_zeile(plain, get_alert_label(metric_id))
+        assert zeile.endswith(f"% {side_label(ereignis)}"), (
+            f"AC-S1-6: {metric_id!r} hat die Katalog-Einheit '%' verloren: "
+            f"{zeile!r}"
+        )
+
+
+# --- AC-S1-7: gleiche Beschriftung -- Doppeldeutigkeit ausdruecklich ------
+
+
+def _beschriftungs_kollisionen() -> dict[str, tuple[str, ...]]:
+    """Gruppen von Soll-Groessen, die sich EINE Alarm-Beschriftung teilen --
+    gerechnet, nicht getippt. Gemessen 2026-08-11: {'Temp': ('temperature',
+    'temperature_cold')}."""
+    nach_label: dict[str, list[str]] = {}
+    for metric_id in _ALARM_SOLL_IDS:
+        nach_label.setdefault(get_alert_label(metric_id), []).append(metric_id)
+    return {lab: tuple(ids) for lab, ids in nach_label.items() if len(ids) > 1}
+
+
+_BESCHRIFTUNGS_KOLLISIONEN = sorted(_beschriftungs_kollisionen().items())
+
+
+def test_ac_s1_7_doppeldeutige_beschriftung_ist_benannt():
+    """AC-S1-7: die Doppeldeutigkeit wird ausdruecklich festgehalten statt
+    stillschweigend uebergangen. Wird sie eines Tages aufgeloest (eigene
+    Beschriftung fuer temperature_cold), muss dieser Zweig bewusst entfernt
+    werden -- er verschwindet nicht von selbst."""
+    assert _BESCHRIFTUNGS_KOLLISIONEN, (
+        "Keine gleichnamigen Alarm-Groessen mehr -- der umgekehrte Pruefzweig "
+        "AC-S1-7 laeuft dann ueber null Faelle. Entweder ist die "
+        "Doppeldeutigkeit behoben (dann diesen Zweig samt Begruendung "
+        "entfernen) oder die Soll-Menge ist kaputt."
+    )
+
+
+@pytest.mark.parametrize("label,metric_ids", _BESCHRIFTUNGS_KOLLISIONEN)
+def test_ac_s1_7_gleichnamige_groessen_trennt_nur_die_kurznachricht(label, metric_ids):
+    """AC-S1-7 (umgekehrter Pruefzweig): fuer gleichnamige Groessen gilt die
+    Zusicherung aus AC-S1-1 nur eingeschraenkt -- Betreff, E-Mail und Telegram
+    sind byte-identisch und koennen sie NICHT unterscheiden. Allein das
+    Kurznachrichten-Kuerzel trennt sie. Wer eine Mutation nur an diesen drei
+    Kanaelen misst, hat nichts bewiesen (s. Pruefhinweis der Spec).
+
+    Adversary-Finding F001, #1703 S1: dieser Test (wie auch
+    test_ac_s1_7_doppeldeutige_beschriftung_ist_benannt oben) beweist nur,
+    dass sich die Kuerzel fuer 'temperature' und 'temperature_cold'
+    UNTERSCHEIDEN -- er kann NICHT beweisen, dass sie richtig herum
+    zugeordnet sind (also 'D' zu temperature, 'N' zu temperature_cold),
+    denn Pruefling (get_sms_code ueber _alert_sms_codes/render_sms) und
+    Massstab (_ALARM_SOLL_IDS/get_alert_label, ebenfalls aus dem Katalog)
+    lesen hier denselben Katalog. Eine Vertauschung der beiden sms_code-
+    Werte direkt im Katalog wuerde Soll und Ist gemeinsam mitwandern lassen
+    und bliebe hier gruen. Die Zuordnung selbst sichert stattdessen
+    tests/tdd/test_issue_917_alert_renderer.py::TestAC6CatalogSmsCodes ab,
+    die die Kuerzel 'D' und 'N' hart als Literal schreibt (Zeile 465ff).
+    Wird jene Klasse geloescht, faellt diese Deckung ersatzlos weg und muss
+    hier (oder an vergleichbarer Stelle) ersetzt werden."""
+    ausgaben = [_label_kanaele(_alert_message(_alert_event(mid))) for mid in metric_ids]
+    for mid, weitere in zip(metric_ids[1:], ausgaben[1:]):
+        for kanal, text in ausgaben[0].items():
+            assert weitere[kanal] == text, (
+                f"AC-S1-7: {kanal} unterscheidet {metric_ids[0]!r} und {mid!r} "
+                f"doch -- der Waechter geht davon aus, dass beide unter der "
+                f"Beschriftung {label!r} ununterscheidbar sind. Wenn das jetzt "
+                "nicht mehr stimmt, ist die Doppeldeutigkeit behoben und "
+                f"dieser Zweig gehoert entfernt.\n{text!r}\n{weitere[kanal]!r}"
+            )
+
+    kuerzel = []
+    for mid in metric_ids:
+        codes = _alert_sms_codes(render_sms(_alert_message(_alert_event(mid))))
+        assert len(codes) == 1, (
+            f"Vorbedingung: genau ein Token erwartet fuer {mid!r}, erkannt: {codes}"
+        )
+        kuerzel.append(codes[0])
+    assert len(set(kuerzel)) == len(kuerzel), (
+        f"AC-S1-7: allein die Kurznachricht trennt die gleichnamigen Groessen "
+        f"{list(metric_ids)} -- hier tut sie es nicht: {kuerzel}"
     )


### PR DESCRIPTION
Epic #1703, Scheibe 1 (Folgearbeit aus #1514). Deckt **Fläche 1** aus `docs/reference/metric_output_matrix.md` §4.1.

## Was unbewacht war

Von **11** produktiv erreichbaren Alarm-Metriken kamen in *allen* Alarm-Renderer-Tests zusammen nur **8** vor, und kein einziger Test iterierte über den Katalog. Ein alarmfähiger Katalogeintrag ohne Alarm-Ausgabe wäre nirgends aufgefallen.

## Was der Wächter jetzt tut

Neue Achse `AC-S1-1..7` in `tests/tdd/test_channel_metric_matrix.py` — Erweiterung des **bestehenden, budgetierten** Gates #1677 B (Option C aus `metric_output_matrix.md` §5: kein zweites Register, kein neues Pflicht-Gate, kein neues Prüfdatum).

- **Soll-Menge gerechnet, nie getippt:** aus `_ALERT_METRIC_TO_CATALOG_ID` (`weather_change_detection.py:82-99`). 11 statt 15, weil `humidity`/`rain_probability` Vorboten-Größen sind und `uv_index`/`snow_depth` keinen Mapping-Eintrag haben — so braucht der Wächter **gar keine Ausnahmeliste**.
- **Zwei Assertion-Familien statt einer:** Betreff/Mail/Telegram lesen `get_alert_label()`, `render_sms` kennt nur `get_sms_code()`. Die SMS-Prüfung ist token-grenzen-bewusst, weil `N` (temperature_cold) Wortanfang von `NL` und `NS` ist — mit Pflicht-Gegenprobe.
- **`_HANDLED_UNITS` gegen die Wirklichkeit gehalten:** die Liste war eine ungeprüft geführte Kopie der sieben Einheiten, die `format_metric_value()` mit Suffix formatiert. AC-S1-4 prüft beide Richtungen über die Vereinigungsmenge; Drift fällt jetzt auf.
- Gemessen an den **vier echten Renderern**, nicht an `_val()`/`_unit_display()` isoliert.

## Mitrepariert (PO-Entscheidung 2026-08-11)

`_unit_display()` hängte für `thunder` hart `%` an — im gebündelten Alarm stand **„Gewitter 2%"**. Der Alarmwert ist eine **Stufe 0–3** (`alert_metrics={"max": "thunder_level"}`), keine Prozentzahl.

Der Sonderfall stammt aus der Design-Vorlage zu #978 und ist durch **PO-Entscheidung #1585** (2026-08-07: genau zwei Gewitter-Metriken — `thunder` = Stärke, `thunder_probability` = Wahrscheinlichkeit) abgelöst. Er war eine *dokumentierte* Entscheidung, keine Nachlässigkeit: die drei Bestands-Assertions in `test_978_deviation_line_readability.py` (`:218`/`:232`/`:350`) **und** der dortige Modul-Docstring, der den Widerspruch festhielt, sind nachgezogen — die Ablösung ist dokumentiert, nicht still. Bei `Regen%` bleibt das Prozentzeichen, weil es dort zum Metriknamen gehört (das bewacht AC-S1-6).

## Prüfung

- **268 passed, 1 skipped** über 10 Alarm-Testdateien, nach Rebase auf `origin/main` erneut gemessen
- **Adversary VERIFIED** — 14 Punkte, 2 Runden, alle 4 Pflicht-Mutationen gefangen
- Renderer-Mail-Gate: `test_issue_811_mode_matrix.py` (41 passed) + `radar_alert_mail_validator.py` Exit 0 gegen eine echt zugestellte Radar-Alarm-Mail
- Produktivcode **netto +2 Zeilen**; `test_loc_limit_override 600` mit PO-Freigabe

## Bewusste Grenzen (in der Spec benannt)

- **Finding F001 (MEDIUM, nicht blockierend):** Ein Wächter, der sein Soll aus demselben Katalog liest wie der Prüfling, kann Katalog-*Zuordnungsfehler* prinzipiell nicht sehen. Eine `D`/`N`-Vertauschung **im Katalog** bliebe hier grün und wird allein von `test_issue_917_alert_renderer.py::TestAC6CatalogSmsCodes` (harte Literale) gefangen. Die Abhängigkeit ist jetzt im Test vermerkt, damit sie bei einer künftigen Löschung nicht unbemerkt verschwindet.
- `CorridorEvent` bleibt unbewacht — **toter Pfad**: `evaluate_corridor_thresholds()` hat keinen Aufrufer, `_send_alert()` übergibt `corridor_hits` nicht.
- `OnsetEvent` bleibt unbewacht — **strukturell metrik-los**, kein `metric_id`-Feld.
- Tausenderpunkt-Abweichung im Ersatzpfad und CAPE-Bypass über nicht-migrierte Compare-Alt-Vorlagen: produktiv praktisch unerreichbar bzw. ungemessen → Sammel-Issue #1199.

Spec: `docs/specs/modules/fix_1703_s1_alert_renderer_matrix.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)