### PR TITLE
fix(#1594): Alarm-Vorlauf-Sperre — keine Doppel-Meldung kurz vor einem geplanten Briefing

### DIFF
--- a/docs/context/fix-1594-alarm-vorlauf-sperre.md
+++ b/docs/context/fix-1594-alarm-vorlauf-sperre.md
@@ -1,0 +1,285 @@
+# Context: fix-1594-alarm-vorlauf-sperre
+
+Issue: #1594 · Track: Full Process · Phase 1 (Kontext), erstellt 2026-08-14
+Verwandt: #1467 (S4 offen), #1800, #1750, #1777, #1233, #1555, #1584
+
+## Request Summary
+
+Änderungsalarme (`forecast_change`) und amtliche Warnungen (`official_alert`) sollen unterdrückt
+werden, wenn ohnehin gleich ein geplantes Briefing derselben Entität rausgeht — symmetrisch
+morgens wie abends, Trip wie Ortsvergleich, ohne feste Uhrzeit im Code. **NowCast bleibt
+ausgenommen** (PO-Entscheid, wörtlich bekräftigt).
+
+## Gemessener Ist-Stand (Produktivsystem, 2026-08-14)
+
+Quelle: `/var/lib/gregor/users/henning/`, nur gelesen.
+
+| Feld des Trips `5f534011` („KHW 403") | Ortszeit | UTC |
+|---|---|---|
+| `alert_quiet_to` | **07:00** | 05:00 |
+| `report_config.morning_time` | **07:00** | 05:00 |
+| `alert_quiet_from` | 20:00 | 18:00 |
+| `report_config.evening_time` | 18:00 | 16:00 |
+
+Das Ende der Ruhezeit fällt heute **exakt auf die geplante Briefing-Zeit**. Am 2026-08-08 stand
+`alert_quiet_to` noch auf 06:00; die Alarm-Uhrzeit im Protokoll ist mitgewandert (bis 06.08. immer
+04:00 UTC, seit 13.08. 05:01/05:02 UTC). Die Alarmzeit folgt der Konfiguration, nicht dem Wetter.
+
+**Es ist kein reines „vorher", sondern ein Wettlauf zweier Takte:**
+
+| Tag | Alarm | Briefing | Reihenfolge |
+|---|---|---|---|
+| 13.08. | 05:02 | 05:00 | Alarm **nach** dem Briefing |
+| 14.08. | 05:01 | 05:04 | Alarm **vor** dem Briefing |
+
+Der Alarm-Takt ist `*/15` (`internal/scheduler/scheduler.go:145`), der Briefing-Takt `0 * * * *`
+(`:141`). Eine Sperre, die nur „N Minuten **vor** dem geplanten Versand" formuliert ist, fängt den
+Fall vom 13.08. nicht.
+
+**Abend-Redundanz gemessen (offene PO-Frage aus dem Issue):** entsteht **nicht** in vergleichbarem
+Ausmaß. Vor dem Abend-Briefing endet keine Ruhezeit (Ruhezeit beginnt 20:00, Briefing 18:00), also
+staut sich nichts auf. Seit 25.07.: **14** Änderungs-/Warn-Alarme in der Stunde vor dem
+Morgen-Briefing, **1** in der Stunde vor dem Abend-Briefing. Der symmetrische Zuschnitt bleibt
+trotzdem richtig — die Zeiten sind frei konfigurierbar, und genau ihre Verschiebung hat den Effekt
+hier binnen einer Woche verschoben.
+
+## 🔴 Der Befund, der die Spec bindet: die Sammel-Zustellung ist ZUGESICHERT
+
+`src/services/compare_official_alert.py:124-125` sagt es wörtlich:
+
+> `#1233: Ruhezeit unterdrueckt frueh -> kein State-Verbrauch der Warnung, damit sie nach Ende der
+> Ruhezeit noch als "neu" zugestellt wird (AC-2).`
+
+Bewacht von `tests/tdd/test_compare_official_alert.py:610`
+(`test_ac1_quiet_hours_suppresses_send_state_and_limit`) mit der Zusicherung: *„Waehrend Ruhezeit
+unterdrueckte Warnung darf KEINEN State schreiben (sonst wird sie nach Ende der Ruhezeit als 'schon
+gemeldet' verschluckt)"*.
+
+**Das Losbrechen am Ruhezeit-Ende ist also kein Versehen, sondern eine bewusst gebaute und
+getestete Eigenschaft aus #1233.** #1594 darf sie nicht still brechen. Die Auflösung, die beide
+Zusicherungen erhält: die neue Sperre schreibt **ebenfalls keinen State** — sie verzögert nur, bis
+das Briefing raus ist, und das Briefing selbst setzt Anker und Melde-Gedächtnis zurück
+(`alert_briefing_anchor.write_anchor_and_reset_memory`, `src/services/alert_briefing_anchor.py:247-303`).
+Die Meldung wird damit **ersetzt**, nicht verschluckt.
+
+## Related Files
+
+### Einhängepunkte — real VIER, nicht fünf
+
+Der Bestandstest `tests/tdd/test_ruhezeit_und_zaehler_folgen_der_ortszone.py:425-624` zählt
+**sieben** Ruhezeit-Stellen (`test_ac3_stelle1..7`). Davon sind Stelle 5 die NowCast-Schranke
+(ausgenommen) und Stelle 3 der geteilte Trip-Adapter, den sich Stelle 2 und 4 bereits teilen:
+
+| # | Datei:Zeile | Alarmart | Rolle |
+|---|---|---|---|
+| 1 | `src/services/trip_alert.py:680` (`_is_quiet_hours`) | Trip Änderung + amtlich | **ein** Adapter für die Aufrufer `:231` und `:1447` |
+| 2 | `src/services/compare_alert.py:183` | Ortsvergleich Änderung | |
+| 3 | `src/services/compare_official_alert.py:126` | Ortsvergleich amtlich | |
+| 4 | `src/services/deviation_alert_engine.py:285` (`evaluate()`) | Engine-Kern | Aufrufer nur `trip_alert.py:282`, `compare_alert.py:400` |
+| — | `src/services/alert_gate.py:98` | **NowCast** | **ausgenommen**, nicht anfassen |
+
+### Bausteine, auf die die Sperre aufsetzt
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/alert_gate.py` (133 Z.) | Vorgesehene Heimat der neuen Funktion. Enthält `check_nowcast_gate()` (`:72`) und `record_nowcast_sent()` (`:119`), `GateResult` (`:47`). **Die Sperre darf NICHT in `check_nowcast_gate` eingebaut werden.** |
+| `src/services/alert_briefing_anchor.py:208` `last_briefing_at()` | Liefert den Zeitpunkt des letzten Briefings je `(entity_id, entity_type)` — geteilt Trip+Vergleich. Deckt die **zweite Hälfte** des Fensters ab („gerade rausgegangen"). |
+| `src/services/compare_slot_scheduler.py:104-171` `presets_due_for_hour()` | Beantwortet für den Ortsvergleich bereits „ist jetzt ein Briefing fällig?" mit `now_utc` als Parameter — inklusive `is_silenced`, `end_date`, `weekly`, Slot-Flags. |
+| `src/services/trip_report_scheduler.py:437-451`, `:724-734`, `:766-790` | Dasselbe für den Trip: Fälligkeits-Fenster, Stunden-Ermittlung, Aktiv-Filter. |
+| `src/services/compare_alert_guard.py:39-54` `is_silenced()` | Der **eine** Stilllegungs-Riegel für alle Alarmpfade (#1467 S2 AG6, AC-28): `paused_at` / `schedule == "manual"` / `archived_at`. |
+| `src/services/briefing_slots.py` (301 Z., #1725, ADR-0051) | Idempotenz-Vermerk `(trip_id, slot, local_day, outcome)`. Trip-seitig, rückblickend. |
+| `src/services/alert_log.py` | `REASON_QUIET_HOURS` / `REASON_COOLDOWN` / `REASON_DAILY_LIMIT`, Zwei-Listen-Ablage `entries` / `not_delivered`. |
+
+### Konfigurations-Quellen
+
+| Seite | Felder | Fundstelle |
+|---|---|---|
+| Trip | `report_config.morning_time`/`evening_time` (Typ `datetime.time`), **ein** Schalter `enabled` | `src/app/models.py:1033,1036-1037`; Laden `src/app/loader.py:572-573`; Flachfelder `:626-629` |
+| Ortsvergleich | `morning_enabled`/`morning_time`/`evening_enabled`/`evening_time` (einzeln schaltbar), `schedule`, `weekday`, `end_date` | `src/app/models.py:1234-1237`; Auflösung `src/services/compare_slot_scheduler.py:81-100` |
+
+## Existing Patterns
+
+- **Geteilter Baustein + dünne Aufrufstellen** (Hausmuster S2 AG1 / S3): `alert_gate.py`,
+  `compare_alert_guard.is_silenced`, `alert_briefing_anchor`. Genau so soll die Sperre entstehen.
+- **Zone kommt aus derselben Auflösung wie die Fälligkeit** (#1726): Trip `anchor_tz(trip, now_utc)`
+  (`src/services/trip_day.py:53-68`), Ortsvergleich `first_resolvable_tz(...)`
+  (`src/utils/timezone.py:77`). Beide werden bereits von den Alarm-Gates benutzt — kein Zonenbruch.
+- **Die Prüf-Reihenfolge ist heute an drei Stellen VERSCHIEDEN** — die Einsortierung der neuen
+  Stufe ist deshalb eine bewusste Entscheidung, keine Formalie:
+
+  | Pfad | Reihenfolge |
+  |---|---|
+  | `alert_gate.check_nowcast_gate` | Ruhezeit → Sperrzeit → Tages-Obergrenze |
+  | `trip_alert` (Änderung, `:231-247`) | Ruhezeit → Sperrzeit → Tages-Obergrenze → Abruf |
+  | `compare_alert` (`:133-190`) | `is_silenced` → Sperrzeit → Tages-Obergrenze → **Ruhezeit** → Abruf |
+
+## Dependencies
+
+- **Upstream:** `DeviationAlertEngine.is_quiet_hours`, `alert_daily_limit`, `ThrottleStore`,
+  `alert_log`, `anchor_tz`/`first_resolvable_tz`, Trip-/Preset-Konfiguration.
+- **Downstream:** `alert_log.json` (`not_delivered`) → Go-Zählung `internal/store/log.go`,
+  Cockpit-Kachel, Briefing-Hinweis `undelivered_since_last_briefing` (#1461),
+  `src/output/renderers/email/undelivered_hint.py`.
+
+## Existing Specs
+
+| Spec | Zusicherung, die die Sperre brechen könnte |
+|---|---|
+| `docs/specs/modules/rework_1467_s3_nowcast.md` | AC-11 „Abbruch an der ERSTEN zutreffenden Stufe"; AC-12 NowCast prüft gegen das **volle** Tagesbudget; AC-9 Δ/amtlich bekommen ausdrücklich **keine** Unterdrückungs-Protokollierung |
+| `docs/specs/modules/fix_1479_ruhezeit_wurzel.md` | AC-11: **kein eigenes `try/except`** um `is_quiet_hours()`-Aufrufe — AST-Wächter |
+| `docs/specs/modules/alert_quiet_hours_localtime.md` (#1312) | AC-6: alle Aufrufer teilen EINEN zentralen Aufruf, Sonderfälle je Alarmart verboten |
+| `docs/specs/modules/fix_1555_nowcast_alert_priority.md` | NowCast bleibt zustellbar, auch wenn `forecast_change` gesperrt ist |
+| `docs/specs/modules/fix_1584_alarm_zeitfenster.md` | Ruhezeiten und Tagesfenster sind **Schnittmenge, keine Ablösung** |
+| `docs/specs/modules/fix_1584c_compare_alarm_zeitfenster.md:356` | nennt #1594 ausdrücklich als „nicht in dieser Scheibe" — bestätigt die Abgrenzung |
+| `docs/specs/modules/feat_1459_alert_protokoll.md` | D4: Cockpit-/Archiv-Zahlen dürfen sich für Bestandstouren um keine Zahl ändern |
+| `docs/specs/modules/fix_1726_ruhezeit_und_zaehler_ortszone.md` | Ruhezeit und Zähler laufen auf der Ortszone |
+
+**ADRs:** ADR-0009 (Alerts sind Δ-Wächter gegen den letzten Briefing-Snapshot — die fachliche
+Begründung, warum die Sperre überhaupt zulässig ist), ADR-0021 (geteilte Engine, mit Nachtrag
+#1467 S3 zur Gate-Reihenfolge), ADR-0044/ADR-0051 (Kalendertag folgt der Ortszeit).
+**Kein ADR zur Frage „wann darf ein Alarm unterdrückt werden"** — bislang implizit.
+
+## Waechter-Tests (für die RED-Phase namentlich zu benennen)
+
+| Zweck | Datei |
+|---|---|
+| Sieben-Stellen-Vollständigkeit (beste Vorlage) | `tests/tdd/test_ruhezeit_und_zaehler_folgen_der_ortszone.py` |
+| #1233-Zusicherung „kein State-Verbrauch" | `tests/tdd/test_compare_official_alert.py:610` |
+| AST-Wächter „kein eigenes try/except" | `tests/tdd/test_alert_quiet_hours_robustness.py:1158-1239` |
+| NowCast-Ausnahme (Negativ-Nachweis) | `tests/tdd/test_alert_gate.py`, `tests/tdd/test_trip_radar_nowcast_gate_migration.py`, `tests/tdd/test_compare_radar_alert_daily_limit.py` |
+| Trip-Änderung | `tests/tdd/test_alert_cooldown_quiet.py`, `tests/tdd/test_alert_quiet_hours_localtime.py`, `tests/tdd/test_issue_1168_alert_engine_extract.py` |
+| Ortsvergleich-Änderung | `tests/tdd/test_compare_alert_quiet_hours_precedes_fetch.py` |
+
+## Risks & Considerations
+
+1. **🔴 Sperre ohne Ersatz = #1555 in neuer Verkleidung.** Vier der fünf realen Ortsvergleiche des
+   PO stehen auf `schedule: "manual"` — sie haben **gar kein** geplantes Briefing. Dort darf die
+   Sperre niemals greifen. Dasselbe gilt für pausierte/archivierte Vergleiche (`is_silenced`),
+   `end_date` in der Vergangenheit, abgeschaltete Slots und Trips ohne Etappe am Zieltag.
+2. **🔴 Die #1233-Zusicherung darf nicht still brechen** (siehe oben). Die Sperre muss dieselbe
+   Eigenschaft haben: kein State-Verbrauch, keine Zähler-Buchung.
+3. **Fenster muss beschränkt sein.** Der Trip hat ein **3-Stunden-Nachholfenster**
+   (`NACHHOL_FENSTER_STUNDEN = 3`, `src/services/trip_report_scheduler.py:105,444`). Eine Sperre
+   „solange ein Briefing aussteht" würde dort bis zu drei Stunden schweigen. Die Sperre braucht
+   eine feste, begrenzte Vorlaufzeit.
+4. **Briefing kann ausfallen.** Geht das Briefing nicht raus (`record_briefing_dispatch_failure`,
+   `src/services/alert_briefing_anchor.py:105`), war die Sperre umsonst. Die Lücke muss auf ein
+   Fenster begrenzt bleiben, damit der nächste Alarm-Takt wieder durchkommt.
+5. **Dritte/vierte Fassung derselben Regel.** „Nächster Versand" existiert bereits im Frontend
+   (`frontend/src/lib/utils/cockpitHelpers568.ts:247` `deriveNextSend`, mit der ausdrücklichen
+   Auflage, deckungsgleich mit `resolve_preset_slots` zu bleiben). Ein neu gerechnetes
+   Python-Pendant wäre eine weitere Fassung. **Empfehlung für die Analyse:** dieselben Funktionen
+   fragen, die den Versand auslösen (`presets_due_for_hour`, Trip-Fälligkeitslogik), mit
+   verschobenem Zeitpunkt — statt die Regel neu zu bauen.
+6. **Minuten existieren nicht.** Go kappt alle Versandzeiten auf die volle Stunde
+   (`internal/store/slot_hour_normalization.go:36-49,66-69,159-164`), beim Schreiben **und** beim
+   Laden. Eine minutengenaue Sperre hätte keinen zusätzlichen Nutzen.
+7. **Keine zwei Wahrheiten.** Der Go-Cron trägt keine Zeit-Konfiguration, er ist nur Taktgeber
+   (`internal/scheduler/scheduler.go:141,145`); die Fälligkeit entscheidet ausschließlich Python.
+   Das Risiko entstünde erst, wenn die Sperre eine eigene Kopie der Zeiten hielte.
+8. **Unterdrückung wird für Δ/amtlich heute NICHT protokolliert** — nur NowCast schreibt seit
+   #1467 S3 einen `not_delivered`-Eintrag. Ohne bewusste Ergänzung bliebe die neue Sperre
+   unsichtbar („warum kam kein Alarm?" unbeantwortbar). Gegenläufig: #1800 sagt, diese Liste sei
+   heute schon zu voll.
+9. **#1467 S4 wird die Aufrufstellen zusammenlegen.** Die Sperre muss das überleben: eigene
+   Funktion in `alert_gate.py`, dünne Aufrufer. #1777 wird zusätzlich die
+   Ortsvergleich-Fälligkeit auf Fenster + Idempotenz umstellen — ein weiteres Argument, die
+   Fälligkeit nicht selbst nachzubauen.
+10. **Trip und Ortsvergleich sind hier strukturell ungleich:** Trip hat *einen* Schalter für beide
+    Slots und ein Nachholfenster, der Ortsvergleich hat Morgen/Abend einzeln schaltbar, kein
+    Nachholfenster, dafür `weekly`/`manual`-Zeitpläne. Ein 1:1 geteilter Fälligkeits-Rechner ist
+    daraus nicht ableitbar; geteilt werden kann die **Sperr-Entscheidung**, nicht die
+    Fälligkeits-Berechnung.
+
+## Analysis (Phase 2)
+
+### Type
+
+**Bug** — nutzersichtbares Fehlverhalten (Meldungsrauschen), reproduzierbar am Produktivprotokoll.
+
+### 🔴 Der gefährlichste Fund der Analyse: `skip_next` wird beim Lesen verbraucht
+
+`src/services/trip_report_scheduler.py:783-788` — `_get_active_trips()` konsumiert
+`report_config.skip_next` per Read-Modify-Write **mit `save_trip()`**, also einem persistenten
+Schreibvorgang, bei **jedem** Aufruf:
+
+```python
+if rc.skip_next is True:
+    new_rc = dataclasses.replace(rc, skip_next=False)
+    new_trip = dataclasses.replace(trip, report_config=new_rc)
+    save_trip(new_trip, user_id=self._user_id)
+    continue
+```
+
+Bestätigt durch den Kommentar an `:428-431` („weil dort `skip_next` bei jedem Sammellauf
+konsumiert wird (RMW auf `report_config`), unabhaengig von der Faelligkeit").
+
+**Folge:** Würde die neue Sperre bequem `_get_active_trips()` bzw. `_collect_due_trips()`
+mitbenutzen, verbrauchte sie im 15-Minuten-Alarm-Takt den Nutzerwunsch „nächstes Briefing
+überspringen", bevor der Briefing-Scheduler ihn je sieht — das Briefing käme trotzdem. **Kein
+bestehender Test fängt das**, weil die Scheduler-Tests den Versandpfad isoliert prüfen, nicht sein
+Zusammenspiel mit einem fremden Takt. Ist Pflicht-Mutation der Adversary-Runde.
+
+### Entscheidungen
+
+| # | Frage | Entscheidung | Begründung |
+|---|---|---|---|
+| 1 | Einhängepunkte | **Drei**: `trip_alert._is_quiet_hours` (deckt `:231` **und** `:1447`), `compare_alert.py:183`, `compare_official_alert.py:126`. **Nicht** der Engine-Kern. | `AlertEvaluationConfig` (`src/services/point_weather.py:54-75`) ist ausdrücklich „kein Trip-Bezug" und trägt weder Versandzeiten noch Kennung — der Engine-Kern *kann* die Sperre nicht rechnen. Zudem läuft `evaluate()` bei beiden Aufrufern erst **nach** dem Wetterabruf (`trip_alert.py:250` vor `:283`; `compare_alert.py:387-394` vor `:401`). |
+| 2 | Einsortierung | Als **zusätzliche letzte, rein lesende Stufe** direkt neben der jeweiligen Ruhezeit-Prüfung, vor dem Abruf. Bestehende Reihenfolgen bleiben unangetastet. | Die drei Ketten haben heute verschiedene Reihenfolgen; sie zu vereinheitlichen ist #1467 S4, nicht dieser Fix. Reines Anhängen = kleinstes Regressionsrisiko. |
+| 3 | Heimat der Funktion | **`src/services/alert_gate.py`**, klar getrennt von `check_nowcast_gate()`. Kein neues Modul. | Ein eigenes Modul erkauft keine echte NowCast-Sicherheit (die kommt aus dem Verhaltenstest, Nr. 7) und zersplittert genau die Steuerung, die #1467 S4 zusammenlegen will. |
+| 4 | „Briefing steht an?" | **Vorhandene Fälligkeitslogik fragen**, nicht neu rechnen. Ortsvergleich: `presets_due_for_hour()` direkt (rein, prüft `is_silenced`/`end_date`/`weekly`/Slot-Flags bereits). Trip: **reines Prädikat herauslösen** — mit allen Aktiv-Filtern, aber **ohne** den `skip_next`-Verbrauch. | Eine eigene Rechnung wäre die vierte Fassung (eine liegt im Frontend, `cockpitHelpers568.ts:247`). Beim Trip verbietet der Seiteneffekt oben die direkte Wiederverwendung. |
+| 5 | Fensterbreite | **Vorlauf: PO-Entscheidung, Empfehlung 60 Minuten.** Nachlauf: über `alert_briefing_anchor.last_briefing_at()` (Tatsache „ist raus"), gedeckelt auf ~15 Min. | Gemessen: die Alarme lagen **60 und 15 Minuten** vor dem Briefing (04:00 und 04:45 UTC gegen 05:00). Ein 15-Minuten-Vorlauf hätte die 11 Alarme um 04:00 **nicht** gefangen. Der Nachlauf über den Anker statt über die Uhr löst zugleich Risiko 4: scheitert der Versand, wird der Anker gar nicht erst fortgeschrieben (`trip_report_scheduler.py:1341` vs. `:1366`) — die Sperre unterdrückt dann nicht. |
+| 6 | Kein State-Verbrauch | Strukturell erfüllt, **wenn die Sperre nur liest**. | Alle Buchungen (`state_svc.save`, `throttle.record`, `daily_limit.increment`) liegen hinter dem Versand (`trip_alert.py:341-350`, `compare_alert.py:300-301,452-458`). Die Sperre sitzt weit davor. Disziplin, kein Automatismus ⇒ eigene Mutation. |
+| 7 | Protokollierung | **Keine.** Status quo bleibt (`logger.debug`). | `rework_1467_s3_nowcast.md` AC-9 legt ausdrücklich fest, dass Δ/amtlich keine Unterdrückungs-Protokollierung bekommen. #1800 nennt die Liste bereits zu voll. Und fachlich wird die Meldung **ersetzt**, nicht verschluckt — eine „nicht zugestellt"-Zeile für etwas, das Minuten später vollständig ankommt, wäre irreführend. |
+| 8 | NowCast-Ausnahme | **Verhaltenstest** als Hauptwächter, kein Struktur-/AST-Test. | Wirkort ist „kommt der NowCast trotzdem durch?", nicht „welche Datei importiert was". Ein Strukturtest würde bei #1467 S4 selbst zum Kollateralschaden. |
+| 9 | Entitäten ohne Briefing | Ortsvergleich fällt automatisch ab (`presets_due_for_hour` prüft alles intern). **Trip nicht** — das herausgelöste Prädikat muss Etappe-am-Zieltag, `report_config.enabled`, `paused_at`, `paused_until` zwingend enthalten. | Sonst schweigt der Alarm bei einem pausierten Trip ohne Ersatz — Fehlerklasse #1555/#1584. |
+| 10 | Schnitt | **Eine Scheibe**, alle vier Aufrufstellen. | LoC ist kein Engpass; der geteilte Baustein entsteht ohnehin entitätsunabhängig; die einzige echte Hürde (Trip-Extraktion) lässt sich durch Schneiden nicht umgehen. |
+
+### Affected Files
+
+| Datei | Art | ~LoC | Beschreibung |
+|---|---|---|---|
+| `src/services/alert_gate.py` | MODIFY | 50-70 | Neue Funktion `check_briefing_imminent(...)` — Vorlauf über die Fälligkeitslogik, Nachlauf über `last_briefing_at()`. Getrennt von `check_nowcast_gate()`. |
+| `src/services/trip_report_scheduler.py` | MODIFY | 15-25 | Reines Fälligkeits-Prädikat herauslösen, **ohne** `skip_next`-Verbrauch. Bestandspfad verhaltensgleich. |
+| `src/services/trip_alert.py` | MODIFY | ~15 | Zwei Aufrufstellen über den geteilten Adapter. |
+| `src/services/compare_alert.py` | MODIFY | ~8 | Eine Aufrufstelle. |
+| `src/services/compare_official_alert.py` | MODIFY | ~8 | Eine Aufrufstelle. |
+
+**Produktivcode ~100-125 LoC** (Limit 250). Testcode wird deutlich umfangreicher — ein
+`loc_limit_override` ist wahrscheinlich nötig.
+
+### Bewusst NICHT in dieser Scheibe
+
+- **Der amtliche Trip-Abruf wird nicht vorgezogen.** `check_official_alert_triggers()` läuft
+  unbedingt bei `trip_alert.py:469`, also **vor** der Prüfung bei `:1447` — die bestehende
+  Ruhezeit-Prüfung spart diesen Abruf schon heute nicht. Die Sperre verhindert die **Meldung**,
+  nicht den Abruf. Das Vorziehen wäre ein Umbau am amtlichen Abrufpfad ohne Bezug zum gemeldeten
+  Problem. Beobachtung für #1199.
+- Vereinheitlichung der drei unterschiedlichen Prüf-Reihenfolgen (→ #1467 S4).
+- Anzeige/Wortwahl unterdrückter Meldungen (→ #1750/#1800, siehe Abgrenzung).
+
+### Mutations-Gegenproben (Pflicht in der Adversary-Runde)
+
+1. Vorlauf auf 0 setzen → ein Alarm kurz vor dem Slot muss trotzdem gesperrt sein.
+2. NowCast-Ausnahme entfernen → bei anstehendem Briefing **und** auslösendem Regenradar muss der
+   NowCast durchgehen, der Änderungsalarm nicht.
+3. `manual`-/pausiertes/archiviertes Preset nicht ausnehmen → Alarm muss durchgehen.
+4. State-Verbrauch einbauen → `alert_state`, Sperrzeit-Speicher und Tageszähler müssen nach einer
+   gesperrten Meldung unverändert sein (#1233-Analogie).
+5. 🔴 `skip_next` durch die Sperre konsumieren → nach einem Sperr-Lauf muss `skip_next` weiterhin
+   `True` sein.
+
+### Open Questions (für die Spec-Freigabe)
+
+- [ ] **Wie lange vor einem Briefing ist eine Meldung überflüssig?** Empfehlung 60 Minuten
+      (deckt alle gemessenen Fälle). Kürzer = weniger Unterdrückung, aber der historische
+      04:00-Fall bliebe ungefangen.
+
+## Abgrenzung
+
+- **Miterledigt:** #1800 erste Frage („Warum kurz vor dem Briefing noch ein Alert?").
+- **Nicht hier:** #1750 und #1800 zweite Frage — Verständlichkeit der Wörter „Sperrzeit"/„Ruhezeit"
+  und die Frage, ob unterdrückte Alarme überhaupt gelistet werden sollen
+  (`src/output/renderers/email/undelivered_hint.py:39,85`). Eigener kleiner Durchlauf.
+- **Nicht hier:** die Ruhezeiten selbst, der Fenster-Zuschnitt des Compare-Abweichungsalarms
+  (#1584 C, erledigt), die Zusammenlegung der Ablaufsteuerungen (#1467 S4).

--- a/docs/specs/modules/fix_1594_alarm_vorlauf_sperre.md
+++ b/docs/specs/modules/fix_1594_alarm_vorlauf_sperre.md
@@ -45,8 +45,8 @@ Briefing) nicht gefangen.
 
 **Diese Scheibe fügt eine zusätzliche, rein lesende Freigabe-Stufe** hinzu: Sie unterdrückt
 einen Änderungsalarm oder eine amtliche Warnung für eine Entität (Trip oder
-Ortsvergleich-Preset), wenn für dieselbe Entität unmittelbar ein geplantes Briefing ansteht
-(Vorlauf) oder gerade eines rausgegangen ist (Nachlauf). Der Wetter-Inhalt geht dem Nutzer dabei
+Ortsvergleich-Preset), wenn für dieselbe Entität unmittelbar ein geplantes Briefing ansteht und
+dieses noch nicht versucht wurde. Der Wetter-Inhalt geht dem Nutzer dabei
 nicht verloren — er kommt vollständig im Briefing an, das Sekunden bis Minuten später folgt. Die
 Meldung wird **ersetzt**, nicht verschluckt. **NowCast-Alarme (Regen-/Gewitter-Onset) sind
 ausdrücklich ausgenommen** (PO-Entscheid) — sie bleiben zeitkritisch und laufen unverändert
@@ -113,7 +113,7 @@ Frontend-Code.
 | Entity | Type | Purpose |
 |--------|------|---------|
 | `src/services/alert_gate.py` | module (Bestand) | Vorgesehene Heimat der neuen Funktion `check_briefing_imminent()`, klar getrennt von `check_nowcast_gate()` |
-| `src/services/alert_briefing_anchor.py::last_briefing_at()` | module (Bestand) | Liefert den Zeitpunkt des letzten Briefings je `(entity_id, entity_type)` — deckt den Nachlauf-Zweig |
+| `src/services/alert_briefing_anchor.py::last_briefing_at()` | module (Bestand) | Zeitpunkt des letzten Briefing-**Versuchs** je `(entity_id, entity_type)` — beendet die Sperre (AC-5). 🔴 Der Anker wird auch bei gescheitertem Versand geschrieben (#1629), das Feld heisst also „versucht", nicht „zugestellt" |
 | `src/services/compare_slot_scheduler.py::presets_due_for_hour()` | module (Bestand) | Beantwortet für den Ortsvergleich „ist jetzt ein Briefing fällig?" — inkl. `is_silenced`/`end_date`/`weekly`/Slot-Flags |
 | `src/services/trip_report_scheduler.py::_get_active_trips()` | module (Bestand) | Vorlage für ein neu herauszulösendes reines Trip-Fälligkeits-Prädikat — **ohne** den `skip_next`-Verbrauch |
 | `src/services/compare_alert_guard.py::is_silenced()` | module (Bestand) | Der eine Stilllegungs-Riegel (`paused_at`/`schedule=="manual"`/`archived_at`), bereits Teil von `presets_due_for_hour()` |
@@ -144,19 +144,52 @@ def check_briefing_imminent(
     zone: ZoneInfo,
     briefing_due_at: Callable[[datetime], bool],  # reines Faelligkeits-Praedikat, gg. Zeitpunkt ausgewertet
     vorlauf_minuten: int = 60,
-    nachlauf_minuten: int = 15,
 ) -> bool
 ```
 
-Zwei ODER-verknüpfte, rein lesende Bedingungen:
+Eine UND-verknüpfte, rein lesende Bedingung — gesperrt wird nur, wenn **beides** zutrifft:
 
 1. **Vorlauf:** Das bestehende Fälligkeits-Prädikat der Entität — beim Ortsvergleich
-   `presets_due_for_hour()`, beim Trip das unten beschriebene herausgelöste Prädikat — wird
-   nicht nur gegen `now`, sondern zusätzlich gegen `now + vorlauf_minuten` ausgewertet. Wird die
-   Entität innerhalb dieses verschobenen Zeitpunkts fällig, steht ihr Briefing unmittelbar
-   bevor.
-2. **Nachlauf:** `alert_briefing_anchor.last_briefing_at(user_id=..., entity_id=...,
-   entity_type=...)` liegt nicht länger als `nachlauf_minuten` zurück.
+   `presets_due_for_hour()`, beim Trip das unten beschriebene herausgelöste Prädikat — ist für
+   irgendeinen Zeitpunkt in `[now, now + vorlauf_minuten]` wahr. Dann steht das Briefing
+   unmittelbar bevor.
+2. **Noch nicht versucht:** Für das anstehende Briefing gab es noch **keinen Versandversuch**.
+   Sobald einer stattgefunden hat, endet die Sperre — unabhängig davon, ob er gelang.
+
+### 🔴 Warum es KEINEN Nachlauf gibt (Korrektur der ersten Fassung, PO-„go" 2026-08-14)
+
+Die erste Fassung dieser Spec hatte eine zweite, ODER-verknüpfte Bedingung („letztes Briefing
+liegt weniger als 15 Minuten zurück") und begründete sie in den Known Limitations damit, dass bei
+einem gescheiterten Versand der Anker unverändert bleibe. **Diese Begründung war falsch — sie war
+angenommen, nicht gemessen.** `_anchor_and_reset()` steht in beiden Versandpfaden ausdrücklich im
+Fehler-Zweig (`src/services/scheduler_dispatch_service.py:561-566`,
+`src/services/trip_report_scheduler.py:1483-1485`); das ist die bewusste Entscheidung aus #1629
+(„Briefing-Anker überlebt Versandfehler"). **`last_briefing_at()` beantwortet damit „wurde ein
+Briefing VERSUCHT?", nicht „wurde eines ZUGESTELLT?".**
+
+Gemessen in der GREEN-Phase: der Nachlauf-Zweig machte **sieben** Bestandstests rot, der
+Vorlauf-Zweig keinen einzigen. Zwei unabhängige Gründe, die jeder für sich zum Wegfall reichen:
+
+- **Er schweigt, wenn nichts ankam.** Weil der Anker auch bei Fehlschlag gesetzt wird,
+  unterdrückte er 15 Minuten lang Alarme, obwohl kein Briefing existiert, das sie ersetzen
+  könnte — exakt die Fehlerklasse #1555/#1584, gegen die AC-7/AC-8 antreten.
+- **Er verschluckt echte neue Information.** Nach dem Briefing ist der Δ-Anker frisch. Ein Alarm,
+  der danach noch auslöst, meldet zwangsläufig etwas, das im Briefing NICHT stand.
+  `tests/tdd/test_compare_briefing_anchor_and_memory_reset.py::test_ac15_starker_ausschlag_nach_dem_briefing_wird_zugestellt`
+  (#1461 AG5) sichert genau das zu: 30 mm im Briefing, danach 55 mm ⇒ muss raus.
+
+Der gemessene 13.08.-Fall (Alarm 05:02, Briefing 05:00) braucht den Nachlauf nicht: der Alarm-Lauf
+startet zum `*/15`-Tick um **05:00**, also zur Briefing-Minute selbst — dort greift der Vorlauf.
+
+### 🔴 Warum „noch nicht versucht" als zweite Bedingung nötig ist
+
+Anker und Idempotenz-Vermerk laufen bei einem Fehlschlag **auseinander**: der Anker wird gesetzt,
+der Vermerk aber zurückgenommen (reserve-then-release, `trip_report_scheduler.py:565-571`,
+`VERMERK_AUSGAENGE` bei `:93`). Der Trip bleibt dadurch bis zu `NACHHOL_FENSTER_STUNDEN = 3`
+(`:105`, `:444`) weiter „fällig". Ohne die zweite Bedingung ergäbe das **60 Minuten Vorlauf + 3
+Stunden Nachholfenster = bis zu 4 Stunden Alarmstille nach einem gescheiterten Versand** (am
+07:00-Slot gemessen: Sperre 06:00–09:59 Ortszeit). Nach einem *erfolgreichen* Briefing entsteht
+dieser Schweif nicht — dort setzt der Vermerk die Fälligkeit sofort auf falsch.
 
 Die genaue Funktionssignatur ist Implementierungsdetail; verbindlich ist die beobachtbare
 Wirkung in den Acceptance Criteria unten.
@@ -222,7 +255,7 @@ Minuten später vollständig ankommt, wäre irreführend.
   und der Ortszone der Entität — alles bereits im Scope der jeweiligen Aufrufstelle, nichts muss
   zusätzlich durchgereicht werden.
 - **Output:** Eine Ja/Nein-Antwort auf „steht für diese Entität unmittelbar ein geplantes
-  Briefing an oder ist gerade eines rausgegangen?". Bei „ja" bricht der Alarm-Lauf für diese
+  Briefing an, das noch nicht versucht wurde?". Bei „ja" bricht der Alarm-Lauf für diese
   Entität ab und verschickt **keine** Meldung; bei „nein" läuft er unverändert weiter.
 - **Side effects:** **Keine.** Die Stufe liest ausschließlich — sie schreibt kein
   Melde-Gedächtnis (`AlertStateService`), keine Sperrzeit (`ThrottleStore`), keinen Tageszähler
@@ -249,7 +282,7 @@ Minuten später vollständig ankommt, wäre irreführend.
 
 | Datei | Art | ~LoC | Beschreibung |
 |---|---|---|---|
-| `src/services/alert_gate.py` | MODIFY | 50–70 | Neue Funktion `check_briefing_imminent(...)` — Vorlauf über das jeweilige Fälligkeits-Prädikat, Nachlauf über `last_briefing_at()`. Getrennt von `check_nowcast_gate()`. |
+| `src/services/alert_gate.py` | MODIFY | 50–70 | Neue Funktion `check_briefing_imminent(...)` — Vorlauf über das jeweilige Fälligkeits-Prädikat, beendet durch den Briefing-Versuch (`last_briefing_at()`). Getrennt von `check_nowcast_gate()`. |
 | `src/services/trip_report_scheduler.py` | MODIFY | 15–25 | Reines Fälligkeits-Prädikat herauslösen, **ohne** `skip_next`-Verbrauch. Bestandspfad (`_get_active_trips`) verhaltensgleich. |
 | `src/services/trip_alert.py` | MODIFY | ~15 | Beide Aufrufstellen (`:231`, `:1447`) über den gemeinsamen Adapter an `_is_quiet_hours()` abgedeckt. |
 | `src/services/compare_alert.py` | MODIFY | ~8 | Eine Aufrufstelle nach `:183`. |
@@ -273,9 +306,8 @@ Minuten später vollständig ankommt, wäre irreführend.
   an, vermerkt sie aber nicht im Melde-Gedächtnis (`scheduler_dispatch_service.py:453-464` fehlt
   das Gegenstück zu `trip_report_scheduler.py:1218-1226`), weshalb der Prüfer sie erneut
   verschickt. Diese Scheibe **mildert** das nur innerhalb ihres Fensters: eine Wiederholung
-  innerhalb der 15 Nachlauf-Minuten fällt weg, eine 20 oder 40 Minuten später nicht. Die Ursache
-  — der fehlende Vermerk — bleibt bestehen. #1714 darf deshalb nicht mit dieser Scheibe
-  geschlossen werden.
+  vor dem Briefing fällt weg, eine kurz danach nicht. Die Ursache — der fehlende Vermerk — bleibt
+  bestehen. #1714 darf deshalb nicht mit dieser Scheibe geschlossen werden.
 
 ## Risiken
 
@@ -286,7 +318,8 @@ Minuten später vollständig ankommt, wäre irreführend.
 | **R3** | `skip_next` wird durch die neue Sperre konsumiert, weil sie bequem `_get_active_trips()` mitbenutzt statt des herausgelösten reinen Prädikats | AC-11 |
 | **R4** | Die neue Sperre schreibt State (Melde-Gedächtnis/Sperrzeit/Tageszähler) und bricht damit die #1233-Zusicherung „kein State-Verbrauch bei Unterdrückung" | AC-10 |
 | **R5** | NowCast wird versehentlich mitgesperrt, weil `check_nowcast_gate()` (oder sein Aufrufer) die neue Funktion mitruft | AC-12 |
-| **R6** | Ohne Nachlauf-Deckel bleibt die Sperre wirksam, obwohl das Briefing gar nicht (mehr) zugestellt wurde (`record_briefing_dispatch_failure`) — Meldeloch ohne Grenze | AC-6 |
+| **R6** | Die Sperre bleibt wirksam, obwohl das Briefing gescheitert ist — bis zu 4 Stunden Alarmstille, weil ein Trip nach einem Fehlschlag das 3-Stunden-Nachholfenster über bleibt (`NACHHOL_FENSTER_STUNDEN`). **In der GREEN-Phase real gemessen**, nicht hypothetisch | AC-5 |
+| **R7** | Ein Alarm gegen den FRISCHEN Anker nach dem Briefing wird unterdrückt, obwohl er zwangsläufig etwas meldet, das im Briefing nicht stand. **In der GREEN-Phase real gemessen** (7 rote Bestandstests) | AC-5 |
 
 ## Test-Plan
 
@@ -365,22 +398,21 @@ Briefing-Lauf warten" wäre unzuverlässig und langsam.
   Then wird diese Warnung NICHT als eigenständige Zusatz-Meldung verschickt.
   - Test: Preset mit fälligem Slot in 10 Minuten, amtliche Warnung simulieren, kein Versand.
 
-**(b) Nachlauf und Fenstergrenzen**
+**(b) Ende der Sperre und Fenstergrenzen**
 
-- **AC-5:** Given eine Entität (Trip oder Ortsvergleich-Preset), deren letztes Briefing
-  nachweislich vor wenigen Minuten (bis zu 15) rausgegangen ist, When unmittelbar danach ein
-  Änderungsalarm oder eine amtliche Warnung für dieselbe Entität ausgelöst würde, Then wird
-  diese Meldung ebenfalls NICHT als eigenständige Zusatz-Meldung verschickt — das entspricht dem
-  gemessenen 13.08.-Fall (Alarm 2 Minuten nach dem Briefing).
-  - Test: `last_briefing_at()` auf „vor 5 Minuten" setzen, Alarm-Bedingung erfüllen, kein
-    Versand.
+- **AC-5:** Given eine Entität, für die das fällige Briefing bereits **versucht** wurde — ob
+  erfolgreich zugestellt oder beim Versand gescheitert —, When danach ein Änderungsalarm oder
+  eine amtliche Warnung für dieselbe Entität ausgelöst würde, Then wird diese Meldung **regulär
+  verschickt**: die Sperre endet mit dem Versuch, nicht mit dem Erfolg.
+  - Test: (a) Briefing erfolgreich verschicken, danach eine Abweichung gegen den frischen Anker
+    erzeugen → Versand erfolgt. (b) Briefing-Versand scheitern lassen
+    (`record_briefing_dispatch_failure`-Pfad), danach Alarm-Bedingung erfüllen → Versand erfolgt.
 
-- **AC-6:** Given eine Entität, deren nächstes Briefing weiter als 60 Minuten entfernt ist UND
-  deren letztes Briefing länger als 15 Minuten zurückliegt (oder es gab noch keins), When ein
-  Änderungsalarm oder eine amtliche Warnung ausgelöst würde, Then wird diese Meldung wie bisher
-  regulär verschickt — die neue Sperre greift außerhalb des Fensters nicht.
-  - Test: nächstes Briefing in 90 Minuten, letztes Briefing vor 30 Minuten, Alarm-Bedingung
-    erfüllen, Versand erfolgt normal.
+- **AC-6:** Given eine Entität, deren nächstes geplantes Briefing weiter als 60 Minuten entfernt
+  ist, When ein Änderungsalarm oder eine amtliche Warnung ausgelöst würde, Then wird diese
+  Meldung wie bisher regulär verschickt — die Sperre greift außerhalb des Vorlauf-Fensters nicht.
+  - Test: nächstes Briefing in 90 Minuten, Alarm-Bedingung erfüllen, Versand erfolgt normal;
+    Grenzfall genau 60 Minuten sperrt, genau 61 Minuten sperrt nicht.
 
 **(c) Kein Schweigen ohne Ersatz**
 
@@ -442,7 +474,7 @@ Briefing-Lauf warten" wäre unzuverlässig und langsam.
 
 **(e) Symmetrie und Mandantentrennung**
 
-- **AC-14:** Given identische Vorlauf-/Nachlauf-Bedingungen, When sie für ein Morgen-Briefing
+- **AC-14:** Given identische Vorlauf-Bedingungen, When sie für ein Morgen-Briefing
   UND für ein Abend-Briefing geprüft werden, sowohl beim Trip als auch beim Ortsvergleich, Then
   wirkt die Sperre in allen vier Kombinationen gleichermaßen — es gibt keine versteckte
   Bevorzugung des Morgen- oder des Trip-Pfads.
@@ -478,20 +510,20 @@ Briefing-Lauf warten" wäre unzuverlässig und langsam.
 - **Der amtliche Trip-Abruf wird durch diese Scheibe nicht vorgezogen** (siehe „Bewusst NICHT in
   dieser Scheibe"). Die Sperre spart also kein Abruf-Kontingent beim amtlichen Trip-Pfad ein,
   nur die Zustellung der resultierenden Meldung entfällt.
-- **Scheitert der Briefing-Versand** (`record_briefing_dispatch_failure`), bleibt der Anker
-  unverändert, und der Nachlauf-Zweig wirkt entsprechend nicht mehr für diesen Fall. Der zuvor
-  im Vorlauf-Fenster unterdrückte Alarm bleibt dadurch für maximal einen Alarm-Takt (bis zu 15
-  Minuten) unzugestellt — der nächste reguläre Alarm-Lauf ist davon nicht betroffen und prüft
-  wieder normal.
+- **Scheitert der Briefing-Versand**, bleibt die im Vorlauf-Fenster unterdrückte Meldung für
+  höchstens einen Alarm-Takt aus: der Versuch beendet die Sperre (AC-5), der nächste Lauf prüft
+  wieder regulär. Der Nutzer bekommt dann zwar kein Briefing, aber seine Alarme laufen weiter —
+  das ist die bewusst gewählte Fehlerrichtung.
 - **Die Abend-Sperre bleibt in der Praxis meist folgenlos**, weil die Abend-Redundanz heute kaum
   auftritt (gemessen: 1 von 15 Fällen seit 25.07.). Das ist kein Defekt dieser Scheibe, sondern
   Ausdruck der aktuell verbreiteten Konfiguration (Ruhezeit-Ende ≠ Abend-Briefing-Zeit) — ändert
   sich die Konfiguration eines Nutzers, greift die Symmetrie sofort.
-- **Ad-hoc-Briefings („Handversand") lösen den Nachlauf nicht aus.**
+- **Ad-hoc-Briefings („Handversand") beenden die Sperre nicht.**
   `write_anchor_and_reset_memory(on_demand=True)` schreibt weder Anker noch Reset (#1007) — ein
-  auf Zuruf abgerufenes Briefing aktualisiert `last_briefing_at()` also nicht und unterdrückt
-  entsprechend keinen nachfolgenden Alarm. Das ist beabsichtigt: ein Ad-hoc-Abruf ist gegenüber
-  beiden Zuständen bewusst read-only, und ein solcher Abruf ersetzt kein geplantes Briefing.
+  auf Zuruf abgerufenes Briefing aktualisiert `last_briefing_at()` also nicht. Ein Handversand
+  kurz vor dem geplanten Slot hebt die Vorlauf-Sperre deshalb nicht auf. Das ist beabsichtigt:
+  ein Ad-hoc-Abruf ist gegenüber beiden Zuständen bewusst read-only und ersetzt kein geplantes
+  Briefing.
 - **Kein ADR zur Grundsatzfrage „wann darf ein Alarm unterdrückt werden".** Diese Scheibe fügt
   eine weitere, implizit begründete Sperrart hinzu (analog Ruhezeit, Sperrzeit, Tageslimit).
   Ein eigenständiger ADR-Nachtrag ist nicht Teil dieser Scheibe (siehe unten).
@@ -508,6 +540,16 @@ Briefing-Lauf warten" wäre unzuverlässig und langsam.
   heute unterschiedlichen Prüf-Reihenfolgen ohnehin zusammenlegt.
 
 ## Changelog
+
+- 2026-08-14 (2): **AC-5 ersetzt, Nachlauf-Zweig gestrichen — PO-„go" nach gemessenem Befund in
+  der GREEN-Phase.** Der Nachlauf machte sieben Bestandstests rot, der Vorlauf keinen. Ursache:
+  die Begründung der ersten Fassung („bei gescheitertem Versand bleibt der Anker unverändert")
+  war **angenommen statt gemessen** und ist falsch — `_anchor_and_reset()` steht in beiden
+  Versandpfaden im Fehler-Zweig (#1629). Neu: die Sperre endet mit dem Briefing-**Versuch**,
+  nicht mit dessen Erfolg; damit entfallen zugleich die real gemessenen bis zu 4 Stunden
+  Alarmstille nach einem Fehlschlag (60 Min Vorlauf + 3 h Nachholfenster). Aufgenommen als R6/R7.
+  Der gemeldete 13.08.-Fall bleibt gefangen, weil der Alarm-Lauf zur Briefing-Minute selbst
+  startet.
 
 - 2026-08-14: Initiale Spec, basierend auf `docs/context/fix-1594-alarm-vorlauf-sperre.md`. Alle
   zehn dort getroffenen Entscheidungen 1:1 übernommen (drei Einhängepunkte, Heimat

--- a/docs/specs/modules/fix_1594_alarm_vorlauf_sperre.md
+++ b/docs/specs/modules/fix_1594_alarm_vorlauf_sperre.md
@@ -12,7 +12,8 @@ tags: [alerts, trip, compare, issue-1594]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-„go" am 2026-08-14 (Klartext-Freigabe der 16 Akzeptanzkriterien auf Deutsch;
+  Vorlaufzeit 60 Minuten separat entschieden)
 
 ## Purpose
 

--- a/docs/specs/modules/fix_1594_alarm_vorlauf_sperre.md
+++ b/docs/specs/modules/fix_1594_alarm_vorlauf_sperre.md
@@ -1,0 +1,499 @@
+---
+entity_id: fix_1594_alarm_vorlauf_sperre
+type: bugfix
+created: 2026-08-14
+updated: 2026-08-14
+status: draft
+version: "1.0"
+tags: [alerts, trip, compare, issue-1594]
+---
+
+# Alarm-Vorlauf-Sperre: keine Doppel-Meldung kurz vor einem geplanten Briefing (Issue #1594)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Änderungsalarme (`forecast_change`) und amtliche Warnungen (`official_alert`) werden derzeit
+auch dann als eigenständige Zusatz-Nachricht verschickt, wenn Minuten später ohnehin ein
+geplantes Briefing mit demselben Inhalt rausgeht. Das ist besonders auffällig am Ende der
+Ruhezeit: Alarme, die während der Ruhezeit unterdrückt wurden, gehen dort **gesammelt** raus,
+sobald die Ruhezeit endet — und genau das fällt bei vielen Nutzern zeitlich mit dem
+Morgen-Briefing zusammen.
+
+**Gemessen am Produktivkonto des PO (Trip `5f534011`, „KHW 403"), 2026-08-14:**
+
+| Tag | Alarm | Briefing | Reihenfolge |
+|---|---|---|---|
+| 13.08. | 05:02 UTC | 05:00 UTC | Alarm **nach** dem Briefing |
+| 14.08. | 05:01 UTC | 05:04 UTC | Alarm **vor** dem Briefing |
+
+`alert_quiet_to` und `report_config.morning_time` stehen beide auf 07:00 Ortszeit (05:00 UTC) —
+das Ende der Ruhezeit fällt exakt auf die geplante Briefing-Zeit. Am 08.08. stand
+`alert_quiet_to` noch auf 06:00; die protokollierte Alarmzeit ist seither mitgewandert (bis
+06.08. durchgehend 04:00 UTC, seit 13.08. 05:01–05:02 UTC) — die Alarmzeit folgt der
+Konfiguration, nicht dem Wetter. Frühere Messungen desselben Kontos zeigen zusätzlich Alarme um
+04:00 und 04:45 UTC gegen ein Briefing um 05:00 UTC, also 60 bzw. 15 Minuten vorher.
+
+**Es ist kein reines „vorher", sondern ein Wettlauf zweier unabhängiger Takte:** der
+Alarm-Takt läuft alle 15 Minuten, der Briefing-Takt stündlich. Eine Sperre, die nur „N Minuten
+**vor** dem geplanten Versand" prüft, hätte den Fall vom 13.08. (Alarm 2 Minuten **nach** dem
+Briefing) nicht gefangen.
+
+**Diese Scheibe fügt eine zusätzliche, rein lesende Freigabe-Stufe** hinzu: Sie unterdrückt
+einen Änderungsalarm oder eine amtliche Warnung für eine Entität (Trip oder
+Ortsvergleich-Preset), wenn für dieselbe Entität unmittelbar ein geplantes Briefing ansteht
+(Vorlauf) oder gerade eines rausgegangen ist (Nachlauf). Der Wetter-Inhalt geht dem Nutzer dabei
+nicht verloren — er kommt vollständig im Briefing an, das Sekunden bis Minuten später folgt. Die
+Meldung wird **ersetzt**, nicht verschluckt. **NowCast-Alarme (Regen-/Gewitter-Onset) sind
+ausdrücklich ausgenommen** (PO-Entscheid) — sie bleiben zeitkritisch und laufen unverändert
+weiter.
+
+## Der Widerspruch zu #1233 und seine Auflösung
+
+`src/services/compare_official_alert.py:124-125` sichert wörtlich zu:
+
+> `#1233: Ruhezeit unterdrueckt frueh -> kein State-Verbrauch der Warnung, damit sie nach Ende
+> der Ruhezeit noch als "neu" zugestellt wird (AC-2).`
+
+Bewacht von `tests/tdd/test_compare_official_alert.py:610`
+(`test_ac1_quiet_hours_suppresses_send_state_and_limit`): eine während der Ruhezeit
+unterdrückte Warnung darf **keinen** State schreiben — sonst würde sie nach Ende der Ruhezeit
+als „schon gemeldet" verschluckt, statt zugestellt zu werden.
+
+**Das Losbrechen am Ruhezeit-Ende ist also kein Versehen, sondern eine bewusst gebaute und
+getestete Eigenschaft aus #1233.** Diese Scheibe darf sie nicht still brechen — und tut es
+nicht: Die neue Vorlauf-Sperre schreibt **ebenfalls keinen State**. Sie verzögert nur bis das
+Briefing raus ist, und das Briefing selbst setzt Δ-Anker und Melde-Gedächtnis zurück
+(`alert_briefing_anchor.write_anchor_and_reset_memory`,
+`src/services/alert_briefing_anchor.py:247-303`). Für eine Entität **ohne** anstehendes
+Briefing bleibt das #1233-Verhalten (Sammel-Zustellung nach Ruhezeit-Ende) vollständig
+unverändert — die neue Sperre greift dort gar nicht (AC-9).
+
+## Symmetrie: morgens wie abends, Trip wie Ortsvergleich
+
+Die Sperre gilt für **beide** Tageszeiten und **beide** Entitätsarten gleichermaßen — es gibt
+keinen fachlichen Grund, warum ein Abend-Briefing weniger Anspruch auf eine unverdoppelte
+Meldung hätte als ein Morgen-Briefing.
+
+**Gemessen:** Die Abend-Redundanz tritt heute faktisch kaum auf. Vor dem Abend-Briefing endet
+keine Ruhezeit (Ruhezeit beginnt um 20:00, Abend-Briefing geht um 18:00 raus), daher staut sich
+dort nichts auf. Seit 25.07.: **14** Änderungs-/Warn-Alarme in der Stunde vor dem
+Morgen-Briefing, **1** in der Stunde vor dem Abend-Briefing. Der symmetrische Zuschnitt bleibt
+trotzdem richtig — Ruhezeiten und Briefing-Zeiten sind pro Nutzer frei konfigurierbar, und genau
+ihre Verschiebung hat den Effekt hier binnen einer Woche entstehen lassen. Eine Sperre, die nur
+für den Morgen gälte, wäre eine unbegründete Ausnahme, sobald ein Nutzer seine Zeiten anders
+legt.
+
+## Source
+
+Drei Einhängepunkte, keiner davon im Engine-Kern:
+
+| Datei:Zeile | Alarmart | Rolle |
+|---|---|---|
+| `src/services/trip_alert.py:680` (`_is_quiet_hours`) | Trip Änderungsalarm **und** Trip amtliche Warnung | **ein** Adapter für beide Aufrufer (`:231` Änderungsalarm, `:1447` amtliche Warnung) |
+| `src/services/compare_alert.py:183` | Ortsvergleich Änderungsalarm | eigene Aufrufstelle |
+| `src/services/compare_official_alert.py:126` | Ortsvergleich amtliche Warnung | eigene Aufrufstelle |
+
+**Nicht** `src/services/deviation_alert_engine.py:285` (`evaluate()`, Engine-Kern): dessen
+`AlertEvaluationConfig` (`src/services/point_weather.py:54-75`) ist ausdrücklich „kein
+Trip-Bezug" und trägt weder Versandzeiten noch eine Entitäts-Kennung — der Engine-Kern *kann*
+die neue Prüfung nicht rechnen. Zudem läuft `evaluate()` bei beiden Aufrufern erst **nach** dem
+Wetterabruf (`trip_alert.py:250` vor `:283`; `compare_alert.py:387-394` vor `:401`) — eine
+Sperre dort würde den Abruf nicht mehr einsparen.
+
+Betroffene Schicht: ausschließlich **Python-Core** (`src/services/`). Kein Go-Code, kein
+Frontend-Code.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/services/alert_gate.py` | module (Bestand) | Vorgesehene Heimat der neuen Funktion `check_briefing_imminent()`, klar getrennt von `check_nowcast_gate()` |
+| `src/services/alert_briefing_anchor.py::last_briefing_at()` | module (Bestand) | Liefert den Zeitpunkt des letzten Briefings je `(entity_id, entity_type)` — deckt den Nachlauf-Zweig |
+| `src/services/compare_slot_scheduler.py::presets_due_for_hour()` | module (Bestand) | Beantwortet für den Ortsvergleich „ist jetzt ein Briefing fällig?" — inkl. `is_silenced`/`end_date`/`weekly`/Slot-Flags |
+| `src/services/trip_report_scheduler.py::_get_active_trips()` | module (Bestand) | Vorlage für ein neu herauszulösendes reines Trip-Fälligkeits-Prädikat — **ohne** den `skip_next`-Verbrauch |
+| `src/services/compare_alert_guard.py::is_silenced()` | module (Bestand) | Der eine Stilllegungs-Riegel (`paused_at`/`schedule=="manual"`/`archived_at`), bereits Teil von `presets_due_for_hour()` |
+| `src/services/deviation_alert_engine.py::DeviationAlertEngine.is_quiet_hours()` | module (Bestand) | Geteilte Ruhezeit-Prüfung an allen drei Einhängepunkten — bleibt unverändert, die neue Stufe kommt zusätzlich |
+| `src/services/trip_alert.py`, `compare_alert.py`, `compare_official_alert.py` | services (Bestand) | Aufrufer der neuen Stufe an den drei Einhängepunkten |
+
+## Estimated Scope
+
+- **LoC:** ~100–125 Produktivcode (siehe Affected Files). Testcode wird deutlich umfangreicher
+  — ein `loc_limit_override` ist wahrscheinlich nötig.
+- **Files:** 5 Produktivdateien geändert, keine neue Produktivdatei (`alert_gate.py` wird
+  erweitert, nicht ersetzt); 3–4 neue Testdateien, bestehende Testdateien namentlich unten.
+- **Effort:** medium — kein neuer Baustein-Typ (das Muster „geteilter Freigabe-Baustein +
+  dünne Aufrufer" existiert bereits aus #1467 S3), aber vier Aufrufstellen und ein
+  Seiteneffekt-Fund (`skip_next`), der besondere Sorgfalt braucht.
+
+## Implementation Details
+
+### Vorgeschlagene Schnittstelle (in der Umsetzung präzisierbar)
+
+```
+def check_briefing_imminent(
+    *,
+    user_id: str,
+    entity_id: str,
+    entity_type: str,          # "route" | "vergleich"
+    now: datetime,
+    zone: ZoneInfo,
+    briefing_due_at: Callable[[datetime], bool],  # reines Faelligkeits-Praedikat, gg. Zeitpunkt ausgewertet
+    vorlauf_minuten: int = 60,
+    nachlauf_minuten: int = 15,
+) -> bool
+```
+
+Zwei ODER-verknüpfte, rein lesende Bedingungen:
+
+1. **Vorlauf:** Das bestehende Fälligkeits-Prädikat der Entität — beim Ortsvergleich
+   `presets_due_for_hour()`, beim Trip das unten beschriebene herausgelöste Prädikat — wird
+   nicht nur gegen `now`, sondern zusätzlich gegen `now + vorlauf_minuten` ausgewertet. Wird die
+   Entität innerhalb dieses verschobenen Zeitpunkts fällig, steht ihr Briefing unmittelbar
+   bevor.
+2. **Nachlauf:** `alert_briefing_anchor.last_briefing_at(user_id=..., entity_id=...,
+   entity_type=...)` liegt nicht länger als `nachlauf_minuten` zurück.
+
+Die genaue Funktionssignatur ist Implementierungsdetail; verbindlich ist die beobachtbare
+Wirkung in den Acceptance Criteria unten.
+
+### Warum „Fälligkeit fragen, nicht neu rechnen"
+
+Eine eigene Zeitrechnung wäre bereits die **dritte** Fassung derselben Regel — eine liegt schon
+im Frontend (`frontend/src/lib/utils/cockpitHelpers568.ts:247`, `deriveNextSend`, mit der
+ausdrücklichen Auflage, deckungsgleich mit `resolve_preset_slots` zu bleiben). Stattdessen
+fragt die neue Stufe dieselben Funktionen, die den tatsächlichen Versand auslösen —
+verschoben um die Vorlaufzeit.
+
+### Trip: reines Fälligkeits-Prädikat ohne `skip_next`-Verbrauch
+
+`src/services/trip_report_scheduler.py::_get_active_trips()` (`:736-793`) konsumiert
+`report_config.skip_next` per Read-Modify-Write **mit `save_trip()`** bei **jedem** Aufruf
+(`:784-789`):
+
+```python
+if rc.skip_next is True:
+    new_rc = dataclasses.replace(rc, skip_next=False)
+    new_trip = dataclasses.replace(trip, report_config=new_rc)
+    save_trip(new_trip, user_id=self._user_id)
+    continue
+```
+
+Würde die neue Sperre diese Methode direkt mitbenutzen, verbrauchte sie im 15-Minuten-Alarmtakt
+den Nutzerwunsch „nächstes Briefing überspringen", bevor der Briefing-Scheduler ihn je sieht —
+das Briefing käme trotzdem. Die Umsetzung löst deshalb ein reines Prädikat heraus, das **alle**
+übrigen Aktiv-Filter aus `_get_active_trips()` enthält — Etappe am Zieltag
+(`trip.get_stage_for_date`), `trip.paused_at is None`, `report_config.enabled is not False`,
+`report_config.paused_until` in der Vergangenheit oder unbesetzt — aber **ohne** den
+`skip_next`-Zweig. `_get_active_trips()` selbst bleibt unverändert (Bestandspfad
+verhaltensgleich), das neue Prädikat ist eine parallele, seiteneffektfreie Funktion.
+
+### Einsortierung an den drei Einhängepunkten
+
+Die neue Stufe wird an jedem der drei Einhängepunkte als **zusätzliche letzte, rein lesende
+Stufe direkt neben der bestehenden Ruhezeit-Prüfung** eingefügt, vor jedem Wetterabruf. Die
+bestehenden — heute an allen drei Stellen unterschiedlichen — Prüf-Reihenfolgen bleiben
+ansonsten unangetastet; das Vereinheitlichen ist #1467 S4, nicht dieser Fix:
+
+| Pfad | Reihenfolge (neue Stufe **fett**) |
+|---|---|
+| `trip_alert._is_quiet_hours` (deckt `:231` und `:1447`) | Ruhezeit → **Vorlauf-Sperre** → (Sperrzeit → Tageslimit → Abruf, unverändert je Aufrufer) |
+| `compare_alert.py:133-196` | `is_silenced` → Sperrzeit → Tageslimit → Ruhezeit(`:183`) → **Vorlauf-Sperre** → Abruf |
+| `compare_official_alert.py:98-141` | `is_silenced` → Migrations-Check → Ruhezeit(`:126`) → **Vorlauf-Sperre** → Abruf |
+
+### Kein State-Verbrauch, keine Protokollierung
+
+Alle Buchungen (`AlertStateService.save`, `ThrottleStore.record`,
+`alert_daily_limit.increment`) liegen an allen drei Einhängepunkten strukturell **hinter** dem
+Versand — die neue Stufe sitzt weit davor und liest nur. Eine unterdrückte Meldung erzeugt
+**keinen** neuen Protokolleintrag: `rework_1467_s3_nowcast.md` AC-9 legt bereits fest, dass
+Δ-Wetter- und amtlicher Pfad keine Unterdrückungs-Protokollierung bekommen, und die Meldung wird
+hier ohnehin **ersetzt**, nicht verschluckt — eine „nicht zugestellt"-Zeile für etwas, das
+Minuten später vollständig ankommt, wäre irreführend.
+
+## Invarianten
+
+- **Reihenfolge:** die neue Stufe läuft an jedem Einhängepunkt NACH der bestehenden
+  Ruhezeit-Prüfung und VOR jedem Wetterabruf. Sie ersetzt keine bestehende Stufe und
+  vertauscht keine bestehende Reihenfolge.
+- **Rein lesend:** `check_briefing_imminent()` schreibt nichts — kein `AlertStateService`, kein
+  `ThrottleStore`, kein Tageszähler, kein `alert_log`-Eintrag, kein `skip_next`-Verbrauch.
+- **NowCast bleibt unberührt:** `check_nowcast_gate()` ruft die neue Funktion nicht auf.
+- Mandantentrennung: `user_id` nie auf `"default"` zurückfallen lassen, jeder Teil mit ZWEI
+  Nutzern verifiziert.
+- Testpolitik: kein Mock-Theater, keine Dateiinhalt-Checks als Verhaltensnachweis.
+- Testdateien nach VERHALTEN benennen, nie nach Issue-Nummer.
+
+## Affected Files
+
+| Datei | Art | ~LoC | Beschreibung |
+|---|---|---|---|
+| `src/services/alert_gate.py` | MODIFY | 50–70 | Neue Funktion `check_briefing_imminent(...)` — Vorlauf über das jeweilige Fälligkeits-Prädikat, Nachlauf über `last_briefing_at()`. Getrennt von `check_nowcast_gate()`. |
+| `src/services/trip_report_scheduler.py` | MODIFY | 15–25 | Reines Fälligkeits-Prädikat herauslösen, **ohne** `skip_next`-Verbrauch. Bestandspfad (`_get_active_trips`) verhaltensgleich. |
+| `src/services/trip_alert.py` | MODIFY | ~15 | Beide Aufrufstellen (`:231`, `:1447`) über den gemeinsamen Adapter an `_is_quiet_hours()` abgedeckt. |
+| `src/services/compare_alert.py` | MODIFY | ~8 | Eine Aufrufstelle nach `:183`. |
+| `src/services/compare_official_alert.py` | MODIFY | ~8 | Eine Aufrufstelle nach `:126`. |
+
+## Bewusst NICHT in dieser Scheibe
+
+- **Der amtliche Trip-Abruf wird nicht vorgezogen.** `check_official_alert_triggers()` läuft
+  unbedingt bei `trip_alert.py:469`, also **vor** der Prüfung bei `:1447` — die bestehende
+  Ruhezeit-Prüfung spart diesen Abruf schon heute nicht, und diese Scheibe ändert daran nichts.
+  Die Sperre verhindert die **Meldung**, nicht den Abruf. Beobachtung für #1199.
+- **Vereinheitlichung der drei unterschiedlichen Prüf-Reihenfolgen** (Ruhezeit/Sperrzeit/
+  Tageslimit-Abfolge unterscheidet sich heute zwischen Trip, Ortsvergleich-Änderung und
+  Ortsvergleich-amtlich) → #1467 S4.
+- **Anzeige/Wortwahl unterdrückter Meldungen** — ob und wie ein unterdrückter Alarm dem Nutzer
+  gegenüber überhaupt benannt wird → #1750/#1800 (zweite Frage).
+- **Kein neuer Go-Endpunkt, kein neuer Cron-Job.** `internal/scheduler/scheduler.go` bleibt
+  unangetastet — die Fälligkeit entscheidet ausschließlich Python.
+- **Kein Frontend-Code.**
+- **#1714 wird NICHT miterledigt.** Dort zeigt das Ortsvergleich-Briefing eine amtliche Warnung
+  an, vermerkt sie aber nicht im Melde-Gedächtnis (`scheduler_dispatch_service.py:453-464` fehlt
+  das Gegenstück zu `trip_report_scheduler.py:1218-1226`), weshalb der Prüfer sie erneut
+  verschickt. Diese Scheibe **mildert** das nur innerhalb ihres Fensters: eine Wiederholung
+  innerhalb der 15 Nachlauf-Minuten fällt weg, eine 20 oder 40 Minuten später nicht. Die Ursache
+  — der fehlende Vermerk — bleibt bestehen. #1714 darf deshalb nicht mit dieser Scheibe
+  geschlossen werden.
+
+## Risiken
+
+| | Risiko | Test, der es fängt |
+|---|---|---|
+| **R1** | Ortsvergleich ohne geplantes Briefing (`manual`, pausiert, archiviert, `end_date` vergangen, Slot aus) wird versehentlich mitgesperrt — Alarm schweigt ohne Ersatz (Fehlerklasse #1555/#1584) | AC-7 |
+| **R2** | Trip ohne geplantes Briefing (pausiert, `enabled: false`, `paused_until`, keine Etappe am Zieltag) wird versehentlich mitgesperrt | AC-8 |
+| **R3** | `skip_next` wird durch die neue Sperre konsumiert, weil sie bequem `_get_active_trips()` mitbenutzt statt des herausgelösten reinen Prädikats | AC-11 |
+| **R4** | Die neue Sperre schreibt State (Melde-Gedächtnis/Sperrzeit/Tageszähler) und bricht damit die #1233-Zusicherung „kein State-Verbrauch bei Unterdrückung" | AC-10 |
+| **R5** | NowCast wird versehentlich mitgesperrt, weil `check_nowcast_gate()` (oder sein Aufrufer) die neue Funktion mitruft | AC-12 |
+| **R6** | Ohne Nachlauf-Deckel bleibt die Sperre wirksam, obwohl das Briefing gar nicht (mehr) zugestellt wurde (`record_briefing_dispatch_failure`) — Meldeloch ohne Grenze | AC-6 |
+
+## Test-Plan
+
+Kern-Schicht (deterministisch, kein Netz), sofern nicht anders vermerkt.
+
+| AC | Datei | Schicht |
+|---|---|---|
+| AC-1, AC-2, AC-8, AC-11 | `tests/tdd/test_trip_alert_briefing_imminent.py` (neu) | Kern |
+| AC-3, AC-7 | `tests/tdd/test_compare_alert_briefing_imminent.py` (neu) | Kern |
+| AC-4, AC-9 | `tests/tdd/test_compare_official_alert_briefing_imminent.py` (neu) | Kern |
+| AC-5, AC-6 | `tests/tdd/test_alert_gate.py` (Bestand, ergänzt — reine `check_briefing_imminent()`-Logik) + je ein Integrationsfall in den drei neuen Dateien | Kern |
+| AC-9 (Bestandsanteil) | `tests/tdd/test_compare_official_alert.py:610` (Bestand, MUSS unverändert grün bleiben) | Kern |
+| AC-10 | alle drei neuen Dateien, je ein State-/Zähler-Snapshot vor/nach | Kern |
+| AC-12 | `tests/tdd/test_alert_gate.py` (Bestand, ergänzt) | Kern |
+| AC-13 | alle drei neuen Dateien, Protokoll-Snapshot vor/nach | Kern |
+| AC-14 | alle drei neuen Dateien, parametrisiert morgens/abends | Kern |
+| AC-15 | `tests/tdd/test_trip_alert_briefing_imminent.py` + `tests/tdd/test_compare_alert_briefing_imminent.py` (neu, je zwei `user_id`-Verzeichnisse) | Kern |
+| AC-16 | `tests/tdd/test_trip_alert_briefing_imminent.py` (neu) — unterdrückte Warnung dem Briefing-Renderer übergeben und im Ergebnis nachweisen | Kern |
+
+### Pflicht-Mutationsgegenproben (Adversary-Runde)
+
+1. Vorlauf auf 0 Minuten setzen → ein Alarm kurz vor dem Slot muss trotzdem gesperrt sein
+   (fängt AC-1–AC-4 gegen einen zu knapp bemessenen Vorlauf ab).
+2. NowCast-Ausnahme entfernen → bei anstehendem Briefing UND auslösendem Regenradar muss der
+   NowCast durchgehen, der Änderungsalarm nicht (AC-12).
+3. `manual`-/pausiertes/archiviertes Preset bzw. pausierten/deaktivierten Trip nicht ausnehmen
+   → der jeweilige Alarm muss trotzdem durchgehen (AC-7, AC-8).
+4. State-Verbrauch einbauen (z. B. `AlertStateService.save` vor der Sperr-Prüfung) →
+   `alert_state`, Sperrzeit-Speicher und Tageszähler müssen nach einer gesperrten Meldung
+   unverändert sein (AC-10).
+5. `skip_next` durch die neue Sperre konsumieren lassen → nach einem Sperr-Lauf muss
+   `skip_next` weiterhin `True` sein (AC-11).
+
+### Bestehende Testdateien, die GRÜN bleiben MÜSSEN
+
+| Zweck | Datei |
+|---|---|
+| Sieben-Stellen-Vollständigkeit der Ruhezeit-Prüfungen | `tests/tdd/test_ruhezeit_und_zaehler_folgen_der_ortszone.py` |
+| #1233-Zusicherung „kein State-Verbrauch bei Ruhezeit-Unterdrückung" | `tests/tdd/test_compare_official_alert.py:610` |
+| AST-Wächter „kein eigenes try/except um `is_quiet_hours()`" | `tests/tdd/test_alert_quiet_hours_robustness.py` |
+| NowCast-Ausnahme (Bestandsverhalten) | `tests/tdd/test_alert_gate.py`, `tests/tdd/test_trip_radar_nowcast_gate_migration.py`, `tests/tdd/test_compare_radar_alert_daily_limit.py` |
+| Trip-Änderungsalarm (Bestandsverhalten) | `tests/tdd/test_alert_cooldown_quiet.py`, `tests/tdd/test_alert_quiet_hours_localtime.py`, `tests/tdd/test_issue_1168_alert_engine_extract.py` |
+| Ortsvergleich-Änderungsalarm (Bestandsverhalten) | `tests/tdd/test_compare_alert_quiet_hours_precedes_fetch.py` |
+
+Live-E2E: nicht vorgesehen — die Fälligkeits-/Zeitfenster-Logik ist deterministisch mit
+eingefrorener Uhrzeit vollständig im Kern prüfbar; ein Nachweis „auf den nächsten echten
+Briefing-Lauf warten" wäre unzuverlässig und langsam.
+
+## Acceptance Criteria
+
+**(a) Kernverhalten — Meldung unterdrückt, wenn ein Briefing unmittelbar bevorsteht**
+
+- **AC-1:** Given ein Trip, für den in Kürze (innerhalb von 60 Minuten) das nächste geplante
+  Briefing verschickt wird, When in diesem Zeitfenster ein Wetter-Änderungsalarm für den Trip
+  ausgelöst würde, Then wird diese Alarm-Nachricht NICHT als eigenständige Zusatz-Meldung
+  verschickt.
+  - Test: Trip mit fälligem Briefing in 30 Minuten, änderungswürdige Wetterdaten simulieren,
+    Versandpfad prüfen — kein Alarm auf keinem Kanal.
+
+- **AC-2:** Given einen Trip, für den in Kürze das nächste geplante Briefing verschickt wird,
+  When in diesem Zeitfenster eine amtliche Unwetterwarnung für den Trip einträfe, Then wird
+  diese Warnung NICHT als eigenständige Zusatz-Meldung verschickt — sie erscheint stattdessen im
+  Briefing.
+  - Test: Trip mit fälligem Briefing in 15 Minuten, amtliche Warnung simulieren, `
+    _send_official_alert_only` liefert „nicht versendet".
+
+- **AC-3:** Given einen Ortsvergleich, für den in Kürze das nächste geplante Briefing verschickt
+  wird, When in diesem Zeitfenster ein Wetter-Änderungsalarm für ein Preset des Vergleichs
+  ausgelöst würde, Then wird diese Alarm-Nachricht NICHT als eigenständige Zusatz-Meldung
+  verschickt.
+  - Test: Preset mit fälligem Morgen-Slot in 45 Minuten, änderungswürdige Wetterdaten für einen
+    Ort simulieren, kein Versand.
+
+- **AC-4:** Given einen Ortsvergleich, für den in Kürze das nächste geplante Briefing verschickt
+  wird, When in diesem Zeitfenster eine amtliche Warnung für ein Preset des Vergleichs einträfe,
+  Then wird diese Warnung NICHT als eigenständige Zusatz-Meldung verschickt.
+  - Test: Preset mit fälligem Slot in 10 Minuten, amtliche Warnung simulieren, kein Versand.
+
+**(b) Nachlauf und Fenstergrenzen**
+
+- **AC-5:** Given eine Entität (Trip oder Ortsvergleich-Preset), deren letztes Briefing
+  nachweislich vor wenigen Minuten (bis zu 15) rausgegangen ist, When unmittelbar danach ein
+  Änderungsalarm oder eine amtliche Warnung für dieselbe Entität ausgelöst würde, Then wird
+  diese Meldung ebenfalls NICHT als eigenständige Zusatz-Meldung verschickt — das entspricht dem
+  gemessenen 13.08.-Fall (Alarm 2 Minuten nach dem Briefing).
+  - Test: `last_briefing_at()` auf „vor 5 Minuten" setzen, Alarm-Bedingung erfüllen, kein
+    Versand.
+
+- **AC-6:** Given eine Entität, deren nächstes Briefing weiter als 60 Minuten entfernt ist UND
+  deren letztes Briefing länger als 15 Minuten zurückliegt (oder es gab noch keins), When ein
+  Änderungsalarm oder eine amtliche Warnung ausgelöst würde, Then wird diese Meldung wie bisher
+  regulär verschickt — die neue Sperre greift außerhalb des Fensters nicht.
+  - Test: nächstes Briefing in 90 Minuten, letztes Briefing vor 30 Minuten, Alarm-Bedingung
+    erfüllen, Versand erfolgt normal.
+
+**(c) Kein Schweigen ohne Ersatz**
+
+- **AC-7:** Given ein Ortsvergleich-Preset OHNE geplantes Briefing (Zeitplan `manual`, pausiert,
+  archiviert, `end_date` in der Vergangenheit oder der betroffene Slot abgeschaltet), When ein
+  Änderungsalarm oder eine amtliche Warnung für dieses Preset ausgelöst würde, Then wird diese
+  Meldung NIEMALS durch die neue Sperre unterdrückt — ohne geplantes Briefing gibt es keinen
+  Ersatz, also darf auch nichts verschluckt werden.
+  - Test: je ein Preset mit `schedule: "manual"`, `paused_at` gesetzt, `archived_at` gesetzt,
+    abgelaufenem `end_date` und abgeschaltetem Slot — in jedem Fall geht der Alarm normal raus.
+
+- **AC-8:** Given einen Trip OHNE geplantes Briefing (pausiert über den Trip-Pause-Knopf,
+  `report_config.enabled` auf falsch, `report_config.paused_until` in der Zukunft, oder keine
+  Etappe am jeweiligen Zieltag), When ein Änderungsalarm oder eine amtliche Warnung für diesen
+  Trip ausgelöst würde, Then wird diese Meldung NIEMALS durch die neue Sperre unterdrückt.
+  - Test: je ein Trip mit `paused_at` gesetzt, `report_config.enabled=False`,
+    `paused_until` in der Zukunft und ohne Etappe am Zieltag — in jedem Fall geht der Alarm
+    normal raus.
+
+**(d) Bestehende Zusicherungen bleiben erhalten**
+
+- **AC-9:** Given eine Entität, deren Ruhezeit endet, OHNE dass für sie ein Briefing ansteht
+  (z. B. Ortsvergleich-Preset mit `schedule: "manual"`), When während der Ruhezeit ein Alarm
+  unterdrückt wurde, Then wird diese Meldung nach Ende der Ruhezeit weiterhin gesammelt
+  zugestellt — die #1233-Eigenschaft bleibt für Entitäten ohne anstehendes Briefing unverändert
+  erhalten, die neue Sperre greift dort nicht.
+  - Test: `tests/tdd/test_compare_official_alert.py:610` bleibt unverändert grün; ergänzender
+    Fall in `test_compare_official_alert_briefing_imminent.py` mit `schedule: "manual"` bestätigt
+    dasselbe Verhalten unter der neuen Sperre.
+
+- **AC-10:** Given eine Meldung, die durch die neue Vorlauf-Sperre unterdrückt wird, When der
+  jeweilige Lauf beendet ist, Then sind weder das Melde-Gedächtnis (`AlertStateService`) noch
+  die Sperrzeit-Ablage (`ThrottleStore`) noch der Tageszähler für diese Entität verändert worden
+  — genau wie bei einer während der Ruhezeit unterdrückten Meldung (#1233-Analogie).
+  - Test: Zustands-Snapshot vor und nach einem durch die neue Sperre unterdrückten Lauf
+    vergleichen — exakte Gleichheit.
+
+- **AC-11:** Given einen Trip, dessen `report_config.skip_next` auf `True` steht, When während
+  des Vorlauf-Fensters ein Alarm-Lauf die neue Sperre prüft, Then bleibt `skip_next` nach diesem
+  Lauf weiterhin `True` — die Sperre darf den Nutzerwunsch „nächstes Briefing überspringen"
+  nicht vorzeitig verbrauchen.
+  - Test: Trip mit `skip_next=True` und fälligem Briefing in Kürze, Alarm-Lauf ausführen,
+    `report_config.skip_next` danach unverändert `True`.
+
+- **AC-12:** Given eine Entität, für die gleichzeitig ein NowCast-Alarm (Regen-/
+  Gewitter-Onset) UND ein Änderungsalarm anstünden UND ein Briefing unmittelbar bevorsteht,
+  When beide Alarmarten geprüft werden, Then wird der NowCast-Alarm trotzdem zugestellt,
+  während der Änderungsalarm unterdrückt bleibt — die neue Sperre wirkt ausschließlich auf
+  Änderungsalarme und amtliche Warnungen, NICHT auf NowCast.
+  - Test: Szenario mit anstehendem Briefing, auslösendem Regenradar UND auslösender
+    Wetteränderung gleichzeitig — NowCast-Versand erfolgt, Änderungsalarm-Versand bleibt aus.
+
+- **AC-13:** Given eine durch die neue Sperre unterdrückte Meldung, When der jeweilige Lauf
+  beendet ist, Then entsteht dafür KEIN neuer Eintrag im Alarm-Protokoll — die Unterdrückung
+  bleibt wie beim Δ-Wetter- und amtlichen Pfad heute unprotokolliert (Status quo aus
+  `rework_1467_s3_nowcast.md` AC-9).
+  - Test: Protokoll-Snapshot vor und nach einem durch die neue Sperre unterdrückten Lauf
+    vergleichen — keine neuen Einträge.
+
+**(e) Symmetrie und Mandantentrennung**
+
+- **AC-14:** Given identische Vorlauf-/Nachlauf-Bedingungen, When sie für ein Morgen-Briefing
+  UND für ein Abend-Briefing geprüft werden, sowohl beim Trip als auch beim Ortsvergleich, Then
+  wirkt die Sperre in allen vier Kombinationen gleichermaßen — es gibt keine versteckte
+  Bevorzugung des Morgen- oder des Trip-Pfads.
+  - Test: dieselbe Fenster-Logik parametrisiert für (Morgen, Abend) × (Trip, Ortsvergleich)
+    durchlaufen, identisches Unterdrückungsverhalten in allen vier Fällen.
+
+- **AC-15:** Given zwei verschiedene Nutzer mit je einer Entität, deren Fälligkeits- und
+  Briefing-Zeitpunkte unabhängig geführt werden, When bei beiden gleichzeitig ein Alarm während
+  des Vorlauf-Fensters des jeweils EIGENEN Briefings ausgelöst wird, Then wirkt die Sperre für
+  jeden Nutzer ausschließlich auf seine eigenen Daten — kein Nutzer beeinflusst den anderen.
+  - Test: zwei `user_id`-Verzeichnisse, unterschiedliche Briefing-Zeiten, je ein Alarm im
+    eigenen Vorlauf-Fenster auslösen, Unterdrückung nur beim jeweils betroffenen Nutzer.
+
+**(f) Die tragende Rechtfertigung — nachgewiesen, nicht vorausgesetzt**
+
+- **AC-16:** Given eine amtliche Warnung, die durch die neue Sperre als eigenständige Meldung
+  unterdrückt wurde, When das unmittelbar folgende geplante Briefing gerendert wird, Then
+  erscheint dieselbe Warnung darin — die Meldung ist damit nachweislich **ersetzt** und nicht
+  verschluckt. Ohne dieses Kriterium wäre die gesamte Scheibe auf einer ungeprüften Annahme
+  gebaut.
+  - Test: dieselbe amtliche Warnung, die den unterdrückten Alarm ausgelöst hätte, dem
+    Briefing-Renderer übergeben (`seg.official_alerts` → Warn-Block,
+    `src/output/renderers/email/html.py:1565-1595`) und im gerenderten Ergebnis nachweisen.
+    Gilt für den Trip-Pfad; für den Wetter-Änderungsalarm ist die Ersetzung baulich gegeben
+    (das Briefing zeigt den vollständigen aktuellen Wetterstand) und wird nicht separat geprüft.
+
+## Known Limitations
+
+- **Minutengenauigkeit ist wirkungslos.** Versandzeiten werden von Go auf die volle Stunde
+  gekappt (`internal/store/slot_hour_normalization.go:36-49,66-69,159-164`), sowohl beim
+  Schreiben als auch beim Laden. Der 60-Minuten-Vorlauf wirkt dadurch effektiv stundenbezogen —
+  eine minutengenaue Sperre hätte keinen zusätzlichen Nutzen.
+- **Der amtliche Trip-Abruf wird durch diese Scheibe nicht vorgezogen** (siehe „Bewusst NICHT in
+  dieser Scheibe"). Die Sperre spart also kein Abruf-Kontingent beim amtlichen Trip-Pfad ein,
+  nur die Zustellung der resultierenden Meldung entfällt.
+- **Scheitert der Briefing-Versand** (`record_briefing_dispatch_failure`), bleibt der Anker
+  unverändert, und der Nachlauf-Zweig wirkt entsprechend nicht mehr für diesen Fall. Der zuvor
+  im Vorlauf-Fenster unterdrückte Alarm bleibt dadurch für maximal einen Alarm-Takt (bis zu 15
+  Minuten) unzugestellt — der nächste reguläre Alarm-Lauf ist davon nicht betroffen und prüft
+  wieder normal.
+- **Die Abend-Sperre bleibt in der Praxis meist folgenlos**, weil die Abend-Redundanz heute kaum
+  auftritt (gemessen: 1 von 15 Fällen seit 25.07.). Das ist kein Defekt dieser Scheibe, sondern
+  Ausdruck der aktuell verbreiteten Konfiguration (Ruhezeit-Ende ≠ Abend-Briefing-Zeit) — ändert
+  sich die Konfiguration eines Nutzers, greift die Symmetrie sofort.
+- **Ad-hoc-Briefings („Handversand") lösen den Nachlauf nicht aus.**
+  `write_anchor_and_reset_memory(on_demand=True)` schreibt weder Anker noch Reset (#1007) — ein
+  auf Zuruf abgerufenes Briefing aktualisiert `last_briefing_at()` also nicht und unterdrückt
+  entsprechend keinen nachfolgenden Alarm. Das ist beabsichtigt: ein Ad-hoc-Abruf ist gegenüber
+  beiden Zuständen bewusst read-only, und ein solcher Abruf ersetzt kein geplantes Briefing.
+- **Kein ADR zur Grundsatzfrage „wann darf ein Alarm unterdrückt werden".** Diese Scheibe fügt
+  eine weitere, implizit begründete Sperrart hinzu (analog Ruhezeit, Sperrzeit, Tageslimit).
+  Ein eigenständiger ADR-Nachtrag ist nicht Teil dieser Scheibe (siehe unten).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue.
+- **Rationale:** ADR-0009 (Alerts als Abweichungs-Wächter gegen den letzten Briefing-Snapshot)
+  trägt bereits die fachliche Begründung, warum eine Unterdrückung hier überhaupt zulässig ist —
+  die Meldung wird durch das nachfolgende Briefing ersetzt, nicht ersatzlos verschluckt. ADR-0009
+  macht keine Aussage über den Zeitpunkt der Unterdrückung, daher genügt die bestehende
+  Begründung ohne Nachtrag. Ein möglicher künftiger ADR-Nachtrag zur Sammelfrage „welche
+  Sperrarten existieren und in welcher Reihenfolge" bleibt #1467 S4 vorbehalten, das die drei
+  heute unterschiedlichen Prüf-Reihenfolgen ohnehin zusammenlegt.
+
+## Changelog
+
+- 2026-08-14: Initiale Spec, basierend auf `docs/context/fix-1594-alarm-vorlauf-sperre.md`. Alle
+  zehn dort getroffenen Entscheidungen 1:1 übernommen (drei Einhängepunkte, Heimat
+  `alert_gate.py`, Fälligkeit fragen statt neu rechnen, 60-Minuten-Vorlauf / 15-Minuten-Nachlauf,
+  kein State-Verbrauch, keine Protokollierung, NowCast-Ausnahme, Ersatzlosigkeits-Schutz für
+  beide Entitätsarten, eine Scheibe für alle vier Aufrufstellen). Alle referenzierten
+  Codestellen und Testdateien am Ist-Code vom 2026-08-14 verifiziert.

--- a/docs/specs/modules/fix_1594_alarm_vorlauf_sperre.md
+++ b/docs/specs/modules/fix_1594_alarm_vorlauf_sperre.md
@@ -214,6 +214,23 @@ Versand — die neue Stufe sitzt weit davor und liest nur. Eine unterdrückte Me
 hier ohnehin **ersetzt**, nicht verschluckt — eine „nicht zugestellt"-Zeile für etwas, das
 Minuten später vollständig ankommt, wäre irreführend.
 
+## Expected Behavior
+
+- **Input:** Der jeweilige Alarm-Lauf (`*/15`-Takt) an einem der drei Einhängepunkte, mit der
+  Entität (`Trip` bzw. Ortsvergleich-Preset-Dict), der Nutzer-Kennung, dem aktuellen Zeitpunkt
+  und der Ortszone der Entität — alles bereits im Scope der jeweiligen Aufrufstelle, nichts muss
+  zusätzlich durchgereicht werden.
+- **Output:** Eine Ja/Nein-Antwort auf „steht für diese Entität unmittelbar ein geplantes
+  Briefing an oder ist gerade eines rausgegangen?". Bei „ja" bricht der Alarm-Lauf für diese
+  Entität ab und verschickt **keine** Meldung; bei „nein" läuft er unverändert weiter.
+- **Side effects:** **Keine.** Die Stufe liest ausschließlich — sie schreibt kein
+  Melde-Gedächtnis (`AlertStateService`), keine Sperrzeit (`ThrottleStore`), keinen Tageszähler
+  (`alert_daily_limit`), keinen Protokolleintrag (`alert_log`), und sie konsumiert insbesondere
+  **nicht** `report_config.skip_next`. Sie beschafft auch keine Wetterdaten: sie sitzt an allen
+  drei Einhängepunkten vor dem Abruf, ein gesperrter Lauf kostet also kein Abruf-Kontingent
+  (Ausnahme: der amtliche Trip-Pfad, dessen Abruf schon heute früher liegt — siehe „Bewusst
+  NICHT in dieser Scheibe").
+
 ## Invarianten
 
 - **Reihenfolge:** die neue Stufe läuft an jedem Einhängepunkt NACH der bestehenden

--- a/src/services/alert_gate.py
+++ b/src/services/alert_gate.py
@@ -41,6 +41,7 @@ from services import alert_daily_limit, alert_log
 from services.alert_briefing_anchor import last_briefing_at
 from services.deviation_alert_engine import DeviationAlertEngine
 from services.throttle_store import ThrottleStore
+from utils.timezone import local_fmt
 
 logger = logging.getLogger("alert_gate")
 
@@ -288,14 +289,14 @@ def check_briefing_imminent(
         logger.debug(
             "Keine Sperre fuer %s: das anstehende Briefing wurde um %s Ortszeit "
             "bereits versucht.",
-            entity_id, letzter_versuch.astimezone(zone).strftime("%H:%M"),
+            entity_id, local_fmt(letzter_versuch, zone),
         )
         return False
 
     logger.debug(
         "Meldung unterdrueckt: Briefing fuer %s ist um %s Ortszeit faellig und "
         "noch nicht versucht.",
-        entity_id, faellig_ab.astimezone(zone).strftime("%H:%M"),
+        entity_id, local_fmt(faellig_ab, zone),
     )
     return True
 

--- a/src/services/alert_gate.py
+++ b/src/services/alert_gate.py
@@ -33,15 +33,56 @@ ein fehlgeschlagener Versuch darf weder Budget noch Sperrzeit verbrauchen
 from __future__ import annotations
 
 import logging
-from datetime import datetime
-from typing import NamedTuple, Optional
+from datetime import datetime, timedelta
+from typing import Callable, NamedTuple, Optional
 from zoneinfo import ZoneInfo
 
 from services import alert_daily_limit, alert_log
+from services.alert_briefing_anchor import last_briefing_at
 from services.deviation_alert_engine import DeviationAlertEngine
 from services.throttle_store import ThrottleStore
 
 logger = logging.getLogger("alert_gate")
+
+# Issue #1594: Vorlauf der Sperre, in Minuten. 60 — PO-Entscheidung, gemessen
+# begruendet: die redundanten Alarme lagen 60 und 15 Minuten vor dem Briefing
+# (04:00 und 04:45 UTC gegen 05:00). Ein 15-Minuten-Vorlauf haette die
+# 04:00-Faelle nicht gefangen.
+#
+# 🔴 Es gibt KEINEN Nachlauf (Spec-Korrektur 2026-08-14). Die erste Fassung
+# hatte einen — „letztes Briefing weniger als 15 Minuten her sperrt" — mit der
+# Begruendung, ein gescheiterter Versand lasse den Anker unveraendert. Diese
+# Begruendung war angenommen, nicht gemessen, und sie ist falsch:
+# `_anchor_and_reset()` steht in BEIDEN Versandpfaden im Fehler-Zweig
+# (`scheduler_dispatch_service.py`, `trip_report_scheduler.py`, #1629).
+# `last_briefing_at()` beantwortet „wurde ein Briefing VERSUCHT?", nicht
+# „wurde eines ZUGESTELLT?" — der Nachlauf schwieg damit gerade dann, wenn
+# nichts ankam. Gemessen in der GREEN-Phase: sieben rote Bestandstests aus dem
+# Nachlauf-Zweig, keiner aus dem Vorlauf. Der Anker hat hier deshalb das
+# UMGEKEHRTE Vorzeichen — er beendet die Sperre, statt sie auszuloesen.
+BRIEFING_VORLAUF_MINUTEN = 60
+
+# Abtastung des Faelligkeits-Fensters. Das Praedikat beantwortet „faellig zu
+# DIESEM Zeitpunkt?"; zwei Stichproben (jetzt und jetzt+Vorlauf) koennen ein
+# dazwischen liegendes Faelligkeits-Fenster ueberspringen. Fuenf Minuten sind
+# feiner als jede real existierende Faelligkeit — Versandzeiten sind
+# stundengenau (Go kappt sie beim Schreiben UND beim Laden,
+# `internal/store/slot_hour_normalization.go`), das schmalste reale Fenster ist
+# damit eine volle Stunde. Die abgetastete Funktion ist rein, die Auswertungen
+# kosten keinen Abruf.
+_ABTAST_SCHRITT_MINUTEN = 5
+
+# Wie weit zurueck der BEGINN eines bereits offenen Faelligkeits-Fensters
+# gesucht wird — noetig, um „gab es fuer DIESES Briefing schon einen Versuch?"
+# von „das war der Versuch von gestern" zu unterscheiden. Das breiteste reale
+# Fenster ist das Trip-Nachholfenster (`NACHHOL_FENSTER_STUNDEN = 3`), der
+# Ortsvergleich prueft Stundengleichheit (eine Stunde); vier Stunden decken
+# beide mit Reserve ab. Bewusst eine eigene Zahl statt eines Imports aus dem
+# Briefing-Scheduler: diese Stufe kennt nur das Praedikat, nicht sein
+# Innenleben. Reicht ein Fenster doch weiter zurueck, faellt die Untergrenze
+# auf `now - 4 h` — die Sperre endet dann eher zu frueh als zu spaet, und das
+# ist die richtige Fehlerrichtung („kein Schweigen ohne Ersatz", AC-7/AC-8).
+_RUECKBLICK_MINUTEN = 240
 
 
 class GateResult(NamedTuple):
@@ -114,6 +155,149 @@ def check_nowcast_gate(
         return GateResult(False, alert_log.REASON_DAILY_LIMIT)
 
     return _ALLOWED
+
+
+def _naechste_faelligkeit(
+    now: datetime,
+    briefing_due_at: Callable[[datetime], bool],
+    vorlauf_minuten: int,
+) -> Optional[datetime]:
+    """Frueheste abgetastete Faelligkeit in `[now, now + vorlauf]` — `None`,
+    wenn dort kein Briefing ansteht."""
+    for versatz in range(0, vorlauf_minuten + 1, _ABTAST_SCHRITT_MINUTEN):
+        moment = now + timedelta(minutes=versatz)
+        if briefing_due_at(moment):
+            return moment
+    return None
+
+
+def _fensterbeginn_untergrenze(
+    now: datetime, briefing_due_at: Callable[[datetime], bool],
+) -> datetime:
+    """Der spaeteste abgetastete Zeitpunkt VOR dem laufenden Faelligkeits-
+    Fenster — die Untergrenze, ab der ein Briefing-Versuch zu DIESEM Slot
+    gehoeren kann.
+
+    Nur aufzurufen, wenn das Fenster jetzt bereits offen ist. Bewusst der
+    letzte NICHT-faellige Zeitpunkt statt des ersten faelligen: `now` liegt
+    im 15-Minuten-Alarmtakt, nicht auf dem Fensterraster, die Rueckwaerts-
+    Stichproben treffen den Fensterbeginn also nicht exakt. Der Versuch selbst
+    liegt zwangslaeufig INNERHALB des Fensters (dort laeuft der Versand), eine
+    Untergrenze bis zu einem Abtastschritt davor ist damit folgenlos — die
+    umgekehrte Wahl waere es nicht: sie erklaerte einen echten Versuch zum
+    „noch nicht versucht" und liesse die Sperre stehen.
+    """
+    for versatz in range(
+        _ABTAST_SCHRITT_MINUTEN, _RUECKBLICK_MINUTEN + 1, _ABTAST_SCHRITT_MINUTEN,
+    ):
+        moment = now - timedelta(minutes=versatz)
+        if not briefing_due_at(moment):
+            return moment
+    return now - timedelta(minutes=_RUECKBLICK_MINUTEN)
+
+
+def check_briefing_imminent(
+    *,
+    user_id: str,
+    entity_id: str,
+    entity_type: str,
+    now: datetime,
+    zone: ZoneInfo,
+    briefing_due_at: Callable[[datetime], bool],
+    vorlauf_minuten: int = BRIEFING_VORLAUF_MINUTEN,
+) -> bool:
+    """Steht fuer diese Entitaet unmittelbar ein geplantes Briefing an, das
+    noch nicht versucht wurde? (Issue #1594)
+
+    `True` bedeutet: die Aenderungs- bzw. amtliche Meldung wird NICHT als
+    eigenstaendige Zusatz-Nachricht verschickt. Sie geht dem Nutzer nicht
+    verloren, sondern kommt Sekunden bis Minuten spaeter vollstaendig im
+    Briefing an — die Meldung wird ERSETZT, nicht verschluckt (ADR-0009).
+
+    Eine UND-verknuepfte Bedingung, beide Haelften rein lesend:
+
+    1. **Vorlauf:** `briefing_due_at` ist fuer irgendeinen Zeitpunkt in
+       `[now, now + vorlauf_minuten]` wahr.
+    2. **Noch nicht versucht:** fuer dieses anstehende Briefing gab es noch
+       keinen Versandversuch. Sobald einer stattgefunden hat — erfolgreich
+       ODER gescheitert — endet die Sperre.
+
+    🔴 Zu (2): `last_briefing_at()` heisst „versucht", nicht „zugestellt" —
+    `_anchor_and_reset()` steht in beiden Versandpfaden im Fehler-Zweig
+    (#1629). Genau deshalb beendet der Anker die Sperre, statt sie
+    auszuloesen: nach einem Fehlschlag laufen Anker und Idempotenz-Vermerk
+    auseinander (Anker gesetzt, Vermerk zurueckgenommen), der Trip bliebe das
+    volle Nachholfenster ueber „faellig" — 60 Minuten Vorlauf + 3 Stunden
+    Nachholfenster = bis zu vier Stunden Alarmstille, real gemessen (R6).
+
+    🔴 Zuordnung des Versuchs zum SLOT, nicht zum Tag: verglichen wird gegen
+    den Beginn des gerade offenen Faelligkeits-Fensters
+    (`_fensterbeginn_untergrenze`), nicht gegen Mitternacht Ortszeit. Sonst
+    beendete das erfolgreich verschickte MORGEN-Briefing auch die Sperre des
+    Abend-Briefings desselben Tages. Ein Anker vom Vortag liegt weit vor jeder
+    Untergrenze (Rueckblick 4 h) und beendet die Sperre folglich nie. Oeffnet
+    das Fenster erst in der Zukunft, ist die Untergrenze `now` — ein Versuch
+    liegt immer in der Vergangenheit, es gibt also nichts zu beenden.
+
+    🔴 Ausdruecklich NICHT fuer NowCast (Regen-/Gewitter-Onset): der bleibt
+    zeitkritisch und laeuft unveraendert weiter. `check_nowcast_gate()` ruft
+    diese Funktion deshalb nicht auf.
+
+    🔴 Rein lesend. Kein Melde-Gedaechtnis (`AlertStateService`), keine
+    Sperrzeit (`ThrottleStore`), kein Tageszaehler, kein `alert_log`-Eintrag —
+    dieselbe Eigenschaft, die #1233 fuer die Ruhezeit-Unterdrueckung
+    zusichert. Und insbesondere kein Verbrauch von `report_config.skip_next`:
+    `briefing_due_at` MUSS seiteneffektfrei sein (der Trip-Sammellauf
+    `_get_active_trips()` ist es NICHT, er konsumiert `skip_next` per
+    Read-Modify-Write mit `save_trip()`).
+
+    Args:
+        user_id: echte Nutzer-Kennung (Mandantentrennung, nie `"default"`).
+        entity_id/entity_type: PROTOKOLL-Kennung des Briefing-Ankers — Trip
+            `(trip.id, "trip")`, Ortsvergleich `(preset_id, "compare")`, genau
+            so, wie beide Briefing-Pfade ihn schreiben
+            (`trip_report_scheduler.py`, `scheduler_dispatch_service.py`).
+        now: Zeitpunkt des Alarm-Laufs. Pflicht-Parameter ohne Systemuhr-
+            Rueckfall (ADR-0051 Regel 3).
+        zone: Ortszone der Entitaet (#1726) — Trip `anchor_tz(trip, now)`,
+            Ortsvergleich `first_resolvable_tz(...)`. Beantwortet „welche
+            Ortszeit war/ist gemeint", und genau so steht es in der Diagnose.
+        briefing_due_at: das bestehende Faelligkeits-Praedikat der Entitaet,
+            gegen einen Zeitpunkt ausgewertet. Es wird GEFRAGT, nicht neu
+            gerechnet — eine eigene Zeitrechnung waere die vierte Fassung
+            derselben Regel (eine liegt bereits im Frontend,
+            `cockpitHelpers568.ts::deriveNextSend`).
+        vorlauf_minuten: Fensterbreite, s. `BRIEFING_VORLAUF_MINUTEN`.
+
+    Returns:
+        True, wenn die Meldung unterdrueckt werden soll.
+    """
+    faellig_ab = _naechste_faelligkeit(now, briefing_due_at, vorlauf_minuten)
+    if faellig_ab is None:
+        return False
+
+    untergrenze = (
+        _fensterbeginn_untergrenze(now, briefing_due_at)
+        if faellig_ab <= now
+        else now
+    )
+    letzter_versuch = last_briefing_at(
+        user_id=user_id, entity_id=entity_id, entity_type=entity_type,
+    )
+    if letzter_versuch is not None and letzter_versuch > untergrenze:
+        logger.debug(
+            "Keine Sperre fuer %s: das anstehende Briefing wurde um %s Ortszeit "
+            "bereits versucht.",
+            entity_id, letzter_versuch.astimezone(zone).strftime("%H:%M"),
+        )
+        return False
+
+    logger.debug(
+        "Meldung unterdrueckt: Briefing fuer %s ist um %s Ortszeit faellig und "
+        "noch nicht versucht.",
+        entity_id, faellig_ab.astimezone(zone).strftime("%H:%M"),
+    )
+    return True
 
 
 def record_nowcast_sent(

--- a/src/services/compare_alert.py
+++ b/src/services/compare_alert.py
@@ -22,6 +22,7 @@ from app.config import Settings
 from app.loader import compare_preset_to_dict, load_all_locations, load_compare_presets
 from services import alert_channel_threshold, alert_daily_limit, alert_log
 import services.alert_urgency as alert_urgency
+from services.alert_gate import check_briefing_imminent
 from services.alert_preset import _PRESET_TABLE
 from services.alert_state import AlertStateService
 from services.compare_alert_channels import (
@@ -30,6 +31,7 @@ from services.compare_alert_channels import (
 )
 from services.compare_alert_guard import is_silenced
 from services.compare_location_weather_source import CompareLocationWeatherSource
+from services.compare_slot_scheduler import presets_due_for_hour
 from services.compare_weather_snapshot import CompareWeatherSnapshotService
 from services.deviation_alert_engine import DeviationAlertEngine
 from services.notification_service import NotificationService
@@ -186,6 +188,23 @@ class CompareAlertService:
             )
             if quiet_hours_active:
                 logger.debug(f"Compare-Alert quiet hours active for preset {preset_id}")
+                continue
+
+            # Issue #1594: steht das geplante Briefing dieses Vergleichs
+            # unmittelbar bevor und wurde es noch nicht versucht, waere dieser
+            # Alarm eine Doppel-Meldung. Zusaetzliche, rein lesende Stufe nach
+            # der Ruhezeit und VOR dem Wetterabruf. Die Faelligkeit wird GEFRAGT —
+            # `presets_due_for_hour` prueft `is_silenced`, `end_date`,
+            # `weekly` und die Slot-Schalter selbst, ein Preset ohne geplantes
+            # Briefing faellt dadurch von allein aus der Sperre (AC-7).
+            if check_briefing_imminent(
+                user_id=self._user_id, entity_id=preset_id, entity_type="compare",
+                now=now, zone=config.zone,
+                briefing_due_at=lambda moment: bool(
+                    presets_due_for_hour([preset], all_locations, moment)
+                ),
+            ):
+                logger.debug(f"Compare-Alert briefing imminent for preset {preset_id}")
                 continue
 
             # Issue #1584 Scheibe C: das Tagesfenster dieses Presets kommt aus

--- a/src/services/compare_official_alert.py
+++ b/src/services/compare_official_alert.py
@@ -34,12 +34,14 @@ from output.renderers.alert.official_alerts import (
 )
 from services import alert_channel_threshold, alert_daily_limit, alert_log
 import services.alert_urgency as alert_urgency
+from services.alert_gate import check_briefing_imminent
 from services.alert_state import AlertStateService
 from services.compare_alert_channels import (
     effective_compare_channels,
     effective_compare_telegram_style,
 )
 from services.compare_alert_guard import is_silenced
+from services.compare_slot_scheduler import presets_due_for_hour
 from services.deviation_alert_engine import DeviationAlertEngine
 from services.notification_service import NotificationService
 from services.official_alerts import get_official_alerts_for_location
@@ -131,6 +133,22 @@ class CompareOfficialAlertService:
             context_label=preset_id,
         ):
             logger.debug(f"Compare official alert quiet hours active for preset {preset_id}")
+            return False
+
+        # Issue #1594: dieselbe Stufe wie im Vergleichs-Aenderungspfad, gleiche
+        # Position (nach der Ruhezeit, VOR `_detect()`). Rein lesend — die
+        # #1233-Zusicherung „kein State-Verbrauch bei Unterdrueckung" bleibt
+        # damit auch fuer diese Stufe erhalten. Ein Preset OHNE geplantes
+        # Briefing faellt aus der Sperre (AC-7/AC-9): `presets_due_for_hour`
+        # prueft Stilllegung, `end_date`, `weekly` und Slot-Schalter selbst.
+        if check_briefing_imminent(
+            user_id=self._user_id, entity_id=preset_id, entity_type="compare",
+            now=datetime.now(timezone.utc), zone=zone,
+            briefing_due_at=lambda moment: bool(
+                presets_due_for_hour([preset], all_locations, moment)
+            ),
+        ):
+            logger.debug(f"Compare official alert briefing imminent for {preset_id}")
             return False
 
         locs = [all_locations[lid] for lid in location_ids if lid in all_locations]

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -232,6 +232,16 @@ class TripAlertService:
             logger.debug(f"Alert suppressed: quiet hours active for trip {trip.id}")
             return False
 
+        # 1a2. Issue #1594: steht das geplante Briefing dieses Trips unmittelbar
+        # bevor und wurde es noch nicht versucht, waere dieser Alarm eine
+        # Doppel-Meldung — der Wetterstand kommt Minuten spaeter vollstaendig
+        # im Briefing an. Zusaetzliche, rein lesende Stufe nach der Ruhezeit
+        # und VOR dem Abruf; die bestehende Reihenfolge bleibt unangetastet
+        # (Vereinheitlichung ist #1467 S4).
+        if self._is_briefing_imminent(trip, now_utc):
+            logger.debug(f"Alert suppressed: briefing imminent for trip {trip.id}")
+            return False
+
         # 1b. Throttle-Check mit per-trip Cooldown (AC-2/3)
         if self._is_throttled_with_cooldown(trip):
             logger.debug(f"Alert throttled for trip {trip.id}")
@@ -700,6 +710,34 @@ class TripAlertService:
             now, trip.alert_quiet_from, trip.alert_quiet_to,
             anchor_tz(trip, now),
             context_label=trip.id,
+        )
+
+    def _is_briefing_imminent(self, trip: "Trip", now: datetime) -> bool:
+        """Issue #1594: Steht fuer diesen Trip unmittelbar ein geplantes
+        Briefing an, das noch nicht versucht wurde?
+
+        DER gemeinsame Adapter beider Trip-Alarmarten — Aenderungsalarm
+        (`check_and_send_alerts`) und amtliche Warnung
+        (`_send_official_alert_only`) fragen dieselbe Stufe, direkt nach der
+        Ruhezeit und VOR jedem Abruf. Rein lesend; das Faelligkeits-Praedikat
+        ist die seiteneffektfreie Fassung aus dem Briefing-Scheduler, die
+        `skip_next` NICHT verbraucht.
+
+        Der Anker liegt unter der PROTOKOLL-Kennung `(trip.id, "trip")` — so
+        schreibt ihn `trip_report_scheduler` (`briefing_entity_type="trip"`);
+        eine andere Kennung faende ihn nie, die Sperre bliebe nach einem
+        gescheiterten Versand das ganze Nachholfenster ueber stehen, ohne dass
+        es auffiele.
+        """
+        from services.alert_gate import check_briefing_imminent
+        from services.trip_report_scheduler import trip_briefing_due_at
+
+        return check_briefing_imminent(
+            user_id=self._user_id, entity_id=trip.id, entity_type="trip",
+            now=now, zone=anchor_tz(trip, now),
+            briefing_due_at=lambda moment: trip_briefing_due_at(
+                trip, moment, user_id=self._user_id,
+            ),
         )
 
     def _is_throttled_with_cooldown(self, trip: "Trip") -> bool:
@@ -1446,6 +1484,12 @@ class TripAlertService:
         now_utc = datetime.now(timezone.utc)
         if self._is_quiet_hours(trip, now_utc):
             logger.debug(f"Official alert suppressed: quiet hours active for trip {trip.id}")
+            return False
+        # Issue #1594: dieselbe Stufe wie im Aenderungspfad, gleiche Position
+        # (nach der Ruhezeit) — die Warnung erscheint im Briefing, das
+        # unmittelbar folgt (AC-16), statt zusaetzlich als eigene Nachricht.
+        if self._is_briefing_imminent(trip, now_utc):
+            logger.debug(f"Official alert suppressed: briefing imminent for trip {trip.id}")
             return False
         if self._is_throttled_with_cooldown(trip):
             logger.debug(f"Official alert throttled for trip {trip.id}")

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -120,6 +120,87 @@ def _is_transient_fetch_error(exc: Exception) -> bool:
 logger = logging.getLogger("trip_report_scheduler")
 
 
+def _slot_stunde(trip: "Trip", report_type: str) -> int:
+    """Konfigurierte Ortsstunde eines Slots — EINE Fassung fuer den Sammellauf
+    und fuer das Faelligkeits-Praedikat (#1594)."""
+    rc = trip.report_config
+    zeit = None
+    if rc is not None:
+        zeit = rc.morning_time if report_type == "morning" else rc.evening_time
+    if zeit is not None:
+        return zeit.hour
+    return 7 if report_type == "morning" else 18
+
+
+def trip_briefing_due_at(
+    trip: "Trip", moment: datetime, *, user_id: str,
+) -> bool:
+    """Ist fuer diesen Trip zum Zeitpunkt ``moment`` ein geplantes Briefing
+    faellig? — das REINE Faelligkeits-Praedikat (Issue #1594).
+
+    Beantwortet dieselbe Frage wie :meth:`TripReportSchedulerService._collect_due_trips`
+    (Aktiv-Filter + Faelligkeits-Fenster + Vermerk), aber SEITENEFFEKTFREI und
+    fuer EINEN Trip: kein `save_trip()`, kein Versand, keine Reservierung.
+
+    🔴 Ohne den ``skip_next``-Zweig aus ``_get_active_trips()``: der konsumiert
+    das Nutzer-Kennzeichen „naechstes Briefing ueberspringen" per
+    Read-Modify-Write MIT ``save_trip()`` bei JEDEM Aufruf. Wuerde die
+    Vorlauf-Sperre jene Methode mitbenutzen, verbrauchte sie den Wunsch im
+    15-Minuten-Alarmtakt, bevor der Briefing-Scheduler ihn je saehe — das
+    Briefing kaeme trotzdem. Fuer die Faelligkeit ist der Unterschied
+    folgenlos: ein uebersprungenes Briefing bleibt ein geplantes Briefing.
+
+    Alle uebrigen Aktiv-Filter sind zwingend enthalten (AC-8): Etappe am
+    Zieltag, ``paused_at``, ``report_config.enabled``, ``paused_until``. Fehlt
+    einer, schwiege der Alarm fuer einen Trip OHNE geplantes Briefing — ohne
+    Ersatz, also verschluckt statt ersetzt (Fehlerklasse #1555/#1584).
+
+    Args:
+        trip: der Trip.
+        moment: Zeitpunkt (UTC), gegen den geprueft wird — die Vorlauf-Sperre
+            wertet dasselbe Praedikat auch gegen spaetere Zeitpunkte aus.
+        user_id: echte Nutzer-Kennung (Mandantentrennung, nie ``"default"``) —
+            traegt den Vermerk-Speicher.
+    """
+    from services.trip_day import trip_local_now
+
+    if trip.paused_at is not None:
+        return False
+    rc = trip.report_config
+    if rc is not None:
+        if rc.enabled is False:
+            return False
+        if rc.paused_until is not None:
+            pu = rc.paused_until
+            if pu.tzinfo is None:
+                pu = pu.replace(tzinfo=timezone.utc)
+            if moment < pu:
+                return False
+
+    vor_ort = trip_local_now(trip, moment)
+    store = BriefingSlotStore(user_id)
+    for report_type, zieltag in (
+        ("morning", vor_ort.date()),
+        ("evening", vor_ort.date() + timedelta(days=1)),
+    ):
+        if trip.get_stage_for_date(zieltag) is None:
+            continue
+        stunde = _slot_stunde(trip, report_type)
+        if not stunde <= vor_ort.hour < stunde + NACHHOL_FENSTER_STUNDEN:
+            continue
+        # Der Vermerk beendet das Nachhol-Fenster, sobald das Briefing raus
+        # ist — sonst schwiege der Alarm bis zu drei Stunden nach einem
+        # bereits zugestellten Briefing. Nach einem GESCHEITERTEN Versand
+        # traegt er nicht (reserve-then-release, `:565-571`); dort endet die
+        # Sperre ueber den Briefing-Anker (`check_briefing_imminent`, R6).
+        if store.is_recorded(
+            trip.id, report_type, vor_ort.date(), zone=vor_ort.tzinfo,
+        ):
+            continue
+        return True
+    return False
+
+
 def _trend_note(thunder: str, precip_mm: float, wind_kmh: int) -> str | None:
     """Returns a hint text when conditions are notable, else None."""
     notes = []
@@ -757,16 +838,16 @@ class TripReportSchedulerService:
         _write_pending_data(path, data)
 
     def _get_morning_hour(self, trip: "Trip") -> int:
-        """Get configured morning hour for trip (default: 7)."""
-        if trip.report_config and trip.report_config.morning_time:
-            return trip.report_config.morning_time.hour
-        return 7
+        """Get configured morning hour for trip (default: 7).
+
+        Issue #1594: die Regel steht in `_slot_stunde()` — dieselbe Fassung,
+        die das Faelligkeits-Praedikat der Vorlauf-Sperre benutzt.
+        """
+        return _slot_stunde(trip, "morning")
 
     def _get_evening_hour(self, trip: "Trip") -> int:
-        """Get configured evening hour for trip (default: 18)."""
-        if trip.report_config and trip.report_config.evening_time:
-            return trip.report_config.evening_time.hour
-        return 18
+        """Get configured evening hour for trip (default: 18). S. oben."""
+        return _slot_stunde(trip, "evening")
 
     def _get_active_trips(self, report_type: str, now_utc: datetime) -> List["Trip"]:
         """

--- a/tests/helpers/alert_log_fixtures.py
+++ b/tests/helpers/alert_log_fixtures.py
@@ -41,6 +41,8 @@ from app.models import (
 )
 from app.trip import Stage, Trip, Waypoint
 
+from tests.helpers.briefing_zeiten import briefing_zeiten_fuer_trip
+
 LAT, LON = 47.0, 11.0
 
 def compare_data_root() -> Path:
@@ -143,7 +145,19 @@ def gust_alert_trip(
             trip_id=trip_id, metrics=metrics, metric_alert_levels=levels,
         ),
     )
-    trip.report_config = TripReportConfig(trip_id=trip_id, send_email=True, alert_on_changes=True)
+    # Issue #1594: ohne gesetzte Zeiten erbt `TripReportConfig` 07:00/18:00
+    # Ortszeit — der Trip waere dann zweimal taeglich 60 Minuten lang
+    # "Briefing steht bevor" und die neue Vorlauf-Sperre unterdrueckte den
+    # Alarm aus einem ZWEITEN Grund. Die Tests hier messen Protokoll und
+    # Kanaele, nicht die Sperre; die Zeiten sind Vorbedingung, keine
+    # Zusicherung. Die Zone kommt aus derselben Aufloesung, die auch die
+    # Sperre benutzt (`anchor_tz`) — eine andere waere ein Pruefort neben dem
+    # Wirkort.
+    morgen, abend = briefing_zeiten_fuer_trip(trip)
+    trip.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=True, alert_on_changes=True,
+        morning_time=morgen, evening_time=abend,
+    )
     trip.alert_cooldown_minutes = 0
     trip.official_alert_triggers_enabled = False
     if alert_channels is not None:

--- a/tests/helpers/briefing_imminent_fixtures.py
+++ b/tests/helpers/briefing_imminent_fixtures.py
@@ -590,3 +590,52 @@ def briefing_anker_setzen(
         user_id=user_id, entity_id=entity_id, entity_type=entity_type, at=moment,
     )
     return moment
+
+
+def briefing_versand_gescheitert(
+    user_id: str, entity_id: str, *, entity_type: str, kind: str,
+    vor_minuten: float = 0.0,
+) -> datetime:
+    """Hinterlaesst genau den Zustand, den ein GESCHEITERTER Briefing-Versand
+    hinterlaesst — ueber die Produktiv-Schreiber, nicht per Handschrift.
+
+    Zwei Spuren, beide aus dem Fehler-Zweig beider Versandpfade (#1629,
+    ``trip_report_scheduler.py:1483-1485``,
+    ``scheduler_dispatch_service.py:561-566``):
+    ``record_briefing_dispatch_failure()`` und — ueber
+    ``_anchor_and_reset()`` → ``write_anchor_and_reset_memory()`` — der
+    Briefing-Anker.
+
+    🔴 KEIN Idempotenz-Vermerk: den nimmt der Fehlschlag zurueck
+    (reserve-then-release, ``trip_report_scheduler.py:565-571``). Genau
+    dadurch bleibt der Trip das volle Nachholfenster ueber „faellig" — die
+    Ausgangslage des 4-Stunden-Schweifs (Risiko R6).
+    """
+    from services.alert_briefing_anchor import (
+        record_briefing_dispatch_failure, record_briefing_sent,
+    )
+
+    moment = datetime.now(timezone.utc) - timedelta(minutes=vor_minuten)
+    record_briefing_dispatch_failure(
+        user_id=user_id, kind=kind, entity_id=entity_id,
+        error=RuntimeError("Versand gescheitert (Testaufbau #1594 AC-5)"),
+    )
+    record_briefing_sent(
+        user_id=user_id, entity_id=entity_id, entity_type=entity_type, at=moment,
+    )
+    return moment
+
+
+def trip_briefing_vermerk_setzen(
+    user_id: str, trip_id: str, *, slot: str = "morning", tage: int = 0,
+) -> None:
+    """Der Idempotenz-Vermerk eines GELUNGENEN Trip-Briefings — ueber den
+    echten Speicher (``BriefingSlotStore.record_outcome``), mit demselben
+    Ausgang ``"sent"``, den der Versandpfad schreibt
+    (``VERMERK_AUSGAENGE``).
+    """
+    from services.briefing_slots import BriefingSlotStore
+
+    BriefingSlotStore(user_id).record_outcome(
+        trip_id, slot, ortstag(TRIP_ZONE, tage), "sent",
+    )

--- a/tests/helpers/briefing_imminent_fixtures.py
+++ b/tests/helpers/briefing_imminent_fixtures.py
@@ -1,0 +1,592 @@
+"""Gemeinsame Bausteine der Vorlauf-Sperre-Tests (Issue #1594).
+
+SPEC: docs/specs/modules/fix_1594_alarm_vorlauf_sperre.md
+
+Mock-frei: echte Trips/Presets/Orte auf Platte, echte Dienste, echte
+Zustandsdateien (``throttle_state.json``, ``alert_daily_count.json``,
+``alert_log.json``, ``alert_state``, ``briefing_anchor.json``). Ersetzt werden
+ausschliesslich die NETZ-Naehte (``_fetch_fresh_weather``,
+``_detect_triggered_locations``, ``_detect``) — und zwar durch echte
+Unterklassen mit echter Implementierung, die ihre Aufrufe zaehlen. Kein
+``Mock()``/``patch()``/``MagicMock``.
+
+**Warum die Zaehl-Naht der richtige Wirkort ist:** die neue Sperre sitzt an
+allen drei Einhaengepunkten VOR dem Wetter-/Warnungs-Abruf. „0 Abrufe" heisst
+damit „gesperrt", „>=1 Abruf" heisst „durchgelassen" — gemessen an der Stelle,
+an der die Sperre wirken SOLL, nicht an der, an der ihr Code steht.
+
+**Keine eingefrorene Systemuhr.** Alle drei Dienstpfade holen ihren Zeitpunkt
+selbst ueber ``datetime.now(timezone.utc)``. Statt die Uhr anzuhalten, legen
+diese Helfer die BRIEFING-ZEITEN relativ zur echten Uhr — ``stunde_versetzt(1)``
+liefert die Ortsstunde in einer Stunde. Der Pruefling muss die Faelligkeit dann
+gegen ``now + Vorlauf`` auswerten, um sie zu sehen. Fuer die reine
+Gate-Funktion, die ihren Zeitpunkt als PARAMETER bekommt, gilt das Gegenteil:
+dort wird ein Zeitpunkt weit weg von der Systemuhr uebergeben, damit ein
+Rueckfall auf die Systemuhr sichtbar WUERDE (Regel aus
+``reference_freeze_time_macht_parameter_vs_systemuhr_unfalsifizierbar``).
+
+Pfadregel #1409: alles ueber ``app.loader.get_data_dir()``/``get_briefings_dir()``,
+nie ueber einen festen Hauptrepo-Pfad.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from datetime import date as date_type
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+from app.config import Settings
+from app.loader import get_briefings_dir, get_data_dir
+
+from tests.helpers.compare_briefings import write_compare_briefings
+
+# Ortszonen der beiden Koordinaten-Saetze — gemessen, nicht angenommen
+# (identisch zu tests/helpers/nowcast_gate_fixtures.py):
+#   tz_for_coords(TRIP_LAT, TRIP_LON) -> Atlantic/Reykjavik (ganzjaehrig UTC+0)
+#   tz_for_coords(LOC_LAT, LOC_LON)   -> Europe/Vienna
+# Der Trip liegt bewusst auf UTC+0: Ortstag und Weltzeittag fallen nie
+# auseinander, damit die Etappen-/Slot-Rechnung der Tests nicht um Mitternacht
+# kippt.
+TRIP_ZONE = ZoneInfo("Atlantic/Reykjavik")
+LOCATION_ZONE = ZoneInfo("Europe/Vienna")
+
+TRIP_LAT, TRIP_LON = 64.13, -21.90
+LOC_LAT, LOC_LON = 47.0, 11.0
+
+# Ruhezeit-Fenster, das „jetzt" sicher NICHT enthaelt (2–3 h voraus). Gesetzt
+# statt weggelassen, damit der Wert real ausgewertet wird, statt in den
+# `not quiet_from`-Kurzschluss zu laufen.
+def ruhezeit_woanders(*, zone: ZoneInfo = LOCATION_ZONE) -> tuple[str, str]:
+    jetzt = datetime.now(timezone.utc).astimezone(zone)
+    return (
+        (jetzt + timedelta(hours=2)).strftime("%H:%M"),
+        (jetzt + timedelta(hours=3)).strftime("%H:%M"),
+    )
+
+
+# ───────────────────────────── Nutzer & Aufraeumen ──────────────────────────
+
+
+def fresh_uid(prefix: str) -> str:
+    return f"tdd-1594-{prefix}-{uuid.uuid4().hex[:6]}"
+
+
+def clean_uid(user_id: str) -> None:
+    d = get_data_dir(user_id)
+    if d.exists():
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def write_user_tier(user_id: str, tier: str = "premium") -> None:
+    d = get_data_dir(user_id)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "user.json").write_text(json.dumps({"id": user_id, "tier": tier}))
+
+
+def settings_email_only() -> Settings:
+    """``can_send_email() == True``; Telegram und SMS ausdruecklich AUS.
+
+    ``Settings`` wird IMMER vollstaendig konstruiert: ein weggelassenes Feld
+    faellt bei pydantic still auf die Prod-``.env`` zurueck — genau so gingen am
+    2026-08-03 echte Telegram-Nachrichten an den Produktiv-Chat des PO (#1477).
+    """
+    return Settings(
+        smtp_host="dummy.invalid", smtp_user="dummy", smtp_pass="dummy",
+        mail_to="dummy@example.invalid",
+        telegram_bot_token="", telegram_chat_id="",
+        seven_api_key="", sms_to="",
+    )
+
+
+# ─────────────────────── Ortsstunden relativ zur echten Uhr ─────────────────
+
+
+def stunde_versetzt(stunden: int, *, zone: ZoneInfo) -> int:
+    """Die Ortsstunde in ``zone``, die in ``stunden`` Stunden gilt."""
+    ziel = datetime.now(timezone.utc) + timedelta(hours=stunden)
+    return ziel.astimezone(zone).hour
+
+
+def uhrzeit(stunde: int) -> str:
+    """``"HH:00:00"`` — das Format, in dem Trip- und Preset-Slots liegen.
+
+    Go kappt Versandzeiten ohnehin auf die volle Stunde
+    (``internal/store/slot_hour_normalization.go``), Minuten waeren hier also
+    eine Genauigkeit, die es im Produktivsystem nicht gibt.
+    """
+    return f"{stunde % 24:02d}:00:00"
+
+
+def ortstag(zone: ZoneInfo, tage: int = 0) -> date_type:
+    return (datetime.now(timezone.utc).astimezone(zone) + timedelta(days=tage)).date()
+
+
+# ─────────────────────────────── Trips schreiben ────────────────────────────
+
+
+def _waypoints(lat: float, lon: float, prefix: str) -> list[dict]:
+    return [
+        {
+            "id": f"{prefix}0", "name": "Start", "lat": lat, "lon": lon,
+            "elevation_m": 500.0, "arrival_calculated": "00:00",
+        },
+        {
+            "id": f"{prefix}1", "name": "Ende", "lat": lat + 0.1, "lon": lon + 0.1,
+            "elevation_m": 600.0, "arrival_calculated": "23:59",
+        },
+    ]
+
+
+def write_trip(
+    user_id: str,
+    trip_id: str,
+    *,
+    morgen_stunde: int,
+    abend_stunde: int,
+    enabled: bool = True,
+    paused_at: Optional[str] = None,
+    paused_until: Optional[datetime] = None,
+    skip_next: bool = False,
+    etappen_tage: tuple[int, ...] = (0, 1, 2),
+    quiet: Optional[tuple[str, str]] = None,
+    cooldown_minutes: int = 0,
+) -> Path:
+    """Schreibt einen Trip als ``briefings/<id>.json`` — das EINZIGE Format,
+    aus dem ``load_all_trips()`` seit dem #1250-Cutover liest.
+
+    Bewusst roh geschrieben statt ueber ``app.loader.save_trip()``: jenes
+    rechnet ``arrival_calculated`` per Naismith neu (Compute-on-Save, #802) und
+    zerstoert damit die ganztaegig aktive Etappe (00:00–23:59), auf die der
+    Radar-Pfad angewiesen ist.
+
+    ``etappen_tage`` sind Tagesversaetze zum ORTStag des Trips. Der Default
+    ``(0, 1, 2)`` deckt heute, morgen und uebermorgen ab: der Morgen-Slot
+    zielt auf den Ortstag, der Abend-Slot auf den Folgetag — und ein Lauf
+    kurz vor Mitternacht wertet die Faelligkeit gegen ``now + Vorlauf`` aus,
+    also bereits im naechsten Ortstag. Ohne den dritten Tag scheiterte ein
+    Abend-Slot-Test in der Randstunde still an der fehlenden Etappe, statt an
+    der Sperre.
+    """
+    stages = [
+        {
+            "id": f"S{versatz}", "name": f"Tag {versatz}",
+            "date": ortstag(TRIP_ZONE, versatz).isoformat(),
+            "waypoints": _waypoints(TRIP_LAT, TRIP_LON, f"WP{versatz}"),
+        }
+        for versatz in etappen_tage
+    ]
+    data: dict = {
+        "id": trip_id,
+        "name": f"Trip {trip_id}",
+        "kind": "route",
+        "alert_cooldown_minutes": cooldown_minutes,
+        "alert_quiet_from": (quiet or (None, None))[0],
+        "alert_quiet_to": (quiet or (None, None))[1],
+        "stages": stages,
+        "report_config": {
+            "trip_id": trip_id,
+            "enabled": enabled,
+            "morning_time": uhrzeit(morgen_stunde),
+            "evening_time": uhrzeit(abend_stunde),
+            "send_email": True,
+            "send_telegram": False,
+            "alert_on_changes": True,
+            "paused_until": paused_until.isoformat() if paused_until else None,
+            "skip_next": skip_next,
+        },
+    }
+    if paused_at is not None:
+        data["paused_at"] = paused_at
+
+    briefings = get_briefings_dir(user_id)
+    briefings.mkdir(parents=True, exist_ok=True)
+    path = briefings / f"{trip_id}.json"
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return path
+
+
+def read_trip_raw(user_id: str, trip_id: str) -> dict:
+    """Der PERSISTIERTE Stand — nicht das Objekt im Speicher.
+
+    ``_get_active_trips()`` verbraucht ``skip_next`` per Read-Modify-Write MIT
+    ``save_trip()``; ein Test, der nur das uebergebene Objekt prueft, sieht
+    diesen Schreibvorgang nicht.
+    """
+    return json.loads((get_briefings_dir(user_id) / f"{trip_id}.json").read_text())
+
+
+def load_trip_obj(user_id: str, trip_id: str):
+    from app.loader import load_all_trips
+
+    for trip in load_all_trips(user_id=user_id):
+        if trip.id == trip_id:
+            return trip
+    raise AssertionError(f"Trip {trip_id!r} nicht ladbar fuer {user_id!r}")
+
+
+# ───────────────────────────── Presets schreiben ────────────────────────────
+
+
+def write_location(user_id: str, loc_id: str = "loc-1594") -> None:
+    from app.loader import save_location
+    from app.user import SavedLocation
+
+    save_location(
+        SavedLocation(
+            id=loc_id, name="Testort", lat=LOC_LAT, lon=LOC_LON, elevation_m=1000,
+        ),
+        user_id=user_id,
+    )
+
+
+def compare_preset(
+    preset_id: str,
+    *,
+    morgen_stunde: Optional[int],
+    abend_stunde: Optional[int] = None,
+    location_ids: Optional[list[str]] = None,
+    schedule: str = "daily",
+    paused_at: Optional[str] = None,
+    archived_at: Optional[str] = None,
+    end_date: Optional[str] = None,
+    quiet: Optional[tuple[str, str]] = None,
+    cooldown_minutes: int = 0,
+) -> dict:
+    """Vergleichs-Preset im Bestandsschema.
+
+    ``morgen_stunde``/``abend_stunde`` auf ``None`` schaltet den jeweiligen
+    Slot AB (``morning_enabled``/``evening_enabled`` = False) — der Fall
+    „Preset ohne geplantes Briefing", ohne dass das Preset stillgelegt waere.
+    """
+    preset: dict = {
+        "id": preset_id,
+        "name": f"Vergleich {preset_id}",
+        "user_id": "default",
+        "location_ids": location_ids or ["loc-1594"],
+        "schedule": schedule,
+        "weekday": None,
+        "profil": "ALLGEMEIN",
+        "hour_from": 9,
+        "hour_to": 16,
+        "empfaenger": ["dummy@example.invalid"],
+        "created_at": "2026-08-01T00:00:00Z",
+        "morning_enabled": morgen_stunde is not None,
+        "morning_time": uhrzeit(morgen_stunde if morgen_stunde is not None else 6),
+        "evening_enabled": abend_stunde is not None,
+        "evening_time": uhrzeit(abend_stunde if abend_stunde is not None else 18),
+        "alert_cooldown_minutes": cooldown_minutes,
+    }
+    if paused_at is not None:
+        preset["paused_at"] = paused_at
+    if archived_at is not None:
+        preset["archived_at"] = archived_at
+    if end_date is not None:
+        preset["end_date"] = end_date
+    if quiet is not None:
+        preset["alert_quiet_from"], preset["alert_quiet_to"] = quiet
+    return preset
+
+
+def write_presets(user_id: str, presets: list[dict]) -> Path:
+    return write_compare_briefings(get_data_dir(user_id), presets)
+
+
+# ══════════════════ Dienstpfade mit ersetzter Netz-Naht ═════════════════════
+
+
+def trip_change_alert_run(user_id: str, trip_id: str) -> int:
+    """Ein echter ``check_and_send_alerts()``-Lauf des Trip-Aenderungsalarms.
+
+    Returns: Anzahl der Wetterabrufe (0 = vor dem Abruf gesperrt).
+    """
+    from services.trip_alert import TripAlertService
+
+    class _Zaehlend(TripAlertService):
+        fetch_aufrufe = 0
+
+        def _fetch_fresh_weather(self, cached_weather):
+            type(self).fetch_aufrufe += 1
+            return []
+
+    _Zaehlend.fetch_aufrufe = 0
+    dienst = _Zaehlend(
+        settings=settings_email_only(), throttle_hours=2, user_id=user_id,
+    )
+    dienst.check_and_send_alerts(load_trip_obj(user_id, trip_id), cached_weather=[])
+    return _Zaehlend.fetch_aufrufe
+
+
+def trip_official_alert_run(user_id: str, trip_id: str) -> tuple[bool, list]:
+    """Ein echter ``_send_official_alert_only()``-Lauf (Trip, amtliche Warnung).
+
+    Diese Methode IST die Aufrufstelle ``trip_alert.py:1447``; der oeffentliche
+    Einstieg darueber holt die Warnungen ueber das Netz — sie werden hier als
+    echte ``OfficialAlert``-Objekte hereingereicht, genau wie der Produktivpfad
+    es tut.
+
+    Returns: ``(versendet, mail_sink-Aufrufe)``.
+    """
+    from services.official_alerts.models import OfficialAlert
+    from services.trip_alert import TripAlertService
+
+    gesendet: list = []
+    dienst = TripAlertService(
+        settings=settings_email_only(), throttle_hours=2, user_id=user_id,
+        mail_sink=lambda *a, **kw: gesendet.append((a, kw)),
+    )
+    warnung = OfficialAlert(
+        source="test-1594", hazard="wind", level=3,
+        label="Sturmwarnung", region_label="Testregion",
+    )
+    # Segment-Kennungen sind numerische Strings (`format_segment_reference`).
+    versendet = dienst._send_official_alert_only(
+        load_trip_obj(user_id, trip_id), [(warnung, ["1"])],
+    )
+    return bool(versendet), gesendet
+
+
+def compare_change_alert_run(user_id: str) -> int:
+    """Echter ``CompareAlertService.check_all_compare_presets()``-Lauf.
+
+    Gezaehlt wird ``_detect_triggered_locations`` — die Netz-Naht direkt hinter
+    der Ruhezeit-Pruefung (``compare_alert.py:183``), also genau dort, wo die
+    neue Sperre einsortiert wird.
+    """
+    from services.compare_alert import CompareAlertService
+
+    class _Zaehlend(CompareAlertService):
+        detect_aufrufe = 0
+
+        def _detect_triggered_locations(
+            self, preset_id, location_ids, all_locations, config, day_window
+        ):
+            type(self).detect_aufrufe += 1
+            return []
+
+    _Zaehlend.detect_aufrufe = 0
+    _Zaehlend(settings=settings_email_only(), user_id=user_id).check_all_compare_presets()
+    return _Zaehlend.detect_aufrufe
+
+
+def compare_official_alert_run(user_id: str) -> int:
+    """Echter ``CompareOfficialAlertService.check_all_compare_presets()``-Lauf.
+
+    Gezaehlt wird ``_detect`` — die Netz-Naht direkt hinter der
+    Ruhezeit-Pruefung (``compare_official_alert.py:126``).
+    """
+    from services.compare_official_alert import CompareOfficialAlertService
+
+    class _Zaehlend(CompareOfficialAlertService):
+        detect_aufrufe = 0
+
+        def _detect(self, preset_id, locs, sources=None):
+            type(self).detect_aufrufe += 1
+            return ([], {})
+
+    _Zaehlend.detect_aufrufe = 0
+    _Zaehlend(settings=settings_email_only(), user_id=user_id).check_all_compare_presets()
+    return _Zaehlend.detect_aufrufe
+
+
+# ─────────────── Amtliche Warnungen: echte Quelle statt Netz ────────────────
+
+
+class FakeOfficialAlertSource:
+    """Echte ``OfficialAlertSource`` (strukturelles Subtyping, kein Mock):
+    zustaendig fuer EINEN Punkt (0.05-Toleranz), liefert steuerbare Warnungen
+    und zaehlt ihre Abrufe. Muster aus ``tests/tdd/test_compare_official_alert.py``.
+    """
+
+    def __init__(self, lat: float = LOC_LAT, lon: float = LOC_LON, alerts=None):
+        self._lat, self._lon = lat, lon
+        self._alerts = alerts if alerts is not None else [official_alert()]
+        self.fetch_calls = 0
+
+    def covers(self, lat: float, lon: float) -> bool:
+        return abs(lat - self._lat) < 0.05 and abs(lon - self._lon) < 0.05
+
+    def fetch(self, lat: float, lon: float, **kwargs):
+        self.fetch_calls += 1
+        return list(self._alerts)
+
+
+def official_alert(level: int = 3, hazard: str = "wind", label: str = "Sturmwarnung"):
+    """Eine amtliche Warnung, deren Gueltigkeit die echte Uhr umschliesst — der
+    Standard-Zeitfenster-Filter ``[now, +inf)`` wuerde sie sonst wegwerfen."""
+    from services.official_alerts.models import OfficialAlert
+
+    jetzt = datetime.now(timezone.utc)
+    return OfficialAlert(
+        source="test-1594", hazard=hazard, level=level, label=label,
+        valid_from=jetzt - timedelta(hours=1),
+        valid_to=jetzt + timedelta(hours=12),
+        region_label="Testregion",
+    )
+
+
+class nur_diese_warnquelle:
+    """Ersetzt die global registrierten Warnquellen fuer die Dauer des Blocks.
+
+    Kein Netz: die echten Quellen (GeoSphere, MeteoAlarm, ...) wuerden sonst
+    HTTP sprechen. Der Vorzustand wird vollstaendig wiederhergestellt.
+    """
+
+    def __init__(self, quelle):
+        self._quelle = quelle
+        self._backup: list = []
+
+    def __enter__(self):
+        import services.official_alerts.base as b
+
+        self._modul = b
+        self._backup = list(b._REGISTERED_SOURCES)
+        b._REGISTERED_SOURCES.clear()
+        b._REGISTERED_SOURCES.append(self._quelle)
+        return self._quelle
+
+    def __exit__(self, *exc):
+        self._modul._REGISTERED_SOURCES.clear()
+        self._modul._REGISTERED_SOURCES.extend(self._backup)
+        return False
+
+
+def compare_official_versand_lauf(user_id: str) -> tuple[int, list]:
+    """Echter Lauf des amtlichen Vergleichspfads MIT echter Warnquelle — hier
+    entsteht heute ein tatsaechlicher Versand samt Melde-Gedaechtnis,
+    Sperrzeit, Tageszaehler und Protokoll-Eintrag.
+
+    Genau diese Buchungen darf die neue Sperre NICHT ausloesen (AC-10/AC-13);
+    ein Lauf mit abgeklemmter Erkennung koennte das gar nicht zeigen.
+
+    Returns: ``(Rueckgabewert des Dienstes, mail_sink-Aufrufe)``.
+    """
+    from services.compare_official_alert import CompareOfficialAlertService
+
+    mails: list = []
+    with nur_diese_warnquelle(FakeOfficialAlertSource()):
+        sent = CompareOfficialAlertService(
+            settings=settings_email_only(), user_id=user_id,
+            mail_sink=lambda subject, body: mails.append((subject, body)),
+        ).check_all_compare_presets()
+    return sent, mails
+
+
+# ══════════════════ Briefing-Renderer (die Ersetzungs-Probe) ════════════════
+
+
+def render_trip_briefing_html(official_alerts: list) -> str:
+    """Rendert ein echtes Trip-Briefing (HTML-Mail) mit den uebergebenen
+    amtlichen Warnungen am Segment — der Pfad, ueber den `seg.official_alerts`
+    im Warn-Block landet (`src/output/renderers/email/html.py:1565-1595`).
+
+    Das ist die Probe fuer die tragende Rechtfertigung der ganzen Scheibe: die
+    unterdrueckte Meldung wird ERSETZT, nicht verschluckt.
+    """
+    from app.metric_catalog import build_default_display_config
+    from app.models import (
+        ForecastDataPoint, ForecastMeta, GPXPoint, NormalizedTimeseries, Provider,
+        SegmentWeatherData, SegmentWeatherSummary, ThunderLevel, TripSegment,
+    )
+    from output.renderers.email.html import render_html
+
+    segment = TripSegment(
+        segment_id=1,
+        start_point=GPXPoint(lat=42.13, lon=9.13, elevation_m=900.0),
+        end_point=GPXPoint(lat=42.10, lon=9.18, elevation_m=1450.0),
+        start_time=datetime(2026, 7, 11, 8, 0, tzinfo=timezone.utc),
+        end_time=datetime(2026, 7, 11, 12, 0, tzinfo=timezone.utc),
+        duration_hours=4.0, distance_km=14.5, ascent_m=820.0, descent_m=440.0,
+    )
+    meta = ForecastMeta(
+        provider=Provider.OPENMETEO, model="demo", grid_res_km=1.3,
+        run=datetime(2026, 7, 11, 0, 0, tzinfo=timezone.utc),
+    )
+    punkte = [
+        ForecastDataPoint(
+            ts=datetime(2026, 7, 11, h, 0, tzinfo=timezone.utc),
+            t2m_c=15.0 + h * 0.3, wind10m_kmh=15.0, precip_1h_mm=0.2,
+            cloud_total_pct=50, thunder_level=ThunderLevel.NONE,
+        )
+        for h in range(8, 14)
+    ]
+    aggregat = SegmentWeatherSummary(
+        temp_min_c=14.0, temp_max_c=22.0, temp_avg_c=18.0,
+        wind_max_kmh=22.0, gust_max_kmh=35.0, precip_sum_mm=0.8,
+        cloud_avg_pct=50, humidity_avg_pct=55, thunder_level_max=ThunderLevel.NONE,
+    )
+    seg_daten = SegmentWeatherData(
+        segment=segment, timeseries=NormalizedTimeseries(meta=meta, data=punkte),
+        aggregated=aggregat, fetched_at=datetime.now(timezone.utc), provider="demo",
+        official_alerts=list(official_alerts),
+    )
+    return render_html(
+        segments=[seg_daten], seg_tables=[[]], trip_name="Vorlauf-Testtour",
+        report_type="morning", dc=build_default_display_config(), night_rows=[],
+        thunder_forecast=None, changes=None, stage_name="Etappe 1",
+        stage_stats={"distance_km": 14.5, "ascent_m": 820}, multi_day_trend=None,
+        compact_summary="Guter Tag.", tz=LOCATION_ZONE, friendly_keys=set(),
+    )
+
+
+# ═════════════════════ Zustands- und Protokoll-Schnappschuss ════════════════
+
+
+def zustand_schnappschuss(user_id: str, entity_id: str) -> dict:
+    """Alles, was ein Alarm-Lauf schreiben KOENNTE — als eine vergleichbare
+    Struktur (AC-10 + AC-13).
+
+    Bewusst breit gelesen: Melde-Gedaechtnis, Sperrzeit-Ablage, Tageszaehler
+    UND das Alarm-Protokoll (beide Listen). Ein Schnappschuss, der nur eine
+    davon abdeckte, liesse genau die Buchung durch, die #1233 verbietet.
+    """
+    from services.alert_state import AlertStateService
+
+    d = get_data_dir(user_id)
+
+    def _json(name: str, default):
+        p = d / name
+        if not p.exists():
+            return default
+        try:
+            return json.loads(p.read_text())
+        except (OSError, ValueError):
+            return default
+
+    protokoll = _json("alert_log.json", {})
+    return {
+        "melde_gedaechtnis": AlertStateService(user_id=user_id).load(entity_id),
+        "sperrzeit": _json("throttle_state.json", {}),
+        "tageszaehler": _json("alert_daily_count.json", {}),
+        "protokoll_entries": (protokoll or {}).get("entries", []),
+        "protokoll_not_delivered": (protokoll or {}).get("not_delivered", []),
+    }
+
+
+def protokoll_eintraege(user_id: str) -> list:
+    """Beide Protokoll-Listen zusammen — fuer AC-13 (kein NEUER Eintrag)."""
+    schnappschuss = zustand_schnappschuss(user_id, "-")
+    return (
+        list(schnappschuss["protokoll_entries"])
+        + list(schnappschuss["protokoll_not_delivered"])
+    )
+
+
+def briefing_anker_setzen(
+    user_id: str, entity_id: str, entity_type: str, *, vor_minuten: float,
+) -> datetime:
+    """Schreibt den Briefing-Anker ueber den ECHTEN Schreiber
+    (``alert_briefing_anchor.record_briefing_sent``) — nicht per Handschrift in
+    die Datei. Damit misst der Test das Format, das der Pruefling selbst
+    schreibt und liest.
+    """
+    from services.alert_briefing_anchor import record_briefing_sent
+
+    moment = datetime.now(timezone.utc) - timedelta(minutes=vor_minuten)
+    record_briefing_sent(
+        user_id=user_id, entity_id=entity_id, entity_type=entity_type, at=moment,
+    )
+    return moment

--- a/tests/helpers/briefing_zeiten.py
+++ b/tests/helpers/briefing_zeiten.py
@@ -1,0 +1,81 @@
+"""Briefing-Zeiten fuer Test-Aufbauten, die NICHT in den Vorlauf der
+Alarm-Sperre (#1594) fallen.
+
+Hintergrund: seit #1594 schweigt der Aenderungs- und der amtliche Alarm, wenn
+fuer dieselbe Entitaet innerhalb der naechsten 60 Minuten ein geplantes
+Briefing ansteht, das noch nicht versucht wurde. Ein Bestandstest, der einen
+Alarm erwartet, misst dann nicht mehr seine eigene Zusicherung, sondern die
+Sperre — er wird taeglich in einem Zeitfenster rot und ausserhalb gruen.
+
+Die Bestandstests konfigurieren gar keine Briefing-Zeiten; sie erben die
+Modell-Vorgaben (``TripReportConfig``: 07:00/18:00 Ortszeit) bzw. den
+Migrations-Rueckfall der Vergleichs-Slots (06:00 Ortszeit). Damit ist jede
+solche Entitaet zweimal taeglich 60 Minuten lang „Briefing steht bevor".
+
+Dieses Modul liefert stattdessen Zeiten, die zu JEDER Wanduhrzeit ausserhalb
+des Vorlaufs liegen. Es haengt bewusst von keinem anderen Test-Helfer ab —
+sonst entstuende ein Import-Ring mit ``compare_briefings``.
+"""
+from __future__ import annotations
+
+from datetime import datetime, time, timezone
+from zoneinfo import ZoneInfo
+
+# Abstand zur JETZIGEN Ortsstunde. Warum drei und nicht eine Stunde:
+# `check_briefing_imminent()` tastet das Fenster [now, now + 60 min] ab, die
+# Faelligkeit selbst gilt fuer die volle Stunde (`slot.hour == hour`). Ein
+# Lauf um 14:59 Ortszeit sieht damit noch die Stunde 15 — ein Abstand von
+# einer Stunde waere je nach Minute mal drin und mal nicht. Zwei Stunden
+# genuegten rechnerisch; drei laesst Luft fuer Tests, die selbst eine Stunde
+# vorspulen.
+MORGEN_ABSTAND_STUNDEN = 3
+ABEND_ABSTAND_STUNDEN = 6
+
+
+def briefing_stunden_ausserhalb_des_vorlaufs(zone: ZoneInfo) -> tuple[int, int]:
+    """Morgen- und Abend-Briefingstunde in ``zone``, beide ausserhalb des
+    60-Minuten-Vorlaufs (#1594).
+
+    ``zone`` MUSS die Zone sein, in der der Pruefling die Faelligkeit
+    auswertet — fuer Trips ``anchor_tz(trip, now)``, fuer Vergleiche
+    ``first_resolvable_tz(...)``. Eine andere Zone waere eine Zusicherung am
+    falschen Ort: die Stunde saehe sicher aus und laege trotzdem im Fenster.
+    """
+    jetzt = datetime.now(timezone.utc).astimezone(zone).hour
+    return (
+        (jetzt + MORGEN_ABSTAND_STUNDEN) % 24,
+        (jetzt + ABEND_ABSTAND_STUNDEN) % 24,
+    )
+
+
+def briefing_zeiten_ausserhalb_des_vorlaufs(zone: ZoneInfo) -> tuple[time, time]:
+    """Dasselbe als ``time``-Paar — fuer ``TripReportConfig``."""
+    morgen, abend = briefing_stunden_ausserhalb_des_vorlaufs(zone)
+    return time(morgen, 0), time(abend, 0)
+
+
+def briefing_zeiten_fuer_trip(trip) -> tuple[time, time]:
+    """Zeiten ausserhalb des Vorlaufs in genau der Zone, in der die Sperre die
+    Faelligkeit DIESES Trips auswertet.
+
+    ``anchor_tz`` ist dieselbe Aufloesung, die ``trip_alert._is_briefing_
+    imminent()`` benutzt. Wer hier stattdessen eine feste Zone (oder die
+    Serverzone) einsetzt, rechnet am Wirkort vorbei: die Stunde saehe sicher
+    aus und laege bei einer Tour in einer anderen Zone trotzdem im Fenster.
+    """
+    from services.trip_day import anchor_tz
+
+    return briefing_zeiten_ausserhalb_des_vorlaufs(
+        anchor_tz(trip, datetime.now(timezone.utc))
+    )
+
+
+def briefing_zeiten_iso(zone: ZoneInfo) -> tuple[str, str]:
+    """Dasselbe als ``"HH:00:00"``-Paar — fuer Preset- und Trip-JSON.
+
+    Go kappt Versandzeiten ohnehin auf die volle Stunde
+    (``internal/store/slot_hour_normalization.go``), und die Faelligkeit
+    vergleicht nur die Stunde.
+    """
+    morgen, abend = briefing_stunden_ausserhalb_des_vorlaufs(zone)
+    return f"{morgen:02d}:00:00", f"{abend:02d}:00:00"

--- a/tests/helpers/compare_briefings.py
+++ b/tests/helpers/compare_briefings.py
@@ -19,21 +19,99 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 
-def write_compare_briefings(user_dir: Path, presets: list[dict]) -> Path:
+def _zone_des_presets(user_dir: Path, preset: dict):
+    """Die Zone, in der der Pruefling die Faelligkeit dieses Presets
+    auswertet — ueber DIESELBE Aufloesung wie ``presets_due_for_hour``:
+    ``first_resolvable_tz`` ueber die Orte in ``location_ids``, sonst UTC.
+
+    Gelesen wird der Ortsbestand, der zum Zeitpunkt des Schreibens auf Platte
+    liegt (``<user_dir>/locations/*.json``, geschrieben von
+    ``app.loader.save_location``). Alle Aufrufer legen die Orte vor dem Preset
+    an — ein Preset verweist ja auf sie. Faellt das doch einmal andersherum,
+    ist die Zone hier UTC und die berechnete Stunde kann daneben liegen; das
+    faellt dann als roter Test auf, nicht still.
+
+    🔴 Bewusst ``resolve_location_tz`` in der Schleife statt
+    ``first_resolvable_tz``: letzteres PROTOKOLLIERT den Fehlschlag als
+    Warnung des Prueflings. Ein Testaufbau darf keine Produktiv-Warnung
+    erzeugen — ``test_issue_461_...::test_manual_presets_are_always_skipped``
+    prueft genau, dass fuer ein uebersprungenes Preset NICHTS protokolliert
+    wird, und ging daran kaputt. Die Auswahlregel („erster AUFLOESBARER Ort,
+    sonst UTC") ist dieselbe.
+    """
+    from utils.timezone import UTC, resolve_location_tz
+
+    orte: dict[str, SimpleNamespace] = {}
+    ordner = Path(user_dir) / "locations"
+    if ordner.exists():
+        for pfad in ordner.glob("*.json"):
+            try:
+                daten = json.loads(pfad.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                continue
+            if isinstance(daten, dict) and daten.get("id"):
+                orte[daten["id"]] = SimpleNamespace(**daten)
+    for lid in preset.get("location_ids") or []:
+        ort = orte.get(lid)
+        if ort is None:
+            continue
+        zone = resolve_location_tz(ort)
+        if zone is not None:
+            return zone
+    return UTC
+
+
+def write_compare_briefings(
+    user_dir: Path, presets: list[dict], *, briefing_stunde_setzen: bool = True,
+) -> Path:
     """Schreibt jedes Preset per-Datei nach ``<user_dir>/briefings/<id>.json``
     mit ``kind="vergleich"``. Gibt das ``briefings/``-Verzeichnis zurueck.
 
     ``user_dir`` ist das Nutzerverzeichnis (z.B. ``tmp_path/users/<uid>`` bzw.
     ``DATA_ROOT/<uid>``). Presets ohne ``id`` erhalten einen stabilen
     Positions-Fallback, damit der Helfer nie still Dateien ueberschreibt.
+
+    **Issue #1594 — Briefing-Stunde:** ein Preset OHNE ``morning_time`` faellt
+    im Pruefling auf den Migrations-Rueckfall „Morgen-Slot aktiv um 06:00
+    Ortszeit" (``compare_slot_scheduler.resolve_preset_slots``). Es ist damit
+    taeglich 60 Minuten lang „Briefing steht unmittelbar bevor" — und die neue
+    Vorlauf-Sperre unterdrueckt in diesem Fenster jeden Vergleichs-Alarm.
+    Bestandstests, die einen Alarm erwarten, messen dann die Sperre statt ihrer
+    eigenen Zusicherung (gemessen: 57 Faelle in 14 Dateien, taeglich zwei
+    Stunden rot).
+
+    Deshalb bekommt ein solches Preset hier eine ausdrueckliche Morgen-Stunde
+    ausserhalb des Vorlaufs. Semantisch bleibt alles gleich: der Rueckfall
+    liefert ``(morning_enabled=True, 06:00, evening_enabled=False, 18:00)``,
+    der gesetzte Wert ``(True, <sichere Stunde>, False, 18:00)`` — nur die
+    Stunde wandert. Presets, die ihre Zeiten SELBST setzen, bleiben unberuehrt;
+    wer eine bestimmte Stunde braucht, bekommt sie.
+
+    ``briefing_stunde_setzen=False`` schaltet das ab — fuer Tests, die den
+    Migrations-Rueckfall selbst pruefen wollen.
+
+    Bewusste Grenze: ``schedule="daily_evening"`` ohne Slot-Felder (Rueckfall
+    auf den ABEND-Slot) wird nicht angefasst — kein Aufrufer benutzt das, und
+    ein halb verstandener Umbau waere schlimmer als der bekannte Rest.
     """
     briefings = Path(user_dir) / "briefings"
     briefings.mkdir(parents=True, exist_ok=True)
     for i, preset in enumerate(presets):
         entry = dict(preset)
         entry["kind"] = "vergleich"
+        if (
+            briefing_stunde_setzen
+            and entry.get("morning_time") is None
+            and entry.get("schedule") != "daily_evening"
+        ):
+            from tests.helpers.briefing_zeiten import briefing_zeiten_iso
+
+            entry["morning_time"], _ = briefing_zeiten_iso(
+                _zone_des_presets(user_dir, entry)
+            )
         preset_id = entry.get("id") or f"preset-{i}"
         (briefings / f"{preset_id}.json").write_text(
             json.dumps(entry, ensure_ascii=False, indent=2), encoding="utf-8"

--- a/tests/helpers/nowcast_gate_fixtures.py
+++ b/tests/helpers/nowcast_gate_fixtures.py
@@ -41,6 +41,7 @@ from app.models import TripReportConfig
 from app.trip import Stage, Trip, Waypoint
 from app.user import SavedLocation
 
+from tests.helpers.briefing_zeiten import briefing_zeiten_fuer_trip
 from tests.helpers.compare_briefings import write_compare_briefings
 
 def preset_root() -> Path:
@@ -416,8 +417,16 @@ def make_trip(
     )
     stages = [stage] + list(extra_stages or [])
     trip = Trip(id=trip_id, name="S3 Nowcast-Trip", stages=stages)
+    # Issue #1594: ohne gesetzte Zeiten erbt `TripReportConfig` 07:00/18:00
+    # Ortszeit. Der Trip waere damit taeglich zweimal 60 Minuten lang
+    # "Briefing steht bevor", und die Vorlauf-Sperre unterdrueckte den Alarm
+    # aus einem ZWEITEN Grund — die Freigabe-Stufe, die diese Tests messen,
+    # waere dann nicht mehr die gemessene. Reine Vorbedingung; die Zone kommt
+    # aus derselben Aufloesung wie in der Sperre selbst (`anchor_tz`).
+    morgen, abend = briefing_zeiten_fuer_trip(trip)
     trip.report_config = TripReportConfig(
         trip_id=trip_id, send_email=True, send_telegram=False,
+        morning_time=morgen, evening_time=abend,
     )
     trip.alert_cooldown_minutes = cooldown_minutes
     trip.alert_quiet_from = quiet_from
@@ -452,6 +461,12 @@ def save_trip(trip: Trip, user_id: str) -> None:
             "trip_id": trip.report_config.trip_id,
             "send_email": trip.report_config.send_email,
             "send_telegram": trip.report_config.send_telegram,
+            # Issue #1594: die Zeiten MUESSEN mitgeschrieben werden. Fehlen
+            # sie in der Datei, setzt der Loader beim Zurueckladen wieder die
+            # Modell-Vorgaben 07:00/18:00 ein — der am Objekt gesetzte Wert
+            # aus `make_trip()` waere dann wirkungslos, und zwar still.
+            "morning_time": trip.report_config.morning_time.isoformat(),
+            "evening_time": trip.report_config.evening_time.isoformat(),
         },
     }
     (trips_dir / f"{trip.id}.json").write_text(json.dumps(data))

--- a/tests/tdd/test_alert_anchor_day_guard.py
+++ b/tests/tdd/test_alert_anchor_day_guard.py
@@ -42,6 +42,7 @@ from app.models import (
 from app.trip import Stage, Trip, Waypoint
 
 from tests.helpers.alert_log_fixtures import LAT, LON, settings_email_only
+from tests.helpers.briefing_zeiten import briefing_zeiten_fuer_trip
 
 # Bewusst absurd hoch: das Delta gegen JEDE reale Vorhersage reisst damit die
 # Boeen-Standardschwelle (20 km/h). Ob ein Alarm rausgeht, haengt so nur noch
@@ -122,8 +123,13 @@ def boeen_trip(trip_id: str, tage: list[date]) -> Trip:
             metric_alert_levels={"wind_gust": "standard"},
         ),
     )
+    # Issue #1594: Briefing-Zeiten ausserhalb des Vorlauf-Fensters — sonst
+    # unterdrueckt die Sperre den Alarm aus einem zweiten Grund und diese
+    # Datei misst nicht mehr den Anker. Vorbedingung, keine Zusicherung.
+    morgen, abend = briefing_zeiten_fuer_trip(trip)
     trip.report_config = TripReportConfig(trip_id=trip_id, send_email=True,
-                                          alert_on_changes=True)
+                                          alert_on_changes=True,
+                                          morning_time=morgen, evening_time=abend)
     trip.alert_cooldown_minutes = 0
     trip.official_alert_triggers_enabled = False
     return trip

--- a/tests/tdd/test_alert_change_urgency_grading.py
+++ b/tests/tdd/test_alert_change_urgency_grading.py
@@ -65,6 +65,7 @@ from tests.helpers.alert_log_fixtures import (
     settings_email_only,
     weather,
 )
+from tests.helpers.briefing_zeiten import briefing_zeiten_fuer_trip
 from tests.helpers.compare_briefings import write_compare_briefings
 
 # Schwellen der Empfindlichkeitsstufe "standard" aus `alert_preset._PRESET_TABLE`.
@@ -130,8 +131,12 @@ def _trip(trip_id: str, levels: dict[str, str], catalog_ids: list[str],
             metric_alert_levels=levels,
         ),
     )
+    # Issue #1594: Briefing-Zeiten ausserhalb des Vorlauf-Fensters — sonst
+    # schwiege der Alarm wegen der Sperre und die Abstufung waere ungemessen.
+    morgen, abend = briefing_zeiten_fuer_trip(trip)
     trip.report_config = TripReportConfig(
         trip_id=trip_id, send_email=True, alert_on_changes=True,
+        morning_time=morgen, evening_time=abend,
     )
     trip.alert_cooldown_minutes = 0
     trip.official_alert_triggers_enabled = False

--- a/tests/tdd/test_alert_channel_threshold.py
+++ b/tests/tdd/test_alert_channel_threshold.py
@@ -67,6 +67,7 @@ from tests.helpers.alert_log_fixtures import (
     weather,
 )
 from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
+from tests.helpers.briefing_zeiten import briefing_zeiten_fuer_trip
 
 # ═══════════════════════════ Telegram-Stub (echtes 127.0.0.1) ═════════════
 #
@@ -166,9 +167,13 @@ def _telegram_trip(trip_id: str) -> Trip:
     eingeschaltetem Telegram-Kanal — Vorbild
     ``test_alert_urgency.py::_telegram_trip``."""
     trip = gust_alert_trip(trip_id)
+    # Issue #1594: das neue `report_config` ERSETZT das von `gust_alert_trip`
+    # gesetzte — ohne die Zeiten hier waere der Trip wieder im Vorlauf-Fenster
+    # und die Sperre unterdrueckte den Alarm vor jeder Schwellen-Pruefung.
+    morgen, abend = briefing_zeiten_fuer_trip(trip)
     trip.report_config = TripReportConfig(
         trip_id=trip_id, send_email=True, send_telegram=True, send_sms=False,
-        alert_on_changes=True,
+        alert_on_changes=True, morning_time=morgen, evening_time=abend,
     )
     trip.alert_cooldown_minutes = 0
     return trip
@@ -202,9 +207,11 @@ def _ac4_trip(trip_id: str) -> Trip:
             metric_alert_levels={"wind_gust": "standard"},
         ),
     )
+    # Issue #1594: Briefing-Zeiten ausserhalb des Vorlaufs (Vorbedingung).
+    morgen, abend = briefing_zeiten_fuer_trip(trip)
     trip.report_config = TripReportConfig(
         trip_id=trip_id, send_email=False, send_telegram=False, send_sms=False,
-        alert_on_changes=True,
+        alert_on_changes=True, morning_time=morgen, evening_time=abend,
     )
     trip.alert_channels = {"email": True, "telegram": True, "sms": False}
     trip.alert_cooldown_minutes = 0
@@ -1214,8 +1221,11 @@ def test_einzeln_auftretende_amtliche_warnung_ohne_wetter_delta_respektiert_kana
             id=f"trip-standalone-official-{uuid.uuid4().hex[:6]}", name="Standalone-Official-Trip",
             stages=[stage], official_warnings=None,
         )
+        # Issue #1594: Briefing-Zeiten ausserhalb des Vorlaufs (Vorbedingung).
+        morgen, abend = briefing_zeiten_fuer_trip(trip)
         trip.report_config = TripReportConfig(
             trip_id=trip.id, send_email=False, send_telegram=False, send_sms=False,
+            morning_time=morgen, evening_time=abend,
         )
         trip.alert_channels = {"email": True, "telegram": True, "sms": False}
         trip.alert_channel_thresholds = {"telegram": "HIGH"}  # email bleibt LOW

--- a/tests/tdd/test_alert_run_deadline.py
+++ b/tests/tdd/test_alert_run_deadline.py
@@ -48,6 +48,8 @@ from app.trip import Stage, Trip, Waypoint
 from services import trip_alert
 from services.trip_alert import TripAlertService
 
+from tests.helpers.briefing_zeiten import briefing_zeiten_fuer_trip
+
 LAT, LON = 47.0, 11.0
 
 
@@ -125,7 +127,12 @@ def _active_trip(trip_id: str, *, lat: float = LAT, lon: float = LON) -> Trip:
         waypoints=[Waypoint(id="G1", name="Start", lat=lat, lon=lon, elevation_m=1000.0)],
     )
     trip = Trip(id=trip_id, name="Deadline-Test-Trip", stages=[stage])
-    trip.report_config = TripReportConfig(trip_id=trip_id, send_email=True)
+    # Issue #1594: Briefing-Zeiten ausserhalb des Vorlaufs — sonst zaehlt der
+    # Lauf weniger gepruefte Trips, weil die Sperre sie vorher abschneidet.
+    morgen, abend = briefing_zeiten_fuer_trip(trip)
+    trip.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=True, morning_time=morgen, evening_time=abend,
+    )
     return trip
 
 
@@ -138,7 +145,12 @@ def _official_trigger_trip(trip_id: str, *, lat: float = LAT, lon: float = LON) 
         waypoints=[Waypoint(id="G1", name="Start", lat=lat, lon=lon, elevation_m=1000.0)],
     )
     trip = Trip(id=trip_id, name="Amtliche-Warnung-Trip", stages=[stage], official_warnings=None)
-    trip.report_config = TripReportConfig(trip_id=trip_id, send_email=True)
+    # Issue #1594: Briefing-Zeiten ausserhalb des Vorlaufs — sonst zaehlt der
+    # Lauf weniger gepruefte Trips, weil die Sperre sie vorher abschneidet.
+    morgen, abend = briefing_zeiten_fuer_trip(trip)
+    trip.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=True, morning_time=morgen, evening_time=abend,
+    )
     return trip
 
 

--- a/tests/tdd/test_alert_tenancy_two_users.py
+++ b/tests/tdd/test_alert_tenancy_two_users.py
@@ -42,6 +42,8 @@ from app.models import (
 from app.trip import Stage, Trip, Waypoint
 from services.official_alerts.models import OfficialAlert
 
+from tests.helpers.briefing_zeiten import briefing_zeiten_fuer_trip
+
 # Pfadregel #1409: Pruefling relativ zur Testdatei, nicht ueber den Hauptrepo-Pfad.
 DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
 
@@ -111,7 +113,13 @@ def _identical_trip() -> Trip:
             metric_alert_levels={"wind_gust": "standard", "thunder_level": "sensibel"},
         ),
     )
-    trip.report_config = TripReportConfig(trip_id=TRIP_ID, send_email=True, alert_on_changes=True)
+    # Issue #1594: Briefing-Zeiten ausserhalb des Vorlaufs — sonst schweigt der
+    # Alarm wegen der Sperre und die Mandantentrennung bleibt ungemessen.
+    morgen, abend = briefing_zeiten_fuer_trip(trip)
+    trip.report_config = TripReportConfig(
+        trip_id=TRIP_ID, send_email=True, alert_on_changes=True,
+        morning_time=morgen, evening_time=abend,
+    )
     trip.alert_cooldown_minutes = 0
     return trip
 

--- a/tests/tdd/test_alert_urgency.py
+++ b/tests/tdd/test_alert_urgency.py
@@ -43,6 +43,7 @@ from tests.helpers.alert_log_fixtures import (
     read_log, settings_email_only, weather,
 )
 from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
+from tests.helpers.briefing_zeiten import briefing_zeiten_fuer_trip
 from tests.helpers.compare_briefings import write_compare_briefings
 
 _GUST_STANDARD_THRESHOLD_KMH = 20.0
@@ -672,9 +673,13 @@ def _make_change() -> WeatherChange:
 
 def _telegram_trip(trip_id: str) -> Trip:
     trip = gust_alert_trip(trip_id)
+    # Issue #1594: dieses `report_config` ERSETZT das von `gust_alert_trip`
+    # gesetzte — ohne die Zeiten laege der Trip wieder im Vorlauf-Fenster und
+    # die Sperre schnitte den Versand vor der Kanal-Pruefung ab.
+    morgen, abend = briefing_zeiten_fuer_trip(trip)
     trip.report_config = TripReportConfig(
         trip_id=trip_id, send_email=True, send_telegram=True, send_sms=False,
-        alert_on_changes=True,
+        alert_on_changes=True, morning_time=morgen, evening_time=abend,
     )
     trip.alert_cooldown_minutes = 0
     return trip

--- a/tests/tdd/test_briefing_anchor_survives_dispatch_failure.py
+++ b/tests/tdd/test_briefing_anchor_survives_dispatch_failure.py
@@ -83,6 +83,7 @@ from app.models import (
 )
 from app.trip import Stage, Trip, Waypoint
 from tests.helpers.arrival_window_fixtures import active_window_offsets, stage_date
+from tests.helpers.briefing_zeiten import briefing_zeiten_fuer_trip
 
 # Pfadregel #1409: Pruefling relativ zur Testdatei aufloesen, nie ueber einen
 # festen Hauptrepo-Pfad — sonst pruefte dieser Test aus dem Worktree die
@@ -213,9 +214,15 @@ def _trip(trip_id: str, *, with_levels: bool = False,
             metric_alert_levels={"wind_gust": "standard"},
         )
     trip = Trip(id=trip_id, name="Anker-Trip #1629", stages=stages, **kwargs)
+    # Issue #1594: Briefing-Zeiten ausserhalb des Vorlauf-Fensters. AC-9 misst,
+    # dass der Alarm-Lauf nach einem gescheiterten Briefing REGULAER prueft —
+    # mit den Vorgabezeiten 07:00/18:00 unterdrueckte ihn dort zeitweise die
+    # Sperre, und der Test haette „still" statt „regulaer" gemessen.
+    morgen, abend = briefing_zeiten_fuer_trip(trip)
     trip.report_config = TripReportConfig(
         trip_id=trip_id, send_email=send_email, send_telegram=send_telegram,
         send_sms=send_sms, alert_on_changes=with_levels,
+        morning_time=morgen, evening_time=abend,
     )
     trip.alert_cooldown_minutes = 0
     trip.official_alerts_enabled = False

--- a/tests/tdd/test_briefing_imminent_gate.py
+++ b/tests/tdd/test_briefing_imminent_gate.py
@@ -141,61 +141,127 @@ def _anker(user_id: str, vor_minuten: float) -> None:
     )
 
 
-# ═════════════════════════ AC-5 — Nachlauf-Fenster ══════════════════════════
+# ══════════ AC-5 — der VERSUCH beendet die Sperre, nicht der Erfolg ═════════
+#
+# 🔴 Die erste Fassung hatte hier ein Nachlauf-Fenster: „letztes Briefing
+# weniger als 15 Minuten her" SPERRTE. Das war falsch begruendet — der Anker
+# wird auch bei gescheitertem Versand geschrieben (#1629), der Nachlauf
+# schwieg also gerade dann, wenn nichts ankam, und machte sieben
+# Bestandstests rot. Der Anker hat jetzt das UMGEKEHRTE Vorzeichen: er
+# BEENDET die Sperre.
 
-
-def test_ac5_kurz_nach_einem_briefing_wird_gesperrt(nutzer):
-    """AC-5: Ist das letzte Briefing dieser Entitaet nachweislich vor wenigen
-    Minuten rausgegangen, wird eine Meldung ebenfalls nicht mehr als eigene
-    Nachricht verschickt — der gemessene 13.08.-Fall (Alarm zwei Minuten NACH
-    dem Briefing).
-
-    Der Nachlauf haengt an der TATSACHE „ein Briefing ist raus"
-    (``alert_briefing_anchor.last_briefing_at``), nicht an einer
-    Uhrzeit-Rechnung: scheitert der Versand, wird der Anker gar nicht erst
-    fortgeschrieben und die Sperre greift zu Recht nicht.
-
-    Das Faelligkeits-Praedikat sagt hier durchgehend „nein" — die Sperre darf
-    also allein aus dem Nachlauf entstehen.
-
-    ROT HEUTE: ``services.alert_gate.check_briefing_imminent`` existiert nicht
-    (ImportError).
-    """
-    uid = nutzer("ac5")
-    _anker(uid, vor_minuten=5)
-
-    assert _sperre(uid, NIE_FAELLIG()) is True, (
-        "Ein Briefing, das vor fuenf Minuten rausging, muss die nachfolgende "
-        "Meldung im Nachlauf-Fenster sperren."
+# Ein Faelligkeits-Fenster, das JETZT offen ist — der Zustand nach einem
+# gescheiterten Versand: der Slot bleibt faellig (der Vermerk wurde
+# zurueckgenommen), obwohl der Versuch stattgefunden hat.
+def OFFENES_FENSTER() -> Faelligkeit:
+    return Faelligkeit(
+        FEST - timedelta(minutes=30), FEST + timedelta(minutes=30),
     )
 
 
-def test_ac5_ohne_jedes_briefing_wird_nicht_gesperrt(nutzer):
-    """AC-5 (Gegenprobe): Gab es fuer diese Entitaet noch nie ein Briefing
-    (Bestandsnutzer, erster Lauf nach der Auslieferung), liefert
-    ``last_briefing_at()`` ``None`` — und die Sperre darf daraus NICHT „gerade
-    rausgegangen" machen.
+def test_ac5_versuch_im_offenen_fenster_beendet_die_sperre(nutzer):
+    """AC-5: Wurde das anstehende Briefing bereits versucht — ob zugestellt
+    oder beim Versand gescheitert —, wird die Meldung regulaer verschickt.
 
-    Ohne diese Haelfte waere eine Implementierung, die bei fehlendem Anker
-    pauschal sperrt, formal AC-5-konform und legte jede Bestandstour still.
+    Das Faelligkeits-Fenster ist hier durchgehend offen, sagt also „das
+    Briefing steht immer noch an". Genau so sieht ein GESCHEITERTER Versand
+    aus: der Anker ist gesetzt (er steht in beiden Versandpfaden im
+    Fehler-Zweig, #1629), der Idempotenz-Vermerk wurde zurueckgenommen.
+    Allein daraus entsteht sonst der gemessene 4-Stunden-Schweif (R6).
 
-    ROT HEUTE: ImportError.
+    ROT vor der Korrektur: der Vorlauf-Zweig sperrt, der Anker konnte die
+    Sperre nicht beenden — er loeste sie aus.
+    """
+    uid = nutzer("ac5-versucht")
+    _anker(uid, vor_minuten=10)
+
+    assert _sperre(uid, OFFENES_FENSTER()) is False, (
+        "Das anstehende Briefing wurde vor zehn Minuten versucht — die Sperre "
+        "muss damit enden, sonst schweigt der Alarm bis zu vier Stunden lang "
+        "fuer ein Briefing, das nie angekommen ist."
+    )
+
+
+def test_ac5_ohne_versuch_bleibt_die_sperre_bestehen(nutzer):
+    """AC-5 (Gegenprobe): Dieselbe Lage, aber ohne jeden Briefing-Anker — der
+    gemeldete 13.08.-Fall (Alarm-Lauf zur Briefing-Minute selbst, noch kein
+    Versuch). Hier MUSS gesperrt werden.
+
+    Ohne diese Haelfte waere eine Implementierung, die nach Bedingung 1 immer
+    durchlaesst, formal AC-5-konform — und der ganze Fix wirkungslos.
     """
     uid = nutzer("ac5-ohne")
 
-    assert _sperre(uid, NIE_FAELLIG()) is False, (
-        "Ohne jeden Briefing-Anker darf nichts gesperrt werden."
+    assert _sperre(uid, OFFENES_FENSTER()) is True, (
+        "Ohne Briefing-Anker gab es noch keinen Versuch — die Meldung muss "
+        "gesperrt bleiben, das Briefing ersetzt sie Minuten spaeter."
+    )
+
+
+def test_ac5_anker_vom_vortag_beendet_die_heutige_sperre_nicht(nutzer):
+    """AC-5 (Zuordnung zum Slot): Ein Briefing-Versuch von GESTERN darf die
+    heutige Sperre nicht beenden — sonst waere die Sperre ab dem zweiten
+    Betriebstag jeder Tour dauerhaft wirkungslos, ohne dass irgendein Test
+    umkippt.
+
+    Eine Implementierung, die nur „gibt es ueberhaupt einen Anker?" fragt,
+    faellt hier durch.
+    """
+    uid = nutzer("ac5-vortag")
+    _anker(uid, vor_minuten=24 * 60)
+
+    assert _sperre(uid, OFFENES_FENSTER()) is True, (
+        "Der Anker liegt 24 Stunden zurueck und gehoert damit zum Briefing von "
+        "gestern — er darf die heutige Sperre nicht beenden."
+    )
+
+
+def test_ac5_versuch_am_morgen_beendet_die_sperre_des_abends_nicht(nutzer):
+    """AC-5 (Zuordnung zum SLOT, nicht zum Ortstag): Zwei Faelligkeits-Fenster
+    am selben Tag — das Morgen-Fenster liegt zwei Stunden zurueck und ist
+    abgearbeitet, das Abend-Fenster steht in 30 Minuten an. Der Anker des
+    Morgen-Briefings darf die Sperre des ABEND-Briefings nicht beenden.
+
+    Ohne diesen Fall waere eine Implementierung, die den Versuch nur gegen
+    Mitternacht Ortszeit abgleicht („heute schon ein Briefing gehabt"),
+    formal AC-5-konform — und liesse jeden Abend-Alarm durch, obwohl das
+    Abend-Briefing Minuten spaeter dasselbe erzaehlt.
+    """
+    uid = nutzer("ac5-zwei-slots")
+    _anker(uid, vor_minuten=120)
+
+    class ZweiFenster:
+        def __init__(self) -> None:
+            self.gefragt: list[datetime] = []
+
+        def __call__(self, moment: datetime) -> bool:
+            self.gefragt.append(moment)
+            morgens = (
+                FEST - timedelta(minutes=125) <= moment
+                <= FEST - timedelta(minutes=115)
+            )
+            abends = (
+                FEST + timedelta(minutes=30) <= moment
+                <= FEST + timedelta(minutes=90)
+            )
+            return morgens or abends
+
+    assert _sperre(uid, ZweiFenster()) is True, (
+        "Der Anker gehoert zum Morgen-Briefing von vor zwei Stunden — das "
+        "Abend-Briefing in 30 Minuten wurde noch nicht versucht und muss "
+        "gesperrt bleiben."
     )
 
 
 # ═══════════════════ AC-6 — Fenstergrenzen in beide Richtungen ══════════════
 
 
-def test_ac6_ausserhalb_beider_fenster_wird_regulaer_verschickt(nutzer):
-    """AC-6: Naechstes Briefing weiter als 60 Minuten entfernt UND letztes
-    laenger als 15 Minuten her — die Meldung geht wie bisher regulaer raus.
+def test_ac6_ausserhalb_des_vorlaufs_wird_regulaer_verschickt(nutzer):
+    """AC-6: Naechstes Briefing weiter als 60 Minuten entfernt — die Meldung
+    geht wie bisher regulaer raus.
 
-    ROT HEUTE: ImportError.
+    Der Anker vor 30 Minuten ist bewusst gesetzt: er darf hier weder sperren
+    (das war der gestrichene Nachlauf) noch sonst etwas bewirken.
     """
     uid = nutzer("ac6")
     _anker(uid, vor_minuten=30)
@@ -212,32 +278,35 @@ def test_ac6_ausserhalb_beider_fenster_wird_regulaer_verschickt(nutzer):
     )
 
 
-def test_ac6_vorlauf_grenze_60_minuten(nutzer):
-    """AC-6 (Grenze des Vorlaufs): Ein Briefing 59 Minuten voraus sperrt, eines
-    75 Minuten voraus nicht. Damit ist die PO-Entscheidung „60 Minuten" als
-    Verhalten gemessen — nicht als Konstante abgelesen.
+def test_ac6_vorlauf_grenze_genau_60_und_61_minuten(nutzer):
+    """AC-6 (Grenze des Vorlaufs, auf die Minute): Ein Briefing GENAU 60
+    Minuten voraus sperrt, eines GENAU 61 Minuten voraus nicht. Damit ist die
+    PO-Entscheidung „60 Minuten" als Verhalten gemessen — nicht als Konstante
+    abgelesen.
 
     Der gemessene Anlassfall lag genau hier: Alarme um 04:00 und 04:45 UTC
     gegen ein Briefing um 05:00. Ein 15-Minuten-Vorlauf haette die 04:00-Faelle
     nicht gefangen.
 
-    ROT HEUTE: ImportError.
+    Die Fenster beginnen exakt auf der Grenze und reichen nach HINTEN weg:
+    ein Fenster, das die Grenze umschliesst, waere in beiden Faellen getroffen
+    und wuerde nichts unterscheiden.
     """
     uid = nutzer("ac6-vorlauf")
-    knapp_drin = Faelligkeit(
-        FEST + timedelta(minutes=55), FEST + timedelta(minutes=59),
+    genau_60 = Faelligkeit(
+        FEST + timedelta(minutes=60), FEST + timedelta(minutes=120),
     )
-    knapp_draussen = Faelligkeit(
-        FEST + timedelta(minutes=70), FEST + timedelta(minutes=80),
+    genau_61 = Faelligkeit(
+        FEST + timedelta(minutes=61), FEST + timedelta(minutes=121),
     )
 
-    assert _sperre(uid, knapp_drin) is True, (
-        "Ein Briefing 55–59 Minuten voraus liegt im Vorlauf-Fenster und muss "
-        "sperren."
+    assert _sperre(uid, genau_60) is True, (
+        "Ein Briefing genau 60 Minuten voraus liegt im Vorlauf-Fenster und "
+        "muss sperren."
     )
-    assert _sperre(uid, knapp_draussen) is False, (
-        "Ein Briefing 70–80 Minuten voraus liegt ausserhalb — hier darf nicht "
-        "gesperrt werden, sonst schweigt der Alarm ohne zeitnahen Ersatz."
+    assert _sperre(uid, genau_61) is False, (
+        "Ein Briefing genau 61 Minuten voraus liegt ausserhalb — hier darf "
+        "nicht gesperrt werden, sonst schweigt der Alarm ohne zeitnahen Ersatz."
     )
 
 
@@ -262,40 +331,33 @@ def test_ac6_faelligkeit_genau_jetzt_sperrt_ebenfalls(nutzer):
     )
 
 
-def test_ac6_nachlauf_grenze_15_minuten(nutzer):
-    """AC-6 (Grenze des Nachlaufs, Risiko R6): Ein Briefing vor 14 Minuten
-    sperrt, eines vor 25 Minuten nicht. Ohne diesen Deckel bliebe die Sperre
-    wirksam, obwohl das Briefing laengst durch ist — ein Meldeloch ohne Grenze.
+def test_ac6_ohne_jede_faelligkeit_wird_nie_gesperrt(nutzer):
+    """AC-6 (Gegenprobe zur gestrichenen Nachlauf-Haelfte): Steht ueberhaupt
+    kein Briefing an, wird NIE gesperrt — auch nicht kurz nach einem gerade
+    verschickten.
 
-    Zwei getrennte Nutzer, damit der Anker des einen den anderen nicht faerbt
-    (er wird pro Nutzerverzeichnis gefuehrt).
-
-    ROT HEUTE: ImportError.
+    Genau hier stand bis zur Spec-Korrektur das Gegenteil („letztes Briefing
+    vor 5 Minuten ⇒ sperren"). Der Anker vor drei Minuten ist deshalb bewusst
+    gesetzt: er ist der Ausloeser, der NICHT mehr ausloesen darf.
     """
-    drin, draussen = nutzer("ac6-nach-drin"), nutzer("ac6-nach-draussen")
-    _anker(drin, vor_minuten=14)
-    _anker(draussen, vor_minuten=25)
+    uid = nutzer("ac6-ohne-faelligkeit")
+    _anker(uid, vor_minuten=3)
 
-    assert _sperre(drin, NIE_FAELLIG()) is True, (
-        "Ein Briefing vor 14 Minuten liegt im Nachlauf-Fenster und muss sperren."
-    )
-    assert _sperre(draussen, NIE_FAELLIG()) is False, (
-        "Ein Briefing vor 25 Minuten liegt ausserhalb — die Sperre muss enden, "
-        "sonst schweigt der Alarm unbegrenzt weiter."
+    assert _sperre(uid, NIE_FAELLIG()) is False, (
+        "Ohne anstehendes Briefing gibt es keinen Ersatz fuer die Meldung — "
+        "ein gerade verschicktes Briefing darf sie nicht sperren."
     )
 
 
-def test_ac6_anker_eines_fremden_gegenstands_sperrt_nicht(nutzer):
+def test_ac6_anker_eines_fremden_gegenstands_beendet_die_sperre_nicht(nutzer):
     """AC-6 (Trennschaerfe): Der Anker liegt je ``(entity_id, entity_type)``.
     Ein frisches Briefing einer ANDEREN Entitaet desselben Nutzers darf die
-    Meldung hier nicht sperren.
+    Sperre hier nicht beenden — fuer DIESE Entitaet gab es noch keinen
+    Versuch.
 
     Ohne diesen Fall waere eine Implementierung, die den Anker nur nach
-    ``user_id`` nachschlaegt, formal AC-5-konform — und legte bei jedem
-    Briefing irgendeiner Tour saemtliche Alarme des Nutzers fuer 15 Minuten
-    still.
-
-    ROT HEUTE: ImportError.
+    ``user_id`` nachschlaegt, formal AC-5-konform — und liesse bei jedem
+    Briefing irgendeiner Tour saemtliche Doppel-Meldungen des Nutzers durch.
     """
     from services.alert_briefing_anchor import record_briefing_sent
 
@@ -305,8 +367,9 @@ def test_ac6_anker_eines_fremden_gegenstands_sperrt_nicht(nutzer):
         at=FEST - timedelta(minutes=3),
     )
 
-    assert _sperre(uid, NIE_FAELLIG()) is False, (
-        "Das Briefing einer fremden Entitaet darf diese hier nicht sperren."
+    assert _sperre(uid, OFFENES_FENSTER()) is True, (
+        "Das Briefing einer fremden Entitaet sagt nichts darueber, ob DIESES "
+        "Briefing schon versucht wurde — die Sperre muss bestehen bleiben."
     )
 
 

--- a/tests/tdd/test_briefing_imminent_gate.py
+++ b/tests/tdd/test_briefing_imminent_gate.py
@@ -1,0 +1,444 @@
+"""TDD RED — Die Vorlauf-Sperre selbst: Fenstergrenzen, NowCast-Ausnahme und
+Symmetrie (Issue #1594, AC-5, AC-6, AC-12, AC-13, AC-14).
+
+SPEC:    docs/specs/modules/fix_1594_alarm_vorlauf_sperre.md
+KONTEXT: docs/context/fix-1594-alarm-vorlauf-sperre.md
+
+Heimat der neuen Funktion ist ``src/services/alert_gate.py``, klar getrennt von
+``check_nowcast_gate()``. RED-Grund fuer AC-5/AC-6: ``check_briefing_imminent``
+existiert dort nicht (ImportError).
+
+═══════════════════════════════════════════════════════════════════════════
+WARUM HIER KEINE UHR EINGEFROREN WIRD
+═══════════════════════════════════════════════════════════════════════════
+
+``check_briefing_imminent()`` bekommt seinen Zeitpunkt als PARAMETER. Wer in so
+einem Fall zusaetzlich die Systemuhr anhaelt, macht genau die Frage
+unfalsifizierbar, um die es geht: benutzt der Pruefling den uebergebenen
+Zeitpunkt oder heimlich die Uhr des Servers?
+
+Die Tests uebergeben deshalb einen FESTEN Zeitpunkt, der Monate von der echten
+Uhr entfernt liegt, und legen Anker und Faelligkeits-Fenster relativ zu DIESEM
+Zeitpunkt. Ein Rueckfall auf die Systemuhr laesst jede positive Zusicherung
+umkippen — der Anker waere Monate alt, das Faelligkeits-Fenster laege in der
+Vergangenheit.
+
+Das Faelligkeits-Praedikat ist eine echte, aufzeichnende Funktion des Tests
+(DI-Naht, wie ``frame_source`` beim Radar) — kein ``Mock()``: es rechnet ein
+echtes Ergebnis aus dem uebergebenen Zeitpunkt.
+
+Die beiden Verhaltens-Abschnitte (AC-12, AC-14) fahren dagegen die ECHTEN
+Dienstpfade mit der echten Uhr und legen stattdessen die Briefing-Zeiten
+relativ dazu — dort ist der Zeitpunkt kein Parameter, sondern wird intern
+geholt.
+
+Pfadregel #1409: alle Pfade relativ zu DIESER Datei bzw. ueber
+``app.loader.get_data_dir()``.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+for _p in (str(ROOT), str(ROOT / "src")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tests.helpers.briefing_imminent_fixtures import (  # noqa: E402
+    LOCATION_ZONE,
+    TRIP_ZONE,
+    clean_uid,
+    compare_change_alert_run,
+    compare_preset,
+    fresh_uid,
+    protokoll_eintraege,
+    ruhezeit_woanders,
+    settings_email_only,
+    stunde_versetzt,
+    trip_change_alert_run,
+    write_location,
+    write_presets,
+    write_trip,
+    write_user_tier,
+)
+from tests.helpers.nowcast_gate_fixtures import (  # noqa: E402
+    CountingFrameSource,
+    reset_radar_cache,
+)
+
+# Weit weg von der echten Uhr: ein Rueckfall auf `datetime.now()` faellt damit
+# in JEDER positiven Zusicherung dieser Datei auf.
+FEST = datetime(2026, 3, 15, 10, 0, tzinfo=timezone.utc)
+
+ENTITY = "e-1594-gate"
+
+
+class Faelligkeit:
+    """Echtes Faelligkeits-Praedikat (kein Mock): liefert True genau dann, wenn
+    der uebergebene Zeitpunkt in einem festen Fenster liegt, und zeichnet alle
+    Abfragen auf.
+
+    Ein FENSTER statt einer Schwelle ist Absicht: bei einer Schwelle
+    („faellig ab X") waere ein Pruefling, der heimlich die Systemuhr benutzt,
+    trotzdem True — die Systemzeit liegt ja weit hinter X. Mit einem Fenster
+    um den uebergebenen Zeitpunkt herum faellt genau dieser Fehler auf.
+    """
+
+    def __init__(self, von: datetime, bis: datetime) -> None:
+        self.von, self.bis = von, bis
+        self.gefragt: list[datetime] = []
+
+    def __call__(self, moment: datetime) -> bool:
+        self.gefragt.append(moment)
+        return self.von <= moment <= self.bis
+
+
+def NIE_FAELLIG() -> Faelligkeit:
+    """Ein Fenster, das garantiert nie getroffen wird — weder vom uebergebenen
+    Zeitpunkt noch von der Systemuhr."""
+    return Faelligkeit(
+        datetime(1999, 1, 1, tzinfo=timezone.utc),
+        datetime(1999, 1, 2, tzinfo=timezone.utc),
+    )
+
+
+@pytest.fixture
+def nutzer():
+    vergeben: list[str] = []
+
+    def _neu(kennung: str, tier: str = "premium") -> str:
+        user_id = fresh_uid(kennung)
+        clean_uid(user_id)
+        write_user_tier(user_id, tier)
+        vergeben.append(user_id)
+        return user_id
+
+    yield _neu
+    for user_id in vergeben:
+        clean_uid(user_id)
+
+
+def _sperre(user_id: str, faelligkeit, **kwargs) -> bool:
+    from services.alert_gate import check_briefing_imminent
+
+    return check_briefing_imminent(
+        user_id=user_id, entity_id=ENTITY, entity_type="route",
+        now=FEST, zone=TRIP_ZONE, briefing_due_at=faelligkeit, **kwargs,
+    )
+
+
+def _anker(user_id: str, vor_minuten: float) -> None:
+    """Briefing-Anker relativ zum FESTEN Zeitpunkt — nicht zur Systemuhr."""
+    from services.alert_briefing_anchor import record_briefing_sent
+
+    record_briefing_sent(
+        user_id=user_id, entity_id=ENTITY, entity_type="route",
+        at=FEST - timedelta(minutes=vor_minuten),
+    )
+
+
+# ═════════════════════════ AC-5 — Nachlauf-Fenster ══════════════════════════
+
+
+def test_ac5_kurz_nach_einem_briefing_wird_gesperrt(nutzer):
+    """AC-5: Ist das letzte Briefing dieser Entitaet nachweislich vor wenigen
+    Minuten rausgegangen, wird eine Meldung ebenfalls nicht mehr als eigene
+    Nachricht verschickt — der gemessene 13.08.-Fall (Alarm zwei Minuten NACH
+    dem Briefing).
+
+    Der Nachlauf haengt an der TATSACHE „ein Briefing ist raus"
+    (``alert_briefing_anchor.last_briefing_at``), nicht an einer
+    Uhrzeit-Rechnung: scheitert der Versand, wird der Anker gar nicht erst
+    fortgeschrieben und die Sperre greift zu Recht nicht.
+
+    Das Faelligkeits-Praedikat sagt hier durchgehend „nein" — die Sperre darf
+    also allein aus dem Nachlauf entstehen.
+
+    ROT HEUTE: ``services.alert_gate.check_briefing_imminent`` existiert nicht
+    (ImportError).
+    """
+    uid = nutzer("ac5")
+    _anker(uid, vor_minuten=5)
+
+    assert _sperre(uid, NIE_FAELLIG()) is True, (
+        "Ein Briefing, das vor fuenf Minuten rausging, muss die nachfolgende "
+        "Meldung im Nachlauf-Fenster sperren."
+    )
+
+
+def test_ac5_ohne_jedes_briefing_wird_nicht_gesperrt(nutzer):
+    """AC-5 (Gegenprobe): Gab es fuer diese Entitaet noch nie ein Briefing
+    (Bestandsnutzer, erster Lauf nach der Auslieferung), liefert
+    ``last_briefing_at()`` ``None`` — und die Sperre darf daraus NICHT „gerade
+    rausgegangen" machen.
+
+    Ohne diese Haelfte waere eine Implementierung, die bei fehlendem Anker
+    pauschal sperrt, formal AC-5-konform und legte jede Bestandstour still.
+
+    ROT HEUTE: ImportError.
+    """
+    uid = nutzer("ac5-ohne")
+
+    assert _sperre(uid, NIE_FAELLIG()) is False, (
+        "Ohne jeden Briefing-Anker darf nichts gesperrt werden."
+    )
+
+
+# ═══════════════════ AC-6 — Fenstergrenzen in beide Richtungen ══════════════
+
+
+def test_ac6_ausserhalb_beider_fenster_wird_regulaer_verschickt(nutzer):
+    """AC-6: Naechstes Briefing weiter als 60 Minuten entfernt UND letztes
+    laenger als 15 Minuten her — die Meldung geht wie bisher regulaer raus.
+
+    ROT HEUTE: ImportError.
+    """
+    uid = nutzer("ac6")
+    _anker(uid, vor_minuten=30)
+    fern = Faelligkeit(FEST + timedelta(minutes=90), FEST + timedelta(minutes=120))
+
+    assert _sperre(uid, fern) is False, (
+        "Briefing in 90 Minuten, letztes vor 30 Minuten — hier darf die neue "
+        "Sperre nicht greifen."
+    )
+    assert fern.gefragt, (
+        "Das Faelligkeits-Praedikat wurde gar nicht befragt — die Sperre "
+        "rechnet die Faelligkeit dann selbst nach, statt sie zu FRAGEN (das "
+        "waere die vierte Fassung derselben Regel, s. Spec)."
+    )
+
+
+def test_ac6_vorlauf_grenze_60_minuten(nutzer):
+    """AC-6 (Grenze des Vorlaufs): Ein Briefing 59 Minuten voraus sperrt, eines
+    75 Minuten voraus nicht. Damit ist die PO-Entscheidung „60 Minuten" als
+    Verhalten gemessen — nicht als Konstante abgelesen.
+
+    Der gemessene Anlassfall lag genau hier: Alarme um 04:00 und 04:45 UTC
+    gegen ein Briefing um 05:00. Ein 15-Minuten-Vorlauf haette die 04:00-Faelle
+    nicht gefangen.
+
+    ROT HEUTE: ImportError.
+    """
+    uid = nutzer("ac6-vorlauf")
+    knapp_drin = Faelligkeit(
+        FEST + timedelta(minutes=55), FEST + timedelta(minutes=59),
+    )
+    knapp_draussen = Faelligkeit(
+        FEST + timedelta(minutes=70), FEST + timedelta(minutes=80),
+    )
+
+    assert _sperre(uid, knapp_drin) is True, (
+        "Ein Briefing 55–59 Minuten voraus liegt im Vorlauf-Fenster und muss "
+        "sperren."
+    )
+    assert _sperre(uid, knapp_draussen) is False, (
+        "Ein Briefing 70–80 Minuten voraus liegt ausserhalb — hier darf nicht "
+        "gesperrt werden, sonst schweigt der Alarm ohne zeitnahen Ersatz."
+    )
+
+
+def test_ac6_faelligkeit_genau_jetzt_sperrt_ebenfalls(nutzer):
+    """AC-6 (untere Grenze): Ist das Briefing GENAU JETZT faellig, muss
+    ebenfalls gesperrt werden.
+
+    Eine Implementierung, die das Praedikat nur gegen ``now + Vorlauf``
+    auswertet und nicht auch gegen ``now``, faellt hier durch — und liesse
+    genau den Fall durch, in dem Alarm und Briefing in derselben Minute
+    kollidieren.
+
+    ROT HEUTE: ImportError.
+    """
+    uid = nutzer("ac6-jetzt")
+    genau_jetzt = Faelligkeit(
+        FEST - timedelta(minutes=5), FEST + timedelta(minutes=5),
+    )
+
+    assert _sperre(uid, genau_jetzt) is True, (
+        "Ein zum Pruefzeitpunkt faelliges Briefing muss die Meldung sperren."
+    )
+
+
+def test_ac6_nachlauf_grenze_15_minuten(nutzer):
+    """AC-6 (Grenze des Nachlaufs, Risiko R6): Ein Briefing vor 14 Minuten
+    sperrt, eines vor 25 Minuten nicht. Ohne diesen Deckel bliebe die Sperre
+    wirksam, obwohl das Briefing laengst durch ist — ein Meldeloch ohne Grenze.
+
+    Zwei getrennte Nutzer, damit der Anker des einen den anderen nicht faerbt
+    (er wird pro Nutzerverzeichnis gefuehrt).
+
+    ROT HEUTE: ImportError.
+    """
+    drin, draussen = nutzer("ac6-nach-drin"), nutzer("ac6-nach-draussen")
+    _anker(drin, vor_minuten=14)
+    _anker(draussen, vor_minuten=25)
+
+    assert _sperre(drin, NIE_FAELLIG()) is True, (
+        "Ein Briefing vor 14 Minuten liegt im Nachlauf-Fenster und muss sperren."
+    )
+    assert _sperre(draussen, NIE_FAELLIG()) is False, (
+        "Ein Briefing vor 25 Minuten liegt ausserhalb — die Sperre muss enden, "
+        "sonst schweigt der Alarm unbegrenzt weiter."
+    )
+
+
+def test_ac6_anker_eines_fremden_gegenstands_sperrt_nicht(nutzer):
+    """AC-6 (Trennschaerfe): Der Anker liegt je ``(entity_id, entity_type)``.
+    Ein frisches Briefing einer ANDEREN Entitaet desselben Nutzers darf die
+    Meldung hier nicht sperren.
+
+    Ohne diesen Fall waere eine Implementierung, die den Anker nur nach
+    ``user_id`` nachschlaegt, formal AC-5-konform — und legte bei jedem
+    Briefing irgendeiner Tour saemtliche Alarme des Nutzers fuer 15 Minuten
+    still.
+
+    ROT HEUTE: ImportError.
+    """
+    from services.alert_briefing_anchor import record_briefing_sent
+
+    uid = nutzer("ac6-fremd")
+    record_briefing_sent(
+        user_id=uid, entity_id="eine-ganz-andere-entitaet", entity_type="route",
+        at=FEST - timedelta(minutes=3),
+    )
+
+    assert _sperre(uid, NIE_FAELLIG()) is False, (
+        "Das Briefing einer fremden Entitaet darf diese hier nicht sperren."
+    )
+
+
+# ═════════ AC-12 + AC-13 — NowCast bleibt aussen vor, kein Protokoll ════════
+
+
+def test_ac12_nowcast_kommt_durch_waehrend_der_aenderungsalarm_schweigt(nutzer):
+    """AC-12 (Risiko R5): Steht ein Briefing unmittelbar bevor UND loest
+    gleichzeitig der Regenradar aus UND liegt eine Wetteraenderung vor, dann
+    wird der NowCast trotzdem zugestellt — nur der Aenderungsalarm schweigt.
+    Die neue Sperre wirkt ausschliesslich auf Aenderungsalarme und amtliche
+    Warnungen.
+
+    Bewusst ein VERHALTENStest, kein Struktur-/Importtest: Wirkort ist „kommt
+    der NowCast trotzdem durch?", nicht „welche Datei importiert was". Ein
+    Strukturtest wuerde bei der Zusammenlegung der Alarmpfade (#1467 S4) selbst
+    zum Kollateralschaden.
+
+    AC-13 gleich mit gemessen: der gesperrte Aenderungsalarm darf keine
+    Protokollzeile erzeugen. Der Radar-Lauf laeuft deshalb NACH dem
+    Protokoll-Vergleich — er schreibt bei Zustellung selbst eine.
+
+    ROT HEUTE: der Aenderungsalarm ruft Wetter ab (keine Sperre).
+    """
+    from services.radar_service import RadarNowcastService
+    from services.trip_alert import TripAlertService
+
+    uid = nutzer("ac12")
+    write_trip(
+        uid, "t-ac12",
+        morgen_stunde=stunde_versetzt(1, zone=TRIP_ZONE),
+        abend_stunde=stunde_versetzt(9, zone=TRIP_ZONE),
+    )
+
+    protokoll_vorher = protokoll_eintraege(uid)
+    abrufe_aenderung = trip_change_alert_run(uid, "t-ac12")
+    protokoll_nachher = protokoll_eintraege(uid)
+
+    reset_radar_cache()
+    quelle = CountingFrameSource(onset_minutes=8)
+    nowcast_mails: list = []
+    nowcast_sent = TripAlertService(
+        settings=settings_email_only(), throttle_hours=2, user_id=uid,
+        radar_service=RadarNowcastService(frame_source=quelle),
+        mail_sink=lambda *a, **kw: nowcast_mails.append((a, kw)),
+    ).check_radar_alerts()
+
+    assert abrufe_aenderung == 0, (
+        f"Der Aenderungsalarm muss im Vorlauf-Fenster schweigen "
+        f"({abrufe_aenderung} Wetterabrufe)."
+    )
+    assert protokoll_nachher == protokoll_vorher, (
+        f"AC-13: der gesperrte Aenderungsalarm darf keine Protokollzeile "
+        f"erzeugen — {len(protokoll_vorher)} -> {len(protokoll_nachher)}."
+    )
+    assert nowcast_sent >= 1 and len(nowcast_mails) >= 1, (
+        f"Der NowCast ist ausdruecklich von der Sperre ausgenommen und muss "
+        f"trotz anstehendem Briefing zugestellt werden: sent={nowcast_sent}, "
+        f"Mails={len(nowcast_mails)}"
+    )
+    assert quelle.call_count >= 1, (
+        f"Voraussetzung: der Radar-Abruf muss ueberhaupt stattgefunden haben "
+        f"({quelle.call_count} Abrufe) — sonst misst der NowCast-Nachweis "
+        f"einen Pfad, der aus einem anderen Grund gar nicht erst losläuft."
+    )
+
+
+# ═════════════ AC-14 — Symmetrie: morgens wie abends, Trip wie ══════════════
+# ═════════════          Ortsvergleich, in allen vier Kombinationen ══════════
+
+
+def _trip_lauf(user_id: str, *, slot: str, nah: bool) -> int:
+    """Ein Trip, dessen ``slot`` in Kuerze (``nah``) bzw. in fuenf Stunden
+    faellig ist; der jeweils andere Slot liegt weit weg."""
+    stunde = stunde_versetzt(1 if nah else 5, zone=TRIP_ZONE)
+    weit = stunde_versetzt(9, zone=TRIP_ZONE)
+    if slot == "morgen":
+        write_trip(user_id, "t-ac14", morgen_stunde=stunde, abend_stunde=weit)
+    else:
+        write_trip(user_id, "t-ac14", morgen_stunde=weit, abend_stunde=stunde)
+    return trip_change_alert_run(user_id, "t-ac14")
+
+
+def _compare_lauf(user_id: str, *, slot: str, nah: bool) -> int:
+    """Dasselbe fuer den Ortsvergleich; der jeweils andere Slot ist
+    ABGESCHALTET (dort sind Morgen und Abend einzeln schaltbar)."""
+    write_location(user_id)
+    stunde = stunde_versetzt(1 if nah else 5, zone=LOCATION_ZONE)
+    if slot == "morgen":
+        preset = compare_preset(
+            "cp-ac14", morgen_stunde=stunde, abend_stunde=None,
+            quiet=ruhezeit_woanders(),
+        )
+    else:
+        preset = compare_preset(
+            "cp-ac14", morgen_stunde=None, abend_stunde=stunde,
+            quiet=ruhezeit_woanders(),
+        )
+    write_presets(user_id, [preset])
+    return compare_change_alert_run(user_id)
+
+
+@pytest.mark.parametrize("art", ["trip", "vergleich"])
+@pytest.mark.parametrize("slot", ["morgen", "abend"])
+def test_ac14_sperre_wirkt_in_allen_vier_kombinationen_gleich(nutzer, art, slot):
+    """AC-14: Dieselbe Fenster-Logik, vier Kombinationen — (Morgen, Abend) ×
+    (Trip, Ortsvergleich). In allen vieren dasselbe Unterdrueckungsverhalten,
+    keine versteckte Bevorzugung des Morgen- oder des Trip-Pfads.
+
+    Die Abend-Redundanz tritt heute faktisch kaum auf (gemessen: 1 von 15
+    Faellen seit 25.07.), weil vor dem Abend-Briefing keine Ruhezeit endet. Der
+    symmetrische Zuschnitt bleibt trotzdem richtig: Ruhezeiten und
+    Briefing-Zeiten sind pro Nutzer frei konfigurierbar, und genau ihre
+    Verschiebung hat den Effekt binnen einer Woche entstehen lassen.
+
+    Jede Kombination faehrt beide Richtungen: nahes Briefing muss sperren,
+    fernes darf nicht. Ein Pfad, der aus einem ganz anderen Grund still ist,
+    faellt an der zweiten Zusicherung auf.
+
+    ROT HEUTE: keine Sperre in keiner der vier Kombinationen.
+    """
+    lauf = _trip_lauf if art == "trip" else _compare_lauf
+
+    abrufe_nah = lauf(nutzer(f"ac14-{art}-{slot}-nah"), slot=slot, nah=True)
+    abrufe_fern = lauf(nutzer(f"ac14-{art}-{slot}-fern"), slot=slot, nah=False)
+
+    assert abrufe_nah == 0, (
+        f"{art}/{slot}: ein Briefing in unter 60 Minuten muss den Alarm sperren "
+        f"({abrufe_nah} Abrufe) — sonst wirkt die Sperre nicht in allen vier "
+        f"Kombinationen gleich."
+    )
+    assert abrufe_fern >= 1, (
+        f"{art}/{slot}: ein Briefing in fuenf Stunden darf NICHT sperren "
+        f"({abrufe_fern} Abrufe)."
+    )

--- a/tests/tdd/test_compare_alert_briefing_imminent.py
+++ b/tests/tdd/test_compare_alert_briefing_imminent.py
@@ -1,0 +1,320 @@
+"""TDD RED — Ortsvergleich (Aenderungsalarm): keine Doppel-Meldung kurz vor
+einem geplanten Briefing (Issue #1594, AC-3, AC-7, AC-10, AC-13, AC-15).
+
+SPEC:    docs/specs/modules/fix_1594_alarm_vorlauf_sperre.md
+KONTEXT: docs/context/fix-1594-alarm-vorlauf-sperre.md
+
+Einhaengepunkt: ``src/services/compare_alert.py:183`` (direkt nach der
+Ruhezeit-Pruefung, VOR dem Wetterabruf). Gemessen wird an der Netz-Naht
+``_detect_triggered_locations`` — sie liegt unmittelbar dahinter, „0 Aufrufe"
+heisst also „vor dem Abruf gesperrt".
+
+RED heute: es gibt keine Vorlauf-Sperre; jeder Lauf im Vorlauf-Fenster ruft ab.
+
+═══════════════════════════════════════════════════════════════════════════
+🔴 EIN BEFUND AUS DER RED-PHASE, DER AC-7 EINSCHRAENKT
+═══════════════════════════════════════════════════════════════════════════
+
+AC-7 nennt fuenf Gruende, aus denen ein Ortsvergleich „kein geplantes
+Briefing" hat: ``schedule: "manual"``, ``paused_at``, ``archived_at``,
+abgelaufenes ``end_date`` und abgeschalteter Slot.
+
+Die ersten DREI davon sind ``compare_alert_guard.is_silenced()`` — und der
+Riegel sitzt in BEIDEN Vergleichs-Alarmpfaden GANZ VORNE, vor Sperrzeit,
+Tageslimit und Ruhezeit (``compare_alert.py:131``,
+``compare_official_alert.py:96``). Gemessen am Ist-Code: ein solches Preset
+loest heute schon NULL Alarme aus. Die neue Sperre kann dort gar keinen
+Schaden anrichten, und ein Test kann „nicht durch die neue Sperre
+unterdrueckt" nicht von „schon vorher stillgelegt" unterscheiden — beide
+Ergebnisse sind null.
+
+Echt gefaehrdet (und hier scharf geprueft) sind deshalb die beiden Gruende,
+bei denen der Alarm HEUTE durchgeht: abgelaufenes ``end_date`` und
+abgeschaltete Slots. Fuer die stillgelegten drei bleibt ein ausdruecklich
+markierter Bestands-Anker: ihr Verhalten (null Alarme) darf sich nicht
+aendern.
+
+Mock-frei: echte Presets/Orte auf Platte, echter Dienst, echte
+Zustandsdateien. Nur die Netz-Naht ist durch eine echte, zaehlende Unterklasse
+ersetzt.
+
+Pfadregel #1409: alle Pfade relativ zu DIESER Datei bzw. ueber
+``app.loader.get_data_dir()``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+for _p in (str(ROOT), str(ROOT / "src")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tests.helpers.briefing_imminent_fixtures import (  # noqa: E402
+    LOCATION_ZONE,
+    clean_uid,
+    compare_change_alert_run,
+    compare_preset,
+    fresh_uid,
+    ortstag,
+    protokoll_eintraege,
+    ruhezeit_woanders,
+    stunde_versetzt,
+    write_location,
+    write_presets,
+    write_user_tier,
+    zustand_schnappschuss,
+)
+
+PRESET = "cp-1594"
+
+
+# NAH: Slot-Stunde = die Stunde, die in einer Stunde gilt — jetzt nicht
+# faellig, in 60 Minuten schon. FERN: fuenf Stunden voraus.
+def NAH() -> int:
+    return stunde_versetzt(1, zone=LOCATION_ZONE)
+
+
+def FERN() -> int:
+    return stunde_versetzt(5, zone=LOCATION_ZONE)
+
+
+@pytest.fixture
+def nutzer():
+    vergeben: list[str] = []
+
+    def _neu(kennung: str, tier: str = "premium") -> str:
+        user_id = fresh_uid(kennung)
+        clean_uid(user_id)
+        write_user_tier(user_id, tier)
+        write_location(user_id)
+        vergeben.append(user_id)
+        return user_id
+
+    yield _neu
+    for user_id in vergeben:
+        clean_uid(user_id)
+
+
+def _lauf(user_id: str, **preset_kwargs) -> int:
+    """Ein echter Vergleichs-Aenderungsalarm-Lauf; liefert die Zahl der
+    Wetterabrufe (0 = vor dem Abruf gesperrt)."""
+    preset_kwargs.setdefault("quiet", ruhezeit_woanders())
+    write_presets(user_id, [compare_preset(PRESET, **preset_kwargs)])
+    return compare_change_alert_run(user_id)
+
+
+# ═══════════ AC-3 — Vergleichs-Aenderungsalarm im Vorlauf-Fenster ═══════════
+
+
+def test_ac3_aenderungsalarm_schweigt_wenn_das_briefing_unmittelbar_bevorsteht(nutzer):
+    """AC-3: Steht das naechste geplante Briefing des Ortsvergleichs in Kuerze
+    an, geht der Wetter-Aenderungsalarm NICHT mehr als eigene Zusatz-Meldung
+    raus.
+
+    Der Gegen-Lauf mit fernem Slot schuetzt vor falschem Gruen: ohne ihn waere
+    die erste Zusicherung auch dann erfuellt, wenn der Pfad aus einem ganz
+    anderen Grund gar nicht erst losliefe (z.B. kein aufloesbarer Ort).
+
+    ROT HEUTE: es gibt keine Vorlauf-Pruefung — beide Laeufe rufen ab.
+    """
+    abrufe_nah = _lauf(nutzer("ac3-nah"), morgen_stunde=NAH())
+    abrufe_fern = _lauf(nutzer("ac3-fern"), morgen_stunde=FERN())
+
+    assert abrufe_nah == 0, (
+        f"Briefing steht in unter 60 Minuten an — der Vergleichs-Alarm muss "
+        f"schweigen und darf kein Wetter abrufen, es waren {abrufe_nah} Abrufe."
+    )
+    assert abrufe_fern >= 1, (
+        f"Ein Briefing in fuenf Stunden darf den Vergleichs-Alarm NICHT sperren "
+        f"— es waren {abrufe_fern} Abrufe."
+    )
+
+
+def test_ac3_abend_slot_wirkt_wie_der_morgen_slot(nutzer):
+    """AC-3 (Symmetrie innerhalb des Vergleichs): dieselbe Sperre greift, wenn
+    der ABEND-Slot in Kuerze faellig ist und der Morgen-Slot abgeschaltet ist.
+
+    Ohne diesen Fall waere eine Implementierung, die nur ``morning_time`` liest,
+    formal AC-3-konform — und die Abend-Sperre existierte nur auf dem Papier.
+
+    ROT HEUTE: keine Sperre, der Abruf laeuft an.
+    """
+    abrufe_abend = _lauf(
+        nutzer("ac3-abend"), morgen_stunde=None, abend_stunde=NAH(),
+    )
+    abrufe_abend_fern = _lauf(
+        nutzer("ac3-abend-fern"), morgen_stunde=None, abend_stunde=FERN(),
+    )
+
+    assert abrufe_abend == 0, (
+        f"Faelliger Abend-Slot in unter 60 Minuten muss ebenso sperren wie der "
+        f"Morgen-Slot ({abrufe_abend} Abrufe)."
+    )
+    assert abrufe_abend_fern >= 1, (
+        f"Ferner Abend-Slot darf nicht sperren ({abrufe_abend_fern} Abrufe)."
+    )
+
+
+# ═══════════ AC-7 — kein Schweigen ohne Ersatz (Preset ohne Briefing) ═══════
+
+
+def test_ac7_abgelaufenes_end_date_wird_nie_gesperrt(nutzer):
+    """AC-7 (Risiko R1), Grund 1 von 2, die heute ueberhaupt Alarme ausloesen:
+    Ein Preset, dessen ``end_date`` in der Vergangenheit liegt, bekommt kein
+    geplantes Briefing mehr (``presets_due_for_hour`` stoppt es ab dem
+    Folgetag) — sein Alarm muss trotzdem unveraendert durchgehen.
+
+    ROT HEUTE ueber den Kontroll-Lauf: das gleich getaktete Preset OHNE
+    ``end_date`` muesste gesperrt sein, ist es aber nicht.
+    """
+    abrufe_abgelaufen = _lauf(
+        nutzer("ac7-enddate"), morgen_stunde=NAH(),
+        end_date=ortstag(LOCATION_ZONE, -3).isoformat(),
+    )
+    abrufe_kontrolle = _lauf(nutzer("ac7-enddate-kontrolle"), morgen_stunde=NAH())
+
+    assert abrufe_abgelaufen >= 1, (
+        f"Preset mit abgelaufenem end_date hat kein Briefing mehr — sein Alarm "
+        f"darf NIEMALS von der Vorlauf-Sperre verschluckt werden "
+        f"({abrufe_abgelaufen} Abrufe)."
+    )
+    assert abrufe_kontrolle == 0, (
+        f"Kontroll-Lauf: dasselbe Preset mit gueltigem Zeitraum muss gesperrt "
+        f"sein — sonst misst dieser Test die Sperre gar nicht "
+        f"({abrufe_kontrolle} Abrufe)."
+    )
+
+
+def test_ac7_abgeschaltete_slots_werden_nie_gesperrt(nutzer):
+    """AC-7 (Risiko R1), Grund 2 von 2: Ein Preset mit abgeschaltetem
+    Morgen- UND Abend-Slot hat kein geplantes Briefing — sein Alarm muss
+    durchgehen. Zusaetzlich der schaerfere Halbfall: NUR der Morgen-Slot ist
+    abgeschaltet, der Abend-Slot liegt fern — auch dann darf nichts gesperrt
+    werden.
+
+    ROT HEUTE ueber den Kontroll-Lauf.
+    """
+    abrufe_kein_slot = _lauf(
+        nutzer("ac7-noslot"), morgen_stunde=None, abend_stunde=None,
+    )
+    abrufe_nur_abend_fern = _lauf(
+        nutzer("ac7-halb"), morgen_stunde=None, abend_stunde=FERN(),
+    )
+    abrufe_kontrolle = _lauf(nutzer("ac7-noslot-kontrolle"), morgen_stunde=NAH())
+
+    assert abrufe_kein_slot >= 1, (
+        f"Preset ohne aktiven Slot hat kein Briefing — sein Alarm darf nicht "
+        f"gesperrt werden ({abrufe_kein_slot} Abrufe)."
+    )
+    assert abrufe_nur_abend_fern >= 1, (
+        f"Abgeschalteter Morgen-Slot zur NAH-Stunde darf nicht als faellig "
+        f"gelten ({abrufe_nur_abend_fern} Abrufe)."
+    )
+    assert abrufe_kontrolle == 0, (
+        f"Kontroll-Lauf: dasselbe Preset mit aktivem Morgen-Slot muss gesperrt "
+        f"sein ({abrufe_kontrolle} Abrufe)."
+    )
+
+
+@pytest.mark.parametrize(
+    "grund,kwargs",
+    [
+        ("schedule_manual", {"schedule": "manual"}),
+        ("paused_at", {"paused_at": "2026-08-01T00:00:00Z"}),
+        ("archived_at", {"archived_at": "2026-08-01T00:00:00Z"}),
+    ],
+)
+def test_ac7_stillgelegte_presets_bleiben_wie_bisher_stumm(nutzer, grund, kwargs):
+    """AC-7, die drei stillgelegten Gruende — BESTANDS-ANKER, kein Sperr-Test.
+
+    🔴 Ausdruecklich markiert: dieser Test ist HEUTE gruen und bleibt es. Er
+    kann die neue Sperre nicht messen, weil ``is_silenced()`` vor jeder
+    Alarm-Stufe abbricht (``compare_alert.py:131``) — „nicht durch die neue
+    Sperre unterdrueckt" und „schon vorher stillgelegt" sind beide null Abrufe.
+
+    Sein Wert liegt woanders: er haelt fest, dass die neue Stufe die
+    Reihenfolge NICHT umbaut. Wuerde sie vor ``is_silenced()`` einsortiert und
+    dabei ein stillgelegtes Preset faelschlich als faellig lesen, entstuende
+    genau hier ein Abruf, der heute nicht existiert.
+    """
+    abrufe = _lauf(nutzer(f"ac7-{grund}"), morgen_stunde=NAH(), **kwargs)
+
+    assert abrufe == 0, (
+        f"Stillgelegtes Preset ({grund}): der Stilllegungs-Riegel muss weiter "
+        f"ganz vorne greifen, es waren {abrufe} Abrufe."
+    )
+
+
+# ═══════ AC-10 + AC-13 — kein State-Verbrauch, keine Protokollzeile ═════════
+
+
+def test_ac10_und_ac13_gesperrter_lauf_hinterlaesst_keine_spur(nutzer):
+    """AC-10 + AC-13: Ein durch die neue Sperre unterdrueckter
+    Vergleichs-Aenderungsalarm veraendert weder Melde-Gedaechtnis noch
+    Sperrzeit-Ablage noch Tageszaehler — und erzeugt keine Protokollzeile.
+
+    Beide ACs zusammen, weil sie denselben Schnappschuss brauchen und dieselbe
+    Zusicherung tragen: die Stufe LIEST nur.
+
+    ROT HEUTE ueber die Voraussetzung (der Lauf ist heute nicht gesperrt).
+    """
+    uid = nutzer("ac10-13")
+    write_presets(uid, [compare_preset(
+        PRESET, morgen_stunde=NAH(), quiet=ruhezeit_woanders(),
+    )])
+
+    vorher = zustand_schnappschuss(uid, f"{PRESET}:loc-1594")
+    protokoll_vorher = protokoll_eintraege(uid)
+    abrufe = compare_change_alert_run(uid)
+    nachher = zustand_schnappschuss(uid, f"{PRESET}:loc-1594")
+    protokoll_nachher = protokoll_eintraege(uid)
+
+    assert abrufe == 0, (
+        f"Voraussetzung: der Lauf muss durch die Vorlauf-Sperre unterdrueckt "
+        f"sein ({abrufe} Abrufe)."
+    )
+    assert nachher["melde_gedaechtnis"] == vorher["melde_gedaechtnis"], (
+        f"Melde-Gedaechtnis veraendert: {vorher['melde_gedaechtnis']!r} -> "
+        f"{nachher['melde_gedaechtnis']!r}"
+    )
+    assert nachher["sperrzeit"] == vorher["sperrzeit"], (
+        f"Sperrzeit-Ablage veraendert: {vorher['sperrzeit']!r} -> "
+        f"{nachher['sperrzeit']!r}"
+    )
+    assert nachher["tageszaehler"] == vorher["tageszaehler"], (
+        f"Tageszaehler veraendert: {vorher['tageszaehler']!r} -> "
+        f"{nachher['tageszaehler']!r}"
+    )
+    assert protokoll_nachher == protokoll_vorher, (
+        f"Die Vorlauf-Sperre darf keine Protokollzeile erzeugen — "
+        f"{len(protokoll_vorher)} -> {len(protokoll_nachher)} Eintraege."
+    )
+
+
+# ═════════════════════════ AC-15 — Mandantentrennung ════════════════════════
+
+
+def test_ac15_sperre_wirkt_nur_auf_die_eigenen_daten_des_nutzers(nutzer):
+    """AC-15: Zwei Nutzer, DIESELBE Preset-Kennung, verschiedene Slot-Zeiten.
+    A steht im Vorlauf-Fenster SEINES Briefings und muss schweigen, B nicht.
+
+    Eine Implementierung, die auf ``"default"`` zurueckfaellt oder die Kennung
+    ohne Nutzer-Bezug nachschlaegt, faellt hier durch.
+
+    ROT HEUTE: A meldet ebenfalls (keine Sperre).
+    """
+    abrufe_a = _lauf(nutzer("ac15-a"), morgen_stunde=NAH())
+    abrufe_b = _lauf(nutzer("ac15-b"), morgen_stunde=FERN())
+
+    assert abrufe_a == 0, (
+        f"Nutzer A steht im Vorlauf-Fenster SEINES Briefings — sein Alarm muss "
+        f"schweigen ({abrufe_a} Abrufe)."
+    )
+    assert abrufe_b >= 1, (
+        f"Nutzer B hat sein Briefing erst in fuenf Stunden — die Sperre von A "
+        f"darf ihn nicht mitnehmen ({abrufe_b} Abrufe)."
+    )

--- a/tests/tdd/test_compare_alert_briefing_imminent.py
+++ b/tests/tdd/test_compare_alert_briefing_imminent.py
@@ -44,6 +44,7 @@ Pfadregel #1409: alle Pfade relativ zu DIESER Datei bzw. ueber
 from __future__ import annotations
 
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -55,6 +56,8 @@ for _p in (str(ROOT), str(ROOT / "src")):
 
 from tests.helpers.briefing_imminent_fixtures import (  # noqa: E402
     LOCATION_ZONE,
+    briefing_anker_setzen,
+    briefing_versand_gescheitert,
     clean_uid,
     compare_change_alert_run,
     compare_preset,
@@ -318,3 +321,68 @@ def test_ac15_sperre_wirkt_nur_auf_die_eigenen_daten_des_nutzers(nutzer):
         f"Nutzer B hat sein Briefing erst in fuenf Stunden — die Sperre von A "
         f"darf ihn nicht mitnehmen ({abrufe_b} Abrufe)."
     )
+
+
+# ════════ AC-5 — der VERSUCH beendet die Sperre, auch ohne Vermerk ══════════
+#
+# 🔴 Der Ortsvergleich hat KEINEN Idempotenz-Vermerk: ``presets_due_for_hour``
+# prueft reine Stundengleichheit. Ein Preset bleibt seine ganze Slot-Stunde
+# ueber „faellig" — auch nach dem gelungenen Versand. Beim Trip nimmt der
+# Vermerk die Faelligkeit; hier traegt die Sperr-Beendigung ALLEIN der
+# Briefing-Anker. Faellt sie aus, schweigt der Alarm bis zum Ende der
+# Slot-Stunde, obwohl das Briefing schon durch ist.
+#
+# Uhr GESTELLT statt geerbt (dasselbe wie im Trip-Teil): der Slot muss
+# bereits LAUFEN, und die uebrigen Tests dieser Datei koennen nur Slots in der
+# Zukunft legen. `check_all_compare_presets()` holt sich den Zeitpunkt selbst,
+# er ist kein Parameter — Einfrieren ist hier also zulaessig.
+# Europe/Vienna liegt Mitte Maerz auf UTC+1: 08:20 UTC = 09:20 Ortszeit.
+_JETZT_UTC = datetime(2026, 3, 15, 8, 20, tzinfo=timezone.utc)
+_SLOT_STUNDE_ORTSZEIT = 9
+
+
+@pytest.mark.parametrize(
+    "ausgang, erwartet_abrufe",
+    [("erfolgreich", True), ("gescheitert", True), ("ohne_versuch", False)],
+)
+def test_ac5_der_briefing_versuch_beendet_die_sperre(
+    nutzer, ausgang, erwartet_abrufe,
+):
+    """AC-5 (Ortsvergleich): Die Sperre endet mit dem Versandversuch — ob er
+    gelang oder scheiterte.
+
+    Der Alarm-Lauf liegt 20 Minuten hinter dem Slot-Beginn, das Preset ist
+    also weiterhin faellig (Stundengleichheit, kein Vermerk). Beide
+    Versandausgaenge schreiben den Briefing-Anker: der gelungene ueber
+    ``_anchor_and_reset()``, der gescheiterte ueber denselben Aufruf im
+    Fehler-Zweig (#1629, ``scheduler_dispatch_service.py:561-566``). Genau
+    deshalb darf der Anker die Sperre nicht AUSLOESEN, sondern muss sie
+    BEENDEN.
+
+    Der Kontrollfall ``ohne_versuch`` haelt die Grenze: ohne Anker steht das
+    Briefing noch aus und die Meldung bleibt gesperrt.
+    """
+    from freezegun import freeze_time
+
+    with freeze_time(_JETZT_UTC):
+        user_id = nutzer(f"ac5-{ausgang}")
+        if ausgang == "erfolgreich":
+            briefing_anker_setzen(user_id, PRESET, "compare", vor_minuten=20)
+        elif ausgang == "gescheitert":
+            briefing_versand_gescheitert(
+                user_id, PRESET, entity_type="compare", kind="vergleich",
+                vor_minuten=20,
+            )
+        abrufe = _lauf(user_id, morgen_stunde=_SLOT_STUNDE_ORTSZEIT)
+
+    if erwartet_abrufe:
+        assert abrufe >= 1, (
+            f"Das Briefing wurde vor 20 Minuten versucht ({ausgang}) — die "
+            f"Sperre muss enden, es waren {abrufe} Abrufe. Ohne den Anker "
+            f"schwiege der Alarm bis zum Ende der Slot-Stunde."
+        )
+    else:
+        assert abrufe == 0, (
+            f"Ohne Versandversuch steht das Briefing der laufenden Slot-Stunde "
+            f"noch aus — der Alarm muss schweigen, es waren {abrufe} Abrufe."
+        )

--- a/tests/tdd/test_compare_dispatch_failed_tally.py
+++ b/tests/tdd/test_compare_dispatch_failed_tally.py
@@ -124,7 +124,13 @@ def dispatch_env(tmp_path, monkeypatch):
 def _write_presets(data_root: Path, user_id: str, presets: list[dict]) -> None:
     user_dir = data_root / "users" / user_id
     user_dir.mkdir(parents=True, exist_ok=True)
-    write_compare_briefings(user_dir, presets)
+    # Issue #1594: KEINE ausgewichene Briefing-Stunde hier. Diese Datei prueft
+    # den BRIEFING-Versand und braucht den Migrations-Rueckfall (Morgen-Slot
+    # 06:00 Ortszeit), auf den der Ausloeser `hour=6` zielt — eine
+    # ausgewichene Stunde machte die Presets unfaellig und der gemessene Lauf
+    # faende gar nicht statt. Die Vorlauf-Sperre beruehrt den Briefing-Pfad
+    # nicht, nur die Alarm-Pfade.
+    write_compare_briefings(user_dir, presets, briefing_stunde_setzen=False)
 
 
 def _write_location(data_root: Path, user_id: str, loc_id: str, name: str) -> None:

--- a/tests/tdd/test_compare_official_alert.py
+++ b/tests/tdd/test_compare_official_alert.py
@@ -87,7 +87,14 @@ def _location(loc_id: str, name: str, lat: float, lon: float) -> SavedLocation:
 
 def _preset(preset_id, location_ids, empfaenger, *, triggers_enabled=None,
             send_telegram=None, send_sms=None, name=None, schedule="daily",
-            archived_at=None, alert_quiet_from=None, alert_quiet_to=None) -> dict:
+            archived_at=None, alert_quiet_from=None, alert_quiet_to=None,
+            morning_time=None) -> dict:
+    """``morning_time`` (Issue #1594): ohne Angabe setzt
+    ``write_compare_briefings()`` eine Stunde ausserhalb des Vorlauf-Fensters,
+    gerechnet gegen die ECHTE Uhr. Tests, die die Uhr des Dienstes EINFRIEREN,
+    muessen die Stunde selbst waehlen — fuer sie ist die echte Uhr die falsche
+    Bezugsgroesse, und die berechnete Stunde faellt je nach Tageszeit mit der
+    eingefrorenen zusammen."""
     # Issue #1233: der Default war frueher "manual" (beliebig gewaehlt, bevor
     # "manual" eine Gating-Bedeutung hatte). Seit #1233 heisst schedule=="manual"
     # "Ortsvergleich deaktiviert" -> Default hier auf "daily" (aktiv) umgestellt,
@@ -112,6 +119,8 @@ def _preset(preset_id, location_ids, empfaenger, *, triggers_enabled=None,
         p["alert_quiet_from"] = alert_quiet_from
     if alert_quiet_to is not None:
         p["alert_quiet_to"] = alert_quiet_to
+    if morning_time is not None:
+        p["morning_time"] = morning_time
     return p
 
 
@@ -371,7 +380,12 @@ def test_f001_compare_alert_localizes_validity_to_location_timezone(monkeypatch)
     b._REGISTERED_SOURCES.clear()
     try:
         save_location(_location("loc-a", "Hermagor", LAT_A, LON_A), user_id=uid)
-        _write_presets(uid, [_preset("p1", ["loc-a"], ["e@x.invalid"])])
+        # Issue #1594: eingefroren auf 08:00 UTC = 10:00 Hermagor — eine aus der
+        # ECHTEN Uhr gerechnete Briefing-Stunde faellt dort zeitweise mit dem
+        # Vorlauf-Fenster zusammen. 16:00 liegt sicher daneben.
+        _write_presets(uid, [_preset(
+            "p1", ["loc-a"], ["e@x.invalid"], morning_time="16:00:00",
+        )])
         # Issue #1460 (P4): Die Warnung liegt jetzt am SELBEN Tag im
         # Tagesfenster statt am Folgetag -- eine erst morgen gueltige Warnung
         # wird heute nicht mehr gemeldet (AC-31). Damit das Ergebnis nicht von
@@ -624,9 +638,16 @@ def test_ac1_quiet_hours_suppresses_send_state_and_limit(monkeypatch):
     b._REGISTERED_SOURCES.clear()
     try:
         save_location(_location("loc-a", "Hermagor", LAT_A, LON_A), user_id=uid)
+        # Issue #1594: Briefing-Stunde ausserhalb des Vorlaufs der EINGEFRORENEN
+        # Runden — 00:00 UTC = 02:00 und 09:00 UTC = 11:00 in Hermagor
+        # (Europe/Vienna); 16:00 liegt von beiden Fenstern weit weg. Ohne das
+        # waere AC-1 zeitweise aus dem falschen Grund gruen: die Sperre
+        # unterdrueckt denselben Versand wie die Ruhezeit, und der Test koennte
+        # die Ruhezeit nicht mehr von ihr unterscheiden.
         _write_presets(uid, [_preset(
             "p1", ["loc-a"], ["e@x.invalid"],
             alert_quiet_from="22:00", alert_quiet_to="06:00",
+            morning_time="16:00:00",
         )])
         register_official_alert_source(_FakeOfficialAlertSource(LAT_A, LON_A, [_alert()]))
         frozen_midnight = datetime(2026, 7, 12, 0, 0, tzinfo=timezone.utc)
@@ -672,9 +693,16 @@ def test_ac2_quiet_hour_suppression_does_not_permanently_swallow_warning(monkeyp
     b._REGISTERED_SOURCES.clear()
     try:
         save_location(_location("loc-a", "Hermagor", LAT_A, LON_A), user_id=uid)
+        # Issue #1594: Briefing-Stunde ausserhalb des Vorlaufs der EINGEFRORENEN
+        # Runden — 00:00 UTC = 02:00 und 09:00 UTC = 11:00 in Hermagor
+        # (Europe/Vienna); 16:00 liegt von beiden Fenstern weit weg. Ohne das
+        # waere AC-1 zeitweise aus dem falschen Grund gruen: die Sperre
+        # unterdrueckt denselben Versand wie die Ruhezeit, und der Test koennte
+        # die Ruhezeit nicht mehr von ihr unterscheiden.
         _write_presets(uid, [_preset(
             "p1", ["loc-a"], ["e@x.invalid"],
             alert_quiet_from="22:00", alert_quiet_to="06:00",
+            morning_time="16:00:00",
         )])
         # Issue #1460 (P4): Die Warnzeiten muessen zur EINGEFRORENEN Uhr passen.
         # Vorher trug die Warnung real-jetzt-relative Zeiten (`_alert()`-Default),

--- a/tests/tdd/test_compare_official_alert_briefing_imminent.py
+++ b/tests/tdd/test_compare_official_alert_briefing_imminent.py
@@ -1,0 +1,282 @@
+"""TDD RED — Ortsvergleich (amtliche Warnung): keine Doppel-Meldung kurz vor
+einem geplanten Briefing (Issue #1594, AC-4, AC-9, AC-10, AC-13).
+
+SPEC:    docs/specs/modules/fix_1594_alarm_vorlauf_sperre.md
+KONTEXT: docs/context/fix-1594-alarm-vorlauf-sperre.md
+
+Einhaengepunkt: ``src/services/compare_official_alert.py:126`` (direkt nach der
+Ruhezeit-Pruefung, VOR ``_detect()``).
+
+Diese Datei faehrt bewusst den ECHTEN Versandpfad mit einer echten, lokalen
+Warnquelle (``FakeOfficialAlertSource`` — strukturelles Subtyping, kein Mock,
+kein Netz) statt mit abgeklemmter Erkennung. Nur so entstehen heute
+tatsaechlich Melde-Gedaechtnis, Sperrzeit, Tageszaehler und Protokoll-Eintrag —
+und nur so lassen sich AC-10/AC-13 ueberhaupt messen. Ein Lauf mit
+abgeklemmtem ``_detect()`` haette gar nichts zu buchen und waere fuer diese
+beiden ACs strukturell blind.
+
+═══════════════════════════════════════════════════════════════════════════
+DIE #1233-ZUSICHERUNG, DIE HIER NICHT BRECHEN DARF
+═══════════════════════════════════════════════════════════════════════════
+
+``compare_official_alert.py:124-125`` sichert woertlich zu: eine waehrend der
+Ruhezeit unterdrueckte Warnung schreibt KEINEN State, damit sie nach Ende der
+Ruhezeit noch als „neu" zugestellt wird. Bewacht von
+``tests/tdd/test_compare_official_alert.py:610``, das unveraendert gruen
+bleiben MUSS.
+
+Die neue Sperre haelt dieselbe Eigenschaft ein: sie liest nur. Fuer eine
+Entitaet OHNE anstehendes Briefing greift sie gar nicht — die Sammel-
+Zustellung nach Ruhezeit-Ende bleibt dort unveraendert (AC-9). Fuer eine
+Entitaet MIT anstehendem Briefing verzoegert sie bis zum Briefing, das den
+Anker setzt und das Melde-Gedaechtnis zuruecksetzt.
+
+Zur Minutengenauigkeit: AC-4 spricht von „in 10 Minuten". Versandzeiten
+existieren im Produktivsystem nur stundengenau (Go kappt sie beim Schreiben
+UND beim Laden, ``internal/store/slot_hour_normalization.go``) — der
+Vorlauf wirkt deshalb stundenbezogen. Die Tests stellen den Slot auf die
+Stunde, die in einer Stunde gilt: jetzt nicht faellig, im Vorlauf-Fenster
+schon.
+
+Pfadregel #1409: alle Pfade relativ zu DIESER Datei bzw. ueber
+``app.loader.get_data_dir()``.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+for _p in (str(ROOT), str(ROOT / "src")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tests.helpers.briefing_imminent_fixtures import (  # noqa: E402
+    LOCATION_ZONE,
+    clean_uid,
+    compare_official_alert_run,
+    compare_official_versand_lauf,
+    compare_preset,
+    fresh_uid,
+    protokoll_eintraege,
+    ruhezeit_woanders,
+    stunde_versetzt,
+    write_location,
+    write_presets,
+    write_user_tier,
+    zustand_schnappschuss,
+)
+
+PRESET = "cp-1594-amtlich"
+ORT = "loc-1594"
+
+
+def NAH() -> int:
+    return stunde_versetzt(1, zone=LOCATION_ZONE)
+
+
+def FERN() -> int:
+    return stunde_versetzt(5, zone=LOCATION_ZONE)
+
+
+def ruhezeit_jetzt(puffer_minuten: int = 20) -> tuple[str, str]:
+    """Ruhezeit-Fenster in der ORTSZONE, das den jetzigen Zeitpunkt umschliesst
+    — seit #1726 wertet ``is_quiet_hours()`` in der Zone des Gegenstands aus,
+    das Fenster muss also in DERSELBEN Zone gebildet werden."""
+    jetzt = datetime.now(timezone.utc).astimezone(LOCATION_ZONE)
+    return (
+        (jetzt - timedelta(minutes=puffer_minuten)).strftime("%H:%M"),
+        (jetzt + timedelta(minutes=puffer_minuten)).strftime("%H:%M"),
+    )
+
+
+@pytest.fixture
+def nutzer():
+    vergeben: list[str] = []
+
+    def _neu(kennung: str, tier: str = "premium") -> str:
+        user_id = fresh_uid(kennung)
+        clean_uid(user_id)
+        write_user_tier(user_id, tier)
+        write_location(user_id, ORT)
+        vergeben.append(user_id)
+        return user_id
+
+    yield _neu
+    for user_id in vergeben:
+        clean_uid(user_id)
+
+
+def _preset_schreiben(user_id: str, **kwargs) -> None:
+    kwargs.setdefault("quiet", ruhezeit_woanders())
+    write_presets(user_id, [compare_preset(PRESET, **kwargs)])
+
+
+# ═════════════ AC-4 — amtliche Vergleichs-Warnung im Vorlauf-Fenster ════════
+
+
+def test_ac4_amtliche_warnung_schweigt_wenn_das_briefing_unmittelbar_bevorsteht(nutzer):
+    """AC-4: Steht das naechste geplante Briefing des Ortsvergleichs in Kuerze
+    an, geht die amtliche Warnung NICHT mehr als eigene Zusatz-Meldung raus.
+
+    Gemessen am echten Versandpfad (Rueckgabe des Dienstes UND Mail-Weg), nicht
+    an einem Zaehler — hier interessiert die ZUSTELLUNG, nicht der Abruf.
+
+    ROT HEUTE: es gibt keine Vorlauf-Pruefung, die Warnung geht raus.
+    """
+    nah = nutzer("ac4-nah")
+    _preset_schreiben(nah, morgen_stunde=NAH())
+    sent_nah, mails_nah = compare_official_versand_lauf(nah)
+
+    fern = nutzer("ac4-fern")
+    _preset_schreiben(fern, morgen_stunde=FERN())
+    sent_fern, mails_fern = compare_official_versand_lauf(fern)
+
+    assert (sent_nah, mails_nah) == (0, []), (
+        f"Briefing steht in unter 60 Minuten an — die amtliche Warnung darf "
+        f"nicht als eigene Meldung rausgehen: sent={sent_nah}, "
+        f"Mails={len(mails_nah)}"
+    )
+    assert sent_fern >= 1 and len(mails_fern) >= 1, (
+        f"Ein Briefing in fuenf Stunden darf die amtliche Warnung NICHT sperren "
+        f"— sonst Schweigen ohne Ersatz: sent={sent_fern}, "
+        f"Mails={len(mails_fern)}"
+    )
+
+
+def test_ac4_sperre_greift_vor_dem_warnungs_abruf(nutzer):
+    """AC-4 (Ergaenzung, Invariante „vor jedem Abruf"): Ein gesperrter Lauf
+    darf die Warnungs-Erkennung gar nicht erst erreichen — die neue Stufe sitzt
+    laut Spec VOR ``_detect()``.
+
+    Gemessen an der Netz-Naht selbst, nicht am Versand: eine Sperre, die erst
+    NACH dem Abruf greift, waere fuer den Nutzer gleich, kostete aber weiter
+    Laufzeit und Kontingent.
+
+    ROT HEUTE: ``_detect`` wird gerufen.
+    """
+    nah = nutzer("ac4-abruf-nah")
+    _preset_schreiben(nah, morgen_stunde=NAH())
+    abrufe_nah = compare_official_alert_run(nah)
+
+    fern = nutzer("ac4-abruf-fern")
+    _preset_schreiben(fern, morgen_stunde=FERN())
+    abrufe_fern = compare_official_alert_run(fern)
+
+    assert abrufe_nah == 0, (
+        f"Die Sperre muss VOR der Warnungs-Erkennung greifen, es waren "
+        f"{abrufe_nah} Aufrufe."
+    )
+    assert abrufe_fern >= 1, (
+        f"Ohne anstehendes Briefing muss die Erkennung unveraendert laufen "
+        f"({abrufe_fern} Aufrufe)."
+    )
+
+
+# ═══════ AC-9 — die #1233-Sammel-Zustellung bleibt fuer Entitaeten OHNE ═════
+# ═══════        anstehendes Briefing vollstaendig erhalten                ═══
+
+
+def test_ac9_ruhezeit_ende_stellt_ohne_anstehendes_briefing_weiter_zu(nutzer):
+    """AC-9: Die bewusst gebaute #1233-Eigenschaft — waehrend der Ruhezeit
+    unterdrueckte Warnungen brechen nach deren Ende gesammelt los — bleibt fuer
+    Entitaeten OHNE anstehendes Briefing UNVERAENDERT.
+
+    Zwei Runden mit demselben Preset und derselben Warnung:
+      Runde 1 — Ruhezeit umschliesst jetzt  -> keine Zustellung, KEIN State.
+      Runde 2 — Ruhezeit liegt woanders     -> Zustellung (die Warnung gilt
+                                               weiterhin als „neu").
+
+    Und die Gegenprobe im selben Test: dasselbe Preset MIT Briefing im
+    Vorlauf-Fenster bleibt in Runde 2 still — dort wird die Warnung nicht
+    verschluckt, sondern vom Briefing Minuten spaeter mitgetragen.
+
+    Ohne die Gegenprobe waere dieser Test heute gruen und bewiese nichts.
+
+    ROT HEUTE: die zweite Haelfte (Preset mit Briefing) stellt zu.
+    """
+    ohne = nutzer("ac9-ohne")
+    _preset_schreiben(
+        ohne, morgen_stunde=None, abend_stunde=None, quiet=ruhezeit_jetzt(),
+    )
+    sent_ruhe, mails_ruhe = compare_official_versand_lauf(ohne)
+    zustand_ruhe = zustand_schnappschuss(ohne, f"{PRESET}:{ORT}")
+
+    _preset_schreiben(ohne, morgen_stunde=None, abend_stunde=None)
+    sent_wach, mails_wach = compare_official_versand_lauf(ohne)
+
+    mit = nutzer("ac9-mit")
+    _preset_schreiben(mit, morgen_stunde=NAH(), quiet=ruhezeit_jetzt())
+    compare_official_versand_lauf(mit)
+    _preset_schreiben(mit, morgen_stunde=NAH())
+    sent_mit, mails_mit = compare_official_versand_lauf(mit)
+
+    assert (sent_ruhe, mails_ruhe) == (0, []), (
+        f"Runde 1: die Ruhezeit muss die Warnung unterdruecken: "
+        f"sent={sent_ruhe}, Mails={len(mails_ruhe)}"
+    )
+    assert not any(
+        k.startswith("official_alert:") for k in zustand_ruhe["melde_gedaechtnis"]
+    ), (
+        f"#1233: eine waehrend der Ruhezeit unterdrueckte Warnung darf KEINEN "
+        f"State schreiben, sonst wird sie nach Ende der Ruhezeit als 'schon "
+        f"gemeldet' verschluckt: {zustand_ruhe['melde_gedaechtnis']!r}"
+    )
+    assert sent_wach >= 1 and len(mails_wach) >= 1, (
+        f"Runde 2 ohne anstehendes Briefing: die Warnung MUSS nach Ende der "
+        f"Ruhezeit gesammelt zugestellt werden — die neue Sperre darf hier gar "
+        f"nicht greifen: sent={sent_wach}, Mails={len(mails_wach)}"
+    )
+    assert (sent_mit, mails_mit) == (0, []), (
+        f"Gegenprobe: dasselbe Preset MIT Briefing im Vorlauf-Fenster muss "
+        f"still bleiben — die Warnung kommt Minuten spaeter im Briefing an: "
+        f"sent={sent_mit}, Mails={len(mails_mit)}"
+    )
+
+
+# ═══════ AC-10 + AC-13 — kein State-Verbrauch, keine Protokollzeile ════════
+
+
+def test_ac10_und_ac13_gesperrter_lauf_hinterlaesst_keine_spur(nutzer):
+    """AC-10 (Risiko R4) + AC-13: Eine durch die neue Sperre unterdrueckte
+    amtliche Vergleichs-Warnung veraendert weder Melde-Gedaechtnis noch
+    Sperrzeit-Ablage noch Tageszaehler — und erzeugt keine Protokollzeile.
+
+    Der Lauf ist bewusst der ECHTE Versandpfad: heute schreibt er alle vier
+    Spuren (``compare_official_alert.py`` bucht State, Sperrzeit, Tageszaehler
+    und Protokoll nach dem Versand). Damit ist dieser Test heute aus dem
+    RICHTIGEN Grund rot — nicht bloss mangels Gelegenheit zu buchen.
+    """
+    uid = nutzer("ac10-13")
+    _preset_schreiben(uid, morgen_stunde=NAH())
+
+    vorher = zustand_schnappschuss(uid, f"{PRESET}:{ORT}")
+    protokoll_vorher = protokoll_eintraege(uid)
+    sent, mails = compare_official_versand_lauf(uid)
+    nachher = zustand_schnappschuss(uid, f"{PRESET}:{ORT}")
+    protokoll_nachher = protokoll_eintraege(uid)
+
+    assert (sent, mails) == (0, []), (
+        f"Voraussetzung: der Lauf muss durch die Vorlauf-Sperre unterdrueckt "
+        f"sein: sent={sent}, Mails={len(mails)}"
+    )
+    assert nachher["melde_gedaechtnis"] == vorher["melde_gedaechtnis"], (
+        f"Melde-Gedaechtnis veraendert: {vorher['melde_gedaechtnis']!r} -> "
+        f"{nachher['melde_gedaechtnis']!r}"
+    )
+    assert nachher["sperrzeit"] == vorher["sperrzeit"], (
+        f"Sperrzeit-Ablage veraendert: {vorher['sperrzeit']!r} -> "
+        f"{nachher['sperrzeit']!r}"
+    )
+    assert nachher["tageszaehler"] == vorher["tageszaehler"], (
+        f"Tageszaehler veraendert: {vorher['tageszaehler']!r} -> "
+        f"{nachher['tageszaehler']!r}"
+    )
+    assert protokoll_nachher == protokoll_vorher, (
+        f"Die Vorlauf-Sperre darf keine Protokollzeile erzeugen — "
+        f"{len(protokoll_vorher)} -> {len(protokoll_nachher)} Eintraege, neu: "
+        f"{protokoll_nachher[len(protokoll_vorher):]!r}"
+    )

--- a/tests/tdd/test_corridor_no_longer_triggers_alerts.py
+++ b/tests/tdd/test_corridor_no_longer_triggers_alerts.py
@@ -45,6 +45,8 @@ from app.models import (
 )
 from app.trip import Stage, Trip, Waypoint
 
+from tests.helpers.briefing_zeiten import briefing_zeiten_fuer_trip
+
 # Pfadregel #1409: Pruefling relativ zur Testdatei, nicht ueber den Hauptrepo-Pfad.
 DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
 
@@ -124,8 +126,12 @@ def _corridor_plus_level_trip(trip_id: str) -> Trip:
         metrics=[MetricConfig(metric_id="gust", enabled=True)],
         metric_alert_levels={"wind_gust": "standard"},
     )
+    # Issue #1594: Briefing-Zeiten ausserhalb des Vorlaufs — sonst schwiege die
+    # Empfindlichkeitsstufe wegen der Sperre statt wegen des Wertebereichs.
+    morgen, abend = briefing_zeiten_fuer_trip(trip)
     trip.report_config = TripReportConfig(
         trip_id=trip_id, send_email=True, alert_on_changes=True,
+        morning_time=morgen, evening_time=abend,
     )
     return trip
 

--- a/tests/tdd/test_issue_1088_official_alert_triggers.py
+++ b/tests/tdd/test_issue_1088_official_alert_triggers.py
@@ -43,6 +43,8 @@ from app.models import (
 )
 from app.trip import Stage, Trip, Waypoint
 
+from tests.helpers.briefing_zeiten import briefing_zeiten_fuer_trip
+
 DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
 
 LAT, LON = 47.0, 11.0
@@ -109,7 +111,11 @@ def _minimal_trip(trip_id: str, **trip_kwargs) -> Trip:
         waypoints=[Waypoint(id="G1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0)],
     )
     trip = Trip(id=trip_id, name="Amtliche-Warnung-Trip", stages=[stage], **trip_kwargs)
-    trip.report_config = TripReportConfig(trip_id=trip_id, send_email=True)
+    # Issue #1594: Briefing-Zeiten ausserhalb des Vorlaufs (Vorbedingung).
+    morgen, abend = briefing_zeiten_fuer_trip(trip)
+    trip.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=True, morning_time=morgen, evening_time=abend,
+    )
     return trip
 
 
@@ -133,7 +139,12 @@ def _delta_trip(trip_id: str, **trip_kwargs) -> Trip:
         ),
         **trip_kwargs,
     )
-    trip.report_config = TripReportConfig(trip_id=trip_id, send_email=True, alert_on_changes=True)
+    # Issue #1594: Briefing-Zeiten ausserhalb des Vorlaufs (Vorbedingung).
+    morgen, abend = briefing_zeiten_fuer_trip(trip)
+    trip.report_config = TripReportConfig(
+        trip_id=trip_id, send_email=True, alert_on_changes=True,
+        morning_time=morgen, evening_time=abend,
+    )
     return trip
 
 
@@ -547,8 +558,12 @@ class TestF001OfficialTriggerViaCheckAllTrips:
             )
             # Wetter-Delta-Alert vom Nutzer explizit deaktiviert, keine aktive Regel
             # (kein preset, keine metric_alert_levels, keine alert_rules).
+            # Issue #1594: Briefing-Zeiten ausserhalb des Vorlaufs — sonst
+            # schwiege der eigenstaendige Trigger wegen der Sperre.
+            morgen, abend = briefing_zeiten_fuer_trip(trip)
             trip.report_config = TripReportConfig(
                 trip_id=trip.id, send_email=True, alert_on_changes=False,
+                morning_time=morgen, evening_time=abend,
             )
             # official_alert_triggers_enabled bleibt None -> Default = aktiv.
             save_trip(trip, user_id=user_id)

--- a/tests/tdd/test_issue_638_alerts_redesign.py
+++ b/tests/tdd/test_issue_638_alerts_redesign.py
@@ -45,6 +45,8 @@ from app.models import (
 from app.trip import Stage, Trip, Waypoint
 import output.channels.telegram as telegram_mod
 
+from tests.helpers.briefing_zeiten import briefing_zeiten_fuer_trip
+
 
 def _reset_alert_state(user_id: str) -> None:
     """State-Bereinigung für Idempotenz (Issue #816: alert_state persistiert;
@@ -254,8 +256,39 @@ def _trip(rule: AlertRule, report_config: TripReportConfig | None = None) -> Tri
         display_config=_alert_display_config("tdd-638-trip"),
     )
     trip.alert_rules = [rule]
+    # Issue #1594: ohne gesetzte Briefing-Zeiten gelten 07:00/18:00 Ortszeit;
+    # die Vorlauf-Sperre schnitte den Alarm dann taeglich fuer je eine Stunde
+    # vor der Kanal-Aufloesung ab. Nur die Vorbedingung wandert — welche
+    # Kanaele an sind, bleibt Sache des jeweiligen Tests.
+    #
+    # 🔴 `report_config=None` wird hier NICHT erfunden: in dieser Datei ist der
+    # Fall bedeutungstragend (nur dann greift der E-Mail-Default, s.
+    # `test_f001_all_channels_off_sends_nothing`). Die zwei Alarm-Tests, die
+    # ihn benutzten, reichen ihr `report_config` jetzt selbst herein — dort
+    # steht auch, warum das ihre Aussage nicht antastet.
     trip.report_config = report_config
+    if trip.report_config is not None:
+        (trip.report_config.morning_time,
+         trip.report_config.evening_time) = briefing_zeiten_fuer_trip(trip)
     return trip
+
+
+def _briefing_config(trip_id: str) -> TripReportConfig:
+    """Briefing-Konfiguration, die den Trip aus dem Vorlauf-Fenster der
+    Alarm-Sperre (#1594) haelt und sonst nichts aussagt.
+
+    ``send_email=True`` bildet den Zustand nach, den ein Trip OHNE
+    ``report_config`` in der Kanal-Aufloesung hat (E-Mail-Default). Fuer
+    Regeln mit explizitem Kanal-Override — die einzigen, die diese
+    Konfiguration bekommen — ist beides ohnehin gleichwertig.
+
+    Die Uhrzeiten setzt :func:`_trip` selbst, in der Zone der Tour
+    (``anchor_tz``) — hier waere jede feste Zone geraten.
+    """
+    return TripReportConfig(
+        trip_id=trip_id, send_email=True, send_telegram=False,
+        alert_on_changes=True,
+    )
 
 
 def _wind_rule(severity: AlertSeverity, channels: list[str]) -> AlertRule:
@@ -302,7 +335,15 @@ def test_ac1_info_severity_alert_is_no_longer_silently_swallowed(
     Heute: info → ChangeSeverity.MINOR → vom MODERATE-Filter verschluckt → kein Versand.
     """
     rule = _wind_rule(AlertSeverity.INFO, channels=["telegram"])
-    trip = _trip(rule, report_config=None)
+    # Issue #1594: mit `report_config=None` gilt der Trip um 07:00/18:00
+    # Ortszeit als briefing-faellig (`_slot_stunde()` faellt genau darauf
+    # zurueck) und die Vorlauf-Sperre schwieg den Alarm ab — der Severity-Fall
+    # waere dann gar nicht mehr gemessen worden. Die Kanal-Aufloesung bleibt
+    # davon unberuehrt: die Regel traegt einen expliziten Override, und ein
+    # Override schlaegt `report_config` (AC-2 dieser Datei). NACHGEMESSEN
+    # ueber `_effective_alert_channels`: mit und ohne `report_config` exakt
+    # {'telegram'}.
+    trip = _trip(rule, report_config=_briefing_config("tdd-638-trip"))
 
     result = _run_alert(trip, _settings(smtp_refuse.port), user_id="tdd-638-ac1")
 
@@ -469,6 +510,11 @@ def test_mixed_rules_union_both_channels(telegram_sink, smtp_refuse, tmp_path):
     )
     trip.alert_rules = [rule_a, rule_b]
     trip.report_config = report_config
+    # Issue #1594: Briefing-Zeiten ausserhalb des Vorlaufs — sonst schwiege der
+    # Alarm wegen der Sperre und die Union-Semantik bliebe ungemessen. Die
+    # Kanal-Flags oben bleiben unberuehrt.
+    (report_config.morning_time,
+     report_config.evening_time) = briefing_zeiten_fuer_trip(trip)
 
     from services.trip_alert import TripAlertService
 
@@ -525,6 +571,10 @@ def test_channel_inheritance_no_alert_rules_uses_report_config(
     )
     trip.alert_rules = []  # keine alert_rules → Kanäle werden aus report_config geerbt
     trip.report_config = report_config
+    # Issue #1594: Briefing-Zeiten ausserhalb des Vorlaufs — die Kanal-Flags
+    # oben (die eigentliche Zusicherung) bleiben unberuehrt.
+    (report_config.morning_time,
+     report_config.evening_time) = briefing_zeiten_fuer_trip(trip)
 
     from services.trip_alert import TripAlertService
 
@@ -568,7 +618,10 @@ def test_telegram_only_user_without_smtp_still_gets_alert(telegram_sink, tmp_pat
         telegram_chat_id="test-chat",
     )
     rule = _wind_rule(AlertSeverity.WARNING, channels=["telegram"])
-    trip = _trip(rule, report_config=None)
+    # Issue #1594: wie in AC-1 — ohne Briefing-Zeiten schwiege die Sperre den
+    # Alarm zeitweise ab, und der SMTP-Guard-Fall waere ungemessen. Die
+    # Kanal-Aufloesung bleibt {'telegram'} (expliziter Override, s. AC-1).
+    trip = _trip(rule, report_config=_briefing_config("tdd-638-trip"))
 
     # State-Bereinigung für Idempotenz (Issue #816: alert_state persistiert;
     # alert_daily_count.json zusaetzlich seit #1070, siehe Kommentar oben).

--- a/tests/tdd/test_ruhezeit_und_zaehler_folgen_der_ortszone.py
+++ b/tests/tdd/test_ruhezeit_und_zaehler_folgen_der_ortszone.py
@@ -183,10 +183,21 @@ def vergleichs_preset(
     *,
     quiet_from: str | None = None,
     quiet_to: str | None = None,
-    morning_time: str = "07:00:00",
+    morning_time: str | None = None,
 ) -> dict:
     """Vergleichs-Preset im Bestandsschema (Feldauswahl analog
-    `tests/test_compare_auto_pause_end_date.py::_make_preset`)."""
+    `tests/test_compare_auto_pause_end_date.py::_make_preset`).
+
+    Issue #1594: `morning_time` stand hier fest auf "07:00:00". Liegt die
+    Ortszeit des Presets in der Stunde davor, unterdrückt die neue
+    Vorlauf-Sperre den Alarm aus einem ZWEITEN Grund — die Ruhezeit-Messung
+    dieser Datei wäre dann nicht mehr die gemessene (belegt: AC-3 Stelle 1/6
+    und AC-4 waren so täglich zwei Stunden rot). Ohne Angabe setzt jetzt
+    `write_compare_briefings()` eine Stunde ausserhalb des Vorlaufs, und zwar
+    in der ZONE DER ORTE dieses Presets — hier stehen Auckland und Los Angeles
+    nebeneinander, eine gemeinsame feste Stunde kann es also gar nicht geben.
+    Wer eine bestimmte Stunde braucht (AC-9: Fälligkeit zur Ortsstunde),
+    übergibt sie weiterhin ausdrücklich."""
     preset: dict = {
         "id": preset_id,
         "name": f"Vergleich {preset_id}",
@@ -202,10 +213,11 @@ def vergleichs_preset(
         "created_at": "2026-08-01T00:00:00Z",
         "archived_at": None,
         "morning_enabled": True,
-        "morning_time": morning_time,
         "evening_enabled": False,
         "evening_time": "18:00:00",
     }
+    if morning_time is not None:
+        preset["morning_time"] = morning_time
     if quiet_from is not None:
         preset["alert_quiet_from"] = quiet_from
     if quiet_to is not None:

--- a/tests/tdd/test_telegram_test_mode_guard.py
+++ b/tests/tdd/test_telegram_test_mode_guard.py
@@ -410,7 +410,10 @@ class TestGuardBlockVisibleInCompareFailedTally:
             "empfaenger": ["gregor-test@henemm.com"],
             "send_telegram": True,
             "created_at": "2026-07-01T00:00:00Z",
-        }])
+        # Issue #1594: der BRIEFING-Versand wird gemessen, nicht ein Alarm —
+        # der Migrations-Rueckfall (Morgen-Slot 06:00 Ortszeit) muss stehen
+        # bleiben, sonst zielt der Ausloeser `hour=6` ins Leere.
+        }], briefing_stunde_setzen=False)
 
         result = run_compare_presets_daily(
             user_id=user_id, data_root=str(data_root), hour=6,

--- a/tests/tdd/test_trip_alert_briefing_imminent.py
+++ b/tests/tdd/test_trip_alert_briefing_imminent.py
@@ -50,6 +50,8 @@ for _p in (str(ROOT), str(ROOT / "src")):
 
 from tests.helpers.briefing_imminent_fixtures import (  # noqa: E402
     TRIP_ZONE,
+    briefing_anker_setzen,
+    briefing_versand_gescheitert,
     clean_uid,
     fresh_uid,
     official_alert,
@@ -57,6 +59,7 @@ from tests.helpers.briefing_imminent_fixtures import (  # noqa: E402
     read_trip_raw,
     render_trip_briefing_html,
     stunde_versetzt,
+    trip_briefing_vermerk_setzen,
     trip_change_alert_run,
     trip_official_alert_run,
     write_trip,
@@ -420,3 +423,143 @@ def test_ac16_unterdrueckte_warnung_erscheint_im_folgenden_briefing(nutzer):
         "sonst waere die Zusicherung durch einen festen Textbaustein erfuellt "
         "und wuerde nichts ueber die Ersetzung aussagen."
     )
+
+
+# ════════ AC-5 + R6 — der VERSUCH beendet die Sperre, nicht der Erfolg ══════
+#
+# 🔴 HIER wird die Uhr GESTELLT, nicht geerbt. Die uebrigen Tests dieser Datei
+# legen die Briefing-Stunde relativ zur echten Uhr; das geht nur fuer Slots in
+# der ZUKUNFT. Diese Faelle brauchen einen Slot, der bereits laeuft, und das
+# Nachholfenster des Trip-Schedulers rechnet ohne Mitternachts-Umbruch
+# (`stunde <= vor_ort.hour < stunde + 3`) — ein Lauf um 01:00 Ortszeit haette
+# sonst still am fehlenden Fenster gemessen statt an der Sperre.
+#
+# Einfrieren ist hier erlaubt und noetig: `check_and_send_alerts()` holt sich
+# den Zeitpunkt SELBST (`datetime.now(timezone.utc)`), er ist kein Parameter.
+# Die Warnung aus
+# `reference_freeze_time_macht_parameter_vs_systemuhr_unfalsifizierbar` gilt
+# fuer die reine Gate-Funktion — dort wird deshalb NICHT eingefroren, sondern
+# ein Zeitpunkt weit weg von der Systemuhr uebergeben
+# (`test_briefing_imminent_gate.py`).
+#
+# Ortszone des Trips ist Atlantic/Reykjavik (ganzjaehrig UTC+0), Ortsstunde ist
+# damit gleich der UTC-Stunde.
+SLOT_STUNDE = 7
+
+
+def _lauf_nach_briefing(user_id: str, *, ausgang: str, jetzt: datetime) -> int:
+    """Ein Alarm-Lauf zum Zeitpunkt ``jetzt``, nachdem das Morgen-Briefing um
+    ``SLOT_STUNDE`` den Ausgang ``ausgang`` genommen hat.
+
+    ``"erfolgreich"``  Anker UND Idempotenz-Vermerk — der Trip ist damit nicht
+                       mehr faellig.
+    ``"gescheitert"``  Anker, ABER kein Vermerk (reserve-then-release) — der
+                       Trip bleibt das ganze Nachholfenster ueber faellig.
+    ``"ohne_versuch"`` weder noch — die Ausgangslage des gemeldeten
+                       13.08.-Falls.
+
+    Returns: Anzahl der Wetterabrufe (0 = gesperrt).
+    """
+    write_trip(
+        user_id, "t-ac5", morgen_stunde=SLOT_STUNDE, abend_stunde=ABEND_WEG(),
+    )
+    slot_zeitpunkt = jetzt.replace(hour=SLOT_STUNDE, minute=0, second=30)
+    vor_minuten = (jetzt - slot_zeitpunkt).total_seconds() / 60.0
+
+    if ausgang == "erfolgreich":
+        briefing_anker_setzen(user_id, "t-ac5", "trip", vor_minuten=vor_minuten)
+        trip_briefing_vermerk_setzen(user_id, "t-ac5", slot="morning")
+    elif ausgang == "gescheitert":
+        briefing_versand_gescheitert(
+            user_id, "t-ac5", entity_type="trip", kind="route",
+            vor_minuten=vor_minuten,
+        )
+    elif ausgang != "ohne_versuch":  # pragma: no cover - Tippfehler-Schutz
+        raise AssertionError(f"unbekannter Ausgang: {ausgang!r}")
+
+    return trip_change_alert_run(user_id, "t-ac5")
+
+
+@pytest.mark.parametrize(
+    "ausgang, erwartet_abrufe",
+    [("erfolgreich", True), ("gescheitert", True), ("ohne_versuch", False)],
+)
+def test_ac5_der_briefing_versuch_beendet_die_sperre(
+    nutzer, ausgang, erwartet_abrufe,
+):
+    """AC-5: Die Sperre endet mit dem VERSUCH, nicht mit dem Erfolg.
+
+    Der Alarm-Lauf liegt fuenf Minuten hinter der Briefing-Stunde — im
+    Vorlauf-Fenster, das Briefing steht dort noch „an". Trotzdem muss die
+    Meldung regulaer rausgehen, sobald ein Versandversuch stattgefunden hat:
+
+    * ``erfolgreich`` — der Idempotenz-Vermerk nimmt dem Trip die Faelligkeit.
+    * ``gescheitert``  — der Vermerk wurde zurueckgenommen, der Trip ist noch
+      faellig; hier MUSS der Briefing-Anker die Sperre beenden. Genau das
+      konnte die erste Fassung nicht: dort loeste der Anker die Sperre aus,
+      statt sie zu beenden, und der Alarm schwieg fuer ein Briefing, das nie
+      angekommen ist.
+    * ``ohne_versuch`` — Kontrolle: ohne jeden Versuch muss gesperrt werden,
+      sonst waere die ganze Scheibe wirkungslos und die beiden anderen Faelle
+      trivial gruen.
+    """
+    from freezegun import freeze_time
+
+    jetzt = datetime(2026, 3, 15, SLOT_STUNDE, 5, tzinfo=timezone.utc)
+    with freeze_time(jetzt):
+        uid = nutzer(f"ac5-{ausgang}")
+        abrufe = _lauf_nach_briefing(uid, ausgang=ausgang, jetzt=jetzt)
+
+    if erwartet_abrufe:
+        assert abrufe >= 1, (
+            f"Das Briefing wurde um {SLOT_STUNDE}:00 bereits versucht "
+            f"({ausgang}) — die Sperre muss enden und der Alarm regulaer "
+            f"pruefen, es waren {abrufe} Abrufe."
+        )
+    else:
+        assert abrufe == 0, (
+            f"Ohne Versandversuch steht das Briefing noch aus — der Alarm muss "
+            f"schweigen, es waren {abrufe} Abrufe."
+        )
+
+
+@pytest.mark.parametrize(
+    "ausgang, erwartet_abrufe", [("gescheitert", True), ("ohne_versuch", False)],
+)
+def test_r6_gescheitertes_briefing_sperrt_nicht_das_ganze_nachholfenster(
+    nutzer, ausgang, erwartet_abrufe,
+):
+    """R6: Kein 4-Stunden-Schweif nach einem gescheiterten Briefing.
+
+    Anker und Idempotenz-Vermerk laufen bei einem Fehlschlag auseinander: der
+    Anker wird geschrieben (#1629), der Vermerk zurueckgenommen
+    (reserve-then-release). Der Trip bleibt dadurch das volle
+    ``NACHHOL_FENSTER_STUNDEN = 3`` ueber „faellig" — zusammen mit den 60
+    Minuten Vorlauf waeren das bis zu VIER Stunden Alarmstille fuer ein
+    Briefing, das nie ankam. In der GREEN-Phase real gemessen: Sperre von
+    06:00 bis 09:59 Ortszeit am 07:00-Slot.
+
+    Der Lauf liegt hier ZWEIEINHALB Stunden hinter der Briefing-Stunde, also
+    tief im Nachholfenster. Der Kontrollfall ``ohne_versuch`` zeigt, dass die
+    Sperre dort tatsaechlich noch greifen WUERDE — ohne ihn bewiese der erste
+    Fall nur, dass irgendetwas anderes den Lauf durchlaesst.
+    """
+    from freezegun import freeze_time
+
+    jetzt = datetime(2026, 3, 15, SLOT_STUNDE + 2, 30, tzinfo=timezone.utc)
+    with freeze_time(jetzt):
+        uid = nutzer(f"r6-{ausgang}")
+        abrufe = _lauf_nach_briefing(uid, ausgang=ausgang, jetzt=jetzt)
+
+    if erwartet_abrufe:
+        assert abrufe >= 1, (
+            f"Der Versand um {SLOT_STUNDE}:00 ist gescheitert und wurde damit "
+            f"versucht — zweieinhalb Stunden spaeter darf der Alarm nicht mehr "
+            f"gesperrt sein, es waren {abrufe} Abrufe (R6)."
+        )
+    else:
+        assert abrufe == 0, (
+            f"Kontrolle: ohne Versandversuch ist der Trip im Nachholfenster "
+            f"weiterhin faellig und der Alarm gesperrt, es waren {abrufe} "
+            f"Abrufe — ohne diese Haelfte misst der Schweif-Nachweis nichts."
+        )

--- a/tests/tdd/test_trip_alert_briefing_imminent.py
+++ b/tests/tdd/test_trip_alert_briefing_imminent.py
@@ -1,0 +1,422 @@
+"""TDD RED — Trip: keine Doppel-Meldung kurz vor einem geplanten Briefing
+(Issue #1594, AC-1, AC-2, AC-8, AC-10, AC-11, AC-13, AC-15, AC-16).
+
+SPEC:    docs/specs/modules/fix_1594_alarm_vorlauf_sperre.md
+KONTEXT: docs/context/fix-1594-alarm-vorlauf-sperre.md
+
+Beide Trip-Aufrufstellen laufen ueber DEN EINEN Adapter
+``TripAlertService._is_quiet_hours`` (``trip_alert.py:680``): der
+Aenderungsalarm bei ``:231``, die amtliche Warnung bei ``:1447``. Trotzdem
+bekommt jede Aufrufstelle einen EIGENEN Nachweis — geteilter Code hat in
+#1697 dreimal in Folge nichts ueber den jeweiligen Aufrufer bewiesen.
+
+RED heute: es gibt keine Vorlauf-Sperre. Jeder Lauf im Vorlauf-Fenster
+beschafft Wetter bzw. verschickt die amtliche Warnung, statt zu schweigen.
+
+═══════════════════════════════════════════════════════════════════════════
+GEKREUZTE PROBE — warum jeder Test ZWEI Laeufe fahrt
+═══════════════════════════════════════════════════════════════════════════
+
+Die Haelfte der ACs dieser Scheibe sind BEWAHRUNGS-Kriterien (AC-8, AC-10,
+AC-11, AC-13, AC-16): sie beschreiben, was sich NICHT aendern darf. Solche
+Zusicherungen sind ohne Gate trivial erfuellt und waeren als Einzel-Assertion
+heute gruen — ein gruener TDD-RED-Test beweist nichts.
+
+Deshalb faehrt jeder Test hier zusaetzlich einen KONTROLL-Lauf mit einer
+Entitaet, deren Briefing im Vorlauf-Fenster liegt, und behauptet dessen
+Unterdrueckung. Diese Haelfte ist heute rot. Nach der Umsetzung bewachen
+beide Haelften gemeinsam die Grenze: gesperrt wird nur, wo ein Briefing
+tatsaechlich folgt.
+
+Mock-frei: echte Trips auf Platte, echte Dienste, echte Zustandsdateien. Nur
+die NETZ-Naehte (``_fetch_fresh_weather``, Warnquellen-Registry) sind durch
+echte Unterklassen bzw. echte Quellen ersetzt.
+
+Pfadregel #1409: alle Pfade relativ zu DIESER Datei bzw. ueber
+``app.loader.get_data_dir()``.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+for _p in (str(ROOT), str(ROOT / "src")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tests.helpers.briefing_imminent_fixtures import (  # noqa: E402
+    TRIP_ZONE,
+    clean_uid,
+    fresh_uid,
+    official_alert,
+    protokoll_eintraege,
+    read_trip_raw,
+    render_trip_briefing_html,
+    stunde_versetzt,
+    trip_change_alert_run,
+    trip_official_alert_run,
+    write_trip,
+    write_user_tier,
+    zustand_schnappschuss,
+)
+
+# Ortsstunden des Trips (Atlantic/Reykjavik, ganzjaehrig UTC+0 — Ortstag und
+# Weltzeittag fallen nie auseinander).
+#
+# NAH: Briefing-Stunde = die Stunde, die in einer Stunde gilt. JETZT ist der
+# Trip damit NICHT faellig, in 60 Minuten schon — genau der Vorlauf-Fall.
+# FERN: fuenf Stunden voraus; auch bei ``now + 60 min`` nicht faellig, und
+# ausserhalb des 3-Stunden-Nachholfensters des Trip-Schedulers.
+def NAH() -> int:
+    return stunde_versetzt(1, zone=TRIP_ZONE)
+
+
+def FERN() -> int:
+    return stunde_versetzt(5, zone=TRIP_ZONE)
+
+
+def ABEND_WEG() -> int:
+    """Abend-Slot weit genug weg, dass er in keinem Fall mit hineinspielt."""
+    return stunde_versetzt(9, zone=TRIP_ZONE)
+
+
+@pytest.fixture
+def nutzer():
+    """Vergibt Nutzer-Kennungen und raeumt sie hinterher weg."""
+    vergeben: list[str] = []
+
+    def _neu(kennung: str, tier: str = "premium") -> str:
+        user_id = fresh_uid(kennung)
+        clean_uid(user_id)
+        write_user_tier(user_id, tier)
+        vergeben.append(user_id)
+        return user_id
+
+    yield _neu
+    for user_id in vergeben:
+        clean_uid(user_id)
+
+
+# ═══════════════ AC-1 — Trip-Aenderungsalarm im Vorlauf-Fenster ═════════════
+
+
+def test_ac1_aenderungsalarm_schweigt_wenn_das_briefing_unmittelbar_bevorsteht(nutzer):
+    """AC-1: Steht das naechste geplante Briefing des Trips in Kuerze an, geht
+    der Wetter-Aenderungsalarm NICHT mehr als eigene Zusatz-Meldung raus.
+
+    Gemessen an der Netz-Naht ``_fetch_fresh_weather`` — die Sperre sitzt VOR
+    dem Abruf, ein gesperrter Lauf kostet also kein Abruf-Kontingent. Der
+    Gegen-Lauf mit fernem Briefing schuetzt vor falschem Gruen: ohne ihn waere
+    die erste Zusicherung auch dann erfuellt, wenn der Pfad aus einem ganz
+    anderen Grund gar nicht erst losliefe.
+
+    ROT HEUTE: es gibt keine Vorlauf-Pruefung — beide Laeufe rufen ab.
+    """
+    nah = nutzer("ac1-nah")
+    write_trip(nah, "t-ac1", morgen_stunde=NAH(), abend_stunde=ABEND_WEG())
+    abrufe_nah = trip_change_alert_run(nah, "t-ac1")
+
+    fern = nutzer("ac1-fern")
+    write_trip(fern, "t-ac1", morgen_stunde=FERN(), abend_stunde=ABEND_WEG())
+    abrufe_fern = trip_change_alert_run(fern, "t-ac1")
+
+    assert abrufe_nah == 0, (
+        f"Briefing steht in unter 60 Minuten an — der Aenderungsalarm muss "
+        f"schweigen und darf kein Wetter abrufen, es waren {abrufe_nah} Abrufe."
+    )
+    assert abrufe_fern >= 1, (
+        f"Ein Briefing in fuenf Stunden darf den Aenderungsalarm NICHT sperren "
+        f"(sonst Schweigen ohne Ersatz) — es waren {abrufe_fern} Abrufe."
+    )
+
+
+# ══════════ AC-2 — amtliche Trip-Warnung im Vorlauf-Fenster (:1447) ═════════
+
+
+def test_ac2_amtliche_warnung_schweigt_wenn_das_briefing_unmittelbar_bevorsteht(nutzer):
+    """AC-2: Dieselbe Sperre wirkt auf die amtliche Warnung des Trips —
+    ``_send_official_alert_only()`` meldet „nicht versendet" und der Mail-Weg
+    bleibt unberuehrt.
+
+    Eigenstaendiger Nachweis fuer DIESE Aufrufstelle, obwohl sie sich den
+    Ruhezeit-Adapter mit AC-1 teilt.
+
+    ROT HEUTE: die Warnung geht raus (Rueckgabe True, eine Mail).
+    """
+    nah = nutzer("ac2-nah")
+    write_trip(nah, "t-ac2", morgen_stunde=NAH(), abend_stunde=ABEND_WEG())
+    versendet_nah, mails_nah = trip_official_alert_run(nah, "t-ac2")
+
+    fern = nutzer("ac2-fern")
+    write_trip(fern, "t-ac2", morgen_stunde=FERN(), abend_stunde=ABEND_WEG())
+    versendet_fern, mails_fern = trip_official_alert_run(fern, "t-ac2")
+
+    assert (versendet_nah, mails_nah) == (False, []), (
+        f"Briefing steht unmittelbar bevor — die amtliche Warnung darf nicht "
+        f"als eigene Meldung rausgehen: versendet={versendet_nah}, "
+        f"Mails={len(mails_nah)}"
+    )
+    assert versendet_fern is True and len(mails_fern) >= 1, (
+        f"Ohne anstehendes Briefing muss die amtliche Warnung unveraendert "
+        f"zugestellt werden: versendet={versendet_fern}, Mails={len(mails_fern)}"
+    )
+
+
+# ═══════════ AC-8 — kein Schweigen ohne Ersatz (Trip ohne Briefing) ═════════
+
+
+def _trip_ohne_briefing(user_id: str, trip_id: str, grund: str) -> None:
+    """Ein Trip, der zur NAH-Stunde faellig WAERE, es aber aus genau einem
+    Grund nicht ist. Die Briefing-Stunde bleibt in allen Faellen NAH — nur so
+    misst der Test den jeweiligen Aktiv-Filter und nicht die Uhrzeit."""
+    gemeinsam = dict(morgen_stunde=NAH(), abend_stunde=ABEND_WEG())
+    if grund == "paused_at":
+        write_trip(user_id, trip_id, paused_at="2026-08-01T00:00:00Z", **gemeinsam)
+    elif grund == "enabled_false":
+        write_trip(user_id, trip_id, enabled=False, **gemeinsam)
+    elif grund == "paused_until":
+        write_trip(
+            user_id, trip_id,
+            paused_until=datetime.now(timezone.utc) + timedelta(hours=6), **gemeinsam,
+        )
+    elif grund == "keine_etappe":
+        # Etappen erst in fuenf bzw. sechs Tagen -> am Zieltag keine Etappe.
+        write_trip(user_id, trip_id, etappen_tage=(5, 6), **gemeinsam)
+    else:  # pragma: no cover - Schutz gegen Tippfehler im Parameter
+        raise AssertionError(f"unbekannter Grund: {grund!r}")
+
+
+@pytest.mark.parametrize(
+    "grund", ["paused_at", "enabled_false", "paused_until", "keine_etappe"],
+)
+def test_ac8_trip_ohne_geplantes_briefing_wird_nie_gesperrt(nutzer, grund):
+    """AC-8 (Risiko R2): Ein Trip, fuer den gar kein Briefing geplant ist,
+    darf NIEMALS durch die neue Sperre stillgelegt werden — es gaebe keinen
+    Ersatz, die Meldung waere verschluckt statt ersetzt (Fehlerklasse
+    #1555/#1584).
+
+    Vier Gruende, vier Faelle — jeder einzeln, weil sie in
+    ``_get_active_trips()`` an vier verschiedenen Stellen stehen und ein
+    herausgeloestes Praedikat jeden davon einzeln vergessen kann.
+
+    Beide Alarmarten werden geprueft: Aenderungsalarm UND amtliche Warnung.
+
+    ROT HEUTE ueber den Kontroll-Lauf: der aktive Trip mit demselben
+    Briefing-Zeitpunkt muesste gesperrt sein, ist es aber nicht.
+    """
+    ohne = nutzer(f"ac8-{grund}")
+    _trip_ohne_briefing(ohne, "t-ac8", grund)
+    abrufe_ohne = trip_change_alert_run(ohne, "t-ac8")
+    versendet_ohne, mails_ohne = trip_official_alert_run(ohne, "t-ac8")
+
+    kontrolle = nutzer(f"ac8-{grund}-kontrolle")
+    write_trip(kontrolle, "t-ac8", morgen_stunde=NAH(), abend_stunde=ABEND_WEG())
+    abrufe_kontrolle = trip_change_alert_run(kontrolle, "t-ac8")
+
+    assert abrufe_ohne >= 1, (
+        f"Trip ohne geplantes Briefing ({grund}): der Aenderungsalarm muss "
+        f"unveraendert durchgehen, es waren {abrufe_ohne} Abrufe."
+    )
+    assert versendet_ohne is True and len(mails_ohne) >= 1, (
+        f"Trip ohne geplantes Briefing ({grund}): die amtliche Warnung muss "
+        f"unveraendert zugestellt werden: versendet={versendet_ohne}, "
+        f"Mails={len(mails_ohne)}"
+    )
+    assert abrufe_kontrolle == 0, (
+        "Kontroll-Lauf: derselbe Trip MIT geplantem Briefing zur selben Stunde "
+        f"muss gesperrt sein — sonst misst dieser Test die Sperre gar nicht "
+        f"(Abrufe={abrufe_kontrolle})."
+    )
+
+
+# ═══════ AC-10 + AC-13 — kein State-Verbrauch, keine Protokollzeile ═════════
+
+
+def test_ac10_gesperrte_meldung_veraendert_keinen_zustand(nutzer):
+    """AC-10 (Risiko R4, #1233-Analogie): Eine durch die neue Sperre
+    unterdrueckte Meldung darf weder Melde-Gedaechtnis noch Sperrzeit-Ablage
+    noch Tageszaehler beruehren.
+
+    Gemessen am amtlichen Trip-Pfad, weil dort HEUTE tatsaechlich alle drei
+    Buchungen entstehen (``trip_alert.py:1494-1499``) — ein Pfad, der heute
+    ohnehin nichts schreibt, koennte die Zusicherung gar nicht pruefen.
+
+    ROT HEUTE: der Lauf stellt zu und bucht alle drei.
+    """
+    uid = nutzer("ac10")
+    write_trip(uid, "t-ac10", morgen_stunde=NAH(), abend_stunde=ABEND_WEG())
+
+    vorher = zustand_schnappschuss(uid, "t-ac10")
+    versendet, mails = trip_official_alert_run(uid, "t-ac10")
+    nachher = zustand_schnappschuss(uid, "t-ac10")
+
+    assert (versendet, mails) == (False, []), (
+        f"Voraussetzung: der Lauf muss durch die Vorlauf-Sperre unterdrueckt "
+        f"werden: versendet={versendet}, Mails={len(mails)}"
+    )
+    assert nachher["melde_gedaechtnis"] == vorher["melde_gedaechtnis"], (
+        f"Melde-Gedaechtnis nach gesperrter Meldung veraendert: "
+        f"{vorher['melde_gedaechtnis']!r} -> {nachher['melde_gedaechtnis']!r}"
+    )
+    assert nachher["sperrzeit"] == vorher["sperrzeit"], (
+        f"Sperrzeit-Ablage nach gesperrter Meldung veraendert: "
+        f"{vorher['sperrzeit']!r} -> {nachher['sperrzeit']!r}"
+    )
+    assert nachher["tageszaehler"] == vorher["tageszaehler"], (
+        f"Tageszaehler nach gesperrter Meldung veraendert: "
+        f"{vorher['tageszaehler']!r} -> {nachher['tageszaehler']!r}"
+    )
+
+
+def test_ac13_gesperrte_meldung_erzeugt_keinen_protokolleintrag(nutzer):
+    """AC-13: Fuer eine durch die neue Sperre unterdrueckte Meldung entsteht
+    KEIN neuer Eintrag im Alarm-Protokoll — weder in ``entries`` noch in
+    ``not_delivered``. Der Delta-Wetter- und der amtliche Pfad bekommen
+    ausdruecklich keine Unterdrueckungs-Protokollierung
+    (``rework_1467_s3_nowcast.md`` AC-9), und die Meldung wird hier ohnehin
+    ERSETZT, nicht verschluckt.
+
+    ROT HEUTE: der Lauf stellt zu und schreibt eine ``entries``-Zeile.
+    """
+    uid = nutzer("ac13")
+    write_trip(uid, "t-ac13", morgen_stunde=NAH(), abend_stunde=ABEND_WEG())
+
+    vorher = protokoll_eintraege(uid)
+    versendet, mails = trip_official_alert_run(uid, "t-ac13")
+    nachher = protokoll_eintraege(uid)
+
+    assert (versendet, mails) == (False, []), (
+        f"Voraussetzung: der Lauf muss gesperrt sein: versendet={versendet}, "
+        f"Mails={len(mails)}"
+    )
+    assert nachher == vorher, (
+        f"Die Vorlauf-Sperre darf keine Protokollzeile erzeugen — "
+        f"{len(vorher)} -> {len(nachher)} Eintraege, neu: "
+        f"{nachher[len(vorher):]!r}"
+    )
+
+
+# ══════════════════ AC-11 — `skip_next` bleibt unverbraucht ════════════════
+
+
+def test_ac11_sperrpruefung_verbraucht_skip_next_nicht(nutzer):
+    """AC-11 (Risiko R3, der gefaehrlichste Fund der Analyse):
+    ``_get_active_trips()`` konsumiert ``report_config.skip_next`` per
+    Read-Modify-Write MIT ``save_trip()`` bei JEDEM Aufruf
+    (``trip_report_scheduler.py:783-788``). Benutzt die neue Sperre diese
+    Methode mit, verbraucht sie im 15-Minuten-Alarmtakt den Nutzerwunsch
+    „naechstes Briefing ueberspringen", bevor der Briefing-Scheduler ihn je
+    sieht — das Briefing kaeme trotzdem.
+
+    Gelesen wird die PERSISTIERTE Datei, nicht das Objekt im Speicher: der
+    Verbrauch passiert genau als Schreibvorgang, ein Speicher-Vergleich saehe
+    ihn nicht.
+
+    ROT HEUTE ueber die erste Zusicherung (kein Sperr-Lauf ohne Sperre).
+    """
+    uid = nutzer("ac11")
+    write_trip(
+        uid, "t-ac11", morgen_stunde=NAH(), abend_stunde=ABEND_WEG(), skip_next=True,
+    )
+    assert read_trip_raw(uid, "t-ac11")["report_config"]["skip_next"] is True, (
+        "Aufbau-Nachweis: der Ausgangszustand muss skip_next=True tragen"
+    )
+
+    abrufe = trip_change_alert_run(uid, "t-ac11")
+    versendet, _mails = trip_official_alert_run(uid, "t-ac11")
+
+    assert (abrufe, versendet) == (0, False), (
+        f"Voraussetzung: beide Trip-Alarmarten muessen im Vorlauf-Fenster "
+        f"gesperrt sein (Abrufe={abrufe}, amtlich versendet={versendet})"
+    )
+    assert read_trip_raw(uid, "t-ac11")["report_config"]["skip_next"] is True, (
+        "Die Vorlauf-Sperre hat den Nutzerwunsch 'naechstes Briefing "
+        "ueberspringen' verbraucht — er steht nach dem Alarm-Lauf nicht mehr "
+        "auf True. Ursache waere die Wiederverwendung von `_get_active_trips()` "
+        "statt eines seiteneffektfreien Praedikats."
+    )
+
+
+# ═════════════════════════ AC-15 — Mandantentrennung ════════════════════════
+
+
+def test_ac15_sperre_wirkt_nur_auf_die_eigenen_daten_des_nutzers(nutzer):
+    """AC-15: Zwei Nutzer, DIESELBE Trip-Kennung, verschiedene Briefing-Zeiten.
+    Die Sperre des einen darf den anderen nicht beruehren.
+
+    Beide Richtungen in EINEM Test: A (Briefing in Kuerze) muss schweigen, B
+    (Briefing in fuenf Stunden) muss melden. Eine Implementierung, die auf
+    ``"default"`` zurueckfaellt oder die Kennung ohne Nutzer-Bezug nachschlaegt,
+    faellt hier durch.
+
+    ROT HEUTE: A meldet ebenfalls (keine Sperre).
+    """
+    a, b = nutzer("ac15-a"), nutzer("ac15-b")
+    geteilte_kennung = "t-1594-geteilt"
+    write_trip(a, geteilte_kennung, morgen_stunde=NAH(), abend_stunde=ABEND_WEG())
+    write_trip(b, geteilte_kennung, morgen_stunde=FERN(), abend_stunde=ABEND_WEG())
+
+    abrufe_a = trip_change_alert_run(a, geteilte_kennung)
+    abrufe_b = trip_change_alert_run(b, geteilte_kennung)
+
+    assert abrufe_a == 0, (
+        f"Nutzer A steht im Vorlauf-Fenster SEINES Briefings — sein Alarm muss "
+        f"schweigen ({abrufe_a} Abrufe)."
+    )
+    assert abrufe_b >= 1, (
+        f"Nutzer B hat sein Briefing erst in fuenf Stunden — die Sperre von A "
+        f"darf ihn nicht mitnehmen ({abrufe_b} Abrufe)."
+    )
+
+
+# ═══════ AC-16 — die tragende Rechtfertigung: ERSETZT, nicht verschluckt ════
+
+
+def test_ac16_unterdrueckte_warnung_erscheint_im_folgenden_briefing(nutzer):
+    """AC-16: Dieselbe amtliche Warnung, die als eigene Meldung unterdrueckt
+    wurde, MUSS im unmittelbar folgenden Briefing erscheinen. Ohne diesen
+    Nachweis waere die gesamte Scheibe auf einer ungeprueften Annahme gebaut —
+    „die Meldung wird ersetzt" waere eine Behauptung, kein Befund.
+
+    Zwei Schritte, EIN Test, damit die Ersetzung als Kette nachgewiesen ist:
+    1. Der Standalone-Versand derselben Warnung wird im Vorlauf-Fenster
+       unterdrueckt (rot heute).
+    2. Dieselbe Warnung, dem Briefing-Renderer als ``seg.official_alerts``
+       uebergeben, taucht im gerenderten Ergebnis auf — nachgewiesen gegen ein
+       Briefing OHNE Warnung, damit die Zusicherung nicht durch einen
+       beliebigen Textbaustein erfuellbar ist.
+
+    Fuer den Wetter-Aenderungsalarm ist die Ersetzung baulich gegeben (das
+    Briefing zeigt den vollstaendigen aktuellen Wetterstand) und wird nicht
+    separat geprueft.
+    """
+    uid = nutzer("ac16")
+    write_trip(uid, "t-ac16", morgen_stunde=NAH(), abend_stunde=ABEND_WEG())
+
+    versendet, mails = trip_official_alert_run(uid, "t-ac16")
+    assert (versendet, mails) == (False, []), (
+        f"Schritt 1: die amtliche Warnung muss im Vorlauf-Fenster unterdrueckt "
+        f"werden: versendet={versendet}, Mails={len(mails)}"
+    )
+
+    warnung = official_alert(level=3, hazard="wind", label="Sturmwarnung")
+    mit_warnung = render_trip_briefing_html([warnung])
+    ohne_warnung = render_trip_briefing_html([])
+
+    assert warnung.label in mit_warnung, (
+        "Schritt 2: die unterdrueckte Warnung muss im folgenden Briefing "
+        f"erscheinen — {warnung.label!r} fehlt im gerenderten Briefing."
+    )
+    assert warnung.region_label in mit_warnung, (
+        "Die Warnung muss mit ihrer Region erscheinen, nicht nur als nackter "
+        f"Text — {warnung.region_label!r} fehlt."
+    )
+    assert warnung.label not in ohne_warnung, (
+        "Gegenprobe: ohne Warnung darf der Text nicht im Briefing stehen — "
+        "sonst waere die Zusicherung durch einen festen Textbaustein erfuellt "
+        "und wuerde nichts ueber die Ersetzung aussagen."
+    )


### PR DESCRIPTION
Behebt #1594: Änderungsalarme und amtliche Warnungen bleiben aus, wenn für dieselbe Entität
innerhalb von 60 Minuten ein geplantes Briefing ansteht, das noch nicht versucht wurde.
**NowCast ist ausgenommen** und läuft unverändert weiter.

## Das gemeldete Problem, am Produktivkonto reproduziert

| Tag | Alarm | Briefing |
|---|---|---|
| 13.08. | 05:02 UTC | 05:00 UTC — Alarm **nach** dem Briefing |
| 14.08. | 05:01 UTC | 05:04 UTC — Alarm **vor** dem Briefing |

`alert_quiet_to` und `report_config.morning_time` stehen beide auf 07:00 Ortszeit: das Ende der
Ruhezeit fällt exakt auf die Briefing-Zeit. Belegt ist die Mechanik dadurch, dass die Alarmzeit
**mit der Konfiguration gewandert** ist — bis 06.08. täglich 04:00 UTC (`quiet_to` 06:00), seit
13.08. 05:01/05:02 UTC (`quiet_to` 07:00).

## Umsetzung

Neue Funktion `check_briefing_imminent()` in `alert_gate.py`, klar getrennt von
`check_nowcast_gate()`, verdrahtet an **drei** Einhängepunkten als zusätzliche, **rein lesende**
Stufe neben der bestehenden Ruhezeit-Prüfung und vor jedem Wetterabruf. Die Fälligkeit wird
**gefragt** (`presets_due_for_hour()` bzw. ein aus `trip_report_scheduler` herausgelöstes reines
Prädikat), nicht neu gerechnet — eine eigene Zeitrechnung wäre die vierte Fassung derselben Regel.

**Nicht** im Engine-Kern: `AlertEvaluationConfig` ist ausdrücklich ohne Trip-Bezug und trägt weder
Versandzeiten noch Kennung; zudem läuft `evaluate()` bei beiden Aufrufern erst *nach* dem Abruf.

## Drei Befunde aus dem Bau, die den Zuschnitt geändert haben

**1. Die Sammel-Zustellung am Ruhezeit-Ende ist eine zugesicherte Eigenschaft (#1233), kein
Versehen.** `compare_official_alert.py:124-125`, bewacht von
`test_compare_official_alert.py::test_ac1_quiet_hours_suppresses_send_state_and_limit`. Die neue
Stufe erhält sie: sie verbraucht ebenfalls keinen State und verzögert nur, bis das Briefing raus
ist — das Briefing setzt Anker und Melde-Gedächtnis selbst zurück, die Meldung wird **ersetzt**.

**2. Der ursprünglich spezifizierte Nachlauf-Zweig ist ersatzlos entfallen.** Seine Begründung
(„bei gescheitertem Versand bleibt der Anker unverändert") war angenommen statt gemessen und ist
falsch: `_anchor_and_reset()` steht in beiden Versandpfaden im `except`-Zweig (#1629).
`last_briefing_at()` bedeutet **versucht**, nicht **zugestellt**. Gemessen: der Nachlauf machte
sieben Bestandstests rot, der Vorlauf keinen. Er hätte (a) geschwiegen, wenn nichts ankam, und
(b) echte neue Information verschluckt — nach dem Briefing ist der Δ-Anker frisch, ein danach
auslösender Alarm meldet zwangsläufig etwas, das im Briefing *nicht* stand. Stattdessen endet die
Sperre mit dem **Versuch**. Das löst zugleich bis zu **4 Stunden Alarmstille** nach einem
gescheiterten Versand (60 Min Vorlauf + 3 h Nachholfenster, am 07:00-Slot gemessen: 06:00–09:59
Ortszeit).

**3. 134 Bestandstests in 27 Dateien wurden tageszeitabhängig rot** — die CI-Ampel hätte in 15 von
24 Stunden rot gestanden, in der Spitze mit 94 Fällen. Ursache strukturell: Bestandstests
konfigurieren keine Briefing-Zeiten und erben die Modell-Vorgaben 07:00/18:00, liegen also täglich
zweimal 60 Minuten im Fenster. Behoben im ersten Commit — ausschließlich **Vorbedingungen**, keine
einzige Assertion. Der Nachweis, dass das nichts verdeckt: derselbe volle Lauf mit neutralisierter
Sperre ist **fallgleich** zur Ausgangslage (39 rot ⟷ 39 rot, identische Namen, 0 neu rot).

## Nachweise

- **46 neue Testfälle**, alle 16 Akzeptanzkriterien abgedeckt
- **Adversary 4 Runden, Verdict VERIFIED** — alle 16 ACs belegt, alle fünf Pflicht-Mutationen
  gefangen (die entfernte NowCast-Ausnahme traf genau den einen Test, der sie bewacht, und sonst
  keinen); Runde 2 griff gezielt die Fixture-Reparatur an und wies per fünf Produktivcode-Mutationen
  nach, dass die reparierten Tests weiterhin ihre ursprüngliche Zusicherung fangen
- **Tageszeit-Matrix über alle 24 Stunden:** 134 → 0
- **Voller `tests/tdd/`-Lauf:** 4 rot, alle umgebungsabhängig und alle schon in der Ausgangsmessung rot

## Bewusst nicht in dieser Scheibe

Der amtliche Trip-Abruf wird nicht vorgezogen (die bestehende Ruhezeit-Prüfung spart ihn ebenfalls
nicht — die Sperre verhindert die *Meldung*, nicht den Abruf) · Vereinheitlichung der drei
unterschiedlichen Prüf-Reihenfolgen (#1467 S4) · Anzeige/Wortwahl unterdrückter Meldungen
(#1750/#1800 zweite Frage) · **#1714 wird NICHT miterledigt** und darf nicht mit dieser Scheibe
geschlossen werden: die Sperre mildert die dortige Wiederholung nur vor dem Briefing, die Ursache
(fehlender Vermerk) bleibt.

Spec: `docs/specs/modules/fix_1594_alarm_vorlauf_sperre.md` (16 ACs, PO-freigegeben)

Refs #1594, #1233, #1629, #1467, #1714

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kiKur8ctBrDKtBAxHBWTk
