### PR TITLE
fix(#1723): Zeitzonen-Waechter auf die Entscheidungs-Schicht ausdehnen

### DIFF
--- a/docs/context/fix-1723-zeitzonen-waechter-entscheidung.md
+++ b/docs/context/fix-1723-zeitzonen-waechter-entscheidung.md
@@ -1,0 +1,148 @@
+# Context: #1723 — Zeitzonen-Wächter auf die Entscheidungs-Schicht ausdehnen
+
+**Workflow:** `fix-1723-zeitzonen-waechter-entscheidung` · **Issue:** #1723 (S1 von Epic #1722)
+**Erhoben:** 2026-08-11 am Stand `e230977d` · Track: Full Process
+
+## Request Summary
+
+Der bestehende Zeitzonen-Wächter (#1402) bewacht die **Darstellung** einer Uhrzeit in
+`src/output/**`. Die elf wiederkehrenden Zeitzonen-Bugs sitzen aber in der **Entscheidung**
+(welcher Kalendertag, ist ein Versand fällig, gilt Ruhezeit, wann kippt ein Zähler) — dort gibt
+es keinen Wächter. S1 dehnt den Geltungsbereich auf `src/services/**` + `api/**` aus, trägt den
+Bestand als `KNOWN_VIOLATIONS` ein und blockt damit **nur Neuzugänge**. Es bewegt keine Zeile
+Produktivcode.
+
+## Papierlage: zwei Fehler im Dach-Issue
+
+| Behauptung in #1722/#1723 | Befund |
+|---|---|
+| „ADR-0049" ist das Zeitzonen-ADR | **Falsch.** ADR-0049 = Premium-SMS (#1676), ADR-0050 = Metrik-Kaskade (#1719). Ein Zeitzonen-ADR existiert nicht; die freie Nummer ist **0051**. Die tragende Grundlage ist **ADR-0044** („Kalendertage folgen der Ortszeit", akzeptiert 2026-08-03). |
+| `docs/analysis/zeitzonen-architektur-2026-08.md` | **Existiert nicht** — weder in `main` noch ungetrackt. |
+
+Beides in #1722 als Kommentar gebucht. Für S1 ist keines davon ein Blocker: der Wächter ändert
+kein Verhalten und wird von ADR-0044 bereits getragen. ADR-0051 wird vor S2 (#1724) fällig, wo
+die Grundsatzentscheidung erstmals verhaltenswirksam wird (PO-Entscheid 2026-08-11).
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `tests/test_output_timezone_guard.py` (702 Z.) | **Der Prüfling.** Wird ausgedehnt. Scanfläche heute: `src/output/**` (Z. 87) + 7 einzeln gelistete Messaging-Dateien (`_MESSAGING_SERVICE_FILES`, Z. 89–103). `KNOWN_VIOLATIONS` ab Z. 463. |
+| `tests/test_success_status_guard.py` | **Das nähere Vorbild.** Scannt bereits **exakt** `api/routers/**` + `src/services/**` (Z. 197f.) — die Scanfläche, die S1 sucht, ist im Repo erprobt. |
+| `tests/test_guard_findings_survive_line_shifts.py` | **Meta-Wächter.** Lädt alle drei großen Wächter und prüft, dass Funde Zeilenverschiebungen überleben. Bestimmt den Prüfträger **zur Laufzeit** aus `_scan_files()` des Wächters — trägt eine ausgedehnte Scanfläche automatisch mit, kann aber den Prüfträger wechseln. |
+| `tests/test_resolution_loss_guard.py` | Dritter großer Wächter, scannt `src/output/**` + `src/services/**`. |
+| `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` | Die inhaltliche Grundlage der Regel. |
+| `.github/ci_tdd_excludes.txt` | `test_output_timezone_guard.py` steht **nicht** darin → läuft in CI. Gilt für alle sieben AST-Wächter. |
+
+## Existing Patterns — sieben AST-Ratschen im Repo
+
+| Wächter | Scanfläche | Ausnahme-Mechanik |
+|---|---|---|
+| `test_success_status_guard.py` | `api/routers/**` + `src/services/**` | `KNOWN_VIOLATIONS` + `_APPROVED_EXCEPTIONS` + Shrink-Test |
+| `test_resolution_loss_guard.py` | `src/output/**` + `src/services/**` | `KNOWN_VIOLATIONS` + Shrink-Test |
+| `test_output_timezone_guard.py` | `src/output/**` + 7 Dateien | `KNOWN_VIOLATIONS` + Shrink-Test |
+| `test_guard_findings_survive_line_shifts.py` | die drei oberen (Meta) | — |
+| `tests/tdd/test_data_root_hardcoding_ratchet.py` | `src/**` + `api/**` | Inline-Marker `# gz-data-path: <Grund>` (≥15 Z.) |
+| `tests/tdd/test_repo_path_hardcoding_ratchet.py` | `tests/**` | Inline-Marker `# gz-main-path: <Grund>` (≥15 Z.) |
+| `tests/tdd/test_fixture_wallclock_ratchet.py` | `tests/**` | `KNOWN_VIOLATIONS` frozenset + Shrink-Test |
+
+**Zwei etablierte Ausnahme-Formen:** zentrale schrumpfende Liste (Bestandsaufnahme) versus
+Inline-Marker (Einzelfall-Begründung im Code). Die drei großen Wächter nutzen die erste.
+
+**Schlüssel-Format (Issue #1466 AP2):** `"pfad::funktion::ordinal"` — nicht `"pfad:zeile"`.
+Zeilennummern wandern; der Meta-Wächter erzwingt die stabile Form. Ein neuer Detektor muss
+dieses Format bedienen, sonst bricht `test_guard_findings_survive_line_shifts.py`.
+
+**Bekannte Falle im Prüfling selbst (#1465):** `_scan_files()` filtert mit `if p.exists()` und
+ließ einen falsch geschriebenen Pfad **wortlos** fallen — der Wächter sah den Drilldown-Formatter
+nie. Gegenmittel ist `test_scan_list_paths_all_exist()` (Z. 522). Wird die Scanfläche auf ganze
+Verzeichnisse umgestellt, muss die entsprechende Zusicherung mitwandern: ein Verzeichnis, das
+nicht existiert, darf nicht still zu „null Funde" führen.
+
+## Gemessener Bestand im Geltungsbereich (AST, Stand `e230977d`)
+
+93 Dateien gescannt (`src/services/**` + `api/**`), **18 betroffen**:
+
+| Muster | AST-Funde | grep-Funde (Issue) |
+|---|---|---|
+| Umgebungsuhr (`.today()`, `.now()`, `.utcnow()` ohne Argument) | **30** | „40 + 10" |
+| Festes Zonen-Literal `ZoneInfo("…")` | **9** | „12" |
+
+Die Differenz ist erklärt: das Issue zählt per `grep` über ganz `src/` + `api/` und trifft dabei
+**Kommentare und Docstrings** mit — bei `datetime.now()` sind 5 von 10 grep-Treffern reine
+Prosa. Ein AST-Scanner sieht sie nicht. Die Größenordnung des Issues stimmt, die exakte Zahl für
+die Bestandsliste ist **30 + 9 = 39**, nicht ~52.
+
+**Verteilung Umgebungsuhr** (Auszug, Schwerpunkte): `trip_report_scheduler.py` 6 ·
+`scheduler_dispatch_service.py` 5 (davon 3 × `.utcnow()`) · `gpx_processing.py` 3 ·
+`api/routers/compare.py` 3 · `trip_command_processor.py` 2 · je 1 in
+`alert_briefing_anchor.py`, `comparison_engine.py`, `compare_preview_service.py`,
+`dispatch_orchestrator.py`, `inbound_telegram_reader.py`, `notification_service.py`,
+`preview_service.py`, `massif_closure.py` (2), `meteo_forets.py`, `api/routers/debug.py`.
+
+**Alle 9 Zonen-Literale namentlich:**
+
+| Fundstelle | Literal | Bewertung |
+|---|---|---|
+| `src/services/alert_daily_limit.py:23` | `Europe/Vienna` | im Issue genannt |
+| `src/services/deviation_alert_engine.py:31` | `Europe/Vienna` | im Issue genannt |
+| `src/services/scheduler_dispatch_service.py:164` | `Europe/Vienna` | im Issue genannt |
+| `api/routers/scheduler.py:34` | `Europe/Vienna` | im Issue genannt |
+| `src/services/notification_service.py:773, 821, 1061, 1063` | `UTC` | **vom Issue nicht erfasst** |
+| `src/services/trip_report_scheduler.py:1820` | `UTC` | **vom Issue nicht erfasst** |
+
+## Risks & Considerations
+
+1. **🔴 `ZoneInfo("UTC")` ist die halbe Fundmenge und vermutlich legitim.** Das Issue formuliert
+   das Muster als „`ZoneInfo("Europe/Vienna")` **und jedes andere feste Zonen-Literal**". Wörtlich
+   angewandt fängt es die 5 UTC-Stellen mit — die nach Hausnorm #1345 („naive Zeitstempel sind
+   UTC") gerade die *richtige* Schreibweise sein können. Sie landeten dann als gebuchte „Schuld"
+   in einer Liste, die per Ratsche nur schrumpfen darf, aber nie schrumpfen *wird*. Klärungsbedarf
+   in der Spec: fängt das Muster jedes Literal, nur Nicht-UTC-Literale, oder Literale außerhalb
+   eines Hausnorm-Kontexts? Vergleichbares Kollateral-Muster:
+   `selectable=False`-Gate (#1719), das alle non-selectable Metriken traf.
+
+2. **🔴 `.utcnow()` ist möglicherweise korrekt, nicht falsch.** Drei Fundstellen in
+   `scheduler_dispatch_service.py` (Z. 69, 213, 240). `datetime.utcnow()` liefert einen **naiven**
+   Zeitstempel — exakt die Hausnorm aus #1345. Das Issue nennt `.utcnow()` gar nicht; es kam erst
+   durch meine Messung dazu. Ob es ins Muster gehört, ist eine Spec-Frage, keine
+   Implementierungs-Entscheidung.
+
+3. **Provider-Ausnahme im Issue geht ins Leere.** #1723 nimmt `src/providers/geosphere.py:372`
+   ausdrücklich aus („API-Parameter, keine Entscheidung"). Die Datei liegt in `src/providers/` und
+   damit **außerhalb** des Geltungsbereichs `src/services/**` + `api/**` — die Ausnahme wird nie
+   gebraucht. Nebenbefund: `geosphere.py:405` deutet die Antwort mit
+   `replace(tzinfo=ZoneInfo("Europe/Vienna"))`, was *keine* reine Parameterübergabe ist; relevant
+   erst, wenn S5 die Fläche weitet.
+
+4. **Der Meta-Wächter kann kippen.** `test_guard_findings_survive_line_shifts.py` wählt „die
+   Datei mit den meisten Funden" als Prüfträger. Ver­dreifacht sich die Fundmenge, wechselt der
+   Prüfträger — der Test muss danach noch grün sein, was nicht selbstverständlich ist.
+
+5. **Wächter, der nichts fängt, ist die gefährlichste Form von Grün.** Das Issue fordert die
+   Mutations-Gegenprobe ausdrücklich: neu eingefügtes `date.today()` in `src/services/` → rot;
+   neu eingefügtes Zonen-Literal → rot; Entfernen eines `KNOWN_VIOLATIONS`-Eintrags, dessen
+   Fundstelle noch existiert → rot. Erfahrungswerte im Repo: eine Typ-Aufzählung in einem
+   AST-Wächter wiederholt gern denselben Klassenfehler, den sie verhindern soll.
+
+6. **Test-Kern muss grün bleiben.** Der Prüfling läuft in CI (`test`-Job). Eine unvollständige
+   `KNOWN_VIOLATIONS`-Liste macht `main` rot und blockt jede parallele Session.
+
+## Dependencies
+
+- **Upstream:** `ast` (stdlib), `Path`; ADR-0044 als inhaltliche Grundlage; Schlüsselformat aus #1466 AP2.
+- **Downstream:** `test_guard_findings_survive_line_shifts.py` (lädt den Prüfling direkt);
+  CI-Job `test`; jeder künftige Commit in `src/services/**` + `api/**`.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1465_zeitzonen_hausnorm.md` — Hausnorm naive UTC
+- `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` — „heute"/„morgen" nach Ortszeit
+- `docs/specs/modules/fix_1409b_repo_path_ratchet.md` — Ratschen-Bauform + „Known Limitations"
+
+## Nicht in dieser Scheibe (aus #1723)
+
+- Muster 3 der Analyse: `.hour`/`.date()` auf einem Zeitstempel ohne nachweisliche Zonen-Auflösung
+  (der eigentliche Fehler von #1470/#1697) — eigene Scheibe.
+- Go-Seite (`time.Now()`, ~225 Fundstellen) — Go führt die Zone im Typ mit, andere Fehlerklasse.
+- Jede Änderung an Produktivcode.

--- a/docs/specs/modules/fix_1723_zeitzonen_waechter_entscheidung.md
+++ b/docs/specs/modules/fix_1723_zeitzonen_waechter_entscheidung.md
@@ -1,0 +1,266 @@
+---
+entity_id: fix_1723_zeitzonen_waechter_entscheidung
+type: bugfix
+created: 2026-08-11
+updated: 2026-08-11
+status: draft
+version: "1.0"
+tags: [tests, guard, ratchet, zeitzone, epic-1722, issue-1723]
+---
+
+<!-- Issue #1723 — Epic #1722, Scheibe S1: Zeitzonen-Wächter (#1402) auf die
+     Entscheidungs-Schicht (src/services/** + api/**) ausdehnen. -->
+
+# Fix #1723 (Epic #1722 S1) — Zeitzonen-Wächter auf die Entscheidungs-Schicht ausdehnen
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Der bestehende Zeitzonen-Wächter `tests/test_output_timezone_guard.py` (Issue #1402) bewacht
+heute nur die **Darstellung** einer Uhrzeit (`src/output/**` + sieben einzeln gelistete
+Messaging-Dateien). Die elf wiederkehrenden Zeitzonen-Bugs des Projekts sitzen aber in der
+**Entscheidung** — welcher Kalendertag gemeint ist, ob ein Versand fällig ist, ob Ruhezeit gilt,
+wann ein Zähler kippt. Diese Lieferung dehnt den Geltungsbereich des bestehenden Wächters auf
+`src/services/**` + `api/**` aus, trägt den heutigen Bestand als `KNOWN_VIOLATIONS` ein und
+blockt damit ausschließlich **Neuzugänge**. Es bewegt keine Zeile Produktivcode.
+
+## Source
+
+- **File:** `tests/test_output_timezone_guard.py` (MODIFY)
+- **Identifier:** `_scan_files()` (Scanfläche erweitern), zwei neue Detektor-Zweige innerhalb der
+  bestehenden `ast.walk(tree)`-Schleife von `_find_violations()` (Muster A „Umgebungsuhr", Muster
+  B „festes Nicht-UTC-Zonen-Literal"), `KNOWN_VIOLATIONS` (neue Einträge), ein neuer Test analog
+  `test_scan_scope_excludes_go_internal_tree` aus `tests/test_success_status_guard.py`.
+
+> **Schicht-Hinweis:** reines Test-Infrastruktur-Artefakt (`tests/`). Die Scanfläche liest
+> Produktivcode unter `src/services/**` und `api/**` (Python-Core/Domain-Backend), verändert ihn
+> aber nicht. Kein Frontend-, Go-API- oder Go-internal-Code betroffen.
+
+## Estimated Scope
+
+- **LoC:** ~350–450 (Budget vom PO auf 500 freigegeben, weil die `KNOWN_VIOLATIONS`-Bestandsliste
+  inline in der `.py`-Testdatei steht und mitzählt: erweiterte Scanfläche + zwei Detektor-Zweige +
+  ~30–40 Restlisten-Einträge + sechs neue Tests)
+- **Files:** 1 MODIFY (`tests/test_output_timezone_guard.py`). Keine weitere Datei.
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `tests/test_success_status_guard.py::_scan_files()` / `test_scan_scope_excludes_go_internal_tree()` | Bauform-Vorbild | Scanfläche `api/routers/**` + `src/services/**` ist im Repo bereits erprobt; Vorbild für die „Scanfläche nicht leer + Positiv-Prüfung je Baum"-Zusicherung |
+| `tests/test_guard_findings_survive_line_shifts.py` | Meta-Wächter, Downstream | Lädt den Prüfling über `_scan_files()`/`_find_violations()` zur Laufzeit, wählt den Prüfträger für den Einfüge-Nachweis automatisch aus „Datei mit den meisten Funden" — kann nach dieser Erweiterung wechseln, muss danach weiterhin grün sein (AC-10) |
+| `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` | inhaltliche Grundlage (Status: Akzeptiert) | „Heute"/„morgen" folgen der Ortszeit — trägt die Bugklasse dieses Wächters bereits |
+| `docs/adr/0051-drei-zeitbegriffe-zone-an-den-daten.md` | Grundsatzentscheidung Epic #1722 (Status: Vorgeschlagen) | ordnet ADR-0044 als Spezialfall ein; S1 ändert kein Verhalten und ist von ihrem Status unabhängig lieferbar, S2 (#1724, bereits live) macht sie erstmals verhaltenswirksam |
+| Issue #1466 AP2 | Schlüsselformat | `"pfad::funktion::ordinal"` statt `"pfad:zeile"` — bereits im Prüfling implementiert (`_number_findings()`, `_MODULE_SCOPE`), gilt unverändert für neue Funde |
+| Issue #1465 | Falle (bereits im Prüfling behoben) | `rglob` auf ein fehlendes Verzeichnis liefert wortlosen Leerlauf — Vorbild für `test_scan_list_paths_all_exist()`; dieselbe Zusicherungsart wird für die neue Scanfläche gebraucht (AC-1) |
+| Issue #1719 (`selectable=False`-Gate) | Präzedenzfall | ein zu weit gefasstes Muster trifft Kollateralschaden — Begründung für E1/E2 unten |
+| Issue #1724 (Epic #1722 S2, LIVE `e21f4f48`) | Bestandsänderung | hat zwei `Europe/Vienna`-Stellen entfernt (`src/services/scheduler_dispatch_service.py`, `api/routers/scheduler.py`) — der heutige Bestand ist NIEDRIGER als die Zahlen im Kontextdokument (Stand `e230977d`); verifiziert per grep am 2026-08-11: nur noch `alert_daily_limit.py` + `deviation_alert_engine.py` |
+| Issue #1726 (Epic #1722 S4) | Folge-Scheibe | übernimmt die verbleibenden `Europe/Vienna`-Stellen zur Behebung, getragen von ADR-0051 |
+
+## Implementation Details
+
+### Scanfläche erweitern
+
+`_scan_files()` liefert zusätzlich zur bisherigen Fläche (`src/output/**` +
+`_MESSAGING_SERVICE_FILES`) alle `*.py` unter `src/services/**` und `api/**` (rekursiv, analog
+`_production_files()` im selben Modul bzw. `_scan_files()` in `test_success_status_guard.py`).
+Die Kombination MUSS über eine Menge geführt werden (`sorted({*...})`, nicht `+=`): sechs der
+sieben bisherigen `_MESSAGING_SERVICE_FILES`-Einträge liegen bereits unter `src/services/` und
+würden sonst doppelt gescannt (harmlos für das Ergebnis, aber unnötige Redundanz). Der siebte
+Eintrag (`src/app/cli.py`) bleibt der einzige, den die neue Fläche nicht mitbringt, und muss in
+`_MESSAGING_SERVICE_FILES` stehen bleiben. Der Modul-Docstring-Kommentar über `_OUTPUT_DIR`
+(„das komplette src/output/-Baumwerk … NICHT gescannt wird …") ist entsprechend zu aktualisieren
+— er beschreibt sonst eine Fläche, die es nicht mehr gibt (dieselbe Fehlerart wie in
+`[[reference_aussagen_ueber_eigenen_code_veralten_still]]`).
+
+### Zwei neue Detektor-Zweige (in derselben `for node in ast.walk(tree):`-Schleife wie die
+bestehenden fünf)
+
+**Muster A — Umgebungsuhr.** `date.today()` (immer ein Fund — `date` kennt keine Zone) sowie
+`datetime.now()` **ohne** ein `tz`-Argument (weder positional noch als Keyword). Erkannt wird
+strukturell über den Attributnamen (`.today`/`.now`), nicht über den Empfängertyp — dieselbe
+Grenze wie bei den übrigen Detektoren dieses Wächters und bei `test_success_status_guard.py`
+(„Struktur, nicht Fachlichkeit"). `.utcnow()` matcht diesen Zweig NICHT (E2 unten) — es genügt,
+`.utcnow()` nicht in die Attributnamen-Menge aufzunehmen, kein Ausschluss-Sonderfall nötig.
+
+**Muster B — festes Nicht-UTC-Zonen-Literal.** `ZoneInfo("<beliebiger String außer "UTC">")` als
+eigenständiger Fund, unabhängig davon, in welcher Ausdrucksform er auftritt (Modulebene-Zuweisung
+wie `VIENNA = ZoneInfo("Europe/Vienna")`, Funktionsargument, Rückfallausdruck). Die vorhandenen
+Helfer `_is_hardcoded_zoneinfo_call()` (matcht jedes Zonen-Literal) und `_is_zoneinfo_utc_call()`
+(matcht nur `"UTC"`) decken die Bedingung bereits ab: Muster B ist `_is_hardcoded_zoneinfo_call(node)
+and not _is_zoneinfo_utc_call(node)` als eigener, neuer Fundzweig — nicht nur innerhalb der
+bestehenden Mid-Body-Rückfallformen (BoolOp/getattr/If/IfExp), die bislang ausschließlich
+`src/output/**` erreichten.
+
+Beide neuen Zweige nutzen dieselbe `record()`-Hilfsfunktion und damit automatisch das bestehende
+Schlüsselformat (`"pfad::funktion::ordinal"`) und die bestehende Bereichsverfolgung (`_scopes()`,
+`_MODULE_SCOPE`) — Modulebene-Funde wie das obige `VIENNA = ...`-Beispiel lösen ohne weitere
+Änderung korrekt zu `<module>` auf.
+
+### E1 — `ZoneInfo("UTC")` wird NICHT gefangen
+
+Fünf der neun gemessenen Zonen-Literal-Funde (Stand `e230977d`) sind `"UTC"`, davon vier
+dokumentierte Notnagel-Rückfälle in `notification_service.py` bei nicht auflösbarem Ort. Nach
+Hausnorm #1345 („naive Zeitstempel sind UTC") ist das die *richtige* Schreibweise — der bekämpfte
+Fehler ist die **geratene** Ortszone, nicht UTC. Muster B fängt deshalb ausschließlich
+Nicht-UTC-Literale (s. o.).
+
+### E2 — `.utcnow()` wird NICHT gefangen
+
+`datetime.utcnow()` liefert *explizit* UTC, während `.now()`/`.today()` *implizit*
+Prozess-Lokalzeit liefern — eine andere Fehlerklasse. Dass `.utcnow()` seit Python 3.12 veraltet
+ist, ist Modernisierungsarbeit und nicht Gegenstand dieses Wächters.
+
+### `KNOWN_VIOLATIONS` frisch messen
+
+Die Restliste für die neue Fläche darf NICHT aus dem Kontextdokument `docs/context/fix-1723-
+zeitzonen-waechter-entscheidung.md` abgeschrieben werden — dessen Zahlen stammen vom Stand
+`e230977d`, seither ist #1724 live und hat zwei `Europe/Vienna`-Stellen entfernt
+(`scheduler_dispatch_service.py`, `api/routers/scheduler.py`; per grep am 2026-08-11 verifiziert:
+nur noch `alert_daily_limit.py` + `deviation_alert_engine.py` tragen `Europe/Vienna`). Maßgeblich
+ist ausschließlich der AST-Scan der fertigen `_find_violations()`-Implementierung, unmittelbar vor
+dem Commit gegen den dann aktuellen Stand von `main` ausgeführt — nicht die grep-Zählungen aus dem
+Issue („40 + 10"/„12"), die Kommentare und Docstrings mitzählen (in `scheduler_dispatch_service.py`
+sind 7 von 12 grep-Treffern reine Prosa aus #1724).
+
+### Interaktion mit dem Meta-Wächter
+
+`tests/test_guard_findings_survive_line_shifts.py` bestimmt den Prüfträger für den
+Einfüge-Nachweis zur Laufzeit aus `_scan_files()` des Wächters selbst („Datei mit den meisten
+Funden"). Wächst die Fundmenge in der neuen Fläche über die bisher reichste Datei
+(`src/output/renderers/alert/official_alerts.py`) hinaus, wechselt der Prüfträger automatisch —
+dieser Test braucht dafür keine Änderung, muss aber nach der Erweiterung nachweislich grün bleiben
+(AC-10).
+
+## Expected Behavior
+
+- **Input:** der aktuelle Stand von `src/output/**`, `_MESSAGING_SERVICE_FILES`, `src/services/**`
+  und `api/**` beim Testlauf.
+- **Output:** `pytest`-Grün, solange kein Fund von Muster A oder Muster B in der erweiterten
+  Fläche unlistet ist. Rot mit `Code reference: <Datei>::<Funktion>::<Ordinal>` bei jedem neuen,
+  unlisteten Fund; ebenso rot, wenn ein `KNOWN_VIOLATIONS`-Eintrag auf eine inzwischen behobene
+  Stelle zeigt (Schrumpf-Ratsche).
+- **Side effects:** keine — reiner Lesezugriff auf den Quellbaum, kein Netzwerk, keine
+  Produktivcode-Änderung.
+
+## Acceptance Criteria
+
+- **AC-1:** Given der Wächter läuft gegen den aktuellen Stand von `src/services/**` und `api/**` / When `_scan_files()` aufgerufen wird / Then enthält die zurückgegebene Liste mindestens eine Datei aus jedem der beiden neu hinzugekommenen Bäume, und kein Eintrag liegt außerhalb der (alten + neuen) Scanfläche
+  - Test: `test_scan_scope_includes_services_and_api_and_is_not_empty()` — analog `test_scan_scope_excludes_go_internal_tree` aus `test_success_status_guard.py`; prüft Nicht-Leere der Gesamtfläche UND je-Baum-Zugehörigkeit.
+
+- **AC-2:** Given ein neu eingefügtes `date.today()` oder `datetime.now()` ohne `tz`-Argument in einer synthetischen Datei unter einem `src/services/`-artigen Pfad / When der Wächter läuft / Then wird die Stelle als Fund gemeldet und der Wächtertest schlägt fehl, sofern der Fund nicht in `KNOWN_VIOLATIONS` steht
+  - Test: synthetischer Wirkungsnachweis (Mutations-Pflicht 1) analog `test_scanner_detects_raw_astimezone_in_synthetic_output_file`, aber für Muster A und explizit außerhalb `src/output/`.
+
+- **AC-3:** Given ein neu eingefügtes `ZoneInfo("<Nicht-UTC-Zone>")`-Literal in einer synthetischen Datei unter einem `api/`-artigen Pfad / When der Wächter läuft / Then wird die Stelle als Fund gemeldet und der Wächtertest schlägt fehl, sofern der Fund nicht in `KNOWN_VIOLATIONS` steht
+  - Test: synthetischer Wirkungsnachweis (Mutations-Pflicht 2) für Muster B, außerhalb `src/output/`.
+
+- **AC-4:** Given ein neu eingefügtes `ZoneInfo("UTC")` in derselben synthetischen Datei / When der Wächter läuft / Then bleibt der Test grün — E1 ist damit nicht nur behauptet, sondern gegengeprobt
+  - Test: synthetischer Gegenprobe-Wirkungsnachweis (Mutations-Pflicht 5, erste Hälfte).
+
+- **AC-5:** Given ein neu eingefügtes `datetime.utcnow()` in derselben synthetischen Datei / When der Wächter läuft / Then bleibt der Test grün — E2 ist damit nicht nur behauptet, sondern gegengeprobt
+  - Test: synthetischer Gegenprobe-Wirkungsnachweis (Mutations-Pflicht 5, zweite Hälfte).
+
+- **AC-6:** Given ein `KNOWN_VIOLATIONS`-Eintrag der neuen Fläche, dessen Fundstelle im Code noch existiert, wird aus der Liste entfernt / When der bestehende Shrink-Test (`test_known_violations_only_shrink`) läuft / Then schlägt er fehl, weil der Scanner die Stelle weiterhin findet, die Liste sie aber nicht mehr trägt
+  - Test: Mutations-Pflicht 3, ausgeführt als String-Ersetzung mit externer Sicherungskopie (Repo-Konvention) gegen einen frisch aus der neuen Fläche gemessenen Eintrag, NICHT `git checkout/stash/reset`.
+
+- **AC-7:** Given je ein eigener synthetischer Wirkungsnachweis für Muster A und für Muster B / When einer der beiden Detektoren durch ein invertiertes Prädikat (z. B. `and has_tz_kw` statt `and not has_tz_kw`) lautlos leerläuft, während der jeweils andere weiter Funde liefert / Then wird genau dieser Ausfall sichtbar — eine reine Summenprüfung über beide Muster hinweg würde ihn verdecken
+  - Test: Mutations-Pflicht 4 — die AC-2- und AC-3-Nachweise müssen JE FÜR SICH auf den eigenen Fundtyp prüfen (`assert kind == "..."`, nicht nur `assert found`), sonst bleibt diese AC unerfüllt.
+
+- **AC-8:** Given der Commit-Zeitpunkt der Implementierung / When `KNOWN_VIOLATIONS` für die neue Fläche befüllt wird / Then stammt jede Zahl aus einem frischen AST-Scan gegen den dann aktuellen Stand von `main` (inkl. der bereits durch #1724 entfernten zwei `Europe/Vienna`-Stellen), NICHT aus den grep-Zählungen des Issues oder den Zahlen im Kontextdokument (Stand `e230977d`)
+  - Test: `test_no_unlisted_output_timezone_violations()` und `test_known_violations_only_shrink()` (bereits vorhanden, unverändert in ihrer Logik) laufen beide grün gegen den finalen Commit-Stand — das ist der einzige Nachweis, dass die Liste weder unter- noch überzählt.
+
+- **AC-9:** Given ein Fund auf Modulebene außerhalb jeder Funktion (z. B. `VIENNA = ZoneInfo("Europe/Vienna")`) in der neuen Fläche / When der Wächter läuft / Then trägt der Fundschlüssel `_MODULE_SCOPE` (`"<module>"`) als Funktionsanteil, im selben Format `"pfad::funktion::ordinal"` wie alle übrigen Funde
+  - Test: Wirkungsnachweis mit einer synthetischen Modulebene-Zuweisung unter einem `src/services/`-artigen Pfad, analog `test_timezone_guard_finding_names_the_enclosing_function` aus dem Meta-Wächter.
+
+- **AC-10:** Given die erweiterte Scanfläche und die ggf. gewachsene Fundmenge / When `tests/test_guard_findings_survive_line_shifts.py` läuft / Then bleibt er vollständig grün — auch wenn `_richest_scanned_file("zeitzone")` dadurch auf eine andere Datei als bisher (`official_alerts.py`) wechselt
+  - Test: `uv run pytest tests/test_guard_findings_survive_line_shifts.py -v` nach Fertigstellung der Erweiterung, vor dem Commit.
+
+- **AC-11:** Given der unveränderte Bestand von `src/output/**` und `_MESSAGING_SERVICE_FILES` / When der erweiterte Wächter läuft / Then bleiben alle bisher bekannten 22 Funde (Restliste vor dieser Lieferung) unverändert erkannt und gelistet — die Erweiterung darf den bestehenden Scope nicht verschmälern
+  - Test: `uv run pytest tests/test_output_timezone_guard.py -v` gegen den unveränderten `src/output/**`-Teilbestand; Regressionsschutz, kein neuer Testcode nötig, da `_all_violations()` beide Flächen gemeinsam prüft.
+
+- **AC-12:** Given die Ausnahme aus #1723 („`src/providers/geosphere.py:372` ist API-Parameter, keine Entscheidung") / When der Wächter läuft / Then ist diese Ausnahme strukturell wirkungslos, weil `src/providers/` außerhalb der Scanfläche (`src/output/**`, `_MESSAGING_SERVICE_FILES`, `src/services/**`, `api/**`) liegt — sie wird dokumentiert, nicht implementiert
+  - Test: keiner nötig (negative Feststellung); in „Known Limitations" festgehalten, damit sie nicht als offene Aufgabe missverstanden wird.
+
+## Test Plan
+
+Alle Läufe erfolgen über `uv run pytest tests/test_output_timezone_guard.py -v` sowie
+(nach jeder Änderung an der Scanfläche/den Detektoren) `uv run pytest
+tests/test_guard_findings_survive_line_shifts.py -v` im Sitzungs-Worktree — beide Dateien sind
+namentlich benannt und damit vom Verbot des breiten Testlaufs (`CLAUDE.md` „Breiter Testlauf
+gesperrt") nicht betroffen.
+
+**Reihenfolge (wichtig für AC-8):** zuerst Scanfläche + beide Detektoren implementieren und alle
+synthetischen Wirkungsnachweise (AC-2 bis AC-7, AC-9) grün bekommen — dabei ist `KNOWN_VIOLATIONS`
+für die neue Fläche noch leer, der Wächter also absichtlich rot gegen den echten Bestand. Erst
+unmittelbar vor dem Commit `_all_violations()` gegen den dann aktuellen `main`-Stand ausführen
+(z. B. per `python3 -c "..."` oder einem Wegwerf-Testlauf) und das Ergebnis 1:1 in
+`KNOWN_VIOLATIONS` übertragen — nicht früher, sonst veraltet die Liste durch parallele Arbeit
+anderer Sessions (`main` ändert sich durch andere PRs).
+
+- **AC-1:** `_scan_files()` direkt aufrufen, prüfen dass `_SERVICES_DIR`/`_API_DIR` (bzw. deren
+  Pfad-Objekte) mindestens einmal als `parent` in der Ergebnisliste vorkommen und dass die
+  Ergebnisliste nicht leer ist.
+- **AC-2/AC-3/AC-7:** je eine synthetische Datei in `tmp_path` unter einem `src/services/`- bzw.
+  `api/`-artigen Unterpfad mit genau einem Muster-A- bzw. Muster-B-Fund; `_find_violations()`
+  direkt aufrufen, `kind`-Wert des Funds prüfen (nicht nur Nicht-Leere).
+- **AC-4/AC-5:** dieselbe synthetische Datei zusätzlich um ein `ZoneInfo("UTC")` bzw.
+  `datetime.utcnow()` ergänzen, erneut scannen, Fundzahl unverändert.
+- **AC-6:** String-Ersetzung mit externer Sicherungskopie: einen frisch gemessenen
+  `KNOWN_VIOLATIONS`-Eintrag der neuen Fläche temporär entfernen, `test_known_violations_only_shrink`
+  laufen lassen, roten Fehlertext gegen den erwarteten Schlüssel prüfen, Sicherungskopie
+  zurückspielen.
+- **AC-8/AC-11:** vollständiger Lauf von `tests/test_output_timezone_guard.py -v` gegen den
+  finalen Commit-Stand — Exit 0 ist der Nachweis, kein separater Test.
+- **AC-9:** synthetische Datei mit `VIENNA = ZoneInfo('Europe/Vienna')` auf Modulebene unter einem
+  `src/services/`-artigen Pfad; Fundschlüssel muss `::<module>::` enthalten.
+- **AC-10:** vollständiger Lauf von `tests/test_guard_findings_survive_line_shifts.py -v`.
+- **AC-12:** keine Testausführung — Dokumentationsnachweis in „Known Limitations".
+
+## Known Limitations
+
+1. **Muster 3 ist explizit außerhalb dieser Scheibe.** `.hour`/`.date()` auf einem Zeitstempel
+   ohne nachweisliche Zonen-Auflösung (der eigentliche Fehler von #1470/#1697) braucht eine
+   Datenfluss-Prüfung über Funktionsgrenzen hinweg und wird hier nicht versucht — eigene Scheibe.
+2. **Go-Seite bleibt ungeprüft.** `time.Now()` (~225 Fundstellen) ist für einen Python-`ast`-Scan
+   strukturell unerreichbar; Go führt die Zone im Typ mit, andere Fehlerklasse (analog AC-15 in
+   `test_success_status_guard.py`).
+3. **Die im Issue #1723 genannte Ausnahme geht ins Leere.** `src/providers/geosphere.py:372` liegt
+   in `src/providers/` — außerhalb von `src/output/**`, `_MESSAGING_SERVICE_FILES`,
+   `src/services/**` und `api/**`. Die Ausnahme wird nie gebraucht (AC-12). Nebenbefund, nicht Teil
+   dieser Lieferung: `geosphere.py:405` deutet die Antwort mit
+   `replace(tzinfo=ZoneInfo("Europe/Vienna"))`, was keine reine Parameterübergabe ist — relevant
+   erst, wenn eine spätere Scheibe (S5) die Fläche auf `src/providers/` weitet.
+4. **`ZoneInfo("UTC")` und `.utcnow()` sind bewusst KEINE Fehlerklasse dieses Wächters (E1/E2).**
+   Fünf Fundstellen (`notification_service.py:773/821/1061/1063`,
+   `trip_report_scheduler.py:1820`) bleiben deshalb unsichtbar — sie sind nach Hausnorm #1345
+   vermutlich richtig, keine offene Schuld.
+5. **Die verbleibenden `Europe/Vienna`-Stellen sind namentlich #1726 (S4) zugeordnet**
+   (`src/services/alert_daily_limit.py`, `src/services/deviation_alert_engine.py`), getragen von
+   ADR-0051. Diese Lieferung trägt sie nur als `KNOWN_VIOLATIONS`-Eintrag, behebt sie nicht.
+6. **`.now()`/`.today()` werden strukturell erkannt, nicht typgeprüft.** Ein Objekt mit einer
+   `.now()`-Methode, die keine Zeitzone betrifft, wäre theoretisch ein Fehlalarm — dieselbe Grenze
+   wie bei den übrigen Wächtern dieses Repos („Struktur, nicht Fachlichkeit",
+   `test_success_status_guard.py`). Am gemessenen Bestand tritt dieser Fall nicht auf.
+7. **Doppelte Scan-Abdeckung von sechs `_MESSAGING_SERVICE_FILES`-Einträgen wird beseitigt, nicht
+   nur toleriert.** Sechs der sieben Einträge liegen unter `src/services/` und wären ohne
+   Mengenbildung (`sorted({*...})`) redundant gescannt — funktional folgenlos, aber unnötig; die
+   Kombination MUSS deshalb über eine Menge geführt werden (s. Implementation Details).
+8. **Der Meta-Wächter kann den Prüfträger wechseln (AC-10), ohne dass das ein Fehler ist** — er
+   wählt zur Laufzeit die fundreichste Datei der (jetzt größeren) Scanfläche neu aus.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** reine Testinfrastruktur-Erweiterung ohne Verhaltensänderung an Produktivcode —
+  keine neue Entscheidungsfläche im Sinne der ADR-Kriterien. Inhaltlich getragen von ADR-0044
+  (akzeptiert, „Kalendertage folgen der Ortszeit") und im Vorgriff auf ADR-0051 (vorgeschlagen,
+  „Drei Zeitbegriffe") ausgerichtet, ohne von deren Status abzuhängen: S1 blockt Neuzugänge in der
+  Entscheidungs-Schicht unabhängig davon, ob ADR-0051 bereits akzeptiert ist.
+
+## Changelog
+
+- 2026-08-11: Initial spec erstellt — Issue #1723, Epic #1722 Scheibe S1.

--- a/docs/specs/modules/fix_1723_zeitzonen_waechter_entscheidung.md
+++ b/docs/specs/modules/fix_1723_zeitzonen_waechter_entscheidung.md
@@ -15,7 +15,7 @@ tags: [tests, guard, ratchet, zeitzone, epic-1722, issue-1723]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-Freigabe 2026-08-11 („go"), inkl. LoC-Budget 500
 
 ## Purpose
 

--- a/docs/specs/modules/fix_1723_zeitzonen_waechter_entscheidung.md
+++ b/docs/specs/modules/fix_1723_zeitzonen_waechter_entscheidung.md
@@ -164,7 +164,7 @@ dieser Test braucht dafür keine Änderung, muss aber nach der Erweiterung nachw
 - **AC-5:** Given ein neu eingefügtes `datetime.utcnow()` in derselben synthetischen Datei / When der Wächter läuft / Then bleibt der Test grün — E2 ist damit nicht nur behauptet, sondern gegengeprobt
   - Test: synthetischer Gegenprobe-Wirkungsnachweis (Mutations-Pflicht 5, zweite Hälfte).
 
-- **AC-6:** Given ein `KNOWN_VIOLATIONS`-Eintrag der neuen Fläche, dessen Fundstelle im Code noch existiert, wird aus der Liste entfernt / When der bestehende Shrink-Test (`test_known_violations_only_shrink`) läuft / Then schlägt er fehl, weil der Scanner die Stelle weiterhin findet, die Liste sie aber nicht mehr trägt
+- **AC-6:** Given ein `KNOWN_VIOLATIONS`-Eintrag der neuen Fläche, dessen Fundstelle im Code noch existiert, wird aus der Liste entfernt / When der Wächter läuft / Then schlägt `test_no_unlisted_output_timezone_violations` fehl, weil der Scanner die Stelle weiterhin findet, die Liste sie aber nicht mehr trägt
   - Test: Mutations-Pflicht 3, ausgeführt als String-Ersetzung mit externer Sicherungskopie (Repo-Konvention) gegen einen frisch aus der neuen Fläche gemessenen Eintrag, NICHT `git checkout/stash/reset`.
 
 - **AC-7:** Given je ein eigener synthetischer Wirkungsnachweis für Muster A und für Muster B / When einer der beiden Detektoren durch ein invertiertes Prädikat (z. B. `and has_tz_kw` statt `and not has_tz_kw`) lautlos leerläuft, während der jeweils andere weiter Funde liefert / Then wird genau dieser Ausfall sichtbar — eine reine Summenprüfung über beide Muster hinweg würde ihn verdecken
@@ -210,9 +210,11 @@ anderer Sessions (`main` ändert sich durch andere PRs).
 - **AC-4/AC-5:** dieselbe synthetische Datei zusätzlich um ein `ZoneInfo("UTC")` bzw.
   `datetime.utcnow()` ergänzen, erneut scannen, Fundzahl unverändert.
 - **AC-6:** String-Ersetzung mit externer Sicherungskopie: einen frisch gemessenen
-  `KNOWN_VIOLATIONS`-Eintrag der neuen Fläche temporär entfernen, `test_known_violations_only_shrink`
+  `KNOWN_VIOLATIONS`-Eintrag der neuen Fläche temporär entfernen, `test_no_unlisted_output_timezone_violations`
   laufen lassen, roten Fehlertext gegen den erwarteten Schlüssel prüfen, Sicherungskopie
-  zurückspielen.
+  zurückspielen. (Der Shrink-Test `test_known_violations_only_shrink` fängt den umgekehrten
+  Fall — einen Eintrag **ohne** Fundstelle; er bleibt beim Entfernen grün, weil Entfernen ein
+  Schrumpfen ist. Adversary-Finding F001, 2026-08-11.)
 - **AC-8/AC-11:** vollständiger Lauf von `tests/test_output_timezone_guard.py -v` gegen den
   finalen Commit-Stand — Exit 0 ist der Nachweis, kein separater Test.
 - **AC-9:** synthetische Datei mit `VIENNA = ZoneInfo('Europe/Vienna')` auf Modulebene unter einem
@@ -251,6 +253,19 @@ anderer Sessions (`main` ändert sich durch andere PRs).
    Kombination MUSS deshalb über eine Menge geführt werden (s. Implementation Details).
 8. **Der Meta-Wächter kann den Prüfträger wechseln (AC-10), ohne dass das ein Fehler ist** — er
    wählt zur Laufzeit die fundreichste Datei der (jetzt größeren) Scanfläche neu aus.
+9. **🔴 Die Flächenerweiterung wirkt auch auf einen BESTEHENDEN Detektor** — das war beim
+   Schreiben dieser Spec nicht bedacht und wurde erst bei der Umsetzung gemessen (2026-08-11).
+   Von den 53 neuen `KNOWN_VIOLATIONS`-Einträgen stammen nur 27 aus den beiden neuen Mustern;
+   **25 kommen aus `raw_astimezone`**, das durch die größere Scanfläche erstmals
+   `src/services/**` + `api/**` sieht (die vier übrigen Altmuster feuern dort nicht — vom
+   Adversary nachgerechnet, nicht angenommen). Folge: Wer künftig in der Entscheidungs-Schicht
+   eine `.astimezone()`-Umrechnung schreibt, muss sie eintragen — auch wenn sie nach Hausnorm
+   #1345 korrekt ist (Umrechnung *nach* UTC). Das ist **dieselbe Reibung, die seit #1402 in
+   `src/output/**` gilt und dort akzeptiert wurde**, keine neue Fehlerklasse und keine
+   Funktionsblockade: der Eintrag ist möglich, der Code bleibt lieferbar. Bewusst NICHT als
+   Ausnahmeregel gebaut — eine solche Regel stünde in keiner freigegebenen Spec und würde die
+   Fundmenge nach Fachlichkeit statt nach Struktur schneiden. Wird die Reibung in der Praxis
+   lästig, ist das eine eigene Scheibe, kein Nachtrag hier. (Adversary-Finding F002, LOW.)
 
 ## Architektur-Entscheidung (ADR)
 

--- a/tests/test_output_timezone_guard.py
+++ b/tests/test_output_timezone_guard.py
@@ -79,13 +79,28 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC = REPO_ROOT / "src"
 
-# Ausgabepfad: das komplette src/output/-Baumwerk (Renderer, Kanäle, Tokens)
-# + die "nachrichtenerzeugenden Services" aus der #1402-Bestandsaufnahme, die
-# selbst Uhrzeiten für Mail/SMS/Telegram/CLI formatieren, aber außerhalb von
-# src/output/ liegen. NICHT gescannt wird der zentrale Aufloeser/Naiv-Guard
-# selbst (``utils/timezone.py``) — der darf ``.astimezone()`` aufrufen, das
-# ist seine Aufgabe.
+# Scanflaeche, zwei Schichten (Issue #1723 hat die zweite ergaenzt):
+#
+# 1. AUSGABE — das komplette src/output/-Baumwerk (Renderer, Kanäle, Tokens)
+#    + die "nachrichtenerzeugenden Services" aus der #1402-Bestandsaufnahme,
+#    die selbst Uhrzeiten für Mail/SMS/Telegram/CLI formatieren, aber
+#    außerhalb von src/output/ liegen.
+# 2. ENTSCHEIDUNG — das komplette src/services/- und api/-Baumwerk: welcher
+#    Kalendertag gemeint ist, ob ein Versand fällig ist, ob Ruhezeit gilt.
+#    Dort greifen die beiden Fundarten der Entscheidungs-Schicht (Muster A/B,
+#    s. _KIND_*-Konstanten unten).
+#
+# Sechs der sieben _MESSAGING_SERVICE_FILES liegen bereits unter
+# src/services/ und sind damit doppelt erfasst — _scan_files() fuehrt die
+# Kombination deshalb ueber eine MENGE. Der siebte Eintrag (src/app/cli.py)
+# ist der einzige, den die neue Flaeche nicht mitbringt.
+#
+# NICHT gescannt wird der zentrale Aufloeser/Naiv-Guard selbst
+# (``utils/timezone.py``) — der darf ``.astimezone()`` aufrufen, das ist
+# seine Aufgabe.
 _OUTPUT_DIR = SRC / "output"
+_SERVICES_DIR = SRC / "services"
+_API_DIR = REPO_ROOT / "api"
 _MESSAGING_SERVICE_FILES = [
     # Issue #1465: stand hier als SRC/"app"/... — diesen Pfad gibt es nicht,
     # die Datei liegt unter services/. `_scan_files()` filtert mit
@@ -111,11 +126,40 @@ _TZ_NAMES = {"tz", "_tz", "alert_tz"}
 # gleich zu lesen ist.
 _MODULE_SCOPE = "<module>"
 
+# Namen der beiden Fundarten der Entscheidungs-Schicht (Issue #1723, Epic
+# #1722 S1). Sie stehen hier als VERTRAG: die roten Wirkungsnachweise unten
+# prüfen den `kind`-Wert wörtlich gegen diese Konstanten, damit ein lautlos
+# leerlaufender Detektor nicht in einer Summe über beide Muster verschwindet
+# (AC-7).
+#   Muster A — Umgebungsuhr: ``date.today()`` / ``datetime.now()`` ohne
+#   ``tz``-Argument. ``.utcnow()`` gehoert NICHT dazu (E2).
+#   Muster B — festes Nicht-UTC-Zonen-Literal: ``ZoneInfo("Europe/Vienna")``
+#   und Verwandte. ``ZoneInfo("UTC")`` gehoert NICHT dazu (E1).
+_KIND_AMBIENT_CLOCK = "ambient_clock"
+_KIND_HARDCODED_NON_UTC_ZONE = "hardcoded_non_utc_zone"
+
+# Attributnamen der Umgebungsuhr (Muster A). ``utcnow`` steht bewusst NICHT
+# hier: es liefert AUSDRUECKLICH Weltzeit, waehrend ``now``/``today`` STILL
+# Prozess-Lokalzeit liefern — andere Fehlerklasse (E1/E2 der Spec). Ein
+# Ausschluss-Sonderfall waere nur eine zweite Stelle, die dasselbe sagt.
+_AMBIENT_CLOCK_ATTRS = {"now", "today"}
+
 
 def _scan_files() -> list[Path]:
-    files = sorted(_OUTPUT_DIR.rglob("*.py"))
-    files += [p for p in _MESSAGING_SERVICE_FILES if p.exists()]
-    return files
+    """Ausgabe- UND Entscheidungs-Schicht, ueber eine MENGE gefuehrt.
+
+    Die Mengenbildung ist keine Kosmetik: sechs der sieben
+    ``_MESSAGING_SERVICE_FILES`` liegen unter ``src/services/`` und kaemen mit
+    ``+=`` zweimal in die Liste (Issue #1723).
+    """
+    return sorted(
+        {
+            *_OUTPUT_DIR.rglob("*.py"),
+            *(p for p in _MESSAGING_SERVICE_FILES if p.exists()),
+            *_SERVICES_DIR.rglob("*.py"),
+            *_API_DIR.rglob("*.py"),
+        }
+    )
 
 
 def _is_zoneinfo_utc_call(node: ast.AST) -> bool:
@@ -336,6 +380,25 @@ def _find_violations(path: Path) -> dict[str, str]:
                 record(node, node.lineno, "silent_tz_ternary")
             elif _is_tz_like(node.orelse) and _is_utc_ish(node.body):
                 record(node, node.lineno, "silent_tz_ternary")
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in _AMBIENT_CLOCK_ATTRS
+        ):
+            # Muster A (#1723) — Umgebungsuhr. ``date.today()`` kennt keine
+            # Zone und ist deshalb IMMER ein Fund; ``datetime.now()`` nur
+            # ohne Zonenargument (``now(zone)`` positional wie ``now(tz=zone)``
+            # als Keyword sind die richtige Schreibweise).
+            has_tz_arg = bool(node.args) or any(kw.arg == "tz" for kw in node.keywords)
+            if node.func.attr == "today" or not has_tz_arg:
+                record(node, node.lineno, _KIND_AMBIENT_CLOCK)
+        elif _is_hardcoded_zoneinfo_call(node) and not _is_zoneinfo_utc_call(node):
+            # Muster B (#1723) — festes Nicht-UTC-Zonen-Literal, in JEDER
+            # Ausdrucksform (Modulebene-Zuweisung, Funktionsargument,
+            # Rueckfallausdruck), nicht nur in den Mid-Body-Rueckfallformen
+            # oberhalb. ``ZoneInfo("UTC")`` ist nach Hausnorm #1345 die
+            # richtige Schreibweise und faellt hier bewusst heraus (E1).
+            record(node, node.lineno, _KIND_HARDCODED_NON_UTC_ZONE)
 
     return _number_findings(raw)
 
@@ -515,7 +578,79 @@ KNOWN_VIOLATIONS: dict[str, str] = {
     "src/output/renderers/alert/official_alerts.py::render_official_alert_sms::0": "Aufrufseite abgesichert (vormals :1690) — render_official_alert_sms (Wächter: test_production_callsites_pass_tz_explicitly).",
     "src/services/radar_service.py::format_now_text::0": "Aufrufseite abgesichert (vormals :219) — format_now_text (Wächter: test_production_callsites_pass_tz_explicitly).",
     "src/services/trip_report_scheduler.py::_build_stage_trend::0": "Aufrufseite abgesichert (vormals :1365) — _build_stage_trend (Wächter: test_production_callsites_pass_tz_explicitly).",
-    "src/services/trip_report_scheduler.py::_build_stage_trend::1": "Aufrufseite abgesichert (vormals :1427) — Ternary-Rückfall zum Default von _build_stage_trend, daran gekoppelt.",
+    # ORDINAL-VERSCHIEBUNG (#1723): Muster A findet in _build_stage_trend ein
+    # `date.today()` (:1812) VOR dem Ternary (:1869) — der Ternary rutscht
+    # dadurch von ::1 auf ::2. Dieselben zwei Codestellen wie bisher, plus der
+    # neue Fund dazwischen; nichts gestrichen.
+    "src/services/trip_report_scheduler.py::_build_stage_trend::1": "Muster A (:1812) — `today = date.today()` datiert den Etappen-Trend auf die Serveruhr statt auf die Ortszeit der Etappe (#1726).",
+    "src/services/trip_report_scheduler.py::_build_stage_trend::2": "Aufrufseite abgesichert (vormals :1427, jetzt :1869) — Ternary-Rückfall zum Default von _build_stage_trend, daran gekoppelt.",
+    # -----------------------------------------------------------------------
+    # ENTSCHEIDUNGS-SCHICHT (Issue #1723, Epic #1722 S1) — Bestandsaufnahme
+    # von `src/services/**` + `api/**`, gemessen am 2026-08-11 gegen
+    # origin/main `0db5eec6` (nach #1724, das zwei Europe/Vienna-Stellen
+    # entfernt hat). 53 Einträge, ausschliesslich per AST-Scan erhoben, nicht
+    # per grep gezaehlt. Sie sind AUFGENOMMEN, nicht entschuldigt: diese
+    # Lieferung blockt nur Neuzugaenge, die Behebung traegt #1726 (S4).
+    # -----------------------------------------------------------------------
+    # --- Muster A: Umgebungsuhr (`date.today()` / `datetime.now()` ohne tz) ---
+    "api/routers/compare.py::run_comparison::0": "Muster A (:53) — Sofort-Vergleich nimmt die Serveruhr als 'jetzt' (#1726).",
+    "api/routers/compare.py::run_comparison::1": "Muster A (:55) — Zieltag 'heute' vom Server, nicht vom Ort (#1726).",
+    "api/routers/compare.py::run_comparison::2": "Muster A (:58) — Zieltag 'morgen' vom Server, nicht vom Ort (#1726).",
+    "api/routers/debug.py::trigger_radar_alert::0": "Muster A (:61) — Debug-Ausloeser datiert auf die Serveruhr (#1726).",
+    "src/output/renderers/email/compare_html.py::_compute_next_send::0": "Muster A (:1377) — naechste Sendezeit gegen den Servertag geprueft (#1726).",
+    "src/services/alert_briefing_anchor.py::briefing_target_day_is_current::0": "Muster A (:169) — Briefing-Anker faellt auf den Servertag zurueck (#1726).",
+    "src/services/compare_preview_service.py::_resolve_target_date::0": "Muster A (:250) — Vorschau-Zieltag vom Server (#1726).",
+    "src/services/comparison_engine.py::dict_to_comparison_result::0": "Muster A (:407) — Zieltag beim Einlesen vom Server (#1726).",
+    "src/services/gpx_processing.py::compute_default_start_date::0": "Muster A (:189) — GPX-Vorgabestart vom Servertag (#1726).",
+    "src/services/gpx_processing.py::compute_default_start_date::1": "Muster A (:193) — zweiter Rueckfall auf den Servertag (#1726).",
+    "src/services/gpx_processing.py::gpx_to_stage_data::0": "Muster A (:223) — Etappendatum faellt auf den Servertag zurueck (#1726).",
+    "src/services/inbound_telegram_reader.py::_find_active_trip::0": "Muster A (:358) — 'aktive Tour heute' gegen den Servertag (#1726).",
+    "src/services/notification_service.py::_target_date_from_report::0": "Muster A (:1676) — Zieltag des Berichts vom Server (#1726).",
+    "src/services/official_alerts/massif_closure.py::_do_request::0": "Muster A (:102) — Abfrage-Datum der franzoesischen Quelle vom Server (#1726).",
+    "src/services/official_alerts/massif_closure.py::fetch::0": "Muster A (:127) — Zeitstempel fuer `last_run` ohne Zone (#1726).",
+    "src/services/official_alerts/meteo_forets.py::covers::0": "Muster A (:130) — Saison-Fenster gegen den Servermonat (#1726).",
+    "src/services/preview_service.py::_resolve_target_date::0": "Muster A (:94) — Vorschau-Zieltag vom Server (#1726).",
+    "src/services/scheduler_dispatch_service.py::_auto_pause_expired_presets::0": "Muster A (:79) — Ablauf eines Presets gegen den Servertag (#1726).",
+    "src/services/scheduler_dispatch_service.py::send_one_compare_preset::0": "Muster A (:368) — Zieltag des Vergleichs-Versands vom Server (#1726).",
+    "src/services/trip_command_processor.py::_show_now::0": "Muster A (:1227) — '/jetzt' datiert auf den Servertag (#1726).",
+    "src/services/trip_command_processor.py::_show_status::0": "Muster A (:1076) — '/status' datiert auf den Servertag (#1726).",
+    "src/services/trip_report_scheduler.py::_clamp_segments_to_today::0": "Muster A (:1497) — Segment-Beschnitt gegen den Servertag (#1726).",
+    "src/services/trip_report_scheduler.py::_collect_future_stage_weather::0": "Muster A (:2205) — 'zukuenftige Etappen' ab Servertag (#1726).",
+    "src/services/trip_report_scheduler.py::_send_trip_report_outcome::0": "Muster A (:932) — Test-Rueckfall vergleicht Zieltag mit Servertag (#1726).",
+    "src/services/trip_report_scheduler.py::select_test_stage::0": "Muster A (:765) — Test-Etappenwahl ab Servertag (#1726).",
+    # --- Muster B: festes Nicht-UTC-Zonen-Literal (namentlich #1726/S4) ---
+    "src/services/alert_daily_limit.py::<module>::0": "Muster B (:23) — `VIENNA = ZoneInfo('Europe/Vienna')` als Tagesgrenze des Alarm-Kontingents; ADR-0051, Behebung #1726.",
+    "src/services/deviation_alert_engine.py::<module>::0": "Muster B (:31) — `VIENNA = ZoneInfo('Europe/Vienna')` als Ruhezeit-Zone; ADR-0051, Behebung #1726.",
+    # --- Bestehende Fundart `raw_astimezone` auf der NEU hinzugekommenen
+    # Flaeche: kein neuer Detektor, nur groesserer Geltungsbereich. Viele davon
+    # sind Umrechnungen NACH UTC (nach Hausnorm #1345 unauffaellig) — der
+    # Scanner unterscheidet das strukturell nicht, deshalb gelistet statt
+    # ausgenommen.
+    "src/services/alert_briefing_anchor.py::record_briefing_sent::0": "raw_astimezone (:195) — Normalisierung des Sendezeitpunkts nach UTC.",
+    "src/services/alert_daily_limit.py::_vienna_date_str::0": "raw_astimezone (:32) — Tagesgrenze ueber die feste VIENNA-Zone, an Muster B oben gekoppelt (#1726).",
+    "src/services/compare_location_weather_source.py::_window_bound::0": "raw_astimezone (:39) — Fenstergrenze aus lokalem Tag + Stunde.",
+    "src/services/compare_location_weather_source.py::fetch::0": "raw_astimezone (:116) — lokaler Tag des Vergleichsorts.",
+    "src/services/compare_official_alert.py::_day_window_end::0": "raw_astimezone (:271) — lokales 'jetzt' des Vergleichsorts.",
+    "src/services/compare_official_alert.py::_day_window_end::1": "raw_astimezone (:275) — Fensterende zurueck nach UTC.",
+    "src/services/deviation_alert_engine.py::is_quiet_hours::0": "raw_astimezone (:112) — Ruhezeit gegen die feste VIENNA-Zone, an Muster B oben gekoppelt (#1726).",
+    "src/services/forecast_budget.py::_today_utc::0": "raw_astimezone (:130) — Kontingent-Tag bewusst in UTC (Zaehlwerk, kein Nutzerdatum).",
+    "src/services/official_alerts/meteoalarm_budget.py::_now_ts::0": "raw_astimezone (:167) — Kontingent-Zeitstempel bewusst in UTC.",
+    "src/services/official_alerts/meteoalarm_budget.py::_today_utc::0": "raw_astimezone (:176) — Kontingent-Tag bewusst in UTC.",
+    "src/services/scheduler_dispatch_service.py::run_compare_presets_daily::0": "raw_astimezone (:179) — Faelligkeit in der Ortszone des Presets (#1724).",
+    "src/services/segment_weather.py::_aggregate_for_segment::0": "raw_astimezone (:254) — Segmentbeginn auf volle UTC-Stunde.",
+    "src/services/segment_weather.py::_aggregate_for_segment::1": "raw_astimezone (:257) — Segmentende auf volle UTC-Stunde.",
+    "src/services/stage_weather.py::_to_utc_date::0": "raw_astimezone (:62) — Etappendatum in UTC.",
+    "src/services/trip_alert.py::_briefing_precip_for_onset::0": "raw_astimezone (:872) — Einsetzstunde auf volle UTC-Stunde.",
+    "src/services/trip_alert.py::check_radar_alerts::0": "raw_astimezone (:1092) — Einsetzzeit in der Ortszone ausgegeben.",
+    "src/services/trip_segments.py::convert_trip_to_segments::0": "raw_astimezone (:184) — Segmentstart aus Etappentag + Startstunde.",
+    "src/services/trip_segments.py::convert_trip_to_segments::1": "raw_astimezone (:189) — Segmentende aus Folgetag + Startstunde.",
+    "src/services/trip_segments.py::convert_trip_to_segments::2": "raw_astimezone (:275) — Ankunftstag in der Zielortzone.",
+    "src/services/trip_segments.py::convert_trip_to_segments::3": "raw_astimezone (:277) — Tagesende aus Ankunftstag + Endstunde.",
+    "src/services/weather_cache.py::get::0": "raw_astimezone (:126) — Cache-Schluessel Fensterbeginn in UTC.",
+    "src/services/weather_cache.py::get::1": "raw_astimezone (:127) — Cache-Schluessel Fensterende in UTC.",
+    "src/services/weather_cache.py::put::0": "raw_astimezone (:177) — Cache-Ablage Fensterbeginn in UTC.",
+    "src/services/weather_cache.py::put::1": "raw_astimezone (:178) — Cache-Ablage Fensterende in UTC.",
+    "src/services/weather_extractor.py::_to_naive_utc::0": "raw_astimezone (:32) — Naiv-Guard nach Hausnorm #1345 (naiv == UTC).",
 }
 
 
@@ -700,3 +835,282 @@ def test_scanner_ignores_zone_abbreviation_mentioned_only_in_docstring(tmp_path)
     )
     found = _find_violations(docstring_file)
     assert not found, f"Docstring-Erwähnung faelschlich als Verstoß gezaehlt: {found}"
+
+
+# ---------------------------------------------------------------------------
+# Entscheidungs-Schicht (Issue #1723, Epic #1722 S1)
+#
+# Der Wächter oben bewacht die DARSTELLUNG einer Uhrzeit. Die wiederkehrenden
+# Zeitzonen-Bugs sitzen aber in der ENTSCHEIDUNG — welcher Kalendertag gemeint
+# ist, ob ein Versand fällig ist, ob Ruhezeit gilt. Die Tests unten dehnen den
+# Nachweis auf `src/services/**` + `api/**` aus (Scanfläche, AC-1) und auf die
+# beiden dort greifenden Fundarten (Muster A/B, AC-2/AC-3/AC-9) inklusive der
+# beiden bewussten Nicht-Fänge (E1/E2, AC-4/AC-5).
+#
+# Die synthetischen Dateien liegen bewusst unter `src/services/`- bzw.
+# `api/`-artigen Pfaden in `tmp_path` — genau die Bäume, die `src/output/**`
+# NICHT enthält.
+# ---------------------------------------------------------------------------
+
+
+def _scope_of(key: str) -> str:
+    """Funktionsanteil aus einem Fundschlüssel ``"pfad::funktion::ordinal"``."""
+    return key.split("::")[-2]
+
+
+def test_scan_scope_includes_services_and_api_and_is_not_empty():
+    """GIVEN die Entscheidungs-Schicht `src/services/**` + `api/**`
+    WHEN `_scan_files()` die Scanfläche aufzählt
+    THEN liegt JEDE `.py`-Datei beider Bäume darin, die Fläche ist nicht leer,
+    kein Eintrag doppelt und keiner ausserhalb der (alten + neuen) Fläche.
+
+    Bauform von `test_scan_scope_excludes_go_internal_tree` in
+    `tests/test_success_status_guard.py`: eine Scanfläche, die nichts ansieht,
+    ist immer grün (#1465). Die Doppelt-Prüfung sichert zusätzlich, dass die
+    Kombination über eine MENGE geführt wird — sechs der sieben
+    `_MESSAGING_SERVICE_FILES` liegen bereits unter `src/services/` und würden
+    sonst zweimal gescannt.
+    """
+    services_dir = SRC / "services"
+    api_dir = REPO_ROOT / "api"
+    services_files = set(services_dir.rglob("*.py"))
+    api_files = set(api_dir.rglob("*.py"))
+    assert services_files and api_files, (
+        "Vorbedingung verletzt: src/services/ oder api/ enthaelt keine .py-"
+        "Datei — dann prueft dieser Test nichts."
+    )
+
+    scanned = _scan_files()
+    assert scanned, "_scan_files() liefert eine LEERE Scanflaeche."
+    assert len(scanned) == len(set(scanned)), (
+        "Scanflaeche enthaelt Dateien doppelt — die Kombination aus "
+        "src/output/**, _MESSAGING_SERVICE_FILES, src/services/** und api/** "
+        "muss ueber eine Menge gefuehrt werden (sorted({*...}), nicht +=): "
+        f"{sorted(str(p) for p in scanned if scanned.count(p) > 1)}"
+    )
+
+    scanned_set = set(scanned)
+    missing_services = sorted(
+        p.relative_to(REPO_ROOT).as_posix() for p in services_files - scanned_set
+    )
+    assert not missing_services, (
+        "Diese Dateien aus src/services/ liegen NICHT in der Scanflaeche — die "
+        "Entscheidungs-Schicht ist damit unbewacht (Issue #1723): "
+        f"{missing_services}"
+    )
+    missing_api = sorted(
+        p.relative_to(REPO_ROOT).as_posix() for p in api_files - scanned_set
+    )
+    assert not missing_api, (
+        "Diese Dateien aus api/ liegen NICHT in der Scanflaeche — die "
+        "Entscheidungs-Schicht ist damit unbewacht (Issue #1723): "
+        f"{missing_api}"
+    )
+
+    allowed = (
+        set(_OUTPUT_DIR.rglob("*.py"))
+        | set(_MESSAGING_SERVICE_FILES)
+        | services_files
+        | api_files
+    )
+    outside = sorted(str(p) for p in scanned_set - allowed)
+    assert not outside, (
+        "Scanflaeche greift ueber die vereinbarte Flaeche hinaus "
+        f"(src/output/**, _MESSAGING_SERVICE_FILES, src/services/**, api/**): {outside}"
+    )
+
+
+def test_scanner_detects_ambient_clock_in_synthetic_services_file(tmp_path):
+    """GIVEN eine synthetische Datei unter einem `src/services/`-artigen Pfad
+    mit `date.today()` und `datetime.now()` OHNE `tz`-Argument
+    WHEN der Scanner laeuft
+    THEN meldet er genau diese zwei Stellen als `ambient_clock` — und die
+    beiden `datetime.now(...)`-Aufrufe MIT Zone nicht.
+
+    Wirkungsnachweis fuer Muster A, ausserhalb von `src/output/`. Der
+    `kind`-Wert wird woertlich geprueft (AC-7): eine blosse `assert found`-
+    Summe wuerde einen lautlos leerlaufenden Muster-A-Detektor verdecken,
+    solange Muster B noch Funde liefert.
+    """
+    services_like = tmp_path / "src" / "services"
+    services_like.mkdir(parents=True)
+    bad_file = services_like / "synthetic_decision_clock.py"
+    bad_file.write_text(
+        "from datetime import date, datetime\n"
+        "\n"
+        "def faellig_heute():\n"
+        "    return date.today()\n"
+        "\n"
+        "def naechster_lauf():\n"
+        "    return datetime.now()\n"
+        "\n"
+        "def mit_zone_keyword(zone):\n"
+        "    return datetime.now(tz=zone)\n"
+        "\n"
+        "def mit_zone_positional(zone):\n"
+        "    return datetime.now(zone)\n",
+        encoding="utf-8",
+    )
+    found = _find_violations(bad_file)
+    assert len(found) == 2, (
+        f"erwartete 2 Funde (date.today() + datetime.now() ohne tz), gefunden "
+        f"{len(found)}: {found}"
+    )
+    assert set(found.values()) == {_KIND_AMBIENT_CLOCK}, (
+        f"erwartete ausschliesslich Fundart {_KIND_AMBIENT_CLOCK!r}, "
+        f"gefunden: {sorted(set(found.values()))}"
+    )
+    assert {_scope_of(k) for k in found} == {"faellig_heute", "naechster_lauf"}, (
+        "Muster A haengt an den falschen Funktionen — erwartet "
+        f"faellig_heute + naechster_lauf, gefunden: {sorted(found)}"
+    )
+
+
+def test_scanner_detects_hardcoded_non_utc_zone_in_synthetic_api_file(tmp_path):
+    """GIVEN eine synthetische Datei unter einem `api/`-artigen Pfad mit
+    `ZoneInfo("Europe/Vienna")`
+    WHEN der Scanner laeuft
+    THEN meldet er die Stelle als `hardcoded_non_utc_zone`.
+
+    Wirkungsnachweis fuer Muster B, ausserhalb von `src/output/` und
+    ausserhalb der bisherigen Mid-Body-Rueckfallformen (BoolOp/getattr/If/
+    IfExp): eine schlichte Zuweisung im Funktionsrumpf ist bislang unsichtbar.
+    Auch hier wird der `kind`-Wert woertlich geprueft (AC-7).
+    """
+    api_like = tmp_path / "api" / "routers"
+    api_like.mkdir(parents=True)
+    bad_file = api_like / "synthetic_decision_zone.py"
+    bad_file.write_text(
+        "from zoneinfo import ZoneInfo\n"
+        "\n"
+        "def fensterbeginn():\n"
+        "    zone = ZoneInfo('Europe/Vienna')\n"
+        "    return zone\n",
+        encoding="utf-8",
+    )
+    found = _find_violations(bad_file)
+    assert len(found) == 1, (
+        f"erwartete 1 Fund (ZoneInfo('Europe/Vienna')), gefunden {len(found)}: {found}"
+    )
+    assert set(found.values()) == {_KIND_HARDCODED_NON_UTC_ZONE}, (
+        f"erwartete Fundart {_KIND_HARDCODED_NON_UTC_ZONE!r}, "
+        f"gefunden: {sorted(set(found.values()))}"
+    )
+    assert {_scope_of(k) for k in found} == {"fensterbeginn"}, (
+        f"Muster B haengt an der falschen Funktion: {sorted(found)}"
+    )
+
+
+def test_scanner_ignores_utc_zone_literal_but_still_flags_the_guessed_zone(tmp_path):
+    """GIVEN eine synthetische Datei, die BEIDES enthaelt — ein geratenes
+    Nicht-UTC-Zonen-Literal und ein `ZoneInfo("UTC")`
+    WHEN der Scanner laeuft
+    THEN meldet er genau EINEN Fund, und zwar das geratene Literal.
+
+    Gegenprobe zu E1 als DIFFERENZ, nicht als blosses "UTC wird nicht
+    gefangen": letzteres waere heute schon gruen, weil ueberhaupt nichts
+    gefangen wird — ein unfehlbarer Test. Nach Hausnorm #1345 ist ein naiver
+    Zeitstempel UTC; bekaempft wird die GERATENE Ortszone, nicht UTC.
+    """
+    api_like = tmp_path / "api" / "routers"
+    api_like.mkdir(parents=True)
+    mixed_file = api_like / "synthetic_utc_vs_guessed.py"
+    mixed_file.write_text(
+        "from zoneinfo import ZoneInfo\n"
+        "\n"
+        "def geratene_zone():\n"
+        "    return ZoneInfo('Europe/Rome')\n"
+        "\n"
+        "def ehrliche_weltzeit():\n"
+        "    return ZoneInfo('UTC')\n",
+        encoding="utf-8",
+    )
+    found = _find_violations(mixed_file)
+    assert len(found) == 1, (
+        "erwartete genau 1 Fund (nur das geratene Nicht-UTC-Literal), gefunden "
+        f"{len(found)}: {found}"
+    )
+    assert {_scope_of(k) for k in found} == {"geratene_zone"}, (
+        "der einzige Fund muss das GERATENE Literal sein, nicht ZoneInfo('UTC'): "
+        f"{sorted(found)}"
+    )
+    assert set(found.values()) == {_KIND_HARDCODED_NON_UTC_ZONE}, (
+        f"erwartete Fundart {_KIND_HARDCODED_NON_UTC_ZONE!r}, "
+        f"gefunden: {sorted(set(found.values()))}"
+    )
+
+
+def test_scanner_ignores_utcnow_but_still_flags_the_naive_now(tmp_path):
+    """GIVEN eine synthetische Datei, die BEIDES enthaelt — `datetime.now()`
+    ohne Zone und `datetime.utcnow()`
+    WHEN der Scanner laeuft
+    THEN meldet er genau EINEN Fund, und zwar `datetime.now()`.
+
+    Gegenprobe zu E2 als DIFFERENZ (s. Test darueber). `.utcnow()` liefert
+    AUSDRUECKLICH Weltzeit, `.now()`/`.today()` liefern STILL Prozess-
+    Lokalzeit — eine andere Fehlerklasse. Dass `.utcnow()` seit Python 3.12
+    veraltet ist, ist Modernisierungsarbeit, kein Zeitzonen-Bug.
+    """
+    services_like = tmp_path / "src" / "services"
+    services_like.mkdir(parents=True)
+    mixed_file = services_like / "synthetic_now_vs_utcnow.py"
+    mixed_file.write_text(
+        "from datetime import datetime\n"
+        "\n"
+        "def prozess_lokalzeit():\n"
+        "    return datetime.now()\n"
+        "\n"
+        "def ausdrueckliche_weltzeit():\n"
+        "    return datetime.utcnow()\n",
+        encoding="utf-8",
+    )
+    found = _find_violations(mixed_file)
+    assert len(found) == 1, (
+        "erwartete genau 1 Fund (nur datetime.now() ohne tz), gefunden "
+        f"{len(found)}: {found}"
+    )
+    assert {_scope_of(k) for k in found} == {"prozess_lokalzeit"}, (
+        "der einzige Fund muss datetime.now() sein, nicht datetime.utcnow(): "
+        f"{sorted(found)}"
+    )
+    assert set(found.values()) == {_KIND_AMBIENT_CLOCK}, (
+        f"erwartete Fundart {_KIND_AMBIENT_CLOCK!r}, "
+        f"gefunden: {sorted(set(found.values()))}"
+    )
+
+
+def test_module_level_zone_literal_finding_names_the_module_scope(tmp_path):
+    """GIVEN ein `VIENNA = ZoneInfo("Europe/Vienna")` auf MODULEBENE, ausserhalb
+    jeder Funktion, unter einem `src/services/`-artigen Pfad
+    WHEN der Scanner laeuft
+    THEN traegt der Fundschlüssel `_MODULE_SCOPE` als Funktionsanteil, im
+    selben Format `"pfad::funktion::ordinal"` wie jeder andere Fund.
+
+    Analog `test_timezone_guard_finding_names_the_enclosing_function` im
+    Meta-Waechter: ein Fund, der seinen Ort nicht benennen kann, ist beim
+    Eintragen in KNOWN_VIOLATIONS nicht wiederzufinden (#1466 AP2).
+    """
+    services_like = tmp_path / "src" / "services"
+    services_like.mkdir(parents=True)
+    module_level_file = services_like / "synthetic_module_level_zone.py"
+    module_level_file.write_text(
+        "from zoneinfo import ZoneInfo\n"
+        "\n"
+        "VIENNA = ZoneInfo('Europe/Vienna')\n"
+        "\n"
+        "def fenster():\n"
+        "    return VIENNA\n",
+        encoding="utf-8",
+    )
+    found = _find_violations(module_level_file)
+    assert len(found) == 1, (
+        f"erwartete 1 Modulebene-Fund, gefunden {len(found)}: {found}"
+    )
+    key = next(iter(found))
+    assert key.endswith(f"::{_MODULE_SCOPE}::0"), (
+        f"Modulebene-Fund traegt den falschen Funktionsanteil: {key!r} — "
+        f"erwartet wurde '…::{_MODULE_SCOPE}::0'"
+    )
+    assert found[key] == _KIND_HARDCODED_NON_UTC_ZONE, (
+        f"erwartete Fundart {_KIND_HARDCODED_NON_UTC_ZONE!r}, gefunden: {found[key]!r}"
+    )


### PR DESCRIPTION
Scheibe **S1** von Epic #1722. Bewegt **keine Zeile Produktivcode**.

## Problem

Der Zeitzonen-Wächter aus #1402 bewachte bisher nur die *Darstellung* einer Uhrzeit
(`src/output/**`). Die elf wiederkehrenden Zeitzonen-Bugs sitzen aber in der
*Entscheidung*: welcher Kalendertag gemeint ist, ob ein Versand fällig ist, ob Ruhezeit
gilt, wann ein Zähler kippt. Diese Schicht war unbewacht — allein unter `src/services/`
lagen 71 ungeprüfte Dateien.

## Änderung

Scanfläche zusätzlich `src/services/**` + `api/**`, zwei neue Detektoren:

- `ambient_clock` — `date.today()`, `datetime.now()` ohne `tz`
- `hardcoded_non_utc_zone` — festes Zonen-Literal außer UTC

**Bewusst NICHT gefangen** (Spec E1/E2, jeweils mit Gegenprobe belegt):

- `ZoneInfo("UTC")` — nach Hausnorm #1345 die *richtige* Schreibweise; vier der fünf
  Fundstellen sind dokumentierte Notnagel-Rückfälle bei nicht auflösbarem Ort. Bekämpft
  wird die **geratene** Ortszone, nicht UTC.
- `.utcnow()` — liefert *explizit* UTC, während `.now()`/`.today()` *implizit*
  Prozess-Lokalzeit liefern. Andere Fehlerklasse; die Python-3.12-Deprecation ist
  Modernisierungsarbeit, kein Zeitzonen-Thema.

Die Gegenproben sind als **Differenz** gebaut (Prüfdatei enthält erlaubten *und* zu
beanstandenden Fall, geprüft wird dass genau einer gemeldet wird) — ein Test
„UTC wird nicht gemeldet" wäre ohne Implementierung schon grün gewesen und hätte nichts
bewacht.

## Bestand

`KNOWN_VIOLATIONS` 22 → 75, frisch gegen `origin/main` gemessen (nicht aus der Analyse
abgeschrieben — #1724 hatte seit deren Erhebung zwei `Europe/Vienna`-Stellen entfernt; die
alte Liste hätte `main` sofort rot gefärbt).

Nur 27 der 53 neuen Einträge stammen aus den neuen Mustern. **25 kommen aus dem
bestehenden `raw_astimezone`-Detektor**, der die größere Fläche erstmals sieht — in der
Spec nicht vorhergesehen, bei der Umsetzung gemessen und als Known Limitation 9
dokumentiert. Die vier übrigen Altmuster feuern dort nicht (nachgerechnet, nicht
angenommen).

Ein Alteintrag hat sein Ordinal verschoben (`_build_stage_trend::1` → `::2`); seine
Begründung wäre still falsch geworden, ohne dass ein Test rot wird — nachgezogen.

Behoben wird **nichts** — das trägt #1726 (S4), ADR-0051.

## Nachweis

- 32 Tests grün (Wächter 16 + Meta-Wächter 16)
- Adversary **VERIFIED**, 2 Runden, 12 Punkte, **8 von 8 Mutationen gefangen** — darunter
  die #1465-Falle (Scanpfad auf ein nicht existierendes Verzeichnis ⇒ stiller Leerlauf)
  und je Muster ein invertiertes Prädikat, das sonst lautlos leerliefe
- 2 LOW-Findings, beide in der Spec nachgezogen

Spec: `docs/specs/modules/fix_1723_zeitzonen_waechter_entscheidung.md` (PO-freigegeben)

Refs #1723, Epic #1722

🤖 Generated with [Claude Code](https://claude.com/claude-code)