### PR TITLE
fix(#1851): Alarm-Tests stellen die Vorbedingung 'kein Briefing faellig' her

### DIFF
--- a/docs/context/fix-1851-alarm-zeitfenster-fixtures.md
+++ b/docs/context/fix-1851-alarm-zeitfenster-fixtures.md
@@ -1,0 +1,190 @@
+# Context: fix-1851-alarm-zeitfenster-fixtures
+
+Issue: [#1851](https://github.com/henemm/gregor_zwanzig/issues/1851) · `priority:high`, `session:taskforce`, `type:bug`
+Klassenfix der Fehlerart: #1709 · Gefunden bei: #1557
+
+## Request Summary
+
+Drei Tests in `tests/unit/test_alarm_zeitfenster_ziel.py` schlagen fehl
+(`assert []` — keine Alarm-Mail zugestellt). Sie blockieren den CI-`test`-Job
+und damit jede Auslieferung. **Der Mechanismus ist NICHT ermittelt.**
+
+## Gemessen (Fakten)
+
+| # | Messung | Ergebnis |
+|---|---|---|
+| 1 | CI `test`-Job auf `main`, Commit `57e36375`, 2026-08-14 20:22 UTC | **grün** |
+| 2 | CI `test`-Job auf PR #1853 (Basis `57e36375`), 2026-08-15 05:29 UTC | **rot**, exakt diese 3 Tests, keine weiteren |
+| 3 | Lokal, Vergleichs-Worktree auf **unverändertem** `origin/main`, 04:33 UTC | **3 failed, 9 passed** |
+| 4 | Lokal im Arbeitszweig (mit #1557-Fixture), 04:33 UTC | identisch `3 failed, 9 passed` |
+
+Aus 3+4 folgt: **unabhängig von #1557.** Aus 1+2 folgt: **derselbe Code, zwei
+Zeitpunkte, zwei Ergebnisse.**
+
+Betroffen:
+- `test_ac1_gewitter_17_uhr_am_tagesziel_wird_zugestellt`
+- `test_ac2a_gewitter_1845_knapp_vor_fensterende_wird_zugestellt`
+- `test_ac3_spaetankunft_2030_faellt_nicht_aus_der_ueberwachung`
+
+Nicht betroffen (grün): `test_ac2b_…1915_knapp_nach_fensterende_bleibt_aus`
+(erwartet **keine** Mail) und die neun übrigen Fälle der Datei.
+
+> Bemerkenswert: die drei Roten erwarten alle **eine Mail**, der grüne
+> Grenzfall erwartet **keine**. Ein Zustand, in dem generell keine Alarme
+> entstehen, würde exakt dieses Muster erzeugen — ist aber nicht belegt.
+
+## Was NICHT die Ursache ist (bereits ausgeschlossen)
+
+- **Nicht die #1557-Änderung** (Messung 3 vs. 4).
+- **Nicht der Tagesfenster-Randfall.** Bei AC-1 erscheint **keine**
+  `Ziel-Segment … liegt nach dem Tagesfenster-Ende`-Warnung. Der
+  Produktivcode `src/services/trip_segments.py:250-295` verhält sich
+  #1584-konform: das Zielsegment endet am Tagesfenster (19:00 Ortszeit),
+  nicht bei Ankunft+2h. Die „Ankunft + 2 h"-Formulierung steht nur im
+  **Assertion-Text des Tests** und beschreibt den alten Bug von #1584 —
+  nicht das beobachtete Verhalten.
+- **Rechnerisch müsste AC-1 grün sein:** Ankunft 13:18 Ortszeit (Europe/Vienna,
+  UTC+2) = 11:18 UTC, Fensterende 19:00 Ortszeit = 17:00 UTC, Gewitter 17:00
+  Ortszeit = 15:00 UTC — liegt im Segment.
+
+## Offene Frage (Kern der Analyse)
+
+**Warum entsteht kein Alarm, obwohl das Segment das Gewitter abdeckt?**
+
+Prüfrichtungen, keine davon bestätigt:
+
+1. **Erster Verdacht — #1594.** Der Basis-Commit `57e36375` ist der Merge von
+   `fix-1594-alarm-vorlauf-sperre`, also einer Änderung an der
+   **Alarm-Zeitsteuerung**. Wenn dort ein Vorlauf-Fenster eingeführt wurde
+   („nicht mehr als N Stunden im Voraus alarmieren"), erklärt das ein
+   Ergebnis, das von der Differenz zwischen Wanduhr und Gewitterzeitpunkt
+   abhängt. Zu prüfen: Was genau tut die Sperre, und greift sie hier?
+2. **Filterung im Alarmpfad.** `src/services/trip_alert.py` filtert Segmente
+   nach Zeitbezug (laut Projektwissen um `:1147-1150` herum „bereits
+   absolviert"). Der Helfer `_alarm_mails` (`:168-208`) umgeht laut eigenem
+   Docstring nur die `datetime.now()`-Filter der **Frisch-Beschaffung**, nicht
+   die des Alarm-Laufs selbst.
+3. **Geteilter Wetter-Cache.** `_alarm_mails` baut
+   `SegmentWeatherService(provider)` **ohne** expliziten Cache
+   (`:193`) — es greift der Prozess-Singleton. Die Datei hat zwar eine eigene
+   Reset-Fixture (`:60-64`), aber der Zusammenhang ist zu prüfen, nicht
+   anzunehmen.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `tests/unit/test_alarm_zeitfenster_ziel.py:168-208` | Helfer `_alarm_mails` — baut Etappe auf `date.today()`, Ankunft als Ortszeit-String |
+| `tests/unit/test_alarm_zeitfenster_ziel.py:113-145` | `_trip()` — Wegpunkte MIT `arrival_calculated`, Default-Tagesfenster 4/19 |
+| `tests/unit/test_alarm_zeitfenster_ziel.py:220-394` | **gehärtete** Fixture-Familie (Reykjavik UTC+0 / Auckland) aus #1667 S1 — die drei roten Fälle nutzen sie NICHT |
+| `src/services/trip_segments.py:250-295` | Zielsegment-Ende am Tagesfenster (#1584) inkl. Mindestfenster-Randfall |
+| `src/services/trip_alert.py` | Alarmlauf, Zeitfilter, `check_and_send_alerts` |
+| `src/app/day_window.py` | `DAY_WINDOW_END_HOUR = 19` |
+| #1594 / Commit `57e36375` | Alarm-Vorlaufsperre — erster Verdacht |
+
+## Risks & Considerations
+
+1. **Test- oder Produktdefekt ist offen — und das ist der Kern.** Wird hier
+   die Fixture „wanduhrunabhängig" gemacht, ohne den Mechanismus zu kennen,
+   und die Ursache liegt in Wahrheit im Alarmpfad, dann wird ein **echter,
+   nutzersichtbarer Ausfall zugekleistert**: Alarme am Tagesziel, die zu
+   bestimmten Zeiten nicht rausgehen. Genau das war der Fehler von #1584, und
+   genau dieser Fall zählt auf dem Karnischen Höhenweg.
+2. **Vorgeschichte mahnt zur Vorsicht.** Zu dieser Rot-Familie wurden bereits
+   **drei** Erklärungen als belegt behandelt, **zwei davon widerlegt**
+   („Ruhezeit unterdrückt nachts Alarme" stand 5 h falsch in #1196; dann ein
+   frei vermessenes Zeitfenster; erst die dritte Messung traf). Eine
+   wiederholte Beobachtung ist keine Ursache.
+3. **Nicht die Grenze vermessen.** Der dokumentierte Fehlgriff ist, das
+   Rot-Fenster immer feiner einzugrenzen, statt zu fragen *warum dort*.
+4. **Rerun ist nicht die Lösung.** Ein günstiger Zeitpunkt macht die Ampel
+   grün, ohne etwas zu beheben — im Projekt bereits einen Abend teuer gewesen.
+
+---
+
+# Analysis (Phase 2)
+
+## Ursache — gemessen, nicht hergeleitet
+
+```
+uv run pytest "tests/unit/test_alarm_zeitfenster_ziel.py::test_ac1_…" \
+  --allow-hosts=127.0.0.1,::1 -p no:randomly --log-cli-level=DEBUG
+→ DEBUG trip_alert:trip_alert.py:242 Alert suppressed: briefing imminent for trip t-221d3bd1
+```
+
+Die Alarme werden von der **Vorlaufsperre aus #1594** unterdrückt.
+
+Kette:
+1. `src/services/trip_alert.py:241` fragt `_is_briefing_imminent(trip, now_utc)`
+   **vor** jedem Abruf — der gemeinsame Adapter beider Trip-Alarmarten (`:715-741`).
+2. Der Adapter ruft `check_briefing_imminent` (`src/services/alert_gate.py:200`)
+   mit dem Fälligkeits-Prädikat `trip_briefing_due_at`
+   (`src/services/trip_report_scheduler.py:135`).
+3. Die Sperre ist wahr, wenn innerhalb von `BRIEFING_VORLAUF_MINUTEN` (60) ein
+   geplantes Briefing fällig **und** noch nicht versucht ist. Dann wird die
+   Meldung **ersetzt**, nicht verschluckt (ADR-0009): sie kommt Minuten später
+   vollständig im Briefing an.
+4. Die Test-Trips aus `_trip()` (`tests/unit/test_alarm_zeitfenster_ziel.py:113`)
+   tragen ein aktives `TripReportConfig` mit Vorgabe-Briefingzeiten. Je nach
+   echter Uhrzeit ist damit ein Briefing fällig — der Alarm wird
+   **planmäßig** unterdrückt und die Zusicherung „Mail kommt an" scheitert.
+
+## Test- oder Produktdefekt? → **Test**
+
+Der Produktivcode verhält sich **korrekt und beabsichtigt**. Die Sperre ist die
+zugesicherte Wirkung von #1594; sie unterdrückt nicht, sondern ersetzt.
+
+Die drei Tests stammen aus **#1584** und wurden geschrieben, **bevor** die
+Sperre existierte. Sie sichern zu „Gewitter am Tagesziel ⇒ Alarm wird
+zugestellt", ohne die Vorbedingung „und es steht kein Briefing an"
+herzustellen. Damit behaupten sie ein Verhalten, das das Produkt in diesem
+Zustand bewusst nicht zeigt.
+
+**Meine Diagnose in #1851 war falsch** („Fixture nimmt an, im Wandertag zu
+laufen"; Fixture-Ort nach Reykjavik verlegen). Sie war plausibel, passte zur
+Beobachtung „zeitabhängig" — und ist widerlegt: bei AC-1 erscheint keine
+Tagesfenster-Warnung, und die Rechnung liegt sauber im Segment. Wäre sie
+umgesetzt worden, hätte sie nichts behoben. Issue #1851 ist korrigiert.
+
+## Nebenbefund mit Gewicht: die Lücke ist beim Einbau der Sperre entstanden
+
+#1594 hat drei bestehende, fremde Tests von grün auf zeitabhängig-rot gekippt,
+**ohne dass es auffiel** — die eigene CI-Ampel lief abends, außerhalb der
+Briefing-Vorlauffenster. Der Effekt zeigt sich erst zu Tageszeiten, zu denen
+niemand liefert. Das ist keine Nachlässigkeit einer Person, sondern eine
+strukturelle Lücke: eine Verhaltensänderung im Alarmpfad kann bestehende
+Alarm-Tests kippen, und die Ampel misst das nur zu ihrer Laufzeit.
+
+## Lösungsrichtung
+
+Die drei Testfälle müssen die Vorbedingung **explizit herstellen**, statt sie
+vom Zufall der Uhrzeit abhängig zu machen: der Test-Trip darf kein fälliges
+Briefing haben. Kandidaten (in der Spec zu entscheiden):
+
+- `report_config.enabled = False` — laut `trip_briefing_due_at`-Docstring ein
+  zwingender Aktiv-Filter; das Prädikat wird damit immer falsch.
+- `paused_at` / `paused_until` setzen — dieselbe Wirkung über einen anderen Filter.
+
+Wichtig ist die **Absicht im Test sichtbar zu machen**: „dieser Trip hat kein
+geplantes Briefing, deshalb ist der Alarm die einzige Zustellform". Ein bloßes
+Verschieben der Uhrzeit wäre wieder nur eine Wanduhr-Wette.
+
+Der grüne Grenzfall `test_ac2b_…1915_knapp_nach_fensterende_bleibt_aus` erwartet
+**keine** Mail und ist deshalb heute aus dem falschen Grund grün — er würde
+auch bei generell unterdrückten Alarmen bestehen. Er gehört mitgehärtet, sonst
+bleibt eine Zusicherung ohne Aussagekraft.
+
+## Affected Files
+
+| Datei | Change | Beschreibung |
+|---|---|---|
+| `tests/unit/test_alarm_zeitfenster_ziel.py` | MODIFY | Test-Trips ohne fälliges Briefing; Absicht dokumentieren |
+| Produktivcode | — | **unverändert** |
+
+## Scope Assessment
+
+- Dateien: 1 · LoC: Produktiv +0, Test ca. +10/−2 · Risiko: **LOW**
+
+## Open Questions
+
+- Keine offenen fachlichen Fragen. Ursache gemessen, Zuordnung eindeutig.

--- a/docs/specs/modules/fix_1851_alarm_tests_vorlaufsperre.md
+++ b/docs/specs/modules/fix_1851_alarm_tests_vorlaufsperre.md
@@ -1,0 +1,278 @@
+---
+entity_id: fix_1851_alarm_tests_vorlaufsperre
+type: bugfix
+created: 2026-08-15
+updated: 2026-08-15
+status: draft
+workflow: fix-1851-alarm-zeitfenster-fixtures
+version: "1.0"
+tags: [issue-1851, tests, fixtures, alerts, briefing-vorlauf, adr-0009]
+---
+
+# Alarm-Zeitfenster-Tests: Vorbedingung „kein fälliges Briefing" herstellen
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Drei Tests in `tests/unit/test_alarm_zeitfenster_ziel.py`
+(`test_ac1_gewitter_17_uhr_am_tagesziel_wird_zugestellt`,
+`test_ac2a_gewitter_1845_knapp_vor_fensterende_wird_zugestellt`,
+`test_ac3_spaetankunft_2030_faellt_nicht_aus_der_ueberwachung`) schlagen
+abhängig von der realen Wanduhr fehl (`assert []`, keine Mail zugestellt).
+Ursache ist **kein** Produktdefekt, sondern eine fehlende Vorbedingung in der
+Testfixture: die Alarm-Vorlaufsperre aus #1594 unterdrückt den Alarm
+planmäßig, sobald für den Test-Trip zufällig ein Briefing fällig ist — die
+Meldung wird dann korrekt ERSETZT statt verschluckt (ADR-0009), nur eben
+nicht als eigenständiger Alarm zugestellt, was die Tests nicht erwarten.
+Diese Spec beschreibt, wie die drei Tests (und der bislang aus dem falschen
+Grund grüne Grenzfall `test_ac2b_…`) die Vorbedingung „für diesen Trip steht
+kein Briefing an" **aktiv herstellen**, statt sie vom Zufall der Uhrzeit
+abhängig zu machen.
+
+## Source
+
+- **File:** `tests/unit/test_alarm_zeitfenster_ziel.py`
+- **Identifier:** `_trip()` (Zeile 113-150) — gemeinsamer Fixture-Konstruktor
+  für alle zwölf Testfälle der Datei
+
+**Ursachenkette (gemessen, s. `docs/context/fix-1851-alarm-zeitfenster-fixtures.md`,
+Abschnitt „Analysis (Phase 2)"):**
+
+1. `src/services/trip_alert.py:241` — `_is_briefing_imminent(trip, now_utc)`
+   wird vor jedem Abruf gefragt; bei `True` bricht `check_and_send_alerts()`
+   mit `Alert suppressed: briefing imminent for trip …` ab (Zeile 242-243).
+2. `_is_briefing_imminent()` (`trip_alert.py:715-741`) ruft
+   `check_briefing_imminent()` (`src/services/alert_gate.py:200`) mit dem
+   Prädikat `trip_briefing_due_at` (`src/services/trip_report_scheduler.py:135`).
+3. `trip_briefing_due_at()` ist wahr, wenn irgendwann in
+   `[jetzt, jetzt + BRIEFING_VORLAUF_MINUTEN]` (60 min) ein geplantes
+   Briefing fällig ist **und** noch nicht versucht wurde
+   (`trip_report_scheduler.py:135-201`).
+4. `_trip()` (`tests/unit/test_alarm_zeitfenster_ziel.py:141-143`) setzt ein
+   aktives `TripReportConfig` mit den Vorgabezeiten `morning_time=07:00`,
+   `evening_time=18:00` (Default, `src/app/models.py:1042-1043`) — je nach
+   echter Wanduhr fällt der Testlauf in eines der beiden 3-Stunden-
+   Nachholfenster (`NACHHOL_FENSTER_STUNDEN=3`,
+   `trip_report_scheduler.py:106,188-189`) und der Alarm wird planmäßig
+   unterdrückt.
+
+**Produktivcode ist korrekt und bleibt unverändert.** Die drei Tests stammen
+aus #1584 und wurden geschrieben, bevor die Sperre aus #1594 existierte; sie
+sichern zu „Gewitter am Tagesziel ⇒ Alarm wird zugestellt", ohne die
+Vorbedingung „und es steht kein Briefing an" herzustellen.
+
+> **Schicht-Hinweis:** Ausschließlich `tests/unit/test_alarm_zeitfenster_ziel.py`.
+> **Kein** Eingriff in `src/`, `api/`, `internal/`, `frontend/`, `cmd/` — die
+> Sperre aus #1594 verhält sich korrekt und wird nicht angefasst (s. AC-5).
+
+## Scope
+
+### Gewählte Lösung: `report_config.enabled = False`
+
+`trip_briefing_due_at()` prüft drei unabhängige, ODER-freie Aktiv-Filter, von
+denen jeder allein genügt, das Prädikat dauerhaft falsch zu machen
+(`trip_report_scheduler.py:167-178`, Docstring Zeile 153-156):
+`trip.paused_at`, `report_config.enabled`, `report_config.paused_until`.
+
+Gewählt wird **`report_config.enabled = False`** (Zeile 171:
+`if rc.enabled is False: return False`), nicht `trip.paused_at` oder
+`paused_until`. Begründung:
+
+1. **Kein Nebeneffekt außerhalb der Briefing-Fälligkeit.** `report_config.enabled`
+   wird im gesamten `src/`-Baum ausschließlich für die
+   Briefing-Fälligkeitsprüfung gelesen (`trip_report_scheduler.py:171,891`,
+   `app/loader.py:628-629,1608` — reine Persistenz/Anzeige). `trip.paused_at`
+   dagegen bedeutet fachlich „der ganze Trip ist pausiert" und wird an
+   anderer Stelle roundtrip-persistiert (`app/loader.py:1486-1487`) — eine
+   unpassende Nebenbedeutung für einen Test, der ausdrücklich NUR das
+   Briefing abschalten will, während der Alarmpfad weiter aktiv sein soll.
+2. **Absicht ist lesbar.** `TripReportConfig(..., enabled=False)` liest sich
+   im Testcode unmittelbar als „für diesen Trip ist kein Briefing geplant" —
+   exakt die Vorbedingung, die hergestellt werden soll.
+3. **`paused_until` wäre gleichwertig, aber unnötig komplexer** (verlangt
+   einen Zeitstempel in der Zukunft statt eines Bool). Kein fachlicher Vorteil
+   gegenüber `enabled=False` für diesen Zweck.
+
+### Affected Files
+
+| Datei | Change | Beschreibung |
+|---|---|---|
+| `tests/unit/test_alarm_zeitfenster_ziel.py` | MODIFY | `_trip()`: `report_config.enabled=False` setzen und Absicht kommentieren; `test_ac2b_…` unverändert lassen (besteht danach aus dem richtigen Grund, s. AC-4); neue Testfunktion für die Gegenprobe (AC-2) |
+| Produktivcode (`src/`, `api/`, `internal/`, `frontend/`, `cmd/`) | — | **unverändert** (AC-5) |
+
+### Estimated Changes
+
+- Files: 1
+- LoC: Produktiv +0/−0, Test ca. +25/−1
+
+## Implementation Details
+
+**1. `_trip()` (Zeile 141-143) ergänzen:**
+
+```
+trip.report_config = TripReportConfig(
+    trip_id=trip_id, send_email=True, alert_on_changes=True,
+    enabled=False,  # #1851: kein Briefing geplant -> Alarm ist die
+                    # einzige Zustellform, unabhaengig von der Wanduhr
+)
+```
+
+Damit ist `trip_briefing_due_at()` für jeden mit `_trip()` gebauten Trip zu
+jedem `moment` `False` (Zeile 171 greift zuerst, vor jeder Zeitrechnung) —
+`_is_briefing_imminent()` liefert nie mehr `True`, die Sperre kann die drei
+betroffenen Tests nicht mehr treffen, unabhängig von der Wanduhr beim
+Testlauf.
+
+**2. `test_ac2b_gewitter_1915_knapp_nach_fensterende_bleibt_aus` bleibt
+unverändert im Code**, profitiert aber automatisch von derselben
+Fixture-Änderung (nutzt `_alarm_mails()` → `_trip()`). Sein
+`assert not mails` ist danach aus dem fachlich richtigen Grund grün: das
+Gewitter um 19:15 Ortszeit liegt außerhalb des Tagesfensters — nicht, weil
+irgendein Alarm generell unterdrückt würde. Beleg dafür ist der Vergleich mit
+`test_ac2a_…` (identische Fixture-Familie, Gewitter 18:45 **innerhalb** des
+Fensters, erwartet `mails`) — beide Tests zusammen zeigen, dass die Fixture
+zwischen „drin" und „draußen" unterscheidet, nicht pauschal unterdrückt
+(s. AC-4).
+
+**3. Neue Testfunktion für die Gegenprobe (AC-2):** baut zwei Varianten
+desselben AC-1-Szenarios (Ankunft 13:18 Ortszeit, Gewitter 17:00 Ortszeit,
+`ALPEN_LAT`/`ALPEN_LON`):
+
+- **Variante A (unrepariert simuliert):** `report_config.enabled=True`
+  (Ausgangszustand vor dieser Scheibe) UND zusätzlich `morning_time` auf die
+  aktuelle Ortsstunde des Trips gesetzt — `stunde =
+  trip_local_now(trip, datetime.now(timezone.utc)).hour`, dann
+  `rc.morning_time = time(stunde, 0)`. Da `_slot_stunde()`
+  (`trip_report_scheduler.py:123-132`) nur `.hour` liest und
+  `trip_briefing_due_at()` das Nachholfenster `[stunde, stunde+3)` gegen die
+  **Ortsstunde des Testlaufs selbst** prüft (Zeile 188-189), trifft dieses
+  Fenster garantiert den Testlauf-Zeitpunkt — unabhängig davon, wann der Test
+  tatsächlich läuft, weil die Stunde relativ zu `datetime.now()` berechnet
+  wird, nicht fest verdrahtet ist. Das stellt „ein Briefing wäre unmittelbar
+  fällig" **aktiv her**, ohne auf eine Tageszeit zu warten.
+- **Variante B (repariert):** identischer Trip, aber `report_config.enabled=False`
+  (die Fixture-Änderung dieser Scheibe).
+
+Beide Varianten laufen über `_alarm_mails()`/`check_and_send_alerts()` mit
+demselben Gewitter (17:00 Ortszeit). Erwartung: Variante A liefert **keine**
+Mail (Beleg, dass die Vorlaufsperre für diese Konfiguration real greift —
+nicht nur behauptet), Variante B liefert eine Mail (Beleg, dass die Scheibe
+die Sperre für die Test-Fixtures tatsächlich neutralisiert).
+
+## Beweiskette geschlossen (nachgemessen 2026-08-15)
+
+Die Vorgabe-Briefingzeiten sind **07:00 und 18:00 Ortszeit**
+(`src/app/models.py:1042-1043`), das Fälligkeitsfenster ist drei Stunden breit
+(`NACHHOL_FENSTER_STUNDEN`, `src/services/trip_report_scheduler.py`). Damit
+erklären sich **beide** Beobachtungen mit demselben Mechanismus:
+
+| Lauf | Ortszeit (Europe/Vienna) | Briefing fällig? | Ergebnis |
+|---|---|---|---|
+| CI auf `main`, 2026-08-14 20:22 UTC | 22:22 | nein (Abendfenster 18:00–21:00 zu) | **grün** |
+| CI auf PR #1853, 2026-08-15 05:29 UTC | 07:29 | ja (Morgenfenster 07:00–10:00 offen, nicht versucht) | **rot** |
+
+Es gibt also keine unerklärte „Kippkante" mehr, die noch zu vermessen wäre.
+
+## Acceptance Criteria
+
+- **AC-1 (alle Fälle wanduhrunabhängig grün):** Given die drei betroffenen
+  Testfälle (`test_ac1_…`, `test_ac2a_…`, `test_ac3_…`) nach der
+  Fixture-Änderung dieser Scheibe / When
+  `uv run pytest tests/unit/test_alarm_zeitfenster_ziel.py -v --allow-hosts=127.0.0.1,::1 -p no:randomly`
+  läuft / Then sind alle 12 Testfälle der Datei grün, unabhängig von der
+  realen Wanduhrzeit beim Lauf.
+  - Test: kompletter Lauf der Datei; Assert Exit 0, keine `assert []`-Fehlschläge
+    mehr in den drei genannten Funktionen. Da `report_config.enabled=False`
+    die Fälligkeitsprüfung strukturell abschaltet (kein Zeitvergleich mehr
+    beteiligt, Zeile 171 greift vor jeder Zeitrechnung), genügt EIN Lauf als
+    Nachweis — es gibt keine Kippkante mehr, die zu einer bestimmten Uhrzeit
+    erneut prüfbar wäre.
+
+- **AC-2 (Gegenprobe — Sperre aktiv herstellen statt abwarten, wichtigster AC):**
+  Given ein Testfall baut Variante A (`report_config.enabled=True`,
+  `morning_time` auf die aktuelle Ortsstunde des Trips gesetzt — berechnet
+  relativ zu `datetime.now()` im Testlauf, s. Implementation Details Punkt 3)
+  und Variante B (`report_config.enabled=False`) desselben AC-1-Szenarios
+  (Ankunft 13:18 Ortszeit, Gewitter 17:00 Ortszeit) / When beide Varianten
+  über `_alarm_mails()` laufen / Then bleibt Variante A ohne zugestellte Mail
+  (die Vorlaufsperre greift nachweislich — der Mechanismus ist real, nicht
+  nur vermutet) und Variante B liefert eine zugestellte Mail (der Fix
+  neutralisiert die Sperre für die Test-Fixtures tatsächlich) — beides ohne
+  auf eine bestimmte Tageszeit zu warten oder eine Test-Uhr zu stellen.
+  - Test: neue Testfunktion mit beiden Varianten; `assert not mails_a`,
+    `assert mails_b`. Kein `freeze_time`, keine Wartezeit — die
+    Briefingzeit von Variante A wird aus der Ortsstunde zum Ausführungszeitpunkt
+    selbst abgeleitet und ist damit bei jedem Lauf diskriminierend.
+
+- **AC-3 (Zusicherung aus #1584 bleibt inhaltlich erhalten):** Given die vier
+  Testfälle `test_ac1_…`, `test_ac2a_…`, `test_ac2b_…`, `test_ac3_…` nach
+  dieser Scheibe / When sie ausgeführt werden / Then prüfen sie unverändert
+  dieselbe fachliche Aussage wie in #1584 spezifiziert — Gewitter
+  **innerhalb** des Tagesfensters ⇒ Alarm wird zugestellt, Gewitter
+  **außerhalb** ⇒ kein Alarm — nur mit korrigierter Vorbedingung, nicht mit
+  abgeschwächter Zusicherung.
+  - Test: Diff-Review der vier `assert`-Zeilen gegen den Stand vor dieser
+    Scheibe (`git diff`); Assert die Assertions selbst (nicht nur die
+    Fixture) sind unverändert bzw. semantisch gleichwertig.
+
+- **AC-4 (`test_ac2b` besteht aus dem richtigen Grund):** Given
+  `test_ac2b_gewitter_1915_knapp_nach_fensterende_bleibt_aus` und
+  `test_ac2a_gewitter_1845_knapp_vor_fensterende_wird_zugestellt` nutzen
+  nach dieser Scheibe dieselbe gehärtete Fixture (`_trip()` mit
+  `enabled=False`) / When beide Tests im selben Lauf ausgeführt werden /
+  Then liefert `test_ac2a_…` eine zugestellte Mail (Gewitter 18:45 Ortszeit,
+  innerhalb) und `test_ac2b_…` liefert keine (Gewitter 19:15 Ortszeit,
+  außerhalb) — das Paar beweist, dass `test_ac2b_…` wegen der
+  Tagesfenster-Grenze grün ist, nicht weil unter der gehärteten Fixture
+  generell keine Alarme mehr entstehen.
+  - Test: beide Tests im selben `pytest`-Lauf; Assert `test_ac2a_…` grün UND
+    `test_ac2b_…` grün. Wären beide aus „genereller Unterdrückung" grün,
+    müsste `test_ac2a_…` (das eine Mail erwartet) rot sein — sein Grün-Status
+    ist der Beleg.
+
+- **AC-5 (Nicht-Wirkung, Produktivcode unangetastet):** Given der
+  vollständige Diff dieser Scheibe / When
+  `git diff --stat origin/main...HEAD -- src/ api/ internal/ frontend/ cmd/`
+  ausgeführt wird / Then ist die Ausgabe leer — die Scheibe belegt damit
+  selbst, dass die Sperre aus #1594 unverändert bleibt und nur die
+  Testfixture angepasst wurde.
+  - Test: `git diff --stat` gegen den Merge-Basis-Commit über exakt diese
+    fünf Verzeichnisse; Assert leere Ausgabe (manueller Nachweis im PR, kein
+    neuer Pytest-Test nötig — repo-strukturelle Prüfung).
+
+## Test Plan
+
+### Automated Tests (TDD RED)
+
+- [ ] AC-2 (Gegenprobe): Neue Testfunktion `test_gegenprobe_vorlaufsperre_wird_durch_fix_neutralisiert` (Arbeitsname) — Variante A rot vor dem Fix (Alarm bleibt aus trotz Gewitter im Fenster, weil `enabled=True` + fällige Briefingzeit), Variante B grün nach dem Fix.
+- [ ] AC-1/AC-3/AC-4: Die drei bestehenden roten Tests werden durch die Fixture-Änderung grün, ohne dass ihre `assert`-Aussagen sich ändern; `test_ac2b_…` bleibt unverändert im Code und wird im selben Lauf gegen `test_ac2a_…` als Paar geprüft.
+
+## Known Limitations
+
+- **Die Sperre selbst (#1594) wird nicht angefasst.** Sie verhält sich
+  korrekt (ADR-0009: ersetzen, nicht verschlucken) — diese Scheibe ändert
+  nichts an ihrem Verhalten, nur an der Testvorbedingung.
+- **Kein neuer Wächter gegen „Verhaltensänderung im Alarmpfad kippt
+  bestehende Alarm-Tests".** Der Nebenbefund aus der Analyse — die eigene
+  CI-Ampel von #1594 lief abends und sah die Kippung der drei Tests nicht,
+  weil der Effekt nur innerhalb der Briefing-Vorlauffenster sichtbar wird —
+  ist damit **nicht behoben**, sondern nur benannt. Gehört in die
+  Nebenbefund-Sammlung (#1199), nicht in diese Scheibe.
+- **Andere Testdateien der Wanduhr-Familie (#1709) bleiben unberührt.** Nur
+  `tests/unit/test_alarm_zeitfenster_ziel.py` ist Gegenstand dieser Scheibe.
+
+## Nicht in dieser Scheibe
+
+- Kein Eingriff in `src/services/trip_alert.py`, `alert_gate.py` oder
+  `trip_report_scheduler.py`.
+- Kein neues Gate/keine neue Dauerregel gegen zukünftige Kollisionen
+  zwischen Alarm-Zeitsteuerungs-Änderungen und bestehenden Alarm-Tests.
+- Keine Sanierung weiterer, möglicherweise ähnlich betroffener Testdateien
+  außerhalb der genannten Datei — nicht durchsucht, nicht Teil dieser Spec.
+
+## Changelog
+
+- 2026-08-15: Initial spec created

--- a/tests/unit/test_alarm_zeitfenster_ziel.py
+++ b/tests/unit/test_alarm_zeitfenster_ziel.py
@@ -41,6 +41,7 @@ from app.models import (
 from app.trip import Stage, Trip, Waypoint
 from services.segment_weather import SegmentWeatherService
 from services.trip_alert import TripAlertService
+from services.trip_day import trip_local_now
 from services.trip_segments import convert_trip_to_segments
 from services.weather_cache import reset_shared_weather_cache_for_tests
 from utils.timezone import tz_for_coords
@@ -140,6 +141,14 @@ def _trip(
     )
     trip.report_config = TripReportConfig(
         trip_id=trip_id, send_email=True, alert_on_changes=True,
+        # #1851: dieser Trip hat bewusst KEIN geplantes Briefing, sonst
+        # ersetzt die Vorlaufsperre aus #1594 (trip_alert.py:241 ->
+        # alert_gate.py:200 -> trip_report_scheduler.py:135/171) den Alarm
+        # planmaessig durch das faellige Briefing (ADR-0009: ersetzen, nicht
+        # verschlucken) -- abhaengig von der Wanduhr beim Testlauf. Der Alarm
+        # bleibt damit die einzige Zustellform, unabhaengig davon, wann der
+        # Test laeuft.
+        enabled=False,
     )
     if day_window is not None:
         trip.report_config.day_window_start_hour = day_window[0]
@@ -168,6 +177,7 @@ def _calm(segment) -> SegmentWeatherData:
 def _alarm_mails(
     lat: float, lon: float, arrival_local: str, thunder_hour: int,
     day_window: tuple[int, int] | None = None,
+    trip: Trip | None = None,
 ) -> list:
     """Ein vollstaendiger Alarm-Lauf; gibt die tatsaechlich zugestellten
     Mails zurueck.
@@ -177,10 +187,16 @@ def _alarm_mails(
     fetch_segment_weather(..., priority="alert_check")``, Fehler pro Segment
     verschluckt) — nur die dortigen ``datetime.now()``-Filter entfallen,
     damit der Test nicht von der realen Uhrzeit abhaengt.
+
+    ``trip`` optional: wird kein Trip uebergeben, baut die Funktion ihn wie
+    bisher selbst ueber ``_trip()`` (alle bestehenden Aufrufer). Die
+    Gegenprobe (#1851, AC-2) braucht dagegen einen Trip mit modifiziertem
+    ``report_config`` (Variante A/B) VOR dem Alarm-Lauf.
     """
     tz = tz_for_coords(lat, lon)
     day = date.today()
-    trip = _trip(f"t-{uuid.uuid4().hex[:8]}", lat, lon, day, arrival_local, day_window)
+    if trip is None:
+        trip = _trip(f"t-{uuid.uuid4().hex[:8]}", lat, lon, day, arrival_local, day_window)
 
     segments = convert_trip_to_segments(trip, day)
     anchor = datetime.combine(day - timedelta(days=1), time(0, 0), tzinfo=timezone.utc)
@@ -428,6 +444,64 @@ def test_ac1_gewitter_17_uhr_am_tagesziel_wird_zugestellt():
     )
 
 
+def test_gegenprobe_vorlaufsperre_wird_durch_fix_neutralisiert():
+    """AC-2 (wichtigster AC): stellt die Sperre AKTIV her, statt auf eine
+    Tageszeit zu warten — kein ``freeze_time``, keine gestellte Uhr.
+
+    Baut zweimal denselben AC-1-Fall (Ankunft 13:18 Ortszeit, Gewitter 17:00
+    Ortszeit, ALPEN_LAT/ALPEN_LON):
+
+    - Variante A (Ausgangszustand vor #1851): ``report_config.enabled=True``
+      UND ``morning_time`` auf die AKTUELLE Ortsstunde des Trips gesetzt
+      (relativ zu ``datetime.now()`` im Testlauf) -> das Nachhol-Fenster
+      [Stunde, Stunde+3) aus #1594 trifft garantiert den Testlauf-Zeitpunkt,
+      egal wann der Test laeuft. Die Vorlaufsperre muss den Alarm
+      unterdruecken -> KEINE Mail.
+    - Variante B (Fixture-Haertung dieser Scheibe): identischer Trip, aber
+      ``report_config.enabled=False`` -> die Sperre ist neutralisiert, der
+      Alarm muss zugestellt werden.
+    """
+    day = date.today()
+
+    trip_a = _trip(f"t-{uuid.uuid4().hex[:8]}", ALPEN_LAT, ALPEN_LON, day, "13:18")
+    trip_a.report_config.enabled = True
+    stunde_jetzt = trip_local_now(trip_a, datetime.now(timezone.utc)).hour
+    trip_a.report_config.morning_time = time(stunde_jetzt, 0)
+    mails_a = _alarm_mails(ALPEN_LAT, ALPEN_LON, "13:18", 17, trip=trip_a)
+    assert not mails_a, (
+        "Gegenprobe Variante A: Mit faelligem Briefing (enabled=True, "
+        "morning_time=aktuelle Ortsstunde) muss die Vorlaufsperre aus #1594 "
+        "den Alarm unterdruecken. Tatsaechlich zugestellt: "
+        f"{[s for s, _ in mails_a]} — die Sperre greift hier nicht, obwohl "
+        "die Vorbedingung (faelliges, unversuchtes Briefing) aktiv "
+        "hergestellt wurde."
+    )
+
+    trip_b = _trip(f"t-{uuid.uuid4().hex[:8]}", ALPEN_LAT, ALPEN_LON, day, "13:18")
+    # #1851 Adversary-Finding F001: Variante B setzt dieselbe faellige
+    # Briefingzeit wie Variante A. Nicht, damit sie scheitert, sondern damit
+    # sie scheitert, WENN der Fix zurueckgenommen wird — sonst wacht diese
+    # Zusicherung nur in den drei Morgenstunden, in denen sie zufaellig
+    # geprueft wurde (Adversary-Finding F001). Ohne dieses Setzen haengt die
+    # Fangkraft an ``_trip()``s Default ``morning_time=07:00``: nur zwischen
+    # 07 und 10 Uhr Ortszeit faellt ein versehentlich zurueckgedrehtes
+    # ``enabled=True`` in der Fixture ueberhaupt auf (3 von 96 gescannten
+    # Zeitpunkten = 12,5 % des Tages). Mit der aktuellen Ortsstunde hat
+    # Variante B zu JEDER Tageszeit ein Briefing, das faellig WAERE — und
+    # bleibt trotzdem gruen, weil ``enabled=False`` die Faelligkeit
+    # strukturell abschaltet (trip_report_scheduler.py:171, Kurzschluss vor
+    # jeder Zeitrechnung). Wird ``enabled=False`` zurueckgedreht, wird
+    # Variante B zu JEDER Uhrzeit rot statt nur zwischen 07 und 10 Uhr.
+    trip_b.report_config.morning_time = time(stunde_jetzt, 0)
+    mails_b = _alarm_mails(ALPEN_LAT, ALPEN_LON, "13:18", 17, trip=trip_b)
+    assert mails_b, (
+        "Gegenprobe Variante B: Ohne faelliges Briefing (enabled=False, die "
+        "Fixture-Haertung aus #1851) muss der Alarm zugestellt werden. Es "
+        "kam KEINE Mail an — die Neutralisierung der Vorlaufsperre wirkt in "
+        "den Test-Fixtures nicht."
+    )
+
+
 def test_ac2a_gewitter_1845_knapp_vor_fensterende_wird_zugestellt():
     """AC-2a: Gewitter 18:45 Ortszeit — innerhalb 19:00, weit ausserhalb der
     alten 2-h-Grenze (15:18). Die diskriminierende Haelfte des Grenzwertpaars."""
@@ -442,7 +516,16 @@ def test_ac2a_gewitter_1845_knapp_vor_fensterende_wird_zugestellt():
 
 def test_ac2b_gewitter_1915_knapp_nach_fensterende_bleibt_aus():
     """AC-2b: Gewitter 19:15 Ortszeit — knapp ausserhalb 19:00. Bewacht die
-    PO-Vorgabe „kein naechtlicher Alarm" an der tatsaechlichen Grenze."""
+    PO-Vorgabe „kein naechtlicher Alarm" an der tatsaechlichen Grenze.
+
+    #1851 AC-4: seit der Fixture-Haertung in ``_trip()`` (``enabled=False``)
+    besteht dieser Test aus dem RICHTIGEN Grund — Gewitter ausserhalb des
+    Tagesfensters, nicht generell unterdrueckte Alarme. Beleg ist das Paar
+    mit ``test_ac2a_…`` (identische Fixture-Familie, Gewitter 18:45
+    INNERHALB des Fensters, erwartet eine Mail): waeren unter der gehaerteten
+    Fixture generell keine Alarme mehr moeglich, muesste ``test_ac2a_…`` rot
+    sein. Sein Gruen-Status im selben Lauf ist der Beleg.
+    """
     mails = _alarm_mails(ALPEN_LAT, ALPEN_LON, "13:18", 19)
     assert not mails, (
         "AC-2b: Ein Gewitter um 19:15 Ortszeit liegt ausserhalb der "


### PR DESCRIPTION
Behebt #1851. **Entblockt PR #1853** (#1557), der an genau diesen drei Tests scheitert.

## Befund

Drei Tests aus #1584 schlugen zeitabhängig fehl — morgens rot, abends grün, bei identischem Commit. Ursache **gemessen**, nicht hergeleitet:

```
DEBUG trip_alert.py:242 Alert suppressed: briefing imminent for trip …
```

Die **Vorlaufsperre aus #1594** unterdrückt den Alarm, wenn binnen 60 Minuten ein Briefing fällig und noch nicht versucht ist — die Meldung wird **ersetzt**, nicht verschluckt (ADR-0009). Vorgabezeiten 07:00/18:00 Ortszeit bei drei Stunden Fälligkeitsfenster erklären beide Beobachtungen:

| Lauf | Ortszeit | Fenster offen? | Ergebnis |
|---|---|---|---|
| CI auf main, 2026-08-14 20:22 UTC | 22:22 | nein | grün |
| CI auf PR #1853, 2026-08-15 05:29 UTC | 07:29 | ja | rot |

**Der Produktivcode ist korrekt und bleibt unverändert (+0/−0).** Die Tests stammen aus der Zeit vor der Sperre und stellen die Vorbedingung „es steht kein Briefing an" nicht her.

## Änderung

Eine Datei: `tests/unit/test_alarm_zeitfenster_ziel.py` (+85/−2).

1. `_trip()` setzt `report_config.enabled=False`. Das Feld wird produktiv **nur** in `src/services/trip_report_scheduler.py:171` und `:891` gelesen, beide im Briefing-Fälligkeitspfad, **nie** im Alarmpfad — nachgemessen. Die Zusicherung der Tests wird dadurch also nicht wirkungslos.
2. Neuer Testfall `test_gegenprobe_vorlaufsperre_wird_durch_fix_neutralisiert`: stellt die Sperre **aktiv her**, statt auf eine Tageszeit zu warten. Variante A (fälliges Briefing) darf **keine** Mail liefern — beweist, dass die Sperre real greift. Variante B (neutralisiert) **muss** eine liefern — beweist, dass der Fix wirkt. Kein `freeze_time`, keine gestellte Uhr.
3. Die vier `assert`-Zeilen von AC-1/AC-2a/AC-2b/AC-3 sind **byteidentisch** zum Vorzustand — die Zusicherung aus #1584 wurde nicht abgeschwächt, nur ihre Vorbedingung sauber gesetzt.

## Adversary: VERIFIED

Vier Mutationen, alle gefangen. Ein Befund war substanziell:

**F001 (MEDIUM, behoben):** Die *Regressions-Fangkraft* hing zunächst an `_trip()`s Default `morning_time=07:00` — ein versehentlich zurückgedrehtes `enabled=True` wäre nur zwischen 07 und 10 Uhr Ortszeit aufgefallen (per 96-Punkte-Scan über 24 h gemessen: 3 von 96 Zeitpunkten = 12,5 % des Tages). Unser Prüflauf lag zufällig darin. Behoben, indem auch Variante B ihre Briefingzeit aus der aktuellen Ortsstunde ableitet — jetzt greift die Fangkraft zu **jeder** Uhrzeit.

**F002 (LOW):** Zwischen der Berechnung der Ortsstunde und dem internen `now` des Alarmlaufs liegt ein Fenster von Millisekunden; kippt exakt dort die Stunde über Mitternacht, verliert Variante A ihre Trennschärfe. Als Kenntnisstand vermerkt.

Ehrlich benannt: `test_ac2b_…` ist **für sich allein** weiterhin nicht diskriminierend — es bestünde auch bei generell unterdrückten Alarmen. Erst im Paar mit `test_ac2a_…` trägt die Aussage. Per Sonde gemessen, nicht wohlwollend gelesen.

## Nachweise

- Datei: **13 passed** (vorher `3 failed, 9 passed`), Lauf um 09:20 Ortszeit — also **im** Morgenfenster, in dem die Sperre ohne Fix zugeschlagen hätte
- Zusammen mit den drei Suiten, die die Sperre selbst absichern (`test_briefing_imminent_gate`, `test_trip_alert_briefing_imminent`, `test_compare_alert_briefing_imminent`): **55 passed**
- `git diff --stat -- src/ api/ internal/ frontend/ cmd/` → leer

## Nicht in dieser Scheibe

Die Sperre selbst (verhält sich korrekt) und ein Wächter gegen „Verhaltensänderung im Alarmpfad kippt bestehende Alarm-Tests". Letzteres ist der eigentliche Nebenbefund: #1594 hat diese drei Tests gekippt, ohne dass es auffiel — die eigene Ampel lief abends, außerhalb der Vorlauffenster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoXrQwyCuBDmq2VHF3631n