### PR TITLE
fix(#1776): staging_gate.py Selbstreferenz bei preflight_base

### DIFF
--- a/.claude/hooks/staging_gate.py
+++ b/.claude/hooks/staging_gate.py
@@ -156,7 +156,7 @@ def _scope_diff_base(head: str | None = None) -> str:
     """
     head = head if head is not None else _head_sha()
     preflight_base = _e2e_paths.read_preflight_base(_shared_repo_dir(), head)
-    if preflight_base is not None:
+    if preflight_base is not None and preflight_base != head:
         if _e2e_paths.commit_exists(preflight_base, _verified_repo_dir()):
             return preflight_base
 

--- a/docs/context/fix-1776-staging-gate-selfref.md
+++ b/docs/context/fix-1776-staging-gate-selfref.md
@@ -1,0 +1,175 @@
+# Bug-Analyse #1776: staging_gate.py Selbstreferenz bei preflight_base
+
+**Status:** Analyse abgeschlossen  
+**Datum:** 2026-08-13  
+**Workflow:** `fix-1776-staging-gate-selfref`  
+**Live-Vorfälle:** 6 dokumentiert (zuletzt 2026-08-13, Deploy #1533 S4/PR #1803)
+
+## Symptom
+
+`staging_gate.py --check` klassifiziert manche Commits mit Produktivcode fälschlich als `docs-only` ("nur Dokumentation, kein Code"). Bei dieser Klassifikation springt das Gate mit `return 0` direkt durch — **ohne jede Staging-Attestations-Prüfung**. Die Folge: Code landet in Produktion ohne Nachweis eines bestandenen Staging-Tests.
+
+**Beispiel aus #1725 (2026-08-12, Merge-Commit `414b0b87`):**
+- `git diff --name-only HEAD~1..HEAD` zeigt: `src/services/briefing_slots.py`, `src/services/dispatch_orchestrator.py`, `src/services/trip_report_scheduler.py`
+- `staging_gate.py --detect-scope` meldet: `docs-only`
+- `gate_check()` Zeile 559: `if scope == "docs-only": return 0` (Early Exit, keine Attestations-Prüfung)
+
+## Root Cause
+
+Zwei verschiedene Fehler-Pfade führen zum gleichen Fehler; beide sind dokumentiert und verifiziert.
+
+### RC 1: Fehlende Selbstreferenz-Prüfung im `preflight_base`-Zweig (Hauptbefund #1776)
+
+**Datei:** `.claude/hooks/staging_gate.py`, Funktion `_scope_diff_base()`, Zeilen 158–161
+
+```python
+# Fehler-Code (aktuell):
+preflight_base = _e2e_paths.read_preflight_base(_shared_repo_dir(), head)
+if preflight_base is not None:
+    if _e2e_paths.commit_exists(preflight_base, _verified_repo_dir()):
+        return preflight_base                             # ← FEHLER: keine Prüfung auf preflight_base == head
+```
+
+**Vergleich mit `marker_sha`-Zweig (Zeile 163–166), der die Prüfung HAT:**
+
+```python
+marker_sha = _e2e_paths.read_last_gate_scope(_shared_repo_dir())
+if marker_sha and marker_sha != head:                   # ← Korrekt: Selbstreferenz-Schutz
+    if _e2e_paths.commit_exists(marker_sha, _verified_repo_dir()):
+        return marker_sha
+return "HEAD~1"
+```
+
+**Mechanismus:**
+
+1. `write_preflight_base()` (`.claude/hooks/_e2e_paths.py`, Zeile 135–152) speichert `{"target_sha": <head>, "base_sha": <basis>}` ab
+2. Bei einem Merge kurz nach dem Preflight kann `base_sha == target_sha` werden (Selbstreferenz)
+3. `_scope_diff_base()` liest diese Basis, prüft sie NICHT auf Selbstreferenz
+4. `_detect_committed_scope()` führt `git diff HEAD..HEAD` aus → leer → `docs-only` fälschlich
+5. `gate_check()` Zeile 559 springt durch: `if scope == "docs-only": return 0`
+
+### RC 2: Marker wird mit `docs-only` auf HEAD geschrieben (Sekundär-Pfad, Issue #1640)
+
+**Datei:** `.claude/hooks/staging_gate.py`, Zeile 568–569
+
+```python
+# Nach einem fehlerhaften docs-only-Durchlauf:
+existing = _e2e_paths.cached_scope_for_sha(_shared_repo_dir(), _head_sha())
+if existing is None or existing == "docs-only":
+    _e2e_paths.write_last_gate_scope(_shared_repo_dir(), _head_sha(), scope)  # ← Marker auf HEAD mit scope=docs-only
+```
+
+**Problem:**
+- Der Marker wird mit `gate_scope_sha == head` geschrieben (normalerweise nur bei Erfolgsfall), hier aber mit `scope=docs-only`
+- Ein zweiter `staging_gate.py`-Lauf (z.B. bei Nachträgen oder Wiederholungen, #1592 C3 gemessen) liest diesen Marker
+- `_scope_diff_base()` Zeile 164 prüft `marker_sha != head` — der Marker zeigt aber auf HEAD
+- Fallback zu `HEAD~1` würde greifen, ABER: Zeile 668–670 in `prod_selftest.py` nutzt den gecachten Scope direkt — ein zweiter Lauf auf `prod_selftest` kann hier keine neuen Tests fahren
+
+## Betroffene Dateien & Aufrufer
+
+| Datei | Funktion | Zeile | Kontext |
+|-------|----------|-------|---------|
+| `.claude/hooks/staging_gate.py` | `_scope_diff_base()` | 158–161 | Liest `preflight_base` ohne Selbstreferenz-Schutz |
+| `.claude/hooks/staging_gate.py` | `_detect_committed_scope()` | 198 | Ruft `_scope_diff_base(head)` auf (Benutzer von RC 1) |
+| `.claude/hooks/staging_gate.py` | `gate_check()` | 559–569 | Springt durch bei `docs-only`, schreibt Marker mit `docs-only` (RC 2) |
+| `.claude/hooks/_e2e_paths.py` | `read_preflight_base()` | 155–169 | Keine Selbstreferenz-Prüfung; gibt `base_sha` auch wenn `== target_sha` |
+| `.claude/hooks/_e2e_paths.py` | `write_preflight_base()` | 135–152 | Speichert ab, auch wenn `base_sha == target_sha` |
+| `.claude/hooks/prod_selftest.py` | `_scope_diff_base()` | 648 | **HAT** die `marker_sha != head`-Prüfung (korrekt) |
+| `.claude/hooks/prod_selftest.py` | `_detect_committed_scope()` | 668–670 | Nutzt gecachten Scope direkt (RC 2 relevant) |
+
+## Tests & Aufrufer-Aufzählung
+
+**Tests, die `_scope_diff_base()` oder Preflight-Basis testen (vorhandene Test-Abdeckung):**
+
+```
+tests/tdd/test_fix_1428_preflight_scope_base.py:118  # test_scope_diff_base_prefers_preflight_hint_over_marker
+tests/tdd/test_fix_1428_preflight_scope_base.py:140  # test_scope_diff_base_ignores_hint_for_wrong_target
+tests/tdd/test_e2e_path_helper.py:301–319           # (Mehrere Aufrufe auf _scope_diff_base())
+tests/tdd/test_prod_selftest_scope_diff_base.py     # Prod-Selftest-Variante (hat den Selbstreferenz-Schutz)
+tests/tdd/test_issue_1109_prod_deploy_marker.py     # Prod-Deploy-Marker-Tests
+tests/tdd/test_issue_668_head_sha_dedup.py          # Subprozess-Deduplizierung
+```
+
+## Geschätzter Aufwand
+
+| Komponente | LoC/Änderung | Aufwand |
+|-----------|---|---|
+| **Fix RC 1** | `staging_gate.py:160` Bedingung `preflight_base != head` hinzufügen | +1 Zeile |
+| **Fix RC 2** | `staging_gate.py:568` – Marker-Herabstufung verhindern | +3–5 Zeilen |
+| **Tests (neu)** | 2 neue Testfunktionen, Fixtures | ~50–80 LoC |
+| **Regression-Tests** | Bestehende Tests in `test_fix_1428_preflight_scope_base.py` | 0 (bereits vorhanden) |
+| **Dokumentation** | Docstring-Aktualisierung | +5 Zeilen |
+
+**Gesamt:** Klein (Hauptdatei: `.claude/hooks/staging_gate.py`)  
+**Risiko:** Niedrig (isolierte Bedingungen-Prüfung)
+
+## Unterschied zu Issue #1640
+
+| Aspekt | #1776 | #1640 |
+|--------|-------|-------|
+| **Hauptursache** | Fehlende Prüfung im preflight-Zweig | Marker wird mit `docs-only` auf HEAD geschrieben |
+| **Betroffen ist** | `_scope_diff_base()` Zeile 158–161 | `gate_check()` Zeile 568–569 |
+| **Symptom** | Erste Runde gibt `docs-only` zurück | Zweite Runde stellt fest, dass Marker auf HEAD zeigt |
+| **Gemeinsam** | Beide führen zu fälschlichem `docs-only` und Durchlassung |
+| **Reparatur** | Getrennte Fixes, aber interdependent |
+
+## Nächste Schritte (Implementierungs-Phase)
+
+1. **Spec schreiben** (`/30-write-spec`): ACs für RC1
+2. **TDD RED** (`/40-tdd-red`): Tests schreiben, rot laufen
+3. **Implementierung** (`/50-implement`): RC1-Fix
+4. **Adversary Verification** (automatisch): Mutation-Test aller geänderten Zeilen
+
+## Analysis
+
+### Type
+Bug
+
+### Scope-Entscheidung (PO-relevant, vor Spec zu bestätigen)
+
+Der Bug-Intake-Report oben nennt zwei Root Causes (RC1, RC2). **Nur RC1 ist Gegenstand dieses
+Fixes.** RC2 (Marker wird nach einem `docs-only`-Lauf mit `docs-only` auf HEAD geschrieben, ein
+zweiter Lauf nutzt den gecachten Wert weiter) überschneidet sich mit dem separat offenen Issue
+#1640 und wird dort behandelt, nicht hier — Vermischung würde denselben kritischen Code
+zweimal aus unterschiedlichen Blickwinkeln anfassen und den engen, klar belegten Zuschnitt von
+#1776 aufweichen. Offene Frage laut Plan-Bewertung: RC1s Fallback-Kette (`marker_sha`) würde
+einen durch RC2 fälschlich gesetzten Marker weiterhin konsumieren — das ist eine Abgrenzungsfrage
+für die Spec-Phase, keine Entscheidung, die hier vorweggenommen wird.
+
+### Affected Files (with changes)
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `.claude/hooks/staging_gate.py` | MODIFY | `_scope_diff_base()` Zeile 158–161: Selbstreferenz-Guard `preflight_base != head` ergänzen (analog `marker_sha`-Zweig Zeile 164) |
+| `tests/tdd/test_fix_1428_preflight_scope_base.py` | MODIFY | 1–2 neue Testfunktionen: Selbstreferenz-Szenario (`base_sha == target_sha`) erzeugen, Fallback auf Marker/`HEAD~1` erwarten statt Selbstreferenz-Rückgabe |
+
+### Scope Assessment
+- Files: 2
+- Estimated LoC: +1 (Fix) / +30–40 (Tests) — 0 Löschungen
+- Risk Level: LOW (isolierte, symmetrische Bedingungsergänzung; kein legitimer Fall gefunden, in dem die Selbstreferenz gewollt ist)
+
+### Technical Approach
+Guard beim Konsum ergänzen, nicht bei der Schreib-/Lesehilfsfunktion:
+`if preflight_base is not None and preflight_base != head:` in `_scope_diff_base()`. Spiegelt
+exakt das bestehende Muster des direkt folgenden `marker_sha`-Zweigs. `prod_selftest.py` ist
+unbetroffen (konsumiert `preflight_base` nicht, sein eigener `marker_sha`-Schutz ist bereits
+korrekt).
+
+Pflicht-Test für die Mutations-Gegenprobe (dieses Projekt verlangt das): ein Test, der
+`write_preflight_base(repo, target, base=target)` (Selbstreferenz) setzt, `_scope_diff_base()`
+mit `head=target` aufruft und ein Ergebnis `!= target` erwartet. Entfernt man die Bedingung
+wieder, liefert die Funktion `target` zurück → Test wird rot. Zusätzlich bestehenden Test
+`test_regular_check_after_reset_agrees_with_preflight_docs_only` als Regressionscheck laufen
+lassen.
+
+### Dependencies
+Keine. Unabhängig von `prod_selftest.py` und von #1640 (RC2, bewusst nicht mitgezogen, siehe
+Scope-Entscheidung oben).
+
+### Open Questions
+- [ ] Deckt der neue Test die drei real beobachteten Vorfälle (#1725, #1803, und der ursprüngliche
+      #1776-Befund) strukturell ab, oder braucht es zusätzlich einen Test je Vorfall? (Vermutlich
+      genügt der eine strukturelle Test — die drei Vorfälle sind dieselbe Ursache.)
+- [ ] Soll die Spec RC1s Wechselwirkung mit dem (separat zu fixenden) RC2 aus #1640 als
+      Nicht-Ziel explizit ausschließen, damit der Adversary später nicht versehentlich RC2 mit
+      hineinzieht?

--- a/docs/project/known_issues.md
+++ b/docs/project/known_issues.md
@@ -59,6 +59,18 @@ Diagnose und Fix-Design stammen von der `henemm-infra`-Claude-Instanz (inkl. Sel
 1. **Eine Diff-BASIS zu hinterlegen ist robuster als einen fertigen Scope-WERT zu cachen**, wenn eine bereits bestehende Schutzregel (hier #1096/F001) genau diesen Wert-Cache für einen bestimmten Ergebnistyp (`docs-only`) grundsätzlich verwirft — der erste, naheliegende Lösungsansatz hätte an der eigenen Schutzregel scheitern müssen.
 2. **Cross-Repo-Root-Cause-Analyse funktioniert**, wenn die diagnostizierende Instanz keinen Schreibzugriff auf das betroffene Repo braucht, um trotzdem den vollständigen Fix (inkl. Code) zu liefern — die Umsetzung bleibt dann bei der zuständigen Instanz.
 
+### Nachtrag (2026-08-13, Fix #1776): verbleibende Selbstreferenz im `preflight_base`-Zweig
+
+Der obige Fix hinterlegt die Diff-Basis, prüfte beim Lesen in `_scope_diff_base()` aber nicht, ob
+`preflight_base` zufällig mit dem aktuellen HEAD identisch ist (Selbstreferenz, z. B. bei einem
+Merge kurz nach dem Preflight). Das ergab denselben `HEAD..HEAD`-Fehlklassifikations-Effekt wie
+das Ursprungsproblem, nur über den neuen Hint statt den alten Marker — dreimal live beobachtet
+(#1725, #1803, sowie der #1776-Befund selbst). Fix: `_scope_diff_base()` verlangt jetzt zusätzlich
+`preflight_base != head`, spiegelbildlich zum bereits vorhandenen `marker_sha != head`-Schutz im
+direkt folgenden Zweig. Details: `docs/specs/modules/fix_1776_staging_gate_selfref.md`. Der
+separate Fehlerpfad über einen fälschlich mit `scope=docs-only` auf HEAD geschriebenen Marker
+(Issue #1640) ist davon unberührt und bleibt offen.
+
 ---
 
 ## BUG-1383-1385-1386-ALERT-TZ: Alarm-Uhrzeiten in drei Renderpfaden in UTC statt Ortszeit

--- a/docs/specs/modules/fix_1776_staging_gate_selfref.md
+++ b/docs/specs/modules/fix_1776_staging_gate_selfref.md
@@ -1,0 +1,134 @@
+---
+entity_id: fix_1776_staging_gate_selfref
+type: module
+created: 2026-08-13
+updated: 2026-08-13
+status: draft
+version: "1.0"
+tags: [bugfix, staging-gate, deploy-safety]
+---
+
+# Fix #1776: staging_gate.py Selbstreferenz bei preflight_base
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`_scope_diff_base()` in `staging_gate.py` liest die vom Preflight hinterlegte Diff-Basis
+(`preflight_base`) ohne zu prüfen, ob diese zufällig mit dem aktuellen HEAD identisch ist. Bei
+Selbstreferenz (`preflight_base == head`) entsteht ein `HEAD..HEAD`-Diff, der immer leer ist und
+fälschlich als `docs-only` klassifiziert wird — das lässt `gate_check()` die komplette
+Staging-Attestations-Prüfung überspringen und Produktivcode ohne Staging-Nachweis passieren.
+Der Fix ergänzt denselben Selbstreferenz-Schutz, den der direkt danach folgende
+`marker_sha`-Zweig bereits hat.
+
+## Source
+
+- **File:** `.claude/hooks/staging_gate.py`
+- **Identifier:** `def _scope_diff_base(head: str | None = None) -> str` (Zeile 158–161 betroffen)
+
+## Estimated Scope
+
+- **LoC:** ~1 (Fix) + ~30–40 (Tests)
+- **Files:** 2
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `.claude/hooks/_e2e_paths.py::read_preflight_base` | function | Liefert die vom Preflight hinterlegte Diff-Basis, die `_scope_diff_base()` konsumiert |
+| `.claude/hooks/_e2e_paths.py::write_preflight_base` | function | Wird im Test verwendet, um den Selbstreferenz-Fall (`base == target`) zu erzeugen |
+| `tests/tdd/test_fix_1428_preflight_scope_base.py` | test module | Bestehende Regressionstests für `_scope_diff_base()`, dürfen durch den Fix nicht brechen |
+
+## Implementation Details
+
+```
+Vorher (.claude/hooks/staging_gate.py, _scope_diff_base(), Zeile 158-161):
+    preflight_base = _e2e_paths.read_preflight_base(_shared_repo_dir(), head)
+    if preflight_base is not None:
+        if _e2e_paths.commit_exists(preflight_base, _verified_repo_dir()):
+            return preflight_base
+
+Nachher:
+    preflight_base = _e2e_paths.read_preflight_base(_shared_repo_dir(), head)
+    if preflight_base is not None and preflight_base != head:
+        if _e2e_paths.commit_exists(preflight_base, _verified_repo_dir()):
+            return preflight_base
+```
+
+Der Guard spiegelt exakt das bestehende Muster des direkt folgenden `marker_sha`-Zweigs
+(Zeile 163–166: `if marker_sha and marker_sha != head:`). Bei Selbstreferenz fällt die Funktion
+durch zur Marker-Prüfung und ggf. weiter zu `"HEAD~1"` — dieselbe Fallback-Kette, die für den
+`marker_sha`-Zweig bereits gilt und getestet ist.
+
+`prod_selftest.py` ist unbetroffen: es hat einen eigenen `_scope_diff_base()`, der
+`preflight_base` nicht konsumiert und dessen `marker_sha`-Schutz bereits korrekt ist.
+
+## Expected Behavior
+
+- **Input:** `_scope_diff_base(head=<SHA>)`, wobei für `<SHA>` per `write_preflight_base()` eine
+  Diff-Basis hinterlegt wurde, die identisch mit `<SHA>` selbst ist (Selbstreferenz).
+- **Output:** Die Funktion gibt **nicht** `<SHA>` zurück, sondern fällt auf die
+  Marker-Basis (falls vorhanden und auflösbar, `!= head`) oder `"HEAD~1"` zurück — dieselbe
+  Fallback-Kette wie im bestehenden `marker_sha`-Zweig.
+- **Side effects:** Keine. Reiner Lesepfad, keine Schreiboperation auf Marker-/Preflight-Dateien.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine per `write_preflight_base(repo, target, base=target)` hinterlegte
+  Selbstreferenz (Preflight-Basis == Ziel-Commit) für den aktuellen HEAD, When
+  `_scope_diff_base(head=target)` aufgerufen wird, Then liefert die Funktion einen Wert `!=
+  target` (Fallback auf Marker-SHA falls vorhanden und auflösbar, sonst `"HEAD~1"`) statt der
+  Selbstreferenz.
+  - Test: Neuer Test in `tests/tdd/test_fix_1428_preflight_scope_base.py` baut ein echtes
+    Temp-Git-Repo, hinterlegt `write_preflight_base(tmp_path, target, target)` (Selbstreferenz)
+    und ruft `GATE._scope_diff_base(head=target)` direkt auf (in-process, kein Mock der
+    Git-Logik). Assertion: Rückgabewert `!= target`. Entfernt man die Bedingung
+    `preflight_base != head` wieder (Mutations-Gegenprobe), liefert die Funktion `target` zurück
+    und der Test wird rot — das belegt, dass der Test die Zusicherung an der Stelle prüft, an der
+    sie wirkt.
+
+- **AC-2:** Given der bestehende Normalfall ohne Selbstreferenz (Preflight-Basis zeigt auf einen
+  von HEAD verschiedenen Commit, wie im Vorfall henemm-infra#148 / #1428), When
+  `gate_check()` mit Preflight (`expected_commit` gesetzt) und danach der reguläre Check nach
+  `git reset --hard` auf denselben Ziel-Commit laufen, Then bleibt das Ergebnis unverändert
+  `docs-only` (Exit 0) für einen tatsächlich docs-only Diff — keine Regression durch den neuen
+  Guard.
+  - Test: Bestehender Test `test_regular_check_after_reset_agrees_with_preflight_docs_only`
+    (`tests/tdd/test_fix_1428_preflight_scope_base.py:84`) läuft nach dem Fix weiterhin grün,
+    ebenso `test_scope_diff_base_prefers_preflight_hint_over_marker` und
+    `test_scope_diff_base_ignores_hint_for_wrong_target` (dieselbe Datei) — alle drei ohne
+    Selbstreferenz-Konstellation, daher vom neuen Guard nicht betroffen.
+
+## Known Limitations
+
+- **RC2 (#1640) ist explizit NICHT Teil dieses Fixes.** Issue #1640 behandelt einen separaten
+  Fehlerpfad: Nach einem fälschlichen `docs-only`-Lauf schreibt `gate_check()`
+  (Zeile 568–569) den Gate-Marker mit `scope=docs-only` auf HEAD. Ein zweiter Lauf liest diesen
+  gecachten Wert über `cached_scope_for_sha()` in `_detect_committed_scope()` direkt, ohne
+  erneut `_scope_diff_base()` zu durchlaufen — der hier eingeführte Guard wirkt dort nicht,
+  weil der fehlerhafte Scope bereits vor Erreichen von `_scope_diff_base()` aus dem Cache
+  zurückgegeben wird. Eine Vermischung beider Fixes würde denselben kritischen Code zweimal aus
+  unterschiedlichen Blickwinkeln anfassen und den Zuschnitt aufweichen — RC2 bleibt eigenständiges
+  Issue.
+- Der neue Guard in `_scope_diff_base()` schützt nur den `preflight_base`-Zweig. Fällt die
+  Funktion nach Selbstreferenz auf den `marker_sha`-Zweig zurück und zeigt AUCH dieser Marker
+  fälschlich auf HEAD (z. B. durch RC2 aus #1640 verursacht), greift dessen bereits vorhandener
+  `marker_sha != head`-Schutz und die Funktion fällt weiter auf `"HEAD~1"` zurück — das ist
+  bestehendes, unverändertes Verhalten und kein Teil dieser Spec.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Isolierter Bugfix an einer bestehenden Bedingungsprüfung, spiegelt ein im selben
+  Modul bereits etabliertes Muster (Selbstreferenz-Schutz im `marker_sha`-Zweig). Keine neue
+  Entscheidungsfläche (Kanäle, Provider, Datenmodell, Auth, Editor-Paradigma, Test-/Deploy-Strategie)
+  betroffen — die Deploy-Gate-Strategie selbst (Staging-Attestation vor Prod-Deploy) bleibt
+  unverändert, es wird nur ein Klassifikationsfehler innerhalb dieser Strategie behoben.
+
+## Changelog
+
+- 2026-08-13: Initial spec created

--- a/tests/tdd/test_fix_1428_preflight_scope_base.py
+++ b/tests/tdd/test_fix_1428_preflight_scope_base.py
@@ -154,3 +154,30 @@ def test_scope_diff_base_ignores_hint_for_wrong_target(tmp_path, monkeypatch):
         "Ein Hint fuer einen fremden Ziel-Commit darf nicht greifen -- Fallback "
         "auf die bestehende Marker-Logik"
     )
+
+
+# ---------------------------------------------------------------------------
+# Unit-Test (c): Selbstreferenz -- Fix #1776. Preflight-Basis == Ziel-Commit
+# selbst (kann bei einem Merge kurz nach dem Preflight entstehen). Ein
+# HEAD..HEAD-Diff waere immer leer und faelschlich "docs-only" (henemm-infra
+# Live-Vorfaelle #1725, #1803). _scope_diff_base() darf die Selbstreferenz
+# nicht zurueckgeben, sondern muss auf die bestehende Marker/HEAD~1-Fallback-
+# Kette ausweichen -- dasselbe Muster, das der marker_sha-Zweig (Zeile
+# 164: "if marker_sha and marker_sha != head") bereits hat.
+# ---------------------------------------------------------------------------
+def test_scope_diff_base_rejects_preflight_hint_self_reference(tmp_path, monkeypatch):
+    _init_repo(tmp_path)
+    target = _commit(tmp_path, {"src/app.py": "x = 1\n"}, "target (Preflight-Basis == Ziel-Commit)")
+    _point(monkeypatch, tmp_path)
+
+    # Selbstreferenz: Preflight-Basis zeigt auf den Ziel-Commit selbst.
+    GATE._e2e_paths.write_preflight_base(tmp_path, target, target)
+
+    _git(["checkout", "-q", target], tmp_path)
+    result = GATE._scope_diff_base(head=target)
+    assert result != target, (
+        "Bei Selbstreferenz (preflight_base == head) darf _scope_diff_base() "
+        "nicht den Ziel-Commit selbst zurueckgeben (HEAD..HEAD-Diff waere "
+        "immer leer und faelschlich docs-only, #1776) -- Fallback auf "
+        "Marker/HEAD~1 erwartet"
+    )


### PR DESCRIPTION
_scope_diff_base() gab die vom Preflight hinterlegte Diff-Basis zurueck, ohne
zu pruefen, ob sie zufaellig mit dem aktuellen HEAD identisch ist. Bei
Selbstreferenz entstand ein leerer HEAD..HEAD-Diff, faelschlich als docs-only
klassifiziert -- das liess das Deploy-Gate die Staging-Attestation komplett
uebergehen. Bereits 3x live beobachtet (#1725, #1803, #1776).

Guard ergaenzt (preflight_base != head), spiegelt den bereits vorhandenen
marker_sha-Schutz im direkt folgenden Zweig. Adversary VERIFIED (Mutations-
Gegenprobe + End-to-End-Beleg am tatsaechlichen Wirkort gate_check()).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
