### PR TITLE
fix(#1719 S4): ein Kürzel je Größe — Telegram folgt dem Register

### DIFF
--- a/docs/context/feat-1719-s4-kuerzel-legende.md
+++ b/docs/context/feat-1719-s4-kuerzel-legende.md
@@ -1,0 +1,183 @@
+# Context: #1719 Scheibe S4 — Legende der Kürzel im Bereich „Reihenfolge"
+
+Erstellt: 2026-08-12 · Workflow: `feat-1719-s4-kuerzel-legende` · Track: Standard
+
+## Request Summary
+
+Der Editor soll die Kürzel auflösen, die in den zugestellten Ausgaben stehen — damit ein
+Nutzer, der in einer SMS `N13` oder in einer Telegram-Tabelle `TF` liest, im Editor
+nachschlagen kann, welche Größe das ist.
+
+## 🔴 Die Issue-Beschreibung ist an zwei Punkten überholt (gemessen 2026-08-12)
+
+Der Issue-Text sagt: *„Backend liefert heute keinen Klartext je Kürzel (`/api/metrics` hat
+`sms_code`, aber kein Beschreibungsfeld — `api/routers/config.py:83-120`)."* Beides trifft
+so nicht mehr zu:
+
+1. **`/api/metrics` liefert Klartext** — `label` (= `label_de`), zusätzlich `col_label` und
+   `sms_code` (`api/routers/config.py:85-97`).
+2. **Eine Legende existiert bereits** — `WeatherV2Reihenfolge.svelte:97-113` zeigt seit
+   #1453 (AC-7) drei Namensformen je Zeile: deutscher Name · `col_label` („Kurzform in der
+   Mail-Stundentabelle") · `sms_code` („Kürzel in der SMS").
+
+**Der eigentliche Defekt ist ein anderer und schwerer:** das als „Kürzel in der SMS"
+beschriftete Badge zeigt bei 5 von 25 Größen ein Kürzel, das in der **Trip**-Kurzform
+nie vorkommt — und die **Telegram**-Kürzelfamilie fehlt vollständig.
+
+## Der gemessene Befund
+
+`sms_code` ist laut Katalog-Kommentar (`api/routers/config.py:97`, Issue #914 Slice 1)
+Teil der **Alarm**-Render-Stammdaten. Die Trip-Kurzform verwendet eine eigene Tabelle mit
+Grammatik-Ausnahmen und Mehrfachkürzeln (`src/output/renderers/sms_trip.py:105-190`).
+
+| metric_id | Editor-Badge („SMS …") | Trip-SMS sendet tatsächlich |
+|---|---|---|
+| `temperature` | `D` | `K` `D` |
+| `temperature_night` | `TN` | **`N`** |
+| `wind_chill` | `TF` | `FK` `FD` `WC` |
+| `thunder` | `TH` | `TH` `TH+` |
+| `fresh_snow` | `NS` | `NS24+` |
+
+`temperature_night` ist der härteste Fall: das Badge nennt ein Kürzel (`TN`), das in
+keiner Trip-SMS auftaucht, während das gesendete `N` im gesamten Editor nirgends erklärt
+wird. Die übrigen 20 Größen stimmen.
+
+Gerechnet mit `scratchpad/kuerzel_matrix.py` gegen `get_all_metrics()` +
+`SMS_MULTI_SYMBOLS_BY_METRIC` / `SMS_SYMBOL_BY_METRIC` — nicht abgetippt.
+
+## Vier Kürzel-Familien, nicht drei
+
+| Ausgabeweg | Quelle im Code | `wind_chill` | im Editor sichtbar? |
+|---|---|---|---|
+| Mail-Stundentabelle (Trip + Vergleich) | `MetricDefinition.col_label` (`email/helpers.py:542`, `email/compare_html.py:498`) | `Feels` | ✅ |
+| **Telegram-Kompaktform (nur Trip)** | `MetricDefinition.compact_label` (`narrow.py:70-148`) | `TF` | ❌ **fehlt** |
+| **Trip-SMS / Premium-SMS** | `SMS_MULTI_SYMBOLS_BY_METRIC` → sonst `SMS_SYMBOL_BY_METRIC` (`sms_trip.py:116-190`) | `FK` `FD` `WC` | ❌ **falsch** (zeigt `sms_code`) |
+| Vergleichs-SMS | `get_sms_code()` = `sms_code` (`comparison.py:625`) | `TF` | ✅ korrekt |
+| Alarm-SMS | `sms_code` | `TF` | (kein eigener Ausweis) |
+
+**Folge für den Zuschnitt:** dasselbe Badge ist im **Vergleichs**-Editor richtig und im
+**Touren**-Editor falsch — die beiden Flächen senden aus verschiedenen Tabellen. Eine
+kontextlose Korrektur würde den Vergleich kaputt machen.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `frontend/src/lib/components/shared/weather-metrics-tab/WeatherV2Reihenfolge.svelte:82-113` | Die Badge-Zeile. Einziger Ort, der die Kürzel rendert. Kennt `activeChannel` — der Kanal-Bezug wäre also verfügbar |
+| `frontend/src/lib/components/shared/WeatherMetricsTab.svelte:170-173, 449-454` | Lädt `/api/sms-symbols` bereits und hält `smsSymbolsByMetric` (metric_id → Kürzel-Liste) — heute nur für die Gefahren-Legende genutzt |
+| `frontend/src/lib/components/shared/WeatherMetricsTab.svelte:1080-1095` | Vorbild-Legende (Gefahren, #1318/#1332): Markup, Testid, Quellendisziplin |
+| `api/routers/config.py:29-70` | `/api/sms-symbols` — `_symbols_for()` bildet exakt die Trip-SMS-Logik ab (MULTI hat Vorrang, `.rstrip(":")`) |
+| `api/routers/config.py:72-120` | `/api/metrics` — liefert `label`/`col_label`/`sms_code`, **kein** `compact_label` |
+| `src/app/metric_catalog.py:36-69` | Feldherkunft: `compact_label`, `col_label`, `sms_code` |
+| `src/output/renderers/sms_trip.py:105-190` | Wahrheit der Trip-SMS-Kürzel inkl. Grammatik-Ausnahmen |
+| `src/output/renderers/narrow.py:70-148` | Wahrheit der Telegram-Kompaktform (`compact_label`) |
+| `src/output/renderers/comparison.py:605-625` | Wahrheit der Vergleichs-SMS (`get_sms_code`) |
+| `src/output/renderers/compare_metric_catalog.py:300-312` | Reicht `col_label`/`sms_code` an die drei Vergleichs-Editoren durch |
+
+## Vier Einbettungen des Bausteins (alle betroffen)
+
+1. Touren-Editor — `WeatherMetricsTab.svelte:1191` (context `route`)
+2. Vergleichs-Übersicht — `WeatherMetricsTab.svelte:1338` (context `vergleich`)
+3. Vergleichs-Stundenverlauf — `CompareHourlyLayoutControls.svelte:221`
+4. Vergleichs-Ausblick — `CompareOutlookLayoutControls.svelte:154`
+
+## Existing Patterns
+
+- **Legende aus Backend-Katalog, nie zweitgetippt** — die Gefahren-Legende (#1318 AC-9)
+  zieht alle Kürzel aus `/api/sms-symbols`, ausdrücklich damit die Anzeige nicht von der
+  versendeten SMS abweichen kann. Genau das Muster fehlt hier für Metriken.
+- **Kein fünfter Vokabular-Ort** (`compare_metric_catalog.py:295-305`): zusätzliche
+  Namensformen reisen aus dem Register mit, statt im Browser neu getippt zu werden.
+- **Playwright-Tripel** aus S2/S3: `<name>.staging.setup.ts` + `.staging.spec.ts` +
+  `playwright.<name>.staging.config.ts` (Vorbild: `metrik-grundauswahl-schneidet-kanal.*`).
+
+## Existing Specs
+
+- `docs/adr/` ADR-0050 — Kaskade Grundauswahl/Kanal (S1)
+- `docs/specs/modules/fix_1453_namensformen.md` — AC-7, führte die heutigen Badges ein
+- `docs/specs/modules/fix_1719_s3_aus_ist_ein_zustand.md` — S3, gleicher Baustein
+- `docs/specs/modules/fix_1719_s2_kaskade_verfeinerung.md` — S2, Lesepfad-Schnitt
+
+## Dependencies
+
+- **Upstream:** `/api/metrics` und `/api/sms-symbols`; Katalog `metric_catalog.py`;
+  Kürzel-Tabellen in `sms_trip.py` / `narrow.py` / `comparison.py`
+- **Downstream:** vier Editor-Einbettungen; `weather_metric_name_forms_visible.test.ts`
+  (#1453 AC-7) prüft die **Anwesenheit** von `label`/`col_label`/`sms_code` im AST aller
+  vier Editoren — ein Ersetzen von `sms_code` bricht diesen Wächter
+
+## 🔴 PO-Entscheid 2026-08-12 (mitten in der Analyse): kein eigenes Telegram-Kürzel
+
+PO wörtlich: *„Warum gibt es ein extra Telegram Kürzel? Das will ich nicht!"*
+
+Damit dreht sich der Zuschnitt: **erst die Kürzelsysteme zusammenführen, dann erklären.**
+Eine Legende für drei Systeme zu bauen hieße, den Zustand zu dokumentieren, den wir
+gerade abschaffen.
+
+### Gemessener Ist-Stand (`scratchpad/tg_vs_sms.py`)
+
+| Verhältnis Telegram (`compact_label`) ↔ Register (`sms_code`) | Anzahl |
+|---|---|
+| identisch | 11 |
+| abweichend ohne fachlichen Grund | 11 |
+| SMS sendet mehrere Token, Telegram genau eines | 3 |
+
+Abweichend: Nacht-Tiefst `TN`/`N` · Gefühlte Nacht `TFN`/`FN` · Luftfeuchte `H`/`HU` ·
+Regenwahrsch. `P%`/`PR` · Schneefallgrenze `SG`/`SL` · Bewölkung `C`/`CT` · Sicht `V`/`VS` ·
+Sonnenstunden `☀`/`SU` · Luftdruck `P`/`HP` · Nullgradgrenze `0G`/`NL` · Neuschnee `NS`/`NS24+`
+
+Luftdruck (`P`) und Regenwahrscheinlichkeit (`P%`) unterscheiden sich in Telegram um ein
+Zeichen — im Register heißen sie `HP` und `PR`.
+
+### Die Systeme sind schon heute in derselben Nachricht gemischt
+
+`sms_trip.py:811` baut die Änderungs-Token der **SMS** über
+`get_compact_label_for_field()` — also aus `compact_label`. Eine SMS enthält damit
+Token aus beiden Systemen nebeneinander.
+
+### Abgeleitete Regel (Spec-Vorschlag)
+
+**Telegram übernimmt das Register-Kürzel — außer wo das Register-Kürzel eine
+Tagesauswertung bezeichnet statt der Größe.**
+
+- **12 Ersetzungen** (die 11 oben + Gewitter `⚡`→`TH`): das Register-Kürzel benennt dort
+  die Größe, nicht ihre Auswertung. Reine Vereinheitlichung.
+- **2 begründete Ausnahmen:** `temperature` (`T`, Register `D` = Tageshöchst, `K` =
+  Tagestiefst) und `wind_chill` (`TF`, Register-Trio `FK`/`FD`/`WC`). Die Telegram-Tabelle
+  zeigt je Zelle einen **Stundenwert** — ein Kürzel, das „Tageshöchst" bedeutet, wäre dort
+  eine falsche Aussage. Diese beiden behalten ihr Größen-Kürzel.
+
+### Wirkorte von `compact_label` (vollständig)
+
+| Ort | Wirkung |
+|---|---|
+| `narrow.py:148` | Spaltenköpfe der Telegram-Stundentabelle |
+| `narrow.py:119` | Detailzeile (laut #1741 ohne Aufrufstelle — toter Pfad) |
+| `narrow.py:493, 748, 757` | Kurzübersicht + Nacht-Zeile |
+| `sms_trip.py:811` via `metric_catalog.py:876` | Änderungs-Token der **SMS** |
+| `metric_format.py:199` | Style-Schalter `style="compact_label"` |
+
+Festgenagelt von 8 Testdateien (`test_issue_635_telegram_weather.py`,
+`test_issue_1001_telegram_bubbles.py`, `test_metric_catalog.py`, `test_channel_metric_matrix.py` u.a.) —
+alle müssen mitgezogen werden.
+
+## Risks & Considerations
+
+1. **Der bestehende Wächter prüft Anwesenheit, nicht Wahrheit.** `weather_metric_name_forms_visible.test.ts`
+   war beim Bau von #1453 grün und hat den falschen Kürzel-Wert nie sehen können — der
+   Test nimmt an, `sms_code` *sei* das SMS-Kürzel. Wird das Feld ausgetauscht, muss dieser
+   Test mitgezogen werden, sonst blockiert er den Fix.
+2. **Kontextabhängigkeit ist Pflicht, keine Kür.** Vergleich sendet `sms_code`, Trip sendet
+   aus `SMS_*_BY_METRIC`. Eine globale Korrektur macht den Vergleich falsch.
+3. **`compact_label` liegt nicht an `/api/metrics` an** — soll die Telegram-Familie
+   erscheinen, braucht der Endpoint ein zusätzliches Feld (additiv, unkritisch), und
+   `compare_metric_catalog.py` müsste es mitreisen lassen.
+4. **Geteilter Baustein, S3-Vorgeschichte.** In genau dieser Datei hat S3 die Ziehgeste
+   lautlos zerbrochen (neue Array-Referenz im Markup). Jede Änderung am Zeilen-Markup
+   braucht den Klickpfad-Nachweis, nicht nur Unit-Tests.
+5. **#1771: kein Playwright-Spec läuft in der CI-Ampel.** Der Klickpfad muss in diesem
+   Workflow von Hand gefahren werden; er bewacht danach nichts automatisch.
+6. **Premium-SMS** hat keinen eigenen Reiter (erbt SMS transitiv, ADR-0049) — die
+   SMS-Kürzel gelten dort mit.
+7. **Nicht-selektierbare Größen** (`cape` u.a., #1585) tauchen in alten Trip-Daten auf;
+   die Legende darf daran nicht scheitern.

--- a/docs/specs/modules/fix_1719_s4_kuerzel_vereinheitlichung.md
+++ b/docs/specs/modules/fix_1719_s4_kuerzel_vereinheitlichung.md
@@ -1,0 +1,235 @@
+---
+entity_id: fix_1719_s4_kuerzel_vereinheitlichung
+type: module
+created: 2026-08-12
+updated: 2026-08-12
+status: draft
+version: "1.0"
+tags: [backend, frontend, metrik-kaskade, kuerzel, telegram, sms, issue-1719]
+---
+
+# #1719 Scheibe S4 — Ein Kürzel je Größe: Telegram und SMS sprechen dieselbe Sprache, der Editor löst sie auf
+
+## Approval
+
+- [ ] Approved — PO, 2026-08-__ („go")
+
+## Purpose
+
+Heute trägt dieselbe Wettergröße bis zu drei verschiedene Kürzel, je nachdem wo sie
+erscheint. Der Nutzer, der in einer SMS `N13` liest, findet im Editor `TN` — und in einer
+Telegram-Tabelle `H`, wo die SMS `HU` schreibt. Diese Scheibe führt die Kürzel zusammen und
+macht sie im Editor auflösbar.
+
+**Zwei Schritte, in dieser Reihenfolge:** erst die Systeme vereinheitlichen, dann erklären.
+Eine Legende für drei Kürzelsysteme zu bauen hieße, einen Zustand zu dokumentieren, den
+diese Scheibe abschafft.
+
+## Source
+
+- Issue #1719, Scheibe S4 (letzte offene Scheibe)
+- **PO-Entscheid 2026-08-12** (mitten in der Analyse, wörtlich): *„Warum gibt es ein extra
+  Telegram Kürzel? Das will ich nicht!"*
+- **PO-Entscheid 2026-08-12** (Gestaltung, vor dem obigen): die Kürzel stehen als
+  beschriftete Marken in der Zeile der Größe, nicht als getrennter Legendenblock.
+- Kontext: `docs/context/feat-1719-s4-kuerzel-legende.md`
+- Vorgänger: ADR-0050 (Kaskade), `fix_1453_namensformen.md` (führte die heutigen Marken ein)
+
+## 🔴 Die Issue-Beschreibung von S4 ist überholt — hier steht der gemessene Stand
+
+Der Issue-Text sagt, das Backend liefere „keinen Klartext je Kürzel". Das trifft nicht zu:
+`/api/metrics` liefert `label`, `col_label` und `sms_code` (`api/routers/config.py:85-97`),
+und `WeatherV2Reihenfolge.svelte:97-113` zeigt seit #1453 bereits zwei Marken je Zeile.
+
+**Der wirkliche Defekt ist ein anderer.** Die Marke „Kürzel in der SMS" zeigt `sms_code` —
+das sind laut `api/routers/config.py:97` die **Alarm**-Stammdaten (#914). Die Trip-SMS
+rendert aus einer anderen Tabelle (`sms_trip.py:105-190`). Bei 5 von 25 Größen weicht das
+Angezeigte vom Gesendeten ab:
+
+| Größe | Editor zeigt | Trip-SMS sendet |
+|---|---|---|
+| Temperatur | `D` | `K` `D` |
+| **Nacht-Tiefsttemperatur** | `TN` | **`N`** |
+| Gefühlte Temperatur | `TF` | `FK` `FD` `WC` |
+| Gewitter | `TH` | `TH` `TH+` |
+| Neuschnee | `NS` | `NS24+` |
+
+Bei der Nachttemperatur nennt der Editor ein Kürzel, das in **keiner** SMS vorkommt, während
+das tatsächlich gesendete `N` nirgends erklärt wird.
+
+## Der Ist-Stand: vier Kürzel-Familien für dieselbe Sache
+
+| Ausgabeweg | Quelle | `wind_chill` | `humidity` |
+|---|---|---|---|
+| Mail-Stundentabelle (Trip + Vergleich) | `col_label` | `Feels` | `Humid` |
+| Telegram-Stundentabelle (nur Trip) | `compact_label` | `TF` | `H` |
+| Trip-SMS | `SMS_MULTI_SYMBOLS_BY_METRIC` → `SMS_SYMBOL_BY_METRIC` | `FK FD WC` | `HU` |
+| Vergleichs-SMS · Alarm-SMS | `sms_code` („Register-Kürzel") | `TF` | `HU` |
+
+`compact_label` und `sms_code` werden **getrennt von Hand gepflegt**. Gemessen
+(`scratchpad/tg_vs_sms.py`): 11 Größen identisch, 11 abweichend, 3 mit Mehrfach-Token.
+Niemand hält sie synchron, also sind sie auseinandergelaufen — Luftdruck heißt in Telegram
+`P`, Regenwahrscheinlichkeit `P%`; im Register `HP` und `PR`.
+
+**Beide Systeme stehen schon heute in derselben Nachricht:** `sms_trip.py:811` baut die
+Änderungs-Token der SMS über `get_compact_label_for_field()`, also aus `compact_label`.
+
+## Requirements
+
+### 1. Telegram übernimmt das Register-Kürzel
+
+**Regel:** Telegram nutzt das Register-Kürzel (`sms_code`) — **außer** wo das
+Register-Kürzel eine *Tagesauswertung* bezeichnet statt der *Größe*.
+
+**12 Ersetzungen** (Register-Kürzel benennt die Größe):
+
+| Größe | Telegram heute | künftig |
+|---|---|---|
+| Nacht-Tiefsttemperatur | `TN` | `N` |
+| Gefühlte Nacht-Tiefsttemperatur | `TFN` | `FN` |
+| Luftfeuchtigkeit | `H` | `HU` |
+| Regenwahrscheinlichkeit | `P%` | `PR` |
+| Schneefallgrenze | `SG` | `SL` |
+| Bewölkung | `C` | `CT` |
+| Sichtweite | `V` | `VS` |
+| Sonnenstunden | `☀` | `SU` |
+| Luftdruck | `P` | `HP` |
+| Nullgradgrenze | `0G` | `NL` |
+| Neuschnee | `NS` | `NS24+` |
+| Gewitter | `⚡` | `TH` |
+
+**2 benannte Ausnahmen** (Register-Kürzel bezeichnet eine Tagesauswertung):
+
+| Größe | bleibt | Grund |
+|---|---|---|
+| Temperatur | `T` | Register führt `D` (Tageshöchst) und `K` (Tagestiefst). Die Telegram-Zelle zeigt einen **Stundenwert** — ein Spaltenkopf „Tageshöchst" wäre dort eine falsche Aussage |
+| Gefühlte Temperatur | `TF` | dito, Register-Trio `FK`/`FD`/`WC` |
+
+> **PO-Entscheidungspunkt A:** Gewitter und Sonnenstunden tragen in Telegram heute ein
+> Symbol (`⚡`, `☀`) statt Buchstaben. Oben sind sie als Ersetzung eingeplant (`TH`, `SU`),
+> weil „ein Kürzel je Größe" sonst nicht gilt. Sollen die beiden Symbole stattdessen
+> bleiben, ist das eine Zeile in der Ausnahmeliste — bitte bei der Freigabe sagen.
+
+### 2. `compact_label` kann nicht mehr wegdriften
+
+Das Feld bleibt bestehen (fünf Wirkorte, acht Testdateien lesen es), wird aber **abgeleitet
+statt zweitgepflegt**: Vorgabe ist das Register-Kürzel; abweichen darf nur, was in einer
+benannten Ausnahmeliste mit Begründung steht (Muster: `_SMS_SYMBOL_GRAMMAR` in
+`sms_trip.py:114`).
+
+Ohne diesen Schritt wiederholt sich der Defekt beim nächsten Katalog-Eintrag — genau so ist
+er entstanden.
+
+### 3. Der Editor zeigt zwei Familien, beide wahr
+
+Je Zeile im Bereich „Reihenfolge" stehen beschriftete Marken:
+
+- **Mail** — `col_label` (die breite Tabelle hat Platz für `Feels`, `Dew`)
+- **Kurzform** — was SMS und Telegram senden, **alle** Kürzel der Größe
+
+```
+1. ⠿ Gefühlte Temperatur  °C    Mail Feels   Kurzform FK FD WC    [Roh|Einfach] [Aus]
+2. ⠿ Nacht-Tiefsttemperatur °C  Mail Nacht   Kurzform N           [Roh|Einfach] [Aus]
+```
+
+**Die Quelle richtet sich nach der Fläche** — der Touren-Editor zeigt die Trip-SMS-Kürzel
+(`/api/sms-symbols`, deckt Mehrfach-Token und Grammatik ab), die drei Vergleichs-Editoren
+das Register-Kürzel, weil die Vergleichs-SMS aus `get_sms_code()` rendert
+(`comparison.py:625`). Eine flächenblinde Korrektur würde den Vergleich falsch machen.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine Telegram-Nachricht eines Trips mit den Größen Luftfeuchtigkeit,
+  Bewölkung, Sichtweite, Luftdruck und Nullgradgrenze / When das Briefing gerendert wird /
+  Then tragen die Spaltenköpfe der Stundentabelle `HU`, `CT`, `VS`, `HP`, `NL` — also
+  dieselben Kürzel, die die SMS für diese Größen sendet.
+  - Test: Kern-Test gegen `render_telegram_bubbles()` mit echter Fixture; Kopfzeile
+    gegen `SMS_SYMBOL_BY_METRIC` gerechnet, nicht abgetippt.
+
+- **AC-2:** Given der vollständige Metrik-Katalog / When Telegram-Kürzel und
+  Register-Kürzel jeder Größe verglichen werden / Then sind sie identisch, außer für die
+  Größen der benannten Ausnahmeliste, und jede Ausnahme trägt eine Begründung.
+  - Test: Wächter über `get_all_metrics()`; ein neuer Katalog-Eintrag mit abweichendem
+    `compact_label` und ohne Ausnahme-Eintrag macht ihn rot.
+
+- **AC-3:** Given die Größen Temperatur und Gefühlte Temperatur / When die
+  Telegram-Stundentabelle gerendert wird / Then stehen dort weiterhin `T` und `TF` — nicht
+  `D`/`K` bzw. `FK`/`FD`/`WC`, weil die Zelle einen Stundenwert zeigt und keine
+  Tagesauswertung.
+  - Test: Kern-Test auf die Spaltenköpfe; Gegenprobe, dass die Ausnahme in der Liste steht.
+
+- **AC-4:** Given ein Trip, dessen SMS ein Änderungs-Token enthält (z.B. Luftfeuchtigkeit
+  steigt) / When die SMS gerendert wird / Then trägt das Änderungs-Token dasselbe Kürzel
+  wie derselbe Wert an anderer Stelle derselben Nachricht — kein Token aus dem alten
+  Telegram-System.
+  - Test: Kern-Test gegen `format_sms_trip()` mit Änderungsdaten; Token-Kürzel gegen das
+    Register gerechnet.
+
+- **AC-5:** Given der Touren-Editor mit geöffnetem Reiter „Wetter-Metriken" / When der
+  Nutzer den Bereich „Reihenfolge" ansieht / Then trägt jede Zeile zwei beschriftete
+  Marken — „Mail" mit der englischen Fachkurzform und „Kurzform" mit **allen** Kürzeln,
+  die SMS und Telegram für diese Größe senden.
+  - Test: Playwright-Klickpfad gegen Staging; für „Gefühlte Temperatur" enthält die
+    Kurzform-Marke `FK`, `FD` **und** `WC`, für „Nacht-Tiefsttemperatur" genau `N`.
+
+- **AC-6:** Given der Touren-Editor / When eine Größe mit mehreren SMS-Kürzeln angezeigt
+  wird / Then erscheinen alle ihre Kürzel, nicht nur das erste.
+  - Test: derselbe Klickpfad; zusätzlich Kern-Wächter, der die angezeigte Kürzelmenge je
+    Größe gegen `/api/sms-symbols` prüft — die Anzeige darf keine eigene Liste führen.
+
+- **AC-7:** Given die drei Vergleichs-Editoren (Übersicht, Stundenverlauf, Ausblick) /
+  When der Bereich „Reihenfolge" angezeigt wird / Then tragen die Zeilen ebenfalls beide
+  Marken, und die Kurzform-Marke zeigt das Register-Kürzel — das, was die Vergleichs-SMS
+  tatsächlich sendet.
+  - Test: Playwright-Klickpfad gegen Staging für mindestens eine der drei Flächen;
+    Kern-Wächter (AST) für alle drei, Muster `weather_metric_name_forms_visible.test.ts`.
+
+- **AC-8:** Given der bestehende Wächter `weather_metric_name_forms_visible.test.ts`
+  (#1453 AC-7) / When die Marken auf die neue Quelle umgestellt sind / Then ist er grün und
+  prüft weiterhin, dass alle vier Editoren die Namensformen tragen.
+  - Test: der Wächter selbst, mit an die neue Quelle angepasster Erwartung. Er prüft heute
+    **Anwesenheit**, nicht Richtigkeit — genau deshalb blieb der falsche Wert unbemerkt.
+
+- **AC-9:** Given eine Größe ohne SMS-Kürzel / When ihre Zeile angezeigt wird / Then
+  erscheint keine leere oder erfundene Kurzform-Marke, sondern gar keine.
+  - Test: Kern-Wächter mit einer Größe ohne Registereintrag.
+
+## Non-Goals (bewusst nicht in dieser Scheibe)
+
+- **Die Mail-Kurzformen bleiben** (`Feels`, `Dew`, `Gust`). Sie stehen in einer breiten
+  Tabelle mit Platz für lesbare Fachkurzformen; der PO-Entscheid betraf ausdrücklich das
+  „extra Telegram Kürzel". Angenommen, nicht erfragt — Widerspruch bei der Freigabe genügt.
+- **Kein Umbau der Trip-SMS-Mehrfachkürzel.** Dass die SMS Tagestiefst und -höchst trennt
+  (`K`/`D`), ist gewollt und bleibt.
+- **Kein Alarm-Kürzel-Ausweis** im Editor. Alarme nutzen `sms_code` und sind nach dieser
+  Scheibe deckungsgleich mit der Kurzform — ein eigener Ausweis wäre Rauschen.
+- **Kein Aufräumen des toten Codes** um `narrow.py:119` (`_detail_lines`, ohne Aufrufstelle,
+  #1741).
+
+## Risks
+
+1. **Nutzersichtbare Änderung an jeder Telegram-Nachricht.** Zwölf Spaltenköpfe heißen
+   anders. Das ist der Zweck, muss aber im Issue-Abschluss klar benannt werden.
+2. **Acht Testdateien nageln `compact_label` fest** — u.a.
+   `test_issue_635_telegram_weather.py`, `test_issue_1001_telegram_bubbles.py`,
+   `test_channel_metric_matrix.py`. Erwartungswerte mitziehen, **keine Assertion
+   entschärfen**: wo ein Test einen Spaltenkopf prüft, bekommt er den neuen Wert, nicht
+   eine gelockerte Prüfung.
+3. **Geteilter Baustein mit S3-Vorgeschichte.** In `WeatherV2Reihenfolge.svelte` hat S3 die
+   Ziehgeste lautlos zerbrochen (neue Array-Referenz im Markup). Jede Änderung am
+   Zeilen-Markup braucht den Klickpfad-Nachweis, dass Ziehen weiter funktioniert.
+4. **#1771: kein Playwright-Spec läuft in der CI-Ampel.** Die Klickpfade dieser Scheibe
+   müssen im Workflow von Hand gefahren werden und bewachen danach nichts automatisch.
+5. **Telegram-Spaltenbreite.** Die Tabelle ist auf schmale Köpfe ausgelegt; `NS24+` ist
+   fünf Zeichen. Die Breitenrechnung (`narrow.py:157-160`) passt sich an — zu prüfen ist,
+   ob die Zeile dadurch umbricht.
+
+## Implementation Details
+
+- Kürzel-Vorgabe und Ausnahmeliste gehören in `metric_catalog.py` neben die
+  `MetricDefinition` — eine Quelle, nicht zwei.
+- Das Frontend führt **keine** eigene Kürzel-Liste; die Kurzform-Marke speist sich aus
+  `/api/sms-symbols` (Touren) bzw. dem bereits gelieferten `sms_code` (Vergleich).
+  `/api/metrics` braucht dafür **kein** neues Feld.
+- Playwright folgt dem S2/S3-Tripel: `<name>.staging.setup.ts` + `.staging.spec.ts` +
+  `playwright.<name>.staging.config.ts`.

--- a/docs/specs/modules/fix_1719_s4_kuerzel_vereinheitlichung.md
+++ b/docs/specs/modules/fix_1719_s4_kuerzel_vereinheitlichung.md
@@ -137,6 +137,75 @@ Je Zeile im Bereich „Reihenfolge" stehen beschriftete Marken:
 das Register-Kürzel, weil die Vergleichs-SMS aus `get_sms_code()` rendert
 (`comparison.py:625`). Eine flächenblinde Korrektur würde den Vergleich falsch machen.
 
+### 4. Die Marken bleiben in jeder Fenstergröße vollständig lesbar
+
+**PO-Vorgabe 2026-08-12:** *„Stelle per Browser Tests sicher, dass alle Zeichen der Legende
+in unterschiedlichen Browserauflösungen sichtbar bleiben. Aktuell ist es etwas Glückssache."*
+
+#### Gemessene Ursache
+
+```css
+.label-cell { display: flex; min-width: 0; }      /* darf unter Inhaltsbreite schrumpfen */
+.metric-label { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.col-badge { /* kein flex-shrink, kein white-space */ }
+.sms-badge { white-space: nowrap; /* kein flex-shrink */ }
+
+@media (max-width: 899px) {
+  .label-cell { flex-wrap: wrap; }                /* unter 900px: Marken brechen um */
+  .metric-label { white-space: normal; }
+}
+```
+
+Die Zeile ist ein Grid `28px 16px 1fr auto`; die Marken sitzen in der `1fr`-Zelle mit
+`min-width: 0`. **Unter 900 px** rettet der Umbruch alles. **Ab 900 px** gibt es keinen
+Umbruch, und weil den Marken `flex-shrink: 0` fehlt, werden sie zusammengedrückt und ihr
+Inhalt beschnitten. Die Bruchzone ist damit **900 px bis ~1300 px**.
+
+Der e2e-Bestand prüft 1280 px (53 Vorkommen) und 390 px (20 Vorkommen) — beide **außerhalb**
+der Bruchzone; 850 px liegt im sicheren Umbruch-Modus. Die vorhandenen Testbreiten umgehen
+den Defekt systematisch, deshalb ist er nie aufgefallen.
+
+**S4 verschärft ihn**, weil die Kurzform-Marke künftig `FK FD WC` statt `TF` trägt.
+
+#### Anforderung
+
+Die Marken sind **unverkürzbar**: Bei Platzmangel kürzt der Name (er ist im Klartext
+daneben ohnehin lesbar), nie ein Kürzel. Reicht der Platz auch dann nicht, bricht die Zelle
+um — in jeder Fensterbreite, nicht erst unter 900 px.
+
+#### „Sichtbar" heißt geometrisch gemessen, nicht „im DOM"
+
+Genau diese Verwechslung machte den Wächter aus #1453 blind. Jede Marke muss in **jeder**
+geprüften Auflösung alle fünf Bedingungen erfüllen:
+
+| # | Bedingung | Messung |
+|---|---|---|
+| 1 | Text nicht beschnitten | `el.scrollWidth <= el.clientWidth + 1` |
+| 2 | vollständig innerhalb ihrer Zeile | `boundingBox` der Marke liegt in dem der `.row` |
+| 3 | vollständig im Sichtfenster | `x >= 0` und `x + width <= viewport.width` |
+| 4 | nicht von einem Nachbarelement überdeckt | `document.elementFromPoint(mitte)` liefert die Marke oder einen Nachfahren |
+| 5 | Textinhalt exakt, kein Auslassungszeichen | gerenderter Text `=== ` erwartetes Kürzel, enthält kein `…` |
+
+Zusätzlich je Auflösung: die Seite scrollt nicht horizontal
+(`documentElement.scrollWidth <= window.innerWidth + 1`).
+
+#### Auflösungsmatrix (verbindlich)
+
+Vierzehn Breiten, mit Schwerpunkt auf der Bruchzone und beiden Rändern der Media-Query:
+
+| Klasse | Auflösungen |
+|---|---|
+| Kleine Handys | 320×568 · 375×667 |
+| Handys | 390×844 · 414×896 |
+| Schmales Fenster / geteilter Bildschirm | 600×900 · 768×1024 |
+| **Media-Query-Ränder** | **899×900 · 901×900** |
+| **Bruchzone** | **960×900 · 1024×768 · 1180×820** |
+| Desktop | 1280×900 · 1440×900 · 1920×1080 |
+
+Geprüft wird gegen den **Worst Case**, nicht gegen eine bequeme Auswahl: „Gefühlte
+Nacht-Tiefsttemperatur" (31 Zeichen, längster Name im Katalog) und „Gefühlte Temperatur"
+(längste Kurzform `FK FD WC`) müssen beide in der Liste stehen.
+
 ## Acceptance Criteria
 
 - **AC-1:** Given eine Telegram-Nachricht eines Trips mit den Größen Luftfeuchtigkeit,
@@ -194,6 +263,36 @@ das Register-Kürzel, weil die Vergleichs-SMS aus `get_sms_code()` rendert
   erscheint keine leere oder erfundene Kurzform-Marke, sondern gar keine.
   - Test: Kern-Wächter mit einer Größe ohne Registereintrag.
 
+- **AC-10:** Given der Touren-Editor mit einer Metrik-Liste, die „Gefühlte
+  Nacht-Tiefsttemperatur" und „Gefühlte Temperatur" enthält / When der Bereich
+  „Reihenfolge" in **jeder** der vierzehn Auflösungen der Matrix geladen wird / Then
+  erfüllt **jede** Marke **jeder** sichtbaren Zeile alle fünf Sichtbarkeits-Bedingungen.
+  - Test: Playwright-Klickpfad gegen Staging, über die Auflösungsliste iterierend, über
+    alle Zeilen iterierend — keine Stichprobe. Fehlermeldung nennt Auflösung, Größe,
+    Marke und die verletzte Bedingung.
+
+- **AC-11:** Given eine der vierzehn Auflösungen / When der Bereich „Reihenfolge"
+  angezeigt wird / Then scrollt die Seite nicht horizontal.
+  - Test: derselbe Lauf; `documentElement.scrollWidth <= window.innerWidth + 1`.
+
+- **AC-12:** Given eine Fensterbreite in der Bruchzone (900–1300 px) und eine Zeile, deren
+  Name und Marken zusammen breiter sind als die Zelle / When die Zeile gerendert wird /
+  Then wird **der Name** gekürzt oder die Zelle bricht um — **nie** eine Marke.
+  - Test: gezielt bei 960 px und 1024 px; die Marke trägt ihren vollen Text
+    (Bedingung 1 und 5), während der Name gekürzt sein **darf**.
+  - Gegenprobe (Pflicht): Entfernt man die Unverkürzbarkeit der Marken aus dem CSS, muss
+    dieser Test rot werden. Wird er es nicht, bewacht er nichts.
+
+- **AC-13:** Given der Reihenfolge-Bereich einer der drei Vergleichs-Flächen / When er in
+  den vierzehn Auflösungen geladen wird / Then gelten AC-10 und AC-11 dort ebenso.
+  - Test: derselbe Klickpfad gegen mindestens eine Vergleichs-Fläche.
+
+- **AC-14:** Given die Ziehgeste im Reihenfolge-Bereich / When nach den Layout-Änderungen
+  eine Zeile per Drag umsortiert wird / Then landet sie an der Zielposition und der Stand
+  wird gespeichert.
+  - Test: Playwright; **Pflicht**, weil S3 in genau dieser Datei die Ziehgeste lautlos
+    zerbrochen hat und 2553 Unit-Tests das nicht gesehen haben.
+
 ## Non-Goals (bewusst nicht in dieser Scheibe)
 
 - **Die Mail-Kurzformen bleiben** (`Feels`, `Dew`, `Gust`). Sie stehen in einer breiten
@@ -223,6 +322,15 @@ das Register-Kürzel, weil die Vergleichs-SMS aus `get_sms_code()` rendert
 5. **Telegram-Spaltenbreite.** Die Tabelle ist auf schmale Köpfe ausgelegt; `NS24+` ist
    fünf Zeichen. Die Breitenrechnung (`narrow.py:157-160`) passt sich an — zu prüfen ist,
    ob die Zeile dadurch umbricht.
+6. **Das Layout-Problem ist vorbestehend, nicht von S4 verursacht** — S4 verschärft es nur.
+   Die Reparatur (Abschnitt 4) ist damit Teil dieser Scheibe, nicht ein Nebenbefund: eine
+   Legende, deren Zeichen bei manchen Fensterbreiten fehlen, erfüllt ihren Zweck nicht.
+7. **Vierzehn Auflösungen × zwei Flächen sind ~28 Browserläufe.** Das kostet Laufzeit im
+   Klickpfad-Bündel. Bewusst in Kauf genommen: die bisherigen zwei Standardbreiten haben
+   die Bruchzone nachweislich verfehlt.
+8. **Die Prüfung testet Geometrie, keine Ästhetik.** Ob eine umgebrochene Zeile *gut
+   aussieht*, entscheidet der PO am Bildschirm — der `fresh-eyes-inspector` bewertet
+   Screenshots aus der Bruchzone ohne Bug-Kontext.
 
 ## Implementation Details
 

--- a/docs/specs/modules/fix_1719_s4_kuerzel_vereinheitlichung.md
+++ b/docs/specs/modules/fix_1719_s4_kuerzel_vereinheitlichung.md
@@ -12,7 +12,10 @@ tags: [backend, frontend, metrik-kaskade, kuerzel, telegram, sms, issue-1719]
 
 ## Approval
 
-- [ ] Approved — PO, 2026-08-__ („go")
+- [x] Approved — PO, 2026-08-12 („go"), ohne Einschränkung. Damit entschieden:
+  **Entscheidungspunkt A** — `⚡` und `☀` werden durch `TH` und `SU` ersetzt (keine
+  Symbol-Ausnahme); **Mail-Kürzel** (`Feels`, `Dew`, `Gust`) bleiben unangetastet;
+  die Auflösungsmatrix aus Abschnitt 4 gilt verbindlich.
 
 ## Purpose
 

--- a/frontend/e2e/kuerzel-marken-sichtbar.staging.setup.ts
+++ b/frontend/e2e/kuerzel-marken-sichtbar.staging.setup.ts
@@ -1,0 +1,34 @@
+import { test as setup, expect } from '@playwright/test';
+import { assertNotProdBaseURL } from './prodUrlGuard';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+// Staging-Auth fuer Issue #1719 Scheibe S4 (Kuerzel-Marken im Bereich
+// "Reihenfolge"). Wie metrik-grundauswahl-schneidet-kanal.staging.setup.ts:
+// nginx-Basic-Auth (GZ_VALIDATOR_*) und App-Login (GZ_AUTH_*) sind ZWEI
+// getrennte Credential-Paare, und die Staging-Instanz hat ein eigenes
+// App-Passwort (s. CLAUDE.md, "Zugangsdaten: DREI Quellen"). Ein storageState
+// statt Login je Test — sonst erschoepfen 14 Aufloesungen x 2 Flaechen das
+// Staging-Login-Rate-Limit (#703).
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const authFile = path.join(__dirname, 'playwright', '.auth', 'staging-1719-s4.json');
+
+setup('authenticate via API (staging) — issue_1719_s4_kuerzel_marken', async ({ playwright }) => {
+	const base = process.env.GZ_SVELTE_BASE ?? 'https://staging.gregor20.henemm.com';
+	assertNotProdBaseURL(base);
+	const nginxUser = process.env.GZ_VALIDATOR_USER ?? 'admin';
+	const nginxPass = process.env.GZ_VALIDATOR_PASS ?? 'test1234';
+	const appUser = process.env.GZ_AUTH_USER ?? process.env.E2E_USER ?? 'admin';
+	const appPass = process.env.GZ_AUTH_PASS ?? process.env.E2E_PASS ?? 'test1234';
+
+	const ctx = await playwright.request.newContext({
+		baseURL: base,
+		ignoreHTTPSErrors: true,
+		httpCredentials: { username: nginxUser, password: nginxPass }
+	});
+	const res = await ctx.post('/api/auth/login', {
+		data: { username: appUser, password: appPass }
+	});
+	expect(res.ok(), `login HTTP ${res.status()}`).toBeTruthy();
+	await ctx.storageState({ path: authFile });
+	await ctx.dispose();
+});

--- a/frontend/e2e/kuerzel-marken-sichtbar.staging.spec.ts
+++ b/frontend/e2e/kuerzel-marken-sichtbar.staging.spec.ts
@@ -507,9 +507,11 @@ test.describe('Issue #1719 S4: die Kuerzel-Marken sind lesbar, in jeder Fensterb
 	// ── AC-12 ───────────────────────────────────────────────────────────────
 	//
 	// Gegenprobe (Spec, Pflicht): nimmt man den Marken die Unverkuerzbarkeit
-	// wieder weg (`flex-shrink: 0` aus `.col-badge`/`.sms-badge` in
-	// WeatherV2Reihenfolge.svelte entfernen, bzw. den Umbruch auf `max-width:
-	// 899px` zurueckstellen), MUSS dieser Test rot werden. Wird er es nicht,
+	// wieder weg (`flex-shrink: 0` aus `.col-badge`/`.kurzform-badge` in
+	// WeatherV2Reihenfolge.svelte entfernen — ODER dort `min-width: 0` bei
+	// `.metric-label` streichen, das war der gemessene Auesloeser: ohne ihn
+	// kann der NAME nicht schrumpfen und die Zelle holt sich den Platz bei den
+	// Marken), MUSS dieser Test rot werden. Wird er es nicht,
 	// bewacht er nichts. Die Gegenprobe laeuft an einem eigenen Staging-Stand;
 	// dieser Test ist so gebaut, dass sie moeglich ist: er misst genau die
 	// beiden Bedingungen, die eine schrumpfende Marke verletzt (1 und 5), und

--- a/frontend/e2e/kuerzel-marken-sichtbar.staging.spec.ts
+++ b/frontend/e2e/kuerzel-marken-sichtbar.staging.spec.ts
@@ -1,0 +1,706 @@
+// E2E (Staging) — Issue #1719 Scheibe S4: die Kuerzel-Marken im Bereich
+// "Reihenfolge" bleiben in JEDER Fensterbreite vollstaendig lesbar.
+//
+// Spec: docs/specs/modules/fix_1719_s4_kuerzel_vereinheitlichung.md
+//   AC-5  zwei beschriftete Marken je Zeile, Kurzform mit ALLEN Kuerzeln
+//   AC-10 fuenf Sichtbarkeits-Bedingungen, 14 Aufloesungen, ALLE Zeilen
+//   AC-11 keine horizontale Seitenscroll-Leiste
+//   AC-12 bei Platzmangel kuerzt der NAME, nie eine Marke
+//   AC-13 dieselbe Zusicherung im Vergleichs-Editor
+//   AC-14 die Ziehgeste ueberlebt die Layout-Aenderung
+//
+// PO-Vorgabe 2026-08-12 woertlich: "Stelle per Browser Tests sicher, dass alle
+// Zeichen der Legende in unterschiedlichen Browserauflösungen sichtbar bleiben.
+// Aktuell ist es etwas Glückssache."
+//
+// GEMESSENE URSACHE (Spec Abschnitt 4): `.label-cell` hat `min-width: 0` und
+// darf unter die Inhaltsbreite schrumpfen; den Marken fehlt `flex-shrink: 0`.
+// UNTER 900px rettet `flex-wrap: wrap` alles, AB 900px gibt es keinen Umbruch —
+// die Bruchzone ist 900..~1300px. Der e2e-Bestand prueft 1280px und 390px,
+// beide AUSSERHALB der Bruchzone. Die vorhandenen Testbreiten umgehen den
+// Defekt systematisch, deshalb ist er nie aufgefallen.
+//
+// "Sichtbar" heisst hier GEOMETRISCH GEMESSEN, nicht "im DOM" — genau diese
+// Verwechslung machte den Waechter aus #1453 blind.
+//
+// SCHREIBT NUR — laeuft in der RED-Phase NICHT (Staging traegt den alten
+// Stand). Der Lauf gehoert in die GREEN-/Verifikationsphase.
+//
+// Ausfuehren (gegen Staging, aus frontend/, NACH Deploy):
+//   set -a; source /home/hem/gregor_zwanzig/.claude/validator.env; set +a
+//   npx playwright test --config=e2e/playwright.kuerzel-marken-sichtbar.staging.config.ts
+
+import {
+	test,
+	expect,
+	type APIRequestContext,
+	type Locator,
+	type Page
+} from '@playwright/test';
+import { createTestLocation } from './helpers';
+
+const TRIP_ID = 'e2e-1719-s4-kuerzel';
+
+/** Testids der beiden Marken. Gleichlautend im AST-Waechter
+ *  src/lib/components/shared/__tests__/weather_metric_kuerzel_marken.test.ts. */
+const MAIL_BADGE = '[data-testid="wm2-mail-badge"]';
+const KURZFORM_BADGE = '[data-testid="wm2-kurzform-badge"]';
+
+/** Sichtbare Beschriftung der Marken — beim Textvergleich abzuziehen. */
+const BESCHRIFTUNGEN = ['Mail', 'Kurzform'];
+
+/** Auflösungsmatrix aus der Spec, Abschnitt 4 — VERBINDLICH, keine Auswahl.
+ *  Schwerpunkt auf der Bruchzone und beiden Raendern der Media-Query. */
+const AUFLOESUNGEN = [
+	{ klasse: 'Kleines Handy', width: 320, height: 568 },
+	{ klasse: 'Kleines Handy', width: 375, height: 667 },
+	{ klasse: 'Handy', width: 390, height: 844 },
+	{ klasse: 'Handy', width: 414, height: 896 },
+	{ klasse: 'Schmales Fenster', width: 600, height: 900 },
+	{ klasse: 'Geteilter Bildschirm', width: 768, height: 1024 },
+	{ klasse: 'Media-Query-Rand (unten)', width: 899, height: 900 },
+	{ klasse: 'Media-Query-Rand (oben)', width: 901, height: 900 },
+	{ klasse: 'Bruchzone', width: 960, height: 900 },
+	{ klasse: 'Bruchzone', width: 1024, height: 768 },
+	{ klasse: 'Bruchzone', width: 1180, height: 820 },
+	{ klasse: 'Desktop', width: 1280, height: 900 },
+	{ klasse: 'Desktop', width: 1440, height: 900 },
+	{ klasse: 'Desktop', width: 1920, height: 1080 }
+] as const;
+
+/** Der Worst Case steht in der Liste, nicht eine bequeme Auswahl (Spec
+ *  Abschnitt 4): "Gefuehlte Nacht-Tiefsttemperatur" ist mit 31 Zeichen der
+ *  laengste Name im Katalog, "Gefuehlte Temperatur" traegt mit `FK FD WC` die
+ *  laengste Kurzform. */
+const TRIP_METRIKEN = [
+	'wind_chill_night',
+	'wind_chill',
+	'temperature_night',
+	'thunder',
+	'humidity',
+	'freezing_level'
+];
+
+const REPORT_CONFIG = {
+	enabled: true,
+	morning_enabled: true,
+	evening_enabled: true,
+	morning_time: '07:00:00',
+	evening_time: '18:00:00',
+	send_email: true,
+	send_telegram: false,
+	send_sms: false,
+	multi_day_trend_morning: false,
+	multi_day_trend_evening: true,
+	multi_day_trend_reports: ['evening'],
+	show_compact_summary: true,
+	show_daylight: true,
+	wind_exposition_min_elevation_m: null,
+	show_stage_stats: true,
+	show_quick_take_tags: true,
+	show_stability: true,
+	show_highlights: true,
+	daily_summary_metrics: ['precipitation', 'wind', 'visibility', 'thunder'],
+	show_metrics_summary: false,
+	show_outlook: true,
+	email_format: 'full',
+	show_yesterday_comparison: true
+};
+
+const aufgeraeumt: { presets: string[]; orte: string[] } = { presets: [], orte: [] };
+
+async function createTrip(request: APIRequestContext) {
+	await request.delete(`/api/trips/${TRIP_ID}`).catch(() => {});
+	const res = await request.post('/api/trips', {
+		data: {
+			id: TRIP_ID,
+			name: 'E2E #1719 S4 Kuerzel-Marken',
+			report_config: REPORT_CONFIG,
+			display_config: {
+				metrics: TRIP_METRIKEN.map((metric_id, order) => ({
+					metric_id,
+					enabled: true,
+					bucket: 'primary',
+					order
+				}))
+			},
+			stages: [
+				{
+					id: `${TRIP_ID}-stage-1`,
+					name: 'Etappe 1',
+					date: new Date().toISOString().slice(0, 10),
+					waypoints: [
+						{ id: `${TRIP_ID}-wp-1`, name: 'Start', lat: 46.5, lon: 8.1, elevation_m: 1800 },
+						{ id: `${TRIP_ID}-wp-2`, name: 'Ziel', lat: 46.6, lon: 8.2, elevation_m: 2400 }
+					]
+				}
+			]
+		}
+	});
+	expect(res.ok(), `Trip-Anlage fehlgeschlagen: HTTP ${res.status()}`).toBeTruthy();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Erwartungswerte kommen aus dem BACKEND, nicht aus dieser Datei
+//
+// AC-6: "die Anzeige darf keine eigene Liste fuehren". Genau deshalb rechnet
+// dieser Test die Erwartung aus derselben Quelle aus, aus der die Oberflaeche
+// sie beziehen soll — waeren die Kuerzel hier abgetippt, koennten Anzeige und
+// zugestellte Nachricht gemeinsam falsch und der Test trotzdem gruen sein.
+// ═══════════════════════════════════════════════════════════════════════════
+
+async function kurzformAusBackend(request: APIRequestContext): Promise<Record<string, string[]>> {
+	const res = await request.get('/api/sms-symbols');
+	expect(res.ok(), `/api/sms-symbols HTTP ${res.status()}`).toBeTruthy();
+	const body = (await res.json()) as { metrics: { metric_id: string; sms_symbols: string[] }[] };
+	return Object.fromEntries(body.metrics.map((m) => [m.metric_id, m.sms_symbols]));
+}
+
+async function mailKurzformAusBackend(request: APIRequestContext): Promise<Record<string, string>> {
+	const res = await request.get('/api/metrics');
+	expect(res.ok(), `/api/metrics HTTP ${res.status()}`).toBeTruthy();
+	const body = (await res.json()) as Record<string, { id: string; col_label: string }[]>;
+	const map: Record<string, string> = {};
+	for (const gruppe of Object.values(body)) for (const m of gruppe) map[m.id] = m.col_label;
+	return map;
+}
+
+async function compareKurzformAusBackend(
+	request: APIRequestContext
+): Promise<{ kurz: Record<string, string>; mail: Record<string, string> }> {
+	const res = await request.get('/api/compare/metrics');
+	expect(res.ok(), `/api/compare/metrics HTTP ${res.status()}`).toBeTruthy();
+	const body = (await res.json()) as
+		| { metric: string; sms_code: string; col_label: string }[]
+		| { metrics: { metric: string; sms_code: string; col_label: string }[] };
+	const liste = Array.isArray(body) ? body : body.metrics;
+	const kurz: Record<string, string> = {};
+	const mail: Record<string, string> = {};
+	for (const e of liste) {
+		kurz[e.metric] = e.sms_code;
+		mail[e.metric] = e.col_label;
+	}
+	return { kurz, mail };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Die Messung: fuenf Bedingungen je Marke (Spec Abschnitt 4)
+// ═══════════════════════════════════════════════════════════════════════════
+
+type Befund = {
+	groesse: string;
+	marke: string;
+	text: string;
+	verletzt: string[];
+};
+
+/** Misst BEIDE Marken einer Zeile im echten Layout. Laeuft im Browser, weil
+ *  nur dort `getBoundingClientRect`, `scrollWidth` und `elementFromPoint` die
+ *  tatsaechliche Darstellung kennen. */
+async function messeZeile(zeile: Locator): Promise<Befund[]> {
+	await zeile.scrollIntoViewIfNeeded();
+	return zeile.evaluate((row, { mailSel, kurzSel }) => {
+		const befunde: {
+			groesse: string;
+			marke: string;
+			text: string;
+			verletzt: string[];
+		}[] = [];
+		const zeilenRect = row.getBoundingClientRect();
+		const groesse = row.getAttribute('data-metric-id') ?? '(ohne data-metric-id)';
+		const vw = window.innerWidth;
+
+		for (const [name, sel] of [
+			['Mail', mailSel],
+			['Kurzform', kurzSel]
+		] as const) {
+			const marken = Array.from(row.querySelectorAll(sel)) as HTMLElement[];
+			if (marken.length === 0) {
+				befunde.push({
+					groesse,
+					marke: name,
+					text: '',
+					verletzt: [`0 Marke "${name}" fehlt in dieser Zeile (Selektor ${sel})`]
+				});
+				continue;
+			}
+			for (const el of marken) {
+				const r = el.getBoundingClientRect();
+				const text = (el.textContent ?? '').replace(/\s+/g, ' ').trim();
+				const verletzt: string[] = [];
+
+				if (r.width === 0 || r.height === 0) {
+					verletzt.push(
+						`0 Marke hat keine Ausdehnung (${r.width}x${r.height}) — sie ist ` +
+							`ausgeblendet statt umgebrochen`
+					);
+				}
+				// 1: Text nicht beschnitten
+				if (el.scrollWidth > el.clientWidth + 1) {
+					verletzt.push(
+						`1 Text beschnitten: scrollWidth ${el.scrollWidth} > clientWidth ${el.clientWidth}`
+					);
+				}
+				// 2: vollstaendig innerhalb ihrer Zeile
+				if (
+					r.left < zeilenRect.left - 1 ||
+					r.right > zeilenRect.right + 1 ||
+					r.top < zeilenRect.top - 1 ||
+					r.bottom > zeilenRect.bottom + 1
+				) {
+					verletzt.push(
+						`2 ragt aus der Zeile: Marke [${Math.round(r.left)},${Math.round(r.right)}]x` +
+							`[${Math.round(r.top)},${Math.round(r.bottom)}], Zeile ` +
+							`[${Math.round(zeilenRect.left)},${Math.round(zeilenRect.right)}]x` +
+							`[${Math.round(zeilenRect.top)},${Math.round(zeilenRect.bottom)}]`
+					);
+				}
+				// 3: vollstaendig im Sichtfenster (waagerecht)
+				if (r.left < -1 || r.right > vw + 1) {
+					verletzt.push(
+						`3 ausserhalb des Sichtfensters: x ${Math.round(r.left)}..${Math.round(r.right)}, ` +
+							`Fensterbreite ${vw}`
+					);
+				}
+				// 4: nicht von einem Nachbarelement ueberdeckt
+				const mitte = document.elementFromPoint(
+					(r.left + r.right) / 2,
+					(r.top + r.bottom) / 2
+				);
+				if (!mitte || !(mitte === el || el.contains(mitte))) {
+					const wer = mitte
+						? `<${mitte.tagName.toLowerCase()} class="${mitte.className}">`
+						: 'nichts (Punkt liegt ausserhalb des Sichtfensters)';
+					verletzt.push(`4 verdeckt: in der Mitte der Marke liegt ${wer}`);
+				}
+				// 5: kein Auslassungszeichen
+				if (text.includes('…') || text.includes('...')) {
+					verletzt.push(`5 Auslassungszeichen im Text: ${JSON.stringify(text)}`);
+				}
+
+				if (verletzt.length > 0) befunde.push({ groesse, marke: name, text, verletzt });
+			}
+		}
+		return befunde;
+	}, { mailSel: MAIL_BADGE, kurzSel: KURZFORM_BADGE });
+}
+
+/** Die Kuerzel einer Marke, ohne ihre Beschriftung. */
+function kuerzelTokens(text: string): string[] {
+	return text
+		.split(/\s+/)
+		.map((t) => t.trim())
+		.filter((t) => t.length > 0 && !BESCHRIFTUNGEN.includes(t));
+}
+
+/** Bedingung 5 in ihrer strengen Form: der gerenderte Text IST das erwartete
+ *  Kuerzel — nicht "enthaelt es irgendwo". */
+async function pruefeTextgleichheit(
+	zeile: Locator,
+	selektor: string,
+	erwartet: string[],
+	wo: string
+): Promise<string | null> {
+	const roh = (await zeile.locator(selektor).first().textContent()) ?? '';
+	const ist = kuerzelTokens(roh.replace(/\s+/g, ' ').trim());
+	const gleich = ist.length === erwartet.length && ist.every((t, i) => t === erwartet[i]);
+	return gleich
+		? null
+		: `${wo}: Marke zeigt [${ist.join(' ')}], das Backend fuehrt [${erwartet.join(' ')}]`;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Navigation
+// ═══════════════════════════════════════════════════════════════════════════
+
+async function oeffneTourenEditor(page: Page): Promise<Locator> {
+	await page.goto(`/trips/${TRIP_ID}?tab=weather`);
+	const reiter = page.getByTestId('trip-detail-tab-weather');
+	await expect(reiter).toBeVisible({ timeout: 15_000 });
+	await page.waitForLoadState('networkidle');
+	await reiter.click();
+	const tab = page.getByTestId('weather-metrics-tab');
+	await expect(tab).toBeVisible({ timeout: 15_000 });
+	await expect(tab.getByTestId('wm2-grundauswahl').locator('.toggle-btn').first()).toBeVisible({
+		timeout: 15_000
+	});
+	return tab;
+}
+
+async function oeffneVergleichsEditor(page: Page, presetId: string): Promise<Locator> {
+	await page.goto(`/compare/${presetId}`);
+	await expect(page.getByTestId('compare-detail-tab-list')).toBeVisible({ timeout: 15_000 });
+	await page.waitForLoadState('networkidle');
+	await page.getByTestId('compare-detail-tab-wetter-metriken').click();
+	const panel = page.getByTestId('compare-detail-panel-wetter-metriken');
+	await expect(panel).toBeVisible({ timeout: 15_000 });
+	return panel;
+}
+
+/** Pointer-Drag gegen `svelte-dnd-action` MIT Warten auf `finalize` — die
+ *  Bibliothek feuert das Ereignis nach `mouseup` unzuverlaessig verzoegert
+ *  (gemessen #1719 S3, 4 Laeufe: 2x gar nicht, 1x sofort, 1x nach ~1,9s). Eine
+ *  feste Pause danach liest den `consider`-Zwischenstand und haelt ihn
+ *  faelschlich fuer einen bestandenen Speichervorgang. Uebernommen aus
+ *  wetter-metriken-vorschau-entfernt.staging.spec.ts. */
+async function ziehe(page: Page, quelle: Locator, ziel: Locator): Promise<void> {
+	await quelle.scrollIntoViewIfNeeded();
+	await ziel.scrollIntoViewIfNeeded();
+	const q = await quelle.boundingBox();
+	const z = await ziel.boundingBox();
+	if (!q || !z) throw new Error('ziehe: Quelle/Ziel ohne BoundingBox');
+
+	await page.evaluate(() => {
+		const zone = document.querySelector('.sortable-zone');
+		if (!zone) throw new Error('ziehe: .sortable-zone nicht im DOM gefunden');
+		(window as unknown as { __gzDndFinalize?: Promise<void> }).__gzDndFinalize = new Promise(
+			(resolve) => zone.addEventListener('finalize', () => resolve(), { once: true })
+		);
+	});
+
+	await page.mouse.move(q.x + q.width / 2, q.y + q.height / 2);
+	await page.mouse.down();
+	await page.mouse.move(q.x + q.width / 2, q.y + q.height / 2 - 12, { steps: 6 });
+	await page.waitForTimeout(120);
+	await page.mouse.move(z.x + z.width / 2, z.y + z.height / 2, { steps: 15 });
+	await page.waitForTimeout(120);
+	await page.mouse.up();
+
+	const gefeuert = await page.evaluate(({ ms }) => {
+		const w = window as unknown as { __gzDndFinalize?: Promise<void> };
+		if (!w.__gzDndFinalize) return Promise.resolve(false);
+		return Promise.race([
+			w.__gzDndFinalize.then(() => true),
+			new Promise<boolean>((r) => setTimeout(() => r(false), ms))
+		]);
+	}, { ms: 4_000 });
+	if (!gefeuert) {
+		throw new Error(
+			'ziehe: finalize blieb aus (>4000ms) — die Ziehgeste hat nicht committet. ' +
+				'Bekannte Flakiness des Pointer-Drag-Helfers (svelte-dnd-action), kein ' +
+				'Produktfehler; Diagnose 2026-08-12 in #1719 S3.'
+		);
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+test.describe('Issue #1719 S4: die Kuerzel-Marken sind lesbar, in jeder Fensterbreite', () => {
+	test.afterAll(async ({ request }) => {
+		await request.delete(`/api/trips/${TRIP_ID}`).catch(() => {});
+		for (const id of aufgeraeumt.presets) {
+			await request.delete(`/api/compare/presets/${id}`).catch(() => {});
+		}
+		for (const id of aufgeraeumt.orte) {
+			await request.delete(`/api/locations/${id}`).catch(() => {});
+		}
+	});
+
+	// ── AC-5 / AC-6 ─────────────────────────────────────────────────────────
+	test('AC-5: jede Zeile traegt beide Marken, die Kurzform mit ALLEN Kuerzeln', async ({
+		page,
+		request
+	}) => {
+		await createTrip(request);
+		const kurz = await kurzformAusBackend(request);
+		const mail = await mailKurzformAusBackend(request);
+
+		await page.setViewportSize({ width: 1440, height: 900 });
+		const tab = await oeffneTourenEditor(page);
+
+		const abweichungen: string[] = [];
+		for (const metricId of TRIP_METRIKEN) {
+			const zeile = tab.locator(
+				`[data-testid="wm2-reihenfolge-row"][data-metric-id="${metricId}"]`
+			);
+			await expect(
+				zeile,
+				`AC-5 FAIL: keine Reihenfolge-Zeile fuer '${metricId}' — Testaufbau pruefen`
+			).toHaveCount(1);
+
+			const erwarteteKurz = kurz[metricId];
+			expect(
+				erwarteteKurz,
+				`Testaufbau: /api/sms-symbols kennt '${metricId}' nicht`
+			).toBeTruthy();
+			const f1 = await pruefeTextgleichheit(
+				zeile,
+				KURZFORM_BADGE,
+				erwarteteKurz,
+				`${metricId} / Kurzform`
+			);
+			if (f1) abweichungen.push(f1);
+
+			const f2 = await pruefeTextgleichheit(
+				zeile,
+				MAIL_BADGE,
+				[mail[metricId]],
+				`${metricId} / Mail`
+			);
+			if (f2) abweichungen.push(f2);
+		}
+
+		expect(
+			abweichungen,
+			'AC-5/AC-6 FAIL: der Editor zeigt andere Kuerzel als die Kanaele senden.\n  ' +
+				abweichungen.join('\n  ') +
+				'\nBesonders hart: "Nacht-Tiefsttemperatur" — der Editor nennt heute ein ' +
+				'Kuerzel, das in KEINER SMS vorkommt, waehrend das gesendete `N` nirgends ' +
+				'erklaert wird.'
+		).toEqual([]);
+	});
+
+	// ── AC-10 / AC-11 / AC-12 (Touren-Editor) ───────────────────────────────
+	test('AC-10/AC-11: in allen 14 Aufloesungen erfuellt jede Marke jeder Zeile alle Bedingungen', async ({
+		page,
+		request
+	}) => {
+		await createTrip(request);
+		const tab = await oeffneTourenEditor(page);
+
+		const alleBefunde: string[] = [];
+		for (const { klasse, width, height } of AUFLOESUNGEN) {
+			await page.setViewportSize({ width, height });
+			// Layout-Umbruch abwarten (Media-Query + Flex-Neuberechnung).
+			await page.waitForTimeout(250);
+
+			const zeilen = tab.locator('[data-testid="wm2-reihenfolge-row"]');
+			const anzahl = await zeilen.count();
+			if (anzahl !== TRIP_METRIKEN.length) {
+				alleBefunde.push(
+					`${width}x${height} (${klasse}): ${anzahl} statt ${TRIP_METRIKEN.length} ` +
+						`Zeilen sichtbar — eine Groesse verschwindet bei dieser Breite`
+				);
+			}
+			for (let i = 0; i < anzahl; i++) {
+				for (const b of await messeZeile(zeilen.nth(i))) {
+					for (const v of b.verletzt) {
+						alleBefunde.push(
+							`${width}x${height} (${klasse}) · ${b.groesse} · Marke "${b.marke}" ` +
+								`(${JSON.stringify(b.text)}): ${v}`
+						);
+					}
+				}
+			}
+
+			// AC-11: die Seite scrollt in dieser Breite nicht waagerecht.
+			const scrollt = await page.evaluate(
+				() => document.documentElement.scrollWidth > window.innerWidth + 1
+			);
+			if (scrollt) {
+				const breite = await page.evaluate(() => document.documentElement.scrollWidth);
+				alleBefunde.push(
+					`${width}x${height} (${klasse}): AC-11 — die Seite scrollt waagerecht ` +
+						`(scrollWidth ${breite} > innerWidth ${width})`
+				);
+			}
+		}
+
+		expect(
+			alleBefunde,
+			`AC-10/AC-11 FAIL — ${alleBefunde.length} Verletzungen:\n  ` + alleBefunde.join('\n  ')
+		).toEqual([]);
+	});
+
+	// ── AC-12 ───────────────────────────────────────────────────────────────
+	//
+	// Gegenprobe (Spec, Pflicht): nimmt man den Marken die Unverkuerzbarkeit
+	// wieder weg (`flex-shrink: 0` aus `.col-badge`/`.sms-badge` in
+	// WeatherV2Reihenfolge.svelte entfernen, bzw. den Umbruch auf `max-width:
+	// 899px` zurueckstellen), MUSS dieser Test rot werden. Wird er es nicht,
+	// bewacht er nichts. Die Gegenprobe laeuft an einem eigenen Staging-Stand;
+	// dieser Test ist so gebaut, dass sie moeglich ist: er misst genau die
+	// beiden Bedingungen, die eine schrumpfende Marke verletzt (1 und 5), und
+	// erlaubt dem NAMEN ausdruecklich, gekuerzt zu sein.
+	test('AC-12: in der Bruchzone kuerzt der Name, nie eine Marke', async ({ page, request }) => {
+		await createTrip(request);
+		const tab = await oeffneTourenEditor(page);
+
+		const befunde: string[] = [];
+		let irgendeinNameGekuerzt = false;
+		for (const width of [960, 1024]) {
+			await page.setViewportSize({ width, height: 900 });
+			await page.waitForTimeout(250);
+
+			const zeilen = tab.locator('[data-testid="wm2-reihenfolge-row"]');
+			const anzahl = await zeilen.count();
+			for (let i = 0; i < anzahl; i++) {
+				const zeile = zeilen.nth(i);
+				await zeile.scrollIntoViewIfNeeded();
+				const messung = await zeile.evaluate((row, { mailSel, kurzSel }) => {
+					const groesse = row.getAttribute('data-metric-id') ?? '?';
+					const name = row.querySelector('.metric-label') as HTMLElement | null;
+					const marken = [
+						...Array.from(row.querySelectorAll(mailSel)),
+						...Array.from(row.querySelectorAll(kurzSel))
+					] as HTMLElement[];
+					return {
+						groesse,
+						nameGekuerzt: name ? name.scrollWidth > name.clientWidth + 1 : false,
+						marken: marken.map((el) => ({
+							text: (el.textContent ?? '').replace(/\s+/g, ' ').trim(),
+							beschnitten: el.scrollWidth > el.clientWidth + 1,
+							scrollWidth: el.scrollWidth,
+							clientWidth: el.clientWidth
+						}))
+					};
+				}, { mailSel: MAIL_BADGE, kurzSel: KURZFORM_BADGE });
+
+				if (messung.nameGekuerzt) irgendeinNameGekuerzt = true;
+				for (const m of messung.marken) {
+					if (m.beschnitten) {
+						befunde.push(
+							`${width}px · ${messung.groesse} · Marke ${JSON.stringify(m.text)} ist ` +
+								`beschnitten (scrollWidth ${m.scrollWidth} > clientWidth ${m.clientWidth}) — ` +
+								`gekuerzt werden darf der NAME, nie ein Kuerzel`
+						);
+					}
+					if (m.text.includes('…') || m.text.includes('...')) {
+						befunde.push(
+							`${width}px · ${messung.groesse} · Marke traegt ein Auslassungszeichen: ` +
+								JSON.stringify(m.text)
+						);
+					}
+				}
+			}
+		}
+
+		expect(befunde, `AC-12 FAIL:\n  ` + befunde.join('\n  ')).toEqual([]);
+		// Rein diagnostisch, keine Zusicherung: ob der Name ueberhaupt kuerzen
+		// MUSSTE, haengt an der Schriftgroesse des Staging-Browsers. Nur
+		// protokolliert, damit ein spaeter gruener Lauf nicht faelschlich als
+		// "Platz war reichlich, also ist nichts bewiesen" gelesen wird.
+		test.info().annotations.push({
+			type: 'AC-12',
+			description: `Name in der Bruchzone gekuerzt: ${irgendeinNameGekuerzt}`
+		});
+	});
+
+	// ── AC-13 (Vergleichs-Editor) ───────────────────────────────────────────
+	test('AC-13: dieselbe Zusicherung im Vergleichs-Editor', async ({ page, request }) => {
+		const ort1 = await createTestLocation(request, { name: 'S4 Nord', lat: 46.5, lon: 8.1 });
+		const ort2 = await createTestLocation(request, { name: 'S4 Sued', lat: 46.9, lon: 8.4 });
+		aufgeraeumt.orte.push(ort1.id, ort2.id);
+		const angelegt = await request.post('/api/compare/presets', {
+			data: {
+				name: 'E2E #1719 S4 Kuerzel-Marken',
+				location_ids: [ort1.id, ort2.id],
+				schedule: 'daily',
+				profil: 'wandern',
+				hour_from: 7,
+				hour_to: 16,
+				empfaenger: ['urlauber@example.com'],
+				display_config: {
+					active_metrics: ['temp_max_c', 'wind_max_kmh', 'sunny_hours_h', 'humidity_avg_pct']
+				}
+			}
+		});
+		expect(angelegt.ok(), `Preset-Anlage HTTP ${angelegt.status()}`).toBeTruthy();
+		const presetId = (await angelegt.json()).id as string;
+		aufgeraeumt.presets.push(presetId);
+
+		const { kurz, mail } = await compareKurzformAusBackend(request);
+		const panel = await oeffneVergleichsEditor(page, presetId);
+
+		const alleBefunde: string[] = [];
+		for (const { klasse, width, height } of AUFLOESUNGEN) {
+			await page.setViewportSize({ width, height });
+			await page.waitForTimeout(250);
+
+			const zeilen = panel.locator('[data-testid="wm2-reihenfolge-row"]');
+			const anzahl = await zeilen.count();
+			expect(anzahl, 'AC-13: keine Reihenfolge-Zeilen im Vergleichs-Editor').toBeGreaterThan(0);
+			for (let i = 0; i < anzahl; i++) {
+				const zeile = zeilen.nth(i);
+				for (const b of await messeZeile(zeile)) {
+					for (const v of b.verletzt) {
+						alleBefunde.push(
+							`${width}x${height} (${klasse}) · ${b.groesse} · Marke "${b.marke}" ` +
+								`(${JSON.stringify(b.text)}): ${v}`
+						);
+					}
+				}
+				// Bedingung 5 streng, mit der Quelle des VERGLEICHS: die
+				// Vergleichs-SMS rendert aus `get_sms_code()` — eine flaechenblinde
+				// Korrektur auf die Trip-Kuerzel wuerde hier falsch anzeigen.
+				const id = (await zeile.getAttribute('data-metric-id')) ?? '';
+				if (kurz[id] !== undefined) {
+					const f = await pruefeTextgleichheit(
+						zeile,
+						KURZFORM_BADGE,
+						[kurz[id]],
+						`${width}px · ${id} / Kurzform`
+					);
+					if (f) alleBefunde.push(f);
+				}
+				if (mail[id] !== undefined) {
+					const f = await pruefeTextgleichheit(
+						zeile,
+						MAIL_BADGE,
+						[mail[id]],
+						`${width}px · ${id} / Mail`
+					);
+					if (f) alleBefunde.push(f);
+				}
+			}
+
+			const scrollt = await page.evaluate(
+				() => document.documentElement.scrollWidth > window.innerWidth + 1
+			);
+			if (scrollt) {
+				alleBefunde.push(
+					`${width}x${height} (${klasse}): AC-11/AC-13 — die Seite scrollt waagerecht`
+				);
+			}
+		}
+
+		expect(
+			alleBefunde,
+			`AC-13 FAIL — ${alleBefunde.length} Verletzungen im Vergleichs-Editor:\n  ` +
+				alleBefunde.join('\n  ')
+		).toEqual([]);
+	});
+
+	// ── AC-14 ───────────────────────────────────────────────────────────────
+	test('AC-14: die Ziehgeste sortiert weiterhin um und speichert', async ({ page, request }) => {
+		// PFLICHT, kein Nice-to-have: S3 hat in genau dieser Datei die Ziehgeste
+		// lautlos zerbrochen (neue Array-Referenz im Zeilen-Markup), und 2553
+		// Unit-Tests haben das nicht gesehen.
+		await createTrip(request);
+		await page.setViewportSize({ width: 1440, height: 900 });
+		const tab = await oeffneTourenEditor(page);
+
+		const zeilen = tab.locator('[data-testid="wm2-reihenfolge-row"]');
+		await expect(zeilen).toHaveCount(TRIP_METRIKEN.length);
+		const ersteVorher = await zeilen.first().getAttribute('data-metric-id');
+		expect(ersteVorher).toBe(TRIP_METRIKEN[0]);
+
+		const quelle = tab.locator(
+			`[data-testid="wm2-reihenfolge-row"][data-metric-id="${TRIP_METRIKEN[2]}"]`
+		);
+		const ziel = tab.locator(
+			`[data-testid="wm2-reihenfolge-row"][data-metric-id="${TRIP_METRIKEN[0]}"]`
+		);
+		await ziehe(page, quelle, ziel);
+
+		await expect(zeilen.first()).toHaveAttribute('data-metric-id', TRIP_METRIKEN[2]);
+		await expect(page.getByTestId('save-indicator')).toHaveAttribute('data-state', 'idle', {
+			timeout: 15_000
+		});
+
+		// Ohne Neuladen waere das nur eine DOM-Bewegung: der lokale
+		// `consider`-Zwischenstand sieht im selben Tab identisch aus.
+		await page.reload();
+		await page.getByTestId('trip-detail-tab-weather').click();
+		const neu = page
+			.getByTestId('weather-metrics-tab')
+			.locator('[data-testid="wm2-reihenfolge-row"]');
+		await expect(
+			neu.first(),
+			'AC-14 FAIL: nach dem Neuladen steht die alte Reihenfolge — die Ziehgeste ' +
+				'hat bewegt, aber nicht gespeichert'
+		).toHaveAttribute('data-metric-id', TRIP_METRIKEN[2], { timeout: 10_000 });
+	});
+});

--- a/frontend/e2e/playwright.kuerzel-marken-sichtbar.staging.config.ts
+++ b/frontend/e2e/playwright.kuerzel-marken-sichtbar.staging.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig } from '@playwright/test';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+// E2E-Config Issue #1719 Scheibe S4 (AC-5, AC-10..AC-14): die Kuerzel-Marken im
+// Bereich "Reihenfolge" bleiben in 14 Fensterbreiten vollstaendig lesbar.
+// Kein lokaler webServer — geprueft wird die auf Staging deployte App selbst.
+// Staging steht hinter nginx-Basic-Auth (GZ_VALIDATOR_*) + App-Login (GZ_AUTH_*).
+//
+// Liegt bewusst UNTER frontend/e2e/ (nicht frontend/ root): das RED-Phasen-
+// Edit-Gate laesst nur die Ordner test/tests/__tests__/spec/e2e zu.
+// testDir '.' loest relativ zu dieser Datei auf.
+//
+// 14 Aufloesungen x 2 Flaechen sind ~28 Messlaeufe (Spec Risiko 7, bewusst in
+// Kauf genommen) — deshalb ein grosszuegiges Zeitlimit je Test.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const user = process.env.GZ_VALIDATOR_USER ?? process.env.E2E_USER ?? 'admin';
+const pass = process.env.GZ_VALIDATOR_PASS ?? process.env.E2E_PASS ?? 'test1234';
+
+export default defineConfig({
+	testDir: '.',
+	timeout: 180_000,
+	retries: 0,
+	use: {
+		baseURL: process.env.GZ_SVELTE_BASE ?? 'https://staging.gregor20.henemm.com',
+		headless: true,
+		ignoreHTTPSErrors: true,
+		httpCredentials: { username: user, password: pass }
+	},
+	projects: [
+		{ name: 'setup', testMatch: /kuerzel-marken-sichtbar\.staging\.setup\.ts/ },
+		{
+			name: 'tests',
+			testMatch: /kuerzel-marken-sichtbar\.staging\.spec\.ts/,
+			dependencies: ['setup'],
+			use: {
+				storageState: path.join(__dirname, 'playwright', '.auth', 'staging-1719-s4.json')
+			}
+		}
+	]
+});

--- a/frontend/src/lib/components/shared/CompareHourlyLayoutControls.svelte
+++ b/frontend/src/lib/components/shared/CompareHourlyLayoutControls.svelte
@@ -136,6 +136,17 @@
 		return map;
 	});
 
+	// Issue #1719 S4: Kurzform-Marke = Register-Kuerzel (`sms_code`) — die
+	// Vergleichs-SMS rendert aus `get_sms_code()`. Die Legacy-Schluessel
+	// bekommen dasselbe Kuerzel wie ihre Groesse, sonst traegt dieselbe Zeile
+	// je nach Auswahlstand mal eine Marke und mal keine.
+	const hourlyKuerzelById = $derived.by(() => {
+		const map: Record<string, string[]> = {};
+		for (const [key, eintrag] of Object.entries(hourlyMetricById))
+			if (eintrag.sms_code) map[key] = [eintrag.sms_code];
+		return map;
+	});
+
 	function onHourlyRemove(key: string): void {
 		const group = hourlyGroups.find(
 			(g) => g.metric_id === key || g.hourly_legacy_keys.includes(key)
@@ -227,6 +238,7 @@
 			onRemove={onHourlyRemove}
 			onDndReorder={handleHourlyDndReorder}
 			onMode={noopHourlyMode}
+			kuerzelById={hourlyKuerzelById}
 		/>
 	</Card>
 {/if}

--- a/frontend/src/lib/components/shared/CompareOutlookLayoutControls.svelte
+++ b/frontend/src/lib/components/shared/CompareOutlookLayoutControls.svelte
@@ -74,6 +74,15 @@
 		return map;
 	});
 
+	// Issue #1719 S4: Kurzform-Marke = Register-Kuerzel (`sms_code`) — die
+	// Vergleichs-SMS rendert aus `get_sms_code()`, nicht aus den
+	// Trip-SMS-Tabellen.
+	const outlookKuerzelById = $derived.by(() => {
+		const map: Record<string, string[]> = {};
+		for (const e of catalog) if (e.sms_code) map[e.metric] = [e.sms_code];
+		return map;
+	});
+
 	function onOutlookRemove(key: string): void {
 		makeOutlookMetricHandler(key)();
 		onOutlookCommit?.();
@@ -160,6 +169,7 @@
 			onRemove={onOutlookRemove}
 			onDndReorder={handleOutlookDndReorder}
 			onMode={noopOutlookMode}
+			kuerzelById={outlookKuerzelById}
 		/>
 	</Card>
 {/if}

--- a/frontend/src/lib/components/shared/WeatherMetricsTab.svelte
+++ b/frontend/src/lib/components/shared/WeatherMetricsTab.svelte
@@ -1025,6 +1025,16 @@
 		return map;
 	});
 
+	// Issue #1719 S4: die Kurzform-Marke des VERGLEICHS zeigt das
+	// Register-Kuerzel — die Vergleichs-SMS rendert aus `get_sms_code()`
+	// (comparison.py:625), nicht aus den Trip-SMS-Tabellen. Genau EIN Kuerzel
+	// je Groesse; Groessen ohne Registereintrag bekommen gar keine Marke.
+	const compareKuerzelById = $derived.by(() => {
+		const map: Record<string, string[]> = {};
+		for (const e of compareCatalog) if (e.sms_code) map[e.metric] = [e.sms_code];
+		return map;
+	});
+
 	// Ziehen = Reihenfolge setzen + SOFORT speichern (s. onCompareCommit-Prop).
 	function onCompareDndReorder(newOrder: string[]) {
 		if (!wiz) return;
@@ -1197,6 +1207,7 @@
 					onRemove={onCompareRemove}
 					onDndReorder={onCompareDndReorder}
 					onMode={noopMode}
+					kuerzelById={compareKuerzelById}
 				/>
 			</Card>
 			{/if}
@@ -1346,6 +1357,7 @@
 							{onMode}
 							offColumns={activeChannelSections.off}
 							onRestore={onRestoreMetric}
+							kuerzelById={metricSymbols}
 						/>
 					</Card>
 				{/snippet}

--- a/frontend/src/lib/components/shared/__tests__/weather_metric_kuerzel_marken.test.ts
+++ b/frontend/src/lib/components/shared/__tests__/weather_metric_kuerzel_marken.test.ts
@@ -1,0 +1,346 @@
+// TDD RED — Issue #1719 Scheibe S4: die Zeile im Bereich "Reihenfolge" traegt
+// ZWEI beschriftete Marken, und die Kurzform-Marke zeigt ALLE Kuerzel, die der
+// Nutzer in der zugestellten Nachricht wirklich liest.
+//
+// Spec: docs/specs/modules/fix_1719_s4_kuerzel_vereinheitlichung.md
+//   AC-5 (zwei beschriftete Marken) · AC-6 (alle Kuerzel, Quelle /api/sms-symbols)
+//   AC-7 (dieselben Marken in den drei Vergleichs-Editoren, Quelle sms_code)
+//   AC-8 (der Bestandswaechter aus #1453 bleibt gruen)
+//   AC-9 (keine leere oder erfundene Marke)
+//
+// Gemessener Ist-Stand (WeatherV2Reihenfolge.svelte:97-113): die Zeile zeigt
+// zwei Marken, aber
+//   * ohne sichtbare Beschriftung ("Mail" steht nur im `title`-Attribut),
+//   * ohne Testid — geometrisch pruefen (AC-10..AC-13) laesst sich so nichts,
+//   * und die zweite Marke zeigt `m.sms_code`, also die ALARM-Stammdaten
+//     (#914). Bei "Gefuehlte Temperatur" steht dort `TF`, waehrend die
+//     Trip-SMS `FK FD WC` sendet; bei "Nacht-Tiefsttemperatur" steht `TN`,
+//     waehrend die SMS `N` sendet. Das Kuerzel `N`, das der Nutzer wirklich
+//     bekommt, ist im gesamten Editor nirgends aufloesbar.
+//
+// Grund fuer AST statt DOM: dieses Repo hat kein vitest/jsdom (package.json
+// "test": node --test). Der Test parst die Komponenten mit dem ECHTEN
+// Svelte-5-Compiler — kein verbotener Dateiinhalt-Vergleich.
+//
+// Der geometrische Nachweis ("die Marke ist auch WIRKLICH lesbar") gehoert
+// nicht hierher: er braucht einen echten Browser und steht in
+// frontend/e2e/kuerzel-marken-sichtbar.staging.spec.ts (AC-10..AC-14).
+//
+// Ausfuehrung:
+//   cd frontend && node --import ./test-lib-loader.mjs --experimental-strip-types --test \
+//     src/lib/components/shared/__tests__/weather_metric_kuerzel_marken.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'svelte/compiler';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SHARED = join(here, '..');
+const REIHENFOLGE = join(SHARED, 'weather-metrics-tab', 'WeatherV2Reihenfolge.svelte');
+// Pfadregel #1409: alles relativ zur eigenen Testdatei — nie ueber einen festen
+// Hauptrepo-Pfad, sonst prueft der Test aus dem Worktree die unveraenderte
+// Hauptrepo-Kopie und meldet falsches Gruen.
+const FRONTEND = resolve(here, '..', '..', '..', '..', '..');
+
+/** Testids, unter denen die beiden Marken auffindbar sein muessen. Sie sind
+ *  kein Selbstzweck: der Browser-Nachweis (AC-10) misst je Aufloesung die
+ *  Geometrie GENAU dieser Elemente. Ohne stabilen Anker gibt es keinen. */
+const MAIL_BADGE = 'wm2-mail-badge';
+const KURZFORM_BADGE = 'wm2-kurzform-badge';
+
+type Knoten = Record<string, any>;
+
+function parseComponent(path: string): any {
+	return parse(readFileSync(path, 'utf-8'), { modern: true });
+}
+
+/** Tiefensuche mit Elternkette — die brauchen wir, um "die Marke steht in
+ *  einem {#if}" und "die Beschriftung steht neben der Marke" zu pruefen. */
+function walk(node: unknown, visit: (n: Knoten, eltern: Knoten[]) => void, eltern: Knoten[] = []): void {
+	if (node === null || typeof node !== 'object') return;
+	if (Array.isArray(node)) {
+		node.forEach((n) => walk(n, visit, eltern));
+		return;
+	}
+	const n = node as Knoten;
+	if (n.type) visit(n, eltern);
+	const kette = n.type ? [...eltern, n] : eltern;
+	for (const key of Object.keys(n)) {
+		if (key === 'parent' || key === 'loc') continue;
+		walk(n[key], visit, kette);
+	}
+}
+
+/** Alle Namen, die ein Teilbaum liest: Bezeichner UND Objekt-Eigenschaften
+ *  (`m.sms_code` liefert 'm' und 'sms_code'). */
+function geleseneNamen(subtree: unknown): Set<string> {
+	const namen = new Set<string>();
+	walk(subtree, (n) => {
+		if (n.type === 'Identifier' && typeof n.name === 'string') namen.add(n.name);
+		if (n.type === 'MemberExpression' && !n.computed && n.property?.type === 'Identifier') {
+			namen.add(n.property.name);
+		}
+	});
+	return namen;
+}
+
+/** Alle Textbausteine eines Teilbaums, zusammengezogen. */
+function textVon(subtree: unknown): string {
+	const teile: string[] = [];
+	walk(subtree, (n) => {
+		if (n.type === 'Text' && typeof n.data === 'string') teile.push(n.data);
+	});
+	return teile.join(' ').replace(/\s+/g, ' ').trim();
+}
+
+function attributWert(n: Knoten, name: string): string | null {
+	for (const a of n.attributes ?? []) {
+		if (a.type !== 'Attribute' || a.name !== name) continue;
+		const v = Array.isArray(a.value) ? a.value : [a.value];
+		const literal = v.find((x: Knoten) => x?.type === 'Text');
+		return literal ? String(literal.data) : '';
+	}
+	return null;
+}
+
+/** Das Element mit `data-testid={testid}` samt seiner Elternkette. */
+function findeMarke(ast: any, testid: string): { knoten: Knoten; eltern: Knoten[] } | null {
+	let treffer: { knoten: Knoten; eltern: Knoten[] } | null = null;
+	walk(ast.fragment, (n, eltern) => {
+		if (n.type !== 'RegularElement') return;
+		if (attributWert(n, 'data-testid') !== testid) return;
+		if (!treffer) treffer = { knoten: n, eltern };
+	});
+	return treffer;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AC-5 — zwei beschriftete Marken je Zeile
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('AC-5: die Zeile traegt zwei beschriftete, auffindbare Marken', () => {
+	for (const [testid, beschriftung, zweck] of [
+		[MAIL_BADGE, 'Mail', 'die englische Fachkurzform der Mail-Stundentabelle (z.B. "Feels")'],
+		[KURZFORM_BADGE, 'Kurzform', 'alle Kuerzel, die SMS und Telegram senden (z.B. "FK FD WC")']
+	] as const) {
+		test(`Marke "${beschriftung}" ist unter data-testid="${testid}" auffindbar`, () => {
+			const ast = parseComponent(REIHENFOLGE);
+			const marke = findeMarke(ast, testid);
+			assert.ok(
+				marke,
+				`AC-5 FAIL (RED): WeatherV2Reihenfolge.svelte hat kein Element mit ` +
+					`data-testid="${testid}" — ${zweck}. Ohne stabilen Anker kann der ` +
+					`Browser-Nachweis (AC-10: fuenf Sichtbarkeits-Bedingungen in 14 ` +
+					`Aufloesungen) die Marke nicht messen. Heute traegt die Zeile zwei ` +
+					`Marken ohne Testid und ohne sichtbare Beschriftung (nur ` +
+					`title-Attribut, WeatherV2Reihenfolge.svelte:102-111).`
+			);
+		});
+
+		test(`Marke "${beschriftung}" ist sichtbar beschriftet, nicht nur per title`, () => {
+			const ast = parseComponent(REIHENFOLGE);
+			const marke = findeMarke(ast, testid);
+			assert.ok(
+				marke,
+				`AC-5 FAIL (RED): keine Marke "${testid}" — ohne sie gibt es auch keine ` +
+					`Beschriftung zu pruefen (Ursache s. Test darueber).`
+			);
+			const eigenerText = textVon(marke.knoten);
+			const eltern = marke.eltern[marke.eltern.length - 1];
+			const umfeld = eltern ? textVon(eltern.fragment ?? eltern) : '';
+			assert.ok(
+				eigenerText.includes(beschriftung) || umfeld.includes(beschriftung),
+				`AC-5 FAIL (RED): die Marke "${testid}" traegt nirgends die sichtbare ` +
+					`Beschriftung "${beschriftung}". Gefunden: eigener Text ${JSON.stringify(eigenerText)}, ` +
+					`Umfeld ${JSON.stringify(umfeld)}. Ein Kuerzel ohne Beschriftung ist ` +
+					`nicht aufloesbar — der Nutzer weiss nicht, ob "TF" in seiner Mail ` +
+					`oder in seiner SMS steht.`
+			);
+		});
+	}
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AC-6 — die Kurzform-Marke zeigt ALLE Kuerzel der Groesse
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('AC-6: die Kurzform-Marke zeigt alle Kuerzel, nicht nur das erste', () => {
+	test('die Marke rendert eine Liste (Schleife oder join), keinen Einzelwert', () => {
+		const ast = parseComponent(REIHENFOLGE);
+		const marke = findeMarke(ast, KURZFORM_BADGE);
+		assert.ok(marke, `AC-6 FAIL (RED): keine Marke "${KURZFORM_BADGE}" — s. AC-5.`);
+
+		let listenform = false;
+		walk(marke!.knoten, (n) => {
+			if (n.type === 'EachBlock') listenform = true;
+			if (
+				n.type === 'CallExpression' &&
+				n.callee?.type === 'MemberExpression' &&
+				n.callee.property?.type === 'Identifier' &&
+				n.callee.property.name === 'join'
+			) {
+				listenform = true;
+			}
+		});
+		assert.ok(
+			listenform,
+			`AC-6 FAIL (RED): die Kurzform-Marke rendert einen Einzelwert. ` +
+				`"Gefuehlte Temperatur" traegt drei Kuerzel (FK FD WC) und "Gewitter" ` +
+				`zwei (TH TH+) — ein skalares Feld kann davon nur eines zeigen, und ` +
+				`die uebrigen bleiben unaufloesbar.`
+		);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AC-9 — keine leere und keine erfundene Marke
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('AC-9: eine Groesse ohne Kuerzel bekommt gar keine Marke', () => {
+	test('die Kurzform-Marke haengt an einer Bedingung ueber ihrer eigenen Quelle', () => {
+		const ast = parseComponent(REIHENFOLGE);
+		const marke = findeMarke(ast, KURZFORM_BADGE);
+		assert.ok(marke, `AC-9 FAIL (RED): keine Marke "${KURZFORM_BADGE}" — s. AC-5.`);
+
+		const inhalt = geleseneNamen(marke!.knoten);
+		const bedingungen = marke!.eltern
+			.filter((e) => e.type === 'IfBlock')
+			.map((e) => geleseneNamen(e.test));
+		assert.ok(
+			bedingungen.length > 0,
+			`AC-9 FAIL (RED): die Kurzform-Marke steht in keinem {#if}. Eine Groesse ` +
+				`ohne Kuerzel bekaeme dann eine leere Marke — "Kurzform" mit nichts ` +
+				`dahinter ist schlechter als gar keine Marke.`
+		);
+		const passend = bedingungen.some((b) => [...b].some((name) => inhalt.has(name)));
+		assert.ok(
+			passend,
+			`AC-9 FAIL: die Bedingung prueft etwas anderes als die Marke anzeigt ` +
+				`(Bedingung liest ${JSON.stringify(bedingungen.map((b) => [...b]))}, ` +
+				`Marke liest ${JSON.stringify([...inhalt])}). Dann kann eine leere Marke ` +
+				`erscheinen, obwohl die Bedingung wahr ist.`
+		);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AC-6 / AC-7 — die Quelle richtet sich nach der Flaeche
+//
+// Spec Abschnitt 3: der Touren-Editor zeigt die TRIP-SMS-Kuerzel
+// (/api/sms-symbols, deckt Mehrfach-Token und Grammatik ab), die drei
+// Vergleichs-Editoren das Register-Kuerzel (`sms_code`) — die Vergleichs-SMS
+// rendert aus `get_sms_code()`. Eine flaechenblinde Korrektur wuerde den
+// Vergleich falsch machen.
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Namen, die eine `<WeatherV2Reihenfolge …>`-Einbettung erreicht: alles aus
+ *  ihren Attributwerten plus — einen Schritt tief — alles aus der Herleitung
+ *  der dort genannten Bezeichner. Zwei Bauarten sind damit gleich gueltig:
+ *  die Kuerzel als EIGENE Eigenschaft uebergeben oder sie in die bestehende
+ *  `metricById`-Zuordnung einweben. Der Test schreibt keine von beiden vor. */
+function erreichteNamen(datei: string, waehle: (attrs: Set<string>) => boolean): Set<string> | null {
+	const ast = parseComponent(datei);
+	let ziel: Knoten | null = null;
+	walk(ast.fragment, (n) => {
+		if (n.type !== 'Component' || n.name !== 'WeatherV2Reihenfolge') return;
+		const attrNamen = new Set<string>(
+			(n.attributes ?? [])
+				.filter((a: Knoten) => a.type === 'Attribute')
+				.map((a: Knoten) => String(a.name))
+		);
+		if (waehle(attrNamen) && !ziel) ziel = n;
+	});
+	if (!ziel) return null;
+
+	const direkt = geleseneNamen((ziel as Knoten).attributes);
+	const alle = new Set(direkt);
+	walk(ast.instance?.content?.body, (n) => {
+		if (n.type !== 'VariableDeclarator') return;
+		const name = n.id?.type === 'Identifier' ? n.id.name : null;
+		if (!name || !direkt.has(name)) return;
+		for (const gelesen of geleseneNamen(n.init)) alle.add(gelesen);
+	});
+	return alle;
+}
+
+describe('AC-6: der Touren-Editor speist die Kurzform-Marke aus /api/sms-symbols', () => {
+	test('die Touren-Einbettung erreicht den Kuerzel-Katalog des Backends', () => {
+		// Die Touren-Einbettung ist die einzige mit `offColumns` (#1719 S3:
+		// "Aus in diesem Kanal" gibt es nur im Trip-Kanal-Reiter).
+		const erreicht = erreichteNamen(join(SHARED, 'WeatherMetricsTab.svelte'), (attrs) =>
+			attrs.has('offColumns')
+		);
+		assert.ok(erreicht, 'Touren-Einbettung von WeatherV2Reihenfolge nicht gefunden');
+		const quellen = ['metricSymbols', 'smsSymbols', 'sms_symbols'];
+		assert.ok(
+			quellen.some((q) => erreicht!.has(q)),
+			`AC-6 FAIL (RED): die Touren-Einbettung erreicht keine der Quellen ` +
+				`${quellen.join('/')} — der Editor zeigt also weiter die ALARM-Stammdaten ` +
+				`(sms_code) statt der Kuerzel, die die Trip-SMS wirklich sendet. ` +
+				`WeatherMetricsTab.svelte laedt /api/sms-symbols bereits und haelt das ` +
+				`Ergebnis in \`metricSymbols\` (Zeile ~171) — es kommt nur nie in der ` +
+				`Zeile an. Erreichbar ist heute: ${JSON.stringify([...erreicht!].sort())}`
+		);
+	});
+});
+
+describe('AC-7: die drei Vergleichs-Editoren speisen die Marke aus dem Register', () => {
+	for (const [name, datei, waehle] of [
+		[
+			'Vergleichs-Uebersicht',
+			'WeatherMetricsTab.svelte',
+			(attrs: Set<string>) => !attrs.has('offColumns')
+		],
+		['Vergleichs-Stundenverlauf', 'CompareHourlyLayoutControls.svelte', () => true],
+		['Vergleichs-Ausblick', 'CompareOutlookLayoutControls.svelte', () => true]
+	] as const) {
+		test(`${name}: die Zeile erreicht das Register-Kuerzel (sms_code)`, () => {
+			const erreicht = erreichteNamen(join(SHARED, datei), waehle);
+			assert.ok(erreicht, `${name}: WeatherV2Reihenfolge-Einbettung nicht gefunden`);
+			assert.ok(
+				erreicht!.has('sms_code'),
+				`AC-7 FAIL: ${name} erreicht kein \`sms_code\`. Die Vergleichs-SMS ` +
+					`rendert aus \`get_sms_code()\` (comparison.py) — eine Zeile ohne ` +
+					`diese Quelle koennte nur ein Kuerzel zeigen, das der Vergleich nie ` +
+					`sendet. Erreichbar: ${JSON.stringify([...erreicht!].sort())}`
+			);
+		});
+	}
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AC-8 — der Bestandswaechter aus #1453 bleibt gruen
+//
+// Er prueft heute die ANWESENHEIT von `label`/`col_label`/`sms_code` in allen
+// vier Editoren. Stellt S4 die Kurzform-Marke auf eine andere Quelle um, faellt
+// er — genau darauf zielt AC-8: er muss MITGEZOGEN werden (Erwartung an die
+// neue Quelle anpassen), nicht entschaerft und nicht geloescht.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('AC-8: der Bestandswaechter aus #1453 laeuft weiterhin gruen', () => {
+	test('weather_metric_name_forms_visible.test.ts besteht', () => {
+		const ergebnis = spawnSync(
+			process.execPath,
+			[
+				'--import',
+				'./test-lib-loader.mjs',
+				'--experimental-strip-types',
+				'--test',
+				'src/lib/components/shared/__tests__/weather_metric_name_forms_visible.test.ts'
+			],
+			{ cwd: FRONTEND, encoding: 'utf-8' }
+		);
+		assert.equal(
+			ergebnis.status,
+			0,
+			`AC-8 FAIL: der Bestandswaechter aus #1453 ist rot (Exit ${ergebnis.status}). ` +
+				`Er prueft, dass alle VIER Editoren die Namensformen tragen. Nach der ` +
+				`Umstellung auf die neue Kurzform-Quelle ist seine Erwartung anzupassen ` +
+				`— nicht seine Pruefung zu lockern.\n${ergebnis.stdout}\n${ergebnis.stderr}`
+		);
+	});
+});

--- a/frontend/src/lib/components/shared/__tests__/weather_metric_kuerzel_marken.test.ts
+++ b/frontend/src/lib/components/shared/__tests__/weather_metric_kuerzel_marken.test.ts
@@ -44,6 +44,7 @@ const REIHENFOLGE = join(SHARED, 'weather-metrics-tab', 'WeatherV2Reihenfolge.sv
 // Pfadregel #1409: alles relativ zur eigenen Testdatei — nie ueber einen festen
 // Hauptrepo-Pfad, sonst prueft der Test aus dem Worktree die unveraenderte
 // Hauptrepo-Kopie und meldet falsches Gruen.
+const LIB = resolve(here, '..', '..', '..');
 const FRONTEND = resolve(here, '..', '..', '..', '..', '..');
 
 /** Testids, unter denen die beiden Marken auffindbar sein muessen. Sie sind
@@ -118,50 +119,93 @@ function findeMarke(ast: any, testid: string): { knoten: Knoten; eltern: Knoten[
 	return treffer;
 }
 
+/** Die Bauteile, die ein Editor unmittelbar rendert: er selbst plus jede
+ *  direkt eingebundene Svelte-Komponente. Mehr Tiefe braucht es nicht — was
+ *  der Nutzer in diesem Reiter sieht, haengt entweder im Reiter selbst oder in
+ *  einem Bauteil, das er unmittelbar einbindet (Muster aus dem Bestands-
+ *  waechter weather_metric_name_forms_visible.test.ts).
+ *
+ *  Wichtig fuer AC-7: die Frage lautet "zeigt DIESE Flaeche beide Marken?",
+ *  nicht "steht irgendwo im Repo eine Datei, die sie zeigt". Baut jemand fuer
+ *  den Vergleich ein eigenes Zeilen-Bauteil (Verstoss gegen die Trip/Compare-
+ *  Teilungs-Invariante), faellt das hier auf, statt still durchzugehen. */
+function anzeigeflaechen(datei: string): string[] {
+	const pfad = join(SHARED, datei);
+	const ast = parseComponent(pfad);
+	const pfade = [pfad];
+	for (const stmt of (ast?.instance?.content?.body as any[]) ?? []) {
+		if (stmt.type !== 'ImportDeclaration') continue;
+		const quelle = String(stmt.source?.value ?? '');
+		if (!quelle.endsWith('.svelte')) continue;
+		pfade.push(
+			quelle.startsWith('$lib/')
+				? join(LIB, quelle.slice('$lib/'.length))
+				: resolve(dirname(pfad), quelle)
+		);
+	}
+	return pfade;
+}
+
+/** Sucht eine Marke in einer Menge von Anzeigeflaechen. */
+function findeMarkeInFlaechen(
+	pfade: string[],
+	testid: string
+): { pfad: string; knoten: Knoten; eltern: Knoten[] } | null {
+	for (const pfad of pfade) {
+		let ast: any;
+		try {
+			ast = parseComponent(pfad);
+		} catch {
+			continue; // nicht aufloesbarer Import: fuer diese Frage unerheblich
+		}
+		const treffer = findeMarke(ast, testid);
+		if (treffer) return { pfad, ...treffer };
+	}
+	return null;
+}
+
+/** Die eine Zusicherung hinter AC-5 UND AC-7: die Flaeche traegt beide Marken,
+ *  unter auffindbarer Testid und mit sichtbarer Beschriftung. Beide ACs
+ *  verlangen wortgleich dasselbe ("tragen die Zeilen ebenfalls beide Marken")
+ *  — deshalb EINE Pruefung, an verschiedenen Flaechen angewandt, statt zweier
+ *  Formulierungen, die auseinanderlaufen koennen. */
+function pruefeBeideMarken(pfade: string[], kontext: string, ac: string): void {
+	for (const [testid, beschriftung, zweck] of [
+		[MAIL_BADGE, 'Mail', 'die englische Fachkurzform der Mail-Stundentabelle (z.B. "Feels")'],
+		[KURZFORM_BADGE, 'Kurzform', 'alle Kuerzel, die der Kanal dieser Flaeche sendet']
+	] as const) {
+		const marke = findeMarkeInFlaechen(pfade, testid);
+		assert.ok(
+			marke,
+			`${ac} FAIL (RED): ${kontext} zeigt keine Marke mit data-testid="${testid}" ` +
+				`— ${zweck}. Durchsucht: ${JSON.stringify(pfade.map((p) => p.split('/').pop()))}. ` +
+				`Heute traegt die Zeile zwei Marken ohne Testid und ohne sichtbare ` +
+				`Beschriftung (nur title-Attribut, WeatherV2Reihenfolge.svelte:102-111). ` +
+				`Ohne stabilen Anker kann auch der Browser-Nachweis (AC-10/AC-13: fuenf ` +
+				`Sichtbarkeits-Bedingungen in 14 Aufloesungen) nichts messen.`
+		);
+		const eigenerText = textVon(marke.knoten);
+		const eltern = marke.eltern[marke.eltern.length - 1];
+		const umfeld = eltern ? textVon(eltern.fragment ?? eltern) : '';
+		assert.ok(
+			eigenerText.includes(beschriftung) || umfeld.includes(beschriftung),
+			`${ac} FAIL (RED): ${kontext} — die Marke "${testid}" traegt nirgends die ` +
+				`sichtbare Beschriftung "${beschriftung}" (eigener Text ` +
+				`${JSON.stringify(eigenerText)}, Umfeld ${JSON.stringify(umfeld)}). Ein ` +
+				`Kuerzel ohne Beschriftung ist nicht aufloesbar — der Nutzer weiss nicht, ` +
+				`ob "TF" in seiner Mail oder in seiner SMS steht.`
+		);
+	}
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // AC-5 — zwei beschriftete Marken je Zeile
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe('AC-5: die Zeile traegt zwei beschriftete, auffindbare Marken', () => {
-	for (const [testid, beschriftung, zweck] of [
-		[MAIL_BADGE, 'Mail', 'die englische Fachkurzform der Mail-Stundentabelle (z.B. "Feels")'],
-		[KURZFORM_BADGE, 'Kurzform', 'alle Kuerzel, die SMS und Telegram senden (z.B. "FK FD WC")']
-	] as const) {
-		test(`Marke "${beschriftung}" ist unter data-testid="${testid}" auffindbar`, () => {
-			const ast = parseComponent(REIHENFOLGE);
-			const marke = findeMarke(ast, testid);
-			assert.ok(
-				marke,
-				`AC-5 FAIL (RED): WeatherV2Reihenfolge.svelte hat kein Element mit ` +
-					`data-testid="${testid}" — ${zweck}. Ohne stabilen Anker kann der ` +
-					`Browser-Nachweis (AC-10: fuenf Sichtbarkeits-Bedingungen in 14 ` +
-					`Aufloesungen) die Marke nicht messen. Heute traegt die Zeile zwei ` +
-					`Marken ohne Testid und ohne sichtbare Beschriftung (nur ` +
-					`title-Attribut, WeatherV2Reihenfolge.svelte:102-111).`
-			);
-		});
-
-		test(`Marke "${beschriftung}" ist sichtbar beschriftet, nicht nur per title`, () => {
-			const ast = parseComponent(REIHENFOLGE);
-			const marke = findeMarke(ast, testid);
-			assert.ok(
-				marke,
-				`AC-5 FAIL (RED): keine Marke "${testid}" — ohne sie gibt es auch keine ` +
-					`Beschriftung zu pruefen (Ursache s. Test darueber).`
-			);
-			const eigenerText = textVon(marke.knoten);
-			const eltern = marke.eltern[marke.eltern.length - 1];
-			const umfeld = eltern ? textVon(eltern.fragment ?? eltern) : '';
-			assert.ok(
-				eigenerText.includes(beschriftung) || umfeld.includes(beschriftung),
-				`AC-5 FAIL (RED): die Marke "${testid}" traegt nirgends die sichtbare ` +
-					`Beschriftung "${beschriftung}". Gefunden: eigener Text ${JSON.stringify(eigenerText)}, ` +
-					`Umfeld ${JSON.stringify(umfeld)}. Ein Kuerzel ohne Beschriftung ist ` +
-					`nicht aufloesbar — der Nutzer weiss nicht, ob "TF" in seiner Mail ` +
-					`oder in seiner SMS steht.`
-			);
-		});
-	}
+describe('AC-5: die Zeile des Touren-Editors traegt zwei beschriftete Marken', () => {
+	test('beide Marken sind auffindbar und sichtbar beschriftet', () => {
+		pruefeBeideMarken([REIHENFOLGE], 'der Touren-Editor', 'AC-5');
+	});
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -288,25 +332,46 @@ describe('AC-6: der Touren-Editor speist die Kurzform-Marke aus /api/sms-symbols
 	});
 });
 
-describe('AC-7: die drei Vergleichs-Editoren speisen die Marke aus dem Register', () => {
-	for (const [name, datei, waehle] of [
-		[
-			'Vergleichs-Uebersicht',
-			'WeatherMetricsTab.svelte',
-			(attrs: Set<string>) => !attrs.has('offColumns')
-		],
-		['Vergleichs-Stundenverlauf', 'CompareHourlyLayoutControls.svelte', () => true],
-		['Vergleichs-Ausblick', 'CompareOutlookLayoutControls.svelte', () => true]
-	] as const) {
+// AC-7 hat ZWEI Halbsaetze, und der erste ist der, der die Arbeit bewacht:
+// "Then tragen die Zeilen ebenfalls BEIDE MARKEN, und die Kurzform-Marke zeigt
+// das Register-Kuerzel". Ein Test, der nur den zweiten prueft (erreicht die
+// Flaeche `sms_code`?), ist heute schon gruen — `compare_metric_catalog.py:309`
+// reicht das Feld seit #1453 durch — und kann die Umstellung nicht bewachen.
+const VERGLEICHSFLAECHEN = [
+	[
+		'Vergleichs-Uebersicht',
+		'WeatherMetricsTab.svelte',
+		(attrs: Set<string>) => !attrs.has('offColumns')
+	],
+	['Vergleichs-Stundenverlauf', 'CompareHourlyLayoutControls.svelte', () => true],
+	['Vergleichs-Ausblick', 'CompareOutlookLayoutControls.svelte', () => true]
+] as const;
+
+describe('AC-7: die drei Vergleichs-Editoren tragen ebenfalls beide Marken', () => {
+	for (const [name, datei] of VERGLEICHSFLAECHEN) {
+		test(`${name}: die Zeile traegt beide beschrifteten Marken`, () => {
+			// Dieselbe Zusicherung wie AC-5 fuer den Touren-Editor — angewandt auf
+			// die Bauteile, die GENAU DIESE Flaeche rendert.
+			pruefeBeideMarken(anzeigeflaechen(datei), name, 'AC-7');
+		});
+	}
+});
+
+describe('AC-7: die Kurzform-Marke des Vergleichs speist sich aus dem Register', () => {
+	for (const [name, datei, waehle] of VERGLEICHSFLAECHEN) {
 		test(`${name}: die Zeile erreicht das Register-Kuerzel (sms_code)`, () => {
+			// INVARIANTEN-WAECHTER, heute gruen und absichtlich so: die Datengrundlage
+			// steht seit #1453. Er bewacht, dass die Umstellung sie nicht mitreisst —
+			// eine flaechenblinde Korrektur auf die Trip-SMS-Kuerzel wuerde den
+			// Vergleich falsch machen (er sendet aus `get_sms_code()`, comparison.py).
+			// KEIN Nachweis, dass AC-7 erfuellt ist; das leistet der Test darueber.
 			const erreicht = erreichteNamen(join(SHARED, datei), waehle);
 			assert.ok(erreicht, `${name}: WeatherV2Reihenfolge-Einbettung nicht gefunden`);
 			assert.ok(
 				erreicht!.has('sms_code'),
-				`AC-7 FAIL: ${name} erreicht kein \`sms_code\`. Die Vergleichs-SMS ` +
-					`rendert aus \`get_sms_code()\` (comparison.py) — eine Zeile ohne ` +
-					`diese Quelle koennte nur ein Kuerzel zeigen, das der Vergleich nie ` +
-					`sendet. Erreichbar: ${JSON.stringify([...erreicht!].sort())}`
+				`AC-7 FAIL: ${name} erreicht kein \`sms_code\`. Eine Zeile ohne diese ` +
+					`Quelle koennte nur ein Kuerzel zeigen, das der Vergleich nie sendet. ` +
+					`Erreichbar: ${JSON.stringify([...erreicht!].sort())}`
 			);
 		});
 	}

--- a/frontend/src/lib/components/shared/__tests__/weather_metric_kuerzel_marken.test.ts
+++ b/frontend/src/lib/components/shared/__tests__/weather_metric_kuerzel_marken.test.ts
@@ -357,6 +357,113 @@ describe('AC-7: die drei Vergleichs-Editoren tragen ebenfalls beide Marken', () 
 	}
 });
 
+// ═══════════════════════════════════════════════════════════════════════════
+// AC-6 / AC-7 — die QUELLE der Kurzform-Marke, je Flaeche (Adversary Runde 2,
+// F002)
+//
+// Der Waechter darunter prueft nur, ob eine Flaeche `sms_code` IRGENDWIE
+// erreicht — das tut sie ueber `metricById` auch dann noch, wenn die
+// Kurzform-Marke laengst aus der falschen Quelle gespeist wird. Gemessen: der
+// Adversary hat die Vergleichs-Einbettung auf die TRIP-Quelle umgebogen, alle
+// 11 Tests blieben gruen. Das ist genau der Fehler, den diese Scheibe behebt —
+// falsche Quelle, falsches Kuerzel —, nur auf der anderen Flaeche.
+//
+// Deshalb hier: nicht "erreicht die Flaeche sms_code?", sondern "woraus wird
+// GENAU DIE `kuerzelById`-Eigenschaft gespeist?".
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Namen, unter denen die TRIP-SMS-Kuerzel (/api/sms-symbols) reisen. */
+const TRIP_QUELLEN = ['metricSymbols', 'smsSymbols', 'sms_symbols'];
+/** Der Name, unter dem das Register-Kuerzel des Vergleichs reist. */
+const REGISTER_QUELLE = 'sms_code';
+
+/** Namen, die AUSSCHLIESSLICH ueber die `kuerzelById`-Eigenschaft einer
+ *  Einbettung erreichbar sind — die dort genannten Bezeichner plus, einen
+ *  Schritt tief, alles aus ihrer Herleitung. Bewusst NICHT ueber alle
+ *  Eigenschaften: `metricById` traegt `sms_code` ohnehin mit, und genau das
+ *  machte den Waechter darunter blind. */
+function kuerzelQuelle(
+	datei: string,
+	waehle: (attrs: Set<string>) => boolean
+): Set<string> | null {
+	const ast = parseComponent(join(SHARED, datei));
+	let ziel: Knoten | null = null;
+	walk(ast.fragment, (n) => {
+		if (n.type !== 'Component' || n.name !== 'WeatherV2Reihenfolge') return;
+		const attrNamen = new Set<string>(
+			(n.attributes ?? [])
+				.filter((a: Knoten) => a.type === 'Attribute')
+				.map((a: Knoten) => String(a.name))
+		);
+		if (waehle(attrNamen) && !ziel) ziel = n;
+	});
+	if (!ziel) return null;
+	const attr = ((ziel as Knoten).attributes ?? []).find(
+		(a: Knoten) => a.type === 'Attribute' && a.name === 'kuerzelById'
+	);
+	if (!attr) return null;
+
+	const direkt = geleseneNamen(attr);
+	const alle = new Set(direkt);
+	walk(ast.instance?.content?.body, (n) => {
+		if (n.type !== 'VariableDeclarator') return;
+		const name = n.id?.type === 'Identifier' ? n.id.name : null;
+		if (!name || !direkt.has(name)) return;
+		for (const gelesen of geleseneNamen(n.init)) alle.add(gelesen);
+	});
+	return alle;
+}
+
+describe('AC-6/AC-7: die Kurzform-Marke wird je Flaeche aus der RICHTIGEN Quelle gespeist', () => {
+	test('Touren-Editor: aus /api/sms-symbols, NICHT aus dem Register', () => {
+		const quelle = kuerzelQuelle('WeatherMetricsTab.svelte', (attrs) =>
+			attrs.has('offColumns')
+		);
+		assert.ok(quelle, 'AC-6 FAIL: die Touren-Einbettung uebergibt kein `kuerzelById`.');
+		assert.ok(
+			TRIP_QUELLEN.some((q) => quelle!.has(q)),
+			`AC-6 FAIL: die Kurzform-Marke des Touren-Editors wird nicht aus ` +
+				`${TRIP_QUELLEN.join('/')} gespeist. Der Editor zeigte dann die ` +
+				`ALARM-Stammdaten statt der Kuerzel, die die Trip-SMS wirklich sendet — ` +
+				`bei "Gefuehlte Temperatur" ein "TF" statt "FK FD WC", bei ` +
+				`"Nacht-Tiefsttemperatur" ein "TN", das in KEINER SMS vorkommt. ` +
+				`Erreichbar: ${JSON.stringify([...quelle!].sort())}`
+		);
+		assert.ok(
+			!quelle!.has(REGISTER_QUELLE),
+			`AC-6 FAIL: die Kurzform-Marke des Touren-Editors wird (auch) aus ` +
+				`\`${REGISTER_QUELLE}\` gespeist. Das ist die Quelle des VERGLEICHS; ` +
+				`die Trip-SMS rendert aus SMS_MULTI_SYMBOLS_BY_METRIC / ` +
+				`SMS_SYMBOL_BY_METRIC. Erreichbar: ${JSON.stringify([...quelle!].sort())}`
+		);
+	});
+
+	for (const [name, datei, waehle] of VERGLEICHSFLAECHEN) {
+		test(`${name}: aus dem Register, NICHT aus den Trip-SMS-Kuerzeln`, () => {
+			const quelle = kuerzelQuelle(datei, waehle);
+			assert.ok(quelle, `AC-7 FAIL: ${name} uebergibt kein \`kuerzelById\`.`);
+			assert.ok(
+				quelle!.has(REGISTER_QUELLE),
+				`AC-7 FAIL: die Kurzform-Marke von ${name} wird nicht aus ` +
+					`\`${REGISTER_QUELLE}\` gespeist. Die Vergleichs-SMS rendert aus ` +
+					`\`get_sms_code()\` (comparison.py:625) — die Marke zeigte dann ein ` +
+					`Kuerzel, das der Vergleich nie sendet. ` +
+					`Erreichbar: ${JSON.stringify([...quelle!].sort())}`
+			);
+			const trip = TRIP_QUELLEN.filter((q) => quelle!.has(q));
+			assert.deepEqual(
+				trip,
+				[],
+				`AC-7 FAIL: die Kurzform-Marke von ${name} wird aus der TRIP-Quelle ` +
+					`gespeist (${trip.join(', ')}). Trip und Vergleich senden aus ` +
+					`VERSCHIEDENEN Tabellen; eine flaechenblinde Quelle macht den ` +
+					`Vergleich falsch — genau der Fehler, den diese Scheibe behebt, nur ` +
+					`auf der anderen Flaeche.`
+			);
+		});
+	}
+});
+
 describe('AC-7: die Kurzform-Marke des Vergleichs speist sich aus dem Register', () => {
 	for (const [name, datei, waehle] of VERGLEICHSFLAECHEN) {
 		test(`${name}: die Zeile erreicht das Register-Kuerzel (sms_code)`, () => {
@@ -388,6 +495,17 @@ describe('AC-7: die Kurzform-Marke des Vergleichs speist sich aus dem Register',
 
 describe('AC-8: der Bestandswaechter aus #1453 laeuft weiterhin gruen', () => {
 	test('weather_metric_name_forms_visible.test.ts besteht', () => {
+		// GEMESSEN 2026-08-12 (GREEN-Phase): OHNE die folgende Env-Bereinigung
+		// meldet dieser Test IMMER `status === 0`. Node vererbt an das Kind
+		// `NODE_TEST_CONTEXT` (gesetzt, weil DIESE Datei selbst unter
+		// `node --test` laeuft); in dieser Betriebsart schreibt der Laeufer TAP
+		// an den Elternprozess und beendet sich mit 0, auch wenn Tests scheitern.
+		// Beleg: derselbe Aufruf liefert direkt `exit=1`, mit
+		// `NODE_TEST_CONTEXT=child-v8` gesetzt `exit=0`.
+		// Der Waechter war damit ein Waechter, der nichts bewacht — er war auch
+		// in der RED-Phase gruen, waehrend die geprueften vier Editoren rot waren.
+		const kindUmgebung = { ...process.env };
+		delete kindUmgebung.NODE_TEST_CONTEXT;
 		const ergebnis = spawnSync(
 			process.execPath,
 			[
@@ -397,7 +515,15 @@ describe('AC-8: der Bestandswaechter aus #1453 laeuft weiterhin gruen', () => {
 				'--test',
 				'src/lib/components/shared/__tests__/weather_metric_name_forms_visible.test.ts'
 			],
-			{ cwd: FRONTEND, encoding: 'utf-8' }
+			{ cwd: FRONTEND, encoding: 'utf-8', env: kindUmgebung }
+		);
+		// Zweiter, unabhaengiger Beleg: der Laeufer MUSS eine Bilanz gedruckt
+		// haben. Ein Kind, das gar nicht erst startet, waere sonst "bestanden".
+		assert.match(
+			ergebnis.stdout ?? '',
+			/^# fail 0$/m,
+			`AC-8 FAIL: der Bestandswaechter meldet keine Null-Bilanz.\n` +
+				`${ergebnis.stdout}\n${ergebnis.stderr}`
 		);
 		assert.equal(
 			ergebnis.status,

--- a/frontend/src/lib/components/shared/__tests__/weather_metric_name_forms_visible.test.ts
+++ b/frontend/src/lib/components/shared/__tests__/weather_metric_name_forms_visible.test.ts
@@ -45,8 +45,27 @@ const here = dirname(fileURLToPath(import.meta.url));
 const SHARED = join(here, '..');
 const LIB = resolve(here, '..', '..', '..'); // frontend/src/lib
 
-/** Die drei Namensformen, wie GET /api/metrics sie je Groesse ausliefert. */
-const FORMEN = ['label', 'col_label', 'sms_code'] as const;
+/** Die drei Namensformen, die eine Zeile je Groesse zeigen muss.
+ *
+ *  #1719 S4: die dritte Form heisst nicht mehr `sms_code`. Der Wert war eine
+ *  ANNAHME dieses Waechters ("sms_code IST das SMS-Kuerzel") — und genau die
+ *  war bei 5 von 25 Groessen falsch: die Trip-SMS sendet fuer
+ *  `temperature_night` ein `N`, das Register fuehrt `TN`. Seit S4 richtet
+ *  sich die Quelle nach der FLAECHE (Touren: /api/sms-symbols ueber
+ *  `kuerzelById`; Vergleich: Register-`sms_code`, ebenfalls ueber
+ *  `kuerzelById`), weil Trip und Vergleich aus verschiedenen Tabellen senden.
+ *
+ *  Geprueft wird unveraendert die ANWESENHEIT aller drei Formen je Editor —
+ *  nur nicht mehr die Herkunft der dritten. Teil 2 dieses Waechters (unten)
+ *  prueft weiterhin namentlich `sms_code`: dort geht es um die
+ *  Datengrundlage der Vergleichs-Eintraege, und die ist das Register. */
+const FORMEN = ['label', 'col_label', 'kurzform'] as const;
+
+/** Namen, unter denen die Kurzform-Kuerzel in eine Zeile gelangen. Mehrere,
+ *  weil die Quelle flaechenabhaengig ist (s.o.) — nicht als Aufweichung: es
+ *  muss weiterhin GENAU EINE Flaeche je Editor geben, die alle drei Formen
+ *  traegt. */
+const KURZFORM_QUELLEN = ['sms_code', 'kuerzelById', 'sms_symbols'];
 
 /** Die vier Editoren. `WeatherMetricsTab.svelte` traegt zwei davon (Touren-
  *  Editor und Compare-Uebersicht) — dieselbe Datei, zwei Kontexte. */
@@ -75,19 +94,19 @@ function walk(node: unknown, visit: (n: Record<string, any>) => void): void {
 	}
 }
 
-/** Welche der drei Formen liest dieser Teilbaum als Eigenschaft eines
- *  Objekts (`m.col_label`, `metric.sms_code`, …)? */
+/** Welche der drei Formen liest dieser Teilbaum? `label`/`col_label` als
+ *  Eigenschaft eines Objekts (`m.col_label`), die Kurzform zusaetzlich als
+ *  eigener Bezeichner — sie reist seit #1719 S4 in einer eigenen Zuordnung
+ *  (`kuerzelById[id]`, rechnender Zugriff) statt als Feld am Metrik-Objekt. */
 function geleseneFormen(subtree: unknown): Set<string> {
 	const gefunden = new Set<string>();
 	walk(subtree, (n) => {
-		if (
-			n.type === 'MemberExpression' &&
-			!n.computed &&
-			n.property?.type === 'Identifier' &&
-			(FORMEN as readonly string[]).includes(n.property.name)
-		) {
-			gefunden.add(n.property.name);
+		if (n.type === 'MemberExpression' && !n.computed && n.property?.type === 'Identifier') {
+			// `label`/`col_label` unveraendert streng: nur als Objekt-Eigenschaft.
+			if ((FORMEN as readonly string[]).includes(n.property.name)) gefunden.add(n.property.name);
+			if (KURZFORM_QUELLEN.includes(n.property.name)) gefunden.add('kurzform');
 		}
+		if (n.type === 'Identifier' && KURZFORM_QUELLEN.includes(n.name)) gefunden.add('kurzform');
 	});
 	return gefunden;
 }

--- a/frontend/src/lib/components/shared/weather-metrics-tab/WeatherV2Reihenfolge.svelte
+++ b/frontend/src/lib/components/shared/weather-metrics-tab/WeatherV2Reihenfolge.svelte
@@ -42,11 +42,21 @@
 		 *  etwas anderes als "nicht übergeben" (kein Default-Wert hier). */
 		offColumns?: string[];
 		onRestore?: (id: string) => void;
+		/** Issue #1719 S4: ALLE Kürzel, die der Kanal DIESER Fläche für eine
+		 *  Größe sendet (metric_id -> Kürzel-Liste). Die Quelle richtet sich
+		 *  nach der Fläche und wird deshalb von der Einbettung geliefert, nicht
+		 *  hier bestimmt: der Touren-Editor reicht `/api/sms-symbols` durch
+		 *  (Mehrfach-Token `FK FD WC`, Grammatikformen), die drei
+		 *  Vergleichs-Editoren das Register-Kürzel `sms_code` — die
+		 *  Vergleichs-SMS rendert aus `get_sms_code()` (comparison.py). Eine
+		 *  flächenblinde Quelle würde den Vergleich falsch beschriften. Größen
+		 *  ohne Eintrag bekommen GAR KEINE Marke, keine leere (AC-9). */
+		kuerzelById: Record<string, string[]>;
 	}
 
 	let {
 		primaryColumns, metricById, friendlyMap, activeChannel, highlight, onRemove, onDndReorder, onMode,
-		offColumns, onRestore,
+		offColumns, onRestore, kuerzelById,
 	}: Props = $props();
 
 	const tgBudget = CHANNEL_COL_BUDGET.telegram;
@@ -74,6 +84,7 @@
 			{@const hl = highlight && highlight.id === id}
 			{@const hasInd = indicatorCapable(id)}
 			{@const useIndicator = friendlyMap[id] === true}
+			{@const kurzform = kuerzelById[id]}
 			{#if showCutLine && i === tgBudget}
 				<div data-testid="wm2-cut-line">
 					<LTCutLine label="Telegram" max={tgBudget} />
@@ -94,19 +105,23 @@
 							     Feld, dort bleibt die Zeile unveraendert. -->
 							<span class="aggregation-badge" data-testid="wm2-aggregation-badge">{m.aggregation_label}</span>
 						{/if}
-						<!-- Issue #1453 (AC-7): alle DREI Namensformen nebeneinander —
-						     ausgeschriebener deutscher Name (oben), englische
-						     Fachkurzform (Mail-Stundentabelle) und SMS-Kuerzel.
-						     Damit ist ein Kuerzel aus einer Mail ("Dew") oder einer
-						     SMS ("DP") im Editor aufloesbar. -->
+						<!-- Issue #1453 (AC-7) / #1719 S4: alle DREI Namensformen
+						     nebeneinander — ausgeschriebener deutscher Name (oben),
+						     englische Fachkurzform der Mail-Stundentabelle und ALLE
+						     Kuerzel der Kurzform. Seit S4 tragen die Marken ihre
+						     Beschriftung SICHTBAR ("Mail"/"Kurzform"): ein blosses
+						     "TF" ist nicht aufloesbar, solange der Nutzer nicht
+						     weiss, ob es in seiner Mail oder in seiner SMS steht. -->
 						{#if m.col_label}
-							<span class="col-badge mono" title="Kurzform in der Mail-Stundentabelle">
-								{m.col_label}
+							<span class="col-badge" data-testid="wm2-mail-badge" title="Kurzform in der Mail-Stundentabelle">
+								<span class="badge-key">Mail</span>
+								<span class="badge-val mono">{m.col_label}</span>
 							</span>
 						{/if}
-						{#if m.sms_code}
-							<span class="sms-badge mono" title="Kürzel in der SMS">
-								SMS {m.sms_code}
+						{#if kurzform && kurzform.length}
+							<span class="kurzform-badge" data-testid="wm2-kurzform-badge" title="Kürzel in SMS, Premium-SMS und Telegram">
+								<span class="badge-key">Kurzform</span>
+								<span class="badge-val mono">{kurzform.join(' ')}</span>
 							</span>
 						{/if}
 					{:else}
@@ -139,6 +154,7 @@
 			<div class="section-subhead aus-subhead">Aus in diesem Kanal</div>
 			{#each offColumns as id (id)}
 				{@const m = metricById[id]}
+				{@const kurzform = kuerzelById[id]}
 				<div class="row aus-row" data-testid="wm2-aus-row" data-metric-id={id}>
 					<div class="label-cell">
 						{#if m}
@@ -150,13 +166,15 @@
 								<span class="aggregation-badge" data-testid="wm2-aggregation-badge">{m.aggregation_label}</span>
 							{/if}
 							{#if m.col_label}
-								<span class="col-badge mono" title="Kurzform in der Mail-Stundentabelle">
-									{m.col_label}
+								<span class="col-badge" data-testid="wm2-mail-badge" title="Kurzform in der Mail-Stundentabelle">
+									<span class="badge-key">Mail</span>
+									<span class="badge-val mono">{m.col_label}</span>
 								</span>
 							{/if}
-							{#if m.sms_code}
-								<span class="sms-badge mono" title="Kürzel in der SMS">
-									SMS {m.sms_code}
+							{#if kurzform && kurzform.length}
+								<span class="kurzform-badge" data-testid="wm2-kurzform-badge" title="Kürzel in SMS, Premium-SMS und Telegram">
+									<span class="badge-key">Kurzform</span>
+									<span class="badge-val mono">{kurzform.join(' ')}</span>
 								</span>
 							{/if}
 						{:else}
@@ -236,6 +254,13 @@
 		gap: 0;
 		min-width: 0;
 	}
+	/* Issue #1719 S4: `min-width: 0` ist der eigentliche Fix — ohne ihn hat ein
+	   Flex-Element `min-width: auto` (= min-content, bei `nowrap` die volle
+	   Textbreite) und kann NICHT schrumpfen. Die Zelle holte sich den fehlenden
+	   Platz stattdessen bei den Marken, deren Inhalt dadurch beschnitten wurde.
+	   Bei Platzmangel kuerzt jetzt der NAME, nie ein Kuerzel: der Name ist der
+	   Klartext und bleibt auch angerissen erkennbar, das Kuerzel daneben ist
+	   die Aufloesung und waere beschnitten wertlos. */
 	.metric-label {
 		font-size: 13.5px;
 		font-weight: 500;
@@ -243,6 +268,8 @@
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
+		min-width: 0;
+		flex-shrink: 1;
 	}
 	.metric-unit {
 		font-size: 10.5px;
@@ -263,28 +290,40 @@
 		line-height: 1.6;
 		white-space: nowrap;
 	}
-	.col-badge {
+	/* Issue #1719 S4: die beiden Marken sind UNVERKUERZBAR. `flex-shrink: 0`
+	   plus `white-space: nowrap` ist die Zusicherung aus AC-12 — nimmt man sie
+	   heraus, wird der Inhalt der Marke zusammengedrueckt (`scrollWidth >
+	   clientWidth`) und der Browser-Nachweis rot. Das war der gemessene Defekt:
+	   unter 900px rettete `flex-wrap: wrap` alles, ab 900px gab es keinen
+	   Umbruch, und den Marken fehlte `flex-shrink: 0`. */
+	.col-badge,
+	.kurzform-badge {
 		font-size: 10px;
 		color: var(--g-ink-3);
 		background: var(--g-paper);
 		border: 1px solid var(--g-rule-soft);
 		border-radius: 3px;
 		padding: 0 4px;
-		margin-left: 6px;
-		line-height: 1.6;
-	}
-	/* Issue #1453: dritte Namensform. Gleiches Badge-Muster wie col-badge, mit
-	   vorangestelltem "SMS", damit die beiden Kuerzel nicht verwechselbar sind. */
-	.sms-badge {
-		font-size: 10px;
-		color: var(--g-ink-3);
-		background: var(--g-paper);
-		border: 1px solid var(--g-rule-soft);
-		border-radius: 3px;
-		padding: 0 4px;
-		margin-left: 4px;
 		line-height: 1.6;
 		white-space: nowrap;
+		flex-shrink: 0;
+	}
+	.col-badge {
+		margin-left: 6px;
+	}
+	.kurzform-badge {
+		margin-left: 4px;
+	}
+	/* Die Beschriftung gehoert IN die Marke, nicht ins title-Attribut: ein
+	   Kuerzel ohne sichtbare Herkunft ist nicht aufloesbar (der Nutzer weiss
+	   sonst nicht, ob "TF" in seiner Mail oder in seiner Kurzform steht).
+	   Unterscheidung ueber Schriftschnitt statt Farbe -- --g-ink-4 waere hier
+	   Hilfstext und ist dafuer gesperrt (Design-Leitprinzipien). */
+	.badge-key {
+		font-weight: 600;
+	}
+	.badge-val {
+		font-weight: 500;
 	}
 	.controls {
 		display: flex;
@@ -348,6 +387,20 @@
 		}
 		.label-cell {
 			flex-wrap: wrap;
+		}
+		/* Issue #1719 S4, Notausgang fuer schmale Fenster (320px): hier bricht
+		   die Zelle ohnehin um. Reicht eine ganze Zeile fuer eine Marke nicht
+		   aus, bricht sie ZWISCHEN ihren Kuerzeln um (`normal` bricht nur an
+		   Leerzeichen, `overflow-wrap: normal` nie innerhalb eines Kuerzels) --
+		   statt aus der Zeile zu ragen und die Seite waagerecht scrollen zu
+		   lassen. Alle Zeichen bleiben sichtbar, nur eben zweizeilig. Bewusst
+		   NUR hier: ab 900px muessen die Marken einzeilig und unverkuerzbar
+		   bleiben, sonst waere die Gegenprobe zu AC-12 blind. */
+		.col-badge,
+		.kurzform-badge {
+			white-space: normal;
+			overflow-wrap: normal;
+			max-width: 100%;
 		}
 		.controls {
 			flex-direction: column;

--- a/src/app/metric_catalog.py
+++ b/src/app/metric_catalog.py
@@ -13,7 +13,7 @@ Defines all available weather metrics with:
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Optional
 
@@ -587,6 +587,173 @@ _METRICS: list[MetricDefinition] = [
         # compact_label dieser Metrik (kollisionsfrei, mnemonisch).
         sms_code="NS", decimals=0, cmp="über", alert_label="Schnee",
     ),
+]
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Kurzform-Kürzel — EINE Quelle für SMS, Premium-SMS und Telegram (#1719 S4)
+# ═══════════════════════════════════════════════════════════════════════════
+# PO 2026-08-12: "Warum gibt es ein extra Telegram Kürzel? Das will ich nicht!"
+# `compact_label` (Telegram) wird deshalb ABGELEITET statt zweitgepflegt:
+# Vorgabe ist das Kürzel, das die Kurzform tatsächlich sendet; abweichen darf
+# nur, was in COMPACT_LABEL_EXCEPTIONS mit Begründung steht.
+#
+# Die Kürzel-Tabellen wohnen deshalb hier und nicht mehr in `sms_trip.py` --
+# der Katalog liest sie beim Ableiten, ein Import in die Gegenrichtung wäre
+# zirkulär (sms_trip -> metric_catalog). `sms_trip` re-exportiert sie unter
+# den bisherigen Namen; alle bestehenden Importstellen bleiben gültig.
+
+# Issue #624: metric_id -> SMS-Symbol für threshold-fähige Metriken.
+#
+# Issue #1435 E3b: keine gepflegte Kürzel-Liste mehr, sondern eine ABLEITUNG
+# aus dem zentralen Wetter-Register (`sms_code`). Damit kann diese Tabelle
+# nicht mehr vom Register abdriften. Die app-freie Formatschicht
+# `output/tokens/` darf das Register nicht lesen und führt die Kürzel dort
+# weiterhin als Literale (Schichtgrenze, abgesichert durch die Ratsche
+# tests/unit/test_sms_token_symbol_register_ratchet.py).
+# Issue #1660 Scheibe B Fix-Loop (Muster #1410, DEC-1): die 14 waehlbaren
+# Metriken als eigene, benannte Konstante -- Single Source fuer
+# _SMS_SYMBOL_METRIC_IDS UNTEN und fuer build_extended_metric_specs()
+# (sms_trip.py). Vorher standen dieselben 14 Ids literal in
+# _SMS_SYMBOL_METRIC_IDS UND in trip_report.py's disabled-only-Schleife -- das
+# Auseinanderdriften war genau die Ursache des Fix-Loop-Bugs (Root-Cause:
+# aktive Metriken bekamen NIE eine MetricSpec, nur abgewaehlte).
+SMS_NULLFORM_METRIC_IDS: tuple[str, ...] = (
+    "humidity",
+    "dewpoint",
+    "wind_direction",
+    "cape",
+    "precip_type",
+    "cloud_total",
+    "cloud_low",
+    "cloud_mid",
+    "cloud_high",
+    "visibility",
+    "sunshine",
+    "uv_index",
+    "pressure",
+    "freezing_level",
+)
+
+_SMS_SYMBOL_METRIC_IDS: tuple[str, ...] = (
+    "precipitation",
+    "rain_probability",
+    "wind",
+    "gust",
+    "thunder",
+    "snow_depth",
+    "snowfall_limit",
+    "fresh_snow",
+    # Issue #1660 Scheibe B: 14 waehlbare Metriken, bisher ohne SMS-Token.
+    # Alle 1:1 (kein Kuerzel-Mehrfach wie wind_chill) -> gehoeren in diese
+    # Register-Ableitung, NICHT in SMS_MULTI_SYMBOLS_BY_METRIC (DEC-1).
+    *SMS_NULLFORM_METRIC_IDS,
+)
+
+# Benannte Ausnahme von der Register-Ableitung: 'TH:' ist Grammatikform (der
+# Doppelpunkt trennt die Gewitter-Stufe vom Kürzel ab, builder.py:16), das
+# Register kennt nur 'TH'. Ausdrücklich NICHT durch #1435 E3b aufgehoben.
+# Fix #1450/Adversary-F001: 'fresh_snow' ebenso -- das Register-Kuerzel ist
+# 'NS', der tatsaechlich gerenderte Wintersport-Token ist 'NS24+'
+# (builder.py::_wintersport, '24+'-Suffix ist Grammatik fuer das
+# 24-Stunden-Fenster). Ohne diese Ausnahme wuerde SMS_SYMBOL_BY_METRIC das
+# falsche Symbol 'NS' fuehren, das nirgends mit dem gerenderten Token
+# uebereinstimmt -- die Abwahl (#944) griffe dadurch weiterhin nicht.
+SMS_SYMBOL_GRAMMAR: dict[str, str] = {"thunder": "TH:", "fresh_snow": "NS24+"}
+
+_SMS_CODE_BY_ID: dict[str, str] = {m.id: m.sms_code for m in _METRICS}
+
+SMS_SYMBOL_BY_METRIC: dict[str, str] = {
+    metric_id: SMS_SYMBOL_GRAMMAR.get(metric_id) or _SMS_CODE_BY_ID[metric_id]
+    for metric_id in _SMS_SYMBOL_METRIC_IDS
+}
+
+# Issue #1410: metric_id -> MEHRERE SMS-Kuerzel derselben Metrik. Eigene
+# Zuordnung, weil eine Metrik hier mehrere Symbole traegt (Nacht/Tiefst/
+# Hoechst) — SMS_SYMBOL_BY_METRIC bildet 1:1 ab und wird zusaetzlich fuer
+# Schwellwerte gelesen (#624), wo diese Symbole nichts zu suchen haben.
+# Fix #1450/Adversary-F001: 'WC' (Wintersport-Tageskennzahl, builder.py::
+# _wintersport) ergaenzt -- ohne diesen Eintrag baut trip_report.py:283-287
+# keinen disabled_specs-Eintrag fuer WC, und die Abwahl von "Gefuehlte
+# Temperatur" im Trip-Editor wirkt sich nicht auf WC aus.
+# Fix #1415 (PO-Entscheidung 2026-08-03): die GEMESSENE Temperatur folgt
+# derselben Regel -- 'N'/'K'/'D' hingen an keinem Eintrag und erschienen
+# deshalb auch bei abgewaehlter Metrik "Temperatur" (Beleg: Trip KHW 403,
+# "K13 D16 FK13 FD16 ..." bei ausgeschalteter Temperatur). Register-Kuerzel
+# taugen dafuer nicht: get_sms_code("temperature") == 'D' waere nur eines von
+# dreien, get_sms_code("temperature_cold") == 'N' gehoert zur internen
+# Alarm-Pseudogroesse (selectable=False), und ein Eintrag in
+# SMS_SYMBOL_BY_METRIC wuerde zusaetzlich einen Schwellwert auf 'D' legen
+# (#624), den es fuer Temperatur-Token gar nicht gibt. Daher hier, in der
+# frueher 'FELT' benannten Mehrfach-Tabelle.
+# Fix #1482: 'thunder' traegt ZWEI Kuerzel -- 'TH:' (berichtete Etappe) und
+# 'TH+:' (Folge-Etappe). 'TH+:' hing an keinem Eintrag und blieb deshalb auch
+# nach Abwahl der Metrik "Gewitter" in der Kurzform stehen. SMS_SYMBOL_BY_METRIC
+# bildet 1:1 ab (nur 'TH:') und wird zusaetzlich fuer Schwellwerte gelesen
+# (#624) -- ein zweiter Eintrag dort wuerde das Schwellwert-Dict verfaelschen.
+# Fix #1484 (PO-Entscheidung 2026-08-03): 'N' wandert von "temperature" zur
+# eigenen waehlbaren Groesse "temperature_night" -- Tages- und Nachttemperatur
+# sind zwei unabhaengige Auswahl-Entscheidungen (Zelt vs. Huette).
+# Fix #1660 Scheibe A: dieselbe Trennung jetzt auch auf der gefuehlten Seite --
+# 'FN' wandert von "wind_chill" zur eigenen waehlbaren Groesse
+# "wind_chill_night". 'WC' (Wintersport-Tageskennzahl) bleibt bewusst bei
+# "wind_chill" (Regression #1450, Spec-Abgrenzung 1).
+SMS_MULTI_SYMBOLS_BY_METRIC: dict[str, tuple[str, ...]] = {
+    "temperature": ("K", "D"),
+    "temperature_night": ("N",),
+    "wind_chill": ("FK", "FD", "WC"),
+    "wind_chill_night": ("FN",),
+    "thunder": ("TH:", "TH+:"),
+}
+
+# #1719 S4: die einzigen Größen, deren Telegram-Kürzel vom Kurzform-Kürzel
+# abweichen DARF. Wert = Begründung (Muster: SMS_SYMBOL_GRAMMAR oben,
+# `gz-eigenstaendig` aus #1481 B). Ein Eintrag ohne Satz ist keine Ausnahme --
+# der Wächter tests/unit/test_telegram_kuerzel_folgt_register.py besteht auf
+# einer lesbaren Begründung.
+COMPACT_LABEL_EXCEPTIONS: dict[str, str] = {
+    "temperature": (
+        "Die Telegram-Zelle zeigt einen STUNDENWERT. Das Register führt für "
+        "diese Größe Tagesauswertungen ('K' Tagestiefst, 'D' Tageshöchst) — "
+        "ein Spaltenkopf 'Tageshöchst' wäre über einem Stundenwert eine "
+        "falsche Aussage."
+    ),
+    "wind_chill": (
+        "Wie 'temperature': die Zelle zeigt einen Stundenwert, das Register "
+        "führt Tagesauswertungen ('FK'/'FD' Tiefst/Höchst, 'WC' "
+        "Wintersport-Tageskennzahl)."
+    ),
+}
+
+
+def _kurzform_kuerzel(metric_id: str, sms_code: str) -> Optional[str]:
+    """Das Kürzel, das die Kurzform (SMS/Premium-SMS) für diese Größe sendet.
+
+    ``None``, wenn die Kurzform für diese Größe gar kein Kürzel führt — dann
+    gibt es nichts zu vereinheitlichen und der gepflegte ``compact_label``
+    bleibt stehen.
+
+    Dieselbe Auflösung wie ``/api/sms-symbols::_symbols_for``: Mehrfach-Token
+    haben Vorrang, davon benennt das ERSTE die Größe (die weiteren benennen
+    Auswertungen); ``':'`` trennt nur eine Stufenangabe ab und gehört nicht
+    zum Kürzel.
+    """
+    mehrfach = SMS_MULTI_SYMBOLS_BY_METRIC.get(metric_id)
+    if mehrfach:
+        return mehrfach[0].rstrip(":")
+    if metric_id not in _SMS_SYMBOL_METRIC_IDS:
+        return None
+    return (SMS_SYMBOL_GRAMMAR.get(metric_id) or sms_code).rstrip(":")
+
+
+# Die Ableitung selbst: ab hier trägt jede MetricDefinition das Kürzel, das
+# der Nutzer in seiner Kurzform liest. Ein neuer Katalog-Eintrag kann damit
+# nicht mehr unbemerkt ein zweites Kürzel einführen.
+_METRICS = [
+    m if m.id in COMPACT_LABEL_EXCEPTIONS
+    else replace(
+        m, compact_label=_kurzform_kuerzel(m.id, m.sms_code) or m.compact_label
+    )
+    for m in _METRICS
 ]
 
 # Lookup by id

--- a/src/output/renderers/sms_trip.py
+++ b/src/output/renderers/sms_trip.py
@@ -19,7 +19,10 @@ from dataclasses import replace
 from typing import TYPE_CHECKING, Optional
 from zoneinfo import ZoneInfo
 
-from app.metric_catalog import get_sms_code
+from app.metric_catalog import (
+    SMS_MULTI_SYMBOLS_BY_METRIC,  # noqa: F401  Re-Export, s. #1719 S4 unten
+    SMS_NULLFORM_METRIC_IDS, SMS_SYMBOL_BY_METRIC,
+)
 from app.models import (
     ExposedSection, NormalizedTimeseries, PrecipType, RiskLevel, RiskType,
     SegmentWeatherData,
@@ -54,71 +57,12 @@ def _sms_stage_prefix(name: str) -> str:
 if TYPE_CHECKING:
     from app.models import WeatherChange
 
-# Issue #624: metric_id -> SMS-Symbol für threshold-fähige Metriken.
-#
-# Issue #1435 E3b: keine gepflegte Kürzel-Liste mehr, sondern eine ABLEITUNG
-# aus dem zentralen Wetter-Register (`metric_catalog.sms_code`). Damit kann
-# diese Tabelle nicht mehr vom Register abdriften. Die Renderer-Schicht darf
-# das Register lesen und tut es bereits (alert/render.py, comparison.py); die
-# app-freie Formatschicht `output/tokens/` darf es nicht und führt die Kürzel
-# dort weiterhin als Literale (Schichtgrenze, abgesichert durch die Ratsche
-# tests/unit/test_sms_token_symbol_register_ratchet.py).
-# Issue #1660 Scheibe B Fix-Loop (Muster #1410, DEC-1): die 14 waehlbaren
-# Metriken als eigene, benannte Konstante -- Single Source fuer
-# _SMS_SYMBOL_METRIC_IDS UNTEN und fuer build_extended_metric_specs() (s.
-# dort). Vorher standen dieselben 14 Ids literal in _SMS_SYMBOL_METRIC_IDS
-# UND in trip_report.py's disabled-only-Schleife -- das Auseinanderdriften
-# war genau die Ursache des Fix-Loop-Bugs (Root-Cause: aktive Metriken
-# bekamen NIE eine MetricSpec, nur abgewaehlte).
-SMS_NULLFORM_METRIC_IDS: tuple[str, ...] = (
-    "humidity",
-    "dewpoint",
-    "wind_direction",
-    "cape",
-    "precip_type",
-    "cloud_total",
-    "cloud_low",
-    "cloud_mid",
-    "cloud_high",
-    "visibility",
-    "sunshine",
-    "uv_index",
-    "pressure",
-    "freezing_level",
-)
-
-_SMS_SYMBOL_METRIC_IDS: tuple[str, ...] = (
-    "precipitation",
-    "rain_probability",
-    "wind",
-    "gust",
-    "thunder",
-    "snow_depth",
-    "snowfall_limit",
-    "fresh_snow",
-    # Issue #1660 Scheibe B: 14 waehlbare Metriken, bisher ohne SMS-Token.
-    # Alle 1:1 (kein Kuerzel-Mehrfach wie wind_chill) -> gehoeren in diese
-    # Register-Ableitung, NICHT in SMS_MULTI_SYMBOLS_BY_METRIC (DEC-1).
-    *SMS_NULLFORM_METRIC_IDS,
-)
-
-# Benannte Ausnahme von der Register-Ableitung: 'TH:' ist Grammatikform (der
-# Doppelpunkt trennt die Gewitter-Stufe vom Kürzel ab, builder.py:16), das
-# Register kennt nur 'TH'. Ausdrücklich NICHT durch #1435 E3b aufgehoben.
-# Fix #1450/Adversary-F001: 'fresh_snow' ebenso -- das Register-Kuerzel ist
-# 'NS' (metric_catalog.py:524), der tatsaechlich gerenderte Wintersport-Token
-# ist 'NS24+' (builder.py::_wintersport, '24+'-Suffix ist Grammatik fuer das
-# 24-Stunden-Fenster). Ohne diese Ausnahme wuerde SMS_SYMBOL_BY_METRIC das
-# falsche Symbol 'NS' fuehren, das nirgends mit dem gerenderten Token
-# uebereinstimmt -- die Abwahl (#944) griffe dadurch weiterhin nicht.
-_SMS_SYMBOL_GRAMMAR: dict[str, str] = {"thunder": "TH:", "fresh_snow": "NS24+"}
-
-SMS_SYMBOL_BY_METRIC: dict[str, str] = {
-    metric_id: _SMS_SYMBOL_GRAMMAR.get(metric_id) or get_sms_code(metric_id)
-    for metric_id in _SMS_SYMBOL_METRIC_IDS
-}
-
-
+# Issue #1719 S4: die Kürzel-Tabellen sind in den Katalog gewandert
+# (`app/metric_catalog.py`, Abschnitt "Kurzform-Kürzel"). Grund: seit S4 leitet
+# der Katalog `compact_label` (Telegram) aus ihnen ab — ein Import in dieser
+# Richtung wäre zirkulär. Fachlich unverändert; hier re-exportiert, damit alle
+# bestehenden Importstellen (trip_report.py, validator_render_service.py,
+# api/routers/config.py, Tests) weiter aus `sms_trip` lesen können.
 def build_extended_metric_specs(
     active_metric_ids: set[str],
     position_by_metric: Optional[dict[str, int]] = None,
@@ -146,44 +90,6 @@ def build_extended_metric_specs(
         for metric_id in SMS_NULLFORM_METRIC_IDS
     ]
 
-
-# Issue #1410: metric_id -> MEHRERE SMS-Kuerzel derselben Metrik. Eigene
-# Zuordnung, weil eine Metrik hier mehrere Symbole traegt (Nacht/Tiefst/
-# Hoechst) — SMS_SYMBOL_BY_METRIC bildet 1:1 ab und wird zusaetzlich fuer
-# Schwellwerte gelesen (#624), wo diese Symbole nichts zu suchen haben.
-# Fix #1450/Adversary-F001: 'WC' (Wintersport-Tageskennzahl, builder.py::
-# _wintersport) ergaenzt -- ohne diesen Eintrag baut trip_report.py:283-287
-# keinen disabled_specs-Eintrag fuer WC, und die Abwahl von "Gefuehlte
-# Temperatur" im Trip-Editor wirkt sich nicht auf WC aus.
-# Fix #1415 (PO-Entscheidung 2026-08-03): die GEMESSENE Temperatur folgt
-# derselben Regel -- 'N'/'K'/'D' hingen an keinem Eintrag und erschienen
-# deshalb auch bei abgewaehlter Metrik "Temperatur" (Beleg: Trip KHW 403,
-# "K13 D16 FK13 FD16 ..." bei ausgeschalteter Temperatur). Register-Kuerzel
-# taugen dafuer nicht: get_sms_code("temperature") == 'D' waere nur eines von
-# dreien, get_sms_code("temperature_cold") == 'N' gehoert zur internen
-# Alarm-Pseudogroesse (selectable=False), und ein Eintrag in
-# SMS_SYMBOL_BY_METRIC wuerde zusaetzlich einen Schwellwert auf 'D' legen
-# (#624), den es fuer Temperatur-Token gar nicht gibt. Daher hier, in der
-# frueher 'FELT' benannten Mehrfach-Tabelle.
-# Fix #1482: 'thunder' traegt ZWEI Kuerzel -- 'TH:' (berichtete Etappe) und
-# 'TH+:' (Folge-Etappe). 'TH+:' hing an keinem Eintrag und blieb deshalb auch
-# nach Abwahl der Metrik "Gewitter" in der Kurzform stehen. SMS_SYMBOL_BY_METRIC
-# bildet 1:1 ab (nur 'TH:') und wird zusaetzlich fuer Schwellwerte gelesen
-# (#624) -- ein zweiter Eintrag dort wuerde das Schwellwert-Dict verfaelschen.
-# Fix #1484 (PO-Entscheidung 2026-08-03): 'N' wandert von "temperature" zur
-# eigenen waehlbaren Groesse "temperature_night" -- Tages- und Nachttemperatur
-# sind zwei unabhaengige Auswahl-Entscheidungen (Zelt vs. Huette).
-# Fix #1660 Scheibe A: dieselbe Trennung jetzt auch auf der gefuehlten Seite --
-# 'FN' wandert von "wind_chill" zur eigenen waehlbaren Groesse
-# "wind_chill_night". 'WC' (Wintersport-Tageskennzahl) bleibt bewusst bei
-# "wind_chill" (Regression #1450, Spec-Abgrenzung 1).
-SMS_MULTI_SYMBOLS_BY_METRIC: dict[str, tuple[str, ...]] = {
-    "temperature": ("K", "D"),
-    "temperature_night": ("N",),
-    "wind_chill": ("FK", "FD", "WC"),
-    "wind_chill_night": ("FN",),
-    "thunder": ("TH:", "TH+:"),
-}
 
 # RiskType → SMS risk label (German, ultra-compact). Used by format_alert_sms.
 _SMS_RISK_LABELS: dict[tuple[RiskType, RiskLevel], str] = {

--- a/tests/tdd/test_issue_1001_telegram_bubbles.py
+++ b/tests/tdd/test_issue_1001_telegram_bubbles.py
@@ -723,16 +723,44 @@ class TestF001OverviewThunderMatchesFooterWorstValue:
         assert len(bubbles) >= 2, f"Erwarte mindestens Kopf+Kurzübersicht, waren {len(bubbles)}"
         overview_text = bubbles[1].text
 
-        thunder_lines = [ln for ln in overview_text.splitlines() if ln.startswith("⚡")]
-        assert thunder_lines, f"Keine Gewitter-Zeile (⚡) in der Kurzübersicht-Bubble:\n{overview_text}"
+        # Issue #1719 S4: die Kurzuebersicht-ZEILE traegt seit der Kuerzel-
+        # Vereinheitlichung das Kurzform-Kuerzel der Groesse ("TH"), die
+        # FUSSZEILE weiterhin das feste Zeichen "⚡" (narrow.py:280, kein
+        # Katalogfeld). Wer die Zeile weiterhin ueber "⚡" auswaehlt, trifft
+        # die Fusszeile — und weil beide "hoch" tragen, bliebe dieser Test
+        # gruen, waehrend der F001-Bug (`hits[-1]` statt Tages-Schlimmstwert)
+        # laengst wieder da waere. Nachgemessen 2026-08-12: mit der alten
+        # Auswahl faengt er die reaktivierte Regression NICHT.
+        # Das Kuerzel wird deshalb aus dem Katalog GEHOLT, nicht abgetippt.
+        from app.metric_catalog import get_metric
+        tg_kuerzel = get_metric("thunder").compact_label
 
-        # Die ERSTE ⚡-Zeile ist die _overview_line("thunder", ...)-Zeile — genau
-        # die Stelle des F001-Bugs (`hits[-1]` statt Tages-Schlimmstwert).
+        thunder_lines = [
+            ln for ln in overview_text.splitlines()
+            if ln.startswith(f"{tg_kuerzel} ") or ln.startswith("⚡")
+        ]
+        assert thunder_lines, (
+            f"Keine Gewitter-Zeile ({tg_kuerzel}/⚡) in der Kurzübersicht-Bubble:"
+            f"\n{overview_text}"
+        )
+
+        overview_lines = [
+            ln for ln in thunder_lines if ln.startswith(f"{tg_kuerzel} ")
+        ]
+        assert overview_lines, (
+            f"Keine Kurzuebersicht-Gewitterzeile ({tg_kuerzel}) gefunden — nur "
+            f"{thunder_lines!r}. Traegt die Zeile ein anderes Kuerzel, ist die "
+            f"Auswahl anzupassen, NICHT die Pruefung."
+        )
+
+        # Die erste Zeile mit dem Groessen-Kuerzel ist die
+        # _overview_line("thunder", ...)-Zeile — genau die Stelle des
+        # F001-Bugs (`hits[-1]` statt Tages-Schlimmstwert).
         # Issue #1491: Gewitter ist eine reguläre Ampel-Spalte geworden --
         # HIGH rendert als deutsches Wort "hoch" (THUNDER_LABEL_DE), nicht
         # mehr als Blitzsymbol "⚡⚡" (siehe email/helpers.py fmt_val
         # key=="thunder"). NONE als "–".
-        overview_thunder_line = thunder_lines[0]
+        overview_thunder_line = overview_lines[0]
         assert "hoch" in overview_thunder_line, (
             f"F001-Regression: Kurzübersicht-Gewitterzeile zeigt nicht das "
             f"Wort 'hoch' (Tages-Schlimmstwert, Issue #1491), sondern "
@@ -740,7 +768,7 @@ class TestF001OverviewThunderMatchesFooterWorstValue:
             f"Wert 'NONE'/'–' des letzten Segments statt des "
             f"Tages-Schlimmstwerts). Ganze Bubble:\n{overview_text}"
         )
-        assert overview_thunder_line.strip() != "⚡ –", (
+        assert overview_thunder_line.strip() != f"{tg_kuerzel} –", (
             f"Widerspruch (F001): Kurzübersicht zeigt 'kein Gewitter' (–), "
             f"obwohl ein Segment HIGH meldete: {overview_thunder_line!r}"
         )
@@ -752,10 +780,12 @@ class TestF001OverviewThunderMatchesFooterWorstValue:
         # zeigt seit jeher das deutsche Wort (THUNDER_LABEL_DE, #1474b), nicht
         # den englischen Enum-Namen "HIGH" — diese Erwartung war bereits vor
         # #1491 veraltet, nur von der frueheren "⚡⚡"-Assertion maskiert.
-        footer_thunder_line = next((ln for ln in thunder_lines if "Sicht" in ln), None)
+        footer_thunder_line = next(
+            (ln for ln in thunder_lines if ln.startswith("⚡") and "Sicht" in ln), None
+        )
         assert footer_thunder_line is not None, f"Keine Fußzeile mit ⚡ gefunden: {thunder_lines}"
         assert "hoch" in footer_thunder_line, f"Fußzeile zeigt nicht 'hoch': {footer_thunder_line!r}"
-        overview_says_none = overview_thunder_line.strip() == "⚡ –"
+        overview_says_none = overview_thunder_line.strip() == f"{tg_kuerzel} –"
         footer_says_none = "kein" in footer_thunder_line
         assert not (overview_says_none and not footer_says_none), (
             f"Widersprüchliche Gewitter-Aussagen in derselben Bubble: "

--- a/tests/unit/test_sms_aenderungs_token_kuerzel.py
+++ b/tests/unit/test_sms_aenderungs_token_kuerzel.py
@@ -1,0 +1,116 @@
+"""Die Aenderungs-Token der SMS tragen das SMS-Kuerzel, nicht das Telegram-Kuerzel.
+
+Issue #1719 Scheibe S4, AC-4 — Spec
+docs/specs/modules/fix_1719_s4_kuerzel_vereinheitlichung.md.
+
+Gemessener Ist-Stand (Kontext-Dokument, Abschnitt "Die Systeme sind schon
+heute in derselben Nachricht gemischt"): ``SMSTripFormatter.format_alert_sms``
+baut seine Token ueber ``metric_catalog.get_compact_label_for_field()`` — also
+aus ``compact_label``, dem TELEGRAM-Kuerzel. Eine SMS traegt damit heute Token
+aus beiden Systemen nebeneinander: der Stundenwert der Luftfeuchtigkeit
+erscheint als ``HU``, ihre Aenderung als ``H``.
+
+Fuer den Nutzer heisst das: zwei Kuerzel fuer dieselbe Groesse in DERSELBEN
+Nachricht — und eines davon steht in keiner Legende.
+
+Erwartung aus Nutzersicht: das Aenderungs-Token traegt dasselbe Kuerzel wie
+derselbe Wert an anderer Stelle. Gerechnet aus ``SMS_SYMBOL_BY_METRIC`` /
+``SMS_MULTI_SYMBOLS_BY_METRIC``, nicht abgetippt.
+
+KEINE Mocks: echte ``WeatherChange``-Objekte, echter Renderaufruf.
+
+Ausfuehren:
+  uv run pytest tests/unit/test_sms_aenderungs_token_kuerzel.py
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def _sms_kuerzel(metric_id: str) -> str:
+    """Das Kuerzel, das die Trip-SMS fuer diese Groesse sendet (MULTI hat
+    Vorrang, ``rstrip(":")`` entfernt die Grammatik-Trennung) — dieselbe
+    Aufloesung wie ``/api/sms-symbols::_symbols_for``."""
+    from output.renderers.sms_trip import (
+        SMS_MULTI_SYMBOLS_BY_METRIC, SMS_SYMBOL_BY_METRIC,
+    )
+    if metric_id in SMS_MULTI_SYMBOLS_BY_METRIC:
+        return SMS_MULTI_SYMBOLS_BY_METRIC[metric_id][0].rstrip(":")
+    return SMS_SYMBOL_BY_METRIC[metric_id].rstrip(":")
+
+
+def _aenderungs_sms(metric_id: str, summary_field: str, delta: float) -> str:
+    """Rendert eine echte Aenderungs-SMS ueber den Produktionspfad."""
+    from app.models import ChangeSeverity, WeatherChange
+    from output.renderers.sms_trip import SMSTripFormatter
+
+    change = WeatherChange(
+        metric=summary_field,
+        old_value=40.0, new_value=40.0 + delta, delta=delta,
+        threshold=10.0, severity=ChangeSeverity.MODERATE,
+        direction="increase" if delta > 0 else "decrease",
+    )
+    return SMSTripFormatter().format_alert_sms([change], "KHW", max_length=160)
+
+
+# Groessen, deren Aenderung die SMS ueberhaupt melden kann (sie brauchen ein
+# `summary_fields`-Feld) UND die genau EIN rein alphabetisches SMS-Kuerzel
+# tragen. Damit bleiben die beiden benannten Ausnahmen (Temperatur, Gefuehlte
+# Temperatur — dort fuehrt die SMS Tagesauswertungen `K`/`D` bzw. `FK`/`FD`)
+# und die Grammatikform `NS24+` (Neuschnee, 24-Stunden-Fenster) aussen vor:
+# beide sind keine reine Umbenennung und gehoeren nicht in diese Frage.
+_EINDEUTIGE = [
+    ("humidity", "humidity_avg_pct"),
+    ("cloud_total", "cloud_avg_pct"),
+    ("visibility", "visibility_min_m"),
+    ("pressure", "pressure_avg_hpa"),
+    ("freezing_level", "freezing_level_m"),
+    ("rain_probability", "pop_max_pct"),
+    ("snowfall_limit", "snowfall_limit_m"),
+]
+
+
+@pytest.mark.parametrize("metric_id,summary_field", _EINDEUTIGE)
+def test_aenderungs_token_traegt_das_sms_kuerzel(metric_id, summary_field):
+    """AC-4: Given ein Trip, dessen SMS ein Aenderungs-Token enthaelt (z.B.
+    Luftfeuchtigkeit steigt) / When die SMS gerendert wird / Then traegt das
+    Token dasselbe Kuerzel, das die SMS fuer diese Groesse auch sonst sendet —
+    kein Token aus dem alten Telegram-System."""
+    erwartet = _sms_kuerzel(metric_id)
+    text = _aenderungs_sms(metric_id, summary_field, delta=+15.0)
+
+    token = [t for t in text.split() if t.startswith("+") is False and "+" in t]
+    assert token, f"Kein Aenderungs-Token in der SMS gefunden: {text!r}"
+    gerendert = token[-1]
+    assert gerendert.startswith(erwartet), (
+        f"AC-4 FAIL ({metric_id}): das Aenderungs-Token der SMS lautet "
+        f"{gerendert!r}, die SMS sendet diese Groesse sonst als {erwartet!r}. "
+        f"Zwei Kuerzel fuer dieselbe Groesse in derselben Nachricht.\n"
+        f"Gerenderte SMS: {text!r}"
+    )
+
+
+def test_umkehrsuche_liefert_fuer_jede_eindeutige_groesse_das_sms_kuerzel():
+    """AC-4, Wirkort statt Aufrufstelle: die Umkehrsuche
+    ``get_compact_label_for_field()`` ist die EINE Quelle der Aenderungs-Token
+    (sms_trip.py, `format_alert_sms`). Sie muss fuer jede eindeutig
+    bekuerzelte Groesse das SMS-Kuerzel liefern — sonst faellt derselbe Fehler
+    beim naechsten Aufrufer wieder an."""
+    from app.metric_catalog import get_compact_label_for_field
+
+    abweichungen = []
+    for metric_id, summary_field in _EINDEUTIGE:
+        treffer = get_compact_label_for_field(summary_field)
+        assert treffer is not None, (
+            f"Testaufbau: '{summary_field}' ist im Katalog keiner Groesse "
+            "zugeordnet — Feldname pruefen."
+        )
+        if treffer[0] != _sms_kuerzel(metric_id):
+            abweichungen.append(
+                f"{metric_id}: Umkehrsuche liefert {treffer[0]!r}, "
+                f"die SMS sendet {_sms_kuerzel(metric_id)!r}"
+            )
+    assert not abweichungen, (
+        "AC-4 FAIL — die Umkehrsuche der Aenderungs-Token spricht das alte "
+        "Telegram-Vokabular:\n  " + "\n  ".join(abweichungen)
+    )

--- a/tests/unit/test_telegram_kuerzel_folgt_register.py
+++ b/tests/unit/test_telegram_kuerzel_folgt_register.py
@@ -349,12 +349,19 @@ def test_kein_telegram_kuerzel_weicht_unbegruendet_von_der_sms_ab():
     ],
 )
 def test_waechter_faengt_einen_neuen_katalogeintrag(ausnahmen, soll_rot, warum):
-    """AC-2, Zaehne des Waechters: ein KUENSTLICHER Katalog-Eintrag mit
-    abweichendem `compact_label` und ohne begruendete Ausnahme macht ihn rot.
+    """WERKZEUG-SELBSTTEST, KEIN AC-2-NACHWEIS — bitte nicht verwechseln.
 
-    Ohne diese Gegenprobe waere `test_kein_telegram_kuerzel_weicht_...` nur
-    eine Momentaufnahme des heutigen Bestands: gruen, sobald jemand einmal
-    aufgeraeumt hat, und blind fuer den naechsten Eintrag."""
+    Geprueft wird ``pruefe_kuerzel`` (oben in DIESER Datei definiert), nicht
+    der Produktivcode: ein KUENSTLICHER Katalog-Eintrag mit abweichendem
+    `compact_label` und ohne begruendete Ausnahme muss den Waechter rot machen.
+    Deshalb ist dieser Test heute gruen und bleibt es — er belegt kein
+    Produktivverhalten.
+
+    Sein Zweck ist die Gegenprobe zum eigentlichen AC-2-Waechter
+    (``test_kein_telegram_kuerzel_weicht_unbegruendet_von_der_sms_ab``, rot):
+    ohne ihn waere jener nur eine Momentaufnahme des heutigen Bestands — gruen,
+    sobald jemand einmal aufgeraeumt hat, und blind fuer den naechsten Eintrag.
+    Ein Waechter, der nur auf dem heutigen Bestand gruen ist, bewacht nichts."""
     kuenstlich = [("nebelbank", "NB", "FG")]
     verstoesse = pruefe_kuerzel(kuenstlich, ausnahmen)
     assert bool(verstoesse) is soll_rot, (

--- a/tests/unit/test_telegram_kuerzel_folgt_register.py
+++ b/tests/unit/test_telegram_kuerzel_folgt_register.py
@@ -371,6 +371,61 @@ def test_waechter_faengt_einen_neuen_katalogeintrag(ausnahmen, soll_rot, warum):
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+# AC-2, Grammatikformen (Adversary Runde 2, F004)
+#
+# Der Waechter oben rechnet BEIDE Seiten aus denselben Tabellen und ist
+# gegenueber den Grammatik-Ausnahmen damit selbstbezueglich: entfernt man sie,
+# aendern sich Soll UND Ist gleichzeitig, und er bleibt gruen. Gefangen wurde
+# das bisher nur von einer thematisch fremden Datei
+# (tests/tdd/test_sms_snow_symbols.py). Die Grammatikformen sind aber Teil der
+# Kuerzel-Wahrheit, die S4 zusichert — der Nutzer liest 'NS24+' in seiner SMS
+# und muss genau das im Editor wiederfinden. Deshalb hier, mit ausdruecklichen
+# Sollwerten und Begruendung.
+# ═══════════════════════════════════════════════════════════════════════════
+
+_GRAMMATIKFORMEN = [
+    ("thunder", "TH:", "der Doppelpunkt trennt die Gewitter-Stufe vom Kuerzel"),
+    ("fresh_snow", "NS24+", "'24+' benennt das 24-Stunden-Fenster des Neuschnees"),
+]
+
+
+@pytest.mark.parametrize("metric_id,erwartet,grund", _GRAMMATIKFORMEN)
+def test_grammatikform_ueberschreibt_das_register_kuerzel(metric_id, erwartet, grund):
+    """AC-2: Given eine Groesse, deren gesendetes Kuerzel eine Grammatikform
+    traegt / When das Kuerzel-Register aufgeloest wird / Then gilt die
+    Grammatikform, NICHT das nackte Register-Kuerzel — sonst nennt die
+    Oberflaeche ein Kuerzel, das in keiner Nachricht so vorkommt."""
+    from app.metric_catalog import get_sms_code
+    from output.renderers.sms_trip import SMS_SYMBOL_BY_METRIC
+
+    ist = SMS_SYMBOL_BY_METRIC[metric_id]
+    assert ist == erwartet, (
+        f"F004 FAIL ({metric_id}): die Kurzform sendet {ist!r}, erwartet ist "
+        f"{erwartet!r} — {grund}. Wurde die Grammatik-Ausnahme entfernt, faellt "
+        f"das Kuerzel auf das nackte Register zurueck und stimmt mit nichts "
+        f"mehr ueberein, was der Nutzer wirklich liest."
+    )
+    assert ist != get_sms_code(metric_id), (
+        f"F004 FAIL ({metric_id}): Grammatikform und Register-Kuerzel sind "
+        f"identisch ({ist!r}). Dann ist die Ausnahme wirkungslos geworden — "
+        f"entweder ist sie verschwunden, oder das Register wurde ihr "
+        f"angeglichen. Beides macht diesen Wachhund blind."
+    )
+
+
+def test_neuschnee_traegt_die_grammatikform_auch_in_telegram():
+    """AC-1/AC-2: Given Neuschnee / When die Telegram-Stundentabelle gerendert
+    wird / Then steht dort 'NS24+' — dasselbe, was die SMS sendet. Ohne die
+    Grammatik-Ausnahme stuende dort 'NS', ein Kuerzel, das in keiner Nachricht
+    vorkommt (Spec-Tabelle, Zeile 'Neuschnee NS -> NS24+')."""
+    kopf = _tabellenkopf(["fresh_snow"])
+    assert kopf == ["NS24+"], (
+        f"F004 FAIL: Spaltenkopf {kopf} statt ['NS24+']. Die Telegram-Tabelle "
+        "nennt eine Groesse anders, als die SMS sie sendet."
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 # AC-9 — eine Groesse ohne Kuerzel bekommt keines angedichtet
 #
 # Der Editor speist die Kurzform-Marke aus /api/sms-symbols (Spec Abschnitt 3).

--- a/tests/unit/test_telegram_kuerzel_folgt_register.py
+++ b/tests/unit/test_telegram_kuerzel_folgt_register.py
@@ -1,0 +1,398 @@
+"""Ein Kuerzel je Groesse: Telegram spricht dieselbe Sprache wie die SMS.
+
+Issue #1719 Scheibe S4 — Spec docs/specs/modules/fix_1719_s4_kuerzel_vereinheitlichung.md
+(AC-1, AC-2, AC-3). PO woertlich (2026-08-12): "Warum gibt es ein extra
+Telegram Kuerzel? Das will ich nicht!"
+
+Heute pflegt der Katalog ZWEI Kuerzel je Groesse von Hand: ``compact_label``
+(Telegram) und ``sms_code`` (Register). Gemessen sind 11 von 25 Groessen
+auseinandergelaufen — Luftdruck heisst in Telegram ``P``, in der SMS ``HP``;
+die Regenwahrscheinlichkeit ``P%`` gegen ``PR``. Niemand haelt die beiden
+Tabellen synchron, also driften sie.
+
+**Das Soll-Kuerzel ist das, was die Trip-SMS TATSAECHLICH sendet** — also
+``SMS_MULTI_SYMBOLS_BY_METRIC`` (Vorrang) bzw. ``SMS_SYMBOL_BY_METRIC``, beide
+in ``output/renderers/sms_trip.py``. Nicht ``sms_code`` allein: bei
+``temperature_night`` fuehrt das Register ``TN``, gesendet wird aber ``N``
+(Spec, Abschnitt 1, Zeile "Nacht-Tiefsttemperatur ... kuenftig N"), und bei
+``fresh_snow`` fuehrt das Register ``NS``, gesendet wird ``NS24+``. Genau diese
+zwei Faelle sind der Kern des gemeldeten Defekts ("das Badge nennt ein Kuerzel,
+das in keiner Trip-SMS auftaucht"), sie duerfen also nicht wegdefiniert werden.
+Fuer die uebrigen 23 Groessen faellt beides zusammen.
+
+Zwei benannte Ausnahmen bleiben (Spec Abschnitt 1): ``temperature`` (``T``) und
+``wind_chill`` (``TF``). Das Register fuehrt dort TAGESAUSWERTUNGEN (``K``/``D``
+bzw. ``FK``/``FD``/``WC``); die Telegram-Zelle zeigt einen STUNDENWERT — ein
+Spaltenkopf "Tageshoechst" waere dort eine falsche Aussage.
+
+KEINE Mocks, KEIN Dateiinhalt-Check: echte Model-Objekte, echter Renderaufruf
+(``render_telegram_bubbles``), Nutzersicht auf den Bubble-Text. Die Erwartung
+wird aus den SMS-Tabellen GERECHNET, nicht abgetippt (Spec AC-1: "gegen
+SMS_SYMBOL_BY_METRIC gerechnet").
+
+Ausfuehren:
+  uv run pytest tests/unit/test_telegram_kuerzel_folgt_register.py
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+import pytest
+
+_TZ = ZoneInfo("Europe/Berlin")
+
+# Mindestlaenge einer Ausnahme-Begruendung. Muster: die `gz-eigenstaendig`-/
+# `gz-main-path`-Ausnahmen der Commit-Waechter (#1409/#1481 B) verlangen
+# ebenfalls 15 sinnvolle Zeichen — eine Ausnahme ohne Satz ist keine.
+_MIN_BEGRUENDUNG = 15
+
+# Kandidaten-Namen fuer die benannte Ausnahmeliste im Katalog. Der erste
+# gefundene gewinnt; `COMPACT_LABEL_EXCEPTIONS` ist der vorgeschlagene Name.
+# Die Liste gehoert laut Spec ("Implementation Details") NEBEN die
+# `MetricDefinition` in `app/metric_catalog.py` — eine Quelle, nicht zwei.
+_AUSNAHMELISTE_NAMEN = (
+    "COMPACT_LABEL_EXCEPTIONS",
+    "COMPACT_LABEL_AUSNAHMEN",
+    "TELEGRAM_KUERZEL_AUSNAHMEN",
+    "_COMPACT_LABEL_EXCEPTIONS",
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Soll-Kuerzel: gerechnet aus den Tabellen, aus denen die SMS wirklich rendert
+# ═══════════════════════════════════════════════════════════════════════════
+
+def _soll_kuerzel(metric_id: str) -> Optional[str]:
+    """Das Kuerzel, das die Trip-SMS fuer ``metric_id`` tatsaechlich sendet.
+
+    Dieselbe Aufloesung wie ``/api/sms-symbols::_symbols_for``
+    (api/routers/config.py): MULTI hat Vorrang, ``rstrip(":")`` entfernt die
+    Grammatik-Trennung ("TH:" -> "TH"). Bei Mehrfach-Token gilt das ERSTE als
+    Kuerzel der Groesse — die weiteren benennen Auswertungen (Tiefst/Hoechst).
+    """
+    from output.renderers.sms_trip import (
+        SMS_MULTI_SYMBOLS_BY_METRIC, SMS_SYMBOL_BY_METRIC,
+    )
+    if metric_id in SMS_MULTI_SYMBOLS_BY_METRIC:
+        return SMS_MULTI_SYMBOLS_BY_METRIC[metric_id][0].rstrip(":")
+    if metric_id in SMS_SYMBOL_BY_METRIC:
+        return SMS_SYMBOL_BY_METRIC[metric_id].rstrip(":")
+    return None
+
+
+def _ausnahmeliste() -> Optional[dict[str, str]]:
+    """Die benannte Ausnahmeliste aus dem Katalog, oder None wenn es keine gibt."""
+    import app.metric_catalog as katalog
+    for name in _AUSNAHMELISTE_NAMEN:
+        wert = getattr(katalog, name, None)
+        if isinstance(wert, dict):
+            return wert
+    return None
+
+
+def pruefe_kuerzel(
+    eintraege: list[tuple[str, str, Optional[str]]],
+    ausnahmen: dict[str, str],
+) -> list[str]:
+    """Reine Pruefregel — liefert je Verstoss eine lesbare Zeile.
+
+    ``eintraege``: (metric_id, compact_label, soll_kuerzel). Als eigene
+    Funktion, damit derselbe Wachhund unten an einem KUENSTLICHEN Katalog-
+    Eintrag vorgefuehrt werden kann: ein Waechter, der nur auf dem heutigen
+    Bestand gruen ist, bewacht nichts (Mutations-Gegenprobe).
+    """
+    verstoesse: list[str] = []
+    for metric_id, compact_label, soll in eintraege:
+        if soll is None:
+            continue  # Groesse ohne SMS-Kuerzel — nichts zu vereinheitlichen
+        if metric_id in ausnahmen:
+            begruendung = str(ausnahmen[metric_id]).strip()
+            if len(begruendung) < _MIN_BEGRUENDUNG:
+                verstoesse.append(
+                    f"{metric_id}: steht in der Ausnahmeliste, aber ohne "
+                    f"Begruendung (>= {_MIN_BEGRUENDUNG} Zeichen), war: "
+                    f"{begruendung!r}"
+                )
+            continue
+        if compact_label != soll:
+            verstoesse.append(
+                f"{metric_id}: Telegram sendet {compact_label!r}, die SMS "
+                f"sendet {soll!r} — dieselbe Groesse, zwei Kuerzel. Entweder "
+                f"gleichziehen oder mit Begruendung in die Ausnahmeliste."
+            )
+    return verstoesse
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fixture: ein echter Renderaufruf, keine Attrappe
+# ═══════════════════════════════════════════════════════════════════════════
+
+def _segment():
+    from app.models import (
+        ForecastDataPoint, ForecastMeta, GPXPoint, NormalizedTimeseries,
+        Provider, SegmentWeatherData, SegmentWeatherSummary, TripSegment,
+    )
+    seg = TripSegment(
+        segment_id=1,
+        start_point=GPXPoint(lat=46.5, lon=8.1, elevation_m=1800.0,
+                             distance_from_start_km=0.0),
+        end_point=GPXPoint(lat=46.6, lon=8.2, elevation_m=2400.0,
+                           distance_from_start_km=6.0),
+        start_time=datetime(2026, 7, 3, 6, 0, tzinfo=timezone.utc),
+        end_time=datetime(2026, 7, 3, 10, 0, tzinfo=timezone.utc),
+        duration_hours=4.0, distance_km=6.0, ascent_m=600.0, descent_m=0.0,
+    )
+    meta = ForecastMeta(
+        provider=Provider.OPENMETEO, model="icon_d2",
+        run=datetime(2026, 7, 3, 0, 0, tzinfo=timezone.utc),
+        grid_res_km=2.0, interp="point_grid",
+    )
+    dps = [
+        ForecastDataPoint(ts=datetime(2026, 7, 3, h, 0, tzinfo=timezone.utc))
+        for h in (6, 7, 8, 9)
+    ]
+    agg = SegmentWeatherSummary(
+        temp_min_c=12.0, temp_max_c=14.0, wind_max_kmh=8.0,
+        precip_sum_mm=0.0, cloud_avg_pct=40,
+    )
+    return SegmentWeatherData(
+        segment=seg, timeseries=NormalizedTimeseries(meta=meta, data=dps),
+        aggregated=agg, fetched_at=datetime.now(timezone.utc),
+        provider="openmeteo",
+    )
+
+
+def _dc(metric_ids: list[str]):
+    from app.models import MetricConfig, UnifiedWeatherDisplayConfig
+    return UnifiedWeatherDisplayConfig(
+        trip_id="e2e-1719-s4",
+        metrics=[
+            MetricConfig(metric_id=m, enabled=True, bucket="primary", order=i)
+            for i, m in enumerate(metric_ids)
+        ],
+        updated_at=datetime.now(timezone.utc),
+    )
+
+
+# Werte je col_key des Katalogs — bewusst schmal, damit die 32-Zeichen-Grenze
+# der Telegram-Tabelle (`narrow._TG_TABLE_WIDTH`) die Kopfzeile nicht umbricht.
+_ZELLWERTE = {
+    "humidity": 60, "cloud": 40, "visibility": 8000, "pressure": 1013,
+    "freeze_lvl": 3200, "temp": 14, "felt": 12,
+}
+
+
+def _tabellenkopf(metric_ids: list[str]) -> list[str]:
+    """Rendert das Briefing und liefert die Spaltenkoepfe der Stundentabelle."""
+    from output.renderers.narrow import render_telegram_bubbles
+
+    rows = [
+        {"time": f"{h:02d}", **_ZELLWERTE} for h in (6, 7, 8, 9)
+    ]
+    bubbles = render_telegram_bubbles(
+        segments=[_segment()], seg_tables=[rows], dc=_dc(metric_ids),
+        report_type="evening", tz=_TZ, trip_name="Kuerzel S4",
+    )
+    tabellen = [b.text for b in bubbles if "<pre>" in b.text]
+    assert tabellen, (
+        "Kein <pre>-Tabellenblock im Briefing — der Testaufbau erreicht den "
+        f"geprueften Renderpfad nicht. Bubbles: {[b.text[:40] for b in bubbles]}"
+    )
+    kopfzeile = tabellen[0].split("<pre>", 1)[1].lstrip("\n").splitlines()[0]
+    kopf = kopfzeile.split()
+    assert len(kopf) == 1 + len(metric_ids), (
+        f"Kopfzeile {kopfzeile!r} hat {len(kopf)} statt {1 + len(metric_ids)} "
+        "Spalten — vermutlich umgebrochen. Testaufbau anpassen (schmalere "
+        "Zellwerte oder weniger Metriken), nicht die Erwartung lockern."
+    )
+    assert kopf[0] == "Zt", f"Erste Spalte ist die Zeit, war: {kopf!r}"
+    return kopf[1:]
+
+
+def _kurzuebersicht(metric_ids: list[str]) -> str:
+    from output.renderers.narrow import render_telegram_bubbles
+
+    rows = [{"time": f"{h:02d}", **_ZELLWERTE} for h in (6, 7, 8, 9)]
+    bubbles = render_telegram_bubbles(
+        segments=[_segment()], seg_tables=[rows], dc=_dc(metric_ids),
+        report_type="evening", tz=_TZ, trip_name="Kuerzel S4",
+    )
+    return next(b.text for b in bubbles if "Kurzübersicht" in b.text)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC-1 — die Stundentabelle traegt die SMS-Kuerzel
+# ═══════════════════════════════════════════════════════════════════════════
+
+_AC1_IDS = ["humidity", "cloud_total", "visibility", "pressure", "freezing_level"]
+
+
+def test_telegram_spaltenkoepfe_tragen_die_kuerzel_der_sms():
+    """AC-1: Given ein Briefing mit Luftfeuchtigkeit, Bewoelkung, Sichtweite,
+    Luftdruck und Nullgradgrenze / When die Telegram-Stundentabelle gerendert
+    wird / Then tragen die Spaltenkoepfe genau die Kuerzel, die die SMS fuer
+    diese Groessen sendet (heute: H/C/V/P/0G gegen HU/CT/VS/HP/NL)."""
+    erwartet = [_soll_kuerzel(m) for m in _AC1_IDS]
+    assert all(erwartet), f"Testaufbau: Groesse ohne SMS-Kuerzel in {_AC1_IDS}"
+
+    kopf = _tabellenkopf(_AC1_IDS)
+    assert kopf == erwartet, (
+        "AC-1 FAIL: die Telegram-Stundentabelle spricht eine andere Sprache "
+        f"als die SMS.\n  Telegram: {kopf}\n  SMS:      {erwartet}\n"
+        "Der Nutzer liest in der SMS ein Kuerzel, das er in der Telegram-"
+        "Tabelle nicht wiederfindet."
+    )
+
+
+def test_telegram_kurzuebersicht_traegt_die_kuerzel_der_sms():
+    """AC-1, zweiter Wirkort: dieselbe Zusicherung fuer die Kurzuebersicht-
+    Bubble (`narrow._overview_line`) — sie liest denselben `compact_label`,
+    steht aber in einer anderen Bubble. Ein Fix nur an der Tabelle waere an
+    der Stelle richtig, an der der Code steht, und falsch dort, wo er wirkt."""
+    text = _kurzuebersicht(_AC1_IDS)
+    zeilen_anfaenge = [
+        z.split(" ", 1)[0] for z in text.splitlines() if z.strip()
+    ]
+    fehlend = [
+        (m, _soll_kuerzel(m)) for m in _AC1_IDS
+        if _soll_kuerzel(m) not in zeilen_anfaenge
+    ]
+    assert not fehlend, (
+        "AC-1 FAIL (Kurzuebersicht): diese Groessen stehen dort NICHT unter "
+        f"dem Kuerzel, das die SMS sendet: {fehlend}.\nGerendert:\n{text}"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC-3 — Temperatur und Gefuehlte Temperatur behalten ihr Stundenkuerzel
+# ═══════════════════════════════════════════════════════════════════════════
+
+def test_temperatur_und_gefuehlte_behalten_das_stundenkuerzel():
+    """AC-3: Given Temperatur und Gefuehlte Temperatur / When die
+    Stundentabelle gerendert wird / Then stehen dort weiterhin `T` und `TF` —
+    NICHT `K`/`D` bzw. `FK`/`FD`/`WC`. Die Zelle zeigt einen Stundenwert; ein
+    Kopf, der "Tagestiefst" bedeutet, waere dort eine falsche Aussage.
+
+    Regressionsschutz: heute gruen, muss die Vereinheitlichung ueberleben."""
+    kopf = _tabellenkopf(["temperature", "wind_chill"])
+    assert kopf == ["T", "TF"], (
+        f"AC-3 FAIL: Spaltenkoepfe {kopf} statt ['T', 'TF']. Die Ausnahme fuer "
+        "Temperatur/Gefuehlte Temperatur ist bei der Vereinheitlichung "
+        "verlorengegangen — die Zelle wuerde eine Tagesauswertung behaupten, "
+        "zeigt aber einen Stundenwert."
+    )
+
+
+def test_ausnahmeliste_nennt_beide_temperaturen_mit_begruendung():
+    """AC-3 Gegenprobe / AC-2: die beiden Ausnahmen stehen NAMENTLICH und mit
+    Begruendung in einer Liste im Katalog — nicht als stiller Sonderfall im
+    Renderer. Ohne diese Liste ist "compact_label darf nicht wegdriften"
+    (Spec Abschnitt 2) nicht pruefbar."""
+    ausnahmen = _ausnahmeliste()
+    assert ausnahmen is not None, (
+        "AC-2/AC-3 FAIL: `app.metric_catalog` fuehrt keine benannte "
+        f"Ausnahmeliste (gesucht: {', '.join(_AUSNAHMELISTE_NAMEN)}). Solange "
+        "es sie nicht gibt, ist jede Abweichung zwischen Telegram- und "
+        "SMS-Kuerzel ununterscheidbar von einem Fluechtigkeitsfehler — genau "
+        "so ist der heutige Zustand entstanden."
+    )
+    for metric_id in ("temperature", "wind_chill"):
+        assert metric_id in ausnahmen, (
+            f"AC-3 FAIL: '{metric_id}' fehlt in der Ausnahmeliste "
+            f"(enthalten: {sorted(ausnahmen)})."
+        )
+        assert len(str(ausnahmen[metric_id]).strip()) >= _MIN_BEGRUENDUNG, (
+            f"AC-3 FAIL: Ausnahme '{metric_id}' ohne Begruendung: "
+            f"{ausnahmen[metric_id]!r}"
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC-2 — der Waechter ueber den ganzen Katalog
+# ═══════════════════════════════════════════════════════════════════════════
+
+def test_kein_telegram_kuerzel_weicht_unbegruendet_von_der_sms_ab():
+    """AC-2: Given der vollstaendige Metrik-Katalog / When Telegram-Kuerzel und
+    SMS-Kuerzel jeder Groesse verglichen werden / Then sind sie identisch,
+    ausser fuer die Groessen der benannten Ausnahmeliste."""
+    from app.metric_catalog import get_all_metrics
+
+    ausnahmen = _ausnahmeliste()
+    assert ausnahmen is not None, (
+        "AC-2 FAIL: keine benannte Ausnahmeliste im Katalog (gesucht: "
+        f"{', '.join(_AUSNAHMELISTE_NAMEN)}) — ohne sie kann `compact_label` "
+        "beim naechsten Katalog-Eintrag genauso wegdriften wie bisher."
+    )
+    eintraege = [
+        (m.id, m.compact_label, _soll_kuerzel(m.id)) for m in get_all_metrics()
+    ]
+    verstoesse = pruefe_kuerzel(eintraege, ausnahmen)
+    assert not verstoesse, (
+        "AC-2 FAIL — dieselbe Groesse traegt zwei Kuerzel:\n  "
+        + "\n  ".join(verstoesse)
+    )
+
+
+@pytest.mark.parametrize(
+    "ausnahmen,soll_rot,warum",
+    [
+        ({}, True, "neuer Eintrag ohne Ausnahme muss auffallen"),
+        ({"nebelbank": "kurz"}, True, "Ausnahme ohne Begruendung zaehlt nicht"),
+        (
+            {"nebelbank": "Telegram zeigt hier den Stundenwert, das Register "
+                          "die Tagesauswertung"},
+            False,
+            "begruendete Ausnahme ist erlaubt",
+        ),
+    ],
+)
+def test_waechter_faengt_einen_neuen_katalogeintrag(ausnahmen, soll_rot, warum):
+    """AC-2, Zaehne des Waechters: ein KUENSTLICHER Katalog-Eintrag mit
+    abweichendem `compact_label` und ohne begruendete Ausnahme macht ihn rot.
+
+    Ohne diese Gegenprobe waere `test_kein_telegram_kuerzel_weicht_...` nur
+    eine Momentaufnahme des heutigen Bestands: gruen, sobald jemand einmal
+    aufgeraeumt hat, und blind fuer den naechsten Eintrag."""
+    kuenstlich = [("nebelbank", "NB", "FG")]
+    verstoesse = pruefe_kuerzel(kuenstlich, ausnahmen)
+    assert bool(verstoesse) is soll_rot, (
+        f"Waechter-Gegenprobe fehlgeschlagen ({warum}): "
+        f"Verstoesse={verstoesse}, erwartet rot={soll_rot}"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AC-9 — eine Groesse ohne Kuerzel bekommt keines angedichtet
+#
+# Der Editor speist die Kurzform-Marke aus /api/sms-symbols (Spec Abschnitt 3).
+# Damit "erscheint keine leere oder erfundene Marke, sondern gar keine"
+# ueberhaupt erreichbar ist, darf schon die Antwort keine leeren und keine
+# erfundenen Eintraege enthalten. Aufruf der ECHTEN Endpoint-Funktion, kein
+# Netz, kein Mock.
+# ═══════════════════════════════════════════════════════════════════════════
+
+def test_kuerzel_katalog_erfindet_keine_und_liefert_keine_leeren():
+    """AC-9: Given eine Groesse ohne Registereintrag (`confidence`, seit #710
+    nicht waehlbar und ohne `sms_code`) / When der Kuerzel-Katalog abgerufen
+    wird / Then fehlt sie dort ganz — statt mit einer leeren Marke zu
+    erscheinen. Und keine gelistete Groesse traegt ein leeres Kuerzel."""
+    from api.routers.config import get_sms_symbols
+
+    antwort = get_sms_symbols()
+    eintraege = {e["metric_id"]: e["sms_symbols"] for e in antwort["metrics"]}
+
+    leer = {
+        mid: syms for mid, syms in eintraege.items()
+        if not syms or any(not str(s).strip() for s in syms)
+    }
+    assert not leer, (
+        f"AC-9 FAIL: /api/sms-symbols liefert leere Kuerzel: {leer}. Der Editor "
+        "wuerde daraus eine Marke 'Kurzform' ohne Inhalt bauen."
+    )
+    assert "confidence" not in eintraege, (
+        "AC-9 FAIL: 'confidence' hat keinen Registereintrag und darf im "
+        "Kuerzel-Katalog nicht auftauchen — sonst erfindet die Oberflaeche "
+        f"eine Marke fuer eine Groesse ohne Kuerzel. Enthalten: {sorted(eintraege)}"
+    )

--- a/tests/unit/test_telegram_thunder_window_konsistenz.py
+++ b/tests/unit/test_telegram_thunder_window_konsistenz.py
@@ -98,10 +98,21 @@ _ROWS = [
 
 def _thunder_statements(*, night_thunder, has_gap):
     """Rendert die Bubbles fuer das Issue-Szenario und liefert alle
-    Gewitter-Aussagen (Text nach '⚡ ', vor einem etwaigen ' · ') der
-    Kurzuebersicht-Bubble."""
+    Gewitter-Aussagen (Text nach der Gewitter-Marke, vor einem etwaigen
+    ' · ') der Kurzuebersicht-Bubble.
+
+    #1719 S4: die Kurzuebersicht-ZEILE traegt seit der Kuerzel-
+    Vereinheitlichung das Kurzform-Kuerzel der Groesse ('TH' statt '⚡') --
+    dasselbe, das die SMS sendet. Die FUSSZEILE traegt weiterhin das Symbol
+    '⚡' (narrow.py:280, festes Zeichen, kein Katalogfeld). Deshalb werden
+    hier beide Marken gesucht; das Kuerzel wird aus dem Katalog GEHOLT, nicht
+    abgetippt. Die Zusicherung selbst ist unveraendert: ZWEI Zeilen, EINE
+    Aussage."""
+    from app.metric_catalog import get_metric
     from app.models import ThunderLevel
     from output.renderers.narrow import render_telegram_bubbles
+
+    marken = (get_metric("thunder").compact_label, "⚡")
 
     night = (
         _make_night_weather(night_thunder) if night_thunder is not None else None
@@ -115,9 +126,10 @@ def _thunder_statements(*, night_thunder, has_gap):
     overview = next(b.text for b in bubbles if "Kurzübersicht" in b.text)
     statements = []
     for line in overview.splitlines():
-        if "⚡" not in line:
+        marke = next((m for m in marken if line.startswith(m)), None)
+        if marke is None:
             continue
-        after = line.split("⚡", 1)[1].strip()
+        after = line[len(marke):].strip()
         statements.append(after.split(" · ", 1)[0].strip())
     return statements
 


### PR DESCRIPTION
## Warum

Dieselbe Wettergröße trug bis zu drei verschiedene Kürzel, je nachdem wo sie erschien. Wer in einer SMS `N13` las, fand im Editor `TN` — und in der Telegram-Tabelle `H`, wo die SMS `HU` schreibt.

**Ursache:** `compact_label` (Telegram) und `sms_code` (Register) wurden getrennt von Hand gepflegt und sind auseinandergelaufen. Gemessen: 11 von 25 Größen wichen ab, ohne fachlichen Grund.

| Größe | Telegram bisher | künftig |
|---|---|---|
| Luftfeuchtigkeit | `H` | `HU` |
| Bewölkung | `C` | `CT` |
| Sichtweite | `V` | `VS` |
| Luftdruck | `P` | `HP` |
| Nullgradgrenze | `0G` | `NL` |
| Nacht-Tiefsttemperatur | `TN` | `N` |
| Regenwahrscheinlichkeit | `P%` | `PR` |
| Schneefallgrenze | `SG` | `SL` |
| Gefühlte Nacht-Tiefst | `TFN` | `FN` |
| Neuschnee | `NS` | `NS24+` |
| Sonnenstunden | `☀` | `SU` |
| Gewitter | `⚡` | `TH` |

Beide Systeme standen außerdem schon in **derselben** Nachricht: die Änderungs-Token der SMS lasen `compact_label`.

## Was sich ändert

1. **Telegram nutzt das Register-Kürzel.** `compact_label` wird abgeleitet statt zweitgepflegt; abweichen darf nur, was in einer benannten Ausnahmeliste mit Begründung steht. Zwei Ausnahmen: Temperatur (`T`) und Gefühlte Temperatur (`TF`) — deren Register-Kürzel bezeichnen Tagesauswertungen (`D`/`K` bzw. `FK`/`FD`/`WC`), die Telegram-Zelle zeigt aber einen Stundenwert.
2. **Der Editor zeigt zwei wahre Marken je Zeile** — „Mail" aus `col_label`, „Kurzform" mit **allen** Kürzeln der Größe. Bisher stand dort `sms_code`, also die **Alarm**-Stammdaten: bei 5 von 25 Größen ein Kürzel, das in keiner Trip-SMS vorkommt.
3. **Die Marken sind unverkürzbar.** Bisher rettete `flex-wrap` sie nur unter 900 px; ab 900 px fehlte `min-width: 0` am Namen, weshalb sich die Zelle den Platz zwangsläufig bei den Kürzeln holte.

## Nutzersichtbare Folge

**Jede Telegram-Nachricht sieht anders aus** — zwölf Spaltenköpfe tragen neue Kürzel. Das ist der Zweck des Issues, keine Nebenwirkung.

## Nachweise

- Adversary: Runde 2 **BROKEN**, Runde 3 **VERIFIED** (17 Punkte, 3 Runden, maschinell validiert)
- 6/6 Pflicht-Mutationsfamilien durchgespielt; drei Testlücken geschlossen, jede mit belegter Gegenprobe
- Briefing-Mail-Validator gegen echt zugestellte Staging-Mail: **Exit 0**
- 2604 Frontend-Tests, 0 fail · Python-Suiten der berührten Module grün · Golden-Mail und Golden-SMS unverändert
- `svelte-check` im A/B gegen sauberen Klon: identisch

**Bemerkenswerter Fund:** Ein Bestandstest wählte seine Zeile am Zeichen `⚡` — genau dem, das diese Änderung ersetzt. Er traf seitdem die Fußzeile statt der Übersichtszeile und blieb grün, während sein Regressionsschutz erloschen war. Nachgewiesen, indem der historische Bug reaktiviert wurde: Test blieb grün. Behoben, Auswahl kommt jetzt aus dem Katalog.

## Offen bis Staging

Die 14 Auflösungen (320–1920 px, Schwerpunkt auf der Bruchzone 900–1300 px) laufen im echten Browser erst gegen Staging — samt der AC-12-Gegenprobe: Layout-Absicherung zurückbauen und nachweisen, dass die Prüfung rot wird.

Refs #1719

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Nachtrag: Randfälle, die mitwandern

- **`cape`** wandert von `CE` auf `CP` mit. **Folgenlos:** die Größe ist seit #1585 `selectable=False` und wird von `_is_selectable` (`models.py:660`) aus jeder Ausgabe gefiltert — das Kürzel erscheint nirgends. Nachgemessen, nicht angenommen.
- **`temperature_cold`** und **`confidence`** bleiben unverändert (ebenfalls nicht wählbar, kein Register-Kürzel bzw. bewusste Ausnahme).

## Nachtrag: ein Wächter, der nichts bewachte

Beim Bau von AC-8 fiel auf, dass ein Test, der per `spawnSync` einen zweiten `node --test`-Lauf startet und dessen Exit-Code prüft, **strukturell blind** ist: Node vererbt `NODE_TEST_CONTEXT` an das Kind, und in dieser Betriebsart meldet der Läufer TAP an den Elternprozess und beendet sich **mit 0, auch wenn Tests scheitern**.

```
scheiternder Test, direkt:                    exit=1
derselbe Test mit NODE_TEST_CONTEXT=child-v8: exit=0
```

Der Wächter war deshalb schon in der RED-Phase grün, während die vier von ihm bewachten Editoren rot waren. Behoben (Variable aus der Kind-Umgebung entfernt, plus unabhängiger Beleg auf `# fail 0`).

**Bestand geprüft: kein anderer Wächter ist so gebaut** — die übrigen Tests mit Kindprozessen werten stdout aus (`e2e_prod_url_guard.test.ts`) oder starten Python (`compareMetricCatalogParity.test.ts`).
