### PR TITLE
fix(#1671): Kurzformat-Mail liest Gewitter aus dem Tagesfenster statt aus dem Gehzeit-Aggregat

### DIFF
--- a/docs/context/fix-1671-compact-gewitter-tagesfenster.md
+++ b/docs/context/fix-1671-compact-gewitter-tagesfenster.md
@@ -1,0 +1,109 @@
+# Context: fix-1671-compact-gewitter-tagesfenster
+
+Issue: [#1671](https://github.com/henemm/gregor_zwanzig/issues/1671) · Labels: `bug`, `priority:high`, `session:khw`
+Gemessen am Stand `e2b5269b` (== `origin/main`) am 2026-08-14, nicht aus dem Ticket übernommen.
+
+## Request Summary
+
+Der Ausblick-Block „Naechste Etappen" der **Kurzformat-Mail** (`X-GZ-Format: compact`)
+baut sein Gewitter-Tageswort weiterhin aus `tok['thunder_plain']` — dem auf die
+Gehzeit geklemmten 24h-Aggregat. HTML-Tabelle, Klartext-Mail und Telegram wurden
+mit #1653 auf `thunder_day_token`/`thunder_night_token` (Tagesfenster bzw.
+Nachtfenster derselben Stundenreihe) umgestellt; die Kurzformat-Mail blieb als
+vierter Ausgabeort zurück. Folge: falsch-negatives *oder* falsch-positives
+Tagesgewitter, und dort fehlt jede Nachtangabe.
+
+## Die Klasse ist ausgezählt (nicht von einem Fall verallgemeinert)
+
+Vier Aufrufer von `format_trend_tokens()` bauen Ausblick-Zeilen:
+
+| # | Ausgabeort | Code | Quelle heute | Stand |
+|---|---|---|---|---|
+| 1 | HTML-Ausblick-Tabelle | `email/outlook.py:208` (`render_outlook_table`) | `thunder_day_token` + `thunder_night_token` | ✅ #1653 |
+| 2 | Klartext-Mail-Ausblick | `email/outlook.py:358` (`render_outlook_plain`) | day/night; `thunder_plain` nur noch als Rückfall **ohne** Stundenreihe | ✅ #1653 |
+| 3 | Telegram-Trendblock | `narrow.py:575` (`_outlook_lines`) | dito | ✅ #1653 |
+| 4 | **Kurzformat-Mail** | `email/compact.py:230-236` | **roh `tok['thunder_plain']`** | ❌ **dieses Issue** |
+
+Kein fünfter Ort:
+- **SMS / Premium-SMS** erreichen den Ausblick strukturell nicht — `SMSTripFormatter`
+  sieht `multi_day_trend` nie, `thunder_sms` wird nirgends gelesen
+  (belegt in `feat_1680_s5a`, „Am Code gemessen" Punkt 6).
+- **Compare-Ausblick** nutzt denselben `outlook.py`-Baustein; ohne Stundenreihe
+  bleibt dort das Aggregatwort korrekt (#1653 AC-6).
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/output/renderers/email/compact.py:230-236` | **Der Prüfling.** Ausblick-Zeile, spaltenformatiert, danach `_ascii()` |
+| `src/output/renderers/email/compact.py:49-61` | `_ASCII_MAP` + `_ascii()`: `⚡`→`T`, `·`→`-`, danach `fold_ascii()` |
+| `src/output/renderers/email/outlook.py:358-410` | Vorbild Klartext: Zweiglogik day-token → `hourly_thunder`-NONE → `thunder_plain` |
+| `src/output/renderers/email/outlook.py:43-59` | `_thunder_token_parts()` — zerlegt `leicht@5(hoch@15)` in (Wort, Stunde, Peak-Zusatz) |
+| `src/output/renderers/narrow.py:571-609` | Vorbild Telegram: dieselbe Zweiglogik, anderes Format (mit Uhrzeit) |
+| `src/output/renderers/email/helpers.py:1005-1065` | `format_trend_tokens()` — SSoT, liefert `thunder_day_token`, `thunder_night_token`, `thunder_day_origin`, `thunder_plain` |
+| `src/output/renderers/email/__init__.py:109` | Einziger Aufrufer von `render_compact()` |
+
+## Existing Patterns
+
+**Die Zweiglogik existiert bereits dreimal fast identisch** (`outlook.py:373-386`,
+`narrow.py:588-601`):
+
+1. Liegt ein `thunder_day_token != "-"` vor → Tageswort daraus.
+2. Sonst, wenn `stage["hourly_thunder"]` gefüllt ist → ausdrücklich „kein Gewitter"
+   (`_THUNDER_MAP["NONE"]["plain"]`) — Stundenreihe da, im Tagesfenster aber leer.
+3. Sonst (Alt-Aufrufer, Compare: gar keine Stundenreihe) → `thunder_plain`.
+4. Nacht: `thunder_night_token != "-"` → Zusatz `· nachts …`.
+
+Das Format unterscheidet sich je Kanal (Klartext ohne Uhrzeit am Tagesteil,
+Telegram mit) — die **Entscheidung** ist identisch, die **Darstellung** nicht.
+
+## Dependencies
+
+- **Upstream:** `format_trend_tokens()` (helpers.py) — liefert alle nötigen Token
+  bereits; `multi_day_trend`-Stages kommen aus `trip_report_scheduler.py` und tragen
+  `hourly_thunder` / `day_window_start_hour` / `day_window_end_hour`.
+- **Downstream:** `render_compact()` → `render_email()` → Kurzformat-Mail-Body.
+  Kein weiterer Verbraucher.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1653_ausblick_tag_nacht_trennung.md` — AC-1..AC-8, das Muster
+- `docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md` — AC-13 (s. Risiko 1)
+- `docs/specs/modules/issue_1361_1368_ausblick_konfigurierbar.md` — AC-11 Byte-Paritätswächter
+
+## Bestehende Wächter, die diese Änderung berühren
+
+| Test | Wirkung |
+|---|---|
+| `tests/tdd/test_thunder_origin_outlook.py::test_ac13_kompaktmail_bleibt_zeichengleich` | **Sichert zu, dass die Kompakt-Mail unempfindlich gegen die Trägerinformation ist.** Bleibt grün, solange wir KEINE Herkunft aufnehmen; wird rot, sobald wir sie aufnehmen |
+| `tests/tdd/test_trip_outlook_parity.py` | Byte-Parität der Trip-Mail gegen aufgezeichnete Golden-Dateien — bewacht `outlook.py`; arbeitet **für** uns, falls wir dort refaktorieren |
+| `tests/tdd/test_outlook_day_night_thunder_split.py` | #1653-Nachweise für Kanäle 1–3 |
+| `tests/tdd/test_issue_811_mode_matrix.py` + `briefing_mail_validator.py` | **Commit-Gate** (`renderer_mail_gate.py`): `compact.py` liegt in `src/output/renderers/email/*.py`, beide müssen frisch vorliegen |
+
+## Risks & Considerations
+
+**Risiko 1 — AC-13 aus #1680 S5a ist eine freigegebene Zusicherung (PO-go 2026-08-13).**
+Sie lautet: der Kompakt-Ausblick bleibt zeichengleich, *„er liest `thunder_plain` und
+wird von dieser Scheibe nicht berührt"*. Die **Begründung** der Zusicherung fällt mit
+#1671 weg (er liest dann nicht mehr `thunder_plain`; und `·`→`-` ist eine saubere
+Faltung, keine Zerstörung). Die Zusicherung selbst bleibt aber gültig, bis sie
+abgelöst wird. ⇒ **PO-Entscheidung nötig**, ob die Herkunft (`thunder_day_origin`)
+mitkommt. Ohne ausdrückliche Ablösung: Herkunft bleibt draußen, AC-13 bleibt grün.
+
+**Risiko 2 — Format im ASCII-Spaltenlayout.** Die Zeile ist
+`{weekday:<3} {name:<26} {temp:<8} {precip:<5} {wind:<5} {thunder}` und wird
+anschließend gefaltet. `⚡mittel @16 · nachts hoch @2` wird zu
+`Tmittel @16 - nachts hoch @2`. Die Gewitterspalte steht am Zeilenende, hat keine
+feste Breite — ein Zusatz sprengt kein Raster, verlängert aber die Zeile.
+
+**Risiko 3 — viertes Duplikat.** Wird die Zweiglogik ein viertes Mal kopiert,
+entsteht genau das Muster, das #1671 überhaupt erst erzeugt hat: drei Stellen
+umgestellt, eine vergessen. Ein geteilter *Entscheidungs*-Helper (Zweigwahl, nicht
+Formatierung) in `helpers.py` schließt die Fehlerklasse ursächlich. Der
+Byte-Paritätswächter aus #1361/#1368 ist dabei der Nachweis, dass ein Umbau an
+`outlook.py` nichts an der Ausgabe ändert.
+
+**Risiko 4 — Nachweisaufwand.** `renderer_mail_gate.py` verlangt vor dem Commit
+zwingend einen frischen `test_issue_811_mode_matrix.py`-Lauf **und** einen
+erfolgreichen `briefing_mail_validator.py`-Lauf gegen eine echt zugestellte
+Staging-Mail im Kurzformat. Das ist der teurere Teil der Scheibe, nicht der Code.

--- a/docs/specs/modules/fix_1671_kompaktmail_ausblick_tagesfenster.md
+++ b/docs/specs/modules/fix_1671_kompaktmail_ausblick_tagesfenster.md
@@ -332,6 +332,19 @@ unverändert. Byte-Parität zum heutigen Stand ist Pflicht (s. Testplan).
 - **`render_outlook_table()` (HTML-Zelle)** — hat eine strukturell andere
   Zweigwahl (s. „Am Code gemessen", Punkt 3) und wird nicht auf den neuen
   Helfer umgestellt.
+- **Der Metrik-Zweig des Trip-Ausblicks (#1841)** — nachgetragen 2026-08-14
+  nach dem Rebase auf `2ceadc9d`: mit #1720 S1 (heute gemergt) hat der
+  **Trip**-Ausblick einen zweiten Renderpfad bekommen. Ist eine
+  Ausblick-Spaltenauswahl gesetzt, rendern HTML-Tabelle und Klartext die
+  `row["cells"]` und überspringen den gesamten Token-Zeilenbau per
+  `continue` (`outlook.py:155-162` bzw. `348-356`); die Gewitterstufe kommt
+  dort aus `summary.thunder_level_max` — dem Gehzeit-Aggregat —, eine
+  Nachtangabe existiert nicht. **Dieselbe Fehlerklasse, ein weiterer
+  Ausgabeort**, als eigenes Issue **#1841** gebucht. Die Kurzformat-Mail
+  kennt diesen Zweig nicht (`compact.py` liest keine `cells`), diese Scheibe
+  bleibt davon unberührt. Die Aussage „die Klasse ist mit vier Ausgabeorten
+  vollständig ausgezählt" im Kontext-Doc gilt für den Token-Pfad — der
+  Metrik-Pfad ist eine fünfte Stelle, die dort noch nicht existierte.
 
 ## Testplan
 

--- a/docs/specs/modules/fix_1671_kompaktmail_ausblick_tagesfenster.md
+++ b/docs/specs/modules/fix_1671_kompaktmail_ausblick_tagesfenster.md
@@ -1,0 +1,444 @@
+---
+entity_id: fix_1671_kompaktmail_ausblick_tagesfenster
+type: bugfix
+created: 2026-08-14
+updated: 2026-08-14
+status: approved
+version: "1.0"
+tags: [gewitter, ausblick, tag-nacht, compact, issue-1671]
+---
+
+<!-- Issue #1671. Grundlage: PFLICHTLEKTUERE
+     docs/context/fix-1671-compact-gewitter-tagesfenster.md (am Stand
+     `e2b5269b` gemessen, nicht aus dem Ticket uebernommen). Vorbilder:
+     docs/specs/modules/fix_1653_ausblick_tag_nacht_trennung.md (Muster:
+     Tag/Nacht-Trennung, drei Kanaele) und
+     docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md
+     (AC-13, die hier bewusst NICHT abgeloest wird). -->
+
+# #1671 — Kurzformat-Mail: Gewitterspalte des Ausblicks liest das falsche Fenster
+
+## Approval
+
+- [x] Approved — PO-go 2026-08-14 (Klartext-Freigabe der ACs auf Deutsch).
+      Zugleich freigegeben: LoC-Limit dieses Workflows auf 500 angehoben.
+
+## Purpose
+
+Der Ausblick-Block „Naechste Etappen" existiert in vier Ausgabeorten. Drei
+davon (HTML-Ausblick-Tabelle, Klartext-Mail-Ausblick, Telegram-Trendblock)
+wurden mit #1653 auf `thunder_day_token`/`thunder_night_token` — das
+Tagesfenster derselben Stundenreihe — umgestellt. Die **Kurzformat-Mail**
+(`X-GZ-Format: compact`, `src/output/renderers/email/compact.py:230-236`)
+baut ihre Gewitterspalte weiterhin aus `tok['thunder_plain']`, dem auf die
+Gehzeit geklemmten 24-Stunden-Aggregat — der vierte, bei #1653 vergessene
+Ausgabeort. Folge: die Kurzformat-Zeile kann ein reales Tagesgewitter
+verschweigen (falsch-negativ) oder ein nicht vorhandenes behaupten
+(falsch-positiv), und eine Nachtangabe fehlt dort strukturell ganz.
+
+Diese Scheibe stellt die Kurzformat-Mail auf dieselbe Quelle
+(`thunder_day_token`/`thunder_night_token`) um wie die drei anderen Kanäle —
+mit eigenem, dem ASCII-Format der Kurzformat-Mail angepasstem
+Darstellungsformat — und beseitigt dabei die Ursache (drei fast identische
+Zweig-Entscheidungen), statt eine vierte Kopie zu schreiben.
+
+## Source
+
+> **Schicht-Hinweis:** ausschließlich Python-Core
+> (`src/output/renderers/email/`). Kein Frontend, keine Go-Beteiligung, kein
+> neuer Endpoint, keine neuen Persistenz-Felder.
+
+- **File:** `src/output/renderers/email/compact.py` — `render_compact()`,
+  Ausblick-Schleife Z. 227–238 (**der Prüfling**).
+- **File:** `src/output/renderers/email/helpers.py` — `format_trend_tokens()`
+  (liefert `thunder_day_token`/`thunder_night_token`/`thunder_plain`
+  unverändert); neuer Entscheidungs-Helfer wird hier ergänzt.
+- **File:** `src/output/renderers/email/outlook.py` —
+  `render_outlook_plain()` Z. 358–414 (Vorbild Darstellungsformat,
+  Refactoring-Ziel für den geteilten Entscheidungs-Helfer),
+  `_thunder_token_parts()` Z. 43–59 (Token-Zerlegung, wiederverwendet).
+- **File:** `src/output/renderers/narrow.py` — `_outlook_lines()`
+  Z. 571–609 (Refactoring-Ziel für denselben Entscheidungs-Helfer).
+
+## Estimated Scope
+
+- **LoC:** ~50–70 Produktivcode (neuer Helfer in `helpers.py`, Ausblick-
+  Logik in `compact.py`, Refactoring der bestehenden Zweige in `outlook.py`
+  und `narrow.py` auf den Helfer) + ~150–220 Testcode (Kern-Suite,
+  Mutations-Gegenproben, Nullfall/Fall-A/Fall-B-Fixtures analog #1653) —
+  voraussichtlich in Summe **über dem 250-Zeilen-Workflow-Limit**;
+  `workflow.py set-field loc_limit_override 500` bei Bedarf in
+  `/50-implement` einholen (identische Einschätzung wie #1653).
+- **Files:** 4 Produktivdateien (MODIFY: `compact.py`, `helpers.py`,
+  `outlook.py`, `narrow.py`), 1 neue Testdatei (CREATE).
+- **Effort:** medium.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `output.renderers.email.helpers.format_trend_tokens()` | vorhanden, unverändert | Liefert `thunder_day_token`, `thunder_night_token`, `thunder_plain`, `thunder_day_origin` — alle nötigen Token bereits vorhanden |
+| `_thunder_token_parts()` | vorhanden, **wandert nach `helpers.py`** | Zerlegt einen Token (`leicht@5(hoch@15)`) in (Wort, Stunde, Peak-Zusatz). Steht heute in `outlook.py:43`; mit dem dritten Verbraucher (`compact.py`) gehört sie neben `format_trend_tokens()`, das diese Token baut. **Nur die Definition wandert** — `outlook.py` importiert sie aus `helpers.py`, seine vier Aufrufstellen bleiben unverändert. Kein Cross-Modul-Import einer privaten Funktion aus einem Schwester-Renderer |
+| `output.renderers.email.helpers._THUNDER_MAP["NONE"]["plain"]` | vorhanden, wiederverwendet | Explizites „kein Gewitter"-Label, wenn Stundenreihe im Tagesfenster leer ist |
+| neuer: `output.renderers.email.helpers.resolve_thunder_day_branch()` | NEU (diese Scheibe) | Einmalige Zweigwahl (day/none/plain), von `compact.py`, `outlook.py`, `narrow.py` genutzt |
+
+## Am Code gemessen
+
+Nachgemessen am Stand `e2b5269b` (== `origin/main`, 2026-08-14):
+
+1. **`compact.py:230-236` liest ausschließlich `tok['thunder_plain']`.**
+   Keine Tag/Nacht-Trennung, kein Zugriff auf `thunder_day_token`/
+   `thunder_night_token`. Bestätigt die Kernbehauptung des Issues.
+
+2. **Die Zweiglogik existiert bereits zweimal fast identisch:**
+   `outlook.py:373-386` (`render_outlook_plain`) und `narrow.py:588-601`
+   (`_outlook_lines`) prüfen in derselben Reihenfolge:
+   (a) `tok.get("thunder_day_token", "-") != "-"` → Wort aus dem Tages-Token
+   via `_thunder_token_parts()`; (b) sonst, wenn `stage.get("hourly_thunder")`
+   gefüllt ist → explizites „kein Gewitter" (`_THUNDER_MAP["NONE"]["plain"]`,
+   Stundenreihe da, im Tagesfenster aber leer); (c) sonst (keine Stundenreihe,
+   Alt-Aufrufer/Compare) → `tok["thunder_plain"]` unverändert.
+
+3. **`render_outlook_table()` (HTML-Zelle) hat eine strukturell andere
+   Zweigwahl** (Z. 233-248: dritter Zweig fällt auf das rohe Aggregat-Level
+   zurück statt auf `thunder_plain`, und es gibt keine explizite
+   „kein Gewitter"-Textausgabe, nur ein leeres `day_part`). Sie wird daher
+   **nicht** auf den neuen Entscheidungs-Helfer umgestellt — nur die beiden
+   strukturell identischen Klartext-Zweige (`outlook.py` Klartext,
+   `narrow.py`).
+
+4. **Beide bestehenden Zweige hängen zusätzlich `tok.get("thunder_day_origin")`
+   an, wenn Branch (a) greift** (`outlook.py:381-383`, `narrow.py:595-597`,
+   aus #1680 S5a). Der neue Entscheidungs-Helfer entscheidet nur den Zweig
+   (day/none/plain), NICHT ob die Herkunft angehängt wird — das bleibt
+   Aufrufer-Formatierung. `compact.py` ruft die Herkunft **nicht** ab (s.
+   „Vom PO entschieden", Punkt 1).
+
+5. **Nachtformat in `outlook.py:398-401`:**
+   `line += f" · nachts {_nm[0]} @{_nm[1]}{_nm[2]}"` — Leerzeichen vor `@`,
+   Peak-Zusatz in Klammern falls vorhanden. Dies ist das Zielformat für die
+   Kurzformat-Mail (PO-Entscheidung 2), nicht `narrow.py`s Variante
+   (`f" · nachts {nt}"`, roher Token ohne Leerzeichen vor `@`).
+
+6. **`compact.py`s ASCII-Faltung läuft NACH dem Zeilenbau:** `_ASCII_MAP`
+   (Z. 49-54) übersetzt `⚡`→`T`, `·`→`-`, `–`→`-`; anschließend
+   `fold_ascii()` faltet Umlaute (Z. 60-61). `_ascii()` wird auf die
+   fertige Zeile angewendet (Z. 237: `lines.append(_ascii(line))`).
+   Beispiel: `⚡leicht · nachts hoch @2` → `Tleicht - nachts hoch @2`.
+
+7. **`renderer_mail_gate.py` stuft `helpers.py` als „geteilten Helfer" ein**
+   (`_SHARED_HELPER_PATTERNS`, `.claude/hooks/renderer_mail_gate.py:76-78`):
+   `src/output/renderers/email/(helpers|design_tokens|profile_signature)\.py$`.
+   Da diese Scheibe `helpers.py` staged, verlangt das Gate **zusätzlich**
+   zum Briefing-Nachweis (Matrix-Test + `briefing_mail_validator.py`) auch
+   den **Compare**-Nachweis (`email_spec_validator.py`) — nicht nur, weil
+   `compact.py` (Briefing-Pfad) betroffen ist, sondern weil der geteilte
+   Helfer potenziell auch den Compare-Pfad berühren könnte. Das ist eine
+   Ergänzung gegenüber dem ursprünglichen Auftrag, gemessen am Gate-Code
+   selbst, nicht vermutet.
+
+8. **`compact.py` zeigt heute keinen Hagel-Zusatz** in der Ausblick-Zeile
+   (kein `_format_hail_note`/`format_hail_note`-Aufruf im gelesenen
+   Ausschnitt Z. 227-238). Diese Scheibe führt keinen ein — reiner
+   Tag/Nacht-Fix, kein Feature-Zuwachs (s. „Nicht in dieser Scheibe").
+
+## Vom PO entschieden (2026-08-14) — gesetzt, nicht Teil der Freigabefrage
+
+1. **Kein Herkunfts-Zusatz im Kurzformat.** `thunder_day_origin` wird NICHT
+   gelesen. `feat_1680_s5a` AC-13 sichert zu, dass der Kompakt-Ausblick
+   zeichengleich bleibt und keine der vier Zutat-Bezeichnungen nennt
+   (PO-go 2026-08-13). Diese Zusicherung wird **nicht** abgelöst — der
+   bestehende Wächter `tests/tdd/test_thunder_origin_outlook.py::test_ac13_kompaktmail_bleibt_zeichengleich`
+   MUSS nach dieser Scheibe weiterhin grün sein. Die *Begründung* der
+   Zusicherung („liest ohnehin nur `thunder_plain`") entfällt mit dieser
+   Scheibe faktisch — die Zeile liest ab jetzt `thunder_day_token`/
+   `thunder_night_token` — die *Zusicherung selbst* bleibt jedoch in Kraft:
+   keine Herkunft in der Kurzformat-Mail. Eine Ablösung von AC-13 wäre ein
+   eigenes Ticket.
+
+2. **Darstellungsformat folgt der Klartext-Mail, nicht Telegram.**
+   Tagesteil ohne Uhrzeit (Wort + optionaler Peak-Zusatz, wie
+   `render_outlook_plain` Z. 373-383, aber ohne den Herkunfts-Zusatz aus
+   Punkt 1), Nachtteil als Zusatz MIT Uhrzeit
+   (`· nachts <stufe> @<h>[<peak>]`, identisch zu `outlook.py:398-401`).
+   Die ACs formulieren die Erwartung an der **zugestellten, ASCII-
+   gefalteten** Zeile (nach `_ascii()`), nicht an einem Zwischenstand.
+
+3. **Geteilter Entscheidungs-Helfer statt viertem Duplikat.** Neue Funktion
+   `resolve_thunder_day_branch(tok: dict, stage: dict) -> str` in
+   `helpers.py`, Rückgabewerte `"day"` / `"none"` / `"plain"` — reine
+   Zweigwahl, KEINE Formatierung. `compact.py`, `outlook.py`
+   (`render_outlook_plain`) und `narrow.py` (`_outlook_lines`) rufen ihn
+   auf; jeder Aufrufer formatiert das Ergebnis weiterhin selbst (Wort mit/
+   ohne Uhrzeit, mit/ohne Herkunft, mit/ohne Emoji-Präfix). `render_outlook_table()`
+   (HTML-Zelle) wird **nicht** umgestellt (s. „Am Code gemessen", Punkt 3).
+
+## Implementation Details
+
+### 1. Neuer Entscheidungs-Helfer (`helpers.py`)
+
+```python
+def resolve_thunder_day_branch(tok: dict, stage: dict) -> str:
+    """Waehlt die Datenquelle fuer das Tages-Gewitterwort (#1671).
+
+    Reine Zweigwahl, KEINE Formatierung -- die drei Aufrufer (compact.py,
+    outlook.py Klartext, narrow.py) stellen das Ergebnis unterschiedlich
+    dar, entscheiden aber identisch. Ersetzt die bis #1671 dreifach fast
+    identisch kopierte if/elif-Kette.
+
+    Returns:
+        "day"   -- tok["thunder_day_token"] traegt einen Wert (!= "-"):
+                   Wort+Uhrzeit aus dem Tagesfenster verwenden.
+        "none"  -- Stundenreihe vorhanden, im Tagesfenster aber leer:
+                   explizites "kein Gewitter" zeigen (_THUNDER_MAP["NONE"]).
+        "plain" -- keine Stundenreihe (Alt-Aufrufer/Compare): auf das
+                   ungefilterte 24h-Aggregat (tok["thunder_plain"]) zurueckfallen.
+    """
+    if tok.get("thunder_day_token", "-") != "-":
+        return "day"
+    if stage.get("hourly_thunder"):
+        return "none"
+    return "plain"
+```
+
+### 2. `compact.py` — Ausblick-Zeile umgestellt
+
+Ersetzt `tok['thunder_plain']` (Z. 235) durch eine neue lokale
+Formatierungsfunktion, die den Entscheidungs-Helfer nutzt:
+
+```python
+from output.renderers.email.helpers import (
+    ..., resolve_thunder_day_branch, _thunder_token_parts,
+)
+
+def _compact_thunder_field(tok: dict, stage: dict) -> str:
+    branch = resolve_thunder_day_branch(tok, stage)
+    if branch == "day":
+        _d = _thunder_token_parts(tok.get("thunder_day_token", "-"))
+        field = f"⚡{_d[0]}{_d[2]}"  # Wort + Peak-Zusatz, KEINE Uhrzeit,
+                                     # KEINE Herkunft (PO-Entscheidung 1)
+    elif branch == "none":
+        field = _THUNDER_MAP["NONE"]["plain"]
+    else:
+        field = tok["thunder_plain"]
+
+    _n = _thunder_token_parts(tok.get("thunder_night_token", "-"))
+    if _n:
+        field += f" · nachts {_n[0]} @{_n[1]}{_n[2]}"
+    return field
+```
+
+Aufruf in der Ausblick-Schleife (ersetzt Z. 235):
+
+```python
+thunder_field = _compact_thunder_field(tok, stage)
+line = (
+    f"{weekday:<3} {name:<26} {tok['temp_str']:<8} "
+    f"{tok['precip_str']:<5} {tok['wind_str']:<5} {thunder_field}"
+)
+```
+
+Die anschließende `_ascii(line)`-Faltung (unverändert) übersetzt `⚡`→`T`,
+`·`→`-`: Beispielzeile `⚡leicht · nachts hoch @2` wird zu
+`Tleicht - nachts hoch @2`.
+
+### 3. `outlook.py` und `narrow.py` — Refactoring auf den Helfer
+
+Die bestehenden if/elif-Ketten (`outlook.py:373-386`, `narrow.py:588-601`)
+werden durch `branch = resolve_thunder_day_branch(tok, stage)` ersetzt; die
+je-Kanal-Formatierung (mit/ohne Herkunft, mit/ohne `⚡`-Präfix) bleibt
+unverändert. Byte-Parität zum heutigen Stand ist Pflicht (s. Testplan).
+
+## Expected Behavior
+
+- **Input:** `stage`-Dict wie bisher (`hourly_thunder`, optional
+  `day_window_start_hour`/`day_window_end_hour`), `tok` = Ergebnis von
+  `format_trend_tokens(stage)`.
+- **Output:** Die Kurzformat-Mail-Ausblick-Zeile zeigt dieselbe
+  Tagesfenster-Stufe wie HTML-Tabelle, Klartext-Mail und Telegram (statt
+  des 24h-Aggregats), plus — neu für diesen Kanal — eine Nachtangabe mit
+  Uhrzeit, falls vorhanden. Kein Herkunfts-Zusatz.
+- **Side effects:** keine — reine Rendering-Funktionen, kein Netz-, kein
+  DB-Zugriff.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine Etappe mit Tagesgewitter „leicht" um 16 Uhr
+  innerhalb des Tagesfensters und einem 24h-Aggregat, das „NONE" zeigt
+  (Fall: Aggregat und Tagesfenster widersprechen sich) / When die
+  Kurzformat-Mail gerendert wird / Then zeigt die Ausblick-Zeile das
+  Tagesgewitter „leicht" — nicht das leere Aggregat.
+
+- **AC-2:** Given dieselbe Konstellation umgekehrt (Aggregat zeigt „HIGH",
+  Tagesfenster ist leer, das Ereignis liegt vollständig in der Nacht) /
+  When die Kurzformat-Mail gerendert wird / Then zeigt der Tagesteil der
+  Zeile explizit „kein Gewitter" (ASCII-gefaltet: „T-" bzw. das gefaltete
+  `_THUNDER_MAP["NONE"]["plain"]`), nicht das fälschlich übernommene
+  Aggregat-„HIGH".
+
+- **AC-3:** Given eine Etappe mit Tagesgewitter „mittel" 14 Uhr UND
+  Nachtgewitter „hoch" 0 Uhr / When die Kurzformat-Mail gerendert wird /
+  Then enthält die zugestellte, ASCII-gefaltete Zeile sowohl den Tagesteil
+  als auch einen Nachtzusatz der Form `- nachts hoch @0` (Bindestrich statt
+  `·` nach der Faltung) — eine Nachtangabe, die im Kompaktformat vor dieser
+  Scheibe strukturell nie erschien.
+
+- **AC-4:** Given eine Etappe ganz ohne Gewitter (Tag und Nacht `NONE`,
+  Stundenreihe vorhanden) / When die Kurzformat-Mail gerendert wird / Then
+  zeigt die Zeile das explizite „kein Gewitter"-Zeichen ohne Nachtzusatz —
+  kein leerer oder abweichender Ausdruck.
+
+- **AC-5:** Given eine Ausblick-Zeile ohne jede Stundenreihe (Alt-Fixture,
+  `hourly_thunder` fehlt) / When die Kurzformat-Mail gerendert wird / Then
+  bleibt die Ausgabe byte-identisch zum Stand vor dieser Änderung
+  (Rückfall auf `thunder_plain`, Zweig „plain"). Referenz ist eine **vor der
+  Implementierung aufgezeichnete** Soll-Zeile (Konstante im Test oder Datei
+  unter `tests/fixtures/`), **nicht** ein zweiter Aufruf desselben Codes im
+  selben Lauf — ein Vorher/Nachher-Vergleich innerhalb eines Laufs ändert
+  sich mit dem Code mit und beweist nichts (Begründung wörtlich aus
+  `tests/tdd/test_trip_outlook_parity.py`).
+
+- **AC-6:** Given ein Trip-Briefing im Kompaktformat / When die Mail
+  gerendert wird / Then enthält der Ausblick-Block **keine** der vier
+  Zutat-Bezeichnungen (CAPE, Blitzdichte, Blitzpotenzial, Superzellen) —
+  `thunder_day_origin` wird nicht gelesen. Der bestehende Wächter
+  `tests/tdd/test_thunder_origin_outlook.py::test_ac13_kompaktmail_bleibt_zeichengleich`
+  bleibt unverändert grün.
+
+- **AC-7:** Given dieselben Gewitterdaten / When HTML-Ausblick-Tabelle UND
+  Klartext-Ausblick der Trip-Vollmail (nicht die Kurzformat-Mail) gerendert
+  werden / Then bleiben beide byte-identisch zum Stand vor dieser Scheibe —
+  nachgewiesen über den unveränderten Bestandswächter
+  `tests/tdd/test_trip_outlook_parity.py` samt seiner Golden-Dateien unter
+  `tests/fixtures/outlook_trip_parity/`, die NICHT neu erzeugt werden.
+  Der Telegram-Trendblock (`narrow.py`) bleibt in Inhalt und Format
+  ebenfalls unverändert.
+
+## Nicht in dieser Scheibe
+
+- **Herkunfts-Zusatz im Kurzformat** — bewusste PO-Entscheidung 1, bleibt
+  ausdrücklich draußen.
+- **SMS / Premium-SMS** — erreichen den Ausblick baulich nicht
+  (`SMSTripFormatter` sieht `multi_day_trend` nie, belegt in
+  `feat_1680_s5a`, „Am Code gemessen" Punkt 6; hier nicht erneut
+  hergeleitet, nur referenziert).
+- **Compare-Ausblick** — teilt sich den `outlook.py`-Baustein, hat aber
+  keine Stundenreihe (`hourly_thunder` fehlt im Compare-Pfad); der Zweig
+  „plain" greift dort unverändert, kein Compare-spezifisches Verhalten
+  wird eingeführt oder geändert.
+- **Hagel-Zusatz in der Kurzformat-Mail** — existiert dort heute nicht und
+  wird von dieser Scheibe nicht eingeführt (s. „Am Code gemessen",
+  Punkt 8).
+- **`render_outlook_table()` (HTML-Zelle)** — hat eine strukturell andere
+  Zweigwahl (s. „Am Code gemessen", Punkt 3) und wird nicht auf den neuen
+  Helfer umgestellt.
+
+## Testplan
+
+Kern-Schicht, deterministisch, keine Mocks — echte Domänen-Objekte
+(`stage`-Dicts wie in `_build_stage_trend()` produziert) und echte
+Renderer-Aufrufe (`format_trend_tokens()` → `render_compact()` bzw. die
+neue `_compact_thunder_field()`). Neue Testdatei nach Verhalten benannt:
+`tests/tdd/test_kompaktmail_ausblick_tagesfenster.py` (NICHT nach
+Issue-Nummer — `test_naming_gate.py` blockt issue-nummerierte
+Testdateinamen beim Commit).
+
+| AC | Test (mindestens) |
+|---|---|
+| AC-1 | `test_tagesgewitter_erscheint_trotz_leerem_24h_aggregat` — Fixture mit Tagesstunde „leicht", 24h-Aggregat „NONE"; prüft die von `render_compact()` zurückgegebene, ASCII-gefaltete Zeile |
+| AC-2 | `test_kein_tagesgewitter_trotz_aggregat_high` — Fixture mit Tagesfenster leer, Nachtstunde „hoch"; Tagesteil zeigt explizit „kein Gewitter", nicht „HIGH" |
+| AC-3 | `test_nachtgewitter_erscheint_mit_uhrzeit_im_kompaktformat` — Fall B (Tag „mittel" 14, Nacht „hoch" 0); geprüft wird die ZUGESTELLTE Zeile nach `_ascii()`, inkl. `- nachts hoch @0` |
+| AC-4 | `test_kein_gewitter_tag_und_nacht_zeigt_explizites_none` |
+| AC-5 | `test_ohne_stundenreihe_bleibt_kurzformat_unveraendert` — Alt-Fixture ohne `hourly_thunder`, Vergleich mit dem heutigen (Vor-Fix) Rendering-Ergebnis |
+| AC-6 | Bestehender Test `tests/tdd/test_thunder_origin_outlook.py::test_ac13_kompaktmail_bleibt_zeichengleich` läuft unverändert grün; zusätzlich `test_kompaktmail_ohne_herkunfts_zusatz` mit Fixture, die im HTML-/Klartext-Pfad nachweislich eine Herkunft erzeugen WÜRDE (Gegenprobe, sonst vakuum-grün) |
+| AC-7 | Bestehender `tests/tdd/test_trip_outlook_parity.py` läuft unverändert grün, Golden-Dateien unangetastet |
+
+## Mutations-Gegenprobe
+
+Jede Mutation nur per String-Ersetzung mit externer Sicherungskopie — nie
+`git checkout`/`stash`/`reset`.
+
+- **(a)** In `_compact_thunder_field()` den Branch-Aufruf durch
+  `branch = "plain"` (fest verdrahtet) ersetzen → AC-1 und AC-2 müssen rot
+  werden (das Tagesfenster-Wort verschwindet zugunsten des Aggregats).
+- **(b)** Den Nachtzusatz-Block in `_compact_thunder_field()` entfernen →
+  AC-3 muss rot werden.
+- **(c)** `tok.get("thunder_day_origin")` zusätzlich an den `"day"`-Zweig
+  von `_compact_thunder_field()` anhängen → AC-6 UND der bestehende
+  `test_ac13_kompaktmail_bleibt_zeichengleich` müssen rot werden. **Diese
+  Mutation prüft die Zusicherung an der Stelle, an der sie WIRKT** — der
+  Test liest die von `render_compact()` zurückgegebene, ASCII-gefaltete
+  Zeile, nicht `_compact_thunder_field()` isoliert; eine Prüfung, die nur
+  die Helper-Funktion isoliert testet, würde die Mutation ebenfalls fangen,
+  aber NICHT belegen, dass die Herkunft auch nicht in der zugestellten Mail
+  landet (z. B. weil eine spätere ASCII-Faltung sie unbemerkt verschluckt
+  oder ein zweiter Aufrufpfad existiert) — deshalb ist der Test auf
+  `render_compact()`-Ebene Pflicht, nicht nur auf Helper-Ebene.
+- **(d)** In `resolve_thunder_day_branch()` die Reihenfolge der Prüfungen
+  vertauschen (`hourly_thunder`-Check vor dem `thunder_day_token`-Check) →
+  AC-1 muss rot werden (eine gefüllte Stundenreihe mit leerem Tagesfenster,
+  aber vorhandenem Nachtwert, würde fälschlich „none" statt „day" liefern,
+  sobald der Tagesteil selbst einen Wert trägt — Testfixture mit beidem
+  gleichzeitig gefüllt nötig).
+- **(e)** Das Leerzeichen vor `@` im Nachtzusatz entfernen
+  (`f" · nachts {_n[0]}@{_n[1]}{_n[2]}"` statt mit Leerzeichen) → AC-3 muss
+  rot werden, WEIL der Test exakt den zugestellten Wortlaut prüft, nicht
+  nur die Anwesenheit von „nachts" und der Stufe (Beleg, dass AC-3 nicht
+  über eine zu grobe Teilstring-Prüfung vakuum-grün ist).
+
+Kommt eine Mutation durch, ist das ein Finding, kein Nebenbefund.
+
+## Nachweis vor Commit
+
+`renderer_mail_gate.py` (#811, un-überspringbar) blockiert jeden Commit,
+der eine Mail-Inhalts-Datei staged, bis die passenden Nachweise frisch
+vorliegen. Diese Scheibe staged sowohl `compact.py` (Briefing-Pfad) als
+auch `helpers.py` (als „geteilter Helfer" eingestuft, s. „Am Code
+gemessen", Punkt 7). Damit sind **beide** Nachweisstränge fällig:
+
+1. **Briefing-Nachweis** (wegen `compact.py`): frischer Lauf von
+   `uv run pytest tests/tdd/test_issue_811_mode_matrix.py` (grün) UND ein
+   erfolgreicher `uv run python3 .claude/hooks/briefing_mail_validator.py`-
+   Lauf gegen eine echt zugestellte Staging-Mail im Kurzformat
+   (`X-GZ-Format: compact`).
+2. **Compare-Nachweis** (wegen `helpers.py`, Shared-Helper-Muster): ein
+   erfolgreicher `uv run python3 .claude/hooks/email_spec_validator.py`-
+   Lauf gegen eine echt zugestellte Staging-Compare-Mail.
+
+Beide Läufe nur bei Exit 0 als „E2E bestanden" verbuchen — kein Mock, kein
+Gmail, gegen Stalwart-Test-Postfach (`GZ_IMAP_*`).
+
+## Known Limitations
+
+- Der neue Entscheidungs-Helfer `resolve_thunder_day_branch()` entscheidet
+  ausschließlich den Zweig, nicht die Formatierung — bei einer künftigen
+  vierten Darstellungsvariante ist weiterhin je-Kanal-Code nötig, nur die
+  Zweigwahl selbst dedupliziert.
+- `render_outlook_table()` (HTML-Zelle) bleibt bei ihrer eigenen,
+  strukturell abweichenden Zweigwahl (s. „Am Code gemessen", Punkt 3) —
+  keine vollständige Vereinheitlichung aller vier Ausgabeorte, nur der
+  beiden Klartext-artigen (Kurzformat, Klartext-Mail) plus Telegram.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue — reine Rendering-/Konsistenz-Korrektur analog
+  #1653, keine neue Grundsatzentscheidung.
+- **Rationale:** Die Umstellung der Kurzformat-Mail auf dieselbe
+  Tagesfenster-Quelle wie die drei anderen Kanäle ist eine Bugfix-Angleichung
+  an ein bereits etabliertes Muster (#1653), keine neue Architektur-
+  Entscheidung.
+
+## Offene Punkte für den PO
+
+Keine — die drei PO-Entscheidungen aus dem Auftrag sind vollständig in
+diese Spec übernommen. Einzige Ergänzung gegenüber dem ursprünglichen
+Auftrag ist eine am Gate-Code gemessene Tatsache (s. „Am Code gemessen",
+Punkt 7): weil `helpers.py` als geteilter Baustein angefasst wird, verlangt
+`renderer_mail_gate.py` zusätzlich zum Briefing-Nachweis auch den
+Compare-Nachweis (`email_spec_validator.py`). Das ist keine
+Entscheidungsfrage, sondern eine Pflicht des bestehenden, un-
+überspringbaren Gates — hier zur Kenntnis, nicht zur Freigabe.
+
+## Changelog
+
+- 2026-08-14: Initial spec created

--- a/docs/specs/modules/fix_1671_kompaktmail_ausblick_tagesfenster.md
+++ b/docs/specs/modules/fix_1671_kompaktmail_ausblick_tagesfenster.md
@@ -80,7 +80,18 @@ Zweig-Entscheidungen), statt eine vierte Kopie zu schreiben.
 | `output.renderers.email.helpers.format_trend_tokens()` | vorhanden, unverändert | Liefert `thunder_day_token`, `thunder_night_token`, `thunder_plain`, `thunder_day_origin` — alle nötigen Token bereits vorhanden |
 | `_thunder_token_parts()` | vorhanden, **wandert nach `helpers.py`** | Zerlegt einen Token (`leicht@5(hoch@15)`) in (Wort, Stunde, Peak-Zusatz). Steht heute in `outlook.py:43`; mit dem dritten Verbraucher (`compact.py`) gehört sie neben `format_trend_tokens()`, das diese Token baut. **Nur die Definition wandert** — `outlook.py` importiert sie aus `helpers.py`, seine vier Aufrufstellen bleiben unverändert. Kein Cross-Modul-Import einer privaten Funktion aus einem Schwester-Renderer |
 | `output.renderers.email.helpers._THUNDER_MAP["NONE"]["plain"]` | vorhanden, wiederverwendet | Explizites „kein Gewitter"-Label, wenn Stundenreihe im Tagesfenster leer ist |
-| neuer: `output.renderers.email.helpers.resolve_thunder_day_branch()` | NEU (diese Scheibe) | Einmalige Zweigwahl (day/none/plain), von `compact.py`, `outlook.py`, `narrow.py` genutzt |
+| neues Modul: `output.renderers.email.thunder_branch` | NEU (diese Scheibe) | Trägt `resolve_thunder_day_branch()` (einmalige Zweigwahl day/none/plain) **und** das hierher verschobene `_thunder_token_parts()` samt `_THUNDER_TOKEN_RE`. Genutzt von `compact.py`, `outlook.py`, `narrow.py` |
+
+**Zielort geändert gegenüber der freigegebenen Fassung (2026-08-14, Tech-Lead-Entscheid).**
+Ursprünglich war `helpers.py` vorgesehen. Diese Datei war durch das Datei-Claim-Gate
+von einer Parallel-Session belegt (verwaister Rest abgeschlossener #1801-Arbeit; die
+Eigentümer-Session hat das schriftlich bestätigt, ein Zurücknehmen der Belegung ist
+im Gate nicht vorgesehen, der Notausgang technisch aus einer laufenden Sitzung nicht
+erreichbar). Statt eine Stunde auf den 4-Stunden-Verfall zu warten, liegen die
+Funktionen nun in einem eigenen Modul — **kein AC ist davon berührt**, der Zielort
+war reines Implementierungsdetail. Zwei Nebeneffekte, beide günstig: `helpers.py`
+(ohnehin ein überladenes Sammelmodul) bleibt unverändert, und der zusätzliche
+Compare-Mail-Nachweis entfällt (s. „Nachweis vor Commit").
 
 ## Am Code gemessen
 
@@ -414,9 +425,15 @@ gemessen", Punkt 7). Damit sind **beide** Nachweisstränge fällig:
    erfolgreicher `uv run python3 .claude/hooks/briefing_mail_validator.py`-
    Lauf gegen eine echt zugestellte Staging-Mail im Kurzformat
    (`X-GZ-Format: compact`).
-2. **Compare-Nachweis** (wegen `helpers.py`, Shared-Helper-Muster): ein
-   erfolgreicher `uv run python3 .claude/hooks/email_spec_validator.py`-
-   Lauf gegen eine echt zugestellte Staging-Compare-Mail.
+2. ~~**Compare-Nachweis** (wegen `helpers.py`, Shared-Helper-Muster)~~ —
+   **entfällt** (2026-08-14): `helpers.py` wird nicht mehr angefasst, s.
+   „Zielort geändert" unter Dependencies. Am Gate-Code nachgemessen:
+   `_SHARED_HELPER_PATTERNS` (`renderer_mail_gate.py:76-78`) nennt
+   ausschließlich `helpers|design_tokens|profile_signature` — das neue Modul
+   `thunder_branch.py` matcht dort **nicht**. Es matcht aber sehr wohl das
+   breite Mail-Inhalts-Muster `src/output/renderers/email/.*\.py$`
+   (`renderer_mail_gate.py:43`), der Briefing-Nachweis aus Punkt 1 bleibt
+   also fällig — er war es über `compact.py` ohnehin.
 
 Beide Läufe nur bei Exit 0 als „E2E bestanden" verbuchen — kein Mock, kein
 Gmail, gegen Stalwart-Test-Postfach (`GZ_IMAP_*`).

--- a/src/output/renderers/email/compact.py
+++ b/src/output/renderers/email/compact.py
@@ -21,8 +21,12 @@ from output.renderers.day_window import DAY_WINDOW_END_HOUR, DAY_WINDOW_START_HO
 from output.renderers.fallback_notice import build_fallback_lines, select_fallback_meta
 from output.renderers.trip_metric_ids import resolve_trip_active_metrics
 from output.renderers.email.helpers import (
-    _AMPEL_STAGE_TONES, build_confidence_hint, build_metrics_summary_pills,
-    build_origin_footer, format_trend_tokens, render_origin_footer_text,
+    _AMPEL_STAGE_TONES, _THUNDER_MAP,
+    build_confidence_hint, build_metrics_summary_pills, build_origin_footer,
+    format_trend_tokens, render_origin_footer_text,
+)
+from output.renderers.email.thunder_branch import (
+    _thunder_token_parts, resolve_thunder_day_branch,
 )
 from output.renderers.email.profile_signature import profile_signature
 from output.renderers.alert.official_alerts import (
@@ -75,6 +79,36 @@ def _severity_prefix(tone: str) -> str:
     if tone in _AMPEL_STAGE_TONES:
         return _AMPEL_ASCII_SEVERITY[_AMPEL_STAGE_TONES.index(tone)]
     return ""
+
+
+def _compact_thunder_field(tok: dict, stage: dict) -> str:
+    """Gewitterspalte der Kompakt-Ausblick-Zeile (#1671).
+
+    Nutzt denselben Entscheidungs-Helfer wie ``render_outlook_plain()`` und
+    ``_outlook_lines()`` (thunder_branch.resolve_thunder_day_branch) -- Tagesteil
+    ohne Uhrzeit (Wort + optionaler Peak-Zusatz), Nachtteil als Zusatz MIT
+    Uhrzeit. KEIN Herkunfts-Zusatz (``thunder_day_origin`` wird bewusst
+    nicht gelesen, PO-Entscheidung 1 der Spec -- AC-13 aus #1680 S5a bleibt
+    fuer die Kompakt-Mail in Kraft).
+    """
+    branch = resolve_thunder_day_branch(tok, stage)
+    # Der Helfer entscheidet nur ueber `thunder_day_token != "-"`; ob der
+    # Token zerlegbar ist (`_THUNDER_TOKEN_RE`), bleibt Aufrufer-Sache --
+    # analog outlook.render_outlook_plain() (#1671-Nachbesserung: ein
+    # gesetzter, aber unzerlegbarer Token darf nicht abstuerzen, sondern
+    # faellt wie im Altcode auf "kein Gewitter" zurueck).
+    _d = _thunder_token_parts(tok.get("thunder_day_token", "-")) if branch == "day" else None
+    if _d:
+        field = f"⚡{_d[0]}{_d[2]}"
+    elif branch in ("day", "none"):
+        field = _THUNDER_MAP["NONE"]["plain"]
+    else:
+        field = tok["thunder_plain"]
+
+    _n = _thunder_token_parts(tok.get("thunder_night_token", "-"))
+    if _n:
+        field += f" · nachts {_n[0]} @{_n[1]}{_n[2]}"
+    return field
 
 
 _STABILITY_TEXTS = {
@@ -230,9 +264,10 @@ def render_compact(
             tok = format_trend_tokens(stage)
             weekday = stage.get("weekday", "")
             name = stage.get("name", "")
+            thunder_field = _compact_thunder_field(tok, stage)
             line = (
                 f"{weekday:<3} {name:<26} {tok['temp_str']:<8} "
-                f"{tok['precip_str']:<5} {tok['wind_str']:<5} {tok['thunder_plain']}"
+                f"{tok['precip_str']:<5} {tok['wind_str']:<5} {thunder_field}"
             )
             lines.append(_ascii(line))
         lines.append("")

--- a/src/output/renderers/email/outlook.py
+++ b/src/output/renderers/email/outlook.py
@@ -22,7 +22,6 @@ die @-time-Hourly-Samples.
 from __future__ import annotations
 
 import html as _html
-import re as _re
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
@@ -31,32 +30,11 @@ if TYPE_CHECKING:
 
 from app.metric_catalog import get_metric
 from output.renderers.email.helpers import format_trend_tokens
+from output.renderers.email.thunder_branch import (
+    _thunder_token_parts, resolve_thunder_day_branch,
+)
 from output.renderers.email.design_tokens import FONT_DATA, tone_css
 from utils.geo import degrees_to_compass
-
-
-_THUNDER_TOKEN_RE = _re.compile(
-    r"^([a-zA-Zäöü]+)@(\d+)(?:\(([a-zA-Zäöü]+)@(\d+)\))?"
-)
-
-
-def _thunder_token_parts(token: Optional[str]):
-    """Zerlegt einen Gewitter-Token in (Erst-Wort, Erst-Stunde, Peak-Zusatz).
-
-    Issue #1653 (F005): ``render_threshold_peak_value`` haengt den
-    Spitzenwert als ``leicht@5(hoch@15)`` an, wenn Erst-Ueberschreitung und
-    Spitze im selben Fenster auseinanderfallen -- der meteorologische
-    Normalfall eines ueber den Nachmittag eskalierenden Gewitters. Wer nur
-    die erste Gruppe liest, unterschlaegt genau die Stufe, vor der der
-    Report warnen soll. Der Peak-Zusatz ist "" (leer), wenn Erst == Peak.
-    """
-    if not token or token == "-":
-        return None
-    m = _THUNDER_TOKEN_RE.match(token)
-    if not m:
-        return None
-    peak_suffix = f" ({m.group(3)} @{m.group(4)})" if m.group(3) else ""
-    return m.group(1), m.group(2), peak_suffix
 
 
 # ---------------------------------------------------------------------------
@@ -374,10 +352,19 @@ def render_outlook_plain(
         # hier ganz -- und umgekehrt behauptete die Zeile ein Tagesgewitter,
         # wenn das Aggregat eine Stufe trug, die Stundenreihe im Tagesfenster
         # aber leer war.
+        # Issue #1671: Zweigwahl aus dem geteilten Helfer (identisch zu
+        # compact.py/narrow.py) -- nur die Formatierung bleibt hier lokal.
         from output.renderers.email.helpers import _THUNDER_MAP
-        thunder_word = tok["thunder_plain"]
-        _d_tok = tok.get("thunder_day_token", "-")
-        _dm = _thunder_token_parts(_d_tok)
+        branch = resolve_thunder_day_branch(tok, stage)
+        # Der Helfer entscheidet nur ueber `thunder_day_token != "-"`; ob
+        # der Token tatsaechlich zerlegbar ist (`_THUNDER_TOKEN_RE`),
+        # bleibt Aufrufer-Sache -- ein gesetzter, aber unzerlegbarer Token
+        # fiel im Altcode auf denselben Zweig zurueck wie "none" (ein
+        # ungesetzter Token bedeutet immer auch keinen hourly_thunder-Wert
+        # dieser Stunde). Reines `if branch == "day": thunder_word = ...`
+        # ohne diesen Guard wuerde bei einem unzerlegbaren Token mit
+        # `_dm is None` abstuerzen (TypeError beim Subscript).
+        _dm = _thunder_token_parts(tok.get("thunder_day_token", "-")) if branch == "day" else None
         if _dm:
             thunder_word = f"⚡{_dm[0]}{_dm[2]}"
             # Issue #1680 S5a: derselbe Zusatz wie in der HTML-Zelle, aus
@@ -386,11 +373,14 @@ def render_outlook_plain(
             _origin = tok.get("thunder_day_origin")
             if _origin:
                 thunder_word += f" · {_origin}"
-        elif stage.get("hourly_thunder"):
-            # Stundenreihe da, im Tagesfenster aber kein Gewitter.
+        elif branch in ("day", "none"):
+            # Stundenreihe da, im Tagesfenster aber kein Gewitter (bzw. ein
+            # gesetzter, aber unzerlegbarer Tages-Token).
             thunder_word = _THUNDER_MAP["NONE"]["plain"]
-        # Ohne jede Stundenreihe (Alt-Aufrufer, Compare) bleibt es beim
-        # Aggregatwort -- der Split kann dort nichts sagen.
+        else:
+            # Ohne jede Stundenreihe (Alt-Aufrufer, Compare) bleibt es beim
+            # Aggregatwort -- der Split kann dort nichts sagen.
+            thunder_word = tok["thunder_plain"]
 
         name_field = f"{name:<26} " if show_name else ""
         line = (

--- a/src/output/renderers/email/thunder_branch.py
+++ b/src/output/renderers/email/thunder_branch.py
@@ -1,0 +1,79 @@
+"""Gewitter-Tagesfenster-Zweigwahl -- Issue #1671.
+
+Vor dieser Scheibe entschied jeder der drei betroffenen Kanaele (Klartext-
+Mail-Ausblick, Telegram-Trendblock, Kompaktformat-Mail) dieselbe if/elif-
+Kette fast identisch selbst: zeigt das Tagesfenster einen Gewitter-Token
+(``thunder_day_token``), das Tageswort daraus -- sonst, wenn ueberhaupt eine
+Stundenreihe vorliegt, ein explizites "kein Gewitter" -- sonst (Alt-
+Aufrufer/Compare ohne Stundenreihe) das ungefilterte 24h-Aggregat
+(``thunder_plain``). Zwei der drei Kopien wurden bereits mit #1653
+geschrieben, die Kompaktformat-Mail blieb bei #1653 aussen vor (die
+eigentliche Ursache dieses Issues) und baute nie eine dritte Kopie.
+
+``resolve_thunder_day_branch()`` ist die EINE Zweigwahl fuer alle drei
+Aufrufer (``compact.py``, ``outlook.py`` Klartext, ``narrow.py``); jeder
+formatiert das Ergebnis weiterhin selbst (mit/ohne Uhrzeit, mit/ohne
+Herkunft, mit/ohne Emoji-Praefix). ``_thunder_token_parts()`` zerlegt einen
+Gewitter-Token in seine Bestandteile und wanderte aus ``outlook.py`` hierher
+(dritter Verbraucher).
+
+Eigenstaendiges Modul statt Ablage in ``helpers.py`` (#1671-Nachtrag): kein
+Import von ``helpers`` hier -- reine Zweig-/Zerlegungs-Logik ohne
+Abhaengigkeit auf das dortige Sammelmodul, keine Zirkelimport-Gefahr.
+"""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+
+_THUNDER_TOKEN_RE = re.compile(
+    r"^([a-zA-Zäöü]+)@(\d+)(?:\(([a-zA-Zäöü]+)@(\d+)\))?"
+)
+
+
+def _thunder_token_parts(token: Optional[str]):
+    """Zerlegt einen Gewitter-Token in (Erst-Wort, Erst-Stunde, Peak-Zusatz).
+
+    Issue #1653 (F005): ``render_threshold_peak_value`` haengt den
+    Spitzenwert als ``leicht@5(hoch@15)`` an, wenn Erst-Ueberschreitung und
+    Spitze im selben Fenster auseinanderfallen -- der meteorologische
+    Normalfall eines ueber den Nachmittag eskalierenden Gewitters. Wer nur
+    die erste Gruppe liest, unterschlaegt genau die Stufe, vor der der
+    Report warnen soll. Der Peak-Zusatz ist "" (leer), wenn Erst == Peak.
+    """
+    if not token or token == "-":
+        return None
+    m = _THUNDER_TOKEN_RE.match(token)
+    if not m:
+        return None
+    peak_suffix = f" ({m.group(3)} @{m.group(4)})" if m.group(3) else ""
+    return m.group(1), m.group(2), peak_suffix
+
+
+def resolve_thunder_day_branch(tok: dict, stage: dict) -> str:
+    """Waehlt die Datenquelle fuer das Tages-Gewitterwort (#1671).
+
+    Reine Zweigwahl, KEINE Formatierung -- die drei Aufrufer (compact.py,
+    outlook.py Klartext, narrow.py) stellen das Ergebnis unterschiedlich
+    dar, entscheiden aber identisch. Ersetzt die bis #1671 dreifach fast
+    identisch kopierte if/elif-Kette. Ob der Tages-Token tatsaechlich
+    zerlegbar ist (``_THUNDER_TOKEN_RE``), prueft dieser Helfer NICHT --
+    das bleibt Aufrufer-Sache (siehe render_outlook_plain()/
+    _compact_thunder_field()), damit ein gesetzter, aber unzerlegbarer
+    Token nicht hier verschluckt wird, sondern beim Aufrufer denselben
+    Rueckfall auf "kein Gewitter" durchlaeuft wie im Altcode.
+
+    Returns:
+        "day"   -- tok["thunder_day_token"] traegt einen Wert (!= "-"):
+                   Wort+Uhrzeit aus dem Tagesfenster verwenden.
+        "none"  -- Stundenreihe vorhanden, im Tagesfenster aber leer:
+                   explizites "kein Gewitter" zeigen (_THUNDER_MAP["NONE"]).
+        "plain" -- keine Stundenreihe (Alt-Aufrufer/Compare): auf das
+                   ungefilterte 24h-Aggregat (tok["thunder_plain"]) zurueckfallen.
+    """
+    if tok.get("thunder_day_token", "-") != "-":
+        return "day"
+    if stage.get("hourly_thunder"):
+        return "none"
+    return "plain"

--- a/src/output/renderers/narrow.py
+++ b/src/output/renderers/narrow.py
@@ -35,6 +35,7 @@ from output.renderers.day_window import (
 )
 from output.metric_format import THUNDER_LABEL_DE
 from output.renderers.email.helpers import _THUNDER_MAP, fmt_val, format_trend_tokens
+from output.renderers.email.thunder_branch import resolve_thunder_day_branch
 from output.renderers.email.unavailable_hint import (
     any_official_alerts_unavailable,
     render_official_alerts_unavailable_plain,
@@ -587,7 +588,10 @@ def _outlook_lines(multi_day_trend: list[dict]) -> list[str]:
         # hoch@0" -- ein Tagesgewitter, das es im Tagesfenster nicht gab.
         dt = tok.get("thunder_day_token", "-")
         nt = tok.get("thunder_night_token", "-")
-        if dt != "-":
+        # Issue #1671: Zweigwahl aus dem geteilten Helfer (identisch zu
+        # compact.py/outlook.py) -- die Formatierung bleibt hier unveraendert.
+        branch = resolve_thunder_day_branch(tok, stage)
+        if branch == "day":
             thunder_part = f"⚡{dt}"
             # Issue #1680 S5a: die tragende Zutat hinter der Tagesstufe --
             # derselbe Token wie in HTML- und Klartext-Mail (AC-3). Ein
@@ -595,7 +599,7 @@ def _outlook_lines(multi_day_trend: list[dict]) -> list[str]:
             _origin = tok.get("thunder_day_origin")
             if _origin:
                 thunder_part += f" · {_origin}"
-        elif stage.get("hourly_thunder"):
+        elif branch == "none":
             thunder_part = _THUNDER_MAP["NONE"]["plain"]
         else:
             thunder_part = tok["thunder_plain"]

--- a/tests/tdd/test_kompaktmail_ausblick_tagesfenster.py
+++ b/tests/tdd/test_kompaktmail_ausblick_tagesfenster.py
@@ -273,6 +273,78 @@ def test_kein_gewitter_tag_und_nacht_zeigt_explizites_none():
 
 
 # ---------------------------------------------------------------------------
+# Adversary-Nachbesserung F002 (Blocker): Peak-Zusatz einer Eskalation
+# innerhalb des Tagesfensters ist unbewacht -- Mutation `_d[2]` entfernen
+# blieb bei 582 Bestandstests gruen, weil keine Fixture eine Eskalation im
+# Tagesfenster nutzte.
+# ---------------------------------------------------------------------------
+
+def test_tagesgewitter_eskalation_zeigt_spitzenstufe_im_kompaktformat():
+    """F002: Given eine Etappe mit einer Gewitter-Eskalation INNERHALB des
+    Tagesfensters (Erst-Ueberschreitung 'leicht' um 5 Uhr, Spitze 'hoch' um
+    15 Uhr -- Vorbild ``test_outlook_day_night_thunder_split.py::
+    TestEscalationWithinWindowShowsPeak``, derselbe meteorologische
+    Normalfall wie #1653 F005) / When die Kurzformat-Mail gerendert wird /
+    Then zeigt die zugestellte, ASCII-gefaltete Ausblick-Zeile sowohl die
+    Erst-Stufe 'leicht' als auch den Peak-Zusatz '(hoch @15)' -- nicht nur
+    die erste, schwaechere Stufe.
+
+    Ohne diese Pruefung liest die Zeile zwar bereits ``thunder_day_token``
+    (AC-1), unterschlaegt aber stillschweigend die staerkere Spitzenstufe,
+    vor der gewarnt werden soll (Adversary-Finding F002).
+    """
+    zeile = _stage(hourly_thunder=(_hv(5, 1.0), _hv(15, 3.0)), thunder="NONE")
+    bericht = _mail([zeile], report_config=_KOMPAKT)
+    ausblick = _kompakt_ausblick_zeile(bericht.email_plain)
+    assert ausblick.endswith("Tleicht (hoch @15)"), (
+        f"Die Kompakt-Ausblick-Zeile muss die Erst-Stufe 'leicht' UND den "
+        f"Peak-Zusatz '(hoch @15)' zeigen -- die Eskalation innerhalb des "
+        f"Tagesfensters darf nicht auf die schwaechere Erst-Stufe "
+        f"zusammenschrumpfen: {ausblick!r}")
+
+
+# ---------------------------------------------------------------------------
+# Adversary-Nachbesserung F001: ein gesetzter, aber unzerlegbarer
+# Tages-Token darf nicht abstuerzen, sondern muss auf "kein Gewitter"
+# zurueckfallen (Guard aus der Nachbesserung waehrend der Implementierung,
+# bislang ohne injizierten Testfall).
+# ---------------------------------------------------------------------------
+
+def test_unzerlegbarer_tagestoken_faellt_auf_kein_gewitter_zurueck():
+    """F001: Given eine Tagesstunde mit einem Gewitter-Rohwert (4.0), der in
+    KEINEM Eintrag von ``_TREND_THUNDER_LABELS`` (nur 1/2/3) vorkommt / When
+    die Kurzformat-Mail gerendert wird / Then wird ``thunder_day_token``
+    zwar gesetzt (``"-@5"``, denn ``render_threshold_peak_value`` liefert
+    fuer eine unbekannte Stufe das Label '-'), ist aber fuer
+    ``_thunder_token_parts()`` NICHT zerlegbar (der Regex verlangt ein
+    Buchstaben-Wort vor dem '@'). Die Zeile faellt auf das explizite
+    'kein Gewitter'-Zeichen zurueck, statt mit ``TypeError:
+    'NoneType' object is not subscriptable`` abzustuerzen.
+
+    Belegt die Invariante, auf der der ``branch == "day"``-Guard aus
+    ``_compact_thunder_field()`` beruht, mit einem echten injizierten Fall
+    (Adversary-Finding F001) -- vorher war die Absicherung nur durch
+    Codeanalyse, nicht durch einen Test verifiziert.
+
+    Bewusst mit Aggregat 'HIGH' (statt 'NONE', analog AC-4): faellt der
+    unzerlegbare Zweig faelschlich auf ``tok["thunder_plain"]`` zurueck
+    (die Mutation, die dieser Test fangen muss), zeigt die Zeile 'THIGH'
+    statt 'T-' -- mit Aggregat 'NONE' waeren beide Rueckfaelle zufaellig
+    identisch und die Mutation bliebe ungefangen.
+    """
+    zeile = _stage(hourly_thunder=(_hv(5, 4.0),), thunder="HIGH")
+    bericht = _mail([zeile], report_config=_KOMPAKT)
+    ausblick = _kompakt_ausblick_zeile(bericht.email_plain)
+    assert ausblick.endswith("T-"), (
+        f"Ein gesetzter, aber unzerlegbarer Tages-Token muss auf das "
+        f"explizite 'kein Gewitter'-Zeichen 'T-' zurueckfallen (nicht "
+        f"abstuerzen und nicht das Aggregat 'HIGH' zeigen): {ausblick!r}")
+    assert "HIGH" not in ausblick, (
+        f"Das Aggregat 'HIGH' darf im Rueckfall nicht durchsickern: "
+        f"{ausblick!r}")
+
+
+# ---------------------------------------------------------------------------
 # AC-5: Bestandsschutz -- Alt-Fixture ohne Stundenreihe bleibt unveraendert
 # ---------------------------------------------------------------------------
 

--- a/tests/tdd/test_kompaktmail_ausblick_tagesfenster.py
+++ b/tests/tdd/test_kompaktmail_ausblick_tagesfenster.py
@@ -1,0 +1,417 @@
+"""TDD RED — Issue #1671: Kurzformat-Mail liest die Gewitterspalte des
+Ausblicks aus dem Tagesfenster statt aus dem 24h-Aggregat.
+
+SPEC: docs/specs/modules/fix_1671_kompaktmail_ausblick_tagesfenster.md
+      (AC-1..AC-7)
+
+RED-Ursache (heute gemessen, `src/output/renderers/email/compact.py:227-238`):
+die Ausblick-Schleife der Kurzformat-Mail liest ausschliesslich
+``tok['thunder_plain']`` -- das auf die Gehzeit geklemmte 24h-Aggregat
+(``stage["thunder"]``, unabhaengig von der Stundenreihe berechnet). HTML-
+Ausblick-Tabelle, Klartext-Mail-Ausblick und Telegram-Trendblock wurden
+bereits mit #1653 auf ``thunder_day_token``/``thunder_night_token`` (die nach
+Tagesfenster gefilterte Stundenreihe) umgestellt -- die Kurzformat-Mail ist
+der vierte, damals vergessene Ausgabeort.
+
+PRUEFORT = WIRKORT. Jeder Test rendert ueber die ECHTE Renderkette bis zur
+zugestellten Zeile: ``TripReportFormatter.format_email()`` mit
+``TripReportConfig(email_format="compact")`` liefert ``.email_plain`` -- den
+ASCII-gefalteten Kompakt-Mailkoerper, wie er tatsaechlich verschickt wird.
+Keine Pruefung endet an ``_compact_thunder_field()`` oder
+``format_trend_tokens()`` isoliert.
+
+KEIN MOCK-THEATER. ``Mock``/``patch``/``MagicMock`` nirgends. Fuer AC-1..AC-4
+wird das Ausblick-Zeilen-Dict wie ``build_outlook_row()`` es in Produktion
+liefert direkt gebaut (Muster ``tests/tdd/test_outlook_day_night_thunder_split.py::_stage``,
+das #1653 -- den unmittelbaren Vorgaenger dieses Fixes -- bereits fuer exakt
+dieselbe Fehlerklasse in den drei anderen Kanaelen bewacht): Aggregat
+(``thunder``) und Stundenreihe (``hourly_thunder``) sind in der Produktion
+ZWEI GETRENNTE Rechnungen (``build_outlook_row()``: ``thunder`` aus
+``summary.thunder_level_max``, ``hourly_thunder`` aus der flachen
+Punktliste) -- ein Stage-Dict mit unabhaengig gesetzten Werten deckt genau
+diese reale Fehlerklasse ab, es ist keine gemockte Fusion, sondern das
+dokumentierte Eingabeformat von ``format_trend_tokens()``. Fuer die
+AC-6-Gegenprobe wird die ECHTE Traeger-Fusion verwendet (wie
+``tests/tdd/test_thunder_origin_outlook.py``), weil dort eine Herkunft
+NACHWEISLICH entstehen muss, nicht nur behauptet werden darf.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import date, datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+# Pfadregel #1409: Pruefling relativ zur EIGENEN Testdatei aufloesen, nie ueber
+# den festen Hauptrepo-Pfad -- sonst pruefte dieser Test aus dem Worktree die
+# unveraenderte Hauptrepo-Kopie und meldete falsches Gruen.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from bs4 import BeautifulSoup  # noqa: E402
+
+from app.metric_catalog import build_default_display_config  # noqa: E402
+from app.model_registry import (  # noqa: E402
+    cape_ladder_thresholds_jkg, lpi_thresholds_jkg,
+)
+from app.models import (  # noqa: E402
+    ForecastDataPoint, ForecastMeta, GPXPoint, NormalizedTimeseries, Provider,
+    SegmentWeatherData, TripReportConfig, TripSegment,
+)
+from output.renderers.email.outlook import build_outlook_row  # noqa: E402
+from output.renderers.trip_report import TripReportFormatter  # noqa: E402
+from output.tokens.dto import HourlyValue  # noqa: E402
+from providers.thunder_enrichment import _fuse_thunder_levels  # noqa: E402
+from providers.thunder_routing import thunder_region_for  # noqa: E402
+from services.weather_metrics import (  # noqa: E402
+    WeatherMetricsService, summarize_points,
+)
+
+_TZ = ZoneInfo("UTC")
+_HEUTE = date(2026, 8, 20)      # Etappe des Briefings (heutiger Tag)
+_MORGEN = date(2026, 8, 21)     # kuenftige Etappe = Ausblick-Zeile
+_WOCHENTAG = "Di"
+_AUSBLICK_UEBERSCHRIFT = "Naechste Etappen"
+_KOMPAKT = TripReportConfig(email_format="compact")
+
+# Die VIER Zutaten der Fusion in ihrer deutschen Beschriftung (AC-6). Keine
+# davon darf im Kompakt-Ausblick auftauchen -- PO-Entscheidung 1 der Spec.
+_ALLE_ZUTATEN = ("Wettercode", "Blitzdichte", "CAPE", "Blitzpotenzial")
+
+
+# ---------------------------------------------------------------------------
+# Fixture-Bausteine
+# ---------------------------------------------------------------------------
+
+def _hv(hour: int, value: float) -> HourlyValue:
+    return HourlyValue(hour=hour, value=value)
+
+
+def _stage(*, weekday: str = "Di", name: str = "Etappe B", temp_lo=9, temp_hi=21,
+           precip_mm=2.5, wind_dir="W", wind_kmh=18, thunder="NONE",
+           hourly_thunder=None, day_window_start_hour=None,
+           day_window_end_hour=None) -> dict:
+    """Ausblick-Zeile mit UNABHAENGIG gesetztem Aggregat (``thunder``) und
+    Stundenreihe (``hourly_thunder``) -- exakt die Faelle, die #1653 fuer
+    HTML/Klartext/Telegram bereits geprueft hat. Kein Python-``None`` als
+    Traeger einer Stufe: die Werte sind das dokumentierte Eingabeformat von
+    ``format_trend_tokens()``, keine gemockte Fusion.
+    """
+    row = dict(
+        weekday=weekday, name=name, note=None,
+        temp_lo=temp_lo, temp_hi=temp_hi, precip_mm=precip_mm,
+        wind_dir=wind_dir, wind_kmh=wind_kmh, thunder=thunder,
+        hourly_precip=(), hourly_wind=(), hourly_gust=(),
+        hourly_thunder=hourly_thunder or (),
+    )
+    if day_window_start_hour is not None:
+        row["day_window_start_hour"] = day_window_start_hour
+    if day_window_end_hour is not None:
+        row["day_window_end_hour"] = day_window_end_hour
+    return row
+
+
+def _heutige_etappe() -> SegmentWeatherData:
+    """Die HEUTIGE Etappe des Briefings -- gewitterfrei, dient nur als
+    Pflicht-Segment fuer ``TripReportFormatter.format_email()``. Ihr Inhalt
+    ist fuer keinen AC dieser Datei von Belang, nur der Ausblick-Block ist
+    der Pruefling."""
+    punkte = [
+        ForecastDataPoint(
+            ts=datetime(_HEUTE.year, _HEUTE.month, _HEUTE.day, h, 0, tzinfo=timezone.utc),
+            t2m_c=18.0, wind10m_kmh=10.0, gust_kmh=20.0, precip_1h_mm=0.2,
+            cloud_total_pct=40, humidity_pct=50, pop_pct=30,
+        )
+        for h in range(6, 18)
+    ]
+    reihe = NormalizedTimeseries(
+        meta=ForecastMeta(provider=Provider.OPENMETEO, model="test", grid_res_km=1.0),
+        data=punkte,
+    )
+    seg = TripSegment(
+        segment_id=1,
+        start_point=GPXPoint(lat=47.0, lon=12.0, elevation_m=1000.0),
+        end_point=GPXPoint(lat=47.1, lon=12.1, elevation_m=1200.0),
+        start_time=datetime(_HEUTE.year, _HEUTE.month, _HEUTE.day, 6, 0, tzinfo=timezone.utc),
+        end_time=datetime(_HEUTE.year, _HEUTE.month, _HEUTE.day, 17, 0, tzinfo=timezone.utc),
+        duration_hours=11.0, distance_km=10.0, ascent_m=500.0, descent_m=200.0,
+    )
+    return SegmentWeatherData(
+        segment=seg, timeseries=reihe,
+        aggregated=WeatherMetricsService().compute_basis_metrics(reihe),
+        fetched_at=datetime.now(timezone.utc), provider="openmeteo",
+    )
+
+
+def _mail(zeilen: list[dict], *, report_config: TripReportConfig | None = None):
+    """Das ECHTE Trip-Briefing ueber den produktiven Formatierer -- Pruefort
+    = Wirkort."""
+    return TripReportFormatter().format_email(
+        [_heutige_etappe()], "Test-Trip", "evening",
+        display_config=build_default_display_config(), tz=_TZ,
+        stage_name="Etappe A", multi_day_trend=zeilen,
+        report_config=report_config,
+    )
+
+
+def _ohne_zeitstempel(text: str) -> str:
+    """Blendet die einzige laufzeitabhaengige Zeile der Kompakt-Mail aus."""
+    return "\n".join(
+        ln for ln in text.splitlines() if not ln.startswith("Generated:")
+    )
+
+
+def _kompakt_ausblick_zeile(text: str, ueberschrift: str = _AUSBLICK_UEBERSCHRIFT) -> str:
+    """Die EINE Ausblick-Zeile aus dem zugestellten Kompakt-Mailkoerper."""
+    assert ueberschrift in text, (
+        f"Kompakt-Ausblick '{ueberschrift}' fehlt in der Mail:\n{text}")
+    rest = text.split(ueberschrift, 1)[1].splitlines()
+    zeilen = []
+    for ln in rest:
+        if not ln.strip():
+            if zeilen:
+                break
+            continue
+        zeilen.append(ln)
+    assert len(zeilen) == 1, (
+        f"Erwartet genau EINE Ausblick-Zeile unter '{ueberschrift}', "
+        f"gefunden: {zeilen!r}")
+    return zeilen[0]
+
+
+# ---------------------------------------------------------------------------
+# AC-1 bis AC-4: die vier Verzweigungen von resolve_thunder_day_branch()
+# ---------------------------------------------------------------------------
+
+def test_tagesgewitter_erscheint_trotz_leerem_24h_aggregat():
+    """AC-1: Given eine Etappe mit Tagesgewitter 'leicht' um 16 Uhr innerhalb
+    des Tagesfensters, waehrend das 24h-Aggregat 'NONE' zeigt (Aggregat und
+    Tagesfenster widersprechen sich) / When die Kurzformat-Mail gerendert
+    wird / Then zeigt die Ausblick-Zeile das Tagesgewitter 'leicht' -- nicht
+    das leere Aggregat.
+
+    Heute (RED): die Zeile liest ``tok['thunder_plain']`` == ``_THUNDER_MAP
+    ["NONE"]["plain"]`` == '⚡–' -> ASCII 'T-'. Das Tagesgewitter aus der
+    Stundenreihe (hour=16, LOW) verschwindet vollstaendig.
+    """
+    zeile = _stage(hourly_thunder=(_hv(16, 1.0),), thunder="NONE")
+    bericht = _mail([zeile], report_config=_KOMPAKT)
+    ausblick = _kompakt_ausblick_zeile(bericht.email_plain)
+    assert ausblick.endswith("Tleicht"), (
+        f"Die Kompakt-Ausblick-Zeile muss auf das Tagesgewitter 'leicht' "
+        f"(ASCII-gefaltet 'Tleicht') enden, nicht auf das leere 24h-Aggregat: "
+        f"{ausblick!r}")
+
+
+def test_kein_tagesgewitter_trotz_aggregat_high():
+    """AC-2: Given dieselbe Konstellation umgekehrt -- 24h-Aggregat 'HIGH',
+    Tagesfenster leer, das Gewitterereignis (hoch, 2 Uhr) liegt vollstaendig
+    in der Nacht / When die Kurzformat-Mail gerendert wird / Then zeigt der
+    Tagesteil explizit 'kein Gewitter' (ASCII-gefaltet 'T-'), nicht das
+    faelschlich uebernommene Aggregat 'HIGH'; der Nachtteil zeigt das echte
+    Nachtgewitter mit Uhrzeit.
+
+    Heute (RED): die Zeile liest ``tok['thunder_plain']`` == ``_THUNDER_MAP
+    ["HIGH"]["plain"]`` == '⚡HIGH' -> ASCII 'THIGH', ohne jeden Nachtzusatz
+    (den es im Kompaktformat vor dieser Scheibe strukturell nie gab).
+    """
+    zeile = _stage(hourly_thunder=(_hv(2, 3.0),), thunder="HIGH")
+    bericht = _mail([zeile], report_config=_KOMPAKT)
+    ausblick = _kompakt_ausblick_zeile(bericht.email_plain)
+    assert ausblick.endswith("T- - nachts hoch @2"), (
+        f"Der Tagesteil muss explizit 'kein Gewitter' zeigen (nicht das "
+        f"Aggregat 'HIGH'), gefolgt vom echten Nachtgewitter mit Uhrzeit: "
+        f"{ausblick!r}")
+    assert "HIGH" not in ausblick, (
+        f"Das faelschlich uebernommene Aggregat 'HIGH' darf in der Zeile "
+        f"nicht mehr auftauchen: {ausblick!r}")
+
+
+def test_nachtgewitter_erscheint_mit_uhrzeit_im_kompaktformat():
+    """AC-3: Given eine Etappe mit Tagesgewitter 'mittel' 14 Uhr UND
+    Nachtgewitter 'hoch' 0 Uhr (Fall B aus #1653) / When die Kurzformat-Mail
+    gerendert wird / Then enthaelt die zugestellte, ASCII-gefaltete Zeile
+    sowohl den Tagesteil als auch einen Nachtzusatz der exakten Form
+    '- nachts hoch @0' (Bindestrich statt '·' nach der Faltung) -- eine
+    Nachtangabe, die im Kompaktformat vor dieser Scheibe strukturell nie
+    erschien.
+
+    Exakte Wortlaut-Pruefung (kein loses ``in``-'nachts'): faengt Mutation
+    (e) der Spec (entferntes Leerzeichen vor '@').
+    """
+    zeile = _stage(hourly_thunder=(_hv(14, 2.0), _hv(0, 3.0)), thunder="MED")
+    bericht = _mail([zeile], report_config=_KOMPAKT)
+    ausblick = _kompakt_ausblick_zeile(bericht.email_plain)
+    assert ausblick.endswith("Tmittel - nachts hoch @0"), (
+        f"Tagesteil 'Tmittel' und Nachtzusatz '- nachts hoch @0' (mit "
+        f"Leerzeichen vor '@') muessen exakt so am Ende der Zeile stehen: "
+        f"{ausblick!r}")
+
+
+def test_kein_gewitter_tag_und_nacht_zeigt_explizites_none():
+    """AC-4: Given eine Etappe ganz ohne Gewitter (Tag- und Nachtstunde mit
+    Wert 0.0, Stundenreihe vorhanden, Aggregat behauptet dagegen 'HIGH') /
+    When die Kurzformat-Mail gerendert wird / Then zeigt die Zeile das
+    explizite 'kein Gewitter'-Zeichen ('T-') ohne Nachtzusatz -- kein leerer
+    oder abweichender Ausdruck, und das falsche Aggregat 'HIGH' wird
+    ignoriert.
+
+    Bewusst mit Aggregat 'HIGH' (statt 'NONE'), damit der Test nicht
+    zufaellig schon am unveraenderten ``tok['thunder_plain']`` gruen waere --
+    nur wenn die Stundenreihe (nicht das Aggregat) den Ausschlag gibt, zeigt
+    die Zeile 'T-' statt 'THIGH'.
+    """
+    zeile = _stage(hourly_thunder=(_hv(10, 0.0), _hv(22, 0.0)), thunder="HIGH")
+    bericht = _mail([zeile], report_config=_KOMPAKT)
+    ausblick = _kompakt_ausblick_zeile(bericht.email_plain)
+    assert ausblick.endswith("T-"), (
+        f"Ohne Gewitter in Tag- und Nachtfenster muss die Zeile explizit "
+        f"'T-' zeigen (nicht das Aggregat 'HIGH'): {ausblick!r}")
+    assert "nachts" not in ausblick, (
+        f"Ohne Nachtgewitter darf kein Nachtzusatz erscheinen: {ausblick!r}")
+    assert "HIGH" not in ausblick, (
+        f"Das falsche Aggregat 'HIGH' darf nicht durchsickern: {ausblick!r}")
+
+
+# ---------------------------------------------------------------------------
+# AC-5: Bestandsschutz -- Alt-Fixture ohne Stundenreihe bleibt unveraendert
+# ---------------------------------------------------------------------------
+
+# Aufgezeichnet VOR jeder Implementierung dieser Scheibe, am Stand
+# `71dd8a2d45d9edd914c6b8209f85e9ebd050a668` (== HEAD dieses Branches beim
+# Schreiben dieses Tests, 2026-08-14), durch einen echten Renderlauf von
+# ``_mail([_AC5_ALT_ZEILE], report_config=_KOMPAKT).email_plain`` durch
+# ``_kompakt_ausblick_zeile()`` -- KEIN zweiter Aufruf desselben Codes zur
+# Testlaufzeit (Spec AC-5, Begruendung woertlich aus
+# tests/tdd/test_trip_outlook_parity.py).
+_AC5_ALT_ZEILE_SOLL = "Mi  Alte Etappe                9-21C   1.5mm NW22  TMED"
+
+_AC5_ALT_ZEILE = dict(
+    weekday="Mi", name="Alte Etappe", note=None,
+    temp_lo=9, temp_hi=21, precip_mm=1.5,
+    wind_dir="NW", wind_kmh=22, thunder="MED",
+    # Bewusst OHNE "hourly_thunder"-Schluessel -- der echte Alt-Aufrufer-Fall
+    # (Spec AC-5: "hourly_thunder fehlt"), nicht nur eine leere Stundenreihe.
+)
+
+
+def test_ohne_stundenreihe_bleibt_kurzformat_unveraendert():
+    """AC-5: Given eine Ausblick-Zeile ganz OHNE Stundenreihe (Alt-Fixture,
+    Schluessel 'hourly_thunder' fehlt) / When die Kurzformat-Mail gerendert
+    wird / Then bleibt die Ausgabe zeichengleich zum Stand vor dieser
+    Aenderung (Rueckfall auf ``thunder_plain``, Zweig 'plain').
+
+    Bestandsschutz -- dieser Test ist bereits JETZT gruen, vor jeder
+    Implementierung: ohne Stundenreihe greift ``resolve_thunder_day_branch()``
+    laut Spec unveraendert auf ``tok['thunder_plain']`` zurueck, denselben
+    Wert, den der heutige (ungeaenderte) Code bereits liefert. Er MUSS nach
+    der Implementierung gruen BLEIBEN -- ein rot werdender Lauf hier heisst,
+    dass sich das Alt-Verhalten veraendert hat.
+    """
+    bericht = _mail([_AC5_ALT_ZEILE], report_config=_KOMPAKT)
+    ausblick = _kompakt_ausblick_zeile(bericht.email_plain)
+    assert ausblick == _AC5_ALT_ZEILE_SOLL, (
+        f"Ohne Stundenreihe darf sich die Kompakt-Ausblick-Zeile NICHT "
+        f"aendern.\nSoll (aufgezeichnet vor der Implementierung):\n"
+        f"{_AC5_ALT_ZEILE_SOLL!r}\nIst:\n{ausblick!r}")
+
+
+# ---------------------------------------------------------------------------
+# AC-6-Gegenprobe: Kurzformat-Mail bleibt ohne Herkunfts-Zusatz
+# ---------------------------------------------------------------------------
+# AC-6 selbst ist der bestehende Bestandswaechter
+# tests/tdd/test_thunder_origin_outlook.py::test_ac13_kompaktmail_bleibt_zeichengleich
+# (wird hier NICHT neu geschrieben). Testplan-Zeile AC-6 verlangt zusaetzlich
+# eine Gegenprobe mit einer Fixture, die im HTML-/Klartext-Pfad NACHWEISLICH
+# eine Herkunft erzeugen WUERDE -- sonst waere eine reine Abwesenheitspruefung
+# vakuum-gruen.
+
+_LAT, _LON, _MODELL = 47.0, 12.0, "icon_d2"   # Gebiet DE_ALPEN
+
+
+def _dp_mit_traeger(h: int, *, cape=None, cin=None) -> ForecastDataPoint:
+    """Ein Stundenpunkt mit ROHWERTEN -- Stufe und Traeger rechnet die
+    ECHTE Fusion (wie tests/tdd/test_thunder_origin_outlook.py::_dp)."""
+    return ForecastDataPoint(
+        ts=datetime(_MORGEN.year, _MORGEN.month, _MORGEN.day, h, 0, tzinfo=timezone.utc),
+        t2m_c=18.0, wind10m_kmh=10.0, gust_kmh=20.0, precip_1h_mm=0.2,
+        cloud_total_pct=40, humidity_pct=50, pop_pct=30,
+        cape_jkg=cape, convective_inhibition_jkg=cin,
+    )
+
+
+def _mit_herkunft_ausblick_zeile() -> dict:
+    """Eine Ausblick-Zeile MIT echter Traeger-Berechnung (#1680 S5a): CAPE
+    400 J/kg bei schwachem Deckel (cin=5) liegt ueber der niedrigsten Sprosse
+    (300 J/kg) und ergibt ueber die echte Fusion 'leicht' mit der Zutat
+    CAPE als einzigem Traeger -- dieselbe Fixture-Bauart wie
+    tests/tdd/test_thunder_origin_outlook.py::test_ac1_..., kein getippter
+    Stufenwert."""
+    punkte = [_dp_mit_traeger(16, cape=400.0, cin=5.0)]
+    region = thunder_region_for(_LAT, _LON)
+    _fuse_thunder_levels(
+        punkte, cape_ladder_thresholds_jkg(_MODELL, region),
+        lpi_thresholds_jkg(region),
+    )
+    zeile = build_outlook_row(summarize_points(punkte), punkte, _WOCHENTAG, _TZ)
+    zeile["name"] = "Etappe B"
+    return zeile
+
+
+def _gew_zelle(html: str, kopf: str = "Gew") -> str:
+    """Der Text der Gewitter-Zelle der Ausblick-Tabelle aus fertigem
+    Mail-HTML (Muster tests/tdd/test_thunder_origin_outlook.py::_gew_zelle)."""
+    suppe = BeautifulSoup(html, "html.parser")
+    tabellen = [
+        t for t in suppe.find_all("table")
+        if {"Tag", kopf} <= {th.get_text(strip=True) for th in t.find_all("th")}
+    ]
+    assert len(tabellen) == 1, (
+        f"Erwartet genau EINE Ausblick-Tabelle mit den Kopfzellen 'Tag' und "
+        f"{kopf!r}, gefunden: {len(tabellen)}")
+    tabelle = tabellen[0]
+    spalte = [th.get_text(strip=True) for th in tabelle.find_all("th")].index(kopf)
+    zeilen = tabelle.find("tbody").find_all("tr")
+    assert len(zeilen) == 1, (
+        f"Erwartet genau EINE Ausblick-Datenzeile, gefunden: {len(zeilen)}")
+    return [td.get_text(strip=True) for td in zeilen[0].find_all("td")][spalte]
+
+
+def test_kompaktmail_ohne_herkunfts_zusatz():
+    """AC-6-Gegenprobe (Testplan-Zeile AC-6): Given dieselbe Fixture, die im
+    HTML-Ausblick der Vollmail NACHWEISLICH die Herkunft 'CAPE' zeigt
+    (#1680 S5a) / When dieselbe Ausblick-Zeile in der Kurzformat-Mail
+    gerendert wird / Then enthaelt die zugestellte Zeile KEINE der vier
+    Zutat-Bezeichnungen -- ``resolve_thunder_day_branch()``/
+    ``_compact_thunder_field()`` lesen ``thunder_day_origin`` laut Spec
+    (PO-Entscheidung 1) nie.
+
+    Gegenprobe zuerst: ohne den Beleg, dass dieselbe Fixture im HTML-Pfad
+    eine Herkunft zeigt, waere die Abwesenheitspruefung im Kompaktformat
+    vakuum-gruen (sie waere auch gruen, wenn CAPE nirgends berechnet
+    wuerde).
+
+    GEMESSEN: dieser Test ist bereits VOR jeder Implementierung gruen (am
+    Stand `71dd8a2d`) -- strukturell erklaerbar, nicht vakuum-gruen: die
+    heutige (ungeaenderte) Ausblick-Schleife in ``compact.py`` liest
+    ausschliesslich ``tok['thunder_plain']`` und ruft nie einen Code-Pfad
+    auf, der ``thunder_day_origin`` anhaengt -- weder vor noch nach dieser
+    Scheibe. Die Gegenprobe selbst (HTML zeigt 'CAPE') beweist, dass an
+    dieser Fixture ueberhaupt eine Herkunft entstuende, also ist die
+    Abwesenheitspruefung nicht vakuum-gruen. Absichern gegen Mutation (c)
+    der Spec (Herkunft an den 'day'-Zweig von ``_compact_thunder_field()``
+    anhaengen) leistet dieser Test erst NACH der Implementierung -- vorher
+    existiert der Zweig noch nicht, den die Mutation treffen wuerde.
+    """
+    zeile = _mit_herkunft_ausblick_zeile()
+
+    voll = _gew_zelle(_mail([zeile]).email_html)
+    assert voll == "leicht @16 · CAPE", (
+        f"Gegenprobe gescheitert: die Vollmail-HTML MUSS die Herkunft 'CAPE' "
+        f"zeigen, sonst beweist die Kompakt-Pruefung nichts: {voll!r}")
+
+    kompakt_bericht = _mail([zeile], report_config=_KOMPAKT)
+    kompakt_ausblick = _kompakt_ausblick_zeile(kompakt_bericht.email_plain)
+    for zutat in _ALLE_ZUTATEN:
+        assert zutat not in kompakt_ausblick, (
+            f"Die Kurzformat-Mail darf keine Zutat {zutat!r} zeigen: "
+            f"{kompakt_ausblick!r}")


### PR DESCRIPTION
Behebt #1671 — der Issue wird erst nach bestandenem Post-Deploy-Selftest geschlossen, bewusst kein `Closes`-Schlüsselwort.

## Was war kaputt

Der Ausblick-Block „Naechste Etappen" der **Kurzformat-Mail** (`X-GZ-Format: compact`) baute sein Gewitter-Tageswort aus `tok['thunder_plain']` — dem auf die Gehzeit geklemmten 24h-Aggregat. HTML-Tabelle, Klartext-Mail und Telegram wurden mit #1653 auf `thunder_day_token`/`thunder_night_token` umgestellt; die Kurzformat-Mail war der **vierte, vergessene Ausgabeort**. Ein reales Tagesgewitter konnte dort verschwinden, ein nicht vorhandenes behauptet werden — und eine Nachtangabe gab es dort strukturell nie.

Die Klasse wurde vollständig ausgezählt: SMS/Premium-SMS erreichen den Ausblick baulich nicht, der Compare-Ausblick teilt sich den `outlook.py`-Baustein.

## Was sich ändert

- **`thunder_branch.py` (neu):** `resolve_thunder_day_branch()` — die bis dahin dreifach kopierte Zweigwahl (`day`/`none`/`plain`) liegt jetzt einmal da und wird von `compact.py`, `outlook.py` (Klartext) und `narrow.py` benutzt. Die **Formatierung** bleibt je Kanal. `_thunder_token_parts()` ist mitgezogen.
- **`compact.py`:** Tagesteil aus dem Tagesfenster (ohne Uhrzeit, wie die Klartext-Mail), neuer Nachtzusatz mit Uhrzeit. Nach ASCII-Faltung z. B. `Tmittel - nachts hoch @0`.

**Abweichung von der Spec, bewusst:** Der Helfer sollte laut Spec in `helpers.py`. Die Datei war durch eine parallele Session belegt; kein AC ist vom Zielort berührt. Begründung in der Spec unter „Zielort geändert". Nebeneffekt: `helpers.py` bleibt unangetastet, der zusätzliche Compare-Mail-Nachweis entfällt.

## Nicht in dieser Scheibe

- Herkunfts-Zusatz im Kompaktformat — **AC-13 aus #1680 S5a bleibt in Kraft**, sein Wächter bleibt grün.
- HTML-Ausblick-Zelle — strukturell andere Zweigwahl (leere Zelle statt „kein Gewitter"-Wort), bereits korrekt.
- Metrik-Zweig des Trip-Ausblicks — **eigener Befund, #1841**: seit #1720 S1 umgeht dieser Pfad die Tag/Nacht-Auflösung komplett.

## Nachweise

- **123 Tests grün**, darunter `test_trip_outlook_parity.py` (Byte-Parität von HTML- und Klartext-Ausblick der Trip-Mail, Golden-Dateien unangetastet) und `test_ac13_kompaktmail_bleibt_zeichengleich`.
- **Adversary, 2 Runden:** Runde 1 **BROKEN** — der Peak-Zusatz bei Gewitter-Eskalation im Tagesfenster war völlig unbewacht (582 Tests blieben grün, als er entfernt wurde). Zwei Tests ergänzt, Runde 2 **VERIFIED**. 8+ Mutationen gefahren, jede gefangen; eine Vakuum-Grün-Falle beim zweiten Test empirisch ausgeschlossen.
- **Mail-Gate:** Mode-Matrix-Test grün + `briefing_mail_validator.py` Exit 0 gegen eine **echt zugestellte** Kurzformat-Mail (`X-GZ-Format: compact` am Test-Postfach verifiziert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKtVZP7cxKT9z8VPbkHTwQ