### PR TITLE
feat(#1680 S3): Herkunft der Gewitterstufe an vier weiteren Ausgabeorten

### DIFF
--- a/docs/context/feat-1680-s3-herkunft-vier-orte.md
+++ b/docs/context/feat-1680-s3-herkunft-vier-orte.md
@@ -1,0 +1,145 @@
+<!-- Issue #1680, Scheibe 3 (vier weitere Ausgabeorte). Vorgaenger: S1 (Ortsvergleich,
+     live 2026-08-12) und S2 (Trip-Kurzzusammenfassung + GEWITTER-Kommando, live 2026-08-12,
+     Merge bacc6f29). Bezug: Epic #1419 Rang 4, Entscheidung E1. -->
+
+# Kontext: Herkunft der Gewitterstufe an vier weiteren Ausgabeorten (#1680 Scheibe 3)
+
+## Zusammenfassung der Anforderung
+
+Die fusionierte Gewitterstufe soll ihre tragenden Signale an vier weiteren Stellen
+nennen. PO-Entscheid zum Umfang (2026-08-13): **Pille im Metriken-Überblick**,
+**Kommando-Timeline je Wegpunkt**, **GLANCE-Tageszeile** und
+**Ortsvergleich-Stundentabelle**.
+
+Auswahlgrund: bei allen vieren liegt die Zutat bereits vor. Keiner braucht ein neues
+Feld, einen strukturellen Umbau oder den Aggregationsweg, der seit Scheibe 2
+bewusst unangeschlossen bleibt.
+
+Fortbestehende PO-Entscheidungen (2026-08-11), unverändert gültig:
+
+| Frage | Entscheidung |
+|---|---|
+| Auslegung | **(ii) alle tragenden Signale** — jede Zutat, die die gezeigte Stufe erreicht. Kein Gewinner wird gekürt |
+| Kanäle | **E-Mail und Telegram ja · SMS und Premium-SMS ausdrücklich OHNE Herkunft** — aktiv abzuwählen, nicht stillschweigend auszulassen |
+
+## Was aus S1 und S2 bereitsteht
+
+| Baustein | Ort | Rolle |
+|---|---|---|
+| `union_of_max_carriers()` | `src/output/metric_format.py` | **die eine** Stelle, an der die Vereinigungsregel gerechnet wird; garantiert seit S2-Finding F001 selbst, dass Stufe `NONE` auf `None` führt |
+| `thunder_signal_carriers()` | `src/output/metric_format.py` | ermittelt je Zeitpunkt die tragenden Signale |
+| `THUNDER_SIGNAL_LABEL_DE` / `thunder_signal_label()` | `src/output/metric_format.py:374-390` | deutscher Wortkatalog, vier feste Schlüssel |
+| `ForecastDataPoint.thunder_level_signals` | `src/app/models.py:204` | `list[str]`, providerseitig befüllt (`providers/thunder_enrichment.py:151`) |
+| `SegmentWeatherSummary.thunder_level_max_signals` | `src/app/models.py:430` | `list[str]`, befüllt in `compute_basis_metrics()` |
+
+Renderweg überall gleich (Hagel-Muster aus #1475): `f"{text} · {note}"`.
+
+## Die vier Ausgabeorte im Einzelnen
+
+### 1. Pille im Metriken-Überblick
+`src/output/renderers/email/helpers.py:1713-1757` (`_pill_for_metric`, thunder-Zweig),
+gespeist von `build_metrics_summary_pills()` (`:1815-1881`).
+
+- **Datenquelle:** `all_dps` aus `build_day_window_points(...)` (`:1861-1864`) — rohe
+  `ForecastDataPoint`-Liste, kein Aggregat. `dp.thunder_level_signals` ist direkt
+  erreichbar, wird heute nicht gelesen.
+- **Nicht mit Compare geteilt:** Aufrufer von `build_metrics_summary_pills()` sind
+  ausschließlich Trip-Renderer (`compact.py:176`, `plain.py:205`, `html.py:1432`);
+  `compare_html.py` ruft sie nicht auf. Die *Datei* `helpers.py` ist geteilt, die
+  *Funktion* nicht.
+- **Platz:** freier Fließtext, kein Zeichenlimit im Code. Das Hagel-Suffix hängt dort
+  bereits (`format_hail_note`).
+
+### 2. Kommando-Timeline je Wegpunkt
+`src/services/trip_command_processor.py:908-939` (`_fmt_timeline`), Gewitterzeile
+`:933-937`.
+
+- **Datenquelle:** `m = p.metrics` (`:928`) — eine `SegmentWeatherSummary` je Wegpunkt,
+  aus `WeatherExtractor.timeline()` (`weather_extractor.py:98`, `metrics=seg.aggregated`).
+  Das ist ein **Einzelsegment**-Aggregat aus `compute_basis_metrics()`, also mit korrekt
+  gerechneter Trägerliste — **nicht** vom `aggregate_stage()`-Rückfall betroffen.
+- **Platz:** freier Zeilentext mit Emoji, kein Limit.
+
+### 3. GLANCE-Tageszeile
+`src/services/trip_command_processor.py:844-854` (`_fmt_day_agg`), Gewitter-Label `:849`.
+
+- **Die Zutat liegt bereits im Aggregat:** `_aggregate_day()` (`:804-842`) rechnet
+  `thunder_signals` seit Scheibe 2 über `union_of_max_carriers()` (`:834-839`). Nur
+  `_fmt_gewitter()` liest den Schlüssel; `_fmt_day_agg()` nicht.
+- 🔴 **Diese Scheibe dreht eine Entscheidung um.** Der Kommentar an `:832-833` hält
+  ausdrücklich fest: „Nur `_fmt_gewitter()` liest den Schluessel; `_fmt_day_agg()` /GLANCE
+  bleibt bewusst zeichengleich (Spec D3, Known Limitation 4)." Das war der S2-Entscheid;
+  der PO hat ihn am 2026-08-13 bewusst abgelöst. Kommentar und Spec-Verweis sind
+  entsprechend nachzuziehen — eine stehengebliebene Notiz, die das Gegenteil behauptet,
+  ist genau die Fehlerklasse, die in S2 zum Streichen eines ganzen Arbeitspunkts führte.
+
+### 4. Ortsvergleich-Stundentabelle
+`src/output/renderers/email/compare_html.py:962-998` (`_render_hour_row`, HTML) und
+`src/output/renderers/comparison.py:329-333` (Klartext).
+
+- **Der Parameter existiert bereits.** `_fmt_thunder(v, hail=None, signals=None)`
+  (`compare_html.py:204-233`) hat den dritten Parameter seit S1. Der Docstring
+  (`:215-220`) hält fest, dass er dort bewusst nicht übergeben wurde — die
+  Stundentabelle blieb in S1 unverändert (AC-11 dort).
+- **Aufrufstellen:** `_render_hour_row` ruft `m["fmt"](value, getattr(dp, "hail_flag", None))`
+  (`:982-983`) — ohne dritten Parameter, obwohl `dp` die Signale trägt. Klartext ebenso
+  (`comparison.py:329-333`).
+- **Anzeige ist Text, nicht Farbe:** Kommentar `compare_html.py:977-981` — „Gewitter als
+  TEXT (kein Ampel-Kreis)". Ein Suffix ist dort also sichtbar.
+
+## Warum drei Kandidaten NICHT in dieser Scheibe sind
+
+| Kandidat | Grund |
+|---|---|
+| **Mehrtages-Ausblick** (`email/outlook.py`) | Die Träger gehen **strukturell** verloren: `HourlyValue` (`src/output/tokens/dto.py:15-18`) ist ein frozen Dataclass mit nur `hour` und `value`. Dazu getrennte Tag-/Nachtanteile (#1653), die zwei eigene Trägerrechnungen bräuchten, und er ist der **einzige** Kandidat, der `aggregate_stage()` als Verbraucher aktivieren würde (`trip_report_scheduler.py:2026`). Eigene Scheibe. |
+| **Trip-Stundentabelle** | Braucht erst einen Seitenkanal analog `row["_hail_flag"]` (`trip_report.py:687`) in `_dp_to_row()` plus Auswertung in `fmt_val()` (`helpers.py:732-757`). Zusätzlich rechnet `_aggregate_night_block()` (`trip_report.py:596-601`) mit `max_thunder()` ohne Trägerlogik — eine zweite, unabhängige Stelle. |
+| **Gewitter-Vorschau** | Primärpfad liest `row["hourly_thunder"]`, also dieselben trägerlosen `HourlyValue` wie der Ausblick (`trip_report_scheduler.py:2266`). Nur der Fallback-Pfad (`:2494-2504`) hätte rohe Datenpunkte. Halb baubar — gehört zum Ausblick. |
+| **Go-DTO** | `internal/model/segment.go:15` hat kein Signalfeld — aber `model.SegmentWeatherSummary` wird laut vollständigem grep über `internal/` **nirgends konstruiert oder gelesen**. Ein Feld dort hätte keinen Verbraucher. |
+| **Frontend** | Keine Komponente rendert eine live abgerufene Gewitterstufe. `CompareMetrics` (`frontend/src/lib/types.ts:426-440`) wird außerhalb von `types.ts` nicht referenziert; alle übrigen `thunder_level_max`-Treffer sind Konfigurations-Oberflächen (Korridor-/Alarm-Editor, Metrik-Auswahl) mit Katalog-Schlüsseln, keine Live-Werte. `TablePreview.svelte:36-39` zeigt statische Demodaten. |
+
+Go und Frontend fallen damit **ersatzlos**, nicht aufgeschoben: es gibt dort keinen Ort,
+an dem die Herkunft erscheinen könnte. Dieselbe Begründung, aus der in S2 der
+`aggregate_stage()`-Zweig draußen blieb — Code ohne Wirkort, den kein Test bewachen kann.
+
+## Der Aggregationsweg bleibt unberührt
+
+`aggregate_stage()` (`src/services/weather_metrics.py:1168-1271`) kennt die Regel
+`union_of_max_carriers` weiterhin nicht und fällt in den generischen `else`-Zweig
+(`:1265-1266`) auf `values[0]` zurück. Gemessen (vollständige Konsumentenanalyse):
+
+- `stage_weather.py:112` liest die Trägerliste **nicht** (nur Temperatur, Wind,
+  Niederschlag, Wettercode).
+- `compact_summary.py:268` (`_aggregate()`) ebenfalls nicht — der Gewittertext dort
+  rechnet bewusst daneben, direkt über die Stundenwerte (`:572-629`, eigener
+  `union_of_max_carriers()`-Aufruf `:628`).
+- `trip_report_scheduler.py:2026` (Mehrtages-Ausblick) **wäre** der erste Verbraucher —
+  liest heute aber nur `agg.thunder_level_max`.
+
+⇒ Keiner der vier Ausgabeorte dieser Scheibe aktiviert den Rückfall. Known Limitation 7
+aus Scheibe 1 bleibt bestehen und gehört in die Ausblick-Scheibe.
+
+## Risiken und Fallstricke
+
+1. 🔴 **Die Voraussetzung des Musters je Ort einzeln prüfen** (Lehre aus AC-12 in S1 und
+   aus dem gestrichenen Arbeitspunkt in S2). Für jeden der vier Orte ist zu belegen, dass
+   **gezeigte Stufe und Trägerliste aus derselben Rechnung** stammen. Bei der Pille und
+   der Stundentabelle ist das je ein Datenpunkt, bei der Timeline ein Segment-Aggregat,
+   bei GLANCE das Tages-Aggregat — vier verschiedene Ebenen.
+2. 🔴 **Kein Leck in SMS und Premium-SMS.** `comparison.py` speist auch die Compare-SMS
+   (`:629`, `_sms_metric_cell`) — in S1 war die Annahme „Compare-SMS zeigt Gewitter gar
+   nicht" gemessen **falsch**. Der Klartext-Zweig der Stundentabelle ist hier besonders
+   zu prüfen. Ebenso der Trip-Rückfall `report.sms_text or report.email_plain`
+   (`notification_service.py:417,433`).
+3. **Geteilte Funktion:** `_fmt_thunder` speist sowohl die S1-Übersichtszeile (mit
+   Herkunft) als auch die Stundentabelle (bisher ohne). Eine Änderung im Rumpf statt an
+   der Aufrufstelle würde die Übersichtszeile mit verändern.
+4. **Zeichengleichheit** überall dort, wo keine Herkunft vorliegt — inklusive
+   Alt-Schnappschüssen ohne das Feld.
+5. **Commit-Gates:** `renderer_mail_gate.py` greift für `email/`-Dateien und
+   `compare_html.py` — Commit blockiert ohne frischen `briefing_mail_validator.py`-Lauf
+   und grüne `tests/tdd/test_issue_811_mode_matrix.py`. Für den Ortsvergleich ist
+   zusätzlich `email_spec_validator.py` der zuständige Validator (zwei Mailpfade, zwei
+   Gates).
+6. **Doku-Drift aktiv nachziehen:** der Kommentar `trip_command_processor.py:832-833`
+   behauptet nach dieser Scheibe das Gegenteil des Codes, ebenso der Docstring-Hinweis in
+   `compare_html.py:215-220`. Beide gehören in den Änderungssatz.

--- a/docs/specs/modules/feat_1680_s3_gewitter_herkunft_vier_orte.md
+++ b/docs/specs/modules/feat_1680_s3_gewitter_herkunft_vier_orte.md
@@ -19,7 +19,7 @@ tags: [thunder, trip, compare, adr-0007, adr-0025, adr-0048, issue-1680, issue-1
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-Freigabe „go" am 2026-08-13 auf die sechzehn Akzeptanzkriterien
 
 ## Purpose
 

--- a/docs/specs/modules/feat_1680_s3_gewitter_herkunft_vier_orte.md
+++ b/docs/specs/modules/feat_1680_s3_gewitter_herkunft_vier_orte.md
@@ -361,17 +361,31 @@ zwei Orte angewendet.
     eine dritte Zutat traegt; Assertion, dass die GLANCE-Zeile nur Zutaten von
     Wegpunkten DES Zieltags nennt.
 
-- **AC-12 (kein Leck Compare-SMS/Telegram):** Given die Ortsvergleich-
-  Stundentabelle zeigt an mindestens einem Ort eine Herkunft, When derselbe
-  Vergleich als SMS oder als Telegram-Nachricht gerendert wird, Then enthaelt
-  weder `render_compare_sms()` noch `render_compare_telegram()` irgendeine der
-  vier Zutat-Bezeichnungen — beide Kanaele zeigen weiterhin ausschliesslich
-  die Uebersichtszeile (kein Zugriff auf die Stundentabellen-Aufrufstellen
-  dieser Scheibe).
+- **AC-12 (kein Leck aus der Stundentabelle in SMS und Telegram):** Given die
+  Ortsvergleich-Stundentabelle zeigt an einer Stunde **unterhalb** der
+  Tages-Hoechststufe eine Zutat, die nur dort vorkommt, When derselbe Vergleich
+  als SMS oder als Telegram-Nachricht gerendert wird, Then taucht diese Zutat
+  in **keinem** der beiden Texte auf; die SMS traegt darueber hinaus
+  **keine** der vier Zutat-Bezeichnungen.
   - Test: dieselbe Fixture wie AC-4, zusaetzlich durch `render_compare_sms()`
-    und `render_compare_telegram()` gerendert; Assertion, dass keiner der
-    beiden Texte „CAPE", „Blitzpotenzial", „Blitzdichte" oder „Wettercode"
-    enthaelt.
+    und `render_compare_telegram()` gerendert. Fuer Telegram: Assertion auf die
+    Abwesenheit der **stundenexklusiven** Zutat (z. B. Blitzdichte auf einer
+    Stunde unterhalb des Tagesmaximums). Fuer die SMS: Assertion auf die
+    Abwesenheit **aller vier** Bezeichnungen (Gegenprobe zu Mutation (f)).
+
+  🔴 **Berichtigt 2026-08-13, vor der Implementierung.** Die urspruengliche
+  Fassung verlangte, dass **auch Telegram** keine der vier Bezeichnungen traegt.
+  Das ist am ausgelieferten Stand nachweislich falsch: die Telegram-**Uebersichts**-
+  zeile zeigt die Herkunft seit Scheibe 1 ausdruecklich, bewacht von
+  `tests/tdd/test_thunder_origin_compare.py::test_ac4_telegram_zeigt_dieselbe_herkunft_wie_die_mail`
+  (gruen, live seit 2026-08-12) und gedeckt vom PO-Entscheid „E-Mail und Telegram
+  **ja**". Die woertliche Fassung waere nur gruen zu bekommen gewesen, indem eine
+  bereits ausgelieferte Zusage bricht. Der Fehler entstand beim Formulieren des
+  Spec-Auftrags („kein Leck in SMS" pauschal, Telegram versehentlich mitgezogen)
+  und wurde in der RED-Phase entdeckt. Geprueft wird jetzt die Aussage, die AC-12
+  tatsaechlich traegt: aus den **neuen** Stundentabellen-Aufrufstellen darf nichts
+  in die Kurznachrichtenkanaele lecken. Der PO-Entscheid bleibt unveraendert —
+  diese Berichtigung stellt die Spec auf ihn zurueck, statt ihn zu aendern.
 
 - **AC-13 (kein Leck Trip-SMS/Premium-SMS):** Given die Pille und die
   GLANCE-Zeile tragen Herkunftsangaben, die in `email_plain` landen, When der
@@ -469,6 +483,46 @@ Isolation auf `union_of_max_carriers()` allein.
 
 Mutationen ausschliesslich per String-Ersetzung mit externer Sicherungskopie
 (kein `git checkout`/`stash`/`reset`, CLAUDE.md-Vorgabe).
+
+## Am Code berichtigt in der RED-Phase (2026-08-13)
+
+Fünf Annahmen dieser Spec haben beim Schreiben der Tests nicht gehalten. Alle
+Soll-Werte der Tests sind am **gemessenen** Verhalten verankert, nicht an den
+Beispieltexten oben. Wer implementiert, richtet sich nach dieser Liste.
+
+1. 🔴 **Die F001-Garantie trägt an der Stundentabelle NICHT.** D4 reicht
+   `dp.thunder_level_signals` **roh** durch, ohne `union_of_max_carriers()` — die
+   in Scheibe 2 eingebaute Zusicherung „Stufe `NONE` ⇒ keine Herkunft" greift dort
+   also gar nicht. Dass eine `NONE`-Stunde nicht zu „— · CAPE" wird, garantiert
+   allein eine **zweite, unabhängige** Zusage: `thunder_signal_carriers()` liefert
+   für `NONE` eine leere Liste (`metric_format.py:470-471`). Einziger Wächter
+   dafür ist `test_ac16_ohne_gewitter_bleibt_die_compare_stundenzelle_zeichengleich`.
+   **Dieselbe Fehlerklasse wie F001 selbst** — eine Zusage, die nur wegen einer
+   Eigenschaft an anderer Stelle hält.
+2. **„kein Gewitter" heißt an den vier Orten DREI verschiedene Dinge:** Pille
+   `kein Gewitter` · Timeline und GLANCE `kein` (`_THUNDER_LABEL`,
+   `trip_command_processor.py:136`) · Compare-Stundenzelle `—`
+   (`_THUNDER_LEVEL_LABEL`, `compare_html.py:166`). Diese Spec sprach durchweg von
+   „kein". **Nicht harmonisieren** — das wäre eine nicht spezifizierte
+   Textänderung an drei ausgelieferten Ausgabeorten.
+3. **Der Beispieltext von AC-1 ist nicht produzierbar.** „Gewitter ab 14:00 ·
+   stärkste 17:00" setzt voraus, dass die Spitzenstunde nach der ersten
+   Erwähnungsstunde liegt. `helpers.py:1734` vergleicht strikt (`>`), die
+   Spitzenstunde ist also die **erste**, die das Maximum erreicht. Bei mehreren
+   gleich hohen Stunden lautet die Pille „ab 14:00 · stärkste 14:00".
+4. **Die Timeline erreicht man NICHT über TODAY/TOMORROW.** Ein blankes
+   `HEUTE`/`MORGEN` löst `_trigger_on_demand()` aus
+   (`trip_command_processor.py:506-509`) — das **volle Tages-Briefing**.
+   `_fmt_timeline()` hängt allein am Query-Schlüssel `timeline_heute`/
+   `timeline_morgen`, den nur die Telegram-Inline-Schaltflächen `tl_today`/
+   `tl_tomorrow` erzeugen.
+5. **Die Testablage weicht von dieser Spec ab.** Der Testplan unten sieht die
+   Erweiterung der beiden Bestandsdateien vor; tatsächlich entstand eine eigene
+   Datei `tests/tdd/test_thunder_origin_four_places.py` (nach Verhalten benannt,
+   verstößt nicht gegen `test_naming_gate.py`). Preis: rund 150 Zeilen
+   Fixture-Gerüst doppeln sich mit den Vorgängerdateien. Bewusst in Kauf genommen,
+   damit die Scheibe als Ganzes nachvollziehbar bleibt; beide Schwesterdateien
+   sind unverändert und grün.
 
 ## Known Limitations
 

--- a/docs/specs/modules/feat_1680_s3_gewitter_herkunft_vier_orte.md
+++ b/docs/specs/modules/feat_1680_s3_gewitter_herkunft_vier_orte.md
@@ -1,0 +1,585 @@
+---
+entity_id: feat_1680_s3_gewitter_herkunft_vier_orte
+type: feature
+created: 2026-08-13
+updated: 2026-08-13
+status: draft
+version: "1.0"
+tags: [thunder, trip, compare, adr-0007, adr-0025, adr-0048, issue-1680, issue-1419]
+---
+
+<!-- Issue #1680, Scheibe 3 (vier weitere Ausgabeorte). Vorgaenger: Scheibe 1
+     (Ortsvergleich, live seit 2026-08-12) und Scheibe 2 (Trip-Kurzzusammenfassung
+     + GEWITTER-Kommando, live seit 2026-08-12, Merge bacc6f29). Bezug: Epic #1419
+     Rang 4, Entscheidung E1. Grundlage: PFLICHTLEKTUERE
+     docs/context/feat-1680-s3-herkunft-vier-orte.md (gemessen 2026-08-13),
+     PO-Entscheid zum Umfang dieser Scheibe (2026-08-13). -->
+
+# Gewitter: Herkunft der Stufe an vier weiteren Ausgabeorten (#1680 Scheibe 3)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Seit Scheibe 1 (Ortsvergleich-Tagesuebersicht) und Scheibe 2 (Trip-Kurzzusammenfassung,
+GEWITTER-Kommando) zeigen zwei Ausgabeorte neben der fusionierten Gewitterstufe die
+tragende(n) Zutat(en). An vier weiteren, vom PO ausgewaehlten Stellen fehlt die
+Angabe noch: der Pille im Metriken-Ueberblick der Trip-Mail, der Kommando-Timeline
+je Wegpunkt, der GLANCE-Tageszeile und der Ortsvergleich-Stundentabelle. Bei allen
+vieren liegt die Zutat bereits als Datenfeld vor — keiner braucht ein neues Feld,
+einen strukturellen Umbau oder den Aggregationsweg `aggregate_stage()`, der seit
+Scheibe 2 bewusst unangeschlossen bleibt. Die Herkunft nennt weiterhin nur die
+Zutat, keine Bewertung und keine Handlungsempfehlung (ADR-0007).
+
+**Diese Scheibe dreht eine Entscheidung aus Scheibe 2 ausdruecklich um.** Scheibe 2
+legte fest (dortige Spec D3, Known Limitation 4), die GLANCE-Tageszeile bleibe
+"bewusst zeichengleich" — sie liest den seit Scheibe 2 im Aggregat vorhandenen
+Schluessel `"thunder_signals"` (`trip_command_processor.py:834-839`) absichtlich
+nicht. Der zugehoerige Kommentar (`trip_command_processor.py:832-833`) haelt das
+wörtlich fest: "Nur `_fmt_gewitter()` liest den Schluessel; `_fmt_day_agg()`
+/GLANCE bleibt bewusst zeichengleich (Spec D3, Known Limitation 4)." Der PO hat
+diese Entscheidung am 2026-08-13 bewusst abgeloest — GLANCE zeigt die Herkunft ab
+dieser Scheibe genauso wie das GEWITTER-Kommando. Kommentar und Docstring-Verweis
+sind im Aenderungssatz zwingend nachzuziehen (s. Implementation Details D3);
+ebenso der Docstring-Hinweis in `compare_html.py:215-220`, der die
+Compare-Stundentabelle noch als bewusst unveraendert beschreibt (AC-11 aus
+Scheibe 1) — beide Notizen wuerden sonst das Gegenteil des neuen Codes behaupten.
+Genau diese Fehlerklasse — eine stehengebliebene Notiz, die eine erledigte oder
+abgeloeste Entscheidung falsch darstellt — fuehrte in Scheibe 2 bereits einmal zum
+Streichen eines ganzen Arbeitspunkts (dort: die urspruengliche S1-Notiz zu
+`aggregate_stage()`).
+
+## Source
+
+> **Schicht-Hinweis:** ausschliesslich Python-Core (`src/output/renderers/email/`,
+> `src/output/renderers/comparison.py`, `src/services/trip_command_processor.py`).
+> Kein Frontend, keine Go-Beteiligung, kein neuer Endpoint, keine neuen
+> Persistenz-Felder — reine Renderlogik an vier bestehenden Andockstellen.
+
+- **File:** `src/output/renderers/email/helpers.py` — `_pill_for_metric()`,
+  thunder-Zweig (Z. 1713-1757), gespeist von `build_metrics_summary_pills()`
+  (Z. 1815-1881, Aufruf `build_day_window_points()` Z. 1861-1864)
+- **File:** `src/services/trip_command_processor.py`:
+  - `_fmt_timeline()` (Z. 908-939), Gewitterzeile Z. 933-937
+  - `_fmt_day_agg()` (Z. 844-854) — GLANCE, liest ab dieser Scheibe
+    `agg.get("thunder_signals")`
+  - `_aggregate_day()` (Z. 804-842) — Berechnung existiert bereits seit
+    Scheibe 2 (Z. 834-839); **nur** der irrefuehrende Kommentar Z. 832-833 wird
+    korrigiert, keine Logikaenderung an dieser Stelle
+- **File:** `src/output/renderers/email/compare_html.py` — `_render_hour_row()`
+  (Z. 962-998, Aufrufstelle Z. 982-983); Docstring-Korrektur an `_fmt_thunder()`
+  (Z. 204-233, insbesondere Z. 215-220)
+- **File:** `src/output/renderers/comparison.py` — Klartext-Stundenschleife in
+  `render_comparison_text()` (Z. 143-341, betroffene Zeilen 322-341, insbesondere
+  329-333)
+- **Nur Kommentar, keine Logikaenderung:** `src/services/notification_service.py`
+  — Kommentare Z. 413-422 (SMS) / Z. 434-441 (Premium-SMS) erwaehnen bereits den
+  Rueckfall `sms_text or email_plain`; nachzutragen ist, dass ab dieser Scheibe
+  auch Pillen- und GLANCE-Text potenziell betroffener Inhalt sind. Die
+  eigentlichen Aufrufstellen liegen bei Messung (2026-08-13) auf Z. 428 (SMS) und
+  Z. 446 (Premium-SMS) — die Scheibe-2-Notiz "`:417,433`" referenzierte den
+  erklaerenden Kommentar, nicht den Aufruf selbst; Zeilen haben sich seither
+  verschoben.
+- **Identifier:** `output.renderers.email.helpers._pill_for_metric()`,
+  `services.trip_command_processor.TripCommandProcessor._fmt_timeline()`,
+  `services.trip_command_processor.TripCommandProcessor._fmt_day_agg()`,
+  `output.renderers.email.compare_html._render_hour_row()`,
+  `output.renderers.comparison.render_comparison_text()`
+
+## Estimated Scope
+
+- **LoC:** ~70-110 Quellcode (vier duenne, additive Andockstellen + zwei
+  Kommentar-/Docstring-Korrekturen, keine neuen Funktionen) + geschaetzt
+  ~220-320 Tests (16 ACs quer ueber vier strukturell verschiedene Ausgabeorte,
+  jeweils Pruefort=Wirkort bis zum zurueckgegebenen Text) ⇒ Gesamt ~290-430.
+  **Schaetzung, keine Messung** — analog Scheibe 1/2 (dort waren fruehere
+  Schaetzungen zu optimistisch) ist ein `loc_limit_override` gegen das
+  250-Zeilen-Limit voraussichtlich noetig, in der RED-Phase neu zu pruefen.
+- **Files:** 5 Quelldateien (s. Source; `notification_service.py` nur
+  Kommentar) + 0 neue Testdateien — Erweiterung der bestehenden, nach Verhalten
+  benannten Module `tests/tdd/test_thunder_origin_trip.py` (Pille, Timeline,
+  GLANCE) und `tests/tdd/test_thunder_origin_compare.py` (Stundentabelle),
+  Vorbild Scheibe 1/2. Keine dritte, issue-nummerierte Testdatei.
+- **Effort:** medium. Additiv, kein Breaking Change, kein Frontend, keine neue
+  Persistenz — alle vier Felder existieren bereits seit Scheibe 1/2. Das Risiko
+  liegt (a) im Nachweis der Kohaerenz je Ort einzeln (vier strukturell
+  verschiedene Aggregationsebenen: Stundenwerte, ein Datenpunkt,
+  Segment-Aggregat, Tages-Aggregat) und (b) im vollstaendigen Nachziehen der
+  zwei jetzt falschen Kommentare/Docstrings (Lehre aus Scheibe 2).
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `docs/context/feat-1680-s3-herkunft-vier-orte.md` | GRUNDLAGE (gemessen) | Belege, Messwerte, PO-Entscheidungen dieser Spec sind daraus uebernommen |
+| `docs/specs/modules/feat_1680_s2_gewitter_herkunft_trip.md` | VORGAENGER | Aufbau/Detailgrad; legt die jetzt ausdruecklich abgeloeste GLANCE-Entscheidung fest (dortige D3, Known Limitation 4) |
+| `docs/specs/modules/feat_1680_s1_gewitter_herkunft_ortsvergleich.md` | VORGAENGER | AC-12-Lehre (Kohaerenz), `_fmt_thunder`-Docstring-Hinweis (Z. 215-220, hier zu korrigieren), AC-11 (Compare-Stundentabelle "bleibt unveraendert" — hier ebenfalls abgeloest) |
+| ADR-0007 (`docs/adr/0007-daten-statt-empfehlungen.md`) | ZUSAGE | Herkunfts-Label ist Beschreibung, keine Bewertung |
+| ADR-0025 (`docs/adr/0025-eine-gewitter-quelle-fuer-alle-briefing-kanaele.md`) | ZUSAGE | Eine Gewitter-Quelle fuer alle Kanaele — diese Scheibe erweitert additiv, baut keine zweite Fusion |
+| ADR-0048 (`docs/adr/0048-modellabhaengige-schwellen-statt-einer-zahl.md`) | KONTEXT | Unbekannte/ungeeichte Herkunft ist keine Aussage ueber die Guete der Eichung |
+| `src/output/metric_format.py:559-609` (`union_of_max_carriers()`) | ZUSAGE (S2) | Garantiert seit S2-Finding F001 SELBST, dass Stufe `NONE` auf `None` fuehrt — diese Scheibe importiert nur, sichert nicht erneut ab |
+| `src/output/metric_format.py:374-390` (`THUNDER_SIGNAL_LABEL_DE`, `thunder_signal_label()`) | ZUSAGE (S1) | Deutscher Wortkatalog, Katalogreihenfolge wettercode/blitzdichte/cape/blitzpotenzial |
+| `src/app/models.py:204` (`ForecastDataPoint.thunder_level_signals`), `:430` (`SegmentWeatherSummary.thunder_level_max_signals`) | ZUSAGE (S1) | Beide Felder existieren bereits additiv, `list[str]` |
+| `src/services/trip_command_processor.py:804-842` (`_aggregate_day()`) | ZUSAGE (S2) | `"thunder_signals"` steht bereits im Rueckgabe-Dict — GLANCE liest denselben Schluessel, keine neue Berechnung |
+| `src/output/renderers/email/compare_html.py:204-233` (`_fmt_thunder()`) | ZUSAGE (S1) | Dritter Parameter `signals` existiert bereits seit Scheibe 1 — diese Scheibe uebergibt ihn an zwei weiteren Aufrufstellen, aendert den Funktionsrumpf NICHT |
+| `.claude/hooks/renderer_mail_gate.py` | WAECHTER | greift fuer `helpers.py` (SHARED_HELPER-Muster — verlangt BEIDE Nachweise, `briefing_mail_validator.py` UND `email_spec_validator.py`, weil die Datei von Trip- UND Compare-Renderern importiert wird) und fuer `compare_html.py` (COMPARE-Muster — verlangt `email_spec_validator.py`). Greift GEMESSEN NICHT fuer `comparison.py` und NICHT fuer `trip_command_processor.py` — keines der vier Pattern-Sets (`_MAIL_PATTERNS`, `_COMPARE_PATTERNS`, `_SHARED_HELPER_PATTERNS`, `_RADAR_PATTERNS`) trifft diese Pfade |
+| `.claude/hooks/touched_tests_gate.py` (#1481 A) | WAECHTER | einziger Commit-Gate-Schutz fuer `comparison.py`/`trip_command_processor.py` in dieser Scheibe — blockiert, wenn ein zu diesen Dateien gehoerender Test rot wird |
+| `tests/tdd/test_issue_811_mode_matrix.py` | WAECHTER | muss gruen sein, bevor der Renderer-Mail-Gate-Matrix-Nachweis fuer `helpers.py` akzeptiert wird |
+
+## PO-Entscheidungen
+
+**Fortbestehend aus Scheibe 1 (2026-08-11) und Scheibe 2 (2026-08-12),
+unveraendert gueltig:**
+
+| Frage | Entscheidung |
+|---|---|
+| Auslegung | **(ii) Alle tragenden Signale.** Genannt wird JEDE Zutat, die die gezeigte Stufe erreicht. Kein Gewinner wird gekuert. |
+| Kanaele | **E-Mail und Telegram JA · SMS und Premium-SMS ausdruecklich OHNE Herkunft** — aktiv abzuwaehlen/zu pruefen, nicht stillschweigend auszulassen. |
+
+**Neu, 2026-08-13 (Umfang dieser Scheibe):**
+
+| Frage | Entscheidung |
+|---|---|
+| Ausgabeorte | Genau **vier**: Pille im Metriken-Ueberblick, Kommando-Timeline je Wegpunkt, GLANCE-Tageszeile, Ortsvergleich-Stundentabelle (HTML + Klartext). Auswahlgrund: bei allen vieren liegt die Zutat bereits vor — kein neues Feld, kein struktureller Umbau. |
+| **GLANCE (abgeloest)** | Scheibe 2 (D3, Known Limitation 4): GLANCE bleibt bewusst zeichengleich. **PO-Entscheid 2026-08-13: aufgehoben.** GLANCE zeigt die Herkunft ab dieser Scheibe, exakt wie das GEWITTER-Kommando, ueber denselben bereits berechneten Aggregat-Schluessel. |
+| **Compare-Stundentabelle (abgeloest)** | Scheibe 1 (AC-11): die Compare-Stundentabelle bleibt unveraendert. **Mit dieser Scheibe abgeloest** — der dritte Parameter von `_fmt_thunder()` wird an beiden Aufrufstellen (HTML, Klartext) ab jetzt uebergeben. |
+| `aggregate_stage()` | Bleibt weiterhin bewusst unangeschlossen — keiner der vier Orte dieser Scheibe aktiviert diesen Rueckfallweg (vollstaendige Konsumentenanalyse, s. Known Limitations). Tech-Lead-Entscheid unveraendert seit Scheibe 1/2. |
+
+## Implementation Details
+
+**D1 — Pille im Metriken-Ueberblick: Vereinigung ueber das Tagesfenster.**
+`_pill_for_metric()` (`helpers.py:1713-1757`) erhaelt bereits `all_dps` — die
+rohe `ForecastDataPoint`-Liste des Tagesfensters (04-19 + Zielstunde,
+`build_day_window_points()`, `helpers.py:1861-1864`). Zusaetzlich zur
+bestehenden `max_lvl`-Schleife (Z. 1721-1736) wird
+`traeger = union_of_max_carriers((dp.thunder_level, dp.thunder_level_signals)
+for dp in all_dps)` berechnet (call-time Import, Muster Z. 1743). Die Herkunft
+haengt NUR am "identifizierten" Zweig an (Z. 1748-1752, wo bereits eine
+Erwaehnungsschwelle ueberschritten wurde), VOR dem bestehenden Hagel-Suffix —
+analog der Reihenfolge in `_fmt_gewitter()` (Scheibe 2, "Zeitfenster/Stufe ·
+Herkunft · Hagel"). Die beiden anderen Rueckgabezweige ("kein Gewitter",
+"Gewitter ?" bei Datenluecke, Z. 1755-1757) bekommen KEINEN Herkunfts-Zusatz:
+bei "kein Gewitter" liefert `union_of_max_carriers` ohnehin `None` (F001-
+Garantie, Stufe `NONE`), bei der Datenluecke wird auch die Stufe selbst nicht
+genannt, eine Herkunft dazu waere inkohaerent.
+
+**D2 — Kommando-Timeline: Segment-Aggregat je Wegpunkt.** `_fmt_timeline()`
+(`trip_command_processor.py:908-939`) liest `m = p.metrics` (Z. 928) — eine
+`SegmentWeatherSummary` je Wegpunkt (`TimelinePoint.metrics = seg.aggregated`,
+`weather_extractor.py:98`). Die Gewitterzeile (Z. 933-937) erweitert sich um
+`traeger = m.thunder_level_max_signals` und haengt bei vorhandenen Traegern
+`" · " + herkunft` hinter `t_label` an: `f"⛈ {t_label} · {herkunft}"` statt
+bisher nur `f"⛈ {t_label}"`. Kein zweiter Datenzugriff: `thunder_level_max` UND
+`thunder_level_max_signals` stammen aus DEMSELBEN `m`, befuellt von
+`compute_basis_metrics()` fuer genau dieses eine Segment — die Timeline zeigt
+mehrere Wegpunkte NACHEINANDER, nie aggregiert, daher ist hier keine
+Vereinigung ueber mehrere Eintraege noetig (anders als bei Pille/GLANCE).
+
+**D3 — GLANCE: liest den seit Scheibe 2 vorhandenen Schluessel (abgeloeste
+Entscheidung).** `_fmt_day_agg()` (`trip_command_processor.py:844-854`)
+erweitert sich um `traeger = agg.get("thunder_signals")` und haengt bei
+vorhandenen Traegern `f" · {herkunft}"` hinter `{thunder_label}` an:
+`f"⛈ Gewitter: {thunder_label} · {herkunft}"` statt bisher nur
+`f"⛈ Gewitter: {thunder_label}"`. Kein neuer Datenzugriff: `_aggregate_day()`
+(Z. 804-842) berechnet `"thunder_signals"` bereits seit Scheibe 2 ueber
+`union_of_max_carriers()` (Z. 834-839) — GENAU der Schluessel, den
+`_fmt_gewitter()` bereits liest (Z. 902-905). Der Kommentar Z. 832-833 ("Nur
+`_fmt_gewitter()` liest den Schluessel; `_fmt_day_agg()`/GLANCE bleibt bewusst
+zeichengleich (Spec D3, Known Limitation 4)") wird durch einen Hinweis auf
+diese Scheibe ersetzt — sonst behauptet der Kommentar das Gegenteil des Codes
+(Lehre aus Scheibe 2, s. Purpose).
+
+**D4 — Ortsvergleich-Stundentabelle: dritter Parameter an zwei bestehenden
+Aufrufstellen, Funktionsrumpf unangetastet.** `_fmt_thunder(v, hail=None,
+signals=None)` (`compare_html.py:204-233`) hat den dritten Parameter bereits
+seit Scheibe 1 — der Rumpf (Z. 226-233) haengt bei vorhandenen `signals`
+bereits korrekt einen `·`-Abschnitt an, VOR dem Hagel-Hinweis. Zwei
+Aufrufstellen werden geaendert:
+- **HTML** — `_render_hour_row()` (`compare_html.py:982-983`): statt
+  `m["fmt"](value, getattr(dp, "hail_flag", None))` neu
+  `m["fmt"](value, getattr(dp, "hail_flag", None), getattr(dp,
+  "thunder_level_signals", None))`, nur wenn `m["fmt"] is _fmt_thunder`
+  (bestehende Bedingung Z. 982 bleibt der Torwaechter).
+- **Klartext** — die Stundenschleife in `render_comparison_text()`
+  (`comparison.py:329-333`): analog derselbe dritte Positionsparameter.
+
+`value` (aus `getattr(dp, m["key"], None)`) traegt die rohe Stufe
+(`dp.thunder_level`), `thunder_level_signals` liegt am SELBEN `dp` — beide aus
+demselben Datenpunkt, kein zweiter Rechenweg. Der Docstring-Hinweis
+`compare_html.py:215-220` ("🔴 Der Zusatz gehoert bewusst NICHT in den Rumpf:
+diese Funktion speist ueber `_HOUR_FMT_OVERRIDES["thunder"]` AUCH die
+Compare-Stundentabelle, die in dieser Scheibe unveraendert bleibt (AC-11)")
+wird korrigiert: die Compare-Stundentabelle bleibt weiterhin OHNE eigene
+Logik im Funktionsrumpf (D4 aendert nur Aufrufstellen), zeigt die Herkunft ab
+dieser Scheibe aber SEHR WOHL — der Verweis auf "AC-11 aus Scheibe 1"
+(damals: unveraendert) ist durch den Hinweis auf die Aufhebung in dieser
+Scheibe zu ersetzen.
+
+**D5 — Kein struktureller Kohaerenz-Guard, vier verschiedene Beweisebenen.**
+Anders als in Scheibe 1 (dort D7: `LocationResult.thunder_level_max` UND die
+Herkunft koennten aus ZWEI unabhaengigen Rechnungen stammen, daher ein
+Laufzeit-Guard in `loc_thunder_signals()`) entstehen an allen vier Orten
+dieser Scheibe Stufe UND Herkunft aus DERSELBEN Rechnung bzw. demselben
+Objekt:
+- **Pille:** dieselbe `all_dps`-Liste speist `max_lvl` UND `traeger`.
+- **Timeline:** dasselbe `m` (`SegmentWeatherSummary`) traegt
+  `thunder_level_max` UND `thunder_level_max_signals`.
+- **GLANCE:** derselbe `_aggregate_day()`-Dict-Aufbau fuellt `"thunder"` UND
+  `"thunder_signals"` in EINEM Funktionsaufruf.
+- **Stundentabelle:** derselbe `dp` liefert `dp.thunder_level` (via
+  `m["key"]`) UND `dp.thunder_level_signals`.
+
+Ein struktureller Guard ist daher an keinem der vier Orte noetig — die
+Kohaerenz wird stattdessen durch AC-8/AC-9/AC-10/AC-11 UND die zugehoerigen
+Mutationsproben nachgewiesen (s. Testplan), nicht durch eine Laufzeit-Pruefung
+im Code. Das ist dieselbe Argumentation wie Scheibe 2s D6, hier auf vier statt
+zwei Orte angewendet.
+
+## Expected Behavior
+
+- **Input:** ein Trip- bzw. Ortsvergleich-Kontext, dessen `ForecastDataPoint`s
+  bzw. `SegmentWeatherSummary`s ueber die echte Anreicherung
+  (`thunder_enrichment.enrich_thunder()`) unterschiedliche Gewitter-Rohwerte
+  tragen (z. B. eine Stunde/ein Wegpunkt mit CAPE oberhalb der Leiter, eine
+  andere/ein anderer mit Blitzpotenzial oberhalb derselben Hoechststufe).
+- **Output:** Pille, Kommando-Timeline, GLANCE-Zeile und
+  Ortsvergleich-Stundentabelle (HTML + Klartext) zeigen neben Stufe/Zeitfenster
+  die tragende(n) Zutat(en); SMS, Premium-SMS, Compare-SMS und
+  Compare-Telegram-Uebersicht bleiben unveraendert ohne Herkunfts-Zusatz.
+- **Side effects:** keine neuen Datenfelder, keine Persistenz-Aenderung — alle
+  gelesenen Felder existieren bereits additiv seit Scheibe 1/2. Zwei
+  Kommentare/Docstrings (`trip_command_processor.py:832-833`,
+  `compare_html.py:215-220`) werden inhaltlich korrigiert, keine
+  Logikaenderung an den betroffenen Zeilen selbst.
+
+## Acceptance Criteria
+
+- **AC-1:** Given die Pille im Metriken-Ueberblick der Trip-Mail zeigt ein
+  Gewitterfenster, das ausschliesslich ueber eine Zutat (z. B. CAPE) zustande
+  kommt, When die Mail gerendert wird, Then lautet die Pille „Gewitter ab
+  14:00 · stärkste 17:00 · CAPE" statt nur „Gewitter ab 14:00 · stärkste
+  17:00".
+  - Test: `_pill_for_metric("thunder", ...)` mit einer Fixture, deren
+    Tagesfenster-Datenpunkte via echter Anreicherung nur CAPE oberhalb der
+    Leiter tragen; Assertion auf den Teilstring „· CAPE" im zurueckgegebenen
+    Pillentext.
+
+- **AC-2:** Given die Kommando-Timeline eines Wegpunkts zeigt eine
+  Gewitterstufe, die ausschliesslich ueber eine Zutat zustande kommt, When der
+  Nutzer TODAY/TOMORROW sendet, Then zeigt die Wegpunkt-Zeile „⛈ leicht ·
+  CAPE" statt nur „⛈ leicht".
+  - Test: `_fmt_timeline()` mit einer Timeline-Fixture, deren Wegpunkt am
+    Zieltag ein `SegmentWeatherSummary` mit `thunder_level_max_signals =
+    ["cape"]` traegt; Assertion auf den Teilstring „· CAPE" in der
+    zurueckgegebenen Zeile dieses Wegpunkts.
+
+- **AC-3 (abgeloeste Entscheidung):** Given die GLANCE-Antwort zeigt eine
+  Tages-Gewitterstufe, die ausschliesslich ueber eine Zutat zustande kommt,
+  When der Nutzer GLANCE sendet, Then zeigt die Zeile „⛈ Gewitter: leicht ·
+  CAPE" statt — wie bis einschliesslich Scheibe 2 — nur „⛈ Gewitter: leicht".
+  Diese Scheibe hebt die in Scheibe 2 getroffene Entscheidung „GLANCE bleibt
+  zeichengleich" ausdruecklich auf.
+  - Test: `_fmt_day_agg()`/`_fmt_glance()` mit derselben Timeline-Fixture wie
+    AC-4 aus Scheibe 2 (zwei Wegpunkte desselben Tages, unterschiedliche
+    Zutaten auf derselben Hoechststufe); Assertion, dass die GLANCE-Zeile
+    (anders als der Scheibe-2-Bestandstest es fuer GLANCE forderte) NUN den
+    Teilstring „· CAPE" bzw. „· Blitzpotenzial" enthaelt.
+
+- **AC-4:** Given ein Ort im Ortsvergleich zeigt in der Stundentabelle eine
+  Gewitterstufe, die ausschliesslich ueber eine Zutat zustande kommt, When die
+  Vergleichsmail (HTML) bzw. der Klartext-Teil derselben Mail gerendert wird,
+  Then zeigt die Stundenzelle „leicht · CAPE" statt nur „leicht" — an BEIDEN
+  Stellen (HTML und Klartext) derselben Mail.
+  - Test: `render_compare_email()` mit einer Fixture, deren `hourly_data`
+    genau einen Datenpunkt mit `thunder_level=LOW`,
+    `thunder_level_signals=["cape"]` enthaelt; Assertion auf den Teilstring
+    „· CAPE" sowohl im `html_body` (Stundentabellen-Zelle) als auch im
+    `text_body` (Klartext-Stundenzeile).
+
+- **AC-5:** Given innerhalb einer Stunde tragen zwei Zutaten gemeinsam die
+  Hoechststufe (z. B. CAPE UND Blitzpotenzial erreichen beide „hoch"), When
+  die Pille gerendert wird, Then werden BEIDE in der Katalogreihenfolge aus
+  `THUNDER_SIGNAL_LABEL_DE` genannt („· CAPE, Blitzpotenzial") — kein Gewinner
+  wird gekuert.
+  - Test: Fixture mit einem Tagesfenster-Datenpunkt, dessen CAPE- und
+    LPI-Rohwerte beide auf die Hoechststufe fuehren; Assertion auf beide
+    Labels in dieser Reihenfolge im Pillentext.
+
+- **AC-6:** Given zwei Stunden desselben Tagesfensters erreichen die
+  Hoechststufe der Pille ueber verschiedene Zutaten (14 Uhr CAPE, 17 Uhr
+  Blitzpotenzial, beide „hoch"), When die Pille gerendert wird, Then nennt sie
+  BEIDE Zutaten, nicht nur die der zeitlich ersten oder der Spitzenstunde.
+  - Test: `_pill_for_metric("thunder", ...)` mit einer `all_dps`-Fixture aus
+    zwei Datenpunkten mit identischer Hoechststufe, aber verschiedenen
+    `thunder_level_signals`; Assertion auf beide Labels im Pillentext.
+
+- **AC-7:** Given zwei Wegpunkte desselben Kalendertags erreichen die
+  Tages-Hoechststufe von GLANCE ueber verschiedene Zutaten, When der Nutzer
+  GLANCE sendet, Then nennt die Zeile BEIDE Zutaten, nicht nur die des
+  zeitlich ersten Wegpunkts.
+  - Test: `_aggregate_day()`/`_fmt_day_agg()` mit einer Timeline-Fixture aus
+    zwei Wegpunkten desselben `target_date` — Wegpunkt A nur CAPE, Wegpunkt B
+    nur Blitzpotenzial, beide auf derselben Hoechststufe; Assertion auf beide
+    Labels in der GLANCE-Zeile.
+
+- **AC-8 (Kohaerenz Pille):** Given die Pille berechnet Stufe UND Herkunft aus
+  DERSELBEN Tagesfenster-Liste (kein zweiter, unabhaengiger Datenzugriff),
+  When eine zusaetzliche Stunde AUSSERHALB dieses Fensters eine dritte,
+  abweichende Zutat traegt, Then erscheint diese dritte Zutat NICHT in der
+  Pille.
+  - Test: `_pill_for_metric("thunder", ...)` direkt mit einer `all_dps`-Liste
+    aufgerufen, die bewusst NICHT alle Rohdaten des Tages enthaelt (eine
+    dritte Zutat existiert nur ausserhalb der uebergebenen Liste); Assertion,
+    dass der Pillentext nur Zutaten aus der uebergebenen Liste nennt.
+
+- **AC-9 (Kohaerenz Stundentabelle):** Given zwei benachbarte Stunden
+  desselben Ortes tragen ihre jeweilige Stufe ueber verschiedene Zutaten, When
+  die Stundentabelle gerendert wird, Then zeigt JEDE Stundenzeile
+  ausschliesslich die Zutat(en) IHRES EIGENEN Datenpunkts — keine Vermischung
+  zwischen benachbarten Zeilen.
+  - Test: `_render_hour_row()`/die Klartext-Schleife mit zwei aufeinander
+    folgenden `dp`s, deren `thunder_level_signals` sich unterscheiden (z. B.
+    Stunde A nur CAPE, Stunde B nur Blitzdichte); Assertion, dass Zeile A nur
+    „CAPE" und Zeile B nur „Blitzdichte" zeigt, nie beide in derselben Zeile.
+
+- **AC-10 (Kohaerenz Timeline):** Given zwei Wegpunkte desselben Tages tragen
+  ihre jeweilige Stufe ueber verschiedene Zutaten, When die Timeline gerendert
+  wird, Then zeigt JEDE Wegpunkt-Zeile ausschliesslich die Zutat(en) IHRES
+  EIGENEN Segment-Aggregats — keine Vermischung zwischen Wegpunkten.
+  - Test: `_fmt_timeline()` mit zwei Wegpunkten, deren
+    `thunder_level_max_signals` sich unterscheiden; Assertion, dass jede Zeile
+    nur die Zutat(en) ihres eigenen Wegpunkts nennt.
+
+- **AC-11 (Kohaerenz GLANCE):** Given `_aggregate_day()` berechnet Stufe UND
+  Herkunft von GLANCE aus derselben, nach `target_date` gefilterten
+  Wegpunktliste, When ein Wegpunkt eines ANDEREN Kalendertags eine dritte,
+  abweichende Zutat traegt, Then erscheint diese dritte Zutat NICHT in der
+  GLANCE-Zeile.
+  - Test: Timeline-Fixture mit einem Wegpunkt ausserhalb `target_date`, der
+    eine dritte Zutat traegt; Assertion, dass die GLANCE-Zeile nur Zutaten von
+    Wegpunkten DES Zieltags nennt.
+
+- **AC-12 (kein Leck Compare-SMS/Telegram):** Given die Ortsvergleich-
+  Stundentabelle zeigt an mindestens einem Ort eine Herkunft, When derselbe
+  Vergleich als SMS oder als Telegram-Nachricht gerendert wird, Then enthaelt
+  weder `render_compare_sms()` noch `render_compare_telegram()` irgendeine der
+  vier Zutat-Bezeichnungen — beide Kanaele zeigen weiterhin ausschliesslich
+  die Uebersichtszeile (kein Zugriff auf die Stundentabellen-Aufrufstellen
+  dieser Scheibe).
+  - Test: dieselbe Fixture wie AC-4, zusaetzlich durch `render_compare_sms()`
+    und `render_compare_telegram()` gerendert; Assertion, dass keiner der
+    beiden Texte „CAPE", „Blitzpotenzial", „Blitzdichte" oder „Wettercode"
+    enthaelt.
+
+- **AC-13 (kein Leck Trip-SMS/Premium-SMS):** Given die Pille und die
+  GLANCE-Zeile tragen Herkunftsangaben, die in `email_plain` landen, When der
+  Trip-Bericht versendet wird, Then enthaelt weder `report.sms_text` noch —
+  ueber den Rueckfallweg `sms_text or email_plain` — die tatsaechlich
+  zugestellte SMS/Premium-SMS irgendeine der vier Zutat-Bezeichnungen; die
+  Gewitterstufe selbst bleibt dort unveraendert sichtbar, und `report.sms_text`
+  ist nicht-leer (belegt, dass der Rueckfall auf `email_plain` strukturell
+  nicht greift, analog Scheibe 2 AC-8/#868).
+  - Test: `TripReportFormatter` mit einer Fixture, deren Pillen-/GLANCE-Text
+    eine Herkunft ausloesen wuerde; Assertion, dass `report.sms_text` weder
+    „CAPE" noch „Blitzpotenzial" noch „Blitzdichte" noch „Wettercode" enthaelt
+    UND dass `report.sms_text` nicht-leer ist.
+
+- **AC-14 (S1-Uebersichtszeile bleibt unveraendert):** Given die
+  Ortsvergleich-Uebersichtszeile (Tagesuebersicht, nicht die Stundentabelle)
+  zeigte vor dieser Scheibe bereits eine Herkunft (Scheibe 1), When diese
+  Scheibe ausgeliefert ist, Then bleibt der Text der Uebersichtszeile
+  fuer eine unveraenderte Fixture zeichengleich — die Aenderung an den
+  Stundentabellen-Aufrufstellen (D4) veraendert NICHT den Rumpf von
+  `_fmt_thunder()` und wirkt sich damit nicht auf `_render_overview_row()`
+  (`compare_html.py`, unveraenderte Aufrufstelle) oder die Klartext-
+  Uebersichtszeile (`comparison.py:248`, unveraenderte Aufrufstelle) aus.
+  - Test: Golden-Text-Vergleich der Uebersichtszeile mit derselben Fixture wie
+    ein Bestandstest aus Scheibe 1, vor und nach dieser Scheibe identisch.
+
+- **AC-15 (keine Aussage bleibt keine Aussage):** Given ein bereits
+  gespeicherter Wetter-Schnappschuss OHNE das Feld
+  `thunder_level_max_signals` (Alt-Snapshot vor Scheibe 1/2) wird fuer die
+  Kommando-Timeline geladen, When der Nutzer TODAY/TOMORROW sendet, Then zeigt
+  die Wegpunkt-Zeile die Gewitterstufe unveraendert, aber OHNE
+  Herkunfts-Zusatz — kein „unbekannt", kein leerer Trenner, kein Fehler.
+  - Test: `WeatherSnapshotService.load()` mit einem Dict ohne den Schluessel
+    deserialisiert; `_fmt_timeline()` mit der daraus entstehenden Timeline
+    aufgerufen; Assertion, dass die Stufe erscheint und kein „·" nach dem
+    Stufenwort folgt.
+
+- **AC-16 (Zeichengleichheit ohne Herkunft):** Given eine Stunde bzw. ein Tag
+  zeigt „kein" Gewitter (keine Zutat erreicht eine Stufe ueber NONE), When
+  Pille, Timeline, GLANCE-Zeile und Stundentabelle gerendert werden, Then
+  bleibt die Ausgabe an ALLEN VIER Orten zeichengleich zu vor dieser Scheibe —
+  kein Herkunfts-Zusatz. Besonders zu pruefen: GLANCE, weil diese Scheibe dort
+  erstmals ueberhaupt Herkunft anzeigt (AC-3) — die NONE-Zeichengleichheit
+  darf davon nicht beruehrt sein.
+  - Test: Fixture ohne jedes Gewittersignal; Assertion, dass
+    `_pill_for_metric()`, `_fmt_timeline()`, `_fmt_day_agg()`/`_fmt_glance()`
+    und `_render_hour_row()`/die Klartext-Zeile textuell unveraendert zu den
+    jeweiligen Bestandsfixtures aus Scheibe 1/2 bleiben.
+
+## Testplan
+
+**Kern-Schicht** (deterministisch, ohne Netz, echte Fusions-/Aggregations-
+/Renderpfade — kein Mock-Theater): keine neue Testdatei. Erweitert werden die
+beiden bestehenden, nach Verhalten benannten Module:
+
+- `tests/tdd/test_thunder_origin_trip.py` (Vorbild Scheibe 2) deckt AC-1, AC-2,
+  AC-3, AC-5, AC-6, AC-7, AC-8, AC-10, AC-11, AC-13, AC-15, AC-16 (Trip-Teile)
+  ueber die echten Funktionen (`_pill_for_metric`, `_fmt_timeline`,
+  `_fmt_day_agg`/`_fmt_glance`, `WeatherSnapshotService.load`,
+  `TripReportFormatter`).
+- `tests/tdd/test_thunder_origin_compare.py` (Vorbild Scheibe 1) deckt AC-4,
+  AC-9, AC-12, AC-14, AC-16 (Compare-Teil) ueber die echten Funktionen
+  (`render_compare_email`, `render_compare_sms`, `render_compare_telegram`).
+
+**Pruefort=Wirkort, ohne Ausnahme:** jeder AC laeuft mindestens einmal durch
+die vollstaendige Kette bis zum zurueckgegebenen Mail-/Kommando-Text — keine
+Isolation auf `union_of_max_carriers()` allein.
+
+### Pflicht-Mutationsproben (mindestens 3, hier 6)
+
+- **(a) Pille: Vereinigung durch „nur der Datenpunkt der Spitzenstunde"
+  ersetzen** (`traeger = peak_dp.thunder_level_signals` statt
+  `union_of_max_carriers(...)` ueber `all_dps`) ⇒ AC-6 MUSS rot werden — zwei
+  Stunden mit unterschiedlicher Zutat auf derselben Hoechststufe zeigten dann
+  nur die Zutat der zeitlich letzten/staerksten Stunde.
+- **(b) GLANCE: den neuen Lesezugriff `agg.get("thunder_signals")` wieder
+  entfernen** (Rueckbau auf den Scheibe-2-Stand) ⇒ AC-3 MUSS rot werden — das
+  ist die zentrale Gegenprobe der in dieser Scheibe abgeloesten Entscheidung.
+- **(c) Compare-HTML: den dritten Parameter am `_render_hour_row()`-Aufruf
+  wieder entfernen** (Rueckbau auf `m["fmt"](value, getattr(dp, "hail_flag",
+  None))`) ⇒ AC-4s HTML-Teilassertion MUSS rot werden.
+- **(d) Compare-Klartext: denselben dritten Parameter in der Stundenschleife
+  von `render_comparison_text()` entfernen** ⇒ AC-4s Klartext-Teilassertion
+  MUSS rot werden — beweist, dass HTML und Klartext unabhaengig voneinander
+  geprueft werden, nicht nur einer der beiden Pfade.
+- **(e) Timeline: `m.thunder_level_max_signals` durch eine EINMAL ausserhalb
+  der Schleife berechnete Traegerliste des ERSTEN Wegpunkts ersetzen** (jede
+  Zeile zeigt dieselbe, globale Liste) ⇒ AC-10 MUSS rot werden.
+- **(f) Compare-SMS: `_sms_metric_cell()` probeweise so umbauen, dass die
+  Gewitter-Zelle ueber dieselbe Aufrufstelle wie die Stundentabelle (mit
+  `signals`) statt ueber `_fmt_overview_cell(..., include_origin=False)`
+  gebaut wird** (simuliert einen versehentlichen Wiederverwendungs-Bug) ⇒
+  AC-12 MUSS rot werden — das ist die aktive Gegenprobe zur PO-Vorgabe „SMS
+  aktiv abgewaehlt, nicht nur strukturell unerreichbar".
+
+Mutationen ausschliesslich per String-Ersetzung mit externer Sicherungskopie
+(kein `git checkout`/`stash`/`reset`, CLAUDE.md-Vorgabe).
+
+## Known Limitations
+
+1. **`sdi_2` (Superzellen) bleibt aussen vor.** Die Fusion hat vier, nicht
+   fuenf Zutaten — unveraendert seit Scheibe 1 (dort Known Limitation 1).
+2. **EU_REST-LPI ist ein ausgewiesener Interim-Wert** (unbelegte Schwelle,
+   Feineichung offen als #1678, ADR-0048). Unveraendert seit Scheibe 1 (dort
+   Known Limitation 2).
+3. **`aggregate_stage()` bleibt unangeschlossen.** Gemessen (vollstaendige
+   Konsumentenanalyse, Kontextdokument): `stage_weather.py:112` liest die
+   Traegerliste nicht (nur Temperatur/Wind/Niederschlag/Wettercode);
+   `compact_summary.py:268` (`_aggregate()`) rechnet den Gewittertext bewusst
+   daneben, direkt ueber die Stundenwerte mit eigenem
+   `union_of_max_carriers()`-Aufruf (`:628`); `trip_report_scheduler.py:2026`
+   (Mehrtages-Ausblick) waere der erste ECHTE Verbraucher, liest heute aber
+   nur `agg.thunder_level_max`. Keiner der vier Orte dieser Scheibe aktiviert
+   den generischen `else`-Zweig (`weather_metrics.py:1265-1266`, liefert
+   `values[0]`). Known Limitation 7 aus Scheibe 1 bleibt bestehen und gehoert
+   in die Ausblick-Scheibe.
+4. **Mehrtages-Ausblick, Trip-Stundentabelle und Gewitter-Vorschau bleiben
+   ohne Herkunft.** Beim Ausblick gehen die Traeger strukturell verloren:
+   `HourlyValue` (`src/output/tokens/dto.py:15-18`) ist ein frozen Dataclass
+   mit nur `hour` und `value` — dazu Tag-/Nacht-Split (#1653). Die
+   Trip-Stundentabelle braucht erst einen Seitenkanal analog
+   `row["_hail_flag"]` (`trip_report.py:687`) plus Auswertung in `fmt_val()`
+   (`helpers.py:732-757`); zusaetzlich rechnet `_aggregate_night_block()`
+   (`trip_report.py:596-601`) ohne Traegerlogik. Beide sind eigene, nicht
+   diese Scheibe.
+5. **Go-DTO und Frontend bleiben ERSATZLOS, nicht aufgeschoben.**
+   `model.SegmentWeatherSummary` (`internal/model/segment.go:15`, Feld
+   `ThunderLevelMax`) wird in `internal/` nirgends konstruiert oder gelesen —
+   kein Feld dort haette einen Verbraucher. `CompareMetrics`
+   (`frontend/src/lib/types.ts:426-440`) wird ausserhalb von `types.ts` nicht
+   referenziert; keine Svelte-Komponente rendert eine live abgerufene
+   Gewitterstufe.
+6. **GLANCE-, GEWITTER- und TIMELINE-Kommando erreichen weiterhin
+   ausschliesslich E-Mail und Telegram — strukturell unveraendert seit
+   Scheibe 2.** `InboundMessage` hat genau zwei Erzeuger
+   (`inbound_email_reader.py`, `inbound_telegram_reader.py`); es gibt keinen
+   SMS-/Premium-SMS-Kommandopfad. Die neu sichtbare Herkunft in Timeline und
+   GLANCE erreicht damit strukturell nur die zwei PO-freigegebenen Kanaele,
+   ohne eigene Kanal-Unterscheidung im Code. Die Doku-Drift am Docstring
+   `trip_command_processor.py:44` (`channel: str  # "email" or "sms"`) bleibt
+   unveraendert offen — nicht Teil dieser Scheibe (nur die zwei explizit in
+   Implementation Details genannten Kommentare werden korrigiert).
+7. **`renderer_mail_gate.py` deckt `comparison.py` und
+   `trip_command_processor.py` GEMESSEN NICHT ab** (s. Dependencies). Der
+   einzige Commit-Gate-Schutz fuer diese beiden Dateien in dieser Scheibe ist
+   `touched_tests_gate.py` (#1481 A) — kein Mail-Validator-Zwang.
+8. **Restrisiko am SMS-Rueckfallausdruck bleibt bestehen** (unveraendert seit
+   Scheibe 2 Known Limitation 5), jetzt mit erweitertem Leck-Potenzial: die
+   Pille und die GLANCE-Zeile tragen ab dieser Scheibe zusaetzlichen
+   Herkunftstext in `email_plain`, der ueber `sms_text or email_plain`
+   (`notification_service.py:428`/`446`) durchreichen wuerde, wenn
+   `sms_text` je leer wuerde. Bewacht durch AC-13 und Mutationsprobe-Analogie
+   zu Scheibe 2 (d).
+9. **`_deserialize_timeseries()` filtert unbekannte Schluessel nicht**
+   (`weather_snapshot.py:301-324`). Unveraendert seit Scheibe 1 (dort Known
+   Limitation 5) — unkritisch fuer additive Aenderungen.
+
+## Nicht in dieser Scheibe
+
+- **Mehrtages-Ausblick** (`email/outlook.py`) — s. Known Limitations 4.
+- **Trip-Stundentabelle** (`trip_report.py:597-601`, `email/html.py:814-825`)
+  — s. Known Limitations 4.
+- **Gewitter-Vorschau** (`email/html.py:1307-1329`, `email/plain.py:307-332`)
+  — Primaerpfad liest dieselben traegerlosen `HourlyValue`s wie der Ausblick;
+  gehoert zur Ausblick-Scheibe.
+- **`aggregate_stage()`s Dispatch-Zweig fuer `union_of_max_carriers`** — s.
+  Known Limitations 3. Der geteilte Helfer steht bereit; der Anschluss ist ein
+  Dreizeiler (analog D1-D3 dieser Spec), gehoert aber in die Scheibe, die den
+  Mehrtages-Ausblick bringt (dort der erste echte Verbraucher).
+- **Go-DTO und Frontend** — s. Known Limitations 5, ersatzlos.
+- **Risiko-Badges der RiskEngine** (`trip_report.py:902-908`) — eigene Skala
+  (`RiskLevel`, nicht `ThunderLevel`), unveraendert seit Scheibe 2.
+- **Alarm-Renderer** (`alert/render.py:39-53,324-390`) — gibt die rohe
+  Ordinalzahl 0-3 aus, keine Wortdarstellung, unveraendert seit Scheibe 2.
+- **Fuenfte Fusions-Zutat, Superzellen (`sdi_2`)** — s. Known Limitations 1.
+- **Doku-Drift am `InboundMessage`-Docstring** (`trip_command_processor.py:44`)
+  — s. Known Limitations 6, bleibt bewusst offen fuer eine spaetere,
+  eigenstaendige Doku-Korrektur.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine (neue) — diese Scheibe wendet ADR-0007 (Daten statt
+  Empfehlungen), ADR-0025 (eine Gewitter-Quelle fuer alle Kanaele) und
+  ADR-0048 (unbekannte/ungeeichte Herkunft = keine Aussage) an, ohne eine
+  davon zu aendern.
+- **Rationale:** Additive Sichtbarmachung einer bereits vorhandenen internen
+  Groesse (welche Zutat trug) an vier weiteren Ausgabeorten ueber bereits
+  bestehende Felder und einen bereits bestehenden geteilten Helfer
+  (`union_of_max_carriers()`, Scheibe 2) — kein neues Architekturprinzip,
+  keine neue Datenquelle, kein neuer Kanal, keine neue Persistenz-Strategie.
+  Das Aufheben zweier fruehererer Tech-Lead-/PO-Entscheidungen (GLANCE,
+  Compare-Stundentabelle) ist eine Produktentscheidung ueber den Umfang, keine
+  Architekturaenderung — beide betroffenen Stellen nutzen weiterhin denselben
+  geteilten Fusionsweg (ADR-0025), nur die Sichtbarkeits-Schranke faellt.
+  Kein Bezug zu ADR-0034 (Herkunfts-Fusszeile/Datenquelle) — andere Dimension,
+  s. Scheibe 1s Architektur-Entscheidung fuer die Abgrenzung.
+
+## Changelog
+
+- 2026-08-13: Initial spec created (Issue #1680, Scheibe 3). Grundlage:
+  `docs/context/feat-1680-s3-herkunft-vier-orte.md`, PO-Entscheid zum Umfang
+  der Scheibe (vier Ausgabeorte) vom 2026-08-13, inklusive der ausdruecklichen
+  Aufhebung zweier fruehererer Entscheidungen (Scheibe 2: GLANCE bleibt
+  zeichengleich; Scheibe 1 AC-11: Compare-Stundentabelle bleibt unveraendert).
+  Am Code nachgemessene Korrektur gegenueber der Aufgabenbeschreibung: der
+  Rueckfallausdruck `sms_text or email_plain` in `notification_service.py`
+  steht bei Messung (2026-08-13) auf Zeile 428 (SMS) bzw. 446 (Premium-SMS),
+  nicht auf „417,433" (das waren die erklaerenden Kommentarzeilen aus
+  Scheibe 2, seither verschoben). `renderer_mail_gate.py` deckt gemessen
+  `comparison.py` und `trip_command_processor.py` nicht ab — als Known
+  Limitation 7 aufgenommen.

--- a/src/output/renderers/comparison.py
+++ b/src/output/renderers/comparison.py
@@ -327,9 +327,19 @@ def render_comparison_text(
                     # Compare-Stundentabelle): Hagel als Text-Anhang, wie in
                     # der HTML-Fassung -- nie als Ring (das ist nur Trip).
                     if m["fmt"] is _fmt_thunder:
+                        # Issue #1680 S3 (Spec D4): die Herkunft der Stufe
+                        # DIESER Stunde, wie in der HTML-Fassung -- HTML und
+                        # Klartext derselben Mail haben zwei unabhaengige
+                        # Aufrufstellen und duerfen nicht auseinanderlaufen
+                        # (AC-4). Stufe und Traeger stammen aus DEMSELBEN `dp`.
+                        # KANAL: die Compare-SMS erreicht diese Schleife nie --
+                        # sie baut ihre Zelle ueber `_sms_metric_cell()` ->
+                        # `_fmt_overview_cell(..., include_origin=False)`
+                        # (PO-Entscheidung, dort aktiv abgewaehlt).
                         text = m["fmt"](
                             getattr(dp, m["key"], None),
                             getattr(dp, "hail_flag", None),
+                            getattr(dp, "thunder_level_signals", None),
                         )
                     else:
                         text = m["fmt"](getattr(dp, m["key"], None))

--- a/src/output/renderers/email/compare_html.py
+++ b/src/output/renderers/email/compare_html.py
@@ -214,10 +214,19 @@ def _fmt_thunder(
 
     Issue #1680 S1: ``signals`` (die tragenden Zutaten der Stufe) ist aus
     demselben Grund ein DRITTER Parameter mit Default ``None`` und steht VOR
-    dem Hagel-Hinweis. 🔴 Der Zusatz gehoert bewusst NICHT in den Rumpf: diese
-    Funktion speist ueber ``_HOUR_FMT_OVERRIDES["thunder"]`` AUCH die
-    Compare-Stundentabelle, die in dieser Scheibe unveraendert bleibt (AC-11)
-    -- sie ruft ohne dritten Parameter und bleibt damit zeichengleich.
+    dem Hagel-Hinweis. 🔴 Der Zusatz gehoert weiterhin bewusst NICHT in den
+    Rumpf, sondern bleibt an der AUFRUFSTELLE: diese Funktion speist ueber
+    ``_HOUR_FMT_OVERRIDES["thunder"]`` AUCH die Compare-Stundentabelle, und
+    jede Stundenzeile muss die Zutat IHRES EIGENEN Datenpunkts nennen (S3
+    AC-9) -- ein Rumpf-Zusatz koennte das gar nicht unterscheiden und wuerde
+    zugleich die Uebersichtszeile mitveraendern (S3 AC-14).
+
+    Issue #1680 S3: die Compare-Stundentabelle uebergibt den dritten Parameter
+    ab jetzt (``_render_hour_row()`` unten, Klartext-Pendant
+    ``comparison.render_comparison_text()``). Der Scheibe-1-Entscheid "die
+    Stundentabelle bleibt unveraendert" (dortiges AC-11) ist mit PO-Entscheid
+    vom 2026-08-13 abgeloest -- der Satz oben stand bis dahin hier und
+    behauptete das Gegenteil des heutigen Codes.
     """
     if v is None:
         return "—"
@@ -980,7 +989,19 @@ def _render_hour_row(
         # (das ist ausschliesslich die Trip-Stundentabelle, Punkt 2). `dp` ist
         # hier bereits im Scope, analog zum Windrichtungs-Muster unten.
         if m["fmt"] is _fmt_thunder:
-            text = m["fmt"](value, getattr(dp, "hail_flag", None))
+            # Issue #1680 S3 (Spec D4): die Herkunft der Stufe DIESER Stunde --
+            # `value` (`dp.thunder_level`) und `dp.thunder_level_signals`
+            # stammen aus DEMSELBEN Datenpunkt, kein zweiter Rechenweg (AC-9).
+            # Die Uebergabe sitzt hier an der Aufrufstelle, NICHT im Rumpf von
+            # `_fmt_thunder()` -- der speist auch die Uebersichtszeile, die
+            # zeichengleich bleiben muss (AC-14). `getattr`, weil Alt-Daten
+            # ohne das Feld die Zelle unveraendert lassen sollen.
+            # KANAL: die Compare-SMS baut ihre Zelle ueber
+            # `comparison._sms_metric_cell()` -> `_fmt_overview_cell(...,
+            # include_origin=False)` und erreicht diese Aufrufstelle nie
+            # (PO-Entscheidung, aktiv abgewaehlt -- s. dortigen Kommentar).
+            text = m["fmt"](value, getattr(dp, "hail_flag", None),
+                            getattr(dp, "thunder_level_signals", None))
         else:
             text = m["fmt"](value)
         # Issue #1335 Scheibe 1 (AC-3): Windrichtung als Kompass-Text an die

--- a/src/output/renderers/email/helpers.py
+++ b/src/output/renderers/email/helpers.py
@@ -1740,16 +1740,38 @@ def _pill_for_metric(
         # zeichengleich zum bisherigen Stand (kein Rauschen, Spec AC-5).
         # Call-time-Import auf den EINEN geteilten Textbaustein (#1481 DRY) --
         # denselben, den `_fmt_gewitter()` nutzt.
-        from output.metric_format import format_hail_note, hail_priority
+        from output.metric_format import (
+            format_hail_note, hail_priority, thunder_signal_label,
+            union_of_max_carriers,
+        )
         _hail_note = format_hail_note(
             hail_priority([getattr(dp, "hail_flag", None) for dp in all_dps])
         )
         _hail_suffix = f" · {_hail_note}" if _hail_note else ""
+        # Issue #1680 S3 (Spec D1): die tragende(n) Zutat(en) DERSELBEN
+        # Tagesfenster-Liste, aus der oben `max_lvl` entstand -- Stufe und
+        # Herkunft aus EINER Rechnung, ohne zweiten Datenzugriff (AC-8). Der
+        # geteilte Helfer statt einer weiteren Eigenimplementierung derselben
+        # Vereinigungsregel (#1480); er garantiert selbst, dass die Stufe
+        # `NONE` auf `None` fuehrt ("kein Gewitter" hat keine Herkunft).
+        # KANAL (PO-Entscheidung, aktiv abgewaehlt -- kein vergessener
+        # Anschluss): die Pille erreicht ausschliesslich E-Mail
+        # (`plain.py:205`, `html.py:1432`, `compact.py:176`). SMS und
+        # Premium-SMS bauen ihren Text ueber `SMSTripFormatter`
+        # (`trip_report.py:441`) und sehen diese Zeichen nie; der Rueckfall
+        # `sms_text or email_plain` (`notification_service.py:428`/`446`)
+        # bleibt der einzige theoretische Weg und ist per AC-13 bewacht.
+        _traeger = union_of_max_carriers(
+            [(dp.thunder_level, getattr(dp, "thunder_level_signals", None))
+             for dp in all_dps]
+        )
+        _herkunft = ", ".join(thunder_signal_label(n) for n in _traeger or [])
+        _origin_suffix = f" · {_herkunft}" if _herkunft else ""
         if first_thunder_ts is not None:
             first_hh = local_hour(first_thunder_ts, tz)
             peak_hh = local_hour(peak_ts or first_thunder_ts, tz)
             return (f"Gewitter ab {first_hh:02d}:00 · stärkste {peak_hh:02d}:00"
-                    f"{_hail_suffix}", "ampel_red")
+                    f"{_origin_suffix}{_hail_suffix}", "ampel_red")
         # Issue #1331: Ziel-Datenluecke (Ankunft->19 Uhr unbeobachtet) darf
         # keine positive Entwarnung "kein Gewitter" vortaeuschen.
         if has_gap:

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -420,6 +420,11 @@ class NotificationService:
         # Unmoeglichkeit. Bewacht wird er am erzeugten Text (Spec AC-8:
         # `sms_text` nicht-leer UND ohne jede Zutat-Bezeichnung), nicht durch
         # die Annahme, er sei unerreichbar.
+        # Issue #1680 S3 (Nachtrag, weiterhin keine Logikaenderung): seit
+        # dieser Scheibe tragen AUCH die Gewitter-Pille des Metriken-
+        # Ueberblicks und die GLANCE-Tageszeile eine Herkunft, die in
+        # `email_plain` landet -- der Rueckfall unten ist damit derselbe
+        # Weg fuer mehr Inhalt, nicht fuer einen neuen.
         telegram_fully_sent = True
         if request.send_sms and self._settings.can_send_sms():
             try:

--- a/src/services/trip_command_processor.py
+++ b/src/services/trip_command_processor.py
@@ -829,8 +829,11 @@ class TripCommandProcessor:
         # tragen -- ueber DIESELBE, nach `target_date` gefilterte Wegpunkt-
         # liste (Stufe und Herkunft aus EINER Rechnung, Spec D6). Der geteilte
         # Helfer statt einer dritten Eigenimplementierung derselben Regel
-        # (#1480). Nur `_fmt_gewitter()` liest den Schluessel; `_fmt_day_agg()`
-        # /GLANCE bleibt bewusst zeichengleich (Spec D3, Known Limitation 4).
+        # (#1480). Issue #1680 S3: `_fmt_day_agg()`/GLANCE liest den Schluessel
+        # jetzt EBENFALLS (Spec D3) -- der Scheibe-2-Entscheid "GLANCE bleibt
+        # bewusst zeichengleich" (dortige D3, Known Limitation 4) ist mit
+        # PO-Entscheid vom 2026-08-13 abgeloest. Verbraucher sind damit
+        # `_fmt_gewitter()` UND `_fmt_day_agg()`.
         from output.metric_format import union_of_max_carriers
         thunder_signals = union_of_max_carriers(
             [(p.metrics.thunder_level_max,
@@ -847,6 +850,22 @@ class TripCommandProcessor:
         t_min = f"{agg['temp_min']:.0f}" if agg['temp_min'] is not None else "?"
         wind = f"{agg['wind_max']:.0f}" if agg['wind_max'] is not None else "?"
         thunder_label = _THUNDER_LABEL.get(agg['thunder'].value if agg['thunder'] else "NONE", "?")
+        # Issue #1680 S3 (Spec D3, abgeloeste Entscheidung): die tragende(n)
+        # Zutat(en) der oben gezeigten Tagesstufe -- aus DEMSELBEN Aggregat,
+        # das auch `agg['thunder']` traegt (`_aggregate_day()`, EINE Rechnung
+        # ueber die nach `target_date` gefilterte Wegpunktliste, AC-11). Ohne
+        # Traeger (kein Gewitter, Alt-Schnappschuss ohne das Feld) bleibt die
+        # Zeile zeichengleich zu bisher (AC-16). Denselben Schluessel und
+        # denselben Textbaustein nutzt `_fmt_gewitter()` -- keine zweite
+        # Formulierung. KANAL: GLANCE erreicht ausschliesslich E-Mail und
+        # Telegram (`InboundMessage` hat genau diese zwei Erzeuger); einen
+        # SMS-/Premium-SMS-Kommandopfad gibt es nicht, die PO-Abwahl "SMS ohne
+        # Herkunft" greift hier strukturell.
+        from output.metric_format import thunder_signal_label
+        _traeger = agg.get("thunder_signals")
+        _herkunft = ", ".join(thunder_signal_label(n) for n in _traeger or [])
+        if _herkunft:
+            thunder_label = f"{thunder_label} · {_herkunft}"
         precip = f"{agg['precip']:.1f}" if agg.get('precip') else "0.0"
         return (
             f"{label}: 🌡 {t_min}–{t_max}°C  💨 {wind} km/h  "
@@ -932,6 +951,22 @@ class TripCommandProcessor:
             precip = f"{m.precip_sum_mm:.1f}" if m.precip_sum_mm is not None else "0.0"
             thunder = m.thunder_level_max
             t_label = _THUNDER_LABEL.get(thunder.value if thunder else "NONE", "?")
+            # Issue #1680 S3 (Spec D2): die tragende(n) Zutat(en) DIESES
+            # Wegpunkts -- `thunder_level_max` UND `thunder_level_max_signals`
+            # stammen aus DEMSELBEN `m` (`SegmentWeatherSummary`, von
+            # `compute_basis_metrics()` fuer genau dieses eine Segment
+            # gerechnet). Die Liste wird PRO Wegpunkt in der Schleife gelesen,
+            # nie einmal ausserhalb -- sonst zeigte jede Zeile dieselbe,
+            # globale Herkunft (AC-10). `getattr`, weil ein Alt-Schnappschuss
+            # vor Scheibe 1/2 das Feld nicht kennt (AC-15): dann bleibt die
+            # Zeile zeichengleich, ohne "unbekannt" und ohne leeren Trenner.
+            # KANAL: die Timeline erreicht nur E-Mail und Telegram (s. Hinweis
+            # in `_fmt_day_agg()`), SMS/Premium-SMS haben keinen Kommandopfad.
+            from output.metric_format import thunder_signal_label
+            _traeger = getattr(m, "thunder_level_max_signals", None)
+            _herkunft = ", ".join(thunder_signal_label(n) for n in _traeger or [])
+            if _herkunft:
+                t_label = f"{t_label} · {_herkunft}"
             lines.append(
                 f"   🌡 {t_min}–{t_max} °C  💨 {wind} km/h  "
                 f"🌧 {precip} mm  ⛈ {t_label}"

--- a/tests/tdd/test_thunder_origin_compare.py
+++ b/tests/tdd/test_thunder_origin_compare.py
@@ -33,8 +33,10 @@ from providers.thunder_enrichment import _fuse_thunder_levels  # noqa: E402
 from providers.thunder_routing import thunder_region_for  # noqa: E402
 
 # Die vier Zutaten der Fusion (metric_format.thunder_level_from_signals) in
-# ihrer deutschen Beschriftung -- KEINE davon darf im SMS-Kanal oder in einer
-# Stundentabelle auftauchen (AC-5, AC-11).
+# ihrer deutschen Beschriftung -- KEINE davon darf im SMS-Kanal auftauchen
+# (AC-5). Die frueher hier ebenfalls genannte Compare-Stundentabelle (AC-11)
+# zeigt die Herkunft seit Issue #1680 Scheibe 3 sehr wohl -- s. den Docstring
+# von ``test_ac11_trip_stundenzelle_bleibt_ohne_herkunft``.
 ALLE_ZUTATEN = ("Wettercode", "Blitzdichte", "CAPE", "Blitzpotenzial")
 
 _TD = re.compile(r"<td[^>]*>(.*?)</td>", re.S)
@@ -246,22 +248,36 @@ def test_ac10_tagesmaximum_vereinigt_die_zutaten_mehrerer_stunden():
         f"Hoechststufe vereinigen: {_html_zellen(html)[0]!r}")
 
 
-def test_ac11_stundentabellen_bleiben_ohne_herkunft():
-    """AC-11: Given diese Scheibe aendert nur die Ortsvergleich-Tagesuebersicht,
-    When Mail und Trip-Stundenzelle gerendert werden, Then traegt keine
-    Stundentabelle einen Herkunfts-Zusatz -- waehrend die Uebersicht derselben
-    Mail ihn zeigt (Gegenprobe)."""
+def test_ac11_trip_stundenzelle_bleibt_ohne_herkunft():
+    """AC-11 (Trip-Haelfte, weiterhin gueltig): Given diese Scheibe aendert
+    nur die Ortsvergleich-Tagesuebersicht, When die Gewitterzelle der
+    TRIP-Stundentabelle gerendert wird, Then bleibt sie zeichengleich -- kein
+    Herkunfts-Zusatz auf der Trip-Seite.
+
+    Gegenprobe im selben Lauf: die Ortsvergleich-Uebersicht derselben Fixture
+    zeigt die Herkunft sehr wohl -- ohne sie waere die zugesicherte
+    ABWESENHEIT auch dann gruen, wenn die Herkunft nirgends erschiene.
+
+    🔴 Die ZWEITE Haelfte dieses AC ist abgeloest (PO-Entscheid 2026-08-13,
+    Issue #1680 Scheibe 3). Hier stand bis dahin die Zusicherung, dass keine
+    der vier Zutaten im Stundenabschnitt der Vergleichsmail (HTML UND
+    Klartext) auftaucht. Die Compare-Stundentabelle zeigt die Herkunft ab
+    Scheibe 3 SEHR WOHL; die Zusicherung ist damit veraltetes Verhalten und
+    ersatzlos entfallen -- nicht bloss umgedreht, sonst stuende dieselbe
+    Aussage doppelt in zwei Dateien. Den neuen Sollzustand bewacht
+    ``test_thunder_origin_four_places.py``, dort
+    ``test_ac4_stundentabelle_nennt_die_zutat_in_html_und_klartext`` und
+    ``test_ac9_jede_stundenzeile_zeigt_nur_die_zutat_ihres_datenpunkts``.
+    Die TRIP-Stundentabelle bleibt auch in Scheibe 3 ausdruecklich aussen vor
+    (dortige Spec, Abschnitt "Nicht in dieser Scheibe") -- deshalb bleibt
+    diese Haelfte stehen.
+    """
     from output.renderers.email.helpers import fmt_val
 
-    html, text = _mail(*_alpen_und_korsika(), stunden=True)
+    html, _ = _mail(*_alpen_und_korsika())
     assert _html_zellen(html)[0] == "hoch · CAPE", (
         f"Gegenprobe gescheitert: die Tagesuebersicht MUSS die Herkunft "
         f"zeigen: {_html_zellen(html)[0]!r}")
-    for abschnitt in (html.split("STUNDEN", 1)[1], text.split("STUNDENVERLAUF", 1)[1]):
-        for zutat in ALLE_ZUTATEN:
-            assert zutat not in abschnitt, (
-                f"Die Compare-Stundentabelle bleibt in dieser Scheibe "
-                f"unveraendert -- '{zutat}' darf dort nicht auftauchen.")
     assert fmt_val("thunder", ThunderLevel.HIGH, row={"_hail_flag": None}) == "hoch", (
         "Die Gewitterzelle der TRIP-Stundentabelle (email/helpers.fmt_val) "
         "bleibt zeichengleich -- kein Herkunfts-Zusatz auf der Trip-Seite.")

--- a/tests/tdd/test_thunder_origin_four_places.py
+++ b/tests/tdd/test_thunder_origin_four_places.py
@@ -1,0 +1,808 @@
+"""TDD RED — Issue #1680 Scheibe 3: Herkunft der Gewitterstufe an vier
+weiteren Ausgabeorten.
+
+SPEC: docs/specs/modules/feat_1680_s3_gewitter_herkunft_vier_orte.md
+(AC-1 bis AC-16)
+KONTEXT: docs/context/feat-1680-s3-herkunft-vier-orte.md
+
+Die vier Ausgabeorte dieser Scheibe:
+  1. Pille im Metriken-Ueberblick der Trip-Mail
+     (``output.renderers.email.helpers._pill_for_metric``, thunder-Zweig)
+  2. Kommando-Timeline je Wegpunkt
+     (``services.trip_command_processor.TripCommandProcessor._fmt_timeline``)
+  3. GLANCE-Tageszeile (``..._fmt_day_agg``)
+  4. Ortsvergleich-Stundentabelle
+     (``email.compare_html._render_hour_row`` HTML +
+      ``renderers.comparison.render_comparison_text`` Klartext)
+
+RED-Ursache (heute, gemessen 2026-08-13): keiner der vier Orte liest die
+bereits vorhandene Traegerliste.
+  - die Pille baut ihren Text ausschliesslich aus ``dp.thunder_level``
+    (``helpers.py:1713-1757``) und nennt keine Zutat,
+  - ``_fmt_timeline()`` (``trip_command_processor.py:933-937``) liest nur
+    ``m.thunder_level_max``, nicht ``m.thunder_level_max_signals``,
+  - ``_fmt_day_agg()`` (``:844-854``) laesst den seit Scheibe 2 vorhandenen
+    Aggregat-Schluessel ``"thunder_signals"`` bewusst liegen (die dortige
+    Entscheidung hebt der PO mit dieser Scheibe auf),
+  - ``_render_hour_row()`` (``compare_html.py:982-983``) und die
+    Klartext-Stundenschleife (``comparison.py:329-333``) rufen
+    ``_fmt_thunder(value, hail)`` OHNE den seit Scheibe 1 vorhandenen dritten
+    Parameter.
+
+Prueford = Wirkort, ohne Ausnahme: JEDER Test laeuft bis zu dem Text, den der
+Nutzer bekommt -- ``TripReport.email_plain``/``email_html``/``sms_text``,
+``CommandResult.confirmation_body`` aus ``TripCommandProcessor.process()``
+bzw. ``html_body``/``text_body`` aus ``render_compare_email()``. Kein
+Zwischenwert steht stellvertretend fuer einen Text.
+
+Kein Mock-Theater: Stufen und Traegerlisten entstehen ueber die ECHTE Fusion
+(``thunder_enrichment._fuse_thunder_levels`` mit den Leitern aus
+``app.model_registry``) und die ECHTE Aggregation
+(``WeatherMetricsService.compute_basis_metrics``). Der Kommandopfad laeuft
+ueber einen echt gespeicherten und wieder geladenen Wetter-Schnappschuss.
+
+🔴 Abweichung von der Spec bei AC-12 -- s. Docstring von
+``test_ac12_compare_sms_und_telegram_zeigen_keine_stunden_herkunft``.
+"""
+from __future__ import annotations
+
+import html as _html
+import json
+import re
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from app.loader import get_snapshots_dir, save_trip  # noqa: E402
+from app.metric_catalog import build_default_display_config  # noqa: E402
+from app.model_registry import (  # noqa: E402
+    cape_ladder_thresholds_jkg, lpi_thresholds_jkg,
+)
+from app.models import (  # noqa: E402
+    ForecastDataPoint, ForecastMeta, GPXPoint, NormalizedTimeseries, Provider,
+    SegmentWeatherData, ThunderLevel, TripSegment,
+)
+from app.trip import Stage, Trip, Waypoint  # noqa: E402
+from app.user import ComparisonResult, LocationResult, SavedLocation  # noqa: E402
+from output.renderers.comparison import (  # noqa: E402
+    render_compare_email, render_compare_sms, render_compare_telegram,
+)
+from output.renderers.trip_report import TripReportFormatter  # noqa: E402
+from providers.thunder_enrichment import _fuse_thunder_levels  # noqa: E402
+from providers.thunder_routing import thunder_region_for  # noqa: E402
+from services.trip_command_processor import (  # noqa: E402
+    InboundMessage, TripCommandProcessor,
+)
+from services.weather_metrics import WeatherMetricsService  # noqa: E402
+from services.weather_snapshot import WeatherSnapshotService  # noqa: E402
+
+# Die VIER Zutaten der Fusion in ihrer deutschen Beschriftung
+# (``metric_format.THUNDER_SIGNAL_LABEL_DE``). Keine davon darf in der
+# Trip-SMS (AC-13) oder in der Compare-SMS (AC-12) auftauchen.
+ALLE_ZUTATEN = ("Wettercode", "Blitzdichte", "CAPE", "Blitzpotenzial")
+
+_TZ = ZoneInfo("UTC")
+_LAT, _LON, _MODELL = 47.0, 12.0, "icon_d2"   # Gebiet DE_ALPEN
+_ETAPPE = "Test-Etappe"
+_TAG = date(2026, 8, 20)
+
+_TRIP_ID = "herkunft-vier-orte"
+_TRIP_NAME = "Herkunft Vier Orte Tour"
+_USER = "default"
+
+_TD = re.compile(r"<td[^>]*>(.*?)</td>", re.S)
+_TR = re.compile(r"<tr[^>]*>(.*?)</tr>", re.S)
+_TBODY = re.compile(r"<tbody>(.*?)</tbody>", re.S)
+_SPAN = re.compile(r"<span[^>]*>(.*?)</span>", re.S)
+
+
+# ---------------------------------------------------------------------------
+# Trip-Fixturen: Rohwerte rein, echte Rechnung raus
+# ---------------------------------------------------------------------------
+
+def _dp(h: int, *, tag: date = _TAG, cape=None, cin=None, lpi=None,
+        dichte=None) -> ForecastDataPoint:
+    """Ein Stundenpunkt mit ROHWERTEN -- Stufe und Traeger rechnet die Fusion."""
+    return ForecastDataPoint(
+        ts=datetime(tag.year, tag.month, tag.day, h, 0, tzinfo=timezone.utc),
+        t2m_c=20.0, wind10m_kmh=8.0, gust_kmh=12.0, precip_1h_mm=0.0,
+        cloud_total_pct=40, humidity_pct=50,
+        cape_jkg=cape, convective_inhibition_jkg=cin,
+        lightning_potential_lpi_jkg=lpi, lightning_density_per_km2_3h=dichte,
+    )
+
+
+def _reihe(punkte: list[ForecastDataPoint]) -> NormalizedTimeseries:
+    """Zeitreihe, deren Punkte durch die ECHTE Fusion gelaufen sind: Gebiet aus
+    ``thunder_routing``, Leitern aus ``model_registry`` -- keine im Test
+    getippte Schwelle (sonst prueft er eine Welt, die es nicht gibt)."""
+    region = thunder_region_for(_LAT, _LON)
+    _fuse_thunder_levels(
+        punkte, cape_ladder_thresholds_jkg(_MODELL, region),
+        lpi_thresholds_jkg(region),
+    )
+    return NormalizedTimeseries(
+        meta=ForecastMeta(provider=Provider.OPENMETEO, model="test",
+                          grid_res_km=1.0),
+        data=punkte,
+    )
+
+
+def _segment(punkte: list[ForecastDataPoint], *, tag: date = _TAG,
+             start_h: int = 6, end_h: int = 17,
+             seg_id: int = 1) -> SegmentWeatherData:
+    """Segment, dessen Aggregat die ECHTE Engine rechnet
+    (``compute_basis_metrics`` -> ``thunder_level_max``/
+    ``thunder_level_max_signals``) -- nicht von Hand gesetzt."""
+    reihe = _reihe(punkte)
+    seg = TripSegment(
+        segment_id=seg_id,
+        start_point=GPXPoint(lat=_LAT, lon=_LON, elevation_m=1000.0),
+        end_point=GPXPoint(lat=_LAT + 0.1, lon=_LON + 0.1, elevation_m=1200.0),
+        start_time=datetime(tag.year, tag.month, tag.day, start_h, 0,
+                            tzinfo=timezone.utc),
+        end_time=datetime(tag.year, tag.month, tag.day, end_h, 0,
+                          tzinfo=timezone.utc),
+        duration_hours=float(end_h - start_h), distance_km=10.0,
+        ascent_m=500.0, descent_m=200.0,
+    )
+    return SegmentWeatherData(
+        segment=seg, timeseries=reihe,
+        aggregated=WeatherMetricsService().compute_basis_metrics(reihe),
+        fetched_at=datetime.now(timezone.utc), provider="openmeteo",
+    )
+
+
+def _mail(segmente):
+    """Der ECHTE Trip-Bericht (HTML + Klartext + SMS) ueber den produktiven
+    Formatierer -- Prueford = Wirkort."""
+    return TripReportFormatter().format_email(
+        segmente, "Test-Trip", "evening",
+        display_config=build_default_display_config(),
+        tz=_TZ, stage_name=_ETAPPE,
+    )
+
+
+def _pille(bericht) -> str:
+    """Die EINE Gewitter-Pille aus dem Metriken-Ueberblick der Klartext-Mail.
+
+    Zusaetzlich wird geprueft, dass derselbe Text auch im HTML-Teil DERSELBEN
+    Mail steht -- die Pille ist ein geteilter Baustein (``compact.py:176``,
+    ``plain.py:205``, ``html.py:1432``); ein Test nur auf dem Klartext liesse
+    offen, ob der HTML-Leser dieselbe Angabe bekommt.
+    """
+    block = bericht.email_plain.split("Metriken-Überblick ━━", 1)[1]
+    zeilen = [ln.strip() for ln in block.split("\n\n", 1)[0].splitlines()
+              if "Gewitter" in ln]
+    assert len(zeilen) == 1, (
+        f"Erwartet genau EINE Gewitter-Pille im Metriken-Ueberblick, "
+        f"gefunden: {zeilen!r}")
+    assert zeilen[0] in bericht.email_html, (
+        f"HTML- und Klartext-Teil derselben Mail muessen dieselbe Pille "
+        f"zeigen: {zeilen[0]!r} fehlt im HTML-Teil")
+    return zeilen[0]
+
+
+# ---------------------------------------------------------------------------
+# Kommandopfad: echter Trip + echter Schnappschuss + echter Prozessor
+# ---------------------------------------------------------------------------
+
+def _alt_schnappschuss() -> None:
+    """Macht den gespeicherten Schnappschuss zu einem ALT-Schnappschuss (vor
+    Scheibe 1): beide Traeger-Schluessel raus, alles andere unberuehrt."""
+    pfad = get_snapshots_dir(_USER) / f"{_TRIP_ID}.json"
+    roh = json.loads(pfad.read_text())
+    for seg in roh["segments"]:
+        seg["aggregated"].pop("thunder_level_max_signals", None)
+        for stunde in seg.get("hourly", []):
+            stunde.pop("thunder_level_signals", None)
+    pfad.write_text(json.dumps(roh, indent=2))
+
+
+@pytest.fixture
+def kommando():
+    """Speichert Trip + Wetter-Schnappschuss und stellt die Kommando-Frage
+    ueber ``TripCommandProcessor.process()`` -- derselbe Weg, den eine
+    eingehende Telegram-/E-Mail-Nachricht nimmt."""
+    jetzt = datetime.now(tz=timezone.utc)
+    heute = jetzt.date()
+
+    def frage(segmente, *, body: str = "GLANCE", alt: bool = False) -> str:
+        save_trip(Trip(id=_TRIP_ID, name=_TRIP_NAME, stages=[
+            Stage(id="S1", name="Heute", date=heute, waypoints=[
+                Waypoint(id="W1", name="Start", lat=_LAT, lon=_LON,
+                         elevation_m=1000),
+            ]),
+        ]), _USER)
+        WeatherSnapshotService(_USER).save(_TRIP_ID, segmente, heute)
+        if alt:
+            _alt_schnappschuss()
+        ergebnis = TripCommandProcessor().process(InboundMessage(
+            channel="telegram", trip_name=_TRIP_NAME, body=body,
+            sender="4711", received_at=jetzt, user_id=_USER,
+        ))
+        assert ergebnis.success, (
+            f"Das Kommando {body!r} muss antworten, nicht scheitern: "
+            f"{ergebnis.confirmation_body!r}")
+        return ergebnis.confirmation_body
+
+    return SimpleNamespace(heute=heute, morgen=heute + timedelta(days=1),
+                           frage=frage)
+
+
+_TIMELINE_HEUTE = "### query: timeline_heute"
+
+
+def _timeline_gewitter(antwort: str) -> list[str]:
+    """Der Gewitter-Abschnitt JEDER Wegpunkt-Zeile, in Wegpunkt-Reihenfolge.
+
+    "   🌡 20–20 °C  💨 8 km/h  🌧 0.0 mm  ⛈ hoch · CAPE" -> "hoch · CAPE".
+    """
+    return [ln.split("⛈ ", 1)[1].strip()
+            for ln in antwort.splitlines() if "⛈ " in ln and "🌡" in ln]
+
+
+def _glance_gewitter(antwort: str, tag_label: str) -> str:
+    """Der Gewitter-Abschnitt der GLANCE-Zeile eines Tages ("heute"/"morgen").
+
+    "heute (13.08): ... ⛈ Gewitter: hoch · CAPE" -> "hoch · CAPE".
+    """
+    zeilen = [ln for ln in antwort.splitlines()
+              if ln.startswith(f"{tag_label} (") and "⛈ Gewitter: " in ln]
+    assert len(zeilen) == 1, (
+        f"Erwartet genau EINE GLANCE-Zeile fuer {tag_label!r}: {antwort!r}")
+    return zeilen[0].split("⛈ Gewitter: ", 1)[1].strip()
+
+
+# ---------------------------------------------------------------------------
+# Ortsvergleich-Fixturen
+# ---------------------------------------------------------------------------
+
+def _cdp(h: int, *, cape=None, cin=None, lpi=None,
+         dichte=None) -> ForecastDataPoint:
+    return ForecastDataPoint(
+        ts=datetime(2026, 8, 6, h, 0, tzinfo=timezone.utc), t2m_c=20.0,
+        cape_jkg=cape, convective_inhibition_jkg=cin,
+        lightning_potential_lpi_jkg=lpi, lightning_density_per_km2_3h=dichte,
+    )
+
+
+def _ort(name: str, punkte: list, *, lat: float = _LAT, lon: float = _LON,
+         modell: str = _MODELL, **felder) -> LocationResult:
+    """Ort, dessen Stunden durch die ECHTE Fusion gelaufen sind."""
+    region = thunder_region_for(lat, lon)
+    _fuse_thunder_levels(
+        punkte, cape_ladder_thresholds_jkg(modell, region),
+        lpi_thresholds_jkg(region),
+    )
+    return LocationResult(
+        location=SavedLocation(id=name.lower(), name=name, lat=lat, lon=lon,
+                               elevation_m=1000),
+        score=50, hourly_data=punkte, **felder,
+    )
+
+
+def _vergleich(*orte: LocationResult) -> ComparisonResult:
+    return ComparisonResult(
+        locations=list(orte), time_window=(12, 20),
+        target_date=date(2026, 8, 6), created_at=datetime(2026, 8, 5, 18, 0),
+    )
+
+
+def _compare_mail(*orte: LocationResult) -> tuple[str, str]:
+    """(html_body, text_body) des Ortsvergleichs MIT Stundentabelle."""
+    return render_compare_email(
+        _vergleich(*orte), enabled_metrics=["thunder_max"],
+        hourly_metrics=["thunder_level"], hourly_enabled=True,
+    )
+
+
+def _html_stunden(html: str) -> dict[str, list[list[str]]]:
+    """{Ortsname: [[Zeit, Gewitterzelle], ...]} aus den HTML-Stundentabellen."""
+    ergebnis: dict[str, list[list[str]]] = {}
+    for block in html.split("STUNDEN", 1)[1].split(">ORT</span>")[1:]:
+        name = _html.unescape(_SPAN.findall(block)[0]).strip()
+        koerper = _TBODY.search(block)
+        ergebnis[name] = [
+            [_html.unescape(c).strip() for c in _TD.findall(zeile)]
+            for zeile in (_TR.findall(koerper.group(1)) if koerper else [])
+        ]
+    return ergebnis
+
+
+def _text_stunden(text: str) -> dict[str, list[str]]:
+    """{Ortsname: ["16:00  Thdr hoch", ...]} aus dem Klartext-Stundenverlauf."""
+    ergebnis: dict[str, list[str]] = {}
+    aktuell = None
+    for zeile in text.split("STUNDENVERLAUF", 1)[1].splitlines():
+        kopf = re.match(r"^(\S.*?) \([A-Z]+\)$", zeile)
+        if kopf:
+            aktuell = kopf.group(1)
+            ergebnis[aktuell] = []
+        elif aktuell is not None and re.match(r"^\s+\d\d:\d\d\s\s", zeile):
+            ergebnis[aktuell].append(zeile.strip())
+    return ergebnis
+
+
+def _html_uebersicht(html: str) -> list[str]:
+    """Zellentexte der Gewitter-Zeile der HTML-Uebersicht (Ortsreihenfolge)."""
+    rest = html.split(">Gewitter</td>", 1)[1]
+    return [_html.unescape(c) for c in _TD.findall(rest.split("</tr>", 1)[0])]
+
+
+def _text_uebersicht(text: str) -> list[str]:
+    """Gewitter-Zellen der Klartext-Uebersicht (Ortsreihenfolge)."""
+    return [ln.split("Gewitter: ", 1)[1].strip()
+            for ln in text.split("STUNDENVERLAUF", 1)[0].splitlines()
+            if "Gewitter: " in ln]
+
+
+# ===========================================================================
+# Ort 1 — Pille im Metriken-Ueberblick
+# ===========================================================================
+
+def test_ac1_pille_nennt_die_tragende_zutat():
+    """AC-1: Given das Gewitterfenster der Pille kommt ausschliesslich ueber
+    CAPE zustande, When die Trip-Mail gerendert wird, Then nennt die Pille die
+    Zutat neben dem Zeitfenster."""
+    seg = _segment([_dp(h, cape=1500.0, cin=5.0) for h in (14, 15, 16)])
+    assert _pille(_mail([seg])) == "Gewitter ab 14:00 · stärkste 14:00 · CAPE", (
+        f"Die Pille muss die tragende Zutat neben dem Zeitfenster nennen: "
+        f"{_pille(_mail([seg]))!r}")
+
+
+def test_ac5_pille_nennt_beide_zutaten_derselben_stunde():
+    """AC-5: Given CAPE UND Blitzpotenzial erreichen in DERSELBEN Stunde die
+    Hoechststufe, When die Pille gerendert wird, Then werden BEIDE in der
+    Katalogreihenfolge aus ``THUNDER_SIGNAL_LABEL_DE`` genannt -- kein
+    Gewinner wird gekuert (PO-Auslegung (ii))."""
+    seg = _segment([_dp(14, cape=1500.0, cin=5.0, lpi=60.0)])
+    zutaten = seg.timeseries.data[0].thunder_level_signals
+    assert zutaten == ["cape", "blitzpotenzial"], (
+        f"Vorbedingung: die ECHTE Fusion muss BEIDE Zutaten als tragend "
+        f"ausweisen -- sonst prueft dieser Test nichts: {zutaten!r}")
+    assert _pille(_mail([seg])) == (
+        "Gewitter ab 14:00 · stärkste 14:00 · CAPE, Blitzpotenzial"), (
+        f"Beide Traeger der Hoechststufe muessen erscheinen, CAPE vor "
+        f"Blitzpotenzial (Katalogreihenfolge): {_pille(_mail([seg]))!r}")
+
+
+def test_ac6_pille_vereinigt_die_zutaten_zweier_stunden():
+    """AC-6: Given ZWEI Stunden desselben Tagesfensters erreichen die
+    Hoechststufe ueber VERSCHIEDENE Zutaten (14 Uhr CAPE, 17 Uhr
+    Blitzpotenzial), When die Pille gerendert wird, Then nennt sie BEIDE --
+    nicht nur die der Spitzenstunde.
+
+    Das ist die Gegenprobe zur Mutation (a) der Spec ("nur der Datenpunkt der
+    Spitzenstunde"): die Spitzenstunde ist hier 14:00 und traegt allein CAPE.
+    """
+    seg = _segment([_dp(14, cape=1500.0, cin=5.0), _dp(17, lpi=60.0)])
+    fruehe, spaete = (dp.thunder_level_signals for dp in seg.timeseries.data)
+    assert (fruehe, spaete) == (["cape"], ["blitzpotenzial"]), (
+        f"Vorbedingung: die beiden Stunden muessen VERSCHIEDENE Zutaten "
+        f"tragen -- sonst belegt die Vereinigung nichts: {fruehe!r}/{spaete!r}")
+    assert _pille(_mail([seg])) == (
+        "Gewitter ab 14:00 · stärkste 14:00 · CAPE, Blitzpotenzial"), (
+        f"Die Pille muss die Traeger ALLER Stunden mit der Hoechststufe "
+        f"vereinigen: {_pille(_mail([seg]))!r}")
+
+
+def test_ac8_pille_nennt_keine_zutat_ausserhalb_des_tagesfensters():
+    """AC-8 (Kohaerenz Pille): Given eine dritte Zutat traegt die Hoechststufe
+    NUR in einer Stunde AUSSERHALB des Tagesfensters (02:00), When die Pille
+    gerendert wird, Then erscheint sie NICHT -- Stufe und Herkunft stammen aus
+    DERSELBEN gefensterten Liste, ohne zweiten Datenzugriff.
+
+    Vorbedingung im selben Test: das SEGMENT-Aggregat kennt die dritte Zutat
+    sehr wohl. Ohne diese Zusicherung waere der Test auch dann gruen, wenn die
+    Fixture die dritte Zutat gar nicht erst erzeugte.
+    """
+    seg = _segment(
+        [_dp(2, dichte=0.5)] + [_dp(h, cape=1500.0, cin=5.0) for h in (14, 15)],
+        start_h=6, end_h=17,
+    )
+    assert seg.aggregated.thunder_level_max_signals == ["blitzdichte", "cape"], (
+        f"Vorbedingung: das Segment-Aggregat MUSS die dritte Zutat kennen -- "
+        f"sonst belegt dieser Test nichts: "
+        f"{seg.aggregated.thunder_level_max_signals!r}")
+    assert _pille(_mail([seg])) == "Gewitter ab 14:00 · stärkste 14:00 · CAPE", (
+        f"Nur Zutaten aus dem Tagesfenster 04-19 duerfen erscheinen -- die "
+        f"Blitzdichte liegt bei 02:00 ausserhalb: {_pille(_mail([seg]))!r}")
+
+
+# ===========================================================================
+# Ort 2 — Kommando-Timeline je Wegpunkt
+# ===========================================================================
+
+def test_ac2_timeline_wegpunkt_nennt_die_tragende_zutat(kommando):
+    """AC-2: Given die Stufe eines Wegpunkts kommt ausschliesslich ueber CAPE
+    zustande, When der Nutzer die Timeline abruft, Then zeigt die
+    Wegpunkt-Zeile "⛈ leicht · CAPE" statt nur "⛈ leicht"."""
+    seg = _segment([_dp(10, tag=kommando.heute, cape=400.0, cin=5.0)],
+                   tag=kommando.heute, start_h=6, end_h=10)
+    antwort = kommando.frage([seg], body=_TIMELINE_HEUTE)
+    assert _timeline_gewitter(antwort) == ["leicht · CAPE"], (
+        f"Die Wegpunkt-Zeile muss die tragende Zutat neben der Stufe nennen: "
+        f"{antwort!r}")
+
+
+def test_ac10_timeline_zeigt_je_wegpunkt_nur_die_eigene_zutat(kommando):
+    """AC-10 (Kohaerenz Timeline): Given zwei Wegpunkte desselben Tages tragen
+    ihre Stufe ueber VERSCHIEDENE Zutaten, When die Timeline gerendert wird,
+    Then zeigt JEDE Zeile ausschliesslich die Zutat ihres EIGENEN
+    Segment-Aggregats -- keine Vermischung zwischen Wegpunkten.
+
+    Gegenprobe zur Mutation (e) der Spec (eine EINMAL ausserhalb der Schleife
+    berechnete, globale Traegerliste): die wuerde beide Zeilen gleich machen.
+    """
+    heute = kommando.heute
+    wegpunkte = [
+        _segment([_dp(10, tag=heute, cape=1500.0, cin=5.0)],
+                 tag=heute, start_h=6, end_h=10, seg_id=1),
+        _segment([_dp(14, tag=heute, lpi=60.0)],
+                 tag=heute, start_h=11, end_h=14, seg_id=2),
+    ]
+    traeger = [s.aggregated.thunder_level_max_signals for s in wegpunkte]
+    assert traeger == [["cape"], ["blitzpotenzial"]], (
+        f"Vorbedingung: die beiden Wegpunkt-Aggregate muessen VERSCHIEDENE "
+        f"Zutaten tragen -- sonst belegt der Test keine Trennung: {traeger!r}")
+    antwort = kommando.frage(wegpunkte, body=_TIMELINE_HEUTE)
+    assert _timeline_gewitter(antwort) == ["hoch · CAPE", "hoch · Blitzpotenzial"], (
+        f"Jede Wegpunkt-Zeile darf NUR die Zutat ihres eigenen Aggregats "
+        f"nennen: {antwort!r}")
+
+
+def test_ac15_alt_schnappschuss_zeigt_die_stufe_ohne_herkunft(kommando):
+    """AC-15: Given ein gespeicherter Schnappschuss OHNE
+    ``thunder_level_max_signals`` (vor Scheibe 1/2) wird fuer die Timeline
+    geladen, When der Nutzer die Timeline abruft, Then zeigt die
+    Wegpunkt-Zeile die Stufe unveraendert, aber OHNE Herkunfts-Zusatz -- kein
+    "unbekannt", kein leerer Trenner, kein Fehler.
+
+    Gegenprobe im selben Test (Spec-Pflicht, sonst waere die zugesicherte
+    ABWESENHEIT von Anfang an gruen): derselbe Trip mit VOLLSTAENDIGEM
+    Schnappschuss nennt die Zutat sehr wohl.
+    """
+    heute = kommando.heute
+    segmente = [_segment([_dp(10, tag=heute, cape=1500.0, cin=5.0)],
+                         tag=heute, start_h=6, end_h=10)]
+
+    vollstaendig = kommando.frage(segmente, body=_TIMELINE_HEUTE)
+    assert _timeline_gewitter(vollstaendig) == ["hoch · CAPE"], (
+        f"Gegenprobe gescheitert: der VOLLSTAENDIGE Schnappschuss MUSS die "
+        f"Herkunft tragen, sonst beweist die Abwesenheit unten nichts: "
+        f"{vollstaendig!r}")
+
+    alt = kommando.frage(segmente, body=_TIMELINE_HEUTE, alt=True)
+    assert _timeline_gewitter(alt) == ["hoch"], (
+        f"Ein Alt-Schnappschuss ohne Traegerfeld zeigt die Stufe unveraendert "
+        f"und KEINEN Zusatz: {alt!r}")
+
+
+# ===========================================================================
+# Ort 3 — GLANCE-Tageszeile (in Scheibe 2 bewusst ausgelassen, jetzt abgeloest)
+# ===========================================================================
+
+def test_ac3_glance_tageszeile_nennt_die_tragende_zutat(kommando):
+    """AC-3 (abgeloeste Entscheidung): Given die Tages-Gewitterstufe kommt
+    ausschliesslich ueber CAPE zustande, When der Nutzer GLANCE sendet, Then
+    zeigt die Zeile "⛈ Gewitter: leicht · CAPE" statt -- wie bis
+    einschliesslich Scheibe 2 -- nur "⛈ Gewitter: leicht".
+
+    Das ist die zentrale Gegenprobe der in dieser Scheibe aufgehobenen
+    Scheibe-2-Entscheidung (dortige D3/Known Limitation 4) und zugleich die
+    Gegenprobe zur Mutation (b) der Spec.
+    """
+    seg = _segment([_dp(10, tag=kommando.heute, cape=400.0, cin=5.0)],
+                   tag=kommando.heute, start_h=6, end_h=10)
+    antwort = kommando.frage([seg], body="GLANCE")
+    assert _glance_gewitter(antwort, "heute") == "leicht · CAPE", (
+        f"Die GLANCE-Tageszeile muss die tragende Zutat nennen: {antwort!r}")
+
+
+def test_ac7_glance_vereinigt_die_zutaten_zweier_wegpunkte(kommando):
+    """AC-7: Given zwei Wegpunkte desselben Kalendertags erreichen die
+    Tages-Hoechststufe ueber VERSCHIEDENE Zutaten, When der Nutzer GLANCE
+    sendet, Then nennt die Zeile BEIDE -- nicht nur die des zeitlich ersten
+    Wegpunkts."""
+    heute = kommando.heute
+    antwort = kommando.frage([
+        _segment([_dp(10, tag=heute, cape=1500.0, cin=5.0)],
+                 tag=heute, start_h=6, end_h=10, seg_id=1),
+        _segment([_dp(14, tag=heute, lpi=60.0)],
+                 tag=heute, start_h=11, end_h=14, seg_id=2),
+    ], body="GLANCE")
+    assert _glance_gewitter(antwort, "heute") == "hoch · CAPE, Blitzpotenzial", (
+        f"Die GLANCE-Zeile muss die Traeger ALLER Wegpunkte mit der "
+        f"Tages-Hoechststufe vereinigen: {antwort!r}")
+
+
+def test_ac11_glance_nennt_keine_zutat_eines_anderen_kalendertags(kommando):
+    """AC-11 (Kohaerenz GLANCE): Given ein Wegpunkt eines ANDEREN
+    Kalendertags traegt eine dritte, abweichende Zutat auf DERSELBEN
+    Hoechststufe, When der Nutzer GLANCE sendet, Then erscheint sie in der
+    Zeile des Zieltags NICHT.
+
+    Gegenprobe im selben Lauf: die "morgen"-Zeile derselben Antwort nennt die
+    dritte Zutat sehr wohl -- die Zutat existiert also, sie ist nur dem
+    anderen Tag zugeordnet.
+    """
+    heute, morgen = kommando.heute, kommando.morgen
+    antwort = kommando.frage([
+        _segment([_dp(10, tag=heute, cape=1500.0, cin=5.0)],
+                 tag=heute, start_h=6, end_h=10, seg_id=1),
+        _segment([_dp(14, tag=morgen, dichte=0.5)],
+                 tag=morgen, start_h=6, end_h=14, seg_id=2),
+    ], body="GLANCE")
+    assert _glance_gewitter(antwort, "morgen") == "hoch · Blitzdichte", (
+        f"Gegenprobe gescheitert: die dritte Zutat MUSS am anderen Tag "
+        f"erscheinen, sonst belegt ihre Abwesenheit heute nichts: {antwort!r}")
+    assert _glance_gewitter(antwort, "heute") == "hoch · CAPE", (
+        f"Die Herkunft muss aus den Wegpunkten DES Zieltags kommen -- die "
+        f"Blitzdichte von morgen darf heute nicht erscheinen: {antwort!r}")
+
+
+# ===========================================================================
+# Ort 4 — Ortsvergleich-Stundentabelle (HTML + Klartext)
+# ===========================================================================
+
+def test_ac4_stundentabelle_nennt_die_zutat_in_html_und_klartext():
+    """AC-4: Given eine Stunde eines verglichenen Ortes zeigt eine Stufe, die
+    ausschliesslich ueber CAPE zustande kommt, When die Vergleichsmail
+    gerendert wird, Then zeigt die Stundenzelle "leicht · CAPE" -- an BEIDEN
+    Stellen (HTML und Klartext) DERSELBEN Mail.
+
+    HTML und Klartext werden getrennt zugesichert (Mutationsproben (c) und
+    (d) der Spec): sie haben zwei unabhaengige Aufrufstellen
+    (``compare_html._render_hour_row`` bzw. die Stundenschleife in
+    ``comparison.render_comparison_text``).
+    """
+    ort = _ort("Capeort", [_cdp(14, cape=400.0, cin=5.0)])
+    assert ort.hourly_data[0].thunder_level_signals == ["cape"], (
+        f"Vorbedingung: die ECHTE Fusion muss CAPE als alleinigen Traeger "
+        f"ausweisen: {ort.hourly_data[0].thunder_level_signals!r}")
+    html, text = _compare_mail(ort)
+    assert _html_stunden(html)["Capeort"] == [["16", "leicht · CAPE"]], (
+        f"Die HTML-Stundenzelle muss die tragende Zutat nennen: "
+        f"{_html_stunden(html)['Capeort']!r}")
+    assert _text_stunden(text)["Capeort"] == ["16:00  Thdr leicht · CAPE"], (
+        f"Der Klartext-Teil DERSELBEN Mail muss dieselbe Herkunft zeigen: "
+        f"{_text_stunden(text)['Capeort']!r}")
+
+
+def test_ac9_jede_stundenzeile_zeigt_nur_die_zutat_ihres_datenpunkts():
+    """AC-9 (Kohaerenz Stundentabelle): Given zwei benachbarte Stunden
+    desselben Ortes tragen ihre Stufe ueber VERSCHIEDENE Zutaten, When die
+    Stundentabelle gerendert wird, Then zeigt JEDE Zeile ausschliesslich die
+    Zutat IHRES EIGENEN Datenpunkts -- keine Vermischung zwischen benachbarten
+    Zeilen, in HTML wie im Klartext."""
+    ort = _ort("Zweistundenort",
+               [_cdp(14, cape=1500.0, cin=5.0), _cdp(15, dichte=0.5)])
+    traeger = [dp.thunder_level_signals for dp in ort.hourly_data]
+    assert traeger == [["cape"], ["blitzdichte"]], (
+        f"Vorbedingung: die beiden Stunden muessen VERSCHIEDENE Zutaten "
+        f"tragen -- sonst belegt der Test keine Trennung: {traeger!r}")
+
+    html, text = _compare_mail(ort)
+    assert _html_stunden(html)["Zweistundenort"] == [
+        ["16", "hoch · CAPE"], ["17", "hoch · Blitzdichte"],
+    ], (f"Jede HTML-Stundenzeile darf nur die Zutat ihres eigenen "
+        f"Datenpunkts zeigen: {_html_stunden(html)['Zweistundenort']!r}")
+    assert _text_stunden(text)["Zweistundenort"] == [
+        "16:00  Thdr hoch · CAPE", "17:00  Thdr hoch · Blitzdichte",
+    ], (f"Dasselbe im Klartext-Teil derselben Mail: "
+        f"{_text_stunden(text)['Zweistundenort']!r}")
+
+
+def test_ac12_compare_sms_und_telegram_zeigen_keine_stunden_herkunft():
+    """AC-12 (kein Leck Compare-SMS/Telegram): Given die Stundentabelle zeigt
+    eine Zutat, die NUR auf Stundenebene existiert (Blitzdichte, unterhalb der
+    Tages-Hoechststufe), When derselbe Vergleich als SMS oder Telegram
+    gerendert wird, Then taucht sie dort NICHT auf -- beide Kanaele zeigen
+    ausschliesslich die Uebersichtszeile.
+
+    🔴 ABWEICHUNG VON DER SPEC (belegt, kein Ermessen): der Spec-Testhinweis
+    zu AC-12 verlangt woertlich, dass "keiner der beiden Texte" eine der vier
+    Zutat-Bezeichnungen enthaelt. Fuer ``render_compare_telegram()`` ist das
+    seit Scheibe 1 nachweislich falsch: dort zeigt die Uebersichtszeile die
+    Herkunft ausdruecklich (S1 AC-4, live seit 2026-08-12, bewacht von
+    ``test_thunder_origin_compare.py::test_ac4_telegram_zeigt_dieselbe_
+    herkunft_wie_die_mail``). Die woertliche Fassung waere also ein Test, der
+    NUR gruen werden koennte, wenn eine ausgelieferte Zusage bricht. Geprueft
+    wird deshalb die Aussage, die AC-12 traegt: eine Zutat, die ausschliesslich
+    aus den NEUEN Stundentabellen-Aufrufstellen dieser Scheibe stammen kann,
+    darf weder in der SMS noch im Telegram erscheinen. Fuer die SMS bleibt die
+    absolute Fassung (keine der vier Zutaten) erhalten -- das ist die
+    Gegenprobe zur Mutation (f) der Spec, die die SMS-Zelle probeweise ueber
+    die Herkunfts-Aufrufstelle baut.
+    """
+    ort = _ort("Leckort", [_cdp(14, cape=1500.0, cin=5.0),
+                           _cdp(15, dichte=0.005)])
+    stufen = [(dp.thunder_level, dp.thunder_level_signals)
+              for dp in ort.hourly_data]
+    assert stufen == [(ThunderLevel.HIGH, ["cape"]),
+                      (ThunderLevel.LOW, ["blitzdichte"])], (
+        f"Vorbedingung: die Blitzdichte darf NUR unterhalb der "
+        f"Tages-Hoechststufe tragen -- sonst stuende sie legitim auch in der "
+        f"Uebersicht: {stufen!r}")
+
+    ergebnis = _vergleich(ort)
+    sms = render_compare_sms(ergebnis, enabled_metrics=["thunder_max"])
+    telegram = render_compare_telegram(ergebnis, enabled_metrics=["thunder_max"])
+    html, text = _compare_mail(ort)
+
+    assert "Blitzdichte" in text.split("STUNDENVERLAUF", 1)[1], (
+        f"Gegenprobe gescheitert: die stundenweise Zutat MUSS in der "
+        f"Stundentabelle erscheinen, sonst beweist ihre Abwesenheit in "
+        f"SMS/Telegram nichts: {_text_stunden(text)!r}")
+
+    assert "hoch" in sms, f"Die Stufe selbst muss in der SMS stehen: {sms!r}"
+    for zutat in ALLE_ZUTATEN:
+        assert zutat not in sms, (
+            f"Compare-SMS ist bewusst OHNE Herkunft (PO-Entscheidung) -- "
+            f"'{zutat}' darf nicht vorkommen: {sms!r}")
+
+    assert "CAPE" in telegram, (
+        f"Gegenprobe gescheitert: Telegram MUSS die Herkunft der "
+        f"Uebersichtszeile weiterhin zeigen (Scheibe 1 AC-4): {telegram!r}")
+    assert "Blitzdichte" not in telegram, (
+        f"Telegram zeigt ausschliesslich die Uebersichtszeile -- die nur "
+        f"stundenweise tragende Blitzdichte darf dort nicht auftauchen: "
+        f"{telegram!r}")
+
+
+def test_ac14_s1_uebersichtszeile_bleibt_zeichengleich():
+    """AC-14: Given die Ortsvergleich-Uebersichtszeile zeigte vor dieser
+    Scheibe bereits eine Herkunft (Scheibe 1), When diese Scheibe
+    ausgeliefert ist, Then bleibt ihr Text fuer eine unveraenderte Fixture
+    zeichengleich -- die Aenderung an den Stundentabellen-Aufrufstellen (D4)
+    ruehrt den Rumpf von ``_fmt_thunder()`` NICHT an.
+
+    Beides in DERSELBEN gerenderten Vergleichsmail: die Uebersicht bleibt
+    Zeichen fuer Zeichen wie in Scheibe 1, die Stundentabelle bekommt die
+    Herkunft neu (Gegenprobe -- ohne sie waere die Zeichengleichheit von
+    Anfang an gruen).
+
+    Der zweite Ort ist der Drift-Fall aus Scheibe 1 AC-12: Engine-Stufe
+    ``HIGH``, aus den Stundenwerten abgeleitet ``MED`` -> die Uebersicht zeigt
+    dort BEWUSST keine Herkunft. Eine Herkunfts-Logik, die faelschlich in den
+    ``_fmt_thunder()``-Rumpf oder in die Uebersichts-Aufrufstelle wanderte,
+    braeche genau hier -- waehrend die Stundenzeile desselben Ortes ihre
+    eigene Zutat sehr wohl zeigt.
+    """
+    orte = (
+        _ort("Alpenort", [_cdp(14, cape=1500.0, cin=5.0)]),
+        _ort("Driftort", [_cdp(14, cape=800.0, cin=5.0)],
+             thunder_level_max=ThunderLevel.HIGH),
+    )
+    html, text = _compare_mail(*orte)
+
+    assert _html_uebersicht(html) == ["hoch · CAPE", "hoch"], (
+        f"Die HTML-Uebersichtszeile muss zeichengleich zu Scheibe 1 bleiben: "
+        f"{_html_uebersicht(html)!r}")
+    assert _text_uebersicht(text) == ["hoch · CAPE", "hoch"], (
+        f"Die Klartext-Uebersichtszeile muss zeichengleich zu Scheibe 1 "
+        f"bleiben: {_text_uebersicht(text)!r}")
+
+    assert _html_stunden(html) == {
+        "Alpenort": [["16", "hoch · CAPE"]],
+        "Driftort": [["16", "mittel · CAPE"]],
+    }, (f"Gegenprobe gescheitert: die Stundentabelle DERSELBEN Mail MUSS die "
+        f"Herkunft je Datenpunkt zeigen -- auch beim Drift-Ort, dessen "
+        f"Uebersicht bewusst keine nennt: {_html_stunden(html)!r}")
+
+
+# ===========================================================================
+# Zeichengleichheit ohne Gewitter — alle vier Orte (AC-16)
+# ===========================================================================
+
+def test_ac16_ohne_gewitter_bleiben_pille_timeline_und_glance_zeichengleich(
+        kommando):
+    """AC-16 (Trip-Teil): Given kein Datenpunkt erreicht eine Stufe ueber
+    NONE, When Pille, Timeline und GLANCE-Zeile gerendert werden, Then bleibt
+    die Ausgabe an allen drei Orten zeichengleich zu vor dieser Scheibe --
+    kein Herkunfts-Zusatz. Besonders GLANCE, weil diese Scheibe dort erstmals
+    ueberhaupt Herkunft anzeigt (AC-3).
+
+    Gegenprobe im selben Test (Spec-Pflicht): dieselben Fixturen mit CAPE
+    ueber der Leiter zeigen die Herkunft an allen drei Orten sehr wohl.
+    """
+    heute = kommando.heute
+    ruhig = _segment([_dp(h, tag=heute, cape=50.0, cin=5.0) for h in (10, 11)],
+                     tag=heute, start_h=6, end_h=11)
+    laut = _segment([_dp(h, tag=heute, cape=1500.0, cin=5.0) for h in (10, 11)],
+                    tag=heute, start_h=6, end_h=11)
+
+    assert _pille(_mail([ruhig])) == "kein Gewitter", (
+        f"Ohne Gewitter bleibt die Pille zeichengleich: "
+        f"{_pille(_mail([ruhig]))!r}")
+    assert _timeline_gewitter(
+        kommando.frage([ruhig], body=_TIMELINE_HEUTE)) == ["kein"], (
+        "Ohne Gewitter bleibt die Timeline-Zeile zeichengleich")
+    assert _glance_gewitter(
+        kommando.frage([ruhig], body="GLANCE"), "heute") == "kein", (
+        "Ohne Gewitter bleibt die GLANCE-Zeile zeichengleich")
+
+    assert _pille(_mail([laut])) == "Gewitter ab 10:00 · stärkste 10:00 · CAPE", (
+        f"Gegenprobe gescheitert: mit erreichter Stufe MUSS die Pille die "
+        f"Herkunft zeigen: {_pille(_mail([laut]))!r}")
+    assert _timeline_gewitter(
+        kommando.frage([laut], body=_TIMELINE_HEUTE)) == ["hoch · CAPE"], (
+        "Gegenprobe gescheitert: die Timeline MUSS die Herkunft zeigen")
+    assert _glance_gewitter(
+        kommando.frage([laut], body="GLANCE"), "heute") == "hoch · CAPE", (
+        "Gegenprobe gescheitert: GLANCE MUSS die Herkunft zeigen")
+
+
+def test_ac16_ohne_gewitter_bleibt_die_compare_stundenzelle_zeichengleich():
+    """AC-16 (Compare-Teil): Given eine Stunde zeigt kein Gewitter, When die
+    Stundentabelle gerendert wird, Then bleibt die Zelle zeichengleich ("—",
+    ohne Trenner) -- in HTML wie im Klartext.
+
+    Gegenprobe im selben Vergleich: der zweite Ort mit erreichter Stufe zeigt
+    seine Herkunft sehr wohl.
+    """
+    ruhig = _ort("Ruhigort", [_cdp(14, cape=50.0, cin=5.0)])
+    laut = _ort("Sturmort", [_cdp(14, cape=1500.0, cin=5.0)])
+    assert ruhig.hourly_data[0].thunder_level == ThunderLevel.NONE, (
+        f"Vorbedingung: der ruhige Ort muss die ECHTE Stufe NONE tragen: "
+        f"{ruhig.hourly_data[0].thunder_level!r}")
+
+    html, text = _compare_mail(ruhig, laut)
+    assert _html_stunden(html)["Ruhigort"] == [["16", "—"]], (
+        f"Ohne erreichte Stufe bleibt die HTML-Stundenzelle zeichengleich: "
+        f"{_html_stunden(html)['Ruhigort']!r}")
+    assert _text_stunden(text)["Ruhigort"] == ["16:00  Thdr —"], (
+        f"Dasselbe im Klartext: {_text_stunden(text)['Ruhigort']!r}")
+
+    assert _html_stunden(html)["Sturmort"] == [["16", "hoch · CAPE"]], (
+        f"Gegenprobe gescheitert: der Ort MIT erreichter Stufe MUSS die "
+        f"Herkunft zeigen: {_html_stunden(html)['Sturmort']!r}")
+
+
+# ===========================================================================
+# Kein Leck in Trip-SMS/Premium-SMS (AC-13)
+# ===========================================================================
+
+def test_ac13_trip_sms_zeigt_die_stufe_aber_keine_herkunft():
+    """AC-13: Given die Pille traegt ab dieser Scheibe eine Herkunft, die in
+    ``email_plain`` landet, When der Trip-Bericht versendet wird, Then
+    enthaelt weder ``report.sms_text`` noch -- ueber den Rueckfallweg
+    ``sms_text or email_plain`` (``notification_service.py:428``/``446``) --
+    die tatsaechlich zugestellte SMS/Premium-SMS eine der vier
+    Zutat-Bezeichnungen; die Gewitterstufe selbst bleibt sichtbar.
+
+    ``report.sms_text`` muss zusaetzlich NICHT-LEER sein: nur dann ist belegt,
+    dass der Rueckfall auf ``email_plain`` strukturell nicht greift (#868,
+    analog Scheibe 2 AC-8).
+
+    Gegenprobe im selben Lauf (Spec-Pflicht): die Pille DERSELBEN Mail zeigt
+    die Herkunft sehr wohl -- sonst waere dieses AC auch dann gruen, wenn die
+    Herkunft nirgends erschiene.
+    """
+    seg = _segment([_dp(h, cape=1500.0, cin=5.0, lpi=60.0) for h in (14, 15, 16)])
+    bericht = _mail([seg])
+
+    assert bericht.sms_text, (
+        "sms_text muss immer erzeugt werden (#868) -- sonst greift der "
+        "Rueckfall `sms_text or email_plain` und traegt die neue Herkunft in "
+        "SMS/Premium-SMS, entgegen der PO-Entscheidung")
+    zugestellt = bericht.sms_text or bericht.email_plain
+    assert "TH:H" in zugestellt, (
+        f"Die Gewitterstufe selbst bleibt in der SMS sichtbar: {zugestellt!r}")
+    for zutat in ALLE_ZUTATEN:
+        assert zutat not in zugestellt, (
+            f"SMS/Premium-SMS sind bewusst OHNE Herkunft (PO-Entscheidung) -- "
+            f"'{zutat}' darf nicht vorkommen: {zugestellt!r}")
+
+    assert _pille(bericht) == (
+        "Gewitter ab 14:00 · stärkste 14:00 · CAPE, Blitzpotenzial"), (
+        f"Gegenprobe gescheitert: die Mail DERSELBEN Fixture MUSS die "
+        f"Herkunft zeigen, sonst beweist die SMS-Abwesenheit nichts: "
+        f"{_pille(bericht)!r}")

--- a/tests/tdd/test_thunder_origin_trip.py
+++ b/tests/tdd/test_thunder_origin_trip.py
@@ -403,9 +403,10 @@ def test_ac9_alt_schnappschuss_zeigt_die_stufe_ohne_herkunft(kommando):
 
 
 def test_ac10_ohne_gewitter_bleiben_beide_ausgabeorte_zeichengleich(kommando):
-    """AC-10 (erste Haelfte): Given kein Datenpunkt erreicht eine Stufe ueber
-    NONE, When Kurzzusammenfassung und GEWITTER-Kommando gerendert werden,
-    Then bleibt die Ausgabe an BEIDEN Orten zeichengleich zu heute.
+    """AC-10 (erste Haelfte; die zweite ist abgeloest, s. Hinweis unter dieser
+    Funktion): Given kein Datenpunkt erreicht eine Stufe ueber NONE, When
+    Kurzzusammenfassung und GEWITTER-Kommando gerendert werden, Then bleibt
+    die Ausgabe an BEIDEN Orten zeichengleich zu heute.
 
     Gegenprobe im selben Test: dieselbe Etappe mit CAPE ueber der Leiter zeigt
     die Herkunft an beiden Orten sehr wohl.
@@ -429,32 +430,25 @@ def test_ac10_ohne_gewitter_bleiben_beide_ausgabeorte_zeichengleich(kommando):
         f"beiden Orten erscheinen: {laute_zeile!r}")
 
 
-def test_ac10_glance_bleibt_ohne_herkunft(kommando):
-    """AC-10 (zweite Haelfte): Given GLANCE liest denselben
-    ``_aggregate_day()``-Dict wie GEWITTER, When der neue Traeger-Schluessel
-    dazukommt, Then bleibt die GLANCE-Zeile zeichengleich (Known Limitation 4).
-
-    Gegenprobe im selben Test: die GEWITTER-Antwort derselben Fixture nennt
-    CAPE -- ohne sie waere dieses AC auch dann gruen, wenn die Herkunft
-    nirgends erschiene.
-    """
-    heute = kommando.heute
-    segmente = [_segment([_dp(h, tag=heute, cape=1500.0, cin=5.0) for h in (14, 15)],
-                         tag=heute, start_h=6, end_h=16)]
-
-    glance = kommando.frage(segmente, body="GLANCE")
-    erwartet = f"heute ({heute:%d.%m}): 🌡 20–20°C  💨 8 km/h  🌧 0.0mm  ⛈ Gewitter: hoch"
-    assert erwartet in glance, (
-        f"Die GLANCE-Tageszeile bleibt zeichengleich -- kein Herkunfts-Zusatz: "
-        f"{glance!r}")
-    for zutat in ALLE_ZUTATEN:
-        assert zutat not in glance, (
-            f"GLANCE bekommt bewusst keinen Zugriff auf den neuen Schluessel "
-            f"-- '{zutat}' darf dort nicht auftauchen: {glance!r}")
-
-    assert "· CAPE" in kommando.frage(segmente), (
-        "Gegenprobe gescheitert: die GEWITTER-Antwort DERSELBEN Fixture MUSS "
-        "die Herkunft nennen")
+# 🔴 Entfernt am 2026-08-13 (Issue #1680 Scheibe 3): hier stand
+# ``test_ac10_glance_bleibt_ohne_herkunft`` -- die zweite Haelfte von AC-10.
+# Sie sicherte zu, dass die GLANCE-Tageszeile den seit Scheibe 2 vorhandenen
+# Traeger-Schluessel bewusst NICHT liest und zeichengleich bleibt (dortige
+# Spec D3, Known Limitation 4). Der PO hat diese Entscheidung mit Scheibe 3
+# ausdruecklich abgeloest: GLANCE zeigt die Herkunft jetzt genau wie das
+# GEWITTER-Kommando. Der Test prueft damit veraltetes Verhalten und ist
+# ersatzlos entfallen -- die Erwartung bloss umzudrehen haette dieselbe
+# Zusicherung in zwei Dateien gestellt, die beim naechsten Wechsel
+# auseinanderlaufen. Neuer Sollzustand:
+# ``test_thunder_origin_four_places.py``, dort
+# ``test_ac3_glance_tageszeile_nennt_die_tragende_zutat`` (Einzelzutat) und
+# ``test_ac7_glance_vereinigt_die_zutaten_zweier_wegpunkte`` (Vereinigung);
+# die NONE-Zeichengleichheit von GLANCE bewacht dort
+# ``test_ac16_ohne_gewitter_bleiben_pille_timeline_und_glance_zeichengleich``.
+# Die einzige weitere Zusicherung der entfernten Funktion war eine Gegenprobe
+# ("die GEWITTER-Antwort derselben Fixture nennt CAPE"); sie bleibt
+# eigenstaendig bewacht von
+# ``test_ac2_gewitter_kommando_nennt_die_tragende_zutat`` weiter oben.
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Scheibe 3 zu #1680. Vier weitere Ausgabeorte nennen die tragende Zutat der Gewitterstufe:

```
Metriken-Überblick (Pille):     Gewitter ab 13:00 · stärkste 13:00 · CAPE
Timeline je Wegpunkt:           ⛈ leicht · CAPE
GLANCE (heute/morgen):          ⛈ Gewitter: leicht · CAPE
Ortsvergleich, Stundentabelle:  14:00   leicht · CAPE
```

E-Mail und Telegram tragen die Herkunft, **SMS und Premium-SMS ausdrücklich nicht**.

## Nichts Neues gebaut — vier Mal etwas benutzt, das schon dalag

Bei allen vier Orten lag die Zutat bereits vor. Zwei Fälle sind bemerkenswert:

- **GLANCE:** Die Trägerliste stand seit Scheibe 2 fertig im Aggregat (`agg["thunder_signals"]`) und wurde nur nicht gelesen — damals eine bewusste Entscheidung.
- **Ortsvergleich-Stundentabelle:** `_fmt_thunder` hat den dritten Parameter seit Scheibe 1; er wurde an dieser Aufrufstelle nur nicht übergeben — ebenfalls bewusst.

Beides hat der PO am 2026-08-13 abgelöst. Netto **+103 Zeilen**, davon rund 60 Kommentar.

## Der Zusatz gehört an die Aufrufstelle, nicht in den Rumpf

`_fmt_thunder` speist die Stundentabelle **und** die bereits ausgelieferte Übersichtszeile aus Scheibe 1. Eine Änderung im Rumpf hätte die stillschweigend mitverändert. Fachlich trägt derselbe Grund: Jede Stundenzeile braucht die Zutat **ihres** Datenpunkts — das könnte ein Rumpf-Zusatz gar nicht unterscheiden. AC-14 bewacht, dass die Übersichtszeile zeichengleich bleibt; die Adversary-Mutation dazu wurde von drei Tests gefangen.

## Zwei Bestandstests bewachten die abgelösten Entscheidungen

Beide Vorgängerscheiben hatten ihre Zurückhaltung ordentlich in Tests gegossen — genau die schlugen jetzt Alarm. Das ist das System, das funktioniert, kein Fehler.

Sie wurden **mitgezogen, nicht umgedreht**: Eine umgedrehte Erwartung stünde doppelt in zwei Dateien und driftete beim nächsten Wechsel auseinander; die neue Zusicherung ist bereits in der S3-Datei bewacht. Beim Compare-Test fällt nur **eine Hälfte** weg — die Trip-Stundentabelle bleibt ausdrücklich ohne Herkunft und wird weiter bewacht, samt der Gegenprobe, die verhindert, dass diese Abwesenheits-Zusicherung vakuum-grün wird. Drei stehengebliebene Notizen sind nachgezogen, darunter eine, die „keine Zutat in einer Stundentabelle" behauptete.

## 🔴 Die dünnste Stelle, ausdrücklich benannt

An der Compare-Stundenzelle wird `dp.thunder_level_signals` **roh** durchgereicht, ohne `union_of_max_carriers()`. Die in Scheibe 2 eingebaute Garantie („Stufe `NONE` ⇒ keine Herkunft") greift dort **nicht**. Dass eine gewitterlose Stunde nicht zu `— · CAPE` wird, hält allein eine zweite, unabhängige Zusage: `thunder_signal_carriers()` liefert für `NONE` eine leere Liste.

Das ist dieselbe Konstellation, die in Scheibe 2 ein Adversary-Finding war — eine Zusage, die nur wegen einer Eigenschaft an anderer Stelle hält. Diesmal steht sie in der Spec, im Commit-Text und hier, statt entdeckt zu werden. Der Adversary hat sie gezielt angegriffen: Mutation (g) macht den `NONE`-Zweig nichtleer und wird von **genau einem** Test gefangen — die Behauptung „ein Wächter" stimmt, und der Wächter greift.

## Nachweis

| Was | Ergebnis |
|---|---|
| Akzeptanzkriterien | 16, jedes bis zum zugestellten Text |
| Tests | 40 grün über drei Dateien, keine Deselektion |
| Mutations-Gegenprobe | 6 Pflicht + 3 eigene = **9, alle gefangen** |
| Adversary | 2 Runden, Verdict **VERIFIED** |
| Zugestellte Briefing-Mail | `briefing_mail_validator.py` Exit 0 |
| Zugestellte Vergleichs-Mail | `email_spec_validator.py` Exit 0 |
| Renderer-Commit-Gate | beide Mailpfade nachgewiesen, `test_issue_811_mode_matrix.py` grün |

**Die SMS-Dichtheit wurde nicht per Wortsuche belegt**, sondern per Sonde: die Beschriftungsfunktion wurde zur Laufzeit eingefärbt, sodass **jeder** angehängte Herkunftstext aufgefallen wäre — auch einer mit unbekannter Bezeichnung. Mit Gegenprobe, dass die Färbung in Mail und Telegram anschlägt; ohne die wäre „nichts gefunden" wertlos.

## Eine Berichtigung an der freigegebenen Spec

AC-12 verlangte ursprünglich, dass **auch Telegram** keine der vier Zutat-Bezeichnungen trägt. Das ist am ausgelieferten Stand falsch: Die Telegram-Übersichtszeile zeigt die Herkunft seit Scheibe 1 ausdrücklich, bewacht von einem grünen Test und gedeckt vom PO-Entscheid „E-Mail und Telegram ja". Die wörtliche Fassung wäre nur grün zu bekommen gewesen, indem eine ausgelieferte Zusage bricht. Aufgefallen in der RED-Phase, berichtigt vor der Implementierung — geprüft wird jetzt, was AC-12 wirklich trägt: aus den **neuen** Stundentabellen-Aufrufstellen darf nichts in die Kurznachrichtenkanäle lecken.

Vier weitere Spec-Annahmen hielten der Messung nicht stand und sind als eigener Abschnitt nachgetragen — darunter, dass „kein Gewitter" an den vier Orten **drei verschiedene Wörter** bedeutet.

## Nicht in dieser Scheibe

Mehrtages-Ausblick · Gewitter-Vorschau · Trip-Stundentabelle (Träger gehen dort strukturell verloren, `HourlyValue` hat kein Signalfeld). **Go-DTO und Frontend fallen ersatzlos** — in Go wird der Datentyp nirgends konstruiert oder gelesen, im Frontend rendert keine Komponente eine echte Gewitterstufe. `aggregate_stage()` bleibt unangeschlossen: keiner der vier Orte aktiviert ihn.

Issue #1680 bleibt offen. Bezug: Epic #1419 Rang 4. Vorgänger: PR #1780 (S1), #1797 (S2).
