### PR TITLE
feat(#1717): Premium-SMS in der Oberflaeche — schaltbar und diagnostizierbar (S3)

### DIFF
--- a/docs/context/feat-1717-s3-premium-sms-ui.md
+++ b/docs/context/feat-1717-s3-premium-sms-ui.md
@@ -1,0 +1,178 @@
+# Context: feat-1717-s3-premium-sms-ui
+
+**Issue:** #1717 — S3: Premium-SMS in der Oberfläche
+**Vorgänger:** S1 (Rückkanal) und S2a (Versandkanal) sind **live** in Produktion
+**Parallel:** #1701 (S2b, Alarm-/Vergleichspfad) — fremde Sitzung
+**Basis:** `origin/main` = `64b78c63`
+
+## Request Summary
+
+Premium-SMS ist als Kanal live, aber **nur über die API schaltbar**. Der Nutzer kann ihn nicht
+selbst ein-/ausschalten und sieht nicht, **wohin** gesendet wird. Auf Tour ist damit nicht
+unterscheidbar, ob der Kanal aus ist, keine Rückadresse gelernt wurde oder sie veraltet ist —
+obwohl das Backend diese drei Fälle bereits unterscheidet (`blocked_reason_codes` aus S2a).
+
+## Der zentrale Fund: beide Platzhalter sind LEBENDIG
+
+Die Annahme bei der Issue-Aufnahme („einer davon ist Alt-Bestand") ist **widerlegt**. Beide
+deaktivierten Platzhalter werden gerendert, nur auf verschiedenen Routen:
+
+| Platzhalter | Route(n) | Stand |
+|---|---|---|
+| `shared/versand-tab/VTBriefingChannels.svelte:187-192` | `/trips/[id]`, `/compare/[id]`, `/compare/new` | live |
+| `edit/EditReportConfigSection.svelte:378` | **`/trips/new`** (Trip-Anlage) | **live** |
+
+**Ursache:** Der Umbau #1232 (`424e403`, 2026-07-12) hat `EditReportConfigSection` nur im
+Briefings-Reiter von `/trips/[id]` durch den geteilten `VersandTab` ersetzt. Die Trip-**Anlage**
+wurde nie migriert. Zeitliche Reihenfolge: `EditReportConfigSection:376-381` ist das Original
+(`7fa597c`, 2026-07-07, #1069), `VTBriefingChannels:187-192` die beim #1232-Umbau übernommene
+Kopie — fünf Tage jünger.
+
+`EditReportConfigSection` hat vier Einbaustellen, aber nur **eine** ist wirksam:
+
+- `edit/TripEditView.svelte:203` — **kein Importer**; die Route `/trips/[id]/edit` ist ein
+  Redirect-Stub. Tot.
+- `briefings-tab/BriefingsTab.svelte:40` — importiert in `TripTabs.svelte:14`, aber **nie als
+  Element gerendert**. Toter Import.
+- `shared/WeatherMetricsTab.svelte:1546` — mit `showChannels={false}`, der Kanalblock erscheint
+  dort nicht.
+- **`trip-new/TripNewEditor.svelte:780` (Desktop) und `:1016` (Mobile)** — `showChannels` nicht
+  gesetzt, Default `true` (`EditReportConfigSection.svelte:44`) ⇒ **Kanalblock inkl.
+  Premium-SMS-Zeile wird gerendert.** Gemountet von `routes/trips/new/+page.svelte:9`.
+
+## Vier Mounts des geteilten Versand-Reiters
+
+| # | Stelle | `context` | Fläche |
+|---|---|---|---|
+| 1 | `trip-detail/BriefingScheduleTab.svelte:130` | `route` | `/trips/[id]` |
+| 2 | `compare/CompareTabs.svelte:1452` | `vergleich` | `/compare/[id]` |
+| 3 | `compare-new/CompareNewEditor.svelte:420` | `vergleich` (Desktop) | `/compare/new` |
+| 4 | `compare-new/CompareNewEditor.svelte:502` | `vergleich` (Mobile) | `/compare/new` |
+
+Kein Mount für die Trip-Anlage — das ist genau die Lücke oben. (Beim Nachbar-Reiter `AlarmeTab`
+sind drei Compare-Mounts dokumentiert; dort deckt `AlarmeScheduleTab.svelte:60` mit
+`context="route"` die Trip-Seite inklusive Anlage ab. Beim Versand ist die Anlage abgehängt.)
+
+## Die Logik steht wörtlich doppelt im Code
+
+Identisch in beiden Komponenten (`VTBriefingChannels.svelte:77-81`,
+`EditReportConfigSection.svelte:102-106`):
+
+```js
+let availableChannels = $derived({
+  email: !!profile?.mail_to,
+  telegram: !!profile?.telegram_chat_id,
+  sms: !!profile?.sms_to && profile?.sms_allowed !== false
+});
+```
+
+`profile` wird **pro Komponenteninstanz eigenständig** per `onMount` von `/api/auth/profile`
+geladen (`VTBriefingChannels.svelte:88-98`, `EditReportConfigSection.svelte:192-197`) — kein
+Store, kein geteilter Zustand.
+
+**Es gibt aber schon geteilte Helfer** für genau diese Art Logik, von beiden Komponenten benutzt:
+`shared/versand-tab/channelContactLabel.ts:30` (Kontakt-Suffix am Checkbox-Label) und
+`channelConnectionStatus()`. **Das ist das Muster für S3** — nicht eine dritte Kopie.
+
+## Die Datenquelle fehlt noch komplett
+
+- Heutige SMS-Darstellung: Label-Suffix ` (nummer)` über `channelContactLabel`, Fehlhinweis
+  „Handynummer fehlt — im Account einrichten" (`VTBriefingChannels.svelte:182-185`). Quelle:
+  `profile.sms_to` — eine **nutzereingegebene** Nummer (`UpdateProfileHandler`,
+  `auth.go:585-586`).
+- Die **gelernte** Rückadresse ist im Frontend **nirgends erreichbar**: `profileResponse`
+  (`auth.go:446-465`) führt sie nicht. Ohne lesende Ergänzung gibt es keine Datenquelle.
+- Tarif-Gate-Vorbild: `profile?.sms_allowed === false` ⇒ „SMS ab Level Standard verfügbar"
+  (`VTBriefingChannels.svelte:178-181`). Backend: `auth.go:504` `SmsAllowed: model.SmsAllowed(tier)`,
+  `model/tier.go:3-6` erlaubt `standard` + `premium`. **Premium-SMS braucht ein eigenes Gate —
+  nur `premium`** (S2a hat dafür `premium_sms_allowed()` in Python; die Go-Seite hat noch keins).
+
+## Go-Seite (gemessen)
+
+**Lesende Profil-Ausgabe:** zwei Vorbilder, und das naheliegende ist falsch.
+`EmailVerified` (`auth.go:457`, Ableitung `:505`) gibt bewusst **keinen** Rohzeitstempel aus —
+AC-20 verlangt, dass `email_verified_at` nie im JSON auftaucht, festgenagelt per
+Negativ-Assertion (`profile_test.go:553-554`). Für die Rückadresse ist `RequestedAt`
+(`auth.go:461`, roh durchgereicht `:507`) das richtige Muster: hier **ist** der Zeitstempel die
+Nutzinformation. Pointer, weil `omitempty` bei `time.Time`-Werten nicht greift.
+
+**Kein Test nagelt die Feldmenge von `profileResponse` fest.** Es gibt nur gezielte Tests für
+`sms_allowed` (`profile_test.go:465-515`) und `email_verified` (`:520-554`). Ein neues Feld ist
+also unbewacht.
+
+**`UpdateProfileHandler`-Decode-Struct** (`auth.go:541-547`) enthält die Felder nicht — S3 ist
+rein lesend, dieses Struct **bleibt unverändert**. Es darf sie nie aufnehmen, sonst wird die
+gelernte Adresse editierbar und die Zusage aus S2a fällt.
+
+**Flaches Trip-Feld — kleiner als im Issue behauptet.** Korrektur: es braucht **keinen**
+Merge-Zweig im Handler. Für die drei bestehenden Flach-Felder existiert keiner
+(`grep` über `internal/handler/trip.go` findet die Feldnamen nicht). Der Weg ist:
+Client schickt `report_config.send_premium_sms` → `mergeConfigMap` (feldweise,
+`config_merge.go:11-22`) → `SaveTrip` → `normalizeTrip` → `deriveFlatFields`
+(`internal/store/trip.go:57-92`) leitet neu ab. Dort werden die Pointer zuerst hart auf `nil`
+zurückgesetzt (`:63-70`, Fix-Loop F001 — sonst bleibt ein Wert stehen, wenn die Quelle
+verschwindet), dann bedingt gesetzt (`:79-87`).
+
+**Frontend liest ohnehin `report_config`, nicht die Flach-Felder** (`VersandTab.svelte:91-93`,
+`types.ts:343-351` nennt sie ausdrücklich „nicht autoritativ"). Das Flach-Feld ist also
+Vollständigkeit des Vertrags, nicht Voraussetzung der Oberfläche.
+
+## Ganzobjekt-Falle — für S3 NICHT relevant, aber zu kennen
+
+`existing.AlertChannels = req.AlertChannels` (`internal/handler/trip.go:368`) ersetzt das
+Unterobjekt **komplett**; `AlertChannelsConfig` (`model/trip.go:183-191`) hat kein viertes Feld.
+Ein Client ohne Kenntnis eines neuen Kanals würde ihn beim Speichern still auf `false` setzen.
+Der Code dokumentiert die Lehre selbst bei `AlertChannelThresholds` (`model/trip.go:193-201`) und
+schützt sie deshalb **zweistufig** (`trip.go:375-386`: „ZWEI Ebenen Datenverlustschutz … Pflicht,
+kein Kann"). **Das betrifft #1701, nicht S3** — S3 rührt `AlertChannels` nicht an.
+
+## Vertrag nachzuziehen
+
+`docs/reference/api_contract.md` erwartet diese Scheibe schon:
+- `:579` — `send_premium_sms` dokumentiert, mit Hinweis „kein eigenes Go-Struct-Feld … folgt erst
+  mit S3"
+- `:741-743` — Trip-DTO-Block listet die drei Flach-Felder, das vierte fehlt
+- `:2690-2736` + `:2832-2833` — Profil-Abschnitt ohne die Rückadress-Felder, mit dem zu
+  revidierenden Hinweis „keine Auth-Profile-Ausgabe in dieser Scheibe"
+
+## Test-Vorbilder und Regressionsnetz
+
+1. **`shared/versand-tab/__tests__/channel_checkbox_dedupe_render.test.ts`** — SSR-Test, prüft
+   **beide** Komponenten für dieselben Profil-Fälle auf identische Beschriftung, Verbindungsstatus
+   und Deaktiviert-Zustand. **Das ist das wichtigste Netz** — es existiert genau, um die
+   Doppelung synchron zu halten, und muss um Premium-SMS erweitert werden.
+2. `shared/__tests__/channel_connection_status.test.ts` — u.a. „SMS hinterlegt aber tarifgesperrt".
+3. `shared/versand-tab/__tests__/channelContactLabel.test.ts` — Kontakt-Suffixe.
+4. `shared/versand-tab/__tests__/sendTargetLabel.test.ts` — Zieltext im Versand-Dialog, zweite
+   Perspektive auf das Tarif-Gate.
+5. `frontend/e2e/issue-609-sms-profil.spec.ts`, `versand-tab.spec.ts`,
+   `compare-hub-versand-inline.spec.ts` — Playwright-Verankerung am Versand-Reiter.
+
+Go-Seite: `internal/store/trip_flat_fields_test.go` (Roundtrip der Flach-Felder, inkl. „bleibt
+`nil` ohne `report_config`" und „kein Stale-Zustand"), `internal/handler/profile_test.go`.
+
+## Risks & Considerations
+
+1. **Eine dritte Kopie der Kanal-Logik wäre der Default-Fehler.** Die Logik „fehlt / veraltet /
+   frisch" gehört in einen geteilten Helfer neben `channelContactLabel.ts`, damit sie genau
+   einmal existiert. Zwei Komponenten rufen sie auf.
+2. **Kontrast:** „zuletzt gemeldet am …" ist ein **Daten-Label**, kein Hilfstext. Die blasseste
+   Textfarbe ist strikt für Platzhalter/Deaktiviertes reserviert (2,85:1 auf Weiß) — genau dieser
+   Wert entscheidet, ob man der Anzeige auf einem Handydisplay trauen kann.
+3. **Die 30-Tage-Frist darf nicht zum zweiten Mal als Zahl auftauchen.** S2a führt sie als
+   `PREMIUM_SMS_REPLY_TTL` in `src/output/channels/premium_sms.py:39`. Das Frontend kann sie nicht
+   importieren — also muss die **Bewertung** vom Server kommen (abgeleiteter Zustand), nicht die
+   Frist ins Frontend kopiert werden. Sonst driften zwei Zahlen auseinander.
+4. **Browser-Gate:** Frontend-Scope ⇒ `staging_gate.py --write-verdict` lädt sechs Kernseiten in
+   echtem Chromium; ohne bestandenen Lauf keine Attestation, kein Prod-Deploy. Dazu ein
+   `fresh-eyes-inspector`-Lauf auf Screenshots ohne Bug-Kontext.
+5. **Pendant-Sperre:** neue Dateien in einseitigen Verzeichnissen werden am Commit blockiert. Ein
+   neuer geteilter Helfer gehört nach `shared/versand-tab/` — dort ist er unproblematisch.
+6. **Nicht in dieser Scheibe:** `/trips/new` auf `VersandTab` umstellen. Vorbestehender Bruch der
+   Teilungsregel, eigener Umbau am Anlege-Editor; gebucht in #1199.
+
+## Nachweis-Grenze
+
+S3 beweist: Kanal schaltbar, Zustand der Rückadresse ablesbar, kein Zustand still verschwiegen.
+**Nicht** bewiesen: dass eine so eingeschaltete Premium-SMS auf dem Gerät ankommt — das bleibt
+#1533.

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -596,7 +596,7 @@ Lawinenlagebericht als eigenstaendiges Datenobjekt (nicht Teil von NormalizedTim
 | timezone                        | str         | Zeitzone (default: "Europe/Vienna")                    |
 | send_email                      | bool        | E-Mail senden? (default: true)                         |
 | send_sms                        | bool        | SMS senden? (default: false)                           |
-| send_premium_sms                | bool        | Premium-SMS (Garmin inReach) senden? (default: false, Issue #1676 S2a) — eigenständiger vierter Kanal `premium_sms`, **nur Trip-Briefing** (Alarmpfad/Ortsvergleich erst mit #1701, s. ADR-0049); Empfänger ist ausschließlich die in Scheibe S1 gelernte Rückadresse aus `user.json`, nie `sms_to`. Lebt aktuell nur im freien `report_config`-Schlüssel (kein eigenes Go-Struct-Feld analog `send_sms`/`send_telegram`, folgt erst mit S3). |
+| send_premium_sms                | bool        | Premium-SMS (Garmin inReach) senden? (default: false, Issue #1676 S2a) — eigenständiger vierter Kanal `premium_sms`, **nur Trip-Briefing** (Alarmpfad/Ortsvergleich erst mit #1701, s. ADR-0049); Empfänger ist ausschließlich die in Scheibe S1 gelernte Rückadresse aus `user.json`, nie `sms_to`. Seit #1717 S3 auch in der Oberfläche schaltbar (Trip-Anlage + Trip-Detail) und als abgeleitetes Go-Struct-Feld `Trip.SendPremiumSms` vorhanden — `report_config.send_premium_sms` bleibt die autoritative Quelle. |
 | alert_on_changes                | bool        | Alerts bei Änderungen? (default: true)                 |
 | change_threshold_temp_c         | float       | Temp-Änderungs-Schwelle [°C] (default: 5.0)            |
 | change_threshold_wind_kmh       | float       | Wind-Änderungs-Schwelle [km/h] (default: 20.0)         |
@@ -761,6 +761,7 @@ type Trip struct {
     SendEmail               *bool                  `json:"send_email,omitempty"`
     SendSms                 *bool                  `json:"send_sms,omitempty"`
     SendTelegram            *bool                  `json:"send_telegram,omitempty"`
+    SendPremiumSms          *bool                  `json:"send_premium_sms,omitempty"`        // Issue #1717 S3 — vierter Kanal (Premium-SMS)
     EndDate                 *string                `json:"end_date,omitempty"`                // max(stage.date), ISO
     Kind                    string                 `json:"kind,omitempty"`                    // ADR-0023-Diskriminator ("route"); nur Migration schreibt ihn
 }
@@ -2725,6 +2726,10 @@ Returns authenticated user profile (requires valid session cookie).
   "sms_allowed": false,
   "requested_tier": "standard",
   "requested_at": "2026-07-07T14:00:00Z",
+  "premium_sms_allowed": false,
+  "premium_sms_reply_state": "none",
+  "premium_sms_reply_to": "15551234567",
+  "premium_sms_reply_at": "2026-08-05T12:00:00Z",
   "has_passkey": true,
   "passkeys": [
     {
@@ -2758,6 +2763,10 @@ Returns authenticated user profile (requires valid session cookie).
 | sms_allowed | bool | Whether SMS channel is available for this user (Issue #1069, Slice 2 of Epic #1067); `true` if `tier` is `standard` or `premium`, `false` for `free`; determines server-side channel-gating in report-dispatch and alert-dispatch |
 | requested_tier | string | Level change requested by the user via `POST /api/auth/tier-change-request` (Issue #1071, Slice 4 of Epic #1067); `omitempty` — absent/empty if no request is pending. Does not change `tier` itself; only the PO setting `tier` manually clears the pending state (once `requested_tier == tier`, the frontend Pending-hint disappears) |
 | requested_at | string (RFC3339) | Timestamp of the pending tier-change request set alongside `requested_tier`; pointer type server-side so it is omitted entirely (not a zero-value timestamp) when no request is pending |
+| premium_sms_allowed | bool | Whether the Premium-SMS channel (Garmin inReach) is available (Issue #1717 S3); **always present**. Own tariff gate `model.PremiumSmsAllowed` — `true` **only** for `tier == "premium"`, deliberately NOT derived from `sms_allowed` (which also lets `standard` through). Otherwise a `standard` user could tick a channel the dispatch path blocks anyway (#1676 S2a AC-8) |
+| premium_sms_reply_state | string | Server-derived state of the learned reply address (Issue #1717 S3): `none` (device never reported), `stale` (reported but past the expiry), `fresh` (valid); **always present**. Derived from `PremiumSmsReplyTo`/`PremiumSmsReplyAt` via `model.DerivePremiumSmsReplyState` against `model.PremiumSmsReplyTTL` (30 days, Go pendant of `PREMIUM_SMS_REPLY_TTL` in `src/output/channels/premium_sms.py`; drift guard: `tests/test_premium_sms_ttl_drift.py`). The UI follows this field only and never recomputes the deadline — otherwise a third copy of the number would exist |
+| premium_sms_reply_to | string | The learned Garmin reply address (Issue #1717 S3, raw value); `omitempty` — absent while the device has never reported. Read-only: the sole writer is the internal endpoint `POST /api/internal/premium-sms-learn` (#1676 S1), `PUT /api/auth/profile` does **not** accept it |
+| premium_sms_reply_at | string (RFC3339) | When that address was learned (Issue #1717 S3, raw value — here the timestamp *is* the payload, unlike `email_verified_at` which is never exposed); pointer server-side so it is omitted entirely instead of a zero-value timestamp. Same read-only rule as `premium_sms_reply_to` |
 | has_passkey | bool | Whether user has registered any passkeys |
 | passkeys | array | List of registered WebAuthn credentials (empty if `has_passkey=false`) |
 
@@ -2788,6 +2797,13 @@ Returns updated profile object (same as `GET /api/auth/profile`).
 - `mail_to`: Optional, any non-empty string (no format validation)
 - `sms_to`: Optional, any non-empty string (no format validation; validation happens during send via SMS provider)
 - Empty strings allowed (unset field)
+- **Not accepted (Issue #1717 S3, AC-7):** `premium_sms_reply_to`, `premium_sms_reply_at`,
+  `premium_sms_reply_state`, `premium_sms_allowed`. The decode struct does not contain them, so
+  sending them is silently a no-op — the learned reply address stays writable **only** by the
+  internal learning endpoint (#1676 S1). Were it editable, the S2a promise "recipient is
+  exclusively the learned reply address, never configuration" would collapse: a user could enter a
+  foreign number and have paid Premium-SMS delivered there. Guarded by
+  `internal/handler/profile_test.go::TestUpdateProfileHandlerIgnoresPremiumSmsReplyFields`
 
 **Error Responses:**
 
@@ -2855,7 +2871,7 @@ type User struct {
     Tier               string                 `json:"tier,omitempty"`  // NEW (Issue #1068, Slice 1 of Epic #1067) — free/standard/premium; empty defaults to "free" at read time
     RequestedTier      string                 `json:"requested_tier,omitempty"`  // NEW (Issue #1071, Slice 4 of Epic #1067) — pending level-change request
     RequestedAt        *time.Time             `json:"requested_at,omitempty"`  // NEW (Issue #1071) — pointer type: plain time.Time's omitempty doesn't work, would serialize as zero-value "0001-01-01T00:00:00Z" instead of being omitted
-    PremiumSmsReplyTo  string                 `json:"premium_sms_reply_to,omitempty"`  // NEW (Issue #1676, Scheibe S1) — vom Garmin inReach zuletzt gelernte Rückadresse (seven.io-Journal, Kennzeichen `inreachlink.com`); einziger Schreiber ist der interne Endpoint `POST /api/internal/premium-sms-learn`; kein Frontend, keine Auth-Profile-Ausgabe in dieser Scheibe
+    PremiumSmsReplyTo  string                 `json:"premium_sms_reply_to,omitempty"`  // NEW (Issue #1676, Scheibe S1) — vom Garmin inReach zuletzt gelernte Rückadresse (seven.io-Journal, Kennzeichen `inreachlink.com`); einziger Schreiber bleibt der interne Endpoint `POST /api/internal/premium-sms-learn`. REVIDIERT durch #1717 S3: `GET /api/auth/profile` gibt den Wert seither LESEND aus (`premium_sms_reply_to` + abgeleitetes `premium_sms_reply_state`), damit die Oberfläche zeigen kann, wohin gesendet wird und ob die Adresse noch gilt — `PUT /api/auth/profile` nimmt ihn weiterhin NICHT an (AC-7)
     PremiumSmsReplyAt  *time.Time             `json:"premium_sms_reply_at,omitempty"`  // NEW (Issue #1676, Scheibe S1) — Empfangszeitpunkt des Go-Endpoints (nicht der seven.io-`timestamp`); pointer-Muster analog RequestedAt
 }
 
@@ -3442,6 +3458,17 @@ function corridorInside(value, min, max) {
 
 ## Changelog
 
+- 2026-08-11: Issue #1717 Scheibe S3 — Premium-SMS in der Oberfläche. `GET /api/auth/profile`
+  liefert vier neue, **rein lesende** Felder: `premium_sms_reply_to`/`premium_sms_reply_at`
+  (Rohwerte, `omitempty`), `premium_sms_reply_state` (`none`/`stale`/`fresh`, immer vorhanden,
+  serverseitig aus `model.PremiumSmsReplyTTL` abgeleitet) und `premium_sms_allowed` (immer
+  vorhanden, eigenes Tarif-Gate `model.PremiumSmsAllowed` — nur `premium`, NICHT von
+  `sms_allowed` abgeleitet). `PUT /api/auth/profile` nimmt keins davon an (AC-7) — die gelernte
+  Rückadresse bleibt allein durch den internen Lernpfad (#1676 S1) schreibbar. `Trip` bekommt
+  das vierte abgeleitete Flach-Feld `send_premium_sms` (nicht autoritativ, aus
+  `report_config.send_premium_sms` bei jedem Load neu abgeleitet und zuvor auf `nil` zurückgesetzt).
+  Die Verfallsfrist existiert damit zwangsläufig zweimal (Python-Sendepfad + Go-Ableitung) und wird
+  von `tests/test_premium_sms_ttl_drift.py` gegeneinander bewacht.
 - 2026-08-11: Issue #1701 Scheibe S2b — Premium-SMS wird vierter Kanal im
   Alarm- UND Ortsvergleich-Pfad (Vorgänger: S2a #1676, ausschließlich
   Trip-Briefing). `AlertChannelsConfig` bekommt `PremiumSms *bool` — dabei

--- a/docs/specs/modules/feat_1717_s3_premium_sms_ui.md
+++ b/docs/specs/modules/feat_1717_s3_premium_sms_ui.md
@@ -1,0 +1,490 @@
+---
+entity_id: feat_1717_s3_premium_sms_ui
+type: module
+created: 2026-08-11
+updated: 2026-08-11
+status: draft
+version: "1.0"
+tags: [sms, premium, garmin, seven-io, channel, frontend, go-api]
+---
+
+<!-- Issue #1717 (Scheibe S3) -- Premium-SMS in der Oberflaeche. Vorgaenger:
+     S1 (feat_1676_s1_premium_sms_rueckkanal.md, live), S2a
+     (feat_1676_s2a_premium_sms_versand.md, live). Nachfolger: S2b/#1701
+     (Alarm-/Vergleichspfad), S2c/#1702 (Kostenstelle), #1533 (Generalprobe
+     auf dem Geraet). Kontext-Grundlage: docs/context/feat-1717-s3-premium-sms-ui.md. -->
+
+# Premium-SMS in der Oberfläche — S3
+
+## Approval
+
+- [x] Approved — PO-Freigabe 2026-08-11 ("freigabe"), 11 ACs inkl. AC-11
+      (Frist-Drift-Wächter, vom Orchestrierer gegen den Entwurf nachgetragen)
+
+## Purpose
+
+Premium-SMS (Garmin inReach), seit S2a ein vollwertiger vierter Versandkanal, wird für den
+Nutzer im Trip-Editor sichtbar und selbst schaltbar — inklusive der von S1 gelernten
+Rückadresse und ihres Alters. Auf Tour soll nicht länger rätselhaft bleiben, ob der Kanal aus
+ist, noch keine Rückadresse gelernt wurde oder sie verfallen ist — das Backend unterscheidet
+diese drei Fälle bereits (S2a, `ChannelBlockedError.reason_code`), die Oberfläche zeigt sie
+bislang nirgends.
+
+## Abgrenzung (nicht in dieser Scheibe)
+
+- **Alarm- und Vergleichspfad (#1701):** Premium-SMS bleibt ausschließlich ein
+  Trip-Briefing-Kanal (ADR-0049). `VTBriefingChannels.svelte` wird zwar in **beiden** Kontexten
+  gemountet (`context="route"` für `/trips/[id]`, `context="vergleich"` für `/compare/[id]` und
+  `/compare/new`, verdrahtet über `shared/VersandTab.svelte:204-247`) — der neue, schaltbare
+  Premium-SMS-Block darf **ausschließlich im `route`-Kontext** erscheinen. AC-1 sichert das
+  strukturell ab.
+- **`/trips/new` auf den geteilten `VersandTab` umstellen:** vorbestehender Bruch der
+  Trip/Compare-Teilungsregel (der Anlege-Editor nutzt weiterhin `EditReportConfigSection`, nicht
+  `VersandTab`), gebucht in #1199. Diese Scheibe aktiviert den Premium-SMS-Block **innerhalb**
+  von `EditReportConfigSection`, ändert aber nichts an dieser strukturellen Abweichung.
+- **Kostenstelle (#1702):** keine Zähler, keine Kontingent-Anzeige.
+- **#1533 — Generalprobe auf dem Gerät:** ob eine über die neue Checkbox aktivierte Premium-SMS
+  tatsächlich am Garmin-Gerät ankommt, bleibt dort. Siehe „Nachweisgrenzen" unten.
+
+## Source
+
+**Frontend (`frontend/src/lib/components/...`, SvelteKit):**
+
+- **File:** `shared/versand-tab/VTBriefingChannels.svelte` (MODIFY, ≈+35 LoC) — der fest
+  deaktivierte Platzhalter (`checked={false} disabled={true}`, Zeilen 187-192) wird durch einen
+  echten, zustandsgetriebenen Block ersetzt, der **nur** rendert, wenn eine neue optionale Prop
+  `onPremiumSmsChange` gesetzt ist — exakt das Gating-Muster des bestehenden
+  `{#if onTelegramStyleChange}` (Zeile 155), das dort schon heute den Kurzstil-Schalter auf den
+  `route`-Zweig beschränkt (`onTelegramStyleChange` wird im `vergleich`-Zweig von `VersandTab`
+  nie übergeben, Zeilen 234-247).
+- **File:** `edit/EditReportConfigSection.svelte` (MODIFY, ≈+35 LoC) — der Platzhalter (Zeilen
+  376-382) wird analog aktiviert; `send_premium_sms` wird **aus der `reportConfig`-Prop
+  initialisiert** (Vorbild im Bestand: `profile` per `untrack(…)`, Zeile 98) und im
+  Write-Back-`$effect` mitgeführt (neben Zeilen 215-217).
+  🔴 **Korrektur:** Die erste Fassung schrieb „Hydration in `onMount`" (neben Zeile 154). Das ist
+  allein **nicht messbar** — `render()` aus `svelte/server` führt `onMount` nicht aus, und AC-10
+  verlangt Sichtbarkeit beim Rendern. Eine Zusicherung, die per Bauart an ihrem eigenen Prüfort
+  nicht ankommen kann, ist keine.
+- **File:** `shared/VersandTab.svelte` (MODIFY, ≈+15 LoC) — **eigenständiger Fund, nicht im
+  Kontextdokument benannt:** dies ist die tatsächliche State-/Persistenz-Schicht für
+  `/trips/[id]` (gemountet von `trip-detail/BriefingScheduleTab.svelte:130-137` mit
+  `bind:reportConfig`). Ohne Ergänzung von `send_premium_sms` hier (analog `send_sms` in
+  Zeilen 68-70 State, 91-93 Hydration, 121-123 Write-Back, 143-151
+  `makeChannelChangeHandler`) bliebe eine in `VTBriefingChannels` geklickte Premium-SMS-Checkbox
+  für `/trips/[id]` folgenlos — der Wert würde nie in `report_config` geschrieben. Nur der
+  `route`-Zweig (Zeilen 202-231) bekommt die neue Prop `onPremiumSmsChange`; der
+  `vergleich`-Zweig (Zeilen 232-285, `CompareTabs.svelte:1452`,
+  `CompareNewEditor.svelte:420,502`) bleibt unverändert — genau die in „Abgrenzung" beschriebene
+  Trennung.
+- **File:** `shared/versand-tab/channelConnectionStatus.ts` (MODIFY, +4 LoC) — `ConnectionProfile`
+  (Zeilen 23-29) bekommt vier neue optionale Felder (`premium_sms_reply_to`,
+  `premium_sms_reply_at`, `premium_sms_reply_state`, `premium_sms_allowed`) als **einzige**
+  kanonische Profilform, statt die drei lokalen `interface Profile`-Kopien (VTBriefingChannels,
+  EditReportConfigSection) unabhängig zu erweitern — `channelContactLabel.ts` importiert
+  `ConnectionProfile` bereits (Zeile 15), der neue Helfer unten reiht sich ein.
+- **File:** `shared/versand-tab/premiumSmsChannelState.ts` (NEU, ≈55 LoC) — geteilter Helfer,
+  Design analog `channelConnectionStatus()` (ein Aufruf liefert Tone/Label/Hinweis/Meldedatum
+  als ein Objekt) statt einer dritten Kopie der Zustandslogik. Liest ausschließlich die vier
+  neuen Profilfelder, rechnet **keine** Frist selbst nach (s. Implementation Details).
+- **File:** `shared/versand-tab/__tests__/channel_checkbox_dedupe_render.test.ts` (MODIFY,
+  ≈+120 LoC) — bestehendes Muster (SSR beider Komponenten, identische Profile, s. AC-2/AC-3/AC-4
+  im Bestand) um Premium-SMS-Fälle erweitert. Das wichtigste Regressionsnetz dieser Scheibe.
+- **File:** `shared/versand-tab/__tests__/premium_sms_channel_state.test.ts` (NEU, ≈70 LoC) —
+  reine Funktionsprüfung des neuen Helfers, u. a. der Server-Autoritäts-Fall (AC-5).
+- **File:** `shared/versand-tab/__tests__/premium_sms_context_gating_render.test.ts` (NEU,
+  ≈60 LoC) — SSR-Nachweis, dass `context="vergleich"` niemals eine schaltbare Premium-SMS-Box
+  zeigt (AC-1).
+
+**Go-API (`internal/...`, Production-API Port 8090):**
+
+- **File:** `internal/model/premium_sms.go` (NEU, ≈45 LoC) — `PremiumSmsReplyTTL` (Go-Pendant zu
+  `PREMIUM_SMS_REPLY_TTL`, `src/output/channels/premium_sms.py:39`, siehe Known Limitations),
+  Zustands-Konstanten `PremiumSmsStateNone`/`PremiumSmsStateStale`/`PremiumSmsStateFresh` und
+  `DerivePremiumSmsReplyState(replyTo string, replyAt *time.Time) string`.
+- **File:** `internal/model/tier.go` (MODIFY, +≈10 LoC) — `PremiumSmsAllowed(tier string) bool`,
+  Struktur analog `SmsAllowed` (Zeilen 3-10), aber ausschließlich `tier == "premium"` — **kein**
+  Aufruf von `SmsAllowed` (das lässt `standard` durch, `:3-6`).
+- **File:** `internal/model/trip.go` (MODIFY, +1 LoC) — `SendPremiumSms *bool
+  \`json:"send_premium_sms,omitempty"\`` neben den bestehenden Flach-Feldern (Zeilen 161-163).
+- **File:** `internal/store/trip.go` (MODIFY, +≈8 LoC) — `deriveFlatFields` (Zeilen 52-92): ein
+  Reset auf `nil` bei den bestehenden Resets (`:63-70`, Fix-Loop F001 aus S2a-Vorbild:
+  Trip-Konvergenz), eine bedingte Ableitung bei den bestehenden `rc[...]`-Zweigen (`:79-87`).
+  **Kein** Merge-Zweig in `internal/handler/trip.go` nötig — der generische, feldweise
+  `mergeConfigMap` (`internal/handler/config_merge.go:11-22`) transportiert
+  `report_config.send_premium_sms` bereits verlustfrei.
+- **File:** `internal/handler/auth.go` (MODIFY, +≈25 LoC) — `profileResponse` (Zeilen 446-465)
+  bekommt vier neue Felder: `PremiumSmsReplyTo`/`PremiumSmsReplyAt` (Rohwerte, Muster
+  `RequestedAt` `:461`/`:507` — Pointer, weil `omitempty` bei `time.Time`-Werten nicht greift),
+  `PremiumSmsReplyState` (abgeleiteter String über `model.DerivePremiumSmsReplyState`, Muster
+  `EmailVerified` `:457`/`:505` — abgeleiteter Zustand statt Rohwert), `PremiumSmsAllowed` (bool,
+  Muster `SmsAllowed` `:454`/`:504`). **`UpdateProfileHandler`s Decode-Struct (Zeilen 541-547)
+  bleibt unverändert** — keins der vier Felder wird dort aufgenommen (AC-7).
+- **File:** `internal/handler/profile_test.go` (MODIFY, +≈90 LoC) — Feldmenge der vier neuen
+  Felder je Drei-Zustands-Fall (Muster `TestGetProfileHandlerSmsAllowedField` `:465-515`), plus
+  Negativ-Test, dass ein PUT mit den beiden Rohfeldern im Body wirkungslos bleibt (Muster der
+  Negativ-Assertion in `TestGetProfileHandlerEmailVerifiedField_AC20` `:553-554`).
+- **File:** `internal/model/premium_sms_test.go` (NEU, ≈90 LoC) — Grenzwerttest der Frist
+  (± 1 Sekunde um 30 Tage, Muster S2a AC-4/AC-5) für `DerivePremiumSmsReplyState`.
+- **File:** `internal/store/trip_flat_fields_test.go` (MODIFY, +≈50 LoC) — Premium-SMS-Fälle in
+  die bestehenden Roundtrip-/Nil-Reset-Tests aufgenommen (Muster
+  `TestLoadTrip_DerivesFlatSlotChannelFieldsFromReportConfig` `:20`,
+  `TestLoadTrip_NoReportConfigLeavesFlatFieldsNil` `:101`).
+
+**Vertrag:**
+
+- **File:** `docs/reference/api_contract.md` (MODIFY) — drei Stellen nachziehen: `:579`
+  (`send_premium_sms`-Zeile — der Hinweis „kein eigenes Go-Struct-Feld … folgt erst mit S3" ist
+  jetzt eingelöst), `:741-743` (Trip-DTO-Flach-Feld-Block, viertes Feld ergänzen), `:2690-2736`
+  (Profil-Response-Beispiel + Field-Definitions-Tabelle, vier neue Zeilen) und `:2832-2833`
+  (`User`-Struct-Kommentar „kein Frontend, keine Auth-Profile-Ausgabe in dieser Scheibe" wird
+  revidiert). Changelog-Eintrag.
+
+## Estimated Scope
+
+- **LoC (Produktivcode):** ≈ 231 (Frontend ≈140: VTBriefingChannels +35, EditReportConfigSection
+  +35, VersandTab +15, channelConnectionStatus +4, premiumSmsChannelState.ts +55; Go ≈91:
+  premium_sms.go +45, tier.go +10, trip.go(model) +1, store/trip.go +8, auth.go +25 minus
+  Überschneidung — grob gerundet).
+- **LoC (Tests):** ≈ 480 (Frontend ≈250: dedupe-Erweiterung 120, state-Test 70, gating-Test 60;
+  Go ≈230: profile_test.go 90, premium_sms_test.go 90, trip_flat_fields_test.go 50).
+- **Gesamt erwartet:** ≈ 700-750. Überschreitet das Default-Limit (250/Workflow) deutlich —
+  LoC-Override bei Implementierungsbeginn erwartungsgemäß nötig (Begründung: zwei Schichten,
+  vier Mount-Punkte, Kontext-Trennung als eigene Zusicherung). Doku zählt nicht mit.
+- **Files:** 5 CREATE (3 Frontend-Tests + 1 Frontend-Modul + 2 Go-Dateien, davon 1 Test) +
+  11 MODIFY.
+- **Effort:** medium-high (zwei Schichten, keine neue Fachlogik — nur Sichtbarmachung
+  bestehender Backend-Zustände).
+- **Risiko:** MEDIUM. Größtes Einzelrisiko ist die Kontext-Trennung (AC-1) — sie ist leicht zu
+  übersehen, weil `VTBriefingChannels.svelte` strukturell für beide Kontexte identisch aussieht
+  und der bestehende Platzhalter in **beiden** heute gleich (fest deaktiviert) rendert. Zweites
+  Risiko: die Cross-Language-TTL-Duplikation (Known Limitations).
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `docs/specs/modules/feat_1676_s1_premium_sms_rueckkanal.md` | Vorgänger-Spec | liefert `model.User.PremiumSmsReplyTo`/`PremiumSmsReplyAt` (`internal/model/user.go:37-38`) — alleinige Rohdatenquelle |
+| `docs/specs/modules/feat_1676_s2a_premium_sms_versand.md` | Vorgänger-Spec, live | Sendepfad, Fail-Closed, `PREMIUM_SMS_REPLY_TTL` (`premium_sms.py:39`), `premium_sms_allowed()` (Python-Vorbild für das neue Go-Pendant) |
+| `docs/adr/0049-premium-sms-vierter-kanal.md` | ADR | Kanalname, „nur Trip-Briefing", die vier fachlichen SMS-vs-Premium-SMS-Unterschiede |
+| `shared/versand-tab/channelContactLabel.ts` | Vorbild | geteilter Helfer statt Doppel-Kopie — Muster für `premiumSmsChannelState.ts` |
+| `shared/versand-tab/channelConnectionStatus.ts` | module, MODIFY | `ConnectionProfile` als einzige kanonische Profilform; `Dot`-Atom akzeptiert bereits `tone="warn"` (`ui/dot/Dot.svelte:10`) |
+| `shared/versand-tab/__tests__/channel_checkbox_dedupe_render.test.ts` | Test-Vorbild, MODIFY | wichtigstes Regressionsnetz — hält beide Komponenten synchron |
+| `internal/model/tier.go::SmsAllowed` | Vorbild, NICHT wiederverwendet | Struktur für `PremiumSmsAllowed` — `SmsAllowed` lässt `standard` durch, das darf Premium-SMS nicht |
+| `internal/store/trip.go::deriveFlatFields` | module, MODIFY | Ableitungs-/Reset-Muster für `Trip.SendPremiumSms` |
+| `internal/handler/config_merge.go::mergeConfigMap` | module | generischer Merge — kein neuer Handler-Zweig nötig |
+| `internal/handler/auth.go::RequestedAt`/`EmailVerified` | Vorbild | Doppelmuster Rohwert (Zeitstempel) vs. abgeleiteter Zustand — beide Formen werden hier gebraucht |
+| `docs/reference/api_contract.md` | Vertrag | drei Stellen erwarten diese Scheibe bereits explizit |
+
+## Implementation Details
+
+### Kontext-Trennung: dasselbe Gating-Muster wie der Telegram-Kurzstil (AC-1)
+
+`VTBriefingChannels.svelte` wird von `VersandTab.svelte` in zwei Kontexten gemountet: `route`
+(`/trips/[id]`, Zeilen 204-212, MIT `onTelegramStyleChange`) und `vergleich` (`/compare/[id]`,
+`/compare/new`, Zeilen 234-247, OHNE `onTelegramStyleChange`). Die Komponente selbst rendert den
+Kurzstil-Schalter schon heute nur `{#if onTelegramStyleChange}` (Zeile 155) — eine reine
+Prop-Anwesenheitsprüfung, kein `context`-String-Vergleich. Premium-SMS folgt demselben Muster:
+neue Prop `onPremiumSmsChange`, nur vom `route`-Zweig übergeben, Block nur `{#if
+onPremiumSmsChange}` sichtbar. Ein `context === 'route'`-Vergleich direkt in der Komponente wäre
+technisch gleichwertig, aber ein zweiter, redundanter Kontrollpunkt — das etablierte Muster
+(Prop-Anwesenheit) reicht und bleibt konsistent zum Bestand.
+
+### Geteilter Zustands-Helfer, keine dritte Kopie
+
+`premiumSmsChannelState(profile: ConnectionProfile | null | undefined)` liefert ein Objekt mit
+`disabled`, `tone` (`'good' | 'warn' | 'neutral'`), `statusLabel`, `hint` und `reportedAtLabel`.
+Eingabe sind ausschließlich die vier neuen `ConnectionProfile`-Felder — keine
+Datums-Arithmetik im Helfer (AC-5). `disabled = !profile.premium_sms_allowed ||
+profile.premium_sms_reply_state !== 'fresh'`. Der Hinweistext für `stale` nennt das Meldedatum,
+aber **keine Frist-Zahl** („Rückadresse verfallen — zuletzt gemeldet am …", nicht „vor mehr als
+30 Tagen") — eine Zahl im Text wäre dieselbe Kopie in Prosaform.
+
+### Server leitet den Zustand ab — zwei Schichten, eine Verantwortung
+
+`GET /api/auth/profile` ist ein Go-Endpoint; die 30-Tage-Frist ist heute ausschließlich als
+`PREMIUM_SMS_REPLY_TTL` im Python-Kern definiert (`premium_sms.py:39`), der den Sendepfad prüft.
+Damit die Anzeige nicht doch eine eigene JS-Konstante braucht, bekommt `internal/model` eine
+**eigene, bewusst benannte** Go-Konstante `PremiumSmsReplyTTL = 30 * 24 * time.Hour` mit einem
+Code-Kommentar, der explizit auf `premium_sms.py:39` verweist. Das ist **kein** Widerspruch zur
+Vorgabe „Frist nicht ins Frontend kopieren" — sie bleibt serverseitig, auf der einzigen Schicht,
+die den HTTP-Endpoint für das Profil bedient. Die Duplikation zwischen Go- und Python-Backend
+ist real, aber strukturell bedingt (zwei getrennte Prozesse ohne gemeinsame Konstante) und wird
+unter „Known Limitations" ausgewiesen, nicht verschwiegen.
+
+### Eigenes Tarif-Gate (analog D7 aus S2a)
+
+`model.PremiumSmsAllowed(tier)` prüft ausschließlich `tier == "premium"`. Keine Delegation an
+`SmsAllowed`, das `standard` **und** `premium` durchlässt (`tier.go:3-6`) — sonst könnte ein
+`standard`-Nutzer den Kanal einschalten, obwohl das Backend ihn beim Versand ohnehin sperren
+würde (S2a AC-8) — eine Checkbox, die etwas verspricht, das serverseitig nie passiert.
+
+### `UpdateProfileHandler` bleibt unverändert (AC-7)
+
+Die Decode-Struct (`auth.go:541-547`) nimmt die vier neuen Felder **nicht** auf. Diese Scheibe
+ist rein lesend — würde die gelernte Rückadresse editierbar, fiele die S2a-Zusage „Empfänger
+ausschließlich die gelernte Rückadresse, niemals aus der Konfiguration" strukturell in sich
+zusammen: ein Nutzer könnte sich selbst eine beliebige `premium_sms_reply_to` eintragen und
+Premium-SMS an eine fremde Nummer schicken lassen.
+
+### Flach-Feld `Trip.SendPremiumSms` — Vertrags-Vollständigkeit, kein neuer Schreibpfad
+
+Analog den drei bestehenden Feldern (`trip.go:161-163`) wird `SendPremiumSms` in
+`deriveFlatFields` zuerst hart auf `nil` zurückgesetzt (neben den bestehenden Resets,
+`store/trip.go:63-70` — sonst bliebe bei verschwindender Quelle ein stiller Altwert stehen,
+Fix-Loop F001 aus S2a), dann bedingt aus `rc["send_premium_sms"]` gesetzt (`:79-87`). Der
+Client schickt weiterhin `report_config.send_premium_sms`; `mergeConfigMap` transportiert das
+generisch. Das Frontend liest ohnehin `report_config`, nicht die Flach-Felder — das Flach-Feld
+ist Vertrags-Vollständigkeit, keine Voraussetzung für die UI (wie in S2a D8 für die anderen drei
+Felder dokumentiert).
+
+### Kontrast: Meldedatum ist ein Daten-Label, keine Fußnote
+
+`.vt-channel-status-label` (`VTBriefingChannels.svelte:226-231`) nutzt bereits bewusst
+`--g-ink-3` statt `--g-ink-4` „in beiden Zuständen" (Zeile 219-Kommentar, Kontrast-Leitprinzip).
+Das Meldedatum-Label folgt derselben Klasse/Farbe — nicht `--g-ink-4` (2,85:1 auf Weiß, laut
+CLAUDE.md strikt Platzhalter/Disabled vorbehalten).
+
+## Expected Behavior
+
+- **Input:** Nutzer öffnet `/trips/new` oder `/trips/[id]` → Versand-/Kanäle-Bereich; Klick auf
+  die Premium-SMS-Checkbox (nur wenn nicht `disabled`).
+- **Output:** `report_config.send_premium_sms` wird beim Speichern mitgeschrieben (Trip-Anlage:
+  `EditReportConfigSection`-Write-Back; Trip-Detail: `VersandTab`-Write-Back → bestehender
+  Speicherpfad, unverändert). `GET /api/auth/profile` liefert zusätzlich
+  `premium_sms_reply_to`/`_at` (roh, `omitempty`), `premium_sms_reply_state`
+  (`"none"|"stale"|"fresh"`, immer vorhanden) und `premium_sms_allowed` (bool, immer vorhanden).
+- **Side effects:** keine. Kein neuer Schreibpfad für die gelernte Rückadresse, kein neuer
+  Cron-Job, keine neue Persistenzdatei. `/compare/*` bleibt unverändert (weiterhin fester
+  Platzhalter).
+
+## Acceptance Criteria
+
+- **AC-1:** Given derselbe geteilte Kanal-Baustein wird sowohl im Trip-Briefing (`/trips/[id]`,
+  `/trips/new`) als auch im Orts-Vergleich (`/compare/[id]`, `/compare/new`) gerendert / When ein
+  Nutzer mit vollständig gültigem Premium-Profil (Premium-Tier, frische Rückadresse) eine dieser
+  Seiten öffnet / Then erscheint eine schaltbare Premium-SMS-Checkbox **ausschließlich** im
+  Trip-Briefing — im Orts-Vergleich bleibt der Kanal weiterhin fest deaktiviert mit dem
+  unveränderten „bald verfügbar"-Hinweis.
+  - Prüfort: **ZWEI Nähte, nicht eine** (korrigiert in der RED-Phase, s.u.). (a) SSR von
+    `VTBriefingChannels` mit identischem Profil in beiden Kontexten — nur `route` zeigt ein
+    editierbares `<input>` für `channel-premium-sms`. (b) SSR von `VersandTab` in beiden Zweigen —
+    dort unterscheidet ohne Profil nicht `disabled`, sondern **ob der schaltbare Block überhaupt
+    entsteht** (`channel-status-premium-sms` vorhanden vs. „bald verfügbar").
+  - 🔴 **Korrektur meines eigenen Prüforts:** Die erste Fassung nannte nur Naht (a). Da die
+    Komponente über **Prop-Anwesenheit** gated und nicht über den `context`-String, wäre die von
+    dieser Spec selbst vorgeschriebene Mutation („`VersandTab` übergibt `onPremiumSmsChange` auch
+    im `vergleich`-Zweig") an Naht (a) **unsichtbar** geblieben — Prüfort ≠ Wirkort, genau der
+    Fehler, den die Leitfrage abfangen soll. Naht (b) ist die wirksame.
+  - Test: `shared/versand-tab/__tests__/premium_sms_context_gating_render.test.ts::premium_sms_switchable_only_in_route_context`
+    und `::vergleich_behaelt_den_unveraenderten_platzhalter_hinweis`
+
+- **AC-2:** Given ein und dasselbe Nutzerprofil / When sowohl die Trip-Anlage
+  (`EditReportConfigSection`) als auch die Trip-Detail-Seite (`VTBriefingChannels`) den
+  Kanalblock rendern / Then zeigen beide Komponenten für die Premium-SMS-Zeile identischen
+  Beschriftungstext, identischen Verbindungsstatus (Dot + Label) und identischen
+  Deaktiviert-Zustand — keine der beiden Komponenten weicht ab.
+  - Prüfort: `channel_checkbox_dedupe_render.test.ts`, erweitert um Premium-SMS-Fälle nach dem
+    bestehenden AC-3-Muster (Zeilen 158-183: Text-Vergleich zwischen beiden Renderings für
+    identisches Profil).
+  - Test: `channel_checkbox_dedupe_render.test.ts::beide_komponenten_zeigen_fuer_identisches_profil_denselben_premium_sms_zustand`
+
+- **AC-3:** Given drei Profile — keine gelernte Rückadresse, eine laut Server veraltete
+  Rückadresse, eine frische Rückadresse / When der Kanalblock die Premium-SMS-Zeile für jedes der
+  drei Profile rendert / Then zeigt jeder der drei Fälle einen paarweise unterschiedlichen
+  Hinweistext — kein Nutzer kann „keine Adresse" mit „veraltete Adresse" verwechseln, weil beide
+  denselben Text zeigen.
+  - Prüfort: SSR-Rendering aller drei Profile, Text-Extraktion des `channel-premium-sms-hint`-Blocks,
+    paarweiser Ungleichheits-Vergleich.
+  - Test: `premium_sms_channel_state.test.ts::state_labels_are_pairwise_distinct`,
+    `channel_checkbox_dedupe_render.test.ts::premium_sms_drei_zustaende_zeigen_unterschiedlichen_hinweistext`
+
+- **AC-4:** Given eine gelernte Rückadresse ist laut Server frisch (`premium_sms_reply_state ==
+  "fresh"`) / When die Premium-SMS-Zeile gerendert wird / Then sind **sowohl** die Zielnummer
+  (`premium_sms_reply_to`) **als auch** das Meldedatum (aus `premium_sms_reply_at`) im
+  sichtbaren Text enthalten — nicht nur eines von beiden.
+  - Prüfort: SSR-Text der Premium-SMS-Zeile enthält sowohl die Roh-Nummer aus dem Fixture-Profil
+    als auch eine aus dem Fixture-Zeitstempel abgeleitete Datumsdarstellung.
+  - Test: `channel_checkbox_dedupe_render.test.ts::premium_sms_fresh_zeigt_zielnummer_und_meldedatum`
+
+- **AC-5:** Given der Server liefert `premium_sms_reply_state` als fertig abgeleiteten Wert, der
+  einem rohen `premium_sms_reply_at` bewusst widerspricht (z. B. `reply_at` von vor einer Stunde,
+  aber `state: "stale"`) / When die Oberfläche das Profil rendert / Then folgt die Anzeige
+  ausnahmslos dem gelieferten `state`-Feld, nicht einer im Frontend nachgerechneten Frist — das
+  belegt, dass im Frontend-Code keine 30-Tage-Konstante existiert.
+  - Prüfort: Unit-Test des `premiumSmsChannelState`-Helfers mit einem absichtlich
+    widersprüchlichen Fixture-Profil; zusätzlich zwei „stale"-Fixtures mit stark
+    unterschiedlichem Alter (31 Tage vs. 400 Tage) müssen einen Hinweistext liefern, der sich nur
+    im Meldedatum, nicht in einer Tage-Zahl unterscheidet.
+  - Test: `premium_sms_channel_state.test.ts::state_feld_gewinnt_gegen_lokal_berechnetes_alter`,
+    `premium_sms_channel_state.test.ts::hinweistext_nennt_keine_tage_zahl`
+  - Mutation: im Helfer wird `Date.now() - replyAt > THIRTY_DAYS_MS` statt
+    `profile.premium_sms_reply_state !== 'fresh'` geprüft.
+
+- **AC-6:** Given ein Nutzer hat Tier `standard` (nicht `premium`) UND eine frische gelernte
+  Rückadresse / When der Kanalblock gerendert wird / Then bleibt die Premium-SMS-Checkbox
+  deaktiviert, obwohl derselbe Nutzer für den normalen SMS-Kanal (`sms_allowed`) als berechtigt
+  gilt — das Tarif-Gate ist eigenständig, nicht von `sms_allowed` abgeleitet.
+  - Prüfort: (a) Go-Funktionstest `model.PremiumSmsAllowed("standard") == false`, (b)
+    SSR-Test mit Profil `{sms_allowed: true, premium_sms_allowed: false, premium_sms_reply_state:
+    "fresh"}` — Checkbox bleibt `disabled`.
+  - Test: `internal/model/premium_sms_test.go::TestPremiumSmsAllowedExcludesStandardTier`,
+    `premium_sms_channel_state.test.ts::disabled_bei_tarif_sperre_trotz_frischer_adresse`
+
+- **AC-7:** Given ein Nutzer sendet `PUT /api/auth/profile` mit `premium_sms_reply_to` und
+  `premium_sms_reply_at` im Body (Versuch, die gelernte Rückadresse selbst zu setzen) / When der
+  Request verarbeitet wird / Then bleiben die zuvor über den internen Lernpfad (S1) gespeicherten
+  Werte in `user.json` unverändert — der Endpoint nimmt die Felder gar nicht erst entgegen.
+  - Prüfort: Go-Handler-Test — `user.json` vor dem PUT mit einer bekannten S1-Rückadresse
+    vorbelegen, PUT mit abweichenden Werten senden, anschließendes `GET` muss den
+    Ursprungswert zeigen.
+  - Test: `internal/handler/profile_test.go::TestUpdateProfileHandlerIgnoresPremiumSmsReplyFields`
+  - Mutation: `PremiumSmsReplyTo`/`PremiumSmsReplyAt` werden zur Decode-Struct in
+    `UpdateProfileHandler` hinzugefügt.
+
+- **AC-8:** Given ein Trip hat `report_config.send_premium_sms = true` gespeichert, danach wird
+  `report_config` komplett entfernt (z. B. Trip ohne Report-Konfiguration) / When der Trip erneut
+  geladen wird / Then ist `Trip.SendPremiumSms` zuerst `true`, nach dem Entfernen der Quelle
+  `nil` — kein stehen gebliebener Altwert.
+  - Prüfort: Roundtrip-Test analog dem bestehenden Muster für `SendSms`
+    (`trip_flat_fields_test.go:20`, `:101`).
+  - Test: `internal/store/trip_flat_fields_test.go::TestLoadTrip_DerivesSendPremiumSmsFromReportConfig`,
+    `::TestLoadTrip_SendPremiumSmsResetToNilWhenReportConfigMissing`
+  - Mutation: der Reset auf `nil` (`store/trip.go:63-70`-Block) wird für `SendPremiumSms`
+    weggelassen.
+
+- **AC-9:** Given eine gelernte Rückadresse ist frisch oder veraltet und das Meldedatum wird
+  angezeigt / When die Premium-SMS-Zeile gerendert wird / Then verwendet das Meldedatum-Label
+  nicht die blasseste Textfarbe (`--g-ink-4`), sondern mindestens `--g-ink-3` — dieselbe Farbe,
+  die der bestehende Verbindungsstatus-Text bereits aus Kontrastgründen verwendet.
+  - Prüfort: die am gerenderten Element **wirkende** Farbe wird aufgelöst — Inline-`style` gewinnt,
+    sonst die eigenen Klassen des Elements gegen das kompilierte Scoped-CSS. Verlangt wird eine
+    **eigene explizite** Farbe am Label; Vererbung reicht nicht.
+  - 🔴 **Korrektur meines eigenen Prüforts:** Die erste Fassung verlangte, den HTML-Ausschnitt auf
+    die Zeichenkette `--g-ink-4`/`--g-ink-3` zu prüfen. Das hätte einen **Inline-Style erzwungen**
+    und gerade die von dieser Spec empfohlene Lösung (dieselbe Klasse wie
+    `.vt-channel-status-label`) rot gemacht, weil Komponenten-CSS im SSR-Body nicht auftaucht. Ein
+    AC, das die eigene Empfehlung verbietet, ist ein Spec-Fehler, kein Testproblem.
+  - Test: `channel_checkbox_dedupe_render.test.ts::meldedatum_label_nutzt_nicht_die_platzhalter_kontrastfarbe`
+
+- **AC-10:** Given ein Trip hat `report_config.send_premium_sms = true` gespeichert und eine
+  frische Rückadresse ist hinterlegt / When die Trip-Anlage ODER die Trip-Detail-Seite den
+  Versand-Bereich rendert / Then ist die Premium-SMS-Checkbox als angehakt dargestellt — der
+  gespeicherte Zustand wird korrekt aus `report_config` geladen, nicht nur aus dem Profil
+  abgeleitet.
+  - Prüfort: SSR-Test mit `reportConfig={send_premium_sms: true}` und frischem Profil, für beide
+    Komponenten — `checked`-Attribut muss gesetzt sein.
+  - Test: `channel_checkbox_dedupe_render.test.ts::premium_sms_checked_spiegelt_report_config_in_beiden_komponenten`
+
+- **AC-11:** Given die Verfallsfrist der gelernten Rückadresse existiert zwangsläufig zweimal — im Python-Sendepfad und in der neuen Go-Ableitung / When jemand künftig nur eine der beiden Zahlen ändert / Then schlägt ein Wächter fehl und benennt beide Fundstellen — die Oberfläche kann nicht „frisch" anzeigen, während der Sendepfad denselben Wert bereits blockt.
+  - Prüfort: die **beiden Quellen selbst**, gegeneinander gelesen — nicht die Oberfläche. Muster und Werkzeug-Klasse liegen vor: `tests/test_egress_inventory_drift.py` liest die Go-Quelle als **Daten** und die Python-Seite über den echten Import (`# doc-compliance-test`-Ausnahme, sonst wäre eine Dateiinhalt-Prüfung als Verhaltensnachweis verboten). Zweites Vorbild: `tests/test_adr_index_drift.py`.
+  - Warum das ein AC ist und keine Fußnote: der Drift-Fall **ist** der Fehler, den diese Scheibe verhindern soll. Eine Anzeige, die der Wirklichkeit widerspricht, ist schlechter als keine — besonders dort, wo es keine zweite Quelle gibt.
+  - Test: `tests/test_premium_sms_ttl_drift.py::go_und_python_frist_sind_deckungsgleich`
+
+- **AC-12:** Given ein Trip hat **ausschließlich** Premium-SMS aktiviert, alle anderen Kanäle aus / When der Versand-Bereich gerendert wird / Then erscheint **kein** Leerzustand „Kein Kanal aktiv" — die Oberfläche behauptet nicht, es sei kein Kanal eingeschaltet, während das Briefing tatsächlich hinausgeht.
+  - Prüfort: **beide** Wirkorte, und der Zähler sitzt nicht dort, wo die Checkbox sitzt — auf `/trips/[id]` hält ihn die Ebene darüber (`VersandTab`), auf `/trips/new` die Komponente selbst (`EditReportConfigSection`). Jeder Fall trägt seine Gegenprobe: alle vier Kanäle aus ⇒ der Leerzustand **muss** erscheinen. Ohne sie wäre der Test auch grün, wenn das geprüfte Element im gewählten Aufbau nie entsteht.
+  - **Herkunft (Tech-Lead-Entscheid 2026-08-11, nach der PO-Freigabe):** Der Befund kam aus dem GREEN-Lauf, nicht aus der Analyse. Aufgenommen, weil er genau der Fehler dieser Scheibe an einer anderen Stelle ist — eine Oberfläche, die einen Zustand falsch darstellt. Nutzersichtbar und mit Gating-Wirkung, deshalb kein Sammel-Eintrag.
+  - **Nebenwirkung, die dabei einen Bestandsfehler behoben hat:** Der Leerzustand war im serverseitigen Rendern **überhaupt nicht erreichbar**, weil `onMount` dort nie läuft und `send_email` beim Rendern immer `true` war. Die drei bestehenden Kanal-Flags werden jetzt wie `send_premium_sms` beim Erzeugen aus `report_config` gelesen. Folge über die Messbarkeit hinaus: ein Trip ohne E-Mail zeigt im ersten Rahmen nicht mehr fälschlich „E-Mail angehakt".
+  - Test: `channel_checkbox_dedupe_render.test.ts`, Abschnitt „#1717 Kanalzaehler"
+
+## Nachweisgrenzen — was diese Scheibe NICHT beweist
+
+- **Keine Geräte-Zustellung.** Wie in S2a: dass eine über die neue Checkbox aktivierte
+  Premium-SMS tatsächlich am Garmin-Gerät ankommt, ist mit den Mitteln dieser Scheibe nicht
+  beweisbar — bleibt #1533.
+- **Kein neuer Beweis für den Speicherpfad selbst.** Dass ein Klick auf die Checkbox letztlich zu
+  einem `PUT`/`POST` führt, der `report_config` persistiert, ist Bestandsmechanik (identisch zu
+  `send_sms`/`send_telegram`) und wird von dieser Scheibe nicht neu bewiesen — nur die
+  **zusätzliche** Zeile `send_premium_sms` im selben, bereits bewiesenen Mechanismus.
+  Playwright-Bestandssuiten (`versand-tab.spec.ts`, `issue-609-sms-profil.spec.ts`) müssen grün
+  bleiben; keine dieser Suiten hängt heute an `channel-premium-sms` (gemessen: kein Treffer in
+  `frontend/e2e/`), also kein Konflikt zu erwarten, aber auch kein neuer E2E-Nachweis für den
+  Klick-Pfad in dieser Spec.
+- **Kein Beweis, dass die Go-TTL-Konstante mit der Python-TTL-Konstante übereinstimmt.** Beide
+  Werte sind zum Zeitpunkt dieser Spec identisch (30 Tage), aber es existiert kein automatischer
+  Abgleich zwischen den beiden Prozessen. Siehe Known Limitations.
+- **Fresh-Eyes + Browser-Gate sind Prozess, kein AC.** Frontend-Scope löst
+  `staging_gate.py --write-verdict` aus (sechs Kernseiten in echtem Chromium,
+  `console(type=error)`/`pageerror`-Sammlung); ohne bestandenen Lauf entsteht keine Attestation,
+  kein Prod-Deploy. Zusätzlich ein `fresh-eyes-inspector`-Lauf auf Screenshots **ohne**
+  Bug-Kontext (Confirmation-Bias-Schutz) — insbesondere für die drei Zustände der Premium-SMS-Zeile
+  und die Kontrast-Zusage aus AC-9. Beides ist Verifikations-Ablauf, kein eigenes AC.
+
+## Mutations-Gegenprobe
+
+Pflicht laut Projektregel — je AC eine gezielte Verfälschung, die mindestens einen Test rot
+machen MUSS:
+
+| AC | Gezielte Verfälschung | Test, der dadurch rot werden MUSS |
+|---|---|---|
+| AC-1 | Gating-Prop-Prüfung entfernt / `VersandTab` übergibt `onPremiumSmsChange` auch im `vergleich`-Zweig | `premium_sms_switchable_only_in_route_context` |
+| AC-2 | `EditReportConfigSection` bekommt eine eigene, leicht abweichende Kopie der Zustandslogik statt `premiumSmsChannelState()` zu importieren | `beide_komponenten_zeigen_fuer_identisches_profil_denselben_premium_sms_zustand` |
+| AC-3 | Hinweistext für „stale" und „none" werden auf denselben generischen String vereinheitlicht | `premium_sms_drei_zustaende_zeigen_unterschiedlichen_hinweistext` |
+| AC-4 | Meldedatum wird aus dem angezeigten Text entfernt (nur Zielnummer bleibt) | `premium_sms_fresh_zeigt_zielnummer_und_meldedatum` |
+| AC-5 | Helfer berechnet `disabled` zusätzlich über `Date.now() - replyAt` statt ausschließlich über `premium_sms_reply_state` | `state_feld_gewinnt_gegen_lokal_berechnetes_alter` |
+| AC-6 | `PremiumSmsAllowed(tier)` delegiert an `SmsAllowed(tier)` statt eigener Prüfung | `TestPremiumSmsAllowedExcludesStandardTier` |
+| AC-7 | Die Felder werden zur Decode-Struct hinzugefügt **UND zugewiesen** (`user.PremiumSmsReplyTo = …`) | `TestUpdateProfileHandlerIgnoresPremiumSmsReplyFields` |
+| | 🔴 **Korrektur (Adversary F001):** Die erste Fassung verlangte nur „zur Decode-Struct hinzufügen". Das ist in Go ein **No-Op** — ein dekodiertes Feld ohne Zuweisung ändert nichts, die Mutation blieb grün und bewies dadurch nichts. Gefährlich ist erst die **Zuweisung**, und die wird gefangen. Eine Mutation, die den Zustand nicht verändert, ist keine Gegenprobe. | |
+| AC-8 | Reset-Zeile `trip.SendPremiumSms = nil` in `deriveFlatFields` weggelassen | `TestLoadTrip_SendPremiumSmsResetToNilWhenReportConfigMissing` |
+| AC-9 | Meldedatum-Label bekommt versehentlich `--g-ink-4` statt `--g-ink-3` (Copy-Paste aus einem Platzhalter-Hinweis) | `meldedatum_label_nutzt_nicht_die_platzhalter_kontrastfarbe` |
+| AC-10 | Initialisierung von `send_premium_sms` aus der `reportConfig`-Prop weggelassen (Feld bleibt beim Laden immer `false`) | `premium_sms_checked_spiegelt_report_config_in_beiden_komponenten` |
+| AC-11 | Go-Frist auf 7 Tage geändert, Python-Frist bleibt bei 30 (die realistische Drift: eine Session ändert einen Wert und kennt den anderen nicht) | `go_und_python_frist_sind_deckungsgleich` |
+| AC-12 | Kanalzähler wieder auf drei Kanäle zurückgedreht — **je Wirkort einzeln** (`VersandTab` und `EditReportConfigSection`), weil eine gemeinsame Quelle nicht existiert | Abschnitt „#1717 Kanalzaehler"; beide Mutationen wurden gefangen, jede mit der Meldung des betroffenen Wirkorts |
+
+## Known Limitations
+
+- **Cross-Language-TTL-Duplikation — bewacht, nicht hingenommen (AC-11).** Die Frist muss in Go
+  ein zweites Mal als Konstante existieren, weil Go und Python getrennte Prozesse sind. Der
+  Entwurf dieser Spec hat das als hingenommenes Risiko eingetragen („ein automatischer Abgleich
+  wäre eigene Arbeit"). **Das ist zurückgewiesen:** genau dieser Drift-Fall ist der Fehler, den
+  diese Scheibe verhindern soll — eine Oberfläche, die „frisch" zeigt, während der Sendepfad
+  blockt. Ihn als Fußnote zu führen, hebt den Zweck der Scheibe auf.
+
+  Das Projekt hat das Muster bereits: `tests/test_egress_inventory_drift.py` gleicht eine
+  Python-Liste mit `internal/egress/inventory.go` ab (Go-Quelle als **Daten** gelesen,
+  Python-Seite über den echten Import, `# doc-compliance-test`-Ausnahme). Begründung dort
+  wörtlich: „zwei Listen driften auseinander … wer 14 Türen einzeln bewacht, vergisst irgendwann
+  eine." Zweites Vorbild: `tests/test_adr_index_drift.py`. Der Abgleich ist damit kein Neubau,
+  sondern eine vorhandene Werkzeug-Klasse — Aufwand: ein Test.
+
+  Verbleibende Grenze: der Wächter erzwingt Gleichheit der **Zahl**, nicht der Semantik. Wer in
+  einem der beiden Prozesse die Bedeutung der Frist ändert (z.B. Vergleich `>=` statt `>`), fällt
+  ihm nicht auf.
+- **Eine anfängliche, wortgleiche Kopie der Zustandslogik wird von keinem Test hier erkannt.**
+  Der Dedupe-Test (AC-2) beweist Verhaltensgleichheit zum Zeitpunkt der Prüfung, keine
+  Quelltext-Identität — käme in `EditReportConfigSection` eine zunächst identische, aber separat
+  gepflegte Kopie statt eines Imports zustande, wäre das erst bei der nächsten Änderung sichtbar,
+  die dann divergiert (wie es `channelContactLabel.ts` vor seiner Extraktion vorgemacht hat,
+  Issue #1510).
+- **Kein Playwright-Klickpfad-Test für Premium-SMS neu.** Die Bestandssuiten decken die
+  bestehenden drei Kanäle ab; ein neuer End-to-End-Klicktest für Premium-SMS ist nicht Teil
+  dieser Scheibe (s. Nachweisgrenzen).
+- **`/trips/new` bleibt strukturell auf `EditReportConfigSection` statt `VersandTab`.**
+  Vorbestehender, bewusst nicht behobener Bruch der Trip/Compare-Teilungsregel (#1199).
+- **Kein Beweis für Geräte-Zustellung** — bleibt #1533.
+
+## Test Coverage
+
+- `shared/versand-tab/__tests__/channel_checkbox_dedupe_render.test.ts` (MODIFY) — AC-2, AC-3,
+  AC-4, AC-9, AC-10 (SSR beider Komponenten, kein Mock).
+- `shared/versand-tab/__tests__/premium_sms_channel_state.test.ts` (NEU) — AC-3, AC-5, AC-6
+  (reine Funktionsprüfung, node:testbar).
+- `shared/versand-tab/__tests__/premium_sms_context_gating_render.test.ts` (NEU) — AC-1.
+- `internal/model/premium_sms_test.go` (NEU) — AC-6 (Funktionsteil), TTL-Grenzwert analog S2a
+  AC-4/AC-5.
+- `internal/handler/profile_test.go` (MODIFY) — AC-7, Feldmenge der vier neuen Profil-Felder.
+- `internal/store/trip_flat_fields_test.go` (MODIFY) — AC-8.
+
+Testdateien liegen unter `frontend/src/lib/components/shared/versand-tab/__tests__/` bzw.
+`internal/model/`, `internal/handler/`, `internal/store/` — Namen nach Verhalten, nicht nach
+Issue-Nummer.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue. Diese Scheibe exponiert ausschließlich die in ADR-0049 bereits
+  getroffenen Entscheidungen (Kanalname, „nur Trip-Briefing", eigenes Tarif-Gate) in der
+  Oberfläche — sie trifft keine neue Architekturentscheidung und weicht von keiner bestehenden
+  ab.
+
+## Changelog
+
+- 2026-08-11: Initial spec erstellt — Issue #1717, Scheibe S3 (Premium-SMS in der Oberfläche)

--- a/frontend/src/lib/components/edit/EditReportConfigSection.svelte
+++ b/frontend/src/lib/components/edit/EditReportConfigSection.svelte
@@ -5,8 +5,12 @@
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import VTSchedulePlan from '../shared/versand-tab/VTSchedulePlan.svelte';
-	import { channelConnectionStatus } from '../shared/versand-tab/channelConnectionStatus';
+	import {
+		channelConnectionStatus,
+		type ConnectionProfile
+	} from '../shared/versand-tab/channelConnectionStatus';
 	import { channelContactLabel } from '../shared/versand-tab/channelContactLabel';
+	import { premiumSmsChannelState } from '../shared/versand-tab/premiumSmsChannelState';
 	import { Dot } from '$lib/components/atoms';
 	import {
 		DEFAULT_DAILY_SUMMARY_METRICS,
@@ -60,10 +64,19 @@
 	let multi_day_trend_morning = $state(false);
 	let multi_day_trend_evening = $state(true);
 
-	// Channels
-	let send_email = $state(true);
-	let send_telegram = $state(false);
-	let send_sms = $state(false);
+	// Channels — Issue #1717 S3: alle vier BEIM ERZEUGEN aus der Prop
+	// initialisiert (untrack, wie `profile` unten) und nicht erst in onMount.
+	// onMount laeuft serverseitig nie, und ein Wert, der erst nach der ersten
+	// Ausgabe erscheint, ist einen Wimpernschlag falsch; ausserdem waere der
+	// Zeitplan-Leerzustand (hasActiveChannel unten) beim Rendern sonst nicht
+	// erreichbar und damit nicht pruefbar. Semantik wie in onMount: E-Mail
+	// Default an, alles andere Default aus.
+	let send_email = $state(untrack(() => reportConfig?.send_email !== false));
+	let send_telegram = $state(untrack(() => reportConfig?.send_telegram === true));
+	let send_sms = $state(untrack(() => reportConfig?.send_sms === true));
+	// Der gespeicherte Anhak-Zustand von Premium-SMS muss schon beim Rendern
+	// stehen (AC-10).
+	let send_premium_sms = $state(untrack(() => reportConfig?.send_premium_sms === true));
 
 	// Bestandsdaten-Erhalt: diese States werden nicht mehr im UI gezeigt,
 	// aber weiterhin für den Read-Modify-Write im merged-Objekt benötigt.
@@ -88,13 +101,10 @@
 	let show_yesterday_comparison = $state(true);
 
 	// --- Profile (Channel-Verfuegbarkeit) --------------------------------------
-	interface Profile {
-		mail_to?: string;
-		email_verified?: boolean;
-		telegram_chat_id?: string;
-		sms_to?: string;
-		sms_allowed?: boolean;
-	}
+	/** Issue #1717 S3: EINE kanonische Profilform (channelConnectionStatus.ts)
+	 * statt einer lokalen Kopie je Komponente — sonst muesste jedes neue
+	 * Profilfeld an drei Stellen nachgezogen werden. */
+	type Profile = ConnectionProfile;
 	let profile = $state<Profile | null>(
 		untrack(() => (profileOverride !== undefined ? profileOverride : null))
 	);
@@ -109,6 +119,9 @@
 	// (analog VTBriefingChannels.svelte).
 	let connectionStatus = $derived(channelConnectionStatus(profile));
 	let contactLabel = $derived(channelContactLabel(profile));
+	// Issue #1717 S3: derselbe geteilte Zustands-Helfer wie in
+	// VTBriefingChannels.svelte — keine zweite Kopie der Logik (AC-2).
+	let premiumSms = $derived(premiumSmsChannelState(profile));
 
 	// Issue #617: Wetter-Kanal-Gating (nur wenn weatherChannels gesetzt)
 	let weatherVisible = $derived(visibleChannels(weatherChannels));
@@ -124,7 +137,13 @@
 	// gar nicht erst gerendert, solange der Kanal-Gating-Leerzustand aktiv ist
 	// — die beiden Leerzustände schließen sich dadurch gegenseitig aus (AC-9).
 	let scheduleGatingEmpty = $derived(weatherChannels !== undefined && weatherEmpty);
-	let hasActiveChannel = $derived(send_email || send_telegram || send_sms);
+	// Issue #1717 S3: Premium-SMS zaehlt mit — wer nur diesen Kanal einschaltet,
+	// bekommt ein echtes Briefing, und ein Leerzustand "Kein Kanal aktiv" waere
+	// eine Anzeige, die der Wirklichkeit widerspricht. Zweite Fassung derselben
+	// Zaehlung: VersandTab.svelte (activeChannelCount, /trips/[id]) — beide
+	// werden im selben Testfall gegeneinander gemessen
+	// (shared/versand-tab/__tests__/channel_checkbox_dedupe_render.test.ts).
+	let hasActiveChannel = $derived(send_email || send_telegram || send_sms || send_premium_sms);
 
 	// --- Initial-Load ----------------------------------------------------------
 	onMount(() => {
@@ -152,6 +171,10 @@
 			if (typeof c.send_email === 'boolean') send_email = c.send_email;
 			if (typeof c.send_telegram === 'boolean') send_telegram = c.send_telegram;
 			if (typeof c.send_sms === 'boolean') send_sms = c.send_sms;
+			// Issue #1717 S3: zusaetzlich zur Initialisierung beim Erzeugen (oben) —
+			// deckt den Fall ab, dass reportConfig erst nach dem Erzeugen der
+			// Komponente eintrifft.
+			if (typeof c.send_premium_sms === 'boolean') send_premium_sms = c.send_premium_sms;
 
 			if (typeof c.show_compact_summary === 'boolean') show_compact_summary = c.show_compact_summary;
 			wind_exposition_min_elevation_m = typeof c.wind_exposition_min_elevation_m === 'number'
@@ -215,6 +238,8 @@
 			send_email,
 			send_telegram,
 			send_sms,
+			// Issue #1717 S3 — vierter Briefing-Kanal, gleicher Write-Back-Pfad.
+			send_premium_sms,
 			multi_day_trend_morning,
 			multi_day_trend_evening,
 			multi_day_trend_reports,
@@ -373,13 +398,32 @@
 					</div>
 				{/if}
 
-				<!-- Premium-SMS (Garmin inReach) — informativer, dauerhaft deaktivierter Slot (Issue #1069) -->
+				<!-- Premium-SMS (Garmin inReach) — Issue #1717 S3: aus dem dauerhaft
+				     deaktivierten Slot (#1069) wird ein echter, schaltbarer Kanal.
+				     Zustand/Texte kommen aus demselben geteilten Helfer wie in
+				     VTBriefingChannels.svelte (Trip-Detail) — dieselben Worte fuer
+				     dieselbe Lage, egal auf welcher Seite (AC-2). -->
 				<div class="text-sm">
 					<span data-testid="channel-premium-sms" class="inline-flex items-center gap-2">
-						<Checkbox checked={false} disabled={true}>Premium-SMS (Garmin inReach)</Checkbox>
+						<Checkbox
+							checked={send_premium_sms}
+							disabled={premiumSms.disabled}
+							onchange={(e) => { send_premium_sms = (e.target as HTMLInputElement).checked; }}
+						>Premium-SMS (Garmin inReach){premiumSms.contactLabel}</Checkbox>
+					</span>
+					<span data-testid="channel-status-premium-sms" class="rc-channel-status">
+						<Dot tone={premiumSms.tone} size={7} />
+						<span class="rc-channel-status-label">{premiumSms.statusLabel}</span>
 					</span>
 				</div>
-				<div class="pl-6 text-xs text-muted-foreground">bald verfügbar</div>
+				<p data-testid="channel-premium-sms-hint" class="pl-6 text-xs rc-channel-hint">
+					{premiumSms.hint}
+				</p>
+				{#if premiumSms.reportedAtLabel}
+					<p data-testid="channel-premium-sms-reported-at" class="rc-premium-reported-at pl-6">
+						{premiumSms.reportedAtLabel}
+					</p>
+				{/if}
 			{/if}
 		{/if}
 	</Card.Root>
@@ -485,6 +529,23 @@
 		font-size: 11px;
 		letter-spacing: 0.04em;
 		color: var(--g-ink-3);
+	}
+	/* Issue #1717 S3 (AC-9): Meldedatum der gelernten Rueckadresse ist ein
+	   DATEN-Label, keine Fussnote — --g-ink-3 wie der Verbindungsstatus, nie
+	   --g-ink-4 (2,85:1 auf Weiss, strikt Platzhalter/Disabled vorbehalten).
+	   1:1 zu .vt-premium-reported-at in VTBriefingChannels.svelte. */
+	.rc-premium-reported-at {
+		font-family: var(--g-font-mono);
+		font-size: 11px;
+		color: var(--g-ink-3);
+		margin: 2px 0 0;
+	}
+	/* Hinweistext des Premium-SMS-Blocks: eigene Klasse statt
+	   text-muted-foreground, damit die Farbe nicht in der Utility-Kette
+	   verschwindet — derselbe Kontrast-Grund wie oben. */
+	.rc-channel-hint {
+		color: var(--g-ink-3);
+		margin: 2px 0 0;
 	}
 </style>
 

--- a/frontend/src/lib/components/shared/VersandTab.svelte
+++ b/frontend/src/lib/components/shared/VersandTab.svelte
@@ -10,7 +10,7 @@
 	// Design-Quelle (1:1): claude-code-handoff/current/jsx/versand-tab.jsx
 	// Spec: docs/specs/modules/versand_tab_route.md
 
-	import { onMount, type Snippet } from 'svelte';
+	import { onMount, untrack, type Snippet } from 'svelte';
 	import { api } from '$lib/api.js';
 	import { toHHMMSS } from '$lib/utils/time';
 	import type { Trip, ReportConfig } from '$lib/types';
@@ -65,9 +65,24 @@
 	let evening_time = $state('18:00');
 	let multi_day_trend_morning = $state(false);
 	let multi_day_trend_evening = $state(false);
-	let send_email = $state(true);
-	let send_telegram = $state(false);
-	let send_sms = $state(false);
+	// Issue #1717 S3: die vier Briefing-Kanal-Flags stehen schon BEIM ERZEUGEN
+	// aus report_config (untrack, Muster EditReportConfigSection.svelte:76) und
+	// nicht erst in onMount. Zwei Gruende: der erste Rahmen zeigte sonst
+	// "E-Mail an" auch fuer einen Trip, der gar keine E-Mail schickt — und der
+	// Zeitplan-Leerzustand unten (activeChannelCount) waere ohne diese
+	// Initialisierung beim Rendern gar nicht erreichbar, also auch nicht
+	// pruefbar. Die Zuweisungen in onMount bleiben (Nachladen), Semantik
+	// identisch: E-Mail Default an, alles andere Default aus.
+	let send_email = $state(untrack(() => reportConfig?.send_email !== false));
+	let send_telegram = $state(untrack(() => reportConfig?.send_telegram === true));
+	let send_sms = $state(untrack(() => reportConfig?.send_sms === true));
+	// Issue #1717 S3: vierter Briefing-Kanal (Premium-SMS, Garmin inReach).
+	// Ohne State/Hydration/Write-Back hier bliebe ein Klick in
+	// VTBriefingChannels auf /trips/[id] folgenlos — dies ist die
+	// Persistenz-Schicht dieser Seite (bind:reportConfig aus
+	// BriefingScheduleTab). Nur route: im vergleich-Zweig ist Premium-SMS kein
+	// Kanal (ADR-0049).
+	let send_premium_sms = $state(untrack(() => reportConfig?.send_premium_sms === true));
 	// Issue #1260 S5: Trip-Kurzstil-Schalter (report_config.telegram_style).
 	// EIN Trip-Feld regelt Briefing UND Alarme — der Schalter erscheint einmal
 	// hier im Versand-Tab.
@@ -91,6 +106,7 @@
 			if (typeof c.send_email === 'boolean') send_email = c.send_email;
 			if (typeof c.send_telegram === 'boolean') send_telegram = c.send_telegram;
 			if (typeof c.send_sms === 'boolean') send_sms = c.send_sms;
+			if (typeof c.send_premium_sms === 'boolean') send_premium_sms = c.send_premium_sms;
 			if (c.telegram_style === 'kurzform' || c.telegram_style === 'rich') {
 				telegram_style = c.telegram_style;
 			}
@@ -121,6 +137,8 @@
 			send_email,
 			send_telegram,
 			send_sms,
+			// Issue #1717 S3 — derselbe Write-Back-Pfad wie die drei darueber.
+			send_premium_sms,
 			telegram_style,
 			multi_day_trend_morning,
 			multi_day_trend_evening,
@@ -129,8 +147,15 @@
 		reportConfig = merged as ReportConfig;
 	});
 
+	// Issue #1717 S3: Premium-SMS zaehlt mit. Wer NUR Premium-SMS einschaltet,
+	// bekommt ein echtes Briefing — ein Leerzustand "Kein Kanal aktiv" waere
+	// dann eine Anzeige, die der Wirklichkeit widerspricht (und sie sperrt die
+	// Zeitplan-Optionen weg, VTSchedulePlan.svelte:77). Dieselbe Zaehlung steht
+	// in EditReportConfigSection.svelte (hasActiveChannel, /trips/new); beide
+	// Fassungen werden im selben Testfall gegeneinander gemessen
+	// (versand-tab/__tests__/channel_checkbox_dedupe_render.test.ts).
 	const activeChannelCount = $derived(
-		[send_email, send_telegram, send_sms].filter(Boolean).length
+		[send_email, send_telegram, send_sms, send_premium_sms].filter(Boolean).length
 	);
 
 	// Issue #1232 Scheibe 2b: vergleich-Zweig — Kanal-Zähler direkt aus wiz.*
@@ -147,6 +172,15 @@
 			else if (channel === 'telegram') send_telegram = v;
 			else send_sms = v;
 			onChannelChange?.(channel, v);
+		};
+	}
+	// Issue #1717 S3: eigener Factory-Handler statt Erweiterung von
+	// makeChannelChangeHandler — dessen onChannelChange-Rueckruf synchronisiert
+	// display_config.channels (#736), und das kennt nur die drei Wetter-Kanaele.
+	// Premium-SMS dort mitzumelden waere ein Feld, das der Empfaenger nicht hat.
+	function makePremiumSmsChangeHandler() {
+		return function doChange(e: Event) {
+			send_premium_sms = (e.target as HTMLInputElement).checked;
 		};
 	}
 	// Issue #1232 Scheibe 2b: vergleich-Zweig — schreibt direkt in wiz.* statt
@@ -203,12 +237,18 @@
 	<div class="versand-tab" data-testid="versand-tab">
 		<VTBriefingChannels
 			{context}
-			channels={{ email: send_email, telegram: send_telegram, sms: send_sms }}
+			channels={{
+				email: send_email,
+				telegram: send_telegram,
+				sms: send_sms,
+				premium_sms: send_premium_sms
+			}}
 			onEmailChange={makeChannelChangeHandler('email')}
 			onTelegramChange={makeChannelChangeHandler('telegram')}
 			onSmsChange={makeChannelChangeHandler('sms')}
 			telegramStyle={telegram_style}
 			onTelegramStyleChange={(s) => (telegram_style = s)}
+			onPremiumSmsChange={makePremiumSmsChangeHandler()}
 		/>
 
 		<VTSchedulePlan

--- a/frontend/src/lib/components/shared/versand-tab/VTBriefingChannels.svelte
+++ b/frontend/src/lib/components/shared/versand-tab/VTBriefingChannels.svelte
@@ -14,14 +14,17 @@
 	import { Eyebrow, Card, Dot } from '$lib/components/atoms';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { CHANNEL_COL_BUDGET } from '$lib/components/trip-detail/metricsEditor';
-	import { channelConnectionStatus } from './channelConnectionStatus';
+	import { channelConnectionStatus, type ConnectionProfile } from './channelConnectionStatus';
 	import { channelContactLabel } from './channelContactLabel';
+	import { premiumSmsChannelState } from './premiumSmsChannelState';
 	import TelegramKurzstilToggle from '$lib/components/shared/TelegramKurzstilToggle.svelte';
 
 	interface Channels {
 		email: boolean;
 		telegram: boolean;
 		sms: boolean;
+		/** Issue #1717 S3 — vierter Briefing-Kanal, nur im route-Kontext schaltbar. */
+		premium_sms?: boolean;
 	}
 	interface Props {
 		context?: 'route' | 'vergleich';
@@ -42,6 +45,13 @@
 		 * Kanaelen im Alarme-Tab (dieselbe geteilte Komponente). */
 		telegramStyle?: 'rich' | 'kurzform';
 		onTelegramStyleChange?: (style: 'rich' | 'kurzform') => void;
+		/** Issue #1717 S3: Premium-SMS (Garmin inReach). Die ANWESENHEIT dieser
+		 * Prop schaltet den schaltbaren Premium-SMS-Block frei — exakt das
+		 * Gating-Muster von onTelegramStyleChange oben. VersandTab uebergibt sie
+		 * nur im route-Zweig; im vergleich-Zweig bleibt der feste
+		 * "bald verfuegbar"-Platzhalter stehen, weil Premium-SMS laut ADR-0049
+		 * ausschliesslich ein Trip-Briefing-Kanal ist (AC-1). */
+		onPremiumSmsChange?: (e: Event) => void;
 		/** RED-Infrastruktur (#1510): optionaler SSR-Test-Override fuer `profile`.
 		 * Falls gesetzt (auch explizit `null`) wird `profile` daraus initialisiert
 		 * und der `onMount`-Fetch uebersprungen — `svelte/server`s `render()` fuehrt
@@ -60,16 +70,14 @@
 		smsTestid = 'channel-sms',
 		telegramStyle = 'rich',
 		onTelegramStyleChange,
+		onPremiumSmsChange,
 		profileOverride
 	}: Props = $props();
 
-	interface Profile {
-		mail_to?: string;
-		telegram_chat_id?: string;
-		sms_to?: string;
-		sms_allowed?: boolean;
-		email_verified?: boolean;
-	}
+	/** Issue #1717 S3: EINE kanonische Profilform (channelConnectionStatus.ts)
+	 * statt einer lokalen Kopie je Komponente — sonst muesste jedes neue
+	 * Profilfeld an drei Stellen nachgezogen werden. */
+	type Profile = ConnectionProfile;
 	let profile = $state<Profile | null>(
 		untrack(() => (profileOverride !== undefined ? profileOverride : null))
 	);
@@ -84,6 +92,9 @@
 	// additiv zu den bestehenden Checkboxen.
 	let connectionStatus = $derived(channelConnectionStatus(profile));
 	let contactLabel = $derived(channelContactLabel(profile));
+	// Issue #1717 S3: geteilter Zustands-Helfer — dieselbe Quelle, die
+	// EditReportConfigSection benutzt (keine zweite Kopie der Logik).
+	let premiumSms = $derived(premiumSmsChannelState(profile));
 
 	onMount(() => {
 		if (profileOverride !== undefined) return;
@@ -184,12 +195,41 @@
 						Handynummer fehlt — <a href="/account">im Account einrichten</a>
 					</div>
 				{/if}
-				<div class="text-sm" style="margin-top: 6px;">
-					<span data-testid="channel-premium-sms" class="inline-flex items-center gap-2">
-						<Checkbox checked={false} disabled={true}>Premium-SMS (Garmin inReach)</Checkbox>
-					</span>
-				</div>
-				<div class="pl-6 text-xs text-muted-foreground">bald verfügbar</div>
+				<!-- Premium-SMS (Garmin inReach) — Issue #1717 S3. Schaltbar NUR wenn
+				     onPremiumSmsChange uebergeben wurde (route-Zweig von VersandTab);
+				     im vergleich-Zweig bleibt der Platzhalter aus #1069 unveraendert
+				     stehen, weil Premium-SMS laut ADR-0049 kein Vergleichs-Kanal ist. -->
+				{#if onPremiumSmsChange}
+					<div class="text-sm" style="margin-top: 6px;">
+						<span data-testid="channel-premium-sms" class="inline-flex items-center gap-2">
+							<Checkbox
+								checked={channels.premium_sms ?? false}
+								disabled={premiumSms.disabled}
+								onchange={onPremiumSmsChange}
+								>Premium-SMS (Garmin inReach){premiumSms.contactLabel}</Checkbox
+							>
+						</span>
+						<span data-testid="channel-status-premium-sms" class="vt-channel-status">
+							<Dot tone={premiumSms.tone} size={7} />
+							<span class="vt-channel-status-label">{premiumSms.statusLabel}</span>
+						</span>
+						<p data-testid="channel-premium-sms-hint" class="vt-channel-sub pl-6">
+							{premiumSms.hint}
+						</p>
+						{#if premiumSms.reportedAtLabel}
+							<p data-testid="channel-premium-sms-reported-at" class="vt-premium-reported-at pl-6">
+								{premiumSms.reportedAtLabel}
+							</p>
+						{/if}
+					</div>
+				{:else}
+					<div class="text-sm" style="margin-top: 6px;">
+						<span data-testid="channel-premium-sms" class="inline-flex items-center gap-2">
+							<Checkbox checked={false} disabled={true}>Premium-SMS (Garmin inReach)</Checkbox>
+						</span>
+					</div>
+					<div class="pl-6 text-xs text-muted-foreground">bald verfügbar</div>
+				{/if}
 			</div>
 		</div>
 	</Card>
@@ -231,5 +271,16 @@
 	}
 	.vt-telegram-style {
 		margin-top: 8px;
+	}
+	/* Issue #1717 S3 (AC-9): das Meldedatum der gelernten Rueckadresse ist ein
+	   DATEN-Label, keine Fussnote — deshalb dieselbe Farbe wie
+	   .vt-channel-status-label (--g-ink-3) und ausdruecklich NICHT --g-ink-4
+	   (2,85:1 auf Weiss, strikt Platzhalter/Disabled vorbehalten). Auf einem
+	   Handydisplay entscheidet genau dieser Kontrast, ob man der Anzeige traut. */
+	.vt-premium-reported-at {
+		font-family: var(--g-font-mono);
+		font-size: 11px;
+		color: var(--g-ink-3);
+		margin: 2px 0 0;
 	}
 </style>

--- a/frontend/src/lib/components/shared/versand-tab/__tests__/channel_checkbox_dedupe_render.test.ts
+++ b/frontend/src/lib/components/shared/versand-tab/__tests__/channel_checkbox_dedupe_render.test.ts
@@ -2,6 +2,14 @@
 // Checkboxen bündeln" (#1510).
 // Spec: docs/specs/modules/fix_1510_versand_ziel_dedupe.md — AC-2, AC-3, AC-4, AC-5, AC-6.
 //
+// ERWEITERT 2026-08-11 um Issue #1717 (Scheibe S3, Premium-SMS in der
+// Oberflaeche) — Spec: docs/specs/modules/feat_1717_s3_premium_sms_ui.md,
+// AC-2, AC-3, AC-4, AC-9, AC-10. Diese Datei ist das Regressionsnetz, das die
+// beiden Kanalblock-Kopien (VTBriefingChannels fuer /trips/[id],
+// EditReportConfigSection fuer /trips/new) synchron haelt: jeder neue Fall wird
+// gegen BEIDE Komponenten mit demselben Profil gemessen. Der #1717-Abschnitt
+// steht unten unter "── #1717 ──".
+//
 // Echtes serverseitiges Rendern der echten Svelte-Komponenten
 // (svelte/server `render`, Hooks: frontend/test-svelte-ssr-hooks.mjs).
 // Keine Mocks, keine reine Datei-Inhalt-Prüfung (Ausnahme AC-6: Testid-Existenz
@@ -46,18 +54,16 @@ register(
 	pathToFileURL(FRONTEND + '/').href
 );
 
+const VT_FILE = path.join(
+	FRONTEND,
+	'src/lib/components/shared/versand-tab/VTBriefingChannels.svelte'
+);
+const EDIT_FILE = path.join(FRONTEND, 'src/lib/components/edit/EditReportConfigSection.svelte');
+
 const { render } = await import('svelte/server');
 const { channelContactLabel } = await import('../channelContactLabel.ts');
-const VTBriefingChannels = (
-	await import(
-		pathToFileURL(path.join(FRONTEND, 'src/lib/components/shared/versand-tab/VTBriefingChannels.svelte')).href
-	)
-).default;
-const EditReportConfigSection = (
-	await import(
-		pathToFileURL(path.join(FRONTEND, 'src/lib/components/edit/EditReportConfigSection.svelte')).href
-	)
-).default;
+const VTBriefingChannels = (await import(pathToFileURL(VT_FILE).href)).default;
+const EditReportConfigSection = (await import(pathToFileURL(EDIT_FILE).href)).default;
 
 interface Profile {
 	mail_to?: string;
@@ -266,6 +272,447 @@ describe('AC-6: EditReportConfigSection zeigt Dot+Label-Verbindungsstatus wie VT
 				html.includes(`data-testid="${testid}"`),
 				`AC-6: Testid "${testid}" fehlt in EditReportConfigSection — heute existiert dort kein ` +
 					'Dot+Label-Verbindungsstatus (nur in VTBriefingChannels).'
+			);
+		}
+	});
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// ── #1717 (S3) — Premium-SMS in der Oberflaeche ──────────────────────────────
+// Spec: docs/specs/modules/feat_1717_s3_premium_sms_ui.md — AC-2, AC-3, AC-4,
+// AC-9, AC-10. Gemessen wird IMMER gegen beide Komponenten mit demselben
+// Profil; genau das ist der Zweck dieser Datei.
+//
+// TESTID-VERTRAG, den dieser Abschnitt festnagelt (Implementierung Phase 6,
+// Namensfamilie wie der Bestand `channel-sms` / `channel-status-sms` /
+// `channel-sms-hint`):
+//   channel-premium-sms              (Bestand) Checkbox + Beschriftung
+//   channel-status-premium-sms       Dot + Mono-Status-Label
+//   channel-premium-sms-hint         Prosa-Hinweis (drei Zustaende)
+//   channel-premium-sms-reported-at  Meldedatum-Label ("zuletzt gemeldet am …")
+//
+// PROP-VERTRAG:
+//   VTBriefingChannels: `channels.premium_sms: boolean` + `onPremiumSmsChange`
+//     (Anwesenheit der Prop schaltet den Block frei, AC-1).
+//   EditReportConfigSection: `reportConfig.send_premium_sms` — der
+//     Anhak-Zustand muss BEIM RENDERN stehen. `svelte/server` fuehrt `onMount`
+//     NICHT aus; eine Hydration allein in `onMount` ist deshalb hier nicht
+//     sichtbar. Der State muss (analog `profile`, EditReportConfigSection.svelte:98
+//     mit `untrack`) aus der Prop initialisiert werden.
+// ══════════════════════════════════════════════════════════════════════════════
+
+const { readFileSync } = await import('node:fs');
+const { compile } = await import('svelte/compiler');
+
+interface PremiumProfile extends Profile {
+	premium_sms_allowed?: boolean;
+	premium_sms_reply_to?: string;
+	premium_sms_reply_at?: string;
+	premium_sms_reply_state?: 'none' | 'stale' | 'fresh';
+}
+
+const REPLY_TO = '15551234567';
+/** Fester Meldezeitpunkt — AC-4 prueft eine daraus abgeleitete Datumsdarstellung.
+ * Mittags UTC, damit keine Zeitzonenverschiebung den Kalendertag dreht. */
+const REPLY_AT = '2026-08-05T12:00:00Z';
+
+const P_FRESH: PremiumProfile = {
+	sms_to: SMS,
+	sms_allowed: true,
+	premium_sms_allowed: true,
+	premium_sms_reply_to: REPLY_TO,
+	premium_sms_reply_at: REPLY_AT,
+	premium_sms_reply_state: 'fresh'
+};
+const P_STALE: PremiumProfile = { ...P_FRESH, premium_sms_reply_state: 'stale' };
+const P_NONE: PremiumProfile = {
+	sms_to: SMS,
+	sms_allowed: true,
+	premium_sms_allowed: true,
+	premium_sms_reply_state: 'none'
+};
+
+function renderVTPremium(profile: PremiumProfile | null, premiumChecked = false): string {
+	return render(VTBriefingChannels, {
+		props: {
+			channels: { email: false, telegram: false, sms: false, premium_sms: premiumChecked },
+			onEmailChange: () => {},
+			onTelegramChange: () => {},
+			onSmsChange: () => {},
+			onPremiumSmsChange: () => {},
+			profileOverride: profile
+		}
+	}).body;
+}
+
+function renderEditPremium(profile: PremiumProfile | null, premiumChecked = false): string {
+	return render(EditReportConfigSection, {
+		props: {
+			reportConfig: premiumChecked ? { send_premium_sms: true } : {},
+			mode: 'edit',
+			showMailContent: false,
+			showSchedule: false,
+			showChannels: true,
+			profileOverride: profile
+		}
+	}).body;
+}
+
+/** Die beiden Renderer als Paar — jeder #1717-Fall laeuft gegen BEIDE. */
+const BEIDE: Array<[string, (p: PremiumProfile | null, c?: boolean) => string]> = [
+	['VTBriefingChannels', renderVTPremium],
+	['EditReportConfigSection', renderEditPremium]
+];
+
+/** Aeusseres HTML des Elements, das das gegebene Testid traegt (Tag-Nesting-
+ * zaehlend, damit verschachtelte gleichnamige Tags korrekt geschlossen werden). */
+function outerHtml(html: string, testid: string): string {
+	const marker = `data-testid="${testid}"`;
+	const mi = html.indexOf(marker);
+	assert.notEqual(
+		mi,
+		-1,
+		`Testid "${testid}" fehlt im gerenderten HTML — der schaltbare Premium-SMS-Block ` +
+			'existiert dort noch nicht (heute: fest deaktivierter Platzhalter). Erwartete Testids: ' +
+			'siehe "TESTID-VERTRAG" im #1717-Kopf dieser Datei.'
+	);
+	const start = html.lastIndexOf('<', mi);
+	const tag = /^<([a-zA-Z0-9-]+)/.exec(html.slice(start, start + 40))?.[1];
+	assert.ok(tag, `Kein Tag-Name vor Testid "${testid}" gefunden.`);
+	const re = new RegExp(`<${tag}\\b[^>]*>|</${tag}>`, 'g');
+	re.lastIndex = start;
+	let depth = 0;
+	let m: RegExpExecArray | null;
+	while ((m = re.exec(html))) {
+		if (m[0].startsWith('</')) {
+			depth--;
+			if (depth === 0) return html.slice(start, m.index + m[0].length);
+		} else if (m[0].endsWith('/>')) {
+			if (m.index === start) return m[0];
+		} else {
+			depth++;
+		}
+	}
+	assert.fail(`Element zu Testid "${testid}" nicht geschlossen.`);
+}
+
+function elementText(html: string, testid: string): string {
+	return visibleText(outerHtml(html, testid));
+}
+
+/** Dot-Ton des Verbindungsstatus (Dot rendert `data-tone`, ui/dot/Dot.svelte). */
+function dotTone(html: string, testid: string): string {
+	const outer = outerHtml(html, testid);
+	const m = /data-tone="([^"]*)"/.exec(outer);
+	assert.ok(m, `Kein Dot (data-tone) innerhalb von "${testid}" — Verbindungsstatus fehlt.`);
+	return m[1];
+}
+
+/** true nur, wenn das boolsche `checked`-Attribut im Tag gesetzt ist. */
+function isChecked(inputTag: string): boolean {
+	return /\bchecked(=""|(?=[\s/>]))/.test(inputTag);
+}
+
+/** Scoped CSS der Komponente — Daten, um die am gerenderten Element
+ * TATSAECHLICH zugewiesene Textfarbe aufzuloesen (AC-9). */
+function scopedCss(file: string): string {
+	return compile(readFileSync(file, 'utf-8'), { generate: 'server', filename: file }).css?.code ?? '';
+}
+
+/** Farb-Token, das am gerenderten Element wirkt: inline `style` gewinnt, sonst
+ * ueber die am Element zugewiesenen Klassen aus dem Komponenten-CSS. */
+function resolveColorToken(outer: string, cssCode: string): string | null {
+	const openTag = outer.slice(0, outer.indexOf('>') + 1);
+	const inline = /style="([^"]*)"/.exec(openTag);
+	if (inline) {
+		const m = /color\s*:\s*var\(\s*(--[a-z0-9-]+)/i.exec(inline[1]);
+		if (m) return m[1];
+	}
+	const cls = /class="([^"]*)"/.exec(openTag);
+	if (!cls) return null;
+	const names = cls[1].split(/\s+/).filter((c) => c && !c.startsWith('svelte-'));
+	for (const name of names) {
+		const rule = new RegExp(`\\.${name}\\b[^{}]*\\{([^}]*)\\}`, 'g');
+		let m: RegExpExecArray | null;
+		while ((m = rule.exec(cssCode))) {
+			const c = /color\s*:\s*var\(\s*(--[a-z0-9-]+)/i.exec(m[1]);
+			if (c) return c[1];
+		}
+	}
+	return null;
+}
+
+// ─── #1717 AC-2 ──────────────────────────────────────────────────────────────
+
+describe('#1717 AC-2: beide Komponenten zeigen denselben Premium-SMS-Zustand', () => {
+	test('beide_komponenten_zeigen_fuer_identisches_profil_denselben_premium_sms_zustand', () => {
+		for (const [name, profile] of [
+			['none', P_NONE],
+			['stale', P_STALE],
+			['fresh', P_FRESH]
+		] as Array<[string, PremiumProfile]>) {
+			const vt = renderVTPremium(profile);
+			const edit = renderEditPremium(profile);
+
+			assert.equal(
+				checkboxLabelText(vt, 'channel-premium-sms'),
+				checkboxLabelText(edit, 'channel-premium-sms'),
+				`AC-2 (${name}): Beschriftung der Premium-SMS-Checkbox weicht zwischen den beiden ` +
+					'Komponenten ab — sie muessen denselben geteilten Helfer benutzen.'
+			);
+			assert.equal(
+				elementText(vt, 'channel-status-premium-sms'),
+				elementText(edit, 'channel-status-premium-sms'),
+				`AC-2 (${name}): Verbindungsstatus-Label weicht ab.`
+			);
+			assert.equal(
+				dotTone(vt, 'channel-status-premium-sms'),
+				dotTone(edit, 'channel-status-premium-sms'),
+				`AC-2 (${name}): Dot-Ton weicht ab.`
+			);
+			assert.equal(
+				elementText(vt, 'channel-premium-sms-hint'),
+				elementText(edit, 'channel-premium-sms-hint'),
+				`AC-2 (${name}): Hinweistext weicht ab.`
+			);
+			assert.equal(
+				isDisabled(checkboxInputTag(vt, 'channel-premium-sms')),
+				isDisabled(checkboxInputTag(edit, 'channel-premium-sms')),
+				`AC-2 (${name}): Deaktiviert-Zustand weicht ab — eine der beiden Seiten laesst ` +
+					'einschalten, was die andere sperrt.'
+			);
+		}
+	});
+});
+
+// ─── #1717 AC-3 ──────────────────────────────────────────────────────────────
+
+describe('#1717 AC-3: drei Zustaende, drei verschiedene Hinweistexte', () => {
+	test('premium_sms_drei_zustaende_zeigen_unterschiedlichen_hinweistext', () => {
+		for (const [komponente, renderer] of BEIDE) {
+			const hints = (
+				[
+					['none', P_NONE],
+					['stale', P_STALE],
+					['fresh', P_FRESH]
+				] as Array<[string, PremiumProfile]>
+			).map(([name, profile]) => {
+				const text = elementText(renderer(profile), 'channel-premium-sms-hint');
+				assert.ok(
+					text.trim().length > 0,
+					`AC-3 (${komponente}, ${name}): leerer Hinweistext — der Zustand bleibt unerklaert.`
+				);
+				return [name, text] as const;
+			});
+
+			for (let i = 0; i < hints.length; i++) {
+				for (let j = i + 1; j < hints.length; j++) {
+					assert.notEqual(
+						hints[i][1],
+						hints[j][1],
+						`AC-3 (${komponente}): "${hints[i][0]}" und "${hints[j][0]}" zeigen denselben Text ` +
+							`("${hints[i][1]}") — "keine Adresse" ist dann nicht von "veraltete Adresse" ` +
+							'zu unterscheiden.'
+					);
+				}
+			}
+		}
+	});
+});
+
+// ─── #1717 AC-4 ──────────────────────────────────────────────────────────────
+
+describe('#1717 AC-4: frische Rueckadresse zeigt Zielnummer UND Meldedatum', () => {
+	/** Plausible Darstellungen des Fixture-Datums. */
+	const datumsKandidaten = (iso: string): string[] => {
+		const d = new Date(iso);
+		const j = d.getFullYear();
+		const m = d.getMonth() + 1;
+		const t = d.getDate();
+		const pad = (n: number) => String(n).padStart(2, '0');
+		return [
+			`${pad(t)}.${pad(m)}.${j}`,
+			`${t}.${m}.${j}`,
+			`${j}-${pad(m)}-${pad(t)}`,
+			`${pad(t)}.${pad(m)}.`,
+			d.toLocaleDateString('de-DE')
+		];
+	};
+
+	test('premium_sms_fresh_zeigt_zielnummer_und_meldedatum', () => {
+		for (const [komponente, renderer] of BEIDE) {
+			const html = renderer(P_FRESH);
+			const sichtbar = [
+				checkboxLabelText(html, 'channel-premium-sms'),
+				elementText(html, 'channel-status-premium-sms'),
+				elementText(html, 'channel-premium-sms-hint'),
+				elementText(html, 'channel-premium-sms-reported-at')
+			].join(' | ');
+
+			assert.ok(
+				sichtbar.includes(REPLY_TO),
+				`AC-4 (${komponente}): Die gelernte Zielnummer "${REPLY_TO}" steht nicht im sichtbaren ` +
+					`Text der Premium-SMS-Zeile — gerendert: "${sichtbar}".`
+			);
+			const kandidaten = datumsKandidaten(REPLY_AT);
+			assert.ok(
+				kandidaten.some((k) => sichtbar.includes(k)),
+				`AC-4 (${komponente}): Kein Meldedatum sichtbar (erwartet eine Darstellung von ` +
+					`${REPLY_AT}, z.B. ${kandidaten.slice(0, 3).join(' / ')}) — gerendert: "${sichtbar}".`
+			);
+		}
+	});
+});
+
+// ─── #1717 AC-9 ──────────────────────────────────────────────────────────────
+
+describe('#1717 AC-9: Meldedatum ist ein Daten-Label, keine Fussnote', () => {
+	test('meldedatum_label_nutzt_nicht_die_platzhalter_kontrastfarbe', () => {
+		const ERLAUBT = ['--g-ink', '--g-ink-1', '--g-ink-2', '--g-ink-3'];
+		for (const [komponente, renderer, file] of [
+			['VTBriefingChannels', renderVTPremium, VT_FILE],
+			['EditReportConfigSection', renderEditPremium, EDIT_FILE]
+		] as Array<[string, (p: PremiumProfile | null) => string, string]>) {
+			const css = scopedCss(file);
+			for (const [name, profile] of [
+				['fresh', P_FRESH],
+				['stale', P_STALE]
+			] as Array<[string, PremiumProfile]>) {
+				const outer = outerHtml(renderer(profile), 'channel-premium-sms-reported-at');
+				const token = resolveColorToken(outer, css);
+
+				assert.notEqual(
+					token,
+					'--g-ink-4',
+					`AC-9 (${komponente}, ${name}): Das Meldedatum-Label nutzt --g-ink-4 (2,85:1 auf Weiss, ` +
+						'strikt Platzhalter/Disabled vorbehalten). Es ist ein Daten-Label und braucht ' +
+						'mindestens --g-ink-3, wie der bestehende Verbindungsstatus-Text.'
+				);
+				assert.ok(
+					token !== null && ERLAUBT.includes(token),
+					`AC-9 (${komponente}, ${name}): Am Meldedatum-Label wirkt keine explizite, ` +
+						`kontrastgesicherte Textfarbe (aufgeloest: ${token ?? 'keine'}; erlaubt: ` +
+						`${ERLAUBT.join(', ')}). Element: ${outer.slice(0, 160)}`
+				);
+			}
+		}
+	});
+});
+
+// ─── #1717 Kanalzaehler (Tech-Lead-Entscheid 2026-08-11) ─────────────────────
+// Befund aus dem GREEN-Bericht zu S3: der Zaehler "wie viele Briefing-Kanaele
+// sind aktiv?" kannte nur drei Kanaele (VersandTab.svelte activeChannelCount,
+// EditReportConfigSection.svelte hasActiveChannel). Wer NUR Premium-SMS
+// einschaltet, sah dadurch den Leerzustand "Kein Kanal aktiv" und keine
+// Zeitplan-Optionen — waehrend das Briefing tatsaechlich rausgeht. Genau der
+// Fehler, den diese Scheibe verhindern soll, nur an einer anderen Stelle.
+//
+// GEMESSEN WIRD AM WIRKORT, in beiden Seiten — und das sind hier NICHT die
+// beiden Kanalblock-Kopien: den Zaehler haelt auf /trips/[id] die Ebene
+// darueber (VersandTab, gibt `hasActiveChannel` an VTSchedulePlan), auf
+// /trips/new EditReportConfigSection selbst. Der Leerzustand selbst lebt in
+// VTSchedulePlan.svelte (`{#if !hasActiveChannel}`), Testid
+// `briefings-channel-empty`.
+//
+// Jeder Fall traegt seine Gegenprobe: mit ALLEN Kanaelen aus MUSS der
+// Leerzustand erscheinen. Ohne diese zweite Messung wuerde der Test auch dann
+// gruen bleiben, wenn das Testid im gewaehlten Render-Aufbau nie entsteht (dann
+// bewacht er nichts).
+
+const EMPTY_TESTID = 'briefings-channel-empty';
+const VERSAND_TAB_FILE = path.join(FRONTEND, 'src/lib/components/shared/VersandTab.svelte');
+const VersandTab = (await import(pathToFileURL(VERSAND_TAB_FILE).href)).default;
+
+/** /trips/[id] — Trip-Editor-Versand-Tab (route-Zweig). */
+function renderVersandTabRoute(cfg: Record<string, unknown>): string {
+	return render(VersandTab, { props: { context: 'route', reportConfig: cfg } }).body;
+}
+
+/** /trips/new — dieselbe Zeitplan-Sektion, andere Fassung des Zaehlers.
+ * `showChannels: false`, damit im HTML nur der EINE Leerzustand aus
+ * VTSchedulePlan vorkommen kann (der Kanal-Gating-Leerzustand aus #617 traegt
+ * dasselbe Testid, haengt aber an `weatherChannels` — hier nicht gesetzt). */
+function renderEditSchedule(cfg: Record<string, unknown>): string {
+	return render(EditReportConfigSection, {
+		props: {
+			reportConfig: cfg,
+			mode: 'edit',
+			showMailContent: false,
+			showSchedule: true,
+			showChannels: false,
+			profileOverride: P_FRESH
+		}
+	}).body;
+}
+
+describe('#1717 Kanalzaehler: Premium-SMS allein ist ein aktiver Kanal', () => {
+	const NUR_PREMIUM = {
+		send_email: false,
+		send_telegram: false,
+		send_sms: false,
+		send_premium_sms: true
+	};
+	const ALLE_AUS = { ...NUR_PREMIUM, send_premium_sms: false };
+
+	test('nur_premium_sms_aktiv_zeigt_keinen_leerzustand_in_beiden_fassungen', () => {
+		for (const [ort, renderer] of [
+			['VersandTab (/trips/[id])', renderVersandTabRoute],
+			['EditReportConfigSection (/trips/new)', renderEditSchedule]
+		] as Array<[string, (c: Record<string, unknown>) => string]>) {
+			// Gegenprobe: der Leerzustand ist in diesem Aufbau erreichbar.
+			assert.ok(
+				renderer(ALLE_AUS).includes(`data-testid="${EMPTY_TESTID}"`),
+				`${ort}: Mit allen vier Kanaelen AUS muss der Leerzustand ` +
+					`"${EMPTY_TESTID}" erscheinen. Fehlt er hier, prueft der Fall unten nichts.`
+			);
+
+			assert.ok(
+				!renderer(NUR_PREMIUM).includes(`data-testid="${EMPTY_TESTID}"`),
+				`${ort}: Nur Premium-SMS ist eingeschaltet — das Briefing geht raus, die ` +
+					`Oberflaeche behauptet aber "Kein Kanal aktiv" (${EMPTY_TESTID}) und sperrt die ` +
+					'Zeitplan-Optionen weg. Der Kanal-Zaehler muss send_premium_sms mitzaehlen.'
+			);
+		}
+	});
+
+	test('zeitplan_optionen_erscheinen_wenn_nur_premium_sms_aktiv_ist', () => {
+		// Positivseite derselben Zusicherung: nicht nur "kein Leerzustand",
+		// sondern der Inhalt, den der Leerzustand ersetzt, ist tatsaechlich da.
+		for (const [ort, renderer] of [
+			['VersandTab (/trips/[id])', renderVersandTabRoute],
+			['EditReportConfigSection (/trips/new)', renderEditSchedule]
+		] as Array<[string, (c: Record<string, unknown>) => string]>) {
+			const html = renderer(NUR_PREMIUM);
+			assert.ok(
+				html.includes('data-testid="morning-master-switch"'),
+				`${ort}: Bei aktivem Premium-SMS muessen die Zeitplan-Karten (Morgen-Briefing) ` +
+					'gerendert sein — sonst kann der Nutzer die Sendezeit seines einzigen Kanals ' +
+					'nicht einstellen.'
+			);
+		}
+	});
+});
+
+// ─── #1717 AC-10 ─────────────────────────────────────────────────────────────
+
+describe('#1717 AC-10: gespeicherter Anhak-Zustand wird gelesen', () => {
+	test('premium_sms_checked_spiegelt_report_config_in_beiden_komponenten', () => {
+		for (const [komponente, renderer] of BEIDE) {
+			const angehakt = checkboxInputTag(renderer(P_FRESH, true), 'channel-premium-sms');
+			assert.equal(
+				isChecked(angehakt),
+				true,
+				`AC-10 (${komponente}): send_premium_sms=true ist gespeichert, die Checkbox rendert aber ` +
+					`nicht angehakt (Tag: ${angehakt}). Bei EditReportConfigSection heisst das: der ` +
+					'Zustand wird nur in onMount hydriert — beim Rendern ist er dann nicht da.'
+			);
+
+			const leer = checkboxInputTag(renderer(P_FRESH, false), 'channel-premium-sms');
+			assert.equal(
+				isChecked(leer),
+				false,
+				`AC-10 (${komponente}): Ohne send_premium_sms darf die Checkbox NICHT angehakt sein ` +
+					`(Tag: ${leer}) — sonst schaltet die Anzeige einen kostenpflichtigen Kanal vor.`
 			);
 		}
 	});

--- a/frontend/src/lib/components/shared/versand-tab/__tests__/premium_sms_channel_state.test.ts
+++ b/frontend/src/lib/components/shared/versand-tab/__tests__/premium_sms_channel_state.test.ts
@@ -1,0 +1,232 @@
+// TDD RED — Issue #1717 (Scheibe S3): Premium-SMS in der Oberflaeche.
+// Spec: docs/specs/modules/feat_1717_s3_premium_sms_ui.md — AC-3, AC-5, AC-6.
+//
+// Reine Funktionspruefung des geteilten Zustands-Helfers
+// `../premiumSmsChannelState.ts` (noch nicht vorhanden -> die Datei bricht beim
+// Import ab, ERR_MODULE_NOT_FOUND: "Funktion fehlt", nicht "Tippfehler").
+// Kein Mock, kein try/catch um den Import — der Fehlschlag soll unmissverstaendlich
+// sein.
+//
+// VERTRAG, den dieser Test festnagelt (Implementierung in Phase 6):
+//
+//   export type PremiumSmsTone = 'good' | 'warn' | 'neutral';
+//   export interface PremiumSmsChannelState {
+//     disabled: boolean;          // Checkbox nicht anklickbar
+//     tone: PremiumSmsTone;       // Dot-Ton (Dot akzeptiert 'warn', ui/dot/Dot.svelte:10)
+//     statusLabel: string;        // Mono-Label neben dem Dot
+//     hint: string;               // Prosa-Hinweis unter der Checkbox
+//     reportedAtLabel: string;    // Meldedatum ("zuletzt gemeldet am ...")
+//   }
+//   export function premiumSmsChannelState(
+//     profile: ConnectionProfile | null | undefined
+//   ): PremiumSmsChannelState;
+//
+// Eingabe sind ausschliesslich die vier neuen ConnectionProfile-Felder
+// (`premium_sms_allowed`, `premium_sms_reply_to`, `premium_sms_reply_at`,
+// `premium_sms_reply_state`). Der Helfer rechnet KEINE Frist nach — die
+// 30-Tage-Frist bleibt serverseitig (AC-5, Kontext-Risiko 3).
+//
+// Pfadregel #1409: der Pruefling wird relativ zu DIESER Datei aufgeloest
+// (`../premiumSmsChannelState.ts`), nie ueber einen festen Hauptrepo-Pfad.
+//
+// Ausfuehrung:
+//   cd frontend && node --import ./test-lib-loader.mjs --experimental-strip-types \
+//     --test src/lib/components/shared/versand-tab/__tests__/premium_sms_channel_state.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { premiumSmsChannelState } from '../premiumSmsChannelState.ts';
+
+/** Profilform wie sie `GET /api/auth/profile` nach S3 liefert (Go: auth.go
+ * profileResponse). Lokal deklariert, damit dieser Test nicht an der
+ * Typdeklaration haengt, sondern am Verhalten. */
+interface PremiumProfile {
+	sms_to?: string;
+	sms_allowed?: boolean;
+	premium_sms_allowed?: boolean;
+	premium_sms_reply_to?: string;
+	premium_sms_reply_at?: string;
+	premium_sms_reply_state?: 'none' | 'stale' | 'fresh';
+}
+
+/** Vom Geraet gelernte Garmin-Rueckadresse (S1) — hat KEINE feste Nummer. */
+const REPLY_TO = '15551234567';
+const SMS_TO = '+49150000000';
+
+function isoAgo(ms: number): string {
+	return new Date(Date.now() - ms).toISOString();
+}
+const TAG_MS = 24 * 60 * 60 * 1000;
+
+/** Premium-Tier, frische gelernte Rueckadresse — der Alles-gut-Fall. */
+const FRESH: PremiumProfile = {
+	sms_to: SMS_TO,
+	sms_allowed: true,
+	premium_sms_allowed: true,
+	premium_sms_reply_to: REPLY_TO,
+	premium_sms_reply_at: isoAgo(2 * TAG_MS),
+	premium_sms_reply_state: 'fresh'
+};
+
+/** Noch nie gemeldet — Backend-Sperrgrund `premium_sms_no_reply_address`. */
+const NONE: PremiumProfile = {
+	sms_to: SMS_TO,
+	sms_allowed: true,
+	premium_sms_allowed: true,
+	premium_sms_reply_state: 'none'
+};
+
+/** Laut Server verfallen — Backend-Sperrgrund `premium_sms_reply_address_stale`. */
+const STALE: PremiumProfile = {
+	...FRESH,
+	premium_sms_reply_at: isoAgo(90 * TAG_MS),
+	premium_sms_reply_state: 'stale'
+};
+
+/** Datumsdarstellungen auf einen Platzhalter normalisieren — was danach noch
+ * unterschiedlich ist, ist KEIN Datum (also z.B. eine Tage-Zahl). */
+function ohneDatum(text: string): string {
+	return text.replace(/\d{1,4}[.\-/]\s?\d{1,2}[.\-/]\s?\d{1,4}/g, '«DATUM»');
+}
+
+describe('#1717 AC-3/AC-5/AC-6 — premiumSmsChannelState (geteilter Zustands-Helfer)', () => {
+	// ─── AC-3 ────────────────────────────────────────────────────────────────
+	test('state_labels_are_pairwise_distinct', () => {
+		const faelle: Array<[string, PremiumProfile]> = [
+			['none', NONE],
+			['stale', STALE],
+			['fresh', FRESH]
+		];
+		const hints = faelle.map(([name, p]) => {
+			const hint = premiumSmsChannelState(p).hint;
+			assert.ok(
+				typeof hint === 'string' && hint.trim().length > 0,
+				`AC-3 (${name}): Hinweistext fehlt — kein Zustand darf still verschwiegen werden.`
+			);
+			return [name, hint] as const;
+		});
+
+		for (let i = 0; i < hints.length; i++) {
+			for (let j = i + 1; j < hints.length; j++) {
+				assert.notEqual(
+					hints[i][1],
+					hints[j][1],
+					`AC-3: Zustaende "${hints[i][0]}" und "${hints[j][0]}" zeigen denselben Hinweistext ` +
+						`("${hints[i][1]}") — ein Nutzer kann "keine Adresse" nicht von "veraltete Adresse" unterscheiden.`
+				);
+			}
+		}
+
+		// Beide Sperrfaelle muessen die Checkbox auch tatsaechlich sperren.
+		for (const [name, p] of [['none', NONE], ['stale', STALE]] as const) {
+			assert.equal(
+				premiumSmsChannelState(p).disabled,
+				true,
+				`AC-3 (${name}): Checkbox waere anklickbar, obwohl der Sendepfad diesen Fall blockt.`
+			);
+		}
+		assert.equal(
+			premiumSmsChannelState(FRESH).disabled,
+			false,
+			'AC-3 (fresh): Checkbox muss bei Premium-Tier + frischer Rueckadresse anklickbar sein.'
+		);
+	});
+
+	// ─── AC-5 ────────────────────────────────────────────────────────────────
+	test('state_feld_gewinnt_gegen_lokal_berechnetes_alter', () => {
+		// (a) Server sagt "stale", der Rohzeitstempel sieht frisch aus (1 Stunde alt).
+		const widerspruchStale: PremiumProfile = {
+			...FRESH,
+			premium_sms_reply_at: isoAgo(60 * 60 * 1000),
+			premium_sms_reply_state: 'stale'
+		};
+		const a = premiumSmsChannelState(widerspruchStale);
+		assert.equal(
+			a.disabled,
+			true,
+			'AC-5: Server sagt "stale", der Zeitstempel ist 1 Stunde alt — die Anzeige folgt dem ' +
+				'state-Feld, nicht einer im Frontend nachgerechneten Frist (sonst steht hier eine ' +
+				'zweite 30-Tage-Konstante).'
+		);
+		assert.equal(
+			ohneDatum(a.hint),
+			ohneDatum(premiumSmsChannelState(STALE).hint),
+			'AC-5: Der widerspruechliche Fall muss dieselbe Aussage tragen wie ein kanonisch ' +
+				'veraltetes Profil — abweichender Text heisst: es wurde lokal gerechnet.'
+		);
+
+		// (b) Gegenrichtung — Server sagt "fresh", der Rohzeitstempel ist 400 Tage alt.
+		const widerspruchFresh: PremiumProfile = {
+			...FRESH,
+			premium_sms_reply_at: isoAgo(400 * TAG_MS),
+			premium_sms_reply_state: 'fresh'
+		};
+		const b = premiumSmsChannelState(widerspruchFresh);
+		assert.equal(
+			b.disabled,
+			false,
+			'AC-5 (Gegenrichtung): Server sagt "fresh" bei 400 Tage altem Zeitstempel — eine lokale ' +
+				'Fristrechnung wuerde hier sperren und damit dem Server widersprechen.'
+		);
+		assert.equal(
+			ohneDatum(b.hint),
+			ohneDatum(premiumSmsChannelState(FRESH).hint),
+			'AC-5 (Gegenrichtung): Aussage muss die eines frischen Profils sein.'
+		);
+	});
+
+	test('hinweistext_nennt_keine_tage_zahl', () => {
+		const stale31 = { ...STALE, premium_sms_reply_at: isoAgo(31 * TAG_MS) };
+		const stale400 = { ...STALE, premium_sms_reply_at: isoAgo(400 * TAG_MS) };
+		const a = premiumSmsChannelState(stale31);
+		const b = premiumSmsChannelState(stale400);
+
+		assert.notEqual(
+			a.reportedAtLabel,
+			b.reportedAtLabel,
+			'AC-5: Zwei unterschiedlich alte Rueckadressen muessen unterschiedliche Meldedaten zeigen.'
+		);
+
+		for (const [name, s] of [['31 Tage alt', a], ['400 Tage alt', b]] as const) {
+			assert.ok(
+				!/\bTag(e|en)?\b/i.test(s.hint),
+				`AC-5 (${name}): Der Hinweistext nennt eine Tage-Angabe ("${s.hint}") — das ist die ` +
+					'30-Tage-Frist in Prosaform, also dieselbe Kopie.'
+			);
+		}
+
+		assert.equal(
+			ohneDatum(a.hint),
+			ohneDatum(b.hint),
+			`AC-5: Die beiden Hinweistexte duerfen sich NUR im Meldedatum unterscheiden — ` +
+				`"${a.hint}" vs. "${b.hint}".`
+		);
+	});
+
+	// ─── AC-6 ────────────────────────────────────────────────────────────────
+	test('disabled_bei_tarif_sperre_trotz_frischer_adresse', () => {
+		const standardTier: PremiumProfile = {
+			sms_to: SMS_TO,
+			sms_allowed: true, // normaler SMS-Kanal erlaubt (Tier standard)
+			premium_sms_allowed: false, // Premium-SMS NICHT (nur Tier premium)
+			premium_sms_reply_to: REPLY_TO,
+			premium_sms_reply_at: isoAgo(1 * TAG_MS),
+			premium_sms_reply_state: 'fresh'
+		};
+		const s = premiumSmsChannelState(standardTier);
+
+		assert.equal(
+			s.disabled,
+			true,
+			'AC-6: Tier standard darf Premium-SMS nicht einschalten koennen, auch nicht mit frischer ' +
+				'Rueckadresse — sonst verspricht die Checkbox etwas, das der Sendepfad (S2a AC-8) blockt.'
+		);
+		assert.notEqual(
+			s.hint,
+			premiumSmsChannelState(FRESH).hint,
+			'AC-6: Ein tarifgesperrter Nutzer sieht denselben Text wie ein voll berechtigter — ' +
+				'die Tarif-Sperre bleibt damit unsichtbar.'
+		);
+	});
+});

--- a/frontend/src/lib/components/shared/versand-tab/__tests__/premium_sms_context_gating_render.test.ts
+++ b/frontend/src/lib/components/shared/versand-tab/__tests__/premium_sms_context_gating_render.test.ts
@@ -1,0 +1,178 @@
+// TDD RED — Issue #1717 (Scheibe S3): Premium-SMS in der Oberflaeche.
+// Spec: docs/specs/modules/feat_1717_s3_premium_sms_ui.md — AC-1.
+//
+// AC-1 ist die Kontext-Trennung: derselbe geteilte Kanal-Baustein
+// (VTBriefingChannels) wird in VIER Mounts gerendert — einmal fuer das
+// Trip-Briefing (`context="route"`, /trips/[id]) und dreimal fuer den
+// Orts-Vergleich (`context="vergleich"`, /compare/[id] + /compare/new Desktop
+// und Mobil, docs/context/feat-1717-s3-premium-sms-ui.md "Vier Mounts").
+// Premium-SMS ist laut ADR-0049 ausschliesslich ein Trip-Briefing-Kanal; im
+// Orts-Vergleich muss der feste "bald verfuegbar"-Platzhalter stehen bleiben.
+//
+// ZWEI NAEHTE, weil eine Naht die Zusicherung nicht traegt:
+//   1. VTBriefingChannels selbst — rendert den schaltbaren Block nur, wenn die
+//      Prop `onPremiumSmsChange` gesetzt ist (Muster `{#if onTelegramStyleChange}`,
+//      VTBriefingChannels.svelte:155).
+//   2. VersandTab — uebergibt diese Prop NUR im route-Zweig (:202-231), nie im
+//      vergleich-Zweig (:232-285). Die in der Spec benannte Mutation
+//      ("VersandTab uebergibt onPremiumSmsChange auch im vergleich-Zweig")
+//      waere an Naht 1 allein UNSICHTBAR — deshalb wird hier der echte
+//      Wirkort mitgemessen, nicht nur der Ort, an dem der Code steht.
+//
+// Echtes serverseitiges Rendern der echten Svelte-Komponenten (svelte/server
+// `render`, Hooks: frontend/test-svelte-ssr-hooks.mjs). Keine Mocks.
+//
+// RED heute: beide Komponentenzweige rendern denselben fest deaktivierten
+// Platzhalter (VTBriefingChannels.svelte:187-192) — es gibt weder die Prop
+// `onPremiumSmsChange` noch das Testid `channel-status-premium-sms`.
+//
+// Pfadregel #1409: alle Pfade relativ zu DIESER Datei.
+//
+// Ausfuehrung:
+//   cd frontend && node --import ./test-lib-loader.mjs --experimental-strip-types \
+//     --test src/lib/components/shared/versand-tab/__tests__/premium_sms_context_gating_render.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { register } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// __tests__ -> versand-tab -> shared -> components -> lib -> src -> frontend
+const FRONTEND = path.resolve(HERE, '../../../../../..');
+
+register(
+	pathToFileURL(path.join(FRONTEND, 'test-svelte-ssr-hooks.mjs')).href,
+	pathToFileURL(FRONTEND + '/').href
+);
+
+const { render } = await import('svelte/server');
+const VTBriefingChannels = (
+	await import(
+		pathToFileURL(
+			path.join(FRONTEND, 'src/lib/components/shared/versand-tab/VTBriefingChannels.svelte')
+		).href
+	)
+).default;
+const VersandTab = (
+	await import(
+		pathToFileURL(path.join(FRONTEND, 'src/lib/components/shared/VersandTab.svelte')).href
+	)
+).default;
+
+interface PremiumProfile {
+	sms_to?: string;
+	sms_allowed?: boolean;
+	premium_sms_allowed?: boolean;
+	premium_sms_reply_to?: string;
+	premium_sms_reply_at?: string;
+	premium_sms_reply_state?: 'none' | 'stale' | 'fresh';
+}
+
+/** Vollstaendig gueltiges Premium-Profil (Premium-Tier, frische Rueckadresse). */
+const FRESH: PremiumProfile = {
+	sms_to: '+49150000000',
+	sms_allowed: true,
+	premium_sms_allowed: true,
+	premium_sms_reply_to: '15551234567',
+	premium_sms_reply_at: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+	premium_sms_reply_state: 'fresh'
+};
+
+/** `<input .../>`-Tag direkt hinter dem gegebenen Testid. */
+function checkboxInputTag(html: string, testid: string): string {
+	const marker = `data-testid="${testid}"`;
+	const markerIdx = html.indexOf(marker);
+	assert.notEqual(markerIdx, -1, `Testid "${testid}" nicht im gerenderten HTML gefunden.`);
+	const inputStart = html.indexOf('<input', markerIdx);
+	assert.notEqual(inputStart, -1, `Kein <input> nach Testid "${testid}" gefunden.`);
+	return html.slice(inputStart, html.indexOf('>', inputStart) + 1);
+}
+
+/** true nur, wenn das boolsche `disabled`-Attribut im Tag gesetzt ist. */
+function isDisabled(inputTag: string): boolean {
+	return /\bdisabled(=""|(?=[\s/>]))/.test(inputTag);
+}
+
+function renderChannels(profile: PremiumProfile | null, withPremiumHandler: boolean): string {
+	const props: Record<string, unknown> = {
+		channels: { email: false, telegram: false, sms: false, premium_sms: false },
+		onEmailChange: () => {},
+		onTelegramChange: () => {},
+		onSmsChange: () => {},
+		profileOverride: profile
+	};
+	if (withPremiumHandler) props.onPremiumSmsChange = () => {};
+	return render(VTBriefingChannels, { props }).body;
+}
+
+function renderVersandTab(context: 'route' | 'vergleich'): string {
+	return render(VersandTab, { props: { context } }).body;
+}
+
+const SCHALTBAR_MARKER = 'data-testid="channel-status-premium-sms"';
+const PLATZHALTER_TEXT = 'bald verfügbar';
+
+describe('#1717 AC-1 — Premium-SMS ist nur im Trip-Briefing schaltbar', () => {
+	test('premium_sms_switchable_only_in_route_context', () => {
+		// ── Naht 1: der geteilte Baustein selbst, IDENTISCHES Profil ──────────
+		const routeHtml = renderChannels(FRESH, true);
+		const vergleichHtml = renderChannels(FRESH, false);
+
+		assert.equal(
+			isDisabled(checkboxInputTag(routeHtml, 'channel-premium-sms')),
+			false,
+			'AC-1 (route): Bei Premium-Tier und frischer Rueckadresse muss die Premium-SMS-Checkbox ' +
+				'im Trip-Briefing editierbar sein (kein disabled-Attribut) — heute steht dort ein ' +
+				'fest deaktivierter Platzhalter (VTBriefingChannels.svelte:187-192).'
+		);
+		assert.equal(
+			isDisabled(checkboxInputTag(vergleichHtml, 'channel-premium-sms')),
+			true,
+			'AC-1 (vergleich): Ohne `onPremiumSmsChange` darf KEINE schaltbare Premium-SMS-Checkbox ' +
+				'entstehen — Premium-SMS ist laut ADR-0049 kein Vergleichs-Kanal.'
+		);
+
+		// ── Naht 2: VersandTab — der Zweig, der die Prop uebergibt ────────────
+		// Ohne Profil (SSR fuehrt onMount/fetch nicht aus) unterscheidet nicht das
+		// disabled-Attribut die beiden Zweige, sondern OB der schaltbare Block
+		// ueberhaupt gerendert wird.
+		const tabRoute = renderVersandTab('route');
+		const tabVergleich = renderVersandTab('vergleich');
+
+		assert.ok(
+			tabRoute.includes(SCHALTBAR_MARKER),
+			'AC-1 (VersandTab route): Der route-Zweig muss `onPremiumSmsChange` uebergeben, damit der ' +
+				`schaltbare Premium-SMS-Block (${SCHALTBAR_MARKER}) entsteht.`
+		);
+		assert.ok(
+			!tabVergleich.includes(SCHALTBAR_MARKER),
+			'AC-1 (VersandTab vergleich): Der vergleich-Zweig darf `onPremiumSmsChange` NICHT ' +
+				'uebergeben — sonst erscheint der schaltbare Premium-SMS-Block auf /compare/[id] und ' +
+				'/compare/new (drei der vier Mounts).'
+		);
+	});
+
+	test('vergleich_behaelt_den_unveraenderten_platzhalter_hinweis', () => {
+		const vergleichHtml = renderChannels(FRESH, false);
+		const tabVergleich = renderVersandTab('vergleich');
+		const tabRoute = renderVersandTab('route');
+
+		assert.ok(
+			vergleichHtml.includes(PLATZHALTER_TEXT),
+			`AC-1 (vergleich): Der unveraenderte "${PLATZHALTER_TEXT}"-Hinweis muss im Orts-Vergleich ` +
+				'stehen bleiben.'
+		);
+		assert.ok(
+			tabVergleich.includes(PLATZHALTER_TEXT),
+			`AC-1 (VersandTab vergleich): "${PLATZHALTER_TEXT}" fehlt — der Vergleich haette dann ` +
+				'einen Kanal ohne jede Erklaerung.'
+		);
+		assert.ok(
+			!tabRoute.includes(PLATZHALTER_TEXT),
+			`AC-1 (VersandTab route): "${PLATZHALTER_TEXT}" darf im Trip-Briefing NICHT mehr stehen — ` +
+				'der Kanal ist seit S2a live und wird hier schaltbar.'
+		);
+	});
+});

--- a/frontend/src/lib/components/shared/versand-tab/channelConnectionStatus.ts
+++ b/frontend/src/lib/components/shared/versand-tab/channelConnectionStatus.ts
@@ -26,6 +26,14 @@ export interface ConnectionProfile {
 	telegram_chat_id?: string;
 	sms_to?: string;
 	sms_allowed?: boolean;
+	/** Issue #1717 S3 — Premium-SMS (Garmin inReach). Vier lesende Felder aus
+	 * GET /api/auth/profile (Go: profileResponse). Hier und NICHT in den lokalen
+	 * `interface Profile`-Kopien der Komponenten, damit es eine kanonische
+	 * Profilform gibt; ausgewertet von premiumSmsChannelState(). */
+	premium_sms_allowed?: boolean;
+	premium_sms_reply_to?: string;
+	premium_sms_reply_at?: string;
+	premium_sms_reply_state?: 'none' | 'stale' | 'fresh';
 }
 
 const NOT_CONNECTED: ChannelConnectionInfo = { tone: 'neutral', label: 'nicht verbunden' };

--- a/frontend/src/lib/components/shared/versand-tab/premiumSmsChannelState.ts
+++ b/frontend/src/lib/components/shared/versand-tab/premiumSmsChannelState.ts
@@ -1,0 +1,106 @@
+// premiumSmsChannelState — Issue #1717 Scheibe S3 (Premium-SMS in der
+// Oberflaeche), Spec docs/specs/modules/feat_1717_s3_premium_sms_ui.md.
+//
+// EIN Aufruf liefert den kompletten Anzeige-Zustand der Premium-SMS-Zeile
+// (Design analog channelConnectionStatus()/channelContactLabel() im selben
+// Ordner). Beide Kanalblock-Komponenten rufen ihn auf — VTBriefingChannels.svelte
+// (/trips/[id], /compare/*) und EditReportConfigSection.svelte (/trips/new).
+// Eine dritte, wortgleiche Kopie der Zustandslogik waere der Default-Fehler
+// dieser Scheibe (vgl. channelContactLabel vor seiner Extraktion, #1510).
+//
+// KEINE Frist-Rechnung hier (AC-5). Die 30-Tage-Frist der gelernten
+// Rueckadresse lebt serverseitig — im Python-Sendepfad
+// (PREMIUM_SMS_REPLY_TTL, src/output/channels/premium_sms.py) und in der
+// Go-Ableitung fuer GET /api/auth/profile (model.PremiumSmsReplyTTL,
+// internal/model/premium_sms.go). Der Helfer folgt ausschliesslich dem fertig
+// gelieferten Feld `premium_sms_reply_state`. Eine dritte Zahl im Frontend
+// wuerde zwangslaeufig irgendwann "frisch" anzeigen, wo der Sendepfad schon
+// blockt — deshalb steht im Hinweistext auch keine Tage-Zahl in Prosaform.
+//
+// Pure Funktion, kein Netz-/DOM-Zugriff — node:testbar.
+
+import type { ConnectionProfile } from './channelConnectionStatus';
+
+export type PremiumSmsTone = 'good' | 'warn' | 'neutral';
+
+export interface PremiumSmsChannelState {
+	/** Checkbox nicht anklickbar (Tarif gesperrt ODER Rueckadresse nicht frisch). */
+	disabled: boolean;
+	/** Dot-Ton neben dem Status-Label (Dot akzeptiert 'warn', ui/dot/Dot.svelte). */
+	tone: PremiumSmsTone;
+	/** Mono-Label neben dem Dot — Vokabular wie channelConnectionStatus(). */
+	statusLabel: string;
+	/** Prosa-Hinweis unter der Checkbox. Drei Zustaende, drei Texte. */
+	hint: string;
+	/** Meldedatum als eigenes Daten-Label ("zuletzt gemeldet am …"), leer wenn
+	 * sich das Geraet noch nie gemeldet hat. */
+	reportedAtLabel: string;
+	/** Suffix fuer die Checkbox-Beschriftung — zeigt WOHIN gesendet wird
+	 * (Muster channelContactLabel: " (nummer)"). */
+	contactLabel: string;
+}
+
+/** Meldedatum als deutsches Kalenderdatum. Bewusst ohne toLocaleDateString:
+ * das Ergebnis darf nicht von der ICU-Ausstattung der Laufzeit abhaengen. */
+function formatReportedAt(iso: string | undefined): string {
+	if (!iso) return '';
+	const d = new Date(iso);
+	if (Number.isNaN(d.getTime())) return '';
+	const pad = (n: number) => String(n).padStart(2, '0');
+	return `${pad(d.getDate())}.${pad(d.getMonth() + 1)}.${d.getFullYear()}`;
+}
+
+export function premiumSmsChannelState(
+	profile: ConnectionProfile | null | undefined
+): PremiumSmsChannelState {
+	const p = profile ?? {};
+	const reportedAt = formatReportedAt(p.premium_sms_reply_at);
+	const reportedAtLabel = reportedAt ? `zuletzt gemeldet am ${reportedAt}` : '';
+	const contactLabel = p.premium_sms_reply_to ? ` (${p.premium_sms_reply_to})` : '';
+	const base = { reportedAtLabel, contactLabel };
+
+	// Tarif-Gate zuerst: es ist eigenstaendig (nur Level Premium) und NICHT von
+	// sms_allowed abgeleitet — model.PremiumSmsAllowed, AC-6. Ein noch nicht
+	// geladenes Profil (null) laeuft bewusst hier hinein: alles gesperrt, bis
+	// der Server geantwortet hat (Verhalten der drei bestehenden Kanaele).
+	if (p.premium_sms_allowed !== true) {
+		return {
+			...base,
+			disabled: true,
+			tone: 'neutral',
+			statusLabel: 'nicht verfügbar',
+			hint: 'Premium-SMS ab Level Premium verfügbar'
+		};
+	}
+
+	// Ab hier entscheidet ausschliesslich der vom Server abgeleitete Zustand.
+	if (p.premium_sms_reply_state === 'fresh') {
+		return {
+			...base,
+			disabled: false,
+			tone: 'good',
+			statusLabel: 'gelernt',
+			hint: 'Das Gerät hat sich gemeldet — Briefings gehen an die gelernte Rückadresse.'
+		};
+	}
+	if (p.premium_sms_reply_state === 'stale') {
+		return {
+			...base,
+			disabled: true,
+			tone: 'warn',
+			statusLabel: 'verfallen',
+			hint:
+				'Rückadresse verfallen — Garmin kann die Nummer inzwischen einem fremden Gerät ' +
+				'zugeteilt haben. Sobald sich das Gerät wieder meldet, ist der Kanal erneut nutzbar.'
+		};
+	}
+	// 'none' und alles Unbekannte: noch nie gemeldet. Bewusst NICHT als
+	// "verfallen" ausgegeben — das behauptete ein Verfallsdatum, das es nie gab.
+	return {
+		...base,
+		disabled: true,
+		tone: 'neutral',
+		statusLabel: 'nicht verbunden',
+		hint: 'Das Gerät hat sich noch nie gemeldet — die Rückadresse wird beim ersten Empfang gelernt.'
+	};
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -238,6 +238,9 @@ export interface ReportConfig {
 	send_email?: boolean;
 	send_telegram?: boolean;
 	send_sms?: boolean;
+	// Issue #1717 S3 — vierter Briefing-Kanal (Premium-SMS, Garmin inReach).
+	// Backend seit #1676 S2a live; report_config bleibt die autoritative Quelle.
+	send_premium_sms?: boolean;
 	alert_on_changes?: boolean;
 	change_threshold_temp_c?: number;
 	change_threshold_wind_kmh?: number;
@@ -349,6 +352,9 @@ export interface Trip {
 	send_email?: boolean;
 	send_sms?: boolean;
 	send_telegram?: boolean;
+	// Issue #1717 S3 — viertes abgeleitetes Kanal-Feld (Premium-SMS),
+	// Go-Pendant: model.Trip.SendPremiumSms.
+	send_premium_sms?: boolean;
 	end_date?: string;
 	// Issue #1258 S1 — scharfes Feld, loest official_alert_triggers_enabled ab
 	// (Legacy-Feld bleibt fuer Rollback erhalten, wird nicht mehr gelesen/geschrieben).

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -444,24 +444,41 @@ func LogoutHandler() http.HandlerFunc {
 // profileResponse is the public view of a User (no password_hash, no public_key).
 // Issue #450 adds the Passkey-summary fields.
 type profileResponse struct {
-	ID             string                `json:"id"`
-	Email          string                `json:"email,omitempty"`
-	DisplayName    string                `json:"display_name,omitempty"`
-	MailTo         string                `json:"mail_to,omitempty"`
-	SmsTo          string                `json:"sms_to,omitempty"`
-	TelegramChatID string                `json:"telegram_chat_id,omitempty"`
-	Tier           string                `json:"tier"`
-	SmsAllowed     bool                  `json:"sms_allowed"`
+	ID             string `json:"id"`
+	Email          string `json:"email,omitempty"`
+	DisplayName    string `json:"display_name,omitempty"`
+	MailTo         string `json:"mail_to,omitempty"`
+	SmsTo          string `json:"sms_to,omitempty"`
+	TelegramChatID string `json:"telegram_chat_id,omitempty"`
+	Tier           string `json:"tier"`
+	SmsAllowed     bool   `json:"sms_allowed"`
 	// Issue #1258 S6 (R1) — aus EmailVerifiedAt abgeleitet, NIE der Zeitstempel
 	// selbst (AC-20).
-	EmailVerified  bool                  `json:"email_verified"`
+	EmailVerified bool `json:"email_verified"`
 	// Issue #1071 — offener Level-Änderungs-Antrag. Fehlt im JSON, solange kein
 	// Antrag vorliegt (omitempty bzw. nil-Pointer).
-	RequestedTier  string                `json:"requested_tier,omitempty"`
-	RequestedAt    *time.Time            `json:"requested_at,omitempty"`
-	CreatedAt      string                `json:"created_at"`
-	HasPasskey     bool                  `json:"has_passkey"`
-	Passkeys       []passkeyProfileEntry `json:"passkeys,omitempty"`
+	RequestedTier string     `json:"requested_tier,omitempty"`
+	RequestedAt   *time.Time `json:"requested_at,omitempty"`
+	// Issue #1717 S3 — Premium-SMS (Garmin inReach) in der Oberflaeche. REIN
+	// LESEND: die Rueckadresse lernt ausschliesslich der interne Rueckkanal
+	// (S1), UpdateProfileHandler nimmt die Felder nicht entgegen (AC-7).
+	//
+	// Rohwerte, Muster RequestedAt (hier IST der Zeitstempel die Nutzinformation
+	// — anders als EmailVerifiedAt, das nie ausgegeben wird): fehlen im JSON,
+	// solange das Geraet sich nie gemeldet hat. Pointer, weil omitempty bei
+	// time.Time-Werten nicht greift.
+	PremiumSmsReplyTo string     `json:"premium_sms_reply_to,omitempty"`
+	PremiumSmsReplyAt *time.Time `json:"premium_sms_reply_at,omitempty"`
+	// Abgeleiteter Zustand ("none"|"stale"|"fresh"), Muster EmailVerified —
+	// die Verfallsfrist bleibt serverseitig, damit die Oberflaeche keine zweite
+	// 30-Tage-Konstante braucht. Immer vorhanden.
+	PremiumSmsReplyState string `json:"premium_sms_reply_state"`
+	// Eigenes Tarif-Gate (nur premium), NICHT von SmsAllowed abgeleitet —
+	// Muster SmsAllowed. Immer vorhanden.
+	PremiumSmsAllowed bool                  `json:"premium_sms_allowed"`
+	CreatedAt         string                `json:"created_at"`
+	HasPasskey        bool                  `json:"has_passkey"`
+	Passkeys          []passkeyProfileEntry `json:"passkeys,omitempty"`
 }
 
 // passkeyProfileEntry exposes a registered Passkey to the client WITHOUT the
@@ -505,9 +522,14 @@ func toProfileResponse(u *model.User) profileResponse {
 		EmailVerified:  u.EmailVerifiedAt != nil,
 		RequestedTier:  u.RequestedTier,
 		RequestedAt:    u.RequestedAt,
-		CreatedAt:      u.CreatedAt.Format(time.RFC3339),
-		HasPasskey:     len(u.PasskeyCredentials) > 0,
-		Passkeys:       passkeys,
+		// Issue #1717 S3: Rohwerte durchgereicht, Zustand + Tarif-Gate abgeleitet.
+		PremiumSmsReplyTo:    u.PremiumSmsReplyTo,
+		PremiumSmsReplyAt:    u.PremiumSmsReplyAt,
+		PremiumSmsReplyState: model.DerivePremiumSmsReplyState(u.PremiumSmsReplyTo, u.PremiumSmsReplyAt),
+		PremiumSmsAllowed:    model.PremiumSmsAllowed(tier),
+		CreatedAt:            u.CreatedAt.Format(time.RFC3339),
+		HasPasskey:           len(u.PasskeyCredentials) > 0,
+		Passkeys:             passkeys,
 	}
 }
 

--- a/internal/handler/profile_test.go
+++ b/internal/handler/profile_test.go
@@ -2,16 +2,19 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/henemm/gregor-api/internal/config"
 	"github.com/henemm/gregor-api/internal/middleware"
+	"github.com/henemm/gregor-api/internal/model"
 )
 
 // TDD RED: Tests for profile endpoints — must FAIL until implemented.
@@ -560,5 +563,247 @@ func TestGetProfileHandlerEmailVerifiedField_AC20(t *testing.T) {
 	}
 	if strings.Contains(unverifiedBody, "email_verified_at") {
 		t.Errorf("AC-20: Zeitstempel email_verified_at darf NIE im JSON-Body stehen, war: %s", unverifiedBody)
+	}
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Issue #1717 (Scheibe S3): Premium-SMS in der Oberflaeche.
+// Spec: docs/specs/modules/feat_1717_s3_premium_sms_ui.md — AC-7 (der Endpoint
+// bleibt rein lesend) und die Feldmenge der vier neuen Profil-Felder, die die
+// Oberflaeche ueberhaupt erst mit Daten versorgt.
+//
+// Herkunft: in der RED-Phase lagen die beiden Funktionen ausserhalb von
+// internal/ und wurden per `go test -overlay` eingespielt (der edit_gate laesst
+// in phase5_tdd_red nur Test-Verzeichnisse zu). Seit Phase 6 stehen sie hier
+// neben TestGetProfileHandlerSmsAllowedField/
+// TestGetProfileHandlerEmailVerifiedField_AC20 — Assertions unveraendert.
+//
+// RED war: `profileResponse` fuehrte keins der vier Felder, und
+// `model.PremiumSmsReplyTTL`/`model.DerivePremiumSmsReplyState` existierten
+// nicht — das Paket uebersetzte deshalb nicht.
+//
+// Keine Mocks: echter Handler, echter Store auf t.TempDir(), echtes user.json.
+// ══════════════════════════════════════════════════════════════════════════════
+
+// Die vier Felder, die S3 lesend ergaenzt. `_state` und `_allowed` sind immer
+// vorhanden (kein omitempty), die beiden Rohwerte nur wenn gelernt.
+const (
+	fieldPremiumReplyTo    = "premium_sms_reply_to"
+	fieldPremiumReplyAt    = "premium_sms_reply_at"
+	fieldPremiumReplyState = "premium_sms_reply_state"
+	fieldPremiumAllowed    = "premium_sms_allowed"
+)
+
+// Feldmenge und abgeleiteter Zustand je Drei-Zustands-Fall. Die Frist wird
+// relativ zu model.PremiumSmsReplyTTL gesetzt, nicht als zweite 30 im Test —
+// die Deckungsgleichheit der Zahl bewacht tests/test_premium_sms_ttl_drift.py.
+func TestGetProfileHandlerPremiumSmsFields(t *testing.T) {
+	s := newTestStore(t)
+	h := GetProfileHandler(s)
+
+	now := time.Now().UTC()
+	frisch := now.Add(-model.PremiumSmsReplyTTL / 2).Format(time.RFC3339)
+	veraltet := now.Add(-model.PremiumSmsReplyTTL - 48*time.Hour).Format(time.RFC3339)
+
+	writeUser := func(id, extra string) {
+		dir := filepath.Join(s.DataDir, "users", id)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		body := fmt.Sprintf(`{"id":%q%s}`, id, extra)
+		if err := os.WriteFile(filepath.Join(dir, "user.json"), []byte(body), 0644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+	}
+	getProfile := func(id string) map[string]interface{} {
+		req := httptest.NewRequest("GET", "/api/auth/profile", nil)
+		req = req.WithContext(middleware.ContextWithUserID(req.Context(), id))
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != 200 {
+			t.Fatalf("%s: expected 200, got %d: %s", id, w.Code, w.Body.String())
+		}
+		var resp map[string]interface{}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("%s: unmarshal: %v (%s)", id, err, w.Body.String())
+		}
+		return resp
+	}
+
+	faelle := []struct {
+		id           string
+		extra        string
+		wantState    string
+		wantAllowed  bool
+		wantReplyTo  string // "" = Feld darf gar nicht im JSON stehen (omitempty)
+		beschreibung string
+	}{
+		{
+			id:           "premium-fresh",
+			extra:        `,"tier":"premium","premium_sms_reply_to":"15551234567","premium_sms_reply_at":"` + frisch + `"`,
+			wantState:    model.PremiumSmsStateFresh,
+			wantAllowed:  true,
+			wantReplyTo:  "15551234567",
+			beschreibung: "Premium-Tier, frische gelernte Rueckadresse",
+		},
+		{
+			id:           "premium-stale",
+			extra:        `,"tier":"premium","premium_sms_reply_to":"15559999999","premium_sms_reply_at":"` + veraltet + `"`,
+			wantState:    model.PremiumSmsStateStale,
+			wantAllowed:  true,
+			wantReplyTo:  "15559999999",
+			beschreibung: "Premium-Tier, laut Frist verfallene Rueckadresse",
+		},
+		{
+			id:           "premium-none",
+			extra:        `,"tier":"premium"`,
+			wantState:    model.PremiumSmsStateNone,
+			wantAllowed:  true,
+			wantReplyTo:  "",
+			beschreibung: "Premium-Tier, Geraet hat sich noch nie gemeldet",
+		},
+		{
+			id:           "standard-fresh",
+			extra:        `,"tier":"standard","premium_sms_reply_to":"15551234567","premium_sms_reply_at":"` + frisch + `"`,
+			wantState:    model.PremiumSmsStateFresh,
+			wantAllowed:  false, // AC-6: eigenes Tarif-Gate, nicht sms_allowed
+			wantReplyTo:  "15551234567",
+			beschreibung: "Standard-Tier trotz frischer Rueckadresse",
+		},
+	}
+
+	for _, f := range faelle {
+		writeUser(f.id, f.extra)
+		resp := getProfile(f.id)
+
+		state, ok := resp[fieldPremiumReplyState]
+		if !ok {
+			t.Fatalf("%s (%s): Feld %q fehlt in der Profil-Antwort — ohne es kann die Oberflaeche "+
+				"die drei Zustaende nicht unterscheiden.", f.id, f.beschreibung, fieldPremiumReplyState)
+		}
+		if state != f.wantState {
+			t.Errorf("%s (%s): %s = %v, want %q", f.id, f.beschreibung, fieldPremiumReplyState, state, f.wantState)
+		}
+
+		allowed, ok := resp[fieldPremiumAllowed]
+		if !ok {
+			t.Fatalf("%s (%s): Feld %q fehlt in der Profil-Antwort.", f.id, f.beschreibung, fieldPremiumAllowed)
+		}
+		if allowed != f.wantAllowed {
+			t.Errorf("%s (%s): %s = %v, want %v", f.id, f.beschreibung, fieldPremiumAllowed, allowed, f.wantAllowed)
+		}
+
+		if f.wantReplyTo == "" {
+			if _, present := resp[fieldPremiumReplyTo]; present {
+				t.Errorf("%s (%s): %s steht im JSON, obwohl nichts gelernt wurde (omitempty).",
+					f.id, f.beschreibung, fieldPremiumReplyTo)
+			}
+			if _, present := resp[fieldPremiumReplyAt]; present {
+				t.Errorf("%s (%s): %s steht im JSON, obwohl nichts gelernt wurde (omitempty).",
+					f.id, f.beschreibung, fieldPremiumReplyAt)
+			}
+			continue
+		}
+		if resp[fieldPremiumReplyTo] != f.wantReplyTo {
+			t.Errorf("%s (%s): %s = %v, want %q — ohne die Zielnummer kann die Oberflaeche nicht "+
+				"zeigen, WOHIN gesendet wird (AC-4).",
+				f.id, f.beschreibung, fieldPremiumReplyTo, resp[fieldPremiumReplyTo], f.wantReplyTo)
+		}
+		at, ok := resp[fieldPremiumReplyAt].(string)
+		if !ok || at == "" {
+			t.Errorf("%s (%s): %s fehlt oder ist leer (%v) — das Meldedatum ist die Nutzinformation "+
+				"(Muster requested_at, auth.go:461), nicht der abgeleitete Zustand allein.",
+				f.id, f.beschreibung, fieldPremiumReplyAt, resp[fieldPremiumReplyAt])
+		} else if _, err := time.Parse(time.RFC3339, at); err != nil {
+			t.Errorf("%s (%s): %s = %q ist kein RFC3339-Zeitstempel: %v",
+				f.id, f.beschreibung, fieldPremiumReplyAt, at, err)
+		}
+	}
+}
+
+// AC-7: `PUT /api/auth/profile` darf die gelernte Rueckadresse NICHT annehmen.
+// Waere sie editierbar, faellt die S2a-Zusage "Empfaenger ist ausschliesslich die
+// gelernte Rueckadresse" in sich zusammen — ein Nutzer koennte sich eine fremde
+// Nummer eintragen und kostenpflichtige Premium-SMS dorthin schicken lassen.
+// Mutation, die hier rot werden MUSS: die beiden Felder in die Decode-Struct
+// von UpdateProfileHandler (auth.go:541-547) aufnehmen.
+func TestUpdateProfileHandlerIgnoresPremiumSmsReplyFields(t *testing.T) {
+	s := newTestStore(t)
+	dir := filepath.Join(s.DataDir, "users", "nora")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	const gelernt = "15551234567"
+	const gelerntAm = "2026-08-05T12:00:00Z"
+	const untergeschoben = "4999999999"
+
+	userJSON := fmt.Sprintf(
+		`{"id":"nora","tier":"premium","mail_to":"nora@henemm.com",`+
+			`"premium_sms_reply_to":%q,"premium_sms_reply_at":%q}`, gelernt, gelerntAm)
+	if err := os.WriteFile(filepath.Join(dir, "user.json"), []byte(userJSON), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// PUT mit untergeschobener Rueckadresse — zusammen mit einer legitimen
+	// Aenderung, damit der Request ein normaler Profil-Speichervorgang ist.
+	body := fmt.Sprintf(
+		`{"display_name":"Nora","premium_sms_reply_to":%q,"premium_sms_reply_at":"2026-08-11T00:00:00Z"}`,
+		untergeschoben)
+	req := httptest.NewRequest("PUT", "/api/auth/profile", strings.NewReader(body))
+	req = req.WithContext(middleware.ContextWithUserID(req.Context(), "nora"))
+	w := httptest.NewRecorder()
+	UpdateProfileHandler(s, config.Config{}).ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// 1. Persistenz: die gelernten Werte stehen unveraendert in user.json.
+	data, err := os.ReadFile(filepath.Join(dir, "user.json"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var persisted map[string]interface{}
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatalf("unmarshal user.json: %v (%s)", err, data)
+	}
+	if persisted["premium_sms_reply_to"] != gelernt {
+		t.Errorf("AC-7: premium_sms_reply_to = %v, want %q — der Endpoint hat die untergeschobene "+
+			"Nummer uebernommen. Damit koennte ein Nutzer Premium-SMS an eine fremde Nummer "+
+			"schicken lassen. Datei: %s", persisted["premium_sms_reply_to"], gelernt, data)
+	}
+	if strings.Contains(string(data), untergeschoben) {
+		t.Errorf("AC-7: die untergeschobene Nummer %q steht in user.json: %s", untergeschoben, data)
+	}
+	at, _ := persisted["premium_sms_reply_at"].(string)
+	if at == "" {
+		t.Errorf("AC-7: premium_sms_reply_at wurde beim PUT geloescht: %s", data)
+	} else if parsed, err := time.Parse(time.RFC3339, at); err != nil {
+		t.Errorf("AC-7: premium_sms_reply_at = %q unlesbar: %v", at, err)
+	} else if want, _ := time.Parse(time.RFC3339, gelerntAm); !parsed.Equal(want) {
+		t.Errorf("AC-7: premium_sms_reply_at = %q, want %q (Meldezeitpunkt wurde ueberschrieben)", at, gelerntAm)
+	}
+
+	// 2. Die legitime Aenderung ist durchgekommen — der Request war kein No-Op.
+	if persisted["display_name"] != "Nora" {
+		t.Errorf("Vorbedingung: display_name = %v, want \"Nora\" — der PUT hat gar nichts geschrieben, "+
+			"dann beweist der Test oben nichts.", persisted["display_name"])
+	}
+
+	// 3. Lesepfad: GET liefert weiterhin den gelernten Wert.
+	getReq := httptest.NewRequest("GET", "/api/auth/profile", nil)
+	getReq = getReq.WithContext(middleware.ContextWithUserID(getReq.Context(), "nora"))
+	getW := httptest.NewRecorder()
+	GetProfileHandler(s).ServeHTTP(getW, getReq)
+	if getW.Code != 200 {
+		t.Fatalf("GET expected 200, got %d: %s", getW.Code, getW.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(getW.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal GET: %v", err)
+	}
+	if resp[fieldPremiumReplyTo] != gelernt {
+		t.Errorf("AC-7: GET liefert %s = %v, want %q", fieldPremiumReplyTo, resp[fieldPremiumReplyTo], gelernt)
 	}
 }

--- a/internal/model/premium_sms.go
+++ b/internal/model/premium_sms.go
@@ -1,0 +1,63 @@
+package model
+
+// Premium-SMS (Garmin inReach) — Issue #1717 Scheibe S3.
+//
+// Die gelernte Rueckadresse (S1, User.PremiumSmsReplyTo/-At) verfaellt. Der
+// Sendepfad prueft das seit S2a in Python
+// (src/output/channels/premium_sms.py). Damit `GET /api/auth/profile` der
+// Oberflaeche denselben Zustand FERTIG ABGELEITET liefern kann — und die
+// Oberflaeche keine eigene Frist braucht — steht hier das Go-Pendant.
+//
+// Zwei Prozesse, zwei Konstanten: Go-API (Port 8090) und Python-Kern teilen
+// keinen Code. Die Deckungsgleichheit der Zahl bewacht deshalb
+// tests/test_premium_sms_ttl_drift.py (AC-11) — laeuft eine der beiden
+// auseinander, zeigt die Oberflaeche "frisch", wo der Sendepfad schon blockt.
+
+import "time"
+
+// PremiumSmsReplyTTL = Verfallsfrist der gelernten Rueckadresse.
+//
+// GO-PENDANT zu PREMIUM_SMS_REPLY_TTL in src/output/channels/premium_sms.py
+// (dort: timedelta(days=30), Spec D6, PO-Entscheid 2026-08-10). BEIDE Werte
+// gemeinsam aendern — der Drift-Waechter tests/test_premium_sms_ttl_drift.py
+// nennt bei einer Abweichung beide Fundstellen.
+const PremiumSmsReplyTTL = 30 * 24 * time.Hour
+
+// Zustandswerte der gelernten Rueckadresse. Wire-Vertrag mit dem Frontend
+// (`premium_sms_reply_state`, ausgewertet in
+// frontend/src/lib/components/shared/versand-tab/premiumSmsChannelState.ts) —
+// wer sie umbenennt, bricht die Anzeige, ohne dass ein Renderer rot wird.
+const (
+	// PremiumSmsStateNone: das Geraet hat sich noch nie gemeldet.
+	PremiumSmsStateNone = "none"
+	// PremiumSmsStateStale: gemeldet, aber laut Frist verfallen.
+	PremiumSmsStateStale = "stale"
+	// PremiumSmsStateFresh: gemeldet und innerhalb der Frist.
+	PremiumSmsStateFresh = "fresh"
+)
+
+// DerivePremiumSmsReplyState bewertet die gelernte Rueckadresse.
+//
+// Bedingung 1 ist die des Sendepfads (`not reply_to or reply_at is None`,
+// premium_sms.py): fehlt eines von beiden, ist das "noch nie gemeldet" — nicht
+// "veraltet". Als "stale" gemeldet wuerde die Oberflaeche ein Verfallsdatum
+// behaupten, das es nie gab.
+//
+// Bedingung 2 ist die Frist, Semantik wie im Sendepfad: `age > TTL` ist
+// veraltet, genau auf der Frist ist noch frisch.
+//
+// Das Alter wird auf ganze Sekunden abgeschnitten. Der Meldezeitpunkt kommt als
+// RFC3339-Zeitstempel; Bruchteile einer Sekunde sind darin Rauschen und duerfen
+// den Zustand nicht kippen. Ohne das Abschneiden entscheidet die Laufzeit
+// zwischen Lesen des Zeitstempels und Vergleich darueber, ob eine genau auf der
+// Frist stehende Adresse noch gilt.
+func DerivePremiumSmsReplyState(replyTo string, replyAt *time.Time) string {
+	if replyTo == "" || replyAt == nil {
+		return PremiumSmsStateNone
+	}
+	age := time.Since(*replyAt).Truncate(time.Second)
+	if age > PremiumSmsReplyTTL {
+		return PremiumSmsStateStale
+	}
+	return PremiumSmsStateFresh
+}

--- a/internal/model/premium_sms_test.go
+++ b/internal/model/premium_sms_test.go
@@ -1,0 +1,143 @@
+package model
+
+// TDD RED — Issue #1717 (Scheibe S3): Premium-SMS in der Oberflaeche.
+// Spec: docs/specs/modules/feat_1717_s3_premium_sms_ui.md — AC-6 (Tarif-Gate)
+// und die Frist-Ableitung, die `GET /api/auth/profile` fuer die Anzeige
+// braucht (AC-3/AC-5 lesen den fertig abgeleiteten Zustand).
+//
+// Herkunft: in der RED-Phase lag diese Datei ausserhalb von internal/ und wurde
+// per `go test -overlay` eingespielt (der edit_gate laesst in phase5_tdd_red nur
+// Test-Verzeichnisse zu). Seit Phase 6 liegt sie an ihrem Zielort neben dem
+// Code — Assertions unveraendert.
+//
+// RED war: `internal/model/premium_sms.go` existierte nicht — weder
+// `PremiumSmsAllowed`, noch `PremiumSmsReplyTTL`, noch
+// `DerivePremiumSmsReplyState`. Das Paket uebersetzte deshalb nicht.
+//
+// Keine Mocks: echte Funktionsaufrufe, echte time.Time-Werte.
+
+import (
+	"testing"
+	"time"
+)
+
+// Vom Geraet gelernte Garmin-Rueckadresse (S1 schreibt sie). Garmin inReach hat
+// KEINE feste Nummer — der Wert ist beispielhaft, nie eine Konfiguration.
+const testReplyTo = "15551234567"
+
+// AC-6: Das Premium-SMS-Tarif-Gate ist eigenstaendig und laesst ausschliesslich
+// `premium` durch. Es darf NICHT an SmsAllowed delegieren — das laesst
+// `standard` mit durch (tier.go:3-10), und ein standard-Nutzer koennte dann
+// einen Kanal einschalten, den der Sendepfad (S2a AC-8) ohnehin blockt.
+func TestPremiumSmsAllowedExcludesStandardTier(t *testing.T) {
+	// Vorbedingung, damit dieser Test nicht still bedeutungslos wird: das
+	// bestehende SMS-Gate laesst `standard` tatsaechlich durch.
+	if !SmsAllowed("standard") {
+		t.Fatalf("Vorbedingung verletzt: SmsAllowed(\"standard\") = false — dann ist die " +
+			"Unterscheidung, die dieser Test bewacht, gegenstandslos geworden.")
+	}
+
+	faelle := []struct {
+		tier string
+		want bool
+	}{
+		{"premium", true},
+		{"standard", false}, // der Kern von AC-6
+		{"free", false},
+		{"", false},
+		{"Premium", false}, // nur exakt "premium" (EffectiveTier normalisiert vorher)
+	}
+	for _, f := range faelle {
+		if got := PremiumSmsAllowed(f.tier); got != f.want {
+			t.Errorf("PremiumSmsAllowed(%q) = %v, want %v", f.tier, got, f.want)
+		}
+	}
+}
+
+// Die drei Zustandswerte sind ein Vertrag mit dem Frontend
+// (`premium_sms_reply_state`, verarbeitet in premiumSmsChannelState.ts). Wer
+// sie umbenennt, bricht die Anzeige ohne dass ein Renderer-Test rot wird.
+func TestPremiumSmsStateConstantsMatchWireContract(t *testing.T) {
+	faelle := []struct {
+		got  string
+		want string
+	}{
+		{PremiumSmsStateNone, "none"},
+		{PremiumSmsStateStale, "stale"},
+		{PremiumSmsStateFresh, "fresh"},
+	}
+	for _, f := range faelle {
+		if f.got != f.want {
+			t.Errorf("Zustands-Konstante = %q, want %q (Vertrag mit dem Frontend)", f.got, f.want)
+		}
+	}
+}
+
+// Ohne gelernte Rueckadresse ODER ohne Zeitstempel ist der Zustand "none" —
+// genau die Bedingung des Sendepfads (`not reply_to or reply_at is None`,
+// src/output/channels/premium_sms.py:73). Ein Zeitstempel ohne Adresse und eine
+// Adresse ohne Zeitstempel sind beides "noch nie gemeldet", nicht "veraltet":
+// als "stale" gemeldet, wuerde die Oberflaeche ein Verfallsdatum behaupten, das
+// es nie gab.
+func TestDerivePremiumSmsReplyStateNoneWithoutLearnedAddress(t *testing.T) {
+	now := time.Now().UTC()
+
+	faelle := []struct {
+		name    string
+		replyTo string
+		replyAt *time.Time
+	}{
+		{"nichts gelernt", "", nil},
+		{"Zeitstempel ohne Adresse", "", &now},
+		{"Adresse ohne Zeitstempel", testReplyTo, nil},
+	}
+	for _, f := range faelle {
+		if got := DerivePremiumSmsReplyState(f.replyTo, f.replyAt); got != PremiumSmsStateNone {
+			t.Errorf("%s: DerivePremiumSmsReplyState = %q, want %q",
+				f.name, got, PremiumSmsStateNone)
+		}
+	}
+}
+
+// Grenzwert der Frist, relativ zur Konstante gemessen (keine zweite 30 im Test —
+// die Deckungsgleichheit der ZAHL bewacht tests/test_premium_sms_ttl_drift.py,
+// AC-11). Semantik wie im Sendepfad: `age > TTL` ist veraltet, `age == TTL` ist
+// noch frisch (premium_sms.py:81).
+func TestDerivePremiumSmsReplyStateFreshInsideTTL(t *testing.T) {
+	now := time.Now().UTC()
+
+	faelle := []struct {
+		name string
+		age  time.Duration
+	}{
+		{"gerade gemeldet", 0},
+		{"eine Sekunde vor der Frist", PremiumSmsReplyTTL - time.Second},
+		{"genau auf der Frist", PremiumSmsReplyTTL},
+	}
+	for _, f := range faelle {
+		at := now.Add(-f.age)
+		if got := DerivePremiumSmsReplyState(testReplyTo, &at); got != PremiumSmsStateFresh {
+			t.Errorf("%s (Alter %v): DerivePremiumSmsReplyState = %q, want %q",
+				f.name, f.age, got, PremiumSmsStateFresh)
+		}
+	}
+}
+
+func TestDerivePremiumSmsReplyStateStaleOneSecondOutsideTTL(t *testing.T) {
+	now := time.Now().UTC()
+
+	faelle := []struct {
+		name string
+		age  time.Duration
+	}{
+		{"eine Sekunde nach der Frist", PremiumSmsReplyTTL + time.Second},
+		{"deutlich nach der Frist", PremiumSmsReplyTTL + 400*24*time.Hour},
+	}
+	for _, f := range faelle {
+		at := now.Add(-f.age)
+		if got := DerivePremiumSmsReplyState(testReplyTo, &at); got != PremiumSmsStateStale {
+			t.Errorf("%s (Alter %v): DerivePremiumSmsReplyState = %q, want %q",
+				f.name, f.age, got, PremiumSmsStateStale)
+		}
+	}
+}

--- a/internal/model/tier.go
+++ b/internal/model/tier.go
@@ -9,6 +9,21 @@ func SmsAllowed(tier string) bool {
 	return smsAllowedTiers[tier]
 }
 
+// PremiumSmsAllowed — Issue #1717 Scheibe S3, eigenstaendiges Tarif-Gate fuer
+// Premium-SMS (Garmin inReach).
+//
+// BEWUSST KEINE Delegation an SmsAllowed: das laesst `standard` mit durch
+// (smsAllowedTiers oben). Ein standard-Nutzer koennte den Kanal dann in der
+// Oberflaeche einschalten, obwohl der Sendepfad ihn ohnehin sperrt (S2a AC-8) —
+// eine Checkbox, die etwas verspricht, das serverseitig nie passiert.
+// Python-Vorbild: premium_sms_allowed() (S2a).
+//
+// Erwartet einen bereits normalisierten Tier (EffectiveTier) — nur exakt
+// "premium" ist erlaubt.
+func PremiumSmsAllowed(tier string) bool {
+	return tier == "premium"
+}
+
 // EffectiveTier normalisiert den gespeicherten Tier-Wert am Lesezeitpunkt auf
 // free/standard/premium.
 //

--- a/internal/model/trip.go
+++ b/internal/model/trip.go
@@ -161,6 +161,9 @@ type Trip struct {
 	SendEmail      *bool   `json:"send_email,omitempty"`
 	SendSms        *bool   `json:"send_sms,omitempty"`
 	SendTelegram   *bool   `json:"send_telegram,omitempty"`
+	// SendPremiumSms — Issue #1717 S3, viertes Kanal-Flach-Feld (Premium-SMS,
+	// Garmin inReach). Wie die drei darueber: abgeleitet, nicht autoritativ.
+	SendPremiumSms *bool `json:"send_premium_sms,omitempty"`
 	// EndDate — max(stage.date), ISO-normalisiert (analog Python @property
 	// trip.end_date). Kein Roundtrip-Verlustrisiko wie bei Corridors, da
 	// Struct-Feld (nicht Extra-Map).

--- a/internal/store/trip.go
+++ b/internal/store/trip.go
@@ -67,6 +67,7 @@ func deriveFlatFields(trip *model.Trip) {
 	trip.SendEmail = nil
 	trip.SendSms = nil
 	trip.SendTelegram = nil
+	trip.SendPremiumSms = nil
 	trip.EndDate = nil
 
 	if rc := trip.ReportConfig; rc != nil {
@@ -84,6 +85,13 @@ func deriveFlatFields(trip *model.Trip) {
 		}
 		if v, ok := rc["send_telegram"].(bool); ok {
 			trip.SendTelegram = &v
+		}
+		// Issue #1717 S3: viertes Kanal-Feld (Premium-SMS). Kein neuer
+		// Schreibpfad — der Client schickt weiterhin
+		// report_config.send_premium_sms, mergeConfigMap transportiert es
+		// generisch.
+		if v, ok := rc["send_premium_sms"].(bool); ok {
+			trip.SendPremiumSms = &v
 		}
 		if v, ok := rc["enabled"].(bool); ok {
 			trip.MorningEnabled = &v

--- a/internal/store/trip_flat_fields_test.go
+++ b/internal/store/trip_flat_fields_test.go
@@ -203,3 +203,136 @@ func TestLoadTrip_EndDateNotStaleWhenStagesClearedToEmpty(t *testing.T) {
 		t.Errorf("SendSms nach Reload = %v, want nil (stale von Platte gelesen!)", *reloaded.SendSms)
 	}
 }
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Issue #1717 (Scheibe S3): Premium-SMS in der Oberflaeche — AC-8.
+// Spec: docs/specs/modules/feat_1717_s3_premium_sms_ui.md.
+//
+// Herkunft: in der RED-Phase lagen die beiden Funktionen ausserhalb von
+// internal/ und wurden per `go test -overlay` eingespielt (der edit_gate laesst
+// in phase5_tdd_red nur Test-Verzeichnisse zu). Seit Phase 6 stehen sie hier
+// neben ihren Vorbildern — Assertions unveraendert.
+//
+// RED war: `model.Trip` hatte kein Feld `SendPremiumSms` und `deriveFlatFields`
+// leitete es nicht ab — das Paket uebersetzte nicht.
+// ══════════════════════════════════════════════════════════════════════════════
+
+// AC-8, erste Haelfte: das Flach-Feld wird aus report_config abgeleitet, und die
+// Ableitung veraendert report_config nicht (sie bleibt die einzige Wahrheit fuer
+// den Versand).
+func TestLoadTrip_DerivesSendPremiumSmsFromReportConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	s := New(tmpDir, "test")
+
+	trip := model.Trip{
+		ID:   "premium-sms-trip",
+		Name: "Premium-SMS Trip",
+		Stages: []model.Stage{
+			{ID: "S1", Name: "Etappe 1", Date: "2026-08-10"},
+		},
+		ReportConfig: map[string]interface{}{
+			"trip_id":          "premium-sms-trip",
+			"enabled":          true,
+			"morning_time":     "07:00:00",
+			"send_email":       true,
+			"send_sms":         false,
+			"send_telegram":    false,
+			"send_premium_sms": true,
+		},
+	}
+	if err := s.SaveTrip(&trip); err != nil {
+		t.Fatalf("SaveTrip failed: %v", err)
+	}
+
+	loaded, err := s.LoadTrip("premium-sms-trip")
+	if err != nil {
+		t.Fatalf("LoadTrip failed: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected trip, got nil")
+	}
+	if loaded.SendPremiumSms == nil || *loaded.SendPremiumSms != true {
+		t.Errorf("SendPremiumSms = %v, want true (abgeleitet aus report_config.send_premium_sms)",
+			loaded.SendPremiumSms)
+	}
+	// Gegenprobe: `false` muss von "nicht gesetzt" (nil) unterscheidbar bleiben.
+	if loaded.SendSms == nil || *loaded.SendSms != false {
+		t.Errorf("SendSms = %v, want false — Pointer-Semantik (nil != false) muss erhalten bleiben",
+			loaded.SendSms)
+	}
+
+	// report_config bleibt unveraendert auf Platte.
+	written, err := os.ReadFile(filepath.Join(tmpDir, "users", "test", "briefings", "premium-sms-trip.json"))
+	if err != nil {
+		t.Fatalf("read written: %v", err)
+	}
+	var onDisk map[string]interface{}
+	if err := json.Unmarshal(written, &onDisk); err != nil {
+		t.Fatalf("unmarshal written: %v", err)
+	}
+	rc, ok := onDisk["report_config"].(map[string]interface{})
+	if !ok {
+		t.Fatal("report_config fehlt oder falscher Typ im geschriebenen File")
+	}
+	if rc["send_premium_sms"] != true {
+		t.Errorf("report_config.send_premium_sms wurde durch die Ableitung veraendert: %v", rc)
+	}
+}
+
+// AC-8, zweite Haelfte: verschwindet die Quelle, verschwindet der abgeleitete
+// Wert — in-memory UND nach dem Reload von Platte. Mutation, die hier rot werden
+// MUSS: die Reset-Zeile `trip.SendPremiumSms = nil` im Reset-Block von
+// deriveFlatFields (internal/store/trip.go:63-70) weglassen. Ohne sie bleibt ein
+// stiller Altwert stehen (Fix-Loop F001 aus #1250 S4) — die Oberflaeche zeigt
+// dann einen kostenpflichtigen Kanal als aktiv, den niemand mehr konfiguriert hat.
+func TestLoadTrip_SendPremiumSmsResetToNilWhenReportConfigMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	s := New(tmpDir, "test")
+
+	trip := model.Trip{
+		ID:   "premium-sms-stale-trip",
+		Name: "Premium-SMS Stale Trip",
+		Stages: []model.Stage{
+			{ID: "S1", Name: "Etappe 1", Date: "2026-08-10"},
+		},
+		ReportConfig: map[string]interface{}{
+			"trip_id":          "premium-sms-stale-trip",
+			"enabled":          true,
+			"send_premium_sms": true,
+		},
+	}
+	if err := s.SaveTrip(&trip); err != nil {
+		t.Fatalf("SaveTrip (befuellt) failed: %v", err)
+	}
+
+	loaded, err := s.LoadTrip("premium-sms-stale-trip")
+	if err != nil {
+		t.Fatalf("LoadTrip (befuellt) failed: %v", err)
+	}
+	if loaded == nil || loaded.SendPremiumSms == nil || *loaded.SendPremiumSms != true {
+		t.Fatalf("Sanity: SendPremiumSms nach befuelltem Save/Load = %v, want true", loaded)
+	}
+
+	// Quelle entziehen (Trip ohne Report-Konfiguration) und speichern.
+	loaded.ReportConfig = nil
+	if err := s.SaveTrip(loaded); err != nil {
+		t.Fatalf("SaveTrip (geleert) failed: %v", err)
+	}
+
+	if loaded.SendPremiumSms != nil {
+		t.Errorf("In-memory SendPremiumSms nach Entfernen von report_config = %v, want nil (stale!)",
+			*loaded.SendPremiumSms)
+	}
+
+	reloaded, err := s.LoadTrip("premium-sms-stale-trip")
+	if err != nil {
+		t.Fatalf("LoadTrip (geleert) failed: %v", err)
+	}
+	if reloaded == nil {
+		t.Fatal("expected trip, got nil")
+	}
+	if reloaded.SendPremiumSms != nil {
+		t.Errorf("SendPremiumSms nach Reload = %v, want nil (stale von Platte gelesen!)",
+			*reloaded.SendPremiumSms)
+	}
+}

--- a/tests/tdd/test_765_backend_hygiene_compliance.py
+++ b/tests/tdd/test_765_backend_hygiene_compliance.py
@@ -99,6 +99,20 @@ _SELF_EXEMPT = {
     # test_egress_inventory_drift.py; # doc-compliance-test.
     # Spec: docs/specs/modules/fix_1435_e5_alert_mapping_unify.md
     "test_alert_metric_mapping_parity.py",
+    # #1717 S3 AC-11 (Tech-Lead-Freigabe 2026-08-11): Frist-Drift-Waechter der
+    # gelernten Premium-SMS-Rueckadresse. Liest internal/model/premium_sms.go
+    # als DATEN, um die Go-Konstante PremiumSmsReplyTTL gegen das per echtem
+    # Import geladene PREMIUM_SMS_REPLY_TTL (src/output/channels/premium_sms.py)
+    # zu stellen — eine Go-Konstante ist aus Python nur als Text erreichbar
+    # (kein Go-Toolchain-Aufruf im Kernlauf). Geprueft wird Deckungsgleichheit
+    # zweier Fristen, nicht das Vorkommen eines Code-Strings; gleiche
+    # Werkzeug-Klasse wie test_egress_inventory_drift.py, traegt
+    # # doc-compliance-test seit seiner Einfuehrung.
+    # Berechtigung endet mit der Doppelung: sobald die Frist nur noch an EINER
+    # Stelle deklariert ist (Go-Ableitung oder Python-Sendepfad faellt weg),
+    # gehoert dieser Eintrag wieder raus.
+    # Spec: docs/specs/modules/feat_1717_s3_premium_sms_ui.md
+    "test_premium_sms_ttl_drift.py",
 }
 # #1408 F005 / #1469: `test_validator_log_unique_filenames.py` stand hier als
 # ausdruecklicher FEHLALARM-Eintrag, weil `_collect_listed_product_paths()`

--- a/tests/test_premium_sms_ttl_drift.py
+++ b/tests/test_premium_sms_ttl_drift.py
@@ -1,0 +1,167 @@
+# doc-compliance-test
+"""Frist-Drift-Waechter Python <-> Go fuer die gelernte Premium-SMS-Rueckadresse.
+
+Issue #1717 (Scheibe S3), AC-11. Spec:
+docs/specs/modules/feat_1717_s3_premium_sms_ui.md.
+
+Werkzeug-Klasse (CLAUDE.md-Ausnahme ``# doc-compliance-test``, Vorbild
+``tests/test_egress_inventory_drift.py``): dieser Laeufer liest
+``internal/model/premium_sms.go`` als DATEN fuer eine Inventar-Regel (decken
+sich die beiden Fristen?), nicht als Verhaltensnachweis auf Code-Strings. Aus
+Python ist eine Go-Konstante nur als Text erreichbar; die Python-Seite kommt
+bewusst ueber den echten Import, damit sie nicht durch einen Parser-Fehler
+stillschweigend falsch gelesen werden kann.
+
+Warum ein AC und keine Fussnote: die Verfallsfrist existiert nach S3
+zwangsläufig zweimal — im Python-Sendepfad (``PREMIUM_SMS_REPLY_TTL``,
+``src/output/channels/premium_sms.py``) und in der neuen Go-Ableitung, die
+``GET /api/auth/profile`` fuer die Oberflaeche berechnet. Aendert eine Sitzung
+nur eine der beiden Zahlen, zeigt die Oberflaeche "frisch", waehrend der
+Sendepfad genau dieselbe Rueckadresse schon blockt — eine Anzeige, die der
+Wirklichkeit widerspricht, ist schlechter als keine.
+
+Erwartung in dieser Phase (TDD RED): ``internal/model/premium_sms.go``
+existiert noch nicht -> ROT.
+
+Pfadregel #1409: der Pruefling wird relativ zu DIESER Datei aufgeloest.
+"""
+from __future__ import annotations
+
+import re
+from datetime import timedelta
+from pathlib import Path
+
+from output.channels.premium_sms import PREMIUM_SMS_REPLY_TTL
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GO_SOURCE = REPO_ROOT / "internal" / "model" / "premium_sms.go"
+
+#: Deklarationsform in der Go-Quelle:
+#:     PremiumSmsReplyTTL = 30 * 24 * time.Hour
+_GO_TTL = re.compile(
+    r"PremiumSmsReplyTTL\s*(?:time\.Duration\s*)?=\s*(?P<expr>[0-9A-Za-z_.*\s]+)"
+)
+
+#: time-Einheiten, die als Faktor auftreten duerfen.
+_GO_UNITS = {
+    "time.Nanosecond": timedelta(microseconds=0.001),
+    "time.Microsecond": timedelta(microseconds=1),
+    "time.Millisecond": timedelta(milliseconds=1),
+    "time.Second": timedelta(seconds=1),
+    "time.Minute": timedelta(minutes=1),
+    "time.Hour": timedelta(hours=1),
+}
+
+
+def _parse_go_duration(expr: str) -> timedelta:
+    """Rechnet einen Go-Duration-Ausdruck wie ``30 * 24 * time.Hour`` aus.
+
+    Erlaubt sind ganzzahlige Faktoren und GENAU eine ``time.*``-Einheit. Alles
+    andere ist ein Fehler und wird gemeldet statt stillschweigend als 0
+    interpretiert -- sonst waere der Waechter gruen, weil er nichts versteht.
+    """
+    faktor = 1
+    einheit: timedelta | None = None
+    for teil in (t.strip() for t in expr.split("*")):
+        if not teil:
+            raise ValueError(f"Leerer Faktor in Go-Ausdruck: {expr!r}")
+        if teil in _GO_UNITS:
+            if einheit is not None:
+                raise ValueError(f"Mehr als eine time-Einheit in {expr!r}")
+            einheit = _GO_UNITS[teil]
+            continue
+        if not teil.isdigit():
+            raise ValueError(f"Unverstaendlicher Faktor {teil!r} in {expr!r}")
+        faktor *= int(teil)
+    if einheit is None:
+        raise ValueError(f"Keine time-Einheit in {expr!r}")
+    return faktor * einheit
+
+
+def _extract_go_ttl(text: str) -> timedelta:
+    """Liest die Go-Frist aus dem Quelltext.
+
+    Jede Zeile wird am ERSTEN ``//`` abgeschnitten und nur der Teil DAVOR
+    geprueft (Vorbild egress-Drift-Waechter F002): eine auskommentierte
+    Deklaration zaehlt nicht, ein Inline-Kommentar hinter einer echten
+    Deklaration stoert nicht.
+    """
+    treffer: list[str] = []
+    for line in text.splitlines():
+        code = line.split("//", 1)[0]
+        m = _GO_TTL.search(code)
+        if m:
+            treffer.append(m.group("expr"))
+    if not treffer:
+        raise AssertionError(
+            "Keine Deklaration von PremiumSmsReplyTTL in "
+            f"{GO_SOURCE.relative_to(REPO_ROOT)} gefunden — dann leitet die "
+            "Go-Seite den Zustand der gelernten Rueckadresse ohne Frist ab."
+        )
+    if len(treffer) > 1:
+        raise AssertionError(
+            f"PremiumSmsReplyTTL ist {len(treffer)}-mal deklariert: {treffer} — "
+            "genau eine Quelle je Prozess, sonst driften schon die Go-Kopien."
+        )
+    return _parse_go_duration(treffer[0])
+
+
+def test_go_und_python_frist_sind_deckungsgleich():
+    """GIVEN je eine Verfallsfrist der gelernten Rueckadresse in Python und Go
+    WHEN eine der beiden Zahlen geaendert wird, die andere nicht
+    THEN schlaegt dieser Test rot und benennt beide Fundstellen.
+    """
+    assert GO_SOURCE.exists(), (
+        f"Go-Quelle fehlt: {GO_SOURCE.relative_to(REPO_ROOT)} — dort gehoert "
+        "PremiumSmsReplyTTL hin (Go-Pendant zu PREMIUM_SMS_REPLY_TTL in "
+        "src/output/channels/premium_sms.py). Ohne sie kann GET /api/auth/profile "
+        "den Zustand der Rueckadresse nicht ableiten (Issue #1717 AC-11)."
+    )
+
+    go_ttl = _extract_go_ttl(GO_SOURCE.read_text(encoding="utf-8"))
+
+    assert go_ttl == PREMIUM_SMS_REPLY_TTL, (
+        "Verfallsfrist der gelernten Premium-SMS-Rueckadresse ist auseinander "
+        f"gelaufen: Go ({GO_SOURCE.relative_to(REPO_ROOT)}: PremiumSmsReplyTTL) "
+        f"= {go_ttl}, Python (src/output/channels/premium_sms.py: "
+        f"PREMIUM_SMS_REPLY_TTL) = {PREMIUM_SMS_REPLY_TTL}. Die Oberflaeche "
+        "wuerde damit 'frisch' anzeigen, wo der Sendepfad schon blockt (oder "
+        "umgekehrt). Beide Werte angleichen — nicht einen."
+    )
+
+
+def test_go_duration_parser_versteht_was_er_liest():
+    """GIVEN der Waechter liest die Go-Seite als Text
+    WHEN der Ausdruck ein anderer ist als erwartet
+    THEN faellt das auf, statt still als 0 durchzugehen.
+
+    Ohne diese Gegenprobe koennte der Drift-Test gruen bleiben, weil der Parser
+    nichts findet und trotzdem etwas vergleicht -- derselbe blinde Fleck, den
+    F002 beim egress-Inventar hatte.
+    """
+    assert _parse_go_duration("30 * 24 * time.Hour") == timedelta(days=30)
+    assert _parse_go_duration(" 7*24*time.Hour ") == timedelta(days=7)
+    assert _parse_go_duration("90 * time.Minute") == timedelta(minutes=90)
+
+    for kaputt in ("30 * 24", "30 * 24 * time.Hour * time.Minute", "dreissig * time.Hour"):
+        try:
+            _parse_go_duration(kaputt)
+        except ValueError:
+            continue
+        raise AssertionError(
+            f"Parser hat {kaputt!r} stillschweigend akzeptiert — dann bewacht er nichts."
+        )
+
+
+def test_go_ttl_extraktion_ignoriert_auskommentierte_deklaration():
+    """GIVEN eine auskommentierte Deklaration und ein Inline-Kommentar
+    WHEN die Go-Quelle geparst wird
+    THEN zaehlt nur die echte Deklaration (F002-Lehre).
+    """
+    text = (
+        "package model\n"
+        "\n"
+        "// PremiumSmsReplyTTL = 7 * 24 * time.Hour  // alter Wert, ersetzt\n"
+        "const PremiumSmsReplyTTL = 30 * 24 * time.Hour // siehe premium_sms.py\n"
+    )
+    assert _extract_go_ttl(text) == timedelta(days=30)


### PR DESCRIPTION
## Was diese Scheibe leistet

Premium-SMS war seit #1676 S2a ein **lebender** Versandkanal, aber nur über die API schaltbar. Der
Nutzer konnte ihn nicht selbst ein- oder ausschalten und sah nicht, **wohin** gesendet wird. Auf
Tour war damit nicht unterscheidbar, ob der Kanal aus ist, keine Rückadresse gelernt wurde oder sie
veraltet ist — obwohl das Backend diese drei Fälle bereits unterscheidet.

Jetzt: Kanal schaltbar, Zielnummer und Meldezeitpunkt sichtbar, die drei Zustände paarweise
unterscheidbar, eigenes Tarif-Gate.

## Die tragende Entscheidung: der Server urteilt, nicht die Oberfläche

`GET /api/auth/profile` liefert `premium_sms_reply_state` als **fertig abgeleiteten** Wert; der
Frontend-Helfer folgt ihm und rechnet **nichts** nach.

Würde die Oberfläche selbst rechnen, gäbe es zwei Fristen — und driften sie auseinander, zeigt die
Anzeige „frisch", während der Sendepfad blockt. **Eine Anzeige, die der Wirklichkeit widerspricht,
ist schlechter als keine**, besonders dort, wo es keine zweite Quelle gibt.

Weil die Frist dadurch zwangsläufig zweimal existiert (Python-Sendepfad, Go-Ableitung — getrennte
Prozesse), bewacht `tests/test_premium_sms_ttl_drift.py` beide gegeneinander. Der Spec-Entwurf hatte
diese Doppelung als **hingenommenes Risiko** geführt; das wurde zurückgewiesen — genau dieser Drift
ist der Fehler, den die Scheibe verhindern soll. Muster und Werkzeug-Klasse lagen vor
(`test_egress_inventory_drift.py`, #1337): es war ein Test, kein Neubau.

## Weitere Entscheidungen, die eine Begründung brauchen

**Die Zustandslogik existiert genau einmal** — im geteilten Helfer `premiumSmsChannelState.ts`,
aufgerufen von Trip-Detail **und** Trip-Anlage. Eine dritte Kopie wäre der Default-Fehler gewesen:
die Kanal-Herleitung steht in diesen zwei Komponenten schon wörtlich doppelt (vorbestehend, #1199).

**Schaltbar nur im Trip-Briefing, nicht im Ortsvergleich.** Dort konnte der Kanal zum Zeitpunkt
dieser Scheibe nichts — ein Schalter wäre eine Lüge gewesen.

**Der Zeitstempel wird roh ausgegeben** (Muster `RequestedAt`), nicht als abgeleiteter Bool. Bei
`EmailVerified` ist das Gegenteil richtig — dort verlangt AC-20 ausdrücklich, dass der Rohwert nie
nach außen geht. Hier **ist** der Zeitstempel die Nutzinformation: „zuletzt gemeldet am …" ist das,
woran man erkennt, ob man der Anzeige trauen kann.

**Eigenes Tarif-Gate** `PremiumSmsAllowed` — keine Delegation an `SmsAllowed`, das lässt `standard`
durch. Wiederverwendung wäre eine stille Rechteausweitung gewesen.

**`UpdateProfileHandler` bleibt unangetastet:** die gelernte Rückadresse ist rein lesend, schreibbar
allein durch den internen Lernpfad aus S1.

**Der Kanalzähler zählt Premium-SMS mit.** Wer nur diesen Kanal einschaltete, sah vorher „Kein Kanal
aktiv", während das Briefing hinausging.

## Ein Bestandsfehler, nebenbei behoben

Der Leerzustand war im serverseitigen Rendern **überhaupt nicht erreichbar**, weil `onMount` dort
nie läuft und `send_email` beim Rendern immer `true` war — ein Test darauf wäre grün gewesen, ohne
etwas zu prüfen. Die Kanal-Flags werden jetzt beim Erzeugen aus `report_config` gelesen. Folge
darüber hinaus: ein Trip ohne E-Mail zeigt im ersten Rahmen nicht mehr fälschlich „E-Mail angehakt".

## Gate-Ausnahme, bewusst und begründet

Der Frist-Wächter liest die Go-Quelle als **Daten** und wird deshalb vom Hygiene-Gate geflaggt.
Eintrag in dessen `_SELF_EXEMPT` — die Liste ist genau für diese Werkzeug-Klasse gebaut, trägt sechs
begründete Präzedenzfälle (darunter das hier zitierte Vorbild) und wird gepflegt (ein Fehlalarm-
Eintrag wurde später wieder entfernt). Der neue Eintrag trägt seine **Verfallsbedingung** im
Kommentar: sobald die Frist nur noch an einer Stelle steht, gehört er raus.

## Nachweis

- **12 ACs**, Adversary **VERIFIED** nach zwei Runden mit **16 tatsächlich ausgeführten Mutationen**
  (12 aus der Spec-Tabelle, 4 eigene). Mutationen per String-Ersetzung mit externer Sicherung und
  `md5sum`-Kontrolle — kein git-Befehl, weil 22 Dateien unkommittet im Worktree lagen.
- Frontend **2520 grün / 0 rot**, **13 Go-Pakete** ok, **893 Python-Tests**, `svelte-check`
  unverändert zur Baseline.

**Vier Spec-Fehler wurden im Prozess gefunden und korrigiert**, jeder mit Herkunft in der Spec
vermerkt: ein Prüfort lag an einer Naht, an der die vorgeschriebene Mutation unsichtbar geblieben
wäre · ein Kriterium verbot die eigene Empfehlung · eine Zusicherung war per Bauart am eigenen
Prüfort nicht messbar · eine Mutations-Vorschrift war ein Go-No-Op und bewies dadurch nichts.

## Nicht in dieser Scheibe

- **#1701** (Alarm-/Vergleichspfad) — inzwischen selbst geliefert
- **#1702** (Kostenstelle)
- **#1199** — `/trips/new` auf den geteilten Versand-Reiter umstellen
- **#1738** — Adversary-Befund F002, **gebucht statt mitbehoben:** auf der Trip-Anlage hängt der
  Premium-SMS-Block in einer Bedingung für die SMS-**Wetter-Metrik**; eine unverwandte
  Anzeige-Einstellung kann den Schalter also verbergen. Vorbestehend seit #1069, durch diese Scheibe
  erst folgenreich.

## Ausdrücklich NICHT bewiesen

Dass eine so eingeschaltete Premium-SMS **auf dem Gerät** ankommt. Das bleibt **#1533**. Ein grüner
Lauf hier heißt: Kanal schaltbar, Zustand ablesbar, kein Zustand still verschwiegen — nicht
„angekommen".

Refs #1717

🤖 Generated with [Claude Code](https://claude.com/claude-code)
