### PR TITLE
chore: Write-Zugriff auf .claude/next_ticket_cache.json ohne Rueckfrage erlauben

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,8 @@
       "Bash",
       "WebSearch",
       "WebFetch",
-      "Monitor"
+      "Monitor",
+      "Write(.claude/next_ticket_cache.json)"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
## Summary
- Der Kurzzeit-Cache aus `/next-ticket` Schritt 0 (`.claude/next_ticket_cache.json`) loeste bei jedem Schreibversuch eine manuelle Bestaetigung aus.
- Gezielte Permission-Allow-Regel (`Write(.claude/next_ticket_cache.json)`) statt generischer Write-Freigabe -- die Datei ist gitignored, worktree-lokal und harmlos.

## Test plan
- [x] `jq -e '.permissions.allow' .claude/settings.json` zeigt die neue Regel, JSON syntaktisch gueltig.
- [x] Reine Tooling-Datei, kein Code in `src/`/`api/`/`internal/`/`frontend/`/`cmd/` -- Staging/Deploy entfaellt laut CLAUDE.md-Ausnahme.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>