### PR TITLE
feat(#1680 S2): Kurzzusammenfassung und GEWITTER-Kommando nennen die Herkunft der Gewitterstufe

### DIFF
--- a/docs/context/feat-1680-s2-herkunft-trip.md
+++ b/docs/context/feat-1680-s2-herkunft-trip.md
@@ -1,0 +1,259 @@
+<!-- Issue #1680, Scheibe 2 (Trip-Seite). Vorgänger: Scheibe 1 (Ortsvergleich),
+     live seit 2026-08-12, Spec docs/specs/modules/feat_1680_s1_gewitter_herkunft_ortsvergleich.md.
+     Bezug: Epic #1419 Rang 4, Entscheidung E1. -->
+
+# Kontext: Herkunft der Gewitterstufe auf der Trip-Seite (#1680 Scheibe 2)
+
+## Zusammenfassung der Anforderung
+
+Die fusionierte Gewitterstufe soll auch im Trip-Briefing sichtbar tragen, **welches
+Signal** sie erreicht hat — so wie es der Ortsvergleich seit Scheibe 1 tut
+(`leicht · CAPE`). PO-Entscheid zum Umfang dieser Scheibe (2026-08-12): **zwei
+Ausgabeorte** — die **Kurzzusammenfassung** in der Trip-Mail und die Antwort auf das
+**GEWITTER-Kommando** — plus der **geteilte Aggregations-Helfer**, der die Regel
+„Vereinigung der Träger der Maximal-Segmente" einmal definiert.
+
+Fortbestehende PO-Entscheidungen aus Scheibe 1 (2026-08-11), unverändert gültig:
+
+| Frage | Entscheidung |
+|---|---|
+| Auslegung | **(ii) alle tragenden Signale** — jede Zutat, die die gezeigte Stufe erreicht. Kein Gewinner wird gekürt, die interne `if`-Reihenfolge der Fusion wird damit **keine** Produktaussage |
+| Kanäle | **E-Mail und Telegram ja · SMS und Premium-SMS ausdrücklich OHNE Herkunft** — aktiv abzuwählen, nicht stillschweigend auszulassen |
+
+## Ausgangslage: was Scheibe 1 bereitgestellt hat
+
+Alle Bausteine existieren und sind produktiv im Einsatz:
+
+| Baustein | Ort | Rolle |
+|---|---|---|
+| `thunder_signal_carriers()` | `src/output/metric_format.py` | ermittelt je Stunde die tragenden Signale |
+| `THUNDER_SIGNAL_LABEL_DE` | `src/output/metric_format.py` | deutscher Wortkatalog (`CAPE`, `Blitzpotenzial`, …) |
+| `_signal_levels()` | `src/output/metric_format.py` | aus der Fusion herausgelöst, zeichengleich |
+| `ForecastDataPoint.thunder_level_signals` | `src/app/models.py:204` | `list[str]`, providerseitig befüllt (`src/providers/thunder_enrichment.py:151`) |
+| `SegmentWeatherSummary.thunder_level_max_signals` | `src/app/models.py:430` | `list[str]`, befüllt in `src/services/weather_metrics.py:462` |
+| `_compute_thunder_level_signals()` | `src/services/weather_metrics.py:616-642` | bildet die Vereinigung je Level-1-Segment |
+
+Die Fusion hat **vier** Zutaten: Wettercode, Blitzdichte (nur Frankreich), CAPE
+(CIN-gedämpft), Blitzpotenzial LPI (nicht Frankreich). `sdi_2` (Superzellen) ist
+**keine** Zutat — das Issue-Beispiel „hoch, Blitzpotenzial+Superzelle" ist am Code
+nicht baubar.
+
+**Kein Trip-Lesepunkt existiert heute.** Einzige Lesestelle von
+`thunder_level_max_signals` ist `src/output/renderers/email/compare_html.py:694`
+(`loc_thunder_signals()`), also Ortsvergleich.
+
+## Der zentrale Befund dieser Scheibe
+
+Die S1-Spec beschrieb als Vorbedingung **einen** ungelösten Aggregationsweg
+(Known Limitation 7: `aggregate_stage()` kennt `union_of_max_carriers` nicht und
+fällt auf `values[0]` zurück). Die Messung zeigt: es sind **drei** Wege, und alle
+drei rechnen die Tages-/Etappenstufe selbst.
+
+| # | Weg | Ort | Kennt Träger? |
+|---|---|---|---|
+| 1 | `aggregate_stage()` | `src/services/weather_metrics.py:1164-1267` | nein — kein Dispatch-Zweig für `union_of_max_carriers`, generischer `else` (Z. 1261-1262) liefert `values[0]`, also die Trägerliste des **ersten** Segments |
+| 2 | `_aggregate_day()` | `src/services/trip_command_processor.py:804-830` | nein — eigene MAX-Schleife `max(thunder_vals, key=thunder_ordinal)` über `p.metrics.thunder_level_max`, Träger kommen dort gar nicht vor |
+| 3 | `_format_thunder()` | `src/output/renderers/compact_summary.py:567-601` | arbeitet direkt auf den Stundenwerten (`dp.thunder_level`), bildet **gar kein** Aggregat |
+
+Die Regel `union_of_max_carriers` ist an `src/services/weather_metrics.py:478`
+**deklariert**, aber an keiner Stelle **ausgewertet**.
+
+⇒ Wer die Herkunft auf die Trip-Seite bringt, muss die Regel **einmal** als
+geteilten Helfer bauen und an den betroffenen Wegen anschließen. Drei
+Eigenimplementierungen wären genau die Fehlerklasse, gegen die #1480 läuft
+(lokale Kopien der Gewitter-Stufenskala, neun Fundstellen).
+
+Warum `aggregate_stage()` trotzdem mitzulösen ist, obwohl die beiden gewählten
+Ausgabeorte ihn umgehen: er hat **drei** Verbraucher —
+`compact_summary.py:263` (`_aggregate()`), `src/services/stage_weather.py:112`
+(Go-Cockpit-Spiegel) und `src/services/trip_report_scheduler.py:2020`
+(Mehrtages-Ausblick). Sobald einer davon die Trägerliste liest, wird der
+`values[0]`-Rückfall zu einem echten Fehler: die Stufe entstünde per MAX über
+alle Segmente, die Herkunft käme aus dem ersten. Präzedenz derselben Fehlerklasse
+im selben `else`-Zweig: #1592 F003 (`cape_model_id`).
+
+## Andockplatz an den beiden Ausgabeorten
+
+An beiden liegt das Suffix-Muster aus dem Hagel-Kennzeichen (#1475) bereits frei —
+derselbe Renderweg wie in Scheibe 1 (`f"{label} · {note}"`):
+
+| Ausgabeort | Datei:Zeile | heutige Ausgabe | vorhandener Platz |
+|---|---|---|---|
+| Kurzzusammenfassung | `src/output/renderers/compact_summary.py:596-601` | `Gewitter möglich 14:00–17:00` | `f"{text} · {note}"` mit `format_hail_note(hail_priority(...))` |
+| GEWITTER-Kommando | `src/services/trip_command_processor.py:874-881` | `⛈ Gewitter heute (13.08.): leicht` | `suffix = f" · {hail_note}" if hail_note else ""` |
+
+Bemerkenswert: die **Kurzzusammenfassung nennt gar keine Stufe**, nur das
+Zeitfenster. Die Herkunft beantwortet dort „worauf beruht diese Gewittermeldung",
+nicht „worauf beruht diese Stufe". Das GEWITTER-Kommando nennt die Stufe als Wort
+(`_THUNDER_LABEL`).
+
+## Vollständige Landkarte der Trip-Ausgabeorte (Abgrenzung)
+
+Gemessen, damit die Abgrenzung dieser Scheibe belegt ist statt geschätzt:
+
+| Ausgabeort | Datei:Zeile | Stufe als Wort? | in dieser Scheibe |
+|---|---|---|---|
+| Kurzzusammenfassung | `compact_summary.py:567-601` | nein (nur Zeitfenster) | **ja** |
+| GEWITTER-Kommando | `trip_command_processor.py:863-881` | ja | **ja** |
+| Kommando-Timeline je Wegpunkt | `trip_command_processor.py:903-913` | ja | nein — kompakte Zeile ohne Suffix-Platz |
+| Tages-Aggregatzeile (`_fmt_day_agg`) | `trip_command_processor.py:832-843` | ja | nein |
+| Mehrtages-Ausblick, Spalte „Gew" | `email/outlook.py:174-298`, `353-403`, `453-537` | ja | nein — Token-Pfad mit getrenntem Tag-/Nachtanteil (#1653), **geteilt mit Compare** |
+| Gewitter-Vorschau (Ersatz für Ausblick) | `email/html.py:1307-1329`, `email/plain.py:307-332` | ja | nein |
+| Pill „Metriken-Überblick" | `email/helpers.py:1713-1757` | ja | nein — **geteilt mit Compare** |
+| Stundentabelle (Zellwert + Ampelfarbe) | `trip_report.py:597-601`, `email/html.py:814-825` | nein | nein |
+| Risiko-Badges der RiskEngine | `trip_report.py:902-908` | ja, aber **eigene Skala** (`RiskLevel`, nicht `ThunderLevel`) | nein |
+| SMS-Token `TH:` / `TH+:` | `sms_trip.py:412-417`, `670-702` | nein (Zahlenwert) | **ausgeschlossen** (PO: kein SMS) |
+| Alarm-Renderer | `alert/render.py:39-53`, `324-390` | nein — gibt die rohe Ordinalzahl 0–3 aus | nein |
+
+Hinweis zur Dateizuordnung: `email/html.py`, `email/plain.py` und `email/compact.py`
+sind faktisch Trip-only (nur über `render_email()` ← `trip_report.py:49/200`
+erreichbar). `email/helpers.py` und `email/outlook.py` sind dagegen **mit dem
+Ortsvergleich geteilt** — eine Änderung dort erschiene sofort in beiden Flächen.
+
+## Verwandte Spezifikationen und Entscheidungen
+
+| Dokument | Bezug |
+|---|---|
+| `docs/specs/modules/feat_1680_s1_gewitter_herkunft_ortsvergleich.md` | Vorgänger-Scheibe, 12 ACs, Known Limitations 3 und 7 |
+| `docs/context/feat-1680-thunder-herkunft.md` | Analyse vor Scheibe 1 (Auslegungsfrage, zwei gemessen widerlegte Irrtümer) |
+| `docs/features/gewitter-gesamtkonzept.md` | Epic #1419, Rang 4 („Herkunft mitführen"), Abschnitt 4.5 Option c |
+| `docs/reference/metric_output_matrix.md` | Zeile 94 führt den Herkunfts-Zusatz als Compare-only; diese Scheibe ergänzt die Trip-Zeilen |
+| ADR-0025 | Eine Gewitter-Quelle für alle Briefing-Kanäle — diese Scheibe ergänzt die gemeinsame Fusion additiv, baut keine zweite |
+| ADR-0007 | Daten statt Empfehlungen — die Herkunft nennt die Zutat, gibt keine Handlungsanweisung |
+| ADR-0048 | Modellabhängige Schwellen; das Label sagt nichts über die Güte der Eichung aus |
+
+## Risiken und Fallstricke
+
+1. 🔴 **Die Voraussetzung des Musters gilt nicht automatisch** — die Lehre aus
+   AC-12 in Scheibe 1. Dort hätte die Zeile beinahe eine Stufe aus dem Engine-Lauf
+   mit einer Herkunft aus einer zweiten, unabhängigen Rechnung gepaart. Für jeden
+   Ausgabeort dieser Scheibe ist einzeln zu prüfen, ob gezeigte Stufe und
+   Trägerliste **aus derselben Rechnung** stammen. Wo nicht: lieber keine
+   Herkunft als eine, die zu einer anderen Zahl gehört.
+2. 🔴 **Persistenz-Kante.** Das GEWITTER-Kommando antwortet aus einem
+   gespeicherten Wetter-Snapshot („Kein Wetter-Snapshot verfügbar" als
+   Fehlerfall). Ob `thunder_level_max_signals` dort überhaupt ankommt, ist die
+   Vorabfrage dieser Scheibe — wird gerade gemessen. Zusätzlich gilt aus
+   Scheibe 1: ein neues Feld MUSS `str` oder `list[str]` sein,
+   `weather_snapshot.py:239,291` behandelt nur skalare Enums, und ein
+   Serialisierungsfehler wird **still geschluckt** (`:85`, `:113`) — der gesamte
+   Schnappschuss wäre weg (gebucht als #1405).
+3. **Regelkopien.** Drei Aggregationswege, eine Regel — ohne geteilten Helfer
+   entstehen Kopien (Fehlerklasse #1480).
+4. **`aggregate_stage()` hat drei Verbraucher**, einer davon der Go-Cockpit-Spiegel
+   (`stage_weather.py:112`). Ein neuer Dispatch-Zweig ändert dort das Verhalten mit.
+5. **Kein Leck in die SMS.** In Scheibe 1 war die Annahme „Compare-SMS zeigt
+   Gewitter gar nicht" **falsch** — `comparison.py:629` rendert es sehr wohl, und
+   ein Suffix wäre automatisch in die SMS gelaufen, per GSM-7 zu `-` entstellt.
+   Für die Trip-SMS ist derselbe Nachweis zu führen: der Ausschluss muss **aktiv**
+   sein und geprüft werden.
+6. **Commit-Gates.** `compact_summary.py` steht auf der Liste des
+   `renderer_mail_gate.py` — der Commit blockiert ohne frischen
+   `briefing_mail_validator.py`-Lauf und grüne `test_issue_811_mode_matrix.py`.
+
+## Ergebnis der Vorabmessungen
+
+### Beide Ausgabeorte sind bedienbar — die Zutat kommt an
+
+**GEWITTER-Kommando (Snapshot-Pfad).** Der Weg trägt, weil beide Richtungen
+generisch arbeiten statt mit gepflegten Feldlisten:
+
+| Schritt | Ort | Befund |
+|---|---|---|
+| Laden | `src/services/weather_extractor.py:84,93` | `timeline()` lädt **ausschließlich** einen gespeicherten Snapshot; `TimelinePoint.metrics = seg.aggregated` reicht das ganze Objekt durch |
+| Serialisieren | `src/services/weather_snapshot.py:229-243` | iteriert über `vars(summary)` — **keine Allowlist**; `list[str]` fällt in den generischen Zweig |
+| Deserialisieren | `src/services/weather_snapshot.py:246-261` | `known_fields` kommt aus `dataclasses.fields()` — **dynamisch**, nicht hartcodiert |
+| Stundenpunkte | `weather_snapshot.py:265-291`, `301-321` | dieselbe generische Mechanik für `thunder_level_signals` |
+
+⇒ Es fehlt **nur die Konsumption**, kein Transport. `_aggregate_day()` liest das
+Feld schlicht nicht und hat im Rückgabe-Dict keinen Schlüssel dafür.
+
+**Kurzzusammenfassung (Frischdaten-Pfad).** Die Objekte stammen direkt aus dem
+Provider-Abruf (`trip_report_scheduler.py:564,1096`), nicht aus dem Snapshot; der
+Snapshot wird erst danach geschrieben (`:1300`). `enrich_thunder()` setzt das Feld
+bereits im Provider (`src/providers/openmeteo.py:1204,1216-1218`), und
+`build_day_window_points()` sammelt die Punkte **per Referenz** ohne Kopie
+(`day_window.py:113-144`). ⇒ Feld kommt an.
+
+### 🔴 Neuer Befund 1: `_merge_hour()` wählt die Herkunft willkürlich
+
+`src/output/renderers/day_window.py:56-71`:
+
+```python
+base = max(dps, key=lambda dp: (thunder_ordinal(dp.thunder_level),
+                                dp.precip_1h_mm or 0.0, dp.gust_kmh or 0.0))
+return dataclasses.replace(
+    base,
+    thunder_level=max_thunder(dp.thunder_level for dp in dps),
+    ...)
+```
+
+Die **Stufe** wird über alle Punkte der Stunde neu gebildet und ist kohärent
+(`base` wird nach derselben Ordnung gewählt, die `max_thunder()` anwendet).
+Die **Trägerliste** steht dagegen nicht in der Override-Liste und kommt
+unverändert von `base` — also von *einem* der Punkte mit Höchststufe, nicht
+aus der Vereinigung aller. Erreichen zwei Punkte derselben Stunde dieselbe
+Stufe über **verschiedene** Zutaten, entscheidet der Tie-Break nach
+Niederschlag und Böen, welche Herkunft überlebt — ein für die Herkunft
+sachfremdes Kriterium.
+
+Das verletzt die freigegebene Auslegung (ii) („alle tragenden Signale, kein
+Gewinner"). Erreichbar an der **Ankunftsstunde**, wo sich Segment- und
+Nachtfenster überschneiden (Docstring `day_window.py:39-41`). ⇒ Gehört in
+diese Scheibe, sonst zeigt die Kurzzusammenfassung dort eine unvollständige
+Herkunft.
+
+### ⚠️ Neuer Befund 2: Restweg der Kurzzusammenfassung in die SMS
+
+`src/services/notification_service.py:417` (SMS) und `:433` (Premium-SMS)
+senden `report.sms_text or report.email_plain`. Die Kurzzusammenfassung steht
+in `email_plain` — bei leerem SMS-Text ginge sie samt Herkunft an beide
+Kurznachrichtenkanäle, entgegen der PO-Entscheidung.
+
+Entschärft, aber nicht ausgeschlossen: `sms_text` wird laut #868 **immer**
+erzeugt (`trip_report.py:441`), der Rückfall ist damit praktisch tot. Als
+Restrisiko zu benennen und durch einen Test am **erzeugten SMS-Text** zu
+bewachen — nicht durch die Annahme, der Zweig sei unerreichbar. In Scheibe 1
+war genau eine solche Annahme („Compare-SMS zeigt Gewitter gar nicht")
+gemessen falsch.
+
+### Der geteilte Helfer: eine Signatur, drei Andockstellen
+
+Die Regel existiert bereits — aber als **private Methode** an der Engine
+(`weather_metrics.py:616-642`, `_compute_thunder_level_signals`), fest an
+`NormalizedTimeseries` gebunden und damit für Segmente und Wegpunkte nicht
+nutzbar. Sie bildet die Vereinigung über alle Stunden, die das Maximum
+erreichen, dedupliziert unter Erhalt der Erstauftrittsreihenfolge, und liefert
+`None` statt einer leeren Liste.
+
+Vorbild für das Herauslösen ist `hail_priority()`
+(`src/output/metric_format.py:568-583`): eine freie Funktion mit **neun**
+Aufrufstellen, aufgerufen sowohl aus `aggregate_stage()` (`:1210`) als auch aus
+`_aggregate_day()` (`:825`) als auch aus der Kurzzusammenfassung (`:600`) —
+genau die drei Wege, um die es hier geht.
+
+Die drei Andockstellen unterscheiden sich nur in dem, worüber vereinigt wird:
+
+| Andockstelle | Vereinigung über | Paare aus |
+|---|---|---|
+| `aggregate_stage()` | Segmente | `s.thunder_level_max` / `s.thunder_level_max_signals` |
+| `_aggregate_day()` | Wegpunkte | `p.metrics.thunder_level_max` / `p.metrics.thunder_level_max_signals` |
+| `_format_thunder()` | gefensterte Stunden | `dp.thunder_level` / `dp.thunder_level_signals` |
+
+Der Aufruf von `_compute_thunder_level_signals` liegt **nicht** in einem
+`try/except` (`weather_metrics.py:438-440`) — das Herauslösen ist semantisch
+sauber. (Prüfung wegen #1752: dort war der Aufrufkontext Teil der Semantik und
+im `grep` unsichtbar.)
+
+### Nebenbefunde
+
+- **Doku-Drift:** Der Kommentar `compact_summary.py:91-93` behauptet,
+  `_aggregate()` sei auch Quelle für Gewitter. Der Code widerspricht:
+  `_format_thunder()` hat gar keinen `summary`-Parameter und liest
+  ausschließlich die Stundenwerte (bewusst so, ADR-0025 Entscheidung 1, #1275).
+- **Totes Gerüst:** `format_location_summary()` (`compact_summary.py:625-668`)
+  hat keinen produktiven Aufrufer im gesamten Repo — nur Tests und Kommentare.
+- **Go-Seite:** `internal/model/segment.go:4-27` kennt kein Signal-Feld; es ließ
+  sich aber keine einzige Konstruktionsstelle von `model.SegmentWeatherSummary{}`
+  in `internal/` finden. Ob das Struct überhaupt auf diesem Datenweg liegt, ist
+  offen — für diese Scheibe ohne Belang, da sie die Go-Seite nicht berührt.

--- a/docs/specs/modules/feat_1680_s2_gewitter_herkunft_trip.md
+++ b/docs/specs/modules/feat_1680_s2_gewitter_herkunft_trip.md
@@ -1,0 +1,505 @@
+---
+entity_id: feat_1680_s2_gewitter_herkunft_trip
+type: feature
+created: 2026-08-12
+updated: 2026-08-12
+status: draft
+version: "1.0"
+tags: [thunder, trip, adr-0007, adr-0025, adr-0048, issue-1680, issue-1419]
+---
+
+<!-- Issue #1680, Scheibe 2 (Trip-Seite). Vorgaenger: Scheibe 1 (Ortsvergleich),
+     live seit 2026-08-12, Spec docs/specs/modules/feat_1680_s1_gewitter_herkunft_ortsvergleich.md.
+     Bezug: Epic #1419 Rang 4, Entscheidung E1. Grundlage: PFLICHTLEKTUERE
+     docs/context/feat-1680-s2-herkunft-trip.md (gemessen 2026-08-12), PO-Entscheid
+     zum Umfang dieser Scheibe (2026-08-12). -->
+
+# Gewitter: Herkunft der Stufe auf der Trip-Seite sichtbar machen (#1680 Scheibe 2)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Seit Scheibe 1 zeigt der Ortsvergleich neben der fusionierten Gewitterstufe die
+tragende(n) Zutat(en) (`hoch · CAPE`). Auf der Trip-Seite fehlt diese Angabe noch
+vollstaendig — die Kurzzusammenfassung der Trip-Mail meldet nur ein Zeitfenster
+(„Gewitter moeglich 14:00–17:00"), das GEWITTER-Kommando nur ein Wort („leicht"),
+ohne dass der Nutzer erfaehrt, worauf die Meldung beruht. Diese Scheibe macht die
+Herkunft an diesen zwei Trip-Ausgabeorten sichtbar UND loest dabei einen strukturellen
+Befund an ZWEI der DREI betroffenen Aggregationswege: die Regel „Vereinigung der
+Traeger der Maximal-Segmente" existiert bereits als private Methode an der Engine,
+aber unabhaengige Aggregationswege auf Tages- und Stunden-Ebene rechnen die Stufe je
+selbst — ohne den geteilten Helfer wuerden hier Kopien derselben Regel entstehen
+(Fehlerklasse #1480). Der dritte Weg (Etappen-Ebene, `aggregate_stage()`) bleibt
+bewusst aussen vor, weil er in dieser Scheibe keinen erreichbaren Konsumenten hat
+(s. Nicht in dieser Scheibe). Die Herkunft nennt weiterhin nur die Zutat, keine
+Bewertung und keine Handlungsempfehlung (ADR-0007).
+
+## Source
+
+> **Schicht-Hinweis:** ausschliesslich Python-Core (`src/output/`,
+> `src/services/`). Kein Frontend, keine Go-Beteiligung, kein neuer Endpoint,
+> keine neuen Persistenz-Felder (alle benoetigten Felder existieren bereits seit
+> Scheibe 1) — reine Aggregations-/Renderlogik.
+
+- **File:** `src/output/metric_format.py` — neue freie Funktion
+  `union_of_max_carriers()`, platziert neben `hail_priority()` (Z. 568-583, Vorbild
+  fuer Struktur und Docstring-Stil)
+- **File:** `src/services/weather_metrics.py` — `_compute_thunder_level_signals()`
+  (Z. 616-642, wird duenner Wrapper um den neuen Helfer). `aggregate_stage()`
+  (Z. 1164-1267) wird in dieser Scheibe NICHT angefasst — s. Nicht in dieser
+  Scheibe.
+- **File:** `src/services/trip_command_processor.py` — `_aggregate_day()`
+  (Z. 804-830), `_fmt_gewitter()` (Z. 863-881)
+- **File:** `src/output/renderers/day_window.py` — `_merge_hour()` (Z. 56-71)
+- **File:** `src/output/renderers/compact_summary.py` — `_format_thunder()`
+  (Z. 567-601); zusaetzlich Korrektur des irrefuehrenden Kommentars Z. 90-94
+  (behauptet, `_aggregate()` sei auch Quelle fuer Gewitter — der Code widerspricht,
+  `_format_thunder()` hat gar keinen `summary`-Parameter, ADR-0025 Entscheidung 1;
+  Fundstelle selbst nachgemessen, die urspruengliche Angabe „91-93" war leicht
+  ungenau)
+- **Nur Kommentar, keine Logikaenderung:** `src/services/notification_service.py`
+  Z. 417, 433 — erklaerender Hinweis am Rueckfallausdruck `report.sms_text or
+  report.email_plain`, dass ein leerer `sms_text` die Herkunft in die SMS/
+  Premium-SMS durchreichen wuerde (Restrisiko, s. Known Limitations)
+- **Identifier:** `output.metric_format.union_of_max_carriers()`,
+  `services.trip_command_processor.TripCommandProcessor._fmt_gewitter()`,
+  `output.renderers.day_window._merge_hour()`,
+  `output.renderers.compact_summary.CompactSummaryFormatter._format_thunder()`
+
+## Estimated Scope
+
+- **LoC:** ~55-90 Quellcode (ein neuer Helfer + vier duenne Andockstellen) +
+  geschaetzt ~150-210 Tests (Pruefeorte=Wirkort ueber zwei getrennte
+  Aggregationswege, s. Testplan) ⇒ Gesamt ~205-300. **Schaetzung, keine Messung**
+  — analog Scheibe 1 (dort war „~80-110" zu optimistisch, gemessen wurden 365
+  Testzeilen) ist ein `loc_limit_override` moeglicherweise noetig, aber in der
+  RED-Phase neu zu pruefen statt hier vorwegzunehmen.
+- **Files:** 5 Quelldateien (s. Source) + 1 neue Testdatei, nach Verhalten
+  benannt: `tests/tdd/test_thunder_origin_trip.py` (Vorbild: S1s
+  `test_thunder_origin_compare.py`).
+- **Effort:** medium. Kein Breaking Change (additiv, alle Datenfelder existieren
+  bereits seit Scheibe 1), kein Frontend, keine neue Persistenz. Das Risiko liegt
+  in der korrekten Vereinigungsregel ueber zwei STRUKTURELL verschiedene
+  Aggregationsebenen (Wegpunkte, Stunden — die dritte, Segmente/
+  `aggregate_stage()`, bleibt unangeschlossen, s. Nicht in dieser Scheibe) und im
+  SMS-Restrisiko (Rueckfallausdruck, muss aktiv geprueft werden).
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `docs/context/feat-1680-s2-herkunft-trip.md` | GRUNDLAGE (gemessen) | Belege, Messwerte, PO-Entscheidungen dieser Spec sind daraus uebernommen |
+| `docs/specs/modules/feat_1680_s1_gewitter_herkunft_ortsvergleich.md` | VORGAENGER | Aufbau, Detailgrad, AC-12-Lehre (Kohaerenz) — dasselbe Muster (eine uebernommene Aussage erst auf ihre Voraussetzung pruefen) greift hier ein zweites Mal bei Known Limitation 7 dort, s. Nicht in dieser Scheibe |
+| ADR-0007 (`docs/adr/0007-daten-statt-empfehlungen.md`) | ZUSAGE | Herkunfts-Label ist Beschreibung, keine Bewertung |
+| ADR-0025 (`docs/adr/0025-eine-gewitter-quelle-fuer-alle-briefing-kanaele.md`) | ZUSAGE | Eine Gewitter-Quelle fuer alle Kanaele — diese Scheibe erweitert additiv, baut keine zweite Fusion |
+| ADR-0048 (`docs/adr/0048-modellabhaengige-schwellen-statt-einer-zahl.md`) | KONTEXT | Unbekannte/ungeeichte Herkunft ist keine Aussage ueber die Guete der Eichung |
+| `src/output/metric_format.py:568-583` (`hail_priority()`) | MUSTER | Freie Funktion, mehrfach importiert statt kopiert — Vorbild fuer `union_of_max_carriers()` |
+| `src/output/metric_format.py:374-390` (`THUNDER_SIGNAL_LABEL_DE`, `thunder_signal_label()`) | ZUSAGE (S1) | Deutscher Wortkatalog, vier feste Schluessel — nicht neu zu definieren |
+| `src/app/models.py:204,430` (`ForecastDataPoint.thunder_level_signals`, `SegmentWeatherSummary.thunder_level_max_signals`) | ZUSAGE (S1) | Beide Felder existieren bereits, `list[str]`, additiv — diese Scheibe legt KEIN neues Feld an |
+| `src/output/renderers/email/compare_html.py:643-658` (`loc_thunder_signals()`) | KONTEXT | Vorbild fuer additive Suffix-Anhaengung, ABER dort mit Kohaerenz-Guard gegen einen zweiten Rechenweg (D7 in S1) — auf der Trip-Seite entfaellt dieser Guard strukturell, s. D5/D6 |
+| `.claude/hooks/renderer_mail_gate.py` | WAECHTER | `compact_summary.py` steht auf der Liste — Commit blockiert ohne frischen `briefing_mail_validator.py`-Lauf UND gruene `tests/tdd/test_issue_811_mode_matrix.py` |
+| `docs/reference/metric_output_matrix.md:94` | KONTEXT | Fuehrt den Herkunfts-Zusatz heute als Compare-only — Zeile ist nach Auslieferung dieser Scheibe um die zwei Trip-Ausgabeorte zu ergaenzen (Doku-Pflege, nicht Teil des Code-Diffs) |
+
+## PO-Entscheidungen
+
+**Fortbestehend aus Scheibe 1 (2026-08-11), unveraendert gueltig:**
+
+| Frage | Entscheidung |
+|---|---|
+| Auslegung | **(ii) Alle tragenden Signale.** Genannt wird JEDE Zutat, die die gezeigte Stufe erreicht. Kein Gewinner wird gekuert. |
+| Kanaele | **E-Mail und Telegram JA · SMS und Premium-SMS ausdruecklich OHNE Herkunft** — aktiv abzuwaehlen/zu pruefen, nicht stillschweigend auszulassen. |
+
+**Neu, 2026-08-12 (Umfang dieser Scheibe):**
+
+| Frage | Entscheidung |
+|---|---|
+| Ausgabeorte | Genau **zwei**: Kurzzusammenfassung der Trip-Mail UND GEWITTER-Kommando. Alle anderen Trip-Ausgabeorte (s. Nicht in dieser Scheibe) bleiben unveraendert. |
+| Geteilter Helfer | Die Regel „Vereinigung der Traeger der Maximal-Segmente" wird EINMAL als freie Funktion herausgeloest (statt kopiert) und an den Aggregationswegen DIESER Scheibe angeschlossen (Wegpunkte, Stunden). Die dritte konzeptionelle Ebene (Segmente/`aggregate_stage()`) bleibt bewusst unangeschlossen — Tech-Lead-Entscheid, s. Nicht in dieser Scheibe. |
+
+## Implementation Details
+
+**D1 — Geteilter Helfer `union_of_max_carriers()` in `metric_format.py`.**
+Generalisiert die bestehende private Methode
+`WeatherMetricsService._compute_thunder_level_signals()`
+(`weather_metrics.py:616-642`) zu einer freien Funktion, Vorbild `hail_priority()`
+(`metric_format.py:568-583`). Nimmt eine Sequenz von Paaren `(stufe, traeger)`
+entgegen — `stufe: Optional[ThunderLevel]`, `traeger: Optional[list[str]]` — und
+liefert die Vereinigung der Traegerlisten aller Paare, deren Stufe das Maximum
+unter den NICHT-`None`-Stufen erreicht (`max_thunder()`), dedupliziert unter
+Erhalt der Erstauftrittsreihenfolge, `None` (nicht `[]`) wenn keine Stufe vorliegt
+oder kein Paar am Maximum einen Traeger nennt. Die genaue Regel ist unveraendert
+gegenueber der bestehenden Methode — nur der Datenzugriff wird generisch (Paare
+statt fest verdrahteter `dp.thunder_level`/`dp.thunder_level_signals`-Attribute):
+
+```
+def union_of_max_carriers(
+    pairs: Iterable[tuple[Optional[ThunderLevel], Optional[list[str]]]],
+) -> Optional[list[str]]:
+    paare = list(pairs)
+    stufen = [s for s, _ in paare if s is not None]
+    if not stufen:
+        return None
+    top = max_thunder(stufen)
+    traeger: list[str] = []
+    for stufe, liste in paare:
+        if stufe != top:
+            continue
+        for name in liste or []:
+            if name not in traeger:
+                traeger.append(name)
+    return traeger or None
+```
+
+`WeatherMetricsService._compute_thunder_level_signals()` wird zum duennen
+Wrapper (`return union_of_max_carriers((dp.thunder_level, dp.thunder_level_signals)
+for dp in timeseries.data)`) — zeichengleiches Verhalten, weil die intern
+berechnete Maximalstufe ueber dieselbe Datenmenge laeuft wie der bisher von
+aussen uebergebene `thunder_max`-Parameter. Der Helfer ist bewusst generisch
+gehalten (Paare statt Attribute), damit neben den in dieser Scheibe
+angeschlossenen Wegpunkten und Stunden auch die Segment-Ebene
+(`aggregate_stage()`) spaeter ohne Umbau andocken kann — s. Nicht in dieser
+Scheibe.
+
+**D2 — `_aggregate_day()` liest die bereits vorhandenen Segment-Trailer.**
+`trip_command_processor.py:804-830` erweitert das Rueckgabe-Dict um
+`"thunder_signals": union_of_max_carriers([(p.metrics.thunder_level_max,
+p.metrics.thunder_level_max_signals) for p in points])`. Kein neuer Datenzugriff
+noetig: `p.metrics` ist `SegmentWeatherSummary` (per `TimelinePoint.metrics =
+seg.aggregated`, `weather_extractor.py:98`), das Feld `thunder_level_max_signals`
+existiert dort bereits seit Scheibe 1 und wird von `compute_basis_metrics()`
+befuellt (`weather_metrics.py:438-440,462`).
+
+**D3 — `_fmt_gewitter()` haengt additiv an, VOR dem Hagel-Suffix.**
+`trip_command_processor.py:863-881` liest `agg.get("thunder_signals")`; sind
+Traeger vorhanden, wird ein zusaetzlicher `·`-Abschnitt zwischen Stufenwort und
+Hagel-Suffix eingefuegt (`f"⛈ Gewitter heute ({today:%d.%m}): {label} ·
+{herkunft}{suffix}"`, wobei `herkunft = ", ".join(thunder_signal_label(n) for n in
+traeger)`). Ohne Traeger bleibt die Zeile zeichengleich zu heute.
+`_fmt_day_agg()`/das GLANCE-Kommando (Z. 832-843), das denselben `agg`-Dict
+liest, bekommt bewusst KEINEN Zugriff auf den neuen Schluessel — Umfang dieser
+Scheibe ist ausschliesslich das GEWITTER-Kommando.
+
+**D4 — `_merge_hour()` ueberschreibt die Traegerliste als Vereinigung.**
+`day_window.py:56-71` erweitert den bestehenden `dataclasses.replace(...)`-Aufruf
+um `thunder_level_signals=union_of_max_carriers((dp.thunder_level,
+dp.thunder_level_signals) for dp in dps)`. Loest den in `docs/context/feat-1680-s2-
+herkunft-trip.md` als „Neuer Befund 1" beschriebenen Fehler: bisher blieb die
+Traegerliste unveraendert bei `base` — also bei GENAU EINEM der Punkte mit
+Hoechststufe, ausgewaehlt ueber einen fuer die Herkunft sachfremden
+Tie-Break (Niederschlag, dann Boeen). Erreichbar an der Ankunftsstunde, wo sich
+Segment- und Nachtfenster ueberschneiden (Docstring `day_window.py:39-41`).
+
+**D5 — `_format_thunder()`: Herkunft bezieht sich auf die Spitzenstufe des
+Zeitfensters (Tech-Lead-Entscheid 2026-08-12, Variante A von zwei erwogenen).**
+Die Kurzzusammenfassung zeigt KEINE Stufe, nur ein Zeitfenster („Gewitter
+moeglich 14:00–17:00") — anders als beim GEWITTER-Kommando gibt es hier kein
+angezeigtes „top", gegen das die Herkunft naturgemaess kohaerent sein muesste.
+Erwogen wurden zwei Auslegungen:
+
+- **Variante A (gewaehlt):** die Herkunft nennt die Zutat(en), die innerhalb
+  des Zeitfensters die HOECHSTE Stufe getragen haben.
+- **Variante B (verworfen):** die Herkunft nennt die Zutaten ALLER Stunden mit
+  irgendeinem Gewitter im Fenster, unabhaengig von deren Stufe.
+
+Gruende fuer Variante A: (1) es ist dieselbe Regel wie an jedem anderen
+Ausgabeort (`union_of_max_carriers`) — keine Sonderlocke fuer einen einzelnen
+Ausgabeort; (2) Variante B naennte bei einer schwachen Wettercode-Stunde und
+einer starken CAPE-Stunde im selben Fenster beide Zutaten und suggerierte, sie
+truegen dieselbe Meldung, obwohl nur eine davon die eigentliche Gefahr ist; (3)
+Variante A haelt Kurzzusammenfassung und GEWITTER-Kommando konsistent, die
+dieselbe Tageslage beschreiben. Berechnung: `traeger =
+union_of_max_carriers((dp.thunder_level, dp.thunder_level_signals) for dp in
+hourly if dp.thunder_level and dp.thunder_level != ThunderLevel.NONE)` —
+dieselbe Teilmenge, die bereits `thunder_hours`/`hail_values` bildet
+(Z. 585-588), kein separater Datenzugriff. Suffix-Reihenfolge: Zeitfenster ·
+Herkunft · Hagel (Hagel-Suffix bleibt am Ende, unveraendert).
+
+**D6 — Kohaerenz ohne zusaetzlichen Guard.** Anders als in Scheibe 1 (dort D7:
+`LocationResult.thunder_level_max` stammt aus dem Engine-Lauf, die Herkunft aber
+aus einer ZWEITEN, unabhaengigen Live-Ableitung — daher der Kohaerenz-Guard in
+`loc_thunder_signals()`) entsteht auf der Trip-Seite die Stufe/das Zeitfenster UND
+die Herkunft an BEIDEN Ausgabeorten aus DEMSELBEN Funktionsaufruf mit DERSELBEN
+Eingabeliste (`_format_thunder(hourly, ...)` bzw. `_aggregate_day(timeline,
+target_date)` fuellt `"thunder"` UND `"thunder_signals"` im selben Dict-Aufbau).
+Ein struktureller Guard ist daher nicht noetig — die Kohaerenz wird stattdessen
+durch AC-6/AC-7 UND die zugehoerigen Mutationsproben nachgewiesen (s. Testplan),
+nicht durch eine Laufzeit-Pruefung im Code.
+
+## Expected Behavior
+
+- **Input:** eine `Trip`/`Stage`-Konfiguration mit Segmenten, deren
+  `ForecastDataPoint`s ueber die echte Anreicherung (`thunder_enrichment.enrich_thunder()`)
+  unterschiedliche Gewitter-Rohwerte tragen (z. B. eine Stunde mit CAPE oberhalb
+  der Leiter, eine andere mit Blitzpotenzial oberhalb derselben Hoechststufe);
+  bzw. ein GEWITTER-Kommando gegen einen gespeicherten Wetter-Snapshot mit
+  gleicher Eigenschaft.
+- **Output:** die Kurzzusammenfassung der Trip-Mail und die Antwort auf das
+  GEWITTER-Kommando zeigen neben Zeitfenster bzw. Stufe die tragende(n)
+  Zutat(en); Trip-SMS und Premium-SMS zeigen weiterhin nur die Stufe bzw. das
+  Zeitfenster, ohne Zutat-Bezeichnung.
+- **Side effects:** keine neuen Datenfelder, keine Persistenz-Aenderung — alle
+  gelesenen Felder existieren bereits additiv seit Scheibe 1. Der neue Helfer
+  `union_of_max_carriers()` ist oeffentlich importierbar und macht
+  `WeatherMetricsService._compute_thunder_level_signals()` zu einem duennen
+  Wrapper (zeichengleiches Verhalten der bestehenden 11 Bestandstests, die an
+  `compute_basis_metrics()` haengen).
+
+## Acceptance Criteria
+
+- **AC-1:** Given die Kurzzusammenfassung der Trip-Mail zeigt ein Gewitterfenster,
+  das ausschliesslich ueber eine Zutat (z. B. CAPE) zustande kommt, When die Mail
+  gerendert wird, Then lautet der Satz „Gewitter moeglich 14:00–17:00 · CAPE"
+  statt nur „Gewitter moeglich 14:00–17:00".
+  - Test: `_format_thunder()`/`format_stage_summary()` mit einer Fixture, deren
+    Stundenpunkte via echter Anreicherung (`_fuse_thunder_levels`) nur CAPE
+    oberhalb der Leiter tragen; Assertion auf den Teilstring „· CAPE" im
+    zurueckgegebenen Text.
+
+- **AC-2:** Given die Antwort auf das GEWITTER-Kommando zeigt eine Gewitterstufe,
+  die ausschliesslich ueber eine Zutat zustande kommt, When der Nutzer GEWITTER
+  sendet, Then lautet die Antwort „⛈ Gewitter heute (13.08.): leicht · CAPE"
+  statt nur „... leicht".
+  - Test: `_fmt_gewitter()` mit einer Timeline-Fixture, deren Wegpunkte am
+    Zieltag nur CAPE-Signale tragen; Assertion auf den Teilstring „· CAPE" in
+    der Antwort.
+
+- **AC-3:** Given innerhalb einer Stunde tragen zwei Zutaten gemeinsam die
+  Hoechststufe (z. B. CAPE UND Blitzpotenzial erreichen beide „hoch"), When die
+  Kurzzusammenfassung gerendert wird, Then werden BEIDE in der
+  Katalogreihenfolge aus `THUNDER_SIGNAL_LABEL_DE` genannt („· CAPE,
+  Blitzpotenzial") — kein Gewinner wird gekuert.
+  - Test: Fixture mit einem Datenpunkt, dessen CAPE- und LPI-Rohwerte beide auf
+    die Hoechststufe fuehren; Assertion auf beide Labels in dieser Reihenfolge
+    im zurueckgegebenen Text.
+
+- **AC-4:** Given zwei Wegpunkte desselben Kalendertags erreichen die
+  Tages-Hoechststufe des GEWITTER-Kommandos ueber verschiedene Zutaten, When der
+  Nutzer GEWITTER sendet, Then nennt die Antwort BEIDE Zutaten, nicht nur die
+  des zeitlich ersten Wegpunkts.
+  - Test: `_aggregate_day()`/`_fmt_gewitter()` mit einer Timeline-Fixture aus
+    zwei Wegpunkten desselben `target_date` — Wegpunkt A nur CAPE, Wegpunkt B
+    nur Blitzpotenzial, beide auf derselben Hoechststufe; Assertion auf beide
+    Labels im zurueckgegebenen Antworttext.
+
+- **AC-5:** Given an der Ankunftsstunde ueberschneiden sich Segment- und
+  Nachtfenster mit zwei Datenpunkten, die dieselbe Hoechststufe ueber
+  verschiedene Zutaten erreichen, When die Kurzzusammenfassung die Stunden zu
+  einem Punkt zusammenfuehrt (`_merge_hour()`), Then traegt der
+  zusammengefuehrte Punkt BEIDE Zutaten — nicht nur die des per
+  Niederschlag/Boeen gewonnenen Tie-Breaks.
+  - Test: `_merge_hour()`/`build_day_window_points()` mit zwei ueberlappenden
+    Datenpunkten derselben Ortszeit-Stunde, deren Niederschlags-/Boeenwerte den
+    Tie-Break zugunsten des Datenpunkts mit NUR einer der beiden Zutaten
+    entscheiden wuerden; Assertion, dass trotzdem beide Zutaten im gerenderten
+    Text erscheinen.
+
+- **AC-6:** Given die Kurzzusammenfassung berechnet Zeitfenster UND Herkunft aus
+  derselben gefensterten Stundenliste (kein zweiter, unabhaengiger
+  Datenzugriff), When eine zusaetzliche Stunde ausserhalb dieser Liste eine
+  dritte, abweichende Zutat traegt, Then erscheint diese dritte Zutat NICHT im
+  Text.
+  - Test: `_format_thunder()` direkt mit einer `hourly`-Liste aufgerufen, die
+    bewusst NICHT alle Rohdaten des Segments enthaelt (eine dritte Zutat
+    existiert nur ausserhalb der uebergebenen Liste, z. B. in einer separaten
+    Segment-Rohzeitreihe); Assertion, dass der Text nur Zutaten aus der
+    uebergebenen Liste nennt.
+
+- **AC-7:** Given `_aggregate_day()` berechnet Stufe UND Herkunft des
+  GEWITTER-Kommandos aus derselben, nach `target_date` gefilterten
+  Wegpunktliste, When ein Wegpunkt eines ANDEREN Kalendertags eine dritte,
+  abweichende Zutat traegt, Then erscheint diese dritte Zutat NICHT in der
+  Kommando-Antwort.
+  - Test: Timeline-Fixture mit einem Wegpunkt ausserhalb `target_date`, der
+    eine dritte Zutat traegt; Assertion, dass die Kommando-Antwort nur Zutaten
+    von Wegpunkten DES Zieltags nennt.
+
+- **AC-8:** Given die Trip-SMS und die Premium-SMS werden aus demselben Bericht
+  wie die E-Mail erzeugt, When der Bericht versendet wird, Then traegt weder
+  der `sms_text` noch — ueber den Rueckfallweg `sms_text or email_plain` — die
+  tatsaechlich zugestellte SMS/Premium-SMS irgendeine der vier
+  Zutat-Bezeichnungen; die Gewitterstufe selbst bleibt dort unveraendert
+  sichtbar.
+  - Test: `TripReportFormatter` mit einer Fixture, deren Gewittersignale in der
+    Kurzzusammenfassung eine Herkunft ausloesen wuerden; Assertion, dass
+    `report.sms_text` weder „CAPE" noch „Blitzpotenzial" noch „Blitzdichte" noch
+    „Wettercode" enthaelt UND dass `report.sms_text` nicht-leer ist (belegt,
+    dass der Rueckfall auf `email_plain` strukturell nicht greift, #868).
+
+- **AC-9:** Given ein bereits gespeicherter Wetter-Schnappschuss OHNE das Feld
+  `thunder_level_max_signals` (Alt-Snapshot vor Scheibe 1/2) wird fuer das
+  GEWITTER-Kommando geladen, When der Nutzer GEWITTER sendet, Then zeigt die
+  Antwort die Gewitterstufe unveraendert, aber OHNE Herkunfts-Zusatz — kein
+  „unbekannt", kein leerer Trenner, kein Fehler.
+  - Test: `WeatherSnapshotService.load()` mit einem Dict ohne den Schluessel
+    deserialisiert; `_fmt_gewitter()` mit der daraus entstehenden Timeline
+    aufgerufen; Assertion, dass die Stufe erscheint und kein „·" im Text folgt.
+
+- **AC-10:** Given eine Stunde bzw. ein Tag zeigt „kein" Gewitter (keine Zutat
+  erreicht eine Stufe ueber NONE), When die Kurzzusammenfassung bzw. das
+  GEWITTER-Kommando gerendert werden, Then bleibt die Ausgabe an BEIDEN Orten
+  zeichengleich zu heute — kein Herkunfts-Zusatz; ebenso bleibt die
+  unveraenderte GLANCE-Antwort (`_fmt_day_agg`), die denselben
+  `_aggregate_day()`-Dict liest, zeichengleich.
+  - Test: Fixture ohne jedes Gewittersignal; Assertion, dass `_format_thunder()`
+    weiterhin `None` liefert (keine Gewitterzeile), `_fmt_gewitter()` „kein"
+    ohne Suffix zeigt, und `_fmt_glance()`/`_fmt_day_agg()` textuell
+    unveraendert zur Bestandsfixture bleiben.
+
+## Testplan
+
+**Kern-Schicht** (deterministisch, ohne Netz, echte Fusions-/Aggregations-
+/Renderpfade — kein Mock-Theater): eine neue Testdatei
+`tests/tdd/test_thunder_origin_trip.py` (nach Verhalten benannt) deckt AC-1 bis
+AC-10 ueber die echten Funktionen
+(`CompactSummaryFormatter._format_thunder`/`format_stage_summary`,
+`TripCommandProcessor._fmt_gewitter`/`_fmt_glance`, `build_day_window_points`/
+`_merge_hour`, `WeatherSnapshotService.load`).
+
+**Prueforte=Wirkort, ohne Ausnahme:** jeder AC laeuft mindestens einmal durch
+die vollstaendige Kette bis zum zurueckgegebenen Mail-/Kommando-Text. Ein
+frueherer Entwurf dieser Spec sah hier eine Ausnahme fuer `aggregate_stage()`
+vor (Test auf Funktionsebene statt ueber die Renderkette) — die Ausnahme ist
+mit dem Entfernen von `aggregate_stage()` aus dem Scheiben-Umfang hinfaellig
+geworden (s. Nicht in dieser Scheibe).
+
+### Pflicht-Mutationsproben (mindestens 3, hier 5)
+
+- **(a) Traegerfilter in `union_of_max_carriers()` entfernen** (Vereinigung ueber
+  ALLE Paare statt nur ueber die am Maximum) ⇒ AC-4/AC-5 MUESSEN rot
+  werden — ein Wegpunkt/Datenpunkt mit niedrigerer Stufe wuerde faelschlich
+  seine Zutat neben der Hoechststufe zeigen.
+- **(b) `_merge_hour()`s neuen Override fuer `thunder_level_signals` entfernen**
+  (Rueckfall auf `base`s unveraenderten Wert) ⇒ AC-5 MUSS rot werden.
+- **(c) `union_of_max_carriers`-Aufruf in `_aggregate_day()` durch
+  `points[0].metrics.thunder_level_max_signals` ersetzen** (erstes statt
+  vereinigtes Element) ⇒ AC-4 MUSS rot werden.
+- **(d) `sms_text = SMSTripFormatter().format_sms(...)` durch `sms_text = ""`
+  ersetzen** (simuliert den bisher nie beobachteten leeren Fall) ⇒ AC-8s
+  zweite Assertion („nicht-leer") MUSS rot werden — beweist, dass der Test die
+  Rueckfall-Kante wirklich prueft, nicht nur behauptet, dass sie nie greift.
+- **(e) Herkunfts-Suffix in `_format_thunder()` UND `_fmt_gewitter()`
+  auskommentieren** (Aufruf des Helfers entfernen) ⇒ AC-1/AC-2 MUESSEN rot
+  werden.
+
+Mutationen ausschliesslich per String-Ersetzung mit externer Sicherungskopie
+(kein `git checkout`/`stash`/`reset`, CLAUDE.md-Vorgabe).
+
+## Known Limitations
+
+1. **`sdi_2` (Superzellen) bleibt aussen vor.** Die Fusion hat vier, nicht fuenf
+   Zutaten — unveraendert seit Scheibe 1 (dort Known Limitation 1). Diese
+   Scheibe erfindet keine fuenfte Zutat.
+2. **EU_REST-LPI ist ein ausgewiesener Interim-Wert** (unbelegte Schwelle,
+   Feineichung offen als #1678, ADR-0048). Das Label „Blitzpotenzial" nennt NUR,
+   welche Zutat die Stufe erreicht hat — keine Aussage ueber die Guete der
+   Eichung (ADR-0007). Unveraendert seit Scheibe 1 (dort Known Limitation 2).
+3. **GEWITTER-Kommando erreicht ausschliesslich E-Mail und Telegram — belegt,
+   nicht angenommen.** `InboundMessage` (die DTO, die Kommandos an den
+   `TripCommandProcessor` traegt) hat GENAU ZWEI Erzeuger:
+   `inbound_email_reader.py:144` (`channel="email"`) und
+   `inbound_telegram_reader.py:222,316` (`channel="telegram"`). Es gibt KEINEN
+   SMS- oder Premium-SMS-Kommandopfad — `inbound_sms_reader.py` existiert zwar,
+   meldet aber nur die Absendernummer an einen internen Endpunkt fuer den
+   Garmin-Ruckkanal (#1676 S1) und erzeugt keine `InboundMessage`. Die Herkunft
+   in `_fmt_gewitter()` erreicht damit strukturell GENAU die zwei Kanaele, die
+   sie laut PO-Entscheidung tragen duerfen — eine Kanal-Unterscheidung in
+   `_fmt_gewitter()` ist NICHT noetig. Doku-Drift: der Docstring
+   `trip_command_processor.py:44` (`channel: str  # "email" or "sms"`) ist
+   veraltet — tatsaechlich sind es „email" und „telegram".
+4. **`_fmt_day_agg()`/GLANCE-Kommando bleibt bewusst unveraendert**, obwohl es
+   denselben `_aggregate_day()`-Dict liest wie `_fmt_gewitter()` — der neue
+   Schluessel `"thunder_signals"` wird dort nicht gelesen (D3, AC-10).
+5. **Restrisiko am SMS-Rueckfallausdruck bleibt bestehen, ist aber gemessen
+   praktisch tot.** `report.sms_text or report.email_plain`
+   (`notification_service.py:417,433`) wuerde bei leerem `sms_text` die
+   Herkunft (als Teil von `email_plain`) an SMS/Premium-SMS durchreichen.
+   `sms_text` wird laut #868 IMMER erzeugt (`trip_report.py:441`) — der Zweig
+   ist praktisch unerreichbar, aber weiterhin ein Restrisiko, keine
+   Unmoeglichkeit (Lehre aus Scheibe 1: „Compare-SMS zeigt Gewitter gar nicht"
+   war eine gemessen falsche Annahme). Bewacht durch AC-8 und Mutationsprobe
+   (d).
+6. **`_deserialize_timeseries()` filtert unbekannte Schluessel nicht**
+   (`weather_snapshot.py:301-324`). Unveraendert seit Scheibe 1 (dort Known
+   Limitation 5) — unkritisch fuer additive Aenderungen, relevant erst bei
+   einem kuenftigen Entfernen eines Feldes.
+
+## Nicht in dieser Scheibe
+
+- **`aggregate_stage()`s Dispatch-Zweig fuer `union_of_max_carriers`**
+  (`weather_metrics.py:1164-1267`). Das Kontextdokument UND die urspruengliche
+  S1-Notiz (dort Known Limitation 7: „die Scheibe, die die Herkunft auf die
+  Trip-Seite bringt, MUSS das zuerst loesen") nahmen an, die Trip-Seite liefe
+  ueber `aggregate_stage()`. Gemessen umgehen BEIDE Ausgabeorte dieser Scheibe
+  ihn strukturell: die Kurzzusammenfassung liest ausschliesslich `hourly`
+  (nicht das `SegmentWeatherSummary`, das `_aggregate()`/`aggregate_stage()`
+  liefert), das GEWITTER-Kommando baut sein eigenes Dict direkt aus `points`,
+  ohne `aggregate_stage()` je aufzurufen. Die Voraussetzung der S1-Notiz trifft
+  fuer diese Scheibe damit NICHT zu — dieselbe Lehre wie AC-12 der
+  Vorgaengerscheibe (eine uebernommene Aussage nicht ungeprueft weiterreichen),
+  hier auf eine schriftliche Notiz statt auf ein Code-Muster angewendet.
+  Tech-Lead-Entscheid: NICHT bauen — ein Aggregations-Zweig fuer einen
+  Verbraucher, den es nicht gibt, waere Code ohne Wirkort, und ein Test darauf
+  bewachte nichts (derselbe Massstab wie S1 Known Limitation 7). Nach dieser
+  Scheibe steht der geteilte Helfer `union_of_max_carriers()` bereit — der
+  Anschluss an `aggregate_stage()` ist dann ein Dreizeiler (analog D2/D4 dieser
+  Spec) und gehoert in die Scheibe, die den **Mehrtages-Ausblick** bringt: dort
+  ist `trip_report_scheduler.py:2020ff` der erste ECHTE Verbraucher. Damit
+  bleibt `src/services/stage_weather.py:112` (Go-Cockpit-Spiegel, ruft
+  `aggregate_stage()` auf) von dieser Scheibe VOLLSTAENDIG unberuehrt — der
+  Blast Radius verkleinert sich entsprechend gegenueber der urspruenglichen
+  Planung.
+- **Mehrtages-Ausblick** (`email/outlook.py:174-298,353-403,453-537`) —
+  Token-Pfad mit getrenntem Tag-/Nachtanteil (#1653), **geteilt mit Compare**.
+- **Pill „Metriken-Ueberblick"** (`email/helpers.py:1713-1757`) — **geteilt mit
+  Compare**.
+- **Gewitter-Vorschau** (`email/html.py:1307-1329`, `email/plain.py:307-332`).
+- **Kommando-Timeline je Wegpunkt** (`trip_command_processor.py:903-913`) —
+  kompakte Zeile ohne Suffix-Platz.
+- **Tages-Aggregatzeile `_fmt_day_agg`** (`trip_command_processor.py:832-843`) —
+  liest denselben `agg`-Dict, bekommt aber bewusst keinen Zugriff auf den neuen
+  Schluessel (s. Known Limitations 4).
+- **Stundentabelle** (`trip_report.py:597-601`, `email/html.py:814-825`).
+- **Compare-Stundentabelle** — bereits in Scheibe 1 explizit ausgeschlossen.
+- **Go-DTO und Frontend** — kein Frontend-Ort rendert heute eine
+  Gewitterstufen-Beschriftung.
+- **Risiko-Badges der RiskEngine** (`trip_report.py:902-908`) — eigene Skala
+  (`RiskLevel`, nicht `ThunderLevel`).
+- **Alarm-Renderer** (`alert/render.py:39-53,324-390`) — gibt die rohe
+  Ordinalzahl 0-3 aus, keine Wortdarstellung.
+- **Fuenfte Fusions-Zutat, Superzellen (`sdi_2`)** — s. Known Limitations 1.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine (neue) — diese Scheibe wendet ADR-0007 (Daten statt
+  Empfehlungen), ADR-0025 (eine Gewitter-Quelle fuer alle Kanaele) und
+  ADR-0048 (unbekannte/ungeeichte Herkunft = keine Aussage) an, ohne eine davon
+  zu aendern.
+- **Rationale:** Additive Sichtbarmachung einer bereits vorhandenen internen
+  Groesse (welche Zutat trug) an zwei weiteren Ausgabeorten, plus das
+  Herausloesen einer bereits existierenden Aggregationsregel in einen geteilten
+  Helfer — kein neues Architekturprinzip, keine neue Datenquelle, kein neuer
+  Kanal, keine neue Persistenz-Strategie. Kein Bezug zu ADR-0034
+  (Herkunfts-Fusszeile/Datenquelle) — andere Dimension, s. Scheibe 1s
+  Architektur-Entscheidung fuer die Abgrenzung.
+
+## Changelog
+
+- 2026-08-12: Initial spec created (Issue #1680, Scheibe 2). Grundlage:
+  `docs/context/feat-1680-s2-herkunft-trip.md`, PO-Entscheid zum Umfang der
+  Scheibe (zwei Ausgabeorte + geteilter Helfer) vom 2026-08-12.
+- 2026-08-12 (Korrektur nach Review, vor Freigabe): `aggregate_stage()` aus dem
+  Scheiben-Umfang entfernt (Tech-Lead-Entscheid — beide Ausgabeorte umgehen ihn
+  strukturell, kein Wirkort in dieser Scheibe, s. Nicht in dieser Scheibe); AC-4
+  (alt, aggregate_stage-Test) ersatzlos gestrichen, verbleibende ACs neu
+  durchnummeriert (AC-1..AC-10), Mutationsprobe (d) (alt) entfernt und die
+  uebrigen umgelabelt. GEWITTER-Kommando-Kanalbefund korrigiert:
+  `InboundMessage` hat genau zwei Erzeuger (E-Mail, Telegram) —
+  `inbound_sms_reader.py` existiert, ist aber kein Kommando-Reader (Garmin-
+  Ruckkanal, #1676 S1); Docstring-Drift `trip_command_processor.py:44`
+  (`"email" or "sms"`) vermerkt. D5 (`_format_thunder()`-Herkunft = Spitzenstufe
+  des Zeitfensters, vormals D6) als bewusste Tech-Lead-Entscheidung mit
+  verworfener Alternative (Vereinigung ueber alle Gewitterstunden im Fenster)
+  festgehalten.

--- a/docs/specs/modules/feat_1680_s2_gewitter_herkunft_trip.md
+++ b/docs/specs/modules/feat_1680_s2_gewitter_herkunft_trip.md
@@ -18,7 +18,7 @@ tags: [thunder, trip, adr-0007, adr-0025, adr-0048, issue-1680, issue-1419]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-Freigabe „go" am 2026-08-12 auf die zehn Akzeptanzkriterien
 
 ## Purpose
 

--- a/src/output/metric_format.py
+++ b/src/output/metric_format.py
@@ -580,8 +580,12 @@ def union_of_max_carriers(
     ``None`` (nicht ``[]``) heisst "keine Aussage": kein Paar nennt eine Stufe
     (z.B. leere Auswahl) ODER kein Paar am Maximum nennt einen Traeger (z.B.
     ein Alt-Schnappschuss ohne das Feld). Eine Stufe ``NONE`` ist dabei eine
-    ECHTE Stufe und kein Ausstiegsgrund — sie fuehrt ueber den leeren
-    Traegerbestand auf ``None``, weil "kein Gewitter" keine Herkunft hat.
+    ECHTE Stufe und kein Ausstiegsgrund — liegt das Maximum aber BEI ``NONE``,
+    ist das Ergebnis ``None``, weil "kein Gewitter" keine Herkunft hat. Das
+    garantiert die Funktion SELBST und verlaesst sich nicht darauf, dass ihre
+    Aufrufer zu einem ``NONE``-Punkt ohnehin keine Traeger liefern — sie ist
+    fuer die Wiederverwendung gebaut, und eine Zusicherung, die nur aus dem
+    Verhalten der heutigen Aufrufer folgt, braeche beim naechsten.
 
     Rueckgabe ist bewusst eine ``list``, NIE ein ``set``: das Ergebnis landet
     ueber ``SegmentWeatherSummary.thunder_level_max_signals`` im Wetter-
@@ -593,6 +597,8 @@ def union_of_max_carriers(
     if not stufen:
         return None
     top = max_thunder(stufen)
+    if top == ThunderLevel.NONE:
+        return None
     traeger: list[str] = []
     for stufe, liste in paare:
         if stufe != top:

--- a/src/output/metric_format.py
+++ b/src/output/metric_format.py
@@ -556,6 +556,53 @@ def thunder_level_from_signals(
     return max_thunder(signals.values())
 
 
+def union_of_max_carriers(
+    pairs: Iterable[tuple[Optional[ThunderLevel], Optional[list[str]]]],
+) -> Optional[list[str]]:
+    """Vereinigt die Traeger DERJENIGEN Paare, die die Hoechststufe erreichen
+    (Issue #1680 S2).
+
+    Die EINE Stelle, an der die Aggregationsregel
+    ``"thunder_level_max_signals": "union_of_max_carriers"`` (deklariert in
+    ``WeatherMetricsService.compute_basis_metrics()``) tatsaechlich gerechnet
+    wird. Herausgeloest aus ``_compute_thunder_level_signals()``, damit die
+    unabhaengigen Aggregationswege (Stunden, Wegpunkte, spaeter Segmente) sie
+    IMPORTIEREN statt sie zu kopieren — dieselbe Fehlerklasse, gegen die #1480
+    laeuft. Muster: ``hail_priority()`` unten.
+
+    Genannt wird JEDE Zutat, die die Hoechststufe traegt (PO-Auslegung (ii),
+    Scheibe 1) — es wird kein Gewinner gekuert, ein Paar unterhalb des Maximums
+    steuert NICHTS bei. Dedupliziert unter Erhalt der ERSTauftrittsreihenfolge;
+    da jede einzelne Traegerliste aus ``thunder_signal_carriers()`` bereits in
+    der Katalogreihenfolge von ``THUNDER_SIGNAL_LABEL_DE`` steht, bleibt die
+    Nennreihenfolge deterministisch — ohne zweites Sortier-Vokabular.
+
+    ``None`` (nicht ``[]``) heisst "keine Aussage": kein Paar nennt eine Stufe
+    (z.B. leere Auswahl) ODER kein Paar am Maximum nennt einen Traeger (z.B.
+    ein Alt-Schnappschuss ohne das Feld). Eine Stufe ``NONE`` ist dabei eine
+    ECHTE Stufe und kein Ausstiegsgrund — sie fuehrt ueber den leeren
+    Traegerbestand auf ``None``, weil "kein Gewitter" keine Herkunft hat.
+
+    Rueckgabe ist bewusst eine ``list``, NIE ein ``set``: das Ergebnis landet
+    ueber ``SegmentWeatherSummary.thunder_level_max_signals`` im Wetter-
+    Schnappschuss, und ein ``set`` braeche dort ``json.dumps`` — der Fehler
+    wird still geschluckt, der GESAMTE Schnappschuss waere weg (#1405).
+    """
+    paare = list(pairs)
+    stufen = [s for s, _ in paare if s is not None]
+    if not stufen:
+        return None
+    top = max_thunder(stufen)
+    traeger: list[str] = []
+    for stufe, liste in paare:
+        if stufe != top:
+            continue
+        for name in liste or []:
+            if name not in traeger:
+                traeger.append(name)
+    return traeger or None
+
+
 # ---------------------------------------------------------------------------
 # Hagel-Kennzeichen (#1475 S5a, Epic #1419)
 #

--- a/src/output/renderers/compact_summary.py
+++ b/src/output/renderers/compact_summary.py
@@ -90,8 +90,13 @@ class CompactSummaryFormatter:
         # Issue #1417: Temperatur/gefuehlte Temperatur des Satzes kommen aus
         # DERSELBEN Gehzeit-Punktliste wie Mail-Kachelzeile, SMS und Telegram
         # -- statt aus `_aggregate()`, das die Ankunftsstunde ausschliesst.
-        # `_aggregate()` bleibt unveraendert Quelle fuer Wolken/Wind/Regen/
-        # Gewitter (nur diese zwei Groessen wechseln die Quelle).
+        # `_aggregate()` bleibt unveraendert Quelle fuer Wolken/Wind/Regen
+        # (nur diese zwei Groessen wechseln die Quelle). NICHT fuer Gewitter:
+        # `_format_thunder()` hat gar keinen `summary`-Parameter und liest
+        # ausschliesslich die gefensterten Stundenwerte -- bewusst so
+        # (ADR-0025 Entscheidung 1, #1275). Die fruehere Nennung von "Gewitter"
+        # an dieser Stelle war eine Aussage ueber eigenen Code, die der Code
+        # nicht deckte (Issue #1680 S2).
         _points = collect_hiking_window_points(segments)
         _temp = hiking_field_min_max(_points, "t2m_c")
         _felt = hiking_field_min_max(_points, "wind_chill_c")
@@ -574,7 +579,10 @@ class CompactSummaryFormatter:
         # entscheiden, ob Gewitter gemeldet wird (Issue #1275).
         # Lokaler Import wie bei ``cloud_emoji`` oben — vermeidet den
         # Zirkelbezug metric_format -> renderers -> compact_summary.
-        from output.metric_format import format_hail_note, hail_priority
+        from output.metric_format import (
+            format_hail_note, hail_priority, thunder_signal_label,
+            union_of_max_carriers,
+        )
 
         thunder_hours = []
         # Issue #1475 Nachbesserung (Punkt 3/AC-4): das Hagel-Kennzeichen
@@ -582,10 +590,18 @@ class CompactSummaryFormatter:
         # Helfer (#1481), kein Parallel-Aggregat. Die Gewitterstufe selbst
         # bleibt davon unberuehrt (AC-10).
         hail_values = []
+        # Issue #1680 S2: die Herkunfts-Paare stammen aus DERSELBEN Schleife
+        # ueber DIESELBE gefensterte Stundenliste wie Zeitfenster und Hagel --
+        # kein zweiter Datenzugriff, damit Fenster und Herkunft nicht aus zwei
+        # Rechnungen stammen koennen (Spec D6, AC-6).
+        thunder_paare = []
         for dp in hourly:
             if dp.thunder_level and dp.thunder_level != ThunderLevel.NONE:
                 thunder_hours.append(local_hour(dp.ts, self._tz))
                 hail_values.append(getattr(dp, "hail_flag", None))
+                thunder_paare.append(
+                    (dp.thunder_level, getattr(dp, "thunder_level_signals", None))
+                )
 
         if not thunder_hours:
             return None
@@ -597,6 +613,22 @@ class CompactSummaryFormatter:
             text = f"⚡ möglich {start_h}:00–{end_h}:00"
         else:
             text = f"Gewitter möglich {start_h}:00–{end_h}:00"
+        # BEIDE Schreibweisen tragen die Herkunft: der Default aus
+        # `build_default_display_config()` ist `use_friendly_format=True`, ein
+        # Suffix nur am unfreundlichen Zweig bliebe fuer den Normalnutzer
+        # unsichtbar. Reihenfolge (Spec D5): Zeitfenster · Herkunft · Hagel.
+        # Die Herkunft nennt die Zutat(en) der HOECHSTEN Stufe im Fenster
+        # (Variante A) -- dieselbe Regel wie an jedem anderen Ausgabeort.
+        # KANAL: dieser Satz gehoert zur E-Mail (`email_plain`/HTML) und zur
+        # Telegram-Kurzfassung. SMS und Premium-SMS bleiben ausdruecklich OHNE
+        # Herkunft (PO-Entscheidung): sie rendern ihre Gewitterangabe in
+        # `sms_trip.py` als eigenes `TH:`-Token aus `dp.thunder_level` und
+        # lesen diesen Text nicht -- aktiv abgewaehlt, nicht stillschweigend
+        # ausgelassen (bewacht durch Spec AC-8).
+        traeger = union_of_max_carriers(thunder_paare)
+        herkunft = ", ".join(thunder_signal_label(n) for n in traeger or [])
+        if herkunft:
+            text = f"{text} · {herkunft}"
         note = format_hail_note(hail_priority(hail_values))
         return f"{text} · {note}" if note else text
 

--- a/src/output/renderers/day_window.py
+++ b/src/output/renderers/day_window.py
@@ -54,7 +54,9 @@ def _merge_hour(dps: list[ForecastDataPoint]) -> ForecastDataPoint:
     # `WeatherMetricsService._compute_thunder_level` fuer `max_thunder`
     # schon verwendet, verhindert, dass der naechste Modulkopf-Import
     # irgendwo in der Renderer-Kette dieselbe Falle wieder aufreisst.
-    from output.metric_format import max_thunder, thunder_ordinal
+    from output.metric_format import (
+        max_thunder, thunder_ordinal, union_of_max_carriers,
+    )
     base = max(
         dps,
         key=lambda dp: (
@@ -66,6 +68,18 @@ def _merge_hour(dps: list[ForecastDataPoint]) -> ForecastDataPoint:
     return dataclasses.replace(
         base,
         thunder_level=max_thunder(dp.thunder_level for dp in dps),
+        # Issue #1680 S2: die Traegerliste MUSS wie die Stufe ueber alle
+        # Punkte der Stunde neu gebildet werden. Ohne diesen Override kam sie
+        # unveraendert von `base` -- also von GENAU EINEM Punkt mit
+        # Hoechststufe, ausgewaehlt ueber einen fuer die Herkunft sachfremden
+        # Tie-Break (Niederschlag, dann Boeen). Erreichbar an der
+        # Ankunftsstunde, wo sich Segment- und Nachtfenster ueberschneiden
+        # (s. Docstring oben) -- die Kurzzusammenfassung nannte dort nur eine
+        # von zwei tragenden Zutaten, entgegen der PO-Auslegung (ii).
+        thunder_level_signals=union_of_max_carriers(
+            (dp.thunder_level, getattr(dp, "thunder_level_signals", None))
+            for dp in dps
+        ),
         precip_1h_mm=_max_optional([dp.precip_1h_mm for dp in dps]),
         pop_pct=_max_optional([dp.pop_pct for dp in dps]),
         wind10m_kmh=_max_optional([dp.wind10m_kmh for dp in dps]),

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -409,6 +409,17 @@ class NotificationService:
                 logger.error(f"E-Mail send failed for {request.trip.name}: {e}")
 
         # SMS
+        #
+        # Issue #1680 S2 (nur Hinweis, keine Logikaenderung): der Rueckfall
+        # `sms_text or email_plain` ist der EINZIGE Weg, auf dem die
+        # Gewitter-Herkunft ("… · CAPE", Teil der Kurzzusammenfassung in
+        # `email_plain`) doch noch in SMS/Premium-SMS landen koennte — beide
+        # Kanaele tragen sie laut PO-Entscheidung ausdruecklich NICHT.
+        # `sms_text` wird seit #868 immer erzeugt (`trip_report.py:441`), der
+        # Zweig ist also praktisch tot; "praktisch tot" ist aber keine
+        # Unmoeglichkeit. Bewacht wird er am erzeugten Text (Spec AC-8:
+        # `sms_text` nicht-leer UND ohne jede Zutat-Bezeichnung), nicht durch
+        # die Annahme, er sei unerreichbar.
         telegram_fully_sent = True
         if request.send_sms and self._settings.can_send_sms():
             try:
@@ -426,6 +437,8 @@ class NotificationService:
         # selbst (Spec D3) und liefert den Grund als Ausnahme zurueck. Eine
         # Bedingung davor wuerde dieselbe Pruefung doppeln und den Grund
         # verschlucken — genau das, was `blocked_channels` verhindert.
+        # Zum Rueckfall `sms_text or email_plain` s. den Hinweis beim
+        # SMS-Block oben (Issue #1680 S2, Herkunft gehoert hier nicht hin).
         if request.send_premium_sms:
             try:
                 PremiumSmsOutput(self._settings).send(

--- a/src/services/trip_command_processor.py
+++ b/src/services/trip_command_processor.py
@@ -825,9 +825,21 @@ class TripCommandProcessor:
         hail_flag = hail_priority(
             [getattr(p.metrics, "hail_flag", None) for p in points]
         )
+        # Issue #1680 S2: die Zutaten, die die oben gebildete Tagesstufe
+        # tragen -- ueber DIESELBE, nach `target_date` gefilterte Wegpunkt-
+        # liste (Stufe und Herkunft aus EINER Rechnung, Spec D6). Der geteilte
+        # Helfer statt einer dritten Eigenimplementierung derselben Regel
+        # (#1480). Nur `_fmt_gewitter()` liest den Schluessel; `_fmt_day_agg()`
+        # /GLANCE bleibt bewusst zeichengleich (Spec D3, Known Limitation 4).
+        from output.metric_format import union_of_max_carriers
+        thunder_signals = union_of_max_carriers(
+            [(p.metrics.thunder_level_max,
+              getattr(p.metrics, "thunder_level_max_signals", None))
+             for p in points]
+        )
         return {"temp_max": temp_max, "temp_min": temp_min, "wind_max": wind_max,
                 "thunder": thunder, "precip": precip, "pop": pop,
-                "hail_flag": hail_flag}
+                "hail_flag": hail_flag, "thunder_signals": thunder_signals}
 
     def _fmt_day_agg(self, agg: dict, label: str) -> str:
         """Formatiert Tages-Aggregat als kompakte Zeile."""
@@ -875,9 +887,22 @@ class TripCommandProcessor:
         # Renderern (#1481 DRY, call-time Import) -- rein deskriptiv NEBEN der
         # Gewitterstufe, ohne Handlungsempfehlung (ADR-0007, Spec AC-8). Bei
         # "unbekannt"/"nein" bleibt die Antwort zeichengleich zu bisher.
-        from output.metric_format import format_hail_note
+        from output.metric_format import format_hail_note, thunder_signal_label
         hail_note = format_hail_note(agg.get("hail_flag"))
         suffix = f" · {hail_note}" if hail_note else ""
+        # Issue #1680 S2: die tragende(n) Zutat(en) der oben gezeigten Stufe --
+        # additiv VOR dem Hagel-Suffix, rein deskriptiv ohne Bewertung
+        # (ADR-0007). Ohne Traeger (kein Gewitter, Alt-Schnappschuss ohne das
+        # Feld) bleibt die Zeile zeichengleich zu bisher.
+        # KANAL: das GEWITTER-Kommando erreicht ausschliesslich E-Mail und
+        # Telegram -- `InboundMessage` hat genau diese zwei Erzeuger
+        # (inbound_email_reader.py, inbound_telegram_reader.py). Es gibt keinen
+        # SMS-/Premium-SMS-Kommandopfad, die PO-Abwahl "SMS ohne Herkunft"
+        # greift hier also strukturell, ohne Kanal-Unterscheidung.
+        traeger = agg.get("thunder_signals")
+        herkunft = ", ".join(thunder_signal_label(n) for n in traeger or [])
+        if herkunft:
+            suffix = f" · {herkunft}{suffix}"
         return f"⛈ Gewitter heute ({today:%d.%m}): {label}{suffix}"
 
     def _fmt_timeline(self, timeline, target_date, label: str, day_token: str) -> str:

--- a/src/services/weather_metrics.py
+++ b/src/services/weather_metrics.py
@@ -629,17 +629,21 @@ class WeatherMetricsService:
 
         ``None`` (keine Aussage) bei fehlender Stufe oder wenn keine Stunde
         eine Zutat nennt -- z.B. ein Alt-Schnappschuss ohne das Feld.
+
+        Issue #1680 S2: der Rumpf ist in die freie Funktion
+        ``output.metric_format.union_of_max_carriers()`` gewandert, damit die
+        anderen Aggregationswege (Wegpunkte des GEWITTER-Kommandos, Stunden
+        der Kurzzusammenfassung) dieselbe Regel importieren statt sie zu
+        kopieren. Zeichengleiches Verhalten: der Helfer bildet sein Maximum
+        ueber DIESELBE Punktmenge, aus der auch ``thunder_max`` stammt
+        (``_compute_thunder_level()``) -- der Parameter bleibt fuer die
+        bestehende Aufrufstelle erhalten, wird aber nicht mehr gebraucht.
         """
-        if thunder_max is None:
-            return None
-        traeger: list[str] = []
-        for dp in timeseries.data:
-            if dp.thunder_level != thunder_max:
-                continue
-            for name in getattr(dp, "thunder_level_signals", None) or []:
-                if name not in traeger:
-                    traeger.append(name)
-        return traeger or None
+        from output.metric_format import union_of_max_carriers
+        return union_of_max_carriers(
+            (dp.thunder_level, getattr(dp, "thunder_level_signals", None))
+            for dp in timeseries.data
+        )
 
     def _compute_hail_flag(
         self,

--- a/tests/tdd/test_thunder_origin_trip.py
+++ b/tests/tdd/test_thunder_origin_trip.py
@@ -1,0 +1,456 @@
+"""TDD RED — Issue #1680 Scheibe 2: Herkunft der Gewitterstufe auf der Trip-Seite.
+
+SPEC: docs/specs/modules/feat_1680_s2_gewitter_herkunft_trip.md (AC-1 bis AC-10)
+KONTEXT: docs/context/feat-1680-s2-herkunft-trip.md
+
+RED-Ursache (heute): ``output.metric_format.union_of_max_carriers()`` existiert
+nicht; ``_aggregate_day()`` hat keinen Schluessel fuer die Traeger,
+``_fmt_gewitter()`` und ``_format_thunder()`` haengen kein Herkunfts-Suffix an,
+und ``day_window._merge_hour()`` laesst ``thunder_level_signals`` unveraendert
+bei ``base`` stehen (Kontext "Neuer Befund 1") -> beide Trip-Ausgabeorte nennen
+die tragende Zutat gar nicht.
+
+Prueforte = Wirkorte: JEDER Test laeuft bis zum Text, den der Nutzer bekommt --
+``TripReport.email_plain``/``sms_text`` bzw. ``CommandResult.confirmation_body``
+aus ``TripCommandProcessor.process()``. Kein Zwischenwert steht fuer einen Text.
+
+Kein Mock-Theater: die Stufen und Traegerlisten entstehen ueber die ECHTE
+Fusion (``thunder_enrichment._fuse_thunder_levels`` mit den Leitern aus
+``app.model_registry``) und die ECHTE Aggregation
+(``WeatherMetricsService.compute_basis_metrics``) -- kein im Test getippter
+Wert, keine getippte Schwelle. Der Kommandopfad laeuft ueber einen echt
+gespeicherten und wieder geladenen Wetter-Schnappschuss.
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from app.loader import get_snapshots_dir, save_trip  # noqa: E402
+from app.metric_catalog import build_default_display_config  # noqa: E402
+from app.model_registry import (  # noqa: E402
+    cape_ladder_thresholds_jkg, lpi_thresholds_jkg,
+)
+from app.models import (  # noqa: E402
+    ForecastDataPoint, ForecastMeta, GPXPoint, NormalizedTimeseries, Provider,
+    SegmentWeatherData, TripSegment,
+)
+from app.trip import Stage, Trip, Waypoint  # noqa: E402
+from output.renderers.trip_report import TripReportFormatter  # noqa: E402
+from providers.thunder_enrichment import _fuse_thunder_levels  # noqa: E402
+from providers.thunder_routing import thunder_region_for  # noqa: E402
+from services.trip_command_processor import (  # noqa: E402
+    InboundMessage, TripCommandProcessor,
+)
+from services.weather_metrics import WeatherMetricsService  # noqa: E402
+from services.weather_snapshot import WeatherSnapshotService  # noqa: E402
+
+# Die VIER Zutaten der Fusion in ihrer deutschen Beschriftung
+# (``metric_format.THUNDER_SIGNAL_LABEL_DE``). Keine davon darf in der SMS
+# oder im GLANCE-Kommando auftauchen (AC-8, AC-10).
+ALLE_ZUTATEN = ("Wettercode", "Blitzdichte", "CAPE", "Blitzpotenzial")
+
+_TZ = ZoneInfo("UTC")
+_LAT, _LON, _MODELL = 47.0, 12.0, "icon_d2"   # Gebiet DE_ALPEN
+_ETAPPE = "Test-Etappe"
+_TAG = date(2026, 8, 20)
+
+_TRIP_ID = "herkunft-trip-kommando"
+_TRIP_NAME = "Herkunft Trip Tour"
+_USER = "default"
+
+
+# ---------------------------------------------------------------------------
+# Fixture-Bausteine: Rohwerte rein, echte Rechnung raus
+# ---------------------------------------------------------------------------
+
+def _dp(h: int, *, tag: date = _TAG, cape=None, cin=None, lpi=None,
+        dichte=None, precip=0.0, gust=12.0) -> ForecastDataPoint:
+    """Ein Stundenpunkt mit ROHWERTEN -- Stufe und Traeger rechnet die Fusion.
+
+    ``precip``/``gust`` sind nur fuer AC-5 interessant: sie entscheiden den
+    Tie-Break in ``_merge_hour()``.
+    """
+    return ForecastDataPoint(
+        ts=datetime(tag.year, tag.month, tag.day, h, 0, tzinfo=timezone.utc),
+        t2m_c=20.0, wind10m_kmh=8.0, gust_kmh=gust, precip_1h_mm=precip,
+        cloud_total_pct=40, humidity_pct=50,
+        cape_jkg=cape, convective_inhibition_jkg=cin,
+        lightning_potential_lpi_jkg=lpi, lightning_density_per_km2_3h=dichte,
+    )
+
+
+def _reihe(punkte: list[ForecastDataPoint]) -> NormalizedTimeseries:
+    """Zeitreihe, deren Punkte durch die ECHTE Fusion gelaufen sind: Gebiet aus
+    ``thunder_routing``, Leitern aus ``model_registry`` -- keine im Test
+    getippte Schwelle (sonst prueft er eine Welt, die es nicht gibt)."""
+    region = thunder_region_for(_LAT, _LON)
+    _fuse_thunder_levels(
+        punkte, cape_ladder_thresholds_jkg(_MODELL, region),
+        lpi_thresholds_jkg(region),
+    )
+    return NormalizedTimeseries(
+        meta=ForecastMeta(provider=Provider.OPENMETEO, model="test", grid_res_km=1.0),
+        data=punkte,
+    )
+
+
+def _segment(punkte: list[ForecastDataPoint], *, tag: date = _TAG,
+             start_h: int = 6, end_h: int = 17, seg_id: int = 1) -> SegmentWeatherData:
+    """Segment, dessen Aggregat die ECHTE Engine rechnet
+    (``compute_basis_metrics`` -> ``thunder_level_max``/
+    ``thunder_level_max_signals``) -- nicht von Hand gesetzt."""
+    reihe = _reihe(punkte)
+    seg = TripSegment(
+        segment_id=seg_id,
+        start_point=GPXPoint(lat=_LAT, lon=_LON, elevation_m=1000.0),
+        end_point=GPXPoint(lat=_LAT + 0.1, lon=_LON + 0.1, elevation_m=1200.0),
+        start_time=datetime(tag.year, tag.month, tag.day, start_h, 0, tzinfo=timezone.utc),
+        end_time=datetime(tag.year, tag.month, tag.day, end_h, 0, tzinfo=timezone.utc),
+        duration_hours=float(end_h - start_h), distance_km=10.0,
+        ascent_m=500.0, descent_m=200.0,
+    )
+    return SegmentWeatherData(
+        segment=seg, timeseries=reihe,
+        aggregated=WeatherMetricsService().compute_basis_metrics(reihe),
+        fetched_at=datetime.now(timezone.utc), provider="openmeteo",
+    )
+
+
+def _dc(friendly: bool = False):
+    """Standard-Anzeigekonfiguration; nur die Schreibweise der Gewitterzeile
+    wird gesteuert (``False`` -> "Gewitter moeglich ...", ``True`` -> "⚡ ...").
+    Beide Zweige von ``_format_thunder()`` muessen die Herkunft tragen."""
+    dc = build_default_display_config()
+    return dataclasses.replace(dc, metrics=[
+        dataclasses.replace(m, use_friendly_format=friendly)
+        if m.metric_id == "thunder" else m
+        for m in dc.metrics
+    ])
+
+
+def _mail(segmente, *, night=None, friendly: bool = False):
+    """Der ECHTE Trip-Bericht (HTML + Klartext + SMS) ueber den produktiven
+    Formatierer -- Prueford = Wirkort."""
+    return TripReportFormatter().format_email(
+        segmente, "Test-Trip", "evening", display_config=_dc(friendly),
+        night_weather=night, tz=_TZ, stage_name=_ETAPPE,
+    )
+
+
+def _kurzfassung(bericht) -> str:
+    """Die EINE Kurzzusammenfassungs-Zeile der Klartext-Mail."""
+    zeilen = [ln for ln in bericht.email_plain.splitlines()
+              if ln.startswith(f"{_ETAPPE}: ")]
+    assert len(zeilen) == 1, (
+        f"Erwartet genau EINE Kurzzusammenfassungs-Zeile in der Klartext-Mail, "
+        f"gefunden: {zeilen!r}")
+    return zeilen[0]
+
+
+def _gewitter_teil(zeile: str) -> str:
+    """"...: 20–20°C, ..., Gewitter möglich 14:00–17:00 · CAPE" -> "14:00–17:00
+    · CAPE". Der Gewitter-Abschnitt steht immer am Ende des Satzes."""
+    for marker in ("Gewitter möglich ", "⚡ möglich "):
+        if marker in zeile:
+            return zeile.split(marker, 1)[1]
+    return ""
+
+
+def _zutaten(zeile: str) -> set[str]:
+    """Die im Gewitter-Abschnitt genannten Zutat-Beschriftungen."""
+    _, _, rest = _gewitter_teil(zeile).partition(" · ")
+    return {t.strip() for t in rest.split(",") if t.strip()}
+
+
+# ---------------------------------------------------------------------------
+# Kommandopfad: echter Trip + echter Schnappschuss + echter Prozessor
+# ---------------------------------------------------------------------------
+
+def _alt_schnappschuss() -> None:
+    """Macht den gespeicherten Schnappschuss zu einem ALT-Schnappschuss (vor
+    Scheibe 1): beide Traeger-Schluessel raus, alles andere unberuehrt."""
+    pfad = get_snapshots_dir(_USER) / f"{_TRIP_ID}.json"
+    roh = json.loads(pfad.read_text())
+    for seg in roh["segments"]:
+        seg["aggregated"].pop("thunder_level_max_signals", None)
+        for stunde in seg.get("hourly", []):
+            stunde.pop("thunder_level_signals", None)
+    pfad.write_text(json.dumps(roh, indent=2))
+
+
+@pytest.fixture
+def kommando():
+    """Speichert Trip + Wetter-Schnappschuss und stellt die Kommando-Frage
+    ueber ``TripCommandProcessor.process()`` -- derselbe Weg, den eine
+    eingehende Telegram-/E-Mail-Nachricht nimmt."""
+    jetzt = datetime.now(tz=timezone.utc)
+    heute = jetzt.date()
+
+    def frage(segmente, *, body: str = "GEWITTER", alt: bool = False) -> str:
+        save_trip(Trip(id=_TRIP_ID, name=_TRIP_NAME, stages=[
+            Stage(id="S1", name="Heute", date=heute, waypoints=[
+                Waypoint(id="W1", name="Start", lat=_LAT, lon=_LON, elevation_m=1000),
+            ]),
+        ]), _USER)
+        WeatherSnapshotService(_USER).save(_TRIP_ID, segmente, heute)
+        if alt:
+            _alt_schnappschuss()
+        ergebnis = TripCommandProcessor().process(InboundMessage(
+            channel="telegram", trip_name=_TRIP_NAME, body=body,
+            sender="4711", received_at=jetzt, user_id=_USER,
+        ))
+        assert ergebnis.success, (
+            f"Das {body}-Kommando muss antworten, nicht scheitern: "
+            f"{ergebnis.confirmation_body!r}")
+        return ergebnis.confirmation_body
+
+    return SimpleNamespace(heute=heute, morgen=heute + timedelta(days=1), frage=frage)
+
+
+def test_ac1_kurzzusammenfassung_nennt_die_tragende_zutat():
+    """AC-1: Given das Gewitterfenster kommt ausschliesslich ueber CAPE
+    zustande, When die Trip-Mail gerendert wird, Then lautet der Satz
+    "Gewitter möglich 14:00–17:00 · CAPE" statt nur "... 14:00–17:00"."""
+    seg = _segment([_dp(h, cape=1500.0, cin=5.0) for h in (14, 15, 16)])
+    zeile = _kurzfassung(_mail([seg]))
+    assert _gewitter_teil(zeile) == "14:00–17:00 · CAPE", (
+        f"Die Kurzzusammenfassung muss die tragende Zutat neben dem "
+        f"Zeitfenster nennen: {zeile!r}")
+
+
+def test_ac1_auch_die_freundliche_schreibweise_traegt_die_herkunft():
+    """AC-1 (zweiter Zweig): ``_format_thunder()`` hat zwei Textvarianten.
+    Die Herkunft haengt an BEIDEN -- sonst zeigt jeder Trip mit der
+    Default-Einstellung (``use_friendly_format=True``) weiterhin nichts."""
+    seg = _segment([_dp(h, cape=1500.0, cin=5.0) for h in (14, 15, 16)])
+    zeile = _kurzfassung(_mail([seg], friendly=True))
+    assert "⚡ möglich 14:00–17:00 · CAPE" in zeile, (
+        f"Auch die freundliche Schreibweise muss die Herkunft tragen: {zeile!r}")
+
+
+def test_ac2_gewitter_kommando_nennt_die_tragende_zutat(kommando):
+    """AC-2: Given die Tagesstufe kommt ausschliesslich ueber CAPE zustande,
+    When der Nutzer GEWITTER sendet, Then lautet die Antwort
+    "⛈ Gewitter heute (dd.mm): leicht · CAPE" statt nur "... leicht"."""
+    seg = _segment([_dp(h, tag=kommando.heute, cape=400.0, cin=5.0) for h in (10, 11)],
+                   tag=kommando.heute, start_h=6, end_h=12)
+    antwort = kommando.frage([seg])
+    assert antwort == f"⛈ Gewitter heute ({kommando.heute:%d.%m}): leicht · CAPE", (
+        f"Die GEWITTER-Antwort muss die tragende Zutat neben der Stufe "
+        f"nennen: {antwort!r}")
+
+
+def test_ac3_beide_zutaten_derselben_stunde_werden_in_katalogreihenfolge_genannt():
+    """AC-3: Given CAPE UND Blitzpotenzial erreichen in derselben Stunde die
+    Hoechststufe, When die Kurzzusammenfassung gerendert wird, Then werden
+    BEIDE in der Reihenfolge aus ``THUNDER_SIGNAL_LABEL_DE`` genannt -- kein
+    Gewinner wird gekuert (PO-Auslegung (ii))."""
+    seg = _segment([_dp(h, cape=1500.0, cin=5.0, lpi=60.0) for h in (14, 15, 16)])
+    zeile = _kurzfassung(_mail([seg]))
+    assert _gewitter_teil(zeile) == "14:00–17:00 · CAPE, Blitzpotenzial", (
+        f"Beide Traeger der Hoechststufe muessen erscheinen, CAPE vor "
+        f"Blitzpotenzial (Katalogreihenfolge): {zeile!r}")
+
+
+def test_ac4_gewitter_kommando_vereinigt_die_zutaten_mehrerer_wegpunkte(kommando):
+    """AC-4: Given zwei Wegpunkte desselben Tages erreichen die Tages-
+    Hoechststufe ueber VERSCHIEDENE Zutaten, When der Nutzer GEWITTER sendet,
+    Then nennt die Antwort BEIDE -- nicht nur die des zeitlich ersten.
+
+    Der dritte Wegpunkt traegt eine dritte Zutat auf NIEDRIGERER Stufe: er
+    darf NICHT genannt werden. Ohne ihn waere dieselbe Zusicherung auch dann
+    gruen, wenn die Vereinigung ueber ALLE Wegpunkte liefe statt nur ueber die
+    am Maximum (Mutationsprobe (a) der Spec).
+    """
+    heute = kommando.heute
+    wegpunkte = [
+        _segment([_dp(10, tag=heute, cape=1500.0, cin=5.0)],
+                 tag=heute, start_h=6, end_h=10, seg_id=1),
+        _segment([_dp(14, tag=heute, lpi=60.0)],
+                 tag=heute, start_h=11, end_h=14, seg_id=2),
+        _segment([_dp(16, tag=heute, dichte=0.005)],
+                 tag=heute, start_h=15, end_h=16, seg_id=3),
+    ]
+    antwort = kommando.frage(wegpunkte)
+    assert antwort == f"⛈ Gewitter heute ({heute:%d.%m}): hoch · CAPE, Blitzpotenzial", (
+        f"Die Antwort muss die Traeger ALLER Wegpunkte mit der Hoechststufe "
+        f"vereinigen -- und nur diese: {antwort!r}")
+
+
+def test_ac5_ankunftsstunde_behaelt_beide_zutaten():
+    """AC-5: Given an der Ankunftsstunde ueberschneiden sich Segment- und
+    Nachtfenster mit zwei Punkten derselben Hoechststufe ueber verschiedene
+    Zutaten, When die Kurzzusammenfassung sie zu EINEM Punkt zusammenfuehrt,
+    Then traegt der Satz BEIDE Zutaten.
+
+    Der Segmentpunkt gewinnt den Tie-Break in ``_merge_hour()`` (mehr Regen,
+    staerkere Boeen) -- ein fuer die Herkunft sachfremdes Kriterium
+    (Kontext "Neuer Befund 1"). Die fruehere Stunde 12:00 traegt eine dritte
+    Zutat auf niedrigerer Stufe und darf nicht mitgenannt werden.
+    """
+    seg = _segment(
+        [_dp(12, dichte=0.005), _dp(16, cape=1500.0, cin=5.0, precip=5.0, gust=90.0)],
+        start_h=6, end_h=16,
+    )
+    night = _reihe([_dp(16, lpi=60.0, precip=0.0, gust=1.0), _dp(18)])
+    zeile = _kurzfassung(_mail([seg], night=night))
+    assert _zutaten(zeile) == {"CAPE", "Blitzpotenzial"}, (
+        f"Die zusammengefuehrte Ankunftsstunde muss BEIDE Traeger der "
+        f"Hoechststufe behalten (und nur diese): {zeile!r}")
+
+
+def test_ac6_zutat_ausserhalb_des_tagesfensters_erscheint_nicht():
+    """AC-6: Given eine dritte Zutat traegt die Hoechststufe NUR in einer
+    Stunde ausserhalb des Tagesfensters (02:00), When die Kurzzusammenfassung
+    gerendert wird, Then erscheint sie NICHT -- Zeitfenster und Herkunft
+    stammen aus derselben gefensterten Liste, ohne zweiten Datenzugriff."""
+    seg = _segment(
+        [_dp(2, dichte=0.5)] + [_dp(h, cape=1500.0, cin=5.0) for h in (14, 15)],
+        start_h=6, end_h=17,
+    )
+    assert seg.aggregated.thunder_level_max_signals == ["blitzdichte", "cape"], (
+        f"Vorbedingung: das SEGMENT-Aggregat kennt die dritte Zutat sehr wohl "
+        f"-- sonst belegt dieser Test nichts: "
+        f"{seg.aggregated.thunder_level_max_signals!r}")
+    zeile = _kurzfassung(_mail([seg]))
+    assert _gewitter_teil(zeile) == "14:00–16:00 · CAPE", (
+        f"Nur Zutaten aus dem gefensterten Stundenbereich duerfen erscheinen "
+        f"-- 'Blitzdichte' liegt bei 02:00 ausserhalb: {zeile!r}")
+
+
+def test_ac7_zutat_eines_anderen_kalendertags_erscheint_nicht(kommando):
+    """AC-7: Given ein Wegpunkt eines ANDEREN Kalendertags traegt eine dritte
+    Zutat, When der Nutzer GEWITTER sendet, Then nennt die Antwort nur Zutaten
+    von Wegpunkten des Zieltags."""
+    heute, morgen = kommando.heute, kommando.morgen
+    antwort = kommando.frage([
+        _segment([_dp(14, tag=heute, cape=1500.0, cin=5.0)],
+                 tag=heute, start_h=6, end_h=14, seg_id=1),
+        _segment([_dp(14, tag=morgen, dichte=0.5)],
+                 tag=morgen, start_h=6, end_h=14, seg_id=2),
+    ])
+    assert antwort == f"⛈ Gewitter heute ({heute:%d.%m}): hoch · CAPE", (
+        f"Die Herkunft muss aus den Wegpunkten DES Zieltags kommen -- die "
+        f"Blitzdichte von morgen darf nicht erscheinen: {antwort!r}")
+
+
+def test_ac8_sms_zeigt_die_stufe_aber_keine_herkunft():
+    """AC-8: Given derselbe Bericht erzeugt Mail UND SMS, When er versendet
+    wird, Then traegt weder ``sms_text`` noch der tatsaechlich zugestellte
+    Rueckfallausdruck ``sms_text or email_plain`` eine der vier Zutat-
+    Bezeichnungen; die Gewitterstufe selbst bleibt sichtbar.
+
+    Gegenprobe im selben Lauf (Spec-Pflicht): die Mail DERSELBEN Fixture zeigt
+    die Herkunft sehr wohl -- sonst waere dieses AC auch dann gruen, wenn die
+    Herkunft nirgends erschiene. Und ``sms_text`` muss nicht-leer sein: nur
+    dann ist belegt, dass der Rueckfall auf ``email_plain``
+    (``notification_service.py:417,433``) strukturell nicht greift (#868).
+    """
+    seg = _segment([_dp(h, cape=1500.0, cin=5.0, lpi=60.0) for h in (14, 15, 16)])
+    bericht = _mail([seg])
+
+    assert bericht.sms_text, (
+        "sms_text muss immer erzeugt werden (#868) -- sonst greift der "
+        "Rueckfall `sms_text or email_plain` und traegt die Herkunft in die "
+        "SMS/Premium-SMS, entgegen der PO-Entscheidung")
+    zugestellt = bericht.sms_text or bericht.email_plain
+    assert "TH:H" in zugestellt, (
+        f"Die Gewitterstufe selbst bleibt in der SMS sichtbar: {zugestellt!r}")
+    for zutat in ALLE_ZUTATEN:
+        assert zutat not in zugestellt, (
+            f"SMS/Premium-SMS sind bewusst OHNE Herkunft (PO-Entscheidung) -- "
+            f"'{zutat}' darf nicht vorkommen: {zugestellt!r}")
+
+    zeile = _kurzfassung(bericht)
+    assert _zutaten(zeile) == {"CAPE", "Blitzpotenzial"}, (
+        f"Gegenprobe gescheitert: die Mail DERSELBEN Fixture MUSS die Herkunft "
+        f"zeigen, sonst beweist die SMS-Abwesenheit nichts: {zeile!r}")
+
+
+def test_ac9_alt_schnappschuss_zeigt_die_stufe_ohne_herkunft(kommando):
+    """AC-9: Given ein gespeicherter Schnappschuss OHNE
+    ``thunder_level_max_signals`` (vor Scheibe 1) wird geladen, When der
+    Nutzer GEWITTER sendet, Then zeigt die Antwort die Stufe unveraendert,
+    aber OHNE Zusatz -- kein "unbekannt", kein leerer Trenner, kein Fehler.
+
+    Gegenprobe im selben Test: derselbe Trip mit VOLLSTAENDIGEM Schnappschuss
+    nennt die Zutat sehr wohl.
+    """
+    heute = kommando.heute
+    segmente = [_segment([_dp(h, tag=heute, cape=1500.0, cin=5.0) for h in (14, 15)],
+                         tag=heute, start_h=6, end_h=16)]
+
+    vollstaendig = kommando.frage(segmente)
+    assert vollstaendig == f"⛈ Gewitter heute ({heute:%d.%m}): hoch · CAPE", (
+        f"Gegenprobe gescheitert: der vollstaendige Schnappschuss MUSS die "
+        f"Herkunft tragen: {vollstaendig!r}")
+
+    alt = kommando.frage(segmente, alt=True)
+    assert alt == f"⛈ Gewitter heute ({heute:%d.%m}): hoch", (
+        f"Ein Alt-Schnappschuss ohne Traegerfeld zeigt die Stufe unveraendert "
+        f"und KEINEN Zusatz: {alt!r}")
+
+
+def test_ac10_ohne_gewitter_bleiben_beide_ausgabeorte_zeichengleich(kommando):
+    """AC-10 (erste Haelfte): Given kein Datenpunkt erreicht eine Stufe ueber
+    NONE, When Kurzzusammenfassung und GEWITTER-Kommando gerendert werden,
+    Then bleibt die Ausgabe an BEIDEN Orten zeichengleich zu heute.
+
+    Gegenprobe im selben Test: dieselbe Etappe mit CAPE ueber der Leiter zeigt
+    die Herkunft an beiden Orten sehr wohl.
+    """
+    heute = kommando.heute
+    ruhig = _segment([_dp(h, tag=heute, cape=50.0, cin=5.0) for h in (14, 15)],
+                     tag=heute, start_h=6, end_h=16)
+    laut = _segment([_dp(h, tag=heute, cape=1500.0, cin=5.0) for h in (14, 15)],
+                    tag=heute, start_h=6, end_h=16)
+
+    ruhige_zeile = _kurzfassung(_mail([ruhig]))
+    assert "möglich" not in ruhige_zeile, (
+        f"Ohne Gewitter bleibt die Kurzzusammenfassung ohne Gewitterteil "
+        f"(und damit ohne Herkunft): {ruhige_zeile!r}")
+    assert kommando.frage([ruhig]) == f"⛈ Gewitter heute ({heute:%d.%m}): kein", (
+        "Ohne Gewitter bleibt die GEWITTER-Antwort zeichengleich zu heute")
+
+    laute_zeile = _kurzfassung(_mail([laut]))
+    assert _zutaten(laute_zeile) == {"CAPE"} and "· CAPE" in kommando.frage([laut]), (
+        f"Gegenprobe gescheitert: mit erreichter Stufe MUSS die Herkunft an "
+        f"beiden Orten erscheinen: {laute_zeile!r}")
+
+
+def test_ac10_glance_bleibt_ohne_herkunft(kommando):
+    """AC-10 (zweite Haelfte): Given GLANCE liest denselben
+    ``_aggregate_day()``-Dict wie GEWITTER, When der neue Traeger-Schluessel
+    dazukommt, Then bleibt die GLANCE-Zeile zeichengleich (Known Limitation 4).
+
+    Gegenprobe im selben Test: die GEWITTER-Antwort derselben Fixture nennt
+    CAPE -- ohne sie waere dieses AC auch dann gruen, wenn die Herkunft
+    nirgends erschiene.
+    """
+    heute = kommando.heute
+    segmente = [_segment([_dp(h, tag=heute, cape=1500.0, cin=5.0) for h in (14, 15)],
+                         tag=heute, start_h=6, end_h=16)]
+
+    glance = kommando.frage(segmente, body="GLANCE")
+    erwartet = f"heute ({heute:%d.%m}): 🌡 20–20°C  💨 8 km/h  🌧 0.0mm  ⛈ Gewitter: hoch"
+    assert erwartet in glance, (
+        f"Die GLANCE-Tageszeile bleibt zeichengleich -- kein Herkunfts-Zusatz: "
+        f"{glance!r}")
+    for zutat in ALLE_ZUTATEN:
+        assert zutat not in glance, (
+            f"GLANCE bekommt bewusst keinen Zugriff auf den neuen Schluessel "
+            f"-- '{zutat}' darf dort nicht auftauchen: {glance!r}")
+
+    assert "· CAPE" in kommando.frage(segmente), (
+        "Gegenprobe gescheitert: die GEWITTER-Antwort DERSELBEN Fixture MUSS "
+        "die Herkunft nennen")

--- a/tests/tdd/test_thunder_origin_trip.py
+++ b/tests/tdd/test_thunder_origin_trip.py
@@ -42,9 +42,10 @@ from app.model_registry import (  # noqa: E402
 )
 from app.models import (  # noqa: E402
     ForecastDataPoint, ForecastMeta, GPXPoint, NormalizedTimeseries, Provider,
-    SegmentWeatherData, TripSegment,
+    SegmentWeatherData, ThunderLevel, TripSegment,
 )
 from app.trip import Stage, Trip, Waypoint  # noqa: E402
+from output.metric_format import union_of_max_carriers  # noqa: E402
 from output.renderers.trip_report import TripReportFormatter  # noqa: E402
 from providers.thunder_enrichment import _fuse_thunder_levels  # noqa: E402
 from providers.thunder_routing import thunder_region_for  # noqa: E402
@@ -454,3 +455,37 @@ def test_ac10_glance_bleibt_ohne_herkunft(kommando):
     assert "· CAPE" in kommando.frage(segmente), (
         "Gegenprobe gescheitert: die GEWITTER-Antwort DERSELBEN Fixture MUSS "
         "die Herkunft nennen")
+
+
+# ---------------------------------------------------------------------------
+# Zusicherung des Helfers selbst (Adversary-Befund F001 zu Scheibe 2)
+# ---------------------------------------------------------------------------
+
+def test_hoechststufe_none_hat_keine_herkunft_auch_mit_gefuellten_traegern():
+    """Given die Hoechststufe eines Aggregats ist ``NONE``, When Traeger
+    mitgeliefert werden, Then ist das Ergebnis ``None`` -- "kein Gewitter" hat
+    keine Herkunft.
+
+    Wirkort ist hier die Funktion selbst: kein heutiger Aufrufer erzeugt zu
+    einem ``NONE``-Punkt eine gefuellte Traegerliste, der Docstring sagt die
+    Eigenschaft aber als Eigenschaft der FUNKTION zu. Der Helfer ist laut
+    Spec D1 ausdruecklich fuer die Wiederverwendung gebaut (kuenftiger
+    ``aggregate_stage()``-Anschluss) -- eine Zusicherung, die nur aus dem
+    Verhalten der Aufrufer folgt, bricht genau dort.
+    """
+    assert union_of_max_carriers([(ThunderLevel.NONE, ["cape"])]) is None, (
+        "Ein einzelner NONE-Punkt mit Traeger darf keine Herkunft nennen")
+    assert union_of_max_carriers([
+        (ThunderLevel.NONE, ["cape"]),
+        (ThunderLevel.NONE, ["wettercode", "lightning"]),
+    ]) is None, (
+        "Auch mehrere NONE-Punkte mit Traegern nennen keine Herkunft")
+
+    # Gegenprobe: sobald irgendein Punkt ueber NONE liegt, traegt NUR er bei --
+    # unveraendertes Verhalten, nicht durch die neue Zusicherung mit-erschlagen.
+    assert union_of_max_carriers([
+        (ThunderLevel.NONE, ["cape"]),
+        (ThunderLevel.LOW, ["wettercode"]),
+    ]) == ["wettercode"], (
+        "Liegt das Maximum ueber NONE, bleibt die Vereinigung der Traeger am "
+        "Maximum unveraendert")


### PR DESCRIPTION
Scheibe 2 zu #1680. Die Gewitterstufe trägt auf der **Trip-Seite** jetzt sichtbar, welche Zutat sie erreicht hat — so wie es der Ortsvergleich seit Scheibe 1 tut.

```
Trip-Mail, Kurzzusammenfassung:
  vorher   ⚡ möglich 14:00–17:00
  nachher  ⚡ möglich 14:00–17:00 · CAPE

Antwort auf GEWITTER (E-Mail/Telegram):
  vorher   ⛈ Gewitter heute (12.08): leicht
  nachher  ⛈ Gewitter heute (12.08): leicht · CAPE
```

E-Mail und Telegram tragen die Herkunft, **SMS und Premium-SMS ausdrücklich nicht** — aktiv abgewählt mit Begründung im Code, nicht stillschweigend ausgelassen (PO-Entscheid).

## Ein geteilter Helfer statt drei Regelkopien

Die Trip-Seite hat **drei** Wege, die eine Tages-Gewitterstufe aggregieren, und jeder rechnet sie selbst. Die Regel „nenne alle Zutaten, die die Höchststufe erreichen" existierte bisher nur als private Methode an der Engine, fest an eine Zeitreihe gebunden. `union_of_max_carriers()` löst sie heraus — nach dem Vorbild von `hail_priority()`, das genau so schon von allen drei Wegen importiert wird statt kopiert zu werden (Fehlerklasse #1480).

Rückgabe ist bewusst `list[str]`, **nie ein `set`**: das Ergebnis landet im Wetter-Schnappschuss, und ein `set` bräche dort `json.dumps` — der Fehler wird still geschluckt, der gesamte Schnappschuss wäre weg (#1405). Die Adversary-Mutation dazu wurde an der echten Serialisierungsstelle gefangen, nicht bloß an der Signatur.

## Zwei Befunde, die erst beim Messen auftauchten

**`_merge_hour()` ließ den Niederschlag über die Herkunft entscheiden.** An der Ankunftsstunde überlappen Segment- und Nachtfenster. Die Stufe wurde über alle Punkte der Stunde neu gebildet, die Trägerliste kam aber unverändert von dem Punkt, der einen Vergleich nach Niederschlag und Böen gewann. Trafen dort zwei Punkte mit gleicher Stufe aus **verschiedenen** Zutaten zusammen, entschied ein sachfremdes Kriterium, welche Ursache angezeigt wird — entgegen der freigegebenen Auslegung, dass *alle* tragenden Signale genannt werden. Jetzt vereinigt.

**Die Kurzzusammenfassung hat zwei Textvarianten, und der Standardfall ist nicht der aus der Spec.** Voreingestellt ist `use_friendly_format=True`, also `⚡ möglich …` statt `Gewitter möglich …`. Ein Suffix nur am zweiten Zweig wäre für den Normalnutzer unsichtbar geblieben: grün getestet und wirkungslos. Beide Zweige werden bedient, mit je einem Test.

## `aggregate_stage()` bleibt bewusst außen vor

Die S1-Spec notierte, die Trip-Scheibe müsse diesen Aggregationsweg zuerst reparieren. Gemessen umgehen ihn **beide** Ausgabeorte dieser Scheibe strukturell — ein Dispatch-Zweig hätte hier keinen erreichbaren Verbraucher und ein Test darauf bewachte nichts. Damit gilt derselbe Tech-Lead-Entscheid wie in Scheibe 1 weiter; der Anschluss gehört in die Scheibe mit dem Mehrtages-Ausblick, wo `trip_report_scheduler.py:2020` der erste echte Verbraucher ist.

Das ist die AC-12-Lehre der Vorgängerscheibe ein zweites Mal — diesmal auf eine übernommene **Notiz** statt auf ein Muster angewandt: erst prüfen, ob ihre Voraussetzung überhaupt gilt.

## Nachweis

| Was | Ergebnis |
|---|---|
| Akzeptanzkriterien | 10, jedes durch die volle Renderkette bis zum zugestellten Text |
| Tests | 13 grün (12 ACs + 1 aus dem Adversary-Finding), keiner deselektiert |
| Mutations-Gegenprobe | 5 Pflicht + 4 eigene; **eine kam durch** → Finding F001, behoben |
| Adversary | 3 Runden, 22 Punkte, Verdict **VERIFIED** |
| Nachbarschaft | per `grep` ermittelt statt geschätzt: 404 Testdateien, 4197 grün |
| Zugestellte Briefing-Mail | `briefing_mail_validator.py` Exit 0 gegen echte IMAP-Zustellung |
| Renderer-Commit-Gate | `test_issue_811_mode_matrix.py` 41 grün |

**Finding F001:** `union_of_max_carriers()` sagte im Docstring zu, eine Höchststufe `NONE` führe auf „keine Herkunft" — hielt das aber nicht. Die Zusage stimmte nur, weil der *Erzeuger* der Trägerlisten für `NONE` ohnehin eine leere Liste liefert: eine Eigenschaft der Aufrufer, formuliert als Eigenschaft der Funktion. Bei einem Helfer, der ausdrücklich zur Wiederverwendung gebaut ist, hätte das beim nächsten Anschluss zugeschlagen. Die Regel wird jetzt an beiden Enden durchgesetzt.

## Nicht in dieser Scheibe

Mehrtages-Ausblick · Pill im Metriken-Überblick · Gewitter-Vorschau · Kommando-Timeline je Wegpunkt · Stundentabelle · Compare-Stundentabelle · Go-DTO und Frontend. Issue #1680 bleibt offen.

Bezug: Epic #1419 Rang 4, Entscheidung E1. Vorgänger: PR #1780 (Scheibe 1).
