### PR TITLE
fix(#1775): Endlosschleife im Trip-Anlege-Dialog nach dem Tagesfenster-Merge

### DIFF
--- a/frontend/src/lib/components/trip-new/TripNewEditor.svelte
+++ b/frontend/src/lib/components/trip-new/TripNewEditor.svelte
@@ -318,6 +318,16 @@
 	// hier bereits das EINE Objekt ist, das auch EditReportConfigSection per
 	// bind:reportConfig haelt.
 	function handleDayWindowChange(w: { day_window_start_hour: number; day_window_end_hour: number }) {
+		// Fix-Loop 2 (Staging-Regression #1775 nach Merge): gleiche Fehlerklasse
+		// wie handleWeatherMetricsChange oben -- ohne Inhaltsgleichheits-Guard
+		// erzeugt jeder Effect-Lauf in WeatherMetricsTab eine neue reportConfig-
+		// Referenz -> neue stubTrip-Referenz -> effect_update_depth_exceeded.
+		if (
+			reportConfig?.day_window_start_hour === w.day_window_start_hour &&
+			reportConfig?.day_window_end_hour === w.day_window_end_hour
+		) {
+			return;
+		}
 		reportConfig = { ...(reportConfig ?? {}), ...w };
 	}
 

--- a/frontend/src/lib/components/trip-new/__tests__/trip_new_editor_weather_metrics_wiring.test.ts
+++ b/frontend/src/lib/components/trip-new/__tests__/trip_new_editor_weather_metrics_wiring.test.ts
@@ -68,11 +68,36 @@ describe('AC-2/AC-3/AC-6 (Test 4-6, Issue #1775): handleDayWindowChange + stubTr
 	// Spec: docs/specs/modules/fix_1775_tagesfenster_anlegen.md § Test 4, Test 5, Test 6
 
 	test('ein handleDayWindowChange-Handler existiert und mergt additiv in reportConfig', () => {
+		// Fix-Loop 2 (Staging-Regression nach #1775-Merge): der Handler prueft
+		// jetzt zuerst auf Inhaltsgleichheit und schreibt nur bei echter
+		// Aenderung -- die Zuweisung folgt deshalb nicht mehr direkt auf die
+		// oeffnende Klammer (analog handleWeatherMetricsChange oben).
 		assert.match(
 			code,
-			/function handleDayWindowChange\([^)]*\)\s*\{\s*reportConfig\s*=\s*\{\s*\.\.\.\(reportConfig\s*\?\?\s*\{\}\),\s*\.\.\.w\s*\};?\s*\}/,
+			/function handleDayWindowChange\([^)]*\)\s*\{[\s\S]*?reportConfig\s*=\s*\{\s*\.\.\.\(reportConfig\s*\?\?\s*\{\}\),\s*\.\.\.w\s*\};?\s*[\s\S]*?\}/,
 			'Kein handleDayWindowChange-Handler gefunden, der additiv in reportConfig mergt — ' +
 				'ohne ihn erreicht das Tagesfenster nie den POST-Payload (#1775)'
+		);
+	});
+
+	test('handleDayWindowChange ueberspringt inhaltsgleiche Aufrufe (Fix-Loop 2, Regressionsschutz)', () => {
+		// Staging-Befund nach dem #1775-Merge (Commit 9149e480): /trips/new war
+		// komplett unbedienbar, effect_update_depth_exceeded SOFORT beim Laden,
+		// 5/5 Reproduktionen, keine Nutzerinteraktion noetig. Root Cause: dieser
+		// Handler schrieb bedingungslos eine neue reportConfig-Referenz, obwohl
+		// WeatherMetricsTab im createMode-$effect bei jedem Effect-Lauf
+		// onDayWindowChange(...) aufruft -- neue reportConfig-Referenz -> neue
+		// stubTrip-Referenz -> Kreis. Exakt dieselbe Fehlerklasse wie
+		// handleWeatherMetricsChange (Fix-Loop 2 zu #1552), dort bereits mit
+		// einem Inhaltsgleichheits-Guard behoben.
+		const fnMatch = code.match(/function handleDayWindowChange\([^)]*\)\s*\{[\s\S]*?\n\t\}/);
+		assert.ok(fnMatch, 'handleDayWindowChange nicht gefunden');
+		assert.match(
+			fnMatch[0],
+			/reportConfig\?\.day_window_start_hour\s*===\s*w\.day_window_start_hour\s*&&\s*reportConfig\?\.day_window_end_hour\s*===\s*w\.day_window_end_hour/,
+			'Kein Inhaltsgleichheits-Guard vor dem Schreiben -- jeder Effect-Lauf in ' +
+				'WeatherMetricsTab erzeugt sonst eine neue reportConfig-Referenz und damit ' +
+				'eine Endlosschleife (effect_update_depth_exceeded, Staging-Regression #1775)'
 		);
 	});
 


### PR DESCRIPTION
## Summary
- **Kritische Staging-Regression** aus PR #1789 (Commit `9149e480`): `/trips/new` war komplett unbedienbar (`effect_update_depth_exceeded`, sofort beim Laden, 5/5 Playwright-Reproduktionen).
- Ursache: `handleDayWindowChange` (`TripNewEditor.svelte`) schrieb bedingungslos eine neue `reportConfig`-Referenz, obwohl `WeatherMetricsTab`s `createMode`-`$effect` bei jedem Lauf `onDayWindowChange` aufruft → neue `reportConfig`-Referenz → neue `stubTrip`-Referenz → Kreis.
- Exakt dieselbe Fehlerklasse wie `handleWeatherMetricsChange` (#1552 Fix-Loop 2) — dort bereits mit einem Inhaltsgleichheits-Guard behoben. Hier fehlte das Gegenstück.
- Gefunden durch einen echten Playwright-Lauf gegen Staging (`staging-validator`-Agent) — kein lokaler Test hätte das gefangen (Source-Inspection kann `$effect`-Läufe nicht ausführen).

## Test plan
- [x] RED-Test bestätigt (Guard fehlte → 1 Test rot)
- [x] Fix angewendet, 30/30 Tests grün (Zielsuite)
- [x] Mutations-Gegenprobe: Guard entfernt → genau der neue Regressionstest wird rot, kein Kollateralschaden
- [ ] Erneute Staging-Verifikation (Playwright) nach diesem Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)