### PR TITLE
feat(#1680): Herkunft der Gewitterstufe im Ortsvergleich (Scheibe 1)

### DIFF
--- a/docs/specs/modules/feat_1680_s1_gewitter_herkunft_ortsvergleich.md
+++ b/docs/specs/modules/feat_1680_s1_gewitter_herkunft_ortsvergleich.md
@@ -1,0 +1,483 @@
+---
+entity_id: feat_1680_s1_gewitter_herkunft_ortsvergleich
+type: feature
+created: 2026-08-12
+updated: 2026-08-12
+status: draft
+version: "1.0"
+tags: [thunder, compare, adr-0007, adr-0025, adr-0048, issue-1680, issue-1419]
+---
+
+<!-- Issue #1680, Scheibe 1 (Ortsvergleich). Bezug #1419 (Epic, Rang 4),
+     Entscheidung E1 (PO 2026-08-08). Grundlage: docs/context/feat-1680-thunder-herkunft.md
+     (Phase 1+2, gemessen 2026-08-11, Analysis-Abschnitt inkl. PO-Entscheidungen
+     am Dateiende). Baut NICHT auf #1760 (CIN-Vorzeichen-Fix) auf, ist aber NACH
+     #1760 entstanden — die Fusionsstruktur in metric_format.py, die diese
+     Scheibe erweitert, ist der Stand NACH dem #1760-Fix. -->
+
+# Gewitter: Herkunft der Stufe im Ortsvergleich sichtbar machen (#1680 Scheibe 1)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Die fusionierte Gewitterstufe (`kein/leicht/mittel/hoch`) entsteht heute aus bis zu
+vier Zutaten (Wettercode, Blitzdichte, CAPE gedämpft durch CIN, Blitzpotenzial LPI),
+zeigt aber nur das Ergebnis — nicht, welche Zutat es erreicht hat. Im Ortsvergleich
+stehen dadurch z. B. Korsika „hoch" und ein Alpen-Ort „hoch" nebeneinander, obwohl
+die Stufen auf völlig verschiedenen physikalischen Größen beruhen (Korsika:
+Blitzdichte aus AROME; Alpen: CAPE/LPI aus ICON-D2/ICON-EU). Die Zeile suggeriert
+eine Vergleichbarkeit, die es auf Rohdaten-Ebene nicht gibt. Diese Scheibe macht
+die Herkunft im Ortsvergleich sichtbar, ohne eine der vier Zutaten zu bewerten
+oder eine Empfehlung daraus abzuleiten (ADR-0007).
+
+## Source
+
+> **Schicht-Hinweis:** ausschließlich Python-Core (`src/output/`, `src/providers/`,
+> `src/app/models.py`, `src/services/weather_metrics.py`). Kein Frontend, keine
+> Go-Beteiligung, kein neuer Endpoint — reine Renderer-/Fusionslogik plus zwei
+> additive Datenmodell-Felder.
+
+- **File:** `src/output/metric_format.py` — `thunder_level_from_signals()`
+  (Z. 369-457), neue `_signal_levels()`, `thunder_signal_carriers()`,
+  `THUNDER_SIGNAL_LABEL_DE`, `thunder_signal_label()`
+- **File:** `src/providers/thunder_enrichment.py` — `_fuse_thunder_levels()`
+  (Z. 95-144)
+- **File:** `src/app/models.py` — `ForecastDataPoint` (Z. 99 ff.),
+  `SegmentWeatherSummary` (Z. 405 ff.)
+- **File:** `src/services/weather_metrics.py` — `_compute_thunder_level()`
+  (Z. 590-609), `compute_metrics()` (Z. 396-492)
+- **File:** `src/output/renderers/email/compare_html.py` — `_fmt_thunder()`
+  (Z. 204-219), neue `loc_thunder_signals()` (analog `loc_hail_flag()`,
+  Z. 643-658), Aufrufstelle `_render_overview_row()` (Z. 703-707)
+- **File:** `src/output/renderers/comparison.py` — `_fmt_overview_cell()`
+  (Z. 503-515), Aufrufstellen Z. 246 (Klartext-Übersicht),
+  `_plain_metric_cell()` (Z. 632-644, Telegram), `_sms_metric_cell()`
+  (Z. 605-629, SMS — bewusst NICHT geändert)
+- **Identifier:** `output.metric_format.thunder_signal_carriers()`,
+  `output.renderers.email.compare_html.loc_thunder_signals()`,
+  `output.renderers.comparison._fmt_overview_cell()`
+
+## Estimated Scope
+
+- **LoC:** ~145-165 Quellcode + ~80-110 Tests, geschätzt **~225-250** gesamt
+  (Limit 250 je Workflow — **knapp**, s. „Nicht in dieser Scheibe" für den
+  ersten Kürzungs-Kandidaten, falls die Umsetzung darüber liegt).
+- **Files:** 6 Quelldateien (s. Source) + 1-2 neue Testdateien, nach
+  Verhalten benannt (nicht nach Issue-Nummer).
+- **Effort:** medium. Kein Breaking Change (additiv, s. D1/D2), kein
+  Frontend, keine Migration — das Risiko liegt im SMS-Ausschluss (muss aktiv
+  geprüft werden, nicht nur unterlassen) und im Persistenz-Feldtyp (D6).
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `docs/context/feat-1680-thunder-herkunft.md` | GRUNDLAGE (gemessen) | Belege, Messwerte, PO-Entscheidungen dieser Spec sind daraus übernommen |
+| ADR-0007 (`docs/adr/0007-daten-statt-empfehlungen.md`) | ZUSAGE | Herkunfts-Label ist Beschreibung, keine Bewertung |
+| ADR-0025 (`docs/adr/0025-eine-gewitter-quelle-fuer-alle-briefing-kanaele.md`) | ZUSAGE | Eine Fusion, eine Skala, für Trip UND Ortsvergleich — diese Scheibe fügt der gemeinsamen Fusion ein additives Feld hinzu, baut keine zweite |
+| ADR-0048 (`docs/adr/0048-modellabhaengige-schwellen-statt-einer-zahl.md`) | KONTEXT | Unbekannte/ungeeichte Herkunft heißt „keine Aussage" — relevant für die EU_REST-LPI-Einschränkung (Known Limitations) |
+| `docs/specs/modules/fix_1760_cin_vorzeichen.md` | VORGÄNGER (Code-Basis) | Die Fusionsstruktur, die diese Scheibe erweitert, ist der Stand NACH diesem Fix |
+| `src/output/renderers/alert/official_alerts.py:91-128` (`_SOURCE_LABELS`/`official_alert_source_label`) | MUSTER | Exakt-Treffer vor Heuristik, nie ein erfundener Wert — Vorbild für `thunder_signal_label()` |
+| `src/output/metric_format.py:487-496` (`format_hail_note`) + `compare_html.py:204-219` (`_fmt_thunder`) | MUSTER | Additiver `f"{label} · {note}"`-Suffix — Vorbild für den Herkunfts-Suffix |
+| `tests/tdd/test_thunder_named_signals_enrichment.py::test_ac9_der_kern_dispatch_kennt_keine_quelle_und_kein_einzelnes_signal` | WÄCHTER | Verbietet Signal-/Quellnamen im Quelltext von `enrich_thunder()` selbst — diese Scheibe hält sich fern davon (D5) |
+
+## PO-Entscheidungen (2026-08-11, nicht verhandelbar)
+
+| Frage | Entscheidung |
+|---|---|
+| Auslegung | **(ii) Alle tragenden Signale.** Genannt wird JEDE Zutat, die die gezeigte Stufe erreicht — z. B. „hoch · CAPE, Blitzpotenzial". Es wird KEIN Gewinner gekürt. |
+| Kanäle | **E-Mail (HTML-Ortsvergleich) + Telegram JA · SMS und Premium-SMS bewusst OHNE Herkunft.** Die Stufe selbst bleibt dort unverändert sichtbar. Das ist eine ausdrückliche Entscheidung, kein stilles Auslassen — der SMS-Zweig muss **aktiv abgewählt** werden. |
+| Scheibe | **Ortsvergleich zuerst.** Trip-Mail-Pill, Nachtblock, Kurzzusammenfassung, Mehrtages-Ausblick, GEWITTER-Kommando, Go-DTO und Frontend sind NICHT in dieser Scheibe. |
+
+## Implementation Details
+
+**D1 — Additive Fusion, keine Signaturänderung.** `thunder_level_from_signals()`
+hat genau einen Produktiv-Aufrufer (`thunder_enrichment.py:135`). Ihr `if`-Block
+(Z. 426-457) wird in eine private `_signal_levels(...) -> dict[str, ThunderLevel]`
+gezogen, die je vorhandenem Signal einen Eintrag unter einem festen Schlüssel
+liefert (`"wettercode"`, `"blitzdichte"`, `"cape"`, `"blitzpotenzial"` — in
+dieser Reihenfolge eingefügt, damit eine spätere Ausgabe deterministisch in
+derselben Reihenfolge iteriert, ohne separat sortieren zu müssen).
+`thunder_level_from_signals()` wird zeichengleich: `return max_thunder(_signal_levels(...).values()) if _signal_levels(...) else None`.
+Alle 11 Bestandstestdateien, die an ihrer Signatur/ihrem Rückgabewert hängen,
+bleiben unverändert grün — das ist der Grund für diese Bauweise statt eines
+Rückgabetyp-Wechsels.
+
+**D2 — Zweite öffentliche Funktion statt Signaturbruch.**
+`thunder_signal_carriers(...)` bekommt dieselbe Keyword-only-Signatur wie
+`thunder_level_from_signals()`, ruft ebenfalls `_signal_levels(...)` und
+liefert die Liste der Signalnamen, deren übersetzte Stufe die fusionierte
+Maximalstufe erreicht (PO-Entscheidung (ii) — **alle** Träger, kein
+Gewinner):
+
+```
+werte = _signal_levels(...)
+if not werte:
+    return []
+top = max_thunder(werte.values())
+return [name for name in werte if werte[name] == top]
+```
+
+Löst Befund A (Gleichstands-Reihenfolge, Kontext-Dokument) auf: weil nichts
+gekürt wird, ist die interne `if`-Reihenfolge der Fusion keine Produktaussage
+mehr.
+
+**D3 — Label-Katalog genau einmal.** `THUNDER_SIGNAL_LABEL_DE` (neben
+`THUNDER_LABEL_DE`, `metric_format.py:236-241`) mappt die vier Schlüssel auf
+`"Wettercode"`, `"Blitzdichte"`, `"CAPE"`, `"Blitzpotenzial"`.
+`thunder_signal_label(name)` liefert bei unbekanntem Namen den rohen Namen
+selbst zurück — kein erfundener Ersatztext (Muster
+`official_alert_source_label()`, `official_alerts.py:112-128`: Exakt-Treffer
+zuerst, dann roher String als Fallback; hier ohne Heuristik-Stufe, weil die
+Signalmenge geschlossen ist — vier feste Schlüssel, kein Namensraum mit
+Präfix-Varianten wie bei den amtlichen Quellen). Diese vier Zutaten sind
+identisch mit den Signalen der Fusion in `metric_format.py` — **nicht** mit
+den DWD-Feldnamen aus `thunder_enrichment._SIGNAL_ZU_FELD` (`"lpi"`,
+`"cin_ml"`, …), die eine andere Ebene (Rohwert-Routing) beschreiben.
+
+**D4 — Per-Datenpunkt-Feld, gefüllt in `_fuse_thunder_levels()`.**
+`ForecastDataPoint.thunder_level_signals: Optional[list[str]] = None` (neu,
+additiv, Default `None`). `_fuse_thunder_levels()`
+(`thunder_enrichment.py:95-144`) ruft zusätzlich zu
+`thunder_level_from_signals(...)` (bereits vorhanden) auch
+`thunder_signal_carriers(...)` mit denselben Argumenten und setzt
+`dp.thunder_level_signals = carriers`, **nur** wenn `fused is not None`
+(exakt dieselbe Überschreib-Bedingung wie beim bestehenden
+`dp.thunder_level = fused`, Z. 143-144) — ein bereits vorhandener Wert bleibt
+sonst erhalten, analog dem Bestandsverhalten.
+
+**D5 — Kein Signalname im Kern-Dispatch.** Die neuen Aufrufe leben in
+`_fuse_thunder_levels()`, **nicht** in `enrich_thunder()` selbst — der von
+`test_ac9_der_kern_dispatch_kennt_keine_quelle_und_kein_einzelnes_signal`
+bewachte Funktionskörper wird nicht angefasst. Die vier Signalnamen
+(`"wettercode"` usw.) stehen ausschließlich in `metric_format.py`
+(`THUNDER_SIGNAL_LABEL_DE`, `_signal_levels()`), nicht im Dispatch von
+`thunder_enrichment.py`.
+
+**D6 — Tagesaggregat: Vereinigung über die Stunden des Maximums, nicht nur
+eine.** `WeatherMetricsService._compute_thunder_level()`
+(`weather_metrics.py:590-609`) bleibt unverändert (liefert weiterhin nur die
+Stufe). Neue private Methode `_compute_thunder_level_signals(timeseries,
+thunder_max) -> list[str]`: sammelt `dp.thunder_level_signals` **aller**
+Datenpunkte, deren `dp.thunder_level == thunder_max`, dedupliziert unter
+Erhalt der ersten Auftrittsreihenfolge. Grund für die Vereinigung statt
+„erste passende Stunde": erreichen zwei verschiedene Stunden desselben Tages
+dieselbe Höchststufe über unterschiedliche Zutaten (z. B. 14 Uhr CAPE, 18 Uhr
+Blitzpotenzial), nennt der Ortsvergleich beide — sonst würde eine willkürlich
+gewählte einzelne Stunde über die angezeigte Herkunft entscheiden.
+`compute_metrics()` (Z. 437-479) ruft die neue Methode auf und trägt das
+Ergebnis in ein neues `SegmentWeatherSummary.thunder_level_max_signals:
+Optional[list[str]] = None` ein (`aggregation_config`-Eintrag:
+`"thunder_level_max_signals": "union_of_max_carriers"`, analog dem
+bestehenden `"hail_flag": "hail_priority"`-Muster).
+
+**D7 — Kein neues `LocationResult`-Feld, aber Herkunft und Stufe MÜSSEN aus
+derselben Rechnung stammen.** 🔴 Das Muster `hail_flag` trägt hier **nicht
+ungeprüft**: `app/user.py::LocationResult` hat für `hail_flag` kein eigenes
+Feld, weshalb `loc_hail_flag()` strukturell immer live ableitet — **für
+Gewitter ist das anders.** `LocationResult.thunder_level_max` **existiert**
+als echtes Feld (Issue #1285, `user.py`), und `_metric_value()`
+(`compare_html.py:630-642`) gibt dem Engine-Wert **Vorrang** vor der
+Live-Ableitung. Ein `loc_thunder_signals()`, das blind live ableitet, würde
+also eine Stufe aus dem Engine-Lauf mit einer Herkunft aus einer **zweiten,
+unabhängigen Rechnung** paaren — „hoch" von der Engine, „· CAPE" aus
+`summarize_points(loc.hourly_data)`. Das ist keine theoretische Kante: es ist
+genau der Fehler „Prüfort ≠ Wirkort", nur als Produktaussage.
+
+**Regel:** `loc_thunder_signals(loc, summary=None) -> Optional[list[str]]`
+leitet aus `_daily_summary(loc)` ab (kein neues Feld an `LocationResult`,
+`services/comparison_engine.py` bleibt unangetastet) und gibt die Träger
+**nur dann** zurück, wenn die live abgeleitete `thunder_level_max` **gleich**
+der angezeigten Stufe ist. Weichen sie ab oder fehlt eine von beiden, liefert
+die Funktion `None` und es erscheint **kein** Herkunfts-Zusatz. „Keine
+Aussage" statt einer Aussage, die nicht zur gezeigten Zahl gehört (ADR-0048,
+ADR-0007). Der Normalfall — Engine-Lauf und `hourly_data` desselben
+Datenstands — erfüllt die Bedingung und zeigt die Herkunft.
+
+**D8 — Rendering: additiver dritter Parameter, SMS aktiv ausgeschlossen.**
+`_fmt_thunder(v, hail=None, signals=None)` (`compare_html.py:204-219`) hängt
+bei vorhandenen `signals` einen zweiten `·`-Abschnitt an, VOR einem
+eventuellen Hagel-Hinweis: `f"{label} · {carrier_text}"` bzw.
+`f"{label} · {carrier_text} · {hail_note}"`, wenn beides vorliegt. Alte
+Aufrufer mit 1-2 Positionsargumenten bleiben zeichengleich (Default `None`).
+Zwei Aufrufwege:
+- **HTML-Übersichtszeile** (`_render_overview_row()`, Z. 703-707): dritter
+  Positionsparameter `loc_thunder_signals(loc, summaries.get(id(loc)))`.
+- **Klartext + Telegram** über `_fmt_overview_cell(fmt, value, loc_result, *,
+  include_origin=False)` (comparison.py:503-515, neuer Keyword-Parameter):
+  ruft bei `fmt is _fmt_thunder` und `include_origin=True` zusätzlich
+  `loc_thunder_signals(loc_result)` auf. Die Klartext-Übersichtszeile
+  (Z. 246) und `_plain_metric_cell()` (Telegram, Z. 632-644) setzen
+  `include_origin=True`. `_sms_metric_cell()` (Z. 605-629) lässt den
+  Parameter **ausdrücklich mit Kommentar** auf `False` — z. B.
+  `_fmt_overview_cell(fmt, value, loc_result)  # Issue #1680: SMS bewusst OHNE Herkunft`
+  — eine reine Default-Belassung ohne Kommentar wäre nicht von einem
+  vergessenen Anschluss unterscheidbar (PO-Vorgabe „aktiv abgewählt, nicht
+  stillschweigend ausgelassen").
+
+**D9 — Persistenz: reine `list[str]`, kein Enum.**
+`weather_snapshot.py::_serialize_summary()`/`_serialize_segment()`
+serialisieren generisch über `vars()` und prüfen nur `isinstance(value, Enum)`
+für Skalare (Z. 232-243, 289-295) — ein `list[str]`-Feld durchläuft
+`json.dumps` unverändert korrekt, **ohne** Änderung an `weather_snapshot.py`.
+Die Falle (Kontext-Dokument, Landmine 1) gilt nur, wenn das Feld ein `set`
+oder eine Liste von **Enum-Membern** wäre — deshalb sind
+`thunder_level_signals`/`thunder_level_max_signals` bewusst als `list[str]`
+(reine Strings, die in D1-D2 erzeugten Schlüssel) typisiert, nie als
+`list[ThunderLevel]`. `_deserialize_summary()` filtert unbekannte Schlüssel
+(Z. 246-262) — ein alter Schnappschuss ohne das Feld lädt unverändert mit
+`thunder_level_max_signals=None`. `_deserialize_timeseries()` filtert
+**nicht** (Z. 301-324, `ForecastDataPoint(ts=..., **kwargs)`) — das betrifft
+nur ein künftiges **Entfernen** des Feldes, nicht diese Scheibe (additiv).
+
+## Expected Behavior
+
+- **Input:** ein `ComparisonResult` mit mindestens zwei `LocationResult`s,
+  deren `hourly_data` `ForecastDataPoint`s mit unterschiedlichen
+  Gewitter-Rohwerten trägt (z. B. ein Ort mit CAPE-Werten oberhalb der
+  Leiter, ein anderer mit Blitzdichte oberhalb der Leiter), durch die echte
+  Anreicherung (`thunder_enrichment.enrich_thunder()`) oder äquivalent
+  vorbelegt.
+- **Output:** die Gewitter-Zeile der Ortsvergleich-Übersicht (HTML, Klartext,
+  Telegram) zeigt neben der Stufe die tragende(n) Zutat(en); SMS/Premium-SMS
+  zeigen nur die Stufe.
+- **Side effects:** zwei neue additive Felder in Wetter-Schnappschüssen
+  (Trip UND Compare, da geteilte Fusion, ADR-0025) — für Trip-Renderer
+  unsichtbar (sie lesen die Felder in dieser Scheibe nicht).
+
+## Acceptance Criteria
+
+- **AC-1:** Given zwei Orte im Ortsvergleich tragen ihre „hoch"-Gewitterstufe
+  über unterschiedliche Zutaten (ein Alpen-Ort über CAPE, ein Korsika-Ort
+  über Blitzdichte), When die HTML-Vergleichsmail versendet wird, Then zeigt
+  die Gewitter-Zeile für jeden Ort einzeln die jeweils tragende Zutat, z. B.
+  „hoch · CAPE" bzw. „hoch · Blitzdichte" — nicht dieselbe Angabe für beide.
+  - Test: `render_compare_email()` mit einer Fixture, die über die echte
+    Fusion (`enrich_thunder`) läuft; Assertion auf beide Teilstrings im
+    zurückgegebenen `html_body`, je Ortsblock getrennt geprüft.
+
+- **AC-2:** Given an einem Ort tragen zwei Zutaten gemeinsam dieselbe
+  Höchststufe (z. B. CAPE UND Blitzpotenzial erreichen beide „hoch"), When
+  die Gewitter-Zeile gerendert wird, Then werden BEIDE genannt,
+  kommagetrennt („hoch · CAPE, Blitzpotenzial") — es wird kein Gewinner
+  gekürt, auch wenn eine Zutat in der internen Prüfreihenfolge zuerst käme.
+  - Test: Fixture mit CAPE- und LPI-Rohwerten, die beide auf die
+    Höchststufe führen; Assertion, dass der Zellentext beide Labels enthält.
+
+- **AC-3:** Given ein Ort zeigt „kein" Gewitter (keine Zutat liefert eine
+  Stufe über NONE), When die Gewitter-Zeile gerendert wird, Then erscheint
+  KEIN Herkunfts-Zusatz — die Zeile bleibt wie vor dieser Änderung.
+  - Test: Fixture ohne jedes Gewittersignal; Assertion, dass der Zellentext
+    keinen `·`-Zusatz trägt.
+
+- **AC-4:** Given der Ortsvergleich wird als Telegram-Nachricht gesendet,
+  When der Nutzer die Nachricht liest, Then zeigt die Gewitter-Zeile
+  dieselbe Herkunfts-Angabe wie die E-Mail (Fließtext statt Farbzelle, aber
+  inhaltsgleich).
+  - Test: `render_compare_telegram()` mit derselben Fixture wie AC-1;
+    Assertion auf denselben Teilstring im zurückgegebenen Text.
+
+- **AC-5:** Given der Ortsvergleich wird als SMS gesendet, When der Nutzer die
+  Nachricht liest, Then zeigt die Nachricht weiterhin die Gewitterstufe
+  selbst, aber KEINE Herkunfts-Angabe — kein `CAPE`, kein `Blitzpotenzial`,
+  kein `Blitzdichte`, kein `Wettercode` im SMS-Text. (Premium-SMS ist im
+  Ortsvergleich-Briefing heute nicht verdrahtet, s. Known Limitations 6 —
+  sobald sie es wird, erbt sie über denselben Renderer denselben Ausschluss.)
+  - Test: `render_compare_sms()` mit derselben Fixture wie AC-1; Assertion,
+    dass die Gewitter-Zelle die Stufen-Abkürzung trägt, aber keinen der vier
+    Zutat-Strings.
+
+- **AC-6:** Given ein Ort hat gleichzeitig ein bestätigtes Hagel-Kennzeichen
+  UND eine Gewitter-Herkunft, When die E-Mail gerendert wird, Then stehen
+  beide Zusätze nebeneinander (z. B. „hoch · CAPE · Hagel: ja"), ohne dass
+  einer den anderen verdrängt.
+  - Test: Fixture mit `hail_flag=True` UND CAPE-Herkunft; Assertion auf
+    beide Teilstrings im `html_body`.
+
+- **AC-7:** Given ein Ort im DWD-Gebiet EU_REST, dessen Gewitterstufe
+  ausschließlich über Blitzpotenzial (LPI, unbelegte Interim-Schwelle)
+  erreicht wird, When die Herkunft angezeigt wird, Then erscheint
+  ausschließlich das Wort „Blitzpotenzial" — ohne Eichungs-Hinweis, ohne
+  Handlungsempfehlung, ohne Bewertung der Schwellen-Güte.
+  - Test: Fixture mit LPI-Region EU_REST, nur LPI oberhalb der Leiter;
+    Assertion auf exakten Zellentext.
+
+- **AC-8:** Given ein bereits versendeter Wetter-Schnappschuss enthält die
+  neue Herkunfts-Angabe, When er zu einem späteren Zeitpunkt aus der
+  Persistenz geladen und erneut für den Ortsvergleich verwendet wird, Then
+  liefert das Laden dieselbe Herkunfts-Angabe zurück, ohne dass der
+  Schnappschuss durch einen Serialisierungsfehler verloren geht.
+  - Test: Roundtrip über die echten `weather_snapshot`-Serialisierungs-/
+    Deserialisierungsfunktionen mit einem `SegmentWeatherSummary`, dessen
+    `thunder_level_max_signals` gesetzt ist; Assertion auf Gleichheit vor/
+    nach dem Roundtrip UND darauf, dass `json.dumps` nicht scheitert (kein
+    `logger.warning`-Pfad ausgelöst).
+
+- **AC-9:** Given ein alter, vor dieser Änderung erzeugter Wetter-
+  Schnappschuss ohne das neue Feld wird geladen, When die Vergleichsmail
+  gerendert wird, Then erscheint die Gewitterstufe unverändert, nur ohne
+  Herkunfts-Zusatz — kein Fehler, kein Absturz.
+  - Test: Deserialisierung eines Dict ohne den neuen Schlüssel; Assertion,
+    dass `thunder_level_max_signals is None` und der Renderaufruf nicht
+    wirft.
+
+- **AC-10:** Given die Gewitterstufe eines Tages entsteht aus mehreren
+  Stunden (Ortsvergleich zeigt den Tageswert), und zwei verschiedene Stunden
+  erreichen dieselbe Tages-Höchststufe über unterschiedliche Zutaten, When
+  die Vergleichsmatrix gerendert wird, Then nennt sie BEIDE Zutaten, nicht
+  nur die einer einzelnen (z. B. der ersten) Stunde.
+  - Test: Fixture mit zwei Stunden desselben Tages — Stunde A nur CAPE über
+    der Leiter, Stunde B nur LPI über derselben Höchststufe — durch die
+    echte Aggregation (`compute_metrics()`/`summarize_points()`); Assertion
+    auf beide Labels im gerenderten Ergebnis.
+
+- **AC-11:** Given der Trip-Bericht (Stundentabelle, Kurzzusammenfassung,
+  Mehrtages-Ausblick) sowie die Compare-Stundentabelle, When #1680 Scheibe 1
+  ausgeliefert ist, Then bleiben alle unverändert — kein Herkunfts-Zusatz
+  dort; diese Scheibe ändert ausschließlich die Ortsvergleich-Tagesübersicht
+  (E-Mail + Telegram).
+  - Test: bestehender Trip-Rendertest (Golden-Output-Vergleich oder
+    Teilstring-Abwesenheitsprüfung) bleibt unverändert grün; zusätzliche
+    Assertion, dass die Compare-Stundentabelle (`_render_hour_row`) keine
+    Zutat-Strings enthält.
+
+- **AC-12:** Given die im Ortsvergleich angezeigte Gewitterstufe stammt aus
+  dem Engine-Lauf (Feld `LocationResult.thunder_level_max`) und weicht von
+  der Stufe ab, die sich aus den Stundenwerten desselben Ortes ergibt, When
+  die Gewitter-Zeile gerendert wird, Then erscheint die Stufe unverändert,
+  aber KEIN Herkunfts-Zusatz — der Nutzer bekommt nie eine Herkunft
+  angezeigt, die zu einer anderen als der gezeigten Stufe gehört.
+  - Test: `LocationResult` mit `thunder_level_max=HIGH` gesetzt, während die
+    `hourly_data` nur auf MED führen; Assertion, dass „hoch" erscheint und
+    keiner der vier Zutat-Strings. Gegenprobe im selben Test: stimmen beide
+    überein, erscheint die Herkunft sehr wohl (sonst wäre das AC auch grün,
+    wenn die Herkunft nie angezeigt würde).
+
+## Testplan
+
+**Kern-Schicht** (deterministisch, ohne Netz, echte Fusions-/Aggregations-
+/Renderpfade — kein Mock-Theater): ein neues Testmodul
+`tests/tdd/test_thunder_origin_compare.py` (nach Verhalten benannt) deckt
+AC-1 bis AC-7, AC-10, AC-11 über die echten Renderfunktionen
+(`render_compare_email`, `render_compare_telegram`, `render_compare_sms`).
+Ein zweites, schmales Modul (oder ein eigener Abschnitt im selben Modul)
+deckt AC-8/AC-9 über `services.weather_snapshot` direkt (Roundtrip,
+Alt-Schnappschuss-Kompatibilität).
+
+**Prüfort = Wirkort:** kein AC wird ausschließlich gegen
+`thunder_level_from_signals()`/`thunder_signal_carriers()` isoliert geprüft
+— jeder Nachweis läuft mindestens einmal durch die vollständige Kette bis
+zur zurückgegebenen `html_body`/`text_body`/Telegram-/SMS-Zeichenkette.
+
+### Pflicht-Mutationsproben (mindestens 3, hier 5)
+
+- **(a) Trägerfilter entfernen** (`thunder_signal_carriers()`: statt
+  `werte[name] == top` alle Schlüssel zurückgeben) ⇒ AC-2/AC-3 MÜSSEN rot
+  werden — bei „kein" erschiene plötzlich ein Zusatz, bei einem
+  Einzel-Träger erschienen fälschlich alle vier möglichen Namen.
+- **(b) `include_origin=True` am Klartext-/Telegram-Aufruf entfernen**
+  (Default `False` überall) ⇒ AC-1 (Klartext-Teil derselben Mail) UND AC-4
+  MÜSSEN rot werden — beweist, dass AC-5 (SMS-Abwesenheit) nicht deshalb grün
+  ist, weil die Herkunft überall abgeschaltet wäre.
+- **(c) `_sms_metric_cell()` auf `include_origin=True` umstellen** ⇒ AC-5
+  MUSS rot werden — das ist die zentrale Gegenprobe zur PO-Vorgabe „aktiv
+  abgewählt, nicht stillschweigend ausgelassen".
+- **(d) `_compute_thunder_level_signals()` auf „nur erste passende Stunde"
+  zurückbauen** (kein `continue`-Sammeln über alle Stunden, sondern
+  `break` nach dem ersten Treffer) ⇒ AC-10 MUSS rot werden.
+- **(e0) Kohärenz-Bedingung aus `loc_thunder_signals()` entfernen** (Träger
+  auch dann zurückgeben, wenn die live abgeleitete Stufe von der angezeigten
+  abweicht) ⇒ AC-12 MUSS rot werden — sonst bewacht nichts die Zusicherung,
+  dass Stufe und Herkunft aus derselben Rechnung stammen.
+- **(e) Feldtyp probeweise auf `set[str]` statt `list[str]` ändern** (an
+  einer Kopie, s. Mutations-Protokoll unten) ⇒ AC-8 MUSS rot werden — der
+  Roundtrip-Test muss den Verlust erkennen (Snapshot lädt nach dem
+  Serialisierungsfehler leer/`None` statt der ursprünglichen Liste), nicht
+  nur prüfen, dass kein Python-`Exception` nach außen dringt (der
+  Bestandscode schluckt den Fehler in `logger.warning`).
+
+Mutationen ausschließlich per String-Ersetzung mit externer Sicherungskopie
+(kein `git checkout`/`stash`/`reset`, CLAUDE.md-Vorgabe).
+
+## Known Limitations
+
+1. **`sdi_2` (Superzellen) bleibt außen vor.** Die Fusion hat vier, nicht
+   fünf Zutaten — das Issue-Beispiel „hoch, Blitzpotenzial+Superzelle" ist
+   am Code nicht baubar (Kontext-Dokument, Befund). Diese Scheibe erfindet
+   keine fünfte Zutat.
+2. **EU_REST-LPI ist ein ausgewiesener Interim-Wert** (unbelegte Schwelle,
+   Feineichung offen als #1678, ADR-0048). Das Label „Blitzpotenzial" nennt
+   NUR, welche Zutat die Stufe erreicht hat — es ist keine Aussage über die
+   Güte der Eichung (ADR-0007). Keine Sonderkennzeichnung in dieser Scheibe.
+3. **Bei Drift zwischen Engine-Wert und Live-Ableitung entfällt die Herkunft
+   (D7, AC-12).** `thunder_level_max_signals` steht bewusst nicht am
+   `LocationResult` der Comparison-Engine, sondern wird live aus
+   `hourly_data` abgeleitet. Weicht die live abgeleitete Stufe vom
+   Engine-Wert ab, zeigt der Ortsvergleich die Stufe **ohne** Herkunft.
+   Bewusster Verzicht: lieber keine Angabe als eine, die zu einer anderen
+   Stufe gehört. Wer die Herkunft auch in diesem Fall sehen will, braucht ein
+   Engine-Feld an `LocationResult` — eigene Scheibe, nicht diese.
+6. **Premium-SMS ist im Ortsvergleich-Briefing nicht verdrahtet.**
+   `comparison.py` kennt keinen Premium-SMS-Zweig; der Kanal wird heute nur
+   im **Alarm**-Pfad aufgelöst (`compare_alert_channels.py:44-45`, #1745).
+   Ein Herkunfts-Zusatz kann dorthin also gar nicht lecken. Sobald der
+   Ortsvergleich Premium-SMS bedient, erbt er über `render_compare_sms()`
+   denselben Ausschluss — die PO-Entscheidung „SMS und Premium-SMS ohne
+   Herkunft" ist damit auch vorwärts erfüllt.
+4. **Ko-Auftretensrate Wettercode/andere Signale bleibt ungemessen**
+   (Kontext-Dokument Befund B) — mit Auslegung (ii) irrelevant für die
+   Anzeige (alle Träger erscheinen ohnehin), aber die Häufigkeit, wie oft
+   der binäre Wettercode zusammen mit CAPE/LPI/Blitzdichte auf derselben
+   Stunde HIGH meldet, ist mit Bordmitteln weiterhin nicht messbar.
+5. **`_deserialize_timeseries()` filtert unbekannte Schlüssel nicht**
+   (`weather_snapshot.py:301-324`). Unkritisch für diese additive Änderung
+   (Hinzufügen ist sicher), aber ein künftiges Entfernen des Feldes bräuchte
+   eine explizite Migration.
+
+## Nicht in dieser Scheibe
+
+- **Compare-Stundentabelle** (HTML `_render_hour_row`, Z. 937-938; Klartext
+  Z. 327-331): zeigt weiterhin nur Stufe + Hagel, keine Herkunft. Begründung:
+  LoC-Budget (`_fmt_thunder`s dritter Parameter ist bereits vorbereitet —
+  additiver Ein-Zeiler je Aufrufstelle als natürlicher Folge-Schnitt, kein
+  struktureller Umbau nötig) UND der primäre Issue-Zweck (Vergleichbarkeit
+  zwischen Orten) wird bereits von der Tagesübersicht bedient, die als
+  Erstes und am prominentesten gelesen wird.
+- **Trip-Mail-Pill, Nachtblock, Kurzzusammenfassung, Mehrtages-Ausblick,
+  GEWITTER-Kommando** (Trip-Seite) — PO-Entscheidung, eigene Scheibe.
+- **Go-DTO / Frontend** — kein Frontend-Ort rendert heute eine
+  Gewitterstufen-Beschriftung; optional für eine spätere Scheibe.
+- **`services/comparison_engine.py`** — bewusst unverändert (D7).
+- **Fünfte Fusions-Zutat, Radar-Nowcast (E3), Superzellen (`sdi_2`)** — nicht
+  Teil dieser Scheibe, s. Known Limitations 1.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine (neue) — diese Scheibe wendet ADR-0007 (Daten statt
+  Empfehlungen), ADR-0025 (eine Gewitter-Quelle für alle Kanäle) und
+  ADR-0048 (unbekannte/ungeeichte Herkunft = keine Aussage) an, ohne eine
+  davon zu ändern.
+- **Rationale:** Kein neues Architekturprinzip — additive Sichtbarmachung
+  einer bereits vorhandenen internen Größe (welche Zutat trug), keine neue
+  Datenquelle, kein neuer Kanal, keine neue Persistenz-Strategie.
+  ⚠️ **Nicht zu verwechseln mit ADR-0034** (Herkunfts-Fußzeile zeigt die
+  reale Datenquelle/Provider) — das ist eine andere Dimension (WELCHER
+  Provider lieferte die Daten), diese Scheibe fragt nach dem AUSLÖSENDEN
+  SIGNAL innerhalb der bereits gelieferten Daten.
+
+## Changelog
+
+- 2026-08-12: Initial spec created (Issue #1680, Scheibe 1). Grundlage:
+  `docs/context/feat-1680-thunder-herkunft.md`, PO-Entscheidungen vom
+  2026-08-11.
+- 2026-08-12 (Korrektur vor Freigabe, am Code nachgemessen): D7 lag falsch.
+  Die Annahme „wie `hail_flag`, also immer live abgeleitet" trägt für Gewitter
+  nicht — `LocationResult.thunder_level_max` **existiert** als Feld (#1285)
+  und `_metric_value()` gibt ihm Vorrang. Ohne Kohärenz-Bedingung hätte die
+  Zeile eine Stufe aus dem Engine-Lauf mit einer Herkunft aus einer zweiten
+  Rechnung gepaart. Ergänzt: AC-12, Mutationsprobe (e0), Known Limitation 3
+  neu gefasst. AC-5 auf SMS präzisiert (Premium-SMS im Ortsvergleich-Briefing
+  nicht verdrahtet → Known Limitation 6).

--- a/docs/specs/modules/feat_1680_s1_gewitter_herkunft_ortsvergleich.md
+++ b/docs/specs/modules/feat_1680_s1_gewitter_herkunft_ortsvergleich.md
@@ -457,6 +457,26 @@ Mutationen ausschließlich per String-Ersetzung mit externer Sicherungskopie
    (Hinzufügen ist sicher), aber ein künftiges Entfernen des Feldes bräuchte
    eine explizite Migration.
 
+7. 🔴 **`aggregate_stage()` kennt die Regel `union_of_max_carriers` nicht**
+   (`src/services/weather_metrics.py`, generischer `else`-Zweig ⇒ `values[0]`).
+   Auf **Etappen**-Ebene gewönne damit die Herkunft des **ersten** Segments,
+   während `thunder_level_max` per MAX über alle Segmente aggregiert — Stufe
+   und Herkunft könnten dort aus verschiedenen Segmenten stammen.
+   **Heute nicht erreichbar** (Adversary Runde 3, vollständige Grep-Analyse
+   aller Lesestellen): der einzige Produktiv-Lesepunkt ist
+   `compare_html.py` → `loc_thunder_signals()` → `_daily_summary()` →
+   `summarize_points()`, der `aggregate_stage()` strukturell umgeht; die drei
+   Aufrufer von `aggregate_stage()` lesen die Trägerliste nicht, und
+   `trip_alert.py`/`compare_alert.py` nutzen ausschließlich
+   `thunder_level_max`.
+   **Tech-Lead-Entscheid 2026-08-12: dokumentieren statt bauen.** Ein
+   Aggregations-Zweig für einen Verbraucher, den es nicht gibt, wäre Code
+   ohne Wirkort — und ein Test darauf bewachte nichts. ⚠️ **Die Scheibe, die
+   die Herkunft auf die Trip-Seite bringt, MUSS das zuerst lösen** — dort
+   entsteht der zweite Verbraucher. Präzedenz derselben Fehlerklasse im
+   selben `else`-Zweig: #1592 F003 (`cape_model_id`), dort war der zweite
+   Verbraucher bereits da und der Befund echt.
+
 ## Nicht in dieser Scheibe
 
 - **Compare-Stundentabelle** (HTML `_render_hour_row`, Z. 937-938; Klartext

--- a/docs/specs/modules/feat_1680_s1_gewitter_herkunft_ortsvergleich.md
+++ b/docs/specs/modules/feat_1680_s1_gewitter_herkunft_ortsvergleich.md
@@ -19,7 +19,7 @@ tags: [thunder, compare, adr-0007, adr-0025, adr-0048, issue-1680, issue-1419]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO, 2026-08-12 („freigabe")
 
 ## Purpose
 

--- a/docs/specs/modules/feat_1680_s1_gewitter_herkunft_ortsvergleich.md
+++ b/docs/specs/modules/feat_1680_s1_gewitter_herkunft_ortsvergleich.md
@@ -48,10 +48,16 @@ oder eine Empfehlung daraus abzuleiten (ADR-0007).
 - **File:** `src/app/models.py` — `ForecastDataPoint` (Z. 99 ff.),
   `SegmentWeatherSummary` (Z. 405 ff.)
 - **File:** `src/services/weather_metrics.py` — `_compute_thunder_level()`
-  (Z. 590-609), `compute_metrics()` (Z. 396-492)
+  (Z. 590-609), `compute_basis_metrics()` (Z. 398 ff.) und der Compare-Wrapper
+  `summarize_points()` (Z. 1071)
 - **File:** `src/output/renderers/email/compare_html.py` — `_fmt_thunder()`
   (Z. 204-219), neue `loc_thunder_signals()` (analog `loc_hail_flag()`,
   Z. 643-658), Aufrufstelle `_render_overview_row()` (Z. 703-707)
+  - 🔴 **`_fmt_thunder` speist auch die Compare-Stundentabelle** (steht in
+    `_HOUR_FMT_OVERRIDES["thunder"]`, Z. 390). Ein Zusatz, der **im Rumpf**
+    von `_fmt_thunder` statt über den neuen dritten Parameter entsteht,
+    leckt sofort dorthin — genau das bewacht AC-11. In der RED-Phase
+    nachgemessen.
 - **File:** `src/output/renderers/comparison.py` — `_fmt_overview_cell()`
   (Z. 503-515), Aufrufstellen Z. 246 (Klartext-Übersicht),
   `_plain_metric_cell()` (Z. 632-644, Telegram), `_sms_metric_cell()`
@@ -62,9 +68,12 @@ oder eine Empfehlung daraus abzuleiten (ADR-0007).
 
 ## Estimated Scope
 
-- **LoC:** ~145-165 Quellcode + ~80-110 Tests, geschätzt **~225-250** gesamt
-  (Limit 250 je Workflow — **knapp**, s. „Nicht in dieser Scheibe" für den
-  ersten Kürzungs-Kandidaten, falls die Umsetzung darüber liegt).
+- **LoC:** ~145-165 Quellcode + **365 Tests (gemessen, nicht geschätzt)**.
+  🔴 Die ursprüngliche Test-Schätzung „~80-110" war zu optimistisch: zwölf
+  ACs, die jedes einmal durch die vollständige Kette bis zum zurückgegebenen
+  Body laufen, sind darin nicht darstellbar. Eine Kürzungsrunde brachte
+  423 → 365 Zeilen ohne Verlust einer Assertion. Gesamt damit **~510-530**
+  gegen ein Limit von 250 ⇒ `loc_limit_override` erforderlich (PO-Entscheid).
 - **Files:** 6 Quelldateien (s. Source) + 1-2 neue Testdateien, nach
   Verhalten benannt (nicht nach Issue-Nummer).
 - **Effort:** medium. Kein Breaking Change (additiv, s. D1/D2), kein
@@ -118,8 +127,17 @@ werte = _signal_levels(...)
 if not werte:
     return []
 top = max_thunder(werte.values())
+if top == ThunderLevel.NONE:      # 🔴 s. Korrektur unten
+    return []
 return [name for name in werte if werte[name] == top]
 ```
+
+🔴 **Korrektur 2026-08-12 (in der RED-Phase am Code gefunden):** Die
+`NONE`-Abfrage fehlte in der ersten Fassung. Ohne sie liefert die Funktion bei
+Stufe „kein" die Träger mit und der Ortsvergleich zeigte `— · CAPE` — ein
+Widerspruch zu AC-3. Ob die Unterdrückung hier oder in
+`loc_thunder_signals()` sitzt, ist frei; geprüft wird die **Wirkung** (kein
+Zusatz bei NONE), nicht der Ort.
 
 Löst Befund A (Gleichstands-Reihenfolge, Kontext-Dokument) auf: weil nichts
 gekürt wird, ist die interne `if`-Reihenfolge der Fusion keine Produktaussage
@@ -168,7 +186,9 @@ Erhalt der ersten Auftrittsreihenfolge. Grund für die Vereinigung statt
 dieselbe Höchststufe über unterschiedliche Zutaten (z. B. 14 Uhr CAPE, 18 Uhr
 Blitzpotenzial), nennt der Ortsvergleich beide — sonst würde eine willkürlich
 gewählte einzelne Stunde über die angezeigte Herkunft entscheiden.
-`compute_metrics()` (Z. 437-479) ruft die neue Methode auf und trägt das
+`compute_basis_metrics()` (Z. 398 ff., **nicht** `compute_metrics()` — die
+Funktion dieses Namens gibt es nicht; in der RED-Phase nachgemessen) ruft die
+neue Methode auf und trägt das
 Ergebnis in ein neues `SegmentWeatherSummary.thunder_level_max_signals:
 Optional[list[str]] = None` ein (`aggregation_config`-Eintrag:
 `"thunder_level_max_signals": "union_of_max_carriers"`, analog dem
@@ -331,7 +351,7 @@ nur ein künftiges **Entfernen** des Feldes, nicht diese Scheibe (additiv).
   nur die einer einzelnen (z. B. der ersten) Stunde.
   - Test: Fixture mit zwei Stunden desselben Tages — Stunde A nur CAPE über
     der Leiter, Stunde B nur LPI über derselben Höchststufe — durch die
-    echte Aggregation (`compute_metrics()`/`summarize_points()`); Assertion
+    echte Aggregation (`compute_basis_metrics()`/`summarize_points()`); Assertion
     auf beide Labels im gerenderten Ergebnis.
 
 - **AC-11:** Given der Trip-Bericht (Stundentabelle, Kurzzusammenfassung,
@@ -473,6 +493,14 @@ Mutationen ausschließlich per String-Ersetzung mit externer Sicherungskopie
 - 2026-08-12: Initial spec created (Issue #1680, Scheibe 1). Grundlage:
   `docs/context/feat-1680-thunder-herkunft.md`, PO-Entscheidungen vom
   2026-08-11.
+- 2026-08-12 (RED-Phase, am Code nachgemessen — drei sachliche Korrekturen
+  ohne AC-Aenderung): `compute_metrics()` gibt es nicht, richtig ist
+  `compute_basis_metrics()` + Wrapper `summarize_points()` · die
+  Pseudo-Implementierung in D2 lieferte bei Stufe NONE die Traeger mit und
+  widersprach damit AC-3 (`NONE`-Abfrage ergaenzt) · `_fmt_thunder` speist
+  ueber `_HOUR_FMT_OVERRIDES` auch die Compare-Stundentabelle, ein Zusatz im
+  Funktionsrumpf leckt dorthin. Test-LoC von Schaetzung 80-110 auf gemessene
+  365 berichtigt.
 - 2026-08-12 (Korrektur vor Freigabe, am Code nachgemessen): D7 lag falsch.
   Die Annahme „wie `hail_flag`, also immer live abgeleitet" trägt für Gewitter
   nicht — `LocationResult.thunder_level_max` **existiert** als Feld (#1285)

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -194,6 +194,15 @@ class ForecastDataPoint:
     #                          S5b/S5c (DWD-Schwelle bzw. Meteo-France AROME)
     hail_flag: Optional[bool] = None
 
+    # Issue #1680 S1: WELCHE Zutaten die fusionierte `thunder_level` dieser
+    # Stunde tragen (Schluessel aus `metric_format.THUNDER_SIGNAL_LABEL_DE`).
+    # BEWUSST `list[str]`, nie `list[ThunderLevel]` oder `set`: die
+    # Schnappschuss-Serialisierung behandelt nur SKALARE Enums, alles andere
+    # bricht `json.dumps` -- und der Fehler wird dort still geschluckt
+    # (`weather_snapshot.py`), der Schnappschuss waere weg. `None` heisst
+    # "keine Aussage", eine leere Liste "keine tragende Zutat".
+    thunder_level_signals: Optional[list[str]] = None
+
     # Issue #435: Test-helper alias — some test helpers init with
     # `wind_dir_deg=` instead of `wind_direction_deg=`. We accept both;
     # __post_init__ canonicalises to wind_direction_deg.
@@ -414,6 +423,11 @@ class SegmentWeatherSummary:
     cloud_avg_pct: Optional[int] = None
     humidity_avg_pct: Optional[int] = None
     thunder_level_max: Optional[ThunderLevel] = None
+    # Issue #1680 S1: Vereinigung der Zutaten ALLER Stunden, die
+    # `thunder_level_max` erreichen (Aggregationsregel
+    # "union_of_max_carriers"). Feldtyp `list[str]` aus demselben Grund wie
+    # `ForecastDataPoint.thunder_level_signals` -- s. dort.
+    thunder_level_max_signals: Optional[list[str]] = None
     visibility_min_m: Optional[int] = None
 
     # Extended metrics (Feature 2.2b) - ALL None for Feature 2.1

--- a/src/output/metric_format.py
+++ b/src/output/metric_format.py
@@ -366,6 +366,124 @@ def _gedaempft_durch_cin(
     return ThunderLevel.NONE
 
 
+# Die vier Zutaten der Fusion, deutsch beschriftet (Issue #1680 S1). Die
+# Einfuegereihenfolge in `_signal_levels()` ist zugleich die Nenn-Reihenfolge
+# der Herkunft -- deterministisch, ohne zweites Sortier-Vokabular.
+# NICHT zu verwechseln mit `thunder_enrichment._SIGNAL_ZU_FELD`: das ist das
+# Rohwert-Routing der Quellen (`"lpi"`, `"cin_ml"`, ...), eine andere Ebene.
+THUNDER_SIGNAL_LABEL_DE: dict[str, str] = {
+    "wettercode": "Wettercode",
+    "blitzdichte": "Blitzdichte",
+    "cape": "CAPE",
+    "blitzpotenzial": "Blitzpotenzial",
+}
+
+
+def thunder_signal_label(name: str) -> str:
+    """Deutsche Beschriftung EINER Fusions-Zutat (Issue #1680 S1).
+
+    Exakt-Treffer zuerst, sonst der rohe Name selbst -- nie ein erfundener
+    Ersatztext (Muster ``official_alert_source_label``, ADR-0007). Ohne
+    Heuristik-Stufe, weil die Signalmenge geschlossen ist (vier feste
+    Schluessel, kein Namensraum mit Praefix-Varianten).
+    """
+    return THUNDER_SIGNAL_LABEL_DE.get(name, name)
+
+
+def _signal_levels(
+    wettercode_level: Optional[ThunderLevel],
+    lightning_density: Optional[float],
+    cape_jkg: Optional[float],
+    lightning_potential_jkg: Optional[float] = None,
+    *,
+    cape_threshold_jkg: Optional[float],
+    cape_med_min: Optional[float],
+    cape_high_min: Optional[float],
+    cin_jkg: Optional[float],
+    lpi_low_min: Optional[float],
+    lpi_med_min: Optional[float],
+    lpi_high_min: Optional[float],
+) -> dict[str, ThunderLevel]:
+    """Die EINZELsignale der Fusion, je Zutat unter festem Schluessel
+    (Issue #1680 S1). Ein Signal, das nichts beitraegt (Wert fehlt ODER seine
+    Leiter ist unkalibriert), erscheint GAR NICHT -- "keine Aussage" ist kein
+    Eintrag mit Stufe ``NONE``.
+
+    Ausgelagert aus ``thunder_level_from_signals()``, damit die Stufe UND ihre
+    Herkunft aus EINER Rechnung stammen (keine zweite Fusionsregel neben der
+    kanonischen, ADR-0025).
+    """
+    levels: dict[str, ThunderLevel] = {}
+
+    if wettercode_level is not None:
+        levels["wettercode"] = wettercode_level
+
+    if lightning_density is not None:
+        levels["blitzdichte"] = _thunder_level_from_ladder(
+            lightning_density, _LIGHTNING_LOW_MIN, _LIGHTNING_MED_MIN, _LIGHTNING_HIGH_MIN,
+        )
+
+    if (cape_jkg is not None
+            and cape_threshold_jkg is not None
+            and cape_med_min is not None
+            and cape_high_min is not None):
+        levels["cape"] = _gedaempft_durch_cin(
+            _thunder_level_from_ladder(
+                cape_jkg, cape_threshold_jkg, cape_med_min, cape_high_min,
+            ),
+            cin_jkg,
+        )
+
+    if (lightning_potential_jkg is not None
+            and lpi_low_min is not None
+            and lpi_med_min is not None
+            and lpi_high_min is not None):
+        levels["blitzpotenzial"] = _thunder_level_from_ladder(
+            lightning_potential_jkg, lpi_low_min, lpi_med_min, lpi_high_min,
+        )
+
+    return levels
+
+
+def thunder_signal_carriers(
+    wettercode_level: Optional[ThunderLevel],
+    lightning_density: Optional[float],
+    cape_jkg: Optional[float],
+    lightning_potential_jkg: Optional[float] = None,
+    *,
+    cape_threshold_jkg: Optional[float],
+    cape_med_min: Optional[float],
+    cape_high_min: Optional[float],
+    cin_jkg: Optional[float],
+    lpi_low_min: Optional[float],
+    lpi_med_min: Optional[float],
+    lpi_high_min: Optional[float],
+) -> list[str]:
+    """Die Zutaten, die die fusionierte Stufe TRAGEN (Issue #1680 S1).
+
+    Dieselben Argumente wie ``thunder_level_from_signals()`` -- absichtlich
+    eine zweite Funktion statt eines Rueckgabetyp-Wechsels, damit die Signatur
+    der Fusion unveraendert bleibt.
+
+    Genannt wird JEDE Zutat, die die Hoechststufe erreicht (PO-Entscheidung
+    (ii)): es wird kein Gewinner gekuert, die interne Pruefreihenfolge ist
+    damit keine Produktaussage. ``NONE`` liefert eine LEERE Liste -- "kein
+    Gewitter" hat keine Herkunft ("— · CAPE" waere ein Widerspruch, Spec AC-3).
+    """
+    levels = _signal_levels(
+        wettercode_level, lightning_density, cape_jkg, lightning_potential_jkg,
+        cape_threshold_jkg=cape_threshold_jkg, cape_med_min=cape_med_min,
+        cape_high_min=cape_high_min, cin_jkg=cin_jkg, lpi_low_min=lpi_low_min,
+        lpi_med_min=lpi_med_min, lpi_high_min=lpi_high_min,
+    )
+    if not levels:
+        return []
+    top = max_thunder(levels.values())
+    if top == ThunderLevel.NONE:
+        return []
+    return [name for name, stufe in levels.items() if stufe == top]
+
+
 def thunder_level_from_signals(
     wettercode_level: Optional[ThunderLevel],
     lightning_density: Optional[float],
@@ -422,39 +540,20 @@ def thunder_level_from_signals(
     KEYWORD-ONLY OHNE DEFAULT, exakt wie ``cape_threshold_jkg``. Ist auch
     nur eine der drei ``None`` (Gebiet unbekannt ODER keine Kalibrierung,
     z.B. FR), traegt das Blitzpotenzial KEIN Signal zur Fusion bei.
+
+    Issue #1680 S1: die Einzelsignale entstehen seither in ``_signal_levels()``
+    -- gleiche Regeln, gleicher Rueckgabewert, nur zusaetzlich unter ihrem
+    Signalnamen abrufbar (``thunder_signal_carriers()``).
     """
-    signals: list[ThunderLevel] = []
-
-    if wettercode_level is not None:
-        signals.append(wettercode_level)
-
-    if lightning_density is not None:
-        signals.append(_thunder_level_from_ladder(
-            lightning_density, _LIGHTNING_LOW_MIN, _LIGHTNING_MED_MIN, _LIGHTNING_HIGH_MIN,
-        ))
-
-    if (cape_jkg is not None
-            and cape_threshold_jkg is not None
-            and cape_med_min is not None
-            and cape_high_min is not None):
-        signals.append(_gedaempft_durch_cin(
-            _thunder_level_from_ladder(
-                cape_jkg, cape_threshold_jkg, cape_med_min, cape_high_min,
-            ),
-            cin_jkg,
-        ))
-
-    if (lightning_potential_jkg is not None
-            and lpi_low_min is not None
-            and lpi_med_min is not None
-            and lpi_high_min is not None):
-        signals.append(_thunder_level_from_ladder(
-            lightning_potential_jkg, lpi_low_min, lpi_med_min, lpi_high_min,
-        ))
-
+    signals = _signal_levels(
+        wettercode_level, lightning_density, cape_jkg, lightning_potential_jkg,
+        cape_threshold_jkg=cape_threshold_jkg, cape_med_min=cape_med_min,
+        cape_high_min=cape_high_min, cin_jkg=cin_jkg, lpi_low_min=lpi_low_min,
+        lpi_med_min=lpi_med_min, lpi_high_min=lpi_high_min,
+    )
     if not signals:
         return None
-    return max_thunder(signals)
+    return max_thunder(signals.values())
 
 
 # ---------------------------------------------------------------------------

--- a/src/output/renderers/comparison.py
+++ b/src/output/renderers/comparison.py
@@ -32,7 +32,7 @@ from output.renderers.email.compare_html import (
     _column_legend_text, _fmt_precip_type, _fmt_thunder,
     _fmt_visibility_overview, _metric_value, _should_merge_wind_dir,
     _units_legend_text, _visible_hour_metrics, derive_row_labels,
-    loc_hail_flag, location_render_order,
+    loc_hail_flag, loc_thunder_signals, location_render_order,
 )
 from output.renderers.email.outlook_state_hint import (
     OutlookState, render_outlook_state_plain,
@@ -243,7 +243,9 @@ def render_comparison_text(
         for (metric_id, _de_label, fmt), row in zip(ordered, labelled):
             value = _metric_value(loc_result, metric_id)
             cell = (
-                _fmt_overview_cell(fmt, value, loc_result)
+                # Issue #1680 S1: der Klartext-Teil der Mail zeigt die
+                # Herkunft der Gewitterstufe genau wie der HTML-Teil.
+                _fmt_overview_cell(fmt, value, loc_result, include_origin=True)
                 if value is not None else "-"
             )
             lines.append(f"   {row['label']}: {cell}")
@@ -500,7 +502,9 @@ _CHANNEL_METRICS: tuple[tuple[str, str], ...] = (
 _PLAIN_ROWS_BY_ID = {row[0]: row for row in _PLAIN_ROWS}
 
 
-def _fmt_overview_cell(fmt, value, loc_result: LocationResult) -> str:
+def _fmt_overview_cell(
+    fmt, value, loc_result: LocationResult, *, include_origin: bool = False,
+) -> str:
     """Issue #1475 Nachbesserung (Punkt 5b, Aufrufstellen 3/5/6): DIE EINE
     Stelle, an der die Ortsvergleich-Kanaele Klartext, SMS und Telegram ihren
     Uebersichtswert formatieren.
@@ -509,9 +513,17 @@ def _fmt_overview_cell(fmt, value, loc_result: LocationResult) -> str:
     Ortes durchgereicht; alle uebrigen Zeilen bleiben zeichengleich. Ohne
     diesen gemeinsamen Baustein haette jeder der drei Kanaele eine eigene
     Kopie derselben Fallunterscheidung bekommen (#1481).
+
+    Issue #1680 S1: ``include_origin`` schaltet die Herkunft der Gewitterstufe
+    zu. 🔴 Default ``False``, weil dieselbe Funktion AUCH die SMS-Zelle baut
+    und die PO-Entscheidung dort ausdruecklich KEINE Herkunft vorsieht -- ohne
+    diesen Schalter leckte der Zusatz automatisch in die SMS, wuerde dort vom
+    GSM-7-Filter zu "-" entstellt und verdraengte ueber den "+N"-Mechanismus
+    hintere Metriken.
     """
     if fmt is _fmt_thunder:
-        return fmt(value, loc_hail_flag(loc_result))
+        signale = loc_thunder_signals(loc_result) if include_origin else None
+        return fmt(value, loc_hail_flag(loc_result), signale)
     return fmt(value)
 
 # Issue #1362 (Scheibe S5b): Compare-Renderer-ID -> zentrale Katalog-Metrik-ID
@@ -626,6 +638,15 @@ def _sms_metric_cell(loc_result: LocationResult, metric_id: str) -> str | None:
     if not code:
         return None
     code = f"{code}{_sms_aggregation_sign(metric_id)}"
+    # Issue #1680 S1 (Spec D8): ``include_origin`` bleibt hier AKTIV ABGEWAEHLT
+    # auf dem Default ``False`` -- die SMS zeigt die Gewitterstufe, aber KEINE
+    # Herkunft. PO-Entscheidung, kein vergessener Anschluss. Drei Gruende:
+    # (1) 153 Zeichen Gesamtbudget und kein Spaltenbudget fuer einen zweiten
+    # ``·``-Abschnitt je Ort; (2) ``_sms_gsm7_safe`` entstellt den Trenner
+    # ``·`` zu ``-``, der Zusatz saehe entstellt aus; (3) der
+    # ``+N``-Mechanismus wuerde die vom Zusatz verdraengten hinteren Metriken
+    # nur noch zaehlen statt zeigen. Gilt ueber denselben Renderer auch fuer
+    # Premium-SMS, sobald der Ortsvergleich ihn bedient.
     return f"{code} {_sms_gsm7_safe(_fmt_overview_cell(fmt, value, loc_result))}"
 
 
@@ -641,7 +662,7 @@ def _plain_metric_cell(loc_result: LocationResult, metric_id: str) -> str | None
     value = _metric_value(loc_result, metric_id)
     if value is None:
         return None
-    return f"{label} {_fmt_overview_cell(fmt, value, loc_result)}"
+    return f"{label} {_fmt_overview_cell(fmt, value, loc_result, include_origin=True)}"
 
 
 def _channel_layout_for_metrics(channel: str, metric_ids: list[str]):

--- a/src/output/renderers/email/compare_html.py
+++ b/src/output/renderers/email/compare_html.py
@@ -201,7 +201,9 @@ def _fmt_visibility(v) -> str:
     return f"{v / 1000:.1f}" if v is not None else "—"
 
 
-def _fmt_thunder(v, hail: Optional[bool] = None) -> str:
+def _fmt_thunder(
+    v, hail: Optional[bool] = None, signals: Optional[list[str]] = None,
+) -> str:
     """Gewitterstufen-Label des Ortsvergleichs.
 
     Issue #1475 Nachbesserung (Punkt 5a): ``hail`` ist ADDITIV mit Default
@@ -209,14 +211,26 @@ def _fmt_thunder(v, hail: Optional[bool] = None) -> str:
     (``format_hail_note(None)`` liefert nichts). Nur bei bestaetigtem Hagel
     (``True``) haengt der rein deskriptive Zusatz an (ADR-0007, kein Rat).
     Die Stufe ``v`` selbst wird davon NIE beeinflusst (AC-10).
+
+    Issue #1680 S1: ``signals`` (die tragenden Zutaten der Stufe) ist aus
+    demselben Grund ein DRITTER Parameter mit Default ``None`` und steht VOR
+    dem Hagel-Hinweis. 🔴 Der Zusatz gehoert bewusst NICHT in den Rumpf: diese
+    Funktion speist ueber ``_HOUR_FMT_OVERRIDES["thunder"]`` AUCH die
+    Compare-Stundentabelle, die in dieser Scheibe unveraendert bleibt (AC-11)
+    -- sie ruft ohne dritten Parameter und bleibt damit zeichengleich.
     """
     if v is None:
         return "—"
     key = v.value if hasattr(v, "value") else str(v)
     label = _THUNDER_LEVEL_LABEL.get(key, "—")
-    from output.metric_format import format_hail_note
+    from output.metric_format import format_hail_note, thunder_signal_label
+    teile = [label]
+    if signals:
+        teile.append(", ".join(thunder_signal_label(s) for s in signals))
     note = format_hail_note(hail)
-    return f"{label} · {note}" if note else label
+    if note:
+        teile.append(note)
+    return " · ".join(teile)
 
 
 def _sev_thunder(v):
@@ -658,6 +672,34 @@ def loc_hail_flag(loc: LocationResult, summary=None) -> Optional[bool]:
     return getattr(summary, "hail_flag", None) if summary is not None else None
 
 
+def loc_thunder_signals(loc: LocationResult, summary=None) -> Optional[list[str]]:
+    """Issue #1680 S1: DER EINE Weg an die Herkunft der Gewitterstufe eines
+    verglichenen Ortes — genutzt von HTML-Uebersicht, Klartext und Telegram
+    (#1481 DRY-Pflicht, keine Parallel-Logik je Kanal).
+
+    🔴 ANDERS als ``loc_hail_flag``: es gibt KEIN Engine-Feld fuer die
+    Herkunft, wohl aber eines fuer die Stufe (``thunder_level_max``, #1285),
+    dem ``_metric_value`` Vorrang gibt. Eine blind live abgeleitete Herkunft
+    wuerde also eine Stufe aus dem Engine-Lauf mit einer Herkunft aus einer
+    ZWEITEN, unabhaengigen Rechnung paaren.
+
+    Deshalb: Traeger NUR, wenn die live abgeleitete Stufe der ANGEZEIGTEN
+    gleicht. Sonst ``None`` — lieber keine Angabe als eine, die zu einer
+    anderen als der gezeigten Stufe gehoert (ADR-0007, ADR-0048).
+    """
+    if summary is None:
+        summary = _daily_summary(loc)
+    if summary is None:
+        return None
+    signals = getattr(summary, "thunder_level_max_signals", None)
+    if not signals:
+        return None
+    gezeigt = _metric_value(loc, "thunder_max", summary)
+    if gezeigt is None or gezeigt != getattr(summary, "thunder_level_max", None):
+        return None
+    return signals
+
+
 def _fmt_metric(value, decimals, unit: str) -> str:
     if value is None:
         return "—"
@@ -704,7 +746,10 @@ def _render_overview_row(
             # Issue #1475 Nachbesserung (Punkt 5b, Aufrufstelle 1): die
             # Gewitter-Zeile bekommt zusaetzlich das Hagel-Kennzeichen DIESES
             # Ortes durchgereicht — alle anderen Zeilen bleiben unveraendert.
-            text = fmt_fn(value, loc_hail_flag(loc, summaries.get(id(loc))))
+            # Issue #1680 S1: dazu die tragenden Zutaten DIESES Ortes.
+            summary = summaries.get(id(loc))
+            text = fmt_fn(value, loc_hail_flag(loc, summary),
+                          loc_thunder_signals(loc, summary))
         elif fmt_fn:
             text = fmt_fn(value)
         else:

--- a/src/providers/thunder_enrichment.py
+++ b/src/providers/thunder_enrichment.py
@@ -126,22 +126,29 @@ def _fuse_thunder_levels(
     Ueberschreibt NUR, wenn die Fusion ein Ergebnis liefert -- liefert sie
     ``None`` ("keine Aussage"), bleibt ein bereits vorhandener Wert an
     ``dp.thunder_level`` erhalten (s. Spec Abschnitt 3, letzter Absatz).
+
+    Issue #1680 S1: zusaetzlich wird festgehalten, WELCHE Zutaten die Stufe
+    tragen (``dp.thunder_level_signals``) -- aus DEMSELBEN Argumentsatz und
+    unter DERSELBEN Ueberschreib-Bedingung, damit Stufe und Herkunft nie aus
+    zwei verschiedenen Rechnungen stammen koennen.
     """
-    from output.metric_format import thunder_level_from_signals
+    from output.metric_format import thunder_level_from_signals, thunder_signal_carriers
 
     cape_low, cape_med, cape_high = cape_ladder or (None, None, None)
     lpi_low, lpi_med, lpi_high = lpi_thresholds or (None, None, None)
     for dp in data:
-        fused = thunder_level_from_signals(
-            dp.thunder_level, dp.lightning_density_per_km2_3h, dp.cape_jkg,
-            dp.lightning_potential_lpi_jkg,
+        werte = (dp.thunder_level, dp.lightning_density_per_km2_3h, dp.cape_jkg,
+                 dp.lightning_potential_lpi_jkg)
+        leitern = dict(
             cape_threshold_jkg=cape_low,
             cape_med_min=cape_med, cape_high_min=cape_high,
             cin_jkg=dp.convective_inhibition_jkg,
             lpi_low_min=lpi_low, lpi_med_min=lpi_med, lpi_high_min=lpi_high,
         )
+        fused = thunder_level_from_signals(*werte, **leitern)
         if fused is not None:
             dp.thunder_level = fused
+            dp.thunder_level_signals = thunder_signal_carriers(*werte, **leitern)
 
 
 def _schwellen_fuer_reihe(

--- a/src/services/weather_metrics.py
+++ b/src/services/weather_metrics.py
@@ -435,6 +435,9 @@ class WeatherMetricsService:
         cloud_avg = self._compute_cloud_cover(timeseries)
         humidity_avg = self._compute_humidity(timeseries)
         thunder_max = self._compute_thunder_level(timeseries)
+        thunder_max_signals = self._compute_thunder_level_signals(
+            timeseries, thunder_max
+        )
         hail_flag = self._compute_hail_flag(timeseries)
         visibility_min = self._compute_visibility(timeseries)
 
@@ -456,6 +459,7 @@ class WeatherMetricsService:
             cloud_avg_pct=cloud_avg,
             humidity_avg_pct=humidity_avg,
             thunder_level_max=thunder_max,
+            thunder_level_max_signals=thunder_max_signals,
             hail_flag=hail_flag,
             visibility_min_m=visibility_min,
             dominant_wmo_code=dominant_wmo,
@@ -471,6 +475,7 @@ class WeatherMetricsService:
                 "cloud_avg_pct": "avg",
                 "humidity_avg_pct": "avg",
                 "thunder_level_max": "max",
+                "thunder_level_max_signals": "union_of_max_carriers",
                 "hail_flag": "hail_priority",
                 "visibility_min_m": "min",
                 "dominant_wmo_code": "max_wmo_severity",
@@ -607,6 +612,34 @@ class WeatherMetricsService:
         # Issue #1214 Scheibe 6: kanonische Ordnungsquelle statt lokalem Dict.
         from output.metric_format import max_thunder
         return max_thunder(levels)
+
+    def _compute_thunder_level_signals(
+        self,
+        timeseries: NormalizedTimeseries,
+        thunder_max: Optional[ThunderLevel],
+    ) -> Optional[list[str]]:
+        """Die Zutaten, die das TAGESmaximum tragen (Issue #1680 S1).
+
+        VEREINIGUNG ueber ALLE Stunden, die ``thunder_max`` erreichen -- nicht
+        die erste passende. Erreichen zwei Stunden desselben Tages dieselbe
+        Hoechststufe ueber verschiedene Zutaten (14 Uhr CAPE, 18 Uhr
+        Blitzpotenzial), entschiede sonst eine willkuerlich gewaehlte Stunde
+        ueber die angezeigte Herkunft. Dedupliziert unter Erhalt der ersten
+        Auftrittsreihenfolge.
+
+        ``None`` (keine Aussage) bei fehlender Stufe oder wenn keine Stunde
+        eine Zutat nennt -- z.B. ein Alt-Schnappschuss ohne das Feld.
+        """
+        if thunder_max is None:
+            return None
+        traeger: list[str] = []
+        for dp in timeseries.data:
+            if dp.thunder_level != thunder_max:
+                continue
+            for name in getattr(dp, "thunder_level_signals", None) or []:
+                if name not in traeger:
+                    traeger.append(name)
+        return traeger or None
 
     def _compute_hail_flag(
         self,

--- a/tests/tdd/test_thunder_enrichment_fuses_level_shared_path.py
+++ b/tests/tdd/test_thunder_enrichment_fuses_level_shared_path.py
@@ -421,6 +421,57 @@ def test_f001_kein_signal_laesst_thunder_level_am_produktionspfad_unveraendert()
     )
 
 
+def test_1680_herkunft_teilt_die_ueberschreib_bedingung_der_stufe():
+    """Issue #1680 S1: `dp.thunder_level_signals` (die Herkunft) haengt an
+    DERSELBEN Ueberschreib-Bedingung wie `dp.thunder_level` -- liefert die
+    Fusion `None` ("keine Aussage"), bleibt auch eine bereits vorhandene
+    Herkunft unangetastet.
+
+    Ohne diese Kopplung wuerde eine zweite Runde ohne Rohsignale einen
+    vorhandenen Traeger-Wert still auf die leere Liste setzen: die Stufe
+    bliebe stehen, die Herkunft waere weg -- genau das, was der Docstring von
+    `_fuse_thunder_levels()` ausschliesst. Zieht man die zweite Zuweisung aus
+    dem `if fused is not None`, muss dieser Test rot werden.
+
+    Gegenprobe im selben Test: liefert die Fusion sehr wohl ein Ergebnis,
+    wird die Herkunft AKTIV mitgezogen -- Stufe und Herkunft stammen dann aus
+    derselben Rechnung, ein alter Traeger-Wert darf nicht stehenbleiben.
+    """
+    from app.model_registry import lpi_thresholds_jkg
+    from app.models import ForecastDataPoint
+    from providers.thunder_enrichment import _fuse_thunder_levels
+
+    ts = datetime.now(timezone.utc)
+    stumm = ForecastDataPoint(
+        ts=ts, thunder_level=None, lightning_density_per_km2_3h=None,
+        cape_jkg=None, lightning_potential_lpi_jkg=None,
+        thunder_level_signals=["cape"],
+    )
+    laut = ForecastDataPoint(
+        ts=ts, thunder_level=None, lightning_density_per_km2_3h=None,
+        cape_jkg=None, lightning_potential_lpi_jkg=60.0,
+        thunder_level_signals=["cape"],
+    )
+
+    _fuse_thunder_levels([stumm, laut], None, lpi_thresholds_jkg("EU_REST"))
+
+    assert stumm.thunder_level_signals == ["cape"], (
+        "dp.thunder_level_signals wurde veraendert, obwohl die Fusion "
+        "'keine Aussage' (None) lieferte -- die Herkunft muss an derselben "
+        f"Ueberschreib-Bedingung haengen wie die Stufe: "
+        f"{stumm.thunder_level_signals!r}"
+    )
+    assert laut.thunder_level == ThunderLevel.HIGH, (
+        f"Gegenprobe-Vorbedingung: 60 J/kg Blitzpotenzial muessen ueber die "
+        f"EU_REST-Leiter 'hoch' ergeben, erhalten {laut.thunder_level!r}"
+    )
+    assert laut.thunder_level_signals == ["blitzpotenzial"], (
+        "Gegenprobe gescheitert: liefert die Fusion ein Ergebnis, MUSS die "
+        "Herkunft mitgezogen werden (sonst gehoerte sie zu einer anderen "
+        f"Rechnung als die Stufe): {laut.thunder_level_signals!r}"
+    )
+
+
 def test_f001_blitzpotenzial_null_komma_null_setzt_stufe_none_am_produktionspfad():
     """F001 Gegenfall: `lightning_potential_lpi_jkg=0.0` (aktiv geprueft,
     unter der LOW-Schwelle 5.0) bei sonst None -- liefert am Produktionspfad

--- a/tests/tdd/test_thunder_origin_compare.py
+++ b/tests/tdd/test_thunder_origin_compare.py
@@ -1,0 +1,266 @@
+"""TDD RED — Issue #1680 Scheibe 1: Herkunft der Gewitterstufe im Ortsvergleich.
+
+SPEC: docs/specs/modules/feat_1680_s1_gewitter_herkunft_ortsvergleich.md
+(AC-1 bis AC-7, AC-10 bis AC-12; AC-8/AC-9 in
+``test_thunder_origin_snapshot_roundtrip.py``).
+
+RED-Ursache (heute): ``metric_format.thunder_signal_carriers()``,
+``ForecastDataPoint.thunder_level_signals`` und
+``compare_html.loc_thunder_signals()`` existieren nicht, ``_fmt_thunder()``
+kennt keinen dritten Parameter -> jede Gewitterzelle zeigt nur die Stufe.
+
+Kein Mock-Theater: echte ``ForecastDataPoint``-Rohwerte, echte Fusion
+(``thunder_enrichment._fuse_thunder_levels`` mit den Leitern aus
+``app.model_registry``), echte Renderer bis zum zurueckgegebenen Body.
+"""
+from __future__ import annotations
+
+import html as _html
+import re
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from app.model_registry import cape_ladder_thresholds_jkg, lpi_thresholds_jkg  # noqa: E402
+from app.models import ForecastDataPoint, ThunderLevel  # noqa: E402
+from app.user import ComparisonResult, LocationResult, SavedLocation  # noqa: E402
+from output.renderers.comparison import (  # noqa: E402
+    render_compare_email, render_compare_sms, render_compare_telegram,
+)
+from providers.thunder_enrichment import _fuse_thunder_levels  # noqa: E402
+from providers.thunder_routing import thunder_region_for  # noqa: E402
+
+# Die vier Zutaten der Fusion (metric_format.thunder_level_from_signals) in
+# ihrer deutschen Beschriftung -- KEINE davon darf im SMS-Kanal oder in einer
+# Stundentabelle auftauchen (AC-5, AC-11).
+ALLE_ZUTATEN = ("Wettercode", "Blitzdichte", "CAPE", "Blitzpotenzial")
+
+_TD = re.compile(r"<td[^>]*>(.*?)</td>", re.S)
+
+
+def _dp(h: int, *, cape=None, cin=None, lpi=None, dichte=None, hail=None):
+    """Ein Stunden-Datenpunkt mit ROHWERTEN -- die Stufe rechnet die Fusion."""
+    return ForecastDataPoint(
+        ts=datetime(2026, 8, 6, h, 0, tzinfo=timezone.utc), t2m_c=20.0,
+        cape_jkg=cape, convective_inhibition_jkg=cin,
+        lightning_potential_lpi_jkg=lpi, lightning_density_per_km2_3h=dichte,
+        hail_flag=hail,
+    )
+
+
+def _ort(name: str, lat: float, lon: float, punkte: list, *,
+         modell: str = "icon_d2", **felder) -> LocationResult:
+    """Ort, dessen Stunden durch die ECHTE Fusion gelaufen sind: Gebiet aus
+    ``thunder_routing``, Schwellenleitern aus ``model_registry`` -- keine im
+    Test getippte Schwelle (sonst prueft er eine Welt, die es nicht gibt)."""
+    region = thunder_region_for(lat, lon)
+    _fuse_thunder_levels(
+        punkte, cape_ladder_thresholds_jkg(modell, region), lpi_thresholds_jkg(region),
+    )
+    return LocationResult(
+        location=SavedLocation(id=name.lower(), name=name, lat=lat, lon=lon,
+                               elevation_m=1000),
+        score=50, hourly_data=punkte, **felder,
+    )
+
+
+def _vergleich(*orte: LocationResult) -> ComparisonResult:
+    return ComparisonResult(
+        locations=list(orte), time_window=(12, 20),
+        target_date=date(2026, 8, 6), created_at=datetime(2026, 8, 5, 18, 0),
+    )
+
+
+def _mail(*orte: LocationResult, stunden=False) -> tuple[str, str]:
+    """(html_body, text_body) des Ortsvergleichs mit NUR der Gewitter-Zeile."""
+    return render_compare_email(
+        _vergleich(*orte), enabled_metrics=["thunder_max"],
+        hourly_metrics=["thunder_level"] if stunden else None,
+        hourly_enabled=stunden,
+    )
+
+
+def _html_zellen(html: str) -> list[str]:
+    """Zellentexte der Gewitter-Zeile der HTML-Uebersicht, in Ortsreihenfolge
+    (alphabetisch, ``location_render_order``)."""
+    rest = html.split(">Gewitter</td>", 1)[1]
+    return [_html.unescape(c) for c in _TD.findall(rest.split("</tr>", 1)[0])]
+
+
+def _text_zellen(text: str, trenner: str = "Gewitter: ") -> list[str]:
+    """Gewitter-Zellen der Klartext-/Telegram-Uebersicht, in Ortsreihenfolge."""
+    return [ln.split(trenner, 1)[1].strip() for ln in text.splitlines() if trenner in ln]
+
+
+def _teile(zelle: str) -> tuple[str, set[str]]:
+    """"hoch · CAPE, Blitzpotenzial" -> ("hoch", {"CAPE", "Blitzpotenzial"})."""
+    stufe, _, rest = zelle.partition(" · ")
+    return stufe, {t.strip() for t in rest.split(",") if t.strip()}
+
+
+def _alpen_und_korsika() -> tuple[LocationResult, LocationResult]:
+    """Zwei Orte auf "hoch" ueber VERSCHIEDENE Zutaten (Spec AC-1).
+
+    Alpenort: CAPE 1500 J/kg bei schwacher Hemmung (CIN 5) -- ueber der
+    obersten Sprosse der icon_d2/DE_ALPEN-Leiter. Korsikaort: Blitzdichte
+    0,5/km2 ueber der obersten Sprosse ihrer Leiter; FR hat keine
+    LPI-Kalibrierung und kein CAPE, dort traegt also nur die Dichte.
+    """
+    return (
+        _ort("Alpenort", 47.0, 12.0, [_dp(14, cape=1500.0, cin=5.0)]),
+        _ort("Korsikaort", 42.0, 9.0, [_dp(14, dichte=0.5)], modell="meteofrance_arome"),
+    )
+
+
+def test_ac1_html_uebersicht_nennt_je_ort_die_eigene_tragende_zutat():
+    """AC-1: Given zwei Orte erreichen "hoch" ueber verschiedene Zutaten,
+    When die Vergleichsmail gerendert wird, Then nennt jede Ortszelle die
+    JEWEILS eigene Zutat -- nicht dieselbe Angabe fuer beide."""
+    html, text = _mail(*_alpen_und_korsika())
+    erwartet = ["hoch · CAPE", "hoch · Blitzdichte"]
+    assert _html_zellen(html) == erwartet, (
+        f"HTML-Uebersicht muss je Ort die tragende Zutat nennen: {_html_zellen(html)!r}")
+    assert _text_zellen(text) == erwartet, (
+        f"Klartext-Teil DERSELBEN Mail muss dieselbe Herkunft zeigen: "
+        f"{_text_zellen(text)!r}")
+
+
+def test_ac4_telegram_zeigt_dieselbe_herkunft_wie_die_mail():
+    """AC-4: Given derselbe Ortsvergleich geht als Telegram-Nachricht raus,
+    When der Nutzer sie liest, Then steht dort dieselbe Herkunfts-Angabe wie
+    in der E-Mail (Fliesstext statt Farbzelle, inhaltsgleich)."""
+    telegram = render_compare_telegram(
+        _vergleich(*_alpen_und_korsika()), enabled_metrics=["thunder_max"])
+    assert _text_zellen(telegram, "Gewitter ") == ["hoch · CAPE", "hoch · Blitzdichte"], (
+        f"Telegram muss dieselbe Herkunft zeigen wie die Mail: {telegram!r}")
+
+
+def test_ac5_sms_zeigt_die_stufe_aber_keine_herkunft():
+    """AC-5: Given derselbe Ortsvergleich geht als SMS raus, When der Nutzer
+    sie liest, Then steht dort die Stufe, aber KEINE der vier Zutaten.
+
+    Gegenprobe im selben Lauf (Spec-Pflicht): Telegram zeigt die Herkunft
+    gegen DIESELBE Fixture sehr wohl -- sonst waere dieses AC auch dann
+    gruen, wenn die Herkunft nirgends erschiene.
+    """
+    result = _vergleich(*_alpen_und_korsika())
+    sms = render_compare_sms(result, enabled_metrics=["thunder_max"])
+    telegram = render_compare_telegram(result, enabled_metrics=["thunder_max"])
+
+    assert "hoch" in sms, f"Die Stufe selbst muss in der SMS stehen: {sms!r}"
+    for zutat in ALLE_ZUTATEN:
+        assert zutat not in sms, (
+            f"SMS ist bewusst OHNE Herkunft (PO-Entscheidung) -- '{zutat}' "
+            f"darf nicht vorkommen: {sms!r}")
+    assert "CAPE" in telegram and "Blitzdichte" in telegram, (
+        f"Gegenprobe gescheitert: Telegram MUSS die Herkunft gegen dieselbe "
+        f"Fixture zeigen, sonst beweist die SMS-Abwesenheit nichts: {telegram!r}")
+
+
+def test_ac2_beide_tragenden_zutaten_werden_genannt():
+    """AC-2: Given CAPE UND Blitzpotenzial erreichen an einem Ort dieselbe
+    Hoechststufe, When die Gewitter-Zeile gerendert wird, Then werden BEIDE
+    kommagetrennt genannt -- es wird kein Gewinner gekuert."""
+    html, _ = _mail(_ort("Beideort", 47.0, 12.0,
+                         [_dp(14, cape=1500.0, cin=5.0, lpi=60.0)]))
+    assert _teile(_html_zellen(html)[0]) == ("hoch", {"CAPE", "Blitzpotenzial"}), (
+        f"Beide Traeger der Hoechststufe muessen erscheinen: {_html_zellen(html)[0]!r}")
+
+
+def test_ac3_stufe_kein_bekommt_keinen_herkunfts_zusatz():
+    """AC-3: Given eine Zutat ist vorhanden, erreicht aber keine Stufe ueber
+    NONE, When die Gewitter-Zeile gerendert wird, Then bleibt die Zelle ohne
+    Herkunfts-Zusatz -- waehrend der zweite Ort im selben Vergleich (Zutat
+    ueber der Leiter) seine Herkunft sehr wohl zeigt."""
+    html, _ = _mail(
+        _ort("Ruhigort", 47.0, 12.0, [_dp(14, cape=100.0, cin=5.0)]),
+        _ort("Sturmort", 47.0, 12.0, [_dp(14, cape=1500.0, cin=5.0)]),
+    )
+    ruhig_zelle, sturm_zelle = _html_zellen(html)
+    assert "·" not in ruhig_zelle, (
+        f"Ohne erreichte Stufe darf KEIN Herkunfts-Zusatz erscheinen: {ruhig_zelle!r}")
+    assert sturm_zelle == "hoch · CAPE", (
+        f"Gegenprobe gescheitert: der Ort MIT erreichter Stufe muss die "
+        f"Herkunft zeigen: {sturm_zelle!r}")
+
+
+def test_ac6_hagel_hinweis_und_herkunft_stehen_nebeneinander():
+    """AC-6: Given ein Ort hat bestaetigten Hagel UND eine Gewitter-Herkunft,
+    When die E-Mail gerendert wird, Then stehen beide Zusaetze nebeneinander,
+    ohne dass einer den anderen verdraengt."""
+    html, _ = _mail(_ort("Hagelort", 47.0, 12.0,
+                         [_dp(14, cape=1500.0, cin=5.0, hail=True)]))
+    assert _html_zellen(html)[0] == "hoch · CAPE · Hagel: ja", (
+        f"Herkunft UND Hagel-Hinweis muessen erscheinen (Herkunft vor Hagel, "
+        f"Spec D8): {_html_zellen(html)[0]!r}")
+
+
+def test_ac7_eu_rest_nennt_nur_blitzpotenzial_ohne_eichungshinweis():
+    """AC-7: Given ein Ort im Gebiet EU_REST erreicht seine Stufe nur ueber
+    das Blitzpotenzial (unbelegte Interim-Schwelle), When die Herkunft
+    erscheint, Then steht dort ausschliesslich "Blitzpotenzial" -- kein
+    Eichungs-Hinweis, keine Bewertung (ADR-0007/ADR-0048)."""
+    html, _ = _mail(_ort("Nordort", 60.0, 25.0, [_dp(14, lpi=60.0)], modell="icon_eu"))
+    assert _html_zellen(html)[0] == "hoch · Blitzpotenzial", (
+        f"EU_REST-LPI wird genannt wie jede andere Zutat -- ohne Zusatz zur "
+        f"Guete der Eichung: {_html_zellen(html)[0]!r}")
+
+
+def test_ac10_tagesmaximum_vereinigt_die_zutaten_mehrerer_stunden():
+    """AC-10: Given zwei Stunden desselben Tages erreichen dieselbe
+    Hoechststufe ueber unterschiedliche Zutaten (14 Uhr CAPE, 18 Uhr
+    Blitzpotenzial), When die Vergleichsmatrix gerendert wird, Then nennt sie
+    BEIDE -- nicht nur die der ersten passenden Stunde."""
+    html, _ = _mail(_ort("Zweiort", 47.0, 12.0,
+                         [_dp(14, cape=1500.0, cin=5.0), _dp(18, lpi=60.0)]))
+    assert _teile(_html_zellen(html)[0]) == ("hoch", {"CAPE", "Blitzpotenzial"}), (
+        f"Das Tagesaggregat muss die Traeger ALLER Stunden mit der "
+        f"Hoechststufe vereinigen: {_html_zellen(html)[0]!r}")
+
+
+def test_ac11_stundentabellen_bleiben_ohne_herkunft():
+    """AC-11: Given diese Scheibe aendert nur die Ortsvergleich-Tagesuebersicht,
+    When Mail und Trip-Stundenzelle gerendert werden, Then traegt keine
+    Stundentabelle einen Herkunfts-Zusatz -- waehrend die Uebersicht derselben
+    Mail ihn zeigt (Gegenprobe)."""
+    from output.renderers.email.helpers import fmt_val
+
+    html, text = _mail(*_alpen_und_korsika(), stunden=True)
+    assert _html_zellen(html)[0] == "hoch · CAPE", (
+        f"Gegenprobe gescheitert: die Tagesuebersicht MUSS die Herkunft "
+        f"zeigen: {_html_zellen(html)[0]!r}")
+    for abschnitt in (html.split("STUNDEN", 1)[1], text.split("STUNDENVERLAUF", 1)[1]):
+        for zutat in ALLE_ZUTATEN:
+            assert zutat not in abschnitt, (
+                f"Die Compare-Stundentabelle bleibt in dieser Scheibe "
+                f"unveraendert -- '{zutat}' darf dort nicht auftauchen.")
+    assert fmt_val("thunder", ThunderLevel.HIGH, row={"_hail_flag": None}) == "hoch", (
+        "Die Gewitterzelle der TRIP-Stundentabelle (email/helpers.fmt_val) "
+        "bleibt zeichengleich -- kein Herkunfts-Zusatz auf der Trip-Seite.")
+
+
+def test_ac12_bei_abweichung_von_engine_wert_und_stunden_keine_herkunft():
+    """AC-12: Given die angezeigte Stufe stammt aus dem Engine-Lauf und weicht
+    von der aus den Stundenwerten abgeleiteten ab, When die Gewitter-Zeile
+    gerendert wird, Then erscheint die Stufe ohne Herkunft -- nie eine
+    Herkunft, die zu einer anderen als der gezeigten Stufe gehoert.
+
+    Gegenprobe im selben Test (Spec-Pflicht): stimmen Engine-Wert und
+    Stundenwert ueberein, erscheint die Herkunft sehr wohl.
+    """
+    # CAPE 800 J/kg bei schwacher Hemmung -> MED ueber die icon_d2-Leiter.
+    html, _ = _mail(
+        _ort("Driftort", 47.0, 12.0, [_dp(14, cape=800.0, cin=5.0)],
+             thunder_level_max=ThunderLevel.HIGH),
+        _ort("Einigort", 47.0, 12.0, [_dp(14, cape=800.0, cin=5.0)],
+             thunder_level_max=ThunderLevel.MED),
+    )
+    drift_zelle, einig_zelle = _html_zellen(html)
+    assert drift_zelle == "hoch", (
+        f"Bei Drift zwischen Engine-Stufe und Stundenwerten darf KEINE "
+        f"Herkunft erscheinen: {drift_zelle!r}")
+    assert einig_zelle == "mittel · CAPE", (
+        f"Gegenprobe gescheitert: bei uebereinstimmender Stufe MUSS die "
+        f"Herkunft erscheinen: {einig_zelle!r}")

--- a/tests/tdd/test_thunder_origin_compare.py
+++ b/tests/tdd/test_thunder_origin_compare.py
@@ -40,13 +40,18 @@ ALLE_ZUTATEN = ("Wettercode", "Blitzdichte", "CAPE", "Blitzpotenzial")
 _TD = re.compile(r"<td[^>]*>(.*?)</td>", re.S)
 
 
-def _dp(h: int, *, cape=None, cin=None, lpi=None, dichte=None, hail=None):
-    """Ein Stunden-Datenpunkt mit ROHWERTEN -- die Stufe rechnet die Fusion."""
+def _dp(h: int, *, cape=None, cin=None, lpi=None, dichte=None, hail=None, code=None):
+    """Ein Stunden-Datenpunkt mit ROHWERTEN -- die Stufe rechnet die Fusion.
+
+    ``code`` ist die Wettercode-Stufe dieser Stunde (``dp.thunder_level``, das
+    Signal "wettercode" der Fusion) -- die EINZIGE Zutat, die schon als Stufe
+    hereinkommt statt als Rohwert.
+    """
     return ForecastDataPoint(
         ts=datetime(2026, 8, 6, h, 0, tzinfo=timezone.utc), t2m_c=20.0,
         cape_jkg=cape, convective_inhibition_jkg=cin,
         lightning_potential_lpi_jkg=lpi, lightning_density_per_km2_3h=dichte,
-        hail_flag=hail,
+        hail_flag=hail, thunder_level=code,
     )
 
 
@@ -167,6 +172,27 @@ def test_ac2_beide_tragenden_zutaten_werden_genannt():
                          [_dp(14, cape=1500.0, cin=5.0, lpi=60.0)]))
     assert _teile(_html_zellen(html)[0]) == ("hoch", {"CAPE", "Blitzpotenzial"}), (
         f"Beide Traeger der Hoechststufe muessen erscheinen: {_html_zellen(html)[0]!r}")
+
+
+def test_ac2_eine_schwaechere_zutat_derselben_stunde_wird_nicht_mitgenannt():
+    """AC-2/AC-10 (Gegenrichtung): Given DIESELBE Stunde traegt zwei Zutaten
+    auf UNTERSCHIEDLICHEN Stufen -- Wettercode nur "leicht", CAPE dagegen
+    "hoch" --, When die Gewitter-Zeile gerendert wird, Then wird NUR die
+    tragende Zutat genannt.
+
+    "Genannt wird JEDE Zutat, die die HOECHSTSTUFE erreicht" ist die
+    Zusicherung; ohne diese Fixture belegt keine Fixture den zweiten Teil des
+    Satzes: alle uebrigen tragen entweder genau ein Signal oder zwei Signale
+    auf DERSELBEN Hoechststufe. Faellt der Filter in
+    ``thunder_signal_carriers()`` weg, wuerde hier zusaetzlich "Wettercode"
+    erscheinen und dem Leser eine Zutat als tragend ausweisen, die die Stufe
+    gar nicht hergibt.
+    """
+    html, _ = _mail(_ort("Mischort", 47.0, 12.0,
+                         [_dp(14, code=ThunderLevel.LOW, cape=1500.0, cin=5.0)]))
+    assert _html_zellen(html)[0] == "hoch · CAPE", (
+        f"Nur die Zutat AUF der Hoechststufe darf erscheinen -- der "
+        f"Wettercode traegt hier nur 'leicht': {_html_zellen(html)[0]!r}")
 
 
 def test_ac3_stufe_kein_bekommt_keinen_herkunfts_zusatz():

--- a/tests/tdd/test_thunder_origin_snapshot_roundtrip.py
+++ b/tests/tdd/test_thunder_origin_snapshot_roundtrip.py
@@ -6,7 +6,9 @@ SPEC: docs/specs/modules/feat_1680_s1_gewitter_herkunft_ortsvergleich.md (D9).
 RED-Ursache: ``SegmentWeatherSummary`` kennt kein Feld
 ``thunder_level_max_signals`` -> ``TypeError``/``AttributeError``.
 Kein Mock-Theater: echte ``WeatherSnapshotService.save()``/``load()`` gegen das
-isolierte Daten-Wurzelverzeichnis der Test-Suite, echter Renderer.
+isolierte Daten-Wurzelverzeichnis der Test-Suite, echter Renderer -- und der
+zu rettende Wert entsteht auf dem ECHTEN Rechenweg (``_fuse_thunder_levels()``
+-> ``summarize_points()``), nicht von Hand getippt (s. ``_echt_gerechnet()``).
 """
 from __future__ import annotations
 
@@ -17,20 +19,54 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 
+from app.model_registry import (  # noqa: E402
+    cape_ladder_thresholds_jkg, lpi_thresholds_jkg,
+)
 from app.models import (  # noqa: E402
-    GPXPoint, SegmentWeatherData, SegmentWeatherSummary, ThunderLevel, TripSegment,
+    ForecastMeta, GPXPoint, NormalizedTimeseries, Provider, SegmentWeatherData,
+    SegmentWeatherSummary, ThunderLevel, TripSegment,
 )
 from app.user import ComparisonResult, LocationResult, SavedLocation  # noqa: E402
 from output.renderers.comparison import render_compare_email  # noqa: E402
+from providers.thunder_enrichment import _fuse_thunder_levels  # noqa: E402
+from providers.thunder_routing import thunder_region_for  # noqa: E402
+from services.weather_metrics import summarize_points  # noqa: E402
 
-from tests.tdd.test_thunder_origin_compare import _html_zellen  # noqa: E402
+from tests.tdd.test_thunder_origin_compare import _dp, _html_zellen  # noqa: E402
 
 _TRIP = "tdd-1680-herkunft"
 _TAG = date(2026, 8, 6)
+_LAT, _LON = 47.0, 12.0
 
 
-def _segment(aggregiert: SegmentWeatherSummary) -> SegmentWeatherData:
-    punkt = GPXPoint(lat=47.0, lon=12.0)
+def _echt_gerechnet() -> tuple[list, SegmentWeatherSummary]:
+    """Stunden UND Tages-Aggregat auf dem ECHTEN Rechenweg (Issue #1680 S1).
+
+    🔴 Der Wert wird hier bewusst NICHT von Hand in die
+    ``SegmentWeatherSummary`` getippt: sonst prueft der Roundtrip nur eine
+    handgeschriebene Liste und nie das, was ``_fuse_thunder_levels()`` und
+    ``WeatherMetricsService._compute_thunder_level_signals()`` tatsaechlich
+    erzeugen. Genau daran liegt der Sprengsatz — liefert der Produktionspfad
+    etwas nicht JSON-Serialisierbares (z.B. ein ``set``), bricht
+    ``json.dumps`` in ``save()``, der Fehler wird dort still zu einem
+    ``logger.warning``, und der GESAMTE Schnappschuss ist weg (``load()``
+    liefert ``None``) — nicht nur die neue Angabe.
+
+    14 Uhr traegt CAPE, 18 Uhr das Blitzpotenzial; das Tagesmaximum
+    vereinigt beide (Aggregationsregel ``union_of_max_carriers``).
+    """
+    region = thunder_region_for(_LAT, _LON)
+    punkte = [_dp(14, cape=1500.0, cin=5.0), _dp(18, lpi=60.0)]
+    _fuse_thunder_levels(
+        punkte, cape_ladder_thresholds_jkg("icon_d2", region),
+        lpi_thresholds_jkg(region),
+    )
+    return punkte, summarize_points(punkte)
+
+
+def _segment(aggregiert: SegmentWeatherSummary, punkte: list | None = None
+             ) -> SegmentWeatherData:
+    punkt = GPXPoint(lat=_LAT, lon=_LON)
     return SegmentWeatherData(
         segment=TripSegment(
             segment_id=1, start_point=punkt, end_point=punkt,
@@ -38,7 +74,12 @@ def _segment(aggregiert: SegmentWeatherSummary) -> SegmentWeatherData:
             end_time=datetime(2026, 8, 6, 18, 0, tzinfo=timezone.utc),
             duration_hours=6.0, distance_km=5.0, ascent_m=300.0, descent_m=100.0,
         ),
-        timeseries=None, aggregated=aggregiert,
+        timeseries=None if punkte is None else NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="snapshot",
+                              grid_res_km=0.0),
+            data=punkte,
+        ),
+        aggregated=aggregiert,
         fetched_at=datetime(2026, 8, 5, 18, 0, tzinfo=timezone.utc),
         provider="openmeteo",
     )
@@ -48,26 +89,39 @@ def test_ac8_snapshot_roundtrip_erhaelt_die_herkunft(caplog):
     """AC-8: Given ein versendeter Schnappschuss traegt die Herkunfts-Angabe,
     When er gespeichert und spaeter wieder geladen wird, Then kommt dieselbe
     Angabe zurueck -- ohne dass ein Serialisierungsfehler sie still (nur als
-    ``logger.warning``) verschluckt."""
+    ``logger.warning``) verschluckt und dabei den GANZEN Schnappschuss
+    mitnimmt."""
     from services.weather_snapshot import WeatherSnapshotService
 
+    punkte, aggregat = _echt_gerechnet()
+    assert aggregat.thunder_level_max == ThunderLevel.HIGH, (
+        f"Vorbedingung: der echte Rechenweg muss 'hoch' ergeben, sonst prueft "
+        f"der Roundtrip die falsche Lage: {aggregat.thunder_level_max!r}")
+
     dienst = WeatherSnapshotService(user_id="tdd-1680")
-    segment = _segment(SegmentWeatherSummary(
-        temp_max_c=20.0, thunder_level_max=ThunderLevel.HIGH,
-        thunder_level_max_signals=["cape", "blitzpotenzial"],
-    ))
     with caplog.at_level(logging.WARNING, logger="services.weather_snapshot"):
-        dienst.save(_TRIP, [segment], _TAG)
+        dienst.save(_TRIP, [_segment(aggregat, punkte)], _TAG)
     geladen = dienst.load(_TRIP)
     warnungen = [r for r in caplog.records if r.name == "services.weather_snapshot"]
 
     assert not warnungen, (
         f"Das Speichern darf nicht in den Warn-Pfad laufen (dort geht der "
         f"Schnappschuss still verloren): {[r.message for r in warnungen]!r}")
-    assert geladen is not None, "Der Schnappschuss muss ladbar sein."
+    assert geladen, (
+        "Der Schnappschuss muss ladbar sein -- laedt er als None/leer, hat "
+        "ein Serialisierungsfehler den gesamten Wetter-Schnappschuss "
+        "verschluckt, nicht nur die Herkunfts-Angabe.")
+    assert aggregat.thunder_level_max_signals == ["cape", "blitzpotenzial"], (
+        f"Der PRODUKTIONSpfad muss die Traeger als geordnete Liste von "
+        f"Zeichenketten liefern -- alles andere (set, Enum, Tupel) bricht "
+        f"json.dumps im Schnappschuss: {aggregat.thunder_level_max_signals!r}")
     assert geladen[0].aggregated.thunder_level_max_signals == ["cape", "blitzpotenzial"], (
         f"Die Herkunft muss den Roundtrip unveraendert ueberstehen: "
         f"{geladen[0].aggregated.thunder_level_max_signals!r}")
+    assert [p.thunder_level_signals for p in geladen[0].timeseries.data] == [
+        ["cape"], ["blitzpotenzial"]], (
+        f"Auch die STUNDEN-Herkunft muss den Roundtrip ueberstehen: "
+        f"{[p.thunder_level_signals for p in geladen[0].timeseries.data]!r}")
 
 
 def test_ac9_alter_schnappschuss_ohne_feld_laedt_und_rendert_ohne_herkunft():

--- a/tests/tdd/test_thunder_origin_snapshot_roundtrip.py
+++ b/tests/tdd/test_thunder_origin_snapshot_roundtrip.py
@@ -1,0 +1,99 @@
+"""TDD RED — Issue #1680 Scheibe 1, AC-8/AC-9: die Herkunfts-Angabe ueberlebt
+die Wetter-Schnappschuss-Persistenz, und ein ALTER Schnappschuss ohne das neue
+Feld laedt und rendert unveraendert weiter.
+
+SPEC: docs/specs/modules/feat_1680_s1_gewitter_herkunft_ortsvergleich.md (D9).
+RED-Ursache: ``SegmentWeatherSummary`` kennt kein Feld
+``thunder_level_max_signals`` -> ``TypeError``/``AttributeError``.
+Kein Mock-Theater: echte ``WeatherSnapshotService.save()``/``load()`` gegen das
+isolierte Daten-Wurzelverzeichnis der Test-Suite, echter Renderer.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from app.models import (  # noqa: E402
+    GPXPoint, SegmentWeatherData, SegmentWeatherSummary, ThunderLevel, TripSegment,
+)
+from app.user import ComparisonResult, LocationResult, SavedLocation  # noqa: E402
+from output.renderers.comparison import render_compare_email  # noqa: E402
+
+from tests.tdd.test_thunder_origin_compare import _html_zellen  # noqa: E402
+
+_TRIP = "tdd-1680-herkunft"
+_TAG = date(2026, 8, 6)
+
+
+def _segment(aggregiert: SegmentWeatherSummary) -> SegmentWeatherData:
+    punkt = GPXPoint(lat=47.0, lon=12.0)
+    return SegmentWeatherData(
+        segment=TripSegment(
+            segment_id=1, start_point=punkt, end_point=punkt,
+            start_time=datetime(2026, 8, 6, 12, 0, tzinfo=timezone.utc),
+            end_time=datetime(2026, 8, 6, 18, 0, tzinfo=timezone.utc),
+            duration_hours=6.0, distance_km=5.0, ascent_m=300.0, descent_m=100.0,
+        ),
+        timeseries=None, aggregated=aggregiert,
+        fetched_at=datetime(2026, 8, 5, 18, 0, tzinfo=timezone.utc),
+        provider="openmeteo",
+    )
+
+
+def test_ac8_snapshot_roundtrip_erhaelt_die_herkunft(caplog):
+    """AC-8: Given ein versendeter Schnappschuss traegt die Herkunfts-Angabe,
+    When er gespeichert und spaeter wieder geladen wird, Then kommt dieselbe
+    Angabe zurueck -- ohne dass ein Serialisierungsfehler sie still (nur als
+    ``logger.warning``) verschluckt."""
+    from services.weather_snapshot import WeatherSnapshotService
+
+    dienst = WeatherSnapshotService(user_id="tdd-1680")
+    segment = _segment(SegmentWeatherSummary(
+        temp_max_c=20.0, thunder_level_max=ThunderLevel.HIGH,
+        thunder_level_max_signals=["cape", "blitzpotenzial"],
+    ))
+    with caplog.at_level(logging.WARNING, logger="services.weather_snapshot"):
+        dienst.save(_TRIP, [segment], _TAG)
+    geladen = dienst.load(_TRIP)
+    warnungen = [r for r in caplog.records if r.name == "services.weather_snapshot"]
+
+    assert not warnungen, (
+        f"Das Speichern darf nicht in den Warn-Pfad laufen (dort geht der "
+        f"Schnappschuss still verloren): {[r.message for r in warnungen]!r}")
+    assert geladen is not None, "Der Schnappschuss muss ladbar sein."
+    assert geladen[0].aggregated.thunder_level_max_signals == ["cape", "blitzpotenzial"], (
+        f"Die Herkunft muss den Roundtrip unveraendert ueberstehen: "
+        f"{geladen[0].aggregated.thunder_level_max_signals!r}")
+
+
+def test_ac9_alter_schnappschuss_ohne_feld_laedt_und_rendert_ohne_herkunft():
+    """AC-9: Given ein vor dieser Aenderung erzeugter Schnappschuss kennt das
+    neue Feld nicht, When er geladen und die Vergleichsmail gerendert wird,
+    Then steht das Feld auf ``None``, die Stufe erscheint unveraendert und es
+    gibt weder Fehler noch Herkunfts-Zusatz."""
+    from services.weather_snapshot import _deserialize_summary
+
+    alt = _deserialize_summary({
+        "temp_max_c": 20.0, "thunder_level_max": "HIGH", "hail_flag": None,
+    })
+    assert alt.thunder_level_max_signals is None, (
+        f"Ein Alt-Schnappschuss ohne das Feld muss mit None laden: "
+        f"{alt.thunder_level_max_signals!r}")
+
+    ort = LocationResult(
+        location=SavedLocation(id="altort", name="Altort", lat=47.0, lon=12.0,
+                               elevation_m=1000),
+        score=50, hourly_data=[], thunder_level_max=alt.thunder_level_max,
+    )
+    html, _ = render_compare_email(
+        ComparisonResult(locations=[ort], time_window=(12, 20), target_date=_TAG,
+                         created_at=datetime(2026, 8, 5, 18, 0)),
+        enabled_metrics=["thunder_max"], hourly_enabled=False,
+    )
+    assert _html_zellen(html) == ["hoch"], (
+        f"Ohne gespeicherte Herkunft zeigt die Zeile nur die Stufe: "
+        f"{_html_zellen(html)!r}")

--- a/tests/unit/test_weather_metrics.py
+++ b/tests/unit/test_weather_metrics.py
@@ -126,14 +126,17 @@ class TestWeatherMetricsServiceKnownValues:
         """
         GIVEN: Timeseries
         WHEN: compute_basis_metrics(timeseries)
-        THEN: aggregation_config has 13 entries with correct functions
+        THEN: aggregation_config has 14 entries with correct functions
 
         Issue #1475 S5a: 12 -> 13 Eintraege — `hail_flag` ("hail_priority")
         ist als Tages-/Etappen-Aggregat hinzugekommen (Spec AC-4).
+        Issue #1680 S1: 13 -> 14 Eintraege — `thunder_level_max_signals`
+        ("union_of_max_carriers") haelt fest, WELCHE Zutaten das
+        Gewitter-Tagesmaximum tragen (Spec AC-10).
         """
         result = service.compute_basis_metrics(known_timeseries)
 
-        assert len(result.aggregation_config) == 13
+        assert len(result.aggregation_config) == 14
         assert result.aggregation_config["temp_min_c"] == "min"
         assert result.aggregation_config["temp_max_c"] == "max"
         assert result.aggregation_config["temp_avg_c"] == "avg"
@@ -147,6 +150,12 @@ class TestWeatherMetricsServiceKnownValues:
         assert result.aggregation_config["dominant_wmo_code"] == "max_wmo_severity"
         assert result.aggregation_config["dni_avg_wm2"] == "avg"
         assert result.aggregation_config["hail_flag"] == "hail_priority"
+        # Issue #1680 S1: ohne diesen Eintrag faellt die Herkunft der
+        # Gewitterstufe bei der Etappen-Aggregation (aggregate_stage())
+        # stillschweigend heraus — ein reiner Zaehltest waere hier blind
+        # fuer "falscher Schluessel drin, thunder_level_max_signals fehlt".
+        assert (result.aggregation_config["thunder_level_max_signals"]
+                == "union_of_max_carriers")
 
 
 class TestWeatherMetricsServiceTemperature:


### PR DESCRIPTION
## Worum es geht

Im Ortsvergleich standen bisher zwei Orte mit „hoch" nebeneinander, ohne dass erkennbar war, dass die Stufen auf völlig verschiedenen physikalischen Größen beruhen — Korsika auf gemessener Blitzdichte, die Alpen auf CAPE bzw. Blitzpotenzial. Die Zeile suggerierte eine Vergleichbarkeit, die es auf Rohdaten-Ebene nicht gab.

Jetzt trägt die Stufe ihre Herkunft mit:

```
Alpenort      Gewitter hoch · CAPE
Korsikaort    Gewitter hoch · Blitzdichte
```

Genannt werden **alle** tragenden Signale, nicht nur eines — damit wird keine interne Gewinner-Reihenfolge zur Produktaussage.

## Kanäle

| Kanal | Herkunft |
|---|---|
| E-Mail (HTML + Klartext) | ja |
| Telegram | ja |
| SMS / Premium-SMS | **nein, aktiv abgewählt** |

Die SMS-Abwahl ist eine PO-Entscheidung und steht mit Begründung im Code: 153 Zeichen Gesamtbudget, der GSM-7-Filter entstellt den Trenner, und der `+N`-Mechanismus hätte hintere Metriken verdrängt. Eine reine Default-Belassung wäre nicht von einem vergessenen Anschluss zu unterscheiden.

## Wie es gebaut ist

Additiv: `thunder_level_from_signals()` bleibt zeichengleich, die Träger kommen aus einer zweiten öffentlichen Funktion. Kosten an den 11 Bestandstestdateien der Fusion: null. Der Breaking-Weg hätte 40 Aufrufstellen und ~27 Assertions gekostet.

Die neuen Felder sind bewusst `list[str]`, nie `list[ThunderLevel]` — die Snapshot-Serialisierung behandelt nur skalare Enums, und ein Fehler dort wird still verschluckt: der komplette Schnappschuss wäre weg, ohne Meldung.

## Zwei Korrekturen, die erst beim Nachmessen auffielen

**AC-12** kam nach der ersten Spec-Fassung dazu. Die Annahme „das funktioniert wie beim Hagel-Kennzeichen, also immer live abgeleitet" trägt für Gewitter nicht: `LocationResult.thunder_level_max` existiert als Feld und hat in `_metric_value()` Vorrang. Ohne Kohärenz-Bedingung hätte die Zeile eine Stufe aus dem Engine-Lauf mit einer Herkunft aus einer zweiten Rechnung gepaart. Jetzt gilt: passt die Herkunft nicht zur gezeigten Stufe, erscheint keine.

Das Issue-Beispiel „hoch, Blitzpotenzial+Superzelle" ist **nicht baubar** — Superzellen sind keine Zutat der Fusion. Die Fusion hat vier: Wettercode, Blitzdichte, CAPE, Blitzpotenzial.

## Nachweis

- **12 ACs**, jedes durch die vollständige Renderkette bis zum zurückgegebenen Body geprüft
- **Adversary, 3 Runden:** 4 Findings gefunden und behoben. Alle vier lagen in den **Tests**, nicht im Produktivcode — darunter ein handgeschriebener Wert, der den echten Rechenweg umging, und ein Zähltest in `tests/unit`, der durch den 14. `aggregation_config`-Eintrag rot geworden war
- **Alle sechs Pflicht-Mutationen plus vier eigene** werden von Tests gefangen
- **Echt zugestellte Vergleichs-Mail:** `email_spec_validator.py` Exit 0

Die Abwesenheits-Zusicherungen (AC-3/5/11/12) tragen jeweils im selben Test gegen dieselbe Fixture eine Anwesenheits-Gegenprobe — sonst wären sie auch dann grün, wenn die Herkunft nirgends erschiene.

## Bewusst offen

`aggregate_stage()` kennt die neue Aggregationsregel nicht (Known Limitation 7, gebucht in #1199). Heute nicht erreichbar — der einzige Lesepunkt umgeht diesen Pfad strukturell. Die Scheibe, die die Herkunft auf die Trip-Seite bringt, muss es zuerst lösen.

Nicht in dieser Scheibe: Trip-Mail-Pill, Nachtblock, Kurzzusammenfassung, Mehrtages-Ausblick, GEWITTER-Kommando, Compare-Stundentabelle, Go-DTO, Frontend.

Bezug: #1680, Epic #1419 Rang 4 (Entscheidung E1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)