### PR TITLE
fix(#1703 S8): fehlgeschlagenes Speichern wird nicht mehr als Erfolg gemeldet

### DIFF
--- a/frontend/src/lib/stores/__tests__/saveStatus.test.ts
+++ b/frontend/src/lib/stores/__tests__/saveStatus.test.ts
@@ -73,6 +73,9 @@ function createTestInstance(): SaveStatus {
 	internals._timer = null;
 	internals._pendingFn = null;
 	internals._inflight = null;
+	// Issue #1703 S8: Merker des letzten gescheiterten Speicherversuchs — auch ein
+	// Konstruktor-Feld (`= null`).
+	internals._unresolvedError = null;
 	return inst;
 }
 
@@ -143,6 +146,90 @@ describe('AC-2 (RED, Issue #1269 (b)): markPristine() geht dirty→idle OHNE sav
 			'function',
 			'SaveStatus.prototype.markPristine muss als parameterlose Methode existieren'
 		);
+	});
+});
+
+// Issue #1703 Scheibe 8 — Staging-Verdict BROKEN (Klickpfad
+// compare-uebersicht-kanal-persistenz.staging.spec.ts, Test "Rollback"):
+// nach einem PUT mit HTTP 500 zeigte der Indikator "Gespeichert" statt "Fehler".
+//
+// Ursache: EINE Geste löst im Vergleichs-Hub ZWEI Commits aus (direkter
+// `onCompareCommit` aus WeatherMetricsTab.editCompareChannel + das
+// Wrapper-Ereignis `.hub-wetter-metriken-wrap` in CompareTabs.svelte). Der erste
+// fängt den 500, rollt die Daten zurück und ruft setError(). Der zweite findet
+// nach dem Rollback keinen Diff mehr, schickt keinen PUT — und landete in
+// markPristine(), das den Fehler überschrieb.
+//
+// Geprüft wird hier der WIRKORT des Fixes: die Zustandsmaschine selbst. Beide
+// Reihenfolgen (mit und ohne zwischenzeitliches setSaving() des zweiten
+// Commits) müssen im Fehlerzustand enden.
+describe('Issue #1703 S8: ein folgenloser zweiter Commit darf einen gescheiterten Speichervorgang nicht in "Gespeichert" umdeuten', () => {
+	test('setError() → markPristine(): Zustand UND Meldung bleiben stehen', () => {
+		const c = createTestInstance();
+		c.setSaved();
+
+		c.setError('E2E-Simulation');
+		c.markPristine();
+
+		assert.equal(
+			c.state,
+			'error',
+			'markPristine() darf einen offenen Fehlschlag nicht auf idle setzen — der Nutzer läse "Gespeichert", ' +
+				'obwohl der PUT scheiterte'
+		);
+		assert.equal(c.error, 'E2E-Simulation', 'die Fehlermeldung muss erhalten bleiben');
+	});
+
+	test('setError() → setSaving() (zweiter Commit) → markPristine(): endet trotzdem im Fehlerzustand', () => {
+		const c = createTestInstance();
+
+		c.setError('E2E-Simulation');
+		// Genau die Reihenfolge des zweiten Commits: er meldet zuerst "Speichere …"
+		// (setSaving leert `error`) und stellt erst danach fest, dass es nichts zu
+		// senden gibt. Ein bloßer `state === 'error'`-Riegel in markPristine()
+		// würde hier NICHT greifen.
+		c.setSaving();
+		c.markPristine();
+
+		assert.equal(c.state, 'error', 'der Fehlschlag ist unbeantwortet — der Indikator muss ihn weiter zeigen');
+		assert.equal(c.error, 'E2E-Simulation', 'die Fehlermeldung muss wiederhergestellt sein');
+	});
+
+	test('echter doSave()-Fehlschlag → markPristine(): bleibt Fehler (Fehlerweg über den Produktionspfad)', async () => {
+		const c = createTestInstance();
+
+		await c.doSave(async () => {
+			throw { detail: 'E2E-Simulation' };
+		});
+		assert.equal(c.state, 'error', 'Vorbedingung: doSave() muss den Fehlschlag in den Fehlerzustand führen');
+
+		c.markPristine();
+
+		assert.equal(c.state, 'error');
+		assert.equal(c.error, 'E2E-Simulation');
+	});
+
+	test('nach einem ECHTEN Erfolg löst sich die Sperre wieder: setSaved() → setSaving() → markPristine() geht auf idle', async () => {
+		const c = createTestInstance();
+		c.setError('E2E-Simulation');
+
+		// Ein späterer, erfolgreicher Speichervorgang beantwortet den Fehlschlag.
+		await c.doSave(async () => {
+			/* echter Erfolgspfad */
+		});
+		assert.equal(c.state, 'idle');
+
+		// Danach ist ein folgenloser Commit wieder ein ganz normaler No-Op.
+		c.setSaving();
+		c.markPristine();
+
+		assert.equal(
+			c.state,
+			'idle',
+			'ohne offenen Fehlschlag muss markPristine() unverändert auf idle gehen — sonst bliebe der Editor ' +
+				'für immer im Fehlerzustand hängen'
+		);
+		assert.equal(c.error, null, 'die alte Meldung darf nach dem Erfolg nicht wieder auftauchen');
 	});
 });
 

--- a/frontend/src/lib/stores/saveStatusStore.svelte.ts
+++ b/frontend/src/lib/stores/saveStatusStore.svelte.ts
@@ -45,6 +45,13 @@ export class SaveStatus {
 
 	private _tripId?: string;
 
+	// Issue #1703 S8 (Staging-Befund BROKEN): die Meldung des letzten ECHTEN
+	// Speicherversuchs, solange sie NICHT durch einen erfolgreichen ersetzt
+	// wurde. Eigenes Feld statt `error`, weil `setSaving()` `error` bewusst
+	// leert — ein zweiter, folgenloser Commit derselben Geste (Diff-Guard
+	// liefert keinen Payload) darf den Fehlschlag trotzdem nicht vergessen.
+	private _unresolvedError: string | null = null;
+
 	constructor(tripId?: string) {
 		this._tripId = tripId;
 	}
@@ -58,6 +65,8 @@ export class SaveStatus {
 		this.savedAt = new Date();
 		this.state = 'idle';
 		this.error = null;
+		// Erst ein ECHTER Erfolg loescht den offenen Fehlschlag (s. markPristine).
+		this._unresolvedError = null;
 	}
 
 	setDirty(): void {
@@ -71,8 +80,25 @@ export class SaveStatus {
 	 * faelschlich dirty gesetzt hatte). savedAt bleibt unangetastet, damit nie
 	 * ein frischer "Gespeichert HH:MM"-Zeitstempel ohne echten Speichervorgang
 	 * vorgetaeuscht wird.
+	 *
+	 * Issue #1703 S8 (Staging-Befund BROKEN, Rollback-Klickpfad): "nichts zu
+	 * speichern" heisst NICHT "gespeichert", solange der letzte echte Versuch
+	 * gescheitert ist. Eine Geste kann mehrere Commits ausloesen (direkter
+	 * `onCompareCommit` + Wrapper-Ereignis in CompareTabs.svelte). Auf dem
+	 * Fehlerpfad faellt der Zustand durch den Rollback wieder mit dem
+	 * gespeicherten Stand zusammen — der zweite Commit findet dann keinen Diff
+	 * und landete hier, wodurch er den gerade gesetzten Fehler mit "Gespeichert"
+	 * ueberschrieb. Der Nutzer las Erfolg, obwohl der PUT mit 500 scheiterte.
 	 */
 	markPristine(): void {
+		// Truthy-Pruefung (nicht `!== null`): Testinstanzen entstehen im Repo per
+		// `Object.create(SaveStatus.prototype)` ohne Konstruktor, das Feld ist dort
+		// `undefined` — und "kein Fehlschlag bekannt" muss dort dasselbe heissen.
+		if (this._unresolvedError) {
+			this.state = 'error';
+			this.error = this._unresolvedError;
+			return;
+		}
 		this.state = 'idle';
 		this.error = null;
 	}
@@ -80,6 +106,7 @@ export class SaveStatus {
 	setError(msg: string): void {
 		this.state = 'error';
 		this.error = msg;
+		this._unresolvedError = msg;
 	}
 
 	async doSave(saveFn: SaveFn, init?: RequestInit): Promise<void> {


### PR DESCRIPTION
Von der Staging-Verifikation gefunden (VERDICT BROKEN, Klickpfad
compare-uebersicht-kanal-persistenz Test 3 reproduzierbar rot).

NUTZERSICHTBAR: Schlaegt das Speichern im Ortsvergleich fehl, zeigte die
Oberflaeche trotzdem 'Gespeichert HH:MM'. Die Daten rollten korrekt zurueck
(kein Datenverlust) -- aber der Nutzer glaubte, seine Aenderung sei
gesichert. Das ist die schlimmere Haelfte: stiller Verlust mit
Erfolgsmeldung.

URSACHE: Eine Geste loest zwei Commits aus (editCompareChannel ruft
onCompareCommit direkt, der Wrapper CompareTabs.svelte:1386 ein zweites
Mal). Im Erfolgsfall harmlos -- der Diff-Guard schluckt den zweiten. Auf
dem FEHLERPFAD kippt es: Aufruf 1 faengt den 500, rollt zurueck, setzt
error. Aufruf 2 findet danach keinen Diff mehr, schickt keinen PUT und
ruft markPristine() -- das ueberschreibt den Fehler mit idle. Die
Reihenfolge ist nicht zufaellig, sondern durch createPutQueue
determiniert (compareHubWizardBridge.ts:442-454).

FIX in der Anzeige-Zustandsmaschine (saveStatusStore): ein Merker haelt
den letzten unbehandelten Fehlschlag fest; markPristine() stellt ihn
wieder her statt ihn zu ueberschreiben. setSaved() loescht ihn.

VERWORFEN, und das ist der Punkt: den direkten onCompareCommit-Aufruf zu
entfernen (die naheliegende Ursachenbeseitigung) haette das Speichern
nach der ZIEHGESTE zerstoert -- editCompareChannel ist der Trichter fuer
alle drei Gesten, und die Ziehgeste erzeugt keinen Klick, den der Wrapper
sehen koennte. Genau diese Zeile hat #1359 eingefuehrt. Am Code gemessen,
nicht angenommen.

Ebenfalls verworfen: ein blosser Riegel 'if state === error return'. Der
zweite Commit ruft vor seiner No-Op-Feststellung setSaving(), das error
leert -- der Riegel liefe ins Leere. Per Mutation belegt (M2 macht genau
einen Test rot).

Beruehrt die GETEILTE Zustandsmaschine (Trip nutzt sie auch); Aenderung
ist additiv, 36 Tests der uebrigen Nutzer gruen.

Gegenproben: Fix zurueckgedreht = 3 Tests rot; schwaecherer Riegel = 1
Test rot. saveStatus 16/16, Compare-Speicherpfad 90/90.

Bekannte Grenze: dass eine Geste zwei Commits ausloest, ist offline nicht
bewacht (.svelte wird von node:test nicht gemountet). Der Nachweis dafuer
haengt am Staging-Klickpfad.

Refs #1703

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
