### PR TITLE
#1752: Radar-/Regen-Alarme folgen dem Alarm-Kanal-Satz (Scheibe B zu #1745)

### DIFF
--- a/docs/adr/0021-shared-deviation-alert-engine.md
+++ b/docs/adr/0021-shared-deviation-alert-engine.md
@@ -117,3 +117,18 @@ dieser Scheibe (Scheibe 2, #1169).
   Architekturprinzip: das bestehende aus diesem ADR wird auf den letzten noch
   abweichenden Pfad angewandt. Details:
   `docs/specs/modules/rework_1467_s3_nowcast.md`.
+- **Nachtrag (Issue #1752, 2026-08-12):** was der Nachtrag zu #1461 S3b-2b für den
+  **Ortsvergleich** vollzogen hat, ist jetzt auch für den **Trip** eingelöst. Der
+  Trip-Radar-Pfad löste seine Kanäle bis dahin über eine eigene Fassung
+  (`_radar_effective_channels()`) auf, die **ausschließlich die Briefing-Flags**
+  las und `trip.alert_channels`/`trip.alert_rules` nie — die im Alarme-Reiter
+  getroffene Auswahl war für Regen-Alarme also wirkungslos (#1745, Befund 2).
+  Die Sonderfassung ist ersatzlos entfallen; das Kanal-Set wird einmal über
+  `_effective_alert_channels()` aufgelöst und im ganzen Radar-Pfad geteilt
+  (Unterdrückungs-Protokoll, Leer-Check, Versand). Damit gibt es **einen**
+  Auflösungsweg für alle vier Trip-Alarmtypen. **Kein neues Architekturprinzip**
+  — dasselbe Muster wie bei S3b-2b, angewandt auf den letzten Pfad, der noch
+  abwich. Zwei benannte Folgen: Radar erbt damit auch die `alert_rules`-Union
+  mit, und ein Alarmversuch ohne erreichbaren Kanal hinterlässt jetzt einen
+  Protokoll-Eintrag statt spurlos abzubrechen. Details:
+  `docs/specs/modules/fix_1752_radar_folgt_alarm_kanaelen.md`.

--- a/docs/context/fix-1752-radar-folgt-alarm-kanaelen.md
+++ b/docs/context/fix-1752-radar-folgt-alarm-kanaelen.md
@@ -1,0 +1,125 @@
+# Context: fix-1752-radar-folgt-alarm-kanaelen
+
+**Issue:** [#1752](https://github.com/henemm/gregor_zwanzig/issues/1752) · Label `bug`, `priority:high`, `session:khw`
+**Track:** Full Process (Intake-Summe 4) · **Basis-Commit `bc7dc418`** · Phase 1+2 zusammengeführt 2026-08-12
+
+## Request Summary
+
+Der Radar-/Regen-Alarm löst seine Kanäle ausschließlich aus `trip.report_config` (Briefing-Flags)
+auf und liest `trip.alert_channels` nie. Wer im Alarme-Reiter Kanäle abwählt, ändert für
+Regen-Alarme **nichts** — das betrifft alle vier Kanäle, nicht nur den neuen. Scheibe B zu #1745,
+dessen Scheibe A (Premium-SMS in der Oberfläche) seit `c28f794b` live ist.
+
+## 🔴 Warum Kontext und Analyse hier zusammenfallen
+
+Die vollständige Analyse steht bereits **im Issue-Body** — sie entstand am 2026-08-11 im Zuge von
+#1745 Scheibe A. Diese Phase hat sie deshalb nicht wiederholt, sondern **gegen den heutigen Code
+zu falsifizieren versucht** (Basis `bc7dc418`, nach #1697, #1667 S3, #1701, #1725, #1745 A).
+
+**Ergebnis: Die Analyse hält vollständig.** Kein inhaltlicher Widerspruch, nur Zeilenverschiebungen.
+Das ist ein Befund, kein Formalismus — in dieser Sitzung hat eine vier Tage alte Notiz bereits
+einmal zu einer falschen Priorisierung geführt (#1584 war längst behoben). Vgl.
+[[reference_aussagen_ueber_eigenen_code_veralten_still]].
+
+## Related Files — heutige Zeilennummern (die der Analyse sind überholt)
+
+| Datei:Zeile | Relevanz | war laut Analyse |
+|---|---|---|
+| `src/services/trip_alert.py:826` | `_radar_effective_channels()` — löst **nur** aus `report_config` auf | `:826` ✓ |
+| `src/services/trip_alert.py:987` | Aufruf 1 — `effective_channels` für `append_suppressed_entry` (Unterdrückungs-Protokoll, **vor** dem Nowcast-Abruf) | `:991` |
+| `src/services/trip_alert.py:1061` | Aufruf 2 — Leer-Check, `continue` mit `logger.warning`, **ohne** Protokolleintrag | `:1059` |
+| `src/services/trip_alert.py:1109` | Aufruf 3 — Versand-Set | `:1107` |
+| `src/services/trip_alert.py:1111-1113` | **zweiter** Leer-Check — nachgemessen **toter Code** (s.u.) | `:1109` |
+| `src/services/trip_alert.py:1123-1125` | `split_by_threshold` auf derselben Variable | `:1121`/`:1130` |
+| `src/services/trip_alert.py:1493-1548` | `_effective_alert_channels()` — die Zielfunktion | `:1491-1546` |
+| `src/services/trip_alert.py:1524-1527` | vier Kanäle im scharfen Zweig | `:1518-1521` |
+| `src/services/trip_alert.py:1517`, `:1534-1542` | `active_rules`, Union über `rule.channels` | `:1515`, `:1531-1540` |
+| `src/services/trip_alert.py:1544-1547` | Tier-Gates SMS / Premium-SMS | `:1542-1545` |
+| `src/services/trip_alert.py:1550-1564` | `_briefing_channels()` — Vererbungszweig, vier Kanäle | `:1548-1562` |
+| `src/services/notification_service.py:1388,1404,1485` | `can_send_*()`-Wiederholung beim Versand | **unverändert** |
+| `src/services/notification_service.py:1499` | Premium-SMS **ohne** Vorprüfung | **unverändert** |
+| 🆕 `src/services/trip_alert.py:936-951` | **Horizont-Guard** aus #1697 AC-4 — neu, in der Analyse nicht enthalten | — |
+
+## Selbst nachgemessen (nicht aus dem Agentenbericht)
+
+**Der zweite Leer-Check (`:1111-1113`) ist toter Code.** Zwischen ihm und dem ersten (`:1061`)
+liegen ausschließlich: Cooldown-Formatierung, Label-/Kontextstrings und der Bau von
+`RadarAlertRequest`. Keine Zeile schreibt auf `trip`, `trip.report_config` oder `self._settings`;
+die Funktion ist rein. Der Docstring sagt es selbst (`:830-834`, seit #1467 S3): „Reine Ableitung
+ohne Seiteneffekt, das Ergebnis ist an beiden Stellen identisch."
+
+**Live-Konfiguration KHW 403** (`/api/_internal/trip/5f534011/loaded`):
+
+| Feld | Wert |
+|---|---|
+| `alert_channels` | `{email: true, telegram: true, sms: true}` — kein `premium_sms` |
+| `alert_channel_thresholds` | `{email: LOW, telegram: LOW, **sms: HIGH**}` |
+| `report_config` | `send_email: true, send_telegram: true, **send_sms: false**, send_premium_sms: false` |
+| `alert_rules` | 4 aktiv, **alle** mit leerer Kanalliste ⇒ erben aus `alert_channels` |
+
+## Was sich für den PO konkret ändert
+
+| Kanal | Regen-Alarm heute | nach der Umstellung |
+|---|---|---|
+| E-Mail | ✓ | ✓ |
+| Telegram | ✓ | ✓ |
+| **SMS** | ✗ (Briefing-Flag aus) | **✓ neu** — Schwelle `HIGH`, trifft nur hohe Dringlichkeit |
+| Premium-SMS | ✗ | ✗, bis der Haken im Alarme-Reiter gesetzt wird |
+
+Das ist die vom PO am 2026-08-11 ausdrücklich in Kauf genommene Verhaltensänderung.
+
+## Existing Patterns
+
+**Präzedenzfall im Ortsvergleich, bereits vollzogen:** #1461 S3b-2b hat den Compare-Radar-Pfad von
+hart `{"email"}` auf den regulären `effective_compare_channels()`-Resolver umgestellt — mit eigenen
+ACs und als **Nachtrag zu ADR-0021**, ohne neue ADR. Die Trip-Seite zieht damit nach.
+
+**Es gibt keine ADR, die „Radar folgt Briefing" festschreibt.** Die einzige Begründung ist eine
+Known-Limitation-Notiz in der archivierten #1258-Spec, die die Angleichung ausdrücklich als eigenes
+Issue ankündigt — dieses hier.
+
+## 🔴 Risiken
+
+**R1 — Die Test-Blindstelle ist real und heute erneut bestätigt.** Alle 30 Testdateien, die
+`check_radar_alerts()` aufrufen, wurden gegen alle Dateien mit `alert_rules`-Zuweisung gekreuzt:
+**keine einzige Kombination**. Auch die neuen #1701-Premium-SMS-Radartests steuern den Kanal
+ausschließlich über `report_config.send_premium_sms`. `test_alarm_zeitfenster_ziel.py:149` setzt
+zwar `alert_channels`, aber dieser Trip-Builder speist nur `check_and_send_alerts()`, nicht den
+Radar-Pfad. **Ein Funktionswechsel macht damit nichts rot — ein grüner Lauf beweist hier nichts.**
+
+**R2 — Der Horizont-Guard darf nicht überholt werden.** Neu seit #1697 (`:936-951`): Ein Segment,
+das erst >60 min in der Zukunft beginnt, führt zu `continue` **vor** allen Kanal-Aufrufen. Eine
+Umstellung auf „Kanal-Set einmal berechnen" darf die Berechnung **nicht** vor diesen Guard ziehen —
+sonst wird für zeitlich irrelevante Segmente die `alert_rules`-Union ausgewertet. Der Guard selbst
+ist rein zeitbasiert und eigens getestet, also kein blinder Wächter.
+
+**R3 — Radar erbt die `alert_rules`-Union mit.** `_effective_alert_channels` legt auf
+`alert_channels` zusätzlich die Union nicht-leerer `rule.channels`. Bei KHW folgenlos (alle vier
+Regeln leer), aber eine echte Bedeutungserweiterung, die in die ACs gehört.
+
+**R4 — Beobachtbarkeit ändert sich, Zustellung nicht.** `_dispatch_alert_message` wiederholt
+`can_send_*()` beim Versand; ein unerreichbarer Kanal wird in beiden Varianten nicht zugestellt.
+Wo heute `:1061` **ohne** Protokolleintrag abbricht, entsteht danach ein `alert_log`-Eintrag mit
+leerem `sent_channels`. Verbesserung — muss als AC formuliert werden, damit die neuen Einträge
+niemand für einen Defekt hält.
+
+## Was die Analyse übersehen hatte (Nachtrag dieser Phase)
+
+**Derselbe Fehler war in dieser Funktion schon einmal produktiv** — und wurde kurz vor der Analyse
+behoben: Bis #1701 (`c91a0844`) stand dort ein globaler Bereitschafts-Guard
+`if not can_email and not can_telegram and not can_sms: continue`, der einen Trip mit
+ausschließlich Premium-SMS verworfen hätte, **bevor** irgendein Kanal-Set aufgelöst wurde. Ersetzt
+durch die heutige kanalbasierte Prüfung. Der zugehörige Test heißt sprechend „Schritt 0: der
+Radar-Bereitschafts-Guard" (`tests/unit/test_alert_channel_premium_sms.py:298-376`).
+
+**Konsequenz für die Spec:** Nach der Umstellung muss mindestens ein Test eine Konfiguration
+prüfen, die **ausschließlich** den neuen Weg nutzt — kein Bestandskanal daneben, der einen Guard
+zufällig passierbar macht. Vgl.
+[[reference_bereitschafts_guard_bricht_ab_vor_der_kanalaufloesung]].
+
+## Offene Fragen für die Spec
+
+- [ ] Weg (b) — `_radar_effective_channels` entfällt ersatzlos, die drei Aufrufstellen nutzen
+      `_effective_alert_channels` — bleibt die Empfehlung. Zu fixieren: Kanal-Set **einmal**
+      berechnen (nach dem Horizont-Guard), zweiten Leer-Check streichen.
+- [ ] ADR: Nachtrag zu ADR-0021 (Compare-Präzedenz) statt neuer ADR.

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -86,10 +86,11 @@ Die folgenden Komponenten leben im Python-Core:
    - **Premium-SMS** (`src/output/channels/premium_sms.py`, `PremiumSmsOutput`,
      `name == "premium_sms"`, seit Issue #1676 S2a) – als **Versandkanal** weiterhin **nur
      Trip-Briefing**, kein Ortsvergleich-Versand. Als **Alarm-Kanal** seit #1701 (Backend)
-     für Gewitter-, Änderungs- und amtliche Alarme verdrahtet, in Trip **und** Ortsvergleich
-     (Regen-/Radar-Alarme lesen weiterhin ausschließlich das Briefing-Flag,
-     `_radar_effective_channels()`, `src/services/trip_alert.py:826-856` — Scheibe B/#1752,
-     noch offen). Fester Absender `4916092172595` (unabhängig von `sms_from`), Empfänger
+     für Gewitter-, Änderungs- und amtliche Alarme verdrahtet, in Trip **und** Ortsvergleich;
+     seit #1752 (Scheibe B) gilt das auch für **Regen-/Radar-Alarme** — sie lösen ihre Kanäle
+     über denselben `_effective_alert_channels()` auf wie alle anderen Alarmtypen. Die frühere
+     Sonderfassung `_radar_effective_channels()`, die ausschließlich die Briefing-Flags las, ist
+     ersatzlos entfallen. Fester Absender `4916092172595` (unabhängig von `sms_from`), Empfänger
      ausschließlich die in S1 gelernte Rückadresse aus `user.json` (nie `sms_to`), Fail-Closed
      bei fehlender oder >30 Tage alter Rückadresse mit auswertbarem Grund in
      `NotificationResult.blocked_channels`, eigenes Tier-Gate (`premium_sms_allowed()`,
@@ -224,12 +225,16 @@ setzbar, noch kein Go-Flach-Feld analog `send_sms`/`send_telegram`.
 Änderungs- und amtliche Alarme, in **beiden** Flächen (Trip UND Ortsvergleich), nicht
 nur Trip. Die zugehörige Oberfläche (Alarme-Reiter, vierte Kanalzeile + eigene
 Dringlichkeits-Schwelle) ist seit #1745 Scheibe A live, ebenfalls in beiden Flächen.
-Regen-/Radar-Alarme lesen weiterhin ausschließlich das Briefing-Flag
-(`_radar_effective_channels()`, `src/services/trip_alert.py:826-856`) — Scheibe B
-(#1752) vereinheitlicht das noch nicht. Der Versand-Pfad selbst (dieser Abschnitt) bleibt
-unverändert Trip-Briefing-only, davon unberührt. Details:
+Mit **#1752 (Scheibe B)** folgen auch **Regen-/Radar-Alarme** dem Alarm-Kanal-Satz: Die
+Sonderfassung `_radar_effective_channels()`, die ausschließlich die Briefing-Flags las, ist
+ersatzlos entfallen; das Kanal-Set wird einmal über `_effective_alert_channels()` aufgelöst
+und im ganzen Radar-Pfad geteilt (Unterdrückungs-Protokoll, Leer-Check, Versand). Damit gibt
+es **einen** Auflösungsweg für alle Alarmtypen — die zwei konkurrierenden Wege waren die
+Ursache von #1745. Der Versand-Pfad selbst (dieser Abschnitt) bleibt unverändert
+Trip-Briefing-only, davon unberührt. Details:
 `docs/specs/modules/feat_1701_alarm_premium_sms.md`,
-`docs/specs/modules/fix_1745_a_alarm_kanal_premium_sms_ui.md`.
+`docs/specs/modules/fix_1745_a_alarm_kanal_premium_sms_ui.md`,
+`docs/specs/modules/fix_1752_radar_folgt_alarm_kanaelen.md`.
 
 ### Telegram Bot-Menü (Automatisches Setup)
 

--- a/docs/specs/modules/fix_1752_radar_folgt_alarm_kanaelen.md
+++ b/docs/specs/modules/fix_1752_radar_folgt_alarm_kanaelen.md
@@ -368,7 +368,30 @@ CI-Lauf nur, dass nichts kaputtgegangen ist — nicht, dass etwas repariert wurd
 | AC-2 | Fallback bei `alert_channels is None` entfällt/bricht | `test_radar_alert_channels_fall_back_to_briefing_when_alert_channels_unset` |
 | AC-3 | Kanal-Schwelle (`split_by_threshold`) wird auf die alte, nicht-geteilte Variable angewendet | `test_radar_alert_below_threshold_channel_uses_shared_channel_set` |
 | AC-4 | Unterdrückungs-Protokoll (`:987`) bleibt bei der alten Auflösung, nur der Versand wird umgestellt | `test_radar_alert_suppressed_entry_matches_dispatch_channel_set` |
-| AC-5 | Der verbliebene erste Leer-Check (`:1061`) wird beim Entfernen des zweiten (`:1111-1113`) auf eine falsche Variable umgehängt | `test_radar_alert_stays_silent_when_all_trip_channels_off` |
+| AC-5 | Der verbliebene erste Leer-Check wird beim Entfernen des zweiten auf eine falsche Variable umgehängt | 🔴 **nicht** `…stays_silent_when_all_trip_channels_off`, sondern `test_radar_alert_logs_configured_but_unreachable_channel` (AC-6) — s. Nachtrag unten |
+| — | **Neu, Fix-Loop 1:** die Kanal-Auflösung wirft für einen Trip (beschädigte `alert_channels` aus der Persistenz) | `test_broken_channel_resolution_of_one_trip_does_not_stop_the_batch` |
+
+🔴 **Nachtrag zu AC-5, im Adversary-Lauf gefunden und im Fix-Loop nachgemessen (2026-08-12).**
+Die obige Zuordnung war **falsch**: Die Mutation wird gefangen, aber **nicht von AC-5** —
+`test_radar_alert_stays_silent_when_all_trip_channels_off` bleibt dabei grün. Grund: drei
+tiefer liegende Sicherungen halten das Verhalten unabhängig vom Leer-Check korrekt —
+`alert_log.append_entry()` verweigert bei leerem Kanal-Set jeden Eintrag
+(`alert_log.py:203-205`), die Sperrzeit wird erst nach `if not delivered: continue` gebucht
+(`trip_alert.py:1139-1142`), und `_dispatch_alert_message()` betritt einen Kanal-Zweig nur bei
+`"<kanal>" in effective_channels`. Gefangen wird die Mutation von **AC-6**, dessen Trip einen
+leeren Briefing-Satz hat und unter der Mutation stumm bliebe.
+
+**Was daraus folgt:** Das System ist an dieser Stelle korrekt und mehrfach abgesichert — die
+*Zusicherung der Spec* über die Abdeckung war es nicht. Ein AC, dessen benannte Mutation von
+einem anderen AC gefangen wird, bewacht seine eigene Codestelle nicht. AC-5 bleibt als
+Verhaltens-Zusicherung sinnvoll (ein stumm geschalteter Trip erzeugt kein Rauschen), taugt aber
+nicht als Nachweis für den Leer-Check. **Merksatz: „ein Test wird rot" ist erst dann ein
+Nachweis, wenn es der Test ist, dem man es zuschreibt.**
+
+**Bewusste Grenze:** Eine andere Lesart derselben Mutation — der Leer-Check ruft
+`_effective_alert_channels(trip)` ein zweites Mal frisch auf — bliebe von **allem** unentdeckt.
+Das ist kein Defekt: die Auflösung ist rein, `trip` ändert sich dazwischen nicht (Begründung
+steht im Code). Es ist aber auch nicht bewacht.
 | AC-6 | Die neue Auflösung prüft weiterhin selbst `can_send_*()`-Erreichbarkeit statt das dem Versand zu überlassen | `test_radar_alert_logs_configured_but_unreachable_channel` |
 | AC-7 | Die Auflösungsstelle nutzt eine eigene Fassung ohne `alert_rules`-Union statt `_effective_alert_channels()` unverändert | `test_radar_alert_channels_follow_active_alert_rule_override` |
 

--- a/docs/specs/modules/fix_1752_radar_folgt_alarm_kanaelen.md
+++ b/docs/specs/modules/fix_1752_radar_folgt_alarm_kanaelen.md
@@ -169,6 +169,15 @@ Code-Referenz (s. Known Limitations).
   als Standard-Settings für alle Kanal-Auflösungs-Tests — kein Kanal ist je zufällig
   "mit-erreichbar".
 
+  🔴 **Ausnahme AC-5, in der RED-Phase gemessen und korrigiert (2026-08-12).** Mit
+  `settings_no_channel_reachable()` liefert auch die **alte** Ableitung ein leeres Set, der Trip
+  bliebe still, und AC-5 wäre **strukturell grün, ohne irgendetwas zu bewachen** — per Sonde
+  nachgewiesen (1 passed vor jeder Änderung). AC-5 läuft deshalb mit `settings_email_only()`:
+  erst wenn das Briefing technisch erreichbar ist, wird der geprüfte Widerspruch „Briefing an,
+  Alarme-Reiter komplett aus" überhaupt sichtbar. Das deckt sich mit dem Given der AC („das
+  Trip-Briefing ist davon unberührt"); die Pflichtnennung oben gilt ausdrücklich nur AC-1/AC-6.
+  **Merksatz: ein Test, der nicht rot werden KANN, ist kein Nachweis.**
+
 ## Entscheidungen (D1–D6)
 
 - **D1 — Ein Auflösungsweg.** Radar folgt `trip.alert_channels` wie alle anderen Alarmtypen;
@@ -188,6 +197,27 @@ Code-Referenz (s. Known Limitations).
 - **D4 — Radar erbt die `alert_rules`-Union mit.** Das ist eine echte Bedeutungserweiterung
   über „Quelle wechseln" hinaus (AC-7) — jede Alternative (eigene Fassung ohne Regel-Teil)
   wäre die zweite, leicht abweichende Kopie, die diese Scheibe beseitigt.
+
+  🔴 **Präzisierung, in der RED-Phase aufgefallen und am Code nachgemessen
+  (`trip_alert.py:1534-1542`, 2026-08-12).** Die Regel-Kanäle **ergänzen** den Alarme-Reiter
+  nicht, sie **ersetzen** ihn je Regel:
+
+  ```
+  ohne aktive Regeln          → Alarme-Reiter (bzw. Briefing-Fallback)
+  mit aktiven Regeln          → Union ÜBER DIE REGELN, je Regel:
+        Regel hat eigene Kanäle  → diese
+        Regel hat keine          → Alarme-Reiter
+  ```
+
+  Folge: Der Alarme-Reiter-Anteil fällt **nur dann vollständig weg, wenn ALLE aktiven Regeln
+  eigene Kanäle tragen**. Hat auch nur eine Regel keine, bleibt er über diese erhalten. Der
+  RED-Bericht formulierte das zu grob („bei mindestens einer Regel mit Kanälen wird der geerbte
+  Anteil komplett verworfen") — das gilt nur bei genau einer aktiven Regel, wie im Test-Aufbau.
+  **Wer „Union aus Alarme-Reiter + Regel" liest, baut etwas anderes.**
+
+  Für den KHW-Trip folgenlos: vier aktive Regeln, **alle** mit leerer Kanalliste ⇒ Ergebnis ist
+  exakt der Alarme-Reiter. Die Semantik ist vorbestehend (#638) und wird hier **nicht** geändert
+  — Radar übernimmt sie nur mit.
 - **D5 — Zustellung ändert sich nicht, Beobachtbarkeit schon.** `_dispatch_alert_message`
   wiederholt `can_send_*()` (`notification_service.py:1388,1404,1485`), Premium-SMS bewusst
   ohne Vorprüfung (`:1499`). Wo heute `:1061` **ohne** Protokolleintrag abbricht (weil die alte

--- a/docs/specs/modules/fix_1752_radar_folgt_alarm_kanaelen.md
+++ b/docs/specs/modules/fix_1752_radar_folgt_alarm_kanaelen.md
@@ -1,0 +1,375 @@
+---
+entity_id: fix_1752_radar_folgt_alarm_kanaelen
+type: module
+created: 2026-08-12
+updated: 2026-08-12
+status: draft
+version: "1.0"
+tags: [radar, nowcast, alarm, channel, trip, alert_rules]
+---
+
+<!-- Issue #1752 -- Scheibe B zu #1745 (Scheibe A: Premium-SMS in der
+     Alarm-Kanal-Auswahl, live seit c28f794b). Kontext-Grundlage:
+     docs/context/fix-1752-radar-folgt-alarm-kanaelen.md (Phase 1+2
+     zusammengefuehrt, Basis-Commit bc7dc418). Formatvorbild:
+     docs/specs/modules/fix_1745_a_alarm_kanal_premium_sms_ui.md. -->
+
+# Radar-/Regen-Alarme folgen dem Alarm-Kanal-Satz (Scheibe B zu #1745)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Regen-/Radar-Alarme lösen ihre Kanäle heute **ausschließlich** aus dem Trip-Briefing
+(`trip.report_config`) auf und lesen `trip.alert_channels`/`trip.alert_rules` nie. Wer im
+Alarme-Reiter Kanäle abweichend vom Briefing einstellt oder eine Alarm-Regel mit eigenem
+Kanal anlegt, ändert damit für Regen-Alarme **nichts** — das betrifft alle vier Kanäle, nicht
+nur Premium-SMS. Diese Scheibe stellt Regen-Alarme auf denselben Auflösungsweg um, den
+Gewitter-, Änderungs- und amtliche Alarme bereits nutzen (`_effective_alert_channels()`), und
+schließt damit die letzte abweichende Stelle im Trip-Alarmsystem.
+
+## Bewusst nicht in dieser Scheibe
+
+- **Der Ortsvergleich.** Der Compare-Radar-Pfad wurde bereits mit #1461 S3b-2b auf den
+  regulären Compare-Kanal-Resolver (`effective_compare_channels()`) umgestellt — siehe
+  ADR-0021, Nachtrag 2026-08-06. Diese Scheibe zieht ausschließlich den Trip-Pfad nach.
+- **Die Oberfläche.** Der Alarme-Reiter kennt Premium-SMS bereits seit #1745 Scheibe A
+  (`c28f794b`, live). Diese Scheibe ändert kein Frontend — sie sorgt nur dafür, dass ein dort
+  gesetzter Haken auch für Regen-Alarme wirkt, nicht nur für Gewitter-/Änderungs-/amtliche
+  Alarme.
+- **Der Horizont-Guard selbst und die Segmentwahl** (`trip_alert.py:908-951`, Issue #1697/#822/
+  #1667 S3). Bleiben unverändert; die Kanalberechnung wird lediglich **hinter** den Guard
+  gehängt (D3), nicht in ihn eingegriffen.
+- **Ein Wrapper, der die bisherige `can_send_*()`-Vorfilterung erhält.** Ausdrücklich
+  verworfen: er würde die Duplikat-Falle nur verschieben, nicht schließen — genau der Zustand,
+  der diesen Bug erzeugt hat (zwei leicht unterschiedliche Kanal-Ableitungen für denselben
+  Trip).
+
+## Source
+
+- **File:** `src/services/trip_alert.py`
+- **Identifier:** `class TripAlertService`, Methode `check_radar_alerts()` (Aufrufer),
+  Methode `_radar_effective_channels()` (entfällt), Methode `_effective_alert_channels()`
+  (Zielfunktion, unverändert)
+
+Betroffene Stellen (Zeilen gemessen gegen Basis-Commit `bc7dc418`):
+
+| Zeile(n) | Heute | Nach dieser Scheibe |
+|---|---|---|
+| `trip_alert.py:826-856` | `_radar_effective_channels()` — löst **nur** aus `report_config` auf | entfällt ersatzlos |
+| `trip_alert.py:936-951` | Horizont-Guard (#1697 AC-4) | unverändert, bleibt VOR der Kanalberechnung |
+| `trip_alert.py:953` (neu davor) | — | neue lokale Variable `effective_channels = self._effective_alert_channels(trip)` |
+| `trip_alert.py:987` | `effective_channels=self._radar_effective_channels(trip)` im Unterdrückungs-Protokoll | `effective_channels=effective_channels` (geteilte Variable) |
+| `trip_alert.py:1061` | `if not self._radar_effective_channels(trip):` | `if not effective_channels:` |
+| `trip_alert.py:1109` | `effective_channels = self._radar_effective_channels(trip)` | Zeile entfällt (Wert bereits vorhanden) |
+| `trip_alert.py:1111-1113` | zweiter Leer-Check (nachgemessen toter Code, s. Kontextdokument) | entfällt |
+| `trip_alert.py:1123-1125` | `split_by_threshold(effective_channels, ...)` | unverändert — liest jetzt die geteilte Variable statt des dritten `_radar_effective_channels()`-Aufrufs |
+
+## Estimated Scope
+
+- **LoC (Produktivcode):** ≈ -35 netto in `trip_alert.py` (eine ~31-zeilige Methode entfällt
+  vollständig, eine Zuweisung wandert an eine neue Stelle, zwei Aufrufstellen werden auf die
+  geteilte Variable umgehängt, ein toter Leer-Check entfällt — die Datei schrumpft).
+- **LoC (Tests):** ≈ 280 NEU (eine neue Testdatei, sieben Tests + Testaufbau; **keine**
+  bestehende Testdatei wird verändert — R1 im Kontextdokument bestätigt, dass keine der 30
+  Testdateien, die `check_radar_alerts()` aufrufen, `alert_channels`/`alert_rules` setzt).
+- **Files:** 1 MODIFY (`src/services/trip_alert.py`) + 1 CREATE
+  (`tests/unit/test_radar_alert_channel_resolution.py`).
+- **Effort:** low-medium. Die Produktivcode-Änderung ist reine Konsolidierung (die
+  Zielfunktion `_effective_alert_channels()` existiert bereits und wird nicht verändert) — der
+  eigentliche Aufwand liegt in der Testabdeckung der bislang komplett unbelegten Kombination
+  „Radar + `alert_channels`/`alert_rules`" (R1).
+- **LoC-Limit-Hinweis:** Produktiv- und Testzeilen zusammen dürften das Default-Limit
+  250/Workflow überschreiten (Tests allein ≈ 280 Zeilen) — `loc_limit_override` bei
+  Implementierungsbeginn wahrscheinlich nötig, endgültige Zahl erst nach der TDD-RED-Phase
+  sicher.
+- **Risiko:** LOW für die Produktivänderung selbst (reines Umhängen auf eine bereits geprüfte
+  Funktion). MEDIUM für die Testarbeit — die Blindstelle R1 bedeutet, dass ein grüner
+  Bestandslauf nichts beweist (s. „Warum ein grüner Testlauf hier nichts beweist" unten).
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `docs/specs/modules/feat_1701_alarm_premium_sms.md` | Vorgänger-Spec, live | `_effective_alert_channels()` ist bereits die Zielfunktion für Gewitter-/Änderungs-/amtliche Alarme — wird hier NICHT verändert, nur an eine vierte Stelle angeschlossen |
+| `docs/specs/modules/fix_1745_a_alarm_kanal_premium_sms_ui.md` | Vorgänger-Scheibe (Scheibe A), live seit `c28f794b` | Oberfläche schreibt bereits `alert_channels`/`alert_rules[].channels` inkl. `premium_sms` — diese Scheibe schließt den Radar-Pfad an denselben Datenbestand an |
+| `docs/adr/0021-shared-deviation-alert-engine.md` | ADR (Nachtrag, keine neue) | Compare-Radar-Präzedenz (#1461 S3b-2b, Nachtrag 2026-08-06) — dieselbe Umstellung, andere Fläche |
+| `docs/adr/0046-alarm-kanal-schwelle.md` | ADR | Schwellenpflicht — bleibt erfüllt, `split_by_threshold` sitzt unverändert auf der (jetzt geteilten) Variable |
+| `tests/helpers/nowcast_gate_fixtures.py::make_trip/settings_no_channel_reachable/read_log/entries_for/write_user_tier` | Test-Baustein, ungeändert wiederverwendet | Trip-Skelett + Log-Lesehelfer für alle sieben neuen Tests |
+| `tests/unit/test_alert_channel_premium_sms.py` | Muster (nicht importiert) | Vorbild für den „ausschließlich neuer Weg"-Testaufbau (Schritt-0-Guard-Lehre, s.u.) |
+| `src/services/alert_log.py::append_entry/_channels_not_sent` | module, gelesen, nicht verändert | liefert die beobachtbare Kanal-Klassifikation (`channel_disabled`/`delivery_failed`/`below_channel_threshold`), auf der alle sieben ACs aufsetzen |
+
+## Implementation Details
+
+### Diff-Plan (eine Datei, `src/services/trip_alert.py`)
+
+1. `_radar_effective_channels()` (`:826-856`) vollständig löschen.
+2. In `check_radar_alerts()` unmittelbar **nach** dem Horizont-Guard (`:936-951`, D3) und
+   **vor** dem `check_nowcast_gate(...)`-Aufruf (`:963-973`) eine lokale Variable einführen:
+   `effective_channels = self._effective_alert_channels(trip)`.
+3. `:987` (Unterdrückungs-Protokoll): `effective_channels=self._radar_effective_channels(trip)`
+   → `effective_channels=effective_channels`.
+4. `:1061` (erster Leer-Check, bleibt bestehen — nur die zweite Stelle ist tot):
+   `if not self._radar_effective_channels(trip):` → `if not effective_channels:`.
+5. `:1109`: die Zeile `effective_channels = self._radar_effective_channels(trip)` entfällt
+   ersatzlos (Wert liegt bereits aus Schritt 2 vor).
+6. `:1111-1113` (zweiter Leer-Check): entfällt ersatzlos — nachgemessen toter Code (reine
+   Funktion, `trip` bleibt zwischen den beiden Checks unverändert, Docstring sagt es selbst).
+7. `:1123-1125` (`split_by_threshold`) bleibt strukturell unverändert — liest jetzt dieselbe,
+   einmalig berechnete Variable statt eines dritten Funktionsaufrufs.
+
+Kein zweiter Aufrufort in der Codebasis ruft `_radar_effective_channels()` auf (per Grep
+bestätigt); die Löschung ist folgenlos für andere Module. Ein Docstring-Verweis in
+`docs/features/architecture.md` erwähnt die Methode namentlich — das ist eine Doku-, keine
+Code-Referenz (s. Known Limitations).
+
+### Testaufbau (Muster für alle sieben neuen Tests)
+
+- Trip-Skelett über `tests.helpers.nowcast_gate_fixtures.make_trip()` — die Etappe deckt
+  bereits den ganzen Tag ab (00:00–23:59 an `TRIP_LAT`/`TRIP_LON`, UTC±0), der Horizont-Guard
+  greift daher nicht. `alert_channels`/`alert_channel_thresholds`/`alert_rules` werden auf dem
+  zurückgegebenen `Trip`-Objekt **direkt gesetzt** — `make_trip()` selbst braucht dafür KEINE
+  Erweiterung (nachgemessen: `Trip.alert_channels` ist ein normales, nach Konstruktion
+  beschreibbares Feld, `tests/unit/test_alert_channel_premium_sms.py::_base_trip` nutzt exakt
+  dasselbe Muster).
+- Der Trip wird **nicht** über `save_trip()`/Disk-Rundlauf eingespeist — `save_trip()`
+  serialisiert `alert_channels`/`alert_rules`/`alert_channel_thresholds` nicht (nachgemessen,
+  `nowcast_gate_fixtures.py:405-434`). Stattdessen: `monkeypatch.setattr(app.loader,
+  "load_all_trips", lambda **kw: [trip])` — dasselbe Muster wie
+  `test_alert_channel_premium_sms.py`.
+- **Kanal-Erreichbarkeit wird bewusst NICHT über echte Transport-Stubs geprüft**, sondern über
+  die im Alarm-Protokoll persistierte Kanal-Klassifikation (`channels_not_sent`, s.
+  `alert_log.py:113-137`): jeder der vier Kanäle bekommt dort **immer** einen Eintrag mit
+  Grund `channel_disabled` (nicht im rohen Opt-in enthalten), `delivery_failed` (im Opt-in,
+  aber technisch nicht zugestellt) oder `below_channel_threshold` (im Opt-in, aber unter der
+  Dringlichkeits-Schwelle). Diese Dreiteilung erlaubt, „wurde der Kanal korrekt AUFGELÖST"
+  von „wurde er tatsächlich ZUGESTELLT" zu trennen, ohne Stub-Server — genau die Trennung, die
+  die sieben ACs brauchen. `settings_no_channel_reachable()` macht dabei bewusst **gar keinen**
+  Kanal technisch erreichbar: ob überhaupt ein Protokoll-Eintrag entsteht, hängt dadurch
+  ausschließlich von der Kanal-**Auflösung**, nie von einem zufällig passierbaren
+  Erreichbarkeits-Nebenpfad ab (Lehre aus „Schritt 0" unten).
+- **`write_user_tier(uid, "standard")` ist Pflicht** vor jedem Testlauf, der den Kanal `sms`
+  im Ergebnis erwartet — `sms_allowed()` liefert `False`, solange kein `user.json` existiert
+  (`user_tier.py:9-20`); ohne diesen Schritt filtert das SMS-Tier-Gate den Kanal am Ende von
+  `_effective_alert_channels()` still wieder heraus, unabhängig vom Testergebnis, das eigentlich
+  geprüft werden soll.
+- **`reset_radar_cache()` zwischen Tests**, sofern mehrere Tests dieselbe Koordinate
+  (`TRIP_LAT`/`TRIP_LON`) verwenden — der Frame-Cache ist ein Prozess-Singleton mit 300s TTL
+  (Vorbild `test_nowcast_suppression_logging.py`).
+- **Lehre aus „Schritt 0"** (`test_alert_channel_premium_sms.py:298-376`, s. auch Kontextdokument
+  „Was die Analyse übersehen hatte"): mindestens ein Test dieser Spec (AC-1, AC-6) darf sich
+  NICHT auf einen zufällig ebenfalls konfigurierten, technisch erreichbaren Zweitkanal
+  verlassen, der einen vorgelagerten Guard passierbar macht. Deshalb `settings_no_channel_reachable()`
+  als Standard-Settings für alle Kanal-Auflösungs-Tests — kein Kanal ist je zufällig
+  "mit-erreichbar".
+
+## Entscheidungen (D1–D6)
+
+- **D1 — Ein Auflösungsweg.** Radar folgt `trip.alert_channels` wie alle anderen Alarmtypen;
+  Fallback auf die Briefing-Kanäle (`_briefing_channels(report_config)`) nur, wenn
+  `alert_channels` **nie gesetzt** wurde (`None`). Kein Einfrieren des Ist-Zustands, keine
+  Migration — Bestandstrips ohne je gespeicherte Alarme-Reiter-Auswahl verhalten sich
+  unverändert (AC-2).
+- **D2 — Kanal-Set einmal berechnen.** Eine lokale Variable, **nach** dem Horizont-Guard
+  (`:936-951`), wiederverwendet an allen drei bisherigen Aufrufstellen. Der zweite Leer-Check
+  (`:1111-1113`) entfällt — nachgemessen toter Code (reine Funktion ohne Seiteneffekt zwischen
+  beiden Checks, Docstring bestätigt es selbst).
+- **D3 — Der Horizont-Guard bleibt vorgelagert.** Die Kanalberechnung darf **nicht** vor
+  `:936-951` gezogen werden, sonst wird für zeitlich irrelevante Segmente die
+  `alert_rules`-Union unnötig ausgewertet. Kein eigener Test in dieser Spec (s. Known
+  Limitations) — Absicherung ist Code-Review, das Endergebnis für ein zeitlich aktives Segment
+  wäre bei vertauschter Reihenfolge identisch.
+- **D4 — Radar erbt die `alert_rules`-Union mit.** Das ist eine echte Bedeutungserweiterung
+  über „Quelle wechseln" hinaus (AC-7) — jede Alternative (eigene Fassung ohne Regel-Teil)
+  wäre die zweite, leicht abweichende Kopie, die diese Scheibe beseitigt.
+- **D5 — Zustellung ändert sich nicht, Beobachtbarkeit schon.** `_dispatch_alert_message`
+  wiederholt `can_send_*()` (`notification_service.py:1388,1404,1485`), Premium-SMS bewusst
+  ohne Vorprüfung (`:1499`). Wo heute `:1061` **ohne** Protokolleintrag abbricht (weil die alte
+  Funktion Erreichbarkeit bereits Teil der Auflösung macht), entsteht nach dieser Scheibe ein
+  `alert_log`-Eintrag mit leerem `sent_channels` (AC-6) — eine gewollte
+  Nachvollziehbarkeits-Verbesserung, kein neuer Defekt.
+- **D6 — Kein neues ADR.** Nachtrag zu ADR-0021; Präzedenz ist #1461 S3b-2b, wo dieselbe
+  Umstellung im Ortsvergleich bereits ohne neue ADR vollzogen wurde. ADR-0046
+  (Schwellenpflicht) bleibt erfüllt: `split_by_threshold` sitzt unverändert bei `:1123-1125`
+  auf derselben (jetzt geteilten) Variable.
+
+## Expected Behavior
+
+- **Input:** Ein Nutzer hat im Alarme-Reiter eines Trips eine Kanal-Auswahl und/oder
+  Dringlichkeits-Schwellen gesetzt, die vom Trip-Briefing abweichen — oder eine Alarm-Regel mit
+  eigenem Kanal angelegt. Ein Regenradar-Alarm wird für diesen Trip ausgelöst
+  (`check_radar_alerts()`, Scheduler-getrieben).
+- **Output:** Der Regen-Alarm berücksichtigt dieselbe Kanal-Auswahl, die auch Gewitter-,
+  Änderungs- und amtliche Alarme berücksichtigen — inklusive der Dringlichkeits-Schwelle je
+  Kanal und der Kanal-Overrides einzelner Alarm-Regeln. Hat der Nutzer den Alarme-Reiter nie
+  angefasst, verhält sich der Regen-Alarm unverändert wie bisher (Briefing-Fallback, D1).
+- **Side effects:** Das Alarm-Protokoll (`alert_log.json`) enthält für Regen-Alarme ab jetzt
+  auch Einträge für Kanäle, die im Alarme-Reiter aktiv, aber technisch (noch) nicht erreichbar
+  sind (D5) — vorher brach der Lauf an dieser Stelle spurlos ab. Kein Feld-Schema-Wechsel, keine
+  Migration, keine Änderung am Ortsvergleich oder an der Oberfläche.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Nutzer hat im Alarme-Reiter eines Trips die Kanäle abweichend vom
+  Trip-Briefing eingestellt — Telegram ist im Briefing aktiv, im Alarme-Reiter aber bewusst
+  ausgeschaltet, dafür SMS im Alarme-Reiter angeschaltet / When ein Regen-Alarm für diesen Trip
+  ausgelöst wird / Then richtet sich der Regen-Alarm nach der Alarme-Reiter-Einstellung — er
+  berücksichtigt SMS, nicht Telegram — genau wie Gewitter-, Änderungs- und amtliche Alarme das
+  bereits heute tun.
+  - Prüfort: das persistierte Alarm-Protokoll (`alert_log.json`) — konkret die
+    Kanal-Aufschlüsselung des Eintrags (`channels_not_sent`), nicht nur der Rückgabewert einer
+    internen Funktion. Settings ohne jeden erreichbaren Kanal (`settings_no_channel_reachable()`),
+    damit kein zufällig erreichbarer Zweitkanal die Aussage verwässert.
+  - Test: `tests/unit/test_radar_alert_channel_resolution.py::test_radar_alert_channels_override_report_config_when_alert_channels_set` (neu)
+  - Mutation: Radar liest weiterhin (auch nur teilweise) `report_config` statt ausschließlich
+    der aus `alert_channels` abgeleiteten Menge — Telegram erschiene dann mit Grund
+    `delivery_failed` (= "war konfiguriert") statt `channel_disabled` (= "war ausgeschaltet").
+
+- **AC-2:** Given ein Bestandstrip hat im Alarme-Reiter NIE eine eigene Kanal-Auswahl
+  gespeichert (`alert_channels` ist technisch ungesetzt) und im Trip-Briefing ist Telegram
+  aktiv / When ein Regen-Alarm ausgelöst wird / Then verhält sich der Regen-Alarm wie bisher —
+  er übernimmt die Briefing-Kanäle als Ersatzwert, für diesen Bestandstrip ändert sich nichts.
+  - Prüfort: Alarm-Protokoll, Kanal-Aufschlüsselung — Gegenprobe zu AC-1 (Fallback statt
+    Override).
+  - Test: `tests/unit/test_radar_alert_channel_resolution.py::test_radar_alert_channels_fall_back_to_briefing_when_alert_channels_unset` (neu)
+  - Mutation: der Fallback bei `alert_channels is None` bricht (z.B. weil der neue Code
+    fälschlich ein leeres Dict statt der echten Fallback-Kette annimmt) — Telegram erschiene
+    trotz aktivem Briefing-Flag als `channel_disabled`.
+
+- **AC-3:** Given ein Nutzer hat im Alarme-Reiter für SMS eine hohe Dringlichkeits-Schwelle
+  eingestellt (nur "hoch" soll durchkommen) und SMS als Regen-Alarm-Kanal aktiviert / When ein
+  Regen-Alarm mit NIEDRIGER Dringlichkeit (leichter, nicht-konvektiver Regen) ausgelöst wird /
+  Then wird SMS nicht tatsächlich angesteuert — im Protokoll erscheint SMS als "unter der
+  eingestellten Schwelle", nicht als "ausgeschaltet" oder "technisch fehlgeschlagen": ein
+  Nutzer, der SMS bewusst nur für dringende Fälle reserviert hat, bekommt bei geringer
+  Dringlichkeit korrekt keine SMS — die Schwelle wirkt weiterhin, auch nach der Umstellung.
+  - Prüfort: `channels_not_sent`-Grund des SMS-Eintrags im Alarm-Protokoll
+    (`REASON_BELOW_THRESHOLD`).
+  - Test: `tests/unit/test_radar_alert_channel_resolution.py::test_radar_alert_below_threshold_channel_uses_shared_channel_set` (neu)
+  - Mutation: die Dringlichkeits-Schwelle wird weiterhin auf dem alten,
+    Briefing-basierten Kanal-Set angewendet statt auf die aus dem Alarme-Reiter aufgelöste
+    Menge — SMS taucht dann gar nicht als "aktiv, aber unter Schwelle" auf, sondern als
+    `channel_disabled` (die Schwellen-Prüfung läuft ins Leere, weil SMS dort nie ankommt).
+
+- **AC-4:** Given ein Regen-Alarm wird durch die Ruhezeit blockiert, BEVOR überhaupt ein
+  Wetterabruf stattfindet, und ein Kanal ist ausschließlich über den Alarme-Reiter (nicht über
+  das Briefing) aktiviert / When diese Unterdrückung protokolliert wird / Then zeigt der
+  Unterdrückungs-Eintrag denselben Kanal, den ein tatsächlicher Versand angesteuert hätte — das
+  Unterdrückungs-Protokoll und der eigentliche Versand dürfen nicht auf unterschiedlichen
+  Kanal-Listen beruhen.
+  - Prüfort: `not_delivered`-Eintrag mit `reason="nowcast"` und Gate-Grund "Ruhezeit" im
+    Alarm-Protokoll — die Stelle VOR dem eigentlichen Versand (`:987`), nicht der Versand
+    selbst.
+  - Test: `tests/unit/test_radar_alert_channel_resolution.py::test_radar_alert_suppressed_entry_matches_dispatch_channel_set` (neu)
+  - Mutation: nur die Versand-Stelle (`:1061`/`:1109`) wird auf die geteilte Variable
+    umgestellt, die Unterdrückungs-Protokollierung (`:987`) bleibt bei der alten (entfernten
+    oder erneut kopierten) Auflösung — bei blockierter Ruhezeit entsteht dann entweder gar kein
+    Eintrag oder ein Eintrag mit einem anderen Kanal als dem, den der Versand angesteuert
+    hätte.
+
+- **AC-5:** Given ein Nutzer hat im Alarme-Reiter ALLE vier Kanäle für Alarme ausgeschaltet,
+  das Trip-Briefing ist davon unberührt / When ein Regen-Alarm ausgelöst würde / Then bleibt
+  der Trip vollständig still — kein Protokoll-Eintrag, keine Sperrzeit wird in Gang gesetzt;
+  ein bewusst stummgeschalteter Trip erzeugt kein Rauschen im Archiv.
+  - Prüfort: Alarm-Protokoll (kein Eintrag für diese Trip-Kennung, weder `entries` noch
+    `not_delivered`) UND die Sperrzeit-Ablage (`throttle_state.json`, Scope `radar`) — beide
+    müssen unverändert bleiben.
+  - Test: `tests/unit/test_radar_alert_channel_resolution.py::test_radar_alert_stays_silent_when_all_trip_channels_off` (neu)
+  - Mutation: der jetzt entfernte, zweite Leer-Check (`:1111-1113`) wird gestrichen, dabei aber
+    versehentlich der verbliebene erste Leer-Check (`:1061`) auf eine andere (nicht-geteilte)
+    Variable umgehängt — trotz vollständig ausgeschalteter Kanäle entstünde dann ein Eintrag
+    und/oder ein Sperrzeit-Eintrag.
+
+- **AC-6:** Given ein Nutzer hat im Alarme-Reiter einen Kanal für Regen-Alarme aktiviert, der
+  gerade technisch nicht erreichbar ist (z.B. kein Telegram-Bot hinterlegt) / When ein
+  Regen-Alarm ausgelöst wird / Then hinterlässt der Versuch einen nachvollziehbaren
+  Protokoll-Eintrag ("Kanal war aktiv, aber technisch nicht erreichbar") statt spurlos zu
+  verschwinden wie bisher — eine gewollte Verbesserung der Nachvollziehbarkeit (D5), kein neuer
+  Fehler.
+  - Prüfort: `not_delivered`-Eintrag mit Kanal-Grund `delivery_failed` statt `channel_disabled`
+    im Alarm-Protokoll. Settings ohne jeden erreichbaren Kanal
+    (`settings_no_channel_reachable()`) — derselbe "Schritt 0"-Aufbau wie bei AC-1, hier aber
+    als Nachweis, dass die neue Auflösung NICHT mehr selbst nach Erreichbarkeit filtert.
+  - Test: `tests/unit/test_radar_alert_channel_resolution.py::test_radar_alert_logs_configured_but_unreachable_channel` (neu)
+  - Mutation: die Kanal-Auflösung prüft weiterhin (wie die alte, entfernte Funktion) selbst die
+    technische Erreichbarkeit als Teil der Auflösung, statt das dem Versand zu überlassen — der
+    Kanal gälte dann schon an der Auflösungsstelle als "aus", der erste Leer-Check (`:1061`)
+    bräche wieder wortlos ab, kein Eintrag entstünde.
+
+- **AC-7:** Given ein Trip hat eine aktive Alarm-Regel mit einem eigenen, vom
+  Standard-Kanalsatz abweichenden Kanal (z.B. nur SMS für genau diese Regel), während der
+  Alarme-Reiter selbst einen anderen Kanal (E-Mail) eingeschaltet hat / When ein Regen-Alarm
+  ausgelöst wird / Then berücksichtigt der Regen-Alarm den Kanal der Regel — genau wie
+  Gewitter-, Änderungs- und amtliche Alarme das bereits tun; Regen-Alarme sind keine Ausnahme
+  von den Alarm-Regeln mehr.
+  - Prüfort: Kanal-Aufschlüsselung im Alarm-Protokoll — der Standard-Kanal (E-Mail) trägt
+    `channel_disabled`, der Regel-Kanal (SMS) trägt `delivery_failed`.
+  - Test: `tests/unit/test_radar_alert_channel_resolution.py::test_radar_alert_channels_follow_active_alert_rule_override` (neu)
+  - Mutation: die neue Auflösungsstelle ruft eine eigene, abgespeckte Fassung ohne den
+    Regel-Union-Teil auf, statt `_effective_alert_channels()` unverändert zu verwenden — der
+    Regel-Kanal bliebe unberücksichtigt, stattdessen gälte weiterhin nur `alert_channels`
+    (E-Mail).
+
+## Warum ein grüner Testlauf hier nichts beweist
+
+Alle 30 Bestands-Testdateien, die `check_radar_alerts()` aufrufen, wurden gegen alle Dateien mit
+`alert_rules`-Zuweisung gekreuzt (Kontextdokument, R1): **keine einzige Kombination**. Jede
+bestehende Radar-Vorlage steuert ihre Kanäle ausschließlich über `report_config` — genau der
+Fall, in dem alte und neue Auflösungsfunktion identisch antworten. Ein Funktionswechsel allein
+macht deshalb keinen einzigen Bestandstest rot; der komplette Bestand bliebe grün, selbst wenn
+die Umstellung nie stattgefunden hätte (Regression: ersatzloses Streichen der Änderung).
+
+Diese Spec ist deshalb bewusst so aufgebaut, dass **ausschließlich** die sieben neuen Tests
+die eigentliche Zusicherung tragen — sie sind der einzige Ort, an dem "Radar folgt
+`alert_channels`/`alert_rules`" beobachtbar geprüft wird. Ohne sie bewiese ein grüner
+CI-Lauf nur, dass nichts kaputtgegangen ist — nicht, dass etwas repariert wurde.
+
+## Mutations-Gegenprobe
+
+| AC | Gezielte Verfälschung | Test, der dadurch rot werden MUSS |
+|---|---|---|
+| AC-1 | Radar liest (teilweise) weiterhin `report_config` statt ausschließlich `alert_channels` | `test_radar_alert_channels_override_report_config_when_alert_channels_set` |
+| AC-2 | Fallback bei `alert_channels is None` entfällt/bricht | `test_radar_alert_channels_fall_back_to_briefing_when_alert_channels_unset` |
+| AC-3 | Kanal-Schwelle (`split_by_threshold`) wird auf die alte, nicht-geteilte Variable angewendet | `test_radar_alert_below_threshold_channel_uses_shared_channel_set` |
+| AC-4 | Unterdrückungs-Protokoll (`:987`) bleibt bei der alten Auflösung, nur der Versand wird umgestellt | `test_radar_alert_suppressed_entry_matches_dispatch_channel_set` |
+| AC-5 | Der verbliebene erste Leer-Check (`:1061`) wird beim Entfernen des zweiten (`:1111-1113`) auf eine falsche Variable umgehängt | `test_radar_alert_stays_silent_when_all_trip_channels_off` |
+| AC-6 | Die neue Auflösung prüft weiterhin selbst `can_send_*()`-Erreichbarkeit statt das dem Versand zu überlassen | `test_radar_alert_logs_configured_but_unreachable_channel` |
+| AC-7 | Die Auflösungsstelle nutzt eine eigene Fassung ohne `alert_rules`-Union statt `_effective_alert_channels()` unverändert | `test_radar_alert_channels_follow_active_alert_rule_override` |
+
+## Known Limitations
+
+- **Der zweite, jetzt entfernte Leer-Check war bereits vor dieser Scheibe toter Code.** Seine
+  Entfernung ändert das Verhalten nicht, nur die Lesbarkeit — AC-5 sichert die Stelle trotzdem
+  ab, weil genau dort (D2) ein Refactoring-Fehler am leichtesten passiert.
+- **Der Compare-Radar-Pfad ist NICHT Teil dieser Scheibe** (bereits mit #1461 S3b-2b
+  umgestellt) — keine Doppelarbeit, aber auch kein erneuter Nachweis hier.
+- **D5s neue `not_delivered`-Einträge sind für Bestandstrips ein sichtbarer Unterschied im
+  Archiv** (mehr Einträge als vorher, sobald ein Nutzer im Alarme-Reiter einen technisch noch
+  nicht erreichbaren Kanal aktiviert) — kein Datenverlust, aber ein Verhaltenszuwachs, den ein
+  Support-Ticket ohne dieses Dokument für einen Fehler halten könnte.
+- **`docs/features/architecture.md` erwähnt `_radar_effective_channels()` namentlich**
+  (per Grep gefunden) — wird durch diese Scheibe nicht aktualisiert (reine Doku-Pflege, kein
+  Code); Nebenbefund-Kandidat für #1199, falls es auffällt.
+- **Ein Nachtrag zu ADR-0021** (analog dem Compare-Nachtrag vom 2026-08-06) ist inhaltlich
+  fällig, aber nicht Teil dieser Spec-Datei — bei der Implementierung nachtragen, nicht in
+  dieser Phase (Schreibrecht ist auf die Spec beschränkt).
+- **D3 (Reihenfolge Horizont-Guard vor Kanalberechnung) ist nicht durch einen eigenen Test
+  abgesichert.** Eine versehentliche Vertauschung würde keinen der sieben neuen Tests rot
+  machen — das Endergebnis für ein zeitlich aktives Segment ist bei beiden Reihenfolgen
+  identisch, nur die Arbeitslast für zeitlich übersprungene Segmente unterscheidet sich.
+  Absicherung ist hier Code-Review (Implementation Details, Schritt 2), nicht Testabdeckung.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue. Nachtrag zu ADR-0021 empfohlen (s. Known Limitations).
+- **Rationale:** Diese Scheibe wendet ein bereits etabliertes Architekturprinzip — ein
+  geteilter Kanal-Resolver für alle Alarmtypen einer Fläche, siehe ADR-0021 Nachtrag
+  2026-08-06 für den Ortsvergleich — symmetrisch auf den letzten noch abweichenden Trip-Pfad
+  an. Keine neue Entscheidung, keine Abweichung von einer bestehenden.
+
+## Changelog
+
+- 2026-08-12: Initial spec erstellt — Issue #1752, Scheibe B zu #1745 (Radar-/Regen-Alarme
+  folgen dem Alarm-Kanal-Satz).

--- a/docs/specs/modules/fix_1752_radar_folgt_alarm_kanaelen.md
+++ b/docs/specs/modules/fix_1752_radar_folgt_alarm_kanaelen.md
@@ -18,7 +18,11 @@ tags: [radar, nowcast, alarm, channel, trip, alert_rules]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO, 2026-08-12 („freigabe", Klartext). Freigegeben ist der Wortlaut dieser
+  Fassung mit sieben Kriterien, einschließlich der drei ausdrücklich benannten Folgen:
+  SMS kommt für Regen-Alarme des KHW-Trips hinzu (Schwelle `HIGH`), Regen-Alarme gehorchen
+  künftig auch einzelnen Alarm-Regeln (D4), und das Alarm-Protokoll bekommt Einträge, wo bisher
+  spurlos abgebrochen wurde (D5).
 
 ## Purpose
 

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -823,38 +823,6 @@ class TripAlertService:
         """Clear radar throttle for a trip (test helper)."""
         self._throttle_store.clear(_RADAR_THROTTLE_SCOPE, trip_id)
 
-    def _radar_effective_channels(self, trip: "Trip") -> set[str]:
-        """Kanal-Set des Radar-Alarms (Issue #1023): globale Faehigkeit UND
-        Trip-Opt-in, bei SMS zusaetzlich das Tier-Gate.
-
-        Issue #1467 S3 aus der Inline-Ableitung herausgezogen — die
-        Unterdrueckungs-Protokollierung braucht dieselbe Liste bereits am
-        Gate, also vor der Erkennung. Reine Ableitung ohne Seiteneffekt, das
-        Ergebnis ist an beiden Stellen identisch; eine zweite Fassung waere
-        genau die Duplikat-Falle, die diese Scheibe beseitigt.
-        """
-        config = trip.report_config
-        channels: set[str] = set()
-        if self._settings.can_send_email() and (not config or getattr(config, "send_email", True)):
-            channels.add("email")
-        if self._settings.can_send_telegram() and config and getattr(config, "send_telegram", False):
-            channels.add("telegram")
-        if (
-            self._settings.can_send_sms() and config
-            and getattr(config, "send_sms", False) and sms_allowed(self._user_id)
-        ):
-            channels.add("sms")
-        if (
-            config and getattr(config, "send_premium_sms", False)
-            and premium_sms_allowed(self._user_id)
-        ):
-            # Bewusst OHNE can_send_*()-Bereitschaftsfrage (D2/Spec-Nachtrag
-            # 2026-08-11): Premium-SMS hat keine feste Rufnummer, die
-            # Sendebereitschaft entscheidet ausschliesslich
-            # `PremiumSmsOutput._resolve_recipient()` zur Sendezeit.
-            channels.add("premium_sms")
-        return channels
-
     def _briefing_precip_for_onset(
         self,
         snapshot,
@@ -950,6 +918,29 @@ class TripAlertService:
                     )
                     continue
 
+            # Issue #1752 (Scheibe B zu #1745, D1/D2): Radar-Alarme folgen
+            # demselben Kanal-Resolver wie Gewitter-, Aenderungs- und amtliche
+            # Alarme — `trip.alert_channels`/`trip.alert_rules` statt der
+            # Briefing-Flags. Das Kanal-Set wird GENAU EINMAL berechnet und an
+            # allen drei Stellen (Unterdrueckungs-Protokoll, Leer-Check,
+            # Versand) geteilt; zwei leicht abweichende Ableitungen waren die
+            # Ursache dieses Bugs.
+            # D3: bewusst NACH dem Horizont-Guard oben — fuer ein Segment, das
+            # zeitlich gar nicht in Frage kommt, darf die `alert_rules`-Union
+            # nicht ausgewertet werden.
+            # Absicherung je Trip, nicht um den Stapellauf: scheitert die
+            # Kanal-Aufloesung EINES Trips (beschaedigte `alert_channels`/
+            # `alert_rules` aus der Persistenz), verlieren sonst ALLE weiteren
+            # Trips dieses Nutzers ihren Radar-Alarm — bei jedem Scheduler-Tick
+            # erneut, bis die Daten repariert sind (Muster `fix_1479`). Breite
+            # Klausel + laute Meldung mit Kennung, wie beim Nowcast-Abruf ein
+            # paar Zeilen weiter unten.
+            try:
+                effective_channels = self._effective_alert_channels(trip)
+            except Exception as e:
+                logger.error(f"Radar alert channel resolution failed for trip {trip.id}: {e}")
+                continue
+
             cooldown_min = (
                 trip.alert_cooldown_minutes
                 if trip.alert_cooldown_minutes is not None
@@ -984,7 +975,7 @@ class TripAlertService:
                     alert_log.append_suppressed_entry(
                         self._user_id, entity_id=trip.id, entity_type="trip",
                         reason=alert_log.REASON_NOWCAST, gate_reason=gate.reason,
-                        effective_channels=self._radar_effective_channels(trip),
+                        effective_channels=effective_channels,
                     )
                 except Exception as e:
                     logger.error(
@@ -1058,7 +1049,7 @@ class TripAlertService:
             # can_send_*()-Bereitschaftsfrage -- ein Trip mit ausschliesslich
             # Premium-SMS hat kein `sms_to`, `can_send_sms()` waere False,
             # obwohl ein funktionsfaehiger Kanal konfiguriert ist.
-            if not self._radar_effective_channels(trip):
+            if not effective_channels:
                 logger.warning(f"No channel configured; skipping radar alert for {trip.id}")
                 continue
 
@@ -1104,18 +1095,12 @@ class TripAlertService:
                 tz=tz,
             )
 
-            # Issue #1023: Kanal-Set für NotificationService bauen; der Service prüft
-            # selbst can_send_*(). Trip-Ebene darf Kanäle explizit deaktivieren.
-            effective_channels = self._radar_effective_channels(trip)
-
-            if not effective_channels:
-                logger.info(f"Radar alert: alle Kanäle auf Trip-Ebene deaktiviert, kein Recording für {trip.id}")
-                continue
-
-            # Issue #1461 S3b-2a: eigenstaendige Inline-Ableitung (Kontext-
-            # Risiko 5) -- ruft `_effective_alert_channels()` bewusst NICHT
-            # auf, muss die Kanal-Schwelle deshalb hier ERNEUT anwenden, sonst
-            # bleibt der Regenradar-Pfad dauerhaft ungefiltert.
+            # Kanal-Schwelle (ADR-0046) auf dem oben einmalig berechneten,
+            # geteilten Kanal-Set. Bis #1752 stand hier ein dritter Aufruf der
+            # eigenen Radar-Ableitung samt zweitem Leer-Check — beides
+            # entfallen: die Aufloesung ist rein, `trip` bleibt zwischen dem
+            # Leer-Check oben (`if not effective_channels`) und dieser Stelle
+            # unveraendert.
             _radar_urgency = alert_urgency.urgency_from_radar(
                 is_convective=_radar_request.is_convective,
                 intensity_label=_radar_request.intensity_label,

--- a/tests/unit/test_radar_alert_channel_resolution.py
+++ b/tests/unit/test_radar_alert_channel_resolution.py
@@ -59,6 +59,8 @@ from __future__ import annotations
 
 import uuid
 
+import pytest
+
 from app.models import (
     AlertMetric,
     AlertRule,
@@ -602,6 +604,67 @@ def test_radar_alert_channels_follow_active_alert_rule_override(monkeypatch):
             "AC-7: bei einer Regel mit eigenem Kanal gewinnt deren Union — "
             "der Standard-Kanal E-Mail zaehlt dann nicht mit, erhalten: "
             f"{reason_for_channel(entry, 'email')!r} (Eintrag: {entry!r})"
+        )
+    finally:
+        clean_uid(uid)
+
+
+# ═══════════ Fehler-Isolation je Trip (Adversary-Finding F001) ══════════════
+
+
+def test_broken_channel_resolution_of_one_trip_does_not_stop_the_batch(monkeypatch):
+    """Given der erste von zwei Trips desselben Nutzers hat ein beschaedigtes
+    Kanal-Feld gespeichert (Liste statt Objekt), sodass die Kanal-Aufloesung
+    fuer ihn scheitert / When der Radar-Stapellauf laeuft / Then wird NUR
+    dieser eine Trip uebersprungen — der zweite Trip wird trotzdem geprueft
+    und hinterlaesst seinen Protokoll-Eintrag.
+
+    Warum diese Zusicherung (Muster ``fix_1479``): die Kanal-Aufloesung dieser
+    Scheibe (``trip_alert.py:931``) sitzt in der Trip-SCHLEIFE, der reale
+    Aufrufer (``api/routers/scheduler.py:96-102``) faengt nichts ab. Ohne
+    Absicherung je Trip reisst ein einziger beschaedigter Trip den gesamten
+    Lauf ab — alle nachfolgenden Trips desselben Nutzers verlieren ihren
+    Radar-Alarm, bei jedem Scheduler-Tick erneut, bis die Daten repariert sind.
+
+    MOCK-FREI (Testpolitik dieser Datei): kein Test-Double des Prueflings —
+    ``alert_channels`` wird auf eine LISTE gesetzt, wie sie eine fehlerhafte
+    Persistenz hinterlaesst; ``_effective_alert_channels()`` ruft darauf
+    ``.get()`` (``trip_alert.py:1500``) und wirft echt. Die ``pytest.raises``-
+    Vorbedingung haelt den Test ehrlich: toleriert die Aufloesung diesen Wert
+    eines Tages, faellt der Test laut aus, statt still nichts mehr zu bewachen.
+
+    PRUEFORT = WIRKORT: Nachweis ist der Protokoll-Eintrag von Trip B im
+    echten ``alert_log.json`` — nicht die blosse Abwesenheit einer Ausnahme.
+    """
+    uid = fresh_uid("f001")
+    clean_uid(uid)
+    try:
+        write_user_tier(uid, "standard")
+        settings = settings_no_channel_reachable()
+        trip_a_id, trip_b_id = _trip_id("f001-kaputt"), _trip_id("f001-heil")
+        trip_a = _radar_trip(trip_a_id, send_email=True)
+        trip_a.alert_channels = ["sms"]  # beschaedigt: Liste statt Objekt
+        trip_b = _radar_trip(
+            trip_b_id, send_email=False,
+            alert_channels={"email": False, "telegram": False, "sms": True},
+        )
+        svc = trip_alert_service(uid, settings, CountingFrameSource(), lambda s, b: None)
+        with pytest.raises(AttributeError):
+            svc._effective_alert_channels(trip_a)
+
+        _run_radar(monkeypatch, uid, [trip_a, trip_b], settings)
+
+        entry = _single_entry(uid, trip_b_id)
+        assert reason_for_channel(entry, "sms") == REASON_DELIVERY_FAILED, (
+            "Der zweite Trip muss trotz des beschaedigten ersten geprueft "
+            "werden und seinen Kanal aufloesen, erhalten: "
+            f"{reason_for_channel(entry, 'sms')!r} (Eintrag: {entry!r})"
+        )
+        assert entries_for(uid, trip_a_id, bucket="entries") == [], (
+            f"Der beschaedigte Trip selbst darf nichts protokollieren: {read_log(uid)!r}"
+        )
+        assert entries_for(uid, trip_a_id, bucket="not_delivered") == [], (
+            f"Auch nicht in 'not_delivered': {read_log(uid)!r}"
         )
     finally:
         clean_uid(uid)

--- a/tests/unit/test_radar_alert_channel_resolution.py
+++ b/tests/unit/test_radar_alert_channel_resolution.py
@@ -1,0 +1,607 @@
+"""TDD RED — Issue #1752 (Scheibe B zu #1745): Regen-/Radar-Alarme folgen dem
+Alarm-Kanal-Satz statt den Briefing-Flags.
+
+SPEC: docs/specs/modules/fix_1752_radar_folgt_alarm_kanaelen.md (AC-1 bis AC-7)
+
+Heute loest ``check_radar_alerts()`` seine Kanaele ueber
+``_radar_effective_channels()`` (``trip_alert.py:826``) auf — eine zweite,
+leicht abweichende Ableitung, die AUSSCHLIESSLICH ``trip.report_config``
+liest und ``trip.alert_channels``/``trip.alert_rules`` nie. Nach dieser
+Scheibe nutzen alle drei Aufrufstellen (``:987``, ``:1061``, ``:1109``)
+dieselbe Funktion wie Gewitter-, Aenderungs- und amtliche Alarme:
+``_effective_alert_channels()``.
+
+PRUEFORT = WIRKORT (CLAUDE.md): geprueft wird NICHT der Rueckgabewert einer
+internen Funktion, sondern die persistierte Nebenwirkung — die
+Kanal-Aufschluesselung ``channels_not_sent`` im echten ``alert_log.json``.
+Deren Rangfolge (``alert_log.py:113-137``) trennt genau die beiden Fragen,
+um die es hier geht:
+
+* ``channel_disabled``  — der Kanal wurde gar nicht erst AUFGELOEST,
+* ``delivery_failed``   — der Kanal WAR aufgeloest, kam aber nicht an,
+* ``below_channel_threshold`` — aufgeloest, aber unter der Dringlichkeits-
+  Schwelle.
+
+Damit laesst sich „wurde der Kanal korrekt aufgeloest?" von „wurde er
+zugestellt?" trennen, ohne echten Versand und ohne Transport-Attrappen.
+
+TESTPOLITIK (CLAUDE.md „Test-Politik: Zwei Schichten", Kern-Schicht):
+mock-frei — echte Trips, echter ``TripAlertService``, echtes
+``alert_log.json``/``throttle_state.json``. Die einzige ``monkeypatch``-Naht
+ist ``app.loader.load_all_trips`` (Trip-Einspeisung, s.u.), kein Test-Double
+eines Prueflings.
+
+WARUM KEIN DISK-RUNDLAUF: ``tests.helpers.nowcast_gate_fixtures.save_trip()``
+serialisiert ``alert_channels``/``alert_rules``/``alert_channel_thresholds``
+NICHT (nachgemessen, ``nowcast_gate_fixtures.py:405-434`` schreibt nur id,
+name, Sperrzeit-/Ruhezeit-Felder, stages und report_config). Ein Rundlauf
+ueber Platte verloere also ausgerechnet die drei Felder, um die es in dieser
+Scheibe geht — der Trip wird deshalb direkt eingespeist.
+
+WARUM ``settings_no_channel_reachable()``: bis #1701 stand in
+``check_radar_alerts()`` ein globaler Bereitschafts-Guard, der einen Trip mit
+ausschliesslich einem neuen Kanal verworfen haette, BEVOR ueberhaupt ein
+Kanal-Set aufgeloest wurde — und alle Bestandstests hatten zufaellig einen
+erreichbaren Zweitkanal daneben, der den Guard passierbar machte (Vorbild
+``tests/unit/test_alert_channel_premium_sms.py:298-376``, „Schritt 0"). Kein
+Kanal ist hier je „mit-erreichbar"; ob ein Protokoll-Eintrag entsteht, haengt
+ausschliesslich an der Kanal-AUFLOESUNG.
+
+AUSNAHME AC-5: dort ist ``settings_email_only()`` noetig — mit unerreichbaren
+Kanaelen waere der Test schon heute gruen und wuerde die Nicht-Umsetzung
+feiern statt sie zu messen (Begruendung im Testdocstring).
+
+Pfadregel #1409: alle Zugriffe laufen ueber ``get_data_dir()`` (pytest-
+isolierte Datenwurzel, #1133) bzw. die Helfer daneben — kein fester
+Hauptrepo-Pfad.
+"""
+from __future__ import annotations
+
+import uuid
+
+from app.models import (
+    AlertMetric,
+    AlertRule,
+    AlertRuleKind,
+    AlertSeverity,
+    TripReportConfig,
+)
+from services.alert_log import (
+    REASON_BELOW_THRESHOLD,
+    REASON_CHANNEL_DISABLED,
+    REASON_DELIVERY_FAILED,
+    REASON_NOWCAST,
+    REASON_QUIET_HOURS,
+)
+
+from tests.helpers.alert_log_fixtures import reason_for_channel
+from tests.helpers.nowcast_gate_fixtures import (
+    SCOPE_TRIP_RADAR,
+    CountingFrameSource,
+    clean_uid,
+    entries_for,
+    fresh_uid,
+    make_trip,
+    quiet_window_elsewhere,
+    quiet_window_now,
+    read_log,
+    read_throttle_state,
+    reset_radar_cache,
+    settings_email_only,
+    settings_no_channel_reachable,
+    suppression_reasons,
+    trip_alert_service,
+    write_user_tier,
+)
+
+
+# ───────────────────────────── Bausteine ────────────────────────────────────
+
+
+def _trip_id(name: str) -> str:
+    return f"trip-1752-{name}-{uuid.uuid4().hex[:6]}"
+
+
+def _radar_trip(
+    trip_id: str,
+    *,
+    send_email: bool = False,
+    send_telegram: bool = False,
+    send_sms: bool = False,
+    alert_channels: dict | None = None,
+    thresholds: dict | None = None,
+    rules: list | None = None,
+    quiet: bool = False,
+):
+    """Trip mit heute ganztaegig aktiver Etappe (Segment-Auswahl und
+    Horizont-Guard greifen daher nicht) plus den drei Alarme-Reiter-Feldern.
+
+    ``make_trip()`` braucht dafuer KEINE Erweiterung: ``alert_channels``,
+    ``alert_channel_thresholds`` und ``alert_rules`` sind normale, nach der
+    Konstruktion beschreibbare ``Trip``-Felder (``app/trip.py:192,214,219``);
+    dasselbe Muster nutzt ``test_alert_channel_premium_sms.py::_base_trip``.
+    """
+    quiet_from, quiet_to = quiet_window_now() if quiet else quiet_window_elsewhere()
+    trip = make_trip(trip_id, quiet_from=quiet_from, quiet_to=quiet_to)
+    trip.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=send_email, send_telegram=send_telegram,
+        send_sms=send_sms, send_premium_sms=False,
+    )
+    if alert_channels is not None:
+        trip.alert_channels = alert_channels
+    if thresholds is not None:
+        trip.alert_channel_thresholds = thresholds
+    if rules is not None:
+        trip.alert_rules = list(rules)
+    return trip
+
+
+def _sms_only_rule() -> AlertRule:
+    """Aktive Alarm-Regel mit eigenem Kanal-Override (#638-Semantik)."""
+    return AlertRule(
+        id="rule-1752-sms", kind=AlertRuleKind.DELTA, metric=AlertMetric.WIND_GUST,
+        threshold=20.0, severity=AlertSeverity.WARNING, enabled=True,
+        unit="km/h", channels=["sms"],
+    )
+
+
+def _run_radar(monkeypatch, uid, trips, settings, mail_sink=None) -> int:
+    """Echter ``check_radar_alerts()``-Lauf mit ausloesendem Nowcast.
+
+    ``CountingFrameSource(onset_minutes=8)`` liefert leichten, NICHT
+    konvektiven Regen (0.6 mm/h) in 8 Minuten — Dringlichkeit ``LOW``
+    (``alert_urgency.urgency_from_radar``), Onset innerhalb der 20-Minuten-
+    Grenze von ``radar_alert_due()``.
+    """
+    import app.loader as loader
+
+    monkeypatch.setattr(loader, "load_all_trips", lambda **kw: list(trips))
+    reset_radar_cache()
+    return trip_alert_service(
+        uid, settings, CountingFrameSource(onset_minutes=8),
+        mail_sink if mail_sink is not None else (lambda subject, body: None),
+    ).check_radar_alerts()
+
+
+def _single_entry(uid: str, trip_id: str) -> dict:
+    """Der EINE Protokoll-Eintrag dieses Trips, egal in welcher Liste.
+
+    Welche Liste (``entries`` vs. ``not_delivered``) entscheidet
+    ``append_entry()`` selbst anhand der Erreichbarkeit (D4, #1459) — das ist
+    hier nicht die gepruefte Zusicherung, geprueft wird die
+    Kanal-Aufschluesselung.
+    """
+    treffer = (
+        entries_for(uid, trip_id, bucket="entries")
+        + entries_for(uid, trip_id, bucket="not_delivered")
+    )
+    assert len(treffer) == 1, (
+        f"Erwartet GENAU EINEN Protokoll-Eintrag fuer {trip_id!r}, gefunden "
+        f"{len(treffer)}. Vollstaendiges Protokoll: {read_log(uid)!r}"
+    )
+    return treffer[0]
+
+
+def _aufgeloeste_kanaele(entry: dict) -> set[str]:
+    """Kanaele, die die AUFLOESUNG als aktiv bestimmt hat.
+
+    Alles ausser ``channel_disabled``: ein Kanal, der zugestellt wurde, unter
+    der Schwelle blieb oder technisch scheiterte, war Teil des effektiven
+    Kanal-Satzes. Nur ``channel_disabled`` heisst „gar nicht aufgeloest".
+    """
+    aktiv = set(entry.get("channels_sent") or [])
+    for item in entry.get("channels_not_sent") or []:
+        if isinstance(item, dict) and item.get("reason") != REASON_CHANNEL_DISABLED:
+            aktiv.add(item.get("channel"))
+    return aktiv
+
+
+def _kanaele_des_unterdrueckungs_eintrags(entry: dict) -> set[str]:
+    """``append_suppressed_entry()`` listet GENAU die effektiven Kanaele
+    (``alert_log.py:322-325``) — jeder mit dem Gate-Grund."""
+    return {
+        item.get("channel")
+        for item in entry.get("channels_not_sent") or []
+        if isinstance(item, dict)
+    }
+
+
+# ═══════════════════════════════ AC-1 ═══════════════════════════════════════
+
+
+def test_radar_alert_channels_override_report_config_when_alert_channels_set(monkeypatch):
+    """AC-1: Given im Alarme-Reiter ist Telegram bewusst AUS und SMS AN,
+    waehrend im Trip-Briefing Telegram AN ist / When ein Regen-Alarm
+    ausgeloest wird / Then richtet sich der Regen-Alarm nach der
+    Alarme-Reiter-Einstellung: SMS zaehlt als aufgeloester Kanal
+    (``delivery_failed`` — war konfiguriert, kam technisch nicht an),
+    Telegram als abgeschalteter (``channel_disabled``).
+
+    ROT-Grund (gemessen, ``trip_alert.py:826-856`` + ``:1061``):
+    ``_radar_effective_channels()`` liest ausschliesslich ``report_config``
+    UND filtert dabei selbst auf technische Erreichbarkeit. Mit
+    ``settings_no_channel_reachable()`` ist das Ergebnis LEER, der Lauf bricht
+    an ``:1061`` wortlos mit ``continue`` ab — es entsteht ueberhaupt kein
+    Protokoll-Eintrag. ``trip.alert_channels`` wird nie gelesen.
+
+    Mutation (Spec AC-1): Radar liest weiterhin (auch nur teilweise)
+    ``report_config`` statt ausschliesslich der aus ``alert_channels``
+    abgeleiteten Menge — Telegram erschiene dann mit ``delivery_failed``
+    (= „war konfiguriert") statt ``channel_disabled`` (= „war ausgeschaltet").
+    """
+    uid = fresh_uid("ac1")
+    clean_uid(uid)
+    try:
+        write_user_tier(uid, "standard")  # sms_allowed() -> True (Falle 2)
+        trip_id = _trip_id("ac1")
+        trip = _radar_trip(
+            trip_id,
+            send_email=False, send_telegram=True,          # Briefing: Telegram AN
+            alert_channels={"email": False, "telegram": False, "sms": True},
+        )
+
+        _run_radar(monkeypatch, uid, [trip], settings_no_channel_reachable())
+
+        entry = _single_entry(uid, trip_id)
+        assert reason_for_channel(entry, "sms") == REASON_DELIVERY_FAILED, (
+            "AC-1: SMS ist im Alarme-Reiter AN und muss deshalb als "
+            "aufgeloester (wenn auch unzustellbarer) Kanal protokolliert "
+            f"werden, erhalten: {reason_for_channel(entry, 'sms')!r} "
+            f"(Eintrag: {entry!r})"
+        )
+        assert reason_for_channel(entry, "telegram") == REASON_CHANNEL_DISABLED, (
+            "AC-1: Telegram ist im Alarme-Reiter AUS — der Briefing-Haken darf "
+            "ihn nicht zurueckholen, erhalten: "
+            f"{reason_for_channel(entry, 'telegram')!r} (Eintrag: {entry!r})"
+        )
+    finally:
+        clean_uid(uid)
+
+
+# ═══════════════════════════════ AC-2 ═══════════════════════════════════════
+
+
+def test_radar_alert_channels_fall_back_to_briefing_when_alert_channels_unset(monkeypatch):
+    """AC-2: Given ein Bestandstrip hat NIE eine eigene Kanal-Auswahl
+    gespeichert (``alert_channels is None``) und im Trip-Briefing ist Telegram
+    aktiv / When ein Regen-Alarm ausgeloest wird / Then uebernimmt der
+    Regen-Alarm die Briefing-Kanaele als Ersatzwert — Telegram bleibt ein
+    aufgeloester Kanal, fuer diesen Trip aendert sich nichts.
+
+    ROT-Grund (gemessen, ``trip_alert.py:840`` + ``:1061``): die alte
+    Ableitung verlangt ZUSAETZLICH ``self._settings.can_send_telegram()``.
+    Mit ``settings_no_channel_reachable()`` faellt Telegram dort heraus, das
+    Kanal-Set ist leer und der Lauf bricht an ``:1061`` ohne Protokoll-Eintrag
+    ab. Die Zielfunktion ``_effective_alert_channels()`` trennt Auflösung und
+    Erreichbarkeit sauber und liefert ``{'telegram'}``.
+
+    Gegenprobe zu AC-1 (Fallback statt Override).
+
+    Mutation (Spec AC-2): der Fallback bei ``alert_channels is None`` bricht
+    (z.B. weil der neue Code faelschlich ein leeres Dict statt der echten
+    Fallback-Kette annimmt) — Telegram erschiene trotz aktivem Briefing-Flag
+    als ``channel_disabled``.
+    """
+    uid = fresh_uid("ac2")
+    clean_uid(uid)
+    try:
+        write_user_tier(uid, "standard")
+        trip_id = _trip_id("ac2")
+        trip = _radar_trip(trip_id, send_email=False, send_telegram=True)
+        assert trip.alert_channels is None, (
+            "Voraussetzung: dieser Bestandstrip hat KEINE eigene Kanal-Auswahl"
+        )
+
+        _run_radar(monkeypatch, uid, [trip], settings_no_channel_reachable())
+
+        entry = _single_entry(uid, trip_id)
+        assert reason_for_channel(entry, "telegram") == REASON_DELIVERY_FAILED, (
+            "AC-2: ohne eigene Alarme-Reiter-Auswahl muss der Briefing-Kanal "
+            "Telegram als aufgeloest gelten, erhalten: "
+            f"{reason_for_channel(entry, 'telegram')!r} (Eintrag: {entry!r})"
+        )
+        assert reason_for_channel(entry, "email") == REASON_CHANNEL_DISABLED, (
+            "AC-2: E-Mail ist im Briefing AUS und darf nicht mit-vererbt "
+            f"werden, erhalten: {reason_for_channel(entry, 'email')!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+# ═══════════════════════════════ AC-3 ═══════════════════════════════════════
+
+
+def test_radar_alert_below_threshold_channel_uses_shared_channel_set(monkeypatch):
+    """AC-3: Given im Alarme-Reiter ist SMS aktiviert und traegt die
+    Dringlichkeits-Schwelle „hoch" / When ein Regen-Alarm mit NIEDRIGER
+    Dringlichkeit (leichter, nicht-konvektiver Regen) ausgeloest wird / Then
+    erscheint SMS im Protokoll als „unter der eingestellten Schwelle"
+    (``below_channel_threshold``) — nicht als „ausgeschaltet" und nicht als
+    „technisch fehlgeschlagen". Die Schwelle wirkt weiterhin, jetzt aber auf
+    dem geteilten Kanal-Satz.
+
+    ROT-Grund (gemessen): ``split_by_threshold()`` (``trip_alert.py:1123``)
+    bekommt heute das Ergebnis von ``_radar_effective_channels()``, das
+    ``alert_channels`` nicht kennt und mit unerreichbaren Kanaelen leer ist —
+    der Lauf endet an ``:1061``, es gibt keinen Eintrag und damit auch keine
+    Schwellen-Aussage.
+
+    Mutation (Spec AC-3): die Schwelle wird weiterhin auf dem alten,
+    Briefing-basierten Kanal-Set angewendet — SMS taucht dann gar nicht als
+    „aktiv, aber unter Schwelle" auf, sondern als ``channel_disabled``.
+    """
+    uid = fresh_uid("ac3")
+    clean_uid(uid)
+    try:
+        write_user_tier(uid, "standard")
+        trip_id = _trip_id("ac3")
+        trip = _radar_trip(
+            trip_id,
+            send_email=True, send_telegram=True,   # Briefing bewusst abweichend
+            alert_channels={"email": False, "telegram": False, "sms": True},
+            thresholds={"sms": "HIGH"},
+        )
+
+        _run_radar(monkeypatch, uid, [trip], settings_no_channel_reachable())
+
+        entry = _single_entry(uid, trip_id)
+        assert reason_for_channel(entry, "sms") == REASON_BELOW_THRESHOLD, (
+            "AC-3: SMS ist eingeschaltet, die Meldung liegt aber unter der "
+            "eingestellten Schwelle 'hoch' — genau das muss im Protokoll "
+            f"stehen, erhalten: {reason_for_channel(entry, 'sms')!r} "
+            f"(Eintrag: {entry!r})"
+        )
+    finally:
+        clean_uid(uid)
+
+
+# ═══════════════════════════════ AC-4 ═══════════════════════════════════════
+
+
+def test_radar_alert_suppressed_entry_matches_dispatch_channel_set(monkeypatch):
+    """AC-4: Given ein Regen-Alarm wird durch die Ruhezeit blockiert, BEVOR
+    ueberhaupt ein Wetterabruf stattfindet, und ein Kanal ist ausschliesslich
+    ueber den Alarme-Reiter aktiviert / When diese Unterdrueckung
+    protokolliert wird / Then zeigt der Unterdrueckungs-Eintrag denselben
+    Kanal, den ein tatsaechlicher Versand angesteuert haette.
+
+    Aufbau: ZWEI Trips in EINEM Lauf, identisch konfiguriert bis auf das
+    Ruhezeit-Fenster — Trip A (Ruhezeit jetzt) laeuft in die Unterdrueckungs-
+    Protokollierung (``:987``), Trip B (Ruhezeit spaeter) in den Versandpfad
+    (``:1061``/``:1109``). Verglichen werden die beiden Kanal-Listen
+    gegeneinander; ein Test, der nur eine Seite prueft, laesst genau die
+    Abweichung zu, um die es geht.
+
+    ROT-Grund (gemessen): beide Stellen rufen ``_radar_effective_channels()``,
+    das ``alert_channels`` nicht liest. Mit unerreichbaren Kanaelen ist das
+    Ergebnis leer — ``append_suppressed_entry()`` kehrt bei leerem Kanal-Set
+    ohne Eintrag zurueck (``alert_log.py:306-308``), der Versandpfad bricht an
+    ``:1061`` ab. Es entsteht KEIN einziger Eintrag.
+
+    Mutation (Spec AC-4): nur die Versand-Stelle (``:1061``/``:1109``) wird
+    auf die geteilte Variable umgestellt, die Unterdrueckungs-Protokollierung
+    (``:987``) bleibt bei der alten Aufloesung — dann entsteht entweder gar
+    kein Unterdrueckungs-Eintrag oder einer mit anderen Kanaelen als der
+    Versand.
+    """
+    uid = fresh_uid("ac4")
+    clean_uid(uid)
+    try:
+        write_user_tier(uid, "standard")
+        trip_quiet_id, trip_loud_id = _trip_id("ac4-quiet"), _trip_id("ac4-loud")
+        # Kanal AUSSCHLIESSLICH ueber den Alarme-Reiter (Briefing: nur E-Mail).
+        kanaele = {"email": False, "telegram": False, "sms": True}
+        trips = [
+            _radar_trip(trip_quiet_id, send_email=True, alert_channels=dict(kanaele), quiet=True),
+            _radar_trip(trip_loud_id, send_email=True, alert_channels=dict(kanaele)),
+        ]
+
+        _run_radar(monkeypatch, uid, trips, settings_no_channel_reachable())
+
+        unterdrueckt = entries_for(uid, trip_quiet_id, bucket="not_delivered")
+        assert len(unterdrueckt) == 1, (
+            "AC-4: die Ruhezeit-Unterdrueckung muss GENAU EINEN Eintrag "
+            f"hinterlassen, gefunden {len(unterdrueckt)}. Protokoll: "
+            f"{read_log(uid)!r}"
+        )
+        assert REASON_QUIET_HOURS in suppression_reasons(unterdrueckt[0]), (
+            f"AC-4: Grund 'Ruhezeit' fehlt im Eintrag: {unterdrueckt[0]!r}"
+        )
+        assert unterdrueckt[0].get("reason") == REASON_NOWCAST, (
+            "AC-4: der Ausloeser bleibt der Nowcast, erhalten: "
+            f"{unterdrueckt[0].get('reason')!r}"
+        )
+
+        versand = _single_entry(uid, trip_loud_id)
+        assert _kanaele_des_unterdrueckungs_eintrags(unterdrueckt[0]) == {"sms"}, (
+            "AC-4: der Unterdrueckungs-Eintrag muss genau den Alarme-Reiter-"
+            "Kanal nennen, erhalten: "
+            f"{_kanaele_des_unterdrueckungs_eintrags(unterdrueckt[0])!r}"
+        )
+        assert (
+            _kanaele_des_unterdrueckungs_eintrags(unterdrueckt[0])
+            == _aufgeloeste_kanaele(versand)
+        ), (
+            "AC-4: Unterdrueckungs-Protokoll und Versand duerfen NICHT auf "
+            "unterschiedlichen Kanal-Listen beruhen — unterdrueckt: "
+            f"{_kanaele_des_unterdrueckungs_eintrags(unterdrueckt[0])!r}, "
+            f"Versand: {_aufgeloeste_kanaele(versand)!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+# ═══════════════════════════════ AC-5 ═══════════════════════════════════════
+
+
+def test_radar_alert_stays_silent_when_all_trip_channels_off(monkeypatch):
+    """AC-5: Given im Alarme-Reiter sind ALLE vier Kanaele ausgeschaltet, das
+    Trip-Briefing ist davon unberuehrt (E-Mail dort weiterhin AN) / When ein
+    Regen-Alarm ausgeloest wuerde / Then bleibt der Trip vollstaendig still —
+    kein Protokoll-Eintrag, keine Sperrzeit, keine Mail.
+
+    WARUM HIER ``settings_email_only()`` STATT ``settings_no_channel_
+    reachable()``: nachgemessen — mit unerreichbaren Kanaelen liefert schon
+    die ALTE Ableitung ein leeres Set, der Trip bliebe auch heute still und
+    der Test waere gruen, ohne irgendetwas zu bewachen (er feierte die
+    Nicht-Umsetzung). Erst ein technisch ERREICHBARER Briefing-Kanal macht
+    den Unterschied sichtbar: heute gewinnt das Briefing-Flag und der Alarm
+    geht raus.
+
+    ROT-Grund (gemessen): ``_radar_effective_channels()`` liefert mit
+    ``report_config.send_email=True`` und erreichbarem SMTP ``{'email'}`` —
+    der Alarm wird zugestellt, ``append_entry()`` schreibt einen Eintrag und
+    ``record_nowcast_sent()`` bucht die Sperrzeit. Der Alarme-Reiter, in dem
+    der Nutzer ALLES abgeschaltet hat, wird komplett ignoriert.
+
+    Mutation (Spec AC-5): beim Entfernen des zweiten (toten) Leer-Checks
+    (``:1111-1113``) wird der verbliebene erste (``:1061``) versehentlich auf
+    eine andere, nicht-geteilte Variable umgehaengt — dann entstuende trotz
+    vollstaendig ausgeschalteter Kanaele wieder ein Eintrag und/oder eine
+    Sperrzeit.
+    """
+    uid = fresh_uid("ac5")
+    clean_uid(uid)
+    try:
+        write_user_tier(uid, "standard")
+        trip_id = _trip_id("ac5")
+        trip = _radar_trip(
+            trip_id,
+            send_email=True,  # Briefing unberuehrt AN
+            alert_channels={
+                "email": False, "telegram": False, "sms": False, "premium_sms": False,
+            },
+        )
+        mails: list = []
+
+        _run_radar(
+            monkeypatch, uid, [trip], settings_email_only(),
+            mail_sink=lambda subject, body: mails.append((subject, body)),
+        )
+
+        log = read_log(uid)
+        assert entries_for(uid, trip_id, bucket="entries") == [], (
+            f"AC-5: ein stumm geschalteter Trip darf keinen Eintrag in "
+            f"'entries' erzeugen: {log!r}"
+        )
+        assert entries_for(uid, trip_id, bucket="not_delivered") == [], (
+            f"AC-5: auch kein Eintrag in 'not_delivered': {log!r}"
+        )
+        assert mails == [], (
+            f"AC-5: bei vollstaendig abgeschalteten Alarm-Kanaelen darf keine "
+            f"Mail hinausgehen, erhalten: {mails!r}"
+        )
+        sperrzeit = read_throttle_state(uid).get(SCOPE_TRIP_RADAR, {})
+        assert trip_id not in sperrzeit, (
+            f"AC-5: es darf keine Sperrzeit fuer {trip_id!r} gebucht werden "
+            f"(sonst schluckt sie den naechsten, gewollten Alarm): {sperrzeit!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+# ═══════════════════════════════ AC-6 ═══════════════════════════════════════
+
+
+def test_radar_alert_logs_configured_but_unreachable_channel(monkeypatch):
+    """AC-6: Given im Alarme-Reiter ist ein Kanal aktiviert, der gerade
+    technisch nicht erreichbar ist (kein Telegram-Bot hinterlegt) / When ein
+    Regen-Alarm ausgeloest wird / Then hinterlaesst der Versuch einen
+    nachvollziehbaren Protokoll-Eintrag („Kanal war aktiv, aber technisch
+    nicht erreichbar" = ``delivery_failed``) statt spurlos zu verschwinden.
+    Gewollte Verbesserung der Nachvollziehbarkeit (Spec D5), kein neuer
+    Fehler.
+
+    Wie AC-1 ohne jeden erreichbaren Kanal (``settings_no_channel_
+    reachable()``) — hier aber als Nachweis, dass die NEUE Aufloesung nicht
+    mehr selbst nach Erreichbarkeit filtert. Kein zufaellig erreichbarer
+    Zweitkanal, der einen vorgelagerten Guard passierbar macht (Lehre aus
+    „Schritt 0", #1701).
+
+    ROT-Grund (gemessen, ``trip_alert.py:840``): die alte Ableitung macht die
+    Erreichbarkeit (``can_send_telegram()``) zum TEIL der Aufloesung. Der
+    Kanal gilt dort schon als „aus", das Set ist leer, ``:1061`` bricht
+    wortlos ab — es entsteht kein Eintrag.
+
+    Mutation (Spec AC-6): die Aufloesung prueft weiterhin selbst die
+    technische Erreichbarkeit, statt das dem Versand zu ueberlassen — der
+    erste Leer-Check braeche wieder wortlos ab, kein Eintrag entstuende.
+    """
+    uid = fresh_uid("ac6")
+    clean_uid(uid)
+    try:
+        write_user_tier(uid, "standard")
+        trip_id = _trip_id("ac6")
+        trip = _radar_trip(
+            trip_id, send_email=False, send_telegram=False,
+            alert_channels={"telegram": True},
+        )
+        settings = settings_no_channel_reachable()
+        assert not settings.can_send_telegram(), (
+            "Testvoraussetzung: Telegram ist technisch NICHT erreichbar"
+        )
+
+        _run_radar(monkeypatch, uid, [trip], settings)
+
+        entry = _single_entry(uid, trip_id)
+        assert reason_for_channel(entry, "telegram") == REASON_DELIVERY_FAILED, (
+            "AC-6: der aktivierte, aber unerreichbare Kanal muss als "
+            "'technisch gescheitert' protokolliert werden (nicht als "
+            "'ausgeschaltet' und nicht gar nicht), erhalten: "
+            f"{reason_for_channel(entry, 'telegram')!r} (Eintrag: {entry!r})"
+        )
+    finally:
+        clean_uid(uid)
+
+
+# ═══════════════════════════════ AC-7 ═══════════════════════════════════════
+
+
+def test_radar_alert_channels_follow_active_alert_rule_override(monkeypatch):
+    """AC-7: Given ein Trip hat eine aktive Alarm-Regel mit eigenem Kanal
+    (nur SMS), waehrend der Alarme-Reiter selbst E-Mail eingeschaltet hat /
+    When ein Regen-Alarm ausgeloest wird / Then beruecksichtigt der
+    Regen-Alarm den Kanal der Regel — Regen-Alarme sind keine Ausnahme von
+    den Alarm-Regeln mehr (Spec D4, echte Bedeutungserweiterung).
+
+    Erwartete Aufschluesselung nach ``_effective_alert_channels()``
+    (``trip_alert.py:1534-1542``): existiert mindestens eine aktive Regel mit
+    nicht-leerer Kanalliste, gewinnt deren Union — der Standard-Kanal E-Mail
+    traegt ``channel_disabled``, der Regel-Kanal SMS ``delivery_failed``.
+
+    ROT-Grund (gemessen): ``_radar_effective_channels()`` liest
+    ``trip.alert_rules`` ueberhaupt nicht; mit unerreichbaren Kanaelen ist
+    das Set leer und der Lauf endet an ``:1061`` ohne Eintrag.
+
+    Mutation (Spec AC-7): die neue Aufloesungsstelle ruft eine eigene,
+    abgespeckte Fassung ohne den Regel-Union-Teil auf, statt
+    ``_effective_alert_channels()`` unveraendert zu verwenden — der
+    Regel-Kanal bliebe unberuecksichtigt, stattdessen gaelte weiterhin nur
+    ``alert_channels`` (E-Mail).
+    """
+    uid = fresh_uid("ac7")
+    clean_uid(uid)
+    try:
+        write_user_tier(uid, "standard")
+        trip_id = _trip_id("ac7")
+        trip = _radar_trip(
+            trip_id, send_email=True,
+            alert_channels={"email": True, "telegram": False, "sms": False},
+            rules=[_sms_only_rule()],
+        )
+
+        _run_radar(monkeypatch, uid, [trip], settings_no_channel_reachable())
+
+        entry = _single_entry(uid, trip_id)
+        assert reason_for_channel(entry, "sms") == REASON_DELIVERY_FAILED, (
+            "AC-7: der Kanal-Override der aktiven Alarm-Regel muss auch fuer "
+            "Regen-Alarme gelten, erhalten: "
+            f"{reason_for_channel(entry, 'sms')!r} (Eintrag: {entry!r})"
+        )
+        assert reason_for_channel(entry, "email") == REASON_CHANNEL_DISABLED, (
+            "AC-7: bei einer Regel mit eigenem Kanal gewinnt deren Union — "
+            "der Standard-Kanal E-Mail zaehlt dann nicht mit, erhalten: "
+            f"{reason_for_channel(entry, 'email')!r} (Eintrag: {entry!r})"
+        )
+    finally:
+        clean_uid(uid)


### PR DESCRIPTION
Behebt den zweiten Befund aus #1745. Scheibe A (Premium-SMS in der Oberfläche) ist seit `c28f794b` live.

## Der Fehler

`_radar_effective_channels()` löste die Kanäle des Radar-/Regen-Alarms **ausschließlich aus `trip.report_config`** auf — den Briefing-Flags — und las `trip.alert_channels` an keiner Stelle. Wer im Alarme-Reiter Kanäle abwählte, änderte für Regen-Alarme **nichts**. Das betraf alle vier Kanäle, nicht nur Premium-SMS.

Ein Test belegt die Fehlwirkung positiv: Heute geht ein Alarm per E-Mail raus, **obwohl im Alarme-Reiter alle vier Kanäle ausgeschaltet sind**.

## Die Änderung

`_radar_effective_channels()` entfällt **ersatzlos**. Das Kanal-Set wird **einmal** bei `trip_alert.py:938` über `_effective_alert_channels(trip)` aufgelöst — nach dem Horizont-Guard — und im ganzen Radar-Pfad geteilt (Unterdrückungs-Protokoll, Leer-Check, Versand). Der zweite Leer-Check war toter Code und ist weg.

Ein Wrapper, der die `can_send_*`-Vorfilterung behält, war ausdrücklich verworfen: Er verschiebt die Duplikat-Falle, statt sie zu schließen — genau der Zustand, der diesen Fehler erzeugt hat.

**Netto −15 Zeilen Produktivcode.** Kein Go, kein Frontend.

## Zwei benannte Folgen

**Radar erbt die `alert_rules`-Union mit.** Regel-Kanäle **ersetzen** dabei je Regel, sie ergänzen nicht — der geerbte Anteil fällt nur weg, wenn **alle** aktiven Regeln eigene Kanäle tragen (`trip_alert.py:1534-1542`). Vorbestehende Semantik aus #638, hier nur übernommen.

**Ein Alarmversuch ohne erreichbaren Kanal hinterlässt jetzt einen Protokolleintrag** statt spurlos abzubrechen. Verbesserung der Nachvollziehbarkeit, als AC festgeschrieben, damit die neuen Einträge niemand für einen Defekt hält.

## 🔴 Warum ein grüner Testlauf hier nichts beweist

**Kein einziger** Bestandstest kombiniert `check_radar_alerts()` mit gesetztem `alert_channels` oder aktiven `alert_rules` — alle 30 aufrufenden Testdateien gegen alle Dateien mit `alert_rules`-Zuweisung gekreuzt, keine Überschneidung. Alle Radar-Vorlagen steuern die Kanäle über `report_config`, wo alt und neu **dasselbe** liefern. Die acht neuen Tests sind der **einzige** Nachweis; Prüfort ist durchgehend der persistierte `alert_log`-Eintrag.

## Adversary: BROKEN → VERIFIED (3 Runden, 14 Punkte)

**Der HIGH-Fund war eine echte Regression.** Die neue Kanalauflösung saß **außerhalb** jedes `try/except`, während die alte Fassung sie **innerhalb** hatte — mit der Begründung wörtlich im Code:

> „Absicherung je Trip, nicht um den Stapellauf: scheitert der Protokoll-Eintrag EINES Trips, verlieren sonst ALLE weiteren Trips dieses Nutzers ihren Radar-Alarm (Muster `fix_1479`)."

Der Aufrufer `api/routers/scheduler.py:96-102` fängt nichts. Ein Trip mit beschädigten Daten hätte den gesamten Alarmlauf abgerissen — bei jedem Scheduler-Tick erneut. Behoben mit Absicherung je Trip (`:938-942`) plus Regressionstest; die Gegenprobe (Absicherung entfernen ⇒ Test rot mit `AttributeError`) wurde eigenständig nachgemessen.

Der Test nutzt bewusst **echte** beschädigte Daten (`alert_channels` als Liste statt Objekt) statt einer Attrappe — die Testdatei schließt Test-Doubles des Prüflings aus.

**Spec-Korrektur aus demselben Lauf:** Die Mutationstabelle ordnete den Fang für AC-5 der falschen Zeile zu. Gefangen wird die Mutation von AC-6; AC-5 bleibt grün, weil drei tiefere Sicherungen kompensieren. Ehrlich nachgetragen statt stehengelassen — Merksatz in der Spec: „ein Test wird rot" ist erst dann ein Nachweis, wenn es der Test ist, dem man es zuschreibt.

## Nachweis

- **93 Tests grün** über sieben benannte Dateien
- Eine vorbestehend rote Bestandsdatei (`test_issue_818_radar_briefing_integration.py`) — per A/B gegen eine wiedereingehängte Kopie der alten Auflösung als **nicht** von dieser Scheibe verursacht belegt; steht in `.github/ci_tdd_excludes.txt`
- Doku nachgezogen: `architecture.md` (2 Stellen), **ADR-0021-Nachtrag** nach dem Muster von #1461 S3b-2b — kein neues ADR, diese Scheibe trifft keine neue Architekturentscheidung

Nebenbefunde in #1199 gebucht.

Refs #1752, #1745, #1199

🤖 Generated with [Claude Code](https://claude.com/claude-code)
