### PR TITLE
fix: /next-ticket darf Belegt-Status nie als Bedingung an den User zurueckgeben

### DIFF
--- a/.claude/commands/next-ticket.md
+++ b/.claude/commands/next-ticket.md
@@ -44,6 +44,13 @@ ohne gültiges `.git` sehen wie ein Tab aus, sind aber keiner). Jede Issue-Numme
 als aktiv erkannt wird → aus der Kandidatenliste ausschließen. Workflows mit sehr altem
 Stand und/oder bereits `gh issue view <N> --json state` CLOSED zählen nicht als belegt.
 
+**Das Ergebnis ist eine Tatsache, kein Vorbehalt.** Genau dafür läuft dieser Schritt — damit
+der User nicht selbst nachsehen muss, ob ein Kandidat gerade woanders läuft. Für JEDEN
+Kandidaten, der es in Schritt 4 in die Empfehlung oder die Alternativen schafft, muss vorher
+feststehen: frei oder belegt. Ließ sich das für einen Worktree technisch nicht prüfen (z. B.
+nicht lesbar, `workflow.py` schlägt fehl): das ehrlich als Lücke benennen ("Tab X konnte
+nicht geprüft werden") statt den Kandidaten trotzdem unter Vorbehalt weiterzureichen.
+
 ## Schritt 3: Backlog + echte Priorität, nicht nur das Label
 
 ```bash
@@ -85,6 +92,14 @@ Ausgabe NUR im Chat dieser Session, kein Artifact, kein Dashboard:
   zuerst anlegen") statt es als startbar hinzustellen.
 - Nur falls die Empfehlung unklar/knapp blockiert ist: 1–2 Alternativen darunter, kurz
   begründet, ebenfalls jeweils mit Issue-Nummer.
+- **VERBOTEN: den Belegt-Status eines anderen Tabs als Bedingung an den User zurückgeben**
+  — Formulierungen wie „falls #N gerade in einem anderen Fenster läuft" sind genau die
+  Prüfung, die Schritt 2 abschließend übernehmen soll, nicht der User. Jede genannte
+  Empfehlung/Alternative ist zum Ausgabezeitpunkt bereits als frei bestätigt. Konnte das für
+  einen Kandidaten nicht geprüft werden, gehört er entweder gar nicht in die Antwort, oder es
+  steht offen dabei "Tab X konnte nicht geprüft werden" — nie als stilles "falls". Erlaubt
+  bleibt ausschließlich ein echter Ermessens-Vorbehalt, der beim User liegt (z. B. "falls du
+  anders priorisieren willst").
 - Keine Tab-Buchstaben, keine Nachrücker-Liste für andere Tabs — das bleibt `/radar`s
   Aufgabe. Wenn der Gesamtüberblick über alle Fenster gefragt ist, `/radar` vorschlagen
   statt hier nachzubauen.


### PR DESCRIPTION
## Summary
- `/next-ticket` gab in der Praxis Formulierungen wie "falls #1776 gerade in einem anderen Fenster laeuft" aus — genau die Belegt-Pruefung, die Schritt 2 des Commands definitiv klaeren soll, statt sie dem User zurueckzugeben.
- Schritt 2 jetzt PFLICHT-Klarstellung: das Ergebnis ist eine Tatsache, kein Vorbehalt. Liess sich ein Kandidat technisch nicht pruefen, muss die Antwort das offen sagen, nicht als "falls" tarnen.
- Schritt 4: explizites Verbot, den Belegt-Status als Bedingung an den User zurueckzugeben. Ein echter Ermessens-Vorbehalt beim User ("falls du anders priorisieren willst") bleibt erlaubt.

## Test plan
- [x] Reine Tooling-Datei (`.claude/commands/`), keine Aenderung an `src/`/`api/`/`internal/`/`frontend/`/`cmd/` — Staging-Validierung/Deploy entfaellt laut CLAUDE.md-Ausnahme.
- [ ] Nach Merge: `/next-ticket` erneut aufrufen und pruefen, dass keine "falls X laeuft"-Formulierung mehr auftaucht.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>