### PR TITLE
fix(#1703 S7): Reihenfolge-Wächter jenseits E-Mail/Telegram-rich

### DIFF
--- a/docs/context/feat-1703-s7-reihenfolge-matrix.md
+++ b/docs/context/feat-1703-s7-reihenfolge-matrix.md
@@ -1,0 +1,226 @@
+# Context: feat-1703-s7-reihenfolge-matrix
+
+Epic #1703 Scheibe 7 — „Reihenfolge-Wächter jenseits E-Mail/Telegram-rich".
+Deckt Fläche 5 aus `docs/reference/metric_output_matrix.md` (Abschnitt 4.2).
+
+## Request Summary
+
+Die vom Nutzer eingestellte **Metrik-Reihenfolge** soll in denjenigen Ausgabeorten
+bewacht werden, die heute keinen katalog-vollständigen Reihenfolge-Wächter haben —
+Trip-Kompaktformen und die Compare-Übersichtstabelle über alle vier Kanäle.
+Zuschnitt für Compare bleibt auf die **Übersicht** beschränkt (Ausblick und
+Stundenverlauf haben nach ADR-0053 weiterhin keine Kanal-Ebene).
+
+## 🔴 Gemessener Ist-Stand — der Issue-Text schneidet zu breit zu
+
+Fläche 5 ist im Matrix-Dokument als „Reihenfolge in **allen** Kanälen außer E-Mail
+und Telegram-rich" beschrieben. **Gemessen trifft das nicht mehr zu.** Zwei der drei
+dort genannten Orte sind längst bewacht — dieselbe Prämissen-Falle wie bei Scheibe 2
+und Scheibe 5.
+
+| Ausgabeort | Reihenfolge bewacht? | Wächter | Deckung |
+|---|---|---|---|
+| Trip E-Mail-Vollformat | ✅ ja | `test_channel_metric_matrix.py` AC-13 | katalog-getrieben, alle 26 |
+| Trip Telegram-rich | ✅ ja | AC-14 | katalog-getrieben |
+| **Trip SMS-Kurzform** | ✅ **ja** | AC-15 (c) + AC-12 | katalog-getrieben — die in Fläche 5 genannte `tokens/builder.py`-Lücke ist mit #1677/#1660 B geschlossen (`_POSITION_SORTABLE_CATEGORIES`) |
+| Trip Kurz-E-Mail (Pillen) | ❌ **nein** | AC-S4-1/2/3 prüfen nur Auswahl/Abwahl | — |
+| Trip Telegram-Kurzform | ❌ **nein** | AC-S4-12/13/14 prüfen nur Auswahl/Abwahl | — |
+| Trip Kompakt-Zusammenfassung | ❌ **nein** | AC-S4-6..10 (feste Positivliste, 10 von 26) | — |
+| **Compare Übersicht** (HTML · Klartext · Telegram · SMS) | ⚠️ **teilweise** | `tests/unit/test_compare_metric_order.py` (#1359) | **4 fest getippte Metriken** von 25 wählbaren, **eine globale Liste** |
+| **Compare: je Kanal eigene Reihenfolge** | ❌ **gar nicht** | — | seit Scheibe 8 (2026-08-13) überhaupt erst möglich |
+
+Der Kopfkommentar von `test_channel_metric_matrix.py` (Zeile 20) nennt den
+SMS-Reihenfolge-Teil noch „RED" — das ist veraltet, der Test läuft grün. Die Zeile
+gehört als Nebenprodukt dieser Scheibe korrigiert.
+
+## Related Files
+
+| Datei | Relevanz |
+|------|-----------|
+| `tests/tdd/test_channel_metric_matrix.py` (3663 Z.) | Zielort der neuen Achse `AC-S7-*` — Option C aus #1514: kein zweites Register, kein neues Gate |
+| `tests/unit/test_compare_metric_order.py` | Bestandswächter #1359: HTML/Klartext/Telegram/SMS mit `ORDER_A`/`ORDER_B` (`cloud_avg`, `temp_max`, `sunny_hours`, `wind_max`) — Prinzip bewacht, Katalog-Deckung nicht |
+| `src/output/renderers/compare_metric_ids.py:200-241` | `resolve_channel_enabled_metrics()` (S8) — Docstring sagt ausdrücklich: „Die Reihenfolge des Ergebnisses ist die der KANAL-Liste" |
+| `src/services/report_config_resolver.py:206-208`, `:309` | `CompareRenderOptions.enabled_metrics_by_channel` — additiv neben `enabled_metrics` |
+| `src/services/scheduler_dispatch_service.py:439/505/509` | Versandpfad: E-Mail/Telegram/SMS lesen je ihre Kanal-Liste |
+| `src/services/compare_preview_service.py:65/70/105/122/186` | Vorschaupfad, dieselben drei Kanäle |
+| `src/output/renderers/comparison.py:143/704/995` | `render_comparison_text()`, `render_compare_telegram()`, `render_compare_sms()`; `_DAILY_PLAIN_ROWS`/`_PLAIN_ROWS` (`:70`/`:100`) sind handgeschriebene Tupel-Listen |
+| `src/output/renderers/email/compare_html.py:1526` | `render_compare_html()` — Zeilenfolge der Übersicht |
+| `src/output/renderers/email/compact.py:96`, `:162-181` | `render_compact()` → `resolve_trip_active_metrics()` → `build_metrics_summary_pills()` — Pillen-Reihenfolge |
+| `src/output/renderers/narrow.py:625` | `render_telegram_bubbles()` — Telegram-Kurzform |
+| `src/output/tokens/builder.py:47/78/112` | `PRIORITY`/`POSITIONAL`/`DEFAULTS` — die Trip-SMS-Sortierung, bereits über AC-15 gedeckt |
+| `docs/reference/metric_output_matrix.md` | Fläche 5 + Abschnitt 6 → Definition of Done: Zelle auf den neuen Wächter umtragen |
+
+## Existing Patterns
+
+- **Achsen-Muster der Scheiben 1–5:** neue AC-Gruppe `AC-S<n>-*` in
+  `test_channel_metric_matrix.py`, Soll-Menge aus dem Katalog **gerechnet**
+  (`get_compare_metric_catalog()` bzw. `get_all_metrics()`), nie getippt; Helper
+  bei Bedarf unter `tests/helpers/` (Vorbild `outlook_columns.py` aus S2).
+- **Ausnahme S6:** eigene Testdatei, wenn die „1 Zeile = 1 Metrik"-Matrix die
+  Struktur nicht ausdrücken kann (dort 1:n). Für Reihenfolge gilt das nicht —
+  paarweise Reihenfolge ist bereits das Muster von AC-13/14/15.
+- **Nachweis am Wirkort:** Ist-Werte aus dem echten Renderer-Aufruf
+  (`render_compare_email()` liefert HTML und Klartext in einem Zug), nicht aus
+  isolierten Hilfsfunktionen.
+- **Paarweise Reihenfolge:** dieselbe Metrik-MENGE in zwei Reihenfolgen rendern und
+  die Indizes vergleichen — schlägt sowohl bei „Reihenfolge ignoriert" als auch bei
+  „intern neu sortiert" an.
+
+## Dependencies
+
+- **Upstream:** `get_compare_metric_catalog()` / `get_all_metrics()` (Soll-Mengen),
+  `resolve_channel_enabled_metrics()`, `resolve_trip_active_metrics()`,
+  `CompareRenderOptions`.
+- **Downstream:** kein Produktivcode hängt am Wächter. Ein etwaiger *Fix* träfe die
+  Compare-Renderer (`comparison.py`, `compare_html.py`) bzw. die Trip-Kompaktformen
+  — beides nutzersichtbare Mail-/Telegram-/SMS-Ausgabe, damit Renderer-Commit-Gate
+  (#811) und Mail-Validator-Pflicht.
+
+## Existing Specs
+
+- `docs/specs/modules/compare_metric_order.md` — #1359, die Reihenfolge-Zusicherung
+  für den Ortsvergleich
+- `docs/specs/modules/fix_1677_sms_reihenfolge.md` — AC-13/14/15, der Trip-Teil
+- `docs/specs/modules/feat_1703_s8_compare_kanal_tabs.md` — die Kanal-Ebene, auf der
+  diese Scheibe aufsetzt
+- `docs/adr/0053-compare-kanal-eigene-metrikauswahl-uebersicht.md` — Zuschnitt:
+  nur Übersicht, Ausblick/Stundenverlauf bleiben global
+- `docs/adr/0050` — Metrik-Kaskade Regel 1/2 („Grundauswahl ist das MAXIMUM, ein
+  Kanal darf nur ABWÄHLEN")
+
+## Risks & Considerations
+
+1. **🔴 Wirkungslücken-Risiko (S8-Fehlerklasse).** `resolve_channel_enabled_metrics()`
+   *behauptet* im Docstring, die Ergebnis-Reihenfolge sei die der Kanal-Liste.
+   Ob die acht Aufrufstellen und die vier Renderer diese Reihenfolge tatsächlich bis
+   in die zugestellte Ausgabe tragen, ist **ungemessen**. In Scheibe 8 waren viermal
+   die reine Funktion getestet und die Aufrufstelle nicht. Leitfrage: *Ist die
+   Zusicherung dort geprüft, wo sie WIRKT?*
+2. **Prämissen-Risiko.** Bei S2 und S5 war der Issue-Zuschnitt falsch. Hier bereits
+   nachgewiesen: Trip-SMS ist entgegen der Flächenbeschreibung schon bewacht. Der
+   endgültige Zuschnitt gehört vor die ACs gemessen, nicht danach.
+3. **Möglicher Produktivcode-Fix.** Fläche 5 notiert: „Compare-Klartext nutzt die
+   Nutzer-Reihenfolge nur als Sichtbarkeitsfilter (#1356)". Ob das nach #1359 noch
+   gilt, ist offen — falls ja, ist es ein nutzersichtbarer Defekt und der Fix gehört
+   in die Scheibe (Muster S2/S6).
+4. **Compare-SMS und das Zeichenbudget.** Die Reihenfolge bestimmt dort, was bei
+   Kappung wegfällt — ein Reihenfolge-Fehler ist in der SMS ein *Inhalts*-Fehler.
+   Drei Grenzen beachten: 160/153/140 Zeichen.
+5. **Renderer-Commit-Gate #811.** Sobald eine Mail-Inhalts-Datei staged wird, sind
+   `test_issue_811_mode_matrix.py` **und** ein frischer `briefing_mail_validator.py`-
+   bzw. `email_spec_validator.py`-Lauf Pflicht.
+6. **Kein neues Gate.** Leitplanke des Epics: Erweiterung des budgetierten Gates
+   #1677 B, kein zweites Register, kein neues Prüfdatum.
+
+## Analysis
+
+### Type
+
+**Feature** (Wächter-Ausbau nach dem Muster der Scheiben 1–5) — mit **zwei
+Kandidaten für einen nutzersichtbaren Produktivcode-Fix**, beide unten belegt.
+
+### Am Code gemessen — die vier offenen Fragen aus dem Kontext
+
+**1. Compare-Klartext folgt der Nutzer-Reihenfolge.** Fläche 5 notiert „nutzt die
+Nutzer-Reihenfolge nur als Sichtbarkeitsfilter (#1356)" — das ist **veraltet**.
+`_ordered_rows()` (`comparison.py:126-140`) setzt sie seit #1359 um; die HTML-Seite
+tut dasselbe über `_visible_metrics()` (`compare_html.py:798`). Beide bauen die
+Zeilenliste generisch aus `enabled_metrics`, sind also strukturell katalog-fähig.
+
+**2. 🔴 Die Kurz-E-Mail verwirft die Reihenfolge — belegt.**
+`build_metrics_summary_pills()` (`email/helpers.py:1844`) kollabiert die geordnete
+Liste zu `ids_set = set(metric_ids)` und rendert ausdrücklich „in **catalog order**"
+(Docstring + Codekommentar `:1899`). Die im Editor eingestellte Reihenfolge kann den
+Pillen-Überblick der Kurz-E-Mail damit **strukturell nicht erreichen**. Kein Test
+bemerkt das: AC-S4-1/2/3 prüfen nur Auswahl und Abwahl.
+
+**3. 🔴 Altbestands-Reihenfolge divergiert zwischen HTML und Klartext derselben
+Compare-Mail — Kandidat, in RED zu belegen.** Bei `enabled_metrics=None` (Preset ohne
+gespeicherte Auswahl) behält jede Seite ihre eigene Quellcode-Reihenfolge:
+
+| Position | HTML (`CV2_METRICS`) | Klartext (`_PLAIN_ROWS`) |
+|---|---|---|
+| 1 | temp_max | temp_max |
+| 2 | wind_max | wind_max |
+| **3** | **precip_sum** | **temp_min** |
+| 4 | pop_max | gust_max |
+
+Beide Mengen sind identisch (25 Zeilen), nur die Ordnung nicht. Der Bestandswächter
+`test_plaintext_order_matches_html_order_in_same_mail` prüft die Parität ausschließlich
+mit **explizit gesetzter** `ORDER_A` — der Altbestandsfall läuft an ihm vorbei.
+
+**4. Trip-Telegram-Kurzübersicht und Compare-Telegram folgen der Reihenfolge, aber
+über zwei verschiedene Wege.** `render_telegram_bubbles()` iteriert die Kurzübersicht
+über `dc.get_enabled_metric_ids()` (`narrow.py:741`) — **nicht** über das
+`render_for_channel()`-Layout, das dieselbe Funktion zwei Zeilen vorher für die
+Tabellen-Bubbles baut. `render_compare_telegram()` (`comparison.py:729-731`) übernimmt
+`enabled_metrics` als `dedup_ids`, schickt sie aber durch
+`_channel_layout_for_metrics()` mit `max_table_cols = 7`: bei mehr als sieben Größen
+entscheidet die Reihenfolge, **welche** Metrik überhaupt erscheint. Ob das Layout die
+Nutzer-Reihenfolge dabei erhält oder nach eigener Priorität umsortiert, ist der
+eigentliche Prüfpunkt.
+
+### Affected Files (with changes)
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `tests/tdd/test_channel_metric_matrix.py` | MODIFY | Neue Achse `AC-S7-*`; zusätzlich Kopfkommentar Z. 20 korrigieren („RED" für AC-15c ist überholt) |
+| `tests/helpers/compare_order.py` | CREATE (evtl.) | Gerechnete Soll-Menge + Label-Auslese je Kanal, Vorbild `outlook_columns.py` (S2) |
+| `docs/specs/modules/fix_1703_s7_reihenfolge_matrix.md` | CREATE | Spec mit ACs |
+| `docs/reference/metric_output_matrix.md` | MODIFY | Fläche 5 + Abschnitt 6 umtragen (Definition of Done) — inkl. der beiden hier belegten Prämissen-Korrekturen |
+| `src/output/renderers/email/helpers.py` | MODIFY (**nur bei PO-Entscheidung**) | Pillen-Reihenfolge der Kurz-E-Mail |
+| `src/output/renderers/comparison.py` | MODIFY (**nur bei PO-Entscheidung**) | Altbestands-Reihenfolge an `CV2_METRICS` angleichen |
+
+### Scope Assessment
+
+- Dateien: 4 sicher, +2 bei Fix
+- Geschätzte LoC: Tests **+380/-15**, Produktivcode **0** (reine Charakterisierung)
+  bzw. **+15/-8** bei beiden Fixes
+- Risiko: **MEDIUM** — der Wächter selbst ist risikofrei; ein Fix ändert die
+  Zeilenfolge in zugestellter E-Mail und im Ortsvergleich, und in der Compare-SMS
+  entscheidet die Reihenfolge unter Zeichendruck über den *Inhalt*
+
+### Technical Approach
+
+Achse `AC-S7-*` in `tests/tdd/test_channel_metric_matrix.py` (Option C: kein zweites
+Register, kein neues Gate), gegliedert in drei Blöcke:
+
+1. **Compare-Übersicht × 4 Kanäle × Katalog** — Soll-Menge aus
+   `get_compare_metric_catalog()` **gerechnet**, paarweise Reihenfolge (dieselbe
+   MENGE in zwei Ordnungen, Indizes vergleichen) gegen die echten Renderer
+   `render_compare_email()` (HTML + Klartext in einem Aufruf), `render_compare_telegram()`,
+   `render_compare_sms()`. Ersetzt die vier getippten Metriken aus #1359 durch
+   Katalog-Deckung, ohne den Bestandstest anzufassen.
+2. **Kanalweise unterschiedliche Reihenfolge in EINER Sendung** — der Nachweis, den
+   Scheibe 8 für die *Auswahl* geführt hat (9/5/2 Metriken), jetzt für die *Ordnung*:
+   `enabled_metrics_by_channel` mit drei verschiedenen Reihenfolgen, geprüft an der
+   zugestellten Ausgabe je Kanal, nicht an `resolve_channel_enabled_metrics()`.
+3. **Trip-Kompaktformen** — Kurz-E-Mail-Pillen, Telegram-Kurzübersicht,
+   Kompakt-Zusammenfassung: Reihenfolge-Achse belegen oder als benannte, begründete
+   Ausnahme charakterisieren.
+
+**Kein neues Gate, kein neues Prüfdatum** (Epic-Leitplanke). Soll-Mengen gerechnet,
+nie getippt — mit der Einschränkung aus S2 F001: *Rechnen sichert Vollständigkeit,
+nie Zuordnung*; die Zuordnung braucht eine eigene Assertion.
+
+### Dependencies
+
+Upstream: `get_compare_metric_catalog()`, `resolve_channel_enabled_metrics()`,
+`resolve_trip_active_metrics()`, `CompareRenderOptions`.
+Downstream: kein Produktivcode hängt am Wächter. Ein Fix träfe Mail-Inhalts-Dateien →
+Renderer-Commit-Gate #811 (`test_issue_811_mode_matrix.py` + frischer Validator-Lauf).
+
+### Open Questions — für die Spec-Freigabe
+
+- [ ] **Kurz-E-Mail-Pillen (Befund 2): charakterisieren oder fixen?**
+      *Empfehlung: fixen.* Der Nutzer stellt je Kanal eine Reihenfolge ein; dass sie
+      in genau einem Ausgabeort verworfen wird, ist ein Bedienelement ohne Wirkung —
+      exakt die Fehlerklasse, gegen die dieses Epic gebaut wurde. Der Eingriff ist
+      klein (`set()` → geordnete Liste). Risiko: die Pillen-Reihenfolge ändert sich
+      für alle Trips, die eine eigene Ordnung gespeichert haben.
+- [ ] **Altbestands-Divergenz HTML/Klartext (Befund 3): charakterisieren oder fixen?**
+      *Empfehlung: erst in RED belegen, dann fixen*, indem `_PLAIN_ROWS` der
+      `CV2_METRICS`-Ordnung folgt. Betrifft nur Presets ohne gespeicherte Auswahl;
+      Presets mit Auswahl sind bereits konsistent. Gegenargument: die
+      `_PLAIN_ROWS`-Ordnung ist in `test_compare_metric_order.py` AC-7 ausdrücklich
+      als Altbestands-Standard **eingefroren** — ein Fix zieht diesen Bestandstest mit.

--- a/docs/reference/metric_output_matrix.md
+++ b/docs/reference/metric_output_matrix.md
@@ -268,7 +268,7 @@ Stundentabelle (AC-6, Charakterisierung).
 | # | Unbewachte Fläche | Ort | Prio | Bemerkung |
 |---|---|---|---|---|
 | 4 | Compare-Übersichtstabelle: **Zellwert** je Metrik | `compare_html.py:294`, `comparison.py:70/100` | 2 | ✅ Erledigt (2026-08-12, Epic #1703 Scheibe 5): Bei Nachmessung trug die pauschale Aussage „nur Zeilen-Existenz bewacht" nicht mehr — 15 der 25 `CV2_METRICS`-Zeilen hatten aus #1296/#1324/#1351/der Gewitter-Suite bereits Wert+Paritäts-Tests. Neuer Wächter `tests/tdd/test_channel_metric_matrix.py` AC-S5-1 (Soll-Menge 15+10=25, disjunkt), AC-S5-2 (die 10 verbleibenden Zeilen, HTML+Klartext gegen unabhängig gerechnete Werte über `render_compare_email()`), AC-S5-3 (Engine-Vorrang vor Live-Ableitung), AC-S5-4 (Formatierungs-Konsistenz `format_value()` vs. `CV2_METRICS`-`decimals`, 10 Felder einzeln), AC-S5-5 (Fehlzeichen-Divergenz HTML `—` vs. Klartext `-`, charakterisiert), AC-S5-6 (Abhängigkeits-Anker auf die 15 bereits gedeckten Zeilen). Reine Charakterisierung, kein Produktivcode-Fix. Spec: `docs/specs/modules/fix_1703_s5_compare_zellwerte.md` |
-| 5 | **Reihenfolge** in allen Kanälen außer E-Mail und Telegram-rich | `tokens/builder.py:78`, `comparison.py:237` | 2 | Compare-Klartext nutzt die Nutzer-Reihenfolge nur als Sichtbarkeitsfilter (#1356) |
+| 5 | **Reihenfolge** in allen Kanälen außer E-Mail und Telegram-rich | `email/helpers.py:1908`, `comparison.py:127/729`, `compare_html.py:798` | 2 | ✅ Erledigt (2026-08-14, Epic #1703 Scheibe 7). 🔴 **Zwei Angaben dieser Zeile waren bei Nachmessung falsch und sind hier ersetzt:** (a) `tokens/builder.py:78` — die Trip-SMS-Reihenfolge ist seit #1677/#1660 B bewacht (`test_channel_metric_matrix.py::test_ac15_…` (c), paarweise über alle 26 Katalog-Metriken, `_POSITION_SORTABLE_CATEGORIES`); (b) „Compare-Klartext nutzt die Reihenfolge nur als Sichtbarkeitsfilter (#1356)" — überholt seit #1359, `_ordered_rows()` (`comparison.py:127-140`) setzt sie um, der HTML-Zwilling `_visible_metrics()` (`compare_html.py:798`) ebenso. Tatsächlich fehlte die **Katalog-Deckung** (bewacht waren 4 von 25 Metriken über `tests/unit/test_compare_metric_order.py`) und die **Kanal-Achse** aus Scheibe 8. Neuer Wächter `tests/tdd/test_channel_metric_matrix.py` AC-S7-1 (Soll-Menge 25 gerechnet + Vakuum-Schutz), AC-S7-2/3 (HTML und Klartext derselben Sendung, alle 25 paarweise), AC-S7-4 (Altbestands-Divergenz HTML `CV2_METRICS` vs. Klartext `_PLAIN_ROWS` ab Position 3 — charakterisiert, nicht gefixt, → #1199), AC-S7-5 (drei Kanäle, drei Reihenfolgen, EINE Sendung — gemessen an der zugestellten Ausgabe über Versand- **und** Vorschaupfad), AC-S7-6 (**Produktivcode-Fix**, s.u.), AC-S7-7 (Trip-Telegram-Kurzübersicht; benennt die zwei Ordnungsquellen in `render_telegram_bubbles()`), AC-S7-8 (Compare-Telegram/SMS unter Kappung — Telegram 7 Spalten, SMS 153 Zeichen), AC-S7-9 (Kompakt-Zusammenfassung ohne Reihenfolge-Achse, benannte Ausnahme). Spec: `docs/specs/modules/fix_1703_s7_reihenfolge_matrix.md` |
 | 6 | Kurzform-Mail, mobile Kompaktzeilen und Kompakt-Zusammenfassung | `email/compact.py:96`, `email/html.py:878`, `compact_summary.py:567` | 2 | ✅ Erledigt (2026-08-12, Epic #1703 Scheibe 4): **drei** verschiedene Orte, die alle „compact" heißen und regelmäßig verwechselt werden — `render_compact()` ist das eigene Kurzformat, `_render_mobile_compact_rows()` sitzt **in** der Vollmail, `CompactSummaryFormatter` erzeugt den Fließtext-Block ebendort — jetzt einzeln bewacht: `tests/tdd/test_channel_metric_matrix.py` AC-S4-1/2/3 (Ort 1), AC-S4-5 (Ort 2), AC-S4-6/6b/7/8-10 (Ort 3). Reine Charakterisierung, kein Produktivcode-Fix. Spec: `docs/specs/modules/fix_1703_s4_kompaktform_matrix.md` |
 | 7 | **Telegram-Kurzform** als eigener Ausgabeort | `narrow.py:346`, `:528–532`, `:586–597` | 2 | ✅ Erledigt (2026-08-12, Epic #1703 Scheibe 4): Wächter `tests/tdd/test_channel_metric_matrix.py` AC-S4-12/13/14 (Auswahl/Abwahl generisch über alle wählbaren Metriken, Resolver-Divergenz zu Ort 1 als Charakterisierung, confidence-Absenz). Reine Charakterisierung, kein Produktivcode-Fix. Spec: `docs/specs/modules/fix_1703_s4_kompaktform_matrix.md` |
 | 8 | Einheiten und Nachkommastellen je Kanal | `metric_catalog.get_decimals()`, `compare_html.py:384` | 3 | nur die Compare-Legende ist bewacht |
@@ -512,23 +512,81 @@ Météo-France-Vigilance (`_vigilance()`, nie erreicht: kein Aufrufer setzt
 `provider="meteofrance"`) bleibt dokumentiert, nicht gefixt. Details:
 `docs/specs/modules/fix_1703_s6_form_waechter.md`.
 
-### Scheibe 7 — Reihenfolge-Wächter jenseits E-Mail und Telegram-rich
+### Scheibe 7 — Reihenfolge-Wächter jenseits E-Mail und Telegram-rich ✅ ERLEDIGT (2026-08-14)
 
-Reihenfolge-Zusicherung für SMS, Compare-Klartext und Compare-Telegram. War
-**abhängig von der PO-Entscheidung zu Compare-Kanal-Tabs (7a)** — diese
-Blockade ist mit Scheibe 8 (✅ ERLEDIGT 2026-08-13) aufgehoben: Compare führt
-jetzt eine kanalbezogene Soll-Reihenfolge, gegen die sich prüfen ließe
-(`display_config.channel_active_metrics`, `resolve_channel_enabled_metrics()`).
+Deckt Fläche 5. Spec: `docs/specs/modules/fix_1703_s7_reihenfolge_matrix.md`.
 
-**Zuschnitt bleibt enger als beim Trip:** Scheibe 8 deckt nur die
-Übersichtstabelle. Ausblick (`outlook_columns()`) und Stundenverlauf
-(`hourly_selectable_metric_ids()`) sind weiterhin je eine einzige globale
-Liste ohne Kanal-Ebene (ADR-0053 Punkt 1) — für sie gibt es weiterhin keine
-kanalbezogene Soll-Reihenfolge. Scheibe 7 kann deshalb vorerst nur die
-**Übersicht** abdecken; ein Reihenfolge-Wächter für Ausblick/Stundenverlauf
-bräuchte zuerst deren eigene Kanal-Kette (ADR-0053, Abschnitt „Folgepflicht").
-*Risiko: mittel. Größe: mittel.* Deckt Fläche 5. **Frei — nicht mehr
-blockiert**, Zuschnitt Compare-Übersicht only.
+🔴 **Der Zuschnitt dieser Scheibe war zweimal falsch beschrieben — beide
+Korrekturen sind vor dem Schreiben der ACs gemessen worden.** Hier stand
+„Reihenfolge-Zusicherung für SMS, Compare-Klartext und Compare-Telegram":
+
+- **Die Trip-SMS war längst bewacht.** `test_channel_metric_matrix.py::test_ac15_…`
+  (c) prüft die Nutzer-Reihenfolge seit #1677 paarweise über alle 26
+  Katalog-Metriken; die in Fläche 5 genannte Lücke `tokens/builder.py:78` ist
+  mit #1677/#1660 B geschlossen (`_POSITION_SORTABLE_CATEGORIES`,
+  `MetricSpec.position`).
+- **Der Compare-Klartext folgt der Reihenfolge.** Die Notiz „nutzt sie nur als
+  Sichtbarkeitsfilter (#1356)" ist seit #1359 überholt (`_ordered_rows()`,
+  `comparison.py:127-140`).
+
+Was tatsächlich fehlte: die **Katalog-Deckung** (bewacht waren 4 von 25
+Metriken, `tests/unit/test_compare_metric_order.py` mit zwei getippten
+Reihenfolgen) und die **Kanal-Achse**, die es erst seit Scheibe 8 gibt. Damit
+wiederholt sich exakt das Muster aus Scheibe 2: *das Prinzip war bewacht, die
+Deckung nicht.*
+
+**Geliefert:** neun ACs (`AC-S7-1` bis `AC-S7-9`) in
+`tests/tdd/test_channel_metric_matrix.py`, 142 Testfälle, plus
+`tests/helpers/compare_order.py`. Der Nachweis der Kanal-Achse hängt an der
+**zugestellten Ausgabe** — drei Kanäle führen dieselbe Metrik-Menge in drei
+Reihenfolgen, geprüft über Versandpfad (`send_one_compare_preset()` mit Sinks)
+und Vorschaupfad, zusammen alle acht Aufrufstellen. Adversary VERIFIED; alle
+fünf Pflicht-Mutationen exakt vom vorgesehenen Test gefangen, die
+Kanal-Mutation an zwei unabhängigen Stellen.
+
+**Der Produktivcode-Fix (AC-S7-6):** `build_metrics_summary_pills()`
+(`email/helpers.py:1908`) kollabierte die geordnete Metrikliste zu
+`set(metric_ids)` und rendert danach eine feste Katalogordnung — die im Editor
+je Kanal eingestellte Reihenfolge konnte den Pillen-Überblick **strukturell
+nicht erreichen**. Ein Bedienelement ohne Wirkung, also genau die Fehlerklasse
+dieses Epics. Der Katalog bleibt weiße Liste (welche Größen überhaupt eine
+Pille haben), gibt aber nicht mehr die Ordnung vor.
+
+Zwei Nebenwirkungen, beide gemessen und gewollt: Der Fix wirkt auf **drei**
+Ausgabeorte (Kurz-E-Mail `compact.py:176` **und** beide Teile der Voll-Mail,
+`html.py:1432`/`plain.py:205`) — dabei schlug **kein** Golden- oder
+Paritätstest an, die Pillen-Reihenfolge der Voll-Mail war also von nichts
+bewacht. Und für Trips ohne jede gespeicherte Auswahl tauschen `visibility`
+und `freezing_level` ihre Plätze, weil `DEFAULT_TRIP_METRIC_IDS` seit #1552
+aus `trip_default_rank` stammt und nicht aus `_PILL_CATALOG_ORDER` — eine
+Ordnungsquelle statt zweier.
+
+**Abgelöste Entscheidung, nicht still vollzogen:** `email_metrics_summary_664.md:88`
+(2026-06-08) legte ausdrücklich fest „Reihenfolge = Katalog-Reihenfolge, nicht
+Eingabereihenfolge", und `test_metric_order_follows_catalog` fror das ein. Die
+alte Wahl war unter ihren Bedingungen richtig — im Juni 2026 gab es keine
+nutzergesetzte Reihenfolge, die Kanal-Layouts kamen erst mit #1575/#1677 (Trip)
+bzw. #1335/#1359 (Compare); die „Eingabereihenfolge" war die zufällige Folge
+der Config-Einträge und trug keine Absicht. Der Test heißt jetzt
+`test_metric_order_follows_input`, prüft paarweise statt einseitig und trägt
+den Ablösungsvermerk (#664 → abgelöst durch #1703 S7), ebenso der Docstring von
+`build_metrics_summary_pills()`.
+
+**Zuschnitt-Grenze, bewusst offen:** Ausblick (`outlook_columns()`) und
+Stundenverlauf (`hourly_selectable_metric_ids()`) des Ortsvergleichs führen
+weiterhin je eine einzige globale Liste ohne Kanal-Ebene (ADR-0053 Punkt 1) —
+für sie gibt es keine kanalbezogene Soll-Reihenfolge, gegen die sich prüfen
+ließe. Ein Wächter dafür bräuchte zuerst deren eigene Kanal-Kette.
+
+**Weitere Grenzen:** Die Altbestands-Divergenz zwischen HTML (`CV2_METRICS`)
+und Klartext (`_PLAIN_ROWS`) ab Position 3 ist charakterisiert, nicht gefixt —
+die `_PLAIN_ROWS`-Ordnung ist in `test_compare_metric_order.py` AC-7 als
+Altbestands-Standard eingefroren, ein Fix wäre eine eigene Entscheidung
+(→ #1199). `render_telegram_bubbles()` führt zwei Ordnungsquellen
+(`dc.get_enabled_metric_ids()` für die Kurzübersicht, `render_for_channel()`
+für die Tabellen-Bubbles); im Versandpfad fallen sie zusammen, das Driftrisiko
+ist benannt (AC-S7-7). `format_stage_summary()` hat keine Reihenfolge-Achse
+(AC-S7-9).
 
 ### Scheibe 8 — Compare-Kanal-Tabs im Frontend ✅ ERLEDIGT (2026-08-13)
 
@@ -589,10 +647,17 @@ gegen Staging: `frontend/e2e/compare-uebersicht-kanal-bedienung.staging.spec.ts`
 Details, alle 15 ACs (AC-S8-1 bis AC-S8-15), Mutations-Gegenproben:
 `docs/specs/modules/feat_1703_s8_compare_kanal_tabs.md`.
 
-**Abhängigkeitsbild (Stand 2026-08-13):** 1, 2, 3, 4, 5, 6, 8 ✅ erledigt ·
-7 frei — nicht mehr blockiert (7a beantwortet, Scheibe 8 live). Zuschnitt
-bleibt auf die Compare-Übersicht beschränkt: Ausblick/Stundenverlauf haben
-weiterhin keine Kanal-Ebene.
+**Abhängigkeitsbild (Stand 2026-08-14):** **alle acht Scheiben ✅ erledigt.**
+Die Flächen 1–7 aus Abschnitt 4 tragen damit jeweils einen Wächter in
+`tests/tdd/test_channel_metric_matrix.py` (Achsen `AC-S1-*` bis `AC-S7-*`);
+Fläche 5 ist mit Scheibe 7 als letzte geschlossen worden.
+
+**Offen bleiben bewusst** — beides braucht eine eigene Entscheidung, keine
+Fortsetzung dieses Epics: (a) Ausblick und Stundenverlauf des Ortsvergleichs
+haben weiterhin keine Kanal-Ebene (ADR-0053 Punkt 1), also auch keine
+kanalbezogene Soll-Reihenfolge; (b) die Flächen 8, 9 und 10 aus Abschnitt 4.2
+(Einheiten/Nachkommastellen je Kanal · Frontend ohne Metrik×Kanal-Matrix ·
+Trip-SMS liest die Kaskade nicht) standen nie im Zuschnitt der acht Scheiben.
 
 ## 7. PO-Entscheidungsvorlage — ENTSCHIEDEN (PO, 2026-08-10)
 

--- a/docs/specs/modules/fix_1703_s7_reihenfolge_matrix.md
+++ b/docs/specs/modules/fix_1703_s7_reihenfolge_matrix.md
@@ -1,0 +1,299 @@
+---
+entity_id: fix_1703_s7_reihenfolge_matrix
+type: module
+created: 2026-08-13
+updated: 2026-08-13
+status: draft
+version: "1.0"
+tags: [reihenfolge, compare, kompaktform, matrix-test, epic-1703, kanal-achse]
+---
+
+<!-- Epic #1703 (Folgearbeit aus #1514), Scheibe 7. Deckt Flaeche 5 aus
+     docs/reference/metric_output_matrix.md §4.2 (Reihenfolge jenseits E-Mail
+     und Telegram-rich). Setzt auf Scheibe 8 auf (Kanal-Ebene der
+     Compare-Uebersicht, ADR-0053). Enthaelt EINEN nutzersichtbaren
+     Produktivcode-Fix (Pillen-Reihenfolge der Kurz-E-Mail); alles Uebrige ist
+     Waechter-Ausbau bzw. Charakterisierung. -->
+
+# Reihenfolge-Wächter jenseits E-Mail/Telegram-rich (#1703 Scheibe 7)
+
+## Approval
+
+- [x] Approved (PO, 2026-08-13 — inkl. `loc_limit_override 550`)
+
+## Purpose
+
+Die im Editor eingestellte **Metrik-Reihenfolge** soll in den Ausgabeorten
+bewacht werden, die heute keinen katalog-vollständigen Reihenfolge-Wächter
+haben. Das sind nach Nachmessung nicht die im Issue genannten, sondern:
+
+- die **Compare-Übersicht** über alle vier Kanäle — dort bewacht der Bestand
+  (`tests/unit/test_compare_metric_order.py`, #1359) nur **4 fest getippte**
+  von 25 wählbaren Metriken und nur **eine globale** Liste,
+- die **Kanal-Achse** der Compare-Übersicht, die es erst seit Scheibe 8 gibt
+  (`enabled_metrics_by_channel`) und für die noch gar kein Reihenfolge-Wächter
+  existiert,
+- die **Trip-Kompaktformen** (Kurz-E-Mail, Telegram-Kurzübersicht,
+  Kompakt-Zusammenfassung), deren Reihenfolge nirgends geprüft wird.
+
+## Korrektur der Scheiben-Prämisse (vor dem Schreiben der ACs gemessen)
+
+Fläche 5 ist im Matrix-Dokument als „Reihenfolge in **allen** Kanälen außer
+E-Mail und Telegram-rich" beschrieben und nennt als Fundstellen
+`tokens/builder.py:78` und `comparison.py:237`. **Beide Angaben treffen nicht
+mehr zu** — dieselbe Prämissen-Falle wie bei Scheibe 2 und Scheibe 5.
+
+| Behauptung in Fläche 5 | Gemessener Ist-Zustand |
+|---|---|
+| Trip-SMS-Reihenfolge unbewacht (`tokens/builder.py:78`) | **bewacht** — `test_channel_metric_matrix.py::test_ac15_sms_kurzform_selection_deselection_and_order` (c) prüft paarweise Reihenfolge über alle 26 Katalog-Metriken; die Lücke ist mit #1677/#1660 B geschlossen (`_POSITION_SORTABLE_CATEGORIES`, `MetricSpec.position`) |
+| Compare-Klartext nutzt die Reihenfolge „nur als Sichtbarkeitsfilter (#1356)" | **überholt** — `_ordered_rows()` (`comparison.py:126-140`) setzt sie seit #1359 um; der HTML-Zwilling `_visible_metrics()` (`compare_html.py:798`) ebenso |
+
+Der Kopfkommentar von `test_channel_metric_matrix.py` (Zeile 20) nennt den
+SMS-Reihenfolge-Teil weiterhin „RED". Das ist seit dem Fix zu #1677 falsch und
+wird in dieser Scheibe mitkorrigiert (AC-S7-10) — ein Kommentar, der eine
+geschlossene Lücke als offen ausweist, ist die Vorstufe zur nächsten
+falschen Prämisse.
+
+## Der Kern der Scheibe
+
+Nach diesen Korrekturen bleiben **drei** Blöcke, in dieser Reihenfolge:
+
+1. **Katalog-Deckung der Compare-Übersicht** (AC-S7-1 bis AC-S7-4). Das Prinzip
+   ist bewacht, die Deckung nicht — genau die Konstellation, die Scheibe 2
+   vorgefunden hat („bewacht war nur das Auswahl-PRINZIP mit zwei fest getippten
+   Auswahlen, nicht die Katalog-DECKUNG").
+2. **Die Kanal-Achse** (AC-S7-5). Scheibe 8 hat für die *Auswahl* an der
+   zugestellten Ausgabe belegt, dass dieselbe Sendung in der E-Mail 9, in
+   Telegram 5 und in der SMS 2 Metriken zeigt. Für die *Ordnung* fehlt dieser
+   Nachweis vollständig.
+3. **Die Trip-Kompaktformen** (AC-S7-6 bis AC-S7-9), darunter der einzige
+   Produktivcode-Fix dieser Scheibe.
+
+## Der Fix (AC-S7-6) — die Kurz-E-Mail verwirft die Reihenfolge
+
+`build_metrics_summary_pills()` (`src/output/renderers/email/helpers.py:1844`)
+bekommt vom Aufrufer `render_compact()` die **geordnete** Liste
+`resolve_trip_active_metrics(dc.metrics, …)` und kollabiert sie sofort zu einer
+Menge:
+
+```python
+ids_set = set(metric_ids)
+# Render in catalog order
+```
+
+Der Docstring sagt es ausdrücklich: „Returns list of (text, tone) tuples **in
+catalog order**". Die im Editor je Kanal eingestellte Reihenfolge kann den
+Metriken-Überblick der Kurz-E-Mail damit **strukturell nicht erreichen**.
+
+Das ist ein Bedienelement ohne Wirkung — die Fehlerklasse, gegen die dieses
+Epic gebaut wurde (#1450, #1362, #1660 A/B, #1677). Kein Test bemerkt es:
+AC-S4-1/2/3 aus Scheibe 4 prüfen Auswahl und Abwahl, nie die Position.
+
+**Empfehlung: fixen.** Der Eingriff ist klein und lokal — die Katalog-Ordnung
+wird zur Ordnung der übergebenen Liste. Für Trips ohne gespeicherte eigene
+Reihenfolge ändert sich nichts, weil `resolve_trip_active_metrics()` dann
+ohnehin die Katalog-Ordnung liefert.
+
+**Was der Fix NICHT tut:** Er ändert weder Auswahl noch Schwellenlogik noch
+die Ampelstufen. Nur die Ausgabereihenfolge der Pillen folgt der Nutzerliste.
+
+## Bewusst NICHT in dieser Scheibe
+
+- **Compare-Ausblick und -Stundenverlauf.** Beide führen weiterhin je eine
+  einzige globale Auswahlliste ohne Kanal-Ebene (ADR-0053 Punkt 1). Es gibt
+  dort keine kanalbezogene Soll-Reihenfolge, gegen die sich prüfen ließe. Ein
+  Wächter dafür bräuchte zuerst deren eigene Kanal-Kette.
+- **Die Altbestands-Divergenz zwischen HTML und Klartext.** Bei
+  `enabled_metrics=None` (Preset ohne gespeicherte Auswahl) behält jede Seite
+  ihre eigene Quellcode-Ordnung: ab Position 3 steht im HTML `precip_sum`, im
+  Klartext `temp_min`; die Mengen sind identisch (25), nur die Ordnung nicht.
+  Sie wird in AC-S7-4 **charakterisiert, nicht gefixt** — die
+  `_PLAIN_ROWS`-Ordnung ist in `test_compare_metric_order.py` (AC-7)
+  ausdrücklich als Altbestands-Standard **eingefroren**, ein Fix zöge diesen
+  Bestandstest mit und gehört als eigene Entscheidung behandelt. Nebenbefund
+  → #1199.
+- **Neue Gates.** Leitplanke des Epics: Erweiterung des bestehenden,
+  budgetierten Gates #1677 B (Option C — kein zweites Register, kein neues
+  Prüfdatum).
+
+## Scope
+
+- **Dateien (Tests):** `tests/tdd/test_channel_metric_matrix.py` (MODIFY,
+  neue Achse `AC-S7-n` + Kopfkommentar-Korrektur), `tests/helpers/compare_order.py`
+  (CREATE, gerechnete Soll-Menge + Label-Auslese je Kanal — Vorbild
+  `tests/helpers/outlook_columns.py` aus Scheibe 2)
+- **Dateien (Produktivcode):** `src/output/renderers/email/helpers.py`
+  (MODIFY, nur AC-S7-6)
+- **Dateien (Doku):** `docs/reference/metric_output_matrix.md` (Fläche 5 +
+  Abschnitt 6 umtragen — Definition of Done jeder Scheibe),
+  `docs/specs/modules/fix_1703_s7_reihenfolge_matrix.md` (diese Datei)
+- **Geschätzte LoC:** Tests **+420/-10**, Produktivcode **+8/-4**
+- **LoC-Limit:** Das Standard-Limit von 250 wird durch den Testanteil
+  überschritten. **Beantragt: `loc_limit_override 550`** — begründet durch
+  neun ACs über vier Kanäle mit paarweiser Reihenfolgeprüfung; die
+  Vorgängerscheiben lagen mit vergleichbarem Zuschnitt bei 600 (S1) bzw. 552
+  Testzeilen (S8).
+
+## Test-Strategie
+
+Alle neuen Tests laufen in der **Kern-Schicht** (deterministisch, ohne Netz),
+gegen die Funktionen, die der Produktivpfad **tatsächlich** aufruft:
+
+| Kanal | Prüfling | Aufrufer im Produktivpfad |
+|---|---|---|
+| Compare E-Mail (HTML + Klartext) | `render_compare_email()` — liefert beide Formen in EINEM Aufruf | `scheduler_dispatch_service.py:439` |
+| Compare Telegram | `render_compare_telegram()` | `scheduler_dispatch_service.py:505` |
+| Compare SMS | `render_compare_sms()` | `scheduler_dispatch_service.py:509` |
+| Trip Kurz-E-Mail | `render_compact()` | `TripReportFormatter.format_email()` |
+| Trip Telegram-Kurzübersicht | `render_telegram_bubbles()` | Telegram-Versandpfad |
+
+**Prüfmuster durchgehend paarweise:** dieselbe Metrik-MENGE in zwei
+Reihenfolgen rendern und die Positionen der beiden Labels vergleichen. Das
+schlägt sowohl bei „Reihenfolge ignoriert" als auch bei „intern nach eigener
+Priorität umsortiert" an — ein Test gegen eine einzelne feste Erwartung täte
+das nicht.
+
+**Soll-Mengen gerechnet, nie getippt** (Epic-Leitplanke), mit der
+Einschränkung aus Scheibe 2 F001: *Rechnen sichert Vollständigkeit, nie
+Zuordnung.* Jede Zuordnungsbehauptung braucht deshalb eine eigene Assertion,
+und jede gerechnete Menge einen Vakuum-Schutz (Mindestgröße), damit ein leerer
+Katalog den Test nicht stillschweigend bestehen lässt.
+
+**Kappungs-bewusst:** Compare-Telegram kappt bei 7 Metrikspalten
+(`CHANNEL_LIMITS["telegram"]`), Compare-SMS am Zeichenbudget. Dort wird
+paarweise mit **zwei** Metriken geprüft, nicht mit der vollen Liste — sonst
+misst der Test die Kappung statt der Reihenfolge.
+
+## Acceptance Criteria
+
+- **AC-S7-1 (Soll-Menge gerechnet, Vakuum-geschützt):** Gegeben der
+  Ortsvergleich-Katalog `get_compare_metric_catalog()`, wenn die Soll-Menge der
+  reihenfolge-fähigen Übersichts-Metriken gebildet wird, dann entsteht sie
+  ausschließlich aus dem Katalog (26 roh minus der nicht wählbaren `cape_max_jkg`
+  = 25) und niemals aus einer getippten Liste; der Test scheitert ausdrücklich,
+  wenn die gerechnete Menge unter 20 Einträge fällt, damit ein leerer oder
+  kaputter Katalog nicht als bestandener Test durchgeht.
+
+- **AC-S7-2 (Compare-HTML folgt der Reihenfolge, über den ganzen Katalog):**
+  Gegeben zwei Metriken aus der Soll-Menge von AC-S7-1, wenn dieselbe
+  Vergleichs-Mail einmal mit der Reihenfolge [A, B] und einmal mit [B, A]
+  gerendert wird, dann steht in der HTML-Übersichtstabelle im ersten Fall die
+  Zeile von A vor der von B und im zweiten Fall umgekehrt — geprüft für jede
+  der 25 Metriken gegen einen festen Partner, nicht nur für vier ausgewählte.
+
+- **AC-S7-3 (Compare-Klartext folgt derselben Reihenfolge, aus derselben
+  Sendung):** Gegeben derselbe Aufruf von `render_compare_email()` wie in
+  AC-S7-2, wenn der Klartext-Teil derselben Mail ausgelesen wird, dann steht
+  dort dieselbe Metrik-Reihenfolge wie im HTML-Teil — die Prüfung erfolgt an
+  einem gemeinsamen Renderaufruf, damit eine Divergenz zwischen den beiden
+  Formen derselben Mail nicht durch getrennte Aufrufe verdeckt wird.
+
+- **AC-S7-4 (Altbestand ohne gespeicherte Auswahl — charakterisiert):** Gegeben
+  ein Vergleich ohne gespeicherte Metrik-Auswahl (`enabled_metrics=None`), wenn
+  HTML- und Klartext-Teil derselben Mail gerendert werden, dann hält der Test
+  den heutigen Zustand als Charakterisierung fest: beide zeigen dieselbe Menge
+  von 25 Zeilen, aber in unterschiedlicher Ordnung (HTML folgt `CV2_METRICS`,
+  Klartext `_PLAIN_ROWS`, erste Abweichung an Position 3). Die Divergenz wird in
+  dieser Scheibe **nicht behoben**; der Test dokumentiert sie mit Begründung,
+  damit sie nicht unbemerkt in eine spätere Scheibe weiterwandert.
+
+- **AC-S7-5 (Kanalweise unterschiedliche Reihenfolge in EINER Sendung):**
+  Gegeben ein Vergleichs-Preset, dessen `channel_active_metrics` für E-Mail,
+  Telegram und SMS dieselben Metriken in **drei verschiedenen** Reihenfolgen
+  führt, wenn eine Sendung über alle drei Kanäle gerendert wird, dann zeigt jeder
+  Kanal seine eigene Reihenfolge — geprüft an der jeweils zugestellten Ausgabe
+  (E-Mail-Tabelle, Telegram-Nachricht, SMS-Text), nicht am Rückgabewert von
+  `resolve_channel_enabled_metrics()`. Zusätzlich wird belegt, dass ein
+  Zurückdrehen der Kanal-Auflösung an mindestens einer der acht Aufrufstellen
+  mindestens einen dieser Tests rot macht.
+
+- **AC-S7-6 (DER FIX — die Kurz-E-Mail folgt der eingestellten Reihenfolge):**
+  Gegeben ein Trip, dessen E-Mail-Kanal-Layout zwei Metriken in einer von der
+  Katalogordnung abweichenden Reihenfolge führt, wenn die Kurz-E-Mail über
+  `render_compact()` gerendert wird, dann erscheinen die beiden Pillen im
+  Metriken-Überblick in der eingestellten Reihenfolge — heute erscheinen sie
+  stattdessen in Katalogordnung, weil `build_metrics_summary_pills()` die
+  geordnete Liste zu einer Menge kollabiert. Auswahl, Abwahl, Schwellenlogik und
+  Ampelstufen bleiben unverändert; das belegt ein Test, der dieselben Pillen bei
+  gleicher Reihenfolge byte-gleich zum Vorzustand hält.
+
+- **AC-S7-7 (Trip-Telegram-Kurzübersicht folgt der Reihenfolge):** Gegeben ein
+  Trip mit zwei Metriken in zwei verschiedenen Reihenfolgen, wenn die
+  Kurzübersicht-Bubble über `render_telegram_bubbles()` gerendert wird, dann
+  folgen die Zeilen der eingestellten Reihenfolge. Der Test hält zusätzlich fest,
+  dass diese Bubble ihre Ordnung aus `dc.get_enabled_metric_ids()` bezieht und
+  **nicht** aus dem `render_for_channel()`-Layout, das dieselbe Funktion für die
+  Tabellen-Bubbles baut — zwei Reihenfolge-Quellen in einem Renderer sind ein
+  Driftrisiko und sollen benannt sein, solange sie bestehen.
+
+- **AC-S7-8 (Compare-Telegram und Compare-SMS folgen der Reihenfolge unter
+  Kappung):** Gegeben zwei Metriken in zwei Reihenfolgen, wenn
+  `render_compare_telegram()` bzw. `render_compare_sms()` gerendert werden, dann
+  folgt die Zellen- bzw. Token-Folge je Ort der eingestellten Reihenfolge. Weil
+  Telegram bei sieben Metrikspalten und die SMS am Zeichenbudget kappt, wird
+  paarweise geprüft; zusätzlich wird belegt, dass bei einer Auswahl oberhalb der
+  Kappungsgrenze die Reihenfolge darüber entscheidet, **welche** Metrik erhalten
+  bleibt — in der SMS ist ein Reihenfolgefehler damit ein Inhaltsfehler.
+
+- **AC-S7-9 (Kompakt-Zusammenfassung — benannte Ausnahme):** Gegeben der
+  Fließtext-Block `format_stage_summary()`, wenn seine Reihenfolge-Achse geprüft
+  wird, dann hält der Test fest, dass er einer festen Positivliste folgt und
+  keine nutzergesteuerte Reihenfolge kennt — als **benannte, begründete
+  Ausnahme** mit Verweis auf AC-S4-6 aus Scheibe 4 (feste Positivliste als
+  akzeptierter Dauerzustand), nicht als stillschweigende Auslassung.
+
+- **AC-S7-10 (Matrix-Dokument und Kopfkommentar sind wahr):** Gegeben die
+  gelieferten Wächter, wenn `docs/reference/metric_output_matrix.md` (Fläche 5,
+  Abschnitt 6) und der Kopfkommentar von `test_channel_metric_matrix.py` gelesen
+  werden, dann tragen beide den neuen Stand — insbesondere ist die Angabe „AC-15
+  (c) → RED" entfernt, weil dieser Teil seit #1677 grün läuft, und die beiden
+  oben belegten Prämissen-Korrekturen sind ausdrücklich vermerkt, damit sie
+  nicht in eine Folgescheibe weiterwandern.
+
+## Mutations-Gegenproben (Pflicht, Adversary)
+
+Der Adversary muss mindestens diese fünf Verfälschungen einzeln vornehmen und
+melden, welcher Test jeweils rot wird — wird einer nicht gefangen, ist das ein
+Finding:
+
+1. In `_ordered_rows()` (`comparison.py`) die Sortierung durch die rohe
+   Quellcode-Ordnung ersetzen → muss AC-S7-3 fangen.
+2. In `_visible_metrics()` (`compare_html.py`) dasselbe → muss AC-S7-2 fangen.
+3. Den Fix aus AC-S7-6 zurückdrehen (`set(metric_ids)` wiederherstellen) → muss
+   genau AC-S7-6 fangen und **keinen** der Scheibe-4-Tests.
+4. An einer der acht Compare-Aufrufstellen `enabled_metrics_by_channel[<kanal>]`
+   durch `enabled_metrics` ersetzen → muss AC-S7-5 fangen.
+5. In der gerechneten Soll-Menge (AC-S7-1) den Katalog durch eine leere Liste
+   ersetzen → muss am Vakuum-Schutz scheitern, nicht stillschweigend bestehen.
+
+Zusätzlich die Leitfrage aus Scheibe 8, die dort viermal getragen hat: *Ist die
+Zusicherung dort geprüft, wo sie WIRKT — oder nur dort, wo der Code steht?*
+`resolve_channel_enabled_metrics()` behauptet in seinem Docstring, die
+Ergebnis-Reihenfolge sei die der Kanal-Liste; geprüft gehört das an der
+zugestellten Ausgabe, nicht an der reinen Funktion.
+
+## Known Limitations
+
+- **Ausblick und Stundenverlauf des Ortsvergleichs bleiben ungedeckt** — sie
+  haben keine Kanal-Ebene (ADR-0053). Kein Versäumnis dieser Scheibe, sondern
+  eine offene Folgepflicht.
+- **Die Altbestands-Divergenz HTML/Klartext wird charakterisiert, nicht
+  behoben** (Begründung oben) → Nebenbefund #1199.
+- **Zwei Reihenfolge-Quellen in `render_telegram_bubbles()`** bleiben bestehen
+  (AC-S7-7 benennt sie). Eine Zusammenführung wäre ein eigener Schnitt.
+- **`format_stage_summary()` bekommt keinen Reihenfolge-Wächter**, weil es
+  keine Reihenfolge-Achse hat (AC-S7-9).
+
+## Definition of Done
+
+- [ ] Alle zehn ACs als Tests in `tests/tdd/test_channel_metric_matrix.py` grün
+- [ ] Fünf Pflicht-Mutationen einzeln nachgemessen, jede vom vorgesehenen Test
+      gefangen
+- [ ] `docs/reference/metric_output_matrix.md` Fläche 5 + Abschnitt 6 umgetragen
+- [ ] Kopfkommentar der Testdatei korrigiert (kein falsches „RED" mehr)
+- [ ] Renderer-Commit-Gate #811 erfüllt (`test_issue_811_mode_matrix.py` grün +
+      frischer `briefing_mail_validator.py`-Lauf), weil AC-S7-6 eine
+      Mail-Inhalts-Datei berührt
+- [ ] Adversary-Verdict VERIFIED
+- [ ] Staging-Verifikation der Kurz-E-Mail-Reihenfolge an einer echt
+      zugestellten Mail (AC-S7-6 ist nutzersichtbar)

--- a/docs/specs/modules/fix_1703_s7_reihenfolge_matrix.md
+++ b/docs/specs/modules/fix_1703_s7_reihenfolge_matrix.md
@@ -90,9 +90,37 @@ Epic gebaut wurde (#1450, #1362, #1660 A/B, #1677). Kein Test bemerkt es:
 AC-S4-1/2/3 aus Scheibe 4 prüfen Auswahl und Abwahl, nie die Position.
 
 **Empfehlung: fixen.** Der Eingriff ist klein und lokal — die Katalog-Ordnung
-wird zur Ordnung der übergebenen Liste. Für Trips ohne gespeicherte eigene
-Reihenfolge ändert sich nichts, weil `resolve_trip_active_metrics()` dann
-ohnehin die Katalog-Ordnung liefert.
+wird zur Ordnung der übergebenen Liste.
+
+🔴 **Korrektur (bei der Umsetzung gemessen, 2026-08-14).** Hier stand: „Für
+Trips ohne gespeicherte eigene Reihenfolge ändert sich nichts, weil
+`resolve_trip_active_metrics()` dann ohnehin die Katalog-Ordnung liefert."
+**Das trifft nicht zu.** Der Altbestands-Rückfall `DEFAULT_TRIP_METRIC_IDS`
+wird seit #1552 aus `trip_default_rank` abgeleitet, nicht aus
+`_PILL_CATALOG_ORDER` — die beiden Listen unterscheiden sich in den letzten
+zwei Positionen:
+
+```
+DEFAULT_TRIP_METRIC_IDS: … thunder, freezing_level, visibility
+_PILL_CATALOG_ORDER    : … thunder, visibility, freezing_level
+```
+
+Für Trips **ohne jede** gespeicherte Auswahl tauschen `visibility` und
+`freezing_level` also ihre Pillenplätze. Der Effekt ist gewollt mitgenommen:
+die Ordnung folgt danach dem Register-Rang statt einer zweiten, separat
+gepflegten Liste — eine Ordnungsquelle statt zweier. Festgehalten in
+`test_altbestand_pillen_folgen_dem_trip_default_rang`
+(`tests/tdd/test_issue_664_metrics_summary.py`), damit die Änderung nicht als
+Rätsel zurückkommt.
+
+**Der Fix wirkt auf DREI Ausgabeorte, nicht auf einen** (ebenfalls bei der
+Umsetzung ausgezählt): `build_metrics_summary_pills()` speist neben der
+Kurz-E-Mail (`compact.py:176`) auch den HTML- und den Klartext-Teil der
+Voll-Mail (`html.py:1432`, `plain.py:205`). Alle drei beziehen ihre Liste aus
+derselben Quelle, in allen dreien ist die Reihenfolge fachlich gemeint — der
+Mitgewinn ist erwünscht und per A/B gegen den Vorzustand belegt. Bezeichnend:
+**kein Golden- oder Paritätstest hat dabei angeschlagen** — die
+Pillen-Reihenfolge der Voll-Mail war bislang von nichts bewacht.
 
 **Was der Fix NICHT tut:** Er ändert weder Auswahl noch Schwellenlogik noch
 die Ampelstufen. Nur die Ausgabereihenfolge der Pillen folgt der Nutzerliste.

--- a/src/output/renderers/email/helpers.py
+++ b/src/output/renderers/email/helpers.py
@@ -1874,6 +1874,17 @@ def build_metrics_summary_pills(
     """Issue #664/#795: Build one (text, tone) pill per metric from segment data.
 
     metric_ids: list of metric IDs to render (from display_config, E-Mail enabled).
+        Issue #1703 S7: die REIHENFOLGE dieser Liste ist die Ausgabereihenfolge
+        der Pillen (Nutzer-Reihenfolge aus dem Kanal-Layout). Bis #1703 S7 galt
+        „Katalog-Reihenfolge, nicht Eingabereihenfolge" (Spec
+        ``email_metrics_summary_664.md:88``, 2026-06-08) -- **#664 → abgeloest
+        durch #1703 S7**. Die alte Wahl war unter ihren Bedingungen richtig:
+        im Juni 2026 gab es keine nutzergesetzte Metrik-Reihenfolge, die
+        Kanal-Layouts kamen erst mit #1575/#1677 (Trip) bzw. #1335/#1359
+        (Compare). Die „Eingabereihenfolge" war die zufaellige Folge der
+        Config-Eintraege und trug keine Absicht; Katalogordnung war die
+        stabilere Wahl. Seit die Eingabe eine Nutzerabsicht traegt, verwirft
+        die Katalogordnung sie.
     sms_mention_thresholds: dict[metric_id -> float] (Issue #1474b) —
         pro Trip eingestellte Erwaehnungsschwellen (aus `MetricConfig.
         sms_threshold`), im `metric_id`-Raum. Nur der `"thunder"`-Zweig in
@@ -1900,7 +1911,9 @@ def build_metrics_summary_pills(
         (``MetricConfig.aggregations``). Additiv: fehlt der Parameter oder ein
         Eintrag, gilt die Katalog-Vorgabe ``pill_default_aggregations()``. Eine
         ausdruecklich leere Liste heisst „keine Kachel" (AC-8).
-    Returns list of (text, tone) tuples in catalog order.
+    Returns list of (text, tone) tuples in ``metric_ids`` order (Issue #1703 S7;
+    zuvor: Katalog-Reihenfolge). Groessen ohne Eintrag in
+    ``_PILL_CATALOG_ORDER`` erzeugen unveraendert keine Pille.
     """
     from output.renderers.day_window import (
         build_day_window_points, collect_hiking_window_points,
@@ -1913,12 +1926,20 @@ def build_metrics_summary_pills(
     # ihre Gehzeit-Extrema ziehen — kein zweiter Rechenweg mehr.
     hiking_dps = collect_hiking_window_points(segments)
 
-    # Render in catalog order
-    ids_set = set(metric_ids)
+    # Issue #1703 Scheibe 7 (AC-S7-6): in der UEBERGEBENEN Reihenfolge rendern.
+    # Bis dahin wurde ``metric_ids`` hier zu ``set(metric_ids)`` kollabiert und
+    # stattdessen ``_PILL_CATALOG_ORDER`` iteriert. ``_PILL_CATALOG_ORDER``
+    # bleibt WEISSE LISTE (welche Groessen ueberhaupt eine Pille haben), gibt
+    # aber nicht mehr die Ordnung vor. ``seen`` haelt die Entdopplung, die
+    # bisher ``set()`` nebenbei erledigt hat -- ``resolve_trip_active_metrics()``
+    # dedupliziert nicht.
+    pill_ids = set(_PILL_CATALOG_ORDER)
+    seen: set[str] = set()
     pills = []
-    for mid in _PILL_CATALOG_ORDER:
-        if mid not in ids_set:
+    for mid in metric_ids:
+        if mid not in pill_ids or mid in seen:
             continue
+        seen.add(mid)
         dps = window_dps if mid in _DAY_WINDOW_PILL_IDS else hiking_dps
         chosen = None if metric_aggregations is None else metric_aggregations.get(mid)
         pill = _pill_for_metric(mid, sms_mention_thresholds, dps, tz=tz, has_gap=has_gap,

--- a/tests/helpers/compare_order.py
+++ b/tests/helpers/compare_order.py
@@ -1,0 +1,238 @@
+"""Soll-Menge und Reihenfolge-Auslese der Compare-Uebersicht — EINE Ableitung.
+
+Epic #1703 Scheibe 7. SPEC: docs/specs/modules/fix_1703_s7_reihenfolge_matrix.md
+
+Die Menge der reihenfolge-faehigen Uebersichts-Groessen wird NICHT getippt. Sie
+ist genau die Menge der vom Compare-Katalog AUSGELIEFERTEN Eintraege
+(``get_compare_metric_catalog()``), uebersetzt in Renderer-Metrik-IDs — der
+Katalog filtert nicht waehlbare Groessen (``cape``, seit #1585) bereits selbst
+heraus. Der Waechter erbt damit die Katalog-Entscheidung, statt sie ein zweites
+Mal zu fuehren (Muster ``tests/helpers/outlook_columns.py`` aus Scheibe 2).
+
+**Grenze, ausdruecklich** (Lehre Scheibe 1 F001 / Scheibe 2 F001): wer sein Soll
+aus demselben Katalog liest wie der Prueflig, bewacht **Vollstaendigkeit**,
+nicht **Zuordnung**. Jede Zuordnungsbehauptung braucht deshalb eine eigene
+Assertion in der Achse selbst.
+
+Die Auslese-Funktionen unten liefern die REIHENFOLGE der Metrik-Zeilen/-Zellen
+je Kanal aus einer fertig gerenderten Ausgabe. Sie sind bewusst tolerant
+gegenueber dem Zell-INHALT (der ist Gegenstand von Scheibe 5) und streng
+gegenueber der Position — das ist die Achse dieser Scheibe.
+"""
+from __future__ import annotations
+
+import re
+
+from app.metric_catalog import aggregation_label_de, get_metric
+from output.renderers.compare_metric_catalog import (
+    COMPARE_METRIC_CATALOG, get_compare_metric_catalog,
+)
+from output.renderers.compare_metric_ids import FRONTEND_TO_RENDERER_METRIC_ID
+from output.renderers.email.compare_html import CV2_METRICS
+from tests.helpers.outlook_columns import nicht_waehlbare_compare_keys
+
+# Vakuum-Schutz-Untergrenze (Muster outlook_columns.py:37-40): ein Waechter,
+# der ueber eine leere oder stark geschrumpfte Menge iteriert, ist immer gruen
+# und bewacht nichts. Gemessen 2026-08-13: 25 ausgelieferte Uebersichts-Groessen.
+COMPARE_ORDER_SOLL_MINDESTGROESSE = 20
+
+_CV2_BY_KEY: dict[str, dict] = {m["key"]: m for m in CV2_METRICS}
+
+# Die Warn-Zeile ist keine sortierbare Groesse: sie steht unabhaengig von der
+# Auswahl immer als erste HTML-Zeile (#1359 AC-6) und wird deshalb aus jeder
+# Reihenfolge-Auslese entfernt.
+WARN_LABEL = "Amtliche Warnungen"
+
+
+def compare_order_soll_metriken(entries: list[dict] | None = None) -> list[str]:
+    """Die reihenfolge-faehigen Uebersichts-Groessen als Renderer-Metrik-IDs,
+    in Katalog-Reihenfolge — GERECHNET aus dem ausgelieferten Compare-Katalog.
+
+    ``entries`` injiziert eine Testkopie der Katalogzeilen (Vorbild
+    ``get_compare_metric_catalog(entries=...)``), damit der Vakuum-Schutz
+    unten ohne Monkeypatch des echten Katalogs pruefbar ist.
+    """
+    return [
+        FRONTEND_TO_RENDERER_METRIC_ID[eintrag["key"]]
+        for eintrag in get_compare_metric_catalog(entries)
+        if eintrag["key"] in FRONTEND_TO_RENDERER_METRIC_ID
+    ]
+
+
+def assert_compare_order_soll_ist_plausibel(
+    entries: list[dict] | None = None,
+) -> list[str]:
+    """Vakuum-Schutz mit ausgesprochener Rechnung: Katalog gross genug, Abzug
+    begruendet, jede Groesse in BEIDEN Uebersichts-Zwillingen (HTML-Zeilen-
+    Register ``CV2_METRICS`` und Klartext-Tabelle ``_PLAIN_ROWS``) auffindbar.
+    Gibt die Soll-Menge zurueck."""
+    from output.renderers.comparison import _PLAIN_ROWS
+
+    roh = COMPARE_METRIC_CATALOG if entries is None else entries
+    zurueckgehalten = nicht_waehlbare_compare_keys(entries)
+    geliefert = get_compare_metric_catalog(entries)
+    soll = compare_order_soll_metriken(entries)
+
+    assert soll, (
+        "Soll-Menge leer — Vakuum. Jede Achse dieser Scheibe liefe ueber null "
+        "Faelle und waere immer gruen."
+    )
+    assert len(soll) >= COMPARE_ORDER_SOLL_MINDESTGROESSE, (
+        f"Vakuum-Schutz: nur {len(soll)} reihenfolge-faehige Uebersichts-"
+        f"Groessen ({soll}) — erwartet mindestens "
+        f"{COMPARE_ORDER_SOLL_MINDESTGROESSE}. Entweder ist der Compare-Katalog "
+        "geschrumpft oder die Soll-Rechnung greift daneben."
+    )
+    assert len(soll) == len(set(soll)), (
+        f"Soll-Menge enthaelt Doppelte: {sorted(soll)} — eine paarweise "
+        "Reihenfolge-Pruefung waere damit mehrdeutig"
+    )
+    assert len(geliefert) == len(roh) - len(zurueckgehalten), (
+        f"Rechnung geht nicht auf: {len(roh)} rohe Katalog-Zeilen "
+        f"- {len(zurueckgehalten)} nicht waehlbare ({zurueckgehalten}) "
+        f"!= {len(geliefert)} ausgelieferte"
+    )
+    assert zurueckgehalten, (
+        "Der Compare-Katalog haelt keine einzige Zeile mehr wegen "
+        "selectable=False zurueck (bis 2026-08-13: 'cape_max_jkg', #1585) — "
+        "der Filterschritt waere unbewacht, die Rechnung oben trivial."
+    )
+    ohne_html_zeile = [m for m in soll if m not in _CV2_BY_KEY]
+    assert not ohne_html_zeile, (
+        f"Ohne HTML-Uebersichtszeile (CV2_METRICS): {ohne_html_zeile} — die "
+        "Reihenfolge-Pruefung koennte sie nie sehen"
+    )
+    plain_ids = {row[0] for row in _PLAIN_ROWS}
+    ohne_klartext_zeile = [m for m in soll if m not in plain_ids]
+    assert not ohne_klartext_zeile, (
+        f"Ohne Klartext-Uebersichtszeile (_PLAIN_ROWS): {ohne_klartext_zeile} "
+        "— HTML und Klartext derselben Mail waeren nicht vergleichbar"
+    )
+    return soll
+
+
+def partner_von(metric_id: str) -> str:
+    """Fester Partner fuer die paarweise Reihenfolge-Pruefung, so gewaehlt,
+    dass die beiden sichtbaren Zeilen NIE dieselbe Basis-Beschriftung
+    bekommen: ``temp_max``/``temp_min`` teilen sich die Katalog-Groesse
+    ``temperature``, alle uebrigen Uebersichts-Groessen sind gegenueber
+    ``temperature`` eindeutig (gemessen ueber ``CV2_METRICS``)."""
+    return "wind_max" if metric_id in ("temp_max", "temp_min") else "temp_max"
+
+
+def uebersichts_label(metric_id: str, sichtbare: list[str]) -> str:
+    """Die erwartete Zeilen-Beschriftung fuer ``metric_id`` bei genau der
+    Auswahl ``sichtbare`` — UNABHAENGIG von ``derive_row_labels()`` aus dem
+    Register gerechnet (Muster ``outlook_columns.compare_outlook_soll_
+    spalten``: sonst waeren Massstab und Prueflig dieselbe Funktion).
+
+    Regel (PO-Vorgabe #1401/#1453): ausgeschriebener deutscher Registername;
+    kommt derselbe Name innerhalb der SICHTBAREN Auswahl mehrfach vor, haengt
+    die deutsche Auswertung an."""
+    eintrag = _CV2_BY_KEY[metric_id]
+    basis = get_metric(eintrag["metric_id"]).label_de
+    gleichnamig = [
+        m for m in sichtbare
+        if m in _CV2_BY_KEY
+        and get_metric(_CV2_BY_KEY[m]["metric_id"]).label_de == basis
+    ]
+    if len(gleichnamig) > 1 and eintrag.get("aggregation"):
+        zusatz = aggregation_label_de(eintrag["aggregation"]) or eintrag["aggregation"]
+        return f"{basis} {zusatz}"
+    return basis
+
+
+# ---------------------------------------------------------------------------
+# Auslese je Kanal — nur die REIHENFOLGE, nie der Zellinhalt
+# ---------------------------------------------------------------------------
+
+_HTML_LABEL_RE = re.compile(
+    r'font-weight:500;font-size:12px;border-right:1px solid #f0ece1;">([^<]*)</td>'
+)
+
+
+def html_uebersicht_labels(html: str) -> list[str]:
+    """Zeilen-Beschriftungen der HTML-Uebersichtstabelle in Render-Reihenfolge,
+    ohne die immer erste Warn-Zeile (Muster ``_html_labels()`` aus
+    ``tests/unit/test_compare_metric_order.py``)."""
+    return [lbl for lbl in _HTML_LABEL_RE.findall(html) if lbl != WARN_LABEL]
+
+
+def klartext_uebersicht_labels(text: str) -> list[str]:
+    """Zeilen-Beschriftungen des ERSTEN Ortsblocks im Klartext-Teil derselben
+    Mail, in Render-Reihenfolge (Muster ``_text_labels()`` ebenda)."""
+    labels: list[str] = []
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if stripped == "STUNDENVERLAUF":
+            break
+        if not raw.startswith("   ") or stripped.startswith("⚠️") or ":" not in stripped:
+            continue
+        label = stripped.split(":", 1)[0]
+        if label in labels:  # zweiter Ortsblock -> fertig
+            break
+        labels.append(label)
+    return labels
+
+
+def telegram_zellen(nachricht: str) -> list[str]:
+    """Die Metrik-Zellen des ERSTEN Ortsblocks einer Compare-Telegram-
+    Nachricht, in Render-Reihenfolge (ganze Zelle, nicht nur das Label —
+    mehrwortige Labels wie "Temp max" wuerden sonst abgeschnitten)."""
+    for raw in nachricht.splitlines():
+        if " · " not in raw and "keine Werte" not in raw:
+            continue
+        return [
+            zelle for zelle in raw.strip().split(" · ")
+            if zelle and zelle != "keine Werte"
+        ]
+    return []
+
+
+def sms_tokens(nachricht: str) -> list[str]:
+    """Die Leerzeichen-getrennten Tokens des ERSTEN Ortsteils einer
+    Compare-SMS (Kuerzel UND Wert), in Render-Reihenfolge."""
+    _kopf, trenner, rumpf = nachricht.partition(": ")
+    if not trenner:
+        return []
+    return rumpf.split("; ")[0].split(" ")
+
+
+def sms_index(nachricht: str, kuerzel: str) -> int | None:
+    """Position des Kuerzel-Tokens in der Compare-SMS — ueber EXAKTE
+    Token-Gleichheit, nicht ueber Teilstring-Suche.
+
+    Begruendung (Muster ``_first_index_starting_with()`` in
+    ``test_channel_metric_matrix.py``): die Compare-Kuerzel sind teilweise
+    Praefixe voneinander ("N" ist Wortanfang von "NL"/"NS", "C" von "CT"/
+    "CL"/"CH"/"CM"). Eine ``in``-Suche schluege am falschen Token an und die
+    Reihenfolge-Aussage waere Zufall. ``None`` = Kuerzel nicht in der
+    Nachricht (z.B. vom Zeichen-Budget verdraengt)."""
+    treffer = [i for i, tok in enumerate(sms_tokens(nachricht)) if tok == kuerzel]
+    assert len(treffer) <= 1, (
+        f"Kuerzel {kuerzel!r} kommt {len(treffer)}-mal im ersten Ortsteil vor "
+        f"— die Positionsaussage waere mehrdeutig.\n{nachricht!r}"
+    )
+    return treffer[0] if treffer else None
+
+
+def sms_kuerzel(loc_result, metric_id: str) -> str:
+    """Das SMS-Kuerzel-Token, unter dem ``metric_id`` in der Compare-SMS
+    erscheint (inkl. Auswertungszeichen ``+``/``-``, #1362 S5b).
+
+    Bewusst aus dem Produktiv-Baustein ``_sms_metric_cell()`` gelesen: er ist
+    hier reiner ORTSFINDER fuer eine Reihenfolge-Aussage und selbst
+    reihenfolge-blind (er kennt genau eine Groesse). Die Zusicherung dieser
+    Achse — dass die Zell-FOLGE der Nutzerliste folgt — entsteht dadurch
+    nicht; sie entsteht aus dem paarweisen Vergleich zweier Renderlaeufe.
+    Ein zweites, hier getipptes Kuerzel-Vokabular waere die vierte Handkopie
+    (s. comparison.py:640-660) und liefe der Katalog-Aenderung hinterher."""
+    from output.renderers.comparison import _sms_metric_cell
+
+    zelle = _sms_metric_cell(loc_result, metric_id)
+    assert zelle is not None, (
+        f"{metric_id!r} hat an diesem Ort keinen SMS-Wert — die Fixture muss "
+        "jede geprueften Groesse befuellen, sonst misst der Test das Fehlen "
+        "statt der Reihenfolge"
+    )
+    return zelle.split(" ", 1)[0]

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -80,6 +80,7 @@ from __future__ import annotations
 
 import dataclasses
 import importlib
+import itertools
 import json
 import re
 from collections import Counter
@@ -4018,11 +4019,18 @@ def _s7_pruefe_kanal_reihenfolge(
         # Das GANZE Label tragen, nie nur sein erstes Wort (Adversary S7 F001):
         # "Gefuehlte Temp. min"/"Gefuehlte Temp. max" und "Wolken"/"Wolken
         # tief" teilen sich den Wortanfang -- ein Wortanfang-Vergleich hielte
-        # ihre Vertauschung fuer richtig (Gegenprobe: AC-S7-5c unten).
-        # Muster AC-S7-8a: volles Label per ``startswith``. Das angehaengte
-        # Leerzeichen trennt zusaetzlich "Wolken " von "Wolken tief" -- jede
-        # der 25 Uebersichts-Zellen hat die Form "<Label> <Wert>" (gemessen
-        # 2026-08-14 ueber alle _S7_SOLL-Groessen).
+        # ihre Vertauschung fuer richtig (Gegenproben: AC-S7-5c/5d unten).
+        # Muster AC-S7-8a: volles Label per ``startswith``.
+        #
+        # Das angehaengte Leerzeichen ist Haertung gegen eine VERTAUSCHTE
+        # GROESSE ("Wolken " faengt nicht auf "Wolken tief 10%" an), nicht
+        # gegen eine vertauschte REIHENFOLGE: auf einer Permutation derselben
+        # Menge sind beide Formen gleichwertig, weil ein Label nur Praefix
+        # eines echt laengeren sein kann und die Gesamtlaenge erhalten bleibt.
+        # 5c/5d unterscheiden es deshalb NICHT (gemessen 2026-08-14: das
+        # Leerzeichen entfernt -> alle fuenf S7-5-Achsen bleiben gruen). Es
+        # kostet nichts, weil jede der 25 Uebersichts-Zellen die Form
+        # "<Label> <Wert>" hat (ebenfalls gemessen).
         assert len(zellen) == len(erwartet) and all(
             z.startswith(f"{e} ") for z, e in zip(zellen, erwartet)
         ), f"{wo}: Telegram zeigt {zellen} statt der Reihenfolge {erwartet}"
@@ -4137,6 +4145,55 @@ def test_ac_s7_5c_telegram_vergleich_faengt_praefix_kollision():
     )
     with pytest.raises(AssertionError):
         _s7_pruefe_kanal_reihenfolge("telegram", vertauscht, "Gegenprobe", ids=ids)
+
+
+@pytest.mark.parametrize(
+    "ids",
+    [
+        ["cloud_avg", "cloud_low_avg"],
+        ["cloud_avg", "cloud_low_avg", "cloud_mid_avg"],
+    ],
+    ids=["paar", "tripel"],
+)
+def test_ac_s7_5d_telegram_vergleich_faengt_die_wolken_kollision(ids):
+    """AC-S7-5 (zweite Pflicht-Gegenprobe, Adversary S7 F002): die Wolken-
+    Familie ist die haertere Kollision -- "Wolken" ist nicht nur
+    wortanfangsgleich mit "Wolken tief"/"Wolken mittel", sondern deren echtes
+    PRAEFIX. AC-S7-5c oben deckt nur das wind_chill-Paar; die Wolken-Familie
+    stand bisher bloss im Kommentar.
+
+    Die drei sind so gewaehlt, dass ALLE denselben Wortanfang "Wolken" tragen
+    -- der frueher benutzte Wortanfang-Vergleich ist damit auf JEDER
+    Vertauschung gruen und kann keine einzige sehen. Geprueft werden alle
+    Vertauschungen statt nur der umgekehrten Folge, und der Tripel-Fall
+    zusaetzlich zum Paar: bei zwei Elementen liesse sich ein Fang noch mit dem
+    Sonderfall der Vollvertauschung erklaeren, bei drei nicht mehr."""
+    erwartet = [_PLAIN_ROWS_BY_ID[m][1] for m in ids]
+    assert len({e.split(" ")[0] for e in erwartet}) == 1, (
+        f"Vakuum: {ids} teilen sich ihren Wortanfang nicht mehr ({erwartet}) "
+        "-- die Gegenprobe pruefte dann eine Kollision, die es nicht gibt"
+    )
+    assert len(set(erwartet)) == len(erwartet), (
+        f"Vakuum: {ids} teilen sich das GANZE Telegram-Label ({erwartet})"
+    )
+
+    for folge in itertools.permutations(ids):
+        if list(folge) == ids:
+            continue
+        vertauscht = render_compare_telegram(
+            _s7_result(), enabled_metrics=list(folge),
+        )
+        zellen = telegram_zellen(vertauscht)
+        assert [z.split(" ")[0] for z in zellen] == [
+            e.split(" ")[0] for e in erwartet
+        ], (
+            f"Vakuum: der ALTE Wortanfang-Vergleich muss auf {zellen} gruen "
+            "sein, sonst belegt die Gegenprobe nichts"
+        )
+        with pytest.raises(AssertionError):
+            _s7_pruefe_kanal_reihenfolge(
+                "telegram", vertauscht, f"Gegenprobe {list(folge)}", ids=ids,
+            )
 
 
 # --- AC-S7-6: DER FIX -- die Kurz-E-Mail folgt der eingestellten Ordnung --

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -1,12 +1,14 @@
-"""TDD RED: Issue #1677 Scheibe B -- Vollstaendigkeits-Matrix Metrik-Katalog x
-Kanal, damit die Fehlerklasse "Bedienelement ohne Wirkung" (#1450, #1362,
-#1660 A/B, #1677) strukturell bewacht ist statt fallweise entdeckt zu werden.
+"""Vollstaendigkeits-Matrix Metrik-Katalog x Kanal, damit die Fehlerklasse
+"Bedienelement ohne Wirkung" (#1450, #1362, #1660 A/B, #1677) strukturell
+bewacht ist statt fallweise entdeckt zu werden. Angelegt als TDD RED zu Issue
+#1677 Scheibe B, seither um mehrere Achsen von Epic #1703 gewachsen -- welcher
+Anteil ROT war, steht bei der jeweiligen Scheibe unten.
 
 SPEC: docs/specs/modules/fix_1677_sms_reihenfolge.md AC-13/AC-14/AC-15.
 
-Parametrisiert ueber ``app.metric_catalog.get_all_metrics()`` (26
-waehlbare Metriken). Pro Kanal wird gegen die Funktion getestet, die der
-jeweilige Produktivpfad TATSAECHLICH aufruft (kein Duplikat-Rendering):
+Parametrisiert ueber ``app.metric_catalog.get_all_metrics()`` (25 waehlbare
+Metriken, gemessen 2026-08-14). Pro Kanal wird gegen die Funktion getestet,
+die der jeweilige Produktivpfad TATSAECHLICH aufruft (kein Duplikat-Rendering):
 - E-Mail:        ``resolve_metric_col_order`` (email/html.py:1021 ``_col_order``)
 - Telegram-rich: ``render_for_channel`` (narrow.py:644)
 - SMS-Kurzform:  ``TripReportFormatter().format_email() -> report.sms_text``
@@ -17,12 +19,17 @@ AC-Zuordnung:
 - AC-14 (Telegram-rich):  test_ac14_telegram_rich_selection_and_order      -> GRUEN (Bestand, #429/#1575)
 - AC-15 (SMS-Kurzform):   test_ac15_sms_kurzform_selection_deselection_and_order
     - (a)/(b) Auswahl/Abwahl -> GRUEN (Bestand, Bug-#944-Muster + #1415/#1660B)
-    - (c) Nutzer-Reihenfolge -> RED (exakt die Luecke aus #1677)
+    - (c) Nutzer-Reihenfolge -> GRUEN seit dem Fix zu #1677/#1660 B
+      (``_POSITION_SORTABLE_CATEGORIES`` in output/tokens/builder.py,
+      ``MetricSpec.position``); beim Schreiben dieser Datei war sie ROT
     - (d) ohne SMS-Layout   -> GRUEN (Charakterisierung, wie AC-2)
 
-E-Mail/Telegram sind bewusste GRUEN-Ausnahmen (Bestandsfunktion, hier nur
-strukturell abgesichert) -- der SMS-Kurzform-Reihenfolge-Teil ist der
-einzige neue, heute rote Anteil dieser Datei.
+Alle drei Achsen laufen heute GRUEN: E-Mail/Telegram waren von Anfang an
+Bestandsfunktion (hier nur strukturell abgesichert), die SMS-Kurzform-
+Reihenfolge ist seit #1677 gefixt. Hier stand bis 2026-08-14, sie sei "der
+einzige neue, heute rote Anteil dieser Datei" -- das galt zum Schreibzeitpunkt
+und war seither ueberholt; der Satz liess den Zuschnitt von Epic #1703
+Scheibe 7 zunaechst zu breit erscheinen.
 
 Epic #1703 Scheibe 3 (AC-1 bis AC-8, unten): schliesst die
 get_all_metrics()-vs-_METRICS-Blindstelle (docs/reference/metric_output_matrix.md
@@ -50,6 +57,24 @@ Trip-Aufrufstellen des geteilten Ausblick-Renderers uebergeben kein
 ``metrics``-Argument, s. Spec "Korrektur der Scheiben-Praemisse"). ROTER
 Anteil: AC-S2-4 (fuenf dauerhaft leere Spalten) und AC-S2-5 (die beiden
 Tages-Aggregationspfade sind auseinandergelaufen).
+
+Epic #1703 Scheibe 7 (AC-S7-1 bis AC-S7-9, weiter unten): die REIHENFOLGE
+derselben 25 Uebersichts-Groessen ueber alle Ausgabeorte
+(docs/reference/metric_output_matrix.md) -- bewacht war bisher, DASS eine
+gewaehlte Groesse erscheint, nicht AN WELCHER STELLE. Die Soll-Menge wird aus
+``get_compare_metric_catalog()`` GERECHNET, nie getippt (AC-S7-1, mit
+Vakuum-Schutz AC-S7-1b). SPEC:
+docs/specs/modules/fix_1703_s7_reihenfolge_matrix.md. Achsen: HTML- und
+Klartext-Zwilling derselben Compare-Mail (AC-S7-2/3), Altbestand ohne
+gespeicherte Auswahl (AC-S7-4, Charakterisierung der HTML/Klartext-Divergenz),
+je Kanal eine EIGENE Reihenfolge in EINER Sendung -- am echten Versand- UND
+Vorschaupfad (AC-S7-5/5b, Gegenprobe zum Label-Vergleich AC-S7-5c),
+Trip-Kurzuebersicht und ihre zwei Reihenfolge-Quellen (AC-S7-7/7b),
+Compare-Telegram/-SMS unter Kappung (AC-S7-8a/8b/8c), Kompakt-Fliesstext als
+benannte Ausnahme ohne Reihenfolge-Achse (AC-S7-9). EINZIGER roter Anteil:
+AC-S7-6 -- die Pillen der Kurz-E-Mail verwarfen die eingestellte Ordnung
+(``build_metrics_summary_pills()`` kollabierte die geordnete Liste zu einer
+Menge).
 """
 from __future__ import annotations
 
@@ -80,12 +105,14 @@ from output.renderers.alert.render import (
     _HANDLED_UNITS, render_email, render_sms, render_subject, render_telegram,
 )
 from output.channels.premium_sms import PremiumSmsOutput
-from output.renderers.channel_layout import render_for_channel
+from output.renderers.channel_layout import CHANNEL_LIMITS, render_for_channel
 from output.renderers.email.compare_html import CV2_METRICS
 from output.renderers.compare_metric_catalog import COMPARE_METRIC_CATALOG, get_compare_metric_catalog
 from output.renderers.compare_metric_ids import FRONTEND_TO_RENDERER_METRIC_ID, resolve_enabled_metrics
-from output.renderers.comparison import render_compare_email
-from output.renderers.email.helpers import resolve_metric_col_order
+from output.renderers.comparison import (
+    _PLAIN_ROWS_BY_ID, render_compare_email, render_compare_sms, render_compare_telegram,
+)
+from output.renderers.email.helpers import _PILL_CATALOG_ORDER, resolve_metric_col_order
 from output.renderers.email.html import _render_mobile_compact_rows
 from output.renderers.sms_trip import SMS_SYMBOL_BY_METRIC, SMS_MULTI_SYMBOLS_BY_METRIC
 from output.renderers.trip_metric_ids import DEFAULT_TRIP_METRIC_IDS
@@ -94,6 +121,11 @@ from services.report_config_resolver import ReportRenderOptions
 from services.weather_change_detection import _ALERT_METRIC_TO_CATALOG_ID, is_alert_metric_active
 from services.weather_metrics import WeatherMetricsService, summarize_points
 
+from tests.helpers.compare_order import (
+    assert_compare_order_soll_ist_plausibel, compare_order_soll_metriken,
+    html_uebersicht_labels, klartext_uebersicht_labels, partner_von,
+    sms_index, sms_kuerzel, telegram_zellen, uebersichts_label,
+)
 from tests.helpers.outlook_columns import (
     assert_soll_menge_ist_plausibel, compare_outlook_soll_paare,
     compare_outlook_soll_spalten,
@@ -105,6 +137,13 @@ from tests.tdd import _min_temp_felt_fixtures as F
 # auch im importierenden Modul).
 from tests.tdd.test_channel_origin_guard_parity import (
     _prod_style_premium_sms_settings, premium_sms_stub,  # noqa: F401 - pytest loest die Fixture per Name auf
+)
+# Issue #1703 S7 AC-S7-5: geteilter Daten-/Engine-Rahmen des Scheibe-8-
+# Waechters -- echte ComparisonEngine-Subklasse, echte Renderer, kein Netz,
+# kein Mock. Wiederverwendet statt kopiert (dasselbe Muster wie oben).
+from tests.unit.test_compare_channel_metrics_reach_the_renderer import (
+    LOCATION as _S7_LOCATION, TARGET_DATE as _S7_TARGET_DATE,
+    env,  # noqa: F401 - pytest loest die Fixture per Name auf
 )
 
 _ALL_METRIC_IDS = [m.id for m in get_all_metrics()]
@@ -3686,3 +3725,746 @@ def test_ac_s5_6_abhaengigkeits_anker_auf_die_15_bereits_gedeckten_zeilen(moduln
             "die Wertpruefung fuer eine der 15 bereits gedeckten Compare-"
             "Uebersichtszeilen ist verwaist."
         )
+
+
+# ===========================================================================
+# Epic #1703 Scheibe 7 (AC-S7-1 bis AC-S7-9): Reihenfolge-Waechter jenseits
+# E-Mail-Vollformat und Telegram-rich (docs/reference/metric_output_matrix.md
+# Flaeche 5). SPEC: docs/specs/modules/fix_1703_s7_reihenfolge_matrix.md
+#
+# Korrektur der Scheiben-Praemisse (s. Spec): Flaeche 5 nennt die
+# Trip-SMS-Reihenfolge als Luecke -- sie ist seit #1677/#1660 B ueber
+# AC-15 (c) oben bewacht. Bewacht war dagegen NICHT die Katalog-DECKUNG der
+# Compare-Uebersicht (Bestand `tests/unit/test_compare_metric_order.py`:
+# 4 fest getippte von 25 Groessen, EINE globale Liste) und gar nicht die
+# Kanal-Achse aus Scheibe 8.
+#
+# Pruefmuster durchgehend PAARWEISE: dieselbe Metrik-MENGE in zwei
+# Reihenfolgen rendern und die Positionen vergleichen. Ein Test gegen eine
+# einzelne feste Erwartung faengt "intern nach eigener Prioritaet umsortiert"
+# nicht.
+#
+# Pruefort = Wirkort: gemessen wird die zugestellte Ausgabe je Kanal, nie der
+# Rueckgabewert von `resolve_channel_enabled_metrics()` (Lehre Scheibe 8:
+# viermal war die reine Funktion geprueft und die Aufrufstelle nicht).
+#
+# ROTER Anteil: AC-S7-6 (die Kurz-E-Mail-Pillen verwerfen die Reihenfolge,
+# `build_metrics_summary_pills()` kollabiert die geordnete Liste zu einer
+# Menge). Alles Uebrige ist Charakterisierung bisher ungeprueften, aber
+# korrekten Verhaltens.
+# ===========================================================================
+
+_S7_SOLL = compare_order_soll_metriken()
+
+
+def _s7_dp(hour: int, temp: float, wind: float) -> ForecastDataPoint:
+    """EIN reich besetzter Stundenpunkt -- jede der 25 Uebersichts-Groessen
+    muss an jedem Ort einen Wert haben, sonst entfaellt ihre Zeile/Zelle und
+    der Test misst das Fehlen statt der Reihenfolge."""
+    return ForecastDataPoint(
+        ts=datetime(2026, 8, 12, hour, 0, tzinfo=timezone.utc),
+        t2m_c=temp, wind10m_kmh=wind, wind_direction_deg=180, gust_kmh=wind + 10,
+        precip_1h_mm=1.0, cloud_total_pct=40, cloud_low_pct=10, cloud_mid_pct=20,
+        cloud_high_pct=30, pop_pct=50, uv_index=4.0, visibility_m=9000,
+        pressure_msl_hpa=1013.0, humidity_pct=70, dewpoint_c=8.0,
+        snow_depth_cm=3.0, snow_new_24h_cm=2.0, snowfall_limit_m=1800,
+        freezing_level_m=3200, precip_type=PrecipType.RAIN,
+        thunder_level=ThunderLevel.MED, wind_chill_c=temp - 2, is_day=1,
+        dni_wm2=300.0,
+    )
+
+
+def _s7_location(loc_id: str, name: str):
+    from app.user import LocationResult, SavedLocation
+
+    return LocationResult(
+        location=SavedLocation(
+            id=loc_id, name=name, lat=47.0, lon=11.0, elevation_m=600,
+        ),
+        score=1,
+        temp_max=22.0, temp_min=11.0, wind_max=15.0, gust_max=30.0,
+        wind_direction_avg=180, wind_chill_min=8.0, wind_chill_max=18.0,
+        cloud_avg=40, cloud_low_avg=10, cloud_mid_avg=20, cloud_high_avg=30,
+        sunny_hours=5, snow_depth_cm=3.0, snow_new_cm=2.0,
+        precip_sum_mm=2.0, pop_max_pct=50, uv_index_max=4.0,
+        visibility_min_m=9000, thunder_level_max=ThunderLevel.MED,
+        hourly_data=[_s7_dp(9, 12.0, 10.0), _s7_dp(12, 22.0, 15.0), _s7_dp(15, 18.0, 12.0)],
+        official_alerts=[],
+    )
+
+
+@lru_cache(maxsize=None)
+def _s7_result(anzahl: int = 3):
+    """``ComparisonResult`` mit ``anzahl`` gleich befuellten Orten. Gecacht --
+    die Renderer sind reine Funktionen, jede Achse liest dasselbe Ergebnis."""
+    from app.user import ComparisonResult
+
+    namen = ["Aachen", "Bremen", "Chemnitz"][:anzahl]
+    return ComparisonResult(
+        locations=[_s7_location(f"s7-{i}", nm) for i, nm in enumerate(namen)],
+        time_window=(0, 23), target_date=date(2026, 8, 12),
+        created_at=datetime(2026, 8, 12, 4, 0),
+    )
+
+
+@lru_cache(maxsize=None)
+def _s7_mail_paar(metric_id: str):
+    """Beide Reihenfolgen EINES Metrik-Paares als ((html_a, text_a),
+    (html_b, text_b)). EIN ``render_compare_email()``-Aufruf je Richtung
+    liefert HTML UND Klartext derselben Mail -- AC-S7-2 und AC-S7-3 lesen
+    denselben Aufruf, damit eine Divergenz zwischen beiden Formen nicht durch
+    getrennte Aufrufe verdeckt wird."""
+    partner = partner_von(metric_id)
+    return (
+        render_compare_email(_s7_result(), enabled_metrics=[metric_id, partner]),
+        render_compare_email(_s7_result(), enabled_metrics=[partner, metric_id]),
+    )
+
+
+# --- AC-S7-1: Soll-Menge gerechnet, Vakuum-geschuetzt ----------------------
+
+def test_ac_s7_1_soll_menge_gerechnet_und_vakuumgeschuetzt():
+    """AC-S7-1: die geprueften Groessen stammen ausschliesslich aus
+    ``get_compare_metric_catalog()`` (26 rohe Katalog-Zeilen minus der nicht
+    waehlbaren ``cape_max_jkg`` = 25), nie aus einer getippten Liste; unter
+    20 Eintraegen scheitert der Vakuum-Schutz ausdruecklich."""
+    soll = assert_compare_order_soll_ist_plausibel()
+    assert soll == _S7_SOLL, (
+        "AC-S7-1: die Modul-Konstante _S7_SOLL und die frisch gerechnete "
+        f"Soll-Menge laufen auseinander: {_S7_SOLL} vs. {soll}"
+    )
+
+
+def test_ac_s7_1b_vakuum_schutz_schlaegt_bei_leerem_katalog_an():
+    """AC-S7-1 (Pflicht-Gegenprobe, Spec Mutation 5): waere der Katalog leer
+    oder stark geschrumpft, MUSS der Vakuum-Schutz scheitern statt
+    stillschweigend zu bestehen -- sonst liefe die ganze Achse ueber null
+    Faelle und waere immer gruen. Geprueft ueber die Katalog-Injektion
+    (``entries=``), ohne den echten Katalog anzufassen."""
+    with pytest.raises(AssertionError):
+        assert_compare_order_soll_ist_plausibel(entries=[])
+    with pytest.raises(AssertionError):
+        assert_compare_order_soll_ist_plausibel(
+            entries=[e for e in COMPARE_METRIC_CATALOG[:3]]
+        )
+
+
+# --- AC-S7-2: Compare-HTML folgt der Reihenfolge, ueber den ganzen Katalog -
+
+@pytest.mark.parametrize("metric_id", _S7_SOLL)
+def test_ac_s7_2_compare_html_folgt_der_reihenfolge(metric_id):
+    """AC-S7-2: dieselbe Vergleichs-Mail, einmal mit [A, B] und einmal mit
+    [B, A] gerendert, zeigt in der HTML-Uebersichtstabelle die beiden Zeilen
+    in genau dieser Reihenfolge -- fuer JEDE der 25 waehlbaren Groessen
+    gegen einen festen Partner, nicht nur fuer vier ausgewaehlte (Bestand
+    #1359)."""
+    partner = partner_von(metric_id)
+    sichtbare = [metric_id, partner]
+    label_m = uebersichts_label(metric_id, sichtbare)
+    label_p = uebersichts_label(partner, sichtbare)
+    assert label_m != label_p, (
+        f"Vakuum: {metric_id!r} und Partner {partner!r} teilen sich die "
+        f"Beschriftung {label_m!r} -- eine Positionsaussage waere mehrdeutig"
+    )
+    (html_a, _text_a), (html_b, _text_b) = _s7_mail_paar(metric_id)
+    assert html_uebersicht_labels(html_a) == [label_m, label_p], (
+        f"AC-S7-2: Reihenfolge [{metric_id}, {partner}] ergibt in der "
+        f"HTML-Uebersicht {html_uebersicht_labels(html_a)}"
+    )
+    assert html_uebersicht_labels(html_b) == [label_p, label_m], (
+        f"AC-S7-2: Reihenfolge [{partner}, {metric_id}] ergibt in der "
+        f"HTML-Uebersicht {html_uebersicht_labels(html_b)} -- dieselbe MENGE "
+        "in zwei Reihenfolgen muss zwei verschiedene Zeilenfolgen ergeben"
+    )
+
+
+# --- AC-S7-3: Compare-Klartext folgt derselben Reihenfolge ----------------
+
+@pytest.mark.parametrize("metric_id", _S7_SOLL)
+def test_ac_s7_3_compare_klartext_folgt_derselben_reihenfolge(metric_id):
+    """AC-S7-3: der Klartext-Teil DERSELBEN Mail (ein Aufruf, zwei Formen)
+    zeigt dieselbe Metrik-Reihenfolge wie der HTML-Teil -- und zwar
+    zugeordnet, nicht nur gleich lang (Lehre Scheibe 2 F001: Rechnen sichert
+    Vollstaendigkeit, nie Zuordnung)."""
+    partner = partner_von(metric_id)
+    sichtbare = [metric_id, partner]
+    label_m = uebersichts_label(metric_id, sichtbare)
+    label_p = uebersichts_label(partner, sichtbare)
+    (html_a, text_a), (html_b, text_b) = _s7_mail_paar(metric_id)
+    for richtung, html, text, erwartet in (
+        ("A", html_a, text_a, [label_m, label_p]),
+        ("B", html_b, text_b, [label_p, label_m]),
+    ):
+        klartext = klartext_uebersicht_labels(text)
+        assert klartext == erwartet, (
+            f"AC-S7-3 (Richtung {richtung}): der Klartext-Teil zeigt "
+            f"{klartext} statt {erwartet}"
+        )
+        assert klartext == html_uebersicht_labels(html), (
+            f"AC-S7-3 (Richtung {richtung}): Klartext {klartext} weicht vom "
+            f"HTML {html_uebersicht_labels(html)} DERSELBEN Mail ab"
+        )
+
+
+# --- AC-S7-4: Altbestand ohne gespeicherte Auswahl (Charakterisierung) ----
+
+def test_ac_s7_4_altbestand_html_und_klartext_divergieren_charakterisiert():
+    """AC-S7-4 (CHARAKTERISIERUNG, kein Fix -- Spec 'Bewusst NICHT in dieser
+    Scheibe'): ohne gespeicherte Auswahl (``enabled_metrics=None``) behaelt
+    jede Form derselben Mail ihre eigene Quellcode-Ordnung. Die MENGEN sind
+    identisch (25 Zeilen), die ORDNUNG nicht -- erste Abweichung an Position
+    3: HTML fuehrt dort ``precip_sum`` (CV2_METRICS), der Klartext
+    ``temp_min`` (_PLAIN_ROWS).
+
+    Ein Fix zoege den Bestandstest ``test_compare_metric_order.py`` AC-7 mit,
+    der die _PLAIN_ROWS-Ordnung ausdruecklich als Altbestands-Standard
+    einfriert -- eigene Entscheidung, Nebenbefund #1199. Faellt dieser Test
+    rot, hat sich das Produktivverhalten geaendert: dann Spec-Korrektur statt
+    Test-Anpassung pruefen."""
+    html, text = render_compare_email(_s7_result(), enabled_metrics=None)
+    html_labels = html_uebersicht_labels(html)
+    text_labels = klartext_uebersicht_labels(text)
+    assert len(html_labels) == len(_S7_SOLL) == len(text_labels), (
+        f"AC-S7-4: {len(html_labels)} HTML- und {len(text_labels)} "
+        f"Klartext-Zeilen bei {len(_S7_SOLL)} Katalog-Groessen"
+    )
+    assert set(html_labels) == set(text_labels), (
+        "AC-S7-4: HTML und Klartext zeigen NICHT dieselbe Menge -- das waere "
+        "ein anderer, schwererer Befund als die reine Ordnungs-Divergenz.\n"
+        f"nur HTML: {sorted(set(html_labels) - set(text_labels))}\n"
+        f"nur Klartext: {sorted(set(text_labels) - set(html_labels))}"
+    )
+    assert html_labels != text_labels, (
+        "AC-S7-4: die Altbestands-Divergenz ist verschwunden -- gut moeglich "
+        "ein bewusster Fix, dann gehoert diese Charakterisierung ersetzt "
+        "(und der Bestandstest AC-7 mitgezogen)."
+    )
+    erste_abweichung = next(
+        i for i, (h, t) in enumerate(zip(html_labels, text_labels)) if h != t
+    )
+    assert erste_abweichung == 2, (
+        f"AC-S7-4: erste Abweichung an Position {erste_abweichung + 1}, "
+        "gemessen 2026-08-13 war es Position 3"
+    )
+    assert html_labels[2] == uebersichts_label("precip_sum", _S7_SOLL), (
+        f"AC-S7-4: HTML-Position 3 traegt {html_labels[2]!r}"
+    )
+    assert text_labels[2] == uebersichts_label("temp_min", _S7_SOLL), (
+        f"AC-S7-4: Klartext-Position 3 traegt {text_labels[2]!r}"
+    )
+
+
+# --- AC-S7-5: kanalweise unterschiedliche Reihenfolge in EINER Sendung ----
+#
+# Die drei Kanal-Listen fuehren DIESELBE Menge in DREI verschiedenen
+# Reihenfolgen, die Grundauswahl (= MAXIMUM, ADR-0050 Regel 1) in einer
+# VIERTEN. Faellt eine der acht Aufrufstellen auf die gemeinsame
+# `opts.enabled_metrics` zurueck, zeigt genau dieser Kanal die vierte
+# Ordnung und faellt EINZELN auf -- ein Nachweis auf
+# `resolve_channel_enabled_metrics()` faenge das nicht (dort ist die
+# Mechanik korrekt, die Wirkung haengt an der Aufrufstelle).
+#
+# Der Daten-/Engine-Rahmen (`env`, oben importiert) ist der Waechter aus
+# Scheibe 8: echte Engine-Subklasse, echte Renderer, kein Mock/patch, kein Netz.
+
+_S7_KANAL_ORDNUNG: dict[str, list[str]] = {
+    "email": ["temp_max_c", "sunny_hours_h", "uv_index_max"],
+    "telegram": ["sunny_hours_h", "uv_index_max", "temp_max_c"],
+    "sms": ["uv_index_max", "temp_max_c", "sunny_hours_h"],
+}
+_S7_GRUNDAUSWAHL = ["temp_max_c", "uv_index_max", "sunny_hours_h"]
+
+
+def _s7_kanal_preset(preset_id: str, user_id: str) -> dict:
+    return {
+        "id": preset_id, "name": "S7-Reihenfolge", "user_id": user_id,
+        "kind": "vergleich", "location_ids": [_S7_LOCATION.id], "schedule": "daily",
+        "profil": "ALLGEMEIN", "created_at": "2026-07-01T00:00:00Z",
+        "send_telegram": True, "send_sms": True,
+        # Stundenverlauf/Ausblick aus: diese Achse betrifft NUR die
+        # Uebersicht -- beide Bloecke wuerden die Kuerzel-Suche stoeren.
+        "hourly_enabled": False, "outlook_enabled": False,
+        "display_config": {
+            "active_metrics": list(_S7_GRUNDAUSWAHL),
+            "channel_active_metrics": {k: list(v) for k, v in _S7_KANAL_ORDNUNG.items()},
+        },
+    }
+
+
+def _s7_erwartete_renderer_ids(kanal: str) -> list[str]:
+    return [FRONTEND_TO_RENDERER_METRIC_ID[k] for k in _S7_KANAL_ORDNUNG[kanal]]
+
+
+def _s7_pruefe_kanal_reihenfolge(
+    kanal: str, ausgabe: str, wo: str, ids: list[str] | None = None,
+) -> None:
+    """Die Reihenfolge-Aussage je Kanal an der jeweils ZUGESTELLTEN Ausgabe --
+    HTML-Zeilenfolge, Telegram-Zellfolge, SMS-Tokenfolge.
+
+    ``ids`` injiziert eine andere Soll-Folge als die des Kanals (Vorbild
+    ``assert_compare_order_soll_ist_plausibel(entries=...)``), damit die
+    Gegenprobe unten den Vergleich selbst pruefen kann."""
+    ids = _s7_erwartete_renderer_ids(kanal) if ids is None else ids
+    if kanal == "email":
+        erwartet = [uebersichts_label(m, ids) for m in ids]
+        assert html_uebersicht_labels(ausgabe) == erwartet, (
+            f"{wo}: die E-Mail zeigt {html_uebersicht_labels(ausgabe)} statt "
+            f"{erwartet} -- vermutlich liest die Aufrufstelle wieder die "
+            f"gemeinsame `opts.enabled_metrics` ({_S7_GRUNDAUSWAHL})"
+        )
+    elif kanal == "telegram":
+        zellen = telegram_zellen(ausgabe)
+        erwartet = [_PLAIN_ROWS_BY_ID[m][1] for m in ids]
+        # Das GANZE Label tragen, nie nur sein erstes Wort (Adversary S7 F001):
+        # "Gefuehlte Temp. min"/"Gefuehlte Temp. max" und "Wolken"/"Wolken
+        # tief" teilen sich den Wortanfang -- ein Wortanfang-Vergleich hielte
+        # ihre Vertauschung fuer richtig (Gegenprobe: AC-S7-5c unten).
+        # Muster AC-S7-8a: volles Label per ``startswith``. Das angehaengte
+        # Leerzeichen trennt zusaetzlich "Wolken " von "Wolken tief" -- jede
+        # der 25 Uebersichts-Zellen hat die Form "<Label> <Wert>" (gemessen
+        # 2026-08-14 ueber alle _S7_SOLL-Groessen).
+        assert len(zellen) == len(erwartet) and all(
+            z.startswith(f"{e} ") for z, e in zip(zellen, erwartet)
+        ), f"{wo}: Telegram zeigt {zellen} statt der Reihenfolge {erwartet}"
+    else:
+        ort = _s7_result(1).locations[0]
+        positionen = [sms_index(ausgabe, sms_kuerzel(ort, m)) for m in ids]
+        assert all(p is not None for p in positionen), (
+            f"{wo}: nicht jede gewaehlte Groesse steht in der SMS "
+            f"({positionen}) -- {ausgabe!r}"
+        )
+        assert positionen == sorted(positionen), (
+            f"{wo}: die SMS-Token-Folge {positionen} widerspricht der "
+            f"eingestellten Reihenfolge {ids} -- {ausgabe!r}"
+        )
+
+
+def test_ac_s7_5_versand_traegt_je_kanal_eine_eigene_reihenfolge(
+    env,  # noqa: F811 - pytest loest die Fixture per Name auf
+    tmp_path,
+):
+    """AC-S7-5: GIVEN ein Vergleich, dessen drei Kanaele DIESELBEN Groessen in
+    DREI verschiedenen Reihenfolgen fuehren / WHEN der echte Versandpfad
+    laeuft / THEN traegt jede zugestellte Nachricht die Reihenfolge IHRES
+    Kanals."""
+    from app.config import Settings
+    from services.scheduler_dispatch_service import send_one_compare_preset
+
+    ordnungen = [tuple(v) for v in _S7_KANAL_ORDNUNG.values()] + [tuple(_S7_GRUNDAUSWAHL)]
+    assert len(set(ordnungen)) == 4, (
+        "Vakuum: die drei Kanal-Reihenfolgen und die Grundauswahl muessen "
+        f"paarweise verschieden sein, sind aber {ordnungen}"
+    )
+
+    versandt: dict[str, list[str]] = {"email": [], "telegram": [], "sms": []}
+    send_one_compare_preset(
+        _s7_kanal_preset("cp-s7-dispatch", env),
+        Settings(
+            smtp_host="dummy.invalid", smtp_user="dummy", smtp_pass="dummy",
+            mail_to="dummy@example.invalid", telegram_bot_token="dummy-token",
+            telegram_chat_id="123456", sms_gateway_url="https://sms.invalid",
+            seven_api_key="k", sms_to="+491700000000",
+        ),
+        env, str(tmp_path), all_locations_cache=[_S7_LOCATION],
+        target_date=_S7_TARGET_DATE, tage_ab_ortstag=0,
+        mail_sink=lambda subject, body: versandt["email"].append(body),
+        telegram_sink=versandt["telegram"].append,
+        sms_sink=versandt["sms"].append,
+    )
+    for kanal, zugestellt in versandt.items():
+        assert len(zugestellt) == 1, (
+            f"{kanal}: eine Zustellung erwartet, waren {len(zugestellt)}"
+        )
+        _s7_pruefe_kanal_reihenfolge(kanal, zugestellt[0], "Versandpfad")
+
+
+def test_ac_s7_5b_vorschau_zeigt_dieselbe_reihenfolge_wie_der_versand(
+    env,  # noqa: F811 - pytest loest die Fixture per Name auf
+):
+    """AC-S7-5 (zweiter Leser derselben Optionen): die Vorschau MUSS je Kanal
+    dieselbe Reihenfolge zeigen wie der Versand -- sonst verspricht der Editor
+    eine andere Zeilenfolge, als ankommt. Deckt die uebrigen fuenf der acht
+    Aufrufstellen (`compare_preview_service.py`)."""
+    from app.loader import get_data_dir, save_location
+    from services.compare_preview_service import ComparePreviewService
+    from tests.helpers.compare_briefings import write_compare_briefings
+
+    save_location(_S7_LOCATION, user_id=env)
+    write_compare_briefings(get_data_dir(env), [_s7_kanal_preset("cp-s7-preview", env)])
+
+    service = ComparePreviewService()
+    args = dict(user_id=env, target_date=_S7_TARGET_DATE.isoformat())
+    payload = service.render_all_channels("cp-s7-preview", **args)
+    for kanal, key in (("email", "email_html"), ("telegram", "telegram"), ("sms", "sms")):
+        _s7_pruefe_kanal_reihenfolge(kanal, payload[key], f"Vorschau[{key}]")
+    _s7_pruefe_kanal_reihenfolge(
+        "telegram", service.render_telegram_preview("cp-s7-preview", **args),
+        "Vorschau render_telegram_preview",
+    )
+    _s7_pruefe_kanal_reihenfolge(
+        "sms", service.render_sms_preview("cp-s7-preview", **args),
+        "Vorschau render_sms_preview",
+    )
+
+
+def test_ac_s7_5c_telegram_vergleich_faengt_praefix_kollision():
+    """AC-S7-5 (Pflicht-Gegenprobe, Adversary S7 F001): der Telegram-Zweig von
+    ``_s7_pruefe_kanal_reihenfolge`` MUSS eine Vertauschung auch dann sehen,
+    wenn beide Labels denselben Wortanfang haben.
+
+    Gemessen an einer ECHT vertauschten Render-Ausgabe, nicht an einem
+    gebastelten String: der frueher benutzte Wortanfang-Vergleich haelt sie
+    fuer richtig, der Label-Vergleich schlaegt an. Ohne diese Achse waere der
+    Fix eine Vermutung."""
+    ids = ["wind_chill_min", "wind_chill_max"]
+    erwartet = [_PLAIN_ROWS_BY_ID[m][1] for m in ids]
+    assert len(set(e.split(" ")[0] for e in erwartet)) == 1, (
+        f"Vakuum: {ids} teilen sich ihren Wortanfang nicht mehr ({erwartet}) "
+        "-- die Gegenprobe pruefte dann eine Kollision, die es nicht gibt"
+    )
+    assert len(set(erwartet)) == len(erwartet), (
+        f"Vakuum: {ids} teilen sich das GANZE Telegram-Label ({erwartet}) -- "
+        "auch ein Label-Vergleich koennte ihre Reihenfolge nicht sehen"
+    )
+
+    vertauscht = render_compare_telegram(
+        _s7_result(), enabled_metrics=list(reversed(ids)),
+    )
+    zellen = telegram_zellen(vertauscht)
+    assert [z.split(" ")[0] for z in zellen] == [e.split(" ")[0] for e in erwartet], (
+        f"Vakuum: der ALTE Wortanfang-Vergleich muss auf {zellen} gruen sein, "
+        "sonst belegt die Gegenprobe nichts"
+    )
+    with pytest.raises(AssertionError):
+        _s7_pruefe_kanal_reihenfolge("telegram", vertauscht, "Gegenprobe", ids=ids)
+
+
+# --- AC-S7-6: DER FIX -- die Kurz-E-Mail folgt der eingestellten Ordnung --
+
+def _s7_email_layout_dc(reihenfolge: list[str]) -> UnifiedWeatherDisplayConfig:
+    """Trip mit E-Mail-KANAL-Layout in ``reihenfolge``. ``format_email()``
+    kollabiert `dc.metrics` vor dem Rendern auf
+    ``get_metrics_for_channel("email", ...)`` (trip_report.py:133-138) --
+    diese Reihenfolge ist damit genau die, die ``render_compact()`` sieht
+    (gemessen 2026-08-13)."""
+    return UnifiedWeatherDisplayConfig(
+        trip_id="s7-pillen",
+        metrics=[
+            MetricConfig(metric_id=m, enabled=True, order=i)
+            for i, m in enumerate(sorted(reihenfolge))
+        ],
+        per_channel_layouts={
+            "email": [
+                MetricConfig(metric_id=m, enabled=True, bucket="primary", order=i)
+                for i, m in enumerate(reihenfolge)
+            ],
+        },
+    )
+
+
+def _s7_pillen(reihenfolge: list[str]) -> list[str]:
+    return [
+        zeile.strip()
+        for zeile in _s4_pill_lines(_s4_email_compact_text(_s7_email_layout_dc(reihenfolge)))
+    ]
+
+
+def _s7_pill_partner(metric_id: str) -> str:
+    """``temperature`` steht als erste Groesse der Katalog-Ordnung
+    (``_PILL_CATALOG_ORDER``) vor jeder anderen -- als Partner macht sie den
+    Unterschied zwischen Katalog- und Nutzer-Ordnung in BEIDEN Richtungen
+    sichtbar."""
+    return "wind" if metric_id == "temperature" else "temperature"
+
+
+@pytest.mark.parametrize("metric_id", _S4_PILL_RELIABLE)
+def test_ac_s7_6_kurz_email_pillen_folgen_der_eingestellten_reihenfolge(metric_id):
+    """AC-S7-6 (DER Produktivcode-Fix dieser Scheibe -- heute ROT): fuehrt das
+    E-Mail-Kanal-Layout zwei Groessen in einer von der Katalogordnung
+    abweichenden Reihenfolge, erscheinen die beiden Pillen im
+    Metriken-Ueberblick der Kurz-E-Mail heute trotzdem in KATALOGORDNUNG:
+    ``build_metrics_summary_pills()`` (email/helpers.py:1899-1901) kollabiert
+    die geordnete Liste zu ``ids_set = set(metric_ids)`` und iteriert
+    anschliessend ``_PILL_CATALOG_ORDER``. Die im Editor eingestellte
+    Reihenfolge kann diesen Ausgabeort strukturell nicht erreichen -- ein
+    Bedienelement ohne Wirkung."""
+    partner = _s7_pill_partner(metric_id)
+    a = _s7_pillen([metric_id, partner])
+    b = _s7_pillen([partner, metric_id])
+    assert len(a) == 2 and len(b) == 2, (
+        f"Vakuum: {metric_id!r}/{partner!r} ergeben {a} bzw. {b} statt je "
+        "zwei Pillen -- ohne zwei Pillen ist keine Reihenfolge messbar"
+    )
+    assert a[0] != a[1], (
+        f"Vakuum: beide Pillen tragen denselben Text {a[0]!r}"
+    )
+    assert a == list(reversed(b)), (
+        f"AC-S7-6: Layout [{metric_id}, {partner}] ergibt {a}, Layout "
+        f"[{partner}, {metric_id}] ergibt {b} -- dieselbe MENGE in zwei "
+        "Reihenfolgen muss zwei verschiedene Pillenfolgen ergeben"
+    )
+    assert a != b, (
+        f"AC-S7-6: beide Layouts ergeben dieselbe Pillenfolge {a} -- die "
+        "eingestellte Reihenfolge wird verworfen"
+    )
+
+
+# Am 2026-08-13 am unveraenderten Renderer abgenommen: Text UND Ampelstufe je
+# Pille bei KATALOG-Ordnung. Der Fix aus AC-S7-6 aendert ausschliesslich die
+# Reihenfolge -- bleibt diese Erwartung gruen, sind Auswahl, Abwahl,
+# Schwellenlogik und Ampelstufen nachweislich unberuehrt.
+_S7_PILLEN_BASIS_KATALOGORDNUNG = [
+    "3-20C - Max 11:00",
+    "gef. 1.0-18.0C - Max 11:00",
+    "! Wind >10 km/h ab 04:00 - max 45 (10:00)",
+    "!!! Boeen >20 km/h ab 04:00 - max 70 (10:00)",
+    "!! Regen ab 05:00 - 8.9 mm",
+    "!!! Regen-W. >20% ab 05:00 - max 95% (11:00)",
+    "!!! Gewitter ab 11:00 - staerkste 11:00",
+    "50% bewoelkt - Max 08:00",
+    "Feuchte 55-55% - Max 08:00",
+    "Sonne 150 min",
+]
+
+
+def test_ac_s7_6b_pilleninhalt_bleibt_bei_katalogordnung_bytegleich():
+    """AC-S7-6 (Begleitschutz): bei einem E-Mail-Layout IN Katalogordnung
+    bleiben die Pillen byte-gleich zum heutigen Zustand -- Text, Ampel-
+    Praefix und Reihenfolge. Der Fix darf nur die Ausgabereihenfolge einer
+    ABWEICHENDEN Nutzerliste aendern, nichts sonst."""
+    katalog_ordnung = [m for m in _PILL_CATALOG_ORDER if m in _S4_PILL_RELIABLE]
+    assert len(katalog_ordnung) == len(_S4_PILL_RELIABLE), (
+        "Vakuum: nicht jede zuverlaessig feuernde Pillen-Metrik steht in "
+        f"_PILL_CATALOG_ORDER: {sorted(set(_S4_PILL_RELIABLE) - set(katalog_ordnung))}"
+    )
+    assert _s7_pillen(katalog_ordnung) == _S7_PILLEN_BASIS_KATALOGORDNUNG, (
+        "AC-S7-6b: der Pillen-INHALT hat sich geaendert, nicht nur die "
+        f"Reihenfolge:\n{_s7_pillen(katalog_ordnung)}"
+    )
+
+
+# --- AC-S7-7: Trip-Telegram-Kurzuebersicht folgt der Reihenfolge ----------
+
+# temperature_night/wind_chill_night unterdruecken ihre eigene Zeile, sobald
+# die Tages-Groesse mitgewaehlt ist (narrow.py:745-760) -- mit einem festen
+# Partner waere ihr Verhalten von der Partnerwahl abhaengig und der Test
+# maesse die Unterdrueckung statt der Reihenfolge. Ihre ANWESENHEIT deckt
+# AC-S4-12.
+_S7_TELEGRAM_ORDER_METRIKEN = [
+    m for m in _ALL_METRIC_IDS if m not in ("temperature_night", "wind_chill_night")
+]
+
+
+def _s7_telegram_layout_dc(reihenfolge: list[str]) -> UnifiedWeatherDisplayConfig:
+    return UnifiedWeatherDisplayConfig(
+        trip_id="s7-telegram",
+        metrics=[
+            MetricConfig(metric_id=m, enabled=True, order=i)
+            for i, m in enumerate(sorted(reihenfolge))
+        ],
+        per_channel_layouts={
+            "telegram": [
+                MetricConfig(metric_id=m, enabled=True, bucket="primary", order=i)
+                for i, m in enumerate(reihenfolge)
+            ],
+        },
+    )
+
+
+def _s7_kurzuebersicht_index(zeilen: list[str], metric_id: str) -> int:
+    """Position der Kurzuebersicht-Zeile einer Groesse. Gesucht wird ueber
+    ``compact_label`` + Leerzeichen -- ohne das Leerzeichen faende "T" auch
+    "TN"/"TH" (Praefix-Kollision, dieselbe Falle wie im SMS-Pfad)."""
+    label = get_metric(metric_id).compact_label
+    treffer = [i for i, z in enumerate(zeilen) if z.startswith(label + " ")]
+    assert len(treffer) == 1, (
+        f"AC-S7-7: {metric_id!r} (Kuerzel {label!r}) kommt {len(treffer)}-mal "
+        f"in der Kurzuebersicht vor: {zeilen!r}"
+    )
+    return treffer[0]
+
+
+@pytest.mark.parametrize("metric_id", _S7_TELEGRAM_ORDER_METRIKEN)
+def test_ac_s7_7_telegram_kurzuebersicht_folgt_der_reihenfolge(metric_id):
+    """AC-S7-7: die Telegram-Kurzuebersicht-Bubble folgt der im
+    Telegram-Kanal eingestellten Reihenfolge -- paarweise ueber alle
+    waehlbaren Groessen."""
+    partner = "temperature" if metric_id == "wind" else "wind"
+    zeilen_a = _s4_kurzuebersicht(_s7_telegram_layout_dc([metric_id, partner]))
+    zeilen_b = _s4_kurzuebersicht(_s7_telegram_layout_dc([partner, metric_id]))
+    assert _s7_kurzuebersicht_index(zeilen_a, metric_id) < _s7_kurzuebersicht_index(
+        zeilen_a, partner
+    ), f"AC-S7-7: [{metric_id}, {partner}] ergibt {zeilen_a}"
+    assert _s7_kurzuebersicht_index(zeilen_b, partner) < _s7_kurzuebersicht_index(
+        zeilen_b, metric_id
+    ), f"AC-S7-7: [{partner}, {metric_id}] ergibt {zeilen_b}"
+
+
+def test_ac_s7_7b_zwei_reihenfolge_quellen_in_einem_renderer():
+    """AC-S7-7 (benanntes Driftrisiko, Charakterisierung): ``render_telegram_
+    bubbles()`` bezieht die Reihenfolge der KURZUEBERSICHT aus
+    ``dc.get_enabled_metric_ids()`` -- der reinen LISTENPOSITION -- und die
+    der TABELLEN-Bubbles zwei Zeilen weiter aus ``render_for_channel()``,
+    das nach dem ``order``-FELD sortiert. Im Versandpfad fallen beide
+    zusammen, weil ``get_metrics_for_channel()`` die Liste vorher nach
+    ``order`` sortiert (models.py:751-770); widersprechen sich die beiden
+    Angaben, laufen sie auseinander. Solange beide Quellen bestehen, soll das
+    benannt sein statt unbemerkt."""
+    from output.renderers.narrow import render_telegram_bubbles
+
+    dc = UnifiedWeatherDisplayConfig(
+        trip_id="s7-drift",
+        metrics=[
+            MetricConfig(metric_id="wind", enabled=True, bucket="primary", order=1),
+            MetricConfig(metric_id="temperature", enabled=True, bucket="primary", order=0),
+        ],
+    )
+    assert dc.get_enabled_metric_ids() == ["wind", "temperature"], (
+        "AC-S7-7b: Quelle 1 (Listenposition) hat sich geaendert"
+    )
+    assert render_for_channel("telegram", dc, "evening").table_columns == [
+        "temperature", "wind",
+    ], "AC-S7-7b: Quelle 2 (order-Feld) hat sich geaendert"
+
+    bubbles = render_telegram_bubbles(
+        segments=[_matrix_segment()], seg_tables=[[]], dc=dc,
+        report_type="evening", tz=F.TZ, trip_name="Issue1703S7",
+        night_weather=F.night_weather(),
+    )
+    zeilen = [
+        z.strip() for z in bubbles[1].text.splitlines()
+        if z.strip() and z.strip() != "Kurzübersicht"
+    ]
+    assert _s7_kurzuebersicht_index(zeilen, "wind") < _s7_kurzuebersicht_index(
+        zeilen, "temperature"
+    ), (
+        "AC-S7-7b: die Kurzuebersicht folgt nicht mehr der Listenposition, "
+        f"sondern offenbar dem order-Feld: {zeilen!r}"
+    )
+
+
+# --- AC-S7-8: Compare-Telegram und -SMS unter Kappung ---------------------
+
+@pytest.mark.parametrize("metric_id", _S7_SOLL)
+def test_ac_s7_8a_compare_telegram_folgt_der_reihenfolge(metric_id):
+    """AC-S7-8 (Telegram): die Zellfolge je Ort folgt der eingestellten
+    Reihenfolge. Paarweise mit ZWEI Groessen geprueft -- mit der vollen
+    Auswahl maesse der Test die 7-Spalten-Kappung statt der Reihenfolge
+    (``CHANNEL_LIMITS["telegram"]["max_table_cols"]``)."""
+    partner = partner_von(metric_id)
+    label_m = _PLAIN_ROWS_BY_ID[metric_id][1]
+    label_p = _PLAIN_ROWS_BY_ID[partner][1]
+    assert label_m != label_p, (
+        f"Vakuum: {metric_id!r} und {partner!r} teilen sich das Telegram-Label"
+    )
+    zellen_a = telegram_zellen(
+        render_compare_telegram(_s7_result(), enabled_metrics=[metric_id, partner])
+    )
+    zellen_b = telegram_zellen(
+        render_compare_telegram(_s7_result(), enabled_metrics=[partner, metric_id])
+    )
+    assert [z.startswith(label_m) for z in zellen_a] == [True, False], (
+        f"AC-S7-8: [{metric_id}, {partner}] ergibt {zellen_a}"
+    )
+    assert [z.startswith(label_p) for z in zellen_b] == [True, False], (
+        f"AC-S7-8: [{partner}, {metric_id}] ergibt {zellen_b}"
+    )
+
+
+@pytest.mark.parametrize("metric_id", _S7_SOLL)
+def test_ac_s7_8b_compare_sms_folgt_der_reihenfolge(metric_id):
+    """AC-S7-8 (SMS): die Kuerzel-Token-Folge je Ort folgt der eingestellten
+    Reihenfolge. Ebenfalls paarweise -- die SMS kappt am Zeichenbudget
+    (``CHANNEL_LIMITS["sms"]["max_chars"]``, gemessen 153)."""
+    partner = partner_von(metric_id)
+    ort = _s7_result().locations[0]
+    kuerzel_m, kuerzel_p = sms_kuerzel(ort, metric_id), sms_kuerzel(ort, partner)
+    assert kuerzel_m != kuerzel_p, (
+        f"Vakuum: {metric_id!r} und {partner!r} teilen sich das SMS-Kuerzel "
+        f"{kuerzel_m!r}"
+    )
+    sms_a = render_compare_sms(_s7_result(), enabled_metrics=[metric_id, partner])
+    sms_b = render_compare_sms(_s7_result(), enabled_metrics=[partner, metric_id])
+    ia_m, ia_p = sms_index(sms_a, kuerzel_m), sms_index(sms_a, kuerzel_p)
+    ib_m, ib_p = sms_index(sms_b, kuerzel_m), sms_index(sms_b, kuerzel_p)
+    assert None not in (ia_m, ia_p, ib_m, ib_p), (
+        f"AC-S7-8: nicht beide Kuerzel in beiden SMS auffindbar "
+        f"({kuerzel_m}/{kuerzel_p}):\nA: {sms_a!r}\nB: {sms_b!r}"
+    )
+    assert ia_m < ia_p, f"AC-S7-8: [{metric_id}, {partner}] ergibt {sms_a!r}"
+    assert ib_p < ib_m, f"AC-S7-8: [{partner}, {metric_id}] ergibt {sms_b!r}"
+
+
+def test_ac_s7_8c_kappung_folgt_der_reihenfolge_und_wird_zum_inhaltsfehler():
+    """AC-S7-8 (Kappungs-Anteil): oberhalb der Kappungsgrenze entscheidet die
+    Reihenfolge, WELCHE Groesse ueberhaupt erhalten bleibt -- in der SMS ist
+    ein Reihenfolgefehler damit ein INHALTSfehler, kein Schoenheitsfehler."""
+    metrik_slots = CHANNEL_LIMITS["telegram"]["max_table_cols"] - 1  # Slot 0 = Zeit
+    assert len(_S7_SOLL) > 2 * metrik_slots, (
+        f"Vakuum: {len(_S7_SOLL)} Groessen reichen nicht, um zwei disjunkte "
+        f"Kappungsfenster von je {metrik_slots} zu belegen"
+    )
+    vorwaerts = telegram_zellen(
+        render_compare_telegram(_s7_result(), enabled_metrics=list(_S7_SOLL))
+    )
+    rueckwaerts = telegram_zellen(
+        render_compare_telegram(_s7_result(), enabled_metrics=list(reversed(_S7_SOLL)))
+    )
+    assert len(vorwaerts) == len(rueckwaerts) == metrik_slots, (
+        f"AC-S7-8c: Telegram zeigt {len(vorwaerts)}/{len(rueckwaerts)} Zellen "
+        f"statt der erwarteten {metrik_slots}"
+    )
+    assert set(vorwaerts).isdisjoint(rueckwaerts), (
+        "AC-S7-8c: die ersten und die letzten sieben Groessen der Auswahl "
+        f"ueberschneiden sich: {sorted(set(vorwaerts) & set(rueckwaerts))}"
+    )
+
+    ort = _s7_result().locations[0]
+    letzte = _S7_SOLL[-1]
+    kuerzel_letzte = sms_kuerzel(ort, letzte)
+    sms_vorwaerts = render_compare_sms(_s7_result(), enabled_metrics=list(_S7_SOLL))
+    sms_rueckwaerts = render_compare_sms(
+        _s7_result(), enabled_metrics=list(reversed(_S7_SOLL))
+    )
+    max_chars = CHANNEL_LIMITS["sms"]["max_chars"]
+    for text in (sms_vorwaerts, sms_rueckwaerts):
+        assert len(text) <= max_chars, f"SMS zu lang ({len(text)}): {text!r}"
+    assert sms_index(sms_vorwaerts, kuerzel_letzte) is None, (
+        f"AC-S7-8c: {letzte!r} steht am Listenende und muesste vom "
+        f"Zeichenbudget verdraengt sein: {sms_vorwaerts!r}"
+    )
+    kuerzel_vorletzte = sms_kuerzel(ort, _S7_SOLL[-2])
+    position_letzte = sms_index(sms_rueckwaerts, kuerzel_letzte)
+    position_vorletzte = sms_index(sms_rueckwaerts, kuerzel_vorletzte)
+    assert position_letzte is not None and position_vorletzte is not None, (
+        f"AC-S7-8c: dieselbe Groesse muesste an erster Listenposition "
+        f"erscheinen: {sms_rueckwaerts!r}"
+    )
+    assert position_letzte < position_vorletzte, (
+        f"AC-S7-8c: {letzte!r} steht in der umgedrehten Liste vor "
+        f"{_S7_SOLL[-2]!r}, erscheint in der SMS aber dahinter: "
+        f"{sms_rueckwaerts!r}"
+    )
+
+
+# --- AC-S7-9: Kompakt-Zusammenfassung -- benannte Ausnahme ----------------
+
+def test_ac_s7_9_kompakt_zusammenfassung_hat_keine_reihenfolge_achse():
+    """AC-S7-9 (benannte, begruendete Ausnahme -- KEIN Fix): der Fliesstext
+    ``format_stage_summary()`` folgt einer festen Positivliste und kennt
+    keine nutzergesteuerte Reihenfolge. Dieselben zwei Groessen in zwei
+    Reihenfolgen ergeben denselben Satz. Anschluss an AC-S4-6/AC-S4-7
+    (feste Positivliste als akzeptierter Dauerzustand, PO-Entscheid
+    2026-08-12) -- hier ausdruecklich festgehalten statt stillschweigend
+    ausgelassen."""
+    basis = _s4_baseline_summary()
+    satz_a = _s4_compact_summary_text(_two_metric_dc("wind", "temperature"))
+    satz_b = _s4_compact_summary_text(_two_metric_dc("temperature", "wind"))
+    assert satz_a != basis, (
+        "Vakuum: die beiden Groessen veraendern den Fliesstext gar nicht -- "
+        f"dann sagt der Reihenfolge-Vergleich unten nichts. Basis: {basis!r}"
+    )
+    assert satz_a == satz_b, (
+        "AC-S7-9: der Fliesstext hat entgegen der Messung eine "
+        f"Reihenfolge-Achse bekommen:\nA: {satz_a!r}\nB: {satz_b!r}"
+    )

--- a/tests/tdd/test_issue_664_metrics_summary.py
+++ b/tests/tdd/test_issue_664_metrics_summary.py
@@ -273,23 +273,101 @@ class TestAC3HelperValues:
         texts = [t for t, _ in pills]
         assert any("40" in t for t in texts), f"40 km/h (max gust) nicht in Pillen: {texts}"
 
-    def test_metric_order_follows_catalog(self):
-        """Reihenfolge der Pillen folgt Katalog, nicht Eingabe-Reihenfolge."""
+    def test_metric_order_follows_input(self):
+        """Reihenfolge der Pillen folgt der Eingabe-Reihenfolge.
+
+        **#664 → abgeloest durch #1703 S7.** Bis dahin galt hier das Gegenteil
+        („Reihenfolge = Katalog-Reihenfolge, nicht Eingabereihenfolge",
+        ``docs/specs/modules/email_metrics_summary_664.md:88``, 2026-06-08).
+        Diese Wahl war unter ihren Bedingungen richtig: im Juni 2026 gab es
+        keine nutzergesetzte Metrik-Reihenfolge -- die Kanal-Layouts kamen erst
+        mit #1575/#1677 (Trip) bzw. #1335/#1359 (Compare). Die
+        „Eingabereihenfolge" war die zufaellige Folge der Config-Eintraege und
+        trug keine Absicht; Katalogordnung war die stabilere Wahl. Seit die
+        Eingabe eine Nutzerabsicht traegt (im Editor je Kanal gezogene
+        Position), verwirft die Katalogordnung sie -- ein Bedienelement ohne
+        Wirkung. Deshalb dreht #1703 S7 die Zusicherung um.
+
+        Paarweise geprueft: dieselbe MENGE in zwei Reihenfolgen muss zwei
+        verschiedene Pillenfolgen ergeben. Eine einzelne feste Erwartung wuerde
+        „intern nach eigener Prioritaet umsortiert" nicht von „Reihenfolge
+        befolgt" unterscheiden.
+        """
         from output.renderers.email.helpers import build_metrics_summary_pills
-        # Eingabe umgekehrt: precipitation NACH temperature
-        segs = _build_segments()
-        pills = build_metrics_summary_pills(
-            segs, ["precipitation", "temperature"], {}, tz=TZ
+
+        def _texts(reihenfolge):
+            return [t for t, _ in build_metrics_summary_pills(
+                _build_segments(), reihenfolge, {}, tz=TZ,
+            )]
+
+        # Katalog-Ordnung waere temperature VOR precipitation -- die Eingabe
+        # dreht das in einer Richtung ausdruecklich um.
+        a = _texts(["precipitation", "temperature"])
+        b = _texts(["temperature", "precipitation"])
+        assert len(a) == 2 and len(b) == 2, (
+            f"Vakuum: nicht beide Pillen feuern mit dieser Fixture ({a} / {b}) "
+            "-- ohne zwei Pillen ist keine Reihenfolge messbar. Der abgeloeste "
+            "Test hatte diese Luecke als `if ... is not None` und waere bei "
+            "einer ausfallenden Pille still gruen geblieben."
         )
-        ids_order = [t for t, _ in pills]
-        # temperature kommt im Katalog vor precipitation → temperature zuerst
-        # Prüfe, dass der temperature-Wert (enthält "°C") vor precipitation (enthält "mm" oder "Regen")
-        temp_pos = next((i for i, t in enumerate(ids_order) if "°C" in t), None)
-        rain_pos = next((i for i, t in enumerate(ids_order) if "mm" in t or "Regen" in t.lower()), None)
-        if temp_pos is not None and rain_pos is not None:
-            assert temp_pos < rain_pos, (
-                f"temperature muss vor precipitation stehen (Katalog-Reihenfolge): {ids_order}"
-            )
+        assert a == list(reversed(b)), (
+            f"Eingabe [precipitation, temperature] ergibt {a}, Eingabe "
+            f"[temperature, precipitation] ergibt {b} -- die uebergebene "
+            "Reihenfolge wird verworfen (#1703 S7)"
+        )
+
+    def test_altbestand_pillen_folgen_dem_trip_default_rang(self):
+        """Befund aus #1703 S7: fuer Trips OHNE gespeicherte Auswahl aendert
+        sich die Pillen-Reihenfolge -- entgegen der Spec-Annahme „da aendert
+        sich nichts".
+
+        Der Fall-A-Rueckfall ``DEFAULT_TRIP_METRIC_IDS`` wird seit #1552 aus
+        dem Register-Feld ``trip_default_rank`` abgeleitet, NICHT aus
+        ``_PILL_CATALOG_ORDER``. Die beiden Listen fuehren dieselben sieben
+        Groessen, aber in den letzten zwei Positionen vertauscht
+        (``freezing_level``/``visibility``). Seit die Pillen der uebergebenen
+        Liste folgen, gewinnt der Register-Rang -- eine Ordnungsquelle statt
+        zweier separat gepflegter Listen. Der Effekt ist gewollt und hier
+        festgehalten, damit er nicht als Raetsel zurueckkommt.
+        """
+        from output.renderers.email.helpers import (
+            _PILL_CATALOG_ORDER, build_metrics_summary_pills,
+        )
+        from output.renderers.trip_metric_ids import DEFAULT_TRIP_METRIC_IDS
+
+        default_ids = list(DEFAULT_TRIP_METRIC_IDS)
+        katalog_ids = [m for m in _PILL_CATALOG_ORDER if m in set(default_ids)]
+        assert sorted(default_ids) == sorted(katalog_ids), (
+            "Vorbedingung entfallen: Standard-Satz und Pillen-Katalog fuehren "
+            f"nicht mehr dieselbe MENGE ({default_ids} / {katalog_ids})"
+        )
+        assert default_ids != katalog_ids, (
+            "Die beiden Ordnungen sind inzwischen identisch -- dann ist dieser "
+            "Charakterisierungstest gegenstandslos und darf weg (#1703 S7)"
+        )
+
+        pillen = build_metrics_summary_pills(
+            _build_segments(), default_ids, {}, tz=TZ,
+        )
+        assert len(pillen) == len(default_ids), (
+            f"Vakuum: {len(pillen)} Pillen fuer {len(default_ids)} Groessen "
+            f"-- nicht jede feuert mit dieser Fixture: {pillen}"
+        )
+        # Zuordnung eigens geprueft: Rechnen sichert Vollstaendigkeit, nie
+        # Zuordnung (#1703 S2 F001). "0°-Linie" = freezing_level, "Sicht" =
+        # visibility -- genau das vertauschte Paar.
+        texte = [t for t, _ in pillen]
+        frost = next(i for i, t in enumerate(texte) if t.startswith("0°-Linie"))
+        sicht = next(i for i, t in enumerate(texte) if t.startswith("Sicht"))
+        assert frost < sicht, (
+            "AC-S7-6/Befund A: der Standard-Satz fuehrt `freezing_level` vor "
+            f"`visibility` (trip_default_rank), die Pillen zeigen: {texte}"
+        )
+        assert katalog_ids.index("visibility") < katalog_ids.index("freezing_level"), (
+            "Gegenprobe entfallen: `_PILL_CATALOG_ORDER` fuehrt `visibility` "
+            "nicht mehr vor `freezing_level` -- dann ist der oben belegte "
+            "Unterschied keiner mehr"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Epic #1703 **Scheibe 7** — Reihenfolge-Wächter jenseits E-Mail/Telegram-rich. Damit sind **alle acht Scheiben** des Epics geliefert; Fläche 5 der Metrik×Kanal-Matrix war die letzte offene.

## Zwei Prämissen des Issue-Texts waren falsch

Vor dem Schreiben der ACs nachgemessen — beide Korrekturen stehen ausdrücklich im Matrix-Dokument, damit sie nicht in eine Folgearbeit weiterwandern:

| Behauptung in Fläche 5 | Gemessener Ist-Zustand |
|---|---|
| Trip-SMS-Reihenfolge unbewacht (`tokens/builder.py:78`) | **bewacht** seit #1677/#1660 B — `test_ac15_…` (c) prüft paarweise über alle 26 Katalog-Metriken |
| Compare-Klartext nutzt die Reihenfolge „nur als Sichtbarkeitsfilter (#1356)" | **überholt** seit #1359 — `_ordered_rows()` setzt sie um, der HTML-Zwilling ebenso |

Tatsächlich fehlten die **Katalog-Deckung** (bewacht waren 4 von 25 Metriken mit zwei getippten Reihenfolgen) und die **Kanal-Achse**, die es erst seit Scheibe 8 gibt. Dasselbe Muster wie bei Scheibe 2: das Prinzip war bewacht, die Deckung nicht.

## Der Produktivcode-Fix (AC-S7-6)

`build_metrics_summary_pills()` kollabierte die geordnete Metrikliste zu `set(metric_ids)` und rendert danach eine feste Katalogordnung — die je Kanal eingestellte Reihenfolge konnte den Pillen-Überblick **strukturell nicht erreichen**. Ein Bedienelement ohne Wirkung, also genau die Fehlerklasse, gegen die dieses Epic gebaut wurde.

Der Fix wirkt auf **drei** Ausgabeorte (Kurz-E-Mail und beide Teile der Voll-Mail), per A/B gegen den Vorzustand belegt. Bezeichnend: **kein Golden- oder Paritätstest schlug dabei an** — die Pillen-Reihenfolge der Voll-Mail war von nichts bewacht.

Nebenwirkung, gemessen und gewollt: Für Trips ohne jede gespeicherte Auswahl tauschen `visibility` und `freezing_level` ihre Plätze, weil `DEFAULT_TRIP_METRIC_IDS` seit #1552 aus `trip_default_rank` stammt und nicht aus der Pillen-Katalogordnung. Eine Ordnungsquelle statt zweier.

## Eine abgelöste Entscheidung, nicht still vollzogen

`email_metrics_summary_664.md:88` legte am 2026-06-08 ausdrücklich fest: „Reihenfolge = Katalog-Reihenfolge, nicht Eingabereihenfolge", und ein Bestandstest fror das ein. Die Wahl war **unter ihren Bedingungen richtig** — im Juni gab es keine nutzergesetzte Reihenfolge, die Kanal-Layouts kamen erst mit #1575/#1677 bzw. #1335/#1359; die „Eingabereihenfolge" war die zufällige Folge der Config-Einträge und trug keine Absicht.

`test_metric_order_follows_catalog` heißt jetzt `test_metric_order_follows_input`, prüft paarweise statt einseitig und trägt den Ablösungsvermerk — ebenso der Docstring der Funktion. Muster wie ADR-0053: die Bedingung benennen, unter der die alte Entscheidung nicht mehr gilt.

## Nachweise

- **AC-S7-1 bis AC-S7-10**, 142 Testfälle in `tests/tdd/test_channel_metric_matrix.py` + `tests/helpers/compare_order.py`
- **Adversary VERIFIED**, 3 Runden, 11 Kriterien belegt, kein offener Punkt
- **Alle fünf Pflicht-Mutationen** vom jeweils vorgesehenen Test gefangen — die Kanal-Mutation an zwei unabhängigen Aufrufstellen (Versand- und Vorschaupfad)
- **Renderer-Gate #811**: `test_issue_811_mode_matrix.py` grün, `briefing_mail_validator.py` und `email_spec_validator.py` je Exit 0 gegen **echt zugestellte** Mails
- **Regressionscheck**: volle Suite offline; die vier Roten sind per A/B gegen unverändertes `origin/main` als vorbestehend belegt (Live-Telegram-Fixture, kein Bezug zum Pillen-Code)

## Zwei Adversary-Findings, beide geschlossen

**F001 (LOW):** Der Telegram-Zweig von AC-S7-5 verglich nur Wortanfänge. Gefixt mit einer Gegenprobe, die *beide* Richtungen zeigt — dass der alte Vergleich eine echte Vertauschung durchließ und der neue anschlägt.

**F002 (MEDIUM):** Die zweite Kollision `Wolken`/`Wolken tief` war nur im Kommentar als gelöst benannt. Der Adversary maß nach: Der Code fing sie, aber aus einem strukturellen Zufall der Zwei-Elemente-Vertauschung. `test_ac_s7_5d` prüft die Wolken-Familie jetzt über **alle Permutationen**, als Paar und als Tripel — beim Tripel greift der Pigeonhole-Sonderfall nicht mehr. Mitkorrigiert: eine falsche Zusicherung im Kommentar des F001-Fixes selbst.

Dreimal dieselbe Fehlerklasse in einer Scheibe: eine Zusicherung, die im Kommentar behauptet, aber von keinem Test erzwungen wird.

## Bewusst offen

- Ausblick und Stundenverlauf des Ortsvergleichs haben weiterhin keine Kanal-Ebene (ADR-0053) — also auch keine kanalbezogene Soll-Reihenfolge zum Prüfen
- Die Altbestands-Divergenz HTML vs. Klartext ab Position 3 ist **charakterisiert, nicht gefixt** — die Ordnung ist in `test_compare_metric_order.py` AC-7 als Altbestands-Standard eingefroren, ein Fix wäre eine eigene Entscheidung (→ #1199)

Spec: `docs/specs/modules/fix_1703_s7_reihenfolge_matrix.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qMKJ4iAGkQKdQacdcn7Xn
