### PR TITLE
fix(#1727 S5b): neun Versandpfade folgen dem Ortstag statt der Serveruhr

### DIFF
--- a/docs/adr/0044-kalendertage-folgen-der-ortszeit.md
+++ b/docs/adr/0044-kalendertage-folgen-der-ortszeit.md
@@ -137,20 +137,41 @@ Regelverstoß — genau das war der Zustand vor #1697.
   Ortszeit-Anzeige der Timeline (`_aggregate_day`, `_fmt_glance`, `_fmt_gewitter`,
   `_fmt_timeline`, `_timeline_buttons` bekommen `tz` als Pflichtparameter).
 
+- **Versandpfade von Trip-Briefing und Ortsvergleich** (#1727 S5b): neun Fundstellen, die
+  auf tatsächlich VERSENDETE Inhalte wirken und in dieser Liste bis dahin gar nicht standen
+  (vierte unvollständige Aufzählung dieses Epics). `select_test_stage`,
+  `_send_trip_report_outcome`s Klemm-Vergleich, `_clamp_segments_to_today`,
+  `_build_stage_trend` und `_collect_future_stage_weather` folgen seither
+  `trip_local_today(trip, now_utc)`; `briefing_target_day_is_current` hat keinen
+  Systemuhr-Rückfall mehr (`today` ist Pflicht und kommt als Ortstag der Tour vom
+  Aufrufer); `_auto_pause_expired_presets` und der Einzelversand-Zweig von
+  `send_one_compare_preset` rechnen über `first_resolvable_tz(locations)` im Ortstag des
+  ersten auflösbaren Preset-Orts; `_target_date_from_report` leitet den Präfix-Tag aus der
+  am DTO bereits aufgelösten `request.trip_tz` ab. An sechs der neun Stellen ist „jetzt"
+  zugleich Pflichtparameter geworden (ADR-0051 Regel 3) — der Briefing-Aufbau steht damit
+  auf EINER Zeitabfrage, obwohl zwischen ihr und dem Ausblick ein Wetterabruf mit
+  Retry-Backoff liegt. An den Fundstellen `_send_trip_report_outcome`,
+  `_target_date_from_report` und `send_one_compare_preset` bleibt die Auflösung bewusst
+  funktionsintern (jeweils vor jedem Netzabruf).
+
 **Lehre für die Pflege dieser Liste:** Sie war nicht falsch, sondern **unvollständig** — und
 eine unvollständige Restliste liest sich wie eine vollständige. Wer hier etwas einträgt,
 sucht vorher nach `date.today()`/`datetime.now().date()` im ganzen Produktivcode, statt nur
 die Datei zu nennen, in der er gerade gearbeitet hat.
 
-### Noch nicht umgesetzt (Stand 2026-08-13)
+### Noch nicht umgesetzt (Stand 2026-08-14)
 
 Der zuvor hier gelistete Briefing-/Versand-Pfad (`_get_target_date`, `_get_active_trips`,
 `save_dated`) ist umgesetzt — s. „Umgesetzt" oben (#1724/#1725). Ebenso der zuvor hier
-gelistete Kommando-/Anzeige-Pfad — s. „Umgesetzt" oben (#1727 S5a/#1795).
+gelistete Kommando-/Anzeige-Pfad — s. „Umgesetzt" oben (#1727 S5a/#1795) und die neun
+Versandpfade aus #1727 S5b.
 
-**Vorschau, Werkzeuge:** `preview_service.py`, `api/routers/debug.py` und
-`tools/weather_validation.py` (S5b/S5c, eigene Scheibe). Zeilennummern bewusst weggelassen —
-sie waren in der Vorfassung dieser Liste binnen Tagen veraltet.
+**Vorschau, Werkzeuge:** `preview_service._resolve_target_date`, `api/routers/debug.py` und
+`tools/weather_validation.py` (S5c, eigene Scheibe). Zeilennummern bewusst weggelassen —
+sie waren in der Vorfassung dieser Liste binnen Tagen veraltet. `preview_service.py` reicht
+seit #1727 S5b zwar `now_utc` an die beiden Scheduler-Methoden durch (mechanisch erzwungen
+durch deren Pflichtparameter), seine EIGENE Tagesbestimmung folgt aber weiterhin dem
+Servertag — die Datei steht deshalb hier UND oben.
 
 **Bewusst NICHT betroffen** (feste Zone ist dort Absicht, kein Verstoß):
 `forecast_budget._today_utc` und `meteoalarm_budget._today_utc` (Kontingent-Tageswechsel in

--- a/docs/context/fix-1727-s5b-versandpfade.md
+++ b/docs/context/fix-1727-s5b-versandpfade.md
@@ -1,0 +1,395 @@
+---
+workflow: fix-1727-s5b-versandpfade
+issue: 1727
+epic: 1722
+created: 2026-08-14
+base_head: 1e5e0be9
+---
+
+# Context: fix-1727-s5b-versandpfade
+
+## Request Summary
+
+Die Fundstellen aus #1727, die den Kalendertag noch aus der Umgebungsuhr (`date.today()`)
+statt aus der Ortszone bestimmen und dabei auf **versendete Briefing-Inhalte** wirken, folgen
+künftig dem Ortstag. Scheibe S5b von #1727 (Epic #1722, ADR-0044/ADR-0051).
+
+## Type
+
+Bugfix gegen eine bereits getroffene Entscheidung (ADR-0044 „Akzeptiert"). Keine offene
+Produktfrage.
+
+---
+
+## Die neun Fundstellen — gemessen, nicht aus dem Ticket übernommen
+
+Ticketstand `1e5e0be9`. Zeilennummern aus `KNOWN_VIOLATIONS` waren durchweg verschoben; die
+Angaben hier sind am Code nachgezählt.
+
+| # | Fundstelle | Codezeile | Prod-Aufrufer | Test-Aufrufstellen |
+|---|---|---|---|---|
+| 1 | `trip_report_scheduler.py:871` `select_test_stage` | `today = date.today()` | 1 | 10 |
+| 2 | `trip_report_scheduler.py:1103` `_send_trip_report_outcome` | `if allow_test_fallback and target_date < date.today():` | 6 | 47 |
+| 3 | `trip_report_scheduler.py:1708` `_clamp_segments_to_today` | `delta_days = (date.today() - from_date).days` | 1 | **0** |
+| 4 | `trip_report_scheduler.py:2023` `_build_stage_trend` | `today = date.today()` | 2 | 27 |
+| 5 | `trip_report_scheduler.py:2416` `_collect_future_stage_weather` | `today = date.today()` | 1 | 6 |
+| 6 | `alert_briefing_anchor.py:169` `briefing_target_day_is_current` | `heute = today or date.today()` | 1 | **0** |
+| 7 | `scheduler_dispatch_service.py:79` `_auto_pause_expired_presets` | `expired = date.fromisoformat(end_date_str) < date.today()` | 1 | **0** |
+| 8 | `notification_service.py:1717` `_target_date_from_report` | `return _date.today()` | 1 (Kette) | **0** |
+| 9 | `scheduler_dispatch_service.py:369` `send_one_compare_preset` | `target_date = date.today()` (Einzelversand-Zweig) | 2 | 67 — **aber keine davon betroffen**, s.u. |
+
+### Wirkung je Fundstelle
+
+| # | Was der Wert entscheidet | Auf VERSENDETEN Inhalt? |
+|---|---|---|
+| 1 | Welche Etappe der Test-Versand nimmt, wenn am Zieltag keine liegt (`s.date >= today`) | ja — Etappenwahl |
+| 2 | Ob die Segmentzeiten für den Wetterabruf auf heute geklemmt werden | ja — Wetter-Input des Test-Fallbacks |
+| 3 | Um wie viele Tage geklemmt wird | mittelbar (Rechenweg von #2) |
+| 4 | Welche künftigen Etappen im Vorhersagehorizont liegen → welche Trendzeilen in die Mail gehen | **ja — Ausblick** |
+| 5 | Dasselbe für den Gewitter-Ausblick (Rückfall, wenn der Trend nicht lädt) | **ja — Gewitter-Ausblick** |
+| 6 | Ob ein Versandfehler-Vermerk verfällt oder nachgeliefert wird | **ja — ob überhaupt zugestellt wird** |
+| 7 | Ob ein Compare-Preset wegen `end_date` pausiert wird | **ja — ob überhaupt versendet wird** |
+| 8 | Datum im Test-/On-Demand-/Catchup-/Teilausfall-Präfix | ja — Text in Mail/SMS/Telegram |
+| 9 | Zieltag des Compare-Einzelversands (Engine, Betreff, Δ-Anker-Versatz) | **ja — Mailinhalt des Ortsvergleichs** |
+
+Damit ist die Ticketaussage „S5b: sichtbar, aber ohne Versand- oder Alarmwirkung" für die
+Restliste widerlegt. Korrektur bereits im Ticket gebucht
+(Kommentar vom 2026-08-14).
+
+### Fundstelle 2 ist ein in sich widersprüchlicher Vergleich
+
+`target_date` stammt an dieser Stelle bereits aus `_get_target_date` → `trip_local_today`
+(`trip_report_scheduler.py:815`), ist also **Ortstag**. Verglichen wird er gegen `date.today()`,
+also den **Servertag**. Zwei Tagesbegriffe in einem `<`-Vergleich — genau die Bruchstelle, vor
+der `docs/context/fix-1697-ortstag-statt-servertag.md` warnt.
+
+### Fundstellen 4 und 5: keine Ausnahme, sondern echter Fix
+
+Beide speisen `is_within_forecast_horizon(stage_date, reference_date)`
+(`src/providers/openmeteo.py:172-178`) — eine reine Funktion
+`(stage_date - reference_date).days <= OPENMETEO_MAX_FORECAST_DAYS`. `stage_date` ist ein
+**Etappentag** (Ortstag-Semantik). Ein Servertag als `reference_date` mischt zwei
+Tagesbegriffe. Die naheliegende Vermutung „Anbieter-Fenster, also UTC richtig — wie
+`forecast_budget._today_utc`" trägt hier **nicht**: dort zählt ein Kontingent, hier wird ein
+Nutzerdatum verglichen. Keine PO-Frage.
+
+### Fundstelle 9: das Paar `(target_date, tage_ab_ortstag)` läuft heute schon auseinander
+
+Der Einzelversand-Zweig (`scheduler_dispatch_service.py:366-370`) setzt
+`target_date = date.today()` (**Servertag**) und `tage_ab_ortstag = 0` (**Versatz gegen den
+Ortstag**). Genau das Auseinanderlaufen, das der Kontrakt aus #1661 F003 verhindern sollte —
+der `ValueError` darüber fängt nur den Fall „eines von beiden übergeben", nicht den Fall
+„beide intern aus verschiedenen Tagesbegriffen gebildet".
+
+### Fundstelle 7: welche Zone gilt für ein Preset mit mehreren Orten?
+
+Ein Compare-Preset hat mehrere Orte mit je eigener Zone. Präzedenzfall vorhanden:
+`first_resolvable_tz()` (aus #1726) und die Referenzzonen-Auflösung in
+`run_compare_presets_daily` (`scheduler_dispatch_service.py:171-184`). Entscheidung gehört in
+die Spec, nicht zum PO — sie folgt dem bestehenden Muster.
+
+---
+
+## 🔴 Der Zuschnitt-Entscheid: Regel 3 hat zwei Hälften, und nur eine ist bezahlbar
+
+ADR-0051 Regel 3 (`docs/adr/0051-drei-zeitbegriffe-zone-an-den-daten.md:67-69`) im Wortlaut:
+
+> **Regel 3 — Keine Umgebungsuhr.**
+> `date.today()`, `datetime.now()` ohne `tz`, `time.Local` und `new Date()` ohne explizite Zone
+> sind im Produktivcode verboten. „Jetzt" wird als Zeitpunkt-Parameter hereingereicht.
+
+Das sind **zwei** Zusicherungen:
+
+- **(a) Kein Servertag-Datum.** Erfüllt, sobald `date.today()` durch
+  `trip_local_today(trip, …)` ersetzt ist. Genau das prüft Muster A des Wächters, und genau das
+  leert die Ausnahmeliste.
+- **(b) „Jetzt" kommt vom Aufrufer.** Verlangt `now_utc` als Pflichtparameter.
+
+**Gemessene Kosten von (b):** Die vier Fundstellen 1, 2, 4, 5 haben überall ein `trip`-Objekt
+im Zugriff, aber **kein** `now_utc`. `_send_trip_report_outcome` löst seines inline auf
+(`:1074-1077`, nicht an eine Variable gebunden, in Fundstelle 2 also nicht verfügbar). Ein
+Pflichtparameter an allen vieren kostet **90 Test-Aufrufstellen** (47 + 10 + 27 + 6) über rund
+20 Dateien. Ein `now_utc: datetime | None = None` mit internem Rückfall wäre der billige Weg —
+und genau die Falle aus #1726 F002: unter `freeze_time` ist nicht unterscheidbar, ob der
+Aufrufer durchreicht oder die Funktion still auf die Uhr zurückfällt.
+
+### 🔴 Korrektur: das „Millisekunden-Rennen" gilt nur für 1, 2 und 3
+
+Die erste Fassung dieser Analyse stufte die gesamte (b)-Restlücke als „Rennen von
+Millisekunden zwischen zwei `now()`-Aufrufen" ein. Das ist für die Fundstellen 1 und 2
+richtig — sie stehen **vor** jedem Netzabruf (`_convert_trip_to_segments` ist ein reiner
+Delegator auf `services.trip_segments`, `:1683-1694`).
+
+Für 4 und 5 ist es **falsch**. Zwischen der Zeitauflösung bei `:1074-1077` und
+`_build_stage_trend` (`:2023`) liegen:
+
+- `self._fetch_weather(...)` (`:1131`) mit echtem Retry-Backoff — `FETCH_RETRY_ATTEMPTS = 2`,
+  `FETCH_RETRY_BACKOFF_SECONDS = 1` (`:72-73`), `time_module.sleep(...)` bei transienten
+  Fehlern (`:1775`, `:1795`), je Segment und aufsummiert
+- amtliche Warnungen je Ort (`:1136-1164`), Ensemble-Anreicherung (`:1208-1209`),
+  `_fetch_night_weather` (`:1232`)
+- `_build_stage_trend` holt danach in seiner eigenen Schleife nochmals Wetter (`:2024-2053`);
+  `_collect_future_stage_weather` ist ein **Rückfall dahinter** (`:2213-2216`), also noch später
+
+**Das Projekt hat dieselbe Kette bereits einmal ausgemessen und schriftlich festgehalten** —
+`dispatch_orchestrator.py:157-163` zum Compare-Pfad: „zwischen `collect_due` und diesem Aufruf
+liegen Wetterabruf, Rendering und die 2s-Warteschlange je vorangehendem Preset, und damit
+**möglicherweise eine Mitternacht**." Auf eine strukturgleiche Kette die
+Millisekunden-Einordnung anzuwenden, war eine Vermutung gegen einen eigenen, gemessenen
+Präzedenzfall.
+
+**Folge für den Zuschnitt:** Bei 4 und 5 genügt (a) nicht. Wird dort ein *eigenes*
+`datetime.now()` aufgelöst, kann es nach einem langen Abruf bereits den **nächsten Ortstag**
+tragen, während `target_date` noch auf dem alten steht — derselbe Zwei-Tagesbegriffe-Bruch,
+nur eine Ebene tiefer. Beide bekommen `now_utc` deshalb als Pflichtparameter.
+
+### Entscheid
+
+| Fundstelle | (a) Ortstag | (b) Zeitpunkt vom Aufrufer | Kosten |
+|---|---|---|---|
+| 1 `select_test_stage` | ✅ | ✅ Pflichtparameter | 10 Test-Aufrufstellen |
+| 2 `_send_trip_report_outcome:1103` | ✅ | teilweise — `now_utc` **einmal oben binden** statt inline bei `:1076` | 0 |
+| 3 `_clamp_segments_to_today` | ✅ | ✅ Tag kommt vom Aufrufer | 0 |
+| 4 `_build_stage_trend` | ✅ | ✅ Pflichtparameter | 27 Test-Aufrufstellen |
+| 5 `_collect_future_stage_weather` | ✅ | ✅ Pflichtparameter | 6 Test-Aufrufstellen |
+| 6 `briefing_target_day_is_current` | ✅ | ✅ `now_utc` liegt am Aufrufort | 0 |
+| 7 `_auto_pause_expired_presets` | ✅ | ✅ `now_utc` liegt am Aufrufort | 0 |
+| 8 `_target_date_from_report` | ✅ | teilweise — Zone aus `request.trip_tz` | 0 |
+| 9 `send_one_compare_preset` | ✅ | teilweise — interne Auflösung, Reihenfolge korrigiert | 0 |
+
+**Verbleibende (b)-Lücke: nur noch die Fundstellen 2, 8 und 9** — dort wird „jetzt" weiterhin
+innerhalb der Funktion aufgelöst, aber jeweils **vor** jedem Netzabruf. Das ist der
+Millisekunden-Fall, für den die Einordnung trägt. Zusammen mit
+`send_on_demand_report` (`trip_report_scheduler.py:966`) bildet er die (b)-Folgescheibe.
+
+Gesamtkosten der Parameter-Durchreichung: **43 Test-Aufrufstellen**, je eine Zeile.
+
+### Wo (b) gratis ist
+
+- **#6:** `_process_pending_markers(self, now_utc: datetime, …)` hat den Parameter
+  (`trip_report_scheduler.py:495`), und `trip` steht an der Fundstelle im Zugriff (`:530`).
+  `briefing_target_day_is_current(entry.get("date"), today=trip_local_today(trip, now_utc))`
+  erfüllt (a) **und** (b) in einer Zeile.
+- **#7:** `pre_pass(self, now_utc: "datetime", due: list)`
+  (`dispatch_orchestrator.py:146`) hat `now_utc` und reicht es **nicht** weiter
+  (`:151`). Durchreichen kostet eine Zeile, 0 Test-Aufrufstellen.
+- **#3:** `_clamp_segments_to_today(segments, from_date)` hat gar kein `trip` — der Tag muss
+  ohnehin vom Aufrufer (`:1104`) kommen, der ihn dort bereits ortsrichtig hat. 0 Aufrufstellen.
+- **#8:** `TripReportRequest` trägt `trip: "Trip"` **und** `trip_tz: ZoneInfo`
+  (`notification_service.py:65/68`) — die Zone liegt bereits aufgelöst am Fundort.
+
+---
+
+## Nicht in dieser Scheibe
+
+- **`trip_report_scheduler.py:966` `send_on_demand_report`** — löst intern
+  `datetime.now(timezone.utc)` auf. Der Tag ist bereits **richtig** (über `_get_target_date` →
+  `trip_local_today`), es fehlt nur (b). **Für Muster A unsichtbar**, weil `datetime.now()` dort
+  ein `tz`-Argument trägt — der Schrumpf-Test deckt diese Stelle nicht ab. Gehört in die
+  (b)-Scheibe.
+- **Die Go-Seite** (225 × `time.Now()`) — unverändert eigener Befund, s. Ticketkörper.
+
+---
+
+## Existing Patterns — erprobt und gehärtet
+
+| Vorlage | Fundort | Was sie zeigt |
+|---|---|---|
+| `trip_local_today(trip, now_utc) -> date` | `src/services/trip_day.py:90` | Der geteilte Baustein. Delegiert auf `trip_local_now(trip, now_utc).date()`. **Keine Kopie bauen** (ADR-0044: kein Zweitauflöser). |
+| `_get_target_date` | `trip_report_scheduler.py:795`, Auflösung `:815` | `now_utc` als Parameter, `trip_local_today` im Rumpf |
+| `_get_active_trips` | `trip_report_scheduler.py:736`, `:763` | Tagesbestimmung **in** der Schleife, je Tour (#1724) |
+| `_collect_due_trips` | `trip_report_scheduler.py:390`, `:442` | `trip_local_now(trip, now_utc)` direkt |
+| `run_compare_presets_daily` | `scheduler_dispatch_service.py:171-184` | `now_utc` atomar ermitteln, dann durchreichen (#1724) |
+| `first_resolvable_tz()` | `src/utils/timezone.py` (#1726) | Zonenwahl bei mehreren Orten |
+
+---
+
+## Nachweisführung
+
+Vollständig **offline** belegbar (Kern-Schicht): `freeze_time` + In-Memory-`Trip`/`Stage`/
+`Waypoint`. Keine Staging-Mail nötig — geprüft wird die Tagesbestimmung, nicht der Transport.
+
+### Vorbedingungs-Anker ist Pflicht
+
+Muster aus S5a (`tests/tdd/test_befehlspfade_folgen_ortszone.py:619-636`): der Test misst
+**zuerst**, dass Ortstag und Servertag bei seiner Fixtur wirklich auseinanderfallen, und dass
+`freeze_time` im Prüfprozess überhaupt greift:
+
+```python
+assert erwartet_parameter != erwartet_systemuhr, (
+    "Testaufbau nicht diskriminierend: … der Fall kann nichts belegen")
+...
+assert tag_uhr != tag_param, (
+    "Testaufbau: Uhr und Parameter muessen auf verschiedene ORTSTAGE fallen, "
+    "nicht nur auf verschiedene Uhrzeiten")
+assert datetime.now(tz=timezone.utc) == FROST_UTC, (
+    "Testaufbau: freeze_time greift nicht …")
+```
+
+Ohne diesen Anker ist die Hauptzusicherung strukturell nie falsifizierbar (#1726 F002).
+
+### 🔴 Die Nachweis-Grenze dieser Scheibe muss benannt bleiben
+
+Der S5a-Wächter gegen „Parameter behalten, im Rumpf ignorieren" (Adversary F001,
+`reference_freeze_time_macht_parameter_vs_systemuhr_unfalsifizierbar`) ist an den Fundstellen
+1, 2, 4, 5 **nicht anwendbar**, weil es dort keinen Parameter gibt, gegen den man die Uhr
+stellen könnte. Geprüft wird dort ausschließlich (a): unter `freeze_time` liefert eine Tour in
+Neuseeland (UTC+12) bzw. an der US-Westküste einen anderen Ortstag als den Servertag. Das ist
+falsifizierbar und ausreichend für die Zusicherung, die diese Scheibe macht — aber es beweist
+**nicht** die zweite Hälfte von Regel 3. Wer den Wächter später sucht: er kommt mit der
+(b)-Scheibe, nicht hier.
+
+### Testfixturen
+
+23 von 24 Fixtur-Dateien liegen in Mitteleuropa (Offset-Fenster 2 h/Tag) und können den Fehler
+strukturell nicht zeigen. Verfügbar:
+
+- `_trip_two_zones` — Wellington + Korsika, mit S5a nach `tests/tdd/conftest.py` gehoben
+- Drei-Zonen-Fixtur Pago Pago (−11) / Korsika (+2) / Kiritimati (+14) aus S5a
+- `tests/unit/test_trip_local_today.py` — Vorbedingungs-Anker-Muster (`:60-63`)
+
+---
+
+## Bestehende Wächter
+
+| Wächter | Wirkung auf diese Scheibe |
+|---|---|
+| `tests/test_output_timezone_guard.py::test_no_unlisted_output_timezone_violations` | Neue Funde blocken |
+| `…::test_known_violations_only_shrink` | **Die neun Einträge müssen im selben Commit entfallen**, sonst rot. Schlüssel: `datei::funktion::ordinal`. Achtung Ordinal-Rückverschiebung bei `_build_stage_trend` (`::2` → `::1`) |
+| `touched_tests_gate.py` | Tests der berührten Dateien müssen grün bleiben |
+| `test_naming_gate.py` | Testdatei nach Verhalten benennen, nie `test_issue_1727*` |
+| LoC-Limit 250 | S5a brauchte 800 (670 Nachweis) für 5 Stellen — **Override ist absehbar, wird vom PO eingeholt** |
+
+---
+
+## Existing Specs & ADRs
+
+| Dokument | Bezug |
+|---|---|
+| `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` (Akzeptiert) | Ortstag statt Servertag; Verbot eines Zweitauflösers |
+| `docs/adr/0051-drei-zeitbegriffe-zone-an-den-daten.md` (Vorgeschlagen) | Regel 3, s.o. |
+| `docs/specs/modules/fix_1727_s5a_befehlspfade_ortstag.md` | Vorgängerscheibe, 10 ACs — Vorbild für Aufbau und Nachweisform |
+| `docs/specs/modules/fix_1724_faelligkeit_in_der_ortszone.md` | Muster „Tagesbestimmung in der Schleife" |
+| `docs/specs/modules/fix_1726_ruhezeit_und_zaehler_ortszone.md` | `first_resolvable_tz()`, Mehrzonen-Wahl |
+| `docs/context/fix-1697-ortstag-statt-servertag.md` | Warum ein halber Schnitt gefährlicher ist als keiner |
+
+### 🔴 Nebenbefund: die ADR-0044-Restliste ist unvollständig
+
+`docs/adr/0044-kalendertage-folgen-der-ortszeit.md:151-153` führt unter „Noch nicht umgesetzt"
+nur `preview_service.py`, `api/routers/debug.py` und `tools/weather_validation.py`. **Keine**
+der acht Fundstellen dieser Scheibe steht dort — obwohl fünf davon auf versendete Inhalte
+wirken. Das ist die vierte unvollständige Aufzählung in diesem Epic (nach den drei aus #1726).
+Die Liste wird mit dieser Scheibe mitgezogen.
+
+---
+
+## Risks & Considerations
+
+- **Fundstelle 2 ändert den Test-Fallback-Pfad.** Im Mismatch-Fenster kann der Klemm-Zweig
+  künftig greifen, wo er vorher nicht griff (und umgekehrt). Betrifft nur
+  `allow_test_fallback=True`, also den Test-Versand — kein regulärer Scheduler-Pfad.
+- **Fundstelle 4 hat einen zweiten Aufrufer in `preview_service.py:218`**, das laut Zuschnitt
+  in eine spätere Scheibe gehört. Der Fix ist funktionsintern (`trip` liegt vor), der
+  Vorschau-Pfad erbt ihn ohne eigene Änderung — kein Scheibenbruch, aber in der Spec zu nennen.
+- **Fundstelle 5 kann `trip=None` bekommen** (Vorschau-Pfad, #1498) — der None-Zweig
+  (`:2409-2413`) muss vor der Zonen-Auflösung greifen.
+- **Fundstelle 7 schreibt Persistenz** (`paused_at` in `briefings/<id>.json`). Read-Modify-Write
+  mit Merge, kein Replace.
+- **Mehrzonen-Touren:** Restfehler = Zonendifferenz zweier benachbarter Etappen am Wechseltag.
+  Unverändert bewusst offen (ADR-0044, PO-Entscheidung).
+
+---
+
+# Analysis
+
+## Type
+
+Bug — Verstoß gegen die akzeptierte ADR-0044. Keine offene Produktfrage.
+
+## 🔴 Zwei eigene Zuschnitt-Entscheide sind der Nachmessung nicht standgehalten
+
+Beide stammen aus der Kontextphase dieses Workflows, beide wurden vom `analysis-challenger`
+und einer eigenen Codemessung gekippt:
+
+1. **„Das Millisekunden-Rennen gilt für die ganze (b)-Lücke."** Falsch für die Fundstellen 4
+   und 5 — dort liegt ein Wetterabruf mit Retry-Backoff dazwischen. Widerlegt durch den
+   **eigenen, bereits schriftlich festgehaltenen Präzedenzfall** in
+   `dispatch_orchestrator.py:157-163` („möglicherweise eine Mitternacht"). Details oben.
+2. **„`send_one_compare_preset` kostet 67 Test-Aufrufstellen, also eigene Scheibe."** Die Zahl
+   stimmt, die Schlussfolgerung nicht: sie gilt für eine **Signaturänderung**, die dieser Fix
+   gar nicht braucht. Der `date.today()`-Zweig (`:366-370`) steht nur zufällig **vor** der
+   Ortsauflösung (`location_ids` `:387`, `order_locations_by_ids(...)` `:399`); beide werden
+   ohnehin immer geladen. Block nach oben ziehen, `first_resolvable_tz(locations)` anwenden —
+   **null** berührte Aufrufstellen, externer Vertrag unverändert.
+
+Gemeinsames Muster: aus einer plausiblen Struktur auf eine Kostengröße geschlossen, statt sie
+zu messen. Beim ersten Mal gegen einen Präzedenzfall im eigenen Repo, beim zweiten Mal gegen
+die Zeilenreihenfolge in der Funktion selbst.
+
+## Technischer Ansatz
+
+Ein Muster, neunmal angewandt — kein neuer Baustein, keine neue Abstraktion:
+
+| Lage am Fundort | Vorgehen | Fundstellen |
+|---|---|---|
+| `trip` vorhanden, `now_utc` vom Aufrufer erreichbar | `now_utc` als Pflichtparameter, `trip_local_today(trip, now_utc)` | 1, 4, 5 |
+| `trip` vorhanden, `now_utc` nur intern (vor jedem I/O) | `now_utc` **einmal** oben binden, dann `trip_local_today(trip, now_utc)` | 2 |
+| Weder `trip` noch `now_utc` | Fertigen Tag vom Aufrufer hereinreichen | 3 |
+| `now_utc` liegt ungenutzt am Aufrufort | Durchreichen, `trip_local_today(trip, now_utc)` | 6, 7 |
+| Zone bereits aufgelöst im DTO | `local_dt(now_utc, request.trip_tz).date()` | 8 |
+| Mehrere Orte, Zone auflösbar | Reihenfolge korrigieren, `first_resolvable_tz(locations)` | 7, 9 |
+
+Fundstelle 2 bindet den Zeitpunkt, den 1, 4 und 5 dann als Parameter bekommen — **eine**
+Zeitabfrage für den gesamten Briefing-Aufbau. Damit verschwindet auch der Fall „Mitternacht
+während des Wetterabrufs", ohne dass `_send_trip_report_outcome` selbst die Signatur ändert.
+
+## Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/services/trip_report_scheduler.py` | MODIFY | Fundstellen 1–5; `now_utc` einmal binden und an drei Helfer durchreichen; Aufruf von `briefing_target_day_is_current` (#6) |
+| `src/services/alert_briefing_anchor.py` | MODIFY | #6 — Pflicht-`today` statt Systemuhr-Rückfall |
+| `src/services/scheduler_dispatch_service.py` | MODIFY | #7 `now_utc`-Parameter; #9 Ortsauflösung vor den Zweig ziehen |
+| `src/services/dispatch_orchestrator.py` | MODIFY | #7 — vorhandenes `now_utc` aus `pre_pass` durchreichen |
+| `src/services/notification_service.py` | MODIFY | #8 — Ortstag aus `request.trip_tz` |
+| `tests/test_output_timezone_guard.py` | MODIFY | Neun `KNOWN_VIOLATIONS`-Einträge entfernen |
+| `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` | MODIFY | Restliste nachziehen (s. Nebenbefund oben) |
+| ~20 Bestandstestdateien | MODIFY | 43 Aufrufstellen auf die neuen Signaturen, je eine Zeile |
+| `tests/tdd/test_<verhalten>.py` | CREATE | Verhaltenstests aller neun Fundstellen |
+
+## Scope Assessment
+
+- **Produktivcode:** ~+70/−30
+- **Bestandstests:** ~43 geänderte Zeilen
+- **Neue Tests:** ~450–600 (S5a brauchte 670 für fünf Fundstellen; hier teilen sich 1/2/4/5
+  eine Fixtur und einen `freeze_time`-Rahmen)
+- **Gesamt: ~600–700 → LoC-Override auf 800 nötig**, vom PO einzuholen, sobald die Testfläche
+  steht. Pro Fundstelle günstiger als S5a (~75 statt ~160 Zeilen).
+- **Risiko: MEDIUM.** Fünf der neun Stellen wirken auf versendete Inhalte, aber jede Änderung
+  ist lokal und ersetzt einen Tagesbegriff durch einen anderen — keine Strukturänderung, keine
+  Persistenz-Migration.
+
+## Risiken
+
+- **Fundstelle 7 schreibt Persistenz** (`paused_at` in `briefings/<id>.json`) —
+  Read-Modify-Write mit Merge, kein Replace.
+- **Fundstelle 9 ändert die Anweisungsreihenfolge** in einer Versandfunktion. Der
+  `ValueError` für fehlende Empfänger (`:389-393`) und der für unauflösbare Orte (`:400`)
+  feuern dann in anderer Reihenfolge relativ zur Datumssetzung. Beides sind Fehlerpfade ohne
+  Nebenwirkung; die Reihenfolge der beiden zueinander bleibt unverändert. In der Spec als
+  ausdrückliche Invariante festzuhalten.
+- **Ungezählt:** ob unter den 67 Aufrufstellen von `send_one_compare_preset` welche den
+  Servertag im `target_date=None`-Pfad ausdrücklich behaupten. Bei mitteleuropäischen Fixturen
+  fällt der Unterschied meist nicht an — vor der Umsetzung auszuzählen, nicht zu schätzen.
+- **Fundstelle 5 kann `trip=None` bekommen** (Vorschau-Pfad, #1498) — der None-Zweig
+  (`:2409-2413`) muss vor der Zonen-Auflösung greifen.
+
+## Offene Punkte für die Spec
+
+1. Zonenwahl für Fundstelle 7 (Preset mit mehreren Orten) — `first_resolvable_tz()`, dem
+   #1726-Muster folgend. Keine PO-Frage.
+2. Ob Fundstelle 8 den Tag aus `request.trip_tz` ableitet oder den bereits bekannten
+   `target_date` durchgereicht bekommt (sauberer, aber ein Feld mehr im DTO).
+3. Die (b)-Restlücke (Fundstellen 2, 8, 9 + `send_on_demand_report`) läuft als weitere
+   S5-Scheibe im bestehenden Ticket, nicht als eigenes Issue — sie blockiert nichts und ist
+   ohne den Kontext dieses Epics nicht verständlich.

--- a/docs/specs/modules/fix_1727_s5b_versandpfade_ortstag.md
+++ b/docs/specs/modules/fix_1727_s5b_versandpfade_ortstag.md
@@ -13,7 +13,7 @@ workflow: fix-1727-s5b-versandpfade
 
 ## Approval
 
-- [ ] Approved — PO-Freigabe ausstehend, 9 ACs auf Deutsch vorgelegt
+- [x] Approved — PO-Freigabe 2026-08-14 („Go"), 9 ACs auf Deutsch vorgelegt
 
 ## Purpose
 
@@ -475,3 +475,10 @@ ebenso zulässig.
 
 - 2026-08-14: Spec erstellt nach Kartierung `docs/context/fix-1727-s5b-versandpfade.md`
   (Basis-HEAD `1e5e0be9`), Vorbild `docs/specs/modules/fix_1727_s5a_befehlspfade_ortstag.md`.
+- 2026-08-14: Vier Korrekturen am Entwurf vor der Vorlage — (1) AC-3 prüft künftig
+  „Parameter gegen Systemuhr" (Muster S5a-F001) statt einer Verzögerungs-Simulation;
+  (2) die Nachweis-Grenze war invertiert: die Probe ist an den Fundstellen mit Pflichtparameter
+  (1, 3, 4, 5, 6, 7) möglich und Pflicht, unmöglich nur an 2, 8, 9; (3) AC-8 nimmt die
+  Ordinal-Rückverschiebung `_build_stage_trend::2` → `::1` auf; (4) Fundstelle 7 räumt das
+  wächter-unsichtbare `datetime.utcnow()` (`scheduler_dispatch_service.py:69`) mit auf.
+- 2026-08-14: PO-Freigabe der 9 ACs („Go").

--- a/docs/specs/modules/fix_1727_s5b_versandpfade_ortstag.md
+++ b/docs/specs/modules/fix_1727_s5b_versandpfade_ortstag.md
@@ -1,0 +1,477 @@
+---
+entity_id: fix_1727_s5b_versandpfade_ortstag
+type: bugfix
+created: 2026-08-14
+updated: 2026-08-14
+status: draft
+version: "1.0"
+tags: [timezone, trip-report-scheduler, scheduler-dispatch-service, compare-preset, issue-1727, issue-1722, adr-0044, adr-0051]
+workflow: fix-1727-s5b-versandpfade
+---
+
+# Fix #1727 S5b — Versandpfade folgen dem Ortstag der Tour
+
+## Approval
+
+- [ ] Approved — PO-Freigabe ausstehend, 9 ACs auf Deutsch vorgelegt
+
+## Purpose
+
+Neun Fundstellen im Trip- und Ortsvergleichs-Versand bestimmen den Kalendertag weiterhin
+über die Serveruhr (`date.today()`) statt über den Ortstag der Tour bzw. des Preset-Orts —
+ein Verstoß gegen die bereits akzeptierte ADR-0044. Anders als die vorangegangene Scheibe S5a
+(Anzeige-/Befehlspfade) wirken alle neun Stellen dieser Scheibe auf **versendete Inhalte**:
+Etappenwahl im Test-Fallback, Wetter-Input, Ausblicks- und Gewitter-Ausblickszeilen, ob ein
+Versandfehler-Vermerk überhaupt noch nachgeliefert wird, ob ein Compare-Preset pausiert wird,
+Datumsangaben im Mail-/SMS-/Telegram-Präfix und der Zieltag des Compare-Einzelversands. Diese
+Scheibe schließt alle neun, indem sie an jeder den geteilten Baustein
+`trip_local_today(trip, now_utc)` (bzw. `first_resolvable_tz(locations)` dort, wo es kein
+`Trip`-Objekt, sondern mehrere Compare-Orte gibt) einsetzt — keine eigene Kopie der
+Zonen-Auflösung.
+
+Zusätzlich zu ADR-0044 (Ortstag statt Servertag) setzt diese Scheibe an sechs der neun
+Fundstellen auch Regel 3 aus ADR-0051 um (`now_utc` als Pflichtparameter statt
+Systemuhr-Default) — an den übrigen drei (Fundstellen 2, 8, 9) bleibt „jetzt" bewusst eine
+interne, aber **vor jedem Netzabruf** liegende Auflösung; das ist der Millisekunden-Fall, für
+den ein Pflichtparameter keinen Sicherheitsgewinn bringt (Begründung unten, „Known
+Limitations").
+
+## Source
+
+- **File:** `src/services/trip_report_scheduler.py`
+  **Identifier:** `select_test_stage` (Zeile 849, Verstoß Zeile 871), `_send_trip_report_outcome`
+  (Zeile 1001, Verstoß Zeile 1103), `_clamp_segments_to_today` (Zeile 1696, Verstoß Zeile 1708),
+  `_build_stage_trend` (Zeile 1984, Verstoß Zeile 2023), `_collect_future_stage_weather`
+  (Zeile 2374, Verstoß Zeile 2416)
+- **File:** `src/services/alert_briefing_anchor.py`
+  **Identifier:** `briefing_target_day_is_current` (Zeile 144, Verstoß Zeile 169)
+- **File:** `src/services/scheduler_dispatch_service.py`
+  **Identifier:** `_auto_pause_expired_presets` (Zeile 60, Verstoß Zeile 79),
+  `send_one_compare_preset` (Zeile 322, Verstoß Zeile 369)
+- **File:** `src/services/notification_service.py`
+  **Identifier:** `_target_date_from_report` (Zeile 1711, Verstoß Zeile 1717)
+- **Zonen-Auflösung (unverändert nutzen):** `src/services/trip_day.py::trip_local_today(trip,
+  now_utc)` (Zeile 90–96), `src/utils/timezone.py::first_resolvable_tz(locations,
+  context_label="")` (Zeile 77–99), `src/utils/timezone.py::local_dt(dt, tz)` (Zeile 109–111)
+- **Zeilennummern gemessen am Basis-HEAD `1e5e0be9`** (2026-08-14); vgl. ADR-0044s eigene Lehre
+  aus veralteten Zeilenangaben.
+
+## Estimated Scope
+
+- **LoC:** Produktivcode ~+70/−30, Bestandstests ~43 geänderte Zeilen (Signaturanpassungen, je
+  eine Zeile), neue Tests ~450–600 → **Gesamt ~600–700 → LoC-Override auf 800 einzuholen**,
+  sobald die Testfläche steht (Zahlen aus der Kartierung übernommen, nicht neu geschätzt)
+- **Files:** 6 Produktivdateien MODIFY (davon 1 rein mechanisch, s. u.), 1 Wächterdatei MODIFY,
+  1 ADR MODIFY, ~20 Bestandstestdateien MODIFY, 1 neue Testdatei CREATE
+- **Effort:** high — die Einzelrechnung ist pro Stelle klein (bestehender, bereits getesteter
+  Baustein), aber fünf der neun Stellen wirken auf tatsächlich versendete Inhalte (Risiko laut
+  Kartierung: MEDIUM)
+
+### Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/services/trip_report_scheduler.py` | MODIFY | Fundstellen 1–5: `now_utc` einmal zu Beginn von `_send_trip_report_outcome` binden und an `select_test_stage`, `_clamp_segments_to_today`, `_build_stage_trend`, `_build_thunder_forecast_from_trend_or_fetch` (reiner Durchreichungs-Helfer, keine eigene Fundstelle) und `_collect_future_stage_weather` durchreichen |
+| `src/services/alert_briefing_anchor.py` | MODIFY | Fundstelle 6: `today` wird Pflichtparameter ohne Systemuhr-Rückfall |
+| `src/services/scheduler_dispatch_service.py` | MODIFY | Fundstelle 7: `_auto_pause_expired_presets` bekommt `now_utc` + Ortsliste, prüft je Preset gegen `first_resolvable_tz(locations)`; Fundstelle 9: Ortsauflösung in `send_one_compare_preset` vor den `target_date is None`-Zweig gezogen |
+| `src/services/dispatch_orchestrator.py` | MODIFY | Fundstelle 7: `pre_pass` reicht sein bereits vorhandenes `now_utc` sowie die in `collect_due` bereits geladene Ortsliste an `_auto_pause_expired_presets` durch |
+| `src/services/notification_service.py` | MODIFY | Fundstelle 8: `_target_date_from_report` leitet den Fallback-Tag aus `request.trip_tz` ab |
+| `src/services/preview_service.py` | MODIFY | **Rein mechanisch, keine eigene Fundstelle:** die beiden Aufrufstellen `_build_stage_trend(...)`/`_build_thunder_forecast_from_trend_or_fetch(...)` (Zeile 218/222) reichen `now_utc=datetime.now(timezone.utc)` durch, weil die Signaturen der Fundstellen 4/5 sonst nicht mehr aufrufbar wären. Die EIGENE Zonen-Logik der Vorschau (`_resolve_target_date`s `date.today()`, Zeile 94) bleibt unverändert — sie gehört laut ADR-0044-Restliste zu „Vorschau, Werkzeuge", einer späteren Scheibe |
+| `tests/test_output_timezone_guard.py` | MODIFY | Neun `KNOWN_VIOLATIONS`-Einträge entfernen (s. AC-8) |
+| `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` | MODIFY | „Umgesetzt"/„Noch nicht umgesetzt" nachziehen — die neun Fundstellen standen dort bislang gar nicht (Nebenbefund der Kartierung) |
+| ~20 Bestandstestdateien | MODIFY | ~43 Aufrufstellen der geänderten Signaturen, je eine Zeile |
+| `tests/tdd/test_<verhalten>.py` | CREATE | Verhaltenstests aller neun Fundstellen, nach Verhalten benannt |
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `services.trip_day.trip_local_today(trip, now_utc)` | module function | Ersetzt `date.today()` an den Fundstellen 1–6, wo ein `Trip`-Objekt vorliegt |
+| `utils.timezone.first_resolvable_tz(locations, context_label="")` | module function | Zonenwahl bei mehreren Compare-Orten (Fundstellen 7, 9) — dasselbe Muster wie in #1726 |
+| `utils.timezone.local_dt(dt, tz)` | module function | Ortszeit aus `now_utc` + aufgelöster Zone (Fundstelle 8, wo bereits eine `ZoneInfo` vorliegt, kein `Trip`) |
+| ADR-0044 (Akzeptiert) | decision | Verlangt Ortstag statt Servertag; die neun Stellen dieser Scheibe standen bislang NICHT in dessen Restliste (Nebenbefund) |
+| ADR-0051 Regel 3 (Vorgeschlagen) | decision | Verbietet Systemuhr-Default; an sechs der neun Fundstellen als Pflichtparameter umgesetzt, an dreien (2, 8, 9) bewusst noch nicht (Millisekunden-Fall, s. Known Limitations) |
+| `trip_report_scheduler._get_target_date`/`_get_active_trips` (#1724) | pattern | Vorbild „`now_utc` als Pflichtparameter, `trip_local_today` im Rumpf" |
+| `scheduler_dispatch_service.run_compare_presets_daily` (#1726) | pattern | Vorbild für Ortsauflösung bei mehreren Compare-Orten über `first_resolvable_tz` |
+| `tests/test_output_timezone_guard.py::test_known_violations_only_shrink` | guard | Die neun Einträge müssen im selben Commit entfallen, sonst rot (s. AC-8) |
+| `docs/specs/modules/fix_1727_s5a_befehlspfade_ortstag.md` | pattern | Vorgängerscheibe — Vorbild für Aufbau, Nachweisform und den Vorbedingungs-Anker (AC-9) |
+| Zwei-/Drei-Zonen-Fixturen aus S5a (`tests/tdd/conftest.py`) | test fixture | Wellington+Korsika sowie Pago Pago/Korsika/Kiritimati — werden wiederverwendet, keine vierte Kopie |
+
+## Implementation Details
+
+Ein Muster, neunmal angewandt — kein neuer Baustein, keine neue Abstraktion:
+
+| Lage am Fundort | Vorgehen | Fundstellen |
+|---|---|---|
+| `trip` vorhanden, `now_utc` vom Aufrufer erreichbar | `now_utc` Pflichtparameter, `trip_local_today(trip, now_utc)` | 1, 4, 5 |
+| `trip` vorhanden, `now_utc` nur intern (vor jedem I/O) | `now_utc` **einmal** oben binden, dann `trip_local_today(trip, now_utc)` | 2 |
+| Weder `trip` noch `now_utc` am Fundort | Fertigen Tag vom Aufrufer hereinreichen | 3 |
+| `now_utc` liegt ungenutzt am Aufrufort | Durchreichen, `trip_local_today(trip, now_utc)` | 6, 7 |
+| Zone bereits als `ZoneInfo` im DTO aufgelöst | `local_dt(now_utc, request.trip_tz).date()` | 8 |
+| Mehrere Orte statt eines Trips, Zone auflösbar | Reihenfolge korrigieren, `first_resolvable_tz(locations)` | 7, 9 |
+
+**Fundstellen 1 + 3 (Test-Fallback-Pipeline):**
+```python
+def select_test_stage(self, trip, report_type, now_utc: datetime):
+    today = trip_local_today(trip, now_utc)
+    ...
+
+def _clamp_segments_to_today(self, segments, from_date, today: date):
+    delta_days = (today - from_date).days
+    ...
+```
+Beide werden ausschließlich aus `_send_trip_report_outcome` heraus aufgerufen; dort ist
+`now_utc` nach der Änderung an Fundstelle 2 bereits gebunden.
+
+**Fundstelle 2 — `now_utc` einmal binden statt zweimal implizit auflösen:**
+```python
+now_utc = datetime.now(timezone.utc)  # jetzt VOR dem if, nicht mehr nur darin
+if target_date is None:
+    target_date = self._get_target_date(report_type, trip, now_utc)
+segments = self._convert_trip_to_segments(trip, target_date)
+...
+if allow_test_fallback and target_date < trip_local_today(trip, now_utc):
+    weather_segments = self._clamp_segments_to_today(
+        segments, target_date, trip_local_today(trip, now_utc),
+    )
+```
+Die externe Signatur von `_send_trip_report_outcome` bleibt unverändert — `now_utc` ist eine
+lokale Variable, kein neuer Parameter (0 Test-Aufrufstellen).
+
+**Fundstellen 4 + 5 — `now_utc` als Pflichtparameter, durchgereicht durch den
+Zwischen-Helfer:**
+```python
+def _build_stage_trend(self, trip, target_date, now_utc: datetime, tz=None):
+    ...
+    today = trip_local_today(trip, now_utc)
+
+def _build_thunder_forecast_from_trend_or_fetch(
+    self, trip, target_date, now_utc: datetime, tz, multi_day_trend=None, night_weather=None,
+):
+    ...  # reicht now_utc an _collect_future_stage_weather durch, keine eigene Fundstelle
+
+def _collect_future_stage_weather(self, trip, target_date, now_utc: datetime, wanted_dates=None):
+    if trip is None:  # #1498 — Reihenfolge bewusst UNVERÄNDERT: vor der Zonen-Auflösung
+        return []
+    ...
+    today = trip_local_today(trip, now_utc)
+```
+Zwei Produktiv-Aufrufer je Funktion: `trip_report_scheduler.py` selbst (hat `now_utc` aus
+Fundstelle 2 im Scope) und `preview_service.py:218`/`:222` (mechanischer Durchreich, s.
+Affected Files).
+
+**Fundstelle 6:**
+```python
+def briefing_target_day_is_current(target_date, *, today: date) -> bool:  # kein Default mehr
+    ...
+
+# Aufrufer trip_report_scheduler.py:538, in _process_pending_markers (hat now_utc UND trip):
+if is_dispatch_error and not briefing_target_day_is_current(
+    entry.get("date"), today=trip_local_today(trip, now_utc),
+):
+```
+
+**Fundstelle 7 — Ortsauflösung analog #1726:**
+```python
+def _auto_pause_expired_presets(presets, user_id, data_root, now_utc, all_locations):
+    by_id = {loc.id: loc for loc in all_locations}
+    for preset in presets:
+        ...
+        locations = order_locations_by_ids(all_locations, preset.get("location_ids") or [])
+        zone = first_resolvable_tz(locations, context_label=f"Preset {preset.get('id')}")
+        heute = local_dt(now_utc, zone).date()
+        expired = date.fromisoformat(end_date_str) < heute
+```
+`pre_pass` (`dispatch_orchestrator.py:146`) hat `now_utc` bereits als Parameter und die
+Ortsliste bereits aus `collect_due` im Cache (`self._all_locations`, dort VOR `pre_pass`
+geladen) — beides wird durchgereicht statt neu aufgelöst.
+
+Im selben Zug ersetzt `now_iso = now_utc.isoformat()` das heutige
+`now_iso = _datetime.utcnow().isoformat() + "Z"` (`scheduler_dispatch_service.py:69`). Das ist
+ein **Zeitstempel**, kein Kalendertag — ADR-0044 greift dort nicht, wohl aber ADR-0051 Regel 3,
+und `datetime.utcnow()` ist zusätzlich veraltet (naiv, ohne Zone). Der Zeitstempel stammt danach
+aus derselben Zeitabfrage wie die Ablauf-Prüfung darüber.
+
+**Fundstelle 8:**
+```python
+@staticmethod
+def _target_date_from_report(report, request: TripReportRequest):
+    if report.segments and report.segments[0].segment:
+        return report.segments[0].segment.start_time.date()
+    return local_dt(datetime.now(timezone.utc), request.trip_tz).date()
+```
+`request.trip_tz` liegt am DTO bereits als `ZoneInfo` vor (`notification_service.py:68`) —
+kein zusätzlicher Parameter nötig.
+
+**Fundstelle 9 — Ortsauflösung vor den Zieltag-Zweig ziehen:**
+```python
+if all_locations_cache is None:
+    all_locations_cache = load_all_locations(user_id=user_id)
+locations = order_locations_by_ids(all_locations_cache, preset.get("location_ids") or [])
+if not locations:
+    raise ValueError(f"Preset {preset_id}: Orte {location_ids} nicht aufloesbar")
+
+if (target_date is None) != (tage_ab_ortstag is None):
+    raise ValueError(...)  # unveraendert
+if target_date is None:
+    target_date = local_dt(datetime.now(timezone.utc), first_resolvable_tz(locations)).date()
+    tage_ab_ortstag = 0
+```
+Der Empfänger-Check (`default_to`) bleibt VOR der Ortsauflösung stehen — seine Position
+relativ zur Orte-Prüfung ändert sich damit **nicht**, nur die Orte-Auflösung wandert vor die
+`target_date`-Bestimmung, weil sie deren Zone liefert.
+
+## Nicht in dieser Scheibe
+
+- **`send_on_demand_report`** (`trip_report_scheduler.py:966`) — löst intern
+  `datetime.now(timezone.utc)` auf und übergibt es an `_get_target_date`; der Tag ist bereits
+  **richtig** (Ortstag über `trip_local_today`), es fehlt nur (b) (Zeitpunkt kommt nicht vom
+  Aufrufer). **Für Muster A unsichtbar**, weil `datetime.now()` hier ein `tz`-Argument trägt —
+  der Wächter-Scanner erkennt nur den Systemuhr-Aufruf ohne Zone. Gehört zusammen mit den
+  Fundstellen 2, 8, 9 in die (b)-Folgescheibe im bestehenden Ticket #1727.
+- **Die Go-Seite** (225 × `time.Now()`) — unverändert eigener Befund außerhalb dieses Epics.
+- **`preview_service.py`s eigene Zonen-Logik** (`_resolve_target_date:94`, `date.today()`) —
+  nur die durch Fundstelle 4/5 erzwungene Signatur-Anpassung der beiden Aufrufstellen ist
+  Teil dieser Scheibe (s. Affected Files); die Vorschau selbst folgt weiterhin dem Servertag
+  und ist Teil der ADR-0044-Restliste „Vorschau, Werkzeuge" (S5c).
+
+## Expected Behavior
+
+- **Input:** ein fälliger Trip-/Compare-Versand (`now_utc` aus dem Scheduler-Zeitpunkt) bzw.
+  ein Handversand/Test-Versand ohne Slot-Kontext.
+- **Output:** Etappenwahl (Test-Fallback), Wetter-Abruf-Fenster, Ausblicks-/
+  Gewitter-Ausblickszeilen, Verfall eines Nachliefer-Vermerks, Auto-Pause eines
+  Compare-Presets, das Datum im Mail-/SMS-/Telegram-Präfix sowie Zieltag und Δ-Anker des
+  Compare-Einzelversands richten sich nach dem **Ortstag der betroffenen Tour bzw. des ersten
+  auflösbaren Preset-Orts** — nicht nach dem Servertag (`Etc/UTC`).
+- **Side effects:** `briefings/<id>.json`-Pause-Einträge (Fundstelle 7) werden weiterhin per
+  Read-Modify-Write mit Merge geschrieben, kein Replace (BUG-DATALOSS-GR221). Keine Migration
+  von Bestandsdaten nötig.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip-Test-Versand (`allow_test_fallback=True`) für eine Tour in einer
+  Zone mit positivem UTC-Offset (z. B. Neuseeland), deren einzige Etappe auf den Servertag D
+  fällt, während der ORTSTAG bereits D+1 ist (Mismatch-Fenster 00:00–12:00 UTC) / When
+  `select_test_stage` (`trip_report_scheduler.py:849`) die Fallback-Etappe wählt und
+  anschließend `_clamp_segments_to_today` (`:1696`) deren Segmentzeiten für den Wetterabruf
+  klemmt / Then zählt Etappe D für `select_test_stage` NICHT mehr als „kommend" (sie ist
+  ortszeitlich bereits vergangen, der Fallback greift auf die chronologisch früheste Etappe
+  zurück), und `_clamp_segments_to_today` verschiebt die Segmentzeiten um
+  `trip_local_today(trip, now_utc) - from_date` statt um `date.today() - from_date` Tage — vor
+  dem Fix behandelte `s.date >= today` Etappe D fälschlich noch als aktuell, weil `today` den
+  Servertag D trug.
+  - Test: `freeze_time` im Mismatch-Fenster, Ein-Etappen-Trip-Fixtur mit Etappe D und
+    Neuseeland-Wegpunkt; Assertion, dass `select_test_stage(trip, report_type, now_utc)` NICHT
+    Etappe D liefert, und dass `_clamp_segments_to_today` mit dem Ortstag-Parameter einen
+    anderen Delta liefert als mit dem (falschen) Servertag.
+
+- **AC-2:** Given `_send_trip_report_outcome` (`trip_report_scheduler.py:1001`) läuft für eine
+  Tour in einer Zone mit negativem UTC-Offset (z. B. PCT), deren `target_date` bereits
+  ortsrichtig aus `_get_target_date` → `trip_local_today` stammt, während der SERVERTAG noch
+  einen Tag zurückliegt (Mismatch-Fenster 12:00–24:00 UTC) / When die Zeile 1103 prüft, ob der
+  Wetter-Klemm-Zweig greift / Then vergleicht sie `target_date < trip_local_today(trip,
+  now_utc)` statt `target_date < date.today()`, wobei `now_utc` EINMAL oben in der Funktion
+  gebunden wird (statt bisher nur innerhalb des `if target_date is None:`-Zweigs bei Zeile
+  1076 aufgelöst zu werden) — vor dem Fix verglich der Code einen bereits ortsrichtigen
+  `target_date` gegen den rohen Servertag, zwei verschiedene Tagesbegriffe im selben
+  `<`-Vergleich.
+  - Test: `freeze_time` im Mismatch-Fenster, `target_date` auf den (aus Serversicht noch
+    nicht erreichten) wahren Ortstag gesetzt; Assertion, dass der Klemm-Zweig NICHT greift,
+    obwohl `date.today() > target_date` gälte — er darf nur greifen, wenn `target_date` auch
+    ortszeitlich in der Vergangenheit liegt.
+
+- **AC-3:** Given zwischen der `now_utc`-Bindung in `_send_trip_report_outcome` und dem
+  Aufruf von `_build_stage_trend` (`:1984`) bzw. dessen Rückfall `_collect_future_stage_weather`
+  (`:2374`) liegt ein echter Wetterabruf mit Retry-Backoff (`_fetch_weather`,
+  `FETCH_RETRY_ATTEMPTS=2`, `FETCH_RETRY_BACKOFF_SECONDS=1`, je Segment aufsummiert) / When
+  beide Funktionen ihren Ausblicks-Horizont über `is_within_forecast_horizon(stage.date,
+  today)` prüfen / Then bestimmen beide `today` über den ALS PARAMETER übergebenen `now_utc`
+  (`trip_local_today(trip, now_utc)`), NICHT über eine eigene `date.today()`-Auflösung im
+  eigenen Funktionskörper — sonst könnte ein langsamer Abruf zwischen Bindung und Aufruf
+  bereits den nächsten Ortstag tragen, während `target_date` noch auf dem alten steht (derselbe
+  Zwei-Tagesbegriffe-Bruch wie #1697, hier zwischen zwei eigenen `now()`-Aufrufen statt gegen
+  die Serveruhr — bereits einmal gemessen und dokumentiert in
+  `dispatch_orchestrator.py:157-163` zum strukturgleichen Compare-Pfad). `now_utc` wird dazu
+  Pflichtparameter beider Funktionen ohne Default.
+  - Test: **Parameter gegen Systemuhr** (Muster S5a-F001, `test_befehlspfade_folgen_ortszone.py`)
+    — `freeze_time(X)` setzen und `now_utc=Y` übergeben, wobei X und Y auf **verschiedene
+    Ortstage** derselben Trip-Zone fallen; Assertion, dass das Ergebnis dem Ortstag von Y folgt.
+    Eine Implementierung, die den Pflichtparameter zwar entgegennimmt, im Rumpf aber
+    `date.today()` benutzt, liefert dann den Ortstag von X und macht den Test rot. Das ist die
+    einzige Form, die den in diesem AC beschriebenen Mitternachtssprung fängt — eine
+    Verzögerungs-Simulation im Wetterabruf prüft nur den Testaufbau, nicht die Zusicherung.
+
+- **AC-4:** Given ein Versandfehler-Vermerk (`reason == "dispatch_error"`) mit Zieltag D
+  wartet in `_process_pending_markers` (`trip_report_scheduler.py:495`) auf Nachlieferung, und
+  die betroffene Tour liegt in einer Zone, in der Ortstag und Servertag zum Prüfzeitpunkt
+  auseinanderfallen / When `briefing_target_day_is_current` (`alert_briefing_anchor.py:144`)
+  an Zeile 538 prüft, ob der Vermerk noch aktuell ist / Then erhält die Funktion
+  `today=trip_local_today(trip, now_utc)` explizit vom Aufrufer statt intern `heute = today or
+  date.today()` aufzulösen — ein Vermerk verfällt (bzw. bleibt gültig) nach dem ORTSTAG der
+  Tour; vor dem Fix konnte er im Mismatch-Fenster einen Tag zu früh verfallen oder einen Tag
+  zu spät weitergeschleppt werden.
+  - Test: `freeze_time` im Mismatch-Fenster, Vermerk mit Zieltag = wahrer Ortstag − 1 (aus
+    Ortssicht bereits abgelaufen, aus Serversicht noch aktuell); Assertion auf
+    `briefing_target_day_is_current`s Rückgabewert unter dem Ortstag-Parameter gegenüber dem
+    (falschen) Servertag-Ergebnis.
+
+- **AC-5:** Given ein Compare-Preset mit `end_date` = Ortstag D des ERSTEN auflösbaren
+  Preset-Orts, dessen Zone vom Servertag abweicht (Mismatch-Fenster) / When
+  `_auto_pause_expired_presets` (`scheduler_dispatch_service.py:60`), aufgerufen aus `pre_pass`
+  (`dispatch_orchestrator.py:146`), prüft, ob das Preset automatisch pausiert wird / Then
+  vergleicht die Funktion `end_date` gegen den über `first_resolvable_tz(locations)` (analog
+  #1726) und das bereits verfügbare `now_utc` aufgelösten Ortstag — statt gegen `date.today()`;
+  vor dem Fix konnte ein Preset im Mismatch-Fenster einen Tag zu früh oder zu spät pausiert
+  werden. Der Persistenz-Schreibweg (`save_compare_preset_pause`, Read-Modify-Write mit Merge)
+  bleibt unverändert.
+  - Test: `freeze_time` im Mismatch-Fenster, Preset mit `end_date` = Ortstag D, erster
+    auflösbarer Ort in einer Zone mit deutlichem Offset; Assertion auf `paused_at` in der
+    geschriebenen `briefings/<id>.json`-Fixtur, abhängig vom Ortstag statt Servertag.
+
+- **AC-6:** Given ein Trip-Report ohne verwertbare Segmente (`report.segments` leer oder
+  `.segment` unbesetzt — der reine Fallback-Fall) wird mit Präfixen versehen / When
+  `_apply_prefixes` (`notification_service.py:1671`) über `_target_date_from_report`
+  (`:1711`) das Zieldatum für den Präfix-Text ermittelt / Then leitet die Funktion den Tag aus
+  `request.trip_tz` ab (`local_dt(datetime.now(timezone.utc), request.trip_tz).date()`) statt
+  `_date.today()` zurückzugeben — die Zone liegt am `TripReportRequest`-DTO bereits als
+  `ZoneInfo` vor; vor dem Fix trug der Präfix-Text im Mismatch-Fenster das falsche Datum.
+  - Test: `freeze_time` im Mismatch-Fenster, `TripReportRequest` mit `trip_tz` einer Zone mit
+    deutlichem Offset, leere `report.segments`; Assertion auf das von
+    `_target_date_from_report` gelieferte Datum gegen den Ortstag statt den Servertag.
+
+- **AC-7:** Given der Compare-Einzelversand (`send_one_compare_preset`,
+  `scheduler_dispatch_service.py:322`) wird OHNE Slot-Kontext aufgerufen (`target_date=None`,
+  `tage_ab_ortstag=None` — z. B. Handversand) für ein Preset mit mehreren Orten in
+  unterschiedlichen Zonen, dessen erster konfigurierter Ort NICHT auflösbar ist / When der
+  `date.today()`-Zweig (Zeile 366–370) greift / Then bestimmt die Funktion den Ortstag über
+  `first_resolvable_tz(locations)` — den ERSTEN AUFLÖSBAREN Ort, überspringt also den
+  unauflösbaren ersten —, und `target_date` sowie `tage_ab_ortstag=0` stammen aus DERSELBEN
+  Zeitabfrage statt aus zwei getrennten (`date.today()` vs. separat behauptetem Versatz 0).
+  **Invariante:** der externe Vertrag der Funktion bleibt unverändert — Parameterliste, Typen
+  und die Reihenfolge der beiden bestehenden `ValueError`-Pfade zueinander (fehlender
+  Empfänger vor unauflösbaren Orten) ändern sich nicht; keine der 67 Aufrufstellen muss
+  zwingend angepasst werden.
+  - Test: `freeze_time` im Mismatch-Fenster, Preset mit zwei Orten unterschiedlicher Zone
+    (erster Ort unauflösbar, zweiter auflösbar), Einzelversand-Aufruf ohne `target_date`;
+    Assertion, dass `target_date` den Ortstag des zweiten Orts trägt, und dass beide
+    bestehenden `ValueError`-Pfade weiterhin in ihrer bisherigen Reihenfolge zueinander
+    auslösen (Empfänger-Fehler bei fehlendem `mail_to` VOR Orte-Fehler bei unauflösbaren IDs).
+
+- **AC-8:** Given alle neun Fundstellen dieser Scheibe sind auf `trip_local_today`/`local_dt`
+  umgestellt / When `tests/test_output_timezone_guard.py::test_known_violations_only_shrink`
+  läuft / Then sind die neun Einträge
+  `src/services/trip_report_scheduler.py::select_test_stage::0`,
+  `src/services/trip_report_scheduler.py::_send_trip_report_outcome::0`,
+  `src/services/trip_report_scheduler.py::_clamp_segments_to_today::0`,
+  `src/services/trip_report_scheduler.py::_build_stage_trend::1`,
+  `src/services/trip_report_scheduler.py::_collect_future_stage_weather::0`,
+  `src/services/alert_briefing_anchor.py::briefing_target_day_is_current::0`,
+  `src/services/scheduler_dispatch_service.py::_auto_pause_expired_presets::0`,
+  `src/services/scheduler_dispatch_service.py::send_one_compare_preset::0` und
+  `src/services/notification_service.py::_target_date_from_report::0` aus `KNOWN_VIOLATIONS`
+  entfernt, und sowohl dieser Test als auch `test_no_unlisted_output_timezone_violations`
+  bleiben grün. **Miterledigt werden muss die Ordinal-Rückverschiebung in
+  `_build_stage_trend`:** der verbleibende Eintrag `::2` (Ternary-Rückfall zum `tz`-Default,
+  bleibt bewusst gelistet) rutscht auf `::1`, sobald der Muster-A-Fund davor entfällt — das ist
+  die Gegenbewegung zu der in `tests/test_output_timezone_guard.py:581-586` dokumentierten
+  Verschiebung aus #1723. Ohne diese Umbenennung meldet der Wächter `::2` als veraltet **und**
+  `::1` als neuen, unbekannten Verstoß, ohne dass sich eine zweite Codestelle geändert hätte.
+  - Test: `tests/test_output_timezone_guard.py::test_known_violations_only_shrink` und
+    `::test_no_unlisted_output_timezone_violations`.
+
+- **AC-9:** Given eine neue Testfunktion dieser Scheibe behauptet, dass Ortstag und Servertag
+  bei ihrer Fixtur auseinanderfallen — der Vorbedingungs-Anker ist Pflicht, keine Kür / When
+  der Test seine Hauptzusicherung prüft / Then belegt er das ZUVOR mit einer eigenen
+  Vorbedingungs-Assertion (Muster `tests/tdd/test_befehlspfade_folgen_ortszone.py:619-636`:
+  `erwartet_parameter != erwartet_systemuhr`, `tag_uhr != tag_param`, `datetime.now(tz=
+  timezone.utc) == FROST_UTC`) — ohne sie ist die Hauptzusicherung strukturell nie
+  falsifizierbar (#1726 F002). An den Fundstellen **1, 3, 4, 5, 6, 7** — überall dort, wo
+  `now_utc` bzw. der fertige Tag künftig als Pflichtparameter hereinkommt — tritt die
+  Parameter-gegen-Systemuhr-Probe aus AC-3 **hinzu**, sie ersetzt den Anker nicht. Nur an den
+  Fundstellen **2, 8, 9** ist sie strukturell unmöglich, weil „jetzt" dort funktionsintern
+  aufgelöst bleibt; dort genügt die (a)-Prüfung „Ortstag ≠ Servertag unter `freeze_time`".
+  - Test: nicht automatisierbar; im QA-Bericht zu belegen, dass jede neue Testfunktion dieser
+    Scheibe eine solche Vorbedingungs-Assertion trägt (Muster: fix_1727_s5a AC-9).
+
+## Nachweisführung
+
+Vollständig **offline** belegbar (Kern-Schicht): `freeze_time` + In-Memory-`Trip`/`Stage`/
+`Waypoint`/`Preset`-Fixturen. Keine Staging-Mail nötig — geprüft wird die Tagesbestimmung,
+nicht der Transport.
+
+Verfügbare Mehrzonen-Fixturen (aus S5a übernommen, keine vierte Kopie):
+
+- `_trip_two_zones` (`tests/tdd/conftest.py`) — Wellington + Korsika, zwölf Stunden auseinander
+- Drei-Zonen-Fixtur Pago Pago (−11) / Korsika (+2) / Kiritimati (+14) aus S5a
+- `tests/unit/test_trip_local_today.py` — Vorbedingungs-Anker-Muster (`:60-63`)
+
+### Nachweis-Grenze dieser Scheibe
+
+Die Parameter-gegen-Systemuhr-Probe (AC-3, Muster S5a-F001) ist **überall dort möglich und
+Pflicht, wo ein Pflichtparameter entsteht**: Fundstellen 1, 3, 4, 5, 6, 7. Sie ist die einzige
+Form, die „Parameter entgegengenommen, im Rumpf ignoriert" fängt — genau die Lücke, an der in
+S5a fünf von sechs Aufrufstellen blind waren.
+
+An den Fundstellen **2, 8 und 9** ist sie strukturell **nicht** möglich, weil „jetzt" dort
+funktionsintern aufgelöst bleibt (bewusst, s. Known Limitations) — es gibt keinen Parameter,
+den man der Uhr entgegenstellen könnte. Geprüft wird dort ausschließlich (a): unter
+`freeze_time` liefert eine Tour bzw. ein Preset-Ort in einer Zone mit deutlichem Offset einen
+anderen Ortstag als den Servertag. Das ist falsifizierbar und ausreichend für die Zusicherung,
+die diese Scheibe an diesen drei Stellen macht.
+
+## Testbenennung
+
+Testdateien nach Verhalten benennen, nicht nach Issue-Nummer — durchgesetzt von
+`test_naming_gate.py`, das neue issue-nummerierte Testdateien hart blockiert. Kein
+`test_issue_1727*`-Name. Vorschlag (analog S5a): `tests/tdd/test_versandpfade_folgen_
+ortszone.py` als Sammel-Datei für alle neun Fundstellen; eine Aufteilung je Fundstelle ist
+ebenso zulässig.
+
+## Known Limitations
+
+**Bekannte Grenzen dieser Scheibe:**
+
+- **Verbleibende Regel-3(b)-Lücke an den Fundstellen 2, 8, 9.** „Jetzt" wird dort weiterhin
+  INNERHALB der jeweiligen Funktion aufgelöst, statt als Pflichtparameter hereinzukommen —
+  jeweils aber **vor** jedem Netzabruf. Das ist der Millisekunden-Fall: das Zeitfenster
+  zwischen Auflösung und Verwendung ist so klein, dass ein Pflichtparameter (mit den
+  zugehörigen ~90 Test-Aufrufstellen bei den betroffenen Funktionen) keinen messbaren
+  Sicherheitsgewinn brächte. Zusammen mit `send_on_demand_report` bildet diese Lücke die
+  (b)-Folgescheibe im bestehenden Ticket #1727 — kein eigenes Issue.
+- **Mehrzonen-Touren:** Restfehler = Zonendifferenz zweier benachbarter Etappen an einem
+  Wechseltag. Unverändert bewusst offen (ADR-0044, PO-Entscheidung).
+- **Ungezählte Menge:** ob unter den 67 Aufrufstellen von `send_one_compare_preset` welche den
+  Servertag im `target_date=None`-Pfad ausdrücklich behaupten (z. B. eine Golden-Datei mit
+  fest erwartetem Datum). Bei mitteleuropäischen Fixturen fällt der Unterschied meist nicht
+  an; vor der Umsetzung ist das auszuzählen, nicht zu schätzen — ein Fund verlangt keine
+  Scope-Änderung, nur eine angepasste Fixtur.
+- **`preview_service.py`:** die durch Fundstellen 4/5 erzwungene Signaturänderung wird an den
+  beiden Aufrufstellen (`:218`/`:222`) mechanisch nachgezogen (`now_utc=datetime.now(
+  timezone.utc)`); die EIGENE Zonen-Logik der Vorschau (`_resolve_target_date`) bleibt in
+  dieser Scheibe unangetastet und folgt weiterhin dem Servertag.
+- **Der Wächter ist blind für `datetime.utcnow()`.** Muster A erkennt `date.today()` und
+  `datetime.now()` ohne `tz`, nicht aber `datetime.utcnow()` — deshalb stand
+  `scheduler_dispatch_service.py:69` nie in `KNOWN_VIOLATIONS`. Diese Scheibe räumt die eine
+  Fundstelle mit auf, erweitert den Detektor aber **nicht**; das gehört zu S5e
+  („Detektor + Liste auf null"). Wie viele weitere `utcnow()`-Stellen es gibt, ist **nicht
+  gemessen**.
+- **`command_log.json`/Persistenz allgemein:** keine der neun Fundstellen dieser Scheibe
+  schreibt einen datumsabhängigen Idempotenz-Schlüssel außer Fundstelle 7
+  (`briefings/<id>.json::paused_at`, unverändert Read-Modify-Write) — keine Migration nötig.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** ADR-0044 (Akzeptiert), ADR-0051 (Vorgeschlagen, Regel 3)
+- **Rationale:** Setzt die bereits akzeptierte ADR-0044-Entscheidung an neun weiteren, bislang
+  in dessen Restliste gar nicht geführten Stellen um — kein offene Produktfrage, ein Bug gegen
+  eine getroffene Entscheidung. Folgt zusätzlich Regel 3 aus ADR-0051 dort, wo die Kosten
+  gemessen niedrig sind (Fundstellen 1, 3, 4, 5, 6, 7); an den Fundstellen 2, 8, 9 bleibt die
+  interne, aber netzabruf-vorgelagerte Auflösung bewusst bestehen (Millisekunden-Fall, s.
+  Known Limitations) — diese Scheibe trifft dazu keine neue Design-Entscheidung, sondern
+  übernimmt die bereits in der Kartierung getroffene Kosten-Nutzen-Abwägung.
+
+## Changelog
+
+- 2026-08-14: Spec erstellt nach Kartierung `docs/context/fix-1727-s5b-versandpfade.md`
+  (Basis-HEAD `1e5e0be9`), Vorbild `docs/specs/modules/fix_1727_s5a_befehlspfade_ortstag.md`.

--- a/docs/specs/modules/fix_1727_s5b_versandpfade_ortstag.md
+++ b/docs/specs/modules/fix_1727_s5b_versandpfade_ortstag.md
@@ -267,9 +267,10 @@ relativ zur Orte-Prüfung ändert sich damit **nicht**, nur die Orte-Auflösung 
     anderen Delta liefert als mit dem (falschen) Servertag.
 
 - **AC-2:** Given `_send_trip_report_outcome` (`trip_report_scheduler.py:1001`) läuft für eine
-  Tour in einer Zone mit negativem UTC-Offset (z. B. PCT), deren `target_date` bereits
-  ortsrichtig aus `_get_target_date` → `trip_local_today` stammt, während der SERVERTAG noch
-  einen Tag zurückliegt (Mismatch-Fenster 12:00–24:00 UTC) / When die Zeile 1103 prüft, ob der
+  Tour in einer Zone mit negativem UTC-Offset (z. B. Los Angeles, im August UTC−7), deren
+  `target_date` bereits ortsrichtig aus `_get_target_date` → `trip_local_today` stammt, während
+  der SERVERTAG dem Ortstag bereits einen Tag VORAUS ist (Mismatch-Fenster 00:00–07:00 UTC) /
+  When die Zeile 1103 prüft, ob der
   Wetter-Klemm-Zweig greift / Then vergleicht sie `target_date < trip_local_today(trip,
   now_utc)` statt `target_date < date.today()`, wobei `now_utc` EINMAL oben in der Funktion
   gebunden wird (statt bisher nur innerhalb des `if target_date is None:`-Zweigs bei Zeile
@@ -482,3 +483,14 @@ ebenso zulässig.
   Ordinal-Rückverschiebung `_build_stage_trend::2` → `::1` auf; (4) Fundstelle 7 räumt das
   wächter-unsichtbare `datetime.utcnow()` (`scheduler_dispatch_service.py:69`) mit auf.
 - 2026-08-14: PO-Freigabe der 9 ACs („Go").
+- 2026-08-14: **Faktenkorrektur ohne Kriterienänderung** (RED-Phase). AC-2 nannte „negativer
+  UTC-Offset … Servertag liegt zurück … Fenster 12:00–24:00 UTC" — das ist in sich
+  widersprüchlich: bei negativem Versatz ist der Servertag dem Ortstag VORAUS, und das Fenster
+  liegt zwischen 00:00 und 07:00 UTC. Die operative Zusicherung („der Klemm-Zweig greift nicht,
+  obwohl `date.today() > target_date` gälte") war und bleibt unberührt; der Testfall trägt
+  entsprechend Los Angeles, 03:00 UTC.
+- 2026-08-14: (b)-Nachweis für Fundstelle 6 sitzt am **Wirkort**. `briefing_target_day_is_current`
+  folgt schon heute ihrem optionalen `today`-Argument — eine Parameter-gegen-Uhr-Probe an der
+  Funktion selbst wäre in der RED-Phase grün gewesen und hätte nichts bewacht. Geprüft wird
+  deshalb der Aufrufer `_process_pending_markers` plus die eigene Zusicherung, dass der
+  Systemuhr-Default ersatzlos entfällt.

--- a/src/services/alert_briefing_anchor.py
+++ b/src/services/alert_briefing_anchor.py
@@ -142,7 +142,7 @@ def record_briefing_dispatch_failure(
 
 
 def briefing_target_day_is_current(
-    target_date: Union[date, str, None], *, today: Optional[date] = None,
+    target_date: Union[date, str, None], *, today: date,
 ) -> bool:
     """Ist der Zieltag eines Nachliefer-Vermerks noch aktuell? (#1662, Punkt 4)
 
@@ -157,16 +157,23 @@ def briefing_target_day_is_current(
     nominell „dauerhafte" Fehlertyp heilte beim einzigen echten Vorfall nach
     rund 13 Stunden von selbst.
 
+    Issue #1727 S5b (ADR-0044/ADR-0051 Regel 3): `today` ist PFLICHT und trägt
+    keinen Systemuhr-Rückfall mehr. Welcher Kalendertag gemeint ist, weiß nur
+    der Aufrufer — er kennt die Tour und damit deren Ortszone. Der frühere
+    Default `today or date.today()` machte den Aufruf-Fehler „Tag vergessen"
+    unsichtbar: die Funktion antwortete plausibel, aber zum Servertag.
+
     Args:
         target_date: Zieltag des Vermerks (`date` oder ISO-Zeichenkette).
-        today: Vergleichstag; ohne Angabe der heutige Tag.
+        today: Vergleichstag (Ortstag der betroffenen Tour), keyword-only,
+            ohne Default.
 
     Returns:
         True, solange der Zieltag heute oder in der Zukunft liegt. Ein
         unlesbarer Zieltag gilt als abgelaufen — ein Vermerk, dessen Zieltag
         niemand bestimmen kann, darf nicht stündlich weitergeschleppt werden.
     """
-    heute = today or date.today()
+    heute = today
     if isinstance(target_date, date):
         tag = target_date
     else:

--- a/src/services/dispatch_orchestrator.py
+++ b/src/services/dispatch_orchestrator.py
@@ -148,7 +148,15 @@ class CompareDispatchStrategy:
         # mit ueberschrittenem end_date -- unabhaengig vom Faelligkeits-Slot.
         from services.scheduler_dispatch_service import _auto_pause_expired_presets
 
-        _auto_pause_expired_presets(self._presets, self._user_id, self._data_root)
+        # Issue #1727 S5b: `now_utc` liegt hier bereits als Parameter vor und
+        # die Ortsliste hat `collect_due` schon geladen -- beides wird
+        # durchgereicht, damit der Ablauf gegen den ORTSTAG des Presets
+        # geprueft wird (ADR-0044) statt gegen den Servertag. Keine zweite
+        # Zeitabfrage, kein zweiter Ladevorgang.
+        _auto_pause_expired_presets(
+            self._presets, self._user_id, self._data_root,
+            now_utc, self._all_locations or [],
+        )
 
     def dispatch_one(self, item) -> None:
         from app.loader import load_all_locations

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -34,7 +34,7 @@ from output.channels.premium_sms import PremiumSmsOutput
 from output.channels.sms import SMSOutput
 from output.channels.telegram import TelegramOutput
 from services.trip_command_processor import CommandResult
-from utils.timezone import local_fmt
+from utils.timezone import local_dt, local_fmt
 
 if TYPE_CHECKING:
     from app.models import (
@@ -1710,11 +1710,18 @@ class NotificationService:
 
     @staticmethod
     def _target_date_from_report(report, request: TripReportRequest):
-        """Versucht, das Zieldatum aus den Segmenten zu ermitteln."""
+        """Versucht, das Zieldatum aus den Segmenten zu ermitteln.
+
+        Issue #1727 S5b (ADR-0044): der Rueckfall (Report ohne verwertbare
+        Segmente) folgt der ZONE DER TOUR, die am DTO bereits als
+        `request.trip_tz` aufgeloest vorliegt — kein zweiter Aufloeser, kein
+        zusaetzlicher Parameter. Vorher stand hier `date.today()`: im
+        Mismatch-Fenster las der Nutzer im Mail-/SMS-/Telegram-Praefix ein
+        Datum, das einen Tag neben dem Tag lag, fuer den das Briefing gilt.
+        """
         if report.segments and report.segments[0].segment:
             return report.segments[0].segment.start_time.date()
-        from datetime import date as _date
-        return _date.today()
+        return local_dt(datetime.now(timezone.utc), request.trip_tz).date()
 
     def _send_email(self, report) -> None:
         """Versendet das Briefing per E-Mail (full oder compact)."""

--- a/src/services/preview_service.py
+++ b/src/services/preview_service.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -214,14 +214,23 @@ class PreviewService:
         multi_day_trend = None
         outlook_state = None
         outlook_horizon_days = None
+        # Issue #1727 S5b: rein mechanischer Durchreich — beide Scheduler-
+        # Methoden verlangen den Zeitpunkt jetzt als Pflichtparameter
+        # (ADR-0051 Regel 3). Die EIGENE Tagesbestimmung der Vorschau
+        # (`_resolve_target_date`) bleibt unangetastet und folgt weiterhin dem
+        # Servertag — sie gehoert in die ADR-0044-Restliste „Vorschau,
+        # Werkzeuge" (S5c), nicht in diese Scheibe.
+        jetzt_utc = datetime.now(timezone.utc)
         if segment_weather and render_options.show_multi_day_trend:
-            trend_result = scheduler._build_stage_trend(trip, target, tz=trip_tz)
+            trend_result = scheduler._build_stage_trend(
+                trip, target, now_utc=jetzt_utc, tz=trip_tz,
+            )
             multi_day_trend = trend_result.rows
             outlook_state = trend_result.state
             outlook_horizon_days = trend_result.horizon_days
         thunder_forecast = scheduler._build_thunder_forecast_from_trend_or_fetch(
-            trip, target, tz=trip_tz, multi_day_trend=multi_day_trend,
-            night_weather=night_weather,
+            trip, target, now_utc=jetzt_utc, tz=trip_tz,
+            multi_day_trend=multi_day_trend, night_weather=night_weather,
         )
 
         # Issue #474: F12 Wetterlage-Label vor format_email berechnen.

--- a/src/services/scheduler_dispatch_service.py
+++ b/src/services/scheduler_dispatch_service.py
@@ -57,7 +57,13 @@ def _load_presets_for_dispatch(user_id: str, data_root: str) -> list | None:
         return None
 
 
-def _auto_pause_expired_presets(presets: list, user_id: str, data_root: str) -> None:
+def _auto_pause_expired_presets(
+    presets: list,
+    user_id: str,
+    data_root: str,
+    now_utc: _datetime,
+    all_locations: list,
+) -> None:
     """Pausiert Presets mit ueberschrittenem `end_date` (Issue #1250 Scheibe 3).
 
     Issue #1207: Extrahiert aus `run_compare_presets_daily` fuer Delegation
@@ -65,8 +71,24 @@ def _auto_pause_expired_presets(presets: list, user_id: str, data_root: str) -> 
     VERBIRGT abgelaufene Presets bereits (compare_slot_scheduler.py Guard) --
     dieser Durchlauf laeuft unabhaengig davon ueber ALLE geladenen Presets,
     um den Pause-Zustand persistent + sichtbar (UI) zu machen.
+
+    Issue #1727 S5b (ADR-0044): `end_date` wird gegen den ORTSTAG des ersten
+    aufloesbaren Preset-Orts geprueft (`first_resolvable_tz`, dasselbe Muster
+    wie die Faelligkeit seit #1726) -- nicht gegen den Servertag. Sonst blieb
+    ein Preset im Mismatch-Fenster einen Tag zu lange aktiv (und verschickte
+    einen abbestellten Vergleich) oder pausierte einen Tag zu frueh.
+    `now_utc` und die Ortsliste kommen vom Aufrufer (`pre_pass`), der beide
+    bereits hat -- ADR-0051 Regel 3, ohne zusaetzliche Zeitabfrage oder
+    zweiten Ladevorgang.
+
+    Der Zeitstempel `now_iso` stammt jetzt aus DERSELBEN Zeitabfrage wie die
+    Ablauf-Pruefung (vorher `datetime.utcnow()`: naiv, ohne Zone, veraltet --
+    und fuer Muster A des Zeitzonen-Waechters unsichtbar).
     """
-    now_iso = _datetime.utcnow().isoformat() + "Z"
+    from services.compare_preview_service import order_locations_by_ids
+    from utils.timezone import first_resolvable_tz, local_dt
+
+    now_iso = now_utc.isoformat()
     for preset in presets:
         if preset.get("archived_at"):
             continue
@@ -75,8 +97,14 @@ def _auto_pause_expired_presets(presets: list, user_id: str, data_root: str) -> 
         end_date_str = preset.get("end_date")
         if not end_date_str:
             continue
+        locations = order_locations_by_ids(
+            all_locations, preset.get("location_ids") or [],
+        )
+        zone = first_resolvable_tz(
+            locations, context_label=f"Preset {preset.get('id', '?')}",
+        )
         try:
-            expired = date.fromisoformat(end_date_str) < date.today()
+            expired = date.fromisoformat(end_date_str) < local_dt(now_utc, zone).date()
         except (ValueError, TypeError) as e:
             logger.warning(
                 "Preset %s: korruptes end_date bei Auto-Pause-Pruefung, "
@@ -363,11 +391,6 @@ def send_one_compare_preset(
             f"{preset.get('id', '?')}, target_date={target_date}, "
             f"tage_ab_ortstag={tage_ab_ortstag})."
         )
-    if target_date is None:
-        # Kein Slot-Kontext (Einzelversand): EINE Zeitabfrage, aus der beide
-        # Formen ohne Differenzbildung hervorgehen.
-        target_date = date.today()
-        tage_ab_ortstag = 0
     from output.renderers.comparison import (
         render_compare_email, render_compare_sms, render_compare_telegram,
     )
@@ -398,6 +421,26 @@ def send_one_compare_preset(
     locations = order_locations_by_ids(all_locations_cache, location_ids)
     if not locations:
         raise ValueError(f"Preset {preset_id}: Orte {location_ids} nicht aufloesbar")
+
+    if target_date is None:
+        # Kein Slot-Kontext (Einzelversand): EINE Zeitabfrage, aus der beide
+        # Formen ohne Differenzbildung hervorgehen.
+        # Issue #1727 S5b (ADR-0044): dieser Block steht jetzt HINTER der
+        # Ortsaufloesung, weil sie die Zone liefert — „heute" ist der Ortstag
+        # des ERSTEN AUFLOESBAREN Orts (`first_resolvable_tz`, Muster #1726),
+        # nicht der Servertag. Vorher behauptete das daneben gesetzte
+        # `tage_ab_ortstag = 0` einen Versatz gegen den ORTSTAG, waehrend
+        # `target_date` vom Server kam — genau die zwei Tagesbegriffe, die der
+        # Kontrakt aus #1661 F003 zusammenhalten sollte.
+        # Der Empfaenger-Check bleibt VOR der Ortspruefung: die Reihenfolge der
+        # beiden ValueError-Pfade zueinander ist unveraendert.
+        from datetime import timezone as _timezone
+
+        from utils.timezone import first_resolvable_tz, local_dt
+
+        zone = first_resolvable_tz(locations, context_label=f"Preset {preset_id}")
+        target_date = local_dt(_datetime.now(_timezone.utc), zone).date()
+        tage_ab_ortstag = 0
 
     profil_str = preset.get("profil", "").lower()
     profile = _parse_activity_profile(profil_str)

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -535,7 +535,17 @@ class TripReportSchedulerService:
             # Issue #1662 AC-4: Verfall ueber den Zieltag (geteilte, reine
             # Entscheidungsfunktion) — ein Morgen-Briefing von gestern ist
             # heute wertlos und wird nicht mehr zugestellt.
-            if is_dispatch_error and not briefing_target_day_is_current(entry.get("date")):
+            # Issue #1727 S5b (ADR-0044): der Vergleichstag ist der ORTSTAG
+            # DIESER Tour und kommt von hier — `now_utc` liegt als Parameter
+            # vor, `trip` steht im Zugriff. Vorher loeste die Funktion still
+            # `date.today()` auf: im Mismatch-Fenster verfiel der Vermerk einen
+            # Tag zu frueh (Briefing nie nachgeliefert) oder wurde einen Tag zu
+            # lange weitergeschleppt.
+            from services.trip_day import trip_local_today
+
+            if is_dispatch_error and not briefing_target_day_is_current(
+                entry.get("date"), today=trip_local_today(trip, now_utc),
+            ):
                 self._remove_pending_marker(trip_id)
                 continue
 
@@ -846,7 +856,9 @@ class TripReportSchedulerService:
             "max_elevation_m": max_elev,
         }
 
-    def select_test_stage(self, trip: "Trip", report_type: str) -> Optional["Stage"]:
+    def select_test_stage(
+        self, trip: "Trip", report_type: str, now_utc: datetime,
+    ) -> Optional["Stage"]:
         """Pick the stage to use for a TEST briefing when no stage matches today/tomorrow.
 
         Issue #768 — Test-Pfad-Fallback (NICHT der reguläre Scheduler):
@@ -858,17 +870,27 @@ class TripReportSchedulerService:
           **erste** (früheste) Etappe zurück.
         - Leere ``stages`` → ``None``.
 
+        Issue #1727 S5b (ADR-0044): „heute" ist der Ortstag DIESES Trips, nicht
+        der Tag der Prozess-Zeitzone (auf dem Server `Etc/UTC`). Sonst zaehlte
+        eine ortszeitlich bereits vergangene Etappe noch als „kommend" — der
+        Test-Versand nahm die falsche Etappe. `now_utc` ist Pflichtparameter
+        (ADR-0051 Regel 3): der Zeitpunkt kommt vom Aufrufer, damit der ganze
+        Briefing-Aufbau auf EINER Zeitabfrage steht.
+
         Args:
             trip: Trip object.
             report_type: "morning" or "evening" (nicht ausschlaggebend für die Wahl,
                 Teil des Kontrakts für Aufrufer-Symmetrie).
+            now_utc: Zeitpunkt des Laufs (Pflichtparameter, s. `_get_target_date`).
 
         Returns:
             Die gewählte Stage oder None bei leeren stages.
         """
+        from services.trip_day import trip_local_today
+
         if not trip.stages:
             return None
-        today = date.today()
+        today = trip_local_today(trip, now_utc)
         upcoming = sorted(
             (s for s in trip.stages if s.date >= today),
             key=lambda s: s.date,
@@ -1068,13 +1090,18 @@ class TripReportSchedulerService:
         logger.info(f"Generating {report_type} report for trip: {trip.name}")
 
         # 1. Convert trip to segments
+        # Issue #1727 S5b: EINE Zeitabfrage fuer den gesamten Briefing-Aufbau,
+        # hier oben gebunden statt weiter unten mehrfach implizit aufgeloest.
+        # Sie speist Zieltag, Etappen-Rueckfall, Klemme, Ausblick und
+        # Gewitter-Ausblick — zwischen ihnen liegt ein Wetterabruf mit
+        # Retry-Backoff und damit moeglicherweise eine Mitternacht
+        # (gemessener Praezedenzfall: dispatch_orchestrator.py:157-163).
+        now_utc = datetime.now(timezone.utc)
         # Issue #1724: Zieltag aus der Ortszeit DIESES Trips (ADR-0044).
         # Fix #1795: ein bereits aufgeloester `target_date` (s. Docstring)
         # ersetzt die interne Auflösung — kein zweiter Auflöser.
         if target_date is None:
-            target_date = self._get_target_date(
-                report_type, trip, datetime.now(timezone.utc),
-            )
+            target_date = self._get_target_date(report_type, trip, now_utc)
         segments = self._convert_trip_to_segments(trip, target_date)
 
         # Issue #768: Test-Pfad-Fallback — wenn am regulären Zieldatum keine
@@ -1082,7 +1109,7 @@ class TripReportSchedulerService:
         # (bzw. früheste) Etappe aus. Der reguläre Scheduler (Default False)
         # bleibt unberührt (AC-7).
         if not segments and allow_test_fallback:
-            fb = self.select_test_stage(trip, report_type)
+            fb = self.select_test_stage(trip, report_type, now_utc)
             if fb is not None:
                 target_date = fb.date
                 segments = self._convert_trip_to_segments(trip, target_date)
@@ -1099,9 +1126,19 @@ class TripReportSchedulerService:
         # nur die Segment-Zeiten, die in _fetch_weather() gehen, wandern auf
         # "heute", damit ein echter Forecast statt eines toten
         # Vergangenheits-Requests entsteht.
+        #
+        # Issue #1727 S5b (ADR-0044): verglichen wird gegen den ORTSTAG der
+        # Tour. `target_date` ist bereits ortsrichtig (`_get_target_date` ->
+        # `trip_local_today`); ein roher `date.today()` daneben stellte zwei
+        # verschiedene Tagesbegriffe in denselben `<`-Vergleich.
+        from services.trip_day import trip_local_today
+
+        heute_am_ort = trip_local_today(trip, now_utc)
         weather_segments = segments
-        if allow_test_fallback and target_date < date.today():
-            weather_segments = self._clamp_segments_to_today(segments, target_date)
+        if allow_test_fallback and target_date < heute_am_ort:
+            weather_segments = self._clamp_segments_to_today(
+                segments, target_date, today=heute_am_ort,
+            )
 
         # 1b. Compute local timezone from coordinates for display
         # (tz_for_coords now imported top-level — Bug #401)
@@ -1240,7 +1277,9 @@ class TripReportSchedulerService:
         outlook_state = None
         outlook_horizon_days = None
         if segment_weather and render_options.show_multi_day_trend:
-            trend_result = self._build_stage_trend(trip, target_date, tz=trip_tz)
+            trend_result = self._build_stage_trend(
+                trip, target_date, now_utc=now_utc, tz=trip_tz,
+            )
             multi_day_trend = trend_result.rows
             outlook_state = trend_result.state
             outlook_horizon_days = trend_result.horizon_days
@@ -1255,8 +1294,8 @@ class TripReportSchedulerService:
         #    damit der Satz ein Gewitter ausserhalb des Tagesfensters nennt --
         #    aus DERSELBEN Reihe, die daneben als Nacht-Tabelle steht.
         thunder_forecast = self._build_thunder_forecast_from_trend_or_fetch(
-            trip, target_date, tz=trip_tz, multi_day_trend=multi_day_trend,
-            night_weather=night_weather,
+            trip, target_date, now_utc=now_utc, tz=trip_tz,
+            multi_day_trend=multi_day_trend, night_weather=night_weather,
         )
 
         # 7b. Vortag-Vergleich (Issue #750): gestrigen Snapshot laden + Deltas
@@ -1694,18 +1733,24 @@ class TripReportSchedulerService:
         return convert_trip_to_segments(trip, target_date)
 
     def _clamp_segments_to_today(
-        self, segments: List[TripSegment], from_date: date,
+        self, segments: List[TripSegment], from_date: date, today: date,
     ) -> List[TripSegment]:
         """Shift segment start_time/end_time from `from_date` to today (Issue #1325).
 
         Pure helper — kein Netz-/IO-Zugriff. Erhält den Uhrzeit-Anteil, nur
-        das Kalenderdatum wandert um `date.today() - from_date` Tage nach
-        vorne. Ausschließlich für den Wetter-Abruf-Input im Test-Fallback-
-        Pfad genutzt, damit ein veralteter Test-Trip (alle Etappen in der
+        das Kalenderdatum wandert um `today - from_date` Tage nach vorne.
+        Ausschließlich für den Wetter-Abruf-Input im Test-Fallback-Pfad
+        genutzt, damit ein veralteter Test-Trip (alle Etappen in der
         Vergangenheit) trotzdem einen echten Forecast statt eines toten
         historischen Datums bekommt.
+
+        Issue #1727 S5b: `today` kommt PFLICHTWEISE vom Aufrufer, der ihn dort
+        bereits ortsrichtig hat (`trip_local_today`). Diese Funktion sieht kein
+        `Trip`-Objekt und könnte den Ortstag gar nicht selbst bestimmen — ein
+        eigenes `date.today()` verschob die Segmentzeiten im Mismatch-Fenster
+        um einen Tag zu wenig oder zu weit (ADR-0044).
         """
-        delta_days = (date.today() - from_date).days
+        delta_days = (today - from_date).days
         if delta_days <= 0:
             return segments
         shift = timedelta(days=delta_days)
@@ -1985,6 +2030,7 @@ class TripReportSchedulerService:
         self,
         trip,
         target_date: date,
+        now_utc: datetime,
         tz=None,
     ):
         """
@@ -1998,12 +2044,23 @@ class TripReportSchedulerService:
         Vorschau-Vergleich (ADR-0025/#1297) lesen genau dieses Feld weiter.
         ``result.state`` benennt zusaetzlich, WARUM der Ausblick entfaellt
         (vorher fuenf Ausstiege, alle mit demselben stummen ``None``).
+
+        Issue #1727 S5b (ADR-0044/ADR-0051 Regel 3): ``now_utc`` ist
+        PFLICHTPARAMETER ohne Default. Der Vorhersage-Horizont wird gegen den
+        ORTSTAG der Tour gemessen (``trip_local_today``), nicht gegen den
+        Servertag — ``stage.date`` ist ein Etappentag mit Ortstag-Semantik, ein
+        Servertag daneben mischt zwei Tagesbegriffe. Und der Zeitpunkt kommt
+        vom Aufrufer, weil zwischen dessen Zeitabfrage und diesem Aufruf ein
+        Wetterabruf mit Retry-Backoff liegt: eine eigene Aufloesung koennte
+        bereits den naechsten Ortstag tragen, waehrend ``target_date`` noch auf
+        dem alten steht.
         """
         from app.models import OutlookState, TrendResult
         from providers.openmeteo import (
             OPENMETEO_MAX_FORECAST_DAYS,
             is_within_forecast_horizon,
         )
+        from services.trip_day import trip_local_today
         from services.weather_metrics import aggregate_stage
 
         WEEKDAYS_DE = ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"]
@@ -2020,7 +2077,7 @@ class TripReportSchedulerService:
         # Information).
         failures: set = set()
         horizon_days: Optional[int] = None
-        today = date.today()
+        today = trip_local_today(trip, now_utc)
         for stage in future_stages[:3]:
             if not is_within_forecast_horizon(stage.date, today):
                 # Fix #1486: war logger.debug — im Betrieb unsichtbar.
@@ -2139,6 +2196,7 @@ class TripReportSchedulerService:
         self,
         trip,
         target_date: date,
+        now_utc: datetime,
         tz: Optional[ZoneInfo],
         multi_day_trend=None,
         night_weather=None,
@@ -2174,6 +2232,12 @@ class TripReportSchedulerService:
         die Tages-Aussage (``level``/``hour``) bleibt geklemmt. Beide
         Aufrufer (Versand und Vorschau) reichen sie durch; genau das traegt
         die Paritaet aus AC-9/AC-11.
+
+        Issue #1727 S5b: ``now_utc`` ist PFLICHTPARAMETER und wird
+        unveraendert an ``_collect_future_stage_weather`` durchgereicht —
+        diese Funktion trifft selbst KEINE Tagesentscheidung (kein eigener
+        Fundort), sie haelt nur den Zeitpunkt auf demselben Weg wie der
+        Rest des Briefing-Aufbaus.
         """
         from app.day_window import resolve_configured_window
 
@@ -2212,7 +2276,7 @@ class TripReportSchedulerService:
 
         if missing_dates:
             fetched = self._collect_future_stage_weather(
-                trip, target_date, wanted_dates=missing_dates,
+                trip, target_date, now_utc=now_utc, wanted_dates=missing_dates,
             )
             fetched_fc = (
                 self._build_thunder_forecast(
@@ -2375,6 +2439,7 @@ class TripReportSchedulerService:
         self,
         trip,
         target_date: date,
+        now_utc: datetime,
         wanted_dates=None,
     ) -> List[SegmentWeatherData]:
         """Issue #1275: fetch weather for the actual next future stages,
@@ -2402,18 +2467,27 @@ class TripReportSchedulerService:
         Fail-soft: a per-stage fetch error is logged and the stage skipped, so
         the corresponding TH+ key is simply absent (SMS shows ``TH+:-``) —
         the report is never blocked.
+
+        Issue #1727 S5b (ADR-0044/ADR-0051 Regel 3): ``now_utc`` ist
+        PFLICHTPARAMETER, der Horizont wird gegen den ORTSTAG der Tour
+        gemessen. Dieser Rueckfall liegt noch HINTER dem Trend-Bauweg, also
+        noch spaeter im Wetterabruf — eine eigene Zeitaufloesung koennte hier
+        bereits auf dem naechsten Ortstag stehen (s. ``_build_stage_trend``).
         """
         from providers.openmeteo import is_within_forecast_horizon
+        from services.trip_day import trip_local_today
 
         # #1498 (Fall 2, Beifang): ohne Trip-Objekt (Vorschau-Pfad, s.
         # Fail-soft-Zusage oben und #1482-Guard im Aufrufer) gibt es keine
         # Etappenliste — vorher stuerzte genau dieser Fall mit
         # AttributeError, sobald der Trend einen Offset nicht abdeckte.
+        # Issue #1727 S5b: Reihenfolge bewusst UNVERAENDERT — dieser Ausstieg
+        # steht VOR der Zonen-Aufloesung, die ohne Trip nicht ginge.
         if trip is None:
             return []
 
         collected: List[SegmentWeatherData] = []
-        today = date.today()
+        today = trip_local_today(trip, now_utc)
         wanted = wanted_dates if wanted_dates is not None else {
             target_date + timedelta(days=1),
             target_date + timedelta(days=2),

--- a/tests/tdd/test_bug_338_openmeteo_call_counter.py
+++ b/tests/tdd/test_bug_338_openmeteo_call_counter.py
@@ -187,7 +187,7 @@ def test_ac2_trend_path_sets_source_trend(tmp_path, monkeypatch):
     trip = _make_trend_trip(target)
 
     # _build_stage_trend schluckt Fehler je Etappe; 429 ist hier erlaubt.
-    scheduler._build_stage_trend(trip, target)
+    scheduler._build_stage_trend(trip, target, now_utc=datetime.now(timezone.utc))
 
     entries = _read_jsonl(log_path)
     sources = {e["source"] for e in entries}

--- a/tests/tdd/test_bug_353_trend_horizon.py
+++ b/tests/tdd/test_bug_353_trend_horizon.py
@@ -20,7 +20,7 @@ GREEN-Zustand KEINEN Netzwerk-Call. Kein ``pytest.mark.live``.
 from __future__ import annotations
 
 import logging
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 # RED: Dieser Import schlägt JETZT fehl (Symbole existieren noch nicht).
 # Er gehört bewusst auf Modul-Ebene, damit die ganze Datei rot wird.
@@ -150,7 +150,9 @@ class TestFarStagesSkippedNoCall:
         trip = _make_far_future_trip()
         service = TripReportSchedulerService()
 
-        result = service._build_stage_trend(trip, date.today(), tz=None)
+        result = service._build_stage_trend(
+            trip, date.today(), now_utc=datetime.now(timezone.utc), tz=None,
+        )
 
         assert result.rows is None, (
             "Ein Trip ausschließlich mit Etappen jenseits today+15 darf KEINE "
@@ -169,7 +171,9 @@ class TestFarStagesSkippedNoCall:
         service = TripReportSchedulerService()
 
         before = _count_trend_calls()
-        service._build_stage_trend(trip, date.today(), tz=None)
+        service._build_stage_trend(
+            trip, date.today(), now_utc=datetime.now(timezone.utc), tz=None,
+        )
         after = _count_trend_calls()
 
         assert after == before, (
@@ -193,7 +197,9 @@ class TestNoErrorLogOnSkip:
         service = TripReportSchedulerService()
 
         with caplog.at_level(logging.ERROR, logger="trip_report_scheduler"):
-            service._build_stage_trend(trip, date.today(), tz=None)
+            service._build_stage_trend(
+            trip, date.today(), now_utc=datetime.now(timezone.utc), tz=None,
+        )
 
         error_records = [
             r for r in caplog.records if r.levelno >= logging.ERROR

--- a/tests/tdd/test_issue_768_test_briefing_fallback.py
+++ b/tests/tdd/test_issue_768_test_briefing_fallback.py
@@ -27,7 +27,7 @@ import imaplib
 import json
 import time
 import uuid
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -151,7 +151,9 @@ class TestAC5FallbackStageSelection:
         user_id, trip_id, future = future_only_trip
         trip = _load_trip(user_id, trip_id)
         service = TripReportSchedulerService(user_id=user_id)
-        stage = service.select_test_stage(trip, "morning")
+        stage = service.select_test_stage(
+            trip, "morning", now_utc=datetime.now(timezone.utc),
+        )
         assert stage is not None, "Fallback muss eine Etappe liefern, nicht None"
         assert stage.date.isoformat() == future, (
             f"Erwartet künftige Etappe {future}, bekommen {stage.date}"
@@ -167,7 +169,9 @@ class TestAC5FallbackStageSelection:
         user_id, trip_id, nearest = multi_future_trip
         trip = _load_trip(user_id, trip_id)
         service = TripReportSchedulerService(user_id=user_id)
-        stage = service.select_test_stage(trip, "evening")
+        stage = service.select_test_stage(
+            trip, "evening", now_utc=datetime.now(timezone.utc),
+        )
         assert stage is not None and stage.date.isoformat() == nearest, (
             f"Erwartet nächste kommende Etappe {nearest}, bekommen "
             f"{getattr(stage, 'date', None)}"
@@ -183,7 +187,9 @@ class TestAC5FallbackStageSelection:
         user_id, trip_id, earliest = past_only_trip
         trip = _load_trip(user_id, trip_id)
         service = TripReportSchedulerService(user_id=user_id)
-        stage = service.select_test_stage(trip, "morning")
+        stage = service.select_test_stage(
+            trip, "morning", now_utc=datetime.now(timezone.utc),
+        )
         assert stage is not None and stage.date.isoformat() == earliest, (
             f"Erwartet früheste Etappe {earliest}, bekommen "
             f"{getattr(stage, 'date', None)}"
@@ -251,8 +257,13 @@ class TestAC8TenantIsolation:
         from services.trip_report_scheduler import TripReportSchedulerService
         ua, ta, fa = future_only_trip
         ub, tb, fb = multi_future_trip
-        sa = TripReportSchedulerService(user_id=ua).select_test_stage(_load_trip(ua, ta), "morning")
-        sb = TripReportSchedulerService(user_id=ub).select_test_stage(_load_trip(ub, tb), "morning")
+        jetzt = datetime.now(timezone.utc)
+        sa = TripReportSchedulerService(user_id=ua).select_test_stage(
+            _load_trip(ua, ta), "morning", now_utc=jetzt,
+        )
+        sb = TripReportSchedulerService(user_id=ub).select_test_stage(
+            _load_trip(ub, tb), "morning", now_utc=jetzt,
+        )
         assert sa.date.isoformat() == fa, f"Nutzer A: erwartet {fa}, bekommen {sa.date}"
         assert sb.date.isoformat() == fb, f"Nutzer B: erwartet {fb}, bekommen {sb.date}"
 

--- a/tests/tdd/test_outlook_day_night_thunder_split.py
+++ b/tests/tdd/test_outlook_day_night_thunder_split.py
@@ -425,14 +425,14 @@ def _trip_with_day_window(start_hour, end_hour):
 
 class TestStageTrendUsesConfiguredDayWindow:
     def _tokens_for_window(self, start_hour, end_hour):
-        from datetime import date
+        from datetime import date, datetime, timezone
         from zoneinfo import ZoneInfo
         from src.output.renderers.email.helpers import format_trend_tokens
 
         service = _TrendSchedulerWithFixedWeather.build(_weather_with_thunder_hours())
         result = service._build_stage_trend(
             _trip_with_day_window(start_hour, end_hour),
-            date.today(), tz=ZoneInfo("UTC"),
+            date.today(), now_utc=datetime.now(timezone.utc), tz=ZoneInfo("UTC"),
         )
         assert result.rows, (
             f"Kein Ausblick gebaut (state={result.state}) -- der Test misst "
@@ -463,14 +463,15 @@ class TestStageTrendUsesConfiguredDayWindow:
 
     def test_rendered_cell_carries_the_individual_window(self):
         """Wirkung statt Faehigkeit: bis in die gerenderte Zelle der Mail."""
-        from datetime import date
+        from datetime import date, datetime, timezone
         from zoneinfo import ZoneInfo
         from src.output.renderers.email.outlook import render_outlook_table
         import re
 
         service = _TrendSchedulerWithFixedWeather.build(_weather_with_thunder_hours())
         result = service._build_stage_trend(
-            _trip_with_day_window(20, 23), date.today(), tz=ZoneInfo("UTC"),
+            _trip_with_day_window(20, 23), date.today(),
+            now_utc=datetime.now(timezone.utc), tz=ZoneInfo("UTC"),
         )
         assert result.rows
         html = render_outlook_table(result.rows)

--- a/tests/tdd/test_outlook_state_named_not_silent.py
+++ b/tests/tdd/test_outlook_state_named_not_silent.py
@@ -121,7 +121,9 @@ def test_ac1_no_future_stages_reports_state_and_logs_nothing(caplog):
     service = _scheduler()
 
     with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
-        result = service._build_stage_trend(trip, date.today(), tz=None)
+        result = service._build_stage_trend(
+            trip, date.today(), now_utc=datetime.now(timezone.utc), tz=None,
+        )
 
     assert result.state is OutlookState.NO_STAGES, (
         "Eine Tour ohne Folge-Etappe muss den Zustand NO_STAGES melden, "
@@ -151,7 +153,9 @@ def test_ac2_beyond_horizon_reports_state_with_real_horizon(caplog):
     service = _scheduler()
 
     with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
-        result = service._build_stage_trend(trip, date.today(), tz=None)
+        result = service._build_stage_trend(
+            trip, date.today(), now_utc=datetime.now(timezone.utc), tz=None,
+        )
 
     assert result.state is OutlookState.BEYOND_HORIZON, (
         "Eine Folge-Etappe jenseits des Vorhersagehorizonts muss den Zustand "
@@ -173,7 +177,9 @@ def test_ac2_beyond_horizon_is_logged_as_warning(caplog):
     service = _scheduler()
 
     with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
-        service._build_stage_trend(trip, date.today(), tz=None)
+        service._build_stage_trend(
+            trip, date.today(), now_utc=datetime.now(timezone.utc), tz=None,
+        )
 
     messages = [r.getMessage() for r in _warnings(caplog)]
     assert any("S2" in m for m in messages), (
@@ -224,7 +230,9 @@ def test_ac3_all_three_failure_causes_report_unavailable():
     OutlookState = _outlook_state()
     for label, build in _unavailable_cases().items():
         trip, weather = build()
-        result = _scheduler(weather)._build_stage_trend(trip, date.today(), tz=None)
+        result = _scheduler(weather)._build_stage_trend(
+            trip, date.today(), now_utc=datetime.now(timezone.utc), tz=None,
+        )
         assert result.state is OutlookState.UNAVAILABLE, (
             f"Ursache '{label}' ist eine Stoerung und muss UNAVAILABLE melden, "
             f"bekam: {result!r}"
@@ -239,7 +247,9 @@ def test_ac3_all_three_failure_causes_log_a_warning(caplog):
         caplog.clear()
         trip, weather = build()
         with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
-            _scheduler(weather)._build_stage_trend(trip, date.today(), tz=None)
+            _scheduler(weather)._build_stage_trend(
+            trip, date.today(), now_utc=datetime.now(timezone.utc), tz=None,
+        )
         messages = [r.getMessage() for r in _warnings(caplog)]
         assert any("S2" in m for m in messages), (
             f"Ursache '{label}' muss ein WARNING mit Etappen-Bezug erzeugen, "

--- a/tests/tdd/test_preview_parity_without_outlook.py
+++ b/tests/tdd/test_preview_parity_without_outlook.py
@@ -112,9 +112,13 @@ def _sent_report(trip, segment_weather, stage_name, trip_tz):
 
     scheduler = TripReportSchedulerService()
     stage = trip.get_stage_for_date(_TARGET)
-    trend_result = scheduler._build_stage_trend(trip, _TARGET, tz=trip_tz)
+    jetzt_utc = datetime.now(timezone.utc)
+    trend_result = scheduler._build_stage_trend(
+        trip, _TARGET, now_utc=jetzt_utc, tz=trip_tz,
+    )
     thunder_forecast = scheduler._build_thunder_forecast_from_trend_or_fetch(
-        trip, _TARGET, tz=trip_tz, multi_day_trend=trend_result.rows,
+        trip, _TARGET, now_utc=jetzt_utc, tz=trip_tz,
+        multi_day_trend=trend_result.rows,
     )
     try:
         from services.weather_pattern import WeatherPatternService

--- a/tests/tdd/test_preview_thunder_matches_sent.py
+++ b/tests/tdd/test_preview_thunder_matches_sent.py
@@ -153,7 +153,8 @@ def _thunder_forecast_from_scheduler(trend: list[dict]) -> dict:
     Quelle, kein Nachbau. trip=None ist sicher, weil der Trend beide Offsets
     abdeckt (kein Fetch)."""
     return TripReportSchedulerService()._build_thunder_forecast_from_trend_or_fetch(
-        None, _TARGET, tz=_UTC, multi_day_trend=trend,
+        None, _TARGET, now_utc=datetime.now(timezone.utc), tz=_UTC,
+        multi_day_trend=trend,
     )
 
 

--- a/tests/tdd/test_th_plus_follows_thunder_metric_and_gap.py
+++ b/tests/tdd/test_th_plus_follows_thunder_metric_and_gap.py
@@ -28,7 +28,7 @@ aus einer echten Codepfad-Verzweigung (Folge-Etappe mit nur EINEM Waypoint ->
 """
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Optional
 
 import pytest
@@ -241,7 +241,8 @@ class TestAC3RealGapShowsUnknown:
 
         svc = TripReportSchedulerService()
         forecast = svc._build_thunder_forecast_from_trend_or_fetch(
-            trip, today, tz=None, multi_day_trend=None,
+            trip, today, now_utc=datetime.now(timezone.utc), tz=None,
+            multi_day_trend=None,
         )
 
         assert forecast is not None, (

--- a/tests/tdd/test_thunder_forecast_fail_soft.py
+++ b/tests/tdd/test_thunder_forecast_fail_soft.py
@@ -95,8 +95,10 @@ class TestThunderForecastFailSoft:
         today = date.today()
         trip = _trip_with_unfetchable_next_stage(today)
 
+        from datetime import datetime, timezone
+
         collected = TripReportSchedulerService()._collect_future_stage_weather(
-            trip, today,
+            trip, today, now_utc=datetime.now(timezone.utc),
         )
 
         assert collected == [], (

--- a/tests/tdd/test_thunder_forecast_stage_consistency.py
+++ b/tests/tdd/test_thunder_forecast_stage_consistency.py
@@ -299,7 +299,8 @@ class TestAC1RenderedOutputsAgree:
 
         scheduler = TripReportSchedulerService()
         thunder_forecast = scheduler._build_thunder_forecast_from_trend_or_fetch(
-            None, _TODAY, tz=_UTC, multi_day_trend=trend,
+            None, _TODAY, now_utc=datetime.now(timezone.utc), tz=_UTC,
+            multi_day_trend=trend,
         )
 
         report = TripReportFormatter().format_email(

--- a/tests/tdd/test_thunder_forecast_trend_reuse.py
+++ b/tests/tdd/test_thunder_forecast_trend_reuse.py
@@ -14,7 +14,7 @@ Spec: docs/specs/bugfix/fix_1275_sms_th_mismatch.md (AC-1/AC-2)
 """
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 from src.output.tokens.dto import HourlyValue
 from src.app.models import ThunderLevel
@@ -63,7 +63,8 @@ class TestTrendReuseNoDoubleFetch:
                Crash, d.h. kein zweiter Fetch (Doppel-Fetch vermieden)
         """
         fc = TripReportSchedulerService()._build_thunder_forecast_from_trend_or_fetch(
-            None, _TARGET, tz=None, multi_day_trend=_trend_rows(),
+            None, _TARGET, now_utc=datetime.now(timezone.utc), tz=None,
+            multi_day_trend=_trend_rows(),
         )
 
         assert fc is not None
@@ -100,7 +101,8 @@ class TestTrendReuseNoDoubleFetch:
             },
         ]
         fc = TripReportSchedulerService()._build_thunder_forecast_from_trend_or_fetch(
-            None, _TARGET, tz=None, multi_day_trend=rest_day_trend,
+            None, _TARGET, now_utc=datetime.now(timezone.utc), tz=None,
+            multi_day_trend=rest_day_trend,
         )
         assert "+1" not in fc, (
             f"+2-Zeile wurde als +1 verwechselt (Index- statt Datums-Match): {fc!r}"

--- a/tests/tdd/test_thunder_next_day_reference_by_report_type.py
+++ b/tests/tdd/test_thunder_next_day_reference_by_report_type.py
@@ -81,7 +81,8 @@ class TestThunderNextDayReferenceByReportType:
         )
 
         fc = svc._build_thunder_forecast_from_trend_or_fetch(
-            None, target, tz=None, multi_day_trend=_trend_rows_for(target),
+            None, target, now_utc=_jetzt(), tz=None,
+            multi_day_trend=_trend_rows_for(target),
         )
 
         expected = (target + timedelta(days=1)).strftime("%d.%m.%Y")
@@ -104,7 +105,8 @@ class TestThunderNextDayReferenceByReportType:
         )
 
         fc = svc._build_thunder_forecast_from_trend_or_fetch(
-            None, target, tz=None, multi_day_trend=_trend_rows_for(target),
+            None, target, now_utc=_jetzt(), tz=None,
+            multi_day_trend=_trend_rows_for(target),
         )
 
         expected = (target + timedelta(days=1)).strftime("%d.%m.%Y")
@@ -126,11 +128,11 @@ class TestThunderNextDayReferenceByReportType:
         evening_target = svc._get_target_date("evening", _trip, _now)
 
         fc_morning = svc._build_thunder_forecast_from_trend_or_fetch(
-            None, morning_target, tz=None,
+            None, morning_target, now_utc=_jetzt(), tz=None,
             multi_day_trend=_trend_rows_for(morning_target),
         )
         fc_evening = svc._build_thunder_forecast_from_trend_or_fetch(
-            None, evening_target, tz=None,
+            None, evening_target, now_utc=_jetzt(), tz=None,
             multi_day_trend=_trend_rows_for(evening_target),
         )
 

--- a/tests/tdd/test_versandpfade_folgen_ortszone.py
+++ b/tests/tdd/test_versandpfade_folgen_ortszone.py
@@ -1,0 +1,859 @@
+"""TDD RED — #1727 S5b: die Versandpfade folgen dem ORTSTAG der Tour.
+
+SPEC: docs/specs/modules/fix_1727_s5b_versandpfade_ortstag.md (AC-1 bis AC-9)
+KONTEXT: docs/context/fix-1727-s5b-versandpfade.md (neun Fundstellen, gemessen)
+ADR-0044 (Kalendertage folgen der Ortszeit), ADR-0051 Regel 3 (keine
+Umgebungsuhr — „jetzt“ kommt vom Aufrufer).
+
+Neun Fundstellen bestimmen „welcher Kalendertag ist gemeint“ über die
+Serveruhr (``date.today()``) statt über den Ortstag der Tour bzw. des ersten
+auflösbaren Preset-Orts. Anders als in der Vorgängerscheibe S5a wirken sie auf
+VERSENDETE Inhalte — Etappenwahl, Wetter-Input, Ausblick, Gewitter-Ausblick,
+Verfall eines Nachliefer-Vermerks, Auto-Pause eines Presets, Datum im
+Mail-/SMS-/Telegram-Präfix und Zieltag des Ortsvergleich-Einzelversands:
+
+    1 ``select_test_stage``                (trip_report_scheduler.py:871)
+    2 ``_send_trip_report_outcome``        (trip_report_scheduler.py:1103)
+    3 ``_clamp_segments_to_today``         (trip_report_scheduler.py:1708)
+    4 ``_build_stage_trend``               (trip_report_scheduler.py:2023)
+    5 ``_collect_future_stage_weather``    (trip_report_scheduler.py:2416)
+    6 ``briefing_target_day_is_current``   (alert_briefing_anchor.py:169)
+    7 ``_auto_pause_expired_presets``      (scheduler_dispatch_service.py:79)
+    8 ``_target_date_from_report``         (notification_service.py:1717)
+    9 ``send_one_compare_preset``          (scheduler_dispatch_service.py:369)
+
+ZWEI NACHWEISFORMEN, BEIDE PFLICHT WO ANWENDBAR
+═══════════════════════════════════════════════════════════════════════════
+(a) **Ortstag ≠ Servertag** — für alle neun. ``freeze_time`` in ein Fenster
+    setzen, in dem beide auseinanderfallen; jeder Test beginnt mit dem
+    Vorbedingungs-Anker ``_anker`` aus ``tests/tdd/conftest.py`` (AC-9), ohne
+    den die Hauptzusicherung strukturell nie fehlschlagen könnte (#1726 F002).
+
+(b) **Parameter gegen Systemuhr** — für die Fundstellen 1, 3, 4, 5, 6, 7,
+    also überall dort, wo ein Pflichtparameter entsteht. ``freeze_time(X)``
+    setzen, ``now_utc=Y`` übergeben, X und Y auf VERSCHIEDENE Ortstage
+    derselben Zone. Nur diese Form fängt „Parameter entgegengenommen, im Rumpf
+    ignoriert“ — in S5a waren fünf von sechs Aufrufstellen dagegen blind
+    (Adversary F001). Sie steht unten in einer eigenen, parametrisierten
+    Familie, deren Erwartungswerte literal nebeneinander stehen.
+    An den Fundstellen 2, 8, 9 ist sie strukturell unmöglich (dort bleibt
+    „jetzt“ funktionsintern, s. Spec „Known Limitations“) — nur (a).
+
+RED-GRÜNDE (gemessen, nicht vermutet)
+═══════════════════════════════════════════════════════════════════════════
+* Fundstellen 1, 3, 4, 5, 7: der Pflichtparameter existiert noch nicht — die
+  Aufrufe scheitern mit ``TypeError``. Alle neuen Parameter werden deshalb
+  als KEYWORD übergeben: ein positionsweise durchgereichtes ``now_utc`` landete
+  bei ``_build_stage_trend`` sonst still im ``tz``-Parameter.
+* Fundstelle 6: ``briefing_target_day_is_current`` trägt heute den
+  Systemuhr-Rückfall ``today or date.today()``; der Aufrufer im Scheduler
+  übergibt gar nichts. Beides fachlich rot, kein ``TypeError``.
+* Fundstellen 2, 8, 9: fachlich rot — geklemmte Segmentzeiten, falsches
+  Präfix-Datum, Servertag als Zieltag des Ortsvergleichs.
+
+TESTPOLITIK (CLAUDE.md „Test-Politik: Zwei Schichten“): Kern-Schicht, kein
+Netz. Echte ``Trip``/``Stage``/``Waypoint``/``SavedLocation``-Objekte, echte
+Preset-Dateien, echter Loader (die autouse-Fixtur ``_isolate_data_root`` hält
+``data/`` isoliert). Kein ``Mock()``/``patch()``/``MagicMock``. Die
+Netz-Nähte laufen über eine echte Unterklasse
+(:class:`_AufzeichnenderScheduler`, DI-Naht am Wetterabruf) bzw. eine
+aufzeichnende Sonde vor der Vergleichs-Engine — beide zeichnen auf, WAS der
+Prüfling entschieden hat, statt eine Annahme zurückzuspiegeln.
+
+Pfadregel #1409: diese Datei liest nichts von der Platte des Hauptrepos.
+"""
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+from freezegun import freeze_time
+
+from app.loader import load_all_trips, save_trip
+from app.models import TripReport
+from app.trip import Trip
+from app.user import SavedLocation
+from services.alert_briefing_anchor import briefing_target_day_is_current
+from services.notification_service import NotificationService, TripReportRequest
+from services.scheduler_dispatch_service import (
+    _auto_pause_expired_presets,
+    send_one_compare_preset,
+)
+from services.trip_report_scheduler import TripReportSchedulerService
+from services.trip_segments import convert_trip_to_segments
+from tests.helpers.compare_briefings import (
+    read_compare_briefings,
+    write_compare_briefings,
+)
+from tests.helpers.nowcast_gate_fixtures import (
+    settings_email_only,
+    settings_no_channel_reachable,
+    trip_stage,
+)
+from tests.tdd.conftest import WP_KORSIKA, WP_NZ, _anker
+
+# ═══════════════════════════ Zonen und Koordinaten ═══════════════════════════
+# Mitteleuropäische Fixturen (Versatz 2 h) können den Fehler strukturell nicht
+# zeigen — deshalb durchgehend Zonen mit deutlichem Versatz.
+
+KORSIKA_ZONE = "Europe/Paris"          # im August UTC+2
+WELLINGTON_ZONE = "Pacific/Auckland"   # im August UTC+12
+LA_ZONE = "America/Los_Angeles"        # im August UTC-7
+WP_LA = (34.05, -118.24)               # Los Angeles
+
+D18, D19, D20, D21, D22, D23 = (date(2026, 8, d) for d in (18, 19, 20, 21, 22, 23))
+
+# ── Die beiden Mismatch-Fenster (a) ──────────────────────────────────────────
+# 14:00 UTC am 20.08. = 02:00 Ortszeit am 21.08. in Wellington: der Ortstag ist
+# dem Servertag VORAUS (positiver Versatz).
+MITTAGS_UTC = datetime(2026, 8, 20, 14, 0, tzinfo=timezone.utc)
+# 03:00 UTC am 21.08. = 20:00 Ortszeit am 20.08. in Los Angeles: der Ortstag
+# hinkt dem Servertag HINTERHER (negativer Versatz). Genau die Lage, in der
+# `target_date < date.today()` fälschlich wahr wird (AC-2).
+WESTKUESTE_UTC = datetime(2026, 8, 21, 3, 0, tzinfo=timezone.utc)
+
+# ── Vorhersage-Horizont ──────────────────────────────────────────────────────
+# `is_within_forecast_horizon(stage_date, today)` ist
+# `(stage_date - today).days <= 15`. Eine Etappe GENAU auf der Grenze des
+# Ortstages liegt einen Tag JENSEITS der Grenze des Servertages — damit
+# entscheidet allein der benutzte Tagesbegriff, ob der Ausblick sie abruft.
+HORIZON_NZ = D21 + timedelta(days=15)        # 05.09.2026 — Ortstag 21.08. + 15
+
+
+def _zone(coords: tuple[float, float]) -> str:
+    return {WP_NZ: WELLINGTON_ZONE, WP_KORSIKA: KORSIKA_ZONE, WP_LA: LA_ZONE}[coords]
+
+
+def _trip(trip_id: str, tage: list[date], coords: tuple[float, float]) -> Trip:
+    """Tour mit je einer Zwei-Wegpunkt-Etappe pro Tag, alle in DERSELBEN Zone.
+
+    ``trip_stage`` ist der geteilte Etappen-Baustein (``tests/helpers/
+    nowcast_gate_fixtures``) — zwei Wegpunkte mit Ankunftszeiten sind Pflicht,
+    ``convert_trip_to_segments`` liefert unterhalb davon eine leere Liste.
+    """
+    return Trip(
+        id=trip_id,
+        name=trip_id,
+        stages=[
+            trip_stage(f"S{i}", tag, coords[0], coords[1], wp_prefix=f"W{i}-")
+            for i, tag in enumerate(tage)
+        ],
+        official_alerts_enabled=False,  # strukturell kein Warnungs-Abruf
+    )
+
+
+def _ort(loc_id: str, coords: tuple[float, float] | None) -> SavedLocation:
+    """Gespeicherter Ort; ``coords=None`` = Ort OHNE auflösbare Zone."""
+    lat, lon = (None, None) if coords is None else coords
+    return SavedLocation(id=loc_id, name=loc_id, lat=lat, lon=lon, elevation_m=500)
+
+
+def _uhr_eingefroren(now_utc: datetime) -> None:
+    """Zweiter Teil des Vorbedingungs-Ankers (AC-9): belegt, dass
+    ``freeze_time`` im PRÜFPROZESS wirklich greift.
+
+    ``_anker`` allein zeigt das NICHT — er vergleicht den Ortstag gegen
+    ``date.today()``, und die echte Systemuhr steht ohnehin auf einem anderen
+    Tag als die Fixtur. Ohne diese Prüfung wäre ein grüner Lauf kein Beweis,
+    sondern ein Zufall.
+    """
+    assert datetime.now(tz=timezone.utc) == now_utc, (
+        "Testaufbau: freeze_time greift nicht, die Systemuhr steht auf "
+        f"{datetime.now(tz=timezone.utc).isoformat()} statt auf "
+        f"{now_utc.isoformat()}"
+    )
+    assert date.today() == now_utc.date(), (
+        f"Testaufbau: date.today() liefert {date.today()}, erwartet den "
+        f"eingefrorenen Weltzeit-Tag {now_utc.date()} — genau diesen Aufruf "
+        "prüft der Test am Prüfling"
+    )
+
+
+def _ortstage(segmente) -> list[date]:
+    """Die ORTSTAGE, auf denen die Segmente beginnen — die fachliche Größe.
+
+    ``TripSegment.start_time`` ist UTC: eine Etappe, die um 00:00 Ortszeit in
+    Neuseeland beginnt, trägt dort den UTC-Vortag, und das Ziel-Segment einer
+    Westküsten-Etappe fällt in UTC auf den Folgetag. Ein Vergleich auf
+    ``start_time.date()`` verwechselte diese Zonenverschiebung mit der
+    Tages-Klemme, um die es hier geht.
+    """
+    from utils.timezone import local_dt, tz_for_coords
+
+    return sorted({
+        local_dt(
+            seg.start_time, tz_for_coords(seg.start_point.lat, seg.start_point.lon),
+        ).date()
+        for seg in segmente
+    })
+
+
+class _AufzeichnenderScheduler(TripReportSchedulerService):
+    """Echte Unterklasse als DI-Naht am EINZIGEN Netzabruf des Prüflings.
+
+    Sie zeichnet auf, für WELCHE Kalendertage der Produktivcode Wetter holen
+    wollte, und liefert nichts zurück. Kein Mock: die Zusicherung hängt an der
+    Entscheidung des echten Prüflings, nicht an einer zurückgespiegelten
+    Annahme. ``[]`` als Rückgabe ist der ehrliche Ausfall-Fall, den der
+    Produktivcode ohnehin kennt (Ausblick: ``UNAVAILABLE``; Briefing:
+    ``no_weather``).
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.abgerufen: list[date] = []
+
+    def _fetch_weather(self, segments, provider=None):
+        self.abgerufen.extend(_ortstage(segments))
+        return []
+
+
+def _scheduler() -> _AufzeichnenderScheduler:
+    """Settings IMMER explizit (#1477): ein blankes ``Settings()`` fällt bei
+    fehlenden Feldern still auf die Produktiv-``.env`` zurück."""
+    return _AufzeichnenderScheduler(settings_email_only(), "default")
+
+
+# ══════════════ AC-1: Test-Fallback wählt und klemmt nach dem Ortstag ══════════════
+
+
+def test_ac1_test_fallback_waehlt_und_klemmt_nach_dem_ortstag():
+    """AC-1 — Fundstellen 1 (``select_test_stage``) und 3
+    (``_clamp_segments_to_today``), die zusammen EINE Kette bilden.
+
+    GIVEN eine Neuseeland-Tour (UTC+12) mit Etappen am 18.08. und 20.08., und
+          ein Zeitpunkt 14:00 UTC am 20.08. — ortszeitlich ist bereits der
+          21.08., auf dem Server noch der 20.08.,
+    WHEN  der Test-Versand über ``select_test_stage`` seine Ersatz-Etappe wählt
+          und ``_clamp_segments_to_today`` deren Segmentzeiten für den
+          Wetterabruf klemmt,
+    THEN  zählt die Etappe vom 20.08. NICHT mehr als „kommend“ — sie ist
+          ortszeitlich vergangen, der Rückfall greift auf die chronologisch
+          früheste Etappe (18.08.) —, und die Klemme verschiebt um
+          ``Ortstag − from_date`` (3 Tage) statt um ``Servertag − from_date``
+          (2 Tage).
+
+    Vor dem Fix trug ``today`` an beiden Stellen den Servertag: ``s.date >=
+    today`` hielt die 20.08.-Etappe fälschlich für aktuell, und die Klemme
+    schob die Segmentzeiten einen Tag zu wenig weit.
+    """
+    with freeze_time(MITTAGS_UTC):
+        _anker(MITTAGS_UTC, WELLINGTON_ZONE, D21)
+        _uhr_eingefroren(MITTAGS_UTC)
+        servertag = date.today()
+        trip = _trip("test-fallback-nz", [D18, D20], WP_NZ)
+
+        gewaehlt = _scheduler().select_test_stage(trip, "morning", now_utc=MITTAGS_UTC)
+
+        segmente = convert_trip_to_segments(trip, D18)
+        assert segmente, "Testaufbau: die Etappe vom 18.08. muss Segmente liefern"
+        geklemmt = _scheduler()._clamp_segments_to_today(segmente, D18, today=D21)
+
+    assert gewaehlt is not None and gewaehlt.date == D18, (
+        f"AC-1: select_test_stage wählte die Etappe vom "
+        f"{getattr(gewaehlt, 'date', None)}, erwartet {D18}. "
+        f"{D20} heißt: der Prüfling hat den Servertag ({servertag}) benutzt und "
+        f"die ortszeitlich bereits vergangene Etappe noch als „kommend“ gezählt "
+        f"(Ortstag {D21})."
+    )
+    verschoben = _ortstage(geklemmt)
+    assert verschoben == [D21], (
+        f"AC-1: _clamp_segments_to_today verschob auf {verschoben}, erwartet "
+        f"[{D21}] (Ortstag). {[D20]} heißt: geklemmt wurde um "
+        f"{(servertag - D18).days} Tage (Servertag − from_date) statt um "
+        f"{(D21 - D18).days} Tage (Ortstag − from_date) — der Wetterabruf liefe "
+        f"dann auf dem falschen Kalendertag."
+    )
+
+
+# ══════════════ AC-2: der Klemm-Zweig vergleicht zwei gleiche Tagesbegriffe ══════════════
+
+
+def test_ac2_klemm_zweig_greift_nicht_am_eigenen_ortstag():
+    """AC-2 — Fundstelle 2 (``_send_trip_report_outcome``, Zeile 1103).
+
+    GIVEN eine Tour an der US-Westküste (UTC−7) mit Etappe am 20.08., ein
+          Zeitpunkt 03:00 UTC am 21.08. — ortszeitlich noch der 20.08., auf dem
+          Server bereits der 21.08. — und ein ``target_date``, das (wie aus
+          ``_get_target_date`` → ``trip_local_today``) bereits ortsrichtig den
+          20.08. trägt,
+    WHEN  der Test-Versand prüft, ob die Segmentzeiten für den Wetterabruf auf
+          „heute“ geklemmt werden,
+    THEN  greift der Klemm-Zweig NICHT — obwohl ``date.today()`` (21.08.)
+          größer ist als ``target_date`` (20.08.). Der Wetterabruf läuft auf
+          dem 20.08.
+
+    Vor dem Fix verglich ``target_date < date.today()`` einen bereits
+    ortsrichtigen Tag gegen den rohen Servertag: zwei verschiedene
+    Tagesbegriffe im selben ``<``-Vergleich, und der Wetterabruf lief einen Tag
+    zu weit vorne.
+
+    Gemessen wird an der Naht, an der es WIRKT: welche Segmentzeiten der
+    Prüfling tatsächlich in den Wetterabruf gibt.
+    """
+    with freeze_time(WESTKUESTE_UTC):
+        _anker(WESTKUESTE_UTC, LA_ZONE, D20)
+        _uhr_eingefroren(WESTKUESTE_UTC)
+        servertag = date.today()
+        assert servertag > D20, (
+            "Testaufbau nicht diskriminierend: der Servertag muss dem Ortstag "
+            f"VORAUS sein (Servertag {servertag}, Ortstag {D20})"
+        )
+        trip = _trip("klemme-westkueste", [D20], WP_LA)
+        scheduler = _scheduler()
+
+        ergebnis = scheduler._send_trip_report_outcome(
+            trip, "morning", allow_test_fallback=True, on_demand=True,
+            target_date=D20,
+        )
+
+    assert ergebnis == "no_weather", (
+        f"Testaufbau: der Prüfling muss bis zum Wetterabruf gekommen sein, "
+        f"lieferte aber {ergebnis!r} — ohne Abruf belegt der Test nichts"
+    )
+    assert scheduler.abgerufen == [D20], (
+        f"AC-2: der Wetterabruf lief auf {scheduler.abgerufen}, erwartet "
+        f"[{D20}] (der ortsrichtige Zieltag). {[D21]} heißt: der Klemm-Zweig "
+        f"hat gegriffen, weil er den ortsrichtigen target_date ({D20}) gegen "
+        f"den Servertag ({servertag}) verglichen hat — zwei Tagesbegriffe in "
+        f"einem Vergleich."
+    )
+
+
+# ══════════════ AC-3: Ausblick und Gewitter-Ausblick am Ortstag ══════════════
+
+
+def test_ac3_ausblick_misst_den_horizont_am_ortstag():
+    """AC-3, erste Hälfte — Fundstelle 4 (``_build_stage_trend``).
+
+    GIVEN eine Neuseeland-Tour (UTC+12) mit Zieltag 20.08. und einer künftigen
+          Etappe GENAU auf der Horizont-Grenze des Ortstages (21.08. + 15 Tage
+          = 05.09.), und ein Zeitpunkt 14:00 UTC am 20.08.,
+    WHEN  der Ausblick prüft, welche künftigen Etappen im Vorhersage-Horizont
+          liegen,
+    THEN  liegt die 05.09.-Etappe INNERHALB — gemessen am Ortstag 21.08. —, der
+          Ausblick ruft für sie Wetter ab und die Trendzeile geht in die Mail.
+
+    Vor dem Fix maß ``is_within_forecast_horizon(stage.date, date.today())``
+    gegen den Servertag 20.08.; die Etappe fiel um genau einen Tag aus dem
+    Horizont und der Ausblick blieb leer (``BEYOND_HORIZON``).
+    """
+    with freeze_time(MITTAGS_UTC):
+        _anker(MITTAGS_UTC, WELLINGTON_ZONE, D21)
+        _uhr_eingefroren(MITTAGS_UTC)
+        servertag = date.today()
+        assert (HORIZON_NZ - D21).days == 15 and (HORIZON_NZ - servertag).days == 16, (
+            "Testaufbau nicht diskriminierend: die Etappe muss am Ortstag genau "
+            "IM und am Servertag genau AUSSERHALB des Horizonts liegen "
+            f"(Etappe {HORIZON_NZ}, Ortstag {D21}, Servertag {servertag})"
+        )
+        trip = _trip("ausblick-nz", [D20, HORIZON_NZ], WP_NZ)
+        scheduler = _scheduler()
+
+        ergebnis = scheduler._build_stage_trend(trip, D20, now_utc=MITTAGS_UTC)
+
+    assert scheduler.abgerufen == [HORIZON_NZ], (
+        f"AC-3: der Ausblick rief Wetter für {scheduler.abgerufen} ab, erwartet "
+        f"[{HORIZON_NZ}]. Eine leere Liste heißt: der Horizont wurde gegen den "
+        f"Servertag ({servertag}) gemessen statt gegen den Ortstag ({D21}) — "
+        f"die Etappe fiel um genau einen Tag heraus (Zustand "
+        f"{getattr(ergebnis, 'state', None)})."
+    )
+
+
+def test_ac3_gewitter_ausblick_misst_den_horizont_am_ortstag():
+    """AC-3, zweite Hälfte — Fundstelle 5 (``_collect_future_stage_weather``).
+
+    GIVEN dieselbe Lage wie oben, aber der Rückfall-Pfad des Gewitter-Ausblicks
+          (er greift, wenn der Trend den gebrauchten Versatz nicht abdeckt),
+    WHEN  er für die ausdrücklich gewünschte Etappe vom 05.09. Wetter sammelt,
+    THEN  gilt sie am Ortstag 21.08. als im Horizont und wird abgerufen.
+
+    Eigener Test statt einer Parametrisierung mit dem Ausblick oben: es sind
+    zwei getrennte Rechenwege mit je eigener ``date.today()``-Auflösung — eine
+    Verfälschung, die nur einen von beiden hebt, ließe den anderen grün.
+    """
+    with freeze_time(MITTAGS_UTC):
+        _anker(MITTAGS_UTC, WELLINGTON_ZONE, D21)
+        _uhr_eingefroren(MITTAGS_UTC)
+        servertag = date.today()
+        trip = _trip("gewitter-ausblick-nz", [D20, HORIZON_NZ], WP_NZ)
+        scheduler = _scheduler()
+
+        scheduler._collect_future_stage_weather(
+            trip, D20, now_utc=MITTAGS_UTC, wanted_dates={HORIZON_NZ},
+        )
+
+    assert scheduler.abgerufen == [HORIZON_NZ], (
+        f"AC-3: der Gewitter-Ausblick rief Wetter für {scheduler.abgerufen} ab, "
+        f"erwartet [{HORIZON_NZ}]. Eine leere Liste heißt: der Horizont wurde "
+        f"gegen den Servertag ({servertag}) gemessen statt gegen den Ortstag "
+        f"({D21}) — die Gewitter-Ausblickszeile fehlt dann in Mail und SMS."
+    )
+
+
+# ══════════════ AC-4: Verfall des Versandfehler-Vermerks am Ortstag ══════════════
+
+
+def _vermerk_schreiben(scheduler: TripReportSchedulerService, trip: Trip,
+                       tag: date) -> Path:
+    """Schreibt EINEN Versandfehler-Vermerk über den echten Schreibweg des
+    Prüflings (``_write_pending_marker``) — keine handgebaute JSON-Attrappe."""
+    scheduler._write_pending_marker(
+        trip, "morning", tag, failed_segment_ids=[], reason="dispatch_error",
+    )
+    from app.loader import get_data_dir
+
+    return get_data_dir(scheduler._user_id) / "pending_briefings.json"
+
+
+def _offene_vermerke(pfad: Path) -> list[str]:
+    return [e["date"] for e in json.loads(pfad.read_text()).get("entries", [])]
+
+
+def _tour_ist_auffindbar(trip: Trip) -> None:
+    """Vorbedingung, ohne die „Vermerk entfernt" mehrdeutig wäre: der Scheduler
+    räumt einen Vermerk AUCH weg, wenn er die zugehörige Tour nicht findet
+    (``trip is None``). Ohne diesen Anker wäre der Test in beide Richtungen aus
+    dem falschen Grund grün bzw. rot."""
+    gefunden = [t.id for t in load_all_trips()]
+    assert trip.id in gefunden, (
+        f"Testaufbau: der Scheduler findet die Tour {trip.id!r} nicht "
+        f"(geladen: {gefunden}) — er entfernte den Vermerk dann mangels Tour, "
+        "nicht wegen des Zieltages"
+    )
+
+
+def test_ac4_versandfehler_vermerk_verfaellt_nach_dem_ortstag():
+    """AC-4 — Fundstelle 6 (``briefing_target_day_is_current`` und ihr
+    Aufrufer in ``_process_pending_markers``).
+
+    GIVEN ein Versandfehler-Vermerk mit Zieltag 20.08. für eine Tour an der
+          US-Westküste (UTC−7) und ein Zeitpunkt 03:00 UTC am 21.08. —
+          ortszeitlich ist noch der 20.08., auf dem Server schon der 21.08.,
+    WHEN  der Scheduler prüft, ob der Vermerk noch aktuell ist,
+    THEN  bleibt er stehen: sein Zieltag IST der laufende Ortstag.
+
+    Vor dem Fix löste die Funktion ``heute = today or date.today()`` intern auf
+    und verglich gegen den Servertag 21.08. — der Vermerk verfiel einen Tag zu
+    früh und das fehlgeschlagene Briefing wurde nie nachgeliefert. Genau diese
+    Stelle entscheidet, ob überhaupt etwas zugestellt wird.
+
+    Der Trip steht in ``due_trip_ids_now``: dann ist der Verfallsprüfung der
+    EINZIGE Weg, den Vermerk zu entfernen — jede andere Entfernung wäre kein
+    Beleg für diese Zusicherung.
+    """
+    with freeze_time(WESTKUESTE_UTC):
+        _anker(WESTKUESTE_UTC, LA_ZONE, D20)
+        _uhr_eingefroren(WESTKUESTE_UTC)
+        servertag = date.today()
+        trip = _trip("vermerk-westkueste", [D20], WP_LA)
+        save_trip(trip)
+        _tour_ist_auffindbar(trip)
+        scheduler = _scheduler()
+        pfad = _vermerk_schreiben(scheduler, trip, D20)
+
+        scheduler._process_pending_markers(WESTKUESTE_UTC, {trip.id})
+
+    assert _offene_vermerke(pfad) == [D20.isoformat()], (
+        f"AC-4: der Vermerk vom {D20} wurde entfernt, obwohl sein Zieltag der "
+        f"laufende ORTSTAG ist. Das heißt: verglichen wurde gegen den Servertag "
+        f"({servertag}) — das Briefing, dessen Zustellung fehlschlug, wird nie "
+        f"nachgeliefert. Offene Vermerke: {_offene_vermerke(pfad)}"
+    )
+
+
+def test_ac4_briefing_target_day_is_current_hat_keinen_systemuhr_rueckfall():
+    """AC-4 / ADR-0051 Regel 3 — ``today`` ist Pflicht, kein Default.
+
+    GIVEN die reine Entscheidungsfunktion ``briefing_target_day_is_current``,
+    WHEN  sie OHNE ``today`` aufgerufen wird,
+    THEN  scheitert sie laut mit ``TypeError``, statt still auf die
+          Umgebungsuhr zurückzufallen.
+
+    Warum das eine eigene Zusicherung ist: ein Rückfall-Default macht den
+    Aufruf-Fehler „Tag vergessen“ unsichtbar — die Funktion liefert dann eine
+    plausible Antwort zum falschen Tagesbegriff. Genau dieser Default steht
+    heute im Code (``heute = today or date.today()``), weshalb dieser Test rot
+    ist: der Aufruf gelingt.
+    """
+    with pytest.raises(TypeError):
+        briefing_target_day_is_current(D20)
+
+
+# ══════════════ AC-5: Auto-Pause eines Presets am Ortstag ══════════════
+
+
+def _preset(preset_id: str, location_ids: list[str], end_date: date) -> dict:
+    return {
+        "id": preset_id,
+        "name": preset_id,
+        "location_ids": location_ids,
+        "schedule": "daily",
+        "weekday": 4,
+        "profil": "ALLGEMEIN",
+        "end_date": end_date.isoformat(),
+    }
+
+
+def _preset_ablage(tmp_path: Path, presets: list[dict],
+                   user_id: str = "default") -> str:
+    """Legt die Presets als echte ``briefings/<id>.json`` an (geteilter
+    Helfer) und gibt den ``data_root`` zurück."""
+    write_compare_briefings(tmp_path / "users" / user_id, presets)
+    return str(tmp_path)
+
+
+def _pausiert(tmp_path: Path, preset_id: str, user_id: str = "default") -> bool:
+    eintraege = read_compare_briefings(tmp_path / "users" / user_id)
+    treffer = [e for e in eintraege if e.get("id") == preset_id]
+    assert treffer, f"Testaufbau: Preset {preset_id} nicht in der Ablage"
+    return bool(treffer[0].get("paused_at"))
+
+
+def test_ac5_preset_pausiert_nach_dem_ortstag_seines_ersten_orts(tmp_path):
+    """AC-5 — Fundstelle 7 (``_auto_pause_expired_presets``).
+
+    GIVEN ein Ortsvergleich-Preset, dessen ``end_date`` auf dem 20.08. liegt
+          und dessen erster auflösbarer Ort in Neuseeland (UTC+12) steht, und
+          ein Zeitpunkt 14:00 UTC am 20.08. — ortszeitlich ist dort bereits der
+          21.08.,
+    WHEN  der Versandlauf prüft, ob das Preset automatisch zu pausieren ist,
+    THEN  wird es pausiert: an SEINEM Ort ist der letzte Tag vorbei.
+
+    Vor dem Fix verglich ``date.fromisoformat(end_date) < date.today()`` gegen
+    den Servertag 20.08. — das Preset blieb einen Tag zu lange aktiv und
+    verschickte einen Vergleich, den der Nutzer abbestellt hatte.
+
+    Geprüft wird am Wirkort: dem ``paused_at`` in der geschriebenen
+    ``briefings/<id>.json`` (Read-Modify-Write mit Merge, unverändert).
+    """
+    presets = [_preset("preset-nz", ["ort-nz"], D20)]
+    data_root = _preset_ablage(tmp_path, presets)
+    orte = [_ort("ort-nz", WP_NZ)]
+
+    with freeze_time(MITTAGS_UTC):
+        _anker(MITTAGS_UTC, WELLINGTON_ZONE, D21)
+        _uhr_eingefroren(MITTAGS_UTC)
+        servertag = date.today()
+        _auto_pause_expired_presets(
+            presets, "default", data_root,
+            now_utc=MITTAGS_UTC, all_locations=orte,
+        )
+
+    assert _pausiert(tmp_path, "preset-nz"), (
+        f"AC-5: das Preset mit end_date {D20} wurde NICHT pausiert, obwohl an "
+        f"seinem Ort (Neuseeland) bereits der {D21} läuft. Das heißt: verglichen "
+        f"wurde gegen den Servertag ({servertag}) — das Preset verschickt einen "
+        f"weiteren Vergleich nach seinem eigenen Ende."
+    )
+
+
+# ══════════════ AC-6: Datum im Präfix-Text aus der Zone des Trips ══════════════
+
+
+def _report(trip: Trip) -> TripReport:
+    """Echter ``TripReport`` OHNE verwertbare Segmente — der Fallback-Fall, in
+    dem ``_target_date_from_report`` den Tag selbst bestimmen muss."""
+    return TripReport(
+        trip_id=trip.id,
+        trip_name=trip.name,
+        report_type="morning",
+        generated_at=datetime.now(timezone.utc),
+        segments=[],
+        email_subject=f"[{trip.name}] Morgen",
+        email_html="",
+        email_plain="Wetterbericht",
+    )
+
+
+def test_ac6_praefix_datum_folgt_der_zone_des_trips():
+    """AC-6 — Fundstelle 8 (``_target_date_from_report``), gemessen an
+    ``_apply_prefixes``, wo der Tag als TEXT beim Nutzer ankommt.
+
+    GIVEN ein Trip-Report ohne verwertbare Segmente (reiner Fallback-Fall) für
+          eine Neuseeland-Tour, dessen Anfrage die Zone bereits als
+          ``trip_tz`` trägt, und ein Zeitpunkt 14:00 UTC am 20.08. —
+          ortszeitlich der 21.08.,
+    WHEN  der Test-Präfix („Test-Vorschau für … am …“) gesetzt wird,
+    THEN  trägt er das Datum 21.08.2026 — den Ortstag der Tour.
+
+    Vor dem Fix lieferte ``_target_date_from_report`` ``date.today()``: der
+    Nutzer las im Mail-/SMS-/Telegram-Präfix ein Datum, das einen Tag neben dem
+    Tag lag, für den das Briefing gilt.
+    """
+    trip = _trip("praefix-nz", [D21], WP_NZ)
+    with freeze_time(MITTAGS_UTC):
+        _anker(MITTAGS_UTC, WELLINGTON_ZONE, D21)
+        _uhr_eingefroren(MITTAGS_UTC)
+        servertag = date.today()
+        anfrage = TripReportRequest(
+            trip=trip,
+            report_type="morning",
+            segment_weather=[],
+            trip_tz=ZoneInfo(WELLINGTON_ZONE),
+            stage_name="Etappe 1",
+            test_prefix=True,
+        )
+        report = _report(trip)
+        NotificationService(settings_email_only(), "default")._apply_prefixes(
+            report, anfrage,
+        )
+
+    assert f"{D21:%d.%m.%Y}" in report.email_plain, (
+        f"AC-6: der Präfix-Text nennt nicht den Ortstag {D21:%d.%m.%Y}.\n"
+        f"  Text:      {report.email_plain.splitlines()[0]!r}\n"
+        f"  Servertag: {servertag:%d.%m.%Y} — steht er dort, hat der Prüfling "
+        f"date.today() benutzt statt der bereits aufgelösten Zone am DTO "
+        f"(request.trip_tz)."
+    )
+
+
+# ══════════════ AC-7: Zieltag des Ortsvergleich-Einzelversands ══════════════
+
+
+class _ZieltagGesehen(Exception):
+    """Sonde vor der Vergleichs-Engine: hält den Zieltag fest, mit dem der
+    Prüfling sie ruft, und bricht dann ab — der Rest der Kette (Wetterabruf,
+    Rendering, Versand) trägt für DIESE Zusicherung nichts bei."""
+
+    def __init__(self, target_date: date) -> None:
+        super().__init__(str(target_date))
+        self.target_date = target_date
+
+
+def _engine_sonde(monkeypatch) -> None:
+    from services.comparison_engine import ComparisonEngine
+
+    def _aufzeichnen(*, target_date, **_rest):
+        raise _ZieltagGesehen(target_date)
+
+    monkeypatch.setattr(ComparisonEngine, "run", _aufzeichnen)
+
+
+def test_ac7_einzelversand_nimmt_den_ortstag_des_ersten_aufloesbaren_orts(
+    monkeypatch,
+):
+    """AC-7 — Fundstelle 9 (``send_one_compare_preset``, Einzelversand-Zweig).
+
+    GIVEN ein Ortsvergleich-Preset mit zwei Orten — der erste ohne auflösbare
+          Zone (Ort ohne Koordinaten), der zweite in Neuseeland (UTC+12) —, ein
+          Handversand OHNE Slot-Kontext (``target_date=None``,
+          ``tage_ab_ortstag=None``) und ein Zeitpunkt 14:00 UTC am 20.08.,
+    WHEN  der Einzelversand seinen Zieltag bestimmt,
+    THEN  ist es der 21.08. — der Ortstag des ERSTEN AUFLÖSBAREN Orts; der
+          unauflösbare erste wird übersprungen, nicht auf UTC zurückgefallen.
+
+    Vor dem Fix stand dort ``target_date = date.today()``: der Vergleich lief
+    auf dem Servertag, während der daneben gesetzte ``tage_ab_ortstag = 0``
+    einen Versatz gegen den ORTSTAG behauptet — zwei Tagesbegriffe, die genau
+    hier auseinanderlaufen.
+    """
+    _engine_sonde(monkeypatch)
+    orte = [_ort("ohne-zone", None), _ort("ort-nz", WP_NZ)]
+    preset = _preset("preset-handversand", ["ohne-zone", "ort-nz"], D23)
+
+    from utils.timezone import resolve_location_tz
+
+    assert resolve_location_tz(orte[0]) is None, (
+        "Testaufbau nicht diskriminierend: der erste Ort muss UNAUFLÖSBAR sein, "
+        "sonst belegt der Test nicht, dass übersprungen statt zurückgefallen wird"
+    )
+
+    with freeze_time(MITTAGS_UTC):
+        _anker(MITTAGS_UTC, WELLINGTON_ZONE, D21)
+        _uhr_eingefroren(MITTAGS_UTC)
+        servertag = date.today()
+        with pytest.raises(_ZieltagGesehen) as gesehen:
+            send_one_compare_preset(
+                preset, settings_email_only(), "default", str(Path("/nicht/benutzt")),
+                all_locations_cache=orte,
+            )
+
+    assert gesehen.value.target_date == D21, (
+        f"AC-7: der Einzelversand lief auf den Zieltag "
+        f"{gesehen.value.target_date}, erwartet {D21} (Ortstag des ersten "
+        f"auflösbaren Orts). {servertag} heißt: date.today() — der Betreff, die "
+        f"Vergleichs-Engine und der Δ-Anker-Versatz stehen dann auf zwei "
+        f"verschiedenen Tagesbegriffen."
+    )
+
+
+def test_ac7_beide_fehlerpfade_behalten_ihre_reihenfolge(monkeypatch):
+    """AC-7, Invariante — der externe Vertrag bleibt unverändert.
+
+    GIVEN ein Preset mit unauflösbaren Orten UND fehlendem Empfänger,
+    WHEN  der Einzelversand aufgerufen wird,
+    THEN  meldet er ZUERST den fehlenden Empfänger; die Orte-Prüfung kommt
+          danach. Die Ortsauflösung wandert für diesen Fix zwar VOR die
+          Zieltag-Bestimmung, darf die beiden Fehlerpfade aber nicht
+          umsortieren.
+
+    Dieser Test ist HEUTE GRÜN — er ist bewusst ein Regressions-Riegel für die
+    Umstellung, kein Bug-Nachweis (die Reihenfolge ist heute richtig und soll
+    es bleiben).
+    """
+    _engine_sonde(monkeypatch)
+    preset = _preset("preset-ohne-empfaenger", ["gibt-es-nicht"], D23)
+
+    with pytest.raises(ValueError) as fehler:
+        send_one_compare_preset(
+            preset, settings_no_channel_reachable(), "default",
+            str(Path("/nicht/benutzt")), all_locations_cache=[],
+        )
+
+    assert "mail_to" in str(fehler.value), (
+        f"AC-7 (Invariante): gemeldet wurde {str(fehler.value)!r}. Erwartet war "
+        "zuerst der fehlende Empfänger (mail_to) — die vorgezogene "
+        "Ortsauflösung hat die Reihenfolge der beiden Fehlerpfade verschoben."
+    )
+
+
+# ═════════ AC-3/AC-9: der Parameter schlägt die Umgebungsuhr ═════════
+#
+# Alle Tests oben frieren die Uhr auf DENSELBEN Zeitpunkt ein, den sie als
+# `now_utc` hereinreichen. `freeze_time` patcht `datetime.now()`/`date.today()`
+# global — damit sind Parameterwert und Systemuhr dort IMMER identisch, und die
+# zweite Hälfte von ADR-0051 Regel 3 („jetzt kommt vom Aufrufer“) ist
+# strukturell nicht falsifizierbar. Eine Verfälschung, die den Pflichtparameter
+# STEHEN lässt und im Rumpf trotzdem `date.today()` benutzt, bliebe ungefangen —
+# genau die Lücke, an der in S5a fünf von sechs Aufrufstellen blind waren
+# (Adversary F001). Die Fälle unten ziehen die beiden Zeitpunkte auseinander.
+#
+# Fachlich trägt diese Familie AC-3: zwischen der Zeitbindung in
+# `_send_trip_report_outcome` und den Ausblicks-Funktionen liegt ein echter
+# Wetterabruf mit Retry-Backoff — dort kann eine Mitternacht liegen (gemessener
+# Präzedenzfall: dispatch_orchestrator.py:157-163). Nur ein durchgereichter
+# Zeitpunkt hält den ganzen Briefing-Aufbau auf EINEM Tagesbegriff.
+
+FROST_UTC = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)   # Uhr: Ortstag 20.08.
+PARAM_UTC = datetime(2026, 8, 22, 12, 0, tzinfo=timezone.utc)   # Parameter: Ortstag 22.08.
+# Horizont-Grenze des PARAMETER-Ortstages: am 22.08. + 15 Tage gerade noch
+# drin, am 20.08. + 15 Tage schon draußen.
+HORIZON_PARAM = D22 + timedelta(days=15)                        # 06.09.2026
+
+
+def _fall_select_test_stage(tmp_path):
+    """Fundstelle 1 — welche Ersatz-Etappe wählt der Test-Versand?"""
+    trip = _trip("param-fallback", [D19, D21], WP_KORSIKA)
+    gewaehlt = _scheduler().select_test_stage(trip, "morning", now_utc=PARAM_UTC)
+    return getattr(gewaehlt, "date", None)
+
+
+def _fall_clamp_segments(tmp_path):
+    """Fundstelle 3 — um wie viele Tage wandern die Segmentzeiten?"""
+    trip = _trip("param-klemme", [D19], WP_KORSIKA)
+    segmente = convert_trip_to_segments(trip, D19)
+    ortstag = PARAM_UTC.astimezone(ZoneInfo(KORSIKA_ZONE)).date()
+    geklemmt = _scheduler()._clamp_segments_to_today(segmente, D19, today=ortstag)
+    return tuple(_ortstage(geklemmt))
+
+
+def _fall_stage_trend(tmp_path):
+    """Fundstelle 4 — welche künftige Etappe liegt im Vorhersage-Horizont?"""
+    trip = _trip("param-ausblick", [D20, HORIZON_PARAM], WP_KORSIKA)
+    scheduler = _scheduler()
+    scheduler._build_stage_trend(trip, D20, now_utc=PARAM_UTC)
+    return tuple(scheduler.abgerufen)
+
+
+def _fall_future_stage_weather(tmp_path):
+    """Fundstelle 5 — dasselbe für den Rückfall des Gewitter-Ausblicks."""
+    trip = _trip("param-gewitter", [D20, HORIZON_PARAM], WP_KORSIKA)
+    scheduler = _scheduler()
+    scheduler._collect_future_stage_weather(
+        trip, D20, now_utc=PARAM_UTC, wanted_dates={HORIZON_PARAM},
+    )
+    return tuple(scheduler.abgerufen)
+
+
+def _fall_pending_marker(tmp_path):
+    """Fundstelle 6 — verfällt der Versandfehler-Vermerk vom 20.08.?
+
+    Der Trip steht in ``due_trip_ids_now``; die Verfallsprüfung ist damit der
+    einzige Weg, den Vermerk zu entfernen.
+    """
+    trip = _trip("param-vermerk", [D20], WP_KORSIKA)
+    save_trip(trip)
+    _tour_ist_auffindbar(trip)
+    scheduler = _scheduler()
+    pfad = _vermerk_schreiben(scheduler, trip, D20)
+    scheduler._process_pending_markers(PARAM_UTC, {trip.id})
+    return tuple(_offene_vermerke(pfad))
+
+
+def _fall_auto_pause(tmp_path):
+    """Fundstelle 7 — wird das am 20.08. endende Preset pausiert?"""
+    presets = [_preset("param-preset", ["ort-korsika"], D20)]
+    data_root = _preset_ablage(tmp_path, presets)
+    _auto_pause_expired_presets(
+        presets, "default", data_root,
+        now_utc=PARAM_UTC, all_locations=[_ort("ort-korsika", WP_KORSIKA)],
+    )
+    return "pausiert" if _pausiert(tmp_path, "param-preset") else "aktiv"
+
+
+@pytest.mark.parametrize("fall, erwartet_parameter, erwartet_systemuhr", [
+    pytest.param(_fall_select_test_stage, D19, D21, id="select-test-stage"),
+    pytest.param(_fall_clamp_segments, (D22,), (D20,), id="clamp-segments"),
+    pytest.param(_fall_stage_trend, (HORIZON_PARAM,), (), id="stage-trend"),
+    pytest.param(_fall_future_stage_weather, (HORIZON_PARAM,), (),
+                 id="future-stage-weather"),
+    pytest.param(_fall_pending_marker, (), ("2026-08-20",), id="pending-marker"),
+    pytest.param(_fall_auto_pause, "pausiert", "aktiv", id="auto-pause"),
+])
+def test_versandpfade_folgen_dem_parameter_nicht_der_systemuhr(
+    fall, erwartet_parameter, erwartet_systemuhr, tmp_path,
+):
+    """AC-3 und AC-9 — die sechs Fundstellen mit Pflichtparameter müssen dem
+    ÜBERGEBENEN Zeitpunkt folgen, nicht der Uhr des Rechners.
+
+    GIVEN die Systemuhr steht auf dem 20.08. (Ortstag 20.08. auf Korsika),
+    WHEN  derselbe Aufruf ``now_utc`` = 22.08. hereinreicht (Ortstag 22.08.),
+    THEN  entspricht das Ergebnis dem 22.08. Ein Prüfling, der den
+          Pflichtparameter zwar entgegennimmt, im Rumpf aber ``date.today()``
+          benutzt, liefert stattdessen das Ergebnis zum 20.08.
+
+    Die beiden Erwartungswerte stehen literal nebeneinander und müssen
+    verschieden sein: das ist die Selbstprüfung, dass der Fall überhaupt
+    zwischen Parameter und Uhr unterscheiden KANN.
+
+    An den Fundstellen 2, 8 und 9 ist diese Probe strukturell unmöglich — dort
+    bleibt „jetzt“ bewusst funktionsintern (Spec „Known Limitations“); für sie
+    gilt allein die (a)-Prüfung weiter oben.
+    """
+    assert erwartet_parameter != erwartet_systemuhr, (
+        f"Testaufbau nicht diskriminierend: Parameter- und Systemuhr-Erwartung "
+        f"sind beide {erwartet_parameter!r} — der Fall kann nichts belegen"
+    )
+
+    with freeze_time(FROST_UTC):
+        tag_uhr = FROST_UTC.astimezone(ZoneInfo(KORSIKA_ZONE)).date()
+        tag_param = PARAM_UTC.astimezone(ZoneInfo(KORSIKA_ZONE)).date()
+        assert tag_uhr != tag_param, (
+            f"Testaufbau: Uhr ({tag_uhr}) und Parameter ({tag_param}) müssen "
+            "auf verschiedene ORTSTAGE fallen, nicht nur auf verschiedene "
+            "Uhrzeiten"
+        )
+        # Belegt, dass die eingefrorene Uhr im Prüfprozess wirklich greift —
+        # sonst wäre ein grüner Lauf kein Beweis, sondern ein Zufall.
+        _uhr_eingefroren(FROST_UTC)
+        beobachtet = fall(tmp_path)
+
+    hinweis = ""
+    if beobachtet == erwartet_systemuhr:
+        hinweis = (
+            f"\n  Das ist GENAU das Ergebnis zum {tag_uhr:%d.%m.%Y} — der "
+            "Prüfling hat den übergebenen Zeitpunkt ignoriert und die "
+            "Systemuhr benutzt (ADR-0051 Regel 3)."
+        )
+    assert beobachtet == erwartet_parameter, (
+        f"Der Versandpfad folgte nicht dem übergebenen Zeitpunkt.\n"
+        f"  übergeben:   {PARAM_UTC.isoformat()} (Ortstag {tag_param:%d.%m.%Y})\n"
+        f"  Systemuhr:   {FROST_UTC.isoformat()} (Ortstag {tag_uhr:%d.%m.%Y})\n"
+        f"  erwartet:    {erwartet_parameter!r}\n"
+        f"  beobachtet:  {beobachtet!r}{hinweis}"
+    )

--- a/tests/tdd/test_versandpfade_folgen_ortszone.py
+++ b/tests/tdd/test_versandpfade_folgen_ortszone.py
@@ -552,6 +552,48 @@ def test_ac5_preset_pausiert_nach_dem_ortstag_seines_ersten_orts(tmp_path):
     )
 
 
+def test_ac5_auto_pause_ueberspringt_den_unaufloesbaren_ersten_ort(tmp_path):
+    """AC-5, zweite Hälfte — „ERSTER AUFLÖSBARER Ort", nicht „Ort Nummer eins".
+
+    GIVEN dasselbe Preset wie oben, aber mit zwei Orten: der erste OHNE
+          auflösbare Zone (Ort ohne Koordinaten), der zweite in Neuseeland,
+    WHEN  der Versandlauf die Auto-Pause prüft,
+    THEN  wird es pausiert — die Zone kommt vom ZWEITEN Ort.
+
+    Eigener Fall, weil der Test darüber ihn nicht abdeckt: bei EINEM
+    auflösbaren Ort liefert ein stumpfer ``locations[0]``-Zugriff dasselbe
+    Ergebnis wie ``first_resolvable_tz`` — die Zusicherung „überspringen statt
+    zurückfallen" (#1378 AC-4, #1726 AC-15) wäre dort strukturell nicht
+    falsifizierbar. Ein Indexzugriff fällt hier still auf Weltzeit zurück, der
+    Ortstag bliebe der 20.08. und das Preset liefe einen Tag zu lange.
+    """
+    presets = [_preset("preset-zwei-orte", ["ohne-zone", "ort-nz"], D20)]
+    data_root = _preset_ablage(tmp_path, presets)
+    orte = [_ort("ohne-zone", None), _ort("ort-nz", WP_NZ)]
+
+    from utils.timezone import resolve_location_tz
+
+    assert resolve_location_tz(orte[0]) is None, (
+        "Testaufbau nicht diskriminierend: der erste Ort muss UNAUFLÖSBAR sein"
+    )
+
+    with freeze_time(MITTAGS_UTC):
+        _anker(MITTAGS_UTC, WELLINGTON_ZONE, D21)
+        _uhr_eingefroren(MITTAGS_UTC)
+        servertag = date.today()
+        _auto_pause_expired_presets(
+            presets, "default", data_root,
+            now_utc=MITTAGS_UTC, all_locations=orte,
+        )
+
+    assert _pausiert(tmp_path, "preset-zwei-orte"), (
+        f"AC-5: das Preset mit end_date {D20} wurde NICHT pausiert. Der erste "
+        f"konfigurierte Ort hat keine auflösbare Zone — wer ihn per Index nimmt, "
+        f"fällt still auf Weltzeit ({servertag}) zurück, statt zum zweiten Ort "
+        f"weiterzugehen (Ortstag {D21})."
+    )
+
+
 # ══════════════ AC-6: Datum im Präfix-Text aus der Zone des Trips ══════════════
 
 

--- a/tests/test_output_timezone_guard.py
+++ b/tests/test_output_timezone_guard.py
@@ -578,12 +578,15 @@ KNOWN_VIOLATIONS: dict[str, str] = {
     "src/output/renderers/alert/official_alerts.py::render_official_alert_sms::0": "Aufrufseite abgesichert (vormals :1690) — render_official_alert_sms (Wächter: test_production_callsites_pass_tz_explicitly).",
     "src/services/radar_service.py::format_now_text::0": "Aufrufseite abgesichert (vormals :219) — format_now_text (Wächter: test_production_callsites_pass_tz_explicitly).",
     "src/services/trip_report_scheduler.py::_build_stage_trend::0": "Aufrufseite abgesichert (vormals :1365) — _build_stage_trend (Wächter: test_production_callsites_pass_tz_explicitly).",
-    # ORDINAL-VERSCHIEBUNG (#1723): Muster A findet in _build_stage_trend ein
-    # `date.today()` (:1812) VOR dem Ternary (:1869) — der Ternary rutscht
-    # dadurch von ::1 auf ::2. Dieselben zwei Codestellen wie bisher, plus der
-    # neue Fund dazwischen; nichts gestrichen.
-    "src/services/trip_report_scheduler.py::_build_stage_trend::1": "Muster A (:1812) — `today = date.today()` datiert den Etappen-Trend auf die Serveruhr statt auf die Ortszeit der Etappe (#1726).",
-    "src/services/trip_report_scheduler.py::_build_stage_trend::2": "Aufrufseite abgesichert (vormals :1427, jetzt :1869) — Ternary-Rückfall zum Default von _build_stage_trend, daran gekoppelt.",
+    # ORDINAL-RUECKVERSCHIEBUNG (#1727 S5b): der Muster-A-Fund in
+    # _build_stage_trend (`today = date.today()`) ist behoben — er folgt jetzt
+    # `trip_local_today(trip, now_utc)`. Damit entfaellt der Eintrag ::1, und
+    # der Ternary rutscht von ::2 auf ::1 zurueck: die Gegenbewegung zu der mit
+    # #1723 hier dokumentierten Verschiebung (s. Kommentar-Historie). Es ist
+    # DIESELBE Codestelle wie bisher, nur mit kleinerem Ordinal; ohne diese
+    # Umbenennung meldete der Waechter ::2 als veraltet UND ::1 als neuen,
+    # unbekannten Verstoss, ohne dass sich dort etwas geaendert haette.
+    "src/services/trip_report_scheduler.py::_build_stage_trend::1": "Aufrufseite abgesichert (vormals :1427/:1869, Ordinal vormals ::2) — Ternary-Rückfall zum Default von _build_stage_trend, daran gekoppelt.",
     # -----------------------------------------------------------------------
     # ENTSCHEIDUNGS-SCHICHT (Issue #1723, Epic #1722 S1) — Bestandsaufnahme
     # von `src/services/**` + `api/**`, gemessen am 2026-08-11 gegen
@@ -610,23 +613,26 @@ KNOWN_VIOLATIONS: dict[str, str] = {
     "api/routers/compare.py::run_comparison::2": "Muster A (:58) — Zieltag 'morgen' vom Server, nicht vom Ort (#1726).",
     "api/routers/debug.py::trigger_radar_alert::0": "Muster A (:61) — Debug-Ausloeser datiert auf die Serveruhr (#1726).",
     "src/output/renderers/email/compare_html.py::_compute_next_send::0": "Muster A (:1377) — naechste Sendezeit gegen den Servertag geprueft (#1726).",
-    "src/services/alert_briefing_anchor.py::briefing_target_day_is_current::0": "Muster A (:169) — Briefing-Anker faellt auf den Servertag zurueck (#1726).",
+    # #1727 S5b: `briefing_target_day_is_current` hat keinen Systemuhr-
+    # Rueckfall mehr — `today` ist Pflicht und kommt als Ortstag der Tour vom
+    # Aufrufer. Eintrag entfaellt.
     "src/services/compare_preview_service.py::_resolve_target_date::0": "Muster A (:250) — Vorschau-Zieltag vom Server (#1726).",
     "src/services/comparison_engine.py::dict_to_comparison_result::0": "Muster A (:407) — Zieltag beim Einlesen vom Server (#1726).",
     "src/services/gpx_processing.py::compute_default_start_date::0": "Muster A (:189) — GPX-Vorgabestart vom Servertag (#1726).",
     "src/services/gpx_processing.py::compute_default_start_date::1": "Muster A (:193) — zweiter Rueckfall auf den Servertag (#1726).",
     "src/services/gpx_processing.py::gpx_to_stage_data::0": "Muster A (:223) — Etappendatum faellt auf den Servertag zurueck (#1726).",
-    "src/services/notification_service.py::_target_date_from_report::0": "Muster A (:1676) — Zieltag des Berichts vom Server (#1726).",
+    # #1727 S5b: `_target_date_from_report` leitet den Rueckfall-Tag aus
+    # `request.trip_tz` ab (Zone liegt am DTO bereits aufgeloest vor).
+    # Eintrag entfaellt.
     "src/services/official_alerts/massif_closure.py::_do_request::0": "Muster A (:102) — Abfrage-Datum der franzoesischen Quelle vom Server (#1726).",
     "src/services/official_alerts/massif_closure.py::fetch::0": "Muster A (:127) — Zeitstempel fuer `last_run` ohne Zone (#1726).",
     "src/services/official_alerts/meteo_forets.py::covers::0": "Muster A (:130) — Saison-Fenster gegen den Servermonat (#1726).",
     "src/services/preview_service.py::_resolve_target_date::0": "Muster A (:94) — Vorschau-Zieltag vom Server (#1726).",
-    "src/services/scheduler_dispatch_service.py::_auto_pause_expired_presets::0": "Muster A (:79) — Ablauf eines Presets gegen den Servertag (#1726).",
-    "src/services/scheduler_dispatch_service.py::send_one_compare_preset::0": "Muster A (:368) — Zieltag des Vergleichs-Versands vom Server (#1726).",
-    "src/services/trip_report_scheduler.py::_clamp_segments_to_today::0": "Muster A (:1497) — Segment-Beschnitt gegen den Servertag (#1726).",
-    "src/services/trip_report_scheduler.py::_collect_future_stage_weather::0": "Muster A (:2205) — 'zukuenftige Etappen' ab Servertag (#1726).",
-    "src/services/trip_report_scheduler.py::_send_trip_report_outcome::0": "Muster A (:932) — Test-Rueckfall vergleicht Zieltag mit Servertag (#1726).",
-    "src/services/trip_report_scheduler.py::select_test_stage::0": "Muster A (:765) — Test-Etappenwahl ab Servertag (#1726).",
+    # #1727 S5b: die sechs Versandpfad-Eintraege dieser Rubrik sind behoben —
+    # `_auto_pause_expired_presets` und `send_one_compare_preset` rechnen ueber
+    # `first_resolvable_tz(locations)` im Ortstag des Presets, die vier
+    # Scheduler-Stellen ueber `trip_local_today(trip, now_utc)` im Ortstag der
+    # Tour. Eintraege entfallen.
     # --- Muster B: festes Nicht-UTC-Zonen-Literal — mit #1726 vollstaendig
     # abgeraeumt (beide `VIENNA`-Konstanten ersatzlos entfallen). Bleibt als
     # Rubrik stehen: ein neuer Fund dieser Art gehoert behoben, nicht gelistet.

--- a/tests/unit/test_thunder_forecast_day_window.py
+++ b/tests/unit/test_thunder_forecast_day_window.py
@@ -34,6 +34,10 @@ from app.models import ThunderLevel
 _UTC = ZoneInfo("UTC")
 _TODAY = date(2026, 7, 3)
 _TOMORROW = date(2026, 7, 4)
+# #1727 S5b: `now_utc` ist Pflichtparameter. Dieser Test misst das Tagesfenster
+# an fertigen Trend-Zeilen — der Zeitpunkt spielt fuer die Zusicherung keine
+# Rolle, er passt hier nur zum Zieltag.
+_NOW_UTC = datetime(2026, 7, 3, 12, 0, tzinfo=timezone.utc)
 
 
 def _dp(day: date, hour: int, thunder: ThunderLevel = ThunderLevel.NONE):
@@ -152,7 +156,7 @@ def test_trend_nachtgewitter_ausserhalb_fenster_ist_entwarnung():
 
     row = _trend_row({2: ThunderLevel.LOW}, ThunderLevel.LOW)
     fc = TripReportSchedulerService()._build_thunder_forecast_from_trend_or_fetch(
-        None, _TODAY, _UTC, multi_day_trend=[row],
+        None, _TODAY, _NOW_UTC, _UTC, multi_day_trend=[row],
     )
     entry = (fc or {}).get("+1")
     assert entry is not None, "Trend-Zeile fuer morgen wurde nicht verwendet"
@@ -172,7 +176,7 @@ def test_trend_ab_stunde_kommt_aus_dem_fenster():
 
     row = _trend_row({2: ThunderLevel.LOW, 19: ThunderLevel.LOW}, ThunderLevel.LOW)
     fc = TripReportSchedulerService()._build_thunder_forecast_from_trend_or_fetch(
-        None, _TODAY, _UTC, multi_day_trend=[row],
+        None, _TODAY, _NOW_UTC, _UTC, multi_day_trend=[row],
     )
     entry = (fc or {}).get("+1")
     assert entry is not None
@@ -194,14 +198,25 @@ class _StubReportConfig:
 
 
 class _StubTrip:
-    """Echtes Datenobjekt (kein Mock): nur die zwei Zugriffe, die
-    _build_thunder_forecast_from_trend_or_fetch auf dem Trip macht."""
+    """Echtes Datenobjekt (kein Mock): nur die Zugriffe, die
+    _build_thunder_forecast_from_trend_or_fetch auf dem Trip macht.
+
+    #1727 S5b: seit der Rueckfall-Pfad den ORTSTAG der Tour bestimmt
+    (`trip_local_today` -> `anchor_tz` -> `display_tz`), sind es drei statt
+    zwei — `stages` und `get_stage_for_date` kommen dazu. Ohne Etappen faellt
+    die Zonenaufloesung auf UTC (`trip_day.trip_tz`); dieser Test misst das
+    Tagesfenster, nicht die Zone.
+    """
 
     def __init__(self, start, end):
         self.report_config = _StubReportConfig(start, end)
+        self.stages: list = []
 
     def get_future_stages(self, target_date):
         return []
+
+    def get_stage_for_date(self, day_date):
+        return None
 
 
 def test_konfiguriertes_fenster_wird_beachtet():
@@ -211,7 +226,7 @@ def test_konfiguriertes_fenster_wird_beachtet():
 
     row = _trend_row({5: ThunderLevel.LOW}, ThunderLevel.LOW)
     fc = TripReportSchedulerService()._build_thunder_forecast_from_trend_or_fetch(
-        _StubTrip(6, 18), _TODAY, _UTC, multi_day_trend=[row],
+        _StubTrip(6, 18), _TODAY, _NOW_UTC, _UTC, multi_day_trend=[row],
     )
     entry = (fc or {}).get("+1")
     assert entry is not None
@@ -231,7 +246,7 @@ def test_mitternachts_fenster_wrap_zaehlt_nachtstunden():
 
     row = _trend_row({23: ThunderLevel.LOW}, ThunderLevel.LOW)
     fc = TripReportSchedulerService()._build_thunder_forecast_from_trend_or_fetch(
-        _StubTrip(22, 2), _TODAY, _UTC, multi_day_trend=[row],
+        _StubTrip(22, 2), _TODAY, _NOW_UTC, _UTC, multi_day_trend=[row],
     )
     entry = (fc or {}).get("+1")
     assert entry is not None

--- a/tests/unit/test_thunder_night_addendum.py
+++ b/tests/unit/test_thunder_night_addendum.py
@@ -101,7 +101,8 @@ def _entry_from_trend(row, *, night_weather=None, key="+1"):
     if night_weather is not None:
         kwargs["night_weather"] = night_weather
     fc = TripReportSchedulerService()._build_thunder_forecast_from_trend_or_fetch(
-        None, _TODAY, _UTC, multi_day_trend=[row], **kwargs,
+        None, _TODAY, datetime.now(timezone.utc), _UTC,
+        multi_day_trend=[row], **kwargs,
     )
     return (fc or {}).get(key)
 

--- a/tests/unit/test_thunder_night_addendum_parity.py
+++ b/tests/unit/test_thunder_night_addendum_parity.py
@@ -319,7 +319,8 @@ def test_ac3_nacht_angabe_und_nacht_tabelle_nennen_dieselbe_stunde():
     row["date"] = date(2026, 7, 12)
 
     forecast = TripReportSchedulerService()._build_thunder_forecast_from_trend_or_fetch(
-        None, target, _UTC, multi_day_trend=[row], night_weather=night,
+        None, target, datetime.now(timezone.utc), _UTC,
+        multi_day_trend=[row], night_weather=night,
     )
 
     report = TripReportFormatter().format_email(


### PR DESCRIPTION
Scheibe S5b von #1727 (Epic #1722). **Das Issue bleibt offen** — S5c, S5d und S5e stehen aus.

## Was sich ändert

Neun Fundstellen im Trip- und Ortsvergleichs-Versand bestimmten den Kalendertag über die
Serveruhr (`date.today()`). Sie folgen jetzt dem Ortstag — bei einer Tour über
`trip_local_today(trip, now_utc)`, bei einem Preset über `first_resolvable_tz(locations)`.

**Alle neun wirken auf tatsächlich versendete Inhalte:**

| Fundstelle | Was daran hing |
|---|---|
| `select_test_stage` | welche Etappe der Test-Versand nimmt |
| `_send_trip_report_outcome` (Klemm-Vergleich) | ein bereits ortsrichtiger Zieltag wurde gegen den Servertag verglichen |
| `_clamp_segments_to_today` | um wie viele Tage das Wetter-Abruf-Fenster verschoben wird |
| `_build_stage_trend` | welche Zeilen im Ausblick erscheinen |
| `_collect_future_stage_weather` | dasselbe für den Gewitter-Ausblick |
| `briefing_target_day_is_current` | ob ein fehlgeschlagenes Briefing nachgeliefert oder verworfen wird |
| `_auto_pause_expired_presets` | wann ein Ortsvergleich automatisch pausiert |
| `_target_date_from_report` | das Datum im Test-/Nachliefer-/Teilausfall-Präfix |
| `send_one_compare_preset` | Zieltag und Δ-Anker des Compare-Einzelversands |

Damit ist die Einschätzung aus dem Zuschnitt-Kommentar des Tickets („sichtbar, aber ohne
Versand- oder Alarmwirkung") für die Restliste widerlegt — belegt vor Beginn der Arbeit,
Korrektur ist im Ticket gebucht.

## ADR-0051 Regel 3

Sechs der neun Stellen bekommen „jetzt" als **Pflichtparameter**. Der Briefing-Aufbau steht
damit auf **einer** Zeitabfrage — nötig, weil zwischen ihr und dem Ausblick ein Wetterabruf
mit Retry-Backoff liegt und dort eine Ortsmitternacht fallen kann. Der Präzedenzfall steht
seit #1661 im eigenen Code (`dispatch_orchestrator.py:157-163`: „und damit möglicherweise eine
Mitternacht").

An den Fundstellen `_send_trip_report_outcome`, `_target_date_from_report` und
`send_one_compare_preset` bleibt die Auflösung bewusst funktionsintern — jeweils **vor** jedem
Netzabruf. Diese Restlücke ist in der Spec unter „Known Limitations" benannt und bildet
zusammen mit `send_on_demand_report` die Folgescheibe.

## Nachweis

- **17 neue Verhaltenstests**, zwei Nachweisformen: Ortstag gegen Servertag überall,
  zusätzlich Parameter gegen Systemuhr an den sechs Stellen mit Pflichtparameter (Muster aus
  S5a-Befund F001, wo fünf von sechs Aufrufstellen dagegen blind waren)
- **148 grün** über alle berührten Dateien
- **Mutations-Gegenprobe: 12 von 12 gefangen.** Bemerkenswert: „nimm stumpf den ersten Ort
  statt des ersten *auflösbaren*" fängt **nur** der eigens dafür ergänzte zweite AC-5-Test;
  das Verschieben des `trip is None`-Ausstiegs hinter die Zonen-Auflösung macht 17
  **vorbestehende** Tests rot
- **Adversary VERIFIED**, 0 Findings, 12/12 Checklistenpunkte
- Vollständige Suite offline: 4 rot, alle als vorbestehend nachgewiesen — die zwei im
  Klemm-Pfad per A/B gegen einen Wegwerf-Abzug des Vorzustands (identische Fehlschläge ohne
  diese Änderung), die Datei steht zudem in `.github/ci_tdd_excludes.txt`

## Wächter

Neun `KNOWN_VIOLATIONS`-Einträge entfallen, einschließlich der **Ordinal-Rückverschiebung**
`_build_stage_trend::2` → `::1`: ohne sie meldet der Wächter einen unveränderten Eintrag als
veraltet *und* als neuen Verstoß. Die ADR-0044-Restliste ist nachgezogen — die neun Stellen
standen dort bislang gar nicht.

## Umfang

6 Produktivdateien, +188/−40. Die Richtlinie nennt maximal 5; die sechste ist
`preview_service.py` mit zwei durchgereichten Argumenten, mechanisch erzwungen, weil die
Vorschau dieselben Scheduler-Methoden aufruft. Zeilenlimit mit 188 von 250 eingehalten.

Spec: `docs/specs/modules/fix_1727_s5b_versandpfade_ortstag.md` (9 ACs, PO-freigegeben)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSU1on9gyRdvj3MRv8e9yd
