### PR TITLE
fix(#1744 A1): Alarm-Ortsangabe — eine Sprache statt zwei

### DIFF
--- a/.claude/hooks/radar_alert_mail_validator.py
+++ b/.claude/hooks/radar_alert_mail_validator.py
@@ -46,9 +46,24 @@ _INTENSITY_LABELS = [
     "Regen",     # Fallback: Teilstring
 ]
 
-# Segment-Erkennungs-Muster: "Etappe N", "km X-Y", oder generischer Segment-Label
+# Segment-Erkennungs-Muster: "Etappe N", "km X-Y", generischer Segment-Label
+# oder die Ziel-Form.
+#
+# Issue #1744 A1 (2026-08-12, an der zugestellten Mail gemessen): seit die
+# Alarme EINE Ortssprache sprechen, nennt eine Radar-Alarm-Mail fuer die letzte
+# Etappe den Ort als "🏁 Ziel" (`segments.format_segment_reference`). Das traf
+# KEINE der vier bisherigen Alternativen — der Waechter beanstandete eine
+# korrekte, PO-freigegebene Ausgabe (P-1, Exit 1) und haette damit jede
+# Ziel-Segment-Warnung blockiert. Die Ziel-Form kommt additiv dazu; keine der
+# vier bestehenden Alternativen wurde entfernt oder gelockert.
+#
+# Das Flaggen-Symbol ist BEWUSST nicht Teil der Bedingung: geprueft wird das
+# Ortswort, nicht seine Dekoration — sonst haengt der Waechter an einem Emoji.
+# Dass die Pruefung ihre Zaehne behaelt (Body ganz ohne Ortsbezug faellt
+# weiterhin durch), sichert
+# tests/tdd/test_radar_alert_validator_location_forms.py.
 _SEGMENT_RE = re.compile(
-    r"(Etappe\s+\d+|km\s+\d+\s*[–\-]\s*\d+|\bseg\b|\bSegment\b)",
+    r"(Etappe\s+\d+|km\s+\d+\s*[–\-]\s*\d+|\bseg\b|\bSegment\b|\bZiel\b)",
     re.IGNORECASE,
 )
 

--- a/docs/context/fix-1744-a-alarm-format.md
+++ b/docs/context/fix-1744-a-alarm-format.md
@@ -1,0 +1,125 @@
+# Context: fix-1744-a-alarm-format
+
+Issue #1744, Scheibe A. Scheibe B (quellenübergreifende Entdopplung) ist an #1467 S4 gebucht
+und **nicht** Gegenstand dieses Workflows.
+
+## Request Summary
+
+Zwei Alarm-Mails zum selben Ereignis sehen für den Nutzer völlig unterschiedlich aus. Der
+Ortsbezug wird in zwei verschiedenen Vokabularen ausgedrückt — `km 8–8` (Radar-Nowcast) gegen
+`🏁 Ziel` (amtliche Warnung) — sodass nicht erkennbar ist, ob derselbe Ort gemeint ist. Das
+Format soll angeglichen werden.
+
+## Der Rahmen ist bereits gemeinsam — nur ein Feld weicht ab
+
+Beide Betreffzeilen haben dieselbe Bauform `[Trip] <Ort> · <Kern>`:
+
+    [KHW 403] km 8–8 · Gewitter in 8 Min          (Radar-Nowcast)
+    [KHW 403] 🏁 Ziel · GELB Gewitter (Di)        (amtliche Warnung)
+
+Die Aufgabe ist damit keine Neukonstruktion, sondern eine **Entscheidung über den Ortsslot**.
+
+## Zwei Betreff-Bauer, nicht mehr
+
+| Funktion | Datei:Zeile | Deckt ab |
+|---|---|---|
+| `render_subject()` (+ `_render_subject_onset()` `render.py:142`) | `src/output/renderers/alert/render.py:294-325` | Trip-Δ, Vergleich-Δ, Trip-Nowcast, Vergleich-Nowcast |
+| `render_official_alert_subject()` | `src/output/renderers/alert/official_alerts.py:859-919` | amtliche Warnung, Trip **und** Vergleich (eine Funktion, `scope_kind="route"\|"locations"`) |
+
+(`output/subject.py::build_email_subject` ist ein dritter Bauer, aber nur für die
+Briefing-Mail — kein Alarm-Pfad.)
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/output/renderers/alert/render.py:100-111` | `_km_str`, `_km_str_onset` — Quelle des `km {a}–{b}`-Formats |
+| `src/output/renderers/alert/render.py:294-325` | `render_subject` — Betreff Δ/Onset/Korridor |
+| `src/output/renderers/alert/render.py:361-388` | E-Mail-Datenblock „Wo & wann" |
+| `src/output/renderers/alert/render.py:551-584` | `render_telegram` (Kopfzeile mit km) |
+| `src/output/renderers/alert/render.py:619-687` | `render_sms` — Kurzform, **Grenze 140 Zeichen** |
+| `src/output/renderers/alert/official_alerts.py:264-291` | `format_segment_reference` — Quelle von `Segment 3–5` / `🏁 Ziel` / `N Segmente` |
+| `src/output/renderers/alert/official_alerts.py:834-919` | `_scope_display`, `render_official_alert_subject` |
+| `src/output/renderers/alert/official_alerts.py:1936-1995` | `build_official_alert_notices` — baut `scope_label` und `sms_scope` |
+| `src/output/renderers/alert/model.py:20-80` | `AlertEvent`/`OnsetEvent`/`CorridorEvent`/`AlertMessage` — Ortsfelder |
+| `src/output/renderers/alert/project.py:96-221, 300-315` | Projektion Domäne → Renderer-Modell; setzt `location_label` |
+| `src/services/trip_segments.py:299-320` | erzeugt `segment_id="Ziel"` |
+| `src/app/models.py:386-401` | `TripSegment` — trägt `segment_id`, **keinen Namen** |
+
+## Der entscheidende Befund: das Δ/Onset-Modell kennt keine Segmente
+
+| Dataclass | Ortsfelder | Segment-Kennung? | Sprechender Name? |
+|---|---|---|---|
+| `AlertEvent` (`model.py:20-27`) | `km_from`, `km_to`, `location_label` | **nein** | nur `location_label`, und das setzt der Trip-Pfad **nie** |
+| `OnsetEvent` (`model.py:31-45`) | dito | **nein** | dito |
+| `CorridorEvent` (`model.py:49-61`) | dito | **nein** | `location_label` wird **nirgends** gesetzt |
+| `OfficialAlertNotice` | `scope_label`, `affected_chips`, `sms_scope` | **ja** (aus rohen `segment_id`) | — |
+
+`"🏁 Ziel"` ist damit **keine Ortsnamens-Auflösung**, sondern das Rendering des literalen
+Strings `segment_id="Ziel"` durch `format_segment_reference`. Der Δ/Onset-Pfad sieht das
+Ziel-Segment ausschließlich als km-Wert (`km_from == km_to == cumulative_dist_km`), weil die
+Segment-Zuordnung dort nur über `distance_from_start_km` läuft.
+
+**Ein sprechender Ortsname ist für Trip-Segmente heute nicht verlässlich verfügbar:**
+`TripSegment` hat kein Namensfeld; erreichbar wäre nur `TripSegment.waypoint.name`
+(`DetectedWaypoint.name`, `app/models.py:375`) — optional und nur gesetzt, wenn in der Nähe ein
+benannter GPX-Wegpunkt liegt.
+
+**Der Ortsvergleich ist bereits konsistent:** dort sprechen beide Alarmarten in Ortsnamen
+(`location_label` bzw. `"alle Orte"`/`"nur Toulon"`). Uneinheitlich ist allein der **Trip**-Pfad.
+
+## Existing Patterns
+
+- **`format_segment_reference()`** (`official_alerts.py:264-291`) ist die einzige bestehende
+  gemeinsame Ortsformatierung: Range-Verdichtung (`Segment 3–5`), Aufzählung (`Segment 3, 5`),
+  Ziel-Sonderfall (`🏁 Ziel`), Verdichtung ab >4 Segmenten (`N Segmente`).
+- **Additive optionale Ortsfelder** sind das etablierte Erweiterungsmuster: `location_label`
+  wurde in #1169/#1170/#1041 genau so eingeführt — neues Feld mit Default `None`, Trip-Pfad
+  setzt es nicht, Regressions-Invariante per Golden-Test abgesichert.
+
+## Existing Specs & ADRs
+
+| Dokument | Was es festlegt |
+|---|---|
+| `docs/specs/modules/warnmail_official_alert_display.md` AC-3 (#1248) | Betreff nennt bei **gemischtem** Umfang eine ehrliche Sammelangabe („mehrere Segmente"), nie ein führendes Einzelsegment |
+| `docs/adr/0033-warn-karte-nur-betroffene-segmente.md` | Warn-Karte nennt ausschließlich den betroffenen Umfang; `free_chips` im Trip-Pfad fest `[]` |
+| `docs/adr/0042-namensform-folgt-der-platzgrenze.md` | Namensklassen für **Metrik**-Labels (nicht für Ortsangaben) |
+| `docs/specs/modules/sms_official_alert_tokens.md` | SMS-Kurzform amtlicher Warnungen inkl. `sms_scope` |
+| PO-Entscheid 2026-08-04 (`e9f23605`, #1467 S2 AG3b) | **Alarm-Kurznachrichten nennen keinen Ort** — die Positionszahl ist die Ortsangabe |
+
+## Risks & Considerations
+
+1. **Die Kurzform ist ausgenommen.** Ein Ortsname in der SMS würde den PO-Entscheid vom
+   2026-08-04 rückgängig machen. Scheibe A betrifft E-Mail, Telegram-Langform und Betreff.
+2. **Zeichengrenze ist 140, nicht 160.** Alle drei Alarm-SMS-Renderer sind auf `limit: int = 140`
+   verdrahtet (`render.py:285`, `render.py:621`, `official_alerts.py:1836`). Die 160 gilt nur für
+   die Briefing-SMS.
+3. **ADR-0033 und AC-3 dürfen nicht still fallen.** Würde die amtliche Warnung auf km-Spannen
+   umgestellt, kollidiert das mit der Sammelangabe-Regel bei gemischtem Umfang. Abweichung ⇒
+   neues ADR, nie stille Rücknahme.
+4. **Der Korridor-Renderer ist toter Code — nicht mit angleichen.** `evaluate_corridor_thresholds()`
+   (`src/services/corridor_threshold.py:68`) hat **keinen** Aufrufer in `src/`/`api/`; der Auslöser
+   wurde am 2026-08-03 in `8f2053f9` (#1460 P1a) bewusst abgelöst („löst #1444 S1 ab", absolute
+   Grenzen standen quer zu ADR-0009/ADR-0013). `corridor_hits` bleibt im Produktivlauf immer leer.
+   Ein Angleichen dieses Pfades wäre Blindleistung und würde eine Fähigkeit suggerieren, die es
+   nicht gibt.
+5. **Renderer-Commit-Gate greift.** Jede Änderung an `src/output/renderers/alert/*.py` blockiert
+   den Commit, bis `tests/tdd/test_issue_811_mode_matrix.py` grün ist und ein
+   `briefing_mail_validator.py`-Lauf bestanden hat.
+6. **Golden-Tests sichern die heutigen Betreffe byte-genau.** Jede Formatänderung zieht mindestens
+   nach: `tests/tdd/test_issue_1169_compare_alert_consumer.py:709`,
+   `tests/tdd/test_issue_917_alert_renderer.py:205`,
+   `tests/tdd/test_issue_919_radar_alert_canonical.py:69`,
+   `tests/tdd/test_official_alert_subject_compact.py:126`.
+7. **Trip/Vergleich-Teilungsregel.** Die Angleichung muss auf **eine** gemeinsame
+   Ortsformatierung hinauslaufen, nicht auf zwei gepflegte Zweitfassungen.
+
+## Nebenbefunde (getrennt gebucht, nicht Teil dieses Workflows)
+
+- **Mehrort-Nowcast verliert in Kurzform alle Orte außer dem ersten.**
+  `_render_sms_onset` (`render.py:285-291`) und `_render_telegram_onset` (`render.py:276-282`)
+  lesen ausschließlich `msg.events[0]`, obwohl `to_multi_location_onset_alert_message`
+  (`project.py:300-315`) N Ereignisse baut. Bewusster Scope-Schnitt aus #1041 Slice 1a, seither
+  ohne Nachzug und ohne Test. → eigenes Issue.
+- **Toter Korridor-Render-Pfad** (Modell, Projektion, vier Renderer, eigener Betreff-Zweig).
+  → Sammel-Eintrag #1199.

--- a/docs/specs/modules/fix_1744_alarm_format_angleichen.md
+++ b/docs/specs/modules/fix_1744_alarm_format_angleichen.md
@@ -27,8 +27,15 @@ Nicht Gegenstand: die quellenübergreifende Entdopplung mehrerer Alarme zum selb
 
 - **Datei:** `src/output/renderers/alert/render.py`, `src/output/renderers/alert/official_alerts.py`,
   `src/output/renderers/alert/model.py`, `src/output/renderers/alert/project.py`
-- **Identifier:** `_km_str`, `_km_str_onset`, `render_subject`, `format_segment_reference`,
-  `AlertEvent`, `OnsetEvent`, `to_alert_message`
+- **Identifier:** `_km_str`, `_km_str_onset`, **`_km_str_events`**, `render_subject`,
+  `format_segment_reference`, `AlertEvent`, `OnsetEvent`, `to_alert_message`
+
+🔴 **Es sind DREI km-Bauer, nicht zwei** (in der RED-Phase 2026-08-12 nachgemessen):
+`_km_str` (`render.py:100-107`), `_km_str_onset` (`render.py:110-111`) und
+**`_km_str_events` (`render.py:386-388`)**. Der dritte speist die Zeile „Wo & wann" der
+Abweichungsmail (`render.py:379`) — also genau die Stelle, die AC-6 regelt. Wer nur die beiden
+erstgenannten umstellt, lässt AC-6 rot. (Ein vierter, `_corridor_when` bei `render.py:117-121`,
+gehört zum toten Korridor-Pfad und bleibt außen vor.)
 
 Schicht: **Python-Core** (Renderer + Projektion). Keine Go-Änderung, keine Frontend-Änderung.
 
@@ -142,11 +149,17 @@ Ortsbezug, Quelle) wird zu Datenzeilen im Aufbau des Nowcasts.
   - Test: die bestehenden Golden-Vergleiche des Ortsvergleichs laufen unverändert grün
     (`tests/tdd/test_issue_1169_compare_alert_consumer.py`).
 
-- **AC-5:** Given ein Trip-Alarm / When die Kurznachricht (SMS und Premium-SMS) gerendert wird /
-  Then nennt sie weiterhin **keinen** Ortsnamen und bleibt innerhalb von 140 Zeichen — der
-  PO-Entscheid vom 2026-08-04 bleibt unangetastet.
+- **AC-5:** Given ein Trip-Abweichungs- oder Nowcast-Alarm / When die Kurznachricht (SMS und
+  Premium-SMS) über `render_sms` gerendert wird / Then nennt sie weiterhin **keinen** Ortsbezug
+  und bleibt innerhalb von 140 Zeichen — der PO-Entscheid vom 2026-08-04 bleibt unangetastet.
   - Test: Kurznachricht für einen Trip-Alarm mit Ziel-Segment rendern; sie darf weder `Ziel`
     noch `Segment` enthalten, und ihre Länge bleibt ≤ 140.
+  - **Abgrenzung (in der RED-Phase gemessen):** Die Kurznachricht der **amtlichen Warnung** ist
+    davon NICHT betroffen — sie trägt seit jeher einen eigenen Kurz-Ortsbezug
+    (`render_official_alert_sms` → `sms_scope`, `official_alerts.py:1960-1967`), gemessene
+    Ist-Ausgabe `KHW403 AMT GELB1/3: TH Mi14-22, nur Ziel`. Das ist Bestand aus #1318 und in
+    `sms_official_alert_tokens.md` geregelt. AC-5 gilt ausschließlich für `render_sms`; wer den
+    amtlichen SMS-Pfad „mit angleicht", bricht eine andere Spec.
 
 - **AC-6:** Given eine Alarm-Mail mit Ortsangabe im Betreff / When der Mail-Körper gerendert
   wird / Then nennt die Zeile „Wo & wann" **denselben** Ortstext wie der Betreff — innerhalb

--- a/docs/specs/modules/fix_1744_alarm_format_angleichen.md
+++ b/docs/specs/modules/fix_1744_alarm_format_angleichen.md
@@ -12,7 +12,7 @@ tags: [alerts, renderer, email, subject]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-Freigabe 2026-08-12 („go"), ACs auf Deutsch vorgelegt
 
 ## Purpose
 

--- a/docs/specs/modules/fix_1744_alarm_format_angleichen.md
+++ b/docs/specs/modules/fix_1744_alarm_format_angleichen.md
@@ -1,0 +1,208 @@
+---
+entity_id: fix_1744_alarm_format_angleichen
+type: module
+created: 2026-08-12
+updated: 2026-08-12
+status: draft
+version: "1.0"
+tags: [alerts, renderer, email, subject]
+---
+
+# Alarm-Format angleichen: eine Ortssprache für alle Trip-Alarme (#1744 Scheibe A)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Zwei Alarm-Mails zum selben Ereignis nennen den Ort heute in zwei verschiedenen Sprachen
+(`km 8–8` gegen `🏁 Ziel`) und sind auch im Aufbau kaum als verwandt zu erkennen. Diese Spec
+gibt allen Trip-Alarmen **eine** Ortssprache — die Segment-Kennung — und **einen** Mail-Aufbau.
+
+Nicht Gegenstand: die quellenübergreifende Entdopplung mehrerer Alarme zum selben Ereignis
+(Scheibe B, gebucht an #1467 S4).
+
+## Source
+
+- **Datei:** `src/output/renderers/alert/render.py`, `src/output/renderers/alert/official_alerts.py`,
+  `src/output/renderers/alert/model.py`, `src/output/renderers/alert/project.py`
+- **Identifier:** `_km_str`, `_km_str_onset`, `render_subject`, `format_segment_reference`,
+  `AlertEvent`, `OnsetEvent`, `to_alert_message`
+
+Schicht: **Python-Core** (Renderer + Projektion). Keine Go-Änderung, keine Frontend-Änderung.
+
+## Estimated Scope
+
+Zwei Liefer-Scheiben, ein gemeinsames Zielbild.
+
+| Scheibe | Inhalt | LoC (Produktiv) | Dateien |
+|---|---|---|---|
+| **A1** | Ortsangabe + Betreff | ~90 | 6 |
+| **A2** | Mail-Körper | ~130 | 2 |
+
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `format_segment_reference` | Funktion | bestehende Ortsformatierung der amtlichen Warnung — wird zur gemeinsamen |
+| `TripSegment.segment_id` | Feld | Quelle der Kennung (`1..N` oder `"Ziel"`) |
+| ADR-0033 | Entscheidung | Warn-Karte nennt nur betroffenen Umfang — bleibt inhaltlich bindend |
+| `warnmail_official_alert_display.md` AC-3 | Spec | ehrliche Sammelangabe bei gemischtem Umfang — bleibt bindend |
+| PO-Entscheid 2026-08-04 (#1467 S2 AG3b) | Entscheidung | Kurznachrichten nennen keinen Ort — bleibt bindend |
+
+## Implementation Details
+
+### Woher die Segment-Kennung kommt
+
+Sie ist an beiden Stellen bereits zur Hand und wird nur nicht weitergereicht:
+
+```
+Abweichungsalarm: project.py:88   match = _find_segment(segments, ch.segment_id)
+                                  → heute nur match.segment.start_point.distance_from_start_km
+                                  → künftig zusätzlich match.segment.segment_id
+
+Nowcast:          trip_alert.py:1098  active.start_point.distance_from_start_km
+                                  → künftig zusätzlich active.segment_id
+                                  → über RadarAlertRequest nach notification_service.py:1234
+```
+
+### Eine Formatierung, zwei Aufrufer
+
+`format_segment_reference()` (heute `official_alerts.py:262-289`) zieht in ein eigenes Modul um
+und wird von **beiden** Renderern importiert. Weder `render.py` noch `official_alerts.py`
+importieren einander heute — der Umzug ist zyklenfrei.
+
+Auflösungsreihenfolge der Ortsangabe (eine Funktion, alle Alarmarten):
+
+```
+1. location_label gesetzt      → Ortsname               (Ortsvergleich, unverändert)
+2. Segment-Kennung vorhanden   → format_segment_reference()
+3. sonst                       → km {von}–{bis}          (Rückfall, z.B. Altdaten)
+```
+
+### Gemeinsamer Mail-Aufbau (A2)
+
+Beide Mailtypen folgen derselben Reihenfolge. Typ-eigene Bausteine sitzen an **festen**
+Positionen, statt den Aufbau zu verdoppeln:
+
+```
+Kennzeichen (Alarmart)          beide
+Überschrift (Kernaussage)       beide
+Warnstufen-Skala                nur amtliche Warnung
+Datenzeilen                     beide   ← hier gleicht sich die amtliche Warnung an
+Sperrzeit-Hinweis               nur Nowcast
+Stand-Zeile                     beide
+Herkunfts-Fußzeile              beide
+```
+
+Die Warnstufen-Skala (GELB · ORANGE · ROT mit „niedrigste von drei") bleibt als **Skala**
+erhalten und wandert nicht in eine Textzeile: sie trägt eine Einordnung, die eine bloße
+Wortangabe verliert. Alles Übrige der amtlichen Warnung (Gefahrenart, Gültigkeitsfenster,
+Ortsbezug, Quelle) wird zu Datenzeilen im Aufbau des Nowcasts.
+
+## Expected Behavior
+
+- **Input:** Trip-Alarme aller Arten (Abweichung, Nowcast, amtliche Warnung), Ortsvergleich-Alarme.
+- **Output:** Betreff, E-Mail (HTML + Text) und Telegram-Langform nennen den Ort in derselben
+  Sprache; beide Mailtypen haben denselben Aufbau.
+- **Side effects:** keine. Reine Darstellungs- und Projektionsänderung, keine Auslöselogik,
+  keine Persistenz, kein Kanal-Routing.
+
+## Acceptance Criteria
+
+### Scheibe A1 — Ortsangabe und Betreff
+
+- **AC-1:** Given ein Trip-Nowcast-Alarm für das Ziel-Segment / When die Alarm-Mail versendet
+  wird / Then nennt die Betreffzeile `🏁 Ziel` statt `km 8–8`, und der Betreff einer amtlichen
+  Warnung für dasselbe Segment nennt denselben Text — die beiden Mails sind als derselbe Ort
+  erkennbar.
+  - Test: beide Mails für denselben Trip und dasselbe Segment rendern und die Ortsangabe der
+    beiden Betreffzeilen auf Gleichheit prüfen. Der Test muss rot werden, wenn nur einer der
+    beiden Pfade umgestellt ist.
+
+- **AC-2:** Given ein Trip-Abweichungsalarm, der die Segmente 3, 4 und 5 betrifft / When der
+  Betreff gerendert wird / Then steht dort `Segment 3–5` — dieselbe Zusammenfassung, die eine
+  amtliche Warnung über dieselben drei Segmente erzeugt.
+  - Test: Abweichungsalarm über drei zusammenhängende Segmente rendern und mit der Ausgabe der
+    amtlichen Warnung über dieselben Segment-Kennungen vergleichen.
+
+- **AC-3:** Given irgendein Trip-Alarm mit Ortsangabe / When die Ortsangabe gebildet wird /
+  Then geschieht das über **genau eine** Funktion: eine Verfälschung dieser Funktion (z.B.
+  `Segment` → `Etappe`) muss den Nowcast-Test, den Abweichungstest UND den Test der amtlichen
+  Warnung gleichzeitig rot machen.
+  - Test: Mutations-Gegenprobe. Bleibt einer der drei grün, existiert noch eine zweite
+    Formatierung — das ist ein Verstoß gegen die Teilungsregel.
+
+- **AC-4:** Given ein Alarm im Ortsvergleich (ein Ort oder mehrere) / When Betreff, Mail und
+  Telegram gerendert werden / Then erscheinen weiterhin die Ortsnamen, unverändert zu heute —
+  die Segment-Kennung greift dort nicht.
+  - Test: die bestehenden Golden-Vergleiche des Ortsvergleichs laufen unverändert grün
+    (`tests/tdd/test_issue_1169_compare_alert_consumer.py`).
+
+- **AC-5:** Given ein Trip-Alarm / When die Kurznachricht (SMS und Premium-SMS) gerendert wird /
+  Then nennt sie weiterhin **keinen** Ortsnamen und bleibt innerhalb von 140 Zeichen — der
+  PO-Entscheid vom 2026-08-04 bleibt unangetastet.
+  - Test: Kurznachricht für einen Trip-Alarm mit Ziel-Segment rendern; sie darf weder `Ziel`
+    noch `Segment` enthalten, und ihre Länge bleibt ≤ 140.
+
+- **AC-6:** Given eine Alarm-Mail mit Ortsangabe im Betreff / When der Mail-Körper gerendert
+  wird / Then nennt die Zeile „Wo & wann" **denselben** Ortstext wie der Betreff — innerhalb
+  einer Mail gibt es keine zwei Ortssprachen mehr.
+  - Test: Betreff und Datenzeile derselben gerenderten Mail gegeneinander prüfen.
+
+- **AC-7:** Given ein Trip-Alarm, dessen Etappe keine Segment-Kennung trägt (Altdaten) / When
+  die Ortsangabe gebildet wird / Then fällt sie auf die km-Spanne zurück, statt leer zu bleiben
+  oder den Versand abzubrechen.
+  - Test: Alarm ohne Segment-Kennung rendern; Ortsangabe ist nicht leer und der Versand läuft.
+
+### Scheibe A2 — Mail-Körper
+
+- **AC-8:** Given je eine Nowcast-Mail und eine amtliche Warn-Mail / When beide gerendert werden /
+  Then haben sie dieselbe Reihenfolge der Bausteine (Kennzeichen, Überschrift, Datenzeilen,
+  Stand-Zeile, Fußzeile), und die Fakten der amtlichen Warnung stehen in Datenzeilen derselben
+  Bauform wie beim Nowcast.
+  - Test: beide Mails rendern und die Abfolge der Bausteine vergleichen.
+
+- **AC-9:** Given eine amtliche Warnung der Stufe GELB / When die Mail gerendert wird / Then ist
+  die Warnstufe weiterhin als **Skala** erkennbar (GELB · ORANGE · ROT mit der Einordnung
+  „niedrigste von drei") und nicht auf ein einzelnes Wort reduziert.
+  - Test: gerenderte Mail enthält alle drei Stufenbezeichnungen und die Einordnung.
+
+- **AC-10:** Given eine amtliche Warnung im neuen Aufbau / When die Mail gerendert wird / Then
+  enthält sie unverändert Gefahrenart, Gültigkeitsfenster, Ortsbezug und Quelle — durch den
+  Umbau geht keine Information verloren.
+  - Test: jede Angabe der heutigen Mail einzeln im neuen Aufbau nachweisen.
+
+- **AC-11:** Given ein Trip mit 63 Segmenten und einer Warnung für 1 Segment / When die Mail
+  gerendert wird / Then erscheinen weiterhin **keine** nicht betroffenen Segmente — ADR-0033
+  bleibt gewahrt.
+  - Test: der bestehende ADR-0033-Test bleibt grün
+    (`tests/tdd/test_official_alert_template_render.py`).
+
+- **AC-12:** Given mehrere amtliche Warnungen mit **verschiedenem** Umfang / When der Betreff
+  gerendert wird / Then steht dort weiterhin die ehrliche Sammelangabe („mehrere Segmente") und
+  nicht ein einzelnes Segment — AC-3 der Warnmail-Spec (#1248) bleibt gewahrt.
+  - Test: der bestehende Test bleibt grün
+    (`tests/tdd/test_official_alert_subject_compact.py`).
+
+## Was sich ausdrücklich NICHT ändert
+
+- Auslösung, Cooldown, Kanal-Routing, Empfängerauflösung, Ruhezeiten, Tageslimit.
+- Die Kurznachricht (SMS, Premium-SMS) — weder Ortsangabe noch Aufbau.
+- Der Ortsvergleich — dort ist die Ortssprache bereits einheitlich.
+- Der Korridor-/Schwellen-Renderer — toter Code seit `8f2053f9` (#1460 P1a), siehe #1199.
+
+## Risiken
+
+1. **Golden-Tests brechen absichtlich.** Mindestens vier Testdateien sichern die heutigen
+   Betreffe byte-genau und müssen mit dem Produktivfix zusammen umgestellt werden — nie vorher,
+   sonst beweist der Test nichts.
+2. **Renderer-Commit-Gate greift.** Jeder Commit an `src/output/renderers/alert/*.py` blockt, bis
+   `tests/tdd/test_issue_811_mode_matrix.py` grün ist und ein `briefing_mail_validator.py`-Lauf
+   bestanden hat.
+3. **A2 berührt ADR-0033-Fläche.** Die Entscheidung selbst (nur betroffener Umfang) bleibt gültig;
+   geändert wird nur ihr Träger. Ein neues ADR hält den geänderten Aufbau fest und verweist auf
+   ADR-0033 als weiterhin bindend.

--- a/scripts/send_gate_test_mails.py
+++ b/scripts/send_gate_test_mails.py
@@ -339,11 +339,12 @@ def build_radar_alert_message(token: str) -> AlertMessage:
         # zurueck -- die Nachweis-Mail zeigte dann genau das Format, das der
         # Produktivpfad seit #1744 NICHT mehr sendet, und der Validator-Lauf
         # bestaetigte eine Darstellung, die es nicht mehr gibt.
-        # BEWUSST numerisch statt "Ziel": `radar_alert_mail_validator.py:49-52`
-        # kennt "Etappe N"/"km X-Y"/"Segment", aber NICHT den Ziel-Sonderfall
-        # "🏁 Ziel" -- mit segment_id="Ziel" faellt P-1, obwohl die Mail korrekt
-        # ist (gemessen 2026-08-12). Die Luecke ist gemeldet, nicht hier gefixt.
-        segment_id="1",
+        # BEWUSST der Ziel-Sonderfall: das ist der Fall aus AC-1 ("🏁 Ziel"
+        # statt "km 8–8"), also genau die Darstellung, um die es in #1744 geht.
+        # Bis zur Waechter-Erweiterung (50a7d968) beanstandete P-1 diese
+        # korrekte Mail -- die Luecke ist gefixt und durch
+        # tests/tdd/test_radar_alert_validator_location_forms.py abgesichert.
+        segment_id="Ziel",
     )
     return AlertMessage(
         trip_short=f"GATE1241 {token}",

--- a/scripts/send_gate_test_mails.py
+++ b/scripts/send_gate_test_mails.py
@@ -335,6 +335,15 @@ def build_radar_alert_message(token: str) -> AlertMessage:
         intensity_label="Leichter Regen",
         source_label="Radar (DWD)",
         briefing_context=None,
+        # Issue #1744 A1: OHNE Kennung faellt die Ortsangabe auf "km 0–8"
+        # zurueck -- die Nachweis-Mail zeigte dann genau das Format, das der
+        # Produktivpfad seit #1744 NICHT mehr sendet, und der Validator-Lauf
+        # bestaetigte eine Darstellung, die es nicht mehr gibt.
+        # BEWUSST numerisch statt "Ziel": `radar_alert_mail_validator.py:49-52`
+        # kennt "Etappe N"/"km X-Y"/"Segment", aber NICHT den Ziel-Sonderfall
+        # "🏁 Ziel" -- mit segment_id="Ziel" faellt P-1, obwohl die Mail korrekt
+        # ist (gemessen 2026-08-12). Die Luecke ist gemeldet, nicht hier gefixt.
+        segment_id="1",
     )
     return AlertMessage(
         trip_short=f"GATE1241 {token}",

--- a/src/output/renderers/alert/model.py
+++ b/src/output/renderers/alert/model.py
@@ -25,6 +25,13 @@ class AlertEvent:
     # nur den kollektiven `AlertMessage.location_label`. Trip-Pfad und
     # Einzel-Ort-Pfad setzen es nie (Regressions-Invariante, AC-7).
     location_label: str | None = None
+    # Issue #1744 A1: additiv, optional, Muster `location_label`. Kennung der
+    # betroffenen Etappe ("1".."N" oder "Ziel") — Quelle der gemeinsamen
+    # Ortssprache aller Alarmarten (`segments.format_alert_location`). Gesetzt
+    # vom Trip-Abweichungspfad (`project.to_alert_message`); der Ortsvergleich
+    # setzt sie nie (ein Vergleichs-Ort hat keine Etappen). `None` -> Rueckfall
+    # auf die km-Spanne (AC-7).
+    segment_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -43,6 +50,10 @@ class OnsetEvent:
     # (to_multi_location_onset_alert_message) — trägt den Ortsnamen DIESES
     # Events. Trip-Radar-Pfad setzt es nie (Regressions-Invariante, AC-2/AC-3).
     location_label: str | None = None
+    # Issue #1744 A1: additiv, optional, analog `AlertEvent.segment_id` (o.).
+    # Gesetzt vom Trip-Radar-Pfad (`RadarAlertRequest` -> `send_radar_alert`);
+    # der Ortsvergleich-Radar setzt sie nie. `None` -> km-Spanne (AC-7).
+    segment_id: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/output/renderers/alert/official_alerts.py
+++ b/src/output/renderers/alert/official_alerts.py
@@ -25,6 +25,12 @@ from output.tokens.hazard_symbols import (
     MIN_SMS_LEVEL, sms_symbol_for,
 )
 
+# Issue #1744 A1: `format_segment_reference` ist seit dem Umzug nach
+# `segments.py` die GEMEINSAME Ortsformatierung aller Alarmarten (vorher hier
+# definiert, faktisch der amtlichen Warnung vorbehalten). Der Import haelt
+# zugleich den Re-Export fuer Bestandsaufrufer (`email/html.py:53`).
+from .segments import format_segment_reference
+
 if TYPE_CHECKING:
     from app.models import SegmentWeatherData
     from app.trip import Trip
@@ -259,36 +265,6 @@ def render_official_alerts_plain(entries: list[tuple[str, list["OfficialAlert"]]
                 suffix = f" ({_format_validity(alert)})"
             lines.append(f"Amtliche Warnung: {alert.label}{suffix}")
     return lines
-
-
-def format_segment_reference(segment_ids: list[str]) -> str:
-    """Issue #1200: kompakter Segment-/Etappen-Bezug fuer die Standalone-
-    Alert-Mail. Numerische IDs werden sortiert, zusammenhaengende Laeufe als
-    Range ('Segment 3–5'), sonst als Aufzaehlung ('Segment 3, 5'). `"Ziel"`
-    wird NIE in die numerische Range/Aufzaehlung gemischt, sondern immer als
-    eigenes Element '🏁 Ziel' angehaengt. Mehr als 4 betroffene Segmente
-    insgesamt -> Verdichtung 'N Segmente' (Begriff bewusst 'Segmente', nicht
-    'Etappen')."""
-    has_ziel = "Ziel" in segment_ids
-    numeric = sorted({int(s) for s in segment_ids if s != "Ziel"})
-
-    total = len(numeric) + (1 if has_ziel else 0)
-    if total > 4:
-        return f"{total} Segmente"
-
-    numeric_part = ""
-    if numeric:
-        is_consecutive = numeric == list(range(numeric[0], numeric[-1] + 1))
-        if is_consecutive and len(numeric) > 1:
-            numeric_part = f"Segment {numeric[0]}–{numeric[-1]}"
-        else:
-            numeric_part = "Segment " + ", ".join(str(n) for n in numeric)
-
-    if numeric_part and has_ziel:
-        return f"{numeric_part}, 🏁 Ziel"
-    if has_ziel:
-        return "🏁 Ziel"
-    return numeric_part
 
 
 def dedupe_official_alerts(

--- a/src/output/renderers/alert/project.py
+++ b/src/output/renderers/alert/project.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta, timezone
 from app.metric_catalog import _METRICS, get_cmp
 from utils.timezone import local_fmt, resolve_location_tz
 from .model import AlertEvent, AlertMessage, CorridorEvent, OnsetEvent
+from .segments import normalize_segment_id
 
 logger = logging.getLogger("alert_project")
 
@@ -91,6 +92,11 @@ def to_alert_message(
                 ch.occurred_at, _tz_for_location(match.segment.start_point, tz)
             ),
             km_from=km_from, km_to=km_to,
+            # Issue #1744 A1: die Kennung der TATSAECHLICH aufgeloesten Etappe
+            # (nicht `ch.segment_id` — `_find_segment` faellt bei nicht
+            # aufloesbarer Kennung auf das erste Segment zurueck, und der Alarm
+            # muss den Ort nennen, den er auch km-seitig meint).
+            segment_id=normalize_segment_id(match.segment.segment_id),
         ))
     corridor_events = (
         to_corridor_events(corridor_hits, segments, tz=tz) if corridor_hits else ()

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -20,6 +20,7 @@ from .model import (
     AlertEvent, AlertMessage, CorridorEvent, OnsetEvent, arrow, delta_pct,
     km_span, over_thr, severity, side_label,
 )
+from .segments import format_alert_location
 
 
 def _sorted(msg: AlertMessage) -> list[AlertEvent]:
@@ -97,18 +98,31 @@ def _label(e: AlertEvent) -> str:
     return get_alert_label(e.metric_id)
 
 
+def _location_of(events, location_label: str | None = None) -> str:
+    """Ortsangabe einer Ereignismenge (Issue #1744 A1) — Betreff, Mailkoerper
+    und Telegram-Langform holen sie ALLE hier, damit eine Mail nicht zwei
+    Ortssprachen spricht (AC-6). Die Reihenfolge location_label -> Segment ->
+    km steht in `segments.format_alert_location` und NUR dort (AC-3).
+
+    Issue #1169: gesetztes `location_label` (Compare-Punkt-Alert) ersetzt die
+    sinnlose km-Spanne eines Punktes ohne km-Kontext; der Trip-Pfad setzt das
+    Feld nie."""
+    a, b = km_span(events)
+    return format_alert_location(
+        location_label, [e.segment_id for e in events], a, b,
+    )
+
+
 def _km_str(msg: AlertMessage) -> str:
-    # Issue #1169: gesetztes location_label (Compare-Punkt-Alert) ersetzt die
-    # sinnlose km-Spanne eines Punktes ohne km-Kontext; Trip-Pfad setzt das
-    # Feld nie (bit-identische Ausgabe, AC-7).
-    if msg.location_label:
-        return msg.location_label
-    a, b = km_span(msg.events)
-    return f"km {int(round(a))}–{int(round(b))}"
+    return _location_of(msg.events, msg.location_label)
 
 
 def _km_str_onset(e: OnsetEvent) -> str:
-    return f"km {int(round(e.km_from))}–{int(round(e.km_to))}"
+    # Bewusst OHNE `location_label`: `_render_telegram_onset` liest auch im
+    # gebuendelten Mehr-Orte-Fall nur `events[0]` (Nebenbefund im Kontext-
+    # Dokument) — mit Ortsnamen stuende dort statt "km 0–0" der Name des
+    # ERSTEN Ortes, und der Ortsvergleich soll unveraendert bleiben (AC-4).
+    return _location_of((e,))
 
 
 # --- Schwellen-Treffer (Issue #1444 S1, ADR-0013: eigener Render-Vertrag,
@@ -376,16 +390,14 @@ def _datablock_single(e: AlertEvent, location_label: str | None = None) -> list[
         f"Alarm-Schwelle {_val(e, e.threshold)}",
         f"Änderung {side_label(e)} {mark}",
     )
-    when = location_label if location_label else _km_str_events((e,))
+    # Issue #1744 A1 (AC-6): DIESELBE Aufloesung wie im Betreff — vorher stand
+    # hier ein dritter, eigener km-Bauer (`_km_str_events`), weshalb der
+    # Mailkoerper km sprach, waehrend der Betreff schon Segmente sprach.
+    when = _location_of((e,), location_label)
     if e.occurred_at:
         when += f" · {e.occurred_at}"
     row3 = ("Wo & wann", when)
     return [row1, row2, row3]
-
-
-def _km_str_events(events) -> str:
-    a, b = km_span(events)
-    return f"km {int(round(a))}–{int(round(b))}"
 
 
 def _datarow_html(label: str, value: str, value_color: str, first: bool) -> str:

--- a/src/output/renderers/alert/segments.py
+++ b/src/output/renderers/alert/segments.py
@@ -1,0 +1,96 @@
+"""Eine Ortssprache fuer alle Alarme (Issue #1744 Scheibe A1).
+
+`format_segment_reference()` stand bis 2026-08-12 in `official_alerts.py` und
+war damit faktisch der amtlichen Warnung vorbehalten; Abweichungs- und
+Nowcast-Alarm bauten ihre Ortsangabe selbst als km-Spanne. Zwei Mails zum
+selben Ort nannten dadurch zwei verschiedene Dinge ("km 8–8" gegen "🏁 Ziel").
+
+Dieses Modul ist die EINE Stelle, an der eine Alarm-Ortsangabe entsteht:
+beide Renderer (`render.py`, `official_alerts.py`) importieren von hier.
+Es importiert selbst nichts aus dem Paket — der Umzug ist zyklenfrei.
+`official_alerts.py` re-exportiert `format_segment_reference` weiter, damit
+Bestandsimporte (z.B. `email/html.py:53`) unveraendert halten.
+"""
+from __future__ import annotations
+
+
+def normalize_segment_id(value) -> str | None:
+    """Rohe Segment-Kennung -> `str` oder `None` (Issue #1744 AC-7).
+
+    `TripSegment.segment_id` ist `int | str` (`app/models.py:389`), gespeicherte
+    Altdaten koennen ohne Kennung ankommen (`WeatherChange.segment_id` hat den
+    Default `""`, `app/models.py:541`). Beides muss hier zu `None` werden, damit
+    die Aufloesung sauber auf die km-Spanne zurueckfaellt statt "Segment None"
+    zu erfinden.
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def format_segment_reference(segment_ids: list[str]) -> str:
+    """Issue #1200: kompakter Segment-/Etappen-Bezug fuer die Standalone-
+    Alert-Mail. Numerische IDs werden sortiert, zusammenhaengende Laeufe als
+    Range ('Segment 3–5'), sonst als Aufzaehlung ('Segment 3, 5'). `"Ziel"`
+    wird NIE in die numerische Range/Aufzaehlung gemischt, sondern immer als
+    eigenes Element '🏁 Ziel' angehaengt. Mehr als 4 betroffene Segmente
+    insgesamt -> Verdichtung 'N Segmente' (Begriff bewusst 'Segmente', nicht
+    'Etappen')."""
+    has_ziel = "Ziel" in segment_ids
+    numeric = sorted({int(s) for s in segment_ids if s != "Ziel"})
+
+    total = len(numeric) + (1 if has_ziel else 0)
+    if total > 4:
+        return f"{total} Segmente"
+
+    numeric_part = ""
+    if numeric:
+        is_consecutive = numeric == list(range(numeric[0], numeric[-1] + 1))
+        if is_consecutive and len(numeric) > 1:
+            numeric_part = f"Segment {numeric[0]}–{numeric[-1]}"
+        else:
+            numeric_part = "Segment " + ", ".join(str(n) for n in numeric)
+
+    if numeric_part and has_ziel:
+        return f"{numeric_part}, 🏁 Ziel"
+    if has_ziel:
+        return "🏁 Ziel"
+    return numeric_part
+
+
+def _renderable_segment_ids(segment_ids) -> list[str]:
+    """Nur Kennungen, die `format_segment_reference` auch verarbeiten kann:
+    "Ziel" oder eine Zahl. Ist auch nur EINE Kennung von anderer Bauart, gilt
+    die ganze Menge als unbrauchbar — eine Teilangabe waere unehrlich (sie
+    verschwiege einen betroffenen Abschnitt), und `int()` wuerde werfen."""
+    ids = [normalize_segment_id(s) for s in segment_ids or ()]
+    usable = [s for s in ids if s]
+    if not usable or len(usable) != len(ids):
+        return []
+    if not all(s == "Ziel" or s.isdigit() for s in usable):
+        return []
+    return usable
+
+
+def format_alert_location(
+    location_label: str | None, segment_ids, km_from: float, km_to: float,
+) -> str:
+    """Die Ortsangabe eines Alarms — DIE gemeinsame Aufloesungsreihenfolge
+    (Issue #1744 AC-3):
+
+    1. `location_label` gesetzt   -> Ortsname (Ortsvergleich, unveraendert)
+    2. Segment-Kennung(en) da     -> `format_segment_reference`
+    3. sonst                      -> `km {von}–{bis}` (Rueckfall, Altdaten)
+
+    Stufe 3 ist kein Notnagel, sondern AC-7: ein Alarm ohne Segment-Kennung
+    muss weiterhin einen Ort nennen und versendet werden.
+    """
+    if location_label:
+        return location_label
+    ids = _renderable_segment_ids(segment_ids)
+    if ids:
+        reference = format_segment_reference(ids)
+        if reference:
+            return reference
+    return f"km {int(round(km_from))}–{int(round(km_to))}"

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -178,6 +178,11 @@ class RadarAlertRequest:
     source_label: str
     tz: ZoneInfo
     briefing_context: str | None = None
+    # Issue #1744 A1: Kennung der betroffenen Etappe ("1".."N"/"Ziel"), additiv
+    # und optional. Ohne sie nennt der Nowcast den Ort weiter als km-Spanne
+    # (AC-7) — genau das taten bis 2026-08-12 ALLE Nowcast-Mails, waehrend die
+    # amtliche Warnung zum selben Ort "🏁 Ziel" sagte.
+    segment_id: str | None = None
 
 
 def build_service_error_email_html(trip_name: str, report_type: str, error_lines: str) -> str:
@@ -1240,6 +1245,7 @@ class NotificationService:
             intensity_label=request.intensity_label,
             source_label=request.source_label,
             briefing_context=request.briefing_context,
+            segment_id=request.segment_id,  # Issue #1744 A1
         )
         # Issue #1402: kein stiller Rueckfall mehr -- `request.tz` ist seit
         # `RadarAlertRequest` ein Pflichtfeld.

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -26,6 +26,7 @@ from services.notification_service import (
     NotificationService,
     RadarAlertRequest,
 )
+from output.renderers.alert.segments import normalize_segment_id
 from services.point_weather import AlertEvaluationConfig, TripSegmentWeatherAdapter
 from services.corridor_threshold import CorridorHit
 from services.throttle_store import ThrottleStore
@@ -1088,6 +1089,10 @@ class TripAlertService:
                 onset_time=_onset_time_str,
                 km_from=active.start_point.distance_from_start_km,
                 km_to=active.end_point.distance_from_start_km,
+                # Issue #1744 A1: dieselbe Etappe, die schon die km-Spanne
+                # liefert — nur zusaetzlich mit ihrer Kennung, damit der
+                # Nowcast denselben Ort benennt wie die amtliche Warnung.
+                segment_id=normalize_segment_id(active.segment_id),
                 is_convective=result.is_convective,
                 intensity_label=_label,
                 source_label=radar_svc.source_label(result.source),

--- a/tests/tdd/test_alert_location_vocabulary.py
+++ b/tests/tdd/test_alert_location_vocabulary.py
@@ -589,6 +589,47 @@ def test_etappe_ohne_segment_kennung_faellt_auf_km_zurueck(segment_id):
     assert _wo_ort(render_email(msg)[1]) == "km 12–20"
 
 
+@pytest.mark.parametrize("unbrauchbar", [None, "", "s7"])
+def test_gemischte_kennungen_fallen_GANZ_auf_km_zurueck(unbrauchbar):
+    """AC-7, gemischter Mehr-Segment-Fall: Given ein Alarm ueber DREI Etappen,
+    von denen zwei eine Kennung tragen und eine nicht / When die Ortsangabe
+    gebildet wird / Then nennt sie die km-Spanne ueber ALLE drei — und NICHT
+    die Teilliste der beiden bekannten.
+
+    Warum das kein Detail ist (Adversary-Befund F003, 2026-08-12): baut man
+    `_renderable_segment_ids` von „alles oder nichts" zu einem Filter um, sagt
+    der Alarm `Segment 3, 5` — die dritte, TATSAECHLICH betroffene Etappe
+    verschwindet spurlos aus der Ortsangabe, obwohl ihre Wetterwerte im Alarm
+    stecken. Fuer den Wanderer heisst das: die Mail nennt zwei Abschnitte und
+    meint drei. Genau diese stille Auslassung ist der Grund fuer die Regel —
+    und sie war bis hierher durch keinen Test bewacht (die Verfaelschung liess
+    99 Tests gruen).
+
+    Der Fall laeuft ueber den echten Produktivpfad `to_alert_message()` mit
+    echten `TripSegment`s, weil die Regel in der Projektion wirkt: dort
+    entscheidet sich, welche Kennungen ueberhaupt am Ereignis landen.
+
+    Die drei Parameter decken die drei Arten unbrauchbarer Kennung ab: fehlend
+    (`None`), leer (`""`, der Default von `WeatherChange.segment_id`) und
+    nicht auswertbar (`"s7"` — weder Zahl noch "Ziel"; ungeprueft wuerde
+    `format_segment_reference` daran mit ValueError abbrechen).
+    """
+    from output.renderers.alert.render import render_email, render_subject
+
+    msg = _delta_message([("3", 4.0, 6.0), ("5", 8.0, 10.0), (unbrauchbar, 12.0, 14.0)])
+
+    ort = _location_slot(render_subject(msg))
+    assert ort == "km 4–14", (
+        f"Ortsangabe deckt nicht alle drei betroffenen Etappen ab: {ort!r}"
+    )
+
+    plain = render_email(msg)[1]
+    assert "Segment" not in plain, (
+        "Die Mail nennt eine Teil-Segmentliste und verschweigt damit eine "
+        f"betroffene Etappe:\n{plain}"
+    )
+
+
 def test_nowcast_ohne_segment_kennung_faellt_auf_km_zurueck():
     """AC-7 (HEUTE GRUEN, Invariante gegen den Fix): dasselbe fuer die
     Nowcast-Bestandsaufrufer, die kein `OnsetEvent.segment_id` setzen

--- a/tests/tdd/test_alert_location_vocabulary.py
+++ b/tests/tdd/test_alert_location_vocabulary.py
@@ -415,6 +415,51 @@ def test_ortsvergleich_radaralarm_bleibt_unveraendert():
 
 
 # ---------------------------------------------------------------------------
+# AC-3/AC-4 — die RANGFOLGE selbst, nicht nur ihre heutigen Auswirkungen
+# ---------------------------------------------------------------------------
+
+def test_ortsname_schlaegt_die_segment_kennung():
+    """Die Aufloesungsreihenfolge lautet `location_label` -> Segment -> km.
+    Dieser Test prueft die ERSTE Stufe an der Stelle, an der sie WIRKT.
+
+    Warum er noetig ist (Adversary-Befund F002, 2026-08-12): vertauscht man in
+    `segments.format_alert_location` die beiden ersten Stufen, wird KEIN
+    anderer Test rot — weil heute kein einziger Aufrufer beide Felder
+    gleichzeitig setzt (`to_alert_message` setzt nur die Segment-Kennung,
+    `to_multi_point_alert_message` nur den Ortsnamen). Die Regel stand damit im
+    Code und in der Spec, war aber unbewacht: eine Verfaelschung waere durch
+    alle 24 Zusicherungen dieser Datei hindurchgelaufen.
+
+    Die Kombination ist deshalb bewusst am Renderer-Modell gebaut und nicht
+    ueber eine Projektion — es GIBT heute keine, die sie erzeugt. Genau das ist
+    die Luecke: die Rangfolge entscheidet erst, wenn ein kuenftiger Aufrufer
+    beides mitgibt (z.B. ein Vergleichs-Ort mit Etappenbezug). Bis dahin haelt
+    dieser Test die Entscheidung fest, statt sie dem Zufall der naechsten
+    Erweiterung zu ueberlassen.
+    """
+    from output.renderers.alert.model import AlertEvent, AlertMessage
+    from output.renderers.alert.render import render_email, render_subject
+
+    event = AlertEvent(
+        metric_id="gust", value_from=50.0, value_to=80.0, threshold=20.0,
+        cmp="über", occurred_at="16:00", km_from=4.0, km_to=6.0,
+        location_label="Toulon", segment_id="3",
+    )
+    msg = AlertMessage(
+        trip_short="Toulon", stand_at="10:00", events=(event,),
+        location_label="Toulon",
+    )
+
+    assert _location_slot(render_subject(msg)) == "Toulon", (
+        "Segment-Kennung verdraengt den Ortsnamen im Betreff — Stufe 1 der "
+        "Aufloesungsreihenfolge greift nicht"
+    )
+    assert _wo_ort(render_email(msg)[1]) == "Toulon", (
+        "Segment-Kennung verdraengt den Ortsnamen im Mailkoerper"
+    )
+
+
+# ---------------------------------------------------------------------------
 # AC-5 — Kurznachricht nennt keinen Ort und bleibt <= 140 Zeichen
 # ---------------------------------------------------------------------------
 

--- a/tests/tdd/test_alert_location_vocabulary.py
+++ b/tests/tdd/test_alert_location_vocabulary.py
@@ -1,0 +1,556 @@
+"""Eine Ortssprache fuer alle Trip-Alarme (#1744 Scheibe A1).
+
+SPEC:    docs/specs/modules/fix_1744_alarm_format_angleichen.md (AC-1 bis AC-7)
+KONTEXT: docs/context/fix-1744-a-alarm-format.md
+
+Heute nennen zwei Alarm-Mails zum selben Ort zwei verschiedene Dinge:
+
+    [KHW 403] km 8–8 · Gewitter in 8 Min        (Radar-Nowcast, render.py:110)
+    [KHW 403] 🏁 Ziel · GELB Gewitter (Mi)      (amtliche Warnung, official_alerts.py:264)
+
+Geprueft wird ausschliesslich die Ausgabe, die den Nutzer erreicht: der
+gerenderte Betreff, der gerenderte Mailkoerper, die gerenderte Kurznachricht.
+Keine Hilfsfunktion isoliert, keine Dateiinhalt-Checks, keine Mocks — echte
+Domaenen-Objekte (`WeatherChange`, `TripSegment`, `OfficialAlert`,
+`SavedLocation`) durch die echten Projektionen und Renderer.
+
+RED-VERTRAG (was die GREEN-Phase anlegen muss, damit diese Datei OHNE Umbau
+gruen wird):
+
+1. `OnsetEvent` (src/output/renderers/alert/model.py:31) bekommt ein additives,
+   optionales Feld ``segment_id: int | str | None = None`` — Namensmuster wie
+   `WeatherChange.segment_id` (models.py:541), `TripSegment.segment_id`
+   (models.py:389) und `CorridorHit.segment_id`. Nur die Nowcast-Tests
+   konstruieren es direkt (`_onset_message`); ohne dieses Feld sind sie rot mit
+   `TypeError: unexpected keyword argument 'segment_id'`.
+2. `AlertEvent` braucht dieselbe Kennung, aber KEIN Test setzt sie hier direkt:
+   der Abweichungspfad laeuft ueber `to_alert_message()` und die echten
+   `TripSegment.segment_id` (project.py:84-94). Wie das Feld dort heisst, ist
+   fuer diese Datei folgenlos.
+3. Die Ortsangabe entsteht in GENAU EINER Funktion (Spec „Eine Formatierung,
+   zwei Aufrufer"), Aufloesungsreihenfolge:
+   `location_label` → Segment-Kennung (`format_segment_reference`) → `km a–b`.
+
+NICHT Gegenstand dieser Datei: AC-8 bis AC-12 (Mail-Koerper, Scheibe A2).
+"""
+from __future__ import annotations
+
+import re
+from datetime import date, datetime, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+UTC = timezone.utc
+TRIP_NAME = "KHW 403"
+TRIP_TZ = ZoneInfo("Europe/Vienna")
+# Warnzeitraum fest datiert -> Wochentag im Betreff ist deterministisch ("Mi").
+WARN_FROM = datetime(2026, 7, 1, 12, 0, tzinfo=UTC)
+WARN_TO = datetime(2026, 7, 1, 20, 0, tzinfo=UTC)
+
+# Betreff-Bauform beider Pfade: "[<Trip>] <Ortsangabe> · <Kernaussage>"
+# (render.py:294-325 bzw. official_alerts.py:859-919).
+_SUBJECT_RE = re.compile(r"^\[[^\]]*\]\s+(?P<where>.+?)\s+·\s+.+$")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — echte Domaenen-Objekte
+# ---------------------------------------------------------------------------
+
+def _gpx(distance_km: float):
+    """GPX-Punkt in Kaernten (Trip-Zeitzone Europe/Vienna)."""
+    from app.models import GPXPoint
+
+    return GPXPoint(lat=46.6, lon=12.9, elevation_m=1900.0,
+                    distance_from_start_km=distance_km)
+
+
+def _segment(segment_id, km_from: float, km_to: float):
+    """Eine Etappe mit Wetterdaten (`SegmentWeatherData`), wie sie der
+    Abweichungs-Detektor an `to_alert_message()` reicht."""
+    from app.models import SegmentWeatherData, SegmentWeatherSummary, TripSegment
+
+    seg = TripSegment(
+        segment_id=segment_id,
+        start_point=_gpx(km_from), end_point=_gpx(km_to),
+        start_time=datetime(2026, 7, 1, 6, 0, tzinfo=UTC),
+        end_time=datetime(2026, 7, 1, 8, 0, tzinfo=UTC),
+        duration_hours=2.0, distance_km=km_to - km_from,
+        ascent_m=200.0, descent_m=50.0,
+    )
+    return SegmentWeatherData(
+        segment=seg, timeseries=None,
+        aggregated=SegmentWeatherSummary(gust_max_kmh=80.0),
+        fetched_at=datetime(2026, 7, 1, 6, 0, tzinfo=UTC), provider="openmeteo",
+    )
+
+
+def _change(segment_id, *, old: float = 50.0, new: float = 80.0):
+    from app.models import ChangeSeverity, WeatherChange
+
+    return WeatherChange(
+        metric="gust_max_kmh", old_value=old, new_value=new, delta=new - old,
+        threshold=20.0, severity=ChangeSeverity.MODERATE, direction="increase",
+        segment_id=segment_id,
+        occurred_at=datetime(2026, 7, 1, 14, 0, tzinfo=UTC),
+    )
+
+
+def _delta_message(specs):
+    """Abweichungsalarm ueber die echte Projektion (`to_alert_message`).
+
+    `specs`: Liste `(segment_id, km_from, km_to)` — je Eintrag eine betroffene
+    Etappe mit genau einer Aenderung. Die Segment-Kennung kommt damit dort her,
+    wo sie im Produktivlauf herkommt: aus `TripSegment.segment_id`
+    (project.py:84). Diese Datei setzt sie NIE direkt am Renderer-Modell.
+    """
+    from output.renderers.alert.project import to_alert_message
+
+    segments = [_segment(sid, a, b) for sid, a, b in specs]
+    changes = [_change(sid) for sid, _a, _b in specs]
+    return to_alert_message(
+        changes, segments, TRIP_NAME, tz=TRIP_TZ, stand_at="10:00",
+    )
+
+
+def _onset_message(*, segment_id="__omit__", km_from: float = 8.0,
+                   km_to: float = 8.0, convective: bool = True):
+    """Radar-Nowcast-Alarm, gebaut wie `NotificationService.send_radar_alert()`
+    (notification_service.py:1234) — dort entsteht das `OnsetEvent` direkt aus
+    dem `RadarAlertRequest`, es gibt keine Projektionsfunktion dazwischen.
+
+    `segment_id="__omit__"` laesst die Kennung weg (Altdaten-/Bestandsaufrufer
+    wie radar_alert_service.py:59 und validator_render_service.py:102).
+    """
+    from output.renderers.alert.model import AlertMessage, OnsetEvent
+
+    kwargs = dict(
+        onset_minutes=8, onset_time="14:08", km_from=km_from, km_to=km_to,
+        is_convective=convective, intensity_label="kraeftiger Regen",
+        source_label="Radar (GeoSphere INCA)",
+        briefing_context="nicht angekuendigt",
+    )
+    if segment_id != "__omit__":
+        kwargs["segment_id"] = segment_id
+    try:
+        event = OnsetEvent(**kwargs)
+    except TypeError as exc:  # RED-Vertrag Punkt 1
+        raise AssertionError(
+            "OnsetEvent traegt keine Segment-Kennung — der Nowcast kann den Ort "
+            "deshalb nur als km-Spanne nennen (model.py:31, Spec #1744 AC-1). "
+            f"Urspruenglicher Fehler: {exc}"
+        ) from exc
+    return AlertMessage(
+        trip_short=TRIP_NAME, stand_at="10:00", events=(event,),
+        source="radar", cooldown_display="60 Min",
+    )
+
+
+def _trip(waypoint_count: int = 10):
+    """Trip mit `waypoint_count` Wegpunkten -> Segmente '1'..'N-1' + 'Ziel'
+    (`_trip_total_segment_ids`, official_alerts.py:1923). Zehn Wegpunkte sorgen
+    dafuer, dass keine der geprueften Warnungen die GESAMTE Route abdeckt —
+    sonst greift der Sonderfall 'gesamte Route' statt der Segment-Kennung."""
+    from app.trip import Stage, Trip, Waypoint
+
+    waypoints = [
+        Waypoint(id=f"w{i}", name=f"P{i}", lat=46.6 + i / 100, lon=12.9 + i / 100,
+                 elevation_m=1900.0 + i)
+        for i in range(waypoint_count)
+    ]
+    stage = Stage(id="s1", name="Tag 1", date=date(2026, 7, 1), waypoints=waypoints)
+    return Trip(id="tdd-1744-khw", name=TRIP_NAME, stages=[stage])
+
+
+def _official_subject(segment_ids: list[str]) -> str:
+    """Betreff der amtlichen Warnung ueber genau den Produktivweg:
+    `build_official_alert_notices()` -> `render_official_alert_subject()`
+    (notification_service.py:823/828)."""
+    from output.renderers.alert.official_alerts import (
+        build_official_alert_notices, render_official_alert_subject,
+    )
+    from services.official_alerts.models import OfficialAlert
+
+    alert = OfficialAlert(
+        source="geosphere_warn", hazard="thunderstorm", level=2, label="Gewitter",
+        valid_from=WARN_FROM, valid_to=WARN_TO, region_label="Kaernten",
+    )
+    notices = build_official_alert_notices(_trip(), [(alert, segment_ids)])
+    return render_official_alert_subject(notices, prefix=TRIP_NAME, tz=TRIP_TZ)
+
+
+def _location_slot(subject: str) -> str:
+    """Die Ortsangabe aus einem Alarm-Betreff."""
+    match = _SUBJECT_RE.match(subject)
+    assert match, f"Betreff hat nicht die Bauform '[Trip] <Ort> · <Kern>': {subject!r}"
+    return match.group("where")
+
+
+def _wo_und_wann(plain: str) -> str:
+    """Wert der Datenzeile 'Wo & wann' aus dem Text-Teil einer Alarm-Mail."""
+    hits = [ln for ln in plain.splitlines() if ln.startswith("Wo & wann: ")]
+    assert len(hits) == 1, f"Genau eine 'Wo & wann'-Zeile erwartet, gefunden: {hits!r}"
+    return hits[0][len("Wo & wann: "):]
+
+
+def _wo_ort(plain: str) -> str:
+    """Nur der ORT aus der 'Wo & wann'-Zeile (vor dem ersten ' · ' steht der
+    Ort, dahinter die Zeit — render.py:379-382 bzw. :233)."""
+    return _wo_und_wann(plain).split(" · ")[0]
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — Nowcast und amtliche Warnung nennen dasselbe Ziel-Segment gleich
+# ---------------------------------------------------------------------------
+
+def test_nowcast_und_amtliche_warnung_nennen_das_ziel_segment_gleich():
+    """AC-1: Given ein Trip-Nowcast-Alarm fuer das Ziel-Segment / When die
+    Alarm-Mail versendet wird / Then nennt die Betreffzeile '🏁 Ziel' statt
+    'km 8–8', und der Betreff einer amtlichen Warnung fuer DASSELBE Segment
+    nennt denselben Text.
+
+    Zwei Zusicherungen, absichtlich beide: die Gleichheit faengt „nur ein Pfad
+    umgestellt"; der Literalwert legt die RICHTUNG fest — der Nowcast
+    uebernimmt die Sprache der amtlichen Warnung, nicht umgekehrt. Ohne den
+    Literal waere auch „beide auf km umgestellt" gruen.
+
+    HEUTE ROT: Nowcast sagt 'km 8–8' (render.py:110), amtliche Warnung
+    '🏁 Ziel' (official_alerts.py:290).
+    """
+    from output.renderers.alert.render import render_subject
+
+    nowcast = _location_slot(render_subject(_onset_message(segment_id="Ziel")))
+    official = _location_slot(_official_subject(["Ziel"]))
+
+    assert nowcast == official, (
+        "Nowcast und amtliche Warnung nennen denselben Ort verschieden: "
+        f"{nowcast!r} vs. {official!r}"
+    )
+    assert nowcast == "🏁 Ziel", (
+        f"Ortsangabe folgt nicht der Segment-Sprache: {nowcast!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — Abweichungsalarm ueber drei Segmente
+# ---------------------------------------------------------------------------
+
+def test_abweichungsalarm_ueber_drei_segmente_nennt_sie_wie_die_amtliche_warnung():
+    """AC-2: Given ein Trip-Abweichungsalarm, der die Segmente 3, 4 und 5
+    betrifft / When der Betreff gerendert wird / Then steht dort 'Segment 3–5'
+    — dieselbe Zusammenfassung, die eine amtliche Warnung ueber dieselben drei
+    Segmente erzeugt.
+
+    HEUTE ROT: der Abweichungsalarm sagt 'km 4–10' (render.py:100-107), die
+    amtliche Warnung 'Segment 3–5'.
+    """
+    from output.renderers.alert.render import render_subject
+
+    msg = _delta_message([("3", 4.0, 6.0), ("4", 6.0, 8.0), ("5", 8.0, 10.0)])
+    delta = _location_slot(render_subject(msg))
+    official = _location_slot(_official_subject(["3", "4", "5"]))
+
+    assert delta == official, (
+        "Abweichungsalarm und amtliche Warnung fassen dieselben Segmente "
+        f"verschieden zusammen: {delta!r} vs. {official!r}"
+    )
+    assert delta == "Segment 3–5", (
+        f"Ortsangabe folgt nicht der Segment-Sprache: {delta!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3 — Teilungs-Nachweis: genau EINE Ortsformatierung
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("segment_id,erwartet", [
+    ("3", "Segment 3"),
+    ("7", "Segment 7"),
+    ("Ziel", "🏁 Ziel"),
+])
+def test_alle_drei_alarmarten_bilden_denselben_ortstext(segment_id, erwartet):
+    """AC-3 (Teilungs-Nachweis): Given irgendein Trip-Alarm mit Ortsangabe /
+    When die Ortsangabe gebildet wird / Then geschieht das ueber GENAU EINE
+    Funktion.
+
+    Dieser Test rendert alle drei Alarmarten fuer DIESELBE Segment-Kennung und
+    prueft sie gegeneinander UND gegen den erwarteten Wortlaut.
+
+    MUTATION, die diesen Test rot machen MUSS (Mutations-Gegenprobe):
+    in der gemeinsamen Ortsformatierung 'Segment' -> 'Etappe' (heute
+    `format_segment_reference`, official_alerts.py:283/285) — dann muessen
+    Nowcast-, Abweichungs- UND Amtliche-Warnung-Zusicherung GLEICHZEITIG
+    fallen. Bleibt eine gruen, existiert eine zweite Formatierung; das ist ein
+    Verstoss gegen die Teilungsregel, kein Detail.
+
+    HEUTE ROT: Nowcast und Abweichungsalarm sprechen km, die amtliche Warnung
+    spricht Segmente.
+    """
+    from output.renderers.alert.render import render_subject
+
+    nowcast = _location_slot(render_subject(_onset_message(segment_id=segment_id)))
+    delta = _location_slot(render_subject(_delta_message([(segment_id, 4.0, 6.0)])))
+    official = _location_slot(_official_subject([segment_id]))
+
+    assert nowcast == erwartet, f"Nowcast-Ortsangabe: {nowcast!r}"
+    assert delta == erwartet, f"Abweichungs-Ortsangabe: {delta!r}"
+    assert official == erwartet, f"Amtliche-Warnung-Ortsangabe: {official!r}"
+
+
+@pytest.mark.parametrize("segment_ids,erwartet", [
+    (["3", "4", "5"], "Segment 3–5"),          # zusammenhaengend -> Range
+    (["3", "5"], "Segment 3, 5"),              # Luecke -> Aufzaehlung
+    (["2", "Ziel"], "Segment 2, 🏁 Ziel"),     # Ziel nie in die Range mischen
+    (["1", "3", "5", "7", "9"], "5 Segmente"),  # >4 -> Verdichtung
+])
+def test_abweichungsalarm_folgt_denselben_verdichtungsregeln(segment_ids, erwartet):
+    """AC-3 (Teilungs-Nachweis, Kanten): Range-Verdichtung, Aufzaehlung,
+    Ziel-Sonderfall und die '>4 Segmente'-Verdichtung sind vier Regeln, die
+    eine handgeschriebene Zweitfassung im Abweichungspfad mit hoher
+    Wahrscheinlichkeit NICHT gleich reproduziert. Genau deshalb stehen sie
+    hier: sie unterscheiden „geteilt" von „nachgebaut".
+
+    HEUTE ROT: der Abweichungsalarm sagt in allen vier Faellen 'km a–b'.
+    """
+    from output.renderers.alert.render import render_subject
+
+    specs = [(sid, 2.0 * n, 2.0 * n + 2.0) for n, sid in enumerate(segment_ids, 1)]
+    delta = _location_slot(render_subject(_delta_message(specs)))
+    official = _location_slot(_official_subject(segment_ids))
+
+    assert delta == official, (
+        f"Abweichungsalarm {delta!r} != amtliche Warnung {official!r} "
+        f"fuer Segmente {segment_ids}"
+    )
+    assert delta == erwartet, f"Ortsangabe: {delta!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC-4 — Ortsvergleich unveraendert (HEUTE GRUEN, Invariante)
+# ---------------------------------------------------------------------------
+
+def _saved_location(loc_id: str, name: str, lat: float, lon: float):
+    from app.user import SavedLocation
+
+    return SavedLocation(id=loc_id, name=name, lat=lat, lon=lon, elevation_m=20)
+
+
+def test_ortsvergleich_aenderungsalarm_nennt_weiterhin_den_ortsnamen():
+    """AC-4 (HEUTE GRUEN, Invariante): Given ein Aenderungsalarm im
+    Ortsvergleich mit einem Ort / When Betreff, Mail und Telegram gerendert
+    werden / Then erscheint weiterhin der Ortsname — die Segment-Kennung greift
+    dort nicht (ein Vergleichs-Ort hat keine Etappen).
+
+    Die Erwartungen sind der HEUTIGE Wortlaut, byte-genau. Sie duerfen sich
+    durch #1744 nicht bewegen; `location_label` bleibt die erste Stufe der
+    Aufloesungsreihenfolge.
+    """
+    from output.renderers.alert.project import to_point_alert_message
+    from output.renderers.alert.render import (
+        render_email, render_subject, render_telegram,
+    )
+
+    msg = to_point_alert_message(
+        [_change("1")], [_saved_location("toulon", "Toulon", 43.12, 5.93)],
+        "Toulon", tz=ZoneInfo("Europe/Paris"), stand_at="10:00",
+    )
+
+    assert render_subject(msg) == "[Toulon] Toulon · ↑ Böen: 50 km/h→80 km/h"
+    assert render_telegram(msg).splitlines()[0] == "<b>Toulon · Toulon · ↑ Böen</b>"
+    assert _wo_und_wann(render_email(msg)[1]) == "Toulon · 16:00"
+
+
+def test_ortsvergleich_mehrere_orte_nennen_weiterhin_ihre_namen():
+    """AC-4 (HEUTE GRUEN, Invariante): derselbe Nachweis fuer den gebuendelten
+    Mehr-Orte-Alarm (`to_multi_point_alert_message`, #1170)."""
+    from output.renderers.alert.project import to_multi_point_alert_message
+    from output.renderers.alert.render import render_subject, render_telegram
+
+    msg = to_multi_point_alert_message(
+        [
+            ("Toulon", [_change("1")], _saved_location("toulon", "Toulon", 43.12, 5.93)),
+            ("Hyères", [_change("1", old=40.0, new=70.0)],
+             _saved_location("hyeres", "Hyères", 43.12, 6.13)),
+        ],
+        tz=ZoneInfo("Europe/Paris"), stand_at="10:00",
+    )
+
+    assert render_subject(msg) == (
+        "[Toulon, Hyères] Toulon, Hyères · ↑ 2 über Schwelle: Böen 80, Böen 70"
+    )
+    assert render_telegram(msg).splitlines()[0] == (
+        "<b>Toulon, Hyères · Toulon, Hyères · 2 über Schwelle</b>"
+    )
+
+
+def test_ortsvergleich_radaralarm_bleibt_unveraendert():
+    """AC-4 (HEUTE GRUEN, Invariante): der Radar-Alarm des Ortsvergleichs hat
+    keine Segmente (`km_from=km_to=0.0`, project.py:308) und traegt den
+    Ortsnamen im Trip-Slot. Sein Betreff nennt heute 'km 0–0'; das ist
+    Bestandsverhalten und NICHT Gegenstand von #1744 — der Test bewacht, dass
+    die neue Segment-Sprache hier weder auftaucht noch etwas abstuerzen laesst.
+    """
+    from output.renderers.alert.project import to_multi_location_onset_alert_message
+    from output.renderers.alert.render import render_subject
+    from services.radar_service import NowcastResult
+
+    def _nc():
+        return NowcastResult(onset_minutes=30, intensity_label="leichter Regen",
+                             source="Radar (AROME-FR)", is_convective=False)
+
+    single = to_multi_location_onset_alert_message(
+        [("Toulon", _saved_location("toulon", "Toulon", 43.12, 5.93), _nc())],
+        tz=ZoneInfo("Europe/Paris"), stand_at="10:00",
+    )
+    multi = to_multi_location_onset_alert_message(
+        [
+            ("Toulon", _saved_location("toulon", "Toulon", 43.12, 5.93), _nc()),
+            ("Hyères", _saved_location("hyeres", "Hyères", 43.12, 6.13), _nc()),
+        ],
+        tz=ZoneInfo("Europe/Paris"), stand_at="10:00",
+    )
+
+    assert render_subject(single) == "[Toulon] km 0–0 · Regen in 30 Min"
+    assert render_subject(multi) == "[Toulon, Hyères] Regen-Alarm: 2 Orte"
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — Kurznachricht nennt keinen Ort und bleibt <= 140 Zeichen
+# ---------------------------------------------------------------------------
+
+def _assert_kurznachricht_ohne_ort(sms: str) -> None:
+    """PO-Entscheid 2026-08-04 (#1467 S2 AG3b): Alarm-Kurznachrichten nennen
+    keinen Ort. SMS und Premium-SMS teilen denselben gerenderten Text
+    (`render_alert_sms`, notification_service.py:1318 -> :1488 SMS / :1502
+    Premium-SMS) — ein Nachweis deckt beide Kanaele.
+    """
+    assert "Segment" not in sms, f"Kurznachricht nennt ein Segment: {sms!r}"
+    assert "Ziel" not in sms, f"Kurznachricht nennt das Ziel: {sms!r}"
+    assert "🏁" not in sms, f"Kurznachricht traegt das Ziel-Symbol: {sms!r}"
+    assert re.search(r"km\d", sms), (
+        f"Kurznachricht hat ihren km-Kopf verloren: {sms!r}"
+    )
+    # Alarm-Grenze ist 140, NICHT 160 (render.py:285/621, official_alerts.py:1836).
+    assert len(sms) <= 140, f"Kurznachricht ist {len(sms)} Zeichen lang: {sms!r}"
+
+
+def test_kurznachricht_des_abweichungsalarms_nennt_keinen_ort():
+    """AC-5 (HEUTE GRUEN, Invariante): Given ein Trip-Abweichungsalarm auf dem
+    Ziel-Segment / When die Kurznachricht gerendert wird / Then nennt sie
+    weiterhin keinen Ortsnamen und bleibt <= 140 Zeichen.
+
+    Der Alarm laeuft ueber `to_alert_message()` mit einer echten Etappe
+    `segment_id='Ziel'` — also genau der Eingabe, aus der der BETREFF nach
+    AC-1 kuenftig '🏁 Ziel' bildet. Der Test bewacht, dass diese Umstellung
+    NICHT in die Kurznachricht durchschlaegt.
+    """
+    from output.renderers.alert.render import render_sms
+
+    _assert_kurznachricht_ohne_ort(render_sms(_delta_message([("Ziel", 8.0, 8.0)])))
+
+
+def test_kurznachricht_des_abweichungsalarms_ueber_mehrere_segmente_nennt_keinen_ort():
+    """AC-5 (HEUTE GRUEN, Invariante): dieselbe Zusicherung fuer den
+    Mehr-Segment-Fall aus AC-2 ('Segment 3–5' im Betreff)."""
+    from output.renderers.alert.render import render_sms
+
+    msg = _delta_message([("3", 4.0, 6.0), ("4", 6.0, 8.0), ("5", 8.0, 10.0)])
+    _assert_kurznachricht_ohne_ort(render_sms(msg))
+
+
+def test_kurznachricht_des_nowcasts_nennt_keinen_ort():
+    """AC-5: dieselbe Zusicherung fuer den Radar-Nowcast.
+
+    ROT bis der RED-Vertrag Punkt 1 erfuellt ist (`OnsetEvent.segment_id`):
+    ohne das Feld laesst sich der Fall „Nowcast KENNT das Ziel-Segment" gar
+    nicht herstellen. Danach ist es eine reine Invariante — der Betreff wechselt
+    auf '🏁 Ziel', die Kurznachricht bleibt bei 'km8-8'.
+    """
+    from output.renderers.alert.render import render_sms
+
+    _assert_kurznachricht_ohne_ort(render_sms(_onset_message(segment_id="Ziel")))
+
+
+# ---------------------------------------------------------------------------
+# AC-6 — eine Mail, eine Ortssprache
+# ---------------------------------------------------------------------------
+
+def test_nowcast_mail_nennt_im_koerper_denselben_ort_wie_im_betreff():
+    """AC-6: Given eine Alarm-Mail mit Ortsangabe im Betreff / When der
+    Mail-Koerper gerendert wird / Then nennt die Zeile 'Wo & wann' DENSELBEN
+    Ortstext wie der Betreff.
+
+    Erst Gleichheit (faengt „Betreff umgestellt, Koerper vergessen"), dann der
+    Wortlaut (faengt „beide noch auf km"). Zusaetzlich muss der Ort auch im
+    HTML-Teil stehen — zugestellt wird beides.
+
+    HEUTE ROT im zweiten Schritt: Betreff und Koerper sagen einvernehmlich
+    'km 8–8'.
+    """
+    from output.renderers.alert.render import render_email, render_subject
+
+    msg = _onset_message(segment_id="Ziel")
+    html, plain = render_email(msg)
+    im_betreff = _location_slot(render_subject(msg))
+    im_koerper = _wo_ort(plain)
+
+    assert im_koerper == im_betreff, (
+        f"Betreff sagt {im_betreff!r}, Mailkoerper sagt {im_koerper!r}"
+    )
+    assert im_betreff == "🏁 Ziel", f"Ortsangabe: {im_betreff!r}"
+    assert im_betreff in html, "Ortsangabe fehlt im HTML-Teil der Mail"
+
+
+def test_abweichungsmail_nennt_im_koerper_denselben_ort_wie_im_betreff():
+    """AC-6: derselbe Nachweis fuer die Abweichungsmail (Ein-Metrik-Fall — nur
+    der traegt eine 'Wo & wann'-Zeile, render.py:361-383)."""
+    from output.renderers.alert.render import render_email, render_subject
+
+    msg = _delta_message([("3", 4.0, 6.0)])
+    html, plain = render_email(msg)
+    im_betreff = _location_slot(render_subject(msg))
+    im_koerper = _wo_ort(plain)
+
+    assert im_koerper == im_betreff, (
+        f"Betreff sagt {im_betreff!r}, Mailkoerper sagt {im_koerper!r}"
+    )
+    assert im_betreff == "Segment 3", f"Ortsangabe: {im_betreff!r}"
+    assert im_betreff in html, "Ortsangabe fehlt im HTML-Teil der Mail"
+
+
+# ---------------------------------------------------------------------------
+# AC-7 — Rueckfall auf km, wenn keine Segment-Kennung vorliegt
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("segment_id", [None, ""])
+def test_etappe_ohne_segment_kennung_faellt_auf_km_zurueck(segment_id):
+    """AC-7 (HEUTE GRUEN, Invariante gegen den Fix): Given ein Trip-Alarm,
+    dessen Etappe keine Segment-Kennung traegt (Altdaten) / When die Ortsangabe
+    gebildet wird / Then faellt sie auf die km-Spanne zurueck, statt leer zu
+    bleiben oder den Versand abzubrechen.
+
+    `WeatherChange.segment_id` hat den Default '' (models.py:541), gespeicherte
+    Altdaten koennen also ohne Kennung ankommen. Die dritte Stufe der
+    Aufloesungsreihenfolge muss das auffangen: ein ungeprueftes
+    `format_segment_reference([None])` wuerde werfen bzw. 'Segment None'
+    liefern — beides faengt dieser Test.
+    """
+    from output.renderers.alert.render import render_email, render_subject
+
+    msg = _delta_message([(segment_id, 12.0, 20.0)])
+    ort = _location_slot(render_subject(msg))
+
+    assert ort == "km 12–20", f"Kein km-Rueckfall ohne Segment-Kennung: {ort!r}"
+    assert _wo_ort(render_email(msg)[1]) == "km 12–20"
+
+
+def test_nowcast_ohne_segment_kennung_faellt_auf_km_zurueck():
+    """AC-7 (HEUTE GRUEN, Invariante gegen den Fix): dasselbe fuer die
+    Nowcast-Bestandsaufrufer, die kein `OnsetEvent.segment_id` setzen
+    (radar_alert_service.py:59, validator_render_service.py:102). Sie duerfen
+    durch den Fix weder leer laufen noch abstuerzen."""
+    from output.renderers.alert.render import render_subject
+
+    ort = _location_slot(render_subject(_onset_message(km_from=8.0, km_to=12.0)))
+
+    assert ort == "km 8–12", f"Kein km-Rueckfall ohne Segment-Kennung: {ort!r}"

--- a/tests/tdd/test_alert_renderer_format_bugs.py
+++ b/tests/tdd/test_alert_renderer_format_bugs.py
@@ -27,13 +27,16 @@ def _local(h: int, m: int, now: datetime) -> datetime:
     ).astimezone(timezone.utc)
 
 
-def _make_msg(trip_name: str = "GR221 Mallorca"):
+def _make_msg(trip_name: str = "GR221 Mallorca", segment_id: str | None = "1"):
+    """Issue #1744 A1: `segment_id=None` erzwingt den km-Rueckfall (Altdaten
+    ohne Etappen-Kennung) — nur dort ist das km-Format ueberhaupt noch im
+    Betreff/Telegram sichtbar, und nur dort kann Bug 1 also noch auftreten."""
     tz = ZoneInfo("Europe/Madrid")
     now = datetime.now(timezone.utc)
     seg_start = datetime(now.year, now.month, now.day, 8, 0, tzinfo=timezone.utc)
     seg_end   = datetime(now.year, now.month, now.day, 13, 30, tzinfo=timezone.utc)
     segment = TripSegment(
-        segment_id="1",
+        segment_id=segment_id,
         start_point=GPXPoint(lat=39.710564, lon=2.62293, elevation_m=410, distance_from_start_km=0.0),
         end_point=GPXPoint(lat=39.747657, lon=2.648606, elevation_m=149, distance_from_start_km=11.2),
         start_time=seg_start, end_time=seg_end,
@@ -60,22 +63,36 @@ def _make_msg(trip_name: str = "GR221 Mallorca"):
 
 
 class TestKmStrNoDuplicatedUnit:
-    """Bug 1: km_span darf km nicht doppelt im String haben."""
+    """Bug 1: km_span darf km nicht doppelt im String haben.
+
+    Issue #1744 A1: Betreff und Telegram nennen den Ort seither als
+    Etappen-Kennung ("Segment 1"); die km-Spanne ist der RUECKFALL fuer Alarme
+    ohne Kennung. Alle drei Faelle laufen deshalb ueber `segment_id=None` —
+    sonst pruefte diese Klasse ein Format, das gar nicht mehr gerendert wird
+    (die beiden "kein doppeltes km"-Zusicherungen waeren trivial erfuellt).
+    """
 
     def test_subject_no_km_km(self):
-        msg = _make_msg()
+        msg = _make_msg(segment_id=None)
         subj = render_subject(msg)
         assert "0 km-" not in subj and "0 km–" not in subj, f"Doppeltes km im Betreff: {subj!r}"
 
     def test_subject_contains_km_range(self):
-        msg = _make_msg()
+        msg = _make_msg(segment_id=None)
         subj = render_subject(msg)
         assert "km 0–11" in subj, f"Km-Bereich fehlt im Betreff: {subj!r}"
 
     def test_telegram_no_km_km(self):
-        msg = _make_msg()
+        msg = _make_msg(segment_id=None)
         tg = render_telegram(msg)
         assert "0 km–" not in tg, f"Doppeltes km in Telegram: {tg!r}"
+
+    def test_subject_names_the_segment_when_known(self):
+        """Issue #1744 A1: mit Kennung nennt der Betreff die Etappe statt km —
+        die Gegenprobe zum Rueckfall oben."""
+        subj = render_subject(_make_msg())
+        assert "Segment 1" in subj, f"Ortsangabe fehlt im Betreff: {subj!r}"
+        assert "km 0–11" not in subj, f"km-Spanne trotz Kennung: {subj!r}"
 
 
 class TestSmsTripNameTruncation:

--- a/tests/tdd/test_issue_1169_compare_alert_consumer.py
+++ b/tests/tdd/test_issue_1169_compare_alert_consumer.py
@@ -737,13 +737,20 @@ def test_ac7_trip_alert_rendering_unchanged():
     html, plain = render_email(msg)
     telegram_text = render_telegram(msg)
 
-    assert subject == "[GR20] km 12–18 · ↑ Niedersch: 2,0 mm→18,0 mm", subject
+    # Issue #1744 A1: die Ortsangabe des Trip-Pfads ist die Etappen-Kennung
+    # ("Segment 1"), nicht mehr die km-Spanne — dieselbe Sprache, die die
+    # amtliche Warnung zum selben Segment spricht. Die km-Spanne bleibt der
+    # Rueckfall fuer Etappen OHNE Kennung (AC-7 von #1744). Erwartungen
+    # nachgezogen, NICHT gelockert: weiterhin Byte-Gleichheit aller drei
+    # Ausgaben. Die Invariante dieses Tests — der Trip-Pfad setzt
+    # `location_label` nie — steht oben unveraendert und gilt weiter.
+    assert subject == "[GR20] Segment 1 · ↑ Niedersch: 2,0 mm→18,0 mm", subject
     assert plain == (
         "Niedersch +800% seit dem Briefing\n\n"
         "↑ +800 % · Änderung über deiner Alarm-Schwelle (10,0 mm)\n\n"
         "Niedersch · mm: 2,0 mm ↑ 18,0 mm +800 %\n"
         "Alarm-Schwelle 10,0 mm: Änderung über ✗\n"
-        "Wo & wann: km 12–18\n\n"
+        "Wo & wann: Segment 1\n\n"
         "Stand: heute 14:00 · verglichen mit dem letzten Briefing"
         # Issue #1241: geteilte Herkunfts-Fußzeile (deviation-alert). Zeile 2
         # trug bis Commit 239f210c (#1338a, ADR-0034) den Renderer-Pfad plus
@@ -754,7 +761,7 @@ def test_ac7_trip_alert_rendering_unchanged():
         "\n\nAbweichungs-Alarm · Open-Meteo"
     ), plain
     assert telegram_text == (
-        "<b>GR20 · km 12–18 · ↑ Niedersch</b>\n"
+        "<b>GR20 · Segment 1 · ↑ Niedersch</b>\n"
         "Niedersch · Schwelle 10,0 mm · 2,0 mm ↑ 18,0 mm · Änderung über"
     ), telegram_text
 

--- a/tests/tdd/test_issue_822_radar_nowcast_segment.py
+++ b/tests/tdd/test_issue_822_radar_nowcast_segment.py
@@ -536,18 +536,27 @@ def test_ac4_mail_body_contains_segment_label_and_cooldown():
             f"AC-4 F003b: Body enthält noch rohen Source-Key 'radar'.\nBody:\n{body}"
         )
 
-        # F003c — km-Wert arithmetisch konsistent (Haversine ±2 km Toleranz)
-        # build_segment_label emittiert z.B. „Etappe 1, km 0–13.1, 07:00–09:00"
-        import re
-        km_match = re.search(r"km\s*[\d.]+[–-]([\d.]+)", body)
-        assert km_match, (
-            f"AC-4 F003c: Body muss einen km-Bereich enthalten (z.B. 'km 0–13.1').\n"
-            f"Body:\n{body}"
+        # Segment-Label — Issue #1744 A1: die Zeile „Wo & wann" nennt die
+        # Etappen-Kennung („Segment 1"), dieselbe Sprache wie Betreff und
+        # amtliche Warnung. Vorher stand hier die km-Spanne.
+        assert "Segment 1" in body, (
+            f"AC-4: Body muss die betroffene Etappe nennen.\nBody:\n{body}"
         )
-        actual_end_km = float(km_match.group(1))
+
+        # F003c — km-Wert arithmetisch konsistent (Haversine ±2 km Toleranz).
+        # Issue #1744 A1: seit die Mail den Ort als Etappen-Kennung nennt, taucht
+        # der km-Wert dort nicht mehr auf. Die Zusicherung bleibt trotzdem
+        # bestehen — sie haengt jetzt an der QUELLE, die der Alarmpfad selbst
+        # liest (`trip_alert.py:1099-1100`: `active.{start,end}_point.
+        # distance_from_start_km` aus `resolve_current_segment`), statt an ihrem
+        # frueheren Abdruck im Mailtext.
+        from services.trip_segments import resolve_current_segment
+        _res = resolve_current_segment(trip, datetime.now(timezone.utc), today)
+        assert _res is not None, "AC-4 F003c: kein aktives Segment aufloesbar."
+        actual_end_km = _res[0].end_point.distance_from_start_km
         assert abs(actual_end_km - expected_km) < 2.0, (
             f"AC-4 F003c: km-Endwert {actual_end_km:.1f} weicht mehr als 2 km von "
-            f"Haversine-Distanz {expected_km:.1f} ab.\nBody:\n{body}"
+            f"Haversine-Distanz {expected_km:.1f} ab."
         )
 
         # Cooldown-Text

--- a/tests/tdd/test_issue_917_alert_renderer.py
+++ b/tests/tdd/test_issue_917_alert_renderer.py
@@ -213,13 +213,19 @@ class TestAC2Subject:
         assert idx_trip < idx_km, f"[trip] muss vor km stehen: {subj!r}"
 
     def test_3events_n_ueber_schwelle_format(self):
-        """≥2 Events → 'N über Schwelle: K1 val1, K2 val2, K3 val3'."""
+        """≥2 Events → 'N über Schwelle: K1 val1, K2 val2, K3 val3'.
+
+        Issue #1744 A1: der Ortsslot nennt die Etappe ("Segment 1"), nicht mehr
+        die km-Spanne — dieselbe Sprache, die die amtliche Warnung zum selben
+        Segment spricht. Die frühere Erwartung `"km" in subj` beschrieb die alte
+        Ortssprache und ist damit abgelöst.
+        """
         from src.output.renderers.alert.render import render_subject
         msg = self._make_msg_3events()
         subj = render_subject(msg)
 
         assert "[GR20]" in subj
-        assert "km" in subj.lower()
+        assert "Segment 1" in subj, f"Ortsangabe fehlt: {subj!r}"
         # "über Schwelle" im Betreff (bei ≥2 Events)
         assert "Schwelle" in subj or "schwelle" in subj.lower(), (
             f"'Schwelle' fehlt bei 3 Events: {subj!r}"
@@ -362,14 +368,22 @@ class TestAC4Telegram:
         # Mindestens 2 Zeilen: erste Zeile + mind. 1 Event-Datenzeile
         assert len(lines) >= 2, f"Zu wenige Zeilen: {text!r}"
 
-    def test_first_line_contains_trip_and_km(self):
-        """Erste Zeile enthält Trip-Name und km-Angabe."""
+    def test_first_line_contains_trip_and_location(self):
+        """Erste Zeile enthält Trip-Name und Ortsangabe.
+
+        Issue #1744 A1: die Ortsangabe ist die Etappen-Kennung ("Segment 1")
+        statt der km-Spanne — die Telegram-Langform folgt derselben Ortssprache
+        wie Betreff und Mailkörper. Die frühere Erwartung `"km" in first_line`
+        beschrieb die alte Ortssprache und ist damit abgelöst.
+        """
         from src.output.renderers.alert.render import render_telegram
         msg = self._make_msg()
         text = render_telegram(msg)
         first_line = text.split("\n")[0]
         assert "GR20" in first_line, f"Trip-Name fehlt in erster Zeile: {first_line!r}"
-        assert "km" in first_line.lower(), f"km fehlt in erster Zeile: {first_line!r}"
+        assert "Segment 1" in first_line, (
+            f"Ortsangabe fehlt in erster Zeile: {first_line!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tdd/test_radar_alert_validator_location_forms.py
+++ b/tests/tdd/test_radar_alert_validator_location_forms.py
@@ -1,0 +1,126 @@
+"""Der Radar-Mail-Waechter muss ALLE drei Ortsformen kennen — und nur die.
+
+Hintergrund (Issue #1744 A1): P-1 des `radar_alert_mail_validator` fragt, ob
+die Alarm-Mail ueberhaupt sagt WO. Seine Formen-Aufzaehlung kannte "Etappe N",
+"km X-Y" und "Segment", aber NICHT die Ziel-Form "🏁 Ziel" — die einzige
+Ortsform, die `format_segment_reference` fuer die letzte Etappe erzeugt. Am
+2026-08-12 an der echt zugestellten Mail gemessen: der Waechter beanstandete
+eine korrekte, PO-freigegebene Ausgabe (Exit 1, P-1) und haette damit jede
+Ziel-Segment-Warnung blockiert — ein faelschlich blockierendes Gate.
+
+Die Erweiterung ist additiv. Damit stellt sich sofort die Gegenfrage, die
+dieser Test dauerhaft beantwortet: **behaelt die Pruefung ihre Zaehne?** Eine
+Formen-Aufzaehlung, die man bei jedem neuen Format nachzieht, verkommt sonst
+zur Attrappe, die alles durchwinkt. Der vierte Fall unten ist deshalb der
+wichtigste: eine Mail OHNE jeden Ortsbezug muss weiterhin beanstandet werden.
+
+Die drei Positiv-Faelle laufen ueber den ECHTEN Renderer (`render_email` auf
+einer echten `AlertMessage`) und die ECHTE Versand-Pipeline
+(`build_mime_message`) — nicht ueber handgeschriebene Wunsch-Strings. Sonst
+prueft der Test seine eigene Annahme darueber, wie die Mail aussieht, statt
+der Mail. Nur der Negativ-Fall ist konstruiert: eine Ausgabe ohne Ortsbezug
+kann der Renderer gar nicht erzeugen, genau deshalb ist sie die Gegenprobe.
+
+Vorbild fuer Aufbau und Modul-Laden: tests/tdd/test_official_alert_mail_validator.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR_PATH = REPO_ROOT / ".claude" / "hooks" / "radar_alert_mail_validator.py"
+
+SRC_DIR = REPO_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+def _load_validator_module():
+    if not VALIDATOR_PATH.exists():
+        pytest.fail(f"Validator-Datei nicht gefunden: {VALIDATOR_PATH}")
+    spec = importlib.util.spec_from_file_location(
+        "radar_alert_mail_validator_probe", VALIDATOR_PATH,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _rendered_radar_mail_plain(segment_id) -> str:
+    """Der Plaintext einer echten Radar-Alarm-Mail — dieselbe Fixture-Bauform
+    wie `scripts/send_gate_test_mails.py::build_radar_alert_message`, damit die
+    Nachweis-Mail des Commit-Gates und dieser Test dasselbe Objekt pruefen."""
+    from output.renderers.alert.model import AlertMessage, OnsetEvent
+    from output.renderers.alert.render import render_email
+
+    onset = OnsetEvent(
+        onset_minutes=25, onset_time="14:30", km_from=0.0, km_to=8.0,
+        is_convective=False, intensity_label="Leichter Regen",
+        source_label="Radar (DWD)", briefing_context=None,
+        segment_id=segment_id,
+    )
+    msg = AlertMessage(
+        trip_short="GATE1241 probe", stand_at="13:05", events=(onset,),
+        source="Radar (DWD)", cooldown_display="2 Stunden",
+    )
+    return render_email(msg)[1]
+
+
+def _as_radar_mail(plain: str):
+    """Verpackt den Text ueber die echte Versand-Pipeline zu der Mail, die der
+    Waechter im Postfach vorfindet (Marker-Header `X-GZ-Mail-Type`)."""
+    from output.channels.email import build_mime_message
+
+    return build_mime_message(
+        subject="[GATE1241 probe] Regen in 25 Min",
+        body=plain,
+        from_addr="gregor_zwanzig@henemm.com",
+        to_header="gregor-test@henemm.com",
+        reply_to=None,
+        html=False,
+        plain_text_body=None,
+        mail_type="radar-alert",
+    )
+
+
+@pytest.mark.parametrize("segment_id,erwartete_ortsangabe", [
+    ("Ziel", "🏁 Ziel"),   # letzte Etappe — die Form, die P-1 bis #1744 nicht kannte
+    ("1", "Segment 1"),    # numerische Etappe
+    (None, "km 0–8"),      # Altdaten ohne Kennung -> km-Rueckfall (#1744 AC-7)
+])
+def test_waechter_akzeptiert_jede_echte_ortsform(segment_id, erwartete_ortsangabe):
+    """Alle drei Ortsformen, die der Renderer ueberhaupt erzeugen kann, muessen
+    den Waechter passieren — sonst blockiert er korrekte Auslieferungen."""
+    plain = _rendered_radar_mail_plain(segment_id)
+    assert f"Wo & wann: {erwartete_ortsangabe} · ab 14:30" in plain, (
+        f"Renderer erzeugt nicht die erwartete Ortsangabe: {plain[:200]!r}"
+    )
+
+    ok, errors = _load_validator_module().validate_message(_as_radar_mail(plain))
+
+    assert ok is True, (
+        f"Waechter beanstandet die korrekte Ortsform {erwartete_ortsangabe!r}: {errors}"
+    )
+
+
+def test_waechter_beanstandet_mail_ohne_jeden_ortsbezug():
+    """Die Gegenprobe: dieselbe Mail, nur ohne Ortsangabe in der Zeile
+    'Wo & wann'. Faellt sie NICHT durch, ist P-1 eine Attrappe und die
+    Erweiterung um die Ziel-Form waere eine Aufweichung gewesen."""
+    plain = _rendered_radar_mail_plain("Ziel").replace(
+        "Wo & wann: 🏁 Ziel · ab 14:30", "Wo & wann: ab 14:30",
+    )
+    assert "Ziel" not in plain and "Segment" not in plain, (
+        "Testaufbau kaputt: der Ortsbezug steckt noch irgendwo im Text"
+    )
+
+    ok, errors = _load_validator_module().validate_message(_as_radar_mail(plain))
+
+    assert ok is False, "Mail ohne jeden Ortsbezug wurde durchgewunken — P-1 hat keine Zaehne mehr"
+    assert any(e.startswith("P-1:") for e in errors), (
+        f"Erwartet eine P-1-Beanstandung, bekommen: {errors}"
+    )


### PR DESCRIPTION
Scheibe **A1** von #1744. Scheibe B (quellenübergreifende Entdopplung) ist an #1467 S4 gebucht,
Scheibe A2 (Mail-Körper) folgt in einem eigenen PR. **Kein `Closes`-Schlüsselwort** — das Issue
wird erst nach dem Post-Deploy-Selftest geschlossen.

## Das Problem

Zwei Alarm-Mails zum selben Ereignis nannten den Ort in zwei verschiedenen Sprachen:

    [KHW 403] km 8–8 · Gewitter in 8 Min          (Radar-Nowcast)
    [KHW 403] 🏁 Ziel · GELB Gewitter (Di)        (amtliche Warnung)

Aus Nutzersicht war nicht erkennbar, dass beide denselben Ort meinen.

## Die Änderung

Alle Trip-Alarme sprechen jetzt die Segment-Kennung — dieselbe Sprache, die die amtliche Warnung
schon sprach. `src/output/renderers/alert/segments.py` (neu) hält die **eine** Ortsformatierung;
`format_segment_reference` wurde dorthin verschoben und wird von beiden Renderern importiert.

`AlertEvent` und `OnsetEvent` bekommen ein additives, optionales `segment_id` (Muster
`location_label`). Gefüllt wird es aus derselben Etappe, die schon die km-Werte liefert.

Der dritte km-Bauer `_km_str_events` entfällt ersatzlos — er speiste die Zeile „Wo & wann", die
damit dieselbe Sprache spricht wie der Betreff.

**Unangetastet:** `render_sms` (kein Ortsbezug, ≤140 Zeichen, PO-Entscheid 2026-08-04), die
amtliche Kurznachricht (`sms_scope`, #1318), der gesamte Ortsvergleich (`location_label` bleibt
erste Stufe), der tote Korridor-Pfad.

## Nachweis an echt zugestellten Mails

Nicht an Attrappen — gesendet über `scripts/send_gate_test_mails.py`, per IMAP aus dem
Test-Postfach über den Betreff-Token identifiziert:

    [GATE1241 9f3a827f] 🏁 Ziel · Regen in 25 Min
       Wo & wann: 🏁 Ziel · ab 14:30

`radar_alert_mail_validator.py` und `official_alert_mail_validator.py`: je Exit 0.

## Ein Wächter, der eine korrekte Mail ablehnte

`radar_alert_mail_validator.py` prüft, ob eine Radar-Alarm-Mail einen Ortsbezug trägt, und zählte
dafür vier Schreibweisen auf: `Etappe N`, `km X–Y`, `seg`, `Segment`. `🏁 Ziel` war keine davon —
eine korrekte Mail für das Ziel-Segment wurde beanstandet (gemessen: Exit 1, P-1). Das Muster ist
**additiv** um `Ziel` erweitert; keine bestehende Alternative entfernt oder gelockert.

Neu abgesichert durch `tests/tdd/test_radar_alert_validator_location_forms.py`: vier Fälle,
darunter der entscheidende — eine Mail **ohne** jeden Ortsbezug wird weiterhin beanstandet. Die
drei Positiv-Fälle laufen durch den echten Renderer und die echte Versand-Pipeline, nicht über
getippte Wunsch-Strings.

## Adversary: 4 Runden, 3 Findings, VERDICT VERIFIED

Alle drei Findings waren **fehlende Wächter**, keine Fehler im neuen Verhalten:

| | Fund | Behoben in |
|---|---|---|
| F001 | CRITICAL — ein Golden-Test war durch die Änderung rot und wurde **still übersprungen**: die Datei trägt `pytestmark = pytest.mark.email`, und `addopts` filtert genau das weg. Drei Prüfläufe meldeten „83 passed, **18 deselected**". | `30cccc34` |
| F002 | MEDIUM — die dokumentierte Rangfolge `location_label → Segment → km` liess sich vertauschen, ohne dass einer von 24 Tests reagierte (kein Aufrufer setzt beide Felder gleichzeitig). | `30cccc34` |
| F003 | HIGH — die „Alles-oder-nichts"-Ehrlichkeitsregel für gemischte Kennungslisten war ungeschützt. Mutation zum Filter: alle 99 Tests grün, aber ein Alarm über drei Etappen nannte nur noch zwei — die dritte verschwand spurlos aus der Ortsangabe. | `e0a497b5` |

Mutations-Gegenprobe: **11 von 12** gezielten Verfälschungen wurden von Tests gefangen; die eine
Lücke war F003 und ist geschlossen. Der Prüfer hat die Entwicklerangaben nicht übernommen,
sondern jede Messung unabhängig wiederholt — und dabei eine Überzeichnung korrigiert (die drei
Testparameter decken auf Datenebene drei Eingaben ab, auf Codeebene aber nur zwei Zweige; beide
Zweige sind belegt abgedeckt).

## Nebenbefunde, getrennt gebucht

- **#1767** — Mehrort-Nowcast-Kurznachricht zeigt nur den ersten Ort, die Zeit gilt scheinbar für alle
- **#1199** — toter Korridor-Renderer · Validator-Vorschau weicht von der echten Mail ab · `render.py:480` nennt im Vergleichsalarm einen unbeteiligten Ort

## Verifikation

- `tests/tdd/test_alert_location_vocabulary.py` — 24 Zusicherungen zu AC-1..AC-7
- `tests/tdd/test_radar_alert_validator_location_forms.py` — 4 Wächter-Fälle
- Golden-Dateien nachgezogen: `test_issue_917_alert_renderer.py`, `test_alert_renderer_format_bugs.py`, `test_issue_822_radar_nowcast_segment.py`, `test_issue_1169_compare_alert_consumer.py`
- Renderer-Gate: `test_issue_811_mode_matrix.py` grün, beide Mail-Validatoren Exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
