### PR TITLE
docs(#1724): ADR-Sektion der Spec auf das kanonische Feldformat bringen

### DIFF
--- a/docs/specs/modules/fix_1724_faelligkeit_in_der_ortszone.md
+++ b/docs/specs/modules/fix_1724_faelligkeit_in_der_ortszone.md
@@ -191,8 +191,9 @@ CLAUDE.md: ein grüner Testlauf beweist nur, dass die Tests durchlaufen.
 
 ## Architektur-Entscheidung (ADR)
 
-ADR-0051 (Regel 2: Zone an den Daten), ADR-0044 (Kalendertag folgt der Ortszeit). Diese Spec
-führt beide im Briefing-Pfad aus, ohne von ihnen abzuweichen.
+- **ADR-Nr.:** ADR-0051, ADR-0044
+- **Rationale:** ADR-0051 (Regel 2: Zone an den Daten), ADR-0044 (Kalendertag folgt der
+  Ortszeit). Diese Spec führt beide im Briefing-Pfad aus, ohne von ihnen abzuweichen.
 
 ## Changelog
 


### PR DESCRIPTION
Die Sektion `## Architektur-Entscheidung (ADR)` nannte ADR-0051 und ADR-0044 nur
im Fliesstext. `workflow.py` (`_adr_gate`, Zeile 455) sucht dort die kanonische
Zeile `**ADR-Nr.:** <wert>` und blockt ohne sie den Workflow-Abschluss —
gemessen beim Ausliefern von #1724.

Inhaltlich unveraendert: dieselben zwei ADRs, dieselbe Begruendung, nur als
`**ADR-Nr.:**` + `**Rationale:**` statt als Absatz.

Betrifft auch die Folge-Scheiben: #1725 und #1726 bauen auf dieser Spec auf und
waeren in dasselbe Gate gelaufen.

Reine Doku, kein Code beruehrt.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
