### PR TITLE
docs(#1594): ADR-0021 um die zweite Freigabe-Funktion nachtragen

### DIFF
--- a/docs/adr/0021-shared-deviation-alert-engine.md
+++ b/docs/adr/0021-shared-deviation-alert-engine.md
@@ -132,3 +132,33 @@ dieser Scheibe (Scheibe 2, #1169).
   mit, und ein Alarmversuch ohne erreichbaren Kanal hinterlässt jetzt einen
   Protokoll-Eintrag statt spurlos abzubrechen. Details:
   `docs/specs/modules/fix_1752_radar_folgt_alarm_kanaelen.md`.
+- **Nachtrag (Issue #1594, 2026-08-14):** `services/alert_gate.py` beherbergt seit
+  dieser Scheibe **zwei voneinander unabhängige Funktionen**, nicht mehr nur die
+  eine Kette. Die im #1467-S3-Nachtrag beschriebene Reihenfolge
+  Ruhezeit → Sperrzeit → Tages-Obergrenze (`check_nowcast_gate()`) gilt
+  unverändert und **ausschließlich für NowCast**. Daneben steht neu
+  `check_briefing_imminent()`: eine rein lesende Stufe, die einen
+  **Änderungsalarm oder eine amtliche Warnung** unterdrückt, wenn für dieselbe
+  Entität innerhalb von 60 Minuten ein geplantes Briefing ansteht, das **noch
+  nicht versucht** wurde. Sie ist an drei Stellen eingehängt
+  (`trip_alert._is_quiet_hours`-Umfeld für beide Trip-Alarmarten,
+  `compare_alert.py`, `compare_official_alert.py`) und wird von
+  `check_nowcast_gate()` **nicht** gerufen — die NowCast-Ausnahme ist damit
+  baulich, nicht durch Sorgfalt an den Aufrufstellen.
+  **Kein neues Architekturprinzip:** die fachliche Zulässigkeit trägt ADR-0009
+  (Alerts sind Δ-Wächter gegen den letzten Briefing-Snapshot) — die Meldung wird
+  durch das folgende Briefing **ersetzt**, nicht ersatzlos verschluckt, weil das
+  Briefing Anker und Melde-Gedächtnis selbst zurücksetzt.
+  Drei benannte Folgen: (1) Die Fälligkeit wird bei den vorhandenen Rechnern
+  **erfragt** (`presets_due_for_hour()` bzw. ein aus `trip_report_scheduler`
+  herausgelöstes reines Prädikat), nicht neu gerechnet — eine eigene
+  Zeitrechnung wäre die vierte Fassung derselben Regel. (2) Das Prädikat trägt
+  bewusst **keinen** `skip_next`-Verbrauch; `_get_active_trips()` schreibt beim
+  Lesen (`save_trip()`) und darf deshalb aus dem 15-Minuten-Alarmtakt nicht
+  gerufen werden. (3) Die Sperre endet mit dem Briefing-**Versuch**, nicht mit
+  dessen Erfolg — `last_briefing_at()` bedeutet „versucht", weil der Anker seit
+  #1629 auch im Fehlerzweig geschrieben wird; eine an den Erfolg gebundene
+  Sperre hätte nach einem gescheiterten Versand bis zu vier Stunden geschwiegen.
+  Eine Unterdrückung durch diese Stufe erzeugt **keinen** Protokolleintrag (Lücke
+  O3 aus dem vorigen Nachtrag bleibt bewusst offen). Details:
+  `docs/specs/modules/fix_1594_alarm_vorlauf_sperre.md`.


### PR DESCRIPTION
Reine Doku-Änderung, kein Code.

ADR-0021 beschreibt im Nachtrag zu #1467 S3 die Freigabe-Steuerung `services/alert_gate.py` als **eine** Kette mit fester Reihenfolge *Ruhezeit → Sperrzeit → Tages-Obergrenze*. Seit #1594 (live `57e36375`) liegen dort **zwei voneinander unabhängige Funktionen**:

- `check_nowcast_gate()` — Kette unverändert, gilt ausschließlich für NowCast
- `check_briefing_imminent()` — neu, unterdrückt Änderungsalarm und amtliche Warnung, wenn innerhalb von 60 Minuten ein noch nicht versuchtes Briefing ansteht

Wer nur den ADR liest, hätte das nicht erfahren. Genau die Drift, die die Projektregel „Entscheidungsflächen vor der Änderung nachsehen" verhindern soll.

**Kein neues ADR** — die fachliche Zulässigkeit trägt ADR-0009 (Alerts als Δ-Wächter gegen den letzten Briefing-Snapshot); die Meldung wird durch das folgende Briefing ersetzt, nicht verschluckt. ADR-0009 bleibt inhaltlich unverändert.

Der Nachtrag hält die drei Folgen fest, die beim Weiterbauen zählen — insbesondere für #1467 S4, das diese Pfade zusammenlegen wird:

1. Die Fälligkeit wird bei den vorhandenen Rechnern **erfragt**, nicht neu gerechnet.
2. Das Prädikat trägt **keinen** `skip_next`-Verbrauch — `_get_active_trips()` schreibt beim Lesen und darf aus dem 15-Minuten-Alarmtakt nicht gerufen werden.
3. Die Sperre endet mit dem **Versuch**, nicht mit dem Erfolg — `last_briefing_at()` bedeutet seit #1629 „versucht".

`tests/test_adr_index_drift.py` grün (2 passed): ein Nachtrag legt keinen neuen ADR-Eintrag an, der Index bleibt unverändert.

Refs #1594, #1467, #1629

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kiKur8ctBrDKtBAxHBWTk