### PR TITLE
fix: Permission-Regel fuer next_ticket_cache als Edit statt Write

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,7 @@
       "WebSearch",
       "WebFetch",
       "Monitor",
-      "Write(.claude/next_ticket_cache.json)"
+      "Edit(.claude/next_ticket_cache.json)"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
`Write(.claude/next_ticket_cache.json)` in `permissions.allow` wirkt nicht — Claude Code prueft Datei-Freigaben ausschliesslich ueber `Edit(pfad)` und meldet die Regel beim Sitzungsstart als unwirksam:

> Permission allow rule (.claude/settings.json): Write(.claude/next_ticket_cache.json) is not matched by file permission checks — only Edit(path) rules are.

`Edit(...)` deckt alle dateischreibenden Werkzeuge ab (Edit, Write, NotebookEdit), die Freigabe bleibt also inhaltlich identisch.

Reine Tooling-Aenderung (`.claude/`), kein Code in `src/`/`api/`/`internal/`/`frontend/`/`cmd/`.

Nachzug zu f4dded18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)