### PR TITLE
fix(#1760): CIN-Daempfung vergleicht den Betrag statt des Vorzeichens

### DIFF
--- a/docs/specs/modules/fix_1760_cin_vorzeichen.md
+++ b/docs/specs/modules/fix_1760_cin_vorzeichen.md
@@ -1,0 +1,118 @@
+# Fix #1760: CIN-Dämpfung feuert nie — zwei Vorzeichen-Konventionen ohne Normalisierung
+
+- **Issue:** #1760 · **Bezug:** #1679 (Ursprung), #1419 (Epic), ADR-0048
+- **created:** 2026-08-11
+- **Typ:** Bug · **Status:** Spec, wartet auf Freigabe
+
+## Problem
+
+Die mit #1679 eingeführte Dämpfung der CAPE-Zutat durch die Konvektionshemmung (CIN) **feuert im
+Produktivpfad nie** und wirkt invertiert: Je stärker der real gemessene Deckel, desto höher die
+ausgegebene Gewitterstufe.
+
+Ursache: Der DWD liefert `cin_ml` als **positiven Betrag**, `_gedaempft_durch_cin()`
+(`src/output/metric_format.py:315-341`) erwartet **negative** Werte. Die erste Bedingung
+`if cin_jkg > -25: return basis` ist bei jedem positiven Wert wahr ⇒ volle Stufe, immer.
+
+**Wirkung, gemessen** (ICON-D2 Alpen, Lauf 2026-08-11 03Z +12 h, 906 390 Gitterpunkte): CAPE
+erzeugt HIGH bei **3,88 %** der Punkte; mit wirksamer Dämpfung wären es **1,44 %** — rund
+**2,7-mal so viele „hoch"-Einstufungen wie beabsichtigt**, im gesamten DWD-Gebiet (DE/Alpen/AT,
+einschließlich Karnischer Höhenweg). Richtung: Über-Warnung.
+
+## Belegte Konventionen (recherchiert 2026-08-11, nicht angenommen)
+
+| Quelle | Vorzeichen | Beleg |
+|---|---|---|
+| **DWD ICON `CIN_ML`** | **positiv** | ICON-Quellcode `src/atm_phy_nwp/mo_opt_nwp_diagnostics.f90:3957-3958`: `! make CIN positive` / `cin(jc) = ABS(cin(jc) - cin_help(jc))` |
+| **GRIB2-Standard** (0/7/7) | **keines definiert** | WMO-Registry 4.2/0-7-7 und NCEP-Tabelle nennen nur Name und `J kg⁻¹`. Das Vorzeichen ist **modellspezifisch** — GFS negativ, ICON positiv |
+| **US-Literatur** (Penn State, SPC) | negativ | Quelle unserer Bänder −25/−50/−100/−200; bezogen auf **MLCIN über 100 hPa** |
+| Open-Meteo (ICON-Domänen) | positiv | nur indirekt über den `-1`-Fehlwert erschlossen — **nicht ausdrücklich belegt** |
+
+Die DWD-*Datenbankbeschreibung* (Tab. 5.6) dokumentiert das Vorzeichen **nicht**; belegt wird es
+allein durch den Modellcode.
+
+**Herkunft der drei Prüfwerte** (damit niemand sie für erfunden hält): **7,29** und **104,47** J/kg
+sind belegte Fixture-Werte aus `tests/tdd/test_dwd_thunder_new_signals_fetch.py:31` bzw.
+`test_dwd_eu_thunder_energy_signals_fetch.py:17`. **767,8** ist **kein** Fixture-Wert, sondern das
+gemessene Maximum aus dem ICON-D2-Alpen-Feld (Lauf 2026-08-11 03Z +12 h, 906 390 Gitterpunkte) —
+also der stärkste real beobachtete Deckel, nicht eine gegriffene Zahl.
+
+### 🔴 Falle: −999,9 heißt „kein Auslösepunkt", nicht „extremer Deckel"
+
+ICON-Code Z. 2700: `missing_value = -999.9_wp ! Missing value for CIN (if no LFC/CAPE was found)`.
+Der **einzige** legitime negative Wert in `CIN_ML` ist der Fehlwert. Ein blindes `abs()` oder ein
+schlichter Vorzeichenwechsel macht daraus **+999,9 = stärkster denkbarer Deckel** — genau verkehrt
+herum. Der bestehende Filter (`dwd.py:240`, `dwd_eu.py:261`, Konstante `dwd.py:206`) fängt ihn
+**vor** jeder Umrechnung ab; diese Reihenfolge ist Teil des Fixes und muss bewacht werden.
+
+## Entscheidung: Vergleich über den Betrag, am Wirkort
+
+Die Dämpfung vergleicht künftig den **Betrag** der Hemmung gegen die Bänder 25/50/100/200,
+statt auf ein Vorzeichen zu vertrauen. Begründung gegenüber den Alternativen:
+
+- **Nicht** beim Einlesen umdrehen: Das Feld `convective_inhibition_jkg` wird in Wetter-Schnappschüsse
+  persistiert (`src/services/weather_snapshot.py:287-296`). Ein Vorzeichenwechsel dort erzeugt
+  Altdaten mit positiven und Neudaten mit negativen Werten in derselben Datei-Familie — eine stille
+  Zweideutigkeit ohne Migration.
+- **Am Wirkort** liegt die einzige Stelle, die den Wert *interpretiert*. Sie schützt damit gegen
+  **jede** Provider-Konvention (GFS negativ, ICON positiv), nicht nur gegen die heute bekannte.
+- Der Betragsvergleich ist **idempotent gegenüber den Bestandstests**: Alle vorhandenen Fälle
+  speisen Werte ≤ 0 ein, deren Betrag dieselbe Bandzuordnung ergibt. Kein Bestandstest ändert sich.
+
+## Acceptance Criteria
+
+- **AC-1:** Given der DWD liefert für eine Etappe eine Konvektionshemmung als positiven Betrag
+(real gemessen: 7,29 · 104,47 · 767,8 J/kg), When die Gewitterstufe aus den Signalen fusioniert
+wird, Then dämpft die Hemmung die CAPE-Zutat nach denselben Bändern wie bei negativer Eingabe —
+also 7,29 ohne Dämpfung (Betrag < 25), 104,47 und 767,8 beide auf „kein Beitrag" (Betrag > 100).
+
+  ⚠️ **Korrektur 2026-08-11 nach der Umsetzung:** Hier stand zuerst „104,47 auf höchstens
+  ‚leicht'". Das war **falsch** und widersprach der Bänder-Tabelle, auf die dieses AC sich beruft:
+  Das Band „auf leicht deckeln" reicht bis Betrag 100 **einschließlich**; 104,47 liegt darüber und
+  fällt damit in „Deckel hält, kein Beitrag". Der Developer hat die dokumentierte Bandlogik
+  implementiert statt der fehlerhaften Prosa zu folgen und den Widerspruch gemeldet — richtig so.
+  Ein Wert im Band „höchstens leicht" wäre z. B. 75.
+
+- **AC-2:** Given eine Konvektionshemmung mit negativem Vorzeichen (Bestandsverhalten, US-Konvention),
+When die CAPE-Zutat gedämpft wird, Then bleibt die Zuordnung unverändert zum Stand vor diesem Fix —
+kein bestehender Testfall ändert sein Ergebnis.
+
+- **AC-3:** Given der DWD meldet den Fehlwert −999,9 („kein Auslösepunkt gefunden"), When der Wert
+eingelesen wird, Then erreicht er die Dämpfung nicht, sondern wird zu „unbekannt", und die
+CAPE-Zutat fällt auf die Notbremse „höchstens leicht" — **niemals** auf „stärkster Deckel" und
+niemals auf „kein Deckel".
+
+- **AC-4:** Given ein Entwickler liest die Dämpfungsfunktion, When er die Vorzeichenfrage klären will,
+Then steht am Code, dass das Vorzeichen modellabhängig ist (DWD/ICON positiv, GFS/US negativ, GRIB2
+legt keines fest), mit Quellenangabe — die Annahme ist damit belegt statt stillschweigend.
+
+- **AC-5:** Given die Änderung ist umgesetzt, When ein Test die real gemessenen DWD-Werte durch den
+Produktivpfad schickt, Then war dieser Test vor dem Fix rot und ist danach grün — geprüft wird die
+**fusionierte Stufe**, nicht nur die Dämpfungsfunktion für sich.
+
+- **AC-6:** Given die Gewitterstufe eines Trips im DWD-Gebiet, When ein Briefing gerendert wird,
+Then fällt die Stufe gegenüber dem Stand vor dem Fix **nur** dort, wo eine Hemmung vorliegt, und
+steigt nirgends — die Dämpfung dämpft ausschließlich.
+
+## Known Limitations (bewusst NICHT in dieser Scheibe)
+
+🔴 **Die Bänder sind für ICON nicht geeicht.** Die Beträge 25/50/100/200 stammen aus US-Praxis für
+**MLCIN über 100 hPa**; ICON mischt über **50 hPa** (ICON-Code Z. 2701-2702: *„Depth of mixed
+surface layer: 50hPa following Huntrieser, 1997"*), rechnet **reversibel** statt pseudoadiabatisch
+und **ohne Entrainment** (ECMWF TM 852, Groenemeijer et al. 2019). Das ist dieselbe Fehlerklasse
+wie ADR-0048 („CAPE ≠ CAPE"), eine Ebene tiefer.
+
+Dieser Fix stellt her, dass die Dämpfung **überhaupt** wirkt — mit Schwellen in der richtigen
+Größenordnung. Er behauptet **nicht**, dass sie geeicht sind. Die Eichung an ICON-Daten gehört zur
+Feineichungs-Familie (E1b, #1678) und wird dort vermerkt.
+
+Ebenfalls nicht in dieser Scheibe: Prüfung, ob **weitere** DWD-Größen dieselbe stille
+Konventions-Annahme tragen (`sdi_2`, `uh_max`, `grau_gsp`).
+
+## Test-Nachweis
+
+- **Rot vor Fix:** Fusion mit `cin_jkg=104.47` und CAPE oberhalb der HIGH-Sprosse liefert heute
+  „hoch", erwartet wird „leicht".
+- **Mutations-Gegenprobe (Pflicht):** Betragsbildung entfernen ⇒ AC-1-Test muss rot werden.
+  Sentinel-Filter entfernen ⇒ AC-3-Test muss rot werden.
+- Bestandssuite `tests/tdd/test_cape_cin_pairing.py` muss **unverändert** grün bleiben (AC-2).

--- a/src/output/metric_format.py
+++ b/src/output/metric_format.py
@@ -318,25 +318,50 @@ def _gedaempft_durch_cin(
     """Daempft eine CAPE-Stufe anhand der Konvektionshemmung CIN (Issue #1679).
 
     Vier belegte Baender (Penn State/COMET, SPC -- Gesamtkonzept 3.7 Schritt 2):
-    schwacher Deckel (> -25) laesst die Leiter voll zaehlen, moderat
-    (-50 < cin <= -25) nimmt genau eine Stufe, grosser Deckel
-    (-100 <= cin <= -50) deckelt auf LOW, darunter traegt CAPE nichts mehr bei.
+    schwacher Deckel (Betrag < 25) laesst die Leiter voll zaehlen, moderat
+    (25 <= Betrag < 50) nimmt genau eine Stufe, grosser Deckel
+    (50 <= Betrag <= 100) deckelt auf LOW, darueber traegt CAPE nichts mehr bei.
     Ein Grenzwert gehoert dabei immer ins staerker daempfende Band.
 
-    Unbekanntes CIN (``None``, strukturell der Fall bei Meteo-France/AROME)
-    faellt auf die Bestands-Notbremse "hoechstens LOW" zurueck -- NICHT auf
-    "kein Deckel": eine fehlende Hemmungsangabe ist keine schwache Hemmung.
+    Unbekanntes CIN (``None``, strukturell der Fall bei Meteo-France/AROME;
+    ebenso der DWD-Fehlwert -999,9 "kein Ausloesepunkt gefunden", der VOR
+    dieser Funktion zu ``None`` gefiltert wird, `dwd.py:206`/`:240`,
+    `dwd_eu.py:261`) faellt auf die Bestands-Notbremse "hoechstens LOW"
+    zurueck -- NICHT auf "kein Deckel": eine fehlende Hemmungsangabe ist
+    keine schwache Hemmung.
+
+    Vorzeichen der Eingabe ist MODELLABHAENGIG, GRIB2 (Parameter 0/7/7 der
+    WMO-Registry) legt keines fest -- nur Name und Einheit (J/kg) sind
+    standardisiert. Der DWD (ICON-D2/ICON-EU) liefert ``cin_ml`` als
+    POSITIVEN Betrag: ICON-Quellcode
+    `src/atm_phy_nwp/mo_opt_nwp_diagnostics.f90:3957-3958`, Kommentar
+    ``! make CIN positive``, gefolgt von ``ABS(...)``. GFS/US-Modelle
+    liefern dagegen negativ -- die US-Literatur (Penn State/SPC), aus der
+    die vier Baender oben stammen, bezieht sich auf **MLCIN ueber 100 hPa**
+    negativ gezaehlt. Deshalb vergleicht diese Funktion den BETRAG der
+    Hemmung, nicht ihr Vorzeichen (Issue #1760) -- ein reiner
+    Vorzeichenvergleich (``cin_jkg > -25``) waere fuer JEDEN positiven
+    ICON-Wert immer wahr und die Daempfung wuerde nie feuern.
+
+    🔴 Bekannte Einschraenkung (Issue #1760 Known Limitations): die Baender
+    selbst sind fuer ICON NICHT geeicht. ICON mischt CIN ueber **50 hPa**
+    (ICON-Code Z. 2701-2702, "Depth of mixed surface layer: 50hPa following
+    Huntrieser, 1997"), reversibel, ohne Entrainment (ECMWF TM 852,
+    Groenemeijer et al. 2019) -- eine andere Rechnung als die US-MLCIN, aus
+    der -25/-50/-100/-200 stammen. Die Schwellen liegen in der richtigen
+    Groessenordnung, sind aber keine ICON-Eichung (Feineichung: #1678).
 
     CIN ist Ausloese-Filter, kein Schweremass (Rasmussen & Blanchard 1998) --
     diese Funktion daempft deshalb ausschliesslich und hebt nie an.
     """
     if cin_jkg is None:
         return min(basis, ThunderLevel.LOW, key=thunder_ordinal)
-    if cin_jkg > -25:
+    betrag = abs(cin_jkg)
+    if betrag < 25:
         return basis
-    if cin_jkg > -50:
+    if betrag < 50:
         return _THUNDER_JE_ORDINAL[max(thunder_ordinal(basis) - 1, 0)]
-    if cin_jkg >= -100:
+    if betrag <= 100:
         return min(basis, ThunderLevel.LOW, key=thunder_ordinal)
     return ThunderLevel.NONE
 

--- a/tests/tdd/test_cape_cin_pairing.py
+++ b/tests/tdd/test_cape_cin_pairing.py
@@ -22,10 +22,12 @@ Keine Mocks: reine Funktionsaufrufe, kein Netz.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 
 from app.models import ThunderLevel
+from app.thunder_scale import thunder_ordinal
 from output.metric_format import thunder_level_from_signals
 
 NONE = ThunderLevel.NONE
@@ -300,3 +302,249 @@ def test_ac8_thunder_level_from_signals_ohne_cin_parameter_bricht_mit_typeerror(
             cape_threshold_jkg=CAPE_LOW,
             lpi_low_min=None, lpi_med_min=None, lpi_high_min=None,
         )
+
+
+# ===========================================================================
+# Issue #1760 -- CIN-Daempfung feuert nie: der DWD liefert `cin_ml` als
+# POSITIVEN Betrag, `_gedaempft_durch_cin()` erwartete bisher ausschliesslich
+# negative Werte (`cin_jkg > -25` ist fuer jeden positiven Wert wahr).
+# SPEC: docs/specs/modules/fix_1760_cin_vorzeichen.md
+#
+# Reale, gemessene DWD-Werte (`cin_ml`, ICON-D2/ICON-EU, 2026-08-11) --
+# NICHT erfunden, sondern aus den belegten Fixture-Aufzeichnungen:
+#   - 7.29 J/kg  -- test_dwd_thunder_new_signals_fetch.py:31 (ICON-D2, KHW)
+#   - 104.47 J/kg -- test_dwd_eu_thunder_energy_signals_fetch.py:17 (ICON-EU)
+#   - 767.8 J/kg  -- NICHT als Fixture-Wert auffindbar (weder in den beiden
+#     genannten Dateien noch sonst im Repo). Wird trotzdem verwendet, weil
+#     die Spec ihn ausdruecklich als "real gemessen" nennt und die
+#     Entwickler-Vorgabe verbietet, eigene Zahlen zu erfinden -- s. Bericht.
+# ===========================================================================
+
+
+# ────────────── #1760 AC-1/AC-5 -- positiver CIN daempft die FUSIONIERTE
+# Stufe (Produktivpfad `thunder_level_from_signals()`, nicht isoliert) ─────
+
+@pytest.mark.parametrize(
+    "cin_positiv, erwartet",
+    [
+        # 7.29 J/kg: Betrag < 25 -- schwacher Deckel, CAPE zaehlt VOLL.
+        (7.29, HIGH),
+        # 104.47 J/kg: Betrag > 100 -- nach der Tabelle in
+        # docs/features/gewitter-gesamtkonzept.md ("unter -100 J/kg: Deckel
+        # haelt, kein Beitrag") liegt das NEGATIVE Pendant -104.47 ebenfalls
+        # in diesem Band, nicht im Band "grosser Deckel" (-100 bis -50).
+        # Die Spec-Prosa zu AC-1 nennt hierfuer "hoechstens 'leicht'" --
+        # das ist mit NONE (schwaecher als LOW) technisch weiterhin erfuellt
+        # ("hoechstens" = Obergrenze), aber NICHT das Band "grosser Deckel"
+        # selbst. S. Bericht: Unstimmigkeit in der Spec-Illustration.
+        (104.47, NONE),
+        # 767.8 J/kg: Betrag weit > 100 -- ebenfalls "Deckel haelt".
+        (767.8, NONE),
+    ],
+)
+def test_1760_ac1_ac5_positiver_cin_daempft_fusionierte_stufe_echte_dwd_werte(
+    cin_positiv, erwartet,
+):
+    """#1760 AC-1 + AC-5: reale, POSITIV gemessene DWD-Werte (`cin_ml`)
+    durchlaufen den Produktivpfad `thunder_level_from_signals()` -- NICHT
+    isoliert `_gedaempft_durch_cin()` -- mit CAPE oberhalb der HIGH-Sprosse
+    (4500 J/kg, volle Leiter: HIGH).
+
+    RED vor dem Fix: `_gedaempft_durch_cin()` prueft `cin_jkg > -25`, was
+    fuer JEDEN positiven Wert wahr ist -- alle drei Faelle liefern HEUTE
+    HIGH statt des erwarteten, gedaempften Ergebnisses.
+    """
+    ergebnis = _call_cape(4500.0, cin_positiv)
+    assert ergebnis == erwartet, (
+        f"CAPE 4500 J/kg mit real gemessenem, POSITIVEM CIN={cin_positiv} "
+        f"muss {erwartet!r} liefern (Betragsvergleich), erhalten {ergebnis!r} "
+        f"-- vor dem Fix wurde jeder positive Wert wie 'kein Deckel' "
+        f"behandelt"
+    )
+
+
+# ────────────── #1760 AC-2 -- Bestandsverhalten (negativ) unveraendert ────
+#
+# Bewusst KEIN neuer Test hier: AC-2 verlangt, dass die bestehenden
+# Parametrisierungen mit negativem CIN (Zeilen 128, 160, 191, 212, 231 vor
+# dieser Ergaenzung) UNVERAENDERT gruen bleiben. Sie werden hier nicht
+# angefasst -- der Beweis ist ein unveraenderter Testlauf derselben Datei.
+
+
+# ────────────── #1760 AC-3 -- Sentinel -999.9 erreicht die Daempfung NIE ──
+
+def test_1760_ac3_gefilterter_sentinel_faellt_ueber_fuse_auf_hoechstens_low():
+    """#1760 AC-3: der DWD-Fehlwert -999.9 ("kein Ausloesepunkt gefunden")
+    wird bereits VOR dieser Funktion gefiltert (`dwd.py:240`/`dwd_eu.py:261`,
+    Konstante `dwd.py:206`) und erreicht die Fusion als `None`. Dieser Test
+    prueft das am Produktionspfad `_fuse_thunder_levels()` (DE_ALPEN/ICON-D2,
+    NICHT das FR-Pendant aus AC-7 oben) -- ein `None`-CIN muss auf
+    "hoechstens LOW" fallen: NIEMALS auf den staerksten Deckel (NONE waere
+    hier bereits ein AC-6-Verstoss, da CAPE weit ueber HIGH liegt) und
+    NIEMALS auf 'kein Deckel' (HIGH waere die Buggy-Interpretation, falls
+    ein `abs()` VOR dem Filter angewendet wuerde und -999.9 zu +999.9 wird).
+
+    Gegenprobe (Mutation): Wird der Sentinel-Filter in `dwd.py`/`dwd_eu.py`
+    entfernt und ein rohes -999.9 erreicht `convective_inhibition_jkg`
+    unveraendert, liefert `_gedaempft_durch_cin()` (Betrag 999.9 > 100)
+    zwar IMMER NOCH `NONE` -- das ist der Fund, den die Mutations-Gegenprobe
+    im Bericht dokumentiert, s. dort.
+    """
+    from app.model_registry import cape_ladder_thresholds_jkg
+    from app.models import ForecastDataPoint
+    from providers.thunder_enrichment import _fuse_thunder_levels
+
+    cape_ladder = cape_ladder_thresholds_jkg("icon_d2", "DE_ALPEN")
+    assert cape_ladder is not None, "Vorbedingung: DE_ALPEN muss kalibriert sein"
+
+    ts = datetime.now(timezone.utc)
+    dp = ForecastDataPoint(
+        ts=ts, thunder_level=None, cape_jkg=cape_ladder[2] + 500.0,
+        convective_inhibition_jkg=None,  # simuliert den bereits gefilterten Sentinel
+    )
+
+    _fuse_thunder_levels([dp], cape_ladder, None)
+
+    assert dp.thunder_level == LOW, (
+        f"DE_ALPEN-Datenpunkt mit CAPE weit ueber HIGH und gefiltertem "
+        f"Sentinel (CIN=None) muss LOW liefern (Notbremse 'hoechstens "
+        f"LOW'), erhalten {dp.thunder_level!r}"
+    )
+
+
+# ────────────── #1760 AC-3 -- Adversary F001: der Sentinel-FILTER selbst ──
+#
+# Der obige Test setzt `convective_inhibition_jkg=None` VORAUS -- er prueft
+# die Daempfung, nicht ob der Filter (`dwd.py:206`/`:240`, `dwd_eu.py:261`)
+# aus dem rohen -999,9 ueberhaupt `None` macht. Die bisher einzigen Tests,
+# die das tun (`test_ac2_..." in test_dwd_thunder_new_signals_fetch.py,
+# `test_f001_..." in test_dwd_eu_thunder_energy_signals_fetch.py) tragen
+# `pytestmark = pytest.mark.live` auf MODUL-Ebene (identisches Vorbild in
+# ~15 weiteren Tests derselben zwei Dateien, CI-Vermessung #1196) und laufen
+# damit NICHT im Standardlauf (`pyproject.toml:65`). Ein Entfernen des
+# Markers nur an diesen zwei Funktionen ist nicht moeglich, ohne den Marker
+# fuer ALLE anderen Tests derselben Datei ebenfalls anzufassen (Modul-Ebene)
+# -- diese sind bewusst als 'live' eingestuft, unabhaengig vom eigentlichen
+# Netzbedarf. Deshalb hier ein eigener, kleiner Kern-Test statt Entmarkierung
+# (Bericht: Wahl (b) statt (a)).
+
+_DWD_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "dwd"
+
+
+@pytest.mark.parametrize(
+    "modul_pfad, fixture_name, marker_ort, echt_ort",
+    [
+        # Koordinaten identisch zu den bestehenden live-Tests uebernommen
+        # (nicht neu geraten) -- dort bereits als Sentinel- bzw. Echtwert-
+        # Gitterpunkt der jeweiligen, echten Aufzeichnung nachgewiesen.
+        (
+            "providers.dwd",
+            "icon_d2_alpen_cin_ml_2026081103_012.grib2.bz2",
+            (53.90, 1.22), (46.40, 12.52),
+        ),
+        (
+            "providers.dwd_eu",
+            "icon_eu_abruzzen_cin_ml_2026081100_000.grib2.bz2",
+            (70.5, -19.8125), (41.8125, 13.3750),
+        ),
+    ],
+    ids=["icon_d2_dwd_py_240", "icon_eu_dwd_eu_py_261"],
+)
+def test_1760_f001_dwd_sentinel_filter_faengt_minus_999_9_am_realen_gitterpunkt(
+    modul_pfad, fixture_name, marker_ort, echt_ort,
+):
+    """#1760 Adversary F001: der DWD-Sentinel-Filter fuer `cin_ml`
+    (Konstante `CIN_ML_LOWER_SENTINEL`, `dwd.py:206`; Filterzeilen
+    `dwd.py:240` und `dwd_eu.py:261`) direkt am Produktionsfilter
+    `_read_point_value()` geprueft -- kein Netz, kein lokaler Server, nur
+    die bereits eingecheckte, echte Aufzeichnung.
+
+    Mutations-Gegenprobe (Pflicht laut Auftrag, s. Bericht):
+    1. `CIN_ML_LOWER_SENTINEL` in `dwd.py:206` auf -9999.9 aendern -> rot.
+    2. Filterzeile `dwd.py:240` entfernen -> rot (nimmt wegen des
+       gemeinsamen Imports `dwd_eu.py:70` auch den ICON-EU-Fall mit).
+    """
+    import importlib
+
+    modul = importlib.import_module(modul_pfad)
+    compressed = (_DWD_FIXTURES / fixture_name).read_bytes()
+
+    marker_lat, marker_lon = marker_ort
+    echt_lat, echt_lon = echt_ort
+    marker_ergebnis = modul._read_point_value(
+        compressed, marker_lat, marker_lon, param="cin_ml",
+    )
+    echt_ergebnis = modul._read_point_value(
+        compressed, echt_lat, echt_lon, param="cin_ml",
+    )
+
+    assert marker_ergebnis is None, (
+        f"{modul_pfad}._read_point_value: Sentinel-Gitterpunkt {marker_ort} "
+        f"liefert {marker_ergebnis!r} statt None -- der -999,9-Filter greift "
+        f"nicht (Fehlwert wuerde als echter, extremer Deckel durchgereicht)"
+    )
+    assert echt_ergebnis is not None and echt_ergebnis > 1, (
+        f"{modul_pfad}._read_point_value: echter Gitterpunkt {echt_ort} "
+        f"liefert {echt_ergebnis!r} -- ohne diesen Vergleichswert waere der "
+        f"Test auch fuer einen Filter gruen, der PAUSCHAL alles auf None "
+        f"setzt statt nur den Sentinel"
+    )
+
+
+# ────────────── #1760 AC-4 -- Vorzeichen-Herkunft am Code belegt ──────────
+
+def test_1760_ac4_docstring_belegt_modellabhaengiges_vorzeichen():
+    """#1760 AC-4: die Docstring von `_gedaempft_durch_cin()` muss die
+    Vorzeichenfrage BELEGEN (nicht nur behaupten) -- ICON-Quellstelle, GRIB2
+    ohne Vorzeichenkonvention, US-Herkunft der Baender. Verhaltensnachweis
+    ueber Wortpruefung ist hier per Definition angemessen (Docstring IST der
+    Nachweisort von AC-4), daher explizit erlaubt via Marker.
+
+    # doc-compliance-test
+    """
+    import inspect
+
+    from output.metric_format import _gedaempft_durch_cin
+
+    doc = inspect.getdoc(_gedaempft_durch_cin) or ""
+    for beleg in (
+        "mo_opt_nwp_diagnostics.f90",  # ICON-Quellcode-Stelle
+        "GRIB2",  # Standard ohne Vorzeichenkonvention
+        "GFS",  # Gegenbeispiel: negatives Vorzeichen
+    ):
+        assert beleg in doc, (
+            f"Docstring von _gedaempft_durch_cin() muss '{beleg}' als Beleg "
+            f"fuer die Vorzeichenfrage enthalten (#1760 AC-4), fehlt aktuell"
+        )
+
+
+# ────────────── #1760 AC-6 -- Daempfung senkt AUSSCHLIESSLICH, hebt nie ───
+
+@pytest.mark.parametrize("cin_betrag", [7.29, 104.47, 767.8])
+def test_1760_ac6_positiv_und_negativ_liefern_identisches_ergebnis(cin_betrag):
+    """#1760 AC-6: derselbe Betrag mit positivem und negativem Vorzeichen
+    liefert IDENTISCHE Ergebnisse -- die Daempfung haengt nur vom Betrag ab,
+    nicht vom Vorzeichen. Vor dem Fix war das positive Ergebnis IMMER
+    `basis` (HIGH) unabhaengig vom Betrag -- fuer 104.47/767.8 waere die
+    Symmetrie damit heute verletzt (RED-Beleg identisch zu AC-1 oben).
+    """
+    positiv = _call_cape(4500.0, cin_betrag)
+    negativ = _call_cape(4500.0, -cin_betrag)
+    assert positiv == negativ, (
+        f"CIN={cin_betrag} und CIN={-cin_betrag} muessen identisch daempfen "
+        f"(nur der Betrag zaehlt), erhalten positiv={positiv!r} vs. "
+        f"negativ={negativ!r}"
+    )
+
+
+@pytest.mark.parametrize("cin_positiv", [7.29, 104.47, 767.8, 30.0, 60.0])
+def test_1760_ac6_daempfung_hebt_die_stufe_nie_ueber_die_basis(cin_positiv):
+    """#1760 AC-6: fuer JEDEN positiven CIN-Wert bleibt das gedaempfte
+    Ergebnis auf oder unter der ungedaempften Basisstufe (HIGH, volle
+    Leiter fuer CAPE=4500) -- die Daempfung dämpft ausschliesslich, sie
+    hebt nie an."""
+    ergebnis = _call_cape(4500.0, cin_positiv)
+    assert thunder_ordinal(ergebnis) <= thunder_ordinal(HIGH), (
+        f"CIN={cin_positiv} (positiv) darf die Stufe NIE ueber HIGH heben, "
+        f"erhalten {ergebnis!r}"
+    )


### PR DESCRIPTION
Behebt #1760. Die mit #1679 eingeführte Dämpfung der CAPE-Zutat durch die Konvektionshemmung feuerte im Produktivpfad **nie** und wirkte invertiert.

## Ursache

Der DWD liefert `cin_ml` als **positiven** Betrag, `_gedaempft_durch_cin()` verglich gegen **negative** Bänder. `if cin_jkg > -25: return basis` ist bei jedem positiven Wert wahr ⇒ volle Stufe, immer. Der stärkste real gemessene Deckel (767,8 J/kg) lieferte die höchste Gewitterstufe.

## Wirkung, gemessen

ICON-D2 Alpen, Lauf 2026-08-11 03Z +12 h, **906.390 Gitterpunkte**: CAPE erzeugte HIGH bei **3,88 %** der Punkte statt **1,44 %** — rund **2,7-mal so viele „hoch"-Einstufungen wie beabsichtigt**, im gesamten DWD-Gebiet (DE/Alpen/AT). Richtung: Über-Warnung.

## Fix

Vergleich auf `abs(cin_jkg)` **am Wirkort**. Für negative Eingaben exakt äquivalent zur alten Logik — alle Bandgrenzen (0,0 / −0,0 / ±1e-9 um −25/−50/−100) unabhängig nachgerechnet, kein einziger Abweichungsfall. Deshalb ändert **kein Bestandstest** sein Ergebnis.

Bewusst **nicht** beim Einlesen gedreht: `convective_inhibition_jkg` wird in Wetter-Schnappschüsse persistiert; ein Vorzeichenwechsel dort erzeugte Altdaten positiv / Neudaten negativ in derselben Datei-Familie.

## Konvention belegt statt angenommen

| Quelle | Vorzeichen | Beleg |
|---|---|---|
| DWD ICON `CIN_ML` | **positiv** | ICON-Quellcode `mo_opt_nwp_diagnostics.f90:3957-3958`: `! make CIN positive`, gefolgt von `ABS()` |
| GRIB2 0/7/7 | **keines** | WMO-Registry nennt nur Name und `J kg⁻¹` — GFS negativ, ICON positiv |
| US-Literatur (Penn State/SPC) | negativ | Quelle unserer Bänder, bezogen auf MLCIN über 100 hPa |

### 🔴 Falle, die der naheliegende Fix ausgelöst hätte

`-999,9` bedeutet beim DWD „kein Auslösepunkt gefunden", **nicht** „extremer Deckel" (ICON-Code Z. 2700). Ein schlichter Vorzeichenwechsel hätte daraus `+999,9` = stärksten Deckel gemacht und Gewitter unterdrückt, wo nur ein Messwert fehlt. Der bestehende Filter fängt ihn **vor** der Umrechnung ab.

## Ehrliche Einschränkung

Die Bänder sind für ICON **nicht geeicht**. ICON mischt über 50 hPa statt 100 hPa, rechnet reversibel und ohne Entrainment (ECMWF TM 852). Dieser PR stellt her, dass die Dämpfung **überhaupt wirkt** — mit Schwellen in der richtigen Größenordnung, ohne Eichungsanspruch. Als Known Limitation dokumentiert, Eichung vermerkt bei #1678.

## Nachweis

- **RED vor Fix belegt:** 5 Tests rot, u.a. reale Werte 104,47 und 767,8 durch den Fusionspfad → fälschlich „hoch"
- **GREEN:** 143 Tests grün über 13 verwandte Dateien
- **Adversary:** 5/6 AC CONFIRMED, AC-6 strukturell bewiesen (jeder Rückgabezweig liefert Ordinal ≤ Eingangs-Ordinal, für jeden denkbaren Float)
- **Finding F001 geschlossen:** Der Sentinel-Filter war nur von `live`-markierten Tests bewacht, die per `pyproject.toml:65` vom CI-Lauf ausgeschlossen sind — man konnte ihn ersatzlos entfernen, ohne dass ein Test rot wurde. Neuer Kern-Test gegen echte GRIB2-Fixtures schließt das; Mutation der Sentinel-Konstante macht ihn nachweislich rot (unabhängig verifiziert, Original per Prüfsumme wiederhergestellt).

F001 war **keine** Regression durch diesen PR: Auch die alte Vorzeichenlogik lieferte für rohes −999,9 `NONE`.

Bezug: #1760 (bleibt offen bis zum Post-Deploy-Selftest), #1679, #1419, ADR-0048

🤖 Generated with [Claude Code](https://claude.com/claude-code)
