### PR TITLE
docs(#1719 S4): metric_output_matrix — compact_label ist abgeleitet, nicht gepflegt

### DIFF
--- a/docs/reference/metric_output_matrix.md
+++ b/docs/reference/metric_output_matrix.md
@@ -43,6 +43,21 @@ prüft, bewacht die E-Mail-Tabelle. Er bewacht **nicht** den Ausblick derselben 
 Ausgabeform definieren: `col_key`/`col_label`, `compact_label`, `sms_code`,
 `alert_label`, `format_modes`, `trip_default_rank`, `selectable`.
 
+> **🔴 Seit #1719 S4 (2026-08-13) ist `compact_label` KEIN unabhängig gepflegtes
+> Feld mehr**, sondern wird aus dem Register-Kürzel (`sms_code`) **abgeleitet**.
+> Abweichen darf nur, was in einer benannten Ausnahmeliste mit Begründung steht
+> — heute `temperature` (`T`) und `wind_chill` (`TF`), weil deren Register-Kürzel
+> eine *Tagesauswertung* bezeichnen (`D`/`K` bzw. `FK`/`FD`/`WC`), die
+> Telegram-Zelle aber einen *Stundenwert* zeigt. Ein Wächter
+> (`tests/unit/test_telegram_kuerzel_folgt_register.py`) macht jeden neuen
+> Alleingang rot.
+>
+> Grund: die beiden Felder wurden getrennt von Hand gepflegt und sind
+> auseinandergelaufen — 11 von 25 Größen trugen in Telegram ein anderes Kürzel
+> als in der SMS, ohne fachlichen Grund (Luftdruck `P` vs. `HP`, Bewölkung `C`
+> vs. `CT`, Nacht-Tiefsttemperatur `TN` vs. `N`). Wer hier ein Kürzel ändern
+> will, ändert `sms_code` — nicht `compact_label`.
+
 Gemessen am oben genannten Commit:
 
 - **28 Einträge in `_METRICS`** (`metric_catalog.py:92`), davon **26 selectable**


### PR DESCRIPTION
Nachzug zur Referenz-Doku nach #1798.

`docs/reference/metric_output_matrix.md` führte `compact_label` und `sms_code` als **zwei eigenständige Felder** auf, die je eine Ausgabeform definieren. Seit #1719 S4 wird das erste aus dem zweiten **abgeleitet** — abweichen darf nur eine benannte Ausnahme mit Begründung.

Wer heute ein Telegram-Kürzel ändern will, ändert `sms_code`, nicht `compact_label`. Die alte Formulierung hätte genau in die Falle geführt, die dieses Issue behoben hat: zwei Felder, getrennt gepflegt, stillschweigend auseinandergelaufen.

Reine Doku-Änderung, kein Code.

Refs #1719

🤖 Generated with [Claude Code](https://claude.com/claude-code)