### PR TITLE
fix(#1703 S6): Form-Waechter ueber Grammatik-Klassen + W?/X?-Kollision behoben

### DIFF
--- a/docs/context/fix-1703-s6-form-waechter.md
+++ b/docs/context/fix-1703-s6-form-waechter.md
@@ -1,0 +1,162 @@
+# Context: Epic #1703 Scheibe 6 — Form-Wächter über Grammatik-Klassen
+
+## Request Summary
+
+Epic #1703, Scheibe 6: Eigener Wächter über die SMS-Symbol-Register (`PRIORITY`,
+`POSITIONAL` in `tokens/builder.py`, `SMS_MULTI_SYMBOLS_BY_METRIC`/`SMS_SYMBOL_BY_METRIC`
+in `metric_catalog.py`) — anders als Scheibe 1-5 iteriert diese Achse über **Symbole**
+("Grammatik-Klassen"), nicht über Metrik-IDs. Ziel laut `docs/reference/metric_output_matrix.md`
+Abschnitt 6 (Scheibe 6): jede Grammatik-Klasse hat genau eine Prioritätsstufe und eine
+definierte Position; kein Kürzel kollidiert mit `HAZARD_SMS_SYMBOLS`.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `src/output/tokens/builder.py:47-65` (`PRIORITY`) | 36 Symbole → Kürzungs-Prioritätsstufe (1-11). Quelle für die meisten Symbole: `SMS_SYMBOL_BY_METRIC`/`SMS_MULTI_SYMBOLS_BY_METRIC` (Katalog) + 6 echte Systemzeichen ohne Katalogbezug (`DBG`, `AV`, `HR:`, `M:`, `MAX`, `Z:` — Debug/Fire/Vigilance). |
+| `src/output/tokens/builder.py:78-99` (`POSITIONAL`, `POS_INDEX`) | 37 `(symbol, category)`-Paare, Sortier-Reihenfolge. `POS_INDEX` nutzt das Tupel als Schlüssel — `TH:` erscheint bewusst zweimal (`forecast` UND `vigilance`), abgesichert über `_POSITION_SORTABLE_CATEGORIES` (Zeile 110). |
+| `src/app/metric_catalog.py:700-706` (`SMS_MULTI_SYMBOLS_BY_METRIC`) | 5 Metrik-IDs → Tupel mehrerer Kürzel (der 1:n-Strukturbruch, S6 im Sonderstrecken-Katalog): `temperature`→(K,D), `temperature_night`→(N,), `wind_chill`→(FK,FD,WC), `wind_chill_night`→(FN,), `thunder`→(TH:,TH+:). 9 eindeutige Symbole, alle bereits in `PRIORITY` vertreten. |
+| `src/app/metric_catalog.py:665-668` (`SMS_SYMBOL_BY_METRIC`) | Die 1:1-Zwillingstabelle (22 Symbole: R, PR, W, G, HU, DP, WD, CP, PT, CT, CL, CM, CH, VS, SU, UV, HP, NL, SD, SL, NS24+, TH:). **Für einen vollständigen Wächter genauso Pflicht wie die Multi-Tabelle** — sonst meldet er 22 legitime Symbole fälschlich als „Waisen". |
+| `src/output/tokens/hazard_symbols.py:15-26` (`HAZARD_SMS_SYMBOLS`) | Separates Register für amtliche Warnungen (10 Einträge: TH, FL, HR, W, SN, IC, HT, CD, FR, CL). Textuelle Überschneidung mit `PRIORITY`-Symbolen: exakt `W`, `CL` (und bei Doppelpunkt-Normalisierung `HR`, `TH`). |
+| `src/output/tokens/builder.py:199-222` (`_vigilance()`, `_official_alerts()`) | Amtliche-Warnungen-Rendering nutzt FESTE `category`/Priorität, **nicht** `PRIORITY[symbol]`/`POS_INDEX[symbol]` — Kollisionsschutz ist strukturell in `render.py` über `category`-Branch verankert, nicht über Namensraum-Trennung der Kürzel selbst. |
+| `src/output/tokens/builder.py:333-344` (`_gap_or()`, Wind-Token-Bau) | **Live-Kollision, verifiziert:** Ein Wind-Datenausfall rendert `Token("W", "?", ...)` → `Token.render()` (`dto.py:130-135`) gibt `f"{symbol}{value}"` = **„W?"** zurück — bytegleich mit `UNAVAILABLE_SYMBOL = "W?"` (`builder.py:74`, Bedeutung „amtliche Warnungen nicht abrufbar"). Beide Bedingungen sind unabhängig voneinander auslösbar; die resultierende SMS-Zeile ist für den Leser nicht unterscheidbar. |
+| `tests/unit/test_sms_token_symbol_register_ratchet.py` (331 Zeilen) | Bestehender Ratschen-Test — prüft NUR den Wintersport-Block + `SMS_SYMBOL_BY_METRIC` gegen `get_sms_code()`. Importiert `HAZARD_SMS_SYMBOLS` an keiner Stelle (verifiziert per Grep) — keine Kollisionsprüfung, keine Vollständigkeitsprüfung von `PRIORITY`/`POSITIONAL` als Ganzes. |
+| `tests/tdd/test_channel_metric_matrix.py` (3663 Zeilen) | Bestehender Matrix-Wächter S1-S5, durchgehend über `get_all_metrics()`/Metrik-IDs parametrisiert — strukturell nicht das richtige Zuhause für eine symbol-basierte Achse (s. Analysis). |
+
+## Existing Patterns
+
+- **Option C bleibt gültig** (Erweiterung eines budgetierten Gates, kein neues Pflicht-Gate) —
+  aber die Matrix-Doku selbst legt für Scheibe 6 fest: „Form-Dimension als eigene Achse, **nicht
+  in die Hauptmatrix gemischt**" (Abschnitt 7b, PO-entschieden). D.h. eine neue, eigenständige
+  Testdatei ist hier die vom Dokument selbst vorgesehene Lösung, kein Abweichen vom Muster.
+- **„Rechnen statt tippen"** (S1-S5-Lehre): Soll-Mengen aus den Produktivmodulen selbst ableiten
+  (`PRIORITY.keys()`, `SMS_MULTI_SYMBOLS_BY_METRIC.values()`, `SMS_SYMBOL_BY_METRIC.values()`),
+  nie eine eigene Symbolliste tippen.
+- **Vorbild-Ratschenmuster** bereits im Repo: `test_sms_token_symbol_register_ratchet.py`
+  (echte Importe statt Regex, Vakuum-Schutz `> 0`, Prüfling aus dem eigenen Worktree #1409) —
+  dieselben Bauprinzipien gelten für den neuen Wächter.
+
+## Dependencies
+
+- **Upstream:** `SMS_MULTI_SYMBOLS_BY_METRIC`/`SMS_SYMBOL_BY_METRIC` (metric_catalog.py) als
+  Soll-Symbolquelle; `PRIORITY`/`POSITIONAL`/`POS_INDEX` (builder.py) als Prüfling;
+  `HAZARD_SMS_SYMBOLS` (hazard_symbols.py) als zweites, unabhängiges Register.
+- **Downstream:** `render.py` (Fusion/Kürzung/Sortierung liest `PRIORITY`/`POS_INDEX`),
+  `_official_alerts()`/`_vigilance()` (Rendering der Warn-Tokens mit fester Kategorie).
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1435_e3b_sms_kuerzel.md` (AC-9) — Spec des bestehenden
+  Ratschen-Tests, Vorbild für Bauprinzipien.
+- `docs/reference/metric_output_matrix.md` Abschnitt 3 (Sonderstrecken-Katalog S1-S6, insb.
+  S6 = `SMS_MULTI_SYMBOLS_BY_METRIC`), Abschnitt 5 Punkt 1 (Form-Dimension-Entscheidung),
+  Abschnitt 6 (Scheibe-6-Text), Abschnitt 7 PO-Entscheidung (b).
+
+## Risks & Considerations
+
+- **Verifizierter, LIVE erreichbarer Fund (kein Verdacht):** `W?` entsteht sowohl bei einem
+  Wind-Datenausfall (`_gap_or()`, `builder.py:333-344`) als auch als dedizierter
+  `UNAVAILABLE_SYMBOL` für „amtliche Warnungen nicht abrufbar" — **bytegleich**, in derselben
+  SMS-Zeile möglich, für den Leser nicht unterscheidbar. Beide Bedingungen sind unabhängig
+  voneinander wahr/falsch. Das ist eine Sicherheits-relevante Ambiguität (könnte verschleiern,
+  dass amtliche Warnungen nicht abrufbar waren), nicht nur kosmetisch — anders als der
+  Em-Dash/Hyphen-Fund aus Scheibe 5. **Muss der Spec als eigener, klar benannter Befund
+  vorgelegt werden — PO-Entscheidung nötig: charakterisieren oder fixen (z. B. distinktes
+  Symbol für `UNAVAILABLE_SYMBOL`)?**
+- **Verifizierter, aber toter Fund:** `TH:`/`HR:` kollidieren strukturell zwischen
+  `HAZARD_SMS_SYMBOLS` (amtliche Warnung) und `VIGI_TH`/`VIGI_HR` (Météo-France-Vigilance,
+  `_vigilance()`) — beide würden bei Level+Stunde identisch als `{symbol}:{level}@{hour}`
+  rendern. Nachgemessen: **kein** produktiver `NormalizedForecast(...)`-Aufruf setzt
+  `provider="meteofrance"` (Default `"open-meteo"`, `dto.py:76`) — `_vigilance()` liefert im
+  Live-Pfad immer `[]`. Analog zu `CorridorEvent`/`OnsetEvent` aus Scheibe 1: benannter,
+  unbewachter toter Pfad, kein Fix nötig, aber zu dokumentieren (Grenzen-Abschnitt).
+- **`W`/`CL` sind format-sicher** (nachgemessen über `Token.render()`): amtliche Warnungen
+  tragen immer ein `:`-Suffix bei Stufe bzw. bleiben bar bei levellosen Hazards (`access_ban`),
+  Forecast-Token tragen immer einen numerischen Wert oder `-`/`?`. Keine echte Textkollision
+  im heutigen Renderpfad — aber die Trennung ist eine **Format-Invariante**, keine
+  **strukturelle Namensraum-Trennung**: ein künftiger Formatwechsel könnte sie stillschweigend
+  aufheben, ohne dass ein Test es bemerkt.
+- **Zwei Referenztabellen nötig, nicht eine:** Ein Wächter, der nur gegen
+  `SMS_MULTI_SYMBOLS_BY_METRIC` prüft, meldet die 22 `SMS_SYMBOL_BY_METRIC`-Symbole und die 6
+  echten Systemzeichen (`DBG`, `AV`, `HR:`, `M:`, `MAX`, `Z:`) fälschlich als unzugeordnet —
+  beide Register + eine benannte Systemzeichen-Ausnahmeliste sind Pflicht.
+- **Testort-Frage vorentschieden, nicht offen:** Die Matrix-Doku selbst (PO-Entscheidung b)
+  sagt „eigene Achse, nicht in die Hauptmatrix" — spricht für eine **neue, eigenständige
+  Testdatei**, nicht für `AC-S6-*` in `test_channel_metric_matrix.py`. Zu bestätigen in der
+  Spec, aber keine offene Designfrage mehr.
+- **Risiko laut Matrix-Dokument: niedrig-mittel. Größe: klein-mittel.** Durch den `W?`-Fund
+  tendenziell am oberen Ende dieser Spanne, nicht am unteren.
+
+## Analysis
+
+### Type
+Feature (neuer, eigenständiger Test-Wächter) mit einem eingebetteten, echten Bug-Kandidaten
+(`W?`-Doppelbedeutung) — die Spec muss für diesen Teil explizit Charakterisierung vs. Fix
+entscheiden, analog zu den PO-Entscheidungen in Scheibe 4/5.
+
+### Bestätigter Kernbefund (eigene Nachrecherche, mit Code-Zeilen verifiziert)
+
+1. **Vollständigkeits-Achse ist unproblematisch:** Alle 9 Multi-Symbole stecken in `PRIORITY`;
+   alle `PRIORITY`-Symbole haben einen `POSITIONAL`-Eintrag (Ausnahme `UNAVAILABLE_SYMBOL`,
+   bewusst — nutzt eine eigene Konstante statt `PRIORITY[...]`). Kein Fix nötig, reine
+   Charakterisierung wie S1/S3.
+2. **`W?`-Kollision ist real und live** — unabhängig voneinander auslösbar, bytegleiches
+   Ergebnis, sicherheitsrelevant (verschleiert ggf. Warnungs-Ausfall). Größter Einzelfund
+   dieser Scheibe.
+3. **`TH:`/`HR:`-Kollision ist real, aber strukturell tot** (kein Aufrufer aktiviert
+   `provider="meteofrance"`) — Charakterisierung als benannte Grenze, kein Fix.
+4. **`W`/`CL` sind heute sicher, aber nur durch eine Format-Invariante, nicht durch
+   Namensraum-Trennung** — ein Wächter sollte das als Regressions-Schutz festhalten (Vorbild
+   AC-S2-8-Mutationsdenken: welche Änderung würde die Trennung stillschweigend aufheben?).
+
+### Affected Files (voraussichtlich)
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `tests/unit/test_sms_symbol_grammar_classes.py` (Name vorläufig) | CREATE | Neue, eigenständige Testdatei — Vollständigkeit (PRIORITY/POSITIONAL/Multi+Single-Tabellen), Kollisionsprüfung gegen HAZARD_SMS_SYMBOLS inkl. Format-Invarianten, W?-Charakterisierung/Fix je nach PO-Entscheidung. |
+| `docs/specs/modules/fix_1703_s6_form_waechter.md` | CREATE | Spec analog S1-S5. |
+| `docs/reference/metric_output_matrix.md` | MODIFY | Scheibe 6 nach Abschluss auf erledigt umtragen (DoD). |
+| `src/output/tokens/builder.py` (`UNAVAILABLE_SYMBOL`) | MÖGLICH, PO-Entscheidung nötig | Nur falls die W?-Kollision gefixt statt charakterisiert wird (z. B. neues, kollisionsfreies Symbol). |
+
+### Scope Assessment
+- Files: 2-4 (neue Testdatei, Spec, Matrix-Dokument-Update, ggf. 1 Zeile Produktivcode bei
+  Fix-Entscheidung zu W?)
+- Estimated LoC: Testcode ~150-250 Zeilen (kleiner als S2/S4/S5 — die Symbolmenge ist klein,
+  ~36-46 Symbole gesamt, keine 25er-Metrik-Vollparametrisierung nötig)
+- Risk Level: MEDIUM — wegen des echten, sicherheitsrelevanten W?-Fundes höher als die
+  Matrix-Doku ursprünglich einschätzte ("niedrig-mittel")
+
+### Technical Approach (Empfehlung)
+
+**Primär Charakterisierung + Vollständigkeitswächter, mit EINER offenen Fix-Frage (W?).**
+Die Vollständigkeits-/Positions-Prüfung (Punkt 1 oben) ist reine Charakterisierung wie
+S1/S3 — kein strukturelles Problem gefunden. Die `TH:`/`HR:`-Kollision wird wie
+`CorridorEvent`/`OnsetEvent` in S1 als benannte, tote Grenze dokumentiert, nicht gefixt.
+
+Die `W?`-Kollision braucht eine PO-Entscheidung, die die Spec vorlegt (nicht selbst
+entscheidet): (a) charakterisieren (Ist-Zustand bewachen, Nebenbefund-Eintrag #1199) oder
+(b) fixen (z. B. `UNAVAILABLE_SYMBOL` auf ein garantiert kollisionsfreies Kürzel ändern —
+das wäre ein winziger, gezielter Produktivcode-Fix außerhalb des sonst reinen
+Charakterisierungs-Musters dieser Epic-Scheiben, aber laut CLAUDE.md-Nebenbefund-Triage
+Kriterium (b) „Sicherheitsrisiko" ein Kandidat für sofortige Behebung statt Sammel-Eintrag).
+
+### Open Questions (für Spec-Freigabe zu klären)
+
+- [ ] **(a) `W?`-Kollision:** Charakterisieren oder fixen? Empfehlung: **fixen** — anders als
+      der kosmetische Em-Dash/Hyphen-Fund aus S5 betrifft dieser Fund die Erkennbarkeit eines
+      Warnungs-Ausfalls, ein Sicherheitsrisiko nach CLAUDE.md-Kriterium (b). Kleinstmöglicher
+      Fix: `UNAVAILABLE_SYMBOL` auf ein Kürzel ändern, das strukturell (nicht nur zufällig)
+      mit keinem Wetter-Symbol kollidieren kann (z. B. ein Zeichen außerhalb des
+      Wetter-Symbol-Alphabets). Zu verifizieren: gibt es Bestandstests, die exakt `"W?"` als
+      String erwarten (Byte-Golden), die ein Symbolwechsel bräche?
+- [ ] **(b) Testort:** Neue eigenständige Testdatei (Empfehlung, siehe Matrix-Doku-Entscheidung
+      b) — zu bestätigen, Namensvorschlag `tests/unit/test_sms_symbol_grammar_classes.py`.
+- [ ] **(c) `TH:`/`HR:`-Vigilance-Kollision:** Nur als Known Limitation dokumentieren (Analog
+      CorridorEvent/OnsetEvent), da strukturell toter Pfad — keine offene Frage, sondern
+      Empfehlung zur Bestätigung.
+
+## Related Non-Scope
+
+- Scheibe 7 (Reihenfolge jenseits E-Mail/Telegram-rich) — andere Fläche, blockiert bis 7a.
+- Scheibe 8 (Compare-Kanal-Tabs Frontend) — kein Bezug zu SMS-Symbolen.
+- Alle Metrik-ID-basierten Achsen (S1-S5) — diese Scheibe iteriert bewusst über Symbole, nicht
+  über Metrik-IDs; kein Duplikat der bestehenden Achsen.

--- a/docs/reference/metric_output_matrix.md
+++ b/docs/reference/metric_output_matrix.md
@@ -473,7 +473,7 @@ bereits gedeckten Zeilen gegen stillen Verlust ihrer Testabdeckung.
 eine selbst gewählte Zusatz-Mutation exakt vom vorgesehenen Test gefangen.
 Details: `docs/specs/modules/fix_1703_s5_compare_zellwerte.md`.
 
-### Scheibe 6 — Form-Wächter über Grammatik-Klassen
+### Scheibe 6 — Form-Wächter über Grammatik-Klassen ✅ ERLEDIGT (2026-08-13)
 
 Eigener Wächter über `PRIORITY`/`POSITIONAL` (`tokens/builder.py:47`, `:78`) und
 `SMS_MULTI_SYMBOLS_BY_METRIC` (`sms_trip.py:180`): jede Grammatik-Klasse hat
@@ -481,6 +481,34 @@ genau eine Prioritätsstufe und eine definierte Position; kein Kürzel kollidier
 mit `HAZARD_SMS_SYMBOLS` (`hazard_symbols.py:15`).
 *Risiko: niedrig–mittel. Größe: klein–mittel. Parallel zu 1–5 machbar*, weil sie
 eine andere Achse als die Metrik-ID benutzt. Deckt Fläche 8 teilweise, S2, S6.
+
+Umgesetzt als 6 ACs (AC-S6-1 bis AC-S6-6) in einer **eigenständigen** neuen
+Testdatei `tests/unit/test_sms_symbol_grammar_classes.py` (nicht als Achse in
+`test_channel_metric_matrix.py` — PO-Vorentscheidung §7b: „Form-Dimension als
+eigene Achse, nicht in die Hauptmatrix gemischt", weil `SMS_MULTI_SYMBOLS_BY_METRIC`
+1:n ist). AC-S6-1/2 sichern die bidirektionale Vollständigkeit
+`PRIORITY`↔`POSITIONAL` (36 bzw. 38 Einträge, `TH:`-Doppeleintrag bewusst über
+`_POSITION_SORTABLE_CATEGORIES` abgesichert); AC-S6-3/4 sichern die
+Katalog-Vollständigkeit (30 eindeutige Symbole aus beiden Katalog-Registern +
+6 benannte Systemzeichen = alle 36 `PRIORITY`-Schlüssel erklärt); AC-S6-5 hält
+die Format-Invariante fest, dass der `!`-Block-Marker der einzige verlässliche
+Diskriminator gegenüber `HAZARD_SMS_SYMBOLS` ist.
+
+**Mitrepariert — echter, sicherheitsrelevanter Fund (AC-S6-6, einziger
+Produktivcode-Fix dieser Scheibe):** Ein Wind-Datenausfall und der dedizierte
+„amtliche Warnungen nicht abrufbar"-Marker renderten **bytegleich** `"W?"` —
+unabhängig voneinander auslösbar, für den Leser nicht unterscheidbar (konnte
+verschleiern, dass amtliche Warnungen ausgefallen waren). `UNAVAILABLE_SYMBOL`
+(`tokens/builder.py`) auf `"X?"` geändert (`X` ist im gesamten
+Wetter-Kürzel-Alphabet unbenutzt und dafür reserviert); zwei Bestandstests
+(`test_sms_trip_unavailable_marker.py`, `test_sms_user_metric_order.py`)
+mechanisch mitgezogen, `docs/reference/sms_format.md` §3.4d aktualisiert.
+Adversary VERIFIED, alle 5 Pflicht-Mutationen exakt vom vorgesehenen Test
+gefangen. **Bekannte, bewusst unbehobene Grenze:** eine strukturell ähnliche,
+aber toter-Pfad-Kollision zwischen `TH:`/`HR:` (Hazard) und der
+Météo-France-Vigilance (`_vigilance()`, nie erreicht: kein Aufrufer setzt
+`provider="meteofrance"`) bleibt dokumentiert, nicht gefixt. Details:
+`docs/specs/modules/fix_1703_s6_form_waechter.md`.
 
 ### Scheibe 7 — Reihenfolge-Wächter jenseits E-Mail und Telegram-rich
 

--- a/docs/reference/sms_format.md
+++ b/docs/reference/sms_format.md
@@ -42,7 +42,7 @@ Diese Spec ersetzt v1.0 und integriert das Format aus dem Vorgänger-Projekt (`w
 ## 2. Token-Reihenfolge (fix)
 
 ```
-{Name}: N K D FN FK FD R PR W G TH: TH+: HU DP WD CP PT CT CL CM CH VS SU UV HP NL C HR:TH: !{Warn-Block} Z: M: [SD NS24+ SL AV WC] W? DBG
+{Name}: N K D FN FK FD R PR W G TH: TH+: HU DP WD CP PT CT CL CM CH VS SU UV HP NL C HR:TH: !{Warn-Block} Z: M: [SD NS24+ SL AV WC] X? DBG
 ```
 
 | Block | Tokens | Pflicht? |
@@ -61,7 +61,7 @@ Diese Spec ersetzt v1.0 und integriert das Format aus dem Vorgänger-Projekt (`w
 | Amtliche Warnungen | `!{Kürzel}:{Stufe}[@{h}]` … (Warn-Block, Marker `!` genau einmal) | nur bei aktiver amtlicher Warnung ab der wirksamen Kanal-Schwelle — Ortsvergleich weiterhin fest ab ORANGE, Trips seit Issue #1461 S3b-2a je Kanal einstellbar, Startwert bereits ab GELB (§3.4c) |
 | Fire-Zonen | `Z: M:` | nur Korsika, weglassen wenn leer |
 | Wintersport | `SD NS24+ SL AV WC` | optional (Kürzel seit #1435 E3b aus dem Wetter-Register, vorher `SN SN24+ SFL`) |
-| Nicht abrufbar | `W?` | nur wenn ≥1 abdeckende amtliche Warn-Quelle beim Fetch ausgefallen ist (§3.4d, Issue #1349) |
+| Nicht abrufbar | `X?` | nur wenn ≥1 abdeckende amtliche Warn-Quelle beim Fetch ausgefallen ist (§3.4d, Issue #1349; Kürzel seit Epic #1703 Scheibe 6 `X?`, vormals `W?` — Kollision mit dem Wind-Datenausfall-Marker) |
 | Debug | `DBG[...]` | nur Dry-Run / Debug-Modus |
 
 **Hinweis zu `HR:TH:`** — Das sind zwei separate Tokens, die ohne Leerzeichen aneinandergeschrieben werden (z.B. `HR:M@17TH:H@17` oder `HR:-TH:-`). Siehe §3.3 und §3.4.
@@ -78,7 +78,7 @@ Diese Spec ersetzt v1.0 und integriert das Format aus dem Vorgänger-Projekt (`w
 
 > **Fix #1483 (2026-08-05):** Bis hierhin gab es die `?`-Form nur für die Schwellwert-Kürzel `R`/`PR`/`W`/`G`/`TH:`/`TH+:`. Die Temperatur-Kürzel `N`/`K`/`D`/`FN`/`FK`/`FD` durchliefen stattdessen `render_temperature()`, das ausschliesslich Zahl oder `-` lieferte — eine Datenlücke erschien dort folglich als `K-` und war von „geprüft, kein Wert” nicht unterscheidbar. Jetzt nutzen beide Pfade denselben gemeinsamen Helfer `_gap_or()` (`builder.py:120-130`): `_mk_metric()` (Zeile 150, Schwellwert-Kürzel) UND die Temperatur-Schleife in `build_token_line()` (Zeile 299). `_wintersport()` (Schneehöhe/Neuschnee/Schneefallgrenze/Lawinenstufe/Windchill) bleibt bewusst unverändert und zeigt weiterhin nie `?` — es ruft `render_int()` über einen eigenen Pfad auf, der mit `_gap_or()` nichts zu tun hat. Details: `docs/specs/modules/fix_1483_temp_gap_marker.md`.
 
-> **Fix #1677 (2026-08-10, v2.23):** Die in §2 gezeigte Token-Reihenfolge ist ab jetzt der **Default** — sie gilt unverändert, solange für den Kanal `sms` keine kanal-eigene Kaskadenebene aktiv ist (weder `per_report_layouts[report_type].sms` noch `per_channel_layouts.sms`, geprüft über `UnifiedWeatherDisplayConfig.cascade_source_for_channel("sms", report_type)`). Ist eine dieser beiden Ebenen gesetzt, bestimmt die dort im SMS-Kanal-Tab des Trip-Editors per Drag&Drop gezogene Reihenfolge die Anzeigefolge der **Vorhersage-** (`R PR W G TH: TH+: HU DP WD CP PT CT CL CM CH VS SU UV HP NL K D FK FD N FN`) und **Wintersport-Token** (`SD NS24+ SL AV WC`) — jede Metrik ist dabei EIN Anker: bei Mehrfach-Symbol-Metriken (`temperature`→`K D`, `temperature_night`→`N`, `wind_chill`→`FK FD WC`, `wind_chill_night`→`FN`, `thunder`→`TH: TH+:`) erben alle zugehörigen Symbole dieselbe Nutzer-Position, ihre interne Reihenfolge (z.B. `K` vor `D`) bleibt fix. **Unverändert fix, unabhängig von jeder Nutzer-Reihenfolge:** die Vigilance-Adjazenz `HR:TH:` (§3.3, ohne Leerzeichen), der amtliche Warn-Block, Fire (`Z: M:`), `W?` und `DBG` — diese System-Blöcke stehen immer hinter dem sortierbaren Block, in ihrer bisherigen relativen Reihenfolge (sie sind nicht Teil der wählbaren Metrik-Kaskade). Die Kürzung bei Überlänge (§6) bleibt unverändert prioritätsbasiert — die Anzeige-Position beeinflusst NICHT, welches Token zuerst fällt. Details: `docs/specs/modules/fix_1677_sms_reihenfolge.md`.
+> **Fix #1677 (2026-08-10, v2.23):** Die in §2 gezeigte Token-Reihenfolge ist ab jetzt der **Default** — sie gilt unverändert, solange für den Kanal `sms` keine kanal-eigene Kaskadenebene aktiv ist (weder `per_report_layouts[report_type].sms` noch `per_channel_layouts.sms`, geprüft über `UnifiedWeatherDisplayConfig.cascade_source_for_channel("sms", report_type)`). Ist eine dieser beiden Ebenen gesetzt, bestimmt die dort im SMS-Kanal-Tab des Trip-Editors per Drag&Drop gezogene Reihenfolge die Anzeigefolge der **Vorhersage-** (`R PR W G TH: TH+: HU DP WD CP PT CT CL CM CH VS SU UV HP NL K D FK FD N FN`) und **Wintersport-Token** (`SD NS24+ SL AV WC`) — jede Metrik ist dabei EIN Anker: bei Mehrfach-Symbol-Metriken (`temperature`→`K D`, `temperature_night`→`N`, `wind_chill`→`FK FD WC`, `wind_chill_night`→`FN`, `thunder`→`TH: TH+:`) erben alle zugehörigen Symbole dieselbe Nutzer-Position, ihre interne Reihenfolge (z.B. `K` vor `D`) bleibt fix. **Unverändert fix, unabhängig von jeder Nutzer-Reihenfolge:** die Vigilance-Adjazenz `HR:TH:` (§3.3, ohne Leerzeichen), der amtliche Warn-Block, Fire (`Z: M:`), `X?` und `DBG` — diese System-Blöcke stehen immer hinter dem sortierbaren Block, in ihrer bisherigen relativen Reihenfolge (sie sind nicht Teil der wählbaren Metrik-Kaskade). Die Kürzung bei Überlänge (§6) bleibt unverändert prioritätsbasiert — die Anzeige-Position beeinflusst NICHT, welches Token zuerst fällt. Details: `docs/specs/modules/fix_1677_sms_reihenfolge.md`.
 
 ---
 
@@ -259,18 +259,20 @@ Beides ist sicherheitsrelevant, nicht kosmetisch: eine amtliche Warnung, die sti
 Nur Vorhersage:   GR20 E5: N9 D24 R0.2@6 W10@11 TH:M@16
 Mit Warnung:      GR20 E5: N9 D24 R0.2@6 W10@11 TH:M@16 !TH:H@14 W:M
 Brand + Sperrung: GR20 E5: N9 D28 R- W12@11 TH:- !FR:H CL
-Nicht abrufbar:   GR20 E5: N9 D24 R0.2@6 W10@11 TH:M@16 W?
+Nicht abrufbar:   GR20 E5: N9 D24 R0.2@6 W10@11 TH:M@16 X?
 ```
 
-### 3.4d Nicht-abrufbar-Marker `W?` (Issue #1349, Folge von #1348)
+### 3.4d Nicht-abrufbar-Marker `X?` (Issue #1349, Folge von #1348; Kürzel seit Epic #1703 Scheibe 6)
 
-Ein **eigenständiger** Marker `W?` (2 Zeichen, GSM-7-sicher) signalisiert: für mindestens ein Segment ist **mindestens eine abdeckende amtliche Warn-Quelle beim Fetch ausgefallen** — „keine Warnung" bedeutet dann **nicht** sicher „alles ruhig". Semantisch das Kurzform-Pendant zum E-Mail-/Telegram-Hinweis „amtliche Warnungen aktuell nicht abrufbar".
+Ein **eigenständiger** Marker `X?` (2 Zeichen, GSM-7-sicher) signalisiert: für mindestens ein Segment ist **mindestens eine abdeckende amtliche Warn-Quelle beim Fetch ausgefallen** — „keine Warnung" bedeutet dann **nicht** sicher „alles ruhig". Semantisch das Kurzform-Pendant zum E-Mail-/Telegram-Hinweis „amtliche Warnungen aktuell nicht abrufbar".
+
+**Kürzel-Historie:** Ursprünglich `W?` — kollidierte bytegleich mit dem Wind-Datenausfall-Marker (Wind-Symbol `W` + Gap-Wert `?`, `_gap_or()`), der unabhängig von einem Warn-Ausfall auftreten kann. Epic #1703 Scheibe 6 (AC-S6-6) hat das auf `X?` geändert — `X` ist im gesamten Wetter-Kürzel-Alphabet unbenutzt und dafür reserviert.
 
 - **Bedingung:** `any(SegmentWeatherData.official_alerts_unavailable)` — gesetzt am echten Fail-soft-Pfad (`get_official_alerts_with_status`, #1348). Strenge Regel: **eine** ausgefallene abdeckende Quelle genügt.
-- **Kein Warn-Block-Token:** `W?` gehört zur eigenen Kategorie `unavailable`, trägt **nie** den `!`-Marker (§3.4c) und darf nicht als amtliche Warnung („`!W?`") gelesen werden. Es ist „nicht abrufbar", nicht „es liegt eine Warnung vor".
+- **Kein Warn-Block-Token:** `X?` gehört zur eigenen Kategorie `unavailable`, trägt **nie** den `!`-Marker (§3.4c) und darf nicht als amtliche Warnung („`!X?`") gelesen werden. Es ist „nicht abrufbar", nicht „es liegt eine Warnung vor".
 - **Position:** am Ende der Zeile (nach Wintersport-Block, vor `DBG`), analog zum Verlässlichkeits-Symbol `C`.
 - **Truncation:** höchste Priorität (12, §6, noch über dem Warn-Block) und **nicht** in der Drop-Liste — der sicherheitsrelevante Marker fällt unter 160-Zeichen-Druck **strukturell nie** weg.
-- **Kanäle:** In Telegram-Kurzform (die `sms_text` sendet) erscheint `W?` automatisch mit; das Telegram-„rich"-Briefing und die Compare-/Trip-Mail zeigen stattdessen die ausgeschriebene Hinweiszeile bzw. den Banner.
+- **Kanäle:** In Telegram-Kurzform (die `sms_text` sendet) erscheint `X?` automatisch mit; das Telegram-„rich"-Briefing und die Compare-/Trip-Mail zeigen stattdessen die ausgeschriebene Hinweiszeile bzw. den Banner.
 
 Quelle des Flags: `src/output/tokens/dto.py` (`NormalizedForecast.official_alerts_unavailable`), Emission in `src/output/tokens/builder.py`. Vertraglich abgesichert durch `docs/specs/modules/feat_1349_sms_unavailable.md`.
 

--- a/docs/specs/modules/fix_1703_s6_form_waechter.md
+++ b/docs/specs/modules/fix_1703_s6_form_waechter.md
@@ -1,0 +1,516 @@
+---
+entity_id: fix_1703_s6_form_waechter
+type: module
+created: 2026-08-12
+updated: 2026-08-12
+status: draft
+version: "1.0"
+tags: [sms, tokens, grammar-classes, matrix-test, epic-1703, safety-fix]
+---
+
+<!-- Epic #1703 (Folgearbeit aus #1514), Scheibe 6. Deckt Sonderstrecken S2+S6
+     und teilweise Flaeche 8 aus docs/reference/metric_output_matrix.md §3/§4/§6
+     (Form-Waechter ueber SMS-Symbol-Grammatik-Klassen). Anders als Scheibe 1-5
+     iteriert diese Achse ueber SYMBOLE, nicht ueber Metrik-IDs. Enthaelt EINEN
+     gezielten, sicherheitsrelevanten Produktivcode-Fix (UNAVAILABLE_SYMBOL),
+     alles Uebrige ist reine Charakterisierung. -->
+
+# Form-Wächter über Grammatik-Klassen (#1703 Scheibe 6)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Die SMS-Symbol-Register (`PRIORITY`/`POSITIONAL` in `tokens/builder.py`,
+`SMS_MULTI_SYMBOLS_BY_METRIC`/`SMS_SYMBOL_BY_METRIC` in `metric_catalog.py`,
+`HAZARD_SMS_SYMBOLS` in `tokens/hazard_symbols.py`) sind heute nur teilweise
+gegeneinander geprüft: der bestehende Ratschen-Test
+(`tests/unit/test_sms_token_symbol_register_ratchet.py`) deckt ausschließlich
+den Wintersport-Block + `SMS_SYMBOL_BY_METRIC` gegen `get_sms_code()` — er
+importiert `HAZARD_SMS_SYMBOLS` an keiner Stelle, prüft `PRIORITY`/`POSITIONAL`
+nicht als Ganzes und kennt `SMS_MULTI_SYMBOLS_BY_METRIC` nicht. Diese Scheibe
+schließt diese Lücke mit einer neuen, eigenständigen Testdatei
+(`tests/unit/test_sms_symbol_grammar_classes.py`) — PO-vorentschieden in
+`metric_output_matrix.md` §7b: „Form-Dimension als eigene Achse, **nicht** in
+die Hauptmatrix gemischt", weil `SMS_MULTI_SYMBOLS_BY_METRIC` (Sonderstrecke S6)
+eine Metrik auf mehrere Kürzel abbildet (1:n) und die Hauptmatrix („1 Zeile = 1
+Metrik") das strukturell nicht ausdrücken kann.
+
+**Diese Scheibe ist überwiegend Charakterisierung — mit EINER benannten
+Ausnahme.** Die Vollständigkeits-/Positions-/Kollisionsprüfung (AC-S6-1 bis
+AC-S6-5) hält den gemessenen Ist-Zustand fest, ohne ihn zu verändern — analog
+zu Scheibe 1/4/5. AC-S6-6 ist die Ausnahme: ein verifizierter, **live
+erreichbarer** Fund — ein Wind-Datenausfall kann bytegleich mit dem
+dedizierten „amtliche Warnungen nicht abrufbar"-Marker kollidieren — wird
+**behoben**, nicht nur dokumentiert, weil er laut CLAUDE.md-Nebenbefund-Triage
+Kriterium (b) ein Sicherheitsrisiko ist (kann verschleiern, dass amtliche
+Warnungen ausgefallen sind), nicht bloß kosmetisch wie der Em-Dash/Hyphen-Fund
+aus Scheibe 5. Der Fix selbst ist ein winziger, gezielter
+Ein-Zeilen-Produktivcode-Edit außerhalb des sonst reinen
+Charakterisierungs-Musters dieser Epic-Scheiben — bewusste Ausnahme, keine
+Abweichung vom Muster.
+
+### Korrektur gegenüber dem Context-Dokument: `POSITIONAL` hat 38 Einträge, nicht 37
+
+`docs/context/fix-1703-s6-form-waechter.md` beziffert `POSITIONAL` mit „37
+`(symbol, category)`-Paare". Nachgezählt (Zeilen 78–99, jede Tupel-Zeile
+einzeln erfasst inkl. der über Konstanten referenzierten Einträge
+`FORECAST_TH`/`FORECAST_THP`/`VIGI_HR`/`VIGI_TH`/`UNAVAILABLE_SYMBOL`): **38**
+Tupel. Die Rechnung, die das erklärt: `PRIORITY` hat 36 Schlüssel (nachgezählt,
+Zeilen 47–65); jedes davon hat mindestens einen `POSITIONAL`-Eintrag, plus
+`UNAVAILABLE_SYMBOL` (`"W?"`, category `unavailable`) — das trägt **keinen**
+`PRIORITY`-Schlüssel (eigene Konstante `UNAVAILABLE_PRIORITY`, s. Purpose oben)
+— macht 37 Symbole, die insgesamt eine Priorität/Position brauchen. `POSITIONAL`
+hat aber 38 Tupel, weil `TH:` (Symbol) **zweimal** vorkommt: einmal Kategorie
+`forecast` (`FORECAST_TH`), einmal Kategorie `vigilance` (`VIGI_TH`) — beide
+Tupel sind wegen der unterschiedlichen Kategorie als `POS_INDEX`-Schlüssel
+eindeutig, teilen sich aber denselben `PRIORITY`-Eintrag (`PRIORITY` ist nur
+über den Symbol-String indiziert, nicht über `(Symbol, Kategorie)`). Rechnung:
+37 „braucht Priorität/Position"-Symbole + 1 Doppeleintrag für `TH:` = 38
+`POSITIONAL`-Tupel. Diese Korrektur ändert nichts an den Empfehlungen des
+Context-Dokuments, nur an der Zählung — Lehre aus Scheibe 2/5 F001: falsche
+Prämissen in Zahlen sind der teuerste Fehlertyp, deshalb hier vor dem Schreiben
+der ACs am Code nachgezählt statt aus dem Context-Dokument übernommen.
+
+## Source
+
+> **Schicht-Hinweis:** ausschließlich Python-Core (`src/output/tokens/`,
+> `src/app/metric_catalog.py`), ausschließlich Testcode plus ein
+> Ein-Zeilen-Produktivcode-Fix. Kein Frontend, keine Go-Beteiligung.
+
+- **File (Prüfling 1 — Priorität/Position):** `src/output/tokens/builder.py` —
+  `PRIORITY` (:47–65, 36 Schlüssel), `POSITIONAL`/`POS_INDEX` (:78–100, 38
+  Tupel), `_POSITION_SORTABLE_CATEGORIES` (:110), `UNAVAILABLE_SYMBOL`/
+  `UNAVAILABLE_PRIORITY` (:74–75, **Fix-Ziel**), `_unavailable()` (:225–231),
+  `_gap_or()` (:139–149), Wind-Token-Konstruktion (:346–361, ruft `_mk_metric()`
+  → `_gap_or()`)
+- **File (Prüfling 2 — Katalog-Register):** `src/app/metric_catalog.py` —
+  `SMS_SYMBOL_BY_METRIC` (:665–668, 22 Symbole, aus `_SMS_SYMBOL_METRIC_IDS`
+  :637–650), `SMS_MULTI_SYMBOLS_BY_METRIC` (:700–706, 5 Metrik-IDs → 9
+  eindeutige Symbole)
+- **File (Prüfling 3 — Hazard-Register):** `src/output/tokens/hazard_symbols.py`
+  — `HAZARD_SMS_SYMBOLS` (:15–26, 10 Einträge), `LEVELLESS_HAZARDS` (:70,
+  `frozenset({"access_ban"})`)
+- **File (Renderpfad, nur zur Verifikation der Diskriminanz):**
+  `src/output/tokens/dto.py::Token.render()` (:130–135), `src/output/tokens/
+  render.py` (`!`-Warnblock-Fusion, Prüfling nur zur Charakterisierung, KEIN
+  Edit)
+- **File (Wächter, CREATE):** `tests/unit/test_sms_symbol_grammar_classes.py`
+- **Files (Migration, kleine Byte-String-Anpassung wegen AC-S6-6):**
+  `tests/tdd/test_sms_trip_unavailable_marker.py` (`_MARKER = "W?"`, Zeile 25
+  — einziger Änderungspunkt),
+  `tests/tdd/test_sms_user_metric_order.py` (`_exact_token_index(sms, "W?")`,
+  Zeile 364, Testfunktion
+  `test_ac7_wintersport_metric_can_precede_forecast_metric_but_stays_before_system_blocks`)
+- **File (Doku, Definition of Done, nicht LoC-relevant):**
+  `docs/reference/sms_format.md` (§3.4d, Zeilen 45/64/262/265/267/270/273 —
+  wire-format-Legende und Marker-Beschreibung), `docs/reference/
+  metric_output_matrix.md` (§3/§4/§6, Scheibe-6-Zeile auf erledigt umtragen)
+
+**Ausdrücklich UNVERÄNDERT (reine Prüfziele, kein Edit):** `PRIORITY`,
+`POSITIONAL`, `POS_INDEX`, `_POSITION_SORTABLE_CATEGORIES`, `UNAVAILABLE_PRIORITY`,
+`_unavailable()`, `_gap_or()`, `SMS_SYMBOL_BY_METRIC`, `SMS_MULTI_SYMBOLS_BY_METRIC`,
+`HAZARD_SMS_SYMBOLS`, `LEVELLESS_HAZARDS`, `Token.render()`, der gesamte
+`!`-Warnblock-Fusionsmechanismus in `render.py`. Einziger Produktivcode-Edit:
+der Literalwert von `UNAVAILABLE_SYMBOL` (`builder.py:74`, s. AC-S6-6).
+
+## Estimated Scope
+
+- **LoC:** ~180-230 Testcode (neue Datei, 6 ACs) + **1 Zeile**
+  Produktivcode-Delta (`builder.py:74`, plus erweiterter Code-Kommentar
+  darüber, ~+6 Zeilen Kommentar) + je ~2 Zeilen Migrations-Anpassung in den
+  zwei Bestandstestdateien (Byte-String-Umstellung, kein Verhaltenswechsel
+  dieser Tests). `docs/`-Aktualisierungen zählen nicht ins Limit.
+- **Files:** 6 (neue Testdatei CREATE, Spec CREATE, `builder.py` MODIFY klein,
+  2 Bestandstestdateien MODIFY klein, `docs/reference/sms_format.md` +
+  `docs/reference/metric_output_matrix.md` MODIFY als DoD-Schritt).
+- **Effort:** medium — kleiner als Scheibe 4/5 (die Symbolmenge ist klein,
+  keine 26er-Metrik-Vollparametrisierung nötig), aber mit einem echten,
+  sicherheitsrelevanten Fix statt reiner Charakterisierung tendenziell am
+  oberen Ende der ursprünglich vom Matrix-Dokument geschätzten Spanne
+  „niedrig-mittel/klein-mittel".
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `src/output/tokens/builder.py::PRIORITY`/`POSITIONAL`/`POS_INDEX` | Prüfling | Kürzungs-Priorität + Sortier-Position aller Grammatik-Klassen |
+| `src/output/tokens/builder.py::UNAVAILABLE_SYMBOL` | Prüfling + Fix-Ziel | einziger Produktivcode-Edit dieser Scheibe |
+| `src/app/metric_catalog.py::SMS_SYMBOL_BY_METRIC`/`SMS_MULTI_SYMBOLS_BY_METRIC` | Soll-Quelle | „rechnen statt tippen" — Katalog-Union als Soll-Menge |
+| `src/output/tokens/hazard_symbols.py::HAZARD_SMS_SYMBOLS`/`LEVELLESS_HAZARDS` | zweites, unabhängiges Register | Kollisionsprüfung |
+| `tests/unit/test_sms_token_symbol_register_ratchet.py` | Vorbild (Bauprinzipien) | echte Importe statt Regex, Vakuum-Schutz, keine handgepflegte Symbolliste |
+| `tests/tdd/test_sms_trip_unavailable_marker.py`, `tests/tdd/test_sms_user_metric_order.py` | Migration (AC-S6-6) | referenzieren den Byte-String `"W?"` für den `UNAVAILABLE_SYMBOL`-Zweck, müssen mitgezogen werden |
+| `docs/reference/metric_output_matrix.md` §3 (S2, S6), §7b | Auftragsquelle | PO-Vorentscheidung „eigene Achse", Sonderstrecken-Definition |
+| Issue #1199 | Ziel für Nebenbefund | residuales Restrisiko der Fix-Wahl (s. Known Limitations 6), kein eigenes Issue |
+
+## Implementation Details
+
+### Die Soll-Menge (gemessen, nicht getippt)
+
+```python
+# Katalog-Union: alle Symbole, die eine waehlbare Metrik im SMS-Kanal traegt.
+katalog_union = (
+    set(SMS_SYMBOL_BY_METRIC.values())
+    | {sym for tpl in SMS_MULTI_SYMBOLS_BY_METRIC.values() for sym in tpl}
+)
+# -> 22 (Single) + 9 (Multi) - 1 Ueberschneidung ("TH:", gehoert zu BEIDEN
+#    Registern -- "thunder" ist by design in _SMS_SYMBOL_METRIC_IDS UND in
+#    SMS_MULTI_SYMBOLS_BY_METRIC; api/routers/config.py:49-54 dokumentiert
+#    dieselbe Dopplung mit einer Vorrang-Regel, Fix #1613) = 30 eindeutige
+#    Katalog-Symbole.
+
+system_symbols = {"DBG", "AV", "HR:", "M:", "MAX", "Z:"}
+# -> 6 Symbole ohne Katalog-Metrik (Debug/Lawine/Vigilance/Fire).
+
+assert katalog_union | system_symbols == set(PRIORITY.keys())  # 30 + 6 = 36
+```
+
+Dieses Gleichungspaar (30 Katalog + 6 System = 36 `PRIORITY`-Schlüssel, exakt)
+ist der Kern von AC-S6-3/AC-S6-4 — es macht sowohl eine „Waise" (Katalogsymbol
+ohne `PRIORITY`-Eintrag) als auch ein „unerklärtes Symbol" (`PRIORITY`-Eintrag,
+der weder aus dem Katalog noch aus der benannten Systemliste stammt) sofort
+sichtbar, ohne dass der Test eine eigene Symbolliste pflegt.
+
+### Die HAZARD-Kollision — Diskriminanz ist der `!`-Präfix, nicht der Namensraum
+
+`HAZARD_SMS_SYMBOLS.values()` = `{TH, FL, HR, W, SN, IC, HT, CD, FR, CL}` (roh,
+ohne Doppelpunkt). Textuelle Überschneidung mit `PRIORITY`/`POSITIONAL`:
+
+| Hazard-Kürzel | Kollidierendes Weather-Symbol | Live erreichbar? | Warum keine Verwechslung |
+|---|---|---|---|
+| `W` | `W` (Wind-Vorhersage) | ja | jeder Vorhersage-Token trägt IMMER einen Wert-Suffix (Zahl/`-`/`?`), jede geleveltee Hazard-Warnung trägt IMMER `:{Stufe}` — reines Byte-Präfix-Match ohne Suffix kommt bei `W` auf keiner Seite vor |
+| `CL` | `CL` (Wolken tief, Vorhersage) | ja | `access_ban` ist der EINZIGE levellose Hazard (`LEVELLESS_HAZARDS`) und rendert bar `"CL"` ohne Suffix; kein Vorhersage-Token rendert je ein bares `"CL"` (immer Zahl/`-`/`?`-Suffix) — die Zeichenketten wären nur gleich, wenn beide bar wären |
+| `HR`/`TH` | `HR:`/`TH:` (Vigilance, NICHT der Hazard-Renderpfad selbst) | **nein** — toter Pfad, s. Known Limitations 1 | kein Test nötig |
+
+**Die tragende Zusicherung ist damit nicht „getrennter Namensraum", sondern
+eine Format-Invariante:** der `!`-Block-Marker steht **exakt einmal** vor dem
+ersten `official_alert`-Token (`_official_alerts()`-Docstring, `builder.py:212–214`)
+und wird **keinem** anderen Kategorie-Token vorangestellt. Solange kein
+Nicht-`official_alert`-Token selbst mit `"!"` beginnt, bleibt jede
+Symbol-Kollision (auch eine künftige, heute nicht vorhergesehene) am
+`!`-Präfix unterscheidbar. AC-S6-5 prüft genau das — generisch, nicht nur für
+`W`/`CL` einzeln.
+
+### Der Fix (AC-S6-6) — `UNAVAILABLE_SYMBOL` von `"W?"` auf `"X?"`
+
+**Verifizierte Kollision:** Ein Wind-Datenausfall (`DailyForecast.has_data_gap
+= True`, leere `wind_hourly`-Samples) lässt `render_threshold_peak_value()`
+`"-"` liefern; `_gap_or("-", True)` (`builder.py:139–149`) macht daraus `"?"`;
+`_mk_metric("W", ...)` (aufgerufen aus der Kernschleife `builder.py:346–361`)
+baut `Token(symbol="W", value="?", ...)`; `Token.render()` (`dto.py:130–135`)
+gibt `f"{symbol}{value}"` = **`"W?"`** zurück. **Bytegleich** mit
+`UNAVAILABLE_SYMBOL = "W?"` (`builder.py:74`), das bei
+`fc.official_alerts_unavailable = True` unabhängig von jedem Wind-Datenwert
+erscheint (`_unavailable()`, `builder.py:225–231`). Beide Flags
+(`DailyForecast.has_data_gap`, `NormalizedForecast.official_alerts_unavailable`)
+sind strukturell unabhängige Booleans auf unterschiedlichen DTO-Ebenen — jede
+Kombination ist möglich. Die resultierende SMS-Zeile ist für den Leser NICHT
+unterscheidbar, ob „Wind-Daten fehlten" oder „amtliche Warnungen waren nicht
+abrufbar" gemeint ist — sicherheitsrelevant, weil Letzteres ein aktiver
+Ausfall der Warnungs-Kette ist, den ein Nutzer nicht mit einer bloßen
+Wind-Datenlücke verwechseln darf.
+
+**Gewählter Ersatzwert: `"X?"`.** Begründung:
+
+1. **Länge bleibt bei 2 Zeichen.** `docs/reference/sms_format.md` §3.4d
+   dokumentiert den Marker explizit als „2 Zeichen, GSM-7-sicher" — ein
+   dokumentierter Design-Constraint (SMS-Zeichenbudget, keine
+   Mehrfach-Segment-Kosten durch GSM-7-Sonderzeichen). Ein längeres Kürzel
+   (z. B. `"AW?"`, `"WARN?"`) würde diesen Constraint verletzen und das
+   ohnehin knappe 160-Zeichen-Budget zusätzlich belasten.
+2. **Kollisionsfrei gegen das gesamte heutige Register**, verifiziert gegen
+   `PRIORITY`, `POSITIONAL`, `SMS_SYMBOL_BY_METRIC`,
+   `SMS_MULTI_SYMBOLS_BY_METRIC`, `HAZARD_SMS_SYMBOLS`: kein einziges Symbol
+   in einem dieser fünf Register beginnt mit `"X"` (das gesamte
+   Wetter-Kürzel-Alphabet nutzt `R, PR, W, G, N, K, D, FN, FK, FD, TH, HU, DP,
+   WD, CP, PT, CT, CL, CM, CH, VS, SU, UV, HP, NL, SD, NS, SL, AV, WC, Z, MAX,
+   M, HR, DBG` — kein `X`).
+3. **`"!W?"` wurde geprüft und verworfen:** ein literal ins Symbol
+   eingebettetes `"!"` würde beim Rendern wie ein zweiter,
+   eigenständiger `!`-Block-Marker aussehen (`"...!TH:H@14 !W?..."`) — ein
+   Leser könnte das als **zweite** amtliche Warnung lesen. Das verschärft
+   genau die Ambiguität, die dieser Fix beheben soll, statt sie aufzulösen.
+4. **Restrisiko, benannt statt verschwiegen:** „strukturell kollisionsfrei
+   für alle Zeiten" ist nicht erreichbar, solange Symbol und Wert denselben
+   Zeichenraum teilen — würde künftig eine Katalog-Metrik das Kürzel `"X"`
+   erhalten UND über `_gap_or()` einen Gap-Wert `"?"` rendern können, entstünde
+   dieselbe Kollisionsklasse erneut. Der Vollständigkeits-Wächter dieser
+   Scheibe (AC-S6-1/3/4) würde eine neue Katalog-Metrik `"X"` selbst nicht
+   automatisch als Kollision mit `"X?"` erkennen (verschiedene Dict-Schlüssel:
+   `"X"` vs. `"X?"`) — deshalb trägt der Produktivcode-Kommentar an
+   `UNAVAILABLE_SYMBOL` eine ausdrückliche Reservierungs-Notiz („`X` ist für
+   `UNAVAILABLE_SYMBOL` reserviert, kein Katalog-Kürzel darf `X` werden").
+   Nebenbefund-Eintrag #1199 für den Fall, dass dieses Risiko je eintritt.
+
+**Migrations-Umfang (verifiziert per Grep, kein weiterer Fund):** genau zwei
+Bestandstestdateien referenzieren den Byte-String `"W?"` **für den
+`UNAVAILABLE_SYMBOL`-Zweck** (nicht für den davon unabhängigen
+Wind-Gap-`"W?"`, der unverändert `"W?"` bleibt, weil er vom Wind-Symbol `"W"`
+kommt, nicht von der Konstante):
+
+- `tests/tdd/test_sms_trip_unavailable_marker.py:25` — `_MARKER = "W?"`, EIN
+  Änderungspunkt (Modulkonstante), alle vier Testfunktionen referenzieren nur
+  `_MARKER`.
+- `tests/tdd/test_sms_user_metric_order.py:364` — `_exact_token_index(sms,
+  "W?")` in `test_ac7_wintersport_metric_can_precede_forecast_metric_but_
+  stays_before_system_blocks`; Kommentar in derselben Funktion (:348–349)
+  ebenfalls anzupassen.
+
+Beide Änderungen sind mechanisch (Byte-String-Austausch), ändern kein
+Testverhalten und sind Teil des Fix-Umfangs von AC-S6-6, keine eigene AC.
+
+## Bindende Test-Architektur-Entscheidung (Prüfort = Wirkort)
+
+Alle ACs dieser Scheibe lesen die Register über **echten Import** der
+Produktivmodule (`from output.tokens.builder import PRIORITY, POSITIONAL,
+POS_INDEX, UNAVAILABLE_SYMBOL, _POSITION_SORTABLE_CATEGORIES`, `from
+app.metric_catalog import SMS_SYMBOL_BY_METRIC, SMS_MULTI_SYMBOLS_BY_METRIC`,
+`from output.tokens.hazard_symbols import HAZARD_SMS_SYMBOLS,
+LEVELLESS_HAZARDS`) — **kein Regex über Quelltext**, **keine handgepflegte
+Symbolliste** außer der ausdrücklich benannten und kommentierten
+Systemzeichen-Ausnahmeliste (Vorbild:
+`tests/unit/test_sms_token_symbol_register_ratchet.py`, Modul-Docstring
+„Bauprinzipien"). AC-S6-6 (der Fix) rendert zusätzlich über den ECHTEN
+Token-Pfad (`build_token_line()`) mit realen `NormalizedForecast`/
+`DailyForecast`-Objekten — kein isolierter `Token(...)`-Konstruktoraufruf,
+sonst würde der Test nicht beweisen, dass die Kollision im tatsächlichen
+Renderpfad entsteht (Lehre aus Scheibe 3/4: isolierte Direktaufrufe
+umgehen den echten Choke-Point).
+
+## Expected Behavior
+
+- **Input:** die fünf Produktivregister unverändert (bis auf den
+  Ein-Zeilen-Fix an `UNAVAILABLE_SYMBOL`), zwei gezielt konstruierte
+  `NormalizedForecast`/`DailyForecast`-Fixtures für AC-S6-6 (eine mit
+  Wind-Datenausfall, eine mit `official_alerts_unavailable=True`), keine
+  echten PO-Daten.
+- **Output:** eine neue, grüne Testdatei
+  `tests/unit/test_sms_symbol_grammar_classes.py`, die Vollständigkeit,
+  Kollisionsfreiheit und die Fix-Wirkung der Grammatik-Klassen-Register
+  absichert; ein Ein-Zeilen-Produktivcode-Edit an `builder.py:74`; zwei kleine
+  Migrations-Edits in Bestandstests.
+- **Side effects:** keine über den benannten Fix hinaus. Kein neues
+  Pflicht-Gate (neue, aber budgetierte Testdatei im bereits etablierten
+  `tests/unit/`-Kern, läuft auf jedem Testlauf/Commit-Gate wie jeder andere
+  Kern-Test).
+
+## Acceptance Criteria
+
+- **AC-S6-1 (Vollständigkeit `PRIORITY` ↔ `POSITIONAL`, bidirektional):**
+  Gegeben die Menge aller Symbole, die eine Priorität ODER eine Position
+  brauchen (`PRIORITY.keys()` ∪ `{UNAVAILABLE_SYMBOL}`, gerechnet 37), wenn
+  sie gegen `POSITIONAL` gehalten wird, dann hat JEDES dieser 37 Symbole
+  mindestens einen `POSITIONAL`-Eintrag, UND jedes Symbol, das in
+  `POSITIONAL` auftaucht, ist entweder ein `PRIORITY`-Schlüssel oder
+  `UNAVAILABLE_SYMBOL` — keine Waise in beide Richtungen.
+  - Test: beide Mengen aus den echten Produktivkonstanten gerechnet (kein
+    getipptes Literal außer `UNAVAILABLE_SYMBOL` selbst als Import),
+    Vakuum-Schutz `len(...) >= 30` auf beiden Seiten, damit ein leer
+    gewordenes Register nicht versehentlich „vollständig" erscheint.
+
+- **AC-S6-2 (`TH:`-Doppeleintrag ist bewusst, Sortier-Kategorie schützt
+  davor):** Gegeben `TH:` erscheint zweimal in `POSITIONAL` (Kategorie
+  `forecast` UND `vigilance`), wenn `POS_INDEX` und
+  `_POSITION_SORTABLE_CATEGORIES` gegen diese Struktur geprüft werden, dann
+  sind beide `("TH:", "forecast")`/`("TH:", "vigilance")`-Tupel als
+  eigenständige `POS_INDEX`-Schlüssel vorhanden, und `_POSITION_SORTABLE_
+  CATEGORIES` enthält `"vigilance"` NICHT (nur `{"forecast", "wintersport"}`)
+  — eine `MetricSpec.position`-Sortierung kann den Vigilance-Eintrag
+  strukturell nicht erreichen.
+  - Test: reine Struktur-Assertion auf den Konstanten selbst (kein Rendering,
+    keine Ausführung des toten Vigilance-Pfads — Prüfung der DATEN, nicht des
+    Laufwegs, analog zur Charakterisierung toter Pfade in Scheibe 1).
+
+- **AC-S6-3 (Katalog-Vollständigkeit — 30 eindeutige Katalog-Symbole, alle in
+  `PRIORITY`):** Gegeben die Vereinigung aus `SMS_SYMBOL_BY_METRIC.values()`
+  (22 Symbole) und den geflatteten `SMS_MULTI_SYMBOLS_BY_METRIC.values()` (9
+  eindeutige Symbole, `"TH:"` überlappt mit der Single-Tabelle — by design,
+  s. Implementation Details), wenn diese Vereinigung (30 eindeutige Symbole)
+  gegen `PRIORITY.keys()` gehalten wird, dann ist JEDES Katalog-Symbol ein
+  `PRIORITY`-Schlüssel — kein Katalogsymbol fällt fälschlich als „Waise"
+  durch, weil BEIDE Register (nicht nur eines) als Soll-Quelle dienen.
+  - Test: `katalog_union.issubset(set(PRIORITY.keys()))`, Vakuum-Schutz
+    `len(katalog_union) == 30` als exakte, aus dem Code gerechnete Zahl (nicht
+    getippt: `len(set(SMS_SYMBOL_BY_METRIC.values()) | {s for t in
+    SMS_MULTI_SYMBOLS_BY_METRIC.values() for s in t})`).
+
+- **AC-S6-4 (System-Ausnahmeliste geschlossen — 36 = 30 Katalog + 6 System,
+  keine unerklärten Symbole):** Gegeben die benannte, kommentierte
+  Systemzeichen-Ausnahmeliste (`{"DBG", "AV", "HR:", "M:", "MAX", "Z:"}` — 6
+  Symbole ohne Katalog-Metrik), wenn `PRIORITY.keys()` minus (Katalog-Union
+  ∪ Systemzeichen-Ausnahmeliste) gebildet wird, dann ist die Differenzmenge
+  LEER — jedes `PRIORITY`-Symbol ist entweder katalogrückführbar oder auf der
+  Ausnahmeliste, keine dritte, unerklärte Kategorie.
+  - Test: `set(PRIORITY.keys()) - (katalog_union | system_symbols) == set()`,
+    UMGEKEHRT auch `system_symbols.isdisjoint(katalog_union)` (die
+    Ausnahmeliste darf sich nicht mit dem Katalog überschneiden — sonst wäre
+    sie keine echte Ausnahme).
+
+- **AC-S6-5 (Format-Invariante — `!`-Präfix als einziger Diskriminator
+  gegenüber `HAZARD_SMS_SYMBOLS`):** Gegeben ein vollständig gerenderter
+  Token-Line-Durchlauf über alle Nicht-`official_alert`-Kategorien
+  (`forecast`, `wintersport`, `fire`, `vigilance`-Konstanten als reine
+  Struktur, `unavailable`, `debug`), wenn jedes gerenderte Token-Ergebnis
+  (`Token.render()`) geprüft wird, dann beginnt KEIN einziges mit dem
+  Zeichen `"!"` — der `!`-Block-Marker bleibt exklusiv dem
+  `official_alert`-Fusionsmechanismus vorbehalten und ist damit der einzige
+  verlässliche Diskriminator gegenüber jedem textuell kollidierenden
+  Hazard-Kürzel (konkret verifiziert für `W`/`CL`, s. Implementation
+  Details-Tabelle).
+  - Test: echtes Rendering eines vollen `build_token_line()`-Durchlaufs mit
+    allen wählbaren Metriken aktiviert (kein Wind-/Warn-Ausfall, damit
+    `UNAVAILABLE_SYMBOL` hier nicht mitmischt — das ist AC-S6-6), Assertion
+    `not any(tok.render().startswith("!") for tok in ...)`; zusätzlich
+    gezielte Stichprobe: `access_ban`-Hazard rendert bar `"CL"`, forecast-`CL`
+    (Wolken tief) rendert nie bar (immer mit Zahl/`-`/`?`-Suffix) — beide
+    Renderformen werden bytegenau verglichen und dürfen sich NIE decken.
+
+- **AC-S6-6 (DER FIX — `UNAVAILABLE_SYMBOL`-Kollision mit dem
+  Wind-Gap-Marker behoben, TDD-RED):** Gegeben zwei unabhängige Zustände —
+  (a) ein Wind-Datenausfall (`DailyForecast.has_data_gap=True`, leere
+  `wind_hourly`) OHNE amtlichen Warnungs-Ausfall, (b) ein amtlicher
+  Warnungs-Ausfall (`NormalizedForecast.official_alerts_unavailable=True`)
+  OHNE Wind-Datenausfall — wenn beide Szenarien über den echten
+  `build_token_line()`-Pfad gerendert werden, dann sind die jeweils
+  resultierenden Marker-Token-Strings NIEMALS bytegleich.
+  - **Vorher (heute, ROT):** Szenario (a) rendert `"W?"` (Wind-Symbol + Gap),
+    Szenario (b) rendert `"W?"` (`UNAVAILABLE_SYMBOL`, unverändert) — beide
+    Strings sind identisch, der Test schlägt fehl. Das ist der einzige rote
+    Anteil dieser Scheibe (analog zum Gewitter-Prozentzeichen-Fix in Scheibe
+    1, AC-5).
+  - **Nachher (nach dem Fix, GRÜN):** `UNAVAILABLE_SYMBOL` ist auf `"X?"`
+    geändert (`builder.py:74`, s. Implementation Details für die Begründung
+    der Wahl); Szenario (a) bleibt unverändert `"W?"`, Szenario (b) liefert
+    jetzt `"X?"` — beide Strings sind verschieden, der Test wird grün.
+  - Test: zwei echte `build_token_line()`-Aufrufe (nicht isolierter
+    `Token(...)`-Konstruktor), Assertion auf Ungleichheit der beiden
+    Marker-Strings; zusätzlich Regressions-Assertion, dass Szenario (a)s Wert
+    unverändert `"W?"` bleibt (der Fix darf NICHT den Wind-Token selbst
+    verändern) UND dass Szenario (b)s Marker weiterhin `!`-frei bleibt
+    (Anschluss an AC-S6-3 aus dem ursprünglichen `feat_1349_sms_unavailable.md`
+    AC-3, unverändert).
+
+## Known Limitations
+
+1. **`TH:`/`HR:`-Vigilance-Kollision bleibt strukturell tot, kein Fix, kein
+   Test.** `_vigilance()` (`builder.py:199–208`) liest `fc.provider !=
+   "meteofrance"` und liefert sonst `[]`. Verifiziert: **kein** produktiver
+   `NormalizedForecast(...)`-Konstruktoraufruf im gesamten `src/` setzt
+   `provider="meteofrance"` — `trip_result.py:84` und `sms_trip.py:498` lassen
+   den Default `"open-meteo"` (`dto.py:76`) stehen. Analog zu
+   `CorridorEvent`/`OnsetEvent` aus Scheibe 1: „Ein Wächter über einen toten
+   Pfad bewacht nichts" — die Kollision bleibt dokumentiert (s. Implementation
+   Details-Tabelle), aber unbewacht.
+2. **AC-S6-5 hält eine Format-Invariante fest, keine strukturelle
+   Namensraum-Trennung.** Ein künftiger Formatwechsel — z. B. würde
+   `access_ban` seine `LEVELLESS_HAZARDS`-Eigenschaft verlieren, oder ein
+   Vorhersage-Token würde je einen leeren Wert ohne Suffix rendern — könnte
+   die heutige Sicherheit stillschweigend aufheben. AC-S6-5s generische
+   `!`-Präfix-Prüfung fängt genau diese Klasse von Regression (jede
+   Verletzung des `!`-exklusiv-für-official_alert-Prinzips wird rot), aber
+   NICHT jede denkbare neue Formatverletzung außerhalb dieses Mechanismus.
+3. **`format_modes`/`default_format_mode` (1:1-Katalogfelder) sind NICHT
+   Gegenstand dieser Scheibe.** Laut `metric_output_matrix.md` §5 Punkt 1
+   gehören sie in die Hauptmatrix (S1-S5-Achse), nicht in diesen
+   Symbol-Wächter — nur die 1:n-Grammatik (`SMS_MULTI_SYMBOLS_BY_METRIC`)
+   sprengt die Hauptmatrix und braucht diese eigene Achse.
+4. **Fläche 8 (`metric_output_matrix.md` §4, „Einheiten und Nachkommastellen
+   je Kanal") wird nur „teilweise" gedeckt, wie das Dokument selbst
+   einschränkt** — diese Scheibe prüft Symbol-Register-Konsistenz, nicht
+   Dezimalstellen/Einheiten-Formatierung (das ist bereits separat über
+   AC-S5-4 in Scheibe 5 für den Compare-Pfad behandelt; ein SMS-seitiges
+   Pendant ist NICHT Gegenstand hier).
+5. **Scheibe 1-5 (Metrik-ID-basierte Achsen) sind ausdrücklich NICHT
+   Gegenstand.** Diese Scheibe iteriert bewusst über Symbole/Grammatik-Klassen,
+   nicht über Metrik-IDs — kein Duplikat der bestehenden Achsen in
+   `tests/tdd/test_channel_metric_matrix.py`.
+6. **Scheibe 7 (Reihenfolge jenseits E-Mail/Telegram-rich) und Scheibe 8
+   (Compare-Kanal-Tabs Frontend) sind NICHT Gegenstand.** Scheibe 7 ist laut
+   Matrix-Dokument bis zur PO-Entscheidung 7a blockiert; Scheibe 8 ist ein
+   eigenes, großes Vorhaben (Datenmodell/Persistenz/Editor), keine
+   Test-Scheibe. Diese Scheibe (6) ist laut Abhängigkeitsbild „jederzeit
+   parallel" zu beiden.
+7. **Die Wahl von `"X?"` ist nicht für alle Zeiten garantiert
+   kollisionsfrei** (s. Implementation Details, Punkt 4 der Begründung) —
+   eine künftige Katalog-Metrik mit Kürzel `"X"` und Gap-fähigem Rendering
+   würde dieselbe Kollisionsklasse reproduzieren. Der Code-Kommentar an
+   `UNAVAILABLE_SYMBOL` reserviert `"X"` ausdrücklich; ein automatischer Fang
+   einer künftigen Verletzung dieser Reservierung ist NICHT Teil dieser
+   Scheibe (AC-S6-1/3/4 prüfen Dict-Schlüssel-Gleichheit, nicht
+   Render-Zeit-Kollisionen zwischen unterschiedlich langen Strings) →
+   Nebenbefund-Eintrag #1199, falls es je eintritt.
+8. **Die zwei migrierten Bestandstests (`test_sms_trip_unavailable_marker.py`,
+   `test_sms_user_metric_order.py`) werden NICHT umbenannt oder
+   umstrukturiert** — nur der Byte-String-Literalwert wird angepasst. Eine
+   Konsolidierung dieser Dateien in die neue Testdatei ist NICHT Gegenstand
+   (CLAUDE.md „kein Big-Bang-Reorg des Bestands").
+
+## Prüfhinweis für den Adversary
+
+Leitfrage aus CLAUDE.md: **Ist die Zusicherung dort geprüft, wo sie WIRKT —
+oder nur dort, wo der Code steht?** Konkret: AC-S6-5/AC-S6-6 MÜSSEN gegen den
+ECHTEN `build_token_line()`-Renderpfad laufen, nicht gegen isolierte
+`Token(...)`-Konstruktoraufrufe — sonst beweist der Test nur, dass ein
+konstruiertes Objekt sich so verhält, wie der Test es konstruiert hat.
+
+**Mutations-Gegenproben (Pflicht, per String-Ersetzung mit externer
+Sicherungskopie — nie `git checkout/stash/reset`):**
+
+- Einen Schlüssel aus `PRIORITY` entfernen (z. B. `"CH"` streichen) — MUSS
+  AC-S6-1 rot werden lassen (Waise in `POSITIONAL`, die keine `PRIORITY` mehr
+  hat).
+- Einen zusätzlichen `POSITIONAL`-Eintrag ohne `PRIORITY`-Pendant einfügen
+  (z. B. `("QQ", "forecast")`) — MUSS AC-S6-1 rot werden lassen (unerklärte
+  Position ohne Priorität).
+- Ein Symbol aus `SMS_MULTI_SYMBOLS_BY_METRIC["thunder"]` entfernen (z. B.
+  `"TH+:"` streichen) — MUSS AC-S6-4 rot werden lassen (die 36=30+6-Gleichung
+  kippt: `"TH+:"` bleibt in `PRIORITY`, fällt aber aus der Katalog-Union
+  heraus und landet als unerklärtes Symbol in der Differenzmenge).
+- `UNAVAILABLE_SYMBOL` versehentlich zurück auf `"W?"` setzen (den Fix
+  rückgängig machen) — MUSS **genau AC-S6-6** rot werden lassen. Das ist der
+  wichtigste Fang dieser Scheibe: er beweist, dass der Fix wirklich geprüft
+  wird, nicht nur behauptet.
+- Einen Forecast-Token testweise mit führendem `"!"` rendern lassen (z. B.
+  `_mk_metric()`s `symbol`-Parameter für `"W"` durch `"!W"` ersetzen) — MUSS
+  AC-S6-5 rot werden lassen.
+
+## Definition of Done
+
+- [ ] AC-S6-1 bis AC-S6-6 grün
+- [ ] Adversary-Verdict VERIFIED, alle fünf Pflicht-Mutationen gefangen
+- [ ] `docs/reference/sms_format.md` §3.4d + Legende (Zeilen 45/64/262/265/267/
+      270/273) von `"W?"` auf `"X?"` umgetragen — die Wire-Format-Spec darf dem
+      Code nach dem Fix nicht widersprechen
+- [ ] `docs/reference/metric_output_matrix.md` §3 (Sonderstrecken S2/S6), §4
+      (Fläche 8, „teilweise") und §6 (Scheibe 6) auf erledigt/referenziert
+      umgetragen
+- [ ] Issue #1703 Scheiben-Checkbox gesetzt, Ergebnis kommentiert (inkl. Hinweis
+      auf den Sicherheits-Fix, nicht nur „Wächter ergänzt")
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine.
+- **Rationale:** Neue, eigenständige Testdatei nach expliziter
+  PO-Vorentscheidung (`metric_output_matrix.md` §7b), aber kein neuer
+  Pflicht-Gate-Mechanismus — läuft im bereits etablierten `tests/unit/`-Kern
+  wie jeder andere Kern-Test (Option C im weiteren Sinne: Erweiterung der
+  bereits budgetierten Epic-#1703-Testinitiative, nur als eigene Datei statt
+  als Achse in `test_channel_metric_matrix.py`, weil die 1:n-Struktur die
+  Hauptmatrix sprengen würde). Der `UNAVAILABLE_SYMBOL`-Fix ist keine neue
+  Entscheidungsfläche (kein Kanal-, Provider-, Datenmodell-, Auth- oder
+  Editor-Paradigma-Wechsel) — er korrigiert einen bytegleichen
+  Kollisionsfehler innerhalb eines bereits bestehenden, PO-entschiedenen
+  Markers (#1349).
+
+## Changelog
+
+- 2026-08-12: Initial spec created (Epic #1703, Scheibe 6). Vollständigkeits-
+  und Kollisionswächter über die SMS-Symbol-Grammatik-Klassen spezifiziert
+  (AC-S6-1 bis AC-S6-5, reine Charakterisierung); die verifizierte,
+  sicherheitsrelevante `UNAVAILABLE_SYMBOL`/Wind-Gap-Kollision wird als
+  einzige Ausnahme dieser Scheibe gefixt (AC-S6-6, `"W?"` → `"X?"`),
+  begründet über CLAUDE.md-Nebenbefund-Triage Kriterium (b). Korrektur der
+  `POSITIONAL`-Zählung gegenüber dem Context-Dokument (38 statt 37 Einträge,
+  nachgerechnet). Migrationsumfang für zwei Bestandstestdateien benannt.

--- a/src/output/tokens/builder.py
+++ b/src/output/tokens/builder.py
@@ -71,7 +71,17 @@ OFFICIAL_ALERT_PRIORITY = 11
 # Issue #1349: "amtliche Warnungen nicht abrufbar" — sicherheitsrelevant,
 # darf unter Truncation-Druck nie wegfallen (ausserhalb DROP_ORDER/
 # _last_resort in render.py; Prioritaet hier nur dokumentarisch >= 11).
-UNAVAILABLE_SYMBOL = "W?"
+# Issue #1703 Scheibe 6 (AC-S6-6): war zuvor "W?" -- bytegleiche Kollision
+# mit dem Wind-Datenausfall-Marker (Symbol "W" + Gap-Wert "?" ueber
+# _gap_or(), siehe Token.render()). Auf "X?" geaendert, weil beide Zustaende
+# (Wind-Datenluecke vs. amtliche Warnungen nicht abrufbar) fachlich
+# unabhaengig sind und fuer den Leser unterscheidbar sein muessen.
+# RESERVIERUNG: "X" ist ab jetzt fuer UNAVAILABLE_SYMBOL reserviert -- kein
+# Katalog-Kuerzel darf kuenftig "X" werden, sonst entsteht ueber ein
+# Gap-faehiges Rendering ("X?") dieselbe Kollisionsklasse erneut (Spec
+# docs/specs/modules/fix_1703_s6_form_waechter.md, Implementation Details
+# Punkt 4).
+UNAVAILABLE_SYMBOL = "X?"
 UNAVAILABLE_PRIORITY = OFFICIAL_ALERT_PRIORITY + 1
 
 # (symbol, category) -> §2 POSITIONAL index. Vigilance shares 'TH:' symbol.
@@ -223,9 +233,10 @@ def _official_alerts(fc: NormalizedForecast) -> list[Token]:
 
 
 def _unavailable(fc: NormalizedForecast) -> list[Token]:
-    """Issue #1349: eigenstaendiger 'W?'-Marker in eigener Kategorie
-    ('unavailable', NICHT 'official_alert') — sonst wuerde render.py's
-    '!'-Warnblock-Fusion ihn faelschlich als amtliche Warnung lesen."""
+    """Issue #1349: eigenstaendiger UNAVAILABLE_SYMBOL-Marker (Issue #1703
+    Scheibe 6: 'X?', vormals 'W?') in eigener Kategorie ('unavailable',
+    NICHT 'official_alert') — sonst wuerde render.py's '!'-Warnblock-Fusion
+    ihn faelschlich als amtliche Warnung lesen."""
     if not fc.official_alerts_unavailable:
         return []
     return [Token(UNAVAILABLE_SYMBOL, "", "unavailable", UNAVAILABLE_PRIORITY)]
@@ -471,7 +482,7 @@ def build_token_line(
 
     # Issue #1677: zweistufige Sortierung. Bucket 0 = Token, deren MetricSpec
     # eine Nutzer-Position traegt (nur 'forecast'/'wintersport' -- die
-    # waehlbare Metrik-Kaskade; Vigilance/amtliche Warnungen/Fire/W?/DBG
+    # waehlbare Metrik-Kaskade; Vigilance/amtliche Warnungen/Fire/X?/DBG
     # sind strukturell nicht sortierbar, DEC-4/Known Limitation 2), sortiert
     # nach dieser Position. Bucket 1 = alle uebrigen Token, unveraendert nach
     # der bisherigen POS_INDEX-Reihenfolge. Ohne jede Position (kein

--- a/tests/tdd/test_sms_trip_unavailable_marker.py
+++ b/tests/tdd/test_sms_trip_unavailable_marker.py
@@ -22,7 +22,7 @@ from zoneinfo import ZoneInfo
 
 _TZ = ZoneInfo("Europe/Berlin")
 _LAT, _LON = 43.7102, 7.2620
-_MARKER = "W?"
+_MARKER = "X?"
 
 
 def _make_dp():

--- a/tests/tdd/test_sms_user_metric_order.py
+++ b/tests/tdd/test_sms_user_metric_order.py
@@ -345,7 +345,7 @@ def test_ac6_drop_order_ignores_display_position():
 def test_ac7_wintersport_metric_can_precede_forecast_metric_but_stays_before_system_blocks():
     """Wintersport-Metrik (snow_depth, Nutzer-Position 0) vor
     Vorhersage-Metrik (gust, Position 2) -- beide bleiben trotzdem vor dem
-    nicht-sortierbaren System-Block (hier: 'W?', amtliche-Warnungen-nicht-
+    nicht-sortierbaren System-Block (hier: 'X?', amtliche-Warnungen-nicht-
     abrufbar-Marker)."""
     order = ["snow_depth", "snowfall_limit", "gust"]
     dc = _sms_layout_dc(order)
@@ -361,13 +361,13 @@ def test_ac7_wintersport_metric_can_precede_forecast_metric_but_stays_before_sys
     sms = report.sms_text
     i_sd = _token_index(sms, "SD")
     i_g = _token_index(sms, "G")
-    i_marker = _exact_token_index(sms, "W?")
+    i_marker = _exact_token_index(sms, "X?")
     assert i_sd < i_g, (
         f"SD (Wintersport, Nutzer-Position 0) muss vor G (Vorhersage, "
         f"Position 2) stehen: {sms!r}"
     )
     assert i_g < i_marker, (
-        f"Systemblock 'W?' muss auch bei umsortierten Fachtoken dahinter "
+        f"Systemblock 'X?' muss auch bei umsortierten Fachtoken dahinter "
         f"bleiben: {sms!r}"
     )
 

--- a/tests/unit/test_sms_symbol_grammar_classes.py
+++ b/tests/unit/test_sms_symbol_grammar_classes.py
@@ -1,0 +1,409 @@
+"""Form-Waechter ueber SMS-Symbol-Grammatik-Klassen (#1703 Scheibe 6).
+
+SPEC: docs/specs/modules/fix_1703_s6_form_waechter.md — AC-S6-1 … AC-S6-6.
+
+Diese Datei iteriert — anders als die vorherigen Scheiben 1-5 — ueber
+SYMBOLE/Grammatik-Klassen, nicht ueber Metrik-IDs (PO-Vorentscheidung
+`docs/reference/metric_output_matrix.md` §7b: eigene Achse, weil
+`SMS_MULTI_SYMBOLS_BY_METRIC` eine Metrik auf mehrere Kuerzel abbildet und
+die 1:1-Hauptmatrix das nicht ausdruecken kann).
+
+AC-S6-1 bis AC-S6-5 sind reine Charakterisierung des HEUTIGEN, korrekten
+Zustands. AC-S6-6 ist der einzige TDD-RED-Test dieser Scheibe: er beweist
+eine verifizierte, sicherheitsrelevante Byte-Kollision zwischen dem
+Wind-Datenausfall-Marker ('W?', Symbol 'W' + Gap-Wert '?') und dem
+dedizierten 'amtliche Warnungen nicht abrufbar'-Marker
+(`UNAVAILABLE_SYMBOL`, heute ebenfalls 'W?'). Der Fix
+(`UNAVAILABLE_SYMBOL` -> 'X?') erfolgt NICHT in dieser Testdatei, sondern
+als Ein-Zeilen-Produktivcode-Edit in der Implementierungsphase danach.
+
+Bauprinzipien (Vorbild: tests/unit/test_sms_token_symbol_register_ratchet.py,
+Bindende Test-Architektur-Entscheidung der Spec, "Pruefort = Wirkort"):
+
+  1. **Kein Regex ueber Quelltext, keine handgepflegte Symbolliste** ausser
+     der ausdruecklich benannten und kommentierten Systemzeichen-
+     Ausnahmeliste (`_SYSTEM_SYMBOLS` unten). Alle Mengen werden aus den
+     echten Produktivkonstanten GERECHNET ("rechnen statt tippen").
+  2. **Echter Import der Produktivmodule**, kein isolierter
+     `Token(...)`-Konstruktoraufruf fuer AC-S6-5/AC-S6-6 — beide rendern
+     ueber den ECHTEN `build_token_line()`-Pfad mit realen
+     `NormalizedForecast`/`DailyForecast`-Objekten (Lehre aus Scheibe 3/4:
+     isolierte Direktaufrufe umgehen den echten Choke-Point).
+  3. **Vakuum-Schutz.** Jeder Vollstaendigkeits-Test behauptet seine eigene
+     Mindest-Trefferzahl — ein leer gewordenes Register darf nicht
+     versehentlich "vollstaendig" erscheinen.
+
+Regel-Budget (CLAUDE.md): kein eigenes Pruefdatum — laeuft im bereits
+etablierten tests/unit/-Kern wie jeder andere Kern-Test (s. Spec ADR).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.metric_catalog import SMS_MULTI_SYMBOLS_BY_METRIC, SMS_SYMBOL_BY_METRIC
+from output.tokens import builder as builder_mod
+from output.tokens.builder import (
+    POS_INDEX,
+    POSITIONAL,
+    PRIORITY,
+    UNAVAILABLE_SYMBOL,
+    _POSITION_SORTABLE_CATEGORIES,
+    build_token_line,
+)
+from output.tokens.dto import DailyForecast, HourlyValue, MetricSpec, NormalizedForecast
+from output.tokens.hazard_symbols import HAZARD_SMS_SYMBOLS, LEVELLESS_HAZARDS, sms_symbol_for
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Systemzeichen ohne Katalog-Metrik (Debug/Lawine/Vigilance/Fire) — die
+# EINZIGE handgepflegte Liste dieser Datei, benannt und begruendet
+# (Implementation Details der Spec, Gleichungspaar 30 Katalog + 6 System = 36).
+_SYSTEM_SYMBOLS = {"DBG", "AV", "HR:", "M:", "MAX", "Z:"}
+
+
+def _katalog_union() -> set[str]:
+    """Alle Symbole, die eine waehlbare Metrik im SMS-Kanal traegt — GERECHNET
+    aus den beiden Katalog-Registern, keine getippte Liste."""
+    return set(SMS_SYMBOL_BY_METRIC.values()) | {
+        sym for tpl in SMS_MULTI_SYMBOLS_BY_METRIC.values() for sym in tpl
+    }
+
+
+# ---------------------------------------------------------------------------
+# Selbstpruefung (#1409: Pruefling muss aus diesem Arbeitsbaum stammen)
+# ---------------------------------------------------------------------------
+
+
+def test_ratchet_inspects_the_code_of_this_worktree():
+    module_path = Path(builder_mod.__file__).resolve()
+    assert str(module_path).startswith(str(REPO_ROOT)), (
+        "Dieser Waechter prueft nicht den Code dieses Arbeitsbaums, sondern "
+        f"{module_path} (erwartet unterhalb {REPO_ROOT})."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-S6-1: bidirektionale Vollstaendigkeit PRIORITY <-> POSITIONAL
+# ---------------------------------------------------------------------------
+
+
+def test_ac_s6_1_priority_positional_bidirectional_completeness():
+    """Jedes Symbol, das eine Prioritaet ODER eine Position braucht, hat
+    beides — in beide Richtungen keine Waise."""
+    needs_priority_or_position = set(PRIORITY.keys()) | {UNAVAILABLE_SYMBOL}
+    positional_symbols = {symbol for symbol, _category in POSITIONAL}
+
+    # Vakuum-Schutz: ein leer gewordenes Register darf nicht "vollstaendig" wirken.
+    assert len(needs_priority_or_position) >= 30, (
+        f"Nur {len(needs_priority_or_position)} Symbole brauchen Prioritaet/"
+        "Position — das Register scheint fast leer, der Waechter wuerde "
+        "nichts pruefen."
+    )
+    assert len(positional_symbols) >= 30, (
+        f"POSITIONAL fuehrt nur {len(positional_symbols)} eindeutige Symbole "
+        "— zu wenig, der Waechter wuerde nichts pruefen."
+    )
+
+    missing_in_positional = needs_priority_or_position - positional_symbols
+    assert not missing_in_positional, (
+        f"Symbole {sorted(missing_in_positional)!r} brauchen eine Prioritaet "
+        "(PRIORITY-Schluessel oder UNAVAILABLE_SYMBOL), haben aber KEINEN "
+        "POSITIONAL-Eintrag — eine Kuerzung koennte sie nie einordnen."
+    )
+
+    orphan_positions = positional_symbols - needs_priority_or_position
+    assert not orphan_positions, (
+        f"Symbole {sorted(orphan_positions)!r} stehen in POSITIONAL, sind "
+        "aber weder PRIORITY-Schluessel noch UNAVAILABLE_SYMBOL — eine "
+        "unerklaerte Position ohne Prioritaet."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-S6-2: TH:-Doppeleintrag ist bewusst, Sortier-Kategorie schuetzt davor
+# ---------------------------------------------------------------------------
+
+
+def test_ac_s6_2_th_double_entry_is_deliberate_and_protected():
+    """'TH:' erscheint zweimal in POSITIONAL (forecast + vigilance) — beide
+    Tupel sind eigenstaendige POS_INDEX-Schluessel; 'vigilance' ist NICHT
+    sortierbar."""
+    th_entries = [(symbol, category) for symbol, category in POSITIONAL if symbol == "TH:"]
+    assert set(th_entries) == {("TH:", "forecast"), ("TH:", "vigilance")}, (
+        f"'TH:' sollte GENAU zweimal in POSITIONAL stehen (forecast + "
+        f"vigilance), gefunden: {th_entries!r}"
+    )
+
+    assert ("TH:", "forecast") in POS_INDEX, "POS_INDEX fehlt ('TH:', 'forecast')."
+    assert ("TH:", "vigilance") in POS_INDEX, "POS_INDEX fehlt ('TH:', 'vigilance')."
+    assert POS_INDEX[("TH:", "forecast")] != POS_INDEX[("TH:", "vigilance")], (
+        "Beide 'TH:'-Tupel muessen unterschiedliche POS_INDEX-Positionen "
+        "haben — sonst waeren sie im Dict nicht unterscheidbar."
+    )
+
+    assert "vigilance" not in _POSITION_SORTABLE_CATEGORIES, (
+        "_POSITION_SORTABLE_CATEGORIES darf 'vigilance' NICHT enthalten — "
+        "sonst koennte eine MetricSpec.position-Sortierung den toten "
+        "Vigilance-Pfad erreichen (Adversary-Hinweis Issue #1677)."
+    )
+    assert _POSITION_SORTABLE_CATEGORIES == {"forecast", "wintersport"}, (
+        f"_POSITION_SORTABLE_CATEGORIES ist {_POSITION_SORTABLE_CATEGORIES!r} "
+        "— erwartet genau {'forecast', 'wintersport'}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-S6-3: Katalog-Vollstaendigkeit — 30 eindeutige Katalog-Symbole
+# ---------------------------------------------------------------------------
+
+
+def test_ac_s6_3_catalog_union_is_complete_subset_of_priority():
+    """Die Vereinigung aus SMS_SYMBOL_BY_METRIC und
+    SMS_MULTI_SYMBOLS_BY_METRIC (30 eindeutige Symbole, 'TH:' ueberlappt by
+    design) ist vollstaendig in PRIORITY vertreten."""
+    katalog_union = _katalog_union()
+
+    assert len(katalog_union) == 30, (
+        f"Katalog-Union hat {len(katalog_union)} eindeutige Symbole, "
+        f"erwartet 30 (22 Single + 9 Multi - 1 Ueberschneidung 'TH:'): "
+        f"{sorted(katalog_union)!r}"
+    )
+
+    missing = katalog_union - set(PRIORITY.keys())
+    assert not missing, (
+        f"Katalog-Symbole {sorted(missing)!r} fehlen in PRIORITY — ein "
+        "waehlbares Metrik-Kuerzel faellt beim Kuerzen fälschlich als "
+        "'Waise' durch."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-S6-4: geschlossene Systemzeichen-Ausnahmeliste
+# ---------------------------------------------------------------------------
+
+
+def test_ac_s6_4_system_exception_list_is_closed_and_disjoint():
+    """PRIORITY.keys() minus (Katalog-Union ∪ Systemzeichen-Ausnahmeliste)
+    ist leer — jedes Symbol ist entweder katalogrueckfuehrbar oder auf der
+    benannten Ausnahmeliste, keine dritte, unerklaerte Kategorie."""
+    katalog_union = _katalog_union()
+
+    assert len(_SYSTEM_SYMBOLS) == 6, (
+        f"Die Systemzeichen-Ausnahmeliste hat {len(_SYSTEM_SYMBOLS)} "
+        f"Eintraege, erwartet 6: {sorted(_SYSTEM_SYMBOLS)!r}"
+    )
+
+    unexplained = set(PRIORITY.keys()) - (katalog_union | _SYSTEM_SYMBOLS)
+    assert not unexplained, (
+        f"PRIORITY-Symbole {sorted(unexplained)!r} sind weder ueber den "
+        "Katalog noch ueber die Systemzeichen-Ausnahmeliste erklaerbar — "
+        "eine dritte, unbenannte Kategorie ist entstanden."
+    )
+
+    assert _SYSTEM_SYMBOLS.isdisjoint(katalog_union), (
+        f"Ueberschneidung zwischen Systemzeichen-Ausnahmeliste und "
+        f"Katalog-Union: {sorted(_SYSTEM_SYMBOLS & katalog_union)!r} — "
+        "die Ausnahmeliste waere dann keine echte Ausnahme mehr."
+    )
+
+    assert set(PRIORITY.keys()) == (katalog_union | _SYSTEM_SYMBOLS), (
+        "PRIORITY.keys() sollte exakt der Vereinigung aus Katalog-Union "
+        f"(30) und Systemzeichen-Ausnahmeliste (6) entsprechen: "
+        f"PRIORITY hat {len(PRIORITY)} Schluessel."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-S6-5: Format-Invariante — '!'-Praefix exklusiv fuer official_alert
+# ---------------------------------------------------------------------------
+
+
+def _build_full_coverage_forecast() -> tuple[NormalizedForecast, list[MetricSpec]]:
+    """Ein NormalizedForecast/DailyForecast-Paar mit allen wählbaren
+    Grammatik-Klassen aktiv (forecast/wintersport/fire/debug), OHNE
+    Wind-/Warn-Ausfall (das ist AC-S6-6). Vigilance bleibt strukturell tot
+    (Known Limitation 1 der Spec, provider='open-meteo')."""
+    today = DailyForecast(
+        night_temp_min_c=5.0, temp_min_c=8.0, temp_max_c=18.0,
+        night_wind_chill_min_c=3.0, wind_chill_min_c=6.0, wind_chill_max_c=15.0,
+        rain_hourly=(HourlyValue(6, 0.5),), pop_hourly=(HourlyValue(11, 40.0),),
+        wind_hourly=(HourlyValue(11, 18.0),), gust_hourly=(HourlyValue(11, 25.0),),
+        thunder_hourly=(HourlyValue(16, 2),),
+        humidity_hourly=(HourlyValue(12, 55.0),), dewpoint_hourly=(HourlyValue(12, 8.0),),
+        cape_hourly=(HourlyValue(15, 300.0),), uv_hourly=(HourlyValue(13, 5.0),),
+        cloud_total_hourly=(HourlyValue(12, 60.0),), cloud_low_hourly=(HourlyValue(12, 40.0),),
+        cloud_mid_hourly=(HourlyValue(12, 20.0),), cloud_high_hourly=(HourlyValue(12, 10.0),),
+        visibility_hourly=(HourlyValue(12, 20000.0),),
+        freezing_level_hourly=(HourlyValue(12, 2500.0),),
+        wind_direction_sector="NW", precip_type_dominant="R",
+        sunshine_hours=6.5, pressure_avg_hpa=1013.0,
+        snow_depth_cm=120.0, snow_new_24h_cm=10.0, snowfall_limit_m=1600.0,
+        avalanche_level=2, wind_chill_c=-5.0, has_data_gap=False,
+    )
+    tomorrow = DailyForecast(thunder_hourly=(HourlyValue(14, 3),))
+    forecast = NormalizedForecast(
+        days=(today, tomorrow), provider="open-meteo", country="FR",
+        fire_zones_high=("208",), fire_zones_max=("209",), fire_massifs=("3",),
+        debug_provider="MET", debug_confidence="MED",
+        official_alerts_unavailable=False,
+    )
+    config = [
+        MetricSpec(symbol=sym, enabled=True)
+        for sym in (
+            "N", "K", "D", "FN", "FK", "FD", "R", "PR", "W", "G", "TH:", "TH+:",
+            "HU", "DP", "WD", "CP", "PT", "CT", "CL", "CM", "CH", "VS", "SU",
+            "UV", "HP", "NL", "SD", "NS24+", "SL", "AV", "WC",
+        )
+    ]
+    return forecast, config
+
+
+def test_ac_s6_5_no_non_alert_token_render_starts_with_bang():
+    """Ueber den echten build_token_line()-Pfad: KEIN Token ausserhalb der
+    Kategorie 'official_alert' rendert mit fuehrendem '!' — der Marker
+    bleibt exklusiv dem amtlichen Warnblock vorbehalten."""
+    forecast, config = _build_full_coverage_forecast()
+    line = build_token_line(
+        forecast, config, report_type="evening", stage_name="Etappe1",
+    )
+    non_alert_tokens = [t for t in line.tokens if t.category != "official_alert"]
+
+    assert len(non_alert_tokens) >= 25, (
+        f"Nur {len(non_alert_tokens)} Nicht-official_alert-Token gerendert "
+        "— die Fixture deckt zu wenige Grammatik-Klassen ab, der Waechter "
+        "wuerde praktisch nichts pruefen."
+    )
+
+    violations = [t for t in non_alert_tokens if t.render().startswith("!")]
+    assert not violations, (
+        "Folgende Nicht-official_alert-Token rendern mit fuehrendem '!': "
+        f"{[(t.symbol, t.category, t.render()) for t in violations]!r} — "
+        "der '!'-Block-Marker ist damit nicht mehr exklusiv dem amtlichen "
+        "Warnblock vorbehalten."
+    )
+
+
+def test_ac_s6_5_access_ban_bare_never_collides_with_forecast_cloud_low():
+    """Stichprobe: 'access_ban' (der EINZIGE levellose Hazard) rendert bar
+    'CL' ohne Suffix; forecast-'CL' (Wolken tief) rendert NIE bar — beide
+    Renderformen sind bytegenau verschieden."""
+    assert LEVELLESS_HAZARDS == frozenset({"access_ban"}), (
+        f"LEVELLESS_HAZARDS ist {LEVELLESS_HAZARDS!r} — erwartet genau "
+        "{'access_ban'} (einziger levelloser Hazard)."
+    )
+    access_ban_symbol = sms_symbol_for("access_ban")
+    assert access_ban_symbol == HAZARD_SMS_SYMBOLS["access_ban"], (
+        "sms_symbol_for('access_ban') weicht vom Katalog HAZARD_SMS_SYMBOLS ab."
+    )
+
+    forecast_ab = NormalizedForecast(
+        days=(DailyForecast(),),
+        official_alerts=((access_ban_symbol, "", None),),
+    )
+    line_ab = build_token_line(
+        forecast_ab, [], report_type="evening", stage_name="EtappeAB",
+    )
+    ab_tokens = [
+        t for t in line_ab.tokens
+        if t.symbol == access_ban_symbol and t.category == "official_alert"
+    ]
+    assert len(ab_tokens) == 1, (
+        f"Erwartet genau EIN official_alert-Token fuer 'access_ban', "
+        f"gefunden: {ab_tokens!r}"
+    )
+    bare_render = ab_tokens[0].render()
+    assert bare_render == access_ban_symbol, (
+        f"'access_ban' MUSS bar (ohne Suffix) rendern — erwartet "
+        f"{access_ban_symbol!r}, war {bare_render!r}."
+    )
+
+    forecast_cl = NormalizedForecast(
+        days=(DailyForecast(cloud_low_hourly=(HourlyValue(12, 40.0),)),),
+    )
+    line_cl = build_token_line(
+        forecast_cl, [MetricSpec(symbol="CL", enabled=True)],
+        report_type="evening", stage_name="EtappeCL",
+    )
+    cl_forecast_tokens = [
+        t for t in line_cl.tokens if t.symbol == "CL" and t.category == "forecast"
+    ]
+    assert len(cl_forecast_tokens) == 1, (
+        f"Erwartet genau EIN forecast-Token fuer 'CL', gefunden: "
+        f"{cl_forecast_tokens!r}"
+    )
+    forecast_render = cl_forecast_tokens[0].render()
+    assert forecast_render != access_ban_symbol, (
+        f"forecast-'CL' rendert bar ({forecast_render!r}) — das wuerde mit "
+        f"'access_ban' ({access_ban_symbol!r}) kollidieren. forecast-'CL' "
+        "MUSS immer einen Zahl/'-'/'?'-Suffix tragen."
+    )
+    assert bare_render != forecast_render, (
+        f"Die beiden Renderformen von 'CL' duerfen sich NIE decken: "
+        f"access_ban={bare_render!r}, forecast={forecast_render!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-S6-6 (RED): UNAVAILABLE_SYMBOL kollidiert heute bytegleich mit dem
+# Wind-Gap-Marker. Dieser Test MUSS beim Erstlauf fehlschlagen.
+# ---------------------------------------------------------------------------
+
+
+def test_ac_s6_6_unavailable_marker_must_never_collide_with_wind_gap_marker():
+    """(a) Wind-Datenausfall OHNE amtlichen Warnungs-Ausfall und (b) amtlicher
+    Warnungs-Ausfall OHNE Wind-Datenausfall MUESSEN ueber den echten
+    build_token_line()-Pfad verschiedene Marker-Strings liefern.
+
+    HEUTE (vor dem Fix in builder.py:74): beide rendern 'W?' -> ROT.
+    NACH dem Fix (UNAVAILABLE_SYMBOL = 'X?'): (a) bleibt 'W?', (b) wird
+    'X?' -> GRUEN.
+    """
+    # Szenario (a): Wind-Datenausfall, keine echte Windmessung im Fenster.
+    today_a = DailyForecast(wind_hourly=(), has_data_gap=True)
+    forecast_a = NormalizedForecast(days=(today_a,), official_alerts_unavailable=False)
+    line_a = build_token_line(
+        forecast_a, [MetricSpec(symbol="W", enabled=True)],
+        report_type="evening", stage_name="EtappeWindGap",
+    )
+    wind_gap_tokens = [
+        t for t in line_a.tokens if t.symbol == "W" and t.category == "forecast"
+    ]
+    assert len(wind_gap_tokens) == 1, (
+        f"Erwartet genau EIN Wind-forecast-Token, gefunden: {wind_gap_tokens!r}"
+    )
+    wind_gap_marker = wind_gap_tokens[0].render()
+
+    # Szenario (b): amtlicher Warnungs-Ausfall, keine Wind-Datenluecke.
+    today_b = DailyForecast(has_data_gap=False)
+    forecast_b = NormalizedForecast(days=(today_b,), official_alerts_unavailable=True)
+    line_b = build_token_line(
+        forecast_b, [], report_type="evening", stage_name="EtappeWarnAusfall",
+    )
+    unavailable_tokens = [t for t in line_b.tokens if t.category == "unavailable"]
+    assert len(unavailable_tokens) == 1, (
+        f"Erwartet genau EIN 'unavailable'-Token, gefunden: {unavailable_tokens!r}"
+    )
+    unavailable_marker = unavailable_tokens[0].render()
+
+    # Regressionsschutz: der Fix darf den Wind-Token selbst nicht veraendern.
+    assert wind_gap_marker == "W?", (
+        f"Szenario (a) (Wind-Datenausfall) sollte unveraendert 'W?' rendern, "
+        f"war {wind_gap_marker!r} — der Fix an UNAVAILABLE_SYMBOL darf den "
+        "Wind-Token selbst nicht beruehren."
+    )
+    # Regressionsschutz: der Marker bleibt weiterhin ausserhalb des
+    # '!'-Warnblocks (Anschluss an feat_1349_sms_unavailable.md AC-3).
+    assert "!" not in unavailable_marker, (
+        f"Szenario (b)s Marker darf NICHT als amtliche Warnung erscheinen "
+        f"('!'-Praefix), war {unavailable_marker!r}."
+    )
+
+    # DER FIX (AC-S6-6): beide Marker-Strings duerfen NIEMALS bytegleich sein.
+    # HEUTE (UNAVAILABLE_SYMBOL noch 'W?'): dieser Assert schlaegt fehl (RED).
+    assert wind_gap_marker != unavailable_marker, (
+        "AC-S6-6: 'Wind-Datenausfall' und 'amtliche Warnungen nicht "
+        f"abrufbar' rendern BEIDE {wind_gap_marker!r} — bytegleiche "
+        "Kollision zwischen zwei fachlich verschiedenen Zustaenden "
+        "(UNAVAILABLE_SYMBOL, builder.py:74, ist noch nicht auf 'X?' "
+        "gefixt). Fix: UNAVAILABLE_SYMBOL von 'W?' auf 'X?' aendern."
+    )


### PR DESCRIPTION
## Summary
- Epic #1703 Scheibe 6: neue, eigenständige Testdatei `tests/unit/test_sms_symbol_grammar_classes.py` (AC-S6-1..6) sichert die SMS-Symbol-Register (`PRIORITY`/`POSITIONAL`, `SMS_MULTI_SYMBOLS_BY_METRIC`/`SMS_SYMBOL_BY_METRIC`) auf Vollständigkeit und Kollisionsfreiheit gegenüber `HAZARD_SMS_SYMBOLS` — eigene Achse statt Erweiterung von `test_channel_metric_matrix.py` (PO-Vorentscheidung, 1:n-Struktur würde die Hauptmatrix sprengen)
- **Sicherheitsrelevanter Fund, einziger Produktivcode-Fix dieser Scheibe (AC-S6-6):** ein Wind-Datenausfall und der dedizierte "amtliche Warnungen nicht abrufbar"-Marker renderten bytegleich `"W?"` — unabhängig voneinander auslösbar, für den Leser nicht unterscheidbar, konnte verschleiern, dass amtliche Warnungen ausgefallen waren. `UNAVAILABLE_SYMBOL` auf `"X?"` geändert, zwei Bestandstests mechanisch migriert, `docs/reference/sms_format.md` §3.4d aktualisiert
- Bekannte, bewusst unbehobene Grenze: eine strukturell ähnliche, aber toter-Pfad-Kollision zwischen `TH:`/`HR:` und Météo-France-Vigilance bleibt dokumentiert, nicht gefixt

Spec: `docs/specs/modules/fix_1703_s6_form_waechter.md`

## Test plan
- [x] `uv run pytest tests/unit/test_sms_symbol_grammar_classes.py tests/tdd/test_sms_trip_unavailable_marker.py tests/tdd/test_sms_user_metric_order.py -v --disable-socket --allow-hosts=127.0.0.1,::1` → 25 passed
- [x] `ruff check` clean
- [x] Adversary VERIFIED — alle 5 Pflicht-Mutationen exakt vom vorgesehenen Test gefangen

Bezieht sich auf #1703 (Epic bleibt offen — Scheibe 6 von 8, Scheiben 7/8 stehen aus; Issue-Checkbox wird nach Merge manuell gesetzt, kein Auto-Close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)