### PR TITLE
fix(#1725): Fälligkeitsfenster von 3 Stunden mit Idempotenz-Schlüssel

### DIFF
--- a/docs/adr/0044-kalendertage-folgen-der-ortszeit.md
+++ b/docs/adr/0044-kalendertage-folgen-der-ortszeit.md
@@ -71,21 +71,24 @@ diesem Tag die Zone, kann die Etappe des Weltzeit-Tages eine andere Zone tragen 
 Ortstages. Der Fehler ist dann die Differenz zweier benachbarter Etappen — in aller Regel
 null. Eine Tour dieser Spannweite hat ohnehin keinen eindeutigen „Kalendertag".
 
-### Wo die Zonen-Auflösung liegt (Stand 2026-08-11, Issue #1697)
+### Wo die Zonen-Auflösung liegt (Stand 2026-08-12, Issue #1697, #1724)
 
 Die drei Bausteine waren ursprünglich **private Methoden** auf `TripCommandProcessor`. Seit
 #1697 liegen sie als Modulfunktionen in **`src/services/trip_day.py`** und werden von dort
-geteilt:
+geteilt; #1724 hat `trip_local_now` ergänzt:
 
 | Funktion | Aufgabe |
 |---|---|
 | `trip_tz(trip)` | Rückfall 2: erste Etappe mit Wegpunkten |
 | `display_tz(trip, day_date)` | Zone der Etappe dieses Tages, sonst `trip_tz` |
 | `anchor_tz(trip, now_utc)` | Auflösung der Henne-Ei-Falle: Zone der Etappe des **Weltzeit**-Tages |
-| `trip_local_today(trip, now_utc)` | **der Ortstag der Tour** — das, was `date.today()` ersetzt |
+| `trip_local_now(trip, now_utc)` | Ortstag UND Ortsstunde der Tour aus EINER Zonen-Auflösung |
+| `trip_local_today(trip, now_utc)` | **der Ortstag der Tour** — das, was `date.today()` ersetzt; dünne Sicht auf `trip_local_now` |
 
-Wer diese Regel anwendet, ruft `trip_local_today()`. Eine eigene Kopie der Zonen-Auflösung
-ist ein Regelverstoß — genau das war der Zustand vor #1697.
+Wer nur den Kalendertag braucht, ruft `trip_local_today()`; wer zusätzlich die Ortsstunde
+braucht — etwa eine Fälligkeitsprüfung wie in #1725 —, ruft `trip_local_now()` direkt, damit
+Tag und Stunde aus derselben Auflösung kommen. Eine eigene Kopie der Zonen-Auflösung ist ein
+Regelverstoß — genau das war der Zustand vor #1697.
 
 ### Umgesetzt
 
@@ -104,22 +107,24 @@ ist ein Regelverstoß — genau das war der Zustand vor #1697.
   `trip_local_today()` bestimmt —, sondern nur die Tages-**Tiefe** der Suche (ein Tag
   zusätzlich statt nur der eine bereits aufgelöste Ortstag). Details:
   `docs/specs/modules/fix_1667_s3_tagesuebergreifende_segmente.md`.
+- **Briefing-/Versand-Pfad** (#1724, live 2026-08-11; Fälligkeitsfenster + Idempotenz #1725,
+  live 2026-08-12): `_get_target_date` und `_get_active_trips` in
+  `src/services/trip_report_scheduler.py` bestimmen den Zieltag jetzt über `trip_local_today`
+  statt `date.today()`; `save_dated`/`load_dated` schreiben und lesen denselben
+  Ortstag-Schlüssel, Schreiber und Leser sind also zusammen umgestellt. #1725 löst zusätzlich
+  die in ADR-0051 beschriebene Stundengleichheits-Falle: Fälligkeit ist jetzt ein Fenster von
+  drei Ortsstunden ab der konfigurierten Stunde, gegen Doppelversand abgesichert über den
+  Vermerk-Speicher `services/briefing_slots.py` (Schlüssel `(trip_id, ortstag, slot)`).
 
 **Lehre für die Pflege dieser Liste:** Sie war nicht falsch, sondern **unvollständig** — und
 eine unvollständige Restliste liest sich wie eine vollständige. Wer hier etwas einträgt,
 sucht vorher nach `date.today()`/`datetime.now().date()` im ganzen Produktivcode, statt nur
 die Datei zu nennen, in der er gerade gearbeitet hat.
 
-### Noch nicht umgesetzt (Stand 2026-08-11)
+### Noch nicht umgesetzt (Stand 2026-08-12)
 
-**Briefing-/Versand-Pfad** (`src/services/trip_report_scheduler.py`) — die größte offene
-Fläche, gleiche Ursache, andere Wirkung („Briefing für den falschen Tag" statt „kein Alarm"):
-
-| Ort | Wirkung |
-|---|---|
-| `_get_target_date` | Zieltag des Briefings, morgens `date.today()` / abends `+1` |
-| `_get_active_trips` | entscheidet, ob ein Trip überhaupt ein Briefing bekommt |
-| `save_dated` | Schlüssel des Wetter-Schnappschusses — **Schreiber und Leser müssen zusammen umgestellt werden**, sonst findet der Alarm-Pfad den Anker nicht mehr |
+Der zuvor hier gelistete Briefing-/Versand-Pfad (`_get_target_date`, `_get_active_trips`,
+`save_dated`) ist umgesetzt — s. „Umgesetzt" oben (#1724/#1725).
 
 **Anzeige, Vorschau, Werkzeuge:** vier Stellen in `src/services/trip_command_processor.py`
 (`_handle_query` — **löst einen Versand aus**, nicht nur eine Anzeige, eigene Abwägung nötig;

--- a/docs/adr/0051-drei-zeitbegriffe-zone-an-den-daten.md
+++ b/docs/adr/0051-drei-zeitbegriffe-zone-an-den-daten.md
@@ -94,6 +94,16 @@ Idempotenz-Schlüssel**: fällig, wenn die Ortsstunde die konfigurierte erreicht
 hat und für `(trip_id, ortstag, slot)` noch nichts vermerkt ist. Ein Mechanismus deckt damit
 fehlende Stunde, doppelte Stunde, ausgefallenen Tick und Scheduler-Neustart ab.
 
+**Umsetzungsvermerk (#1724 live 2026-08-11, #1725 live 2026-08-12):** Der Briefing-Versandpfad
+(`src/services/trip_report_scheduler.py`, `services/briefing_slots.py`) setzt „Die
+Fälligkeitsfrage wird umgekehrt" und „Fälligkeit plus Idempotenz-Schlüssel" für den
+Trip-Versand bereits um — der Cron liefert einen Zeitpunkt, jeder Trip prüft seine eigene
+Ortsstunde gegen ein Fenster von drei Stunden ab der konfigurierten, abgesichert über den
+Schlüssel `(trip_id, ortstag, slot)`. Der Compare-Versandpfad (`CompareDispatchStrategy`)
+ist davon unberührt und prüft weiterhin auf Stundengleichheit. Die übrigen Regeln dieses ADR
+(drei Zeitbegriffe, Regel 1–3, Wächter-Ausdehnung) sind von diesem Vermerk unberührt und
+bleiben Gegenstand der noch offenen PO-Entscheidung über den ADR-Status.
+
 ## Verworfene Alternativen
 
 - **Alles bei Weltzeit lassen.** Konsistent und umstellungs-immun, für den Nutzer aber falsch —

--- a/docs/analysis/zeitzonen-architektur-2026-08.md
+++ b/docs/analysis/zeitzonen-architektur-2026-08.md
@@ -21,6 +21,12 @@ die nächste Aufrufstelle beginnt die Debatte von vorn.
 | Ortszone des Trips | `services/trip_day.py` (ADR-0044) | Nur im Alarm-Pfad, seit #1697 |
 | Browser-Zone | Frontend | Anzeige — dort ebenfalls auf Wien festgenagelt |
 
+**Nachtrag (Stand 2026-08-12):** Diese Tabelle zeigt den Stand vor der Umsetzung. Mit
+S2/S3 (#1724/#1725) entscheidet für die Briefing-Fälligkeit der Trips nicht mehr
+`Europe/Vienna`, sondern die Ortszone des Trips (`services/trip_day.py`) — Details in
+„Übertragung auf Gregor Zwanzig" unten. Ruhezeit, Tageszähler und Ortsvergleich hängen
+unverändert an `Europe/Vienna` (offen: S4/#1726).
+
 `Europe/Vienna` ist eine feste Konstante ohne fachliche Herleitung — keine Stelle im Code leitet
 sie aus einer Eigenschaft des Trips, des Orts oder des Nutzers ab. Sie deckt sich **zufällig** mit
 der Zone des Betreibers; das macht sie nicht richtig, es erklärt nur, warum der Fehler bisher
@@ -109,9 +115,9 @@ ganzen Lauf. Es gilt nur nirgends verbindlich.
 
 ## Übertragung auf Gregor Zwanzig
 
-### Der eine Umbau, der die Wien-Konstante entfernt
+### Der eine Umbau, der die Wien-Konstante entfernt (umgesetzt — S2/#1724, live 2026-08-11)
 
-Heute (`trip_report_scheduler.py:345-358`) fragt der Versand:
+Bis dahin fragte der Versand (`trip_report_scheduler.py`):
 
 > Es ist 07:00 **in Wien** — welche Trips haben 07:00 konfiguriert?
 
@@ -120,9 +126,9 @@ Eine globale Uhr, N Trips. Richtig wäre die Umkehrung:
 > Für jeden Trip: wie spät ist es **in seiner** Zone — passt das zu seiner Konfiguration?
 
 Der Cron tickt weiter stündlich; er liefert nur noch einen Zeitpunkt, keine Stunde mehr. Die
-Schleife über die Trips existiert bereits (`_collect_due_trips`) — der Stundenvergleich wandert
-hinein, und die Zone kommt aus derselben Quelle, die der Alarm-Pfad seit #1697 benutzt
-(`trip_day.trip_local_today` / `display_tz`). Das **löscht** die Wien-Konstante, statt einen
+Schleife über die Trips existierte bereits (`_collect_due_trips`) — der Stundenvergleich ist
+mit S2 dorthinein gewandert, und die Zone kommt aus derselben Quelle, die der Alarm-Pfad seit
+#1697 benutzt (`trip_day.trip_local_now`). Das **löscht** die Wien-Konstante, statt einen
 weiteren Sonderfall danebenzustellen.
 
 Dasselbe gilt unverändert für Ruhezeit (`deviation_alert_engine`), Tageszähler
@@ -153,14 +159,17 @@ Die übliche Lösung ersetzt Gleichheit durch **Fälligkeit plus Idempotenz-Schl
 - nach Versand wird genau dieser Schlüssel vermerkt.
 
 Ein Mechanismus deckt damit vier Fälle ab: fehlende Stunde (nachgeholt), doppelte Stunde (nur
-einmal), ausgefallener Tick, Scheduler-Neustart. Die „pending marker" im Scheduler sind bereits
-die Hälfte davon — es fehlt der Ortstag im Schlüssel.
+einmal), ausgefallener Tick, Scheduler-Neustart. Die „pending marker" im Scheduler deckten
+bereits die Hälfte davon ab — es fehlte der Ortstag im Schlüssel. **Umgesetzt mit S3/#1725,
+live 2026-08-12:** eigener Vermerk-Speicher `services/briefing_slots.py` mit genau diesem
+Schlüssel `(trip_id, ortstag, slot)`, neben den bestehenden „pending markern" (die weiterhin
+Wetterausfälle behandeln, ein anderer Zweck).
 
-### Der Wächter muss von der Darstellung in die Entscheidung wandern
+### Der Wächter muss von der Darstellung in die Entscheidung wandern (Muster 1+2 umgesetzt — S1/#1723, live 2026-08-11)
 
 `tests/test_output_timezone_guard.py` ist die richtige Bauform (AST-Ratsche, `KNOWN_VIOLATIONS`
-darf nur schrumpfen). Zu erweitern ist der Geltungsbereich auf `src/services/**` und `api/**`,
-mit diesen Fundmustern:
+darf nur schrumpfen). Der Geltungsbereich ist inzwischen auf `src/services/**` und `api/**`
+erweitert, mit diesen Fundmustern:
 
 1. `date.today()` und `datetime.now()` ohne `tz`-Argument — die Umgebungsuhr;
 2. `ZoneInfo("Europe/Vienna")` (und jede feste Zone) außerhalb von Testdateien und
@@ -168,24 +177,23 @@ mit diesen Fundmustern:
 3. `.hour` / `.date()` auf einem Zeitstempel, der nicht nachweislich durch eine Zonen-Auflösung
    gegangen ist — der eigentliche Fehler von #1470 und #1697.
 
-Muster 1 und 2 sind heute ohne Kontextwissen entscheidbar. Muster 3 ist die interessante und
-die teuerste Prüfung; sie sollte einer eigenen Scheibe vorbehalten bleiben, nicht die ersten
-beiden aufhalten.
+Muster 1 und 2 sind mit S1 umgesetzt; die gefundenen Verstöße stehen als `KNOWN_VIOLATIONS`
+im Wächter, größtenteils Fundstellen für #1726/#1727. Muster 3 bleibt die interessante und
+teuerste Prüfung — weiterhin einer eigenen Scheibe vorbehalten, nicht Teil von S1.
 
 ## Vorgeschlagene Schnittfolge
 
 | Scheibe | Inhalt | Warum in dieser Reihenfolge |
 |---|---|---|
 | **S0** (#1722) | ADR: die drei Regeln beschließen, ADR-0044 als Spezialfall darunter einordnen | Ohne beschlossene Regel bleibt jede Scheibe Geschmacksfrage |
-| **S1** (#1723) | Wächter-Ausweitung, Muster 1+2, Bestand als `KNOWN_VIOLATIONS` | Stoppt den Zuwachs sofort, ohne eine Zeile Produktivcode zu bewegen |
-| **S2** (#1724) | Fälligkeit umkehren: Stundenvergleich je Trip in seiner Zone; Wien-Konstante fällt | Der eine Umbau mit der größten Nutzerwirkung |
-| **S3** (#1725) | Gleichheit → Fälligkeit + Idempotenz-Schlüssel `(trip, ortstag, slot)` | Setzt S2 voraus; ohne S2 gibt es keinen Ortstag |
+| ✅ **S1** (#1723), live 2026-08-11 | Wächter-Ausweitung, Muster 1+2, Bestand als `KNOWN_VIOLATIONS` | Stoppt den Zuwachs sofort, ohne eine Zeile Produktivcode zu bewegen |
+| ✅ **S2** (#1724), live 2026-08-11 | Fälligkeit umkehren: Stundenvergleich je Trip in seiner Zone; Wien-Konstante fällt | Der eine Umbau mit der größten Nutzerwirkung |
+| ✅ **S3** (#1725), live 2026-08-12 | Gleichheit → Fälligkeit + Idempotenz-Schlüssel `(trip, ortstag, slot)` | Setzt S2 voraus; ohne S2 gibt es keinen Ortstag |
 | **S4** (#1726) | Ruhezeit, Tageszähler, Ortsvergleichs-Slots auf die Ortszone | Gleiche Wurzel, eigene Nutzerwirkung, eigener Nachweis |
 | **S5** (#1727) | Restliche `date.today()`-Fundstellen; `KNOWN_VIOLATIONS` schrumpft auf null | Aufräumen, wenn die Regel schon trägt |
 
-Der offene Briefing-Pfad aus #1697 (`_get_target_date`, `_get_active_trips`, `save_dated`) ist
-Teil von S2/S5 — er sollte **nicht** vorher einzeln behoben werden, sonst entsteht die zwölfte
-Einzelbehebung.
+Der zuvor offene Briefing-Pfad aus #1697 (`_get_target_date`, `_get_active_trips`,
+`save_dated`) ist mit S2 (#1724) behoben — Details in ADR-0044.
 
 ## Was bewusst offen bleibt
 

--- a/docs/context/fix-1725-faelligkeit-idempotenz.md
+++ b/docs/context/fix-1725-faelligkeit-idempotenz.md
@@ -1,0 +1,497 @@
+# Context: fix-1725-faelligkeit-idempotenz
+
+Issue **#1725** — S3 von Epic #1722 (Zeitzonen-Architektur). Setzt **#1724 (S2)** voraus;
+S2 ist seit `e21f4f48` live und geschlossen.
+
+## Request Summary
+
+Die Briefing-Fälligkeit wird heute über **Stundengleichheit** entschieden
+(`konfigurierte_stunde == trip_lokale_stunde`). Ein Ortstag hat aber nicht immer 24 Stunden:
+am Frühjahrs-Umstellungstag fehlt eine Ortsstunde (ein auf 02:00 gestelltes Briefing entfällt
+ersatzlos), am Herbsttag existiert sie zweimal (das Briefing geht zweimal raus). Gleichheit
+wird ersetzt durch **Fälligkeit + Idempotenz-Schlüssel**: fällig, wenn die Ortsstunde die
+konfigurierte erreicht oder überschritten hat **und** für `(trip_id, ortstag, slot)` noch
+nichts vermerkt ist; nach Versand wird genau dieser Schlüssel vermerkt.
+
+Der Fehler entsteht **erst durch die Verbesserung aus S2** — vorher war die Rechnung
+umstellungs-immun, weil sie in einer festen Zone lief.
+
+## Der Versandpfad — vollständige Kette
+
+| Schritt | Ort |
+|---|---|
+| Go-Cron `"0 * * * *"`, Job `briefing_dispatch` | `internal/scheduler/scheduler.go:141` |
+| → `tripReports()` → `runForAllUsers("trip_reports_hourly", "/api/scheduler/trip-reports")` | `scheduler.go:271,280,190` |
+| HTTP-Einstieg Python, `now_utc = datetime.now(timezone.utc)` (ohne `at`-Param) | `api/routers/scheduler.py:26,44` |
+| `TripReportSchedulerService(user_id).send_due_reports(now_utc)` | `api/routers/scheduler.py:53-56` |
+| → `run_briefing_dispatch("route", user_id, now_utc, settings)` | `src/services/trip_report_scheduler.py:350-352` |
+| Strategie-Auflösung `_STRATEGY["route"] → TripDispatchStrategy` | `src/services/dispatch_orchestrator.py:174-177,204` |
+| `strategy.collect_due(now_utc)` → **`_collect_due_trips`** | `dispatch_orchestrator.py:59-60` → `trip_report_scheduler.py:354` |
+| `strategy.pre_pass(...)` → `_process_pending_markers` | `dispatch_orchestrator.py:62-66` → `trip_report_scheduler.py:389` |
+| Schleife `strategy.dispatch_one(item)` → `_send_trip_report_outcome`, 2,0 s Pause zwischen Items | `dispatch_orchestrator.py:68-80,217-218` |
+| Kanäle E-Mail/SMS/Premium-SMS/Telegram in **einem** Aufruf, je eigenes `try/except` | `src/services/notification_service.py:309-521` |
+
+**Die heutige Fälligkeitsprüfung** — die zu ersetzende Stelle:
+
+```
+if self._get_morning_hour(trip) == self._trip_local_hour(trip, now_utc):   # :372
+if self._get_evening_hour(trip) == self._trip_local_hour(trip, now_utc):   # :375
+```
+
+`_trip_local_hour` (`:379-387`) = `trip_local_now(trip, now_utc).hour` — derselbe Auflöser,
+den der Alarm-Pfad seit #1697 benutzt.
+
+## Outcome-Werte: fünf, und nur einer heißt „gesendet"
+
+`_send_trip_report_outcome` (`trip_report_scheduler.py:871-1303`) gibt zurück:
+
+| Wert | Zeile | Bedeutung |
+|---|---|---|
+| `no_stage` | :919-921 | keine Etappe am Zieltag — früher Return **vor** jedem Versandversuch |
+| `no_weather` | :1028 | Totalausfall Wetterdaten (Schwelle `OUTAGE_WITHHOLD_RATIO = 0.75`, :1004) — früher Return |
+| `no_channels` | :1287-1290 | kein Kanal konfiguriert |
+| `channels_unreachable` | :1291-1302 | konfiguriert, aber keiner erreicht |
+| `sent` | :1303 | Default-Return am Funktionsende |
+
+`result.sent` entsteht als **`sent=bool(sent_channels)`** (`notification_service.py:515`) — „gesendet"
+heißt „**mindestens ein** Kanal hat zugestellt", nicht „alle". Gelingt E-Mail und scheitert
+Premium-SMS, ist der Outcome `sent`; der Ausfall ist nur am Fehlen in `sent_channels` sichtbar.
+
+**Folge für den Schlüssel:** Es gibt bereits genau **einen** Outcome je
+`(trip, report_type, target_date)` — ein Pro-Kanal-Schlüssel würde eine Unterscheidung
+einführen, die im übrigen Code nirgends existiert.
+
+## Kandidaten für den Idempotenz-Träger
+
+Es gibt **heute keinen Fälligkeits-Idempotenz-Check überhaupt**. Der einzige Schutz gegen
+Doppelversand ist strukturell: der Cron feuert einmal pro Stunde. Ein zweiter Lauf in
+derselben Stunde (Neustart, manueller Trigger) hätte heute keinen Schutz.
+
+| Kandidat | Form | Schreibsicherung | Passung |
+|---|---|---|---|
+| **`briefing_log.json`** (`internal/store/log.go:10-15`, geschrieben `trip_report_scheduler.py:1452-1470`) | `{trip_id, kind, sent_at, channels[]}` — `kind` **ist** der Slot | 🔴 weder atomar (`path.write_text()`, :1470) noch gesperrt | Grundform stimmt, **scheidet aber aus** (s. Analyse): #1007 F001 verbietet Einträge mit `channels=[]` (:1234-1246), weil die Cockpit-Kachel #393 sonst einen Versand vortäuscht — vier der fünf Vermerk-Fälle haben keine Kanäle. Bleibt als **Rückwärts-Ableitung** beim Rollout nützlich |
+| `throttle_state.json` (`src/services/throttle_store.py`) | `{scope: {key: iso}}`, zweistufig | ✅ stärkste: `fcntl`-Lock + `tempfile`+`os.replace` (:103-158) | Semantisch fremd — Cooldown-**Fenster** („innerhalb N Minuten"), nicht exakte Slot-Identität. Tripel nur als zusammengesetzter Key-String = Formatbruch |
+| `pending_briefings.json` | `{trip_id, report_type, date, slot_hour, failed_segment_ids, attempts, created_at, reason?}` | atomar, aber **kein** Lock | Felder passen, **Semantik nicht**: ein „offene Arbeit"-Marker, der bei Auflösung **verschwindet** — nach erfolgreichem Versand existiert kein Nachweis mehr. Als alleiniger Idempotenz-Träger ungeeignet |
+
+Die Issue-Annahme „die pending marker sind bereits die halbe Miete" trägt damit **nicht**:
+sie sind eine Warteschlange offener Arbeit, kein Sende-Protokoll.
+
+**Ergebnis der Analyse: keiner der drei taugt als Träger** — es entsteht ein eigener,
+schmaler Speicher (`briefing_slots.json`). Begründung unten unter „Analysis".
+
+Zur Go-Seite: `briefing_log.json` wird von Go **nur gelesen**
+(`internal/handler/cockpit.go:21`, `internal/handler/briefing_history.go:25`,
+`internal/store/log.go:98`) und in keinem Produktivpfad geschrieben. Eine Schema-Erweiterung
+hätte dort also keine Parität erzwungen — `encoding/json` ignoriert unbekannte Felder.
+
+## Zeit-Infrastruktur
+
+- `src/services/trip_day.py`: `trip_tz` (:29), `display_tz` (:45), `anchor_tz` (:55),
+  **`trip_local_now`** (:74, seit #1724 — Tag *und* Uhrzeit aus **einer** Zonen-Auflösung),
+  `trip_local_today` (:90). Zone via TimezoneFinder (`utils/timezone.py:29-37`), Lazy-Singleton.
+- **Fallback bei Auflösungs-Fehlschlag, zwei Ebenen:** `tz_for_coords` → `ZoneInfo("UTC")`
+  (`utils/timezone.py:35-37`); `trip_tz` ohne Wegpunkte → importierte `UTC`-Konstante.
+- **`local_dt(dt, tz)`** (`utils/timezone.py:81-83`) = `_as_utc(dt).astimezone(tz)`; `_as_utc`
+  (:74-78) markiert naive Zeitstempel **erst** explizit als UTC, statt `.astimezone()` die
+  Prozess-Zone raten zu lassen.
+- `_get_target_date` (`trip_report_scheduler.py:689-713`) liefert bereits den **Ortstag** —
+  der `ortstag`-Teil des Schlüssels ist vorhanden, nicht neu zu erfinden.
+
+### ADR-0044 — die Falle, die dieses Issue ausdrücklich nennt
+
+`docs/adr/0044-kalendertage-folgen-der-ortszeit.md:59-67`, wörtlich gemessen:
+
+```
+2026-03-29: gleiche tzinfo-Subtraktion=24.0  über UTC=23.0
+2026-10-25: gleiche tzinfo-Subtraktion=24.0  über UTC=25.0
+```
+
+> „Tragen zwei zeitzonenbehaftete Zeitpunkte dasselbe `tzinfo`-Objekt, rechnet Python auf den
+> nackten Wanduhr-Werten und ignoriert den Offset-Wechsel — an jedem Tag 24,0. Beide
+> Zeitpunkte müssen erst nach UTC umgerechnet werden, im Projekt über `local_dt(dt, UTC)`."
+
+Ebenda `:46-49`: „Jedes Tagesfenster muss seine Länge **berechnen** statt sie zu setzen. Eine
+Signatur mit `hours: int` ist damit falsch."
+
+### ADR-0051 (Status: **Vorgeschlagen**, nicht Akzeptiert)
+
+- **Regel 2:** „Die Zone gehört an die Daten, nicht an den Server."
+- **Regel 3:** „Keine Umgebungsuhr. `date.today()`, `datetime.now()` ohne `tz` … sind im
+  Produktivcode verboten. ‚Jetzt' wird als Zeitpunkt-Parameter hereingereicht."
+- `:89-95` beschreibt den Idempotenz-Schlüssel bereits wörtlich so, wie #1725 ihn verlangt.
+
+## 🔴 Wächter-Fallen beim Anfassen dieser Dateien
+
+`tests/test_output_timezone_guard.py` scannt seit #1723 auch `src/services/**` und `api/**` —
+`trip_report_scheduler.py` ist **doppelt** erfasst.
+
+- **Löst aus:** `date.today()` (immer), `datetime.now()` ohne `tz`, `ZoneInfo("<Zone ≠ UTC>")`,
+  rohes `x.astimezone(...)`.
+- **Löst nicht aus:** `local_dt(...)`/`local_hour(...)` aus `utils.timezone` (Datei ist vom
+  Scan ausgenommen, `:97-100`), `datetime.now(tz=...)`, `.utcnow()`, `ZoneInfo("UTC")`.
+- **🔴 Ordinal-Falle:** `KNOWN_VIOLATIONS`-Schlüssel sind `pfad::funktion::ordinal` — das
+  Ordinal ist die Position **innerhalb der Funktion**. `_send_trip_report_outcome::0` ist
+  gelistet (heute `:932`). Wird davor ein weiterer Treffer eingefügt, **verschiebt sich das
+  Ordinal des Altbestands, ohne dass ein Test rot wird** — die hinterlegte Begründung
+  beschreibt dann die falsche Stelle. Genau das ist in #1723 einmal passiert.
+
+## Test-Muster: Zeit wird hereingereicht, nicht gepatcht
+
+`tests/tdd/test_briefing_faelligkeit_ortszone.py:13-15`, `:87-98` — `_faellig(scheduler, now_utc)`
+ruft `_collect_due_trips(now_utc)` mit synthetisch konstruierten Zeitpunkten. `freeze_time`
+kommt nur vor, um im **Testcode** einen exakten Zeitpunkt zu erzeugen, der dann explizit
+weitergereicht wird (`tests/unit/test_trip_local_today.py:159-162`).
+
+### Der Test, der planmäßig rot wird
+
+`tests/tdd/test_briefing_faelligkeit_ortszone.py:312-348`
+(`test_ac7_sommerzeit_luecke_ist_gemessen_nicht_behauptet`) nagelt das heutige Fehlverhalten
+fest: `treffer_am(2026-03-29) == 0`, `treffer_am(2026-10-25) == 2`. Er schreitet den Ortstag
+korrekt von Ortsmitternacht zu Ortsmitternacht ab. Der Test-Docstring sagt selbst, dass #1725
+ihn rot macht und auf das Zielverhalten umzuschreiben hat.
+
+**🔴 Prüfort = Wirkort:** Dieser Test ruft **`_collect_due_trips`**, nicht den Versand. Sitzt
+der Idempotenz-Check nur in `_send_trip_report_outcome`, meldet die Sammlung nach der
+`>=`-Umstellung ab der konfigurierten Stunde **jede** Stunde bis Mitternacht als fällig, und
+dieser Test kann das nicht sehen. Der Check gehört in die Sammel-Phase.
+
+### Was an DST-Tests fehlt
+
+- `tests/unit/test_trip_local_today.py:145-199` prüft nur die **Stabilität des Kalendertags**
+  eine Minute vor/nach der Umstellung — nicht die Häufigkeit der Doppelstunde.
+- **Kein `fold`-Handling im Repo** (`grep` über `tests/`, `trip_day.py`, `utils/timezone.py`
+  ohne Treffer) — die doppelte Herbststunde wird nirgends disambiguiert.
+- **Kein Test mit `Australia/Lord_Howe`** — der 24,5-h-Fall existiert nur als Text in ADRs und
+  einem Docstring (`trip_command_processor.py:204-206`).
+
+## 🔴 Die Tick-Zustellung hat denselben Fehler — eine Ebene tiefer
+
+Nachgemessen am Bibliothekscode, nicht angenommen.
+
+- Der Go-Cron läuft in **einer prozessweiten Zone**: `cron.New(cron.WithLocation(loc))`
+  (`internal/scheduler/scheduler.go:112`), `loc = time.LoadLocation(cfg.SchedulerTimezone)`
+  (`:106`), `SchedulerTimezone` = `GZ_SCHEDULER_TIMEZONE`, **Default `Europe/Vienna`**
+  (`internal/config/config.go:20,52`). Im Worktree ist die Variable nirgends gesetzt.
+- `github.com/robfig/cron/v3 v3.0.1` (`go.mod:13`) sagt in der eigenen Doku
+  (`doc.go:169-170`): *„Be aware that jobs scheduled during daylight-savings leap-ahead
+  transitions will not be run!"* Die eigene Testsuite der Bibliothek belegt es für einen
+  stündlichen Job (`spec_test.go:117-121`, America/New_York 2012-03-11):
+  `01:00-0500` → next `03:00-0400` — **der 02:00-Slot fällt ersatzlos aus**. Umgekehrt
+  (`spec_test.go:139-141`) feuert er an der Rückstellung **zweimal**. Der Mechanismus in
+  `spec.go` (`Next()` über echte `time.Duration`-Addition) ist zonenunabhängig.
+
+**Folge:** An der Wiener Frühjahrs-Umstellung fehlt **eine Tick-Stunde für alle Nutzer
+weltweit** — auch für einen Trip in Auckland, wo an dem Tag gar keine Umstellung ist. Der
+Fehler ist damit nicht auf Trips in DST-Zonen beschränkt, wie das Issue annimmt.
+
+Genau das repariert die vorgeschlagene Lösung mit: Der nächste Tick sieht den Trip weiterhin
+als fällig (`ortsstunde >= konfigurierte_stunde`, kein Vermerk) und holt nach — **aber nur,
+wenn das Nachhol-Fenster mindestens eine Stunde zulässt.** Das ist ein starkes fachliches
+Argument in der offenen Frage 1.
+
+**Weitere Befunde derselben Ebene:**
+
+- **Go schickt keinen Zeitpunkt mit.** `triggerEndpointForUser` postet
+  `pythonURL + path + "?user_id=" + uid` (`scheduler.go:546-547`); der Parameter `at` in
+  `api/routers/scheduler.py:26` existiert, wird von Go aber nie befüllt — Python nimmt seine
+  **Ankunftszeit** (`:43-44`), nicht den Solltermin. Für eine `>=`-Prüfung ist das
+  unproblematisch, für die heutige `==`-Prüfung ist jede Verzögerung über die Stundengrenze
+  ein verlorener Slot.
+- **Kein Retry, kein Nachtrag.** Genau ein `client.Post` (`scheduler.go:547`), kein
+  Backoff-Loop. Fehler landen als `status:"error"` in `s.lastRuns` (`:519-523`); der Tick ist
+  weg. Overlap-Skip lässt `lastRuns[jobID]` **bewusst unverändert** (`:497`).
+- **Neustart holt nichts nach.** `lastRuns`/`overlapState` sind In-Memory (`:104-165`);
+  `cron.run()` berechnet `entry.Next` frisch ab dem aktuellen `now`.
+- **`last_run` taugt nicht zur Lückenerkennung.** `Status()` (`:676-736`) liest nur
+  `cron.Entries()` und die In-Memory-Map — keine Persistenz. Ein übersprungener Slot ist
+  darüber nicht von „war nicht fällig" unterscheidbar.
+
+### Andere Einstiegspunkte, die denselben Vermerk berühren
+
+| Pfad | Ort | Umgeht die Fälligkeitsprüfung |
+|---|---|---|
+| Manueller Test-Versand `POST /api/scheduler/trips/{id}/send` | `api/routers/scheduler.py:204-205,230-232` | ja (#695) |
+| Inbound-Kommando „heute"/„morgen" → `send_on_demand_report` | `src/services/trip_command_processor.py:575` | ja |
+| Inbound-Kommando „report" → `send_test_report` | `src/services/trip_command_processor.py:1018` | ja |
+| Legacy-CLI `--report morning/evening` | `src/app/cli.py` | eigener Pfad, laut CLAUDE.md kein Produktivpfad |
+
+**Fachliche Konsequenz:** Ein per SMS angefordertes „heute" darf dem Nutzer **nicht** sein
+reguläres Briefing wegnehmen — On-Demand-Versand darf also keinen Vermerk setzen. Das ist in
+der Spec zu entscheiden, nicht implizit zu lassen.
+
+## Compare-Pfad: getrennt, aber über ein gemeinsames Skelett erreichbar
+
+`CompareDispatchStrategy` (`dispatch_orchestrator.py:86-171`) hat eine **eigene**
+Fälligkeitsprüfung in `src/services/compare_slot_scheduler.py:102-156` (`presets_due_for_hour`)
+— mit derselben Stundengleichheit (`:152,154`) und der festen Zone
+`NOCH_NICHT_ORTSZEIT_SIEHE_1726 = "Europe/Vienna"` (`dispatch_orchestrator.py:117,134`).
+
+Geteilt ist nur das Skelett in `dispatch_orchestrator.py`: Strategie-Dispatch, `smtp_guard`,
+`pre_pass`-Hook, die `due`-Schleife, das `(sent, failed)`-Format.
+
+**🔴 Abgrenzung:** Änderungen in `trip_report_scheduler.py` berühren Compare strukturell
+nicht. Wandert der Idempotenz-Check dagegen als neuer Hook **ins Skelett** (etwa ein
+`already_sent(item)` vor `dispatch_one`), verändert er den Compare-Pfad automatisch mit —
+vor #1726 und ohne Nachweis. AC-8 von #1724 verlangt für Compare bit-identisches Verhalten.
+
+## Berührungspunkt mit offener Arbeit: #1557
+
+**#1557 ist offen:** Der Versand meldet `sent`, obwohl kein Wetter verfügbar war
+(erwartet: `no_weather` / HTTP 422). Ein Vermerk, der an `outcome == "sent"` hängt, hakt in
+diesem Fall ein inhaltlich leeres Briefing als erledigt ab — und der Nachholmechanismus,
+der genau dafür gedacht ist, greift nie. Die Spec muss das auflösen oder ausdrücklich
+abgrenzen.
+
+Immerhin: `_append_briefing_log` wird bereits **nur** bei `result.sent` und konfiguriertem
+Kanal geschrieben (`:1237-1246`) — das Sende-Protokoll ist an dieser Stelle ehrlicher als der
+Outcome-String.
+
+## Dependencies
+
+- **Upstream:** `trip_day.trip_local_now`/`trip_local_today`, `utils.timezone.local_dt`,
+  `_get_target_date`, `load_all_trips`, `get_data_dir`, `NotificationService.send_trip_report`.
+- **Downstream:** `dispatch_orchestrator.run_briefing_dispatch` (auch Compare),
+  `api/routers/scheduler.py`, Go-Seite `internal/store/log.go` +
+  `internal/handler/briefing_history.go` (liest `briefing_log.json` — **Schema-Parität nötig,
+  wenn ein Feld hinzukommt**), `internal/store/pending_briefings.go`.
+
+## Existing Specs & ADRs
+
+| Dokument | Bezug |
+|---|---|
+| `docs/specs/modules/fix_1724_faelligkeit_in_der_ortszone.md` | S2, direkte Vorlage; AC-7 ist der Test, der hier rot wird; AC-8 (Compare bit-identisch), AC-9 (ein `now_utc` für den ganzen Lauf) |
+| `docs/adr/0051-drei-zeitbegriffe-zone-an-den-daten.md` | Regeln 1–3; beschreibt den Schlüssel bereits wörtlich; Status **Vorgeschlagen** |
+| `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` | Ortstag-Definition, die `tzinfo`-Falle, „Tagesfenster berechnen statt setzen" |
+| `docs/analysis/zeitzonen-architektur-2026-08.md:132-157` | Herleitung der Scheibe, Umstellungstag-Messtabelle |
+| `docs/specs/modules/fix_1723_zeitzonen_waechter_entscheidung.md` | Wächter-Fläche und `KNOWN_VIOLATIONS`-Mechanik |
+
+## Risks & Considerations
+
+1. **`>=` ohne wirksamen Vermerk = stündlicher Serienversand** an echte Empfänger, inklusive
+   kostenpflichtiger Premium-SMS. Das ist die gefährlichste Änderung des Vorhabens; der
+   Vermerk muss **vor** der Umstellung stehen und in der Sammel-Phase greifen.
+2. **Prüfort = Wirkort** — siehe oben: Check in `_collect_due_trips`, nicht nur im Versand.
+3. **Nachhol-Fenster ist fachlich ungeklärt** (Issue lässt es offen). Ein Briefing, das um
+   23:00 Ortszeit eintrifft, ist wertlos bis irreführend.
+4. **Ein Vermerk-Speicher muss atomar und gesperrt schreiben** — Vorbild `throttle_store`,
+   aber mit umgekehrter Fehlerrichtung (s. Analyse: fail-closed statt fail-open).
+5. **Ordinal-Verschiebung im Zeitzonen-Wächter** (s.o.) — still, kein Test wird rot.
+6. **Compare-Pfad darf sich nicht mitverändern** (#1726, AC-8 aus #1724).
+7. 🔴 **`_process_pending_markers` ist der eigentliche Sprengsatz.**
+   `trip_report_scheduler.py:445-448` räumt den Nachliefer-Marker weg, sobald der Trip in
+   `due_trip_ids_now` steht. Mit `>=` und ohne wirksamen Filter steht dort **jede Stunde**
+   jeder Trip — der gesamte #1012-Nachliefermechanismus wird stillgelegt, ohne dass ein
+   Versand sichtbar schiefgeht. Erst in der Analyse gefunden.
+8. **Kein `fold`-Handling im Repo** — die doppelte Herbststunde ist bisher nirgends
+   disambiguiert; der Nachweis muss die Stundenhäufigkeit zählen, nicht Zeilen.
+9. **Mandantentrennung:** `get_data_dir(user_id="default")` und
+   `TripReportSchedulerService(user_id="default")` tragen beide einen `"default"`-Default —
+   jeder neue Speicherzugriff muss die echte `user_id` durchreichen.
+
+10. **Der Tick selbst fällt an Umstellungstagen aus** (s.o.) — für **alle** Nutzer, nicht nur
+    für Trips in DST-Zonen. Die Lösung deckt das mit ab, aber nur bei ausreichendem
+    Nachhol-Fenster.
+11. **Andere Einstiegspunkte** (Test-Versand, Inbound-Kommandos) umgehen die
+    Fälligkeitsprüfung heute vollständig — ihr Verhältnis zum Vermerk ist zu entscheiden.
+
+## Offene Fragen für die Spec (PO-Entscheid)
+
+1. **Wie weit darf nachgeholt werden?** Bis Ende des Ortstags, N Stunden, oder gar nicht?
+   Das Tick-Ergebnis oben verschiebt die Antwort: mindestens eine Stunde ist nötig, damit der
+   an Umstellungstagen ausfallende Cron-Tick überhaupt aufgefangen wird.
+2. **Welcher Outcome erzeugt den Vermerk?** Nur `sent` — oder auch `no_stage` (dauerhaft
+   nichts zu senden) und `no_channels` (Konfigurationsfrage, kein Datenproblem)?
+3. **Trägt `briefing_log.json` den Vermerk** (ein Feld mehr, Go-Parität, Härtung des
+   Schreibmusters) oder entsteht ein eigener Speicher?
+4. **Setzt ein On-Demand-Versand („heute" per SMS, Test-Versand) den Vermerk?** Vorschlag:
+   nein — sonst nimmt eine Nutzeranfrage dem Nutzer sein reguläres Briefing weg.
+
+---
+
+# Analysis
+
+**Typ:** Bug (Label `bug`, `area:trips`). Der Fehler entsteht durch die Verbesserung aus S2.
+
+## Technischer Ansatz
+
+### Der Check sitzt in der Sammel-Phase
+
+`_collect_due_trips(self, now_utc) -> List[Tuple[Trip, str, date]]` — das dritte Element ist
+der **Ortstag des Laufs** (`trip_local_today(trip, now_utc)`), ausdrücklich **nicht**
+`target_date` (bei `evening` ist das Ortstag + 1, `trip_report_scheduler.py:709-713`).
+
+Drei unabhängige Gründe gegen einen Check erst im Versand:
+
+1. Prüfort = Wirkort — der bestehende Test ruft `_collect_due_trips`
+   (`tests/tdd/test_briefing_faelligkeit_ortszone.py:93`).
+2. `run_briefing_dispatch` schläft **2,0 s je Element** (`dispatch_orchestrator.py:216-219`);
+   eine unehrliche `due`-Liste kostet reale Laufzeit.
+3. `pre_pass` konsumiert `due_trip_ids_now` (`dispatch_orchestrator.py:64-66`) → Risiko 7.
+
+Nebenbefund zu AC-9: `_send_trip_report_outcome` liest bei `:905` seine **eigene** Uhr. Bei
+2 s/Element und Mitternachtsnähe kann der dort abgeleitete Tag vom Sammelzeitpunkt abweichen.
+Wird der Schlüssel im Sammellauf gebildet und mitgereicht, ist die Drift für die Idempotenz
+wirkungslos. `:905` selbst bleibt unangetastet (gehört zu #1726).
+
+### Eigener Speicher: `data/users/<uid>/briefing_slots.json`
+
+Schema: `{"entries": [{"trip_id", "slot", "local_day", "recorded_at", "outcome"}]}`
+
+`briefing_log.json` scheidet aus, weil #1007 F001 Einträge mit `channels=[]` verbietet
+(`:1234-1246`) — sonst täuscht die Cockpit-Kachel #393 einen Versand vor. Vier der fünf
+Vermerk-Fälle haben keine Kanäle. Es sind **zwei verschiedene Aussagen**: „wurde zugestellt"
+(Protokoll) gegen „Slot ist abgearbeitet" (Quittung).
+
+- **Schreibmuster** nach `throttle_store._update()` (`:116-158`): `fcntl` über
+  `services.file_lock.acquire_exclusive` (`file_lock.py:28`), `tempfile` + `os.replace`,
+  Sperre auf einer Sidecar-Datei.
+- 🔴 **Aber mit umgekehrter Fehlerrichtung.** `throttle_store` ist bei Sperren-Timeout
+  **fail-open** (`:139-150`). Für eine Idempotenz-Quittung heißt „nicht geschrieben"
+  = Doppelversand in der nächsten Stunde, inklusive kostenpflichtiger Premium-SMS. Der neue
+  Speicher ist **fail-closed**: gelingt die Reservierung nicht, wird nicht gesendet.
+- **reserve-then-release:** Vermerk **vor** dem Versand schreiben, nur bei
+  `channels_unreachable` oder Ausnahme zurücknehmen. Stirbt der Prozess mitten im Versand,
+  bleibt der Vermerk stehen — nie doppelt.
+- **Keine Migration** (Datei existiert noch nicht), stattdessen **Rückwärts-Ableitung beim
+  Lesen**: fehlt ein Vermerk, gilt der Slot als erledigt, wenn `briefing_log.json` einen
+  Eintrag mit passendem `trip_id` + `kind` trägt, dessen `sent_at` in den Ortstag fällt.
+  Beseitigt den einzigen echten Doppelversand-Fall: den Deploy mitten im Nachhol-Fenster.
+
+### Nachhol-Fenster: 3 Stunden
+
+Bedingung: `konfigurierte_stunde <= ortsstunde < konfigurierte_stunde + 3`.
+
+| Option | Trade-off |
+|---|---|
+| bis Ende des Ortstags | Fängt jeden Ausfall — aber Morgen-Briefing um 23:00. Schlimmer: ein neu angelegter oder aus `paused_until` (`:671-677`) zurückkehrender Trip feuert **rückwirkend**, weil `_get_active_trips` nur die Etappe prüft (`:656-657`) |
+| **N = 3 Stunden** | Deckt den ausfallenden Cron-Tick (1 h) mit Reserve für einen gescheiterten HTTP-Post ohne Retry (`scheduler.go:547`). Rückwirkendes Feuern strukturell ausgeschlossen. Eine Konstante, in beide Richtungen testbar |
+| bis zum nächsten Slot | Bei nur aktiviertem Morgen-Slot degeneriert es zur ersten Option — zwei Slot-Konfigurationen, zwei Verhalten |
+
+Eine Deckelung am Tagesende erübrigt sich: für Slot 22 sind es die Ortsstunden 22 und 23; ab
+Ortsmitternacht wechselt der Ortstag und `0 >= 22` ist falsch. **DST fällt korrekt aus:**
+Frühjahr, Slot 02:00 → Ortsstunde 03 erfüllt `3 >= 2 and 3 < 5` → genau einmal. Herbst,
+Ortsstunde 02 doppelt → erstes Vorkommen vermerkt, zweites gefiltert → genau einmal.
+
+### Vermerk je Outcome
+
+| Outcome | Vermerk | Begründung |
+|---|---|---|
+| `sent` (`:1303`) | **ja** | zugestellt |
+| `no_stage` (`:921`) | **ja** | nichts zu senden; Wiederholen ändert nichts |
+| `no_weather` (`:1028`) | **ja** | 🔴 **Umkehrung der ursprünglichen Annahme.** Ohne Vermerk: stündliche „keine Daten"-Hinweis-Mail (`:1010`), stündlicher voller Wetterabruf (Kontingent #1329) — und der #1012-Marker wird jede Stunde weggeräumt (`:445-448`). Die Nachholung für diesen Fall **existiert bereits** und ist getestet (`:470-497`): der Marker prüft stündlich, ob die Daten da sind, und liefert mit Präfix nach. Zwei konkurrierende Wiederholpfade wären der Fehler |
+| `no_channels` (`:1287-1290`) | **ja** | Konfigurationszustand, ändert sich nicht binnen Stunden. Der Wetterabruf läuft **vor** dieser Prüfung — ohne Vermerk verbrennt das dreimal Kontingent für nichts |
+| `channels_unreachable` (`:1291-1302`) | **nein** | genau der Nachholfall. Kein Doppelversand möglich: per Definition hat niemand etwas bekommen (`sent = bool(sent_channels)`) |
+| Ausnahme (`:1204-1209`) | **nein** | fällt durch reserve-then-release automatisch heraus |
+
+**Gegen #1557 indifferent:** Meldet der Versand fälschlich `sent` statt `no_weather`, führen
+beide Zweige zum selben Ergebnis — Vermerk gesetzt, Nachholung über den Pending-Marker. Eine
+Regel „Vermerk nur bei `sent`" wäre es nicht: sie hakte unter #1557 ein inhaltsleeres
+Briefing als erledigt ab **und** schriebe keinen Marker.
+
+### Compare bleibt unberührt
+
+**Sicher:** `trip_report_scheduler.py` · `TripDispatchStrategy`
+(`dispatch_orchestrator.py:35-83`) · neues Modul `briefing_slots.py`.
+
+**Verboten:** jeder neue Hook in `run_briefing_dispatch` (`:180-221`), insbesondere ein
+`already_sent(item)` vor `dispatch_one` (`:212`) · eine gemeinsame Basisklasse für beide
+Strategien · `compare_slot_scheduler.presets_due_for_hour` (`:102-156`) — das ist #1726.
+
+Nötig sind exakt zwei Zeilen in `dispatch_orchestrator.py`, beide **innerhalb** von
+`TripDispatchStrategy`: `pre_pass` (`:65`, 3-Tupel-Entpackung) und `dispatch_one` (`:74`).
+
+### On-Demand-Pfade: weder lesen noch schreiben
+
+Test-Versand (`api/routers/scheduler.py:230`), „heute"/„morgen"
+(`trip_report_scheduler.py:822`), „report" (`:774`), Legacy-CLI ignorieren den Vermerk
+vollständig — nicht schreiben (sonst nimmt eine Nutzeranfrage das reguläre Briefing weg),
+nicht lesen (sonst ist der Test-Knopf nach dem regulären Versand tot).
+
+**Kein Flag nötig:** Sitzt der Vermerk in einem neuen Wrapper `_dispatch_due_item()`, der nur
+von `TripDispatchStrategy.dispatch_one` gerufen wird, entsteht die Trennung durch den
+**Aufrufer**.
+
+## Affected Files
+
+| Datei | Art | Produktiv-LoC |
+|---|---|---|
+| `src/services/briefing_slots.py` | CREATE | ~110 |
+| `src/services/trip_report_scheduler.py` | MODIFY | ~55 |
+| `src/services/dispatch_orchestrator.py` | MODIFY | ~6 |
+| `tests/tdd/test_briefing_slot_idempotenz.py` | CREATE | zählt nicht |
+| `tests/tdd/test_briefing_faelligkeit_ortszone.py` | MODIFY (AC-7 umschreiben) | zählt nicht |
+
+**Summe ≈ 170 / 250 LoC.** Reicht, aber nicht komfortabel. Schnittkante bei Überlauf:
+Retention/Prune (~20 LoC) in eine zweite Scheibe. **Nicht** herausschneiden:
+Rückwärts-Ableitung und fail-closed-Sperre.
+
+**Kein `KNOWN_VIOLATIONS`-Eintrag, keine Ordinal-Verschiebung:** `_collect_due_trips` bekommt
+nur `trip_local_now`/`trip_local_today` (ausgenommen), der Wrapper ist ein eigener
+Funktionsraum, und `briefing_slots.py` bleibt sauber, solange es `datetime.now(tz=...)`
+benutzt und kein `ZoneInfo("<Zone>")`/rohes `.astimezone()`.
+
+## Risk Level: HIGH — entschärft durch die Schnittführung
+
+**Der gefährliche Zustand `>=` ohne wirksamen Vermerk wird durch zwei Commits in einem PR
+unerreichbar:**
+
+- **Commit A:** neuer Speicher + Rückwärts-Ableitung + Vermerk wird geschrieben und gefiltert
+  — **Fälligkeit bleibt `==`**. Verhaltensneutral, weil ein Slot bei `==` ohnehin genau
+  einmal feuert; der Filter ist ein No-op. Der Schreibpfad ist danach bewiesen.
+- **Commit B:** `==` → `>=` + 3-h-Fenster (`:372,375`).
+
+Jeder Zwischenstand ist auslieferbar; Revert oder Bisect landet nie im gefährlichen Zustand.
+
+Weitere Risiken:
+
+- **`skip_next` wird in `_get_active_trips` (`:678-683`) bei jedem Sammellauf konsumiert**,
+  unabhängig von der Fälligkeit. Bleibt unverändert, **solange der Filter nach
+  `_get_active_trips` sitzt**. Wer ihn zum Sparen davorzieht, ändert `skip_next` still mit.
+- **Kontingent:** `channels_unreachable` zieht bis zu drei Wetterabrufe statt einem (#1329).
+  Bewusst, begrenzt.
+- **`data/` muss untracked bleiben** — die neue Datei nie committen.
+
+## Nachweis-Strategie
+
+Neue Datei `tests/tdd/test_briefing_slot_idempotenz.py` (Verhaltensname, nicht Issue-Nummer —
+`test_naming_gate.py` blockt sonst). Zeit durchgehend als Parameter.
+
+🔴 **Die Falle vorweg:** Bei funktionierendem Vermerk liefert **jede** Fensterbreite an einem
+normalen Tag genau einen Treffer. Ein Test, der nur Treffer zählt, kann die Fensterbreite
+**nicht sehen** — sie ist nur an einem ausgefallenen Tick beobachtbar (T4).
+
+| # | Testfall | Verfälschung, die ihn rot macht |
+|---|---|---|
+| T1 | Europe/Paris, `morning=02:00`, 2026-03-29, Ortstag abgeschritten → **genau 1** | `>=` zurück auf `==` → 0 |
+| T2 | dito 2026-10-25 (Doppelstunde) → **genau 1** | Vermerk-Filter entfernen → 2 |
+| T3 | Normaler Tag, **jede einzelne Ortsstunde** gezählt → nur Stunde 07 trifft | Fälligkeit auf `<=` drehen → 8 Treffer |
+| **T4** | **Tick-Ausfall:** Stunde H auslassen, dann H+1 → fällig; H+3 → nicht fällig | Fenster 3→1 macht Teil 1 rot, 3→„bis Tagesende" macht Teil 2 rot. **Einziger Test, der die Fensterbreite in beide Richtungen festnagelt** |
+| T5 | `morning=07:00` **und** `evening=07:00` → beide fällig in derselben Stunde | `slot` aus dem Schlüssel entfernen → nur einer |
+| T6 | Zwei aufeinanderfolgende Ortstage → an beiden fällig | `local_day` aus dem Schlüssel entfernen → Tag 2 stumm |
+| T7 | Zwei Trips, gleiche Zone, gleiche Stunde → beide fällig | `trip_id` aus dem Schlüssel entfernen → nur einer |
+| T8 | Outcome-Matrix: vier setzen Vermerk, `channels_unreachable` nicht → nächste Stunde erneut fällig | `channels_unreachable` in die Vermerk-Menge schieben → rot |
+| T9 | `briefing_slots.json` fehlt, `briefing_log.json` trägt passenden Eintrag im Ortstag → **nicht** fällig | Rückwärts-Ableitung entfernen → fällig (Doppelversand beim Deploy) |
+| T10 | Trip mit Etappe heute, `morning=07:00`, erstmals um Ortsstunde 20 ausgewertet → **nicht** fällig | Fenster → „bis Tagesende" → fällig |
+| **T11** | `CompareDispatchStrategy.collect_due` über 24 h unverändert (AC-8 aus #1724) | Filter ins geteilte Skelett verschieben → Compare-Zahl ändert sich |
+| **T12** | Nach `send_on_demand_report` ist der reguläre Slot zur Stunde H **weiterhin** fällig | Vermerk in `_send_trip_report_outcome` statt in den Wrapper → rot |
+| T13 | Sperre nicht erhältlich → **kein** Versand statt Versand ohne Vermerk | fail-open wie `throttle_store:139-150` → rot |
+| T14 | `Australia/Lord_Howe` (24,5 h): Ortsstundenfolge ohne Loch und ohne Dopplung → unauffällig | schließt die notierte Repo-Lücke |
+
+**Ausdrücklich markierte Lücke — T13:** ein mockfreier Aufbau (gehaltener `flock`-fd im
+selben Prozess, verkürztes `LOCK_TIMEOUT_SECONDS`) gilt als machbar, ist aber **nicht
+verifiziert**. Falls teuer, trotzdem als Kern-Test bauen — die Fehlerrichtung ist die
+sicherheitskritischste Einzelentscheidung des Vorhabens.
+
+**`fold` wird nicht gebraucht:** Es wird nie eine mehrdeutige Wanduhrzeit konstruiert; die
+Ortsstunde entsteht immer aus einem eindeutigen UTC-Zeitpunkt (`trip_day.py:74`). Die
+Doppelstunde erscheint als zwei unterscheidbare UTC-Zeitpunkte und wird vom Vermerk getrennt.
+
+## Umsetzungsreihenfolge
+
+1. Spec + PO-Freigabe (drei Entscheidungen: Fenster 3 h, Outcome-Matrix, On-Demand)
+2. RED: T1–T14; `test_briefing_faelligkeit_ortszone.py:312-348` auf 1/1 statt 0/2 umschreiben
+3. Commit A (GREEN, verhaltensneutral), Fälligkeit bleibt `==`
+4. Commit B: `==` → `>=` + `NACHHOL_FENSTER_STUNDEN = 3`
+5. Adversary mit Pflichtmutationen: Fenster 3→1 und 3→24 · Schlüssel um je ein Glied kürzen ·
+   Filter ins geteilte Skelett verschieben · Vermerk nach `_send_trip_report_outcome` verlegen
+6. Ein PR, zwei Commits, A vor B

--- a/docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md
+++ b/docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md
@@ -1,0 +1,442 @@
+---
+entity_id: fix_1725_faelligkeit_und_idempotenz
+type: bugfix
+created: 2026-08-11
+updated: 2026-08-11
+status: draft
+workflow: fix-1725-faelligkeit-idempotenz
+version: "1.0"
+tags: [issue-1725, epic-1722, timezone, adr-0051, adr-0044, scheduler, briefing, idempotenz]
+---
+
+# Fix #1725 — Briefing-Fälligkeit als Fenster + Idempotenz-Schlüssel
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Die Fälligkeitsprüfung des Trip-Briefings vergleicht heute zwei Stunden auf **Gleichheit**:
+`self._get_morning_hour(trip) == self._trip_local_hour(trip, now_utc)` bzw. dieselbe Prüfung
+für den Abend-Slot (`src/services/trip_report_scheduler.py:372,375`). Das setzt voraus, dass
+jede Ortsstunde eines Tages genau einmal existiert. An Zeitumstellungstagen stimmt das nicht:
+am Frühjahrstag fehlt eine Ortsstunde ersatzlos (ein auf 02:00 gestelltes Briefing entfällt),
+am Herbsttag existiert sie zweimal (das Briefing geht zweimal raus). Ursache ist zusätzlich,
+dass der stündliche Go-Cron-Tick an genau diesen Tagen selbst eine Stunde auslässt bzw.
+verdoppelt (`internal/scheduler/scheduler.go:112`, Bibliotheksverhalten von
+`robfig/cron/v3`) — unabhängig von der Trip-Zone, weltweit für alle Nutzer.
+
+Diese Spec ersetzt die Gleichheitsprüfung durch ein **Fälligkeitsfenster** von 3 Stunden
+kombiniert mit einem **Idempotenz-Schlüssel** `(trip_id, ortstag, slot)`: ein Trip ist fällig,
+solange die Ortsstunde die konfigurierte Stunde erreicht oder überschritten hat, aber noch
+innerhalb des Fensters liegt, UND für den Schlüssel noch kein Vermerk existiert. Der Fehler
+entsteht **erst durch die Verbesserung aus #1724 (S2)** — vorher lief die Rechnung in einer
+festen Zone und war damit zufällig umstellungs-immun.
+
+## Source
+
+- **File:** `src/services/trip_report_scheduler.py`
+- **Identifier:** `_collect_due_trips`, `_send_trip_report_outcome`
+- Epic #1722, Kontext-Dokument `docs/context/fix-1725-faelligkeit-idempotenz.md`
+- ADR-0051 (drei Zeitbegriffe, Zone an den Daten — Status Vorgeschlagen), ADR-0044
+  (Kalendertag folgt der Ortszeit)
+- Setzt voraus: #1724 (S2), live seit `e21f4f48`
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `docs/specs/modules/fix_1724_faelligkeit_in_der_ortszone.md` | spec | Direkte Vorlage; AC-7 dort ist der Test, der hier planmäßig auf Zielverhalten umgeschrieben wird; AC-8 (Compare bit-identisch), AC-9 (ein `now_utc` je Lauf) gelten unverändert fort |
+| `src/services/trip_day.py` (`trip_local_now`, `trip_local_today`) | module | Liefert Ortsstunde und Ortstag; unverändert genutzt, kein zweiter Auflöser |
+| `src/services/dispatch_orchestrator.py` (`TripDispatchStrategy`) | module | Aufrufkette `collect_due` → `pre_pass` → `dispatch_one`; hier docken die zwei neuen Zeilen an |
+| `src/services/throttle_store.py` | module | Vorbild für Schreibmuster (`fcntl`-Lock + `tempfile`+`os.replace`); Fehlerrichtung wird bewusst **umgekehrt** (fail-closed statt fail-open) |
+| `internal/store/log.go`, `internal/handler/briefing_history.go`, `internal/handler/cockpit.go` | Go | Lesen `briefing_log.json` nur; keine Schema-Änderung an dieser Datei nötig, da der Vermerk in einem eigenen Speicher entsteht |
+| ADR-0051, ADR-0044 | adr | Regelgrundlage; siehe „Architektur-Entscheidung" unten |
+
+## Scope
+
+### Affected Files
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `src/services/briefing_slots.py` | CREATE | Neuer Speicher `data/users/<uid>/briefing_slots.json`: reserve-then-release, `fcntl`-Lock, atomarer Schreibvorgang (`tempfile`+`os.replace`), fail-closed bei Sperren-Timeout, Rückwärts-Ableitung aus `briefing_log.json` beim ersten Lesen ohne eigene Datei |
+| `src/services/trip_report_scheduler.py` | MODIFY | `_collect_due_trips`: Gleichheit → Fensterbedingung + Vermerk-Filter; neuer Wrapper `_dispatch_due_item()` um `_send_trip_report_outcome`, der den Vermerk je nach Outcome setzt |
+| `src/services/dispatch_orchestrator.py` | MODIFY | Zwei Zeilen **innerhalb** `TripDispatchStrategy`: `pre_pass` (3-Tupel-Entpackung unverändert) und `dispatch_one` ruft den neuen Wrapper statt direkt `_send_trip_report_outcome` |
+| `tests/tdd/test_briefing_slot_idempotenz.py` | CREATE | T1–T14, Verhaltensname statt Issue-Nummer (`test_naming_gate.py`) |
+| `tests/tdd/test_briefing_faelligkeit_ortszone.py` | MODIFY | AC-7-Test (`:312-348`) wird von „0 Treffer / 2 Treffer" auf „1 Treffer / 1 Treffer" umgeschrieben — planmäßiges RED dieser Datei ist Teil des Vorhabens |
+
+### Estimated Changes
+
+- Files: 5 (3 Produktivcode, 2 Tests)
+- LoC: ~170 Produktivcode (`briefing_slots.py` ~110, `trip_report_scheduler.py` ~55,
+  `dispatch_orchestrator.py` ~6); Testcode zählt nicht gegen das Limit von 250
+
+## Problem/Kontext
+
+Der heutige Vergleich prüft **Stundengleichheit**, nicht **Fälligkeit**. Das war unauffällig,
+solange die Uhr eine feste Zone (Wien) war — mit #1724 läuft sie nun je Trip in dessen
+Ortszone, und dort existiert die Ortsstunde an Umstellungstagen nicht immer genau einmal:
+
+- **Frühjahr** (Europe/Paris, 2026-03-29): Ortsstunde 02 existiert nicht. Ein auf 02:00
+  gestelltes Briefing wird an diesem Tag **nie** fällig — heute: 0 Treffer.
+- **Herbst** (2026-10-25): Ortsstunde 02 existiert zweimal. Dasselbe Briefing wird **zweimal**
+  fällig — heute: 2 Treffer, doppelter Versand an echte Empfänger.
+
+Ein zweiter, unabhängiger Fehler auf derselben Ebene: Der Go-Cron läuft in einer
+**prozessweiten** Zone (`GZ_SCHEDULER_TIMEZONE`, Default `Europe/Vienna`,
+`internal/config/config.go:20,52`) und nutzt `robfig/cron/v3`, dessen eigene Dokumentation
+und Testsuite belegen, dass ein stündlicher Job an der Frühjahrs-Umstellung eine Stunde
+**auslässt** und an der Herbst-Umstellung **zweimal** feuert
+(`scheduler.go:112`; Bibliotheks-`spec_test.go:117-121,139-141`). Das betrifft **alle**
+Nutzer weltweit an diesem Tag, nicht nur Trips in DST-Zonen — auch ein Trip in Auckland
+verliert an diesem Tag einen Tick.
+
+Heute existiert **kein** Fälligkeits-Idempotenz-Schutz überhaupt: Ein zweiter Lauf in
+derselben Stunde (Neustart, manueller Trigger) hätte keinen Schutz gegen Doppelversand. Der
+einzige Schutz ist strukturell, dass der Cron einmal pro Stunde feuert.
+
+## Ziel
+
+Fälligkeit wird durch ein **Fenster + Idempotenz-Schlüssel** ersetzt:
+
+```
+fällig ⟺ konfigurierte_stunde <= ortsstunde < konfigurierte_stunde + 3
+          UND kein Vermerk für (trip_id, ortstag, slot)
+```
+
+Das erreicht drei Dinge gleichzeitig:
+
+1. **Frühjahr korrekt:** Ortsstunde springt von 01 auf 03 (die 02 existiert nicht); 03 erfüllt
+   `3 >= 2 and 3 < 5` → genau ein Treffer statt keinem.
+2. **Herbst korrekt:** Ortsstunde 02 kommt zweimal vor; das erste Vorkommen setzt den Vermerk,
+   das zweite wird durch ihn gefiltert → genau ein Treffer statt zwei.
+3. **Ausgefallener Cron-Tick wird aufgefangen:** Verpasst der Tick eine Stunde (Umstellungstag,
+   gescheiterter HTTP-Post ohne Retry, `scheduler.go:547`), sieht der nächste Lauf den Trip
+   weiterhin als fällig, solange er innerhalb der 3 Stunden liegt.
+
+## Nicht-Ziele (Abgrenzung)
+
+- **Der Ortsvergleichs-Pfad wird nicht umgestellt.** `CompareDispatchStrategy.collect_due`
+  (`dispatch_orchestrator.py:86-171`) behält seine eigene Stundengleichheit
+  (`compare_slot_scheduler.py:152,154`) und die feste Zone
+  `NOCH_NICHT_ORTSZEIT_SIEHE_1726 = "Europe/Vienna"` — das ist #1726. AC-8 aus #1724 (bit-
+  identisches Compare-Verhalten) gilt fort und wird hier erneut nachgewiesen (AC-11/T11).
+- **`_send_trip_report_outcome:905` liest weiter seine eigene Uhr**, statt den im Sammellauf
+  gebildeten Zeitpunkt zu übernehmen. Das ist bekannte Drift zwischen Sammel- und
+  Versandzeitpunkt (2,0 s Pause je Element, `dispatch_orchestrator.py:216-219`) und gehört zu
+  #1726. Für die Idempotenz ist sie wirkungslos, weil der Schlüssel bereits im Sammellauf
+  gebildet und durchgereicht wird.
+- **#1557 wird nicht behoben.** Der Versand meldet dort fälschlich `sent`, obwohl kein Wetter
+  verfügbar war (erwartet: `no_weather`). Die hier getroffene Outcome-Wahl ist gegen diesen
+  Fehler **indifferent**: `sent` und `no_weather` landen beide in der Vermerk-Menge (siehe
+  Entwurf unten), also führt eine Fehlklassifikation zwischen den beiden zum selben Ergebnis.
+  Eine Regel „Vermerk nur bei `sent`" wäre es **nicht** — sie würde unter #1557 ein
+  inhaltsleeres Briefing als erledigt abhaken UND zusätzlich keinen Marker schreiben, also
+  auch die Nachholung über den Pending-Marker verhindern.
+- **Der ausfallende Go-Cron-Tick wird nicht repariert**, sondern durch das Nachhol-Fenster
+  **aufgefangen**. Eine Behebung in `robfig/cron` oder ein eigener Nachtrag-Mechanismus auf
+  Go-Seite ist nicht Teil dieser Scheibe.
+- **Retention/Prune für `briefing_slots.json`** ist nicht Teil dieser Scheibe. Die Datei wächst
+  unbegrenzt; Bereinigung folgt als eigene, kleine Nachfolge-Arbeit (siehe Known Limitations).
+
+## Entwurf/Umbau
+
+### Prüfort = Wirkort: Check in der Sammel-Phase, nicht im Versand
+
+Der Fälligkeits- und Vermerk-Filter sitzt in `_collect_due_trips`
+(`trip_report_scheduler.py`), nicht erst in `_send_trip_report_outcome`. Drei Gründe:
+
+1. Der bestehende Test aus #1724 ruft `_collect_due_trips` direkt
+   (`tests/tdd/test_briefing_faelligkeit_ortszone.py:93`) — Prüfort und Wirkort müssen
+   übereinstimmen.
+2. `run_briefing_dispatch` schläft 2,0 s je Element der `due`-Liste
+   (`dispatch_orchestrator.py:216-219`); eine unehrlich lange Liste kostet reale Laufzeit.
+3. `_process_pending_markers` (`trip_report_scheduler.py:445-448`) räumt den #1012-
+   Nachliefer-Marker weg, sobald der Trip in `due_trip_ids_now` steht. Stünde dort mit `>=`
+   ohne Filter **jede Stunde** jeder Trip, würde der gesamte Nachliefermechanismus lautlos
+   stillgelegt — ohne dass ein sichtbarer Versandfehler entsteht.
+
+### Eigener Speicher statt Wiederverwendung
+
+`briefing_log.json` scheidet als Träger aus: #1007 F001 verbietet dort Einträge mit
+`channels=[]` (`:1234-1246`), weil sonst die Cockpit-Kachel #393 einen Versand vortäuscht —
+vier der fünf Vermerk-Fälle (`no_stage`, `no_weather`, `no_channels`, Ausnahme) haben aber
+keine Kanäle. `throttle_state.json` ist semantisch fremd (Cooldown-Fenster, kein
+Slot-Schlüssel) und **fail-open** bei Sperren-Timeout — für eine Idempotenz-Quittung wäre das
+die falsche Fehlerrichtung. `pending_briefings.json` ist eine Warteschlange offener Arbeit, die
+nach Auflösung **verschwindet** — kein Sende-Protokoll.
+
+Es entsteht `data/users/<uid>/briefing_slots.json`, Schema
+`{"entries": [{"trip_id", "slot", "local_day", "recorded_at", "outcome"}]}`:
+
+- **Schreibmuster** wie `throttle_store._update()`: `fcntl`-Lock über
+  `services.file_lock.acquire_exclusive`, `tempfile`+`os.replace`.
+- 🔴 **Fehlerrichtung umgekehrt:** `throttle_store` ist fail-open, weil ein zu grober Cooldown
+  nur einen doppelten Hinweis kostet. Hier heißt „Sperre nicht erhalten" = potenzieller
+  Doppelversand, inklusive kostenpflichtiger Premium-SMS — also **fail-closed**: gelingt die
+  Reservierung nicht, wird **nicht** gesendet (AC-13).
+- **Reserve-then-release:** Der Vermerk wird **vor** dem Versandversuch geschrieben und nur bei
+  `channels_unreachable` oder einer Ausnahme wieder zurückgenommen. Stirbt der Prozess mitten
+  im Versand, bleibt der Vermerk stehen — nie doppelt, im schlimmsten Fall ein ausgelassener
+  Slot, der über das Nachhol-Fenster in der nächsten Stunde erneut versucht wird (sofern noch
+  im Fenster).
+- **Keine Migration nötig** (Datei existiert noch nicht). Stattdessen **Rückwärts-Ableitung
+  beim ersten Lesen ohne eigene Datei:** fehlt ein Vermerk in `briefing_slots.json`, gilt der
+  Slot als bereits erledigt, wenn `briefing_log.json` einen Eintrag mit passender `trip_id` +
+  `kind` (= Slot) trägt, dessen `sent_at` in den aktuellen Ortstag fällt. Das verhindert den
+  einzigen realistischen Doppelversand-Fall: ein Deploy mitten im Nachhol-Fenster.
+
+### Vermerk je Outcome
+
+| Outcome | Vermerk | Begründung |
+|---|---|---|
+| `sent` | ja | zugestellt |
+| `no_stage` | ja | nichts zu senden; ein Wiederholungsversuch ändert daran nichts |
+| `no_weather` | ja | Ohne Vermerk: stündliche „keine Daten"-Mail, stündlicher voller Wetterabruf (Kontingent #1329) — der bestehende #1012-Pending-Marker deckt die Nachholung bereits ab; ein zweiter, konkurrierender Wiederholpfad wäre der Fehler |
+| `no_channels` | ja | Konfigurationszustand, ändert sich nicht binnen Stunden; der Wetterabruf läuft **vor** dieser Prüfung, ohne Vermerk verbrennt das Kontingent für nichts |
+| `channels_unreachable` | **nein** | genau der beabsichtigte Nachholfall — per Definition (`sent=bool(sent_channels)`) hat niemand etwas bekommen |
+| Ausnahme | nein | fällt durch reserve-then-release automatisch heraus |
+
+### Nachhol-Fenster: 3 Stunden
+
+`konfigurierte_stunde <= ortsstunde < konfigurierte_stunde + 3`. Deckt den ausfallenden
+Cron-Tick (1 Stunde) mit Reserve für einen gescheiterten, nicht wiederholten HTTP-Post. Eine
+Deckelung am Tagesende ist nicht nötig: für Slot 22 sind es die Ortsstunden 22 und 23; ab
+Ortsmitternacht wechselt der Ortstag, und `0 >= 22` ist falsch. Eine Alternative „bis Tagesende"
+wurde verworfen, weil sie neu angelegte oder aus `paused_until` zurückkehrende Trips
+**rückwirkend** feuern ließe — `_get_active_trips` (`:656-657`) prüft nur die Etappe, nicht das
+Anlagedatum (AC-10).
+
+### Compare bleibt unberührt
+
+Geändert werden ausschließlich `trip_report_scheduler.py`, `TripDispatchStrategy`
+(`dispatch_orchestrator.py:35-83`) und das neue Modul `briefing_slots.py`. **Verboten:** jeder
+neue Hook im geteilten Skelett von `run_briefing_dispatch` (`:180-221`, insbesondere ein
+`already_sent(item)` vor `dispatch_one:212`), eine gemeinsame Basisklasse für beide Strategien,
+oder ein Antasten von `compare_slot_scheduler.presets_due_for_hour` — das ist #1726.
+
+### On-Demand-Pfade: weder lesen noch schreiben
+
+Manueller Test-Versand (`api/routers/scheduler.py:230`), Inbound-Kommandos „heute"/„morgen"
+(`trip_command_processor.py:575`) und „report" (`:1018`) sowie die Legacy-CLI berühren den
+Vermerk nicht: nicht schreiben (sonst nimmt eine Nutzeranfrage dem Nutzer sein reguläres
+Briefing weg), nicht lesen (sonst wäre der Test-Knopf nach dem regulären Versand tot). Die
+Trennung entsteht über den **Aufrufer**: Der Vermerk sitzt in einem neuen Wrapper
+`_dispatch_due_item()`, der ausschließlich von `TripDispatchStrategy.dispatch_one` gerufen
+wird — kein zusätzliches Flag nötig (AC-12).
+
+### Zwei Commits in einem PR — der gefährliche Zustand wird unerreichbar
+
+Der riskanteste Zwischenschritt wäre `>=` **ohne** wirksamen Vermerk: das führt zu
+stündlichem Serienversand an echte Empfänger, inklusive kostenpflichtiger Premium-SMS. Die
+Umsetzung wird deshalb in zwei Commits geschnitten, beide im selben PR:
+
+- **Commit A (verhaltensneutral):** Speicher, Rückwärts-Ableitung und Vermerk-Filter werden
+  gebaut und in `_collect_due_trips` verdrahtet — **die Fälligkeit bleibt `==`**. Ein Slot
+  feuert bei `==` ohnehin genau einmal, der neue Filter ist dabei ein No-op. Der Schreibpfad
+  ist nach diesem Commit bewiesen (T1/T2/T5-T14 laufen bereits gegen ihn, soweit sie nicht die
+  Fensterbreite selbst prüfen).
+- **Commit B (Verhaltensänderung):** `==` wird zu `>=` mit `NACHHOL_FENSTER_STUNDEN = 3`
+  (`:372,375`).
+
+Weil Commit A den Vermerk bereits scharf schaltet, bevor Commit B die Fensteröffnung vornimmt,
+ist jeder Zwischenstand auslieferbar — ein Revert oder ein Bisect zwischen den beiden Commits
+landet nie im gefährlichen Zustand „offenes Fenster ohne Schutz".
+
+## Acceptance Criteria
+
+- **AC-1 (Frühjahrs-Umstellung — Slot fällt nicht mehr aus):** Given ein Trip in
+  `Europe/Paris` mit Morgen-Briefing 02:00 und ein Sammellauf am 29.03.2026, an dem die
+  Ortsstunde 02 nicht existiert / When der Versandlauf den Ortstag abschreitet / Then wird der
+  Trip **genau einmal** als fällig gesammelt (bei Ortsstunde 03, weil `3 >= 2 und 3 < 5`) —
+  heute entfällt der Versand ersatzlos.
+  - Test: T1 in `test_briefing_slot_idempotenz.py`.
+
+- **AC-2 (Herbst-Umstellung — keine Doppelzustellung):** Given derselbe Trip an einem
+  Sammellauf am 25.10.2026, an dem die Ortsstunde 02 zweimal existiert / When beide Vorkommen
+  der Ortsstunde 02 im Lauf durchschritten werden / Then wird der Trip **genau einmal** als
+  fällig markiert — das erste Vorkommen setzt den Vermerk, das zweite wird durch ihn gefiltert;
+  heute geht das Briefing zweimal raus.
+  - Test: T2.
+
+- **AC-3 (Normaler Tag — nur die konfigurierte Stunde trifft):** Given ein Trip mit
+  Morgen-Briefing 07:00 an einem Tag ohne Zeitumstellung / When jede der 24 Ortsstunden dieses
+  Tages einzeln durchlaufen wird / Then ist der Trip in genau der Stunde fällig, in der die
+  Ortsstunde 07 erreicht wird, und in keiner der übrigen 23.
+  - Test: T3.
+
+- **AC-4 (Nachhol-Fenster — beide Grenzen zugleich):** Given Slot-Stunde H fällt aus, weil der
+  stündliche Tick nicht lief (Umstellungstag oder gescheiterter HTTP-Post ohne Retry) / When
+  der nächste Lauf in Ortsstunde H+1 stattfindet / Then wird der Trip nachträglich als fällig
+  gesammelt; findet der nächste Lauf dagegen erst in Ortsstunde H+3 statt, ist er **nicht mehr**
+  fällig — das Nachhol-Fenster umfasst genau 3 Stunden, in beide Richtungen geprüft.
+  - Test: T4 — einziger Test, der die Fensterbreite in beide Richtungen festnagelt.
+
+- **AC-5 (Schlüssel braucht den Slot):** Given ein Trip mit Morgen- **und** Abend-Briefing,
+  beide auf 07:00 gestellt / When die Ortsstunde 07 erreicht wird / Then werden **beide** Slots
+  unabhängig voneinander als fällig gesammelt und unabhängig vermerkt — der Vermerk des einen
+  Slots blockiert den anderen nicht.
+  - Test: T5.
+
+- **AC-6 (Schlüssel braucht den Ortstag):** Given ein Trip, dessen Morgen-Briefing an zwei
+  aufeinanderfolgenden Ortstagen fällig wird / When der Lauf am zweiten Ortstag ausgeführt wird
+  / Then ist der Trip erneut fällig — der Vermerk vom Vortag blockiert den neuen Tag nicht.
+  - Test: T6.
+
+- **AC-7 (Schlüssel braucht die Trip-ID):** Given zwei verschiedene Trips in derselben Zone
+  mit identischer Briefing-Stunde / When diese Ortsstunde erreicht wird / Then werden **beide**
+  Trips unabhängig voneinander als fällig gesammelt und vermerkt — der Vermerk des einen Trips
+  darf den anderen nicht blockieren.
+  - Test: T7.
+
+- **AC-8 (Outcome-Matrix entscheidet über den Vermerk):** Given ein Versandversuch endet mit
+  einem der vier Ausgänge `sent`, `no_stage`, `no_weather` oder `no_channels` / When der
+  Versuch abgeschlossen ist / Then wird für alle vier ein Vermerk gesetzt, sodass dieser Slot
+  an diesem Ortstag **nicht erneut** verarbeitet wird — auch nicht in den verbleibenden
+  Stunden des Nachhol-Fensters; nur beim Ausgang `channels_unreachable` bleibt der Vermerk
+  aus, sodass der nächste Lauf innerhalb des Fensters einen weiteren Versuch unternimmt.
+  - Test: T8.
+
+- **AC-9 (Rollout ohne Doppelversand beim Deploy):** Given `briefing_slots.json` existiert
+  noch nicht (frischer Rollout dieser Änderung), aber `briefing_log.json` enthält für den Trip
+  bereits einen Eintrag mit passender Trip-ID und Slot-Art, dessen Sendezeitpunkt in den
+  aktuellen Ortstag fällt / When die Fälligkeit geprüft wird / Then gilt der Slot als bereits
+  erledigt und wird **nicht** erneut fällig.
+  - Test: T9.
+
+- **AC-10 (Kein rückwirkendes Feuern bei neuen/reaktivierten Trips):** Given ein Trip wird neu
+  angelegt oder kehrt aus einer Pause (`paused_until`) zurück, seine erste Etappe liegt heute,
+  die konfigurierte Morgen-Stunde liegt aber mehr als 3 Stunden zurück / When der erste
+  Sammellauf danach stattfindet / Then wird der Trip **nicht** rückwirkend als fällig behandelt
+  — das Nachhol-Fenster schließt diesen Fall strukturell aus.
+  - Test: T10.
+
+- **AC-11 (Ortsvergleich bleibt bit-identisch):** Given der Ortsvergleichs-Pfad
+  (`CompareDispatchStrategy.collect_due`) mit unveränderter Konfiguration / When derselbe
+  Versandlauf über 24 Stunden ausgeführt wird wie vor dieser Änderung / Then ist sein
+  Fälligkeitsergebnis **bit-identisch** zum Stand davor — der Idempotenz-Check wirkt
+  ausschließlich im Trip-Pfad, nicht im geteilten Skelett.
+  - Test: T11.
+
+- **AC-12 (On-Demand-Versand ist vom Vermerk unabhängig):** Given ein Nutzer fordert per
+  SMS-Kommando „heute" oder über den Test-Versand-Knopf ein Briefing außerhalb des regulären
+  Slots an / When dieser On-Demand-Versand ausgeführt wird / Then setzt er **keinen** Vermerk
+  für den regulären Slot, und er liest auch **keinen** — der reguläre Slot bleibt zur Stunde H
+  weiterhin fällig, und der Test-Knopf funktioniert nach einem regulären Versand weiter.
+  - Test: T12.
+
+- **AC-13 (Sperre nicht erhältlich → kein Versand, fail-closed):** Given die Schreibsperre auf
+  `briefing_slots.json` ist innerhalb der konfigurierten Zeit nicht zu bekommen (z.B. gehaltene
+  Sperre in einem parallelen Prozess) / When ein Trip zum Versand ansteht / Then wird **nicht**
+  gesendet, statt ohne wirksamen Vermerk zu senden — die Fehlerrichtung ist bewusst umgekehrt
+  zu `throttle_store`, das bei Sperren-Timeout fail-open ist.
+  - Test: T13 (Machbarkeit als ausdrückliche Lücke markiert, siehe Known Limitations).
+
+- **AC-14 (`Australia/Lord_Howe` — 24,5-Stunden-Tag unauffällig):** Given ein Trip in der Zone
+  `Australia/Lord_Howe` (Halbstunden-Versatz, an ihren eigenen Umstellungstagen 24,5 Stunden
+  lang) mit konfigurierter Briefing-Stunde / When der Sammellauf über den vollständigen Ortstag
+  läuft / Then wird der Trip genau einmal fällig, ohne Lücke und ohne Dopplung — der
+  Halbstunden-Versatz bricht die Fälligkeitsprüfung nicht.
+  - Test: T14.
+
+## Nachweis-Strategie
+
+Kern-Schicht, deterministisch: kein Netz, kein echtes Postfach. Zeit wird als Parameter
+hereingereicht (Muster aus #1724: `_faellig(scheduler, now_utc)` ruft `_collect_due_trips`
+direkt), nicht per Patch auf die Systemuhr. Neue Datei
+`tests/tdd/test_briefing_slot_idempotenz.py` (Verhaltensname, nicht Issue-Nummer —
+`test_naming_gate.py` blockt sonst).
+
+🔴 **Falle, die die Testfälle vorwegnehmen:** Bei funktionierendem Vermerk liefert **jede**
+Fensterbreite an einem normalen Tag genau einen Treffer. Ein Test, der nur Treffer zählt, kann
+die Fensterbreite selbst nicht sehen — sie ist ausschließlich an einem ausgefallenen Tick
+beobachtbar (T4), deshalb ist T4 der einzige Test, der beide Fenstergrenzen zugleich prüft.
+
+| # | AC | Testfall | Verfälschung, die ihn rot macht |
+|---|---|---|---|
+| T1 | AC-1 | Europe/Paris, `morning=02:00`, 2026-03-29 → genau 1 | `>=` zurück auf `==` → 0 Treffer |
+| T2 | AC-2 | dito 2026-10-25 (Doppelstunde) → genau 1 | Vermerk-Filter entfernen → 2 Treffer |
+| T3 | AC-3 | Normaler Tag, jede einzelne Ortsstunde gezählt → nur Stunde 07 trifft | Fälligkeit auf `<=` drehen → 8 Treffer |
+| T4 | AC-4 | Stunde H ausgelassen → H+1 fällig, H+3 nicht mehr | Fenster 3→1 macht ersten Teil rot, 3→„bis Tagesende" macht zweiten Teil rot |
+| T5 | AC-5 | `morning=07:00` und `evening=07:00` → beide fällig | `slot` aus dem Schlüssel entfernen → nur einer feuert |
+| T6 | AC-6 | Zwei aufeinanderfolgende Ortstage → an beiden fällig | `local_day` aus dem Schlüssel entfernen → Tag 2 bleibt stumm |
+| T7 | AC-7 | Zwei Trips, gleiche Zone, gleiche Stunde → beide fällig | `trip_id` aus dem Schlüssel entfernen → nur einer feuert |
+| T8 | AC-8 | Outcome-Matrix: vier setzen Vermerk, `channels_unreachable` nicht | `channels_unreachable` in die Vermerk-Menge schieben → nächste Stunde bleibt still, Test rot |
+| T9 | AC-9 | `briefing_slots.json` fehlt, `briefing_log.json` trägt passenden Eintrag im Ortstag → nicht fällig | Rückwärts-Ableitung entfernen → fällig (Doppelversand beim Deploy) |
+| T10 | AC-10 | Trip mit Etappe heute, `morning=07:00`, erstmals um Ortsstunde 20 ausgewertet → nicht fällig | Fenster auf „bis Tagesende" → fällig |
+| T11 | AC-11 | `CompareDispatchStrategy.collect_due` über 24 h unverändert | Filter ins geteilte Skelett verschieben → Compare-Zahl ändert sich |
+| T12 | AC-12 | Nach `send_on_demand_report` ist der reguläre Slot zur Stunde H weiterhin fällig | Vermerk in `_send_trip_report_outcome` statt im Wrapper setzen → rot |
+| T13 | AC-13 | Sperre nicht erhältlich → kein Versand statt Versand ohne Vermerk | fail-open wie `throttle_store:139-150` → rot |
+| T14 | AC-14 | `Australia/Lord_Howe`: Ortsstundenfolge ohne Loch und ohne Dopplung → unauffällig | schließt die bisher unbelegte Repo-Lücke |
+
+Zusätzlich wird der bestehende Test `test_briefing_faelligkeit_ortszone.py:312-348`
+(`test_ac7_sommerzeit_luecke_ist_gemessen_nicht_behauptet`) planmäßig umgeschrieben: von
+„0 Treffer am 29.03. / 2 Treffer am 25.10." auf „1 Treffer / 1 Treffer" — sein
+Docstring sagt bereits, dass #1725 ihn rot macht und auf das Zielverhalten umstellt.
+
+**Mutations-Gegenprobe (Pflicht, `.claude/agents/implementation-validator.md` Schritt 3b):**
+mindestens die vier in der Analyse benannten Mutationen sind gegenzuprüfen: Fenster 3→1 und
+3→24, Schlüssel um je ein Glied kürzen (Slot/Ortstag/Trip-ID einzeln), Filter ins geteilte
+Skelett verschieben, Vermerk nach `_send_trip_report_outcome` statt in den Wrapper verlegen.
+
+## Estimated Scope
+
+- **LoC:** ~170 Produktivcode über drei Dateien (`briefing_slots.py` CREATE ~110,
+  `trip_report_scheduler.py` MODIFY ~55, `dispatch_orchestrator.py` MODIFY ~6); Testcode zählt
+  nicht gegen das Limit.
+- **Files:** 3 Produktivdateien, 2 Testdateien (1 neu, 1 geändert).
+- **Effort:** medium — die einzelnen Änderungen sind klein, aber die Reihenfolge (zwei Commits,
+  siehe Entwurf) und die Fehlerrichtung des neuen Speichers sind sicherheitskritisch und
+  brauchen sorgfältige Mutations-Gegenprobe.
+- **Limit-Reserve:** 250/Workflow reicht, aber nicht komfortabel (~170/250). Bei Überlauf ist
+  die Schnittkante Retention/Prune für `briefing_slots.json` (~20 LoC) — die gehört ohnehin
+  nicht in diese Scheibe (s.u.). **Nicht** herausschneidbar: Rückwärts-Ableitung und
+  fail-closed-Sperre, beide sind Teil der Sicherheitsargumentation.
+
+## Known Limitations
+
+- **T13 (fail-closed bei Sperren-Timeout) ist als machbar eingeschätzt, aber nicht
+  verifiziert.** Ein mockfreier Aufbau (gehaltener `flock`-Filedescriptor im selben Prozess,
+  verkürztes `LOCK_TIMEOUT_SECONDS` für den Testlauf) gilt als plausibel, ist aber nicht vorab
+  gebaut worden. Sollte er sich als unverhältnismäßig teuer erweisen, ist das im PR explizit zu
+  benennen — die Fehlerrichtung selbst bleibt die sicherheitskritischste Einzelentscheidung
+  des Vorhabens und darf nicht ungeprüft bleiben.
+- **`fold` wird bewusst nicht gebraucht.** Es wird nie eine mehrdeutige Wanduhrzeit
+  konstruiert — die Ortsstunde entsteht immer aus einem eindeutigen UTC-Zeitpunkt
+  (`trip_day.py:74`). Die Doppelstunde im Herbst erscheint als zwei unterscheidbare
+  UTC-Zeitpunkte und wird über den Vermerk getrennt, nicht über Wanduhr-Disambiguierung.
+- **`skip_next` würde still mitverändert, wenn der neue Filter vor `_get_active_trips`
+  gezogen würde.** `skip_next` wird bei jedem Sammellauf konsumiert (`:678-683`), unabhängig
+  von der Fälligkeit. Solange der Filter **nach** `_get_active_trips` sitzt, bleibt das
+  Verhalten unverändert — wer ihn zum Sparen davorzieht, ändert `skip_next` ungewollt mit. Das
+  ist eine Implementierungsreihenfolge, kein separater Test, weil sie nicht als beobachtbares
+  Verhalten isolierbar ist, ohne den ganzen Sammellauf nachzubauen.
+- **Retention/Prune für `briefing_slots.json`** ist nicht Teil dieser Scheibe. Die Datei wächst
+  unbegrenzt mit jedem Sammellauf-Vermerk; eine Bereinigungsstrategie (z.B. Einträge älter als
+  N Tage) folgt als eigene, kleine Nachfolge-Arbeit.
+- **`data/` muss untracked bleiben** — die neue Datei `briefing_slots.json` darf nie committet
+  werden.
+- **Kontingent-Nebenwirkung bewusst in Kauf genommen:** `channels_unreachable` löst bis zu drei
+  Wetterabrufe statt einem aus (#1329), weil dort kein Vermerk entsteht. Begrenzt auf den
+  Nachholfall, nicht Gegenstand dieser Scheibe.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** ADR-0051, ADR-0044
+- **Rationale:** ADR-0051 (Status: Vorgeschlagen) beschreibt in Regel 3 „Keine Umgebungsuhr —
+  ‚Jetzt' wird als Zeitpunkt-Parameter hereingereicht" und nennt den Idempotenz-Schlüssel
+  `(trip_id, ortstag, slot)` bereits wörtlich (`:89-95`) — diese Spec ist die konkrete
+  Umsetzung dieser bereits formulierten Regel, kein neuer Grundsatz. ADR-0044 legt fest, dass
+  jedes Tagesfenster seine Länge **berechnen** muss statt sie zu setzen (`:46-49`) und dass
+  zwei zeitzonenbehaftete Zeitpunkte vor einem Vergleich nach UTC umgerechnet werden müssen
+  (`:59-67`) — beide Regeln werden hier angewendet, nicht verändert. Ein **neues** ADR ist
+  deshalb nicht nötig: Es entsteht keine neue Entscheidungsfläche, sondern die Umsetzung einer
+  bereits vorgeschlagenen Regel im Briefing-Pfad. Wird ADR-0051 im Zuge dieser oder einer
+  Folge-Scheibe von „Vorgeschlagen" auf „Akzeptiert" gehoben, ist diese Spec einer seiner
+  ersten praktischen Nachweise.
+
+## Changelog
+
+- 1.0 (2026-08-11): Initial spec created, aus `docs/context/fix-1725-faelligkeit-idempotenz.md`
+  auf Basis der Vorlage `fix_1724_faelligkeit_in_der_ortszone.md`.

--- a/docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md
+++ b/docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md
@@ -3,7 +3,7 @@ entity_id: fix_1725_faelligkeit_und_idempotenz
 type: bugfix
 created: 2026-08-11
 updated: 2026-08-11
-status: draft
+status: approved
 workflow: fix-1725-faelligkeit-idempotenz
 version: "1.0"
 tags: [issue-1725, epic-1722, timezone, adr-0051, adr-0044, scheduler, briefing, idempotenz]
@@ -13,7 +13,7 @@ tags: [issue-1725, epic-1722, timezone, adr-0051, adr-0044, scheduler, briefing,
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-Freigabe 2026-08-11 („go"), inklusive Nachhol-Fenster von 3 Stunden
 
 ## Purpose
 

--- a/docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md
+++ b/docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md
@@ -187,6 +187,26 @@ Es entsteht `data/users/<uid>/briefing_slots.json`, Schema
   `kind` (= Slot) trägt, dessen `sent_at` in den aktuellen Ortstag fällt. Das verhindert den
   einzigen realistischen Doppelversand-Fall: ein Deploy mitten im Nachhol-Fenster.
 
+### Schnittstelle (in der RED-Phase festgelegt, für GREEN verbindlich)
+
+`services.briefing_slots.BriefingSlotStore(user_id)`, Datei
+`get_data_dir(uid)/briefing_slots.json`, Sperr-Sidecar `briefing_slots.json.lock`.
+
+| Methode | Vertrag |
+|---|---|
+| `is_recorded(trip_id, slot, local_day, zone=None)` | liegt ein Vermerk vor? |
+| `reserve(trip_id, slot, local_day, zone=None) -> bool` | **True nur bei frischer Reservierung** — False sowohl bei bestehendem Vermerk als auch bei **nicht erhaltener Sperre** (fail-closed) |
+| `record_outcome(trip_id, slot, local_day, outcome)` | Ausgang festhalten |
+| `release(trip_id, slot, local_day)` | Rücknahme bei `channels_unreachable` / Ausnahme |
+
+- **Abweichung von der ursprünglichen Fassung:** der optionale `zone`-Parameter. Die
+  Rückwärts-Ableitung braucht die Ortszone, um zu entscheiden, ob `sent_at` aus
+  `briefing_log.json` in den Ortstag fällt; ohne ihn wird gegen UTC ausgewertet.
+- `_dispatch_due_item(trip, report_type, local_day) -> str | None`; `None` bedeutet **kein
+  Versandversuch**. Eine Ausnahme aus dem Versand wird nach dem `release` **weitergereicht**,
+  nicht geschluckt — `dispatch_one` fängt sie wie bisher.
+- `LOCK_TIMEOUT_SECONDS` als Modul-Attribut zur Laufzeit lesen (Begründung s. Known Limitations).
+
 ### Vermerk je Outcome
 
 | Outcome | Vermerk | Begründung |
@@ -357,15 +377,15 @@ beobachtbar (T4), deshalb ist T4 der einzige Test, der beide Fenstergrenzen zugl
 |---|---|---|---|
 | T1 | AC-1 | Europe/Paris, `morning=02:00`, 2026-03-29 → genau 1 | `>=` zurück auf `==` → 0 Treffer |
 | T2 | AC-2 | dito 2026-10-25 (Doppelstunde) → genau 1 | Vermerk-Filter entfernen → 2 Treffer |
-| T3 | AC-3 | Normaler Tag, jede einzelne Ortsstunde gezählt → nur Stunde 07 trifft | Fälligkeit auf `<=` drehen → 8 Treffer |
+| T3 | AC-3 | Normaler Tag, jede einzelne Ortsstunde gezählt → nur Stunde 07 trifft | Fälligkeit auf `<=` drehen → der Treffer wandert auf Ortsstunde 00. **Korrektur zur RED-Phase:** hier stand „→ 8 Treffer"; das gilt nur **ohne** wirksamen Vermerk. Mit Vermerk liefert auch die verdrehte Bedingung genau **einen** Treffer — der Test muss deshalb die **Stunde** des Treffers prüfen, nicht deren Anzahl |
 | T4 | AC-4 | Stunde H ausgelassen → H+1 fällig, H+3 nicht mehr | Fenster 3→1 macht ersten Teil rot, 3→„bis Tagesende" macht zweiten Teil rot |
-| T5 | AC-5 | `morning=07:00` und `evening=07:00` → beide fällig | `slot` aus dem Schlüssel entfernen → nur einer feuert |
+| T5 | AC-5 | `morning=07:00` und `evening=07:00` → **zwei Versandversuche** | `slot` aus dem Schlüssel entfernen → nur einer feuert. **Präzisierung zur RED-Phase:** gemessen werden Versandversuche, **nicht** gesammelte Zeilen — beide Elemente fallen in *derselben* Sammlung an und der Vermerk entsteht erst danach, an der Sammlung wäre die Mutation unsichtbar |
 | T6 | AC-6 | Zwei aufeinanderfolgende Ortstage → an beiden fällig | `local_day` aus dem Schlüssel entfernen → Tag 2 bleibt stumm |
-| T7 | AC-7 | Zwei Trips, gleiche Zone, gleiche Stunde → beide fällig | `trip_id` aus dem Schlüssel entfernen → nur einer feuert |
+| T7 | AC-7 | Zwei Trips, gleiche Zone, gleiche Stunde → **zwei Versandversuche** | `trip_id` aus dem Schlüssel entfernen → nur einer feuert (gemessen wie T5 an Versandversuchen) |
 | T8 | AC-8 | Outcome-Matrix: vier setzen Vermerk, `channels_unreachable` nicht | `channels_unreachable` in die Vermerk-Menge schieben → nächste Stunde bleibt still, Test rot |
 | T9 | AC-9 | `briefing_slots.json` fehlt, `briefing_log.json` trägt passenden Eintrag im Ortstag → nicht fällig | Rückwärts-Ableitung entfernen → fällig (Doppelversand beim Deploy) |
 | T10 | AC-10 | Trip mit Etappe heute, `morning=07:00`, erstmals um Ortsstunde 20 ausgewertet → nicht fällig | Fenster auf „bis Tagesende" → fällig |
-| T11 | AC-11 | `CompareDispatchStrategy.collect_due` über 24 h unverändert | Filter ins geteilte Skelett verschieben → Compare-Zahl ändert sich |
+| T11 | AC-11 | Compare über 24 h unverändert, gemessen über **`run_briefing_dispatch`** statt über `collect_due` allein — ein Hook im geteilten Skelett wäre an `collect_due` unsichtbar | Filter ins geteilte Skelett verschieben oder gemeinsame Basisklasse → Compare-Verhalten ändert sich |
 | T12 | AC-12 | Nach `send_on_demand_report` ist der reguläre Slot zur Stunde H weiterhin fällig | Vermerk in `_send_trip_report_outcome` statt im Wrapper setzen → rot |
 | T13 | AC-13 | Sperre nicht erhältlich → kein Versand statt Versand ohne Vermerk | fail-open wie `throttle_store:139-150` → rot |
 | T14 | AC-14 | `Australia/Lord_Howe`: Ortsstundenfolge ohne Loch und ohne Dopplung → unauffällig | schließt die bisher unbelegte Repo-Lücke |
@@ -396,12 +416,18 @@ Skelett verschieben, Vermerk nach `_send_trip_report_outcome` statt in den Wrapp
 
 ## Known Limitations
 
-- **T13 (fail-closed bei Sperren-Timeout) ist als machbar eingeschätzt, aber nicht
-  verifiziert.** Ein mockfreier Aufbau (gehaltener `flock`-Filedescriptor im selben Prozess,
-  verkürztes `LOCK_TIMEOUT_SECONDS` für den Testlauf) gilt als plausibel, ist aber nicht vorab
-  gebaut worden. Sollte er sich als unverhältnismäßig teuer erweisen, ist das im PR explizit zu
-  benennen — die Fehlerrichtung selbst bleibt die sicherheitskritischste Einzelentscheidung
-  des Vorhabens und darf nicht ungeprüft bleiben.
+- **T13 (fail-closed bei Sperren-Timeout): Lücke in der RED-Phase geschlossen.** Der mockfreie
+  Aufbau ist gebaut und die tragende Prämisse nachgemessen — zwei `os.open` derselben Datei im
+  **selben** Prozess kollidieren bei `flock` real (`BlockingIOError`). Auflage an die
+  Umsetzung: `LOCK_TIMEOUT_SECONDS` muss zur Laufzeit als **Modul-Attribut** gelesen werden
+  (`briefing_slots.LOCK_TIMEOUT_SECONDS`), nicht per `from … import` in eine lokale Konstante
+  gebunden — sonst kann der Test die Frist nicht verkürzen und wartet die vollen 2 s.
+- 🔴 **Die Fangkraft-Angaben in der Nachweis-Tabelle sind hergeleitet, nicht gemessen.** Ein
+  Wegwerf-Prüfstand mit Referenz-Implementierung und Mutationen war in der RED-Phase nicht
+  baubar (`edit_gate` lässt dort keine Code-Datei zu, auch nicht außerhalb des Repos; das Gate
+  wurde nicht umgangen). **Konsequenz:** die Mutations-Gegenprobe in Phase 6b muss vollständig
+  laufen — insbesondere für die sieben Tests, die ohne den Fix zufällig grün wären (T3, T5, T6,
+  T7, T10, T11, T14).
 - **`fold` wird bewusst nicht gebraucht.** Es wird nie eine mehrdeutige Wanduhrzeit
   konstruiert — die Ortsstunde entsteht immer aus einem eindeutigen UTC-Zeitpunkt
   (`trip_day.py:74`). Die Doppelstunde im Herbst erscheint als zwei unterscheidbare

--- a/docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md
+++ b/docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md
@@ -264,6 +264,20 @@ Weil Commit A den Vermerk bereits scharf schaltet, bevor Commit B die Fensteröf
 ist jeder Zwischenstand auslieferbar — ein Revert oder ein Bisect zwischen den beiden Commits
 landet nie im gefährlichen Zustand „offenes Fenster ohne Schutz".
 
+**Nachtrag aus der Umsetzung (2026-08-11): die Trennung fand statt, aber als zwei
+Arbeitsschritte, nicht als zwei Commits.** Schritt A wurde vollständig gebaut und **gemessen**,
+bevor B begann — und hat dabei zwei Befunde zutage gefördert, die sonst untergegangen wären
+(der Aufbaufehler in T2 und der On-Demand-Nebeneffekt der Rückwärts-Ableitung). Abgelegt wird
+das Ergebnis als **ein** Commit. Begründung:
+
+- Der Sicherheitszweck ist damit **strenger** erfüllt als geplant: Wo kein Zwischenstand
+  existiert, kann auch keiner den gefährlichen Zustand tragen.
+- Der Messwert aus Schritt A ist protokolliert: `due_A ⊆ due_alt` gilt strukturell (die
+  Stundenbedingung war unverändert `==`, der Filter kann eine Zeile nur entfernen), gemessen
+  wurde genau eine Reduktion — die beabsichtigte Herbst-Doppelstunde 2 → 1.
+- Ein nachträgliches Auseinanderschneiden des fertigen Arbeitsbaums wäre **Rekonstruktion**
+  eines Zwischenstands, der so nie getestet wurde — mehr Risiko als Nutzen.
+
 ## Acceptance Criteria
 
 - **AC-1 (Frühjahrs-Umstellung — Slot fällt nicht mehr aus):** Given ein Trip in

--- a/src/services/briefing_slots.py
+++ b/src/services/briefing_slots.py
@@ -1,0 +1,285 @@
+"""BriefingSlotStore — Idempotenz-Vermerk je (trip_id, ortstag, slot) (#1725).
+
+SPEC: docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md
+ADR-0051 (Idempotenz-Schluessel), ADR-0044 (Kalendertag folgt der Ortszeit)
+
+Eigener Speicher ``data/users/<uid>/briefing_slots.json`` statt Wiederverwendung
+von ``briefing_log.json`` (dort sind Eintraege ohne Kanaele verboten, #1007 F001)
+oder ``throttle_state.json`` (Cooldown-Fenster, kein Slot-Schluessel).
+
+Schreibmuster wie ``throttle_store._update()``: Sidecar-Sperre ueber
+``services.file_lock.acquire_exclusive`` plus ``tempfile``+``os.replace``.
+
+🔴 Fehlerrichtung UMGEKEHRT zum Vorbild: ``throttle_store`` ueberspringt bei
+Sperren-Timeout still den Schreibvorgang (fail-open) — dort kostet das einen
+doppelten Hinweis. Hier heisst "nicht geschrieben" Doppelversand an echte
+Empfaenger inklusive kostenpflichtiger Premium-SMS, also fail-closed:
+:meth:`BriefingSlotStore.reserve` liefert ohne Sperre ``False``, und der
+Aufrufer sendet dann NICHT (AC-13).
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import logging
+import os
+import tempfile
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Callable, Optional
+from zoneinfo import ZoneInfo
+
+from services import file_lock
+from services.file_lock import acquire_exclusive
+from utils.timezone import UTC, local_dt
+
+logger = logging.getLogger("briefing_slots")
+
+#: Zeitgrenze fuer die Sidecar-Sperre. Wird zur LAUFZEIT als Modul-Attribut
+#: gelesen (``briefing_slots.LOCK_TIMEOUT_SECONDS``) statt in eine lokale
+#: Konstante gebunden — sonst kann ein Test die Frist nicht kuerzen und
+#: wartet die vollen 2 s (Spec, Known Limitations zu T13).
+LOCK_TIMEOUT_SECONDS = file_lock.LOCK_TIMEOUT_SECONDS
+
+_STATE_FILENAME = "briefing_slots.json"
+_LOCK_SUFFIX = ".lock"
+_BRIEFING_LOG_FILENAME = "briefing_log.json"
+
+
+class BriefingSlotStore:
+    """Vermerk-Speicher fuer den Schluessel ``(trip_id, slot, local_day)``.
+
+    ``local_day`` ist der ORTSTAG des Laufs (ADR-0044), nicht der Zieltag des
+    Briefings — ein Abend-Briefing berichtet ueber morgen, gehoert aber zum
+    heutigen Slot.
+    """
+
+    def __init__(self, user_id: str, data_dir: Optional[Path] = None) -> None:
+        self._user_id = user_id
+        if data_dir is not None:
+            self._dir = Path(data_dir)
+        else:
+            from app.loader import get_data_dir
+            self._dir = get_data_dir(user_id)
+        self._path = self._dir / _STATE_FILENAME
+
+    # --- Oeffentliche Schnittstelle (Spec „Schnittstelle") ---
+
+    def is_recorded(
+        self, trip_id: str, slot: str, local_day: date,
+        zone: Optional[ZoneInfo] = None,
+    ) -> bool:
+        """Liegt ein Vermerk vor?
+
+        Schliesst die Rueckwaerts-Ableitung aus ``briefing_log.json`` ein
+        (AC-9) — die greift aber nur, solange dieser Speicher noch keine
+        eigene Datei hat (s. :meth:`_log_bezeugt_versand`).
+        """
+        if self._find(self._load(), trip_id, slot, local_day) is not None:
+            return True
+        return self._log_bezeugt_versand(trip_id, slot, local_day, zone)
+
+    def reserve(
+        self, trip_id: str, slot: str, local_day: date,
+        zone: Optional[ZoneInfo] = None,
+    ) -> bool:
+        """``True`` nur bei FRISCHER Reservierung.
+
+        ``False`` bei bestehendem Vermerk, beim Rollout-Nachweis aus
+        ``briefing_log.json`` (AC-9) UND bei nicht erhaltener Sperre (AC-13).
+        """
+        def _op(data: dict) -> bool:
+            if self._find(data, trip_id, slot, local_day) is not None:
+                return False
+            if self._log_bezeugt_versand(trip_id, slot, local_day, zone):
+                return False
+            data.setdefault("entries", []).append(
+                self._eintrag(trip_id, slot, local_day, None)
+            )
+            return True
+
+        return self._update(_op)
+
+    def record_outcome(
+        self, trip_id: str, slot: str, local_day: date, outcome: str,
+    ) -> None:
+        """Ausgang des Versandversuchs festhalten (Read-Modify-Write)."""
+        def _op(data: dict) -> bool:
+            eintrag = self._find(data, trip_id, slot, local_day)
+            if eintrag is None:
+                data.setdefault("entries", []).append(
+                    self._eintrag(trip_id, slot, local_day, outcome)
+                )
+            else:
+                eintrag["outcome"] = outcome
+            return True
+
+        self._update(_op)
+
+    def release(self, trip_id: str, slot: str, local_day: date) -> None:
+        """Reservierung zuruecknehmen (``channels_unreachable`` / Ausnahme)."""
+        def _op(data: dict) -> bool:
+            eintraege = data.get("entries", [])
+            rest = [
+                e for e in eintraege
+                if not self._passt(e, trip_id, slot, local_day)
+            ]
+            if len(rest) == len(eintraege):
+                return False
+            data["entries"] = rest
+            return True
+
+        self._update(_op)
+
+    # --- Schluessel ---
+
+    @staticmethod
+    def _eintrag(trip_id: str, slot: str, local_day: date, outcome: Optional[str]) -> dict:
+        return {
+            "trip_id": trip_id,
+            "slot": slot,
+            "local_day": local_day.isoformat(),
+            "recorded_at": datetime.now(tz=timezone.utc).isoformat(),
+            "outcome": outcome,
+        }
+
+    @staticmethod
+    def _passt(eintrag: object, trip_id: str, slot: str, local_day: date) -> bool:
+        """Alle DREI Glieder muessen stimmen — je eines weggelassen faellt ein
+        anderer Nutzer, ein anderer Slot oder der Folgetag mit heraus."""
+        return (
+            isinstance(eintrag, dict)
+            and eintrag.get("trip_id") == trip_id
+            and eintrag.get("slot") == slot
+            and eintrag.get("local_day") == local_day.isoformat()
+        )
+
+    def _find(
+        self, data: dict, trip_id: str, slot: str, local_day: date,
+    ) -> Optional[dict]:
+        for eintrag in data.get("entries", []):
+            if self._passt(eintrag, trip_id, slot, local_day):
+                return eintrag
+        return None
+
+    # --- Rueckwaerts-Ableitung aus briefing_log.json (AC-9) ---
+
+    def _log_bezeugt_versand(
+        self, trip_id: str, slot: str, local_day: date, zone: Optional[ZoneInfo],
+    ) -> bool:
+        """Solange ``briefing_slots.json`` NICHT existiert, gilt ein Slot als
+        erledigt, wenn ``briefing_log.json`` einen Versand mit passender
+        Trip-Kennung und Slot-Art traegt, dessen ``sent_at`` in ``local_day``
+        faellt.
+
+        Deckt den Rollout-Uebergang ab: ein Deploy mitten im Nachhol-Fenster,
+        wenn der eigene Speicher noch gar nicht angelegt ist. ``zone`` ist die
+        Ortszone des Trips; ohne sie wird ``sent_at`` gegen UTC ausgewertet
+        (nur der Scheduler kennt die Zone).
+
+        🔴 Die Existenz-Bedingung steht bewusst HIER, an EINER Stelle, durch
+        die beide Aufrufer (:meth:`is_recorded`, :meth:`reserve`) laufen. Sie
+        ist die engere von zwei moeglichen Lesarten (PO-Entscheidung
+        2026-08-11) und schuetzt den On-Demand-Pfad: ``_append_briefing_log``
+        (``trip_report_scheduler.py:1246``) unterscheidet NICHT nach
+        ``on_demand``, ein per SMS angefordertes „heute" schreibt also einen
+        Log-Eintrag mit ``kind="morning"``. Wuerde die Ableitung dauerhaft
+        gelten, naehme diese Anfrage dem Nutzer sein regulaeres Briefing
+        desselben Tages weg (AC-12). Preis der engen Lesart: beim Rollout
+        bleibt ein einmaliges Fenster von Stunden, in dem ein Trip ungeschuetzt
+        ist, sobald ein ANDERER Trip die Datei bereits angelegt hat — ein
+        seltenes doppeltes Briefing gegen einen dauerhaften Ausfall.
+        """
+        if self._path.exists():
+            return False
+        pfad = self._dir / _BRIEFING_LOG_FILENAME
+        if not pfad.exists():
+            return False
+        try:
+            data = json.loads(pfad.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return False
+        if not isinstance(data, dict):
+            return False
+        for eintrag in data.get("entries", []):
+            if not isinstance(eintrag, dict):
+                continue
+            if eintrag.get("trip_id") != trip_id or eintrag.get("kind") != slot:
+                continue
+            sent_at = self._parse(eintrag.get("sent_at"))
+            if sent_at is None:
+                continue
+            if local_dt(sent_at, zone or UTC).date() == local_day:
+                return True
+        return False
+
+    @staticmethod
+    def _parse(raw: object) -> Optional[datetime]:
+        if not raw or not isinstance(raw, str):
+            return None
+        try:
+            return datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+
+    # --- Load / Write (atomar, reload-vor-write) ---
+
+    def _load(self) -> dict:
+        if not self._path.exists():
+            return {}
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else {}
+        except (json.JSONDecodeError, OSError):
+            return {}
+
+    def _write(self, data: dict) -> None:
+        self._dir.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            dir=str(self._dir), prefix=".briefing_slots_", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(json.dumps(data, indent=2))
+            os.replace(tmp_name, self._path)
+        except OSError:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+            raise
+
+    def _update(self, mutate: Callable[[dict], bool]) -> bool:
+        """Reload-mutate-write unter einer Sidecar-Sperre.
+
+        Die Sperre liegt auf ``<state>.lock``, NICHT auf der Zieldatei —
+        ``_write()`` tauscht deren Inode per ``os.replace``, ein Lock darauf
+        wuerde danach nichts mehr serialisieren (Begruendung wie
+        ``throttle_store._update``).
+
+        Rueckgabe ist das Ergebnis von ``mutate`` (``True`` = geschrieben) —
+        und ``False``, wenn die Sperre nicht innerhalb
+        ``LOCK_TIMEOUT_SECONDS`` zu bekommen war. Genau hier weicht dieser
+        Speicher bewusst vom Vorbild ab: nicht "Schreibvorgang uebersprungen
+        und weiter", sondern "nicht reserviert" — der Aufrufer sendet dann
+        nicht (AC-13).
+        """
+        self._dir.mkdir(parents=True, exist_ok=True)
+        lock_path = str(self._path) + _LOCK_SUFFIX
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+        try:
+            if not acquire_exclusive(fd, LOCK_TIMEOUT_SECONDS):
+                logger.warning(
+                    "Dateisperre %s nicht innerhalb %.2fs erhalten -- "
+                    "kein Vermerk, also kein Versand",
+                    lock_path, LOCK_TIMEOUT_SECONDS,
+                )
+                return False
+            try:
+                data = self._load()
+                geaendert = mutate(data)
+                if geaendert:
+                    self._write(data)
+                return geaendert
+            finally:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)

--- a/src/services/briefing_slots.py
+++ b/src/services/briefing_slots.py
@@ -180,15 +180,19 @@ class BriefingSlotStore:
         🔴 Die Existenz-Bedingung steht bewusst HIER, an EINER Stelle, durch
         die beide Aufrufer (:meth:`is_recorded`, :meth:`reserve`) laufen. Sie
         ist die engere von zwei moeglichen Lesarten (PO-Entscheidung
-        2026-08-11) und schuetzt den On-Demand-Pfad: ``_append_briefing_log``
-        (``trip_report_scheduler.py:1246``) unterscheidet NICHT nach
-        ``on_demand``, ein per SMS angefordertes „heute" schreibt also einen
-        Log-Eintrag mit ``kind="morning"``. Wuerde die Ableitung dauerhaft
-        gelten, naehme diese Anfrage dem Nutzer sein regulaeres Briefing
-        desselben Tages weg (AC-12). Preis der engen Lesart: beim Rollout
-        bleibt ein einmaliges Fenster von Stunden, in dem ein Trip ungeschuetzt
-        ist, sobald ein ANDERER Trip die Datei bereits angelegt hat — ein
-        seltenes doppeltes Briefing gegen einen dauerhaften Ausfall.
+        2026-08-11): Die Ableitung dient allein dem Rollout-Uebergang, danach
+        ist der eigene Speicher massgeblich. Preis dafuer: beim Rollout bleibt
+        ein einmaliges Fenster von Stunden, in dem ein Trip ungeschuetzt ist,
+        sobald ein ANDERER Trip die Datei bereits angelegt hat — ein seltenes
+        doppeltes Briefing gegen einen sonst dauerhaften Ausfall.
+
+        🔴 Die enge Lesart allein genuegte NICHT (Adversary F004): sie
+        verkuerzte den Schaden am On-Demand-Pfad von dauerhaft auf einen Tag,
+        beseitigte ihn aber nicht. ``_append_briefing_log`` haelt seit diesem
+        Fix ``on_demand`` im Eintrag fest, und die Schleife unten ueberspringt
+        solche Eintraege — sonst naehme ein per SMS angefordertes „heute" dem
+        Nutzer sein regulaeres Briefing desselben Ortstags (AC-12), still, ohne
+        Protokollzeile.
         """
         if self._path.exists():
             return False
@@ -205,6 +209,15 @@ class BriefingSlotStore:
             if not isinstance(eintrag, dict):
                 continue
             if eintrag.get("trip_id") != trip_id or eintrag.get("kind") != slot:
+                continue
+            if eintrag.get("on_demand") is True:
+                # Issue #1725 (Adversary F004): ein angefordertes Briefing
+                # („heute"/„morgen" per SMS, Test-Versand-Knopf) darf dem
+                # Nutzer sein REGULAERES nicht wegnehmen (AC-12). Bestandsdaten
+                # tragen das Feld nicht — ein fehlender Schluessel gilt deshalb
+                # als regulaer, die Ableitung greift dort weiterhin. Das ist
+                # die sichere Richtung: lieber ein Briefing zu wenig als eines
+                # doppelt.
                 continue
             sent_at = self._parse(eintrag.get("sent_at"))
             if sent_at is None:

--- a/src/services/briefing_slots.py
+++ b/src/services/briefing_slots.py
@@ -187,12 +187,14 @@ class BriefingSlotStore:
         doppeltes Briefing gegen einen sonst dauerhaften Ausfall.
 
         🔴 Die enge Lesart allein genuegte NICHT (Adversary F004): sie
-        verkuerzte den Schaden am On-Demand-Pfad von dauerhaft auf einen Tag,
-        beseitigte ihn aber nicht. ``_append_briefing_log`` haelt seit diesem
-        Fix ``on_demand`` im Eintrag fest, und die Schleife unten ueberspringt
-        solche Eintraege — sonst naehme ein per SMS angefordertes „heute" dem
+        verkuerzte den Schaden am angeforderten Versand von dauerhaft auf einen
+        Tag, beseitigte ihn aber nicht. ``_append_briefing_log`` haelt deshalb
+        im Eintrag fest, ob der Versand ANGEFORDERT war, und die Schleife unten
+        ueberspringt solche Eintraege — sonst naehme eine Nutzeranfrage dem
         Nutzer sein regulaeres Briefing desselben Ortstags (AC-12), still, ohne
-        Protokollzeile.
+        Protokollzeile. Seit F006 gilt das fuer ALLE DREI von AC-12 genannten
+        Wege; zuvor kennzeichnete nur der SMS-Weg seine Eintraege, waehrend
+        Test-Versand-Knopf und Inbound-Kommando „report" weiter durchschlugen.
         """
         if self._path.exists():
             return False
@@ -211,8 +213,9 @@ class BriefingSlotStore:
             if eintrag.get("trip_id") != trip_id or eintrag.get("kind") != slot:
                 continue
             if eintrag.get("on_demand") is True:
-                # Issue #1725 (Adversary F004): ein angefordertes Briefing
-                # („heute"/„morgen" per SMS, Test-Versand-Knopf) darf dem
+                # Issue #1725 (Adversary F004/F006): ein angefordertes Briefing
+                # (SMS „heute"/„morgen", Test-Versand-Knopf, Inbound-Kommando
+                # „report" — alle drei setzen es) darf dem
                 # Nutzer sein REGULAERES nicht wegnehmen (AC-12). Bestandsdaten
                 # tragen das Feld nicht — ein fehlender Schluessel gilt deshalb
                 # als regulaer, die Ableitung greift dort weiterhin. Das ist

--- a/src/services/dispatch_orchestrator.py
+++ b/src/services/dispatch_orchestrator.py
@@ -62,13 +62,24 @@ class TripDispatchStrategy:
     def pre_pass(self, now_utc: "datetime", due: list) -> None:
         # Issue #1012 (b2): Catch-up ZUERST, offene Nachliefer-Marker vor den
         # regulaeren faelligen Slots abarbeiten (AC-6/AC-7).
-        due_trip_ids_now = {trip.id for trip, _ in due}
+        # Issue #1725: `collect_due` liefert (trip, report_type, ortstag).
+        due_trip_ids_now = {trip.id for trip, _, _ in due}
         self._sent += self._service._process_pending_markers(now_utc, due_trip_ids_now)
 
     def dispatch_one(self, item) -> None:
-        trip, report_type = item
+        trip, report_type, local_day = item
         try:
-            outcome = self._service._send_trip_report_outcome(trip, report_type)
+            # Issue #1725: NICHT direkt `_send_trip_report_outcome` -- der
+            # Wrapper reserviert zuerst den Vermerk (trip_id, ortstag, slot)
+            # und gibt ihn je nach Ausgang frei. Er ist bewusst die EINZIGE
+            # Stelle, die den Vermerk anfasst: die On-Demand-Pfade rufen
+            # weiterhin `_send_trip_report_outcome` und bleiben unberuehrt.
+            outcome = self._service._dispatch_due_item(trip, report_type, local_day)
+            if outcome is None:
+                # Kein Versandversuch (Slot bereits vermerkt oder Sperre nicht
+                # zu bekommen). Weder gesendet noch technisch fehlgeschlagen --
+                # der Wrapper hat den Grund bereits protokolliert.
+                return
             # Issue #1012 (c): "no_weather" (kompletter Ausfall) zaehlt als
             # failed statt sent -- alle anderen Outcomes bleiben sent.
             if outcome == "no_weather":

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -1334,7 +1334,9 @@ class TripReportSchedulerService:
                 f"Trip report NOT sent (configured channel unreachable): {trip.name} ({report_type})"
             )
         else:
-            self._append_briefing_log(trip.id, report_type, result.sent_channels)
+            self._append_briefing_log(
+                trip.id, report_type, result.sent_channels, on_demand=on_demand,
+            )
             logger.info(f"Trip report sent: {trip.name} ({report_type})")
 
         # 8c. Issue #1662 AC-5: Der gelungene Versand macht einen offenen
@@ -1550,11 +1552,24 @@ class TripReportSchedulerService:
         """
         reset_alert_memory(user_id=self._user_id, entity_id=trip_id)
 
-    def _append_briefing_log(self, trip_id: str, kind: str, channels: List[str]) -> None:
+    def _append_briefing_log(
+        self, trip_id: str, kind: str, channels: List[str], on_demand: bool = False,
+    ) -> None:
         """Issue #393: Hängt einen Briefing-Versand-Eintrag an briefing_log.json an.
 
         Wird von Go (GET /api/cockpit/status) read-only gelesen. Kein Bereinigen —
         das Frontend filtert auf "heute".
+
+        Issue #1725 (Adversary F004): `on_demand` hält fest, dass der Eintrag aus
+        einem angeforderten Versand stammt („heute"/„morgen" per SMS,
+        Test-Versand-Knopf) und NICHT aus dem regulären Slot. Die
+        Rückwärts-Ableitung in `briefing_slots._log_bezeugt_versand` überspringt
+        solche Einträge — ohne das Feld nähme eine SMS-Anfrage dem Nutzer sein
+        reguläres Briefing desselben Ortstags (AC-12). Der Eintrag selbst wird
+        weiterhin geschrieben: ihn wegzulassen änderte die Cockpit-Kachel #393,
+        und das ist eine andere Scheibe. Go liest die Datei nur
+        (`internal/store/log.go:23`) und ignoriert unbekannte Felder, schreibt
+        sie also auch nicht weg.
         """
         path = get_data_dir(self._user_id) / "briefing_log.json"
         data = json.loads(path.read_text()) if path.exists() else {"entries": []}
@@ -1563,6 +1578,7 @@ class TripReportSchedulerService:
             "kind": kind,
             "sent_at": datetime.now(tz=timezone.utc).isoformat(),
             "channels": channels,
+            "on_demand": on_demand,
         })
         # Issue #1614: ein frischer Nutzer ohne jedes vorherige Datenverzeichnis
         # (kein Trip-Snapshot, kein Alert-State) hatte hier noch kein

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -36,6 +36,7 @@ from services.alert_briefing_anchor import (
     reset_alert_memory,
     write_anchor_and_reset_memory,
 )
+from services.briefing_slots import BriefingSlotStore
 from services.day_comparison import DayComparison
 from services.notification_service import NotificationService, TripReportRequest
 from services.user_tier import premium_sms_allowed, sms_allowed
@@ -67,6 +68,27 @@ FETCH_RETRY_BACKOFF_SECONDS = 1
 _TRANSIENT_FETCH_ERROR_MARKERS = (
     "502", "503", "504", "timeout", "timed out", "overloaded",
 )
+
+# Issue #1725: Ausgaenge, die den Slot fuer diesen Ortstag abschliessen.
+# `channels_unreachable` fehlt bewusst -- dort hat per Definition
+# (`sent = bool(sent_channels)`) niemand etwas bekommen, das ist der einzige
+# beabsichtigte Nachholfall. `no_weather` steht dagegen drin: ohne Vermerk
+# gaebe es eine stuendliche "keine Daten"-Mail plus stuendlichen vollen
+# Wetterabruf gegen das Kontingent (#1329), waehrend der #1012-Pending-Marker
+# die Nachlieferung bereits abdeckt.
+VERMERK_AUSGAENGE = frozenset({"sent", "no_stage", "no_weather", "no_channels"})
+
+# Issue #1725: Breite des Faelligkeitsfensters in Ortsstunden.
+# `konfigurierte_stunde <= ortsstunde < konfigurierte_stunde + 3`. Drei
+# Stunden decken den an Umstellungstagen ausfallenden Cron-Tick (1 Stunde,
+# `robfig/cron/v3`) mit Reserve fuer einen gescheiterten, nicht wiederholten
+# HTTP-Post (`scheduler.go:547`). Eine Deckelung am Tagesende ist nicht
+# noetig: fuer Slot 22 sind es die Ortsstunden 22 und 23, ab Ortsmitternacht
+# wechselt der Ortstag und `0 >= 22` ist falsch. Die Alternative „bis
+# Tagesende" wurde verworfen, weil sie neu angelegte oder aus `paused_until`
+# zurueckkehrende Trips RUECKWIRKEND feuern liesse (AC-10) --
+# `_get_active_trips` prueft nur die Etappe, nicht das Anlagedatum.
+NACHHOL_FENSTER_STUNDEN = 3
 
 
 def _is_transient_fetch_error(exc: Exception) -> bool:
@@ -351,8 +373,8 @@ class TripReportSchedulerService:
             "route", self._user_id, now_utc, settings=self._settings,
         )
 
-    def _collect_due_trips(self, now_utc: datetime) -> List[Tuple["Trip", str]]:
-        """Sammelt alle (trip, report_type)-Paare, die JETZT fällig sind.
+    def _collect_due_trips(self, now_utc: datetime) -> List[Tuple["Trip", str, date]]:
+        """Sammelt alle (trip, report_type, ortstag)-Tripel, die JETZT fällig sind.
 
         Issue #1207: Extrahiert aus dem Sendelauf fuer Delegation durch
         `TripDispatchStrategy.collect_due()` -- Morgen- UND Abend-Fälligkeit
@@ -366,25 +388,94 @@ class TripReportSchedulerService:
         Ortszeit, damit ein auf 07:00 gestelltes Briefing ueberall um 07:00
         Ortszeit ankommt statt um 17:00 (Auckland) oder 22:00 des Vortages
         (PCT).
-        """
-        due: List[Tuple["Trip", str]] = []
-        for trip in self._get_active_trips("morning", now_utc):
-            if self._get_morning_hour(trip) == self._trip_local_hour(trip, now_utc):
-                due.append((trip, "morning"))
-        for trip in self._get_active_trips("evening", now_utc):
-            if self._get_evening_hour(trip) == self._trip_local_hour(trip, now_utc):
-                due.append((trip, "evening"))
-        return due
 
-    def _trip_local_hour(self, trip: "Trip", now_utc: datetime) -> int:
-        """Die Stunde, die der Wanderer dieses Trips gerade auf der Uhr hat.
+        Issue #1725: Faelligkeit ist ein FENSTER, keine Stundengleichheit --
+        `konfigurierte_stunde <= ortsstunde < konfigurierte_stunde +
+        NACHHOL_FENSTER_STUNDEN`, kombiniert mit dem Vermerk-Filter unten.
+        Ein Ortstag hat nicht immer 24 Stunden: am Fruehjahrs-Umstellungstag
+        fehlt eine Ortsstunde ersatzlos (ein auf 02:00 gestelltes Briefing
+        entfiel), am Herbsttag existiert sie zweimal (es ging zweimal raus).
+        Das Fenster faengt zusaetzlich den Cron-Tick auf, der an genau diesen
+        Tagen weltweit fuer ALLE Nutzer ausfaellt (`scheduler.go:112`).
+        Erst der Vermerk macht das Fenster gefahrlos -- ohne ihn waere `>=`
+        stuendlicher Serienversand.
 
-        Issue #1724. Zone aus `trip_day` -- derselbe Aufloeser, den der
-        Alarm-Pfad seit #1697 benutzt, kein zweiter Weg.
+        Drittes Element ist der ORTSTAG DES LAUFS -- zusammen mit
+        Trip-Kennung und Slot der Idempotenz-Schluessel. Ausdruecklich NICHT
+        `target_date`: das Abend-Briefing berichtet ueber morgen, gehoert aber
+        zum heutigen Slot. Ortstag und Ortsstunde entstehen aus EINER
+        Zonen-Aufloesung (`trip_local_now`) -- zwei koennen an der Tagesgrenze
+        auseinanderfallen (#1697).
+
+        Der Vermerk-Filter sitzt HIER und nicht erst im Versand (Pruefort =
+        Wirkort): `_process_pending_markers` (`:445-448`) raeumt den
+        #1012-Nachliefer-Marker weg, sobald der Trip in `due_trip_ids_now`
+        steht -- eine unehrlich lange Liste legte den Nachliefermechanismus
+        lautlos still. Und er sitzt NACH `_get_active_trips`, weil dort
+        `skip_next` bei jedem Sammellauf konsumiert wird (`:678-683`),
+        unabhaengig von der Faelligkeit.
         """
         from services.trip_day import trip_local_now
 
-        return trip_local_now(trip, now_utc).hour
+        store = BriefingSlotStore(self._user_id)
+        due: List[Tuple["Trip", str, date]] = []
+        for report_type, slot_stunde in (
+            ("morning", self._get_morning_hour),
+            ("evening", self._get_evening_hour),
+        ):
+            for trip in self._get_active_trips(report_type, now_utc):
+                vor_ort = trip_local_now(trip, now_utc)
+                stunde = slot_stunde(trip)
+                if not stunde <= vor_ort.hour < stunde + NACHHOL_FENSTER_STUNDEN:
+                    continue
+                ortstag = vor_ort.date()
+                if store.is_recorded(
+                    trip.id, report_type, ortstag, zone=vor_ort.tzinfo,
+                ):
+                    continue
+                due.append((trip, report_type, ortstag))
+        return due
+
+    def _dispatch_due_item(
+        self, trip: "Trip", report_type: str, local_day: date,
+    ) -> Optional[str]:
+        """Versand EINES faelligen Slots, abgesichert durch den Vermerk (#1725).
+
+        Reserve-then-release: der Vermerk entsteht VOR dem Versandversuch und
+        wird nur bei `channels_unreachable` oder einer Ausnahme wieder
+        zurueckgenommen. Stirbt der Prozess mitten im Versand, bleibt er
+        stehen -- nie doppelt, im schlimmsten Fall ein ausgelassener Slot.
+
+        Ausschliesslich `TripDispatchStrategy.dispatch_one` ruft diese Methode.
+        Dadurch bleiben die On-Demand-Pfade (Test-Knopf, Inbound-Kommandos,
+        Legacy-CLI) vom Vermerk unberuehrt, ohne dass ein zusaetzliches Flag
+        noetig waere (AC-12) -- sie rufen `_send_trip_report_outcome` direkt.
+
+        Returns:
+            Den Ausgang des Versandversuchs -- oder `None`, wenn gar keiner
+            stattfand (Slot bereits vermerkt oder Sperre nicht zu bekommen,
+            fail-closed, AC-13). Eine Ausnahme aus dem Versand wird nach dem
+            `release` WEITERGEREICHT, nicht geschluckt.
+        """
+        from services.trip_day import trip_tz
+
+        store = BriefingSlotStore(self._user_id)
+        if not store.reserve(trip.id, report_type, local_day, zone=trip_tz(trip)):
+            logger.warning(
+                "Slot %s/%s am %s nicht reservierbar -- kein Versandversuch",
+                trip.id, report_type, local_day,
+            )
+            return None
+        try:
+            outcome = self._send_trip_report_outcome(trip, report_type)
+        except Exception:
+            store.release(trip.id, report_type, local_day)
+            raise
+        if outcome in VERMERK_AUSGAENGE:
+            store.record_outcome(trip.id, report_type, local_day, outcome)
+        else:
+            store.release(trip.id, report_type, local_day)
+        return outcome
 
     def _process_pending_markers(self, now_utc: datetime, due_trip_ids_now: set) -> int:
         """Issue #1012 (b2): Verarbeitet offene Nachliefer-Marker VOR den

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -884,7 +884,11 @@ class TripReportSchedulerService:
         """
         if report_type not in ("morning", "evening"):
             raise ValueError(f"Invalid report_type: {report_type}")
-        return self._send_trip_report(trip, report_type, allow_test_fallback=True)
+        # Issue #1725 (Adversary F006): `angefordert=True` — dieser Weg traegt
+        # das Inbound-Kommando „report" (`trip_command_processor.py:1019`).
+        return self._send_trip_report(
+            trip, report_type, allow_test_fallback=True, angefordert=True,
+        )
 
     def send_test_report_outcome(self, trip: "Trip", report_type: str) -> str:
         """
@@ -908,7 +912,11 @@ class TripReportSchedulerService:
         """
         if report_type not in ("morning", "evening"):
             raise ValueError(f"Invalid report_type: {report_type}")
-        return self._send_trip_report_outcome(trip, report_type, allow_test_fallback=True)
+        # Issue #1725 (Adversary F006): `angefordert=True` — dieser Weg traegt
+        # den Test-Versand-Knopf (`api/routers/scheduler.py:232`).
+        return self._send_trip_report_outcome(
+            trip, report_type, allow_test_fallback=True, angefordert=True,
+        )
 
     def send_on_demand_report(self, trip: "Trip", report_type: str) -> bool:
         """
@@ -932,7 +940,11 @@ class TripReportSchedulerService:
         """
         if report_type not in ("morning", "evening"):
             raise ValueError(f"Invalid report_type: {report_type}")
-        return self._send_trip_report_outcome(trip, report_type, on_demand=True)
+        # Issue #1725: `angefordert=True` NEBEN `on_demand=True` — die beiden
+        # bedeuten Verschiedenes, siehe `_send_trip_report_outcome`.
+        return self._send_trip_report_outcome(
+            trip, report_type, on_demand=True, angefordert=True,
+        )
 
     def _send_trip_report(
         self,
@@ -940,6 +952,7 @@ class TripReportSchedulerService:
         report_type: str,
         allow_test_fallback: bool = False,
         on_demand: bool = False,
+        angefordert: bool = False,
     ) -> bool:
         """
         Generate and send report for a single trip — legacy bool wrapper.
@@ -955,7 +968,8 @@ class TripReportSchedulerService:
             configured), False if no matching stage/weather data found.
         """
         outcome = self._send_trip_report_outcome(
-            trip, report_type, allow_test_fallback=allow_test_fallback, on_demand=on_demand,
+            trip, report_type, allow_test_fallback=allow_test_fallback,
+            on_demand=on_demand, angefordert=angefordert,
         )
         return outcome in ("sent", "no_channels")
 
@@ -966,6 +980,7 @@ class TripReportSchedulerService:
         allow_test_fallback: bool = False,
         on_demand: bool = False,
         catchup_prefix: str | None = None,
+        angefordert: bool = False,
     ) -> str:
         """
         Generate and send report for a single trip.
@@ -977,6 +992,21 @@ class TripReportSchedulerService:
                 Briefings ("Nachgeliefert …" / "Aktualisiert …"), wird von
                 _process_pending_markers() bei erfolgreicher Nachlieferung
                 gesetzt.
+            angefordert: Issue #1725 (Adversary F006) — der Versand geht auf
+                eine Nutzeranfrage zurück (SMS „heute"/„morgen", Test-Versand-
+                Knopf, Inbound-Kommando „report") statt auf den regulären Slot.
+                Fließt AUSSCHLIESSLICH in den `briefing_log.json`-Eintrag, damit
+                die Rückwärts-Ableitung ihn überspringen kann (AC-12).
+                🔴 Bewusst NICHT `on_demand` mitbenutzt: dieses Flag trägt
+                sieben weitere Bedeutungen, die für Test-Versand und „report"
+                allesamt unerwünscht wären — es unterdrückt den
+                Ausfall-Hinweisversand (`:1097`), setzt eine „auf Anfrage"-
+                Kennzeichnung in den Mail-Text (`:1462`), hält Anker und
+                Alarm-Gedächtnis an (`:1265`), unterdrückt beide
+                Nachliefer-Marker (`:1296`/`:1393`, `:1351`), verhindert das
+                Aufräumen des Versandfehler-Vermerks (`:1345`) und die
+                Entdopplung amtlicher Warnungen (`:1368`). Ein Flag mit zwei
+                Bedeutungen führt den nächsten Leser in die Irre.
 
         Returns:
             "no_stage" if no matching stage, "no_weather" if the weather
@@ -1335,7 +1365,7 @@ class TripReportSchedulerService:
             )
         else:
             self._append_briefing_log(
-                trip.id, report_type, result.sent_channels, on_demand=on_demand,
+                trip.id, report_type, result.sent_channels, angefordert=angefordert,
             )
             logger.info(f"Trip report sent: {trip.name} ({report_type})")
 
@@ -1553,23 +1583,30 @@ class TripReportSchedulerService:
         reset_alert_memory(user_id=self._user_id, entity_id=trip_id)
 
     def _append_briefing_log(
-        self, trip_id: str, kind: str, channels: List[str], on_demand: bool = False,
+        self, trip_id: str, kind: str, channels: List[str], angefordert: bool = False,
     ) -> None:
         """Issue #393: Hängt einen Briefing-Versand-Eintrag an briefing_log.json an.
 
         Wird von Go (GET /api/cockpit/status) read-only gelesen. Kein Bereinigen —
         das Frontend filtert auf "heute".
 
-        Issue #1725 (Adversary F004): `on_demand` hält fest, dass der Eintrag aus
-        einem angeforderten Versand stammt („heute"/„morgen" per SMS,
-        Test-Versand-Knopf) und NICHT aus dem regulären Slot. Die
-        Rückwärts-Ableitung in `briefing_slots._log_bezeugt_versand` überspringt
-        solche Einträge — ohne das Feld nähme eine SMS-Anfrage dem Nutzer sein
-        reguläres Briefing desselben Ortstags (AC-12). Der Eintrag selbst wird
-        weiterhin geschrieben: ihn wegzulassen änderte die Cockpit-Kachel #393,
-        und das ist eine andere Scheibe. Go liest die Datei nur
-        (`internal/store/log.go:23`) und ignoriert unbekannte Felder, schreibt
-        sie also auch nicht weg.
+        Issue #1725 (Adversary F004/F006): `angefordert` hält fest, dass der
+        Eintrag aus einem vom Nutzer ANGEFORDERTEN Versand stammt und nicht aus
+        dem regulären Slot. Angefordert sind alle drei Wege, die AC-12
+        aufzählt: SMS „heute"/„morgen" (`send_on_demand_report`), der
+        Test-Versand-Knopf (`send_test_report_outcome`,
+        `api/routers/scheduler.py:232`) und das Inbound-Kommando „report"
+        (`send_test_report`, `trip_command_processor.py:1019`). Die
+        Rückwärts-Ableitung in `briefing_slots._log_bezeugt_versand`
+        überspringt solche Einträge — ohne das Feld nähme eine Nutzeranfrage
+        dem Nutzer sein reguläres Briefing desselben Ortstags (AC-12).
+
+        Der Eintrag selbst wird weiterhin geschrieben: ihn wegzulassen änderte
+        die Cockpit-Kachel #393, und das ist eine andere Scheibe. Der
+        JSON-Schlüssel heißt weiterhin `on_demand` — er ist das Wire-Format,
+        das `briefing_slots` liest; Go liest die Datei nur
+        (`internal/store/log.go:23`), ignoriert unbekannte Felder und schreibt
+        sie deshalb auch nicht weg.
         """
         path = get_data_dir(self._user_id) / "briefing_log.json"
         data = json.loads(path.read_text()) if path.exists() else {"entries": []}
@@ -1578,7 +1615,7 @@ class TripReportSchedulerService:
             "kind": kind,
             "sent_at": datetime.now(tz=timezone.utc).isoformat(),
             "channels": channels,
-            "on_demand": on_demand,
+            "on_demand": angefordert,
         })
         # Issue #1614: ein frischer Nutzer ohne jedes vorherige Datenverzeichnis
         # (kein Trip-Snapshot, kein Alert-State) hatte hier noch kein

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -82,7 +82,7 @@ VERMERK_AUSGAENGE = frozenset({"sent", "no_stage", "no_weather", "no_channels"})
 # `konfigurierte_stunde <= ortsstunde < konfigurierte_stunde + 3`. Drei
 # Stunden decken den an Umstellungstagen ausfallenden Cron-Tick (1 Stunde,
 # `robfig/cron/v3`) mit Reserve fuer einen gescheiterten, nicht wiederholten
-# HTTP-Post (`scheduler.go:547`). Eine Deckelung am Tagesende ist nicht
+# HTTP-Post (`scheduler.triggerEndpointForUser`). Eine Deckelung am Tagesende ist nicht
 # noetig: fuer Slot 22 sind es die Ortsstunden 22 und 23, ab Ortsmitternacht
 # wechselt der Ortstag und `0 >= 22` ist falsch. Die Alternative „bis
 # Tagesende" wurde verworfen, weil sie neu angelegte oder aus `paused_until`
@@ -396,7 +396,8 @@ class TripReportSchedulerService:
         fehlt eine Ortsstunde ersatzlos (ein auf 02:00 gestelltes Briefing
         entfiel), am Herbsttag existiert sie zweimal (es ging zweimal raus).
         Das Fenster faengt zusaetzlich den Cron-Tick auf, der an genau diesen
-        Tagen weltweit fuer ALLE Nutzer ausfaellt (`scheduler.go:112`).
+        Tagen weltweit fuer ALLE Nutzer ausfaellt (`cron.New(cron.WithLocation)`
+        in `internal/scheduler/scheduler.go`, Verhalten von `robfig/cron/v3`).
         Erst der Vermerk macht das Fenster gefahrlos -- ohne ihn waere `>=`
         stuendlicher Serienversand.
 
@@ -408,12 +409,12 @@ class TripReportSchedulerService:
         auseinanderfallen (#1697).
 
         Der Vermerk-Filter sitzt HIER und nicht erst im Versand (Pruefort =
-        Wirkort): `_process_pending_markers` (`:445-448`) raeumt den
-        #1012-Nachliefer-Marker weg, sobald der Trip in `due_trip_ids_now`
-        steht -- eine unehrlich lange Liste legte den Nachliefermechanismus
-        lautlos still. Und er sitzt NACH `_get_active_trips`, weil dort
-        `skip_next` bei jedem Sammellauf konsumiert wird (`:678-683`),
-        unabhaengig von der Faelligkeit.
+        Wirkort): `_process_pending_markers` raeumt den #1012-Nachliefer-Marker
+        weg, sobald der Trip in `due_trip_ids_now` steht -- eine unehrlich
+        lange Liste legte den Nachliefermechanismus lautlos still. Und er sitzt
+        NACH `_get_active_trips`, weil dort `skip_next` bei jedem Sammellauf
+        konsumiert wird (RMW auf `report_config`), unabhaengig von der
+        Faelligkeit.
         """
         from services.trip_day import trip_local_now
 
@@ -885,7 +886,7 @@ class TripReportSchedulerService:
         if report_type not in ("morning", "evening"):
             raise ValueError(f"Invalid report_type: {report_type}")
         # Issue #1725 (Adversary F006): `angefordert=True` — dieser Weg traegt
-        # das Inbound-Kommando „report" (`trip_command_processor.py:1019`).
+        # das Inbound-Kommando „report" (`trip_command_processor._trigger_report`).
         return self._send_trip_report(
             trip, report_type, allow_test_fallback=True, angefordert=True,
         )
@@ -913,7 +914,7 @@ class TripReportSchedulerService:
         if report_type not in ("morning", "evening"):
             raise ValueError(f"Invalid report_type: {report_type}")
         # Issue #1725 (Adversary F006): `angefordert=True` — dieser Weg traegt
-        # den Test-Versand-Knopf (`api/routers/scheduler.py:232`).
+        # den Test-Versand-Knopf (`api/routers/scheduler.send_test_trip_report`).
         return self._send_trip_report_outcome(
             trip, report_type, allow_test_fallback=True, angefordert=True,
         )
@@ -998,15 +999,29 @@ class TripReportSchedulerService:
                 Fließt AUSSCHLIESSLICH in den `briefing_log.json`-Eintrag, damit
                 die Rückwärts-Ableitung ihn überspringen kann (AC-12).
                 🔴 Bewusst NICHT `on_demand` mitbenutzt: dieses Flag trägt
-                sieben weitere Bedeutungen, die für Test-Versand und „report"
-                allesamt unerwünscht wären — es unterdrückt den
-                Ausfall-Hinweisversand (`:1097`), setzt eine „auf Anfrage"-
-                Kennzeichnung in den Mail-Text (`:1462`), hält Anker und
-                Alarm-Gedächtnis an (`:1265`), unterdrückt beide
-                Nachliefer-Marker (`:1296`/`:1393`, `:1351`), verhindert das
-                Aufräumen des Versandfehler-Vermerks (`:1345`) und die
-                Entdopplung amtlicher Warnungen (`:1368`). Ein Flag mit zwei
+                sieben weitere Bedeutungen über acht Lesestellen (weil
+                `_mark_briefing_undelivered` zweimal vorkommt; vor diesem Fix
+                waren es neun — die neunte, der Log-Eintrag, ist jetzt
+                `angefordert`), die für Test-Versand und „report" allesamt
+                unerwünscht wären. Es
+                unterdrückt den Ausfall-Hinweisversand
+                (`send_no_data_hint`-Zweig im Totalausfall), setzt eine
+                „auf Anfrage"-Kennzeichnung in den Mail-Text
+                (`on_demand_prefix` in `_build_trip_report_request`), hält
+                Anker und Alarm-Gedächtnis an
+                (`write_anchor_and_reset_memory` in `_anchor_and_reset`),
+                unterdrückt beide Nachliefer-Marker
+                (`_mark_briefing_undelivered` im Ausnahme- UND im
+                `channels_unreachable`-Zweig, `_write_pending_marker` beim
+                Teilausfall), verhindert das Aufräumen des
+                Versandfehler-Vermerks (`_clear_dispatch_error_marker`) und
+                die Entdopplung amtlicher Warnungen
+                (`record_official_alerts_reported`). Ein Flag mit zwei
                 Bedeutungen führt den nächsten Leser in die Irre.
+                Absichtlich Namen statt Zeilennummern: diese Aufzählung stand
+                zuerst mit Zahlen hier und zeigte nach dem eigenen Commit um
+                30 Zeilen daneben — ausgerechnet der Verweis auf die
+                Log-Zeile landete auf dem Gegenbeispiel (Adversary F008).
 
         Returns:
             "no_stage" if no matching stage, "no_weather" if the weather
@@ -1594,9 +1609,10 @@ class TripReportSchedulerService:
         Eintrag aus einem vom Nutzer ANGEFORDERTEN Versand stammt und nicht aus
         dem regulären Slot. Angefordert sind alle drei Wege, die AC-12
         aufzählt: SMS „heute"/„morgen" (`send_on_demand_report`), der
-        Test-Versand-Knopf (`send_test_report_outcome`,
-        `api/routers/scheduler.py:232`) und das Inbound-Kommando „report"
-        (`send_test_report`, `trip_command_processor.py:1019`). Die
+        Test-Versand-Knopf (`send_test_report_outcome`, gerufen von
+        `api/routers/scheduler.send_test_trip_report`) und das Inbound-Kommando
+        „report" (`send_test_report`, gerufen von
+        `trip_command_processor._trigger_report`). Die
         Rückwärts-Ableitung in `briefing_slots._log_bezeugt_versand`
         überspringt solche Einträge — ohne das Feld nähme eine Nutzeranfrage
         dem Nutzer sein reguläres Briefing desselben Ortstags (AC-12).
@@ -1605,8 +1621,8 @@ class TripReportSchedulerService:
         die Cockpit-Kachel #393, und das ist eine andere Scheibe. Der
         JSON-Schlüssel heißt weiterhin `on_demand` — er ist das Wire-Format,
         das `briefing_slots` liest; Go liest die Datei nur
-        (`internal/store/log.go:23`), ignoriert unbekannte Felder und schreibt
-        sie deshalb auch nicht weg.
+        (`store.LoadBriefingLog`, kein Schreibpfad), ignoriert unbekannte
+        Felder und schreibt sie deshalb auch nicht weg.
         """
         path = get_data_dir(self._user_id) / "briefing_log.json"
         data = json.loads(path.read_text()) if path.exists() else {"entries": []}

--- a/tests/tdd/test_briefing_anchor_survives_dispatch_failure.py
+++ b/tests/tdd/test_briefing_anchor_survives_dispatch_failure.py
@@ -348,7 +348,9 @@ def test_ac3_versandfehler_zaehlt_weiterhin_als_fehlschlag_und_wird_protokollier
     strategy._service = _fixture_scheduler(25.0)(settings=settings, user_id=uid)
 
     with caplog.at_level(logging.ERROR, logger="dispatch_orchestrator"):
-        strategy.dispatch_one((trip, "morning"))
+        # Issue #1725: `collect_due` liefert (trip, report_type, ORTSTAG) —
+        # das dritte Glied des Idempotenz-Schluessels.
+        strategy.dispatch_one((trip, "morning", stage_date(LAT, LON)))
 
     assert strategy.result() == (0, 1), (
         "Ein Versandfehler muss weiterhin als fehlgeschlagener Lauf zaehlen "
@@ -1214,7 +1216,9 @@ def test_gelingender_regulaerer_versand_macht_den_vermerk_gegenstandslos(monkeyp
 
     zugestellt = _recording_email(monkeypatch)
     strategy = _strategy(uid, _settings_email_ok())
-    due = [(trip, "morning")]
+    # Issue #1725: `collect_due` liefert (trip, report_type, ORTSTAG) — das
+    # dritte Glied des Idempotenz-Schluessels.
+    due = [(trip, "morning", stage_date(LAT, LON))]
 
     strategy.pre_pass(now_utc=_zeitpunkt_ortsstunde(7), due=due)
     assert _dispatch_marker(uid) is not None, (
@@ -1227,7 +1231,7 @@ def test_gelingender_regulaerer_versand_macht_den_vermerk_gegenstandslos(monkeyp
         f"zustellen (Doppel-Nachricht): {zugestellt!r} (#1662 AC-5)"
     )
 
-    strategy.dispatch_one((trip, "morning"))
+    strategy.dispatch_one((trip, "morning", stage_date(LAT, LON)))
 
     assert len(zugestellt) == 1, (
         f"Der Nutzer muss genau EINE Nachricht bekommen, erhalten: "
@@ -1263,9 +1267,10 @@ def test_erneut_gescheiterter_regulaerer_versand_haelt_den_vermerk_am_leben():
     _seed_marker(uid, trip, reason="dispatch_error")
 
     strategy = _strategy(uid, _settings_email_broken())
-    due = [(trip, "morning")]
+    # Issue #1725: dritte Stelle = Ortstag (Idempotenz-Schluessel).
+    due = [(trip, "morning", stage_date(LAT, LON))]
     strategy.pre_pass(now_utc=_zeitpunkt_ortsstunde(7), due=due)
-    strategy.dispatch_one((trip, "morning"))
+    strategy.dispatch_one((trip, "morning", stage_date(LAT, LON)))
 
     assert strategy.result() == (0, 1), (
         f"Vorbedingung: der Lauf muss als gescheitert zaehlen, erhalten: "

--- a/tests/tdd/test_briefing_faelligkeit_ortszone.py
+++ b/tests/tdd/test_briefing_faelligkeit_ortszone.py
@@ -98,9 +98,74 @@ def _faellig(scheduler, now_utc: datetime) -> set[tuple[str, str]]:
     return {(eintrag[0].id, eintrag[1]) for eintrag in scheduler._collect_due_trips(now_utc)}
 
 
-def _stunden_eines_tages(tag: date) -> list[datetime]:
-    start = datetime(tag.year, tag.month, tag.day, 0, 0, tzinfo=timezone.utc)
-    return [start + timedelta(hours=h) for h in range(24)]
+def _scheduler_ohne_netz(user_id: str):
+    """Echter Scheduler, bei dem AUSSCHLIESSLICH die Naht zum Netz ersetzt ist
+    — kein Mock, eine echte Unterklasse mit echter Implementierung.
+
+    Issue #1725: Fälligkeit ist seither ein FENSTER von drei Ortsstunden, und
+    die Einmaligkeit entsteht durch den Vermerk `(trip_id, ortstag, slot)`, der
+    erst beim VERSAND geschrieben wird. Wer nur sammelt, sieht deshalb drei
+    Treffer statt einem — die Tests unten fahren die vollständige Kette
+    (`_lauf`), und dafür darf der Versand nicht ins Netz gehen.
+    """
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    class _OhneNetz(TripReportSchedulerService):
+        def _send_trip_report_outcome(self, trip, report_type, **kwargs):
+            return "sent"
+
+    return _OhneNetz(user_id=user_id)
+
+
+def _lauf(scheduler, now_utc: datetime) -> set[tuple[str, str, date]]:
+    """Ein vollständiger Sammellauf: sammeln, dann jedes fällige Element über
+    `_dispatch_due_item` abarbeiten — genau die Kette, die
+    `run_briefing_dispatch` fährt (`collect_due` → Schleife über
+    `dispatch_one`), ohne die 2s-Pause und ohne `pre_pass`.
+
+    Rückgabe ist die GESAMMELTE Menge, jeweils mit dem ORTSTAG des Laufs als
+    drittem Glied (Issue #1725) — nur mit ihm lässt sich ein Treffer dem
+    Ortstag zuordnen, zu dem er gehört.
+    """
+    gesammelt = list(scheduler._collect_due_trips(now_utc))
+    for trip, report_type, ortstag in gesammelt:
+        scheduler._dispatch_due_item(trip, report_type, ortstag)
+    return {(t.id, rt, tag) for t, rt, tag in gesammelt}
+
+
+def _slots(scheduler, now_utc: datetime) -> set[tuple[str, str]]:
+    """`_lauf` ohne den Ortstag — für die Tests, die genau EINE Zone messen und
+    deshalb ohnehin nur Zeitpunkte eines einzigen Ortstags durchlaufen."""
+    return {(trip_id, rt) for trip_id, rt, _ in _lauf(scheduler, now_utc)}
+
+
+def _ortstag_schritte(zone: "ZoneInfo | timezone", tag: date) -> list[datetime]:
+    """Stündliche UTC-Zeitpunkte, die den ORTSTAG `tag` in `zone` abdecken —
+    von Ortsmitternacht zu Ortsmitternacht.
+
+    Issue #1725: gezählt wird über den ORTSTAG, nicht mehr über den UTC-Tag.
+    Der Produktivcode entscheidet über Ortstage (ADR-0044), und die
+    Einmaligkeit gilt je Ortstag — ein UTC-Tag deckt bei jedem Zonen-Versatz
+    Teile ZWEIER Ortstage ab (bei Kathmandu +5:45 beginnt er um 05:45
+    Ortszeit) und zählte dann zwei völlig korrekte Treffer AUS ZWEI ORTSTAGEN
+    als Dopplung. Wer hier auf eine Iteration über den UTC-Tag zurückdreht
+    (die frühere Fassung `_stunden_eines_tages`, mit dieser Änderung
+    entfallen), misst wieder am falschen Maßstab.
+
+    Die Länge des Ortstags wird BERECHNET (ADR-0044): beide Ortsmitternachte
+    werden erst nach UTC gebracht, dort verglichen. Ein Vergleich der beiden
+    Wanduhr-Werte mit identischem `tzinfo` ergäbe an JEDEM Tag 24,0 h und
+    verschluckte die Umstellungstage.
+    """
+    start = datetime(tag.year, tag.month, tag.day, 0, 0, tzinfo=zone)
+    ende = start + timedelta(days=1)  # Wanduhr-Addition -> nächste Ortsmitternacht
+    t = start.astimezone(timezone.utc)
+    grenze = ende.astimezone(timezone.utc)
+    schritte = []
+    while t < grenze:
+        schritte.append(t)
+        t += timedelta(hours=1)
+    return schritte
 
 
 # ---------------------------------------------------------------------------
@@ -117,11 +182,14 @@ def test_ac1_auckland_faellig_genau_zur_ortsstunde():
     # zum jeweiligen Ortstag existiert.
     tage = [date(2026, 8, 19), date(2026, 8, 20), date(2026, 8, 21)]
     _schreibe("tz-ac1", [_trip_json("nz", lat, lon, tage)])
-    scheduler = _scheduler("tz-ac1")
+    # Issue #1725: vollständige Kette (sammeln + versenden) über den ORTSTAG.
+    # Die Fälligkeit ist seither ein Fenster; erst der beim Versand
+    # geschriebene Vermerk macht daraus genau einen Treffer.
+    scheduler = _scheduler_ohne_netz("tz-ac1")
 
     treffer = [
-        now for now in _stunden_eines_tages(date(2026, 8, 20))
-        if ("nz", "morning") in _faellig(scheduler, now)
+        now for now in _ortstag_schritte(zone, date(2026, 8, 20))
+        if ("nz", "morning") in _slots(scheduler, now)
     ]
 
     assert len(treffer) == 1, (
@@ -148,12 +216,24 @@ def test_ac2_vier_zonen_je_zur_eigenen_ortsstunde():
         for name, (lat, lon) in ZONEN.items()
     ]
     _schreibe("tz-ac2", trips)
-    scheduler = _scheduler("tz-ac2")
+    scheduler = _scheduler_ohne_netz("tz-ac2")
+
+    # Issue #1725: EIN gemeinsamer Lauf wie bisher, aber über die VEREINIGUNG
+    # der vier Ortstage 2026-08-20 statt über den UTC-Tag — die vier Zonen
+    # haben zum selben Zeitpunkt verschiedene Ortstage. Gezählt werden je Trip
+    # nur die Treffer, die auf SEINEN Ortstag 2026-08-20 fallen (drittes Glied
+    # der Sammlung). Über einen UTC-Tag gezählt fielen bei Kathmandu (+5:45)
+    # zwei völlig korrekte Treffer aus ZWEI Ortstagen zusammen.
+    ortstag = date(2026, 8, 20)
+    schritte = sorted({
+        t for zone_name in ZONEN
+        for t in _ortstag_schritte(ZoneInfo(zone_name), ortstag)
+    })
 
     ankunft: dict[str, list[datetime]] = {t["id"]: [] for t in trips}
-    for now in _stunden_eines_tages(date(2026, 8, 20)):
-        for trip_id, rt in _faellig(scheduler, now):
-            if rt == "morning":
+    for now in schritte:
+        for trip_id, rt, tag in _lauf(scheduler, now):
+            if rt == "morning" and tag == ortstag:
                 ankunft[trip_id].append(now)
 
     for zone_name in ZONEN:
@@ -238,11 +318,12 @@ def test_ac4_korsika_unveraendert(konfig_stunde: int):
         f"tz-ac4-{konfig_stunde}",
         [_trip_json("korsika", lat, lon, tage, morning=f"{konfig_stunde:02d}:00:00")],
     )
-    scheduler = _scheduler(f"tz-ac4-{konfig_stunde}")
+    scheduler = _scheduler_ohne_netz(f"tz-ac4-{konfig_stunde}")
 
+    # Issue #1725: vollständige Kette über den ORTSTAG (s. `_ortstag_schritte`).
     treffer = [
-        now for now in _stunden_eines_tages(date(2026, 8, 20))
-        if ("korsika", "morning") in _faellig(scheduler, now)
+        now for now in _ortstag_schritte(ZoneInfo("Europe/Paris"), date(2026, 8, 20))
+        if ("korsika", "morning") in _slots(scheduler, now)
     ]
 
     # Vorher: fällig, wenn Wiener Stunde == konfig_stunde. Wien und Paris
@@ -295,11 +376,14 @@ def test_ac6_trip_ohne_wegpunkte_verliert_sein_briefing_nicht():
     for stage in trip["stages"]:
         stage["waypoints"] = []
     _schreibe("tz-ac6", [trip])
-    scheduler = _scheduler("tz-ac6")
+    scheduler = _scheduler_ohne_netz("tz-ac6")
 
+    # Issue #1725: vollständige Kette über den ORTSTAG. Ortszone dieses Trips
+    # ist der dokumentierte UTC-Rückfall aus `trip_day.trip_tz` (keine
+    # Wegpunkte), sein Ortstag ist damit der UTC-Tag.
     treffer = [
-        now for now in _stunden_eines_tages(date(2026, 8, 20))
-        if ("ohne-wp", "morning") in _faellig(scheduler, now)
+        now for now in _ortstag_schritte(timezone.utc, date(2026, 8, 20))
+        if ("ohne-wp", "morning") in _slots(scheduler, now)
     ]
     assert len(treffer) == 1, (
         f"Trip ohne Wegpunkte verliert sein Briefing (Treffer: {len(treffer)}) — "

--- a/tests/tdd/test_briefing_faelligkeit_ortszone.py
+++ b/tests/tdd/test_briefing_faelligkeit_ortszone.py
@@ -89,8 +89,13 @@ def _faellig(scheduler, now_utc: datetime) -> set[tuple[str, str]]:
 
     Ruft die Fälligkeitssammlung mit einem ZEITPUNKT auf — vor dem Fix nimmt
     sie eine vorberechnete Stunde und schlägt hier fehl.
+
+    Issue #1725: die Sammlung liefert seither ein DRITTES Element (den Ortstag
+    des Laufs, Teil des Idempotenz-Schlüssels). Die Tests dieser Datei fragen
+    unverändert nur nach Trip und Slot — deshalb wird hier nur der Kopf des
+    Tupels ausgewertet, statt die Stelligkeit festzunageln.
     """
-    return {(t.id, rt) for t, rt in scheduler._collect_due_trips(now_utc)}
+    return {(eintrag[0].id, eintrag[1]) for eintrag in scheduler._collect_due_trips(now_utc)}
 
 
 def _stunden_eines_tages(tag: date) -> list[datetime]:
@@ -306,45 +311,71 @@ def test_ac6_trip_ohne_wegpunkte_verliert_sein_briefing_nicht():
 
 
 # ---------------------------------------------------------------------------
-# AC-7 — Sommerzeit: bekannte Lücke festnageln, NICHT als behoben ausgeben
+# AC-7 — Sommerzeit: an beiden Umstellungstagen genau ein Briefing
 # ---------------------------------------------------------------------------
 
-def test_ac7_sommerzeit_luecke_ist_gemessen_nicht_behauptet():
+def test_ac7_sommerzeit_umstellung_liefert_genau_ein_briefing():
     """Given Trip auf Korsika mit Briefing 02:00 / When der Lauf an den beiden
-    Umstellungstagen geht / Then haelt dieser Test das TATSAECHLICHE Verhalten
-    fest: am 29.03. faellt das Briefing aus, am 25.10. wird es zweimal faellig.
+    Umstellungstagen den Ortstag abschreitet / Then faellt das Briefing an
+    BEIDEN Tagen genau einmal: am 29.03. nachgeholt (die Ortsstunde 02
+    existiert nicht, Ortsstunde 03 erfuellt `3 >= 2 and 3 < 5`), am 25.10.
+    nur beim ERSTEN Durchlauf der doppelten Ortsstunde 02 — der Vermerk
+    filtert den zweiten.
 
-    Das ist kein Nachweis einer Behebung — die Behebung ist #1725. Wird dieser
-    Test dort rot, ist das die Absicht: er wird dann auf das Zielverhalten
-    umgeschrieben.
+    Bis #1725 hielt dieser Test hier das Fehlverhalten fest (0 Treffer am
+    29.03., 2 am 25.10.) und sagte in seinem Docstring an, dass er auf das
+    Zielverhalten umgeschrieben wird, sobald die Luecke geschlossen ist. Genau
+    das ist hier geschehen; die Fallabdeckung selbst (Fenster, Idempotenz-
+    Schluessel, Outcome-Matrix) liegt in
+    `tests/tdd/test_briefing_slot_idempotenz.py`.
+
+    Der Vermerk entsteht erst beim VERSAND — der Lauf hier ist deshalb die
+    vollstaendige Kette aus `run_briefing_dispatch` (sammeln, dann jedes
+    faellige Element ueber `_dispatch_due_item` abarbeiten). Ersetzt ist nur
+    die Naht zum Netz.
     """
+    from services.trip_report_scheduler import TripReportSchedulerService
+
     lat, lon = ZONEN["Europe/Paris"]
     zone = ZoneInfo("Europe/Paris")
     tage = [date(2026, 3, 28), date(2026, 3, 29), date(2026, 3, 30),
             date(2026, 10, 24), date(2026, 10, 25), date(2026, 10, 26)]
     _schreibe("tz-ac7", [_trip_json("korsika", lat, lon, tage, morning="02:00:00")])
-    scheduler = _scheduler("tz-ac7")
+
+    class _OhneNetz(TripReportSchedulerService):
+        """Echte Unterklasse, die nur den Versand ersetzt — kein Mock."""
+
+        def _send_trip_report_outcome(self, trip, report_type, **kwargs):
+            return "sent"
+
+    scheduler = _OhneNetz(user_id="tz-ac7")
 
     def treffer_am(tag: date) -> int:
-        # Ortstag von Ortsmitternacht bis Ortsmitternacht abschreiten.
+        # Ortstag von Ortsmitternacht bis Ortsmitternacht abschreiten. Die
+        # Laenge wird BERECHNET (ADR-0044): beide Ortsmitternachte erst nach
+        # UTC bringen, sonst ergibt die Subtraktion an jedem Tag 24,0 h.
         start = datetime(tag.year, tag.month, tag.day, 0, 0, tzinfo=zone)
         ende = start + timedelta(days=1)
         t = start.astimezone(timezone.utc)
         n = 0
         while t < ende.astimezone(timezone.utc):
-            if ("korsika", "morning") in _faellig(scheduler, t):
+            gesammelt = list(scheduler._collect_due_trips(t))
+            for trip, report_type, ortstag in gesammelt:
+                scheduler._dispatch_due_item(trip, report_type, ortstag)
+            if ("korsika", "morning") in [(x.id, rt) for x, rt, _ in gesammelt]:
                 n += 1
             t += timedelta(hours=1)
         return n
 
-    assert treffer_am(date(2026, 3, 29)) == 0, (
-        "Fruehjahrs-Umstellung: Ortsstunde 02 existiert nicht, das Briefing "
-        "entfaellt. Wenn hier 1 steht, ist die Luecke geschlossen — dann "
-        "gehoert dieser Test nach #1725 umgeschrieben, nicht angepasst."
+    assert treffer_am(date(2026, 3, 29)) == 1, (
+        "Fruehjahrs-Umstellung: die Ortsstunde 02 existiert nicht — das "
+        "Briefing muss trotzdem genau einmal fallen (nachgeholt in Ortsstunde "
+        "03). 0 heisst: die Faelligkeit haengt wieder an Stundengleichheit."
     )
-    assert treffer_am(date(2026, 10, 25)) == 2, (
-        "Herbst-Umstellung: Ortsstunde 02 existiert zweimal, das Briefing wird "
-        "zweimal faellig (bekannte Luecke, #1725)."
+    assert treffer_am(date(2026, 10, 25)) == 1, (
+        "Herbst-Umstellung: die Ortsstunde 02 existiert zweimal — das Briefing "
+        "darf trotzdem nur einmal fallen. 2 heisst: der Idempotenz-Schluessel "
+        "(trip_id, ortstag, slot) greift nicht."
     )
 
 

--- a/tests/tdd/test_briefing_slot_idempotenz.py
+++ b/tests/tdd/test_briefing_slot_idempotenz.py
@@ -1029,83 +1029,139 @@ def _aufzeichnender_mailversand(monkeypatch) -> list:
     return zugestellt
 
 
-def test_t12b_zugestellter_on_demand_versand_laesst_den_regulaeren_slot_faellig(
-    monkeypatch,
+#: Die DREI Einstiege, die AC-12 als „angefordert" aufzaehlt, plus der
+#: regulaere Weg als Gegenrichtung. Zweites Glied: bleibt der regulaere Slot
+#: danach faellig?
+ANGEFORDERTE_EINSTIEGE = [
+    # SMS-Kommando „heute"/„morgen" (`trip_command_processor.py:576`).
+    ("send_on_demand_report", True),
+    # Test-Versand-Knopf der Oberflaeche (`api/routers/scheduler.py:232`).
+    ("send_test_report_outcome", True),
+    # Inbound-Kommando „report" (`trip_command_processor.py:1019`).
+    ("send_test_report", True),
+    # Gegenrichtung (Adversary F007): der REGULAERE Versand — derselbe Aufruf,
+    # den auch der #1012-Nachliefer-Pfad ohne vorherige Reservierung macht.
+    ("regulaerer_versand", False),
+]
+
+
+def _ausloesen(scheduler, trip, einstieg: str):
+    """Ruft genau den benannten Einstieg — kein Nachbau, keine Abkuerzung."""
+    if einstieg == "regulaerer_versand":
+        return scheduler._send_trip_report_outcome(trip, "morning")
+    ergebnis = getattr(scheduler, einstieg)(trip, "morning")
+    # `send_test_report` liefert den bool-Bestand (#1007), die beiden anderen
+    # den Ausgangs-String. Auf eine gemeinsame Aussage bringen.
+    return "sent" if ergebnis is True else ergebnis
+
+
+@pytest.mark.parametrize("einstieg,bleibt_faellig", ANGEFORDERTE_EINSTIEGE)
+def test_t12b_angeforderter_versand_laesst_den_regulaeren_slot_faellig(
+    monkeypatch, einstieg: str, bleibt_faellig: bool,
 ):
-    """Given ein per SMS angefordertes „heute" wird TATSAECHLICH zugestellt
-    (Ausgang `sent`) / When der regulaere Sammellauf zur konfigurierten Stunde
-    laeuft / Then ist der Slot weiterhin faellig.
+    """Given ein Briefing wird ueber einen der drei ANGEFORDERTEN Wege
+    tatsaechlich zugestellt (Ausgang `sent`) / When der regulaere Sammellauf
+    zur konfigurierten Stunde laeuft / Then ist der Slot weiterhin faellig.
+    Der vierte Fall prueft die Gegenrichtung: nach einem REGULAEREN Versand
+    gilt der Slot als erledigt.
 
     🔴 Adversary-Finding F004 — die Luecke, die T12 nicht sehen kann: T12 prueft
     einen On-Demand-Versand, der ehrlich in `no_stage` endet, und kehrt damit
-    zurueck, BEVOR `_append_briefing_log` (`trip_report_scheduler.py:1337`)
-    erreicht ist. Genau dieser Log-Eintrag ist aber die Spur, ueber die ein
-    angefordertes Briefing dem Nutzer sein regulaeres wegnahm: die
-    Rueckwaerts-Ableitung (AC-9) liest `trip_id`, `kind` und `sent_at`, solange
-    `briefing_slots.json` noch nicht existiert — also genau in dem Zeitfenster
-    nach einem Deploy, in dem typischerweise der Test-Versand gedrueckt wird.
+    zurueck, BEVOR `_append_briefing_log` erreicht ist. Genau dieser
+    Log-Eintrag ist aber die Spur, ueber die ein angefordertes Briefing dem
+    Nutzer sein regulaeres wegnahm: die Rueckwaerts-Ableitung (AC-9) liest
+    `trip_id`, `kind` und `sent_at`, solange `briefing_slots.json` noch nicht
+    existiert — also genau in dem Zeitfenster nach einem Deploy, in dem
+    typischerweise der Test-Versand gedrueckt wird.
+
+    🔴 Adversary-Finding F006 — warum ueber ALLE DREI Einstiege parametrisiert:
+    Der erste Fix kennzeichnete nur den SMS-Weg. Test-Versand-Knopf und
+    Inbound-Kommando „report" schrieben weiterhin einen unmarkierten Eintrag
+    und nahmen dem Nutzer sein regulaeres Briefing — von AC-12 ausdruecklich
+    aufgezaehlt, von keinem Test gesehen. Ein Test, der nur einen der drei
+    Wege faehrt, ist gegen genau diesen Fehler blind.
+
+    🔴 Adversary-Finding F007 — warum der vierte Fall dazugehoert: Ohne ihn
+    faengt kein Test, wenn JEDER Versand als angefordert markiert wird. Er
+    faehrt bewusst `_send_trip_report_outcome` direkt statt ueber
+    `_dispatch_due_item`: das ist die Form, in der auch der
+    #1012-Nachliefer-Pfad sendet — OHNE vorherige Reservierung, der Speicher
+    fehlt also noch und die Rueckwaerts-Ableitung ist die einzige Absicherung.
+    Ueber den Wrapper gemessen waere die Markierung folgenlos, weil `reserve`
+    die Datei ohnehin anlegt.
 
     Ersetzt sind ausschliesslich die zwei Naehte zum Netz: der Wetterabruf
     (Fixture-Unterklasse) und der Mail-Transportrand (aufzeichnende Funktion).
     `_send_trip_report_outcome`, der Log-Schreiber, der Speicher und die
     Sammlung laufen echt.
 
-    RED-Charakter: Mutations-Waechter — rot bei: `on_demand` nicht im
-    Log-Eintrag festgehalten oder in `_log_bezeugt_versand` nicht uebersprungen.
-    Dann faellt das regulaere Briefing dieses Ortstags still aus — ohne
-    Protokollzeile, ohne Fehlerzaehler.
+    RED-Charakter: Mutations-Waechter — rot bei: `angefordert` an EINEM der
+    drei Einstiege nicht gesetzt (dann faellt genau dessen Parameterfall),
+    nicht in den Log-Eintrag geschrieben, in `_log_bezeugt_versand` nicht
+    uebersprungen — oder, im vierten Fall, hart auf `True` gesetzt.
     """
     from app.loader import get_data_dir, load_all_trips
     from services.trip_day import trip_local_today
 
+    nutzer = f"slot-t12b-{einstieg}"
     jetzt = datetime.now(timezone.utc)
     heute_ort = local_dt(jetzt, PARIS).date()
-    _schreibe("slot-t12b", [_trip_json(
+    _schreibe(nutzer, [_trip_json(
         "korsika", *KORSIKA,
         [heute_ort - timedelta(days=1), heute_ort, heute_ort + timedelta(days=1)],
         morning="07:00:00",
     )])
-    trip = load_all_trips(user_id="slot-t12b")[0]
+    trip = load_all_trips(user_id=nutzer)[0]
     ortstag = trip_local_today(trip, jetzt)
     settings = _zustellbare_settings()
     zugestellt = _aufzeichnender_mailversand(monkeypatch)
-    scheduler = _scheduler_mit_fixture_wetter("slot-t12b", settings)
+    scheduler = _scheduler_mit_fixture_wetter(nutzer, settings)
 
-    # a) Der On-Demand-Versand geht wirklich raus.
-    assert scheduler.send_on_demand_report(trip, "morning") == "sent", (
-        "Testaufbau prueft nichts: nur ein zugestellter On-Demand-Versand "
-        "erreicht `_append_briefing_log` — genau darum geht es hier."
+    # a) Der Versand geht ueber DIESEN Einstieg wirklich raus.
+    assert _ausloesen(scheduler, trip, einstieg) == "sent", (
+        f"Testaufbau prueft nichts: nur ein zugestellter Versand ueber "
+        f"`{einstieg}` erreicht `_append_briefing_log` — genau darum geht es."
     )
     assert len(zugestellt) == 1, (
         f"Genau eine zugestellte Nachricht erwartet, gefunden {len(zugestellt)}"
     )
     log_eintraege = json.loads(
-        (get_data_dir("slot-t12b") / "briefing_log.json").read_text(encoding="utf-8")
+        (get_data_dir(nutzer) / "briefing_log.json").read_text(encoding="utf-8")
     )["entries"]
     assert [e["kind"] for e in log_eintraege] == ["morning"], (
         "Testaufbau prueft nichts: der Log-Eintrag, um den es geht, muss "
         f"entstanden sein. Gefunden: {log_eintraege}"
     )
-
-    # b) Die eigentliche Zusicherung (AC-12): der regulaere Slot bleibt faellig.
-    assert not (get_data_dir("slot-t12b") / "briefing_slots.json").exists(), (
+    assert not (get_data_dir(nutzer) / "briefing_slots.json").exists(), (
         "Testaufbau prueft nichts: ohne eigenen Speicher greift die "
         "Rueckwaerts-Ableitung gar nicht, und der Fall waere unerreichbar."
     )
-    assert not BriefingSlotStore("slot-t12b").is_recorded(
+
+    # b) Die eigentliche Zusicherung.
+    erledigt = BriefingSlotStore(nutzer).is_recorded(
         "korsika", "morning", ortstag, zone=PARIS,
-    ), (
-        "Ein angefordertes Briefing darf den regulaeren Slot nicht als "
-        "erledigt erscheinen lassen."
     )
-    assert ("korsika", "morning") in _sammlung(
-        _scheduler("slot-t12b"), _zeitpunkt(PARIS, ortstag, 7),
-    ), (
-        "Der regulaere 07:00-Slot muss weiterhin faellig sein (AC-12). Ist er "
-        "es nicht, hat die Rueckwaerts-Ableitung den On-Demand-Eintrag aus "
-        "briefing_log.json gelesen — der Nutzer verliert sein regulaeres "
-        "Briefing dieses Ortstags stillschweigend."
+    gesammelt = ("korsika", "morning") in _sammlung(
+        _scheduler(nutzer), _zeitpunkt(PARIS, ortstag, 7),
     )
+
+    if bleibt_faellig:
+        assert not erledigt and gesammelt, (
+            f"Der regulaere 07:00-Slot muss nach `{einstieg}` weiterhin "
+            "faellig sein (AC-12). Ist er es nicht, hat die "
+            "Rueckwaerts-Ableitung den Eintrag dieses ANGEFORDERTEN Versands "
+            "gelesen — der Nutzer verliert sein regulaeres Briefing dieses "
+            f"Ortstags stillschweigend. erledigt={erledigt}, "
+            f"gesammelt={gesammelt}"
+        )
+    else:
+        assert erledigt and not gesammelt, (
+            "Nach einem REGULAEREN Versand muss der Slot als erledigt gelten "
+            "(AC-9). Gilt er es nicht, ist der Eintrag faelschlich als "
+            "angefordert markiert und die Rollout-Absicherung ausgehebelt — "
+            "der #1012-Nachliefer-Pfad sendet ohne Reservierung, dort ist sie "
+            f"die einzige. erledigt={erledigt}, gesammelt={gesammelt}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tdd/test_briefing_slot_idempotenz.py
+++ b/tests/tdd/test_briefing_slot_idempotenz.py
@@ -133,9 +133,13 @@ from services.briefing_slots import BriefingSlotStore  # noqa: E402
 # Koordinaten je Zone — echte Orte, damit TimezoneFinder sie auflöst.
 KORSIKA = (42.30, 8.93)          # Europe/Paris
 LORD_HOWE = (-31.5545, 159.0821)  # Australia/Lord_Howe (+10:30/+11:00)
+# Adversary-Finding F002: eine Zone, deren ORTSTAG zur Briefing-Stunde vom
+# UTC-Tag abweicht — 07:00 Ortszeit am 20.08. ist 2026-08-19T19:00Z.
+AUCKLAND = (-36.85, 174.76)      # Pacific/Auckland (+12:00)
 
 PARIS = ZoneInfo("Europe/Paris")
 LORD_HOWE_TZ = ZoneInfo("Australia/Lord_Howe")
+AUCKLAND_TZ = ZoneInfo("Pacific/Auckland")
 
 # Die vier Ausgänge, die laut Spec einen Vermerk setzen, und der eine, der
 # es nicht tut (Spec „Vermerk je Outcome").
@@ -413,9 +417,17 @@ def test_t4_nachhol_fenster_faengt_h_plus_1_und_endet_vor_h_plus_3():
     genau einen Treffer — sichtbar wird die Breite nur an einem AUSGELASSENEN
     Lauf. Der Lauf zur Stunde H findet hier deshalb bewusst NICHT statt.
 
+    Adversary-Finding F001: H+1 und H+3 allein nageln die Breite NICHT fest —
+    beide Aussagen gelten auch bei Fensterbreite 2, und die Mutation 3 -> 2
+    liess die gesamte Suite gruen. Teil 1b prueft deshalb Ortsstunde H+2, den
+    einzigen Wert, der 3 von 2 unterscheidet. Der PO hat die drei Stunden
+    ausdruecklich freigegeben; ohne diese Messung koennte ein spaeterer Umbau
+    sie unbemerkt verengen, und der zweite ausgefallene Tick fiele still aus.
+
     RED-Charakter: Mutations-Waechter — rot bei: Fenster 3 -> 1 (dann ist H+1
-    nicht mehr faellig, erster Teil rot) UND bei Fenster 3 -> „bis Tagesende"
-    (dann ist H+3 noch faellig, zweiter Teil rot).
+    nicht mehr faellig, erster Teil rot), Fenster 3 -> 2 (dann ist H+2 nicht
+    mehr faellig, Teil 1b rot) UND bei Fenster 3 -> „bis Tagesende" (dann ist
+    H+3 noch faellig, zweiter Teil rot).
     """
     tage = [date(2026, 8, 19), date(2026, 8, 20), date(2026, 8, 21)]
     tag = date(2026, 8, 20)
@@ -430,6 +442,20 @@ def test_t4_nachhol_fenster_faengt_h_plus_1_und_endet_vor_h_plus_3():
         "der Slot nachgeholt werden. Ist er es nicht, ist das Nachhol-Fenster "
         "kleiner als 2 Stunden und faengt den an Umstellungstagen "
         "ausfallenden Cron-Tick nicht."
+    )
+
+    # Teil 1b (F001): Stunden 07 UND 08 ausgelassen, erster Lauf um 09
+    # Ortszeit. Diese Stunde unterscheidet Fensterbreite 3 von Breite 2 —
+    # `7 <= 9 < 10` trifft, `7 <= 9 < 9` nicht.
+    _schreibe("slot-t4c", [_trip_json("korsika", *KORSIKA, tage, morning="07:00:00")])
+    zweiter_nachzuegler = _scheduler("slot-t4c")
+    assert ("korsika", "morning") in _sammlung(
+        zweiter_nachzuegler, _zeitpunkt(PARIS, tag, 9)
+    ), (
+        "Zwei Ticks in Folge ausgefallen (07 und 08) — in Ortsstunde 09 muss "
+        "der Slot noch nachgeholt werden. Ist er es nicht, ist das Fenster auf "
+        "zwei Stunden verengt und deckt nur EINEN ausgefallenen Tick ab, "
+        "obwohl der PO drei Stunden freigegeben hat."
     )
 
     # Teil 2: Stunden 07, 08, 09 ausgelassen, erster Lauf um 10 Ortszeit.
@@ -661,16 +687,26 @@ def test_t9_rueckwaerts_ableitung_aus_dem_briefing_log():
     wird die Rueckwaerts-Ableitung selbst, also der Zustand direkt nach einem
     Deploy mitten im Nachhol-Fenster.
 
+    Teil c (Adversary-Finding F002) prueft, dass die Ableitung `sent_at` im
+    ORTSTAG des Trips auswertet und nicht in UTC: In `Europe/Paris` liegen
+    Ortstag und UTC-Tag zur Stunde 07 auf demselben Datum, die Zone ist am
+    Ergebnis also gar nicht ablesbar — beide Verfaelschungen (Zone nicht
+    durchgereicht, `zone or UTC` hart auf UTC) blieben mit den Teilen a/b
+    gruen. In `Pacific/Auckland` faellt 07:00 Ortszeit am 20.08. auf
+    `2026-08-19T19:00Z`, also einen ANDEREN UTC-Tag.
+
     RED-Charakter: Mutations-Waechter — rot bei: Rueckwaerts-Ableitung
-    entfernt; dann bekommt jeder Nutzer, dessen Briefing kurz vor dem Deploy
-    rausging, es im Fenster ein zweites Mal.
+    entfernt (dann bekommt jeder Nutzer, dessen Briefing kurz vor dem Deploy
+    rausging, es im Fenster ein zweites Mal) und, fuer Teil c, bei fehlender
+    Zonen-Durchreichung bzw. UTC-Auswertung von `sent_at`.
     """
     tage = [date(2026, 8, 19), date(2026, 8, 20), date(2026, 8, 21)]
     tag = date(2026, 8, 20)
     sieben_uhr = _zeitpunkt(PARIS, tag, 7)
 
-    def _mit_log(user: str, sent_at: datetime) -> None:
-        _schreibe(user, [_trip_json("korsika", *KORSIKA, tage, morning="07:00:00")])
+    def _mit_log(user: str, sent_at: datetime,
+                 koordinaten: tuple[float, float] = KORSIKA) -> None:
+        _schreibe(user, [_trip_json("korsika", *koordinaten, tage, morning="07:00:00")])
         pfad = get_data_dir(user) / "briefing_log.json"
         pfad.parent.mkdir(parents=True, exist_ok=True)
         pfad.write_text(json.dumps({"entries": [{
@@ -701,6 +737,26 @@ def test_t9_rueckwaerts_ableitung_aus_dem_briefing_log():
     ), (
         "Ein Eintrag vom VORTAG darf den heutigen Slot nicht blockieren — "
         "sonst faellt das Briefing nach dem ersten Tag dauerhaft aus."
+    )
+
+    # c) F002: Zone, deren Ortstag zur Briefing-Stunde vom UTC-Tag abweicht.
+    #    07:00 Ortszeit am 20.08. in Auckland ist 2026-08-19T19:00Z — wer
+    #    `sent_at` gegen UTC statt gegen den Ortstag auswertet, findet den
+    #    Eintrag nicht und sendet nach dem Deploy ein zweites Mal.
+    auckland_sieben_uhr = _zeitpunkt(AUCKLAND_TZ, tag, 7)
+    assert local_dt(auckland_sieben_uhr, UTC).date() != tag, (
+        "Testaufbau prueft nichts: UTC-Tag und Ortstag muessen hier "
+        f"auseinanderfallen, gefunden {local_dt(auckland_sieben_uhr, UTC).date()}"
+    )
+    _mit_log("slot-t9-auckland", auckland_sieben_uhr, koordinaten=AUCKLAND)
+    assert ("korsika", "morning") not in _sammlung(
+        _scheduler("slot-t9-auckland"), auckland_sieben_uhr
+    ), (
+        "Der Log-Eintrag liegt im ORTSTAG des Trips (20.08. Auckland), auch "
+        "wenn sein UTC-Tag der 19.08. ist. Wird `sent_at` gegen UTC statt "
+        "gegen den Ortstag ausgewertet — oder die Zone gar nicht erst "
+        "durchgereicht —, greift die Rueckwaerts-Ableitung fuer jeden Trip "
+        "oestlich von etwa UTC+8 und westlich von etwa UTC-5 nicht mehr."
     )
 
 
@@ -892,6 +948,166 @@ def test_t12_on_demand_schreibt_keinen_vermerk_und_liest_keinen(caplog):
     )
 
 
+# Alle Transport-Felder ausdruecklich unbrauchbar: `Settings()` faellt bei
+# fehlenden Feldern still auf die Prod-`.env` im Worktree zurueck (#1477).
+# SMTP ist vollstaendig, aber auf einen nicht existierenden Host gesetzt — der
+# Transportrand selbst wird unten durch eine aufzeichnende Funktion ersetzt.
+_TOTE_TRANSPORT_FELDER: dict = {
+    "smtp_host": "dummy.invalid", "smtp_user": "dummy", "smtp_pass": "dummy",
+    "mail_to": "dummy@example.com",
+    "telegram_bot_token": "", "telegram_chat_id": "",
+    "telegram_test_bot_token": "", "telegram_test_chat_id": "",
+    "sms_gateway_url": "", "seven_api_key": "", "sms_to": "",
+}
+
+
+def _zustellbare_settings():
+    """Echte `Settings`: E-Mail sendefaehig, Telegram/SMS nachweislich nicht."""
+    from app.config import Settings
+
+    settings = Settings(**_TOTE_TRANSPORT_FELDER)
+    assert settings.can_send_email() is True, (
+        "Vorbedingung: ohne sendefaehigen Kanal endet der Versand in "
+        "'no_channels' und erreicht den briefing_log-Eintrag nie."
+    )
+    # Sicherung (#1477): kein Kanal, der echte Nachrichten ausloesen koennte.
+    assert settings.can_send_telegram() is False
+    assert settings.can_send_sms() is False
+    return settings
+
+
+def _scheduler_mit_fixture_wetter(user_id: str, settings):
+    """Echter Scheduler, bei dem NUR der Wetterabruf aus einer Fixture kommt —
+    Haus-Muster `_FixtureScheduler` aus
+    `tests/tdd/test_briefing_anchor_survives_dispatch_failure.py:226`.
+
+    Kein Mock: eine echte Unterklasse, die `_fetch_weather` durch echte
+    `SegmentWeatherData`-Objekte beantwortet. Alles danach — Rendering,
+    Kanalauswahl, `_append_briefing_log` — laeuft unveraendert echt.
+    """
+    from app.models import (
+        ForecastMeta,
+        NormalizedTimeseries,
+        Provider,
+        SegmentWeatherData,
+        SegmentWeatherSummary,
+    )
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    class _MitFixtureWetter(TripReportSchedulerService):
+        def _fetch_weather(self, segments, provider=None):
+            return [
+                SegmentWeatherData(
+                    segment=s,
+                    timeseries=NormalizedTimeseries(
+                        meta=ForecastMeta(
+                            provider=Provider.OPENMETEO, model="test", grid_res_km=1.0,
+                        ),
+                        data=[],
+                    ),
+                    aggregated=SegmentWeatherSummary(),
+                    fetched_at=datetime.now(timezone.utc),
+                    provider="openmeteo",
+                )
+                for s in segments
+            ]
+
+    return _MitFixtureWetter(settings=settings, user_id=user_id)
+
+
+def _aufzeichnender_mailversand(monkeypatch) -> list:
+    """Ersetzt den Transportrand `EmailOutput.send` durch eine echte,
+    aufzeichnende Funktion (Haus-Muster) — kein Netz, kein Mock-Objekt."""
+    from output.channels.email import EmailOutput
+
+    zugestellt: list = []
+
+    def _record(self, *, subject, body, **kwargs):
+        zugestellt.append({"subject": subject, "body": body})
+
+    monkeypatch.setattr(EmailOutput, "send", _record)
+    return zugestellt
+
+
+def test_t12b_zugestellter_on_demand_versand_laesst_den_regulaeren_slot_faellig(
+    monkeypatch,
+):
+    """Given ein per SMS angefordertes „heute" wird TATSAECHLICH zugestellt
+    (Ausgang `sent`) / When der regulaere Sammellauf zur konfigurierten Stunde
+    laeuft / Then ist der Slot weiterhin faellig.
+
+    🔴 Adversary-Finding F004 — die Luecke, die T12 nicht sehen kann: T12 prueft
+    einen On-Demand-Versand, der ehrlich in `no_stage` endet, und kehrt damit
+    zurueck, BEVOR `_append_briefing_log` (`trip_report_scheduler.py:1337`)
+    erreicht ist. Genau dieser Log-Eintrag ist aber die Spur, ueber die ein
+    angefordertes Briefing dem Nutzer sein regulaeres wegnahm: die
+    Rueckwaerts-Ableitung (AC-9) liest `trip_id`, `kind` und `sent_at`, solange
+    `briefing_slots.json` noch nicht existiert — also genau in dem Zeitfenster
+    nach einem Deploy, in dem typischerweise der Test-Versand gedrueckt wird.
+
+    Ersetzt sind ausschliesslich die zwei Naehte zum Netz: der Wetterabruf
+    (Fixture-Unterklasse) und der Mail-Transportrand (aufzeichnende Funktion).
+    `_send_trip_report_outcome`, der Log-Schreiber, der Speicher und die
+    Sammlung laufen echt.
+
+    RED-Charakter: Mutations-Waechter — rot bei: `on_demand` nicht im
+    Log-Eintrag festgehalten oder in `_log_bezeugt_versand` nicht uebersprungen.
+    Dann faellt das regulaere Briefing dieses Ortstags still aus — ohne
+    Protokollzeile, ohne Fehlerzaehler.
+    """
+    from app.loader import get_data_dir, load_all_trips
+    from services.trip_day import trip_local_today
+
+    jetzt = datetime.now(timezone.utc)
+    heute_ort = local_dt(jetzt, PARIS).date()
+    _schreibe("slot-t12b", [_trip_json(
+        "korsika", *KORSIKA,
+        [heute_ort - timedelta(days=1), heute_ort, heute_ort + timedelta(days=1)],
+        morning="07:00:00",
+    )])
+    trip = load_all_trips(user_id="slot-t12b")[0]
+    ortstag = trip_local_today(trip, jetzt)
+    settings = _zustellbare_settings()
+    zugestellt = _aufzeichnender_mailversand(monkeypatch)
+    scheduler = _scheduler_mit_fixture_wetter("slot-t12b", settings)
+
+    # a) Der On-Demand-Versand geht wirklich raus.
+    assert scheduler.send_on_demand_report(trip, "morning") == "sent", (
+        "Testaufbau prueft nichts: nur ein zugestellter On-Demand-Versand "
+        "erreicht `_append_briefing_log` — genau darum geht es hier."
+    )
+    assert len(zugestellt) == 1, (
+        f"Genau eine zugestellte Nachricht erwartet, gefunden {len(zugestellt)}"
+    )
+    log_eintraege = json.loads(
+        (get_data_dir("slot-t12b") / "briefing_log.json").read_text(encoding="utf-8")
+    )["entries"]
+    assert [e["kind"] for e in log_eintraege] == ["morning"], (
+        "Testaufbau prueft nichts: der Log-Eintrag, um den es geht, muss "
+        f"entstanden sein. Gefunden: {log_eintraege}"
+    )
+
+    # b) Die eigentliche Zusicherung (AC-12): der regulaere Slot bleibt faellig.
+    assert not (get_data_dir("slot-t12b") / "briefing_slots.json").exists(), (
+        "Testaufbau prueft nichts: ohne eigenen Speicher greift die "
+        "Rueckwaerts-Ableitung gar nicht, und der Fall waere unerreichbar."
+    )
+    assert not BriefingSlotStore("slot-t12b").is_recorded(
+        "korsika", "morning", ortstag, zone=PARIS,
+    ), (
+        "Ein angefordertes Briefing darf den regulaeren Slot nicht als "
+        "erledigt erscheinen lassen."
+    )
+    assert ("korsika", "morning") in _sammlung(
+        _scheduler("slot-t12b"), _zeitpunkt(PARIS, ortstag, 7),
+    ), (
+        "Der regulaere 07:00-Slot muss weiterhin faellig sein (AC-12). Ist er "
+        "es nicht, hat die Rueckwaerts-Ableitung den On-Demand-Eintrag aus "
+        "briefing_log.json gelesen — der Nutzer verliert sein regulaeres "
+        "Briefing dieses Ortstags stillschweigend."
+    )
+
+
 # ---------------------------------------------------------------------------
 # AC-13 / T13 — Sperre nicht erhältlich → kein Versand (fail-closed)
 # ---------------------------------------------------------------------------
@@ -994,4 +1210,66 @@ def test_t14_lord_howe_halbstundenversatz_bleibt_unauffaellig(tag: date, stunde:
     assert _ortsstunde(treffer[0], LORD_HOWE_TZ) == stunde, (
         f"Treffer liegt auf Ortsstunde "
         f"{_ortsstunde(treffer[0], LORD_HOWE_TZ)}, konfiguriert war {stunde}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T15 (Adversary-Finding F003) — der Schlüssel trägt den ORTSTAG, nicht den
+# UTC-Tag: das Fenster darf über die UTC-Tagesgrenze nicht auseinanderfallen
+# ---------------------------------------------------------------------------
+
+def test_t15_fenster_ueber_der_utc_tagesgrenze_sendet_nur_einmal():
+    """Given ein Trip in `Europe/Paris` mit Morgen-Briefing 01:00 — die drei
+    Fensterstunden 01/02/03 Ortszeit liegen auf ZWEI verschiedenen UTC-Tagen
+    (23:00 des Vortags, 00:00 und 01:00) / When der volle Ortstag abgeschritten
+    wird / Then geht genau EIN Morgen-Briefing raus.
+
+    🔴 Warum dieser Fall fehlte: `_collect_due_trips` bildet den Ortstag mit
+    `vor_ort.date()`. Ersetzt man das durch `now_utc.date()`, blieb die gesamte
+    Suite gruen (Adversary Z3) — kein Test verliess den Bereich, in dem Ortstag
+    und UTC-Tag ohnehin gleich sind. `test_ac4_korsika_unveraendert` klammert
+    die Konfigurationsstunden 0 und 1 per `parametrize` ausdruecklich aus, also
+    genau diesen Bereich.
+
+    Der Schaden waere ein DOPPELVERSAND an echte Empfaenger inklusive
+    kostenpflichtiger Premium-SMS: Der in Ortsstunde 01 geschriebene Vermerk
+    truege den UTC-Tag des Vortages, die Pruefung in Ortsstunde 02 fragte nach
+    dem heutigen — kein Treffer, zweiter Versand.
+
+    Gezaehlt werden VERSANDVERSUCHE des Morgen-Slots. Der Abend-Slot bleibt
+    unbeachtet: `_trip_json(evening=None)` schaltet ihn nicht ab, `loader.py`
+    setzt ihn per Default auf 18:00 (s. T2).
+
+    RED-Charakter: Mutations-Waechter — rot bei: `ortstag = now_utc.date()`
+    statt `vor_ort.date()`, also einem Schluessel, der den UTC-Tag statt des
+    Ortstags traegt.
+    """
+    tage = [date(2026, 8, 19), date(2026, 8, 20), date(2026, 8, 21)]
+    tag = date(2026, 8, 20)
+    _schreibe("slot-t15", [_trip_json("korsika", *KORSIKA, tage, morning="01:00:00")])
+    scheduler = _scheduler_mit_festem_ausgang("slot-t15")
+
+    # Vorbedingung: die Fensterstunden liegen tatsaechlich auf zwei UTC-Tagen.
+    utc_tage = {
+        local_dt(_zeitpunkt(PARIS, tag, h), UTC).date() for h in (1, 2, 3)
+    }
+    assert len(utc_tage) == 2, (
+        "Testaufbau prueft nichts: die drei Fensterstunden muessen ueber die "
+        f"UTC-Tagesgrenze reichen, gefunden {sorted(utc_tage)}"
+    )
+
+    treffer = [
+        now for now in _ortstag_schritte(PARIS, tag)
+        if ("korsika", "morning") in _lauf(scheduler, now)
+    ]
+
+    assert [_ortsstunde(t, PARIS) for t in treffer] == [1], (
+        "Erwartet genau ein Treffer auf Ortsstunde 01, gefunden "
+        f"{[_ortsstunde(t, PARIS) for t in treffer]}"
+    )
+    morgens = [v for v in scheduler.versandversuche if v[1] == "morning"]
+    assert morgens == [("korsika", "morning")], (
+        "Genau EIN Morgen-Versand ueber das ganze Fenster. Mehr heisst: der "
+        "Vermerk aus Ortsstunde 01 wurde in Ortsstunde 02 nicht gefunden, weil "
+        f"der Schluessel den UTC-Tag traegt statt den Ortstag. Gefunden: {morgens}"
     )

--- a/tests/tdd/test_briefing_slot_idempotenz.py
+++ b/tests/tdd/test_briefing_slot_idempotenz.py
@@ -339,7 +339,15 @@ def test_t2_herbst_doppelstunde_sendet_nur_einmal():
     assert _ortsstunde(treffer[0], PARIS) == 2, (
         f"Erwartet Ortsstunde 02, gefunden {_ortsstunde(treffer[0], PARIS)}"
     )
-    assert len(scheduler.versandversuche) == 1, (
+    # Gemessen wird ausschliesslich der MORGEN-Slot — AC-2 sagt die
+    # Doppelstunde dieses Slots zu. `_trip_json(evening=None)` schaltet den
+    # Abend-Slot NICHT ab: `loader.py:573` setzt `evening_time` per Default
+    # auf 18:00, und dieser Lauf schreitet den vollen Ortstag ab, also faellt
+    # der Abend-Slot um 18:00 Ortszeit an. Das ist unveraendertes
+    # Bestandsverhalten und gehoert nicht zu dieser Zusicherung — wer hier
+    # wieder auf `len(versandversuche)` zurueckbaut, misst den Abend-Slot mit.
+    morgens = [v for v in scheduler.versandversuche if v[1] == "morning"]
+    assert morgens == [("korsika", "morning")], (
         "Genau ein Versandversuch — der Vermerk muss den zweiten Durchlauf "
         f"der Doppelstunde stoppen, gefunden {scheduler.versandversuche}"
     )

--- a/tests/tdd/test_briefing_slot_idempotenz.py
+++ b/tests/tdd/test_briefing_slot_idempotenz.py
@@ -1,0 +1,989 @@
+"""TDD RED — #1725: Briefing-Fälligkeit als Fenster + Idempotenz-Schlüssel.
+
+Spec: docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md (AC-1..AC-14)
+Kontext: docs/context/fix-1725-faelligkeit-idempotenz.md
+ADR-0051 (Zeit als Parameter, Zone an den Daten), ADR-0044 (Ortstag, UTC-Vergleich)
+
+Zielverhalten, gegen das hier durchgehend geprüft wird::
+
+    fällig ⟺ konfigurierte_stunde <= ortsstunde < konfigurierte_stunde + 3
+             UND kein Vermerk für (trip_id, ortstag, slot)
+
+Vermerk gesetzt bei `sent`, `no_stage`, `no_weather`, `no_channels` — NICHT bei
+`channels_unreachable` und nicht bei einer Ausnahme (reserve-then-release).
+
+RED-Ursache vor dem Fix: `_collect_due_trips` vergleicht Stunden auf
+GLEICHHEIT (`trip_report_scheduler.py:372,375`). Ein Ortstag hat aber nicht
+immer 24 Stunden — am 29.03. fehlt eine Ortsstunde (Briefing entfällt), am
+25.10. existiert sie zweimal (Briefing geht zweimal raus). Zusätzlich fehlt
+heute jeder Idempotenz-Schutz: ein zweiter Lauf in derselben Stunde
+(Neustart, manueller Trigger) sendet ungebremst erneut.
+
+────────────────────────────────────────────────────────────────────────────
+🔴 RED-Charakter je Test — Pflichtangabe (Auftrag Team-Lead)
+────────────────────────────────────────────────────────────────────────────
+Diese Datei schlägt in der RED-Phase VOLLSTÄNDIG fehl (das Modul
+`services.briefing_slots` existiert nicht → Collection-Error). Das ist gültiges
+RED, aber KEIN Beweis für die Fangkraft der einzelnen Tests. Jeder Test trägt
+deshalb in seinem Docstring eine Zeile
+
+    RED-Charakter: <Fehlernachweis|Mutations-Wächter> — rot bei: <Verfälschung>
+
+Fehlernachweis = wäre auch ohne den Fix rot (misst den gemeldeten Defekt).
+Mutations-Wächter = wäre heute zufällig grün; sein Wert liegt darin, NACH der
+Implementierung rot zu werden, wenn ein Schlüsselglied entfällt, das Fenster
+verstellt oder der Filter verschoben wird.
+
+🔴 Die wichtigste Falle: bei funktionierendem Vermerk liefert JEDE
+Fensterbreite an einem normalen Tag genau EINEN Treffer. Ein Test, der nur
+Treffer zählt, kann die Fensterbreite nicht sehen. **T4 ist der einzige Test,
+der beide Fenstergrenzen festnagelt.** Zwei Folgefallen, die hier bewusst
+adressiert sind:
+  * Die Mutation „Fälligkeit auf `<=` drehen" ergibt unter wirksamem Vermerk
+    ebenfalls genau einen Treffer (bei Ortsstunde 00 statt 07). T3 prüft
+    deshalb die STUNDE des Treffers, nicht nur deren Anzahl.
+  * Die Mutationen „Slot / Trip-ID aus dem Schlüssel entfernen" sind an der
+    Sammlung unsichtbar, weil beide Elemente in DERSELBEN Sammlung anfallen —
+    der Vermerk entsteht erst beim Versand danach. T5/T7 zählen deshalb
+    VERSANDVERSUCHE, nicht gesammelte Zeilen.
+
+────────────────────────────────────────────────────────────────────────────
+Schnittstellen-Entscheidungen (die GREEN-Phase richtet sich danach)
+────────────────────────────────────────────────────────────────────────────
+1. `services.briefing_slots.BriefingSlotStore(user_id: str)`
+   * Speicher `get_data_dir(user_id)/briefing_slots.json`, Schema
+     `{"entries": [{"trip_id", "slot", "local_day", "recorded_at", "outcome"}]}`,
+     `local_day` als ISO-Datum (`YYYY-MM-DD`).
+   * Sperr-Sidecar `briefing_slots.json.lock` (Muster `throttle_store`).
+   * `LOCK_TIMEOUT_SECONDS` wird als MODUL-ATTRIBUT zur Laufzeit gelesen
+     (`briefing_slots.LOCK_TIMEOUT_SECONDS`), damit ein Test die Frist kürzen
+     kann; Default = `file_lock.LOCK_TIMEOUT_SECONDS` (2.0 s).
+   * `is_recorded(trip_id, slot, local_day: date, zone=None) -> bool` —
+     schließt die Rückwärts-Ableitung aus `briefing_log.json` ein (AC-9).
+     `zone` (die Ortszone des Trips) entscheidet dabei, ob `sent_at` in
+     `local_day` fällt; sie ist optional, weil nur der Scheduler sie kennt.
+     Ohne `zone` wird `sent_at` gegen UTC ausgewertet.
+   * `reserve(trip_id, slot, local_day, zone=None) -> bool` — True nur bei
+     FRISCHER Reservierung. False, wenn bereits ein Vermerk/eine Reservierung
+     besteht ODER die Sperre nicht zu bekommen war (fail-closed, AC-13).
+   * `record_outcome(trip_id, slot, local_day, outcome: str) -> None`
+   * `release(trip_id, slot, local_day) -> None` — nimmt die Reservierung
+     zurück.
+2. `TripReportSchedulerService._collect_due_trips(now_utc)` liefert
+   `list[tuple[Trip, str, date]]`; drittes Element ist der ORTSTAG DES LAUFS
+   (`trip_local_today(trip, now_utc)`), ausdrücklich nicht `target_date`.
+3. `TripReportSchedulerService._dispatch_due_item(trip, report_type, local_day)`
+   `-> str | None`: reserviert, sendet nur bei erfolgreicher Reservierung,
+   vermerkt/entlässt je Ausgang, gibt den Ausgang zurück — bzw. `None`, wenn
+   gar kein Versandversuch stattfand. Eine Ausnahme aus dem Versand wird nach
+   dem `release` WEITERGEREICHT (`dispatch_one` fängt sie wie bisher).
+4. `trip_report_scheduler.NACHHOL_FENSTER_STUNDEN = 3`.
+
+────────────────────────────────────────────────────────────────────────────
+Test-Politik (CLAUDE.md „Zwei Schichten")
+────────────────────────────────────────────────────────────────────────────
+Kern-Schicht, deterministisch: kein Netz, kein Postfach. Zeit wird
+ausschließlich als PARAMETER hereingereicht (ADR-0051 Regel 3) — nie per Patch
+auf die Systemuhr. Einzige Ausnahme ist T12, weil `send_on_demand_report`
+konstruktionsbedingt keinen Zeitpunkt annimmt (`:905` liest dort seine eigene
+Uhr; das gehört zu #1726 und wird hier nicht angefasst).
+
+Kein Mock-Theater: Speicher, Schlüsselbildung, Fenster und Filter laufen
+ECHT. Ersetzt wird an genau einer Stelle die Naht zum Netz — der Versand
+selbst (`_send_trip_report_outcome`) — durch eine ECHTE Unterklasse, die einen
+der fünf dokumentierten Ausgänge zurückgibt und ihre Aufrufe mitschreibt. Ihr
+Rückgabewert ist die EINGABE der geprüften Entscheidung, nicht deren Ergebnis;
+behauptet wird nichts, gemessen wird der Zustand des echten Speichers über die
+echte Sammlung. Zwei Tests kommen ohne diese Naht aus und bewachen damit, dass
+der Vermerk NICHT im Versand sitzt: T12 (On-Demand-Pfad, echter `no_stage`)
+und T9 (reine Sammlung).
+
+Ortstage werden von Ortsmitternacht zu Ortsmitternacht abgeschritten und die
+Häufigkeit jeder einzelnen Ortsstunde gezählt — nicht Zeilen. ADR-0044-Falle:
+zwei zeitzonenbehaftete Zeitpunkte mit demselben `tzinfo` subtrahieren sich auf
+nackten Wanduhr-Werten (jeder Tag scheinbar 24,0 h); jeder Vergleich läuft
+deshalb über `local_dt(dt, UTC)`, nie über rohes `.astimezone`.
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import logging
+import os
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterator
+from zoneinfo import ZoneInfo
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))
+
+from app.loader import get_briefings_dir, get_data_dir  # noqa: E402
+from utils.timezone import UTC, local_dt  # noqa: E402
+
+# Bewusst auf Modulebene: solange `services.briefing_slots` fehlt, ist die
+# gesamte Datei ein Collection-Error — das RED ist damit unuebersehbar und
+# nicht als Reihe einzelner AttributeErrors zu verwechseln.
+from services import briefing_slots  # noqa: E402,F401  (T13 kuerzt die Sperrfrist)
+from services.briefing_slots import BriefingSlotStore  # noqa: E402
+
+# Koordinaten je Zone — echte Orte, damit TimezoneFinder sie auflöst.
+KORSIKA = (42.30, 8.93)          # Europe/Paris
+LORD_HOWE = (-31.5545, 159.0821)  # Australia/Lord_Howe (+10:30/+11:00)
+
+PARIS = ZoneInfo("Europe/Paris")
+LORD_HOWE_TZ = ZoneInfo("Australia/Lord_Howe")
+
+# Die vier Ausgänge, die laut Spec einen Vermerk setzen, und der eine, der
+# es nicht tut (Spec „Vermerk je Outcome").
+VERMERK_AUSGAENGE = ("sent", "no_stage", "no_weather", "no_channels")
+OHNE_VERMERK = "channels_unreachable"
+
+
+# ---------------------------------------------------------------------------
+# Aufbau-Helfer (Muster aus tests/tdd/test_briefing_faelligkeit_ortszone.py)
+# ---------------------------------------------------------------------------
+
+def _trip_json(trip_id: str, lat: float, lon: float, tage: list[date],
+               morning: str | None = "07:00:00",
+               evening: str | None = None) -> dict:
+    """Trip mit je einer Etappe pro Datum, alle am selben Wegpunkt."""
+    report_config: dict = {"enabled": True}
+    if morning is not None:
+        report_config["morning_time"] = morning
+    if evening is not None:
+        report_config["evening_time"] = evening
+    return {
+        "id": trip_id,
+        "name": f"Trip {trip_id}",
+        "stages": [
+            {
+                "id": f"{trip_id}-s{i}",
+                "name": f"Etappe {i}",
+                "date": d.isoformat(),
+                "waypoints": [
+                    {"id": f"{trip_id}-wp{i}a", "name": "Start",
+                     "lat": lat, "lon": lon, "elevation_m": 800},
+                    {"id": f"{trip_id}-wp{i}b", "name": "Ziel",
+                     "lat": lat + 0.05, "lon": lon + 0.05, "elevation_m": 1200},
+                ],
+            }
+            for i, d in enumerate(tage)
+        ],
+        "report_config": report_config,
+    }
+
+
+def _schreibe(user_id: str, trips: list[dict]) -> None:
+    """Echte Trip-Dateien im isolierten Daten-Root (conftest `_isolate_data_root`).
+
+    Mandantentrennung: jeder Test bekommt eine EIGENE, sprechende `user_id` —
+    nie `"default"`.
+    """
+    ordner = get_briefings_dir(user_id)
+    ordner.mkdir(parents=True, exist_ok=True)
+    for t in trips:
+        (ordner / f"{t['id']}.json").write_text(json.dumps(t), encoding="utf-8")
+
+
+def _scheduler(user_id: str):
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    return TripReportSchedulerService(user_id=user_id)
+
+
+def _sammlung(scheduler, now_utc: datetime) -> set[tuple[str, str]]:
+    """Nur SAMMELN, nicht versenden — misst den Prüfort `_collect_due_trips`."""
+    return {(t.id, rt) for t, rt, _ in scheduler._collect_due_trips(now_utc)}
+
+
+def _lauf(scheduler, now_utc: datetime) -> list[tuple[str, str]]:
+    """Ein vollständiger Sammellauf: sammeln, dann jedes fällige Element über
+    den echten Wrapper abarbeiten — genau die Kette, die
+    `run_briefing_dispatch` fährt (`collect_due` → Schleife über
+    `dispatch_one`), ohne die 2s-Pause und ohne `pre_pass`.
+
+    Rückgabe ist die GESAMMELTE Liste. Wer die Wirkung des Vermerks auf die
+    Sammlung misst, prüft damit den Prüfort, den die Spec verlangt (Filter in
+    `_collect_due_trips`, nicht erst im Versand).
+    """
+    gesammelt = list(scheduler._collect_due_trips(now_utc))
+    for trip, report_type, ortstag in gesammelt:
+        scheduler._dispatch_due_item(trip, report_type, ortstag)
+    return [(t.id, rt) for t, rt, _ in gesammelt]
+
+
+def _ortstag_schritte(zone: ZoneInfo, tag: date) -> Iterator[datetime]:
+    """Schreitet den ORTSTAG stündlich von Ortsmitternacht zu Ortsmitternacht ab.
+
+    Die Länge des Tages wird BERECHNET, nicht gesetzt (ADR-0044 `:46-49`):
+    beide Ortsmitternachte werden über `local_dt(..., UTC)` nach UTC gebracht,
+    erst dort wird verglichen. Ein Vergleich der beiden Wanduhr-Werte mit
+    identischem `tzinfo` ergäbe an JEDEM Tag 24,0 h und würde die
+    Umstellungstage genau verschlucken.
+    """
+    start = datetime(tag.year, tag.month, tag.day, 0, 0, tzinfo=zone)
+    ende = start + timedelta(days=1)  # Wanduhr-Addition -> nächste Ortsmitternacht
+    t = local_dt(start, UTC)
+    grenze = local_dt(ende, UTC)
+    while t < grenze:
+        yield t
+        t += timedelta(hours=1)
+
+
+def _ortsstunde(now_utc: datetime, zone: ZoneInfo) -> int:
+    return local_dt(now_utc, zone).hour
+
+
+def _zeitpunkt(zone: ZoneInfo, tag: date, ortsstunde: int) -> datetime:
+    """UTC-Zeitpunkt zu einer eindeutigen Ortsstunde des Ortstags."""
+    return local_dt(datetime(tag.year, tag.month, tag.day, ortsstunde, 0, tzinfo=zone), UTC)
+
+
+def _scheduler_mit_festem_ausgang(user_id: str, ausgang: str = "sent",
+                                  ausnahme: BaseException | None = None):
+    """Echter `TripReportSchedulerService`, bei dem AUSSCHLIESSLICH die Naht
+    zum Netz ersetzt ist.
+
+    Kein Mock: eine echte Unterklasse mit echter Implementierung. Sie gibt
+    einen der fünf dokumentierten Ausgangs-Strings zurück (bzw. wirft eine echte
+    Ausnahme) und schreibt jeden Aufruf mit. Alles, was geprüft wird — Fenster,
+    Schlüsselbildung, Speicher, Filter —, läuft unverändert echt. Der
+    Versandversuch selbst ist im deterministischen Kern-Testlauf ohnehin nicht
+    ehrlich herstellbar: vier der fünf Ausgänge erfordern einen vollständigen
+    Wetterabruf und einen Kanalversuch.
+    """
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    class _SchedulerMitFestemAusgang(TripReportSchedulerService):
+        versandversuche: list[tuple[str, str]] = []
+
+        def _send_trip_report_outcome(self, trip, report_type, **kwargs):
+            self.versandversuche.append((trip.id, report_type))
+            if self.ausnahme is not None:
+                raise self.ausnahme
+            return self.ausgang
+
+    scheduler = _SchedulerMitFestemAusgang(user_id=user_id)
+    scheduler.versandversuche = []
+    scheduler.ausgang = ausgang
+    scheduler.ausnahme = ausnahme
+    return scheduler
+
+
+# ---------------------------------------------------------------------------
+# AC-1 / T1 — Frühjahrs-Umstellung: der Slot fällt nicht mehr aus
+# ---------------------------------------------------------------------------
+
+def test_t1_fruehjahr_slot_faellt_nicht_mehr_aus():
+    """Given Trip auf Korsika (Europe/Paris), Morgen-Briefing 02:00, Ortstag
+    2026-03-29 (die Ortsstunde 02 existiert an diesem Tag nicht) / When der
+    Ortstag von Ortsmitternacht zu Ortsmitternacht abgeschritten wird / Then
+    ist der Trip GENAU EINMAL fällig, und zwar bei Ortsstunde 03
+    (`3 >= 2 and 3 < 5`).
+
+    RED-Charakter: Fehlernachweis — rot bei: heutiger Stundengleichheit
+    (`>=` zurück auf `==`), dann entfällt der Versand ersatzlos (0 Treffer).
+    """
+    tage = [date(2026, 3, 28), date(2026, 3, 29), date(2026, 3, 30)]
+    _schreibe("slot-t1", [_trip_json("korsika", *KORSIKA, tage, morning="02:00:00")])
+    scheduler = _scheduler_mit_festem_ausgang("slot-t1")
+
+    treffer = [
+        now for now in _ortstag_schritte(PARIS, date(2026, 3, 29))
+        if ("korsika", "morning") in _lauf(scheduler, now)
+    ]
+
+    assert len(treffer) == 1, (
+        "Fruehjahrs-Umstellung: das auf 02:00 gestellte Briefing muss genau "
+        f"einmal fallen, gefunden {len(treffer)} "
+        f"({[local_dt(t, PARIS).isoformat() for t in treffer]}). 0 heisst: die "
+        "nicht existierende Ortsstunde 02 laesst den Slot ersatzlos ausfallen."
+    )
+    assert _ortsstunde(treffer[0], PARIS) == 3, (
+        "Die Ortsstunde 02 existiert am 29.03. nicht — der Nachhol-Treffer "
+        f"gehoert auf Ortsstunde 03, gefunden {_ortsstunde(treffer[0], PARIS)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 / T2 — Herbst-Umstellung: keine Doppelzustellung
+# ---------------------------------------------------------------------------
+
+def test_t2_herbst_doppelstunde_sendet_nur_einmal():
+    """Given derselbe Trip am Ortstag 2026-10-25 (die Ortsstunde 02 existiert
+    zweimal) / When beide Vorkommen im Lauf durchschritten werden / Then wird
+    der Trip GENAU EINMAL gesammelt — das erste Vorkommen setzt den Vermerk,
+    das zweite wird durch ihn gefiltert.
+
+    RED-Charakter: Fehlernachweis — rot bei: fehlendem Vermerk-Filter, dann
+    geht das Briefing zweimal an echte Empfaenger (heutiger Zustand: 2).
+    """
+    tage = [date(2026, 10, 24), date(2026, 10, 25), date(2026, 10, 26)]
+    _schreibe("slot-t2", [_trip_json("korsika", *KORSIKA, tage, morning="02:00:00")])
+    scheduler = _scheduler_mit_festem_ausgang("slot-t2")
+
+    treffer = [
+        now for now in _ortstag_schritte(PARIS, date(2026, 10, 25))
+        if ("korsika", "morning") in _lauf(scheduler, now)
+    ]
+
+    assert len(treffer) == 1, (
+        "Herbst-Umstellung: die Ortsstunde 02 kommt zweimal vor — gesammelt "
+        f"werden darf der Slot trotzdem nur einmal, gefunden {len(treffer)} "
+        f"({[local_dt(t, PARIS).isoformat() for t in treffer]})."
+    )
+    assert _ortsstunde(treffer[0], PARIS) == 2, (
+        f"Erwartet Ortsstunde 02, gefunden {_ortsstunde(treffer[0], PARIS)}"
+    )
+    assert len(scheduler.versandversuche) == 1, (
+        "Genau ein Versandversuch — der Vermerk muss den zweiten Durchlauf "
+        f"der Doppelstunde stoppen, gefunden {scheduler.versandversuche}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3 / T3 — normaler Tag: nur die konfigurierte Stunde trifft
+# ---------------------------------------------------------------------------
+
+def test_t3_normaler_tag_trifft_nur_die_konfigurierte_stunde():
+    """Given Trip mit Morgen-Briefing 07:00 an einem Tag ohne Zeitumstellung /
+    When jede der 24 Ortsstunden einzeln durchlaufen wird / Then trifft genau
+    die Ortsstunde 07 und keine der uebrigen 23; und nach dem Versand meldet
+    schon die SAMMLUNG den Slot in Ortsstunde 08 nicht mehr.
+
+    Zweite Zusicherung = Pruefort gleich Wirkort: der Filter gehoert in
+    `_collect_due_trips`, nicht erst in den Versand — sonst raeumt
+    `_process_pending_markers` (`:445-448`) jede Stunde den #1012-Marker weg
+    und legt den Nachliefermechanismus lautlos still.
+
+    RED-Charakter: Mutations-Waechter — rot bei: Faelligkeit auf `<=` gedreht
+    (dann trifft Ortsstunde 00 statt 07; die blosse ANZAHL bliebe wegen des
+    Vermerks 1 und saehe die Verfaelschung nicht) sowie bei einem Filter, der
+    erst im Versand statt in der Sammlung sitzt.
+    """
+    tage = [date(2026, 8, 19), date(2026, 8, 20), date(2026, 8, 21)]
+    _schreibe("slot-t3", [_trip_json("korsika", *KORSIKA, tage, morning="07:00:00")])
+    scheduler = _scheduler_mit_festem_ausgang("slot-t3")
+
+    treffer = [
+        now for now in _ortstag_schritte(PARIS, date(2026, 8, 20))
+        if ("korsika", "morning") in _lauf(scheduler, now)
+    ]
+
+    assert [_ortsstunde(t, PARIS) for t in treffer] == [7], (
+        "An einem normalen Tag muss genau die konfigurierte Ortsstunde 07 "
+        f"treffen, gefunden {[_ortsstunde(t, PARIS) for t in treffer]}"
+    )
+
+    # Prüfort = Wirkort: der Vermerk wirkt bereits auf die Sammlung.
+    acht_uhr = _zeitpunkt(PARIS, date(2026, 8, 20), 8)
+    assert ("korsika", "morning") not in _sammlung(scheduler, acht_uhr), (
+        "In Ortsstunde 08 liegt der Slot noch im Nachhol-Fenster, ist aber "
+        "bereits vermerkt — die SAMMLUNG darf ihn nicht mehr melden. Sitzt der "
+        "Filter erst im Versand, raeumt `_process_pending_markers` jede Stunde "
+        "den Nachliefer-Marker weg."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 / T4 — Nachhol-Fenster, BEIDE Grenzen zugleich
+# ---------------------------------------------------------------------------
+
+def test_t4_nachhol_fenster_faengt_h_plus_1_und_endet_vor_h_plus_3():
+    """Given die Slot-Stunde H faellt aus, weil der stuendliche Tick nicht lief
+    (Umstellungstag oder gescheiterter HTTP-Post ohne Retry,
+    `scheduler.go:547`) / When der naechste Lauf in Ortsstunde H+1 stattfindet
+    / Then ist der Trip nachtraeglich faellig; findet er erst in Ortsstunde
+    H+3 statt, ist er NICHT mehr faellig.
+
+    🔴 Der EINZIGE Test, der die Fensterbreite in beide Richtungen festnagelt.
+    Bei wirksamem Vermerk liefert jede Fensterbreite an einem normalen Tag
+    genau einen Treffer — sichtbar wird die Breite nur an einem AUSGELASSENEN
+    Lauf. Der Lauf zur Stunde H findet hier deshalb bewusst NICHT statt.
+
+    RED-Charakter: Mutations-Waechter — rot bei: Fenster 3 -> 1 (dann ist H+1
+    nicht mehr faellig, erster Teil rot) UND bei Fenster 3 -> „bis Tagesende"
+    (dann ist H+3 noch faellig, zweiter Teil rot).
+    """
+    tage = [date(2026, 8, 19), date(2026, 8, 20), date(2026, 8, 21)]
+    tag = date(2026, 8, 20)
+
+    # Teil 1: Stunde 07 ausgelassen, erster Lauf um 08 Ortszeit.
+    _schreibe("slot-t4a", [_trip_json("korsika", *KORSIKA, tage, morning="07:00:00")])
+    nachzuegler = _scheduler("slot-t4a")
+    assert ("korsika", "morning") in _sammlung(
+        nachzuegler, _zeitpunkt(PARIS, tag, 8)
+    ), (
+        "Der Tick zur Ortsstunde 07 ist ausgefallen — in Ortsstunde 08 muss "
+        "der Slot nachgeholt werden. Ist er es nicht, ist das Nachhol-Fenster "
+        "kleiner als 2 Stunden und faengt den an Umstellungstagen "
+        "ausfallenden Cron-Tick nicht."
+    )
+
+    # Teil 2: Stunden 07, 08, 09 ausgelassen, erster Lauf um 10 Ortszeit.
+    _schreibe("slot-t4b", [_trip_json("korsika", *KORSIKA, tage, morning="07:00:00")])
+    zu_spaet = _scheduler("slot-t4b")
+    assert ("korsika", "morning") not in _sammlung(
+        zu_spaet, _zeitpunkt(PARIS, tag, 10)
+    ), (
+        "Ortsstunde 10 liegt DREI Stunden hinter der konfigurierten 07 und "
+        "damit ausserhalb des Fensters (`7 <= 10 < 10` ist falsch). Ein "
+        "Morgen-Briefing, das noch bis Tagesende nachgeholt wird, kaeme um "
+        "23:00 Ortszeit an und liesse neu angelegte oder aus `paused_until` "
+        "zurueckkehrende Trips rueckwirkend feuern."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5 / T5 — der Schlüssel braucht den Slot
+# ---------------------------------------------------------------------------
+
+def test_t5_schluessel_ohne_slot_wuerde_den_zweiten_slot_verschlucken():
+    """Given ein Trip mit Morgen- UND Abend-Briefing, beide auf 07:00 / When
+    die Ortsstunde 07 erreicht wird / Then werden BEIDE Slots unabhaengig
+    voneinander versendet und unabhaengig vermerkt.
+
+    Gezaehlt werden VERSANDVERSUCHE, nicht gesammelte Zeilen: beide Slots
+    fallen in DERSELBEN Sammlung an, der Vermerk des ersten entsteht erst beim
+    Versand danach. Eine an der Sammlung gemessene Zusicherung koennte einen
+    slotlosen Schluessel nicht sehen.
+
+    RED-Charakter: Mutations-Waechter — rot bei: `slot` aus dem Schluessel
+    entfernt; dann scheitert die Reservierung des zweiten Slots am Vermerk des
+    ersten und nur einer wird gesendet.
+    """
+    tage = [date(2026, 8, 19), date(2026, 8, 20), date(2026, 8, 21)]
+    _schreibe("slot-t5", [_trip_json(
+        "korsika", *KORSIKA, tage, morning="07:00:00", evening="07:00:00",
+    )])
+    scheduler = _scheduler_mit_festem_ausgang("slot-t5")
+
+    _lauf(scheduler, _zeitpunkt(PARIS, date(2026, 8, 20), 7))
+
+    assert sorted(scheduler.versandversuche) == [
+        ("korsika", "evening"), ("korsika", "morning"),
+    ], (
+        "Morgen- und Abend-Slot sind zwei verschiedene Schluessel und muessen "
+        "beide gesendet werden. Gefunden: "
+        f"{sorted(scheduler.versandversuche)} — fehlt einer, traegt der "
+        "Idempotenz-Schluessel den Slot nicht."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-6 / T6 — der Schlüssel braucht den Ortstag
+# ---------------------------------------------------------------------------
+
+def test_t6_schluessel_ohne_ortstag_wuerde_den_folgetag_verstummen_lassen():
+    """Given ein Trip, dessen Morgen-Briefing an zwei aufeinanderfolgenden
+    Ortstagen faellig wird / When der Lauf an beiden Tagen ausgefuehrt wird /
+    Then ist er an beiden Tagen faellig — der Vermerk vom Vortag blockiert den
+    neuen Tag nicht.
+
+    RED-Charakter: Mutations-Waechter — rot bei: `local_day` aus dem
+    Schluessel entfernt; dann bleibt Tag 2 stumm und der Nutzer bekommt nach
+    dem ersten Briefing nie wieder eines.
+    """
+    tage = [date(2026, 8, 19), date(2026, 8, 20), date(2026, 8, 21), date(2026, 8, 22)]
+    _schreibe("slot-t6", [_trip_json("korsika", *KORSIKA, tage, morning="07:00:00")])
+    scheduler = _scheduler_mit_festem_ausgang("slot-t6")
+
+    tag1 = _lauf(scheduler, _zeitpunkt(PARIS, date(2026, 8, 20), 7))
+    tag2 = _lauf(scheduler, _zeitpunkt(PARIS, date(2026, 8, 21), 7))
+
+    assert ("korsika", "morning") in tag1, "Tag 1 muss faellig sein"
+    assert ("korsika", "morning") in tag2, (
+        "Tag 2 muss ebenfalls faellig sein — der Vermerk vom Vortag darf den "
+        "neuen Ortstag nicht blockieren. Fehlt der Ortstag im Schluessel, "
+        "verstummt das Briefing nach dem ersten Versand dauerhaft."
+    )
+    assert len(scheduler.versandversuche) == 2, (
+        f"Zwei Ortstage, zwei Versandversuche — gefunden {scheduler.versandversuche}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-7 / T7 — der Schlüssel braucht die Trip-ID
+# ---------------------------------------------------------------------------
+
+def test_t7_schluessel_ohne_trip_id_wuerde_den_zweiten_trip_verschlucken():
+    """Given zwei verschiedene Trips desselben Nutzers in derselben Zone mit
+    identischer Briefing-Stunde / When diese Ortsstunde erreicht wird / Then
+    werden BEIDE gesendet und unabhaengig vermerkt.
+
+    Auch hier werden VERSANDVERSUCHE gezaehlt: beide Trips fallen in derselben
+    Sammlung an, der Vermerk entsteht erst danach.
+
+    RED-Charakter: Mutations-Waechter — rot bei: `trip_id` aus dem Schluessel
+    entfernt; dann nimmt der erste Trip dem zweiten sein Briefing weg.
+    """
+    tage = [date(2026, 8, 19), date(2026, 8, 20), date(2026, 8, 21)]
+    _schreibe("slot-t7", [
+        _trip_json("korsika-nord", *KORSIKA, tage, morning="07:00:00"),
+        _trip_json("korsika-sued", *KORSIKA, tage, morning="07:00:00"),
+    ])
+    scheduler = _scheduler_mit_festem_ausgang("slot-t7")
+
+    _lauf(scheduler, _zeitpunkt(PARIS, date(2026, 8, 20), 7))
+
+    assert sorted(scheduler.versandversuche) == [
+        ("korsika-nord", "morning"), ("korsika-sued", "morning"),
+    ], (
+        "Zwei Trips zur selben Stunde sind zwei verschiedene Schluessel. "
+        f"Gefunden: {sorted(scheduler.versandversuche)} — fehlt einer, traegt "
+        "der Idempotenz-Schluessel die Trip-Kennung nicht."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-8 / T8 — die Outcome-Matrix entscheidet über den Vermerk
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("ausgang", VERMERK_AUSGAENGE)
+def test_t8_vier_ausgaenge_setzen_den_vermerk(ausgang: str):
+    """Given ein Versandversuch endet mit `sent`, `no_stage`, `no_weather`
+    oder `no_channels` / When die naechste Stunde INNERHALB des Nachhol-
+    Fensters laeuft / Then wird der Slot nicht erneut verarbeitet.
+
+    RED-Charakter: Mutations-Waechter — rot bei: einem der vier Ausgaenge aus
+    der Vermerk-Menge entfernt; dann laeuft der Slot in den verbleibenden
+    Fensterstunden erneut (bei `no_weather`: stuendliche „keine Daten"-Mail +
+    stuendlicher voller Wetterabruf gegen das Kontingent #1329, und der
+    #1012-Nachliefer-Marker wird jede Stunde weggeraeumt).
+    """
+    tage = [date(2026, 8, 19), date(2026, 8, 20), date(2026, 8, 21)]
+    user = f"slot-t8-{ausgang}"
+    _schreibe(user, [_trip_json("korsika", *KORSIKA, tage, morning="07:00:00")])
+    scheduler = _scheduler_mit_festem_ausgang(user, ausgang=ausgang)
+
+    erste = _lauf(scheduler, _zeitpunkt(PARIS, date(2026, 8, 20), 7))
+    zweite = _lauf(scheduler, _zeitpunkt(PARIS, date(2026, 8, 20), 8))
+
+    assert ("korsika", "morning") in erste, "Stunde 07 muss faellig sein"
+    assert ("korsika", "morning") not in zweite, (
+        f"Ausgang '{ausgang}' setzt laut Spec einen Vermerk — in Stunde 08 "
+        "(noch im Nachhol-Fenster) darf der Slot nicht erneut verarbeitet werden."
+    )
+    assert len(scheduler.versandversuche) == 1, (
+        f"Genau ein Versandversuch bei Ausgang '{ausgang}', gefunden "
+        f"{scheduler.versandversuche}"
+    )
+
+
+def test_t8_channels_unreachable_haelt_den_slot_offen():
+    """Given ein Versandversuch endet mit `channels_unreachable` / When die
+    naechste Stunde innerhalb des Nachhol-Fensters laeuft / Then unternimmt
+    der Lauf einen weiteren Versuch — per Definition
+    (`sent = bool(sent_channels)`) hat niemand etwas bekommen.
+
+    RED-Charakter: Mutations-Waechter — rot bei: `channels_unreachable` in die
+    Vermerk-Menge geschoben; dann bleibt der einzige beabsichtigte Nachholfall
+    still.
+    """
+    tage = [date(2026, 8, 19), date(2026, 8, 20), date(2026, 8, 21)]
+    _schreibe("slot-t8-offen", [
+        _trip_json("korsika", *KORSIKA, tage, morning="07:00:00"),
+    ])
+    scheduler = _scheduler_mit_festem_ausgang("slot-t8-offen", ausgang=OHNE_VERMERK)
+
+    _lauf(scheduler, _zeitpunkt(PARIS, date(2026, 8, 20), 7))
+    zweite = _lauf(scheduler, _zeitpunkt(PARIS, date(2026, 8, 20), 8))
+
+    assert ("korsika", "morning") in zweite, (
+        "Bei 'channels_unreachable' hat niemand etwas bekommen — der naechste "
+        "Lauf im Fenster muss es erneut versuchen."
+    )
+    assert len(scheduler.versandversuche) == 2, (
+        f"Zwei Versuche erwartet, gefunden {scheduler.versandversuche}"
+    )
+
+
+def test_t8_ausnahme_nimmt_die_reservierung_zurueck():
+    """Given der Versand wirft eine Ausnahme / When die naechste Stunde
+    innerhalb des Fensters laeuft / Then ist der Slot erneut faellig — die
+    Reservierung wird durch reserve-then-release zurueckgenommen, und die
+    Ausnahme erreicht unveraendert den Aufrufer (`dispatch_one` faengt sie).
+
+    RED-Charakter: Mutations-Waechter — rot bei: `release` im Ausnahmepfad
+    entfernt (dann bleibt der Slot als vermerkt stehen, obwohl nichts
+    passiert ist) oder bei einem Wrapper, der die Ausnahme schluckt und damit
+    die Fehlerzaehlung in `dispatch_one` still auf Erfolg dreht.
+    """
+    tage = [date(2026, 8, 19), date(2026, 8, 20), date(2026, 8, 21)]
+    _schreibe("slot-t8-ausnahme", [
+        _trip_json("korsika", *KORSIKA, tage, morning="07:00:00"),
+    ])
+    scheduler = _scheduler_mit_festem_ausgang(
+        "slot-t8-ausnahme", ausnahme=RuntimeError("Kanal wirft"),
+    )
+
+    trip, report_type, ortstag = scheduler._collect_due_trips(
+        _zeitpunkt(PARIS, date(2026, 8, 20), 7)
+    )[0]
+    with pytest.raises(RuntimeError):
+        scheduler._dispatch_due_item(trip, report_type, ortstag)
+
+    assert ("korsika", "morning") in _sammlung(
+        scheduler, _zeitpunkt(PARIS, date(2026, 8, 20), 8)
+    ), (
+        "Nach einer Ausnahme darf kein Vermerk zurueckbleiben — der Slot muss "
+        "im Nachhol-Fenster erneut faellig sein."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-9 / T9 — Rollout ohne Doppelversand beim Deploy
+# ---------------------------------------------------------------------------
+
+def test_t9_rueckwaerts_ableitung_aus_dem_briefing_log():
+    """Given `briefing_slots.json` existiert noch nicht (frischer Rollout),
+    aber `briefing_log.json` traegt fuer den Trip einen Eintrag mit passender
+    Slot-Art, dessen `sent_at` in den aktuellen Ortstag faellt / When die
+    Faelligkeit geprueft wird / Then gilt der Slot als erledigt.
+
+    Gegenprobe im selben Test: liegt derselbe Eintrag am VORTAG, ist der Slot
+    faellig. Ohne diese Gegenprobe koennte „nicht faellig" auch aus einem
+    kaputten Aufbau stammen.
+
+    Der Speicher wird hier bewusst NICHT ueber die Sammlung befuellt: geprueft
+    wird die Rueckwaerts-Ableitung selbst, also der Zustand direkt nach einem
+    Deploy mitten im Nachhol-Fenster.
+
+    RED-Charakter: Mutations-Waechter — rot bei: Rueckwaerts-Ableitung
+    entfernt; dann bekommt jeder Nutzer, dessen Briefing kurz vor dem Deploy
+    rausging, es im Fenster ein zweites Mal.
+    """
+    tage = [date(2026, 8, 19), date(2026, 8, 20), date(2026, 8, 21)]
+    tag = date(2026, 8, 20)
+    sieben_uhr = _zeitpunkt(PARIS, tag, 7)
+
+    def _mit_log(user: str, sent_at: datetime) -> None:
+        _schreibe(user, [_trip_json("korsika", *KORSIKA, tage, morning="07:00:00")])
+        pfad = get_data_dir(user) / "briefing_log.json"
+        pfad.parent.mkdir(parents=True, exist_ok=True)
+        pfad.write_text(json.dumps({"entries": [{
+            "trip_id": "korsika",
+            "kind": "morning",
+            "sent_at": sent_at.isoformat(),
+            "channels": ["email"],
+        }]}), encoding="utf-8")
+
+    # a) Eintrag aus DIESEM Ortstag -> Slot gilt als erledigt.
+    _mit_log("slot-t9-heute", _zeitpunkt(PARIS, tag, 7))
+    assert not (get_data_dir("slot-t9-heute") / "briefing_slots.json").exists(), (
+        "Testaufbau prueft nichts: der eigene Speicher darf hier noch nicht "
+        "existieren, sonst greift die Rueckwaerts-Ableitung gar nicht."
+    )
+    assert ("korsika", "morning") not in _sammlung(
+        _scheduler("slot-t9-heute"), sieben_uhr
+    ), (
+        "briefing_log.json weist den Versand dieses Ortstags bereits nach — "
+        "ohne eigenen Vermerk muss die Rueckwaerts-Ableitung greifen, sonst "
+        "sendet der erste Lauf nach dem Deploy ein zweites Mal."
+    )
+
+    # b) Gegenprobe: derselbe Eintrag vom Vortag blockiert nicht.
+    _mit_log("slot-t9-gestern", _zeitpunkt(PARIS, tag - timedelta(days=1), 7))
+    assert ("korsika", "morning") in _sammlung(
+        _scheduler("slot-t9-gestern"), sieben_uhr
+    ), (
+        "Ein Eintrag vom VORTAG darf den heutigen Slot nicht blockieren — "
+        "sonst faellt das Briefing nach dem ersten Tag dauerhaft aus."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-10 / T10 — kein rückwirkendes Feuern bei neuen/reaktivierten Trips
+# ---------------------------------------------------------------------------
+
+def test_t10_neuer_trip_feuert_nicht_rueckwirkend():
+    """Given ein Trip wird neu angelegt (oder kehrt aus `paused_until`
+    zurueck), seine erste Etappe liegt heute, die konfigurierte Morgen-Stunde
+    liegt aber mehr als 3 Stunden zurueck / When der erste Sammellauf danach
+    stattfindet / Then ist er NICHT faellig.
+
+    `_get_active_trips` (`:656-657`) prueft nur die Etappe, nicht das
+    Anlagedatum — das Nachhol-Fenster ist der einzige Mechanismus, der diesen
+    Fall ausschliesst.
+
+    RED-Charakter: Mutations-Waechter — rot bei: Fenster auf „bis Tagesende"
+    geoeffnet; dann bekommt jeder frisch angelegte Trip sofort ein Briefing,
+    das auf eine laengst vergangene Uhrzeit datiert ist.
+    """
+    tag = date(2026, 8, 20)
+    _schreibe("slot-t10", [_trip_json(
+        "frisch", *KORSIKA, [tag, tag + timedelta(days=1)], morning="07:00:00",
+    )])
+    scheduler = _scheduler("slot-t10")
+
+    assert ("frisch", "morning") not in _sammlung(
+        scheduler, _zeitpunkt(PARIS, tag, 20)
+    ), (
+        "Ortsstunde 20 liegt 13 Stunden hinter der konfigurierten 07 — ein "
+        "gerade erst angelegter Trip darf sein Morgen-Briefing nicht "
+        "rueckwirkend bekommen."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-11 / T11 — der Ortsvergleich bleibt bit-identisch
+# ---------------------------------------------------------------------------
+
+def _compare_preset_schreiben(user_id: str, stunde: int) -> None:
+    """Echtes Vergleichs-Preset in `briefings/` (Cutover-Lesepfad #1250 S7b)."""
+    ordner = get_briefings_dir(user_id)
+    ordner.mkdir(parents=True, exist_ok=True)
+    (ordner / "vgl-1.json").write_text(json.dumps({
+        "id": "vgl-1",
+        "kind": "vergleich",
+        "name": "Alpen vs Voralpen",
+        "user_id": user_id,
+        "schedule": "daily",
+        "location_ids": ["ort-a", "ort-b"],
+        "empfaenger": ["nutzer@example.com"],
+        "morning_enabled": True,
+        "morning_time": f"{stunde:02d}:00:00",
+        "evening_enabled": False,
+        "evening_time": "18:00:00",
+    }), encoding="utf-8")
+
+
+def test_t11_ortsvergleich_kennt_keinen_vermerk(monkeypatch):
+    """Given der Ortsvergleichs-Pfad mit unveraenderter Konfiguration / When
+    derselbe Versandlauf ueber 24 Stunden ausgefuehrt wird / Then feuert das
+    Preset genau zur konfigurierten Stunde der festen Vergleichs-Zone — und
+    ein ZWEITER Lauf in derselben Stunde feuert erneut.
+
+    Der zweite Lauf ist der eigentliche Waechter: der Idempotenz-Schutz darf
+    ausschliesslich im Trip-Pfad wirken. Gemessen wird ueber das GETEILTE
+    Skelett `run_briefing_dispatch`, nicht nur ueber `collect_due` — ein Hook
+    im Skelett (etwa `already_sent(item)` vor `dispatch_one`) waere an
+    `collect_due` allein unsichtbar. Ersetzt ist nur `dispatch_one` (die Naht
+    zum echten Vergleichs-Versand), `collect_due` und `pre_pass` laufen echt.
+
+    RED-Charakter: Mutations-Waechter — rot bei: Vermerk-Filter ins geteilte
+    Skelett `run_briefing_dispatch` verschoben oder in eine gemeinsame
+    Basisklasse beider Strategien gezogen; dann verstummt der zweite Lauf und
+    der Ortsvergleich hat vor #1726 still seine Faelligkeit geaendert.
+    """
+    from app.config import Settings
+    from services import dispatch_orchestrator as orchestrator
+
+    _compare_preset_schreiben("slot-t11", 9)
+    protokoll: list = []
+
+    class _MitgeschriebenerVergleich(orchestrator.CompareDispatchStrategy):
+        def dispatch_one(self, item) -> None:
+            protokoll.append(item[0].get("id"))
+
+    monkeypatch.setitem(orchestrator._STRATEGY, "vergleich", _MitgeschriebenerVergleich)
+    zone = ZoneInfo(orchestrator.CompareDispatchStrategy.NOCH_NICHT_ORTSZEIT_SIEHE_1726)
+    settings = Settings(is_test_mode=True)
+
+    stunden_mit_versand = []
+    for now in _ortstag_schritte(zone, date(2026, 8, 20)):
+        vorher = len(protokoll)
+        orchestrator.run_briefing_dispatch("vergleich", "slot-t11", now, settings=settings)
+        if len(protokoll) > vorher:
+            stunden_mit_versand.append(_ortsstunde(now, zone))
+
+    assert stunden_mit_versand == [9], (
+        "Der Ortsvergleich muss unveraendert genau zur konfigurierten Stunde "
+        f"seiner festen Zone feuern, gefunden {stunden_mit_versand}"
+    )
+
+    # Zweiter Lauf in derselben Stunde: Compare kennt keinen Vermerk.
+    vorher = len(protokoll)
+    orchestrator.run_briefing_dispatch(
+        "vergleich", "slot-t11", _zeitpunkt(zone, date(2026, 8, 20), 9), settings=settings,
+    )
+    assert len(protokoll) == vorher + 1, (
+        "Ein zweiter Lauf in derselben Stunde muss den Vergleich erneut "
+        "versenden — der Idempotenz-Schutz aus #1725 gehoert ausschliesslich "
+        "in den Trip-Pfad, nicht ins geteilte Skelett (#1726, AC-8 aus #1724)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-12 / T12 — On-Demand-Versand ist vom Vermerk unabhängig
+# ---------------------------------------------------------------------------
+
+def test_t12_on_demand_schreibt_keinen_vermerk_und_liest_keinen(caplog):
+    """Given ein Nutzer fordert per SMS-Kommando ein Briefing ausserhalb des
+    regulaeren Slots an / When dieser On-Demand-Versand laeuft / Then setzt er
+    KEINEN Vermerk fuer den regulaeren Slot und liest auch KEINEN.
+
+    🔴 Dieser Test kommt bewusst OHNE die Versand-Naht aus: `send_on_demand_
+    report` laeuft in den ECHTEN `_send_trip_report_outcome` und erreicht dort
+    ehrlich den Ausgang `no_stage` (frueher Return vor jedem Wetterabruf, kein
+    Netz). Genau dadurch faengt er die Verfaelschung, die eine Unterklasse
+    verdecken wuerde.
+
+    Zeit: `send_on_demand_report` nimmt konstruktionsbedingt keinen Zeitpunkt
+    an (`:905` liest dort seine eigene Uhr — bekannte Drift, gehoert zu #1726).
+    Der Ortstag wird deshalb ueber dieselbe Ableitung wie im Produktivcode
+    (`trip_local_today`) aus der aktuellen Uhr bestimmt.
+
+    RED-Charakter: Mutations-Waechter — rot bei: Vermerk in
+    `_send_trip_report_outcome` statt im Wrapper `_dispatch_due_item` gesetzt
+    (dann nimmt eine SMS-Anfrage dem Nutzer sein regulaeres Briefing weg) und
+    rot bei einem On-Demand-Pfad, der den Vermerk LIEST (dann ist der
+    Test-Knopf nach dem regulaeren Versand tot).
+    """
+    from app.loader import load_all_trips
+    from services.trip_day import trip_local_today
+
+    jetzt = datetime.now(timezone.utc)
+    _schreibe("slot-t12", [_trip_json(
+        "korsika", *KORSIKA, [local_dt(jetzt, PARIS).date() - timedelta(days=1)],
+        morning="07:00:00", evening="18:00:00",
+    )])
+    trip = load_all_trips(user_id="slot-t12")[0]
+    ortstag = trip_local_today(trip, jetzt)
+    scheduler = _scheduler("slot-t12")
+    store = BriefingSlotStore("slot-t12")
+
+    # a) Der On-Demand-Versand endet ehrlich mit `no_stage` — einem Ausgang,
+    #    der im REGULAEREN Pfad einen Vermerk setzt.
+    assert scheduler.send_on_demand_report(trip, "evening") == "no_stage", (
+        "Testaufbau prueft nichts: der On-Demand-Versand muss hier ohne Netz "
+        "im Ausgang 'no_stage' enden."
+    )
+    assert not store.is_recorded("korsika", "evening", ortstag), (
+        "Ein per SMS angefordertes Briefing darf dem Nutzer sein regulaeres "
+        "nicht wegnehmen — der On-Demand-Pfad setzt keinen Vermerk. Steht hier "
+        "einer, sitzt er in `_send_trip_report_outcome` statt im Wrapper."
+    )
+
+    # b) Ein bestehender Vermerk macht den Test-Knopf nicht tot.
+    assert store.reserve("korsika", "evening", ortstag), (
+        "Testaufbau prueft nichts: die Reservierung muss frisch gelingen."
+    )
+    store.record_outcome("korsika", "evening", ortstag, "sent")
+    assert store.is_recorded("korsika", "evening", ortstag), (
+        "Testaufbau prueft nichts: der Vermerk muss nach `record_outcome` stehen."
+    )
+
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="trip_report_scheduler"):
+        ergebnis = scheduler.send_on_demand_report(trip, "evening")
+
+    assert ergebnis == "no_stage", (
+        "Der On-Demand-Versand muss trotz bestehendem Vermerk denselben "
+        f"ehrlichen Ausgang liefern, gefunden {ergebnis!r}"
+    )
+    assert any("Generating evening report" in eintrag.getMessage()
+               for eintrag in caplog.records), (
+        "Der On-Demand-Pfad ist gar nicht erst in den Versand eingetreten — "
+        "er liest offenbar den Vermerk. Damit waere der Test-Versand-Knopf "
+        "nach dem regulaeren Briefing des Tages tot (#695)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-13 / T13 — Sperre nicht erhältlich → kein Versand (fail-closed)
+# ---------------------------------------------------------------------------
+
+def test_t13_ohne_sperre_wird_nicht_gesendet(monkeypatch):
+    """Given die Schreibsperre auf `briefing_slots.json` ist nicht zu bekommen
+    / When ein Trip zum Versand ansteht / Then wird NICHT gesendet, statt ohne
+    wirksamen Vermerk zu senden.
+
+    Mockfreier Aufbau: die Sperre wird mit einem ECHTEN, im selben Prozess
+    gehaltenen `flock`-Filedeskriptor auf der echten Sidecar-Datei belegt.
+    `flock` haengt an der Open-File-Description, nicht am Prozess — ein
+    zweiter `os.open` derselben Datei kollidiert also real (nachgemessen).
+    Die Zeitgrenze wird ueber das Modul-Attribut gekuerzt, damit der Test
+    nicht 2 Sekunden wartet.
+
+    RED-Charakter: Mutations-Waechter — rot bei: fail-open wie
+    `throttle_store:139-150` (Warnung loggen und trotzdem weitermachen). Dort
+    kostet ein verpasster Schreibvorgang einen doppelten Hinweis; hier
+    bedeutet er einen echten Doppelversand inklusive kostenpflichtiger
+    Premium-SMS.
+    """
+    tage = [date(2026, 8, 19), date(2026, 8, 20), date(2026, 8, 21)]
+    _schreibe("slot-t13", [_trip_json("korsika", *KORSIKA, tage, morning="07:00:00")])
+    scheduler = _scheduler_mit_festem_ausgang("slot-t13")
+
+    monkeypatch.setattr(briefing_slots, "LOCK_TIMEOUT_SECONDS", 0.05, raising=False)
+
+    trip, report_type, ortstag = scheduler._collect_due_trips(
+        _zeitpunkt(PARIS, date(2026, 8, 20), 7)
+    )[0]
+
+    verzeichnis = get_data_dir("slot-t13")
+    verzeichnis.mkdir(parents=True, exist_ok=True)
+    sperrdatei = str(verzeichnis / "briefing_slots.json.lock")
+    fd = os.open(sperrdatei, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        ergebnis = scheduler._dispatch_due_item(trip, report_type, ortstag)
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+    assert scheduler.versandversuche == [], (
+        "Die Reservierung war nicht zu bekommen — dann darf NICHT gesendet "
+        "werden. Ein Versand ohne wirksamen Vermerk ist ein Doppelversand in "
+        f"der naechsten Stunde. Gefunden: {scheduler.versandversuche}"
+    )
+    assert ergebnis is None, (
+        "Ohne Versandversuch gibt es keinen Ausgang zu melden — erwartet None, "
+        f"gefunden {ergebnis!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-14 / T14 — Australia/Lord_Howe (Halbstunden-Versatz, 24,5-Stunden-Tag)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("tag,stunde", [
+    # 2026-04-05: Ende der Sommerzeit, Ortstag 24,5 h lang. Die Ortsstunde 01
+    # kommt ZWEIMAL vor (01:00 und 01:30) -- Doppelstunde im Halbstunden-Raster.
+    (date(2026, 4, 5), 1),
+    (date(2026, 4, 5), 7),
+    # 2026-10-04: Beginn der Sommerzeit, Ortstag 23,5 h lang (01:00 -> 02:30).
+    (date(2026, 10, 4), 2),
+    (date(2026, 10, 4), 7),
+])
+def test_t14_lord_howe_halbstundenversatz_bleibt_unauffaellig(tag: date, stunde: int):
+    """Given ein Trip in `Australia/Lord_Howe` (Halbstunden-Versatz, an den
+    eigenen Umstellungstagen 24,5 bzw. 23,5 Stunden lang) / When der
+    Sammellauf ueber den vollstaendigen Ortstag laeuft / Then wird der Trip
+    genau einmal faellig, ohne Luecke und ohne Dopplung.
+
+    Der Fall existierte im Repo bisher nur als Text in ADRs und einem
+    Docstring — kein einziger Test hat ihn je gemessen.
+
+    RED-Charakter: fuer (05.04., 01:00) Fehlernachweis — die Ortsstunde 01
+    kommt an diesem Tag zweimal vor, die heutige Stundengleichheit liefert
+    dort ZWEI Treffer. Fuer die uebrigen Faelle Mutations-Waechter — rot bei:
+    einer Faelligkeitsrechnung, die den Halbstunden-Versatz auf volle Stunden
+    rundet oder den Ortstag mit fest gesetzten 24 Stunden abschreitet.
+    """
+    tage = [tag - timedelta(days=1), tag, tag + timedelta(days=1)]
+    user = f"slot-t14-{tag.isoformat()}-{stunde}"
+    _schreibe(user, [_trip_json(
+        "lordhowe", *LORD_HOWE, tage, morning=f"{stunde:02d}:00:00",
+    )])
+    scheduler = _scheduler_mit_festem_ausgang(user)
+
+    treffer = [
+        now for now in _ortstag_schritte(LORD_HOWE_TZ, tag)
+        if ("lordhowe", "morning") in _lauf(scheduler, now)
+    ]
+
+    assert len(treffer) == 1, (
+        f"{tag} / konfiguriert {stunde:02d}:00 — erwartet genau ein Treffer, "
+        f"gefunden {len(treffer)}: "
+        f"{[local_dt(t, LORD_HOWE_TZ).isoformat() for t in treffer]}"
+    )
+    assert _ortsstunde(treffer[0], LORD_HOWE_TZ) == stunde, (
+        f"Treffer liegt auf Ortsstunde "
+        f"{_ortsstunde(treffer[0], LORD_HOWE_TZ)}, konfiguriert war {stunde}"
+    )


### PR DESCRIPTION
S3 des Zeitzonen-Epics #1722. Setzt #1724 voraus (live seit `e21f4f48`).

## Problem

Die Fälligkeitsprüfung verglich `konfigurierte_stunde == ortsstunde`. Das setzt voraus, dass jede Ortsstunde eines Tages genau einmal existiert — an Umstellungstagen stimmt das nicht:

| Wirkung | vorher | nachher |
|---|---|---|
| Frühjahrs-Umstellung, Briefing 02:00 | entfällt **ersatzlos** | kommt genau einmal |
| Herbst-Umstellung, Doppelstunde | geht **zweimal** raus | genau einmal |
| Ausgefallener Tick | Tag verloren | wird nachgeholt (3 h) |
| Zwei Läufe in derselben Stunde | **kein Schutz** | Doppelversand unmöglich |

Der Fehler entstand **erst durch die Verbesserung aus #1724** — vorher lief die Rechnung in einer festen Zone und war damit zufällig umstellungs-immun. Genau die Falle, die ADR-0044 benannt hatte.

**Zusätzlich gemessen:** Der Go-Cron läuft prozessweit in `Europe/Vienna`; `robfig/cron/v3` überspringt an der Frühjahrs-Umstellung eine Tick-Stunde ersatzlos (belegt an `doc.go` und der Testsuite der Bibliothek). Das trifft **alle** Nutzer weltweit, auch Trips ohne eigene Umstellung. Das Nachhol-Fenster fängt es auf.

## Lösung

```
fällig ⟺ konfigurierte_stunde <= ortsstunde < konfigurierte_stunde + 3
         UND kein Vermerk für (trip_id, ortstag, slot)
```

Neuer Speicher `src/services/briefing_slots.py` → `data/users/<uid>/briefing_slots.json`:
- `fcntl`-Sperre, atomarer Schreibvorgang, reserve-then-release
- **fail-closed**, anders als das Vorbild `throttle_store` — „Sperre nicht erhalten" hieße hier Doppelversand, inklusive kostenpflichtiger Premium-SMS
- Rückwärts-Ableitung aus `briefing_log.json`, solange die eigene Datei fehlt (Deploy mitten im Fenster)

Vermerk setzen bei `sent`/`no_stage`/`no_weather`/`no_channels`, **nicht** bei `channels_unreachable` (der Nachholfall). `no_weather` bewusst mit Vermerk: die Nachholung leistet dort bereits der #1012-Marker, zwei konkurrierende Wiederholpfade wären der Fehler.

Die drei angeforderten Versandwege (SMS „heute"/„morgen", Test-Versand-Knopf, Inbound „report") kennzeichnen sich über einen **eigenen** Parameter `angefordert` und nehmen dem Nutzer sein reguläres Briefing nicht weg.

## Warum ein eigener Parameter statt `on_demand`

Ausgezählt: `on_demand` wird in `_send_trip_report_outcome` an acht Stellen gelesen, nur eine davon ist der Log-Eintrag. Die anderen sieben hätten sich für Test-Versand und „report" mitgeändert — darunter der Mail-Text, die Alarm-Referenz und drei Stellen, die den #1012/#1662-Nachliefermechanismus stilllegen. Kein Test hätte das gefangen. Die Messtabelle steht im Docstring am Wirkort.

## Abgrenzung

Nicht Teil dieser Scheibe: der Ortsvergleichs-Pfad (#1726, AC-8 aus #1724 gilt fort und ist erneut nachgewiesen), #1557, die Reparatur des Go-Cron selbst, Retention für die neue Datei.

## Nachweis

**101 Tests grün.** Adversary: **4 Runden, Verdict VERIFIED**, 49 Punkte belegt — zwei Runden davor BROKEN:

- **F004/F006 (HIGH):** Ein angeforderter Versand unterdrückte den regulären Slot. Der erste Fix deckte nur einen von drei Wegen ab; ausgerechnet der Test-Versand-Knopf blieb offen — das, was nach einem Deploy gedrückt wird, also im einzigen Zeitfenster, in dem der Fehler auftreten kann. Die Fläche ist am Ende von beiden Seiten ausgezählt: ein Schreiber, vier Aufrufer, drei gekennzeichnet.
- **F001–F003 (MEDIUM):** drei Mutationslücken. Das Fenster 3→2 blieb unbemerkt (geprüft wurden nur die Ränder H+1 und H+3, nicht der Wert dazwischen); der Zonen-Parameter war unbewacht, weil der Test in einer Zone spielte, wo Ortstag und UTC-Tag zusammenfallen; die Verwechslung von Ortstag und UTC-Tag hätte Doppelversand bei Briefing-Stunde 01 bedeutet.

Jede Reparatur trägt ihre Gegenprobe: nimmt man den Fix heraus, wird genau der zugehörige Test rot. Die vier umgebauten #1724-Tests wurden unabhängig nachgemessen (Zone fest / Zone UTC / Rückfall geraten) — sie fangen weiterhin, was sie vorher fingen.

Drei nicht-blockierende Nachträge nach #1199 gebucht.

Refs #1725

🤖 Generated with [Claude Code](https://claude.com/claude-code)
