### PR TITLE
test(#1720 S1): Playwright-Selektoren des Ausblick-Klickpfads richtigstellen

### DIFF
--- a/docs/specs/fast/fix-1720-s1-playwright-selektoren.md
+++ b/docs/specs/fast/fix-1720-s1-playwright-selektoren.md
@@ -1,0 +1,53 @@
+# Mini-Spec: Playwright-Selektoren des Trip-Ausblick-Klickpfads richtigstellen
+
+<!-- Nacharbeit zu #1720 Scheibe 1. Herkunft: Staging-Validator F001/F002 (beide LOW,
+     ausdrücklich als Testautoren-Befunde eingestuft, kein Produktfehler). -->
+
+## Warum
+
+`frontend/e2e/trip-outlook-metric-selection.staging.spec.ts` entstand in der RED-Phase und
+konnte dort strukturell nicht gegen Staging laufen — der Stand war noch nicht deployt. Beim
+ersten echten Lauf zeigten sich zwei falsche Annahmen über die Oberfläche. Die
+Staging-Verifikation lief deshalb mit korrigierten Selektoren; die Datei im Repo trägt die
+Korrektur noch nicht und schlägt fehl, wenn jemand sie ausführt.
+
+Ein Test, der aus falschen Gründen rot ist, kostet den Nächsten eine Fehlersuche am Produkt.
+
+## Was ändert sich
+
+- **Speichern:** Der Helfer klickt `data-testid=weather-metrics-tab-save`. Diesen Knopf gibt es
+  im Trip-Kontext nicht — `WeatherMetricsTab.svelte:1451` rendert ihn nur
+  `{#if isDirty && !saveController && !createMode}`, und der Trip übergibt einen
+  `saveController` (Autosave, 700 ms Debounce). Stattdessen auf den PUT warten
+  (`page.waitForResponse`), so wie es der Validator im bestätigten Nachlauf getan hat.
+- **Gegenprobe zu AC-13:** Sie wechselt zu `data-testid=trip-detail-tab-briefings` und sucht
+  dort `report-show-outlook`. Der Schalter lebt im **selben** Wetter-Reiter
+  (`WeatherMetricsTab.svelte:1780-1787` bindet `EditReportConfigSection` inline);
+  `BriefingScheduleTab.svelte:117-119` hält ausdrücklich fest: „Mail-Inhalt bleibt unangetastet
+  im Inhalt-Tab". Gegenprobe ohne Tab-Wechsel prüfen.
+
+## Was darf sich nicht ändern
+
+- Die geprüften Zusicherungen selbst — AC-6, AC-7, AC-11 und AC-13 bleiben inhaltlich gleich.
+  Geändert wird nur, **wie** der Test die Oberfläche anspricht, nicht **was** er behauptet.
+- Kein Produktivcode. Kein Eintrag in `.github/ci_e2e_specs.txt` (Positivliste wächst nur nach
+  dem Vermessungsverfahren aus ADR-0054).
+
+## Manuelle Test-Schritte
+
+1. Aus `frontend/`: `npx playwright test --config=playwright.trip-outlook.staging.config.ts`
+2. Alle Prüfungen grün, ohne Selektor-Anpassung von Hand.
+3. Gegenprobe, dass der Test etwas bewacht: Abwahl im Testablauf entfernen ⇒ der AC-6-Fall
+   muss rot werden.
+
+## Acceptance Criteria
+
+- **AC-1:** Given die Datei `trip-outlook-metric-selection.staging.spec.ts` im Repo-Zustand,
+  When sie unverändert gegen Staging läuft, Then bestehen alle enthaltenen Prüfungen — ohne
+  dass jemand vorher Selektoren von Hand anpassen muss.
+- **AC-2:** Given der Trip-Editor speichert per Autosave statt per Knopf, When der Test eine
+  Auswahl ändert, Then wartet er auf die tatsächliche Speicher-Antwort des Servers und nicht
+  auf ein Element, das im Trip-Kontext gar nicht gerendert wird.
+- **AC-3:** Given der bestehende Ein/Aus-Schalter für den Ausblick liegt im selben
+  Wetter-Reiter, When die Gegenprobe zu AC-13 ihn sucht, Then findet sie ihn dort — ohne
+  Wechsel in den Versand-Reiter.

--- a/frontend/e2e/trip-outlook-metric-selection.staging.spec.ts
+++ b/frontend/e2e/trip-outlook-metric-selection.staging.spec.ts
@@ -1,30 +1,24 @@
-// TDD RED — #1720 Scheibe 1: Abschnitt "3-Tages-Vorschau" im Wetter-Metriken-
-// Reiter des Trips (AC-6, AC-7, AC-13).
+// Staging-Klickpfad — #1720 Scheibe 1: Abschnitt "3-Tages-Vorschau" im
+// Wetter-Metriken-Reiter des Trips (AC-6, AC-7, AC-11, AC-13).
 //
 // Spec: docs/specs/modules/feat_1720_s1_trip_ausblick_metriken.md
+// Nacharbeit: docs/specs/fast/fix-1720-s1-playwright-selektoren.md
 // Kontext: docs/context/feat-1720-vorschau-metriken.md
-// Workflow: feat-1720-vorschau-metriken
 //
 // Namensregel (CLAUDE.md): nach Verhalten benannt, nicht nach Ticket.
 // Muster: compare-outlook-metric-selection.staging.spec.ts — dieselbe
 // Bedienflaeche, nur im Trip-Kontext (parametrisiert statt kopiert).
 //
-// 🔴 IN DER RED-PHASE NICHT AUSFUEHRBAR: der Abschnitt existiert auf Staging
-// noch nicht ('ausblick' steht in COMPARE_ONLY_SECTIONS,
-// weatherMetricsTabSections.ts:56). Der Lauf gehoert in die GREEN-Phase,
-// nach dem Staging-Deploy.
+// Die Datei entstand in der RED-Phase und war dort strukturell nicht
+// ausfuehrbar (der Abschnitt war noch nicht deployt). Zwei Annahmen ueber die
+// Oberflaeche hielten dem ersten echten Lauf nicht stand und sind hier
+// richtiggestellt — s. `wartetAufAutosave` (kein Speichern-Knopf im Trip) und
+// die Gegenprobe in AC-13 (der Ausblick-Schalter lebt im selben Reiter).
 //
 // Ausfuehren (gegen Staging, aus frontend/):
 //   set -a; source /home/hem/gregor_zwanzig/.claude/validator.env; set +a
 //   set -a; source /home/hem/gregor_zwanzig_staging/.env; set +a
 //   npx playwright test --config=playwright.trip-outlook.staging.config.ts
-//
-// ⚠️ Die genannte Config `frontend/playwright.trip-outlook.staging.config.ts`
-// FEHLT noch: der Edit-Wächter der RED-Phase laesst dort keine Datei zu
-// (kein Test-Pfad). Sie ist in der GREEN-Phase anzulegen, 1:1 nach dem
-// Muster `playwright.compare-outlook.staging.config.ts` — Projekte `setup`
-// (diese `.staging.setup.ts`) und `chromium` mit
-// `storageState: 'playwright/.auth/staging-trip-outlook.json'`.
 //
 // Zugangsdaten-Hinweis (CLAUDE.md, 2026-08-08): nginx-Schranke =
 // GZ_VALIDATOR_*, App-Anmeldung = GZ_AUTH_* aus der STAGING-.env — die .env
@@ -62,14 +56,22 @@ function vorschauAbschnitt(reiter: Locator): Locator {
 	return reiter.getByTestId('weather-metrics-ausblick');
 }
 
-async function speichern(page: Page, reiter: Locator, tripId: string): Promise<void> {
-	const put = page.waitForResponse(
-		(r) => r.url().includes(`/api/trips/${tripId}`) && r.request().method() === 'PUT',
-		{ timeout: 10000 }
+/** Der Trip-Editor hat KEINEN Speichern-Knopf: `TripTabs` reicht einen
+ *  `saveController` hinein, und `WeatherMetricsTab.svelte:1451` rendert
+ *  `weather-metrics-tab-save` nur `{#if isDirty && !saveController && !createMode}`.
+ *  Gespeichert wird per Autosave (700 ms Debounce) — `scheduleAutoSave()`
+ *  schreibt die Ausblick-Auswahl per PUT auf `/api/trips/{id}/weather-config`
+ *  (WeatherMetricsTab.svelte:960). Der Test wartet deshalb auf die echte
+ *  Speicher-Antwort statt auf einen Knopf, den es hier nicht gibt.
+ *
+ *  Scharfschalten VOR der Geste: der Debounce kann sonst ablaufen, bevor
+ *  jemand zuhoert. */
+function wartetAufAutosave(page: Page, tripId: string) {
+	return page.waitForResponse(
+		(r) =>
+			r.url().includes(`/api/trips/${tripId}/weather-config`) && r.request().method() === 'PUT',
+		{ timeout: 15000 }
 	);
-	await reiter.getByTestId('weather-metrics-tab-save').click();
-	await put;
-	await page.waitForLoadState('networkidle');
 }
 
 test.describe('Trip-Vorschau: waehlbare Spalten im Wetter-Metriken-Reiter (#1720 S1, Staging)', () => {
@@ -98,10 +100,12 @@ test.describe('Trip-Vorschau: waehlbare Spalten im Wetter-Metriken-Reiter (#1720
 		// Eine Groesse abwaehlen, die in der Grundvorbelegung aktiv ist.
 		const boeen = abschnitt.getByTestId('compare-layout-outlook-metric-gust').locator('input');
 		await expect(boeen, 'Vorbedingung: Böen ist vor der Abwahl angehakt').toBeChecked();
+		const gespeichertePut = wartetAufAutosave(page, trip.id);
 		await boeen.uncheck();
 		await expect(boeen).not.toBeChecked();
 
-		await speichern(page, reiter, trip.id);
+		await gespeichertePut;
+		await page.waitForLoadState('networkidle');
 
 		// Serverstand ist die eigentliche Aussage, nicht nur der DOM.
 		const gespeichert = await page.request.get(`/api/trips/${trip.id}`);
@@ -184,11 +188,14 @@ test.describe('Trip-Vorschau: waehlbare Spalten im Wetter-Metriken-Reiter (#1720
 			'AC-13: kein zweiter Ausblick-Schalter (Beschriftung des Compare-Toggles)'
 		).toHaveCount(0);
 
-		// Gegenprobe: der EINE vorhandene Schalter lebt weiterhin im
-		// Inhalt-/Versand-Bereich und ist unberuehrt.
-		await page.getByTestId('trip-detail-tab-briefings').first().click();
+		// Gegenprobe: der EINE vorhandene Schalter lebt weiterhin in der
+		// Mail-Inhalt-Karte — und die sitzt im SELBEN Wetter-Metriken-Reiter,
+		// nicht im Versand-Reiter: `WeatherMetricsTab.svelte:1780-1787` bindet
+		// `EditReportConfigSection` (Abschnitt 'report_config') inline ein,
+		// `BriefingScheduleTab.svelte:117-119` haelt ausdruecklich fest
+		// "Mail-Inhalt bleibt unangetastet im Inhalt-Tab". Also ohne Tab-Wechsel.
 		await expect(
-			page.getByTestId('report-show-outlook'),
+			reiter.getByTestId('report-show-outlook'),
 			'AC-13: der bestehende Ein/Aus-Schalter fuer den Ausblick muss erhalten bleiben'
 		).toBeVisible({ timeout: 10000 });
 


### PR DESCRIPTION
Nacharbeit zu #1720 Scheibe 1 (bereits live). **Nur die Playwright-Datei — kein Produktivcode.**

## Warum

`frontend/e2e/trip-outlook-metric-selection.staging.spec.ts` entstand in der RED-Phase und konnte dort strukturell nicht gegen Staging laufen — der Stand war noch nicht deployt. Beim ersten echten Lauf zeigten sich zwei falsche Annahmen über die Oberfläche (Staging-Validator F001/F002, beide LOW, ausdrücklich als Testautoren-Befunde eingestuft). Die Verifikation lief mit korrigierten Selektoren; die Datei im Repo trug die Korrektur nicht.

**Gemessen vorher: `2 failed, 3 passed`.** Ein Test, der aus falschen Gründen rot ist, kostet den Nächsten eine Fehlersuche am Produkt.

## Was geändert wurde

- **Speichern:** Der Helfer klickte `weather-metrics-tab-save`. Den Knopf gibt es im Trip nicht — `WeatherMetricsTab.svelte:1451` rendert ihn nur ohne `saveController`, und der Trip nutzt Autosave (700 ms Debounce). Jetzt wird auf den echten PUT auf `/api/trips/{id}/weather-config` gewartet, **gezielt** statt lose (sonst fängt die Zusage den zweiten, `report_config`-PUT). Die Zusage wird **vor** der Geste scharfgeschaltet, sonst läuft der Debounce ab, bevor jemand zuhört.
- **Gegenprobe zu AC-13:** Sie wechselte in den Versand-Reiter und suchte dort `report-show-outlook`. Der Schalter lebt im **selben** Wetter-Reiter (`WeatherMetricsTab.svelte:1780-1787` bindet `EditReportConfigSection` inline).
- **Kopfkommentar:** Die RED-Notiz behauptete, die Config fehle und die Datei sei nicht ausführbar — beides überholt.

Geändert wurde nur, **wie** der Test die Oberfläche anspricht, nicht **was** er behauptet.

## Nachweis

`5 passed`, dreimal hintereinander ohne Retry (5.1s / 6.3s / 5.5s) im Repo-Zustand, ohne Handanpassung.

**Gegenprobe, dass der Test etwas bewacht** — beide Mutationen rot:
- Abwahl entfernt → rot an der DOM-Zusicherung, der PUT kam nie
- Abwahl + DOM-Zusicherung + Warten entfernt → rot an „übrige Größen müssen erhalten bleiben"

**Nebenbefund daraus:** Ohne Speichern ist `outlook_metrics` eines frischen Trips leer — dann wäre die „`gust` nicht enthalten"-Zusicherung **trivial erfüllt**, also vakuum-grün. Gefangen wird das nur von der zweiten Zeile (`length > 0`). Die beiden wirken als Paar; wer eine streicht, entwertet die andere still.

22 Staging-Testtrips angelegt und vollständig wieder abgeräumt (`DELETE` 204, Rest 0).

Kein Eintrag in `.github/ci_e2e_specs.txt` — die Positivliste wächst nur nach dem Verfahren aus ADR-0054.

Refs #1720

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qMKJ4iAGkQKdQacdcn7Xn