### PR TITLE
fix(#1727 S5c): Vorschau, Anzeige und Sofort-Vergleich folgen dem Ortstag

### DIFF
--- a/api/routers/compare.py
+++ b/api/routers/compare.py
@@ -46,16 +46,20 @@ def run_comparison(
     if not selected:
         return {"error": "no_locations_found", "locations": []}
 
-    # Default: if before 14:00 → today, else tomorrow
+    # Default: if before 14:00 → today, else tomorrow (Issue #1727 S5c,
+    # ADR-0044): "14:00" ist die ORTSZEIT des ersten aufloesbaren Orts, nicht
+    # mehr die zonenlose Serveruhr — Stunde UND Tag kommen aus DERSELBEN
+    # Aufloesung, sonst waere die Schwelle in sich widersprochen.
     if target_date:
         td = date.fromisoformat(target_date)
     else:
-        now = datetime.now()
-        if now.hour < 14:
-            td = date.today()
-        else:
-            from datetime import timedelta
-            td = date.today() + timedelta(days=1)
+        from datetime import timedelta, timezone
+
+        from utils.timezone import first_resolvable_tz, local_dt
+
+        zone = first_resolvable_tz(selected, context_label="Sofort-Vergleich")
+        local_now = local_dt(datetime.now(timezone.utc), zone)
+        td = local_now.date() if local_now.hour < 14 else local_now.date() + timedelta(days=1)
 
     profile = None
     if activity_profile:

--- a/docs/adr/0044-kalendertage-folgen-der-ortszeit.md
+++ b/docs/adr/0044-kalendertage-folgen-der-ortszeit.md
@@ -153,6 +153,20 @@ Regelverstoß — genau das war der Zustand vor #1697.
   Retry-Backoff liegt. An den Fundstellen `_send_trip_report_outcome`,
   `_target_date_from_report` und `send_one_compare_preset` bleibt die Auflösung bewusst
   funktionsintern (jeweils vor jedem Netzabruf).
+- **Vorschau-, Anzeige- und Sofort-Vergleichspfade** (#1727 S5c): sieben Fundstellen in fünf
+  Dateien. Die Trip-Vorschau (`preview_service.py`) — `_resolve_target_date` UND
+  `_build_report` — folgt seither `trip_local_today(trip, now_utc)`; EIN von den drei
+  öffentlichen `render_*_preview`-Methoden einmal gebundenes `now_utc` speist beide Aufrufe,
+  die zuvor bei `_build_report` separat aufgelöste zweite Systemuhr entfällt ersatzlos. Die
+  Compare-Vorschau (`compare_preview_service.py::_resolve_target_date`) und der
+  Sofort-Vergleich (`api/routers/compare.py::run_comparison`, alle drei Funde im selben
+  Commit — Stunde UND Zieltag „heute"/„morgen" aus DERSELBEN Auflösung) folgen
+  `first_resolvable_tz(locations)`, demselben Muster wie der Compare-Versand seit S5b. Der
+  Mail-Footer „Nächster Versand" (`compare_html.py::_compute_next_send`) übernimmt das in
+  `render_compare_html` bereits aufgelöste `header_tz`, statt selbst ein zweites Mal
+  aufzulösen. Die siebte Fundstelle, `comparison_engine.py::dict_to_comparison_result`,
+  wurde NICHT korrigiert, sondern als toter Code (0 Aufrufer im gesamten Repo) ersatzlos
+  entfernt.
 
 **Lehre für die Pflege dieser Liste:** Sie war nicht falsch, sondern **unvollständig** — und
 eine unvollständige Restliste liest sich wie eine vollständige. Wer hier etwas einträgt,
@@ -166,18 +180,48 @@ Der zuvor hier gelistete Briefing-/Versand-Pfad (`_get_target_date`, `_get_activ
 gelistete Kommando-/Anzeige-Pfad — s. „Umgesetzt" oben (#1727 S5a/#1795) und die neun
 Versandpfade aus #1727 S5b.
 
-**Vorschau, Werkzeuge:** `preview_service._resolve_target_date`, `api/routers/debug.py` und
-`tools/weather_validation.py` (S5c, eigene Scheibe). Zeilennummern bewusst weggelassen —
-sie waren in der Vorfassung dieser Liste binnen Tagen veraltet. `preview_service.py` reicht
-seit #1727 S5b zwar `now_utc` an die beiden Scheduler-Methoden durch (mechanisch erzwungen
-durch deren Pflichtparameter), seine EIGENE Tagesbestimmung folgt aber weiterhin dem
-Servertag — die Datei steht deshalb hier UND oben.
+`preview_service._resolve_target_date` (samt `_build_report`) ist mit #1727 S5c erledigt und
+nach „Umgesetzt" oben gewandert. `tools/weather_validation.py` ist damit ebenfalls KEINE
+offene Arbeit mehr — s. „Bewusst NICHT betroffen" unten, wo die begründete Ausnahme steht.
+
+**Fünfte unvollständige Aufzählung dieses Epics:** `compare_preview_service._resolve_target_date`
+fehlte in dieser Restliste vollständig, obwohl der Wächter
+(`tests/test_output_timezone_guard.py::KNOWN_VIOLATIONS`) sie bereits als offenen Fund
+führte — weder oben noch unten stand sie je drin. Mit #1727 S5c ist sie behoben (s.
+„Umgesetzt" oben); hier ausdrücklich als das benannt, was sie war, statt sie stillschweigend
+als „schon immer bekannt" durchgehen zu lassen.
+
+**S5d — vier Dateien, sieben verbleibende Muster-A-Funde (Wächter-Restliste, nachgezählt am
+Stand nach S5c):**
+
+- `api/routers/debug.py` — `trigger_radar_alert` (1): Debug-Auslöser für Radar-Alarme datiert
+  weiterhin auf die Serveruhr.
+- `src/services/gpx_processing.py` — `compute_default_start_date` (2), `gpx_to_stage_data`
+  (1).
+- `src/services/official_alerts/massif_closure.py` — `_do_request`, `fetch` (2).
+- `src/services/official_alerts/meteo_forets.py` — `covers` (1).
+
+**Sechste unvollständige Aufzählung dieses Epics:** die drei letztgenannten Dateien
+(`gpx_processing.py`, `massif_closure.py`, `meteo_forets.py`) standen bis zu dieser Scheibe in
+KEINEM Abschnitt dieses ADR — weder oben noch unten —, obwohl der Wächter
+(`tests/test_output_timezone_guard.py::KNOWN_VIOLATIONS`) sie durchgehend als offene Funde
+führte. Nur `api/routers/debug.py` war hier bislang erwähnt. Hier ausdrücklich als das
+benannt, was sie waren, statt sie stillschweigend unter „bleibt offen" mitzumeinen. Nach S5d
+ist die Muster-A-Liste des Wächters vollständig leer; offen bleiben dann nur noch
+`raw_astimezone`-Funde, die dritte Fundart des Wächters (stille Mid-Body-Rückfälle, per
+`BoolOp`/`getattr`/`If`/`IfExp` erkannt) sowie die vom Wächter nicht gescannten Bereiche
+(S5e).
 
 **Bewusst NICHT betroffen** (feste Zone ist dort Absicht, kein Verstoß):
 `forecast_budget._today_utc` und `meteoalarm_budget._today_utc` (Kontingent-Tageswechsel in
 UTC) sowie der manuelle `?hour=`-Testauslöser des Versand-Orchestrators
 (`CompareDispatchStrategy.MANUAL_TRIGGER_REFERENCE_ZONE`) — ein Ops-/Debug-Werkzeug ohne
 Preset-Bezug, für das „Stunde X" bei preset-eigenen Zonen keine EINE Bedeutung mehr hätte.
+Seit #1727 S5c außerdem `tools/weather_validation.py`s Punkt-Validierungsmodus (`:288`,
+begründet über einen `# gz-main-path:`-Kommentar an der Zeile): das Werkzeug fragt seine
+Referenzdaten selbst ausdrücklich mit `"timezone": "UTC"` ab (`fetch_openmeteo`, `:31`) — ein
+Ortstag-Default erzeugte einen Widerspruch INNERHALB desselben Skripts (Validierungsziel UTC,
+Validierungs-Default Ortszeit).
 
 Die beiden Alarm-Module, die bis 2026-08-12 an dieser Stelle als bewusste Ausnahme standen
 (Ruhezeit-Engine und Tageszähler, fest `Europe/Vienna`), sind **keine Ausnahme mehr** — sie

--- a/docs/context/fix-1727-s5c-vorschau-anzeige.md
+++ b/docs/context/fix-1727-s5c-vorschau-anzeige.md
@@ -1,0 +1,316 @@
+# Context: #1727 S5c — Vorschau, Anzeige, Sofort-Vergleich folgen dem Ortstag
+
+- **Workflow:** `fix-1727-s5c-vorschau-anzeige` (Full Process)
+- **Basis:** `e2b5269b`
+- **Vorgänger:** S5a (`dbad9614`, live), S5b (`b26d88a9`, live)
+- **Epic:** #1722 · **ADR:** 0044 (Kalendertage folgen der Ortszeit), 0051 (Drei Zeitbegriffe, Regel 3)
+
+## Request Summary
+
+Die vierte Scheibe von #1727 stellt die Vorschau-, Anzeige- und Sofort-Vergleichs-Pfade vom
+Servertag auf den Ortstag um. Sieben Fundstellen in fünf Dateien, alle im Wächter
+`tests/test_output_timezone_guard.py` als „Muster A" (Umgebungsuhr) geführt.
+
+## Die sieben Fundstellen — gemessen, nicht übernommen
+
+| Datei:Zeile | Funktion | Wirkung | Zone am Fundort verfügbar? |
+|---|---|---|---|
+| `src/services/preview_service.py:94` | `_resolve_target_date` | Vorschau (3 GET-Endpunkte), **kein Versand** | **JA** — `trip` ist bereits Parameter |
+| `src/services/compare_preview_service.py:258` | `_resolve_target_date` | Vorschau (`POST /api/preview/compare/{id}`), **kein Versand** | **JA** — `locations` steht in `_prepare()` bei `:147` vor dem Aufruf `:148` |
+| `api/routers/compare.py:53` | `run_comparison` | „jetzt" für die 14:00-Schwelle | **JA** — `selected` steht bei `:41/:44` fest |
+| `api/routers/compare.py:55` | `run_comparison` | Zieltag „heute" | JA (s.o.) |
+| `api/routers/compare.py:58` | `run_comparison` | Zieltag „morgen" | JA (s.o.) |
+| `src/services/comparison_engine.py:407` | `dict_to_comparison_result` | **kein Aufrufer** | — |
+| `src/output/renderers/email/compare_html.py:1443` | `_compute_next_send` | **versendete Mail**, Footer „Nächster Versand" | **JA** — `header_tz` bei `:1604`, aber Signaturänderung nötig |
+
+**Vollständigkeit geprüft:** Die fünf Dateien enthalten genau sieben Umgebungsuhr-Aufrufe —
+deckungsgleich mit den sieben Wächter-Einträgen. Keine `utcnow()`-Blindstelle wie in S5b
+(der Wächter erkennt nur `.today()` und `.now()` ohne `tz`, siehe „Wächter" unten).
+
+## Die drei Befunde, die den Zuschnitt verändern
+
+### 1. Vier der sieben Fundstellen hängen an Code, den niemand aufruft
+
+- **`dict_to_comparison_result` ist produktiv tot.** Kein Aufruf in `src/`, `api/`, `tests/`,
+  `frontend/`, `internal/`, `cmd/`. Der einzige Testbezug ist ein `hasattr`-Strukturtest
+  (`tests/refactor/test_epic_129a_1_module_structure.py:36,45-46`).
+  Zwei Code-Kommentare behaupten aktive Nutzung — `compare_html.py:643` nennt den
+  „Validator-Render-Pfad" als Nutzer, aber `validator_render_service.py:151-184` baut
+  `ComparisonResult` direkt (`:168-172`) und ruft die Funktion nicht. `user.py:144` nennt sie
+  als Beispiel-Aufrufer ohne aktiven Aufruf.
+- **`GET /api/compare` hat keinen Frontend-Aufrufer.** Suche in `frontend/src` nach dem
+  bloßen Pfad: null Treffer; alle Treffer sind `/api/compare/metrics` bzw.
+  `/api/compare/presets/…`. Der aktive Weg ist `POST /api/preview/compare/{preset_id}`
+  (`api/routers/preview.py:96`). Zwei Tests treffen den Endpunkt
+  (`test_sport_aware_scoring.py:251`, `test_hail_flag_metrics_catalog_and_compare_api.py:103`),
+  beide ohne `target_date` und ohne Prüfung der 14:00-Regel.
+
+**Daraus folgt eine Produktfrage, keine technische:** Zeitzonen-Korrektur an unbenutztem Code
+oder ersatzlos entfernen? Vier von sieben Fundstellen und die gesamte 14:00-Heuristik hängen
+daran.
+
+### 2. Die 14:00-Heuristik ist nirgends spezifiziert
+
+`api/routers/compare.py:49-58` entscheidet „vor 14:00 → heute, sonst morgen". Die Schwelle
+kommt an keiner anderen Stelle im Code vor (keine Konstante, kein zweiter Fundort), und in
+`docs/` steht keine Spezifikation dazu. Einzige „Spezifikation" ist der Query-Docstring
+(`:28`, „defaults to today/tomorrow based on time"). Kein Test prüft sie.
+
+Sie hat **zwei** zonenabhängige Teile, die getrennt zu entscheiden sind: die Stunde
+(`now.hour`, `:53`) und den Tag (`date.today()`, `:55`/`:58`).
+
+### 3. Zwei konkurrierende „erster Ort"-Auflösungen in derselben Mail
+
+Beide berufen sich auf #1378 AC-4:
+
+| Ort | Auflösung | Verhalten bei nicht auflösbarem erstem Ort |
+|---|---|---|
+| Kopfzeile, `compare_html.py:1604` | `location_tz(locations[0].location)` | fällt still auf **UTC** |
+| Zieltag im Versand, `scheduler_dispatch_service.py:441` | `first_resolvable_tz(locations)` | überspringt ihn, nimmt den **nächsten** auflösbaren |
+
+Sie fallen genau dann auseinander, wenn der erste Ort keine auflösbare Zone trägt: Die
+Kopfzeile derselben Mail zeigt dann Weltzeit, während ihr Zieltag in der Zone des zweiten Orts
+gerechnet wurde. Genau die Falle, für die `first_resolvable_tz` in #1726 gebaut wurde — die
+Kopfzeile hat den Fix nie bekommen. **Steht in keiner Restliste und in keinem Wächter**
+(`location_tz` ist keine Umgebungsuhr, also kein Muster A).
+
+Für `_compute_next_send` ist damit zu entscheiden, welche der beiden Zonen der Footer erbt.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/preview_service.py` | Fundstelle; `:217-222` dokumentiert die S5b-Entscheidung, diesen Fund an S5c zu delegieren; `:222` löst bereits `jetzt_utc` auf, aber in einer anderen Methode |
+| `src/services/compare_preview_service.py` | Fundstelle; `_prepare()` `:129-176` hat die Orte vor dem Datumsaufruf |
+| `api/routers/compare.py` | Fundstelle ×3; Alt-Bestand ohne Frontend-Aufrufer |
+| `src/services/comparison_engine.py` | Fundstelle; `dict_to_comparison_result` ohne Aufrufer |
+| `src/output/renderers/email/compare_html.py` | Fundstelle im **versendeten** Mail-Footer; `:1604` zweite Zonen-Auflösung |
+| `src/services/trip_day.py` | Baustein `trip_local_today(trip, now_utc)` (`:90-96`) — Domänenschicht |
+| `src/utils/timezone.py` | Baustein `first_resolvable_tz(locations)` (`:77-99`), `local_dt`, `location_tz` |
+| `src/services/scheduler_dispatch_service.py` | Vorbild aus S5b (`:439-442`): Zone auflösen, dann `local_dt(now, zone).date()` |
+| `tests/test_output_timezone_guard.py` | Der Wächter; Schrumpf-Test + Ordinal-Schlüssel |
+
+## Existing Patterns
+
+- **Der S5b-Griff:** Zone am Aufrufort auflösen, `local_dt(now_utc, zone).date()` statt
+  `date.today()`. Vorbild `scheduler_dispatch_service.py:439-442`.
+- **Zone nie doppelt auflösen** (ADR-0044): Ein zweiter Auflöser in derselben Kette ist ein
+  Regelverstoß. Bei `preview_service` ist deshalb zu prüfen, ob das vorhandene `trip_tz`
+  (`:226`) und ein neues `trip_local_today` aus **einer** Auflösung kommen.
+- **Regel 3 (ADR-0051):** „Jetzt" wird als Parameter hereingereicht. In S5b bewusst
+  funktionsintern gelassen, wo die Auflösung unmittelbar vor jedem Netzabruf steht.
+- **`# gz-main-path:`-Muster (#1409)** als Vorbild für begründete Zeilen-Ausnahmen, wenn UTC
+  die richtige Antwort ist.
+
+## Dependencies
+
+- **Upstream:** `trip_day.trip_local_today`, `utils.timezone.{first_resolvable_tz, local_dt,
+  location_tz}` — alle vorhanden, kein neuer Baustein nötig.
+- **Downstream:** drei Vorschau-Endpunkte (`/api/preview/{id}/{email,sms,telegram}`), die
+  Compare-Vorschau (`POST /api/preview/compare/{id}`), der Footer jeder versendeten
+  Vergleichs-Mail.
+
+## Existing Specs
+
+- `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` — Restliste „Vorschau, Werkzeuge"
+- `docs/adr/0051-drei-zeitbegriffe-zone-an-den-daten.md` — Regel 2 und Regel 3
+- `docs/specs/modules/fix_1727_s5a_befehlspfade_ortstag.md`, `…s5b_versandpfade_ortstag.md`
+- `docs/context/fix-1697-ortstag-statt-servertag.md` — Fundstellen-Karte nach Wirkung
+
+## Risks & Considerations
+
+1. **Die ADR-Restliste ist zum fünften Mal unvollständig.** ADR-0044 nennt für S5c
+   `preview_service._resolve_target_date`, `api/routers/debug.py` und
+   `tools/weather_validation.py`. Davon gehört nach dem Zuschnitt vom 2026-08-14 nur die erste
+   zu S5c; `debug.py` steht dort unter S5d, und **`tools/weather_validation.py` kommt in keiner
+   Scheibe vor** — die Datei existiert und hat einen offenen Fund (`:288`), den der Wächter
+   nicht scannt (`tools/` liegt außerhalb seines Geltungsbereichs). Umgekehrt fehlt
+   `compare_preview_service._resolve_target_date` in der ADR-Liste, obwohl der Wächter sie
+   führt. Das ADR warnt an genau dieser Stelle selbst davor: „Sie war nicht falsch, sondern
+   unvollständig — und eine unvollständige Restliste liest sich wie eine vollständige."
+2. **Die Testfläche kann den Fehler strukturell kaum zeigen.** 23 von 24 Fixtur-Dateien liegen
+   in Mitteleuropa. Für die Compare-Seite braucht es Orte mit exotischen Zonen; Vorlagen:
+   `_trip_two_zones` (`tests/tdd/test_drilldown_day_window_local_date.py:415-431`) und die
+   Drei-Zonen-Fixtur aus S5a (Pago Pago / Korsika / Kiritimati).
+3. **`freeze_time` macht Parameter-gegen-Systemuhr unfalsifizierbar** (S5a-Befund F001): Jeder
+   Test setzt `freeze_time(X)` gegen einen abweichenden Parameterwert `Y`.
+4. **Die Ordinal-Verschiebung geht in beide Richtungen** (S5b): Werden in
+   `run_comparison` nicht alle drei Funde gemeinsam behoben, verschieben sich die Ordinale der
+   verbleibenden — der Wächter meldet dieselbe Stelle dann gleichzeitig als veraltet und als
+   neuen Verstoß.
+5. **Kein bestehender Test bewacht die Umstellung.** Für `preview_service._resolve_target_date`
+   gibt es einen Test, der nur `is not None` prüft; `compare_preview_service._resolve_target_date`
+   hat null direkte Tests; der einzige Footer-Test
+   (`test_issue_1110_compare_mail_v2.py:680-696`) prüft nur, dass kein `—`-Platzhalter
+   erscheint. Die Umstellung bricht keinen davon — der Nachweis muss vollständig neu entstehen.
+6. **Der Wächter ist blind für `utcnow()`** (`_AMBIENT_CLOCK_ATTRS = {"now", "today"}`,
+   `tests/test_output_timezone_guard.py:141-145`) — bewusst so, weil `utcnow()` ausdrücklich
+   Weltzeit liefert. Für die fünf S5c-Dateien nachgemessen: keine `utcnow()`-Stelle.
+
+## Analysis
+
+### Type
+
+Bug (Fehlerklasse des Epics #1722: Kalendertag folgt der Serveruhr statt dem Ortstag).
+
+### Zwei Befunde dieses Kontext-Dokuments haben der Nachmessung nicht standgehalten
+
+Beide oben in „Die drei Befunde" formuliert, beide vom `analysis-challenger` gekippt und am
+Code gegengeprüft. **Gemeinsames Muster: aus einer unvollständigen Suche auf eine
+Wirkungsaussage geschlossen** — dieselbe Klasse, die dieses Epic bereits fünfmal getroffen hat.
+
+1. **„`GET /api/compare` hat keinen Aufrufer" ist falsch.** Die Suche deckte nur
+   `frontend/src` ab. Der Endpunkt ist im Go-Stack verdrahtet: `internal/router/router.go:156`
+   registriert ihn mit einem eigens gebauten `CompareProxyHandler`
+   (`internal/handler/proxy.go:73-100`) — 60 Sekunden Timeout „because the comparison fetches
+   weather data for multiple locations", inklusive `appendUserID` für die Mandantentrennung.
+   Er ist über die öffentliche API erreichbar. **Er wird repariert, nicht entfernt** —
+   Entfernen wäre ein stiller Breaking Change am öffentlichen API-Vertrag.
+2. **„Die Kopfzeilen-Auflösung `location_tz(locations[0].location)` ist fehlerhaft" ist
+   falsch.** Sie ist die wörtliche Umsetzung von PO-freigegebenem AC-4 aus #1378
+   (`docs/specs/modules/issue_1378_compare_zeitbasis.md:262-271`): Zeitbasis ist der
+   **erstgenannte** Ort der konfigurierten Reihenfolge, ausdrücklich nicht der erste
+   auflösbare. AC-7 (`:292-299`) verlangt nur einen **sichtbaren** UTC-Rückfall — geleistet
+   durch `local_stamp()` (`src/utils/timezone.py:132-137`). `first_resolvable_tz` wurde in
+   #1726 für eine andere fachliche Frage gebaut (Ruhezeit, Zähler, Fälligkeit).
+   **Die Kopfzeile bleibt unangetastet**; sie umzustellen wäre eine Regression gegen AC-4.
+
+Bestehen bleibt Befund 1 (`dict_to_comparison_result` ohne Aufrufer) — vom Challenger per
+Volltextsuche im ganzen Repo bestätigt: einziger Treffer ist die Definition selbst.
+
+### Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/services/preview_service.py` | MODIFY | `_resolve_target_date` nimmt `now_utc` (Pflicht) und rechnet über `trip_local_today`; `_build_report` erbt dasselbe `now_utc` statt der eigenen Auflösung bei `:223` |
+| `src/services/compare_preview_service.py` | MODIFY | `_resolve_target_date(given, locations, now_utc)`; Zone über `first_resolvable_tz(locations)` in `_prepare()` |
+| `api/routers/compare.py` | MODIFY | alle drei Funde gemeinsam: Zone aus `selected`, Stunde **und** Tag in Ortszeit |
+| `src/services/comparison_engine.py` | DELETE | `dict_to_comparison_result` (`:394-439`) ersatzlos — 0 Aufrufer |
+| `src/output/renderers/email/compare_html.py` | MODIFY | `tz` an `_render_abo_footer` und `_compute_next_send` durchreichen; Quelle ist das bereits aufgelöste `header_tz` (`:1604`) |
+| `tests/refactor/test_epic_129a_1_module_structure.py` | MODIFY | `hasattr`-Zeile für die gelöschte Funktion entfällt |
+| `tools/weather_validation.py` | MODIFY | begründete Zeilen-Ausnahme (`:288`), kein Verhaltens-Fix |
+| `tests/test_output_timezone_guard.py` | MODIFY | sechs Einträge entfallen (drei durch Fix, drei durch Löschung/Umstellung) |
+
+### Scope Assessment
+
+- Dateien: 8 (davon 2 Tests, 1 Werkzeug)
+- Produktivcode: geschätzt **+50/−60** (Löschungen überwiegen an einer Stelle)
+- Testcode: geschätzt **+200**
+- Risiko: **MEDIUM** — eine Fundstelle wirkt auf versendete Mails, drei auf einen öffentlich
+  erreichbaren Endpunkt
+
+Das LoC-Limit (250) reicht ohne Override. *(Der Plan-Agent berichtet getrennte Budgets für
+Produktiv- und Testcode à 250/500 aus dem Gate-Quellcode — **nicht nachgeprüft**, da die
+Schätzung ohnehin unter dem strengeren Wert aus CLAUDE.md liegt.)*
+
+### Technical Approach
+
+**F1 `preview_service`** — `now_utc` wird **Pflichtparameter** (Regel 3). Kosten ausgezählt:
+3 Produktiv-Aufrufer (alle in derselben Datei, `:324/:351/:377`) und 5 direkte Test-Aufrufe
+(`tests/tdd/test_epic_140_preview_endpoints.py:89,456,503,518,532`). Die 14 Testdateien, die
+nur die öffentlichen `render_*_preview`-Methoden benutzen, sind **nicht** betroffen.
+Zusätzlich entfällt die zweite Zeitauflösung bei `:223` — das eine `now_utc` speist beide.
+
+**Zwei Zonen-Auflösungen bleiben bestehen, und das ist Absicht:** `trip_local_today` löst über
+`anchor_tz` die Zone der Etappe am **Weltzeit**-Tag auf; `trip_tz` in `_build_report`
+(`:170`) löst die Zone der **Ziel**-Etappe auf. Sie beantworten verschiedene Fragen (welcher
+Tag ist „heute" vs. welche Zone rendert diesen Tag) und können an einer Etappengrenze
+auseinanderfallen. Das ist die bereits PO-akzeptierte Näherung aus `anchor_tz` („Known
+Limitation, PO 2026-08-10"), die der Versandpfad genauso lebt. **Die Spec benennt das
+ausdrücklich, statt stillschweigend Gleichheit zu unterstellen.**
+
+**F2 `compare_preview_service`** — Zone über `first_resolvable_tz(locations)` in `_prepare()`
+auflösen (die Orte stehen bei `:147` fest, der Aufruf folgt bei `:148`), `now_utc` als
+Pflichtparameter. Kosten: 1 Produktiv-Aufrufer, **0 Test-Aufrufer**. Damit spiegelt die
+Vorschau exakt das Muster, das der Compare-**Versand** seit S5b nutzt
+(`scheduler_dispatch_service.py:441-442`) — Parität entsteht, sie bricht nicht.
+
+**F3–F5 `run_comparison`** — Zone aus `selected` (steht bei `:41/:44` fest), dann **Stunde und
+Tag aus derselben Ortszeit**:
+```python
+zone = first_resolvable_tz(selected, context_label="Sofort-Vergleich")
+local_now = local_dt(datetime.now(timezone.utc), zone)
+td = local_now.date() if local_now.hour < 14 else local_now.date() + timedelta(days=1)
+```
+`now_utc` bleibt **funktionsintern** — ein FastAPI-Query-Handler ist kein sinnvoller Ort für
+einen Pflichtparameter, den kein Aufrufer von außen setzen kann. **Alle drei Funde müssen im
+selben Commit fallen** (Ordinal-Risiko, s. Risiken).
+
+**F6 `dict_to_comparison_result`** — ersatzlos entfernen. Der `hasattr`-Test zieht mit; ohne
+die Anpassung wird er laut rot, meldet sich also selbst.
+
+**F7 `_compute_next_send`** — `tz` durchreichen, Quelle ist das bereits aufgelöste `header_tz`.
+`_render_abo_footer` und `_compute_next_send` haben je genau **einen** Aufrufer, `local_dt` ist
+bereits importiert, und die **öffentliche Signatur von `render_compare_html`/
+`render_compare_email` bleibt unangetastet** — keine der ~90 Testdateien, die diese Funktionen
+aufrufen, ist betroffen. Günstigste Fundstelle der Scheibe.
+
+**F8 `tools/weather_validation.py:288`** — kein Fix, sondern eine begründete Zeilen-Ausnahme
+im Muster `# gz-main-path:` (#1409). Begründung ist am Code belegt: Das Werkzeug fragt seine
+Referenzdaten selbst ausdrücklich mit `"timezone": "UTC"` ab (`:31`), um die unverfälschte
+Anbieter-Antwort gegen die ortszeit-transformierte Pipeline zu halten. Ein Ortstag-Default
+erzeugte einen Widerspruch **innerhalb desselben Skripts**. Sie wird **jetzt** eingetragen,
+damit sie nicht ein sechstes Mal durch die Restliste fällt.
+
+### Nachweisführung
+
+- **Vorbedingungs-Anker ist inzwischen geteilt:** `_anker(now_utc, zone, erwarteter_ortstag)`
+  liegt seit #1795 in `tests/tdd/conftest.py:88-109` — S5c importiert ihn, statt die
+  S5a-Inline-Fassung zu kopieren.
+- **Trip-Fixtur mit zwei Zonen:** `trip_two_zones` (`tests/tdd/conftest.py:56-76`,
+  Wellington UTC+12 / Korsika UTC+2).
+- **Ort mit exotischer Zone:** `SavedLocation(..., timezone=None)` mit Koordinaten, die
+  `tz_for_coords` auflöst — Muster aus `tests/tdd/test_compare_local_time_basis.py:88-92`;
+  für einen großen Versatz Pago Pago (`lat=-14.28, lon=-170.70`, UTC−11) aus
+  `tests/tdd/test_befehlspfade_folgen_ortszone.py:56-57`.
+- **Parameter gegen Systemuhr** (S5a-Befund F001) ist Pflicht für F1 und F2, weil beide einen
+  Pflichtparameter bekommen: `freeze_time(X)` gegen `now_utc=Y`, Muster in
+  `tests/tdd/test_befehlspfade_folgen_ortszone.py:591-652`. Für F7 ist die Probe strukturell
+  unmöglich (kein exponierter Parameter) — dort trägt der Vorbedingungs-Anker allein.
+- **Golden-Test-Risiko am Footer gemessen, nicht vermutet:** Der einzige Footer-Test
+  (`tests/tdd/test_issue_1110_compare_mail_v2.py:680-698`) prüft nur die Anwesenheit der
+  Beschriftung und die Abwesenheit des `—`-Platzhalters, keine Datumszeichenkette und kein
+  `freeze_time`. Er bricht durch die Umstellung nicht.
+
+### Risiken
+
+1. **Ordinal-Verschiebung bei drei Funden in einer Funktion.** `run_comparison::0/1/2` teilen
+   sich einen Funktionsraum; das Ordinal ist der zeilensortierte Index
+   (`tests/test_output_timezone_guard.py:279-280`). Werden nur zwei behoben, meldet der
+   Wächter den dritten gleichzeitig als veraltet **und** als neuen Verstoß.
+2. **Der Löschpfad zieht Tests mit.** `dict_to_comparison_result` zu entfernen erfordert die
+   Anpassung des `hasattr`-Tests. Der Endpunkt bleibt, also bleiben seine zwei Tests
+   unangetastet.
+3. **Die Testfläche liegt zu 23/24 in Mitteleuropa** — jede Fixtur muss ausdrücklich eine
+   Zone wählen, in der Ortstag und Servertag auseinanderfallen, und der Anker muss das
+   **zuerst** messen.
+
+### Nebenbefund (nicht in dieser Scheibe)
+
+Footer und Compare-**Versand**-Zieltag lösen „erster Ort" verschieden auf
+(`location_tz(locations[0])` vs. `first_resolvable_tz(locations)`) und divergieren, wenn der
+erste Ort keine auflösbare Zone trägt. Beides ist für sich regelkonform — AC-4 für die
+Anzeige, #1726 AC-15 für die Fälligkeit. Ob dieselbe Mail zwei Tagesbegriffe tragen darf, ist
+eine eigene Frage und gehört nicht in eine Zeitzonen-Aufräumscheibe. **Kein Muster A, in
+keinem Wächter** → eigener Befund.
+
+### Open Questions
+
+Keine blockierenden. Die im Kontext offenen Punkte sind entschieden: Endpunkt bleibt (Go-Proxy
+belegt), Kopfzeile bleibt (AC-4 belegt), `dict_to_comparison_result` entfällt (0 Aufrufer),
+`weather_validation` bekommt eine Ausnahme statt eines Fixes. Alle vier stehen in der Spec zur
+PO-Freigabe.
+
+## Wächter-Restliste (Stand nach S5b)
+
+59 Einträge gesamt: **14 × Muster A**, 23 × `raw_astimezone`, 2 × dauerhaft, 20 ×
+aufrufseitig abgesichert.
+
+Die 14 offenen Muster-A-Einträge: `api/routers/compare.py` (3), `compare_html.py` (1),
+`compare_preview_service.py` (1), `comparison_engine.py` (1), `preview_service.py` (1) — das
+sind die **sieben von S5c** — sowie `api/routers/debug.py` (1), `gpx_processing.py` (3),
+`massif_closure.py` (2), `meteo_forets.py` (1) — die **sieben von S5d**.
+
+**Nach S5c und S5d ist die Muster-A-Liste leer.** Es bleiben die 23 `raw_astimezone`-Einträge,
+der Detektor Muster 3, die ungescannten Stellen (`openmeteo.py`, `tools/weather_validation.py`)
+und das Frontend — alles S5e.

--- a/docs/specs/modules/fix_1727_s5c_vorschau_anzeige_ortstag.md
+++ b/docs/specs/modules/fix_1727_s5c_vorschau_anzeige_ortstag.md
@@ -1,0 +1,489 @@
+---
+entity_id: fix_1727_s5c_vorschau_anzeige_ortstag
+type: bugfix
+created: 2026-08-14
+updated: 2026-08-14
+status: draft
+version: "1.0"
+tags: [timezone, preview-service, compare-preview-service, compare-router, comparison-engine, compare-html, issue-1727, issue-1722, adr-0044, adr-0051]
+workflow: fix-1727-s5c-vorschau-anzeige
+---
+
+# Fix #1727 S5c — Vorschau, Anzeige, Sofort-Vergleich folgen dem Ortstag
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Sieben Fundstellen in fünf Dateien bestimmen den Kalendertag der Trip- und Compare-Vorschau
+sowie des Sofort-Vergleichs (`GET /api/compare`) weiterhin über die Serveruhr
+(`date.today()`/`datetime.now()` ohne Zone) statt über den Ortstag der Tour bzw. des
+Preset-Orts — ein Verstoß gegen die bereits akzeptierte ADR-0044. Anders als S5b (Versandpfade)
+wirken die Fundstellen dieser Scheibe primär auf **Vorschau- und Anzeige-Pfade** — mit einer
+Ausnahme: `compare_html.py::_compute_next_send` sitzt im Footer einer tatsächlich versendeten
+Ortsvergleichs-Mail. Diese Scheibe schließt sechs der sieben Fundstellen, indem sie an jeder den
+geteilten Baustein `trip_local_today(trip, now_utc)` bzw. `first_resolvable_tz(locations)`
+einsetzt — keine eigene Kopie der Zonen-Auflösung. Die siebte Fundstelle
+(`dict_to_comparison_result`) wird ersatzlos entfernt, weil sie keinen Aufrufer hat.
+
+Zusätzlich entscheidet diese Scheibe zwei Produktfragen, die das Kontext-Dokument als offen
+markiert hatte, aber der `analysis-challenger` am Code widerlegt hat: `GET /api/compare` bleibt
+bestehen (Go-Proxy `CompareProxyHandler` verdrahtet ihn öffentlich, `internal/router/router.go:156`),
+und die Kopfzeilen-Zeitbasis der Compare-Mail (`location_tz(locations[0].location)`) bleibt
+unangetastet (wörtliche Umsetzung von #1378 AC-4). Beide sind damit keine offenen Fragen mehr,
+sondern in dieser Spec entschiedener Rahmen.
+
+## Source
+
+- **File:** `src/services/preview_service.py`
+  **Identifier:** `_resolve_target_date` (Zeile 84, Verstoß Zeile 94), `_build_report`
+  (Zeile 120, zweite Zeitauflösung Zeile 223)
+- **File:** `src/services/compare_preview_service.py`
+  **Identifier:** `_resolve_target_date` (Modulfunktion, Zeile 255, Verstoß Zeile 258),
+  `_prepare` (Zeile 129, Orte stehen bei Zeile 147 fest, Aufruf folgt Zeile 148)
+- **File:** `api/routers/compare.py`
+  **Identifier:** `run_comparison` (Zeile 26, drei Verstöße Zeile 53/55/58)
+- **File:** `src/services/comparison_engine.py`
+  **Identifier:** `dict_to_comparison_result` (Zeile 394–439, Verstoß Zeile 407) — wird entfernt
+- **File:** `src/output/renderers/email/compare_html.py`
+  **Identifier:** `_compute_next_send` (Zeile 1438, Verstoß Zeile 1443), `_render_abo_footer`
+  (Zeile 1457, einziger Aufrufer Zeile 1670), `render_compare_html` (Zeile 1526, `header_tz`
+  bereits aufgelöst Zeile 1604)
+- **File:** `tools/weather_validation.py`
+  **Identifier:** Punkt-Validierungsmodus, Zeile 288 (Zeilen-Ausnahme, kein Fix)
+- **Zonen-Auflösung (unverändert nutzen):** `src/services/trip_day.py::trip_local_today(trip,
+  now_utc)` (Zeile 90–96) und `::anchor_tz` (Zeile 55–71), `src/utils/timezone.py::
+  first_resolvable_tz(locations, context_label="")` (Zeile 77–99), `::local_dt(dt, tz)`
+  (Zeile 109–111)
+- **Öffentlicher Aufrufer von `GET /api/compare` (Go-Seite, unverändert):**
+  `internal/router/router.go:156` (`handler.CompareProxyHandler`), `internal/handler/proxy.go:73-100`
+- **Zeilennummern gemessen am Basis-HEAD `e2b5269b`** (2026-08-14); vgl. ADR-0044s eigene Lehre
+  aus veralteten Zeilenangaben — die `KNOWN_VIOLATIONS`-Kommentare im Wächter selbst tragen zum
+  Teil noch ältere Zeilennummern (`:1377` statt der aktuellen `:1443` bei `compare_html.py`), das
+  ist normale Drift und kein Fund dieser Scheibe.
+
+## Estimated Scope
+
+- **LoC:** Produktivcode ~+50/−60 (Löschungen überwiegen an einer Stelle — `comparison_engine.py`
+  verliert ~45 Zeilen), Testcode ~+200 (Zahlen aus der Kartierung übernommen, nicht neu
+  geschätzt). Das LoC-Limit (250) reicht ohne Override.
+- **Files:** 8 laut Kartierung (5 Fundstellendateien inkl. Löschziel, 1 Wächterdatei MODIFY,
+  1 Strukturtestdatei MODIFY, 1 Werkzeugdatei MODIFY) plus neue Verhaltenstestdatei(en) und
+  mechanisch mitgezogene Bestandstestdateien (s. u.)
+- **Effort:** medium — Risiko laut Kartierung **MEDIUM** (eine Fundstelle wirkt auf versendete
+  Mails, drei auf einen öffentlich erreichbaren Endpunkt)
+
+**Direkt am Code nachgemessen, nicht im Kontext-Dokument beziffert:** `_build_report`
+(`preview_service.py:120`) verliert seine eigene `jetzt_utc = datetime.now(timezone.utc)`
+(Zeile 223) und bekommt `now_utc` als Pflichtparameter — zusätzlich zu den 3 Produktiv-Aufrufern
+(`:325/:352/:378`, dieselben drei Stellen wie bei `_resolve_target_date`) binden das neun
+Bestandstest-Aufrufstellen in sechs Dateien: `tests/unit/test_preview_night_block.py` (3×,
+Zeile 221/265/309), `tests/tdd/test_thunder_night_addendum_parity.py` (1×, Zeile 233),
+`tests/tdd/test_sms_preview_matches_sent.py` (1×, Zeile 82),
+`tests/tdd/test_epic_140_preview_endpoints.py` (2×, Zeile 471/486),
+`tests/tdd/test_preview_parity_without_outlook.py` (1×, Zeile 170),
+`tests/tdd/test_preview_render_options_parity.py` (1×, Zeile 108) — je eine mechanische
+`now_utc=`-Ergänzung, analog zum S5b-Muster „~20 Bestandstestdateien, je eine Zeile".
+
+### Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/services/preview_service.py` | MODIFY | `_resolve_target_date` nimmt `now_utc` (Pflicht) und rechnet über `trip_local_today` statt `date.today()`; `_build_report` erbt dasselbe `now_utc` statt der eigenen Auflösung bei `:223` — beide Funktionen speist EIN `now_utc`, das jeder der drei öffentlichen `render_*_preview`-Methoden einmal bindet |
+| `src/services/compare_preview_service.py` | MODIFY | `_resolve_target_date(given, locations, now_utc)`; Zone über `first_resolvable_tz(locations)`, aufgelöst in `_prepare()` aus den dort bereits geladenen Orten (`:147`); `given is not None`-Zweig unverändert |
+| `api/routers/compare.py` | MODIFY | `run_comparison`: alle drei Funde (Stunde, Zieltag heute, Zieltag morgen) im selben Commit auf `first_resolvable_tz(selected)` + `local_dt(...)` umgestellt; `now_utc` bleibt funktionsintern (Query-Handler, kein sinnvoller externer Pflichtparameter); Endpunkt selbst bleibt bestehen |
+| `src/services/comparison_engine.py` | DELETE | `dict_to_comparison_result` (`:394-439`) ersatzlos — 0 Aufrufer im gesamten Repo (Volltextsuche, Definition ausgenommen) |
+| `src/output/renderers/email/compare_html.py` | MODIFY | `_compute_next_send` und `_render_abo_footer` bekommen `tz` als Parameter; Quelle ist das in `render_compare_html` bereits aufgelöste `header_tz` (`:1604`) — analog zum bestehenden Muster `render_undelivered_html(undelivered, tz=header_tz)` (`:1665`). Öffentliche Signatur von `render_compare_html`/`render_compare_email` bleibt unangetastet |
+| `tests/refactor/test_epic_129a_1_module_structure.py` | MODIFY | `hasattr(mod, "dict_to_comparison_result")`-Zeile (`:45-46`) entfällt bzw. wird auf Abwesenheit geprüft |
+| `tools/weather_validation.py` | MODIFY | begründete Zeilen-Ausnahme (`:288`) im Muster `# gz-main-path:` (#1409), kein Verhaltens-Fix |
+| `tests/test_output_timezone_guard.py` | MODIFY | sieben `KNOWN_VIOLATIONS`-Einträge entfallen (s. AC-7) |
+| `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` | MODIFY | „Umgesetzt"/„Noch nicht umgesetzt" nachziehen: die Restliste „Vorschau, Werkzeuge" (`:169-174`) nennt aktuell `preview_service._resolve_target_date`, `api/routers/debug.py` UND `tools/weather_validation.py` in einem Satz — nach dieser Scheibe gehört nur noch `api/routers/debug.py` dorthin (S5d), `weather_validation.py` trägt eine dokumentierte Ausnahme statt offen zu sein |
+| ~6 Bestandstestdateien (`_build_report`-Aufrufer) | MODIFY | 9 Aufrufstellen, je eine Zeile `now_utc=` ergänzt (s. o.) |
+| `tests/tdd/test_<verhalten>.py` | CREATE | Verhaltenstests aller sieben Fundstellen inkl. Vorbedingungs-Anker, nach Verhalten benannt |
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `services.trip_day.trip_local_today(trip, now_utc)` | module function | Ersetzt `date.today()` an F1 (`preview_service`) |
+| `utils.timezone.first_resolvable_tz(locations, context_label="")` | module function | Zonenwahl bei mehreren Compare-Orten (F2, F3–F5) — dasselbe Muster wie #1726 und S5b |
+| `utils.timezone.local_dt(dt, tz)` | module function | Ortszeit aus `now_utc` + aufgelöster Zone (F2, F3–F5, F7) |
+| `header_tz` (bereits aufgelöst in `render_compare_html`, `:1604`) | local variable | Quelle für F7 — keine zweite Auflösung (ADR-0044) |
+| ADR-0044 (Akzeptiert) | decision | Verlangt Ortstag statt Servertag; die Restliste „Vorschau, Werkzeuge" wird durch diese Scheibe präzisiert (Nebenbefund: die Liste war zum fünften Mal unvollständig) |
+| ADR-0051 (Vorgeschlagen), Regel 2 + Regel 3 | decision | Regel 2 (Zone gehört an die Daten) begründet `first_resolvable_tz`/`trip_local_today` statt Server-/Prozesszone; Regel 3 (keine Umgebungsuhr) begründet `now_utc` als Pflichtparameter an F1/F2 |
+| `CompareProxyHandler` (`internal/handler/proxy.go:73-100`), `internal/router/router.go:156` | consumer (Go) | Belegt den öffentlichen Aufrufer von `GET /api/compare` — der Endpunkt bleibt, wird nicht entfernt |
+| `tests/refactor/test_epic_129a_1_module_structure.py::test_comparison_engine` | guard | Hasattr-Test auf `dict_to_comparison_result` — wird mit F6 angepasst, sonst rot |
+| `tests/test_output_timezone_guard.py::test_known_violations_only_shrink` | guard | Die sieben Einträge müssen im selben Commit entfallen, sonst rot (s. AC-7) |
+| `docs/specs/modules/fix_1727_s5a_befehlspfade_ortstag.md`, `…s5b_versandpfade_ortstag.md` | pattern | Vorgängerscheiben — Vorbild für Aufbau, Nachweisform, `_anker` |
+| `_anker` (`tests/tdd/conftest.py:88-109`), `trip_two_zones` (`:56-76`) | test fixture | Geteilter Vorbedingungs-Anker und Zwei-Zonen-Trip-Fixtur (seit #1795) — keine dritte Kopie |
+| `SavedLocation(..., timezone=None)` mit Pago-Pago-Koordinaten (`lat=-14.28, lon=-170.70`) | test fixture | Muster aus `tests/tdd/test_befehlspfade_folgen_ortszone.py:56-57` — Ort mit über `tz_for_coords` aufgelöster exotischer Zone, für F2/F3-F5 |
+
+## Implementation Details
+
+Ein Muster, sechsmal angewandt (F6 ist Löschung, kein Umbau) — kein neuer Baustein:
+
+| Lage am Fundort | Vorgehen | Fundstellen |
+|---|---|---|
+| `trip` vorhanden, drei öffentliche Aufrufer im selben Modul | `now_utc` Pflichtparameter in `_resolve_target_date` UND `_build_report`, `trip_local_today(trip, now_utc)` | F1 |
+| Mehrere Orte statt eines Trips, Orte vor dem Datumsaufruf bereits geladen | `now_utc` Pflichtparameter, Zone über `first_resolvable_tz(locations)` | F2 |
+| Weder `trip` noch persistente Zone am Fundort, FastAPI-Query-Handler | `now_utc` bleibt funktionsintern, Zone aus den bereits aufgelösten `selected`-Orten | F3–F5 |
+| Funktion ohne Aufrufer | ersatzlos entfernen, abhängigen Struktur-Test mitziehen | F6 |
+| Zone bereits eine Ebene höher aufgelöst (`header_tz`) | `tz` durchreichen statt zweiter Auflösung | F7 |
+| Werkzeug fragt seine Referenz selbst mit `"timezone": "UTC"` ab | begründete Zeilen-Ausnahme statt Fix | F8 |
+
+**F1 — `preview_service.py`, EIN `now_utc` speist zwei Funktionen:**
+```python
+def _resolve_target_date(self, trip: "Trip", given_date: str | None, now_utc: datetime) -> date:
+    if given_date:
+        return date.fromisoformat(given_date)
+    today = trip_local_today(trip, now_utc)
+    ...  # unveraendert: sortierte Etappensuche ab `today`
+
+def _build_report(self, trip: "Trip", target: date, report_type: str, now_utc: datetime,
+                   demo: bool = False):
+    ...
+    # Zeile 223 entfaellt: kein eigenes `jetzt_utc = datetime.now(timezone.utc)` mehr
+    if segment_weather and render_options.show_multi_day_trend:
+        trend_result = scheduler._build_stage_trend(trip, target, now_utc=now_utc, tz=trip_tz)
+```
+Alle drei öffentlichen Methoden (`render_email_preview`, `render_sms_preview`,
+`render_telegram_preview`) binden `now_utc = datetime.now(timezone.utc)` einmal und reichen es an
+beide Aufrufe durch — damit bestimmen `_resolve_target_date` (welche Etappe ist "heute") und
+`_build_report`s Trend-/Ausblicks-Beschaffung (welcher Tag gilt beim Wetterabruf) garantiert
+denselben Ortstag, statt zweier potenziell auseinanderfallender `date.today()`-Momentaufnahmen.
+
+**F2 — `compare_preview_service.py`, Zone aus bereits geladenen Orten:**
+```python
+def _resolve_target_date(given: str | date | None, locations: list, now_utc: datetime) -> date:
+    if given is None or given == "":
+        zone = first_resolvable_tz(locations, context_label="Compare-Vorschau")
+        return local_dt(now_utc, zone).date()
+    if isinstance(given, date):
+        return given
+    return date.fromisoformat(str(given))
+
+# in _prepare():
+locations = self._resolve_locations(preset, user_id=user_id)          # :147, unveraendert
+resolved_date = _resolve_target_date(target_date, locations, datetime.now(timezone.utc))
+```
+Damit spiegelt die Vorschau exakt das Muster, das der Compare-**Versand** seit S5b nutzt
+(`scheduler_dispatch_service.py:441-442`) — Parität entsteht, sie bricht nicht. 0 Test-Aufrufer
+(`_resolve_target_date` wird nur aus `_prepare()` heraus aufgerufen).
+
+**F3–F5 — `api/routers/compare.py::run_comparison`, alle drei Funde im selben Commit:**
+```python
+if target_date:
+    td = date.fromisoformat(target_date)
+else:
+    zone = first_resolvable_tz(selected, context_label="Sofort-Vergleich")
+    local_now = local_dt(datetime.now(timezone.utc), zone)
+    td = local_now.date() if local_now.hour < 14 else local_now.date() + timedelta(days=1)
+```
+`now_utc` bleibt funktionsintern — ein FastAPI-Query-Handler ist kein sinnvoller Ort für einen
+von außen gesetzten Pflichtparameter. Werden nicht alle drei Funde gemeinsam behoben, verschiebt
+sich das Ordinal der verbleibenden im Wächter (Risiko, s. u.) — deshalb ist die Atomarität selbst
+Teil von AC-3.
+
+**F6 — `comparison_engine.py`, ersatzlose Löschung:**
+`dict_to_comparison_result` (`:394-439`) entfällt vollständig. Der zugehörige Struktur-Test
+(`tests/refactor/test_epic_129a_1_module_structure.py:45-46`) prüft danach NICHT mehr
+`hasattr(mod, "dict_to_comparison_result") == True`; entweder die Assertion entfällt oder sie
+wird auf `False` gedreht — beides macht die Absicht (Symbol existiert nicht mehr) explizit statt
+den Test kommentarlos still zu lassen.
+
+**F7 — `compare_html.py`, `tz` durchreichen statt zweiter Auflösung:**
+```python
+def _compute_next_send(schedule, weekday, tz) -> Optional[str]:
+    if not schedule:
+        return None
+    today = local_dt(datetime.now(timezone.utc), tz).date()
+    ...  # Rest unveraendert
+
+def _render_abo_footer(preset_name, preset_schedule, preset_weekday, location_count, sig, tz) -> str:
+    next_send = _compute_next_send(preset_schedule, preset_weekday, tz) or "—"
+    ...
+
+# in render_compare_html():
+abo_html = _render_abo_footer(preset_name, preset_schedule, preset_weekday, len(locations), sig,
+                               header_tz)
+```
+`header_tz` liegt bei Aufruf bereits vor (`:1604`) — exakt das Muster, das
+`render_undelivered_html(undelivered, tz=header_tz)` (`:1665`) schon nutzt. `_render_abo_footer`
+und `_compute_next_send` haben je genau einen Aufrufer; die öffentliche Signatur von
+`render_compare_html`/`render_compare_email` ändert sich nicht — keine der ~90 Testdateien, die
+diese Funktionen aufrufen, ist betroffen.
+
+**F8 — `tools/weather_validation.py:288`, begründete Ausnahme statt Fix:**
+```python
+if args.lat and args.lon:
+    target_date = args.date or date.today().isoformat()  # gz-main-path: Werkzeug fragt seine
+    # Referenzdaten selbst mit "timezone": "UTC" ab (Zeile 31) -- ein Ortstag-Default erzeugte
+    # einen Widerspruch INNERHALB desselben Skripts.
+```
+Kein Code-Verhalten ändert sich; die Zeile trägt danach eine für den Wächter lesbare Begründung
+(`tools/` liegt außerhalb von dessen Geltungsbereich, die Ausnahme ist trotzdem dokumentiert,
+damit sie nicht ein sechstes Mal unvollständig durch eine ADR-Restliste fällt).
+
+## Nicht in dieser Scheibe
+
+- **Die Kopfzeilen-Auflösung `location_tz(locations[0].location)`** (`compare_html.py:1604`)
+  bleibt unverändert — sie ist die wörtliche Umsetzung von PO-freigegebenem AC-4 aus #1378
+  (`docs/specs/modules/issue_1378_compare_zeitbasis.md:262-271`): Zeitbasis ist der
+  **erstgenannte** Ort der konfigurierten Reihenfolge, ausdrücklich nicht der erste auflösbare.
+  Sie umzustellen wäre eine Regression gegen AC-4, kein Fix.
+- **Die Divergenz zwischen Footer-Zone und Compare-Versand-Zieltag.** `_compute_next_send`
+  bekommt mit F7 `header_tz` (= `location_tz(locations[0])`, fällt bei nicht auflösbarem ersten
+  Ort still auf UTC), während der Compare-**Versand** seinen Zieltag über
+  `first_resolvable_tz(locations)` (überspringt einen nicht auflösbaren ersten Ort) bestimmt
+  (`scheduler_dispatch_service.py:441`). Beide sind für sich regelkonform — AC-4 für die
+  Kopfzeile/den Footer, #1726 AC-15 für die Fälligkeit. Sie divergieren nur, wenn der erste Ort
+  keine auflösbare Zone trägt. Ob dieselbe Mail zwei verschiedene "erster Ort"-Auflösungen tragen
+  darf, ist eine eigene fachliche Frage und gehört nicht in diese Zeitzonen-Aufräumscheibe.
+- **`api/routers/debug.py`** (Debug-Auslöser für Radar-Alarme) und **`gpx_processing.py`/
+  `massif_closure.py`/`meteo_forets.py`** — die verbleibenden sieben offenen Muster-A-Einträge
+  des Wächters, S5d.
+- **Der Wächter bleibt blind für `datetime.utcnow()`** (`_AMBIENT_CLOCK_ATTRS = {"now", "today"}`,
+  `tests/test_output_timezone_guard.py:145`) — für die fünf S5c-Dateien nachgemessen: keine
+  `utcnow()`-Stelle vorhanden, der Detektor selbst wird hier nicht erweitert (S5e).
+- **`send_on_demand_report`** (`trip_report_scheduler.py:966`) und die Go-Seite — unverändert aus
+  S5b übernommene offene (b)-Folgescheibe bzw. eigener Befund außerhalb des Epics.
+
+## Zwei bewusst nebeneinander bestehende Zonen-Auflösungen in `preview_service`
+
+`_resolve_target_date`/`_build_report` nutzen nach dieser Scheibe **zwei** Zonen-Auflösungen, und
+das ist Absicht, keine Inkonsistenz:
+
+- `trip_local_today(trip, now_utc)` (über `anchor_tz`, `trip_day.py:55-71`) beantwortet „welcher
+  Kalendertag ist gerade?" — Zone ist die der Etappe am **Weltzeit**-Tag. Das ist der bewusst
+  gewählte Anker, weil die naive Alternative „erste Etappe der Tour" bei einer Tour über mehrere
+  Zonen bis zu zehn Stunden danebenlag (`anchor_tz`-Docstring). Restfehler: die Zonendifferenz
+  zweier **benachbarter** Etappen an einem Wechseltag — „Known Limitation, PO 2026-08-10",
+  unverändert akzeptiert.
+- `trip_tz = tz_for_coords(segments[0].start_point.lat, segments[0].start_point.lon)`
+  (`_build_report:170`) beantwortet eine andere Frage: „in welcher Zone wird die **Ziel**-Etappe
+  gerendert?" — Zone der ersten Segment-Koordinate von `target`, nicht der Weltzeit-Etappe.
+
+Beide Fragen können an einer Etappengrenze auseinanderfallen; das ist dieselbe Näherung, die der
+Versandpfad seit S5b lebt. **Diese Spec benennt das ausdrücklich** — eine stillschweigende
+Gleichsetzung beider Zonen wäre der Fehler, den diese Scheibe nicht macht.
+
+## Nachweisführung
+
+Vollständig **offline** belegbar (Kern-Schicht): `freeze_time` + In-Memory-`Trip`/`Stage`/
+`Waypoint`/`SavedLocation`-Fixturen. Für F1–F6 keine Staging-Mail nötig (Vorschau- bzw.
+Struktur-Pfad). Für F7 genügt der Render-Aufruf gegen den fertigen HTML-String — kein Versand
+nötig, geprüft wird die Tagesbestimmung, nicht der Transport.
+
+Verfügbare Mehrzonen-Fixturen (aus S5a/S5b übernommen, keine vierte Kopie):
+
+- `trip_two_zones` (`tests/tdd/conftest.py:56-76`) — Wellington (UTC+12) + Korsika (UTC+2)
+- `SavedLocation(..., timezone=None)` mit Koordinaten, die `tz_for_coords` auflöst (Muster
+  `tests/tdd/test_compare_local_time_basis.py:88-92`); für einen großen Versatz Pago Pago
+  (`lat=-14.28, lon=-170.70`, UTC−11) aus `tests/tdd/test_befehlspfade_folgen_ortszone.py:56-57`
+- Vorbedingungs-Anker `_anker(now_utc, zone, erwarteter_ortstag)`
+  (`tests/tdd/conftest.py:88-109`, seit #1795 geteilt) — S5c importiert ihn, statt eine eigene
+  Fassung zu schreiben
+
+**Parameter gegen Systemuhr** (Muster S5a-F001) ist **Pflicht überall dort, wo ein
+Pflichtparameter entsteht** — F1 (`_resolve_target_date` UND `_build_report`) und F2
+(`_resolve_target_date`): `freeze_time(X)` gegen `now_utc=Y` mit unterschiedlichen Ortstagen;
+eine Implementierung, die den Parameter entgegennimmt, im Rumpf aber `date.today()` benutzt,
+liefert den Ortstag von X und macht den Test rot. Ohne diese Probe ist „Parameter behalten, im
+Rumpf ignoriert" strukturell nicht falsifizierbar (S5a-Befund F001).
+
+**Für F3–F5 und F7 ist diese Probe strukturell unmöglich** — `now_utc` bleibt an beiden Stellen
+funktionsintern (kein exponierter Parameter, den man der Uhr entgegenstellen könnte). Dort trägt
+ausschließlich (a): unter `freeze_time` liefert eine Zone mit deutlichem Offset einen anderen
+Ortstag als den Servertag — belegt durch den Vorbedingungs-Anker.
+
+**Golden-Test-Risiko am Footer gemessen, nicht vermutet:** Der einzige Footer-Test
+(`tests/tdd/test_issue_1110_compare_mail_v2.py:680-698`) prüft nur die Anwesenheit der
+Beschriftung „Nächster Versand" und die Abwesenheit des `—`-Platzhalters, keine Datumszeichenkette
+und kein `freeze_time`. Er bricht durch die F7-Umstellung nicht — der Nachweis für F7 muss
+vollständig neu entstehen.
+
+## Testbenennung
+
+Testdateien nach Verhalten benennen, nicht nach Issue-Nummer — durchgesetzt von
+`test_naming_gate.py`, das neue issue-nummerierte Testdateien hart blockiert. Kein
+`test_issue_1727*`-Name. Vorschlag (analog S5a/S5b):
+`tests/tdd/test_vorschau_anzeige_folgen_ortszone.py` als Sammel-Datei für alle sieben
+Fundstellen; eine Aufteilung je Fundstelle ist ebenso zulässig.
+
+## Expected Behavior
+
+Beispiel: Eine Tour in Neuseeland (`Pacific/Auckland`, UTC+12), Server auf Weltzeit,
+Abruf am 20.08.2026 um 14:00 UTC — am Ort ist es bereits der 21.08., 02:00 Uhr.
+
+| Was der Nutzer tut | Bisher | Nach dieser Scheibe |
+|---|---|---|
+| Trip-Vorschau ohne Datum öffnen | Etappe des **20.08.** (Servertag) | Etappe des **21.08.** (Ortstag) |
+| Ortsvergleichs-Vorschau ohne Datum öffnen | Vergleich für den **Servertag** | Vergleich für den **Ortstag des ersten auflösbaren Orts** |
+| `GET /api/compare` ohne `target_date` | Schwelle „vor 14:00" an der **Serverstunde**, Tag vom Server — Stunde und Tag können aus verschiedenen Tagesbegriffen stammen | Stunde **und** Tag aus **derselben** Ortszeit |
+| Vergleichs-Mail lesen, Fußzeile „Nächster Versand" | Datum vom **Servertag** berechnet, während die Kopfzeile derselben Mail bereits Ortszeit zeigt | Datum aus **derselben Zone wie die Kopfzeile** |
+
+Unverändert bleibt jeder Aufruf **mit** ausdrücklichem Datum: Wer ein Datum angibt, bekommt
+genau dieses — der `given is not None`-Zweig wird nicht angefasst.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine Trip-Vorschau (`render_email_preview`/`render_sms_preview`/
+  `render_telegram_preview`, `preview_service.py`) wird OHNE explizites `target_date` für eine
+  Tour in einer Zone mit deutlichem UTC-Offset aufgerufen (Fixtur `trip_two_zones`, Wellington
+  UTC+12), sodass Ortstag und Servertag zum Aufrufzeitpunkt auseinanderfallen / When
+  `_resolve_target_date(trip, given_date=None, now_utc)` (`:84`) die Etappe wählt und
+  anschließend `_build_report(trip, target, report_type, now_utc, ...)` (`:120`) denselben
+  `now_utc` für die Trend-/Ausblicks-Beschaffung verwendet / Then bestimmen BEIDE Funktionen
+  „heute" über `trip_local_today(trip, now_utc)`, NICHT über je eine eigene
+  `date.today()`-Auflösung — die zweite, bislang bei `:223` liegende Auflösung entfällt
+  ersatzlos, ein einziges `now_utc` speist beide Entscheidungen.
+  - Test: **Parameter gegen Systemuhr** (Muster S5a-F001) — `freeze_time(X)` gegen `now_utc=Y`
+    mit unterschiedlichen Ortstagen derselben Trip-Zone; Assertion, dass das gewählte
+    Vorschau-Datum dem Ortstag von Y folgt, nicht dem von X. Vorbedingungs-Anker `_anker` davor
+    Pflicht.
+
+- **AC-2:** Given eine Compare-Vorschau (`POST /api/preview/compare/{preset_id}`) wird OHNE
+  explizites `target_date` für ein Preset mit mehreren Orten unterschiedlicher Zonen
+  aufgerufen, dessen ERSTER konfigurierter Ort keine auflösbare Zone trägt / When `_prepare()`
+  (`compare_preview_service.py:129`) die Orte auflöst (`:147`) und danach
+  `_resolve_target_date(None, locations, now_utc)` (Modulfunktion, `:255`) aufruft / Then
+  bestimmt die Funktion das Ergebnis über `first_resolvable_tz(locations)` (überspringt den
+  unauflösbaren ersten Ort) und das übergebene `now_utc`, NICHT über `date.today()`; der
+  `given is not None`-Zweig (explizites Datum von der UI) bleibt dabei unverändert.
+  - Test: Parameter gegen Systemuhr (wie AC-1) plus Vorbedingungs-Anker, Fixtur mit zwei Orten
+    (erster ohne auflösbare Zone, zweiter mit deutlichem Offset); Assertion auf das gelieferte
+    Datum gegen die Zone des zweiten Orts.
+
+- **AC-3:** Given `GET /api/compare` (öffentlich erreichbar über den Go-Proxy
+  `CompareProxyHandler`, `internal/router/router.go:156`) wird OHNE `target_date` für
+  `location_ids` aufgerufen, deren erster auflösbarer Ort in einer Zone liegt, in der die
+  Ortszeit kurz vor bzw. kurz nach 14:00 Uhr steht, während die Serveruhr in einem anderen
+  Fenster steht / When `run_comparison` (`api/routers/compare.py:26`, Verstöße `:53/:55/:58`)
+  sowohl die 14:00-Schwelle als auch den Zieltag „heute"/„morgen" bestimmt / Then beruhen BEIDE
+  Entscheidungen auf DERSELBEN Ortszeit (`local_dt(datetime.now(timezone.utc),
+  first_resolvable_tz(selected))`) statt auf der naiven, zonenlosen Serveruhr — alle drei
+  Fundstellen ändern sich im selben Commit; bliebe eine davon auf Servertag stehen, wäre die
+  14:00-Schwelle in sich widersprüchlich (Stunde einer Zone, Tag einer anderen).
+  - Test: zwei Szenarien unter `freeze_time` — Ortszeit 13:xx Uhr (→ `td` = heutiger Ortstag) und
+    Ortszeit 14:xx Uhr (→ `td` = Ortstag + 1) — bei einer Serveruhr, die jeweils im anderen
+    Fenster steht als die Ortszeit; Assertion auf `td` im JSON-Response von `run_comparison`.
+    Vorbedingungs-Anker davor Pflicht.
+
+- **AC-4:** Given `services.comparison_engine.dict_to_comparison_result` (`:394-439`) hat außer
+  der eigenen Definition und dem Struktur-Test `tests/refactor/test_epic_129a_1_module_structure
+  .py::test_comparison_engine` keinen Aufrufer in `src/`, `api/`, `tests/`, `frontend/`,
+  `internal/`, `cmd/` (Volltextsuche, Definitionsstelle ausgenommen) / When die Funktion
+  ersatzlos entfernt wird / Then gelingt `import services.comparison_engine` weiterhin,
+  `hasattr(mod, "dict_to_comparison_result")` liefert `False`, und der Struktur-Test prüft NICHT
+  mehr auf Anwesenheit, sondern auf Abwesenheit (oder die Assertion entfällt ersatzlos) — kein
+  verbleibender Muster-A-Fund für eine tote Funktion.
+  - Test: `tests/refactor/test_epic_129a_1_module_structure.py::test_comparison_engine`
+    angepasst; `tests/test_output_timezone_guard.py::test_known_violations_only_shrink`/
+    `::test_no_unlisted_output_timezone_violations` bleiben grün, nachdem der zugehörige Eintrag
+    entfernt wurde.
+
+- **AC-5:** Given eine versendete Ortsvergleichs-Mail, deren Kopfzeile bereits
+  `header_tz = location_tz(locations[0].location)` aufgelöst hat (`compare_html.py:1604`), und
+  deren Abo-Preset ein `weekly`- oder `daily`-Schedule trägt, in einer Zone mit deutlichem
+  Offset zur Serveruhr / When `render_compare_html` über `_render_abo_footer` (`:1457`) den
+  Footer-Text „Nächster Versand" via `_compute_next_send(schedule, weekday, tz)` (`:1438`)
+  berechnet / Then erhält `_compute_next_send` `tz` als zusätzlichen Parameter, dessen Quelle
+  DAS BEREITS AUFGELÖSTE `header_tz` ist (`local_dt(datetime.now(timezone.utc), tz).date()`
+  statt `date.today()`), und `_render_abo_footer` reicht `tz` unverändert durch — analog zum
+  bestehenden Muster `render_undelivered_html(undelivered, tz=header_tz)` (`:1665`). Die
+  öffentliche Signatur von `render_compare_html`/`render_compare_email` bleibt unangetastet.
+  - Test: Für F7 ist die Parameter-gegen-Systemuhr-Probe strukturell unmöglich (kein von außen
+    exponierter Parameter) — stattdessen Vorbedingungs-Anker + `freeze_time` gegen eine Zone mit
+    deutlichem Offset; Assertion auf das im gerenderten Footer-HTML enthaltene Datum, je einmal
+    für `weekly`- und `daily`-Schedule.
+
+- **AC-6:** Given `tools/weather_validation.py:288` löst
+  `target_date = args.date or date.today().isoformat()` im Punkt-Validierungsmodus
+  (`--lat`/`--lon` ohne `--date`) auf, während dasselbe Werkzeug seine Referenzdaten in
+  `fetch_openmeteo` ausdrücklich mit `"timezone": "UTC"` abfragt (`:31`) / When diese Zeile im
+  Zuge der Scheibe bewertet wird / Then bekommt sie KEINEN Verhaltens-Fix, sondern eine
+  begründete Zeilen-Ausnahme im Muster `# gz-main-path:` (#1409) mit einer fachlichen Begründung
+  von mindestens 15 sinnvollen Zeichen, die auf die UTC-Abfrage der Referenzdaten verweist — ein
+  Ortstag-Default erzeugte sonst einen Widerspruch INNERHALB desselben Skripts (Validierungsziel
+  UTC, Validierungs-Default Ortszeit).
+  - Test: nicht automatisierbar — `tools/` liegt außerhalb des Geltungsbereichs von
+    `tests/test_output_timezone_guard.py`; im QA-Bericht die Kommentarzeile am Fundort zitieren.
+
+- **AC-7:** Given alle sechs umgestellten bzw. entfernten Fundstellen dieser Scheibe
+  (`preview_service._resolve_target_date`, `compare_preview_service._resolve_target_date`,
+  `api/routers/compare.py::run_comparison` dreifach, `comparison_engine.dict_to_comparison_result`,
+  `compare_html._compute_next_send`) sind umgesetzt / When
+  `tests/test_output_timezone_guard.py::test_known_violations_only_shrink` und
+  `::test_no_unlisted_output_timezone_violations` laufen / Then sind die SIEBEN zugehörigen
+  `KNOWN_VIOLATIONS`-Einträge entfernt: `api/routers/compare.py::run_comparison::0`,
+  `::run_comparison::1`, `::run_comparison::2`,
+  `src/output/renderers/email/compare_html.py::_compute_next_send::0`,
+  `src/services/compare_preview_service.py::_resolve_target_date::0`,
+  `src/services/comparison_engine.py::dict_to_comparison_result::0`,
+  `src/services/preview_service.py::_resolve_target_date::0` — und beide Tests bleiben grün. Da
+  alle drei `run_comparison`-Einträge im selben Commit entfallen (statt nur einzelne), entsteht
+  KEINE Ordinal-Verschiebung für verbleibende Einträge derselben Funktion — anders als bei einer
+  Teilbehebung (Risiko, s. u.).
+  - Test: `tests/test_output_timezone_guard.py::test_known_violations_only_shrink`,
+    `::test_no_unlisted_output_timezone_violations`.
+
+- **AC-8:** Given eine neue Testfunktion dieser Scheibe behauptet, dass Ortstag und Servertag bei
+  ihrer Fixtur auseinanderfallen — der Vorbedingungs-Anker ist Pflicht, keine Kür / When der Test
+  seine Hauptzusicherung prüft / Then belegt er das ZUVOR mit dem geteilten Vorbedingungs-Anker
+  `_anker(now_utc, zone, erwarteter_ortstag)` (`tests/tdd/conftest.py:88-109`) — ohne ihn ist die
+  Hauptzusicherung strukturell nie falsifizierbar (#1726 F002). An F1 und F2 tritt zusätzlich die
+  Parameter-gegen-Systemuhr-Probe aus AC-1/AC-2 hinzu, sie ersetzt den Anker nicht; an F3–F5 und
+  F7 ist diese Probe strukturell unmöglich (kein exponierter Parameter) — dort trägt der Anker
+  allein.
+  - Test: nicht automatisierbar; im QA-Bericht zu belegen, dass jede neue Testfunktion dieser
+    Scheibe den geteilten Anker importiert und aufruft (Muster: fix_1727_s5a/s5b AC-9).
+
+## Known Limitations
+
+- **Die Divergenz Footer-Zone vs. Compare-Versand-Zieltag bleibt offen.** Siehe „Nicht in dieser
+  Scheibe" — eigene fachliche Frage, kein Zeitzonen-Bug im Sinne dieser Scheibe.
+- **`api/routers/debug.py`, `gpx_processing.py`, `massif_closure.py`, `meteo_forets.py`** — die
+  verbleibenden sieben Muster-A-Einträge des Wächters gehören zu S5d. Nach S5c und S5d ist die
+  Muster-A-Liste vollständig leer.
+- **Der Wächter bleibt blind für `datetime.utcnow()`.** Für die fünf Dateien dieser Scheibe
+  nachgemessen: keine `utcnow()`-Stelle vorhanden. Der Detektor selbst (`_AMBIENT_CLOCK_ATTRS`)
+  wird nicht erweitert — S5e.
+- **Mehrzonen-Touren:** Restfehler = Zonendifferenz zweier benachbarter Etappen an einem
+  Wechseltag. Unverändert bewusst offen (ADR-0044, PO-Entscheidung 2026-08-10, s. „Zwei
+  Zonen-Auflösungen" oben).
+- **`send_on_demand_report`** (`trip_report_scheduler.py:966`) und die Go-Seite (225 ×
+  `time.Now()`) — unverändert aus S5b übernommene offene (b)-Folgescheibe bzw. eigener Befund
+  außerhalb des Epics.
+- **`tools/weather_validation.py`** bekommt mit dieser Scheibe erstmals eine dokumentierte
+  Ausnahme statt eines stillen Fehlens in jeder ADR-Restliste; ein etwaiger sechster Fund an
+  anderer Stelle desselben Werkzeugs ist damit nicht ausgeschlossen — nur diese eine Zeile ist
+  geprüft.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** ADR-0044 (Akzeptiert), ADR-0051 (Vorgeschlagen, Regel 2 + Regel 3)
+- **Rationale:** Setzt die bereits akzeptierte ADR-0044-Entscheidung an sechs weiteren, in dessen
+  Restliste teils fehlenden Stellen um und entfernt eine siebte (F6) als toten Code — kein
+  offene Produktfrage, ein Bug gegen eine getroffene Entscheidung. Regel 2 aus ADR-0051 (Zone
+  gehört an die Daten) begründet `first_resolvable_tz`/`trip_local_today` statt einer
+  Server-/Prozesszone; Regel 3 (keine Umgebungsuhr) begründet `now_utc` als Pflichtparameter an
+  F1/F2. An F3–F5 und F7 bleibt „jetzt" bewusst funktionsintern (kein sinnvoller externer
+  Pflichtparameter möglich bzw. keine zweite Auflösung nötig, weil die Zone bereits vorliegt) —
+  diese Scheibe trifft dazu keine neue Design-Entscheidung, sondern übernimmt die in der
+  Kartierung getroffene Kosten-Nutzen-Abwägung.
+
+## Changelog
+
+- 2026-08-14: Spec erstellt nach Kartierung `docs/context/fix-1727-s5c-vorschau-anzeige.md`
+  (Basis-HEAD `e2b5269b`), Vorbild `docs/specs/modules/fix_1727_s5b_versandpfade_ortstag.md`.
+- 2026-08-14: Wächter-Restliste direkt gegen `tests/test_output_timezone_guard.py` nachgemessen:
+  SIEBEN (nicht sechs) `KNOWN_VIOLATIONS`-Einträge sind von dieser Scheibe betroffen —
+  deckungsgleich mit den sieben Fundstellen des Kontext-Dokuments (`api/routers/compare.py` ×3,
+  `compare_html.py` ×1, `compare_preview_service.py` ×1, `comparison_engine.py` ×1,
+  `preview_service.py` ×1).
+- 2026-08-14: Zusätzliche, im Kontext-Dokument nicht bezifferte Testkosten direkt am Code
+  nachgemessen: `_build_report` bekommt mit F1 ebenfalls `now_utc` als Pflichtparameter (nicht
+  nur `_resolve_target_date`); neun Bestandstest-Aufrufstellen in sechs Dateien betroffen (s.
+  Estimated Scope).

--- a/docs/specs/modules/fix_1727_s5c_vorschau_anzeige_ortstag.md
+++ b/docs/specs/modules/fix_1727_s5c_vorschau_anzeige_ortstag.md
@@ -13,7 +13,7 @@ workflow: fix-1727-s5c-vorschau-anzeige
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-Freigabe 2026-08-14 („go")
 
 ## Purpose
 

--- a/src/output/renderers/email/compare_html.py
+++ b/src/output/renderers/email/compare_html.py
@@ -21,7 +21,7 @@ SPEC: docs/specs/modules/issue_1110_compare_mail_v2.md
 from __future__ import annotations
 
 import html as _html
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Optional
 from zoneinfo import ZoneInfo
 
@@ -640,8 +640,9 @@ def _daily_summary(loc: LocationResult):
     """Tages-Aggregat eines Ortes aus ``hourly_data`` (kanonische Trip-Regeln).
 
     Der Renderer darf sich NICHT darauf verlassen, dass die ComparisonEngine
-    gelaufen ist: ``dict_to_comparison_result()`` und der Validator-Render-Pfad
-    fuettern denselben Renderer ohne Engine. Genau dieses Live-Ableiten aus
+    gelaufen ist: der Validator-Render-Pfad fuettert denselben Renderer ohne
+    Engine (``dict_to_comparison_result()`` -- der frühere zweite Fuetterer --
+    ist mit Issue #1727 S5c als toter Code entfernt). Genau dieses Live-Ableiten aus
     ``hourly_data`` macht ``uv_max`` heute schon (Issue #1110); die vier neuen
     Zeilen folgen demselben Muster.
     """
@@ -1435,12 +1436,18 @@ def _render_legend(hourly_metrics: list[str] | None = None, hourly_enabled: bool
     )
 
 
-def _compute_next_send(schedule, weekday) -> Optional[str]:
+def _compute_next_send(schedule, weekday, tz) -> Optional[str]:
     """Known Limitation (SPEC): liefert None (-> '—'), wenn schedule nicht
-    ermittelbar ist."""
+    ermittelbar ist.
+
+    Issue #1727 S5c (ADR-0044): ``today`` kommt aus ``tz`` (bereits von
+    ``render_compare_html`` aufgeloestes ``header_tz``) statt aus der
+    zonenlosen ``date.today()``-Serveruhr — dieselbe Zeitbasis wie die
+    Kopfzeile derselben Mail.
+    """
     if not schedule:
         return None
-    today = date.today()
+    today = local_dt(datetime.now(timezone.utc), tz).date()
     schedule_str = str(schedule).lower()
     if "weekly" in schedule_str and weekday is not None:
         try:
@@ -1454,9 +1461,9 @@ def _compute_next_send(schedule, weekday) -> Optional[str]:
     return None
 
 
-def _render_abo_footer(preset_name, preset_schedule, preset_weekday, location_count: int, sig) -> str:
+def _render_abo_footer(preset_name, preset_schedule, preset_weekday, location_count: int, sig, tz) -> str:
     name = _html.escape(preset_name) if preset_name else "Ortsvergleich"
-    next_send = _compute_next_send(preset_schedule, preset_weekday) or "—"
+    next_send = _compute_next_send(preset_schedule, preset_weekday, tz) or "—"
     return (
         f'<div style="padding:20px 24px;background:{G_PAPER};border-top:1px solid #e6e1d3;">'
         f'<table style="width:100%;border-collapse:collapse;"><tr>'
@@ -1667,7 +1674,9 @@ def render_compare_html(
     )
 
     legend_html = _render_legend(hourly_metrics, hourly_enabled)
-    abo_html = _render_abo_footer(preset_name, preset_schedule, preset_weekday, len(locations), sig)
+    abo_html = _render_abo_footer(
+        preset_name, preset_schedule, preset_weekday, len(locations), sig, header_tz,
+    )
     app_footer_html = _render_app_footer()
 
     # Nur nicht-leere Bloecke einreihen (kein Doppel-Newline durch leeren

--- a/src/services/compare_preview_service.py
+++ b/src/services/compare_preview_service.py
@@ -30,7 +30,7 @@ Fallback.
 from __future__ import annotations
 
 import logging
-from datetime import date
+from datetime import date, datetime, timezone
 
 logger = logging.getLogger(__name__)
 
@@ -145,7 +145,9 @@ class ComparePreviewService:
 
         preset = self._load_preset(preset_id, user_id=user_id)
         locations = self._resolve_locations(preset, user_id=user_id)
-        resolved_date = _resolve_target_date(target_date)
+        resolved_date = _resolve_target_date(
+            target_date, locations, datetime.now(timezone.utc),
+        )
         profile = _parse_activity_profile(str(preset.get("profil", "")).lower())
 
         # Issue #1361/#1372 S1b (AC-2): die Vorschau MUSS mit demselben
@@ -252,10 +254,17 @@ def order_locations_by_ids(locations: list, location_ids: list[str]) -> list:
     return [by_id[loc_id] for loc_id in location_ids if loc_id in by_id]
 
 
-def _resolve_target_date(given: str | date | None) -> date:
-    """ISO-String/`date`/None → `date`. None = heute (analog Einzelversand)."""
+def _resolve_target_date(
+    given: str | date | None, locations: list, now_utc: datetime,
+) -> date:
+    """ISO-String/`date`/None → `date`. None = Ortstag des ersten aufloesbaren
+    Orts (Issue #1727 S5c, ADR-0044/-0051) — analog zum Compare-Versandpfad
+    seit S5b (``scheduler_dispatch_service.py``), nicht mehr die zonenlose
+    Serveruhr. Der ``given``-Zweig bleibt unveraendert."""
     if given is None or given == "":
-        return date.today()
+        from utils.timezone import first_resolvable_tz, local_dt
+        zone = first_resolvable_tz(locations, context_label="Compare-Vorschau")
+        return local_dt(now_utc, zone).date()
     if isinstance(given, date):
         return given
     try:

--- a/src/services/comparison_engine.py
+++ b/src/services/comparison_engine.py
@@ -391,54 +391,6 @@ class ComparisonEngine:
         )
 
 
-def dict_to_comparison_result(
-    results: List[Dict[str, Any]],
-    time_window: tuple[int, int],
-    target_date: Any,
-) -> ComparisonResult:
-    """
-    Convert dict-based results from UI to ComparisonResult dataclass.
-
-    This enables the UI button to use the same renderer as subscriptions.
-    """
-    from datetime import date
-
-    if target_date is None:
-        target_date = date.today()
-
-    location_results = []
-    for r in results:
-        if r.get("error"):
-            continue
-        loc_result = LocationResult(
-            location=r["location"],
-            score=r.get("score", 0),
-            snow_depth_cm=r.get("snow_depth_cm"),
-            snow_new_cm=r.get("snow_new_cm"),
-            temp_min=r.get("temp_min"),
-            temp_max=r.get("temp_max"),
-            wind_max=r.get("wind_max"),
-            wind_direction_avg=r.get("wind_direction_avg"),
-            gust_max=r.get("gust_max"),
-            wind_chill_min=r.get("wind_chill_min"),
-            wind_chill_max=r.get("wind_chill_max"),
-            cloud_avg=r.get("cloud_avg"),
-            cloud_low_avg=r.get("cloud_low_avg"),
-            cloud_mid_avg=r.get("cloud_mid_avg"),
-            cloud_high_avg=r.get("cloud_high_avg"),
-            sunny_hours=r.get("sunny_hours"),
-            hourly_data=r.get("hourly_data", []),
-            outlook_hourly_data=r.get("outlook_hourly_data", []),
-        )
-        location_results.append(loc_result)
-
-    return ComparisonResult(
-        locations=location_results,
-        time_window=time_window,
-        target_date=target_date,
-    )
-
-
 def fetch_forecast_for_location(
     loc: SavedLocation,
     hours: int = COMPARE_FORECAST_HOURS,

--- a/src/services/preview_service.py
+++ b/src/services/preview_service.py
@@ -81,17 +81,22 @@ class PreviewService:
             )
         return load_trip(path)
 
-    def _resolve_target_date(self, trip: "Trip", given_date: str | None) -> date:
+    def _resolve_target_date(self, trip: "Trip", given_date: str | None, now_utc: datetime) -> date:
         """Liefert das Ziel-Datum: gegebenes oder nächstes Stage-Datum.
 
         Falls kein Stage in der Zukunft, nimm das erste Stage-Datum überhaupt.
+
+        Issue #1727 S5c: ``now_utc`` ist Pflicht (ADR-0051 Regel 3) — "heute"
+        bestimmt sich über ``trip_local_today(trip, now_utc)`` (Ortstag der
+        Tour), nicht mehr über die zonenlose ``date.today()``-Serveruhr.
         """
         if given_date:
             try:
                 return date.fromisoformat(given_date)
             except ValueError as e:
                 raise ValueError(f"Ungültiges Datum '{given_date}', ISO erwartet") from e
-        today = date.today()
+        from services.trip_day import trip_local_today
+        today = trip_local_today(trip, now_utc)
         # Issue #990 / Adversary F001: Trip komplett ohne Etappen ist ein
         # anderer Fall als "Etappen ohne genug Wegpunkte". Ein wegpunktloser
         # Trip hat keine im Wegpunkt-Editor bearbeitbare Etappe — daher hier
@@ -122,6 +127,7 @@ class PreviewService:
         trip: "Trip",
         target: date,
         report_type: str,
+        now_utc: datetime,
         demo: bool = False,
     ):
         """Gemeinsame Pipeline: segments → weather → format_email → TripReport.
@@ -130,6 +136,10 @@ class PreviewService:
             trip: Trip-Modell
             target: Ziel-Datum
             report_type: 'morning' | 'evening'
+            now_utc: Zeitpunkt "jetzt" (Issue #1727 S5c, ADR-0051 Regel 3) —
+                Pflichtparameter, speist BEIDE Ausblicks-/Trend-Aufrufe unten
+                (ein einziger Zeitpunkt statt zweier potenziell auseinander-
+                fallender ``datetime.now()``-Momentaufnahmen).
             demo: Wenn True (Issue #483), wird der FixtureProvider statt der
                 Live-OpenMeteo-API genutzt. Damit ist die Vorschau immer
                 verfügbar — unabhängig von API-Limit oder Datum.
@@ -214,27 +224,26 @@ class PreviewService:
         multi_day_trend = None
         outlook_state = None
         outlook_horizon_days = None
-        # Issue #1727 S5b: rein mechanischer Durchreich — beide Scheduler-
-        # Methoden verlangen den Zeitpunkt jetzt als Pflichtparameter
-        # (ADR-0051 Regel 3). Die EIGENE Tagesbestimmung der Vorschau
-        # (`_resolve_target_date`) bleibt unangetastet und folgt weiterhin dem
-        # Servertag — sie gehoert in die ADR-0044-Restliste „Vorschau,
-        # Werkzeuge" (S5c), nicht in diese Scheibe.
-        jetzt_utc = datetime.now(timezone.utc)
+        # Issue #1727 S5c: EIN von aussen uebergebenes `now_utc` speist BEIDE
+        # Scheduler-Methoden — dieselbe Zeitbasis, mit der `_resolve_target_date`
+        # (aufgerufen von den drei oeffentlichen render_*_preview-Methoden)
+        # bereits die Etappe gewaehlt hat. Die frueher hier lokal aufgeloeste
+        # zweite `datetime.now(timezone.utc)` entfaellt ersatzlos (ADR-0051
+        # Regel 3, keine Umgebungsuhr).
         if segment_weather and render_options.show_multi_day_trend:
             # Issue #1720 S1: `report_type` ist hier NICHT optional -- der
             # Zeilenbau loest damit die Ausblick-Spalten auf. Ohne ihn baute
             # die Vorschau die Zellen nach dem Abend-Default (Spaltenversatz
             # bei Morgen-/Abend-Overrides, nur in der Vorschau).
             trend_result = scheduler._build_stage_trend(
-                trip, target, now_utc=jetzt_utc, tz=trip_tz,
+                trip, target, now_utc=now_utc, tz=trip_tz,
                 report_type=report_type,
             )
             multi_day_trend = trend_result.rows
             outlook_state = trend_result.state
             outlook_horizon_days = trend_result.horizon_days
         thunder_forecast = scheduler._build_thunder_forecast_from_trend_or_fetch(
-            trip, target, now_utc=jetzt_utc, tz=trip_tz,
+            trip, target, now_utc=now_utc, tz=trip_tz,
             multi_day_trend=multi_day_trend, night_weather=night_weather,
         )
 
@@ -326,9 +335,10 @@ class PreviewService:
         if report_type not in VALID_REPORT_TYPES:
             raise ValueError(f"Ungültiger report_type '{report_type}'")
         trip = self._load_trip(trip_id, user_id)
-        target = self._resolve_target_date(trip, target_date)
+        now_utc = datetime.now(timezone.utc)
+        target = self._resolve_target_date(trip, target_date, now_utc=now_utc)
         report, _segments, _stage_name, _trip_tz = self._build_report(
-            trip, target, report_type, demo=demo,
+            trip, target, report_type, now_utc=now_utc, demo=demo,
         )
         # Issue #722: compact format — wrap plain text in <pre> for browser preview
         if not report.email_html and report.email_plain:
@@ -353,9 +363,10 @@ class PreviewService:
         if report_type not in VALID_REPORT_TYPES:
             raise ValueError(f"Ungültiger report_type '{report_type}'")
         trip = self._load_trip(trip_id, user_id)
-        target = self._resolve_target_date(trip, target_date)
+        now_utc = datetime.now(timezone.utc)
+        target = self._resolve_target_date(trip, target_date, now_utc=now_utc)
         report, _segment_weather, _stage_name, _trip_tz = self._build_report(
-            trip, target, report_type, demo=demo,
+            trip, target, report_type, now_utc=now_utc, demo=demo,
         )
         # Issue #954: kein eigener Renderpfad mehr — report.sms_text ist bereits
         # der #944-korrekte Versandtext (inkl. disabled_specs-Filterung).
@@ -379,9 +390,10 @@ class PreviewService:
         if report_type not in VALID_REPORT_TYPES:
             raise ValueError(f"Ungültiger report_type '{report_type}'")
         trip = self._load_trip(trip_id, user_id)
-        target = self._resolve_target_date(trip, target_date)
+        now_utc = datetime.now(timezone.utc)
+        target = self._resolve_target_date(trip, target_date, now_utc=now_utc)
         report, _segments, _stage_name, _trip_tz = self._build_report(
-            trip, target, report_type, demo=demo,
+            trip, target, report_type, now_utc=now_utc, demo=demo,
         )
         bubbles = report.telegram_bubbles or []
         body = "\n\n---\n\n".join(bubbles)

--- a/tests/refactor/test_epic_129a_1_module_structure.py
+++ b/tests/refactor/test_epic_129a_1_module_structure.py
@@ -33,7 +33,8 @@ def test_comparison_scoring():
 
 def test_comparison_engine():
     """AC-2 (engine): services.comparison_engine exportiert ComparisonEngine,
-    fetch_forecast_for_location, dict_to_comparison_result.
+    fetch_forecast_for_location. ``dict_to_comparison_result`` hatte 0
+    Aufrufer und ist mit Issue #1727 S5c ersatzlos entfernt.
     """
     mod = importlib.import_module("services.comparison_engine")
     assert hasattr(mod, "ComparisonEngine"), (
@@ -42,8 +43,9 @@ def test_comparison_engine():
     assert hasattr(mod, "fetch_forecast_for_location"), (
         "services.comparison_engine.fetch_forecast_for_location fehlt"
     )
-    assert hasattr(mod, "dict_to_comparison_result"), (
-        "services.comparison_engine.dict_to_comparison_result fehlt"
+    assert not hasattr(mod, "dict_to_comparison_result"), (
+        "services.comparison_engine.dict_to_comparison_result existiert noch — "
+        "sollte mit #1727 S5c entfernt worden sein (0 Aufrufer)"
     )
 
 

--- a/tests/tdd/test_epic_140_preview_endpoints.py
+++ b/tests/tdd/test_epic_140_preview_endpoints.py
@@ -10,6 +10,7 @@ werden im Test toleriert (HTTP 200 bei Erfolg, HTTP 503 bei API-Fehler — beide
 from __future__ import annotations
 
 import shutil
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -86,7 +87,9 @@ class TestT1PreviewService:
     def test_resolve_target_date_returns_first_future_stage(self, service):
         """Wenn kein Datum gegeben, liefert _resolve_target_date das nächste Stage-Datum."""
         trip = service._load_trip("gr221-mallorca", user_id="default")
-        target = service._resolve_target_date(trip, given_date=None)
+        target = service._resolve_target_date(
+            trip, given_date=None, now_utc=datetime.now(timezone.utc),
+        )
         # Muss ein ISO-Datum-String sein oder ein date-Objekt
         assert target is not None
 
@@ -453,7 +456,9 @@ class TestIssue990WaypointSkip:
         stage_ok = _make_stage990("ok", today + timedelta(days=1), num_waypoints=2)
         trip = _make_trip990([stage_empty, stage_ok])
 
-        target = service._resolve_target_date(trip, given_date=None)
+        target = service._resolve_target_date(
+            trip, given_date=None, now_utc=datetime.now(timezone.utc),
+        )
 
         assert target == stage_ok.date, (
             f"Erwartet: nächste renderbare Etappe ({stage_ok.date}), "
@@ -468,7 +473,10 @@ class TestIssue990WaypointSkip:
         trip = _make_trip990([stage_empty])
 
         with pytest.raises(LookupError) as exc_info:
-            service._build_report(trip, stage_empty.date, "morning", demo=True)
+            service._build_report(
+                trip, stage_empty.date, "morning",
+                now_utc=datetime.now(timezone.utc), demo=True,
+            )
 
         assert "waypoint" in str(exc_info.value).lower(), (
             f"Fehlertext muss 'waypoint' enthalten, war: {exc_info.value!r}"
@@ -483,7 +491,10 @@ class TestIssue990WaypointSkip:
         no_stage_date = date(2026, 9, 15)
 
         with pytest.raises(LookupError) as exc_info:
-            service._build_report(trip, no_stage_date, "morning", demo=True)
+            service._build_report(
+                trip, no_stage_date, "morning",
+                now_utc=datetime.now(timezone.utc), demo=True,
+            )
 
         assert "waypoint" not in str(exc_info.value).lower(), (
             f"Generischer 'keine Stage'-Fall darf 'waypoint' nicht enthalten, "
@@ -500,7 +511,9 @@ class TestIssue990WaypointSkip:
         trip = _make_trip990([stage_past, stage_future])
 
         with pytest.raises((LookupError, ValueError)) as exc_info:
-            service._resolve_target_date(trip, given_date=None)
+            service._resolve_target_date(
+                trip, given_date=None, now_utc=datetime.now(timezone.utc),
+            )
 
         assert "waypoint" in str(exc_info.value).lower(), (
             f"Fehlertext bei komplett wegpunktlosem Trip muss 'waypoint' "
@@ -515,7 +528,9 @@ class TestIssue990WaypointSkip:
         stage_second = _make_stage990("second", date(2026, 8, 2), num_waypoints=4)
         trip = _make_trip990([stage_second, stage_first])  # bewusst unsortiert
 
-        target = service._resolve_target_date(trip, given_date=None)
+        target = service._resolve_target_date(
+            trip, given_date=None, now_utc=datetime.now(timezone.utc),
+        )
 
         assert target == stage_first.date, (
             f"Erwartet: früheste renderbare Etappe ({stage_first.date}), war: {target}"
@@ -529,7 +544,9 @@ class TestIssue990WaypointSkip:
         trip = _make_trip990([])
 
         with pytest.raises(ValueError) as exc_info:
-            service._resolve_target_date(trip, given_date=None)
+            service._resolve_target_date(
+                trip, given_date=None, now_utc=datetime.now(timezone.utc),
+            )
 
         assert not isinstance(exc_info.value, LookupError), (
             "Trip ohne jede Etappe darf NICHT als LookupError/waypoint-Fall behandelt werden"

--- a/tests/tdd/test_preview_parity_without_outlook.py
+++ b/tests/tdd/test_preview_parity_without_outlook.py
@@ -168,7 +168,7 @@ def test_preview_matches_sent_when_the_outlook_is_absent():
     # Der ECHTE Vorschau-Pfad — inklusive der Stelle, an der die
     # Ausblick-Parameter an die Render-Naht uebergeben werden.
     preview, segment_weather, stage_name, trip_tz = PreviewService()._build_report(
-        trip, _TARGET, _REPORT_TYPE, demo=True,
+        trip, _TARGET, _REPORT_TYPE, now_utc=datetime.now(timezone.utc), demo=True,
     )
     sent, trend_result = _sent_report(trip, segment_weather, stage_name, trip_tz)
 

--- a/tests/tdd/test_preview_render_options_parity.py
+++ b/tests/tdd/test_preview_render_options_parity.py
@@ -22,7 +22,7 @@ FixtureProvider (Issue #346/#483), kein Dateiinhalt-Check.
 from __future__ import annotations
 
 import copy
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 _FIXTURE_DIR = Path(__file__).resolve().parents[2] / "fixtures" / "openmeteo"
@@ -106,7 +106,8 @@ def test_preview_does_not_mutate_display_config_and_matches_reference_render():
     before = trip_for_preview.display_config.show_compact_summary
 
     preview_report, _segments, _stage_name, _tz = PreviewService()._build_report(
-        trip_for_preview, target, "morning", demo=True,
+        trip_for_preview, target, "morning",
+        now_utc=datetime.now(timezone.utc), demo=True,
     )
 
     after = trip_for_preview.display_config.show_compact_summary

--- a/tests/tdd/test_sms_preview_matches_sent.py
+++ b/tests/tdd/test_sms_preview_matches_sent.py
@@ -79,7 +79,9 @@ def _render() -> tuple[str, str]:
     _make_and_save_trip()
     ps = PreviewService()
     trip = ps._load_trip(_TRIP_ID, user_id=_USER)
-    report, *_rest = ps._build_report(trip, _TARGET, "morning", demo=True)
+    report, *_rest = ps._build_report(
+        trip, _TARGET, "morning", now_utc=datetime.now(timezone.utc), demo=True,
+    )
     _subject, token_line = ps.render_sms_preview(
         _TRIP_ID, user_id=_USER, report_type="morning",
         target_date=_TARGET.isoformat(), demo=True,

--- a/tests/tdd/test_trip_outlook_dispatch_mail.py
+++ b/tests/tdd/test_trip_outlook_dispatch_mail.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import sys
 import uuid
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 # Pfadregel #1409: Pruefling relativ zur eigenen Testdatei aufloesen.
@@ -509,7 +509,7 @@ def test_ac17_vorschau_zeigt_denselben_ausblick_wie_die_zugestellte_mail():
     sched_mod.TripReportSchedulerService = _fixture_scheduler_klasse()
     try:
         report, *_ = PreviewService(settings=settings)._build_report(
-            trip, date.today(), "morning",
+            trip, date.today(), "morning", now_utc=datetime.now(timezone.utc),
         )
     finally:
         sched_mod.TripReportSchedulerService = original

--- a/tests/tdd/test_vorschau_anzeige_folgen_ortszone.py
+++ b/tests/tdd/test_vorschau_anzeige_folgen_ortszone.py
@@ -1,0 +1,652 @@
+"""TDD RED — #1727 S5c: Vorschau, Anzeige, Sofort-Vergleich folgen dem ORTSTAG.
+
+SPEC: docs/specs/modules/fix_1727_s5c_vorschau_anzeige_ortstag.md (AC-1 bis AC-8)
+KONTEXT: docs/context/fix-1727-s5c-vorschau-anzeige.md (sieben Fundstellen, gemessen)
+ADR-0044 (Kalendertage folgen der Ortszeit), ADR-0051 Regel 2 (Zone gehoert an
+die Daten) + Regel 3 (keine Umgebungsuhr).
+
+Sieben Fundstellen in fuenf Dateien bestimmen "welcher Kalendertag ist
+gemeint" ueber die Serveruhr (``date.today()``/``datetime.now()`` ohne Zone)
+statt ueber den Ortstag der Tour bzw. des ersten aufloesbaren Preset-Orts.
+Anders als S5b (Versandpfade) wirken sie primUER auf VORSCHAU-/ANZEIGE-Pfade,
+mit einer Ausnahme (F7, versendete Mail):
+
+    F1  preview_service._resolve_target_date + _build_report   (:84 / :120)
+    F2  compare_preview_service._resolve_target_date            (:255)
+    F3  api/routers/compare.py::run_comparison, Stunde          (:53)
+    F4  api/routers/compare.py::run_comparison, Zieltag heute   (:55)
+    F5  api/routers/compare.py::run_comparison, Zieltag morgen  (:58)
+    F6  comparison_engine.dict_to_comparison_result (tot, 0 Aufrufer) (:394)
+    F7  compare_html._compute_next_send / _render_abo_footer    (:1438/:1457)
+
+ZWEI NACHWEISFORMEN, PFLICHT WO ANWENDBAR (AC-8)
+===============================================================================
+(a) Vorbedingungs-Anker ``_anker`` (tests/tdd/conftest.py) vor JEDER
+    Hauptzusicherung, die einen vom Weltzeit-/Servertag abweichenden Ortstag
+    behauptet — sonst waere sie strukturell nie falsifizierbar (#1726 F002).
+
+(b) Parameter gegen Systemuhr (S5a-Befund F001) — PFLICHT genau dort, wo ein
+    Pflichtparameter entsteht: F1 (``_resolve_target_date`` UND
+    ``_build_report``) und F2 (``_resolve_target_date``). ``freeze_time(X)``
+    setzen, ``now_utc=Y`` mit ANDEREM Ortstag uebergeben; die Assertion muss
+    auf Y zeigen, nicht auf X. An F3-F5 und F7 bleibt "jetzt" bewusst
+    funktionsintern (kein exponierter Parameter) — dort traegt der Anker
+    allein (a).
+
+MATHEMATISCHE ANMERKUNG ZU AC-3 (gemessen, nicht vermutet)
+===============================================================================
+``run_comparison`` bestimmt "heute/morgen" ueber EINE 14:00-Schwelle, die
+sowohl die Stunde als auch den Tag traegt. Fuer die beiden hier gewaehlten
+Szenarien ("voraus"/"hinterher") gilt: eine Konstruktion, die GLEICHZEITIG
+(1) einen Tagesumbruch zwischen Welt- und Ortszeit zeigt (Anker-Pflicht),
+UND (2) die lokale Uhrzeit nahe 14:00 UND (3) einen vom Servercode
+tatsaechlich abweichenden target_date liefert, ist mit den real existierenden
+Zeitzonen-Offsets (max. +14h Kiritimati, min. -11h Samoa, beide < 24h) fuer
+den ">=14 Uhr lokal"-Zweig NICHT konstruierbar (nachgerechnet: ein
+Tagesumbruch VORWAERTS haelt die neue lokale Stunde immer < Offset <= 14h,
+ein Tagesumbruch RUECKWAERTS braucht fuer eine abweichende Antwort eine
+Serverstunde >= 14 UND einen Offset < -14h, den es nicht gibt). Die beiden
+ersten zwei Szenarien unten nutzen deshalb den TAGES-Anteil der Schwelle als
+Diskriminator (Ortstag bereits uebergelaufen, Ortsstunde < 14:00 in beiden
+Faellen) — das ist exakt die im Spec-Beispiel genannte Eigenschaft "Stunde
+UND Tag aus DERSELBEN Ortszeit", nur mit rechnerisch tragfaehigen Werten
+statt der illustrativen "13:xx/14:xx"-Uhrzeiten. Ein DRITTES Szenario
+(Team-Lead-Review) deckt die andere Haelfte ab: Orts- und Servertag sind
+DENSELBE Kalendertag, aber Orts- und Serverstunde liegen auf
+VERSCHIEDENEN Seiten der 14-Uhr-Schwelle. Erst zusammen bewachen die drei
+Tests BEIDE Haelften der Schwelle -- zwei den Tag, einer die Stunde. Ohne
+das dritte Szenario besteht eine Implementierung, die nur den Tag auf
+Ortszeit umstellt, die Stunde aber weiter von der Serveruhr nimmt, beide
+Tag-Tests unbemerkt (dieselbe Fehlerklasse "Zusicherung behauptet, von
+keinem Test bewacht", die dieses Epic bereits mehrfach getroffen hat).
+
+RED-GRUENDE (gemessen, nicht vermutet)
+===============================================================================
+* F1: der Pflichtparameter ``now_utc`` existiert an ``_resolve_target_date``
+  UND ``_build_report`` noch nicht -> ``TypeError``.
+* F2: ``_resolve_target_date`` ist heute eine 1-Parameter-Funktion
+  (``given``) -> ``TypeError`` bei 3 Argumenten.
+* F3-F5: fachlich rot -- ``run_comparison`` liefert ein ``target_date``, das
+  aus der zonenlosen Serveruhr stammt, nicht aus der Ortszeit.
+* F6: fachlich rot -- ``dict_to_comparison_result`` existiert noch
+  (``hasattr`` liefert heute ``True``).
+* F7: fachlich rot -- der Footer "Naechster Versand" rechnet noch mit
+  ``date.today()`` statt der bereits aufgeloesten Kopfzeilen-Zone.
+
+TESTPOLITIK (CLAUDE.md "Test-Politik: Zwei Schichten"): Kern-Schicht, kein
+Netz. Echte ``Trip``/``Stage``/``Waypoint``/``SavedLocation``/
+``ComparisonResult``-Objekte. Kein ``Mock()``/``patch()``/``MagicMock`` --
+die Netz-Naehte laufen ueber den bestehenden Demo-Modus (echter
+``FixtureProvider``, Issue #483) bzw. ueber ``monkeypatch.setattr`` auf
+echte, lokal konstruierte DTOs/Spione (Muster
+``test_hail_flag_metrics_catalog_and_compare_api.py``), die AUFZEICHNEN, was
+der Pruefling tatsaechlich entscheidet, statt eine Annahme zurueckzuspiegeln.
+
+Pfadregel #1409: diese Datei liest nichts von der Platte des Hauptrepos.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+from freezegun import freeze_time
+
+from app.models import OutlookState, TrendResult
+from app.trip import Trip
+from app.user import ComparisonResult, LocationResult, SavedLocation
+from services.compare_preview_service import _resolve_target_date as _cps_resolve_target_date
+from services.preview_service import PreviewService
+from services.trip_report_scheduler import TripReportSchedulerService
+from tests.helpers.nowcast_gate_fixtures import settings_email_only, trip_stage
+from tests.tdd.conftest import WP_NZ, _anker
+
+# ═══════════════════════════ Zonen und Koordinaten ═══════════════════════════
+# Mitteleuropaeische Fixturen (Versatz 2h) koennen den Fehler strukturell
+# nicht zeigen -- durchgehend Zonen mit deutlichem Versatz.
+
+WELLINGTON_ZONE = "Pacific/Auckland"   # im August UTC+12
+PAGO_ZONE = "Pacific/Pago_Pago"        # UTC-11, kein DST
+PAGO = (-14.28, -170.70)               # Pago Pago -- Muster aus S5a/S5b
+
+D19, D20, D21, D22 = (date(2026, 8, d) for d in (19, 20, 21, 22))
+
+# ── Einzel-Szenario (a): Ortstag != Servertag, EIN now_utc ──────────────────
+# 14:00 UTC am 20.08. = 02:00 Ortszeit am 21.08. in Wellington.
+MITTAGS_UTC = datetime(2026, 8, 20, 14, 0, tzinfo=timezone.utc)
+
+# ── Parameter-gegen-Systemuhr (b): ZWEI now_utc, verschiedene Ortstage ──────
+# 20:00 UTC am 19.08. = 08:00 Ortszeit am 20.08. in Wellington (Ortstag D20).
+FROST_UTC = datetime(2026, 8, 19, 20, 0, tzinfo=timezone.utc)
+# 20:00 UTC am 21.08. = 08:00 Ortszeit am 22.08. in Wellington (Ortstag D22).
+PARAM_UTC = datetime(2026, 8, 21, 20, 0, tzinfo=timezone.utc)
+
+
+def _preview_trip(trip_id: str, tage_und_koordinaten: list) -> Trip:
+    """Tour mit je einer RENDERBAREN (2-Wegpunkt-)Etappe pro Tag.
+
+    ``trip_two_zones`` (conftest) baut nur 1-Wegpunkt-Etappen -- unterhalb
+    von ``PreviewService._MIN_WAYPOINTS_FOR_RENDER`` (2) und damit fuer
+    ``_resolve_target_date``s Auto-Resolve nicht renderbar. Dieser Helfer
+    nutzt stattdessen ``trip_stage`` (2 Wegpunkte je Etappe), analog dem
+    ``_trip``-Helfer aus S5b.
+    """
+    return Trip(
+        id=trip_id,
+        name=trip_id,
+        stages=[
+            trip_stage(f"S{i}", tag, lat, lon, wp_prefix=f"W{i}-")
+            for i, (tag, (lat, lon)) in enumerate(tage_und_koordinaten)
+        ],
+        official_alerts_enabled=False,  # strukturell kein Warnungs-Abruf
+    )
+
+
+def _ort(loc_id: str, coords) -> SavedLocation:
+    """Gespeicherter Ort; ``coords=None`` = Ort OHNE aufloesbare Zone."""
+    lat, lon = (None, None) if coords is None else coords
+    return SavedLocation(id=loc_id, name=loc_id, lat=lat, lon=lon, elevation_m=500)
+
+
+def _uhr_eingefroren(now_utc: datetime) -> None:
+    """Belegt, dass ``freeze_time`` im PRUEFPROZESS wirklich greift -- ohne
+    diese Pruefung waere ein gruener Lauf kein Beweis, sondern ein Zufall."""
+    assert datetime.now(tz=timezone.utc) == now_utc, (
+        "Testaufbau: freeze_time greift nicht, die Systemuhr steht auf "
+        f"{datetime.now(tz=timezone.utc).isoformat()} statt auf "
+        f"{now_utc.isoformat()}"
+    )
+
+
+# ═══════════════════════ AC-1: preview_service (F1) ═══════════════════════
+
+
+def test_ac1_resolve_target_date_folgt_dem_parameter_nicht_der_systemuhr():
+    """AC-1, erste Haelfte -- ``PreviewService._resolve_target_date`` (F1).
+
+    GIVEN eine Neuseeland-Tour (UTC+12) mit Etappen am 19.08. und 21.08.,
+    WHEN  ``_resolve_target_date(trip, given_date=None, now_utc=Y)`` unter
+          eingefrorener Systemuhr X aufgerufen wird, wobei X und Y auf
+          verschiedene Ortstage derselben Zone fallen,
+    THEN  waehlt die Auto-Resolve-Logik die Etappe gemessen am Ortstag VON Y
+          -- nicht von X. Bei X (Ortstag 20.08.) waere die 21.08.-Etappe die
+          naechste kommende; bei Y (Ortstag 22.08.) liegen BEIDE Etappen
+          bereits in der Vergangenheit, der Rueckfall greift auf die
+          chronologisch ERSTE Etappe (19.08.) -- ein eindeutig
+          unterscheidbares Ergebnis.
+
+    RED heute: ``now_utc`` existiert an ``_resolve_target_date`` noch nicht
+    -> ``TypeError``.
+    """
+    trip = _preview_trip("preview-param-nz", [(D19, WP_NZ), (D21, WP_NZ)])
+    service = PreviewService(settings_email_only())
+
+    with freeze_time(FROST_UTC):
+        _anker(FROST_UTC, WELLINGTON_ZONE, D20)
+        _uhr_eingefroren(FROST_UTC)
+        ergebnis = service._resolve_target_date(trip, None, now_utc=PARAM_UTC)
+
+    ortstag_param = PARAM_UTC.astimezone(ZoneInfo(WELLINGTON_ZONE)).date()
+    assert ortstag_param == D22, (
+        "Testaufbau nicht diskriminierend: PARAM_UTC muss auf Ortstag "
+        f"{D22} fallen, liegt aber auf {ortstag_param}"
+    )
+    assert ergebnis == D19, (
+        f"AC-1: _resolve_target_date lieferte {ergebnis}, erwartet {D19} "
+        f"(chronologisch erste Etappe, weil am Ortstag von now_utc={PARAM_UTC.isoformat()} "
+        f"({ortstag_param}) BEIDE Etappen bereits vergangen sind). "
+        f"{D21} heisst: der Pruefling hat die eingefrorene Systemuhr "
+        f"({FROST_UTC.isoformat()}, Ortstag {D20}) benutzt statt des "
+        "uebergebenen Parameters now_utc (ADR-0051 Regel 3)."
+    )
+
+
+def test_ac1_build_report_folgt_dem_parameter_nicht_der_systemuhr(monkeypatch):
+    """AC-1, zweite Haelfte -- ``PreviewService._build_report`` (F1).
+
+    GIVEN dieselbe Situation wie oben, aber am ``_build_report``-Aufruf: ein
+          echter Demo-Report (FixtureProvider, kein Netz) fuer eine Etappe am
+          19.08. in Neuseeland,
+    WHEN  ``_build_report(trip, target, "evening", now_utc=Y, demo=True)``
+          aufgerufen wird,
+    THEN  erhalten SOWOHL ``_build_stage_trend`` ALS AUCH
+          ``_build_thunder_forecast_from_trend_or_fetch`` GENAU dieses Y --
+          nicht die eingefrorene Systemuhr X UND nicht je eine eigene, im
+          Rumpf neu aufgeloeste ``datetime.now(timezone.utc)``. Ein DI-Spion
+          (echte Unterklassen-Methode, kein Mock) zeichnet auf, WELCHEN
+          Zeitpunkt der Pruefling tatsaechlich durchreicht.
+
+    Vor dem Fix hatte ``_build_report`` gar keinen ``now_utc``-Parameter --
+    die zweite, bislang bei preview_service.py:223 liegende
+    ``jetzt_utc = datetime.now(timezone.utc)``-Aufloesung ist genau die
+    Stelle, die AC-1 abschafft.
+
+    RED heute: ``now_utc`` existiert an ``_build_report`` noch nicht ->
+    ``TypeError``.
+    """
+    gesehen_trend: list = []
+    gesehen_thunder: list = []
+
+    def _trend_spion(self, trip, target_date, now_utc, tz=None):
+        gesehen_trend.append(now_utc)
+        return TrendResult(rows=None, state=OutlookState.NO_STAGES)
+
+    def _thunder_spion(self, trip, target_date, now_utc, tz,
+                        multi_day_trend=None, night_weather=None):
+        gesehen_thunder.append(now_utc)
+        return None
+
+    monkeypatch.setattr(TripReportSchedulerService, "_build_stage_trend", _trend_spion)
+    monkeypatch.setattr(
+        TripReportSchedulerService,
+        "_build_thunder_forecast_from_trend_or_fetch",
+        _thunder_spion,
+    )
+
+    ziel_tag = FROST_UTC.date()
+    trip = _preview_trip("preview-build-report-param-nz", [(ziel_tag, WP_NZ)])
+    service = PreviewService(settings_email_only())
+
+    with freeze_time(FROST_UTC):
+        _anker(FROST_UTC, WELLINGTON_ZONE, D20)
+        _uhr_eingefroren(FROST_UTC)
+        service._build_report(trip, ziel_tag, "evening", now_utc=PARAM_UTC, demo=True)
+
+    assert gesehen_trend == [PARAM_UTC], (
+        f"AC-1: _build_stage_trend erhielt now_utc={gesehen_trend!r}, erwartet "
+        f"[{PARAM_UTC.isoformat()}]. {[FROST_UTC]} heisst: die Systemuhr statt "
+        "des Parameters wurde durchgereicht."
+    )
+    assert gesehen_thunder == [PARAM_UTC], (
+        f"AC-1: _build_thunder_forecast_from_trend_or_fetch erhielt "
+        f"now_utc={gesehen_thunder!r}, erwartet [{PARAM_UTC.isoformat()}] -- "
+        "dasselbe now_utc wie _build_stage_trend (EIN Zeitpunkt speist beide "
+        "Entscheidungen, keine zweite Aufloesung)."
+    )
+
+
+# ═══════════════ AC-2: compare_preview_service._resolve_target_date (F2) ═══════════════
+
+
+def test_ac2_resolve_target_date_folgt_dem_parameter_und_dem_ersten_aufloesbaren_ort():
+    """AC-2 -- ``compare_preview_service._resolve_target_date`` (F2).
+
+    GIVEN zwei Orte -- der ERSTE ohne aufloesbare Zone (keine Koordinaten),
+          der ZWEITE in Neuseeland (UTC+12) -- und kein explizites Datum,
+    WHEN  ``_resolve_target_date(None, locations, now_utc=Y)`` unter
+          eingefrorener Systemuhr X aufgerufen wird (X != Y, verschiedene
+          Ortstage),
+    THEN  liefert die Funktion den ORTSTAG des ZWEITEN (ersten AUFLOESBAREN)
+          Orts zum Zeitpunkt Y -- weder den unaufloesbaren ersten Ort noch
+          die Systemuhr X.
+
+    Ohne den unaufloesbaren ersten Ort waere "ueberspringen statt UTC" nicht
+    falsifizierbar (#1378 AC-4/#1726 AC-15-Muster, wie in S5b AC-5 zweite
+    Haelfte).
+
+    RED heute: ``_resolve_target_date`` ist eine 1-Parameter-Funktion
+    (``given``) -> ``TypeError`` bei 3 Argumenten.
+    """
+    orte = [_ort("ohne-zone", None), _ort("ort-nz", WP_NZ)]
+
+    from utils.timezone import resolve_location_tz
+
+    assert resolve_location_tz(orte[0]) is None, (
+        "Testaufbau nicht diskriminierend: der erste Ort muss UNAUFLOESBAR "
+        "sein, sonst belegt der Test nicht, dass uebersprungen statt auf UTC "
+        "zurueckgefallen wird"
+    )
+
+    with freeze_time(FROST_UTC):
+        _anker(FROST_UTC, WELLINGTON_ZONE, D20)
+        _uhr_eingefroren(FROST_UTC)
+        ergebnis = _cps_resolve_target_date(None, orte, PARAM_UTC)
+
+    ortstag_param = PARAM_UTC.astimezone(ZoneInfo(WELLINGTON_ZONE)).date()
+    assert ergebnis == ortstag_param, (
+        f"AC-2: _resolve_target_date lieferte {ergebnis}, erwartet "
+        f"{ortstag_param} (Ortstag des zweiten/ersten aufloesbaren Orts zum "
+        f"Zeitpunkt now_utc={PARAM_UTC.isoformat()}). {D20} (Systemuhr-Ortstag) "
+        f"oder {FROST_UTC.date()} (nackter UTC-Tag) heissen: der Parameter "
+        "wurde ignoriert bzw. die Zone gar nicht aufgeloest."
+    )
+
+
+def test_ac2_gegebenes_datum_bleibt_unveraendert():
+    """AC-2, Invariante -- der ``given is not None``-Zweig aendert sich NICHT.
+
+    GIVEN ein explizit uebergebenes ISO-Datum (von der UI gesetzt),
+    WHEN  ``_resolve_target_date(given, locations, now_utc)`` aufgerufen
+          wird,
+    THEN  kommt GENAU dieses Datum zurueck -- unabhaengig von Orten und
+          now_utc. Die Zonen-/Parameter-Erweiterung aus AC-2 darf diesen
+          Zweig nicht anfassen (Spec "Then": "der given is not None-Zweig
+          ... bleibt dabei unveraendert").
+
+    RED heute aus demselben Signaturgrund wie oben (3 statt 1 Argument) --
+    NACH dem Fix bleibt dieser Test ein reiner Regressions-Riegel (analog
+    S5b AC-7, zweiter Test).
+    """
+    orte = [_ort("ort-nz", WP_NZ)]
+    erwartet = date(2026, 8, 1)
+
+    ergebnis = _cps_resolve_target_date(erwartet.isoformat(), orte, PARAM_UTC)
+
+    assert ergebnis == erwartet, (
+        f"AC-2 (Invariante): explizit uebergebenes Datum {erwartet} kam als "
+        f"{ergebnis} zurueck -- der given is not None-Zweig darf durch die "
+        "Zonen-/now_utc-Erweiterung NICHT veraendert werden."
+    )
+
+
+# ═══════════════ AC-3: GET /api/compare (F3-F5, run_comparison) ═══════════════
+
+
+@pytest.fixture
+def client():
+    from fastapi.testclient import TestClient
+    from api.main import app
+
+    return TestClient(app)
+
+
+def _leeres_vergleichsergebnis(target_date: date) -> ComparisonResult:
+    """Minimaler, echter ``ComparisonResult`` OHNE Orte -- die Sonde
+    interessiert sich nur fuer das ``target_date``, mit dem ``run_comparison``
+    die Engine aufruft bzw. das direkt im JSON-Response landet
+    (``api/routers/compare.py:120``)."""
+    return ComparisonResult(locations=[], time_window=(9, 16), target_date=target_date)
+
+
+def test_ac3_sofortvergleich_ortszeit_ist_dem_servertag_bereits_voraus(client, monkeypatch):
+    """AC-3, Szenario "voraus" -- Fundstellen F3-F5 (``run_comparison``).
+
+    GIVEN ein Ort in Neuseeland (UTC+12) und ein Zeitpunkt 13:00 UTC am
+          20.08. -- ortszeitlich ist bereits 01:00 Uhr am 21.08., auf dem
+          Server noch der 20.08. um 13:00 (< 14 Uhr),
+    WHEN  ``GET /api/compare`` OHNE ``target_date`` aufgerufen wird,
+    THEN  ist ``target_date`` im JSON-Response der 21.08. -- der Ortstag,
+          nicht der Servertag.
+
+    Vor dem Fix: die Serverstunde (13 Uhr, < 14) waehlte "heute" gemessen am
+    zonenlosen Servertag (20.08.) -- ohne zu sehen, dass am Ort bereits der
+    naechste Kalendertag laeuft.
+
+    RED heute: fachlich rot (kein TypeError -- ``run_comparison`` nimmt
+    keinen neuen Parameter, das Ergebnis ist schlicht falsch).
+    """
+    import app.loader as loader_mod
+    from services.comparison_engine import ComparisonEngine
+
+    ort = _ort("voraus-nz", WP_NZ)
+    monkeypatch.setattr(loader_mod, "load_all_locations", lambda *a, **kw: [ort])
+    monkeypatch.setattr(
+        ComparisonEngine, "run",
+        staticmethod(lambda **kwargs: _leeres_vergleichsergebnis(kwargs.get("target_date"))),
+    )
+
+    jetzt_utc = datetime(2026, 8, 20, 13, 0, tzinfo=timezone.utc)
+    with freeze_time(jetzt_utc):
+        _anker(jetzt_utc, WELLINGTON_ZONE, D21)
+        _uhr_eingefroren(jetzt_utc)
+        servertag = date.today()
+        resp = client.get(f"/api/compare?location_ids={ort.id}")
+
+    assert resp.status_code == 200, resp.text
+    daten = resp.json()
+    assert daten.get("target_date") == D21.isoformat(), (
+        f"AC-3: target_date={daten.get('target_date')!r}, erwartet "
+        f"{D21.isoformat()} (Ortstag in {WELLINGTON_ZONE} um "
+        f"{jetzt_utc.isoformat()}, dort bereits 01:00 Uhr des Folgetags). "
+        f"{servertag.isoformat()} heisst: die Serverstunde (< 14 Uhr UTC) hat "
+        "'heute' anhand des zonenlosen Servertags gewaehlt."
+    )
+
+
+def test_ac3_sofortvergleich_ortszeit_hinkt_dem_servertag_hinterher(client, monkeypatch):
+    """AC-3, Szenario "hinterher" -- Fundstellen F3-F5 (``run_comparison``).
+
+    GIVEN ein Ort in Pago Pago (UTC-11) und ein Zeitpunkt 00:30 UTC am
+          20.08. -- ortszeitlich ist erst 13:30 Uhr des VORTAGS (19.08.), auf
+          dem Server bereits der 20.08.,
+    WHEN  ``GET /api/compare`` OHNE ``target_date`` aufgerufen wird,
+    THEN  ist ``target_date`` im JSON-Response der 19.08. -- der Ortstag,
+          nicht der um einen Tag zu weit vorne liegende Servertag.
+
+    Vor dem Fix: der Servertag (20.08.) wurde 1:1 uebernommen, ohne den
+    negativen Zonenversatz zu beruecksichtigen.
+
+    RED heute: fachlich rot (analog zum "voraus"-Szenario, umgekehrte
+    Richtung).
+    """
+    import app.loader as loader_mod
+    from services.comparison_engine import ComparisonEngine
+
+    ort = _ort("hinterher-pago", PAGO)
+    monkeypatch.setattr(loader_mod, "load_all_locations", lambda *a, **kw: [ort])
+    monkeypatch.setattr(
+        ComparisonEngine, "run",
+        staticmethod(lambda **kwargs: _leeres_vergleichsergebnis(kwargs.get("target_date"))),
+    )
+
+    jetzt_utc = datetime(2026, 8, 20, 0, 30, tzinfo=timezone.utc)
+    with freeze_time(jetzt_utc):
+        _anker(jetzt_utc, PAGO_ZONE, D19)
+        _uhr_eingefroren(jetzt_utc)
+        servertag = date.today()
+        resp = client.get(f"/api/compare?location_ids={ort.id}")
+
+    assert resp.status_code == 200, resp.text
+    daten = resp.json()
+    assert daten.get("target_date") == D19.isoformat(), (
+        f"AC-3: target_date={daten.get('target_date')!r}, erwartet "
+        f"{D19.isoformat()} (Ortstag in {PAGO_ZONE} um {jetzt_utc.isoformat()}, "
+        "dort erst 13:30 Uhr des VORTAGS). "
+        f"{servertag.isoformat()} heisst: der Servertag wurde uebernommen, "
+        "ohne den negativen Zonenversatz zu beruecksichtigen."
+    )
+
+
+def test_ac3_sofortvergleich_serverstunde_ueber_14_ortsstunde_darunter(client, monkeypatch):
+    """AC-3, Szenario "Stundenschwelle" -- Fundstellen F3-F5 (``run_comparison``).
+
+    GIVEN ein Ort in Pago Pago (UTC-11) und ein Zeitpunkt 14:30 UTC am
+          20.08. -- die SERVERSTUNDE (14) liegt bereits >= 14 Uhr, die
+          ORTSSTUNDE (03:30) liegt NOCH darunter, waehrend Ortstag UND
+          Servertag auf DEMSELBEN Kalendertag liegen (20.08., KEIN
+          Tagesumbruch),
+    WHEN  ``GET /api/compare`` OHNE ``target_date`` aufgerufen wird,
+    THEN  ist ``target_date`` im JSON-Response der 20.08. -- die ORTSSTUNDE
+          entscheidet (< 14, kein Aufschlag), NICHT die Serverstunde.
+
+    Grund fuer diesen dritten Test (Team-Lead-Review nach dem ersten
+    Durchlauf): die beiden Tests oben ("voraus"/"hinterher") haben in BEIDEN
+    Faellen Orts- UND Serverstunde unter 14 -- der Stundenzweig ist dort
+    identisch. Eine Implementierung, die NUR den Tag auf ``first_resolvable_tz``
+    umstellt, die Stunde aber weiterhin ueber die (zonenlose) Serveruhr
+    entscheidet, besteht BEIDE Tests oben unbemerkt. Erst dieser dritte Test
+    erzwingt, dass auch die STUNDE aus derselben Ortszeit kommt wie der Tag
+    -- exakt die Klasse "Zusicherung behauptet, von keinem Test bewacht", die
+    dieses Epic bereits mehrfach getroffen hat.
+
+    Vorbedingungs-Anker: HIER faellt bewusst NICHT der Ortstag vom Servertag
+    ab (beide 20.08.) -- der geteilte ``_anker`` (der GENAU diese Divergenz
+    erzwingt, s. ``tests/tdd/conftest.py:88-109``) ist deshalb das FALSCHE
+    Werkzeug fuer diesen Test und wird hier bewusst NICHT verwendet. Der
+    diskriminierende Umstand ist ein anderer: Orts- und Serverstunde liegen
+    auf VERSCHIEDENEN Seiten der 14-Uhr-Schwelle, bei GLEICHEM Kalendertag.
+    Das wird als eigene Vorbedingung explizit gemessen (statt des Ankers),
+    bevor die Hauptzusicherung geprueft wird -- Muster identisch zum Anker
+    (erst messen, dann behaupten), nur mit der fuer diesen Fall richtigen
+    Groesse.
+
+    RED heute: fachlich rot -- die Serverstunde (>= 14) haengt den Tag an,
+    obwohl am Ort noch derselbe Kalendertag laeuft.
+    """
+    import app.loader as loader_mod
+    from services.comparison_engine import ComparisonEngine
+
+    ort = _ort("stunde-pago", PAGO)
+    monkeypatch.setattr(loader_mod, "load_all_locations", lambda *a, **kw: [ort])
+    monkeypatch.setattr(
+        ComparisonEngine, "run",
+        staticmethod(lambda **kwargs: _leeres_vergleichsergebnis(kwargs.get("target_date"))),
+    )
+
+    jetzt_utc = datetime(2026, 8, 20, 14, 30, tzinfo=timezone.utc)
+    erwarteter_tag = date(2026, 8, 20)
+    with freeze_time(jetzt_utc):
+        _uhr_eingefroren(jetzt_utc)
+        ortszeit = jetzt_utc.astimezone(ZoneInfo(PAGO_ZONE))
+        assert ortszeit.hour < 14 <= jetzt_utc.hour, (
+            "Testaufbau nicht diskriminierend: die Ortsstunde muss < 14, die "
+            f"Serverstunde muss >= 14 sein -- Ortsstunde {ortszeit.hour}, "
+            f"Serverstunde {jetzt_utc.hour}"
+        )
+        assert ortszeit.date() == jetzt_utc.date() == erwarteter_tag, (
+            "Testaufbau nicht diskriminierend: Ortstag und Servertag muessen "
+            f"DENSELBEN Kalendertag tragen ({erwarteter_tag}) -- sonst "
+            "wiederholte dieser Test den Tagesumbruch der beiden Szenarien "
+            "oben, statt die Stundenschwelle ISOLIERT zu pruefen. Ortstag "
+            f"{ortszeit.date()}, Servertag {jetzt_utc.date()}"
+        )
+        resp = client.get(f"/api/compare?location_ids={ort.id}")
+
+    assert resp.status_code == 200, resp.text
+    daten = resp.json()
+    assert daten.get("target_date") == erwarteter_tag.isoformat(), (
+        f"AC-3: target_date={daten.get('target_date')!r}, erwartet "
+        f"{erwarteter_tag.isoformat()} (Ortsstunde {ortszeit.hour}:xx < 14, "
+        "kein Aufschlag -- Ortstag und Servertag sind an diesem Tag GLEICH, "
+        "nur die Stunde entscheidet). "
+        f"{(erwarteter_tag + timedelta(days=1)).isoformat()} heisst: die "
+        f"Serverstunde ({jetzt_utc.hour} Uhr UTC, >= 14) hat den Tag "
+        "angehaengt, obwohl am Ort (Pago Pago) noch derselbe Kalendertag "
+        "laeuft -- eine Implementierung, die nur den TAG auf Ortszeit "
+        "umstellt, die STUNDE aber weiter von der Serveruhr nimmt, waere "
+        "durch die beiden Tag-Tests oben NICHT gefangen worden."
+    )
+
+
+# ═══════════════ AC-4: tote Funktion dict_to_comparison_result (F6) ═══════════════
+
+
+def test_ac4_dict_to_comparison_result_ist_ersatzlos_entfernt():
+    """AC-4 -- ``services.comparison_engine.dict_to_comparison_result`` (F6).
+
+    GIVEN die Funktion hat 0 Aufrufer in src/, api/, tests/, frontend/,
+          internal/, cmd/ (Volltextsuche, Definitionsstelle ausgenommen --
+          Kontext-Dokument, vom analysis-challenger bestaetigt),
+    WHEN  sie ersatzlos entfernt wird,
+    THEN  gelingt ``import services.comparison_engine`` weiterhin, aber
+          ``hasattr(mod, "dict_to_comparison_result")`` liefert ``False``.
+
+    RED heute: fachlich rot -- die Funktion existiert noch
+    (``hasattr`` liefert heute ``True``).
+    """
+    import services.comparison_engine as mod
+
+    assert hasattr(mod, "ComparisonEngine"), (
+        "Testaufbau: das Modul muss weiterhin importierbar bleiben und "
+        "ComparisonEngine exportieren"
+    )
+    assert not hasattr(mod, "dict_to_comparison_result"), (
+        "AC-4: services.comparison_engine.dict_to_comparison_result existiert "
+        "noch -- die Funktion hat 0 Aufrufer im gesamten Repo (Kontext-Dokument, "
+        "Volltextsuche) und soll ersatzlos entfallen"
+    )
+
+
+# ═══════════════ AC-5: Footer "Naechster Versand" folgt header_tz (F7) ═══════════════
+
+
+def _footer_ergebnis(target_date: date) -> ComparisonResult:
+    ort = SavedLocation(id="footer-nz", name="Footer-NZ", lat=WP_NZ[0], lon=WP_NZ[1],
+                        elevation_m=100)
+    return ComparisonResult(
+        locations=[LocationResult(location=ort)], time_window=(9, 16),
+        target_date=target_date,
+    )
+
+
+def test_ac5_footer_naechster_versand_weekly_folgt_der_kopfzeilen_zone():
+    """AC-5, ``weekly``-Schedule -- ``_compute_next_send``/``_render_abo_footer`` (F7).
+
+    GIVEN eine versendete Vergleichs-Mail mit EINEM Ort in Neuseeland
+          (UTC+12, damit ``header_tz`` = diese Zone traegt) und einem
+          ``weekly``-Abo auf Wochentag Freitag (4), zu einem Zeitpunkt, an
+          dem der ORTSTAG (21.08., ein Freitag) bereits einen Tag vor dem
+          Servertag (20.08., Donnerstag) liegt,
+    WHEN  ``render_compare_email`` den Footer "Naechster Versand" berechnet,
+    THEN  zeigt der Footer den 28.08.2026 -- den naechsten Freitag AB dem
+          ORTSTAG (21.08. IST bereits Freitag, also faellt der naive
+          "0 Tage"-Fall auf den `or 7`-Zweig, naechster Freitag = 28.08.).
+
+    Vor dem Fix rechnet ``_compute_next_send`` mit ``date.today()``
+    (Servertag 20.08., ein Donnerstag): naechster Freitag = 21.08. -- ein
+    ANDERES Datum als der korrekte 28.08., weil der Wochentag-Modulo-7-Wert
+    fuer Donnerstag->Freitag (1 Tag) vom Freitag->Freitag-Fall (7 Tage,
+    `or 7`-Zweig) abweicht. Genau dieser Weekday-Randfall macht die beiden
+    Zeitbasen sichtbar unterscheidbar (bei den meisten anderen Wochentagen
+    wuerde ein Ein-Tages-Versatz im Modulo-7 wieder herausfallen -- gemessen,
+    nicht vermutet).
+
+    RED heute: fachlich rot -- der Footer zeigt den Servertag-Wert.
+    """
+    from output.renderers.comparison import render_compare_email
+
+    with freeze_time(MITTAGS_UTC):
+        _anker(MITTAGS_UTC, WELLINGTON_ZONE, D21)
+        _uhr_eingefroren(MITTAGS_UTC)
+        servertag = date.today()
+        assert D21.weekday() == 4 and servertag.weekday() == 3, (
+            "Testaufbau nicht diskriminierend: Ortstag muss ein Freitag (4), "
+            f"Servertag ein Donnerstag (3) sein -- Ortstag {D21} "
+            f"({D21.weekday()}), Servertag {servertag} ({servertag.weekday()})"
+        )
+        ergebnis = _footer_ergebnis(D21)
+        html_body, _text = render_compare_email(
+            ergebnis, preset_name="Footer-Test-Weekly",
+            preset_schedule="weekly", preset_weekday=4,
+        )
+
+    erwartet = "28.08.2026"
+    falsch_server = "21.08.2026"
+    assert erwartet in html_body, (
+        f"AC-5 (weekly): Footer zeigt nicht {erwartet!r} (naechster Freitag ab "
+        f"dem ORTSTAG {D21}, Wochentag 4). Enthaelt stattdessen "
+        f"{falsch_server!r}: {falsch_server in html_body} -- das waere der "
+        "Servertag-Wert (date.today() statt header_tz)."
+    )
+
+
+def test_ac5_footer_naechster_versand_daily_folgt_der_kopfzeilen_zone():
+    """AC-5, ``daily``-Schedule -- ``_compute_next_send``/``_render_abo_footer`` (F7).
+
+    GIVEN dieselbe Lage wie oben, aber ein ``daily``-Abo,
+    WHEN  ``render_compare_email`` den Footer berechnet,
+    THEN  zeigt der Footer den 22.08.2026 -- den Ortstag (21.08.) plus 1 Tag.
+
+    Vor dem Fix: Servertag (20.08.) + 1 Tag = 21.08. -- ein anderes Datum.
+
+    RED heute: fachlich rot.
+    """
+    from output.renderers.comparison import render_compare_email
+
+    with freeze_time(MITTAGS_UTC):
+        _anker(MITTAGS_UTC, WELLINGTON_ZONE, D21)
+        _uhr_eingefroren(MITTAGS_UTC)
+        servertag = date.today()
+        ergebnis = _footer_ergebnis(D21)
+        html_body, _text = render_compare_email(
+            ergebnis, preset_name="Footer-Test-Daily",
+            preset_schedule="daily", preset_weekday=None,
+        )
+
+    erwartet = "22.08.2026"
+    falsch_server = "21.08.2026"
+    assert erwartet in html_body, (
+        f"AC-5 (daily): Footer zeigt nicht {erwartet!r} (Ortstag {D21} + 1 Tag). "
+        f"Enthaelt stattdessen {falsch_server!r}: {falsch_server in html_body} -- "
+        f"das waere der Servertag ({servertag}) + 1 Tag."
+    )

--- a/tests/tdd/test_vorschau_anzeige_folgen_ortszone.py
+++ b/tests/tdd/test_vorschau_anzeige_folgen_ortszone.py
@@ -121,6 +121,21 @@ FROST_UTC = datetime(2026, 8, 19, 20, 0, tzinfo=timezone.utc)
 # 20:00 UTC am 21.08. = 08:00 Ortszeit am 22.08. in Wellington (Ortstag D22).
 PARAM_UTC = datetime(2026, 8, 21, 20, 0, tzinfo=timezone.utc)
 
+# Adversary-Fund F001 (#1727 S5c QA-Runde): mit PARAM_UTC (Ortstag D22) landen
+# der korrekte Pfad UND ein Mutant, der ``now_utc`` ignoriert und stattdessen
+# ``date.today()`` benutzt, beim GLEICHEN Ergebnis (D19) -- der Mutant faellt
+# durch den Rueckfall auf die "chronologisch erste Etappe", der korrekte Pfad
+# ebenso (weil am Ortstag D22 beide Etappen laengst vergangen sind); der
+# nackte UTC-Kalendertag von FROST_UTC (= D19, s.u.) trifft zufaellig exakt
+# dieselbe Etappe. Dieser eigene Wert trifft stattdessen EXAKT die ZWEITE
+# Etappe -- der korrekte Pfad matcht sie direkt im Haupt-Vergleich
+# ``stage_date >= today``, nicht ueber den Rueckfall; ein Mutant landet weiter
+# bei der ERSTEN Etappe (D19, nackter UTC-Tag von FROST_UTC). Zwei
+# unterscheidbare Ergebnisse statt eines zufaelligen Zusammentreffens.
+# 20:00 UTC am 20.08. = 08:00 Ortszeit am 21.08. in Wellington (Ortstag D21,
+# faellt exakt auf die zweite Etappe).
+PARAM_UTC_STAGE_MATCH = datetime(2026, 8, 20, 20, 0, tzinfo=timezone.utc)
+
 
 def _preview_trip(trip_id: str, tage_und_koordinaten: list) -> Trip:
     """Tour mit je einer RENDERBAREN (2-Wegpunkt-)Etappe pro Tag.
@@ -161,43 +176,93 @@ def _uhr_eingefroren(now_utc: datetime) -> None:
 # ═══════════════════════ AC-1: preview_service (F1) ═══════════════════════
 
 
-def test_ac1_resolve_target_date_folgt_dem_parameter_nicht_der_systemuhr():
+def test_ac1_resolve_target_date_folgt_dem_parameter_nicht_der_systemuhr(monkeypatch):
     """AC-1, erste Haelfte -- ``PreviewService._resolve_target_date`` (F1).
 
     GIVEN eine Neuseeland-Tour (UTC+12) mit Etappen am 19.08. und 21.08.,
     WHEN  ``_resolve_target_date(trip, given_date=None, now_utc=Y)`` unter
           eingefrorener Systemuhr X aufgerufen wird, wobei X und Y auf
           verschiedene Ortstage derselben Zone fallen,
-    THEN  waehlt die Auto-Resolve-Logik die Etappe gemessen am Ortstag VON Y
-          -- nicht von X. Bei X (Ortstag 20.08.) waere die 21.08.-Etappe die
-          naechste kommende; bei Y (Ortstag 22.08.) liegen BEIDE Etappen
-          bereits in der Vergangenheit, der Rueckfall greift auf die
-          chronologisch ERSTE Etappe (19.08.) -- ein eindeutig
-          unterscheidbares Ergebnis.
+    THEN  ruft der Pruefling ``trip_local_today(trip, now_utc)`` MIT dem
+          uebergebenen Y auf -- nicht mit X.
+
+    Fund-Geschichte, warum dieser Test per DI-SPION misst statt ueber die
+    gewaehlte Etappe zu schliessen (Adversary #1727 S5c, QA-Runde 3):
+
+    F001: Die urspruengliche Fixtur nutzte ``PARAM_UTC`` (Ortstag 22.08.,
+    BEIDE Etappen vergangen). Der korrekte Pfad landete dort ueber den
+    Rueckfall auf die "chronologisch erste Etappe" (19.08.) -- GENAU das
+    Ergebnis, das ein Mutant liefert, der ``now_utc`` ignoriert und
+    stattdessen ``date.today()`` benutzt (der nackte UTC-Kalendertag der
+    eingefrorenen Systemuhr X ist 19.08. und trifft zufaellig dieselbe,
+    erste Etappe). Fix: ``PARAM_UTC_STAGE_MATCH`` (Ortstag 21.08.), dessen
+    Ortstag EXAKT auf die zweite Etappe faellt.
+
+    F002: Dieser Fix schloss die Kollision am UNTEREN Rand, liess die
+    STRUKTURELLE Kollisionszone aber offen. Der Ortstag von ``FROST_UTC``
+    (20.08.) UND der von ``PARAM_UTC_STAGE_MATCH`` (21.08.) liegen BEIDE im
+    Intervall (19.08., 21.08.] der Zwei-Etappen-Fixtur -- die
+    ``stage_date >= today``-Schleife waehlt in BEIDEN Faellen dieselbe
+    zweite Etappe. Eine Mutation, die den Parameter formal behaelt, im
+    Rumpf aber ``trip_local_today(trip, datetime.now(timezone.utc))``
+    aufruft (Systemuhr statt Parameter, Zonenaufloesung bleibt korrekt),
+    blieb dadurch unentdeckt -- und DIESMAL ohne AST-Wächter als Backstop:
+    ``datetime.now(timezone.utc)`` ist an drei Stellen in
+    ``preview_service.py`` legitim (``has_tz_arg = True``,
+    ``tests/test_output_timezone_guard.py:383-393``).
+
+    Der Umweg ueber die Etappenauswahl ist strukturell immer nur so scharf
+    wie die zufaellige Lage der Etappendaten -- eine dritte Kollisionszone
+    liesse sich mit demselben Muster jederzeit wiederfinden. Ein DI-Spion
+    direkt auf ``trip_local_today`` misst stattdessen MIT WELCHEM ARGUMENT
+    der Pruefling die Funktion aufruft -- die Zusicherung, die AC-8
+    tatsaechlich meint, geprueft an der Stelle, an der sie wirkt. Analog
+    zum zweiten AC-1-Test unten (``_build_report``), der genau dasselbe
+    Muster fuer die Scheduler-Aufrufe nutzt. **Nicht wieder auf einen
+    Etappen-Umweg vereinfachen** -- das waere ein Rueckfall auf F001/F002.
 
     RED heute: ``now_utc`` existiert an ``_resolve_target_date`` noch nicht
     -> ``TypeError``.
     """
+    import services.trip_day as trip_day_mod
+
+    gesehen_now_utc: list = []
+    _echte_trip_local_today = trip_day_mod.trip_local_today
+
+    def _trip_local_today_spion(trip_arg, now_utc_arg):
+        gesehen_now_utc.append(now_utc_arg)
+        return _echte_trip_local_today(trip_arg, now_utc_arg)
+
+    monkeypatch.setattr(trip_day_mod, "trip_local_today", _trip_local_today_spion)
+
     trip = _preview_trip("preview-param-nz", [(D19, WP_NZ), (D21, WP_NZ)])
     service = PreviewService(settings_email_only())
 
     with freeze_time(FROST_UTC):
         _anker(FROST_UTC, WELLINGTON_ZONE, D20)
         _uhr_eingefroren(FROST_UTC)
-        ergebnis = service._resolve_target_date(trip, None, now_utc=PARAM_UTC)
+        ergebnis = service._resolve_target_date(
+            trip, None, now_utc=PARAM_UTC_STAGE_MATCH,
+        )
 
-    ortstag_param = PARAM_UTC.astimezone(ZoneInfo(WELLINGTON_ZONE)).date()
-    assert ortstag_param == D22, (
-        "Testaufbau nicht diskriminierend: PARAM_UTC muss auf Ortstag "
-        f"{D22} fallen, liegt aber auf {ortstag_param}"
+    assert gesehen_now_utc == [PARAM_UTC_STAGE_MATCH], (
+        f"AC-1/AC-8: trip_local_today wurde mit now_utc={gesehen_now_utc!r} "
+        f"aufgerufen, erwartet [{PARAM_UTC_STAGE_MATCH.isoformat()}] -- der "
+        "Pruefling hat entweder den Parameter gar nicht an trip_local_today "
+        "durchgereicht (leere Liste) oder die eingefrorene Systemuhr "
+        f"({FROST_UTC.isoformat()}) statt des uebergebenen Parameters "
+        "gelesen (F002, ADR-0051 Regel 3)."
     )
-    assert ergebnis == D19, (
-        f"AC-1: _resolve_target_date lieferte {ergebnis}, erwartet {D19} "
-        f"(chronologisch erste Etappe, weil am Ortstag von now_utc={PARAM_UTC.isoformat()} "
-        f"({ortstag_param}) BEIDE Etappen bereits vergangen sind). "
-        f"{D21} heisst: der Pruefling hat die eingefrorene Systemuhr "
-        f"({FROST_UTC.isoformat()}, Ortstag {D20}) benutzt statt des "
-        "uebergebenen Parameters now_utc (ADR-0051 Regel 3)."
+    ortstag_param = PARAM_UTC_STAGE_MATCH.astimezone(ZoneInfo(WELLINGTON_ZONE)).date()
+    assert ortstag_param == D21, (
+        "Testaufbau nicht diskriminierend: PARAM_UTC_STAGE_MATCH muss auf "
+        f"Ortstag {D21} fallen (exakt die zweite Etappe), liegt aber auf "
+        f"{ortstag_param}"
+    )
+    assert ergebnis == D21, (
+        f"AC-1: _resolve_target_date lieferte {ergebnis}, erwartet {D21} "
+        f"(die Etappe am Ortstag von now_utc={PARAM_UTC_STAGE_MATCH.isoformat()} "
+        f"({ortstag_param}))."
     )
 
 
@@ -227,12 +292,19 @@ def test_ac1_build_report_folgt_dem_parameter_nicht_der_systemuhr(monkeypatch):
     gesehen_trend: list = []
     gesehen_thunder: list = []
 
-    def _trend_spion(self, trip, target_date, now_utc, tz=None):
+    def _trend_spion(self, trip, target_date, now_utc, **kwargs):
+        # **kwargs statt einzeln nachgezogener Parameter (tz, report_type, ...):
+        # dieser Spion bewacht AUSSCHLIESSLICH now_utc (AC-1) -- der bleibt
+        # explizit benannt und wird unten geprueft. Alles andere (Issue
+        # #1720 S1 hat report_type ergaenzt, kuenftige Erweiterungen sind
+        # nicht ausgeschlossen) wird stillschweigend entgegengenommen, statt
+        # bei JEDER Signaturerweiterung von _build_stage_trend erneut mit
+        # einem TypeError zu brechen, der wie ein Testfehler aussieht, aber
+        # nur Signatur-Drift ist.
         gesehen_trend.append(now_utc)
         return TrendResult(rows=None, state=OutlookState.NO_STAGES)
 
-    def _thunder_spion(self, trip, target_date, now_utc, tz,
-                        multi_day_trend=None, night_weather=None):
+    def _thunder_spion(self, trip, target_date, now_utc, **kwargs):
         gesehen_thunder.append(now_utc)
         return None
 

--- a/tests/test_output_timezone_guard.py
+++ b/tests/test_output_timezone_guard.py
@@ -608,16 +608,10 @@ KNOWN_VIOLATIONS: dict[str, str] = {
     # Massen-Umschrift den Shrink-Vergleich unnoetig verrauschen wuerde.
     # -----------------------------------------------------------------------
     # --- Muster A: Umgebungsuhr (`date.today()` / `datetime.now()` ohne tz) ---
-    "api/routers/compare.py::run_comparison::0": "Muster A (:53) — Sofort-Vergleich nimmt die Serveruhr als 'jetzt' (#1726).",
-    "api/routers/compare.py::run_comparison::1": "Muster A (:55) — Zieltag 'heute' vom Server, nicht vom Ort (#1726).",
-    "api/routers/compare.py::run_comparison::2": "Muster A (:58) — Zieltag 'morgen' vom Server, nicht vom Ort (#1726).",
     "api/routers/debug.py::trigger_radar_alert::0": "Muster A (:61) — Debug-Ausloeser datiert auf die Serveruhr (#1726).",
-    "src/output/renderers/email/compare_html.py::_compute_next_send::0": "Muster A (:1377) — naechste Sendezeit gegen den Servertag geprueft (#1726).",
     # #1727 S5b: `briefing_target_day_is_current` hat keinen Systemuhr-
     # Rueckfall mehr — `today` ist Pflicht und kommt als Ortstag der Tour vom
     # Aufrufer. Eintrag entfaellt.
-    "src/services/compare_preview_service.py::_resolve_target_date::0": "Muster A (:250) — Vorschau-Zieltag vom Server (#1726).",
-    "src/services/comparison_engine.py::dict_to_comparison_result::0": "Muster A (:407) — Zieltag beim Einlesen vom Server (#1726).",
     "src/services/gpx_processing.py::compute_default_start_date::0": "Muster A (:189) — GPX-Vorgabestart vom Servertag (#1726).",
     "src/services/gpx_processing.py::compute_default_start_date::1": "Muster A (:193) — zweiter Rueckfall auf den Servertag (#1726).",
     "src/services/gpx_processing.py::gpx_to_stage_data::0": "Muster A (:223) — Etappendatum faellt auf den Servertag zurueck (#1726).",
@@ -627,7 +621,12 @@ KNOWN_VIOLATIONS: dict[str, str] = {
     "src/services/official_alerts/massif_closure.py::_do_request::0": "Muster A (:102) — Abfrage-Datum der franzoesischen Quelle vom Server (#1726).",
     "src/services/official_alerts/massif_closure.py::fetch::0": "Muster A (:127) — Zeitstempel fuer `last_run` ohne Zone (#1726).",
     "src/services/official_alerts/meteo_forets.py::covers::0": "Muster A (:130) — Saison-Fenster gegen den Servermonat (#1726).",
-    "src/services/preview_service.py::_resolve_target_date::0": "Muster A (:94) — Vorschau-Zieltag vom Server (#1726).",
+    # #1727 S5c: die sieben verbleibenden Vorschau-/Anzeige-/Sofort-Vergleichs-
+    # Eintraege dieser Rubrik (api/routers/compare.py::run_comparison x3,
+    # compare_html.py::_compute_next_send, compare_preview_service.py::
+    # _resolve_target_date, comparison_engine.py::dict_to_comparison_result
+    # [entfernt], preview_service.py::_resolve_target_date) sind behoben.
+    # Eintraege entfallen.
     # #1727 S5b: die sechs Versandpfad-Eintraege dieser Rubrik sind behoben —
     # `_auto_pause_expired_presets` und `send_one_compare_preset` rechnen ueber
     # `first_resolvable_tz(locations)` im Ortstag des Presets, die vier

--- a/tests/unit/test_preview_night_block.py
+++ b/tests/unit/test_preview_night_block.py
@@ -219,7 +219,7 @@ def test_demo_preview_night_fetch_never_touches_live_openmeteo(monkeypatch):
     trip = _demo_trip_single_stage(target, show_night_block=True)
 
     report, _segments, _stage_name, _tz = PreviewService()._build_report(
-        trip, target, "evening", demo=True,
+        trip, target, "evening", now_utc=datetime.now(timezone.utc), demo=True,
     )
 
     assert calls == [], (
@@ -262,7 +262,9 @@ def test_preview_night_fetch_follows_night_metric_selection(monkeypatch):
         "aktiviert haben (build_default_display_config, #1484)."
     )
 
-    PreviewService()._build_report(trip, target, "evening", demo=True)
+    PreviewService()._build_report(
+        trip, target, "evening", now_utc=datetime.now(timezone.utc), demo=True,
+    )
 
     assert calls, (
         "Die Vorschau beschafft KEINE Nachtdaten, obwohl die "
@@ -306,7 +308,9 @@ def test_preview_skips_night_fetch_when_neither_selected(monkeypatch):
         for mc in trip.display_config.metrics
     ]
 
-    PreviewService()._build_report(trip, target, "evening", demo=True)
+    PreviewService()._build_report(
+        trip, target, "evening", now_utc=datetime.now(timezone.utc), demo=True,
+    )
 
     assert calls == [], (
         "Die Vorschau beschafft Nachtdaten, obwohl weder Nacht-Tabelle noch "

--- a/tests/unit/test_thunder_night_addendum_parity.py
+++ b/tests/unit/test_thunder_night_addendum_parity.py
@@ -232,6 +232,7 @@ def _run_both_paths(monkeypatch, tmp_path, *, show_night_block: bool):
     recorder.label = "vorschau"
     PreviewService()._build_report(
         _trip(show_night_block=show_night_block), _TODAY, "morning",
+        now_utc=_dt.datetime.now(_dt.timezone.utc),
     )
 
     return recorder.entry("versand"), recorder.entry("vorschau")

--- a/tools/weather_validation.py
+++ b/tools/weather_validation.py
@@ -285,6 +285,10 @@ def main():
     args = parser.parse_args()
 
     if args.lat and args.lon:
+        # gz-main-path: dieses Werkzeug fragt seine Referenzdaten selbst
+        # ausdruecklich mit "timezone": "UTC" ab (fetch_openmeteo, Zeile 31) --
+        # ein Ortstag-Default erzeugte einen Widerspruch INNERHALB desselben
+        # Skripts (Validierungsziel UTC, Validierungs-Default Ortszeit).
         target_date = args.date or date.today().isoformat()
         validate_point(args.lat, args.lon, target_date)
     elif args.trip:


### PR DESCRIPTION
Vierte Scheibe von #1727 (Epic #1722, ADR-0044/ADR-0051). Sieben Fundstellen in fünf Dateien bestimmen den Kalendertag nicht mehr an der Serveruhr.

## Was sich ändert

Beispiel Neuseeland, Server auf Weltzeit, 20.08. um 14:00 UTC — am Ort ist bereits der 21.08.:

| Pfad | Bisher | Danach |
|---|---|---|
| Trip-Vorschau ohne Datum | Etappe des Servertags | Etappe des Ortstags |
| Ortsvergleichs-Vorschau ohne Datum | Servertag | Ortstag des ersten **auflösbaren** Orts |
| `GET /api/compare` ohne `target_date` | 14-Uhr-Schwelle an der Serverstunde, Tag vom Server | Stunde **und** Tag aus derselben Ortszeit |
| Fußzeile „Nächster Versand" der Vergleichs-Mail | Servertag, obwohl die Kopfzeile Ortszeit zeigt | dieselbe Zone wie die Kopfzeile |

Aufrufe **mit** ausdrücklichem Datum bleiben unverändert.

`comparison_engine.dict_to_comparison_result` wird ersatzlos entfernt statt korrigiert — null Aufrufer im gesamten Repo. `tools/weather_validation.py` bekommt eine begründete Zeilen-Ausnahme (`# gz-main-path:`) statt eines Fixes: Das Werkzeug fragt seine Referenzdaten selbst mit `"timezone": "UTC"` ab, ein Ortstag-Default widerspräche dem im selben Skript.

Sieben `KNOWN_VIOLATIONS`-Einträge entfallen. Nach S5d ist die Muster-A-Liste des Wächters leer.

## Zwei eigene Analyse-Aussagen wurden gekippt

Beide vom `analysis-challenger`, beide am Code gegengeprüft:

1. **`GET /api/compare` ist kein toter Code.** Die Suche „kein Aufrufer" deckte nur `frontend/src` ab. Der Endpunkt hat einen eigens gebauten Go-Proxy (`internal/router/router.go:156`, `CompareProxyHandler` mit 60s-Timeout und `appendUserID`) und ist öffentlich erreichbar. Er wird repariert, nicht entfernt.
2. **Die Kopfzeilen-Zeitbasis ist kein Fehler.** `location_tz(locations[0].location)` setzt PO-freigegebenes AC-4 aus #1378 wörtlich um (erstgenannter Ort, ausdrücklich nicht der erste auflösbare). Sie bleibt unangetastet; der Footer erbt sie.

## Nachweis

10 neue Tests. Drei Eigenheiten, die erst durch Nachrechnen entstanden:

- **AC-3 braucht drei Fälle, nicht zwei.** Der „ab 14 Uhr"-Zweig ist bei gleichzeitigem Tagesumbruch mit echten Zonen nicht konstruierbar (max. +14/−11 Stunden reichen rechnerisch nicht). Zwei Tests bewachen deshalb den Tag, ein dritter die Stunde. Ohne ihn bestünde eine Implementierung, die den Tag auf Ortszeit umstellt und die Stunde weiter von der Serveruhr nimmt, alle Tests.
- **Der dritte AC-3-Test nutzt bewusst nicht den geteilten Anker** — er verlangt Ortstag *gleich* Servertag und prüft seine eigene Vorbedingung (Ortsstunde und Serverstunde auf verschiedenen Seiten der Schwelle).
- **AC-5 weekly liegt auf Freitag**, dem einzigen Wochentag, an dem der Modulo-7-Sprung zwischen Orts- und Servertag sichtbar divergiert.

**Adversary VERIFIED** nach vier Runden, zwei Testqualitäts-Findings gefunden und geschlossen: Die Parameter-gegen-Systemuhr-Probe war zweimal nicht diskriminierend — erst gegen `date.today()` (Fixtur-Kollision), dann gegen `trip_local_today(trip, datetime.now(timezone.utc))`, wofür **kein** AST-Wächter als Backstop greift. Sie misst jetzt per Spion direkt das Argument der Auflösung, statt über die Etappenauswahl zu schließen. Mutations-Gegenprobe an allen Fundstellen, jede Verfälschung gefangen.

Renderer-Mail-Gate: `email_spec_validator.py` Exit 0 gegen eine echt zugestellte Vergleichs-Mail (drei Orte in drei Zonen, Zustellung ans Test-Postfach per Log belegt).

## ADR-Pflege

Die Restliste in ADR-0044 ist fortgeschrieben — dabei zwei **weitere** unvollständige Aufzählungen benannt: `compare_preview_service._resolve_target_date` fehlte dort vollständig, und `gpx_processing`/`massif_closure`/`meteo_forets` standen in *keinem* Abschnitt, obwohl der Wächter sie führte. Das ADR warnt an genau dieser Stelle selbst davor.

## Nicht in dieser Scheibe

- Ob Fußzeile und Versand-Zieltag derselben Mail zwei verschiedene „erste Orte" benutzen dürfen (`location_tz(locations[0])` gegen `first_resolvable_tz`) — eigener Befund, kein Muster A.
- `debug.py`, GPX-Import, Fremdquellen — S5d.

Refs #1727

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSU1on9gyRdvj3MRv8e9yd
