### PR TITLE
docs(#1744 A1): Ortssprache der Alarme in der Doku nachgezogen

### DIFF
--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -275,8 +275,12 @@ für `ComparePreset`-Orte auf, ohne die Auswertungslogik zu duplizieren. Wetter-
 `compare_weather_snapshot.py` persistiert (`data/users/<user_id>/compare_weather_snapshots/`)
 und beim Report-Versand (`send_one_compare_preset()`) aktualisiert; der 15-Minuten-Check liest
 nur. Versand ohne Trip-Bindung über `NotificationService.send_location_deviation_alert()`; der
-geteilte Alert-Renderer zeigt bei gesetztem `AlertMessage.location_label` den Ortsnamen statt
-der (bei einem Punkt sinnlosen) km-Spanne. Alarmkonfiguration ist in Scheibe 2 hartkodiert
+geteilte Alert-Renderer löst den Ortsbezug seit #1744 A1 in **einer** Funktion
+(`renderers/alert/segments.py::format_alert_location`) über drei Stufen auf: gesetztes
+`location_label` → Ortsname (Ortsvergleich), sonst Segment-Kennung über
+`format_segment_reference` (`Segment 3–5`, `🏁 Ziel` — dieselbe Sprache wie die amtliche
+Warnung), sonst km-Spanne als Rückfall. Die Kurznachricht (SMS/Premium-SMS) nennt bewusst
+weiterhin keinen Ortsbezug. Alarmkonfiguration ist in Scheibe 2 hartkodiert
 (Default-Sensitivität „standard", 120 Min Cooldown, nur E-Mail) — editierbare UI folgt in
 Scheibe 3 (#1170). Scheduler: `POST /api/scheduler/compare-alert-checks`, Go-Cron-Job
 `compare_alert_checks` (`*/15 * * * *`, 7. registrierter Job). Details:

--- a/docs/features/issue-816-alert-deviation-core.md
+++ b/docs/features/issue-816-alert-deviation-core.md
@@ -151,12 +151,19 @@ Betreff: [GR20] Wetter ändert sich seit dem Briefing
 
 Wetter ändert sich seit dem Briefing
 
-Regen      2 → 18 mm     (Etappe 3, km 12–18, 14–16 Uhr)
-Böen      25 → 48 km/h   (Etappe 3, km 12–18, 14–16 Uhr)
-Temp      22 → 16 °C     (Etappe 3, km 18–24, 16–18 Uhr)
+Regen      2 → 18 mm     (Segment 3, 14–16 Uhr)
+Böen      25 → 48 km/h   (Segment 3, 14–16 Uhr)
+Temp      22 → 16 °C     (Segment 4, 16–18 Uhr)
 
 Stand: heute 13:30 · verglichen mit dem letzten Briefing
 ```
+
+> **Hinweis (#1744 A1, 2026-08-12):** Der Ortsbezug lautet seit dieser Änderung
+> `Segment N` bzw. `🏁 Ziel` statt einer km-Spanne — dieselbe Sprache, die die
+> amtliche Warnung spricht; die km-Spanne bleibt der Rückfall für Etappen ohne
+> Kennung. Die obige Beispiel-Mail ist im Übrigen eine **Entwurfsskizze aus #816**
+> und bildet den heutigen Renderer nicht zeilengetreu ab (real: Datenzeilen mit
+> „Wo & wann"). Maßgeblich ist der Renderer, nicht diese Skizze.
 
 **km-Erweiterung:** `build_segment_label()` in `helpers.py` wird um km erweitert:
 - Neu: `"Etappe N, km X–Y, HH:MM–HH:MM"`

--- a/docs/specs/modules/fix_1744_alarm_format_angleichen.md
+++ b/docs/specs/modules/fix_1744_alarm_format_angleichen.md
@@ -3,10 +3,15 @@ entity_id: fix_1744_alarm_format_angleichen
 type: module
 created: 2026-08-12
 updated: 2026-08-12
-status: draft
-version: "1.0"
+status: partial
+version: "1.1"
 tags: [alerts, renderer, email, subject]
 ---
+
+> **Liefer-Stand 2026-08-12:** Scheibe **A1** (AC-1 bis AC-7) ist ausgeliefert und live —
+> PR #1781, Merge `942fc778`, in Produktion über `0861a9a8`. Adversary VERIFIED nach vier
+> Runden (drei Findings behoben), Staging VERIFIED 7/7 an echt zugestellten Mails.
+> Scheibe **A2** (AC-8 bis AC-12, Mail-Körper) ist **offen**. #1744 bleibt deshalb offen.
 
 # Alarm-Format angleichen: eine Ortssprache für alle Trip-Alarme (#1744 Scheibe A)
 


### PR DESCRIPTION
Reine Doku-Nachpflege zur bereits ausgelieferten Scheibe A1 von #1744 (PR #1781, live über `0861a9a8`). Kein Produktivcode — Staging- und Prod-Schritte entfallen nach der Doku-Ausnahme des Liefer-Workflows.

## Was überholt war

| Datei | Vorher | Jetzt |
|---|---|---|
| `docs/features/architecture.md` | „Ortsname statt km-Spanne" — beschrieb nur eine von drei Stufen | Alle drei Stufen der einen Auflösungsfunktion: `location_label` → Segment-Kennung → km als Rückfall; Hinweis, dass die Kurznachricht weiterhin keinen Ortsbezug nennt |
| `docs/features/issue-816-alert-deviation-core.md` | Beispiel-Mail mit `km 12–18` | `Segment 3` — plus ehrlicher Hinweis, dass die Beispiel-Mail eine Entwurfsskizze aus #816 ist und den heutigen Renderer ohnehin nicht zeilengetreu abbildet |
| `docs/specs/modules/fix_1744_alarm_format_angleichen.md` | `status: draft` | `status: partial` — A1 live, A2 (Mail-Körper) offen |

## Geprüft und bewusst nicht geändert

`docs/reference/mail_validators.md` beschreibt die Prüfungen des Radar-Validators gar nicht (nur dessen IMAP-Variablen-Muster). Durch die additive `_SEGMENT_RE`-Erweiterung um die Ziel-Form ist dort nichts falsch geworden.

## Kein Issue-Close

#1744 bleibt offen — Scheibe A2 (Mail-Körper angleichen, AC-8 bis AC-12) steht noch aus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)