### PR TITLE
feat(#1680 S5a): Herkunft der Gewitterstufe im Mehrtages-Ausblick

### DIFF
--- a/docs/context/feat-1680-s5-ausblick-vorschau-herkunft.md
+++ b/docs/context/feat-1680-s5-ausblick-vorschau-herkunft.md
@@ -1,0 +1,298 @@
+# Context: #1680 Scheibe 5 — Herkunft der Gewitterstufe im Mehrtages-Ausblick und in der Gewitter-Vorschau
+
+**Erstellt:** 2026-08-13 · **Workflow:** `feat-1680-s5-ausblick-vorschau-herkunft` · **Track:** Full Process
+**Basis:** `origin/main` @ `2d96b346` (S4 `b6daae3e` enthalten)
+
+## Request Summary
+
+Die letzten beiden Ausgabeorte aus #1680 sollen die tragende Zutat der
+Gewitterstufe nennen: der **Mehrtages-Ausblick** (`⚡leicht · nachts leicht @20`)
+und die **Gewitter-Vorschau** (`↳ Gewitter möglich`). Beide wurden in den
+Scheiben 1–4 viermal ausgeklammert mit der Begründung, sie seien "strukturell
+blockiert" durch `HourlyValue` (nur `hour`/`value`) und den unangeschlossenen
+`aggregate_stage()`.
+
+## 🔴 Die übernommene Begründung hält der Messung nur zur Hälfte stand
+
+Das ist zum dritten Mal dieselbe Lehre (S1 AC-12, S2 "übernommene Notiz"): eine
+von Scheibe zu Scheibe weitergereichte Behauptung über den eigenen Code wurde
+nie nachgemessen.
+
+| Behauptung aus S1–S4 | Messung (2026-08-13) |
+|---|---|
+| "Der Mehrtages-Ausblick ist der **erste echte Verbraucher** von `aggregate_stage()`" | **Halb falsch.** `aggregate_stage()` läuft dort zwar (`trip_report_scheduler.py:2026`), aber die **angezeigte** Gewitterstufe kommt NICHT aus `agg.thunder_level_max`, sondern aus den Stundenproben `hourly_thunder` (`outlook.py:234-243`, `helpers.py:1007-1020`). `agg` speist nur `row["thunder"]`, das seinerseits **nur als Fail-soft** dient, wenn keine Stundenprobe im Fenster liegt (`outlook.py:239-243`, `trip_report_scheduler.py:2284-2291`). |
+| "Die Träger gehen strukturell verloren, weil `HourlyValue` nur `hour`/`value` hat" | **Zutreffend für den Transportweg, aber die Quelle liegt vor der Verengung.** `build_outlook_row(summary, points, …)` (`outlook.py:420ff`) bekommt die **rohen `ForecastDataPoint`s** als `points` übergeben (`trip_report_scheduler.py:2046-2049`) und baut die `HourlyValue`-Tupel erst selbst (`outlook.py:463-477`). `ForecastDataPoint.thunder_level_signals` ist dort verfügbar (gesetzt in `providers/thunder_enrichment.py:151`). Die Träger sind also **in der Hand des Row-Builders** — die Verengung ist selbstgemacht und umgehbar, ohne `HourlyValue` anzufassen. |
+
+**Folge:** Der Weg über `agg.thunder_level_max_signals` wäre der **falsche** — er
+verletzte die AC-12-Regel aus Scheibe 1 ("passt die Herkunft nicht zur gezeigten
+Stufe, erscheint keine"), weil `agg` das **Kalendertags-Maximum** trägt, die
+angezeigte Stufe aber das **Tagesfenster-Maximum** ist. Beide können
+auseinanderfallen — genau der Fehler, den #1498 Fall 2 und #1653 bereits
+repariert haben.
+
+## 🔴 Ein latenter Fehler, der heute schon erreichbar ist
+
+`weather_metrics.py:478` deklariert seit Scheibe 1:
+```python
+"thunder_level_max_signals": "union_of_max_carriers",
+```
+`aggregate_stage()` (`weather_metrics.py:1168-1266`) hat aber **keinen Zweig**
+für diese Regel — sie fällt in den generischen `else`: `values[0]`
+(`weather_metrics.py:1265-1266`). Bei einer Etappe mit mehreren Segmenten
+liefert das die Trägerliste des **ersten** Segments, auch wenn ein anderes
+Segment die Höchststufe trägt.
+
+Das ist **kein rein theoretischer Pfad**: `aggregate_stage()` läuft im
+Ausblick-Pfad (`trip_report_scheduler.py:2026`). Der Fehler ist heute nur
+unsichtbar, weil niemand `thunder_level_max_signals` aus `agg` liest. Known
+Limitation 7 (S1) / 3 (S4) ist damit **fällig**, unabhängig davon, welchen Weg
+die Anzeige nimmt.
+
+## Related Files
+
+| Datei | Relevanz |
+|------|-----------|
+| `src/output/renderers/email/outlook.py:420-490` | `build_outlook_row()` — hat `points` (rohe `ForecastDataPoint`s) UND baut die `HourlyValue`-Tupel. **Die Naht, an der die Träger heute verloren gehen.** Geteilt Trip↔Compare. |
+| `src/output/renderers/email/outlook.py:234-258` / `:372-390` | Gewitter-Zelle HTML / Klartext; `_thunder_token_parts()` (`:43-59`), Wortlaut-Map `_THUNDER_LEVEL_LABEL` (`:195-198`) |
+| `src/output/renderers/email/helpers.py:897-1020` | `format_trend_tokens(stage: dict)` — **einzige Quelle der Trend-Semantik** für HTML, Klartext, Telegram, SMS. Erzeugt `thunder_day_token` / `thunder_night_token` getrennt nach Tagesfenster. |
+| `src/services/trip_report_scheduler.py:1956-2101` | `_build_multi_day_trend()` — `aggregate_stage()` (`:2026`), `_flat_points` (`:2046-2049`), `build_outlook_row()` (`:2069`), `row["date"]` (`:2079`, #1275) |
+| `src/services/trip_report_scheduler.py:2103-2192` | `_build_thunder_forecast_from_trend_or_fetch()` — **Primärpfad** der Vorschau, wiederverwendet die Ausblick-Zeilen |
+| `src/services/trip_report_scheduler.py:2216-2310` | `_thunder_entry_from_trend_row()` — leitet Level/Stunde aus `row["hourly_thunder"]` **im Fenster** ab; `row["thunder"]` nur Fail-soft (`:2284-2291`) |
+| `src/services/trip_report_scheduler.py:2407-2555` | `_build_thunder_forecast()` — **Fallback-Pfad** der Vorschau, aggregiert `ForecastDataPoint`s direkt (`:2494-2504`); Träger dort **vollständig sichtbar** |
+| `src/output/renderers/email/plain.py:307-332` | Vorschau-Block Klartext; `outlook_active`-Unterdrückung (#1313 E1) |
+| `src/output/renderers/email/html.py:1307-1329` | Vorschau-Block HTML, wortgleiche Unterdrückung |
+| `src/services/weather_metrics.py:468-483` | `aggregation_config` — Regel `union_of_max_carriers` deklariert (`:478`) |
+| `src/services/weather_metrics.py:1168-1266` | `aggregate_stage()` — **fehlender Dispatch-Zweig**, `else: values[0]` |
+| `src/output/metric_format.py:559-609` | `union_of_max_carriers()` — geteilter Baustein aus S2, Rückgabe bewusst `list` (nicht `set`, #1405) |
+| `src/output/metric_format.py:448-484` | `thunder_signal_carriers()` — erzeugt die Trägerliste |
+| `src/output/metric_format.py:374-379` | `THUNDER_SIGNAL_LABEL_DE` — **vier** Zutaten: Wettercode, Blitzdichte, CAPE, Blitzpotenzial |
+| `src/app/models.py:425-430` | `SegmentWeatherSummary.thunder_level_max` / `.thunder_level_max_signals` |
+| `src/providers/thunder_enrichment.py:151` | setzt `dp.thunder_level_signals` auf dem `ForecastDataPoint` |
+| `src/output/tokens/dto.py:15-18` | `HourlyValue` (frozen, `hour`+`value`) — die verengte Zwischenform |
+
+### Die drei weiteren Ausblick-Implementierungen
+
+`outlook.py` ist **nicht** der einzige Ausblick. Alle drei lesen dasselbe
+`stage`-dict über `format_trend_tokens()`:
+
+| Ort | Datei:Zeile | Kanal |
+|---|---|---|
+| Trip-Mail HTML + Klartext | `email/outlook.py:208` / `:353` | E-Mail |
+| Telegram-Trendblock | `narrow.py:575` `_outlook_lines()` | Telegram |
+| Kompakt-Mail "Nächste Etappen" | `email/compact.py:230` | E-Mail (compact) |
+
+Ein Feld im `row`-dict bzw. ein neuer Token aus `format_trend_tokens()` wird von
+**allen dreien** strukturell geerbt — wie in S4 bei Telegram-rich. Das ist eine
+Produktentscheidung für die Spec, kein Implementierungsdetail.
+
+## Existing Patterns
+
+- **`union_of_max_carriers()`** (S2) — der geteilte Baustein liegt fertig vor;
+  Aufrufer u.a. `compact_summary.py:584,628`, `trip_report.py:650-651`,
+  `helpers.py:1752,1771`, `day_window.py:58,79`, `trip_command_processor.py:841`.
+- **`hail_flag` / `hail_priority` (#1475 S5a)** ist das **Vorbild** für einen
+  Dispatch-Zweig in `aggregate_stage()`: Sonderfall **vor** dem generischen
+  `is not None`-Vorfilter (`weather_metrics.py:1205-1217`), weil die Regel die
+  vollständige Werteliste braucht. `union_of_max_carriers` braucht zusätzlich
+  die **gepaarte** Stufe — es aggregiert `(level, signals)`-Paare, nicht eine
+  Werteliste. Das ist der eine Punkt, an dem das Vorbild nicht 1:1 trägt.
+- **S4-Muster** (`_dp_to_row`): Träger direkt aus `ForecastDataPoint`s
+  fenstergerecht berechnen, statt sie durch eine verengte Zwischenform zu ziehen.
+- **Abwesenheits-ACs brauchen eine Gegenprobe** an derselben Fixture (S1/S2/S3),
+  sonst sind sie vakuum-grün.
+
+## Dependencies
+
+- **Upstream:** `thunder_signal_carriers()` → `dp.thunder_level_signals` →
+  `_flat_points` → `build_outlook_row()`; `aggregate_stage()` → `agg`
+- **Downstream:** `format_trend_tokens()` → **drei** Ausblick-Renderer;
+  `row` → `_thunder_entry_from_trend_row()` → Vorschau (E-Mail/SMS/Telegram);
+  `outlook.py` → **Compare-Ausblick** (geteilte Naht)
+
+## Existing Specs
+
+- `docs/specs/modules/feat_1680_s1_gewitter_herkunft_ortsvergleich.md` — AC-12-Regel
+- `docs/specs/modules/feat_1680_s2_gewitter_herkunft_trip.md` — `union_of_max_carriers()`, F001
+- `docs/specs/modules/feat_1680_s3_gewitter_herkunft_vier_orte.md` — roher Durchgriff ohne Garantie
+- `docs/specs/modules/feat_1680_s4_gewitter_herkunft_trip_stundentabelle.md` — Known Limitations 3/4
+- `docs/reference/metric_output_matrix.md:89-90,113` — Ausblick-Zeilen, Rest-Scope
+- `docs/specs/modules/issue_1361_1368_ausblick_konfigurierbar.md` — AC-11 Paritätswächter
+- ADR-0025 (Vorschau=Versand), #1498 Fall 2, #1651/#1653 (Tag/Nacht-Fenster), #1275 (Row-Reuse), #1313 E1 (Unterdrückung)
+
+## Risks & Considerations
+
+1. **🔴 Byte-Golden-Paritätswächter.** `tests/tdd/test_trip_outlook_parity.py`
+   vergleicht die **gesamte** Trip-Mail (HTML + Klartext) gegen aufgezeichnete
+   Golden-Dateien in `tests/fixtures/outlook_trip_parity/`. Jede sichtbare
+   Änderung am Ausblick macht ihn rot. Er ist **bewusst** so gebaut ("die
+   Golden-Dateien sind der Beweis, sie werden NICHT neu erzeugt"). Er muss —
+   wie die zwei Bestandstests in S3 — **begründet mitgezogen** werden, samt
+   Nachtrag in `tests/fixtures/outlook_trip_parity/README.md`. Das Aufweichen
+   des Wächters wäre ein Regelverstoß.
+2. **🔴 Tag- und Nachtstufe sind getrennt.** `thunder_day_token` und
+   `thunder_night_token` entstehen aus **verschiedenen** Stundenmengen
+   (`helpers.py:1005-1020`). Eine einzige Trägerliste für beide würde
+   Nacht-Träger an die Tagesstufe heften — der AC-12-Fehler aus S1 in neuer
+   Gestalt. Die Träger müssen **je Fenster** berechnet werden.
+3. **🔴 `aggregate_stage()`s fehlender Zweig ist ein echter latenter Fehler**,
+   nicht nur eine Lücke (s.o.). Er ist heute erreichbar, aber unbenutzt.
+4. **Geteilte Naht Trip↔Compare.** `build_outlook_row()` und
+   `render_outlook_table()` bedienen beide Flächen. Ob der **Compare-Ausblick**
+   die Herkunft mitbekommen soll, ist eine Produktentscheidung (Compare hat sie
+   seit S1/S3 in anderen Ausgabeorten). Ein `include_origin`-Parameter existiert
+   dort bereits als Muster.
+5. **Drei Ausblick-Kanäle erben strukturell** (E-Mail, Telegram, Kompakt-Mail) —
+   s.o. In S4 war genau das eine bewusst dokumentierte Known Limitation.
+6. **Die Vorschau erscheint nur, wenn der Ausblick NICHT aktiv ist** (#1313 E1,
+   `plain.py:309`, `html.py:1309`). Im Abend-Default mit Ausblick entfällt sie.
+   Sichtbar wird sie u.a., wenn der Nutzer den Ausblick abgeschaltet hat
+   (`show_outlook=False`) — dann greift trotzdem der **Primärpfad** über die
+   Trend-Zeilen, sofern `multi_day_trend` gefüllt ist. **Beide Vorschau-Pfade
+   (Primär `_thunder_entry_from_trend_row`, Fallback `_build_thunder_forecast`)
+   müssen dieselbe Herkunft liefern**, sonst hängt die Aussage davon ab, ob der
+   Trend zufällig vorlag — eine Wiederholung von #1555 (Tier-Lücke).
+7. **Der Vorschau-Text trägt bereits zwei Zusätze** (Hagel `· Hagel: ja`,
+   Nacht-Halbsatz `, nachts … ab 02:00`). Ein dritter Zusatz muss sich in diese
+   Reihenfolge einfügen, ohne den Nacht-Halbsatz zu zerschneiden.
+8. **`ForecastDataPoint.thunder_level_signals` muss auf dem Ausblick-Pfad
+   tatsächlich gefüllt sein.** Der Ausblick holt Wetter über `_fetch_weather()`
+   für **künftige** Etappen — ob die Anreicherung (`thunder_enrichment.py`) dort
+   ebenso läuft wie im Hauptpfad, ist **zu messen**, nicht anzunehmen. Wenn
+   nicht, wäre die ganze Scheibe wirkungslos (Prüfort ≠ Wirkort).
+9. **SMS/Premium-SMS bleiben ohne Herkunft** (PO-Entscheid seit S1). Der
+   Ausblick speist auch SMS-Token (`thunder_sms`) — die Dichtheit ist erneut
+   nachzuweisen, per Sonde statt Wortsuche (S3-Muster).
+10. **Serialisierung:** neue Felder als `list[str]`, nie `set` — ein
+    `json.dumps`-Fehler kostet den **gesamten** Wetter-Schnappschuss lautlos
+    (#1405, `weather_snapshot.py:83-86`).
+
+---
+
+# Analysis
+
+## Type
+**Feature** (Fortsetzung Epic #1419 Rang 4 / #1680, Scheibe 5)
+
+## 🔴 Zwei Funde, die den Plan tragen — beide nachgemessen
+
+**Fund A: Der Scheduler darf `union_of_max_carriers` NICHT importieren.**
+`tests/unit/test_notification_service.py:183-192` ist eine Architektur-Wache,
+die in `src/services/trip_report_scheduler.py` **zeilengenau einen** Import aus
+der Darstellungsschicht erlaubt:
+```python
+_ALLOWED_SHARED_IMPORT = "from output.renderers.email.outlook import build_outlook_row"
+```
+Der naheliegende Ansatz „`union_of_max_carriers()` einfach im Scheduler
+aufrufen" ist damit gesperrt. Die Berechnung muss in `build_outlook_row()`
+(Darstellungsschicht) oder über `services.weather_metrics` laufen.
+
+**Fund B: Der Fallback-Pfad der Vorschau bekommt die Herkunft geschenkt.**
+`_build_thunder_forecast()` baut für das Hagel-Kennzeichen bereits
+`summarize_points(thunder_dps)` (`trip_report_scheduler.py:2552`).
+`summarize_points()` (`weather_metrics.py:1108-1133`) ruft
+`compute_basis_metrics()`, und das setzt `thunder_level_max_signals` schon
+heute über `union_of_max_carriers` (`weather_metrics.py:438,462`) — für
+**dieselbe** Punktmenge, die auch `level`/`hour` liefert. Es genügt, das
+vorhandene Aggregat in eine Variable zu heben und ein zweites Feld zu lesen.
+**Null neue Aggregationslogik, kein zusätzlicher Datenzugriff.**
+
+Das Vorbild dafür steht direkt daneben: `_thunder_entry_from_trend_row()` liest
+bereits `"hail": row.get("hail")` (`trip_report_scheduler.py:2335`) — Fix #1475
+löste dort **exakt dasselbe** Zwei-Pfade-Problem, das Risiko 6 oben für die
+Herkunft befürchtet. Das Muster ist wortgleich übertragbar.
+
+## Weitere Messungen, die Annahmen korrigierten
+
+| Annahme | Messung |
+|---|---|
+| „Telegram hat 32 Zeichen Breite" (aus S4 übernommen) | **Falsch für den Ausblick.** `_outlook_lines()` nutzt `_TG_PROSE_WIDTH = 56` mit Wort-Umbruch (`narrow.py:53`), nicht `_TG_TABLE_WIDTH`. Die 32 gelten der Stundentabelle aus S4. |
+| „SMS-Dichtheit muss nachgewiesen werden" | **Strukturell gegeben.** SMS/Premium-SMS bauen ihren Text über `SMSTripFormatter` und sehen `multi_day_trend` nie. `thunder_sms` aus `format_trend_tokens()` wird **nirgends gelesen** — toter Token. |
+| „Die Kompakt-Mail erbt mit" | **Nein.** Sie liest nur `thunder_plain` (`compact.py:234`) und faltet nach ASCII (`_ascii()`), was `·` ohnehin zerstörte. |
+| „Ein neuer Schlüssel bricht den Zeilenbau-Test" | Nur bei bedingungslosem Setzen. `build_outlook_row()` filtert optionale Felder bereits über `row.update({k: v for k, v in optional.items() if v is not None})` (`outlook.py:517`), und `union_of_max_carriers()` liefert selbst `None` statt `[]` (`metric_format.py:597-600`). |
+
+## Affected Files
+
+### Scheibe 5a — Mehrtages-Ausblick
+
+| Datei | Change | Beschreibung |
+|------|--------|--------------|
+| `src/output/renderers/email/outlook.py` | MODIFY | `build_outlook_row()`: Träger je Fenster aus `points` berechnen → optionaler Schlüssel; Gewitter-Zelle HTML (`:234-258`) + Klartext (`:369-390`) um Herkunft ergänzen |
+| `src/output/renderers/narrow.py` | MODIFY | Telegram-Trendblock (`:588-597`) — strukturelles Erbe, eigener Zweig nötig |
+| `tests/tdd/test_trip_outlook_parity.py` | UNVERÄNDERT | bleibt grün (Fixture ohne Träger) — **Beleg** für „ohne Träger zeichengleich" |
+| `tests/golden/email/test_outlook_thunder_day_night_golden.py` | UNVERÄNDERT | dito |
+| `tests/tdd/test_thunder_origin_outlook.py` | CREATE | neue Suite |
+
+### Scheibe 5b — Gewitter-Vorschau
+
+| Datei | Change | Beschreibung |
+|------|--------|--------------|
+| `src/services/trip_report_scheduler.py` | MODIFY | `_thunder_entry_from_trend_row()` +1 Zeile (Primär); `_build_thunder_forecast()` Aggregat in Variable heben (Fallback) |
+| `src/output/renderers/email/plain.py` | MODIFY | Vorschau-Block (`:317-328`) |
+| `src/output/renderers/email/html.py` | MODIFY | Vorschau-Block (`:1313-1323`) |
+| `tests/tdd/test_thunder_origin_preview.py` | CREATE | neue Suite |
+
+## Scope Assessment
+
+| | Dateien | Produktiv-LoC | Risiko |
+|---|---|---|---|
+| **S5a Ausblick** | 2 + 1 Test | ~45–60 | MEDIUM (geteilte Naht Trip↔Compare, Golden-Wächter) |
+| **S5b Vorschau** | 3 + 1 Test | ~20–25 | LOW (zwei vorhandene Call-Sites, Muster #1475) |
+
+Tests dominieren wie in allen Vorgängerscheiben (S4: 437 Testzeilen zu 14
+Produktivzeilen). `loc_limit_override` wird voraussichtlich nötig — wie in S1–S3.
+
+## Technical Approach (Entscheidungen)
+
+**1. Schnitt: zwei Scheiben, S5a vor S5b.** Jede Vorgängerscheibe deckte genau
+einen Ausgabeort. S5a liefert den `row`-Vertrag, S5b konsumiert ihn — echte
+Vorgänger/Nachfolger-Beziehung statt künstlicher Trennung.
+
+**2. Wortlaut: Herkunft nur am Tagesteil, unmittelbar hinter der Uhrzeit.**
+```
+nur Tag:            leicht @16 · CAPE
+Tag + Nacht:        leicht @16 · CAPE · nachts hoch @0
+Tag+Nacht+Hagel:    leicht @16 · CAPE · nachts hoch @0 · Hagel: ja
+zwei Zutaten:       leicht @16 · CAPE, Blitzdichte
+```
+Begründung: Übernimmt den seit S1 an sechs Fundstellen etablierten
+`" · "`-Wortlaut unverändert und begrenzt den Zuwachs auf **ein** zusätzliches
+`·`. Eine eigene Nachtherkunft brächte bis zu vier `·` mit drei Bedeutungen in
+eine Zelle — Lesbarkeit unter Zeitdruck schlägt Vollständigkeit
+(CLAUDE.md Design-Leitprinzip).
+
+**3. Nur der Tagesteil trägt Herkunft** — deckungsgleich mit der bestehenden
+Asymmetrie: die Vorschau liefert `level`/`hour` ohnehin nur für das Tagesfenster
+(ADR-0025), der Nacht-Halbsatz trägt schon heute keine eigenen Strukturdaten.
+Folge: reine Nachtgewitter-Tage zeigen **nie** eine Herkunft — bewusster
+Verzicht, als AC festzuhalten, damit ihn kein späterer Adversary „repariert".
+
+**4. Neuer Schlüssel nur bei vorhandenen Trägern** (Option a) — fügt sich in das
+vorhandene `optional`-Filtermuster ein und lässt beide Golden-Wächter
+unangetastet grün.
+
+**5. Compare-Ausblick erbt mit, ohne Unterdrückung.** `build_outlook_row()` ist
+die geteilte Naht (`compare_html.py:1167`); Compare zeigt die Herkunft seit
+S1/S3 an anderen Stellen. Ein `include_origin`-Schalter zum Abschalten wäre
+Zusatzkomplexität für negativen Produktwert.
+
+**6. Beide Vorschau-Pfade** — eine Regel an zwei vorhandenen Call-Sites, nicht
+zwei Implementierungen. Sonst hinge die Aussage davon ab, ob der Trend zufällig
+vorlag (Wiederholung von #1555).
+
+## Open Questions (für die Spec-Phase zu messen)
+
+- [ ] **🔴 Ist der Fallback-Zweig `outlook.py:238-243` im Betrieb erreichbar?**
+      Er zeigt die Aggregat-Stufe, wenn **keine** Stundenreihe vorliegt
+      (Kommentar: „Alt-Fixtures"). Davon hängt ab, ob der fehlende
+      `aggregate_stage()`-Dispatch-Zweig in dieser Scheibe einen **Wirkort**
+      hat. Ist er unerreichbar, wäre der Fix Code ohne Verbraucher — genau der
+      Fehler, den S2 vermieden hat. Ist er erreichbar, gehört der Fix in S5a und
+      Known Limitation 7 fällt endlich. **Messen, nicht raten** — diese Frage
+      entscheidet, ob `aggregate_stage()` zum fünften Mal vertagt wird.
+- [ ] **Trägt `LocationResult.outlook_hourly_data` (Compare) die Signale ebenso
+      zuverlässig?** Andere Punktliste als der Trip-Ausblick-Fetch
+      (`comparison_engine.py:177`). Risiko 8 gilt hier ein zweites Mal.
+- [ ] **Fenster-Konsistenz:** `build_outlook_row()` und `format_trend_tokens()`
+      lösen das Tagesfenster **zweimal unabhängig** auf. Ein Test mit einem von
+      4/19 **abweichenden** Fenster ist Pflicht — sonst bleibt die
+      gefährlichste Annahme der Scheibe unbewiesen.

--- a/docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md
+++ b/docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md
@@ -345,13 +345,65 @@ Jede Mutation nur per String-Ersetzung mit externer Sicherungskopie — **nie**
   rot werden.
 - **(e)** Feld bedingungslos setzen statt nur bei vorhandenen Trägern → der
   Bestandstest `test_build_outlook_row_without_selection_is_unchanged` muss rot
-  werden (Beleg, dass AC-8 nicht durch Zufall grün ist).
+  werden (Beleg, dass AC-8 nicht durch Zufall grün ist). **Achtung:** Diese
+  Mutation prüft **AC-8 und AC-10**, ausdrücklich **nicht** AC-7 — s.
+  „In der GREEN-Phase präzisiert", Punkt A.
 - **(f)** Herkunft **vor** statt hinter der Uhrzeit einfügen → AC-1 muss rot
   werden.
 - **(g)** Herkunfts-Zusatz zusätzlich in die Kompakt-Mail hängen → AC-13 muss
   rot werden.
 
 Kommt eine Mutation durch, ist das ein Finding, kein Nebenbefund.
+
+## In der GREEN-Phase präzisiert
+
+**A. AC-7 hängt an einem anderen Mechanismus, als Implementation Detail 1
+nahelegt — und zwar an einem anderen, als hier zunächst stand.** Der
+Schlüssel-Filter („nur setzen, wenn Träger vorhanden") trägt **AC-8 und
+AC-10**, nicht AC-7. Gemessen: Bei einem Wert unterhalb der niedrigsten
+Sprosse liefert die echte Fusion `ThunderLevel.NONE` **mit einer leeren Liste
+`[]`** — also `is not None`, der Schlüssel **wird** gesetzt.
+
+AC-7 ist **doppelt** abgesichert, und die erste der beiden Absicherungen ist
+die wirksame:
+1. `thunder_signal_carriers()` (`metric_format.py:481-483`, Scheibe 1) gibt bei
+   Höchststufe `NONE` bereits `[]` zurück — die echte Kette erzeugt **nie** ein
+   Paar `(NONE, ["cape"])`.
+2. `union_of_max_carriers()` (`metric_format.py:599-601`, Scheibe 2, Finding
+   F001) hält dieselbe Zusage nochmals aus eigener Kraft.
+
+Die erste Fassung dieses Absatzes schrieb AC-7 allein Absicherung 2 zu. Der
+Adversary hat das widerlegt: Entfernt man Absicherung 2, bleibt die **gesamte**
+S5a-Suite grün (14/14) — gefangen wird die Mutation nur von einem
+**Bestandstest aus Scheibe 2**
+(`tests/tdd/test_thunder_origin_trip.py:458-486`). **Für die
+Mutations-Gegenprobe heißt das:** Weder Mutation (e) noch ein Angriff auf
+Absicherung 2 belegt AC-7 innerhalb dieser Scheibe. Wer AC-7 wirklich brechen
+will, muss Absicherung 1 angreifen.
+
+Das ist in diesem Workflow das **dritte** Mal, dass eine Aussage über den
+eigenen Code der Messung nicht standhielt — nach der aus S1–S4 übernommenen
+`aggregate_stage()`-Notiz und der ersten Fassung von AC-11. Kein
+Verhaltensfehler, aber ein Beleg dafür, dass auch eine frisch geschriebene
+Begründung geprüft gehört.
+
+**B. Ein toter Winkel, der erst in Scheibe 5b gefährlich wird.** Der
+Herkunfts-Token wird **unabhängig** von `sms_threshold_thunder` berechnet. Hebt
+ein Nutzer die Nennschwelle an, kann `thunder_day_token == "-"` sein, während
+der Herkunfts-Token gefüllt ist. Heute leckt nichts, weil alle drei Renderer
+den Zusatz ausschließlich **innerhalb** des Tages-Token-Zweigs anhängen. Ein
+Verbraucher in **S5b**, der den Herkunfts-Token liest, **ohne** vorher
+`thunder_day_token` zu prüfen, zeigte eine Herkunft zu einer Stufe, die nirgends
+steht — die AC-12-Fehlerklasse aus Scheibe 1. **Gehört als Vorgabe in die
+S5b-Spec**, nicht als Nachbesserung hierher: Der Zeilen-Vertrag darf nicht über
+den Scheibenrand hinweg geändert werden.
+
+**C. Der Spalten-Schlüssel `signals` reist wie `hail` an jeder Spalte mit**,
+verbraucht wird er nur bei `kind == "ordinal"` — und ordinal ist im
+Compare-Katalog ausschließlich Gewitter. Bewusst nach dem Hagel-Vorbild gebaut
+(Spec-Vorgabe); käme je eine zweite ordinale Größe dazu, bekäme sie
+Gewitter-Zutaten angeheftet. Dieselbe latente Eigenschaft trägt der
+Hagel-Schlüssel seit #1475 — geerbte Annahme, kein neuer Fehler.
 
 ## Known Limitations
 

--- a/docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md
+++ b/docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md
@@ -374,6 +374,22 @@ Kommt eine Mutation durch, ist das ein Finding, kein Nebenbefund.
    bewusst nicht.
 6. **Ein Zeilenumbruch im Telegram-Trendblock ist hinnehmbar** (56 Zeichen,
    Wort-Umbruch) — kein Datenverlust, s. AC-3.
+7. **Dieselben zwei Zutaten können in umgekehrter Reihenfolge erscheinen**
+   (in der RED-Phase gemessen). Gipfeln beide Signale in **einer** Stunde,
+   lautet die Zeile `CAPE, Blitzpotenzial` (Katalogreihenfolge); fallen sie auf
+   **zwei** Stunden, lautet sie `Blitzpotenzial, CAPE` (zeitliche Reihenfolge).
+   Das folgt aus der in AC-4 festgelegten Erstauftritts-Reihenfolge von
+   `union_of_max_carriers()`. Für den Empfänger kann das wie eine **Rangfolge**
+   aussehen, ist aber nur die Uhrzeit — es gibt bewusst keinen Gewinner
+   (Auslegung ii). Eine Vereinheitlichung gehörte in
+   `union_of_max_carriers()` selbst und beträfe **alle** Verbraucher seit
+   Scheibe 2; sie ist deshalb ausdrücklich nicht Teil dieser Scheibe.
+   Sammel-Eintrag (#1199), kein eigenes Issue.
+8. **Der Metrik-Zweig (AC-11b) ist compare-exklusiv.** Der Trip ruft die
+   Ausblick-Renderer immer mit `metrics=None` (`html.py:1357`,
+   `plain.py:338`); nur der Ortsvergleich setzt eine Auswahl
+   (`compare_html.py:1241`). Die dortige Erweiterung kann die Trip-Golden
+   strukturell nicht berühren.
 
 ## Nicht in dieser Scheibe
 

--- a/docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md
+++ b/docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md
@@ -4,7 +4,7 @@ type: feature
 created: 2026-08-13
 updated: 2026-08-13
 status: draft
-version: "1.0"
+version: "1.1"
 tags: [thunder, trip, compare, telegram, outlook, adr-0007, adr-0025, issue-1680, issue-1419]
 ---
 
@@ -23,6 +23,10 @@ tags: [thunder, trip, compare, telegram, outlook, adr-0007, adr-0025, issue-1680
 
 - [x] Approved — PO-go 2026-08-13 (13 ACs, Wortlaut und beide vorgelegten
       Entscheidungen: Nachtteil ohne Herkunft, Compare-Ausblick erbt mit)
+- [x] Approved v1.1 — PO-go 2026-08-13. Nachtrag nach RED-Messung: AC-11 in
+      AC-11a/AC-11b geteilt (Compare hat ZWEI Renderpfade, der Metrik-Zweig
+      ist der Regelfall), AC-4 Reihenfolge praezisiert. Siehe "Am Code
+      gemessen" Punkt 9.
 
 ## Purpose
 
@@ -69,6 +73,15 @@ Handlungsempfehlung (ADR-0007).
 - **File:** `src/output/metric_format.py` — `union_of_max_carriers()`
   (Z. 559–609) und `THUNDER_SIGNAL_LABEL_DE` (Z. 374–379), beide unverändert
   wiederverwendet.
+- **File:** `src/output/renderers/compare_outlook_metric_ids.py` —
+  `outlook_columns()` (Z. 78) und `format_outlook_value()` (Z. 117–135) für
+  **AC-11b**. Der Zweig mit gesetzter Metrik-Auswahl umgeht den Token-Pfad
+  vollständig (früher Return `outlook.py:148`, `continue` `outlook.py:342`) und
+  baut die Zelle über `_fmt_thunder(value, column.get("hail"))`. Erweiterung
+  exakt nach dem **Hagel-Vorbild** (#1475 Punkt 5b, „Aufrufstelle 4"): ein
+  zusätzlicher Spalten-Schlüssel, durchgereicht an den dritten Parameter von
+  `_fmt_thunder`, den es seit Scheibe 1 bereits gibt
+  (`email/compare_html.py:204-242`).
 
 ## Wortlaut (freigabepflichtig)
 
@@ -114,8 +127,12 @@ eigenen Strukturdaten.
 
 - **AC-4:** Given eine Etappe, deren Höchststufe im Tagesfenster von **zwei**
   Zutaten gleichzeitig getragen wird / When der Ausblick gerendert wird / Then
-  werden **beide** Zutaten genannt, mit `", "` verbunden, in stabiler
-  Reihenfolge (Auslegung (ii): alle tragenden Signale, kein Gewinner gekürt).
+  werden **beide** Zutaten genannt, mit `", "` verbunden (Auslegung (ii): alle
+  tragenden Signale, kein Gewinner gekürt). **Reihenfolge:** die von
+  `union_of_max_carriers()` gelieferte — dedupliziert, in Erstauftritts-
+  Reihenfolge über die betrachteten Stunden. Bei einem einzelnen Punkt ist das
+  die Katalogreihenfolge, über mehrere Stunden hinweg die zeitliche. Es wird
+  **keine** eigene Sortierung eingeführt (unverändert gegenüber S1–S4).
 
 - **AC-5:** Given eine Etappe mit Gewitter **und** Hagel-Kennzeichen / When der
   Ausblick gerendert wird / Then steht die Herkunft **vor** dem Hagel-Zusatz,
@@ -152,10 +169,19 @@ eigenen Strukturdaten.
   **ohne** Herkunft — nie eine Herkunft, die nicht zur gezeigten Stufe gehört
   (AC-12-Regel aus Scheibe 1).
 
-- **AC-11:** Given einen Ortsvergleich mit aktivem Ausblick / When dessen
-  Ausblick-Tabelle gerendert wird / Then nennt auch sie die Herkunft — der
-  geteilte Zeilenbau wird **nicht** trip-seitig abgeschaltet
-  (Trip/Compare-Teilungs-Invariante).
+- **AC-11a:** Given einen Ortsvergleich **ohne** Metrik-Auswahl für den
+  Ausblick (Altbestand, `outlook_metrics` fehlt) / When dessen Ausblick-Tabelle
+  gerendert wird / Then nennt auch sie die Herkunft über denselben Token-Pfad
+  wie der Trip — der geteilte Zeilenbau wird **nicht** trip-seitig
+  abgeschaltet (Trip/Compare-Teilungs-Invariante).
+
+- **AC-11b:** Given einen Ortsvergleich **mit** gesetzter Metrik-Auswahl
+  (der Regelfall jedes über die Oberfläche gepflegten Vergleichs) und einer
+  gewählten Gewitter-Spalte / When dessen Ausblick-Tabelle gerendert wird /
+  Then nennt die Gewitter-Zelle ebenfalls die tragende Zutat. Die Herkunft
+  stammt dort aus **derselben** Rechnung wie die dort gezeigte Stufe (dem
+  Tages-Aggregat `summarize_points()`), nicht aus dem Tagesfenster — beide
+  gehören zusammen (AC-10-Regel). Nachweis in HTML **und** Klartext.
 
 - **AC-12:** Given einen Trip-Briefing-Versand über SMS bzw. Premium-SMS /
   When der Text erzeugt wird / Then enthält er **keine** der vier
@@ -236,6 +262,22 @@ Abwesenheits-Zusicherung.
 **8. Die aus S4 übernommene Telegram-Breite von 32 Zeichen gilt hier nicht.**
 Der Trendblock nutzt `_TG_PROSE_WIDTH = 56` mit Wort-Umbruch
 (`narrow.py:53`); die 32 (`_TG_TABLE_WIDTH`) gehören der Stundentabelle aus S4.
+
+**9. Der Compare-Ausblick hat ZWEI Renderpfade — in der RED-Phase gemessen,
+nach der ersten Freigabe (Spec-Korrektur v1.1).** Die erste Fassung von AC-11
+unterstellte, der Ortsvergleich erbe die Herkunft allein über den geteilten
+Zeilenbau. Gemessen trifft das **nur für Altbestand** zu: Ist
+`outlook_metrics` gesetzt, nimmt `render_outlook_table()` einen frühen Return
+(`outlook.py:148-172`), `render_outlook_plain()` ein `continue`
+(`outlook.py:342-351`); beide bauen die Zelle aus `stage["cells"]` und
+berühren `format_trend_tokens()`, `thunder_day_token` und `gew_str` **nie**
+(gemessen: Zelle `leicht` statt `leicht @16`). `resolve_outlook_metrics()`
+liefert `None` ausschließlich, wenn das Feld **fehlt**
+(`compare_outlook_metric_ids.py:53-54`) — die Oberfläche schreibt es
+(`compareHubWizardBridge.ts:714-719`). Der Metrik-Zweig ist damit der
+**Regelfall**, nicht der Randfall. Ein AC-11 nur über den Token-Pfad wäre grün
+getestet und für real gepflegte Vergleiche **unsichtbar** — dieselbe
+Fehlerklasse wie in S2 (Suffix am falschen Textzweig) und S3. Daher AC-11a/b.
 
 ## Implementation Details
 

--- a/docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md
+++ b/docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md
@@ -1,0 +1,345 @@
+---
+entity_id: feat_1680_s5a_gewitter_herkunft_ausblick
+type: feature
+created: 2026-08-13
+updated: 2026-08-13
+status: draft
+version: "1.0"
+tags: [thunder, trip, compare, telegram, outlook, adr-0007, adr-0025, issue-1680, issue-1419]
+---
+
+<!-- Issue #1680, Scheibe 5a (Mehrtages-Ausblick). Vorgaenger: S1 Ortsvergleich
+     (live 2026-08-12), S2 Trip-Kurzzusammenfassung + GEWITTER-Kommando (live
+     2026-08-12), S3 vier weitere Orte (live 2026-08-13), S4 Trip-Stundentabelle
+     (live 2026-08-13). Nachfolger: S5b (Gewitter-Vorschau) konsumiert den hier
+     entstehenden Zeilen-Vertrag. Bezug: Epic #1419 Rang 4, Entscheidung E1.
+     Grundlage: PFLICHTLEKTUERE docs/context/feat-1680-s5-ausblick-vorschau-herkunft.md
+     (vor dieser Spec gemessen, inkl. vier Explore-Laeufen und einer unabhaengigen
+     Bewertung). -->
+
+# Gewitter: Herkunft der Stufe im Mehrtages-Ausblick sichtbar machen (#1680 Scheibe 5a)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Seit den Scheiben 1–4 nennen acht Ausgabeorte neben der fusionierten
+Gewitterstufe die tragende Zutat (`leicht · CAPE`). Der **Mehrtages-Ausblick**
+— die Tabelle „Nächste Etappen" mit einer Zeile je künftiger Etappe — ist
+einer der beiden letzten Orte ohne Herkunft. Er zeigt heute
+`leicht @16 · nachts hoch @0` und lässt offen, worauf die Einstufung beruht.
+
+Das ist genau dort besonders folgenreich, wo der Ausblick hingehört: Er zeigt
+**drei verschiedene Tage an drei verschiedenen Orten** untereinander. Stufen
+aus verschiedenen Gebieten und Modellen stehen damit unmittelbar nebeneinander
+und suggerieren eine Vergleichbarkeit, die ohne Herkunftsangabe nicht gegeben
+ist — dieselbe Begründung, die das Issue für den Ortsvergleich nennt
+(Gesamtkonzept Abschnitt 4/4.1).
+
+Die Herkunft nennt weiterhin nur die Zutat, keine Bewertung und keine
+Handlungsempfehlung (ADR-0007).
+
+## Source
+
+> **Schicht-Hinweis:** ausschließlich Python-Core
+> (`src/output/renderers/`). Kein Frontend, keine Go-Beteiligung, kein neuer
+> Endpoint, keine neuen Persistenz-Felder. Der Zeitplaner
+> (`trip_report_scheduler.py`) wird in dieser Scheibe **nicht** angefasst —
+> siehe „Am Code gemessen", Punkt 2.
+
+- **File:** `src/output/renderers/email/outlook.py`
+  - `build_outlook_row()` (Z. 415–520) — baut heute `hourly_thunder` als
+    `HourlyValue`-Tupel aus den rohen `points` (Z. 463–477) und wirft dabei
+    `dp.thunder_level_signals` weg. Hier entsteht das neue, optionale
+    Trägerfeld. Additiv-Filter `row.update({k: v for k, v in optional.items()
+    if v is not None})` (Z. 517) ist die vorhandene Naht.
+  - `render_outlook_table()` — HTML-Gewitterzelle (Z. 233–265)
+  - `render_outlook_plain()` — Klartext-Gewitterfeld (Z. 358–397)
+- **File:** `src/output/renderers/email/helpers.py` — `format_trend_tokens()`
+  (Z. 897–1045), Tag-/Nacht-Aufteilung am Tagesfenster (Z. 1005–1020). **Hier**
+  entsteht der Herkunfts-Token, weil hier auch `thunder_day_token` entsteht —
+  eine Fensterauflösung, nicht zwei (s. AC-9).
+- **File:** `src/output/renderers/narrow.py` — Telegram-Trendblock
+  `_outlook_lines()` (Z. 570–599), liest `thunder_day_token`/
+  `thunder_night_token` (Z. 588–589), Breite `_TG_PROSE_WIDTH = 56` mit
+  Wort-Umbruch.
+- **File:** `src/output/metric_format.py` — `union_of_max_carriers()`
+  (Z. 559–609) und `THUNDER_SIGNAL_LABEL_DE` (Z. 374–379), beide unverändert
+  wiederverwendet.
+
+## Wortlaut (freigabepflichtig)
+
+Die Herkunft steht **unmittelbar hinter der Tagesstufe**, mit demselben
+Trenner `" · "` wie in den Scheiben 1–4. Bei mehreren tragenden Zutaten werden
+sie mit `", "` verbunden — ebenfalls wie in den Vorgängerscheiben.
+
+| Fall | HTML-Zelle | Klartext | Telegram |
+|---|---|---|---|
+| nur Tag | `leicht @16 · CAPE` | `⚡leicht · CAPE` | `⚡leicht@16 · CAPE` |
+| Tag + Nacht | `leicht @16 · CAPE · nachts hoch @0` | `⚡leicht · CAPE · nachts hoch @0` | `⚡leicht@16 · CAPE · nachts hoch @0` |
+| Tag + Nacht + Hagel | `leicht @16 · CAPE · nachts hoch @0 · Hagel: ja` | dito + ` · Hagel: ja` | (Telegram führt keinen Hagel-Zusatz) |
+| zwei Zutaten | `leicht @16 · CAPE, Blitzdichte` | `⚡leicht · CAPE, Blitzdichte` | `⚡leicht@16 · CAPE, Blitzdichte` |
+| nur Nacht | `nachts hoch @0` (**unverändert, ohne Herkunft**) | dito | dito |
+| kein Gewitter | `–` (**unverändert**) | `⚡–` (**unverändert**) | unverändert |
+
+**Der Nachtteil bekommt bewusst KEINE Herkunft** (AC-6). Begründung: Der
+Trenner `·` trägt in dieser Zelle bereits zwei Bedeutungen (Tag/Nacht-Trennung
+und Hagel-Zusatz). Eine eigene Nachtherkunft brächte bis zu **vier** Trenner
+mit **drei** Bedeutungen in eine Zelle, die unter Zeitdruck gelesen wird —
+CLAUDE.md-Leitprinzip „Lesbarkeit schlägt Vollständigkeit". Die Asymmetrie ist
+zudem bereits etabliert: Die Vorschau liefert `level`/`hour` ohnehin nur für
+das Tagesfenster (ADR-0025), der Nacht-Halbsatz trägt schon heute keine
+eigenen Strukturdaten.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine künftige Etappe, deren Tages-Gewitterstufe im
+  Tagesfenster von genau einer Zutat getragen wird / When die HTML-Ausblick-
+  Tabelle der Trip-Vollmail gerendert wird / Then steht in der Gewitter-Spalte
+  dieser Zeile die Stufe mit Uhrzeit, gefolgt von `" · "` und der deutschen
+  Bezeichnung der Zutat (z. B. `leicht @16 · CAPE`).
+
+- **AC-2:** Given dieselbe Etappe / When der Klartext-Ausblick derselben Mail
+  gerendert wird / Then trägt das Gewitterfeld denselben Zusatz im selben
+  Wortlaut (`⚡leicht · CAPE`) — der Klartext führt wie bisher keine
+  Tagesuhrzeit.
+
+- **AC-3:** Given dieselbe Etappe / When der Telegram-Trendblock gerendert wird
+  / Then nennt auch er die Zutat hinter der Tagesstufe. Der Inhalt muss im
+  selben Ausblick-Block stehen, nicht zwingend als zusammenhängender
+  Teilstring — die Breite von 56 Zeichen darf umbrechen.
+
+- **AC-4:** Given eine Etappe, deren Höchststufe im Tagesfenster von **zwei**
+  Zutaten gleichzeitig getragen wird / When der Ausblick gerendert wird / Then
+  werden **beide** Zutaten genannt, mit `", "` verbunden, in stabiler
+  Reihenfolge (Auslegung (ii): alle tragenden Signale, kein Gewinner gekürt).
+
+- **AC-5:** Given eine Etappe mit Gewitter **und** Hagel-Kennzeichen / When der
+  Ausblick gerendert wird / Then steht die Herkunft **vor** dem Hagel-Zusatz,
+  und der Hagel-Zusatz bleibt wortgleich erhalten
+  (`leicht @16 · CAPE · Hagel: ja`).
+
+- **AC-6:** Given eine Etappe mit Gewitter **im Nachtfenster** / When der
+  Ausblick gerendert wird / Then trägt der Nachtteil **keine** Herkunft, und
+  der Nachtteil bleibt gegenüber heute zeichengleich. Gegenprobe an derselben
+  Fixture: Läge dasselbe Gewitter im Tagesfenster, erschiene die Herkunft sehr
+  wohl — der Test darf nicht vakuum-grün sein.
+
+- **AC-7:** Given eine Etappe **ohne** Gewitter im Tagesfenster / When der
+  Ausblick gerendert wird / Then enthält die Gewitterzelle **weder** eine
+  Zutat-Bezeichnung **noch** einen zusätzlichen `·`-Trenner — sie bleibt
+  zeichengleich zu heute (`–` bzw. `⚡–`).
+
+- **AC-8:** Given Ausblick-Zeilen, die **keine** Trägerinformation führen
+  (Alt-Aufrufer, aufgezeichnete Fixtures) / When HTML- und Klartext-Ausblick
+  gerendert werden / Then ist die Ausgabe **byte-identisch** zu heute. Nachweis
+  ist der unveränderte Bestandswächter `tests/tdd/test_trip_outlook_parity.py`,
+  der grün bleiben MUSS, ohne dass seine Golden-Dateien angefasst werden.
+
+- **AC-9:** Given ein Trip mit einem vom Standard **abweichenden** Tagesfenster
+  (nicht 4–19 Uhr) und einem Gewitter, das nur in diesem abweichenden Fenster
+  liegt / When der Ausblick gerendert wird / Then stammen angezeigte Stufe
+  **und** angezeigte Herkunft aus demselben Fenster — die Herkunft wird an
+  derselben Stelle und mit demselben Fensterwert ermittelt wie
+  `thunder_day_token`.
+
+- **AC-10:** Given eine Etappe, deren Wetterpunkte eine Gewitterstufe tragen,
+  für die **keine** Trägerliste vorliegt (z. B. aufgezeichneter Schnappschuss
+  vor Scheibe 1) / When der Ausblick gerendert wird / Then erscheint die Stufe
+  **ohne** Herkunft — nie eine Herkunft, die nicht zur gezeigten Stufe gehört
+  (AC-12-Regel aus Scheibe 1).
+
+- **AC-11:** Given einen Ortsvergleich mit aktivem Ausblick / When dessen
+  Ausblick-Tabelle gerendert wird / Then nennt auch sie die Herkunft — der
+  geteilte Zeilenbau wird **nicht** trip-seitig abgeschaltet
+  (Trip/Compare-Teilungs-Invariante).
+
+- **AC-12:** Given einen Trip-Briefing-Versand über SMS bzw. Premium-SMS /
+  When der Text erzeugt wird / Then enthält er **keine** der vier
+  Zutat-Bezeichnungen. Nachweis per Sonde (Beschriftungsfunktion zur Laufzeit
+  markieren), nicht per Wortsuche — mit Gegenprobe, dass die Sonde in E-Mail
+  und Telegram anschlägt.
+
+- **AC-13:** Given ein Trip-Briefing im **Kompaktformat** / When die Mail
+  gerendert wird / Then bleibt deren Ausblick-Block („Naechste Etappen")
+  zeichengleich zu heute — er liest `thunder_plain` und wird von dieser
+  Scheibe nicht berührt.
+
+## Am Code gemessen (korrigiert gegenüber den Vorgängerscheiben)
+
+**1. Die Stufe im Ausblick kommt NICHT aus `aggregate_stage()`.** S1–S4 haben
+weitergereicht, der Mehrtages-Ausblick sei „der erste echte Verbraucher" dieses
+Aggregators. Gemessen: `aggregate_stage()` läuft dort zwar
+(`trip_report_scheduler.py:2026`), aber die **angezeigte** Stufe stammt aus den
+Stundenproben im Tagesfenster (`outlook.py:234-243`, `helpers.py:1013-1017`).
+Das Aggregat speist nur `row["thunder"]` — und das dient ausschließlich einem
+Notnagel-Zweig.
+
+**2. Dieser Notnagel-Zweig ist in BEIDEN Produktivpfaden unerreichbar** —
+bewiesen, nicht vermutet:
+- `aggregate_stage()` aggregiert ausschließlich Segmente mit `has_error=False`
+  (`weather_metrics.py:1194-1197`).
+- Von den drei Konstruktionen einer `SegmentWeatherData` tragen die beiden mit
+  `timeseries=None` **immer** `has_error=True` (`segment_weather.py:158-166`,
+  `:205-213`); die einzige mit `has_error=False` hat **immer** eine Zeitreihe
+  (`:283-289`).
+- `_flat_points` sammelt aus allen Segmenten mit Zeitreihe
+  (`trip_report_scheduler.py:2046-2049`) — enthält also die Punkte jedes
+  aggregierten Segments.
+- `_compute_thunder_level()` (`weather_metrics.py:605-607`) und der
+  Stundenreihen-Bau (`outlook.py:471`) filtern mit **derselben** Bedingung
+  `dp.thunder_level is not None`.
+- Folge: „Aggregat trägt eine Stufe" ⟹ „Stundenreihe ist nicht leer". Der Zweig
+  verlangt beides gegenteilig gleichzeitig und ist damit unerreichbar. Im
+  Compare-Pfad ist die Punktmenge ohnehin identisch
+  (`compare_html.py:1164-1168`).
+
+**Konsequenz:** Der in `aggregation_config` (`weather_metrics.py:478`)
+deklarierte, aber in `aggregate_stage()` **nicht implementierte** Zweig
+`union_of_max_carriers` bleibt auch in dieser Scheibe ohne erreichbaren
+Verbraucher. Ihn hier zu ergänzen wäre Code ohne Wirkort — genau der Fehler,
+den Scheibe 2 bewusst vermieden hat. Er bleibt Known Limitation, **aber ab
+sofort mit Beweiskette statt mit Vermutung** (s. Known Limitations 1).
+
+**3. Der Zeitplaner darf `union_of_max_carriers` nicht importieren.** Eine
+Architektur-Wache (`tests/unit/test_notification_service.py:183-192`) erlaubt
+in `trip_report_scheduler.py` **zeilengenau einen** Import aus der
+Darstellungsschicht (`build_outlook_row`). Die Berechnung gehört deshalb in
+die Darstellungsschicht — was ohnehin der richtige Ort ist (Punkt 4).
+
+**4. Die Trägerinformation geht nicht verloren, sie wird weggeworfen.**
+`build_outlook_row()` bekommt die rohen `ForecastDataPoint`s und verengt sie
+**selbst** zu `HourlyValue` (nur `hour`/`value`). `dp.thunder_level_signals` ist
+dort verfügbar (gesetzt in `thunder_enrichment.py:151`, unter **derselben**
+Bedingung wie die Stufe selbst). Eine Änderung an `HourlyValue` ist **nicht**
+nötig — die in S3/S4 notierte „strukturelle Blockade" bestand nur eine Zeile zu
+spät.
+
+**5. Die Anreicherung läuft auf dem Ausblick-Pfad ohne Schalter**
+(`openmeteo.py:1198-1204`, bewusst nicht an `enrich_ensemble` gekoppelt).
+Diese Scheibe verursacht **keine** zusätzlichen Netzabrufe — sie liest ein Feld,
+das ohnehin gefüllt wird (relevant für Kontingent #1329).
+
+**6. SMS erreicht der Ausblick strukturell nicht.** SMS und Premium-SMS bauen
+ihren Text über `SMSTripFormatter` und sehen `multi_day_trend` nie. Der Token
+`thunder_sms` aus `format_trend_tokens()` wird **nirgends** gelesen. AC-12 ist
+damit eine strukturelle Zusicherung, kein Balanceakt.
+
+**7. Die Kompakt-Mail erbt nicht mit.** Sie liest ausschließlich
+`thunder_plain` (`compact.py:234`) und faltet ihren Text nach ASCII
+(`_ascii()`), was den Trenner `·` ohnehin zerstörte. Daher AC-13 als
+Abwesenheits-Zusicherung.
+
+**8. Die aus S4 übernommene Telegram-Breite von 32 Zeichen gilt hier nicht.**
+Der Trendblock nutzt `_TG_PROSE_WIDTH = 56` mit Wort-Umbruch
+(`narrow.py:53`); die 32 (`_TG_TABLE_WIDTH`) gehören der Stundentabelle aus S4.
+
+## Implementation Details
+
+1. **`build_outlook_row()` reicht die Träger je Stunde durch, fertig
+   berechnet wird nichts.** Parallel zu `hourly_thunder` entsteht ein
+   optionales Feld mit `(Stunde, Stufe, Trägerliste)` je Punkt, der eine
+   Gewitterstufe trägt. Es wird **nur gesetzt, wenn mindestens ein Punkt eine
+   Trägerliste hat** — über den vorhandenen `optional`-Filter (Z. 517). Damit
+   bleibt der Bestandstest `test_build_outlook_row_without_selection_is_unchanged`
+   grün, ohne ihn anzufassen.
+
+2. **Die Fensterfilterung und die Vereinigung passieren in
+   `format_trend_tokens()`** — an **derselben** Stelle, an der auch
+   `thunder_day_token` entsteht (`helpers.py:1005-1020`), mit **demselben**
+   `win_start`/`win_end`. Das ist die einzige Konstruktion, die AC-9
+   strukturell erfüllt statt durch Disziplin; zwei unabhängige
+   Fensterauflösungen wären genau die Fehlerklasse aus #1653/#1498.
+
+3. **Vereinigt wird über den vorhandenen Baustein**
+   `union_of_max_carriers((stufe, träger) …)` (`metric_format.py:559`) über die
+   Stunden **im Tagesfenster**. Er liefert selbst `None` statt `[]`, wenn keine
+   Träger vorliegen — kein Sonderfall nötig. Damit gilt AC-10 aus eigener Kraft
+   der Funktion (die in S2 als Finding F001 nachgehärtete Garantie).
+
+4. **Ergebnis ist ein neuer Token** (fertiger Zusatztext oder `None`), den die
+   drei Renderer an derselben Stelle anhängen, an der sie heute schon den
+   Tagesteil bauen. Die Zeichensetzung bleibt je Kanal die vorhandene.
+
+5. **Neue Testdatei** `tests/tdd/test_thunder_origin_outlook.py` — nach
+   Verhalten benannt, nicht nach Issue-Nummer (Namensregel).
+
+## Was sich NICHT ändern darf
+
+- `tests/tdd/test_trip_outlook_parity.py` **und seine Golden-Dateien** bleiben
+  unangetastet und grün (AC-8). Wird dieser Wächter rot, ist das der Befund —
+  nicht ein veralteter Referenzstand.
+- `tests/golden/email/test_outlook_thunder_day_night_golden.py` bleibt grün und
+  seine Golden-Datei unangetastet (Fixture führt keine Träger).
+- `HourlyValue` (`src/output/tokens/dto.py:15-18`) bleibt unverändert.
+- `aggregate_stage()` bleibt unverändert (s. „Am Code gemessen", Punkt 2).
+- `src/services/trip_report_scheduler.py` wird **nicht** angefasst.
+- Die Kompakt-Mail bleibt zeichengleich (AC-13).
+- SMS und Premium-SMS bleiben ohne Herkunft (AC-12).
+- Der Nachtteil bleibt zeichengleich (AC-6).
+
+## Test-Strategie
+
+Kern-Schicht, deterministisch: echte Renderkette bis zum zurückgegebenen
+String, keine Mocks. Jeder Abwesenheits-AC (AC-6, AC-7, AC-10, AC-12, AC-13)
+trägt eine **Gegenprobe an derselben Fixture**, die belegt, dass die Herkunft
+dort überhaupt entstünde — sonst bewacht er nichts (Muster aus S1–S4).
+
+### Pflicht-Mutationen (Gegenprobe, keine Kür)
+
+Jede Mutation nur per String-Ersetzung mit externer Sicherungskopie — **nie**
+`git checkout`/`stash`/`reset`.
+
+- **(a)** Herkunft an den **Nacht**teil statt an den Tagesteil hängen → AC-6
+  muss rot werden.
+- **(b)** Fensterfilterung für die Träger entfernen (ganzer Kalendertag) →
+  AC-9 muss rot werden.
+- **(c)** `union_of_max_carriers` durch „erste Trägerliste" ersetzen → AC-4
+  muss rot werden.
+- **(d)** Trägerliste auch bei Stufe ohne passende Träger anhängen → AC-10 muss
+  rot werden.
+- **(e)** Feld bedingungslos setzen statt nur bei vorhandenen Trägern → der
+  Bestandstest `test_build_outlook_row_without_selection_is_unchanged` muss rot
+  werden (Beleg, dass AC-8 nicht durch Zufall grün ist).
+- **(f)** Herkunft **vor** statt hinter der Uhrzeit einfügen → AC-1 muss rot
+  werden.
+- **(g)** Herkunfts-Zusatz zusätzlich in die Kompakt-Mail hängen → AC-13 muss
+  rot werden.
+
+Kommt eine Mutation durch, ist das ein Finding, kein Nebenbefund.
+
+## Known Limitations
+
+1. **`aggregate_stage()` bleibt unangeschlossen — jetzt mit Beweis.** Der in
+   `aggregation_config` deklarierte Zweig `union_of_max_carriers` ist weiterhin
+   nicht implementiert (`weather_metrics.py:1265-1266`, `else: values[0]`). Bei
+   einer Etappe mit mehreren Segmenten lieferte er die Trägerliste des
+   **ersten** Segments statt der Vereinigung. Erreichbar ist dieser Wert heute
+   **nur** über den in „Am Code gemessen" Punkt 2 als unerreichbar bewiesenen
+   Notnagel-Zweig. Bleibt gebucht (#1199); ein Fix braucht zuerst einen echten
+   Verbraucher.
+2. **Der Nachtteil trägt nie eine Herkunft** (AC-6, bewusst). Reine
+   Nachtgewitter-Tage zeigen damit keine Zutat.
+3. **`sdi_2` (Superzellen) bleibt außen vor** — die Fusion hat vier Zutaten,
+   nicht fünf (unverändert seit S1).
+4. **EU_REST-LPI bleibt ein ausgewiesener Interim-Wert** (#1678, ADR-0048),
+   unverändert seit S1.
+5. **Telegram erbt den Zusatz strukturell** (wie S4): Wer künftig den
+   Tages-Token ändert, ändert Telegram mit. Ein eigener Kanal-Schalter existiert
+   bewusst nicht.
+6. **Ein Zeilenumbruch im Telegram-Trendblock ist hinnehmbar** (56 Zeichen,
+   Wort-Umbruch) — kein Datenverlust, s. AC-3.
+
+## Nicht in dieser Scheibe
+
+- **Gewitter-Vorschau** — folgt als **Scheibe 5b**; sie konsumiert den hier
+  entstehenden Zeilen-Vertrag über beide ihrer Pfade
+  (`_thunder_entry_from_trend_row` primär, `_build_thunder_forecast` als
+  Rückfall).
+- **`aggregate_stage()`s Dispatch-Zweig** — s. Known Limitations 1.
+- **Eine eigene Herkunft für den Nachtteil** — s. AC-6, bewusste
+  Produktentscheidung.
+- **Go-DTO und Frontend** — ersatzlos, kein Verbraucher (unverändert seit S3).
+- **Kompakt-Mail** — s. AC-13.

--- a/docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md
+++ b/docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md
@@ -21,7 +21,8 @@ tags: [thunder, trip, compare, telegram, outlook, adr-0007, adr-0025, issue-1680
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-go 2026-08-13 (13 ACs, Wortlaut und beide vorgelegten
+      Entscheidungen: Nachtteil ohne Herkunft, Compare-Ausblick erbt mit)
 
 ## Purpose
 

--- a/src/output/renderers/compare_outlook_metric_ids.py
+++ b/src/output/renderers/compare_outlook_metric_ids.py
@@ -125,6 +125,10 @@ def format_outlook_value(value: object, column: dict) -> str:
     Issue #1475 Nachbesserung (Punkt 5b, Aufrufstelle 4): traegt ``column``
     den Schluessel ``"hail"``, wird er an ``_fmt_thunder`` durchgereicht --
     ohne den Schluessel bleibt die Zelle zeichengleich zum bisherigen Stand.
+
+    Issue #1680 S5a (AC-11b): ``"signals"`` folgt exakt derselben Bauart --
+    dritter Parameter von ``_fmt_thunder``, additiv, ohne den Schluessel
+    zeichengleich.
     """
     from output.renderers.email.compare_html import _fmt_precip_type, _fmt_thunder
 
@@ -132,7 +136,7 @@ def format_outlook_value(value: object, column: dict) -> str:
         return "–"
     kind = column.get("kind")
     if kind == "ordinal":
-        return _fmt_thunder(value, column.get("hail"))
+        return _fmt_thunder(value, column.get("hail"), column.get("signals"))
     if kind == "enum":
         return _fmt_precip_type(value)
     try:

--- a/src/output/renderers/email/helpers.py
+++ b/src/output/renderers/email/helpers.py
@@ -1018,6 +1018,22 @@ def format_trend_tokens(stage: dict) -> dict:
         "TH", _night_samples, threshold=thunder_thr, is_level=True,
         level_labels=_TREND_THUNDER_LABELS,
     )
+    # Issue #1680 S5a: die tragende Zutat der TAGES-Stufe. Bewusst HIER und
+    # mit denselben `_win_start`/`_win_end` wie `thunder_day_token` -- eine
+    # zweite, unabhaengige Fensterauflösung waere genau die Fehlerklasse aus
+    # #1653/#1498 (Stufe aus dem einen, Herkunft aus dem anderen Fenster,
+    # Spec AC-9). Der Nachtteil bekommt bewusst KEINE Herkunft (AC-6).
+    from output.metric_format import thunder_signal_label, union_of_max_carriers
+
+    _signal_rows = stage.get("hourly_thunder_signals") or ()
+    _day_carriers = union_of_max_carriers(
+        (stufe, traeger) for stunde, stufe, traeger in _signal_rows
+        if hour_in_window(stunde, _win_start, _win_end)
+    )
+    thunder_day_origin = (
+        ", ".join(thunder_signal_label(s) for s in _day_carriers)
+        if _day_carriers else None
+    )
 
     return {
         "temp_str": temp_str,
@@ -1039,6 +1055,8 @@ def format_trend_tokens(stage: dict) -> dict:
         # Issue #1653: Tag/Nacht getrennt (additiv)
         "thunder_day_token": thunder_day_token,
         "thunder_night_token": thunder_night_token,
+        # Issue #1680 S5a: fertiger Herkunfts-Zusatz des Tagesteils (oder None)
+        "thunder_day_origin": thunder_day_origin,
     }
 
 

--- a/src/output/renderers/email/outlook.py
+++ b/src/output/renderers/email/outlook.py
@@ -235,6 +235,11 @@ def render_outlook_table(
         _d = _thunder_token_parts(d_tok)
         if _d:
             day_part = f"{_d[0]} @{_d[1]}{_d[2]}"
+            # Issue #1680 S5a: die tragende Zutat unmittelbar hinter der
+            # Uhrzeit des Tagesteils -- vor Nacht- und Hagel-Zusatz (AC-1/AC-5).
+            _origin = tokens.get("thunder_day_origin")
+            if _origin:
+                day_part += f" · {_origin}"
         elif not (stage.get("hourly_thunder") or ()) and thunder_level in (
             "LOW", "MED", "HIGH",
         ):
@@ -370,6 +375,12 @@ def render_outlook_plain(
         _dm = _thunder_token_parts(_d_tok)
         if _dm:
             thunder_word = f"⚡{_dm[0]}{_dm[2]}"
+            # Issue #1680 S5a: derselbe Zusatz wie in der HTML-Zelle, aus
+            # demselben Token -- der Klartext fuehrt wie bisher keine
+            # Tagesuhrzeit (AC-2).
+            _origin = tok.get("thunder_day_origin")
+            if _origin:
+                thunder_word += f" · {_origin}"
         elif stage.get("hourly_thunder"):
             # Stundenreihe da, im Tagesfenster aber kein Gewitter.
             thunder_word = _THUNDER_MAP["NONE"]["plain"]
@@ -460,6 +471,12 @@ def build_outlook_row(
     _hourly_wind: list = []
     _hourly_gust: list = []
     _hourly_thunder: list = []
+    # Issue #1680 S5a: die tragenden Zutaten je Stunde REICHEN nur durch --
+    # gefiltert und vereinigt wird erst in `format_trend_tokens()`, an
+    # derselben Stelle und mit demselben Fenster wie `thunder_day_token`
+    # (eine Fensterauflösung, nicht zwei; Spec AC-9).
+    _thunder_signals: list = []
+    _hat_signale = False
     for dp in points:
         lh = _lh(dp.ts, tz)
         if dp.precip_1h_mm is not None:
@@ -475,6 +492,12 @@ def build_outlook_row(
             _hourly_thunder.append(HourlyValue(
                 hour=lh, value=float(thunder_label_value(dp.thunder_level))
             ))
+            _signale = getattr(dp, "thunder_level_signals", None)
+            if _signale is not None:
+                _hat_signale = True
+            _thunder_signals.append(
+                (lh, dp.thunder_level, list(_signale or ()))
+            )
 
     row = dict(
         weekday=weekday,
@@ -514,6 +537,14 @@ def build_outlook_row(
         # (Compare, Bestandstests) erhalten ein zeichengleiches Row-Dict.
         "day_window_start_hour": day_window_start_hour,
         "day_window_end_hour": day_window_end_hour,
+        # Issue #1680 S5a: (Stunde, Stufe, Traegerliste) je Stunde mit
+        # Gewitterstufe. Steht bewusst im None-gefilterten `optional`-Block:
+        # fuehrt KEIN Punkt eine Traegerliste (Alt-Schnappschuss vor Scheibe 1,
+        # Bestandsfixturen), bleibt das Row-Dict zeichengleich (AC-8/AC-10,
+        # Paritaets-Test tests/tdd/test_trip_outlook_parity.py).
+        "hourly_thunder_signals": (
+            tuple(_thunder_signals) if _hat_signale else None
+        ),
     }
     row.update({k: v for k, v in optional.items() if v is not None})
 
@@ -527,9 +558,17 @@ def build_outlook_row(
         # Gewitter-Zelle des Ausblicks denselben Zusatz zeigt wie die
         # Uebersichtstabelle derselben Mail.
         _hail = getattr(summary, "hail_flag", None)
+        # Issue #1680 S5a (AC-11b): dieselbe Bauart wie der Hagel-Wert oben --
+        # die tragenden Zutaten reisen als Spalten-Eigenschaft mit. Quelle ist
+        # bewusst das TAGES-Aggregat `summary.thunder_level_max_signals`, also
+        # DIESELBE Rechnung wie die hier gezeigte Stufe (`col["field"]`), nicht
+        # das Tagesfenster -- eine Herkunft, die nicht zur gezeigten Stufe
+        # gehoert, waere der AC-12-Fehler aus Scheibe 1.
+        _signals = getattr(summary, "thunder_level_max_signals", None)
         row["cells"] = [
             format_outlook_value(
-                getattr(summary, col["field"], None), {**col, "hail": _hail},
+                getattr(summary, col["field"], None),
+                {**col, "hail": _hail, "signals": _signals},
             )
             for col in outlook_columns(metrics)
         ]

--- a/src/output/renderers/narrow.py
+++ b/src/output/renderers/narrow.py
@@ -589,6 +589,12 @@ def _outlook_lines(multi_day_trend: list[dict]) -> list[str]:
         nt = tok.get("thunder_night_token", "-")
         if dt != "-":
             thunder_part = f"⚡{dt}"
+            # Issue #1680 S5a: die tragende Zutat hinter der Tagesstufe --
+            # derselbe Token wie in HTML- und Klartext-Mail (AC-3). Ein
+            # Zeilenumbruch auf _TG_PROSE_WIDTH ist hinnehmbar (Wort-Umbruch).
+            _origin = tok.get("thunder_day_origin")
+            if _origin:
+                thunder_part += f" · {_origin}"
         elif stage.get("hourly_thunder"):
             thunder_part = _THUNDER_MAP["NONE"]["plain"]
         else:

--- a/tests/tdd/test_thunder_origin_outlook.py
+++ b/tests/tdd/test_thunder_origin_outlook.py
@@ -1,0 +1,744 @@
+"""TDD RED — Issue #1680 Scheibe 5a: Herkunft der Gewitterstufe im
+Mehrtages-Ausblick (Trip-Mail HTML + Klartext, Telegram-Trendblock,
+Compare-Ausblick).
+
+SPEC: docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md v1.1
+      (AC-1..AC-10, AC-11a, AC-11b, AC-12, AC-13 — 14 Tests)
+KONTEXT: docs/context/feat-1680-s5-ausblick-vorschau-herkunft.md
+
+RED-Ursache (heute gemessen): ``build_outlook_row()``
+(``src/output/renderers/email/outlook.py:463-477``) verengt die rohen
+``ForecastDataPoint``s selbst zu ``HourlyValue``-Tupeln und wirft dabei
+``dp.thunder_level_signals`` weg. ``format_trend_tokens()``
+(``email/helpers.py:1005-1020``) kann darum keinen Herkunfts-Token neben
+``thunder_day_token`` bilden, und die drei Ausblick-Renderer
+(``render_outlook_table``/``render_outlook_plain``/``narrow._outlook_lines``)
+zeigen die Stufe ohne die tragende Zutat: heute steht dort ``leicht @16``
+statt ``leicht @16 · CAPE``.
+
+PRUEFORT = WIRKORT. Alle Trip-ACs laufen ueber die ECHTE Renderkette bis zum
+zugestellten Text: ``TripReportFormatter.format_email()`` liefert
+``email_html``/``email_plain``/``telegram_bubbles``/``sms_text`` in EINEM
+Lauf; gemessen wird die Gewitter-ZELLE der Ausblick-Tabelle aus dem
+fertigen Mail-HTML (nicht der Rueckgabewert eines Bausteins). AC-11a und
+AC-11b laufen ueber die echte Vergleichsmail (``render_compare_html`` /
+``render_comparison_text``) — AC-11a ohne, AC-11b MIT gesetzter
+Metrik-Auswahl, weil der Ortsvergleich zwei voellig getrennte
+Ausblick-Renderpfade hat (Spec v1.1, "Am Code gemessen" Punkt 9).
+
+KEIN MOCK-THEATER. Stufen und Traegerlisten entstehen ausschliesslich ueber
+die ECHTE Fusion (``providers.thunder_enrichment._fuse_thunder_levels`` mit
+den geeichten Leitern aus ``app.model_registry``) — kein im Test getippter
+Stufenwert, keine getippte Schwelle. Einzige Laufzeit-Instrumentierung ist
+die SONDE in AC-12: dort werden die WERTE der Beschriftungstabelle
+``metric_format.THUNDER_SIGNAL_LABEL_DE`` voruebergehend durch eindeutige
+Marker ersetzt (in-place, mit Wiederherstellung in ``finally``) — die Spec
+verlangt fuer AC-12 ausdruecklich einen Sonden-Nachweis statt einer
+Wortsuche. Kein ``Mock``/``patch``/``MagicMock``.
+
+GEGENPROBEN. Jeder Abwesenheits-AC (AC-6, AC-7, AC-10, AC-12, AC-13) belegt
+an DERSELBEN Fixture zuerst, dass die Herkunft dort ueberhaupt entstuende —
+ohne diese Gegenprobe bewacht ein Abwesenheits-Test nichts (Muster S1-S4).
+Genau diese Gegenproben machen die Abwesenheits-Tests heute rot.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+# Pfadregel #1409: Pruefling relativ zur EIGENEN Testdatei aufloesen, nie ueber
+# den festen Hauptrepo-Pfad — sonst pruefte dieser Test aus dem Worktree die
+# unveraenderte Hauptrepo-Kopie und meldete falsches Gruen.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from bs4 import BeautifulSoup  # noqa: E402
+
+from app.day_window import resolve_configured_window  # noqa: E402
+from app.metric_catalog import build_default_display_config  # noqa: E402
+from app.model_registry import (  # noqa: E402
+    cape_ladder_thresholds_jkg, lpi_thresholds_jkg,
+)
+from app.models import (  # noqa: E402
+    ForecastDataPoint, ForecastMeta, GPXPoint, NormalizedTimeseries, Provider,
+    SegmentWeatherData, TripReportConfig, TripSegment,
+)
+from app.user import ComparisonResult, LocationResult, SavedLocation  # noqa: E402
+from output.renderers.compare_outlook_metric_ids import (  # noqa: E402
+    resolve_outlook_metrics,
+)
+from output.renderers.email.compare_html import render_compare_html  # noqa: E402
+from output.renderers.email.outlook import build_outlook_row  # noqa: E402
+from output.renderers.comparison import render_comparison_text  # noqa: E402
+from output.renderers.trip_report import TripReportFormatter  # noqa: E402
+from output.tokens.dto import HourlyValue  # noqa: E402
+from providers.thunder_enrichment import _fuse_thunder_levels  # noqa: E402
+from providers.thunder_routing import thunder_region_for  # noqa: E402
+from services.weather_metrics import (  # noqa: E402
+    WeatherMetricsService, summarize_points,
+)
+
+# Die VIER Zutaten der Fusion in ihrer deutschen Beschriftung
+# (``metric_format.THUNDER_SIGNAL_LABEL_DE``). Keine davon darf in SMS/
+# Premium-SMS auftauchen (AC-12).
+ALLE_ZUTATEN = ("Wettercode", "Blitzdichte", "CAPE", "Blitzpotenzial")
+
+_TZ = ZoneInfo("UTC")
+_LAT, _LON, _MODELL = 47.0, 12.0, "icon_d2"   # Gebiet DE_ALPEN
+_HEUTE = date(2026, 8, 20)     # Etappe des Briefings
+_MORGEN = date(2026, 8, 21)    # kuenftige Etappe = Ausblick-Zeile
+_WOCHENTAG = "Di"
+_AUSBLICK_UEBERSCHRIFT = "Nächste Etappen"
+_COMPARE_UEBERSCHRIFT = "3-Tages-Ausblick"
+
+
+# ---------------------------------------------------------------------------
+# Fixture-Bausteine: Rohwerte rein, ECHTE Rechnung raus
+# ---------------------------------------------------------------------------
+
+def _dp(h: int, *, tag: date = _MORGEN, cape=None, cin=None, lpi=None,
+        dichte=None, hail=None) -> ForecastDataPoint:
+    """Ein Stundenpunkt mit ROHWERTEN — Stufe und Traeger rechnet die Fusion.
+
+    Geeichte Leitern der Testregion DE_ALPEN/icon_d2 (gemessen, nicht
+    geraten): CAPE 300/750/1200 J/kg, LPI 1/30/50 J/kg, Blitzdichte
+    0.003/0.015/0.075 je km2. ``cin=5.0`` liegt im Band "schwacher Deckel"
+    (Betrag < 25) und laesst die CAPE-Leiter voll zaehlen.
+    """
+    return ForecastDataPoint(
+        ts=datetime(tag.year, tag.month, tag.day, h, 0, tzinfo=timezone.utc),
+        t2m_c=18.0, wind10m_kmh=10.0, gust_kmh=20.0, precip_1h_mm=0.2,
+        cloud_total_pct=40, humidity_pct=50, pop_pct=30,
+        cape_jkg=cape, convective_inhibition_jkg=cin,
+        lightning_potential_lpi_jkg=lpi, lightning_density_per_km2_3h=dichte,
+        hail_flag=hail,
+    )
+
+
+def _fusioniere(punkte: list[ForecastDataPoint]) -> list[ForecastDataPoint]:
+    """Wendet die ECHTE Fusion in-place an (setzt ``dp.thunder_level`` UND
+    ``dp.thunder_level_signals``) — keine im Test getippte Schwelle."""
+    region = thunder_region_for(_LAT, _LON)
+    _fuse_thunder_levels(
+        punkte, cape_ladder_thresholds_jkg(_MODELL, region),
+        lpi_thresholds_jkg(region),
+    )
+    return punkte
+
+
+def _ruhige_etappe() -> SegmentWeatherData:
+    """Die HEUTIGE Etappe des Briefings — bewusst GEWITTERFREI.
+
+    ``cape=200`` liegt unter der niedrigsten Sprosse (300 J/kg) und ergibt
+    ueber die echte Fusion ``ThunderLevel.NONE`` mit LEERER Traegerliste.
+    Damit ist der Ausblick der EINZIGE Ort der Mail, an dem eine
+    Zutat-Bezeichnung entstehen kann — sonst faerbte die Herkunft der
+    Stundentabelle aus Scheibe 4 die Gegenproben von AC-12/AC-13 gruen,
+    ohne dass diese Scheibe irgendetwas bewirkt haette.
+    """
+    punkte = _fusioniere([_dp(h, tag=_HEUTE, cape=200.0) for h in range(6, 18)])
+    reihe = NormalizedTimeseries(
+        meta=ForecastMeta(provider=Provider.OPENMETEO, model="test", grid_res_km=1.0),
+        data=punkte,
+    )
+    seg = TripSegment(
+        segment_id=1,
+        start_point=GPXPoint(lat=_LAT, lon=_LON, elevation_m=1000.0),
+        end_point=GPXPoint(lat=_LAT + 0.1, lon=_LON + 0.1, elevation_m=1200.0),
+        start_time=datetime(_HEUTE.year, _HEUTE.month, _HEUTE.day, 6, 0, tzinfo=timezone.utc),
+        end_time=datetime(_HEUTE.year, _HEUTE.month, _HEUTE.day, 17, 0, tzinfo=timezone.utc),
+        duration_hours=11.0, distance_km=10.0, ascent_m=500.0, descent_m=200.0,
+    )
+    return SegmentWeatherData(
+        segment=seg, timeseries=reihe,
+        aggregated=WeatherMetricsService().compute_basis_metrics(reihe),
+        fetched_at=datetime.now(timezone.utc), provider="openmeteo",
+    )
+
+
+def _ausblick_zeile(punkte: list[ForecastDataPoint], *,
+                    report_config: TripReportConfig | None = None,
+                    traeger_verwerfen: bool = False) -> dict:
+    """Eine Ausblick-Zeile GENAU so, wie der Zeitplaner sie baut.
+
+    Wortgleich zu ``trip_report_scheduler._build_multi_day_trend()``
+    (``:2064-2081``): Tagesfenster EINMAL ueber ``resolve_configured_window()``
+    aus ``trip.report_config`` aufloesen und an ``build_outlook_row()``
+    durchreichen, danach ``name`` ergaenzen.
+
+    ``traeger_verwerfen=True`` bildet einen aufgezeichneten Schnappschuss VOR
+    Scheibe 1 nach: die Stufe steht am Datenpunkt, die Traegerliste fehlt
+    (AC-10).
+    """
+    punkte = _fusioniere(punkte)
+    if traeger_verwerfen:
+        for p in punkte:
+            p.thunder_level_signals = None
+    win_start, win_end = resolve_configured_window(
+        getattr(report_config, "day_window_start_hour", None),
+        getattr(report_config, "day_window_end_hour", None),
+    )
+    zeile = build_outlook_row(
+        summarize_points(punkte), punkte, _WOCHENTAG, _TZ,
+        day_window_start_hour=win_start, day_window_end_hour=win_end,
+    )
+    zeile["name"] = "Etappe B"
+    return zeile
+
+
+def _mail(zeilen: list[dict], *, report_config: TripReportConfig | None = None):
+    """Das ECHTE Trip-Briefing (HTML + Klartext + SMS + Telegram-Bubbles)
+    ueber den produktiven Formatierer — Pruefort = Wirkort."""
+    return TripReportFormatter().format_email(
+        [_ruhige_etappe()], "Test-Trip", "evening",
+        display_config=build_default_display_config(), tz=_TZ,
+        stage_name="Etappe A", multi_day_trend=zeilen,
+        report_config=report_config,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Messsonden auf der ZUGESTELLTEN Ausgabe
+# ---------------------------------------------------------------------------
+
+def _gew_zelle(html: str, kopf: str = "Gew") -> str:
+    """Der Text der Gewitter-Zelle der Ausblick-Tabelle aus fertigem Mail-HTML.
+
+    Die Ausblick-Tabelle ist die EINZIGE Tabelle der Mail mit der Kopfzelle
+    "Tag" — daran wird die Flaeche erkannt, nicht an einer Faehigkeit oder
+    einem Inhalt, der sich mit dieser Scheibe aendert. Die Spalte wird
+    anschliessend ueber ihren Kopf gefunden, nicht ueber einen festen Index —
+    eine spaeter eingeschobene Spalte darf diesen Test nicht still
+    verschieben.
+
+    ``kopf`` ist die Beschriftung der Gewitter-Spalte: im festen
+    Sieben-Spalten-Ausblick "Gew" (Trip und Compare-Altbestand), bei gesetzter
+    Metrik-Auswahl der Katalogname "Gewitter" (``outlook_columns()``, AC-11b).
+    """
+    suppe = BeautifulSoup(html, "html.parser")
+    tabellen = [
+        t for t in suppe.find_all("table")
+        if {"Tag", kopf} <= {th.get_text(strip=True) for th in t.find_all("th")}
+    ]
+    assert len(tabellen) == 1, (
+        f"Erwartet genau EINE Ausblick-Tabelle mit den Kopfzellen 'Tag' und "
+        f"{kopf!r}, gefunden: {len(tabellen)}")
+    tabelle = tabellen[0]
+    spalte = [th.get_text(strip=True) for th in tabelle.find_all("th")].index(kopf)
+    zeilen = tabelle.find("tbody").find_all("tr")
+    assert len(zeilen) == 1, (
+        f"Erwartet genau EINE Ausblick-Datenzeile, gefunden: {len(zeilen)}")
+    return [td.get_text(strip=True) for td in zeilen[0].find_all("td")][spalte]
+
+
+def _klartext_ausblick_zeile(text: str, ueberschrift: str = _AUSBLICK_UEBERSCHRIFT) -> str:
+    """Die Ausblick-Zeile aus dem Klartext-Block der zugestellten Mail."""
+    assert ueberschrift in text, (
+        f"Klartext-Ausblick '{ueberschrift}' fehlt in der Mail:\n{text}")
+    rest = text.split(ueberschrift, 1)[1].splitlines()
+    zeilen = []
+    for ln in rest:
+        if not ln.strip():
+            if zeilen:
+                break
+            continue
+        zeilen.append(ln)
+    assert len(zeilen) == 1, (
+        f"Erwartet genau EINE Ausblick-Zeile unter '{ueberschrift}', "
+        f"gefunden: {zeilen!r}")
+    return zeilen[0]
+
+
+def _telegram_ausblick(bericht) -> str:
+    """Der Telegram-Ausblick-Block als EINE Zeile.
+
+    ``_outlook_lines()`` bricht an Wortgrenzen auf ``_TG_PROSE_WIDTH = 56``
+    um (``narrow._wrap``). Das Wieder-Zusammenfuegen mit einem Leerzeichen
+    stellt den Originaltext exakt her, solange kein einzelnes Wort laenger
+    als 56 Zeichen ist — deshalb darf hier auf zusammenhaengende Teilstrings
+    geprueft werden, ohne AC-3 ("nicht zwingend zusammenhaengend") zu
+    verschaerfen.
+    """
+    bubbles = [b for b in bericht.telegram_bubbles if b.startswith("Ausblick")]
+    assert len(bubbles) == 1, (
+        f"Erwartet genau EINE Ausblick-Bubble, gefunden: {bubbles!r}")
+    return " ".join(bubbles[0].splitlines()[1:])
+
+
+def _compare_mail(punkte: list[ForecastDataPoint], *,
+                  outlook_metrics: list[dict] | None = None) -> tuple[str, str]:
+    """Die ECHTE Vergleichsmail (HTML + Klartext) fuer EINEN Ort mit Ausblick.
+
+    ``outlook_metrics=None`` = Altbestand ohne gespeicherte Spaltenauswahl
+    (Token-Pfad, AC-11a); eine gesetzte Auswahl geht in den Metrik-Zweig
+    (AC-11b). Die Auswahl laeuft durch den produktiven Aufloeser
+    ``resolve_outlook_metrics()``, nicht als handgetipptes Dict.
+    """
+    punkte = _fusioniere(punkte)
+    ort = LocationResult(
+        location=SavedLocation(id="ort-a", name="Ort A", lat=_LAT, lon=_LON,
+                               elevation_m=1000, timezone="UTC"),
+        score=50, hourly_data=punkte, outlook_hourly_data=punkte,
+    )
+    ergebnis = ComparisonResult(
+        locations=[ort], time_window=(0, 23), target_date=_MORGEN,
+        created_at=datetime(2026, 8, 20, 4, 1),
+    )
+    return (
+        render_compare_html(ergebnis, outlook_enabled=True,
+                            outlook_metrics=outlook_metrics),
+        render_comparison_text(ergebnis, outlook_enabled=True,
+                               outlook_metrics=outlook_metrics),
+    )
+
+
+def _ohne_zeitstempel(text: str) -> str:
+    """Blendet die einzige laufzeitabhaengige Zeile der Kompakt-Mail aus."""
+    return "\n".join(
+        ln for ln in text.splitlines() if not ln.startswith("Generated:")
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-1 bis AC-5: der Wortlaut in den drei Kanaelen
+# ---------------------------------------------------------------------------
+
+def test_ac1_html_ausblickzelle_nennt_die_tragende_zutat():
+    """AC-1: Given eine kuenftige Etappe, deren Tages-Gewitterstufe im
+    Tagesfenster von genau einer Zutat getragen wird / When die
+    HTML-Ausblick-Tabelle der Trip-Vollmail gerendert wird / Then steht in
+    der Gewitter-Spalte dieser Zeile die Stufe mit Uhrzeit, gefolgt von
+    " · " und der deutschen Bezeichnung der Zutat (z. B. "leicht @16 · CAPE").
+
+    Exakte Gleichheit statt ``in``: die Herkunft muss HINTER der Uhrzeit
+    stehen (Pflicht-Mutation (f) der Spec haengt sie davor).
+    """
+    bericht = _mail([_ausblick_zeile([_dp(16, cape=400.0, cin=5.0)])])
+    zelle = _gew_zelle(bericht.email_html)
+    assert zelle == "leicht @16 · CAPE", (
+        f"Die Gewitter-Zelle des HTML-Ausblicks muss die tragende Zutat "
+        f"hinter der Uhrzeit nennen. Erwartet 'leicht @16 · CAPE', "
+        f"erhalten: {zelle!r}")
+
+
+def test_ac2_klartext_ausblick_traegt_denselben_zusatz():
+    """AC-2: Given dieselbe Etappe / When der Klartext-Ausblick derselben Mail
+    gerendert wird / Then traegt das Gewitterfeld denselben Zusatz im selben
+    Wortlaut ("⚡leicht · CAPE") — der Klartext fuehrt wie bisher keine
+    Tagesuhrzeit."""
+    bericht = _mail([_ausblick_zeile([_dp(16, cape=400.0, cin=5.0)])])
+    zeile = _klartext_ausblick_zeile(bericht.email_plain)
+    assert "⚡leicht · CAPE" in zeile, (
+        f"Der Klartext-Ausblick muss '⚡leicht · CAPE' zeigen (ohne "
+        f"Tagesuhrzeit, wie bisher): {zeile!r}")
+
+
+def test_ac3_telegram_trendblock_nennt_die_zutat():
+    """AC-3: Given dieselbe Etappe / When der Telegram-Trendblock gerendert
+    wird / Then nennt auch er die Zutat hinter der Tagesstufe. Der Inhalt muss
+    im selben Ausblick-Block stehen, nicht zwingend als zusammenhaengender
+    Teilstring — die Breite von 56 Zeichen darf umbrechen (deshalb wird der
+    Block vor der Pruefung wieder zusammengefuegt, s. ``_telegram_ausblick``)."""
+    bericht = _mail([_ausblick_zeile([_dp(16, cape=400.0, cin=5.0)])])
+    block = _telegram_ausblick(bericht)
+    assert "⚡leicht@16 · CAPE" in block, (
+        f"Der Telegram-Ausblick muss '⚡leicht@16 · CAPE' zeigen: {block!r}")
+
+
+def test_ac4_zwei_tragende_zutaten_werden_beide_genannt():
+    """AC-4: Given eine Etappe, deren Hoechststufe im Tagesfenster von ZWEI
+    Zutaten gleichzeitig getragen wird / When der Ausblick gerendert wird /
+    Then werden BEIDE Zutaten genannt, mit ", " verbunden (Auslegung (ii):
+    alle tragenden Signale, kein Gewinner gekuert). Reihenfolge = die von
+    ``union_of_max_carriers()`` gelieferte: dedupliziert, in Erstauftritts-
+    Reihenfolge ueber die betrachteten Stunden (Spec v1.1).
+
+    Zwei Fixturen, weil sie verschiedene Fehler fangen:
+    (a) EIN Punkt mit zwei Zutaten — Erstauftritt ist hier die Reihenfolge in
+        ``_signal_levels()``, also die Katalogreihenfolge: "CAPE,
+        Blitzpotenzial". Prueft Verbinder und Reihenfolge innerhalb einer
+        Stunde.
+    (b) ZWEI Punkte mit je EINER Zutat — Erstauftritt ist hier die ZEITLICHE
+        Reihenfolge: 15 Uhr (Blitzpotenzial) vor 16 Uhr (CAPE), also
+        "Blitzpotenzial, CAPE". Nur (b) faellt bei der Pflicht-Mutation (c)
+        der Spec ("union_of_max_carriers durch 'erste Traegerliste'
+        ersetzen"); bei (a) waere die erste Liste zufaellig schon die
+        Vereinigung.
+
+    Beide Erwartungen sind exakt statt reihenfolge-unempfindlich formuliert:
+    seit v1.1 legt die Spec die Reihenfolge fest, und eine festgelegte Regel
+    ohne Test ist keine Regel. Dass DIESELBEN zwei Zutaten je nach Verteilung
+    auf eine oder zwei Stunden in umgekehrter Reihenfolge erscheinen, ist die
+    ausdrueckliche Spec-Aussage ("bei einem einzelnen Punkt die
+    Katalogreihenfolge, ueber mehrere Stunden hinweg die zeitliche") — kein
+    Testartefakt.
+    """
+    zelle_a = _gew_zelle(_mail([
+        _ausblick_zeile([_dp(16, cape=1500.0, cin=5.0, lpi=60.0)])
+    ]).email_html)
+    assert zelle_a == "hoch @16 · CAPE, Blitzpotenzial", (
+        f"Beide Traeger der Hoechststufe muessen mit ', ' verbunden in "
+        f"Erstauftritts-Reihenfolge erscheinen — innerhalb EINER Stunde ist "
+        f"das die Katalogreihenfolge: {zelle_a!r}")
+
+    zelle_b = _gew_zelle(_mail([_ausblick_zeile(
+        [_dp(15, lpi=60.0), _dp(16, cape=1500.0, cin=5.0)]
+    )]).email_html)
+    assert zelle_b == "hoch @15 · Blitzpotenzial, CAPE", (
+        f"Tragen ZWEI Stunden des Tagesfensters die Hoechststufe ueber "
+        f"verschiedene Zutaten, muessen BEIDE erscheinen (Vereinigung, nicht "
+        f"die erste Liste) — in zeitlicher Erstauftritts-Reihenfolge: "
+        f"{zelle_b!r}")
+
+
+def test_ac5_herkunft_steht_vor_dem_hagel_zusatz():
+    """AC-5: Given eine Etappe mit Gewitter UND Hagel-Kennzeichen / When der
+    Ausblick gerendert wird / Then steht die Herkunft VOR dem Hagel-Zusatz,
+    und der Hagel-Zusatz bleibt wortgleich erhalten
+    ("leicht @16 · CAPE · Hagel: ja")."""
+    bericht = _mail([_ausblick_zeile([_dp(16, cape=400.0, cin=5.0, hail=True)])])
+    zelle = _gew_zelle(bericht.email_html)
+    assert zelle == "leicht @16 · CAPE · Hagel: ja", (
+        f"Die Herkunft gehoert zwischen Uhrzeit und Hagel-Zusatz, der Hagel-"
+        f"Zusatz bleibt wortgleich: {zelle!r}")
+    zeile = _klartext_ausblick_zeile(bericht.email_plain)
+    assert "⚡leicht · CAPE · Hagel: ja" in zeile, (
+        f"Dieselbe Reihenfolge im Klartext-Ausblick: {zeile!r}")
+
+
+# ---------------------------------------------------------------------------
+# AC-6 bis AC-8, AC-10: die Abwesenheits-Zusicherungen (je mit Gegenprobe)
+# ---------------------------------------------------------------------------
+
+def test_ac6_nachtteil_bleibt_ohne_herkunft():
+    """AC-6: Given eine Etappe mit Gewitter IM NACHTFENSTER / When der Ausblick
+    gerendert wird / Then traegt der Nachtteil KEINE Herkunft, und der
+    Nachtteil bleibt gegenueber heute zeichengleich.
+
+    Gegenprobe an DERSELBEN Fixture: dieselben Stundenpunkte, nur mit einem
+    Tagesfenster 0-3 statt 4-19 — dasselbe Gewitter liegt dann im Tagesteil
+    und die Herkunft erscheint sehr wohl. Ohne diese Gegenprobe waere der
+    Test auch dann gruen, wenn die Herkunft nirgends erschiene.
+    """
+    nacht = _gew_zelle(_mail([_ausblick_zeile([_dp(2, cape=400.0, cin=5.0)])]).email_html)
+    assert nacht == "nachts leicht @2", (
+        f"Der Nachtteil bleibt zeichengleich zu heute und traegt KEINE "
+        f"Herkunft: {nacht!r}")
+
+    tag = _gew_zelle(_mail([_ausblick_zeile(
+        [_dp(2, cape=400.0, cin=5.0)],
+        report_config=TripReportConfig(day_window_start_hour=0, day_window_end_hour=3),
+    )]).email_html)
+    assert tag == "leicht @2 · CAPE", (
+        f"Gegenprobe gescheitert: laege dasselbe Gewitter im Tagesfenster, "
+        f"MUESSTE die Herkunft erscheinen — sonst beweist der Nacht-Fall "
+        f"nichts: {tag!r}")
+
+
+def test_ac7_ohne_gewitter_bleibt_die_zelle_zeichengleich():
+    """AC-7: Given eine Etappe OHNE Gewitter im Tagesfenster / When der Ausblick
+    gerendert wird / Then enthaelt die Gewitterzelle WEDER eine
+    Zutat-Bezeichnung NOCH einen zusaetzlichen ·-Trenner — sie bleibt
+    zeichengleich zu heute ("–" bzw. "⚡–").
+
+    Gegenprobe an DERSELBEN Fixture: dieselbe Stunde, nur mit einem CAPE-Wert
+    ueber der niedrigsten Sprosse (400 statt 50 J/kg). ``cape=50`` erzeugt
+    ueber die echte Fusion ein ECHTES ``ThunderLevel.NONE`` mit leerer
+    Traegerliste — kein Python-``None``, das schon ein frueher Guard
+    abfinge.
+    """
+    ruhig = _mail([_ausblick_zeile([_dp(16, cape=50.0)])])
+    zelle_ruhig = _gew_zelle(ruhig.email_html)
+    assert zelle_ruhig == "–", (
+        f"Ohne Gewitter im Tagesfenster bleibt die Zelle zeichengleich '–' "
+        f"— kein Zutat-Name, kein zusaetzliches '·': {zelle_ruhig!r}")
+    zeile_ruhig = _klartext_ausblick_zeile(ruhig.email_plain)
+    assert zeile_ruhig.rstrip().endswith("⚡–"), (
+        f"Der Klartext-Ausblick bleibt zeichengleich '⚡–': {zeile_ruhig!r}")
+
+    laut = _gew_zelle(_mail([_ausblick_zeile([_dp(16, cape=400.0, cin=5.0)])]).email_html)
+    assert laut == "leicht @16 · CAPE", (
+        f"Gegenprobe gescheitert: mit erreichter Stufe MUSS die Herkunft "
+        f"erscheinen, sonst beweist die ruhige Zelle nichts: {laut!r}")
+
+
+def test_ac8_alt_aufrufer_zeilen_bleiben_byte_identisch():
+    """AC-8: Given Ausblick-Zeilen, die KEINE Traegerinformation fuehren
+    (Alt-Aufrufer, aufgezeichnete Fixtures) / When HTML- und Klartext-Ausblick
+    gerendert werden / Then ist die Ausgabe byte-identisch zu heute.
+
+    Die hier gebaute Zeile ist ein Alt-Aufrufer-Dict in genau der Gestalt der
+    aufgezeichneten Golden-Fixturen unter
+    ``tests/fixtures/outlook_trip_parity/`` (Zeilenbau ``parity_rows()``):
+    feste Schluessel, ``hourly_thunder`` als reine ``HourlyValue``-Tupel,
+    KEINE Traegerdaten. Weil diese Fixturen keine Traeger fuehren, MUSS die
+    Ausgabe zeichengleich bleiben — der unveraenderte Bestandswaechter
+    ``tests/tdd/test_trip_outlook_parity.py`` (heute gruen, gemessen) ist der
+    formale Nachweis und darf weder angefasst noch neu erzeugt werden. Hier
+    wird nur die Verhaltensseite geprueft: keine Zutat, kein zusaetzliches
+    ``·``.
+
+    Wirksamkeits-Gegenprobe: dieselbe Stunde ueber die echte Kette (MIT
+    Traegern) zeigt die Herkunft sehr wohl.
+    """
+    alt_zeile = dict(
+        weekday=_WOCHENTAG, name="Etappe B", note=None,
+        temp_lo=9, temp_hi=21, precip_mm=2.5, wind_dir="W", wind_kmh=18,
+        thunder="MED", rain_probability_pct=55, confidence_pct=82,
+        hourly_precip=(HourlyValue(hour=14, value=2.1),),
+        hourly_wind=(HourlyValue(hour=15, value=18.0),),
+        hourly_gust=(HourlyValue(hour=15, value=44.0),),
+        hourly_thunder=(HourlyValue(hour=16, value=2.0),),
+    )
+    alt = _mail([alt_zeile])
+    zelle_alt = _gew_zelle(alt.email_html)
+    assert zelle_alt == "mittel @16", (
+        f"Eine Zeile ohne Traegerinformation bleibt zeichengleich zu heute: "
+        f"{zelle_alt!r}")
+    zeile_alt = _klartext_ausblick_zeile(alt.email_plain)
+    for zutat in ALLE_ZUTATEN:
+        assert zutat not in zeile_alt, (
+            f"Alt-Aufrufer-Zeile darf keine Zutat '{zutat}' zeigen: {zeile_alt!r}")
+
+    neu = _gew_zelle(_mail([_ausblick_zeile([_dp(16, cape=400.0, cin=5.0)])]).email_html)
+    assert neu == "leicht @16 · CAPE", (
+        f"Gegenprobe gescheitert: eine Zeile MIT Traegern MUSS die Herkunft "
+        f"zeigen, sonst beweist die Alt-Zeile nichts: {neu!r}")
+
+
+def test_ac10_stufe_ohne_traegerliste_bleibt_ohne_herkunft():
+    """AC-10: Given eine Etappe, deren Wetterpunkte eine Gewitterstufe tragen,
+    fuer die KEINE Traegerliste vorliegt (aufgezeichneter Schnappschuss vor
+    Scheibe 1) / When der Ausblick gerendert wird / Then erscheint die Stufe
+    OHNE Herkunft — nie eine Herkunft, die nicht zur gezeigten Stufe gehoert
+    (AC-12-Regel aus Scheibe 1).
+
+    Gegenprobe an DERSELBEN Fixture: dieselben Stundenpunkte MIT ihrer
+    Traegerliste zeigen die Herkunft sehr wohl.
+    """
+    ohne = _gew_zelle(_mail([_ausblick_zeile(
+        [_dp(16, cape=400.0, cin=5.0)], traeger_verwerfen=True,
+    )]).email_html)
+    assert ohne == "leicht @16", (
+        f"Ohne Traegerliste erscheint die Stufe unveraendert und OHNE "
+        f"Herkunfts-Zusatz: {ohne!r}")
+
+    mit = _gew_zelle(_mail([_ausblick_zeile([_dp(16, cape=400.0, cin=5.0)])]).email_html)
+    assert mit == "leicht @16 · CAPE", (
+        f"Gegenprobe gescheitert: mit Traegerliste MUSS die Herkunft "
+        f"erscheinen, sonst beweist der Alt-Schnappschuss nichts: {mit!r}")
+
+
+# ---------------------------------------------------------------------------
+# AC-9: EINE Fensterauflösung fuer Stufe UND Herkunft
+# ---------------------------------------------------------------------------
+
+def test_ac9_stufe_und_herkunft_stammen_aus_demselben_tagesfenster():
+    """AC-9: Given ein Trip mit einem vom Standard ABWEICHENDEN Tagesfenster
+    (nicht 4-19 Uhr) und einem Gewitter, das nur in diesem abweichenden
+    Fenster liegt / When der Ausblick gerendert wird / Then stammen angezeigte
+    Stufe UND angezeigte Herkunft aus demselben Fenster — die Herkunft wird an
+    derselben Stelle und mit demselben Fensterwert ermittelt wie
+    ``thunder_day_token``.
+
+    Die Fixture traegt ZWEI Stunden mit derselben Hoechststufe (hoch), aber
+    verschiedenen Zutaten: 10 Uhr ueber die Blitzdichte, 21 Uhr ueber CAPE.
+    Damit ist die Fensterfrage entscheidbar statt zufaellig richtig:
+    - Fenster 20-23 → Tagesteil 21 Uhr, Herkunft CAPE, "Blitzdichte" darf
+      NICHT erscheinen (faellt bei Pflicht-Mutation (b), Fensterfilterung
+      entfernt: dann stuende dort "CAPE, Blitzdichte").
+    - Standardfenster 4-19 an DENSELBEN Punkten → Tagesteil 10 Uhr, Herkunft
+      Blitzdichte. Beide Faelle zusammen belegen, dass Stufe und Herkunft
+      MITEINANDER umschalten.
+    Der Nachtteil traegt in beiden Faellen keine Herkunft (AC-6).
+    """
+    abweichend = _gew_zelle(_mail([_ausblick_zeile(
+        [_dp(10, dichte=0.1), _dp(21, cape=1500.0, cin=5.0)],
+        report_config=TripReportConfig(day_window_start_hour=20, day_window_end_hour=23),
+    )]).email_html)
+    assert abweichend == "hoch @21 · CAPE · nachts hoch @10", (
+        f"Im abweichenden Fenster 20-23 muessen Stufe UND Herkunft aus der "
+        f"21-Uhr-Stunde stammen (CAPE), nicht aus der 10-Uhr-Stunde "
+        f"(Blitzdichte): {abweichend!r}")
+
+    standard = _gew_zelle(_mail([_ausblick_zeile(
+        [_dp(10, dichte=0.1), _dp(21, cape=1500.0, cin=5.0)],
+    )]).email_html)
+    assert standard == "hoch @10 · Blitzdichte · nachts hoch @21", (
+        f"Im Standardfenster 4-19 muessen Stufe UND Herkunft aus der "
+        f"10-Uhr-Stunde stammen: {standard!r}")
+
+
+# ---------------------------------------------------------------------------
+# AC-11a/AC-11b: der Ortsvergleich hat ZWEI Ausblick-Renderpfade
+# ---------------------------------------------------------------------------
+
+def test_ac11a_compare_ausblick_ohne_metrikauswahl_erbt_die_herkunft():
+    """AC-11a: Given einen Ortsvergleich OHNE Metrik-Auswahl fuer den Ausblick
+    (Altbestand, ``outlook_metrics`` fehlt) / When dessen Ausblick-Tabelle
+    gerendert wird / Then nennt auch sie die Herkunft ueber denselben
+    Token-Pfad wie der Trip — der geteilte Zeilenbau wird NICHT trip-seitig
+    abgeschaltet (Trip/Compare-Teilungs-Invariante).
+
+    Geprueft wird die ECHTE Vergleichsmail (``render_compare_html`` /
+    ``render_comparison_text``), nicht der Baustein: "CAPE" steht in dieser
+    Mail seit S1/S3 auch in der Uebersicht und in der Stundentabelle, deshalb
+    wird gezielt die Gewitter-ZELLE des Ausblick-Blocks bzw. die Zeile unter
+    "3-Tages-Ausblick" gemessen.
+    """
+    html, text = _compare_mail([_dp(16, cape=400.0, cin=5.0)])
+    zelle = _gew_zelle(html)
+    assert zelle == "leicht @16 · CAPE", (
+        f"Der Compare-Ausblick erbt den geteilten Zeilenbau und muss die "
+        f"Herkunft ebenso nennen: {zelle!r}")
+    zeile = _klartext_ausblick_zeile(text, _COMPARE_UEBERSCHRIFT)
+    assert "⚡leicht · CAPE" in zeile, (
+        f"Auch der Klartext-Ausblick der Vergleichsmail muss die Herkunft "
+        f"nennen: {zeile!r}")
+
+
+def test_ac11b_compare_ausblick_mit_metrikauswahl_nennt_die_herkunft():
+    """AC-11b: Given einen Ortsvergleich MIT gesetzter Metrik-Auswahl (der
+    Regelfall jedes ueber die Oberflaeche gepflegten Vergleichs) und einer
+    gewaehlten Gewitter-Spalte / When dessen Ausblick-Tabelle gerendert wird /
+    Then nennt die Gewitter-Zelle ebenfalls die tragende Zutat. Die Herkunft
+    stammt dort aus DERSELBEN Rechnung wie die dort gezeigte Stufe (dem
+    Tages-Aggregat ``summarize_points()``), nicht aus dem Tagesfenster — beide
+    gehoeren zusammen (AC-10-Regel). Nachweis in HTML UND Klartext.
+
+    Dieser Zweig umgeht den Token-Pfad vollstaendig: frueher Return
+    ``outlook.py:148``, ``continue`` ``outlook.py:342``; die Zelle entsteht in
+    ``format_outlook_value()`` → ``_fmt_thunder()``. Deshalb steht dort auch
+    KEINE ``@``-Uhrzeit — erwartet wird ``leicht · CAPE``, nicht
+    ``leicht @16 · CAPE``.
+
+    Zwei Fixturen, weil sie verschiedene Fehler fangen:
+    (a) EINE Stunde mit CAPE — Tages-Aggregat und Tagesfenster sind sich einig;
+        prueft Wortlaut und Klartext-Pfad.
+    (b) NACHT-Stunde ``hoch`` ueber CAPE + TAG-Stunde ``leicht`` ueber
+        Blitzdichte — Tages-Aggregat (``hoch``/CAPE) und Tagesfenster-Token
+        (``leicht``/Blitzdichte) sagen VERSCHIEDENES. Nur damit ist
+        entscheidbar, ob Stufe und Herkunft aus derselben Rechnung stammen:
+        wer hier den Token-Pfad-Traeger anhaengt, schreibt "hoch · Blitzdichte"
+        — eine Herkunft, die nicht zur gezeigten Stufe gehoert (genau der
+        AC-12-Fehler aus Scheibe 1).
+    """
+    auswahl = resolve_outlook_metrics([
+        {"metric_id": "temperature", "aggregation": "max"},
+        {"metric_id": "thunder", "aggregation": "max"},
+    ])
+    assert auswahl and len(auswahl) == 2, (
+        f"Die Auswahl muss durch den produktiven Aufloeser kommen und die "
+        f"Gewitter-Spalte enthalten: {auswahl!r}")
+
+    html_a, text_a = _compare_mail([_dp(16, cape=400.0, cin=5.0)],
+                                   outlook_metrics=auswahl)
+    zelle_a = _gew_zelle(html_a, kopf="Gewitter")
+    assert zelle_a == "leicht · CAPE", (
+        f"Auch der Metrik-Zweig des Compare-Ausblicks muss die tragende Zutat "
+        f"nennen (ohne Uhrzeit, wie dort ueblich): {zelle_a!r}")
+    zeile_a = _klartext_ausblick_zeile(text_a, _COMPARE_UEBERSCHRIFT)
+    assert "Gewitter leicht · CAPE" in zeile_a, (
+        f"Der Klartext-Ausblick des Metrik-Zweigs muss dieselbe Herkunft "
+        f"zeigen: {zeile_a!r}")
+
+    html_b, _ = _compare_mail(
+        [_dp(2, cape=1500.0, cin=5.0), _dp(16, dichte=0.005)],
+        outlook_metrics=auswahl,
+    )
+    zelle_b = _gew_zelle(html_b, kopf="Gewitter")
+    assert zelle_b == "hoch · CAPE", (
+        f"Stufe UND Herkunft muessen im Metrik-Zweig aus dem Tages-Aggregat "
+        f"stammen (hoch ueber CAPE aus der Nachtstunde), nicht aus dem "
+        f"Tagesfenster: {zelle_b!r}")
+    assert "Blitzdichte" not in zelle_b, (
+        f"Die Zutat der Tagesfenster-Stunde gehoert NICHT zur gezeigten "
+        f"Aggregat-Stufe und darf dort nicht erscheinen: {zelle_b!r}")
+
+
+# ---------------------------------------------------------------------------
+# AC-12/AC-13: die beiden bewusst ausgenommenen Ausgabewege
+# ---------------------------------------------------------------------------
+
+def test_ac12_sms_und_premium_sms_bleiben_ohne_herkunft():
+    """AC-12: Given einen Trip-Briefing-Versand ueber SMS bzw. Premium-SMS /
+    When der Text erzeugt wird / Then enthaelt er KEINE der vier
+    Zutat-Bezeichnungen. Nachweis per Sonde (Beschriftungsfunktion zur
+    Laufzeit markieren), nicht per Wortsuche — mit Gegenprobe, dass die Sonde
+    in E-Mail und Telegram anschlaegt.
+
+    Die Sonde ersetzt die WERTE von ``THUNDER_SIGNAL_LABEL_DE`` in-place durch
+    eindeutige Marker. In-place, weil ``thunder_signal_label()`` die Tabelle
+    zur AUFRUFZEIT liest — die Sonde wirkt damit unabhaengig davon, wie die
+    Implementierung die Funktion importiert. Wiederherstellung in ``finally``.
+
+    SMS und Premium-SMS teilen sich ``report.sms_text`` (ein Text, zwei
+    Transporte); geprueft wird zusaetzlich der tatsaechliche Rueckfall
+    ``sms_text or email_plain``.
+    """
+    from output import metric_format
+
+    sonde = "ZUTATSONDE"
+    original = dict(metric_format.THUNDER_SIGNAL_LABEL_DE)
+    try:
+        for schluessel in list(metric_format.THUNDER_SIGNAL_LABEL_DE):
+            metric_format.THUNDER_SIGNAL_LABEL_DE[schluessel] = f"{sonde}-{schluessel}"
+        bericht = _mail([_ausblick_zeile([_dp(16, cape=400.0, cin=5.0)])])
+
+        assert sonde in _gew_zelle(bericht.email_html), (
+            "Gegenprobe gescheitert: die Sonde muss in der HTML-Ausblick-"
+            "Zelle anschlagen, sonst beweist ihre Abwesenheit in der SMS "
+            f"nichts. Zelle: {_gew_zelle(bericht.email_html)!r}")
+        assert sonde in _telegram_ausblick(bericht), (
+            "Gegenprobe gescheitert: die Sonde muss im Telegram-Ausblick "
+            f"anschlagen: {_telegram_ausblick(bericht)!r}")
+
+        assert bericht.sms_text, (
+            "sms_text muss immer erzeugt werden — sonst greift der Rueckfall "
+            "`sms_text or email_plain` und die Herkunft koennte in die SMS "
+            "durchsickern")
+        zugestellt = bericht.sms_text or bericht.email_plain
+        assert sonde not in zugestellt, (
+            f"SMS/Premium-SMS sind bewusst OHNE Herkunft — die Sonde darf "
+            f"dort NICHT anschlagen: {zugestellt!r}")
+        for zutat in ALLE_ZUTATEN:
+            assert zutat not in zugestellt, (
+                f"'{zutat}' darf im SMS-Text nicht vorkommen: {zugestellt!r}")
+    finally:
+        metric_format.THUNDER_SIGNAL_LABEL_DE.clear()
+        metric_format.THUNDER_SIGNAL_LABEL_DE.update(original)
+
+
+def test_ac13_kompaktmail_bleibt_zeichengleich():
+    """AC-13: Given ein Trip-Briefing im KOMPAKTFORMAT / When die Mail
+    gerendert wird / Then bleibt deren Ausblick-Block ("Naechste Etappen")
+    zeichengleich zu heute — er liest ``thunder_plain`` und wird von dieser
+    Scheibe nicht beruehrt.
+
+    "Zeichengleich zu heute" wird als Unempfindlichkeit gegen die
+    Traegerinformation gemessen: dieselbe Etappe einmal MIT und einmal OHNE
+    Traegerliste muss denselben Kompakttext ergeben (bis auf die
+    laufzeitabhaengige "Generated:"-Zeile).
+
+    Gegenprobe an DERSELBEN Fixture: die VOLLMAIL derselben Zeile zeigt die
+    Herkunft sehr wohl — ohne diese Gegenprobe waere der Test auch dann
+    gruen, wenn die Scheibe gar nichts bewirkte.
+    """
+    kompakt = TripReportConfig(email_format="compact")
+    mit = _mail([_ausblick_zeile([_dp(16, cape=400.0, cin=5.0)])],
+                report_config=kompakt).email_plain
+    ohne = _mail([_ausblick_zeile([_dp(16, cape=400.0, cin=5.0)],
+                                  traeger_verwerfen=True)],
+                 report_config=kompakt).email_plain
+    assert _ohne_zeitstempel(mit) == _ohne_zeitstempel(ohne), (
+        "Die Kompakt-Mail darf sich durch die Traegerinformation NICHT "
+        f"aendern.\nMIT Traegern:\n{mit}\nOHNE Traeger:\n{ohne}")
+    for zutat in ALLE_ZUTATEN:
+        assert zutat not in mit, (
+            f"Die Kompakt-Mail darf keine Zutat '{zutat}' zeigen:\n{mit}")
+
+    voll = _gew_zelle(_mail([_ausblick_zeile([_dp(16, cape=400.0, cin=5.0)])]).email_html)
+    assert voll == "leicht @16 · CAPE", (
+        f"Gegenprobe gescheitert: die Vollmail DERSELBEN Etappe MUSS die "
+        f"Herkunft zeigen, sonst beweist die Kompakt-Mail nichts: {voll!r}")


### PR DESCRIPTION
Die Ausblick-Tabelle „Nächste Etappen" nennt jetzt neben der Tages-Gewitterstufe die tragende Zutat: `leicht @16 · CAPE`.

Das wiegt genau hier schwer: Der Ausblick zeigt **drei Tage an drei Orten untereinander** — Stufen aus verschiedenen Gebieten und Modellen direkt nebeneinander. Ohne Herkunftsangabe suggeriert das eine Vergleichbarkeit, die nicht besteht (Issue-Begründung, Gesamtkonzept 4/4.1).

| Fall | HTML-Zelle | Klartext | Telegram |
|---|---|---|---|
| nur Tag | `leicht @16 · CAPE` | `⚡leicht · CAPE` | `⚡leicht@16 · CAPE` |
| Tag + Nacht | `leicht @16 · CAPE · nachts hoch @0` | dito | dito |
| zwei Zutaten | `leicht @16 · CAPE, Blitzdichte` | dito | dito |
| kein Gewitter | `–` unverändert | `⚡–` unverändert | unverändert |

Ohne Herkunft bleiben bewusst: **SMS/Premium-SMS** (erreichen den Ausblick strukturell nicht), **Kompaktformat** (liest einen anderen Token und faltet nach ASCII) und der **Nachtteil**.

## Die Begründung der Vorgängerscheiben hielt der Messung nicht stand

S1–S4 reichten weiter, der Ausblick sei blockiert, weil `aggregate_stage()` erst angeschlossen werden müsse. Gemessen:

- Die **angezeigte** Stufe kommt aus den Stundenproben im Tagesfenster, nicht aus dem Aggregat. Dessen Wert speist nur einen Notnagel-Zweig.
- Dieser Zweig ist in **beiden** Produktivpfaden unerreichbar: Nur Segmente mit `has_error=False` gehen ins Aggregat, und die einzige solche Konstruktion (`segment_weather.py:283`) trägt **immer** eine Zeitreihe; beide Seiten filtern zudem mit derselben Bedingung. Ein Dispatch-Zweig hätte weiterhin keinen Verbraucher — Known Limitation 1 bleibt, ab jetzt mit Beweiskette statt Vermutung.
- Eine Änderung an `HourlyValue` ist **nicht** nötig: `build_outlook_row()` hat die rohen `ForecastDataPoint`s in der Hand und verengt sie selbst. Die Träger gingen nicht verloren, sie wurden weggeworfen.

## AC-9 ist strukturell erfüllt, nicht durch Disziplin

Der Herkunfts-Token entsteht in `format_trend_tokens()` an derselben Stelle und mit **denselben** Fenstergrenzen wie `thunder_day_token`. Zwei unabhängige Fensterauflösungen wären genau die Fehlerklasse aus #1653/#1498 — Stufe aus dem einen, Herkunft aus dem anderen Fenster.

## Ein Kriterium wäre wirkungslos gewesen — gefunden in der RED-Phase

Die erste, bereits freigegebene Spec-Fassung unterstellte, der Ortsvergleich erbe die Herkunft allein über den geteilten Zeilenbau. Bei gesetzter Metrik-Auswahl nimmt der Renderer aber einen früheren Ausstieg (`outlook.py:148`, `:342`) und baut die Zelle über `_fmt_thunder`. Entscheidend: Diese Auswahl ist nur leer, wenn das Feld **fehlt** — die Oberfläche schreibt es. Der Metrik-Zweig ist damit der **Regelfall**, nicht der Randfall.

AC-11 wäre grün getestet und für real gepflegte Vergleiche unsichtbar geblieben — dieselbe Fehlerklasse wie in S2 (Suffix am falschen Textzweig) und S3. Aufgeteilt in AC-11a/AC-11b, gelöst nach dem Hagel-Vorbild (#1475 Punkt 5b) über den dritten Parameter, den `_fmt_thunder` seit S1 hat, gespeist aus `summarize_points()` — derselben Rechnung wie die dort gezeigte Stufe.

## Nachweis

| Was | Ergebnis |
|---|---|
| Akzeptanzkriterien | 14, je ein Test durch die volle Renderkette bis zum fertigen Mail-Text |
| Tests | 14/14 grün, keine Deselektion, keine Mocks |
| Bestandswächter | 53 grün, **Golden-Dateien nicht angefasst** (Byte-Paritätswächter der Trip-Mail, Tag/Nacht-Golden, Compare-Ausblick, Tag/Nacht-Split) |
| Mutations-Gegenprobe | 11 (7 Pflicht + 4 eigene), jede fing genau den vorhergesagten Test |
| Adversary | 3 Runden, Verdict **VERIFIED** |
| Renderer-Gate #811 | Mode-Matrix grün (41) + `briefing_mail_validator` **und** `email_spec_validator` je Exit 0 gegen echt zugestellte Mails (Zustellweg per Log belegt, nicht per Erfolgsmeldung) |
| Regressionslauf | vollständig offline; die drei roten Tests per A/B gegen einen unveränderten `origin/main`-Klon als **vorbestehend** belegt |

Umfang: **+122/−3** in 4 Produktivdateien, davon rund die Hälfte Kommentar. Keine Änderung an `HourlyValue`, `aggregate_stage()` oder dem Zeitplaner.

## Adversary-Finding F001 (LOW, kein Verhaltensfehler)

AC-7 ist doppelt abgesichert — und meine Spec schrieb es der falschen Hälfte zu. `thunder_signal_carriers()` liefert bei Höchststufe `NONE` bereits eine leere Liste; die echte Kette erzeugt nie ein Paar aus „kein Gewitter" und gefüllten Trägern. Entfernt man die zweite Absicherung, bleibt die **gesamte** S5a-Suite grün — gefangen wird das nur von einem Bestandstest aus S2. Spec korrigiert.

Das ist in diesem Workflow das **dritte** Mal, dass eine Aussage über den eigenen Code der Messung nicht standhielt: nach der aus S1–S4 übernommenen Notiz und der ersten Fassung von AC-11.

## Bewusst offen

- **`aggregate_stage()`** bleibt unangeschlossen (Known Limitation 1, jetzt bewiesen).
- **Reihenfolge zweier Zutaten** wechselt je nach Stundenverteilung zwischen Katalog- und zeitlicher Folge — nutzersichtbar, kann wie eine Rangfolge wirken, ist aber nur die Uhrzeit. Eine Vereinheitlichung beträfe alle Verbraucher seit S2 → Sammel-Eintrag #1199.
- **Gewitter-Vorschau** folgt als **Scheibe 5b** und liest nur den hier entstandenen Zeilen-Vertrag. Vorgabe für 5b steht in der Spec: Der Herkunfts-Token darf nie ohne vorherige Prüfung des Stufen-Tokens gelesen werden.

Bezug: Epic #1419 Rang 4, Entscheidung E1. Vorgänger: #1780 (S1), #1797 (S2), #1806 (S3), #1817 (S4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
