### PR TITLE
docs(#1685): Melde-Gedächtnis-Schema und Reset-Verhalten richtigstellen

### DIFF
--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -259,14 +259,32 @@ Scheibe 3 (#1170). Scheduler: `POST /api/scheduler/compare-alert-checks`, Go-Cro
 
 2. **Melde-Gedächtnis (`alert_state`)**
    - Persistenz: `data/users/<user_id>/alert_state/<trip_id>.json`
-   - Schema: `{ "<metric>:<segment_id>": { "last_reported_value": float, "reported_at": ISO-8601 } }`
-   - **Re-Alert-Logik:**
+   - Eine Datei, **zwei Schlüsselräume**:
+     - Änderungs-Raum: `{ "<metric>:<segment_id>": { "last_reported_value": float, "reported_at": ISO-8601 } }`
+     - Amtlicher Raum: `{ "official_alert:<ident>:<hazard>:<valid_from>:<valid_to>": { "last_reported_value": float, "reported_at": ISO-8601, "valid_from": ISO-8601|null, "valid_to": ISO-8601|null } }`
+       — Schlüsselbildung `official_alert_state_key()`, `ident` nach Präzedenz `dedup_id` >
+       `region_label` > `label`; Präfix-Konstante `OFFICIAL_ALERT_KEY_PREFIX` in
+       `services/alert_state.py`. Die Felder `valid_from`/`valid_to` kamen mit **#1685**;
+       Bestandseinträge ohne sie bleiben gültig (Read-Modify-Write mit Merge).
+   - **Re-Alert-Logik (Änderungs-Raum):**
      - Neu (kein Eintrag): Alert sent, Eintrag angelegt
      - Stagnation (`|current - last| < threshold`): unterdrückt
      - Eskalation (`|current - last| >= threshold`): erneut Alert, Wert aktualisiert
+   - **Re-Alert-Logik (amtlicher Raum) seit #1685 (2026-08-11):** entscheidet
+     `official_alert_revision_verdict()` in `output/renderers/alert/official_alerts.py` —
+     **geteilt** von Trip (`trip_alert.check_official_alert_triggers`) und Ortsvergleich
+     (`compare_official_alert._detect`). Überlappt das Gültigkeitsfenster einer Warnung **echt**
+     mit dem eines gemeldeten Eintrags gleicher Identität + Gefahr, bleibt sie **still**;
+     Ausnahmen: Stufe gestiegen ODER Beginn **≥ 2 h früher** (PO-Entscheidung: ein früher
+     eintretendes Ereignis zwingt zum Umplanen). Aneinandergrenzende Fenster sind **keine**
+     Überlappung und bleiben zwei Warnungen — präzisiert #1245 AC-4 zu „T2 überlappt T1 nicht".
+     Bei stiller Revision wird fortgeschrieben (alter Schlüssel entfällt, `reported_at` bleibt
+     das Datum der tatsächlichen Meldung); ohne diese Fortschreibung meldete das dritte Glied
+     einer Revisionskette fälschlich erneut. Die **Anzeige** (`dedupe_official_alerts`) ist davon
+     unberührt — beide Perioden bleiben in der Mail sichtbar.
    - **Reset seit #1460 T1 (2026-08-03, ADR-0043):** beim Briefing-Versand wird nur noch der
-     Änderungs-Raum (`<feld>:<segment>`) gelöscht — der amtliche Raum (Präfix `official_alert:`,
-     s. u.) überlebt den Reset, damit dessen Entprellung nicht bei jedem Briefing verlorengeht.
+     Änderungs-Raum (`<feld>:<segment>`) gelöscht — der amtliche Raum überlebt den Reset, damit
+     dessen Entprellung nicht bei jedem Briefing verlorengeht.
      Vorher löschte `AlertStateService.reset()` die komplette Datei.
 
 3. **Symmetrische Δ-Erkennung**

--- a/docs/features/issue-816-alert-deviation-core.md
+++ b/docs/features/issue-816-alert-deviation-core.md
@@ -38,22 +38,45 @@ data/users/<user_id>/alert_state/
   └── <trip_id>.json
 ```
 
-**Schema:**
+**Schema:** eine Datei, **zwei** Schlüsselräume.
+
 ```json
 {
   "<metric>:<segment_id>": {
     "last_reported_value": 18.5,
     "reported_at": "2026-06-14T13:30:00+00:00"
+  },
+  "official_alert:<ident>:<hazard>:<valid_from>:<valid_to>": {
+    "last_reported_value": 2.0,
+    "reported_at": "2026-08-10T05:01:19+00:00",
+    "valid_from": "2026-08-10T12:00:00+00:00",
+    "valid_to": "2026-08-10T20:00:00+00:00"
   }
 }
 ```
 
-**Re-Alert-Logik:**
+Der zweite Raum gehört den **amtlichen Warnungen** (Präfix-Konstante
+`OFFICIAL_ALERT_KEY_PREFIX`, Schlüsselbildung `official_alert_state_key()` in
+`src/output/renderers/alert/official_alerts.py`). `ident` folgt der Präzedenz
+`dedup_id` > `region_label` > `label`. Die Felder `valid_from`/`valid_to` kamen mit
+**#1685** hinzu; Bestandseinträge ohne sie bleiben gültig (Read-Modify-Write mit Merge)
+und werden dann wie vor #1685 allein über den exakten Schlüsseltreffer bewertet.
+
+**Re-Alert-Logik (Δ-Raum):**
 - **Erste Erkennung:** Eintrag fehlt → Alert send, Eintrag angelegt mit aktuellem Wert.
 - **Stagnation:** `|current - last_reported| < threshold` → unterdrückt (keine E-Mail).
 - **Eskalation:** `|current - last_reported| >= threshold` → erneut Alert, Wert aktualisiert.
 
-**Reset:** Beim Briefing-Versand wird die komplette Datei gelöscht (siehe Punkt 3 unten).
+**Re-Alert-Logik (amtliche Warnungen, #1685):** entscheidet
+`official_alert_revision_verdict()` — geteilt von Trip und Ortsvergleich. Überlappt das
+Gültigkeitsfenster einer Warnung **echt** mit dem eines bereits gemeldeten Eintrags gleicher
+Identität + Gefahr, bleibt sie **still**; Ausnahmen: die Stufe ist gestiegen ODER der Beginn
+liegt **≥ 2 h früher**. Aneinandergrenzende Fenster (A endet 22:00, B beginnt 22:00) gelten
+**nicht** als Überlappung und bleiben zwei Warnungen (#1245 AC-4, dort präzisiert zu „T2
+überlappt T1 nicht"). Bei stiller Revision wird der Eintrag fortgeschrieben — der alte
+Schlüssel entfällt, `reported_at` bleibt das Datum der **tatsächlichen** Meldung.
+
+**Reset:** siehe Punkt 3 — er trifft **nur** den Δ-Raum, nicht die amtlichen Warnungen.
 
 ### 2. Read-Only Briefing-Snapshot
 
@@ -65,11 +88,18 @@ Der Snapshot bleibt stabil bis zum nächsten Briefing (Morgen ODER Abend) — er
 
 ### 3. Reset beim Briefing
 
-**Änderung in `trip_report_scheduler.py` (Z. 628–633):**
-Nach dem `WeatherSnapshotService.save()`-Block wird `AlertStateService.reset(trip_id)` aufgerufen.
-Dies löscht den kompletten Trip-Alert-State — der nächste Alert startet mit leerem Gedächtnis.
+Nach dem `WeatherSnapshotService.save()`-Block wird `AlertStateService.reset(trip_id)`
+aufgerufen — heute über die geteilte Fassung `reset_alert_memory()` in
+`src/services/alert_briefing_anchor.py`, an die der Scheduler nur noch delegiert.
 
-**Effekt:** Nach jedem Briefing endet der "Alert-Zyklus"; die Abweichung wird neu gemessen.
+**Effekt:** Nach jedem Briefing endet der „Alert-Zyklus"; die Abweichung wird neu gemessen.
+
+**🔴 Der Reset löscht NICHT die ganze Datei.** Hier stand bis 2026-08-11 „Dies löscht den
+kompletten Trip-Alert-State" — das ist **seit #1460 (P2) falsch**. `AlertStateService.reset()`
+schneidet am Präfix `official_alert:` und **behält** die amtlichen Warnungen: sie haben ihre
+eigene Entprellung und überleben den Briefing-Versand. Ohne diesen Schnitt galt dieselbe,
+unveränderte amtliche Warnung nach jedem Briefing wieder als „neu" und wurde erneut gemeldet.
+Bleibt nach dem Schnitt kein amtlicher Eintrag übrig, verschwindet die Datei wie bisher ganz.
 
 ### 4. Symmetrische Δ-Erkennung
 


### PR DESCRIPTION
Doku-Nachtrag zu #1685 (PR #1730). Reine `docs/**`-Änderung, kein Code.

## Was unvollständig war

`architecture.md:262` und `issue-816-alert-deviation-core.md:41-49` zeigten das Melde-Gedächtnis nur mit dem Änderungs-Raum. Der **amtliche** Schlüsselraum (`official_alert:…`) fehlte im Schema — und mit ihm die Felder `valid_from`/`valid_to`, die #1685 hinzugefügt hat.

Beide Dateien führen jetzt beide Schlüsselräume und beschreiben `official_alert_revision_verdict()` als **geteilte** Fassung von Trip und Ortsvergleich.

## Was schlicht falsch war (Altfehler)

`issue-816-alert-deviation-core.md:70` behauptete: *„Dies löscht den kompletten Trip-Alert-State — der nächste Alert startet mit leerem Gedächtnis."*

Das ist **seit #1460 (P2, 2026-08-03) falsch.** `AlertStateService.reset()` schneidet am Präfix `official_alert:` und **behält** die amtlichen Warnungen — sie haben ihre eigene Entprellung und müssen den Briefing-Versand überleben. Ohne diesen Schnitt galt dieselbe unveränderte Warnung nach jedem Briefing wieder als „neu".

`architecture.md:267-270` war an dieser Stelle bereits korrekt — die beiden Dokumente **widersprachen einander**. Die falsche Fassung ist jetzt ausdrücklich als überholt gekennzeichnet, statt sie stillschweigend zu ersetzen.

Kein neues ADR: ADR-0043 deckt den Reset-Schnitt ab, ADR-0040 die Entprellungs-Richtung. `test_adr_index_drift.py` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)