### PR TITLE
feat: /next-ticket erkennt alle in diesem Repo tatsaechlich genutzten Epic-Ketten-Formen

### DIFF
--- a/.claude/commands/next-ticket.md
+++ b/.claude/commands/next-ticket.md
@@ -91,9 +91,16 @@ Fork mit `gh issue view` + Code-Grep, wie in `/radar` Schritt 3 — Titel-/Label
 allein reicht nicht als Nachweis.
 
 **Erst den eigenen Strang zu Ende prüfen, PFLICHT vor dem Rest des Backlogs.** Gehört das
-zuletzt in diesem Tab bearbeitete Issue zu einer Kette (Epic-Bezug im Body, "Folge zu #X",
-"Scheibe N von #X", gemeinsames `epic`-Label)? Wenn ja, ist das nächste offene Folge-Issue
-im selben Strang der Standard-Kandidat — ein Themenwechsel kostet nach einem `/clear`
+zuletzt in diesem Tab bearbeitete Issue zu einer Kette? In diesem Repo tatsächlich verwendete
+Schreibweisen dafür, alle gleichwertig erkennen (Vielfalt ist Bestand, keine davon ist
+"falsch"): **"Folge zu #X"**, **"Scheibe N von #X"**, **"Nachzug zu #X"**, **"Teil von #X"**,
+**"S<N>[a-z]? zu/von #X"** (z. B. "S2-Nachzug zu #1457"), sowie ein **Issue-Titel-Präfix**
+`#<Epic-Nr> S<N>[a-z]?:` (z. B. "#1676 S2b: ..." — die Epic-Nummer steht dabei VOR dem
+Doppelpunkt, nicht als Fließtext-Referenz). Gemeinsames `epic`-Label zählt zusätzlich als
+Hinweis, ersetzt aber keine der Textformen. Steht KEINE dieser Formen im Titel/Body, gilt das
+Issue als eigenständig — nicht aktiv nach einer Kette suchen, die nirgends benannt ist.
+Trifft eine der Formen zu, ist das nächste offene Folge-Issue im selben Strang der
+Standard-Kandidat — ein Themenwechsel kostet nach einem `/clear`
 echten Aufwand (Domänenwissen, bereits gelesene Spec/Analyse geht verloren, wird andernorts
 neu aufgebaut). Nur verdrängen, wenn ein anderer Punkt nachweislich dringender ist (harter
 Termin, kritischer/produktionsrelevanter Bug, ausdrückliche PO-Vorgabe) — dann in der


### PR DESCRIPTION
## Summary
- `/next-ticket` erkannte fuer Epic-Ketten bisher nur zwei Schreibweisen ("Folge zu #X", "Scheibe N von #X"). Real im Backlog verwendet werden mindestens vier weitere, strukturell verschiedene Formen.
- Bewusst KEIN Gate bei `gh issue create`, das eine einzige Schreibweise erzwingt — die bestehenden Muster sind zu unterschiedlich, um "echte" Folge-Referenz zuverlaessig von einer beilaeufigen "siehe #X"-Erwaehnung zu unterscheiden; ein solches Gate wuerde entweder die etablierte Vielfalt brechen oder haeufig fehlalarmen.
- Stattdessen die Lese-Seite erweitert: Schritt 3 erkennt jetzt zusaetzlich "Nachzug zu #X", "Teil von #X", "S<N> zu/von #X" und das Titel-Praefix-Muster "#<Epic-Nr> S<N>:".

## Test plan
- [x] Reine Tooling-Datei (`.claude/commands/`), kein Code in `src/`/`api/`/`internal/`/`frontend/`/`cmd/` — Staging/Deploy entfaellt laut CLAUDE.md-Ausnahme.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>