### PR TITLE
fix(#1756): Idempotenz-Lock gegen doppelten manuellen Trip-Versand

### DIFF
--- a/api/routers/scheduler.py
+++ b/api/routers/scheduler.py
@@ -276,6 +276,14 @@ def send_test_trip_report(trip_id: str, user_id: str = "default", report_type: s
                 "nicht erreichbar)"
             ),
         )
+    # Issue #1756: ein zweiter Sendeversuch waehrend ein erster fuer
+    # denselben Schluessel noch laeuft wird abgewiesen statt parallel
+    # ausgefuehrt (Doppelversand-Schutz).
+    if outcome == "already_in_progress":
+        raise HTTPException(
+            status_code=409,
+            detail=f"Versand für {report_type} läuft bereits — bitte warten",
+        )
     return {"status": "ok", "trip_id": trip_id, "report_type": report_type, "sent": True}
 
 

--- a/docs/context/fix-1756-send-timeout-502.md
+++ b/docs/context/fix-1756-send-timeout-502.md
@@ -1,0 +1,154 @@
+# Context: fix-1756-send-timeout-502
+
+## Request Summary
+Der manuelle Sendeknopf im Trip-Editor (`POST /api/trips/{id}/send`) liefert nach ~60s einen 502
+im Browser, obwohl der Versand im Hintergrund 3–4 Minuten später trotzdem erfolgreich abschließt.
+Kein Erfolgs-Feedback, Risiko doppelter Zustellung durch Wiederholungsklicks.
+
+## Root-Cause-Verifikation (heute nachgemessen, nicht nur aus dem Issue übernommen)
+
+1. **Timeout-Quelle gefunden:** `/home/hem/henemm-infra/nginx/gregor20.henemm.com.conf` setzt
+   **kein** `proxy_read_timeout` — es greift Nginx' Default von **60s**. Das erklärt den exakten
+   60,0s-Cutoff aus dem Issue-Log; der Go-Client-Timeout (120s, `proxy.go:275`) wird nie erreicht,
+   weil Nginx vorher killt. Diese Datei liegt in einem **anderen Repo** (`henemm-infra`) — eine
+   reine Timeout-Anhebung müsste dort separat ausgeliefert werden (Cross-Repo-Änderung).
+2. **Laufzeit-Ursache bestätigt, aber kein Bug:** `_send_trip_report_outcome()`
+   (`src/services/trip_report_scheduler.py:1001`) baut für `evening` standardmäßig den
+   Mehrtages-Ausblick (`_build_stage_trend`, Zeile ~1242, aktiv wenn
+   `render_options.show_multi_day_trend`) und darauf aufbauend die Gewitter-Vorschau
+   (`_build_thunder_forecast_from_trend_or_fetch`). Das ist **beabsichtigter Bestandteil** des
+   Abend-Briefings — der Testversand soll ja exakt das zeigen, was auch real verschickt wird
+   (`docs/specs/_archive/modules/issue_695_test_briefing_send.md`, AC-4: "sendet ... genau das
+   E-Mail-Briefing"). Die Langsamkeit selbst liegt am bekannten Ein-Request-je-Zeitschritt-je-
+   Parameter-Abruf bei DWD (`providers/dwd.py`, ~7–20s/Segment) für die künftigen Tage.
+3. **Kein Idempotenz-Schutz gefunden:** Weder Backend (`api/routers/scheduler.py`,
+   `trip_report_scheduler.py`) noch Frontend haben einen serverseitigen Lock/Dedup gegen einen
+   zweiten Sendeversuch für denselben Trip+`report_type` während ein erster noch läuft. Der
+   Frontend-Button sperrt nur, solange `testBriefingLoading` in DERSELBEN Browser-Session true
+   ist — sobald der 502 zurückkommt, wird `testBriefingLoading` in `finally` wieder `false`
+   (`+page.svelte:246`), der Button ist wieder klickbar, obwohl der erste Versand serverseitig
+   noch läuft. Genau das erzeugte im Issue-Log zwei echte POSTs 68s auseinander.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `internal/handler/proxy.go:254-293` (`SendTripReportProxyHandler`) | Synchroner Go-Proxy, `client.Timeout: 120s`, gibt bei jedem `client.Do`-Fehler pauschal 502 zurück — unterscheidet nicht zwischen "Upstream tot" und "Upstream noch am Rechnen" |
+| `api/routers/scheduler.py:205-279` (`send_test_trip_report`) | Python-Endpunkt, synchron, ruft `send_test_report_outcome()` und blockt bis zum fertigen Versand |
+| `src/services/trip_report_scheduler.py:908-935` (`send_test_report_outcome`) | Öffentlicher Outcome-Wrapper, `allow_test_fallback=True, angefordert=True` |
+| `src/services/trip_report_scheduler.py:1001-1330` (`_send_trip_report_outcome`) | Kernpfad: Segmente, Wetterabruf, Mehrtages-Ausblick, Gewitter-Vorschau, Versand — hier entsteht die Laufzeit |
+| `src/services/trip_report_scheduler.py:1721-1850` (`_fetch_weather`) | Pro-Segment-Abruf mit Retry/Backoff — läuft für JEDES Ausblick-Segment, nicht nur die angefragte Etappe |
+| `providers/dwd.py` | Bekannter langsamer Pfad: ein API-Request je Zeitschritt je Parameter (siehe Memory `reference_gewitter_apis_vier_dienste_und_eichung.md`) |
+| `frontend/src/routes/trips/[id]/+page.svelte:209-250` (`handleTestBriefing`) | Blockierender `fetch`, kein serverseitiger Lock, `testBriefingLoading` wird bei jedem Abschluss (auch Fehler) zurückgesetzt |
+| `/home/hem/henemm-infra/nginx/gregor20.henemm.com.conf` | Kein `proxy_read_timeout` gesetzt → Nginx-Default 60s greift; **anderes Repo** |
+| `docs/specs/_archive/modules/issue_695_test_briefing_send.md` | Ursprüngliche Spec des Sendeknopfs — synchrones Design war zum Zeitpunkt (#695) bewusste Entscheidung, AC-4 verlangt inhaltliche Deckungsgleichheit mit dem echten Versand |
+
+## Existing Patterns
+
+- **Kein Async-Job/Poll-Muster im Code vorhanden** (`BackgroundTasks`, `job_id`, o. ä. — Grep über
+  `api/` und `src/services/` ergab nichts). Ein Poll-basiertes Muster für diesen Bug wäre
+  architektonisches Neuland in diesem Projekt, kein Wiederverwenden eines bestehenden Bausteins.
+- Der bestehende `/api/scheduler/status`-Endpoint trackt bereits `last_run`/Fehler pro
+  Scheduler-Job (siehe CLAUDE.md "Monitoring") — strukturell ähnlich zu dem, was ein
+  Status-Poll-Endpoint für den Testversand bräuchte, aber für Cron-Jobs, nicht für
+  On-Demand-Sends pro Trip.
+- `send_on_demand_report()` (Zeile 936ff.) ist ein Geschwisterpfad (SMS "heute"/"morgen") mit
+  demselben `_send_trip_report_outcome()`-Kern — eine Lösung, die dort ebenfalls durchschlägt,
+  sollte geprüft werden, ist aber laut Issue nicht gemeldet (SMS-Inbound hat vermutlich andere
+  Zeitbudgets/keinen synchronen Browser-Request).
+
+## Dependencies
+
+- **Upstream:** `NotificationService` (Renderer + Versand), `SegmentWeatherService` →
+  `providers/openmeteo.py` + `providers/dwd.py` (Gewitter-Anreicherung), `WeatherPatternService`
+  (Stabilitäts-Label)
+- **Downstream:** Nur der Trip-Editor-Sendeknopf (`+page.svelte`) konsumiert
+  `POST /api/trips/{id}/send` — kein weiterer bekannter Aufrufer dieses spezifischen Go-Routes.
+  `send_test_report_outcome()` selbst hat laut Docstring **6 bestehende bool-Aufrufer** über
+  `send_test_report()` (unangetastet, nicht Teil dieses Bugs) plus den einen
+  Outcome-Aufrufer hier.
+
+## Existing Specs
+- `docs/specs/_archive/modules/issue_695_test_briefing_send.md` — Ursprungs-Spec des Sendeknopfs (archiviert)
+
+## Risks & Considerations
+
+- **Cross-Repo-Anteil:** Eine reine Nginx-Timeout-Anhebung liegt in `henemm-infra`, nicht in
+  diesem Repo — wenn die Lösung diesen Hebel braucht, ist eine MQ-Nachricht an `infra` oder ein
+  separater PR dort nötig. Timeout-Anhebung allein behebt laut Issue-Vorschlag ohnehin nicht die
+  zugrunde liegende Langsamkeit.
+- **Inhaltliche Parität wahren:** Der Testversand-Button soll weiterhin exakt das senden, was der
+  echte Abend-Report enthält (AC-4 aus #695) — den Mehrtages-Ausblick für den Testpfad einfach
+  wegzulassen würde diese Garantie brechen und wäre eine stille Verhaltensänderung.
+- **Idempotenz/Doppel-Versand ist der eigentliche Schaden**, nicht nur die falsche
+  Fehlermeldung — jede Lösung muss einen zweiten Klick während eines laufenden Sends
+  server-seitig abfangen (bisher nicht vorhanden), sonst bleibt das Kernrisiko aus dem Issue
+  auch nach einem UI-Fix bestehen.
+- **Mandantenfähigkeit:** Ein etwaiger Lock/Status muss pro `user_id` + `trip_id` (+ `report_type`)
+  scopen, nicht global — sonst blockiert Nutzer A den Testversand von Nutzer B.
+- **Go-Proxy unterscheidet nicht** zwischen "Python tot" und "Python rechnet noch" — beides
+  landet aktuell als generisches 502 `upstream unreachable`, was die irreführende Fehlermeldung
+  im Issue erklärt.
+
+## Analysis
+
+### Type
+Bug
+
+### Optionen-Bewertung (Plan/Sonnet-Agent, gegengeprüft gegen `proxy.go`/`scheduler.py`/`+page.svelte`)
+
+| Option | Ansatz | Idempotenz gelöst? | Scope | Risiko |
+|---|---|---|---|---|
+| A — nur Timeout-Kette anheben | Nginx `proxy_read_timeout` + Go `client.Timeout` hoch | Nein | ~5 LoC, cross-repo | gering, aber unzureichend |
+| B — voller Async/Poll | 202+`job_id`, neuer Status-Endpoint, Frontend-Poll-Loop, State-Store | Ja (Nebenprodukt) | deutlich >250 LoC, sprengt Standard-Budget | architektonisches Neuland, kein bestehendes Muster |
+| **C — In-Process-Lock + Timeout-Anhebung (empfohlen)** | Lock `(user_id, trip_id, report_type)` um `_send_trip_report_outcome()`, bei Belegung 409 statt 502; Timeout-Kette moderat hoch als Trittstein | **Ja, direkt** | ~60–90 LoC Hauptrepo + kleine Nginx-Änderung (nicht Budget-relevant) | gering — nutzt bestehendes Fehler-Response-Schema (analog no_stage/no_weather/no_channels) |
+
+### Affected Files (with changes) — Option C
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/services/trip_report_scheduler.py` | MODIFY | In-Process-Lock (Dict + `threading.Lock`, Key `(user_id, trip_id, report_type)`) um `_send_trip_report_outcome()`-Aufruf im Test-Pfad; bei Belegung eigener Outcome-Wert statt normalem Ablauf |
+| `api/routers/scheduler.py` | MODIFY | Neuer Outcome → HTTP 409 mit sprechendem Detail ("Versand läuft bereits"), analog zu bestehenden 422-Zweigen |
+| `internal/handler/proxy.go` | MODIFY | `client.Timeout` moderat anheben (z. B. 300s); 409 unverändert durchreichen (Passthrough funktioniert bereits generisch über `resp.StatusCode`) |
+| `frontend/src/routes/trips/[id]/+page.svelte` | MODIFY | 409 → eigene Meldung ("Versand läuft bereits, bitte warten") statt genereller Fehlermeldung; kein automatischer Retry |
+| `henemm-infra/nginx/gregor20.henemm.com.conf` | MODIFY (anderes Repo) | `proxy_read_timeout` setzen (z. B. 300s), synchron zu Go-Timeout — per MQ-Nachricht an `infra` |
+
+### Scope Assessment
+- Files: 4 im Hauptrepo + 1 im `henemm-infra`-Repo
+- Estimated LoC: ~60–90 (Hauptrepo, unter dem 250-LoC-Standard-Budget)
+- Risk Level: LOW — kein neues Architekturmuster, Lock hängt sich an bestehendes Fehler-Schema
+
+### Technical Approach
+**Empfehlung: Option C.** Das Issue benennt zwei Symptome, aber nur eines ist der tatsächliche
+Schaden: das reale Doppel-Zustellungsrisiko durch fehlende Idempotenz-Sperre — nicht die
+irreführende 502-Meldung als solche. Option C behebt das direkt und ursächlich mit minimalem,
+bestehende Patterns nutzendem Code, bleibt sicher unter dem LoC-Budget und führt keine neue
+Architektur-Kategorie (Async/Polling) ein, die es im Projekt noch nie gab (größtes Neurisiko
+bei Option B). Die Timeout-Anhebung (Kern von Option A) wird als Trittstein mitgenommen, aber
+nicht als alleinige Lösung — die 3–4 Minuten Wartezeit bleiben, sind aber mit ehrlicher
+Fehlermeldung bei Doppelklick vertretbar und wahren die Paritäts-Garantie aus AC-4 (#695), da
+der synchrone Pfad unverändert bleibt. Volles Async/Polling (Option B) bleibt eine legitime
+spätere Ausbaustufe, falls „minutenlanges blindes Warten" selbst zum wiederkehrenden
+Beschwerdepunkt wird.
+
+**Einschränkung dokumentieren:** Der In-Process-Lock wirkt nur pro Systemd-Prozess. Laut
+Architektur laufen `gregor-python`/`-staging` je als ein Prozess — unkritisch, aber als Kommentar
+im Code festhalten, falls das Deployment künftig auf Multi-Worker wechselt.
+
+### Dependencies
+- Upstream: keine neuen Abhängigkeiten — nutzt bestehendes Fehler-Response-Schema in
+  `scheduler.py` (422-Zweige) als Vorbild für den neuen 409-Zweig.
+- Downstream: `send_test_report()` (6 bestehende bool-Aufrufer) bleibt unberührt — anderer
+  Codepfad, nicht der hier geänderte `send_test_report_outcome()`-Wrapper.
+- Reihenfolge: zuerst Python-Lock + Router-Mapping + Go-Passthrough + Frontend im Hauptrepo
+  (dieser Workflow), danach MQ-Nachricht an `infra` für die Nginx-Timeout-Anhebung — beide
+  unabhängig deploybar, aber der Lock sollte zuerst live sein, damit auch vor der
+  Infra-Änderung kein Doppelversand mehr möglich ist.
+
+### Open Questions
+- [ ] Soll `send_on_demand_report()` (SMS "heute"/"morgen", derselbe `_send_trip_report_outcome()`-Kern) denselben Lock mitbekommen, obwohl im Issue nicht gemeldet? (Empfehlung: ja, gleicher Lock-Key-Raum, minimal-invasiv, verhindert dieselbe Klasse Doppelversand über einen anderen Trigger)
+- [ ] 409-Text im Frontend: reicht eine einfache Meldung, oder soll der Button währenddessen einen Poll starten, um automatisch auf "gesendet" umzuschalten? (Empfehlung: nein für diesen Fix — das wäre bereits ein Stück Option B; einfache Meldung reicht, User kann Seite neu laden)
+
+## Next Step
+Weiter mit `/20-analyse` zur Lösungsoptionen-Bewertung (Async/Poll vs. schlankerer Testpfad vs.
+Timeout-Kette) und Empfehlung.

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -1,7 +1,13 @@
 
 # API Contract — Gregor Zwanzig
 
-**Updated:** 2026-08-11 (Issue #1719 Scheibe S3, `fix-1719-s3-aus-ist-ein-zustand` — die
+**Updated:** 2026-08-14 (Issue #1756 — Send-Idempotenz-Lock: `POST /api/trips/{trip_id}/send`
+lehnt einen zweiten Sendeversuch für denselben `(user_id, trip_id, report_type)`-Schlüssel,
+während ein erster noch läuft, jetzt mit neuem Statuscode 409 ab statt einen echten
+Doppelversand auszulösen (Prozess-lokaler `threading.Lock`, keine Persistenz); Go-Proxy-Timeout
+in `SendTripReportProxyHandler` von 120s auf 300s angehoben, da der reguläre Erfolgsfall durch
+den vollständigen Mehrtages-Ausblick 3–4 Minuten dauern kann. Details Section 14.5, Spec
+`docs/specs/modules/fix_1756_send_idempotenz_lock.md`); 2026-08-11 (Issue #1719 Scheibe S3, `fix-1719-s3-aus-ist-ein-zustand` — die
 Live-Vorschau „So kommt es an" ist auf PO-Entscheid ersatzlos entfernt:
 `WeatherV2MailPreview.svelte` (der einzige Live-Konsument des unten beschriebenen
 `/api/_validator/sms-fidelity-preview`) ist gelöscht, ebenso `trip-detail/smsFidelityPreview.ts`.
@@ -1319,9 +1325,12 @@ Triggers immediate test briefing send for one trip. Returns success/failure base
 | Status | Scenario | Detail |
 |--------|----------|--------|
 | 404 | Trip `trip_id` not found for user | `"Trip {trip_id} not found"` |
+| 409 | Another send for the same `(user_id, trip_id, report_type)` is already in progress (Issue #1756) | `"Versand für {report_type} läuft bereits — bitte warten"` |
 | 422 | SMTP not configured for user (Issue #474) | `"SMTP not configured for this user"` |
 | 422 | No stages for target date (Bug #716 — AC-1) | `"Kein Briefing für {report_type} — keine Etappendaten für das aktuelle Datum"` |
 | 422 | Invalid `report_type` | `"Invalid report_type: {value}"` |
+
+**Idempotenz (Issue #1756):** Ein zweiter Aufruf für denselben `(user_id, trip_id, report_type)`-Schlüssel während ein erster Versand noch läuft (z. B. wiederholter Klick nach vorzeitigem Proxy-Timeout) wird mit HTTP 409 abgewiesen statt einen zweiten echten Versand auszulösen. Der Lock ist prozesslokal (`threading.Lock`, In-Memory), keine Persistenz. Der Go-Proxy (`SendTripReportProxyHandler`) hat außerdem einen auf 300s (vorher 120s) angehobenen Timeout, da der reguläre Erfolgsfall durch den vollständigen Mehrtages-Ausblick 3–4 Minuten dauern kann.
 
 **Multi-Tenant Behavior:**
 - `user_id` query parameter determines which user's data (trip, email config) is used

--- a/docs/specs/modules/fix_1756_send_idempotenz_lock.md
+++ b/docs/specs/modules/fix_1756_send_idempotenz_lock.md
@@ -1,0 +1,253 @@
+---
+entity_id: fix_1756_send_idempotenz_lock
+type: module
+created: 2026-08-14
+updated: 2026-08-14
+status: draft
+version: "1.0"
+tags: [bug, scheduler, mandantenfaehigkeit]
+---
+
+# Send-Idempotenz-Lock für manuellen Trip-Versand (Issue #1756)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Der manuelle Sendeknopf im Trip-Editor liefert nach ~60s einen 502, obwohl der
+Versand serverseitig 3–4 Minuten später trotzdem erfolgreich abschließt. Ohne
+serverseitigen Schutz kann ein zweiter Klick (verleitet durch die
+irreführende Fehlermeldung) während eines laufenden Versands einen echten
+zweiten Versand desselben Briefings auslösen. Diese Spec führt einen
+In-Process-Lock pro `(user_id, trip_id, report_type)` ein, der einen
+zweiten gleichzeitigen Sendeversuch mit HTTP 409 abweist statt ihn parallel
+auszuführen, plus eine moderate Anhebung der Timeout-Kette als Trittstein
+für den regulären Erfolgsfall.
+
+## Source
+
+- **File:** `src/services/trip_report_scheduler.py`
+- **Identifier:** `TripReportSchedulerService._send_trip_report_outcome`, `TripReportSchedulerService.send_test_report_outcome`, `TripReportSchedulerService.send_on_demand_report`
+
+> **Schicht-Hinweis:** Diese Spec berührt alle drei Schichten:
+> - **Python-Core / Domain-Backend** → `src/services/trip_report_scheduler.py` (Lock), `api/routers/scheduler.py` (409-Mapping)
+> - **Go-API** → `internal/handler/proxy.go` (`SendTripReportProxyHandler`, Timeout-Anhebung, 409-Passthrough bereits generisch vorhanden)
+> - **Frontend / User-UI** → `frontend/src/routes/trips/[id]/+page.svelte` (`handleTestBriefing`, 409-Meldungstext)
+>
+> Verifiziert per Grep der betroffenen Symbolnamen vor dem Schreiben dieser Spec (Zeilen unten mit Stand 2026-08-14).
+
+## Estimated Scope
+
+- **LoC:** ~60–90 (Hauptrepo, unter dem 250-LoC-Standard-Budget)
+- **Files:** 5 im Hauptrepo (`src/services/trip_report_scheduler.py`, `api/routers/scheduler.py`, `internal/handler/proxy.go`, `frontend/src/routes/trips/[id]/+page.svelte`, `src/services/trip_command_processor.py` — Nachtrag Adversary-Runde, s. AC-9); 1 Follow-up außerhalb des Repos (`henemm-infra`, siehe „Cross-Repo-Follow-up")
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `threading.Lock` (stdlib) | library | Prozess-lokale Sperre pro Lock-Key, kein neuer Fremd-Baustein |
+| `TripReportSchedulerService._send_trip_report_outcome` | internal | Kernpfad, der gesperrt wird — unverändert in seiner fachlichen Logik |
+| `api/routers/scheduler.py: send_test_trip_report` | internal | Bestehendes 422-Fehler-Schema als Vorbild für den neuen 409-Zweig |
+| `internal/handler/proxy.go: SendTripReportProxyHandler` | internal | Reicht `resp.StatusCode` bereits generisch durch — 409 braucht dort keine neue Fallunterscheidung, nur die Timeout-Konstante ändert sich |
+| `frontend/.../+page.svelte: handleTestBriefing` | internal | Generischer 4xx-Zweig zeigt `body.detail` bereits an (siehe Implementation Details) — Änderungsbedarf ggf. nur im Backend-Text |
+| `src/services/trip_command_processor.py: _on_demand_failure_body` | internal | Mappt Outcome → SMS-Antworttext für den On-Demand-Pfad (#1007); braucht einen Zweig für `already_in_progress`, sonst fällt der neue Outcome fälschlich auf den `no_stage`-Text zurück (Nachtrag Adversary-Runde) |
+
+## Implementation Details
+
+### 1. Lock im Python-Core (`src/services/trip_report_scheduler.py`)
+
+Modul-weites (nicht instanz-gebundenes!) Lock-Register, da pro Request eine
+neue `TripReportSchedulerService`-Instanz erzeugt wird
+(`api/routers/scheduler.py:229`: `service = TripReportSchedulerService(user_id=user_id)`)
+— ein Instanzattribut würde daher NIE mit sich selbst kollidieren:
+
+```python
+# Modul-Ebene, oberhalb der Klasse
+_send_locks: Dict[Tuple[str, str, str], bool] = {}
+_send_locks_guard = threading.Lock()
+
+
+def _try_acquire_send_lock(user_id: str, trip_id: str, report_type: str) -> bool:
+    key = (user_id, trip_id, report_type)
+    with _send_locks_guard:
+        if _send_locks.get(key):
+            return False
+        _send_locks[key] = True
+        return True
+
+
+def _release_send_lock(user_id: str, trip_id: str, report_type: str) -> None:
+    key = (user_id, trip_id, report_type)
+    with _send_locks_guard:
+        _send_locks.pop(key, None)
+```
+
+`send_test_report_outcome()` und `send_on_demand_report()` (beide rufen
+`_send_trip_report_outcome()` auf, Zeilen 908 und 936) klammern ihren
+jeweiligen Aufruf:
+
+```python
+if not _try_acquire_send_lock(self._user_id, trip.id, report_type):
+    return "already_in_progress"
+try:
+    return self._send_trip_report_outcome(...)
+finally:
+    _release_send_lock(self._user_id, trip.id, report_type)
+```
+
+`send_on_demand_report()` gibt `OnDemandErgebnis(outcome=..., zieltag=...)`
+zurück — der `"already_in_progress"`-Zweig braucht dort einen Platzhalter-
+`zieltag` (z. B. den bereits berechneten `zieltag` vor dem Lock-Versuch, da
+`_get_target_date` keine teure/blockierende Operation ist und vor dem
+Lock-Erwerb passieren kann, ohne die Sperrsemantik zu verändern).
+
+**Freigabe ist PFLICHT per `finally`** — ein Fehler im Sendepfad (Exception,
+Timeout) darf den Lock nicht dauerhaft belegt lassen, sonst wird aus dem
+502-Bug ein permanentes 409 nach dem ersten Absturz.
+
+### 2. Outcome-Mapping im Router (`api/routers/scheduler.py`)
+
+Neuer Zweig in `send_test_trip_report`, analog zu den bestehenden
+`no_stage`/`no_weather`/`no_channels`-422-Zweigen (Zeilen 219–260), aber mit
+HTTP 409 statt 422 (Ressourcen-Konflikt, nicht Validierungsfehler):
+
+```python
+if outcome == "already_in_progress":
+    raise HTTPException(
+        status_code=409,
+        detail=f"Versand für {report_type} läuft bereits — bitte warten",
+    )
+```
+
+`send_on_demand_report()` wird über den Inbound-Kommandopfad
+(`trip_command_processor`) aufgerufen, nicht über diesen HTTP-Router — dessen
+Aufrufer muss den neuen Outcome-Wert `"already_in_progress"` ebenfalls kennen
+(mindestens: nicht als Fehler loggen, sondern als erwarteten Kollisionsfall).
+
+### 3. Go-Proxy-Timeout (`internal/handler/proxy.go`)
+
+`SendTripReportProxyHandler` (Zeile ~254): `client := &http.Client{Timeout: 120 * time.Second}`
+wird auf `300 * time.Second` angehoben. Das 409-Passthrough ist bereits
+generisch implementiert (`w.WriteHeader(resp.StatusCode)`, Zeile ~289) —
+hier ist **keine Codeänderung** nötig, nur eine Verifikation per Test/Review,
+dass 409 unverändert durchgereicht wird.
+
+### 4. Frontend-Meldung (`frontend/src/routes/trips/[id]/+page.svelte`)
+
+`handleTestBriefing()` (Zeile 209 ff.) unterscheidet bereits zwischen
+`res.status >= 500` (generische Serverfehler-Meldung, `detail` wird
+absichtlich NICHT angezeigt) und dem `else`-Zweig, der `body.detail`
+anzeigt, sofern vorhanden (Zeile ~232). Ein 409 fällt strukturell bereits in
+diesen zweiten Zweig — die vom Backend gesetzte Detail-Meldung
+("Versand für … läuft bereits — bitte warten") erscheint damit **ohne
+weitere Frontend-Codeänderung**. Diese Spec verlangt trotzdem einen
+Frontend-Test (AC-7), der das für den 409-Fall explizit absichert, damit ein
+künftiges Refactoring dieses Zweigs den 409-Fall nicht versehentlich in die
+generische 5xx-Meldung verschiebt. Kein automatischer Retry, kein Poll —
+unverändert gegenüber dem bestehenden Verhalten.
+
+## Expected Behavior
+
+- **Input:** Zwei (quasi-)gleichzeitige `POST /api/trips/{id}/send`-Aufrufe
+  für denselben `user_id`+`trip_id`+`report_type`, während der erste Aufruf
+  noch läuft.
+- **Output:** Erster Aufruf läuft wie bisher durch (`"sent"`/`"no_stage"`/…).
+  Zweiter Aufruf erhält sofort HTTP 409 mit sprechendem Detail, OHNE dass ein
+  zweiter echter Versand angestoßen wird. Nach Abschluss des ersten Aufrufs
+  (Erfolg oder Fehler) ist ein neuer Versand für denselben Schlüssel wieder
+  möglich.
+- **Side effects:** Keine Persistenzänderung — der Lock lebt ausschließlich
+  im Prozessspeicher (Dict), kein Datei-/DB-Zustand. Wirkt nur innerhalb
+  eines Systemd-Prozesses (`gregor-python`/`-staging` laufen je als ein
+  Prozess — siehe „Known Limitations").
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Testversand für Trip A (User X, `report_type=evening`) läuft bereits / When während dieser Laufzeit ein zweiter `send_test_report_outcome()`-Aufruf für denselben Trip A, User X und `report_type=evening` erfolgt / Then liefert der zweite Aufruf den Outcome `"already_in_progress"`, OHNE dass ein zweiter echter Versand (E-Mail/Telegram/SMS) ausgelöst wird.
+  - Test: Zwei sequenzielle/simultane Aufrufe von `send_test_report_outcome()` im selben Prozess (Lock künstlich vorbelegt oder über einen blockierenden Mock im ersten Aufruf simuliert); prüfen, dass der Versand-Mock (Notification-Layer) nur EINMAL aufgerufen wird. Dies ist der Bug-Nachweis: rot vor Fix (heute läuft der zweite Aufruf ungehindert durch und ruft den Versand ein zweites Mal auf), grün nach Fix.
+
+- **AC-2:** Given kein Versand für Trip A, User X, `report_type=evening` läuft gerade / When `send_test_report_outcome()` aufgerufen wird / Then läuft der Versand wie bisher unverändert durch (Outcome bleibt `"sent"`/`"no_stage"`/`"no_weather"`/`"no_channels"`/`"channels_unreachable"`, keine Regression am bestehenden Verhalten aus #695/#1325).
+  - Test: Einzelner Aufruf ohne Lock-Kollision liefert denselben Outcome wie vor dieser Änderung (bestehende Tests aus #695/#1325 bleiben grün, ergänzt um einen expliziten „Lock wird danach wieder freigegeben"-Check).
+
+- **AC-3:** Given ein zweiter Aufruf trifft auf einen belegten Lock / When der Router-Endpunkt `POST /api/scheduler/trips/{trip_id}/send` den Outcome `"already_in_progress"` erhält / Then antwortet der Router mit HTTP 409 und einem sprechenden Detail-Text (z. B. "Versand für evening läuft bereits — bitte warten"), unterscheidbar von den bestehenden 422-Fehlerzweigen.
+  - Test: HTTP-Client-Test gegen den FastAPI-Router mit gemocktem `send_test_report_outcome()`-Rückgabewert `"already_in_progress"`; prüft Statuscode 409 und Vorhandensein eines nicht-leeren `detail`-Felds.
+
+- **AC-4:** Given ein Versand ist abgeschlossen (egal ob erfolgreich oder mit Exception beendet) / When derselbe Lock-Schlüssel danach erneut angefragt wird / Then wird der Lock erfolgreich neu erworben (kein dauerhaftes Blockieren nach einem einzelnen abgeschlossenen oder fehlgeschlagenen Versand).
+  - Test: `_send_trip_report_outcome()` wirft eine Exception (simuliert), anschließender zweiter Aufruf für denselben Schlüssel muss den Lock wieder frei vorfinden (nicht `"already_in_progress"` liefern) — beweist, dass die Freigabe per `finally` und nicht nur im Erfolgspfad passiert.
+
+- **AC-5:** Given zwei verschiedene Nutzer (User X und User Y) lösen jeweils gleichzeitig einen Testversand für ihren jeweils eigenen Trip mit identischer `trip_id` und identischem `report_type` aus (Mandantentrennung: `trip_id`s sind pro Nutzer eigene IDs, ein Zusammentreffen ist über Test-Fixtures gezielt herbeigeführt) / When beide Aufrufe zeitgleich laufen / Then blockiert keiner der beiden Aufrufe den anderen — beide erhalten unabhängig voneinander den Outcome ihres eigenen Versands, keiner `"already_in_progress"` durch den jeweils anderen Nutzer.
+  - Test: Zwei `TripReportSchedulerService`-Instanzen mit unterschiedlichem `user_id` (z. B. `"user_x"`, `"user_y"`), gleicher `trip_id`-String, gleicher `report_type`; beide Sendeversuche parallel/verschachtelt anstoßen und prüfen, dass beide durchlaufen (kein `"already_in_progress"` bei keinem der beiden). Pflicht-Zwei-Nutzer-Test gemäß CLAUDE.md-Mandantenfähigkeits-Vorgabe.
+
+- **AC-6:** Given `send_on_demand_report()` (SMS "heute"/"morgen"-Inbound-Pfad) nutzt denselben `_send_trip_report_outcome()`-Kern / When während eines laufenden On-Demand-Versands für Trip A, User X, `report_type` ein zweiter On-Demand-Aufruf für denselben Schlüssel eintrifft / Then liefert `send_on_demand_report()` ein `OnDemandErgebnis` mit `outcome="already_in_progress"`, ohne einen zweiten echten Versand auszulösen — derselbe Lock-Schutz wie im Testversand-Pfad (AC-1), gemeinsamer Lock-Key-Raum über beide Aufrufer hinweg.
+  - Test: Analog AC-1, aber über `send_on_demand_report()` statt `send_test_report_outcome()`; zusätzlich ein Test, der zeigt, dass ein laufender Testversand (`send_test_report_outcome`) einen gleichzeitigen On-Demand-Versand (`send_on_demand_report`) für denselben Schlüssel ebenfalls blockiert (geteilter Lock-Key-Raum, nicht zwei getrennte Register).
+
+- **AC-7:** Given der Trip-Editor erhält HTTP 409 vom Sende-Endpunkt / When `handleTestBriefing()` die Antwort verarbeitet / Then zeigt die Oberfläche die vom Backend gelieferte Detail-Meldung an (unterscheidbar von der generischen 5xx-"Serverfehler"-Meldung), OHNE einen automatischen Retry oder Poll auszulösen.
+  - Test: Frontend-Unit-/Component-Test mit gemocktem `fetch`, der 409 + `{"detail": "Versand für evening läuft bereits — bitte warten"}` zurückgibt; prüft, dass `testBriefingMessage` genau diesen Text (oder den Backend-Detail-Text) enthält und `testBriefingStatus` NICHT erneut `fetch` auslöst.
+
+- **AC-8:** Given der Go-Proxy-Handler `SendTripReportProxyHandler` / When der Python-Upstream länger als die bisherigen 120s, aber innerhalb von 300s antwortet / Then liefert der Go-Proxy die tatsächliche Antwort (inkl. 409-Fälle unverändert durchgereicht) statt eines generischen 502 "upstream unreachable".
+  - Test: Go-Test gegen `SendTripReportProxyHandler` mit einem simulierten Upstream, der z. B. nach 150s antwortet (oder Timeout-Konstante direkt inspiziert `client.Timeout == 300*time.Second`); zusätzlicher Test bestätigt, dass ein vom Upstream gelieferter 409-Statuscode unverändert im Response-StatusCode ankommt.
+
+- **AC-9 (Nachtrag Adversary-Runde, 2026-08-14):** Given der SMS-Inbound-Pfad "heute"/"morgen" löst über `send_on_demand_report()` einen Kollisionsfall aus (`outcome="already_in_progress"`, s. AC-6) / When `_on_demand_failure_body()` in `src/services/trip_command_processor.py` diesen Outcome in SMS-Antworttext übersetzt / Then liefert die Funktion einen Text, der den Kollisionsfall benennt (z. B. "Versand läuft bereits — bitte kurz warten"), NICHT den bestehenden `no_stage`-Fallback-Text ("Keine Etappe geplant"), der fachlich falsch wäre.
+  - Test: Direkter Unit-Test von `_on_demand_failure_body("already_in_progress", label, target_date)` (mock-frei, reine Mapping-Funktion, Muster: `tests/tdd/test_issue_1007_heute_voll_briefing.py`), prüft den zurückgegebenen Text auf Unterscheidbarkeit vom `no_stage`-Text.
+
+## Known Limitations
+
+- Der In-Process-Lock wirkt nur pro Systemd-Prozess. `gregor-python` und
+  `gregor-python-staging` laufen laut Architektur je als **ein** Prozess —
+  unkritisch heute, aber bei einem künftigen Wechsel auf Multi-Worker/
+  Multi-Prozess-Deployment würde der Lock nicht mehr prozessübergreifend
+  wirken. Als Kommentar im Code festhalten (siehe Implementation Details).
+- Die Nginx-`proxy_read_timeout`-Anhebung (siehe „Cross-Repo-Follow-up") ist
+  NICHT Teil dieses Workflows und muss separat in `henemm-infra` ausgeliefert
+  werden, damit der Erfolgsfall auch am produktiven Reverse-Proxy nicht mehr
+  vorzeitig abbricht. Der Lock allein löst bereits das Kernrisiko (Doppel-
+  Versand); ohne die Infra-Änderung bleibt die irreführende 502-Meldung im
+  Erfolgsfall vorerst bestehen, aber ohne Datenschaden.
+- Kein Async-/Poll-Muster (Option B aus der Analyse) — die 3–4 Minuten
+  Wartezeit für den Testversand bleiben bestehen. Bewusst nicht in dieser
+  Scheibe adressiert (siehe `docs/context/fix-1756-send-timeout-502.md`,
+  Abschnitt „Technical Approach").
+- **Renderer-Commit-Gate (#811):** nicht betroffen — diese Änderung fasst
+  keine Mail-Renderer-Dateien (`src/output/renderers/...`) an, nur den
+  Versand-Orchestrierungspfad (Lock) und die Fehler-Mapping-/Proxy-/UI-
+  Schicht darüber.
+- **Pendant-Gate (#1481 B):** nicht betroffen — keine neuen Dateien in
+  `frontend/src/lib/components/{compare,trip-detail,...}` oder in
+  präfigierten Renderer-Pfaden; die geänderte Datei
+  `frontend/src/routes/trips/[id]/+page.svelte` liegt außerhalb des vom
+  Gate erfassten Komponentenbaums.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Der In-Process-Lock ist ein lokaler Implementierungsdetail-
+  Fix innerhalb des bestehenden synchronen Sendepfads, keine Änderung an
+  einer der in CLAUDE.md gelisteten Entscheidungsflächen (Kanäle, Provider,
+  Datenmodell/Persistenz, Auth, Editor-Paradigma, Test-/Deploy-Strategie).
+  Die Timeout-Anhebung ist eine Konfigurationsanpassung, keine
+  Architekturentscheidung. Sollte ein künftiger Wechsel auf Multi-
+  Prozess-Deployment den Lock-Mechanismus selbst ersetzen müssen (z. B.
+  durch einen verteilten Lock), wäre DAS ein eigenes ADR-würdiges Thema —
+  nicht diese Scheibe.
+
+## Cross-Repo-Follow-up
+
+Die Nginx-`proxy_read_timeout`-Einstellung in
+`henemm-infra/nginx/gregor20.henemm.com.conf` (aktuell kein expliziter Wert
+gesetzt → Nginx-Default 60s greift, siehe Root-Cause-Verifikation in
+`docs/context/fix-1756-send-timeout-502.md`) liegt außerhalb dieses Repos
+und ist **nicht Teil der ACs dieses Workflows**. Empfehlung: `proxy_read_timeout 300s;`
+synchron zum neuen Go-Client-Timeout (AC-8) setzen, damit der Erfolgsfall
+(3–4 Minuten Laufzeit durch den absichtlich vollständigen Mehrtages-
+Ausblick) auch am produktiven Reverse-Proxy nicht mehr vorzeitig abbricht.
+Diese Änderung ist unabhängig deploybar; der Lock (AC-1–AC-6) löst das
+eigentliche Schadensrisiko (Doppelversand) bereits ohne sie. Nach Abschluss
+dieses Workflows: MQ-Nachricht an die `infra`-Instanz mit Verweis auf diese
+Spec und den empfohlenen Wert.
+
+## Changelog
+
+- 2026-08-14: Initial spec created (Issue #1756)

--- a/frontend/src/routes/trips/[id]/__tests__/testBriefingLockResponse.test.ts
+++ b/frontend/src/routes/trips/[id]/__tests__/testBriefingLockResponse.test.ts
@@ -1,0 +1,82 @@
+// Issue #1756 — AC-7: HTTP 409 ("already_in_progress") zeigt die Backend-
+// Detail-Meldung, unterscheidbar von der generischen 5xx-Serverfehler-
+// Meldung, OHNE automatischen Retry/Poll.
+// Spec: docs/specs/modules/fix_1756_send_idempotenz_lock.md — AC-7.
+//
+// doc-compliance-test (Quelltext-Pruefung). Grund identisch zu
+// pageServerEtagPassthrough.test.ts im selben Ordner: `+page.svelte`
+// importiert `$app/state`/`$app/navigation` — virtuelle SvelteKit-Module,
+// die node --test (kein vitest/jsdom in diesem Repo) nicht aufloesen kann.
+//
+// RED-Charakter: Mutations-Waechter, HEUTE BEREITS GRUEN. Laut Spec
+// (Implementation Details Punkt 4) faellt ein 409 strukturell bereits in
+// den bestehenden generischen 4xx-Zweig (`else if (detail)`), der die
+// Backend-Meldung anzeigt -- kein Frontend-Codeaenderung fuer AC-7 noetig.
+// Dieser Test ist deshalb bewusst ein Regressions-Waechter, keine
+// Bug-Reproduktion: sein Wert liegt darin, ein kuenftiges Refactoring
+// (z.B. den 409-Fall versehentlich in den >=500-Zweig verschieben) rot
+// werden zu lassen.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, '..', '+page.svelte'), 'utf-8');
+
+function handleTestBriefingBody(): string {
+	const start = src.indexOf('async function handleTestBriefing(');
+	assert.ok(start >= 0, 'handleTestBriefing() wurde in +page.svelte nicht gefunden');
+	const end = src.indexOf('\n\t}\n', start);
+	assert.ok(end > start, 'Funktionsende von handleTestBriefing() nicht gefunden');
+	return src.slice(start, end);
+}
+
+describe('AC-7: 409 "already_in_progress" zeigt die Backend-Meldung, kein Retry', () => {
+	test('test_handleTestBriefing_hasDistinctBranchForServerErrorsVs4xxDetail', () => {
+		const body = handleTestBriefingBody();
+		// Serverfehler-Zweig (>=500): generische Meldung, KEIN roher detail-Text.
+		assert.match(
+			body,
+			/res\.status\s*>=\s*500/,
+			'handleTestBriefing() unterscheidet nicht nach res.status >= 500 -- ' +
+				'ohne diesen Zweig waere ein 409 nicht von einem 5xx-Serverfehler unterscheidbar'
+		);
+		// 4xx-Zweig zeigt den Backend-Detail-Text (409 faellt hierher, da 409 < 500).
+		assert.match(
+			body,
+			/else\s+if\s*\(\s*detail\s*\)\s*\{\s*\n?\s*testBriefingMessage\s*=\s*detail\s*;/,
+			'handleTestBriefing() setzt testBriefingMessage bei einem 4xx mit detail (z.B. 409) ' +
+				'nicht auf den Backend-Detail-Text'
+		);
+	});
+
+	test('test_handleTestBriefing_500BranchDoesNotShowRawDetail', () => {
+		const body = handleTestBriefingBody();
+		const serverErrorIdx = body.search(/if\s*\(\s*res\.status\s*>=\s*500\s*\)\s*\{/);
+		assert.ok(serverErrorIdx >= 0, '>=500-Zweig nicht gefunden');
+		const elseIfIdx = body.indexOf('else if (detail)', serverErrorIdx);
+		assert.ok(elseIfIdx > serverErrorIdx, 'else-if(detail)-Zweig nicht NACH dem >=500-Zweig gefunden');
+		const serverErrorBranch = body.slice(serverErrorIdx, elseIfIdx);
+		assert.doesNotMatch(
+			serverErrorBranch,
+			/testBriefingMessage\s*=\s*detail\s*;/,
+			'Der >=500-Zweig darf den rohen detail-Text NICHT anzeigen -- sonst waere ein ' +
+				'409 nicht mehr von einem echten Serverfehler unterscheidbar, faellt ein Refactoring ' +
+				'den 409-Fall versehentlich in diesen Zweig'
+		);
+	});
+
+	test('test_handleTestBriefing_makesExactlyOneFetchCall_noAutoRetry', () => {
+		const body = handleTestBriefingBody();
+		const fetchCalls = body.match(/\bfetch\(/g) ?? [];
+		assert.equal(
+			fetchCalls.length,
+			1,
+			`handleTestBriefing() darf genau EINEN fetch()-Aufruf enthalten (kein automatischer ` +
+				`Retry/Poll bei 409), gefunden ${fetchCalls.length}`
+		);
+	});
+});

--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -272,7 +272,9 @@ func SendTripReportProxyHandler(pythonURL string) http.HandlerFunc {
 		}
 		req.Header.Set("Content-Type", "application/json")
 
-		client := &http.Client{Timeout: 120 * time.Second}
+		// Issue #1756 (AC-8): 120s -> 300s, der reguläre Erfolgsfall
+		// (vollständiger Mehrtages-Ausblick) braucht 3-4 Minuten.
+		client := &http.Client{Timeout: 300 * time.Second}
 		resp, err := client.Do(req)
 		if err != nil {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/handler/trip_send_timeout_test.go
+++ b/internal/handler/trip_send_timeout_test.go
@@ -1,0 +1,94 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/henemm/gregor-api/internal/middleware"
+)
+
+// Issue #1756 — SendTripReportProxyHandler: Timeout-Anhebung 120s -> 300s
+// (AC-8) plus 409-Passthrough. Spec: docs/specs/modules/fix_1756_send_idempotenz_lock.md
+
+func dispatchTripSend(h http.HandlerFunc, path, userID string) *httptest.ResponseRecorder {
+	r := chi.NewRouter()
+	r.Method("POST", "/api/trips/{id}/send", h)
+	req := httptest.NewRequest("POST", path, nil)
+	if userID != "" {
+		req = req.WithContext(middleware.ContextWithUserID(req.Context(), userID))
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func sendTripReportHandlerSource(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd() fehlgeschlagen: %v", err)
+	}
+	proxyPath := filepath.Join(wd, "proxy.go")
+	raw, err := os.ReadFile(proxyPath)
+	if err != nil {
+		t.Fatalf("proxy.go konnte nicht gelesen werden (%s): %v", proxyPath, err)
+	}
+	src := string(raw)
+
+	start := strings.Index(src, "func SendTripReportProxyHandler(")
+	if start < 0 {
+		t.Fatal("SendTripReportProxyHandler nicht in proxy.go gefunden")
+	}
+	rest := src[start:]
+	nextFunc := regexp.MustCompile(`\n}\n\n// \w`).FindStringIndex(rest)
+	if nextFunc == nil {
+		t.Fatal("Funktionsende von SendTripReportProxyHandler nicht gefunden")
+	}
+	return rest[:nextFunc[0]]
+}
+
+func TestSendTripReportProxyHandlerTimeoutIs300Seconds(t *testing.T) {
+	body := sendTripReportHandlerSource(t)
+
+	if strings.Contains(body, "120 * time.Second") {
+		t.Errorf("SendTripReportProxyHandler traegt noch den alten 120s-Timeout -- erwartet 300s (AC-8): %s",
+			body)
+	}
+	if !strings.Contains(body, "300 * time.Second") {
+		t.Errorf("SendTripReportProxyHandler traegt keinen 300s-Timeout (AC-8). Funktionskoerper: %s", body)
+	}
+}
+
+func startFakeSchedulerPython(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/scheduler/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestSendTripReportProxyHandlerPropagates409(t *testing.T) {
+	py := startFakeSchedulerPython(t, 409, `{"detail":"Versand fuer evening laeuft bereits - bitte warten"}`)
+
+	h := SendTripReportProxyHandler(py.URL)
+	w := dispatchTripSend(h, "/api/trips/korsika/send?report_type=evening", "alice")
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409 to propagate from Python, got %d (body=%q)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "laeuft bereits") {
+		t.Errorf("expected upstream detail body to pass through unchanged, got %q", w.Body.String())
+	}
+}

--- a/src/services/trip_command_processor.py
+++ b/src/services/trip_command_processor.py
@@ -241,7 +241,7 @@ def _on_demand_failure_body(outcome: str, label: str, target_date: date) -> str:
     """Formatiert den Antworttext für einen nicht-erfolgreichen On-Demand-Versand.
 
     outcome: "no_stage" | "no_weather" | "no_channels" | "channels_unreachable"
-    (alles außer "sent").
+    | "already_in_progress" (alles außer "sent").
     """
     human_date = f"{target_date:%d.%m.%Y}"
     if outcome == "no_weather":
@@ -263,6 +263,10 @@ def _on_demand_failure_body(outcome: str, label: str, target_date: date) -> str:
             "Versandweg für diesen Trip konfiguriert, aber nicht erreichbar "
             "— Briefing nicht gesendet. Verbindung prüfen."
         )
+    # Issue #1756 AC-9: Kollisionsfall (Lock belegt) darf nicht mit "keine
+    # Etappe" verwechselt werden.
+    if outcome == "already_in_progress":
+        return f"{label} ({human_date}): Versand läuft bereits — bitte kurz warten."
     # "no_stage" (Default/Fallback)
     return f"{label} ({human_date}): Keine Etappe geplant"
 

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -12,6 +12,7 @@ import dataclasses
 import json
 import logging
 import os
+import threading
 import time as time_module
 from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
@@ -274,6 +275,30 @@ def record_corrupt_trip_observability(
         corrupt_files=[name for name, _ in corrupt],
         newly_notified=newly,
     )
+
+
+# Issue #1756: In-Process-Lock gegen doppelten manuellen Trip-Versand.
+# Modul-Ebene (nicht instanz-gebunden): pro Request entsteht eine neue
+# TripReportSchedulerService-Instanz (api/routers/scheduler.py), ein
+# Instanzattribut würde daher nie mit sich selbst kollidieren. Wirkt nur
+# innerhalb eines Systemd-Prozesses (siehe Spec „Known Limitations").
+_send_locks: Dict[Tuple[str, str, str], bool] = {}
+_send_locks_guard = threading.Lock()
+
+
+def _try_acquire_send_lock(user_id: str, trip_id: str, report_type: str) -> bool:
+    key = (user_id, trip_id, report_type)
+    with _send_locks_guard:
+        if _send_locks.get(key):
+            return False
+        _send_locks[key] = True
+        return True
+
+
+def _release_send_lock(user_id: str, trip_id: str, report_type: str) -> None:
+    key = (user_id, trip_id, report_type)
+    with _send_locks_guard:
+        _send_locks.pop(key, None)
 
 
 class TripReportSchedulerService:
@@ -949,11 +974,17 @@ class TripReportSchedulerService:
         """
         if report_type not in ("morning", "evening"):
             raise ValueError(f"Invalid report_type: {report_type}")
-        # Issue #1725 (Adversary F006): `angefordert=True` — dieser Weg traegt
-        # den Test-Versand-Knopf (`api/routers/scheduler.send_test_trip_report`).
-        return self._send_trip_report_outcome(
-            trip, report_type, allow_test_fallback=True, angefordert=True,
-        )
+        # Issue #1756: Idempotenz-Lock gegen doppelten Versand bei erneutem Klick.
+        if not _try_acquire_send_lock(self._user_id, trip.id, report_type):
+            return "already_in_progress"
+        try:
+            # Issue #1725 (Adversary F006): `angefordert=True` — dieser Weg traegt
+            # den Test-Versand-Knopf (`api/routers/scheduler.send_test_trip_report`).
+            return self._send_trip_report_outcome(
+                trip, report_type, allow_test_fallback=True, angefordert=True,
+            )
+        finally:
+            _release_send_lock(self._user_id, trip.id, report_type)
 
     def send_on_demand_report(self, trip: "Trip", report_type: str) -> OnDemandErgebnis:
         """
@@ -986,11 +1017,17 @@ class TripReportSchedulerService:
         if report_type not in ("morning", "evening"):
             raise ValueError(f"Invalid report_type: {report_type}")
         zieltag = self._get_target_date(report_type, trip, datetime.now(timezone.utc))
-        # Issue #1725: `angefordert=True` NEBEN `on_demand=True` — die beiden
-        # bedeuten Verschiedenes, siehe `_send_trip_report_outcome`.
-        outcome = self._send_trip_report_outcome(
-            trip, report_type, on_demand=True, angefordert=True, target_date=zieltag,
-        )
+        # Issue #1756: geteilter Lock-Key-Raum mit send_test_report_outcome().
+        if not _try_acquire_send_lock(self._user_id, trip.id, report_type):
+            return OnDemandErgebnis(outcome="already_in_progress", zieltag=zieltag)
+        try:
+            # Issue #1725: `angefordert=True` NEBEN `on_demand=True` — die beiden
+            # bedeuten Verschiedenes, siehe `_send_trip_report_outcome`.
+            outcome = self._send_trip_report_outcome(
+                trip, report_type, on_demand=True, angefordert=True, target_date=zieltag,
+            )
+        finally:
+            _release_send_lock(self._user_id, trip.id, report_type)
         return OnDemandErgebnis(outcome=outcome, zieltag=zieltag)
 
     def _send_trip_report(

--- a/tests/tdd/test_issue_1007_heute_voll_briefing.py
+++ b/tests/tdd/test_issue_1007_heute_voll_briefing.py
@@ -450,6 +450,12 @@ def test_f002_no_stage_body_nennt_keine_etappe_geplant():
     assert "Keine Etappe geplant" in body, body
 
 
+def test_ac9_already_in_progress_body_nennt_kollisionsfall_nicht_keine_etappe():
+    body = _on_demand_failure_body("already_in_progress", "Heute", date(2026, 7, 10))
+    assert "Keine Etappe geplant" not in body, body
+    assert "läuft bereits" in body or "warten" in body, body
+
+
 # ---------------------------------------------------------------------------
 # Regressionstest (Runde 3) — On-Demand-'heute' darf die kombinierte
 # heute+morgen-Momentaufnahme NICHT mit nur dem Zieltag überschreiben.

--- a/tests/tdd/test_send_idempotenz_lock.py
+++ b/tests/tdd/test_send_idempotenz_lock.py
@@ -1,0 +1,468 @@
+"""TDD RED — #1756: In-Process-Lock gegen doppelten manuellen Trip-Versand.
+
+Spec: docs/specs/modules/fix_1756_send_idempotenz_lock.md (AC-1..AC-6)
+Kontext: docs/context/fix-1756-send-timeout-502.md
+
+Zielverhalten: `_try_acquire_send_lock`/`_release_send_lock` (Modulebene in
+`services.trip_report_scheduler`) sperren `_send_trip_report_outcome()` pro
+Schlüssel `(user_id, trip_id, report_type)`. Ein zweiter Aufruf waehrend ein
+erster fuer denselben Schluessel laeuft, liefert den Outcome
+`"already_in_progress"` statt einen zweiten echten Versand auszuloesen. Der
+Router mappt diesen Outcome auf HTTP 409.
+
+RED heute: `_try_acquire_send_lock`/`_release_send_lock` existieren nicht
+(`AttributeError`/`ImportError`) — `send_test_report_outcome()` und
+`send_on_demand_report()` rufen `_send_trip_report_outcome()` ungebremst auf,
+ein zweiter gleichzeitiger Aufruf laeuft ungehindert durch.
+
+Test-Politik (CLAUDE.md „Zwei Schichten"): Kern-Schicht, deterministisch,
+kein Netz. Kein Mock-Theater — ersetzt wird ausschliesslich die Naht zum
+Netz (`_send_trip_report_outcome`) durch eine ECHTE Unterklasse (Muster
+`tests/tdd/test_briefing_slot_idempotenz.py::_scheduler_mit_festem_ausgang`),
+die entweder sofort einen Ausgang zurueckgibt oder — fuer die
+„gleichzeitig"-Faelle — kontrolliert auf einem echten `threading.Event`
+blockiert, bis der Test das Lock-Verhalten des zweiten Aufrufs geprueft hat.
+Kein `sleep`-Timing-Raten: der erste Aufruf meldet ueber ein Event, dass er
+die Naht betreten hat (und damit — nach dem Fix — den Lock haelt), bevor der
+zweite Aufruf im Hauptthread synchron gestartet wird.
+
+────────────────────────────────────────────────────────────────────────────
+RED-Charakter je Test (Konvention aus tests/tdd/test_briefing_slot_idempotenz.py)
+────────────────────────────────────────────────────────────────────────────
+AC-1/AC-3/AC-4/AC-6 sind Fehlernachweise: sie sind heute rot, weil der Lock
+fehlt. AC-2 und AC-5 sind bewusst Mutations-Waechter, die HEUTE SCHON GRUEN
+sind — sie pruefen die ABWESENHEIT von Blockade (kein Lock-Konflikt, zwei
+verschiedene Nutzer), was ohne jeden Lock trivial erfuellt ist. Ihr Wert
+entsteht erst NACH dem Fix: sie muessen auch dann gruen bleiben und faengen
+so eine ueberscharfe Lock-Implementierung (z.B. ein Lock ohne user_id im
+Schluessel), die faelschlich auch unbeteiligte Aufrufe blockiert.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "src"))
+
+from app.loader import get_briefings_dir, load_all_trips  # noqa: E402
+
+KORSIKA = (42.30, 8.93)  # Europe/Paris — echter Ort, TimezoneFinder loest ihn auf.
+
+
+# ---------------------------------------------------------------------------
+# Aufbau-Helfer (Muster: tests/tdd/test_briefing_slot_idempotenz.py::_trip_json)
+# ---------------------------------------------------------------------------
+
+
+def _trip_json(trip_id: str) -> dict:
+    heute = date.today()
+    return {
+        "id": trip_id,
+        "name": f"Trip {trip_id}",
+        "stages": [{
+            "id": f"{trip_id}-s0",
+            "name": "Etappe 0",
+            "date": heute.isoformat(),
+            "waypoints": [
+                {"id": f"{trip_id}-wp0a", "name": "Start",
+                 "lat": KORSIKA[0], "lon": KORSIKA[1], "elevation_m": 800},
+                {"id": f"{trip_id}-wp0b", "name": "Ziel",
+                 "lat": KORSIKA[0] + 0.05, "lon": KORSIKA[1] + 0.05, "elevation_m": 1200},
+            ],
+        }],
+        "report_config": {"enabled": True, "evening_time": "18:00:00"},
+    }
+
+
+def _schreibe_trip(user_id: str, trip_id: str) -> None:
+    """Mandantentrennung: jeder Test bekommt eine eigene, sprechende user_id."""
+    ordner = get_briefings_dir(user_id)
+    ordner.mkdir(parents=True, exist_ok=True)
+    (ordner / f"{trip_id}.json").write_text(json.dumps(_trip_json(trip_id)), encoding="utf-8")
+
+
+def _lade_trip(user_id: str, trip_id: str):
+    trips = load_all_trips(user_id=user_id)
+    trip = next(t for t in trips if t.id == trip_id)
+    return trip
+
+
+def _scheduler_mit_festem_ausgang(user_id: str, ausgang: str = "sent"):
+    """Echter `TripReportSchedulerService`, bei dem AUSSCHLIESSLICH die Naht
+    zum Netz (`_send_trip_report_outcome`) ersetzt ist — sofortige Rueckgabe,
+    kein Blockieren. Zaehlt Versandversuche mit."""
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    class _SchedulerMitFestemAusgang(TripReportSchedulerService):
+        def _send_trip_report_outcome(self, trip, report_type, **kwargs):
+            self.versandversuche.append((trip.id, report_type))
+            return self.ausgang
+
+    scheduler = _SchedulerMitFestemAusgang(user_id=user_id)
+    scheduler.versandversuche = []
+    scheduler.ausgang = ausgang
+    return scheduler
+
+
+def _scheduler_blockierend(user_id: str, betreten: threading.Event,
+                           weiter: threading.Event, ausgang: str = "sent",
+                           ausnahme: BaseException | None = None):
+    """Echter `TripReportSchedulerService`, dessen Naht zum Netz beim ERSTEN
+    Aufruf kontrolliert blockiert: signalisiert per Event, dass sie betreten
+    wurde (und — nach dem Fix — den Lock haelt), wartet dann auf Freigabe.
+    `ausnahme` (falls gesetzt) wirft NUR beim allerersten Aufruf -- ein
+    etwaiger dritter Aufruf (nach Lock-Freigabe) muss normal durchlaufen
+    koennen, um die Freigabe ueberhaupt beweisen zu koennen. Kein Mock: echte
+    Unterklasse, echte Aufrufmitschrift."""
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    geworfen = {"wert": False}
+
+    class _SchedulerBlockierend(TripReportSchedulerService):
+        def _send_trip_report_outcome(self, trip, report_type, **kwargs):
+            self.versandversuche.append((trip.id, report_type))
+            betreten.set()
+            weiter.wait(timeout=5)
+            if ausnahme is not None and not geworfen["wert"]:
+                geworfen["wert"] = True
+                raise ausnahme
+            return ausgang
+
+    scheduler = _SchedulerBlockierend(user_id=user_id)
+    scheduler.versandversuche = []
+    return scheduler
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — zweiter gleichzeitiger Testversand-Aufruf liefert already_in_progress
+# ---------------------------------------------------------------------------
+
+
+def test_ac1_zweiter_gleichzeitiger_testversand_liefert_already_in_progress():
+    """Given ein Testversand fuer Trip A (User X, evening) laeuft bereits /
+    When waehrend dieser Laufzeit ein zweiter `send_test_report_outcome()`-
+    Aufruf fuer denselben Schluessel erfolgt / Then liefert der zweite Aufruf
+    `"already_in_progress"`, OHNE dass ein zweiter echter Versand ausgeloest
+    wird (Versand-Mitschrift zaehlt nur EINEN Eintrag).
+
+    Bug-Nachweis: rot vor Fix (der zweite Aufruf laeuft heute ungehindert
+    durch und ruft die Naht ein zweites Mal auf), gruen nach Fix.
+
+    RED-Charakter: Fehlernachweis — rot bei fehlendem Lock (heutiger Zustand).
+    """
+    user_id = "send-lock-ac1"
+    trip_id = "korsika"
+    _schreibe_trip(user_id, trip_id)
+    trip = _lade_trip(user_id, trip_id)
+
+    betreten = threading.Event()
+    weiter = threading.Event()
+    scheduler = _scheduler_blockierend(user_id, betreten, weiter)
+
+    ergebnisse: list[str] = []
+    thread = threading.Thread(
+        target=lambda: ergebnisse.append(scheduler.send_test_report_outcome(trip, "evening")),
+    )
+    thread.start()
+    assert betreten.wait(timeout=5), "Erster Aufruf hat die Netz-Naht nicht betreten"
+
+    zweiter_ausgang = scheduler.send_test_report_outcome(trip, "evening")
+
+    weiter.set()
+    thread.join(timeout=5)
+
+    assert zweiter_ausgang == "already_in_progress", (
+        f"Erwartet 'already_in_progress' waehrend ein Versand fuer denselben "
+        f"Schluessel laeuft, bekommen {zweiter_ausgang!r}"
+    )
+    assert ergebnisse == ["sent"], f"Erster Aufruf muss unveraendert durchlaufen: {ergebnisse}"
+    assert scheduler.versandversuche == [(trip_id, "evening")], (
+        "Die Netz-Naht darf nur EINMAL betreten worden sein — ein zweiter "
+        f"echter Versandversuch waere ein Doppelversand: {scheduler.versandversuche}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — ohne Lock-Kollision laeuft der Versand unveraendert durch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("ausgang", ["sent", "no_stage", "no_weather", "no_channels", "channels_unreachable"])
+def test_ac2_ohne_kollision_liefert_unveraenderten_outcome(ausgang: str):
+    """Given kein Versand fuer den Schluessel laeuft gerade / When
+    `send_test_report_outcome()` aufgerufen wird / Then bleibt der Outcome
+    unveraendert (keine Regression an #695/#1325), UND der Lock ist danach
+    wieder frei (ein direkt folgender Aufruf blockiert nicht).
+
+    RED-Charakter: Mutations-Waechter — heute bereits gruen (kein Lock, also
+    auch keine faelschliche Blockade). Wert entsteht NACH dem Fix: faengt
+    einen Lock, der versehentlich nicht freigegeben wird oder den Outcome
+    verfaelscht."""
+    user_id = f"send-lock-ac2-{ausgang}"
+    trip_id = "korsika"
+    _schreibe_trip(user_id, trip_id)
+    trip = _lade_trip(user_id, trip_id)
+    scheduler = _scheduler_mit_festem_ausgang(user_id, ausgang=ausgang)
+
+    outcome = scheduler.send_test_report_outcome(trip, "evening")
+    assert outcome == ausgang, f"Erwartet unveraenderten Outcome {ausgang!r}, bekommen {outcome!r}"
+
+    # Lock-Freigabe: ein zweiter, direkt folgender Aufruf darf NICHT
+    # 'already_in_progress' liefern -- der erste ist bereits abgeschlossen.
+    zweiter = scheduler.send_test_report_outcome(trip, "evening")
+    assert zweiter != "already_in_progress", (
+        "Der Lock muss nach Abschluss des ersten Aufrufs wieder frei sein, "
+        f"bekommen {zweiter!r} beim direkt folgenden Aufruf"
+    )
+    assert len(scheduler.versandversuche) == 2, (
+        f"Beide Aufrufe muessen die Naht betreten, gefunden {scheduler.versandversuche}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3 — Router mappt already_in_progress auf HTTP 409
+# ---------------------------------------------------------------------------
+
+
+def test_ac3_router_mappt_already_in_progress_auf_409(monkeypatch):
+    """Given der Router-Endpunkt `POST /api/scheduler/trips/{trip_id}/send`
+    erhaelt den Outcome `"already_in_progress"` / When die Antwort gebaut
+    wird / Then ist der Statuscode 409 mit einem nicht-leeren `detail`-Feld,
+    unterscheidbar von den bestehenden 422-Fehlerzweigen.
+
+    RED-Charakter: Fehlernachweis — rot, weil der Router den Outcome
+    'already_in_progress' heute nicht kennt und in den 200-Erfolgspfad
+    faellt (`{"status": "ok", ..., "sent": True}`) statt 409 zu liefern."""
+    from fastapi.testclient import TestClient
+    from api.main import app
+
+    user_id = "send-lock-ac3"
+    trip_id = "korsika"
+    _schreibe_trip(user_id, trip_id)
+
+    monkeypatch.setattr("app.config.Settings.can_send_email", lambda self: True)
+    monkeypatch.setattr(
+        "services.trip_report_scheduler.TripReportSchedulerService.send_test_report_outcome",
+        lambda self, trip, report_type: "already_in_progress",
+    )
+
+    resp = TestClient(app).post(
+        f"/api/scheduler/trips/{trip_id}/send",
+        params={"user_id": user_id, "report_type": "evening"},
+    )
+
+    assert resp.status_code == 409, (
+        f"Erwartet 409 bei Outcome 'already_in_progress', bekommen "
+        f"{resp.status_code}. Body: {resp.text}"
+    )
+    body = resp.json()
+    assert body.get("detail"), f"Kein nicht-leeres 'detail'-Feld in der 409-Antwort: {body}"
+    assert body["detail"] != "SMTP not configured for this user", (
+        "Die 409-Meldung darf nicht mit dem bestehenden 422-Zweig verwechselt werden"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 — Lock wird nach Exception per finally wieder freigegeben
+# ---------------------------------------------------------------------------
+
+
+def test_ac4_lock_wird_nach_exception_wieder_freigegeben():
+    """Given ein Versandversuch wirft eine Exception, WAEHREND er laeuft
+    haelt er (nach dem Fix) den Lock / When ein zweiter Aufruf waehrend
+    dieser Laufzeit eintrifft, DANACH ein dritter / Then wird der zweite
+    Aufruf mit 'already_in_progress' abgewiesen (Lock war belegt), der
+    dritte Aufruf (nach Abschluss inkl. Exception) darf die Naht dagegen
+    erneut betreten — beweist Freigabe per `finally`, nicht nur im
+    Erfolgspfad.
+
+    Zwei Teile in einem Test, weil beide zusammen erst beweiskraeftig sind:
+    Teil 1 (waehrend die Exception noch aussteht) ist der Fehlernachweis.
+    Teil 2 (nach Abschluss) waere ohne Teil 1 ein Mutations-Waechter, der
+    schon ohne jeden Lock gruen ist (ohne Lock blockiert ohnehin nichts).
+
+    RED-Charakter: Fehlernachweis (Teil 1) — rot, weil der Lock heute nicht
+    existiert: der zweite Aufruf blockiert nicht auf 'already_in_progress',
+    sondern betritt die Naht ebenfalls und wirft dieselbe Exception.
+    """
+    user_id = "send-lock-ac4"
+    trip_id = "korsika"
+    _schreibe_trip(user_id, trip_id)
+    trip = _lade_trip(user_id, trip_id)
+
+    betreten = threading.Event()
+    weiter = threading.Event()
+    scheduler = _scheduler_blockierend(
+        user_id, betreten, weiter, ausnahme=RuntimeError("Versandpfad wirft (simuliert)"),
+    )
+
+    fehler: list[BaseException] = []
+
+    def _erster_aufruf() -> None:
+        try:
+            scheduler.send_test_report_outcome(trip, "evening")
+        except RuntimeError as exc:
+            fehler.append(exc)
+
+    thread = threading.Thread(target=_erster_aufruf)
+    thread.start()
+    assert betreten.wait(timeout=5), "Erster Aufruf hat die Netz-Naht nicht betreten"
+
+    # Teil 1: waehrend der erste Aufruf noch (kurz vor der Exception) laeuft,
+    # muss der Lock ihn als belegt ausweisen.
+    zweiter_waehrend_laufzeit = scheduler.send_test_report_outcome(trip, "evening")
+    assert zweiter_waehrend_laufzeit == "already_in_progress", (
+        "Waehrend der erste Aufruf laeuft (kurz vor seiner Exception) muss "
+        f"ein zweiter Aufruf blockiert werden, bekommen {zweiter_waehrend_laufzeit!r}"
+    )
+
+    weiter.set()
+    thread.join(timeout=5)
+    assert fehler and isinstance(fehler[0], RuntimeError), (
+        "Der erste Aufruf muss die Exception unveraendert weiterreichen"
+    )
+
+    # Teil 2: NACH der Exception muss der Lock frei sein.
+    dritter_nach_exception = scheduler.send_test_report_outcome(trip, "evening")
+    assert dritter_nach_exception != "already_in_progress", (
+        "Nach einer Exception im ersten Aufruf muss der Lock frei sein "
+        f"(finally-Freigabe), bekommen {dritter_nach_exception!r}"
+    )
+    assert len(scheduler.versandversuche) == 2, (
+        f"Nur der 1. und 3. Aufruf duerfen die Naht betreten haben — der 2. Aufruf "
+        f"wird per Lock abgewiesen, bevor er sie erreicht (Teil 1 oben): "
+        f"{scheduler.versandversuche}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — Mandantentrennung: zwei Nutzer blockieren sich nicht gegenseitig
+# ---------------------------------------------------------------------------
+
+
+def test_ac5_zwei_nutzer_blockieren_sich_nicht_bei_identischer_trip_id():
+    """Given zwei verschiedene Nutzer (User X, User Y) loesen gleichzeitig
+    einen Testversand fuer ihren jeweils eigenen Trip mit identischer
+    `trip_id` und identischem `report_type` aus / When beide Aufrufe
+    zeitgleich laufen / Then blockiert keiner der beiden den anderen — beide
+    erhalten ihren eigenen Outcome, keiner 'already_in_progress'.
+
+    Pflicht-Zwei-Nutzer-Test gemaess CLAUDE.md-Mandantenfaehigkeits-Vorgabe.
+    """
+    trip_id = "gleicher-slug"
+    _schreibe_trip("send-lock-ac5-x", trip_id)
+    _schreibe_trip("send-lock-ac5-y", trip_id)
+    trip_x = _lade_trip("send-lock-ac5-x", trip_id)
+    trip_y = _lade_trip("send-lock-ac5-y", trip_id)
+
+    betreten_x = threading.Event()
+    weiter_x = threading.Event()
+    scheduler_x = _scheduler_blockierend("send-lock-ac5-x", betreten_x, weiter_x)
+    scheduler_y = _scheduler_mit_festem_ausgang("send-lock-ac5-y", ausgang="sent")
+
+    ergebnisse: list[str] = []
+    thread = threading.Thread(
+        target=lambda: ergebnisse.append(scheduler_x.send_test_report_outcome(trip_x, "evening")),
+    )
+    thread.start()
+    assert betreten_x.wait(timeout=5), "User X hat die Netz-Naht nicht betreten"
+
+    ausgang_y = scheduler_y.send_test_report_outcome(trip_y, "evening")
+
+    weiter_x.set()
+    thread.join(timeout=5)
+
+    assert ausgang_y != "already_in_progress", (
+        f"User Y darf durch User X' laufenden Versand nicht blockiert werden "
+        f"(identische trip_id/report_type, verschiedene user_id), bekommen {ausgang_y!r}"
+    )
+    assert ergebnisse == ["sent"], f"User X' Versand muss unveraendert durchlaufen: {ergebnisse}"
+
+
+# ---------------------------------------------------------------------------
+# AC-6 — send_on_demand_report() teilt denselben Lock-Key-Raum
+# ---------------------------------------------------------------------------
+
+
+def test_ac6_on_demand_zweiter_aufruf_liefert_already_in_progress():
+    """Given `send_on_demand_report()` nutzt denselben `_send_trip_report_
+    outcome()`-Kern / When waehrend eines laufenden On-Demand-Versands ein
+    zweiter On-Demand-Aufruf fuer denselben Schluessel eintrifft / Then
+    liefert `send_on_demand_report()` ein `OnDemandErgebnis` mit
+    `outcome="already_in_progress"`, ohne einen zweiten echten Versand."""
+    user_id = "send-lock-ac6"
+    trip_id = "korsika"
+    _schreibe_trip(user_id, trip_id)
+    trip = _lade_trip(user_id, trip_id)
+
+    betreten = threading.Event()
+    weiter = threading.Event()
+    scheduler = _scheduler_blockierend(user_id, betreten, weiter)
+
+    ergebnisse = []
+    thread = threading.Thread(
+        target=lambda: ergebnisse.append(scheduler.send_on_demand_report(trip, "evening")),
+    )
+    thread.start()
+    assert betreten.wait(timeout=5), "Erster On-Demand-Aufruf hat die Netz-Naht nicht betreten"
+
+    zweites_ergebnis = scheduler.send_on_demand_report(trip, "evening")
+
+    weiter.set()
+    thread.join(timeout=5)
+
+    assert zweites_ergebnis.outcome == "already_in_progress", (
+        f"Erwartet 'already_in_progress' beim zweiten On-Demand-Aufruf, "
+        f"bekommen {zweites_ergebnis.outcome!r}"
+    )
+    assert zweites_ergebnis.zieltag is not None, (
+        "Der Platzhalter-Zieltag muss auch im Kollisionsfall gesetzt sein "
+        "(vor dem Lock-Versuch berechnet)"
+    )
+    assert ergebnisse and ergebnisse[0].outcome == "sent", (
+        f"Erster On-Demand-Aufruf muss unveraendert durchlaufen: {ergebnisse}"
+    )
+    assert scheduler.versandversuche == [(trip_id, "evening")], (
+        f"Die Netz-Naht darf nur EINMAL betreten worden sein: {scheduler.versandversuche}"
+    )
+
+
+def test_ac6_geteilter_lock_key_raum_testversand_blockiert_on_demand():
+    """Given ein laufender Testversand (`send_test_report_outcome`) fuer Trip
+    A, User X, evening / When waehrend dieser Laufzeit ein On-Demand-Aufruf
+    (`send_on_demand_report`) fuer DENSELBEN Schluessel eintrifft / Then wird
+    auch dieser mit `outcome='already_in_progress'` abgewiesen — geteilter
+    Lock-Key-Raum, nicht zwei getrennte Register."""
+    user_id = "send-lock-ac6-geteilt"
+    trip_id = "korsika"
+    _schreibe_trip(user_id, trip_id)
+    trip = _lade_trip(user_id, trip_id)
+
+    betreten = threading.Event()
+    weiter = threading.Event()
+    scheduler = _scheduler_blockierend(user_id, betreten, weiter)
+
+    ergebnisse: list[str] = []
+    thread = threading.Thread(
+        target=lambda: ergebnisse.append(scheduler.send_test_report_outcome(trip, "evening")),
+    )
+    thread.start()
+    assert betreten.wait(timeout=5), "Testversand hat die Netz-Naht nicht betreten"
+
+    on_demand_ergebnis = scheduler.send_on_demand_report(trip, "evening")
+
+    weiter.set()
+    thread.join(timeout=5)
+
+    assert on_demand_ergebnis.outcome == "already_in_progress", (
+        "Ein laufender Testversand muss einen gleichzeitigen On-Demand-Aufruf "
+        f"fuer denselben Schluessel blockieren, bekommen {on_demand_ergebnis.outcome!r} "
+        "-- getrennte Lock-Register waeren ein Konstruktionsfehler, kein Idempotenz-Schutz."
+    )
+    assert ergebnisse == ["sent"], f"Testversand muss unveraendert durchlaufen: {ergebnisse}"


### PR DESCRIPTION
## Summary
- Klick auf „Senden" im Trip-Editor konnte nach einem 502-Timeout wiederholt werden und einen echten Doppelversand auslösen — ein In-Process-Lock pro `(user_id, trip_id, report_type)` weist einen zweiten Sendeversuch während ein erster noch läuft jetzt mit HTTP 409 ab.
- Go-Proxy-Timeout in `SendTripReportProxyHandler` von 120s auf 300s angehoben, da der reguläre Erfolgsfall (vollständiger Mehrtages-Ausblick) 3–4 Minuten dauert.
- AC-9 (Adversary-Nachtrag): der SMS-„heute"/„morgen"-Antworttext kennt den neuen Kollisionsfall ebenfalls (`_on_demand_failure_body`), statt fälschlich „Keine Etappe geplant" zu antworten.

## Test plan
- [x] Python: 18/18 grün (`tests/tdd/test_send_idempotenz_lock.py`, `tests/unit/test_trip_send_endpoint_no_channels.py`)
- [x] Go: 2/2 grün (`internal/handler/trip_send_timeout_test.go`)
- [x] Regression: 27/27 grün (`tests/tdd/test_briefing_slot_idempotenz.py`, #1725), 3/3 grün (`tests/tdd/test_issue_1007_heute_voll_briefing.py`, #1007)
- [x] Adversary VERIFIED — 9/9 ACs bestätigt, 5/5 gezielte Mutationsproben gefangen
- [x] Doku aktualisiert (`docs/reference/api_contract.md`)

Bezieht sich auf #1756 — Issue wird manuell nach bestandenem Post-Deploy-Selftest geschlossen (Liefer-Workflow Schritt 5), nicht automatisch beim Merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019iTRSqaPDVQ4GwJdJkHcHY
