### PR TITLE
test(#1719): Ziehgeste wartet auf finalize statt auf eine feste Frist (S3)

### DIFF
--- a/frontend/e2e/wetter-metriken-vorschau-entfernt.staging.spec.ts
+++ b/frontend/e2e/wetter-metriken-vorschau-entfernt.staging.spec.ts
@@ -24,14 +24,50 @@ import { test, expect, type APIRequestContext, type Locator, type Page } from '@
 
 const TRIP_ID = 'e2e-1719-s3-vorschau-weg';
 
-// Identisch zu layout-tab-route.spec.ts:23-48 — Pointer-basierte
+// Basiert auf layout-tab-route.spec.ts:23-48 — Pointer-basierte
 // Drag-Simulation (svelte-dnd-action reagiert nicht auf natives HTML5-Drag).
+//
+// Diagnose-Fund (2026-08-12, #1719 S3 — Team-Lead-Auftrag "Reihenfolge-
+// Persistenz diagnostizieren"): `svelte-dnd-action` feuert das `finalize`-
+// CustomEvent auf der Drag-Zone NACH dem `mouseup` unzuverlässig verzögert.
+// Messung (4 Läufe gegen Staging, rohes DOM-CustomEvent-Log auf
+// `.sortable-zone`, unabhängig vom App-Code): 2× kein `finalize` innerhalb
+// der Testlaufzeit, 1× sofort, 1× erst nach ~1,9s. Ohne `finalize` ruft
+// `SortableList.svelte::handleDndFinalize` niemals `onDndReorder` auf — kein
+// `channelBuckets`-Edit, kein PUT, keine Persistenz. Die vorher hier
+// stehende feste `waitForTimeout(120)`-Pause nach dem Drop maskierte das:
+// der Test las den DOM-Zwischenstand aus `handleDndConsider` (der lokal
+// bereits die neue Reihenfolge zeigt, OHNE dass sie je committet wurde) und
+// hielt das fälschlich für einen bestandenen Speichervorgang. Bei tatsächlich
+// gefeuertem `finalize` ist die App-Logik nachweislich korrekt (PUT-Body mit
+// `precipitation order:0`, GET nach Reload bitgenau identisch) — der Fehler
+// liegt ausschließlich in der Test-Simulation, nicht im Produktcode.
+//
+// Der geteilte Helfer in layout-tab-route.spec.ts (und weiteren Dateien,
+// z.B. compare-hub-inline-edit.spec.ts) hat dieselbe Schwäche — reproduziert
+// mit layout-tab-route.spec.ts AC-3, 2× hintereinander lokal fehlgeschlagen,
+// KEIN S3-Bezug. Der Umbau dort ist bewusst NICHT Teil dieser Scheibe
+// (Team-Lead-Entscheid: "nur unseren eigenen Helfer robust machen, nichts
+// Geteiltes anfassen") — separat zu buchen.
 async function dragDndZoneItem(page: Page, source: Locator, target: Locator): Promise<void> {
 	await source.scrollIntoViewIfNeeded();
 	await target.scrollIntoViewIfNeeded();
 	const sourceBox = await source.boundingBox();
 	const targetBox = await target.boundingBox();
 	if (!sourceBox || !targetBox) throw new Error('dragDndZoneItem: source/target ohne BoundingBox');
+
+	// Vor dem Drag: Promise auf der Zone verdrahten, die bei `finalize`
+	// aufloest. `document.querySelector` genuegt — diese Ansicht zeigt genau
+	// EINE Reihenfolge-Zone (die mobile FAB/Sheet-Duplizierung ist mit AC-1
+	// dieser Scheibe entfernt).
+	await page.evaluate(() => {
+		const zone = document.querySelector('.sortable-zone');
+		if (!zone) throw new Error('dragDndZoneItem: .sortable-zone nicht im DOM gefunden');
+		(window as unknown as { __gzDndFinalize?: Promise<void> }).__gzDndFinalize = new Promise((resolve) => {
+			zone.addEventListener('finalize', () => resolve(), { once: true });
+		});
+	});
+
 	await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2);
 	await page.mouse.down();
 	await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2 - 12, {
@@ -43,6 +79,27 @@ async function dragDndZoneItem(page: Page, source: Locator, target: Locator): Pr
 	});
 	await page.waitForTimeout(120);
 	await page.mouse.up();
+
+	// Großzügiges Zeitfenster ueber dem gemessenen Maximum (~1,9s). Feuert
+	// `finalize` nicht, scheitert der Test HIER mit klarer Ursache — statt
+	// spaeter unspezifisch an einer Persistenz-Assertion, die faelschlich
+	// als Produktfehler gelesen werden koennte.
+	const FINALIZE_TIMEOUT_MS = 4_000;
+	const fired = await page.evaluate(({ ms }) => {
+		const w = window as unknown as { __gzDndFinalize?: Promise<void> };
+		if (!w.__gzDndFinalize) return Promise.resolve(false);
+		return Promise.race([
+			w.__gzDndFinalize.then(() => true),
+			new Promise<boolean>((resolve) => setTimeout(() => resolve(false), ms))
+		]);
+	}, { ms: FINALIZE_TIMEOUT_MS });
+	if (!fired) {
+		throw new Error(
+			`dragDndZoneItem: finalize blieb aus (>${FINALIZE_TIMEOUT_MS}ms) — Ziehgeste hat nicht ` +
+			'committet. Bekannte Flakiness des Pointer-Drag-Helfers (svelte-dnd-action), kein ' +
+			'Produktfehler — siehe Kommentar ueber dieser Funktion (Diagnose 2026-08-12).'
+		);
+	}
 }
 
 const REPORT_CONFIG = {


### PR DESCRIPTION
Letzter Nachtrag zu Scheibe S3 von #1719. **Nur eine Testdatei, kein Produktivcode.**

## Was war

Der Klickpfad AC-2 war reproduzierbar rot und sah wie ein Speicher-Fehler aus. Drei Läufe hintereinander, Diagnose zunächst "die Reihenfolge wird nicht persistiert".

## Was es wirklich ist

Die **Testgeste**. `svelte-dnd-action` feuert sein `finalize`-Ereignis bei zeiger-simuliertem Ziehen unzuverlässig — in vier gemessenen Läufen **zweimal gar nicht**, einmal erst nach **~1,9 s**. Der Helfer wartete stattdessen eine feste Frist von 120 ms.

**Die Falle:** Die DOM-Prüfung direkt nach dem Ziehen besteht **auch ohne** `finalize` — sie sieht nur den lokalen `consider`-Zwischenstand von `SortableList`, der ohne `finalize` nie an die Anwendung übergeben wird. Erst die Prüfung nach dem Neuladen fällt um. Das liest sich zwangsläufig als "Persistenz kaputt".

## Die Anwendung ist nachweislich korrekt

Per Netzwerk-Mitschnitt gemessen: Bei gefeuertem `finalize` enthält der PUT-Body `channel_layouts.email` mit `precipitation order:0, temperature order:1, wind order:2`, und das Neuladen liefert denselben Stand **bitgenau** zurück. Reproduziert wurde der Fehlschlag außerdem an `layout-tab-route.spec.ts` AC-3 — einem Test aus #1232, der #1719 gar nicht berührt. Der Befund ist also **älter als diese Scheibe**.

## Was hier geändert wird

Nur der Helfer **dieser einen Datei** wartet jetzt auf das rohe `finalize`-Ereignis und scheitert bei Ausbleiben mit klarer Meldung — damit ein künftiger Fehlschlag nicht wieder als Produktfehler missdeutet wird. Der geteilte Helfer bleibt unangetastet, damit fremdes Risiko den Nachweis dieser Scheibe nicht verwässert.

Separat gebucht als **#1771**, zusammen mit dem größeren Befund: **kein einziger Playwright-Spec läuft in der CI-Ampel** — der gesamte Klickpfad-Bestand ist unbewacht.

## Nachweis

- Vorschau-Bündel **dreimal hintereinander grün** (je ~5 s; vorher lief derselbe Test ins Zeitlimit)
- Danach **alle fünf Bündel in einem Durchlauf grün** — damit sind alle **13 Akzeptanzkriterien** von S3 auf Staging gemessen

Refs #1719

🤖 Generated with [Claude Code](https://claude.com/claude-code)