### PR TITLE
fix(#1719 S2): Kanal-Ebene schneidet die Grundauswahl, statt sie zu ersetzen

### DIFF
--- a/docs/context/fix-1719-s2-kaskade-verfeinerung.md
+++ b/docs/context/fix-1719-s2-kaskade-verfeinerung.md
@@ -1,0 +1,341 @@
+<!-- Kontext-Dokument zu Issue #1719 Scheibe S2 (Backend-Verfeinerung).
+     Erhoben 2026-08-11 auf Basis-Commit 32b781ed (Merge PR #1735 = S1).
+     S1 (ADR-0050 + Pruefstand) ist geliefert; S3 (Frontend) und S4 (Legende)
+     sind spaetere Scheiben. -->
+
+# Context: Metrik-Kaskade — die Kanal-Ebene schneidet die Grundauswahl, statt sie zu ersetzen (#1719 Scheibe S2)
+
+## Request Summary
+
+`UnifiedWeatherDisplayConfig.get_metrics_for_channel()` waehlt heute **eine**
+Kaskadenebene aus und gibt sie **vollstaendig** zurueck; eine Kanal-Ebene
+ersetzt damit die Grundauswahl komplett und kann eine global abgewaehlte
+Metrik wieder scharfschalten. ADR-0050 legt das Gegenteil fest: die
+Grundauswahl ist das Maximum, ein Kanal darf nur abwaehlen. S2 baut den
+Lesepfad auf diese Verfeinerungs-Semantik um, sodass der in S1 gebaute
+Pruefstand-Test AC-7 (`xfail(strict=True)`) gruen wird und seine Markierung
+entfaellt.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/app/models.py:825-863` | **Der Wirkort.** `get_metrics_for_channel()` — dreistufige Auswahl (per_report > per_channel > global), jede Stufe gibt ihre Liste ungeschnitten zurueck |
+| `src/app/models.py:670-703` | `_filter_metrics_by_report_type()` — gemeinsamer Filter fuer morning/evening-Flags + `selectable`-Gate (#1585). Definiert, was „global aktiv fuer diesen Report-Typ" heisst |
+| `src/app/models.py:712-734` | `_cascade_source_for_channel()` — geteilte Ebenen-Erkennung, genutzt von `get_metrics_for_channel()` UND `cascade_source_for_channel()`. Seit #1677 DEC-2 gibt es keine zweite Kopie der drei if-Zweige |
+| `src/output/renderers/trip_report.py:126-139` | **Die Falle.** `dataclasses.replace(dc, metrics=active_metrics)` ersetzt die Grundauswahl durch die E-Mail-Auswahl (und zwingt alles auf `enabled=True`). Ab hier „luegt" `dc` ueber die eigene Grundauswahl |
+| `src/output/renderers/trip_report.py:132, 295, 301` | `_dc_uncollapsed` — die in #1575 eingefuehrte Absicherung, damit SMS die Kollabierung nicht mitbekommt. Vorbild fuer das, was Telegram fehlt |
+| `src/output/renderers/trip_report.py:256-276` | Uebergibt `dc=dc` (die **kollabierte** Instanz) an `render_telegram_bubbles` |
+| `src/output/renderers/narrow.py:661` | `render_for_channel("telegram", dc, report_type)` — laeuft damit auf der kollabierten `dc` |
+| `src/output/renderers/channel_layout.py:86-90` | `render_for_channel()` — einziger Telegram-Tabellen-Einstieg in die Kaskade, erbt jede Aenderung automatisch |
+| `api/routers/validator.py:141-159, 292` | Validator-Endpoint `/api/_validator/metrics-for-channel`; delegiert an die echten Methoden, erbt automatisch |
+| `src/app/loader.py:758` | `data.get("metrics") or []` — eine fehlende globale Liste wird zu `[]`, nicht katalog-aufgefuellt |
+| `src/app/loader.py:836-871` | Parse-Zweig `channel_layouts` — erzeugt `per_channel_layouts`; fehlt der Schluessel, bleibt `None` (Rueckfall auf global) |
+| `tests/tdd/test_channel_metric_matrix.py:820-846` | **AC-7**, `xfail(strict=True)`, Ziel `dewpoint` (global AUS, SMS-Ebene AN). Wird S2 gruen, meldet `strict` die abgelaufene Ausnahme selbst |
+| `tests/fixtures/metric_cascade/khw_display_config_widerspruch.json` | Anonymisierte Fixture: 26 globale Metriken, `channel_layouts.sms` mit 26 Eintraegen, davon `wind_chill`/`cape` abgewaehlt. Enthaelt **keinen** hinzufuegenden Fall — AC-7 konstruiert ihn |
+| `docs/adr/0050-metrik-kaskade-verfeinerung-nicht-ersetzung.md` | Die Zusage, gegen die S2 gebaut wird |
+
+## Gemessene Befunde (2026-08-11)
+
+### 1. Bestandsdaten: der verbotene Zustand kommt in Produktion nicht vor
+
+Datenwurzel ist ausschliesslich `/var/lib/gregor` (`GZ_DATA_DIR` der
+Produktions-Units; `loader.py:1084-1101` bestaetigt die Aufloesung). Trip-
+Konfiguration liegt unter `users/<uid>/briefings/<id>.json`; der frueher
+genutzte `trips/`-Ordner ist dort bereits als tot umbenannt.
+
+| Pruefung | Ergebnis |
+|---|---|
+| `display_config`-Traeger insgesamt (4 Nutzer) | 16 |
+| davon mit non-leerem `channel_layouts` | 2 |
+| mit `channel_layouts_per_report` | 0 |
+| **verbotener Widerspruch** (global `false` + Kanal `true`) | **0** |
+| erlaubte Gegenrichtung (global `true` + Kanal `false`) | sms 2, telegram 1 |
+
+**Folge:** Die im Issue-Text vorgesehene einmalige Zusammenfuehrung von
+Bestandstrips hat kein Migrationsvolumen. Ein Schnitt im Lesepfad genuegt.
+Der Verzicht ist damit gemessen begruendet, nicht angenommen.
+
+**Sonderfall ohne Handlungsbedarf:** Compare-Preset `cp-eb6ba0b239d90e37`
+traegt `channel_layouts` (je 24 Metriken) **ohne** globale `metrics`-Liste —
+aelteres Schema mit `active_metrics`. Da der Ortsvergleich die Kaskade gar
+nicht benutzt (s. Befund 3), ist diese Datenlage inert. Der Fall bleibt
+trotzdem als Regel relevant (s. Befund 4).
+
+### 2. Der Telegram-Pfad laeuft auf einer kollabierten Grundauswahl
+
+`trip_report.py:138` ersetzt `dc.metrics` durch die aufgeloeste **E-Mail**-
+Auswahl. `trip_report.py:259` reicht genau diese Instanz an
+`render_telegram_bubbles` weiter, das bei `narrow.py:661`
+`render_for_channel("telegram", dc, report_type)` aufruft. Die Dicts
+`per_channel_layouts`/`per_report_layouts` ueberleben `dataclasses.replace`
+unveraendert — nur `metrics` ist ersetzt.
+
+Heute faellt das nicht auf: der `per_channel`-Zweig liest `self.metrics`
+ueberhaupt nicht. **Sobald S2 gegen `self.metrics` schneidet, schneidet
+Telegram gegen die E-Mail-Auswahl** (`Telegram ∩ E-Mail`). Eine Metrik, die
+fuer Telegram gewaehlt und fuer E-Mail abgewaehlt ist, verschwaende still —
+aus dem Bugfix wuerde ein neuer Bug derselben Familie.
+
+Fuer SMS ist diese Falle in #1575 bereits getreten und mit `_dc_uncollapsed`
+(`trip_report.py:132`) umschifft worden. Telegram hat diese Absicherung nicht.
+
+### 3. Nicht betroffene Pfade (Scope-Einsparung, gemessen)
+
+- **Ortsvergleich:** `comparison.py:647-670` (`_channel_layout_for_metrics`)
+  baut eine Wegwerf-`UnifiedWeatherDisplayConfig` **ohne** Kanal-Ebenen —
+  `_cascade_source_for_channel()` liefert dort immer `"global"`. Compare-
+  Channel-Layouts wurden mit #1351 entfernt
+  (`scripts/migrate_1351_drop_compare_channel_layouts.py`). ADR-0050 beruehrt
+  den Compare-Pfad nicht.
+- **Premium-SMS:** `premium_sms.py:19-21` sendet `report.sms_text`
+  unveraendert — kein eigener Renderpfad, keine eigene Kanal-Ebene noetig.
+  Damit ist die offene Frage der S1-Spec („bekommt Premium-SMS eine eigene
+  Ebene?") fuer S2 beantwortet: nein, es erbt die SMS-Kaskade transitiv.
+- **Alarme:** `src/output/renderers/alert/*` kennt die Kaskade nicht (0
+  Treffer); Alarm-Auswahl laeuft ueber `metric_alert_levels` /
+  `get_alert_enabled_metrics()` — eine andere Auswahlachse.
+- **Go:** `channel_layouts` wird in `internal/handler/compare_preset.go:333`
+  und `internal/model/compare_preset.go:46` nur als opaker JSON-Schluessel
+  durchgereicht, ohne Interpretation. `internal/handler/proxy.go:370` ist
+  reiner HTTP-Forward. Keine Go-Aenderung noetig.
+- **Frontend:** keine Stelle ruft `/api/_validator/metrics-for-channel` auf;
+  `channelLayoutsDirty.ts:41` vergleicht nur Roh-Arrays. Es gibt heute keine
+  Live-Vorschau der aufgeloesten Kaskade im Editor — Frontend ist S3.
+
+### 3b. Schreibpfad — falls doch eine Migration beschlossen wird
+
+- **Go schreibt `display_config` an zwei Stellen:**
+  `internal/handler/weather_config.go:99` (`PutTripWeatherConfigHandler`) und
+  `internal/handler/trip.go:305-306` (`UpdateTripHandler`), beide via
+  `mergeConfigMap` (`internal/handler/config_merge.go:11-22`). Das ist ein
+  **flacher Merge auf oberster Schluesselebene**: wird `channel_layouts`
+  gesendet, wird der ganze Teilbaum ersetzt, nicht pro Kanal gemergt. Das
+  Frontend gleicht das aktiv aus (`WeatherMetricsTab.svelte:754-775` →
+  `channelMetricLayouts.ts:25-34`, Docstring nennt BUG-DATALOSS-GR221).
+- **Python `save_trip()`** (`loader.py:1657-1723`) macht RMW ueber
+  `_deep_merge_preserve_unknown` (Z.125-137): Dicts rekursiv, **Listen
+  komplett ersetzt**. `metrics` und `channel_layouts.<kanal>` sind Listen —
+  ein Python-Schreibvorgang ueberschreibt sie also vollstaendig mit dem
+  In-Memory-Stand. Aufrufer: `trip_command_processor.py` (Inbound-Kommandos),
+  `trip_report_scheduler.py:646`.
+- **Praezedenzfall „Lazy-Migration beim Speichern":**
+  `internal/store/trip.go:235` ruft `migrateMetricAlertLevels()` (Z.283-305)
+  nur im Save-Pfad. Zeigt, dass es dafuer ein etabliertes Muster gibt, falls
+  eine physische Bereinigung doch gewuenscht wird.
+- **Migrations-Skript-Muster** (13 Stueck unter `scripts/migrate_*.py`,
+  Ausfuehrung dokumentiert in `docs/reference/operations_playbook.md:341-380`):
+  Dry-Run-Default, `--execute`, `--backup-dir`, zweiphasig
+  `_collect_plan()`/`_apply()`, Idempotenz-Pflicht. Naechster Verwandter:
+  `scripts/migrate_1262_flat_metrics.py` (dieselbe Baustelle
+  `display_config.metrics`).
+- **Compare hat keine `channel_layouts` mehr** — mit #1351 ersatzlos
+  entfernt; das Migrationsskript nennt ausdruecklich, dass Trip-Presets
+  (`kind=route`) unangetastet bleiben, weil `channel_layouts` dort eine echte
+  Kaskadenstufe ist. S2 ist damit **Trip-only**.
+- **`channel_layouts_per_report` hat keine Frontend-Schreibstelle** — nur
+  Lesevorkommen (`types.ts:291`) und ein Dirty-Check
+  (`cockpitHelpers568.ts:58`). Die dritte Kaskadenstufe wird heute von
+  keinem Bedienelement erzeugt.
+
+### 4. Vorbestehende Kaskaden-Umgehungen (nicht S2-Scope, aber zu benennen)
+
+- `narrow.py:735/741/776` — die Telegram-**Kurzuebersicht** und die
+  Tagesfusszeile lesen `dc.get_enabled_metric_ids()` statt der Kanal-Kaskade
+  und damit (wegen Befund 2) die E-Mail-Auswahl. Der Docstring bei
+  `narrow.py:648` beschreibt das als beabsichtigt („alle konfigurierten
+  Metriken, `telegram_kurzform` wirkungslos — AC-10"). Aendert sich durch S2
+  nicht von selbst.
+- `validator.py:115,134` — `get_enabled_metrics()` bewusst global, andere
+  Fragestellung (Erkennung, ob ueberhaupt eine `display_config` gesetzt ist).
+
+## Existing Patterns
+
+- **Ein Ableitungsweg je Frage (#1677 DEC-2):** Ebenen-Erkennung liegt
+  ausschliesslich in `_cascade_source_for_channel()`; `models.py` und
+  `api/routers/validator.py` teilen sie. Ein S2-Schnitt gehoert nach
+  demselben Muster an genau **eine** Stelle, nicht in jeden Renderer.
+- **Kollabierungs-Schutz per unverfaelschter Kopie:** `_dc_uncollapsed`
+  (`trip_report.py:132`) ist das etablierte Muster, wenn ein Kanal nach der
+  E-Mail-Kollabierung noch die echte Grundauswahl braucht.
+- **Altbestand ist ein eigenes Signal, keine leere Liste:**
+  `_trip_metrics_altbestand` (`trip_report.py:128`) unterscheidet „Feld fehlt"
+  von „alles bewusst abgewaehlt" und wird an alle drei E-Mail-Renderer
+  durchgereicht (`html.py:984`, `compact.py:114`, `plain.py:127`).
+- **Zentraler Choke-Point fuer Katalog-Regeln:**
+  `_filter_metrics_by_report_type()` traegt bereits das `selectable`-Gate
+  (#1585) — der natuerliche Ort, an dem auch das globale Maximum wirken kann.
+
+## Dependencies
+
+- **Upstream:** `src/app/loader.py` (`_parse_display_config`) liefert
+  `metrics`, `per_channel_layouts`, `per_report_layouts`;
+  `src/app/metric_catalog.py` liefert `selectable`.
+- **Downstream:** E-Mail (`trip_report.py:135` → `html.py`/`compact.py`/
+  `plain.py`/`compact_summary.py`), SMS (`trip_report.py:295` →
+  `sms_trip.py`), Premium-SMS (transitiv), Telegram-Tabellen
+  (`narrow.py:661` → `channel_layout.py:90`), Validator-Endpoint
+  (`validator.py:292`) und ueber ihn der Go-Proxy.
+
+## Existing Specs
+
+- `docs/adr/0050-metrik-kaskade-verfeinerung-nicht-ersetzung.md` — die Zusage
+  (Regeln 1-5); Regel 4 ist Frontend/S3.
+- `docs/specs/modules/fix_1719_s1_kaskade_pruefstand.md` — Pruefstand, AC-7
+  als `xfail(strict=True)`, offene Fragen die S2 beantworten muss.
+- `docs/reference/metric_output_matrix.md` (#1514) — Ausgabeorte je Metrik.
+- ADR-0049 (Kanalliste E-Mail · Telegram · SMS · Premium-SMS).
+
+## Risks & Considerations
+
+1. **Der Schnitt gegen eine kollabierte `dc`** (Befund 2) ist das groesste
+   Risiko: er verwandelt den Fix in einen neuen Bug derselben Familie und
+   waere gruen, wenn der Test nur SMS und E-Mail prueft. Ein Telegram-AC mit
+   einer Metrik, die in Telegram AN und in E-Mail AUS ist, ist Pflicht.
+2. **Leere/fehlende Grundauswahl darf nicht „alles verboten" heissen.**
+   `loader.py:758` macht aus einem fehlenden `metrics`-Feld `[]`. Ein
+   Maximum-Filter, der `[]` als „nichts erlaubt" liest, wuerde Altbestands-
+   Trips (und den Compare-Sonderfall aus Befund 1) auf null Metriken
+   schneiden — Totalausfall statt Bugfix. Regel muss lauten: **keine globale
+   Ebene ⇒ kein Maximum definiert ⇒ nicht schneiden.**
+3. **Report-Typ-Flags im Schnitt.** Das Maximum ist report-typ-abhaengig
+   (`morning_enabled`/`evening_enabled`). Ein Kanal-Eintrag mit
+   `evening_enabled=True`, dessen globaler Eintrag `evening_enabled=False`
+   traegt, fuegt fuer diesen Report-Typ hinzu — muss also ebenfalls fallen.
+4. **Reihenfolge und Format bleiben kanal-eigen** (ADR-0050 Regel 5). Der
+   Schnitt darf nur Eintraege ENTFERNEN, nie die Position oder
+   `format_mode`/`use_friendly_format` des Kanal-Eintrags veraendern.
+5. **Stufe 1 (`per_report_layouts`) muss mitgeschnitten werden**, sonst
+   verlagert sich das Schlupfloch nur eine Ebene nach oben. Heute im Bestand
+   ungenutzt (0 Traeger) — genau deshalb billig jetzt, teuer spaeter.
+6. **Metrik im Kanal, die global gar nicht vorkommt:** unter Regel 1 nicht
+   im Maximum ⇒ faellt. Im Bestand nur im inerten Compare-Sonderfall
+   vorhanden; muss dennoch bewusst entschieden und getestet werden.
+7. **`xfail(strict=True)` entfernen ist Teil der Definition of Done** —
+   sonst schlaegt AC-7 als XPASS fehl und die CI-Ampel kippt.
+8. **Doku-Drift:** Der Docstring bei `models.py:826-841` beschreibt die
+   Ersetzungs-Semantik; ebenso `loader.py:836-841`. Beide behaupten nach dem
+   Umbau etwas Falsches ueber den eigenen Code.
+
+## Analysis
+
+### Type
+
+Bug (ADR-0050 ist die Zusage; der Code haelt sie nicht ein).
+
+### Zwei Korrekturen an den Befunden oben (Adversary-Runde der Analyse)
+
+**K1 — „0 Widerspruechen im Bestand" ist eine Momentaufnahme, keine
+Invariante.** Der bereits ausgelieferte Editor erzeugt den verbotenen
+Zustand jederzeit neu, ohne S3: `editActiveChannel()`
+(`WeatherMetricsTab.svelte:638`) legt beim ERSTEN Anfassen eines Kanal-Tabs
+eine Kopie der globalen Auswahl an (`channelMetricLayouts.ts:67-79`,
+`startChannelOverride`); danach lebt sie unabhaengig weiter, und
+`onToggleMetric` (Z.662-673) aendert ausschliesslich die globale Ebene.
+`buildWeatherPayload()` (Z.754-775) sendet beide Ebenen unabgeglichen in
+EINEM PATCH; `config_merge.go:11-22` validiert nichts quer.
+**Reproduktionsfolge, die jeder Nutzer heute ausloesen kann:** SMS-Tab
+oeffnen → zurueck zur Grundauswahl → dort eine Metrik abwaehlen → speichern.
+Konsequenz: Der Schnitt muss **jeden Aufruf** schuetzen; eine Einmal-
+Migration wuerde den Zustand nur bis zum naechsten Speichern aufraeumen.
+Das ist das staerkere Argument gegen die Migration als die Zaehlung selbst.
+
+**K2 — Telegram folgt schon HEUTE der E-Mail-Auswahl, nicht erst nach S2.**
+Hat ein Trip eine eigene `channel_layouts.email`-Ebene und **keine**
+Telegram-Ebene, faellt `get_metrics_for_channel("telegram", …)` auf Stufe 3
+und liest `self.metrics` — das ist zu diesem Zeitpunkt die kollabierte
+E-Mail-Auswahl (`trip_report.py:138`). Das ist ein **bereits scharfer
+Fehler**, kein blosses Risiko des Umbaus. S2 behebt ihn mit.
+
+### Verworfen: `seg_tables` global verbreitern
+
+Der Vorschlag, die Stundenzeilen einmal aus dem vollen Maximum zu bauen,
+weil die E-Mail ihre Spalten ohnehin aus `dc.metrics` ziehe, ist **am Code
+widerlegt**: `html.py:673` und `html.py:903` leiten die Spalten ueber
+`visible_cols(rows)` aus den **Zeilen-Schluesseln** ab
+(`email/helpers.py:296-299`). Gefiltert wird nur ueber `allowed_col_keys`,
+und `_allowed_col_keys_for_horizon()` (`html.py:924-947`) liefert bei
+`horizon=None` ausdruecklich `None` — `horizon` ist `None` fuer **alle
+Etappen ab Tag 4** (`helpers.py:318-322`). Breitere Zeilen haetten dort neue
+Spalten in die Trip-Mail geschoben. Stattdessen bekommt Telegram eine
+**eigene** Zeilenmenge; der E-Mail-Pfad bleibt unberuehrt.
+
+### Technical Approach (Entscheidungen)
+
+- **D1 — Ort des Schnitts:** in `get_metrics_for_channel()`
+  (`models.py:825-863`), **nicht** im geteilten
+  `_filter_metrics_by_report_type()`. Letzteres wird mit drei verschiedenen
+  Listen aufgerufen, darunter `self.metrics` selbst; ein Maximum-Parameter
+  waere an zwei von drei Aufrufstellen unbenutzt und vermischte zwei
+  Zustaendigkeiten.
+- **D2 — Schnittmenge:** gegen die **IDs** aus
+  `self.get_metrics_for_report_type(report_type)`, nicht gegen rohe
+  `enabled`-Flags. Nur so wirkt ADR-0050 Regel 3 auch fuer
+  `morning_enabled`/`evening_enabled`, und die abgeleiteten Nachtgroessen
+  (`temperature_night`/`wind_chill_night`, `loader.py:803-834`) sowie das
+  `selectable`-Gate (#1585) bleiben korrekt beruecksichtigt.
+- **D3 — beide Kanal-Ebenen gegen dieselbe globale Menge**, NICHT verkettet:
+  `per_report_layouts[rt][ch]` wird gegen die globale Menge geschnitten, nicht
+  zusaetzlich gegen `per_channel_layouts[ch]`. ADR-0050 Regel 1 nennt
+  ausdruecklich die Grundauswahl als Maximum, keine Zwischenebene; eine
+  Verkettung wuerde einen Report-Typ-Override auf das einschraenken, was der
+  allgemeine Kanal-Layer zufaellig enthaelt.
+- **D4 — leere Grundauswahl:** `if not self.metrics: nicht schneiden`. Die
+  Pruefung sitzt direkt an der Schnittstelle (Pruefort = Wirkort), nicht als
+  Wiederverwendung von `_trip_metrics_altbestand` (`trip_report.py:128`) aus
+  einer anderen Datei.
+- **D5 — Telegram:** `trip_report.py` uebergibt `dc=_dc_uncollapsed` an
+  `render_telegram_bubbles` UND baut fuer Telegram eine eigene Zeilenmenge
+  aus derselben unverfaelschten Grundauswahl. Ohne die zweite Haelfte
+  erschienen Spalten ohne Werte („–"), weil `_dp_to_row()`
+  (`trip_report.py:636-638`) nur Metriken eintraegt, die in der uebergebenen
+  `dc` aktiv sind.
+- **D6 — keine Datenmigration.** Begruendung: kein Bestandsfall (gemessen)
+  UND der Editor erzeugt den Zustand laufend neu (K1) — eine Einmal-
+  Migration loeste das Problem nicht dauerhaft, der Lesepfad-Schnitt schon.
+  Das entspricht dem in ADR-0050 bereits benannten Preis „stiller Rueckfall
+  auf AUS fuer Alt-Konfigurationen".
+- **D7 — Premium-SMS** bekommt keine eigene Ebene (erbt `report.sms_text`,
+  `notification_service.py:412/428/449`); **Compare** bleibt unberuehrt
+  (`compare_preset_from_dict` ruft `_parse_display_config()` gar nicht auf,
+  `loader.py:238-289`).
+
+### Affected Files
+
+| Datei | Aenderung | Beschreibung |
+|---|---|---|
+| `src/app/models.py` | MODIFY | Maximum-Schnitt in `get_metrics_for_channel()` + Docstring-Korrektur |
+| `src/output/renderers/trip_report.py` | MODIFY | `_dc_uncollapsed` an Telegram + eigene Telegram-Zeilenmenge |
+| `src/app/loader.py` | MODIFY | nur Docstring-Korrektur (Z.836-841 behauptet Ersetzung) |
+| `tests/tdd/test_channel_metric_matrix.py` | MODIFY | `xfail(strict)` entfernen + neue ACs (Telegram-Wert, per_report, leere Grundauswahl) |
+| `tests/tdd/test_issue_429_channel_layouts.py` | MODIFY | 2 Fixtures: Kanal-Metriken global ergaenzen |
+| `tests/tdd/test_issue_434_per_report_layouts.py` | MODIFY | 1 Fixture |
+| `tests/integration/test_issue_448_validator_metrics_for_channel.py` | MODIFY | 2 Fixtures |
+
+### Scope Assessment
+
+- Dateien: 7 (3 Produktivcode, 4 Tests)
+- Geschaetzte LoC: ~+110 / -25 (Limit 250)
+- Risiko: **MEDIUM-HIGH** — Produktivpfad aller vier Kanaele; das Risiko
+  liegt nicht im Schnitt selbst, sondern in seinen Wechselwirkungen mit der
+  E-Mail-Kollabierung.
+
+### Bekannt rot werdende Bestandstests (mechanisch zu reparieren)
+
+`test_issue_429_channel_layouts.py::test_ac3_…` (Z.189-203) und
+`::test_ac5_…` (Z.224-238), `test_issue_434_per_report_layouts.py::test_ac3_…`
+(Z.170-183), `test_issue_448_validator_metrics_for_channel.py::test_ac2_…`
+(Z.232-247) und `::test_ac3_…` (Z.249-264). Alle fuenf haben Kanal-Metriken,
+die in der globalen Liste **nicht** vorkommen — genau das von ADR-0050
+verbotene Muster. Reparatur = globale Liste um diese IDs ergaenzen.
+
+### Open Questions
+
+- Keine blockierenden. Bewusst **ausserhalb** S2: die Telegram-
+  Kurzuebersicht (`narrow.py:735/741/776`) umgeht die Kaskade und liest
+  `get_enabled_metric_ids()` direkt — sie bleibt an die E-Mail-Kollabierung
+  gekoppelt. Durch S2 wird das nicht schlimmer (Adversary Angriff 5).
+- Die Wurzel — dass `dataclasses.replace(dc, metrics=…)` die `dc` ueber ihre
+  eigene Grundauswahl luegen laesst — bleibt bestehen; sie sauber
+  aufzuloesen hiesse, drei E-Mail-Renderer von `dc.metrics` zu entkoppeln.
+  Als Folgearbeit notieren, nicht in S2.

--- a/docs/specs/modules/fix_1719_s2_kaskade_verfeinerung.md
+++ b/docs/specs/modules/fix_1719_s2_kaskade_verfeinerung.md
@@ -63,9 +63,13 @@ Datenmigration (D6, begründet).
 
 ## Estimated Scope
 
-- **LoC:** ~+110/-25 (Limit 250) — 3 Produktivcode-Dateien + Docstring-Korrekturen,
-  4 Testdateien (1 neuer Abschnitt + 4 Fixture-Reparaturen).
-- **Files:** 7 (3 Produktivcode, 4 Tests) — siehe Affected Files.
+- **LoC:** ~+170/-25 (Limit 250) — 3 Produktivcode-Dateien + Docstring-Korrekturen,
+  4 Python-Testdateien (1 neuer Abschnitt + 4 Fixture-Reparaturen) und 1 neuer
+  Playwright-Klickpfad inkl. Staging-Setup (~60 Zeilen nach Bestandsmuster).
+- **Files:** 8 (3 Produktivcode, 5 Tests davon 1 Browser-Klickpfad) — siehe
+  Affected Files.
+- **Deploy-Folge:** Durch den Klickpfad gegen Staging ist der Scope **nicht**
+  `docs-only`; die Auslieferung durchläuft die volle Staging-Verifikation.
 - **Effort:** medium-high. Der Schnitt selbst ist klein; das Risiko liegt in
   der Wechselwirkung mit der E-Mail-Kollabierung (Kontext-Dokument, Risiko 1)
   — Produktivpfad aller vier Kanäle (E-Mail, Telegram, SMS, Premium-SMS).
@@ -81,6 +85,7 @@ Datenmigration (D6, begründet).
 | `tests/fixtures/metric_cascade/khw_display_config_widerspruch.json` | WIRD WIEDERVERWENDET | Basis-Fixture; neue Ein-/Mehrfeld-Varianten (u. a. `channel_layouts.email`/`.telegram`, `per_report_layouts`) nach dem in Scheibe 1 etablierten Muster |
 | `docs/reference/metric_output_matrix.md` | REFERENZ | Ausgabeorte je Metrik (#1514) |
 | `tests/tdd/test_issue_429_channel_layouts.py`, `test_issue_434_per_report_layouts.py`, `tests/integration/test_issue_448_validator_metrics_for_channel.py` | WIRD REPARIERT | Fünf bekannt rot werdende Bestandstests, s. eigener Abschnitt unten |
+| `frontend/e2e/metrik-grundauswahl-schneidet-kanal.staging.spec.ts` (+ Staging-Setup/Config nach Bestandsmuster) | NEU | **Pflicht-Klickpfad zu AC-10** (PO-Leitplanke #1719): die Editor-Sequenz wird geklickt, nicht konstruiert. Einzige Frontend-Datei dieser Scheibe — sie ändert das Frontend nicht, sie bedient es |
 
 ## Implementation Details
 
@@ -321,10 +326,36 @@ unangetastet (s. AC-6).
   Kontext-Dokument: SMS-Tab öffnen → zurück zur Grundauswahl → dort abwählen →
   speichern) / When alle drei Kanal-Renderpfade laufen / Then verschwindet die
   Metrik auch aus dem SMS-Kanal.
-  - Test: zweistufig konstruierte Fixture-Variante (erst Kanal-Ebene =
-    Kopie der Grundauswahl, dann NUR der globale Eintrag geändert) — ergänzt
-    AC-1 um den Nachweis, dass auch der über den Editor real erreichbare
-    Entstehungsweg (nicht nur die vorgefundene Ist-Fixture) abgesichert ist.
+  - Test A (Kern-Suite): zweistufig konstruierte Fixture-Variante (erst
+    Kanal-Ebene = Kopie der Grundauswahl, dann NUR der globale Eintrag
+    geändert) — ergänzt AC-1 um den Nachweis, dass auch der über den Editor
+    real erreichbare Entstehungsweg abgesichert ist.
+  - **Test B (PFLICHT — echter Browser-Klickpfad, PO-Leitplanke aus #1719):**
+    Test A konstruiert die Datenlage von Hand und belegt damit **nicht**,
+    dass der Editor sie tatsächlich so erzeugt — eine Aussage über den
+    Editor ohne den Editor. Deshalb zusätzlich ein Playwright-Klickpfad
+    unter `frontend/e2e/` gegen Staging, der die Sequenz **klickt**:
+    Trip-Editor öffnen → Reiter „Wetterwerte" → **SMS-Kanal anwählen**
+    (erzeugt die Kanal-Kopie, `WeatherMetricsTab.svelte:638`) → zurück zur
+    **Grundauswahl** → dort die Ziel-Metrik abwählen → speichern → danach
+    die **zugestellte Ausgabe** prüfen (Test-Briefing bzw.
+    Kurzform-Vorschau des echten Versandwegs): die Metrik darf im SMS-Text
+    nicht mehr vorkommen.
+    Bewusst **kein** Deploy-Gate-Ersatz: das Frontend-Browser-Gate (#1558)
+    lädt sechs Seiten und sammelt Konsolenfehler — es klickt keinen AC durch
+    und genügt hier nicht.
+    Namensregel: nach Verhalten benennen (z. B.
+    `frontend/e2e/metrik-grundauswahl-schneidet-kanal.staging.spec.ts`),
+    nicht nach Issue-Nummer. Vorbilder für Aufbau und Staging-Setup:
+    `frontend/e2e/weather-metrics-tab-autosave.spec.ts`,
+    `frontend/e2e/issue-776-metrics-toggle.spec.ts`,
+    `frontend/e2e/layout-tab-route.spec.ts`.
+    **Wichtig für die Erwartung:** Der Klickpfad beweist die Zusicherung von
+    S2 (die zugestellte Ausgabe folgt der Grundauswahl), NICHT das
+    Editor-Verhalten aus ADR-0050 Regel 4 („Aus ist ein Zustand") — das ist
+    S3. Er läuft daher bewusst gegen den **unveränderten** Editor: dass der
+    Editor eine widersprüchliche Datenlage schreibt, ist hier
+    Versuchsaufbau, nicht Fehler.
 
 - **AC-11 (SMS/Premium-SMS erben ohne eigene Änderung am Versandpfad):**
   Given `output/channels/premium_sms.py` sendet `report.sms_text` unverändert

--- a/docs/specs/modules/fix_1719_s2_kaskade_verfeinerung.md
+++ b/docs/specs/modules/fix_1719_s2_kaskade_verfeinerung.md
@@ -255,6 +255,28 @@ unangetastet (s. AC-6).
   - Test: `report.telegram_bubbles`-Text parsen (Vorbild
     `_narrow_table`-Zeilenformat), Zellwert der Zielmetrik gegen den erwarteten
     numerischen Wert aus `F.segment()` prüfen — NICHT nur Spalten-Präsenz.
+  - **Nachbesserung (Adversary F001, Fix-Runde nach BROKEN-Verdict):** die
+    ursprüngliche Zielmetrik `humidity` ist global AN — der Pflicht-
+    Mutationsprobe (a) unten ("Schnitt aus D1 weglassen") blieb damit für
+    AC-5 wirkungslos, weil `humidity` auch OHNE D1-Schnitt sichtbar bliebe.
+    AC-5 führt deshalb eine ZWEITE, unabhängige Zielmetrik (Muster AC-1:
+    global AUS, in der eigenen Telegram-Ebene AN), die AUSSCHLIESSLICH über
+    D1 aus dem Ergebnis fällt — erst damit fängt AC-5 beides: den Ausfall von
+    D1 (Metrik erscheint überhaupt in der Kanal-Auswahl) UND den Ausfall von
+    D5 (Metrik zeigt „–" statt Wert). Gemessen (Mutationsprobe, s. u.):
+    `test_kaskade_ac7_...` (AC-1) und `test_kaskade_s2_ac5_...` (AC-5)
+    schlagen unter Mutation (a) jetzt BEIDE fehl.
+  - **Nachbesserung (Adversary F003, eigener Test):** der Force-Enable-Schritt
+    in der D5-Konstruktion (`dataclasses.replace(mc, enabled=True)`,
+    `trip_report.py`) war bis zur Fix-Runde unbewacht. Neuer Test
+    `test_kaskade_s2_ac5b_evening_override_forces_real_telegram_value`: ein
+    globaler Eintrag mit `enabled: false` + `evening_enabled: true`, KEINE
+    eigene Telegram-Ebene (Kaskade fällt auf `global`) — die Telegram-Spalte
+    erscheint (D2 lässt sie über `evening_enabled` durch), muss aber den
+    ECHTEN Messwert zeigen, nicht „–". Gemessen (Mutationsprobe): wird der
+    Force-Enable-Schritt entfernt, bleibt die Spalte erhalten, aber jede
+    Zelle zeigt „–" — genau das fängt dieser Test, AC-3/AC-4/AC-5 bleiben
+    davon unberührt.
 
 - **AC-6 (E-Mail bleibt unverändert, insbesondere Etappen ab Tag 4):** Given
   ein Trip ohne Kanal-Widerspruch (E-Mail-Kanal-Ebene fehlt oder ist mit der
@@ -397,14 +419,46 @@ unangetastet (s. AC-6).
     (`trip_report.py:295-296`) — das ist der korrekte Wirkort für diese
     Zusicherung.
 
+- **AC-13 (Adversary F004 — Telegram-Kurzübersicht/Fußzeile respektieren
+  `evening_enabled` auch OHNE eigene Telegram-Ebene):** Given eine Metrik ist
+  global AN, `evening_enabled: false`, OHNE eigene `channel_layouts.telegram`
+  (Kaskade fällt auf `global`) / When der ECHTE Renderpfad (`format_email()` →
+  `report.telegram_bubbles`) für `report_type="evening"` läuft / Then
+  erscheint die Metrik NICHT in der Telegram-Kurzübersicht-Bubble — weder als
+  Wertzeile noch als Geisterzeile mit „–". Grund (gemessen, ersetzt die
+  frühere Known Limitation 1): `render_telegram_bubbles()` bekam bis zu dieser
+  Fix-Runde `dc=_dc_uncollapsed` (die ungefilterte Grundauswahl); die
+  Kurzübersicht-Schleife UND die Fußzeilen-Gates (Sicht/0°C-Grenze/Gewitter,
+  `narrow.py:296-307`) lesen `dc.get_enabled_metric_ids()` DIREKT, ohne durch
+  `get_metrics_for_channel()` zu gehen, und blieben dadurch vom D1-D4-Schnitt
+  strukturell unberührt. Fix: `render_telegram_bubbles()` bekommt
+  `dc=_dc_telegram` (D5, bereits report-typ-/kanal-kaskadiert) — EINE Quelle
+  für Tabellenspalten, Kurzübersicht UND Fußzeile. Der innere Aufruf
+  `render_for_channel("telegram", dc, report_type)` (`narrow.py:661`) bleibt
+  dabei idempotent (gemessen: AC-3/AC-4/AC-5 unverändert grün) — er ruft
+  intern erneut `get_metrics_for_channel()` auf, das gegen eine bereits
+  kaskadierte `dc` denselben Ergebnis-Satz liefert, keinen zweiten Verlust.
+  - Test: `test_kaskade_s2_ac13_telegram_overview_respects_evening_enabled_without_own_layer`
+    — `report.telegram_bubbles`-Kurzübersichtstext auf Abwesenheit des
+    Metrik-Kürzels prüfen (Vorbild AC-4/AC-5, NICHT `render_for_channel()`
+    direkt).
+
 ## Known Limitations
 
-1. **Bestehende Kaskaden-Umgehung bleibt bestehen:** die Telegram-
-   Kurzübersicht (`narrow.py:735/741/776`) liest `dc.get_enabled_metric_ids()`
-   statt der Kanal-Kaskade und bleibt damit an die (nach D5 weiterhin
-   kollabierte) E-Mail-Auswahl gekoppelt. Durch S2 wird das nicht schlimmer
-   (bereits in S1 als „Adversary Angriff 5" benannt) — Behebung ist nicht Teil
-   dieser Scheibe.
+1. ~~Bestehende Kaskaden-Umgehung bleibt bestehen~~ **Behoben in dieser
+   Fix-Runde (Adversary F004, s. AC-13).** Ursprünglicher Text (nachweislich
+   falsch, s. u.): „die Telegram-Kurzübersicht liest `dc.get_enabled_metric_ids()`
+   statt der Kanal-Kaskade und bleibt damit an die kollabierte E-Mail-Auswahl
+   gekoppelt — durch S2 wird das nicht schlimmer." Gemessen (Adversary-Dialog
+   nach dem ersten Implementierungsdurchgang): das stimmte nicht — S2 baute
+   mit `_dc_telegram`/`seg_tables_telegram` bereits die korrekt kaskadierte
+   Zeilenmenge, reichte sie aber NICHT an `render_telegram_bubbles()` als
+   `dc` durch (dort stand weiterhin `dc=_dc_uncollapsed`). Die
+   Kurzübersicht/Fußzeile war damit schlimmer dran als vor S2 in dem Sinn,
+   dass die Tabellenspalten bereits korrekt gefiltert waren, während
+   Kurzübersicht/Fußzeile derselben Bubble die ungefilterte Grundauswahl
+   zeigten — ein sichtbarer Widerspruch INNERHALB derselben Bubble. Fix:
+   `dc=_dc_telegram` (s. AC-13).
 2. **`dataclasses.replace(dc, metrics=…)` bleibt bestehen** — die Wurzel, dass
    `dc` nach der E-Mail-Kollabierung über ihre eigene Grundauswahl „lügt",
    wird nicht aufgelöst. D5 umschifft die Auswirkung für Telegram gezielt
@@ -422,9 +476,9 @@ unangetastet (s. AC-6).
 - **Frontend** (Editor-Zustandsanzeige „Aus ist ein Zustand" statt Löschung,
   `CHANNEL_COL_BUDGET.sms`-Korrektur, ADR-0050 Regel 4) — Scheibe S3.
 - **Legende/Erklärtext zur Kaskade im UI** — Scheibe S4.
-- **Telegram-Kurzübersicht** (`narrow.py:735/741/776`) — bleibt an die
-  E-Mail-Kollabierung gekoppelt, ausdrücklich unverändert durch diese Scheibe
-  (s. Known Limitations 1).
+- ~~Telegram-Kurzübersicht bleibt an die E-Mail-Kollabierung gekoppelt~~ **Doch
+  in dieser Scheibe behoben** (Adversary F004, s. AC-13 + Known Limitations 1)
+  — die ursprüngliche Abgrenzung war nachweislich falsch, s. Korrektur oben.
 - **Auflösung der `dataclasses.replace`-Kollabierung als Ganzes** (drei
   E-Mail-Renderer von `dc.metrics` entkoppeln) — Folgearbeit, nicht S2.
 - **Datenmigration für Bestandstrips** — D6, begründet verzichtet.
@@ -468,12 +522,22 @@ MÜSSEN über den echten End-zu-End-Pfad (`report.telegram_bubbles`) laufen.
   sie ausschließt.
 - **(c) `if not self.metrics`-Schutz (D4) entfernen** ⇒ AC-7 (Leerauswahl)
   MUSS rot werden — die SMS-Kanal-Ebene würde auf `[]` kollabieren.
-- **(d) `dc=_dc_uncollapsed` an `render_telegram_bubbles` zurückdrehen** (Z.
-  260 wieder `dc=dc`) ⇒ AC-4 MUSS rot werden (K2-Regression: Telegram folgt
-  wieder der kollabierten E-Mail-Auswahl statt der Grundauswahl). AC-3 bleibt
-  davon UNBERÜHRT, weil `per_channel_layouts`/`per_report_layouts` von
-  `dataclasses.replace` nicht verändert werden (Kontext-Dokument Abschnitt 2)
-  — AC-3 prüft ausschließlich den Fall MIT eigener Telegram-Ebene.
+- **(d) `dc=_dc_telegram` an `render_telegram_bubbles` auf `dc=_dc_uncollapsed`
+  zurückdrehen** ⇒ **korrigiert (Adversary F004, gemessen statt der
+  urspruenglichen Erwartung):** AC-4 bleibt davon entgegen der ersten Fassung
+  dieser Zeile UNBERÜHRT (grün) — AC-4 prüft `table_text` (aus
+  `seg_tables_telegram`, unabhängig vom `dc=`-Parameter von
+  `render_telegram_bubbles`) und `cells` (über `_kaskade_telegram_cells()`,
+  ruft `render_for_channel()` auf einer frisch geladenen `dc` auf, geht nie
+  durch `render_telegram_bubbles`). AC-13 fängt diese Mutation stattdessen —
+  sie prüft exakt die Stelle, die vom `dc=`-Parameter abhängt:
+  `dc.get_enabled_metric_ids()` in der Kurzübersicht-Schleife
+  (`narrow.py:735/741/776`). AC-3 bleibt ebenfalls UNBERÜHRT, weil
+  `per_channel_layouts`/`per_report_layouts` von `dataclasses.replace` nicht
+  verändert werden (Kontext-Dokument Abschnitt 2) — AC-3 prüft ausschließlich
+  den Fall MIT eigener Telegram-Ebene. Mutationsprobe durchgeführt (Fix-Runde
+  nach BROKEN-Verdict): `pytest -k "s2_ac13 or s2_ac3 or s2_ac4 or s2_ac5"`
+  unter der zurückgedrehten Mutation → genau AC-13 rot, AC-3/AC-4/AC-5 grün.
 - **(e) die eigene Telegram-Zeilenmenge (D5, zweite Hälfte) zurückdrehen**
   (Telegram bekommt wieder die aus der kollabierten `dc` gebaute `seg_tables`,
   während `dc=_dc_uncollapsed` für die Spaltenermittlung korrekt bleibt) ⇒
@@ -483,6 +547,13 @@ MÜSSEN über den echten End-zu-End-Pfad (`report.telegram_bubbles`) laufen.
   belegt, dass AC-3 und AC-5 unterschiedliche Dinge bewachen — ein Fix, der
   nur die Spalten-Hälfte von D5 umsetzt, muss trotzdem als unvollständig
   auffallen.
+- **(f) Force-Enable-Schritt der D5-Konstruktion entfernen** (Adversary F003:
+  `dataclasses.replace(mc, enabled=True)` beim Bau von `_telegram_active_metrics`
+  auf ein reines Durchreichen ohne Force-Enable zurückdrehen) ⇒
+  `test_kaskade_s2_ac5b_evening_override_forces_real_telegram_value` MUSS rot
+  werden — die Telegram-Spalte bleibt (D2 lässt die Metrik über
+  `evening_enabled` durch), aber jede Zelle zeigt „–" statt des echten
+  Messwerts. AC-3/AC-4/AC-5 bleiben davon UNBERÜHRT (geprüft, gemessen).
 - **Verwechslungsprobe (Vorbild S1):** in AC-9/AC-10 versehentlich dieselbe
   Ziel-Metrik-ID wie AC-1/AC-7 verwenden — muss an der jeweiligen
   Vorbedingungs-Assertion (global aktiv vs. global inaktiv) erkennbar
@@ -526,3 +597,14 @@ nicht zu verwässern.
 - 2026-08-11: Initial spec created (Issue #1719, Scheibe 2). Grundlage:
   `docs/context/fix-1719-s2-kaskade-verfeinerung.md` (gemessen, Basis-Commit
   `32b781ed` = Merge PR #1735, Scheibe 1).
+- 2026-08-11: Fix-Runde nach Adversary-Verdict BROKEN. F004 (CRITICAL):
+  `render_telegram_bubbles` bekommt `dc=_dc_telegram` statt `dc=_dc_uncollapsed`
+  — Known Limitations 1 und der zugehörige „Nicht in dieser Scheibe"-Eintrag
+  waren nachweislich falsch (die Telegram-Kurzübersicht/Fußzeile ist jetzt
+  Teil des Fixes, s. neuer AC-13). F001: AC-5 um eine zweite, D1-sensitive
+  Zielmetrik erweitert (Mutationsprobe (a) fängt jetzt AC-1 UND AC-5). F003:
+  neuer Test `test_kaskade_s2_ac5b_...` für den bis dahin unbewachten
+  Force-Enable-Schritt der D5-Konstruktion. Mutationsprobe (d) korrigiert
+  (gemessen: AC-13 fängt sie, nicht AC-4 wie ursprünglich angenommen), neue
+  Mutationsprobe (f) für F003 ergänzt. F002 (vorbestehende Lücke,
+  `loader.py:777`) bewusst NICHT behoben — separat gebucht.

--- a/docs/specs/modules/fix_1719_s2_kaskade_verfeinerung.md
+++ b/docs/specs/modules/fix_1719_s2_kaskade_verfeinerung.md
@@ -1,0 +1,497 @@
+---
+entity_id: fix_1719_s2_kaskade_verfeinerung
+type: bugfix
+created: 2026-08-11
+updated: 2026-08-11
+status: draft
+version: "1.0"
+tags: [metrics, cascade, adr-0050, issue-1719, telegram]
+---
+
+<!-- Issue #1719, Scheibe 2 -- Backend-Verfeinerungsfilter. Baut auf Scheibe 1
+     (ADR-0050 + Pruefstand, docs/specs/modules/fix_1719_s1_kaskade_pruefstand.md)
+     auf: der dort gebaute AC-7-Test (xfail(strict=True)) wird mit dieser
+     Scheibe gruen, seine Markierung entfaellt. Grundlage:
+     docs/context/fix-1719-s2-kaskade-verfeinerung.md (gemessen 2026-08-11,
+     Basis-Commit 32b781ed = Merge PR #1735). S3 (Frontend), S4 (Legende) sind
+     eigene, spaetere Scheiben. -->
+
+# Metrik-Kaskade: die Kanal-Ebene schneidet die Grundauswahl, statt sie zu ersetzen (#1719 Scheibe 2)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+ADR-0050 (Scheibe 1) legt fest: die globale Metrik-Auswahl ist das Maximum,
+eine Kanal-Ebene darf nur abwählen, nie hinzufügen. Der heutige Code hält das
+nicht ein — `UnifiedWeatherDisplayConfig.get_metrics_for_channel()`
+(`src/app/models.py:825-863`) **ersetzt** die Grundauswahl vollständig, sobald
+eine Kanal-Ebene existiert, statt sie zu begrenzen. Der in Scheibe 1 gebaute
+Prüfstand `tests/tdd/test_channel_metric_matrix.py::test_kaskade_ac7_sms_channel_must_not_add_globally_disabled_metric`
+belegt das reproduzierbar rot (`xfail(strict=True)`). Diese Scheibe baut den
+Lesepfad auf die Verfeinerungs-Semantik um: ein Maximum-Schnitt in
+`get_metrics_for_channel()` (D1/D2/D3/D4) sowie die Behebung eines zweiten,
+bereits heute scharfen Fehlers (K2 aus dem Kontext-Dokument) — Telegram folgt
+ohne eigene Kanal-Ebene der **kollabierten E-Mail-Auswahl** statt der
+Grundauswahl, weil `trip_report.py` eine bereits auf E-Mail reduzierte
+`dc`-Instanz an den Telegram-Renderer durchreicht. Kein Frontend, keine
+Datenmigration (D6, begründet).
+
+## Source
+
+> **Schicht-Hinweis:** ausschließlich Python-Core (`src/app/`,
+> `src/output/renderers/`) + Testcode. Kein Frontend, keine Go-Beteiligung —
+> `channel_layouts` wird dort nur als opaker JSON-Schlüssel durchgereicht
+> (Kontext-Dokument Abschnitt 3, „Go").
+
+- **File:** `src/app/models.py` — `UnifiedWeatherDisplayConfig.get_metrics_for_channel()`
+  (Z. 825-863), `_cascade_source_for_channel()` (Z. 712-734, **unverändert**),
+  `_filter_metrics_by_report_type()` (Z. 670-703, **unverändert** — wird
+  aufgerufen, nicht erweitert, s. D1)
+- **File:** `src/output/renderers/trip_report.py` — `TripReportFormatter.format_email()`,
+  Kollabierungsschritt (Z. 122-138), `_dc_uncollapsed` (Z. 132),
+  `seg_tables`-Bau (Z. 146), `render_telegram_bubbles`-Aufruf (Z. 256-276,
+  insb. `dc=dc` Z. 260 und `seg_tables=seg_tables` Z. 259)
+- **File:** `src/app/loader.py` — `_parse_display_config()`, Docstring des
+  `channel_layouts`-Parse-Zweigs (Z. 836-841)
+- **Identifier:** `app.models.UnifiedWeatherDisplayConfig.get_metrics_for_channel()`,
+  `output.renderers.trip_report.TripReportFormatter.format_email()`,
+  `output.renderers.narrow.render_telegram_bubbles()`,
+  `output.renderers.channel_layout.render_for_channel()`
+
+## Estimated Scope
+
+- **LoC:** ~+110/-25 (Limit 250) — 3 Produktivcode-Dateien + Docstring-Korrekturen,
+  4 Testdateien (1 neuer Abschnitt + 4 Fixture-Reparaturen).
+- **Files:** 7 (3 Produktivcode, 4 Tests) — siehe Affected Files.
+- **Effort:** medium-high. Der Schnitt selbst ist klein; das Risiko liegt in
+  der Wechselwirkung mit der E-Mail-Kollabierung (Kontext-Dokument, Risiko 1)
+  — Produktivpfad aller vier Kanäle (E-Mail, Telegram, SMS, Premium-SMS).
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `docs/context/fix-1719-s2-kaskade-verfeinerung.md` | GRUNDLAGE (gemessen) | Alle Zahlen/Belegstellen dieser Spec sind daraus übernommen, nicht neu recherchiert |
+| `docs/adr/0050-metrik-kaskade-verfeinerung-nicht-ersetzung.md` | ZUSAGE | Regeln 1-5, gegen die diese Scheibe umsetzt (Regel 4 bleibt S3) |
+| `docs/specs/modules/fix_1719_s1_kaskade_pruefstand.md` | VORGÄNGER | Prüfstand, Basis-Fixture, Test-Helfer (`_load_cascade_dc`, `_cascade_sms_variant`, `_kaskade_mail_headers`, `_kaskade_telegram_cells`, `_kaskade_sms_text`, `_kaskade_report`) |
+| `tests/tdd/test_channel_metric_matrix.py` | WIRD ERWEITERT | `xfail(strict=True)` bei AC-7 entfällt; neuer, eigener Abschnitt mit den ACs dieser Scheibe |
+| `tests/fixtures/metric_cascade/khw_display_config_widerspruch.json` | WIRD WIEDERVERWENDET | Basis-Fixture; neue Ein-/Mehrfeld-Varianten (u. a. `channel_layouts.email`/`.telegram`, `per_report_layouts`) nach dem in Scheibe 1 etablierten Muster |
+| `docs/reference/metric_output_matrix.md` | REFERENZ | Ausgabeorte je Metrik (#1514) |
+| `tests/tdd/test_issue_429_channel_layouts.py`, `test_issue_434_per_report_layouts.py`, `tests/integration/test_issue_448_validator_metrics_for_channel.py` | WIRD REPARIERT | Fünf bekannt rot werdende Bestandstests, s. eigener Abschnitt unten |
+
+## Implementation Details
+
+**D1 — Ort des Schnitts:** in `get_metrics_for_channel()`
+(`models.py:825-863`), **nicht** im geteilten `_filter_metrics_by_report_type()`
+(Z. 670-703). Letzteres wird mit drei verschiedenen Listen aufgerufen,
+darunter `self.metrics` selbst — ein Maximum-Parameter wäre an einer von drei
+Aufrufstellen unbenutzt und vermischte zwei Zuständigkeiten (Report-Typ-Filter
+vs. Kaskaden-Schnitt). Der Schnitt betrifft **ausschließlich** die Zweige
+`source == "per_report"` und `source == "per_channel"` — der `source ==
+"global"`-Zweig (Z. 862-863, `_sorted_by_layout(self.get_metrics_for_report_type(report_type))`)
+bleibt unverändert, weil er selbst bereits das Maximum ist. Diese Abgrenzung
+ist zugleich die Absicherung gegen einen Fix, der versehentlich zu breit
+schneidet und dadurch Kanäle ohne eigene Ebene (E-Mail/Telegram bei einer
+reinen SMS-Kanal-Fixture) verändert (s. AC-2).
+
+**D2 — Schnittmenge:** gegen die **IDs** aus
+`self.get_metrics_for_report_type(report_type)` (Z. 814-823, ruft
+`_filter_metrics_by_report_type(self.metrics, report_type)` auf), nicht gegen
+rohe `enabled`-Flags. Nur so wirkt ADR-0050 Regel 3 auch für
+`morning_enabled`/`evening_enabled` (s. AC-9), und die abgeleiteten
+Nachtgrößen (`temperature_night`/`wind_chill_night`, `loader.py:803-834`, dort
+nur an `self.metrics` angehängt) sowie das `selectable`-Gate (#1585,
+`_is_selectable()`, Z. 646-667) bleiben korrekt berücksichtigt, weil sie
+bereits Teil der Menge sind, gegen die geschnitten wird.
+
+**D3 — beide Kanal-Ebenen gegen dieselbe globale Menge, NICHT verkettet:**
+`per_report_layouts[report_type][channel]` wird gegen die globale Menge
+geschnitten, nicht zusätzlich gegen `per_channel_layouts[channel]`. ADR-0050
+Regel 1 nennt ausdrücklich die Grundauswahl als Maximum, keine
+Zwischenebene — eine Verkettung würde einen Report-Typ-Override fälschlich auf
+das einschränken, was der allgemeine Kanal-Layer zufällig enthält (s. AC-8).
+
+**D4 — leere Grundauswahl:** `if not self.metrics:` → nicht schneiden, Kanal-
+Ebene bleibt vollständig erhalten. Die Prüfung sitzt direkt in
+`get_metrics_for_channel()` (Prüfort = Wirkort), **nicht** als Wiederverwendung
+von `_trip_metrics_altbestand` (`trip_report.py:128`, das lebt in einer
+anderen Datei und misst denselben Sachverhalt zu einem anderen Zeitpunkt für
+einen anderen Zweck). Begründung: `loader.py:758` macht aus einem fehlenden
+`metrics`-Feld `[]`; ein Maximum-Filter, der `[]` als „nichts erlaubt" liest,
+würde Altbestands-Trips und den inerten Compare-Sonderfall (Kontext-Dokument
+Abschnitt 1) auf null Metriken schneiden — Totalausfall statt Bugfix (s. AC-7).
+
+**D5 — Telegram (behebt K2 zusätzlich zum Kern-Fix):** `format_email()`
+übergibt an `render_telegram_bubbles()` (Aufruf Z. 256-276) `dc=_dc_uncollapsed`
+statt der kollabierten `dc` (heute Z. 260: `dc=dc`) — damit liest
+`render_for_channel("telegram", …)` (`narrow.py:661`) im `global`-Fallback-Zweig
+wieder `self.metrics` der **echten** Grundauswahl statt der E-Mail-Auswahl.
+Zusätzlich braucht Telegram eine **eigene** Zeilenmenge: die heute geteilte
+`seg_tables` (`trip_report.py:146`, gebaut aus der kollabierten `dc` via
+`_extract_hourly_rows()`/`_dp_to_row()`, Z. 627-649) bleibt für E-Mail
+unverändert (s. AC-6), Telegram bekommt eine zweite, aus `_dc_uncollapsed`
+gebaute Zeilenmenge. Ohne diese zweite Hälfte erschienen Telegram-Spalten ohne
+Werte („–"), weil `_dp_to_row()` (Z. 636-649) nur Metriken einträgt, die in
+der übergebenen `dc` `enabled` sind — die Spalte wäre über `dc=_dc_uncollapsed`
+zwar sichtbar, aber leer (s. AC-3 vs. AC-5, unten getrennt geprüft).
+
+**D6 — keine Datenmigration.** Begründung (Kontext-Dokument, K1): kein
+Bestandsfall (0 verbotene Widersprüche, gemessen) UND der ausgelieferte Editor
+erzeugt den Widerspruchszustand laufend neu (`WeatherMetricsTab.svelte:638`
+kopiert die Grundauswahl beim ersten Anfassen eines Kanal-Tabs, `onToggleMetric`
+ändert danach nur noch die globale Ebene) — eine Einmal-Migration löste das
+Problem nicht dauerhaft, der Lesepfad-Schnitt schon. Entspricht dem in
+ADR-0050 bereits benannten Preis „stiller Rückfall auf AUS für
+Alt-Konfigurationen" (s. AC-10 für die Editor-Sequenz als Datenlage-Test).
+
+**D7 — Premium-SMS/Compare unberührt:** Premium-SMS bekommt keine eigene
+Kaskaden-Ebene (`premium_sms.py:19-21` sendet `report.sms_text` unverändert,
+`trip_report.py:295` liest die SMS-Kaskade unter dem Schlüssel `"sms"`) — es
+erbt die SMS-Kaskade transitiv (s. AC-11). Der Ortsvergleich ruft
+`_parse_display_config()` gar nicht auf (`comparison.py:647-670` baut eine
+Wegwerf-Config ohne Kanal-Ebenen) und ist damit von dieser Scheibe strukturell
+nicht berührt.
+
+**Verworfen (Kontext-Dokument): `seg_tables` global verbreitern.** Der
+Vorschlag, die Stundenzeilen für ALLE Kanäle aus dem vollen Maximum zu bauen
+(statt einer Telegram-eigenen Zeilenmenge, D5), ist am Code widerlegt:
+`email/html.py:673,903` leiten die Mail-Spalten über `visible_cols(rows)` aus
+den Zeilen-Schlüsseln ab, gefiltert nur über `allowed_col_keys`, und
+`_allowed_col_keys_for_horizon()` liefert bei `horizon=None` ausdrücklich
+`None` — das ist der Fall für **alle Etappen ab Tag 4**. Breitere Zeilen
+schöben dort ungefiltert neue Spalten in die Trip-Mail. Telegram bekommt
+deshalb eine **eigene** Zeilenmenge; der E-Mail-Pfad (Z. 146) bleibt
+unangetastet (s. AC-6).
+
+## Expected Behavior
+
+- **Input:** die Basis-Fixture aus Scheibe 1 (`khw_display_config_widerspruch.json`,
+  über den echten Loader geparst) sowie kontrollierte Ein-/Mehrfeld-Varianten
+  davon (u. a. mit ergänzten `channel_layouts.email`/`.telegram`- und
+  `per_report_layouts`-Einträgen), unveränderte `F.segment()`/`F.night_weather()`-
+  Wetterdaten (Vorbild Scheibe 1, AC-10).
+- **Output:** `get_metrics_for_channel()` liefert für `per_report`/`per_channel`-
+  Quellen nur noch Metriken, deren ID auch in
+  `get_metrics_for_report_type(report_type)` steht; der `global`-Zweig ist
+  unverändert. Der bestehende `test_kaskade_ac7_…`-Test läuft ohne
+  `xfail`-Markierung grün. Telegram folgt ohne eigene Ebene der Grundauswahl
+  und zeigt für eigene Telegram-Auswahl echte Werte statt „–".
+- **Side effects:** keine neue Persistenz, kein neues Pflicht-Gate. E-Mail-
+  Ausgabe für Trips ohne Kanal-Widerspruch bleibt byte-identisch (s. AC-6).
+
+## Acceptance Criteria
+
+- **AC-1 (Kern — Kanal darf nicht hinzufügen):** Given eine Kanal-Ebene führt
+  eine Metrik `enabled: true`, die in der globalen Grundauswahl `enabled:
+  false` ist / When die drei Kanal-Renderpfade (E-Mail-Kopfzeile,
+  Telegram-rich-Zellen, SMS-Text) über den echten Renderpfad laufen / Then
+  erscheint die Metrik in KEINEM der drei Kanäle — ADR-0050 Regel 1/2 gilt.
+  - Test: der bestehende `tests/tdd/test_channel_metric_matrix.py::test_kaskade_ac7_sms_channel_must_not_add_globally_disabled_metric`
+    (Z. 827-848) läuft gegen den umgebauten Produktivcode grün; die
+    `@pytest.mark.xfail(strict=True, …)`-Markierung (Z. 823-826) MUSS entfernt
+    werden — sonst schlägt der Test als `XPASS` fehl (S1, Known Limitation 2).
+
+- **AC-2 (Abwahl wirkt nur im eigenen Kanal — Gegenprobe zum S1-Spec-Fehler,
+  ADR-0050 Regel 5):** Given eine SMS-Kanal-Ebene wählt eine global aktive
+  Metrik ab (`enabled: false` oder weggelassen), E-Mail und Telegram haben
+  KEINE eigene Kanal-Ebene für diesen Report-Typ / When der Schnitt aus D1
+  läuft / Then bleibt die Metrik in E-Mail und Telegram unverändert sichtbar —
+  der Schnitt (D1) greift ausschließlich in den `per_report`/`per_channel`-
+  Zweigen von `get_metrics_for_channel()`, NIE im `global`-Zweig
+  (Z. 862-863). Eine SMS-Abwahl darf E-Mail/Telegram strukturell nicht
+  verändern können.
+  - Test: Regressions-Bestätigung der bereits in Scheibe 1 korrigierten
+    AC-4/AC-6-Fälle (`test_kaskade_ac4_…`, `test_kaskade_ac6_…`) NACH dem
+    Umbau — beide bleiben unverändert grün, plus eine Assertion, dass
+    `cascade_source_for_channel("email"/"telegram", …)` weiterhin `"global"`
+    liefert (Beleg, dass der `global`-Zweig unangetastet blieb).
+
+- **AC-3 (Telegram MIT eigener Telegram-Ebene = Telegram ∩ Grundauswahl):**
+  Given eine Fixture-Variante mit `channel_layouts.telegram`, die eine global
+  aktive Metrik abwählt / When `render_for_channel("telegram", dc,
+  report_type)` läuft / Then fehlt die Metrik in `table_columns` +
+  `detail_metrics`, alle übrigen global aktiven Metriken bleiben vorhanden.
+  - Test: strukturelle Spalten-Prüfung wie der bestehende
+    `_kaskade_telegram_cells()`-Helfer (`test_channel_metric_matrix.py:708-710`,
+    ruft `render_for_channel` direkt mit der geladenen Fixture-`dc` auf) —
+    diese Prüfung ist von der E-Mail-Kollabierung (D5) UNABHÄNGIG, weil sie
+    nicht über `format_email()` läuft.
+
+- **AC-4 (Telegram OHNE eigene Telegram-Ebene folgt Grundauswahl, NICHT
+  E-Mail-Auswahl — behebt K2):** Given eine Fixture-Variante mit
+  `channel_layouts.email` (Metrik X dort abgewählt, global aktiv) UND KEINER
+  eigenen `channel_layouts.telegram` / When der ECHTE Renderpfad
+  `TripReportFormatter().format_email(...)` läuft (NICHT `render_for_channel()`
+  direkt mit der frisch geladenen `dc`, s. Hinweis unten) / Then erscheint
+  Metrik X weiterhin in den Telegram-Bubbles, weil Telegram ohne eigene Ebene
+  auf die Grundauswahl fällt — nicht auf die kollabierte E-Mail-Auswahl.
+  - **Wichtiger Konstruktionshinweis:** `_kaskade_telegram_cells()` (S1-Helfer)
+    lädt die `dc` frisch und ruft `render_for_channel` direkt auf — dieser Weg
+    geht NIE durch `format_email()`s Kollabierungsschritt (Z. 122-138) und
+    kann K2 deshalb strukturell nicht sehen. AC-4 MUSS stattdessen über
+    `report.telegram_bubbles` (Ergebnis von `_kaskade_report(dc).telegram_bubbles`
+    o. ä., der echte End-zu-End-Pfad) prüfen — sonst wäre der Test grün, ohne
+    K2 zu bewachen (exakt die Fehlerklasse aus CLAUDE.md „Prüfort = Wirkort").
+  - Test: `report.telegram_bubbles`-Text auf das Vorhandensein von Metrik X
+    (Label/Zelle) prüfen, gegen eine Fixture-Variante mit
+    `channel_layouts.email` ⊊ Grundauswahl und ohne `channel_layouts.telegram`.
+
+- **AC-5 (Telegram zeigt echten WERT, nicht „–"):** Given eine
+  Fixture-Variante, in der eine Metrik in `channel_layouts.telegram` AN und in
+  `channel_layouts.email` AUS ist (beide Ebenen ⊊ Grundauswahl, aber
+  unterschiedlich) / When der ECHTE Renderpfad (`format_email()` →
+  `render_telegram_bubbles`) läuft / Then trägt die Telegram-Tabellenzelle den
+  ECHTEN Zahlenwert der Metrik (aus `F.segment()`), nicht ein leeres Feld oder
+  „–" — das ist der Nachweis für die D5-„zweite Hälfte" (eigene
+  Telegram-Zeilenmenge), unabhängig vom Spalten-Nachweis aus AC-3.
+  - Test: `report.telegram_bubbles`-Text parsen (Vorbild
+    `_narrow_table`-Zeilenformat), Zellwert der Zielmetrik gegen den erwarteten
+    numerischen Wert aus `F.segment()` prüfen — NICHT nur Spalten-Präsenz.
+
+- **AC-6 (E-Mail bleibt unverändert, insbesondere Etappen ab Tag 4):** Given
+  ein Trip ohne Kanal-Widerspruch (E-Mail-Kanal-Ebene fehlt oder ist mit der
+  Grundauswahl identisch) mit mindestens einer Etappe, für die
+  `_allowed_col_keys_for_horizon()` `None` liefert (`html.py:924-947`,
+  `horizon=None` ab Tag 4, `helpers.py:318-322`) / When `format_email()` vor
+  und nach dem Umbau mit identischem Input läuft / Then sind `email_html` und
+  `email_plain` byte-identisch — insbesondere bleibt die
+  Stundentabellen-Kopfzeile unverändert, weil `seg_tables` (`trip_report.py:146`)
+  weiterhin ausschließlich aus der kollabierten `dc` gebaut wird und die
+  Telegram-eigene Zeilenmenge (D5) eine separate Variable ist, die den
+  E-Mail-Pfad nicht berührt.
+  - **Test (verbindliche Form — „vorher/nachher" ist KEIN automatisierbarer
+    Wächter):** Ein Test, der nur zwei Läufe *derselben* Codeversion
+    vergleicht, kann nie rot werden. Die Zusicherung ist stattdessen als
+    Eigenschaft EINES Laufs zu prüfen: Given eine Fixture-Variante, in der
+    die **Telegram**-Ebene eine echte Obermenge der **E-Mail**-Ebene ist
+    (mindestens eine Metrik nur in Telegram) / When `format_email()` läuft /
+    Then enthält die Kopfzeile der E-Mail-Stundentabelle für eine Etappe mit
+    `horizon=None` **genau** die Spalten der E-Mail-Auswahl — die
+    Telegram-exklusive Metrik darf dort NICHT auftauchen.
+    Das ist der Wächter gegen den in der Analyse verworfenen Ansatz
+    („`seg_tables` global verbreitern"): würde jemand die Zeilenmenge
+    gemeinsam statt getrennt aufbauen, liefe genau dieser Test rot, weil
+    `visible_cols(rows)` (`email/helpers.py:296-299`) die Spalten bei
+    `allowed_col_keys=None` aus den Zeilen-Schlüsseln ableitet.
+    Zusätzlich zulässig, aber nicht ausreichend: ein in der RED-Phase gegen
+    den unveränderten Stand aufgenommenes Soll-Artefakt (Golden File) der
+    E-Mail-Ausgabe derselben Fixture.
+
+- **AC-7 (Leere/fehlende Grundauswahl schneidet nicht):** Given `dc.metrics ==
+  []` (leere globale Liste) UND eine SMS-Kanal-Ebene mit mehreren aktiven
+  Einträgen / When `get_metrics_for_channel("sms", …)` läuft / Then bleibt die
+  vollständige SMS-Kanal-Ebene unverändert erhalten — D4 greift, kein
+  Totalausfall.
+  - Test: Fixture-Variante mit geleerter `metrics`-Liste (Roh-JSON-Patch,
+    Vorbild `_cascade_sms_variant`), Assertion `len(get_metrics_for_channel("sms",
+    …)) == len(per_channel_layouts["sms"])`.
+
+- **AC-8 (`per_report_layouts` wird gegen die globale Menge geschnitten, NICHT
+  gegen `per_channel_layouts`):** Given `per_report_layouts["evening"]["sms"]`
+  enthält eine Metrik, die global aktiv, aber im allgemeinen
+  `per_channel_layouts["sms"]` nicht enthalten oder dort deaktiviert ist /
+  When `get_metrics_for_channel("sms", "evening")` läuft / Then bleibt die
+  Metrik im Ergebnis erhalten — der Schnitt (D3) prüft ausschließlich gegen
+  die globale Menge, eine Verkettung mit der Kanal-Ebene würde sie fälschlich
+  ausschließen.
+  - Test: Fixture-Variante, die zusätzlich `per_report_layouts.evening.sms`
+    ergänzt (in der Basis-Fixture nicht vorhanden, 0 Bestandsträger laut
+    Kontext-Dokument), Ziel-Metrik global aktiv + per_channel abweichend.
+
+- **AC-9 (Report-Typ-Flags wirken im Schnitt):** Given ein globaler Eintrag
+  mit `evening_enabled=False` für eine Metrik, deren SMS-Kanal-Eintrag
+  `enabled: true` (ohne eigenen `evening_enabled`-Override) führt / When der
+  SMS-Renderpfad für `report_type="evening"` läuft / Then fehlt die Metrik im
+  SMS-Text für den Abend-Report, weil D2 gegen
+  `get_metrics_for_report_type("evening")` schneidet, wo die Metrik wegen
+  `evening_enabled=False` nicht enthalten ist — ein Schnitt gegen rohe
+  `enabled`-Flags hätte sie fälschlich durchgelassen.
+  - Test: Fixture-Variante mit `evening_enabled: false` am globalen Eintrag
+    einer kollisionssicheren Ziel-Metrik, SMS-Kanal-Eintrag unverändert aktiv;
+    Assertion gegen `report.sms_text` für `report_type="evening"`.
+
+- **AC-10 (Editor-Sequenz aus K1 als Datenlage-AC):** Given eine SMS-Kanal-
+  Ebene ist zunächst ein vollständiger Snapshot der Grundauswahl (identische
+  Einträge/Zustände) — danach wird AUSSCHLIESSLICH der globale Eintrag einer
+  Metrik auf `enabled: false` gesetzt, der SMS-Kanal-Eintrag bleibt
+  unverändert `enabled: true` (exakt die Reproduktionsfolge aus dem
+  Kontext-Dokument: SMS-Tab öffnen → zurück zur Grundauswahl → dort abwählen →
+  speichern) / When alle drei Kanal-Renderpfade laufen / Then verschwindet die
+  Metrik auch aus dem SMS-Kanal.
+  - Test: zweistufig konstruierte Fixture-Variante (erst Kanal-Ebene =
+    Kopie der Grundauswahl, dann NUR der globale Eintrag geändert) — ergänzt
+    AC-1 um den Nachweis, dass auch der über den Editor real erreichbare
+    Entstehungsweg (nicht nur die vorgefundene Ist-Fixture) abgesichert ist.
+
+- **AC-11 (SMS/Premium-SMS erben ohne eigene Änderung am Versandpfad):**
+  Given `output/channels/premium_sms.py` sendet `report.sms_text` unverändert
+  (Z. 19-21) UND `trip_report.py:295` liest die SMS-Kaskade unter dem
+  Schlüssel `"sms"` / When AC-1 bis AC-2 sowie AC-9/AC-10 gegen `report.sms_text`
+  laufen / Then gilt jedes Ergebnis strukturell auch für Premium-SMS — kein
+  separater Render-Aufruf oder eigene Kaskaden-Ebene `channel_layouts.premium_sms`
+  nötig oder vorhanden (D7).
+  - **Test (verbindliche Form — Struktur-Behauptung genügt NICHT):** Die
+    Abwesenheit eines `"premium_sms"`-Schlüssels zu assertieren, belegt das
+    Verhalten nicht; „erbt sich schon" ist bei diesem Kanal bereits einmal
+    falsch gewesen. Der Nachweis läuft über den **echten Versandweg**: der
+    Text, den `PremiumSmsOutput.send()` hinausgibt, wird an einem lokalen
+    HTTP-Empfänger abgenommen (bestehendes Muster `premium_sms_stub`,
+    `tests/tdd/test_channel_origin_guard_parity.py:211-229` — echter Server,
+    kein Mock) und muss (a) zeichengleich `report.sms_text` sein und (b) das
+    Kürzel der durch den Schnitt entfernten Metrik NICHT enthalten.
+    Damit ist Premium-SMS als vierter, gleichrangiger Kanal an derselben
+    Zusicherung gemessen wie die anderen drei — nicht bloß als Erbe
+    behauptet.
+
+- **AC-12 (Abgeleitete Nachtgrößen fallen nicht unbeabsichtigt aus einer
+  Kanal-Ebene):** Given die globale Liste enthält einen `"temperature"`-
+  Eintrag, sodass `loader.py:810-819` `"temperature_night"` ableitet und an
+  `self.metrics` anhängt, UND eine SMS-Kanal-Ebene führt ebenfalls einen
+  expliziten `"temperature_night"`-Eintrag mit `enabled: true` (wie ein
+  Editor-Snapshot ihn nach K1 anlegen könnte) / When
+  `get_metrics_for_channel("sms", …)` läuft / Then bleibt `"temperature_night"`
+  im SMS-Ergebnis erhalten — der Schnitt (D2, ID-basiert gegen
+  `get_metrics_for_report_type()`) erkennt die abgeleitete Größe korrekt, ohne
+  Sonderbehandlung, weil ihre ID bereits Teil des abgeleiteten globalen
+  Maximums ist.
+  - Test: Fixture-Variante mit globalem `"temperature"` + explizitem
+    `"temperature_night"`-Eintrag im SMS-Kanal-Layout; Assertion auf die von
+    `get_metrics_for_channel("sms", …)` zurückgegebene ID-Liste (nicht auf den
+    SMS-Text — Nachtgrößen haben eine eigene, hier nicht betroffene
+    Token-Ableitung, s. `reference_trip_temperature_is_specially_computed`).
+    Diese Liste speist direkt `_sms_metrics_ordered`/`sms_metric_ids`
+    (`trip_report.py:295-296`) — das ist der korrekte Wirkort für diese
+    Zusicherung.
+
+## Known Limitations
+
+1. **Bestehende Kaskaden-Umgehung bleibt bestehen:** die Telegram-
+   Kurzübersicht (`narrow.py:735/741/776`) liest `dc.get_enabled_metric_ids()`
+   statt der Kanal-Kaskade und bleibt damit an die (nach D5 weiterhin
+   kollabierte) E-Mail-Auswahl gekoppelt. Durch S2 wird das nicht schlimmer
+   (bereits in S1 als „Adversary Angriff 5" benannt) — Behebung ist nicht Teil
+   dieser Scheibe.
+2. **`dataclasses.replace(dc, metrics=…)` bleibt bestehen** — die Wurzel, dass
+   `dc` nach der E-Mail-Kollabierung über ihre eigene Grundauswahl „lügt",
+   wird nicht aufgelöst. D5 umschifft die Auswirkung für Telegram gezielt
+   (analog dem `_dc_uncollapsed`-Muster für SMS aus #1575), löst die Ursache
+   aber nicht auf. Folgearbeit, nicht S2.
+3. **Keine Datenmigration für Bestandstrips** mit bereits „erweiternden"
+   Kanal-Layouts — bewusster Verzicht (D6). Betroffene Konfigurationen fallen
+   nach dieser Scheibe still auf AUS zurück (ADR-0050, „Negativ/Preis").
+4. **Docstring-Korrekturen sind Teil dieser Scheibe** (`models.py:826-841`,
+   `loader.py:836-841` beschreiben heute eine Ersetzungs-Semantik) — reiner
+   Text, kein Verhaltens-Nachweis nötig.
+
+## Nicht in dieser Scheibe
+
+- **Frontend** (Editor-Zustandsanzeige „Aus ist ein Zustand" statt Löschung,
+  `CHANNEL_COL_BUDGET.sms`-Korrektur, ADR-0050 Regel 4) — Scheibe S3.
+- **Legende/Erklärtext zur Kaskade im UI** — Scheibe S4.
+- **Telegram-Kurzübersicht** (`narrow.py:735/741/776`) — bleibt an die
+  E-Mail-Kollabierung gekoppelt, ausdrücklich unverändert durch diese Scheibe
+  (s. Known Limitations 1).
+- **Auflösung der `dataclasses.replace`-Kollabierung als Ganzes** (drei
+  E-Mail-Renderer von `dc.metrics` entkoppeln) — Folgearbeit, nicht S2.
+- **Datenmigration für Bestandstrips** — D6, begründet verzichtet.
+
+## Offene Fragen
+
+Keine blockierenden. Die in Scheibe 1 als offen benannte Migrationsfrage ist
+mit D6 beantwortet (Verzicht, begründet). Die übrigen dort offen gelassenen
+Punkte (Telegram-Kurzübersicht, `dataclasses.replace`-Auflösung) sind bewusste
+Abgrenzungen dieser Scheibe (s. „Nicht in dieser Scheibe"), keine offenen
+Fragen.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** ADR-0050 (`docs/adr/0050-metrik-kaskade-verfeinerung-nicht-ersetzung.md`),
+  bereits in Scheibe 1 verabschiedet und indiziert.
+- **Rationale:** Diese Scheibe setzt Regeln 1-3 und 5 der bestehenden
+  Entscheidung im Produktivcode um (Regel 4 ist Frontend/S3). Kein neues ADR
+  nötig, kein Änderungsbedarf am ADR-Index.
+
+## Prüfhinweis für den Adversary
+
+Leitfrage aus CLAUDE.md: **Ist die Zusicherung dort geprüft, wo sie WIRKT —
+oder nur dort, wo der Code steht?** Konkreter Fallstrick in dieser Scheibe:
+der S1-Helfer `_kaskade_telegram_cells()` ruft `render_for_channel()` direkt
+mit einer frisch geladenen `dc` auf und geht NIE durch `format_email()`s
+Kollabierungsschritt — er kann K2 (AC-4) strukturell nicht sehen. AC-4/AC-5
+MÜSSEN über den echten End-zu-End-Pfad (`report.telegram_bubbles`) laufen.
+
+**Pflicht-Mutationsproben:**
+
+- **(a) Schnitt aus D1 weglassen** (Zeilen um `models.py:846-860` auf die
+  alte Ersetzung zurückdrehen) ⇒ AC-1 UND AC-5 (Telegram-Wert) MÜSSEN BEIDE
+  rot werden, nicht nur eines — AC-1 prüft SMS/E-Mail/Telegram-Spalten für den
+  Kern-Fall, AC-5 prüft zusätzlich den Telegram-Wert für einen anderen
+  Fixture-Fall; ein Fix, der nur einen der beiden Pfade repariert, muss
+  sichtbar bleiben.
+- **(b) Schnitt gegen rohe `enabled`-Flags statt gegen
+  `get_metrics_for_report_type()`** ⇒ AC-9 (Report-Typ-Flags) MUSS rot werden
+  — die Metrik bliebe fälschlich im Abend-SMS-Text, obwohl `evening_enabled`
+  sie ausschließt.
+- **(c) `if not self.metrics`-Schutz (D4) entfernen** ⇒ AC-7 (Leerauswahl)
+  MUSS rot werden — die SMS-Kanal-Ebene würde auf `[]` kollabieren.
+- **(d) `dc=_dc_uncollapsed` an `render_telegram_bubbles` zurückdrehen** (Z.
+  260 wieder `dc=dc`) ⇒ AC-4 MUSS rot werden (K2-Regression: Telegram folgt
+  wieder der kollabierten E-Mail-Auswahl statt der Grundauswahl). AC-3 bleibt
+  davon UNBERÜHRT, weil `per_channel_layouts`/`per_report_layouts` von
+  `dataclasses.replace` nicht verändert werden (Kontext-Dokument Abschnitt 2)
+  — AC-3 prüft ausschließlich den Fall MIT eigener Telegram-Ebene.
+- **(e) die eigene Telegram-Zeilenmenge (D5, zweite Hälfte) zurückdrehen**
+  (Telegram bekommt wieder die aus der kollabierten `dc` gebaute `seg_tables`,
+  während `dc=_dc_uncollapsed` für die Spaltenermittlung korrekt bleibt) ⇒
+  AC-5 (Wert) MUSS rot werden — die Spalte erscheint, aber leer/„–". AC-3
+  (Spalten-Präsenz, geprüft unabhängig von `seg_tables` über
+  `render_for_channel`/`_kaskade_telegram_cells`) bleibt dabei GRÜN. Das
+  belegt, dass AC-3 und AC-5 unterschiedliche Dinge bewachen — ein Fix, der
+  nur die Spalten-Hälfte von D5 umsetzt, muss trotzdem als unvollständig
+  auffallen.
+- **Verwechslungsprobe (Vorbild S1):** in AC-9/AC-10 versehentlich dieselbe
+  Ziel-Metrik-ID wie AC-1/AC-7 verwenden — muss an der jeweiligen
+  Vorbedingungs-Assertion (global aktiv vs. global inaktiv) erkennbar
+  scheitern, bevor die eigentliche Prüfung überhaupt läuft.
+
+## Bekannt rot werdende Bestandstests (mechanisch zu reparieren)
+
+Fünf Bestandstests haben Kanal-Metriken, die in der jeweiligen globalen
+Fixture-Liste **nicht** vorkommen — genau das von ADR-0050 verbotene Muster,
+das D1 jetzt schneidet:
+
+- `tests/tdd/test_issue_429_channel_layouts.py::test_ac3_per_channel_layout_wins_over_global`
+  (Z. 189-203) — Kanal-Layout führt `temperature`, `wind_chill`, `wind`,
+  `gust`, `precipitation`, `cloud_total`.
+- `tests/tdd/test_issue_429_channel_layouts.py::test_ac5_channel_limits_still_applied_with_per_channel_layouts`
+  (Z. 224-238) — Telegram-Layout mit 10 `metric_{i}`-Einträgen.
+- `tests/tdd/test_issue_434_per_report_layouts.py::test_ac3_per_report_wins_over_per_channel`
+  (Z. 170-183) — `per_report`-Override führt `temperature`, `precipitation`,
+  `wind`, `gust`, `wind_chill`.
+- `tests/integration/test_issue_448_validator_metrics_for_channel.py::test_ac2_per_channel_layout_returns_per_channel`
+  (Z. 232-247) — Kanal-Layout führt `precipitation`.
+- `tests/integration/test_issue_448_validator_metrics_for_channel.py::test_ac3_per_report_beats_per_channel`
+  (Z. 249-264) — `per_report`-Override führt `sunshine_hours`, Kanal-Layout
+  `wind_speed`.
+
+**Reparatur = globale Liste der jeweiligen Test-Fixture-Hilfsfunktion
+(`_per_channel_trip_data()`, `_per_report_trip_data()`, `trip_per_channel`,
+`trip_per_report_and_channel`) um genau diese fehlenden Metrik-IDs ergänzen.**
+Die Reparatur darf die Testaussage NICHT abschwächen: jeder Test prüft nach
+der Ergänzung weiterhin dieselbe Kaskaden-Priorität (per_report > per_channel
+> global) wie vorher — nur die Vorbedingung „Kanal-Metrik ist auch global
+aktiv" kommt hinzu, weil sie unter ADR-0050 immer gelten muss. Assertions auf
+die Ergebnis-Liste/-Reihenfolge bleiben unverändert; wo ein Test bislang eine
+NICHT global vorhandene Metrik als Erwartung nutzte, muss diese Erwartung
+durch dieselbe Metrik ersetzt werden, nachdem sie auch der globalen Liste
+hinzugefügt wurde — nicht durch eine andere, um die geprüfte Kaskadenlogik
+nicht zu verwässern.
+
+## Changelog
+
+- 2026-08-11: Initial spec created (Issue #1719, Scheibe 2). Grundlage:
+  `docs/context/fix-1719-s2-kaskade-verfeinerung.md` (gemessen, Basis-Commit
+  `32b781ed` = Merge PR #1735, Scheibe 1).

--- a/frontend/e2e/metrik-grundauswahl-schneidet-kanal.staging.setup.ts
+++ b/frontend/e2e/metrik-grundauswahl-schneidet-kanal.staging.setup.ts
@@ -1,0 +1,35 @@
+import { test as setup, expect } from '@playwright/test';
+import { assertNotProdBaseURL } from './prodUrlGuard';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+// Staging-Auth für Issue #1719 Scheibe 2 AC-10 Test B. Analog
+// compare-hub-save-chip.staging.setup.ts: nginx-Basic-Auth (Validator-Creds)
+// UND App-Login (gz_session-Cookie via GZ_AUTH_*) sind getrennte
+// Credential-Paare (s. reference_staging_app_login_creds_live_in_staging_env
+// bei Staging-Ziel). Ein storageState statt Login pro Test — sonst erschöpft
+// die Suite das Staging-Login-Rate-Limit (#703).
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const authFile = path.join(__dirname, 'playwright', '.auth', 'staging-1719-s2.json');
+
+setup('authenticate via API (staging) — issue_1719_s2_kaskade_verfeinerung', async ({
+	playwright
+}) => {
+	const base = process.env.GZ_SVELTE_BASE ?? 'https://staging.gregor20.henemm.com';
+	assertNotProdBaseURL(base);
+	const nginxUser = process.env.GZ_VALIDATOR_USER ?? 'admin';
+	const nginxPass = process.env.GZ_VALIDATOR_PASS ?? 'test1234';
+	const appUser = process.env.GZ_AUTH_USER ?? process.env.E2E_USER ?? 'admin';
+	const appPass = process.env.GZ_AUTH_PASS ?? process.env.E2E_PASS ?? 'test1234';
+
+	const ctx = await playwright.request.newContext({
+		baseURL: base,
+		ignoreHTTPSErrors: true,
+		httpCredentials: { username: nginxUser, password: nginxPass }
+	});
+	const res = await ctx.post('/api/auth/login', {
+		data: { username: appUser, password: appPass }
+	});
+	expect(res.ok(), `login HTTP ${res.status()}`).toBeTruthy();
+	await ctx.storageState({ path: authFile });
+	await ctx.dispose();
+});

--- a/frontend/e2e/metrik-grundauswahl-schneidet-kanal.staging.spec.ts
+++ b/frontend/e2e/metrik-grundauswahl-schneidet-kanal.staging.spec.ts
@@ -1,0 +1,136 @@
+// E2E (Staging) — Issue #1719 Scheibe 2 AC-10 Test B: die real erreichbare
+// Editor-Sequenz aus K1 (Kontext-Dokument) wird GEKLICKT, nicht konstruiert.
+// SMS-Kanal-Reiter editieren (erzeugt die Kanal-Kopie, copy-on-write,
+// WeatherMetricsTab.svelte:638) -> zurück zur (immer sichtbaren)
+// Grundauswahl -> dort die Ziel-Metrik abwählen -> speichern -> zugestellte
+// SMS-Kurzform (api/routers/preview.py, echter format_email()-Renderpfad)
+// darf die Metrik nicht mehr führen.
+//
+// Läuft bewusst gegen den UNVERÄNDERTEN Editor (S3 behebt "Aus ist ein
+// Zustand" erst später) — der Klickpfad beweist die S2-Zusicherung (die
+// zugestellte Ausgabe folgt der Grundauswahl), nicht ADR-0050 Regel 4.
+//
+// Vorbilder: weather-metrics-tab-autosave.spec.ts (createTrip/report_config-
+// Normalisierung gegen den Mount-Effekt-Autosave), layout-tab-route.spec.ts
+// (channel-tab-*, wm2-reihenfolge-row, "Aus"-Button), issue-776-metrics-
+// toggle.spec.ts (Testaufbau-Konventionen).
+//
+// Ausführen (gegen Staging, aus frontend/):
+//   set -a; source /home/hem/gregor_zwanzig/.claude/validator.env; set +a
+//   npx playwright test --config=e2e/playwright.metrik-grundauswahl-schneidet-kanal.staging.config.ts
+
+import { test, expect, type APIRequestContext } from '@playwright/test';
+
+const TRIP_ID = 'e2e-1719-s2-kaskade';
+
+// Vorab-normalisierter report_config-Blob (exakt wie layout-tab-route.spec.ts):
+// verhindert, dass EditReportConfigSections Mount-Effekt einen Auto-Save mit
+// noch-leeren buckets schedult und die Metriken-Seed überschreibt.
+const REPORT_CONFIG = {
+	enabled: true,
+	morning_enabled: true,
+	evening_enabled: true,
+	morning_time: '07:00:00',
+	evening_time: '18:00:00',
+	send_email: true,
+	send_telegram: false,
+	send_sms: false,
+	multi_day_trend_morning: false,
+	multi_day_trend_evening: true,
+	multi_day_trend_reports: ['evening'],
+	show_compact_summary: true,
+	show_daylight: true,
+	wind_exposition_min_elevation_m: null,
+	show_stage_stats: true,
+	show_quick_take_tags: true,
+	show_stability: true,
+	show_highlights: true,
+	daily_summary_metrics: ['precipitation', 'wind', 'visibility', 'thunder'],
+	show_metrics_summary: false,
+	show_outlook: true,
+	email_format: 'full',
+	show_yesterday_comparison: true
+};
+
+async function createTrip(request: APIRequestContext) {
+	await request.delete(`/api/trips/${TRIP_ID}`).catch(() => {});
+	await request.post('/api/trips', {
+		data: {
+			id: TRIP_ID,
+			name: 'E2E #1719 S2 Kaskade',
+			report_config: REPORT_CONFIG,
+			display_config: {
+				metrics: [
+					{ metric_id: 'gust', enabled: true, bucket: 'primary', order: 0 },
+					{ metric_id: 'precipitation', enabled: true, bucket: 'primary', order: 1 }
+				]
+			},
+			stages: [
+				{
+					id: `${TRIP_ID}-stage-1`,
+					name: 'Etappe 1',
+					date: new Date().toISOString().slice(0, 10),
+					waypoints: [
+						{ id: `${TRIP_ID}-wp-1`, name: 'Start', lat: 46.5, lon: 8.1, elevation_m: 1800 },
+						{ id: `${TRIP_ID}-wp-2`, name: 'Ziel', lat: 46.6, lon: 8.2, elevation_m: 2400 }
+					]
+				}
+			]
+		}
+	});
+}
+
+test.describe('Issue #1719 S2 AC-10 Test B: Grundauswahl-Abwahl schneidet SMS-Kanal-Kopie', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.setViewportSize({ width: 1440, height: 900 });
+	});
+
+	test.afterAll(async ({ request }) => {
+		await request.delete(`/api/trips/${TRIP_ID}`).catch(() => {});
+	});
+
+	test('SMS-Reiter-Edit + Grundauswahl-Abwahl -> "gust" verschwindet aus der zugestellten SMS-Vorschau', async ({
+		page,
+		request
+	}) => {
+		await createTrip(request);
+		await page.goto(`/trips/${TRIP_ID}?tab=weather`);
+		await page.getByTestId('trip-detail-tab-weather').click();
+		const tab = page.getByTestId('weather-metrics-tab');
+		await expect(tab).toBeVisible({ timeout: 10_000 });
+		await expect(tab.getByTestId('wm2-grundauswahl').locator('.toggle-btn').first()).toBeVisible({
+			timeout: 10_000
+		});
+
+		// SMS-Kanal-Reiter öffnen UND editieren -> copy-on-write legt die
+		// SMS-Kanal-Kopie als Snapshot der Grundauswahl an (gust bleibt darin
+		// aktiv -- nur precipitation wird IN DIESER Kopie entfernt).
+		await tab.getByTestId('channel-tab-sms').click();
+		const precipRow = tab.locator('[data-testid="wm2-reihenfolge-row"][data-metric-id="precipitation"]');
+		await expect(precipRow).toBeVisible();
+		await precipRow.getByRole('button', { name: 'Aus' }).click();
+		await expect(page.getByTestId('save-indicator')).toHaveAttribute('data-state', 'idle', {
+			timeout: 10_000
+		});
+
+		// Zurück zur Grundauswahl (kanalunabhängig immer sichtbar) -> Ziel-Metrik
+		// dort abwählen ("[title]" statt Text: "Böen" wäre sonst kein Substring-
+		// Kollisionsrisiko, aber title ist der robustere, geprüfte Anker).
+		const gustToggle = tab.locator('[data-testid="wm2-grundauswahl"] .toggle-btn[title="Böen"]');
+		await expect(gustToggle).toHaveClass(/\bon\b/);
+		await gustToggle.click();
+		await expect(page.getByTestId('save-indicator')).toHaveAttribute('data-state', 'idle', {
+			timeout: 10_000
+		});
+
+		// Zugestellte Ausgabe: der echte Versandweg-Renderpfad (format_email(),
+		// api/routers/preview.py), NICHT der Validator-Endpoint.
+		const res = await request.get(`/api/preview/${TRIP_ID}/sms?type=morning&demo=true`);
+		expect(res.ok(), `preview HTTP ${res.status()}`).toBeTruthy();
+		const body = (await res.json()) as { token_line: string };
+		expect(
+			/(^|\s)G\d/.test(body.token_line),
+			`'gust' (Kürzel 'G') erscheint trotz globaler Abwahl in der zugestellten SMS-Vorschau: ${body.token_line}`
+		).toBe(false);
+	});
+});

--- a/frontend/e2e/playwright.metrik-grundauswahl-schneidet-kanal.staging.config.ts
+++ b/frontend/e2e/playwright.metrik-grundauswahl-schneidet-kanal.staging.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from '@playwright/test';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+// E2E-Config Issue #1719 Scheibe 2 AC-10 Test B (Metrik-Kaskade: eine
+// Grundauswahl-Abwahl muss auch einen bereits eigenständigen SMS-Kanal
+// schneiden) gegen Staging. Kein lokaler webServer. Staging steht hinter
+// nginx-Basic-Auth (Validator-Creds) + App-Login (GZ_AUTH_*). Vorbild:
+// playwright.1273-s1.red.config.ts.
+//
+// Liegt bewusst UNTER frontend/e2e/ (nicht frontend/ root): der RED-Phase
+// Edit-Gate blockt Code-Dateien außerhalb der always_allowed_dirs (u.a.
+// "e2e/", s. openspec.yaml). testDir '.' löst relativ zu dieser Datei auf.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const user = process.env.GZ_VALIDATOR_USER ?? process.env.E2E_USER ?? 'admin';
+const pass = process.env.GZ_VALIDATOR_PASS ?? process.env.E2E_PASS ?? 'test1234';
+
+export default defineConfig({
+	testDir: '.',
+	timeout: 90_000,
+	retries: 0,
+	use: {
+		baseURL: process.env.GZ_SVELTE_BASE ?? 'https://staging.gregor20.henemm.com',
+		headless: true,
+		ignoreHTTPSErrors: true,
+		httpCredentials: { username: user, password: pass }
+	},
+	projects: [
+		{ name: 'setup', testMatch: /metrik-grundauswahl-schneidet-kanal\.staging\.setup\.ts/ },
+		{
+			name: 'tests',
+			testMatch: /metrik-grundauswahl-schneidet-kanal\.staging\.spec\.ts/,
+			dependencies: ['setup'],
+			use: {
+				storageState: path.join(__dirname, 'playwright', '.auth', 'staging-1719-s2.json')
+			}
+		}
+	]
+});

--- a/src/app/loader.py
+++ b/src/app/loader.py
@@ -838,7 +838,11 @@ def _parse_display_config(data: Dict[str, Any]) -> "UnifiedWeatherDisplayConfig"
     # get_metrics_for_channel auf die globale Liste zurückfällt. Eine
     # bewusst vollstaendig geleerte Kanal-Konfiguration (alle Kanal-Listen
     # []) wird seit #1394 NICHT mehr auf None zurueckgefallen (AC-7,
-    # models.py:603-606 dokumentiert diesen Vertrag bereits).
+    # models.py:603-606 dokumentiert diesen Vertrag bereits). Ist eine
+    # Kanal-Ebene vorhanden, ERSETZT sie die globale Liste HIER beim Laden
+    # NICHT -- sie wird erst beim Lesen ueber get_metrics_for_channel() gegen
+    # das globale Maximum geschnitten (ADR-0050, Issue #1719 Scheibe 2); hier
+    # wird nur roh geparst.
     per_channel_layouts: Optional[Dict[str, List[MetricConfig]]] = None
     raw_channel_layouts = data.get("channel_layouts")
     if (

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -825,12 +825,28 @@ class UnifiedWeatherDisplayConfig:
     def get_metrics_for_channel(self, channel: str, report_type: str) -> list[MetricConfig]:
         """Liefert die Metriken-Liste für einen Kanal (Issue #429 + #434).
 
-        Dreistufige Kaskade:
+        Dreistufige Kaskade, ADR-0050: die globale Auswahl (Ebene 3) ist das
+        MAXIMUM -- Ebenen 1/2 duerfen davon nur ABWAEHLEN, nie ergaenzen
+        (Issue #1719 Scheibe 2).
         1. per_report_layouts[report_type][channel] (Issue #434) — höchste Priorität.
-           Leere Liste = expliziter User-Wunsch, kein Fallback.
+           Leere Liste = expliziter User-Wunsch, kein Fallback. Wird gegen das
+           globale Maximum geschnitten (s.u.), NICHT zusaetzlich gegen
+           per_channel_layouts verkettet -- ADR-0050 kennt nur EIN Maximum,
+           keine Zwischenebene (#1719 AC-8).
         2. per_channel_layouts[channel] (Issue #429) — zweite Stufe.
-           Leere Liste = expliziter User-Wunsch, kein Fallback.
-        3. globale Liste via get_metrics_for_report_type(report_type) — Fallback.
+           Leere Liste = expliziter User-Wunsch, kein Fallback. Ebenfalls
+           gegen das globale Maximum geschnitten.
+        3. globale Liste via get_metrics_for_report_type(report_type) — Fallback
+           UND zugleich das Maximum selbst; hier greift kein Schnitt (er
+           wuerde sich gegen sich selbst richten und waere wirkungslos).
+
+        Maximum-Schnitt (#1719 Scheibe 2): Ebenen 1/2 werden auf die IDs
+        geschnitten, die ``get_metrics_for_report_type(report_type)`` liefert
+        -- NICHT gegen rohe ``enabled``-Flags, damit ``morning_enabled``/
+        ``evening_enabled`` (ADR-0050 Regel 3) und das ``selectable``-Gate
+        (#1585) im Schnitt korrekt wirken. Ist ``self.metrics`` leer, ist kein
+        Maximum definiert -- es wird NICHT geschnitten (sonst Totalausfall
+        fuer Altbestand ohne globale Liste, s. ``_clip_to_global_maximum``).
 
         Issue #1575: JEDE Ebene laeuft durch dieselbe Sortierung nach der im
         Editor eingestellten Position — sonst verhielte sich ein Trip mit
@@ -847,20 +863,43 @@ class UnifiedWeatherDisplayConfig:
             report_channel_metrics = self.per_report_layouts[report_type][channel]  # type: ignore[index]
             if len(report_channel_metrics) == 0:
                 return []
-            return _sorted_by_layout(
-                _filter_metrics_by_report_type(report_channel_metrics, report_type),
-            )
+            filtered = _filter_metrics_by_report_type(report_channel_metrics, report_type)
+            return _sorted_by_layout(self._clip_to_global_maximum(filtered, report_type))
 
         if source == "per_channel":
             channel_metrics = self.per_channel_layouts[channel]  # type: ignore[index]
             if len(channel_metrics) == 0:
                 return []
-            return _sorted_by_layout(
-                _filter_metrics_by_report_type(channel_metrics, report_type),
-            )
+            filtered = _filter_metrics_by_report_type(channel_metrics, report_type)
+            return _sorted_by_layout(self._clip_to_global_maximum(filtered, report_type))
 
-        # Ebene 3: globaler Fallback
+        # Ebene 3: globaler Fallback -- ist bereits das Maximum, kein Schnitt.
         return _sorted_by_layout(self.get_metrics_for_report_type(report_type))
+
+    def _clip_to_global_maximum(
+        self, metrics: list[MetricConfig], report_type: str,
+    ) -> list[MetricConfig]:
+        """Schneidet eine Kanal-Ebene (per_report/per_channel) gegen das
+        globale Maximum (ADR-0050, #1719 Scheibe 2, D1-D4).
+
+        Nur aufgerufen aus den per_report/per_channel-Zweigen von
+        ``get_metrics_for_channel()`` -- NIE aus dem global-Zweig, der selbst
+        das Maximum ist (D1).
+
+        Schnittmenge sind die IDs aus
+        ``get_metrics_for_report_type(report_type)`` (D2) -- nicht rohe
+        ``enabled``-Flags, damit morning_enabled/evening_enabled-Overrides
+        und das selectable-Gate (#1585) im Schnitt wirken.
+
+        D4: ``self.metrics`` leer -> kein Maximum definiert -> nicht
+        schneiden. Pruefort = Wirkort, keine Wiederverwendung von
+        ``_trip_metrics_altbestand`` (misst denselben Sachverhalt an anderer
+        Stelle fuer einen anderen Zweck).
+        """
+        if not self.metrics:
+            return metrics
+        allowed_ids = {mc.metric_id for mc in self.get_metrics_for_report_type(report_type)}
+        return [mc for mc in metrics if mc.metric_id in allowed_ids]
 
     def cascade_source_for_channel(self, channel: str, report_type: str) -> CascadeSource:
         """Issue #1677 AC-9: auf welcher Kaskadenebene antwortet

--- a/src/output/renderers/trip_report.py
+++ b/src/output/renderers/trip_report.py
@@ -253,11 +253,37 @@ class TripReportFormatter:
 
         # Issue #1001: Multi-Bubble-Telegram-Rendering (ersetzt #360-Narrow-Body).
         # Reine Zusatzberechnung — email_plain bleibt unveraendert.
+        # Issue #1719 Scheibe 2 (K2): Telegram folgt ohne eigene Kanal-Ebene
+        # der GRUNDAUSWAHL, nicht der kollabierten E-Mail-Auswahl (analog dem
+        # _dc_uncollapsed-Muster fuer SMS, #1575). seg_tables (oben, Z. 146)
+        # bleibt fuer die E-Mail unveraendert (AC-6) -- Telegram bekommt eine
+        # EIGENE, aus derselben unverfaelschten Basis gebaute Zeilenmenge,
+        # sonst blieben Telegram-Zellen leer ("-"), weil _dp_to_row() nur
+        # Metriken eintraegt, die in der uebergebenen dc enabled sind.
+        _telegram_active_metrics = [
+            dataclasses.replace(mc, enabled=True)
+            for mc in _dc_uncollapsed.get_metrics_for_channel("telegram", report_type)
+        ]
+        _dc_telegram = dataclasses.replace(_dc_uncollapsed, metrics=_telegram_active_metrics)
+        seg_tables_telegram = [self._extract_hourly_rows(s, _dc_telegram) for s in segments]
+        # Adversary F004 (S2-Fix-Runde): dc=_dc_telegram statt dc=_dc_uncollapsed
+        # -- render_telegram_bubbles() liest dc NICHT nur fuer die
+        # Spalten-/Zeilenermittlung (render_for_channel(), idempotent gegen
+        # eine bereits kaskadierte dc), sondern narrow.py:735/741/776 lesen
+        # dc.get_enabled_metric_ids() DIREKT, ohne durch get_metrics_for_channel()
+        # zu gehen. Mit _dc_uncollapsed (der rohen, ungefilterten Grundauswahl)
+        # blieb die Telegram-Kurzuebersicht + Fusszeile (Sicht/0°C-Grenze/
+        # Gewitter) vom D1-D4-Schnitt UNBERUEHRT -- eine Metrik mit
+        # evening_enabled=False erschien dort trotzdem (als "-"-Geisterzeile
+        # bzw., mit passenden Segment-Aggregaten, mit echtem Zahlenwert).
+        # _dc_telegram traegt bereits die report-typ- UND kanal-kaskadierte
+        # Menge (Z. 266-270 oben) -- EINE Quelle fuer Tabellenspalten,
+        # Kurzuebersicht UND Fusszeile.
         from output.renderers.narrow import render_telegram_bubbles
         telegram_bubbles_result = render_telegram_bubbles(
             segments=segments,
-            seg_tables=seg_tables,
-            dc=dc,
+            seg_tables=seg_tables_telegram,
+            dc=_dc_telegram,
             report_type=report_type,
             tz=self._tz,
             trip_name=trip_name,

--- a/tests/integration/test_issue_448_validator_metrics_for_channel.py
+++ b/tests/integration/test_issue_448_validator_metrics_for_channel.py
@@ -83,7 +83,14 @@ def trip_global():
 
 @pytest.fixture
 def trip_per_channel():
-    """AC-2: Trip mit channel_layouts["email"], kein per_report."""
+    """AC-2: Trip mit channel_layouts["email"], kein per_report.
+
+    Issue #1719 Scheibe 2 (ADR-0050): die globale Liste ist seit dieser
+    Scheibe das Maximum, gegen das channel_layouts geschnitten wird -- sie
+    muss deshalb precipitation/humidity fuehren (sonst schneidet der
+    per_channel-Zweig sie jetzt weg, obwohl der Trip sie im Email-Layout
+    fuehrt).
+    """
     user_id = f"test_issue_448_{uuid.uuid4().hex[:8]}"
     trip_id = "trip-per-channel"
     _write_trip(user_id, trip_id, {
@@ -95,6 +102,8 @@ def trip_per_channel():
             "metrics": [
                 {"metric_id": "temperature", "enabled": True},
                 {"metric_id": "wind_speed", "enabled": True},
+                {"metric_id": "precipitation", "enabled": True},
+                {"metric_id": "humidity", "enabled": True},
             ],
             "channel_layouts": {
                 "email": [
@@ -113,6 +122,10 @@ def trip_per_report_and_channel():
     """AC-3: Trip mit per_report_layouts["morning"]["email"] UND channel_layouts["email"].
 
     per_report muss per_channel schlagen.
+
+    Issue #1719 Scheibe 2 (ADR-0050): die globale Liste ist das Maximum --
+    wind_speed (per_channel) und sunshine_hours (per_report) muessen deshalb
+    auch global gefuehrt werden, sonst schneidet der Schnitt sie weg.
     """
     user_id = f"test_issue_448_{uuid.uuid4().hex[:8]}"
     trip_id = "trip-per-report-and-channel"
@@ -124,6 +137,8 @@ def trip_per_report_and_channel():
             "trip_id": trip_id,
             "metrics": [
                 {"metric_id": "temperature", "enabled": True},
+                {"metric_id": "wind_speed", "enabled": True},
+                {"metric_id": "sunshine_hours", "enabled": True},
             ],
             "channel_layouts": {
                 "email": [

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -59,6 +59,7 @@ from output.renderers.alert.model import AlertEvent, AlertMessage, side_label
 from output.renderers.alert.render import (
     _HANDLED_UNITS, render_email, render_sms, render_subject, render_telegram,
 )
+from output.channels.premium_sms import PremiumSmsOutput
 from output.renderers.channel_layout import render_for_channel
 from output.renderers.compare_metric_catalog import COMPARE_METRIC_CATALOG, get_compare_metric_catalog
 from output.renderers.compare_metric_ids import FRONTEND_TO_RENDERER_METRIC_ID, resolve_enabled_metrics
@@ -68,6 +69,13 @@ from output.renderers.trip_report import TripReportFormatter
 from services.weather_change_detection import _ALERT_METRIC_TO_CATALOG_ID, is_alert_metric_active
 
 from tests.tdd import _min_temp_felt_fixtures as F
+# Issue #1719 S2 AC-11: geteilter Premium-SMS-Stub (echter lokaler HTTP-
+# Server, kein Mock) -- Vorbild-Fixture wiederverwendet statt kopiert (Muster
+# bereits etabliert: pytest erkennt eine importierte @pytest.fixture-Funktion
+# auch im importierenden Modul).
+from tests.tdd.test_channel_origin_guard_parity import (
+    _prod_style_premium_sms_settings, premium_sms_stub,
+)
 
 _ALL_METRIC_IDS = [m.id for m in get_all_metrics()]
 
@@ -644,6 +652,18 @@ _AC4_5_TARGET = "freezing_level"   # Symbol "NL", global AN, SMS-Kanal AN (Basis
 _AC7_TARGET = "dewpoint"           # Symbol "DP", global AUS (Basis) -- NICHT wind_chill (Verwechslungsprobe)
 _AC12_PAIR = ("humidity", "gust")  # Symbole "HU"/"G", beide SMS-Kanal AN (Basis)
 
+# S2 AC-4 (Team-Lead-Befund/Freigabe, Nachbesserung 2026-08-11): eine EINZIGE
+# Zielmetrik reicht fuer AC-4 nicht -- Telegram-Tabellen haben nur 7 Spalten-
+# Slots (CHANNEL_LIMITS["telegram"]["max_table_cols"]=8 inkl. Zeit-Spalte,
+# channel_layout.py:47). _AC4_5_TARGET ("freezing_level", order=12 in der
+# Basis-Fixture) faellt strukturell aus diesem Platzbudget, ganz unabhaengig
+# von der Kaskade -- narrow.py::_detail_lines() (baut die Detail-Zeile fuer
+# ueberzaehlige Metriken) hat 0 Aufrufstellen in render_telegram_bubbles(),
+# "ueberzaehlig" heisst hier also "gar nicht sichtbar", nicht nur "nicht in
+# der Tabelle". "rain_probability" (order=3, Label "P%") faellt dagegen IN
+# die ersten 7 primary-Slots und beweist K2 direkt im <pre>-Tabellentext.
+_AC4_TABLE_BUDGET_TARGET = "rain_probability"  # Symbol/Label "P%", global AN, order=3 (< 7)
+
 
 def _load_cascade_fixture_raw() -> dict:
     return json.loads(_CASCADE_FIXTURE_PATH.read_text())
@@ -817,13 +837,9 @@ def test_kaskade_ac6_wind_chill_contradiction_baseline_stays_green():
     assert "wind_chill" in cells, f"AC-6: Telegram folgt ebenso der Grundauswahl: {cells}"
 
 
-# --- AC-7 (Pflicht-AC): Widerspruchsfall global AUS + Kanal AN -- MUSS heute ROT sein ---
+# --- AC-7 (Pflicht-AC): Widerspruchsfall global AUS + Kanal AN -- #1719 S2 behebt ---
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="ADR-0050 Regel 2 -- Kanal darf nicht hinzufuegen; Umbau in #1719 S2",
-)
 def test_kaskade_ac7_sms_channel_must_not_add_globally_disabled_metric():
     target = _AC7_TARGET
     symbol = SMS_SYMBOL_BY_METRIC[target]
@@ -1037,6 +1053,520 @@ def test_kaskade_ac12_sms_order_is_applied_not_positional():
     )
     assert ib_first is not None and ib_second is not None and ib_second < ib_first, (
         f"AC-12: Reihenfolge B ({second_id} vor {first_id}) nicht umgesetzt: {sms_ba!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #1719 Scheibe 2: Metrik-Kaskade -- Verfeinerungsfilter (ADR-0050
+# Regeln 1-3/5 im Produktivcode). SPEC:
+# docs/specs/modules/fix_1719_s2_kaskade_verfeinerung.md (12 ACs).
+#
+# AC-1 ist der bereits bestehende test_kaskade_ac7_... oben -- die
+# xfail(strict)-Markierung aus der S1-RED-Phase ist mit dieser Scheibe
+# ENTFERNT (der Test lief zuvor per `pytest --runxfail` als RED-Beleg,
+# s. Spec AC-1 "Wichtiger Konstruktionshinweis"; jetzt regulaer GRUEN).
+# Die restlichen elf ACs bekommen die eigene Namensform
+# `test_kaskade_s2_ac<n>_...`, damit sie NICHT mit den S1-Funktionsnamen
+# (test_kaskade_ac2_..., test_kaskade_ac4_..., ...) kollidieren -- S1 und S2
+# zaehlen ihre ACs unabhaengig voneinander, S2 AC-2 ist NICHT S1 AC-2.
+#
+# Gemessener RED/GRUEN-Start je AC (diese Session, 2026-08-11): S2-AC-2/3/11/12
+# starten GRUEN (Regressionsschutz/Charakterisierung, kein Mangel). S2-AC-4/5/
+# 9/10 starten ROT (echte, gemessene Bugs). S2-AC-7/8 starten -- ENTGEGEN der
+# urspruenglichen Erwartung -- ebenfalls GRUEN: der heutige Code schneidet
+# ueberhaupt nicht (weder gegen global noch gegen per_channel), die beiden
+# Kanten werden erst durch die kommende Implementierung ueberhaupt beruehrbar.
+# Details dazu im Bericht an den Product Owner.
+# ---------------------------------------------------------------------------
+
+
+def _global_entry(raw: dict, metric_id: str) -> dict:
+    return next(e for e in raw["metrics"] if e["metric_id"] == metric_id)
+
+
+def _cascade_channel_variant(channel_layouts: dict) -> UnifiedWeatherDisplayConfig:
+    """Roh-JSON-Variante der Basis-Fixture mit VOLLSTAENDIG ersetztem
+    channel_layouts (statt einzelner Feld-Patches wie _cascade_sms_variant) --
+    fuer die email-/telegram-Kanal-Ebenen dieser Scheibe, die die Basis-
+    Fixture nicht traegt. Erneut durch den ECHTEN Loader (S1 AC-2)."""
+    raw = _load_cascade_fixture_raw()
+    raw["channel_layouts"] = channel_layouts
+    return _parse_display_config(raw)
+
+
+_S2_LABEL_TOKEN_RE_CACHE: dict[str, "re.Pattern[str]"] = {}
+
+
+def _label_token_present(text: str, label: str) -> bool:
+    """Sucht `label` als abgegrenzten Token (Leerraum-/Zeilengrenzen) in
+    `text` -- robust gegen Zeilenumbrueche durch die Telegram-Bubble-Breite
+    (_TG_TABLE_WIDTH=32, narrow.py), die einzelne Woerter/Kuerzel nie mitten
+    zerschneidet (narrow.py::_wrap)."""
+    pattern = _S2_LABEL_TOKEN_RE_CACHE.setdefault(
+        label, re.compile(rf"(?<!\S){re.escape(label)}(?!\S)"),
+    )
+    return pattern.search(text) is not None
+
+
+def _kaskade_telegram_table_text(report) -> str:
+    """Der <pre>-Textblock der (ersten) Telegram-Segment-Tabellenbubble --
+    echter End-zu-End-Pfad (report.telegram_bubbles), NICHT render_for_channel()
+    direkt (Konstruktionshinweis AC-4/AC-5 der Spec: der direkte Aufruf geht
+    nie durch format_email()s Kollabierungsschritt und kann K2 strukturell
+    nicht sehen)."""
+    for bubble in report.telegram_bubbles:
+        if "<pre>" in bubble:
+            return bubble.split("<pre>", 1)[1].split("</pre>", 1)[0]
+    raise AssertionError(f"keine Telegram-Tabellenbubble gefunden: {report.telegram_bubbles!r}")
+
+
+# --- S2 AC-2: Kanal-Grenze bleibt dicht -- SMS-Abwahl aendert email/telegram nicht ---
+
+
+def test_kaskade_s2_ac2_sms_deselect_cannot_affect_email_or_telegram_source():
+    """S2 AC-2 (Regressions-Bestaetigung + global-Zweig-Beleg): die S1-Faelle
+    AC-4/AC-6 oben bleiben nach dem Umbau unveraendert gruen (nicht dupliziert
+    -- diese Funktion ergaenzt nur die fehlende Zusicherung, dass E-Mail und
+    Telegram strukturell auf der GLOBALEN Ebene antworten; der Schnitt aus D1
+    greift ausschliesslich in den per_report-/per_channel-Zweigen)."""
+    dc = _load_cascade_dc()
+    assert dc.cascade_source_for_channel("email", "evening") == "global"
+    assert dc.cascade_source_for_channel("telegram", "evening") == "global"
+
+
+# --- S2 AC-3: Telegram MIT eigener Ebene = Telegram ∩ Grundauswahl ---
+
+
+def test_kaskade_s2_ac3_telegram_own_layer_intersects_base_selection():
+    """S2 AC-3: geprueft ueber render_for_channel() direkt (wie
+    _kaskade_telegram_cells) -- bewusst UNABHAENGIG von format_email()s
+    Kollabierungsschritt (D5), weil eine EIGENE Telegram-Ebene die
+    Ersetzungssemantik des heutigen Codes bereits korrekt behandelt (der
+    per_channel-Zweig liest self.metrics gar nicht)."""
+    target = _AC4_5_TARGET  # "freezing_level", global AN in der Basis-Fixture
+    raw = _load_cascade_fixture_raw()
+    telegram_layout = [
+        {**e, "enabled": False} if e["metric_id"] == target else e
+        for e in raw["metrics"]
+    ]
+    dc = _cascade_channel_variant({"telegram": telegram_layout})
+    assert dc.cascade_source_for_channel("telegram", "evening") == "per_channel"
+
+    cells = _kaskade_telegram_cells(dc)
+    assert target not in cells, (
+        f"S2 AC-3: {target!r} bleibt trotz eigener Telegram-Abwahl sichtbar: {cells}"
+    )
+    assert "wind_chill" in cells, (
+        f"S2 AC-3: eine andere global aktive Metrik faellt faelschlich mit weg: {cells}"
+    )
+
+
+# --- S2 AC-4/AC-5: Telegram OHNE eigene Ebene -- K2 (Spalte + echter Wert) ---
+
+
+def test_kaskade_s2_ac4_telegram_without_own_layer_follows_base_not_email():
+    """S2 AC-4 (K2): der ECHTE Renderpfad -- report.telegram_bubbles, NICHT
+    render_for_channel() direkt (s. Konstruktionshinweis der Spec: der
+    direkte Aufruf geht nie durch die E-Mail-Kollabierung und kann K2
+    strukturell nicht sehen).
+
+    ZWEI Zielmetriken (Team-Lead-Befund/Freigabe, Nachbesserung 2026-08-11):
+    Telegram-Tabellen haben nur 7 Metrik-Slots (Platzbudget, s.
+    ``_AC4_TABLE_BUDGET_TARGET``-Kommentar oben) -- eine Metrik jenseits
+    dieses Budgets verschwindet aus dem <pre>-Tabellentext, UNABHAENGIG
+    davon, ob die Kaskade sie korrekt durchlaesst. Ein einzelner
+    Tabellen-Check koennte deshalb aus dem falschen Grund rot werden (Budget
+    statt Kaskade) oder aus dem falschen Grund gruen bleiben, wenn die
+    Zielmetrik zufaellig im Budget liegt. Deshalb zwei Assertions:
+    ``_AC4_TABLE_BUDGET_TARGET`` (im Budget) beweist K2 direkt im
+    Tabellentext; ``_AC4_5_TARGET`` (ausserhalb des Budgets) beweist, dass
+    der Schnitt sie trotzdem in der Kanal-AUSWAHL belaesst (table_columns +
+    detail_metrics) -- verschwindet sie DORT auch, liegt es an der Kaskade,
+    nicht am Platzbudget.
+    """
+    table_target = _AC4_TABLE_BUDGET_TARGET
+    capacity_target = _AC4_5_TARGET
+    raw = _load_cascade_fixture_raw()
+    email_layout = [
+        {**e, "enabled": False} if e["metric_id"] in (table_target, capacity_target) else e
+        for e in raw["metrics"]
+    ]
+    dc = _cascade_channel_variant({"email": email_layout})
+    assert dc.cascade_source_for_channel("email", "evening") == "per_channel"
+    assert dc.cascade_source_for_channel("telegram", "evening") == "global", (
+        "Vorbedingung: Telegram hat keine eigene Ebene -- muss auf 'global' fallen"
+    )
+
+    report = _kaskade_report(dc)
+    table_text = _kaskade_telegram_table_text(report)
+    assert _label_token_present(table_text, get_metric(table_target).compact_label), (
+        f"S2 AC-4 (K2): {table_target!r} fehlt in der Telegram-Tabelle trotz globaler Aktivierung "
+        f"-- Telegram folgt faelschlich der E-Mail-Kollabierung statt der Grundauswahl: {table_text!r}"
+    )
+
+    cells = _kaskade_telegram_cells(dc)
+    assert capacity_target in cells, (
+        f"S2 AC-4: {capacity_target!r} muss trotz Telegram-Tabellen-Platzbudget Teil der "
+        f"Kanal-AUSWAHL bleiben (table_columns+detail_metrics) -- fehlt sie auch DORT, liegt es "
+        f"an der Kaskade (E-Mail-Kollabierung), nicht am Platzbudget: {cells}"
+    )
+
+
+def test_kaskade_s2_ac5_telegram_own_layer_shows_real_value_not_dash():
+    """S2 AC-5 (D5, zweite Haelfte -- eigene Telegram-Zeilenmenge): 'humidity'
+    ist in F.segment() KONSTANT 55 (humidity_pct, s. _min_temp_felt_fixtures)
+    -- die Telegram-Zelle muss diesen echten Wert zeigen, nicht '-'.
+
+    Adversary F001-Nachbesserung (Pflicht-Mutationsprobe (a) der Spec, "Schnitt
+    aus D1 weglassen" muss AC-1 UND AC-5 rot machen): 'humidity' allein ist
+    global AN und bleibt deshalb auch OHNE den D1-Schnitt sichtbar -- ein Fix,
+    der nur D5 (Wert) umsetzt, aber D1 (Schnitt) weglaesst, blieb bislang
+    unbemerkt. Zweite Zielmetrik 'cloud_mid' (Muster AC-1/_AC7_TARGET: global
+    AUS, eigene Telegram-Ebene AN) prueft D1 unabhaengig vom Wert-Nachweis."""
+    target = "humidity"
+    d1_target = "cloud_mid"
+    raw = _load_cascade_fixture_raw()
+    global_entry = _global_entry(raw, target)
+    assert global_entry.get("enabled", True) is True, "Vorbedingung: Ziel global aktiv"
+    d1_global_entry = _global_entry(raw, d1_target)
+    assert d1_global_entry.get("enabled", True) is False, (
+        "Vorbedingung: D1-Zielmetrik muss global INAKTIV sein (Muster AC-1)"
+    )
+
+    dc = _cascade_channel_variant({
+        "telegram": [
+            {**global_entry, "enabled": True},
+            {**d1_global_entry, "enabled": True},
+        ],
+        "email": [{**global_entry, "enabled": False}],
+    })
+    assert dc.cascade_source_for_channel("telegram", "evening") == "per_channel"
+    assert dc.cascade_source_for_channel("email", "evening") == "per_channel"
+
+    report = _kaskade_report(dc)
+    table_text = _kaskade_telegram_table_text(report)
+    assert _label_token_present(table_text, get_metric(target).compact_label), (
+        f"S2 AC-5: Spalte {get_metric(target).compact_label!r} fehlt in der Telegram-Tabelle: {table_text!r}"
+    )
+    assert _label_token_present(table_text, "55"), (
+        f"S2 AC-5: Zelle zeigt nicht den echten Messwert 55 (humidity_pct, F.segment() konstant) "
+        f"-- vermutlich '-' statt Wert (D5 fehlt): {table_text!r}"
+    )
+
+    cells = _kaskade_telegram_cells(dc)
+    assert d1_target not in cells, (
+        f"S2 AC-5 (F001): {d1_target!r} erscheint trotz globaler Abwahl in der Telegram-Kanal-Auswahl "
+        f"-- die eigene Telegram-Ebene darf die globale Grundauswahl nur einschraenken, nie erweitern "
+        f"(D1-Schnitt fehlt): {cells}"
+    )
+
+
+# --- S2 AC-5-Nachbesserung (F003): Force-Enable-Schritt der D5-Konstruktion ---
+
+
+def test_kaskade_s2_ac5b_evening_override_forces_real_telegram_value():
+    """Adversary F003: 'temperature' ist global INAKTIV (enabled:false), aber
+    evening_enabled=true hebt sie fuer den Abend-Report an (D2, kein eigenes
+    Telegram-Layout -- Kaskade faellt auf 'global'). trip_report.py erzwingt
+    beim Bau von _dc_telegram enabled=True auf jeder Metrik aus dem D2-Schnitt
+    (dataclasses.replace(mc, enabled=True)) -- OHNE diesen Schritt bliebe das
+    urspruengliche enabled=False stehen, und _dp_to_row() traegt nur Metriken
+    ein, die in der uebergebenen dc enabled sind: die Telegram-Zelle zeigte
+    '-' statt des echten Messwerts, obwohl die Spalte (ueber evening_enabled)
+    korrekt erscheint."""
+    target = "temperature"
+    raw = _load_cascade_fixture_raw()
+    raw["metrics"] = [
+        {**e, "enabled": False, "evening_enabled": True} if e["metric_id"] == target else e
+        for e in raw["metrics"]
+    ]
+    dc = _parse_display_config(raw)
+    assert dc.cascade_source_for_channel("telegram", "evening") == "global", (
+        "Vorbedingung: keine eigene Telegram-Ebene -- Kaskade faellt auf 'global'"
+    )
+
+    report = _kaskade_report(dc)
+    table_text = _kaskade_telegram_table_text(report)
+    assert _label_token_present(table_text, get_metric(target).compact_label), (
+        f"F003: Spalte {get_metric(target).compact_label!r} fehlt trotz evening_enabled=True: "
+        f"{table_text!r}"
+    )
+    assert _label_token_present(table_text, "15.0"), (
+        f"F003: Zelle zeigt nicht den echten Messwert 15.0 (t2m_c, F.segment() Basisstunde) -- "
+        f"vermutlich '-' statt Wert (Force-Enable-Schritt in trip_report.py fehlt): {table_text!r}"
+    )
+
+
+# --- S2 AC-6: E-Mail-Stundentabelle bleibt bei horizon=None exakt bei der eigenen Auswahl ---
+
+
+def test_kaskade_s2_ac6_email_stays_within_own_selection_at_horizon_none_stage():
+    """S2 AC-6 (Waechter gegen den verworfenen Ansatz 'seg_tables global
+    verbreitern'): die Telegram-Ebene ist echte Obermenge der E-Mail-Ebene
+    (zusaetzlich 'humidity'); geprueft an einer Etappe mit horizon=None
+    (Tag 4+, delta>=3 zum Report-Datum, email/html.py:924-947) -- dort
+    filtert _allowed_col_keys_for_horizon() NICHT, visible_cols() liest die
+    Spalten direkt aus den Zeilen-Schluesseln (email/helpers.py:296-299).
+    Eine distinkte segment_id ("SEG 4") isoliert die Kopfzeile GENAU dieser
+    Etappe -- sonst faende re.search blind das erste <thead> im HTML."""
+    dc = _cascade_channel_variant({
+        "email": [{"metric_id": "wind_chill", "enabled": True}],
+        "telegram": [
+            {"metric_id": "wind_chill", "enabled": True},
+            {"metric_id": "humidity", "enabled": True},
+        ],
+    })
+    assert dc.cascade_source_for_channel("email", "evening") == "per_channel"
+    assert dc.cascade_source_for_channel("telegram", "evening") == "per_channel"
+
+    seg_today = F.segment(day=F.DAY)
+    seg_horizon_none = F.segment(day=F.DAY + 3)
+    seg_horizon_none = dataclasses.replace(
+        seg_horizon_none,
+        segment=dataclasses.replace(seg_horizon_none.segment, segment_id=4),
+    )
+    report = TripReportFormatter().format_email(
+        [seg_today, seg_horizon_none], trip_name="Kaskade1719S2AC6", report_type="evening",
+        night_weather=None, display_config=dc, stage_name=F.STAGE_NAME, tz=F.TZ,
+    )
+    html = report.email_html
+    start = html.index("SEG 4")
+    rest = html[start:]
+    nxt = re.search(r"SEG \d", rest[1:])
+    block = rest[: nxt.start() + 1] if nxt else rest
+    head = re.search(r"<thead><tr>(.*?)</tr></thead>", block, re.S)
+    assert head, "S2 AC-6: keine Kopfzeile fuer die horizon=None-Etappe (SEG 4) gefunden"
+    headers = [
+        re.sub(r"<[^>]+>", "", th).strip()
+        for th in re.findall(r"<th[^>]*>.*?</th>", head.group(1), re.S)
+    ]
+    metric_cols = [h for h in headers if h not in {"Time", "Risk"}]
+    assert metric_cols == [get_metric("wind_chill").col_label], (
+        f"S2 AC-6: Kopfzeile der horizon=None-Etappe enthaelt mehr als die E-Mail-Auswahl "
+        f"(Telegram-exklusive Metrik 'humidity' darf hier NICHT auftauchen): {headers}"
+    )
+
+
+# --- S2 AC-7 (D4): leere/fehlende Grundauswahl schneidet nicht ---
+
+
+def test_kaskade_s2_ac7_empty_base_selection_does_not_cut_sms_channel():
+    """S2 AC-7 (D4): eine SMS-Kanal-Ebene MIT MEHREREN AKTIVEN Eintraegen
+    (bewusst kein Mix aus aktiv/inaktiv wie in der Basis-Fixture -- eine
+    Vergleichs-Laenge gegen deren VOLLE, gemischte per_channel_layouts-Liste
+    waere strukturell IMMER falsch, weil inaktive Eintraege ohnehin nie
+    zurueckkommen, unabhaengig vom Schnitt) bleibt bei LEERER globaler Liste
+    vollstaendig erhalten -- kein Totalausfall."""
+    raw = {
+        "trip_id": "x1719s2ac7",
+        "metrics": [],
+        "channel_layouts": {"sms": [
+            {"metric_id": "uv_index", "enabled": True},
+            {"metric_id": "cloud_low", "enabled": True},
+            {"metric_id": "visibility", "enabled": True},
+        ]},
+    }
+    dc = _parse_display_config(raw)
+    assert dc.cascade_source_for_channel("sms", "evening") == "per_channel"
+
+    result = dc.get_metrics_for_channel("sms", "evening")
+    assert len(result) == len(dc.per_channel_layouts["sms"]), (
+        f"S2 AC-7: leere Grundauswahl schneidet die SMS-Kanal-Ebene auf {len(result)} von "
+        f"{len(dc.per_channel_layouts['sms'])} Eintraegen -- D4 fehlt: "
+        f"{[mc.metric_id for mc in result]}"
+    )
+
+
+# --- S2 AC-8 (D3): per_report_layouts wird gegen GLOBAL geschnitten, nicht gegen per_channel ---
+
+
+def test_kaskade_s2_ac8_per_report_layer_cuts_against_global_not_per_channel():
+    """S2 AC-8 (D3): 'uv_index' ist global aktiv, aber im ALLGEMEINEN
+    per_channel_layouts.sms NICHT enthalten -- der per_report-Override fuer
+    'evening' fuehrt sie trotzdem. Eine Verkettung mit per_channel (statt des
+    in D3 vorgeschriebenen Schnitts gegen die globale Menge) wuerde sie
+    faelschlich ausschliessen."""
+    raw = _load_cascade_fixture_raw()
+    global_entry = _global_entry(raw, "uv_index")
+    assert global_entry.get("enabled", True) is True, "Vorbedingung: Ziel global aktiv"
+    raw["channel_layouts"]["sms"] = [
+        e for e in raw["channel_layouts"]["sms"] if e["metric_id"] != "uv_index"
+    ]
+    raw["channel_layouts_per_report"] = {
+        "evening": {"sms": [{"metric_id": "uv_index", "enabled": True}]},
+    }
+    dc = _parse_display_config(raw)
+    assert dc.cascade_source_for_channel("sms", "evening") == "per_report"
+
+    result_ids = [mc.metric_id for mc in dc.get_metrics_for_channel("sms", "evening")]
+    assert "uv_index" in result_ids, (
+        f"S2 AC-8: 'uv_index' faellt aus dem per_report-Ergebnis, obwohl es global aktiv ist "
+        f"(Schnitt darf nur gegen die globale Menge pruefen, nicht gegen per_channel): {result_ids}"
+    )
+
+
+# --- S2 AC-9 (D2): Report-Typ-Flags wirken im Schnitt ---
+
+
+def test_kaskade_s2_ac9_evening_disabled_globally_excludes_from_evening_sms():
+    """S2 AC-9 (D2): der globale Eintrag fuehrt evening_enabled=False, der
+    SMS-Kanal-Eintrag ist unveraendert enabled=true OHNE eigenen
+    evening_enabled-Override -- ein Schnitt gegen rohe enabled-Flags (statt
+    gegen get_metrics_for_report_type()) liesse die Metrik faelschlich
+    durch."""
+    target = "cloud_low"  # aktiv im SMS-Kanal-Layout der Basis-Fixture, kollisionssicheres Symbol 'CL'
+    symbol = SMS_SYMBOL_BY_METRIC[target]
+    raw = _load_cascade_fixture_raw()
+    global_entry = _global_entry(raw, target)
+    assert global_entry.get("enabled", True) is True, "Vorbedingung: Ziel ist heute global aktiv"
+    raw["metrics"] = [
+        {**e, "evening_enabled": False} if e["metric_id"] == target else e
+        for e in raw["metrics"]
+    ]
+    dc = _parse_display_config(raw)
+
+    sms = _kaskade_sms_text(dc)
+    assert _first_index_starting_with(sms, symbol) is None, (
+        f"S2 AC-9: {target!r} ({symbol!r}) erscheint im Abend-SMS-Text trotz globalem "
+        f"evening_enabled=False -- der Schnitt muss gegen get_metrics_for_report_type"
+        f"('evening') pruefen, nicht gegen rohes enabled: {sms!r}"
+    )
+
+
+# --- S2 AC-10 Test A: Editor-Sequenz -- SMS-Snapshot, dann NUR Grundauswahl abwaehlen ---
+
+
+def _cascade_editor_sequence_variant(target: str) -> UnifiedWeatherDisplayConfig:
+    """K1-Reproduktionsfolge (Kontext-Dokument): SMS-Tab oeffnen -> Kanal-
+    Ebene wird zur exakten Kopie der Grundauswahl (WeatherMetricsTab.svelte:638,
+    startChannelOverride) -> zurueck zur Grundauswahl -> NUR der globale
+    Eintrag wird geaendert, die SMS-Kopie bleibt unberuehrt."""
+    raw = _load_cascade_fixture_raw()
+    raw["channel_layouts"] = {"sms": [dict(e) for e in raw["metrics"]]}
+    raw["metrics"] = [
+        {**e, "enabled": False} if e["metric_id"] == target else e
+        for e in raw["metrics"]
+    ]
+    return _parse_display_config(raw)
+
+
+def test_kaskade_s2_ac10_editor_sequence_global_deselect_after_channel_snapshot():
+    target = _AC4_5_TARGET  # global AN in der Basis-Fixture, wird hier NACH dem Snapshot AUS gesetzt
+    symbol = SMS_SYMBOL_BY_METRIC[target]
+    dc = _cascade_editor_sequence_variant(target)
+
+    sms_copy_entry = next(mc for mc in dc.per_channel_layouts["sms"] if mc.metric_id == target)
+    assert sms_copy_entry.enabled is True, "Vorbedingung: die SMS-Kopie blieb unveraendert aktiv"
+    global_entry = next(mc for mc in dc.metrics if mc.metric_id == target)
+    assert global_entry.enabled is False, "Vorbedingung: NUR die Grundauswahl wurde abgewaehlt"
+
+    sms = _kaskade_sms_text(dc)
+    assert _first_index_starting_with(sms, symbol) is None, (
+        f"S2 AC-10 Test A: {target!r} ({symbol!r}) verschwindet nicht aus dem SMS-Kanal, obwohl "
+        f"die real erreichbare Editor-Sequenz (Kanal-Snapshot -> Grundauswahl-Abwahl) das "
+        f"verlangt: {sms!r}"
+    )
+
+
+# --- S2 AC-11: Premium-SMS am ECHTEN Versandweg gemessen, nicht als Struktur-Behauptung ---
+
+
+def test_kaskade_s2_ac11_premium_sms_forwards_the_cut_sms_text(premium_sms_stub):
+    """S2 AC-11 (D7 -- Premium-SMS hat keine eigene Kaskaden-Ebene): am
+    echten lokalen HTTP-Empfaenger gemessen (Muster premium_sms_stub aus
+    test_channel_origin_guard_parity.py), nicht per String-Vergleich im
+    Quelltext. Bewusst dieselbe Vorbedingung wie S1 AC-1/S2 AC-1 (dewpoint
+    global AUS, SMS-Kanal AN): solange der Kern-Fix aussteht, muss
+    Premium-SMS denselben Fehler REPRODUZIEREN (transitiv geerbt), nicht
+    zufaellig verdecken."""
+    target = _AC7_TARGET
+    symbol = SMS_SYMBOL_BY_METRIC[target]
+    on_dc = _cascade_sms_variant({target: {"enabled": True}})
+    report = _kaskade_report(on_dc)
+
+    settings = _prod_style_premium_sms_settings(
+        premium_sms_stub.port, seven_sandbox_key="sandbox-key",
+    )
+    PremiumSmsOutput(settings).send("Betreff", report.sms_text)
+
+    assert len(premium_sms_stub.received) == 1, (
+        f"Erwartet genau EINEN POST, bekommen: {premium_sms_stub.received!r}"
+    )
+    sent_text = premium_sms_stub.received[0]["payload"]["text"]
+    assert sent_text == report.sms_text, (
+        f"S2 AC-11: Premium-SMS-Text weicht vom SMS-Text ab: {sent_text!r} != {report.sms_text!r}"
+    )
+    assert _first_index_starting_with(sent_text, symbol) is None, (
+        f"S2 AC-11: {target!r} ({symbol!r}) erscheint im Premium-SMS-Text trotz globaler Abwahl "
+        f"-- Premium-SMS erbt die (noch ungefixte) SMS-Kaskade transitiv: {sent_text!r}"
+    )
+
+
+# --- S2 AC-12: abgeleitete Nachtgroesse (temperature_night) faellt nicht aus dem Schnitt ---
+
+
+def test_kaskade_s2_ac12_derived_night_metric_survives_the_cut():
+    """S2 AC-12 (D2, ID-basiert): 'temperature_night' wird hier ERZWUNGEN
+    ABGELEITET (kein expliziter Eintrag in raw['metrics'], loader.py:810-819
+    haengt sie an self.metrics), die SMS-Kanal-Ebene fuehrt sie zusaetzlich
+    explizit mit enabled:true -- die ID muss trotzdem im Schnitt-Ergebnis
+    bleiben, weil sie bereits Teil des abgeleiteten globalen Maximums ist."""
+    raw = _load_cascade_fixture_raw()
+    raw["metrics"] = [
+        {**e, "enabled": True} if e["metric_id"] == "temperature" else e
+        for e in raw["metrics"]
+        if e["metric_id"] != "temperature_night"
+    ]
+    raw["channel_layouts"]["sms"] = [
+        e for e in raw["channel_layouts"]["sms"] if e["metric_id"] != "temperature_night"
+    ] + [{"metric_id": "temperature_night", "enabled": True}]
+    dc = _parse_display_config(raw)
+
+    global_tn = next(mc for mc in dc.metrics if mc.metric_id == "temperature_night")
+    assert global_tn.derived is True, "Vorbedingung: die Nachtgroesse muss ABGELEITET sein"
+    assert global_tn.enabled is True, "Vorbedingung: Ableitung erbt den AN-Zustand von 'temperature'"
+
+    result_ids = [mc.metric_id for mc in dc.get_metrics_for_channel("sms", "evening")]
+    assert "temperature_night" in result_ids, (
+        f"S2 AC-12: die abgeleitete Nachtgroesse faellt aus dem Schnitt heraus: {result_ids}"
+    )
+
+
+# --- S2 AC-13 (Adversary F004-Regression): Telegram-Kurzuebersicht respektiert evening_enabled ---
+
+
+def test_kaskade_s2_ac13_telegram_overview_respects_evening_enabled_without_own_layer():
+    """S2 AC-13 (F004): 'visibility' ist global AN, evening_enabled=False,
+    OHNE eigene Telegram-Ebene (Kaskade faellt auf 'global'). Der D1-D4-Schnitt
+    (get_metrics_for_channel) schliesst sie fuer report_type='evening' korrekt
+    aus -- render_telegram_bubbles() bekam bis zu diesem Fix jedoch
+    dc=_dc_uncollapsed (die UNGEFILTERTE Grundauswahl) statt dc=_dc_telegram.
+    narrow.py:735/741/776 lesen dc.get_enabled_metric_ids() DIREKT, ohne durch
+    get_metrics_for_channel() zu gehen -- die Telegram-Kurzuebersicht zeigte
+    die Metrik deshalb trotzdem (als '-'-Geisterzeile, weil seg_tables_telegram
+    bereits korrekt gefiltert war). Muss ueber den ECHTEN Pfad format_email()
+    -> report.telegram_bubbles laufen (Konstruktionshinweis der Spec, nicht
+    render_for_channel() direkt -- der geht nie durch die Kollabierung)."""
+    target = "visibility"
+    raw = _load_cascade_fixture_raw()
+    global_entry = _global_entry(raw, target)
+    assert global_entry.get("enabled", True) is True, "Vorbedingung: Ziel global aktiv"
+    raw["metrics"] = [
+        {**e, "evening_enabled": False} if e["metric_id"] == target else e
+        for e in raw["metrics"]
+    ]
+    dc = _parse_display_config(raw)
+    assert dc.cascade_source_for_channel("telegram", "evening") == "global", (
+        "Vorbedingung: keine eigene Telegram-Ebene -- Kaskade faellt auf 'global'"
+    )
+
+    report = _kaskade_report(dc, "evening")
+    overview = F.overview_bubble(report)
+    assert overview, f"Keine Kurzuebersicht-Bubble gefunden: {report.telegram_bubbles!r}"
+    assert F.overview_line(report, get_metric(target).compact_label) == "", (
+        f"S2 AC-13: {target!r} erscheint in der Telegram-Kurzuebersicht trotz "
+        f"evening_enabled=False (ohne eigene Kanal-Ebene) -- render_telegram_bubbles() muss die "
+        f"report-typ-/kanal-kaskadierte dc lesen, nicht die ungefilterte Grundauswahl: {overview!r}"
     )
 
 

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -74,7 +74,7 @@ from tests.tdd import _min_temp_felt_fixtures as F
 # bereits etabliert: pytest erkennt eine importierte @pytest.fixture-Funktion
 # auch im importierenden Modul).
 from tests.tdd.test_channel_origin_guard_parity import (
-    _prod_style_premium_sms_settings, premium_sms_stub,
+    _prod_style_premium_sms_settings, premium_sms_stub,  # noqa: F401 - pytest loest die Fixture per Name auf
 )
 
 _ALL_METRIC_IDS = [m.id for m in get_all_metrics()]
@@ -1471,7 +1471,9 @@ def test_kaskade_s2_ac10_editor_sequence_global_deselect_after_channel_snapshot(
 # --- S2 AC-11: Premium-SMS am ECHTEN Versandweg gemessen, nicht als Struktur-Behauptung ---
 
 
-def test_kaskade_s2_ac11_premium_sms_forwards_the_cut_sms_text(premium_sms_stub):
+def test_kaskade_s2_ac11_premium_sms_forwards_the_cut_sms_text(
+    premium_sms_stub,  # noqa: F811 - pytest loest die Fixture per Name auf
+):
     """S2 AC-11 (D7 -- Premium-SMS hat keine eigene Kaskaden-Ebene): am
     echten lokalen HTTP-Empfaenger gemessen (Muster premium_sms_stub aus
     test_channel_origin_guard_parity.py), nicht per String-Vergleich im

--- a/tests/tdd/test_issue_429_channel_layouts.py
+++ b/tests/tdd/test_issue_429_channel_layouts.py
@@ -58,13 +58,37 @@ def _legacy_trip_data() -> dict[str, Any]:
 
 
 def _per_channel_trip_data() -> dict[str, Any]:
-    """Neuer Trip MIT `channel_layouts` — Email und Telegram haben eigene Listen."""
+    """Neuer Trip MIT `channel_layouts` — Email und Telegram haben eigene Listen.
+
+    Issue #1719 Scheibe 2 (ADR-0050): eine Kanal-Ebene darf die globale
+    Grundauswahl nur noch verfeinern (schneiden), nicht mehr ergaenzen — die
+    globale Liste muss deshalb JEDE Metrik-ID fuehren, die irgendeine
+    Kanal-Ebene unten benutzt (sonst schneidet get_metrics_for_channel() sie
+    jetzt weg). "metric_0".."metric_9" sind reine Struktur-Test-IDs ohne
+    Katalog-Eintrag (AC-5, Telegram-Slot-Limit) und werden hier bewusst
+    ebenfalls global gefuehrt, damit sie den Schnitt ueberleben. Alle
+    Ergaenzungen bewusst als "primary" mit steigendem `order` -- AC-4
+    vergleicht get_metrics_for_channel() (sortiert) gegen
+    get_metrics_for_report_type() (unsortiert) auf ID-Gleichheit; ein
+    "secondary"-Eintrag dazwischen wuerde die beiden Reihenfolgen
+    auseinanderlaufen lassen, ohne dass das etwas mit dieser Scheibe zu tun
+    haette.
+    """
     return {
         "trip_id": "per-channel-trip",
         "metrics": [
-            # Globale Fallback-Liste — wird für Kanäle ohne Eintrag verwendet (Signal, SMS).
+            # Globale Fallback-Liste — wird für Kanäle ohne Eintrag verwendet (Signal, SMS)
+            # UND ist seit #1719 S2 das Maximum fuer email/telegram unten.
             {"metric_id": "temperature", "enabled": True, "bucket": "primary", "order": 0},
             {"metric_id": "wind", "enabled": True, "bucket": "primary", "order": 1},
+            {"metric_id": "wind_chill", "enabled": True, "bucket": "primary", "order": 2},
+            {"metric_id": "gust", "enabled": True, "bucket": "primary", "order": 3},
+            {"metric_id": "precipitation", "enabled": True, "bucket": "primary", "order": 4},
+            {"metric_id": "cloud_total", "enabled": True, "bucket": "primary", "order": 5},
+            *[
+                {"metric_id": f"metric_{i}", "enabled": True, "bucket": "primary", "order": 6 + i}
+                for i in range(10)
+            ],
         ],
         "channel_layouts": {
             "email": [

--- a/tests/tdd/test_issue_434_per_report_layouts.py
+++ b/tests/tdd/test_issue_434_per_report_layouts.py
@@ -44,13 +44,25 @@ def _legacy_trip_data() -> dict[str, Any]:
 
 
 def _per_report_trip_data() -> dict[str, Any]:
-    """Trip MIT channel_layouts_per_report — Morning und Evening haben verschiedene Email-Listen."""
+    """Trip MIT channel_layouts_per_report — Morning und Evening haben verschiedene Email-Listen.
+
+    Issue #1719 Scheibe 2 (ADR-0050): die globale Liste ist das Maximum, gegen
+    das jede Kanal-/Report-Ebene unten geschnitten wird -- sie muss deshalb
+    jede unten verwendete Metrik-ID fuehren (precipitation, gust, wind_chill
+    kamen sonst nur in channel_layouts/channel_layouts_per_report vor). Alle
+    Ergaenzungen bewusst "primary" mit steigendem `order` -- AC-4 vergleicht
+    den (sortierten) globalen Fallback von get_metrics_for_channel() gegen
+    das (unsortierte) get_metrics_for_report_type() auf ID-Gleichheit.
+    """
     return {
         "trip_id": "per-report-trip-434",
         "metrics": [
             # Globale Fallback-Liste
             {"metric_id": "temperature", "enabled": True, "bucket": "primary", "order": 0},
             {"metric_id": "wind", "enabled": True, "bucket": "primary", "order": 1},
+            {"metric_id": "precipitation", "enabled": True, "bucket": "primary", "order": 2},
+            {"metric_id": "gust", "enabled": True, "bucket": "primary", "order": 3},
+            {"metric_id": "wind_chill", "enabled": True, "bucket": "primary", "order": 4},
         ],
         "channel_layouts": {
             # Per-Kanal-Fallback (#429)


### PR DESCRIPTION
Setzt **ADR-0050** im Produktivcode um (Issue #1719, Scheibe S2): Die Grundauswahl ist das Maximum, eine Kanal-Ebene darf nur abwaehlen — nie hinzufuegen.

Bisher **ersetzte** eine vorhandene Kanal-Liste die globale vollstaendig. Eine dort abgewaehlte Metrik konnte ueber den Kanal wieder scharf werden; genau das war der KHW-Befund, mit dem das Issue eroeffnet wurde.

## Produktivcode

| Datei | Aenderung |
|---|---|
| `src/app/models.py` | `_clip_to_global_maximum()` schneidet `per_report`/`per_channel` auf die IDs aus `get_metrics_for_report_type()`. Der globale Zweig bleibt unberuehrt — er IST das Maximum. Geschnitten wird gegen die **report-typ-aufgeloeste** Menge, nicht gegen rohe `enabled`-Flags, sonst wirkte eine Abwahl „nur abends" im Kanal nicht. Leere Grundauswahl ⇒ **kein** Schnitt (sonst faellt ein Altbestands-Trip auf null Metriken). |
| `src/output/renderers/trip_report.py` | Telegram bekommt eine eigene, unverfaelschte Sicht. Bisher reichte `format_email()` die auf die E-Mail-Auswahl kollabierte `dc` weiter — Telegram folgte damit **still der E-Mail**. Jetzt speisen sich Tabellenspalten, Kurzuebersicht und Fusszeile aus EINER Quelle (`_dc_telegram`), samt eigener Stundenzeilen. |
| `src/app/loader.py` | Docstring, der die alte Ersetzungs-Semantik beschrieb. |

**Die E-Mail bleibt unveraendert.** Eine gemeinsame, breitere Zeilenmenge haette dort ab Etappentag 4 neue Spalten erzeugt: `visible_cols(rows)` leitet die Spalten aus den Zeilen-Schluesseln ab, und `_allowed_col_keys_for_horizon()` filtert bei `horizon=None` nicht. AC-6 bewacht das.

## Keine Datenmigration — begruendet

Der von ADR-0050 verbotene Zustand kommt im Bestand **0-mal** vor (16 Konfigurationstraeger, 4 Nutzer, gemessen). Wichtiger noch: der bereits ausgelieferte Editor erzeugt ihn jederzeit neu (Kanal-Reiter oeffnen → zurueck zur Grundauswahl → abwaehlen → speichern). Eine Einmal-Bereinigung loeste das Problem also nicht dauerhaft — nur der Schnitt im Lesepfad tut das.

## Nachweise

- **14 Zusicherungen** am echten Renderpfad (`format_email()`, `report.telegram_bubbles`, `report.sms_text`), Varianten durchlaufen jeweils den echten Loader.
- **Playwright-Klickpfad gegen Staging**, der die Editor-Sequenz **klickt** statt sie zu konstruieren (PO-Leitplanke des Issues). Vor dem Fix reproduzierbar rot: `E1: G30@4` — die abgewaehlte Groesse stand weiter in der zugestellten Kurzform.
- Der S1-Pruefstand-Test verliert seine `xfail(strict)`-Markierung.
- Fuenf Bestandstests wurden rot, weil ihre Fixtures Kanal-Metriken fuehrten, die global gar nicht existierten — das von ADR-0050 verbotene Muster. Repariert wurde ausschliesslich die Fixture, **keine Assertion**.
- Renderer-Mail-Gate: Modus-Matrix gruen + `briefing_mail_validator.py` gegen eine echt zugestellte Mail (Exit 0).

## Adversary: VERIFIED nach drei Runden

Runde 1/2 ergaben **BROKEN**. Der wichtigste Fund war eine Regression, die dieser Fix selbst eingebaut hatte: Telegrams **Kurzuebersicht und Fusszeile** lesen `dc.get_enabled_metric_ids()` direkt, also ohne Tageszeit-Filter. Vorher wirkte dieser Filter dort als Nebeneffekt der E-Mail-Kollabierung — nach dem ersten Wurf gar nicht mehr. Eine fuer den Abend abgeschaltete Groesse waere wieder aufgetaucht, in der Fusszeile sogar mit einem echten, fachlich falschen Zahlenwert.

Die Spec hatte ausdruecklich behauptet, das koenne nicht passieren. Behoben, mit eigenem Waechter (AC-13) abgesichert und zusaetzlich mit echten Fusszeilen-Werten gegengeprueft; die Spec-Aussage ist richtiggestellt.

Alle fuenf Pflicht-Mutationsproben treffen exakt den vorgesehenen Test, ohne Kollateralschaden.

## Sichtbare Verhaltensaenderungen

1. Was in der Grundauswahl abgewaehlt ist, verschwindet ab jetzt in **allen** Kanaelen.
2. Trips mit eigener E-Mail-Auswahl zeigen in **Telegram** andere Spalten als bisher — naemlich die richtigen (vorher folgte Telegram still der E-Mail).
3. Trips mit eigener **Telegram**-Auswahl zeigen Kurzuebersicht und Fusszeile jetzt passend zu dieser Auswahl statt zu allen konfigurierten Groessen. Folgt aus ADR-0050, kollidiert mit keinem bestehenden Test.

## Nebenbefunde

- **#1741** — Telegram rendert nichts jenseits der 7. Tabellenspalte: `detail_metrics` wird berechnet, `_detail_lines()` hat null Aufrufstellen.
- **#1199** — die globale `order`-Uebernahme im Loader ist unbewacht (vorbestehend, von dieser Scheibe unberuehrt).

Refs #1719

🤖 Generated with [Claude Code](https://claude.com/claude-code)
