### PR TITLE
fix(#1703 S2): Ausblick-Matrix -- fuenf dauerhaft leere Spalten im Ortsvergleich

### DIFF
--- a/docs/context/feat-1703-s2-ausblick-matrix.md
+++ b/docs/context/feat-1703-s2-ausblick-matrix.md
@@ -1,0 +1,301 @@
+# Context: Ausblick-Tabelle Trip + Compare (#1703 Scheibe 2)
+
+**Workflow:** `feat-1703-s2-ausblick-matrix`
+**Issue:** #1703 (Epic), Scheibe 2
+**Erstellt:** 2026-08-11
+**Branch:** `feat-1703-s2-ausblick-matrix` (von `origin/main` `e21f4f48`)
+
+## Request Summary
+
+Die Metrik×Kanal-Matrix (`tests/tdd/test_channel_metric_matrix.py`, Gate #1677 B) um
+eine Achse für die **Ausblick-Tabelle** erweitern, damit die laut
+`docs/reference/metric_output_matrix.md` §4.1 größte unbewachte Fläche ("Fläche 2")
+geschlossen wird. Vorbild und Leitplanken: Scheibe 3 (erledigt) und Scheibe 1 (erledigt),
+beide in derselben Testdatei.
+
+## Der zentrale Befund: die Prämisse der Scheibe stimmt so nicht
+
+Issue-Text und `metric_output_matrix.md:74/94` sagen, `outlook_columns()` "speist beide
+Mail-Familien". **Gemessen ist das falsch.** Alle sechs Aufrufstellen des geteilten
+Renderers, vollständig:
+
+| Aufrufstelle | Familie | `metrics=` |
+|---|---|---|
+| `src/output/renderers/email/html.py:1357` | Trip | **nein** |
+| `src/output/renderers/email/plain.py:338` | Trip | **nein** |
+| `src/services/trip_report_scheduler.py:1844` | Trip | **nein** |
+| `src/output/renderers/comparison.py:348` | Compare | ja |
+| `src/output/renderers/email/compare_html.py:1101` (`build_outlook_row`) | Compare | ja |
+| `src/output/renderers/email/compare_html.py:1175` (`render_outlook_table`) | Compare | ja |
+
+Keine Wrapper, kein `functools.partial`, keine kwargs-Durchreichung — jede Stelle ruft
+literal auf.
+
+**Konsequenz:** `outlook_columns()` wird ausschließlich vom Ortsvergleich erreicht.
+Der Trip-Ausblick läuft im festen Legacy-Spaltenpfad. Eine Metrik-Achse im Sinne von
+"jede Katalogmetrik erscheint als Spalte" existiert für den Trip **strukturell nicht** —
+der Nutzer kann dort keine Ausblick-Spalten wählen.
+
+Das ist kein Defekt, sondern der dokumentierte Bestandsschutz: `test_compare_outlook_metric_selection.py`
+AC-9 hält ausdrücklich fest, dass eine fehlende Auswahl die bisherigen sieben festen
+Spalten liefert.
+
+## Die tatsächliche Lücke (nachgemessen)
+
+Der Ortsvergleich-Ausblick ist katalog-getrieben und **teilweise** bewacht:
+`tests/tdd/test_compare_outlook_metric_selection.py` (433 Z., #1361/#1368) prüft das
+Auswahl-*Prinzip* — nur gewählte Spalten erscheinen (AC-1), Klartext deckungsgleich zu
+HTML (AC-2), leere Auswahl entfernt den Block (AC-8), fehlende Auswahl behält die sieben
+Legacy-Spalten (AC-9), unbekannte Einträge werden verworfen und geloggt (AC-10).
+
+Dafür benutzt die Datei **genau zwei** fest getippte Auswahlen (`:35-36`):
+`{"metric_id": "temperature", "aggregation": "max"}` und
+`{"metric_id": "precipitation", "aggregation": "sum"}`, dazu zwei ungültige Paare
+(`einhorn/max`, `confidence/min`, `:410-412`).
+
+Repo-weite Gegenprobe: **kein** Test paart `get_compare_metric_catalog()` mit dem
+Ausblick-Renderer. Die Treffer auf den Compare-Katalog in `tests/` betreffen den
+Endpunkt, die Stundentabelle, die Formatmigration und `cape` — nie den Ausblick.
+
+> **Die Lücke ist also nicht das Auswahl-Prinzip, sondern die Katalog-Deckung:
+> 2 von 25 Paaren sind je durch den Ausblick-Renderer gelaufen.** Für die übrigen 23
+> kann heute kein Test sagen, ob sie eine Spalte ergeben, welchen Kopf sie trägt und ob
+> die Zelle einen plausiblen Wert zeigt.
+
+## Die Soll-Menge (gemessen, nicht getippt)
+
+Quelle: `src/output/renderers/compare_metric_catalog.py`.
+
+- `COMPARE_METRIC_CATALOG` (`:76-162`) — kuratierte Liste, **26** Roh-Einträge
+- `get_compare_metric_catalog()` (`:251-322`) reichert an und filtert `selectable=False`
+  heraus (`:284-285`) → **25** ausgelieferte Einträge; es fällt genau `cape_max_jkg`
+  weg (`cape.selectable=False` seit #1585, `metric_catalog.py:382`)
+- `key_for(metric_id, aggregation)` (`:239-248`) — Umkehrindex über die **rohe** Liste,
+  also vor dem Filter
+
+Die 25 Paare tragen je `metric_id` + `aggregation`; `label` und `aggregation_label`
+entstehen erst zur Aufrufzeit aus `get_metric(metric_id).label_de` bzw.
+`aggregation_label_de(aggregation)` — im Katalog steht kein getippter Name.
+
+**Formzweige:** genau **1× `kind="ordinal"`** (`thunder_level_max`), genau **1× `kind="enum"`**
+(`precip_type_dominant`), **23× `kind="range"`**. Damit sind alle drei Zweige von
+`format_outlook_value()` (`compare_outlook_metric_ids.py:117-145`) durch die Soll-Menge
+belegbar.
+
+**Zweite Hürde nach dem Katalog:** `outlook_columns()` verlangt zusätzlich
+`summary_field_for(metric_id, aggregation) is not None` (`compare_outlook_metric_ids.py:98-100`).
+Laufzeitgeprüft lösen alle 25 ausgelieferten Paare auf einen `SegmentWeatherSummary`-Feldnamen
+auf — die Doppelbedingung ist heute also deckungsgleich, aber nicht per Konstruktion.
+Genau das macht sie zu einem lohnenden Wächter-Punkt.
+
+**Vorhandener getippter Größenanker:** `tests/tdd/test_compare_metric_catalog_endpoint.py:519`
+behauptet `len(get_compare_metric_catalog()) == 25`.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/output/renderers/compare_outlook_metric_ids.py` | `outlook_columns()` (`:78`), `format_outlook_value()` (`:117`), `resolve_outlook_metrics()` (`:45`) — Prüfling |
+| `src/output/renderers/compare_metric_catalog.py` | Soll-Mengen-Quelle: `COMPARE_METRIC_CATALOG` (`:76`), `get_compare_metric_catalog()` (`:251`), `key_for()` (`:239`) |
+| `src/output/renderers/email/outlook.py` | Geteilter Renderer; katalog-getriebener Zweig `:148-172` (HTML) / `:342-351` (Klartext) / `:520-535` (Zeilenbau) |
+| `src/app/metric_catalog.py` | `summary_field_for()` (`:608-619`), `_METRICS` (`:92-590`, 28 Einträge), `get_all_metrics()` (`:701`) |
+| `src/app/models.py` | `SegmentWeatherSummary` (`:388-468`) — Zielfelder der Auflösung |
+| `src/output/renderers/comparison.py` | `render_compare_email()`, Klartext-Aufruf `:348` |
+| `src/output/renderers/email/compare_html.py` | Compare-HTML-Aufrufe `:1101`/`:1175`; `_fmt_thunder` (`:204`), `_fmt_precip_type` (`:244`) |
+| `tests/tdd/test_channel_metric_matrix.py` | Zieldatei der neuen Achse (1568 Z.) |
+| `tests/tdd/test_compare_outlook_metric_selection.py` | Bestehende Prinzip-Prüfung (433 Z.) — Abgrenzung, nicht Ersatz |
+| `tests/unit/test_compare_hourly_catalog_columns.py` + `tests/helpers/hourly_columns.py` | **Vorbild** für "rechnen statt tippen" + Vakuum-Schutz |
+| `tests/tdd/test_trip_outlook_parity.py` + `tests/fixtures/outlook_trip_parity/` | Byte-Golden des Trip-Legacy-Pfads — darf nicht brechen |
+
+## Existing Patterns
+
+**Bauschema der Matrix-Datei** (aus Scheibe 1 und 3, beide in derselben Datei):
+
+1. Soll-Menge aus einer **benannten Produktivkonstante** rechnen
+   (`_alarm_soll_ids()` `:1068-1077` aus `_ALERT_METRIC_TO_CATALOG_ID`;
+   `_NON_SELECTABLE_METRIC_IDS` `:531` aus `_METRICS`)
+2. **Vakuum-Schutz** mit Mindestgröße gegen stilles Schrumpfen
+   (`_ALARM_SOLL_MINDESTGROESSE = 8` `:1082`, geprüft `:1247-1321`)
+3. Ausnahmen nie kopieren, sondern aus dem Produktivmodul lesen
+   (`_SELECTABLE_GATE_EXEMPT` aus `app.models:643`)
+4. Ist-Werte aus dem **echten Renderpfad**, nicht aus Hilfsfunktionen —
+   `TripReportFormatter().format_email()`, HTML per Regex geparst (`_mail_table()` `:288-315`).
+   Kein `Mock`/`patch` in der Datei (0 Treffer).
+
+**Vorbild `tests/helpers/hourly_columns.py:100-158`:** Soll-Mengen-Funktion plus
+`assert_soll_menge_ist_plausibel()` (Katalog ≥ 24, Ausnahmemenge nicht leer,
+Rechnung `len(soll) == len(katalog) - 1 - len(ausgenommen)`).
+
+**Echte Compare-Mail mit Ausblick-Auswahl** (kürzester Weg, aus
+`test_compare_outlook_metric_selection.py:109-127`):
+
+```python
+from output.renderers.comparison import render_compare_email
+html, text = render_compare_email(
+    result, outlook_enabled=True,
+    outlook_metrics=[{"metric_id": "temperature", "aggregation": "max"}],
+)
+```
+
+Ein Aufruf liefert **HTML und Klartext** — deckt den bekannten Klartext-blinden Fleck
+des Mail-Validators mit ab.
+
+## Dependencies
+
+- **Upstream:** `compare_metric_catalog` → `metric_catalog` (`get_metric`, `summary_field_for`,
+  `selectable`), `models.SegmentWeatherSummary`
+- **Downstream:** `email/outlook.py` (beide Familien), `compare_html.py`, `comparison.py`;
+  Änderungen am Renderer treffen Trip **und** Compare
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1703_s1_alert_renderer_matrix.md` — Vorgängerscheibe, Spec-Struktur
+- `docs/specs/modules/fix_1703_s3_selectable_metrics.md` — Vorgängerscheibe
+- `docs/specs/modules/issue_1361_1368_ausblick_konfigurierbar.md` — Ursprungsspec des Auswahl-Ausblicks
+- `docs/reference/metric_output_matrix.md` §4.1 (Fläche 2), §6 (Scheibe 2) — Definition of Done
+- ADR-0037 (datengetriebene Ausblick-Spalten), ADR-0005/#710 (`confidence` nicht wählbar)
+
+## Verdachtsmomente — Ergebnis der Messung (2026-08-11)
+
+1. **`hail` erreicht den Ausblick nie — WIDERLEGT.** `outlook_columns()` setzt den
+   Schlüssel tatsächlich nie, aber die Produktions-Aufrufstelle injiziert ihn:
+   `outlook.py:532` ruft `format_outlook_value(..., {**col, "hail": _hail})`. Gemessen:
+   `format_outlook_value(ThunderLevel.MED, {**spalte, "hail": True})` → `'mittel · Hagel: ja'`.
+   Der Docstring beschreibt korrekt, dass der **Aufrufer** den Schlüssel ergänzt.
+2. **Doppelbedingung Katalog ∧ `summary_field_for` — BESTÄTIGT deckungsgleich.**
+   Alle 25 ausgelieferten Paare überstehen beide Prüfungen; `resolve_outlook_metrics()`
+   verwirft keines, `outlook_columns()` liefert 25 Spalten. Deckungsgleich, aber nicht
+   erzwungen → lohnender Wächterpunkt.
+3. **Dublettenlogik der Spaltenbeschriftung — BESTÄTIGT wirksam.** Bei voller Auswahl
+   entstehen `Temperatur Maximum`/`Temperatur Minimum` und
+   `Gefühlte Temperatur Minimum`/`Gefühlte Temperatur Maximum`; **keine** doppelten Köpfe.
+4. **`temperature`+`avg`** ist zentral auflösbar (`temp_avg_c`), im Compare-Katalog nicht
+   vertreten — offene Frage, aber ohne Nutzerwirkung (nicht wählbar, also kein Defekt).
+
+## Risks & Considerations
+
+- **Geteilter Renderer:** jede Produktivänderung an `email/outlook.py` trifft die Trip-Mail.
+  Schutz: `tests/fixtures/outlook_trip_parity/` (Byte-Golden, laut README **nie**
+  nachziehen — ein roter Lauf ist ein Befund) und `tests/golden/email/outlook-thunder-day-night.txt`.
+- **Renderer-Commit-Gate** greift, sobald eine Datei unter `src/output/renderers/email/*.py`
+  gestaged wird (`renderer_mail_gate.py`) — dann sind `test_issue_811_mode_matrix.py` +
+  ein frischer Validator-Lauf Pflicht. Bei reiner Test-Scheibe entfällt das.
+- **Katalog-Wächter-Grenze** (Lehre aus Scheibe 1, Finding F001): Ein Test, der sein Soll
+  aus `get_compare_metric_catalog()` liest, bewacht **Vollständigkeit**, nicht
+  **Zuordnung**. Eine Vertauschung *im Katalog* bliebe grün. Muss in der Spec als Grenze
+  benannt und, wo ein redundanter Alt-Wächter existiert, im Testdocstring verlinkt werden.
+- **Abgrenzung zu Scheibe 4:** Telegram (`narrow.py:571` `_outlook_lines()`) und
+  Kompakt-Mail (`email/compact.py:227-238`) haben **eigene** Ausblick-Implementierungen,
+  die `outlook.py` gar nicht importieren. Sie gehören nicht in diese Scheibe.
+- **LoC:** Scheibe 1 lag mit Schätzung um Faktor 2,75 daneben (Override auf 600 nötig).
+  Hier vorab realistisch schätzen.
+
+---
+
+# Analysis (2026-08-11)
+
+## Type
+
+**Feature** (Wächter-Achse) — **mit** einem dabei gefundenen, nutzersichtbaren Produktivdefekt.
+
+## Hauptbefund: fünf Ausblick-Spalten sind dauerhaft leer
+
+Gemessen über den echten Mail-Pfad (`render_compare_email()` mit allen 25 Katalogpaaren,
+reich besetzte Stundenpunkte): **20 von 25 Zellen zeigen einen Wert, 5 zeigen `–`** —
+in HTML **und** Klartext, an jedem der drei Ausblickstage.
+
+| Spalte | Summary-Feld | Stundenwert im Datensatz |
+|---|---|---|
+| Schneehöhe | `snow_depth_cm` | `snow_depth_cm=30.0` gesetzt |
+| Neuschnee | `snow_new_sum_cm` | `snow_new_24h_cm=4.0` gesetzt |
+| Windrichtung | `wind_direction_avg_deg` | `wind_direction_deg=210.0` gesetzt |
+| Gefühlte Temperatur Minimum | `wind_chill_min_c` | `wind_chill_c` gesetzt |
+| Gefühlte Temperatur Maximum | `wind_chill_max_c` | `wind_chill_c` gesetzt |
+
+**Ursache, isoliert:** `services/weather_metrics.py:1071` `summarize_points()` ist eine
+**handgepflegte Aufzählung** von Zusatz-Aggregaten. Sie ruft `compute_basis_metrics()` plus
+elf namentlich verdrahtete `_compute_*`-Regeln (`:1097-1111`). Die fünf Regeln für die
+obigen Felder existieren als Methoden und sind im **Trip**-Pfad
+`compute_extended_metrics()` (`:752-760`) angeschlossen — in `summarize_points()` nie.
+
+**Nachgemessen, dass der Fix trägt:** alle fünf Methoden liefern auf dem Compare-Eingang
+korrekte Werte (`_compute_snow_depth`→30.0, `_compute_fresh_snow`→16.0,
+`_compute_wind_direction`→210, `_compute_wind_chill`→5.0, `_compute_wind_chill_max`→23.0).
+
+**Kein dokumentierter Vorsatz — im Gegenteil:** Der Kommentar `:763-765` hält die
+*spiegelbildliche* Lücke fest (#1391: Schneefallgrenze fehlte im **Trip**-Pfad, obwohl
+`summarize_points()` sie setzte). #1324 und #1392 sind Flicken an derselben Naht. Zwei
+handgepflegte Listen, die deckungsgleich bleiben müssten, sind dreimal auseinandergelaufen.
+
+**Nutzerwirkung:** Wer im Ortsvergleich eine dieser fünf Größen für den 3-Tages-Ausblick
+wählt, bekommt dauerhaft eine Strichspalte — unabhängig vom Wetter. Nach der
+Nebenbefund-Triage ist das Kategorie (a), nutzersichtbares Fehlverhalten.
+
+## Entscheidung: die Trip-Seite bekommt keine Achse
+
+Die im Kontext offene Frage ist beantwortet — **negativ, mit Begründung**: Ein
+Abdeckungs-Wächter für die festen sieben Trip-Spalten wäre schwächer als der bestehende
+Schutz. `tests/tdd/test_trip_outlook_parity.py` vergleicht das **gesamte** Ausblick-HTML
+und den Klartext byte-genau gegen `tests/fixtures/outlook_trip_parity/`. Jede stille
+Erweiterung oder Beschneidung des Legacy-Pfads ist dort bereits rot — strenger, als eine
+Metrik-Achse es je wäre. Eine zweite Prüfung desselben Sachverhalts wäre Regel-Zuwachs
+ohne Fang.
+
+Scheibe 2 ist damit **Compare-only**. Das ist keine Verkleinerung des Auftrags, sondern
+die Korrektur einer falschen Prämisse im Issue-Text: Der Trip-Ausblick hat keine
+wählbaren Spalten, also auch keine Metrik×Kanal-Fläche.
+
+## Affected Files
+
+| Datei | Typ | Beschreibung |
+|---|---|---|
+| `src/services/weather_metrics.py` | MODIFY | Die fünf fehlenden `_compute_*`-Regeln in `summarize_points()` verdrahten (`:1097-1111`) |
+| `tests/tdd/test_channel_metric_matrix.py` | MODIFY | Neue Achse AC-S2-1..n (Ausblick × Compare-Katalog) |
+| `tests/helpers/outlook_columns.py` | CREATE | Soll-Mengen-Ableitung + `assert_soll_menge_ist_plausibel()` (Vorbild `hourly_columns.py`) |
+| `docs/specs/modules/fix_1703_s2_ausblick_matrix.md` | CREATE | Spec |
+| `docs/reference/metric_output_matrix.md` | MODIFY | Fläche 2 + Scheibe 2 umtragen (Definition of Done) |
+
+## Scope Assessment
+
+- **Dateien:** 5 (3 Code/Test, 2 Doku)
+- **Geschätzte LoC (zählend):** ~+300 (Test-Achse ~200, Helfer ~70, Produktivfix ~10,
+  Anpassung roter Bestandstests ~20). Doku zählt nicht.
+- **Risiko:** MITTEL
+
+**LoC-Warnung:** Das überschreitet das 250er-Limit. Bei Scheibe 1 lag die Schätzung um
+Faktor 2,75 daneben; ich schätze hier bewusst großzügig und hole die Freigabe für
+`loc_limit_override 600` zusammen mit der Spec-Freigabe ein, statt sie später als
+Prozess-Unterbrechung nachzureichen.
+
+## Technischer Ansatz
+
+1. **Soll-Menge rechnen, nicht tippen:** Helfer leitet die 25 Paare aus
+   `get_compare_metric_catalog()` ab. Vakuum-Schutz analog `hourly_columns.py:130-158`
+   (Mindestgröße, Rechnung `len(ausgeliefert) == len(roh) - len(nicht_selectable)`).
+2. **Prüfort = Wirkort:** Ist-Werte aus `render_compare_email()` — ein Aufruf liefert HTML
+   **und** Klartext, beide aus derselben `outlook_columns()`-Quelle. Damit ist der
+   bekannte Klartext-blinde Fleck des Mail-Validators mit abgedeckt.
+3. **Drei Ebenen, aufsteigend streng:** (a) jede Katalogmetrik ergibt eine Spalte,
+   (b) jeder Spaltenkopf ist eindeutig, (c) **jede Zelle trägt einen Wert** bei
+   vorhandenem Stundenwert — Ebene (c) ist die, die den Defekt fängt.
+4. **Der Produktivfix bekommt einen reziproken Wächter,** keine Fünferliste: beide
+   Aggregationspfade (`compute_extended_metrics` ↔ `summarize_points`) gegeneinander
+   halten — dieselbe Bauart wie `_HANDLED_UNITS` in Scheibe 1. Sonst ist die nächste
+   Drift wieder unbewacht.
+
+## Risiken
+
+- **Der Fix wirkt über den Ausblick hinaus.** `summarize_points()` speist auch die
+  Compare-Übersichtstabelle (`compare_html.py:627`) und die Kompakt-Zusammenfassung
+  (`compact_summary.py:651`). Dort erscheinen künftig Werte, wo bisher Striche standen —
+  gewollt, aber Bestandstests/Goldens können rot werden. In RED zu messen, nicht zu raten.
+- **Katalog-Wächter-Grenze (Scheibe-1-Lehre F001):** Eine Achse, die ihr Soll aus
+  `get_compare_metric_catalog()` liest, bewacht Vollständigkeit, nicht Zuordnung. Als
+  Grenze in die Spec, nicht stillschweigend.
+- **Trip-Paritäts-Golden** darf nicht brechen; `summarize_points()` ist nicht der
+  Trip-Aggregator, ein Bruch wäre also ein Signal, kein Nachziehgrund.
+
+## Open Questions
+
+- [ ] Keine blockierenden. `temperature`+`avg` (im Compare-Katalog nicht vertreten) wird
+      als Beobachtung in der Spec vermerkt, nicht in dieser Scheibe geändert.

--- a/docs/specs/modules/fix_1703_s2_ausblick_matrix.md
+++ b/docs/specs/modules/fix_1703_s2_ausblick_matrix.md
@@ -214,6 +214,19 @@ bemerkt, statt still eine Strichspalte zu erzeugen.
     Docstring der neuen Achse vermerkt, damit der Anker bei einer künftigen Aufräumaktion
     nicht unbemerkt als „hartcodiert, unschön" verschwindet (Lehre aus Scheibe 1, F001).
 
+- **AC-8:** Gegeben der Fix läuft auf Staging, wenn die Vergleichs-Mail-Vorschau im
+  **echten Browser** für einen Vergleich geöffnet wird, in dem eine der fünf betroffenen
+  Größen für den Ausblick gewählt ist, dann zeigt die Spalte einen Wert statt des
+  Fehlzeichens — und die Browser-Konsole bleibt fehlerfrei.
+  - Test: Playwright gegen Staging, angemeldete Ansicht, Vorschau-Iframe geladen
+    (`frontend/src/lib/components/preview/EmailIframe.svelte` rendert das hier geänderte
+    HTML), Konsolenfehler und `pageerror` eingesammelt, Screenshot als Beleg.
+  - **Begründung, warum das trotz Backend-Scope hierher gehört:** Der Änderungssatz
+    berührt keine Datei unter `frontend/**`, die Wirkung ist aber an der Oberfläche
+    sichtbar. Ein reiner Backend-Nachweis (gerenderte Mail im Test) belegt nicht, dass der
+    Nutzer den Wert auch in der Vorschau sieht. Deploy-Scope trotzdem `--scope backend`
+    setzen — `docs-only` wäre fail-open.
+
 ## Known Limitations
 
 - **Zuordnung bleibt unbewacht.** Ein Wächter, der sein Soll aus demselben Katalog liest
@@ -244,8 +257,10 @@ bemerkt, statt still eine Strichspalte zu erzeugen.
 
 ## Definition of Done
 
-- [ ] AC-1 bis AC-7 grün
+- [ ] AC-1 bis AC-8 grün
 - [ ] Adversary-Verdict VERIFIED, alle drei Pflicht-Mutationen gefangen
+- [ ] Browser-Beleg zu AC-8 im Änderungssatz (Playwright gegen Staging, angemeldete
+      Ansicht, Screenshot + Konsolenprotokoll)
 - [ ] `docs/reference/metric_output_matrix.md`: Fläche 2 (§4.1) auf den neuen Wächter
       umgetragen, Scheibe 2 (§6) auf erledigt, Compare-only-Korrektur vermerkt
 - [ ] Issue #1703 Scheiben-Checkbox gesetzt, Ergebnis kommentiert

--- a/docs/specs/modules/fix_1703_s2_ausblick_matrix.md
+++ b/docs/specs/modules/fix_1703_s2_ausblick_matrix.md
@@ -16,10 +16,12 @@ tags: [metrics, outlook, compare, matrix-test, epic-1703, aggregation]
 
 ## Approval
 
-- [ ] Approved — ACs auf Deutsch vorgelegt, PO-Freigabe ausstehend.
-  Mitfreizugeben: (a) Zuschnitt **Compare-only** statt „Trip + Compare" (s. Purpose),
-  (b) Produktivfix an `summarize_points()` in dieser Scheibe (s. AC-4/AC-5),
-  (c) `loc_limit_override 600`.
+- [x] Approved — PO-Freigabe 2026-08-11 („go — alles drei freigegeben"), AC-1 bis AC-8 auf
+  Deutsch vorgelegt und bestätigt. Mitfreigegeben: (a) Zuschnitt **Compare-only** statt
+  „Trip + Compare" (s. Purpose), (b) Produktivfix an `summarize_points()` in dieser
+  Scheibe (s. AC-4/AC-5), (c) `loc_limit_override 600`.
+- AC-8 (Browser-Nachweis) wurde auf PO-Nachfrage nach Frontend-Tests ergänzt, bevor die
+  Freigabe erteilt wurde.
 
 ## Purpose
 

--- a/docs/specs/modules/fix_1703_s2_ausblick_matrix.md
+++ b/docs/specs/modules/fix_1703_s2_ausblick_matrix.md
@@ -1,0 +1,257 @@
+---
+entity_id: fix_1703_s2_ausblick_matrix
+type: module
+created: 2026-08-11
+updated: 2026-08-11
+status: draft
+version: "1.0"
+tags: [metrics, outlook, compare, matrix-test, epic-1703, aggregation]
+---
+
+<!-- Epic #1703 (Folgearbeit aus #1514), Scheibe 2. Deckt Flaeche 2 aus
+     docs/reference/metric_output_matrix.md §4.1. Voraussetzung Scheibe 3
+     (PR #1710) erledigt; Scheibe 1 (PR #1732) erledigt. -->
+
+# Ausblick-Tabelle × alle wählbaren Vergleichs-Metriken (#1703 Scheibe 2)
+
+## Approval
+
+- [ ] Approved — ACs auf Deutsch vorgelegt, PO-Freigabe ausstehend.
+  Mitfreizugeben: (a) Zuschnitt **Compare-only** statt „Trip + Compare" (s. Purpose),
+  (b) Produktivfix an `summarize_points()` in dieser Scheibe (s. AC-4/AC-5),
+  (c) `loc_limit_override 600`.
+
+## Purpose
+
+Der 3-Tages-Ausblick des Ortsvergleichs ist datengetrieben: der Nutzer wählt aus **25**
+Größe×Auswertung-Paaren, welche Spalten die Tabelle zeigt. Bewacht ist heute nur das
+Auswahl-*Prinzip* — `tests/tdd/test_compare_outlook_metric_selection.py` prüft mit **zwei**
+fest getippten Auswahlen, dass nur Gewähltes erscheint. Die **Katalog-Deckung** ist
+unbewacht: 2 von 25 Paaren sind je durch den Renderer gelaufen.
+
+Diese Scheibe hängt eine Matrix-Achse in den bestehenden, budgetierten Wächter
+`tests/tdd/test_channel_metric_matrix.py` (#1677 B) — und repariert dabei einen gemessenen,
+nutzersichtbaren Defekt: **fünf der 25 wählbaren Spalten sind dauerhaft leer.**
+
+### Korrektur der Scheiben-Prämisse: Compare-only
+
+Issue-Text und `metric_output_matrix.md:74/94` sagen, `outlook_columns()` speise „beide
+Mail-Familien". **Gemessen ist das falsch.** Von den sechs Aufrufstellen des geteilten
+Renderers übergeben die drei Trip-Stellen (`email/html.py:1357`, `email/plain.py:338`,
+`trip_report_scheduler.py:1844`) **kein** `metrics`-Argument; sie laufen im festen
+Legacy-Spaltenpfad. Nur der Ortsvergleich (`comparison.py:348`, `compare_html.py:1101`
+und `:1175`) ist katalog-getrieben.
+
+Der Trip-Ausblick hat also keine wählbaren Spalten und damit **keine Metrik×Kanal-Fläche**.
+Ein Abdeckungs-Wächter dafür wäre zudem *schwächer* als der Bestand: `test_trip_outlook_parity.py`
+vergleicht das gesamte Ausblick-HTML **und** den Klartext byte-genau gegen
+`tests/fixtures/outlook_trip_parity/`. Jede stille Erweiterung oder Beschneidung ist dort
+bereits rot. Eine zweite Prüfung desselben Sachverhalts wäre Regel-Zuwachs ohne Fang
+(Regel-Budget). Deshalb: **Compare-only, mit Begründung, statt stillem Weglassen.**
+
+## Source
+
+- **File:** `src/output/renderers/compare_outlook_metric_ids.py` (Prüfling),
+  `src/services/weather_metrics.py` (Fix), `tests/tdd/test_channel_metric_matrix.py` (Wächter)
+- **Identifier:** `outlook_columns:78` · `format_outlook_value:117` ·
+  `summarize_points:1071` · `compute_extended_metrics:752-771`
+
+Schicht: **Python-Core** (`src/output/renderers/`, `src/services/`). Keine Go-, keine
+Frontend-Berührung.
+
+## Estimated Scope
+
+- **LoC:** ~300 zählend (Test-Achse ~200, Helfer ~70, Produktivcode ~10, Anpassung roter
+  Bestandstests ~20; `docs/` zählt nicht)
+- **Files:** 5
+- **Effort:** medium
+
+> **LoC-Limit:** Die Schätzung liegt über 250. Bei Scheibe 1 lag sie um Faktor 2,75
+> daneben; deshalb wird die Freigabe für `loc_limit_override 600` **vorab** zusammen mit
+> dieser Spec eingeholt statt später als Prozess-Unterbrechung.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `src/output/renderers/compare_metric_catalog.py` | Katalog | `get_compare_metric_catalog()` — **die Soll-Mengen-Quelle** |
+| `src/app/metric_catalog.py` | Katalog | `summary_field_for()` — zweite Auflösungsbedingung |
+| `src/app/models.py` | Datentypen | `SegmentWeatherSummary`, `ThunderLevel`, `PrecipType` |
+| `src/services/weather_metrics.py` | Produktivmodul | beide Tages-Aggregationspfade |
+| `src/output/renderers/comparison.py` | Renderpfad | `render_compare_email()` — liefert HTML **und** Klartext |
+| `tests/tdd/test_channel_metric_matrix.py` | Wächter (Bestand) | Zieldatei, wird erweitert |
+| `tests/helpers/hourly_columns.py` | Vorbild | Muster „Soll rechnen, nicht tippen" + Vakuum-Schutz |
+| `tests/tdd/test_compare_outlook_metric_selection.py` | Abgrenzung | prüft das Prinzip, nicht die Deckung |
+
+## Implementation Details
+
+### Die Soll-Menge (gemessen 2026-08-11, nicht getippt)
+
+```
+# Quelle: das Produktivmodul selbst, nicht der Test.
+COMPARE_METRIC_CATALOG          -> 26 rohe Eintraege
+get_compare_metric_catalog()    -> 25 ausgeliefert
+Differenz                       -> cape_max_jkg (cape.selectable=False seit #1585)
+```
+
+Alle 25 Paare überstehen **beide** Auflösungsbedingungen (`key_for()` und
+`summary_field_for()`); `resolve_outlook_metrics()` verwirft keines, `outlook_columns()`
+liefert 25 Spalten. Formzweige: genau 1× `ordinal` (Gewitter), 1× `enum`
+(Niederschlagsart), 23× `range`.
+
+### Der gemessene Defekt (AC-4)
+
+Echte Vergleichs-Mail mit allen 25 Paaren und reich besetzten Stundenpunkten:
+**20 Zellen tragen einen Wert, 5 tragen das Fehlzeichen** — in HTML und Klartext, an
+jedem der drei Ausblickstage:
+
+| Spalte | Summary-Feld | im Stundenpunkt vorhanden |
+|---|---|---|
+| Schneehöhe | `snow_depth_cm` | `snow_depth_cm` |
+| Neuschnee | `snow_new_sum_cm` | `snow_new_24h_cm` |
+| Windrichtung | `wind_direction_avg_deg` | `wind_direction_deg` |
+| Gefühlte Temperatur Minimum | `wind_chill_min_c` | `wind_chill_c` |
+| Gefühlte Temperatur Maximum | `wind_chill_max_c` | `wind_chill_c` |
+
+**Ursache:** `summarize_points()` (`weather_metrics.py:1071`) ist eine handgepflegte
+Aufzählung — `compute_basis_metrics()` plus elf namentlich verdrahtete `_compute_*`-Regeln
+(`:1097-1111`). Die fünf Regeln für obige Felder existieren
+(`_compute_snow_depth:887`, `_compute_fresh_snow:964`, `_compute_wind_direction:969`,
+`_compute_wind_chill:872`, `_compute_wind_chill_max:879`) und sind im **Trip**-Pfad
+`compute_extended_metrics()` (`:752-760`) angeschlossen — im Vergleichspfad nie.
+
+Gegengemessen, dass der Fix trägt: auf dem Compare-Eingang liefern alle fünf korrekte
+Werte (30.0 · 16.0 · 210 · 5.0 · 23.0).
+
+**Kein dokumentierter Vorsatz.** Der Kommentar `:763-765` hält die *spiegelbildliche*
+Lücke fest (#1391: Schneefallgrenze fehlte im Trip-Pfad, obwohl der Vergleich sie setzte).
+#1324 und #1392 sind weitere Flicken an derselben Naht — zwei Listen, die deckungsgleich
+bleiben müssten und dreimal auseinandergelaufen sind. Deshalb AC-5.
+
+### Die Fehlzeichen-Falle (AC-4)
+
+Zwei verschiedene Striche, die im Terminal gleich aussehen:
+
+| Zeichen | Bedeutung | Quelle |
+|---|---|---|
+| `–` (U+2013) | **Wert fehlt** | `format_outlook_value(None, …)` |
+| `—` (U+2014) | Gewitterstufe „keine" / Niederschlagsart unbekannt | `_fmt_thunder`/`_fmt_precip_type` |
+
+Ein Wächter, der auf „irgendein Strich" prüft, hielte eine gültige Gewitter-Zelle
+fälschlich für einen Fehler — und ein Wächter, der beide gleichsetzt, übersähe den echten
+Fehlwert. AC-4 unterscheidet sie ausdrücklich.
+
+### Ausnahme-Muster
+
+Keine Ausnahmeliste nötig: Die Soll-Menge kommt aus `get_compare_metric_catalog()`, das
+nicht-wählbare Größen bereits selbst herausfiltert. Damit erbt der Wächter die
+Katalog-Entscheidung, statt sie zu kopieren (Muster aus Scheibe 3: Ausnahmen nie zweimal
+führen).
+
+## Expected Behavior
+
+Nach dieser Scheibe gilt: Wählt ein Nutzer eine beliebige der 25 Größen für den
+3-Tages-Ausblick des Ortsvergleichs, erscheint eine Spalte mit eindeutigem Kopf, und die
+Zelle zeigt den Tageswert, sobald die Stundendaten ihn hergeben — in HTML wie im Klartext.
+Fällt künftig eine Größe aus einem der beiden Tages-Aggregationspfade heraus, wird das
+bemerkt, statt still eine Strichspalte zu erzeugen.
+
+## Acceptance Criteria
+
+- **AC-1:** Gegeben ein Nutzer wählt alle im Vergleich wählbaren Ausblick-Größen, wenn die
+  Vergleichs-Mail erzeugt wird, dann trägt der Ausblick für **jede** dieser Größen genau
+  eine Spalte — in der HTML-Tabelle **und** in der Klartext-Fassung derselben Mail.
+  - Test: Soll-Menge aus `get_compare_metric_catalog()` gerechnet; eine echte Mail über
+    `render_compare_email()` (ein Aufruf liefert beide Formen); Kopfzeile aus dem HTML und
+    die Klartext-Zeile werden gegen dieselbe Soll-Menge gehalten. Keine Größe darf im
+    Klartext fehlen, die im HTML steht — und umgekehrt.
+
+- **AC-2:** Gegeben der Wächter läuft, wenn die Menge der zu prüfenden Größen bestimmt
+  wird, dann stammt sie ausschließlich aus dem Vergleichs-Katalog und ist niemals im Test
+  aufgezählt.
+  - Test: ein Plausibilitäts-Wächter schlägt fehl, wenn die Menge leer ist, unter 20
+    Einträge fällt, oder die Rechnung „roh minus nicht-wählbar = ausgeliefert" nicht
+    aufgeht (Vakuum-Schutz nach `hourly_columns.py:130-158`). Ein Wächter, der über eine
+    leere Menge iteriert, ist immer grün und bewacht nichts.
+
+- **AC-3:** Gegeben alle Größen sind gewählt, wenn die Spaltenköpfe erzeugt werden, dann
+  trägt keine zwei Spalten dieselbe Beschriftung.
+  - Test: die Köpfe der echten Mail werden auf Dubletten geprüft. Heute erfüllt, weil die
+    Auswertung angehängt wird, sobald dieselbe Größe mehrfach vorkommt
+    („Temperatur Maximum"/„Temperatur Minimum", „Gefühlte Temperatur Minimum"/„Maximum").
+    Bricht diese Logik, entstünden zwei ununterscheidbare Spalten.
+
+- **AC-4:** Gegeben die Stundendaten enthalten für eine gewählte Größe Werte, wenn der
+  Ausblick erzeugt wird, dann zeigt die zugehörige Zelle einen Wert und **nicht** das
+  Fehlzeichen — für jede der 25 Größen.
+  - Test: ein Stundendatensatz, der jedes Quellfeld besetzt; jede Zelle jeder
+    Ausblickszeile wird geprüft. Das Fehlzeichen `–` (U+2013) gilt als Verstoß; das
+    inhaltliche `—` (U+2014) einer Gewitterstufe „keine" ausdrücklich **nicht** — die
+    beiden Striche werden unterschieden, nicht gleichgesetzt.
+  - **Heute rot für fünf Größen** (Schneehöhe, Neuschnee, Windrichtung, Gefühlte
+    Temperatur Minimum und Maximum) — das ist der rote Anteil dieser Scheibe.
+
+- **AC-5:** Gegeben die beiden Tages-Aggregationspfade des Produkts (Trip und Vergleich),
+  wenn sie auf demselben Stundensatz gegeneinander gehalten werden, dann füllt der
+  Vergleichspfad jedes Tagesfeld, das der Trip-Pfad füllt.
+  - Test: beide Pfade laufen über denselben Stundensatz; die Feldmengen werden verglichen.
+    Eine Abweichung ist nur zulässig, wenn sie im Wächter namentlich als bewusste Ausnahme
+    geführt ist. Damit fällt die nächste Drift auf, statt erneut als Strichspalte beim
+    Nutzer zu landen — dieselbe Bauart wie die Einheiten-Prüfung aus Scheibe 1.
+
+- **AC-6:** Gegeben der Fix an der Vergleichs-Aggregation ist eingespielt, wenn Trip-Mail
+  und die bereits heute gefüllten Ausblick-Zellen erzeugt werden, dann bleiben sie
+  unverändert.
+  - Test: der Trip-Paritäts-Golden bleibt grün (`test_trip_outlook_parity.py`), und die 20
+    heute gefüllten Zellen behalten ihre Werte. Der Fix darf nicht über sein Ziel
+    hinausschießen.
+
+- **AC-7:** Gegeben jemand entfernt eine Größe aus dem Vergleichs-Katalog, wenn die Tests
+  laufen, dann fällt das auf — und der Wächter benennt, worauf er sich dabei stützt.
+  - Test: Die Mindestgröße aus AC-2 greift bei größeren Streichungen; die einzelne
+    Streichung fängt der unabhängige, getippte Größenanker in
+    `test_compare_metric_catalog_endpoint.py:519` (`== 25`). Diese Abhängigkeit wird im
+    Docstring der neuen Achse vermerkt, damit der Anker bei einer künftigen Aufräumaktion
+    nicht unbemerkt als „hartcodiert, unschön" verschwindet (Lehre aus Scheibe 1, F001).
+
+## Known Limitations
+
+- **Zuordnung bleibt unbewacht.** Ein Wächter, der sein Soll aus demselben Katalog liest
+  wie der Prüfling, sieht Fehler *in* diesem Katalog nicht: Vertauschte man Einheit oder
+  Auswertung zweier Einträge, bliebe diese Achse grün. „Rechnen statt tippen" gilt für die
+  Soll-**Menge**, nicht für die Soll-**Zuordnung** (Scheibe 1, Finding F001).
+- **`temperature` + `avg`** ist zentral auflösbar (`temp_avg_c`), im Vergleichs-Katalog
+  aber nicht vertreten. Ohne Nutzerwirkung (nicht wählbar), daher hier nur vermerkt.
+- **Der Fix wirkt über den Ausblick hinaus:** `summarize_points()` speist auch die
+  Vergleichs-Übersichtstabelle (`compare_html.py:627`) und die Kompakt-Zusammenfassung
+  (`compact_summary.py:651`). Dort erscheinen künftig Werte, wo Striche standen — gewollt,
+  aber der Umfang roter Bestandstests wird in der RED-Phase gemessen, nicht geschätzt.
+- **Telegram- und Kompakt-Ausblick bleiben außen vor:** `narrow.py:571` und
+  `email/compact.py:227` haben eigene Ausblick-Implementierungen, die `outlook.py` nicht
+  importieren. Sie gehören zu Scheibe 4.
+
+## Prüfhinweis für den Adversary
+
+- Die Mutations-Gegenprobe muss **außerhalb** des Testcodes ansetzen: eine der fünf neu
+  verdrahteten Zeilen in `summarize_points()` entfernen — AC-4 muss rot werden.
+- Zweite Pflicht-Mutation: eine Zeile aus `compute_extended_metrics()` entfernen — AC-5
+  muss rot werden (sonst prüft AC-5 nur eine Richtung).
+- Dritte: die Unterscheidung der beiden Striche in AC-4 auf „irgendein Strich" verkürzen —
+  ein Gewitter-Tag ohne Gewitter muss dann fälschlich rot werden. Wird er es nicht, prüft
+  AC-4 die Zellen nicht wirklich.
+- Leitfrage: Ist die Zusicherung an der Stelle geprüft, an der sie **wirkt** — an der
+  gerenderten Mail — oder nur dort, wo der Code steht?
+
+## Definition of Done
+
+- [ ] AC-1 bis AC-7 grün
+- [ ] Adversary-Verdict VERIFIED, alle drei Pflicht-Mutationen gefangen
+- [ ] `docs/reference/metric_output_matrix.md`: Fläche 2 (§4.1) auf den neuen Wächter
+      umgetragen, Scheibe 2 (§6) auf erledigt, Compare-only-Korrektur vermerkt
+- [ ] Issue #1703 Scheiben-Checkbox gesetzt, Ergebnis kommentiert
+
+## Changelog
+
+| Version | Datum | Änderung |
+|---|---|---|
+| 1.0 | 2026-08-11 | Erstfassung, ACs zur Freigabe vorgelegt |

--- a/docs/specs/modules/fix_1703_s2_ausblick_matrix.md
+++ b/docs/specs/modules/fix_1703_s2_ausblick_matrix.md
@@ -125,6 +125,12 @@ Aufzählung — `compute_basis_metrics()` plus elf namentlich verdrahtete `_comp
 Gegengemessen, dass der Fix trägt: auf dem Compare-Eingang liefern alle fünf korrekte
 Werte (30.0 · 16.0 · 210 · 5.0 · 23.0).
 
+> Diese fünf Zahlen stammen aus der **Analyse-Sonde** vom 2026-08-11, nicht aus der
+> Test-Fixture — sie gelten für den dort verwendeten Stundensatz. Die Fixture der Achse
+> rechnet mit anderen Eingangswerten (Wind-Chill 4.0/16.0). Beides ist richtig, aber es
+> sind **nicht** dieselben Erwartungswerte; wer sie verwechselt, baut einen Test gegen die
+> falsche Zahl. Aufgefallen im Adversary-Lauf (F001).
+
 **Kein dokumentierter Vorsatz.** Der Kommentar `:763-765` hält die *spiegelbildliche*
 Lücke fest (#1391: Schneefallgrenze fehlte im Trip-Pfad, obwohl der Vergleich sie setzte).
 #1324 und #1392 sind weitere Flicken an derselben Naht — zwei Listen, die deckungsgleich
@@ -231,10 +237,22 @@ bemerkt, statt still eine Strichspalte zu erzeugen.
 
 ## Known Limitations
 
-- **Zuordnung bleibt unbewacht.** Ein Wächter, der sein Soll aus demselben Katalog liest
-  wie der Prüfling, sieht Fehler *in* diesem Katalog nicht: Vertauschte man Einheit oder
-  Auswertung zweier Einträge, bliebe diese Achse grün. „Rechnen statt tippen" gilt für die
-  Soll-**Menge**, nicht für die Soll-**Zuordnung** (Scheibe 1, Finding F001).
+- **Zuordnung bleibt unbewacht — an ZWEI Stellen, nicht einer.** Ein Wächter, der sein Soll
+  aus demselben Katalog liest wie der Prüfling, sieht Fehler *in* diesem Katalog nicht:
+  Vertauschte man Einheit oder Auswertung zweier Einträge, bliebe diese Achse grün.
+  „Rechnen statt tippen" gilt für die Soll-**Menge**, nicht für die Soll-**Zuordnung**
+  (Scheibe 1, Finding F001).
+
+  **Nachtrag 2026-08-11 (Adversary-Finding F001 dieser Scheibe):** Dieselbe Lücke bestand
+  eine Ebene tiefer, **im Fix selbst**. AC-4 prüft „Zelle trägt nicht das Fehlzeichen",
+  AC-5 prüft „welche Felder sind befüllt" — keiner prüfte, **welcher Wert** darin steht.
+  Vertauschte man in `summarize_points()` die Zuweisungen von `wind_chill_min_c` und
+  `wind_chill_max_c` (die einzigen zwei der fünf neuen Felder mit nahezu gleichnamigen
+  Rechenregeln), blieben alle 58 Tests der Achse grün; repo-weit prüfte kein Test die
+  Zahlenwerte dieser Felder. Die ursprüngliche Fassung dieses Abschnitts benannte nur
+  Katalog-interne Vertauschungen und war damit zu eng. **Geschlossen** durch eine
+  Wert-Zusicherung mit unabhängig aus den Stundendaten gerechneten Erwartungswerten
+  (s. Abschnitt „Nachbesserung F001").
 - **`temperature` + `avg`** ist zentral auflösbar (`temp_avg_c`), im Vergleichs-Katalog
   aber nicht vertreten. Ohne Nutzerwirkung (nicht wählbar), daher hier nur vermerkt.
 - **Der Fix wirkt über den Ausblick hinaus:** `summarize_points()` speist auch die

--- a/src/services/weather_metrics.py
+++ b/src/services/weather_metrics.py
@@ -1109,6 +1109,17 @@ def summarize_points(points: list) -> Optional[SegmentWeatherSummary]:
     summary.cloud_low_avg_pct = svc._compute_cloud_low(ts)
     summary.cloud_mid_avg_pct = svc._compute_cloud_mid(ts)
     summary.cloud_high_avg_pct = svc._compute_cloud_high(ts)
+    # Issue #1703 S2: GEGENRICHTUNG zu #1391 -- dort fehlte die
+    # Schneefallgrenze im Trip-Pfad, obwohl der Vergleich sie setzte; hier
+    # fehlten diese fuenf im Vergleichspfad, obwohl compute_extended_metrics()
+    # sie laengst fuellt (:752-760). Folge waren fuenf dauerhaft leere
+    # Ausblick-Spalten des Ortsvergleichs. Kanonische Trip-Regeln, keine
+    # eigene Rechenvorschrift.
+    summary.snow_depth_cm = svc._compute_snow_depth(ts)
+    summary.snow_new_sum_cm = svc._compute_fresh_snow(ts)
+    summary.wind_direction_avg_deg = svc._compute_wind_direction(ts)
+    summary.wind_chill_min_c = svc._compute_wind_chill(ts)
+    summary.wind_chill_max_c = svc._compute_wind_chill_max(ts)
     return summary
 
 

--- a/tests/helpers/outlook_columns.py
+++ b/tests/helpers/outlook_columns.py
@@ -1,0 +1,133 @@
+"""Soll-Menge der Ausblick-Spalten des Ortsvergleichs — EINE Ableitung.
+
+Epic #1703 Scheibe 2. SPEC: docs/specs/modules/fix_1703_s2_ausblick_matrix.md
+
+Die Zahl der Ausblick-Spalten wird NICHT getippt. Sie ist genau die Menge der
+vom Compare-Katalog AUSGELIEFERTEN Groesse-Auswertung-Paare
+(``get_compare_metric_catalog()``) — der Katalog filtert zentral nicht
+waehlbare Groessen (``cape``, seit #1585) bereits selbst heraus. Damit erbt der
+Waechter die Katalog-Entscheidung, statt sie ein zweites Mal zu fuehren
+(Muster ``tests/helpers/hourly_columns.py``: Ausnahmen nie zweimal pflegen).
+
+Waechst der Katalog um ein Paar, zieht die Soll-Menge automatisch mit.
+
+**Grenze, ausdruecklich** (Lehre aus Scheibe 1, Finding F001): wer sein Soll
+aus demselben Katalog liest wie der Prueflig, bewacht **Vollstaendigkeit**,
+nicht **Zuordnung**. Vertauschte man Einheit oder Auswertung zweier
+Katalog-Zeilen, bliebe jede darauf gestuetzte Achse gruen.
+
+Die erwartete Spaltenueberschrift wird hier aus den Katalog-Feldern
+``label`` + ``aggregation_label`` GERECHNET und nicht aus
+``outlook_columns()`` uebernommen: sonst waeren Massstab und Prueflig
+dieselbe Funktion und die Beschriftungs-Zusicherung bewiese nichts. Die Regel
+"bei mehrfach vorkommendem Namen haengt die Auswertung an" ist die
+freigegebene Produktvorgabe (PO-Entscheidung 2026-07-27, "keine zwei gleich
+beschrifteten Spalten") — sie steht hier als Soll, nicht als Kopie einer
+Implementierung.
+"""
+from __future__ import annotations
+
+from collections import Counter
+
+from app.metric_catalog import get_metric, summary_field_for
+from output.renderers.compare_metric_catalog import (
+    COMPARE_METRIC_CATALOG, get_compare_metric_catalog,
+)
+
+# Vakuum-Schutz-Untergrenze (Muster hourly_columns.py:130-158): ein Waechter,
+# der ueber eine leere oder stark geschrumpfte Menge iteriert, ist immer gruen
+# und bewacht nichts. Gemessen 2026-08-11: 25 ausgelieferte Paare.
+OUTLOOK_SOLL_MINDESTGROESSE = 20
+
+
+def nicht_waehlbare_compare_keys(entries: list[dict] | None = None) -> list[str]:
+    """Die Katalog-Schluessel, die ``get_compare_metric_catalog()`` wegen
+    ``selectable=False`` zurueckhaelt — gelesen aus dem zentralen Register,
+    nicht hier aufgezaehlt."""
+    quelle = COMPARE_METRIC_CATALOG if entries is None else entries
+    return [e["key"] for e in quelle if not get_metric(e["metric_id"]).selectable]
+
+
+def compare_outlook_soll_spalten(entries: list[dict] | None = None) -> list[dict]:
+    """Je ausgeliefertem Katalog-Paar ein Soll-Eintrag, in Katalog-Reihenfolge.
+
+    ``entries`` injiziert eine Testkopie der Katalogzeilen (Vorbild
+    ``get_compare_metric_catalog(entries=...)``), damit die
+    Plausibilitaets-Rechnung ohne Monkeypatch des echten Katalogs pruefbar
+    ist.
+    """
+    geliefert = get_compare_metric_catalog(entries)
+    haeufigkeit = Counter(e["label"] for e in geliefert)
+    soll: list[dict] = []
+    for eintrag in geliefert:
+        label = eintrag["label"]
+        auswertung_label = eintrag.get("aggregation_label", "")
+        mehrdeutig = haeufigkeit[label] > 1 and bool(auswertung_label)
+        soll.append({
+            "key": eintrag["key"],
+            "metric_id": eintrag["metric_id"],
+            "aggregation": eintrag["aggregation"],
+            "label": label,
+            "ueberschrift": f"{label} {auswertung_label}" if mehrdeutig else label,
+            "summary_field": summary_field_for(
+                eintrag["metric_id"], eintrag["aggregation"],
+            ),
+            "kind": eintrag.get("kind", "range"),
+        })
+    return soll
+
+
+def compare_outlook_soll_paare(entries: list[dict] | None = None) -> list[dict]:
+    """Die Auswahl im Speicherformat der Bedienflaeche (#1373-Vokabular) —
+    genau das, was ein Nutzer waehlt, der alles waehlt."""
+    return [
+        {"metric_id": s["metric_id"], "aggregation": s["aggregation"]}
+        for s in compare_outlook_soll_spalten(entries)
+    ]
+
+
+def assert_soll_menge_ist_plausibel(entries: list[dict] | None = None) -> list[dict]:
+    """Vakuum-Schutz mit ausgesprochener Rechnung: Katalog gross genug, Abzug
+    begruendet, Ergebnis > 0, jedes Paar aufloesbar. Gibt die Soll-Menge
+    zurueck."""
+    roh = COMPARE_METRIC_CATALOG if entries is None else entries
+    zurueckgehalten = nicht_waehlbare_compare_keys(entries)
+    geliefert = get_compare_metric_catalog(entries)
+    soll = compare_outlook_soll_spalten(entries)
+
+    assert soll, (
+        "Soll-Menge leer — Vakuum. Jede Achse dieser Scheibe liefe ueber null "
+        "Faelle und waere immer gruen."
+    )
+    assert len(soll) >= OUTLOOK_SOLL_MINDESTGROESSE, (
+        f"Vakuum-Schutz: nur {len(soll)} waehlbare Ausblick-Paare "
+        f"({[s['key'] for s in soll]}) — erwartet mindestens "
+        f"{OUTLOOK_SOLL_MINDESTGROESSE}. Entweder ist der Compare-Katalog "
+        "geschrumpft oder die Soll-Rechnung greift daneben."
+    )
+    assert len(geliefert) == len(roh) - len(zurueckgehalten), (
+        f"Rechnung geht nicht auf: {len(roh)} rohe Katalog-Zeilen "
+        f"- {len(zurueckgehalten)} nicht waehlbare ({zurueckgehalten}) "
+        f"!= {len(geliefert)} ausgelieferte"
+    )
+    assert len(soll) == len(geliefert), (
+        f"Soll-Menge ({len(soll)}) und ausgelieferter Katalog "
+        f"({len(geliefert)}) sind auseinandergelaufen"
+    )
+    assert zurueckgehalten, (
+        "Der Compare-Katalog haelt keine einzige Zeile mehr wegen "
+        "selectable=False zurueck (bis 2026-08-11: 'cape_max_jkg', #1585) — "
+        "der Filterschritt waere damit unbewacht, die Rechnung oben trivial."
+    )
+    ohne_feld = [s["key"] for s in soll if not s["summary_field"]]
+    assert not ohne_feld, (
+        f"Katalog-Paare ohne ``SegmentWeatherSummary``-Feld: {ohne_feld} — "
+        "``outlook_columns()`` verwirft sie stillschweigend "
+        "(compare_outlook_metric_ids.py:98-100), die Spalte fehlte dann ganz"
+    )
+    doppelt = [u for u, n in Counter(s["ueberschrift"] for s in soll).items() if n > 1]
+    assert not doppelt, (
+        f"Zwei Soll-Spalten teilen sich eine Ueberschrift: {doppelt} — die "
+        "Auswertungs-Unterscheidung greift nicht mehr"
+    )
+    return soll

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -2667,3 +2667,177 @@ def test_ac_s2_7_groessenanker_faengt_die_einzelne_streichung():
         "Ersatz schaffen, bevor der Anker verschwindet."
     )
     pruefung(klasse())
+
+
+# --- AC-S2-8: die fuenf neuen Zellen tragen den RICHTIGEN Wert ------------
+
+# Adversary-Finding F001 (Scheibe 2, HIGH): AC-S2-4 prueft "die Zelle traegt
+# nicht das Fehlzeichen", AC-S2-5 "welche Felder sind ueberhaupt befuellt" --
+# KEINER von beiden prueft, WELCHER Wert drinsteht. Vertauscht man in
+# ``summarize_points()`` (weather_metrics.py:1121-1122) die Zuweisungen
+# ``wind_chill_min_c`` und ``wind_chill_max_c`` gegeneinander, bleibt diese
+# ganze Achse gruen -- und repo-weit prueft kein Test die Zahlenwerte dieser
+# fuenf Felder. Genau dort ist ein Vertauscher am wahrscheinlichsten: es sind
+# die einzigen zwei der fuenf mit nahezu gleichnamigen Helferfunktionen
+# (``_compute_wind_chill`` / ``_compute_wind_chill_max``), und beide Zellen
+# zeigen danach einen plausiblen Wert -- der Fehler ist unsichtbar.
+#
+# Massstab: die Erwartung wird aus den STUNDENWERTEN der Fixture gerechnet --
+# weder aus ``_compute_*`` noch aus der Ausgabe von ``summarize_points()``.
+# Beides hielte die Ausgabe gegen sich selbst und fiele auf denselben
+# Vertauscher erneut herein.
+_S2_NEUE_FELDER_REGEL = {
+    "snow_depth_cm": "MAXIMUM ueber die Stundenwerte snow_depth_cm",
+    "snow_new_sum_cm": "SUMME ueber die Stundenwerte snow_new_24h_cm",
+    "wind_direction_avg_deg": "Tagesmittel ueber die Stundenwerte wind_direction_deg",
+    "wind_chill_min_c": "MINIMUM ueber die Stundenwerte wind_chill_c",
+    "wind_chill_max_c": "MAXIMUM ueber die Stundenwerte wind_chill_c",
+}
+
+_S2_ZELLENZAHL = re.compile(r"^-?\d+(?:[.,]\d+)?")
+
+
+def _s2_erwartete_tageswerte(tagespunkte: list[ForecastDataPoint]) -> dict[str, float]:
+    """Die fuenf Tageswerte, aus den Stundenwerten GERECHNET (Regeln oben).
+
+    Die Windrichtung wird bewusst NICHT als Kreismittel nachgebaut: die Fixture
+    haelt sie ueber den Tag konstant, und der Tageswert einer konstanten Reihe
+    ist genau dieser Wert -- unabhaengig von der Mittelungsvorschrift. Ein hier
+    nachgebautes ``atan2`` waere eine Kopie der Implementierung, kein
+    unabhaengiger Massstab.
+    """
+    richtungen = {p.wind_direction_deg for p in tagespunkte}
+    assert len(richtungen) == 1, (
+        f"Vorbedingung: die Fixture haelt die Windrichtung ueber den Tag "
+        f"konstant, gemessen {sorted(richtungen)} -- ohne Konstanz traegt die "
+        f"vorschriftsfreie Erwartung fuer wind_direction_avg_deg nicht"
+    )
+    return {
+        "snow_depth_cm": max(p.snow_depth_cm for p in tagespunkte),
+        "snow_new_sum_cm": sum(p.snow_new_24h_cm for p in tagespunkte),
+        "wind_direction_avg_deg": float(richtungen.pop()),
+        "wind_chill_min_c": min(p.wind_chill_c for p in tagespunkte),
+        "wind_chill_max_c": max(p.wind_chill_c for p in tagespunkte),
+    }
+
+
+def _s2_erwartungen_je_ausblickstag() -> list[tuple[date, dict[str, float]]]:
+    """Je Ausblickstag der Mail ein Paar (Tag, gerechnete Soll-Werte)."""
+    punkte = _s2_punkte(ThunderLevel.MED)
+    tage = sorted({p.ts.date() for p in punkte})
+    return [
+        (tag, _s2_erwartete_tageswerte([p for p in punkte if p.ts.date() == tag]))
+        for tag in tage
+    ]
+
+
+def _s2_erwartungen_sind_unterscheidbar(
+    erwartungen: list[tuple[date, dict[str, float]]],
+) -> None:
+    """Vakuum-Gegenprobe: eine Wert-Zusicherung faengt eine Vertauschung nur,
+    wenn die vertauschten Werte ueberhaupt verschieden sind. Sind sie gleich,
+    ist AC-S2-8 blind -- dann muss der Test scheitern und das sagen, statt
+    stillschweigend nichts zu bewachen."""
+    for tag, werte in erwartungen:
+        if werte["wind_chill_min_c"] == werte["wind_chill_max_c"]:
+            pytest.fail(
+                f"Vakuum: am Ausblickstag {tag} liefert die Fixture fuer "
+                f"wind_chill_min_c und wind_chill_max_c denselben Wert "
+                f"({werte['wind_chill_min_c']!r}) -- eine Vertauschung der "
+                "beiden Zuweisungen in summarize_points() waere damit "
+                "unsichtbar und AC-S2-8 blind. Die Stundenreihe des Tages "
+                "braucht eine Temperaturspreizung."
+            )
+    felder = list(_S2_NEUE_FELDER_REGEL)
+    for nummer, eins in enumerate(felder):
+        for zwei in felder[nummer + 1:]:
+            if all(werte[eins] == werte[zwei] for _, werte in erwartungen):
+                pytest.fail(
+                    f"Vakuum: {eins} und {zwei} tragen an JEDEM Ausblickstag "
+                    "denselben Soll-Wert. Waeren ihre Zuweisungen in "
+                    "summarize_points() vertauscht oder beide auf dieselbe "
+                    "``_compute_*``-Regel gelegt, bliebe AC-S2-8 gruen -- die "
+                    "Fixture muss die fuenf Felder unterscheidbar machen."
+                )
+
+
+def test_ac_s2_8_die_fuenf_neuen_felder_tragen_den_gerechneten_wert():
+    """AC-S2-8: ``summarize_points()`` liefert fuer die fuenf mit dieser Scheibe
+    verdrahteten Tagesfelder GENAU den Wert, den die Stundenwerte hergeben --
+    nicht nur "kein Fehlzeichen" (AC-S2-4) und nicht nur "ueberhaupt befuellt"
+    (AC-S2-5). Schliesst Adversary-Finding F001: die Zuweisungen duerfen weder
+    vertauscht noch auf die falsche ``_compute_*``-Regel gelegt sein."""
+    erwartungen = _s2_erwartungen_je_ausblickstag()
+    _s2_erwartungen_sind_unterscheidbar(erwartungen)
+    punkte = _s2_punkte(ThunderLevel.MED)
+
+    for tag, soll in erwartungen:
+        aggregat = summarize_points([p for p in punkte if p.ts.date() == tag])
+        ist = {feld: getattr(aggregat, feld) for feld in _S2_NEUE_FELDER_REGEL}
+        for feld, regel in _S2_NEUE_FELDER_REGEL.items():
+            assert ist[feld] == soll[feld], (
+                f"AC-S2-8: ``summarize_points()`` liefert am Ausblickstag {tag} "
+                f"fuer {feld} den Wert {ist[feld]!r}; aus den Stundenwerten "
+                f"gerechnet ({regel}) sind es {soll[feld]!r}.\n"
+                f"Ist:  {ist}\nSoll: {soll}\n"
+                "Haeufigster Grund: in weather_metrics.py sind zwei Zuweisungen "
+                "VERTAUSCHT -- bei wind_chill_min_c/wind_chill_max_c "
+                "(``_compute_wind_chill`` vs. ``_compute_wind_chill_max``) "
+                "faellt das sonst nirgends auf, weil danach beide Zellen einen "
+                "plausiblen Wert zeigen."
+            )
+
+
+def _s2_zellenzahl(zelle: str) -> float:
+    """Die fuehrende Zahl eines Ausblick-Zellentexts ("16 cm" -> 16.0).
+
+    Geprueft wird der WERT, nicht die Schreibweise -- Einheit und
+    Nachkommastellen bewacht AC-S2-6.
+    """
+    treffer = _S2_ZELLENZAHL.match(zelle.strip())
+    assert treffer is not None, (
+        f"AC-S2-8: die Ausblick-Zelle {zelle!r} beginnt nicht mit einer Zahl -- "
+        "ohne Zahl ist der Wert nicht pruefbar"
+    )
+    return float(treffer.group().replace(",", "."))
+
+
+def test_ac_s2_8_ausblick_zelle_zeigt_den_gerechneten_wert():
+    """AC-S2-8 (Wirkort): derselbe gerechnete Tageswert steht in der Zelle der
+    ECHTEN Vergleichs-Mail -- HTML UND Klartext, an jedem der drei Tage. Der
+    Nachweis an ``summarize_points()`` allein zeigte nur, dass das Aggregat
+    stimmt, nicht dass der Nutzer den richtigen Wert sieht (Pruefort =
+    Wirkort)."""
+    erwartungen = _s2_erwartungen_je_ausblickstag()
+    _s2_erwartungen_sind_unterscheidbar(erwartungen)
+    nach_feld = {s["summary_field"]: s for s in _S2_SOLL}
+    dezimalen = {e["key"]: e.get("decimals") or 0 for e in get_compare_metric_catalog()}
+
+    html, text = _s2_mail()
+    kopf, zeilen = _s2_html_ausblick(html)
+    klartext = _s2_klartext_ausblick(text)
+    assert len(zeilen) == len(klartext) == len(erwartungen), (
+        f"AC-S2-8: {len(zeilen)} HTML-Tageszeilen, {len(klartext)} "
+        f"Klartext-Tageszeilen, {len(erwartungen)} Ausblickstage in den "
+        "Stundendaten -- ohne 1:1-Zuordnung ist kein Tageswert pruefbar"
+    )
+
+    for nummer, (tag, soll) in enumerate(erwartungen):
+        for feld, regel in _S2_NEUE_FELDER_REGEL.items():
+            spalte = nach_feld[feld]
+            erwartet = round(soll[feld], dezimalen[spalte["key"]])
+            for form, zelle in (
+                ("HTML", zeilen[nummer][kopf.index(spalte["ueberschrift"])]),
+                ("KLARTEXT", klartext[nummer][spalte["ueberschrift"]]),
+            ):
+                assert _s2_zellenzahl(zelle) == erwartet, (
+                    f"AC-S2-8: die {form}-Zelle der Spalte "
+                    f"{spalte['ueberschrift']!r} ({spalte['key']} -> "
+                    f"SegmentWeatherSummary.{feld}) zeigt am Ausblickstag {tag} "
+                    f"{zelle!r}; aus den Stundenwerten gerechnet ({regel}) "
+                    f"gehoert dort {erwartet!r} hin.\nSoll des Tages: {soll}\n"
+                    "Haeufigster Grund: vertauschte Zuweisungen in "
+                    "summarize_points() -- bei Gefuehlter Temperatur "
+                    "Minimum/Maximum zeigen dann beide Spalten einen "
+                    "plausiblen, aber getauschten Wert."
+                )

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -33,28 +33,47 @@ docs/specs/modules/fix_1703_s3_selectable_metrics.md. Kein Produktivcode-Fix
 -- Charakterisierungstest fuer bereits korrektes, bisher unbewachtes
 Verhalten (alle 8 ACs laufen heute bereits GRUEN).
 
-Epic #1703 Scheibe 1 (AC-S1-1 bis AC-S1-7, ganz unten): Alarm-Renderer x alle
+Epic #1703 Scheibe 1 (AC-S1-1 bis AC-S1-7, weiter unten): Alarm-Renderer x alle
 alarmfaehigen Metriken (docs/reference/metric_output_matrix.md Flaeche 1) --
 die vier Alarm-Renderer waren fuer 8 von 11 produktiv erreichbaren
 Alarm-Groessen ungeprueft. SPEC:
 docs/specs/modules/fix_1703_s1_alert_renderer_matrix.md. EINZIGER roter
 Anteil dieser Achse: AC-S1-5 im gebuendelten Fall (Gewitter-Prozentzeichen).
+
+Epic #1703 Scheibe 2 (AC-S2-1 bis AC-S2-7, ganz unten): Ausblick-Tabelle des
+Ortsvergleichs x alle 25 waehlbaren Katalog-Paare
+(docs/reference/metric_output_matrix.md Flaeche 2) -- bewacht war bisher nur
+das Auswahl-PRINZIP mit zwei fest getippten Auswahlen
+(test_compare_outlook_metric_selection.py), nicht die Katalog-DECKUNG. SPEC:
+docs/specs/modules/fix_1703_s2_ausblick_matrix.md. Compare-only (die drei
+Trip-Aufrufstellen des geteilten Ausblick-Renderers uebergeben kein
+``metrics``-Argument, s. Spec "Korrektur der Scheiben-Praemisse"). ROTER
+Anteil: AC-S2-4 (fuenf dauerhaft leere Spalten) und AC-S2-5 (die beiden
+Tages-Aggregationspfade sind auseinandergelaufen).
 """
 from __future__ import annotations
 
 import dataclasses
 import json
 import re
+from collections import Counter
+from datetime import date, datetime, timedelta, timezone
+from functools import lru_cache
 from pathlib import Path
 
 import pytest
+from bs4 import BeautifulSoup
 
 from app.loader import _parse_display_config
 from app.metric_catalog import (
     _METRICS, build_default_display_config, format_metric_value, get_all_metrics,
     get_alert_label, get_cmp, get_metric, get_sms_code,
 )
-from app.models import AlertMetric, MetricConfig, UnifiedWeatherDisplayConfig, _SELECTABLE_GATE_EXEMPT
+from app.models import (
+    AlertMetric, ForecastDataPoint, ForecastMeta, MetricConfig, NormalizedTimeseries,
+    PrecipType, Provider, ThunderLevel, UnifiedWeatherDisplayConfig,
+    _SELECTABLE_GATE_EXEMPT,
+)
 from output.renderers.alert.model import AlertEvent, AlertMessage, side_label
 from output.renderers.alert.render import (
     _HANDLED_UNITS, render_email, render_sms, render_subject, render_telegram,
@@ -63,11 +82,17 @@ from output.channels.premium_sms import PremiumSmsOutput
 from output.renderers.channel_layout import render_for_channel
 from output.renderers.compare_metric_catalog import COMPARE_METRIC_CATALOG, get_compare_metric_catalog
 from output.renderers.compare_metric_ids import FRONTEND_TO_RENDERER_METRIC_ID, resolve_enabled_metrics
+from output.renderers.comparison import render_compare_email
 from output.renderers.email.helpers import resolve_metric_col_order
 from output.renderers.sms_trip import SMS_SYMBOL_BY_METRIC, SMS_MULTI_SYMBOLS_BY_METRIC
 from output.renderers.trip_report import TripReportFormatter
 from services.weather_change_detection import _ALERT_METRIC_TO_CATALOG_ID, is_alert_metric_active
+from services.weather_metrics import WeatherMetricsService, summarize_points
 
+from tests.helpers.outlook_columns import (
+    assert_soll_menge_ist_plausibel, compare_outlook_soll_paare,
+    compare_outlook_soll_spalten,
+)
 from tests.tdd import _min_temp_felt_fixtures as F
 # Issue #1719 S2 AC-11: geteilter Premium-SMS-Stub (echter lokaler HTTP-
 # Server, kein Mock) -- Vorbild-Fixture wiederverwendet statt kopiert (Muster
@@ -2098,3 +2123,547 @@ def test_ac_s1_7_gleichnamige_groessen_trennt_nur_die_kurznachricht(label, metri
         f"AC-S1-7: allein die Kurznachricht trennt die gleichnamigen Groessen "
         f"{list(metric_ids)} -- hier tut sie es nicht: {kuerzel}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Epic #1703 Scheibe 2 (AC-S2-1 bis AC-S2-7): Ausblick-Tabelle des
+# Ortsvergleichs x alle waehlbaren Katalog-Paare
+# (docs/reference/metric_output_matrix.md Flaeche 2).
+# SPEC: docs/specs/modules/fix_1703_s2_ausblick_matrix.md.
+#
+# Eigene AC-Nummerierung (AC-S2-n), damit sie weder mit AC-13/14/15 (#1677 B)
+# noch mit AC-1..AC-8 (Scheibe 3) oder AC-S1-n (Scheibe 1) kollidiert.
+#
+# Compare-only: die drei Trip-Aufrufstellen des geteilten Ausblick-Renderers
+# (email/html.py:1357, email/plain.py:338, trip_report_scheduler.py:1844)
+# uebergeben KEIN ``metrics``-Argument und laufen im festen Legacy-Spaltenpfad
+# -- der Trip-Ausblick hat keine waehlbaren Spalten und damit keine
+# Metrik-x-Kanal-Flaeche (Spec "Korrektur der Scheiben-Praemisse"). Sein Schutz
+# ist der Byte-Golden tests/tdd/test_trip_outlook_parity.py.
+#
+# Pruefort = Wirkort: alle Ist-Werte stammen aus ``render_compare_email()`` --
+# EIN Aufruf liefert HTML UND Klartext, damit ist der Klartext-blinde Fleck des
+# Pflicht-Mail-Validators mit abgedeckt (#1366). Nie an ``outlook_columns()``
+# isoliert gemessen; der Massstab kommt aus dem Katalog (tests/helpers/
+# outlook_columns.py), nicht aus derselben Funktion.
+#
+# ABHAENGIGKEIT, die nicht weggeraeumt werden darf (AC-S2-7): die einzelne
+# Streichung einer Katalog-Zeile faengt diese Achse NICHT -- ihre Soll-Menge
+# schrumpft dann einfach mit. Sie faengt der unabhaengige, GETIPPTE
+# Groessenanker tests/tdd/test_compare_metric_catalog_endpoint.py::
+# TestUnknownMetricIdFailsVisibly::test_real_catalog_resolves_completely
+# (``len(get_compare_metric_catalog()) == 25``, Zeile 519). Wird jene Zeile bei
+# einer kuenftigen Aufraeumaktion als "hartcodiert, unschoen" entfernt, faellt
+# diese Deckung ersatzlos weg (Lehre aus Scheibe 1, Finding F001).
+# ---------------------------------------------------------------------------
+
+# Zwei Striche, die im Terminal gleich aussehen und NICHT gleichgesetzt werden
+# duerfen (Spec "Die Fehlzeichen-Falle"):
+_S2_FEHLZEICHEN = "–"      # – format_outlook_value(None, ...): Wert FEHLT
+_S2_KEINE_ANGABE = "—"     # — Gewitterstufe "keine" / Niederschlagsart unbekannt
+
+# Eindeutiger Marker der Ausblick-Tabelle (nur auf dieser einen Tabelle
+# gesetzt, identisch zu test_compare_outlook_metric_selection.py:27).
+_S2_TABELLEN_MARKER = "border-top:2px solid #1d1c1a"
+_S2_KLARTEXT_UEBERSCHRIFT = "3-Tages-Ausblick"
+
+_S2_SOLL = compare_outlook_soll_spalten()
+_S2_SOLL_PAARE = compare_outlook_soll_paare()
+_S2_SOLL_IDS = [f"{s['metric_id']}:{s['aggregation']}" for s in _S2_SOLL]
+
+_S2_STARTTAG = date(2026, 7, 20)
+_S2_TAGE = ((6.0, 18.0), (9.0, 27.0), (11.0, 23.0))
+
+# Die fuenf Tagesfelder, deren Ausblick-Zelle vor dem Fix dauerhaft das
+# Fehlzeichen trug (gemessen 2026-08-11 an der echten Vergleichs-Mail, HTML wie
+# Klartext, an jedem der drei Tage) -- der ROTE Anteil von AC-S2-4. Die Liste
+# bleibt nach dem Fix stehen: sie begrenzt die Charakterisierung in AC-S2-6 auf
+# die 20 bereits gefuellten Zellen und bleibt der Beleg des roten Anteils.
+_S2_DEFEKTE_FELDER = frozenset({
+    "snow_depth_cm", "snow_new_sum_cm", "wind_direction_avg_deg",
+    "wind_chill_min_c", "wind_chill_max_c",
+})
+
+
+def _s2_punkt(tag: date, stunde: int, temp: float, thunder) -> ForecastDataPoint:
+    """Ein REICH besetzter Stundenpunkt: jedes Quellfeld, aus dem eine der 25
+    Ausblick-Spalten ihren Tageswert zieht, traegt einen Wert. Nur so heisst
+    eine Strichzelle "der Aggregationspfad fuellt das Feld nicht" statt
+    "der Test hat nichts hineingelegt" (AC-S2-4)."""
+    return ForecastDataPoint(
+        ts=datetime(tag.year, tag.month, tag.day, stunde, 0, tzinfo=timezone.utc),
+        t2m_c=temp, wind10m_kmh=15.0, wind_direction_deg=210, gust_kmh=25.0,
+        precip_1h_mm=1.1, precip_rate_mmph=1.1, cloud_total_pct=50,
+        thunder_level=thunder, cape_jkg=400.0, pop_pct=55,
+        pressure_msl_hpa=1013.0, humidity_pct=70, dewpoint_c=5.0, uv_index=4.0,
+        snow_depth_cm=30.0, snow_new_24h_cm=4.0, snowfall_limit_m=2200,
+        precip_type=PrecipType.RAIN, freezing_level_m=3000,
+        wind_chill_c=temp - 2.0, visibility_m=20000,
+        cloud_low_pct=30, cloud_mid_pct=40, cloud_high_pct=20,
+        wmo_code=61, is_day=1, dni_wm2=300.0, confidence_pct=80, hail_flag=False,
+    )
+
+
+def _s2_punkte(thunder) -> list[ForecastDataPoint]:
+    """Drei Kalendertage a vier Stundenpunkte (UTC 02/08/14/20 = Ortszeit
+    04/10/16/22 in Europe/Vienna -- derselbe Kalendertag, kein Tagesuebergang)."""
+    punkte: list[ForecastDataPoint] = []
+    for versatz, (tief, hoch) in enumerate(_S2_TAGE):
+        tag = _S2_STARTTAG + timedelta(days=versatz)
+        for stunde, temp in zip((2, 8, 14, 20), (tief, (tief + hoch) / 2, hoch, (tief + hoch) / 2)):
+            punkte.append(_s2_punkt(tag, stunde, temp, thunder))
+    return punkte
+
+
+@lru_cache(maxsize=None)
+def _s2_mail(thunder_name: str = "MED") -> tuple[str, str]:
+    """Die ECHTE Vergleichs-Mail mit ALLEN waehlbaren Ausblick-Groessen.
+    Gecacht, weil jede parametrisierte Achse dieselbe Mail liest."""
+    from app.user import ComparisonResult, LocationResult, SavedLocation
+
+    punkte = _s2_punkte(ThunderLevel[thunder_name])
+    heute = [p for p in punkte if p.ts.date() == _S2_STARTTAG]
+    ort = LocationResult(
+        location=SavedLocation(
+            id="innsbruck", name="Innsbruck", lat=47.27, lon=11.40,
+            elevation_m=574, timezone="Europe/Vienna",
+        ),
+        score=50, hourly_data=heute, outlook_hourly_data=punkte,
+    )
+    ergebnis = ComparisonResult(
+        locations=[ort], time_window=(9, 16), target_date=_S2_STARTTAG,
+        created_at=datetime(2026, 7, 20, 4, 1),
+    )
+    return render_compare_email(
+        ergebnis, outlook_enabled=True, outlook_metrics=list(_S2_SOLL_PAARE),
+    )
+
+
+def _s2_html_ausblick(html: str) -> tuple[list[str], list[list[str]]]:
+    """Kopfzeile + Tageszeilen der Ausblick-Tabelle der echten HTML-Mail."""
+    soup = BeautifulSoup(html, "html.parser")
+    tabellen = [t for t in soup.find_all("table")
+                if _S2_TABELLEN_MARKER in str(t.get("style", ""))]
+    assert len(tabellen) == 1, (
+        f"Erwartet genau eine Ausblick-Tabelle (Marker {_S2_TABELLEN_MARKER!r}), "
+        f"gefunden {len(tabellen)}"
+    )
+    kopf = [th.get_text(strip=True) for th in tabellen[0].find_all("th")]
+    zeilen = [[td.get_text(strip=True) for td in tr.find_all("td")]
+              for tr in tabellen[0].find("tbody").find_all("tr")]
+    return kopf, zeilen
+
+
+def _s2_klartext_ausblick(text: str) -> list[dict[str, str]]:
+    """Je Tageszeile des Klartext-Ausblicks eine Zuordnung Ueberschrift -> Wert.
+
+    Der Renderer schreibt ``f"{Wochentag:<3} " + "  ".join(f"{Label} {Wert}")``
+    (email/outlook.py:344-350) -- die Paare trennen ZWEI Leerzeichen, Label und
+    Wert eines. Beide enthalten selbst Leerzeichen ("Temperatur Maximum",
+    "15 km/h"), deshalb wird je Token die LAENGSTE passende Soll-Ueberschrift
+    abgespalten: "Wind" ist echter Wortanfang von "Windrichtung".
+    """
+    ueberschriften = sorted((s["ueberschrift"] for s in _S2_SOLL), key=len, reverse=True)
+    zeilen = text.split("\n")
+    start = next(
+        (i for i, z in enumerate(zeilen) if z.strip() == _S2_KLARTEXT_UEBERSCHRIFT),
+        None,
+    )
+    assert start is not None, (
+        f"Im Klartext derselben Mail ist kein Ausblick-Block auffindbar "
+        f"(gesucht: {_S2_KLARTEXT_UEBERSCHRIFT!r}).\n{text}"
+    )
+    ergebnis: list[dict[str, str]] = []
+    for zeile in zeilen[start + 1:]:
+        if not zeile.strip():
+            break
+        zellen: dict[str, str] = {}
+        for token in zeile.split("  ")[1:]:
+            token = token.strip()
+            treffer = next((u for u in ueberschriften if token.startswith(u)), None)
+            assert treffer is not None, (
+                f"Klartext-Ausblick fuehrt den Abschnitt {token!r}, der zu "
+                f"keiner Soll-Ueberschrift passt: {zeile!r}"
+            )
+            zellen[treffer] = token[len(treffer):].strip()
+        ergebnis.append(zellen)
+    return ergebnis
+
+
+def _s2_zelle_ist_fehlwert(zellentext: str) -> bool:
+    """NUR das Fehlzeichen U+2013 zaehlt als "Wert fehlt".
+
+    Der Gedankenstrich U+2014 ist eine INHALTLICHE Aussage (Gewitterstufe
+    "keine", unbekannte Niederschlagsart) und ausdruecklich KEIN Verstoss --
+    s. test_ac_s2_4_keine_gewitterstufe_ist_kein_fehlwert. Wer beide gleichsetzt,
+    macht aus einem gewitterfreien Tag faelschlich einen Fehler; wer den
+    Unterschied ganz aufgibt, uebersieht den echten Fehlwert.
+    """
+    return zellentext.strip() == _S2_FEHLZEICHEN
+
+
+# --- AC-S2-1: jede waehlbare Groesse ergibt genau eine Spalte -------------
+
+
+@pytest.mark.parametrize("soll", _S2_SOLL, ids=_S2_SOLL_IDS)
+def test_ac_s2_1_jede_waehlbare_groesse_ergibt_genau_eine_spalte(soll):
+    """AC-S2-1: waehlt der Nutzer alle im Vergleich waehlbaren Ausblick-Groessen,
+    traegt der Ausblick fuer JEDE genau eine Spalte -- in der HTML-Tabelle UND
+    im Klartext derselben Mail. Die erwartete Ueberschrift kommt aus dem
+    Katalog (label + aggregation_label), nicht aus ``outlook_columns()``."""
+    html, text = _s2_mail()
+    kopf, _ = _s2_html_ausblick(html)
+    erwartet = soll["ueberschrift"]
+
+    assert kopf.count(erwartet) == 1, (
+        f"AC-S2-1: die HTML-Kopfzeile fuehrt die Ueberschrift {erwartet!r} "
+        f"({soll['key']}) {kopf.count(erwartet)}x statt genau einmal: {kopf}"
+    )
+    for nummer, zellen in enumerate(_s2_klartext_ausblick(text), start=1):
+        assert erwartet in zellen, (
+            f"AC-S2-1: Tageszeile {nummer} des KLARTEXT-Ausblicks fuehrt keine "
+            f"Spalte {erwartet!r} ({soll['key']}), obwohl das HTML sie zeigt -- "
+            f"vorhanden: {sorted(zellen)}"
+        )
+
+
+def test_ac_s2_1_html_und_klartext_zeigen_dieselbe_spaltenmenge():
+    """AC-S2-1 (Gegenrichtung): keine Groesse darf im Klartext fehlen, die im
+    HTML steht -- und keine darf dort ZUSAETZLICH stehen. Ohne diese Richtung
+    bliebe eine ueberzaehlige Spalte unbemerkt."""
+    html, text = _s2_mail()
+    kopf, zeilen = _s2_html_ausblick(html)
+    erwartet = [s["ueberschrift"] for s in _S2_SOLL]
+
+    assert kopf == ["Tag"] + erwartet, (
+        f"AC-S2-1: die HTML-Kopfzeile weicht von der Katalog-Soll-Menge ab.\n"
+        f"Ist:      {kopf}\nErwartet: {['Tag'] + erwartet}"
+    )
+    assert len(zeilen) == len(_S2_TAGE), (
+        f"AC-S2-1: erwartet {len(_S2_TAGE)} Ausblick-Tageszeilen, erhalten "
+        f"{len(zeilen)}"
+    )
+    for zeile in zeilen:
+        assert len(zeile) == len(erwartet) + 1, (
+            f"AC-S2-1: Tageszeile traegt {len(zeile)} Zellen statt "
+            f"{len(erwartet) + 1} (Tag + {len(erwartet)} Groessen): {zeile}"
+        )
+    klartext = _s2_klartext_ausblick(text)
+    assert len(klartext) == len(_S2_TAGE), (
+        f"AC-S2-1: der Klartext-Ausblick hat {len(klartext)} Tageszeilen statt "
+        f"{len(_S2_TAGE)}"
+    )
+    for nummer, zellen in enumerate(klartext, start=1):
+        assert sorted(zellen) == sorted(erwartet), (
+            f"AC-S2-1: Tageszeile {nummer} des Klartexts zeigt andere Spalten "
+            f"als der Katalog verlangt.\nNur im Klartext: "
+            f"{sorted(set(zellen) - set(erwartet))}\nFehlt im Klartext: "
+            f"{sorted(set(erwartet) - set(zellen))}"
+        )
+
+
+# --- AC-S2-2: Soll-Menge gerechnet, nie getippt (Vakuum-Schutz) -----------
+
+
+def test_ac_s2_2_soll_menge_wird_gerechnet_und_ist_plausibel():
+    """AC-S2-2: die geprueften Groessen stammen ausschliesslich aus
+    ``get_compare_metric_catalog()``. Der Plausibilitaets-Waechter schlaegt an,
+    wenn die Menge leer ist, unter die Mindestgroesse faellt, die Rechnung
+    "roh minus nicht-waehlbar = ausgeliefert" nicht aufgeht oder ein Paar kein
+    ``SegmentWeatherSummary``-Feld aufloest. Die parametrisierte Konstante ist
+    der Mutations-Ort, die Neuberechnung hier der unabhaengige Pruefort."""
+    frisch = assert_soll_menge_ist_plausibel()
+
+    assert [s["key"] for s in frisch] == [s["key"] for s in _S2_SOLL], (
+        f"Die parametrisierte Soll-Menge {[s['key'] for s in _S2_SOLL]} weicht "
+        f"vom Katalog {[s['key'] for s in frisch]} ab -- eine im Test "
+        "aufgezaehlte oder gekuerzte Liste ist genau das, was AC-S2-2 verbietet"
+    )
+    # Zweite Aufloesungsbedingung: ``outlook_columns()`` verlangt NEBEN dem
+    # Katalog-Treffer ein ``summary_field_for()``-Ergebnis
+    # (compare_outlook_metric_ids.py:98-100). Beide Bedingungen sind heute
+    # deckungsgleich, aber nicht per Konstruktion -- genau deshalb geprueft.
+    from output.renderers.compare_outlook_metric_ids import resolve_outlook_metrics
+
+    aufgeloest = resolve_outlook_metrics(list(_S2_SOLL_PAARE))
+    assert aufgeloest is not None and len(aufgeloest) == len(_S2_SOLL), (
+        f"AC-S2-2: ``resolve_outlook_metrics()`` verwirft "
+        f"{len(_S2_SOLL) - len(aufgeloest or [])} der {len(_S2_SOLL)} "
+        "Katalog-Paare -- Katalog-Zugehoerigkeit und Feld-Aufloesung sind "
+        "auseinandergelaufen, die verworfenen Groessen haetten gar keine Spalte"
+    )
+    kinds = Counter(s["kind"] for s in _S2_SOLL)
+    assert kinds["ordinal"] >= 1 and kinds["enum"] >= 1 and kinds["range"] >= 1, (
+        f"AC-S2-2: die Soll-Menge belegt nicht mehr alle drei Formzweige von "
+        f"``format_outlook_value()`` (gemessen 2026-08-11: 1 ordinal, 1 enum, "
+        f"23 range) -- gezaehlt: {dict(kinds)}"
+    )
+
+
+# --- AC-S2-3: keine zwei Spalten mit derselben Beschriftung ---------------
+
+
+def test_ac_s2_3_keine_zwei_spalten_mit_gleicher_beschriftung():
+    """AC-S2-3: bei voller Auswahl traegt keine zwei Spalten dieselbe
+    Beschriftung. Die Unterscheidung entsteht dadurch, dass die Auswertung
+    angehaengt wird, sobald derselbe Name mehrfach vorkommt -- die
+    Vakuum-Gegenprobe stellt sicher, dass dieser Zweig ueberhaupt greift
+    (sonst prueft der Test eine Regel, die nie zur Anwendung kommt)."""
+    mehrfach = [n for n, anzahl in Counter(s["label"] for s in _S2_SOLL).items()
+                if anzahl > 1]
+    assert mehrfach, (
+        "Vakuum: keine Groesse kommt im Ausblick-Katalog mehrfach vor -- die "
+        "Auswertungs-Unterscheidung waere nie aktiv und dieser Test bewachte "
+        "nichts (gemessen 2026-08-11: 'Temperatur' und 'Gefuehlte Temperatur')"
+    )
+
+    html, _ = _s2_mail()
+    kopf, _ = _s2_html_ausblick(html)
+    doppelt = [n for n, anzahl in Counter(kopf).items() if anzahl > 1]
+    assert not doppelt, (
+        f"AC-S2-3: die Ausblick-Tabelle traegt mehrfach dieselbe Spalten-"
+        f"beschriftung {doppelt} -- zwei ununterscheidbare Spalten: {kopf}"
+    )
+
+
+# --- AC-S2-4: jede Zelle traegt einen Wert (DER rote Anteil) --------------
+
+
+@pytest.mark.parametrize("soll", _S2_SOLL, ids=_S2_SOLL_IDS)
+def test_ac_s2_4_jede_zelle_traegt_einen_wert(soll):
+    """AC-S2-4: enthalten die Stundendaten fuer eine gewaehlte Groesse Werte,
+    zeigt die zugehoerige Zelle einen Wert und NICHT das Fehlzeichen -- in HTML
+    und Klartext, an jedem der drei Ausblickstage.
+
+    HEUTE ROT fuer fuenf Groessen (Schneehoehe, Neuschnee, Windrichtung,
+    Gefuehlte Temperatur Minimum/Maximum): ``summarize_points()``
+    (weather_metrics.py:1071) verdrahtet die zugehoerigen ``_compute_*``-Regeln
+    nicht, obwohl sie existieren und im Trip-Pfad angeschlossen sind -- s.
+    AC-S2-5."""
+    html, text = _s2_mail()
+    kopf, zeilen = _s2_html_ausblick(html)
+    spalte = kopf.index(soll["ueberschrift"])
+
+    for nummer, zeile in enumerate(zeilen, start=1):
+        assert not _s2_zelle_ist_fehlwert(zeile[spalte]), (
+            f"AC-S2-4: die HTML-Zelle der Spalte {soll['ueberschrift']!r} "
+            f"({soll['key']} -> SegmentWeatherSummary.{soll['summary_field']}) "
+            f"zeigt am Ausblickstag {nummer} das Fehlzeichen "
+            f"{_S2_FEHLZEICHEN!r}, obwohl die Stundendaten den Wert hergeben "
+            "-- der Tages-Aggregationspfad des Vergleichs fuellt das Feld nicht"
+        )
+    for nummer, zellen in enumerate(_s2_klartext_ausblick(text), start=1):
+        assert not _s2_zelle_ist_fehlwert(zellen[soll["ueberschrift"]]), (
+            f"AC-S2-4: die KLARTEXT-Zelle der Spalte {soll['ueberschrift']!r} "
+            f"({soll['key']} -> SegmentWeatherSummary.{soll['summary_field']}) "
+            f"zeigt am Ausblickstag {nummer} das Fehlzeichen "
+            f"{_S2_FEHLZEICHEN!r}"
+        )
+
+
+def test_ac_s2_4_keine_gewitterstufe_ist_kein_fehlwert():
+    """AC-S2-4 (Pflicht-Gegenprobe): ein Tag OHNE Gewitter zeigt in der
+    Gewitter-Zelle den Gedankenstrich U+2014 -- eine inhaltliche Aussage
+    ("keine Stufe"), KEIN fehlender Wert. Verkuerzt man die Unterscheidung in
+    ``_s2_zelle_ist_fehlwert()`` auf "irgendein Strich", muss dieser Test rot
+    werden; bliebe er gruen, prueft AC-S2-4 die Zellen nicht wirklich."""
+    gewitter = next((s for s in _S2_SOLL if s["kind"] == "ordinal"), None)
+    assert gewitter is not None, (
+        "Vakuum: der Compare-Katalog fuehrt keine ordinale Groesse mehr -- die "
+        "Gegenprobe haette keinen Gegenstand"
+    )
+
+    html, _ = _s2_mail("NONE")
+    kopf, zeilen = _s2_html_ausblick(html)
+    zelle = zeilen[0][kopf.index(gewitter["ueberschrift"])]
+
+    assert zelle == _S2_KEINE_ANGABE, (
+        f"Vorbedingung: ohne Gewitter erwartet die Zelle {_S2_KEINE_ANGABE!r} "
+        f"(U+2014, inhaltlich 'keine Stufe'), gemessen: {zelle!r}"
+    )
+    assert not _s2_zelle_ist_fehlwert(zelle), (
+        f"AC-S2-4 (Gegenprobe): {zelle!r} (U+2014) wird als fehlender Wert "
+        f"gewertet -- U+2014 und das Fehlzeichen {_S2_FEHLZEICHEN!r} (U+2013) "
+        "sind zwei verschiedene Aussagen und duerfen nicht gleichgesetzt werden"
+    )
+
+
+# --- AC-S2-5: die beiden Tages-Aggregationspfade decken sich --------------
+
+# Namentlich gefuehrte, bewusste Abweichungen der beiden Pfade (gemessen
+# 2026-08-11 auf demselben Stundensatz). Eine NICHT gelistete Abweichung ist
+# ein Befund -- genau daran ist die Fuenferluecke aus AC-S2-4 entstanden.
+_S2_NUR_TRIP_ERLAUBT = {
+    "confidence_pct_min": (
+        "Vorhersage-Verlaesslichkeit ist keine waehlbare Vergleichs-Groesse "
+        "(confidence.selectable=False, ADR-0005/#710) und hat im Ausblick "
+        "keine Spalte -- eine Verdrahtung in summarize_points() waere "
+        "Scope-Zuwachs ohne Nutzerwirkung"
+    ),
+}
+_S2_NUR_COMPARE_ERLAUBT = {
+    "hail_flag": (
+        "``compute_extended_metrics()`` baut ein NEUES Summary und kopiert "
+        "hail_flag nicht aus dem Basis-Aggregat mit (weather_metrics.py:774ff, "
+        "gesetzt wird es in compute_basis_metrics:459) -- eigener Befund an "
+        "derselben Naht, nicht Gegenstand dieser Scheibe"
+    ),
+}
+
+
+def _s2_aggregat_felder(summary) -> set[str]:
+    return {
+        f.name for f in dataclasses.fields(summary)
+        if f.name != "aggregation_config" and getattr(summary, f.name) is not None
+    }
+
+
+def test_ac_s2_5_beide_tagesaggregationen_fuellen_dieselben_felder():
+    """AC-S2-5: auf DEMSELBEN Stundensatz fuellt der Vergleichspfad
+    (``summarize_points()``) jedes Tagesfeld, das der Trip-Pfad
+    (``compute_extended_metrics()``) fuellt -- und umgekehrt. Abweichungen sind
+    nur zulaessig, wenn sie oben namentlich gefuehrt sind.
+
+    Beide Seiten laufen mit DERSELBEN neutralen Provider-Kennung
+    (``model="aggregate"``, wie ``summarize_points()`` sie selbst setzt), damit
+    das rein metadaten-abgeleitete ``cape_model_id`` keine Schein-Abweichung
+    erzeugt.
+
+    HEUTE ROT: fuenf Felder fehlen dem Vergleichspfad -- dieselben fuenf, deren
+    Ausblick-Zellen in AC-S2-4 das Fehlzeichen tragen. Damit faellt die naechste
+    Drift der beiden handgepflegten Listen auf, statt erneut als Strichspalte
+    beim Nutzer zu landen (#1324/#1391/#1392 sind drei Flicken an derselben
+    Naht)."""
+    punkte = [p for p in _s2_punkte(ThunderLevel.MED) if p.ts.date() == _S2_STARTTAG]
+    dienst = WeatherMetricsService()
+    reihe = NormalizedTimeseries(
+        meta=ForecastMeta(provider=Provider.OPENMETEO, model="aggregate", grid_res_km=0.0),
+        data=list(punkte),
+    )
+    trip = _s2_aggregat_felder(
+        dienst.compute_extended_metrics(reihe, dienst.compute_basis_metrics(reihe))
+    )
+    vergleich = _s2_aggregat_felder(summarize_points(punkte))
+
+    assert trip and vergleich, (
+        f"Vakuum: ein Pfad liefert gar keine Felder (Trip {len(trip)}, "
+        f"Vergleich {len(vergleich)}) -- der Mengenvergleich waere sinnlos"
+    )
+    fehlt_im_vergleich = sorted(trip - vergleich - set(_S2_NUR_TRIP_ERLAUBT))
+    assert not fehlt_im_vergleich, (
+        f"AC-S2-5: der Vergleichspfad ``summarize_points()`` fuellt "
+        f"{fehlt_im_vergleich} nicht, der Trip-Pfad ``compute_extended_metrics()`` "
+        "schon. Jedes dieser Felder ist im Ausblick des Ortsvergleichs eine "
+        "dauerhaft leere Spalte. Entweder die fehlende ``_compute_*``-Regel "
+        "verdrahten oder die Abweichung in _S2_NUR_TRIP_ERLAUBT begruenden."
+    )
+    fehlt_im_trip = sorted(vergleich - trip - set(_S2_NUR_COMPARE_ERLAUBT))
+    assert not fehlt_im_trip, (
+        f"AC-S2-5 (Gegenrichtung): der Trip-Pfad fuellt {fehlt_im_trip} nicht, "
+        "der Vergleichspfad schon -- dieselbe Drift, nur spiegelbildlich "
+        "(so entstand #1391). Ohne diese Richtung bliebe eine gestrichene Zeile "
+        "in ``compute_extended_metrics()`` unbemerkt."
+    )
+    unnoetig = sorted((set(_S2_NUR_TRIP_ERLAUBT) & vergleich)
+                      | (set(_S2_NUR_COMPARE_ERLAUBT) & trip))
+    assert not unnoetig, (
+        f"AC-S2-5: die Ausnahmen {unnoetig} sind gegenstandslos geworden -- "
+        "beide Pfade fuellen die Felder inzwischen. Eintraege streichen, sonst "
+        "deckt die Ausnahmeliste kuenftige Drift zu."
+    )
+
+
+# --- AC-S2-6: der Fix schiesst nicht ueber sein Ziel hinaus ---------------
+
+# Die 20 Zellen, die schon VOR dem Fix einen Wert trugen -- gemessen
+# 2026-08-11 am ersten Ausblickstag der Mail aus ``_s2_mail()``. Schluessel ist
+# der ``SegmentWeatherSummary``-Feldname (stabiler als die Beschriftung, die
+# AC-S2-1 ohnehin bewacht).
+_S2_UNVERAENDERTE_ZELLEN = {
+    "sunny_hours": "4.0 h", "wind_max_kmh": "15 km/h", "cloud_avg_pct": "50 %",
+    "visibility_min_m": "20000 m", "precip_sum_mm": "4.4 mm", "uv_index_max": "4",
+    "temp_max_c": "18 °C", "thunder_level_max": "mittel", "temp_min_c": "6 °C",
+    "gust_max_kmh": "25 km/h", "freezing_level_m": "3000 m", "pop_max_pct": "55 %",
+    "humidity_avg_pct": "70 %", "dewpoint_avg_c": "5 °C",
+    "snowfall_limit_m": "2200 m", "precip_type_dominant": "Regen",
+    "cloud_low_avg_pct": "30 %", "cloud_mid_avg_pct": "40 %",
+    "cloud_high_avg_pct": "20 %", "pressure_avg_hpa": "1013 hPa",
+}
+
+
+def test_ac_s2_6_bereits_gefuellte_zellen_behalten_ihre_werte():
+    """AC-S2-6: der Fix an der Vergleichs-Aggregation darf ueber sein Ziel nicht
+    hinausschiessen -- die 20 heute bereits gefuellten Ausblick-Zellen behalten
+    Wert und Schreibweise. (Die Trip-Mail schuetzt zusaetzlich der Byte-Golden
+    tests/tdd/test_trip_outlook_parity.py; ``summarize_points()`` ist nicht der
+    Trip-Aggregator, ein Bruch dort waere ein Signal, kein Nachziehgrund.)"""
+    alle_felder = {s["summary_field"] for s in _S2_SOLL}
+    assert set(_S2_UNVERAENDERTE_ZELLEN) | set(_S2_DEFEKTE_FELDER) == alle_felder, (
+        "Die Charakterisierung deckt den Katalog nicht mehr ab.\nNicht "
+        f"charakterisiert: {sorted(alle_felder - set(_S2_UNVERAENDERTE_ZELLEN) - set(_S2_DEFEKTE_FELDER))}\n"
+        f"Nicht mehr im Katalog: {sorted(set(_S2_UNVERAENDERTE_ZELLEN) | set(_S2_DEFEKTE_FELDER) - alle_felder)}"
+    )
+
+    html, _ = _s2_mail()
+    kopf, zeilen = _s2_html_ausblick(html)
+    for soll in _S2_SOLL:
+        erwartet = _S2_UNVERAENDERTE_ZELLEN.get(soll["summary_field"])
+        if erwartet is None:
+            continue
+        ist = zeilen[0][kopf.index(soll["ueberschrift"])]
+        assert ist == erwartet, (
+            f"AC-S2-6: die Zelle {soll['ueberschrift']!r} ({soll['key']}) des "
+            f"ersten Ausblickstags zeigt {ist!r} statt {erwartet!r} -- der Fix "
+            "an der Vergleichs-Aggregation hat einen bereits korrekten Wert "
+            "veraendert"
+        )
+
+
+# --- AC-S2-7: Streichungen aus dem Katalog fallen auf ---------------------
+
+
+def test_ac_s2_7_mindestgroesse_faengt_groessere_streichungen():
+    """AC-S2-7 (erste Haelfte): der Vakuum-Schutz aus AC-S2-2 schlaegt an, wenn
+    der Katalog deutlich schrumpft. Geprueft ueber DIESELBE Funktion, die der
+    echte Waechter aufruft (injizierte Katalogkopie statt Monkeypatch) -- eine
+    im Test nachgebaute Pruflogik bewiese nichts."""
+    gekuerzt = COMPARE_METRIC_CATALOG[:len(COMPARE_METRIC_CATALOG) // 2]
+    with pytest.raises(AssertionError) as fehler:
+        assert_soll_menge_ist_plausibel(entries=gekuerzt)
+    assert "Vakuum-Schutz" in str(fehler.value), (
+        f"AC-S2-7: der Plausibilitaets-Waechter scheitert an einem halbierten "
+        f"Katalog aus dem falschen Grund: {fehler.value}"
+    )
+
+
+def test_ac_s2_7_groessenanker_faengt_die_einzelne_streichung():
+    """AC-S2-7 (zweite Haelfte): eine EINZELNE gestrichene Katalog-Zeile faengt
+    diese Achse nicht -- ihre Soll-Menge schruempfte lautlos mit. Sie faengt der
+    unabhaengige, getippte Groessenanker in
+    ``test_compare_metric_catalog_endpoint.py`` (``== 25``, Zeile 519).
+
+    Dieser Test macht die Abhaengigkeit pruefbar statt nur behauptet: wird der
+    Anker bei einer kuenftigen Aufraeumaktion als "hartcodiert, unschoen"
+    entfernt, faellt HIER auf, dass die Deckung ersatzlos weg ist (Lehre aus
+    Scheibe 1, Finding F001 -- dort verwies der Kommentar auf einen Anker, den
+    niemand gegen Loeschung sicherte)."""
+    try:
+        from tests.tdd import test_compare_metric_catalog_endpoint as anker
+    except ImportError as exc:  # pragma: no cover - Datei geloescht
+        raise AssertionError(
+            "AC-S2-7: das Ankermodul tests/tdd/"
+            "test_compare_metric_catalog_endpoint.py ist nicht mehr importierbar "
+            f"-- die einzelne Katalog-Streichung ist damit unbewacht: {exc}"
+        ) from exc
+
+    klasse = getattr(anker, "TestUnknownMetricIdFailsVisibly", None)
+    pruefung = getattr(klasse, "test_real_catalog_resolves_completely", None)
+    assert pruefung is not None, (
+        "AC-S2-7: der getippte Groessenanker "
+        "TestUnknownMetricIdFailsVisibly::test_real_catalog_resolves_completely "
+        "existiert nicht mehr. Er ist die EINZIGE Stelle, die das Streichen "
+        "einer einzelnen Compare-Katalog-Zeile bemerkt -- diese Achse rechnet "
+        "ihr Soll aus demselben Katalog und schrumpft stillschweigend mit. "
+        "Ersatz schaffen, bevor der Anker verschwindet."
+    )
+    pruefung(klasse())


### PR DESCRIPTION
Epic #1703, Scheibe 2. Deckt Flaeche 2 aus `docs/reference/metric_output_matrix.md` §4.1.

## Was der Nutzer heute sieht

Im 3-Tages-Ausblick des Ortsvergleichs kann man aus 25 Wettergroessen waehlen. **Fuenf davon liefern dauerhaft eine leere Spalte** — Spalte da, Kopf richtig, Zelle immer Strich, unabhaengig vom Wetter:

Schneehoehe · Neuschnee · Windrichtung · Gefuehlte Temperatur Minimum · Gefuehlte Temperatur Maximum

## Ursache

`summarize_points()` (`weather_metrics.py:1071`) ist eine handgepflegte Aufzaehlung von Tages-Aggregaten. Die fuenf Rechenregeln existieren und sind im Trip-Pfad `compute_extended_metrics()` (`:752-760`) laengst angeschlossen — im Vergleichspfad nie. Gegenrichtung zu #1391; #1324 und #1392 sind weitere Flicken an derselben Naht.

Fix: **11 Zeilen** Produktivcode.

## Korrektur der Scheiben-Praemisse

Das Issue sagt "Trip + Compare". Gemessen uebergeben alle drei Trip-Aufrufstellen kein `metrics`-Argument und laufen im festen Legacy-Spaltenpfad — der Trip-Ausblick hat keine waehlbaren Spalten und damit keine Metrik-Achse. Er ist zudem durch den byte-genauen Golden-Vergleich in `test_trip_outlook_parity.py` strenger bewacht, als eine Matrix-Achse es waere. Diese Scheibe ist deshalb **Compare-only** (PO-freigegeben).

## Der Waechter

Neue Achse **AC-S2-1..8** in `tests/tdd/test_channel_metric_matrix.py` — Erweiterung des bestehenden, budgetierten Gates #1677 B, kein neues Pflicht-Gate. Soll-Menge aus `get_compare_metric_catalog()` **gerechnet** (25 Paare), nie getippt; Vakuum-Schutz in `tests/helpers/outlook_columns.py`.

Ist-Werte kommen aus der **echten** Vergleichs-Mail (`render_compare_email()`, HTML und Klartext aus einem Aufruf) — nicht aus `outlook_columns()` isoliert.

Zwei Feinheiten, ohne die der Waechter nichts wert waere:
- `–` (U+2013, Wert fehlt) und `—` (U+2014, Gewitterstufe "keine") werden **unterschieden**. Gleichgesetzt schluege der Test bei jedem gewitterfreien Tag falsch an.
- AC-S2-5 haelt **beide** Tages-Aggregationspfade gegeneinander, in beiden Richtungen — damit faellt die naechste Drift auf, statt erneut als Strichspalte beim Nutzer zu landen.

## Adversary

**VERIFIED**, 2 Runden, 7 Kriterien, alle drei Pflicht-Mutationen gefangen. Die vierte, frei gewaehlte Mutation fand ein echtes Loch (**F001 HIGH**): Vertauschte man `wind_chill_min_c`/`wind_chill_max_c` im Fix, blieben alle 58 Tests gruen — AC-S2-4 prueft nur "nicht leer", AC-S2-5 nur die Feld-Menge, und repo-weit sicherte kein Test die Zahlenwerte.

**Geschlossen** mit AC-S2-8: Erwartungswerte unabhaengig aus den Stundenwerten gerechnet, geprueft auf zwei Ebenen (Aggregat und Zelle der echten Mail). Gegenprobe selbst nachgemessen — unter der Vertauschung werden beide Tests rot, nach Ruecksicherung 60 gruen.

## Nachweise

- Zielachse 60 gruen, auch unter `--disable-socket` (netzfrei, CI-tauglich)
- 250 gruen ueber Zielachse, **beide** Ausblick-Goldens und die Vergleichs-Suiten — **kein Bestandstest angepasst**, kein Golden nachgezogen
- Spec: `docs/specs/modules/fix_1703_s2_ausblick_matrix.md` (PO-freigegeben, AC-1..AC-8)

## Offen nach dem Merge

AC-8 der Spec ist der **Browser-Nachweis auf Staging**: die Vergleichs-Mail-Vorschau (`EmailIframe`) zeigt das hier geaenderte HTML. Der Aenderungssatz beruehrt kein `frontend/**`, die Wirkung ist aber an der Oberflaeche sichtbar — deshalb Deploy-Scope `--scope backend`, nicht `docs-only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)