### PR TITLE
test(#1703 S5): Compare-Zellwert-Vollstaendigkeit bewacht

### DIFF
--- a/docs/context/fix-1703-s5-compare-zellwerte.md
+++ b/docs/context/fix-1703-s5-compare-zellwerte.md
@@ -1,0 +1,191 @@
+# Context: Epic #1703 Scheibe 5 — Compare-Zellwert-Vollständigkeit
+
+## Request Summary
+
+Epic #1703, Scheibe 5: Über die reine Zeilen-EXISTENZ hinaus in
+`tests/tdd/test_channel_metric_matrix.py` (Achse `AC-S5-n`, Fortsetzung S1-S4)
+prüfen, dass jede Zelle der Compare-Übersichtstabelle (HTML **und** Klartext)
+einen plausiblen Wert trägt, UND dass HTML und Klartext derselben Mail für
+dieselbe Wetterlage dieselbe Zahl zeigen. Ziel laut
+`docs/reference/metric_output_matrix.md` Fläche 4 / Abschnitt 6 Scheibe 5.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `src/output/renderers/email/compare_html.py:305-371` (`CV2_METRICS`) | Soll-Menge der Scheibe: 26 Einträge = `warn` + **25 Metrik-Zeilen**. Zellwert kommt aus `_metric_value(loc, m["key"], summary)` (:644), formatiert per `m["fmt"]` (Sonderfälle: `_fmt_thunder`, `_fmt_precip_type`, `_fmt_visibility_overview`) oder generisch `_fmt_metric(value, m.get("decimals"), m.get("unit"))` (:703-709, Default `decimals=0`, `None` → `"—"` U+2014 Em-Dash). |
+| `src/output/renderers/comparison.py:70-120` (`_PLAIN_ROWS`/`_DAILY_PLAIN_ROWS`) | Klartext-Pendant. **Wert-Quelle bereits geteilt**: importiert `_metric_value` direkt aus `compare_html.py` (Zeile 30-36) — kein zweiter Berechnungsweg. Formatierung dagegen **nicht** einheitlich: teils dieselben geteilten Formatter (`_fmt_thunder`, `_fmt_precip_type`, `_fmt_visibility_overview`), teils eigene Lambdas mit `:.0f`/`:.1f`, teils der katalog-getriebene `format_value(metric_id, v, style="plain")` — drei parallele Formatierungswege für denselben Zahlenwert. |
+| `tests/tdd/test_channel_metric_matrix.py` (3157 Zeilen; endet aktuell bei `test_ac_s4_14_telegram_narrow_confidence_absent` :3150) | Bestehender Matrix-Wächter (Option C, #1514). `AC-S5-n` wäre die fünfte Achse. |
+| `tests/tdd/test_channel_metric_matrix.py:2703-2860` (AC-S2-8, Scheibe 2) | **Direktes Vorbild-Muster**: `_s2_erwartete_tageswerte()` (:2703) rechnet Soll-Werte unabhängig aus rohen `ForecastDataPoint`-Stundenwerten (max/min/sum), `_s2_erwartungen_sind_unterscheidbar()` (:2737) ist eine Vakuum-Gegenprobe (verglichene Felder müssen selbst unterscheidbare Werte tragen, sonst wäre eine Vertauschung unsichtbar), `test_ac_s2_8_ausblick_zelle_zeigt_den_gerechneten_wert` (:2808) prüft die Soll-Zahl an der ECHTEN Mail (HTML-Spaltenindex + `_s2_klartext_ausblick()`-Parser :2260). |
+| `tests/unit/test_compare_mail_metric_link_completeness.py` | Bestehender Row-Existenz-Wächter (`test_every_overview_row_links_to_the_central_catalog`) — prüft nur, dass jede `CV2_METRICS`-Zeile ein auflösbares `metric_id`+`aggregation` trägt, **keine** Wertprüfung. Genau die Lücke, die Scheibe 5 schließt. |
+| `src/services/weather_metrics.py:927-1015` (`_compute_wind_direction`, `_compute_cloud_low/mid/high`, `_compute_freezing_level`, `_compute_snowfall_limit`) | Rohberechnung der "Klasse A/B"-Felder — alle bereits mit `round()` auf `int` normalisiert, bevor sie ins `LocationResult` bzw. die Live-Aggregation wandern. |
+
+## Existing Patterns
+
+- **Achsen-Erweiterung statt neues Register** (Option C): `AC-S5-*`-Tests in
+  derselben Datei, mit Docstring-Block der Scope/Nicht-Scope festhält (Vorbild
+  Kopf von S1-S4).
+- **Soll-Menge GERECHNET, nie getippt**: für Scheibe 5 ist die Soll-Menge
+  `CV2_METRICS` selbst (25 Metrik-Zeilen + `warn`) — **nicht**
+  `get_compare_metric_catalog()` (anderes Key-Vokabular, primär Scheibe-2-Scope
+  für die Ausblick-Tabelle).
+- **"Rechnen statt tippen" sichert Vollständigkeit, nie Zuordnung** (S2-Lehre,
+  F001 HIGH): eine Vertauschung zweier Felder blieb in S2 trotz gerechneter
+  Soll-Menge grün, weil kein Test die *Zahlenwerte* prüfte. AC-S2-8 schließt
+  das mit unabhängig aus Rohdaten gerechneten Erwartungswerten — direktes
+  Vorbild für Scheibe 5.
+- **Prüfort = Wirkort**: gegen die echte Mail (`render_compare_email()`, HTML
+  und Klartext in einem Aufruf), nicht gegen isolierte Renderer-Direktaufrufe.
+
+## Dependencies
+
+- **Upstream:** `_metric_value()` (compare_html.py:644) als gemeinsame
+  Wert-Quelle; `_DAILY_AGGREGATE_FIELD` (:608) entscheidet Engine-Feld vs.
+  Live-Ableitung (`_daily_summary()` → `summarize_points()`); Roh-Berechnung
+  in `weather_metrics.py` (`_compute_*`-Methoden, Zeilen 793-1015).
+- **Downstream:** `render_compare_email()` (Versandpfad) ruft beide Renderer
+  für dieselbe `ComparisonResult` auf.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1703_s1_alert_renderer_matrix.md`,
+  `fix_1703_s2_ausblick_matrix.md`, `fix_1703_s3_selectable_metrics.md`,
+  `fix_1703_s4_kompaktform_matrix.md` — Vorbild-Format der Vorscheiben.
+  AC-S2-8 in S2 ist das direkte technische Vorbild.
+- `docs/specs/modules/issue_1110_compare_mail_v2.md` — Klartext-Renderer-Vertrag.
+- `docs/reference/metric_output_matrix.md` Abschnitt 4.2 (Fläche 4), Abschnitt 6
+  (Scheibe-5-Text).
+
+## Risks & Considerations
+
+- **Kernrisiko laut Matrix-Dokument:** Doppel-Quellen-Historie #1356 (HTML und
+  Klartext liefen bei der **Reihenfolge** einmal auseinander, weil zwei
+  unabhängige Listen dieselbe Semantik doppelt trugen — inzwischen mit
+  `_ordered_rows()`/#1359 gefixt). Dieselbe Zwei-Listen-Architektur (`CV2_METRICS`
+  vs. `_PLAIN_ROWS`) besteht strukturell weiter — jetzt für **Werte/Formatierung**
+  statt Reihenfolge.
+- **Wert-Quelle ist bereits geteilt** (`_metric_value` importiert, kein zweiter
+  Berechnungsweg) — geringeres Risiko als ursprünglich vom Matrix-Dokument
+  suggeriert. Das eigentliche Risiko liegt in der **Formatierung**, nicht im Wert.
+- **Verifizierter, konkreter Fund (kein Verdacht):** Fehlender Wert wird
+  unterschiedlich dargestellt — HTML zeigt `—` (U+2014, Em-Dash, `_fmt_metric`
+  Zeile 705), Klartext zeigt `-` (U+002D, ASCII-Hyphen, `comparison.py:249`)
+  für **dieselbe** fehlende Zelle. Muss in der Spec entschieden werden:
+  Charakterisierung (Ist-Zustand bewachen) oder Fix (Angleichung)?
+- **Widerlegter Verdacht aus der Erstrecherche:** `wind_direction_avg` und
+  `cloud_low/mid/high_avg` formatieren in `comparison.py` ohne `:.0f`-Rundung
+  (`f"{v}°"`/`f"{v}%"`) — sah zunächst wie ein Rundungs-Divergenzrisiko aus.
+  Nachgemessen in `weather_metrics.py:946-1015`: alle vier Werte werden an der
+  Berechnungsquelle bereits mit `round()` auf `int` normalisiert, bevor sie das
+  `LocationResult` erreichen — kein tatsächliches Divergenzrisiko unter
+  heutigen Typannahmen. **Lehre für die Spec:** nicht bei der Formatierungs-
+  Zeile stehenbleiben, sondern bis zur Berechnungsquelle zurückverfolgen.
+- **Drei parallele Formatierungswege in `_PLAIN_ROWS`**: (a) geteilte Formatter
+  (`_fmt_thunder`, `_fmt_precip_type`, `_fmt_visibility_overview` — importiert,
+  kein Risiko), (b) eigene Lambdas mit expliziter Dezimalstellen-Angabe (meist
+  deckungsgleich mit `CV2_METRICS`-`decimals`, aber nicht automatisch
+  gehalten — reine Konvention, kein Wächter), (c) katalog-getriebener
+  `format_value(metric_id, v, style="plain")` (temp_max/min, wind_max,
+  gust_max, wind_chill_min/max, cloud_avg, snow_depth_cm, sunny_hours,
+  dewpoint_avg) — eine **dritte**, unabhängige Formatierungsquelle neben
+  `_fmt_metric`+`decimals`-Dict. Ob `format_value(..., style="plain")` und
+  `_fmt_metric(..., decimals=CV2_METRICS[...]["decimals"])` für dieselbe Größe
+  immer dieselbe Nachkommastellenzahl liefern, ist **ungeklärt** — zu klären in
+  der Analyse/Spec, ggf. per Sub-Agent-Nachmessung je Feld.
+- **`warn`-Zeile** (amtliche Warnungen) hat keinen numerischen "Zellwert" im
+  engeren Sinn — vermutlich analog Scheibe 2 aus der 25er-Soll-Menge
+  ausgenommen; zu bestätigen in der Spec.
+- **Risiko laut Matrix-Dokument: mittel. Größe: mittel.**
+
+## Analysis
+
+### Type
+Feature (Erweiterung des bestehenden Matrix-Wächters um eine neue Achse,
+primär Charakterisierung — ggf. mit punktuellem Fix, falls der
+Fehlzeichen-Fund oder eine Formatierungs-Divergenz als echter Bug eingestuft
+wird).
+
+### Bestätigter Kernbefund (eigene Nachrecherche, mit Code-Zeilen verifiziert)
+
+1. **Wert-Quelle bereits geteilt, Formatierung nicht.** `comparison.py`
+   importiert `_metric_value` direkt aus `compare_html.py` — keine zweite
+   Wert-Berechnung. Divergenzrisiko sitzt ausschließlich in der Formatierung,
+   die auf drei unterschiedliche Arten passiert (s. Risks).
+2. **Ein realer, unabhängig verifizierter Darstellungs-Unterschied:** fehlender
+   Wert → HTML `—` (U+2014) vs. Klartext `-` (U+002D). Bytegenau nachgemessen
+   (`od -c`), kein Interpretationsfehler.
+3. **Ein zunächst vermuteter Rundungs-Unterschied (`wind_direction_avg`,
+   `cloud_*_avg`) ist bei Nachmessung KEIN echtes Risiko** — die
+   Berechnungsquelle rundet bereits auf `int`. Dieser Punkt ist explizit als
+   widerlegt dokumentiert, um eine falsche Spec-Prämisse zu vermeiden (Lehre
+   aus S2 F001: falsche Prämissen in ACs sind der teuerste Fehlertyp).
+4. **Soll-Menge = `CV2_METRICS`, 25 Metrik-Zeilen + `warn`** — bytegenau
+   ausgezählt, deckt sich mit der Fläche-2-Aussage aus S2 ("25 Paare"), ist
+   aber eine **andere** Liste (Compare-Übersicht statt Ausblick-Tabelle).
+
+### Affected Files (voraussichtlich)
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `tests/tdd/test_channel_metric_matrix.py` | MODIFY | Neue Achse `AC-S5-1..n`, Vorbild AC-S2-8: unabhängig aus Rohdaten gerechnete Erwartungswerte, gegen echte HTML-Zelle UND echte Klartext-Zeile geprüft, plus Vakuum-Gegenprobe. |
+| `docs/specs/modules/fix_1703_s5_compare_zellwerte.md` | CREATE | Spec analog S1-S4. |
+| `docs/reference/metric_output_matrix.md` | MODIFY | Fläche 4 nach Abschluss auf neuen Wächter umtragen (DoD). |
+| `src/output/renderers/comparison.py` bzw. `compare_html.py` | MÖGLICH, unklar | Nur falls der Em-Dash/Hyphen-Fund oder eine gefundene Formatierungs-Divergenz als Fix statt Charakterisierung eingestuft wird — **PO-Entscheidung nötig, s. Open Questions**. |
+
+### Scope Assessment
+- Files: 2-4 (Testdatei, Spec, Matrix-Dokument-Update, ggf. 1 Produktivdatei
+  bei Fix-Entscheidung)
+- Estimated LoC: Testcode ~150-300 Zeilen (Vorbild AC-S2-8 war für 5 Felder
+  bereits ~150 Zeilen inkl. Helfer; 25 Metrik-Zeilen sind größer, aber
+  vermutlich nicht linear — viele Felder teilen sich Formatierungslogik und
+  können gruppiert parametrisiert werden statt einzeln ausgeschrieben)
+- Risk Level: MEDIUM — die Formatierungs-Divergenz ist ein echtes,
+  unstrukturiertes Feld (drei parallele Wege), nicht trivial durchzuzählen wie
+  bei S1/S3 (Soll-Menge aus einer einzelnen Quelle).
+
+### Technical Approach (Empfehlung)
+
+**Primär Charakterisierung, mit einer offenen Fix-Frage.** Analog S1-S4: die
+Wert-Quelle ist bereits korrekt geteilt (kein Produktivcode-Fehler dort). Die
+Formatierungs-Divergenzen sind ein eigener Befund — ob sie als akzeptierter
+Ist-Zustand bewacht oder als Fix behandelt werden, ist eine PO-Entscheidung
+(insbesondere der Em-Dash/Hyphen-Fund, der nutzersichtbar in jeder Mail mit
+fehlenden Werten auftritt).
+
+Testaufbau nach AC-S2-8-Muster:
+1. Erwartungswerte unabhängig aus `hourly_data`/Roh-Timeseries rechnen (nicht
+   aus `_metric_value` oder `summarize_points()` abschreiben) für eine
+   Stichprobe der 25 Zeilen — mindestens je einen Vertreter pro
+   Formatierungsweg (a/b/c aus Risks), nicht alle 25 einzeln.
+2. Gegen die echte Mail prüfen: HTML-Zelle (Positions-/Label-Auflösung wie
+   `derive_row_labels()`) UND Klartext-Zeile (`_PLAIN_ROWS`-Parser analog
+   `_s2_klartext_ausblick()`).
+3. Vakuum-Gegenprobe: verglichene Testfälle müssen selbst unterscheidbare
+   Werte tragen.
+4. Fehlzeichen-Konsistenz (`—` vs. `-`) als eigener AC — Charakterisierung
+   oder Fix je nach PO-Entscheidung.
+
+### Open Questions (für Spec-Freigabe zu klären)
+
+- [ ] **(a) Em-Dash/Hyphen-Divergenz:** Charakterisieren (Ist-Zustand
+      bewachen) oder fixen (Klartext auf `—` angleichen, oder HTML auf `-`)?
+      Nutzersichtbar, aber kosmetisch — passt eher zum Muster
+      "Nebenbefund/Sammel-Eintrag" als zu einem eigenen Fix, sofern der PO
+      nicht widerspricht.
+- [ ] **(b) Formatierungs-Stichprobe vs. Vollabdeckung:** Reicht ein
+      Vertreter je Formatierungsweg (a/b/c), oder soll `format_value(...,
+      style="plain")` gegen `_fmt_metric(..., decimals=...)` für ALLE
+      betroffenen Felder (temp_max/min, wind_max, gust_max, wind_chill_min/max,
+      cloud_avg, snow_depth_cm, sunny_hours, dewpoint_avg — 9 Felder) einzeln
+      auf Dezimalstellen-Gleichheit geprüft werden? Empfehlung: alle 9, da
+      `format_value` ein Katalog-Pfad ist, der sich unabhängig vom
+      `CV2_METRICS`-`decimals`-Dict ändern kann (kein Wächter hält sie heute
+      zusammen).
+- [ ] **(c) `warn`-Zeile:** aus der Soll-Menge ausnehmen (kein Zellwert im
+      engeren Sinn), analog Scheibe-2-Vorgehen?
+
+## Related Non-Scope
+
+- Scheibe 6 (Form-Wächter Grammatik-Klassen) — Fläche 8, unabhängige Achse.
+- Scheibe 7/8 (Reihenfolge/Compare-Kanal-Tabs) — Fläche 5, blockiert bis 7a.
+- Reihenfolge-Aspekt von #1356 ist bereits durch `_ordered_rows()`/#1359
+  gefixt — nicht erneut Gegenstand dieser Scheibe.

--- a/docs/reference/metric_output_matrix.md
+++ b/docs/reference/metric_output_matrix.md
@@ -248,7 +248,7 @@ Stundentabelle (AC-6, Charakterisierung).
 
 | # | Unbewachte Fläche | Ort | Prio | Bemerkung |
 |---|---|---|---|---|
-| 4 | Compare-Übersichtstabelle: **Zellwert** je Metrik | `compare_html.py:294`, `comparison.py:70/100` | 2 | nur Zeilen-Existenz ist bewacht; ein falscher Wert in der Zelle bleibt grün |
+| 4 | Compare-Übersichtstabelle: **Zellwert** je Metrik | `compare_html.py:294`, `comparison.py:70/100` | 2 | ✅ Erledigt (2026-08-12, Epic #1703 Scheibe 5): Bei Nachmessung trug die pauschale Aussage „nur Zeilen-Existenz bewacht" nicht mehr — 15 der 25 `CV2_METRICS`-Zeilen hatten aus #1296/#1324/#1351/der Gewitter-Suite bereits Wert+Paritäts-Tests. Neuer Wächter `tests/tdd/test_channel_metric_matrix.py` AC-S5-1 (Soll-Menge 15+10=25, disjunkt), AC-S5-2 (die 10 verbleibenden Zeilen, HTML+Klartext gegen unabhängig gerechnete Werte über `render_compare_email()`), AC-S5-3 (Engine-Vorrang vor Live-Ableitung), AC-S5-4 (Formatierungs-Konsistenz `format_value()` vs. `CV2_METRICS`-`decimals`, 10 Felder einzeln), AC-S5-5 (Fehlzeichen-Divergenz HTML `—` vs. Klartext `-`, charakterisiert), AC-S5-6 (Abhängigkeits-Anker auf die 15 bereits gedeckten Zeilen). Reine Charakterisierung, kein Produktivcode-Fix. Spec: `docs/specs/modules/fix_1703_s5_compare_zellwerte.md` |
 | 5 | **Reihenfolge** in allen Kanälen außer E-Mail und Telegram-rich | `tokens/builder.py:78`, `comparison.py:237` | 2 | Compare-Klartext nutzt die Nutzer-Reihenfolge nur als Sichtbarkeitsfilter (#1356) |
 | 6 | Kurzform-Mail, mobile Kompaktzeilen und Kompakt-Zusammenfassung | `email/compact.py:96`, `email/html.py:878`, `compact_summary.py:567` | 2 | ✅ Erledigt (2026-08-12, Epic #1703 Scheibe 4): **drei** verschiedene Orte, die alle „compact" heißen und regelmäßig verwechselt werden — `render_compact()` ist das eigene Kurzformat, `_render_mobile_compact_rows()` sitzt **in** der Vollmail, `CompactSummaryFormatter` erzeugt den Fließtext-Block ebendort — jetzt einzeln bewacht: `tests/tdd/test_channel_metric_matrix.py` AC-S4-1/2/3 (Ort 1), AC-S4-5 (Ort 2), AC-S4-6/6b/7/8-10 (Ort 3). Reine Charakterisierung, kein Produktivcode-Fix. Spec: `docs/specs/modules/fix_1703_s4_kompaktform_matrix.md` |
 | 7 | **Telegram-Kurzform** als eigener Ausgabeort | `narrow.py:346`, `:528–532`, `:586–597` | 2 | ✅ Erledigt (2026-08-12, Epic #1703 Scheibe 4): Wächter `tests/tdd/test_channel_metric_matrix.py` AC-S4-12/13/14 (Auswahl/Abwahl generisch über alle wählbaren Metriken, Resolver-Divergenz zu Ort 1 als Charakterisierung, confidence-Absenz). Reine Charakterisierung, kein Produktivcode-Fix. Spec: `docs/specs/modules/fix_1703_s4_kompaktform_matrix.md` |
@@ -422,12 +422,39 @@ gate-unabhängige Mechanismen geschützt (Pillen-Katalog-Whitelist
 tatsächlich. Spec entsprechend korrigiert (Docstrings + AC-Wortlaut).
 Details: `docs/specs/modules/fix_1703_s4_kompaktform_matrix.md`.
 
-### Scheibe 5 — Compare-Zellwert-Vollständigkeit
+### Scheibe 5 — Compare-Zellwert-Vollständigkeit ✅ ERLEDIGT (2026-08-12)
 
 Über die Zeilen-Existenz hinaus prüfen, dass die Zelle je Metrik einen
 plausiblen Wert trägt und dass HTML (`compare_html.py:294`) und Klartext
 (`comparison.py:70/100`) für dieselbe Wetterlage dieselbe Zahl zeigen.
 *Risiko: mittel (Doppel-Quellen-Historie #1356). Größe: mittel.* Deckt Fläche 4.
+
+**Korrektur der Scheiben-Prämisse (bei Nachmessung, vor dem Schreiben der
+ACs):** Die pauschale Aussage „nur Zeilen-Existenz bewacht" traf nur noch auf
+10 der 25 `CV2_METRICS`-Zeilen zu — 15 hatten aus #1296/#1324/#1351 und der
+Gewitter-Testsuite bereits Wert+Paritäts-Tests. Die Wert-**Quelle** war zudem
+bereits geteilt (`comparison.py` importiert `_metric_value` direkt aus
+`compare_html.py`), das eigentliche Risiko lag in der **Formatierung**
+(drei parallele Wege: geteilte Formatter, eigene Lambdas, katalog-getriebenes
+`format_value()`), nicht im Wert selbst.
+
+Umgesetzt als 6 ACs (AC-S5-1 bis AC-S5-6, 29 parametrisierte Testfälle) in
+`tests/tdd/test_channel_metric_matrix.py`, gemessen gegen die echte Mail
+(`render_compare_email()`, HTML und Klartext in einem Aufruf). AC-S5-1 rechnet
+die 15+10-Aufteilung der 25 Zeilen disjunkt und lückenlos; AC-S5-2 sichert die
+10 zuvor ungeprüften Zeilen wertmäßig ab (unabhängig aus rohen Stundenwerten
+gerechnet, nicht aus `summarize_points()` übernommen — Lehre aus AC-S2-8/F001);
+AC-S5-3 belegt den Engine-Vorrang vor Live-Ableitung; AC-S5-4 hält
+`format_value()`-Dezimalstellen gegen `CV2_METRICS`-`decimals` für alle 10
+betroffenen Felder einzeln synchron (Nebenbefund: `wind_chill_min/max` und
+`dewpoint_avg` lesen im Klartext die `temperature`-Katalog-ID statt der
+eigenen — heute folgenlos, in #1199 gebucht); AC-S5-5 charakterisiert die
+Fehlzeichen-Divergenz (HTML `—` U+2014 vs. Klartext `-` U+002D) bewusst ohne
+Fix (PO-Entscheidung dieser Spec: kosmetisch); AC-S5-6 verankert die 15
+bereits gedeckten Zeilen gegen stillen Verlust ihrer Testabdeckung.
+**Kein Produktivcode-Fix.** Adversary VERIFIED, alle 4 Pflicht-Mutationen plus
+eine selbst gewählte Zusatz-Mutation exakt vom vorgesehenen Test gefangen.
+Details: `docs/specs/modules/fix_1703_s5_compare_zellwerte.md`.
 
 ### Scheibe 6 — Form-Wächter über Grammatik-Klassen
 

--- a/docs/specs/modules/fix_1703_s5_compare_zellwerte.md
+++ b/docs/specs/modules/fix_1703_s5_compare_zellwerte.md
@@ -1,0 +1,445 @@
+---
+entity_id: fix_1703_s5_compare_zellwerte
+type: module
+created: 2026-08-12
+updated: 2026-08-12
+status: draft
+version: "1.0"
+tags: [metrics, compare, overview, matrix-test, epic-1703]
+---
+
+<!-- Epic #1703 (Folgearbeit aus #1514), Scheibe 5. Schliesst Flaeche 4 aus
+     docs/reference/metric_output_matrix.md §4.2/§6 (Compare-Uebersichtstabelle:
+     Zellwert je Metrik, HTML/Klartext-Paritaet). Reine Charakterisierung +
+     zwei neue, generische Struktur-Achsen (Formatierungs-Konsistenz,
+     Fehlzeichen), KEIN Produktivcode-Fix. -->
+
+# Compare-Zellwert-Vollständigkeit (#1703 Scheibe 5)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`tests/tdd/test_channel_metric_matrix.py` (Option C, EIN Register, keine neue
+Datei — #1677 B) um eine fünfte Achse (`AC-S5-n`) erweitern, analog Scheibe 1
+(`AC-S1-n`), Scheibe 2 (`AC-S2-n`) und Scheibe 4 (`AC-S4-n`) in derselben
+Datei. Ziel ist die Compare-**Übersichtstabelle** (`CV2_METRICS`,
+`compare_html.py:305-371`, 25 Metrik-Zeilen + `warn`): über die reine
+Zeilen-**Existenz** hinaus soll geprüft werden, dass jede Zelle einen
+plausiblen, unabhängig gerechneten Wert trägt — und dass HTML und Klartext
+derselben Mail für dieselbe Wetterlage dieselbe Zahl zeigen.
+
+**Kein Produktivcode-Fix ist Auftrag dieser Scheibe.** Die Wert-Quelle ist
+bereits geteilt (`comparison.py` importiert `_metric_value` direkt aus
+`compare_html.py`, kein zweiter Berechnungsweg) — das eigentliche Risiko
+liegt in der Formatierung, nicht im Wert selbst, und wird hier
+charakterisiert, nicht verändert.
+
+### Korrektur der Scheiben-Prämisse: Fläche 4 ist nicht „nur Zeilen-Existenz",
+### sondern 15 von 25 Zeilen bereits wertgeprüft
+
+`metric_output_matrix.md` §4.2 (Zeile 250) behauptet pauschal: „nur
+Zeilen-Existenz ist bewacht; ein falscher Wert in der Zelle bleibt grün."
+**Bei Nachmessung im Bestand trifft das nur noch auf 10 der 25 Zeilen zu.**
+Drei Vorläufer-Issues (#1296, #1324, #1351) haben beim Ergänzen fehlender
+Zeilen bereits Wert+Paritäts-Tests mitgeliefert:
+
+| Zeile(n) | Testdatei::Testfunktion | Prüft |
+|---|---|---|
+| temp_min, gust_max, freezing_level | `tests/unit/test_compare_extra_daily_metrics.py::test_selected_{temp_min,gust_max,freezing_level}_metric_appears_in_overview_matrix` + `::test_plaintext_shows_the_three_remaining_new_rows` | HTML-Wert gegen `WeatherMetricsService`, Klartext-Wert gegen dieselbe Referenz |
+| wind_direction_avg, wind_chill_min, cloud_low/mid/high_avg, humidity_avg, dewpoint_avg, pressure_avg, precip_type, snowfall_limit | `tests/unit/test_compare_metric_parity.py::test_selected_*_metric_appears_in_overview_matrix` + `::test_plaintext_shows_all_ten_new_rows` | dieselbe Bauart, 10 Zeilen |
+| wind_chill_max | `tests/test_wind_chill_max_selectable.py::test_compare_html_renderer_shows_wind_chill_max_value` + `::test_compare_plain_renderer_shows_wind_chill_max_value` | dieselbe Bauart, 1 Zeile |
+| thunder_max | `tests/tdd/test_thunder_low_output_channels.py::test_ac11_compare_html_zeigt_leicht` (Teil der laut `metric_output_matrix.md` „bestbewachten" Gewitter-Achse, 6 Renderpfade inkl. Compare-HTML) | Zellwert + Zell-Ampel für das Gewitter-Signal |
+
+Macht **14 + 1 = 15 der 25 Zeilen** bereits wertgeprüft. Die verbleibenden
+**10** Zeilen (`temp_max, wind_max, cloud_avg, sunny_hours, snow_depth_cm,
+snow_new_cm, precip_sum, pop_max, uv_max, visibility_min`) haben **keine**
+unabhängige Wert-Zusicherung — nur eine grobe Regressions-Prüfung mit
+getippten Literalen für drei von ihnen
+(`test_existing_{fifteen,eleven}_metrics_unchanged_after_{addition,fix}`,
+HTML-only, kein Klartext-Abgleich) und generische
+Plausibilitäts-/Format-Prüfung durch den Mail-Validator
+(`tests/unit/test_compare_mail_overview_plausibility_coverage.py`), die einen
+*unplausiblen* Wert findet, aber keinen *falschen* (z. B. eine Feldvertauschung
+mit einem ebenso plausiblen Nachbarwert).
+
+**Konsequenz für den Zuschnitt dieser Scheibe:** kein Duplikat der 15 bereits
+gedeckten Zeilen — stattdessen (a) die 10 ungedeckten Zeilen neu abgesichert
+(AC-S5-2), (b) zwei generische Achsen ergänzt, die *keine* der 25 Bestandstests
+prüft: Formatierungs-Konsistenz zwischen `format_value()` und
+`_fmt_metric`/`CV2_METRICS`-`decimals` (AC-S5-4) und die
+Fehlzeichen-Divergenz HTML vs. Klartext (AC-S5-5), (c) ein Abhängigkeits-Anker
+auf die 15 bereits gedeckten Zeilen, damit ein künftiges stilles Löschen
+dieser Testdateien nicht unbemerkt eine Lücke reißt (AC-S5-6, Lehre aus
+Scheibe 1/2 F001: „rechnen statt tippen" sichert Vollständigkeit nur, wenn die
+Abhängigkeit selbst bewacht ist).
+
+### Entscheidung der drei offenen Fragen (PO-Empfehlung dieser Spec)
+
+1. **Em-Dash/Hyphen-Divergenz (HTML `—` vs. Klartext `-` bei fehlendem
+   Wert):** **charakterisieren, nicht fixen.** Kosmetisch, keine
+   Fehlinformation (beide Zeichen sind für den Leser eindeutig „kein Wert") —
+   passt ins Sammel-Issue #1199, kein eigener Fix in dieser Scheibe (AC-S5-5
+   hält den Ist-Zustand fest, ein künftiger *stiller* Wechsel eines der beiden
+   Zeichen fällt aber auf).
+2. **Formatierungs-Stichprobe vs. Vollabdeckung (`format_value(...,
+   style="plain")` gegen `_fmt_metric(..., decimals=...)`):** **alle
+   gemessenen Felder einzeln**, nicht nur eine Stichprobe. Kein bestehender
+   Wächter hält `format_value` und den `CV2_METRICS`-`decimals`-Dict
+   synchron; ein künftiges Auseinanderlaufen (z. B. eine Katalog-Änderung an
+   `temperature.decimals`) muss feldgenau auffallen, nicht nur „irgendwo".
+   **Korrektur gegenüber dem Context-Dokument:** dort war von „9 Feldern" die
+   Rede — bytegenau nachgezählt sind es **10** (`temp_max, temp_min, wind_max,
+   gust_max, wind_chill_min, wind_chill_max, cloud_avg, snow_depth_cm,
+   sunny_hours, dewpoint_avg`; die Aufzählung im Context-Dokument nannte
+   dieselben zehn Felder, nur die Summe war um eins daneben — Lehre aus
+   Scheibe 2 F001: falsche Prämissen in ACs sind der teuerste Fehlertyp,
+   deshalb hier vor dem Schreiben der ACs am Code nachgezählt statt aus dem
+   Context-Dokument übernommen).
+3. **`warn`-Zeile aus der 25er-Soll-Menge ausnehmen:** **ja**, analog Scheibe
+   2 (Ausblick-Tabelle) und dem bestehenden Wächter
+   `test_compare_mail_metric_link_completeness.py`, der die Warn-Zeile aus
+   demselben Grund überspringt: sie zeigt gestapelte Warn-Chips, keinen
+   numerischen Wert.
+
+## Source
+
+> **Schicht-Hinweis:** ausschließlich Python-Core, ausschließlich Testcode
+> (`tests/tdd/`). Kein Frontend, keine Go-Beteiligung.
+
+- **File (Prüfling HTML):** `src/output/renderers/email/compare_html.py` —
+  `CV2_METRICS` (:305-371), `_fmt_metric` (:703), `_metric_value` (:644),
+  `_DAILY_AGGREGATE_FIELD` (:608), `_render_overview_row` (:712)
+- **File (Prüfling Klartext):** `src/output/renderers/comparison.py` —
+  `_PLAIN_ROWS`/`_DAILY_PLAIN_ROWS` (:70-120), `render_comparison_text`
+  (:143-258, Fehlzeichen-Zeile :249), `_fmt_overview_cell` (:505)
+- **File (Formatierungsquelle 3):** `src/output/metric_format.py` —
+  `format_value()` (:67-117, `_NO_VALUE = "–"` U+2013, **im Compare-
+  Übersichtspfad nicht erreichbar**, s. „Die Fehlzeichen-Lage" unten)
+- **File (Wächter):** `tests/tdd/test_channel_metric_matrix.py`
+
+**Ausdrücklich UNVERÄNDERT (reine Prüfziele, kein Edit):** `CV2_METRICS`,
+`_fmt_metric`, `_metric_value`, `_DAILY_AGGREGATE_FIELD`, `_PLAIN_ROWS`,
+`_DAILY_PLAIN_ROWS`, `format_value`, `render_compare_email`.
+
+## Bindende Test-Architektur-Entscheidung (PFLICHT, Prüfort = Wirkort)
+
+Alle **neuen** Tests dieser Scheibe (AC-S5-2, AC-S5-3, AC-S5-5) MÜSSEN über
+`render_compare_email(result, ...)` — **einen** Aufruf, der HTML und Klartext
+zurückgibt — laufen, nicht über zwei isolierte Aufrufe von
+`render_compare_html()`/`render_comparison_text()`. Grund: `render_compare_email`
+ist der tatsächliche Produktions-Einstiegspunkt („Single entry point for all
+compare-email render callers", `comparison.py:415`); ein isolierter
+Doppelaufruf bewiese Paritätsfreiheit nur unter der (hier zutreffenden, aber
+nicht selbstverständlichen) Annahme, dass beide Funktionen rein und
+seiteneffektfrei sind. Die Vorgänger-Tests aus #1296/#1324 riefen beide
+Renderer separat auf demselben `ComparisonResult` — das war für ihren Zweck
+ausreichend, aber diese Scheibe folgt dem strengeren Muster aus Scheibe 2
+(AC-S2-8: „ein Aufruf liefert beide Formen"), um die Klartext-blinde-Fleck-
+Erfahrung aus #1366 nicht zu wiederholen.
+
+## Estimated Scope
+
+- **LoC:** ~200-280 Testcode (6 ACs, eine generische Achse mit 10 Zeilen, zwei
+  Stichproben-Achsen, ein Struktur-Check über 10 Katalogfelder, ein
+  Abhängigkeits-Anker). Kein Produktivcode-Delta.
+- **Files:** 3 (`tests/tdd/test_channel_metric_matrix.py` Erweiterung,
+  `docs/specs/modules/fix_1703_s5_compare_zellwerte.md` CREATE,
+  `docs/reference/metric_output_matrix.md` MODIFY als Definition-of-Done-Schritt
+  — zählt nicht gegen das LoC-Limit, `docs/` ist ausgenommen).
+- **Effort:** medium — kleiner als Scheibe 2/4, weil ein erheblicher Teil der
+  Fläche bereits durch #1296/#1324/#1351 gedeckt ist (s. Korrektur-Abschnitt).
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `src/output/renderers/email/compare_html.py::CV2_METRICS`/`_metric_value`/`_fmt_metric` | Prüfling (HTML) | Zeilen-Definition, Wert-Auflösung, generische Formatierung |
+| `src/output/renderers/comparison.py::_PLAIN_ROWS`/`_DAILY_PLAIN_ROWS`/`render_compare_email` | Prüfling (Klartext + kombinierter Einstieg) | Klartext-Formatierung, Fehlzeichen-Zweig (:249) |
+| `src/output/metric_format.py::format_value`/`src/app/metric_catalog.py::get_metric` | Formatierungsquelle 3 | Katalog-`decimals` für die 10 `format_value`-Felder |
+| `src/services/weather_metrics.py::summarize_points`/`WeatherMetricsService.compute_basis_metrics` | Soll-Wert-Quelle (Klasse B / Klasse A mit Trip-Regel) | unabhängig gerechnete Erwartungswerte für die 10 neu geprüften Zeilen |
+| `tests/unit/test_compare_metric_parity.py`, `test_compare_extra_daily_metrics.py`, `tests/test_wind_chill_max_selectable.py`, `tests/tdd/test_thunder_low_output_channels.py` | Abhängigkeits-Anker (AC-S5-6) | die bereits 15 wertgeprüften Zeilen — dürfen nicht unbemerkt verschwinden |
+| `tests/unit/test_compare_mail_metric_link_completeness.py` | Abgrenzung | Zeilen-**Existenz** (Register-Verknüpfung), nicht Zellwert — bleibt unverändert |
+| `docs/specs/modules/fix_1703_s2_ausblick_matrix.md` (AC-S2-8) | Vorbild-Muster | „Soll unabhängig aus Rohdaten rechnen" + Vakuum-Gegenprobe |
+
+## Implementation Details
+
+### Die 10 neu zu prüfenden Zeilen — Klasse A vs. Klasse B
+
+`_metric_value()` liest zwei strukturell verschiedene Wege (`compare_html.py:644-654`):
+
+- **Klasse A** (kein Eintrag in `_DAILY_AGGREGATE_FIELD`): `getattr(loc, key,
+  None)` — der Renderer liest ein bereits fertiges `LocationResult`-Feld,
+  ohne selbst zu aggregieren. Betroffen: `temp_max, wind_max, cloud_avg,
+  sunny_hours, snow_depth_cm, snow_new_cm` (6 der 10).
+- **Klasse B** (Eintrag in `_DAILY_AGGREGATE_FIELD`): Engine-Feld hat
+  Vorrang, sonst Live-Ableitung über `_daily_summary()` →
+  `summarize_points(loc.hourly_data)`. Betroffen: `precip_sum, pop_max,
+  uv_max, visibility_min` (4 der 10; `thunder_max` ist ebenfalls Klasse B,
+  aber s. Known Limitations — nicht Teil dieser Achse).
+
+**Soll-Berechnung je Klasse** (kein Wert wird aus dem Renderer selbst
+abgeschrieben):
+
+| Zeile | Klasse | Soll-Regel |
+|---|---|---|
+| `temp_max`, `wind_max`, `cloud_avg`, `sunny_hours` | A | `WeatherMetricsService().compute_basis_metrics(ts).{temp_max_c,wind_max_kmh,cloud_avg_pct,sunny_hours}` über dieselben rohen `ForecastDataPoint` — dieselbe kanonische Trip-Regel, die bereits die 15 gedeckten Zeilen als Referenz nutzen |
+| `snow_depth_cm`, `snow_new_cm` | A, ohne Trip-Regel erreichbar | direkt auf `LocationResult` gesetzter, unterscheidbarer Literalwert (analog `cloud_low_avg` in #1324) — die Renderer-Zusicherung ist „liest das richtige Feld, formatiert richtig, zeigt in HTML+Klartext denselben Wert", **nicht** „die Aggregationsformel stimmt" (die liegt in der ComparisonEngine, außerhalb dieses Renderers, s. Known Limitations) |
+| `precip_sum` (sum), `pop_max` (max), `uv_max` (max), `visibility_min` (min) | B, Live-Ableitung | aus rohen Stundenwerten nach der bei `summarize_points()` (`weather_metrics.py:470-481`) hinterlegten Regel gerechnet — Muster identisch zu `_S2_NEUE_FELDER_REGEL` (AC-S2-8) |
+
+**Vakuum-Gegenprobe (PFLICHT):** alle 10 Testwerte müssen paarweise
+unterscheidbar sein — sonst bliebe eine Feldvertauschung in
+`_DAILY_AGGREGATE_FIELD` oder eine falsche Zeilen-Zuordnung in `CV2_METRICS`
+unsichtbar (Lehre aus AC-S2-8/F001).
+
+**`visibility_min` Einheiten-Hinweis:** die Zeile nutzt `_fmt_visibility_overview`
+(m → km-Umrechnung), nicht den generischen `_fmt_metric`-Pfad — die
+Ist-Wert-Extraktion muss den Faktor 1000 kennen, sonst meldet der Test einen
+falschen Mismatch.
+
+### Engine-Vorrang (AC-S5-3) — Stichprobe, kein Vollabdeckungs-Anspruch
+
+Die Vorrangregel `if value is not None: return value` (vor der
+Live-Ableitung, `compare_html.py:648-651`) ist **generischer, feldunabhängiger
+Code** — sie wird nicht elfmal dupliziert. Ein Nachweis an zwei Feldern
+(`precip_sum`, `pop_max`; beide generischer `_fmt_metric`-Pfad, unterschiedliche
+Nachkommastellen 1 vs. 0) genügt, um die Regel zu demonstrieren. Bisher
+**ungetestet**: alle bestehenden Klasse-B-Tests aus #1296/#1324 setzen
+bewusst **kein** Engine-Feld und prüfen nur den Live-Fallback (Kommentar
+`test_compare_extra_daily_metrics.py:86-89`: „bekommen bewusst KEIN
+`LocationResult`-Feld").
+
+### Formatierungs-Konsistenz (AC-S5-4) — 10 Felder, rein strukturell
+
+Kein Rendering nötig — reiner Katalog-Abgleich: für jedes der 10 Felder wird
+`get_metric(<im Klartext-Lambda tatsächlich übergebene metric_id>).decimals`
+(oder 0 bei `None`) gegen `CV2_METRICS[<key>].get("decimals")` (oder 0 bei
+fehlend, `_fmt_metric`-Default) gehalten:
+
+| CV2-Key | Klartext ruft `format_value(...)` mit | gemessen: Katalog-`decimals` | gemessen: `CV2_METRICS`-`decimals` |
+|---|---|---|---|
+| `temp_max`, `temp_min` | `"temperature"` | 0 | 0 (kein Eintrag) |
+| `wind_max` | `"wind"` | 0 | 0 |
+| `gust_max` | `"wind"` | 0 | 0 |
+| `wind_chill_min`, `wind_chill_max` | `"temperature"` ⚠️ | 0 | 0 |
+| `dewpoint_avg` | `"temperature"` ⚠️ | 0 | 0 |
+| `cloud_avg` | `"cloud_total"` | 0 | 0 |
+| `snow_depth_cm` | `"snow_depth"` | 0 | 0 |
+| `sunny_hours` | `"sunshine"` (style `"bare"`, manueller `"h"`-Suffix) | 1 | 1 |
+
+**Verifizierter Nebenbefund (⚠️, keine Fehlfunktion heute):** die
+Klartext-Lambdas für `wind_chill_min`, `wind_chill_max` und `dewpoint_avg`
+rufen `format_value("temperature", ...)` — mit der Katalog-ID der
+**Temperatur**, nicht mit der eigenen ID (`"wind_chill"`/`"dewpoint"`). Heute
+ohne sichtbare Wirkung, weil `wind_chill.decimals` und `dewpoint.decimals`
+beide (über den `None`-Default) ebenfalls 0 sind — bei einer künftigen
+unabhängigen Katalog-Änderung (z. B. `wind_chill.decimals = 1`) würde die
+Klartext-Zeile trotzdem bei 0 Nachkommastellen bleiben, weil sie faktisch die
+`temperature`-Konfiguration liest. AC-S5-4 hält diese drei Zeilen **einzeln**
+fest (nicht nur aggregiert), damit ein künftiges Auseinanderlaufen sofort die
+richtige Zeile benennt. Nebenbefund-Eintrag in #1199 vorgesehen, kein Fix
+dieser Scheibe (kosmetisch, aktuell folgenlos).
+
+### Die Fehlzeichen-Lage (AC-S5-5) — zwei Zeichen im Übersichtspfad, nicht drei
+
+| Zeichen | Bedeutung | Quelle | Im Compare-Übersichtspfad erreichbar? |
+|---|---|---|---|
+| `—` (U+2014, EM DASH) | Wert fehlt | `_fmt_metric(None, …)` (`compare_html.py:705`) | **ja** — HTML-Zellen ohne Wert, generischer `_fmt_metric`-Pfad |
+| `-` (U+002D, ASCII HYPHEN) | Wert fehlt | `render_comparison_text()` Zeile 249 (`else "-"`, VOR jedem `fmt`-Aufruf) | **ja** — Klartext-Zeilen ohne Wert, für ALLE Zeilen (auch die drei mit eigenem `fmt`) |
+| `–` (U+2013, EN DASH) | Wert fehlt | `format_value()`s `_NO_VALUE` (`metric_format.py:96`) | **nein** — die Klartext-Lambdas prüfen `value is not None` bereits VOR dem `format_value`-Aufruf; dieser Zweig ist im Compare-Übersichtspfad strukturell tot |
+
+AC-S5-5 prüft also eine **zwei**-Zeichen-Divergenz, nicht drei — wer hier drei
+Striche vermutet, verwechselt eine im Modul existierende, aber an dieser
+Stelle unerreichbare Konstante mit dem tatsächlich gerenderten Zeichen (Lehre
+aus S2s eigener Fehlzeichen-Tabelle: „irgendein Strich" ist keine Prüfung).
+Geprüft wird eine Stichprobe von zwei generischen `_fmt_metric`-Zeilen
+(`temp_max`, `cloud_avg`) mit fehlendem Wert — die drei Zeilen mit eigenem
+`fmt` (`thunder_max`, `visibility_min`, `precip_type`) haben ihre eigene
+None-Behandlung und sind hier ausdrücklich **nicht** geprüft (Known
+Limitations).
+
+## Expected Behavior
+
+- **Input:** dieselben `CV2_METRICS`/`_PLAIN_ROWS`-Register (unverändert), ein
+  `LocationResult` mit gezielt gesetzten Klasse-A-Feldern und einem reich
+  besetzten `hourly_data`-Satz für die Klasse-B-Live-Ableitung, keine echten
+  PO-Daten.
+- **Output:** ein neuer, grüner Testblock in
+  `tests/tdd/test_channel_metric_matrix.py`, der die 10 bislang ungeprüften
+  Zellen der Compare-Übersichtstabelle wertmäßig absichert, die
+  Formatierungs-Konsistenz zwischen den drei Formatierungswegen strukturell
+  festhält, die Fehlzeichen-Divergenz charakterisiert und die 15 bereits
+  gedeckten Zeilen über einen Abhängigkeits-Anker vor stillem Wegfall schützt.
+- **Side effects:** keine. Kein Produktivcode-Edit, keine neue Persistenz,
+  kein neues Pflicht-Gate (Erweiterung des bestehenden #1677-B-Gates).
+
+## Acceptance Criteria
+
+- **AC-S5-1 (Soll-Menge gerechnet, Bucket-Vollständigkeit):** Gegeben
+  `CV2_METRICS` ohne die `warn`-Zeile, wenn die zu prüfende Soll-Menge
+  bestimmt wird, dann sind es genau 25 Metrik-Zeilen (Vakuum-Schutz ≥ 20,
+  analog AC-S2-2), und die Aufteilung „15 bereits wertgeprüft (AC-S5-6) + 10
+  neu geprüft (AC-S5-2)" ergibt exakt diese 25 — ohne Überschneidung, ohne
+  Lücke.
+  - Test: `len(CV2_METRICS) - 1 == 25` (minus Warn-Zeile) plus
+    `len(bereits_gedeckt) + len(neu_geprueft) == 25` und
+    `bereits_gedeckt.isdisjoint(neu_geprueft)`, beide Mengen aus dem
+    Produktivmodul (`CV2_METRICS`-Keys) gerechnet, nicht getippt.
+
+- **AC-S5-2 (die 10 ungeprüften Zeilen zeigen den gerechneten Wert, HTML UND
+  Klartext):** Gegeben ein `LocationResult` mit den 10 Zeilen aus der obigen
+  Tabelle auf paarweise unterscheidbare Werte gesetzt bzw. aus rohen
+  Stundenwerten gerechnet, wenn die echte Vergleichs-Mail über
+  `render_compare_email()` gerendert wird, dann zeigt sowohl die HTML-Zelle
+  als auch die Klartext-Zeile jeder der 10 Zeilen exakt den erwarteten,
+  formatierten Wert — kein Fehlzeichen, kein vertauschtes Feld.
+  - Test: Vakuum-Gegenprobe vor der Wert-Zusicherung (analog
+    `_s2_erwartungen_sind_unterscheidbar`); HTML-Zellenauflösung über die
+    `min-width:760px`-Übersichtstabelle (Muster `_overview_rows()` aus
+    `test_compare_metric_parity.py`), Klartext-Zeilenauflösung über
+    `derive_row_labels(..., form="long")` + Label-Präfix-Parsing (Muster
+    `_plain_row_value()`).
+
+- **AC-S5-3 (Klasse B: Engine-Feld hat Vorrang vor Live-Ableitung,
+  Stichprobe):** Gegeben ein `LocationResult`, bei dem sowohl das
+  Engine-Tagesfeld (`precip_sum_mm`, `pop_max_pct`) als auch `hourly_data`
+  gesetzt sind, mit voneinander abweichenden Werten, wenn die echte
+  Vergleichs-Mail gerendert wird, dann zeigt die Zelle (HTML wie Klartext)
+  den Engine-Wert, nicht den aus den Stundenwerten live abgeleiteten Wert.
+  - Test: zwei Felder genügen (generischer, feldunabhängiger Code-Pfad in
+    `_metric_value()`, s. Implementation Details) — kein Anspruch auf alle 11
+    Klasse-B-Zeilen.
+
+- **AC-S5-4 (Formatierungs-Konsistenz `format_value` vs. `_fmt_metric`/
+  `CV2_METRICS`-`decimals`, 10 Felder einzeln):** Gegeben die 10 Zeilen, deren
+  Klartext-Formatierung über den katalog-getriebenen
+  `format_value(metric_id, v, style=...)` läuft (`temp_max, temp_min,
+  wind_max, gust_max, wind_chill_min, wind_chill_max, cloud_avg,
+  snow_depth_cm, sunny_hours, dewpoint_avg` — bytegenau nachgezählt, s.
+  Korrektur oben), wenn die Nachkommastellen aus `get_metric(<im Lambda
+  verwendete metric_id>).decimals` (Klartext-Pfad) gegen
+  `CV2_METRICS[...]["decimals"]`/`_fmt_metric`-Default (HTML-Pfad) gehalten
+  werden, dann stimmen sie für jedes der 10 Felder **einzeln** überein —
+  heute alle bei 0 außer `sunny_hours` (1 auf beiden Seiten).
+  - Test: reiner Struktur-Vergleich, kein Rendering nötig; parametrisiert
+    über die 10 Felder, jeder Fehlschlag benennt genau das betroffene Feld.
+    Hält zusätzlich den `wind_chill`/`dewpoint`-vs-`temperature`-Nebenbefund
+    fest (Kommentar mit Verweis auf #1199).
+
+- **AC-S5-5 (Fehlzeichen-Charakterisierung, zwei Zeichen):** Gegeben eine
+  Zelle einer generischen `_fmt_metric`-Zeile (`temp_max` oder `cloud_avg`)
+  ohne verfügbaren Wert, wenn die echte Vergleichs-Mail gerendert wird, dann
+  zeigt HTML `—` (U+2014 EM DASH) und Klartext `-` (U+002D ASCII HYPHEN) für
+  dieselbe fehlende Zelle — diese Divergenz wird als gemessener Ist-Zustand
+  **charakterisiert, nicht gefixt** (PO-Entscheidung dieser Spec, s. Purpose).
+  Ein künftiger stiller Wechsel eines der beiden Zeichen fällt auf.
+  - Test: bytegenauer Zeichenvergleich (`ord()` bzw. Codepoint-Assertion,
+    keine visuelle „sieht aus wie"-Prüfung); der dritte, im Modul existierende
+    En-Dash-Zweig (`format_value`s `_NO_VALUE`) ist hier ausdrücklich NICHT
+    Gegenstand (strukturell unerreichbar, s. Implementation Details).
+
+- **AC-S5-6 (Abhängigkeits-Anker auf die 15 bereits wertgeprüften Zeilen):**
+  Gegeben die vier Testdateien, die heute die Wert+Paritäts-Prüfung für 15 der
+  25 Zeilen tragen (`test_compare_metric_parity.py`,
+  `test_compare_extra_daily_metrics.py`, `test_wind_chill_max_selectable.py`,
+  `test_thunder_low_output_channels.py`), wenn diese Scheibe abgeschlossen
+  ist, dann benennt ein Anker-Test genau diese Dateien/Funktionen namentlich
+  und schlägt sichtbar fehl, wenn eine davon nicht mehr importierbar ist oder
+  eine der genannten Testfunktionen verschwindet.
+  - Test: Muster `AC-S2-7` (Abhängigkeits-Anker auf einen getippten
+    Größenanker) — hier auf vier Dateien statt einer erweitert, jede einzeln
+    benannt, damit ein Fehlschlag sofort sagt, welche Zeile(n) verwaist sind.
+
+## Known Limitations
+
+1. **`thunder_max` ist bewusst nicht Teil von AC-S5-2/AC-S5-5.** Die Zeile
+   nutzt einen eigenen, mehrargumentigen Formatierer (`_fmt_thunder` mit
+   Hagel-Kennzeichen und Signal-Herkunft, `compare_html.py:744-752`) und ist
+   bereits über die dedizierte Gewitter-Testsuite
+   (`test_thunder_low_output_channels.py`, laut `metric_output_matrix.md`
+   „bestbewachter Fall", 6 Renderpfade inkl. Compare-HTML) charakterisiert.
+   Eine zweite, generische Prüfung hier wäre Regel-Zuwachs ohne Fang.
+2. **Klasse-A-Zeilen ohne Trip-Regel (`snow_depth_cm`, `snow_new_cm`) prüfen
+   Feldmapping + Formatierung, nicht die Aggregationsformel.** Die
+   ComparisonEngine, die diese `LocationResult`-Felder aus rohen Stundendaten
+   befüllt, liegt außerhalb dieses Renderers und dieser Scheibe.
+3. **Die drei Zeilen mit eigenem `fmt` (`thunder_max`, `visibility_min`,
+   `precip_type`) sind von AC-S5-5 ausgenommen.** Ihre eigene
+   None-Behandlung (`_fmt_thunder(None,…)`, `_fmt_visibility_overview(None)`,
+   `_fmt_precip_type(None)`) ist hier nicht nachgemessen — mögliches Ziel
+   einer künftigen Scheibe, kein Fund dieser.
+4. **`format_value`s `_NO_VALUE`-Zweig (En-Dash, U+2013) ist im
+   Compare-Übersichtspfad strukturell unerreichbar** (s. Implementation
+   Details „Die Fehlzeichen-Lage") — nicht mit den zwei tatsächlich
+   gerenderten Zeichen zu verwechseln.
+5. **Stundentabelle (`HOUR_METRICS`) ist NICHT Gegenstand dieser Scheibe** —
+   andere Tabelle, bereits durch `tests/unit/test_compare_hourly_catalog_columns.py`
+   gedeckt (laut `metric_output_matrix.md` „der einzige echte
+   Wirkungs-Vollständigkeitstest im Bestand").
+6. **Reihenfolge (Fläche 5) und Form-Dimension (Fläche 8) sind nicht
+   Gegenstand.** Reihenfolge ist bereits durch `_ordered_rows()`/#1359
+   gefixt (Doppel-Quellen-Historie #1356) und Gegenstand von Scheibe 7;
+   Formen (Grammatik-Klassen) sind Scheibe 6.
+7. **Ausblick-Tabelle (Scheibe 2, `outlook_columns()`) ist eine andere
+   Tabelle mit anderer Metrikliste** (`get_compare_metric_catalog()`, 25
+   Paare für den 3-Tages-Ausblick) — nicht zu verwechseln mit `CV2_METRICS`
+   (25 Zeilen für den Tageswert-Übersichtsblock). Beide Listen haben
+   zufällig dieselbe Größe (25), sind aber inhaltlich unabhängig.
+
+## Prüfhinweis für den Adversary
+
+Leitfrage aus CLAUDE.md: **Ist die Zusicherung dort geprüft, wo sie WIRKT —
+oder nur dort, wo der Code steht?** Konkret: AC-S5-2/3/5 MÜSSEN gegen die
+ECHTE Mail (`render_compare_email()`) laufen, nicht gegen isolierte
+`_metric_value()`-Direktaufrufe.
+
+**Mutations-Gegenproben (Pflicht, per String-Ersetzung mit externer
+Sicherungskopie — nie `git checkout/stash/reset`):**
+
+- In `_DAILY_AGGREGATE_FIELD` (`compare_html.py:608`) die Zuordnung zweier
+  der vier Klasse-B-Felder aus AC-S5-2 vertauschen (z. B. `precip_sum` ↔
+  `pop_max`) — MUSS AC-S5-2 rot werden lassen (Feldvertauschungs-Fang, Lehre
+  aus AC-S2-8/F001).
+- Den Vorrang-Zweig in `_metric_value()` (`compare_html.py:648-651`)
+  entfernen (immer live ableiten, Engine-Feld ignorieren) — MUSS AC-S5-3 rot
+  werden lassen.
+- `_fmt_metric`s None-Rückgabe (`compare_html.py:705`) von `"—"` auf `"–"`
+  ändern (Em-Dash → En-Dash) — MUSS AC-S5-5 rot werden lassen (beweist, dass
+  der bytegenaue Zeichenvergleich wirklich das Zeichen prüft, nicht nur „ist
+  ein Strich vorhanden").
+- Für EIN Feld aus AC-S5-4 (z. B. `snow_depth`) `decimals` im Katalog
+  (`metric_catalog.py`) probeweise auf `1` setzen — MUSS **genau die
+  `snow_depth_cm`-Teilprüfung** von AC-S5-4 rot werden lassen, keine der
+  anderen neun (Feld-Granularitäts-Fang).
+
+## Definition of Done
+
+- [ ] AC-S5-1 bis AC-S5-6 grün
+- [ ] Adversary-Verdict VERIFIED, alle vier Pflicht-Mutationen gefangen
+- [ ] `docs/reference/metric_output_matrix.md`: Fläche 4 (§4.2, Zeile 250) und
+      Scheibe 5 (§6) auf erledigt umgetragen, inkl. der Korrektur „14 von 25
+      bereits wertgeprüft" (Doku darf die pauschale Alt-Aussage nicht
+      unkorrigiert stehen lassen)
+- [ ] Issue #1703 Scheiben-Checkbox gesetzt, Ergebnis kommentiert
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine.
+- **Rationale:** reine Testerweiterung eines bereits etablierten,
+  budgetierten Gates (#1677 B); keine neue Entscheidungsfläche (kein Kanal,
+  kein Provider, kein Datenmodell-, Auth- oder Editor-Paradigma-Wechsel).
+  Analog zu Scheibe 3/4.
+
+## Changelog
+
+- 2026-08-12: Initial spec created (Epic #1703, Scheibe 5). Scheiben-Prämisse
+  gegen den Bestand nachgemessen: 15 von 25 Zeilen bereits über #1296/#1324/
+  #1351/Gewitter-Suite wertgeprüft, statt der pauschal „unbewacht"
+  behaupteten Fläche 4. Zuschnitt entsprechend auf die 10 ungeprüften Zeilen
+  plus zwei neue generische Achsen (Formatierungs-Konsistenz,
+  Fehlzeichen-Charakterisierung) plus Abhängigkeits-Anker reduziert. Drei
+  offene Fragen aus dem Context-Dokument entschieden: Em-Dash/Hyphen
+  charakterisieren statt fixen, alle 10 (korrigiert von „9") Formatierungs-
+  Felder einzeln statt Stichprobe, `warn`-Zeile ausgenommen.

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -54,6 +54,7 @@ Tages-Aggregationspfade sind auseinandergelaufen).
 from __future__ import annotations
 
 import dataclasses
+import importlib
 import json
 import re
 from collections import Counter
@@ -80,6 +81,7 @@ from output.renderers.alert.render import (
 )
 from output.channels.premium_sms import PremiumSmsOutput
 from output.renderers.channel_layout import render_for_channel
+from output.renderers.email.compare_html import CV2_METRICS
 from output.renderers.compare_metric_catalog import COMPARE_METRIC_CATALOG, get_compare_metric_catalog
 from output.renderers.compare_metric_ids import FRONTEND_TO_RENDERER_METRIC_ID, resolve_enabled_metrics
 from output.renderers.comparison import render_compare_email
@@ -3155,3 +3157,507 @@ def test_ac_s4_14_telegram_narrow_confidence_absent():
     'confidence' bereits ab, bevor render_telegram_bubbles() sie sieht."""
     lines = _s4_kurzuebersicht(_single_metric_dc("confidence", enabled=True))
     assert lines == [], f"AC-S4-14: 'confidence' erscheint: {lines!r}"
+
+
+# ===========================================================================
+# Epic #1703 Scheibe 5 (AC-S5-1 bis AC-S5-6): Compare-Zellwert-
+# Vollstaendigkeit der Uebersichtstabelle (CV2_METRICS,
+# docs/reference/metric_output_matrix.md Flaeche 4). Reine
+# Charakterisierung, kein Produktivcode-Fix.
+# SPEC: docs/specs/modules/fix_1703_s5_compare_zellwerte.md
+#
+# Korrektur der Scheiben-Praemisse (s. Spec): 15 der 25 Uebersichtszeilen
+# sind bereits wertgeprueft (#1296/#1324/#1351, Gewitter-Suite) -- AC-S5-6
+# haelt den Abhaengigkeits-Anker darauf. Diese Scheibe schliesst die
+# restlichen 10 Zeilen (AC-S5-2, Engine-Vorrang-Stichprobe AC-S5-3) und
+# ergaenzt zwei generische Achsen, die KEINER der 25 Bestandstests prueft:
+# Formatierungs-Konsistenz (AC-S5-4) und Fehlzeichen-Divergenz (AC-S5-5).
+#
+# Pruefort = Wirkort (Bindende Test-Architektur-Entscheidung der Spec):
+# AC-S5-2/3/5 laufen ueber ``render_compare_email()`` -- EIN Aufruf liefert
+# HTML UND Klartext derselben Mail, kein isolierter Doppelaufruf (sonst
+# Klartext-blinder Fleck, #1366).
+# ===========================================================================
+
+_S5_CV2_BY_KEY: dict[str, dict] = {m["key"]: m for m in CV2_METRICS}
+
+
+def _s5_label(key: str) -> str:
+    """Beschriftung derselben Zeile wie im Renderer -- ueber den Katalog
+    abgeleitet (``label_de``, Muster ``derive_row_labels``), nicht
+    getippt. Innerhalb JEDER in dieser Scheibe gefilterten Zeilenauswahl
+    ist jede der zehn Metrik-IDs paarweise verschieden (s. unten), daher
+    ohne Kollisions-Zusatz ('Maximum'/'Minimum')."""
+    return get_metric(_S5_CV2_BY_KEY[key]["metric_id"]).label_de
+
+
+_S5_TAGS = re.compile(r"<[^>]+>")
+
+
+def _s5_overview_rows(html: str) -> list[dict]:
+    """Zeilen der Uebersichtstabelle als {'label': str, 'cells': [...]}} --
+    Muster ``_overview_rows()`` aus ``test_compare_metric_parity.py`` (Spec
+    AC-S5-2 Test-Hinweis)."""
+    start = html.index("min-width:760px")
+    body = html[html.index("<tbody>", start) + len("<tbody>"):html.index("</tbody>", start)]
+    rows = []
+    for row_html in re.findall(r"<tr[^>]*>(.*?)</tr>", body, re.S):
+        cells = [
+            _S5_TAGS.sub("", c).strip()
+            for c in re.findall(r"<td[^>]*>(.*?)</td>", row_html, re.S)
+        ]
+        if cells:
+            rows.append({"label": cells[0], "cells": cells[1:]})
+    return rows
+
+
+def _s5_html_wert(html: str, label: str) -> str:
+    zeilen = _s5_overview_rows(html)
+    treffer = [r for r in zeilen if r["label"] == label]
+    assert len(treffer) == 1, (
+        f"AC-S5: erwartet genau eine HTML-Zeile mit Beschriftung {label!r}, "
+        f"gefunden {len(treffer)}: {[r['label'] for r in zeilen]}"
+    )
+    assert len(treffer[0]["cells"]) == 1, (
+        f"AC-S5: erwartet genau eine Wertzelle (ein Ort) fuer {label!r}, "
+        f"gefunden {treffer[0]['cells']!r}"
+    )
+    return treffer[0]["cells"][0]
+
+
+def _s5_klartext_wert(text: str, label: str) -> str:
+    """Klartext-Zeilenwert -- Muster ``_plain_row_value()`` aus
+    ``test_compare_metric_parity.py`` (Spec AC-S5-2 Test-Hinweis), hier per
+    Label-PRAEFIX statt Schluesselwort-Enthaltensein: die Beschriftung ist
+    innerhalb der gefilterten Auswahl dieser Scheibe eindeutig."""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(f"{label}:"):
+            return stripped.split(":", 1)[1].strip()
+    pytest.fail(
+        f"AC-S5: im Klartext derselben Mail ist keine Zeile {label!r} "
+        f"auffindbar.\n{text}"
+    )
+    return ""  # unreachable, haelt Typpruefer ruhig
+
+
+_S5_ZELLENZAHL = re.compile(r"^-?\d+(?:[.,]\d+)?")
+
+
+def _s5_zellenzahl(zelle: str) -> float:
+    """Die fuehrende Zahl einer Uebersichts-Zelle ("22°C" -> 22.0). Geprueft
+    wird der WERT, nicht die Schreibweise -- Einheit/Nachkommastellen
+    bewacht AC-S5-4."""
+    treffer = _S5_ZELLENZAHL.match(zelle.strip())
+    assert treffer is not None, (
+        f"AC-S5: die Zelle {zelle!r} beginnt nicht mit einer Zahl -- ohne "
+        "Zahl ist der Wert nicht pruefbar"
+    )
+    return float(treffer.group().replace(",", "."))
+
+
+# Klasse-A-Felder ohne Trip-Regel (snow_depth_cm/snow_new_cm, s. Spec
+# Implementation Details): unterscheidbarer Literalwert statt Aggregation --
+# die ComparisonEngine, die diese Felder aus Stundendaten befuellt, liegt
+# ausserhalb dieses Renderers (Known Limitations Punkt 2).
+_S5_SNOW_DEPTH_CM = 12.0
+_S5_SNOW_NEW_CM = 7.0
+
+# Vier reich besetzte Stundenpunkte EINES Tages (Spalten: Stunde, Temp,
+# Wind, Wolken, Regen, PoP, UV, Sicht_m, DNI) -- jedes der zehn Felder
+# unterschiedlich ueber die Stunden verteilt, damit MIN/MAX/SUM/AVG sich
+# unterscheiden (Vakuum-Gegenprobe unten, Lehre AC-S2-8).
+_S5_STUNDENWERTE = (
+    (6, 10.0, 15.0, 20, 1.0, 30, 2.0, 15000, 100.0),
+    (10, 18.0, 25.0, 50, 2.0, 50, 6.0, 12000, 500.0),
+    (14, 22.0, 35.0, 60, 1.4, 65, 9.0, 8000, 700.0),
+    (18, 15.0, 20.0, 30, 0.0, 40, 3.0, 20000, 200.0),
+)
+
+
+def _s5_punkte() -> list[ForecastDataPoint]:
+    return [
+        ForecastDataPoint(
+            ts=datetime(2026, 8, 12, stunde, 0, tzinfo=timezone.utc),
+            t2m_c=temp, wind10m_kmh=wind, cloud_total_pct=wolken,
+            precip_1h_mm=regen, pop_pct=pop, uv_index=uv, visibility_m=sicht,
+            dni_wm2=dni, is_day=1, thunder_level=ThunderLevel.NONE,
+        )
+        for stunde, temp, wind, wolken, regen, pop, uv, sicht, dni in _S5_STUNDENWERTE
+    ]
+
+
+def _s5_timeseries(hourly: list[ForecastDataPoint]) -> NormalizedTimeseries:
+    meta = ForecastMeta(provider=Provider.OPENMETEO, model="s5-test", grid_res_km=1.0)
+    return NormalizedTimeseries(meta=meta, data=hourly)
+
+
+def _s5_location(hourly: list[ForecastDataPoint]):
+    """Klasse A (temp_max/wind_max/cloud_avg/sunny_hours): derselbe Trip-Weg
+    wie die 15 bereits gedeckten Zeilen (``WeatherMetricsService``, s. Spec
+    Implementation Details) -- diese Werte werden wie von der
+    ComparisonEngine VORGEGEBEN behandelt, der Renderer liest sie nur per
+    ``getattr`` (Klasse A hat keine eigene Aggregation). snow_depth_cm/
+    snow_new_cm: unterscheidbarer Literalwert (Klasse A ohne Trip-Regel).
+    Klasse-B-Felder (precip_sum_mm etc.) bleiben BEWUSST auf ihrem Default
+    None -- AC-S5-2 prueft damit den Live-Ableitungspfad, AC-S5-3 separat
+    den Engine-Vorrang."""
+    from app.user import LocationResult, SavedLocation
+
+    basis = WeatherMetricsService().compute_basis_metrics(_s5_timeseries(hourly))
+    return LocationResult(
+        location=SavedLocation(
+            id="s5-ort", name="S5-Ort", lat=47.0, lon=11.0, elevation_m=500,
+        ),
+        score=50,
+        temp_max=basis.temp_max_c, wind_max=basis.wind_max_kmh,
+        cloud_avg=basis.cloud_avg_pct, sunny_hours=basis.sunny_hours,
+        snow_depth_cm=_S5_SNOW_DEPTH_CM, snow_new_cm=_S5_SNOW_NEW_CM,
+        hourly_data=hourly,
+    )
+
+
+_S5_NEU_GEPRUEFT_ORDER = (
+    "temp_max", "wind_max", "cloud_avg", "sunny_hours",
+    "snow_depth_cm", "snow_new_cm", "precip_sum", "pop_max", "uv_max",
+    "visibility_min",
+)
+
+_S5_DECIMALS: dict[str, int] = {
+    "temp_max": 0, "wind_max": 0, "cloud_avg": 0, "sunny_hours": 1,
+    "snow_depth_cm": 0, "snow_new_cm": 0, "precip_sum": 1, "pop_max": 0,
+    "uv_max": 0, "visibility_min": 1,
+}
+# visibility_min: HTML/Klartext zeigen km, die Fixture traegt m (Faktor
+# 1000, s. Spec "visibility_min Einheiten-Hinweis").
+_S5_FAKTOR: dict[str, float] = {"visibility_min": 0.001}
+
+
+def _s5_erwartete_werte(hourly: list[ForecastDataPoint]) -> dict[str, float]:
+    """Die zehn Soll-Tageswerte, UNABHAENGIG von der Uebersichtstabelle
+    gerechnet (Spec Implementation Details, Klasse A/B).
+
+    Klasse A (temp_max/wind_max/cloud_avg/sunny_hours) kommt aus derselben
+    Trip-Regel, mit der ``_s5_location`` das ``LocationResult`` befuellt --
+    der Renderer hat hierfuer keine eigene Aggregation, ein Fehler koennte
+    nur in der Zellzuordnung/Formatierung stecken.
+
+    Klasse B (precip_sum/pop_max/uv_max/visibility_min) wird HANDFEST aus
+    den Stundenwerten gerechnet (SUM/MAX/MAX/MIN) -- NICHT ueber
+    ``summarize_points()``/``compute_basis_metrics()``: sonst hielte ein
+    Fehler in deren ``_compute_*``-Regeln die Renderer-Ausgabe gegen sich
+    selbst, und eine vertauschte Zuweisung bliebe unsichtbar (Lehre
+    AC-S2-8/F001)."""
+    basis = WeatherMetricsService().compute_basis_metrics(_s5_timeseries(hourly))
+    return {
+        "temp_max": basis.temp_max_c,
+        "wind_max": basis.wind_max_kmh,
+        "cloud_avg": basis.cloud_avg_pct,
+        "sunny_hours": basis.sunny_hours,
+        "snow_depth_cm": _S5_SNOW_DEPTH_CM,
+        "snow_new_cm": _S5_SNOW_NEW_CM,
+        "precip_sum": sum(p.precip_1h_mm for p in hourly),
+        "pop_max": max(p.pop_pct for p in hourly),
+        "uv_max": max(p.uv_index for p in hourly),
+        "visibility_min": min(p.visibility_m for p in hourly),
+    }
+
+
+def _s5_werte_sind_unterscheidbar(soll: dict[str, float]) -> None:
+    """Vakuum-Gegenprobe (Muster ``_s2_erwartungen_sind_unterscheidbar``):
+    eine Wert-Zusicherung faengt eine Feldvertauschung nur, wenn die
+    vertauschten Werte ueberhaupt verschieden sind."""
+    felder = list(soll)
+    for i, eins in enumerate(felder):
+        for zwei in felder[i + 1:]:
+            if soll[eins] == soll[zwei]:
+                pytest.fail(
+                    f"Vakuum: {eins} und {zwei} tragen denselben Soll-Wert "
+                    f"({soll[eins]!r}) -- eine Vertauschung waere damit "
+                    "unsichtbar und AC-S5-2 blind. Die Fixture muss die "
+                    "zehn Felder unterscheidbar machen."
+                )
+
+
+@lru_cache(maxsize=None)
+def _s5_mail_neue_felder() -> tuple[str, str]:
+    """Die ECHTE Vergleichs-Mail (``render_compare_email``) mit genau den
+    zehn neu geprueften Zeilen (Filterung ueber ``enabled_metrics`` -- alle
+    zehn Katalog-IDs sind paarweise verschieden, daher keine Label-Kollision/
+    -Zusatz durch ``derive_row_labels``). Gecacht, weil jede AC-S5-2-Instanz
+    dieselbe Mail liest."""
+    from app.user import ComparisonResult
+
+    hourly = _s5_punkte()
+    ort = _s5_location(hourly)
+    ergebnis = ComparisonResult(
+        locations=[ort], time_window=(6, 18), target_date=date(2026, 8, 12),
+        created_at=datetime(2026, 8, 12, 4, 1),
+    )
+    return render_compare_email(ergebnis, enabled_metrics=list(_S5_NEU_GEPRUEFT_ORDER))
+
+
+# --- AC-S5-1: Soll-Menge gerechnet, Bucket-Vollstaendigkeit ---------------
+
+_S5_BEREITS_GEDECKT = frozenset({
+    # tests/unit/test_compare_extra_daily_metrics.py (#1296)
+    "temp_min", "gust_max", "freezing_level",
+    # tests/unit/test_compare_metric_parity.py (#1324)
+    "wind_direction_avg", "wind_chill_min", "cloud_low_avg", "cloud_mid_avg",
+    "cloud_high_avg", "humidity_avg", "dewpoint_avg", "pressure_avg",
+    "precip_type", "snowfall_limit",
+    # tests/test_wind_chill_max_selectable.py
+    "wind_chill_max",
+    # tests/tdd/test_thunder_low_output_channels.py (AC-11)
+    "thunder_max",
+})
+
+
+def test_ac_s5_1_soll_menge_gerechnet_und_vollstaendig():
+    """AC-S5-1: die 25 Compare-Uebersichtszeilen (CV2_METRICS ohne ``warn``)
+    zerfallen VOLLSTAENDIG und UEBERSCHNEIDUNGSFREI in die 15 bereits
+    wertgeprueften (AC-S5-6) und die 10 neu geprueften (AC-S5-2) Zeilen --
+    beide Mengen kommen aus dem Produktivmodul, nicht getippt."""
+    ist_keys = {m["key"] for m in CV2_METRICS if m["key"] != "warn"}
+    assert len(ist_keys) == 25 >= 20, (
+        f"Vakuum: {len(ist_keys)} Compare-Uebersichtszeilen (ohne 'warn') -- "
+        "unter der Mindestgroesse waere die Bucket-Aufteilung unten trivial"
+    )
+    neu_gepr = frozenset(_S5_NEU_GEPRUEFT_ORDER)
+    assert len(neu_gepr) == 10, f"Vakuum: {sorted(neu_gepr)} enthaelt Duplikate"
+    assert _S5_BEREITS_GEDECKT.isdisjoint(neu_gepr), (
+        f"AC-S5-1: {sorted(_S5_BEREITS_GEDECKT & neu_gepr)} stehen in BEIDEN "
+        "Buckets -- Ueberschneidung statt Aufteilung"
+    )
+    vereinigung = _S5_BEREITS_GEDECKT | neu_gepr
+    assert vereinigung == ist_keys, (
+        f"AC-S5-1: 15+10 deckt nicht die vollen 25 CV2_METRICS-Zeilen.\n"
+        f"Fehlt in 15+10: {sorted(ist_keys - vereinigung)}\n"
+        f"Zusaetzlich in 15+10 (existiert nicht mehr in CV2_METRICS): "
+        f"{sorted(vereinigung - ist_keys)}"
+    )
+
+
+# --- AC-S5-2: die zehn ungeprueften Zeilen zeigen den gerechneten Wert ----
+
+
+@pytest.mark.parametrize("key", _S5_NEU_GEPRUEFT_ORDER)
+def test_ac_s5_2_die_zehn_ungeprueften_zeilen_zeigen_den_gerechneten_wert(key):
+    """AC-S5-2: die zehn bislang ungeprueften Compare-Uebersichtszeilen
+    zeigen in der ECHTEN Vergleichs-Mail (``render_compare_email``) sowohl
+    HTML als auch Klartext exakt den unabhaengig gerechneten Tageswert --
+    kein Fehlzeichen, kein vertauschtes Feld."""
+    hourly = _s5_punkte()
+    soll = _s5_erwartete_werte(hourly)
+    _s5_werte_sind_unterscheidbar(soll)
+    label = _s5_label(key)
+    erwartet = round(soll[key] * _S5_FAKTOR.get(key, 1.0), _S5_DECIMALS[key])
+
+    html, text = _s5_mail_neue_felder()
+    html_zelle = _s5_html_wert(html, label)
+    assert _s5_zellenzahl(html_zelle) == erwartet, (
+        f"AC-S5-2: die HTML-Zelle {label!r} ({key}) zeigt {html_zelle!r}; "
+        f"aus den Stundenwerten gerechnet gehoert dort {erwartet!r} hin "
+        f"(Soll-Rohwert {soll[key]!r})."
+    )
+    klartext_zelle = _s5_klartext_wert(text, label)
+    assert _s5_zellenzahl(klartext_zelle) == erwartet, (
+        f"AC-S5-2: die KLARTEXT-Zeile {label!r} ({key}) zeigt "
+        f"{klartext_zelle!r}; aus den Stundenwerten gerechnet gehoert dort "
+        f"{erwartet!r} hin (Soll-Rohwert {soll[key]!r})."
+    )
+
+
+# --- AC-S5-3: Klasse B -- Engine-Feld hat Vorrang vor Live-Ableitung ------
+
+_S5_VORRANG_FELDER = ("precip_sum", "pop_max")
+
+
+@pytest.mark.parametrize("key", _S5_VORRANG_FELDER)
+def test_ac_s5_3_engine_feld_hat_vorrang_vor_live_ableitung(key):
+    """AC-S5-3: ist am ``LocationResult`` ein Engine-Tagesfeld gesetzt UND
+    ``hourly_data`` mit einem ABWEICHENDEN Wert vorhanden, zeigt die Zelle
+    (HTML wie Klartext) den Engine-Wert -- der generische, feldunabhaengige
+    Vorrang-Zweig in ``_metric_value()`` (compare_html.py:648-651). Zwei
+    Felder genuegen als Stichprobe (Spec 'Engine-Vorrang')."""
+    from app.user import ComparisonResult, LocationResult, SavedLocation
+
+    hourly = _s5_punkte()
+    if key == "precip_sum":
+        live_wert = sum(p.precip_1h_mm for p in hourly)
+        engine_feld, engine_wert = "precip_sum_mm", live_wert + 50.0
+    else:
+        live_wert = max(p.pop_pct for p in hourly)
+        engine_feld, engine_wert = "pop_max_pct", min(100, round(live_wert / 2))
+    assert engine_wert != live_wert, (
+        "Vakuum: Engine- und Live-Wert muessen sich unterscheiden, sonst "
+        "waere ein fehlender Vorrang unsichtbar"
+    )
+
+    ort = LocationResult(
+        location=SavedLocation(
+            id="s5-vorrang", name="S5-Vorrang", lat=47.0, lon=11.0, elevation_m=500,
+        ),
+        score=50, hourly_data=hourly, **{engine_feld: engine_wert},
+    )
+    ergebnis = ComparisonResult(
+        locations=[ort], time_window=(6, 18), target_date=date(2026, 8, 12),
+        created_at=datetime(2026, 8, 12, 4, 1),
+    )
+    html, text = render_compare_email(ergebnis, enabled_metrics=[key])
+    label = _s5_label(key)
+    erwartet = round(engine_wert, _S5_DECIMALS[key])
+
+    html_zelle = _s5_html_wert(html, label)
+    assert _s5_zellenzahl(html_zelle) == erwartet, (
+        f"AC-S5-3: die HTML-Zelle {label!r} ({key}) zeigt {html_zelle!r} -- "
+        f"erwartet den Engine-Wert {erwartet!r}, nicht den Live-Wert "
+        f"{live_wert!r}"
+    )
+    klartext_zelle = _s5_klartext_wert(text, label)
+    assert _s5_zellenzahl(klartext_zelle) == erwartet, (
+        f"AC-S5-3: die KLARTEXT-Zeile {label!r} ({key}) zeigt "
+        f"{klartext_zelle!r} -- erwartet den Engine-Wert {erwartet!r}, "
+        f"nicht den Live-Wert {live_wert!r}"
+    )
+
+
+# --- AC-S5-4: Formatierungs-Konsistenz format_value <-> CV2_METRICS -------
+
+_S5_FORMAT_FELDER: dict[str, str] = {
+    # CV2-Key -> Katalog-Metrik-ID, die der Klartext-Lambda TATSAECHLICH
+    # uebergibt (comparison.py _PLAIN_ROWS/_DAILY_PLAIN_ROWS, s. Spec
+    # "Formatierungs-Konsistenz"). wind_chill_min/wind_chill_max/
+    # dewpoint_avg rufen "temperature" statt der eigenen ID -- Nebenbefund
+    # (#1199): heute folgenlos, weil beide Seiten bei 0 Nachkommastellen
+    # liegen, faellt aber bei kuenftiger Katalog-Aenderung dieser drei IDs
+    # nicht mehr auf.
+    "temp_max": "temperature",
+    "temp_min": "temperature",
+    "wind_max": "wind",
+    "gust_max": "wind",
+    "wind_chill_min": "temperature",
+    "wind_chill_max": "temperature",
+    "dewpoint_avg": "temperature",
+    "cloud_avg": "cloud_total",
+    "snow_depth_cm": "snow_depth",
+    "sunny_hours": "sunshine",
+}
+
+
+@pytest.mark.parametrize("cv2_key,klartext_metric_id", sorted(_S5_FORMAT_FELDER.items()))
+def test_ac_s5_4_formatierung_katalog_und_uebersicht_bleiben_synchron(cv2_key, klartext_metric_id):
+    """AC-S5-4: fuer jedes der zehn ``format_value``-getriebenen Felder
+    stimmen die Nachkommastellen des Katalogs (Klartext-Pfad,
+    ``get_metric(...).decimals``) und von ``CV2_METRICS``/``_fmt_metric``
+    (HTML-Pfad) EINZELN ueberein -- rein struktureller Vergleich, kein
+    Rendering noetig. Ein Fehlschlag benennt genau das betroffene Feld
+    (Feld-Granularitaets-Fang)."""
+    katalog_decimals = get_metric(klartext_metric_id).decimals or 0
+    cv2_eintrag = next(m for m in CV2_METRICS if m["key"] == cv2_key)
+    cv2_decimals = cv2_eintrag.get("decimals") or 0
+    assert katalog_decimals == cv2_decimals, (
+        f"AC-S5-4: {cv2_key!r} zeigt im Klartext "
+        f"get_metric({klartext_metric_id!r}).decimals={katalog_decimals}, "
+        f"in der HTML-Uebersicht aber CV2_METRICS[{cv2_key!r}]"
+        f"['decimals']={cv2_decimals} -- die beiden Formatierungswege sind "
+        "auseinandergelaufen."
+    )
+
+
+# --- AC-S5-5: Fehlzeichen-Charakterisierung -- HTML EM DASH, Klartext HYPHEN
+
+_S5_FEHLZEICHEN_FELDER = ("temp_max", "cloud_avg")
+
+
+@pytest.mark.parametrize("key", _S5_FEHLZEICHEN_FELDER)
+def test_ac_s5_5_fehlzeichen_html_em_dash_klartext_hyphen(key):
+    """AC-S5-5 (Charakterisierung, kein Fix -- PO-Entscheidung, s. Spec
+    Purpose): fehlt der Wert einer generischen ``_fmt_metric``-Zeile, zeigt
+    HTML das EM DASH U+2014, Klartext den ASCII HYPHEN U+002D --
+    bytegenauer Codepoint-Vergleich, keine 'sieht aus wie ein Strich'-
+    Pruefung. Der dritte, im Modul existierende En-Dash-Zweig
+    (``format_value``s ``_NO_VALUE``) ist hier NICHT Gegenstand (im
+    Compare-Uebersichtspfad strukturell unerreichbar, s. Spec)."""
+    from app.user import ComparisonResult, LocationResult, SavedLocation
+
+    ort = LocationResult(
+        location=SavedLocation(
+            id="s5-fehlwert", name="S5-Fehlwert", lat=47.0, lon=11.0, elevation_m=500,
+        ),
+        score=50,  # temp_max/cloud_avg bleiben auf ihrem Default None
+    )
+    ergebnis = ComparisonResult(
+        locations=[ort], time_window=(6, 18), target_date=date(2026, 8, 12),
+        created_at=datetime(2026, 8, 12, 4, 1),
+    )
+    html, text = render_compare_email(ergebnis, enabled_metrics=[key])
+    label = _s5_label(key)
+
+    html_zelle = _s5_html_wert(html, label)
+    assert len(html_zelle) == 1 and ord(html_zelle) == 0x2014, (
+        f"AC-S5-5: HTML-Zelle {label!r} ({key}) ohne Wert zeigt {html_zelle!r} "
+        f"(Codepoints {[hex(ord(c)) for c in html_zelle]}) -- erwartet genau "
+        "U+2014 EM DASH"
+    )
+    klartext_zelle = _s5_klartext_wert(text, label)
+    assert len(klartext_zelle) == 1 and ord(klartext_zelle) == 0x2D, (
+        f"AC-S5-5: KLARTEXT-Zeile {label!r} ({key}) ohne Wert zeigt "
+        f"{klartext_zelle!r} (Codepoints {[hex(ord(c)) for c in klartext_zelle]}) "
+        "-- erwartet genau U+002D ASCII HYPHEN"
+    )
+
+
+# --- AC-S5-6: Abhaengigkeits-Anker auf die 15 bereits gedeckten Zeilen ----
+
+_S5_ANKER_MODULE: dict[str, tuple[str, ...]] = {
+    "tests.unit.test_compare_metric_parity": (
+        "test_selected_wind_direction_metric_appears_in_overview_matrix",
+        "test_selected_wind_chill_min_metric_appears_in_overview_matrix",
+        "test_selected_cloud_low_metric_appears_in_overview_matrix",
+        "test_selected_cloud_mid_metric_appears_in_overview_matrix",
+        "test_selected_cloud_high_metric_appears_in_overview_matrix",
+        "test_selected_humidity_metric_appears_in_overview_matrix",
+        "test_selected_dewpoint_metric_appears_in_overview_matrix",
+        "test_selected_pressure_metric_appears_in_overview_matrix",
+        "test_selected_precip_type_metric_appears_in_overview_matrix",
+        "test_selected_snowfall_limit_metric_appears_in_overview_matrix",
+        "test_plaintext_shows_all_ten_new_rows",
+    ),
+    "tests.unit.test_compare_extra_daily_metrics": (
+        "test_selected_temp_min_metric_appears_in_overview_matrix",
+        "test_selected_gust_max_metric_appears_in_overview_matrix",
+        "test_selected_freezing_level_metric_appears_in_overview_matrix",
+        "test_plaintext_shows_the_three_remaining_new_rows",
+    ),
+    "tests.test_wind_chill_max_selectable": (
+        "test_compare_html_renderer_shows_wind_chill_max_value",
+        "test_compare_plain_renderer_shows_wind_chill_max_value",
+    ),
+    "tests.tdd.test_thunder_low_output_channels": (
+        "test_ac11_compare_html_zeigt_leicht",
+    ),
+}
+
+
+@pytest.mark.parametrize("modulname", sorted(_S5_ANKER_MODULE))
+def test_ac_s5_6_abhaengigkeits_anker_auf_die_15_bereits_gedeckten_zeilen(modulname):
+    """AC-S5-6: die vier Testdateien, die heute 15 der 25 CV2_METRICS-Zeilen
+    wertgeprueft halten, muessen importierbar bleiben und die genannten
+    Testfunktionen weiterhin fuehren -- verschwindet eine, reisst diese
+    Scheibe eine unbemerkte Deckungsluecke (Lehre Scheibe 1/2 F001)."""
+    try:
+        modul = importlib.import_module(modulname)
+    except ImportError as exc:
+        pytest.fail(
+            f"AC-S5-6: {modulname} ist nicht mehr importierbar ({exc}) -- "
+            "die Wertpruefung fuer einen Teil der 15 bereits gedeckten "
+            "Compare-Uebersichtszeilen ist verwaist."
+        )
+        return
+    for name in _S5_ANKER_MODULE[modulname]:
+        assert hasattr(modul, name), (
+            f"AC-S5-6: {modulname} fuehrt keine Testfunktion {name!r} mehr -- "
+            "die Wertpruefung fuer eine der 15 bereits gedeckten Compare-"
+            "Uebersichtszeilen ist verwaist."
+        )


### PR DESCRIPTION
## Summary
- Epic #1703 Scheibe 5: neue Achse AC-S5-1..6 in `tests/tdd/test_channel_metric_matrix.py` (29 parametrisierte Fälle) sichert die Compare-Übersichtstabelle (`CV2_METRICS`) wertmäßig ab, nicht nur zeilenweise
- Korrektur der Scheiben-Prämisse: bei Nachmessung waren bereits 15 von 25 Zeilen über #1296/#1324/#1351/Gewitter-Suite wertgeprüft — die verbleibenden 10 werden hier unabhängig aus rohen Stundenwerten gerechnet und gegen HTML+Klartext der echten Mail (`render_compare_email()`) geprüft
- Zusätzlich: Formatierungs-Konsistenz `format_value()` vs. `CV2_METRICS`-`decimals`, Fehlzeichen-Charakterisierung (HTML Em-Dash vs. Klartext Hyphen), Abhängigkeits-Anker auf die 15 bereits gedeckten Zeilen
- Reine Charakterisierung, **kein Produktivcode-Fix**

Spec: `docs/specs/modules/fix_1703_s5_compare_zellwerte.md`

## Test plan
- [x] `uv run pytest tests/tdd/test_channel_metric_matrix.py -k "ac_s5" -v --disable-socket --allow-hosts=127.0.0.1,::1` → 29 passed
- [x] Volle Datei: 318 passed, 1 pre-existing skip (keine Regression)
- [x] `ruff check` clean
- [x] Adversary VERIFIED — alle 4 Pflicht-Mutationen + 1 selbst gewählte Zusatz-Mutation exakt vom vorgesehenen Test gefangen

Bezieht sich auf #1703 (Epic bleibt offen — Scheibe 5 von 8, weitere Scheiben 6/7/8 stehen aus; Issue-Checkbox wird nach Merge manuell gesetzt, kein Auto-Close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)