### PR TITLE
test(#1703 S4): Kompaktform-Varianten und Telegram-Kurzform bewacht

### DIFF
--- a/docs/context/feat-1703-s4-kompaktform-matrix.md
+++ b/docs/context/feat-1703-s4-kompaktform-matrix.md
@@ -1,0 +1,147 @@
+# Context: Epic #1703 Scheibe 4 — Kompaktform-Matrix
+
+## Request Summary
+
+Epic #1703, Scheibe 4: Vier bisher unbewachte, namensähnliche "compact"-Ausgabeorte als eigene
+Achse in `tests/tdd/test_channel_metric_matrix.py` aufnehmen (Fortsetzung der Achsen aus Scheibe
+1–3, AC-Präfix `AC-S4-n`). Ziel laut `docs/reference/metric_output_matrix.md` Abschnitt 4.2 (Fläche
+6+7) und Abschnitt 6 (Scheibe 4): die drei Verwechslungs-Orte + Telegram-Kurzform testtechnisch
+disambiguieren.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `src/output/renderers/email/compact.py:96` (`render_compact`) | Eigenständiges Kurzformat der E-Mail (Text-only). Nutzt `resolve_trip_active_metrics(dc.metrics, altbestand=...)` — **derselbe Resolver** wie an anderer Stelle im Vollmail-Pfad (Issue #1394 T2b). Ignoriert laut Docstring explizit alle Baustein-Toggles (`show_highlights` etc.) — PO-Entscheidung #722 —, **nicht** aber die Metrik-Auswahl selbst. |
+| `src/output/renderers/email/html.py:878` (`_render_mobile_compact_rows`) | Mobile Kompaktzeilen **innerhalb** der Vollmail (kein eigenständiger Kanal). Rendert Stundentabellen-Zeilen über `allowed_col_keys`/`col_order`, die von außen hereingereicht werden — keine eigene Metrik-Selektionslogik hier, sondern reiner Präsentations-Layer. |
+| `src/output/renderers/compact_summary.py` (`CompactSummaryFormatter`, `format_stage_summary` ab Z.42; `format_location_summary` ab Z.625) | Fließtext-Kompakt-Zusammenfassung. **Zwei Wrapper um einen geteilten Kern** (`format_weather_summary`, Issue #1278): Trip-Wrapper (`format_stage_summary`) nutzt rohes `dc.metrics` gefiltert auf `.enabled` (Z.168); Compare-Wrapper (`format_location_summary`) nutzt Parameter `enabled_metrics` (Compare-Renderer-IDs), übersetzt via `RENDERER_TO_TRIP_METRIC_ID`. Einzige der vier Stellen mit **etwas** Testabdeckung — aber nur für Gewitter/Hagel, nicht für Metrik-Selektion generell. |
+| `src/output/renderers/narrow.py` (`render_telegram_bubbles` ab Z.625; Helfer ab Z.346, Z.586–597) | Telegram-Kurzform (SPEC: `docs/specs/modules/feat_1001_telegram_redesign.md`). Nutzt `dc.get_enabled_metric_ids()` (Z.735/741/776) — **ein dritter Mechanismus**, weder `resolve_trip_active_metrics` noch rohes `dc.metrics`-Filtern. Kommentar Z.649/721: ein Flag `telegram_kurzform` ist hier laut AC-10 (#1001) **wirkungslos** — bereits dokumentiertes, gewolltes Verhalten, keine neue Lücke. |
+| `tests/tdd/test_channel_metric_matrix.py` (2843 Zeilen) | Bestehender Matrix-Wächter, Option C (#1514 Entscheidung): **ein** Register, achsenweise erweitert. Etablierte Konvention: `AC-S1-n` (Scheibe 1, Alarm-Renderer), `AC-S2-n` (Scheibe 2, Ausblick-Tabelle). Scheibe 4 würde `AC-S4-n` fortsetzen. |
+| `docs/specs/modules/fix_1703_s1_alert_renderer_matrix.md`, `fix_1703_s2_ausblick_matrix.md`, `fix_1703_s3_selectable_metrics.md` | Vorbild-Specs der bereits gelieferten Scheiben — Format, AC-Struktur, Umgang mit "Soll-Menge gerechnet, nie getippt". |
+| `src/output/renderers/trip_metric_ids.py` (`resolve_trip_active_metrics`) | Kanonischer Resolver, von Scheibe 4 potenziell als Referenzverhalten heranzuziehen. |
+| `src/app/models.py` (`UnifiedWeatherDisplayConfig.get_enabled_metric_ids`) | Der von `narrow.py` genutzte alternative Resolver — Abweichungsverhalten zu `resolve_trip_active_metrics` ist ungeklärt. |
+
+## Existing Patterns
+
+- **Achsen-Erweiterung statt neues Register** (Option C, PO-Entscheid aus #1514): jede Scheibe fügt
+  `AC-Sn-*`-Tests in dieselbe Datei ein, mit ausführlichem Docstring-Block, der Scope und
+  Nicht-Scope der Achse festhält (siehe Kopf von Scheibe 1/2 in der Testdatei, Z.36–51).
+- **Soll-Menge GERECHNET, nie getippt** — Vorbild `tests/helpers/outlook_columns.py`,
+  `test_compare_hourly_catalog_columns.py:122`. Für Scheibe 4 wäre die Soll-Menge vermutlich aus
+  `_METRICS`/`_SELECTABLE_GATE_EXEMPT` (wie S1/S3) oder aus dem jeweiligen Resolver selbst
+  abzuleiten — zu klären in der Analyse.
+- **Gegenprobe ist Pflicht** (Token-Grenzen-Bewusstsein, Mutations-Gegenprobe) — S1 hatte dafür
+  `test_ac_s1_2_sms_praefix_gegenprobe`.
+- **Charakterisierung vor Fix:** S1/S3 haben bewusstes, dokumentiertes Verhalten (z.B.
+  `temperature_cold`-Dublette, `telegram_kurzform` wirkungslos) NICHT repariert, sondern als
+  Ist-Zustand bewacht — nur echte, unbewachte Lücken wurden geschlossen.
+
+## Dependencies
+
+- **Upstream:** `resolve_trip_active_metrics()` (compact.py), `dc.get_enabled_metric_ids()`
+  (narrow.py), rohes `dc.metrics`/`enabled_metrics`-Parameter (compact_summary.py) — drei
+  unterschiedliche Selektionswege für denselben fachlichen Zweck ("welche Metrik ist aktiv").
+  `_METRICS`/`_SELECTABLE_GATE_EXEMPT` (`metric_catalog.py`), `RENDERER_TO_TRIP_METRIC_ID`
+  (`compare_metric_ids.py`), `format_hail_note`/`hail_priority` (`metric_format.py`).
+- **Downstream:** `render_compact()` wird im E-Mail-Kompaktformat-Dispatch genutzt (Format `compact`
+  neben `full`, siehe `X-GZ-Format`-Header-Konvention aus CLAUDE.md); `render_telegram_bubbles()`
+  ist der produktive Telegram-Ausgabeweg; `CompactSummaryFormatter`/`format_location_summary`
+  speisen sowohl Trip-Mails als auch Ortsvergleich-Renderer.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1703_s1_alert_renderer_matrix.md`
+- `docs/specs/modules/fix_1703_s2_ausblick_matrix.md`
+- `docs/specs/modules/fix_1703_s3_selectable_metrics.md`
+- `docs/specs/modules/feat_1001_telegram_redesign.md` (Telegram-Bubbles, u.a. AC-10 zu
+  `telegram_kurzform`)
+- `docs/specs/modules/issue_722_email_compact_format.md` (`render_compact`, Baustein-Ignoranz)
+- `docs/reference/metric_output_matrix.md` Abschnitt 4.2 (Flächen 6+7), Abschnitt 6 (Scheibe-4-Text)
+
+## Risks & Considerations
+
+- **Kernrisiko der Scheibe (aus dem Matrix-Dokument wörtlich):** die drei "compact"-benannten Orte
+  werden im Code und in Commits regelmäßig verwechselt — Testnamen MÜSSEN das auflösen (z.B.
+  `test_ac_s4_x_email_compact_...` vs. `..._mobile_compact_rows_...` vs.
+  `..._compact_summary_...` vs. `..._telegram_narrow_...`).
+- **Drei-Wege-Divergenz bei der Metrik-Selektion** (Hauptfund dieser Kontext-Phase): `compact.py`
+  nutzt den kanonischen Resolver, `narrow.py` einen anderen (`get_enabled_metric_ids`),
+  `compact_summary.py` filtert roh auf `.enabled` bzw. nimmt einen übersetzten Parameter. Ob diese
+  drei Wege bei denselben Eingaben dasselbe Ergebnis liefern, ist **ungeklärt** — passt zum
+  wiederkehrenden Projektmuster "dc.metrics kollabiert je nach Kanal unterschiedlich"
+  (vgl. Memory zu #1719 S2, `reference_trip_renderers_see_collapsed_metrics`). Das ist vermutlich
+  die eigentliche Prüffläche der Scheibe, nicht nur Vollständigkeit.
+- **`confidence`/`cape` (Fläche 3, Scheibe 3 Vorbild)** — zu prüfen, ob diese vier Orte dieselbe
+  Blindstelle hätten wie die bereits gefixten Kanäle, falls die Scheibe-3-Wächter sie nicht
+  automatisch mitdecken.
+- **Bereits dokumentiertes, NICHT zu reparierendes Verhalten** (nur charakterisieren):
+  `telegram_kurzform` ist laut #1001 AC-10 wirkungslos; `render_compact()` ignoriert
+  Baustein-Toggles bewusst (#722); `CompactSummaryFormatter` migriert bewusst NICHT auf
+  `metric_format.format_value` (Klassifikation Issue #1214 Scheibe 5c) — eigene Wolken-Emoji-Skala
+  weicht bewusst von der Katalog-Skala ab (Angleichung ist Scheibe 6, nicht Scheibe 4).
+- **`_render_mobile_compact_rows` (html.py:878) hat vermutlich keine eigene Metrik-Selektionslogik**
+  — reiner Präsentations-Layer über von außen hereingereichte `allowed_col_keys`. Zu klären in der
+  Analyse: ob diese Stelle überhaupt eine eigene Achse braucht oder ob sie über den bestehenden
+  Vollmail-Tabellenwächter bereits indirekt gedeckt ist (Fläche 6 nennt sie trotzdem separat).
+- **Risiko laut Matrix-Dokument: mittel, Größe: mittel** (Scheibe 4).
+
+## Analysis
+
+### Type
+Feature (Erweiterung eines bestehenden Test-Wächters um eine neue Achse, kein Bug-Fix).
+
+### Bestätigter Kernbefund (Sub-Agent, mit Code-Zitaten verifiziert)
+
+Reale, unbeabsichtigte Divergenz zwischen den drei Metrik-Selektionswegen:
+- `resolve_trip_active_metrics()` (`trip_metric_ids.py:54-56`): Fallback auf `DEFAULT_TRIP_METRIC_IDS`, wenn aktive Auswahl leer UND `altbestand=True`.
+- `get_enabled_metric_ids()` (`models.py:802-804`): KEIN Fallback, liefert `[]`.
+- **Beide** wenden das `selectable=False`-Gate NICHT an — anders als `get_metrics_for_channel()`/`get_metrics_for_report_type()` (`models.py:684`, Kommentar Z.845-846, #1585). Eine zentral nicht-wählbare Metrik (`cape`, `confidence`) könnte bei Altbestandstrips mit `enabled=True` über `render_compact()` oder `render_telegram_bubbles()` durchrutschen.
+- `compact_summary.py` ist ein **dritter** Weg: keine generische Resolver-Funktion, sondern eine handgeschriebene `if/elif`-Kette für ~10 fest benannte Metrik-IDs — die übrigen ~16 wählbaren Katalog-Metriken (z.B. `uv_index`, `snow_depth`, `freezing_level`) haben dort **strukturell keine Zelle**.
+
+### Zusätzlich gefundene Specs (Ergänzung zur Related-Specs-Liste oben)
+`docs/specs/modules/compact_summary.md` (v1.4, approved), `docs/specs/modules/compare_location_summary.md` (v2.1, draft), `docs/specs/_archive/modules/issue_614_615_telegram_kurzform.md`, `docs/specs/modules/feat_1260_telegram_kurzstil.md` (v1.0, draft), `docs/specs/_archive/modules/issue_729_render_compact_empty_guard.md`, `docs/specs/_archive/modules/issue_831_mobile_einfach_stundenraster.md`, `docs/specs/_archive/modules/fix_1330_compact_summary_daywindow.md`, `docs/specs/_archive/modules/bug_305_mobile_email_v2.md`, `docs/specs/_archive/modules/bug_636_mobile_email_table.md`.
+
+### Affected Files (with changes)
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `tests/tdd/test_channel_metric_matrix.py` | MODIFY | Neue Achse `AC-S4-1` (email/compact.py) bis `AC-S4-4` (narrow.py), analog S1-S3-Muster. Geschätzt 12-16 neue Testfunktionen. |
+| `docs/specs/modules/fix_1703_s4_kompaktform_matrix.md` | CREATE | Spec analog S1-S3. |
+| `docs/reference/metric_output_matrix.md` | MODIFY | Flächen 6+7 nach Abschluss auf den neuen Wächter umtragen (DoD jeder Scheibe). |
+| Produktivcode (`compact.py`, `html.py`, `compact_summary.py`, `narrow.py`) | KEINE Änderung | Charakterisierung, kein Fix — siehe Technical Approach. |
+
+### Scope Assessment
+- Files: 2-3 (Testdatei, Spec, Matrix-Dokument-Update)
+- Estimated LoC: Produktivcode 0; Testcode ~150-250 Zeilen (12-16 Testfunktionen)
+- Risk Level: LOW-MEDIUM — kein Assertion-Overlap mit den vier Bestandstestdateien zu diesen Renderern (`test_issue_729_render_compact_empty.py`, `test_compact_summary_*.py`, `test_issue_1001_telegram_bubbles.py`, `test_bug305_mobile_email.py`/`test_bug_636_...py`), da diese Struktur/Leerfälle prüfen, nicht Metrik-Vollständigkeit.
+
+### Technical Approach (Empfehlung des Plan-Agenten)
+**Charakterisierung, nicht Fix.** Die Resolver-Divergenz ist derselbe Fehlertyp wie in Scheibe 3 (fehlendes `_is_selectable`-Gate an einem weiteren Choke-Point) — dort war die Antwort ein Test, kein Redesign. Eine Vereinheitlichung der drei Resolver wäre echte Produktivcode-Änderung mit Verhaltensänderung an mehreren Kanälen gleichzeitig — das ist PO-Sache, nicht Teil dieser Scheibe.
+
+Vier Namensblöcke in der Matrix-Datei:
+- `AC-S4-1_email_compact_*` (render_compact, generisch über alle 26 Metriken, ~3-4 Tests)
+- `AC-S4-2_mobile_compact_rows_*` — **schlank**: kein eigener Selektionsweg (nimmt `allowed_col_keys`/`col_order` vom Aufrufer entgegen), deckt sich mit Bestand AC-13. Ein Charakterisierungstest reicht, keine volle 26er-Parametrisierung.
+- `AC-S4-3_compact_summary_*` — mit benannter Positivliste (~10 Metrik-IDs) + expliziter Nichtscope-Aussage für den Rest, analog `_NIGHT_SCALAR_IDS`-Muster (`channel_layout.py:88`). ~5-6 Tests (Trip-Wrapper, Compare-Wrapper, Nichtscope, Gate-Charakterisierung).
+- `AC-S4-4_telegram_narrow_*` (render_telegram_bubbles, generisch über alle 26, ~3-4 Tests inkl. Divergenz-Charakterisierung ggü. AC-S4-1).
+
+`_render_mobile_compact_rows` bekommt bewusst **keine** volle eigene Achse — Risiko sonst: ein Test, der `resolve_metric_col_order()` faktisch ein zweites Mal prüft.
+
+### Dependencies
+Wie in "Dependencies" oben, bestätigt durch Sub-Agent-Recherche. Keine neuen gefunden.
+
+### Open Questions — GEKLÄRT (PO-Entscheid 2026-08-12)
+
+- [x] **(a) Resolver-Divergenz — mit Wirkort-Nachweis geklärt.** PO-Sorge war zunächst: „confidence" könnte über die drei Kurzformen durchrutschen. **Nachgemessen an der echten Versandstelle** (`TripReportFormatter.format_email()`, nicht isoliert): Kein aktueller Verstoß. `format_email()` filtert `dc` IMMER über `get_metrics_for_channel()` (das `_is_selectable()`-Gate, #1585), BEVOR `render_compact()`, `CompactSummaryFormatter.format_stage_summary()` oder `render_telegram_bubbles()` (via `_dc_telegram`, bereits mit Adversary-Fix aus einer früheren Scheibe abgesichert) die Metrikliste sehen. `report_type` ist in JEDER Produktiv-Aufrufstelle (`preview_service.VALID_REPORT_TYPES`) hart auf `("morning", "evening")` beschränkt — der ungefilterte Zweig in `format_email()` (Zeile ~129 ff., nur für andere `report_type`-Werte) ist damit in Produktion **totes Gleis**. Die vierte Stelle, `format_location_summary()` (Compare-Wrapper), ist **selbst tot** — nirgends mehr aufgerufen seit Rework #1300 (PO-Entscheid 2026-07-17, Summary-Block aus Vergleichs-Mail entfernt; `docs/specs/modules/rework_1300_compare_summary_block_removal.md`, Status im Dokument noch "draft", aber Aufrufstellen in `compare_html.py`/`comparison.py` bestätigt entfernt).
+  **Restrisiko (strukturell, nicht akut):** Die drei Funktionen haben selbst KEIN eigenes Gate — sie verlassen sich vollständig auf den vorgeschalteten Aufrufer. Ein künftiger neuer Aufrufer, der diese Vorfilterung vergisst, würde lautlos durchrutschen, ohne dass ein bestehender Test es fängt.
+  **PO-Entscheid:** Scheibe 4 bewacht NUR den heutigen (korrekten) Zustand — Tests laufen über die ECHTE Aufrufkette (`format_email()`), nicht isoliert gegen die nackten Renderer-Funktionen (Prüfort=Wirkort-Prinzip, wie bei S1-S3). KEIN zusätzliches Produktivcode-Schloss in dieser Scheibe. Das strukturelle Restrisiko (kein Defense-in-Depth in den Funktionen selbst) wird als Nebenbefund in #1199 gebucht, kein eigenes Issue (nicht nutzersichtbar, aktuell kein Fehlverhalten).
+- [x] **(b) CompactSummaryFormatter-Nichtscope:** PO-Entscheid: **Ja, als Sollzustand festschreiben.** Die Positivliste (~10 von 26 Metriken im Fließtext) bleibt bewusster Dauerzustand, keine Erweiterung.
+
+### Konsequenz für den Testaufbau (wichtig, ersetzt frühere Annahme)
+
+Die AC-S4-Tests für `render_compact()`, `CompactSummaryFormatter.format_stage_summary()` und `render_telegram_bubbles()` MÜSSEN wie die bestehenden AC-1/AC-2-Tests (Scheibe 3) über `TripReportFormatter().format_email()` mit `report_type` in `{"morning","evening"}` laufen — NICHT durch isolierten Direktaufruf der nackten Funktionen mit `_single_metric_dc()`. Ein isolierter Test würde einen Zustand prüfen, der in Produktion nie eintritt (falscher Prüfort), und könnte fälschlich ROT werden, obwohl nichts kaputt ist. `format_location_summary()` (Compare-Wrapper) bekommt KEINE eigene AC — sie ist tot; ein kurzer Charakterisierungssatz im Spec-Dokument reicht („nicht produktiv verdrahtet seit #1300").
+
+## Related Non-Scope (für die Analyse-Phase markiert, nicht Teil von Scheibe 4)
+
+- Scheibe 5 (Compare-Zellwert-Vollständigkeit) — Fläche 4.
+- Scheibe 6 (Form-Wächter über Grammatik-Klassen, u.a. die Wolken-Emoji-Skala-Angleichung) —
+  Fläche 8 teilweise.
+- Scheibe 7 (Reihenfolge jenseits E-Mail/Telegram-rich) — Fläche 5, blockiert bis 7a entschieden.

--- a/docs/reference/metric_output_matrix.md
+++ b/docs/reference/metric_output_matrix.md
@@ -213,6 +213,14 @@ Modul-Docstring sind nachgezogen. Spec:
 >
 > Grenzen: Telegram (`narrow.py:571`) und Kompakt-Mail (`email/compact.py:227`) haben eigene
 > Ausblick-Implementierungen, die `outlook.py` nicht importieren → Scheibe 4.
+>
+> **Nachtrag (2026-08-12, Scheibe 4 abgeschlossen):** dieser Trend-/Ausblick-Pfad
+> (`narrow.py:571` `_outlook_lines()`, `email/compact.py` "Naechste Etappen"-Block —
+> beide über `format_trend_tokens()`) ist NICHT Teil dessen, was Scheibe 4 bewacht.
+> Deren vier Ausgabeorte (s. Abschnitt 6) sind die Metrik-Übersichts-/Kurzform-Pfade
+> (Pillen, mobile Zeilen, Fließtext-Zusammenfassung, Telegram-Kurzübersicht), nicht
+> dieser separate Trend-Block. Der „→ Scheibe 4"-Verweis ist damit nur teilweise
+> eingelöst; der Trend-/Ausblick-Pfad in Telegram und Kompakt-Mail bleibt unbewacht.
 
 **Fläche 3 — Nicht-wählbare Register-Metriken.** `metric_catalog.py:695` —
 `get_all_metrics()` gibt `[m for m in _METRICS if m.selectable]` zurück. Jeder
@@ -241,8 +249,8 @@ Stundentabelle (AC-6, Charakterisierung).
 |---|---|---|---|---|
 | 4 | Compare-Übersichtstabelle: **Zellwert** je Metrik | `compare_html.py:294`, `comparison.py:70/100` | 2 | nur Zeilen-Existenz ist bewacht; ein falscher Wert in der Zelle bleibt grün |
 | 5 | **Reihenfolge** in allen Kanälen außer E-Mail und Telegram-rich | `tokens/builder.py:78`, `comparison.py:237` | 2 | Compare-Klartext nutzt die Nutzer-Reihenfolge nur als Sichtbarkeitsfilter (#1356) |
-| 6 | Kurzform-Mail, mobile Kompaktzeilen und Kompakt-Zusammenfassung | `email/compact.py:96`, `email/html.py:878`, `compact_summary.py:567` | 2 | **drei** verschiedene Orte, die alle „compact" heißen und regelmäßig verwechselt werden: `render_compact()` ist das eigene Kurzformat, `_render_mobile_compact_rows()` sitzt **in** der Vollmail, `CompactSummaryFormatter` erzeugt den Fließtext-Block ebendort. Nur der dritte hat überhaupt einen Test — und nur für Gewitter/Hagel |
-| 7 | **Telegram-Kurzform** als eigener Ausgabeort | `narrow.py:346`, `:528–532`, `:586–597` | 2 | taucht in keiner Matrix auf, obwohl es der Prüfweg für die SMS-Grammatik ist |
+| 6 | Kurzform-Mail, mobile Kompaktzeilen und Kompakt-Zusammenfassung | `email/compact.py:96`, `email/html.py:878`, `compact_summary.py:567` | 2 | ✅ Erledigt (2026-08-12, Epic #1703 Scheibe 4): **drei** verschiedene Orte, die alle „compact" heißen und regelmäßig verwechselt werden — `render_compact()` ist das eigene Kurzformat, `_render_mobile_compact_rows()` sitzt **in** der Vollmail, `CompactSummaryFormatter` erzeugt den Fließtext-Block ebendort — jetzt einzeln bewacht: `tests/tdd/test_channel_metric_matrix.py` AC-S4-1/2/3 (Ort 1), AC-S4-5 (Ort 2), AC-S4-6/6b/7/8-10 (Ort 3). Reine Charakterisierung, kein Produktivcode-Fix. Spec: `docs/specs/modules/fix_1703_s4_kompaktform_matrix.md` |
+| 7 | **Telegram-Kurzform** als eigener Ausgabeort | `narrow.py:346`, `:528–532`, `:586–597` | 2 | ✅ Erledigt (2026-08-12, Epic #1703 Scheibe 4): Wächter `tests/tdd/test_channel_metric_matrix.py` AC-S4-12/13/14 (Auswahl/Abwahl generisch über alle wählbaren Metriken, Resolver-Divergenz zu Ort 1 als Charakterisierung, confidence-Absenz). Reine Charakterisierung, kein Produktivcode-Fix. Spec: `docs/specs/modules/fix_1703_s4_kompaktform_matrix.md` |
 | 8 | Einheiten und Nachkommastellen je Kanal | `metric_catalog.get_decimals()`, `compare_html.py:384` | 3 | nur die Compare-Legende ist bewacht |
 | 9 | **Frontend** ohne Metrik×Kanal-Matrix | `WeatherMetricsTab.svelte:411`, `compareMetricDefs.ts` | 3 | das Frontend führt eigene Register; Drift zum Backend fällt erst im Betrieb auf |
 | 10 | **Trip-SMS liest die Kaskade nicht** | `sms_trip.py:606` `format_sms()` — kein Aufruf von `get_metrics_for_channel()`/`cascade_source_for_channel()`; Ersatz-Verdrahtung `trip_report.py:301` | 2 | dokumentiert in `fix_1575_channel_metric_selection.md`; Folge-Issue #1689 (`format_sms`-Merge verschluckt Spec-Felder) |
@@ -374,13 +382,44 @@ gegen den echten Renderpfad (`TripReportFormatter().format_email()`, nicht die p
 ungenutzte `email/helpers.py::dp_to_row()`). Details, Sollzustand je Metrik, Mutations-
 Gegenprobe: `docs/specs/modules/fix_1703_s3_selectable_metrics.md`.
 
-### Scheibe 4 — Kurzform-Mail, Kompaktzeilen, Kompakt-Zusammenfassung, Telegram-Kurzform
+### Scheibe 4 — Kurzform-Mail, Kompaktzeilen, Kompakt-Zusammenfassung, Telegram-Kurzform ✅ ERLEDIGT (2026-08-12)
 
 Vier bisher namenlose Ausgabeorte als eigene Matrix-Spalten aufnehmen:
 `email/compact.py:96`, `email/html.py:878`, `compact_summary.py:567`,
 `narrow.py:346/586–597`. Die Verwechslung der ersten drei ist selbst ein
 wiederkehrender Fehler und sollte in den Testnamen aufgelöst werden.
 *Risiko: mittel. Größe: mittel.* Deckt Flächen 6 und 7.
+
+Umgesetzt als 15 ACs (AC-S4-1 bis AC-S4-15, teils als kombinierte
+Positiv-/Negativ-Assertion in einer parametrisierten Testfunktion
+zusammengefasst) in `tests/tdd/test_channel_metric_matrix.py`, gemessen
+gegen den echten Renderpfad (`TripReportFormatter().format_email()`,
+`email_format="compact"` bzw. Telegram-Pfad) statt isolierter
+Direktaufrufe — dieselbe Prüfort-=-Wirkort-Pflicht wie in Scheibe 3.
+Reine Charakterisierung, **kein Produktivcode-Fix**, auch dort nicht, wo
+die Recherche eine strukturelle Eigenheit aufdeckte: Resolver-Divergenz
+Ort 1 (`resolve_trip_active_metrics()`, Fallback auf
+`DEFAULT_TRIP_METRIC_IDS` bei leerer Auswahl) vs. Ort 5
+(`get_enabled_metric_ids()`, kein Fallback) — als Nebenbefund in #1199
+gebucht (Eintrag 2026-08-12), kein Fix hier; Positivliste von
+`format_stage_summary()` bleibt akzeptierter Dauerzustand (PO-Anschluss
+an #1214 Scheibe 5c). Ort 4 (`format_location_summary()`,
+Compare-Wrapper) bleibt ohne Test — totes Gleis seit #1300. **Nicht
+Gegenstand dieser Scheibe:** die eigenen Ausblick-/Trend-Implementierungen
+in `narrow.py:571` (`_outlook_lines()`) und `email/compact.py`
+("Naechste Etappen"-Block), die `outlook.py` nicht importieren (s.
+Fläche 2 Grenzen, Nachtrag oben) — Scheibe 4 deckt die
+Metrik-Übersichts-/Kurzform-Pfade, nicht diesen separaten Trend-Block.
+
+**Adversary-Finding F001 (geschlossen):** die ursprüngliche Spec-Fassung
+behauptete für AC-S4-3 (Ort 1) und AC-S4-8 (Ort 3), dieselbe zentrale
+`_is_selectable()`-Gate-Wirkung greife wie an Ort 5. Die
+Mutations-Gegenprobe widerlegte das — Ort 1 und Ort 3 sind durch lokale,
+gate-unabhängige Mechanismen geschützt (Pillen-Katalog-Whitelist
+`_PILL_CATALOG_ORDER` bzw. fehlender `confidence`-Zweig in
+`compact_summary.py`); nur AC-S4-14 (Telegram) belegt die Gate-Wirkung
+tatsächlich. Spec entsprechend korrigiert (Docstrings + AC-Wortlaut).
+Details: `docs/specs/modules/fix_1703_s4_kompaktform_matrix.md`.
 
 ### Scheibe 5 — Compare-Zellwert-Vollständigkeit
 

--- a/docs/specs/modules/fix_1703_s4_kompaktform_matrix.md
+++ b/docs/specs/modules/fix_1703_s4_kompaktform_matrix.md
@@ -1,0 +1,470 @@
+---
+entity_id: fix_1703_s4_kompaktform_matrix
+type: module
+created: 2026-08-12
+updated: 2026-08-12
+status: draft
+version: "1.0"
+tags: [metrics, compact, telegram, matrix-test, epic-1703]
+---
+
+<!-- Epic #1703 (Folgearbeit aus #1514), Scheibe 4. Schliesst Flaechen 6+7
+     aus docs/reference/metric_output_matrix.md §4.2/§6 (Kompaktform-
+     Varianten und Telegram-Kurzform). Reine Charakterisierung/Regressions-
+     Absicherung, KEIN Produktivcode-Fix. -->
+
+# Kompaktform-Varianten und Telegram-Kurzform absichern (#1703 Scheibe 4)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`tests/tdd/test_channel_metric_matrix.py` (Option C, EIN Register, keine
+neue Datei — #1677 B, `metric_output_matrix.md` §5) um eine vierte Achse
+(`AC-S4-n`) erweitern, analog Scheibe 1 (`AC-S1-n`) und Scheibe 2
+(`AC-S2-n`) in derselben Datei. Ziel sind die vier Ausgabeorte, an denen
+Wetterdaten in **Kompaktform** erscheinen — Kurz-E-Mail, mobile
+Kompaktzeilen innerhalb der Vollmail, Fließtext-Kompakt-Zusammenfassung
+(Trip und Compare) sowie Telegram-Kurzform. Diese Orte sind bisher
+unbewacht (Flächen 6+7, `docs/reference/metric_output_matrix.md` §4.2/§6).
+
+**Kein Produktivcode-Fix ist Auftrag dieser Scheibe.** Auch dort, wo die
+Recherche eine strukturelle Eigenheit aufdeckt (Resolver-Divergenz Ort 1
+vs. Ort 5, Positivliste in Ort 3), hält diese Scheibe den gemessenen
+Ist-Zustand als Test fest, statt ihn zu verändern.
+
+### Korrektur gegenüber der ursprünglichen Fassung (Adversary-Finding F001, gemessen 2026-08-12)
+
+Die erste Fassung dieser Spec behauptete in AC-S4-3 und AC-S4-8 — und im
+„Prüfhinweis für den Adversary" als **MUSS**-Bedingung —, dass die Absenz
+von `confidence` an Ort 1 (`render_compact()`) und Ort 3
+(`format_stage_summary()`) durch dasselbe zentrale `_is_selectable()`-Gate
+(`models.py:684`) bewirkt wird wie an Ort 5 (Telegram). Die vorgeschriebene
+Mutations-Gegenprobe (`_SELECTABLE_GATE_EXEMPT` um `"confidence"` erweitert)
+widerlegt das: **nur** `test_ac_s4_14_telegram_narrow_confidence_absent`
+wurde rot, AC-S4-3 und AC-S4-8[`confidence`] blieben grün, obwohl das Gate
+`confidence` in diesem Zustand durchlässt.
+
+Tatsächliche, jeweils **lokale und gate-unabhängige** Schutzursache
+(im Code verifiziert, nicht vermutet):
+
+| Ort | Warum `confidence` dort nie erscheint |
+|---|---|
+| Ort 1 `render_compact()` | `build_metrics_summary_pills()` iteriert über die feste Whitelist `_PILL_CATALOG_ORDER` (`src/output/renderers/email/helpers.py:1271-1276`, Schleife Z. 1872-1874) und überspringt jede Metrik, die dort nicht steht. `"confidence"` steht nicht drin. |
+| Ort 3 `format_stage_summary()` | `src/output/renderers/compact_summary.py` enthält überhaupt keinen `if`/`elif`-Zweig für `"confidence"` (0 Treffer in der Datei) — dieselbe Positivlisten-Mechanik wie bei AC-S4-9/AC-S4-10. |
+| Ort 5 `render_telegram_bubbles()` | **Hier** wirkt das zentrale Gate tatsächlich — per Mutations-Gegenprobe bestätigt (AC-S4-14 wird korrekt rot). |
+
+**Konsequenz für diese Spec:** AC-S4-3 und AC-S4-8 sind unten auf die
+gemessene Ursache umformuliert; die Tests selbst und das Produktivverhalten
+bleiben unverändert (`confidence` erscheint nachweislich an keinem der
+Orte). Beide ACs bleiben als Regression-Baseline ihres jeweiligen
+Choke-Points bestehen — sie belegen aber **nicht** die Gate-Wirkung, das
+tut allein AC-S4-14. Der „Prüfhinweis für den Adversary" ist entsprechend
+korrigiert. Kein Produktivcode-Fix (unverändertes Purpose oben).
+
+## Source
+
+> **Schicht-Hinweis:** ausschließlich Python-Core, ausschließlich
+> Testcode (`tests/tdd/`). Kein Frontend, keine Go-Beteiligung.
+
+Vier Ausgabeorte:
+
+1. `src/output/renderers/email/compact.py::render_compact()` (Z. 96) —
+   Kurz-E-Mail. Nutzt `resolve_trip_active_metrics()`
+   (`trip_metric_ids.py:54-56`, Fallback auf `DEFAULT_TRIP_METRIC_IDS` bei
+   leerer Auswahl + `altbestand=True`).
+2. `src/output/renderers/email/html.py::_render_mobile_compact_rows()`
+   (Z. 878) — mobile Kompaktzeilen INNERHALB der Vollmail. Reiner
+   Präsentations-Layer ohne eigene Selektionslogik (nimmt
+   `allowed_col_keys`/`col_order` vom Aufrufer entgegen).
+3. `src/output/renderers/compact_summary.py::CompactSummaryFormatter
+   .format_stage_summary()` (Trip-Wrapper, Z. 47ff) — Fließtext-Kompakt-
+   Zusammenfassung. Handgeschriebene if/elif-Kette für genau diese
+   Positivliste: `temperature`, `temperature_night`, `wind_chill`,
+   `wind_chill_night`, `cloud_total`, `precipitation`, `rain_probability`,
+   `wind`, `gust`, `wind_direction`, `thunder` (~10 von 26 wählbaren
+   Katalog-Metriken).
+4. `src/output/renderers/compact_summary.py::format_location_summary()`
+   (Compare-Wrapper, Z. 625) — TOTES GLEIS, nirgends mehr aufgerufen seit
+   Rework #1300 (PO-Entscheid 2026-07-17,
+   `docs/specs/modules/rework_1300_compare_summary_block_removal.md`;
+   verifiziert per grep in `compare_html.py`/`comparison.py`, keine
+   Treffer).
+5. `src/output/renderers/narrow.py::render_telegram_bubbles()` (Z. 625) —
+   Telegram-Kurzform. Nutzt `dc.get_enabled_metric_ids()`
+   (`models.py:802-804`, KEIN Fallback — Divergenz zu Ort 1).
+
+**Ausdrücklich UNVERÄNDERT (reine Prüfziele, kein Edit):** alle fünf oben
+genannten Funktionen, `resolve_trip_active_metrics()`
+(`trip_metric_ids.py:54-56`), `DEFAULT_TRIP_METRIC_IDS`,
+`get_enabled_metric_ids()` (`models.py:802-804`),
+`get_metrics_for_channel()`/`_is_selectable()` (`models.py:684`/`629-650`).
+
+## Bindende Test-Architektur-Entscheidung (PFLICHT, empirisch verifiziert — Prüfort = Wirkort)
+
+Tests für Orte 1/3/5 MÜSSEN über
+`TripReportFormatter().format_email(report_type="morning"|"evening", ...)`
+laufen (Vorbild: bestehende `_mail_table()`/`_telegram_cells()`-Helfer in
+der Testdatei) — **NICHT** isolierter Direktaufruf der nackten Funktionen
+mit `_single_metric_dc()`/`_two_metric_dc()`. Grund: `format_email()`
+filtert `dc` IMMER über `get_metrics_for_channel()`
+(`_is_selectable()`-Gate, `models.py:684`, #1585) BEVOR diese drei
+Funktionen die Metrikliste sehen — verifiziert, dass `report_type` in
+JEDER Produktiv-Aufrufstelle hart auf `("morning", "evening")`
+beschränkt ist (`preview_service.VALID_REPORT_TYPES`).
+
+- Für `render_compact()`: `email_format="compact"` als Parameter (früher
+  Return-Zweig in `email/__init__.py:109`, liefert
+  `("", compact_text)`).
+- Für `render_telegram_bubbles()`: läuft in `trip_report.py` bereits über
+  eigens vorgefilterte `_dc_telegram` (Kommentar bei
+  `trip_report.py:270-281`, Adversary-Fix einer früheren Scheibe —
+  referenzieren, nicht neu erklären).
+
+Ein isolierter Aufruf mit synthetischem `dc` würde die vorgelagerte
+Kollabierung umgehen und — wie bei Scheibe 3 gezeigt — den falschen
+Choke-Point prüfen.
+
+## Estimated Scope
+
+- **LoC:** ~150-250 Testcode (15 ACs, davon die Mehrzahl mit echtem
+  Mehrfach-Render gegen die tatsächliche Produktionspipeline). Kein
+  Produktivcode-Delta.
+- **Files:** 1 (`tests/tdd/test_channel_metric_matrix.py`, Erweiterung —
+  kein neues Modul, s. Test-Namensregel CLAUDE.md).
+- **Effort:** medium — vier unterschiedliche Choke-Points mit
+  unterschiedlicher Resolver-Logik (Fallback vs. kein Fallback,
+  Positivliste vs. generischer Katalog), mehr Fallunterscheidungen als
+  Scheibe 3.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `tests/tdd/test_channel_metric_matrix.py` (AC-S1-n/AC-S2-n-Block) | REFERENZ (Teststil, gleiche Datei) | Vorbild für Helfer (`_mail_table()`/`_telegram_cells()`), Parametrisierungsstil über `_METRICS` |
+| `docs/specs/modules/fix_1703_s3_selectable_metrics.md` | REFERENZ (Vorgänger-Scheibe) | Format-Vorbild dieser Spec; belegt "Prüfort = Wirkort"-Pflicht am selben Register |
+| `docs/reference/metric_output_matrix.md` §4.2/§6 | WIRD AKTUALISIERT (Doku-Nachtrag) | Definition of Done: Flächen 6+7 auf "erledigt, Wächter: …" umtragen |
+| Issue #1214 Scheibe 5c | REFERENZ (PO-Entscheid) | Positivliste von `format_stage_summary()` ist akzeptierter Dauerzustand, keine Erweiterung in dieser Scheibe |
+| `docs/specs/modules/rework_1300_compare_summary_block_removal.md` | REFERENZ | Beleg, dass `format_location_summary()` totes Gleis ist |
+| `src/app/trip_metric_ids.py::resolve_trip_active_metrics()`/`DEFAULT_TRIP_METRIC_IDS` | UNVERÄNDERT | Resolver für Ort 1, Fallback-Verhalten wird charakterisiert, nicht geändert |
+| `src/app/models.py::get_enabled_metric_ids()` (Z. 802-804) | UNVERÄNDERT | Resolver für Ort 5, KEIN Fallback — Divergenz wird charakterisiert |
+| Issue #1199 | Ziel für Nebenbefund | Resolver-Divergenz Ort 1 vs. Ort 5 wird dort gebucht (Eintrag 2026-08-12), kein eigenes Issue |
+
+## Implementation Details
+
+Vier neue Testgruppen in `tests/tdd/test_channel_metric_matrix.py`,
+Namenspräfixe disambiguieren die drei "compact"-Verwechslungsorte
+(PFLICHT):
+
+- `test_ac_s4_1_email_compact_*` (Ort 1, `render_compact()`)
+- `test_ac_s4_2_mobile_compact_rows_*` (Ort 2, `_render_mobile_compact_rows()`)
+- `test_ac_s4_3_compact_summary_*` (Ort 3, `format_stage_summary()`)
+- `test_ac_s4_4_telegram_narrow_*` (Ort 5, `render_telegram_bubbles()`)
+
+Ort 1 und Ort 5 laufen als generische Achse über `_METRICS`
+(`selectable=True`-Teilmenge), parametrisiert wie AC-S1/AC-S3 aus den
+Vorgänger-Scheiben. Ort 3 läuft NICHT generisch über `_METRICS`, sondern
+über die feste, im Code handgeschriebene Positivliste (s. Source Punkt 3)
+plus eine Gegenprobe mit Metriken außerhalb dieser Liste. Ort 2 bekommt
+keine eigene Achse, nur einen einzelnen Charakterisierungstest. Ort 4
+bekommt keinen Test (totes Gleis).
+
+## Expected Behavior
+
+- **Input:** der zentrale Metrik-Katalog `_METRICS` (unverändert), Trip-
+  Konfigurationen mit gezielt einzeln/kombiniert aktivierten bzw.
+  deaktivierten Metriken, ein Fall mit leerer Auswahl (Fallback-Test Ort
+  1), keine echten PO-Daten.
+- **Output:** ein neuer, grüner Testblock in
+  `tests/tdd/test_channel_metric_matrix.py`, der für alle vier
+  Kompaktform-Ausgabeorte den gemessenen Ist-Zustand absichert —
+  einschließlich der beiden strukturellen Eigenheiten (Positivliste Ort
+  3, Resolver-Divergenz Ort 1 vs. Ort 5) als bewusst nicht gefixte
+  Charakterisierung.
+- **Side effects:** keine. Kein Produktivcode-Edit, keine neue
+  Persistenz, kein neues Pflicht-Gate (Erweiterung des bestehenden
+  #1677-B-Gates).
+
+## Acceptance Criteria
+
+### Ort 1 — `render_compact()` (Kurz-E-Mail)
+
+- **AC-S4-1 (generische Achse — aktivierte wählbare Metrik erscheint):**
+  Given ein Trip mit genau einer wählbaren Metrik aus `_METRICS`
+  (`selectable=True`) aktiviert (`enabled=True`), parametrisiert über den
+  Katalog / When `render_compact()` über `format_email(email_format=
+  "compact", ...)` gerendert wird / Then erscheint diese Metrik (Symbol
+  oder Token) im kompakten Text, und keine andere wählbare Metrik
+  erscheint.
+  - Test: echtes Rendering über `TripReportFormatter().format_email()`
+    mit `email_format="compact"`, parametrisiert über eine Teilmenge von
+    `_METRICS` (Vorbild AC-S1/AC-S3-Muster).
+
+- **AC-S4-2 (Fallback bei leerer Auswahl):** Given ein Trip ohne jede
+  aktivierte Metrik (leere Auswahl, `altbestand=True`-Pfad) / When
+  `resolve_trip_active_metrics()` intern den Fallback zieht und
+  `render_compact()` darüber läuft / Then erscheinen die Metriken aus
+  `DEFAULT_TRIP_METRIC_IDS` im kompakten Text — keine leere Ausgabe.
+  - Test: Trip-Fixture mit leerer `metrics`-Liste, echtes Rendering wie
+    AC-S4-1, Assertion auf Nicht-Leere UND auf die konkreten
+    Default-IDs.
+
+- **AC-S4-3 (confidence nirgends, auch mit theoretisch persistiertem
+  `enabled=True`):** Given `confidence.selectable=False` / When ein Trip
+  mit `MetricConfig(metric_id="confidence", enabled=True)` über
+  `render_compact()` gerendert wird / Then erscheint "confidence"/
+  "Sicherheit" nicht im kompakten Text — Ursache ist die feste
+  Pillen-Katalog-Whitelist `_PILL_CATALOG_ORDER`
+  (`email/helpers.py:1271-1276`), die `"confidence"` nicht enthält und
+  deshalb in `build_metrics_summary_pills()` (Z. 1872-1874) überspringt,
+  **unabhängig** vom zentralen `_is_selectable()`-Gate.
+  - **Korrektur gegenüber der ursprünglichen Fassung (Adversary-Finding
+    F001, 2026-08-12):** hier stand zuvor „das `_is_selectable()`-Gate
+    wirkt auch hier, obwohl `render_compact()` einen eigenen Resolver
+    nutzt". Die Mutations-Gegenprobe (`_SELECTABLE_GATE_EXEMPT` um
+    `"confidence"` erweitert) lässt AC-S4-3 fälschlich GRÜN — dieser Ort
+    prüft die Gate-Bedingung nicht und kann sie strukturell auch nicht
+    prüfen (s. Known Limitations 5). Die Gate-Wirkung beweist AC-S4-14.
+  - Test: wie AC-S4-1, Negativ-Assertion, Regression-Baseline des
+    Kurz-E-Mail-Choke-Points (kein Gate-Nachweis).
+
+- **AC-S4-4 (deaktivierte Metrik erscheint nicht):** Given eine wählbare
+  Metrik mit `enabled=False` / When `render_compact()` darüber läuft /
+  Then erscheint sie nicht im kompakten Text.
+  - Test: wie AC-S4-1, Negativ-Fall derselben Parametrisierung.
+
+### Ort 2 — `_render_mobile_compact_rows()` (mobile Kompaktzeilen in der Vollmail)
+
+- **AC-S4-5 (keine eigene Selektionslogik, Charakterisierung):** Given
+  `_render_mobile_compact_rows()` erhält `allowed_col_keys`/`col_order`
+  vom Aufrufer (Präsentations-Layer ohne eigenen Filter) / When die
+  Funktion mit einer vom Aufrufer bereits reduzierten Spaltenliste
+  aufgerufen wird / Then rendert sie exakt diese Liste ohne zusätzliche
+  Filterung oder Auslassung — deckt sich mit dem bestehenden Bestand
+  AC-13 (voller Mail-Renderpfad), keine eigenständige Achse nötig.
+  - Test: ein Aufruf mit einer bewusst gekürzten `allowed_col_keys`-Liste,
+    Assertion, dass genau diese Spalten im HTML-Fragment erscheinen —
+    kein Vollständigkeits-Loop über `_METRICS`.
+
+### Ort 3 — `format_stage_summary()` (Fließtext-Kompakt-Zusammenfassung, Trip)
+
+- **AC-S4-6 (Positivliste — alle 10 Einträge erscheinen bei
+  Aktivierung):** Given eine Trip-Konfiguration mit allen 10
+  Positivlisten-Metriken aktiviert (`temperature`, `temperature_night`,
+  `wind_chill`, `wind_chill_night`, `cloud_total`, `precipitation`,
+  `rain_probability`, `wind`, `gust`, `wind_direction`, `thunder`) / When
+  `format_stage_summary()` läuft / Then erscheint zu jeder der 10 eine
+  Erwähnung im Fließtext.
+  - Test: parametrisiert über die feste Positivliste, echtes Rendering.
+
+- **AC-S4-7 (Nichtscope — Metriken außerhalb der Positivliste erscheinen
+  nie, Charakterisierung des Dauerzustands):** Given eine wählbare
+  Metrik aus `_METRICS`, die NICHT in der Positivliste steht
+  (~16 verbleibende Katalog-Metriken), aktiviert (`enabled=True`) / When
+  `format_stage_summary()` läuft / Then erscheint sie NICHT im
+  Fließtext — dies ist kein Bug, sondern PO-Entscheid (#1214 Scheibe 5c),
+  diese Scheibe erweitert die Positivliste NICHT.
+  - Test: parametrisiert über `_METRICS` minus Positivliste, Negativ-
+    Assertion, Kommentar mit Verweis auf #1214 Scheibe 5c.
+
+- **AC-S4-8 (confidence nirgends):** Given `confidence.selectable=False`
+  / When ein Trip mit `confidence.enabled=True` über
+  `format_stage_summary()` gerendert wird / Then erscheint "confidence"/
+  "Sicherheit" nicht im Fließtext — Ursache ist dieselbe strukturelle
+  Positivlisten-Mechanik wie bei AC-S4-9/AC-S4-10: `compact_summary.py`
+  hat überhaupt keinen `if`/`elif`-Zweig für `"confidence"` (0 Treffer in
+  der Datei), **unabhängig** vom zentralen `_is_selectable()`-Gate.
+  - **Korrektur gegenüber der ursprünglichen Fassung (Adversary-Finding
+    F001, 2026-08-12):** dieser AC wurde zuvor gemeinsam mit AC-S4-3 und
+    AC-S4-14 als „aktiver Gate-Choke-Point" geführt. Die
+    Mutations-Gegenprobe lässt ihn fälschlich GRÜN — er ist
+    Regression-Baseline, kein Gate-Nachweis (s. Known Limitations 5).
+  - Test: wie AC-S4-7, Spezialfall confidence, Regression-Baseline.
+
+- **AC-S4-9 (temperature_cold — nicht in Positivliste, erscheint nicht,
+  Charakterisierung):** Given `temperature_cold` (selectable=False,
+  exemptiert in `_SELECTABLE_GATE_EXEMPT`) NICHT in der Positivliste
+  steht / When ein Trip mit `temperature_cold.enabled=True` über
+  `format_stage_summary()` gerendert wird / Then erscheint "TmpMin"/
+  "temperature_cold" nicht im Fließtext — anders als beim Mail-
+  Spalten-Fallback (Scheibe 3, AC-5) hat `format_stage_summary()` keinen
+  `remaining`-Fallback-Mechanismus, die Exemption wirkt hier nicht.
+  - Test: echtes Rendering, Negativ-Assertion, expliziter Kommentar zur
+    Divergenz gegenüber Scheibe 3 AC-5.
+
+- **AC-S4-10 (cape — nicht in Positivliste, erscheint nicht):** Given
+  `cape` (selectable=False, NICHT exemptiert) NICHT in der Positivliste
+  steht / When ein Trip mit `cape.enabled=True` über
+  `format_stage_summary()` gerendert wird / Then erscheint "CAPE"/"CP"
+  nicht im Fließtext.
+  - Test: wie AC-S4-9, Regression-Baseline gegen S3-AC-2-Muster.
+
+- **AC-S4-11 (deaktivierte Positivlisten-Metrik erscheint nicht):**
+  Given eine Positivlisten-Metrik mit `enabled=False` / When
+  `format_stage_summary()` läuft / Then erscheint sie nicht im
+  Fließtext.
+  - Test: parametrisiert über die Positivliste, Negativ-Fall.
+
+### Ort 4 — `format_location_summary()` (Compare-Wrapper, totes Gleis)
+
+Kein AC. Charakterisierung genügt im Fließtext (s. Known Limitations) —
+die Funktion ist seit #1300 (2026-07-17) von keinem Aufrufer mehr
+erreichbar; ein Test würde totes Verhalten prüfen, keinen Nutzerpfad.
+
+### Ort 5 — `render_telegram_bubbles()` (Telegram-Kurzform)
+
+- **AC-S4-12 (generische Achse — aktivierte wählbare Metrik
+  erscheint):** Given ein Trip mit genau einer wählbaren Metrik aus
+  `_METRICS` aktiviert (`enabled=True`), parametrisiert über den Katalog
+  / When `render_telegram_bubbles()` über die vorgefilterte
+  `_dc_telegram` (`trip_report.py:270-281`) gerendert wird / Then
+  erscheint diese Metrik in der Telegram-Bubble, keine andere wählbare
+  Metrik erscheint.
+  - Test: echtes Rendering über `TripReportFormatter().format_email()`
+    mit Telegram-Pfad, Vorbild `_telegram_cells()`-Helfer im Bestand.
+
+- **AC-S4-13 (leere Auswahl — KEIN Fallback, Resolver-Divergenz zu Ort 1,
+  Charakterisierung als Ist-Zustand):** Given ein Trip ohne jede
+  aktivierte Metrik / When `get_enabled_metric_ids()`
+  (`models.py:802-804`) intern aufgerufen wird und
+  `render_telegram_bubbles()` darüber läuft / Then bleibt die
+  Telegram-Ausgabe leer bzw. ohne Metrik-Bubbles — anders als Ort 1
+  (AC-S4-2), wo `resolve_trip_active_metrics()` auf
+  `DEFAULT_TRIP_METRIC_IDS` zurückfällt. Diese Divergenz wird hier als
+  gemessener Ist-Zustand festgehalten, NICHT gefixt (s. Known
+  Limitations, Nebenbefund #1199).
+  - Test: Trip-Fixture mit leerer `metrics`-Liste, echtes Rendering wie
+    AC-S4-12, Assertion auf Abwesenheit jeder Default-Metrik-Bubble —
+    Gegenstück zu AC-S4-2, bewusst mit anderem erwartetem Ergebnis.
+
+- **AC-S4-14 (confidence nirgends):** Given `confidence.selectable=False`
+  / When ein Trip mit `confidence.enabled=True` über
+  `render_telegram_bubbles()` gerendert wird / Then erscheint
+  "confidence"/"Sicherheit" nicht in der Telegram-Ausgabe.
+  - Test: wie AC-S4-12, Negativ-Assertion, Regression-Baseline gegen
+    S3-AC-1-Muster (dort Mail/Compare, hier Telegram als vierter
+    Choke-Point).
+
+- **AC-S4-15 (deaktivierte Metrik erscheint nicht):** Given eine
+  wählbare Metrik mit `enabled=False` / When
+  `render_telegram_bubbles()` darüber läuft / Then erscheint sie nicht.
+  - Test: wie AC-S4-12, Negativ-Fall derselben Parametrisierung.
+
+## Known Limitations
+
+1. **Compare-Wrapper (`format_location_summary()`) ist totes Gleis,
+   keine Testabdeckung nötig.** Nirgends mehr aufgerufen seit #1300
+   (2026-07-17). Ein Test würde ein Verhalten prüfen, das keinen
+   Nutzerpfad mehr erreicht — kein AC in dieser Scheibe.
+2. **Positivliste von `format_stage_summary()` bleibt Dauerzustand**
+   (PO-Entscheid 2026-08-12, Anschluss an #1214 Scheibe 5c). Die
+   verbleibenden ~16 wählbaren Katalog-Metriken erscheinen dort
+   strukturell nie — AC-S4-7 hält das als akzeptierte Charakterisierung
+   fest, keine Erweiterung der Liste ist Auftrag dieser Scheibe.
+3. **Resolver-Divergenz** (`resolve_trip_active_metrics()` mit
+   `DEFAULT_TRIP_METRIC_IDS`-Fallback in Ort 1 vs.
+   `get_enabled_metric_ids()` ohne Fallback in Ort 5) ist am jeweiligen
+   Wirkort neutralisiert — beide Orte verhalten sich innerhalb ihres
+   eigenen Kontexts konsistent, die Divergenz zeigt sich nur im
+   Seitenvergleich (AC-S4-2 vs. AC-S4-13). Strukturell bleibt sie
+   fragil: ein künftiger Refactor, der beide Resolver zusammenlegt,
+   könnte das Fallback-Verhalten unbeabsichtigt auf Telegram
+   übertragen oder umgekehrt entfernen. Bereits als Nebenbefund in
+   **#1199 gebucht (Eintrag vom 2026-08-12)** — kein neues Issue, kein
+   Fix in dieser Scheibe.
+4. **Nicht Gegenstand dieser Scheibe (Epic-Vorgabe):** die übrigen
+   Flächen aus `metric_output_matrix.md` §4.2 (Alarm-Renderer-Matrix
+   Scheibe 1, Ausblick-Tabelle Scheibe 2, `get_all_metrics()`-
+   Blindstelle Scheibe 3, Compare-Zellwert, Einheiten,
+   Frontend-Register, Trip-SMS-Kaskade) — nur Flächen 6+7
+   (Kompaktform-Varianten + Telegram-Kurzform) sind Ziel dieser
+   Scheibe.
+5. **Für Ort 1 und Ort 3 ist ein „echter" Gate-Test strukturell nicht
+   möglich — das ist eine Grenze, keine Lücke** (Adversary-Finding F001,
+   2026-08-12). Ein Test, der die Wirkung des zentralen
+   `_is_selectable()`-Gates an diesen beiden Orten beweist, bräuchte eine
+   Katalog-Metrik, die **gleichzeitig** (a) in `_PILL_CATALOG_ORDER`
+   (`email/helpers.py:1271-1276`) bzw. in der Positivliste von
+   `format_stage_summary()` steht **und** (b) `selectable=False` ist.
+   Eine solche Metrik existiert im Katalog derzeit nicht: die
+   `selectable=False`-Menge (`confidence`, `temperature_cold`, `cape`)
+   ist disjunkt zu beiden Listen. Solange das so bleibt, sind AC-S4-3 und
+   AC-S4-8 Regression-Baselines ihres jeweiligen Choke-Points — die
+   Gate-Wirkung wird ausschließlich von AC-S4-14 (Ort 5, Telegram)
+   bewacht. Wird künftig eine gelistete Metrik auf `selectable=False`
+   gesetzt, entsteht die Testbarkeit von selbst und der Nachweis ist
+   nachzuziehen.
+
+## Definition of Done
+
+Nach grünem Testlauf **zusätzlich zum Code-Merge** (Epic-Vorgabe, nicht
+optional): `docs/reference/metric_output_matrix.md` §4.2 „Flächen 6+7"
+und §6 „Scheibe 4" aktualisieren — von einer offenen Beschreibung auf
+einen Verweis auf den neuen Wächter umstellen (Testdatei + die neuen
+AC-Nummern in `tests/tdd/test_channel_metric_matrix.py`), analog wie
+Scheibe 3 markiert wurde.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine.
+- **Rationale:** reine Testerweiterung eines bereits etablierten,
+  budgetierten Gates (#1677 B); keine neue Entscheidungsfläche (kein
+  Kanal, kein Provider, kein Datenmodell-, Auth- oder
+  Editor-Paradigma-Wechsel). Analog zu Scheibe 3.
+
+## Prüfhinweis für den Adversary
+
+Leitfrage aus CLAUDE.md: **Ist die Zusicherung dort geprüft, wo sie
+WIRKT — oder nur dort, wo der Code steht?** Konkret: Orte 1/3/5 MÜSSEN
+gegen den ECHTEN Renderpfad (`TripReportFormatter().format_email()`)
+getestet werden, nicht gegen isolierte Direktaufrufe — genau die Falle,
+die Scheibe 3 bereits einmal aufgedeckt hat (s. „Bindende
+Test-Architektur-Entscheidung" oben).
+
+**Mutations-Gegenproben (Pflicht, per String-Ersetzung mit externer
+Sicherungskopie — nie `git checkout/stash/reset`):**
+
+- `_SELECTABLE_GATE_EXEMPT` um `"confidence"` erweitern — welcher Test
+  wird rot? MUSS **genau AC-S4-14** sein (Ort 5, Telegram — der einzige
+  Ort, an dem das zentrale Gate die entscheidende Variable ist).
+  AC-S4-3 (Ort 1) und AC-S4-8 (Ort 3) bleiben dabei **erwartungsgemäß
+  grün**: sie sind durch lokale, gate-unabhängige Mechanismen geschützt
+  (Pillen-Katalog-Whitelist bzw. fehlender `confidence`-Zweig, s.
+  „Korrektur gegenüber der ursprünglichen Fassung" und Known Limitations
+  5). **Diese Erwartung wurde am 2026-08-12 korrigiert** — die frühere
+  Fassung forderte hier alle drei Tests rot und definierte damit eine
+  Bedingung, die der Code strukturell nicht erfüllen kann (Finding F001).
+- Die Positivliste in `format_stage_summary()` um eine Metrik aus dem
+  Nichtscope-Set kürzen (eine bereits gelistete entfernen) — MUSS
+  AC-S4-6 rot werden lassen (Vollständigkeits-Fang).
+- Den Fallback in `resolve_trip_active_metrics()` deaktivieren (leere
+  Auswahl liefert `[]` statt `DEFAULT_TRIP_METRIC_IDS`) — MUSS AC-S4-2
+  rot werden lassen, AC-S4-13 bleibt davon unberührt (anderer Resolver).
+- `get_enabled_metric_ids()` um denselben Fallback-Mechanismus erweitern
+  wie Ort 1 — MUSS AC-S4-13 rot werden lassen (die Divergenz-Assertion
+  erwartet explizit KEINEN Fallback).
+
+## Changelog
+
+- 2026-08-12: Initial spec created (Epic #1703, Scheibe 4). Vier
+  Ausgabeorte (Kurz-E-Mail, mobile Kompaktzeilen, Fließtext-Zusammen-
+  fassung Trip, Telegram-Kurzform) gegen den echten Renderpfad
+  spezifiziert; Compare-Wrapper als totes Gleis ausgeschlossen;
+  Resolver-Divergenz Ort 1 vs. Ort 5 als Nebenbefund #1199 gebucht statt
+  in dieser Scheibe gefixt.
+- 2026-08-12: **Korrektur nach Adversary-Runde 1 (Finding F001, HIGH).**
+  AC-S4-3 und AC-S4-8 behaupteten fälschlich denselben
+  `_is_selectable()`-Gate-Mechanismus wie AC-S4-14; die
+  Mutations-Gegenprobe zeigt, dass Ort 1 und Ort 3 durch unabhängige,
+  lokale Mechanismen geschützt sind (Pillen-Katalog-Whitelist
+  `_PILL_CATALOG_ORDER` bzw. fehlender `confidence`-Zweig in
+  `compact_summary.py`) und nur Ort 5 den Gate-Mechanismus tatsächlich
+  demonstriert. Korrigiert: neuer Abschnitt „Korrektur gegenüber der
+  ursprünglichen Fassung", AC-S4-3- und AC-S4-8-Wortlaut,
+  Adversary-Prüfhinweis (Erwartung: genau AC-S4-14 rot), neue Known
+  Limitation 5 (echter Gate-Test für Ort 1/3 mangels passender
+  Katalog-Metrik strukturell unmöglich). Dazu die beiden Docstrings in
+  `tests/tdd/test_channel_metric_matrix.py`. Kein Produktivcode-Delta,
+  keine Assertion-Änderung — Produktivverhalten war und bleibt korrekt.

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -83,11 +83,8 @@ from output.renderers.channel_layout import render_for_channel
 from output.renderers.compare_metric_catalog import COMPARE_METRIC_CATALOG, get_compare_metric_catalog
 from output.renderers.compare_metric_ids import FRONTEND_TO_RENDERER_METRIC_ID, resolve_enabled_metrics
 from output.renderers.comparison import render_compare_email
-from output.renderers.email.compact import render_compact
 from output.renderers.email.helpers import resolve_metric_col_order
 from output.renderers.email.html import _render_mobile_compact_rows
-from output.renderers.compact_summary import CompactSummaryFormatter
-from output.renderers.narrow import render_telegram_bubbles
 from output.renderers.sms_trip import SMS_SYMBOL_BY_METRIC, SMS_MULTI_SYMBOLS_BY_METRIC
 from output.renderers.trip_metric_ids import DEFAULT_TRIP_METRIC_IDS
 from output.renderers.trip_report import TripReportFormatter

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -83,9 +83,15 @@ from output.renderers.channel_layout import render_for_channel
 from output.renderers.compare_metric_catalog import COMPARE_METRIC_CATALOG, get_compare_metric_catalog
 from output.renderers.compare_metric_ids import FRONTEND_TO_RENDERER_METRIC_ID, resolve_enabled_metrics
 from output.renderers.comparison import render_compare_email
+from output.renderers.email.compact import render_compact
 from output.renderers.email.helpers import resolve_metric_col_order
+from output.renderers.email.html import _render_mobile_compact_rows
+from output.renderers.compact_summary import CompactSummaryFormatter
+from output.renderers.narrow import render_telegram_bubbles
 from output.renderers.sms_trip import SMS_SYMBOL_BY_METRIC, SMS_MULTI_SYMBOLS_BY_METRIC
+from output.renderers.trip_metric_ids import DEFAULT_TRIP_METRIC_IDS
 from output.renderers.trip_report import TripReportFormatter
+from services.report_config_resolver import ReportRenderOptions
 from services.weather_change_detection import _ALERT_METRIC_TO_CATALOG_ID, is_alert_metric_active
 from services.weather_metrics import WeatherMetricsService, summarize_points
 
@@ -2841,3 +2847,314 @@ def test_ac_s2_8_ausblick_zelle_zeigt_den_gerechneten_wert():
                     "Minimum/Maximum zeigen dann beide Spalten einen "
                     "plausiblen, aber getauschten Wert."
                 )
+
+
+# ===========================================================================
+# Epic #1703 Scheibe 4 (AC-S4-1 bis AC-S4-15): Kompaktform-Varianten und
+# Telegram-Kurzform. Vier Ausgabeorte -- Kurz-E-Mail (render_compact),
+# mobile Kompaktzeilen (_render_mobile_compact_rows), Fliesstext-Kompakt-
+# Zusammenfassung (CompactSummaryFormatter.format_stage_summary), Telegram-
+# Kurzform (render_telegram_bubbles). Reine Charakterisierung, kein
+# Produktivcode-Fix. Spec: docs/specs/modules/fix_1703_s4_kompaktform_matrix.md
+#
+# KORREKTUR ggue. Spec (waehrend TDD-RED empirisch gemessen, 2026-08-12):
+# - Ort 1 (render_compact) ist SELBST threshold-/fixture-gated: von den 15
+#   _PILL_CATALOG_ORDER-Metriken feuern mit _matrix_segment() nur 10
+#   zuverlaessig (cloud_low/visibility/uv_index/freezing_level/dewpoint
+#   liefern mit dieser Fixture keinen Wert -- Fixture-Grenze, kein Befund
+#   dieser Scheibe). AC-S4-1 ist auf die 10 zuverlaessig feuernden skaliert.
+# - wind_direction erzeugt NIRGENDS (weder Ort 1 -- ohnehin nicht im
+#   Pillen-Katalog -- noch Ort 3) einen sichtbaren Unterschied -- echter,
+#   gemessener Noop. Eigene Charakterisierung AC-S4-6b statt Aufnahme in die
+#   generische AC-S4-6-Parametrisierung.
+# - Ort 5 (render_telegram_bubbles) ist ENTGEGEN der urspruenglichen Annahme
+#   VOLL generisch: alle 25 waehlbaren Metriken erzeugen zuverlaessig eine
+#   Kurzuebersicht-Zeile (kein Dash-/Threshold-Ausfall) -- robusterer Befund
+#   als angenommen, AC-S4-12 deckt den vollen Katalog ab, keine Restriktion.
+# ===========================================================================
+
+
+def _s4_compact_render_options(dc: UnifiedWeatherDisplayConfig) -> ReportRenderOptions:
+    return ReportRenderOptions(
+        email_format="compact", show_outlook=True, show_stage_stats=True,
+        show_stability=True, show_compact_summary=True,
+        show_multi_day_trend=False, show_yesterday_comparison=True,
+        display_config=dc,
+    )
+
+
+def _s4_email_compact_text(dc: UnifiedWeatherDisplayConfig) -> str:
+    """Ort 1 -- echtes Rendering ueber render_compact() via format_email()
+    (Pruefort=Wirkort, s. Spec 'Bindende Test-Architektur-Entscheidung')."""
+    report = TripReportFormatter().format_email(
+        [_matrix_segment()], trip_name="Issue1703S4", report_type="evening",
+        night_weather=F.night_weather(), display_config=dc, stage_name=F.STAGE_NAME,
+        tz=F.TZ, render_options=_s4_compact_render_options(dc),
+    )
+    return report.email_plain
+
+
+def _s4_pill_lines(text: str) -> list[str]:
+    if "== Metriken-Ueberblick ==" not in text:
+        return []
+    section = text.split("== Metriken-Ueberblick ==")[1].split("-" * 10)[0]
+    return [line for line in section.splitlines() if line.strip()]
+
+
+def _s4_compact_summary_text(dc: UnifiedWeatherDisplayConfig) -> str:
+    """Ort 3 -- echtes Rendering ueber format_stage_summary() via
+    format_email(). Extraktion der isolierten Zeile ueber ihre feste
+    Position (email/plain.py:148-167: Icon/Eyebrow, Trip-Report-Zeile,
+    Etappenname, Datum, Leerzeile, DANN die Zusammenfassung) -- in den hier
+    genutzten Fixtures ist stage_stats immer None, die Position ist damit
+    deterministisch."""
+    report = TripReportFormatter().format_email(
+        [_matrix_segment()], trip_name="Issue1703S4", report_type="evening",
+        night_weather=F.night_weather(), display_config=dc, stage_name=F.STAGE_NAME,
+        tz=F.TZ,
+    )
+    lines = report.email_plain.splitlines()
+    idx = lines.index("")
+    return lines[idx + 1]
+
+
+def _s4_telegram_bubbles(dc: UnifiedWeatherDisplayConfig) -> list[str]:
+    """Ort 5 -- echtes Rendering ueber render_telegram_bubbles() via
+    format_email(); Telegram bekommt intern eine eigens vorgefilterte
+    _dc_telegram (trip_report.py:270-281, Adversary-Fix einer frueheren
+    Scheibe)."""
+    report = TripReportFormatter().format_email(
+        [_matrix_segment()], trip_name="Issue1703S4", report_type="evening",
+        night_weather=F.night_weather(), display_config=dc, stage_name=F.STAGE_NAME,
+        tz=F.TZ,
+    )
+    return report.telegram_bubbles
+
+
+def _s4_kurzuebersicht(dc: UnifiedWeatherDisplayConfig) -> list[str]:
+    bubbles = _s4_telegram_bubbles(dc)
+    assert len(bubbles) >= 2, f"AC-S4: Kurzuebersicht-Bubble fehlt: {bubbles!r}"
+    kb = bubbles[1]
+    return [
+        line for line in kb.splitlines()
+        if line.strip() and line.strip() != "Kurzübersicht"
+    ]
+
+
+# --- Ort 1 -- render_compact() (Kurz-E-Mail) --------------------------------
+
+_S4_PILL_RELIABLE = [
+    "temperature", "wind_chill", "wind", "gust", "precipitation",
+    "rain_probability", "thunder", "cloud_total", "humidity", "sunshine",
+]
+
+
+@pytest.mark.parametrize("metric_id", _S4_PILL_RELIABLE)
+def test_ac_s4_1_email_compact_selection(metric_id):
+    """AC-S4-1: eine aktivierte, zuverlaessig feuernde Katalog-Metrik erzeugt
+    genau eine Pillen-Zeile im Kurz-E-Mail-Ueberblick; deaktiviert erscheint
+    keine."""
+    on_lines = _s4_pill_lines(_s4_email_compact_text(_single_metric_dc(metric_id, enabled=True)))
+    off_lines = _s4_pill_lines(_s4_email_compact_text(_single_metric_dc(metric_id, enabled=False)))
+    assert len(on_lines) == 1, (
+        f"AC-S4-1: {metric_id!r} aktiv -> genau 1 Pillen-Zeile erwartet, "
+        f"gemessen {on_lines!r}"
+    )
+    assert off_lines == [], (
+        f"AC-S4-1: {metric_id!r} deaktiviert -> keine Pillen-Zeile erwartet, "
+        f"gemessen {off_lines!r}"
+    )
+
+
+def test_ac_s4_2_email_compact_fallback_on_empty_selection():
+    """AC-S4-2: leere Metrikliste (Altbestand-Pfad) laesst render_compact()
+    ueber resolve_trip_active_metrics() auf DEFAULT_TRIP_METRIC_IDS
+    zurueckfallen -- keine leere Ausgabe."""
+    dc = UnifiedWeatherDisplayConfig(trip_id="s4-empty", metrics=[])
+    lines = _s4_pill_lines(_s4_email_compact_text(dc))
+    assert lines, (
+        "AC-S4-2: leere Metrikliste (altbestand=True) soll auf "
+        f"DEFAULT_TRIP_METRIC_IDS={DEFAULT_TRIP_METRIC_IDS} zurueckfallen -- "
+        "gemessen keine einzige Pillen-Zeile"
+    )
+
+
+def test_ac_s4_3_email_compact_confidence_absent():
+    """AC-S4-3: confidence (selectable=False) erscheint nicht im Kurz-E-Mail-
+    Text.
+
+    Korrektur (Adversary-Finding F001, 2026-08-12): die fruehere Docstring-
+    Behauptung "das vorgelagerte _is_selectable()-Gate (models.py:684) wirkt
+    auch hier" ist per Mutations-Gegenprobe widerlegt -- mit "confidence" in
+    _SELECTABLE_GATE_EXEMPT laesst das Gate die Metrik durch, und dieser
+    Test bleibt trotzdem GRUEN. Die tatsaechliche Schutzursache ist lokal
+    und vom zentralen Gate unabhaengig: build_metrics_summary_pills()
+    iteriert ueber die feste Whitelist _PILL_CATALOG_ORDER
+    (email/helpers.py:1271-1276, Schleife Z. 1872-1874) und ueberspringt
+    jede Metrik, die dort nicht steht -- "confidence" steht dort nicht drin.
+    Der Test bleibt als Regression-Baseline des Kurz-E-Mail-Choke-Points
+    bestehen, beweist aber NICHT die Gate-Wirkung; die beweist AC-S4-14
+    (Telegram)."""
+    lines = _s4_pill_lines(_s4_email_compact_text(_single_metric_dc("confidence", enabled=True)))
+    assert lines == [], (
+        f"AC-S4-3: 'confidence' erscheint im Kurz-E-Mail-Ueberblick: {lines!r}"
+    )
+
+
+# --- Ort 2 -- _render_mobile_compact_rows() (mobile Kompaktzeilen) --------
+
+def test_ac_s4_5_mobile_compact_rows_no_own_selection_logic():
+    """AC-S4-5: _render_mobile_compact_rows() hat keine eigene
+    Selektionslogik -- sie rendert exakt die vom Aufrufer uebergebene
+    allowed_col_keys-Menge. Charakterisierung, keine eigene Achse (deckt
+    sich mit Bestand AC-13)."""
+    rows = [{"time": "12", "temp": 15.0, "wind": 20.0, "precip": 2.0}]
+    html = _render_mobile_compact_rows(rows, friendly_keys=set(), allowed_col_keys={"temp"})
+    temp_label = get_metric("temperature").col_label
+    wind_label = get_metric("wind").col_label
+    assert temp_label in html, (
+        f"AC-S4-5: erlaubte Spalte {temp_label!r} fehlt im HTML-Fragment"
+    )
+    assert wind_label not in html, (
+        f"AC-S4-5: nicht erlaubte Spalte {wind_label!r} erscheint trotzdem: {html}"
+    )
+
+
+# --- Ort 3 -- format_stage_summary() (Fliesstext-Kompakt-Zusammenfassung) --
+
+_S4_POSITIVLIST = [
+    "temperature", "temperature_night", "wind_chill", "wind_chill_night",
+    "cloud_total", "precipitation", "rain_probability", "wind", "gust",
+    "wind_direction", "thunder",
+]
+_S4_POSITIVLIST_OBSERVABLE = [m for m in _S4_POSITIVLIST if m != "wind_direction"]
+_S4_NICHTSCOPE = [m for m in _ALL_METRIC_IDS if m not in _S4_POSITIVLIST]
+
+
+def _s4_baseline_summary() -> str:
+    return _s4_compact_summary_text(UnifiedWeatherDisplayConfig(trip_id="s4-base", metrics=[]))
+
+
+@pytest.mark.parametrize("metric_id", _S4_POSITIVLIST_OBSERVABLE)
+def test_ac_s4_6_compact_summary_positivlist_selection(metric_id):
+    """AC-S4-6: jede der 10 beobachtbaren Positivlisten-Metriken (alle ausser
+    wind_direction, s. AC-S4-6b) erzeugt aktiviert einen vom Basissatz (nur
+    Etappenname) abweichenden Fliesstext; deaktiviert bleibt der Basissatz."""
+    baseline = _s4_baseline_summary()
+    on_text = _s4_compact_summary_text(_single_metric_dc(metric_id, enabled=True))
+    off_text = _s4_compact_summary_text(_single_metric_dc(metric_id, enabled=False))
+    assert on_text != baseline, (
+        f"AC-S4-6: {metric_id!r} aktiv soll den Fliesstext gegenueber dem "
+        f"Basissatz {baseline!r} veraendern -- gemessen identisch"
+    )
+    assert off_text == baseline, (
+        f"AC-S4-6: {metric_id!r} deaktiviert soll den Basissatz {baseline!r} "
+        f"liefern -- gemessen {off_text!r}"
+    )
+
+
+def test_ac_s4_6b_compact_summary_wind_direction_is_noop():
+    """AC-S4-6b (Charakterisierung eines gemessenen Noops): wind_direction
+    steht in der Positivliste (Source Punkt 3), veraendert den Fliesstext
+    aber weder aktiviert noch deaktiviert -- die Kompassrichtung wird an
+    keiner Stelle des Fliesstext-Formulierers ausgegeben. Kein Fix (Auftrag
+    dieser Scheibe ist reine Charakterisierung). Faellt dieser Test rot,
+    hat sich das Produktivverhalten geaendert -- dann Spec-Korrektur statt
+    Test-Anpassung pruefen."""
+    baseline = _s4_baseline_summary()
+    on_text = _s4_compact_summary_text(_single_metric_dc("wind_direction", enabled=True))
+    assert on_text == baseline, (
+        f"AC-S4-6b: 'wind_direction' aktiv veraendert den Fliesstext entgegen "
+        f"der Messung -- gemessen {on_text!r} statt Basissatz {baseline!r}"
+    )
+
+
+@pytest.mark.parametrize("metric_id", _S4_NICHTSCOPE)
+def test_ac_s4_7_compact_summary_nichtscope_metrics_never_appear(metric_id):
+    """AC-S4-7 (Charakterisierung des Dauerzustands, PO-Entscheid 2026-08-12,
+    Anschluss an #1214 Scheibe 5c): eine waehlbare Metrik ausserhalb der
+    Positivliste erscheint nie im Fliesstext -- kein Bug, keine Erweiterung
+    in dieser Scheibe."""
+    baseline = _s4_baseline_summary()
+    text = _s4_compact_summary_text(_single_metric_dc(metric_id, enabled=True))
+    assert text == baseline, (
+        f"AC-S4-7: {metric_id!r} (ausserhalb Positivliste) veraendert den "
+        f"Fliesstext: {text!r} statt Basissatz {baseline!r}"
+    )
+
+
+@pytest.mark.parametrize("metric_id", ["confidence", "temperature_cold", "cape"])
+def test_ac_s4_8_10_compact_summary_non_selectable_absent(metric_id):
+    """AC-S4-8/9/10: confidence/temperature_cold/cape (selectable=False)
+    erscheinen nie im Fliesstext. Anders als beim Mail-Spalten-Fallback
+    (Scheibe 3, AC-5) hat format_stage_summary() keinen remaining-Fallback-
+    Mechanismus -- die Exemption von temperature_cold wirkt hier nicht,
+    weil die Metrik schlicht nicht in der Positivliste steht (AC-S4-9).
+
+    Korrektur fuer den confidence-Fall (Adversary-Finding F001,
+    2026-08-12): auch AC-S4-8 belegt NICHT die Wirkung des zentralen
+    _is_selectable()-Gates -- unter der Mutations-Gegenprobe ("confidence"
+    in _SELECTABLE_GATE_EXEMPT) bleibt dieser Fall GRUEN. Die Schutzursache
+    ist dieselbe strukturelle Positivlisten-Mechanik wie bei
+    AC-S4-9/AC-S4-10: compact_summary.py enthaelt ueberhaupt keinen
+    if/elif-Zweig fuer "confidence" (0 Treffer in der Datei), unabhaengig
+    vom Gate-Zustand. Regression-Baseline, kein Gate-Nachweis -- den fuehrt
+    AC-S4-14 (Telegram)."""
+    baseline = _s4_baseline_summary()
+    text = _s4_compact_summary_text(_single_metric_dc(metric_id, enabled=True))
+    assert text == baseline, (
+        f"AC-S4-8/9/10: {metric_id!r} erscheint im Fliesstext: {text!r}"
+    )
+
+
+# Ort 4 (format_location_summary(), Compare-Wrapper): bewusst KEIN Test.
+# Seit Rework #1300 (2026-07-17) von keinem Aufrufer mehr erreicht (grep in
+# compare_html.py/comparison.py: keine Treffer) -- ein Test wuerde totes
+# Verhalten pruefen, keinen Nutzerpfad. S. Spec Known Limitations Punkt 1.
+
+
+# --- Ort 5 -- render_telegram_bubbles() (Telegram-Kurzform) ---------------
+
+@pytest.mark.parametrize("metric_id", _ALL_METRIC_IDS)
+def test_ac_s4_12_telegram_narrow_selection(metric_id):
+    """AC-S4-12: eine aktivierte waehlbare Metrik erzeugt genau eine Zeile
+    (Kuerzel am Zeilenanfang) in der Telegram-Kurzuebersicht; deaktiviert
+    keine. Generisch ueber alle 25 waehlbaren Metriken -- anders als Ort 1
+    (Pillen, threshold-/fixture-gated) liefert _overview_line() fuer jede
+    Metrik zuverlaessig einen Wert oder einen Platzhalter-Strich (gemessen)."""
+    label = get_metric(metric_id).compact_label
+    on_lines = _s4_kurzuebersicht(_single_metric_dc(metric_id, enabled=True))
+    off_lines = _s4_kurzuebersicht(_single_metric_dc(metric_id, enabled=False))
+    assert any(line.startswith(label + " ") for line in on_lines), (
+        f"AC-S4-12: {metric_id!r} aktiv -> keine Zeile mit Kuerzel {label!r} "
+        f"in der Kurzuebersicht: {on_lines!r}"
+    )
+    assert not any(line.startswith(label + " ") for line in off_lines), (
+        f"AC-S4-12: {metric_id!r} deaktiviert -> Zeile mit Kuerzel {label!r} "
+        f"erscheint trotzdem: {off_lines!r}"
+    )
+
+
+def test_ac_s4_13_telegram_narrow_no_fallback_on_empty_selection():
+    """AC-S4-13 (Resolver-Divergenz-Charakterisierung, Ist-Zustand, kein
+    Fix): leere Metrikliste laesst render_telegram_bubbles() -- anders als
+    Ort 1 (AC-S4-2, DEFAULT_TRIP_METRIC_IDS-Fallback) -- OHNE jede
+    Metrik-Zeile. get_enabled_metric_ids() (models.py:802-804) kennt
+    keinen Fallback. Nebenbefund zur strukturellen Divergenz gebucht in
+    #1199 (Eintrag vom 2026-08-12)."""
+    dc = UnifiedWeatherDisplayConfig(trip_id="s4-empty-tg", metrics=[])
+    lines = _s4_kurzuebersicht(dc)
+    assert lines == [], (
+        "AC-S4-13: leere Metrikliste soll KEINE Kurzuebersicht-Zeile "
+        f"erzeugen (kein Fallback, anders als Ort 1) -- gemessen {lines!r}"
+    )
+
+
+def test_ac_s4_14_telegram_narrow_confidence_absent():
+    """AC-S4-14: confidence erscheint nicht in der Telegram-Kurzuebersicht --
+    render_telegram_bubbles() liest dc.get_enabled_metric_ids() ohne
+    eigenes selectable-Gate, aber die vorgelagerte _dc_telegram-Filterung
+    (trip_report.py:270-281, Adversary-Fix einer frueheren Scheibe) faengt
+    'confidence' bereits ab, bevor render_telegram_bubbles() sie sieht."""
+    lines = _s4_kurzuebersicht(_single_metric_dc("confidence", enabled=True))
+    assert lines == [], f"AC-S4-14: 'confidence' erscheint: {lines!r}"


### PR DESCRIPTION
## Zusammenfassung
Epic #1703 Scheibe 4: die vier bisher unbewachten "kurzen" Ausgabeorte (Kurz-E-Mail, mobile Kompaktzeilen, Fließtext-Kompakt-Zusammenfassung, Telegram-Kurzform) werden jetzt vom bestehenden Matrix-Wächter bewacht (`tests/tdd/test_channel_metric_matrix.py`, AC-S4-1..15, 68 neue Testfälle). Reine Charakterisierung, kein Produktivcode-Fix.

Adversary VERIFIED nach einer Fix-Runde (Finding F001 behoben: Docstring-Begründung korrigiert).

Spec: `docs/specs/modules/fix_1703_s4_kompaktform_matrix.md`

## Test plan
- [x] `uv run pytest tests/tdd/test_channel_metric_matrix.py -v -k "ac_s4"` — 68 passed
- [x] Vollständiger Lauf derselben Datei (222 Bestandstests) — keine Regression
- [x] Adversary-Dialog (2 Runden) mit Mutations-Gegenprobe — VERIFIED
- [x] CI-Ampel (5 Checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)