### PR TITLE
docs(#1745): Alarm-Kanal Premium-SMS in der Doku nachziehen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ Beide Wächter lassen bei **eigener** Störung immer durch und sagen es — ein 
 
 Signal ist entfernt: kein `SignalOutput`/`signal_text`/`send_signal`, kein `/api/preview/{trip}/signal`. Wiedereinführung müsste neu spezifiziert werden. (Callmebot bleibt serverseitig für andere Dienste.)
 
-**Die Kanal-Liste lautet seit 2026-08-10 vier, nicht drei:** E-Mail · Telegram · SMS · Premium-SMS. Hier stand bis dahin „Kanäle sind nur noch E-Mail · Telegram · SMS" — das war nach der Signal-Entfernung richtig und ist seit #1676 S2a (ADR-0049, schreibt ADR-0004 fort) überholt. Premium-SMS ist heute nur im **Trip-Briefing** verdrahtet; Alarm- und Vergleichspfad folgen mit #1701, die Oberfläche mit S3. Zur Gleichrangigkeit der vier Kanäle siehe „Projekt-Ueberblick" oben.
+**Die Kanal-Liste lautet seit 2026-08-10 vier, nicht drei:** E-Mail · Telegram · SMS · Premium-SMS. Hier stand bis dahin „Kanäle sind nur noch E-Mail · Telegram · SMS" — das war nach der Signal-Entfernung richtig und ist seit #1676 S2a (ADR-0049, schreibt ADR-0004 fort) überholt. Als **Versandkanal** ist Premium-SMS weiterhin nur im **Trip-Briefing** verdrahtet (kein Ortsvergleich-Versand). Als **Alarm-Kanal** ist Premium-SMS seit #1701 (Backend) und #1745 Scheibe A (Oberfläche, Alarme-Reiter) in **beiden** Flächen (Trip UND Ortsvergleich) verdrahtet — hier stand bis 2026-08-11 „Alarm- und Vergleichspfad folgen mit #1701, die Oberfläche mit S3", das ist damit eingeholt. Wirkt sofort für Gewitter-, Änderungs- und amtliche Alarme, **nicht** für Regen-/Radar-Alarme, die weiterhin am Briefing-Flag hängen (Scheibe B, #1752, offen). Zur Gleichrangigkeit der vier Kanäle siehe „Projekt-Ueberblick" oben.
 
 ## Confidence (Vorhersage-Verlässlichkeit) — NICHT wählbar als Metrik (2026-06-10, Issue #710)
 

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -1,6 +1,13 @@
 # Architektur – Gregor Zwanzig
 
-**Updated:** 2026-08-11 (Issue #1667 S3 — Radar-/NowCast-Alarm-Segmentauswahl in `check_radar_alerts` tagesübergreifend: `trip_segments.py::resolve_current_segment()` fällt bei einer Etappe mit Ankunft nach Mitternacht auf das noch aktive Ziel-Segment des Vortags zurück (aktiv heute → aktiv gestern → Vorschau heute[0] → nichts) statt `[]`/Falsch-Ortung zu liefern; der Briefing-Schnappschuss-Vergleich liest fortan unter dem Datum des gewählten Segments statt starr unter `today`; Issue #1667 damit vollständig geschlossen); 2026-08-10 (Issue #1676 Scheibe S2a — Premium-SMS wird vierter Versandkanal `premium_sms`, ausschließlich fürs Trip-Briefing: fester Absender `4916092172595`, Empfänger die in S1 gelernte Rückadresse aus `user.json`, Verfall nach 30 Tagen ohne Nachlernen, fail-closed mit auswertbarem Grund statt stillem Ausbleiben, eigenes Tier-Gate nur `premium`; ADR-0049 schreibt ADR-0004 fort — Kanalliste jetzt E-Mail · Telegram · SMS · Premium-SMS; Alarm-/Vergleichspfad und Oberfläche folgen erst mit S2b/#1701 bzw. S3); 2026-08-10 (Issue #1676 Scheibe S1 — neuer Premium-SMS-Rückkanal: `InboundSmsReader` pollt das seven.io-Journal auf Garmin-inReach-Antworten und lernt die Rückadresse über den neuen internen Go-Endpoint `POST /api/internal/premium-sms-learn`; kein Trip-Befehlskanal, kein Frontend); 2026-08-03 (Issue #1460 Teil 1, ADR-0043 löst ADR-0040 ab — Wertebereich (`corridors[].notify`) fällt als Alarm-Auslöser weg, Empfindlichkeitsstufe bleibt einziger Regler und wirkt bei Gewitter über das erreichte Niveau statt die Sprunggröße, symmetrisch für Verschärfung und Entwarnung; Melde-Gedächtnis-Reset löscht beim Briefing nur noch den Änderungs-Raum, der amtliche Raum bleibt erhalten); 2026-07-21 (Doku-Audit #1341 — Frontend-Sektionen auf Ist-Stand: Wizards entfernt, Organisms-Barrel korrigiert, /api/subscriptions → /api/compare/presets + /api/briefings); 2026-07-03 (Issue #1001 — Telegram-Ausgabe neu gebaut: `render_telegram_bubbles()` ersetzt `render_narrow()` für den Telegram-Kanal, Multi-Bubble-Versand statt Prosa-Nachricht, echte Monospace-Segment-Tabellen, Inline-Keyboard-Aktionen-Bubble); 2026-06-30 (Issue #919 — Radar-Alert auf kanonischen Renderer migriert: `OnsetEvent`-Datenklasse + `cooldown_display` in `model.py`, Onset-Zweige in alle vier `render_*`-Funktionen, `check_radar_alerts` baut jetzt `AlertMessage(OnsetEvent(...))`, `src/outputs/radar_alert.py` gelöscht); 2026-06-26 (Issue #887 — SMS/Telegram Report-Konsistenz: SMS `pop_hourly` aus `agg.pop_max_pct`, Telegram Detail-Zeile mit config-gesteuerten Metriken; Issue #884 — HTML-Mail Fidelity: 8-Sektion-Layout mit zweispaltigem Header + Stats-Grid, Ziel-Sektion, Ausblick mit Risk-Dot, Kommandos-Sektion, zweigeteilt Footer); 2026-06-15 (Issue #822 — Radar-/Regen-Nowcast-Alert segmentbewusst: gemeinsamer Segment-Helfer, aktives/nächstes Segment nach Tageszeit, Ort-Label via build_segment_label, Tour-TZ via tz_for_coords, dynamischer Cooldown-Text); 2026-06-14 (Issue #816 — Alert-Abweichungs-Kern: read-only Snapshot, alert_state Melde-Gedächtnis, knapper Render-Pfad); 2026-06-12 (Issue #758 — Einheitlicher Speicher-Status-Indikator + Trip-Editor Auto-Save; #733 Briefing-Mail-Validator Marker-Header); 2026-06-11 (Issue #749 — Day Comparison Renderer: render_day_comparison_html/plain für Vortag-Vergleich-Sektion); 2026-06-09 (Issue #675 — Etappen-Startzeiten Editor-Widget; Issue #671 — Bot-Menü automatisch beim Service-Start + Live-Selftest); 2026-06-08 (Issue #655 — Telegram callback_query + editMessageText Zoom-Navigation); 2026-06-07 (Issue #637 — Telegram Webhook Migration); 2026-06-03 (Issue #572 — Inbound-Handler Multi-User Routing); 2026-05-31 (Issue #483 — Demo-Modus im Vorschau-Tab; Issue #495 — MapCanvas Leaflet-Karte; Issue #475 — OutputLayoutEditor zu Organisms)
+**Updated:** 2026-08-11 (Issue #1745 Scheibe A — Premium-SMS ist jetzt auch im
+Alarme-Reiter als vierter Kanal sichtbar/schaltbar, mit eigener Dringlichkeits-Schwelle, in
+**beiden** Flächen (Trip UND Ortsvergleich); wirkt sofort für Gewitter-, Änderungs- und
+amtliche Alarme, **nicht** für Regen-/Radar-Alarme, die weiterhin am Briefing-Flag hängen
+(Scheibe B, #1752, noch offen); reines Frontend, keine Backend-Änderung — löst die
+„Alarm-/Vergleichspfad und Oberfläche folgen erst mit S2b/#1701 bzw. S3"-Aussage der
+#1676-S2a-Zeile unten ab, die inzwischen von #1701 (Backend) und #1745 (Oberfläche)
+eingeholt wurde; siehe „Premium-SMS als Versandkanal" unten); 2026-08-11 (Issue #1667 S3 — Radar-/NowCast-Alarm-Segmentauswahl in `check_radar_alerts` tagesübergreifend: `trip_segments.py::resolve_current_segment()` fällt bei einer Etappe mit Ankunft nach Mitternacht auf das noch aktive Ziel-Segment des Vortags zurück (aktiv heute → aktiv gestern → Vorschau heute[0] → nichts) statt `[]`/Falsch-Ortung zu liefern; der Briefing-Schnappschuss-Vergleich liest fortan unter dem Datum des gewählten Segments statt starr unter `today`; Issue #1667 damit vollständig geschlossen); 2026-08-10 (Issue #1676 Scheibe S2a — Premium-SMS wird vierter Versandkanal `premium_sms`, ausschließlich fürs Trip-Briefing: fester Absender `4916092172595`, Empfänger die in S1 gelernte Rückadresse aus `user.json`, Verfall nach 30 Tagen ohne Nachlernen, fail-closed mit auswertbarem Grund statt stillem Ausbleiben, eigenes Tier-Gate nur `premium`; ADR-0049 schreibt ADR-0004 fort — Kanalliste jetzt E-Mail · Telegram · SMS · Premium-SMS; Alarm-/Vergleichspfad und Oberfläche folgen erst mit S2b/#1701 bzw. S3); 2026-08-10 (Issue #1676 Scheibe S1 — neuer Premium-SMS-Rückkanal: `InboundSmsReader` pollt das seven.io-Journal auf Garmin-inReach-Antworten und lernt die Rückadresse über den neuen internen Go-Endpoint `POST /api/internal/premium-sms-learn`; kein Trip-Befehlskanal, kein Frontend); 2026-08-03 (Issue #1460 Teil 1, ADR-0043 löst ADR-0040 ab — Wertebereich (`corridors[].notify`) fällt als Alarm-Auslöser weg, Empfindlichkeitsstufe bleibt einziger Regler und wirkt bei Gewitter über das erreichte Niveau statt die Sprunggröße, symmetrisch für Verschärfung und Entwarnung; Melde-Gedächtnis-Reset löscht beim Briefing nur noch den Änderungs-Raum, der amtliche Raum bleibt erhalten); 2026-07-21 (Doku-Audit #1341 — Frontend-Sektionen auf Ist-Stand: Wizards entfernt, Organisms-Barrel korrigiert, /api/subscriptions → /api/compare/presets + /api/briefings); 2026-07-03 (Issue #1001 — Telegram-Ausgabe neu gebaut: `render_telegram_bubbles()` ersetzt `render_narrow()` für den Telegram-Kanal, Multi-Bubble-Versand statt Prosa-Nachricht, echte Monospace-Segment-Tabellen, Inline-Keyboard-Aktionen-Bubble); 2026-06-30 (Issue #919 — Radar-Alert auf kanonischen Renderer migriert: `OnsetEvent`-Datenklasse + `cooldown_display` in `model.py`, Onset-Zweige in alle vier `render_*`-Funktionen, `check_radar_alerts` baut jetzt `AlertMessage(OnsetEvent(...))`, `src/outputs/radar_alert.py` gelöscht); 2026-06-26 (Issue #887 — SMS/Telegram Report-Konsistenz: SMS `pop_hourly` aus `agg.pop_max_pct`, Telegram Detail-Zeile mit config-gesteuerten Metriken; Issue #884 — HTML-Mail Fidelity: 8-Sektion-Layout mit zweispaltigem Header + Stats-Grid, Ziel-Sektion, Ausblick mit Risk-Dot, Kommandos-Sektion, zweigeteilt Footer); 2026-06-15 (Issue #822 — Radar-/Regen-Nowcast-Alert segmentbewusst: gemeinsamer Segment-Helfer, aktives/nächstes Segment nach Tageszeit, Ort-Label via build_segment_label, Tour-TZ via tz_for_coords, dynamischer Cooldown-Text); 2026-06-14 (Issue #816 — Alert-Abweichungs-Kern: read-only Snapshot, alert_state Melde-Gedächtnis, knapper Render-Pfad); 2026-06-12 (Issue #758 — Einheitlicher Speicher-Status-Indikator + Trip-Editor Auto-Save; #733 Briefing-Mail-Validator Marker-Header); 2026-06-11 (Issue #749 — Day Comparison Renderer: render_day_comparison_html/plain für Vortag-Vergleich-Sektion); 2026-06-09 (Issue #675 — Etappen-Startzeiten Editor-Widget; Issue #671 — Bot-Menü automatisch beim Service-Start + Live-Selftest); 2026-06-08 (Issue #655 — Telegram callback_query + editMessageText Zoom-Navigation); 2026-06-07 (Issue #637 — Telegram Webhook Migration); 2026-06-03 (Issue #572 — Inbound-Handler Multi-User Routing); 2026-05-31 (Issue #483 — Demo-Modus im Vorschau-Tab; Issue #495 — MapCanvas Leaflet-Karte; Issue #475 — OutputLayoutEditor zu Organisms)
 
 ## Überblick
 Gregor Zwanzig ist ein verteiltes System mit separatem Frontend (SvelteKit) und einem Dual-Stack-Backend (Go + Python):
@@ -9,8 +16,11 @@ Gregor Zwanzig ist ein verteiltes System mit separatem Frontend (SvelteKit) und 
 - **Python-Core:** Wetter-Domäne (Provider, Risk Engine, Aggregation), alle Kanal-Renderer und -Transporte, Scheduler, Alerts, Inbound-Handler (FastAPI, Port 8000)
 - **Frontend:** SvelteKit Web-UI für Trip-Management, Konfiguration und Orts-Vergleiche
 - **Channels:** E-Mail (SMTP), Telegram, SMS (seven.io), Premium-SMS (seven.io, Garmin
-  inReach — seit Issue #1676 S2a **nur im Trip-Briefing** verdrahtet, nicht im Alarmpfad und
-  nicht im Ortsvergleich; siehe ADR-0049)
+  inReach) — als **Versandkanal** seit Issue #1676 S2a weiterhin **nur im Trip-Briefing**
+  (kein Ortsvergleich-Versand); als **Alarm-Kanal** seit #1701 (Backend) und #1745 Scheibe A
+  (Oberfläche, Alarme-Reiter) in **beiden** Flächen verdrahtet — Trip UND Ortsvergleich,
+  für Gewitter-, Änderungs- und amtliche Alarme, **nicht** für Regen-/Radar-Alarme (Scheibe
+  B, #1752, offen); siehe ADR-0049
 - **Abo-Objekte:** Briefing-Subscriptions für Trips (ADR-0023) und Compare-Presets für Orts-Vergleiche — getrennte Domänenobjekte, keine gemeinsame „Subscription“-Abstraktion mehr
 
 Siehe `docs/adr/0015-dual-stack-zielarchitektur.md` für die verbindliche Zuständigkeitsgrenze.
@@ -74,16 +84,20 @@ Die folgenden Komponenten leben im Python-Core:
      Spec: `docs/specs/modules/telegram_send_pacing.md`.
    - **SMS** (`src/output/channels/sms.py`) – SMS-Versand via seven.io
    - **Premium-SMS** (`src/output/channels/premium_sms.py`, `PremiumSmsOutput`,
-     `name == "premium_sms"`, seit Issue #1676 S2a) – **nur Trip-Briefing**, kein Alarm-
-     und kein Ortsvergleich-Pfad (folgt frühestens mit #1701). Fester Absender
-     `4916092172595` (unabhängig von `sms_from`), Empfänger ausschließlich die in S1
-     gelernte Rückadresse aus `user.json` (nie `sms_to`), Fail-Closed bei fehlender oder
-     >30 Tage alter Rückadresse mit auswertbarem Grund in `NotificationResult.blocked_channels`,
-     eigenes Tier-Gate (`premium_sms_allowed()`, ausschließlich Tier `premium`). Teilt sich
-     mit `SMSOutput` die Basisklasse `SevenIoChannelBase` (Sicherheitssperren + HTTP-Transport
-     genau einmal statt zweimal). Kein eigener Render-Pfad — Text kommt unverändert aus
-     `report.sms_text`. Kein Frontend-Schalter (folgt mit S3). Details: ADR-0049,
-     `docs/specs/modules/feat_1676_s2a_premium_sms_versand.md`.
+     `name == "premium_sms"`, seit Issue #1676 S2a) – als **Versandkanal** weiterhin **nur
+     Trip-Briefing**, kein Ortsvergleich-Versand. Als **Alarm-Kanal** seit #1701 (Backend)
+     für Gewitter-, Änderungs- und amtliche Alarme verdrahtet, in Trip **und** Ortsvergleich
+     (Regen-/Radar-Alarme lesen weiterhin ausschließlich das Briefing-Flag,
+     `_radar_effective_channels()`, `src/services/trip_alert.py:826-856` — Scheibe B/#1752,
+     noch offen). Fester Absender `4916092172595` (unabhängig von `sms_from`), Empfänger
+     ausschließlich die in S1 gelernte Rückadresse aus `user.json` (nie `sms_to`), Fail-Closed
+     bei fehlender oder >30 Tage alter Rückadresse mit auswertbarem Grund in
+     `NotificationResult.blocked_channels`, eigenes Tier-Gate (`premium_sms_allowed()`,
+     ausschließlich Tier `premium`). Teilt sich mit `SMSOutput` die Basisklasse
+     `SevenIoChannelBase` (Sicherheitssperren + HTTP-Transport genau einmal statt zweimal).
+     Kein eigener Render-Pfad — Text kommt unverändert aus `report.sms_text`. Frontend-Schalter
+     im Versand-Reiter seit #1717 S3, im Alarme-Reiter (Trip UND Ortsvergleich) seit #1745
+     Scheibe A. Details: ADR-0049, `docs/specs/modules/feat_1676_s2a_premium_sms_versand.md`.
 
 ### Datenfluss (Produktiv)
 
@@ -200,10 +214,22 @@ Rückadresse ist seit Scheibe S2a live (s. u.) — **nur fürs Trip-Briefing**.
 
 Aufbauend auf der gelernten Rückadresse aus S1 ist Premium-SMS seit S2a ein
 vierter, eigenständiger Versandkanal `premium_sms` (s. „Channels" oben und
-ADR-0049). Bewusst **nicht** verdrahtet: Alarmpfad und Ortsvergleich (folgen
-frühestens mit #1701), Oberfläche (folgt mit S3). `send_premium_sms` ist bis
-dahin nur über den freien `report_config`-Schlüssel setzbar, noch kein
-Go-Flach-Feld analog `send_sms`/`send_telegram`.
+ADR-0049). S2a selbst verdrahtete bewusst **nicht**: Alarmpfad und Ortsvergleich
+(folgten mit #1701), Oberfläche (folgte mit #1717 S3 für den Versand-Reiter).
+`send_premium_sms` war bis dahin nur über den freien `report_config`-Schlüssel
+setzbar, noch kein Go-Flach-Feld analog `send_sms`/`send_telegram`.
+
+🔴 **Nachtrag (der Absatz oben beschreibt den Stand von S2a, 2026-08-10 — inzwischen
+überholt):** Der Alarmpfad ist seit #1701 (Backend) verdrahtet — für Gewitter-,
+Änderungs- und amtliche Alarme, in **beiden** Flächen (Trip UND Ortsvergleich), nicht
+nur Trip. Die zugehörige Oberfläche (Alarme-Reiter, vierte Kanalzeile + eigene
+Dringlichkeits-Schwelle) ist seit #1745 Scheibe A live, ebenfalls in beiden Flächen.
+Regen-/Radar-Alarme lesen weiterhin ausschließlich das Briefing-Flag
+(`_radar_effective_channels()`, `src/services/trip_alert.py:826-856`) — Scheibe B
+(#1752) vereinheitlicht das noch nicht. Der Versand-Pfad selbst (dieser Abschnitt) bleibt
+unverändert Trip-Briefing-only, davon unberührt. Details:
+`docs/specs/modules/feat_1701_alarm_premium_sms.md`,
+`docs/specs/modules/fix_1745_a_alarm_kanal_premium_sms_ui.md`.
 
 ### Telegram Bot-Menü (Automatisches Setup)
 

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -3465,6 +3465,18 @@ function corridorInside(value, min, max) {
 
 ## Changelog
 
+- 2026-08-11: Issue #1745 Scheibe A — Premium-SMS als vierter Kanal in der Alarm-Kanal-Auswahl
+  (Alarme-Reiter, Trip UND Ortsvergleich). **Keine DTO-/Feld-Änderung** — `alert_channels.premium_sms`
+  und `alert_channel_thresholds.premium_sms` (s. Abschnitte unten) existieren bereits seit #1701 S2b;
+  diese Scheibe macht sie erstmals über die Oberfläche bedienbar (vierte Kanalzeile „Premium-SMS
+  (Garmin inReach)" direkt unter SMS, gesperrt mit Hinweis unter Tarif `standard`, eigene
+  Dringlichkeits-Schwelle). Reines Frontend (`frontend/src/lib/components/shared/AlarmeTab.svelte`
+  u.a.), kein Go-/Python-Code geändert. Klarstellung, da leicht zu verwechseln: das gilt nur für den
+  **Alarm**-Pfad — der **Versand**-Pfad (`send_premium_sms`, Trip-Briefing) bleibt seit #1676 S2a
+  bewusst auf Trips beschränkt, kein Ortsvergleich-Versand; die Alarm-Kanal-Auswahl war schon seit
+  #1701 ausdrücklich auch für den Vergleich vorgesehen (#1701 AC-4) und ist das jetzt auch in der
+  Oberfläche. Regen-/Radar-Alarme lesen weiterhin nur das Briefing-Flag, unverändert durch diese
+  Scheibe (Scheibe B, #1752, offen). Spec: `docs/specs/modules/fix_1745_a_alarm_kanal_premium_sms_ui.md`.
 - 2026-08-11: Issue #1717 Scheibe S3 — Premium-SMS in der Oberfläche. `GET /api/auth/profile`
   liefert vier neue, **rein lesende** Felder: `premium_sms_reply_to`/`premium_sms_reply_at`
   (Rohwerte, `omitempty`), `premium_sms_reply_state` (`none`/`stale`/`fresh`, immer vorhanden,


### PR DESCRIPTION
Reiner Doku-Nachzug zu #1745 Scheibe A (PR #1768, Merge `c28f794b`). Kein Code.

## Der Befund

`docs/features/architecture.md` behauptete an **drei** Stellen im Präsens, Premium-SMS sei nur im Trip-Briefing verdrahtet und Alarm-/Vergleichspfad sowie Oberfläche folgten noch (`:11-13`, `:76-78`, `:203-204`, Stand vor dieser Änderung). Beides ist eingelöst — Backend mit #1701, Oberfläche mit #1745 Scheibe A.

## Die Unterscheidung, die verwischt war

| Rolle | Geltungsbereich |
|---|---|
| **Versand**kanal (Briefing) | weiterhin **nur Trip**, kein Ortsvergleich (ADR-0049) |
| **Alarm**kanal | **beide** Flächen — Trip **und** Ortsvergleich (#1701 AC-4) |

Genau diese Verwechslung war die Fehlerquelle. Sie steht jetzt ausdrücklich in beiden Dateien.

## Mit dokumentiert: die Einschränkung

Ein gesetzter Premium-SMS-Haken wirkt für Gewitter-, Änderungs- und amtliche Alarme — **nicht** für Regen-/Radar-Alarme. Die hängen bis Scheibe B (**#1752**) weiter am Briefing-Flag. Ohne diesen Hinweis entstünde genau die falsche Erwartung, deren Fehlen #1745 überhaupt gemeldet hat.

## Bewusst nicht angefasst

**ADR-0049** enthält die Formulierung "Bis dahin ist Premium-SMS ausdrücklich kein Alarm-Kanal" (`:108-110`). Das ist zum ADR-Datum (2026-08-10) korrekt und beschreibt den damaligen Preis der Scheibe S2a. ADRs werden nicht retroaktiv umgeschrieben, wenn sich ein Vorwärtsverweis erfüllt — dafür gibt es "Status: Abgelöst durch". Diese Scheibe trifft keine neue Architekturentscheidung, also auch keine neue ADR.

`api_contract.md` bekommt nur einen Changelog-Eintrag: Die Feldtabellen waren bereits korrekt (die DTOs existieren seit #1701 S2b), diese Scheibe macht sie lediglich über die Oberfläche bedienbar.

Refs #1745, #1752

🤖 Generated with [Claude Code](https://claude.com/claude-code)