### PR TITLE
fix(#1726): Ruhezeit, Alarm-Tageszaehler und Vergleichs-Faelligkeit in der Ortszone

### DIFF
--- a/docs/adr/0044-kalendertage-folgen-der-ortszeit.md
+++ b/docs/adr/0044-kalendertage-folgen-der-ortszeit.md
@@ -115,6 +115,19 @@ Regelverstoß — genau das war der Zustand vor #1697.
   die in ADR-0051 beschriebene Stundengleichheits-Falle: Fälligkeit ist jetzt ein Fenster von
   drei Ortsstunden ab der konfigurierten Stunde, gegen Doppelversand abgesichert über den
   Vermerk-Speicher `services/briefing_slots.py` (Schlüssel `(trip_id, ortstag, slot)`).
+- **Ruhezeit, Alarm-Tageszähler und Ortsvergleichs-Slot-Fälligkeit** (#1726, S4 des Epics
+  #1722): `deviation_alert_engine.is_quiet_hours()` und `alert_daily_limit.{load,is_allowed,
+  increment}` bekamen einen **Pflicht**-Parameter `zone` (kein Default — ein impliziter
+  Wien-/UTC-Rückfall wäre genau die behobene Fehlerklasse); beide `VIENNA`-Konstanten sind
+  ersatzlos entfallen. Der Tageszähler führt seither einen Stand **je Zone**
+  (`{"zones": {...}}`, Altbestand wandert beim ersten Zugriff unter `Europe/Vienna`) — der
+  bewusste Preis ist, dass ein Nutzer mit Objekten in drei Zonen das Kontingent dreimal
+  bekommt. `compare_slot_scheduler.presets_due_for_hour` prüft jedes Preset gegen die Zone
+  **seines ersten auflösbaren Orts** statt alle gegen eine gemeinsame Stunde. Die Zone kommt
+  bei Touren aus `anchor_tz`/`trip_local_now`, bei Ortsvergleichen aus dem neuen
+  `utils.timezone.first_resolvable_tz()` — der einen fachlichen Auswahlregel für „erster
+  Ort" (#1378 AC-4), die einen gelöschten oder zonenlosen Ersteintrag überspringt statt
+  still auf Weltzeit zu kippen.
 
 **Lehre für die Pflege dieser Liste:** Sie war nicht falsch, sondern **unvollständig** — und
 eine unvollständige Restliste liest sich wie eine vollständige. Wer hier etwas einträgt,
@@ -135,8 +148,14 @@ Vorfassung dieser Liste binnen Tagen veraltet.
 
 **Bewusst NICHT betroffen** (feste Zone ist dort Absicht, kein Verstoß):
 `forecast_budget._today_utc` und `meteoalarm_budget._today_utc` (Kontingent-Tageswechsel in
-UTC), `alert_daily_limit` und `deviation_alert_engine` (fest `Europe/Vienna`),
-Slot-Stunde im Versand-Orchestrator.
+UTC) sowie der manuelle `?hour=`-Testauslöser des Versand-Orchestrators
+(`CompareDispatchStrategy.MANUAL_TRIGGER_REFERENCE_ZONE`) — ein Ops-/Debug-Werkzeug ohne
+Preset-Bezug, für das „Stunde X" bei preset-eigenen Zonen keine EINE Bedeutung mehr hätte.
+
+Die beiden Alarm-Module, die bis 2026-08-12 an dieser Stelle als bewusste Ausnahme standen
+(Ruhezeit-Engine und Tageszähler, fest `Europe/Vienna`), sind **keine Ausnahme mehr** — sie
+folgen seit #1726 der Ortszone, s. „Umgesetzt" oben. Ebenso die Slot-Stunde des
+Ortsvergleichs, die dort ebenfalls gelistet war.
 
 Vollständige Fundstellen-Karte nach Wirkung sortiert:
 `docs/context/fix-1697-ortstag-statt-servertag.md`.

--- a/docs/context/fix-1726-ruhezeit-ortszone.md
+++ b/docs/context/fix-1726-ruhezeit-ortszone.md
@@ -1,0 +1,209 @@
+# Context: fix-1726-ruhezeit-ortszone
+
+Issue **#1726** (S4 des Epics **#1722**), Label `bug`, `area:trips`, `area:compare`.
+Erhoben 2026-08-12 gegen `origin/main` `bc7dc418` durch drei parallele Kartierungs-Agenten.
+Alle Angaben sind am Code gemessen; wo nicht, steht es ausdrücklich dabei.
+
+## Request Summary
+
+Drei Entscheidungen laufen heute auf der Wiener Uhr, obwohl sie den Nutzer an seinem Ort
+betreffen: das **Ruhezeit-Fenster**, der **Reset des Alarm-Tageszählers** und die
+**Fälligkeit von Ortsvergleichs-Slots**. Sie sollen auf die Ortszone umgestellt werden.
+Beide `VIENNA`-Konstanten entfallen.
+
+## Die drei Fundstellen
+
+| Was | Fundstelle | heutige Uhr |
+|---|---|---|
+| Ruhezeit-Fenster | `src/services/deviation_alert_engine.py:31` (`VIENNA`), wirksam `:112` | `Europe/Vienna` |
+| Alarm-Tageszähler-Reset | `src/services/alert_daily_limit.py:23` (`VIENNA`), wirksam `:32` | `Europe/Vienna` |
+| Ortsvergleichs-Slot-Fälligkeit | `src/services/dispatch_orchestrator.py:128` (`NOCH_NICHT_ORTSZEIT_SIEHE_1726`), wirksam `:141` | `Europe/Vienna` |
+
+Das Issue nennt für die dritte Stelle noch `scheduler_dispatch_service.py:164`; der Code ist
+seit #1724 nach `dispatch_orchestrator.py` umgezogen. Der Aufrufer dort ist
+`run_compare_presets_daily()` (`scheduler_dispatch_service.py:136-183`), der `now_utc` als
+reinen Zeitpunkt liefert — die Umkehrung aus ADR-0051 ist auf der Aufruferseite also bereits
+vollzogen, nur die Strategie rechnet noch in Wien.
+
+## Related Files
+
+### Ruhezeit — sieben Aufrufstellen, alle über einen geteilten Baustein
+
+`DeviationAlertEngine.is_quiet_hours(now, quiet_from, quiet_to, context_label="")`
+(`deviation_alert_engine.py:84-143`) ist statisch und location-generisch. Die Zone ist **nicht**
+parametrisiert.
+
+| # | Aufrufstelle | Dienst | Objekt im Scope | Zone beschaffbar? |
+|---|---|---|---|---|
+| 1 | `compare_official_alert.py:119` | Amtliche Warnung, Vergleich | `preset`, `all_locations`, `location_ids` | ja, über die Orte |
+| 2 | `trip_alert.py:229` | Wetter-Abweichung, Trip | `trip` | ja, `trip_day.py` |
+| 3 | `trip_alert.py:688` | Adapter `_is_quiet_hours(trip, now)` | `trip` | ja |
+| 4 | `trip_alert.py:1443` | Amtliche Warnung, Trip | `trip` | ja |
+| 5 | `alert_gate.py:93` | Nowcast-Schranke, **geteilt Trip+Vergleich** | nur Schlüsselwort-Parameter, **kein Objekt** | nein — Zone muss durchgereicht werden |
+| 6 | `compare_alert.py:176` | Wetter-Abweichung, Vergleich | `preset`, `all_locations`, `config` | ja, über die Orte |
+| 7 | `deviation_alert_engine.py:286` | `evaluate()`, Engine-Kern | nur `config: AlertEvaluationConfig` | nein — Zone müsste ins Konfig-Objekt |
+
+Die beiden Aufrufer von #5 haben ihr Objekt: `trip_alert.py:963` (`trip`) und
+`compare_radar_alert.py:131` (`preset`, `all_locations`).
+
+`AlertEvaluationConfig` (`point_weather.py:54-71`) ist ein reines Datenobjekt, das laut eigenem
+Docstring genau die `trip.*`-Werte bündelt und „ein künftiger Compare-Adapter … aus einem
+`ComparePreset` bauen" würde. Ein Zonen-Feld dort ist der Weg, der die Trip/Compare-Teilung
+wahrt.
+
+### Tageszähler — ein Datensatz je Nutzer, zehn Aufrufstellen
+
+`alert_daily_limit.py`: `load`/`is_allowed`/`increment`, alle mit `(user_id, now, …)`. Datei
+`<get_data_dir(user_id)>/alert_daily_count.json`, Schema exakt:
+
+```json
+{"date": "2026-07-07", "count": 2}
+```
+
+**Kein Diskriminator** — keine Trip-, Preset- oder Zonen-Kennung. Trip- und Vergleichs-Alarme
+teilen denselben Datensatz; das ist kein Nebeneffekt, sondern zugesichert (AC-5 in
+`tests/tdd/test_issue_1070_daily_alert_limit.py`). Schreibweise ist bereits
+Read-Modify-Write über Tempfile + `os.replace()` (`:94-99`).
+
+Aufrufstellen — **elf**: `alert_gate.py:105/:123`, `compare_official_alert.py:138/:182`,
+`trip_alert.py:240/:344/:1449/:1490`, `compare_alert.py:151/:293`, dazu die reine Lesestelle
+`trip_report_scheduler.py:1570`.
+
+⚠️ Diese Zeile stand hier zunächst mit **zehn** Stellen — `compare_alert.py:151`
+(`is_allowed(..., reason="forecast_change")`, im selben Preset-Lauf wie `:293`) ging beim
+Übertragen aus dem Kartierungs-Bericht verloren, obwohl der Bericht sie hatte. Gefunden hat es
+der spec-writer beim Nachmessen. Das ist exakt die Fehlerklasse, die dieses Dokument unter
+Risiko 9 beschreibt und die #1725 zweimal getroffen hat: **eine unvollständige Aufzählung liest
+sich wie eine vollständige.** Wer hier eine Aufrufstellen-Liste verwendet, zählt sie am Code
+nach, statt sie zu glauben.
+
+### Ortsvergleichs-Slots
+
+`CompareDispatchStrategy.collect_due()` (`dispatch_orchestrator.py:130-146`) →
+`presets_due_for_hour(presets, hour, today)` (`compare_slot_scheduler.py:102-156`) prüft
+**Stundengleichheit** (`:152`). Slots sind zwei Preset-Felder (`morning_time`,
+`evening_time`); beide können gleichzeitig fällig sein.
+
+## Existing Patterns
+
+**Das Vorbild steht fertig im Trip-Pfad.** `TripReportSchedulerService._collect_due_trips`
+(`trip_report_scheduler.py:376-438`):
+
+```python
+vor_ort = trip_local_now(trip, now_utc)                              # Zone je Trip
+if not stunde <= vor_ort.hour < stunde + NACHHOL_FENSTER_STUNDEN:    # Fenster = 3 (:91)
+    continue
+if store.is_recorded(trip.id, report_type, vor_ort.date(), zone=vor_ort.tzinfo):
+    continue                                                          # Idempotenz
+```
+
+**Zonen-Auflösung ist vorhanden, es ist nichts zu erfinden:**
+
+| Werkzeug | Zweck | Rückfall |
+|---|---|---|
+| `utils/timezone.resolve_location_tz(location)` | der **einzige** erlaubte Auflöser für Orte (PO-Entscheidung E3, #1378) | `SavedLocation.timezone` → `tz_for_coords(lat, lon)` → `None` |
+| `services/trip_day.trip_local_now(trip, now_utc)` | Ortstag **und** Ortsstunde eines Trips aus **einer** Auflösung | UTC-Konstante bei Trips ohne Wegpunkte |
+| `utils/timezone.local_dt(dt, tz)` | reine Umrechnung; `.astimezone()` ist vom Wächter verboten | — |
+
+**Präzedenzfall für den Mehrzonen-Fall — bereits PO-entschieden:** Die Compare-Mail nimmt für
+ihre Kopfzeile die Zone des **erstgenannten Orts der konfigurierten Reihenfolge**:
+
+```python
+# compare_html.py:1535-1538 — Issue #1378 (AC-4)
+# Kopfzeilen-Zeitbasis = Ortszeit des ERSTGENANNTEN Ortes der konfigurierten
+# Reihenfolge (`location_render_order`, #1359) -- nicht alphabetisch, nicht Serverzeit.
+header_tz = location_tz(locations[0].location) if locations else UTC
+```
+
+Klartext-Pendant `comparison.py:216`. Die Ortsliste `LocationIDs` ist geordnet und stabil
+(`order_locations_by_ids`, #1359). Individuelle Ortsblöcke bleiben in ihrer **eigenen** Zone —
+nur die preset-weite Angabe folgt dem ersten Ort. ⚠️ Der Kommentar bei `comparison.py:201-202`
+behauptet noch alphabetische Sortierung; das ist seit #1359 falsch — der Code gilt, nicht der
+Kommentar.
+
+## Dependencies
+
+- **Upstream:** `utils/timezone`, `services/trip_day`, `services/user_tier.daily_alert_limit`,
+  `app.loader.get_data_dir`, Go-Cron `internal/scheduler/scheduler.go:143` (stündlich)
+- **Downstream:** alle vier proaktiven Alarmwege (Trip-Abweichung, Trip-amtlich, Vergleich-
+  Abweichung, Vergleich-amtlich), beide Nowcast-Wege über `alert_gate`, der Starkregen-Hinweis
+  im Briefing, der Ortsvergleichs-Versand
+
+## Existing Specs
+
+| Spec | Inhalt |
+|---|---|
+| `docs/adr/0051-drei-zeitbegriffe-zone-an-den-daten.md` | **Status „Vorgeschlagen".** Regel 2: „Die Zone gehört an die Daten, nicht an den Server." Stundengleichheit als Fälligkeitsprüfung ist unzulässig. |
+| `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` | Akzeptiert. Listet `alert_daily_limit` und `deviation_alert_engine` heute noch als **„bewusst NICHT betroffen"** — muss fortgeschrieben werden. Verwirft ausdrücklich eine Nutzer-Zeitzonen-Einstellung. |
+| `docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md` | Das Vorbild: Fenster + `BriefingSlotStore`. |
+| `docs/specs/modules/fix_1724_faelligkeit_in_der_ortszone.md` | Vorstufe: Fälligkeit je Trip in seiner Zone. |
+| `docs/specs/modules/issue_1378_compare_zeitbasis.md` | Liefert den „erster Ort"-Präzedenzfall und PO-Entscheidung E3. |
+| `docs/specs/modules/alert_daily_limit.md` | Schreibt den Vienna-Reset heute fest. |
+
+## Risks & Considerations
+
+1. **Der nutzerweite Zähler hat keine Ortszone.** ADR-0051 Regel 2 zeigt auf „die Zone des
+   Gegenstands, über den geredet wird" — der Gegenstand ist hier der Nutzer, und eine
+   Nutzer-Zone ist von ADR-0044 ausdrücklich verworfen. Würde jede Aufrufstelle ihre eigene
+   Zone mitbringen, schriebe derselbe Lauf den `date`-Schlüssel zwischen zwei Kalendertagen
+   hin und her; bei jedem Wechsel setzt `increment()` auf 1 zurück und **das Limit griffe
+   effektiv nie** — es bremst kostenpflichtige Premium-SMS. Produktentscheidung nötig.
+
+2. **Deploy mitten am Tag ändert die Bedeutung von `date` still.** Steht der Zähler auf dem
+   Wiener Datum und liest der neue Code ein abweichendes Ortsdatum, greift
+   `data.get("date") == today` nicht → Reset auf 0 → **Kontingent-Leck** für den Rest des Tages.
+   Braucht dieselbe Rückwärts-Ableitung, die #1725 für den Versand-Vermerk gebaut hat.
+
+3. **Der Ortsvergleich hat keinerlei Idempotenz-Mechanik** — gemessen: `letzter_versand` ist ein
+   reines Anzeigefeld, nirgends als Sperre gelesen. Schutz vor Doppelversand ist heute allein die
+   exakte Stundengleichheit. Wird nur die Zone getauscht, bleibt die Umstellungstag-Lücke stehen
+   (29.03. Slot entfällt, 25.10. Slot doppelt). Wird zusätzlich auf ein Fenster umgestellt,
+   **muss** das Compare-Pendant zu `BriefingSlotStore` mitkommen — sonst stündlicher
+   Serienversand.
+
+4. **Der Go-Cron tickt selbst in Wiener Zeit** (`internal/config/config.go:20`,
+   `SchedulerTimezone` default `Europe/Vienna`) und fällt an Umstellungstagen aus. Das ist
+   S5/#1727, begrenzt aber, was #1726 allein erreichen kann.
+
+5. **Vier Einträge der Wächter-Ausnahmeliste gehören zu dieser Scheibe** und müssen mit dem Fix
+   verschwinden — `test_known_violations_only_shrink()` (`test_output_timezone_guard.py:694`)
+   erzwingt es: `:622`, `:623` (Muster B) und `:630`, `:636` (gekoppelte `raw_astimezone`).
+
+6. **Die Compare-Konstante ist unbewacht.** `NOCH_NICHT_ORTSZEIT_SIEHE_1726` steht **nicht** in
+   der Liste — der AST-Scanner sieht ein String-Literal in einer Klassenvariable nicht als feste
+   Zone. Die am deutlichsten benannte Fundstelle des Issues hat keinen Wächter.
+
+7. **Fehlzuordnung in derselben Liste:** Der Blockkommentar bei `:593` weist alle 53
+   Bestandseinträge #1726 zu, darunter ~25 Muster-A-Fundstellen (`date.today()`), die das Epic
+   ausdrücklich S5/#1727 zuordnet. Wird #1726 geschlossen, verweist die Liste auf ein
+   erledigtes Issue.
+
+8. **Der #1479-AST-Wächter bricht nicht.** `tests/tdd/test_alert_quiet_hours_robustness.py`
+   (AC-11) prüft nur, dass kein eigenes `try/except` um den Aufruf steht, nicht die
+   Argumentliste. Eine Signaturerweiterung ist zulässig. `#1479` selbst bleibt gewahrt:
+   unbrauchbarer Ruhezeit-Wert gilt weiter als „keine Ruhezeit gesetzt".
+
+9. **Der Testbestand nagelt Wien fest, teils im Test selbst falsch.**
+   `tests/helpers/nowcast_gate_fixtures.py` verdrahtet `VIENNA` zentral für mehrere Suiten.
+   `test_issue_883_acute_danger_override.py` AC-5 legt einen Trip auf Island-Koordinaten,
+   baut das Fenster aber über `VIENNA` — der Fehlerfall dieses Issues steckt bereits im Test.
+   Betroffen außerdem: `test_alert_quiet_hours_localtime.py`,
+   `test_alert_quiet_hours_robustness.py` (AC-9), `test_compare_alert_quiet_hours_precedes_fetch.py`,
+   `test_compare_radar_alert.py`, `test_issue_1168_alert_engine_extract.py`,
+   `test_issue_1070_daily_alert_limit.py` (prüft Reset **und** JSON-Schema wörtlich gegen Wien).
+
+10. **Die Oberfläche nennt keine Zone.** `AlertQuietHoursCard.svelte` sagt nur „Stille Stunden";
+    heute wäre die ehrliche Beschriftung „Wiener Zeit". Nach dem Fix wird sie nutzersichtbar zur
+    Ortszeit — Scope ist damit **full-stack**, das Frontend-Browser-Gate greift.
+
+11. **Beide Sommerzeit-Wechseltage sind Pflichtfälle** (ADR-0051), geprüft auf die Häufigkeit
+    *jeder einzelnen Stunde*. Ruhezeit über Mitternacht (Wrap) je einmal östlich und westlich
+    von Wien.
+
+## Nebenbefund (kein Teil dieser Scheibe)
+
+`trip_report_scheduler.py:1570` prüft `alert_daily_limit.is_allowed(..., reason="nowcast")` für
+den Starkregen-Kurzfristhinweis im Briefing, **bucht aber nie** — gemessen: die fünf
+`increment()`-Aufrufe im Produktivcode liegen alle woanders. Vermutlich Absicht (der Hinweis ist
+Teil des Briefings, kein eigener Alarm), aber die Asymmetrie ist nirgends begründet.
+Kandidat für #1199.

--- a/docs/specs/modules/fix_1726_ruhezeit_und_zaehler_ortszone.md
+++ b/docs/specs/modules/fix_1726_ruhezeit_und_zaehler_ortszone.md
@@ -5,7 +5,7 @@ created: 2026-08-12
 updated: 2026-08-12
 status: draft
 workflow: fix-1726-ruhezeit-ortszone
-version: "1.0"
+version: "1.1"
 tags: [issue-1726, epic-1722, timezone, adr-0051, adr-0044, alert-daily-limit, quiet-hours, compare, scheduler]
 ---
 
@@ -31,10 +31,12 @@ Diese Scheibe stellt alle drei auf die Ortszone um. Beide `VIENNA`-Konstanten en
   `src/services/compare_alert.py`, `src/services/compare_official_alert.py`,
   `src/services/compare_radar_alert.py`, `src/services/dispatch_orchestrator.py`,
   `src/services/compare_slot_scheduler.py`, `src/services/scheduler_dispatch_service.py`,
+  `src/utils/timezone.py`,
   `frontend/src/lib/components/alerts-tab/AlertQuietHoursCard.svelte`
 - **Identifier:** `DeviationAlertEngine.is_quiet_hours`, `DeviationAlertEngine.evaluate`,
   `alert_daily_limit.{load,is_allowed,increment}`, `check_nowcast_gate`,
-  `CompareDispatchStrategy.collect_due`, `presets_due_for_hour`
+  `CompareDispatchStrategy.collect_due`, `presets_due_for_hour`,
+  `utils.timezone.first_resolvable_tz` (neu)
 - Issue #1726, S4 des Epics #1722. Kontext-Dokument
   `docs/context/fix-1726-ruhezeit-ortszone.md` (erhoben 2026-08-12 gegen `bc7dc418`).
 - ADR-0051 (drei Zeitbegriffe, Zone an den Daten — Status Vorgeschlagen), ADR-0044 (Kalendertag
@@ -48,10 +50,10 @@ Diese Scheibe stellt alle drei auf die Ortszone um. Beide `VIENNA`-Konstanten en
 |--------|------|---------|
 | `docs/adr/0051-drei-zeitbegriffe-zone-an-den-daten.md` | adr | Regel 2 ("Die Zone gehört an die Daten, nicht an den Server") — Grundlage aller drei Umstellungen |
 | `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` | adr | Listet `alert_daily_limit`/`deviation_alert_engine` heute als „bewusst NICHT betroffen" — wird hier fortgeschrieben (AC-12) |
-| `src/utils/timezone.py` (`resolve_location_tz`, `location_tz`) | module | EINZIGER Auflöser für Orte (PO-Entscheidung E3, #1378) — kein zweiter Weg |
+| `src/utils/timezone.py` (`resolve_location_tz`, `location_tz`, neu `first_resolvable_tz`) | module | EINZIGER Auflöser für Orte (PO-Entscheidung E3, #1378) — kein zweiter Weg; `first_resolvable_tz` präzisiert „erster Ort" auf „erster AUFLÖSBARER Ort" (E1, AC-15, s. Entwurf Abschnitt B) |
 | `src/services/trip_day.py` (`trip_local_now`, `anchor_tz`) | module | EINZIGER Auflöser für Trips, day-aware (nicht `trip_tz`, das ist fix auf die erste Etappe mit Wegpunkten) |
-| `src/services/compare_preview_service.py` (`order_locations_by_ids`) | module | Die vom Nutzer konfigurierte Ortsreihenfolge (#1359) — Basis für „erster Ort" (E1) |
-| `docs/specs/modules/issue_1378_compare_zeitbasis.md` | spec | Liefert den Präzedenzfall „Zone des erstgenannten Orts" (AC-4), hier auf Ruhezeit/Zähler/Fälligkeit übertragen |
+| `src/services/compare_preview_service.py` (`order_locations_by_ids`) | module | Die vom Nutzer konfigurierte Ortsreihenfolge (#1359) — liefert die Sequenz, die `first_resolvable_tz` (s. o.) auswertet |
+| `docs/specs/modules/issue_1378_compare_zeitbasis.md` | spec | Liefert den Präzedenzfall „Zone des erstgenannten Orts" (AC-4), hier auf Ruhezeit/Zähler/Fälligkeit übertragen — dort mit derselben, hier erst geschlossenen Lücke (s. Bekannte Grenzen) |
 | `docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md` | spec | Unmittelbares Vorbild für Struktur und Nachweis-Strategie dieser Spec |
 | Issue #1777 | issue | Fälligkeitsfenster + Idempotenz-Vermerk für den Ortsvergleich — bewusst NICHT Teil dieser Scheibe |
 | Issue #1727 | issue | S5 des Epics — die ~25 Muster-A-Funde (`date.today()`) der Wächter-Restliste |
@@ -64,15 +66,16 @@ Diese Scheibe stellt alle drei auf die Ortszone um. Beide `VIENNA`-Konstanten en
 | File | Change Type | Description |
 |------|-------------|--------------|
 | `src/services/deviation_alert_engine.py` | MODIFY | `VIENNA`-Konstante entfällt; `is_quiet_hours()` bekommt Pflicht-Parameter `zone: ZoneInfo`; `evaluate()` reicht `config.zone` (Rückfall UTC) durch |
+| `src/utils/timezone.py` | MODIFY | Neuer Baustein `first_resolvable_tz(locations, context_label="")` — die EINE Stelle, an der „erster auflösbarer Ort" implementiert ist (Abschnitt B, AC-15) |
 | `src/services/point_weather.py` | MODIFY | `AlertEvaluationConfig` bekommt neues Feld `zone: Optional[ZoneInfo] = None` |
 | `src/services/alert_gate.py` | MODIFY | `check_nowcast_gate()` bekommt Pflicht-Parameter `zone: ZoneInfo`, reicht ihn an `is_quiet_hours()` UND an `alert_daily_limit.is_allowed()`/`record_nowcast_sent()` an `increment()` weiter |
 | `src/services/alert_daily_limit.py` | MODIFY | `VIENNA`-Konstante entfällt; Schema-Wechsel auf zonenweise Zähler (`{"zones": {...}}`); `load`/`is_allowed`/`increment` bekommen Pflicht-Parameter `zone: ZoneInfo`; Rückwärts-Migration für Altbestand |
 | `src/services/trip_alert.py` | MODIFY | Sieben Stellen (Ruhezeit-Adapter `:672-691`, drei Aufrufer, `check_nowcast_gate`-Aufruf `:963`, vier `alert_daily_limit`-Aufrufe, `AlertEvaluationConfig`-Konstruktion `:265`) reichen `anchor_tz(trip, now)`/`trip_local_now(...).tzinfo` durch |
-| `src/services/compare_official_alert.py` | MODIFY | `:119` (is_quiet_hours) und `:138`/`:182` (alert_daily_limit) bekommen die Zone des ERSTEN Orts (`location_ids[0]`) |
-| `src/services/compare_alert.py` | MODIFY | `:151` (is_allowed — s. Korrektur unten), `:176` (is_quiet_hours über `AlertEvaluationConfig.zone`), `:293` (increment), `_build_eval_config()` (`:452-478`) bekommen die Zone des ersten Orts |
-| `src/services/compare_radar_alert.py` | MODIFY | `:131` (`check_nowcast_gate`-Aufruf) bekommt die Zone des ersten Orts |
+| `src/services/compare_official_alert.py` | MODIFY | `:119` (is_quiet_hours) und `:138`/`:182` (alert_daily_limit) bekommen die Zone aus `first_resolvable_tz(...)` (`utils/timezone.py`) |
+| `src/services/compare_alert.py` | MODIFY | `:151` (is_allowed — s. Korrektur unten), `:176` (is_quiet_hours über `AlertEvaluationConfig.zone`), `:293` (increment), `_build_eval_config()` (`:452-478`) bekommen die Zone aus `first_resolvable_tz(...)` |
+| `src/services/compare_radar_alert.py` | MODIFY | `:131` (`check_nowcast_gate`-Aufruf) bekommt die Zone aus `first_resolvable_tz(...)` |
 | `src/services/dispatch_orchestrator.py` | MODIFY | `CompareDispatchStrategy.collect_due()` lädt `all_locations` vorab und übergibt sie an `presets_due_for_hour`; `NOCH_NICHT_ORTSZEIT_SIEHE_1726` entfällt als Fälligkeits-Zone |
-| `src/services/compare_slot_scheduler.py` | MODIFY | `presets_due_for_hour(presets, hour, today)` → `presets_due_for_hour(presets, all_locations, now_utc)`, löst je Preset seine eigene Zone auf (s. Entwurf, Abschnitt D) |
+| `src/services/compare_slot_scheduler.py` | MODIFY | `presets_due_for_hour(presets, hour, today)` → `presets_due_for_hour(presets, all_locations, now_utc)`, löst je Preset über `first_resolvable_tz(...)` seine eigene Zone auf (s. Entwurf, Abschnitt D) |
 | `src/services/scheduler_dispatch_service.py` | MODIFY | Kommentar/Konstantenname am manuellen `?hour=`-Trigger angepasst (Verhalten unverändert, s. Entwurf Abschnitt D) |
 | `frontend/.../alerts-tab/AlertQuietHoursCard.svelte` | MODIFY | Neue Prop für die Zonen-Bezeichnung im Hinweistext |
 | `frontend/.../shared/AlarmeTab.svelte` | MODIFY | Beide Mount-Punkte (`:429`/`:431`) übergeben die neue Prop kontextabhängig |
@@ -96,9 +99,9 @@ alle Aufrufer von `presets_due_for_hour`: `tests/test_compare_auto_pause_end_dat
 
 ### Estimated Changes
 
-- Files: 12 Produktivdateien (10 Python, 2 Svelte) + 1 ADR + 1 Wächter-Datei + 1 neue Testdatei
+- Files: 13 Produktivdateien (11 Python, 2 Svelte) + 1 ADR + 1 Wächter-Datei + 1 neue Testdatei
   + ~13 bestehende Testdateien mit mechanischer Signatur-Folgeänderung
-- LoC: siehe „Estimated Scope" unten (~220 Produktivcode)
+- LoC: siehe „Estimated Scope" unten (~235 Produktivcode)
 
 ## Problem/Kontext
 
@@ -131,8 +134,10 @@ Kopie (ADR-0044, "Lehre für die Pflege dieser Liste").
 
 Für Mehrzonen-Fälle (ein Ortsvergleich mit Orten in verschiedenen Zonen) gilt EINHEITLICH die
 bereits PO-entschiedene Regel aus #1378 (AC-4): die Zone des **erstgenannten Orts der
-konfigurierten Reihenfolge** (`order_locations_by_ids`, #1359). Kein neues Datenfeld, keine
-zweite Regel für einen anderen Anwendungsfall derselben Frage.
+konfigurierten Reihenfolge** (`order_locations_by_ids`, #1359), präzisiert als „erster Ort,
+dessen Zone sich auflösen lässt" — umgesetzt in `utils.timezone.first_resolvable_tz` (s. Entwurf
+Abschnitt B, AC-15). Kein neues Datenfeld, keine zweite Regel für einen anderen Anwendungsfall
+derselben Frage.
 
 ## Abgrenzung
 
@@ -170,12 +175,12 @@ Jede der sieben Aufrufstellen liefert ihre Zone aus dem Objekt, das sie ohnehin 
 
 | # | Aufrufstelle | Zone-Quelle | Code-Änderung nötig an |
 |---|---|---|---|
-| 1 | `compare_official_alert.py:119` (amtliche Warnung, Vergleich) | erster Ort aus `location_ids`/`all_locations` | dieser Zeile |
+| 1 | `compare_official_alert.py:119` (amtliche Warnung, Vergleich) | `first_resolvable_tz(...)` (`utils/timezone.py`) | dieser Zeile |
 | 2 | `trip_alert.py:229` (Adapter-Aufruf, Wetter-Abweichung Trip) | Trip | keine — Zone entsteht im Adapter |
 | 3 | `trip_alert.py:688` (`_is_quiet_hours`-Adapter, tatsächlicher `is_quiet_hours`-Aufruf) | `anchor_tz(trip, now)` | dieser Zeile — EINZIGE Codeänderung für #2 UND #4 |
 | 4 | `trip_alert.py:1443` (Adapter-Aufruf, amtliche Warnung Trip) | Trip | keine — teilt sich den Adapter mit #2 |
-| 5 | `alert_gate.py:93` (Nowcast-Schranke, geteilt Trip+Vergleich) | **kein Objekt im Scope** — Zone als Parameter durchgereicht von den zwei Aufrufern (`trip_alert.py:963`: `anchor_tz(trip, now_utc)`; `compare_radar_alert.py:131`: erster Ort) | `check_nowcast_gate()`-Signatur + beide Aufrufer |
-| 6 | `compare_alert.py:176` (Wetter-Abweichung, Vergleich) | `config.zone`, gesetzt in `_build_eval_config()` (`:452-478`) aus dem ersten Ort | `AlertEvaluationConfig`-Konstruktion, nicht die Aufrufzeile selbst |
+| 5 | `alert_gate.py:93` (Nowcast-Schranke, geteilt Trip+Vergleich) | **kein Objekt im Scope** — Zone als Parameter durchgereicht von den zwei Aufrufern (`trip_alert.py:963`: `anchor_tz(trip, now_utc)`; `compare_radar_alert.py:131`: `first_resolvable_tz(...)`) | `check_nowcast_gate()`-Signatur + beide Aufrufer |
+| 6 | `compare_alert.py:176` (Wetter-Abweichung, Vergleich) | `config.zone`, gesetzt in `_build_eval_config()` (`:452-478`) aus `first_resolvable_tz(...)` | `AlertEvaluationConfig`-Konstruktion, nicht die Aufrufzeile selbst |
 | 7 | `deviation_alert_engine.py:286` (`evaluate()`, Engine-Kern) | `config.zone` (Rückfall UTC bei `None`, sichtbar dokumentiert) | dieser Zeile |
 
 Zwei und vier bzw. drei sind bewusst als GETRENNTE Zeilen der Tabelle aufgeführt, obwohl sie
@@ -190,7 +195,7 @@ bewies in #1697 dreimal in Folge nichts über den jeweiligen Aufrufer (ADR-0051,
 |---|---|---|
 | `services.trip_day.anchor_tz(trip, now_utc)` bzw. `trip_local_now(trip, now_utc).tzinfo` | Zone eines Trips, **tagesbewusst** (Etappe des Weltzeit-Tages) — dieselbe Auflösung, die #1724/#1725 für die Briefing-Fälligkeit benutzen, NICHT `trip_tz()` (das ist fix auf die erste Etappe mit Wegpunkten und tagesUNabhängig) | importierte `UTC`-Konstante bei Trips ohne Wegpunkte |
 | `utils.timezone.location_tz(location)` | Zone eines Orts, MIT UTC-Rückfall (identisch zu `compare_html.py:1537`, derselbe Aufruf für die Compare-Kopfzeile) | `UTC`, sichtbar über dieselbe Konvention wie die Mail-Kopfzeile |
-| `services.compare_preview_service.order_locations_by_ids(locations, location_ids)[0]` bzw. direkt `all_locations.get(location_ids[0])` | „erster Ort der konfigurierten Reihenfolge" (E1) | — |
+| `utils.timezone.first_resolvable_tz(locations, context_label="")` (NEU) | Zone des ERSTEN Orts EINER SEQUENZ, dessen Zone sich auflösen lässt — Ersatz für den naiven Indexzugriff `location_ids[0]` | `UTC`, protokolliert (s. u.) |
 
 **Warum `location_tz()` (UTC-Rückfall) statt `resolve_location_tz()` (`None`-Rückfall):**
 Ruhezeit-/Zähler-/Fälligkeits-Logik brauchen eine KONKRETE Zone, kein `None` — dieselbe
@@ -219,6 +224,40 @@ obwohl der zweite Ort der Liste eine gültige Zone trägt. Deshalb gilt:
 Das ist keine Abweichung von PO-Entscheidung E1, sondern ihre präzise Fassung: „erster Ort" war
 als fachliche Auswahl gemeint, nicht als `[0]`. Nachweis: AC-15.
 
+**Diese Regel bekommt EINEN benannten Baustein, keine fünf Kopien.** Die Auswahl wird an
+mindestens fünf Compare-Stellen gebraucht (`compare_alert.py:151`/`:176`/`:293`,
+`compare_official_alert.py:119`/`:138`/`:182`, `compare_radar_alert.py:131`, dazu
+`presets_due_for_hour`). Würde jede ihre eigene Überspring-Schleife bauen, entstünde genau die
+„eigene Kopie der Zonen-Auflösung", die ADR-0044 als Regelverstoß benennt — und diese Spec
+fordert an drei Stellen selbst „EINZIGER Auflöser, keine zweite Kopie". Neu in
+`src/utils/timezone.py`:
+
+```python
+def first_resolvable_tz(locations: Iterable, context_label: str = "") -> ZoneInfo:
+    """Zone des ersten Orts der Reihenfolge, dessen Zone sich auflösen lässt.
+
+    Überspringt `None` (gelöschter Ort, ID zeigt ins Leere) und Orte ohne
+    auflösbare Zone. Liefert kein Ergebnis einen Treffer, ist der Rückfall UTC
+    — dann aber mit `logger.warning` samt `context_label`, nicht still.
+    """
+```
+
+**Warum `utils/timezone.py` und nicht `compare_preview_service.py`** (wo
+`order_locations_by_ids` wohnt): Dort liegen `resolve_location_tz` und `location_tz`, also die
+Auflösungs-Domäne selbst — der Baustein ist eine Anwendung dieser Auflösung, kein
+Compare-Ablauf. Die Signatur nimmt bewusst eine **fertige Sequenz** statt `(location_ids,
+all_locations)`, damit sie kein Compare-Vokabular kennt und vom Trip-Pfad aus nutzbar bleibt.
+Die Aufrufer bauen die Sequenz in einer Zeile:
+
+```python
+tz = first_resolvable_tz(
+    (all_locations.get(lid) for lid in location_ids), context_label=preset_id
+)
+```
+
+`context_label` folgt dem Muster, das `is_quiet_hours` seit #1479 für protokollierbare Herkunft
+verwendet.
+
 **Warum `anchor_tz`/`trip_local_now` statt `trip_tz()` für Trips:** `trip_tz()` beantwortet nur
 „welcher Kalendertag ist gerade" (fix auf die erste Etappe mit Wegpunkten). Ruhezeit und Zähler
 werden dagegen fortlaufend geprüft, während der Trip läuft — ein mehrtägiger Trek, der die Zone
@@ -227,7 +266,7 @@ liefert genau das aus EINER Auflösung (Ortstag UND -stunde), konsistent mit #17
 
 ### C. Tageszähler — Schema, Migration, korrigierte Aufrufstellen-Liste
 
-**🔴 Korrektur der im Kontext-Dokument gezählten Aufrufstellen:** Das Kontext-Dokument nennt
+**🔴 Korrektur der im Kontext-Dokument gezählten Aufrufstellen:** Das Kontext-Dokument nennte
 „zehn Aufrufstellen". Nachgemessen (`grep -n 'alert_daily_limit\.\(is_allowed\|increment\|load\)'`
 über `src/`) sind es **elf** — `compare_alert.py:151` (`is_allowed(..., reason="forecast_change")`,
 im selben Preset-Loop wie die bereits gelistete `:293`) fehlte in der Aufzählung. Genau diese
@@ -248,7 +287,8 @@ Nebenbefund, unverändert).
 
 Zonen-Schlüssel = `str(zone)` (IANA-Name, z. B. `"Europe/Vienna"`; UTC-Rückfall unter dem
 Schlüssel `"UTC"`). `load`/`is_allowed`/`increment` bekommen einen Pflicht-Parameter
-`zone: ZoneInfo` (kein Default — dieselbe Begründung wie bei `is_quiet_hours`).
+`zone: ZoneInfo` (kein Default — dieselbe Begründung wie bei `is_quiet_hours`). Die Zone für
+Compare-Aufrufstellen kommt einheitlich aus `first_resolvable_tz(...)` (Abschnitt B).
 
 **Migration/Bestandserhalt (Projektregel: Read-Modify-Write mit Merge, niemals Replace):** Trifft
 `load`/`increment` beim ersten Zugriff auf das ALTE Schema (Top-Level-Schlüssel `"date"`/`"count"`,
@@ -265,15 +305,16 @@ Zonen-Ebene, nicht nur auf Datei-Ebene).
 `CompareDispatchStrategy.collect_due()` bildet heute EINEN `vor_ort`-Zeitpunkt für den GESAMTEN
 Lauf und übergibt `presets_due_for_hour(presets, vor_ort.hour, vor_ort.date())` — alle Presets
 eines Laufs werden gegen DIESELBE Stunde/denselben Tag geprüft. Unter E1 hat aber JEDES Preset
-potenziell eine ANDERE Zone (sein eigener erster Ort) — ein einzelner globaler `vor_ort`-Wert
-kann das nicht mehr abbilden. Reines Konstanten-Tauschen reicht hier NICHT.
+potenziell eine ANDERE Zone (die seines ersten auflösbaren Orts) — ein einzelner globaler
+`vor_ort`-Wert kann das nicht mehr abbilden. Reines Konstanten-Tauschen reicht hier NICHT.
 
 **Umbau:** `presets_due_for_hour(presets, hour, today)` wird zu
-`presets_due_for_hour(presets, all_locations, now_utc)`. Intern wird je Preset die Zone seines
-ersten Orts aufgelöst, `vor_ort = local_dt(now_utc, zone)` gebildet, und die BISHERIGE
-Stundengleichheits-Prüfung (`slots.morning_time.hour == vor_ort.hour` usw.) läuft unverändert
-gegen dieses preset-eigene `vor_ort`. `collect_due()` lädt `all_locations` dafür vor dem Aufruf
-(bisher nur lazy in `dispatch_one()`, `:168-169`).
+`presets_due_for_hour(presets, all_locations, now_utc)`. Intern wird je Preset über
+`first_resolvable_tz((all_locations.get(lid) for lid in preset.get("location_ids") or []),
+context_label=preset_id)` die Zone aufgelöst, `vor_ort = local_dt(now_utc, zone)` gebildet, und
+die BISHERIGE Stundengleichheits-Prüfung (`slots.morning_time.hour == vor_ort.hour` usw.) läuft
+unverändert gegen dieses preset-eigene `vor_ort`. `collect_due()` lädt `all_locations` dafür vor
+dem Aufruf (bisher nur lazy in `dispatch_one()`, `:168-169`).
 
 **Der manuelle `?hour=`-Testtrigger** (`scheduler_dispatch_service.py:170-181`, Endpunkt für
 manuell ausgelöste Testläufe) konstruiert heute einen `now_utc`, dessen Stunde in
@@ -331,6 +372,20 @@ Issue zeigen (AC-14).
   War nie die tatsächliche Regel (der Kommentar bei `comparison.py:201-202` behauptet das noch,
   ist seit #1359 falsch) — die konfigurierte Reihenfolge (`location_ids`) gilt, nicht eine vom
   System erzeugte Sortierung.
+- **„Erster Ort" als reiner Indexzugriff `location_ids[0]`.** Erwogen als einfachste Umsetzung,
+  aber verworfen: ein gelöschter oder unauflösbarer erster Ort führte zu einem stillen
+  UTC-Rückfall, obwohl ein späterer Ort der Liste eine gültige Zone hätte — genau die
+  Fehlerklasse, die diese Scheibe beseitigt, nur mit einem anderen falschen Ergebnis (UTC statt
+  Wien). Ersetzt durch `first_resolvable_tz()` (Abschnitt B, AC-15).
+- **`first_resolvable_tz()` in `compare_preview_service.py` ansiedeln** (neben
+  `order_locations_by_ids`, mit Compare-Vokabular `location_ids`/`all_locations` als Parameter).
+  Erwogen wegen der thematischen Nähe zu `order_locations_by_ids` — verworfen, weil die Funktion
+  selbst kein Compare-Wissen braucht: sie wertet eine FERTIGE Sequenz von Orten aus, kein Preset.
+  Mit einer generischen Sequenz-Signatur bleibt sie stattdessen in `utils/timezone.py`, wo bereits
+  `resolve_location_tz`/`location_tz` wohnen — die eigentliche Auflösungs-Domäne — und bliebe vom
+  Trip-Pfad aus nutzbar, falls dort je ein Mehrzonen-Fall entstünde (heute nicht der Fall, aber
+  keine Weichenstellung dagegen). Die Compare-Aufrufer bauen die Sequenz selbst in einer Zeile
+  (Abschnitt B).
 - **Fälligkeitsfenster + Idempotenz auch für den Ortsvergleich, in derselben Scheibe wie der
   Zonentausch.** Erwogen, aber PO-Entscheidung E3 (2026-08-12): getrennt, weil die
   Fälligkeitsfrage und die Zonenfrage unabhängig beantwortbar sind und die Zusammenlegung die
@@ -450,7 +505,8 @@ Issue zeigen (AC-14).
   Ruhezeit, Tageszähler oder Slot-Fälligkeit für diesen Vergleich bestimmt werden / Then gilt die
   Zone des ersten Orts, der sich AUFLÖSEN LÄSST — nicht Weltzeit. Nur wenn kein einziger Ort eine
   Zone liefert, gilt UTC, und dieser Fall wird im Protokoll mit der Vergleichs-Kennung sichtbar
-  gemacht, statt still zu geschehen.
+  gemacht, statt still zu geschehen. Wirkt in `utils.timezone.first_resolvable_tz()` (Abschnitt
+  B), genutzt von allen Compare-Aufrufstellen dieser Scheibe (Abschnitte A, C, D).
 
 ## Nachweis-Strategie
 
@@ -469,7 +525,7 @@ Scheibe verwenden deshalb `Pacific/Auckland` (östlich) und `America/Los_Angeles
 | AC-1 | Auckland-Trip, Ruhezeit-Wrap, Alarm bei Weltzeit, die in Auckland Nacht/in Wien Tag ist → unterdrückt | `zone`-Parameter ignorieren, weiter fest `VIENNA` verwenden |
 | AC-2 | LA-Trip, spiegelbildlich → unterdrückt | dito |
 | AC-3 | Sieben Einzeltests, je EINE der sieben Stellen mit einer Nicht-Wien-Zone | eine der sieben Stellen den `zone`-Parameter NICHT durchreichen lassen — nur die anderen sechs Tests bleiben grün |
-| AC-4 | Zwei Orte, zwei Zonen, Ruhezeit trifft nur bei Zone von `location_ids[0]`; Reihenfolge tauschen → Ruhezeit-Ergebnis kippt mit | `location_ids[0]` durch eine feste/alphabetische Auswahl ersetzen |
+| AC-4 | Zwei Orte, zwei Zonen, beide auflösbar, Ruhezeit trifft nur bei Zone von `location_ids[0]`; Reihenfolge tauschen → Ruhezeit-Ergebnis kippt mit | `location_ids[0]` durch eine feste/alphabetische Auswahl ersetzen |
 | AC-5 | `"25:00"`/`"abc"`/`None`-Ruhezeitwert mit gesetztem `zone`-Parameter → weiterhin `False`, kein Traceback | `try/except` um den neuen Parameter entfernen |
 | AC-6 | Zähler-Reset exakt an Orts-Mitternacht, Auckland UND LA, je knapp davor/danach geprüft | Reset weiterhin gegen `_vienna_date_str` statt zonenspezifisch |
 | AC-7 | Zwei Zonen, beide am Limit, unabhängige Zähler | ein gemeinsamer Schlüssel ohne Zonen-Diskriminator |
@@ -480,26 +536,27 @@ Scheibe verwenden deshalb `Pacific/Auckland` (östlich) und `America/Los_Angeles
 | AC-12 | Dateiinhalt-Prüfung (`# doc-compliance-test`): ADR-0044 nennt `alert_daily_limit`/`deviation_alert_engine` nicht mehr unter „Bewusst NICHT betroffen" | ADR unverändert lassen |
 | AC-13 | `test_known_violations_only_shrink()` bleibt grün nach Entfernen der vier Einträge | einen der vier Einträge stehen lassen |
 | AC-14 | Dateiinhalt-Prüfung: Kommentar bei `:593` referenziert die Muster-A-Restliste korrekt auf #1727 | Kommentar unverändert lassen |
-| AC-15 | Vergleich mit gelöschtem erstem Ort + gültigem zweitem Ort in Nicht-UTC-Zone → Ruhezeit folgt dem zweiten Ort; separater Fall „kein Ort auflösbar" → UTC UND Protokolleintrag | `location_ids[0]` als reinen Indexzugriff belassen (fällt still auf UTC) |
+| AC-15 | Vergleich mit gelöschtem erstem Ort + gültigem zweitem Ort in Nicht-UTC-Zone → Ruhezeit folgt dem zweiten Ort; separater Fall „kein Ort auflösbar" → UTC UND Protokolleintrag | `first_resolvable_tz`s Skip-Schleife durch direkten `location_ids[0]`-Zugriff ersetzen (fällt still auf UTC) |
 
 **Mutations-Gegenprobe (Pflicht):** mindestens gegenzuprüfen — `zone`-Parameter an einer der
 sieben Ruhezeit-Stellen stillschweigend ignorieren, Zähler-Migration durch Replace ersetzen,
-`location_ids[0]` durch eine andere Ortsauswahl ersetzen, `presets_due_for_hour` mit einem
-globalen statt preset-eigenen `vor_ort` belassen.
+`first_resolvable_tz`s Skip-Schleife durch direkten Index-0-Zugriff ersetzen,
+`presets_due_for_hour` mit einem globalen statt preset-eigenen `vor_ort` belassen.
 
 ## Estimated Scope
 
-- **LoC:** ~220 Produktivcode über 10 Python- + 2 Svelte-Dateien (grösste Einzelposten:
+- **LoC:** ~235 Produktivcode über 11 Python- + 2 Svelte-Dateien (grösste Einzelposten:
   `alert_daily_limit.py` ~60 wegen Schema-Migration, `trip_alert.py` ~25 wegen sieben
   Aufrufstellen, `compare_slot_scheduler.py`/`dispatch_orchestrator.py` zusammen ~45 wegen der
-  Restrukturierung von `presets_due_for_hour`); Testcode und die Wächter-Listen-Korrektur zählen
-  nicht gegen das Limit.
-- **Files:** 12 Produktivdateien, 1 ADR, 1 Wächter-Datei, 1 neue Testdatei, ~13 bestehende
+  Restrukturierung von `presets_due_for_hour`, `utils/timezone.py` ~15 für
+  `first_resolvable_tz`); Testcode und die Wächter-Listen-Korrektur zählen nicht gegen das
+  Limit.
+- **Files:** 13 Produktivdateien, 1 ADR, 1 Wächter-Datei, 1 neue Testdatei, ~13 bestehende
   Testdateien mit mechanischer Signatur-Folgeänderung.
 - **Effort:** high — nicht wegen algorithmischer Komplexität, sondern wegen der Anzahl
   unabhängig nachzuweisender Aufrufstellen (7 Ruhezeit + 11 Zähler + 1 Fälligkeits-Restrukturierung)
   und der Pflicht-Enumeration aus #1725s Lehre.
-- **Limit-Reserve:** ~220/250 ist knapp. 🔴 **Die naheliegende Ausweichoption ist keine.** Die
+- **Limit-Reserve:** ~235/250 ist knapp. 🔴 **Die naheliegende Ausweichoption ist keine.** Die
   Restrukturierung von `presets_due_for_hour`/`dispatch_orchestrator.py` (Abschnitt D, ~45 LoC)
   ist zwar technisch die am ehesten separierbare Einheit, aber sie herauszuschneiden hiesse: die
   **Ortsvergleichs-Slot-Fälligkeit bliebe vollständig auf Wien**. Das ist eine der DREI im Issue
@@ -529,9 +586,11 @@ globalen statt preset-eigenen `vor_ort` belassen.
   Umstellungstagen weiterhin aus/verdoppelt — unabhängig von dieser Scheibe, s. Abgrenzung.
 - **Dieselbe Präzisierung fehlt der Compare-Mail-Kopfzeile.** `compare_html.py:1535-1538` und
   `comparison.py:216` greifen mit `locations[0]` zu und fallen bei einem unauflösbaren ersten Ort
-  ebenso still auf UTC — der Präzedenzfall, dem AC-15 folgt, trägt den Mangel selbst. Hier
-  bewusst NICHT mitrepariert (die Kopfzeile ist Darstellung, nicht Entscheidung, und ein
-  UTC-Zeitstempel dort ist sichtbar falsch statt still wirksam). Zu buchen als eigener Eintrag.
+  ebenso still auf UTC — der Präzedenzfall, dem AC-15 folgt, trägt den Mangel selbst. Der
+  „gelöschte ID"-Fall tritt dort nicht auf (`result.locations` enthält nur bereits verarbeitete
+  Orte), der „unauflösbare Zone"-Fall aber schon. Hier bewusst NICHT mitrepariert (die Kopfzeile
+  ist Darstellung, nicht Alarm-Entscheidung, und ein UTC-Zeitstempel dort ist sichtbar falsch
+  statt still wirksam). Zu buchen als eigener Eintrag für den Team-Lead.
 - **Die Oberfläche nennt einen Referenzpunkt, keinen konkreten Zonennamen.** „Ortszeit der Tour"/
   „Ortszeit des ersten Orts" sagt WOVON die Zeit abhängt, nicht WELCHE IANA-Zone konkret gilt
   (z. B. „Europe/Paris"). Eine genauere Beschriftung wäre möglich, ist aber nicht Teil dieser
@@ -559,3 +618,13 @@ globalen statt preset-eigenen `vor_ort` belassen.
   Basis der Vorlage `fix_1725_faelligkeit_und_idempotenz.md`. Korrektur gegenüber dem
   Kontext-Dokument: die Zähler-Aufrufstellen sind ELF, nicht zehn (`compare_alert.py:151` ergänzt,
   s. Entwurf Abschnitt C).
+- 1.1 (2026-08-12): Nachtrag NACH PO-Freigabe (ACs unverändert im Wortlaut, Nummerierung,
+  Reihenfolge — nur Verortung der in AC-15 zugesicherten Regel präzisiert). Neue Funktion
+  `first_resolvable_tz()` in `utils/timezone.py` benannt (Abschnitt B, mit Skip-Logik über
+  gelöschte/unauflösbare Orte + protokolliertem UTC-Rückfall); Platzierung gegen
+  `compare_preview_service.py` abgewogen und begründet (generische Sequenz-Signatur statt
+  Compare-Vokabular, Nähe zu `resolve_location_tz`/`location_tz`, Abschnitt B + Verworfene
+  Alternativen). Dependencies, Affected-Files-Tabelle, Abschnitte A/C/D sowie
+  Nachweis-Strategie/Mutations-Gegenprobe auf `first_resolvable_tz(...)` umgestellt statt
+  `location_ids[0]`/„erster Ort". Estimated Changes/Scope auf ~235 LoC / 13 Produktivdateien
+  angehoben (inkl. `utils/timezone.py` ~15 LoC).

--- a/docs/specs/modules/fix_1726_ruhezeit_und_zaehler_ortszone.md
+++ b/docs/specs/modules/fix_1726_ruhezeit_und_zaehler_ortszone.md
@@ -1,0 +1,561 @@
+---
+entity_id: fix_1726_ruhezeit_und_zaehler_ortszone
+type: bugfix
+created: 2026-08-12
+updated: 2026-08-12
+status: draft
+workflow: fix-1726-ruhezeit-ortszone
+version: "1.0"
+tags: [issue-1726, epic-1722, timezone, adr-0051, adr-0044, alert-daily-limit, quiet-hours, compare, scheduler]
+---
+
+# Fix #1726 — Ruhezeit, Alarm-Tageszähler und Ortsvergleichs-Fälligkeit in der Ortszone
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Drei Entscheidungen laufen heute unabhängig von Trip oder Ort immer auf der Wiener Uhr, obwohl
+sie den Nutzer an SEINEM Ort betreffen: das **Ruhezeit-Fenster** für Alarme
+(`deviation_alert_engine.py:31`, Konstante `VIENNA`), der **Reset des Alarm-Tageszählers**
+(`alert_daily_limit.py:23`, dieselbe Konstante) und die **Fälligkeits-Zone des
+Ortsvergleichs-Versands** (`dispatch_orchestrator.py:128`, `NOCH_NICHT_ORTSZEIT_SIEHE_1726`).
+Diese Scheibe stellt alle drei auf die Ortszone um. Beide `VIENNA`-Konstanten entfallen ersatzlos.
+
+## Source
+
+- **Files:** `src/services/deviation_alert_engine.py`, `src/services/alert_daily_limit.py`,
+  `src/services/alert_gate.py`, `src/services/point_weather.py`, `src/services/trip_alert.py`,
+  `src/services/compare_alert.py`, `src/services/compare_official_alert.py`,
+  `src/services/compare_radar_alert.py`, `src/services/dispatch_orchestrator.py`,
+  `src/services/compare_slot_scheduler.py`, `src/services/scheduler_dispatch_service.py`,
+  `frontend/src/lib/components/alerts-tab/AlertQuietHoursCard.svelte`
+- **Identifier:** `DeviationAlertEngine.is_quiet_hours`, `DeviationAlertEngine.evaluate`,
+  `alert_daily_limit.{load,is_allowed,increment}`, `check_nowcast_gate`,
+  `CompareDispatchStrategy.collect_due`, `presets_due_for_hour`
+- Issue #1726, S4 des Epics #1722. Kontext-Dokument
+  `docs/context/fix-1726-ruhezeit-ortszone.md` (erhoben 2026-08-12 gegen `bc7dc418`).
+- ADR-0051 (drei Zeitbegriffe, Zone an den Daten — Status Vorgeschlagen), ADR-0044 (Kalendertag
+  folgt der Ortszeit — Status Akzeptiert, wird hier fortgeschrieben)
+- Setzt voraus: #1724 (S2, live), #1725 (S3, live `414b0b87`) — beide liefern das Vorbild für
+  die Zonen-Auflösung von Trips (`trip_local_now`/`anchor_tz`)
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `docs/adr/0051-drei-zeitbegriffe-zone-an-den-daten.md` | adr | Regel 2 ("Die Zone gehört an die Daten, nicht an den Server") — Grundlage aller drei Umstellungen |
+| `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` | adr | Listet `alert_daily_limit`/`deviation_alert_engine` heute als „bewusst NICHT betroffen" — wird hier fortgeschrieben (AC-12) |
+| `src/utils/timezone.py` (`resolve_location_tz`, `location_tz`) | module | EINZIGER Auflöser für Orte (PO-Entscheidung E3, #1378) — kein zweiter Weg |
+| `src/services/trip_day.py` (`trip_local_now`, `anchor_tz`) | module | EINZIGER Auflöser für Trips, day-aware (nicht `trip_tz`, das ist fix auf die erste Etappe mit Wegpunkten) |
+| `src/services/compare_preview_service.py` (`order_locations_by_ids`) | module | Die vom Nutzer konfigurierte Ortsreihenfolge (#1359) — Basis für „erster Ort" (E1) |
+| `docs/specs/modules/issue_1378_compare_zeitbasis.md` | spec | Liefert den Präzedenzfall „Zone des erstgenannten Orts" (AC-4), hier auf Ruhezeit/Zähler/Fälligkeit übertragen |
+| `docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md` | spec | Unmittelbares Vorbild für Struktur und Nachweis-Strategie dieser Spec |
+| Issue #1777 | issue | Fälligkeitsfenster + Idempotenz-Vermerk für den Ortsvergleich — bewusst NICHT Teil dieser Scheibe |
+| Issue #1727 | issue | S5 des Epics — die ~25 Muster-A-Funde (`date.today()`) der Wächter-Restliste |
+| `internal/config/config.go:20` (`SchedulerTimezone`) | go | Der Go-Cron tickt weiterhin in `Europe/Vienna` — unverändert, s. Abgrenzung |
+
+## Scope
+
+### Affected Files
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `src/services/deviation_alert_engine.py` | MODIFY | `VIENNA`-Konstante entfällt; `is_quiet_hours()` bekommt Pflicht-Parameter `zone: ZoneInfo`; `evaluate()` reicht `config.zone` (Rückfall UTC) durch |
+| `src/services/point_weather.py` | MODIFY | `AlertEvaluationConfig` bekommt neues Feld `zone: Optional[ZoneInfo] = None` |
+| `src/services/alert_gate.py` | MODIFY | `check_nowcast_gate()` bekommt Pflicht-Parameter `zone: ZoneInfo`, reicht ihn an `is_quiet_hours()` UND an `alert_daily_limit.is_allowed()`/`record_nowcast_sent()` an `increment()` weiter |
+| `src/services/alert_daily_limit.py` | MODIFY | `VIENNA`-Konstante entfällt; Schema-Wechsel auf zonenweise Zähler (`{"zones": {...}}`); `load`/`is_allowed`/`increment` bekommen Pflicht-Parameter `zone: ZoneInfo`; Rückwärts-Migration für Altbestand |
+| `src/services/trip_alert.py` | MODIFY | Sieben Stellen (Ruhezeit-Adapter `:672-691`, drei Aufrufer, `check_nowcast_gate`-Aufruf `:963`, vier `alert_daily_limit`-Aufrufe, `AlertEvaluationConfig`-Konstruktion `:265`) reichen `anchor_tz(trip, now)`/`trip_local_now(...).tzinfo` durch |
+| `src/services/compare_official_alert.py` | MODIFY | `:119` (is_quiet_hours) und `:138`/`:182` (alert_daily_limit) bekommen die Zone des ERSTEN Orts (`location_ids[0]`) |
+| `src/services/compare_alert.py` | MODIFY | `:151` (is_allowed — s. Korrektur unten), `:176` (is_quiet_hours über `AlertEvaluationConfig.zone`), `:293` (increment), `_build_eval_config()` (`:452-478`) bekommen die Zone des ersten Orts |
+| `src/services/compare_radar_alert.py` | MODIFY | `:131` (`check_nowcast_gate`-Aufruf) bekommt die Zone des ersten Orts |
+| `src/services/dispatch_orchestrator.py` | MODIFY | `CompareDispatchStrategy.collect_due()` lädt `all_locations` vorab und übergibt sie an `presets_due_for_hour`; `NOCH_NICHT_ORTSZEIT_SIEHE_1726` entfällt als Fälligkeits-Zone |
+| `src/services/compare_slot_scheduler.py` | MODIFY | `presets_due_for_hour(presets, hour, today)` → `presets_due_for_hour(presets, all_locations, now_utc)`, löst je Preset seine eigene Zone auf (s. Entwurf, Abschnitt D) |
+| `src/services/scheduler_dispatch_service.py` | MODIFY | Kommentar/Konstantenname am manuellen `?hour=`-Trigger angepasst (Verhalten unverändert, s. Entwurf Abschnitt D) |
+| `frontend/.../alerts-tab/AlertQuietHoursCard.svelte` | MODIFY | Neue Prop für die Zonen-Bezeichnung im Hinweistext |
+| `frontend/.../shared/AlarmeTab.svelte` | MODIFY | Beide Mount-Punkte (`:429`/`:431`) übergeben die neue Prop kontextabhängig |
+| `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` | MODIFY | Abschnitt „Bewusst NICHT betroffen" fortgeschrieben (AC-12) |
+| `tests/test_output_timezone_guard.py` | MODIFY | Vier Einträge (`:622`, `:623`, `:630`, `:635`) entfernt; Blockkommentar `:593` korrigiert |
+| `tests/tdd/test_ruhezeit_und_zaehler_folgen_der_ortszone.py` | CREATE | Neue AC-Nachweise (Verhaltensname, nicht Issue-Nummer — `test_naming_gate.py`) |
+
+**Bestehende Tests mit reiner Signatur-Folgeänderung** (kein neuer Testinhalt, aber jeder Aufruf
+von `is_quiet_hours`/`check_nowcast_gate`/`alert_daily_limit.*` ohne den neuen `zone`-Parameter
+wird zum `TypeError`): `tests/helpers/nowcast_gate_fixtures.py` (zentrale `VIENNA`-Fixture,
+`quiet_window_now`/`quiet_window_elsewhere`/`seed_daily_counter`/`read_daily_counter`),
+`tests/tdd/test_issue_1070_daily_alert_limit.py`, `tests/tdd/test_alert_quiet_hours_localtime.py`,
+`tests/tdd/test_alert_quiet_hours_robustness.py`,
+`tests/tdd/test_compare_alert_quiet_hours_precedes_fetch.py`,
+`tests/tdd/test_compare_radar_alert.py`, `tests/tdd/test_issue_1168_alert_engine_extract.py`,
+`tests/tdd/test_issue_883_acute_danger_override.py` (baut das Fenster fälschlich über `VIENNA`
+trotz Island-Koordinaten — das ist der Fehlerfall dieses Issues, steckt bereits im Test), dazu
+alle Aufrufer von `presets_due_for_hour`: `tests/test_compare_auto_pause_end_date.py`,
+`tests/tdd/test_compare_preset_loader.py`, `tests/tdd/test_compare_preset_slot_dispatch.py`,
+`tests/tdd/test_compare_alert_paused_archived_silent.py`, `tests/tdd/test_compare_anchor_target_date.py`.
+
+### Estimated Changes
+
+- Files: 12 Produktivdateien (10 Python, 2 Svelte) + 1 ADR + 1 Wächter-Datei + 1 neue Testdatei
+  + ~13 bestehende Testdateien mit mechanischer Signatur-Folgeänderung
+- LoC: siehe „Estimated Scope" unten (~220 Produktivcode)
+
+## Problem/Kontext
+
+**Ruhezeit.** `DeviationAlertEngine.is_quiet_hours()` (`deviation_alert_engine.py:84-143`)
+konvertiert `now` fest nach `Europe/Vienna`, bevor sie gegen `quiet_from`/`quiet_to` prüft.
+Gemessen (ADR-0051): für eine Ruhezeit 22:00–07:00 liegt ein Alarm um 08:00 Neuseeland-Ortszeit
+(= innerhalb der Wach-Stunden) heute noch in der als Wien ausgewerteten Nacht — er würde
+unterdrückt, obwohl der Nutzer wach ist. Umgekehrt geht ein Alarm um 03:00 Neuseeland-Ortszeit
+(mitten in der Nacht) durch, weil er auf Wiener Uhr tagsüber liegt.
+
+**Alarm-Tageszähler.** `alert_daily_limit.py` resettet ebenfalls auf Wiener Kalendertag-Wechsel
+(`_vienna_date_str`, `:31-32`). Ein Nutzer mit Objekten in mehreren Zonen hat de facto EINEN
+gemeinsamen Reset-Zeitpunkt, der zu keiner seiner Zonen passt.
+
+**Ortsvergleichs-Fälligkeit.** `CompareDispatchStrategy.collect_due()`
+(`dispatch_orchestrator.py:130-146`) bildet EINEN `vor_ort`-Zeitpunkt aus der festen Konstante
+`NOCH_NICHT_ORTSZEIT_SIEHE_1726 = "Europe/Vienna"` und prüft alle Presets eines Laufs gegen
+dieselbe Stunde/denselben Tag. Ein auf 07:00 gestelltes Preset mit Orten in Neuseeland geht damit
+zur falschen Weltzeit raus.
+
+Ursache aller drei: Die Entscheidung „ist jetzt X" beantwortet der SERVER, nicht der GEGENSTAND,
+über den geredet wird (ADR-0051 Regel 2).
+
+## Ziel
+
+Alle drei Entscheidungen lösen ihre Zone aus den Daten auf, EINHEITLICH über die bereits
+vorhandenen Bausteine `utils.timezone.{resolve_location_tz,location_tz}` (Orte) und
+`services.trip_day.{trip_local_now,anchor_tz}` (Trips) — keine neue Auflösung, keine zweite
+Kopie (ADR-0044, "Lehre für die Pflege dieser Liste").
+
+Für Mehrzonen-Fälle (ein Ortsvergleich mit Orten in verschiedenen Zonen) gilt EINHEITLICH die
+bereits PO-entschiedene Regel aus #1378 (AC-4): die Zone des **erstgenannten Orts der
+konfigurierten Reihenfolge** (`order_locations_by_ids`, #1359). Kein neues Datenfeld, keine
+zweite Regel für einen anderen Anwendungsfall derselben Frage.
+
+## Abgrenzung
+
+- **Fälligkeitsfenster + Idempotenz-Vermerk für den Ortsvergleich sind NICHT Teil dieser
+  Scheibe** — das trägt Issue **#1777**. Hier wird bei der Ortsvergleichs-Slot-Fälligkeit
+  AUSSCHLIESSLICH die Zone getauscht (Wien → erster Ort); die Prüfung selbst bleibt
+  Stundengleichheit (`==`, `compare_slot_scheduler.py:152,154`). Die Umstellungstag-Lücke
+  (29.03. Slot entfällt ersatzlos, 25.10. Slot geht doppelt raus) bleibt für den Vergleich damit
+  vorerst bestehen — unverändert gegenüber heute, nur jetzt in der Zone des ersten Orts statt in
+  Wien.
+- **Die ~25 Muster-A-Funde der Wächter-Restliste (`date.today()`/`datetime.now()` ohne Zone)
+  sind NICHT Teil dieser Scheibe** — sie tragen S5/**#1727**. Diese Scheibe korrigiert nur den
+  Blockkommentar, der sie fälschlich #1726 zuweist (AC-14), behebt sie aber nicht.
+- **Der Go-Cron tickt weiterhin in `Europe/Vienna`** (`internal/config/config.go:20`,
+  `SchedulerTimezone`, Default `Europe/Vienna`). Diese Scheibe ändert nichts an der
+  Cron-Auslösung selbst — nur daran, WIE die ausgelöste Prüfung ihre Fälligkeit/Ruhezeit/ihren
+  Zähler bewertet. Der an Umstellungstagen ausfallende/doppelte Tick (`robfig/cron/v3`,
+  dokumentiert in `docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md`) bleibt bestehen
+  und ist ebenfalls S5/#1727-Territorium.
+- **Keine Nutzer-Zeitzonen-Einstellung.** Bereits in ADR-0044 verworfen, hier nicht erneut zur
+  Wahl gestellt.
+- **Der manuelle `?hour=`-Testtrigger** (`scheduler_dispatch_service.py:170-181`) behält seine
+  Interpretation gegen eine feste Referenz-Zone (s. Entwurf Abschnitt D) — das ist ein
+  Ops-/Debug-Werkzeug, kein Nutzerpfad, und nicht Gegenstand einer eigenen Zusicherung in dieser
+  Spec.
+
+## Entwurf/Umbau
+
+### A. Ruhezeit — sieben Aufrufstellen, EIN geteilter Kern
+
+`DeviationAlertEngine.is_quiet_hours()` bekommt einen Pflicht-Parameter `zone: ZoneInfo` (kein
+Default) statt der festen `VIENNA`-Konstante — bewusst PFLICHT, nicht optional mit
+Wien-Rückfall: ein impliziter Rückfall wäre genau die Fehlerklasse, die diese Scheibe beseitigt.
+Jede der sieben Aufrufstellen liefert ihre Zone aus dem Objekt, das sie ohnehin im Scope hat:
+
+| # | Aufrufstelle | Zone-Quelle | Code-Änderung nötig an |
+|---|---|---|---|
+| 1 | `compare_official_alert.py:119` (amtliche Warnung, Vergleich) | erster Ort aus `location_ids`/`all_locations` | dieser Zeile |
+| 2 | `trip_alert.py:229` (Adapter-Aufruf, Wetter-Abweichung Trip) | Trip | keine — Zone entsteht im Adapter |
+| 3 | `trip_alert.py:688` (`_is_quiet_hours`-Adapter, tatsächlicher `is_quiet_hours`-Aufruf) | `anchor_tz(trip, now)` | dieser Zeile — EINZIGE Codeänderung für #2 UND #4 |
+| 4 | `trip_alert.py:1443` (Adapter-Aufruf, amtliche Warnung Trip) | Trip | keine — teilt sich den Adapter mit #2 |
+| 5 | `alert_gate.py:93` (Nowcast-Schranke, geteilt Trip+Vergleich) | **kein Objekt im Scope** — Zone als Parameter durchgereicht von den zwei Aufrufern (`trip_alert.py:963`: `anchor_tz(trip, now_utc)`; `compare_radar_alert.py:131`: erster Ort) | `check_nowcast_gate()`-Signatur + beide Aufrufer |
+| 6 | `compare_alert.py:176` (Wetter-Abweichung, Vergleich) | `config.zone`, gesetzt in `_build_eval_config()` (`:452-478`) aus dem ersten Ort | `AlertEvaluationConfig`-Konstruktion, nicht die Aufrufzeile selbst |
+| 7 | `deviation_alert_engine.py:286` (`evaluate()`, Engine-Kern) | `config.zone` (Rückfall UTC bei `None`, sichtbar dokumentiert) | dieser Zeile |
+
+Zwei und vier bzw. drei sind bewusst als GETRENNTE Zeilen der Tabelle aufgeführt, obwohl sie
+sich denselben Code teilen (`_is_quiet_hours`-Adapter, `:672-691`) — jede muss trotzdem
+EIGENSTÄNDIG mit einem Alarm in einer Nicht-Wien-Zone nachgewiesen werden. Geteilter Code
+bewies in #1697 dreimal in Folge nichts über den jeweiligen Aufrufer (ADR-0051,
+„Folgepflichten").
+
+### B. Zonen-Auflösung — es ist nichts zu erfinden
+
+| Werkzeug | Zweck | Rückfall |
+|---|---|---|
+| `services.trip_day.anchor_tz(trip, now_utc)` bzw. `trip_local_now(trip, now_utc).tzinfo` | Zone eines Trips, **tagesbewusst** (Etappe des Weltzeit-Tages) — dieselbe Auflösung, die #1724/#1725 für die Briefing-Fälligkeit benutzen, NICHT `trip_tz()` (das ist fix auf die erste Etappe mit Wegpunkten und tagesUNabhängig) | importierte `UTC`-Konstante bei Trips ohne Wegpunkte |
+| `utils.timezone.location_tz(location)` | Zone eines Orts, MIT UTC-Rückfall (identisch zu `compare_html.py:1537`, derselbe Aufruf für die Compare-Kopfzeile) | `UTC`, sichtbar über dieselbe Konvention wie die Mail-Kopfzeile |
+| `services.compare_preview_service.order_locations_by_ids(locations, location_ids)[0]` bzw. direkt `all_locations.get(location_ids[0])` | „erster Ort der konfigurierten Reihenfolge" (E1) | — |
+
+**Warum `location_tz()` (UTC-Rückfall) statt `resolve_location_tz()` (`None`-Rückfall):**
+Ruhezeit-/Zähler-/Fälligkeits-Logik brauchen eine KONKRETE Zone, kein `None` — dieselbe
+Abwägung, die die Compare-Kopfzeile bereits trifft. Der Rückfall bleibt dadurch konsistent zu
+dem, was der Nutzer in der Mail ohnehin sieht, statt eine zweite, abweichende Konvention
+einzuführen.
+
+**🔴 „Erster Ort" ist eine fachliche Auswahlregel, kein Indexzugriff.** Nachgemessen: Eine
+*leere* Ortsliste ist an beiden Compare-Stellen ausgeschlossen (`compare_alert.py:123`,
+`compare_official_alert.py:90`: `if not preset_id or not location_ids`). **Aber die ID kann ins
+Leere zeigen** — `compare_official_alert.py:128` filtert genau darauf
+(`[all_locations[lid] for lid in location_ids if lid in all_locations]`), weil ein gelöschter Ort
+in `location_ids` stehen bleibt. Dann ist `all_locations.get(location_ids[0])` gleich `None`, und
+`location_tz(None)` stürzt **nicht** ab, sondern liefert still `UTC`
+(`utils/timezone.py:67-71` → `resolve_location_tz` → `getattr(None, "lat", …)` ist `None` →
+`None` → `or UTC`). Dasselbe passiert bei einem Ort ohne Koordinaten und bei einem, für den
+`tz_for_coords` „UTC" liefert (`:60-64` gibt in beiden Fällen `None`).
+
+Das wäre exakt die Fehlerklasse dieser Scheibe, nur mit UTC statt Wien: ein stiller Rückfall,
+obwohl der zweite Ort der Liste eine gültige Zone trägt. Deshalb gilt:
+
+> **Maßgeblich ist der erste Ort der konfigurierten Reihenfolge, dessen Zone auflösbar ist.**
+> Erst wenn KEINER der Orte eine Zone liefert, gilt UTC — und dieser Fall wird sichtbar
+> protokolliert (`logger.warning` mit Preset-Kennung), nicht verschwiegen.
+
+Das ist keine Abweichung von PO-Entscheidung E1, sondern ihre präzise Fassung: „erster Ort" war
+als fachliche Auswahl gemeint, nicht als `[0]`. Nachweis: AC-15.
+
+**Warum `anchor_tz`/`trip_local_now` statt `trip_tz()` für Trips:** `trip_tz()` beantwortet nur
+„welcher Kalendertag ist gerade" (fix auf die erste Etappe mit Wegpunkten). Ruhezeit und Zähler
+werden dagegen fortlaufend geprüft, während der Trip läuft — ein mehrtägiger Trek, der die Zone
+wechselt, braucht die Zone SEINER AKTUELLEN Etappe, nicht die des Starttags. `trip_local_now`
+liefert genau das aus EINER Auflösung (Ortstag UND -stunde), konsistent mit #1725.
+
+### C. Tageszähler — Schema, Migration, korrigierte Aufrufstellen-Liste
+
+**🔴 Korrektur der im Kontext-Dokument gezählten Aufrufstellen:** Das Kontext-Dokument nennt
+„zehn Aufrufstellen". Nachgemessen (`grep -n 'alert_daily_limit\.\(is_allowed\|increment\|load\)'`
+über `src/`) sind es **elf** — `compare_alert.py:151` (`is_allowed(..., reason="forecast_change")`,
+im selben Preset-Loop wie die bereits gelistete `:293`) fehlte in der Aufzählung. Genau diese
+Fehlerklasse — eine unvollständige Aufrufstellen-Liste, bei der der ungenannte Weg ungeschützt
+bleibt — hat #1725 bereits zweimal getroffen. Vollständige, nachgemessene Liste:
+
+`alert_gate.py:105`/`:123` · `compare_official_alert.py:138`/`:182` ·
+`trip_alert.py:240`/`:344`/`:1449`/`:1490` · `compare_alert.py:151`/`:293` · dazu die reine
+Lesestelle `trip_report_scheduler.py:1570` (Starkregen-Kurzfristhinweis, bucht nie — s. #1199,
+Nebenbefund, unverändert).
+
+**Neues Schema** `data/users/<uid>/alert_daily_count.json`:
+
+```json
+{"zones": {"Europe/Vienna": {"date": "2026-08-12", "count": 2},
+           "Pacific/Auckland": {"date": "2026-08-12", "count": 1}}}
+```
+
+Zonen-Schlüssel = `str(zone)` (IANA-Name, z. B. `"Europe/Vienna"`; UTC-Rückfall unter dem
+Schlüssel `"UTC"`). `load`/`is_allowed`/`increment` bekommen einen Pflicht-Parameter
+`zone: ZoneInfo` (kein Default — dieselbe Begründung wie bei `is_quiet_hours`).
+
+**Migration/Bestandserhalt (Projektregel: Read-Modify-Write mit Merge, niemals Replace):** Trifft
+`load`/`increment` beim ersten Zugriff auf das ALTE Schema (Top-Level-Schlüssel `"date"`/`"count"`,
+kein `"zones"`-Schlüssel), wird der Bestand unter dem Schlüssel `"Europe/Vienna"` in die neue
+Struktur übernommen. Begründung: der Alt-Zähler wurde de facto nach Wiener Kalendertag geführt —
+`"Europe/Vienna"` ist die einzige Zone, für die der Bestandswert eine korrekte Fortsetzung ist.
+Für jede andere Zone beginnt der Zähler bei 0. Die Migration ist idempotent (kein separates
+Skript, geschieht beim nächsten Zugriff) und schreibt nur die betroffene Zone — alle übrigen
+Zonen-Einträge einer bereits migrierten Datei bleiben beim `increment()` unangetastet (Merge auf
+Zonen-Ebene, nicht nur auf Datei-Ebene).
+
+### D. Ortsvergleichs-Slot-Fälligkeit — Zonentausch erfordert Restrukturierung
+
+`CompareDispatchStrategy.collect_due()` bildet heute EINEN `vor_ort`-Zeitpunkt für den GESAMTEN
+Lauf und übergibt `presets_due_for_hour(presets, vor_ort.hour, vor_ort.date())` — alle Presets
+eines Laufs werden gegen DIESELBE Stunde/denselben Tag geprüft. Unter E1 hat aber JEDES Preset
+potenziell eine ANDERE Zone (sein eigener erster Ort) — ein einzelner globaler `vor_ort`-Wert
+kann das nicht mehr abbilden. Reines Konstanten-Tauschen reicht hier NICHT.
+
+**Umbau:** `presets_due_for_hour(presets, hour, today)` wird zu
+`presets_due_for_hour(presets, all_locations, now_utc)`. Intern wird je Preset die Zone seines
+ersten Orts aufgelöst, `vor_ort = local_dt(now_utc, zone)` gebildet, und die BISHERIGE
+Stundengleichheits-Prüfung (`slots.morning_time.hour == vor_ort.hour` usw.) läuft unverändert
+gegen dieses preset-eigene `vor_ort`. `collect_due()` lädt `all_locations` dafür vor dem Aufruf
+(bisher nur lazy in `dispatch_one()`, `:168-169`).
+
+**Der manuelle `?hour=`-Testtrigger** (`scheduler_dispatch_service.py:170-181`, Endpunkt für
+manuell ausgelöste Testläufe) konstruiert heute einen `now_utc`, dessen Stunde in
+`NOCH_NICHT_ORTSZEIT_SIEHE_1726` (Wien) exakt `hour` ist. Mit preset-eigenen Zonen hat „Stunde
+X" keine EINE Bedeutung mehr. Entscheidung: der Trigger bleibt gegen eine FESTE Referenz-Zone
+verankert (unbenannt umbenannt zu `MANUAL_TRIGGER_REFERENCE_ZONE = "Europe/Vienna"`, reiner
+Name-Wechsel zur Klarstellung des jetzt einzigen Zwecks) — er ist ein Ops-/Debug-Werkzeug ohne
+Bezug zu einem bestimmten Preset und braucht keine preset-eigene Zone. Das Verhalten des
+Endpunkts selbst ändert sich dadurch NICHT.
+
+### E. Oberfläche
+
+`AlertQuietHoursCard.svelte` bekommt eine neue Prop (Text, nicht Zeitzonen-Berechnung — die
+Karte kennt keine `ZoneInfo`-Logik, das bleibt Backend-Domäne). `shared/AlarmeTab.svelte`
+(`:429`/`:431`) übergibt sie kontextabhängig: beim Trip „der Tour", beim Vergleich „des ersten
+Orts" — EIN geteilter Baustein (Trip/Compare-Teilungsregel), keine zweite Komponente.
+
+### F. ADR-0044 Fortschreibung
+
+`docs/adr/0044-kalendertage-folgen-der-ortszeit.md`, Abschnitt „Bewusst NICHT betroffen (feste
+Zone ist dort Absicht, kein Verstoß)" nennt heute `alert_daily_limit` und
+`deviation_alert_engine` als Ausnahmen. Diese Scheibe kehrt das um — der Abschnitt wird
+fortgeschrieben, die beiden Module wandern in „Umgesetzt". Kein neues ADR: ADR-0051 trägt die
+Entscheidung bereits (wie bei #1725).
+
+### G. Wächter-Bereinigung
+
+Vier Einträge in `KNOWN_VIOLATIONS` (`tests/test_output_timezone_guard.py`) gehören zu dieser
+Scheibe und MÜSSEN verschwinden, weil der Scanner sie nach dem Fix nicht mehr findet
+(`test_known_violations_only_shrink()` erzwingt das):
+
+- `:622` — `alert_daily_limit.py::<module>::0` (Muster B, `VIENNA`-Konstante)
+- `:623` — `deviation_alert_engine.py::<module>::0` (Muster B, `VIENNA`-Konstante)
+- `:630` — `alert_daily_limit.py::_vienna_date_str::0` (raw_astimezone, an Muster B gekoppelt)
+- `:635` — `deviation_alert_engine.py::is_quiet_hours::0` (raw_astimezone, an Muster B gekoppelt)
+
+Zusätzlich wird der Blockkommentar bei `:593` korrigiert: er weist derzeit ALLE 53
+Bestandseinträge — darunter ~25 Muster-A-Funde, die tatsächlich #1727 zugeordnet sind —
+pauschal #1726 zu. Nach dem Schliessen von #1726 darf die Liste nicht mehr auf ein erledigtes
+Issue zeigen (AC-14).
+
+## Verworfene Alternativen
+
+- **Tageszähler: jede Aufrufstelle bringt ihre eigene Zone an EINEN gemeinsamen Datensatz** (statt
+  getrennter Zonen-Buckets). Verworfen: derselbe Lauf schriebe den `date`-Schlüssel je nach
+  Aufrufer zwischen zwei Kalendertagen hin und her; `increment()` setzt bei jedem Nichttreffer auf
+  1 zurück (`alert_daily_limit.py:86,90-93`) — das Limit griffe effektiv NIE, und es bremst
+  kostenpflichtige Premium-SMS nicht mehr. Bewusster Preis der gewählten Lösung (getrennte
+  Zonen-Buckets): Wer Objekte in drei Zonen hat, bekommt das Kontingent dreimal — das ist zu
+  benennen, nicht zu verstecken (AC-7).
+- **Eine Nutzer-Zeitzonen-Einstellung** als Referenz für den Tageszähler. In ADR-0044 bereits
+  verworfen ("der Wanderer ist unterwegs, nicht zu Hause") — hier nicht erneut zur Wahl gestellt,
+  aus demselben Grund auf den Zähler übertragen.
+- **Alphabetische Sortierung der Orte** als Referenz für „erster Ort" beim Mehrzonen-Vergleich.
+  War nie die tatsächliche Regel (der Kommentar bei `comparison.py:201-202` behauptet das noch,
+  ist seit #1359 falsch) — die konfigurierte Reihenfolge (`location_ids`) gilt, nicht eine vom
+  System erzeugte Sortierung.
+- **Fälligkeitsfenster + Idempotenz auch für den Ortsvergleich, in derselben Scheibe wie der
+  Zonentausch.** Erwogen, aber PO-Entscheidung E3 (2026-08-12): getrennt, weil die
+  Fälligkeitsfrage und die Zonenfrage unabhängig beantwortbar sind und die Zusammenlegung die
+  Scheibe unnötig vergrössert hätte. Trägt #1777.
+
+## Acceptance Criteria
+
+- **AC-1 (Ruhezeit östlich von Wien wird in der ECHTEN Ortszeit geprüft):** Given ein Trip mit
+  Wegpunkt in `Pacific/Auckland` und Ruhezeit 22:00–07:00 / When ein Wetter-Abweichungs-Alarm zu
+  einem Zeitpunkt ansteht, der in Auckland innerhalb des Ruhezeit-Fensters, in Wien aber tagsüber
+  liegt / Then wird der Alarm unterdrückt — heute ginge er durch, weil die Prüfung fälschlich
+  gegen Wien läuft. Wirkt in `deviation_alert_engine.py:84-143`, verdrahtet über
+  `trip_alert.py:229/688`.
+
+- **AC-2 (Ruhezeit westlich von Wien wird in der ECHTEN Ortszeit geprüft):** Given derselbe
+  Aufbau mit Wegpunkt in `America/Los_Angeles` / When ein Alarm zu einem Zeitpunkt ansteht, der
+  in Los Angeles innerhalb, in Wien aber ausserhalb des Ruhezeit-Fensters liegt / Then wird der
+  Alarm unterdrückt.
+
+- **AC-3 (Alle sieben Ruhezeit-Prüfstellen bekommen dieselbe Ortszone, nicht nur die
+  einfachsten):** Given jede der sieben Stellen, an denen eine Ruhezeit-Prüfung im Code steht —
+  amtliche Warnung Vergleich (`compare_official_alert.py:119`), Wetter-Abweichung Trip
+  (`trip_alert.py:229`), der geteilte Adapter selbst (`trip_alert.py:688`), amtliche Warnung Trip
+  (`trip_alert.py:1443`), die Nowcast-Schranke (`alert_gate.py:93`, kein eigenes Objekt — Zone von
+  den zwei Aufrufern durchgereicht), Wetter-Abweichung Vergleich (`compare_alert.py:176`) und der
+  Engine-Kern selbst (`deviation_alert_engine.py:286`) / When an dieser Stelle ein Alarm für eine
+  Entität in einer Nicht-Wien-Zone ausgelöst würde / Then wertet JEDE der sieben Stellen die
+  Ruhezeit in DIESER Zone aus, nicht in Wien — einzeln nachgewiesen, nicht nur über den geteilten
+  Code miterschlossen (geteilter Code bewies in #1697 dreimal nichts über den jeweiligen
+  Aufrufer).
+
+- **AC-4 (Mehrzonen-Vergleich — Ruhezeit folgt dem ERSTEN Ort und wandert mit der
+  Reihenfolge):** Given ein Ortsvergleich mit Orten in zwei verschiedenen Zonen in der vom
+  Nutzer konfigurierten Reihenfolge / When die Ruhezeit für diesen Vergleich geprüft wird / Then
+  gilt die Ortszeit des ERSTGENANNTEN Orts — und wird ein anderer Ort in der Konfiguration an die
+  erste Stelle verschoben, verschiebt sich die wirksame Ruhezeit nachweislich mit. Wirkt in
+  `compare_alert.py:176`/`compare_official_alert.py:119`/`compare_radar_alert.py:131`, Grundlage
+  ist `order_locations_by_ids` (#1359).
+
+- **AC-5 (#1479 bleibt gewahrt — kein Programmabsturz durch den neuen Zonen-Parameter):** Given
+  ein unbrauchbarer Ruhezeit-Wert (`"25:00"`, `"abc"`, ein Nicht-String) / When die Ruhezeit an
+  irgendeiner der sieben Stellen geprüft wird / Then gilt weiterhin „keine Ruhezeit gesetzt"
+  statt eine Ausnahme durchzureichen — auch mit dem zusätzlichen Zonen-Parameter unverändert.
+  Wirkt `deviation_alert_engine.py:109-139`.
+
+- **AC-6 (Tageszähler resettet zur ORTS-Mitternacht, nicht zur Wiener):** Given ein Trip/Preset
+  in einer Zone östlich von Wien (`Pacific/Auckland`) UND eines westlich (`America/Los_Angeles`)
+  / When ein Alarm knapp VOR bzw. knapp NACH der jeweiligen Orts-Mitternacht ausgelöst wird,
+  während in Wien noch derselbe bzw. bereits ein anderer Kalendertag gilt / Then zählt der Alarm
+  zum Ortstag, nicht zum Wiener Tag — in beiden Richtungen nachgewiesen. Wirkt
+  `alert_daily_limit.py` (`load`/`increment`).
+
+- **AC-7 (Getrennte Zähler pro Zone — kein gegenseitiges Verbrauchen, bewusster Preis
+  benannt):** Given ein Nutzer hat zwei Objekte (z. B. zwei Trips oder ein Trip und einen
+  Ortsvergleich) in unterschiedlichen Zonen, beide mit erreichtem Tageslimit in ihrer jeweiligen
+  Zone / When in beiden Zonen je ein weiterer Alarm ausgelöst würde / Then wird das Kontingent
+  jeder Zone UNABHÄNGIG geführt — ein ausgeschöpftes Kontingent in Zone A blockiert Zone B nicht,
+  UND ein Alarm in Zone A verbraucht nicht das Kontingent von Zone B. Der bewusste Preis (wer
+  Objekte in drei Zonen hat, bekommt das Kontingent dreimal) ist Teil dieser Zusicherung, kein
+  verstecktes Nebenprodukt.
+
+- **AC-8 (Bestandsdaten bleiben beim Rollout erhalten — kein Kontingent-Leck):** Given ein
+  bestehender Zähler im ALTEN Schema (`{"date": ..., "count": N}`, keine Zonenkennung) liegt
+  bereits auf der Festplatte, mit einem Zählerstand ungleich 0 für den heutigen Wiener Tag / When
+  der neue Code diesen Zähler zum ersten Mal für einen Trip/Ortsvergleich in `Europe/Vienna`
+  liest oder erhöht / Then bleibt der Bestandswert erhalten und wird NICHT unbegründet auf 0
+  zurückgesetzt — ein Deploy mitten am Tag führt für Wiener Zeit nicht zu einem Kontingent-Leck
+  (Read-Modify-Write mit Merge).
+
+- **AC-9 (Ortsvergleichs-Slot-Fälligkeit folgt der Zone des ersten Orts, Prüfung bleibt
+  unverändert):** Given ein Ortsvergleichs-Preset mit Orten in einer Zone abweichend von Wien,
+  konfiguriertem Morgen-Slot 07:00 / When der Versandlauf zu einem Zeitpunkt läuft, der in der
+  Zone des ERSTEN Orts genau 07:00 ist, aber in Wien eine andere Stunde / Then wird das Preset als
+  fällig erkannt — heute würde es das nicht, weil die Prüfung fälschlich gegen Wien läuft. Zwei
+  Presets desselben Nutzers mit ersten Orten in unterschiedlichen Zonen sind zu unterschiedlichen
+  Weltzeit-Momenten fällig. Die Prüfung selbst bleibt Stundengleichheit (kein Fenster, keine
+  Idempotenz — das trägt #1777). Wirkt `dispatch_orchestrator.py` (`CompareDispatchStrategy.
+  collect_due`) und `compare_slot_scheduler.py` (`presets_due_for_hour`).
+
+- **AC-10 (Beide Sommerzeit-Wechseltage — Häufigkeit jeder einzelnen Stunde, nicht die
+  Zeilenzahl):** Given der Frühjahrs-Umstellungstag 29.03.2026 UND der Herbst-Umstellungstag
+  25.10.2026, je in einer Zone mit Sommerzeit-Wechsel und einer Ruhezeit über Mitternacht (Wrap)
+  / When der Tageszähler-Reset bzw. die Ruhezeit-Prüfung über den gesamten Tag beobachtet wird,
+  Stunde für Stunde / Then verhält sich beides an der jeweils EXAKTEN Orts-Mitternacht korrekt —
+  am Frühjahrstag (23 Ortsstunden) ohne vorzeitigen Reset, am Herbsttag (25 Ortsstunden, Stunde 02
+  existiert zweimal) ohne doppelten Reset.
+
+- **AC-11 (Oberfläche nennt die Zonen-Basis der Ruhezeit):** Given der Alarme-Reiter zeigt die
+  Ruhezeit-Karte, einmal im Trip-Kontext und einmal im Ortsvergleichs-Kontext / When die Karte
+  angezeigt wird / Then benennt sie die Ortszeit-Basis unterschiedlich — beim Trip „Ortszeit der
+  Tour", beim Vergleich „Ortszeit des ersten Orts" — statt wie bisher gar keine Zone zu nennen.
+  Wirkt `AlertQuietHoursCard.svelte`, gemountet aus `shared/AlarmeTab.svelte:429/431` als EIN
+  geteilter Baustein für beide Kontexte.
+
+- **AC-12 (ADR-0044 nachgezogen):** Given ADR-0044 listet `alert_daily_limit` und
+  `deviation_alert_engine` unter „Bewusst NICHT betroffen (feste Zone ist dort Absicht)" / When
+  diese Scheibe live ist / Then ist dieser Abschnitt fortgeschrieben — beide Module stehen nicht
+  mehr als Ausnahme, sondern folgen der Ortszone wie die übrigen bereits umgesetzten Bereiche.
+
+- **AC-13 (Wächter-Restliste schrumpft um genau die vier zugehörigen Einträge):** Given die vier
+  Einträge `:622`, `:623`, `:630`, `:635` in `tests/test_output_timezone_guard.py` / When diese
+  Scheibe live ist / Then findet der Scanner diese Stellen nicht mehr, die vier Einträge sind aus
+  `KNOWN_VIOLATIONS` entfernt, und `test_known_violations_only_shrink()` bleibt grün.
+
+- **AC-14 (Fehlzuordnung im Blockkommentar korrigiert):** Given der Blockkommentar bei
+  `tests/test_output_timezone_guard.py:593` weist derzeit ALLE 53 Bestandseinträge — auch die
+  ~25 Muster-A-Funde, die tatsächlich #1727 zugeordnet sind — pauschal #1726 zu / When diese
+  Scheibe schliesst / Then ist der Kommentar so korrigiert, dass er die verbleibenden
+  Muster-A-Funde korrekt #1727 nennt und nicht mehr auf ein bereits erledigtes Issue zeigt.
+  - Test: Datei-Inhalts-Prüfung mit `# doc-compliance-test`-Kennzeichnung (Ausnahme von der
+    „kein Dateiinhalt-Check"-Regel, weil hier die Dokumentations-Korrektheit selbst der
+    Gegenstand ist).
+
+- **AC-15 (Ein gelöschter oder unauflösbarer erster Ort kippt den Vergleich nicht still auf
+  Weltzeit):** Given ein Ortsvergleich, dessen erstgenannter Ort gelöscht wurde oder keine
+  auflösbare Zone hat, während ein späterer Ort in der Liste eine gültige Zone trägt / When
+  Ruhezeit, Tageszähler oder Slot-Fälligkeit für diesen Vergleich bestimmt werden / Then gilt die
+  Zone des ersten Orts, der sich AUFLÖSEN LÄSST — nicht Weltzeit. Nur wenn kein einziger Ort eine
+  Zone liefert, gilt UTC, und dieser Fall wird im Protokoll mit der Vergleichs-Kennung sichtbar
+  gemacht, statt still zu geschehen.
+
+## Nachweis-Strategie
+
+Kern-Schicht, deterministisch: kein Netz, keine echten Postfächer. Zeit wird als Parameter
+hereingereicht, nicht per Patch auf die Systemuhr — Muster aus #1724/#1725. Neue Datei
+`tests/tdd/test_ruhezeit_und_zaehler_folgen_der_ortszone.py` (Verhaltensname, nicht
+Issue-Nummer — `test_naming_gate.py` blockt sonst).
+
+🔴 **Falle, die die Testfälle vorwegnehmen:** `Europe/Paris` fällt UTC-Offset-mässig mit Wien
+zusammen — ein Test dort kann eine Zonen-Zusicherung strukturell nicht von einem Wien-Rückfall
+unterscheiden (kostete in #1725 bereits eine Adversary-Runde). Alle Ost/West-Nachweise dieser
+Scheibe verwenden deshalb `Pacific/Auckland` (östlich) und `America/Los_Angeles` (westlich).
+
+| AC | Testfall | Verfälschung, die ihn rot macht |
+|---|---|---|
+| AC-1 | Auckland-Trip, Ruhezeit-Wrap, Alarm bei Weltzeit, die in Auckland Nacht/in Wien Tag ist → unterdrückt | `zone`-Parameter ignorieren, weiter fest `VIENNA` verwenden |
+| AC-2 | LA-Trip, spiegelbildlich → unterdrückt | dito |
+| AC-3 | Sieben Einzeltests, je EINE der sieben Stellen mit einer Nicht-Wien-Zone | eine der sieben Stellen den `zone`-Parameter NICHT durchreichen lassen — nur die anderen sechs Tests bleiben grün |
+| AC-4 | Zwei Orte, zwei Zonen, Ruhezeit trifft nur bei Zone von `location_ids[0]`; Reihenfolge tauschen → Ruhezeit-Ergebnis kippt mit | `location_ids[0]` durch eine feste/alphabetische Auswahl ersetzen |
+| AC-5 | `"25:00"`/`"abc"`/`None`-Ruhezeitwert mit gesetztem `zone`-Parameter → weiterhin `False`, kein Traceback | `try/except` um den neuen Parameter entfernen |
+| AC-6 | Zähler-Reset exakt an Orts-Mitternacht, Auckland UND LA, je knapp davor/danach geprüft | Reset weiterhin gegen `_vienna_date_str` statt zonenspezifisch |
+| AC-7 | Zwei Zonen, beide am Limit, unabhängige Zähler | ein gemeinsamer Schlüssel ohne Zonen-Diskriminator |
+| AC-8 | Alt-Schema-Datei mit Zählerstand ungleich 0, Zugriff in `Europe/Vienna` → Bestand erhalten | Migration durch Replace statt Merge ersetzen |
+| AC-9 | Zwei Presets, unterschiedliche erste Orte, unterschiedliche Zonen, je zur eigenen 07:00 fällig | `presets_due_for_hour` weiterhin mit EINEM globalen `hour`/`today` aufrufen |
+| AC-10 | 29.03. und 25.10.2026, Auckland/LA, Reset UND Ruhezeit stundenweise beobachtet | Tageslänge als fixe 24h annehmen statt zu berechnen |
+| AC-11 | Playwright/Component-Test: Karte im Trip- vs. Vergleichs-Kontext zeigt unterschiedlichen Text | Text hart auf einen Kontext verdrahten |
+| AC-12 | Dateiinhalt-Prüfung (`# doc-compliance-test`): ADR-0044 nennt `alert_daily_limit`/`deviation_alert_engine` nicht mehr unter „Bewusst NICHT betroffen" | ADR unverändert lassen |
+| AC-13 | `test_known_violations_only_shrink()` bleibt grün nach Entfernen der vier Einträge | einen der vier Einträge stehen lassen |
+| AC-14 | Dateiinhalt-Prüfung: Kommentar bei `:593` referenziert die Muster-A-Restliste korrekt auf #1727 | Kommentar unverändert lassen |
+| AC-15 | Vergleich mit gelöschtem erstem Ort + gültigem zweitem Ort in Nicht-UTC-Zone → Ruhezeit folgt dem zweiten Ort; separater Fall „kein Ort auflösbar" → UTC UND Protokolleintrag | `location_ids[0]` als reinen Indexzugriff belassen (fällt still auf UTC) |
+
+**Mutations-Gegenprobe (Pflicht):** mindestens gegenzuprüfen — `zone`-Parameter an einer der
+sieben Ruhezeit-Stellen stillschweigend ignorieren, Zähler-Migration durch Replace ersetzen,
+`location_ids[0]` durch eine andere Ortsauswahl ersetzen, `presets_due_for_hour` mit einem
+globalen statt preset-eigenen `vor_ort` belassen.
+
+## Estimated Scope
+
+- **LoC:** ~220 Produktivcode über 10 Python- + 2 Svelte-Dateien (grösste Einzelposten:
+  `alert_daily_limit.py` ~60 wegen Schema-Migration, `trip_alert.py` ~25 wegen sieben
+  Aufrufstellen, `compare_slot_scheduler.py`/`dispatch_orchestrator.py` zusammen ~45 wegen der
+  Restrukturierung von `presets_due_for_hour`); Testcode und die Wächter-Listen-Korrektur zählen
+  nicht gegen das Limit.
+- **Files:** 12 Produktivdateien, 1 ADR, 1 Wächter-Datei, 1 neue Testdatei, ~13 bestehende
+  Testdateien mit mechanischer Signatur-Folgeänderung.
+- **Effort:** high — nicht wegen algorithmischer Komplexität, sondern wegen der Anzahl
+  unabhängig nachzuweisender Aufrufstellen (7 Ruhezeit + 11 Zähler + 1 Fälligkeits-Restrukturierung)
+  und der Pflicht-Enumeration aus #1725s Lehre.
+- **Limit-Reserve:** ~220/250 ist knapp. 🔴 **Die naheliegende Ausweichoption ist keine.** Die
+  Restrukturierung von `presets_due_for_hour`/`dispatch_orchestrator.py` (Abschnitt D, ~45 LoC)
+  ist zwar technisch die am ehesten separierbare Einheit, aber sie herauszuschneiden hiesse: die
+  **Ortsvergleichs-Slot-Fälligkeit bliebe vollständig auf Wien**. Das ist eine der DREI im Issue
+  genannten Kernsachen, nicht eine Verfeinerung — die Scheibe schrumpfte von drei Umstellungen
+  auf zwei, und AC-9 wanderte samt erneuter Freigabepflicht nach #1777. **Das ist deshalb eine
+  PO-Entscheidung, keine Entwickler-Entscheidung.** Der reguläre Weg bei Überschreitung ist die
+  Anhebung des LoC-Rahmens per Override — ebenfalls nur mit PO-Zustimmung. Nicht
+  herausschneidbar: die Zähler-Migration (Sicherheitsargumentation, AC-8) und die sieben
+  Ruhezeit-Stellen (zusammenhängende Zusicherung, AC-3).
+
+## Bekannte Grenzen
+
+- **Compare-Fälligkeits-Lücke bleibt bestehen.** Die Umstellungstag-Lücke (29.03. Slot entfällt,
+  25.10. Slot doppelt) für den Ortsvergleich wird durch diese Scheibe NICHT behoben — nur die
+  Zone ändert sich, nicht die Prüfmethode. Behebung: #1777.
+- **Mehrzonen-Trips behalten den ADR-0044-Restfehler.** `anchor_tz`/`trip_local_now` treffen bei
+  einem Zonenwechsel zwischen zwei benachbarten Etappen am selben Tag ggf. die falsche Etappe —
+  bereits als akzeptierter Restfehler in ADR-0044 dokumentiert, hier geerbt, nicht neu
+  eingeführt.
+- **Rollout-Übergang beim Tageszähler ist für Nicht-Wien-Zonen grosszügiger, nie enger.** Jede
+  Zone ausser `Europe/Vienna` beginnt beim ersten Zugriff nach dem Rollout bei Zählerstand 0,
+  auch wenn am selben Wiener Tag bereits Alarme für ein Objekt in dieser Zone gesendet wurden.
+  Das erlaubt für den Rest dieses einen Tages potenziell mehr Alarme als das Limit vorsieht — nie
+  weniger. Das ist die sichere Richtung (kein blockierter Alarm) und einmalig auf den Rollout-Tag
+  begrenzt.
+- **Der Go-Cron bleibt Wien-getaktet** (`internal/config/config.go:20`) und fällt an
+  Umstellungstagen weiterhin aus/verdoppelt — unabhängig von dieser Scheibe, s. Abgrenzung.
+- **Dieselbe Präzisierung fehlt der Compare-Mail-Kopfzeile.** `compare_html.py:1535-1538` und
+  `comparison.py:216` greifen mit `locations[0]` zu und fallen bei einem unauflösbaren ersten Ort
+  ebenso still auf UTC — der Präzedenzfall, dem AC-15 folgt, trägt den Mangel selbst. Hier
+  bewusst NICHT mitrepariert (die Kopfzeile ist Darstellung, nicht Entscheidung, und ein
+  UTC-Zeitstempel dort ist sichtbar falsch statt still wirksam). Zu buchen als eigener Eintrag.
+- **Die Oberfläche nennt einen Referenzpunkt, keinen konkreten Zonennamen.** „Ortszeit der Tour"/
+  „Ortszeit des ersten Orts" sagt WOVON die Zeit abhängt, nicht WELCHE IANA-Zone konkret gilt
+  (z. B. „Europe/Paris"). Eine genauere Beschriftung wäre möglich, ist aber nicht Teil dieser
+  Scheibe (kein PO-Auftrag dafür vorliegend).
+- **Der manuelle `?hour=`-Testtrigger** bleibt an eine feste Referenz-Zone gebunden (Abschnitt D)
+  — für Presets mit mehreren Zonen gibt es dort strukturell keine EINE richtige Antwort auf
+  „Stunde X"; das Werkzeug ist für gezielte Einzeltests gedacht, nicht für einen
+  produktionsgetreuen Multi-Zonen-Lauf.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** ADR-0051, ADR-0044
+- **Rationale:** ADR-0051 (Status: Vorgeschlagen) formuliert in Regel 2 bereits „Die Zone gehört
+  an die Daten, nicht an den Server" — diese Spec ist die konkrete Anwendung dieser Regel auf
+  Ruhezeit, Tageszähler und Ortsvergleichs-Fälligkeit, kein neuer Grundsatz. ADR-0044 (Status:
+  Akzeptiert) listet beide betroffenen Module bisher als bewusste Ausnahme; diese Spec hebt die
+  Ausnahme auf und schreibt den ADR-Abschnitt „Umgesetzt" fort (AC-12). Ein NEUES ADR ist nicht
+  nötig: es entsteht keine neue Entscheidungsfläche, sondern die dritte praktische Umsetzung
+  einer bereits vorgeschlagenen Regel im Alarm-/Versandpfad, nach #1724 (Fälligkeit Trip) und
+  #1725 (Fälligkeitsfenster + Idempotenz Trip).
+
+## Changelog
+
+- 1.0 (2026-08-12): Initial spec created, aus `docs/context/fix-1726-ruhezeit-ortszone.md` auf
+  Basis der Vorlage `fix_1725_faelligkeit_und_idempotenz.md`. Korrektur gegenüber dem
+  Kontext-Dokument: die Zähler-Aufrufstellen sind ELF, nicht zehn (`compare_alert.py:151` ergänzt,
+  s. Entwurf Abschnitt C).

--- a/docs/specs/modules/fix_1726_ruhezeit_und_zaehler_ortszone.md
+++ b/docs/specs/modules/fix_1726_ruhezeit_und_zaehler_ortszone.md
@@ -13,7 +13,7 @@ tags: [issue-1726, epic-1722, timezone, adr-0051, adr-0044, alert-daily-limit, q
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-Freigabe („go") 2026-08-12, 15 ACs
 
 ## Purpose
 

--- a/frontend/src/lib/components/alerts-tab/AlertQuietHoursCard.svelte
+++ b/frontend/src/lib/components/alerts-tab/AlertQuietHoursCard.svelte
@@ -3,10 +3,14 @@
     import { Checkbox } from '$lib/components/ui/checkbox';
     import { Eyebrow } from '$lib/components/atoms';
 
+    // Issue #1726: `zonen_bezug` benennt, WOVON die Ortszeit abhängt — beim
+    // Trip „der Tour", beim Ortsvergleich „des ersten Orts". Reiner Text: welche
+    // IANA-Zone gilt, entscheidet das Backend (`anchor_tz`/`first_resolvable_tz`).
     let {
         quiet_from = $bindable<string | undefined>(undefined),
         quiet_to   = $bindable<string | undefined>(undefined),
-    }: { quiet_from?: string; quiet_to?: string } = $props();
+        zonen_bezug = 'der Tour',
+    }: { quiet_from?: string; quiet_to?: string; zonen_bezug?: string } = $props();
 
     let enabled = $state(quiet_from !== undefined && quiet_to !== undefined);
 
@@ -32,7 +36,7 @@
             data-testid="alert-quiet-hours-toggle"
         >Aktiv</Checkbox>
     </div>
-    <p class="hint">In diesem Zeitraum keine Alerts senden — gestaute Alerts gehen mit dem nächsten Morgen-Briefing mit.</p>
+    <p class="hint">In diesem Zeitraum keine Alerts senden (Ortszeit {zonen_bezug}) — gestaute Alerts gehen mit dem nächsten Morgen-Briefing mit.</p>
     {#if enabled}
         <div class="time-row">
             <label>

--- a/frontend/src/lib/components/shared/AlarmeTab.svelte
+++ b/frontend/src/lib/components/shared/AlarmeTab.svelte
@@ -425,10 +425,12 @@
 					<AlertCooldownCard bind:cooldown_minutes={cooldownMinutes} />
 				{/if}
 			{:else if id === 'quiet-hours'}
+				<!-- Issue #1726: EIN geteilter Baustein, zwei Bezugsgrössen — beim
+				     Vergleich gilt die Zone des erstgenannten Orts (#1378 AC-4). -->
 				{#if context === 'vergleich'}
-					<AlertQuietHoursCard bind:quiet_from={wiz!.alertQuietFrom} bind:quiet_to={wiz!.alertQuietTo} />
+					<AlertQuietHoursCard bind:quiet_from={wiz!.alertQuietFrom} bind:quiet_to={wiz!.alertQuietTo} zonen_bezug="des ersten Orts" />
 				{:else}
-					<AlertQuietHoursCard bind:quiet_from={quietFrom} bind:quiet_to={quietTo} />
+					<AlertQuietHoursCard bind:quiet_from={quietFrom} bind:quiet_to={quietTo} zonen_bezug="der Tour" />
 				{/if}
 			{:else if id === 'radar'}
 				<ChannelToggle

--- a/frontend/src/lib/components/shared/__tests__/alarme_tab_quiet_hours_zone_hinweis.test.ts
+++ b/frontend/src/lib/components/shared/__tests__/alarme_tab_quiet_hours_zone_hinweis.test.ts
@@ -1,0 +1,172 @@
+// TDD RED — Issue #1726 (AC-11): die Ruhezeit-Karte benennt ihre Zeit-Basis,
+// und zwar KONTEXTABHÄNGIG — beim Trip „Ortszeit der Tour", beim Ortsvergleich
+// „Ortszeit des ersten Orts". Heute nennt sie gar keine Zone; ehrlich wäre
+// derzeit „Wiener Zeit" (Kontext-Dokument, Risiko 10).
+//
+// Spec: docs/specs/modules/fix_1726_ruhezeit_und_zaehler_ortszone.md (AC-11, E)
+//
+// WARUM AlarmeTab UND NICHT NUR DIE KARTE: `AlertQuietHoursCard.svelte` ist der
+// Ort, an dem der Text steht — aber NICHT der Ort, an dem über den Kontext
+// entschieden wird. Das passiert an den beiden Mount-Punkten
+// (`shared/AlarmeTab.svelte:429/431`). Ein Test, der nur die Karte mit einer
+// von Hand gesetzten Prop rendert, wäre auch dann grün, wenn beide Mounts
+// denselben Text übergeben — Prüfort ≠ Wirkort. Deshalb wird der geteilte
+// Organism serverseitig gerendert (svelte/server, Hooks:
+// frontend/test-svelte-ssr-hooks.mjs), einmal je Kontext. Vorbild:
+// shared/__tests__/alarme_tab_premium_sms_channel_row_render.test.ts (#1745 A).
+//
+// 🔴 SSR FÜHRT `onMount` NIE AUS. Der Tarif-Fetch in AlarmeTab läuft dort also
+// nicht — `profileOverride` wird deshalb explizit gesetzt (Testhaken aus
+// #1745 A), damit der Rendervorgang nicht am fehlenden Profil hängt.
+//
+// RED HEUTE: `AlertQuietHoursCard` hat keine Prop für die Zonen-Bezeichnung und
+// gibt in beiden Kontexten denselben Hinweistext aus — weder „Tour" noch
+// „erste" taucht im Kartenbereich auf, und beide Kontexte liefern dieselbe
+// Zeichenkette.
+//
+// Pfadregel #1409: Prüfling relativ zu DIESER Datei auflösen.
+//
+// Ausführen:
+//   cd frontend && node --import ./test-lib-loader.mjs --experimental-strip-types --test \
+//     src/lib/components/shared/__tests__/alarme_tab_quiet_hours_zone_hinweis.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { register } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// __tests__ -> shared -> components -> lib -> src -> frontend
+const FRONTEND = path.resolve(HERE, '../../../../..');
+
+register(
+	pathToFileURL(path.join(FRONTEND, 'test-svelte-ssr-hooks.mjs')).href,
+	pathToFileURL(FRONTEND + '/').href
+);
+
+const { render } = await import('svelte/server');
+const AlarmeTab = (
+	await import(pathToFileURL(path.join(FRONTEND, 'src/lib/components/shared/AlarmeTab.svelte')).href)
+).default;
+
+const TRIP = {
+	id: 'trip-1726',
+	name: 'Karnischer Höhenweg',
+	stages: [],
+	alert_rules: [],
+	display_config: {},
+	report_config: { send_email: true, send_telegram: true, send_sms: false },
+	alert_quiet_from: '22:00',
+	alert_quiet_to: '07:00'
+};
+
+/** Wizard-Stellvertreter mit den Feldern, die AlarmeTab im vergleich-Zweig
+ *  liest (plain object — SSR braucht keine Runen). */
+function wizStub(): Record<string, unknown> {
+	return {
+		officialWarningsEnabled: true,
+		radarAlertEnabled: false,
+		activeMetricKeys: null,
+		metricAlertLevels: {},
+		sendTelegram: true,
+		sendSms: false,
+		sendPremiumSms: false,
+		channelThresholds: {},
+		telegramStyle: 'rich',
+		alertCooldownMinutes: 30,
+		alertQuietFrom: '22:00',
+		alertQuietTo: '07:00'
+	};
+}
+
+const PROFIL = { premium_sms_allowed: false };
+
+function renderRoute(): string {
+	return render(AlarmeTab, {
+		props: {
+			context: 'route',
+			trip: TRIP,
+			activeMetrics: [],
+			metricLevels: {},
+			existingChannels: { email: true, telegram: true, sms: false },
+			profileOverride: PROFIL
+		}
+	}).body;
+}
+
+function renderVergleich(): string {
+	return render(AlarmeTab, {
+		props: {
+			context: 'vergleich',
+			wiz: wizStub(),
+			catalog: [],
+			profileOverride: PROFIL
+		}
+	}).body;
+}
+
+/** Schneidet GENAU den Bereich der Ruhezeit-Karte aus dem gerenderten HTML.
+ *
+ *  Die Begrenzung ist wichtig, nicht kosmetisch: ein zu grosszügiger Ausschnitt
+ *  nimmt die nachfolgende Beispiel-Sektion mit, deren Inhalt sich zwischen den
+ *  Kontexten ohnehin unterscheidet — der Vergleich „beide Kontexte liefern
+ *  NICHT denselben Text" wäre dann strukturell immer grün und bewachte nichts.
+ */
+function quietCardHtml(body: string): string {
+	const marker = 'data-testid="alert-quiet-hours-card"';
+	const start = body.indexOf(marker);
+	assert.notEqual(start, -1, 'Die Ruhezeit-Karte fehlt im gerenderten Alarme-Reiter.');
+	const next = body.indexOf('class="alarme-section', start);
+	return next === -1 ? body.slice(start) : body.slice(start, next);
+}
+
+describe('#1726 AC-11 — Ruhezeit-Karte nennt ihre Zonen-Basis', () => {
+	test('Trip-Kontext nennt die Ortszeit der Tour', () => {
+		const karte = quietCardHtml(renderRoute());
+
+		assert.match(
+			karte,
+			/Ortszeit/,
+			'Im Trip-Kontext muss die Karte sagen, auf welche Ortszeit sich die ' +
+				'Ruhezeit bezieht — heute nennt sie gar keine Zone.'
+		);
+		assert.match(
+			karte,
+			/Tour/,
+			'Beim Trip ist die Bezugsgrösse die Tour ("Ortszeit der Tour").'
+		);
+	});
+
+	test('Vergleichs-Kontext nennt die Ortszeit des ersten Orts', () => {
+		const karte = quietCardHtml(renderVergleich());
+
+		assert.match(
+			karte,
+			/Ortszeit/,
+			'Auch im Ortsvergleich muss die Zeit-Basis benannt sein.'
+		);
+		assert.match(
+			karte,
+			/ersten Orts/,
+			'Beim Ortsvergleich gilt die Zone des erstgenannten Orts (#1378 AC-4) ' +
+				'— genau das muss dort stehen.'
+		);
+	});
+
+	test('beide Kontexte liefern NICHT denselben Text', () => {
+		// Der eigentliche Wirkungsnachweis: ein hart auf einen Kontext
+		// verdrahteter Text (die Verfälschung aus der Nachweis-Strategie)
+		// fällt hier auf, auch wenn beide Einzelprüfungen oben zufällig
+		// zuträfen.
+		const route = quietCardHtml(renderRoute());
+		const vergleich = quietCardHtml(renderVergleich());
+
+		assert.notEqual(
+			route,
+			vergleich,
+			'Trip und Ortsvergleich beziehen sich auf verschiedene Zonen — der ' +
+				'Hinweistext darf nicht in beiden Mounts identisch sein.'
+		);
+	});
+});

--- a/src/services/alert_daily_limit.py
+++ b/src/services/alert_daily_limit.py
@@ -6,8 +6,12 @@ Persistiert einen pro-Nutzer-Tageszähler proaktiver Alerts (Deviation +
 Radar/Onset + Compare, Issue #1213) unter
 ``<get_data_dir(user_id)>/alert_daily_count.json`` (respektiert
 `GZ_DATA_DIR`/`_DATA_ROOT`, #1133). Reset erfolgt bei Kalendertag-Wechsel in
-Europe/Vienna (nicht UTC). ``now`` ist durchgehend Funktionsparameter — kein
-``datetime.now()`` in diesem Modul.
+der ORTSZONE des Gegenstands (Issue #1726) — ein Zaehler JE ZONE:
+``{"zones": {"Europe/Vienna": {"date": "2026-08-12", "count": 2}, ...}}``.
+Bewusster Preis: wer Objekte in drei Zonen hat, bekommt das Kontingent
+dreimal. Die Alternative (EIN Datensatz, jeder Aufrufer bringt seine Zone mit)
+schriebe ``date`` zwischen zwei Kalendertagen hin und her — ``increment()``
+setzt bei Nichttreffer auf 1 zurueck, das Limit griffe NIE.
 """
 from __future__ import annotations
 
@@ -19,8 +23,12 @@ from pathlib import Path
 from zoneinfo import ZoneInfo
 
 from services.user_tier import daily_alert_limit
+from utils.timezone import local_dt
 
-VIENNA = ZoneInfo("Europe/Vienna")
+#: Zone, unter der ein Zaehler im ALTEN Schema (Top-Level ``date``/``count``)
+#: uebernommen wird: der Altbestand wurde de facto nach Wiener Kalendertag
+#: gefuehrt. Jede andere Zone beginnt bei 0 — grosszuegiger, nie enger.
+_LEGACY_ZONE_KEY = "Europe/Vienna"
 
 
 def _counter_path(user_id: str) -> Path:
@@ -28,26 +36,49 @@ def _counter_path(user_id: str) -> Path:
     return get_data_dir(user_id) / "alert_daily_count.json"
 
 
-def _vienna_date_str(now: datetime) -> str:
-    return now.astimezone(VIENNA).date().isoformat()
+def _local_date_str(now: datetime, zone: ZoneInfo) -> str:
+    return local_dt(now, zone).date().isoformat()
 
 
-def load(user_id: str, now: datetime) -> int:
-    """Return the current alert count for the Vienna-calendar-day of `now`.
-
-    Pure read: if the stored date does not match today's Vienna date, this
-    returns 0 WITHOUT writing anything (reset is load-only semantics).
-    """
-    path = _counter_path(user_id)
+def _load_zones(path: Path) -> dict:
+    """Alle Zonen-Zaehler der Datei, Alt-Schema eingeschlossen. Grundlage des
+    Merge auf ZONEN-Ebene (Projektregel): der Aufrufer bekommt IMMER den ganzen
+    Bestand und schreibt nur seinen Schluessel neu. Die Migration ist idempotent
+    und geschieht beim naechsten Zugriff."""
     if not path.exists():
-        return 0
+        return {}
     try:
         data = json.loads(path.read_text())
     except (json.JSONDecodeError, OSError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    zones = data.get("zones")
+    if isinstance(zones, dict):
+        return zones
+    if data.get("date"):
+        return {_LEGACY_ZONE_KEY: {"date": data["date"], "count": data.get("count", 0)}}
+    return {}
+
+
+def _count_for(zones: dict, zone: ZoneInfo, today: str) -> int:
+    entry = zones.get(str(zone))
+    if not isinstance(entry, dict) or entry.get("date") != today:
         return 0
-    if data.get("date") != _vienna_date_str(now):
+    try:
+        return int(entry.get("count", 0))
+    except (TypeError, ValueError):
         return 0
-    return int(data.get("count", 0))
+
+
+def load(user_id: str, now: datetime, zone: ZoneInfo) -> int:
+    """Zaehlerstand fuer den Kalendertag von `now` IN `zone`. Pure read: passt
+    der gespeicherte Tag nicht zum Ortstag, liefert die Funktion 0, OHNE etwas
+    zu schreiben. `zone` ist PFLICHT — ein Default waere ein stiller Rueckfall
+    auf eine geratene Zone, also genau der behobene Fehler."""
+    return _count_for(
+        _load_zones(_counter_path(user_id)), zone, _local_date_str(now, zone)
+    )
 
 
 # Issue #1555: feste Reserve-Tabelle je endlichem `limit`-Wert. Reserviert
@@ -58,8 +89,10 @@ def load(user_id: str, now: datetime) -> int:
 _FORECAST_CHANGE_RESERVE = {2: 1, 4: 2}
 
 
-def is_allowed(user_id: str, now: datetime, reason: str | None = None) -> bool:
-    """Return True if another alert may be sent today for this user.
+def is_allowed(
+    user_id: str, now: datetime, zone: ZoneInfo, reason: str | None = None
+) -> bool:
+    """Return True if another alert may be sent today for this user IN `zone`.
 
     `reason="forecast_change"` prüft bei endlichem `limit` gegen eine um die
     NowCast-Reserve reduzierte Obergrenze (#1555). Jeder andere `reason`
@@ -71,31 +104,27 @@ def is_allowed(user_id: str, now: datetime, reason: str | None = None) -> bool:
     effective_limit = limit
     if reason == "forecast_change":
         effective_limit = limit - _FORECAST_CHANGE_RESERVE.get(limit, 0)
-    return load(user_id, now) < effective_limit
+    return load(user_id, now, zone) < effective_limit
 
 
-def increment(user_id: str, now: datetime) -> None:
-    """Read-modify-write the daily counter, resetting on a new Vienna day.
+def increment(user_id: str, now: datetime, zone: ZoneInfo) -> None:
+    """Read-modify-write des Zaehlers DIESER Zone, Reset am dortigen Ortstag.
 
     Issue #1213: atomarer Write (tmp-Datei + `os.replace`) statt direktem
     `write_text` — verhindert einen halb geschriebenen/korrupten Zähler bei
-    gleichzeitigem Zugriff (Scheduler + API).
+    gleichzeitigem Zugriff (Scheduler + API). Issue #1726: geschrieben wird der
+    GESAMTE Zonen-Bestand zurueck, nur mit dem eigenen Schluessel erhoeht —
+    Merge auf Zonen-Ebene, nicht bloss auf Datei-Ebene.
     """
     path = _counter_path(user_id)
-    today = _vienna_date_str(now)
-    count = 0
-    if path.exists():
-        try:
-            data = json.loads(path.read_text())
-            if data.get("date") == today:
-                count = int(data.get("count", 0))
-        except (json.JSONDecodeError, OSError):
-            count = 0
+    today = _local_date_str(now, zone)
+    zones = _load_zones(path)
+    zones[str(zone)] = {"date": today, "count": _count_for(zones, zone, today) + 1}
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=".alert_daily_count_", suffix=".tmp")
     try:
         with os.fdopen(fd, "w") as f:
-            f.write(json.dumps({"date": today, "count": count + 1}))
+            f.write(json.dumps({"zones": zones}))
         os.replace(tmp_name, path)
     except OSError:
         if os.path.exists(tmp_name):

--- a/src/services/alert_gate.py
+++ b/src/services/alert_gate.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 from typing import NamedTuple, Optional
+from zoneinfo import ZoneInfo
 
 from services import alert_daily_limit, alert_log
 from services.deviation_alert_engine import DeviationAlertEngine
@@ -78,6 +79,7 @@ def check_nowcast_gate(
     quiet_to: Optional[str],
     context_label: str,
     now: datetime,
+    zone: ZoneInfo,
     daily_limit_reason: str = "nowcast",
     throttle_store: Optional[ThrottleStore] = None,
 ) -> GateResult:
@@ -89,9 +91,12 @@ def check_nowcast_gate(
     Compare-eigener Grund waere zwar heute gleichwertig, verloere den Schutz
     aber still, sobald die Reserve-Tabelle waechst. Beide Nowcast-Pfade
     benutzen deshalb denselben Grund.
-    """
+
+    Issue #1726: `zone` ist PFLICHT und geht an BEIDE zonenabhaengigen Stufen —
+    Ruhezeit UND Tages-Obergrenze. Die Schranke hat kein eigenes Objekt im Scope
+    (geteilt Trip+Vergleich), deshalb liefern ihre zwei Aufrufer die Zone."""
     if DeviationAlertEngine.is_quiet_hours(
-        now, quiet_from, quiet_to, context_label=context_label
+        now, quiet_from, quiet_to, zone, context_label=context_label
     ):
         logger.debug("Nowcast-Alarm unterdrueckt (Ruhezeit) fuer %s", context_label)
         return GateResult(False, alert_log.REASON_QUIET_HOURS)
@@ -102,7 +107,7 @@ def check_nowcast_gate(
         logger.debug("Nowcast-Alarm unterdrueckt (Sperrzeit) fuer %s", context_label)
         return GateResult(False, alert_log.REASON_COOLDOWN)
 
-    if not alert_daily_limit.is_allowed(user_id, now, reason=daily_limit_reason):
+    if not alert_daily_limit.is_allowed(user_id, now, zone, reason=daily_limit_reason):
         logger.debug(
             "Nowcast-Alarm unterdrueckt (Tages-Obergrenze) fuer %s", context_label
         )
@@ -117,8 +122,12 @@ def record_nowcast_sent(
     throttle_scope: str,
     throttle_key: str,
     now: datetime,
+    zone: ZoneInfo,
     throttle_store: Optional[ThrottleStore] = None,
 ) -> None:
-    """Tageszaehler und Sperrzeit buchen — NUR nach erfolgreicher Zustellung."""
-    alert_daily_limit.increment(user_id, now)
+    """Tageszaehler und Sperrzeit buchen — NUR nach erfolgreicher Zustellung.
+    #1726: `zone` ist PFLICHT; wer hier eine andere uebergibt als
+    `check_nowcast_gate()`, fuellt einen anderen Zaehler als den geprueften.
+    """
+    alert_daily_limit.increment(user_id, now, zone)
     _resolve_store(user_id, throttle_store).record(throttle_scope, throttle_key, now)

--- a/src/services/compare_alert.py
+++ b/src/services/compare_alert.py
@@ -36,6 +36,7 @@ from services.notification_service import NotificationService
 from services.point_weather import AlertEvaluationConfig
 from services.report_config_resolver import resolve_compare_time_window
 from services.throttle_store import ThrottleStore
+from utils.timezone import first_resolvable_tz
 
 logger = logging.getLogger("compare_alert")
 
@@ -145,14 +146,20 @@ class CompareAlertService:
                 logger.debug(f"Compare-Alert cooldown active for preset {preset_id}")
                 continue
 
+            # Issue #1726: die Konfiguration entsteht VOR der Tageslimit-Frage,
+            # weil sie die Ortszone traegt — Ruhezeit, Zaehler und Engine
+            # benutzen danach DIESELBE Aufloesung. Reine Vorverlegung eines
+            # seiteneffektfreien Erbauers, kein Verhaltenswechsel.
+            config = self._build_eval_config(preset, cooldown_minutes, all_locations)
+
             # Issue #1213 (AC-6): Compare an dieselbe Tageslimit-Prüfung
             # anbinden wie der Trip-Pfad (Epic #1067 Slice 3, #1070).
             # Issue #1555: reason="forecast_change" reserviert einen Anteil für NowCast.
-            if not alert_daily_limit.is_allowed(self._user_id, now, reason="forecast_change"):
+            if not alert_daily_limit.is_allowed(
+                self._user_id, now, config.zone, reason="forecast_change",
+            ):
                 logger.debug(f"Compare-Alert suppressed: daily limit reached for preset {preset_id}")
                 continue
-
-            config = self._build_eval_config(preset, cooldown_minutes)
 
             # Issue #1467 S2 AG2: Ruhezeit VOR den Wetterabruf ziehen — bisher
             # prüfte nur die Engine (`DeviationAlertEngine.evaluate()`), NACH
@@ -174,7 +181,8 @@ class CompareAlertService:
             # Aufrufstelle: der Schutz gehört in den geteilten Baustein
             # (ADR-0021), nicht in eine vierte Kopie.
             quiet_hours_active = DeviationAlertEngine.is_quiet_hours(
-                now, config.quiet_from, config.quiet_to, context_label=preset_id
+                now, config.quiet_from, config.quiet_to, config.zone,
+                context_label=preset_id,
             )
             if quiet_hours_active:
                 logger.debug(f"Compare-Alert quiet hours active for preset {preset_id}")
@@ -290,7 +298,7 @@ class CompareAlertService:
 
             self._finalize_triggered_state(finalized)
             self._throttle_store.record("compare_preset", preset_id, now)
-            alert_daily_limit.increment(self._user_id, now)
+            alert_daily_limit.increment(self._user_id, now, config.zone)
             sent += 1
 
         return sent
@@ -449,7 +457,9 @@ class CompareAlertService:
                 }
             entry["state_svc"].save(entry["entity_id"], alert_state)
 
-    def _build_eval_config(self, preset: dict, cooldown_minutes) -> AlertEvaluationConfig:
+    def _build_eval_config(
+        self, preset: dict, cooldown_minutes, all_locations: dict,
+    ) -> AlertEvaluationConfig:
         """B2-Defaults, vorwärtskompatible Overrides via `preset.get(feld, DEFAULT)`.
 
         Issue #1467 S2 AG4: die Kanalliste war hier fest `{"email"}` verdrahtet —
@@ -475,6 +485,12 @@ class CompareAlertService:
             ),
             channels=effective_compare_channels(preset, self._settings, self._user_id),
             display_config=self._display_config_from_active_metrics(preset),
+            # Issue #1726: Zone des ERSTEN aufloesbaren Orts (#1378 AC-4,
+            # AC-15) — die EINE Stelle, an der der Vergleich sie bildet.
+            zone=first_resolvable_tz(
+                (all_locations.get(lid) for lid in preset.get("location_ids") or []),
+                context_label=preset.get("id", ""),
+            ),
         )
 
     def _display_config_from_active_metrics(self, preset: dict):

--- a/src/services/compare_official_alert.py
+++ b/src/services/compare_official_alert.py
@@ -43,6 +43,7 @@ from services.compare_alert_guard import is_silenced
 from services.deviation_alert_engine import DeviationAlertEngine
 from services.notification_service import NotificationService
 from services.official_alerts import get_official_alerts_for_location
+from utils.timezone import first_resolvable_tz
 
 logger = logging.getLogger("compare_official_alert")
 
@@ -114,12 +115,19 @@ class CompareOfficialAlertService:
                 return False
         elif not preset.get("official_alert_triggers_enabled", True):
             return False
+        # Issue #1726: Ruhezeit UND Tageszaehler laufen auf der Ortszeit des
+        # ERSTEN aufloesbaren Orts (#1378 AC-4, AC-15) — EINE Aufloesung fuer
+        # beide Stufen, damit sie nicht auseinanderfallen.
+        zone = first_resolvable_tz(
+            (all_locations.get(lid) for lid in location_ids), context_label=preset_id,
+        )
         # #1233: Ruhezeit unterdrueckt frueh -> kein State-Verbrauch der Warnung,
         # damit sie nach Ende der Ruhezeit noch als "neu" zugestellt wird (AC-2).
         if DeviationAlertEngine.is_quiet_hours(
             datetime.now(timezone.utc),
             preset.get("alert_quiet_from"),
             preset.get("alert_quiet_to"),
+            zone,
             context_label=preset_id,
         ):
             logger.debug(f"Compare official alert quiet hours active for preset {preset_id}")
@@ -135,7 +143,7 @@ class CompareOfficialAlertService:
             return False
 
         now = datetime.now(timezone.utc)
-        if not alert_daily_limit.is_allowed(self._user_id, now):
+        if not alert_daily_limit.is_allowed(self._user_id, now, zone):
             logger.debug(f"Compare official alert suppressed: daily limit for preset {preset_id}")
             return False
 
@@ -179,7 +187,7 @@ class CompareOfficialAlertService:
             return False
 
         self._record_state(preset_id, per_location_new)
-        alert_daily_limit.increment(self._user_id, now)
+        alert_daily_limit.increment(self._user_id, now, zone)
         return True
 
     def _detect(

--- a/src/services/compare_radar_alert.py
+++ b/src/services/compare_radar_alert.py
@@ -28,6 +28,7 @@ from app.loader import compare_preset_to_dict, load_all_locations, load_compare_
 from services import alert_channel_threshold, alert_log
 import services.alert_urgency as alert_urgency
 from services.alert_gate import check_nowcast_gate, record_nowcast_sent
+from utils.timezone import first_resolvable_tz
 from services.alert_state import AlertStateService
 from services.compare_alert_channels import effective_compare_channels
 from services.compare_alert_guard import is_silenced
@@ -128,6 +129,12 @@ class CompareRadarAlertService:
         # eigenen Cooldown (presetseigene Datei `compare_radar_alert_throttle.json`)
         # und die Ruhezeit-Pruefung NACH der Erkennung; die Tages-Obergrenze
         # fehlte hier bisher vollstaendig.
+        # Issue #1726: Ortszeit des ERSTEN aufloesbaren Orts (#1378 AC-4,
+        # AC-15). Dieselbe Zone geht in die Buchung — sonst pruefte die
+        # Schranke einen anderen Zaehler als sie fuellt.
+        zone = first_resolvable_tz(
+            (all_locations.get(lid) for lid in location_ids), context_label=preset_id,
+        )
         gate = check_nowcast_gate(
             user_id=self._user_id,
             throttle_scope=_THROTTLE_SCOPE,
@@ -137,6 +144,7 @@ class CompareRadarAlertService:
             quiet_to=preset.get("alert_quiet_to"),
             context_label=preset_id,
             now=datetime.now(timezone.utc),
+            zone=zone,
         )
         if not gate.allowed:
             # Die Protokollierung darf den Stapellauf NIE mitreissen: ein
@@ -218,6 +226,7 @@ class CompareRadarAlertService:
         record_nowcast_sent(
             user_id=self._user_id, throttle_scope=_THROTTLE_SCOPE,
             throttle_key=preset_id, now=datetime.now(timezone.utc),
+            zone=zone,
         )
         return True
 

--- a/src/services/compare_slot_scheduler.py
+++ b/src/services/compare_slot_scheduler.py
@@ -8,7 +8,7 @@ Reine Funktionen (kein IO, kein globaler State):
   rohen Preset-Dict. Fehlt `morning_time` (Marker "nie migriert"), greift
   die Migrations-Fallback-Tabelle aus der Spec (abhaengig vom Alt-Wert von
   `schedule`).
-- `presets_due_for_hour(presets, hour, today)` liefert je faelligem Preset
+- `presets_due_for_hour(presets, all_locations, now_utc)` liefert je faelligem Preset
   ein `DuePreset(preset, target_date, tage_ab_ortstag)` (Morgen-Slot -> today
   bzw. Versatz 0, Abend-Slot -> today+1 bzw. Versatz +1), inkl. Pause-
   (`schedule == "manual"`), Archiv- (`archived_at`) und Laufzeit-Guard
@@ -17,10 +17,11 @@ Reine Funktionen (kein IO, kein globaler State):
 from __future__ import annotations
 
 import logging
-from datetime import date, time as dt_time, timedelta
+from datetime import date, datetime, time as dt_time, timedelta
 from typing import NamedTuple
 
 from services.compare_alert_guard import is_silenced
+from utils.timezone import first_resolvable_tz, local_dt
 
 logger = logging.getLogger("scheduler.compare_slot")
 
@@ -99,9 +100,17 @@ def resolve_preset_slots(preset: dict) -> PresetSlots:
     return PresetSlots(morning_enabled, morning_time, evening_enabled, evening_time)
 
 
-def presets_due_for_hour(presets: list, hour: int, today: date) -> list:
+def presets_due_for_hour(presets: list, all_locations: dict, now_utc: datetime) -> list:
     """Liefert je faelligem Preset ein `DuePreset`-Tripel
     `(preset, target_date, tage_ab_ortstag)`.
+
+    Issue #1726: JEDES Preset wird gegen SEINE eigene Ortszone geprueft (die
+    seines ersten aufloesbaren Orts, `first_resolvable_tz`). Bis dahin galten
+    EINE Stunde und EIN Tag aus einer festen Zone fuer den ganzen Lauf — ein auf
+    07:00 gestelltes Preset mit Orten in Neuseeland ging zur falschen Weltzeit
+    raus. Preset-eigene Zonen sind mit einem globalen Zeitpunkt nicht abbildbar,
+    deshalb Ortsliste + ZEITPUNKT statt Stunde/Tag; die Pruefung selbst bleibt
+    Stundengleichheit (Fenster/Idempotenz traegt #1777).
 
     Guards (in dieser Reihenfolge): stillgelegt laut
     `compare_alert_guard.is_silenced` — `paused_at` gesetzt ODER
@@ -125,6 +134,13 @@ def presets_due_for_hour(presets: list, hour: int, today: date) -> list:
         if is_silenced(preset):
             continue
 
+        preset_id = preset.get("id", "?")
+        vor_ort = local_dt(now_utc, first_resolvable_tz(
+            (all_locations.get(lid) for lid in preset.get("location_ids") or []),
+            context_label=preset_id,
+        ))
+        hour, today = vor_ort.hour, vor_ort.date()
+
         try:
             end_date_str = preset.get("end_date")
             if end_date_str:
@@ -144,7 +160,7 @@ def presets_due_for_hour(presets: list, hour: int, today: date) -> list:
             logger.warning(
                 "Preset %s: korrupte Zeitplan-Daten (end_date/morning_time/"
                 "evening_time), wird uebersprungen: %s",
-                preset.get("id", "?"),
+                preset_id,
                 e,
             )
             continue

--- a/src/services/deviation_alert_engine.py
+++ b/src/services/deviation_alert_engine.py
@@ -25,10 +25,9 @@ from zoneinfo import ZoneInfo
 from app.models import ChangeSeverity, GPXPoint, WeatherChange
 from services.point_weather import AlertEvaluationConfig, PointWeatherData
 from services.weather_change_detection import WeatherChangeDetectionService
+from utils.timezone import UTC, local_dt
 
 logger = logging.getLogger(__name__)
-
-VIENNA = ZoneInfo("Europe/Vienna")  # Vorbild alert_daily_limit.py:21
 
 
 @dataclass
@@ -85,20 +84,18 @@ class DeviationAlertEngine:
         now: datetime,
         quiet_from: Optional[str],
         quiet_to: Optional[str],
+        zone: ZoneInfo,
         context_label: str = "",
     ) -> bool:
-        """Prüft, ob `now` (in Europe/Vienna-Lokalzeit) innerhalb des
+        """Prüft, ob `now` (in der ORTSZEIT von `zone`) innerhalb des
         konfigurierten Ruhezeit-Fensters liegt — inkl. Mitternachts-Wrap.
 
-        Issue #1312 (Scheibe D1): `now` wird VOR dem Vergleich nach
-        Europe/Vienna konvertiert, weil Nutzer die Uhrzeiten in gefühlter
-        Lokalzeit eingeben. Naive datetimes (kein tzinfo) werden als UTC
-        interpretiert (konservativ, deckungsgleich mit dem bisherigen
-        De-facto-Verhalten aller sechs Aufrufer). DST wird durch ZoneInfo
-        automatisch korrekt behandelt (Sommer +2h, Winter +1h). Vorbild:
-        `alert_daily_limit.py` (dieselbe Konvention für den
-        Tageszähler-Reset). Mitternachts-Wrap-Logik unverändert aus
-        `TripAlertService._is_quiet_hours()` übernommen.
+        Issue #1726: `zone` ist PFLICHT, ohne Default. Bis dahin rechnete die
+        Funktion fest in `Europe/Vienna` — ein Alarm um 03:00 Neuseeland-Zeit
+        ging mitten in der Nacht durch, weil er auf Wiener Uhr tagsüber lag
+        (ADR-0051 Regel 2); ein Wien-Rückfall waere dieselbe Fehlerklasse, nur
+        leiser. Umrechnung ueber `utils.timezone.local_dt` (naiv = UTC, #1345),
+        Mitternachts-Wrap unveraendert.
 
         Issue #1479 (Wurzel-Härtung): ein unbrauchbarer Ruhezeit-Wert gilt als
         „keine Ruhezeit gesetzt" (`False`) statt eine Ausnahme an den Aufrufer
@@ -108,8 +105,7 @@ class DeviationAlertEngine:
         """
         if not quiet_from or not quiet_to:
             return False
-        aware_now = now if now.tzinfo is not None else now.replace(tzinfo=timezone.utc)
-        local_now = aware_now.astimezone(VIENNA)
+        local_now = local_dt(now, zone)
         try:
             from_time = time_type.fromisoformat(quiet_from)
             to_time = time_type.fromisoformat(quiet_to)
@@ -283,7 +279,12 @@ class DeviationAlertEngine:
         """
         now = now or datetime.now(timezone.utc)
 
-        if self.is_quiet_hours(now, config.quiet_from, config.quiet_to):
+        # Issue #1726: Zone aus der Konfiguration, die der Adapter aus SEINEM
+        # Gegenstand aufgeloest hat. Ohne Zone gilt Weltzeit — sichtbar hier,
+        # statt als geratene Zone irgendwo im Kern.
+        if self.is_quiet_hours(
+            now, config.quiet_from, config.quiet_to, config.zone or UTC
+        ):
             return EvaluationResult(triggered=False, suppressed_reason="quiet_hours")
 
         active_detector = self._select_detector(config)

--- a/src/services/dispatch_orchestrator.py
+++ b/src/services/dispatch_orchestrator.py
@@ -120,30 +120,28 @@ class CompareDispatchStrategy:
     def empty_result(self) -> tuple[int, int]:
         return (0, 0)
 
-    #: Issue #1726 (offen): der Ortsvergleich entscheidet Faelligkeit weiterhin
-    #: an dieser festen Zone. Sie steht hier SICHTBAR statt versteckt, weil die
-    #: zugehoerige Produktfrage offen ist -- welche Zone gilt bei einem
-    #: Vergleich ueber Orte in mehreren Zonen? Das ist eine Entscheidung, keine
-    #: Ableitung, und wird nicht nebenbei in #1724 getroffen.
-    NOCH_NICHT_ORTSZEIT_SIEHE_1726 = "Europe/Vienna"
+    #: Referenz-Zone des manuellen `?hour=`-Testausloesers
+    #: (`scheduler_dispatch_service.run_compare_presets_daily`) -- reines
+    #: Ops-/Debug-Werkzeug ohne Preset-Bezug. Die FAELLIGKEIT selbst haengt
+    #: seit #1726 an der Ortszone des jeweiligen Presets, nicht mehr hier.
+    MANUAL_TRIGGER_REFERENCE_ZONE = "Europe/Vienna"
 
     def collect_due(self, now_utc: "datetime") -> list:
-        from zoneinfo import ZoneInfo
-
+        from app.loader import load_all_locations
         from services.compare_slot_scheduler import presets_due_for_hour
         from services.scheduler_dispatch_service import _load_presets_for_dispatch
-        from utils.timezone import local_dt
 
         presets = _load_presets_for_dispatch(self._user_id, self._data_root)
         if presets is None:
             return []
         self._presets = presets
-        # Verhaltensgleich zum Stand vor #1724: Stunde UND Kalendertag aus
-        # derselben festen Zone -- vorher kam die Stunde vom Aufrufer und der
-        # Tag aus `date.today()` (Prozess-Zeitzone). Beide jetzt aus EINER
-        # Ableitung, damit sie an der Tagesgrenze nicht auseinanderfallen.
-        vor_ort = local_dt(now_utc, ZoneInfo(self.NOCH_NICHT_ORTSZEIT_SIEHE_1726))
-        return presets_due_for_hour(presets, vor_ort.hour, vor_ort.date())
+        # Issue #1726: jedes Preset wird gegen die Ortszone SEINES ersten
+        # aufloesbaren Orts geprueft -- ein globaler `vor_ort` kann das nicht
+        # abbilden. Ortsliste deshalb vorab laden (bisher lazy) und mitgeben.
+        if self._all_locations is None:
+            self._all_locations = load_all_locations(user_id=self._user_id)
+        by_id = {loc.id: loc for loc in self._all_locations}
+        return presets_due_for_hour(presets, by_id, now_utc)
 
     def pre_pass(self, now_utc: "datetime", due: list) -> None:
         # Issue #1250 Scheibe 3 (AC-10/AC-11/AC-12): Auto-Pause fuer Presets

--- a/src/services/point_weather.py
+++ b/src/services/point_weather.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from typing import TYPE_CHECKING, List, Optional, Protocol, Set
+from zoneinfo import ZoneInfo
 
 if TYPE_CHECKING:
     from app.models import (
@@ -69,6 +70,10 @@ class AlertEvaluationConfig:
     # Eintrag). None = kein Backfill (Abwärtskompatibilität für generische
     # Aufrufer ohne Weather-Tab-Kontext, z. B. reine metric_alert_levels-Nutzung).
     display_config: Optional["UnifiedWeatherDisplayConfig"] = None
+    # Issue #1726: Ortszone des Gegenstands fuer die Ruhezeit-Pruefung (Trip:
+    # `anchor_tz`, Vergleich: `first_resolvable_tz`). `None` = der Erbauer
+    # kennt keine; die Engine rechnet dann in Weltzeit statt zu raten.
+    zone: Optional[ZoneInfo] = None
 
 
 class LocationWeatherSource(Protocol):

--- a/src/services/scheduler_dispatch_service.py
+++ b/src/services/scheduler_dispatch_service.py
@@ -163,19 +163,20 @@ def run_compare_presets_daily(
 
     from services.dispatch_orchestrator import CompareDispatchStrategy, run_briefing_dispatch
 
-    # Issue #1724: der Orchestrator nimmt jetzt einen ZEITPUNKT statt einer
-    # Stunde -- welche Stunde das ist, entscheidet der jeweilige Versandweg.
-    # Der Ortsvergleich bleibt dabei bewusst auf seiner festen Zone (#1726),
-    # das Verhalten ist unveraendert.
+    # Issue #1724: der Orchestrator nimmt einen ZEITPUNKT statt einer Stunde.
+    # Issue #1726: die Faelligkeit haengt jetzt je Preset an der Ortszone
+    # seines ersten Orts; nur der manuelle `?hour=`-Testausloeser bleibt an
+    # einer festen Referenz-Zone verankert -- "Stunde X" hat sonst keine EINE
+    # Bedeutung mehr. Verhalten des Endpunkts unveraendert.
     if hour is None:
         now_utc = _datetime.now(_timezone.utc)
     else:
         # Manuelles Ausloesen mit ausdruecklicher Stunde: Zeitpunkt bilden,
-        # dessen Stunde in der Vergleichs-Zone genau `hour` ist -- damit
-        # bleibt der bestehende Endpunkt-Vertrag (`?hour=`) erhalten.
+        # dessen Stunde in der Referenz-Zone genau `hour` ist -- damit bleibt
+        # der bestehende Endpunkt-Vertrag (`?hour=`) erhalten.
         from zoneinfo import ZoneInfo
 
-        zone = ZoneInfo(CompareDispatchStrategy.NOCH_NICHT_ORTSZEIT_SIEHE_1726)
+        zone = ZoneInfo(CompareDispatchStrategy.MANUAL_TRIGGER_REFERENCE_ZONE)
         now_utc = _datetime.now(zone).replace(
             hour=hour, minute=0, second=0, microsecond=0,
         ).astimezone(_timezone.utc)

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -30,7 +30,7 @@ from output.renderers.alert.segments import normalize_segment_id
 from services.point_weather import AlertEvaluationConfig, TripSegmentWeatherAdapter
 from services.corridor_threshold import CorridorHit
 from services.throttle_store import ThrottleStore
-from services.trip_day import trip_local_today
+from services.trip_day import anchor_tz, trip_local_today
 from services.user_tier import premium_sms_allowed, sms_allowed
 from services.weather_change_detection import WeatherChangeDetectionService
 from utils.timezone import tz_for_coords
@@ -227,7 +227,8 @@ class TripAlertService:
             return False
 
         # 1. QuietHours-Check (AC-4/5/6): Alert während stiller Stunden unterdrücken
-        if self._is_quiet_hours(trip, datetime.now(timezone.utc)):
+        now_utc = datetime.now(timezone.utc)
+        if self._is_quiet_hours(trip, now_utc):
             logger.debug(f"Alert suppressed: quiet hours active for trip {trip.id}")
             return False
 
@@ -238,7 +239,10 @@ class TripAlertService:
 
         # 1c. Issue #1070: Tages-Obergrenze nach Nutzerlevel (Free/Standard/Premium)
         # Issue #1555: reason="forecast_change" reserviert einen Anteil für NowCast.
-        if not alert_daily_limit.is_allowed(self._user_id, datetime.now(timezone.utc), reason="forecast_change"):
+        # Issue #1726: der Tageszaehler laeuft auf dem KALENDERTAG DER TOUR.
+        if not alert_daily_limit.is_allowed(
+            self._user_id, now_utc, anchor_tz(trip, now_utc), reason="forecast_change",
+        ):
             logger.debug(f"Alert suppressed: daily limit reached for trip {trip.id}")
             return False
 
@@ -273,6 +277,7 @@ class TripAlertService:
             ),
             channels=self._effective_alert_channels(trip),
             display_config=trip.display_config,
+            zone=anchor_tz(trip, now_utc),
         )
         engine = DeviationAlertEngine()
         eval_result = engine.evaluate(
@@ -342,7 +347,9 @@ class TripAlertService:
         # 7. Update throttle (only on success) + persist
         self._throttle_store.record("trip", trip.id, datetime.now(timezone.utc))
         # Issue #1070: nur bei tatsaechlichem Versand zaehlen (F001-Symmetrie)
-        alert_daily_limit.increment(self._user_id, datetime.now(timezone.utc))
+        alert_daily_limit.increment(
+            self._user_id, now_utc, anchor_tz(trip, now_utc),
+        )
 
         return True
 
@@ -685,9 +692,13 @@ class TripAlertService:
 
         Returns:
             True if alerts should be suppressed (quiet hours active)
-        """
+
+        Issue #1726: Zone aus `anchor_tz(trip, now)` — der TAGESBEWUSSTEN
+        Aufloesung, nicht `trip_tz()`. Ein Trek durch mehrere Zonen braucht die
+        Zone SEINER AKTUELLEN Etappe, nicht die des Starttags."""
         return DeviationAlertEngine.is_quiet_hours(
             now, trip.alert_quiet_from, trip.alert_quiet_to,
+            anchor_tz(trip, now),
             context_label=trip.id,
         )
 
@@ -961,6 +972,7 @@ class TripAlertService:
                 quiet_to=trip.alert_quiet_to,
                 context_label=trip.id,
                 now=now_utc,
+                zone=anchor_tz(trip, now_utc),
                 throttle_store=self._throttle_store,
             )
             if not gate.allowed:
@@ -1158,6 +1170,7 @@ class TripAlertService:
             record_nowcast_sent(
                 user_id=self._user_id, throttle_scope=_RADAR_THROTTLE_SCOPE,
                 throttle_key=trip.id, now=datetime.now(timezone.utc),
+                zone=anchor_tz(trip, now_utc),
                 throttle_store=self._throttle_store,
             )
             sent += 1
@@ -1430,13 +1443,16 @@ class TripAlertService:
         (has_active_rules, _filter_significant_changes), da ein eigenständiger
         amtlicher Trigger laut PO-Entscheidung unabhängig vom Wetter-Delta feuern soll.
         """
-        if self._is_quiet_hours(trip, datetime.now(timezone.utc)):
+        now_utc = datetime.now(timezone.utc)
+        if self._is_quiet_hours(trip, now_utc):
             logger.debug(f"Official alert suppressed: quiet hours active for trip {trip.id}")
             return False
         if self._is_throttled_with_cooldown(trip):
             logger.debug(f"Official alert throttled for trip {trip.id}")
             return False
-        if not alert_daily_limit.is_allowed(self._user_id, datetime.now(timezone.utc)):
+        if not alert_daily_limit.is_allowed(
+            self._user_id, now_utc, anchor_tz(trip, now_utc),
+        ):
             logger.debug(f"Official alert suppressed: daily limit reached for trip {trip.id}")
             return False
 
@@ -1477,7 +1493,9 @@ class TripAlertService:
         if result.sent:
             self._record_official_alert_state(trip.id, official_notices)
             self._throttle_store.record("trip", trip.id, datetime.now(timezone.utc))
-            alert_daily_limit.increment(self._user_id, datetime.now(timezone.utc))
+            alert_daily_limit.increment(
+                self._user_id, now_utc, anchor_tz(trip, now_utc),
+            )
         return result.sent
 
     def _effective_alert_channels(self, trip: "Trip") -> set[str]:

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -1567,7 +1567,13 @@ class TripReportSchedulerService:
             if minutes_until_start > NOWCAST_HORIZON_MIN:
                 return None
 
-        if not alert_daily_limit.is_allowed(self._user_id, now_utc, reason="nowcast"):
+        # Issue #1726: reine Lesestelle (bucht nie), liest aber denselben
+        # Zaehler wie der Alarm-Pfad — also auf dem Kalendertag der TOUR.
+        from services.trip_day import anchor_tz
+
+        if not alert_daily_limit.is_allowed(
+            self._user_id, now_utc, anchor_tz(trip, now_utc), reason="nowcast",
+        ):
             return None
 
         from services.radar_service import INTENSITY_HEAVY, RadarNowcastService

--- a/src/utils/timezone.py
+++ b/src/utils/timezone.py
@@ -8,9 +8,12 @@ SPEC: docs/specs/bugfix/utc_localtime_display.md
 """
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Iterable, Optional
 from zoneinfo import ZoneInfo
+
+logger = logging.getLogger(__name__)
 
 UTC = ZoneInfo("UTC")
 
@@ -69,6 +72,31 @@ def location_tz(location) -> ZoneInfo:
     die immer eine Zeitzone brauchen (Stundenauswahl, Beschriftung, Ausblick,
     Kopfzeile). Der Rueckfall bleibt durch ``local_stamp()`` sichtbar."""
     return resolve_location_tz(location) or UTC
+
+
+def first_resolvable_tz(locations: Iterable, context_label: str = "") -> ZoneInfo:
+    """Zone des ERSTEN Orts der Reihenfolge, dessen Zone sich aufloesen laesst.
+
+    Die fachliche Fassung von "erster Ort" (#1378 AC-4, #1726 AC-15): ein
+    reiner Indexzugriff ``location_ids[0]`` faellt still auf UTC, sobald die
+    erste Kennung ins Leere zeigt (geloeschter Ort) oder der Ort keine
+    aufloesbare Zone traegt — obwohl ein SPAETERER Ort eine gueltige haette.
+    Deshalb wird uebersprungen statt zurueckgefallen; ``None``-Eintraege sind
+    erlaubt (Sequenz ``(all_locations.get(lid) for lid in ids)``). Loest KEIN
+    Ort eine Zone auf, gilt UTC — sichtbar im Protokoll, nicht still.
+    """
+    for location in locations:
+        if location is None:
+            continue
+        tz = resolve_location_tz(location)
+        if tz is not None:
+            return tz
+    logger.warning(
+        "Keine aufloesbare Zeitzone%s — es gilt Weltzeit (UTC). Ruhezeit, "
+        "Tageszaehler und Faelligkeit rechnen damit NICHT in der Ortszeit.",
+        f" fuer {context_label}" if context_label else "",
+    )
+    return UTC
 
 
 def _as_utc(dt: datetime) -> datetime:

--- a/tests/helpers/compare_slot_time.py
+++ b/tests/helpers/compare_slot_time.py
@@ -23,3 +23,34 @@ def utc_moment(today: date, hour: int) -> datetime:
     """Weltzeit-Zeitpunkt mit Ortsstunde ``hour`` am Ortstag ``today`` — fuer
     Presets ohne aufloesbare Orte (Zone = UTC)."""
     return datetime(today.year, today.month, today.day, hour, tzinfo=timezone.utc)
+
+
+def utc_slot_for_manual_hour(hour: int) -> str:
+    """Slot-Uhrzeit (``"HH:MM:SS"``) fuer ein Preset OHNE aufloesbaren Ort, das
+    ueber den manuellen Ausloeser ``run_compare_presets_daily(hour=...)``
+    faellig werden soll.
+
+    Der Ausloeser verankert seinen Zeitpunkt in der Referenz-Zone
+    (``CompareDispatchStrategy.MANUAL_TRIGGER_REFERENCE_ZONE``) — ein reines
+    Ops-Werkzeug ohne Preset-Bezug, den der Produktiv-Cron nicht benutzt. Ein
+    Preset ohne aufloesbaren Ort rechnet seit #1726 dagegen in UTC und sieht
+    zu DEMSELBEN Zeitpunkt eine ANDERE Stunde; mit dem 06:00-Migrations-
+    Rueckfall waere es bei ``hour=6`` gar nicht mehr faellig und der Test
+    pruefte einen Lauf, der nie stattfindet.
+
+    Die Stunde wird aus derselben Umrechnung gewonnen, die der Ausloeser
+    benutzt, statt getippt: als feste "04:00:00" haenge sie am Sommerzeit-
+    Versatz der Referenz-Zone und waere im Winter falsch.
+    """
+    from zoneinfo import ZoneInfo
+
+    from services.dispatch_orchestrator import CompareDispatchStrategy
+
+    zone = ZoneInfo(CompareDispatchStrategy.MANUAL_TRIGGER_REFERENCE_ZONE)
+    utc_hour = (
+        datetime.now(zone)
+        .replace(hour=hour, minute=0, second=0, microsecond=0)
+        .astimezone(timezone.utc)
+        .hour
+    )
+    return f"{utc_hour:02d}:00:00"

--- a/tests/helpers/compare_slot_time.py
+++ b/tests/helpers/compare_slot_time.py
@@ -1,0 +1,25 @@
+"""Zeitpunkt-Helfer fuer `compare_slot_scheduler.presets_due_for_hour` (#1726).
+
+Die Funktion nahm bis #1726 eine fertige Stunde und einen fertigen Kalendertag
+entgegen. Seit #1726 loest sie beides SELBST auf — je Preset in der Ortszone
+seines ersten aufloesbaren Orts. Aufrufer geben deshalb einen ZEITPUNKT und
+die Ortsliste.
+
+Bestandstests, die nur „Slot 7 Uhr am Tag D" ausdruecken wollten und gar keine
+Orte kennen, uebergeben eine LEERE Ortsliste: dann greift der dokumentierte
+UTC-Rueckfall (`utils.timezone.first_resolvable_tz`), und `utc_moment(D, 7)`
+ist genau der Zeitpunkt, an dem die Ortsstunde 7 und der Ortstag D ist.
+
+Bewusst KEIN Standardwert fuer die Zone: wer eine Zonen-Aussage pruefen will,
+baut seine Orte selbst und rechnet den Zeitpunkt dagegen — sonst prueft der
+Test die Zonenwahl nicht, sondern nur, dass sie irgendwas liefert.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+
+def utc_moment(today: date, hour: int) -> datetime:
+    """Weltzeit-Zeitpunkt mit Ortsstunde ``hour`` am Ortstag ``today`` — fuer
+    Presets ohne aufloesbare Orte (Zone = UTC)."""
+    return datetime(today.year, today.month, today.day, hour, tzinfo=timezone.utc)

--- a/tests/helpers/nowcast_gate_fixtures.py
+++ b/tests/helpers/nowcast_gate_fixtures.py
@@ -53,7 +53,18 @@ def preset_root() -> Path:
 
     return get_data_root() / "users"
 
-VIENNA = ZoneInfo("Europe/Vienna")
+# Issue #1726: Ruhezeit und Tageszaehler laufen nicht mehr auf der Wiener Uhr,
+# sondern auf der ORTSZONE des jeweiligen Gegenstands. Die Helfer unten nehmen
+# sie deshalb als Parameter. Die beiden Konstanten sind die Zonen der
+# DEFAULT-Koordinaten dieser Datei — gemessen, nicht angenommen:
+#   tz_for_coords(LAT, LON)           -> Europe/Vienna
+#   tz_for_coords(TRIP_LAT, TRIP_LON) -> Atlantic/Reykjavik
+# Wer einen Vergleich aus `location()` baut, braucht LOCATION_ZONE; wer einen
+# Trip aus `make_trip()` baut, TRIP_ZONE. Ein gemeinsamer Default waere fuer
+# eine der beiden Seiten still falsch (Versatz 1-2 h) und der Test dann gruen
+# aus dem falschen Grund.
+LOCATION_ZONE = ZoneInfo("Europe/Vienna")
+TRIP_ZONE = ZoneInfo("Atlantic/Reykjavik")
 
 LAT, LON = 47.0, 11.0
 
@@ -208,21 +219,24 @@ def reset_radar_cache() -> None:
 # ─────────────────────────── Ruhezeit-Fenster ───────────────────────────────
 
 
-def quiet_window_now(buffer_minutes: int = 5) -> tuple[str, str]:
-    """``(from, to)`` in Europe/Vienna-Lokalzeit, das den JETZIGEN Zeitpunkt
-    umschliesst — ``is_quiet_hours()`` vergleicht seit #1312 gegen Wien."""
-    now = datetime.now(timezone.utc).astimezone(VIENNA)
+def quiet_window_now(
+    buffer_minutes: int = 5, *, zone: ZoneInfo = LOCATION_ZONE,
+) -> tuple[str, str]:
+    """``(from, to)`` in der Ortszeit von ``zone``, das den JETZIGEN Zeitpunkt
+    umschliesst. Seit #1726 wertet ``is_quiet_hours()`` in der Zone des
+    Gegenstands aus — das Fenster muss in DERSELBEN Zone gebildet werden."""
+    now = datetime.now(timezone.utc).astimezone(zone)
     return (
         (now - timedelta(minutes=buffer_minutes)).strftime("%H:%M"),
         (now + timedelta(minutes=buffer_minutes)).strftime("%H:%M"),
     )
 
 
-def quiet_window_elsewhere() -> tuple[str, str]:
+def quiet_window_elsewhere(*, zone: ZoneInfo = LOCATION_ZONE) -> tuple[str, str]:
     """Ein GESETZTES Ruhezeit-Fenster, das „jetzt" NICHT enthaelt (2–3 h
     voraus). Schaerfer als „gar keine Ruhezeit", weil der Wert damit real
     ausgewertet wird statt in den ``not quiet_from``-Kurzschluss zu laufen."""
-    now = datetime.now(timezone.utc).astimezone(VIENNA)
+    now = datetime.now(timezone.utc).astimezone(zone)
     return (
         (now + timedelta(hours=2)).strftime("%H:%M"),
         (now + timedelta(hours=3)).strftime("%H:%M"),
@@ -236,24 +250,33 @@ def daily_counter_path(user_id: str) -> Path:
     return get_data_dir(user_id) / "alert_daily_count.json"
 
 
-def vienna_today() -> str:
-    return datetime.now(timezone.utc).astimezone(VIENNA).date().isoformat()
+def local_today(zone: ZoneInfo = LOCATION_ZONE) -> str:
+    return datetime.now(timezone.utc).astimezone(zone).date().isoformat()
 
 
-def seed_daily_counter(user_id: str, count: int) -> None:
+def seed_daily_counter(
+    user_id: str, count: int, *, zone: ZoneInfo = LOCATION_ZONE,
+) -> None:
+    """Zaehlerstand vorbelegen — im Schema, das der Pruefling seit #1726
+    SCHREIBT (``{"zones": {"<zone>": {...}}}``). Bewusst nicht im Alt-Schema:
+    der Helfer soll den Normalfall herstellen, nicht die Migration testen (die
+    hat ihren eigenen Nachweis in AC-8)."""
     path = daily_counter_path(user_id)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps({"date": vienna_today(), "count": count}))
+    path.write_text(json.dumps(
+        {"zones": {str(zone): {"date": local_today(zone), "count": count}}}
+    ))
 
 
-def read_daily_counter(user_id: str) -> int:
+def read_daily_counter(user_id: str, *, zone: ZoneInfo = LOCATION_ZONE) -> int:
     path = daily_counter_path(user_id)
     if not path.exists():
         return 0
     data = json.loads(path.read_text())
-    if data.get("date") != vienna_today():
+    entry = (data.get("zones") or {}).get(str(zone))
+    if not isinstance(entry, dict) or entry.get("date") != local_today(zone):
         return 0
-    return int(data.get("count", 0))
+    return int(entry.get("count", 0))
 
 
 def throttle_state_path(user_id: str) -> Path:

--- a/tests/tdd/test_alert_gate.py
+++ b/tests/tdd/test_alert_gate.py
@@ -36,7 +36,7 @@ from app.loader import save_location
 
 from tests.helpers.nowcast_gate_fixtures import (
     SCOPE_COMPARE_RADAR, CountingFrameSource, clean_uid, compare_radar_service,
-    fresh_uid, location, quiet_window_elsewhere, quiet_window_now,
+    LOCATION_ZONE, fresh_uid, location, quiet_window_elsewhere, quiet_window_now,
     radar_preset, read_daily_counter, read_throttle_state, record_throttle,
     reset_radar_cache, seed_daily_counter, settings_email_only,
     settings_no_channel_reachable, write_presets, write_user_tier,
@@ -106,7 +106,7 @@ def test_ac11_ruhezeit_stoppt_vor_der_sperrzeit_pruefung():
             user_id=uid, throttle_scope=SCOPE_COMPARE_RADAR, throttle_key=preset_id,
             cooldown_minutes=120, quiet_from=quiet_from, quiet_to=quiet_to,
             context_label=preset_id, now=datetime.now(timezone.utc),
-            throttle_store=store,
+            zone=LOCATION_ZONE, throttle_store=store,
         )
 
         assert ergebnis.allowed is False, (
@@ -146,6 +146,7 @@ def test_ac11_sperrzeit_stoppt_vor_der_tages_obergrenze():
             user_id=uid, throttle_scope=SCOPE_COMPARE_RADAR, throttle_key=preset_id,
             cooldown_minutes=120, quiet_from=quiet_from, quiet_to=quiet_to,
             context_label=preset_id, now=datetime.now(timezone.utc),
+            zone=LOCATION_ZONE,
         )
 
         assert ergebnis.allowed is False, f"Die Sperrzeit muss sperren: {ergebnis!r}"
@@ -176,6 +177,7 @@ def test_ac11_freie_bahn_wird_durchgelassen():
             user_id=uid, throttle_scope=SCOPE_COMPARE_RADAR, throttle_key=preset_id,
             cooldown_minutes=120, quiet_from=quiet_from, quiet_to=quiet_to,
             context_label=preset_id, now=datetime.now(timezone.utc),
+            zone=LOCATION_ZONE,
         )
 
         assert ergebnis.allowed is True, (
@@ -215,11 +217,15 @@ def test_ac12_vergleichs_nowcast_prueft_gegen_das_volle_tagesbudget():
 
         write_user_tier(reserve, "free")     # Limit 2, Reserve 1
         seed_daily_counter(reserve, 1)
-        assert alert_daily_limit.is_allowed(reserve, jetzt, reason="forecast_change") is False, (
+        assert alert_daily_limit.is_allowed(
+            reserve, jetzt, LOCATION_ZONE, reason="forecast_change",
+        ) is False, (
             "Aufbau-Nachweis: bei count=1 und Limit 2 muss die #1555-Reserve den "
             "Aenderungsalarm bereits sperren — sonst prueft dieser Test nichts"
         )
-        assert alert_daily_limit.is_allowed(reserve, jetzt, reason="nowcast") is True, (
+        assert alert_daily_limit.is_allowed(
+            reserve, jetzt, LOCATION_ZONE, reason="nowcast",
+        ) is True, (
             "Aufbau-Nachweis: derselbe Stand muss fuer den Nowcast frei sein"
         )
         _setup_compare(reserve, "cp-1467s3-ac12")

--- a/tests/tdd/test_alert_quiet_hours_localtime.py
+++ b/tests/tdd/test_alert_quiet_hours_localtime.py
@@ -33,8 +33,13 @@ datetime.now().
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 from services.deviation_alert_engine import DeviationAlertEngine
+
+# Issue #1726: die Zone ist jetzt Pflicht-Parameter statt Modul-Konstante.
+# Diese Datei prueft die WIENER Auslegung — sie uebergibt sie deshalb selbst.
+VIENNA = ZoneInfo("Europe/Vienna")
 
 
 # ---------------------------------------------------------------------------
@@ -53,7 +58,7 @@ def test_ac1_summer_2230_vienna_is_suppressed():
     20:30 UTC liegt NICHT im Fenster 22:00-06:00 -> False. Rot vor Fix.
     """
     now = datetime(2026, 6, 15, 20, 30, tzinfo=timezone.utc)
-    result = DeviationAlertEngine.is_quiet_hours(now, "22:00", "06:00")
+    result = DeviationAlertEngine.is_quiet_hours(now, "22:00", "06:00", VIENNA)
     assert result is True
 
 
@@ -72,7 +77,7 @@ def test_ac2_summer_0700_vienna_not_suppressed():
     Fenster bis 06:00 UTC -> True (faelschlich unterdrueckt). Rot vor Fix.
     """
     now = datetime(2026, 6, 16, 5, 0, tzinfo=timezone.utc)
-    result = DeviationAlertEngine.is_quiet_hours(now, "22:00", "06:00")
+    result = DeviationAlertEngine.is_quiet_hours(now, "22:00", "06:00", VIENNA)
     assert result is False
 
 
@@ -92,7 +97,7 @@ def test_ac3_winter_2230_vienna_is_suppressed():
     -> False. Rot vor Fix.
     """
     now = datetime(2026, 1, 15, 21, 30, tzinfo=timezone.utc)
-    result = DeviationAlertEngine.is_quiet_hours(now, "22:00", "06:00")
+    result = DeviationAlertEngine.is_quiet_hours(now, "22:00", "06:00", VIENNA)
     assert result is True
 
 
@@ -113,7 +118,7 @@ def test_ac4_wrap_inside_2330_vienna_is_suppressed():
     -> False. Rot vor Fix.
     """
     now = datetime(2026, 6, 15, 21, 30, tzinfo=timezone.utc)
-    result = DeviationAlertEngine.is_quiet_hours(now, "22:00", "06:00")
+    result = DeviationAlertEngine.is_quiet_hours(now, "22:00", "06:00", VIENNA)
     assert result is True
 
 
@@ -133,7 +138,7 @@ def test_ac4_wrap_outside_2100_vienna_not_suppressed_anchor():
     damit der Fix den Wrap-Vergleich nicht versehentlich umkehrt.
     """
     now = datetime(2026, 6, 15, 19, 0, tzinfo=timezone.utc)
-    result = DeviationAlertEngine.is_quiet_hours(now, "22:00", "06:00")
+    result = DeviationAlertEngine.is_quiet_hours(now, "22:00", "06:00", VIENNA)
     assert result is False
 
 
@@ -153,7 +158,7 @@ def test_ac5_no_quiet_hours_configured_never_suppressed_anchor():
     liegt VOR jeder Zeitkonvertierung und bleibt vom Fix unberuehrt.
     """
     now = datetime(2026, 6, 15, 22, 30, tzinfo=timezone.utc)
-    result = DeviationAlertEngine.is_quiet_hours(now, None, None)
+    result = DeviationAlertEngine.is_quiet_hours(now, None, None, VIENNA)
     assert result is False
 
 
@@ -176,5 +181,5 @@ def test_naive_datetime_interpreted_as_utc():
     -> False. Rot vor Fix.
     """
     now = datetime(2026, 6, 15, 20, 30)  # bewusst ohne tzinfo
-    result = DeviationAlertEngine.is_quiet_hours(now, "22:00", "06:00")
+    result = DeviationAlertEngine.is_quiet_hours(now, "22:00", "06:00", VIENNA)
     assert result is True

--- a/tests/tdd/test_alert_quiet_hours_robustness.py
+++ b/tests/tdd/test_alert_quiet_hours_robustness.py
@@ -71,6 +71,7 @@ import textwrap
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -80,6 +81,11 @@ from app.user import SavedLocation
 
 from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
 from tests.helpers.compare_briefings import write_compare_briefings
+
+# Issue #1726: `is_quiet_hours` nimmt die Zone jetzt als Pflicht-Parameter
+# (frueher Modul-Konstante `deviation_alert_engine.VIENNA`). Diese Datei prueft
+# die #1479-Haertung, nicht die Zonenwahl — sie bleibt deshalb bei Wien.
+VIENNA = ZoneInfo("Europe/Vienna")
 
 _REPO = Path(__file__).resolve().parents[2]
 SERVICES_DIR = _REPO / "src" / "services"
@@ -622,13 +628,13 @@ def test_ac6_unusable_quiet_value_returns_false_without_raising(unusable):
 
     now = datetime(2026, 8, 3, 12, 0, tzinfo=timezone.utc)
 
-    as_from = DeviationAlertEngine.is_quiet_hours(now, unusable, "23:00")
+    as_from = DeviationAlertEngine.is_quiet_hours(now, unusable, "23:00", VIENNA)
     assert as_from is False, (
         f"Unbrauchbarer Beginn {unusable!r} muss als 'keine Ruhezeit gesetzt' "
         f"gelten — erwartet False, erhalten: {as_from!r} (AC-6)"
     )
 
-    as_to = DeviationAlertEngine.is_quiet_hours(now, "22:00", unusable)
+    as_to = DeviationAlertEngine.is_quiet_hours(now, "22:00", unusable, VIENNA)
     assert as_to is False, (
         f"Unbrauchbares Ende {unusable!r} muss als 'keine Ruhezeit gesetzt' "
         f"gelten — erwartet False, erhalten: {as_to!r} (AC-6)"
@@ -662,8 +668,8 @@ def test_ac7_empty_quiet_value_returns_false_and_writes_no_warning(caplog, empty
     now = datetime(2026, 8, 3, 12, 0, tzinfo=timezone.utc)
 
     with caplog.at_level(logging.WARNING):
-        as_from = DeviationAlertEngine.is_quiet_hours(now, empty, "23:00")
-        as_to = DeviationAlertEngine.is_quiet_hours(now, "22:00", empty)
+        as_from = DeviationAlertEngine.is_quiet_hours(now, empty, "23:00", VIENNA)
+        as_to = DeviationAlertEngine.is_quiet_hours(now, "22:00", empty, VIENNA)
 
     assert as_from is False and as_to is False, (
         f"Leerer/fehlender Ruhezeit-Wert {empty!r} muss False liefern — "
@@ -704,7 +710,7 @@ def test_ac8_caught_exception_is_logged_with_type_values_and_label(caplog):
 
     with caplog.at_level(logging.WARNING):
         result = DeviationAlertEngine.is_quiet_hours(
-            now, 2200, "23:00", context_label=label,
+            now, 2200, "23:00", VIENNA, context_label=label,
         )
 
     assert result is False, f"Erwartet False, erhalten: {result!r} (AC-8)"
@@ -950,34 +956,34 @@ def test_ac9_valid_quiet_window_still_suppresses_including_midnight_wrap():
     Sommer-/Winterzeit eine andere Ortszeit und der Test wuerde am
     Zeitumstellungstag etwas anderes pruefen als behauptet.
     """
-    from services.deviation_alert_engine import VIENNA, DeviationAlertEngine
+    from services.deviation_alert_engine import DeviationAlertEngine
 
     def at(month: int, day: int, hour: int, minute: int = 0) -> datetime:
         return datetime(2026, month, day, hour, minute, tzinfo=VIENNA)
 
-    assert DeviationAlertEngine.is_quiet_hours(at(6, 15, 23, 30), "22:00", "07:00") is True, (
+    assert DeviationAlertEngine.is_quiet_hours(at(6, 15, 23, 30), "22:00", "07:00", VIENNA) is True, (
         "23:30 Ortszeit liegt im Fenster 22:00-07:00 (Mitternachts-Wrap) (AC-9)"
     )
-    assert DeviationAlertEngine.is_quiet_hours(at(6, 16, 3, 0), "22:00", "07:00") is True, (
+    assert DeviationAlertEngine.is_quiet_hours(at(6, 16, 3, 0), "22:00", "07:00", VIENNA) is True, (
         "03:00 Ortszeit liegt nach Mitternacht noch im Fenster 22:00-07:00 (AC-9)"
     )
-    assert DeviationAlertEngine.is_quiet_hours(at(6, 16, 7, 0), "22:00", "07:00") is False, (
+    assert DeviationAlertEngine.is_quiet_hours(at(6, 16, 7, 0), "22:00", "07:00", VIENNA) is False, (
         "07:00 exakt ist das ENDE des Fensters und wird nicht mehr unterdrueckt (AC-9)"
     )
-    assert DeviationAlertEngine.is_quiet_hours(at(6, 16, 12, 0), "22:00", "07:00") is False, (
+    assert DeviationAlertEngine.is_quiet_hours(at(6, 16, 12, 0), "22:00", "07:00", VIENNA) is False, (
         "12:00 Ortszeit liegt ausserhalb des Fensters 22:00-07:00 (AC-9)"
     )
-    assert DeviationAlertEngine.is_quiet_hours(at(1, 15, 23, 30), "22:00", "07:00") is True, (
+    assert DeviationAlertEngine.is_quiet_hours(at(1, 15, 23, 30), "22:00", "07:00", VIENNA) is True, (
         "Auch in der Winterzeit gilt dasselbe Fenster in Ortszeit (AC-9)"
     )
-    assert DeviationAlertEngine.is_quiet_hours(at(6, 15, 15, 0), "08:00", "22:00") is True, (
+    assert DeviationAlertEngine.is_quiet_hours(at(6, 15, 15, 0), "08:00", "22:00", VIENNA) is True, (
         "15:00 Ortszeit liegt im normalen (nicht wrappenden) Fenster 08:00-22:00 (AC-9)"
     )
-    assert DeviationAlertEngine.is_quiet_hours(at(6, 15, 23, 0), "22:00", None) is False, (
+    assert DeviationAlertEngine.is_quiet_hours(at(6, 15, 23, 0), "22:00", None, VIENNA) is False, (
         "Halb ausgefuelltes Fenster (Beginn ohne Ende) darf NIE unterdruecken "
         "— Known Limitation aus #181 (AC-9)"
     )
-    assert DeviationAlertEngine.is_quiet_hours(at(6, 15, 23, 0), None, "07:00") is False, (
+    assert DeviationAlertEngine.is_quiet_hours(at(6, 15, 23, 0), None, "07:00", VIENNA) is False, (
         "Halb ausgefuelltes Fenster (Ende ohne Beginn) darf NIE unterdruecken (AC-9)"
     )
 
@@ -1021,7 +1027,7 @@ _SELF_CHECK_VIOLATION = textwrap.dedent(
     """
     def check(now, a, b):
         try:
-            active = DeviationAlertEngine.is_quiet_hours(now, a, b)
+            active = DeviationAlertEngine.is_quiet_hours(now, a, b, VIENNA)
         except Exception:
             active = False
         return active
@@ -1040,7 +1046,7 @@ _SELF_CHECK_SUPPRESS_VIOLATION = textwrap.dedent(
     def check(now, a, b):
         active = False
         with contextlib.suppress(Exception):
-            active = DeviationAlertEngine.is_quiet_hours(now, a, b)
+            active = DeviationAlertEngine.is_quiet_hours(now, a, b, VIENNA)
         return active
     """
 )
@@ -1051,14 +1057,14 @@ _SELF_CHECK_BARE_SUPPRESS_VIOLATION = textwrap.dedent(
     def check(now, a, b):
         active = False
         with suppress(ValueError, TypeError):
-            active = DeviationAlertEngine.is_quiet_hours(now, a, b)
+            active = DeviationAlertEngine.is_quiet_hours(now, a, b, VIENNA)
         return active
     """
 )
 _SELF_CHECK_CLEAN = textwrap.dedent(
     """
     def check(now, a, b):
-        active = DeviationAlertEngine.is_quiet_hours(now, a, b, context_label="x")
+        active = DeviationAlertEngine.is_quiet_hours(now, a, b, VIENNA, context_label="x")
         if active:
             return False
         return True
@@ -1070,7 +1076,7 @@ _SELF_CHECK_CLEAN_WITH = textwrap.dedent(
     """
     def check(now, a, b, lock):
         with lock:
-            return DeviationAlertEngine.is_quiet_hours(now, a, b, context_label="x")
+            return DeviationAlertEngine.is_quiet_hours(now, a, b, VIENNA, context_label="x")
     """
 )
 

--- a/tests/tdd/test_briefing_faelligkeit_ortszone.py
+++ b/tests/tdd/test_briefing_faelligkeit_ortszone.py
@@ -539,30 +539,50 @@ def test_gegenprobe_zieltag_wird_je_trip_bestimmt_nicht_einmal_fuer_alle():
     )
 
 
+class _Ort:
+    """Ort-Stellvertreter mit genau den Feldern, die `resolve_location_tz`
+    liest (`timezone`, `lat`, `lon`) — echtes Objekt, kein Mock."""
+
+    def __init__(self, loc_id: str, lat: float, lon: float) -> None:
+        self.id = loc_id
+        self.lat = lat
+        self.lon = lon
+        self.timezone = None
+
+
 def test_gegenprobe_ortsvergleich_tag_und_stunde_aus_derselben_zone():
     """Verfälschung M4: der Ortsvergleich holt seinen Kalendertag wieder aus
-    `date.today()` (Prozess-Zeitzone) statt aus derselben Zone wie die Stunde.
+    einer ZWEITEN Ableitung (`date.today()`, Prozess-Zeitzone) statt aus
+    derselben Zone wie die Stunde — an der Tagesgrenze fallen beide dann
+    auseinander. Das war der Zustand vor #1724.
 
-    AC-8 fordert unveraendertes Compare-Verhalten — unveraendert heisst hier
-    ausdruecklich NICHT "egal": Stunde und Tag muessen aus EINER Ableitung
-    kommen, sonst fallen sie an der Tagesgrenze auseinander. Genau das war der
-    Zustand vor #1724 (Stunde vom Aufrufer, Tag aus `date.today()`).
+    🔴 Fortgeschrieben mit #1726: Bis dahin bildete `collect_due()` Stunde und
+    Tag SELBST, aus einer festen Zone, und der Test las beide am Aufruf von
+    `presets_due_for_hour` ab. Seit #1726 hat jedes Preset seine EIGENE Zone
+    (die seines ersten Orts) — ein globaler Stunde/Tag-Wert kann das nicht mehr
+    abbilden, `collect_due()` reicht deshalb den ZEITPUNKT und die Ortsliste
+    durch. Die Zusicherung selbst bleibt: Stunde UND Tag entstehen aus EINER
+    Zonen-Ableitung. Sie wird jetzt an den zwei Stellen geprüft, an denen sie
+    wirkt — Durchreichung oben, Ableitung unten.
     """
-    from datetime import date as _date
-
+    from services.compare_slot_scheduler import presets_due_for_hour
     from services.dispatch_orchestrator import CompareDispatchStrategy
     from utils.timezone import local_dt
 
-    zone = ZoneInfo(CompareDispatchStrategy.NOCH_NICHT_ORTSZEIT_SIEHE_1726)
-    # 23:30 UTC: in der Vergleichs-Zone ist bereits der Folgetag.
+    # 23:30 UTC am 20.08.: in Auckland ist bereits der 21.08. (+12). Bewusst
+    # NICHT Wien: Wien war bis #1726 die fest verdrahtete Vergleichs-Zone, ein
+    # Rueckfall darauf waere hier unsichtbar.
     now = datetime(2026, 8, 20, 23, 30, tzinfo=timezone.utc)
-    vor_ort = local_dt(now, zone)
+    lat, lon = ZONEN["Pacific/Auckland"]
+    vor_ort = local_dt(now, ZoneInfo("Pacific/Auckland"))
     assert vor_ort.date() != now.date(), "Testaufbau prueft nichts"
 
-    gesehen: list[tuple[int, _date]] = []
+    # (1) `collect_due()` reicht den ZEITPUNKT unveraendert durch und legt die
+    #     Ortsliste dazu — es darf Stunde/Tag NICHT vorab selbst festlegen.
+    gesehen: list[tuple[dict, datetime]] = []
 
-    def _protokollierend(presets, hour, today):
-        gesehen.append((hour, today))
+    def _protokollierend(presets, all_locations, now_utc):
+        gesehen.append((all_locations, now_utc))
         return []
 
     import services.compare_slot_scheduler as css
@@ -581,9 +601,31 @@ def test_gegenprobe_ortsvergleich_tag_und_stunde_aus_derselben_zone():
         css.presets_due_for_hour = echte_funktion
         sds._load_presets_for_dispatch = echter_loader
 
-    assert gesehen == [(vor_ort.hour, vor_ort.date())], (
-        f"Stunde und Kalendertag muessen aus derselben Zonen-Ableitung stammen. "
-        f"Erwartet {(vor_ort.hour, vor_ort.date())}, gesehen {gesehen}"
+    assert len(gesehen) == 1 and gesehen[0][1] == now, (
+        f"Der Zeitpunkt muss unveraendert durchgereicht werden, damit jedes "
+        f"Preset ihn in SEINER Zone auswerten kann. Gesehen: {gesehen!r}"
+    )
+    assert isinstance(gesehen[0][0], dict), (
+        "Die Ortsliste gehoert dazu — ohne sie kann keine Preset-Zone "
+        f"aufgeloest werden. Gesehen: {gesehen[0][0]!r}"
+    )
+
+    # (2) Die echte Funktion leitet Stunde UND Tag aus DERSELBEN Zone ab: das
+    #     Preset ist zur Auckland-Ortsstunde faellig und traegt den
+    #     Auckland-Ortstag — nicht den UTC-Tag.
+    ort = _Ort("loc-akl", lat, lon)
+    preset = {
+        "id": "p1", "schedule": "daily", "location_ids": ["loc-akl"],
+        "morning_enabled": True, "morning_time": f"{vor_ort.hour:02d}:00:00",
+        "evening_enabled": False, "evening_time": "18:00:00",
+    }
+
+    faellig = presets_due_for_hour([preset], {"loc-akl": ort}, now)
+
+    assert [(p["id"], td) for p, td, _v in faellig] == [("p1", vor_ort.date())], (
+        f"Stunde und Kalendertag muessen aus derselben Zonen-Ableitung stammen "
+        f"(erwartet Ortstag {vor_ort.date()}, UTC-Tag waere {now.date()}). "
+        f"Gefunden: {faellig!r}"
     )
 
 

--- a/tests/tdd/test_briefing_slot_idempotenz.py
+++ b/tests/tdd/test_briefing_slot_idempotenz.py
@@ -797,30 +797,80 @@ def test_t10_neuer_trip_feuert_nicht_rueckwirkend():
 # AC-11 / T11 — der Ortsvergleich bleibt bit-identisch
 # ---------------------------------------------------------------------------
 
-def _compare_preset_schreiben(user_id: str, stunde: int) -> None:
-    """Echtes Vergleichs-Preset in `briefings/` (Cutover-Lesepfad #1250 S7b)."""
+def _compare_preset_schreiben(user_id: str, stunde: int) -> list[str]:
+    """Echtes Vergleichs-Preset in `briefings/` (Cutover-Lesepfad #1250 S7b)
+    samt seinen ORTEN; gibt deren Kennungen zurueck.
+
+    Issue #1726: die Faelligkeit des Vergleichs haengt nicht mehr an einer
+    festen Zone, sondern an der Ortszone des Presets. Die Orte muessen deshalb
+    real auf der Platte liegen — ohne sie greift der dokumentierte
+    UTC-Rueckfall, und der Test pruefte die Faelligkeit gegen eine Zone, die
+    nur ein Ausfall-Ersatz ist. Auckland mit Absicht: bei einer
+    mitteleuropaeischen Zone waere ein Rueckfall auf eine feste Wiener Uhr im
+    August unsichtbar, weil der Sommerzeit-Versatz derselbe ist (dieselbe
+    Falle wie im Kopf von test_ruhezeit_und_zaehler_folgen_der_ortszone.py).
+    """
+    orte = {"ort-a": AUCKLAND, "ort-b": AUCKLAND}
+    ort_ordner = get_data_dir(user_id) / "locations"
+    ort_ordner.mkdir(parents=True, exist_ok=True)
+    for ort_id, (lat, lon) in orte.items():
+        (ort_ordner / f"{ort_id}.json").write_text(json.dumps({
+            "id": ort_id, "name": f"Ort {ort_id}",
+            "lat": lat, "lon": lon, "elevation_m": 100,
+        }), encoding="utf-8")
+
     ordner = get_briefings_dir(user_id)
     ordner.mkdir(parents=True, exist_ok=True)
     (ordner / "vgl-1.json").write_text(json.dumps({
         "id": "vgl-1",
         "kind": "vergleich",
-        "name": "Alpen vs Voralpen",
+        "name": "Auckland-Vergleich",
         "user_id": user_id,
         "schedule": "daily",
-        "location_ids": ["ort-a", "ort-b"],
+        "location_ids": list(orte),
         "empfaenger": ["nutzer@example.com"],
         "morning_enabled": True,
         "morning_time": f"{stunde:02d}:00:00",
         "evening_enabled": False,
         "evening_time": "18:00:00",
     }), encoding="utf-8")
+    return list(orte)
+
+
+def _vergleichs_zone(user_id: str, ort_ids: list[str]) -> ZoneInfo:
+    """Die Zone, in der ueber die Faelligkeit des Presets ENTSCHIEDEN wird —
+    abgeleitet auf demselben Weg wie im Produktivcode.
+
+    Issue #1726: `CompareDispatchStrategy.collect_due()` baut `{loc.id: loc}`
+    aus `load_all_locations` und `presets_due_for_hour` loest daraus
+    `first_resolvable_tz(...)` auf. Genau diese zwei Zeilen stehen hier —
+    NICHT eine getippte Zonen-Konstante. Eine getippte Zone koennte still
+    neben der zustaendigen liegen; der Test waere dann gruen, ohne die
+    Faelligkeit zu pruefen.
+    """
+    from app.loader import load_all_locations
+    from utils.timezone import first_resolvable_tz
+
+    orte = {loc.id: loc for loc in load_all_locations(user_id=user_id)}
+    return first_resolvable_tz(
+        (orte.get(lid) for lid in ort_ids), context_label="vgl-1",
+    )
 
 
 def test_t11_ortsvergleich_kennt_keinen_vermerk(monkeypatch):
     """Given der Ortsvergleichs-Pfad mit unveraenderter Konfiguration / When
-    derselbe Versandlauf ueber 24 Stunden ausgefuehrt wird / Then feuert das
-    Preset genau zur konfigurierten Stunde der festen Vergleichs-Zone — und
-    ein ZWEITER Lauf in derselben Stunde feuert erneut.
+    derselbe Versandlauf ueber einen Ortstag ausgefuehrt wird / Then feuert das
+    Preset genau zur konfigurierten Stunde SEINER Ortszone — und ein ZWEITER
+    Lauf in derselben Stunde feuert erneut.
+
+    Issue #1726 hat die feste Vergleichs-Zone abgeloest
+    (`NOCH_NICHT_ORTSZEIT_SIEHE_1726`, bis dahin `Europe/Vienna`): die
+    Faelligkeit haengt jetzt an der Ortszone des jeweiligen Presets. Die hier
+    geprueffte Zusicherung bleibt davon UNBERUEHRT — sie lautet „genau eine
+    Stunde am Ortstag feuert, und ein zweiter Lauf in derselben Stunde feuert
+    erneut". Nur der Bezugspunkt wandert von der Konstante zum Preset, und er
+    wird deshalb ueber denselben Weg abgeleitet wie im Produktivcode
+    (`_vergleichs_zone`), nicht getippt.
 
     Der zweite Lauf ist der eigentliche Waechter: der Idempotenz-Schutz darf
     ausschliesslich im Trip-Pfad wirken. Gemessen wird ueber das GETEILTE
@@ -837,7 +887,7 @@ def test_t11_ortsvergleich_kennt_keinen_vermerk(monkeypatch):
     from app.config import Settings
     from services import dispatch_orchestrator as orchestrator
 
-    _compare_preset_schreiben("slot-t11", 9)
+    ort_ids = _compare_preset_schreiben("slot-t11", 9)
     protokoll: list = []
 
     class _MitgeschriebenerVergleich(orchestrator.CompareDispatchStrategy):
@@ -845,7 +895,7 @@ def test_t11_ortsvergleich_kennt_keinen_vermerk(monkeypatch):
             protokoll.append(item[0].get("id"))
 
     monkeypatch.setitem(orchestrator._STRATEGY, "vergleich", _MitgeschriebenerVergleich)
-    zone = ZoneInfo(orchestrator.CompareDispatchStrategy.NOCH_NICHT_ORTSZEIT_SIEHE_1726)
+    zone = _vergleichs_zone("slot-t11", ort_ids)
     settings = Settings(is_test_mode=True)
 
     stunden_mit_versand = []
@@ -857,7 +907,7 @@ def test_t11_ortsvergleich_kennt_keinen_vermerk(monkeypatch):
 
     assert stunden_mit_versand == [9], (
         "Der Ortsvergleich muss unveraendert genau zur konfigurierten Stunde "
-        f"seiner festen Zone feuern, gefunden {stunden_mit_versand}"
+        f"seiner Ortszone feuern, gefunden {stunden_mit_versand}"
     )
 
     # Zweiter Lauf in derselben Stunde: Compare kennt keinen Vermerk.

--- a/tests/tdd/test_compare_alert_paused_archived_silent.py
+++ b/tests/tdd/test_compare_alert_paused_archived_silent.py
@@ -947,7 +947,7 @@ def test_paused_preset_is_not_due_for_regular_compare_briefing():
     Zeitplan aktiv (`schedule="daily"`), nicht archiviert, `end_date` 30 Tage
     in der Zukunft, Morgen-Slot 07:00 aktiv.
 
-    WHEN `presets_due_for_hour(..., hour=7, today=...)` fuer genau diese
+    WHEN `presets_due_for_hour(..., {}, utc_moment(..., 7))` fuer genau diese
     Stunde laeuft.
 
     THEN ist das Preset NICHT faellig — ein pausierter Ortsvergleich bekommt
@@ -959,10 +959,11 @@ def test_paused_preset_is_not_due_for_regular_compare_briefing():
     kommen — sonst waere der Test auch ohne die AG6-Wirkung gruen.
     """
     from services.compare_slot_scheduler import presets_due_for_hour
+    from tests.helpers.compare_slot_time import utc_moment
 
     paused = _briefing_preset("cp-briefing-paused", paused_at=PAUSED_AT)
 
-    due = presets_due_for_hour([paused], hour=7, today=BRIEFING_TODAY)
+    due = presets_due_for_hour([paused], {}, utc_moment(BRIEFING_TODAY, 7))
 
     assert due == [], (
         "Pausierter Ortsvergleich (paused_at gesetzt, schedule='daily', "
@@ -975,7 +976,7 @@ def test_active_preset_with_same_fixture_is_due_for_regular_compare_briefing():
     """F001 GEGENPROBE — dieselbe Fixture OHNE `paused_at`.
 
     GIVEN denselben Ortsvergleich, nur ohne gesetztes `paused_at`.
-    WHEN `presets_due_for_hour(..., hour=7, today=...)` laeuft.
+    WHEN `presets_due_for_hour(..., {}, utc_moment(..., 7))` laeuft.
     THEN ist er faellig mit Zieldatum heute.
 
     Ohne diese Gegenprobe waere „nie faellig" eine bestehende Loesung fuer den
@@ -983,10 +984,11 @@ def test_active_preset_with_same_fixture_is_due_for_regular_compare_briefing():
     Unterschied macht.
     """
     from services.compare_slot_scheduler import presets_due_for_hour
+    from tests.helpers.compare_slot_time import utc_moment
 
     active = _briefing_preset("cp-briefing-active")
 
-    due = presets_due_for_hour([active], hour=7, today=BRIEFING_TODAY)
+    due = presets_due_for_hour([active], {}, utc_moment(BRIEFING_TODAY, 7))
 
     # Tripel seit #1661 (F003): (preset, target_date, tage_ab_ortstag) —
     # Morgen-Slot briefed ueber den laufenden Tag, Versatz 0.
@@ -1003,7 +1005,7 @@ def test_paused_preset_is_not_due_for_evening_compare_briefing():
     mit AKTIVEM ABEND-SLOT (18:00) statt Morgen-Slot — `paused_at` gesetzt,
     `schedule="daily"`, nicht archiviert, `end_date` 30 Tage in der Zukunft.
 
-    WHEN `presets_due_for_hour(..., hour=18, today=...)` laeuft.
+    WHEN `presets_due_for_hour(..., {}, utc_moment(..., 18))` laeuft.
 
     THEN ist das Preset NICHT faellig.
 
@@ -1015,12 +1017,13 @@ def test_paused_preset_is_not_due_for_evening_compare_briefing():
     an denen sie wirkt.
     """
     from services.compare_slot_scheduler import presets_due_for_hour
+    from tests.helpers.compare_slot_time import utc_moment
 
     paused = _briefing_preset(
         "cp-briefing-evening-paused", slot="evening", paused_at=PAUSED_AT
     )
 
-    due = presets_due_for_hour([paused], hour=18, today=BRIEFING_TODAY)
+    due = presets_due_for_hour([paused], {}, utc_moment(BRIEFING_TODAY, 18))
 
     assert due == [], (
         "Pausierter Ortsvergleich (paused_at gesetzt, schedule='daily', "
@@ -1035,17 +1038,18 @@ def test_active_preset_is_due_for_evening_compare_briefing():
 
     GIVEN denselben Ortsvergleich mit aktivem Abend-Slot, nur ohne gesetztes
     `paused_at`.
-    WHEN `presets_due_for_hour(..., hour=18, today=...)` laeuft.
+    WHEN `presets_due_for_hour(..., {}, utc_moment(..., 18))` laeuft.
     THEN ist er faellig, Zieldatum MORGEN (der Abend-Slot briefed den Folgetag).
 
     Ohne diese Gegenprobe waere „der Abend-Slot ist nie faellig" eine
     bestehende Loesung fuer den Test darueber.
     """
     from services.compare_slot_scheduler import presets_due_for_hour
+    from tests.helpers.compare_slot_time import utc_moment
 
     active = _briefing_preset("cp-briefing-evening-active", slot="evening")
 
-    due = presets_due_for_hour([active], hour=18, today=BRIEFING_TODAY)
+    due = presets_due_for_hour([active], {}, utc_moment(BRIEFING_TODAY, 18))
 
     expected_date = BRIEFING_TODAY + timedelta(days=1)
     # Tripel seit #1661 (F003): der Abend-Slot briefed den Folgetag, Versatz +1.

--- a/tests/tdd/test_compare_alert_quiet_hours_precedes_fetch.py
+++ b/tests/tdd/test_compare_alert_quiet_hours_precedes_fetch.py
@@ -54,6 +54,9 @@ def _data_root_users() -> Path:
     return get_data_root() / "users"
 
 VIENNA = ZoneInfo("Europe/Vienna")
+# Issue #1726: der Tageszaehler laeuft in der Ortszone des ERSTEN Orts des
+# Vergleichs. `loc-c` liegt bei 46.5/10.5 -> Italien, Europe/Rome.
+_ORTS_ZONE = ZoneInfo("Europe/Rome")
 
 
 # ───────────────────────── Helfer (1:1 aus test_issue_1170 übernommen) ──────
@@ -422,7 +425,7 @@ def test_ac6_suppressed_run_leaves_throttle_and_daily_limit_untouched():
         now = datetime.now(timezone.utc)
         # Zähler-Snapshot VOR dem Lauf — echte Stores, kein Mock.
         before_last_sent = ThrottleStore(uid).last_sent("compare_preset", preset_id)
-        before_daily_count = alert_daily_limit.load(uid, now)
+        before_daily_count = alert_daily_limit.load(uid, now, _ORTS_ZONE)
 
         settings = _settings_email_capable_dummy()
         sent_subjects: list[str] = []
@@ -440,7 +443,7 @@ def test_ac6_suppressed_run_leaves_throttle_and_daily_limit_untouched():
         # Zähler-Snapshot NACH dem Lauf — frische Store-Instanz, kein
         # In-Memory-Zustand aus dem Lauf selbst.
         after_last_sent = ThrottleStore(uid).last_sent("compare_preset", preset_id)
-        after_daily_count = alert_daily_limit.load(uid, now)
+        after_daily_count = alert_daily_limit.load(uid, now, _ORTS_ZONE)
 
         assert after_last_sent == before_last_sent, (
             f"Sperrzeit-Zaehler wurde trotz durch Ruhezeit unterdruecktem Lauf "

--- a/tests/tdd/test_compare_anchor_target_date.py
+++ b/tests/tdd/test_compare_anchor_target_date.py
@@ -709,6 +709,7 @@ def test_f003_tagessprung_zwischen_sammeln_und_schreiben_verschiebt_den_anker_ni
     import services.scheduler_dispatch_service as dispatch_mod
     from app.loader import get_data_root
     from services.compare_slot_scheduler import presets_due_for_hour
+    from tests.helpers.compare_slot_time import utc_moment
     from services.dispatch_orchestrator import CompareDispatchStrategy
 
     sz = Szenario(monkeypatch, tmp_path, ALPEN_LAT, ALPEN_LON)
@@ -724,7 +725,7 @@ def test_f003_tagessprung_zwischen_sammeln_und_schreiben_verschiebt_den_anker_ni
     # T1 — Sammelzeitpunkt: der Systemtag ist Tag D, der Abend-Slot briefed
     # ueber D+1. Exakt das, was `CompareDispatchStrategy.collect_due()` mit
     # `date.today() == D` liefert.
-    faellig = presets_due_for_hour([preset], hour=18, today=tag_d)
+    faellig = presets_due_for_hour([preset], {}, utc_moment(tag_d, 18))
     assert len(faellig) == 1, (
         "Fixtur-Schutz: der Abend-Slot muss zur Stunde 18 faellig sein, sonst "
         f"bewacht der Test nichts. Gefunden: {faellig!r}"

--- a/tests/tdd/test_compare_dispatch_failed_tally.py
+++ b/tests/tdd/test_compare_dispatch_failed_tally.py
@@ -36,6 +36,7 @@ import pytest
 
 from app.models import ForecastDataPoint, ThunderLevel
 from tests.helpers.compare_briefings import write_compare_briefings
+from tests.helpers.compare_slot_time import utc_slot_for_manual_hour
 
 TARGET_DATE = date(2026, 7, 18)
 
@@ -72,6 +73,23 @@ def _preset(preset_id: str, location_ids: list[str], **extra) -> dict:
     }
     preset.update(extra)
     return preset
+
+
+def _broken_preset(preset_id: str, location_ids: list[str], **extra) -> dict:
+    """Ein faelliges Preset, dessen Versand am unaufloesbaren Ort scheitert.
+
+    Issue #1726: der Fehlschlag-Pfad und die Zonen-Aufloesung haengen seither
+    an DERSELBEN Bedingung — loest keiner der `location_ids` einen Ort auf,
+    scheitert nicht nur `order_locations_by_ids`, sondern es gibt auch keine
+    Ortszone, und das Preset rechnet in UTC. Der Ausloeser `hour=6` verankert
+    in Europe/Vienna; ohne eigenen Slot waere so ein Preset also gar nicht
+    mehr faellig und der Fehlschlag traete nie ein. Der Slot wird deshalb auf
+    die UTC-Stunde desselben Zeitpunkts gesetzt (berechnet, nicht getippt).
+    Die geprueften Zaehler bleiben unveraendert.
+    """
+    return _preset(
+        preset_id, location_ids, morning_time=utc_slot_for_manual_hour(6), **extra,
+    )
 
 
 @pytest.fixture
@@ -222,8 +240,8 @@ class TestTotalFailureVisible:
 
         data_root, user_id = dispatch_env
         _write_presets(data_root, user_id, [
-            _preset("cp-fail-1", ["loc-missing-a"]),
-            _preset("cp-fail-2", ["loc-missing-b"]),
+            _broken_preset("cp-fail-1", ["loc-missing-a"]),
+            _broken_preset("cp-fail-2", ["loc-missing-b"]),
         ])
 
         result = run_compare_presets_daily(
@@ -250,8 +268,8 @@ class TestTotalFailureVisible:
 
         data_root, user_id = dispatch_env
         _write_presets(data_root, user_id, [
-            _preset("cp-fail-1", ["loc-missing-a"]),
-            _preset("cp-fail-2", ["loc-missing-b"]),
+            _broken_preset("cp-fail-1", ["loc-missing-a"]),
+            _broken_preset("cp-fail-2", ["loc-missing-b"]),
         ])
 
         client = TestClient(app)
@@ -296,7 +314,7 @@ def test_mixed_run_reports_exact_success_and_failure_counts(
     _write_location(data_root, user_id, "loc-ibk", "Innsbruck")
     _write_presets(data_root, user_id, [
         _preset("cp-a-ok", ["loc-ibk"]),
-        _preset("cp-b-bad", ["loc-missing"]),
+        _broken_preset("cp-b-bad", ["loc-missing"]),
     ])
 
     result = run_compare_presets_daily(
@@ -385,7 +403,7 @@ def test_broken_preset_only_increments_failed_others_still_dispatch(
     # Alphabetische Dateinamen-Ordnung: das kaputte Preset liegt in der Mitte.
     _write_presets(data_root, user_id, [
         _preset("cp-a-ok", ["loc-ibk"]),
-        _preset("cp-b-broken", ["loc-missing"]),
+        _broken_preset("cp-b-broken", ["loc-missing"]),
         _preset("cp-c-ok", ["loc-ibk"]),
     ])
 

--- a/tests/tdd/test_compare_official_alert.py
+++ b/tests/tdd/test_compare_official_alert.py
@@ -18,6 +18,7 @@ import json
 import shutil
 import uuid
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 from pathlib import Path
 
 from app.config import Settings
@@ -644,7 +645,11 @@ def test_ac1_quiet_hours_suppresses_send_state_and_limit(monkeypatch):
             f"Waehrend Ruhezeit unterdrueckte Warnung darf KEINEN State schreiben "
             f"(sonst wird sie nach Ende der Ruhezeit als 'schon gemeldet' verschluckt): {state!r}"
         )
-        assert alert_daily_limit.load(uid, frozen_midnight) == 0, (
+        # Issue #1726: der Zaehler laeuft in der Ortszone des ersten Orts;
+        # Hermagor liegt in Europe/Vienna.
+        assert alert_daily_limit.load(
+            uid, frozen_midnight, ZoneInfo("Europe/Vienna"),
+        ) == 0, (
             "Tageslimit darf bei unterdruecktem Versand NICHT erhoeht werden"
         )
     finally:

--- a/tests/tdd/test_compare_preset_loader.py
+++ b/tests/tdd/test_compare_preset_loader.py
@@ -39,6 +39,7 @@ from app.loader import (
 )
 from app.models import ComparePreset
 from services.compare_slot_scheduler import presets_due_for_hour
+from tests.helpers.compare_slot_time import utc_moment
 from services.scheduler_dispatch_service import (
     run_compare_presets_daily,
     save_compare_preset_status,
@@ -226,14 +227,14 @@ def test_ac5_presets_due_for_hour_identical_via_raw_dict_and_new_loader(tmp_path
     # Alter Pfad: rohes json.loads, wie es die 5 Call-Sites bisher taten.
     # _write_presets liefert das briefings/-Verzeichnis -> user_dir ist dessen Elternteil.
     raw_presets = read_compare_briefings(path.parent)
-    due_old = presets_due_for_hour(raw_presets, hour, today)
+    due_old = presets_due_for_hour(raw_presets, {}, utc_moment(today, hour))
 
     # Neuer Pfad: zentraler Loader + Dataclass -> Dict-Form via dem
     # produktiv genutzten compare_preset_to_dict() fuer die bestehende
     # reine Funktion presets_due_for_hour.
     loaded = load_compare_presets(user_id="testuser", data_root=str(data_root))
     due_new = presets_due_for_hour(
-        [compare_preset_to_dict(p) for p in loaded], hour, today
+        [compare_preset_to_dict(p) for p in loaded], {}, utc_moment(today, hour)
     )
 
     # Issue #1661 (Adversary-Finding F003): `presets_due_for_hour` liefert

--- a/tests/tdd/test_compare_preset_slot_dispatch.py
+++ b/tests/tdd/test_compare_preset_slot_dispatch.py
@@ -10,7 +10,7 @@ Getestet wird ein noch nicht existierendes, rein deterministisches Modul
   Liest die 5 neuen Slot-Felder aus einem rohen Preset-Dict, wendet bei
   fehlendem `morning_time` (Nil-Check-Marker "Altdaten, nie migriert") die
   Migrations-Fallback-Tabelle aus der Spec an.
-- `presets_due_for_hour(presets, hour, today) -> list[DuePreset]`
+- `presets_due_for_hour(presets, all_locations, now_utc) -> list[DuePreset]`
   Liefert je faelligem Preset den Tagesbezug in BEIDEN Formen — Zieldatum
   (Morgen-Slot -> heute, Abend-Slot -> morgen) UND Versatz gegen den Ortstag
   (0 bzw. +1) —, inkl. Pause-/Archiv-/Laufzeit-Guards.
@@ -32,6 +32,7 @@ from datetime import date, timedelta
 import pytest
 
 from services.compare_slot_scheduler import presets_due_for_hour, resolve_preset_slots
+from tests.helpers.compare_slot_time import utc_moment
 from services.scheduler_dispatch_service import build_compare_preset_subject
 
 TODAY = date(2026, 7, 12)
@@ -76,8 +77,8 @@ def test_ac4_morning_slot_due_at_configured_hour_not_outside():
         evening_enabled=False, evening_time="18:00:00",
     )
 
-    due_at_7 = presets_due_for_hour([preset], hour=7, today=TODAY)
-    due_at_8 = presets_due_for_hour([preset], hour=8, today=TODAY)
+    due_at_7 = presets_due_for_hour([preset], {}, utc_moment(TODAY, 7))
+    due_at_8 = presets_due_for_hour([preset], {}, utc_moment(TODAY, 8))
 
     assert due_at_7 == [(preset, TODAY, 0)]
     assert due_at_8 == []
@@ -94,8 +95,8 @@ def test_ac5_evening_slot_due_targets_next_day():
         evening_enabled=True, evening_time="18:00:00",
     )
 
-    due_at_18 = presets_due_for_hour([preset], hour=18, today=TODAY)
-    due_at_17 = presets_due_for_hour([preset], hour=17, today=TODAY)
+    due_at_18 = presets_due_for_hour([preset], {}, utc_moment(TODAY, 18))
+    due_at_17 = presets_due_for_hour([preset], {}, utc_moment(TODAY, 17))
 
     assert due_at_18 == [(preset, TODAY + timedelta(days=1), 1)]
     assert due_at_17 == []
@@ -147,7 +148,7 @@ def test_migration_fallback_manual_still_paused_despite_active_slot():
     unabhaengig vom migrierten Slot."""
     preset = _without_slot_fields(_preset(schedule="manual"))
 
-    due = presets_due_for_hour([preset], hour=6, today=TODAY)
+    due = presets_due_for_hour([preset], {}, utc_moment(TODAY, 6))
 
     assert due == []
 
@@ -165,8 +166,8 @@ def test_ac6_manual_schedule_with_explicit_slots_never_due():
         evening_enabled=True, evening_time="18:00:00",
     )
 
-    due_morning = presets_due_for_hour([preset], hour=7, today=TODAY)
-    due_evening = presets_due_for_hour([preset], hour=18, today=TODAY)
+    due_morning = presets_due_for_hour([preset], {}, utc_moment(TODAY, 7))
+    due_evening = presets_due_for_hour([preset], {}, utc_moment(TODAY, 18))
 
     assert due_morning == []
     assert due_evening == []
@@ -184,7 +185,7 @@ def test_ac7_end_date_in_past_never_due():
         end_date=(TODAY - timedelta(days=1)).isoformat(),
     )
 
-    due = presets_due_for_hour([preset], hour=7, today=TODAY)
+    due = presets_due_for_hour([preset], {}, utc_moment(TODAY, 7))
 
     assert due == []
 
@@ -199,7 +200,7 @@ def test_ac7_end_date_today_still_due():
         end_date=TODAY.isoformat(),
     )
 
-    due = presets_due_for_hour([preset], hour=7, today=TODAY)
+    due = presets_due_for_hour([preset], {}, utc_moment(TODAY, 7))
 
     assert due == [(preset, TODAY, 0)]
 
@@ -214,7 +215,7 @@ def test_ac7_end_date_none_unbounded_still_due():
         end_date=None,
     )
 
-    due = presets_due_for_hour([preset], hour=7, today=TODAY)
+    due = presets_due_for_hour([preset], {}, utc_moment(TODAY, 7))
 
     assert due == [(preset, TODAY, 0)]
 
@@ -231,7 +232,7 @@ def test_ac8_archived_preset_never_due():
         archived_at="2026-07-01T00:00:00Z",
     )
 
-    due = presets_due_for_hour([preset], hour=7, today=TODAY)
+    due = presets_due_for_hour([preset], {}, utc_moment(TODAY, 7))
 
     assert due == []
 
@@ -248,7 +249,7 @@ def test_kl5_same_hour_for_morning_and_evening_yields_two_entries():
         evening_enabled=True, evening_time="09:45:00",
     )
 
-    due = presets_due_for_hour([preset], hour=9, today=TODAY)
+    due = presets_due_for_hour([preset], {}, utc_moment(TODAY, 9))
 
     assert due == [(preset, TODAY, 0), (preset, TODAY + timedelta(days=1), 1)]
 
@@ -265,7 +266,7 @@ def test_kl2_morning_time_minutes_are_ignored_for_due_check():
         evening_enabled=False, evening_time="18:00:00",
     )
 
-    due = presets_due_for_hour([preset], hour=7, today=TODAY)
+    due = presets_due_for_hour([preset], {}, utc_moment(TODAY, 7))
     _, morning_time, _, _ = resolve_preset_slots(preset)
 
     assert due == [(preset, TODAY, 0)]
@@ -288,8 +289,8 @@ def test_explicit_slot_fields_override_schedule_fallback():
         evening_enabled=True, evening_time="20:00:00",
     )
 
-    due_morning_hour = presets_due_for_hour([preset], hour=6, today=TODAY)
-    due_evening_hour = presets_due_for_hour([preset], hour=20, today=TODAY)
+    due_morning_hour = presets_due_for_hour([preset], {}, utc_moment(TODAY, 6))
+    due_evening_hour = presets_due_for_hour([preset], {}, utc_moment(TODAY, 20))
 
     assert due_morning_hour == []
     assert due_evening_hour == [(preset, TODAY + timedelta(days=1), 1)]
@@ -316,9 +317,9 @@ def test_ac11_two_user_preset_lists_evaluated_independently():
         evening_enabled=True, evening_time="07:00:00",
     )
 
-    result_a = presets_due_for_hour([preset_user_a], hour=7, today=TODAY)
-    result_b = presets_due_for_hour([preset_user_b], hour=7, today=TODAY)
-    combined = presets_due_for_hour([preset_user_a, preset_user_b], hour=7, today=TODAY)
+    result_a = presets_due_for_hour([preset_user_a], {}, utc_moment(TODAY, 7))
+    result_b = presets_due_for_hour([preset_user_b], {}, utc_moment(TODAY, 7))
+    combined = presets_due_for_hour([preset_user_a, preset_user_b], {}, utc_moment(TODAY, 7))
 
     assert result_a == [(preset_user_a, TODAY, 0)]
     assert result_b == [(preset_user_b, TODAY + timedelta(days=1), 1)]
@@ -370,7 +371,7 @@ def test_f002_corrupt_end_date_skips_only_that_preset():
         evening_enabled=False, evening_time="18:00:00",
     )
 
-    due = presets_due_for_hour([corrupt_preset, valid_preset], hour=7, today=TODAY)
+    due = presets_due_for_hour([corrupt_preset, valid_preset], {}, utc_moment(TODAY, 7))
 
     assert due == [(valid_preset, TODAY, 0)]
 
@@ -399,7 +400,7 @@ def test_f003_slot_versatz_und_zieldatum_stammen_aus_derselben_zeitabfrage():
         evening_enabled=True, evening_time="09:45:00",
     )
 
-    due = presets_due_for_hour([preset], hour=9, today=TODAY)
+    due = presets_due_for_hour([preset], {}, utc_moment(TODAY, 9))
 
     versaetze = [eintrag.tage_ab_ortstag for eintrag in due]
     assert versaetze == [0, 1], (

--- a/tests/tdd/test_compare_radar_alert.py
+++ b/tests/tdd/test_compare_radar_alert.py
@@ -32,6 +32,7 @@ import json
 import re
 import shutil
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 from pathlib import Path
 
 from app.config import Settings
@@ -198,9 +199,9 @@ def _quiet_hours_window_now(buffer_minutes: int = 3) -> tuple[str, str]:
     vergleicht seit D1 gegen Europe/Vienna-Lokalzeit statt UTC, daher wird das
     Fenster um die Vienna-lokale „jetzt"-Zeit gelegt — sonst würde jeder
     UTC-Offset (60/120 Min) den engen 3-Minuten-Puffer sprengen."""
-    from services.deviation_alert_engine import VIENNA
-
-    now = datetime.now(timezone.utc).astimezone(VIENNA)
+    # Issue #1726: die Zone ist kein Modul-Attribut mehr, sondern haengt am
+    # Ort. Die Presets dieser Datei liegen in Oesterreich -> Europe/Vienna.
+    now = datetime.now(timezone.utc).astimezone(ZoneInfo("Europe/Vienna"))
     start = (now - timedelta(minutes=buffer_minutes)).strftime("%H:%M")
     end = (now + timedelta(minutes=buffer_minutes)).strftime("%H:%M")
     return start, end

--- a/tests/tdd/test_data_root_migration_services.py
+++ b/tests/tdd/test_data_root_migration_services.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import json
 import uuid
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 from app.config import Settings
 from app.loader import get_data_dir
@@ -95,7 +96,7 @@ def test_ac3_radar_alert_throttle_file_under_isolated_root():
 
     record_nowcast_sent(
         user_id=uid, throttle_scope=_THROTTLE_SCOPE, throttle_key=preset_id,
-        now=datetime.now(timezone.utc),
+        now=datetime.now(timezone.utc), zone=ZoneInfo("Europe/Vienna"),
     )
 
     expected = get_data_dir(uid) / "throttle_state.json"

--- a/tests/tdd/test_issue_1070_daily_alert_limit.py
+++ b/tests/tdd/test_issue_1070_daily_alert_limit.py
@@ -89,14 +89,24 @@ def _counter_path(uid: str) -> Path:
     return get_data_dir(uid) / "alert_daily_count.json"
 
 
-def _today_vienna_date_str() -> str:
-    return datetime.now(timezone.utc).astimezone(ZoneInfo("Europe/Vienna")).date().isoformat()
+# Issue #1726: der Tageszaehler laeuft in der ORTSZONE des Gegenstands, nicht
+# mehr fest in Wien. Gemessen (`utils.timezone.tz_for_coords`):
+#   Trip-Wegpunkte dieser Datei (LAT/LON = 42.20/9.10, Korsika) -> Europe/Paris
+#   Vergleichs-Ort `loc-1555` (46.9/10.9)                       -> Europe/Vienna
+VIENNA = ZoneInfo("Europe/Vienna")
+TRIP_ZONE = ZoneInfo("Europe/Paris")
 
 
-def _seed_daily_counter(uid: str, count: int) -> None:
+def _today_str(zone: ZoneInfo) -> str:
+    return datetime.now(timezone.utc).astimezone(zone).date().isoformat()
+
+
+def _seed_daily_counter(uid: str, count: int, zone: ZoneInfo = TRIP_ZONE) -> None:
     path = _counter_path(uid)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps({"date": _today_vienna_date_str(), "count": count}))
+    path.write_text(json.dumps(
+        {"zones": {str(zone): {"date": _today_str(zone), "count": count}}}
+    ))
 
 
 # ═══════════════════ Modul-Ebene: services.alert_daily_limit ════════════════
@@ -114,30 +124,30 @@ class TestModuleFreeTierLimitAndViennaReset:
             _write_user_tier(uid, "free")
             day1 = datetime(2026, 7, 7, 10, 0, tzinfo=timezone.utc)
 
-            assert is_allowed(uid, day1) is True, "1. Alert am Tag muss erlaubt sein"
-            increment(uid, day1)
-            assert is_allowed(uid, day1) is True, "2. Alert (Free-Limit 2) muss noch erlaubt sein"
-            increment(uid, day1)
-            assert is_allowed(uid, day1) is False, (
+            assert is_allowed(uid, day1, VIENNA) is True, "1. Alert am Tag muss erlaubt sein"
+            increment(uid, day1, VIENNA)
+            assert is_allowed(uid, day1, VIENNA) is True, "2. Alert (Free-Limit 2) muss noch erlaubt sein"
+            increment(uid, day1, VIENNA)
+            assert is_allowed(uid, day1, VIENNA) is False, (
                 "3. Alert am selben Tag muss unterdrückt werden (Free-Limit 2 erreicht)"
             )
 
             data = json.loads(_counter_path(uid).read_text())
-            assert data == {"date": "2026-07-07", "count": 2}, (
+            assert data == {"zones": {"Europe/Vienna": {"date": "2026-07-07", "count": 2}}}, (
                 f"Zählerdatei nach 2 Increments unerwartet: {data}"
             )
 
             # AC-4: Vienna-Mitternachts-Reset, NICHT UTC.
             # 2026-07-07 23:30 UTC == 2026-07-08 01:30 Vienna (Sommerzeit UTC+2).
             day1_late_utc = datetime(2026, 7, 7, 23, 30, tzinfo=timezone.utc)
-            assert is_allowed(uid, day1_late_utc) is True, (
+            assert is_allowed(uid, day1_late_utc, VIENNA) is True, (
                 "Nach dem Vienna-Mitternachts-Übergang (23:30 UTC == 01:30 Vienna) "
                 "muss das volle Tagesbudget wieder verfügbar sein — Reset ist "
                 "Vienna-, nicht UTC-basiert"
             )
-            increment(uid, day1_late_utc)
+            increment(uid, day1_late_utc, VIENNA)
             data2 = json.loads(_counter_path(uid).read_text())
-            assert data2 == {"date": "2026-07-08", "count": 1}, (
+            assert data2 == {"zones": {"Europe/Vienna": {"date": "2026-07-08", "count": 1}}}, (
                 f"Nach Vienna-Reset erwartete Zählerdatei date=2026-07-08 count=1, got {data2}"
             )
         finally:
@@ -156,11 +166,11 @@ class TestModuleStandardTierLimit:
             _write_user_tier(uid, "standard")
             now = datetime(2026, 7, 7, 10, 0, tzinfo=timezone.utc)
             for i in range(4):
-                assert is_allowed(uid, now) is True, (
+                assert is_allowed(uid, now, VIENNA) is True, (
                     f"Standard-Nutzer: Alert Nr. {i + 1} muss noch erlaubt sein (Limit 4)"
                 )
-                increment(uid, now)
-            assert is_allowed(uid, now) is False, (
+                increment(uid, now, VIENNA)
+            assert is_allowed(uid, now, VIENNA) is False, (
                 "Standard-Nutzer: 5. Alert am selben Tag muss unterdrückt werden (Limit 4)"
             )
         finally:
@@ -178,8 +188,8 @@ class TestModulePremiumTierNoLimit:
             _write_user_tier(uid, "premium")
             now = datetime(2026, 7, 7, 10, 0, tzinfo=timezone.utc)
             for _ in range(6):
-                increment(uid, now)
-            assert is_allowed(uid, now) is True, (
+                increment(uid, now, VIENNA)
+            assert is_allowed(uid, now, VIENNA) is True, (
                 "Premium-Nutzer darf trotz count=6 nie durch das Tageslimit blockiert werden"
             )
         finally:
@@ -201,7 +211,7 @@ class TestModuleLoadResetSemantics:
             before_mtime = counter_path.stat().st_mtime_ns
 
             now = datetime(2026, 7, 7, 10, 0, tzinfo=timezone.utc)
-            result = load(uid, now)
+            result = load(uid, now, VIENNA)
 
             assert result == 0, "load() muss bei veraltetem Datum 0 liefern (Reset-Semantik)"
             after_mtime = counter_path.stat().st_mtime_ns
@@ -340,7 +350,7 @@ def test_ac1_radar_alert_suppressed_when_free_daily_limit_reached():
         )
 
         data = json.loads(_counter_path(uid).read_text())
-        assert data["count"] == 2, (
+        assert data["zones"][str(TRIP_ZONE)]["count"] == 2, (
             f"AC-1: Zähler darf bei unterdrücktem Alert nicht erhöht werden, got {data}"
         )
 
@@ -470,10 +480,20 @@ def _weather_data(segment_id: int | str = 1, **summary_kwargs) -> SegmentWeather
 
 def _deviation_trip(trip_id: str) -> Trip:
     """Trip mit Telegram-Briefing-Kanal und aktiver Δ-Erkennung (Vorbild
-    test_issue_816_alert_deviation.py `_trip`)."""
+    test_issue_816_alert_deviation.py `_trip`).
+
+    Issue #1726: der Wegpunkt liegt jetzt auf DENSELBEN Koordinaten wie die
+    Radar-Trips dieser Datei (`LAT`/`LON`, Korsika). Vorher stand er auf
+    47.0/11.0 (Europe/Vienna) — seit der Tageszaehler je ORTSZONE gefuehrt
+    wird, haetten die beiden Trips damit getrennte Kontingente, und AC-5
+    („kein Umgehungspfad zwischen Radar- und Deviation-Alerts") wuerde
+    versehentlich das Gegenteil messen: nicht den fehlenden Riegel, sondern
+    die gewollte Zonen-Trennung aus AC-7. Die Zusicherung des Tests bleibt
+    unveraendert, nur die Zone der beiden Gegenstaende ist jetzt dieselbe.
+    """
     stage = Stage(
         id="T1", name="Tag 1", date=date_type(2026, 4, 5),
-        waypoints=[Waypoint(id="G1", name="Start", lat=47.0, lon=11.0, elevation_m=1000.0)],
+        waypoints=[Waypoint(id="G1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0)],
     )
     trip = Trip(
         id=trip_id, name="1070 Deviation-Trip", stages=[stage],
@@ -532,7 +552,7 @@ def test_ac5_cross_path_daily_limit_shared_between_radar_and_deviation(telegram_
             )
 
         counter_data = json.loads(_counter_path(uid).read_text())
-        assert counter_data["count"] == 2, (
+        assert counter_data["zones"][str(TRIP_ZONE)]["count"] == 2, (
             f"Vorbedingung: Zähler muss nach 2 erfolgreichen Radar-Alerts bei 2 "
             f"stehen, got {counter_data}"
         )
@@ -606,7 +626,7 @@ def test_ac6_radar_gate_passes_but_no_channel_delivered_leaves_counter_unchanged
         assert not mail_calls
 
         now = datetime.now(timezone.utc)
-        after_count = load(uid, now)
+        after_count = load(uid, now, TRIP_ZONE)
         assert after_count == 1, (
             f"F001: Zähler darf bei delivered=False nicht erhöht werden, "
             f"erwartet 1 (unverändert), got {after_count}"
@@ -651,7 +671,7 @@ def test_ac2_wiring_standard_limit_allows_fourth_blocks_fifth():
 
         assert result == 1, f"AC-2: 4. Alert für Standard muss noch erlaubt sein, got {result}"
         assert len(mail_calls) == 1, "AC-2: 4. Alert muss per E-Mail versendet werden"
-        assert load(uid, datetime.now(timezone.utc)) == 4, "AC-2: Zähler muss auf 4 steigen"
+        assert load(uid, datetime.now(timezone.utc), TRIP_ZONE) == 4, "AC-2: Zähler muss auf 4 steigen"
 
         # count=4 -> 5. Alert blockiert
         trip_id_5th = f"trip-{uuid.uuid4().hex[:6]}"
@@ -670,7 +690,7 @@ def test_ac2_wiring_standard_limit_allows_fourth_blocks_fifth():
 
         assert result_5th == 0, f"AC-2: 5. Alert für Standard muss blockiert sein, got {result_5th}"
         assert not mail_calls_5th, "AC-2: 5. Alert darf keinen E-Mail-Versand auslösen"
-        assert load(uid, datetime.now(timezone.utc)) == 4, "AC-2: Zähler darf nicht steigen"
+        assert load(uid, datetime.now(timezone.utc), TRIP_ZONE) == 4, "AC-2: Zähler darf nicht steigen"
     finally:
         _clean_user(uid)
 
@@ -704,7 +724,7 @@ def test_ac3_wiring_premium_no_limit():
 
         assert result == 1, f"AC-3: Premium-Alert trotz count=6 muss erlaubt sein, got {result}"
         assert len(mail_calls) == 1, "AC-3: Premium-Alert muss versendet werden"
-        assert load(uid, datetime.now(timezone.utc)) == 7, "AC-3: Zähler muss weiter steigen"
+        assert load(uid, datetime.now(timezone.utc), TRIP_ZONE) == 7, "AC-3: Zähler muss weiter steigen"
     finally:
         _clean_user(uid)
 
@@ -739,7 +759,7 @@ def test_ac6_deviation_gate_passes_but_no_channel_delivered_leaves_counter_uncha
         result = svc.check_and_send_alerts(trip, cached, fresh_weather=fresh)
 
         assert result is False, "Kein Kanal konfiguriert -> delivered=False"
-        assert load(uid, datetime.now(timezone.utc)) == 1, (
+        assert load(uid, datetime.now(timezone.utc), TRIP_ZONE) == 1, (
             "F001 (Deviation): Zähler darf bei delivered=False nicht erhöht werden"
         )
     finally:
@@ -840,7 +860,7 @@ def test_ac1_1555_free_tier_first_forecast_change_alert_delivered_at_reduced_bou
             f"AC-1: erster forecast_change-Alarm bei count=0 muss zugestellt werden, got {result}"
         )
         assert telegram_sink.send_count() == 1, "AC-1: Telegram-Sink muss genau 1 Versand zeigen"
-        assert load(uid, datetime.now(timezone.utc)) == 1, "AC-1: Zähler muss auf 1 steigen"
+        assert load(uid, datetime.now(timezone.utc), TRIP_ZONE) == 1, "AC-1: Zähler muss auf 1 steigen"
     finally:
         _clean_user(uid)
 
@@ -880,7 +900,7 @@ def test_ac2_1555_free_tier_forecast_change_suppressed_but_nowcast_still_deliver
             f"AC-2: forecast_change muss bei count=1 (Reserve-Grenze 1) "
             f"unterdrückt werden, got {dev_result}"
         )
-        assert load(uid, datetime.now(timezone.utc)) == 1, (
+        assert load(uid, datetime.now(timezone.utc), TRIP_ZONE) == 1, (
             "AC-2: Zähler darf durch den unterdrückten forecast_change-Alarm nicht steigen"
         )
 
@@ -903,7 +923,7 @@ def test_ac2_1555_free_tier_forecast_change_suppressed_but_nowcast_still_deliver
             f"erlaubt sein, got {radar_result}"
         )
         assert len(mail_calls) == 1, "AC-2: nowcast-Alarm muss tatsächlich versendet werden"
-        assert load(uid, datetime.now(timezone.utc)) == 2, "AC-2: Zähler muss nach nowcast auf 2 steigen"
+        assert load(uid, datetime.now(timezone.utc), TRIP_ZONE) == 2, "AC-2: Zähler muss nach nowcast auf 2 steigen"
     finally:
         _clean_user(uid)
 
@@ -937,7 +957,7 @@ def test_ac3_1555_standard_tier_forecast_change_suppressed_but_nowcast_still_del
             f"AC-3: forecast_change muss bei count=2 (Standard, Reserve-Grenze 2) "
             f"unterdrückt werden, got {dev_result}"
         )
-        assert load(uid, datetime.now(timezone.utc)) == 2, (
+        assert load(uid, datetime.now(timezone.utc), TRIP_ZONE) == 2, (
             "AC-3: Zähler darf durch den unterdrückten forecast_change-Alarm nicht steigen"
         )
 
@@ -959,7 +979,7 @@ def test_ac3_1555_standard_tier_forecast_change_suppressed_but_nowcast_still_del
             f"erlaubt sein, got {radar_result}"
         )
         assert len(mail_calls) == 1, "AC-3: nowcast-Alarm muss tatsächlich versendet werden"
-        assert load(uid, datetime.now(timezone.utc)) == 3, "AC-3: Zähler muss nach nowcast auf 3 steigen"
+        assert load(uid, datetime.now(timezone.utc), TRIP_ZONE) == 3, "AC-3: Zähler muss nach nowcast auf 3 steigen"
     finally:
         _clean_user(uid)
 
@@ -990,7 +1010,7 @@ def test_ac4_1555_premium_tier_unlimited_for_both_forecast_change_and_nowcast(te
 
         assert dev_result is True, f"AC-4: Premium forecast_change trotz count=6 muss zugestellt werden, got {dev_result}"
         assert telegram_sink.send_count() == 1
-        assert load(uid, datetime.now(timezone.utc)) == 7, "AC-4: Zähler steigt weiter (kein Deckel)"
+        assert load(uid, datetime.now(timezone.utc), TRIP_ZONE) == 7, "AC-4: Zähler steigt weiter (kein Deckel)"
 
         trip_id = f"trip-radar-{uid}"
         radar_trip = _make_trip(trip_id, send_email=True, send_telegram=False)
@@ -1007,7 +1027,7 @@ def test_ac4_1555_premium_tier_unlimited_for_both_forecast_change_and_nowcast(te
 
         assert radar_result == 1, f"AC-4: Premium nowcast trotz count=7 muss zugestellt werden, got {radar_result}"
         assert len(mail_calls) == 1
-        assert load(uid, datetime.now(timezone.utc)) == 8
+        assert load(uid, datetime.now(timezone.utc), TRIP_ZONE) == 8
     finally:
         _clean_user(uid)
 
@@ -1031,7 +1051,7 @@ def test_ac5_1555_is_allowed_without_reason_argument_uses_full_limit_backward_co
         _seed_daily_counter(uid, 1)
         now = datetime.now(timezone.utc)
 
-        assert is_allowed(uid, now) is True, (
+        assert is_allowed(uid, now, TRIP_ZONE) is True, (
             "AC-5: is_allowed(uid, now) ohne reason muss bei count=1/Free "
             "gegen das volle Limit (2) prüfen -> True, nicht gegen die "
             "reduzierte forecast_change-Obergrenze (1)"
@@ -1064,7 +1084,7 @@ def test_ac6_1555_compare_forecast_change_suppressed_at_reserve_boundary():
     _clean_compare_preset_dir(uid)
     try:
         _write_user_tier(uid, "free")
-        _seed_daily_counter(uid, 1)
+        _seed_daily_counter(uid, 1, VIENNA)
 
         loc = SavedLocation(id="loc-1555", name="ReserveOrt", lat=46.9, lon=10.9, elevation_m=900)
         save_location(loc, user_id=uid)
@@ -1090,7 +1110,7 @@ def test_ac6_1555_compare_forecast_change_suppressed_at_reserve_boundary():
             f"count=1 (Free, Reserve-Grenze 1) unterdrücken, got sent={sent}"
         )
         assert sent_subjects == [], "AC-6: mail_sink wurde trotz Reserve aufgerufen"
-        assert alert_daily_limit.load(uid, datetime.now(timezone.utc)) == 1, (
+        assert alert_daily_limit.load(uid, datetime.now(timezone.utc), VIENNA) == 1, (
             "AC-6: Zähler darf bei unterdrücktem Compare-Alarm nicht steigen"
         )
     finally:

--- a/tests/tdd/test_issue_1168_alert_engine_extract.py
+++ b/tests/tdd/test_issue_1168_alert_engine_extract.py
@@ -343,13 +343,16 @@ def test_ac2_quiet_hours_midnight_wrap_suppresses_alert(telegram_sink, clean_use
     )
 
     # Teil 2: End-to-End über check_and_send_alerts(), Ruhezeitfenster dynamisch
-    # um die echte aktuelle Uhrzeit gelegt (±1h), kein Zeit-Mock. Issue #1312:
-    # `is_quiet_hours` vergleicht seit D1 gegen Europe/Vienna-Lokalzeit, daher
-    # muss das Fenster um die Vienna-lokale "jetzt"-Zeit zentriert werden statt
-    # um die rohe UTC-Zeit — sonst reißt der CEST-Offset (+2h) das Fenster.
-    from services.deviation_alert_engine import VIENNA
+    # um die echte aktuelle Uhrzeit gelegt (±1h), kein Zeit-Mock. Issue #1726:
+    # `is_quiet_hours` vergleicht in der ORTSZONE DER TOUR (vorher fest
+    # Europe/Vienna). Das Fenster wird deshalb um die Ortszeit ebendieser Tour
+    # zentriert — aus DERSELBEN Auflösung, die der Prüfling benutzt, statt aus
+    # einer im Test wiederholten Zonen-Annahme.
+    from services.trip_day import anchor_tz
 
-    now = datetime.now(timezone.utc).astimezone(VIENNA)
+    now = datetime.now(timezone.utc).astimezone(
+        anchor_tz(trip, datetime.now(timezone.utc))
+    )
     quiet_from = (now.replace(second=0, microsecond=0) - timedelta(hours=1)).time()
     quiet_to = (now.replace(second=0, microsecond=0) + timedelta(hours=1)).time()
     trip.alert_quiet_from = quiet_from.strftime("%H:%M")

--- a/tests/tdd/test_issue_461_compare_preset_dispatch.py
+++ b/tests/tdd/test_issue_461_compare_preset_dispatch.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import pytest
 
 from tests.helpers.compare_briefings import read_compare_briefings, write_compare_briefings
+from tests.helpers.compare_slot_time import utc_slot_for_manual_hour
 
 
 # ---------------------------------------------------------------------------
@@ -249,12 +250,17 @@ class TestComparePresetsFilterLogic:
         from services.scheduler_dispatch_service import run_compare_presets_daily as _run_compare_presets_daily
 
         # Preset mit leeren location_ids → sollte error_count erhöhen, nicht crashen
+        # Issue #1726: ohne aufloesbaren Ort gibt es auch keine Ortszone, das
+        # Preset rechnet also in UTC — waehrend `hour=6` in der Referenz-Zone
+        # Europe/Vienna verankert ist. Der Slot bekommt deshalb die UTC-Stunde
+        # desselben Zeitpunkts, sonst ist das Preset nicht mehr faellig und der
+        # Fehlschlag, den `failed == 1` nachweist, faende gar nicht statt.
         bad_preset = _make_preset(preset_id="cp-bad", schedule="daily", location_ids=[])
+        bad_preset["morning_time"] = utc_slot_for_manual_hour(6)
         _write_presets(tmp_path, "default", [bad_preset])
 
         # Kein pytest.raises — Fehler werden intern abgefangen
-        # hour=6: expliziter Morgen-Slot (Default-Fallback ohne morning_time,
-        # s. resolve_preset_slots) -- macht das Preset deterministisch
+        # hour=6: expliziter Morgen-Slot -- macht das Preset deterministisch
         # faellig, statt von der Wanduhrzeit des Testlaufs abzuhaengen
         # (Issue #1290 Nebenbefund: die neue failed==1-Assertion braucht
         # einen tatsaechlich fahrplanmaessig faelligen Lauf).

--- a/tests/tdd/test_issue_509_preset_migration.py
+++ b/tests/tdd/test_issue_509_preset_migration.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from tests.helpers.compare_briefings import write_compare_briefings
+from tests.helpers.compare_slot_time import utc_slot_for_manual_hour
 
 
 # ---------------------------------------------------------------------------
@@ -74,11 +75,16 @@ class TestEmpfaengerFallback:
 
         preset = _minimal_preset("cp-no-emp", empfaenger=[])
         preset["location_ids"] = ["loc-x"]
+        # Issue #1726: `loc-x` existiert nicht, damit hat das Preset keine
+        # Ortszone und rechnet in UTC — `hour=6` ist aber in Europe/Vienna
+        # verankert. Ohne den passenden UTC-Slot waere es nicht mehr faellig
+        # und die erwartete Warnung entstuende nie.
+        preset["morning_time"] = utc_slot_for_manual_hour(6)
         _write_presets(tmp_path, "fallback-user", [preset])
 
         with caplog.at_level(logging.WARNING, logger="scheduler.dispatch"):
-            # hour=6 fixiert den Morgen-Slot (Fallback morning_time=06:00),
-            # sonst ist das Preset nur zur realen Vienna-Stunde 6 faellig (Zeit-Flake).
+            # hour=6 fixiert den Morgen-Slot, sonst ist das Preset nur zur
+            # realen Vienna-Stunde 6 faellig (Zeit-Flake).
             _run_compare_presets_daily(user_id="fallback-user", data_root=str(tmp_path), hour=6)
 
         skip_msgs = [r.message for r in caplog.records if "empfaenger" in r.message.lower()]
@@ -105,6 +111,11 @@ class TestEmpfaengerFallback:
 
         preset = _minimal_preset("cp-fallback", empfaenger=[])
         preset["location_ids"] = ["loc-does-not-exist"]  # nicht leer, aber kein Match
+        # Issue #1726: kein aufloesbarer Ort → keine Ortszone → das Preset
+        # rechnet in UTC, `hour=6` verankert dagegen in Europe/Vienna. Ohne
+        # den passenden UTC-Slot bliebe das Preset unfaellig und der gepruefte
+        # "nicht aufloesbar"-Abbruch traete nie ein.
+        preset["morning_time"] = utc_slot_for_manual_hour(6)
         _write_presets(tmp_path, "fallback-user2", [preset])
 
         with caplog.at_level(logging.INFO, logger="scheduler.dispatch"):

--- a/tests/tdd/test_issue_511_weekly_scheduler.py
+++ b/tests/tdd/test_issue_511_weekly_scheduler.py
@@ -15,10 +15,12 @@ KEINE MOCKS — Projektkonvention (CLAUDE.md).
 """
 from __future__ import annotations
 
+import json
 import logging
 from datetime import date
 from pathlib import Path
 from tests.helpers.compare_briefings import write_compare_briefings
+from tests.helpers.compare_slot_time import utc_slot_for_manual_hour
 
 import pytest
 
@@ -64,6 +66,52 @@ def _write_presets(tmp_path: Path, user_id: str, presets: list[dict]) -> Path:
     return user_dir
 
 
+def _due_in_utc(preset: dict) -> dict:
+    """Setzt den Morgen-Slot eines ortslosen Presets auf die UTC-Stunde, die
+    dem Ausloeser `hour=6` entspricht (Issue #1726).
+
+    Presets dieser Datei tragen absichtlich `location_ids=[]` — der Versand
+    soll frueh und netzfrei am unaufloesbaren Ort scheitern, damit die
+    Verarbeitung im Log nachweisbar ist. Seit #1726 hat ein solches Preset
+    aber auch keine Ortszone und rechnet in UTC, waehrend `hour=6` in
+    Europe/Vienna verankert ist: ohne diesen Slot ist es nicht mehr faellig,
+    wird nie versendet — und die Log-Zusicherung waere allein durch die
+    Zonen-Warnung erfuellt, ohne dass je ein Versand stattfand.
+    """
+    preset["morning_time"] = utc_slot_for_manual_hour(6)
+    return preset
+
+
+def _write_location(tmp_path: Path, user_id: str, loc_id: str) -> None:
+    """Legt einen echten Ort mit Koordinaten an (Innsbruck → Europe/Vienna).
+
+    Fuer Presets, die NICHT am Ort scheitern sollen: ein Ort mit gueltigen
+    Koordinaten loest seit #1726 immer eine Zone auf, das Preset laeuft damit
+    auf der Ortszeit und erzeugt keine Zonen-Warnung.
+    """
+    loc_dir = tmp_path / "users" / user_id / "locations"
+    loc_dir.mkdir(parents=True, exist_ok=True)
+    (loc_dir / f"{loc_id}.json").write_text(
+        json.dumps({
+            "id": loc_id, "name": "Innsbruck", "lat": 47.27, "lon": 11.39,
+            "elevation_m": 574,
+        }),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def locations_from_tmp(tmp_path, monkeypatch):
+    """Bindet `load_all_locations` an `tmp_path`.
+
+    Die Tests reichen `data_root` als Argument durch, `load_all_locations`
+    liest aber ausschliesslich den Modul-Datenpfad — ohne diese Bindung
+    schaute die Ortsaufloesung am echten `data/users/` vorbei."""
+    from app import loader as app_loader
+
+    monkeypatch.setattr(app_loader, "_DATA_ROOT", str(tmp_path))
+
+
 # ---------------------------------------------------------------------------
 # Klasse 1: TestWeeklyPresetDispatch
 # ---------------------------------------------------------------------------
@@ -85,32 +133,48 @@ class TestWeeklyPresetDispatch:
 
         RED: schlägt aktuell fehl, weil weekly still mit `continue` übersprungen wird
              (keine Log-Ausgabe mit der preset_id)
+
+        Issue #1726: die Zusicherung verlangt jetzt die Abbruch-Meldung des
+        VERSANDS (`"Preset <id>: …"` aus `_dispatch_due_preset`), statt die
+        preset_id irgendwo im Log zu suchen. Seit #1726 nennt auch die
+        Zonen-Warnung die preset_id — die alte Fassung war damit erfüllt, OHNE
+        dass je ein Versand stattfand (gemessen: das Preset war gar nicht mehr
+        fällig, einzige Log-Zeile war die Zonen-Warnung). Geprüft wird das
+        Präfix, nicht der Abbruch-GRUND: ob der Helper am fehlenden Empfänger
+        oder am unauflösbaren Ort abbricht, hängt an der Konto-Konfiguration
+        der Testumgebung; beide belegen gleich gut, dass er lief.
         """
         from services.scheduler_dispatch_service import run_compare_presets_daily as _run_compare_presets_daily
 
         today_weekday = date.today().weekday()
-        preset = _make_preset(
+        preset = _due_in_utc(_make_preset(
             preset_id="cp-weekly-match",
             schedule="weekly",
             weekday=today_weekday,
             location_ids=[],  # leer → löst "no location_ids" warning aus, wenn verarbeitet
             empfaenger=["test@example.com"],
-        )
+        ))
         _write_presets(tmp_path, "default", [preset])
 
         with caplog.at_level(logging.WARNING):
-            # hour=6 fixiert den Morgen-Slot (Fallback morning_time=06:00),
-            # sonst nur zur realen Vienna-Stunde 6 faellig (Zeit-Flake).
+            # hour=6 fixiert den Morgen-Slot, sonst nur zur realen
+            # Vienna-Stunde 6 faellig (Zeit-Flake).
             _run_compare_presets_daily(user_id="default", data_root=str(tmp_path), hour=6)
 
-        # Nach Fix: Preset wurde versucht → Log enthält "cp-weekly-match"
+        # Nach Fix: Preset wurde versucht → Log enthält den Versand-Abbruch
         # Aktuell (RED): Preset still übersprungen → kein Log-Eintrag
-        assert any("cp-weekly-match" in record.message for record in caplog.records), (
+        assert any(
+            record.message.startswith("Preset cp-weekly-match:")
+            for record in caplog.records
+        ), (
             "Weekly-Preset mit passendem Wochentag muss verarbeitet werden (Log-Warnung "
-            "über leere location_ids erwartet), wird aber still übersprungen."
+            "über leere location_ids erwartet), wird aber still übersprungen. "
+            f"Log: {[r.message for r in caplog.records]}"
         )
 
-    def test_weekly_preset_silently_skipped_on_non_matching_weekday(self, tmp_path, caplog):
+    def test_weekly_preset_silently_skipped_on_non_matching_weekday(
+        self, tmp_path, caplog, locations_from_tmp,
+    ):
         """
         AC-2
         GIVEN: compare_presets.json mit einem weekly-Preset, weekday == morgen
@@ -118,16 +182,26 @@ class TestWeeklyPresetDispatch:
         THEN: Preset wird still übersprungen — kein Log, kein Fehler
 
         Dieser Test ist von Anfang an grün (vor und nach Fix gleich).
+
+        Issue #1726: das Preset bekommt einen ECHTEN Ort statt leerer
+        `location_ids`. Ein ortsloses Preset hat seit #1726 keine Ortszone und
+        meldet das — zu Recht, aber die Meldung nennt die preset_id und
+        verletzt damit die Zusicherung "kein Log-Eintrag", obwohl der geprüfte
+        Wochentag-Guard weiterhin still überspringt. Mit Ort (Innsbruck →
+        Europe/Vienna) trifft die Ortsstunde die Referenz-Zone des Auslösers,
+        das Preset ist am richtigen Slot, und allein der Wochentag entscheidet
+        — genau die geprüfte Aussage.
         """
         from services.scheduler_dispatch_service import run_compare_presets_daily as _run_compare_presets_daily
 
         today_weekday = date.today().weekday()
         tomorrow_weekday = (today_weekday + 1) % 7
+        _write_location(tmp_path, "default", "loc-ibk")
         preset = _make_preset(
             preset_id="cp-weekly-tomorrow",
             schedule="weekly",
             weekday=tomorrow_weekday,
-            location_ids=[],
+            location_ids=["loc-ibk"],
         )
         _write_presets(tmp_path, "default", [preset])
 
@@ -152,21 +226,26 @@ class TestWeeklyPresetDispatch:
               manual wird still übersprungen (kein Log-Eintrag)
 
         RED: schlägt aktuell fehl, weil weekly still übersprungen wird (kein Log für cp-weekly-both)
+
+        Issue #1726: wie bei AC-1 verlangen die beiden Positiv-Zusicherungen
+        jetzt das Präfix der Versand-Abbruchmeldung. Die bloße preset_id im Log
+        steht seit #1726 auch in der Zonen-Warnung eines ortslosen Presets und
+        belegt damit keine Verarbeitung mehr.
         """
         from services.scheduler_dispatch_service import run_compare_presets_daily as _run_compare_presets_daily
 
         today_weekday = date.today().weekday()
-        daily = _make_preset(
+        daily = _due_in_utc(_make_preset(
             preset_id="cp-daily-both",
             schedule="daily",
             location_ids=[],
-        )
-        weekly = _make_preset(
+        ))
+        weekly = _due_in_utc(_make_preset(
             preset_id="cp-weekly-both",
             schedule="weekly",
             weekday=today_weekday,
             location_ids=[],
-        )
+        ))
         manual = _make_preset(
             preset_id="cp-manual-both",
             schedule="manual",
@@ -178,12 +257,18 @@ class TestWeeklyPresetDispatch:
             # hour=6: deterministischer Morgen-Slot (s.o.).
             _run_compare_presets_daily(user_id="default", data_root=str(tmp_path), hour=6)
 
-        assert any("cp-daily-both" in r.message for r in caplog.records), (
-            "Daily-Preset muss verarbeitet werden (Log-Warnung über leere location_ids)"
+        assert any(
+            r.message.startswith("Preset cp-daily-both:") for r in caplog.records
+        ), (
+            "Daily-Preset muss verarbeitet werden (Log-Warnung über leere location_ids). "
+            f"Log: {[r.message for r in caplog.records]}"
         )
-        assert any("cp-weekly-both" in r.message for r in caplog.records), (
+        assert any(
+            r.message.startswith("Preset cp-weekly-both:") for r in caplog.records
+        ), (
             "Weekly-Preset mit passendem Wochentag muss verarbeitet werden — "
-            "aktuell (RED) wird es still übersprungen"
+            f"aktuell (RED) wird es still übersprungen. "
+            f"Log: {[r.message for r in caplog.records]}"
         )
         assert not any("cp-manual-both" in r.message for r in caplog.records), (
             "Manual-Preset muss still übersprungen werden (kein Log-Eintrag)"

--- a/tests/tdd/test_issue_649_compare_daily_dedup.py
+++ b/tests/tdd/test_issue_649_compare_daily_dedup.py
@@ -27,8 +27,18 @@ faellig". `_daily_preset()` hat keine Slot-Felder → Migrations-Fallback
 (Morgen-Slot aktiv @06:00, siehe `compare_slot_scheduler.resolve_preset_slots`).
 Alle Aufrufe hier uebergeben deshalb explizit `hour=6`, damit die Tests
 deterministisch bleiben (statt von der aktuellen Wanduhrzeit abzuhaengen).
+
+Update #1726: `hour=6` ist in der Referenz-Zone Europe/Vienna verankert. Die
+Presets hier haben absichtlich KEINEN aufloesbaren Ort (das ist der gepruefte
+Fehlschlag-Pfad) und damit seither auch keine Ortszone — sie rechnen in UTC
+und sehen zu diesem Zeitpunkt eine andere Stunde. Der Morgen-Slot wird deshalb
+auf die UTC-Stunde desselben Zeitpunkts gesetzt (`utc_slot_for_manual_hour`),
+sonst ist kein Preset mehr faellig und die Tests pruefen einen Lauf, der nie
+stattfindet. Der oben beschriebene Migrations-Rueckfall greift damit nicht
+mehr — er ist in `test_compare_preset_slot_dispatch.py` eigens geprueft.
 """
 from tests.helpers.compare_briefings import write_compare_briefings
+from tests.helpers.compare_slot_time import utc_slot_for_manual_hour
 import logging
 import uuid
 
@@ -53,6 +63,9 @@ def _daily_preset(preset_id="cp-649", location_ids=("loc-missing",), schedule="d
         "name": f"Vergleich {preset_id}",
         "location_ids": list(location_ids),
         "schedule": schedule,
+        # Issue #1726: ortslose Presets rechnen in UTC, der Ausloeser `hour=6`
+        # verankert in Europe/Vienna — ohne diesen Slot waeren sie unfaellig.
+        "morning_time": utc_slot_for_manual_hour(6),
         "profil": "SUMMER_TREKKING",
         "hour_from": 9,
         "hour_to": 16,

--- a/tests/tdd/test_issue_883_acute_danger_override.py
+++ b/tests/tdd/test_issue_883_acute_danger_override.py
@@ -416,18 +416,23 @@ def test_ac5_override_respects_quiet_hours():
     """AC-5: GUARD — konvektive Gefahr, aber jetzt ist Nachtruhe → KEIN Alert.
 
     Der Override durchbricht nur die Briefing-Unterdrückung, nicht die Quiet Hours.
-    Issue #1312: `is_quiet_hours` vergleicht seit D1 gegen Europe/Vienna-
-    Lokalzeit statt UTC, daher wird das Fenster um die Vienna-lokale „jetzt"-
-    Zeit gelegt — sonst läge die Vienna-Zeit bei CEST (+2h) genau am oberen
-    Fensterrand (potenziell flaky im Sommer).
+
+    🔴 Issue #1726: Dieser Test baute sein Ruhezeit-Fenster bis dahin über
+    `Europe/Vienna` — obwohl die Tour auf ISLAND liegt (`LAT`/`LON` = 64.0/
+    -22.0, `Atlantic/Reykjavik`, UTC+0). Er war nur deshalb grün, weil der
+    Prüfling denselben falschen Bezug benutzte; das ist der Fehler dieses
+    Issues, im Test selbst. Das Fenster kommt jetzt aus der ORTSZONE der Tour
+    — abgeleitet aus ihren eigenen Koordinaten, nicht erneut angenommen. Die
+    Zusicherung („der Override durchbricht die Nachtruhe nicht") ist
+    unverändert; sie wird jetzt an der Zone gemessen, an der sie wirkt.
     """
-    from services.deviation_alert_engine import VIENNA
+    from utils.timezone import tz_for_coords
 
     uid = f"tdd-883-ac5-{uuid.uuid4().hex[:6]}"
     _clean_user(uid)
     try:
-        now = datetime.now(timezone.utc).astimezone(VIENNA)
-        # Fenster um die Vienna-lokale "jetzt"-Zeit (±2h); _is_quiet_hours
+        now = datetime.now(timezone.utc).astimezone(tz_for_coords(LAT, LON))
+        # Fenster um die ORTS-lokale "jetzt"-Zeit (±2h); _is_quiet_hours
         # behandelt Mitternachts-Wrap.
         quiet_from = (now - timedelta(hours=2)).strftime("%H:%M")
         quiet_to = (now + timedelta(hours=2)).strftime("%H:%M")

--- a/tests/tdd/test_nowcast_suppression_logging.py
+++ b/tests/tdd/test_nowcast_suppression_logging.py
@@ -38,7 +38,7 @@ from tests.helpers.alert_log_fixtures import gust_alert_trip, weather
 from tests.helpers.nowcast_gate_fixtures import (
     LAT, LON, SCOPE_COMPARE_RADAR, SCOPE_TRIP_RADAR, CountingFrameSource,
     clean_uid, compare_radar_service, entries_for, fresh_uid, location,
-    make_trip, quiet_window_elsewhere, quiet_window_now, radar_preset,
+    TRIP_ZONE, make_trip, quiet_window_elsewhere, quiet_window_now, radar_preset,
     read_log, record_throttle, save_trip, seed_daily_counter,
     settings_email_only, suppression_reasons, trip_alert_service,
     write_presets, write_user_tier,
@@ -228,12 +228,17 @@ def _run_trip(
     uid: str, trip_id: str, *, quiet: bool = False, throttled: bool = False,
     daily_limit_reached: bool = False,
 ) -> int:
-    quiet_from, quiet_to = quiet_window_now() if quiet else quiet_window_elsewhere()
+    # Issue #1726: Ruhezeit und Zaehler laufen in der Ortszone der TOUR —
+    # `make_trip()` legt ihre Wegpunkte nach Island (TRIP_ZONE), nicht nach Wien.
+    quiet_from, quiet_to = (
+        quiet_window_now(zone=TRIP_ZONE) if quiet
+        else quiet_window_elsewhere(zone=TRIP_ZONE)
+    )
     save_trip(make_trip(trip_id, quiet_from=quiet_from, quiet_to=quiet_to), uid)
     if throttled:
         record_throttle(uid, SCOPE_TRIP_RADAR, trip_id,
                         datetime.now(timezone.utc) - timedelta(minutes=5))
-    seed_daily_counter(uid, 2 if daily_limit_reached else 0)
+    seed_daily_counter(uid, 2 if daily_limit_reached else 0, zone=TRIP_ZONE)
     return trip_alert_service(
         uid, settings_email_only(), CountingFrameSource(onset_minutes=8),
         lambda subject, body: None,

--- a/tests/tdd/test_ruhezeit_und_zaehler_folgen_der_ortszone.py
+++ b/tests/tdd/test_ruhezeit_und_zaehler_folgen_der_ortszone.py
@@ -85,11 +85,13 @@ from tests.helpers.nowcast_gate_fixtures import (  # noqa: E402
     location,
     make_trip,
     preset_root,
-    radar_preset,
+    read_daily_counter,
     reset_radar_cache,
     save_trip,
+    seed_daily_counter,
     settings_email_only,
     trip_alert_service,
+    trip_stage,
     write_user_tier,
 )
 
@@ -1395,4 +1397,431 @@ def test_ac15_kein_aufloesbarer_ort_ergibt_utc_und_einen_protokolleintrag(
     ), (
         "Der UTC-Rückfall darf nicht still geschehen: er gehört mit der "
         "Vergleichs-Kennung ins Protokoll."
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# FIX-LOOP 1 — drei Stellen, die KEIN Test bewachte
+#
+# Der Adversary hat die Verdrahtung als korrekt gelesen und trotzdem BROKEN
+# geurteilt — nicht behauptet, sondern gemessen: er hat den Produktivcode an
+# drei Stellen verfälscht, und die Suite blieb grün. Ein grüner Testlauf
+# beweist nur, dass die Tests durchlaufen, nicht dass sie etwas bewachen.
+#
+# Jeder Test dieses Abschnitts nennt im Docstring die Verfälschung, gegen die
+# er rot wird, und WARUM die vorhandenen Tests sie durchgelassen haben.
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _segment_wetter(precip_sum_mm: float, segment_id: int = 1):
+    """Ein echtes `SegmentWeatherData` mit vorgegebener Niederschlagssumme.
+
+    Aufbau übernommen aus `test_issue_1070_daily_alert_limit.py::_weather_data`
+    — dieselbe Δ-Erkennung, dieselben Feldnamen. Ohne echte Wetterdaten auf
+    BEIDEN Seiten (`cached` und `fresh`) wird `DeviationAlertEngine.evaluate()`
+    gar nicht erst erreicht; genau daran scheiterte die Absicherung von F001.
+    """
+    from app.models import (
+        ForecastMeta,
+        GPXPoint,
+        NormalizedTimeseries,
+        Provider,
+        SegmentWeatherData,
+        SegmentWeatherSummary,
+        TripSegment,
+    )
+
+    start = datetime(2026, 4, 5, 8, 0, tzinfo=UTC)
+    return SegmentWeatherData(
+        segment=TripSegment(
+            segment_id=segment_id,
+            start_point=GPXPoint(
+                lat=47.0, lon=11.0, elevation_m=1000, distance_from_start_km=12.0,
+            ),
+            end_point=GPXPoint(
+                lat=47.1, lon=11.1, elevation_m=1500, distance_from_start_km=18.0,
+            ),
+            start_time=start, end_time=start + timedelta(hours=4),
+            duration_hours=4.0, distance_km=6.0, ascent_m=500, descent_m=0,
+        ),
+        timeseries=NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="test", grid_res_km=1.0),
+            data=[],
+        ),
+        aggregated=SegmentWeatherSummary(precip_sum_mm=precip_sum_mm),
+        fetched_at=datetime.now(UTC),
+        provider="openmeteo",
+    )
+
+
+def _trip_mit_aenderungserkennung(user_id: str, trip_id: str, zone_name: str,
+                                  quiet: tuple[str, str]):
+    """Trip wie :func:`trip_mit_ruhezeit`, zusätzlich mit scharfer
+    Δ-Erkennung für `precipitation_sum` — sonst filtert die Engine die
+    Änderung als unbedeutend weg, bevor irgendetwas versendet wird."""
+    from app.models import MetricConfig, UnifiedWeatherDisplayConfig
+
+    trip = trip_mit_ruhezeit(user_id, trip_id, zone_name, quiet)
+    trip.display_config = UnifiedWeatherDisplayConfig(
+        trip_id=trip_id,
+        metrics=[MetricConfig(metric_id="precipitation", enabled=True)],
+        metric_alert_levels={"precipitation_sum": "standard"},
+    )
+    return trip
+
+
+def _deviation_versand(user_id: str, zone_name: str, quiet: tuple[str, str]):
+    """Ein VOLLSTÄNDIGER `check_and_send_alerts()`-Lauf mit echten Wetterdaten
+    auf beiden Seiten — bis in `DeviationAlertEngine.evaluate()` hinein und
+    weiter bis zum Versand. Liefert `(ergebnis, anzahl_versendeter_mails)`."""
+    from services.trip_alert import TripAlertService
+
+    gesendet: list = []
+    dienst = TripAlertService(
+        settings=settings_email_only(), throttle_hours=0, user_id=user_id,
+        mail_sink=lambda *a, **kw: gesendet.append((a, kw)),
+    )
+    trip = _trip_mit_aenderungserkennung(user_id, "t-kern-trip", zone_name, quiet)
+    ergebnis = dienst.check_and_send_alerts(
+        trip, [_segment_wetter(2.0)], fresh_weather=[_segment_wetter(18.0)],
+    )
+    return ergebnis, len(gesendet)
+
+
+def test_f001_zweite_ruhezeit_pruefung_der_engine_nutzt_die_trip_zone(sauberer_nutzer):
+    """F001 — `trip_alert.py:279`: die Zone in `AlertEvaluationConfig`.
+
+    Diese Zone wirkt NICHT an der Stelle, an der sie steht, sondern in der
+    ZWEITEN Ruhezeit-Prüfung, die innerhalb von `DeviationAlertEngine.
+    evaluate()` läuft (`deviation_alert_engine.py:285-287`).
+
+    Warum kein bestehender Test sie bewacht: alle Trip-Fixturen dieser Datei
+    halten `_fetch_fresh_weather()` bei `[]` an. Der Ablauf bricht dann schon
+    bei `trip_alert.py:252-254` ab — also VOR der Bildung der Konfiguration.
+    `evaluate()` wird über den TRIP-Erbauer nie erreicht; AC-3 Stelle 7 misst
+    ausschliesslich den COMPARE-Erbauer. Gemessen: eine fest verdrahtete
+    Wiener Zone an `:279` liess alle 52 Tests grün.
+
+    Wie dieser Test die INNERE Prüfung von der äusseren trennt: das
+    Ruhezeit-Fenster liegt um die WIENER Ortszeit. Die äussere Prüfung
+    (`:230`, Zone Auckland) lässt den Lauf damit durch — und die innere muss
+    dasselbe tun. Rechnet sie in Wien, unterdrückt sie, und nichts kommt an.
+
+    ROT bei der Verfälschung `zone=anchor_tz(trip, now_utc)` →
+    `ZoneInfo("Europe/Vienna")` an `:279`.
+    """
+    ergebnis, versendet = _deviation_versand(
+        sauberer_nutzer("f001-kern"), "Pacific/Auckland", fenster_um_jetzt(VIENNA),
+    )
+
+    assert ergebnis is True, (
+        "Ein Fenster um die WIENER Uhrzeit darf den Auckland-Trip nirgends "
+        "stilllegen — auch nicht in der zweiten Prüfung im Engine-Kern, die "
+        "ihre Zone aus `AlertEvaluationConfig` bezieht."
+    )
+    assert versendet >= 1, "Der Alarm muss tatsächlich hinausgehen, nicht nur True melden."
+
+    # Gegenprobe in derselben Bauart: liegt das Fenster um die AUCKLAND-Zeit,
+    # muss derselbe Lauf still bleiben. Ohne sie wäre die Zusicherung oben
+    # auch von einem Alarm erfüllt, der gar keine Ruhezeit mehr prüft.
+    ergebnis_ruhig, versendet_ruhig = _deviation_versand(
+        sauberer_nutzer("f001-kern-gegen"), "Pacific/Auckland",
+        fenster_um_jetzt(AUCKLAND),
+    )
+
+    assert ergebnis_ruhig is False
+    assert versendet_ruhig == 0, (
+        "Die Auckland-Ruhezeit muss denselben Lauf unterdrücken — sonst misst "
+        "die Zusicherung oben einen Pfad ohne jede Ruhezeit-Prüfung."
+    )
+
+
+# ── F002: `anchor_tz` gegen `trip_tz` — nur ein MEHRETAPPIGER Trip trennt sie ─
+#
+# `anchor_tz(trip, now)` liefert die Zone der Etappe des WELTZEIT-Tages,
+# `trip_tz(trip)` die der ERSTEN Etappe mit Wegpunkten. Bei einem Trip mit
+# genau einer Etappe ist das zwangsläufig dieselbe Zone — und jede Trip-Fixture
+# dieser Datei baut genau eine. Gemessen: ersetzt man JEDEN `anchor_tz`-Aufruf
+# in `trip_alert.py` durch `trip_tz(trip)`, bleibt die gesamte Suite grün.
+#
+# Das wiegt schwer, weil Abschnitt B der Spec ausdrücklich begründet, warum
+# `anchor_tz` nötig ist: „ein mehrtägiger Trek, der die Zone wechselt, braucht
+# die Zone SEINER AKTUELLEN Etappe, nicht die des Starttags". Diese Begründung
+# hatte bis hierher keinen Wächter.
+
+
+def trip_zwei_zonen(user_id: str, trip_id: str, *, erste_zone: str,
+                    heutige_zone: str, quiet: tuple[str | None, str | None]):
+    """Trip über ZWEI Etappen in verschiedenen Zonen.
+
+    Etappe 1 (erste der Liste, mit Wegpunkten, GESTERN) liegt in `erste_zone`
+    — das ist, was `trip_tz()` liefert. Etappe 2 trägt den heutigen
+    Weltzeit-Tag und liegt in `heutige_zone` — das ist, was `anchor_tz()`
+    liefert. Nur so lassen sich die beiden Auflösungen überhaupt
+    unterscheiden.
+    """
+    heute = datetime.now(UTC).date()
+    lat_erste, lon_erste = KOORDINATEN[erste_zone]
+    lat_heute, lon_heute = KOORDINATEN[heutige_zone]
+    trip = make_trip(
+        trip_id,
+        cooldown_minutes=0,
+        quiet_from=quiet[0],
+        quiet_to=quiet[1],
+        stage_date=heute - timedelta(days=1),
+        lat=lat_erste,
+        lon=lon_erste,
+        extra_stages=[
+            trip_stage("S2", heute, lat_heute, lon_heute, wp_prefix="B"),
+        ],
+    )
+    trip.report_config.alert_on_changes = True
+    save_trip(trip, user_id)
+    return trip
+
+
+def test_f002_anchor_tz_und_trip_tz_liefern_bei_diesem_trip_verschiedene_zonen():
+    """F002 (Vorbedingung, grüner Anker): Der Prüf-Trip der beiden folgenden
+    Tests trennt die zwei Auflösungen tatsächlich.
+
+    Kein Prüfling-Test — er sichert nur, dass die folgenden Zusicherungen
+    überhaupt etwas unterscheiden können. Fiele er, wären sie so blind wie die
+    einetappigen Fixturen, die den Fehler durchgelassen haben.
+    """
+    from services.trip_day import anchor_tz, trip_tz
+
+    trip = trip_zwei_zonen(
+        _uid("f002-vorbedingung"), "t-vorbedingung",
+        erste_zone="America/Los_Angeles", heutige_zone="Pacific/Auckland",
+        quiet=(None, None),
+    )
+    jetzt = datetime.now(UTC)
+
+    assert str(trip_tz(trip)) == "America/Los_Angeles", (
+        "Die erste Etappe mit Wegpunkten liegt in Los Angeles."
+    )
+    assert str(anchor_tz(trip, jetzt)) == "Pacific/Auckland", (
+        "Die Etappe des heutigen Weltzeit-Tages liegt in Auckland — nur wenn "
+        "beide Auflösungen hier auseinanderfallen, messen die folgenden Tests "
+        "die Wahl zwischen ihnen."
+    )
+    clean_uid(_uid("f002-vorbedingung"))
+
+
+def _zwei_zonen_lauf(user_id: str, quiet: tuple[str | None, str | None]) -> int:
+    """`check_and_send_alerts()` für den zweietappigen Trip; liefert die Zahl
+    der Wetterabrufe (0 = vorher unterdrückt)."""
+    dienst = trip_abweichungsdienst(user_id)
+    trip = trip_zwei_zonen(
+        user_id, "t-zwei-zonen",
+        erste_zone="America/Los_Angeles", heutige_zone="Pacific/Auckland",
+        quiet=quiet,
+    )
+    dienst.check_and_send_alerts(trip, cached_weather=[])
+    return type(dienst).fetch_aufrufe
+
+
+def test_f002_ruhezeit_folgt_der_heutigen_etappe_nicht_der_ersten(sauberer_nutzer):
+    """F002 (Ruhezeit) — `trip_alert.py:700` (`_is_quiet_hours`-Adapter).
+
+    Given ein Trek, dessen erste Etappe in Los Angeles liegt und dessen Etappe
+    des heutigen Tages in Auckland / When die Ruhezeit geprüft wird / Then
+    gilt die Zone der HEUTIGEN Etappe.
+
+    ROT bei der Verfälschung `anchor_tz(trip, now)` → `trip_tz(trip)`: dann
+    kippen BEIDE Zusicherungen gleichzeitig — der Auckland-Lauf liefe weiter,
+    der Los-Angeles-Lauf würde stillgelegt.
+    """
+    abrufe_heutige_etappe = _zwei_zonen_lauf(
+        sauberer_nutzer("f002-ruhe-heute"), fenster_um_jetzt(AUCKLAND),
+    )
+    abrufe_erste_etappe = _zwei_zonen_lauf(
+        sauberer_nutzer("f002-ruhe-erste"), fenster_um_jetzt(LOS_ANGELES),
+    )
+
+    assert abrufe_heutige_etappe == 0, (
+        "Die Ruhezeit muss der Zone der heutigen Etappe (Auckland) folgen."
+    )
+    assert abrufe_erste_etappe >= 1, (
+        "Die Zone der ERSTEN Etappe (Los Angeles) darf einen Trek, der längst "
+        "woanders ist, nicht mehr stilllegen — genau dafür gibt es `anchor_tz`."
+    )
+
+
+def test_f002_tageszaehler_folgt_der_heutigen_etappe_nicht_der_ersten(sauberer_nutzer):
+    """F002 (Tageszähler) — `trip_alert.py:243` (`is_allowed`).
+
+    Given derselbe Trek (erste Etappe Los Angeles, heutige Etappe Auckland)
+    und ein Free-Kontingent, das in EINER der beiden Zonen erschöpft ist /
+    When ein Abweichungs-Alarm ansteht / Then entscheidet der Auckland-Zähler.
+
+    Free-Limit 2, davon reserviert `reason="forecast_change"` einen Platz für
+    NowCast (#1555) — ein Stand von 1 sperrt also bereits.
+
+    ROT bei derselben Verfälschung wie oben (`anchor_tz` → `trip_tz`): dann
+    entscheidet der Los-Angeles-Zähler und beide Zusicherungen kippen.
+    """
+    def lauf(zone: ZoneInfo, kennung: str) -> int:
+        user_id = sauberer_nutzer(kennung)
+        seed_daily_counter(user_id, 1, zone=zone)
+        return _zwei_zonen_lauf(user_id, (None, None))
+
+    abrufe_bei_vollem_auckland = lauf(AUCKLAND, "f002-zaehler-heute")
+    abrufe_bei_vollem_la = lauf(LOS_ANGELES, "f002-zaehler-erste")
+
+    assert abrufe_bei_vollem_auckland == 0, (
+        "Erschöpftes Kontingent in der Zone der HEUTIGEN Etappe muss den "
+        "Alarm sperren — vor jedem Wetterabruf."
+    )
+    assert abrufe_bei_vollem_la >= 1, (
+        "Ein erschöpftes Kontingent in der Zone der ERSTEN Etappe geht diesen "
+        "Trek nichts mehr an; das Auckland-Kontingent steht auf 0."
+    )
+
+
+# ── F003: Prüfung und Buchung des Kontingents dürfen nicht auseinanderlaufen ──
+#
+# Beide Vergleichspfade lösen die Zone EINMAL auf und benutzen sie für die
+# Prüfung (`is_allowed`) UND die Buchung (`increment`). Dass beide dieselbe
+# Zone sehen, hängt allein an einer gemeinsamen lokalen Variable. Gemessen:
+# stellt man NUR `increment()` auf eine feste Wiener Zone um, bleibt alles
+# grün — AC-6/AC-7 prüfen `alert_daily_limit.*` ausschliesslich direkt über
+# den Testhelfer, nie über die tatsächlichen Aufrufstellen. `alert_gate.py`
+# benennt die Gefahr im eigenen Docstring: „wer hier eine andere zone
+# uebergibt als check_nowcast_gate(), fuellt einen anderen Zaehler als den
+# geprueften".
+#
+# Beide Tests unten laufen deshalb über den ECHTEN Preset-Lauf und messen die
+# Wirkung, die eine Divergenz hätte: der Riegel greift nicht mehr.
+
+
+def _amtlicher_vergleichsdienst_mit_warnung(user_id: str, gesendet: list):
+    """`CompareOfficialAlertService`, dessen Netz-Naht `_detect()` bei JEDEM
+    Lauf eine echte amtliche Warnung liefert — der Riegel, der den zweiten
+    bzw. dritten Lauf stoppen muss, ist dann allein das Tageskontingent."""
+    from services.compare_official_alert import CompareOfficialAlertService
+    from services.official_alerts.models import OfficialAlert
+
+    class _MitWarnung(CompareOfficialAlertService):
+        def _detect(self, preset_id, locs, sources=None):
+            warnung = OfficialAlert(
+                source="test-quelle", hazard="wind", level=3,
+                label="Sturmwarnung", region_label="Testregion",
+            )
+            return ([(warnung, [loc.id for loc in locs])], {})
+
+    return _MitWarnung(
+        settings=settings_email_only(), user_id=user_id,
+        mail_sink=lambda *a, **kw: gesendet.append((a, kw)),
+    )
+
+
+def test_f003_amtlicher_vergleich_bucht_in_der_zone_die_er_auch_prueft(
+    sauberer_nutzer,
+):
+    """F003 (amtliche Warnung) — `compare_official_alert.py:146` (`is_allowed`)
+    gegen `:190` (`increment`).
+
+    Given ein Free-Nutzer (Kontingent 2) mit einem Vergleich in Auckland /
+    When drei amtliche Warnungen nacheinander anstehen / Then gehen die ersten
+    beiden hinaus und die dritte wird gesperrt.
+
+    Das fängt eine Divergenz zwischen Prüf- und Buchungszone in BEIDE
+    Richtungen: bucht `increment()` woanders als `is_allowed()` prüft, steht
+    der geprüfte Zähler dauerhaft auf 0 und der Riegel greift nie.
+
+    ROT bei der Verfälschung `alert_daily_limit.increment(self._user_id, now,
+    zone)` → feste Wiener Zone an `:190` (dritter Lauf geht dann ebenfalls
+    hinaus).
+    """
+    user_id = sauberer_nutzer("f003-amtlich")
+    schreibe_ort(user_id, "loc-akl", "Pacific/Auckland")
+    schreibe_presets(user_id, [vergleichs_preset("cp-kontingent", ["loc-akl"])])
+
+    gesendet: list = []
+    dienst = _amtlicher_vergleichsdienst_mit_warnung(user_id, gesendet)
+    laeufe = [dienst.check_all_compare_presets() for _ in range(3)]
+
+    assert laeufe == [1, 1, 0], (
+        f"Free-Kontingent 2: zwei Warnungen gehen hinaus, die dritte ist "
+        f"gesperrt. Gemessen: {laeufe}"
+    )
+    assert read_daily_counter(user_id, zone=AUCKLAND) == 2, (
+        "Gebucht werden muss in DERSELBEN Zone, gegen die geprüft wird."
+    )
+    assert read_daily_counter(user_id, zone=VIENNA) == 0, (
+        "Eine Buchung auf der Wiener Uhr wäre ein Zähler, den niemand liest."
+    )
+
+
+class _OrtsWetterQuelle:
+    """Echte `LocationWeatherSource`-Naht (kein Mock): liefert für jeden Ort
+    ein festes `PointWeatherData` mit vorgegebener Niederschlagssumme, ohne
+    Netzzugriff. Vorbild: `test_issue_1070_daily_alert_limit.py::
+    _ScriptedComparePointSource`."""
+
+    def __init__(self, precip_sum_mm: float) -> None:
+        self._precip = precip_sum_mm
+
+    def fetch(self, point_id: str, lat: float, lon: float,
+              start_hour: int | None = None, end_hour: int | None = None):
+        from app.models import SegmentWeatherSummary
+        from services.point_weather import PointWeatherData
+
+        return PointWeatherData(
+            id=point_id, name=point_id, lat=lat, lon=lon, timeseries=None,
+            aggregated=SegmentWeatherSummary(precip_sum_mm=self._precip),
+            fetched_at=datetime.now(UTC), provider="test-fix-loop",
+        )
+
+
+def test_f003_vergleichs_aenderungsalarm_bucht_in_der_zone_die_er_auch_prueft(
+    sauberer_nutzer,
+):
+    """F003 (Änderungsalarm) — `compare_alert.py:158` (`is_allowed`) gegen
+    `:301` (`increment`). Strukturell identisch angreifbar wie der amtliche
+    Pfad, deshalb hier eigenständig nachgewiesen.
+
+    Given ein Free-Nutzer mit ZWEI Vergleichen am selben Auckland-Ort, beide
+    mit einer deutlichen Wetter-Abweichung gegen ihren Δ-Anker / When der
+    Alarmlauf beide abarbeitet / Then geht genau EINER hinaus: der erste
+    verbraucht das um die NowCast-Reserve verringerte Kontingent (Free 2 − 1),
+    der zweite sieht es als erschöpft.
+
+    ROT bei der Verfälschung `alert_daily_limit.increment(self._user_id, now,
+    config.zone)` → feste Wiener Zone: dann bleibt der Auckland-Zähler auf 0
+    und BEIDE Vergleiche senden.
+    """
+    from services.compare_alert import CompareAlertService
+    from services.compare_weather_snapshot import CompareWeatherSnapshotService
+
+    user_id = sauberer_nutzer("f003-aenderung")
+    ort = schreibe_ort(user_id, "loc-akl", "Pacific/Auckland")
+    preset_ids = ["cp-erst", "cp-zweit"]
+    schreibe_presets(
+        user_id, [vergleichs_preset(pid, ["loc-akl"]) for pid in preset_ids],
+    )
+    anker = _OrtsWetterQuelle(2.0)
+    for preset_id in preset_ids:
+        CompareWeatherSnapshotService(user_id=user_id).save(
+            preset_id, ort.id, anker.fetch(ort.id, ort.lat, ort.lon),
+        )
+
+    gesendet: list = []
+    dienst = CompareAlertService(
+        settings=settings_email_only(), user_id=user_id,
+        weather_source=_OrtsWetterQuelle(30.0),
+        mail_sink=lambda *a, **kw: gesendet.append((a, kw)),
+    )
+    versandt = dienst.check_all_compare_presets()
+
+    assert versandt == 1, (
+        f"Der zweite Vergleich muss am Kontingent scheitern, das der erste "
+        f"verbraucht hat. Gemessen: {versandt} Versände."
+    )
+    assert read_daily_counter(user_id, zone=AUCKLAND) == 1, (
+        "Gebucht werden muss in DERSELBEN Zone, gegen die geprüft wird."
+    )
+    assert read_daily_counter(user_id, zone=VIENNA) == 0, (
+        "Eine Buchung auf der Wiener Uhr wäre ein Zähler, den niemand liest."
     )

--- a/tests/tdd/test_ruhezeit_und_zaehler_folgen_der_ortszone.py
+++ b/tests/tdd/test_ruhezeit_und_zaehler_folgen_der_ortszone.py
@@ -1,0 +1,1390 @@
+"""TDD RED — #1726: Ruhezeit, Alarm-Tageszähler und Ortsvergleichs-Fälligkeit
+folgen der ORTSZONE statt der Wiener Uhr.
+
+Spec: docs/specs/modules/fix_1726_ruhezeit_und_zaehler_ortszone.md (15 ACs)
+Kontext: docs/context/fix-1726-ruhezeit-ortszone.md
+ADR-0051 (Die Zone gehört an die Daten, nicht an den Server), ADR-0044.
+
+Drei Entscheidungen laufen heute auf `Europe/Vienna`, obwohl sie den Nutzer an
+SEINEM Ort betreffen:
+
+* Ruhezeit-Fenster  — `deviation_alert_engine.py:31` (`VIENNA`), wirksam `:112`
+* Tageszähler-Reset — `alert_daily_limit.py:23` (`VIENNA`), wirksam `:32`
+* Slot-Fälligkeit   — `dispatch_orchestrator.py:128`
+  (`NOCH_NICHT_ORTSZEIT_SIEHE_1726`), wirksam `:141`
+
+═══════════════════════════════════════════════════════════════════════════
+ZWEI FALLEN, DIE DIESE DATEI BEWUSST VERMEIDET
+═══════════════════════════════════════════════════════════════════════════
+
+**1. Die falsche Zone macht den Test blind.** `Europe/Paris` hat denselben
+UTC-Versatz wie Wien — ein Test dort kann strukturell nicht unterscheiden, ob
+die Zone aus den Daten kam oder still auf Wien zurückfiel (kostete in #1725
+eine Adversary-Runde). Alle Ost/West-Nachweise benutzen deshalb
+`Pacific/Auckland` (+12) und `America/Los_Angeles` (−7). Die beiden
+Sommerzeit-Wechseltage (AC-10) sind EU-Umstellungstage — dort ist
+`Europe/Lisbon` die Zone der Wahl: sie schaltet zum selben Zeitpunkt wie Wien
+(EU-weit 01:00 UTC), hat aber einen ANDEREN Versatz (+0/+1 statt +1/+2). Ein
+stiller Wien-Rückfall fällt damit trotzdem auf.
+
+**2. Ein Test, der aus dem falschen Grund rot ist, beweist nichts.** Nach der
+Umstellung bekommen `is_quiet_hours`, `check_nowcast_gate` und
+`alert_daily_limit.*` einen Pflicht-Parameter `zone`. Ein Test, der heute nur
+mit `TypeError: unexpected keyword argument 'zone'` scheitert, wäre ein
+Signatur-Test — er würde auch grün, wenn der Parameter entgegengenommen und
+IGNORIERT wird.
+
+Deshalb gilt hier durchgehend:
+
+* Wo möglich läuft der Nachweis über den **echten Dienstpfad** (Trip-Alarm,
+  Vergleichs-Alarm, Nowcast-Schranke, Versand-Orchestrator). Deren Signaturen
+  ändern sich NICHT — die Tests sind reine Verhaltenstests.
+* Wo die neue Signatur unvermeidbar ist (die drei `alert_daily_limit`-
+  Funktionen, der Engine-Kern), läuft der Aufruf über :func:`mit_zone`: die
+  Zone wird übergeben, sobald der Prüfling sie annimmt, und sonst weggelassen.
+  Dadurch ist der Test schon HEUTE mit einem Zählerstand/Unterdrückungs-
+  Ergebnis rot, nicht mit einem `TypeError`. Zugleich ist jedes Szenario so
+  gewählt, dass ein **entgegengenommener, aber ignorierter** `zone`-Parameter
+  den Test WEITERHIN rot lässt. Jeder solche Test sagt das im Docstring.
+* Jeder Test trägt im Docstring, WARUM er heute rot ist — „weil die Prüfung
+  gegen Wien läuft" ist der gewünschte Grund, „weil das Argument unbekannt
+  ist" nicht.
+
+**Gekreuzte Probe.** Viele Dienstpfad-Tests fahren ZWEI Läufe: einmal mit
+einem Ruhezeit-Fenster um „jetzt in der Ortszone" und einmal mit einem um
+„jetzt in Wien". Nach dem Fix muss sich das Ergebnis GENAU UMKEHREN. Das ist
+schärfer als ein einzelner Lauf und schützt gleichzeitig vor falschem Grün:
+bricht der Pfad vorzeitig ab (z.B. kein aktives Segment), wären BEIDE Läufe
+still — der Kreuz-Assert fällt darauf herein nicht.
+
+Kern-Schicht, deterministisch: kein Netz, keine echten Postfächer, keine
+`Mock()`/`patch()`/`MagicMock`. Netz-Nähte werden durch echte Unterklassen mit
+echter Implementierung ersetzt (Muster `_OhneNetz` aus
+`test_briefing_faelligkeit_ortszone.py`).
+
+Pfadregel #1409: alle Pfade relativ zu DIESER Datei.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date as date_type
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))
+
+from tests.helpers.compare_briefings import write_compare_briefings  # noqa: E402
+from tests.helpers.nowcast_gate_fixtures import (  # noqa: E402
+    CountingFrameSource,
+    clean_uid,
+    location,
+    make_trip,
+    preset_root,
+    radar_preset,
+    reset_radar_cache,
+    save_trip,
+    settings_email_only,
+    trip_alert_service,
+    write_user_tier,
+)
+
+# ═════════════════════════ Zonen und Koordinaten ══════════════════════════
+
+VIENNA = ZoneInfo("Europe/Vienna")
+AUCKLAND = ZoneInfo("Pacific/Auckland")          # +12/+13 — östlich
+LOS_ANGELES = ZoneInfo("America/Los_Angeles")    # −8/−7  — westlich
+LISBON = ZoneInfo("Europe/Lisbon")               # +0/+1  — EU-DST, ≠ Wien
+UTC = timezone.utc
+
+# Echte Orte, damit TimezoneFinder sie auflöst (offline, kein Netz).
+KOORDINATEN = {
+    "Pacific/Auckland": (-36.85, 174.76),
+    "America/Los_Angeles": (34.05, -118.24),
+    "Europe/Lisbon": (38.72, -9.14),
+    "Europe/Vienna": (48.21, 16.37),
+}
+
+# Ruhezeit über Mitternacht (Wrap) — die Form, die der Nutzer real einstellt.
+RUHE_VON, RUHE_BIS = "22:00", "07:00"
+
+# ── Feste Zeitpunkte für die Pfade, die `now` als Parameter annehmen ───────
+# 2026-08-12 14:00 UTC: Auckland 02:00 (13.8., IM Fenster) · Wien 16:00
+# (ausserhalb) · Los Angeles 07:00 (ausserhalb — 07:00 ist die exklusive
+# Obergrenze). GENAU EINE der drei Zonen ist ruhig.
+JETZT_AUCKLAND_NACHT = datetime(2026, 8, 12, 14, 0, tzinfo=UTC)
+# 2026-08-12 06:30 UTC: Los Angeles 23:30 (11.8., IM Fenster) · Wien 08:30
+# (ausserhalb) · Auckland 18:30 (ausserhalb). Spiegelbild des obigen.
+JETZT_LA_NACHT = datetime(2026, 8, 12, 6, 30, tzinfo=UTC)
+
+
+def fenster_um_jetzt(zone: ZoneInfo, puffer_minuten: int = 45) -> tuple[str, str]:
+    """Ruhezeit-Fenster, das den JETZIGEN Zeitpunkt in `zone` umschliesst.
+
+    Für die Dienstpfade, die ihre Zeit selbst über `datetime.now(utc)` holen —
+    dort lässt sich der Zeitpunkt nicht hereinreichen, wohl aber das Fenster
+    um ihn herum legen.
+
+    Warum ±45 Minuten sicher unterscheidbar ist: Auckland/Wien liegen 10–12 h
+    auseinander, Los Angeles/Wien 8–10 h, Auckland/Los Angeles 19–21 h. Ein
+    90-Minuten-Fenster um die Ortszeit der einen Zone kann die Ortszeit einer
+    anderen nie mit enthalten. Mitternachts-Überläufe deckt die Wrap-Logik von
+    `is_quiet_hours()` ab.
+    """
+    jetzt = datetime.now(UTC).astimezone(zone)
+    return (
+        (jetzt - timedelta(minutes=puffer_minuten)).strftime("%H:%M"),
+        (jetzt + timedelta(minutes=puffer_minuten)).strftime("%H:%M"),
+    )
+
+
+def ortstag(zone: ZoneInfo) -> date_type:
+    return datetime.now(UTC).astimezone(zone).date()
+
+
+# ═══════════════════════ Ablage: Orte und Presets ═════════════════════════
+
+
+def schreibe_ort(user_id: str, loc_id: str, zone_name: str):
+    """Echter `SavedLocation` über den Produktiv-Schreiber `save_location()`."""
+    from app.loader import save_location
+
+    lat, lon = KOORDINATEN[zone_name]
+    loc = location(loc_id, f"Ort {loc_id}", lat=lat, lon=lon)
+    save_location(loc, user_id=user_id)
+    return loc
+
+
+def schreibe_ort_ohne_koordinaten(user_id: str, loc_id: str):
+    """Ort, dessen Zone NICHT auflösbar ist (Koordinaten auf 0/0 = Nullmeridian
+    im Golf von Guinea → `tz_for_coords` liefert "UTC" → `resolve_location_tz`
+    liefert `None`). Kein Konstrukt-Trick: genau diese Lage ist der reale Fall
+    „Ort ohne brauchbare Zone" aus `utils/timezone.py:60-64`."""
+    from app.loader import save_location
+
+    loc = location(loc_id, f"Ort {loc_id}", lat=0.0, lon=0.0)
+    save_location(loc, user_id=user_id)
+    return loc
+
+
+def vergleichs_preset(
+    preset_id: str,
+    location_ids: list[str],
+    *,
+    quiet_from: str | None = None,
+    quiet_to: str | None = None,
+    morning_time: str = "07:00:00",
+) -> dict:
+    """Vergleichs-Preset im Bestandsschema (Feldauswahl analog
+    `tests/test_compare_auto_pause_end_date.py::_make_preset`)."""
+    preset: dict = {
+        "id": preset_id,
+        "name": f"Vergleich {preset_id}",
+        "user_id": "default",
+        "location_ids": location_ids,
+        "schedule": "daily",
+        "weekday": None,
+        "profil": "ALLGEMEIN",
+        "hour_from": 9,
+        "hour_to": 16,
+        "empfaenger": ["dummy@example.invalid"],
+        "letzter_versand": None,
+        "created_at": "2026-08-01T00:00:00Z",
+        "archived_at": None,
+        "morning_enabled": True,
+        "morning_time": morning_time,
+        "evening_enabled": False,
+        "evening_time": "18:00:00",
+    }
+    if quiet_from is not None:
+        preset["alert_quiet_from"] = quiet_from
+    if quiet_to is not None:
+        preset["alert_quiet_to"] = quiet_to
+    return preset
+
+
+def schreibe_presets(user_id: str, presets: list[dict]) -> None:
+    write_compare_briefings(preset_root() / user_id, presets)
+
+
+# ═════════════ Dienstpfade mit ersetzter Netz-Naht (keine Mocks) ══════════
+
+
+def offizieller_vergleichsdienst(user_id: str):
+    """`CompareOfficialAlertService`, bei dem AUSSCHLIESSLICH die Netz-Naht
+    `_detect()` durch eine echte, zählende Implementierung ersetzt ist.
+
+    `_detect()` ist die erste Stelle des Pfads, die amtliche Warnungen über das
+    Netz holt — und sie liegt HINTER der Ruhezeit-Prüfung
+    (`compare_official_alert.py:119`). Die Zählung ist damit der direkte
+    Wirkungs-Nachweis: 0 Aufrufe = unterdrückt, ≥1 = durchgelassen.
+    """
+    from services.compare_official_alert import CompareOfficialAlertService
+
+    class _Zaehlend(CompareOfficialAlertService):
+        detect_aufrufe = 0
+
+        def _detect(self, preset_id, locs, sources=None):
+            type(self).detect_aufrufe += 1
+            return ([], {})
+
+    _Zaehlend.detect_aufrufe = 0
+    return _Zaehlend(settings=settings_email_only(), user_id=user_id)
+
+
+def vergleichs_alarmdienst(user_id: str):
+    """`CompareAlertService` mit ersetzter Netz-Naht `_detect_triggered_locations()`
+    (liegt hinter der Ruhezeit-Prüfung `compare_alert.py:176`)."""
+    from services.compare_alert import CompareAlertService
+
+    class _Zaehlend(CompareAlertService):
+        detect_aufrufe = 0
+
+        def _detect_triggered_locations(
+            self, preset_id, location_ids, all_locations, config, day_window
+        ):
+            type(self).detect_aufrufe += 1
+            return []
+
+    _Zaehlend.detect_aufrufe = 0
+    return _Zaehlend(settings=settings_email_only(), user_id=user_id)
+
+
+def trip_abweichungsdienst(user_id: str):
+    """`TripAlertService` mit ersetzter Netz-Naht `_fetch_fresh_weather()`
+    (liegt hinter der Ruhezeit-Prüfung `trip_alert.py:229`)."""
+    from services.trip_alert import TripAlertService
+
+    class _Zaehlend(TripAlertService):
+        fetch_aufrufe = 0
+
+        def _fetch_fresh_weather(self, cached_weather):
+            type(self).fetch_aufrufe += 1
+            return []
+
+    _Zaehlend.fetch_aufrufe = 0
+    return _Zaehlend(
+        settings=settings_email_only(), throttle_hours=2, user_id=user_id,
+    )
+
+
+def trip_mit_ruhezeit(user_id: str, trip_id: str, zone_name: str,
+                      quiet: tuple[str, str]):
+    """Aktiver Trip in `zone_name` mit gesetzter Ruhezeit, auf Platte."""
+    lat, lon = KOORDINATEN[zone_name]
+    trip = make_trip(
+        trip_id,
+        cooldown_minutes=0,
+        quiet_from=quiet[0],
+        quiet_to=quiet[1],
+        stage_date=ortstag(ZoneInfo(zone_name)),
+        lat=lat,
+        lon=lon,
+    )
+    trip.report_config.alert_on_changes = True
+    save_trip(trip, user_id)
+    return trip
+
+
+def mit_zone(funktion, *args, zone: ZoneInfo):
+    """Ruft eine Prüfling-Funktion mit `zone=`, SOBALD sie den Parameter
+    annimmt — und ohne ihn, solange sie das nicht tut.
+
+    Ohne diese Fallunterscheidung wäre jeder Zähler-/Ruhezeit-Test HEUTE nur
+    mit `TypeError: unexpected keyword argument 'zone'` rot. Das wäre ein
+    Signatur-Befund, kein Verhaltensbefund — und er würde bereits grün, wenn
+    der Parameter entgegengenommen und ignoriert wird. So misst der Test
+    stattdessen schon heute das ERGEBNIS („welcher Zählerstand steht da?",
+    „wird unterdrückt?") und bleibt nach der Umstellung wortgleich gültig. Ein
+    entgegengenommener, aber ignorierter Parameter fällt weiterhin durch, weil
+    jedes Szenario Wiener und Ortszeit auseinanderzieht.
+
+    Die Signatur wird gelesen, nicht geraten — kein `try/except TypeError`, das
+    einen echten Programmfehler nach der Umstellung verschlucken könnte.
+    """
+    import inspect
+
+    if "zone" in inspect.signature(funktion).parameters:
+        return funktion(*args, zone=zone)
+    return funktion(*args)
+
+
+def _uid(kennung: str) -> str:
+    return f"tdd-1726-{kennung}"
+
+
+@pytest.fixture
+def sauberer_nutzer():
+    """Vergibt Nutzer-Kennungen und räumt sie hinterher weg."""
+    vergeben: list[str] = []
+
+    def _neu(kennung: str, tier: str = "free") -> str:
+        user_id = _uid(kennung)
+        clean_uid(user_id)
+        write_user_tier(user_id, tier)
+        vergeben.append(user_id)
+        return user_id
+
+    yield _neu
+    for user_id in vergeben:
+        clean_uid(user_id)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC-1 / AC-2 — Ruhezeit östlich und westlich von Wien
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _trip_deviation_lauf(user_id: str, zone_name: str, quiet: tuple[str, str]) -> int:
+    """Ein echter `check_and_send_alerts()`-Lauf; liefert die Zahl der
+    Wetterabrufe (0 = durch die Ruhezeit unterdrückt)."""
+    dienst = trip_abweichungsdienst(user_id)
+    trip = trip_mit_ruhezeit(user_id, f"{user_id}-trip", zone_name, quiet)
+    dienst.check_and_send_alerts(trip, cached_weather=[])
+    return type(dienst).fetch_aufrufe
+
+
+def test_ac1_ruhezeit_oestlich_folgt_der_ortszeit_nicht_wien(sauberer_nutzer):
+    """AC-1: Trip mit Wegpunkt in `Pacific/Auckland`, Ruhezeit 22:00–07:00.
+
+    Given ein Alarm-Zeitpunkt, der in Auckland IM Ruhezeit-Fenster liegt, in
+    Wien aber tagsüber / Then wird der Alarm unterdrückt (kein Wetterabruf).
+    Gekreuzt: ein Fenster um die WIENER Ortszeit darf denselben Trip NICHT
+    mehr unterdrücken.
+
+    ROT HEUTE, weil die Prüfung gegen Wien läuft (`deviation_alert_engine.py:112`):
+    das Auckland-Fenster greift nicht (Abruf findet statt), das Wien-Fenster
+    greift fälschlich (kein Abruf). Beide Erwartungen sind heute exakt
+    invertiert — es ist ein Verhaltens-, kein Signaturbefund.
+    """
+    abrufe_auckland = _trip_deviation_lauf(
+        sauberer_nutzer("ac1-ort"), "Pacific/Auckland", fenster_um_jetzt(AUCKLAND)
+    )
+    abrufe_wien = _trip_deviation_lauf(
+        sauberer_nutzer("ac1-wien"), "Pacific/Auckland", fenster_um_jetzt(VIENNA)
+    )
+
+    assert abrufe_auckland == 0, (
+        "Ruhezeit in Auckland-Ortszeit muss den Abweichungs-Alarm unterdrücken "
+        "— vor jedem Wetterabruf."
+    )
+    assert abrufe_wien >= 1, (
+        "Ein Fenster um die WIENER Uhrzeit darf einen Auckland-Trip nicht mehr "
+        "stilllegen — sonst hängt die Ruhezeit weiter am Server."
+    )
+
+
+def test_ac2_ruhezeit_westlich_folgt_der_ortszeit_nicht_wien(sauberer_nutzer):
+    """AC-2: Spiegelbild mit `America/Los_Angeles`.
+
+    ROT HEUTE aus demselben Grund wie AC-1 — die Prüfung läuft gegen Wien.
+    """
+    abrufe_la = _trip_deviation_lauf(
+        sauberer_nutzer("ac2-ort"), "America/Los_Angeles", fenster_um_jetzt(LOS_ANGELES)
+    )
+    abrufe_wien = _trip_deviation_lauf(
+        sauberer_nutzer("ac2-wien"), "America/Los_Angeles", fenster_um_jetzt(VIENNA)
+    )
+
+    assert abrufe_la == 0, (
+        "Ruhezeit in Los-Angeles-Ortszeit muss den Abweichungs-Alarm unterdrücken."
+    )
+    assert abrufe_wien >= 1, (
+        "Ein Fenster um die WIENER Uhrzeit darf einen LA-Trip nicht mehr stilllegen."
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC-3 — Alle SIEBEN Ruhezeit-Prüfstellen, je EINZELN nachgewiesen
+#
+# Geteilter Code bewies in #1697 dreimal in Folge nichts über den jeweiligen
+# Aufrufer. Deshalb sieben Tests, keiner erschliesst die anderen mit.
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _official_compare_lauf(user_id: str, quiet: tuple[str, str]) -> int:
+    schreibe_ort(user_id, "loc-akl", "Pacific/Auckland")
+    schreibe_presets(user_id, [
+        vergleichs_preset("cp-1", ["loc-akl"], quiet_from=quiet[0], quiet_to=quiet[1])
+    ])
+    dienst = offizieller_vergleichsdienst(user_id)
+    dienst.check_all_compare_presets()
+    return type(dienst).detect_aufrufe
+
+
+def test_ac3_stelle1_amtliche_warnung_vergleich(sauberer_nutzer):
+    """AC-3 Stelle 1 — `compare_official_alert.py:119` (amtliche Warnung,
+    Ortsvergleich). Zone-Quelle: erster Ort aus `location_ids`.
+
+    ROT HEUTE: die Ruhezeit dieses Vergleichs wird gegen Wien ausgewertet, der
+    Ort liegt in Auckland. Nachweis über den echten Dienst
+    (`check_all_compare_presets`), gemessen an der Netz-Naht dahinter.
+    """
+    aufrufe_ort = _official_compare_lauf(
+        sauberer_nutzer("ac3s1-ort"), fenster_um_jetzt(AUCKLAND)
+    )
+    aufrufe_wien = _official_compare_lauf(
+        sauberer_nutzer("ac3s1-wien"), fenster_um_jetzt(VIENNA)
+    )
+
+    assert aufrufe_ort == 0, "Auckland-Ruhezeit muss die amtliche Vergleichs-Warnung stoppen."
+    assert aufrufe_wien >= 1, "Wiener Ruhezeit darf einen Auckland-Vergleich nicht stoppen."
+
+
+def test_ac3_stelle2_wetterabweichung_trip(sauberer_nutzer):
+    """AC-3 Stelle 2 — `trip_alert.py:229` (Wetter-Abweichung, Trip).
+
+    Eigenständiger Nachweis für DIESE Aufrufstelle, obwohl sie sich den
+    Adapter mit Stelle 4 teilt (Spec, Entwurf A).
+
+    ROT HEUTE: Prüfung gegen Wien, Trip in Los Angeles.
+    """
+    abrufe_ort = _trip_deviation_lauf(
+        sauberer_nutzer("ac3s2-ort"), "America/Los_Angeles", fenster_um_jetzt(LOS_ANGELES)
+    )
+    abrufe_wien = _trip_deviation_lauf(
+        sauberer_nutzer("ac3s2-wien"), "America/Los_Angeles", fenster_um_jetzt(VIENNA)
+    )
+
+    assert abrufe_ort == 0
+    assert abrufe_wien >= 1
+
+
+def test_ac3_stelle3_geteilter_ruhezeit_adapter(sauberer_nutzer):
+    """AC-3 Stelle 3 — `trip_alert.py:688` (`_is_quiet_hours`-Adapter selbst).
+
+    Der Adapter nimmt `(trip, now)` entgegen; seine Signatur ändert sich durch
+    diese Scheibe NICHT — der Test reicht deshalb einen FESTEN Zeitpunkt herein
+    und misst die Antwort. `JETZT_AUCKLAND_NACHT` liegt in Auckland um 02:00
+    (im Fenster 22:00–07:00) und in Wien um 16:00 (ausserhalb).
+
+    ROT HEUTE: der Adapter liefert `False`, weil er auf 16:00 Wiener Zeit prüft.
+    """
+    user_id = sauberer_nutzer("ac3s3")
+    dienst = trip_abweichungsdienst(user_id)
+    trip = trip_mit_ruhezeit(user_id, "t-adapter", "Pacific/Auckland",
+                             (RUHE_VON, RUHE_BIS))
+
+    assert dienst._is_quiet_hours(trip, JETZT_AUCKLAND_NACHT) is True, (
+        "02:00 Ortszeit Auckland liegt im Fenster 22:00–07:00 — der geteilte "
+        "Adapter muss die Zone des Trips auflösen (anchor_tz), nicht Wien."
+    )
+    # Gegenprobe in derselben Zone: 16:00 Ortszeit Auckland ist wach.
+    wach = JETZT_AUCKLAND_NACHT - timedelta(hours=10)  # Auckland 16:00
+    assert dienst._is_quiet_hours(trip, wach) is False, (
+        "16:00 Ortszeit Auckland liegt ausserhalb — sonst wäre die Zusicherung "
+        "durch ein pauschales True erfüllbar."
+    )
+
+
+def test_ac3_stelle4_amtliche_warnung_trip(sauberer_nutzer):
+    """AC-3 Stelle 4 — `trip_alert.py:1443` (amtliche Warnung, Trip;
+    `_send_official_alert_only`).
+
+    Diese Methode IST die Aufrufstelle. Der öffentliche Einstieg darüber
+    (`check_official_alert_triggers`) holt die Warnungen über das Netz — sie
+    werden hier deshalb als echte `OfficialAlert`-Objekte hereingereicht,
+    genau wie der Produktivpfad es tut.
+
+    ROT HEUTE: Ruhezeit gegen Wien geprüft, Trip in Auckland → der Versand
+    läuft an, der Mail-Sink füllt sich.
+    """
+    from services.official_alerts.models import OfficialAlert
+
+    def lauf(quiet: tuple[str, str], kennung: str) -> int:
+        user_id = sauberer_nutzer(kennung)
+        gesendet: list = []
+        from services.trip_alert import TripAlertService
+
+        dienst = TripAlertService(
+            settings=settings_email_only(), throttle_hours=2, user_id=user_id,
+            mail_sink=lambda *a, **kw: gesendet.append((a, kw)),
+        )
+        trip = trip_mit_ruhezeit(user_id, "t-amtlich", "Pacific/Auckland", quiet)
+        warnung = OfficialAlert(
+            source="test-quelle", hazard="wind", level=3,
+            label="Sturmwarnung", region_label="Testregion",
+        )
+        # Segment-Kennungen sind numerische Strings (`format_segment_reference`).
+        dienst._send_official_alert_only(trip, [(warnung, ["1"])])
+        return len(gesendet)
+
+    versand_ort = lauf(fenster_um_jetzt(AUCKLAND), "ac3s4-ort")
+    versand_wien = lauf(fenster_um_jetzt(VIENNA), "ac3s4-wien")
+
+    assert versand_ort == 0, (
+        "Auckland-Ruhezeit muss die amtliche Trip-Warnung unterdrücken."
+    )
+    assert versand_wien >= 1, (
+        "Wiener Ruhezeit darf die amtliche Warnung eines Auckland-Trips nicht "
+        "unterdrücken."
+    )
+
+
+def test_ac3_stelle5_nowcast_schranke(sauberer_nutzer):
+    """AC-3 Stelle 5 — `alert_gate.py:93` (Nowcast-Schranke, geteilt
+    Trip+Vergleich). Kein Objekt im Scope: die Zone muss von den beiden
+    Aufrufern durchgereicht werden.
+
+    Nachweis über den echten Trip-Radar-Pfad (`check_radar_alerts`), gemessen
+    an der Radar-Naht `CountingFrameSource` — sie liegt HINTER der Schranke, ein
+    gesperrter Lauf kostet keinen Abruf (Modul-Docstring `alert_gate.py`).
+
+    Der Test ruft `check_nowcast_gate()` bewusst NICHT direkt auf: das wäre ein
+    Signatur-Test, der auch bei entgegengenommenem, aber ignoriertem `zone`
+    grün würde.
+
+    ROT HEUTE: die Schranke wertet die Ruhezeit gegen Wien aus.
+    """
+    def lauf(quiet: tuple[str, str], kennung: str) -> int:
+        user_id = sauberer_nutzer(kennung)
+        reset_radar_cache()
+        lat, lon = KOORDINATEN["Pacific/Auckland"]
+        trip = make_trip(
+            "t-radar", cooldown_minutes=0, quiet_from=quiet[0], quiet_to=quiet[1],
+            stage_date=ortstag(AUCKLAND), lat=lat, lon=lon,
+        )
+        save_trip(trip, user_id)
+        quelle = CountingFrameSource()
+        dienst = trip_alert_service(
+            user_id, settings_email_only(), quelle, mail_sink=lambda *a, **kw: None,
+        )
+        dienst.check_radar_alerts()
+        return quelle.call_count
+
+    abrufe_ort = lauf(fenster_um_jetzt(AUCKLAND), "ac3s5-ort")
+    abrufe_wien = lauf(fenster_um_jetzt(VIENNA), "ac3s5-wien")
+
+    assert abrufe_ort == 0, (
+        "Die Nowcast-Schranke muss die Auckland-Ruhezeit sehen — vor dem Abruf."
+    )
+    assert abrufe_wien >= 1, (
+        "Ohne diesen Gegen-Lauf wäre die erste Zusicherung auch dann erfüllt, "
+        "wenn der Radar-Pfad aus einem ganz anderen Grund gar nicht erst "
+        "losläuft (z.B. kein aktives Segment)."
+    )
+
+
+def _compare_deviation_lauf(user_id: str, quiet: tuple[str, str]) -> int:
+    schreibe_ort(user_id, "loc-akl", "Pacific/Auckland")
+    schreibe_presets(user_id, [
+        vergleichs_preset("cp-dev", ["loc-akl"], quiet_from=quiet[0], quiet_to=quiet[1])
+    ])
+    dienst = vergleichs_alarmdienst(user_id)
+    dienst.check_all_compare_presets()
+    return type(dienst).detect_aufrufe
+
+
+def test_ac3_stelle6_wetterabweichung_vergleich(sauberer_nutzer):
+    """AC-3 Stelle 6 — `compare_alert.py:176` (Wetter-Abweichung, Vergleich).
+    Zone-Quelle: `config.zone`, gesetzt in `_build_eval_config()` aus dem
+    ersten Ort.
+
+    ROT HEUTE: Prüfung gegen Wien, Ort in Auckland → der Wetterabruf läuft an.
+    """
+    aufrufe_ort = _compare_deviation_lauf(
+        sauberer_nutzer("ac3s6-ort"), fenster_um_jetzt(AUCKLAND)
+    )
+    aufrufe_wien = _compare_deviation_lauf(
+        sauberer_nutzer("ac3s6-wien"), fenster_um_jetzt(VIENNA)
+    )
+
+    assert aufrufe_ort == 0, "Auckland-Ruhezeit muss VOR dem Wetterabruf greifen."
+    assert aufrufe_wien >= 1, "Wiener Ruhezeit darf einen Auckland-Vergleich nicht stoppen."
+
+
+def _eval_config(dienst, preset: dict, all_locations: dict):
+    """Baut die `AlertEvaluationConfig` über den PRODUKTIVEN Erbauer
+    (`CompareAlertService._build_eval_config`) — nicht von Hand im Test.
+
+    Nur so misst der Test, was der Produktivpfad tatsächlich in die Engine
+    hineingibt. Ob der Erbauer die Ortsliste künftig als zusätzlichen
+    Parameter braucht, entscheidet die GREEN-Phase; der Test liest das an der
+    echten Signatur ab, statt es festzunageln.
+    """
+    import inspect
+
+    signatur = inspect.signature(dienst._build_eval_config)
+    extra = {}
+    if "all_locations" in signatur.parameters:
+        extra["all_locations"] = all_locations
+    return dienst._build_eval_config(preset, 0, **extra)
+
+
+def test_ac3_stelle7_engine_kern(sauberer_nutzer):
+    """AC-3 Stelle 7 — `deviation_alert_engine.py:286` (`evaluate()`, der Kern).
+    Zone-Quelle: `config.zone` (Rückfall UTC).
+
+    Die Konfiguration entsteht über den PRODUKTIVEN Erbauer, der Zeitpunkt wird
+    hereingereicht (`now=`, bestehender Parameter). Gemessen wird das
+    Auswertungs-ERGEBNIS, nicht die Argumentliste.
+
+    ROT HEUTE: `config` trägt keine Zone, die Engine rechnet in Wien (16:00,
+    wach) statt in Auckland (02:00, Ruhezeit) — `suppressed_reason` ist
+    `"no_significant_changes"` statt `"quiet_hours"`.
+
+    Ein entgegengenommener, aber IGNORIERTER `zone`-Parameter liefert dasselbe
+    falsche Ergebnis — dieser Test lässt sich damit nicht befriedigen.
+    """
+    from services.deviation_alert_engine import DeviationAlertEngine
+
+    user_id = sauberer_nutzer("ac3s7")
+    loc = schreibe_ort(user_id, "loc-akl", "Pacific/Auckland")
+    preset = vergleichs_preset("cp-kern", ["loc-akl"],
+                               quiet_from=RUHE_VON, quiet_to=RUHE_BIS)
+    schreibe_presets(user_id, [preset])
+
+    dienst = vergleichs_alarmdienst(user_id)
+    config = _eval_config(dienst, preset, {"loc-akl": loc})
+
+    ergebnis = DeviationAlertEngine().evaluate(
+        cached=[], fresh=[], config=config, alert_state={},
+        now=JETZT_AUCKLAND_NACHT,
+    )
+
+    assert ergebnis.triggered is False
+    assert ergebnis.suppressed_reason == "quiet_hours", (
+        "Der Engine-Kern muss die Zone aus der Konfiguration nehmen — 02:00 "
+        "Ortszeit Auckland liegt im Fenster 22:00–07:00. Heute rechnet er in "
+        f"Wien (16:00) und meldet {ergebnis.suppressed_reason!r}."
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC-4 — Mehrzonen-Vergleich: Ruhezeit folgt dem ERSTEN Ort
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_ac4_ruhezeit_folgt_dem_ersten_ort_und_wandert_mit_der_reihenfolge(
+    sauberer_nutzer,
+):
+    """AC-4: Zwei Orte, zwei Zonen — massgeblich ist der ERSTGENANNTE.
+
+    Given ein Vergleich [Auckland, Los Angeles] mit einem Ruhezeit-Fenster um
+    die Auckland-Ortszeit / Then ist er ruhig. When derselbe Vergleich als
+    [Los Angeles, Auckland] konfiguriert wird / Then ist er NICHT mehr ruhig —
+    das Ergebnis kippt mit der Reihenfolge.
+
+    ROT HEUTE: beide Reihenfolgen werden gegen Wien geprüft, das Ergebnis ist
+    in beiden Fällen dasselbe (nicht ruhig) — die Reihenfolge hat gar keine
+    Wirkung. Der Kipp-Nachweis schlägt fehl.
+
+    Eine feste oder alphabetische Ortsauswahl (statt `location_ids[0]`) fällt
+    hier ebenfalls durch: „Auckland" käme alphabetisch immer zuerst und das
+    Ergebnis kippte nicht.
+    """
+    fenster = fenster_um_jetzt(AUCKLAND)
+
+    def lauf(reihenfolge: list[str], kennung: str) -> int:
+        user_id = sauberer_nutzer(kennung)
+        schreibe_ort(user_id, "loc-akl", "Pacific/Auckland")
+        schreibe_ort(user_id, "loc-lax", "America/Los_Angeles")
+        schreibe_presets(user_id, [
+            vergleichs_preset("cp-multi", reihenfolge,
+                              quiet_from=fenster[0], quiet_to=fenster[1])
+        ])
+        dienst = vergleichs_alarmdienst(user_id)
+        dienst.check_all_compare_presets()
+        return type(dienst).detect_aufrufe
+
+    auckland_zuerst = lauf(["loc-akl", "loc-lax"], "ac4-akl-first")
+    la_zuerst = lauf(["loc-lax", "loc-akl"], "ac4-lax-first")
+
+    assert auckland_zuerst == 0, (
+        "Erster Ort Auckland → die Auckland-Ruhezeit gilt für den Vergleich."
+    )
+    assert la_zuerst >= 1, (
+        "Rückt Los Angeles an die erste Stelle, gilt dessen Ortszeit — dasselbe "
+        "Fenster liegt dort nicht in der Nacht, der Vergleich läuft weiter."
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC-5 — #1479 bleibt gewahrt (grüner Regressions-Anker)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize(
+    "kaputt",
+    [("25:00", "07:00"), ("abc", "07:00"), ("22:00", "xx:yy")],
+    ids=["stunde-25", "kein-zeitformat", "kaputtes-ende"],
+)
+def test_ac5_unbrauchbarer_ruhezeitwert_bleibt_keine_ruhezeit(sauberer_nutzer, kaputt):
+    """AC-5 (grüner Regressions-Anker, KEIN RED-Fall): ein unbrauchbarer
+    Ruhezeit-Wert gilt weiterhin als „keine Ruhezeit gesetzt" — auch mit dem
+    zusätzlichen Zonen-Parameter.
+
+    Dieser Test ist HEUTE grün und muss es bleiben. Er bewacht die Zusicherung
+    aus #1479 gegen die naheliegende Regression, die Zonen-Auflösung ausserhalb
+    (oder anstelle) des bestehenden `try/except` zu platzieren
+    (`deviation_alert_engine.py:109-139`).
+    """
+    user_id = sauberer_nutzer(f"ac5-{kaputt[0]}-{kaputt[1]}".replace(":", ""))
+    dienst = trip_abweichungsdienst(user_id)
+    trip = trip_mit_ruhezeit(user_id, "t-kaputt", "Pacific/Auckland", kaputt)
+
+    assert dienst._is_quiet_hours(trip, JETZT_AUCKLAND_NACHT) is False
+
+
+def test_ac5_nicht_string_ruhezeitwert_bleibt_keine_ruhezeit(sauberer_nutzer):
+    """AC-5, zweiter Teil (grüner Anker): ein Nicht-String (`int`) darf keine
+    Ausnahme an den Aufrufer durchreichen — der gefährlichste Fehlerfall wäre
+    ein Alarm-Totalausfall für ALLE Touren des Kontos (#1467)."""
+    user_id = sauberer_nutzer("ac5-nichtstring")
+    dienst = trip_abweichungsdienst(user_id)
+    trip = trip_mit_ruhezeit(user_id, "t-int", "Pacific/Auckland", ("22:00", "07:00"))
+    trip.alert_quiet_from = 2200  # kein String — kommt so aus einer Nutzerdatei
+
+    assert dienst._is_quiet_hours(trip, JETZT_AUCKLAND_NACHT) is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC-6 — Tageszähler resettet zur ORTS-Mitternacht
+#
+# Die drei Modulfunktionen bekommen den Zonen-Parameter zwangsläufig. Die
+# Szenarien sind deshalb so gewählt, dass ein entgegengenommener, aber
+# IGNORIERTER `zone`-Parameter sie WEITERHIN rot lässt: gemessen wird immer
+# ein Zählerstand, der sich zwischen Wiener und Ortstag unterscheidet.
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Auckland-Mitternacht (NZST, +12) = 12:00 UTC. Wien bleibt über beide
+# Zeitpunkte im selben Kalendertag (13:30 / 14:30 MESZ).
+VOR_AUCKLAND_MITTERNACHT = datetime(2026, 8, 12, 11, 30, tzinfo=UTC)
+NACH_AUCKLAND_MITTERNACHT = datetime(2026, 8, 12, 12, 30, tzinfo=UTC)
+# Wiener Mitternacht (MESZ, +2) = 22:00 UTC des Vortags. Auckland bleibt über
+# beide Zeitpunkte im selben Kalendertag (09:30 / 10:30 des 13.8.).
+VOR_WIENER_MITTERNACHT = datetime(2026, 8, 12, 21, 30, tzinfo=UTC)
+NACH_WIENER_MITTERNACHT = datetime(2026, 8, 12, 22, 30, tzinfo=UTC)
+# Los-Angeles-Mitternacht (PDT, −7) = 07:00 UTC. Wien bleibt im selben Tag.
+VOR_LA_MITTERNACHT = datetime(2026, 8, 12, 6, 30, tzinfo=UTC)
+NACH_LA_MITTERNACHT = datetime(2026, 8, 12, 7, 30, tzinfo=UTC)
+
+
+def test_ac6_zaehler_resettet_an_auckland_mitternacht(sauberer_nutzer):
+    """AC-6 (östlich): Der Zähler springt an der AUCKLAND-Mitternacht auf 0.
+
+    Given ein Alarm um 23:30 Auckland-Ortszeit (= 11:30 UTC) / When um 00:30
+    Auckland-Ortszeit (= 12:30 UTC) gelesen wird / Then steht der Zähler auf 0.
+    In Wien ist zwischen beiden Zeitpunkten NICHTS passiert (13:30 → 14:30,
+    derselbe Tag).
+
+    ROT HEUTE: der Reset hängt an `_vienna_date_str` — der Wiener Tag hat nicht
+    gewechselt, also liefert `load()` weiterhin 1.
+    """
+    from services import alert_daily_limit
+
+    user_id = sauberer_nutzer("ac6-akl-reset")
+    mit_zone(
+        alert_daily_limit.increment, user_id, VOR_AUCKLAND_MITTERNACHT, zone=AUCKLAND,
+    )
+
+    assert mit_zone(
+        alert_daily_limit.load, user_id, VOR_AUCKLAND_MITTERNACHT, zone=AUCKLAND,
+    ) == 1, "Vor der Orts-Mitternacht muss die Buchung sichtbar sein."
+    assert mit_zone(
+        alert_daily_limit.load, user_id, NACH_AUCKLAND_MITTERNACHT, zone=AUCKLAND,
+    ) == 0, (
+        "Nach der Auckland-Mitternacht beginnt der Ortstag neu — heute läuft "
+        "der Reset noch auf der Wiener Uhr und der Zähler bleibt bei 1."
+    )
+
+
+def test_ac6_zaehler_resettet_nicht_an_wiener_mitternacht(sauberer_nutzer):
+    """AC-6 (östlich, Gegenrichtung): Die WIENER Mitternacht darf einen
+    Auckland-Zähler NICHT zurücksetzen.
+
+    Given ein Alarm um 09:30 Auckland-Ortszeit (= 21:30 UTC) / When um 10:30
+    Auckland-Ortszeit (= 22:30 UTC) gelesen wird — in Wien ist inzwischen
+    Mitternacht vorbei / Then steht der Zähler unverändert auf 1.
+
+    ROT HEUTE: der Wiener Tageswechsel setzt ihn auf 0 — ein Kontingent-Leck
+    mitten am Ortstag.
+    """
+    from services import alert_daily_limit
+
+    user_id = sauberer_nutzer("ac6-akl-kein-reset")
+    mit_zone(
+        alert_daily_limit.increment, user_id, VOR_WIENER_MITTERNACHT, zone=AUCKLAND,
+    )
+
+    assert mit_zone(
+        alert_daily_limit.load, user_id, NACH_WIENER_MITTERNACHT, zone=AUCKLAND,
+    ) == 1, (
+        "Derselbe Auckland-Ortstag — der Zähler darf nicht mitten am Tag "
+        "aufgefüllt werden, nur weil in Wien ein neuer Tag begonnen hat."
+    )
+
+
+def test_ac6_zaehler_resettet_an_los_angeles_mitternacht(sauberer_nutzer):
+    """AC-6 (westlich): Spiegelbild zu Auckland.
+
+    Alarm um 23:30 LA-Ortszeit (= 06:30 UTC), Lesung um 00:30 LA-Ortszeit
+    (= 07:30 UTC). In Wien: 08:30 → 09:30, derselbe Tag.
+
+    ROT HEUTE: kein Wiener Tageswechsel → `load()` liefert weiterhin 1.
+    """
+    from services import alert_daily_limit
+
+    user_id = sauberer_nutzer("ac6-lax-reset")
+    mit_zone(
+        alert_daily_limit.increment, user_id, VOR_LA_MITTERNACHT, zone=LOS_ANGELES,
+    )
+
+    assert mit_zone(
+        alert_daily_limit.load, user_id, VOR_LA_MITTERNACHT, zone=LOS_ANGELES,
+    ) == 1
+    assert mit_zone(
+        alert_daily_limit.load, user_id, NACH_LA_MITTERNACHT, zone=LOS_ANGELES,
+    ) == 0, (
+        "Nach der Los-Angeles-Mitternacht beginnt der Ortstag neu."
+    )
+
+
+def test_ac6_zaehler_resettet_nicht_an_wiener_mitternacht_westlich(sauberer_nutzer):
+    """AC-6 (westlich, Gegenrichtung): Die Wiener Mitternacht (22:00 UTC) fällt
+    für Los Angeles mitten in den Nachmittag (15:00 Ortszeit) — der Zähler
+    bleibt stehen.
+
+    ROT HEUTE: der Wiener Tageswechsel setzt ihn auf 0.
+    """
+    from services import alert_daily_limit
+
+    user_id = sauberer_nutzer("ac6-lax-kein-reset")
+    mit_zone(
+        alert_daily_limit.increment, user_id, VOR_WIENER_MITTERNACHT, zone=LOS_ANGELES,
+    )
+
+    assert mit_zone(
+        alert_daily_limit.load, user_id, NACH_WIENER_MITTERNACHT, zone=LOS_ANGELES,
+    ) == 1, (
+        "In Los Angeles ist es 15:00 desselben Ortstags — der Zähler darf durch "
+        "die Wiener Mitternacht nicht aufgefüllt werden."
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC-7 — Getrennte Zähler pro Zone, BEIDE Richtungen
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_ac7_ausgeschoepfte_zone_blockiert_die_andere_nicht(sauberer_nutzer):
+    """AC-7 (Richtung 1): Ein in Zone A ausgeschöpftes Kontingent blockiert
+    Zone B nicht.
+
+    Given ein Free-Nutzer (Limit 2), dessen Auckland-Kontingent voll ist / When
+    ein Alarm für ein Objekt in Los Angeles anstünde / Then ist er erlaubt.
+
+    ROT HEUTE: es gibt genau EINEN Zähler ohne Zonen-Unterscheidung — nach zwei
+    Buchungen ist ALLES gesperrt. Ein ignorierter `zone`-Parameter ändert daran
+    nichts, dieser Test bliebe rot.
+    """
+    from services import alert_daily_limit
+
+    user_id = sauberer_nutzer("ac7-richtung1")
+    jetzt = JETZT_AUCKLAND_NACHT
+    mit_zone(
+        alert_daily_limit.increment, user_id, jetzt, zone=AUCKLAND,
+    )
+    mit_zone(
+        alert_daily_limit.increment, user_id, jetzt, zone=AUCKLAND,
+    )
+
+    assert mit_zone(
+        alert_daily_limit.is_allowed, user_id, jetzt, zone=AUCKLAND,
+    ) is False, (
+        "Zwei Buchungen = Free-Limit erreicht (Vorbedingung des Tests)."
+    )
+    assert mit_zone(
+        alert_daily_limit.is_allowed, user_id, jetzt, zone=LOS_ANGELES,
+    ) is True, (
+        "Das Kontingent wird je Zone geführt — der bewusste Preis dieser "
+        "Lösung (wer Objekte in drei Zonen hat, bekommt es dreimal) ist Teil "
+        "der Zusicherung, kein Nebenprodukt."
+    )
+
+
+def test_ac7_alarm_in_einer_zone_verbraucht_die_andere_nicht(sauberer_nutzer):
+    """AC-7 (Richtung 2): Ein Alarm in Zone A verbraucht NICHTS von Zone B.
+
+    ROT HEUTE: ein gemeinsamer Zähler ohne Zonen-Diskriminator — jede Buchung
+    schlägt überall durch.
+    """
+    from services import alert_daily_limit
+
+    user_id = sauberer_nutzer("ac7-richtung2")
+    jetzt = JETZT_AUCKLAND_NACHT
+    mit_zone(
+        alert_daily_limit.increment, user_id, jetzt, zone=AUCKLAND,
+    )
+
+    assert mit_zone(
+        alert_daily_limit.load, user_id, jetzt, zone=AUCKLAND,
+    ) == 1
+    assert mit_zone(
+        alert_daily_limit.load, user_id, jetzt, zone=LOS_ANGELES,
+    ) == 0, (
+        "Der Zählerstand von Los Angeles darf durch eine Auckland-Buchung "
+        "nicht steigen."
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC-8 — Bestandsdaten überleben den Rollout
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _schreibe_alt_schema(user_id: str, tag: date_type, count: int) -> Path:
+    """Zähler-Datei im ALTEN Schema `{"date": ..., "count": N}` — genau so,
+    wie sie heute auf der Produktions-Platte liegt."""
+    from app.loader import get_data_dir
+
+    ordner = get_data_dir(user_id)
+    ordner.mkdir(parents=True, exist_ok=True)
+    pfad = ordner / "alert_daily_count.json"
+    pfad.write_text(json.dumps({"date": tag.isoformat(), "count": count}))
+    return pfad
+
+
+def test_ac8_bestandszaehler_bleibt_beim_ersten_zugriff_erhalten(sauberer_nutzer):
+    """AC-8: Ein Deploy mitten am Tag darf kein Kontingent-Leck erzeugen.
+
+    Given ein Zähler im ALTEN Schema mit Stand 2 für den heutigen Wiener Tag /
+    When der neue Code ihn zum ersten Mal für `Europe/Vienna` liest und erhöht /
+    Then bleibt der Bestand erhalten (2 → 3), er wird nicht auf 0 gesetzt.
+
+    GRÜN HEUTE — und das ist Absicht: dieser Teil von AC-8 sichert eine
+    Eigenschaft, die der Altcode bereits hat, und die beim Schema-Wechsel
+    verloren gehen würde (Migration per Replace statt Merge). Er ist der
+    Regressions-Anker, nicht der RED-Fall. Von einem entgegengenommenen, aber
+    ignorierten `zone`-Parameter wäre er ebenfalls erfüllt — den scharfen Teil
+    trägt `test_ac8_migration_faellt_nur_der_wiener_zone_zu`.
+    """
+    from services import alert_daily_limit
+
+    user_id = sauberer_nutzer("ac8-bestand")
+    jetzt = JETZT_AUCKLAND_NACHT
+    _schreibe_alt_schema(user_id, jetzt.astimezone(VIENNA).date(), 2)
+
+    assert mit_zone(
+        alert_daily_limit.load, user_id, jetzt, zone=VIENNA,
+    ) == 2, (
+        "Der Altbestand wurde nach Wiener Kalendertag geführt — für diese Zone "
+        "ist er die korrekte Fortsetzung."
+    )
+    mit_zone(
+        alert_daily_limit.increment, user_id, jetzt, zone=VIENNA,
+    )
+    assert mit_zone(
+        alert_daily_limit.load, user_id, jetzt, zone=VIENNA,
+    ) == 3
+
+
+def test_ac8_migration_faellt_nur_der_wiener_zone_zu(sauberer_nutzer):
+    """AC-8 (Schärfung): Der Altbestand gilt NUR für `Europe/Vienna`; jede
+    andere Zone beginnt bei 0, und eine Buchung dort lässt den Wiener Stand
+    unangetastet (Merge auf ZONEN-Ebene, nicht nur auf Datei-Ebene).
+
+    ROT HEUTE — und auch mit einem ignorierten `zone`-Parameter: dort läge der
+    Auckland-Stand bei 2 statt 0 und stiege gemeinsam mit dem Wiener.
+    """
+    from services import alert_daily_limit
+
+    user_id = sauberer_nutzer("ac8-merge")
+    jetzt = JETZT_AUCKLAND_NACHT
+    _schreibe_alt_schema(user_id, jetzt.astimezone(VIENNA).date(), 2)
+
+    assert mit_zone(
+        alert_daily_limit.load, user_id, jetzt, zone=AUCKLAND,
+    ) == 0, (
+        "Für Auckland ist der Wiener Altbestand keine sinnvolle Fortsetzung."
+    )
+    mit_zone(
+        alert_daily_limit.increment, user_id, jetzt, zone=AUCKLAND,
+    )
+
+    assert mit_zone(
+        alert_daily_limit.load, user_id, jetzt, zone=AUCKLAND,
+    ) == 1
+    assert mit_zone(
+        alert_daily_limit.load, user_id, jetzt, zone=VIENNA,
+    ) == 2, (
+        "Die Auckland-Buchung darf den migrierten Wiener Eintrag nicht "
+        "überschreiben (Read-Modify-Write mit Merge, niemals Replace)."
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC-9 — Ortsvergleichs-Slot-Fälligkeit folgt der Zone des ersten Orts
+# ═══════════════════════════════════════════════════════════════════════════
+
+# 2026-08-12 19:30 UTC → Auckland 07:30 (13.8.) · Wien 21:30 · LA 12:30
+FAELLIG_IN_AUCKLAND = datetime(2026, 8, 12, 19, 30, tzinfo=UTC)
+# 2026-08-12 14:30 UTC → Los Angeles 07:30 · Wien 16:30 · Auckland 02:30
+FAELLIG_IN_LOS_ANGELES = datetime(2026, 8, 12, 14, 30, tzinfo=UTC)
+
+
+def _faellige_presets(user_id: str, now_utc: datetime) -> set[str]:
+    """Fällige Preset-Kennungen über den ECHTEN Versand-Orchestrator.
+
+    `CompareDispatchStrategy.collect_due(now_utc)` nimmt schon heute einen
+    ZEITPUNKT — die Signatur ändert sich durch diese Scheibe nicht. Der Test
+    ist damit ein reiner Verhaltenstest.
+    """
+    from app.loader import get_data_root
+    from services.dispatch_orchestrator import CompareDispatchStrategy
+
+    strategie = CompareDispatchStrategy(
+        settings_email_only(), user_id, data_root=str(get_data_root()),
+    )
+    return {eintrag[0].get("id") for eintrag in strategie.collect_due(now_utc)}
+
+
+def _zwei_presets_in_zwei_zonen(user_id: str) -> None:
+    schreibe_ort(user_id, "loc-akl", "Pacific/Auckland")
+    schreibe_ort(user_id, "loc-lax", "America/Los_Angeles")
+    schreibe_presets(user_id, [
+        vergleichs_preset("cp-akl", ["loc-akl"], morning_time="07:00:00"),
+        vergleichs_preset("cp-lax", ["loc-lax"], morning_time="07:00:00"),
+    ])
+
+
+def test_ac9_preset_ist_zur_eigenen_ortsstunde_faellig(sauberer_nutzer):
+    """AC-9: Ein Preset mit Morgen-Slot 07:00 und Orten in Auckland ist fällig,
+    wenn es DORT 07:00 ist — nicht, wenn es in Wien 07:00 ist.
+
+    ROT HEUTE: `collect_due()` bildet EINEN `vor_ort`-Zeitpunkt aus der festen
+    Konstante `NOCH_NICHT_ORTSZEIT_SIEHE_1726` und prüft alle Presets gegen
+    dieselbe Stunde. Um 19:30 UTC ist es in Wien 21:30 — nichts ist fällig.
+    """
+    user_id = sauberer_nutzer("ac9-akl")
+    _zwei_presets_in_zwei_zonen(user_id)
+
+    assert _faellige_presets(user_id, FAELLIG_IN_AUCKLAND) == {"cp-akl"}, (
+        "Um 07:30 Auckland-Ortszeit ist genau das Auckland-Preset fällig — das "
+        "Los-Angeles-Preset (dort 12:30) nicht."
+    )
+
+
+def test_ac9_zwei_presets_sind_zu_verschiedenen_weltzeiten_faellig(sauberer_nutzer):
+    """AC-9 (Gegenstück): Dasselbe Konto, dieselbe Slot-Uhrzeit, aber erste
+    Orte in verschiedenen Zonen → verschiedene Weltzeit-Momente.
+
+    ROT HEUTE: beide Läufe liefern die leere Menge, weil beide gegen die Wiener
+    Stunde geprüft werden (21:30 bzw. 16:30).
+    """
+    user_id = sauberer_nutzer("ac9-lax")
+    _zwei_presets_in_zwei_zonen(user_id)
+
+    assert _faellige_presets(user_id, FAELLIG_IN_LOS_ANGELES) == {"cp-lax"}, (
+        "Um 07:30 Los-Angeles-Ortszeit ist genau das LA-Preset fällig."
+    )
+
+
+def test_ac9_wiener_slotstunde_macht_fremde_presets_nicht_faellig(sauberer_nutzer):
+    """AC-9 (Kontrolle): Wenn es in WIEN 07:00 ist, darf kein Preset fällig
+    sein, dessen erster Ort anderswo liegt.
+
+    ROT HEUTE genau umgekehrt: um 05:30 UTC ist es in Wien 07:30 und BEIDE
+    Presets gelten als fällig, obwohl es in Auckland 17:30 und in Los Angeles
+    22:30 ist.
+    """
+    user_id = sauberer_nutzer("ac9-wien")
+    _zwei_presets_in_zwei_zonen(user_id)
+    wien_0730 = datetime(2026, 8, 12, 5, 30, tzinfo=UTC)
+
+    assert _faellige_presets(user_id, wien_0730) == set(), (
+        "Die Wiener Uhr entscheidet über gar nichts mehr."
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC-10 — Beide Sommerzeit-Wechseltage, Häufigkeit JEDER EINZELNEN Stunde
+#
+# Die beiden von der Spec vorgegebenen Daten sind EU-Umstellungstage. Wien ist
+# als Prüfzone unbrauchbar (ein Rückfall wäre unsichtbar), Paris ebenso
+# (gleicher Versatz). `Europe/Lisbon` schaltet zum selben Zeitpunkt, hat aber
+# +0/+1 statt +1/+2 — ein Wien-Rückfall verschiebt jede Grenzstunde um eine
+# Stunde und fällt auf.
+# ═══════════════════════════════════════════════════════════════════════════
+
+FRUEHJAHR = date_type(2026, 3, 29)   # 23 Ortsstunden, Stunde 01 fehlt (Lissabon)
+HERBST = date_type(2026, 10, 25)     # 25 Ortsstunden, Stunde 01 zweimal (Lissabon)
+
+
+def _stundenraster(tag: date_type, zone: ZoneInfo) -> list[datetime]:
+    """Alle vollen Ortsstunden des Kalendertags `tag` in `zone`, als
+    UTC-Zeitpunkte — gerechnet, nicht getippt.
+
+    Es wird von 24 Stunden VOR bis 24 Stunden NACH dem Tag in UTC-Schritten
+    gelaufen und behalten, was in der Ortszone auf diesem Kalendertag zur
+    vollen Stunde liegt. Ein Tag mit 23 bzw. 25 Ortsstunden entsteht dadurch
+    von selbst — die Zahl wird nirgends angenommen.
+    """
+    start = datetime.combine(tag, datetime.min.time(), tzinfo=UTC) - timedelta(days=1)
+    raster: list[datetime] = []
+    for i in range(24 * 3):
+        moment = start + timedelta(hours=i)
+        lokal = moment.astimezone(zone)
+        if lokal.date() == tag and lokal.minute == 0:
+            raster.append(moment)
+    return raster
+
+
+def test_ac10_fruehjahrs_umstellungstag_hat_23_ortsstunden():
+    """AC-10 (Vorbedingung, grüner Anker): Der 29.03.2026 hat in
+    `Europe/Lisbon` 23 Ortsstunden, Stunde 01 existiert nicht.
+
+    Kein Prüfling-Test — er sichert nur ab, dass die folgenden Tests am
+    richtigen Tag messen. Fiele er, wären die AC-10-Aussagen bedeutungslos.
+    """
+    stunden = [m.astimezone(LISBON).hour for m in _stundenraster(FRUEHJAHR, LISBON)]
+
+    assert len(stunden) == 23
+    assert stunden.count(1) == 0, "Die übersprungene Stunde ist 01 (WET→WEST)."
+    assert all(stunden.count(h) == 1 for h in stunden)
+
+
+def test_ac10_herbst_umstellungstag_hat_25_ortsstunden():
+    """AC-10 (Vorbedingung, grüner Anker): Der 25.10.2026 hat in
+    `Europe/Lisbon` 25 Ortsstunden, Stunde 01 existiert zweimal."""
+    stunden = [m.astimezone(LISBON).hour for m in _stundenraster(HERBST, LISBON)]
+
+    assert len(stunden) == 25
+    assert stunden.count(1) == 2, "Die doppelte Stunde ist 01 (WEST→WET)."
+
+
+@pytest.mark.parametrize("tag", [FRUEHJAHR, HERBST], ids=["fruehjahr", "herbst"])
+def test_ac10_ruhezeit_stimmt_an_jeder_einzelnen_stunde_des_umstellungstags(tag):
+    """AC-10: Ruhezeit-Wrap 22:00–07:00, Stunde für Stunde über den ganzen
+    Umstellungstag geprüft — nicht die Zeilenzahl, sondern JEDE Stunde.
+
+    ROT HEUTE: `is_quiet_hours` rechnet in Wien. Lissabon liegt eine Stunde
+    dahinter, also weicht das Ergebnis an jeder Grenzstunde ab (z.B. 21:00
+    Lissabon = 22:00 Wien: heute unterdrückt, richtig wäre wach).
+    """
+    from services.deviation_alert_engine import DeviationAlertEngine
+
+    abweichungen: list[tuple[str, int, bool, bool]] = []
+    for moment in _stundenraster(tag, LISBON):
+        lokale_stunde = moment.astimezone(LISBON).hour
+        erwartet = lokale_stunde >= 22 or lokale_stunde < 7
+        gemessen = mit_zone(
+            DeviationAlertEngine.is_quiet_hours,
+            moment, RUHE_VON, RUHE_BIS, zone=LISBON,
+        )
+        if gemessen is not erwartet:
+            abweichungen.append(
+                (moment.isoformat(), lokale_stunde, erwartet, gemessen)
+            )
+
+    assert not abweichungen, (
+        f"Ruhezeit weicht am {tag} an diesen Ortsstunden ab "
+        f"(Zeitpunkt, Ortsstunde, erwartet, gemessen): {abweichungen}"
+    )
+
+
+@pytest.mark.parametrize("tag", [FRUEHJAHR, HERBST], ids=["fruehjahr", "herbst"])
+def test_ac10_zaehler_haelt_ueber_den_ganzen_umstellungstag(sauberer_nutzer, tag):
+    """AC-10: Der Tageszähler wird an einem Umstellungstag WEDER vorzeitig
+    (Frühjahr) NOCH doppelt (Herbst) zurückgesetzt.
+
+    Gebucht wird an der ERSTEN Ortsstunde des Tages; danach wird an JEDER
+    weiteren Ortsstunde desselben Tages gelesen — überall muss 1 stehen. Erst
+    die erste Stunde des Folgetags liefert 0.
+
+    ROT HEUTE: gelesen wird gegen den WIENER Kalendertag. Der wechselt gegenüber
+    dem Lissabonner um eine Stunde versetzt, also fällt der Zähler an der
+    falschen Stelle auf 0.
+    """
+    from services import alert_daily_limit
+
+    user_id = sauberer_nutzer(f"ac10-{tag.isoformat()}")
+    raster = _stundenraster(tag, LISBON)
+    mit_zone(
+        alert_daily_limit.increment, user_id, raster[0], zone=LISBON,
+    )
+
+    zu_frueh = [
+        moment.astimezone(LISBON).isoformat()
+        for moment in raster
+        if mit_zone(
+        alert_daily_limit.load, user_id, moment, zone=LISBON,
+    ) != 1
+    ]
+    assert not zu_frueh, (
+        f"Der Zähler wurde am {tag} mitten am Ortstag zurückgesetzt: {zu_frueh}"
+    )
+
+    erste_stunde_folgetag = _stundenraster(tag + timedelta(days=1), LISBON)[0]
+    assert mit_zone(
+        alert_daily_limit.load, user_id, erste_stunde_folgetag, zone=LISBON,
+    ) == 0, "An der Orts-Mitternacht des Folgetags muss der Zähler neu beginnen."
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC-12 / AC-13 / AC-14 — Dokumentation und Wächter-Restliste
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_ac12_adr_0044_nennt_die_beiden_module_nicht_mehr_als_ausnahme():
+    """AC-12 — doc-compliance-test.
+
+    ADR-0044 listet `alert_daily_limit` und `deviation_alert_engine` heute
+    unter „Bewusst NICHT betroffen (feste Zone ist dort Absicht)". Nach dieser
+    Scheibe stimmt das nicht mehr.
+
+    Dateiinhalt-Prüfung ist hier ausdrücklich zulässig (Spec AC-12): der
+    Gegenstand der Zusicherung IST die Dokumentation.
+
+    ROT HEUTE: der Absatz steht unverändert da.
+    """
+    # doc-compliance-test
+    adr = (ROOT / "docs/adr/0044-kalendertage-folgen-der-ortszeit.md").read_text(
+        encoding="utf-8"
+    )
+    marker = "**Bewusst NICHT betroffen**"
+    assert marker in adr, "Der Abschnitt selbst muss erhalten bleiben."
+
+    start = adr.index(marker)
+    ende = adr.find("\n\n", start)
+    absatz = adr[start:ende if ende != -1 else len(adr)]
+
+    for modul in ("alert_daily_limit", "deviation_alert_engine"):
+        assert modul not in absatz, (
+            f"ADR-0044 führt `{modul}` weiterhin als bewusste Ausnahme — nach "
+            "#1726 folgt das Modul der Ortszone und gehört in den Abschnitt "
+            "'Umgesetzt'."
+        )
+
+
+def test_ac13_waechter_restliste_verliert_genau_die_vier_eintraege():
+    """AC-13: Die vier zu dieser Scheibe gehörenden Einträge sind aus
+    `KNOWN_VIOLATIONS` entfernt.
+
+    Geprüft wird die DATENSTRUKTUR des Wächters, nicht der Dateitext — nach dem
+    Fix findet der Scanner diese Stellen nicht mehr, und
+    `test_known_violations_only_shrink()` würde sie sonst als „stale" melden.
+
+    ROT HEUTE: alle vier stehen noch drin.
+    """
+    from tests.test_output_timezone_guard import KNOWN_VIOLATIONS
+
+    zu_entfernen = [
+        "src/services/alert_daily_limit.py::<module>::0",
+        "src/services/deviation_alert_engine.py::<module>::0",
+        "src/services/alert_daily_limit.py::_vienna_date_str::0",
+        "src/services/deviation_alert_engine.py::is_quiet_hours::0",
+    ]
+    verblieben = [k for k in zu_entfernen if k in KNOWN_VIOLATIONS]
+
+    assert not verblieben, (
+        "Diese Einträge gehören zu #1726 und müssen mit dem Fix verschwinden "
+        f"(die Liste darf nur schrumpfen): {verblieben}"
+    )
+
+
+def test_ac14_blockkommentar_weist_die_muster_a_restliste_1727_zu():
+    """AC-14 — doc-compliance-test.
+
+    Der Blockkommentar bei `tests/test_output_timezone_guard.py:593` weist
+    heute ALLE 53 Bestandseinträge pauschal #1726 zu — auch die ~25
+    Muster-A-Funde, die tatsächlich #1727 (S5) tragen. Nach dem Schliessen von
+    #1726 zeigte die Liste auf ein erledigtes Issue.
+
+    ROT HEUTE: der Kommentar nennt #1727 nirgends.
+    """
+    # doc-compliance-test
+    quelle = (ROOT / "tests/test_output_timezone_guard.py").read_text(encoding="utf-8")
+    marker = "ENTSCHEIDUNGS-SCHICHT (Issue #1723"
+    assert marker in quelle, "Der Blockkommentar selbst muss erhalten bleiben."
+
+    start = quelle.index(marker)
+    block = quelle[start:start + 1400]
+
+    assert "#1727" in block, (
+        "Der Blockkommentar muss die verbleibenden Muster-A-Funde auf #1727 "
+        "verweisen, statt sie weiter #1726 zuzuschreiben."
+    )
+    assert "die Behebung traegt #1726 (S4)" not in block, (
+        "Die pauschale Zuweisung der GESAMTEN Restliste an #1726 ist nach dem "
+        "Schliessen dieses Issues falsch."
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC-15 — Gelöschter/unauflösbarer erster Ort kippt nicht still auf Weltzeit
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_ac15_geloeschter_erster_ort_faellt_auf_den_naechsten_aufloesbaren(
+    sauberer_nutzer,
+):
+    """AC-15: Steht in `location_ids` eine Kennung, zu der es keinen Ort mehr
+    gibt (gelöschter Ort — der Filter in `compare_official_alert.py:128` gibt
+    es zu), gilt die Zone des ersten Orts, der sich AUFLÖSEN LÄSST.
+
+    Given ein Vergleich [gelöschte-ID, Auckland] mit einem Fenster um die
+    Auckland-Ortszeit / Then ist er ruhig.
+
+    ROT HEUTE: geprüft wird gegen Wien. Und ein naiver Fix
+    (`all_locations.get(location_ids[0])` als reiner Indexzugriff) fällt hier
+    ebenfalls durch: `location_tz(None)` liefert still UTC, und in UTC ist das
+    Auckland-Fenster nicht erfüllt.
+    """
+    fenster = fenster_um_jetzt(AUCKLAND)
+    user_id = sauberer_nutzer("ac15-geloescht")
+    schreibe_ort(user_id, "loc-akl", "Pacific/Auckland")
+    schreibe_presets(user_id, [
+        vergleichs_preset("cp-luecke", ["loc-weg", "loc-akl"],
+                          quiet_from=fenster[0], quiet_to=fenster[1])
+    ])
+    dienst = vergleichs_alarmdienst(user_id)
+    dienst.check_all_compare_presets()
+
+    assert type(dienst).detect_aufrufe == 0, (
+        "Der erste AUFLÖSBARE Ort bestimmt die Zone — ein gelöschter Eintrag "
+        "davor darf den Vergleich nicht still auf Weltzeit kippen."
+    )
+
+
+def test_ac15_kein_aufloesbarer_ort_ergibt_utc_und_einen_protokolleintrag(
+    sauberer_nutzer, caplog,
+):
+    """AC-15 (zweiter Teil): Löst KEIN Ort eine Zone auf, gilt UTC — aber
+    sichtbar, mit der Vergleichs-Kennung im Protokoll.
+
+    Given ein Vergleich, dessen einziger Ort keine auflösbare Zone hat (0/0) /
+    When die Ruhezeit bestimmt wird / Then gilt UTC (das Fenster um die
+    UTC-Uhrzeit unterdrückt), UND es steht eine Warnung mit der Preset-Kennung
+    im Protokoll.
+
+    ROT HEUTE: geprüft wird gegen Wien (das UTC-Fenster greift dort nicht), und
+    protokolliert wird gar nichts.
+    """
+    import logging
+
+    fenster = fenster_um_jetzt(ZoneInfo("UTC"))
+    user_id = sauberer_nutzer("ac15-nichts")
+    schreibe_ort_ohne_koordinaten(user_id, "loc-nirgendwo")
+    schreibe_presets(user_id, [
+        vergleichs_preset("cp-ohne-zone", ["loc-nirgendwo"],
+                          quiet_from=fenster[0], quiet_to=fenster[1])
+    ])
+    dienst = vergleichs_alarmdienst(user_id)
+
+    with caplog.at_level(logging.WARNING):
+        dienst.check_all_compare_presets()
+
+    assert type(dienst).detect_aufrufe == 0, (
+        "Ohne auflösbare Zone gilt UTC — das UTC-Fenster muss greifen."
+    )
+    assert any(
+        "cp-ohne-zone" in eintrag.getMessage() for eintrag in caplog.records
+    ), (
+        "Der UTC-Rückfall darf nicht still geschehen: er gehört mit der "
+        "Vergleichs-Kennung ins Protokoll."
+    )

--- a/tests/tdd/test_ruhezeit_und_zaehler_folgen_der_ortszone.py
+++ b/tests/tdd/test_ruhezeit_und_zaehler_folgen_der_ortszone.py
@@ -159,16 +159,20 @@ def schreibe_ort(user_id: str, loc_id: str, zone_name: str):
     return loc
 
 
-def schreibe_ort_ohne_koordinaten(user_id: str, loc_id: str):
-    """Ort, dessen Zone NICHT auflösbar ist (Koordinaten auf 0/0 = Nullmeridian
-    im Golf von Guinea → `tz_for_coords` liefert "UTC" → `resolve_location_tz`
-    liefert `None`). Kein Konstrukt-Trick: genau diese Lage ist der reale Fall
-    „Ort ohne brauchbare Zone" aus `utils/timezone.py:60-64`."""
-    from app.loader import save_location
-
-    loc = location(loc_id, f"Ort {loc_id}", lat=0.0, lon=0.0)
-    save_location(loc, user_id=user_id)
-    return loc
+# 🔴 KORREKTUR DER RED-PHASE (GREEN, #1726). Hier stand ein Helfer
+# `schreibe_ort_ohne_koordinaten()`, der einen Ort auf 0/0 legte und behauptete,
+# `tz_for_coords(0, 0)` liefere "UTC" und damit `resolve_location_tz() is None`.
+# NACHGEMESSEN mit der installierten `timezonefinder`: sie liefert dort
+# `Etc/GMT` — seit Version 6 sind die Ozean-Zonen (`Etc/GMT±X`) in den Daten,
+# `timezone_at()` gibt für keinen Punkt der Erde mehr `None` zurück. Der Ort war
+# also sehr wohl auflösbar, der Test hätte die Zusicherung nie gemessen (er wäre
+# an der Protokoll-Erwartung hängengeblieben, ohne dass am Prüfling etwas fehlt).
+#
+# Der reale „kein Ort auflösbar"-Fall ist deshalb NICHT die Koordinate, sondern
+# die ins Leere zeigende Kennung: ein gelöschter Ort bleibt in `location_ids`
+# stehen (genau dafür filtert `compare_official_alert.py:128`). Zeigt die
+# EINZIGE Kennung ins Leere, löst kein Ort auf — das ist der Fall, den AC-15
+# meint, und er wird unten unverändert scharf geprüft.
 
 
 def vergleichs_preset(
@@ -1357,21 +1361,25 @@ def test_ac15_kein_aufloesbarer_ort_ergibt_utc_und_einen_protokolleintrag(
     """AC-15 (zweiter Teil): Löst KEIN Ort eine Zone auf, gilt UTC — aber
     sichtbar, mit der Vergleichs-Kennung im Protokoll.
 
-    Given ein Vergleich, dessen einziger Ort keine auflösbare Zone hat (0/0) /
-    When die Ruhezeit bestimmt wird / Then gilt UTC (das Fenster um die
-    UTC-Uhrzeit unterdrückt), UND es steht eine Warnung mit der Preset-Kennung
-    im Protokoll.
+    Given ein Vergleich, dessen EINZIGE Ortskennung ins Leere zeigt (der Ort
+    wurde gelöscht, die Kennung blieb im Preset stehen) / When die Ruhezeit
+    bestimmt wird / Then gilt UTC (das Fenster um die UTC-Uhrzeit
+    unterdrückt), UND es steht eine Warnung mit der Preset-Kennung im
+    Protokoll.
 
     ROT HEUTE: geprüft wird gegen Wien (das UTC-Fenster greift dort nicht), und
     protokolliert wird gar nichts.
+
+    Zur Wahl des Falls s. den Korrektur-Block oben bei den Ablage-Helfern:
+    eine Koordinate ohne auflösbare Zone gibt es seit `timezonefinder` 6 nicht
+    mehr, die ins Leere zeigende Kennung ist der reale Fall.
     """
     import logging
 
     fenster = fenster_um_jetzt(ZoneInfo("UTC"))
     user_id = sauberer_nutzer("ac15-nichts")
-    schreibe_ort_ohne_koordinaten(user_id, "loc-nirgendwo")
     schreibe_presets(user_id, [
-        vergleichs_preset("cp-ohne-zone", ["loc-nirgendwo"],
+        vergleichs_preset("cp-ohne-zone", ["loc-alle-weg"],
                           quiet_from=fenster[0], quiet_to=fenster[1])
     ])
     dienst = vergleichs_alarmdienst(user_id)

--- a/tests/tdd/test_starkregen_kurzfristhinweis.py
+++ b/tests/tdd/test_starkregen_kurzfristhinweis.py
@@ -43,6 +43,7 @@ from app.config import Settings
 from app.models import TripReportConfig
 from app.trip import Stage, Trip, Waypoint
 from services import alert_daily_limit
+from utils.timezone import tz_for_coords
 from services.radar_service import (
     INTENSITY_CONVECTIVE, INTENSITY_DRY, INTENSITY_HEAVY, INTENSITY_MODERATE,
     NowcastResult, RadarNowcastService,
@@ -300,9 +301,13 @@ def test_ac1_budget_erschoepft_blockiert_fetch_und_hinweis(monkeypatch):
     trip = _active_trip(f"trip-ac1-{uuid.uuid4().hex[:6]}")
 
     now = datetime.now(timezone.utc)
-    alert_daily_limit.increment(uid, now)
-    alert_daily_limit.increment(uid, now)
-    assert alert_daily_limit.is_allowed(uid, now, reason="nowcast") is False, (
+    # Issue #1726: der Zaehler laeuft in der Ortszone der TOUR — `LAT`/`LON`
+    # liegen auf Island. Wer hier eine andere Zone belegt als der Pruefling
+    # liest, erschoepft ein Kontingent, das nie geprueft wird.
+    trip_zone = tz_for_coords(LAT, LON)
+    alert_daily_limit.increment(uid, now, trip_zone)
+    alert_daily_limit.increment(uid, now, trip_zone)
+    assert alert_daily_limit.is_allowed(uid, now, trip_zone, reason="nowcast") is False, (
         "Testvoraussetzung: Free-Tier-Tageslimit (2) muss ausgeschoepft sein."
     )
 

--- a/tests/tdd/test_throttle_store.py
+++ b/tests/tdd/test_throttle_store.py
@@ -457,8 +457,11 @@ def test_daily_limit_increment_is_atomic():
     uid = f"tdd-throttle-atomic-{uuid.uuid4().hex[:6]}"
     now = datetime(2026, 7, 7, 10, 0, tzinfo=timezone.utc)
 
-    alert_daily_limit.increment(uid, now)
-    alert_daily_limit.increment(uid, now)
+    # Issue #1726: der Zaehler ist zonenweise; diese Zusicherung prueft die
+    # Schreibmechanik (atomar, isolierte Wurzel), nicht die Zonenwahl.
+    zone = ZoneInfo("Europe/Vienna")
+    alert_daily_limit.increment(uid, now, zone)
+    alert_daily_limit.increment(uid, now, zone)
 
     counter_dir = get_data_dir(uid)
     assert counter_dir.exists(), (
@@ -472,7 +475,9 @@ def test_daily_limit_increment_is_atomic():
     )
 
     data = json.loads((counter_dir / "alert_daily_count.json").read_text())
-    assert data["count"] == 2, f"Zähler nach 2 Increments unerwartet: {data}"
+    assert data["zones"][str(zone)]["count"] == 2, (
+        f"Zähler nach 2 Increments unerwartet: {data}"
+    )
 
 
 # ═══════════════ AC-7: get_time_until_next_alert per-Trip-Cooldown ══════════

--- a/tests/tdd/test_trip_radar_nowcast_gate_migration.py
+++ b/tests/tdd/test_trip_radar_nowcast_gate_migration.py
@@ -34,7 +34,7 @@ from datetime import datetime, timezone
 
 from tests.helpers.nowcast_gate_fixtures import (
     SCOPE_TRIP_RADAR, CountingFrameSource, clean_uid, fresh_uid, make_trip,
-    quiet_window_elsewhere, quiet_window_now, read_daily_counter,
+    TRIP_ZONE, quiet_window_elsewhere, quiet_window_now, read_daily_counter,
     read_throttle_state, record_throttle, save_trip, seed_daily_counter,
     settings_email_only, trip_alert_service, write_user_tier,
 )
@@ -51,9 +51,13 @@ def _run_trip_scenario(
     """EIN Trip-Nowcast-Lauf mit auslloesendem Onset. Liefert
     ``(rueckgabewert, mail_aufrufe)``."""
     write_user_tier(uid, "free")  # Limit 2/Tag
-    seed_daily_counter(uid, 2 if daily_limit_reached else 0)
+    seed_daily_counter(uid, 2 if daily_limit_reached else 0, zone=TRIP_ZONE)
 
-    quiet_from, quiet_to = quiet_window_now() if quiet else quiet_window_elsewhere()
+    # Issue #1726: Ortszone der TOUR (Island), nicht Wien.
+    quiet_from, quiet_to = (
+        quiet_window_now(zone=TRIP_ZONE) if quiet
+        else quiet_window_elsewhere(zone=TRIP_ZONE)
+    )
     trip = make_trip(trip_id, cooldown_minutes=120, quiet_from=quiet_from, quiet_to=quiet_to)
     save_trip(trip, uid)
 
@@ -93,9 +97,9 @@ def test_szenario_a_ohne_sperre_wird_zugestellt_und_gebucht():
             f"Sperrzeit des Trip-Nowcast fehlt unter Scope {SCOPE_TRIP_RADAR!r} "
             f"mit Schluessel {trip_id!r}: {state!r}"
         )
-        assert read_daily_counter(uid) == 1, (
+        assert read_daily_counter(uid, zone=TRIP_ZONE) == 1, (
             f"Tageszaehler muss nach genau einer Zustellung auf 1 stehen, "
-            f"steht auf {read_daily_counter(uid)}"
+            f"steht auf {read_daily_counter(uid, zone=TRIP_ZONE)}"
         )
     finally:
         clean_uid(uid)
@@ -113,7 +117,7 @@ def test_szenario_b_ruhezeit_unterdrueckt():
 
         assert sent == 0, f"Ruhezeit muss den Trip-Nowcast unterdruecken, erhalten: {sent}"
         assert mails == [], "Waehrend der Ruhezeit darf keine Mail rausgehen"
-        assert read_daily_counter(uid) == 0, "Unterdrueckter Alarm darf nicht zaehlen"
+        assert read_daily_counter(uid, zone=TRIP_ZONE) == 0, "Unterdrueckter Alarm darf nicht zaehlen"
         assert trip_id not in read_throttle_state(uid).get(SCOPE_TRIP_RADAR, {}), (
             "Unterdrueckter Alarm darf keine Sperrzeit buchen"
         )
@@ -133,7 +137,7 @@ def test_szenario_c_sperrzeit_unterdrueckt():
 
         assert sent == 0, f"Sperrzeit muss den Trip-Nowcast unterdruecken, erhalten: {sent}"
         assert mails == [], "Innerhalb der Sperrzeit darf keine Mail rausgehen"
-        assert read_daily_counter(uid) == 0, "Unterdrueckter Alarm darf nicht zaehlen"
+        assert read_daily_counter(uid, zone=TRIP_ZONE) == 0, "Unterdrueckter Alarm darf nicht zaehlen"
     finally:
         clean_uid(uid)
 
@@ -150,9 +154,9 @@ def test_szenario_d_tageslimit_unterdrueckt():
 
         assert sent == 0, f"Tageslimit muss den Trip-Nowcast unterdruecken, erhalten: {sent}"
         assert mails == [], "Bei erreichtem Tageslimit darf keine Mail rausgehen"
-        assert read_daily_counter(uid) == 2, (
+        assert read_daily_counter(uid, zone=TRIP_ZONE) == 2, (
             f"Der Zaehler darf beim unterdrueckten Alarm nicht wachsen, steht auf "
-            f"{read_daily_counter(uid)}"
+            f"{read_daily_counter(uid, zone=TRIP_ZONE)}"
         )
         assert trip_id not in read_throttle_state(uid).get(SCOPE_TRIP_RADAR, {}), (
             "Unterdrueckter Alarm darf keine Sperrzeit buchen"

--- a/tests/test_output_timezone_guard.py
+++ b/tests/test_output_timezone_guard.py
@@ -589,8 +589,20 @@ KNOWN_VIOLATIONS: dict[str, str] = {
     # von `src/services/**` + `api/**`, gemessen am 2026-08-11 gegen
     # origin/main `0db5eec6` (nach #1724, das zwei Europe/Vienna-Stellen
     # entfernt hat). 53 Einträge, ausschliesslich per AST-Scan erhoben, nicht
-    # per grep gezaehlt. Sie sind AUFGENOMMEN, nicht entschuldigt: diese
-    # Lieferung blockt nur Neuzugaenge, die Behebung traegt #1726 (S4).
+    # per grep gezaehlt. Sie sind AUFGENOMMEN, nicht entschuldigt: die
+    # Bestandsaufnahme selbst blockt nur Neuzugaenge.
+    #
+    # ZUORDNUNG (korrigiert mit #1726, S4): #1726 hat NUR die vier
+    # Entscheidungs-Stellen der Ruhezeit und des Alarm-Tageszaehlers behoben
+    # (Muster B in `alert_daily_limit.py`/`deviation_alert_engine.py` samt der
+    # zwei daran gekoppelten `raw_astimezone`-Funde) — die stehen deshalb
+    # unten nicht mehr. Die verbleibenden ~25 Muster-A-Funde
+    # (`date.today()`/`datetime.now()` ohne Zone) traegt **#1727** (S5); der
+    # frueher hier stehende pauschale Verweis „die Behebung traegt #1726"
+    # zeigte nach dem Schliessen von #1726 auf ein erledigtes Issue. Die
+    # `(#1726)`-Vermerke in den Einzelzeilen unten sind aus demselben Grund
+    # als **#1727** zu lesen; sie bleiben nur deshalb stehen, weil ihre
+    # Massen-Umschrift den Shrink-Vergleich unnoetig verrauschen wuerde.
     # -----------------------------------------------------------------------
     # --- Muster A: Umgebungsuhr (`date.today()` / `datetime.now()` ohne tz) ---
     "api/routers/compare.py::run_comparison::0": "Muster A (:53) — Sofort-Vergleich nimmt die Serveruhr als 'jetzt' (#1726).",
@@ -618,21 +630,19 @@ KNOWN_VIOLATIONS: dict[str, str] = {
     "src/services/trip_report_scheduler.py::_collect_future_stage_weather::0": "Muster A (:2205) — 'zukuenftige Etappen' ab Servertag (#1726).",
     "src/services/trip_report_scheduler.py::_send_trip_report_outcome::0": "Muster A (:932) — Test-Rueckfall vergleicht Zieltag mit Servertag (#1726).",
     "src/services/trip_report_scheduler.py::select_test_stage::0": "Muster A (:765) — Test-Etappenwahl ab Servertag (#1726).",
-    # --- Muster B: festes Nicht-UTC-Zonen-Literal (namentlich #1726/S4) ---
-    "src/services/alert_daily_limit.py::<module>::0": "Muster B (:23) — `VIENNA = ZoneInfo('Europe/Vienna')` als Tagesgrenze des Alarm-Kontingents; ADR-0051, Behebung #1726.",
-    "src/services/deviation_alert_engine.py::<module>::0": "Muster B (:31) — `VIENNA = ZoneInfo('Europe/Vienna')` als Ruhezeit-Zone; ADR-0051, Behebung #1726.",
+    # --- Muster B: festes Nicht-UTC-Zonen-Literal — mit #1726 vollstaendig
+    # abgeraeumt (beide `VIENNA`-Konstanten ersatzlos entfallen). Bleibt als
+    # Rubrik stehen: ein neuer Fund dieser Art gehoert behoben, nicht gelistet.
     # --- Bestehende Fundart `raw_astimezone` auf der NEU hinzugekommenen
     # Flaeche: kein neuer Detektor, nur groesserer Geltungsbereich. Viele davon
     # sind Umrechnungen NACH UTC (nach Hausnorm #1345 unauffaellig) — der
     # Scanner unterscheidet das strukturell nicht, deshalb gelistet statt
     # ausgenommen.
     "src/services/alert_briefing_anchor.py::record_briefing_sent::0": "raw_astimezone (:195) — Normalisierung des Sendezeitpunkts nach UTC.",
-    "src/services/alert_daily_limit.py::_vienna_date_str::0": "raw_astimezone (:32) — Tagesgrenze ueber die feste VIENNA-Zone, an Muster B oben gekoppelt (#1726).",
     "src/services/compare_location_weather_source.py::_window_bound::0": "raw_astimezone (:39) — Fenstergrenze aus lokalem Tag + Stunde.",
     "src/services/compare_location_weather_source.py::fetch::0": "raw_astimezone (:116) — lokaler Tag des Vergleichsorts.",
     "src/services/compare_official_alert.py::_day_window_end::0": "raw_astimezone (:271) — lokales 'jetzt' des Vergleichsorts.",
     "src/services/compare_official_alert.py::_day_window_end::1": "raw_astimezone (:275) — Fensterende zurueck nach UTC.",
-    "src/services/deviation_alert_engine.py::is_quiet_hours::0": "raw_astimezone (:112) — Ruhezeit gegen die feste VIENNA-Zone, an Muster B oben gekoppelt (#1726).",
     "src/services/forecast_budget.py::_today_utc::0": "raw_astimezone (:130) — Kontingent-Tag bewusst in UTC (Zaehlwerk, kein Nutzerdatum).",
     "src/services/official_alerts/meteoalarm_budget.py::_now_ts::0": "raw_astimezone (:167) — Kontingent-Zeitstempel bewusst in UTC.",
     "src/services/official_alerts/meteoalarm_budget.py::_today_utc::0": "raw_astimezone (:176) — Kontingent-Tag bewusst in UTC.",

--- a/tests/unit/test_radar_alert_channel_resolution.py
+++ b/tests/unit/test_radar_alert_channel_resolution.py
@@ -84,6 +84,7 @@ from tests.helpers.nowcast_gate_fixtures import (
     entries_for,
     fresh_uid,
     make_trip,
+    TRIP_ZONE,
     quiet_window_elsewhere,
     quiet_window_now,
     read_log,
@@ -123,7 +124,11 @@ def _radar_trip(
     Konstruktion beschreibbare ``Trip``-Felder (``app/trip.py:192,214,219``);
     dasselbe Muster nutzt ``test_alert_channel_premium_sms.py::_base_trip``.
     """
-    quiet_from, quiet_to = quiet_window_now() if quiet else quiet_window_elsewhere()
+    # Issue #1726: Ortszone der TOUR (Island), nicht Wien.
+    quiet_from, quiet_to = (
+        quiet_window_now(zone=TRIP_ZONE) if quiet
+        else quiet_window_elsewhere(zone=TRIP_ZONE)
+    )
     trip = make_trip(trip_id, quiet_from=quiet_from, quiet_to=quiet_to)
     trip.report_config = TripReportConfig(
         trip_id=trip_id, send_email=send_email, send_telegram=send_telegram,


### PR DESCRIPTION
S4 des Zeitzonen-Epics #1722. Setzt #1724 und #1725 voraus (beide live).

Refs #1726 — Issue wird erst nach bestandenem Post-Deploy-Selftest geschlossen.

## Was sich ändert

Drei Entscheidungen liefen auf der Wiener Uhr, obwohl sie den Nutzer an SEINEM Ort betreffen
(ADR-0051 Regel 2). Beide `VIENNA`-Konstanten entfallen ersatzlos.

| Was | vorher | jetzt |
|---|---|---|
| Ruhezeit-Fenster | `Europe/Vienna` | Trip: Zone der heutigen Etappe · Vergleich: erster auflösbarer Ort |
| Alarm-Tageszähler | ein Stand je Nutzer, Reset zur Wiener Mitternacht | ein Stand **je Zone**, Reset zur jeweiligen Ortsmitternacht |
| Ortsvergleichs-Slot-Fälligkeit | eine globale Wiener Stunde für alle Presets | je Preset die Zone seines ersten Orts |

Gemessene Nutzerwirkung: Eine Ruhezeit 22:00–07:00 lag in Neuseeland auf 08:00–17:00 Ortszeit —
still während des Wandertags, laut die ganze Nacht. Der Tageszähler kippte dort um 10:00, auf dem
PCT um 15:00 Ortszeit, also mitten am Wandertag.

## Drei PO-Entscheidungen (2026-08-12)

1. **Mehrzonen-Vergleich → erstgenannter Ort.** Keine neue Regel: dieselbe wendet die
   Vergleichs-Mail seit #1378 (AC-4) für ihre Kopfzeile an. Präzisiert zu „erster Ort, dessen
   Zone **auflösbar** ist" — ein gelöschter erster Ort darf nicht still auf Weltzeit kippen
   (AC-15, neuer Baustein `utils.timezone.first_resolvable_tz`).
2. **Tageszähler getrennt je Zone.** Der naheliegende Weg — jede Aufrufstelle bringt ihre Zone an
   EINEN gemeinsamen Datensatz — ist nachgemessen unbrauchbar: derselbe Lauf schriebe den
   Tagesschlüssel hin und her, `increment()` setzt bei jedem Nichttreffer auf 1 zurück, das Limit
   griffe **nie** mehr. Bewusster Preis: wer Objekte in drei Zonen hat, bekommt das Kontingent
   dreimal.
3. **Fälligkeitsfenster + Idempotenz für den Vergleich → #1777.** Hier nur der Zonentausch; die
   Prüfung bleibt Stundengleichheit, die Umstellungstag-Lücke bleibt vorerst bestehen.

## Nachweis

15 ACs, 58 Tests grün (Kernsuite + Zeitzonen-Wächter), Frontend 3/3, `ruff` sauber.

**Adversary: BROKEN in Runde 1, VERIFIED in Runde 2.** Drei Findings, alle derselben Art —
Zusicherungen, die nicht dort geprüft waren, wo sie wirken:

- **F001:** Zone in der Zweitprüfung der Alarm-Maschine unbewacht — die Fixtures lieferten nie
  echte Wetterdaten, `evaluate()` wurde nie erreicht.
- **F002:** `anchor_tz` liess sich projektweit durch `trip_tz` ersetzen, ohne dass ein Test rot
  wurde — **alle** Trip-Fixtures hatten nur eine Etappe, damit sind beide Auflösungen immer
  gleich. Die Spec begründet ausdrücklich, warum die tagesbewusste Variante nötig ist; diese
  Begründung hatte keinen Wächter.
- **F003:** Kontingent in Zone A prüfen, in Wien buchen — Prüfung und Buchung teilten nur eine
  lokale Variable. Beide Vergleichspfade betroffen.

Fix-Loop: +430 Zeilen **ausschliesslich Testcode**, kein Produktivcode — die Verdrahtung war
korrekt, es fehlte die Bewachung. Jeder neue Test ist per Mutation belegt: die jeweilige
Verfälschung macht genau ihn rot, sonst nichts.

## Mitgeliefert

- `docs/adr/0044` fortgeschrieben — es führte `alert_daily_limit` und `deviation_alert_engine`
  bis heute als bewusste Wien-Ausnahme.
- Vier Einträge der Zeitzonen-Ausnahmeliste entfernt; der Blockkommentar wies ~25 fremde
  Muster-A-Funde fälschlich #1726 zu, jetzt korrekt #1727.
- Zwei Bestandstests, deren Aussage sich ändert, je mit Begründung im Docstring: `test_issue_883`
  AC-5 baute sein Ruhezeit-Fenster über Wien für eine Tour auf **Island** — Test und Prüfling
  teilten den falschen Bezug, die Zusicherung konnte nie fehlschlagen. `test_issue_1070` AC-5
  brauchte gleiche Koordinaten, sonst hätte es mit zonenweisen Zählern AC-7 gemessen statt des
  Umgehungs-Riegels.

## Bekannte Grenzen

- Der Go-Cron tickt weiter in Wiener Zeit (`internal/config/config.go:20`) und fällt an
  Umstellungstagen aus — S5/#1727.
- Am Rollout-Tag ist das Kontingent für Nicht-Wien-Zonen einmalig grosszügiger, nie enger.
- Vorbestehend rot, gegen Baseline gemessen und nicht von dieser Scheibe verursacht:
  `test_issue_1168` ×2, `test_issue_883` ×4, `test_compare_official_alert::test_ac8_…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
