### PR TITLE
fix 1795 timeline ortszeit

### DIFF
--- a/docs/adr/0044-kalendertage-folgen-der-ortszeit.md
+++ b/docs/adr/0044-kalendertage-folgen-der-ortszeit.md
@@ -128,23 +128,29 @@ Regelverstoß — genau das war der Zustand vor #1697.
   `utils.timezone.first_resolvable_tz()` — der einen fachlichen Auswahlregel für „erster
   Ort" (#1378 AC-4), die einen gelöschten oder zonenlosen Ersteintrag überspringt statt
   still auf Weltzeit zu kippen.
+- **Anzeige-/Kommando-Pfad in `trip_command_processor.py` und `inbound_telegram_reader.py`**
+  (#1727 S5a, live 2026-08-13, `fd87fca6`; `_handle_query` mit dieser Scheibe, #1795): `_show_status`,
+  `_show_now` und `command_date` (für `### ruhetag`) lösen den Kalendertag seither über
+  `trip_local_today` auf, `inbound_telegram_reader.py` reicht `received_at` durch statt selbst
+  `date.today()` zu bilden. `_handle_query` — löst zusätzlich einen Versand aus, nicht nur eine
+  Anzeige — folgt seit #1795 derselben EINEN Auflösung (`trip_local_now`) für Kopfzeile UND
+  Ortszeit-Anzeige der Timeline (`_aggregate_day`, `_fmt_glance`, `_fmt_gewitter`,
+  `_fmt_timeline`, `_timeline_buttons` bekommen `tz` als Pflichtparameter).
 
 **Lehre für die Pflege dieser Liste:** Sie war nicht falsch, sondern **unvollständig** — und
 eine unvollständige Restliste liest sich wie eine vollständige. Wer hier etwas einträgt,
 sucht vorher nach `date.today()`/`datetime.now().date()` im ganzen Produktivcode, statt nur
 die Datei zu nennen, in der er gerade gearbeitet hat.
 
-### Noch nicht umgesetzt (Stand 2026-08-12)
+### Noch nicht umgesetzt (Stand 2026-08-13)
 
 Der zuvor hier gelistete Briefing-/Versand-Pfad (`_get_target_date`, `_get_active_trips`,
-`save_dated`) ist umgesetzt — s. „Umgesetzt" oben (#1724/#1725).
+`save_dated`) ist umgesetzt — s. „Umgesetzt" oben (#1724/#1725). Ebenso der zuvor hier
+gelistete Kommando-/Anzeige-Pfad — s. „Umgesetzt" oben (#1727 S5a/#1795).
 
-**Anzeige, Vorschau, Werkzeuge:** vier Stellen in `src/services/trip_command_processor.py`
-(`_handle_query` — **löst einen Versand aus**, nicht nur eine Anzeige, eigene Abwägung nötig;
-`command_date` für `### ruhetag`; `_show_status` und `_show_now`), dazu
-`inbound_telegram_reader.py`, `preview_service.py`, `api/routers/debug.py` und
-`tools/weather_validation.py`. Zeilennummern bewusst weggelassen — sie waren in der
-Vorfassung dieser Liste binnen Tagen veraltet.
+**Vorschau, Werkzeuge:** `preview_service.py`, `api/routers/debug.py` und
+`tools/weather_validation.py` (S5b/S5c, eigene Scheibe). Zeilennummern bewusst weggelassen —
+sie waren in der Vorfassung dieser Liste binnen Tagen veraltet.
 
 **Bewusst NICHT betroffen** (feste Zone ist dort Absicht, kein Verstoß):
 `forecast_budget._today_utc` und `meteoalarm_budget._today_utc` (Kontingent-Tageswechsel in

--- a/docs/context/fix-1795-timeline-ortszeit.md
+++ b/docs/context/fix-1795-timeline-ortszeit.md
@@ -1,0 +1,369 @@
+# Context: fix-1795-timeline-ortszeit
+
+**Issue:** [#1795](https://github.com/henemm/gregor_zwanzig/issues/1795) · **Typ:** bug ·
+**Track:** Full Process · **Stand der Messung:** 2026-08-13, HEAD `dbad9614`
+
+## Request Summary
+
+Die Telegram-/E-Mail-Antworten der Query-Familie (`glance`, `heute_gewitter`, `timeline_heute`,
+`timeline_morgen`, `heute`, `morgen`) bestimmen ihren Kalendertag über den **Weltzeit**-Tag der
+eingehenden Nachricht, und die Timeline gibt die Ankunftszeit **roh in Weltzeit** aus. Beides
+muss auf die Ortszeit der Tour (ADR-0044) — und zwar **gemeinsam**, weil Filter und Anzeige
+heute konsistent UTC sind.
+
+Herausgeschnitten aus #1727 S5a mit ausdrücklicher Begründung
+(`docs/context/fix-1727-s5a-befehlspfade.md:55-79`, `docs/specs/modules/fix_1727_s5a_befehlspfade_ortstag.md:105-113`).
+
+## Der Befund in einem Satz
+
+`_handle_query` berechnet `today`/`tomorrow` **einmal** (`trip_command_processor.py:503-504`,
+`received_at.date()`) und speist damit **sieben** Verbraucher; `_fmt_timeline` formatiert den
+UTC-Zeitstempel ungewandelt (`:948`, `:950`). Auf Korsika steht bei 08:00 Ortszeit `06:00`;
+in Neuseeland liegt der Tag zwölf Stunden lang daneben.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/trip_command_processor.py:503-504` | **Ursprung** — `today = received_at.date()`, der einzige verbliebene Rohzugriff im Modul |
+| `src/services/trip_command_processor.py:812` | Tagesfilter `_aggregate_day`: `p.arrival_time.date() == target_date` |
+| `src/services/trip_command_processor.py:938-941` | Tagesfilter `_fmt_timeline`, identisches Muster |
+| `src/services/trip_command_processor.py:943, 948, 950` | Anzeige: Kopfzeile + zwei rohe `f"🕐 {p.arrival_time:%H:%M}"` |
+| `src/services/trip_command_processor.py:879-897` | `_fmt_glance` — `{today:%d.%m}`-Beschriftung ×4 |
+| `src/services/trip_command_processor.py:898` | `_fmt_gewitter` — dito |
+| `src/services/trip_command_processor.py:980-985` | `_timeline_buttons`, filtert indirekt über `_aggregate_day` |
+| `src/services/trip_command_processor.py:274-306` | `_fetch_and_save_snapshot` — schreibt `target_date` als **Schlüssel** (s. „Gemeinsamer Datenträger") |
+| `src/services/trip_command_processor.py:566-597`, `:240-272` | `_trigger_on_demand` / `_on_demand_failure_body` — Datum nur im Fehlertext |
+| `src/services/trip_report_scheduler.py:922` | `send_on_demand_report` — soll den benutzten Zieltag **zurückgeben** |
+| `src/services/trip_report_scheduler.py:1040-1042` | `_send_trip_report_outcome` kennt den Zieltag bereits (ortszeitrichtig seit #1724) |
+| `src/services/trip_day.py:29-96` | Die geteilten Bausteine — `trip_tz`, `display_tz`, `anchor_tz`, `trip_local_now`, `trip_local_today` |
+| `src/utils/timezone.py:106-125` | `_as_utc`, `local_dt`, `local_hour`, `local_fmt` |
+| `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` | Die Regel — **Restliste ist veraltet** (s. „Risks") |
+
+## Existing Patterns — das Muster liegt fertig da
+
+**Im selben Modul, eine Bildschirmseite weiter oben:** `_day_window` (`:740-779`) löst
+`anchor_tz(trip, received_at)` auf, leitet daraus `day_date` und `display_tz(trip, day_date)`
+ab und **gibt die Zone im Tupel zurück** (`(from_time, hours, day_date, tz)`), damit Aufrufer
+sie durchreichen statt sie ein zweites Mal zu holen (Docstring `:763-766`). Konsument:
+`_format_drilldown:800` — `local_fmt(pt.ts, tz)`. Genau das fehlt der Timeline-Seite.
+
+**Identisches Feld, bereits ortszeitrichtig:** `src/output/renderers/trip_report.py:159` —
+`arrival_date = local_dt(last_seg.segment.end_time, self._tz).date()`. Das ist dasselbe
+`segment.end_time`, das als `TimelinePoint.arrival_time` in die Timeline geht.
+
+Weitere Vorlagen: `src/output/renderers/day_window.py:153-156` · `src/services/briefing_slots.py:228`
+· `src/output/renderers/email/compare_html.py:1135`.
+
+**Eine eigene Kopie der Zonen-Auflösung ist laut ADR-0044 ein Regelverstoß.** `trip_local_now`
+(`trip_day.py:74-88`) existiert genau dafür, Tag und Ortsstunde aus **einer** Auflösung zu ziehen.
+Die Importe stehen bereits (`trip_command_processor.py:23-24`).
+
+## Datenmodell — gemessen, nicht aus Annotationen gelesen
+
+- `TimelinePoint` (`weather_extractor.py:39-43`): `arrival_time`, `elevation_m`, `label`, `metrics`.
+  **Kein `ts`** — das gibt es nur am `DrilldownPoint`.
+- `arrival_time = seg.segment.end_time` (`weather_extractor.py:95`) ist **aware UTC**:
+  `trip_segments.py:183-192` stempelt die Ortszone auf die Wanduhrzeit und rechnet nach UTC;
+  `TripSegment` hat kein `__post_init__`, das die `tzinfo` strippt; die Serialisierung
+  (`weather_snapshot.py:269-270/345-346`) erhält sie. Empirisch in einer echten Snapshot-Datei:
+  `"start_time": "2026-08-12T06:00:00+00:00"`.
+- **Die Hausnorm „naive UTC" (#1345) gilt hier NICHT** — sie betrifft `ForecastDataPoint.ts`
+  (`app/models.py:211-222`).
+- `local_dt` verträgt beides: `_as_utc` (`utils/timezone.py:106-110`) deutet naive Werte als UTC,
+  aware Werte werden konvertiert. Der Ortstag-Filter ist damit für `arrival_time` und `ts`
+  identisch schreibbar.
+- `timeline()` liest die **undatierte** Datei `{trip_id}.json` und enthält Segmente **beider**
+  Tage; die Tagestrennung passiert erst beim Formatieren — also genau an den zwei Filterstellen.
+
+## 🔴 Gemeinsamer Datenträger — der Punkt, den das Ticket nicht nennt
+
+`_fetch_and_save_snapshot` schreibt `WeatherSnapshotService.save(trip.id, …, today)`
+(`:304`), und `save()` stempelt `target_date` in die **undatierte Ankerdatei** `{trip_id}.json`
+(`weather_snapshot.py:73, 82`). Dieselbe Datei schreibt der Scheduler
+(`trip_report_scheduler.py:1300`) — dort aber mit dem **Ortstag** (seit #1724). Gelesen wird sie
+vom Alarm-Pfad: `trip_alert._get_cached_weather` vergleicht `load_target_date()` gegen
+`trip_local_today()` und verwirft bei Ungleichheit mit `reason="wrong_day"`
+(`trip_alert.py:616-637`). Der undatierte Anker ist dabei **kein Notnagel, sondern der reguläre
+Nachtpfad** (#1661).
+
+**Zwei Schreiber derselben Datei mit zwei Tagesbegriffen.** Damit ist die Lage strukturell
+anders als die von S5a beschriebene „Anzeige-Divergenz ohne gemeinsamen Datenträger"
+(`fix_1727_s5a_befehlspfade_ortstag.md:262-267`) — jene Aussage galt für den S5a-Zuschnitt und
+bleibt dort richtig, trifft aber auf `_handle_query` nicht zu.
+
+### ✅ Empirisch belegt (Analyse-Phase, Wegwerf-Probe ohne Netz)
+
+Trip in Wellington (`Pacific/Auckland`, im August UTC+12, kein DST), `now_utc = 2026-08-13T13:00Z`
+⇒ UTC-Tag `2026-08-13`, `trip_local_today()` `2026-08-14` (echtes Mismatch-Fenster).
+
+- Anker mit `target_date = now_utc.date()` (der Weg, den `_fetch_and_save_snapshot` heute nimmt)
+  ⇒ `_get_cached_weather(..., tagesgleicher_anker_noetig=True)` liefert **`None`**, Log:
+  `Alarm-Anker … verworfen (wrong_day) — falscher Tag: target_date=2026-08-13, heute ist 2026-08-14`.
+- Gegenprobe mit `target_date` = Ortstag ⇒ Anker kommt durch (1 Segment).
+
+Die Kette schlägt also tatsächlich durch, nicht nur am Code gelesen.
+
+**Ehrliche Eingrenzung des Schadens:** `_fetch_and_save_snapshot` läuft **nur**, wenn kein
+Snapshot ladbar ist (`:518` `if not timeline.available`). Im Regelfall legt der Befehlspfad
+deshalb einen Anker an, wo keiner war — er überschreibt keinen guten. Die Folge ist dann nicht
+„Alarm bricht weg, wo er vorher lief", sondern: der neu angelegte Anker trägt im Mismatch-Fenster
+einen Tag, den der Alarm-Pfad sofort verwirft — eine verpasste Reparatur, kein Rückschritt.
+
+🔴 **Diese Entwarnung gilt nicht absolut.** `WeatherSnapshotService.load()` (`weather_snapshot.py:196-226`)
+gibt bei **jeder** Lesestörung `None` zurück (`JSONDecodeError`, `ValueError`, `KeyError`, `OSError`),
+nicht nur bei fehlender Datei — und `save()` (`:61-86`) schreibt **nicht atomar**
+(`filepath.write_text(...)`, kein Temp-File mit Rename). Eine an sich gute, korrekt datierte
+Ankerdatei, die gerade unlesbar ist, führt damit ebenfalls auf `not timeline.available` und wird
+überschrieben. Schmaler, **vorbestehender** Fall, nicht durch #1795 verursacht — aber „überschreibt
+keinen guten Anker" ist als Absolutsatz falsch.
+
+## Dependencies
+
+**Upstream (was wir benutzen):** `services.trip_day` (`anchor_tz`, `display_tz`,
+`trip_local_today`, `trip_local_now`) · `utils.timezone` (`local_dt`, `local_fmt`) ·
+`WeatherExtractor.timeline` · `WeatherSnapshotService`.
+
+**Downstream (was von uns abhängt):**
+
+- **Zwei Einstiege, beide über `TripCommandProcessor.process`:** Telegram
+  (`inbound_telegram_reader.py:191-245`) und E-Mail (`inbound_email_reader.py:144-153`).
+  **SMS/Premium-SMS haben keinen Kommandopfad** (`inbound_sms_reader.py`, Kommentar
+  `trip_command_processor.py:967-968`). Eine Umstellung in `_handle_query` deckt beide ab.
+- `received_at` stammt in beiden Fällen von der **Serveruhr** (`datetime.now(tz=timezone.utc)`),
+  nicht vom Telegram-`date`-Feld — aware UTC.
+- **Callback-Buttons tragen kein Datum:** `tl_today`/`tl_tomorrow` werden über
+  `_CALLBACK_QUERY_MAP` (`inbound_telegram_reader.py:61-62`) in `### query: …` übersetzt und
+  mit **frischem** `now_utc` (`:320`) erneut durch `_handle_query` geschickt. Ein Ortstagwechsel
+  zwischen Anzeige und Klick verschiebt die Antwort also gewollt-relativ; es gibt keinen
+  eingefrorenen Token, der nachgezogen werden müsste.
+- `send_on_demand_report` hat **genau einen** Produktiv-Aufrufer
+  (`trip_command_processor.py:580`, Behandlung `if outcome != "sent"`), dazu 8 Test-Aufrufstellen;
+  eine davon ist eine Signatur-/Vertragsliste (`tests/tdd/test_briefing_slot_idempotenz.py:1087`).
+
+## Existing Specs & ADRs
+
+- `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` — die Regel
+- `docs/adr/0051-drei-zeitbegriffe-zone-an-den-daten.md` — Regel 3: kein Systemuhr-Default
+- `docs/specs/modules/fix_1727_s5a_befehlspfade_ortstag.md` — Vorgänger-Scheibe, „Nicht in dieser Scheibe" `:105-113`
+- `docs/context/fix-1727-s5a-befehlspfade.md` — Zuschnitt-Entscheid `:55-79`, offene Punkte `:277-307`
+- `docs/context/fix-1697-ortstag-statt-servertag.md` — Fundstellen-Karte nach Wirkung
+
+## Bestehende Wächter — was mitgezogen werden muss
+
+| Wächter | Bindung | Verhalten bei #1795 |
+|---|---|---|
+| `tests/test_success_status_guard.py:1622-1632`, `:1839`, `:1930` | Schlüssel `pfad::funktion::**ordinal**` — **keine Zeilennummern** (`_number_findings`, `:1312-1345`) | **Kein Nachzug**, solange `_handle_query` seine **vier** `success=True`-Rückgaben in gleicher Reihenfolge behält (`return` bei `:525`, `:534`, `:542`, `:551`). Nur ein neuer **literaler** `success=True` verschiebt Ordinale — ein `success=<Variable>` wird vom Detektor gar nicht erfasst (`_asserts_constant_success`, `:691-724`; `False` fehlt in `_SUCCESS_LITERALS`, `:220`). 🔴 **Spec-Auflage: `_handle_query` NICHT zerlegen** — bei sieben `tz`-Argumenten ist das verführerisch und bricht `:1622-1632` + `:1839` (=4) + Summenprüfung `:1930` (33/42) auf einen Schlag |
+| `tests/test_output_timezone_guard.py` | 9 AST-Muster + Aufrufstellen-Prüfung; `trip_command_processor.py` steht auf der Scanfläche (`:111`) | **Keine `KNOWN_VIOLATIONS`-Einträge mehr** für die Datei — S5a hat die letzten zwei entfernt. Also: nichts zu streichen, aber **nichts Neues einführen** (kein rohes `.astimezone()`, kein `date.today()`, kein Zonenliteral) |
+| — | — | **Warum der Wächter #1795 nicht sehen konnte:** ein `ast.JoinedStr` ohne Umrechnung ist keins der neun Muster. Der Fehler ist eine *fehlende* Operation, und Abwesenheit ist syntaktisch nicht von „Wert ist schon lokal" zu unterscheiden (Modul-Docstring `:66-77`) |
+
+**Keine der berührten Dateien steht in `.github/ci_tdd_excludes.txt`** — alle einschlägigen
+Wächter laufen in CI.
+
+## 🔴 Tests, die durch die TAG-Umstellung rot werden
+
+**Drei** Bestandsdateien, nicht zwei — die dritte fiel erst in der Analyse-Phase auf. Alle sind
+**echte Folgearbeit**, kein Kollateralschaden zum Wegdrücken:
+
+| Datei | Warum | Wirkung |
+|---|---|---|
+| `tests/tdd/test_thunder_origin_four_places.py:206-236` | Fixtur `kommando` nutzt `datetime.now(tz=timezone.utc)` und legt die Etappe auf den **UTC**-Tag; Koordinaten `47.0, 12.0` (`:91`) = Europe/Vienna | `_aggregate_day` findet nichts. Trifft `:423`, `:435`, `:492`, `:509`, `:526`, `:705` |
+| `tests/tdd/test_thunder_origin_trip.py:192-219` | **Dritte Fixtur, gleiches Muster**, Koordinaten `:64`, Segmente 06:00–17:00 UTC (`:108-122`) | Zusicherungen `:249`, `:286`, `:343`, `:395`, `:400`, `:424` auf `⛈ Gewitter heute ({heute:%d.%m})` mit `heute` = UTC-Tag |
+| `tests/tdd/test_issue_1007_heute_voll_briefing.py` | `date.today()` an sieben Stellen (`:248`, `:280`, `:294`, `:322`, `:343`, `:365-366`, `:397`, `:446`), dazu `assert today_str in html` (`:280-283`); Koordinaten `47.2692, 11.4041` | Trägt `pytestmark = pytest.mark.email` (`:43`) — **fällt in der Standard-Lane nicht auf**. Ist im selben Fenster **schon heute** brüchig, weil `_get_target_date` seit #1724 den Ortstag nimmt; #1795 macht es nur sichtbar |
+
+**Das Mismatch-Fenster ist jahreszeitabhängig:** für Europe/Vienna im **Sommer** (CEST, UTC+2)
+22:00–24:00 UTC, im **Winter** (CET, UTC+1) nur 23:00–24:00 UTC. Die Breite ist stets
+|UTC-Offset| Stunden. Dass `date.today()` auf diesem Rechner dem UTC-Tag entspricht, ist belegt:
+Server steht auf `Etc/UTC` (`timedatectl`), CI läuft auf `ubuntu-latest` (Default UTC), und der
+Code sagt es an drei Stellen unabhängig (`trip_command_processor.py:1143`,
+`trip_report_scheduler.py:786-787`, `compare_location_weather_source.py:79`).
+
+**Die Reparatur ist in allen drei Fällen dieselbe:** auf einen festen, zonensicheren Zeitpunkt
+einfrieren statt `datetime.now()`. Das ist derselbe Fixturen-Fehler, den ADR-0044 und #1726 F002
+beschreiben — nur diesmal in der Gegenrichtung sichtbar.
+
+Die 🕐-**Uhrzeit** macht dagegen keinen Bestandstest rot: `_timeline_gewitter`
+(`test_thunder_origin_four_places.py:242-249`) liest nur Zeilen mit `⛈` **und** `🌡`, nie die
+🕐-Zeile, und keine Assertion im Repo greift auf `Timeline ·` zu.
+
+## Nachweis-Bausteine, die schon existieren
+
+- `tests/tdd/conftest.py:51-76` — `WP_NZ` (Wellington, im August UTC+12), `WP_KORSIKA` (UTC+2),
+  `trip_two_zones(day0)` mit drei Etappen über zwei Zonen.
+- `tests/tdd/test_befehlspfade_folgen_ortszone.py:49-70` — `PAGO` (UTC−11), `KIRITIMATI` (UTC+14),
+  `LA`, sowie `NACHTS_UTC` / `MITTAGS_UTC` (Mismatch-Fenster). **Liegen lokal, nicht in der
+  conftest** — beim Wiederverwenden heben statt kopieren.
+- `_anker(now_utc, zone, erwarteter_ortstag)` (`:100-118`) — Pflicht-Vorbedingung, die misst,
+  dass Ortstag ≠ Weltzeit-Tag **und** ≠ `date.today()` (Fehlerklasse #1726 F002).
+- `test_befehlspfade_folgen_dem_parameter_nicht_der_systemuhr` (`:517-670`) — die Vorlage gegen
+  „Parameter behalten, im Rumpf ignorieren": zwei literal getrennte Erwartungen, Selbstprüfung
+  auf Verschiedenheit (`:637`), `freeze_time`-Wirksamkeitsanker (`:651`).
+
+## Risks & Considerations
+
+- **🔴 Sommerzeit ist hier schärfer als in S5a.** S5a durfte sich auf einen exemplarischen Tag
+  beschränken, weil es eine reine *Datums*bestimmung war (`fix-1727-s5a-befehlspfade.md:270-275`).
+  #1795 stellt zusätzlich die **Uhrzeit-Anzeige** um — ADR-0044 verlangt dafür ausdrücklich
+  **beide** Wechseltage. Die S5a-Suite deckt **keinen** ab (alle Daten 19.–23.08.2026).
+- **Der gefährliche Schnitt geht in BEIDE Richtungen** (Challenger-Befund — das Ticket warnt nur
+  vor einer). Wird nur der **Tag** gezogen, vergleicht der Filter einen Ortstag gegen
+  UTC-Zeitstempel ⇒ „Keine Etappe geplant", der Bruch aus #1697. Wird nur die **Uhrzeit**
+  lokalisiert, bleibt die Punktmenge zwar stimmig, aber die Nachricht trägt dann zwei
+  Zeitbegriffe: Kopfzeile `📋 Timeline · Heute (20.08.)` (UTC-Tag, `:945`) über Zeilen
+  `🕐 00:30` (Ortszeit, `:948`). Vorher UTC-konsistent-aber-falsch, nachher
+  lokal-korrekt-aber-tagesinkonsistent — genau wovor ADR-0051 warnt.
+- **Zone einmal auflösen und durchreichen.** Fünf Formatierer (`_aggregate_day`, `_fmt_glance`,
+  `_fmt_gewitter`, `_fmt_timeline`, `_timeline_buttons`) haben heute **keinen** `tz`-Parameter.
+  Eine zweite Auflösung im Rumpf wäre der von ADR-0044 verbotene Zweitauflöser.
+- **`send_on_demand_report` ist mit `-> bool` annotiert, liefert aber einen Outcome-String**
+  (`trip_report_scheduler.py:922` gegen Docstring `:934-940`). Die Annotation ist seit #1007
+  falsch. Sie wird für den Rückgabe-Zieltag ohnehin angefasst.
+- **Nur zwei Outcomes rendern überhaupt ein Datum:** `no_weather` (`:250-254`) und
+  `no_stage`/Default (`:272`). `no_channels` und `channels_unreachable` nicht, der Erfolgsfall
+  auch nicht.
+- 🔴 **Die Begründung für den Rückgabe-Zieltag war falsch dokumentiert** (Challenger-Befund).
+  Sie lautete „sonst entsteht eine zweite `today`-Definition" — das stimmt seit S5a nicht mehr:
+  `_trigger_on_demand` (`:566-597`) bekommt `target_date` als **Parameter** und löst nichts
+  selbst auf. Die tatsächliche Begründung ist eine andere: `_send_trip_report_outcome`
+  bestimmt seinen Zieltag intern über `datetime.now(timezone.utc)` zum **Ausführungs**zeitpunkt
+  (`trip_report_scheduler.py:1040-1042`), nicht über `received_at`. Trifft eine Nachricht knapp
+  vor und der Versand knapp nach der Ortsmitternacht, nennt der Antworttext einen anderen Tag
+  als den versandten. Der Rückgabe-Zieltag schließt genau diese Lücke.
+- **ADR-0044s Restliste ist veraltet:** sie führt `_show_status`, `_show_now` und `command_date`
+  noch als offen, obwohl S5a genau die geliefert hat (letzte Änderung am ADR: `fa53c4a3`/#1726).
+  Das ADR warnt selbst davor — „eine unvollständige Restliste liest sich wie eine vollständige".
+  Mit #1795 nachziehen.
+- **Nachweiskosten über Implementierungskosten.** S5a: Produktivcode +74/−20, Gesamt-LoC 800.
+  Hier kommen beide Sommerzeittage und die Reparatur zweier Bestandsfixturen dazu — **LoC-Limit
+  250 wird nicht reichen**, Override früh und begründet einplanen statt dreimal nachschätzen.
+- `data/` muss untracked bleiben.
+
+---
+
+# Analysis
+
+## Type
+
+**Bug.** Nutzersichtbares Fehlverhalten (falsche Uhrzeit, falscher Tag) mit einem
+Persistenz-Anteil (Anker-Schlüssel). Kein Feature.
+
+## 🔴 Neuer Befund der Analyse-Phase: der Anker deckt strukturell nur EINEN Tag ab
+
+Gemessen mit einer Wegwerf-Probe: `_send_trip_report_outcome` berechnet **genau einen**
+`target_date` (`trip_report_scheduler.py:1040-1043`) und schreibt daraus **ein** Tages-Set in die
+undatierte Ankerdatei (`:1300`). `_fetch_and_save_snapshot` ist der **einzige** Schreiber, der
+beide Tage holt (`trip_command_processor.py:297-299`) — und er läuft nur, wenn gar kein Snapshot
+ladbar ist (`:518`).
+
+**Folge:** Sobald der Scheduler einmal einen Anker geschrieben hat, wird der Zwei-Tage-Abruf nie
+wieder ausgelöst. Der Anker trägt dann je nach letztem Lauf entweder heute (Morgen-Briefing) oder
+morgen (Abend-Briefing) — **nie beides**. Probe bestätigt: `timeline_morgen` antwortet
+„Morgen (14.08): Keine Etappe geplant", obwohl die Etappe im Trip existiert.
+
+**Das ist ein eigenständiger, vorbestehender Defekt — keine Regression durch #1795**, und die
+Ortstag-Umstellung verschiebt nur, *welcher* der beiden Tage fehlt.
+
+🔴 **Konsequenz für die Spec:** Ein AC der Form „`timeline_morgen` zeigt nach dem Fix die morgige
+Etappe" wäre mit einem gewöhnlichen Scheduler-Anker **strukturell nie grün** — unabhängig von
+einer korrekten Implementierung. Die ACs müssen sich auf die **Filter- und Formatierlogik**
+beziehen (welcher Tag wird verglichen, welche Zone wird angezeigt), und der Testaufbau muss den
+Anker explizit mit beiden Tagen bestücken. Der Defekt selbst gehört in ein **eigenes Issue**
+(Triage a: nutzersichtbares Fehlverhalten).
+
+## Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/services/trip_command_processor.py` | MODIFY | `_handle_query` (eine Auflösung, zwei Zonen), `_trigger_on_demand`, `_aggregate_day`, `_fmt_glance`, `_fmt_gewitter`, `_fmt_timeline`, `_timeline_buttons`, `_fetch_and_save_snapshot` |
+| `src/services/trip_report_scheduler.py` | MODIFY | `OnDemandErgebnis`-NamedTuple, `send_on_demand_report`, optionaler `target_date`-Parameter an `_send_trip_report_outcome` |
+| `tests/tdd/test_timeline_folgt_der_ortszeit.py` | CREATE | Neue Suite (~17 Tests) |
+| `tests/tdd/conftest.py` | MODIFY | DST-Fixtur (Europe/Paris, beide Wechseltage) heben |
+| `tests/tdd/test_thunder_origin_four_places.py` | MODIFY | Fixtur einfrieren |
+| `tests/tdd/test_thunder_origin_trip.py` | MODIFY | Fixtur einfrieren |
+| `tests/tdd/test_issue_1007_heute_voll_briefing.py` | MODIFY | `date.today()` an sieben Stellen einfrieren |
+| `tests/tdd/test_briefing_slot_idempotenz.py`, `tests/tdd/test_issue_1087_trip_official_alerts.py` | MODIFY | Rückgabetyp nachziehen (`.outcome`) |
+| `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` | MODIFY | Restliste nachziehen (zählt nicht auf LoC) |
+
+## Scope Assessment
+
+- **Produktivcode:** ≈ **+100/−35** (`trip_command_processor.py` +73/−29, `trip_report_scheduler.py` +27/−6)
+- **Testcode:** ≈ **760** (neue Suite ~650, Bestandsreparaturen ~110)
+- **Gesamt ≈ 900 gezählte Zeilen** ⇒ **LoC-Override 1000** (Reserve für Adversary-Nachforderungen;
+  S5a lag bei 848 und brauchte zwei nachträgliche Wächter)
+- **Risiko: MEDIUM–HIGH** — kritischer Pfad, breite Anzeigeänderung, Persistenz-Anteil
+
+## Technical Approach (Empfehlung)
+
+**Zone einmal auflösen, als Pflichtparameter durchreichen** — Variante (a), nach dem Muster von
+`_format_drilldown` (`:781-785`, dessen Docstring den Pflichtparameter ausdrücklich begründet):
+
+```
+local_now = trip_local_now(trip, received_at)      # EINE Auflösung
+today     = local_now.date();  tomorrow = today + timedelta(days=1)
+tz_heute  = display_tz(trip, today)
+tz_morgen = display_tz(trip, tomorrow)
+```
+
+Die zwei `display_tz`-Aufrufe sind **keine** verbotene Zweitauflösung — genau das tut
+`_day_window:770-779` heute schon (Anker bestimmt den Tag, `display_tz` die Anzeige *dieses*
+Tages). Verboten ist die Kopie der Auflösungslogik im Rumpf eines Formatierers.
+
+**Warum nicht Instanzzustand (`self._tz`):** damit lässt sich einem Formatierer im Test keine
+*falsche* Zone unterschieben — „liest das Feld" und „löst selbst auf" sind von außen nicht
+unterscheidbar. Mit explizitem Parameter greift die fertige S5a-Vorlage
+`test_befehlspfade_folgen_dem_parameter_nicht_der_systemuhr` unverändert.
+
+**`send_on_demand_report`:** `target_date: date | None = None` als optionaler Parameter an
+`_send_trip_report_outcome` (**eine** Stelle, `:1039-1042`) statt die 465-Zeilen-Funktion
+umzubauen; Rückgabe als NamedTuple `OnDemandErgebnis(outcome, zieltag)`. Ein NamedTuple ist nicht
+`True` und fällt im Normalisierer `test_briefing_slot_idempotenz.py:1098-1103` in den else-Zweig
+⇒ **laut rot, nicht still falsch**. Nebengewinn: `_trigger_on_demand` verliert seinen
+`target_date`-Parameter, der `heute`/`morgen`-Zweig braucht `today`/`tomorrow` gar nicht mehr.
+
+**Vier `_aggregate_day`-Aufrufstellen**, nicht drei: `:885`, `:886`, `:904`, `:985`. Eine
+übersehene filtert weiter nach UTC und fällt nur im Mismatch-Fenster auf.
+
+## Schnitt: EINE Scheibe
+
+- **Tag zuerst** = der #1697-Bruch selbst. Ausgeschlossen.
+- **Uhrzeit zuerst** = zwei Zeitbegriffe in einer Nachricht (s. Risks). Ausgeschlossen.
+- **Entlang der Kommandos** = zwei `today`-Definitionen in `_handle_query`. Ausgeschlossen.
+- **Rückgabe-Zieltag abtrennen** wäre technisch sauber (≈ +35/−10 Produktiv), kauft aber genau
+  die Divergenz zurück, die S5a nach #1795 verwiesen hat, plus eine zweite Spec-, RED-,
+  Adversary- und Staging-Runde. Der Override auf 1000 ist billiger.
+
+## Nutzersichtbare Verhaltensänderungen (alle GEWOLLT, gehören in die Spec)
+
+1. **Die 🕐-Spalte verschiebt sich für jeden Nutzer, jeden Tag** um den UTC-Offset (Korsika +2 h) —
+   nicht nur im Mismatch-Fenster. Kein Golden-Test greift darauf zu; ohne ausdrückliche Nennung
+   liest der nächste Leser das als Regression.
+2. Die vier Query-Kommandos nennen im Mismatch-Fenster einen anderen Tag. Damit **endet** die
+   Divergenz zu `/status`, die `fix_1727_s5a_befehlspfade_ortstag.md:260-266` als Known Limitation
+   führt.
+3. `_fetch_and_save_snapshot` schreibt den Anker künftig mit dem Ortstag ⇒ der Alarm-Leser
+   verwirft ihn nicht mehr. Das **schaltet Alarme frei, die vorher nicht liefen** — ein Nutzer
+   kann im Mismatch-Fenster nach einem `glance` plötzlich eine Alarm-Meldung bekommen.
+   Zu **belegen**, nicht zu behaupten.
+
+## Open Questions
+
+- [x] Eigenes Issue für die einspurige Anker-Abdeckung angelegt: **#1818** (Triage a),
+      Rückverweis in #1795 gebucht (`issuecomment-5281861125`).
+
+## Offene Entscheidungen für die Spec
+
+1. **Welche Zone für den Filter?** `anchor_tz(trip, received_at)` bestimmt den *Kalendertag*;
+   für die *Anzeige* eines konkreten Tages ist `display_tz(trip, day_date)` das Vorbild
+   (`_day_window:770-779` nutzt beide). Vorschlag: exakt dem `_day_window`-Muster folgen, damit
+   Timeline und Drilldown derselben Nachricht garantiert denselben Tag meinen.
+2. **`_fetch_and_save_snapshot`:** fällt der `target_date`-Schlüssel automatisch mit um (er hängt
+   an derselben `today`-Variablen) — oder braucht er eine eigene AC, weil er ein
+   **Persistenz**-Schlüssel ist und nicht nur eine Anzeige? Vorschlag: eigene AC, mit Bezug auf
+   den Alarm-Leser.
+3. **Rückgabe von `send_on_demand_report`:** Tupel `(outcome, target_date)` oder Dataclass?
+   Trifft einen Produktiv-Aufrufer und acht Testaufrufe, davon eine Vertragsliste.
+4. **Sommerzeit-Umfang:** beide Wechseltage × welche Zonen? Vorschlag: beide Tage in **einer**
+   Zone mit Umstellung (Europe/Paris) plus die Zonenspreizung über Wellington/Korsika für den
+   Tagesversatz — nicht das Kreuzprodukt.
+5. **Bestandsfixturen einfrieren:** in dieser Scheibe mitreparieren (nötig für Grün) — aber als
+   eigene ACs sichtbar machen, damit der Aufwand nicht als „Nebenbei" verschwindet.

--- a/docs/specs/modules/fix_1795_timeline_ortszeit.md
+++ b/docs/specs/modules/fix_1795_timeline_ortszeit.md
@@ -61,10 +61,11 @@ derselben Nachricht (ADR-0051, s. „Warum eine Scheibe und kein Schnitt"). Hera
 
 | Datei | Änderung | Beschreibung |
 |---|---|---|
-| `src/services/trip_command_processor.py` | MODIFY | `_handle_query` (eine Auflösung, zwei Zonen), `_trigger_on_demand`, `_aggregate_day` (4 Aufrufstellen), `_fmt_glance`, `_fmt_gewitter`, `_fmt_timeline`, `_timeline_buttons`, `_fetch_and_save_snapshot` |
+| `src/services/trip_command_processor.py` | MODIFY | `_handle_query` (eine Auflösung, zwei Zonen), `_trigger_on_demand`, `_aggregate_day` (4 Aufrufstellen), `_fmt_glance`, `_fmt_gewitter`, `_fmt_timeline`, `_timeline_buttons` |
 | `src/services/trip_report_scheduler.py` | MODIFY | `OnDemandErgebnis`-NamedTuple, `send_on_demand_report`, optionaler `target_date`-Parameter an `_send_trip_report_outcome` |
-| `tests/tdd/test_timeline_folgt_der_ortszeit.py` | CREATE | Neue Suite (~17 Tests), Verhaltensname statt Issue-Nummer |
-| `tests/tdd/conftest.py` | MODIFY | DST-Fixtur (Europe/Paris, beide Wechseltage) heben |
+| `tests/tdd/test_timeline_folgt_der_ortszeit.py` | CREATE | Neue Suite, Verhaltensname statt Issue-Nummer |
+| `tests/tdd/conftest.py` | MODIFY | `_anker()`-Helfer heben (Vorbedingungs-Anker, aus `test_befehlspfade_folgen_ortszone.py`) |
+| `tests/tdd/test_befehlspfade_folgen_ortszone.py` | MODIFY | Altnutzer des gehobenen `_anker()` nachziehen (Import statt lokaler Kopie) |
 | `tests/tdd/test_thunder_origin_four_places.py` | MODIFY | Fixtur `kommando` einfrieren (`:206-236`) |
 | `tests/tdd/test_thunder_origin_trip.py` | MODIFY | Fixtur einfrieren (`:192-219`) |
 | `tests/tdd/test_issue_1007_heute_voll_briefing.py` | MODIFY | `date.today()` an sieben Stellen einfrieren (`:248`, `:280`, `:294`, `:322`, `:343`, `:365-366`, `:397`, `:446`) |
@@ -356,3 +357,20 @@ Neue Suite `tests/tdd/test_timeline_folgt_der_ortszeit.py` — nach Verhalten be
 
 - 2026-08-13: Spec erstellt nach `docs/context/fix-1795-timeline-ortszeit.md` (Basis-HEAD
   `dbad9614`).
+- 2026-08-13 (nach Umsetzung, Umfangsprüfung): Dateitabelle an die tatsächliche Lieferung
+  angeglichen — die ACs sind unberührt, nur die beschreibende Liste war falsch geworden.
+  Drei Abweichungen:
+  1. **`_fetch_and_save_snapshot` wurde NICHT geändert.** AC-8 ist trotzdem erfüllt, und zwar
+     strukturell: die Funktion bekommt `today` unverändert vom Aufrufer, und der trägt seit
+     dieser Scheibe den Ortstag (`trip_command_processor.py:532`). Weniger Diff als
+     angekündigt, gleiche Wirkung.
+  2. **`tests/tdd/conftest.py`** hat nicht die DST-Fixtur aufgenommen, sondern den
+     `_anker()`-Helfer (Vorbedingungs-Anker). Die DST-Fälle liegen lokal in der neuen Suite;
+     AC-5 ist inhaltlich abgedeckt (29.03. und 25.10.2026).
+  3. **`tests/tdd/test_befehlspfade_folgen_ortszone.py`** war in der Tabelle nicht vorgesehen,
+     wurde aber angefasst — als Altnutzer des gehobenen `_anker()`. Eine dritte Kopie wäre der
+     Fehler gewesen, den ADR-0044 für die Zonen-Auflösung selbst verbietet.
+- 2026-08-13: **Testumfang über der Schätzung.** Die neue Suite ist 928 statt geschätzter ~650
+  Zeilen. Ursache sind die Adversary-Runden (F001, F002, F004, F005) — genau der Posten, für den
+  der Override von 1000 Reserve tragen sollte; die Reserve war zu klein. Produktivcode liegt mit
+  +111/−42 im geschätzten Korridor.

--- a/docs/specs/modules/fix_1795_timeline_ortszeit.md
+++ b/docs/specs/modules/fix_1795_timeline_ortszeit.md
@@ -1,0 +1,358 @@
+---
+entity_id: fix_1795_timeline_ortszeit
+type: module
+created: 2026-08-13
+updated: 2026-08-13
+status: draft
+version: "1.0"
+tags: [bug, zeitzonen, telegram, adr-0044]
+workflow: fix-1795-timeline-ortszeit
+---
+
+# Fix #1795 — Timeline und Query-Familie folgen der Ortszeit der Tour
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Die Query-Familie (`glance`, `heute_gewitter`, `timeline_heute`, `timeline_morgen`, `heute`,
+`morgen`) bestimmt ihren Kalendertag über den **UTC-Tag** der eingehenden Nachricht
+(`trip_command_processor.py:503-504`, `received_at.date()`) statt über den Ortstag der Tour
+(ADR-0044), und die Timeline zeigt Ankunftszeiten **roh in UTC** (`:948`, `:950`) statt in der
+Ortszeit des jeweiligen Wegpunkts. Diese Scheibe stellt **beides gemeinsam** um, weil Filter und
+Anzeige heute konsistent UTC sind — ein halber Fix erzeugt zwei widersprüchliche Zeitbegriffe in
+derselben Nachricht (ADR-0051, s. „Warum eine Scheibe und kein Schnitt"). Herausgeschnitten aus
+#1727 S5a mit ausdrücklicher Begründung
+(`docs/specs/modules/fix_1727_s5a_befehlspfade_ortstag.md:105-113`).
+
+## Source
+
+- **File:** `src/services/trip_command_processor.py`
+  **Identifier:** `_handle_query` (:499-564), `_trigger_on_demand` (:566-596), `_aggregate_day`
+  (:808-...), `_fmt_glance` (:879-896), `_fmt_gewitter` (:898-929), `_fmt_timeline` (:931-978),
+  `_timeline_buttons` (:980-1005), `_fetch_and_save_snapshot` (:274-306),
+  `_on_demand_failure_body` (:240-267)
+- **File:** `src/services/trip_report_scheduler.py`
+  **Identifier:** `send_on_demand_report` (:922-948), `_send_trip_report_outcome` (:977-1043)
+- **Zonen-Auflösung (unverändert nutzen):** `src/services/trip_day.py::trip_local_now` (:74-88),
+  `display_tz` (:45-52); `src/utils/timezone.py::local_fmt` (:119-121)
+
+## Estimated Scope
+
+- **LoC:** Produktivcode ≈ **+100/−35** (`trip_command_processor.py` +73/−29,
+  `trip_report_scheduler.py` +27/−6); Testcode ≈ **760** (neue Suite ~650, Bestandsreparaturen
+  ~110); **Gesamt ≈ 900 gezählte Zeilen**.
+  **LoC-Override 1000** (statt Limit 250) — begründet: die Sommerzeit-Pflicht aus ADR-0044
+  verlangt beide Wechseltage geprüft auf Stundenebene, dazu drei Bestandsfixturen, die durch die
+  Tag-Umstellung rot werden (s. AC-9), und zwei Vertragslisten-Aufrufer des Rückgabetyps. #1727
+  S5a — die direkte Vorgängerscheibe mit vergleichbarem Muster — lag bei 848 gezählten Zeilen und
+  brauchte trotzdem zwei nachträgliche Wächter-Anpassungen durch Adversary-Nachforderungen; der
+  Puffer auf 1000 ist keine Bequemlichkeit, sondern eine gemessene Reserve.
+- **Files:** 10 (2 Produktivdateien MODIFY, 1 neue Testdatei CREATE, `tests/tdd/conftest.py`
+  MODIFY, 3 Bestandstestdateien MODIFY zum Einfrieren von Fixturen, 2 Testdateien MODIFY wegen
+  Rückgabetyp-Änderung, 1 ADR MODIFY — zählt nicht auf LoC)
+- **Effort:** high — kritischer Pfad (jeder Telegram-/Mail-Befehl der Query-Familie), breite
+  Anzeigeänderung, Persistenz-Anteil (Anker-Schlüssel), zwei Bestands-Wächter mit harten
+  strukturellen Auflagen (s. u.)
+
+### Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/services/trip_command_processor.py` | MODIFY | `_handle_query` (eine Auflösung, zwei Zonen), `_trigger_on_demand`, `_aggregate_day` (4 Aufrufstellen), `_fmt_glance`, `_fmt_gewitter`, `_fmt_timeline`, `_timeline_buttons`, `_fetch_and_save_snapshot` |
+| `src/services/trip_report_scheduler.py` | MODIFY | `OnDemandErgebnis`-NamedTuple, `send_on_demand_report`, optionaler `target_date`-Parameter an `_send_trip_report_outcome` |
+| `tests/tdd/test_timeline_folgt_der_ortszeit.py` | CREATE | Neue Suite (~17 Tests), Verhaltensname statt Issue-Nummer |
+| `tests/tdd/conftest.py` | MODIFY | DST-Fixtur (Europe/Paris, beide Wechseltage) heben |
+| `tests/tdd/test_thunder_origin_four_places.py` | MODIFY | Fixtur `kommando` einfrieren (`:206-236`) |
+| `tests/tdd/test_thunder_origin_trip.py` | MODIFY | Fixtur einfrieren (`:192-219`) |
+| `tests/tdd/test_issue_1007_heute_voll_briefing.py` | MODIFY | `date.today()` an sieben Stellen einfrieren (`:248`, `:280`, `:294`, `:322`, `:343`, `:365-366`, `:397`, `:446`) |
+| `tests/tdd/test_briefing_slot_idempotenz.py` | MODIFY | Vertragsliste (`:1087`) auf `.outcome`/`OnDemandErgebnis` nachziehen |
+| `tests/tdd/test_issue_1087_trip_official_alerts.py` | MODIFY | Aufrufstelle auf `.outcome` nachziehen |
+| `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` | MODIFY | Restliste nachziehen (zählt nicht auf LoC) |
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `services.trip_day.trip_local_now(trip, now_utc)` | module function | EINE Zonen-Auflösung für Ortstag UND Ortsstunde beider Query-Tage (heute/morgen) |
+| `services.trip_day.display_tz(trip, day_date)` | module function | Anzeige-Zone je Tag — heute/morgen können unterschiedliche Zonen tragen (AC-4) |
+| `utils.timezone.local_fmt(dt, tz)` | module function | Ersetzt die rohe `f"{p.arrival_time:%H:%M}"`-Formatierung in `_fmt_timeline` (`:948`, `:950`) |
+| ADR-0044 (Akzeptiert) | decision | Verlangt Ortstag statt UTC-Tag; `_handle_query` steht dort namentlich unter „Noch nicht umgesetzt" |
+| ADR-0051 Regel 3 (Vorgeschlagen) | decision | Verbietet Systemuhr-Default — `tz`/`now_utc` werden an allen berührten Funktionen als Pflichtparameter hereingereicht |
+| `docs/specs/modules/fix_1727_s5a_befehlspfade_ortstag.md` | spec | Vorgänger-Scheibe, grenzt `_handle_query` ausdrücklich aus (`:105-113`), liefert das Pflichtparameter-Muster |
+| `tests/tdd/test_befehlspfade_folgen_ortszone.py::test_befehlspfade_folgen_dem_parameter_nicht_der_systemuhr` (`:517-670`) | test | Vorlage gegen „Parameter behalten, im Rumpf ignorieren" (S5a Adversary-Befund F001), Grundlage für AC-6 |
+| `tests/test_success_status_guard.py:1622-1632`, `:1839`, `:1930` | guard | Bindet `_handle_query` an vier `success=True`-Literale in fester Reihenfolge — Auflage: Funktion nicht zerlegen |
+| `tests/test_output_timezone_guard.py` | guard | 9 AST-Muster; keine `KNOWN_VIOLATIONS`-Einträge mehr für `trip_command_processor.py` — nichts Neues einführen |
+| `trip_alert._get_cached_weather` (`:616-637`) | consumer | Liest den von `_fetch_and_save_snapshot` geschriebenen Anker; verwirft ihn bei `target_date != trip_local_today()` mit `reason="wrong_day"` |
+
+## Implementation Details
+
+**Zone einmal auflösen, als Pflichtparameter durchreichen (Variante a)** — nach dem Muster von
+`_format_drilldown` (`:781-785`), dessen Docstring den Pflichtparameter ausdrücklich begründet
+(„ein Default würde die Ortszeit wieder still gegen die Prozess-Zeitzone tauschen", `:787-788`):
+
+```python
+local_now = trip_local_now(trip, received_at)      # EINE Auflösung (trip_day.py:74-88)
+today     = local_now.date()
+tomorrow  = today + timedelta(days=1)
+tz_heute  = display_tz(trip, today)
+tz_morgen = display_tz(trip, tomorrow)
+```
+
+Die zwei `display_tz`-Aufrufe sind **keine** verbotene Zweitauflösung — genau das tut
+`_day_window` (`:770-779`) heute schon (der Anker bestimmt den Tag, `display_tz` die Anzeige
+*dieses* Tages). Verboten ist die Kopie der Auflösungslogik im Rumpf eines Formatierers.
+
+Alle fünf Formatierer (`_aggregate_day`, `_fmt_glance`, `_fmt_gewitter`, `_fmt_timeline`,
+`_timeline_buttons`) bekommen `tz` als Pflichtparameter; `_fmt_timeline` nutzt
+`local_fmt(p.arrival_time, tz)` statt der rohen `f"{p.arrival_time:%H:%M}"` an den zwei Stellen
+`:948`/`:950`.
+
+**Warum nicht Instanzzustand (`self._tz`):** Damit ließe sich einem Formatierer im Test keine
+*falsche* Zone unterschieben — „liest das Feld" und „löst selbst auf" sind von außen nicht
+unterscheidbar. Mit explizitem Parameter greift die fertige S5a-Vorlage
+`test_befehlspfade_folgen_dem_parameter_nicht_der_systemuhr` unverändert (Grundlage AC-6).
+
+**`send_on_demand_report`:** neuer Rückgabetyp `OnDemandErgebnis(outcome: str, zieltag: date)`
+(NamedTuple) statt des bisherigen `-> bool`-annotierten Outcome-Strings (die Annotation war seit
+#1007 ohnehin falsch, s. Analyse-Dokument „Risks"). `_send_trip_report_outcome` bekommt einen
+optionalen Parameter `target_date: date | None = None` (**eine** Stelle, `:1039-1042`) — bei
+gesetztem Wert wird er statt der internen `datetime.now(timezone.utc)`-Auflösung verwendet, sonst
+bleibt das bisherige Verhalten für die sechs bestehenden Aufrufer unverändert. Ein NamedTuple ist
+nicht `True` und fällt im Normalisierer `test_briefing_slot_idempotenz.py:1098-1103` in den
+else-Zweig ⇒ **laut rot, nicht still falsch**, sollte eine Aufrufstelle die Migration verpassen.
+
+`_trigger_on_demand` verliert seinen `target_date`-Parameter (Nebengewinn) — der Fehlertext liest
+den Zieltag künftig aus `OnDemandErgebnis.zieltag`, nicht aus einer zweiten, im Aufrufer geraten
+Variable (Grundlage AC-7).
+
+`_fetch_and_save_snapshot` bekommt `today`/`tomorrow` aus derselben Auflösung wie oben (kein
+eigener Zonenzugriff) und schreibt `WeatherSnapshotService.save(trip.id, …, today)` künftig mit
+dem Ortstag als `target_date`-Schlüssel (Grundlage AC-8).
+
+## 🔴 Auflagen
+
+- **`_handle_query` darf NICHT zerlegt werden.** Bei sieben `tz`-Argumenten ist eine Aufspaltung
+  in kleinere Funktionen verführerisch — sie bricht den B18-Wächter an drei Stellen gleichzeitig
+  (`tests/test_success_status_guard.py:1622-1632`, `:1839`, `:1930`), weil der Detektor an
+  Ordinalen literaler `success=True`-Rückgaben hängt, nicht an Zeilennummern.
+- **VIER, nicht drei, `_aggregate_day`-Aufrufstellen:** `:885`, `:886`, `:904`, `:985`. Eine
+  übersehene filtert weiter nach UTC und fällt nur im Mismatch-Fenster auf.
+- **Kein rohes `.astimezone()`, kein `date.today()`, kein `datetime.now()` ohne `tz`, kein
+  Zonenliteral.** `tests/test_output_timezone_guard.py` läuft in CI und darf keine neuen Funde
+  auf `trip_command_processor.py` bekommen.
+
+## Nutzersichtbare Verhaltensänderungen (alle GEWOLLT)
+
+1. **Die `🕐`-Spalte verschiebt sich für JEDEN Nutzer an JEDEM Tag** um den UTC-Offset (Korsika
+   +2 h) — nicht nur im Mismatch-Fenster. Kein Golden-Test greift heute darauf zu; ohne
+   ausdrückliche Nennung liest der nächste Leser das als Regression.
+2. Die vier Query-Kommandos nennen im Mismatch-Fenster einen anderen Tag als heute. Damit
+   **endet** die Divergenz zu `/status`, die
+   `fix_1727_s5a_befehlspfade_ortstag.md:260-266` als Known Limitation führt.
+3. `_fetch_and_save_snapshot` schreibt den Anker künftig mit dem Ortstag ⇒ der Alarm-Leser
+   (`trip_alert._get_cached_weather`) verwirft ihn nicht mehr. Das **schaltet Alarme frei, die
+   vorher im Mismatch-Fenster nicht liefen** — belegt durch AC-8, nicht nur behauptet.
+
+## Nicht in dieser Scheibe
+
+- **#1818 (einspurige Anker-Abdeckung).** `_send_trip_report_outcome` berechnet genau **einen**
+  `target_date` (`trip_report_scheduler.py:1040-1043`) und schreibt daraus ein Tages-Set in die
+  undatierte Ankerdatei (`:1300`). `_fetch_and_save_snapshot` ist der einzige Schreiber, der
+  beide Tage holt (`trip_command_processor.py:297-299`) — er läuft aber nur, wenn kein Snapshot
+  ladbar ist (`:518`). Sobald der Scheduler einmal geschrieben hat, wird der Zwei-Tage-Abruf nie
+  wieder ausgelöst; der Anker trägt dann je nach letztem Lauf entweder heute ODER morgen — nie
+  beides. Ein AC der Form „`timeline_morgen` zeigt nach dem Fix die morgige Etappe" wäre mit
+  einem gewöhnlichen Scheduler-Anker damit **strukturell nie grün** — unabhängig von einer
+  korrekten Implementierung dieser Scheibe. Deshalb beziehen sich die ACs hier auf Filter- und
+  Formatierlogik, und der Testaufbau bestückt den Anker/die Timeline explizit mit beiden Tagen
+  statt sich auf den Scheduler-Anker zu verlassen. #1818 ist als eigenes Issue gebucht.
+- **S5b/S5c-Dateien:** `preview_service.py`, `comparison_engine.py`, `gpx_processing.py`,
+  `openmeteo.py`, `api/routers/debug.py`, `tools/weather_validation.py`.
+- **Koordinaten-Cache für `tz_for_coords`.** Bewusste Nicht-Entscheidung aus S5a: `.timezone_at()`
+  je Tour und Aufruf ist linear und billig; keine Optimierung ohne gemessenen Engpass.
+- **Die Go-Seite.**
+
+## Expected Behavior
+
+- **Input:** ein eingehender Telegram- oder Mail-Befehl der Query-Familie (`received_at`, ein
+  UTC-Zeitpunkt), ein Trip mit Wegpunkten.
+- **Output:** Kalendertag (Filter, Kopfzeile) und Uhrzeit-Anzeige (`🕐`-Zeilen) entsprechen der
+  Ortszeit der jeweils betroffenen Etappe — nicht dem UTC-Tag/der UTC-Uhrzeit der Nachricht.
+- **Side effects:** der bei fehlendem Snapshot geschriebene Wetter-Anker
+  (`WeatherSnapshotService.save`) trägt künftig den Ortstag als `target_date`-Schlüssel statt des
+  UTC-Tages; der Alarm-Leser liest denselben Schlüssel (s. AC-8).
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine Tour auf Korsika (Europe/Paris, im August UTC+2) hat eine Etappe mit einem
+  Wegpunkt, dessen `arrival_time` auf `06:00 UTC` steht (= 08:00 Ortszeit) / When `timeline_heute`
+  zu `MITTAGS_UTC` (14:00 UTC, bewusst AUSSERHALB des Mismatch-Fensters) abgefragt wird / Then
+  zeigt die Timeline-Zeile `🕐 08:00`, nicht `🕐 06:00`.
+  - Test: Abfragezeitpunkt bewusst außerhalb des Mismatch-Fensters wählen, damit allein die
+    Uhrzeitumrechnung geprüft wird, nicht ein Tageswechsel; Assertion, dass `🕐 08:00` in
+    `confirmation_body` steht und `🕐 06:00` nicht.
+
+- **AC-2:** Given eine Tour auf Korsika mit einer Etappe für den Ortstag D+1 / When eine
+  Nachricht zu `NACHTS_UTC` (22:30 UTC = 00:30 Ortszeit des Folgetags, Mismatch-Fenster) für
+  `glance`, `heute_gewitter`, `timeline_heute` und `timeline_morgen` gesendet wird / Then beziehen
+  sich „heute"/„morgen" bei allen VIER Kommandos auf den Ortstag (D+1/D+2), erkennbar an der
+  Datumsbeschriftung in der jeweiligen Kopfzeile — vor dem Fix trugen alle vier noch den UTC-Tag
+  (D/D+1).
+  - Test: parametrisierter Test über die vier `query_key`-Werte, Assertion auf das erwartete
+    Ortstag-Datum in der Kopfzeile jedes `confirmation_body`.
+
+- **AC-3:** Given ein vorhandener Wetter-Snapshot trägt eine Etappe für den Ortstag D+1, die
+  Nachricht kommt zu `NACHTS_UTC` (Mismatch-Fenster, Ortstag = D+1) / When `timeline_heute`
+  abgefragt wird / Then nennt die Kopfzeile den Ortstag D+1 UND darunter steht mindestens eine
+  `🕐`-Zeile mit einer ortszeitrichtig umgerechneten Uhrzeit — wer nur den Filter auf den Ortstag
+  umstellt, aber die Uhrzeit weiter roh in UTC formatiert, bekommt „Keine Etappe geplant" (der
+  Filter sucht einen Tag, den die unveränderten Rohdaten für eine andere Zone tragen); das muss
+  dieser Test laut fehlschlagen lassen.
+  - Test: eine einzige Assertion-Gruppe prüft BEIDE Bestandteile gemeinsam (Kopfzeilen-Datum UND
+    Vorhandensein/Wert einer `🕐`-Zeile) — ein Test, der nur eines von beidem prüft, lässt einen
+    Halb-Fix durch.
+
+- **AC-4:** Given eine Tour hat die heutige Etappe in Neuseeland (Pacific/Auckland, im August
+  UTC+12) und die morgige auf Korsika (Europe/Paris, UTC+2) — Fixtur `trip_two_zones`
+  (`tests/tdd/conftest.py:55-76`) / When `glance` abgefragt wird / Then beschriftet und filtert
+  `_fmt_glance` den heutigen Abschnitt in der neuseeländischen Zone und den morgigen Abschnitt in
+  der korsischen Zone — je Tag die Zone SEINER EIGENEN Etappe, nicht eine gemeinsame Zone für
+  beide Tage.
+  - Test: `trip_two_zones`-Fixtur verwenden, Assertion auf die je Abschnitt erwartete
+    Ortsuhrzeit/das erwartete Datum; eine gemeinsame Zone für beide Tage ist die bequeme falsche
+    Abkürzung, die dieser Test fangen muss.
+
+- **AC-5:** Given eine Tour in Europe/Paris hat Wegpunkte mit `arrival_time`-Werten rund um beide
+  Sommerzeit-Wechseltage 2026 — 29.03. (Lücke, Ortstag hat 23 Stunden) und 25.10. (Doppelstunde,
+  Ortstag hat 25 Stunden) / When `timeline_heute`/`timeline_morgen` an beiden Tagen abgefragt wird
+  / Then zeigt jede `🕐`-Zeile die korrekte Ortsstunde des jeweiligen Wegpunkts — geprüft auf die
+  Häufigkeit JEDER EINZELNEN Stunde (ADR-0044), nicht nur auf das Datum.
+  - Test: zwei separate Testfälle (29.03. und 25.10.), je mit mehreren Wegpunkten über den
+    Umstellungszeitpunkt verteilt; Assertion auf die exakte `%H:%M`-Zeichenkette jeder Zeile, nicht
+    nur auf die Zeilenzahl.
+
+- **AC-6:** Given `freeze_time(X)` ist aktiv UND gleichzeitig wird `received_at = Y` übergeben, X
+  und Y liegen auf verschiedenen Ortstagen der Tour / When eine der vier Query-Kommandos
+  verarbeitet wird / Then folgt das Ergebnis (Kopfzeilen-Datum, gefilterte Etappe) `Y`, nicht der
+  eingefrorenen Systemuhr `X` — Vorlage `tests/tdd/test_befehlspfade_folgen_ortszone.py:517-670`
+  (Adversary-Befund F001 aus S5a: „Parameter behalten, im Rumpf ignorieren").
+  - Test: zwei literal getrennte Erwartungen (eine für X, eine für Y), Assertion, dass das
+    Ergebnis der Y-Erwartung entspricht und NICHT der X-Erwartung; `freeze_time`-Wirksamkeitsanker
+    wie in der Vorlage.
+
+- **AC-7:** Given `send_on_demand_report` liefert für einen Aufruf, bei dem am regulären Zieltag
+  keine Etappe existiert, ein `OnDemandErgebnis` mit einem `zieltag`, der vom lokal im Aufrufer
+  berechneten `today`/`tomorrow` bewusst abweicht (z. B. weil der interne
+  `_send_trip_report_outcome`-Aufruf knapp nach Ortsmitternacht ausgeführt wird) / When der
+  Fehlertext für `/heute`/`/morgen` gerendert wird / Then nennt er den TATSÄCHLICH benutzten
+  Zieltag (`OnDemandErgebnis.zieltag`), nicht ein vom Aufrufer selbst geratenes Datum.
+  - Test: `_send_trip_report_outcome` mit einem `target_date` aufrufen, der bewusst vom im
+    Aufrufer lokal berechneten `today`/`tomorrow` abweicht; Assertion, dass der Fehlertext den
+    `OnDemandErgebnis.zieltag`-Wert trägt.
+
+- **AC-8:** Given eine Tour im Mismatch-Fenster hat noch keinen ladbaren Wetter-Snapshot
+  (`timeline.available is False`) / When `_handle_query` daraufhin `_fetch_and_save_snapshot`
+  auslöst / Then trägt die geschriebene Ankerdatei `target_date` = Ortstag (nicht UTC-Tag), und
+  ein anschließender Aufruf von `trip_alert._get_cached_weather` verwirft sie NICHT MEHR mit
+  `reason="wrong_day"` — die Gegenrichtung (UTC-Tag als Schlüssel ⇒ Verwurf) ist im
+  Analyse-Dokument empirisch belegt (Wegwerf-Probe, Wellington-Trip, `now_utc=2026-08-13T13:00Z`).
+  - Test: Mismatch-Fenster-Fixtur ohne Snapshot, `_handle_query` auslösen, danach
+    `trip_alert._get_cached_weather` auf denselben Trip aufrufen; Assertion, dass sie ein Ergebnis
+    liefert (nicht `None`) und kein `wrong_day`-Log erscheint.
+
+- **AC-9:** Given die drei Bestandsdateien `test_thunder_origin_four_places.py`,
+  `test_thunder_origin_trip.py` und `test_issue_1007_heute_voll_briefing.py` nutzen bisher
+  `datetime.now(tz=timezone.utc)` bzw. `date.today()` in ihren Fixturen / When der komplette
+  Testlauf dieser drei Dateien zu einem beliebigen Ausführungszeitpunkt läuft — auch mitten im
+  Mismatch-Fenster für Europe/Vienna — / Then sind alle Tests weiterhin grün, weil die Fixturen
+  auf einen festen, zonensicheren Zeitpunkt eingefroren sind statt an die Systemuhr gekoppelt zu
+  bleiben.
+  - Test: die drei Dateien unter `freeze_time` auf einen Zeitpunkt **im** Mismatch-Fenster
+    (z. B. 22:30 UTC, Europe/Vienna im Sommer) laufen lassen. Vorbedingungs-Anker: zuerst
+    messen, dass Ortstag und UTC-Tag zu diesem Zeitpunkt wirklich auseinanderfallen — sonst
+    prüft der Lauf nichts. Gegenprobe zur Falsifizierbarkeit: derselbe Lauf auf dem Stand
+    **vor** dem Einfrieren muss rot sein.
+
+- **AC-10:** Given die Umstellung auf `tz`-Pflichtparameter und `trip_local_now` ist an allen
+  Formatierern abgeschlossen / When `tests/test_output_timezone_guard.py` und
+  `tests/test_success_status_guard.py` laufen / Then bleibt `test_output_timezone_guard.py` ohne
+  neuen `KNOWN_VIOLATIONS`-Eintrag für `trip_command_processor.py` grün, und
+  `test_success_status_guard.py` bleibt ohne Nachzug grün, weil `_handle_query` seine vier
+  `success=True`-Rückgaben (`:525`, `:534`, `:542`, `:551`) in Zahl und Reihenfolge unverändert
+  behält.
+  - Test: `tests/test_output_timezone_guard.py::test_known_violations_only_shrink` und die drei
+    referenzierten Assertions in `tests/test_success_status_guard.py` laufen lassen; beide grün
+    ohne Änderung an den Wächterdateien selbst.
+
+- **AC-11:** Given die Restliste „Noch nicht umgesetzt" in
+  `docs/adr/0044-kalendertage-folgen-der-ortszeit.md:142-147` nennt **fünf** Stellen, die
+  längst geliefert sind — `_show_status`, `_show_now`, `command_date` und
+  `inbound_telegram_reader.py` (alle vier aus #1727 S5a, `fd87fca6`) sowie `_handle_query`
+  (diese Scheibe); die Datei wurde zuletzt mit `fa53c4a3`/#1726 angefasst, S5a hat sie
+  **nicht** nachgezogen / When diese Scheibe live geht / Then stehen alle fünf im Abschnitt
+  „Umgesetzt", mit ihrer jeweiligen Issue-Nummer, und die Restliste enthält nur noch
+  tatsächlich Offenes (`preview_service.py`, `api/routers/debug.py`,
+  `tools/weather_validation.py` → S5b/S5c).
+  - Test: `# doc-compliance-test` — Assertion, dass keiner der fünf Namen mehr unterhalb der
+    Überschrift „Noch nicht umgesetzt" steht und `_handle_query` unter „Umgesetzt" auftaucht
+    (die laut CLAUDE.md einzige erlaubte Ausnahme für einen Dateiinhalts-Check).
+  - 🔴 Begründung, warum das ein AC ist und keine Fleißaufgabe: das ADR warnt an dieser Stelle
+    selbst — „eine unvollständige Restliste liest sich wie eine vollständige". Genau dieser
+    Fehler ist bereits eingetreten und blieb eine Scheibe lang unbemerkt.
+
+## Nachweisführung
+
+Vollständig offline belegbar (Kern-Schicht): `freeze_time` (freezegun) plus In-Memory-`Trip`/
+`Stage`/`Waypoint`-Fixturen, analog zu `tests/unit/test_trip_local_today.py`. Keine Staging-Mail
+nötig — der Versand selbst ist unberührt, alle betroffenen Stellen sind Filter-, Formatier- und
+ein Persistenz-Schlüssel-Pfad.
+
+## Testbenennung
+
+Neue Suite `tests/tdd/test_timeline_folgt_der_ortszeit.py` — nach Verhalten benannt, kein
+`test_issue_1795*`-Name (durchgesetzt von `test_naming_gate.py`).
+
+## Known Limitations
+
+- **Mehrzonen-Restfehler** (ADR-0044, bewusst offen, PO-Entscheidung): Wechselt der Wanderer an
+  genau dem betreffenden Tag die Zeitzone, bleibt die Differenz zweier benachbarter Etappen als
+  Restfehler — eine Tour dieser Spannweite hat ohnehin keinen eindeutigen „Kalendertag".
+- **Das Mismatch-Fenster ist jahreszeitabhängig:** für Europe/Vienna im Sommer (CEST, UTC+2) 2
+  Stunden breit, im Winter (CET, UTC+1) nur 1 Stunde. Die Breite ist stets |UTC-Offset| Stunden.
+- **`WeatherSnapshotService.save()` schreibt nicht atomar** (`filepath.write_text(...)`, kein
+  Temp-File mit Rename), und `load()` (`:196-226`) gibt bei JEDER Lesestörung `None` zurück
+  (`JSONDecodeError`, `ValueError`, `KeyError`, `OSError`), nicht nur bei fehlender Datei. Eine an
+  sich gute, korrekt datierte Ankerdatei, die gerade unlesbar ist, führt damit ebenfalls auf
+  `not timeline.available` und wird überschrieben. Schmaler, **vorbestehender** Fall, nicht durch
+  diese Scheibe verursacht.
+- **Einspurige Anker-Abdeckung** (#1818, eigenes Issue, s. „Nicht in dieser Scheibe") — ein
+  vorbestehender, unabhängiger Defekt, den diese Scheibe nicht behebt.
+
+## Warum eine Scheibe und kein Schnitt
+
+- **„Tag zuerst"** = der #1697-Bruch selbst: der Filter vergleicht einen Ortstag gegen
+  unveränderte UTC-Zeitstempel ⇒ „Keine Etappe geplant". Ausgeschlossen.
+- **„Uhrzeit zuerst"** = zwei Zeitbegriffe in einer Nachricht: Kopfzeile nennt den UTC-Tag, die
+  `🕐`-Zeilen darunter zeigen bereits Ortszeit — genau wovor ADR-0051 warnt. Ausgeschlossen.
+- **„Rückgabe-Zieltag abtrennen"** wäre technisch sauber (≈ +35/−10 Produktiv), kauft aber genau
+  die Divergenz zurück, die S5a bereits ausdrücklich auf #1795 verwiesen hat, plus eine zweite
+  Spec-, RED-, Adversary- und Staging-Runde. Der LoC-Override auf 1000 ist billiger als eine
+  zweite volle Runde.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** ADR-0044 (Akzeptiert), ADR-0051 Regel 3 (Vorgeschlagen)
+- **Rationale:** Setzt die bereits akzeptierte ADR-0044-Entscheidung an der zuletzt namentlich
+  gelisteten Stelle (`_handle_query` und die Query-Familie) um — keine offene Produktfrage, ein
+  Bug gegen eine getroffene Entscheidung, kein neues ADR nötig. Folgt zusätzlich Regel 3 aus
+  ADR-0051 (`tz`/`now_utc` als Pflichtparameter, kein Systemuhr-Default), obwohl jenes ADR noch
+  „Vorgeschlagen" ist — Regel 3 ist an anderer Stelle (#1724, #1726, #1727 S5a) bereits umgesetzt
+  und dort als bindendes Muster etabliert, an dem sich diese Scheibe ausdrücklich orientiert.
+
+## Changelog
+
+- 2026-08-13: Spec erstellt nach `docs/context/fix-1795-timeline-ortszeit.md` (Basis-HEAD
+  `dbad9614`).

--- a/docs/specs/modules/fix_1795_timeline_ortszeit.md
+++ b/docs/specs/modules/fix_1795_timeline_ortszeit.md
@@ -13,7 +13,7 @@ workflow: fix-1795-timeline-ortszeit
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-Freigabe („go") am 2026-08-13
 
 ## Purpose
 

--- a/src/services/trip_command_processor.py
+++ b/src/services/trip_command_processor.py
@@ -20,7 +20,7 @@ from typing import Optional
 
 from app.loader import get_data_dir, get_snapshots_dir, load_all_trips, save_trip
 from app.trip import Stage, Trip
-from services.trip_day import anchor_tz, display_tz, trip_local_today
+from services.trip_day import anchor_tz, display_tz, trip_local_now, trip_local_today
 from utils.timezone import UTC, local_dt, local_fmt, local_hour
 
 logger = logging.getLogger(__name__)
@@ -499,18 +499,30 @@ class TripCommandProcessor:
     def _handle_query(
         self, trip: Trip, query_key: str, received_at: datetime, user_id: str,
     ) -> CommandResult:
-        """Dispatch read-only query. Never mutates trip state."""
-        today = received_at.date()
+        """Dispatch read-only query. Never mutates trip state.
+
+        Fix #1795 (ADR-0044): "heute"/"morgen" folgen dem ORTStag der Tour,
+        nicht dem UTC-Tag von ``received_at`` — EINE Auflösung
+        (``trip_local_now``), aus der Tag UND (via ``display_tz``, je Tag
+        seine eigene Zone, AC-4) die Anzeige-Zonen hervorgehen. Alle
+        Formatierer bekommen ``tz`` als Pflichtparameter durchgereicht
+        (Docstring-Begründung: siehe ``_format_drilldown``) — ein Default
+        würde die Ortszeit wieder still gegen die Prozess-Zeitzone tauschen.
+        """
+        local_now = trip_local_now(trip, received_at)
+        today = local_now.date()
         tomorrow = today + timedelta(days=1)
+        tz_heute = display_tz(trip, today)
+        tz_morgen = display_tz(trip, tomorrow)
 
         # Issue #1007: heute/morgen lösen das volle Tages-Briefing aus (kein
         # Einzeiler-Aggregat mehr) — eigener Zweig VOR dem Timeline-Setup, da
         # der Scheduler die Wetterdaten selbst holt (keine WeatherExtractor-
         # Timeline nötig).
         if query_key == "heute":
-            return self._trigger_on_demand(trip, "morning", "Heute", today, user_id)
+            return self._trigger_on_demand(trip, "morning", "Heute", user_id)
         elif query_key == "morgen":
-            return self._trigger_on_demand(trip, "evening", "Morgen", tomorrow, user_id)
+            return self._trigger_on_demand(trip, "evening", "Morgen", user_id)
 
         from services.weather_extractor import WeatherExtractor
         extractor = WeatherExtractor(user_id=user_id)
@@ -521,7 +533,7 @@ class TripCommandProcessor:
             timeline = extractor.timeline(trip.id)
 
         if query_key == "glance":
-            body = self._fmt_glance(timeline, today, tomorrow)
+            body = self._fmt_glance(timeline, today, tomorrow, tz_heute, tz_morgen)
             return CommandResult(
                 success=True, command="glance",
                 confirmation_subject=f"[{trip.name}] Glance",
@@ -530,7 +542,7 @@ class TripCommandProcessor:
                 reply_markup=_GLANCE_BUTTONS,
             )
         elif query_key == "heute_gewitter":
-            body = self._fmt_gewitter(timeline, today)
+            body = self._fmt_gewitter(timeline, today, tz_heute)
             return CommandResult(
                 success=True, command="heute_gewitter",
                 confirmation_subject=f"[{trip.name}] Gewitter heute",
@@ -538,22 +550,22 @@ class TripCommandProcessor:
                 trip_name=trip.name,
             )
         elif query_key == "timeline_heute":
-            body = self._fmt_timeline(timeline, today, "Heute", "today")
+            body = self._fmt_timeline(timeline, today, "Heute", "today", tz_heute)
             return CommandResult(
                 success=True, command="timeline_heute",
                 confirmation_subject=f"[{trip.name}] Timeline heute",
                 confirmation_body=body,
                 trip_name=trip.name,
-                reply_markup=self._timeline_buttons(timeline, today, "today"),
+                reply_markup=self._timeline_buttons(timeline, today, "today", tz_heute),
             )
         elif query_key == "timeline_morgen":
-            body = self._fmt_timeline(timeline, tomorrow, "Morgen", "tomorrow")
+            body = self._fmt_timeline(timeline, tomorrow, "Morgen", "tomorrow", tz_morgen)
             return CommandResult(
                 success=True, command="timeline_morgen",
                 confirmation_subject=f"[{trip.name}] Timeline morgen",
                 confirmation_body=body,
                 trip_name=trip.name,
-                reply_markup=self._timeline_buttons(timeline, tomorrow, "tomorrow"),
+                reply_markup=self._timeline_buttons(timeline, tomorrow, "tomorrow", tz_morgen),
             )
         # Fallback (should not reach)
         return CommandResult(
@@ -564,7 +576,7 @@ class TripCommandProcessor:
         )
 
     def _trigger_on_demand(
-        self, trip: Trip, report_type: str, label: str, target_date: date, user_id: str,
+        self, trip: Trip, report_type: str, label: str, user_id: str,
     ) -> CommandResult:
         """Issue #1007: heute/morgen lösen das volle Tages-Briefing aus statt
         des bisherigen Einzeiler-Aggregats. Wiederverwendung des On-Demand-
@@ -572,17 +584,24 @@ class TripCommandProcessor:
         ohne [TEST]-Präfix). Adversary-Fix F001/F002: `send_on_demand_report`
         liefert ein Outcome ("sent"/"no_stage"/"no_weather"/"no_channels")
         statt eines bloßen bool — nur "sent" unterdrückt die Bestätigung.
+
+        Fix #1795 AC-7: der Fehlertext nennt den TATSAECHLICH von
+        `send_on_demand_report` benutzten Zieltag (`OnDemandErgebnis.zieltag`)
+        — kein eigener, im Aufrufer aus `received_at` geratener `target_date`
+        mehr (Nebengewinn: der Parameter entfaellt hier ersatzlos).
         """
         from services.trip_report_scheduler import TripReportSchedulerService
         query_key = "heute" if report_type == "morning" else "morgen"
         buttons = _HEUTE_BUTTONS if report_type == "morning" else _MORGEN_BUTTONS
         service = TripReportSchedulerService(user_id=user_id)
-        outcome = service.send_on_demand_report(trip, report_type)
-        if outcome != "sent":
+        ergebnis = service.send_on_demand_report(trip, report_type)
+        if ergebnis.outcome != "sent":
             return CommandResult(
                 success=True, command=query_key,
                 confirmation_subject=f"[{trip.name}] {label}",
-                confirmation_body=_on_demand_failure_body(outcome, label, target_date),
+                confirmation_body=_on_demand_failure_body(
+                    ergebnis.outcome, label, ergebnis.zieltag,
+                ),
                 trip_name=trip.name,
                 reply_markup=buttons,
             )
@@ -805,11 +824,17 @@ class TripCommandProcessor:
             lines.append(line)
         return "\n".join(lines)
 
-    def _aggregate_day(self, timeline, target_date) -> Optional[dict]:
-        """Aggregiere Timeline-Punkte für target_date. None wenn keine Punkte."""
+    def _aggregate_day(self, timeline, target_date, tz) -> Optional[dict]:
+        """Aggregiere Timeline-Punkte für target_date. None wenn keine Punkte.
+
+        Fix #1795: der Filter vergleicht den ORTStag des Wegpunkts
+        (``local_dt(p.arrival_time, tz).date()``), nicht mehr den rohen
+        UTC-Tag von ``arrival_time`` — ``tz`` ist Pflichtparameter, s.
+        ``_handle_query``.
+        """
         from app.models import ThunderLevel as TL
         from output.metric_format import thunder_ordinal
-        points = [p for p in timeline.points if p.arrival_time.date() == target_date]
+        points = [p for p in timeline.points if local_dt(p.arrival_time, tz).date() == target_date]
         if not points:
             return None
         temp_max = max((p.metrics.temp_max_c for p in points if p.metrics.temp_max_c is not None), default=None)
@@ -876,14 +901,17 @@ class TripCommandProcessor:
             f"🌧 {precip}mm  ⛈ Gewitter: {thunder_label}"
         )
 
-    def _fmt_glance(self, timeline, today, tomorrow) -> str:
+    def _fmt_glance(self, timeline, today, tomorrow, tz_heute, tz_morgen) -> str:
+        """Fix #1795 AC-4: je Tag die Zone SEINER EIGENEN Etappe — ``tz_heute``
+        für ``today``, ``tz_morgen`` für ``tomorrow`` (nicht eine gemeinsame
+        Zone für beide Tage)."""
         if not timeline.available:
             return (
                 "Kein Wetter-Snapshot verfügbar. "
                 "Bitte einen Report anfordern um aktuelle Daten zu laden."
             )
-        agg_heute = self._aggregate_day(timeline, today)
-        agg_morgen = self._aggregate_day(timeline, tomorrow)
+        agg_heute = self._aggregate_day(timeline, today, tz_heute)
+        agg_morgen = self._aggregate_day(timeline, tomorrow, tz_morgen)
         lines = ["🗓 Glance — heute & morgen", ""]
         if agg_heute:
             lines.append(self._fmt_day_agg(agg_heute, f"heute ({today:%d.%m})"))
@@ -895,13 +923,13 @@ class TripCommandProcessor:
             lines.append(f"morgen ({tomorrow:%d.%m}): Keine Etappe geplant")
         return "\n".join(lines)
 
-    def _fmt_gewitter(self, timeline, today) -> str:
+    def _fmt_gewitter(self, timeline, today, tz) -> str:
         if not timeline.available:
             return (
                 "Kein Wetter-Snapshot verfügbar. "
                 "Bitte einen Report anfordern um aktuelle Daten zu laden."
             )
-        agg = self._aggregate_day(timeline, today)
+        agg = self._aggregate_day(timeline, today, tz)
         if not agg:
             return f"Heute ({today:%d.%m}): Keine Etappe geplant — kein Gewitter-Status."
         thunder = agg["thunder"]
@@ -928,15 +956,21 @@ class TripCommandProcessor:
             suffix = f" · {herkunft}{suffix}"
         return f"⛈ Gewitter heute ({today:%d.%m}): {label}{suffix}"
 
-    def _fmt_timeline(self, timeline, target_date, label: str, day_token: str) -> str:
-        """Vertikale Timeline: pro Wegpunkt zwei Zeilen (Zeit/Höhe + Metriken)."""
+    def _fmt_timeline(self, timeline, target_date, label: str, day_token: str, tz) -> str:
+        """Vertikale Timeline: pro Wegpunkt zwei Zeilen (Zeit/Höhe + Metriken).
+
+        Fix #1795: sowohl der Tagesfilter (``local_dt(...).date()``, AC-3) als
+        auch die 🕐-Uhrzeit (``local_fmt``, AC-1/AC-5) laufen über die
+        durchgereichte Ortszone — kein rohes ``arrival_time.date()``/
+        ``:%H:%M`` auf dem UTC-Zeitstempel mehr.
+        """
         if not timeline.available:
             return (
                 "Kein Wetter-Snapshot verfügbar. "
                 "Bitte einen Report anfordern um aktuelle Wetterdaten zu laden."
             )
         pts = sorted(
-            [p for p in timeline.points if p.arrival_time.date() == target_date],
+            [p for p in timeline.points if local_dt(p.arrival_time, tz).date() == target_date],
             key=lambda p: p.arrival_time,
         )
         if not pts:
@@ -945,9 +979,9 @@ class TripCommandProcessor:
         lines = [f"📋 Timeline · {label} ({target_date:%d.%m})", ""]
         for p in pts:
             if p.elevation_m is not None:
-                lines.append(f"🕐 {p.arrival_time:%H:%M} · {int(p.elevation_m)} m")
+                lines.append(f"🕐 {local_fmt(p.arrival_time, tz)} · {int(p.elevation_m)} m")
             else:
-                lines.append(f"🕐 {p.arrival_time:%H:%M}")
+                lines.append(f"🕐 {local_fmt(p.arrival_time, tz)}")
             m = p.metrics
             t_min = f"{m.temp_min_c:.0f}" if m.temp_min_c is not None else "?"
             t_max = f"{m.temp_max_c:.0f}" if m.temp_max_c is not None else "?"
@@ -977,12 +1011,12 @@ class TripCommandProcessor:
             )
         return "\n".join(lines)
 
-    def _timeline_buttons(self, timeline, target_date, day_token: str) -> dict:
+    def _timeline_buttons(self, timeline, target_date, day_token: str, tz) -> dict:
         """Drilldown-Buttons je kritischer Metrik + immer Zurück."""
         from app.models import ThunderLevel
         from output.metric_format import thunder_ordinal
         back = {"text": "⬅️ Zurück", "callback_data": "glance"}
-        agg = self._aggregate_day(timeline, target_date) if timeline.available else None
+        agg = self._aggregate_day(timeline, target_date, tz) if timeline.available else None
         if not agg:
             return {"inline_keyboard": [[back]]}
 

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -15,7 +15,7 @@ import os
 import time as time_module
 from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Tuple
 from zoneinfo import ZoneInfo
 
 import httpx
@@ -51,6 +51,20 @@ if TYPE_CHECKING:
 # vermeiden. Hinweis: `time` ist hier die datetime.time-Klasse — der echte
 # Zeit-Modul wird als `time_module` importiert.
 INTER_MAIL_DELAY_SECONDS = 2
+
+
+class OnDemandErgebnis(NamedTuple):
+    """Fix #1795 AC-7: Rückgabetyp von ``send_on_demand_report`` — ein bloßer
+    Outcome-String (die frühere ``-> bool``-Annotation war seit #1007 ohnehin
+    falsch) reicht dem Aufrufer nicht, WELCHER Ortstag tatsächlich benutzt
+    wurde (``_send_trip_report_outcome`` löst ihn intern über
+    ``datetime.now(timezone.utc)`` zum Ausführungs-, nicht Empfangszeitpunkt
+    auf). Ein NamedTuple ist nicht ``True`` und fällt in einem Normalisierer,
+    der noch mit dem alten bool/str rechnet, laut in den else-Zweig — eine
+    vergessene Migrationsstelle wird sichtbar rot, nicht still falsch.
+    """
+    outcome: str
+    zieltag: date
 
 # Issue #1113: >75 % fehlende Segmente -> Guard wie Totalausfall (#1012);
 # Retry-Budget pro Segment bei transienten Fetch-Fehlern (1s/2s Backoff).
@@ -919,7 +933,7 @@ class TripReportSchedulerService:
             trip, report_type, allow_test_fallback=True, angefordert=True,
         )
 
-    def send_on_demand_report(self, trip: "Trip", report_type: str) -> bool:
+    def send_on_demand_report(self, trip: "Trip", report_type: str) -> OnDemandErgebnis:
         """
         Send an on-demand full briefing triggered by an inbound heute/morgen command.
 
@@ -928,24 +942,34 @@ class TripReportSchedulerService:
         Zieltag keine Etappe liegt) und OHNE „[TEST]"-Präfix — stattdessen eine
         dezente „auf Anfrage"-Kennzeichnung im Mail-Body.
 
+        Fix #1795 AC-7: der Zieltag wird HIER einmal aufgelöst (Ortstag, s.
+        `_get_target_date`) und an `_send_trip_report_outcome` durchgereicht
+        — derselbe Wert kommt im Rückgabe-`zieltag` an, statt dass ein
+        Aufrufer ihn ein zweites Mal aus `received_at` raten muss (Nebengewinn:
+        `_trigger_on_demand` verliert dadurch seinen eigenen `target_date`-
+        Parameter).
+
         Args:
             trip: Trip object
             report_type: "morning" (heute) or "evening" (morgen)
 
         Returns:
-            Outcome string: "sent" | "no_stage" | "no_weather" | "no_channels" |
-            "channels_unreachable"
-            (Issue #1007 Adversary-Fix F001/F002 — Outcome-Unterscheidung statt
-            eines bloßen bool, damit der Aufrufer "keine Etappe" von "keine
-            Wetterdaten" und von "kein Kanal aktiv" unterscheiden kann).
+            OnDemandErgebnis(outcome, zieltag) — outcome: "sent" | "no_stage" |
+            "no_weather" | "no_channels" | "channels_unreachable" (Issue #1007
+            Adversary-Fix F001/F002 — Outcome-Unterscheidung statt eines
+            bloßen bool, damit der Aufrufer "keine Etappe" von "keine
+            Wetterdaten" und von "kein Kanal aktiv" unterscheiden kann);
+            zieltag: der TATSAECHLICH benutzte Ortstag.
         """
         if report_type not in ("morning", "evening"):
             raise ValueError(f"Invalid report_type: {report_type}")
+        zieltag = self._get_target_date(report_type, trip, datetime.now(timezone.utc))
         # Issue #1725: `angefordert=True` NEBEN `on_demand=True` — die beiden
         # bedeuten Verschiedenes, siehe `_send_trip_report_outcome`.
-        return self._send_trip_report_outcome(
-            trip, report_type, on_demand=True, angefordert=True,
+        outcome = self._send_trip_report_outcome(
+            trip, report_type, on_demand=True, angefordert=True, target_date=zieltag,
         )
+        return OnDemandErgebnis(outcome=outcome, zieltag=zieltag)
 
     def _send_trip_report(
         self,
@@ -982,6 +1006,7 @@ class TripReportSchedulerService:
         on_demand: bool = False,
         catchup_prefix: str | None = None,
         angefordert: bool = False,
+        target_date: date | None = None,
     ) -> str:
         """
         Generate and send report for a single trip.
@@ -1022,6 +1047,13 @@ class TripReportSchedulerService:
                 zuerst mit Zahlen hier und zeigte nach dem eigenen Commit um
                 30 Zeilen daneben — ausgerechnet der Verweis auf die
                 Log-Zeile landete auf dem Gegenbeispiel (Adversary F008).
+            target_date: Fix #1795 — optionaler, bereits aufgelöster Ortstag.
+                Gesetzt (von `send_on_demand_report`): wird STATT der
+                internen `datetime.now(timezone.utc)`-Auflösung unten benutzt
+                — EINE Auflösung, kein Zweitauflöser. `None` (Default): die
+                sechs bestehenden Aufrufer bleiben unverändert, die Funktion
+                löst den Zieltag wie bisher selbst zum Ausführungszeitpunkt
+                auf.
 
         Returns:
             "no_stage" if no matching stage, "no_weather" if the weather
@@ -1037,9 +1069,12 @@ class TripReportSchedulerService:
 
         # 1. Convert trip to segments
         # Issue #1724: Zieltag aus der Ortszeit DIESES Trips (ADR-0044).
-        target_date = self._get_target_date(
-            report_type, trip, datetime.now(timezone.utc),
-        )
+        # Fix #1795: ein bereits aufgeloester `target_date` (s. Docstring)
+        # ersetzt die interne Auflösung — kein zweiter Auflöser.
+        if target_date is None:
+            target_date = self._get_target_date(
+                report_type, trip, datetime.now(timezone.utc),
+            )
         segments = self._convert_trip_to_segments(trip, target_date)
 
         # Issue #768: Test-Pfad-Fallback — wenn am regulären Zieldatum keine

--- a/tests/tdd/conftest.py
+++ b/tests/tdd/conftest.py
@@ -12,6 +12,7 @@ import sys
 from datetime import date as _date
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -72,6 +73,39 @@ def trip_two_zones(
             )
             for i, (lat, lon) in enumerate(coords)
         ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Vorbedingungs-Anker -- geteilter Ort (Issue #1795, gehoben aus
+# tests/tdd/test_befehlspfade_folgen_ortszone.py:100-118, #1727 S5a).
+#
+# Eine dritte Kopie waere derselbe Regelverstoss, den ADR-0044 fuer die
+# Zonen-Aufloesung selbst verbietet -- der Altnutzer importiert ab #1795
+# von hier statt einer eigenen Definition.
+# ---------------------------------------------------------------------------
+
+def _anker(now_utc: datetime, zone: str, erwarteter_ortstag: _date) -> None:
+    """Vorbedingungs-Anker — PFLICHT vor jeder Hauptzusicherung, die einen
+    vom Weltzeit-/Servertag abweichenden Ortstag behauptet.
+
+    Belegt, dass Ortstag, Weltzeit-Tag und Servertag bei DIESER Fixtur zu
+    DIESEM Zeitpunkt wirklich auseinanderfallen. Ohne ihn koennte die
+    Hauptzusicherung strukturell nie fehlschlagen (Fehlerklasse #1726 F002).
+    Der Sollwert wird aus der Zone gebildet, nicht aus dem Prueflingsweg.
+    """
+    ortstag = now_utc.astimezone(ZoneInfo(zone)).date()
+    assert ortstag == erwarteter_ortstag, (
+        f"Testaufbau: Ortstag in {zone} ist {ortstag}, der Test rechnet mit "
+        f"{erwarteter_ortstag} (Zeitpunkt {now_utc.isoformat()})"
+    )
+    assert ortstag != now_utc.date(), (
+        f"Testaufbau nicht diskriminierend: Ortstag ({ortstag}) und "
+        f"Weltzeit-Tag ({now_utc.date()}) sind gleich (#1726 F002)"
+    )
+    assert ortstag != _date.today(), (
+        f"Testaufbau nicht diskriminierend: Ortstag ({ortstag}) und Servertag "
+        f"date.today() ({_date.today()}) sind gleich (#1726 F002)"
     )
 
 

--- a/tests/tdd/test_befehlspfade_folgen_ortszone.py
+++ b/tests/tdd/test_befehlspfade_folgen_ortszone.py
@@ -42,7 +42,7 @@ from services.trip_command_processor import (
     InboundMessage,
     TripCommandProcessor,
 )
-from tests.tdd.conftest import WP_KORSIKA, WP_NZ, trip_two_zones
+from tests.tdd.conftest import WP_KORSIKA, WP_NZ, _anker, trip_two_zones
 
 # Zonen, deren Ortstag sich zum selben Augenblick unterscheidet.
 KORSIKA_ZONE = "Europe/Paris"          # im August UTC+2
@@ -97,27 +97,9 @@ def _befehl(trip: Trip, body: str, now_utc: datetime,
     ))
 
 
-def _anker(now_utc: datetime, zone: str, erwarteter_ortstag: date) -> None:
-    """Vorbedingungs-Anker (AC-9) — PFLICHT vor jeder Hauptzusicherung.
-
-    Belegt, dass Ortstag, Weltzeit-Tag und Servertag bei DIESER Fixtur zu
-    DIESEM Zeitpunkt wirklich auseinanderfallen. Ohne ihn koennte die
-    Hauptzusicherung strukturell nie fehlschlagen (Fehlerklasse #1726 F002).
-    Der Sollwert wird aus der Zone gebildet, nicht aus dem Prueflingsweg.
-    """
-    ortstag = now_utc.astimezone(ZoneInfo(zone)).date()
-    assert ortstag == erwarteter_ortstag, (
-        f"Testaufbau: Ortstag in {zone} ist {ortstag}, der Test rechnet mit "
-        f"{erwarteter_ortstag} (Zeitpunkt {now_utc.isoformat()})"
-    )
-    assert ortstag != now_utc.date(), (
-        f"Testaufbau nicht diskriminierend: Ortstag ({ortstag}) und "
-        f"Weltzeit-Tag ({now_utc.date()}) sind gleich (#1726 F002)"
-    )
-    assert ortstag != date.today(), (
-        f"Testaufbau nicht diskriminierend: Ortstag ({ortstag}) und Servertag "
-        f"date.today() ({date.today()}) sind gleich (#1726 F002)"
-    )
+# ``_anker`` ist ab #1795 nach ``tests/tdd/conftest.py`` gehoben (geteilter
+# Ort statt einer zweiten Kopie, s. dortiger Docstring) — hier nur noch
+# importiert (s. Import-Block oben).
 
 
 # ══════════════════════ AC-1/AC-2: /status filtert nach Ortstag ══════════════════════

--- a/tests/tdd/test_briefing_slot_idempotenz.py
+++ b/tests/tdd/test_briefing_slot_idempotenz.py
@@ -963,7 +963,9 @@ def test_t12_on_demand_schreibt_keinen_vermerk_und_liest_keinen(caplog):
 
     # a) Der On-Demand-Versand endet ehrlich mit `no_stage` — einem Ausgang,
     #    der im REGULAEREN Pfad einen Vermerk setzt.
-    assert scheduler.send_on_demand_report(trip, "evening") == "no_stage", (
+    # Fix #1795: send_on_demand_report() liefert seit AC-7 ein
+    # OnDemandErgebnis(outcome, zieltag) statt eines bloszen Strings.
+    assert scheduler.send_on_demand_report(trip, "evening").outcome == "no_stage", (
         "Testaufbau prueft nichts: der On-Demand-Versand muss hier ohne Netz "
         "im Ausgang 'no_stage' enden."
     )
@@ -984,7 +986,7 @@ def test_t12_on_demand_schreibt_keinen_vermerk_und_liest_keinen(caplog):
 
     caplog.clear()
     with caplog.at_level(logging.INFO, logger="trip_report_scheduler"):
-        ergebnis = scheduler.send_on_demand_report(trip, "evening")
+        ergebnis = scheduler.send_on_demand_report(trip, "evening").outcome
 
     assert ergebnis == "no_stage", (
         "Der On-Demand-Versand muss trotz bestehendem Vermerk denselben "
@@ -1083,7 +1085,9 @@ def _aufzeichnender_mailversand(monkeypatch) -> list:
 #: regulaere Weg als Gegenrichtung. Zweites Glied: bleibt der regulaere Slot
 #: danach faellig?
 ANGEFORDERTE_EINSTIEGE = [
-    # SMS-Kommando „heute"/„morgen" (`trip_command_processor.py:576`).
+    # SMS-Kommando „heute"/„morgen" (`trip_command_processor.py:576`). Fix
+    # #1795: liefert seit AC-7 OnDemandErgebnis(outcome, zieltag) -- `_ausloesen`
+    # zieht `.outcome`, bevor der bool/str-Normalisierer greift.
     ("send_on_demand_report", True),
     # Test-Versand-Knopf der Oberflaeche (`api/routers/scheduler.py:232`).
     ("send_test_report_outcome", True),
@@ -1100,6 +1104,11 @@ def _ausloesen(scheduler, trip, einstieg: str):
     if einstieg == "regulaerer_versand":
         return scheduler._send_trip_report_outcome(trip, "morning")
     ergebnis = getattr(scheduler, einstieg)(trip, "morning")
+    # Fix #1795: send_on_demand_report() liefert seit AC-7 ein
+    # OnDemandErgebnis(outcome, zieltag) statt eines bloszen Strings --
+    # zuerst entpacken, DANACH greift die bool/str-Normalisierung.
+    if einstieg == "send_on_demand_report":
+        ergebnis = ergebnis.outcome
     # `send_test_report` liefert den bool-Bestand (#1007), die beiden anderen
     # den Ausgangs-String. Auf eine gemeinsame Aussage bringen.
     return "sent" if ergebnis is True else ergebnis

--- a/tests/tdd/test_issue_1007_heute_voll_briefing.py
+++ b/tests/tdd/test_issue_1007_heute_voll_briefing.py
@@ -72,6 +72,26 @@ _load_main_env()
 
 LAT, LON = 47.2692, 11.4041
 
+
+def _heute_lokal() -> date:
+    """Der Ortstag JETZT fuer die Testtour (Europe/Vienna) -- dieselbe
+    Berechnung, die ``_handle_query`` seit Fix #1795 benutzt
+    (``trip_local_now``), NICHT ``date.today()`` (roher UTC-Tag).
+
+    Ohne diese Angleichung liefe der Test im Mismatch-Fenster (22:00-24:00
+    UTC im Sommer, Europe/Vienna) auf eine Etappe, deren Datum vom
+    tatsaechlich abgefragten Ortstag abweicht -- ``heute``/``morgen``
+    faenden dann keine Etappe. Bewusst KEIN literal eingefrorener Zeitpunkt
+    (``freeze_time``/hartkodiertes Datum): dieser Test versendet echt per
+    SMTP und fragt echtes Wetter ab, ein in der Vergangenheit/Zukunft
+    eingefrorenes "jetzt" wuerde den echten Forecast-Abruf verfaelschen.
+    Ruft freezegun-transparent ``datetime.now()`` auf -- unter einem
+    AEUSSEREN ``freeze_time`` (z. B. der AC-9-Gegenprobe) liefert diese
+    Funktion denselben Ortstag wie der Pruefling.
+    """
+    from utils.timezone import local_dt, tz_for_coords
+    return local_dt(datetime.now(timezone.utc), tz_for_coords(LAT, LON)).date()
+
 # Issue #1044: FESTES Mittagsfenster, keine now()-Abhängigkeit. Das Voll-Briefing
 # filtert die Timeline nach `arrival_time.date() == target_date` (siehe
 # TripCommandProcessor._aggregate_day / _fmt_timeline) — NICHT nach "jetzt aktiv".
@@ -245,7 +265,7 @@ def test_ac1_ac3_ac5_heute_sendet_volles_briefing_genau_eine_mail():
     user_id = "tdd-1007-ac1"
     trip_name = "TDD1007 AC1 HeuteVoll"
     _make_user(user_id)
-    _make_trip(user_id, "tdd-1007-ac1-trip", trip_name, date.today())
+    _make_trip(user_id, "tdd-1007-ac1-trip", trip_name, _heute_lokal())
 
     baseline_uid = _max_uid()
     result = _process(user_id, trip_name, "heute")
@@ -277,7 +297,7 @@ def test_ac1_ac3_ac5_heute_sendet_volles_briefing_genau_eine_mail():
     assert "Anfrage" in html or "Anfrage" in subj, (
         "Kennzeichnung 'auf Anfrage' fehlt in Betreff und Body"
     )
-    today_str = date.today().strftime("%d.%m.%Y")
+    today_str = _heute_lokal().strftime("%d.%m.%Y")
     assert today_str in html, (
         f"Briefing nennt nicht das heutige Datum {today_str}"
     )
@@ -291,7 +311,7 @@ def test_ac2_morgen_sendet_volles_briefing_fuer_morgen():
     user_id = "tdd-1007-ac2"
     trip_name = "TDD1007 AC2 MorgenVoll"
     _make_user(user_id)
-    tomorrow = date.today() + timedelta(days=1)
+    tomorrow = _heute_lokal() + timedelta(days=1)
     _make_trip(user_id, "tdd-1007-ac2-trip", trip_name, tomorrow)
 
     baseline_uid = _max_uid()
@@ -319,7 +339,7 @@ def test_ac4_keine_etappe_keine_mail_klare_antwort():
     trip_name = "TDD1007 AC4 KeineEtappe"
     _make_user(user_id)
     _make_trip(user_id, "tdd-1007-ac4-trip", trip_name,
-               date.today() + timedelta(days=10))
+               _heute_lokal() + timedelta(days=10))
 
     result = _process(user_id, trip_name, "heute")
 
@@ -340,7 +360,7 @@ def test_ac6_glance_bleibt_kurzform_ohne_versand():
     user_id = "tdd-1007-ac6"
     trip_name = "TDD1007 AC6 Glance"
     _make_user(user_id)
-    _make_trip(user_id, "tdd-1007-ac6-trip", trip_name, date.today())
+    _make_trip(user_id, "tdd-1007-ac6-trip", trip_name, _heute_lokal())
 
     result = _process(user_id, trip_name, "glance")
 
@@ -362,8 +382,8 @@ def test_ac8_zwei_nutzer_isolation():
     name_a, name_b = "TDD1007 IsoUserA", "TDD1007 IsoUserB"
     _make_user(user_a)
     _make_user(user_b)
-    _make_trip(user_a, "tdd-1007-iso", name_a, date.today())
-    _make_trip(user_b, "tdd-1007-iso", name_b, date.today())
+    _make_trip(user_a, "tdd-1007-iso", name_a, _heute_lokal())
+    _make_trip(user_b, "tdd-1007-iso", name_b, _heute_lokal())
 
     baseline_uid = _max_uid()
     result = _process(user_a, name_a, "heute")
@@ -394,7 +414,7 @@ def test_f001_keine_kanaele_aktiv_keine_stille_ohne_versand():
         trip_id="tdd-1007-f001-trip",
         send_email=False, send_sms=False, send_telegram=False,
     )
-    _make_trip(user_id, "tdd-1007-f001-trip", trip_name, date.today(), report_config=rc)
+    _make_trip(user_id, "tdd-1007-f001-trip", trip_name, _heute_lokal(), report_config=rc)
 
     baseline_uid = _max_uid()
     result = _process(user_id, trip_name, "heute")
@@ -443,7 +463,7 @@ def test_snapshot_bleibt_kombiniert_nach_heute():
     heilt."""
     user_id = "tdd-1007-adv-verify"
     trip_name = "TDD1007 SnapshotBleibtKombiniert"
-    today = date.today()
+    today = _heute_lokal()
     tomorrow = today + timedelta(days=1)
     _make_user(user_id)
     trip = _make_trip_two_stages(

--- a/tests/tdd/test_issue_1087_trip_official_alerts.py
+++ b/tests/tdd/test_issue_1087_trip_official_alerts.py
@@ -232,9 +232,10 @@ class TestAC1TripOfficialAlertsFR:
             try:
                 register_official_alert_source(counting_source)
 
+                # Fix #1795 AC-7: OnDemandErgebnis(outcome, zieltag) statt bloszem String.
                 outcome = TripReportSchedulerService(user_id=user_id).send_on_demand_report(
                     trip, "morning"
-                )
+                ).outcome
                 assert counting_source.fetch_calls >= 1, (
                     "RED: der Trip-Briefing-Pfad ruft die registrierten "
                     "Official-Alert-Quellen noch nicht ab (fetch_calls=0)."
@@ -486,9 +487,10 @@ class TestAC3ToggleNoFetch:
             oa_base._REGISTERED_SOURCES.clear()
             try:
                 register_official_alert_source(counting_source)
+                # Fix #1795 AC-7: OnDemandErgebnis(outcome, zieltag) statt bloszem String.
                 outcome = TripReportSchedulerService(user_id=user_id).send_on_demand_report(
                     trip, "morning"
-                )
+                ).outcome
                 assert outcome == "sent", f"Erwartet Outcome 'sent', bekommen {outcome!r}"
                 assert counting_source.fetch_calls == 0, (
                     "official_alerts_enabled=False muss den Fetch verhindern, aber "
@@ -580,9 +582,10 @@ class TestAC4FailSoft:
             try:
                 register_official_alert_source(erroring_source)
 
+                # Fix #1795 AC-7: OnDemandErgebnis(outcome, zieltag) statt bloszem String.
                 outcome = TripReportSchedulerService(user_id=user_id).send_on_demand_report(
                     trip, "morning"
-                )
+                ).outcome
                 assert erroring_source.fetch_calls >= 1, (
                     "RED: der Trip-Briefing-Pfad ruft die registrierten "
                     "Official-Alert-Quellen noch nicht ab (fetch_calls=0), "
@@ -650,9 +653,10 @@ class TestAC5CompactFormat:
             try:
                 register_official_alert_source(counting_source)
 
+                # Fix #1795 AC-7: OnDemandErgebnis(outcome, zieltag) statt bloszem String.
                 outcome = TripReportSchedulerService(user_id=user_id).send_on_demand_report(
                     trip, "morning"
-                )
+                ).outcome
                 assert counting_source.fetch_calls >= 1, (
                     "RED: der Trip-Briefing-Pfad ruft die registrierten "
                     "Official-Alert-Quellen noch nicht ab (fetch_calls=0)."

--- a/tests/tdd/test_thunder_origin_four_places.py
+++ b/tests/tdd/test_thunder_origin_four_places.py
@@ -209,8 +209,17 @@ def _alt_schnappschuss() -> None:
 def kommando():
     """Speichert Trip + Wetter-Schnappschuss und stellt die Kommando-Frage
     ueber ``TripCommandProcessor.process()`` -- derselbe Weg, den eine
-    eingehende Telegram-/E-Mail-Nachricht nimmt."""
-    jetzt = datetime.now(tz=timezone.utc)
+    eingehende Telegram-/E-Mail-Nachricht nimmt.
+
+    Fix #1795 AC-9: ``jetzt`` war ``datetime.now(tz=timezone.utc)`` --
+    ``_handle_query`` bestimmt den Kalendertag seit #1795 ueber den ORTStag
+    (``trip_local_now``, Koordinaten 47.0/12.0 = Europe/Vienna). Im
+    Mismatch-Fenster (22:00-24:00 UTC im Sommer) waere der Ortstag ein
+    anderer als ``heute`` (= UTC-Tag der echten Systemuhr) -- die Fixtur
+    haengt jetzt auf einem festen, zonensicheren Zeitpunkt statt an der
+    Systemuhr.
+    """
+    jetzt = datetime(2026, 8, 20, 9, 0, tzinfo=timezone.utc)
     heute = jetzt.date()
 
     def frage(segmente, *, body: str = "GLANCE", alt: bool = False) -> str:

--- a/tests/tdd/test_thunder_origin_trip.py
+++ b/tests/tdd/test_thunder_origin_trip.py
@@ -193,8 +193,17 @@ def _alt_schnappschuss() -> None:
 def kommando():
     """Speichert Trip + Wetter-Schnappschuss und stellt die Kommando-Frage
     ueber ``TripCommandProcessor.process()`` -- derselbe Weg, den eine
-    eingehende Telegram-/E-Mail-Nachricht nimmt."""
-    jetzt = datetime.now(tz=timezone.utc)
+    eingehende Telegram-/E-Mail-Nachricht nimmt.
+
+    Fix #1795 AC-9: ``jetzt`` war ``datetime.now(tz=timezone.utc)`` --
+    ``_handle_query`` bestimmt den Kalendertag seit #1795 ueber den ORTStag
+    (``trip_local_now``, Koordinaten 47.0/12.0 = Europe/Vienna). Im
+    Mismatch-Fenster (22:00-24:00 UTC im Sommer) waere der Ortstag ein
+    anderer als ``heute`` (= UTC-Tag der echten Systemuhr) -- die Fixtur
+    haengt jetzt auf einem festen, zonensicheren Zeitpunkt statt an der
+    Systemuhr.
+    """
+    jetzt = datetime(2026, 8, 20, 9, 0, tzinfo=timezone.utc)
     heute = jetzt.date()
 
     def frage(segmente, *, body: str = "GEWITTER", alt: bool = False) -> str:

--- a/tests/tdd/test_timeline_folgt_der_ortszeit.py
+++ b/tests/tdd/test_timeline_folgt_der_ortszeit.py
@@ -66,10 +66,14 @@ _ADR_0044 = (
 # ---------------------------------------------------------------------------
 
 def _seg(arrival_time: datetime, coords: tuple[float, float], *,
-         elevation_m: int = 1500, seg_id: int = 1) -> SegmentWeatherData:
+         elevation_m: int = 1500, seg_id: int = 1,
+         wind_max_kmh: float = 20.0) -> SegmentWeatherData:
     """Ein Timeline-Punkt mit kontrolliertem ``arrival_time`` (aware UTC) --
     Metriken sind Platzhalter, nur ``arrival_time``/Koordinaten sind fuer
-    diese Suite relevant (Filter-/Formatier-Logik, nicht Wetterinhalt)."""
+    diese Suite relevant (Filter-/Formatier-Logik, nicht Wetterinhalt).
+    ``wind_max_kmh`` optional erhoehbar (Adversary-Fix F002/AC-4-Nachtrag):
+    ab 40 km/h loest ``_timeline_buttons`` den Wind-Drilldown-Button aus --
+    ein von aussen beobachtbares Signal, OB ein Wegpunkt gefunden wurde."""
     lat, lon = coords
     segment = TripSegment(
         segment_id=seg_id,
@@ -78,7 +82,9 @@ def _seg(arrival_time: datetime, coords: tuple[float, float], *,
         start_time=arrival_time - timedelta(hours=2), end_time=arrival_time,
         duration_hours=2.0, distance_km=5.0, ascent_m=100.0, descent_m=0.0,
     )
-    aggregated = SegmentWeatherSummary(temp_min_c=10.0, temp_max_c=18.0, wind_max_kmh=20.0)
+    aggregated = SegmentWeatherSummary(
+        temp_min_c=10.0, temp_max_c=18.0, wind_max_kmh=wind_max_kmh,
+    )
     return SegmentWeatherData(
         segment=segment, timeseries=None, aggregated=aggregated,
         fetched_at=arrival_time, provider="test",
@@ -199,11 +205,56 @@ def test_ac3_timeline_heute_koppelt_datum_und_uhrzeit():
           eine ortszeitrichtig umgerechnete 🕐-Zeile -- EINE Assertion-Gruppe
           prueft BEIDES gemeinsam, ein Halb-Fix (nur Filter ODER nur
           Formatierung umgestellt) muss hier durchfallen.
+
+    🔴 Nachbesserung (Adversary-Befund F001): die urspruengliche Fassung
+    waehlte ``ankunft_heute`` so, dass roher UTC-Tag (21.08.) UND Ortstag
+    (21.08.) zufaellig zusammenfielen -- ein auf rohes UTC zurueckgedrehter
+    Filter (``p.arrival_time.date() == target_date``) fand denselben Punkt
+    TROTZDEM, der Test blieb bei diesem Halb-Fix gruen. ``ankunft_heute``
+    liegt jetzt bewusst im Mismatch-Fenster (22:30 UTC am VORTAG = 00:30
+    Ortszeit): roher UTC-Tag (20.08.) != Ortstag (21.08.) -- ein
+    zurueckgedrehter Filter findet den Punkt NICHT mehr (Timeline leer,
+    uhrzeit_ok wird False), eine zurueckgedrehte Formatierung zeigt "22:30"
+    statt "00:30" (uhrzeit_ok ebenfalls False). Beide Richtungen fallen
+    ueber dieselbe Assertion durch. Die Drei-Wege-Vorbedingung (Ortstag ==
+    D21, roher Tag != D21) wird im Testkoerper GEMESSEN, nicht nur im
+    Kommentar behauptet.
+
+    🔴 Zweite Nachbesserung (eigene Mutations-Gegenprobe): ``ankunft_morgen``
+    lag urspruenglich EBENFALLS im Mismatch-Fenster (21.08. 22:30 UTC), mit
+    rohem UTC-Tag 21.08. -- IDENTISCH mit ``D21``, dem Zieltag von "heute".
+    Unter dem zurueckgedrehten Filter fiel dadurch nicht "kein Punkt
+    gefunden" auf, sondern der FALSCHE Punkt (``ankunft_morgen`` statt
+    ``ankunft_heute``) wurde als "heute" gezeigt -- zufaellig mit derselben
+    lokalen Uhrzeit "00:30", sodass die Assertion trotzdem gruen blieb. Die
+    Mutations-Gegenprobe deckte das auf. ``ankunft_morgen`` liegt jetzt
+    bewusst AUSSERHALB des Mismatch-Fensters (roher Tag == Ortstag == D22),
+    kann also unter keiner Filter-Variante mit D21 verwechselt werden --
+    im Testkoerper gemessen, nicht nur behauptet.
     """
-    ankunft_heute = datetime(2026, 8, 21, 6, 0, tzinfo=timezone.utc)    # 08:00 Korsika
-    ankunft_morgen = datetime(2026, 8, 22, 6, 0, tzinfo=timezone.utc)   # 08:00 Korsika (Folgetag)
+    ankunft_heute = datetime(2026, 8, 20, 22, 30, tzinfo=timezone.utc)   # 00:30 Korsika am 21.08, Mismatch-Fenster
+    ankunft_morgen = datetime(2026, 8, 22, 10, 0, tzinfo=timezone.utc)  # 12:00 Korsika am 22.08, ausserhalb des Fensters
 
     with freeze_time(NACHTS_UTC):
+        assert ankunft_heute.astimezone(ZoneInfo(KORSIKA_ZONE)).date() == D21, (
+            "Testaufbau: ankunft_heute muss lokal (Korsika) auf den Ortstag "
+            f"{D21} fallen"
+        )
+        assert ankunft_heute.date() != D21, (
+            "Testaufbau nicht diskriminierend: roher UTC-Tag von "
+            f"ankunft_heute ({ankunft_heute.date()}) darf nicht mit dem "
+            f"Ortstag ({D21}) zusammenfallen -- sonst faende ein auf rohes "
+            "UTC zurueckgedrehter Filter denselben Punkt trotzdem (Adversary "
+            "F001)"
+        )
+        assert ankunft_morgen.date() != D21, (
+            "Testaufbau nicht diskriminierend: roher UTC-Tag von "
+            f"ankunft_morgen ({ankunft_morgen.date()}) darf nicht mit D21 "
+            "zusammenfallen -- sonst koennte ein zurueckgedrehter Filter "
+            "diesen Punkt statt ankunft_heute als 'heute' zeigen und die "
+            "Assertion zufaellig gruen bleiben"
+        )
+
         _anker(NACHTS_UTC, KORSIKA_ZONE, D21)
         trip = _trip("ac3-kopplung", [D21, D22], WP_KORSIKA)
         save_trip(trip)
@@ -215,7 +266,7 @@ def test_ac3_timeline_heute_koppelt_datum_und_uhrzeit():
         body = _befehl(trip, "### query: timeline_heute", NACHTS_UTC).confirmation_body
 
     kopfzeile_ok = f"({D21:%d.%m})" in body
-    uhrzeit_ok = "🕐 08:00" in body
+    uhrzeit_ok = "🕐 00:30" in body
     assert kopfzeile_ok and uhrzeit_ok, (
         "AC-3: EINE Assertion-Gruppe muss BEIDE Bestandteile pruefen -- den "
         "Kopfzeilen-Ortstag UND eine ortszeitrichtig umgerechnete 🕐-Zeile "
@@ -322,6 +373,217 @@ def test_ac4_glance_nutzt_je_tag_die_eigene_zone():
         f"AC-4: die KORSIKA-Etappe (eigene Zone: Europe/Paris) wurde nicht "
         f"gefunden -- eine gemeinsame Wellington-Zone (Mutante ii) findet "
         f"sie nicht:\n{body}"
+    )
+
+
+# ═══════════ Adversary-Fix F005 (schliesst die Fehlerklasse aus F002/F004) ═══════════
+#
+# Ausgezaehlt: SIEBEN Zonen-Entscheidungspunkte in `_handle_query` --
+# `glance` reicht ZWEI Argumente durch (`tz_heute` fuer heute, `tz_morgen`
+# fuer morgen, EIN Aufruf `_fmt_glance(..., tz_heute, tz_morgen)`),
+# `heute_gewitter` EINES, `timeline_heute` ZWEI (Text via `_fmt_timeline`,
+# Buttons via `_timeline_buttons`), `timeline_morgen` ebenfalls ZWEI.
+# AC-2/AC-3 nutzen einzonige Korsika-Touren (`tz_heute == tz_morgen` dort),
+# AC-4 deckt nur `glance` ab -- ein Zonentausch an JEDEM der sechs
+# UEBRIGEN Punkte blieb dadurch fuer sich genommen unsichtbar (F002/F004,
+# beide inzwischen geschlossen -- s. Bericht).
+#
+# EIN parametrisierter Test statt vier/fuenf Einzeltests, auf EINER
+# Mehrzonen-Tour (`trip_two_zones`: heute Wellington, morgen Korsika):
+# fuer jedes der vier Kommandos ein Wegpunkt, dessen Ortszeit unter der
+# EIGENEN Zone einen ANDEREN Tag/eine andere Uhrzeit ergibt als unter der
+# Zone des jeweils ANDEREN Tages. Wo ein `reply_markup` existiert
+# (`timeline_heute`/`timeline_morgen`), traegt es eine eigene Assertion --
+# sonst bliebe der Button-Pfad unbewacht. Ersetzt die drei F002-Tests und
+# den F004-Test vollstaendig (geloescht -- die Matrix deckt exakt dieselbe
+# Fehlerklasse ab, staerker: alle sieben Punkte statt einzelner, s. Beleg
+# im Bericht des Auftrags: Mutations-Gegenprobe ueber alle sieben Punkte).
+
+_F005_ABFRAGE = datetime(2026, 8, 19, 6, 0, tzinfo=timezone.utc)
+_F005_HEUTE_ZEIT = datetime(2026, 8, 18, 15, 0, tzinfo=timezone.utc)    # 03:00 Wellington 19.08, 17:00 Korsika 18.08
+_F005_MORGEN_ZEIT = datetime(2026, 8, 20, 18, 0, tzinfo=timezone.utc)   # 20:00 Korsika 20.08, 06:00 Wellington 21.08
+
+
+@pytest.mark.parametrize("query_key, body_cmd", [
+    pytest.param("glance", "### query: glance", id="glance"),
+    pytest.param("heute_gewitter", "### query: heute_gewitter", id="heute_gewitter"),
+    pytest.param("timeline_heute", "### query: timeline_heute", id="timeline_heute"),
+    pytest.param("timeline_morgen", "### query: timeline_morgen", id="timeline_morgen"),
+])
+def test_f005_alle_vier_kommandos_nutzen_die_zone_ihrer_eigenen_etappe(query_key, body_cmd):
+    """Adversary-Fix F005.
+
+    GIVEN eine Mehrzonen-Tour hat die heutige Etappe in Neuseeland
+          (Pacific/Auckland) und die morgige auf Korsika (Europe/Paris), je
+          ein Wegpunkt liegt so, dass seine Ortszeit unter der EIGENEN Zone
+          einen anderen Tag/eine andere Uhrzeit ergibt als unter der Zone
+          des jeweils ANDEREN Tages,
+    WHEN  eines der vier Query-Kommandos abgefragt wird,
+    THEN  spiegeln Text UND (wo vorhanden) ``reply_markup`` den unter der
+          EIGENEN Zone gefundenen Wegpunkt -- ein Tausch der Zone an JEDEM
+          der sieben Entscheidungspunkte in ``_handle_query`` (glance
+          heute/morgen, heute_gewitter, timeline_heute Text/Buttons,
+          timeline_morgen Text/Buttons) muss fuer das jeweils betroffene
+          Kommando durchfallen.
+    """
+    ortstag_heute = _F005_ABFRAGE.astimezone(ZoneInfo(WELLINGTON_ZONE)).date()
+    morgen_tag = ortstag_heute + timedelta(days=1)
+
+    heute_wellington = _F005_HEUTE_ZEIT.astimezone(ZoneInfo(WELLINGTON_ZONE))
+    heute_korsika = _F005_HEUTE_ZEIT.astimezone(ZoneInfo(KORSIKA_ZONE))
+    morgen_korsika = _F005_MORGEN_ZEIT.astimezone(ZoneInfo(KORSIKA_ZONE))
+    morgen_wellington = _F005_MORGEN_ZEIT.astimezone(ZoneInfo(WELLINGTON_ZONE))
+
+    # Vorbedingungen -- fuer JEDEN Parameterfall gemessen (nicht behauptet):
+    # die EIGENE Zone muss den Wegpunkt auf den erwarteten Ortstag legen,
+    # die FREMDE Zone auf einen ANDEREN Tag UND eine andere Uhrzeit --
+    # sonst waere der jeweilige Zonentausch strukturell unsichtbar.
+    assert ortstag_heute == date(2026, 8, 19), (
+        f"Testaufbau: Ortstag heute (Wellington) muss 19.08 sein, ist {ortstag_heute}"
+    )
+    assert heute_wellington.date() == ortstag_heute, (
+        "Testaufbau: heute_zeit muss lokal (Wellington, EIGENE Zone der "
+        f"heutigen Etappe) auf den heutigen Ortstag {ortstag_heute} fallen"
+    )
+    assert heute_korsika.date() != ortstag_heute, (
+        "Testaufbau nicht diskriminierend: unter der FALSCHEN Zone "
+        "(Korsika, Zone von MORGEN) muss heute_zeit auf einen ANDEREN Tag "
+        "fallen -- sonst faende ein Zonentausch den Wegpunkt trotzdem"
+    )
+    assert heute_wellington.strftime("%H:%M") != heute_korsika.strftime("%H:%M"), (
+        "Testaufbau nicht diskriminierend: die beiden Zonen muessen fuer "
+        "heute_zeit tatsaechlich verschiedene Ortszeiten ergeben"
+    )
+    assert morgen_korsika.date() == morgen_tag, (
+        "Testaufbau: morgen_zeit muss lokal (Korsika, EIGENE Zone der "
+        f"morgigen Etappe) auf den morgigen Ortstag {morgen_tag} fallen"
+    )
+    assert morgen_wellington.date() != morgen_tag, (
+        "Testaufbau nicht diskriminierend: unter der FALSCHEN Zone "
+        "(Wellington, Zone von HEUTE) muss morgen_zeit auf einen ANDEREN "
+        "Tag fallen -- sonst faende ein Zonentausch den Wegpunkt trotzdem"
+    )
+    assert morgen_korsika.strftime("%H:%M") != morgen_wellington.strftime("%H:%M"), (
+        "Testaufbau nicht diskriminierend: die beiden Zonen muessen fuer "
+        "morgen_zeit tatsaechlich verschiedene Ortszeiten ergeben"
+    )
+
+    with freeze_time(_F005_ABFRAGE):
+        trip = trip_two_zones(ortstag_heute, trip_id=f"f005-{query_key}")
+        save_trip(trip)
+        _save_snapshot(trip.id, [
+            _seg(_F005_HEUTE_ZEIT, WP_NZ, seg_id=1, wind_max_kmh=45.0),
+            _seg(_F005_MORGEN_ZEIT, WP_KORSIKA, seg_id=2, wind_max_kmh=45.0),
+        ])
+
+        ergebnis = _befehl(trip, body_cmd, _F005_ABFRAGE)
+        body = ergebnis.confirmation_body
+
+    if query_key == "glance":
+        assert f"heute ({ortstag_heute:%d.%m}): Keine Etappe geplant" not in body, (
+            "F005 [glance, heute-Argument]: der heutige Wegpunkt "
+            f"(Wellington) wurde nicht gefunden:\n{body}"
+        )
+        assert f"morgen ({morgen_tag:%d.%m}): Keine Etappe geplant" not in body, (
+            "F005 [glance, morgen-Argument]: der morgige Wegpunkt (Korsika) "
+            f"wurde nicht gefunden:\n{body}"
+        )
+    elif query_key == "heute_gewitter":
+        assert "Keine Etappe geplant" not in body, (
+            "F005 [heute_gewitter]: der heutige Wegpunkt (Wellington) wurde "
+            f"nicht gefunden:\n{body}"
+        )
+    elif query_key == "timeline_heute":
+        erwartete_zeile = f"🕐 {heute_wellington.strftime('%H:%M')}"
+        assert erwartete_zeile in body, (
+            "F005 [timeline_heute, Text]: die ortszeitrichtige "
+            f"(Wellington-)Uhrzeit fehlt:\n{body}"
+        )
+        callbacks = [
+            btn["callback_data"]
+            for row in ergebnis.reply_markup["inline_keyboard"]
+            for btn in row
+        ]
+        assert "dd_wind_today" in callbacks, (
+            "F005 [timeline_heute, Buttons]: der Wind-Drilldown-Button "
+            f"fehlt: {callbacks!r}"
+        )
+    elif query_key == "timeline_morgen":
+        erwartete_zeile = f"🕐 {morgen_korsika.strftime('%H:%M')}"
+        assert erwartete_zeile in body, (
+            "F005 [timeline_morgen, Text]: die ortszeitrichtige "
+            f"(Korsika-)Uhrzeit fehlt:\n{body}"
+        )
+        callbacks = [
+            btn["callback_data"]
+            for row in ergebnis.reply_markup["inline_keyboard"]
+            for btn in row
+        ]
+        assert "dd_wind_tomorrow" in callbacks, (
+            "F005 [timeline_morgen, Buttons]: der Wind-Drilldown-Button "
+            f"fehlt: {callbacks!r}"
+        )
+
+
+# ═══════ Dokumentierte Grenze der F005-Matrix: EIN Rest-Fall aus F002 ═══════
+#
+# Die F005-Matrix oben deckt (per Mutations-Gegenprobe belegt, s. Bericht des
+# Auftrags) alle SIEBEN `_handle_query`-Entscheidungspunkte UND zusaetzlich,
+# als Nebeneffekt derselben Konstruktion, drei der vier urspruenglichen
+# F002-Mutationen (den internen UTC-Ruckfall in `_fmt_gewitter`,
+# `_timeline_buttons` und im HEUTE-Zweig von `_fmt_glance`). EINE
+# F002-Mutation bleibt strukturell unerreichbar: der interne UTC-Ruckfall im
+# MORGEN-Zweig von `_fmt_glance` (`agg_morgen = self._aggregate_day(...,
+# UTC)` statt `tz_morgen`).
+#
+# Beweis (nicht nur behauptet): fuer einen Wegpunkt, der unter Korsika
+# (+2h) auf den morgigen Ortstag T faellt, aber unter Weltzeit NICHT (also
+# den internen UTC-Ruckfall faengt), MUSS der Zeitpunkt in der zweistuen-
+# digen Luecke [T-1 22:00, T 00:00) UTC liegen (dem Teil von Korsikas
+# Tagesfenster [T-1 22:00, T 22:00), der VOR dem UTC-Tageswechsel liegt).
+# Wellingtons Tagesfenster fuer T ist [T-1 12:00, T 12:00) (+12h) -- und
+# [T-1 22:00, T 00:00) liegt VOLLSTAENDIG darin (T-1 22:00 >= T-1 12:00,
+# T 00:00 <= T 12:00). JEDER Zeitpunkt, der den UTC-Ruckfall faengt, faellt
+# also zwangslaeufig AUCH unter Wellington auf T -- ein Wellington/Korsika-
+# Tausch (F004/F005s Fehlerklasse) waere an genau diesem Punkt dann NICHT
+# mehr diskriminierbar. Beide Eigenschaften gleichzeitig sind fuer EINEN
+# Wegpunkt auf dieser Zweizonen-Tour unerreichbar -- deshalb bleibt dieser
+# EINE Fall als eigener, einzoniger Test stehen (Mismatch-Fenster-Muster,
+# unveraendert aus F002 uebernommen) statt in der Matrix aufzugehen.
+
+
+def test_f002_rest_glance_morgen_internen_utc_ruckfall():
+    """Adversary-Fix F002, Rest-Fall (s. Beweis oben): der MORGEN-Zweig von
+    ``_fmt_glance`` muss ``tz_morgen`` tatsaechlich verwenden -- nicht nur
+    einen ANDEREN Zonenwert (das deckt F005), sondern auch nicht intern auf
+    UTC zurueckfallen. Einzonige Korsika-Tour, Wegpunkt im Mismatch-Fenster.
+    """
+    morgen_zeit = datetime(2026, 8, 21, 22, 30, tzinfo=timezone.utc)  # 00:30 Korsika am 22.08
+    heute_zeit = datetime(2026, 8, 21, 10, 0, tzinfo=timezone.utc)    # unauffaellig, kein Mismatch
+
+    with freeze_time(NACHTS_UTC):
+        assert morgen_zeit.astimezone(ZoneInfo(KORSIKA_ZONE)).date() == D22, (
+            "Testaufbau: morgen_zeit muss lokal (Korsika) auf D22 fallen"
+        )
+        assert morgen_zeit.date() != D22, (
+            "Testaufbau nicht diskriminierend: roher UTC-Tag von morgen_zeit "
+            "darf nicht mit D22 zusammenfallen -- sonst faende ein interner "
+            "UTC-Ruckfall denselben Punkt trotzdem"
+        )
+
+        _anker(NACHTS_UTC, KORSIKA_ZONE, D21)
+        trip = _trip("f002-rest-glance-morgen", [D21, D22], WP_KORSIKA)
+        save_trip(trip)
+        _save_snapshot(trip.id, [
+            _seg(heute_zeit, WP_KORSIKA, seg_id=1),
+            _seg(morgen_zeit, WP_KORSIKA, seg_id=2),
+        ])
+
+        body = _befehl(trip, "### query: glance", NACHTS_UTC).confirmation_body
+
+    assert f"morgen ({D22:%d.%m}): Keine Etappe geplant" not in body, (
+        "F002 (Rest): der morgige Wegpunkt wurde nicht gefunden -- der "
+        f"MORGEN-Zweig von _fmt_glance nutzt offenbar nicht tz_morgen:\n{body}"
     )
 
 

--- a/tests/tdd/test_timeline_folgt_der_ortszeit.py
+++ b/tests/tdd/test_timeline_folgt_der_ortszeit.py
@@ -1,0 +1,666 @@
+"""TDD RED — Fix #1795: Timeline und Query-Familie folgen der Ortszeit der Tour.
+
+SPEC: docs/specs/modules/fix_1795_timeline_ortszeit.md (AC-1 bis AC-8, AC-11)
+KONTEXT: docs/context/fix-1795-timeline-ortszeit.md
+
+Deckt die Query-Familie (`glance`, `heute_gewitter`, `timeline_heute`,
+`timeline_morgen`, `heute`, `morgen`) ab: `_handle_query` bestimmt heute den
+Kalendertag ueber den UTC-Tag der Nachricht (`received_at.date()`) statt ueber
+den Ortstag der Tour (ADR-0044), und `_fmt_timeline` formatiert Ankunftszeiten
+roh in UTC statt in der Ortszeit des Wegpunkts.
+
+Testpolitik (CLAUDE.md "Test-Politik: Zwei Schichten"): Kern-Schicht, kein
+Netz. Echte ``Trip``/``Stage``/``Waypoint``-Objekte, echter
+``TripCommandProcessor`` ueber den PRODUKTIVEN Eintrittspunkt
+``process()``, echte Wetter-Schnappschuesse (``WeatherSnapshotService.save``)
+-- kein ``Mock()``/``patch()``. Fuer AC-8 laeuft der echte Fetch-Pfad ueber
+die projektweit autouse gesetzte ``GZ_TEST_FIXTURE_DIR`` (Issue #346,
+``tests/conftest.py``): kein Live-API-Call, kein Mock-Theater.
+
+Pfadregel #1409: diese Datei liest nichts vom Hauptrepo-Pfad; ADR-0044
+(AC-11) wird relativ zur eigenen Testdatei aufgeloest.
+
+🔴 Jeder Test, der einen Wetter-Schnappschuss braucht, bestueckt ihn
+ausdruecklich mit Segmenten fuer HEUTE UND MORGEN (#1818: ein einspuriger
+Scheduler-Anker deckt strukturell nur einen Tag ab -- s. Spec "Nicht in
+dieser Scheibe").
+"""
+from __future__ import annotations
+
+import re
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+from freezegun import freeze_time
+
+from app.loader import save_trip
+from app.models import GPXPoint, SegmentWeatherData, SegmentWeatherSummary, TripSegment
+from app.trip import Stage, Trip, Waypoint
+from services.trip_alert import TripAlertService
+from services.trip_report_scheduler import TripReportSchedulerService
+from services.weather_snapshot import WeatherSnapshotService
+from tests.tdd.conftest import WP_KORSIKA, WP_NZ, _anker, trip_two_zones
+from tests.tdd.test_befehlspfade_folgen_ortszone import (
+    D20,
+    D21,
+    D22,
+    D23,
+    KORSIKA_ZONE,
+    MITTAGS_UTC,
+    NACHTS_UTC,
+    WELLINGTON_ZONE,
+    _befehl,
+    _trip,
+)
+
+_ADR_0044 = (
+    Path(__file__).resolve().parents[2]
+    / "docs" / "adr" / "0044-kalendertage-folgen-der-ortszeit.md"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helfer -- Wetter-Schnappschuss mit kontrolliertem `arrival_time`
+# ---------------------------------------------------------------------------
+
+def _seg(arrival_time: datetime, coords: tuple[float, float], *,
+         elevation_m: int = 1500, seg_id: int = 1) -> SegmentWeatherData:
+    """Ein Timeline-Punkt mit kontrolliertem ``arrival_time`` (aware UTC) --
+    Metriken sind Platzhalter, nur ``arrival_time``/Koordinaten sind fuer
+    diese Suite relevant (Filter-/Formatier-Logik, nicht Wetterinhalt)."""
+    lat, lon = coords
+    segment = TripSegment(
+        segment_id=seg_id,
+        start_point=GPXPoint(lat=lat, lon=lon, elevation_m=elevation_m - 100),
+        end_point=GPXPoint(lat=lat, lon=lon, elevation_m=elevation_m),
+        start_time=arrival_time - timedelta(hours=2), end_time=arrival_time,
+        duration_hours=2.0, distance_km=5.0, ascent_m=100.0, descent_m=0.0,
+    )
+    aggregated = SegmentWeatherSummary(temp_min_c=10.0, temp_max_c=18.0, wind_max_kmh=20.0)
+    return SegmentWeatherData(
+        segment=segment, timeseries=None, aggregated=aggregated,
+        fetched_at=arrival_time, provider="test",
+    )
+
+
+def _save_snapshot(trip_id: str, segments: list[SegmentWeatherData],
+                    user_id: str = "default") -> None:
+    """Speichert Segmente als UNDATIERTEN Schnappschuss -- derselbe Weg, den
+    ``WeatherExtractor.timeline()`` liest. Die Tagestrennung passiert erst
+    beim Formatieren (weather_extractor.py), nicht hier."""
+    WeatherSnapshotService(user_id).save(
+        trip_id, segments, segments[0].segment.end_time.date(),
+    )
+
+
+def _stage_mit_zwei_wegpunkten(stage_id: str, tag: date,
+                                coords: tuple[float, float]) -> Stage:
+    """Etappe mit ZWEI Wegpunkten -- ``convert_trip_to_segments()`` verwirft
+    Etappen mit weniger (``trip_segments.py``)."""
+    lat, lon = coords
+    return Stage(
+        id=stage_id, name=f"Etappe {tag:%d.%m.}", date=tag,
+        waypoints=[
+            Waypoint(id=f"{stage_id}-A", name="Start", lat=lat, lon=lon, elevation_m=500),
+            Waypoint(id=f"{stage_id}-B", name="Ziel", lat=lat + 0.05, lon=lon + 0.05,
+                     elevation_m=800),
+        ],
+    )
+
+
+# ══════════════════════ AC-1: Uhrzeit-Umrechnung, AUSSERHALB des Mismatch-Fensters ══════════════════════
+
+
+def test_ac1_timeline_zeigt_ortszeit_nicht_die_rohe_utc_zeit():
+    """AC-1.
+
+    GIVEN eine Korsika-Etappe (Europe/Paris, im August UTC+2) hat einen
+          Wegpunkt mit ``arrival_time`` 06:00 UTC (= 08:00 Ortszeit),
+    WHEN  ``timeline_heute`` zu MITTAGS_UTC (14:00 UTC) abgefragt wird --
+          bewusst AUSSERHALB des Mismatch-Fensters, damit allein die
+          Uhrzeitumrechnung geprueft wird, kein Tageswechsel,
+    THEN  zeigt die Timeline-Zeile "🕐 08:00", nicht "🕐 06:00".
+    """
+    assert MITTAGS_UTC.astimezone(ZoneInfo(KORSIKA_ZONE)).date() == D20 == MITTAGS_UTC.date(), (
+        "Testaufbau (Kontrolllauf): MITTAGS_UTC muss AUSSERHALB des Mismatch-"
+        "Fensters liegen (Orts- und Weltzeit-Tag identisch), sonst prueft "
+        "AC-1 versehentlich einen Tageswechsel statt der Uhrzeit"
+    )
+    ankunft = datetime(2026, 8, 20, 6, 0, tzinfo=timezone.utc)
+
+    with freeze_time(MITTAGS_UTC):
+        trip = _trip("ac1-uhrzeit", [D20], WP_KORSIKA)
+        save_trip(trip)
+        _save_snapshot(trip.id, [_seg(ankunft, WP_KORSIKA)])
+
+        body = _befehl(trip, "### query: timeline_heute", MITTAGS_UTC).confirmation_body
+
+    assert "🕐 08:00" in body, (
+        f"AC-1: erwartete Ortszeit '🕐 08:00' (Ankunft 06:00 UTC, Korsika "
+        f"UTC+2) fehlt in der Timeline:\n{body}"
+    )
+    assert "🕐 06:00" not in body, (
+        f"AC-1: die Timeline zeigt noch die rohe UTC-Zeit '🕐 06:00' statt "
+        f"der umgerechneten Ortszeit:\n{body}"
+    )
+
+
+# ══════════════════════ AC-2: alle vier Kommandos folgen dem Ortstag ══════════════════════
+
+
+@pytest.mark.parametrize("query_key, body_cmd, erwartete_tage", [
+    pytest.param("glance", "### query: glance", (D21, D22), id="glance"),
+    pytest.param("heute_gewitter", "### query: heute_gewitter", (D21,), id="heute_gewitter"),
+    pytest.param("timeline_heute", "### query: timeline_heute", (D21,), id="timeline_heute"),
+    pytest.param("timeline_morgen", "### query: timeline_morgen", (D22,), id="timeline_morgen"),
+])
+def test_ac2_vier_kommandos_folgen_dem_ortstag(query_key, body_cmd, erwartete_tage):
+    """AC-2.
+
+    GIVEN eine Korsika-Tour mit Etappen fuer den Ortstag D+1/D+2,
+    WHEN  eine Nachricht zu NACHTS_UTC (22:30 UTC = 00:30 Ortszeit des
+          Folgetags, Mismatch-Fenster) fuer eines der vier Kommandos kommt,
+    THEN  bezieht sich "heute"/"morgen" auf den ORTSTAG (D+1/D+2) -- vor dem
+          Fix trugen alle vier noch den UTC-Tag der Nachricht (D/D+1).
+    """
+    with freeze_time(NACHTS_UTC):
+        _anker(NACHTS_UTC, KORSIKA_ZONE, D21)
+        trip = _trip(f"ac2-{query_key}", [D21, D22], WP_KORSIKA)
+        save_trip(trip)
+        _save_snapshot(trip.id, [
+            _seg(datetime(2026, 8, 21, 10, 0, tzinfo=timezone.utc), WP_KORSIKA, seg_id=1),
+            _seg(datetime(2026, 8, 22, 10, 0, tzinfo=timezone.utc), WP_KORSIKA, seg_id=2),
+        ])
+
+        body = _befehl(trip, body_cmd, NACHTS_UTC).confirmation_body
+
+    for tag in erwartete_tage:
+        erwartet = f"({tag:%d.%m})"
+        assert erwartet in body, (
+            f"AC-2 [{query_key}]: erwartete Ortstag-Beschriftung {erwartet!r} "
+            f"fehlt in der Kopfzeile — vor dem Fix trug sie den UTC-Tag der "
+            f"Nachricht ({NACHTS_UTC.date():%d.%m}/"
+            f"{NACHTS_UTC.date() + timedelta(days=1):%d.%m}).\n{body}"
+        )
+
+
+# ══════════════════════ AC-3: Kopplung Datum + Uhrzeit ══════════════════════
+
+
+def test_ac3_timeline_heute_koppelt_datum_und_uhrzeit():
+    """AC-3.
+
+    GIVEN ein Wetter-Snapshot traegt eine Etappe fuer den Ortstag D+1, die
+          Nachricht kommt zu NACHTS_UTC (Mismatch-Fenster, Ortstag = D+1),
+    WHEN  ``timeline_heute`` abgefragt wird,
+    THEN  nennt die Kopfzeile den Ortstag D+1 UND darunter steht mindestens
+          eine ortszeitrichtig umgerechnete 🕐-Zeile -- EINE Assertion-Gruppe
+          prueft BEIDES gemeinsam, ein Halb-Fix (nur Filter ODER nur
+          Formatierung umgestellt) muss hier durchfallen.
+    """
+    ankunft_heute = datetime(2026, 8, 21, 6, 0, tzinfo=timezone.utc)    # 08:00 Korsika
+    ankunft_morgen = datetime(2026, 8, 22, 6, 0, tzinfo=timezone.utc)   # 08:00 Korsika (Folgetag)
+
+    with freeze_time(NACHTS_UTC):
+        _anker(NACHTS_UTC, KORSIKA_ZONE, D21)
+        trip = _trip("ac3-kopplung", [D21, D22], WP_KORSIKA)
+        save_trip(trip)
+        _save_snapshot(trip.id, [
+            _seg(ankunft_heute, WP_KORSIKA, seg_id=1),
+            _seg(ankunft_morgen, WP_KORSIKA, seg_id=2),
+        ])
+
+        body = _befehl(trip, "### query: timeline_heute", NACHTS_UTC).confirmation_body
+
+    kopfzeile_ok = f"({D21:%d.%m})" in body
+    uhrzeit_ok = "🕐 08:00" in body
+    assert kopfzeile_ok and uhrzeit_ok, (
+        "AC-3: EINE Assertion-Gruppe muss BEIDE Bestandteile pruefen -- den "
+        "Kopfzeilen-Ortstag UND eine ortszeitrichtig umgerechnete 🕐-Zeile "
+        f"(kopfzeile_ok={kopfzeile_ok}, uhrzeit_ok={uhrzeit_ok}):\n{body}"
+    )
+
+
+# ══════════════════════ AC-4: Mehrzonen — je Tag die eigene Zone ══════════════════════
+
+
+def test_ac4_glance_nutzt_je_tag_die_eigene_zone():
+    """AC-4.
+
+    GIVEN eine Tour hat die heutige Etappe in Neuseeland (Pacific/Auckland,
+          UTC+12) und die morgige auf Korsika (Europe/Paris, UTC+2),
+    WHEN  ``glance`` abgefragt wird,
+    THEN  beschriftet/filtert ``_fmt_glance`` den heutigen Abschnitt in der
+          neuseelaendischen Zone und den morgigen in der korsischen Zone --
+          je Tag die Zone SEINER EIGENEN Etappe, nicht eine gemeinsame Zone.
+
+    🔴 Nachbesserung (PO-Review): die urspruengliche Fassung diskriminierte
+    nur EINE falsche Abkuerzung ("immer Korsika-Zone"), nicht "immer
+    Wellington-Zone". Die Wegpunkt-Zeiten sind jetzt so gewaehlt, dass alle
+    DREI moeglichen Lagen ein VERSCHIEDENES Ergebnis liefern:
+
+      (i)   je Tag die eigene Zone (KORREKT)   -> heute gefunden, morgen gefunden
+      (ii)  immer Wellington-Zone (falsch)     -> heute gefunden, morgen NICHT gefunden
+      (iii) immer Korsika-Zone (falsch)        -> heute NICHT gefunden, morgen gefunden
+
+    Vier Vorbedingungen tragen das:
+      1. heute_zeit liegt lokal (Wellington) auf ortstag_heute            [i, ii]
+      2. heute_zeit liegt lokal (Korsika) NICHT auf ortstag_heute         [iii]
+      3. morgen_zeit liegt lokal (Korsika) auf korsika_tag                [i, iii]
+      4. morgen_zeit liegt lokal (Wellington) NICHT auf korsika_tag       [ii]
+
+    🔴 Belegte Grenze (statt behauptet): heute_zeit traegt zusaetzlich ein
+    rohes UTC-Datum ≠ Wellington-Ortsdatum (treibt das RED des HEUTIGEN,
+    unreparierten Codes, der nach rohem UTC filtert). Dieselbe Eigenschaft
+    fuer morgen_zeit (rohes UTC-Datum ≠ Korsika-Ortsdatum) ist mit
+    Bedingung 4 NICHT gleichzeitig erfuellbar -- Rechnung:
+    Korsika-Ortstag(korsika_tag) deckt UTC [D-1 22:00, D 22:00). Darin ist
+    "rohes Datum ≠ korsika_tag" nur das erste Zweistundenfenster
+    [D-1 22:00, D 00:00). Wellington-Ortstag(korsika_tag) deckt UTC
+    [D-1 12:00, D 12:00) -- und [D-1 22:00, D 00:00) liegt VOLLSTAENDIG
+    darin. Jeder Punkt mit rohem Datum ≠ korsika_tag faellt also zwangs-
+    laeufig auch in Wellingtons korsika_tag-Fenster (Bedingung 4 verletzt).
+    Ein einzelner Zeitpunkt kann beide Eigenschaften nicht gleichzeitig
+    tragen. Das RED des Ist-Zustands haengt deshalb ausschliesslich an
+    heute_zeit -- ausreichend, da EINE fehlschlagende Assertion genuegt.
+    """
+    heute_zeit = datetime(2026, 8, 18, 20, 0, tzinfo=timezone.utc)     # 08:00 Wellington am 19.08, RAW-UTC 18.08
+    morgen_zeit = datetime(2026, 8, 20, 18, 0, tzinfo=timezone.utc)    # 20:00 Korsika am 20.08, 06:00 Wellington am 21.08
+    abfrage = datetime(2026, 8, 19, 6, 0, tzinfo=timezone.utc)
+
+    with freeze_time(abfrage):
+        ortstag_heute = abfrage.astimezone(ZoneInfo(WELLINGTON_ZONE)).date()
+        assert ortstag_heute == date(2026, 8, 19), (
+            f"Testaufbau: Ortstag heute (Wellington) muss 19.08 sein, ist {ortstag_heute}"
+        )
+        korsika_tag = ortstag_heute + timedelta(days=1)
+
+        # Bedingung 1 + 2 (heute_zeit): eigene Zone trifft, fremde (Korsika) nicht.
+        assert heute_zeit.astimezone(ZoneInfo(WELLINGTON_ZONE)).date() == ortstag_heute, (
+            "Testaufbau: heute_zeit muss lokal (Wellington) auf den Ortstag heute fallen"
+        )
+        assert heute_zeit.astimezone(ZoneInfo(KORSIKA_ZONE)).date() != ortstag_heute, (
+            "Testaufbau nicht diskriminierend: heute_zeit muesste unter der "
+            "falschen Korsika-Zone ZUFAELLIG denselben Ortstag treffen -- "
+            "Mutante (iii) waere damit ungefangen"
+        )
+        assert heute_zeit.date() != ortstag_heute, (
+            "Testaufbau nicht diskriminierend: RAW-UTC-Datum und Wellington-"
+            "Ortsdatum des heutigen Wegpunkts sind gleich (#1726 F002) -- "
+            "treibt das RED des unreparierten (roh-UTC-filternden) Codes"
+        )
+
+        # Bedingung 3 + 4 (morgen_zeit): eigene Zone trifft, fremde (Wellington) nicht.
+        assert morgen_zeit.astimezone(ZoneInfo(KORSIKA_ZONE)).date() == korsika_tag, (
+            "Testaufbau: morgen_zeit muss lokal (Korsika) auf den Folgetag fallen"
+        )
+        assert morgen_zeit.astimezone(ZoneInfo(WELLINGTON_ZONE)).date() != korsika_tag, (
+            "Testaufbau nicht diskriminierend: morgen_zeit muesste unter der "
+            "falschen Wellington-Zone ZUFAELLIG denselben Ortstag treffen -- "
+            "Mutante (ii) waere damit ungefangen"
+        )
+
+        trip = trip_two_zones(ortstag_heute, trip_id="ac4-mehrzonen")
+        save_trip(trip)
+        _save_snapshot(trip.id, [
+            _seg(heute_zeit, WP_NZ, seg_id=1),
+            _seg(morgen_zeit, WP_KORSIKA, seg_id=2),
+        ])
+
+        body = _befehl(trip, "### query: glance", abfrage).confirmation_body
+
+    assert f"heute ({ortstag_heute:%d.%m})" in body, f"AC-4: Kopfzeile 'heute' fehlt:\n{body}"
+    assert f"morgen ({korsika_tag:%d.%m})" in body, f"AC-4: Kopfzeile 'morgen' fehlt:\n{body}"
+    assert f"heute ({ortstag_heute:%d.%m}): Keine Etappe geplant" not in body, (
+        "AC-4: die NEUSEELAND-Etappe (eigene Zone: Wellington) wurde nicht "
+        f"gefunden -- rohe UTC-Filterung (Ist-Zustand) bzw. eine "
+        f"gemeinsame Korsika-Zone (Mutante iii) findet sie nicht:\n{body}"
+    )
+    assert f"morgen ({korsika_tag:%d.%m}): Keine Etappe geplant" not in body, (
+        f"AC-4: die KORSIKA-Etappe (eigene Zone: Europe/Paris) wurde nicht "
+        f"gefunden -- eine gemeinsame Wellington-Zone (Mutante ii) findet "
+        f"sie nicht:\n{body}"
+    )
+
+
+# ══════════════════════ AC-5: Sommerzeit-Wechseltage ══════════════════════
+
+
+@pytest.mark.parametrize(
+    "wechseltag, punkte_utc, erwartete_lokalzeiten, abfrage_utc",
+    [
+        pytest.param(
+            date(2026, 3, 29),
+            [
+                datetime(2026, 3, 29, 0, 30, tzinfo=timezone.utc),
+                datetime(2026, 3, 29, 1, 30, tzinfo=timezone.utc),
+                datetime(2026, 3, 29, 2, 0, tzinfo=timezone.utc),
+            ],
+            ["01:30", "03:30", "04:00"],
+            datetime(2026, 3, 29, 12, 0, tzinfo=timezone.utc),
+            id="fruehjahr-luecke-23h",
+        ),
+        pytest.param(
+            date(2026, 10, 25),
+            [
+                datetime(2026, 10, 25, 0, 30, tzinfo=timezone.utc),
+                datetime(2026, 10, 25, 1, 30, tzinfo=timezone.utc),
+                datetime(2026, 10, 25, 2, 0, tzinfo=timezone.utc),
+            ],
+            ["02:30", "02:30", "03:00"],
+            datetime(2026, 10, 25, 12, 0, tzinfo=timezone.utc),
+            id="herbst-doppelstunde-25h",
+        ),
+    ],
+)
+def test_ac5_sommerzeit_wechseltage_zeigen_die_korrekte_ortsstunde(
+    wechseltag, punkte_utc, erwartete_lokalzeiten, abfrage_utc,
+):
+    """AC-5.
+
+    GIVEN eine Korsika-Tour (Europe/Paris) hat Wegpunkte rund um einen
+          Sommerzeit-Wechseltag -- 29.03. (Luecke, Ortstag 23h) oder 25.10.
+          (Doppelstunde, Ortstag 25h),
+    WHEN  ``timeline_heute`` abgefragt wird,
+    THEN  zeigt jede 🕐-Zeile die korrekte Ortsstunde -- geprueft auf die
+          exakte %H:%M-Zeichenkette JEDER Zeile (ADR-0044), nicht nur die
+          Zeilenzahl. Am 25.10. muss "02:30" ZWEIMAL erscheinen (echte
+          Doppelstunde), nicht dedupliziert.
+    """
+    with freeze_time(abfrage_utc):
+        offsets = {p.astimezone(ZoneInfo(KORSIKA_ZONE)).utcoffset() for p in punkte_utc}
+        assert len(offsets) == 2, (
+            f"Testaufbau: die Wegpunkte muessen VOR und NACH dem Sommerzeit-"
+            f"Wechsel liegen (zwei UTC-Offsets), gesehen: {offsets}"
+        )
+        trip = _trip(f"ac5-{wechseltag.isoformat()}", [wechseltag], WP_KORSIKA)
+        save_trip(trip)
+        _save_snapshot(trip.id, [_seg(t, WP_KORSIKA, seg_id=i) for i, t in enumerate(punkte_utc)])
+
+        body = _befehl(trip, "### query: timeline_heute", abfrage_utc).confirmation_body
+
+    beobachtete_zeilen = [ln for ln in body.splitlines() if ln.startswith("🕐 ")]
+    beobachtete_zeiten = [ln.split(" ", 1)[1].split(" ", 1)[0] for ln in beobachtete_zeilen]
+    assert beobachtete_zeiten == erwartete_lokalzeiten, (
+        f"AC-5 ({wechseltag:%d.%m.}): erwartete Ortsstunden {erwartete_lokalzeiten}, "
+        f"beobachtet {beobachtete_zeiten} (rohe UTC-Zeiten waeren "
+        f"{[t.strftime('%H:%M') for t in punkte_utc]}).\n{body}"
+    )
+
+
+# ══════════════════════ AC-6: Parameter schlaegt die Systemuhr ══════════════════════
+#
+# Vorlage: tests/tdd/test_befehlspfade_folgen_ortszone.py:517-670 (Adversary-
+# Befund F001 aus S5a: "Parameter behalten, im Rumpf ignorieren"). Anders als
+# dort (wo `date.today()`/`datetime.now()` schon HEUTE aufgerufen wird)
+# nutzt `_handle_query` bereits `received_at` -- der aktuelle Fehler ist "roher
+# UTC-Tag statt Ortstag", nicht "ignoriert den Parameter".
+#
+# 🔴 Nachbesserung (PO-Review): die urspruengliche Systemuhr (20.08. 12:00Z,
+# Ortstag Korsika 20.08.) fiel zufaellig mit dem ROHEN UTC-Tag von NACHTS_UTC
+# (ebenfalls 20.08.) zusammen -- zwei verschiedene Fehlerursachen ("liest die
+# Systemuhr" vs. "faellt in den heutigen Ist-Zustand zurueck") erzeugten
+# dieselbe Ausgabe, der Test war damit eine Dublette von AC-2 statt eigen-
+# staendig aussagekraeftig. Die neue Systemuhr (18.08. 12:00Z, Ortstag
+# Korsika 18.08.) traegt einen Ortstag, der sich von BEIDEN unterscheidet:
+# vom Ortstag des Parameters (21.08.) UND von dessen rohem UTC-Tag (20.08.).
+# Die Drei-Wege-Trennung ist PFLICHT-Vorbedingung im Testkoerper selbst,
+# nicht nur ein Kommentar.
+
+_AC6_SYSTEMUHR = datetime(2026, 8, 18, 12, 0, tzinfo=timezone.utc)   # Ortstag Korsika 18.08, kein Mismatch
+
+
+def _ac6_setup_und_frage(trip_id: str, body_cmd: str) -> "frozenset[str]":
+    trip = _trip(trip_id, [D20, D21, D22, D23], WP_KORSIKA)
+    save_trip(trip)
+    _save_snapshot(trip.id, [
+        _seg(datetime(2026, 8, 21, 10, 0, tzinfo=timezone.utc), WP_KORSIKA, seg_id=1),
+        _seg(datetime(2026, 8, 22, 10, 0, tzinfo=timezone.utc), WP_KORSIKA, seg_id=2),
+    ])
+    body = _befehl(trip, body_cmd, NACHTS_UTC).confirmation_body
+    return _daten_in_kopfzeile(body)
+
+
+_DATUM_RE = re.compile(r"\((\d{2}\.\d{2})\)")
+
+
+def _daten_in_kopfzeile(body: str) -> "frozenset[str]":
+    """Alle 'DD.MM'-Datumsangaben in Klammern im Antworttext."""
+    return frozenset(_DATUM_RE.findall(body))
+
+
+def _erwartete_daten(rollen: tuple[str, ...], heute: date, morgen: date) -> "frozenset[str]":
+    """Formatiert die als 'heute'/'morgen' erwarteten Kopfzeilen-Daten fuer
+    genau die Rollen, die das jeweilige Kommando zeigt (glance zeigt beide,
+    die anderen drei genau eine)."""
+    werte = {"heute": heute, "morgen": morgen}
+    return frozenset(f"{werte[r]:%d.%m}" for r in rollen)
+
+
+@pytest.mark.parametrize("trip_id, body_cmd, rollen", [
+    pytest.param("ac6-glance", "### query: glance", ("heute", "morgen"), id="glance"),
+    pytest.param("ac6-gewitter", "### query: heute_gewitter", ("heute",), id="heute_gewitter"),
+    pytest.param("ac6-tl-heute", "### query: timeline_heute", ("heute",), id="timeline_heute"),
+    pytest.param("ac6-tl-morgen", "### query: timeline_morgen", ("morgen",), id="timeline_morgen"),
+])
+def test_ac6_vier_kommandos_folgen_dem_parameter_nicht_der_systemuhr(trip_id, body_cmd, rollen):
+    """AC-6.
+
+    GIVEN freeze_time(_AC6_SYSTEMUHR) ist aktiv UND gleichzeitig wird
+          received_at = NACHTS_UTC uebergeben -- Systemuhr-Ortstag, Parameter-
+          Ortstag UND der ROHE UTC-Tag des Parameters liegen auf DREI
+          verschiedenen Tagen,
+    WHEN  eine der vier Query-Kommandos verarbeitet wird,
+    THEN  folgt das Ergebnis dem ORTSTAG des Parameters -- weder der
+          eingefrorenen Systemuhr noch (der heute noch beobachtbare
+          Ist-Zustand) dem rohen UTC-Tag des Parameters.
+
+    Drei-Wege-Vorbedingung: erwartet_parameter, erwartet_systemuhr und
+    erwartet_roh_utc muessen PAARWEISE verschieden sein -- sonst kann der
+    Test zwei verschiedene Fehlerursachen ("liest die Systemuhr" vs. "faellt
+    auf den unreparierten roh-UTC-Ist-Zustand zurueck") nicht auseinander-
+    halten.
+    """
+    heute_param = NACHTS_UTC.astimezone(ZoneInfo(KORSIKA_ZONE)).date()
+    heute_uhr = _AC6_SYSTEMUHR.astimezone(ZoneInfo(KORSIKA_ZONE)).date()
+    heute_roh = NACHTS_UTC.date()
+
+    erwartet_parameter = _erwartete_daten(rollen, heute_param, heute_param + timedelta(days=1))
+    erwartet_systemuhr = _erwartete_daten(rollen, heute_uhr, heute_uhr + timedelta(days=1))
+    erwartet_roh_utc = _erwartete_daten(rollen, heute_roh, heute_roh + timedelta(days=1))
+
+    assert len({erwartet_parameter, erwartet_systemuhr, erwartet_roh_utc}) == 3, (
+        "Testaufbau nicht trennscharf: Parameter-, Systemuhr- und Roh-UTC-"
+        "Erwartung muessen PAARWEISE verschieden sein, sonst kann der Test "
+        "nicht zwischen 'liest die Systemuhr' und 'faellt auf den rohen "
+        f"UTC-Tag zurueck' unterscheiden (parameter={erwartet_parameter!r}, "
+        f"systemuhr={erwartet_systemuhr!r}, roh_utc={erwartet_roh_utc!r})"
+    )
+
+    with freeze_time(_AC6_SYSTEMUHR):
+        assert heute_uhr != heute_param, (
+            f"Testaufbau: Systemuhr ({heute_uhr}) und Parameter ({heute_param}) "
+            "muessen auf verschiedene ORTSTAGE fallen"
+        )
+        assert datetime.now(tz=timezone.utc) == _AC6_SYSTEMUHR, (
+            "Testaufbau: freeze_time greift nicht, die Systemuhr steht auf "
+            f"{datetime.now(tz=timezone.utc).isoformat()}"
+        )
+        beobachtet = _ac6_setup_und_frage(trip_id, body_cmd)
+
+    hinweis = ""
+    if beobachtet == erwartet_systemuhr:
+        hinweis = (
+            f"\n  Das ist GENAU das Ergebnis zur eingefrorenen Systemuhr "
+            f"({heute_uhr:%d.%m.%Y}) -- der Pruefling liest die Systemuhr "
+            "statt des Parameters."
+        )
+    elif beobachtet == erwartet_roh_utc:
+        hinweis = (
+            f"\n  Das ist GENAU der heutige Ist-Zustand: der Pruefling nutzt "
+            f"zwar den Parameter, aber dessen ROHEN UTC-Tag "
+            f"({heute_roh:%d.%m.%Y}) statt des Ortstags (ADR-0044 hier noch "
+            "nicht angewendet)."
+        )
+    assert beobachtet == erwartet_parameter, (
+        f"AC-6: das Ergebnis folgte nicht dem Ortstag des uebergebenen "
+        f"Zeitpunkts.\n"
+        f"  uebergeben:      {NACHTS_UTC.isoformat()} (Ortstag {heute_param:%d.%m.%Y}, "
+        f"roher UTC-Tag {heute_roh:%d.%m.%Y})\n"
+        f"  Systemuhr:       {_AC6_SYSTEMUHR.isoformat()} (Ortstag {heute_uhr:%d.%m.%Y})\n"
+        f"  erwartet:        {sorted(erwartet_parameter)}\n"
+        f"  beobachtet:      {sorted(beobachtet)}{hinweis}"
+    )
+
+
+# ══════════════════════ AC-7: Rueckgabe-Zieltag ══════════════════════
+
+
+def test_ac7_fehlertext_nennt_den_tatsaechlich_benutzten_zieltag():
+    """AC-7.
+
+    GIVEN eine Nachricht wird EMPFANGEN um 23:00 Ortszeit (Ortstag 20.08.),
+          aber die VERARBEITUNG laeuft erst um 03:00 Ortszeit des naechsten
+          Tages (Ortstag 21.08.) -- eine reale Verzoegerung, die den vom
+          Aufrufer aus `received_at` geratenen Zieltag (20.08.) vom
+          TATSAECHLICH von `_get_target_date()` (Systemuhr zum
+          Ausfuehrungszeitpunkt) benutzten Zieltag (21.08.) trennt,
+    WHEN  ``send_on_demand_report()`` direkt aufgerufen wird UND ueber den
+          vollen Befehlspfad (### heute) der Fehlertext gerendert wird,
+    THEN  traegt das zurueckgegebene ``OnDemandErgebnis.zieltag`` den
+          TATSAECHLICH benutzten Tag (21.08.), und der Fehlertext nennt
+          GENAU dieses Datum -- nicht das vom Aufrufer geratene (20.08.).
+
+    Der Typ ``OnDemandErgebnis`` existiert noch nicht -> dieser Test ist
+    zulaessig per ``AttributeError`` rot (Spec-Vorgabe): ``send_on_demand_
+    report()`` liefert heute einen bloßen String, ``"no_stage".outcome``
+    wirft ``AttributeError``.
+    """
+    empfangen = datetime(2026, 8, 20, 21, 0, tzinfo=timezone.utc)     # 23:00 Korsika, Ortstag 20.08
+    verarbeitet = datetime(2026, 8, 21, 1, 0, tzinfo=timezone.utc)    # 03:00 Korsika, Ortstag 21.08
+    assert empfangen.astimezone(ZoneInfo(KORSIKA_ZONE)).date() == D20, (
+        "Testaufbau: Empfangszeitpunkt muss auf Ortstag 20.08 fallen"
+    )
+    assert verarbeitet.astimezone(ZoneInfo(KORSIKA_ZONE)).date() == D21, (
+        "Testaufbau: Verarbeitungszeitpunkt muss auf Ortstag 21.08 fallen -- "
+        "sonst gibt es keine Luecke zwischen Empfang und Verarbeitung"
+    )
+
+    trip = _trip("ac7-zieltag", [D20], WP_KORSIKA)
+    save_trip(trip)
+
+    with freeze_time(verarbeitet):
+        assert datetime.now(tz=timezone.utc) == verarbeitet, (
+            "Testaufbau: freeze_time greift nicht"
+        )
+        direkt = TripReportSchedulerService(user_id="default").send_on_demand_report(
+            trip, "morning",
+        )
+        assert direkt.outcome == "no_stage", (
+            f"Testaufbau: erwartet 'no_stage' (keine Etappe am Ortstag "
+            f"{D21:%d.%m.%Y}), beobachtet {direkt!r}"
+        )
+        assert direkt.zieltag == D21, (
+            f"AC-7: OnDemandErgebnis.zieltag muss der TATSAECHLICH benutzte "
+            f"Ortstag sein ({D21:%d.%m.%Y}), beobachtet {direkt!r}"
+        )
+
+        ergebnis = _befehl(trip, "### heute", empfangen)
+
+    assert ergebnis.success is True, ergebnis.confirmation_body
+    assert "(21.08.2026)" in ergebnis.confirmation_body, (
+        "AC-7: der Fehlertext muss den TATSAECHLICH von send_on_demand_report "
+        "benutzten Zieltag (21.08., Ortstag zum Verarbeitungszeitpunkt) "
+        "nennen, nicht das vom Aufrufer aus dem Empfangszeitpunkt geratene "
+        f"Datum (20.08.).\n{ergebnis.confirmation_body!r}"
+    )
+    assert "(20.08.2026)" not in ergebnis.confirmation_body, (
+        "AC-7: der Fehlertext zeigt noch das vom Aufrufer geratene, falsche "
+        f"Datum (20.08.):\n{ergebnis.confirmation_body!r}"
+    )
+
+
+# ══════════════════════ AC-8: Anker-Schluessel ══════════════════════
+
+
+def test_ac8_anker_traegt_den_ortstag_und_wird_vom_alarm_pfad_akzeptiert():
+    """AC-8.
+
+    GIVEN eine Tour im Mismatch-Fenster hat noch keinen ladbaren
+          Wetter-Snapshot,
+    WHEN  ``_handle_query`` daraufhin ``_fetch_and_save_snapshot`` ausloest
+          (echter Fetch ueber die autouse-``GZ_TEST_FIXTURE_DIR``, kein
+          Mock),
+    THEN  traegt die geschriebene Ankerdatei ``target_date`` = Ortstag
+          (nicht UTC-Tag), und ein anschliessender Aufruf von
+          ``trip_alert._get_cached_weather`` verwirft sie NICHT MEHR mit
+          ``reason="wrong_day"``.
+    """
+    with freeze_time(NACHTS_UTC):
+        _anker(NACHTS_UTC, KORSIKA_ZONE, D21)
+        trip = Trip(id="ac8-anker", name="ac8-anker", stages=[
+            _stage_mit_zwei_wegpunkten("S1", D21, WP_KORSIKA),
+            _stage_mit_zwei_wegpunkten("S2", D22, WP_KORSIKA),
+        ])
+        save_trip(trip)
+
+        ergebnis = _befehl(trip, "### query: glance", NACHTS_UTC)
+        assert ergebnis.success is True, ergebnis.confirmation_body
+
+        cached = TripAlertService(user_id="default")._get_cached_weather(
+            trip, tagesgleicher_anker_noetig=True, now_utc=NACHTS_UTC,
+        )
+
+    assert cached is not None, (
+        "AC-8: der von _fetch_and_save_snapshot geschriebene Anker wurde vom "
+        "Alarm-Pfad verworfen (reason=wrong_day) -- er traegt noch den "
+        f"UTC-Tag der Nachricht ({NACHTS_UTC.date().isoformat()}) statt des "
+        f"Ortstags ({D21.isoformat()})"
+    )
+
+
+# ══════════════════════ AC-11: ADR-0044-Restliste ist aktuell ══════════════════════
+
+# doc-compliance-test
+
+_AC11_NAMEN = (
+    "_show_status", "_show_now", "command_date",
+    "inbound_telegram_reader.py", "_handle_query",
+)
+
+
+def test_ac11_adr_restliste_ist_aktuell():
+    """AC-11, doc-compliance-test.
+
+    # doc-compliance-test: prueft eine im ADR GEMACHTE Zusicherung (die
+    Restliste "Noch nicht umgesetzt"), weil AC-11 der Spec ausdruecklich
+    einen Doku-Abgleich verlangt -- kein Ersatz fuer einen Verhaltensnachweis
+    (das sind AC-1 bis AC-8 oben, ueber den Produktionspfad).
+
+    GIVEN die Restliste "Noch nicht umgesetzt" nennt fuenf Stellen, die
+          laengst geliefert sind (_show_status, _show_now, command_date,
+          inbound_telegram_reader.py aus #1727 S5a; _handle_query aus dieser
+          Scheibe),
+    WHEN  diese Scheibe live geht,
+    THEN  stehen alle fuenf NICHT MEHR unterhalb "Noch nicht umgesetzt", und
+          _handle_query steht unter "Umgesetzt".
+    """
+    text = _ADR_0044.read_text(encoding="utf-8")
+
+    ueberschrift = "### Noch nicht umgesetzt"
+    assert ueberschrift in text, f"AC-11: Ueberschrift {ueberschrift!r} fehlt im ADR"
+    _, _, rest = text.partition(ueberschrift)
+    rest_bis_naechster_abschnitt = rest.split("\n## ", 1)[0]
+
+    verbliebene = [n for n in _AC11_NAMEN if n in rest_bis_naechster_abschnitt]
+    assert not verbliebene, (
+        f"AC-11: die folgenden Namen stehen noch unter {ueberschrift!r}, "
+        f"obwohl sie geliefert sind: {verbliebene}"
+    )
+
+    umgesetzt_teil, _, _ = text.partition(ueberschrift)
+    assert "_handle_query" in umgesetzt_teil, (
+        "AC-11: '_handle_query' muss unter 'Umgesetzt' auftauchen"
+    )


### PR DESCRIPTION
- **docs(#1795): Kontext und Spec fuer Timeline-Ortszeit**
- **docs(#1795): Spec vom PO freigegeben**
- **test(#1795): RED - Timeline und Query-Familie folgen der Ortszeit**
- **fix(#1795): Timeline und Query-Familie folgen der Ortszeit der Tour**
