### PR TITLE
fix(#1847): Trip-Briefing protokolliert den E-Mail-Empfaenger

### DIFF
--- a/docs/context/fix-1847-briefing-versand-ohne-zustellung.md
+++ b/docs/context/fix-1847-briefing-versand-ohne-zustellung.md
@@ -1,0 +1,210 @@
+# Context: fix-1847-briefing-versand-ohne-zustellung
+
+Issue: [#1847](https://github.com/henemm/gregor_zwanzig/issues/1847) · Label `bug`, `priority:high`
+Track: Full Process (Intake-Score 5/6)
+
+## Request Summary
+
+`POST /api/trips/<id>/send` antwortet auf Staging mit `{"status":"ok","sent":true}` und
+protokolliert `Trip report sent`, ohne dass eine E-Mail zugestellt wird. Betroffen ist damit
+nicht nur das Feature, sondern der **Nachweisweg** aller Mail-Gates
+(`renderer_mail_gate.py` → `briefing_mail_validator.py` verlangt eine echt zugestellte Mail).
+
+## 🔴 AUFGELÖST (2026-08-15): Die Mail WURDE zugestellt — #1847 ist als Bug ungültig
+
+**Beweis.** Beide vermissten Mails liegen in `gregor-staging@henemm.com`, sekundengenau
+passend zu den Log-Zeilen:
+
+```
+Subject: [E2E 1671 Kompakt-Ausblick] Etappe 1 — Abend    To: gregor-staging@…  14 Aug 19:24:43
+Subject: [E2E 1671 Kompakt-Ausblick] Etappe 1 — Morgen   To: gregor-staging@…  14 Aug 19:41:02
+Log:     Trip report sent … (evening) 19:24:43,090  /  (morning) 19:41:02,918
+```
+
+**Ursache.** `/var/lib/gregor-staging/users/default/user.json` enthält
+`mail_to: "gregor-staging@henemm.com"`, geschrieben am **2026-08-14 16:08**. Die
+Sicherungskopie `user.json.bak-1243` (2026-07-14) hat **kein** `mail_to` — der Schlüssel wurde
+an diesem Tag neu hinzugefügt. `with_user_profile()` übernimmt ihn (`src/app/config.py:385-386`)
+und leitet damit jeden `default`-Versand am Test-Postfach vorbei.
+
+**Warum es niemand sah — der eigentliche Fehler in der Beweisführung.** Die Systemd-Unit setzt
+`Environment=GZ_DATA_DIR=/var/lib/gregor-staging` (Drop-in `1595-datenwurzel.conf`, #1595).
+Der Ordner `/home/hem/gregor_zwanzig_staging/data/`, in dem das Ticket „KEIN `user.json`"
+festgestellt hat, ist **Altbestand und wird vom Dienst nicht gelesen**. Dieselbe Falle hat auch
+meine erste Gegenmessung getroffen: `Settings().with_user_profile('default')` ohne gesetztes
+`GZ_DATA_DIR` liefert `mail_to='gregor-test@henemm.com'` — das misst die stillgelegte
+Datenwurzel, nicht die des Dienstes. **Vor jeder Aussage über Staging-Nutzerdaten:
+`systemctl cat <dienst> | grep GZ_DATA_DIR`.**
+
+**Zeitleiste, die es bestätigt:**
+
+| Zeit (UTC, 14.08.) | Ereignis | Postfach |
+|---|---|---|
+| 16:06:07 | `e2e-1680-s5b-origin` (User `default`) | **gregor-test** ✅ |
+| 16:08 | `user.json` bekommt `mail_to: gregor-staging@` | — |
+| 17:19:12 | `e2e-1801-ampel-check` (User `default`) | **gregor-staging** |
+| 19:24:43 / 19:41:02 | `e2e-1671-kompakt` (User `default`) | **gregor-staging** |
+| 15.08. 05:00:33 | Kontrollversand User `validator-issue110` (eigenes Profil) | **gregor-test** ✅ |
+
+Der Kontrollversand belegt zugleich: der Versandweg auf dem **aktuellen** Staging-Stand
+(`57e36375`) ist intakt. Es ist kein Code-Regress und keine Infrastrukturstörung.
+
+**Vierte dokumentierte Wiederholung** derselben Falle — nach #1351, #1403, #1782.
+Siehe [[reference_two_test_mailboxes_imap_user_trap]],
+[[reference_staging_compare_versand_meldet_ok_ohne_zustellung]].
+
+## Was davon trotzdem eine echte Aufgabe bleibt
+
+Die Diagnose kostete rund eine Stunde, weil der Trip-Briefing-Pfad den Empfänger **nicht**
+protokolliert. Im Compare-Pfad steht er wörtlich im Log — dort war dieselbe Falle 2026-08-12
+in einer Minute aufgeklärt. Das Ticket sagt das selbst und hat damit recht; nur seine
+Ursachen-Diagnose war falsch. Der verbleibende, tragfähige Kern steht unten unter
+„Verbleibender Zuschnitt".
+
+### Weitere Spuren aus dem Staging-Journal
+
+```
+19:24:36  POST …/send?report_type=evening&user_id=default → 409 Conflict   (Idempotenz-Lock #1756)
+19:24:43  INFO trip_report_scheduler: Trip report sent: E2E 1671 Kompakt-Ausblick (evening)
+19:41:02  INFO trip_report_scheduler: Trip report sent: E2E 1671 Kompakt-Ausblick (morning)
+19:41:02  POST …/send?report_type=morning&user_id=default → 200 OK
+```
+
+- Der Versand dauert **~0,7 s** und hinterlässt **keine SMTP-Spur** — weder Erfolg noch Fehler.
+- Der erste Versuch (19:24:36) lief auf **409**; das `Trip report sent` 7 s später gehört zu
+  einem anderen Aufruf.
+- Auf Staging ist der Egress-Wächter aktiv und blockt sichtbar externe Hosts
+  (`EgressBlockedError` für `ensemble-api.open-meteo.com`, `warnungen.zamg.at`). Ob er auch
+  den SMTP-Weg trifft, ist **nicht geprüft**.
+- Staging-SMTP: `GZ_SMTP_HOST=mail.henemm.com`, Port 587, User `gregor-test` → also der
+  **Stalwart-/Nicht-Resend-Pfad** in `email.py`, nicht Resend.
+
+### Verbleibender Zuschnitt (Vorschlag nach der Auflösung)
+
+1. **Empfänger im Trip-Briefing-Pfad protokollieren** — Vorbild
+   `scheduler_dispatch_service.py:571`. Verhindert Wiederholung Nr. 5.
+2. **Empfänger in `_append_briefing_log()` mitschreiben** (:1799-1830 schreibt heute nur
+   `channels`) — damit der Nachweis auch nachträglich führbar ist.
+3. **`api/routers/scheduler.py:286`** (`"sent": True` hartkodiert) — bekannter, geduldeter
+   Verstoß B1 in `tests/test_success_status_guard.py:1518`. Unabhängig von #1847 real,
+   aber ein **eigener** Zuschnitt.
+4. **Entscheidung nötig:** Soll `default` auf Staging weiter nach `gregor-staging@` senden?
+   Die Mail-Validatoren lesen `GZ_TEST_IMAP_USER` (= `gregor-test`), d.h. der dokumentierte
+   Nachweisweg über einen `default`-Trip trägt so nicht.
+
+### Nicht mehr zutreffend — Spuren aus der ursprünglichen Fehlersuche
+
+*Der folgende Abschnitt entstand vor der Auflösung und wird nur als Protokoll aufbewahrt.*
+
+### Was diese Spuren logisch erzwingen
+
+`NotificationService` hängt `sent_channels.append("email")` **nach** `_send_email` an
+(`src/services/notification_service.py:403-409`); `sent = bool(sent_channels)`
+(:538-541). Die Erfolgszeile `Trip report sent` (`trip_report_scheduler.py:1578`) feuert nur
+bei `result.sent`. Und `EmailOutput.send()` signalisiert Fehler **ausschließlich per Exception**
+(`src/output/channels/email.py:607-616`, Rückgabetyp `-> None`).
+
+⇒ `EmailOutput.send()` ist ohne Exception zurückgekehrt. Der Versand wurde also
+**angenommen** und ist danach verschwunden. Die Analyse muss zwischen mindestens diesen
+Möglichkeiten entscheiden:
+
+1. SMTP-Übergabe an Stalwart erfolgreich, Zustellung danach verworfen (Stalwart-seitig).
+2. Ein Guard hat den Empfänger stillschweigend umgeschrieben — `email.py:655-663`
+   (`running_origin(...) == "test"` → Umschaltung auf `_ORIGIN_GUARD_TEST_RECIPIENT`).
+3. Der Trip trug einen eigenen Empfänger-Override (`to=…`), der ins Leere lief.
+4. Egress-Guard greift auf dem SMTP-Weg, ohne dass es eine Exception gibt.
+
+Möglichkeit 2 ist deshalb aussichtsreich, weil sie eine **stille Umschaltung mit
+Warn-Log** ist — und im Journal-Ausschnitt keine Warnung stand, was sie wiederum
+unwahrscheinlich macht. **Nicht raten, messen.**
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `api/routers/scheduler.py:204-286` | Endpoint `POST /trips/{trip_id}/send`. **Zeile 286: `return {"status": "ok", …, "sent": True}` ist hartkodiert** — der Erfolgsstatus folgt keinem Ergebnis. |
+| `src/services/trip_report_scheduler.py:1141-1634` | `_send_trip_report_outcome()` — leitet `no_stage`/`no_weather`/`no_channels`/`channels_unreachable`/`sent` ab. Erfolgs-Log :1578 **ohne Empfänger**. |
+| `src/services/trip_report_scheduler.py:405` | `Settings().with_user_profile(user_id)` — eine von **zwei unabhängigen** Auflösungen desselben Werts. |
+| `src/services/notification_service.py:384-541` | `no_channel_configured` :384-391 · E-Mail-Versand :403-409 · `sent=bool(sent_channels)` :538-541 · Fehler-Weitergabe :527-529 (E-Mail-Fehler wird verschluckt, sobald **irgendein** anderer Kanal zustellte). |
+| `src/app/config.py:355-402` | `with_user_profile()` — **drei stille `return base`**: fehlende Datei :376-377, JSON-/OSError :379-381, keine Overrides :400-401. |
+| `src/app/config.py:148` | `mail_to: Optional[str]` — **ein einzelner String**, keine Empfängerliste. Die Ticket-Formulierung „Empfängerliste" existiert im Trip-Pfad nicht. |
+| `src/app/config.py:305-312` | `can_send_email()` — die einzige Stelle, an der ein leeres `mail_to` überhaupt auffällt (→ 422 im Router :226-229). |
+| `src/output/channels/email.py:607-616` | `send() -> None` — **kein Rückgabewert**, kein Early-Return; Fehlersignal nur per Exception. |
+| `src/output/channels/email.py:643-650` | Empfänger-Fallback `recipients = list(to) if to else [self._to]`. |
+| `src/output/channels/email.py:655-663` | **Herkunftssperre #1476** — bei Testlauf-Herkunft wird der Empfänger still auf die Test-Mailbox umgeschaltet (mit `logger.warning`). |
+| `src/output/channels/email.py:713-770` | Empfänger-Guards: Resend-Allowlist (#1147/#1219) und Lokal-Guard (#1235). Beide werfen `OutputConfigError` — nie stiller Erfolg **innerhalb** des Kanals. |
+| `src/services/scheduler_dispatch_service.py:410-415, 554, 571` | **Das Vorbild:** Compare-Pfad leitet `default_to` her, wirft `ValueError` bei fehlendem `mail_to` (fail-loud) und protokolliert `Compare preset %s sent to %s`. |
+
+## Existing Patterns
+
+- **Fail-loud vor dem Versand** (Compare-Pfad, `scheduler_dispatch_service.py:410-415`):
+  Empfänger explizit herleiten, bei Fehlen `ValueError` werfen. Für den Trip-Briefing-Pfad
+  existiert dieses Muster **nicht**.
+- **Empfänger protokollieren** (Compare-Pfad, :571). Im Trip-Pfad kommt `mail_to`/`recipient`
+  im gesamten Modul nicht vor; `_append_briefing_log()` :1799-1830 speichert nur `channels`,
+  keine Adresse.
+- **Outcome-Enum statt Boolean** (`trip_report_scheduler.py`): der Router hat für jeden
+  Negativ-Outcome bereits einen eigenen 422-Zweig (#1403, #1325, #904, #1756). Das Muster
+  ist etabliert — eine neue Ursache bekommt einen neuen Zweig, keine neue Mechanik.
+- **Teilungsregel Trip ↔ Compare** (CLAUDE.md): Der Compare-Pfad kann hier ausnahmsweise als
+  Referenz dienen, weil er dieselbe Frage bereits gelöst hat.
+
+## Dependencies
+
+- **Upstream:** `Settings` / `with_user_profile()` (`src/app/config.py`) ·
+  `NotificationService` · `EmailOutput` + `build_mime_message` · Stalwart auf
+  `mail.henemm.com:587` · Egress-Guard (`src/app/egress_guard.py`).
+- **Downstream:** Go-API-Proxy (`internal/`) → Frontend-Sende-Dialog ·
+  Go-Cron-Scheduler (ruft denselben Dienst stündlich) · **`briefing_mail_validator.py` und
+  `renderer_mail_gate.py`** (der Nachweisweg selbst) · Alarm-Pfad, der über
+  `_briefing_channels()` erbt.
+
+## Existing Specs
+
+| Spec | Bezug |
+|---|---|
+| `docs/specs/modules/waechter_1405_erfolg_wirkung.md` | AST-Wächter „Erfolg heißt Wirkung" (#1405). Belegte Vorfälle #1290/#1346/#1348/#1403 — **#1847 ist der nächste derselben Klasse.** |
+| `docs/specs/modules/waechter_1405_stille_aufloesung.md` | Hälfte A — stille Auflösung. |
+| `docs/specs/modules/fix_1756_send_idempotenz_lock.md` | Der 409 um 19:24:36. |
+| `docs/specs/modules/fix_1662_versandfehler_nachliefern.md` · `fix_1629_briefing_anker_versandfehler.md` | Vorhandene Behandlung von Versandfehlern im Briefing-Pfad. |
+| `docs/specs/modules/fix_1412_s3a_transport_kapselung_mail.md` | Transport-Kapselung Mail. |
+| `docs/reference/mail_validators.md` | Der bedrohte Nachweisweg. |
+
+## Bestehende Wächter — und ihre Lücke
+
+- `tests/test_success_status_guard.py:1518-1520` **listet genau diesen Endpoint als bekannten,
+  geduldeten Verstoß**:
+  `"api/routers/scheduler.py::send_test_trip_report::0": "B1 (#1403/#1405) — send_test_trip_report: 'sent': True trotz outcome."`
+  Der Wächter prüft laut eigenem Docstring (:135-142) **nicht**, ob alle Rückgabewerte
+  abgedeckt sind — nur, ob der Status überhaupt vom Aufrufergebnis abhängt.
+- `tests/unit/test_trip_send_endpoint_no_channels.py` deckt `no_channels` und
+  `channels_unreachable` ab — **schließt den Empfänger-Fall aber strukturell aus**:
+  `_patch_can_send_email` :169-178 setzt `can_send_email → True`, `_patch_email_transport`
+  :160-165 ersetzt `NotificationService._send_email`. Beide Stellen, an denen ein
+  Empfänger-Problem auffallen würde, sind ausgehängt.
+- `tests/tdd/test_compare_alert_recipient_settings.py:448-462` sichert „kein stiller Erfolg"
+  für den **Compare**-Pfad. **Kein Pendant für den Trip-Briefing-Pfad.**
+- Kein Test behauptet „Empfänger-Problem ⇒ kein `sent=true`" für `POST /trips/{trip_id}/send`.
+
+## Risks & Considerations
+
+1. **Die Ursache ist unbekannt.** Der einzige dokumentierte Erklärungsansatz ist widerlegt.
+   Die Analyse-Phase muss zuerst die Zustellung instrumentieren, bevor irgendetwas geändert
+   wird — sonst härtet man den falschen Pfad
+   ([[feedback_adversary_may_harden_the_wrong_path]]).
+2. **Prüfort = Wirkort.** Ein Test, der `_send_email` oder `can_send_email` mockt, kann diesen
+   Bug per Konstruktion nicht sehen — genau daran scheitert der bestehende Test heute. Der
+   RED-Test muss bis zum echten Sendezweig laufen und darf nur den Steckdosenrand
+   (`EmailOutput._dial_and_send`) ersetzen ([[reference_mail_sink_verdeckt_den_echten_sendeweg]]).
+3. **Zwei unabhängige Settings-Auflösungen** (Router :226 und Service :405) können
+   auseinanderlaufen — ein Riegel an nur einer Stelle wirkt nicht.
+4. **E-Mail-Fehler werden verschluckt**, sobald ein anderer Kanal zustellte
+   (`notification_service.py:527-529`). Ein Fix, der nur `sent` korrigiert, lässt den
+   Teilausfall weiter unsichtbar.
+5. **Der Wächter aus #1405 muss mitgezogen werden**: wird Zeile 286 repariert, muss der
+   Eintrag aus der Verstoß-Liste in `test_success_status_guard.py` **entfernt** werden —
+   sonst behauptet der Wächter weiter einen Verstoß, den es nicht mehr gibt.
+6. **Staging-Egress-Guard** ist aktiv und blockt externe Hosts. Jede Messung auf Staging muss
+   das mitdenken; ein lokal grüner Versandweg beweist dort nichts.
+7. **Nachweis-Aufwand mitschätzen:** Der Nachweis braucht eine echt zugestellte Staging-Mail
+   plus IMAP-Gegenprobe im richtigen Postfach — nicht nur einen grünen Unit-Test.

--- a/docs/specs/fast/fix-1847-briefing-empfaenger-log.md
+++ b/docs/specs/fast/fix-1847-briefing-empfaenger-log.md
@@ -1,0 +1,128 @@
+# Mini-Spec: Trip-Briefing protokolliert den E-Mail-Empfänger
+
+Issue: [#1847](https://github.com/henemm/gregor_zwanzig/issues/1847) · Fast Track
+Kontext & Beweisführung: `docs/context/fix-1847-briefing-versand-ohne-zustellung.md`
+
+## Approval
+
+- [x] Approved — PO Henning, 2026-08-15 („gogogo"). Freigegeben sind AC-1 bis AC-4 samt
+  der drei benannten Tech-Lead-Entscheidungen: Empfänger **unmaskiert**, Endpoint-Status
+  und `send()`-Signatur **außerhalb** dieser Scheibe, bekannte Grenze (konfigurierter statt
+  post-Guard-Empfänger) akzeptiert.
+
+## Anlass
+
+#1847 wurde als „Staging meldet `sent:true`, es kommt keine Mail" gemeldet. Die Mail **war**
+zugestellt — an `gregor-staging@henemm.com` statt an `gregor-test@henemm.com`, weil
+`/var/lib/gregor-staging/users/default/user.json` ein abweichendes `mail_to` trug. Die
+Diagnose kostete rund eine Stunde. Im **Ortsvergleich**-Pfad steht der Empfänger wörtlich im
+Protokoll (`src/services/scheduler_dispatch_service.py:571`), weshalb dieselbe Falle dort am
+2026-08-12 in einer Minute aufgeklärt war. Der Trip-Briefing-Pfad hat diese Zeile nicht.
+
+Das ist die **vierte** Wiederholung derselben Falle (#1351, #1403, #1782, #1847). Diese
+Scheibe zieht die bereits bewährte Zeile aus dem Compare-Pfad nach — sie erfindet keine neue
+Regel, sie schließt eine Lücke gegenüber der bestehenden Norm.
+
+## Was ändert sich
+
+- `src/services/trip_report_scheduler.py`, Erfolgszweig bei :1578: die Zeile
+  `Trip report sent: {trip.name} ({report_type})` nennt zusätzlich die **zugestellten Kanäle**
+  und — sofern E-Mail dabei war — den **E-Mail-Empfänger** (`self._settings.mail_to`).
+  Vorbild für Wortlaut und Detailtiefe: `scheduler_dispatch_service.py:571`.
+- `src/services/trip_report_scheduler.py`, `_append_briefing_log()` (:1799-1830): der Eintrag
+  bekommt zusätzlich den E-Mail-Empfänger, damit der Nachweis auch **nachträglich** führbar
+  ist und nicht nur im flüchtigen Journal steht.
+
+## Was darf sich nicht ändern
+
+- **Der Erfolgs-/Fehlerzweig selbst.** Die Unterscheidung `no_channel_configured` /
+  `not result.sent` / Erfolg (:1567-1578) bleibt unangetastet; es wird nur die vorhandene
+  Erfolgszeile angereichert. Kein neuer Outcome, kein geänderter HTTP-Status.
+- **Die Bedingung, wann `_append_briefing_log` überhaupt schreibt.** Ein Eintrag mit
+  `channels=[]` würde der Cockpit-Kachel (#393/#1007) einen Versand vortäuschen — diese
+  Zusicherung ist im Docstring festgehalten und bleibt gültig.
+- **Bestehende Schlüssel im `briefing_log.json`-Eintrag** (`trip_id`, `kind`, `sent_at`,
+  `channels`, `on_demand`). Es wird ausschließlich **ergänzt**. Go liest die Datei nur
+  (`store.LoadBriefingLog`) und ignoriert unbekannte Felder — im Docstring bereits so
+  dokumentiert, deshalb ist das Ergänzen abwärtskompatibel.
+- **Der Empfänger wird nicht maskiert.** Bewusste Entscheidung: eine Maskierung wie
+  `g***@henemm.com` hätte `gregor-test@` und `gregor-staging@` **nicht** unterscheidbar
+  gemacht und damit genau den Zweck verfehlt. Der Compare-Pfad protokolliert ebenfalls
+  unmaskiert; das Journal ist nur mit erhöhten Rechten lesbar.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip mit aktivem E-Mail-Kanal und `mail_to = "gregor-test@henemm.com"`,
+  When das Briefing erfolgreich versendet wird, Then enthält die Protokollzeile des
+  erfolgreichen Versands die Zeichenkette `gregor-test@henemm.com` — geprüft am tatsächlich
+  ausgegebenen Log-Datensatz, nicht am Quelltext.
+- **AC-2:** Given derselbe erfolgreiche Versand, When danach `briefing_log.json` gelesen wird,
+  Then trägt der neu angehängte Eintrag den E-Mail-Empfänger, und die Schlüssel `trip_id`,
+  `kind`, `sent_at`, `channels`, `on_demand` sind unverändert vorhanden.
+- **AC-3:** Given ein Trip, dessen einziger aktiver Kanal Telegram ist (kein E-Mail-Versand),
+  When das Briefing erfolgreich versendet wird, Then nennt die Protokollzeile **keinen**
+  E-Mail-Empfänger und der `briefing_log`-Eintrag behauptet keinen E-Mail-Empfänger — eine
+  Zeile, die bei jedem Versand eine Adresse nennt, wäre keine Zustell-Aussage.
+- **AC-4:** Given ein Trip, bei dem der E-Mail-Versand fehlschlägt und kein anderer Kanal
+  zustellt, When der Versand ausgewertet wird, Then wird **keine** Erfolgszeile
+  protokolliert und **kein** `briefing_log`-Eintrag geschrieben; die bestehende
+  Fehlerzeile `E-Mail send failed …` bleibt unverändert und die Ausnahme wird unverändert
+  weitergereicht.
+
+  > **Korrektur 2026-08-15 (nach PO-Freigabe, Substanz unverändert).** Die freigegebene
+  > Fassung verlangte hier die Warnzeile `Trip report NOT sent …`. Das ist am Code nicht
+  > erreichbar und war ein Fehler in dieser Spec, nicht in der Umsetzung: bei leerem
+  > `sent_channels` wirft `notification_service.py:527-528` die Ausnahme weiter,
+  > `trip_report_scheduler.py:1522-1535` fängt sie, schreibt Fehlervermerk und Anker und
+  > reicht sie durch — die Dreier-Auswertung bei :1566-1578 wird nie betreten. Die
+  > Warnzeile gehört zum Fall „Kanal konfiguriert, aber unerreichbar" (Telegram) und ist
+  > dort bereits von `tests/unit/test_trip_send_endpoint_no_channels.py` abgedeckt.
+  > **Die zugesicherte Wirkung ist dieselbe:** kein stiller Erfolg, kein Log-Eintrag.
+  > Gefunden vom Developer-Agent vor dem ersten Edit, vom Orchestrator am Code
+  > gegengeprüft.
+
+## Manuelle Test-Schritte
+
+1. Auf Staging ein Briefing unter `user_id=default` auslösen:
+   `curl -X POST "http://localhost:8001/api/scheduler/trips/<id>/send?user_id=default&report_type=morning"`
+2. `sudo -n journalctl -u gregor-python-staging | grep "Trip report sent" | tail -1` →
+   die Zeile nennt `gregor-test@henemm.com`.
+3. `sudo -n python3 -c "import json;print(json.load(open('/var/lib/gregor-staging/users/default/briefing_log.json'))['entries'][-1])"`
+   → der Eintrag trägt denselben Empfänger.
+4. Gegenprobe im Postfach (`GZ_TEST_IMAP_USER`): die Mail liegt bei genau dieser Adresse.
+
+## Inline-Test (wird während Implementierung geschrieben)
+
+- [ ] AC-1/AC-2: Versand über den **echten** Pfad, nur `EmailOutput._dial_and_send`
+      ersetzt (nicht `_send_email`, nicht `can_send_email` — beides hängt genau die Stellen
+      aus, an denen der Empfänger sichtbar würde; siehe
+      `tests/unit/test_trip_send_endpoint_no_channels.py:160-178` als Gegenbeispiel).
+      Prüfung über `caplog` und die geschriebene `briefing_log.json`.
+- [ ] AC-3: Telegram-only-Trip — Zusicherung, dass keine Adresse auftaucht. **Zweiter
+      Netzrand PFLICHT:** zusätzlich `TelegramOutput._post` ersetzen und Dummy-Zugangsdaten
+      per `monkeypatch.setenv` setzen, sonst sendet der Testfall echt an Telegram. Anlass
+      ist kein hypothetisches Risiko: am 2026-08-03 gingen so echte Nachrichten an den
+      Produktiv-Chat des PO (#1477).
+- [ ] AC-4: E-Mail-Fehler ohne Ersatzkanal — Warnzeile bleibt, kein Log-Eintrag.
+- [ ] Mutations-Gegenprobe: Empfänger aus der Log-Zeile entfernen ⇒ AC-1 muss rot werden.
+
+## Nicht in dieser Scheibe
+
+- **`api/routers/scheduler.py:286`** (`"sent": True` hartkodiert). Real, aber eigenes Thema —
+  bereits als Verstoß **B1** in `tests/test_success_status_guard.py:1518` geführt.
+- **`EmailOutput.send() -> None`** (kein Erfolgssignal an den Aufrufer, Klasse 4 desselben
+  Wächters). Eine Signaturänderung dort zieht das Renderer-Commit-Gate (#811) nach sich und
+  gehört in eine eigene Scheibe.
+- **Telegram-/SMS-/Premium-SMS-Empfänger.** Diese Scheibe adressiert die belegte Falle
+  (E-Mail-Postfach). Für die anderen Kanäle ist keine entsprechende Fehlklasse belegt.
+
+## Bekannte Grenze
+
+Protokolliert wird der **konfigurierte** Empfänger (`settings.mail_to`), den
+`_send_email` ohne `to=`-Override an den Kanal gibt (`notification_service.py:1726-1745`,
+`email.py:643-650`). Die Herkunftssperre #1476 (`email.py:655-663`) kann den Empfänger im
+Kanal noch umschalten — das greift ausschließlich bei Testlauf-Herkunft und ist im
+Serverbetrieb nicht erreichbar. Im gemeldeten Fehlerbild sind konfigurierter und
+tatsächlicher Empfänger deshalb identisch, und die Zeile hätte #1847 in einer Minute
+aufgeklärt. Der post-Guard-Wert wäre nur über eine Signaturänderung an `send()` zu bekommen —
+siehe „Nicht in dieser Scheibe".

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -1572,10 +1572,29 @@ class TripReportSchedulerService:
                 f"Trip report NOT sent (configured channel unreachable): {trip.name} ({report_type})"
             )
         else:
-            self._append_briefing_log(
-                trip.id, report_type, result.sent_channels, angefordert=angefordert,
+            # Issue #1847: die Erfolgszeile nennt zusaetzlich die tatsaechlich
+            # zugestellten Kanaele und — sofern E-Mail dabei war — den
+            # E-Mail-Empfaenger. Vorbild ist der Compare-Pfad
+            # (scheduler_dispatch_service.py:571, "Compare preset %s sent to
+            # %s"): dort war "Versand gemeldet, Postfach leer" in einer Minute
+            # aufgeklaert, hier kostete dieselbe Falle eine Stunde (vierte
+            # Wiederholung: #1351, #1403, #1782, #1847). Bewusst UNMASKIERT —
+            # eine Maskierung machte gregor-test@ und gregor-staging@
+            # ununterscheidbar und verfehlte genau den Zweck.
+            mail_empfaenger = (
+                self._settings.mail_to if "email" in result.sent_channels else None
             )
-            logger.info(f"Trip report sent: {trip.name} ({report_type})")
+            self._append_briefing_log(
+                trip.id, report_type, result.sent_channels,
+                angefordert=angefordert, mail_empfaenger=mail_empfaenger,
+            )
+            logger.info(
+                "Trip report sent: %s (%s) via %s%s",
+                trip.name,
+                report_type,
+                ",".join(result.sent_channels),
+                f" to {mail_empfaenger}" if mail_empfaenger else "",
+            )
 
         # 8c. Issue #1662 AC-5: Der gelungene Versand macht einen offenen
         # Versandfehler-Vermerk gegenstandslos — der Nutzer hat sein Briefing
@@ -1798,6 +1817,7 @@ class TripReportSchedulerService:
 
     def _append_briefing_log(
         self, trip_id: str, kind: str, channels: List[str], angefordert: bool = False,
+        mail_empfaenger: Optional[str] = None,
     ) -> None:
         """Issue #393: Hängt einen Briefing-Versand-Eintrag an briefing_log.json an.
 
@@ -1822,16 +1842,28 @@ class TripReportSchedulerService:
         das `briefing_slots` liest; Go liest die Datei nur
         (`store.LoadBriefingLog`, kein Schreibpfad), ignoriert unbekannte
         Felder und schreibt sie deshalb auch nicht weg.
+
+        Issue #1847: `mail_empfaenger` hält fest, an WELCHE Adresse das
+        Briefing per E-Mail ging — sonst ist „Versand gemeldet, Postfach leer"
+        nachträglich nicht mehr auflösbar (vierte Wiederholung derselben Falle:
+        #1351, #1403, #1782, #1847). Der Schlüssel `mail_to` entsteht nur, wenn
+        E-Mail auch tatsächlich zugestellt wurde — ein Eintrag, der bei JEDEM
+        Versand eine Adresse nennt, wäre keine Zustell-Aussage. Rein additiv:
+        die bestehenden Schlüssel bleiben unverändert, Go ignoriert den neuen
+        (s.o.).
         """
         path = get_data_dir(self._user_id) / "briefing_log.json"
         data = json.loads(path.read_text()) if path.exists() else {"entries": []}
-        data["entries"].append({
+        eintrag: Dict[str, object] = {
             "trip_id": trip_id,
             "kind": kind,
             "sent_at": datetime.now(tz=timezone.utc).isoformat(),
             "channels": channels,
             "on_demand": angefordert,
-        })
+        }
+        if mail_empfaenger:
+            eintrag["mail_to"] = mail_empfaenger
+        data["entries"].append(eintrag)
         # Issue #1614: ein frischer Nutzer ohne jedes vorherige Datenverzeichnis
         # (kein Trip-Snapshot, kein Alert-State) hatte hier noch kein
         # Zielverzeichnis — path.write_text() scheiterte mit FileNotFoundError.

--- a/tests/unit/test_briefing_recipient_logging.py
+++ b/tests/unit/test_briefing_recipient_logging.py
@@ -1,0 +1,367 @@
+"""Issue #1847: Der Trip-Briefing-Pfad protokolliert den E-Mail-Empfaenger.
+
+Spec: docs/specs/fast/fix-1847-briefing-empfaenger-log.md
+Kontext: docs/context/fix-1847-briefing-versand-ohne-zustellung.md
+
+Anlass: "Versand gemeldet, Postfach leer" kostete rund eine Stunde Diagnose,
+weil die Erfolgszeile des Trip-Briefings den Empfaenger nicht nennt. Im
+Compare-Pfad steht er wortwoertlich im Protokoll
+(`scheduler_dispatch_service.py:571`); dort war dieselbe Falle in einer Minute
+aufgeklaert.
+
+PRUEFORT = WIRKORT: der Versand laeuft ueber den ECHTEN Pfad
+(`send_test_report_outcome` -> `_send_trip_report_outcome` ->
+`NotificationService.send_trip_report` -> `EmailOutput.send`). Ersetzt wird
+AUSSCHLIESSLICH der aeusserste Netzrand:
+
+* `EmailOutput._dial_and_send` (SMTP-Steckdose, #1412 S3a: der EINE Ort, an
+  dem eine SMTP-Verbindung entsteht) und
+* `TelegramOutput._post` (Bot-API-Steckdose, #1370: der EINE Transportweg) --
+  ohne dieses zweite Substitut wuerde der Telegram-Testfall echt senden
+  (#1477: am 2026-08-03 gingen so Nachrichten an den Produktiv-Chat).
+
+Bewusst NICHT ersetzt werden `NotificationService._send_email`,
+`Settings.can_send_email` und `mail_sink` -- genau diese drei haengen die
+Stellen aus, an denen der Empfaenger ueberhaupt erst sichtbar wird (siehe
+`tests/unit/test_trip_send_endpoint_no_channels.py:160-178` als
+Gegenbeispiel). Die Empfaenger-Aufloesung (`Settings.with_user_profile` ->
+`mail_to`), alle Empfaenger-Guards (#1219/#1235/#1476) und die Zustellbilanz
+(`sent_channels`) laufen unveraendert echt.
+
+Zugangsdaten sind bewusst DUMMY-Werte: selbst wenn ein Netzrand-Substitut
+ausfiele, koennte weder eine Mail noch eine Telegram-Nachricht ein echtes Ziel
+erreichen.
+
+AC-1: erfolgreicher E-Mail-Versand -> die Erfolgszeile nennt die
+      Empfaengeradresse (geprueft am ausgegebenen Log-Datensatz).
+AC-2: derselbe Versand -> der briefing_log.json-Eintrag traegt den
+      Empfaenger, alle Altfelder bleiben unveraendert vorhanden.
+AC-3: Telegram-only-Trip -> weder Logzeile noch Eintrag nennen eine
+      E-Mail-Adresse.
+AC-4: E-Mail scheitert ohne Ersatzkanal -> keine Erfolgszeile, kein
+      briefing_log-Eintrag, bestehender Fehlerpfad unveraendert.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import smtplib
+from datetime import date
+from pathlib import Path
+
+import httpx
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+EMPFAENGER = "gregor-test@henemm.com"
+
+# Dummy-Zugangsdaten: kein einziger Wert erreicht ein echtes Ziel. Sie sind
+# noetig, weil `can_send_email()` und die Test-Modus-Guards (#1288/#1363/#1476)
+# BEWUSST nicht ausgehaengt werden -- ohne echte Konfiguration braucht der
+# Testlauf trotzdem eine vollstaendige.
+DUMMY_ENV = {
+    "GZ_SMTP_HOST": "mail.henemm.com",
+    "GZ_SMTP_PORT": "587",
+    "GZ_SMTP_USER": "tdd-1847",
+    "GZ_SMTP_PASS": "tdd-1847-kein-echtes-passwort",
+    "GZ_TEST_SMTP_HOST": "mail.henemm.com",
+    "GZ_TEST_SMTP_USER": "tdd-1847",
+    "GZ_TEST_SMTP_PASS": "tdd-1847-kein-echtes-passwort",
+    "GZ_TELEGRAM_BOT_TOKEN": "tdd-1847-kein-echter-token",
+    "GZ_TELEGRAM_CHAT_ID": "tdd-1847-chat",
+    "GZ_TELEGRAM_TEST_BOT_TOKEN": "tdd-1847-kein-echter-token",
+    "GZ_TELEGRAM_TEST_CHAT_ID": "tdd-1847-chat",
+}
+
+
+class _TodayOnlyOpenMeteoDouble:
+    """Echte, aufgezeichnete Innsbruck-Fixturdaten fuer 'heute' (Muster #1325)."""
+
+    name = "openmeteo"
+
+    def __init__(self) -> None:
+        from providers.fixture import FixtureProvider
+
+        self._fixture = FixtureProvider(str(REPO_ROOT / "fixtures" / "openmeteo"))
+
+    def fetch_forecast(self, location, start=None, end=None,
+                       enrich_ensemble=True, enrich_snow=True):
+        return self._fixture.fetch_forecast(
+            location, start=start, end=end,
+            enrich_ensemble=enrich_ensemble, enrich_snow=enrich_snow,
+        )
+
+
+class Netzrand:
+    """Sammelt, was die beiden Steckdosen tatsaechlich zu sehen bekommen."""
+
+    def __init__(self) -> None:
+        self.smtp: list[dict] = []
+        self.telegram: list[dict] = []
+        self.smtp_fehler: BaseException | None = None
+
+
+@pytest.fixture
+def netzrand(monkeypatch) -> Netzrand:
+    for key, value in DUMMY_ENV.items():
+        monkeypatch.setenv(key, value)
+
+    from output.channels.telegram import reset_telegram_rate_limit_for_tests
+
+    reset_telegram_rate_limit_for_tests()
+
+    rand = Netzrand()
+
+    def _smtp_steckdose(self, host, port, user, password, recipients, msg,
+                        from_addr, deadline_at):
+        rand.smtp.append({
+            "host": host, "recipients": list(recipients), "from": from_addr,
+        })
+        if rand.smtp_fehler is not None:
+            raise rand.smtp_fehler
+
+    def _telegram_steckdose(self, url, payload, *, chat_id=None):
+        rand.telegram.append({"chat_id": chat_id, "payload": payload})
+        return httpx.Response(
+            200, json={"ok": True, "result": {"message_id": len(rand.telegram)}},
+        )
+
+    monkeypatch.setattr(
+        "output.channels.email.EmailOutput._dial_and_send", _smtp_steckdose,
+    )
+    monkeypatch.setattr(
+        "output.channels.telegram.TelegramOutput._post", _telegram_steckdose,
+    )
+    monkeypatch.setattr(
+        "providers.base.get_provider", lambda name: _TodayOnlyOpenMeteoDouble(),
+    )
+    return rand
+
+
+def _trip_anlegen(user_id: str, trip_id: str, report_config: dict) -> None:
+    """Legt Nutzerprofil (mit mail_to) und Trip im isolierten Datenbaum an."""
+    from app.loader import get_briefings_dir, get_data_dir
+
+    profil = get_data_dir(user_id) / "user.json"
+    profil.parent.mkdir(parents=True, exist_ok=True)
+    profil.write_text(json.dumps({"mail_to": EMPFAENGER}))
+
+    briefings_dir = get_briefings_dir(user_id)
+    briefings_dir.mkdir(parents=True, exist_ok=True)
+    (briefings_dir / f"{trip_id}.json").write_text(json.dumps({
+        "id": trip_id,
+        "name": "TDD-1847 Trip",
+        "kind": "route",
+        "stages": [{
+            "id": "st-heute",
+            "name": "Etappe heute",
+            "date": date.today().isoformat(),
+            "waypoints": [
+                {"id": "wp1", "name": "Innsbruck", "lat": 47.2692,
+                 "lon": 11.4041, "elevation_m": 574},
+                {"id": "wp2", "name": "Hafelekar", "lat": 47.3103,
+                 "lon": 11.3844, "elevation_m": 2269},
+            ],
+        }],
+        # Kein MeteoAlarm-Fetch -- der Kern-Test bleibt netzfrei.
+        "official_alerts_enabled": False,
+        "report_config": report_config,
+        "alert_rules": [],
+    }))
+
+
+def _versenden(user_id: str, trip_id: str):
+    from app.loader import get_briefings_dir, load_trip
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    trip = load_trip(get_briefings_dir(user_id) / f"{trip_id}.json")
+    service = TripReportSchedulerService(user_id=user_id)
+    return service.send_test_report_outcome(trip, "morning")
+
+
+def _erfolgszeilen(caplog) -> list[str]:
+    return [
+        r.getMessage() for r in caplog.records
+        if r.getMessage().startswith("Trip report sent:")
+    ]
+
+
+def _log_eintraege(user_id: str) -> list[dict]:
+    from app.loader import get_data_dir
+
+    pfad = get_data_dir(user_id) / "briefing_log.json"
+    if not pfad.exists():
+        return []
+    return json.loads(pfad.read_text())["entries"]
+
+
+# ---------------------------------------------------------------------------
+# AC-1 / AC-2: erfolgreicher E-Mail-Versand
+# ---------------------------------------------------------------------------
+
+
+class TestAC1ErfolgszeileNenntEmpfaenger:
+    def test_erfolgszeile_enthaelt_die_empfaengeradresse(self, netzrand, caplog):
+        user_id, trip_id = "tdd-1847-mail", "tdd-1847-mail-trip"
+        _trip_anlegen(user_id, trip_id, {
+            "send_email": True, "send_telegram": False, "send_sms": False,
+        })
+
+        with caplog.at_level(logging.INFO):
+            outcome = _versenden(user_id, trip_id)
+
+        assert outcome == "sent", f"Erwartet 'sent', bekommen {outcome!r}"
+        assert netzrand.smtp, (
+            "Die SMTP-Steckdose wurde nie erreicht -- der Test haette den "
+            "echten Sendeweg verfehlt und koennte den Empfaenger gar nicht "
+            "sehen (Pruefort != Wirkort)."
+        )
+        assert netzrand.smtp[0]["recipients"] == [EMPFAENGER], (
+            f"Unerwarteter Empfaenger am SMTP-Rand: {netzrand.smtp}"
+        )
+
+        zeilen = _erfolgszeilen(caplog)
+        assert len(zeilen) == 1, f"Erwartet genau eine Erfolgszeile: {zeilen}"
+        assert EMPFAENGER in zeilen[0], (
+            "BUG #1847: die Erfolgszeile nennt den E-Mail-Empfaenger nicht -- "
+            "genau das kostete eine Stunde Diagnose. Zeile: " + zeilen[0]
+        )
+
+    def test_erfolgszeile_nennt_die_zugestellten_kanaele(self, netzrand, caplog):
+        user_id, trip_id = "tdd-1847-kanal", "tdd-1847-kanal-trip"
+        _trip_anlegen(user_id, trip_id, {
+            "send_email": True, "send_telegram": True, "send_sms": False,
+        })
+
+        with caplog.at_level(logging.INFO):
+            outcome = _versenden(user_id, trip_id)
+
+        assert outcome == "sent"
+        zeilen = _erfolgszeilen(caplog)
+        assert zeilen, "Keine Erfolgszeile protokolliert"
+        assert "email" in zeilen[0] and "telegram" in zeilen[0], (
+            f"Erfolgszeile soll die zugestellten Kanaele nennen: {zeilen[0]}"
+        )
+
+
+class TestAC2BriefingLogTraegtEmpfaenger:
+    def test_eintrag_traegt_empfaenger_und_alle_altfelder(self, netzrand, caplog):
+        user_id, trip_id = "tdd-1847-log", "tdd-1847-log-trip"
+        _trip_anlegen(user_id, trip_id, {
+            "send_email": True, "send_telegram": False, "send_sms": False,
+        })
+
+        with caplog.at_level(logging.INFO):
+            outcome = _versenden(user_id, trip_id)
+        assert outcome == "sent"
+
+        eintraege = _log_eintraege(user_id)
+        assert len(eintraege) == 1, f"Erwartet genau einen Eintrag: {eintraege}"
+        eintrag = eintraege[0]
+
+        assert eintrag.get("mail_to") == EMPFAENGER, (
+            "BUG #1847: der briefing_log-Eintrag traegt den E-Mail-Empfaenger "
+            f"nicht -- der Nachweis ist nachtraeglich nicht fuehrbar: {eintrag}"
+        )
+        # Altfelder unveraendert (Wire-Format fuer Go/briefing_slots,
+        # #393/#1007/#1725) -- ergaenzt wird, nicht ersetzt.
+        assert eintrag["trip_id"] == trip_id
+        assert eintrag["kind"] == "morning"
+        assert eintrag["channels"] == ["email"]
+        assert eintrag["on_demand"] is True
+        assert isinstance(eintrag["sent_at"], str) and eintrag["sent_at"]
+
+
+# ---------------------------------------------------------------------------
+# AC-3: Telegram-only -- keine Adresse behaupten
+# ---------------------------------------------------------------------------
+
+
+class TestAC3TelegramOnlyNenntKeineAdresse:
+    def test_keine_email_adresse_in_zeile_und_eintrag(self, netzrand, caplog):
+        user_id, trip_id = "tdd-1847-telegram", "tdd-1847-telegram-trip"
+        _trip_anlegen(user_id, trip_id, {
+            "send_email": False, "send_telegram": True, "send_sms": False,
+        })
+
+        with caplog.at_level(logging.INFO):
+            outcome = _versenden(user_id, trip_id)
+
+        assert outcome == "sent", f"Erwartet 'sent', bekommen {outcome!r}"
+        assert netzrand.smtp == [], (
+            f"Ohne E-Mail-Kanal darf die SMTP-Steckdose nicht laufen: {netzrand.smtp}"
+        )
+        assert netzrand.telegram, "Telegram-Steckdose wurde nie erreicht"
+
+        zeilen = _erfolgszeilen(caplog)
+        assert zeilen, "Keine Erfolgszeile protokolliert"
+        assert "@" not in zeilen[0], (
+            "Eine Zeile, die bei JEDEM Versand eine Adresse nennt, waere keine "
+            f"Zustell-Aussage: {zeilen[0]}"
+        )
+
+        eintraege = _log_eintraege(user_id)
+        assert len(eintraege) == 1, f"Erwartet genau einen Eintrag: {eintraege}"
+        eintrag = eintraege[0]
+        assert eintrag["channels"] == ["telegram"]
+        assert "mail_to" not in eintrag, (
+            f"Ohne E-Mail-Versand darf kein Empfaenger behauptet werden: {eintrag}"
+        )
+        assert not any(
+            isinstance(v, str) and "@" in v for v in eintrag.values()
+        ), f"Keine Adresse im Eintrag erwartet: {eintrag}"
+
+
+# ---------------------------------------------------------------------------
+# AC-4: E-Mail scheitert, kein Ersatzkanal
+# ---------------------------------------------------------------------------
+
+
+class TestAC4FehlgeschlagenerVersand:
+    def test_kein_erfolg_und_kein_log_eintrag(self, netzrand, caplog):
+        """Erreichbares Verhalten dieses Falls (Spec-Korrektur 2026-08-15):
+        bei leerem `sent_channels` reicht `notification_service.py:527-528`
+        den E-Mail-Fehler weiter, `trip_report_scheduler.py:1522-1535` faengt
+        ihn, schreibt Fehlervermerk + Anker und reicht ihn durch -- die
+        Dreier-Auswertung (:1566-1578) wird nie betreten. Zugesichert bleibt
+        die Wirkung: kein stiller Erfolg, kein Log-Eintrag, bestehende
+        Fehlerzeile unveraendert. Den Zweig mit der Warnzeile ("Kanal
+        konfiguriert, aber unerreichbar") deckt
+        `test_trip_send_endpoint_no_channels.py` ab.
+        """
+        from output.channels.base import OutputError
+
+        user_id, trip_id = "tdd-1847-fehler", "tdd-1847-fehler-trip"
+        _trip_anlegen(user_id, trip_id, {
+            "send_email": True, "send_telegram": False, "send_sms": False,
+        })
+        # Dauerhafter Auth-Fehler: `send()` bricht ohne Retry und ohne
+        # Ersatzweg ab -- derselbe Fehlerpfad wie ein ablehnender Postausgang,
+        # aber ohne Wartezeit im Testlauf.
+        netzrand.smtp_fehler = smtplib.SMTPAuthenticationError(
+            535, b"5.7.8 Authentication credentials invalid",
+        )
+
+        with caplog.at_level(logging.INFO):
+            with pytest.raises(OutputError):
+                _versenden(user_id, trip_id)
+
+        assert netzrand.smtp, "SMTP-Steckdose wurde nie erreicht"
+        assert _erfolgszeilen(caplog) == [], (
+            "Ohne Zustellung darf keine Erfolgszeile -- und damit kein "
+            "Empfaenger als 'zugestellt' -- im Protokoll stehen."
+        )
+        fehlerzeilen = [
+            r.getMessage() for r in caplog.records
+            if "E-Mail send failed" in r.getMessage()
+        ]
+        assert fehlerzeilen, (
+            "Der bestehende Fehlerpfad (notification_service.py:409) muss "
+            "unveraendert melden."
+        )
+        assert _log_eintraege(user_id) == [], (
+            "Kein briefing_log-Eintrag ohne Zustellung -- ein Eintrag mit "
+            "channels=[] taeuschte der Cockpit-Kachel (#393/#1007) einen "
+            "Versand vor."
+        )


### PR DESCRIPTION
Behebt den tragfähigen Kern von #1847. Das gemeldete Symptom selbst war **kein Bug**: die Mails lagen in `gregor-staging@henemm.com`, sekundengenau passend zum Protokoll — `/var/lib/gregor-staging/users/default/user.json` trug seit dem 14.08. um 16:08 ein abweichendes `mail_to`. Das ist die **vierte** Wiederholung derselben Falle (#1351, #1403, #1782, #1847), und sie kostete jedes Mal Stunden, weil der Trip-Briefing-Pfad den Empfänger nicht protokolliert. Im Compare-Pfad steht er seit jeher im Log (`scheduler_dispatch_service.py:571`) — dort war dieselbe Falle in einer Minute erledigt.

Der Staging-Datenstand wurde separat korrigiert (nicht Teil dieses PRs).

## Änderung

`src/services/trip_report_scheduler.py` (+36/−4):

- Erfolgszeile nennt die zugestellten Kanäle und — sofern E-Mail dabei war — den Empfänger:
  `Trip report sent: KHW 403 (morning) via email to gregor-test@henemm.com`
  Der Präfix `Trip report sent: <name> (<typ>)` bleibt wörtlich erhalten, weil Bestandstests darauf greifen.
- `_append_briefing_log()` schreibt `mail_to` bei tatsächlichem E-Mail-Versand. Rein additiv; `trip_id`/`kind`/`sent_at`/`channels`/`on_demand` unverändert. Go liest die Datei nur (`store.LoadBriefingLog`) und ignoriert unbekannte Felder.

**Unmaskiert, bewusst:** eine Maskierung wie `g***@henemm.com` hätte `gregor-test@` und `gregor-staging@` ununterscheidbar gemacht und den Zweck verfehlt. Der Compare-Pfad protokolliert ebenfalls unmaskiert; das Journal ist nur mit erhöhten Rechten lesbar.

## Tests

`tests/unit/test_briefing_recipient_logging.py` (neu) — fährt den **echten** Sendeweg und ersetzt ausschließlich die beiden Steckdosen `EmailOutput._dial_and_send` und `TelegramOutput._post`, dazu Dummy-Zugangsdaten per `monkeypatch.setenv`.

🔴 `can_send_email` und `_send_email` bleiben bewusst unangetastet — genau diese beiden hängen die Stellen aus, an denen der Empfänger überhaupt sichtbar wird. Der bestehende `test_trip_send_endpoint_no_channels.py` patcht beide und ist für diese Fehlerklasse deshalb blind.

**80 passed** über sechs Dateien (neue Suite, `test_trip_send_endpoint_no_channels`, `test_success_status_guard`, `test_mail_recipient_parity`, `test_briefing_log`, `test_briefing_slot_idempotenz`), gefahren mit `--allow-hosts=127.0.0.1,::1`.

**Mutations-Gegenprobe: 3 Mutationen, 3 Fänge.** Empfänger aus der Logzeile → AC-1 rot · `mail_to` aus dem Eintrag → AC-2 rot · Bedingung `"email" in sent_channels` entfernt → AC-3 rot. Vom Orchestrator unabhängig nachgestellt (M1), Prüfsumme nach Rückbau identisch.

## Bewusst nicht in dieser Scheibe

- `api/routers/scheduler.py:286` (`"sent": True` hartkodiert) — bereits als Verstoß **B1** in `tests/test_success_status_guard.py:1518` geführt.
- `EmailOutput.send() -> None` (kein Erfolgssignal an den Aufrufer) — eine Signaturänderung zieht das Renderer-Commit-Gate (#811) nach sich.

## Bekannte Grenze

Protokolliert wird der **konfigurierte** Empfänger (`settings.mail_to`), den `_send_email` ohne `to=`-Override an den Kanal gibt. Die Herkunftssperre #1476 kann den Empfänger im Kanal noch umschalten — das greift nur bei Testlauf-Herkunft und ist im Serverbetrieb nicht erreichbar. Im Fehlerbild von #1847 sind konfigurierter und tatsächlicher Empfänger identisch.

## Spec-Korrektur nach Freigabe

AC-4 verlangte ursprünglich die Warnzeile `Trip report NOT sent …`. Am Code nicht erreichbar: bei leerem `sent_channels` wirft `notification_service.py:527-528` weiter, `trip_report_scheduler.py:1522-1535` reicht durch — die Dreier-Auswertung wird nie betreten. Die zugesicherte **Wirkung** (kein stiller Erfolg, kein Log-Eintrag) ist unverändert. Fehler lag in der Spec, nicht in der Umsetzung; Begründung steht als Zitatblock unter AC-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkcADMkLBm15RZTFCusycW
