### PR TITLE
test(#1719 S4): Klickpfad trennt eigenen Defekt von fremdem Bauteil (#1791)

### DIFF
--- a/docs/specs/modules/fix_1719_s4_kuerzel_vereinheitlichung.md
+++ b/docs/specs/modules/fix_1719_s4_kuerzel_vereinheitlichung.md
@@ -209,6 +209,39 @@ Geprüft wird gegen den **Worst Case**, nicht gegen eine bequeme Auswahl: „Gef
 Nacht-Tiefsttemperatur" (31 Zeichen, längster Name im Katalog) und „Gefühlte Temperatur"
 (längste Kurzform `FK FD WC`) müssen beide in der Liste stehen.
 
+#### 🔴 Nachtrag 2026-08-12 nach der Staging-Messung: zwei Korrekturen
+
+**a) Die Mechanismus-Begründung oben ist falsch.** Der Staging-Prüfer hat in echtem Chromium
+mit den realen Zeilenbreiten dreimal gegengeprüft: `min-width: 0` an `.metric-label` ist
+neben dem dort bereits vorhandenen `overflow: hidden` **redundant** (Flexbox-Spec: das
+automatische Minimum ist 0, sobald `overflow` nicht `visible` ist), und `flex-shrink: 0` an
+den Marken ist neben `white-space: nowrap` ohne `overflow: hidden` **ebenfalls redundant**.
+Erst wenn man **beides gleichzeitig** entfernt, entsteht eine Verletzung — und zwar als
+Zeilen-Überlauf, nicht als Beschneiden der Marke. Das war eine **am Code gelesene, nie
+gemessene** Annahme von mir. Die Zusicherung selbst bleibt richtig; nur ihre Herleitung war
+es nicht. *Lehre: eine CSS-Wirkungskette gehört im Browser nachgemessen, bevor sie als
+Begründung in eine Spec wandert.*
+
+**b) Zwei verschiedene Defekte unterhalb von 900 px, unterschiedlich behandelt** (#1791):
+
+| Breite | Art | Behandlung |
+|---|---|---|
+| **320×568** | **24 echte Beschneidungen** — Marken auf Inhaltsbreite null (`clientWidth` 8–9 = Polster+Rahmen, `scrollWidth` bis 47) | Breite **ganz ausgenommen**, Zeile auskommentiert |
+| 375–899 px | ausschließlich Überdeckung durch mobile Navigation + fixierten „✓ Gespeichert"-Streifen | **nur Bedingung 4** ausgesetzt |
+| ab 901 px | sauber | unverändert geprüft |
+
+Der Unterschied ist wesentlich: Bei 320 px versagt **das Kürzel-Layout selbst** (Positionsnummer,
+Griff, Textspalte und Bedienknöpfe teilen sich eine Breite, für die Textspalte bleibt nichts).
+Zwischen 375 und 899 px steht dagegen nur ein **fremdes Bauteil** davor — dort ist keine
+einzige Beschneidung messbar. Ganze Breiten wegzulassen hätte dort auch die Bedingungen
+1/2/3/5 blind gemacht, also genau die Zusicherung dieser Scheibe.
+
+PO-Entscheid 2026-08-12: ausliefern, beide Fälle in #1791. **Beim Schließen gehören die
+320-px-Zeile und der `mobileNavZone`-Block zurück bzw. weg.**
+
+**Ergebnis nach der Anpassung:** 6/6 grün in 13 Auflösungen gegen Staging `18af3c4b`
+(AC-5, AC-10/11, AC-12, AC-13, AC-14).
+
 ## Acceptance Criteria
 
 - **AC-1:** Given eine Telegram-Nachricht eines Trips mit den Größen Luftfeuchtigkeit,

--- a/frontend/e2e/kuerzel-marken-sichtbar.staging.spec.ts
+++ b/frontend/e2e/kuerzel-marken-sichtbar.staging.spec.ts
@@ -52,7 +52,18 @@ const BESCHRIFTUNGEN = ['Mail', 'Kurzform'];
 /** Auflösungsmatrix aus der Spec, Abschnitt 4 — VERBINDLICH, keine Auswahl.
  *  Schwerpunkt auf der Bruchzone und beiden Raendern der Media-Query. */
 const AUFLOESUNGEN = [
-	{ klasse: 'Kleines Handy', width: 320, height: 568 },
+	// 🔴 320×568 ist AUSGENOMMEN (#1791, PO-Entscheid 2026-08-12): dort werden die
+	// Marken auf Inhaltsbreite NULL gequetscht (`clientWidth` 8–9 = Polster+Rahmen,
+	// `scrollWidth` bis 47) — 24 echte Beschneidungen, je 12 in beiden Editoren.
+	// Das ist ein ECHTER Defekt der Kuerzel-Darstellung, nicht bloss ein fremdes
+	// Bauteil davor: in der Zeile teilen sich Positionsnummer, Griff, Textspalte
+	// und Bedienknoepfe eine Breite, und bei 320px bleibt fuer die Textspalte
+	// nichts uebrig. Ab 375px tritt es NICHT mehr auf.
+	// Erreichbarkeit fraglich: bei 320px existiert `trip-detail-tab-weather` gar
+	// nicht (eigene Messung, 20s Timeout) — der Klickpfad kommt nur hin, weil er
+	// in Normalgroesse oeffnet und danach verkleinert.
+	// **Beim Schliessen von #1791 gehoert diese Zeile zurueck.**
+	// { klasse: 'Kleines Handy', width: 320, height: 568 },
 	{ klasse: 'Kleines Handy', width: 375, height: 667 },
 	{ klasse: 'Handy', width: 390, height: 844 },
 	{ klasse: 'Handy', width: 414, height: 896 },
@@ -263,11 +274,27 @@ async function messeZeile(zeile: Locator): Promise<Befund[]> {
 					);
 				}
 				// 4: nicht von einem Nachbarelement ueberdeckt
+				//
+				// 🔴 #1791: unterhalb von 900px greift die mobile Media-Query — dort
+				// belegen die vollbreite Bottom-Nav und der dauerhaft fixierte
+				// „✓ Gespeichert"-Streifen die unteren ~60–90px permanent, und jede
+				// Zeile, die beim sequentiellen Durchscrollen dort landet, ist
+				// verdeckt. Gemessen 2026-08-12 gegen `18af3c4b`: zwischen 375 und
+				// 899px sind ALLE Verletzungen von dieser Art, KEINE ist ein
+				// „beschnitten" (Bedingung 1). Die Zusicherung dieser Scheibe —
+				// Marken werden nie abgeschnitten — gilt dort also; was scheitert,
+				// ist ein fremdes, vorbestehendes Bauteil, kein Kuerzel-Layout.
+				//
+				// Deshalb wird NICHT die Breite ausgenommen (das wuerde auch die
+				// Bedingungen 1/2/3/5 dort blind machen), sondern genau diese eine
+				// Bedingung — und nur unterhalb der Media-Query-Grenze.
+				// **Beim Schliessen von #1791 faellt dieser Block ersatzlos weg.**
+				const mobileNavZone = vw < 900;
 				const mitte = document.elementFromPoint(
 					(r.left + r.right) / 2,
 					(r.top + r.bottom) / 2
 				);
-				if (!mitte || !(mitte === el || el.contains(mitte))) {
+				if (!mobileNavZone && (!mitte || !(mitte === el || el.contains(mitte)))) {
 					const wer = mitte
 						? `<${mitte.tagName.toLowerCase()} class="${mitte.className}">`
 						: 'nichts (Punkt liegt ausserhalb des Sichtfensters)';


### PR DESCRIPTION
## Warum

Der Klickpfad aus #1787 fand bei der Staging-Verifikation Verletzungen unterhalb von 900 px. Ausgezählt sind es **zwei verschiedene Sachen**, die nicht gleich behandelt werden dürfen — und genau diese Unterscheidung fehlte.

| Breite | Art | Anzahl | Ursache |
|---|---|---|---|
| **320×568** | **beschnitten** | 24 | eigener Defekt der Kürzel-Darstellung |
| 375–899 px | **verdeckt** | alle | fremdes Bauteil davor |
| ab 901 px | — | 0 | sauber |

**Bei 320 px** werden die Marken auf Inhaltsbreite **null** gequetscht (`clientWidth` 8–9 ist reines Polster plus Rahmen, `scrollWidth` bis 47). In der Zeile teilen sich Positionsnummer, Griff, Textspalte und Bedienknöpfe eine Breite; dort bleibt für die Textspalte nichts übrig. Ab 375 px tritt es nicht mehr auf.

**Zwischen 375 und 899 px** ist dagegen **keine einzige** Beschneidung messbar — alle Treffer sind Überdeckungen durch die vollbreite mobile Navigationsleiste und den dauerhaft fixierten „✓ Gespeichert"-Streifen, die dort die unteren ~60–90 px permanent belegen.

## Was sich ändert

- **320 px** ist aus der Matrix genommen (Zeile **auskommentiert, nicht gelöscht**).
- **Bedingung 4 (nicht überdeckt)** ist unterhalb von 900 px ausgesetzt — **nicht** die Breiten weggelassen. Ein Weglassen hätte dort auch die Bedingungen 1/2/3/5 blind gemacht, also genau die Zusicherung, um die es in dieser Scheibe geht.
- Beides mit Verweis auf **#1791** und dem ausdrücklichen Vermerk, dass es beim Schließen zurückgebaut wird.

## Eine Spec-Korrektur in eigener Sache

Die Mechanismus-Begründung in der Spezifikation war **falsch**. Ich hatte geschrieben, den Marken fehle `flex-shrink: 0`. Im echten Browser nachgemessen (dreimal gegengeprüft, mit den realen Zeilenbreiten von Staging):

- `min-width: 0` an `.metric-label` ist neben dem dort bereits vorhandenen `overflow: hidden` **redundant** — nach Flexbox-Spec ist das automatische Minimum 0, sobald `overflow` nicht `visible` ist.
- `flex-shrink: 0` an den Marken ist neben `white-space: nowrap` ohne `overflow: hidden` **ebenfalls redundant**.
- Erst **beides gleichzeitig** entfernt erzeugt eine Verletzung — und zwar als Zeilen-Überlauf, nicht als Beschneiden der Marke.

Das war eine am Code **gelesene, nie gemessene** Annahme. Die Zusicherung selbst („Kürzel werden nie abgeschnitten") bleibt richtig und ist ab 375 px belegt; nur ihre Herleitung war es nicht.

## Nachweis

**6/6 grün** in 13 Auflösungen im echten Chromium gegen Staging `18af3c4b`: AC-5, AC-10/11, AC-12, AC-13, AC-14. Kein Produktivcode berührt — nur Prüfcode und Spezifikation.

Refs #1719, #1791

🤖 Generated with [Claude Code](https://claude.com/claude-code)
