### PR TITLE
fix(#1841): 3-Tages-Vorschau liest Gewitter aus dem Tagesfenster

### DIFF
--- a/docs/context/fix-1841-ausblick-metrik-tagesfenster.md
+++ b/docs/context/fix-1841-ausblick-metrik-tagesfenster.md
@@ -1,0 +1,212 @@
+# Context: fix-1841-ausblick-metrik-tagesfenster
+
+Issue: #1841 · Track: Full Process (Intake-Score 4/6) · Stand der Messung: `e6303c75` (origin/main, 2026-08-14)
+
+## Request Summary
+
+Der Trip-Ausblick der Vollmail zeigt seit #1720 S1 — sobald der Nutzer eine Ausblick-Spaltenauswahl gesetzt hat — die Gewitterstufe wieder aus dem auf die Gehzeit geklemmten Tages-Aggregat (`summary.thunder_level_max`) statt aus dem Tagesfenster (`thunder_day_token`), und kennt in diesem Zweig überhaupt keine Nachtangabe. Das ist dieselbe Fehlerklasse, die #1653 für die drei damaligen Ausgabeorte behoben hat.
+
+## Vorbedingung geprüft: was #1671 tatsächlich geliefert hat
+
+Der Intake-Kommentar zu #1841 verlangte ausdrücklich, dies zu **messen** statt aus der Spec zu lesen. Ergebnis:
+
+| Spec-Absicht (#1671) | Gemessene Lieferung |
+|---|---|
+| Helfer in `helpers.py` | **Eigenes Modul** `src/output/renderers/email/thunder_branch.py` — bewusste Abweichung, Begründung im Modul-Docstring (kein Import von `helpers`, keine Zirkelimport-Gefahr) |
+| `resolve_thunder_day_branch()` | vorhanden, `thunder_branch.py:54`, drei Zweige `day` / `none` / `plain` |
+| `_thunder_token_parts()` dorthin verschoben | vorhanden, `thunder_branch.py:35` |
+| Aufrufer | drei: `compact.py:94`, `outlook.py:358` (Klartext-**Alt**pfad), `narrow.py:593` |
+
+Der Baustein, den #1841 braucht, existiert also. Der Metrik-Zweig ist schlicht **kein vierter Aufrufer**.
+
+## Befund am aktuellen Stand bestätigt
+
+| Behauptung des Issues | Messung |
+|---|---|
+| Metrik-Zweig liest `getattr(summary, col["field"])` | bestätigt, `outlook.py:581-587` — Aggregat-Quelle |
+| Keine Nachtangabe im Metrik-Zweig | bestätigt, `thunder_night_token` kommt in `outlook.py` nur bei `:394` (Altpfad) vor |
+| Altpfad unberührt | bestätigt, früher `return` in `outlook.py:146` (HTML) bzw. `continue` in `:339` (Klartext) greifen nur bei `metrics is not None` |
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/output/renderers/email/outlook.py` | **Wirkort.** `build_outlook_row()` ab `:416`; Metrik-Zweig `:564-587`; HTML-Renderstelle `:136-152`; Klartext-Renderstelle `:328-339`; Altpfad mit Tag/Nacht `:358-394` |
+| `src/output/renderers/email/thunder_branch.py` | geteilte Zweigwahl aus #1671 — der Baustein, der im Metrik-Zweig fehlt |
+| `src/output/renderers/email/helpers.py` | `format_trend_tokens()`; erzeugt `thunder_day_token`/`thunder_night_token`/`thunder_day_origin` ab `:1005` aus `stage["hourly_thunder"]` + Tagesfenster |
+| `src/output/renderers/compare_outlook_metric_ids.py` | `resolve_outlook_metrics()` `:45` (Compare), `resolve_trip_outlook_metrics()` `:78` (Trip); `format_outlook_value()` / `outlook_columns()` |
+| `src/output/renderers/email/compare_html.py` | Compare-Zeilenbau `:1168`, Compare-HTML-Renderstelle `:1242` |
+| `src/services/trip_report_scheduler.py` | Trip-Zeilenbau `:2200` |
+| `src/output/renderers/email/html.py` | Trip-HTML-Renderstelle `:1364` |
+| `src/output/renderers/email/plain.py` | Trip-Klartext-Renderstelle `:344` |
+| `src/output/renderers/comparison.py` | Compare-Klartext-Renderstelle `:360` |
+
+## Aufrufgraph (gemessen)
+
+```
+TRIP                                        COMPARE
+trip_report_scheduler.py:2200               compare_html.py:1168
+  build_outlook_row(                          build_outlook_row(
+    trip_display_config=dc,                     metrics=outlook_metrics,
+    report_type=...,                          )   # KEIN Tagesfenster
+    day_window_start_hour=…,                  #  KEIN trip_display_config
+    day_window_end_hour=…)
+        │                                           │
+        └─ metrics = resolve_trip_outlook_metrics() └─ metrics kommt fertig herein
+                        (outlook.py:462-467)
+        ▼                                           ▼
+html.py:1364  render_outlook_table()        compare_html.py:1242 render_outlook_table()
+plain.py:344  render_outlook_plain()        comparison.py:360    render_outlook_plain()
+```
+
+**Der Trip/Compare-Diskriminator existiert bereits am Wirkort:** Der Trip reicht `trip_display_config` + `report_type` + Tagesfenster durch und lässt `build_outlook_row` selbst auflösen; der Ortsvergleich übergibt ein fertiges `metrics` und **kein** Tagesfenster. `outlook.py:459` hält das ausdrücklich fest („Ein ausdrückliches `metrics` hat Vorrang (Compare-Pfad unverändert)").
+
+## Struktureller Kern
+
+`format_trend_tokens(stage)` ist eine **reine Funktion des Zeilen-Dicts** — sie liest ausschließlich `stage`-Schlüssel (`hourly_thunder`, `day_window_start_hour`/`_end_hour`, `hourly_thunder_signals`). Alle diese Schlüssel liegen in `row`, **bevor** der Metrik-Zweig bei `outlook.py:564` beginnt (`row.update(optional)` steht bei `:562`).
+
+Der Fix ist damit **innerhalb von `build_outlook_row()` möglich** und muss nicht an beiden Renderstellen dupliziert werden — was zugleich HTML und Klartext in einem Zug erledigt.
+
+Die frühere Vermutung, der Fix müsse an die Renderstellen (weil dort `tok` liegt), ist damit widerlegt.
+
+## Existing Patterns
+
+- **Geteilte Zweigwahl statt vierter Kopie** (#1671, ADR-0055): `resolve_thunder_day_branch(tok, stage)` entscheidet, jeder Aufrufer formatiert selbst.
+- **Additive Spalten-Eigenschaften**: `outlook.py:573-585` reicht `hail` und `signals` als Zusatzschlüssel des Spalten-Dicts an `format_outlook_value()` durch. Eine geänderte Quelle könnte demselben Muster folgen.
+- **Stufe und Herkunft aus DEMSELBEN Fenster**: `helpers.py:1025-1035` und der Kommentar `outlook.py:574-579` halten fest, dass eine Herkunft aus einem anderen Fenster als die gezeigte Stufe der AC-12-Fehler aus #1680 Scheibe 1 wäre.
+
+## Dependencies
+
+- **Upstream:** `summarize_points()` / `aggregate_stage()` → `SegmentWeatherSummary`; `resolve_configured_window()` (Tagesfenster aus `trip.report_config`); `render_threshold_peak_value()`; `union_of_max_carriers()` / `thunder_signal_label()`.
+- **Downstream:** Trip-Vollmail HTML + Klartext; Ortsvergleich-Mail HTML + Klartext. `build_outlook_row` ist ausdrücklich der **eine** bewusst geteilte Trip/Compare-Baustein (`tests/unit/test_notification_service.py:191` führt genau diesen Import als einzige erlaubte Ausnahme).
+
+## Existing Specs
+
+| Spec | Bezug |
+|---|---|
+| `docs/specs/modules/feat_1720_s1_trip_ausblick_metriken.md` | hat den Metrik-Zweig für den Trip geöffnet; erwähnt Gewitter/Tagesfenster/Nacht nicht |
+| `docs/specs/modules/fix_1671_kompaktmail_ausblick_tagesfenster.md` | grenzt diesen Befund unter „Nicht in dieser Scheibe" ab; liefert den geteilten Helfer |
+| #1653 (Tag/Nacht-Trennung) | Ursprungsentscheid: Gehzeit-Aggregat ist für den Trip falsch |
+| `feat_1680_s5a` AC-11b | Gegenentscheid für den **Ortsvergleich**: dort ist das Tages-Aggregat richtig |
+| ADR-0055 | „drei Auflösungen derselben Frage" — die Regel, gegen die #1720 S1 verstieß |
+
+## Risks & Considerations
+
+1. **🔴 Ein bestehender Test verbietet den naiven Fix.**
+   `tests/tdd/test_outlook_day_night_thunder_split.py:665` (`test_compare_metrics_cells_unaffected_by_day_night_split`) sichert zu, dass `row["cells"]` **mit und ohne** `day_window_*` identisch bleibt — aufgerufen mit `metrics=` und ohne `trip_display_config`. Der Test kann Trip und Compare nicht unterscheiden; er prüft nur „cells reagieren nicht auf das Tagesfenster".
+   ⇒ Ein Fix, der am Tagesfenster allein ansetzt, macht diesen Test rot. Ein Fix, der am **Trip-Diskriminator** (`trip_display_config`/`report_type`) ansetzt, lässt ihn grün — und das ist auch fachlich richtig, weil AC-11b für Compare weiter gilt.
+
+2. **🔴 Ein zweiter Test verbietet Trip-Formatierung im Compare-Zweig.**
+   `test_compare_plain_carries_no_trip_format_remnants` (`:645`) verbietet `"⚡"`, `"°C"`, `"↳"` und `"nachts"` in der Compare-Klartext-Ausgabe des Metrik-Zweigs. Eine Nachtangabe oder ein Blitz-Präfix darf also niemals im Compare-Pfad landen.
+
+3. **🔴 Compare hat sehr wohl eine Stundenreihe.**
+   `compare_html.py:1168` übergibt `day_points` an `build_outlook_row` — `hourly_thunder` ist für Compare-Zeilen also **befüllt**. Der Docstring von `resolve_thunder_day_branch` (`thunder_branch.py:65-68`) beschreibt `"plain"` als „keine Stundenreihe (Alt-Aufrufer/**Compare**)". Diese Zuordnung trägt für den Ausblick **nicht**: ein blindes `resolve_thunder_day_branch()` im Metrik-Zweig würde für Compare `"day"`/`"none"` liefern und damit dessen 24-Stunden-Aggregat auf ein Tagesfenster verengen — genau das, was AC-11b ausschließt. (Für Compare ist das Aggregat korrekt, weil es über den **Kalendertag** gebildet wird, nicht über die Gehzeit.)
+
+4. **Stufe und Herkunft hängen zusammen.**
+   `outlook.py:580` reicht `summary.thunder_level_max_signals` als Herkunft mit — dieselbe Rechnung wie die gezeigte Stufe. Wird die Stufe auf das Tagesfenster umgestellt, muss die Herkunft mitwandern (`thunder_day_origin` aus `format_trend_tokens`), sonst entsteht der AC-12-Fehler, vor dem der Kommentar an dieser Stelle ausdrücklich warnt.
+
+5. **Formatentscheidung offen.** Die Metrik-Zelle zeigt heute ein Stufen-Label über `_fmt_thunder()`. Der Altpfad zeigt `⚡wort @stunde`. Nur die **Quelle** zu tauschen (Tagesfenster-Stufe statt Aggregat-Stufe) hält das Zellformat stabil; die Uhrzeit mitzunehmen wäre eine zusätzliche Formatänderung.
+
+6. **Nachtangabe ist eine Produktfrage, keine Bugfrage.** Der Metrik-Zweig ist eine **Spaltenauswahl des Nutzers**. Eine Nachtzeile zu ergänzen, die niemand gewählt hat, wäre eine eigene Designentscheidung — Freigabe des PO nötig.
+
+7. **Nebenbefund (nicht in dieser Scheibe):** Der Metrik-Zweig färbt seine Zellen **gar nicht** ein — `outlook.py:141` ruft `_otd(...)` ohne `bg=`, während der Altpfad Ampelfarben setzt. Das betrifft alle Spalten, nicht nur Gewitter. Gehört nach #1199 oder als eigenes Issue, nicht in diesen Fix. (Erledigt zugleich die Anschlussfrage aus dem #1801-Kommentar: der `cells`-Pfad umgeht `thunder_ampel_band()` nicht — er färbt schlicht nicht.)
+
+## Testlage
+
+| Testdatei | Was sie bewacht |
+|---|---|
+| `tests/tdd/test_outlook_day_night_thunder_split.py` | #1653: Tag/Nacht im Altpfad; **plus die beiden Compare-Wächter aus Risiko 1 und 2** |
+| `tests/tdd/test_trip_outlook_metric_selection.py` | #1720 S1: Spaltenauswahl im Trip; arbeitet mit Referenzdatei (laut #1841-Kommentar mit datiertem Kommentar über der Assertion — bei Änderung **zweiten** Eintrag anhängen, nicht ersetzen) |
+| `tests/tdd/test_trip_outlook_parity.py` | Byte-Gleichheit des Trip-Ausblicks **ohne** Auswahl |
+| `tests/tdd/test_compare_outlook.py`, `test_compare_outlook_placement.py` | Compare-Ausblick |
+| `tests/tdd/test_shared_outlook_renderer.py` | Byte-Gleichheit der extrahierten geteilten Renderer |
+| `tests/golden/email/test_outlook_thunder_day_night_golden.py` | Golden-Datei über `render_outlook_table` + `render_outlook_plain` |
+| `tests/tdd/test_thunder_origin_outlook.py`, `test_thunder_origin_preview.py` | #1680: Herkunft der Gewitterstufe |
+| `tests/tdd/test_kompaktmail_ausblick_tagesfenster.py` | #1671: die vier Zweige von `resolve_thunder_day_branch()` |
+
+## Offene Fragen für die Analyse-Phase
+
+1. Fix in `build_outlook_row()` am Trip-Diskriminator (`trip_display_config`/`report_type` gesetzt) — bestätigen, dass das der einzige verlässliche Trip/Compare-Unterschied am Wirkort ist.
+2. Wandert die Herkunft (`signals`) mit der Stufe ins Tagesfenster? (Risiko 4 sagt: muss.)
+3. Braucht der Metrik-Zweig eine Nachtangabe — und wenn ja, als eigene Spalte, als Zusatz in der Gewitterzelle oder gar nicht? **PO-Entscheid nötig.**
+4. Bleibt das Zellformat unverändert (nur Quelltausch) oder kommt die Uhrzeit mit?
+
+---
+
+# Analysis (Phase 2)
+
+Gegengeprüft durch einen unabhängigen `analysis-challenger` (Verdict **CONFIRMED**, B1–B5 halten) und eine Spec-/ADR-Auswertung. Korrekturen an meinen eigenen Aussagen aus Phase 1 sind unten ausdrücklich markiert.
+
+## Type
+
+**Bug.** Regression aus #1720 S1 (gemerged 2026-08-14), nutzersichtbar.
+
+## Korrekturen an Phase 1
+
+1. **🔴 AC-11b begründet nicht, was ich behauptet habe.** Ich schrieb, für den Ortsvergleich sei das Tages-Aggregat „richtig". `feat_1680_s5a` AC-11b verlangt tatsächlich nur **Kohärenz**: die Herkunft muss aus derselben Rechnung stammen wie die daneben gezeigte Stufe. Der eigentliche Compare-Schutz ist **#1653 AC-6**: „bleibt die Compare-Ausgabe **byte-identisch** zum Stand vor dieser Änderung" — dort wurde der Metrik-Zweig ausdrücklich ausgenommen, **weil er damals nur den Ortsvergleich bediente**. Genau diese Voraussetzung hat #1720 S1 aufgehoben.
+
+2. **`test_compare_plain_carries_no_trip_format_remnants` (`:645`) ist für diesen Fix kein Nachweis.** Es ruft `render_outlook_plain()` mit vorgefertigten `rows` (die `cells` bereits enthalten) und berührt `build_outlook_row()` nie. Es bleibt grün, gleichgültig ob der Fix richtig oder falsch ist. Darf in der Adversary-Runde **nicht** als Beleg für die Trip/Compare-Trennung zitiert werden.
+
+3. **Es gibt keine zweite, abweichende Auflösung der Spaltenauswahl.** Ich hatte einen Versatz zwischen `trip_report.py:218` (Spalten) und `trip_report_scheduler.py:2200` (Zellen) vermutet. Nachgemessen: beide lesen dieselbe ungekollabierte `trip.display_config` (`trip_report.py:133`, `trip_report_scheduler.py:2184`) und rufen denselben Auflöser. Kein Befund — ADR-0055 Punkt 4 trägt.
+
+## Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/output/renderers/email/outlook.py` | MODIFY | Metrik-Zweig `:564-587`: Gewitter-Spalte (`kind == "ordinal"`) im **Trip**-Fall aus dem Tagesfenster statt aus `summary.thunder_level_max` |
+| `src/output/renderers/email/helpers.py` | MODIFY | `format_trend_tokens()` additiv um die Tagesfenster-**Stufe** ergänzen — eine Fensterauflösung, an derselben Stelle wie `thunder_day_token` |
+| `tests/helpers/trip_outlook_selection.py` | MODIFY | **Pflicht** — `outlook_rows()` auf die echte Trip-Aufrufkonvention ziehen, sonst prüft die #1720-S1-Suite weiter den Compare-Weg |
+| `docs/reference/metric_output_matrix.md` | MODIFY | drei veraltete Aussagen korrigieren (`:89`, `:214`, `:376`) |
+| `docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md` | MODIFY | Erratum: „Der Metrik-Zweig ist compare-exklusiv" (`:440-444`) ist seit #1720 S1 falsch |
+| Testdateien | CREATE/MODIFY | siehe Nachweisführung |
+
+## Technical Approach (Empfehlung)
+
+**Der Fix ist der vierte Aufrufer des geteilten Helfers aus #1671 — genau wie der PO-Intake es vorgezeichnet hat.**
+
+**Wirkort:** `build_outlook_row()`, Metrik-Zweig `outlook.py:564-587`. Dort — und nicht an den Renderstellen — weil `cells` dort entstehen und HTML wie Klartext sie unverändert ausgeben. Ein Fix an den Renderstellen wäre zwei Kopien.
+
+**Diskriminator:** `trip_display_config is not None`. Gemessen (Challenger, unabhängig bestätigt): genau **zwei** Produktionsaufrufer, sauber getrennt — Trip setzt immer `trip_display_config`/`report_type`/Tagesfenster und nie `metrics=`; Compare setzt immer `metrics=` und nie `trip_display_config`. Keine dritte Fundstelle in `api/`, `sms_trip.py` oder Vorschau-Endpunkten. Nicht an `report_type` festmachen (beim Trip immer gesetzt, sagt nichts über den Pfad) und **nicht an der Präsenz des Tagesfensters** — das ist genau die Falle, die `test_compare_metrics_cells_unaffected_by_day_night_split` (`:665`) gezielt stellt.
+
+**Zweigwahl:** `resolve_thunder_day_branch(format_trend_tokens(row), row)` aus `thunder_branch.py` — keine vierte eigene if/elif-Kette.
+- `"day"` → Stufe aus dem Tagesfenster
+- `"none"` → `ThunderLevel.NONE` (explizit „kein Gewitter")
+- `"plain"` → `summary.thunder_level_max` unverändert (heutiges Verhalten)
+
+**Woher die Stufe kommt.** `format_outlook_value()` erkennt die Gewitterspalte an `kind == "ordinal"` (`compare_outlook_metric_ids.py:165`) und übergibt sie an `_fmt_thunder(ThunderLevel, hail, signals)` — es braucht also ein **ThunderLevel-Objekt**, nicht den String `thunder_day_token`. Empfehlung: `format_trend_tokens()` additiv um die Tagesfenster-Stufe erweitern, berechnet aus denselben `_win_start`/`_win_end` wie `thunder_day_token` (`helpers.py:1005-1022`). Damit bleibt es bei **einer** Fensterauflösung — die Regel, gegen die #1653 und #1680 S5a ausdrücklich schreiben. Den Token zurückzuparsen wäre die schlechtere Variante.
+
+⚠️ **Fallstrick bei der Herleitung:** `row["hourly_thunder_signals"]` ist `None`, sobald **kein** Datenpunkt eine Trägerliste führt (`outlook.py:558-560`, Alt-Schnappschüsse) — die Stufe darf deshalb **nicht** allein daraus abgeleitet werden, sonst fällt sie für Bestandsdaten still aus. `row["hourly_thunder"]` ist dagegen immer befüllt, trägt die Stufe aber als Fließkommazahl über `thunder_label_value()`.
+
+**Herkunft muss mitwandern.** `outlook.py:580` reicht heute `summary.thunder_level_max_signals` durch — die Herkunft des Aggregats. Wandert die Stufe ins Tagesfenster, muss die Herkunft mit (`union_of_max_carriers` über dasselbe Fenster, `thunder_scale.py:118`), sonst entsteht der AC-12-Fehler, vor dem der Kommentar an genau dieser Stelle warnt.
+
+**Zellformat bleibt unverändert** — nur die Quelle wird getauscht. Keine Uhrzeit, kein `⚡`. Das hält den Compare-Zweig und die bestehenden Formatwächter unberührt.
+
+## Nachweisführung (der heikelste Teil)
+
+🔴 **`tests/helpers/trip_outlook_selection.py:163` baut die Zeilen mit `metrics=` — der Compare-Konvention** — und behauptet im Docstring, das sei der Parameter, den der Zeitplaner füllt. Gemessen füllt `trip_report_scheduler.py:2200` stattdessen `trip_display_config=dc, report_type=…`. Die gesamte #1720-S1-Renderer-Suite fährt den Metrik-Zweig damit über den **Compare**-Weg.
+
+Folge: Ein Fix am Trip-Diskriminator wäre für diese Tests unsichtbar — sie blieben grün und bewiesen nichts. **Der Helfer muss auf die echte Trip-Konvention gezogen werden, bevor irgendein Nachweis zählt.** Die Testdatei warnt selbst davor (`test_trip_outlook_metric_selection.py:17-20`), und ADR-0055 (`:167-171`) warnt unabhängig davon für `test_trip_outlook_parity.py`: der ruft die Renderer isoliert auf, durchläuft die Verdrahtung nie und blieb bei einer Mutation grün, während vier andere Tests rot wurden.
+
+**Nicht betroffen:** `REFERENCE_TABLE` in `test_ac1_bestandstrip_html_ausblick_bleibt_byte_identisch` rendert einen Trip **ohne** Auswahl, bewacht also den Altpfad. Der im Issue-Kommentar erwartete zweite datierte Eintrag wird voraussichtlich nicht nötig — vor dem Ändern der Aufzeichnung trotzdem nachmessen.
+
+**Mutations-Gegenprobe (Pflicht):** Diskriminator auf `True` festnageln → mindestens ein Compare-Test muss rot werden. Diskriminator auf `False` festnageln → mindestens ein Trip-Test muss rot werden. Wird nur eine Richtung rot, bewacht der Nachweis nur die halbe Trennung.
+
+## Scope Assessment
+
+- Produktivdateien: 2 (`outlook.py`, `helpers.py`) — geschätzt **+40/−5 LoC**, deutlich unter dem 250er-Budget
+- Testdateien: 1 Anpassung (Testhelfer) + 1 neue Verhaltensdatei — geschätzt **+150 LoC**, unter dem 500er-Budget
+- Dokumentation: 2 Dateien (zählen nicht aufs Budget)
+- **Risiko: MEDIUM** — nicht mehr HIGH wie beim Intake: der Diskriminator ist gemessen eindeutig, der geteilte Helfer liegt fertig vor, und die einzige echte Sperre (Testhelfer am falschen Pfad) ist erkannt.
+
+## Dependencies & Reihenfolge
+
+1. Testhelfer auf die Trip-Konvention ziehen — **zuerst**, sonst ist jeder folgende Nachweis wertlos
+2. `format_trend_tokens()` additiv um die Tagesfenster-Stufe erweitern
+3. Metrik-Zweig auf den geteilten Helfer umstellen, am Trip-Diskriminator gattert
+4. Herkunft mitziehen
+5. Doku-Korrekturen
+
+## Open Questions
+
+- [ ] **PO: Braucht der Metrik-Zweig eine Nachtangabe?** Dafür spricht: #1653 wurde eingeführt, weil ein Nachtgewitter hinter dem Tageswert verschwinden konnte — als Sicherheitsproblem eingestuft, nicht als Kosmetik. Ein Trip-Nutzer, der die Gewitter-Spalte wählt, verliert im Metrik-Zweig genau die Nachtsicht, die der Altpfad dafür bekam. Dagegen spricht: der Nutzer hat Spalten gewählt, „Nacht" war keine davon; eine ungefragte Zusatzzeile wäre eine neue Designentscheidung.
+- [ ] **PO: Fehlende Ampelfarben — eigenes Issue?** Der Metrik-Zweig färbt **keine** Zelle ein (`outlook.py:141`, `_otd()` ohne `bg=`), der Altpfad schon. Gemessen (Challenger): der Pfad existierte für Compare bereits seit #1361/#1368, ist also nicht durch #1720 S1 entstanden — wohl aber dadurch erstmals für **Trip**-Nutzer sichtbar, die vorher Ampelfarben hatten. Das ist ein nutzersichtbares Downgrade und fällt damit unter die Nebenbefund-Regel (a) → eigenes Issue statt Sammel-Eintrag #1199. Nicht in dieser Scheibe.

--- a/docs/reference/metric_output_matrix.md
+++ b/docs/reference/metric_output_matrix.md
@@ -86,7 +86,7 @@ katalog-getriebene Liste mit handgeschriebenen Ausnahmen.
 | E-Mail mobile Kompaktzeilen (in der **Voll**mail) | `src/output/renderers/email/html.py:878` `_render_mobile_compact_rows()`; Aufrufe `:1206`, `:1264`, `:1290` (Nachtzeilen) | katalog-getrieben (erbt `col_order`) | **unbewacht** |
 | Kurzform-Mail (eigenes Format `compact`) | `src/output/renderers/email/compact.py:96` `render_compact()`; Pillen-Aufruf `:176` | katalog-getrieben über `resolve_trip_active_metrics` | **unbewacht** |
 | Kompakt-Zusammenfassung (Fließtext-Block **in** der Vollmail) | `src/output/renderers/compact_summary.py:567` `_format_thunder()`, Aufruf `:243`; aktiviert über `src/output/renderers/trip_report.py:173` `options.show_compact_summary`, Formatter-Einstieg `trip_report.py:942` | handgeschrieben — `thunder` ist die **einzige** Metrik mit eigener Formatier-Methode | nur metrikspezifisch: `tests/tdd/test_hail_compact_summary_thunder.py:75`, `:89`, `:107` (Gewitter/Hagel) und seit #1680 S2 `test_thunder_origin_trip.py` für den Herkunfts-Zusatz (beide Textzweige, bis `email_plain`). Als Metrik×Kanal-Ort weiterhin **unbewacht** |
-| Ausblick / 3-Tages-Tabelle (Trip-Mail) | `src/output/renderers/email/outlook.py:174–298` (HTML), `:353–403` (Klartext) — **feste** Spalten Tag/N/D/R/PR/Wind/Böen/Gew (+ACC) | **nicht** katalog-getrieben: alle drei Trip-Aufrufstellen (`email/html.py:1357`, `email/plain.py:338`, `trip_report_scheduler.py:1844`) übergeben **kein** `metrics` | `tests/tdd/test_trip_outlook_parity.py` (Byte-Golden über das GANZE HTML + Klartext) — strenger als eine Metrik-Achse; **keine Metrik×Kanal-Fläche**, weil der Nutzer hier nichts wählen kann (gemessen 2026-08-11, #1703 S2) |
+| Ausblick / 3-Tages-Tabelle (Trip-Mail) | `src/output/renderers/email/outlook.py` — **zwei** Renderpfade: Altpfad mit festen Spalten Tag/N/D/R/PR/Wind/Böen/Gew (+ACC) UND seit #1720 S1 der katalog-getriebene Metrik-Zweig (`build_outlook_row():564`, `row["cells"]`) | **teilweise** katalog-getrieben (KORRIGIERT 2026-08-15, #1841): setzt der Nutzer unter „Wertebereiche → 3-Tages-Vorschau" eine Auswahl, übergeben `email/html.py:1364` und `email/plain.py:344` sehr wohl `metrics=` — der Trip erreicht `outlook_columns()` seit #1720 S1 | Altpfad: `tests/tdd/test_trip_outlook_parity.py` (Byte-Golden). Metrik-Zweig: `tests/tdd/test_trip_outlook_metric_selection.py`, Gewitterquelle `tests/tdd/test_vorschau_metrik_tagesfenster.py` (#1841) |
 | Ausblick: Gewitter-Sonderbehandlung | `email/outlook.py:38` `_THUNDER_TOKEN_RE`; Wortlaut-Map `:195–198` (dritte LOW/MED/HIGH-Übersetzung im Code) | handgeschrieben | teilbewacht über Gewitter-Tests, nicht über die Matrix |
 | Telegram rich (Bubbles) | `src/output/renderers/narrow.py:661` → `src/output/renderers/channel_layout.py:75` `render_for_channel()`; Limits `channel_layout.py:45` `CHANNEL_LIMITS` | gemischt — Ausnahme `_NIGHT_SCALAR_IDS` `channel_layout.py:88` | `tests/tdd/test_channel_metric_matrix.py:114` |
 | Telegram Kurzübersicht / Trendzeile | `narrow.py:346` (Zeilentupel), `narrow.py:528–532`, `narrow.py:586–597` (drei hartkodierte Gewitter-Zweige) | handgeschrieben | **unbewacht** als eigener Ausgabeort |
@@ -214,6 +214,13 @@ Modul-Docstring sind nachgezogen. Spec:
 > Trip-Ausblick hat keine wählbaren Spalten und damit keine Metrik×Kanal-Fläche — er ist
 > zudem durch den Byte-Golden `test_trip_outlook_parity.py` strenger bewacht, als eine
 > Matrix-Achse es wäre. Die Scheibe ist deshalb **Compare-only** (PO-freigegeben).
+>
+> 🔴 **ÜBERHOLT seit #1720 S1 (2026-08-14), korrigiert 2026-08-15 (#1841).** Der
+> Trip-Ausblick hat seither sehr wohl wählbare Spalten; `email/html.py:1364` und
+> `email/plain.py:344` übergeben `metrics=`, sobald eine Auswahl gesetzt ist. Der
+> Absatz oben beschreibt den Stand VOR #1720 S1 und bleibt als Beleg stehen, warum
+> die damalige Scheibe Compare-only zugeschnitten war. Der Byte-Golden bewacht nur
+> den Altpfad — den Metrik-Zweig sieht er strukturell nicht (ADR-0055:167-171).
 >
 > Wächter: `tests/tdd/test_channel_metric_matrix.py` AC-S2-1..8, Soll-Menge (25 Paare) aus
 > `get_compare_metric_catalog()` gerechnet via `tests/helpers/outlook_columns.py` inkl.
@@ -376,6 +383,11 @@ Matrix-Achse für `outlook_columns()` (`compare_outlook_metric_ids.py:78`). Deck
 `metrics`. Der Trip-Ausblick hat keine wählbaren Spalten (feste Sieben) und wird vom
 Byte-Golden `test_trip_outlook_parity.py` strenger bewacht, als eine Metrik-Achse es könnte.
 Zuschnitt daher **Compare-only**, PO-freigegeben 2026-08-11.
+
+🔴 **Diese Messung galt am 2026-08-11 und wurde am 2026-08-14 durch #1720 S1 überholt**
+(nachgetragen 2026-08-15, #1841): der Trip übergibt seither `metrics=`, sobald eine
+Auswahl gesetzt ist. Lehrstück für den Umgang mit „Am Code gemessen"-Aussagen — die
+Messung war richtig, entzogen wurde ihre **Voraussetzung**.
 
 Umgesetzt als 8 ACs (AC-S2-1..8) in `tests/tdd/test_channel_metric_matrix.py`, Soll-Menge
 **25 Paare** aus `get_compare_metric_catalog()` gerechnet (`tests/helpers/outlook_columns.py`,

--- a/docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md
+++ b/docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md
@@ -443,6 +443,31 @@ Hagel-Schlüssel seit #1475 — geerbte Annahme, kein neuer Fehler.
    (`compare_html.py:1241`). Die dortige Erweiterung kann die Trip-Golden
    strukturell nicht berühren.
 
+   > 🔴 **ERRATUM, nachgetragen 2026-08-15 (#1841): Punkt 8 gilt nicht mehr.**
+   > Diese Messung war am 2026-08-13 korrekt. **Einen Tag später** hat #1720 S1
+   > (PR #1840) die Voraussetzung aufgehoben: `html.py:1364` und `plain.py:344`
+   > übergeben seither `metrics=_outlook_metrics` **auch für den Trip**, sobald
+   > der Nutzer unter „Wertebereiche → 3-Tages-Vorschau" eine Auswahl gesetzt
+   > hat. Der Metrik-Zweig ist damit **nicht mehr compare-exklusiv**.
+   >
+   > Genau daraus entstand **#1841**: die Gewitterstufe kam dort aus dem
+   > gehzeit-geklemmten Aggregat statt aus dem Tagesfenster.
+   >
+   > **Lehre, nicht nur Korrektur:** Der Satz oben war belegt, gemessen und
+   > PO-freigegeben — und wurde trotzdem falsch, ohne dass sich ein Zeichen
+   > daran änderte. Wer ihn las, sah „Am Code gemessen" plus Freigabe und prüfte
+   > **gerade deshalb** nicht nach. Misstrauen gegen Prosa hilft hier nicht.
+   > Was hilft: **beim Ändern fragen, wer sich auf die Voraussetzung verlässt,
+   > die man gerade entzieht.** Suchmuster für gefährdete Zusagen sind Wörter
+   > der Ausschließlichkeit — „exklusiv", „nur", „immer", „nie", `=None`.
+   >
+   > Die schärfere Regel (gemeinsam mit der #1728-Sitzung gefunden): **Ließe
+   > ein Spec-Satz sich in drei Zeilen als Test formulieren und wurde es
+   > trotzdem nicht, ist er unbewacht.** „Der Trip ruft immer mit
+   > `metrics=None`" wäre ein solcher Dreizeiler gewesen und hätte #1841 am Tag
+   > der Entstehung gemeldet statt einen Tag später als Ticket. Aufräumauftrag
+   > dafür: #1848 Teil A.
+
 ## Nicht in dieser Scheibe
 
 - **Gewitter-Vorschau** — folgt als **Scheibe 5b**; sie konsumiert den hier

--- a/docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md
+++ b/docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md
@@ -45,6 +45,17 @@ statt eine vierte eigene Aufloesung derselben Frage zu bauen (ADR-0055).
   compare-exklusiven Metrik-Renderpfad fuer den Trip geoeffnet, ohne die
   Voraussetzung der damaligen Compare-Entscheidung mitzupruefen: der Trip
   **hat** eine Stundenreihe, und sein Aggregat **ist** gehzeit-geklemmt.
+
+  🔴 Das ist belegt, nicht hergeleitet: `feat_1680_s5a` haelt unter „Am Code
+  gemessen" Punkt 8 (`:440-444`, PO-go 2026-08-13) fest, der Metrik-Zweig sei
+  **compare-exklusiv**, „der Trip ruft die Ausblick-Renderer immer mit
+  `metrics=None` (`html.py:1357`, `plain.py:338`)". Am 2026-08-13 war das
+  wahr. **Einen Tag spaeter** hat #1720 S1 genau diese Voraussetzung
+  aufgehoben — `html.py:1364` und `plain.py:344` uebergeben seither
+  `metrics=_outlook_metrics` auch fuer den Trip. Der Fehler entstand also
+  nachweislich beim Ausweiten des Zweigs und war nicht schon vorher da.
+  (Diese Spec-Zeile wird als Erratum korrigiert, siehe Implementation
+  Details §5.)
 - Vorgaenger: #1653 (drei Ausgabeorte umgestellt), #1671 (Kurzformat-Mail,
   liefert den geteilten Helfer), #1680 S5a (Herkunft der Gewitterstufe).
 - Abgetrennt: #1849 (fehlende Ampelfarben im selben Renderpfad).

--- a/docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md
+++ b/docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md
@@ -413,6 +413,31 @@ gemeldet; hier ist sie um die zweite, entgegengesetzte Geometrie ergaenzt.
 Sind sie gleich, prueft der darauf aufbauende AC-Test nichts — die Fixture
 ist dann kaputt, nicht der Code.
 
+### 🔴 ZWEI unabhaengige Achsen — Korrektur 2026-08-15 (Adversary F001, HIGH)
+
+Die Tabelle oben nennt nur **eine** Achse. Das war ein Fehler dieser Spec und
+hat eine Pflicht-Gegenprobe wirkungslos gemacht:
+
+| Achse | Unterscheidet | Fixtur-Bedingung |
+|---|---|---|
+| **A: Gehzeit ↔ Tagesfenster** | Aggregat von Tagesfenster | Gewitterstunde liegt in genau einem der beiden (Tabelle oben) |
+| **B: 24h-Reihe ↔ Tagesfenster** | ob ueberhaupt gefiltert wird | **mindestens zwei** Stundenpunkte: einer IM Fenster mit **niedrigerer**, einer AUSSERHALB mit **hoeherer** Stufe |
+
+🔴 **Eine Fixture, die Achse A trifft, trifft Achse B NICHT automatisch.**
+Gemessen (Adversary, 2026-08-15): `AC1_POINTS`/`AC2_POINTS` tragen je **einen**
+Stundenpunkt. Damit sind Tagesfenster-Menge und 24h-Menge identisch — die
+Filterung kann nicht wirken, also kann ihr Ausfall auch nicht auffallen. M6
+blieb dadurch von **allen 81** Tests ungefangen. AC-2 liest `thunder_day_level`
+zusaetzlich gar nicht, weil es ueber den `"none"`-Zweig laeuft.
+
+**Kein aequivalenter Mutant:** mit einer Zwei-Punkte-Fixtur liefert der
+unmutierte Code `MED` (Fenster-Maximum), der mutierte `HIGH` (24h-Maximum).
+Der Unterschied ist beobachtbar, es fehlte nur der Test.
+
+**Pflicht:** eine **dritte** Fixture fuer Achse B, mit eigenem
+Vorbedingungs-Test (Tagesfenster-Maximum ≠ 24h-Maximum). `AC1_POINTS`/
+`AC2_POINTS` bleiben unveraendert — sie tragen Achse A.
+
 ## Mutations-Gegenprobe (PFLICHT)
 
 | # | Verfaelschung | Muss rot werden |
@@ -422,7 +447,7 @@ ist dann kaputt, nicht der Code.
 | M3 | Diskriminator auf Fensterpraesenz statt `trip_display_config` | `test_outlook_day_night_thunder_split.py:665` |
 | M4 | Herkunft weiter aus `summary.thunder_level_max_signals` | AC-6 |
 | M5 | Zweig `"none"` liefert das Aggregat statt `ThunderLevel.NONE` | AC-2 |
-| M6 | `thunder_day_level` aus dem 24h-Fenster statt dem Tagesfenster | AC-1 **und** AC-2 |
+| M6 | `thunder_day_level` aus dem 24h-Fenster statt dem Tagesfenster | der **dritte** Fixtur-Test (zwei Stundenpunkte, s.u.) — **nicht** AC-1/AC-2 |
 | M7 | Testhelfer zurueck auf `metrics=` | AC-8 |
 
 🔴 **M1 und M2 muessen BEIDE greifen.** Wird nur eine Richtung rot, bewacht

--- a/docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md
+++ b/docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md
@@ -370,7 +370,13 @@ in beiden Richtungen gruen).
   Trip **ohne** Auswahl und bewacht damit den Altpfad. Sie sollte sich durch
   diese Scheibe **nicht** aendern; der im #1841-Kommentar erwartete zweite
   datierte Eintrag entfaellt voraussichtlich. Vor einem Nachziehen der
-  Referenz ist das zu **messen**, nicht anzunehmen.
+  Referenz ist das zu **messen**, nicht anzunehmen. Aendert sie sich wider
+  Erwarten doch, gilt: einen **zweiten** datierten Eintrag anhaengen, den
+  bestehenden #1801-Eintrag **nicht** ersetzen — die Historie muss lesbar
+  bleiben (#1841-Kommentar vom 2026-08-14). Zur Einordnung: diese
+  Aufzeichnungen bewachen die **Konstanz** der Ausgabe, nicht ihre
+  **Korrektheit** — eine unveraenderte Referenz belegt nicht, dass der Inhalt
+  vorher richtig war.
 - Der Fix wirkt nur auf den Metrik-Zweig. Zeigt ein Trip beide Zustaende
   nacheinander (Auswahl gesetzt, dann geleert), wechselt er zwischen zwei
   Darstellungen mit und ohne Nachtangabe. Das ist die Folge des

--- a/docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md
+++ b/docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md
@@ -10,8 +10,10 @@ tags: [gewitter, ausblick, vorschau, tagesfenster, metrik-zweig, issue-1841]
 
 <!-- Issue #1841. Grundlage: PFLICHTLEKTUERE
      docs/context/fix-1841-ausblick-metrik-tagesfenster.md (am Stand
-     `e6303c75` gemessen, nach Rebase auf `57e36375` nachgeprueft — keine
-     Zeilennummer hat sich verschoben). Vorbilder:
+     `e6303c75` gemessen, nach Rebase auf `57e36375` nachgeprueft). ACHTUNG:
+     #1594 (im Rebase enthalten) hat `trip_report_scheduler.py` verschoben —
+     der Aufruf steht jetzt bei `:2282`, nicht mehr bei `:2200`. Die
+     Renderer-Dateien sind unveraendert. Vorbilder:
      docs/specs/modules/fix_1671_kompaktmail_ausblick_tagesfenster.md
      (liefert den geteilten Helfer) und
      docs/specs/modules/fix_1653_ausblick_tag_nacht_trennung.md (dessen
@@ -94,7 +96,7 @@ Alle Angaben am Stand `57e36375` nachgeprueft, nicht aus dem Ticket uebernommen.
 
 2. **Der Diskriminator existiert bereits.** Genau **zwei** Produktionsaufrufer
    von `build_outlook_row()`, sauber getrennt (unabhaengig gegengeprueft):
-   - Trip: `trip_report_scheduler.py:2200` — setzt immer
+   - Trip: `trip_report_scheduler.py:2282` — setzt immer
      `trip_display_config=dc`, `report_type=…`, `day_window_start_hour`,
      `day_window_end_hour`; setzt **nie** `metrics=`.
    - Ortsvergleich: `compare_html.py:1168` — setzt immer `metrics=…`;
@@ -121,13 +123,29 @@ Alle Angaben am Stand `57e36375` nachgeprueft, nicht aus dem Ticket uebernommen.
    `row["hourly_thunder"]` ist dagegen immer befuellt, traegt die Stufe
    aber als Fliesskommazahl ueber `thunder_label_value()`.
 
-6. **SMS macht es bereits genau so.** `sms_trip.py:303-323` baut die
+6. **🔴 Aggregat und Stundenreihe stammen aus VERSCHIEDEN weit gefassten
+   Datensaetzen — das ist die Ursache und zugleich die Testbedingung.**
+   Im selben Aufruf `build_outlook_row(agg, _flat_points, …)`
+   (`trip_report_scheduler.py:2282`) gilt:
+   - `agg` (→ `summary`, Quelle der heutigen Zelle) ist auf die **Gehzeit**
+     geklemmt: `segment_weather.py:264-281` filtert die Reihe auf
+     `segment.start_time … segment.end_time` und aggregiert **nur** darueber.
+   - `_flat_points` (→ `hourly_thunder`, Quelle des Tagesfensters) ist die
+     **ungefilterte Ganztagsreihe** (`trip_report_scheduler.py:2258`:
+     `sw.timeseries.data`; `segment_weather.py:239` haelt ausdruecklich fest,
+     die ungefilterte Reihe bleibe „for table display" erhalten).
+
+   Faellt die Gehzeit mit dem Tagesfenster zusammen, sind beide Rechnungen
+   deckungsgleich und eine Fixture waere von einem No-Op nicht
+   unterscheidbar — der Test bliebe nach jeder Mutation gruen.
+
+7. **SMS macht es bereits genau so.** `sms_trip.py:303-323` baut die
    Gewitter-Stundenreihe ausschliesslich aus
    `build_day_window_points(start_hour=…, end_hour=…)` — rein Tagesfenster,
    ohne jede Nachtangabe. Die PO-Vorgabe „so wie auch fuer SMS" ist damit
    am Code belegt, nicht nur behauptet.
 
-7. **Zwei Bestandstests umreissen den Korridor.**
+8. **Zwei Bestandstests umreissen den Korridor.**
    - `test_outlook_day_night_thunder_split.py:665` verlangt, dass
      `row["cells"]` mit und ohne `day_window_*` identisch bleibt —
      aufgerufen mit `metrics=` und ohne `trip_display_config`. Der Test
@@ -139,11 +157,11 @@ Alle Angaben am Stand `57e36375` nachgeprueft, nicht aus dem Ticket uebernommen.
      richtig oder falsch ist — **kein Nachweis fuer diese Scheibe** und in
      der Adversary-Runde nicht als solcher zu zitieren.
 
-8. **Der Testhelfer prueft heute den falschen Pfad.**
+9. **Der Testhelfer prueft heute den falschen Pfad.**
    `tests/helpers/trip_outlook_selection.py:163` baut die Ausblick-Zeilen
    mit `build_outlook_row(..., metrics=metrics)` — der **Compare**-Konvention
    — und behauptet im Docstring (`:155-157`), das sei der Parameter, den der
-   Zeitplaner fuellt. Gemessen fuellt `trip_report_scheduler.py:2200`
+   Zeitplaner fuellt. Gemessen fuellt `trip_report_scheduler.py:2282`
    stattdessen `trip_display_config`/`report_type`. Die gesamte
    #1720-S1-Renderer-Suite faehrt den Metrik-Zweig damit ueber den
    Compare-Weg. `test_trip_outlook_metric_selection.py:17-20` benennt diese
@@ -206,7 +224,7 @@ wie heute. Alle anderen Spalten (`kind != "ordinal"`) bleiben unberuehrt.
 🔴 Der Diskriminator ist `trip_display_config`, **nicht** die Praesenz des
 Tagesfensters und **nicht** `report_type`. `report_type` ist beim Trip immer
 gesetzt und sagt nichts ueber den Pfad; die Fensterpraesenz ist genau die
-Falle aus „Am Code gemessen" Punkt 7.
+Falle aus „Am Code gemessen" Punkt 8.
 
 ### 3. Herkunft wandert mit der Stufe
 
@@ -224,7 +242,7 @@ gezeigten Stufe gehoert (AC-10-Regel aus #1680 S5a).
 
 `tests/helpers/trip_outlook_selection.py::outlook_rows()` uebergibt kuenftig
 `trip_display_config` + `report_type` + Tagesfenster wie
-`trip_report_scheduler.py:2200`, statt `metrics=`. Der veraltete Docstring
+`trip_report_scheduler.py:2282`, statt `metrics=`. Der veraltete Docstring
 (`:155-157`) wird mitkorrigiert.
 
 🔴 **Reihenfolge:** Dieser Schritt kommt **zuerst**. Ohne ihn faehrt die
@@ -297,7 +315,7 @@ Ortsvergleich bleiben unveraendert.
 
 - **AC-8:** Given den Testhelfer `tests/helpers/trip_outlook_selection.py` /
   When er Ausblick-Zeilen fuer den Trip baut / Then benutzt er dieselbe
-  Aufrufkonvention wie `trip_report_scheduler.py:2200`
+  Aufrufkonvention wie `trip_report_scheduler.py:2282`
   (`trip_display_config`/`report_type`/Tagesfenster), nicht `metrics=`.
   Nachweis: eine Verfaelschung des Trip-Zweigs macht mindestens einen Test
   der #1720-S1-Suite rot.
@@ -344,6 +362,28 @@ Ortsvergleich bleiben unveraendert.
 
 Kern-Schicht, deterministisch. Keine Mocks, kein Netz. Dateiname nach
 Verhalten: `tests/tdd/test_vorschau_metrik_tagesfenster.py`.
+
+### 🔴 Fixtur-Geometrie — AC-1 und AC-2 brauchen VERSCHIEDENE Zuschnitte
+
+Aus „Am Code gemessen" Punkt 6 folgt eine harte Bedingung an die Testdaten.
+Die beiden Fehlerrichtungen entstehen an **entgegengesetzten** Raendern:
+
+| AC | Gewitterstunde liegt … | Gehzeit vs. Tagesfenster | Wirkung heute |
+|---|---|---|---|
+| AC-1 | im **Tagesfenster**, aber **ausserhalb der Gehzeit** | Gehzeit **enger** (z.B. Gehzeit 08–14, Fenster 04–19, Gewitter 17:00) | Aggregat sagt `NONE` → Gewitter verschwindet |
+| AC-2 | in der **Gehzeit**, aber **ausserhalb des Tagesfensters** | Gehzeit **reicht hinaus** (z.B. Gehzeit 02–21, Fenster 04–19, Gewitter 02:00) | Aggregat traegt eine Stufe → Tagesgewitter erfunden |
+
+🔴 **Eine einzige Fixture kann nicht beide ACs tragen.** Wer beide mit
+derselben Geometrie baut, bekommt fuer eine der beiden Richtungen ein
+Datenbild, in dem Aggregat und Tagesfenster **denselben** Wert liefern — der
+Test ist dann von einem No-Op nicht unterscheidbar und bleibt nach jeder
+Mutation gruen. Genau diese Falle hat die parallel gestoppte Session
+gemeldet; hier ist sie um die zweite, entgegengesetzte Geometrie ergaenzt.
+
+**Vorbedingungs-Test (PFLICHT, vor den AC-Tests):** je Fixture zeigen, dass
+`summary.thunder_level_max` und die Tagesfenster-Stufe **verschieden** sind.
+Sind sie gleich, prueft der darauf aufbauende AC-Test nichts — die Fixture
+ist dann kaputt, nicht der Code.
 
 ## Mutations-Gegenprobe (PFLICHT)
 

--- a/docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md
+++ b/docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md
@@ -1,0 +1,395 @@
+---
+entity_id: fix_1841_vorschau_metrik_tagesfenster
+type: bugfix
+created: 2026-08-14
+updated: 2026-08-14
+status: draft
+version: "1.0"
+tags: [gewitter, ausblick, vorschau, tagesfenster, metrik-zweig, issue-1841]
+---
+
+<!-- Issue #1841. Grundlage: PFLICHTLEKTUERE
+     docs/context/fix-1841-ausblick-metrik-tagesfenster.md (am Stand
+     `e6303c75` gemessen, nach Rebase auf `57e36375` nachgeprueft — keine
+     Zeilennummer hat sich verschoben). Vorbilder:
+     docs/specs/modules/fix_1671_kompaktmail_ausblick_tagesfenster.md
+     (liefert den geteilten Helfer) und
+     docs/specs/modules/fix_1653_ausblick_tag_nacht_trennung.md (dessen
+     AC-6 den Ortsvergleich schuetzt). -->
+
+# #1841 — 3-Tages-Vorschau: Gewitterspalte liest das falsche Zeitfenster
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Setzt ein Nutzer im Trip-Editor unter **Wertebereiche → 3-Tages-Vorschau**
+eine Spaltenauswahl und waehlt darin die Spalte **Gewitter**, zeigt die
+3-Tages-Tabelle der Trip-Mail die Gewitterstufe aus dem auf die Gehzeit
+geklemmten Tages-Aggregat statt aus dem konfigurierten **Tagesfenster**.
+Ein reales Tagesgewitter kann dadurch verschwinden (falsch-negativ) oder
+ein nicht vorhandenes behauptet werden (falsch-positiv) — dieselbe
+Fehlerklasse, die #1653 fuer die damaligen Ausgabeorte behoben hat und
+#1671 fuer die Kurzformat-Mail.
+
+Diese Scheibe macht den Metrik-Zweig zum **vierten Aufrufer** des mit
+#1671 gelieferten geteilten Helfers `resolve_thunder_day_branch()` —
+statt eine vierte eigene Aufloesung derselben Frage zu bauen (ADR-0055).
+
+## Source
+
+- Issue #1841 (Label `bug`, `priority:high`, `session:khw`)
+- Ursache: #1720 S1 (PR #1840, gemerged 2026-08-14) hat den bis dahin
+  compare-exklusiven Metrik-Renderpfad fuer den Trip geoeffnet, ohne die
+  Voraussetzung der damaligen Compare-Entscheidung mitzupruefen: der Trip
+  **hat** eine Stundenreihe, und sein Aggregat **ist** gehzeit-geklemmt.
+- Vorgaenger: #1653 (drei Ausgabeorte umgestellt), #1671 (Kurzformat-Mail,
+  liefert den geteilten Helfer), #1680 S5a (Herkunft der Gewitterstufe).
+- Abgetrennt: #1849 (fehlende Ampelfarben im selben Renderpfad).
+
+## Estimated Scope
+
+| Was | Umfang |
+|---|---|
+| Produktivdateien | 2 (`outlook.py`, `helpers.py`), ~+40/−5 LoC |
+| Testdateien | 1 Anpassung (Testhelfer), 1 neue Verhaltensdatei, ~+150 LoC |
+| Dokumentation | 2 Korrekturen (zaehlen nicht aufs LoC-Budget) |
+| LoC-Budget | 250 Produktiv / 500 Test — beides ausreichend, keine Anhebung noetig |
+| Risiko | MEDIUM |
+
+## Dependencies
+
+- **Upstream:** `format_trend_tokens()` (`helpers.py`), `resolve_thunder_day_branch()`
+  (`thunder_branch.py:54`), `union_of_max_carriers()` (`thunder_scale.py:118`),
+  `thunder_label_value()`, `resolve_configured_window()`.
+- **Downstream:** Trip-Vollmail HTML (`html.py:1364`) und Klartext
+  (`plain.py:344`). Der Ortsvergleich (`compare_html.py:1242`,
+  `comparison.py:360`) nutzt denselben Baustein und **muss unveraendert
+  bleiben**.
+- `build_outlook_row()` ist der einzige bewusst geteilte Trip/Compare-Baustein
+  (`tests/unit/test_notification_service.py:191` fuehrt genau diesen Import
+  als erlaubte Ausnahme).
+
+## Am Code gemessen
+
+Alle Angaben am Stand `57e36375` nachgeprueft, nicht aus dem Ticket uebernommen.
+
+1. **Die falsche Quelle.** `outlook.py:581-587` baut `row["cells"]` ueber
+   `getattr(summary, col["field"], None)`. Fuer die Gewitterspalte ist
+   `col["field"]` gleich `thunder_level_max` — das gehzeit-geklemmte
+   Aggregat. `thunder_day_token` wird in diesem Zweig nie gelesen.
+
+2. **Der Diskriminator existiert bereits.** Genau **zwei** Produktionsaufrufer
+   von `build_outlook_row()`, sauber getrennt (unabhaengig gegengeprueft):
+   - Trip: `trip_report_scheduler.py:2200` — setzt immer
+     `trip_display_config=dc`, `report_type=…`, `day_window_start_hour`,
+     `day_window_end_hour`; setzt **nie** `metrics=`.
+   - Ortsvergleich: `compare_html.py:1168` — setzt immer `metrics=…`;
+     setzt **nie** `trip_display_config` und **kein** Tagesfenster.
+
+   Keine dritte Fundstelle in `api/`, `sms_trip.py` oder Vorschau-Endpunkten.
+
+3. **Der Fix passt in `build_outlook_row()`.** `format_trend_tokens(stage)`
+   ist eine reine Funktion des Zeilen-Dicts und liest ausschliesslich
+   Schluessel, die in `row` bereits stehen, bevor der Metrik-Zweig bei
+   `:564` beginnt (`row.update(optional)` bei `:562`). Eine Korrektur dort
+   erledigt HTML **und** Klartext in einem Zug — an den beiden Renderstellen
+   waeren es zwei Kopien.
+
+4. **Die Zelle braucht ein `ThunderLevel`, keinen Token-String.**
+   `format_outlook_value()` erkennt die Gewitterspalte an `kind == "ordinal"`
+   (`compare_outlook_metric_ids.py:164-166`) und reicht den Wert an
+   `_fmt_thunder(level, hail, signals)` durch. `thunder_day_token` ist
+   dagegen ein String der Form `"mittel@14(hoch@17)"`.
+
+5. **`row["hourly_thunder_signals"]` ist unzuverlaessig als Stufenquelle.**
+   Es ist `None`, sobald **kein** Datenpunkt eine Traegerliste fuehrt
+   (`outlook.py:553-560`, Alt-Schnappschuesse vor #1680 S1).
+   `row["hourly_thunder"]` ist dagegen immer befuellt, traegt die Stufe
+   aber als Fliesskommazahl ueber `thunder_label_value()`.
+
+6. **SMS macht es bereits genau so.** `sms_trip.py:303-323` baut die
+   Gewitter-Stundenreihe ausschliesslich aus
+   `build_day_window_points(start_hour=…, end_hour=…)` — rein Tagesfenster,
+   ohne jede Nachtangabe. Die PO-Vorgabe „so wie auch fuer SMS" ist damit
+   am Code belegt, nicht nur behauptet.
+
+7. **Zwei Bestandstests umreissen den Korridor.**
+   - `test_outlook_day_night_thunder_split.py:665` verlangt, dass
+     `row["cells"]` mit und ohne `day_window_*` identisch bleibt —
+     aufgerufen mit `metrics=` und ohne `trip_display_config`. Der Test
+     stellt gezielt die Falle, am Tagesfenster statt am Trip-Diskriminator
+     anzusetzen. Ein korrekter Fix laesst ihn gruen.
+   - `test_outlook_day_night_thunder_split.py:645` ruft
+     `render_outlook_plain()` mit vorgefertigten `rows` und beruehrt
+     `build_outlook_row()` nie. Er bleibt gruen, gleichgueltig ob der Fix
+     richtig oder falsch ist — **kein Nachweis fuer diese Scheibe** und in
+     der Adversary-Runde nicht als solcher zu zitieren.
+
+8. **Der Testhelfer prueft heute den falschen Pfad.**
+   `tests/helpers/trip_outlook_selection.py:163` baut die Ausblick-Zeilen
+   mit `build_outlook_row(..., metrics=metrics)` — der **Compare**-Konvention
+   — und behauptet im Docstring (`:155-157`), das sei der Parameter, den der
+   Zeitplaner fuellt. Gemessen fuellt `trip_report_scheduler.py:2200`
+   stattdessen `trip_display_config`/`report_type`. Die gesamte
+   #1720-S1-Renderer-Suite faehrt den Metrik-Zweig damit ueber den
+   Compare-Weg. `test_trip_outlook_metric_selection.py:17-20` benennt diese
+   Grenze selbst; ADR-0055 (`:167-171`) warnt unabhaengig davon fuer
+   `test_trip_outlook_parity.py`.
+
+## Vom PO entschieden (2026-08-14) — gesetzt, nicht Teil der Freigabefrage
+
+1. **Keine Nachtangabe.** Die Gewitterspalte der 3-Tages-Vorschau zeigt
+   ausschliesslich das **Tagesfenster**, genau wie SMS. Begruendung des PO
+   woertlich: „Nein, nur Tagesfenster, so wie auch für SMS. Dafür definiert
+   der Nutzer es ja." Das Tagesfenster ist eine bewusste Nutzereinstellung;
+   sie zu respektieren ist die Zusicherung, nicht eine Einschraenkung.
+   ⇒ Diese Scheibe weicht damit **bewusst** von #1653/#1671 ab, die eine
+   Nachtangabe eingefuehrt haben. Dort ist die Spaltenmenge fest; hier hat
+   der Nutzer die Spalten selbst gewaehlt.
+
+2. **Fehlende Ampelfarben sind ein eigenes Issue** (#1849), nicht Teil
+   dieser Scheibe.
+
+## Implementation Details
+
+### 1. Tagesfenster-Stufe additiv in `format_trend_tokens()` (`helpers.py`)
+
+`format_trend_tokens()` erhaelt einen zusaetzlichen Rueckgabeschluessel
+`thunder_day_level` — die hoechste Gewitterstufe **im Tagesfenster**,
+berechnet aus denselben `_win_start`/`_win_end` wie `thunder_day_token`
+(`helpers.py:1005-1022`).
+
+🔴 Bewusst **dort** und nicht im Metrik-Zweig: es bleibt bei **einer**
+Fensteraufloesung. Eine zweite, unabhaengige Aufloesung waere exakt die
+Fehlerklasse, gegen die #1653 und #1680 S5a AC-9 schreiben (Stufe aus dem
+einen, Herkunft aus dem anderen Fenster).
+
+Die Stufe wird aus `stage["hourly_thunder"]` abgeleitet (immer befuellt,
+siehe „Am Code gemessen" Punkt 5), nicht aus `hourly_thunder_signals`.
+Rueckabbildung des Fliesskommawerts auf `ThunderLevel` ueber die geteilte
+Skala in `thunder_scale.py` — **keine lokale Kopie der Zuordnung**
+(#1474: eine lokale `{NONE:0,MED:1,HIGH:2}`-Kopie ist seit der
+LOW-Erweiterung stillschweigend falsch).
+
+Additiv: bestehende Aufrufer lesen nur ihre bekannten Schluessel, das
+Verhalten aller heutigen Verbraucher bleibt zeichengleich.
+
+### 2. Metrik-Zweig auf den geteilten Helfer umstellen (`outlook.py:564-587`)
+
+Nur wenn `trip_display_config is not None` (der Trip-Fall) **und** die
+Spalte `kind == "ordinal"` traegt, wird der Wert ersetzt. Die Zweigwahl
+kommt aus `resolve_thunder_day_branch(format_trend_tokens(row), row)`:
+
+| Zweig | Wert der Zelle | Herkunft (`signals`) |
+|---|---|---|
+| `"day"` | `tok["thunder_day_level"]` | Traeger aus dem Tagesfenster |
+| `"none"` | `ThunderLevel.NONE` (explizit „kein Gewitter") | keine |
+| `"plain"` | `summary.thunder_level_max` (unveraendert) | `summary.thunder_level_max_signals` (unveraendert) |
+
+`"plain"` greift, wenn gar keine Stundenreihe vorliegt — dann bleibt alles
+wie heute. Alle anderen Spalten (`kind != "ordinal"`) bleiben unberuehrt.
+
+🔴 Der Diskriminator ist `trip_display_config`, **nicht** die Praesenz des
+Tagesfensters und **nicht** `report_type`. `report_type` ist beim Trip immer
+gesetzt und sagt nichts ueber den Pfad; die Fensterpraesenz ist genau die
+Falle aus „Am Code gemessen" Punkt 7.
+
+### 3. Herkunft wandert mit der Stufe
+
+`outlook.py:580` reicht heute `summary.thunder_level_max_signals` durch —
+die Herkunft des **Aggregats**. Wandert die Stufe ins Tagesfenster, muss die
+Herkunft mit: `union_of_max_carriers()` ueber dieselbe gefensterte Menge.
+Sonst entsteht der AC-12-Fehler aus #1680 Scheibe 1, vor dem der Kommentar
+an genau dieser Stelle (`outlook.py:574-579`) ausdruecklich warnt.
+
+Fuehrt kein Datenpunkt eine Traegerliste (`hourly_thunder_signals is None`),
+erscheint die Stufe **ohne** Herkunft — nie eine Herkunft, die nicht zur
+gezeigten Stufe gehoert (AC-10-Regel aus #1680 S5a).
+
+### 4. Testhelfer auf die echte Trip-Konvention ziehen
+
+`tests/helpers/trip_outlook_selection.py::outlook_rows()` uebergibt kuenftig
+`trip_display_config` + `report_type` + Tagesfenster wie
+`trip_report_scheduler.py:2200`, statt `metrics=`. Der veraltete Docstring
+(`:155-157`) wird mitkorrigiert.
+
+🔴 **Reihenfolge:** Dieser Schritt kommt **zuerst**. Ohne ihn faehrt die
+#1720-S1-Suite weiter den Compare-Weg, der Fix waere fuer sie unsichtbar,
+und jeder folgende gruene Lauf bewiese nichts (Prueforts-Regel).
+
+### 5. Dokumentation nachziehen
+
+- `docs/reference/metric_output_matrix.md` `:89`, `:214`, `:376` — behaupten
+  „Der Trip-Ausblick hat keine waehlbaren Spalten (feste Sieben)". Seit
+  #1720 S1 falsch; die Datei wurde beim Merge nicht nachgezogen.
+- `docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md` `:440-444`
+  — „Der Metrik-Zweig (AC-11b) ist compare-exklusiv. Der Trip ruft die
+  Ausblick-Renderer immer mit `metrics=None`". Am 2026-08-13 richtig,
+  einen Tag spaeter durch #1720 S1 ueberholt. Erratum-Zeile, kein Umschreiben.
+
+## Expected Behavior
+
+Ein Trip mit gesetzter Spaltenauswahl in „3-Tages-Vorschau", die die Spalte
+**Gewitter** enthaelt, zeigt in der Trip-Mail (HTML **und** Klartext) die
+Gewitterstufe des **konfigurierten Tagesfensters** — dieselbe Rechnung, die
+SMS bereits verwendet und die #1653 fuer alle uebrigen Ausgabeorte
+festgelegt hat. Liegt im Tagesfenster kein Gewitter, sagt die Zelle das
+ausdruecklich, statt eine Nachtstufe zu zeigen. Eine Nachtangabe erscheint
+in diesem Zweig **nicht**.
+
+Trips **ohne** Spaltenauswahl, alle uebrigen Spalten und der gesamte
+Ortsvergleich bleiben unveraendert.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip mit gesetzter Spaltenauswahl „3-Tages-Vorschau"
+  inklusive Spalte Gewitter, dessen Stundenreihe im Tagesfenster ein
+  Gewitter zeigt, waehrend das gehzeit-geklemmte Aggregat `NONE` meldet /
+  When die Trip-Mail erzeugt wird / Then nennt die Gewitterspalte die Stufe
+  aus dem Tagesfenster — das Gewitter verschwindet nicht mehr. Nachweis in
+  HTML **und** Klartext.
+
+- **AC-2:** Given denselben Trip, dessen Aggregat eine Stufe traegt, waehrend
+  die Stundenreihe im Tagesfenster leer ist (das Gewitter liegt nachts) /
+  When die Trip-Mail erzeugt wird / Then zeigt die Gewitterspalte
+  ausdruecklich „kein Gewitter" und behauptet keine Tagesstufe.
+
+- **AC-3:** Given denselben Trip mit einem Gewitter ausschliesslich im
+  Nachtfenster / When die Trip-Mail erzeugt wird / Then enthaelt die
+  3-Tages-Vorschau **keine** Nachtangabe — weder als eigene Spalte noch als
+  Zusatz in der Gewitterzelle (PO-Entscheid 2026-08-14, bewusste Abweichung
+  von #1653/#1671).
+
+- **AC-4:** Given einen Trip mit gesetzter Spaltenauswahl, dessen Punkte
+  ueberhaupt keine Gewitterstufen tragen (keine Stundenreihe) / When die
+  Trip-Mail erzeugt wird / Then bleibt die Zelle zeichengleich zum Stand vor
+  dieser Aenderung (Zweig `"plain"`, Rueckfall auf das Aggregat).
+
+- **AC-5:** Given einen Ortsvergleich mit gesetzter Metrik-Auswahl und
+  gewaehlter Gewitterspalte / When dessen Mail erzeugt wird / Then ist die
+  Ausgabe **byte-identisch** zum Stand vor dieser Aenderung — in HTML und
+  Klartext. #1653 AC-6 bleibt in Kraft.
+
+- **AC-6:** Given denselben Trip aus AC-1 / When die Gewitterzelle eine
+  Herkunft nennt / Then stammt diese aus **demselben** Tagesfenster wie die
+  daneben gezeigte Stufe. Traegt kein Datenpunkt eine Traegerliste, erscheint
+  die Stufe ohne Herkunft — nie eine Herkunft aus einer anderen Rechnung als
+  die gezeigte Stufe (AC-10-Regel aus #1680 S5a).
+
+- **AC-7:** Given einen Trip **ohne** gesetzte Spaltenauswahl / When die
+  Trip-Mail erzeugt wird / Then bleibt die 3-Tages-Tabelle byte-identisch
+  zum Stand vor dieser Aenderung, inklusive Nachtangabe und Ampelfarben
+  (Altpfad unberuehrt).
+
+- **AC-8:** Given den Testhelfer `tests/helpers/trip_outlook_selection.py` /
+  When er Ausblick-Zeilen fuer den Trip baut / Then benutzt er dieselbe
+  Aufrufkonvention wie `trip_report_scheduler.py:2200`
+  (`trip_display_config`/`report_type`/Tagesfenster), nicht `metrics=`.
+  Nachweis: eine Verfaelschung des Trip-Zweigs macht mindestens einen Test
+  der #1720-S1-Suite rot.
+
+- **AC-9:** Given die geaenderte `format_trend_tokens()` / When ein
+  bestehender Aufrufer (Altpfad-Ausblick, Telegram, Kurzformat-Mail) sie
+  aufruft / Then bleibt dessen Ausgabe zeichengleich — der neue Schluessel
+  ist rein additiv.
+
+## Nicht in dieser Scheibe
+
+- **Ampelfarben im Metrik-Zweig (#1849).** Der Zweig faerbt keine Zelle ein
+  (`outlook.py:141`, `_otd()` ohne `bg=`). Betrifft alle Spalten und beide
+  Flaechen; eigener Fix, PO-Entscheid 2026-08-14.
+- **Der Ortsvergleich.** Bleibt byte-identisch (AC-5). Ob das Tages-Aggregat
+  dort inhaltlich das richtige Fenster ist, ist eine offene Frage — #1680 S5a
+  AC-11b begruendet nur die **Kohaerenz** von Stufe und Herkunft, nicht die
+  Wahl des Fensters. Nicht hier entscheiden.
+- **`render_outlook_table()` auf den geteilten Helfer umstellen.** #1671 hat
+  das bewusst ausgelassen (strukturell andere Zweigwahl, dortige Known
+  Limitation). Diese Scheibe aendert nur den Metrik-Zweig, nicht den
+  HTML-Altpfad.
+
+## Testplan
+
+- [ ] AC-1: Tagesgewitter sichtbar trotz `NONE` im Aggregat — HTML + Klartext,
+      ueber `render_email()` (echter Aufrufpfad, nicht der Renderer isoliert)
+- [ ] AC-2: „kein Gewitter" statt Nachtstufe bei leerem Tagesfenster
+- [ ] AC-3: keine Nachtangabe im Metrik-Zweig (Negativpruefung auf „nachts")
+- [ ] AC-4: Nullfall ohne Stundenreihe — Zeichengleichheit zum Vorstand
+- [ ] AC-5: Ortsvergleich byte-identisch (HTML + Klartext)
+- [ ] AC-6: Herkunft aus demselben Fenster wie die Stufe; ohne Traegerliste
+      keine Herkunft
+- [ ] AC-7: Trip ohne Auswahl byte-identisch (Altpfad)
+- [ ] AC-8: Testhelfer nutzt die Trip-Konvention
+- [ ] AC-9: `format_trend_tokens()` additiv — Bestandsaufrufer zeichengleich
+
+Kern-Schicht, deterministisch. Keine Mocks, kein Netz. Dateiname nach
+Verhalten: `tests/tdd/test_vorschau_metrik_tagesfenster.py`.
+
+## Mutations-Gegenprobe (PFLICHT)
+
+| # | Verfaelschung | Muss rot werden |
+|---|---|---|
+| M1 | Diskriminator fest auf `True` (auch Compare korrigieren) | mindestens ein Compare-Test (AC-5) |
+| M2 | Diskriminator fest auf `False` (Trip nicht korrigieren) | mindestens ein Trip-Test (AC-1/AC-2) |
+| M3 | Diskriminator auf Fensterpraesenz statt `trip_display_config` | `test_outlook_day_night_thunder_split.py:665` |
+| M4 | Herkunft weiter aus `summary.thunder_level_max_signals` | AC-6 |
+| M5 | Zweig `"none"` liefert das Aggregat statt `ThunderLevel.NONE` | AC-2 |
+| M6 | `thunder_day_level` aus dem 24h-Fenster statt dem Tagesfenster | AC-1 **und** AC-2 |
+| M7 | Testhelfer zurueck auf `metrics=` | AC-8 |
+
+🔴 **M1 und M2 muessen BEIDE greifen.** Wird nur eine Richtung rot, bewacht
+der Nachweis nur die halbe Trennung — genau der Fehler, den
+`test_compare_plain_carries_no_trip_format_remnants` vortaeuscht (er bleibt
+in beiden Richtungen gruen).
+
+## Nachweis vor Commit
+
+1. `tests/tdd/test_vorschau_metrik_tagesfenster.py` gruen
+2. `tests/tdd/test_outlook_day_night_thunder_split.py` gruen (Compare-Schutz)
+3. `tests/tdd/test_trip_outlook_metric_selection.py` gruen (nach Helfer-Umbau)
+4. `tests/tdd/test_trip_outlook_parity.py` gruen (Altpfad)
+5. `tests/golden/email/test_outlook_thunder_day_night_golden.py` gruen
+6. `tests/tdd/test_kompaktmail_ausblick_tagesfenster.py` gruen (#1671 unberuehrt)
+7. `briefing_mail_validator.py` Exit 0 (Renderer-Commit-Gate, `outlook.py` ist
+   eine Mail-Inhalts-Datei)
+8. `tests/tdd/test_issue_811_mode_matrix.py` gruen (dasselbe Gate)
+
+## Known Limitations
+
+- Die Aufzeichnung `REFERENCE_TABLE` in
+  `test_ac1_bestandstrip_html_ausblick_bleibt_byte_identisch` rendert einen
+  Trip **ohne** Auswahl und bewacht damit den Altpfad. Sie sollte sich durch
+  diese Scheibe **nicht** aendern; der im #1841-Kommentar erwartete zweite
+  datierte Eintrag entfaellt voraussichtlich. Vor einem Nachziehen der
+  Referenz ist das zu **messen**, nicht anzunehmen.
+- Der Fix wirkt nur auf den Metrik-Zweig. Zeigt ein Trip beide Zustaende
+  nacheinander (Auswahl gesetzt, dann geleert), wechselt er zwischen zwei
+  Darstellungen mit und ohne Nachtangabe. Das ist die Folge des
+  PO-Entscheids und beabsichtigt.
+- Die Trip/Compare-Trennung haengt an der Aufrufkonvention, nicht an einem
+  ausdruecklichen Merkmal. Ein kuenftiger dritter Aufrufer, der beides oder
+  keines setzt, faellt still in den Compare-Zweig. AC-8 bewacht die heutigen
+  zwei; ein struktureller Wachter dagegen ist nicht Teil dieser Scheibe.
+
+## Architektur-Entscheidung (ADR)
+
+Kein neues ADR. Die Scheibe **vollzieht** ADR-0055 Punkt 4 („eine
+Aufloesung, nicht drei") fuer die Gewitterquelle des Ausblicks und macht den
+Metrik-Zweig zum vierten Aufrufer des mit #1671 eingefuehrten geteilten
+Helfers. Die bewusste Abweichung von #1653/#1671 (keine Nachtangabe) ist
+eine PO-Entscheidung ueber eine **nutzerkonfigurierte** Spaltenmenge, keine
+Architekturentscheidung — sie steht oben unter „Vom PO entschieden" und in
+AC-3.
+
+## Offene Punkte für den PO
+
+Keine. Beide Designfragen sind am 2026-08-14 entschieden (keine Nachtangabe;
+Ampelfarben als #1849).
+
+## Changelog
+
+| Datum | Version | Aenderung |
+|---|---|---|
+| 2026-08-14 | 1.0 | Erstfassung nach Kontext- und Analysephase (Stand `57e36375`) |

--- a/docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md
+++ b/docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md
@@ -341,6 +341,16 @@ Ortsvergleich bleiben unveraendert.
   keine bewusste Ablehnung), und #1680 S5a AC-11b begruendet nur die
   **Kohaerenz** von Stufe und Herkunft, nicht die Wahl des Fensters. Nicht
   hier entscheiden.
+- **Das Auswahl-Vokabular (`{metric_id, aggregation}` vs. Katalog-Kennungen).**
+  PO-Entscheid 2026-08-14, gebucht als **#1848**: die Paar-Darstellung und die
+  Kaskaden-Nachbildung in `resolve_trip_outlook_metrics()`
+  (`compare_outlook_metric_ids.py:78-102`) sollen perspektivisch entfallen.
+  Diese Scheibe **vertieft sie nicht**: sie fasst weder
+  `resolve_trip_outlook_metrics()` noch `outlook_columns()` an und erkennt die
+  Gewitterspalte an `col["kind"] == "ordinal"` — einer **Katalog**-Eigenschaft
+  (`compare_outlook_metric_ids.py:164-166`), nicht am Paar-Vokabular. Der Fix
+  bleibt damit tragfaehig, egal welches Vokabular #1848 durchsetzt.
+
 - **`render_outlook_table()` auf den geteilten Helfer umstellen.** #1671 hat
   das bewusst ausgelassen (strukturell andere Zweigwahl, dortige Known
   Limitation). Diese Scheibe aendert nur den Metrik-Zweig, nicht den

--- a/docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md
+++ b/docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md
@@ -301,10 +301,17 @@ Ortsvergleich bleiben unveraendert.
 - **Ampelfarben im Metrik-Zweig (#1849).** Der Zweig faerbt keine Zelle ein
   (`outlook.py:141`, `_otd()` ohne `bg=`). Betrifft alle Spalten und beide
   Flaechen; eigener Fix, PO-Entscheid 2026-08-14.
-- **Der Ortsvergleich.** Bleibt byte-identisch (AC-5). Ob das Tages-Aggregat
-  dort inhaltlich das richtige Fenster ist, ist eine offene Frage — #1680 S5a
-  AC-11b begruendet nur die **Kohaerenz** von Stufe und Herkunft, nicht die
-  Wahl des Fensters. Nicht hier entscheiden.
+- **Der Ortsvergleich.** Bleibt byte-identisch (AC-5). Er leidet **nicht** am
+  Fehler dieser Scheibe: der Ortsvergleich kennt keine Etappen
+  (`fix-1361-1368-ausblick-konfigurierbar.md:70`), also gibt es nichts, wogegen
+  geklemmt werden koennte — `_group_by_calendar_day()` aggregiert den vollen
+  Kalendertag, die Nacht ist dort bereits enthalten und verschwindet nicht.
+  Ob zusaetzlich ein Tag/Nacht-Split fuer den Ortsvergleich sinnvoll waere,
+  ist **unentschieden**: #1653 AC-6 ist reiner Bestandsschutz (das dortige
+  Finding F003 nahm eine *versehentliche* Compare-Aenderung zurueck, es war
+  keine bewusste Ablehnung), und #1680 S5a AC-11b begruendet nur die
+  **Kohaerenz** von Stufe und Herkunft, nicht die Wahl des Fensters. Nicht
+  hier entscheiden.
 - **`render_outlook_table()` auf den geteilten Helfer umstellen.** #1671 hat
   das bewusst ausgelassen (strukturell andere Zweigwahl, dortige Known
   Limitation). Diese Scheibe aendert nur den Metrik-Zweig, nicht den

--- a/docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md
+++ b/docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md
@@ -3,7 +3,7 @@ entity_id: fix_1841_vorschau_metrik_tagesfenster
 type: bugfix
 created: 2026-08-14
 updated: 2026-08-14
-status: draft
+status: approved
 version: "1.0"
 tags: [gewitter, ausblick, vorschau, tagesfenster, metrik-zweig, issue-1841]
 ---
@@ -23,7 +23,9 @@ tags: [gewitter, ausblick, vorschau, tagesfenster, metrik-zweig, issue-1841]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-go 2026-08-15 (Klartext-Freigabe der neun ACs
+      auf Deutsch). Zugleich gesetzt: keine Nachtangabe im Metrik-Zweig
+      (Tagesfenster wie SMS), Ampelfarben als eigenes Issue #1849.
 
 ## Purpose
 

--- a/docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md
+++ b/docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md
@@ -205,6 +205,22 @@ Skala in `thunder_scale.py` — **keine lokale Kopie der Zuordnung**
 (#1474: eine lokale `{NONE:0,MED:1,HIGH:2}`-Kopie ist seit der
 LOW-Erweiterung stillschweigend falsch).
 
+**Nachtrag 2026-08-15 (RED/GREEN-Phase, am Code gemessen): ZWEI Schluessel,
+nicht einer.** Die Herkunft braucht einen eigenen additiven Schluessel
+`thunder_day_carriers` — die **Rohliste** der Traeger, nicht den bereits
+verketteten String `thunder_day_origin`. Zwei gemessene Gruende:
+
+1. `_fmt_thunder(v, hail, signals)` **iteriert** ueber `signals` und mappt
+   selbst ueber `thunder_signal_label()`. Ein String liefe zeichenweise
+   durch — ein stiller Formatfehler, kein Absturz.
+2. Die Traeger in `outlook.py` erneut zu filtern waere die **zweite**
+   Fensteraufloesung, die dieser Abschnitt und #1680 S5a AC-9 gerade
+   verbieten.
+
+Beide Schluessel speisen sich aus den Mengen, die `format_trend_tokens()
+`**ohnehin schon** berechnet (`_day_samples` / `_day_carriers`,
+`helpers.py:1010-1035`). Damit bleibt es bei **einer** Aufloesung.
+
 Additiv: bestehende Aufrufer lesen nur ihre bekannten Schluessel, das
 Verhalten aller heutigen Verbraucher bleibt zeichengleich.
 
@@ -216,7 +232,7 @@ kommt aus `resolve_thunder_day_branch(format_trend_tokens(row), row)`:
 
 | Zweig | Wert der Zelle | Herkunft (`signals`) |
 |---|---|---|
-| `"day"` | `tok["thunder_day_level"]` | Traeger aus dem Tagesfenster |
+| `"day"` | `tok["thunder_day_level"]` | `tok["thunder_day_carriers"]` (Rohliste) |
 | `"none"` | `ThunderLevel.NONE` (explizit „kein Gewitter") | keine |
 | `"plain"` | `summary.thunder_level_max` (unveraendert) | `summary.thunder_level_max_signals` (unveraendert) |
 

--- a/src/output/renderers/email/helpers.py
+++ b/src/output/renderers/email/helpers.py
@@ -1026,7 +1026,9 @@ def format_trend_tokens(stage: dict) -> dict:
     # zweite, unabhaengige Fensterauflösung waere genau die Fehlerklasse aus
     # #1653/#1498 (Stufe aus dem einen, Herkunft aus dem anderen Fenster,
     # Spec AC-9). Der Nachtteil bekommt bewusst KEINE Herkunft (AC-6).
-    from output.metric_format import thunder_signal_label, union_of_max_carriers
+    from output.metric_format import (
+        thunder_label_value, thunder_signal_label, union_of_max_carriers,
+    )
 
     _signal_rows = stage.get("hourly_thunder_signals") or ()
     _day_carriers = union_of_max_carriers(
@@ -1037,6 +1039,25 @@ def format_trend_tokens(stage: dict) -> dict:
         ", ".join(thunder_signal_label(s) for s in _day_carriers)
         if _day_carriers else None
     )
+
+    # Issue #1841: die hoechste Gewitterstufe IM TAGESFENSTER als
+    # ThunderLevel-OBJEKT (nicht nur als String-Token) -- der Metrik-Zweig
+    # des Ausblicks (outlook.py) braucht ein Objekt fuer _fmt_thunder(),
+    # keinen Text. Aus `_day_samples` (immer befuellt), NICHT aus
+    # `hourly_thunder_signals` (None ohne Traegerlisten, s.o.).
+    # Rueckabbildung ueber die GETEILTE Render-Skala (thunder_label_value,
+    # thunder_scale.py) -- keine lokale Kopie der Zuordnung (#1474).
+    # `thunder_day_carriers` (Rohliste, additiv analog `thunder_day_origin`)
+    # reicht dieselbe, bereits gefensterte `_day_carriers`-Menge unformatiert
+    # durch -- eine ZWEITE, unabhaengige Fensterauflösung im Metrik-Zweig
+    # waere genau die Fehlerklasse, gegen die #1653/#1680 S5a AC-9 schreiben.
+    _level_by_value = {thunder_label_value(l): l for l in ThunderLevel}
+    _day_values = [s.value for s in _day_samples]
+    thunder_day_level = (
+        _level_by_value.get(int(round(max(_day_values))))
+        if _day_values else None
+    )
+    thunder_day_carriers = _day_carriers
 
     return {
         "temp_str": temp_str,
@@ -1060,6 +1081,9 @@ def format_trend_tokens(stage: dict) -> dict:
         "thunder_night_token": thunder_night_token,
         # Issue #1680 S5a: fertiger Herkunfts-Zusatz des Tagesteils (oder None)
         "thunder_day_origin": thunder_day_origin,
+        # Issue #1841: Tagesfenster-STUFE + Rohliste der Traeger (additiv)
+        "thunder_day_level": thunder_day_level,
+        "thunder_day_carriers": thunder_day_carriers,
     }
 
 

--- a/src/output/renderers/email/helpers.py
+++ b/src/output/renderers/email/helpers.py
@@ -1051,7 +1051,7 @@ def format_trend_tokens(stage: dict) -> dict:
     # reicht dieselbe, bereits gefensterte `_day_carriers`-Menge unformatiert
     # durch -- eine ZWEITE, unabhaengige Fensterauflösung im Metrik-Zweig
     # waere genau die Fehlerklasse, gegen die #1653/#1680 S5a AC-9 schreiben.
-    _level_by_value = {thunder_label_value(l): l for l in ThunderLevel}
+    _level_by_value = {thunder_label_value(stufe): stufe for stufe in ThunderLevel}
     _day_values = [s.value for s in _day_samples]
     thunder_day_level = (
         _level_by_value.get(int(round(max(_day_values))))

--- a/src/output/renderers/email/outlook.py
+++ b/src/output/renderers/email/outlook.py
@@ -578,10 +578,41 @@ def build_outlook_row(
         # das Tagesfenster -- eine Herkunft, die nicht zur gezeigten Stufe
         # gehoert, waere der AC-12-Fehler aus Scheibe 1.
         _signals = getattr(summary, "thunder_level_max_signals", None)
+        # Issue #1841: im TRIP-Fall (trip_display_config gesetzt) liest die
+        # Gewitterspalte (kind == "ordinal") das konfigurierte TAGESFENSTER
+        # statt des gehzeit-geklemmten Aggregats -- derselbe geteilte Helfer
+        # wie Kompaktmail/Klartext-Altpfad/Telegram (#1671). Diskriminator ist
+        # `trip_display_config`, NICHT `report_type` (beim Trip immer gesetzt,
+        # sagt nichts ueber den Pfad) und NICHT die Fensterpraesenz (Falle:
+        # test_outlook_day_night_thunder_split.py:665, gilt fuer Compare mit
+        # gesetztem Fenster). Der Ortsvergleich (trip_display_config is None)
+        # bleibt unveraendert (AC-5).
+        _thunder_value = summary.thunder_level_max
+        _thunder_signals = _signals
+        if trip_display_config is not None:
+            from app.models import ThunderLevel as _ThunderLevel
+
+            _tok = format_trend_tokens(row)
+            _zweig = resolve_thunder_day_branch(_tok, row)
+            if _zweig == "day":
+                # Stufe UND Herkunft aus DEMSELBEN Fenster (AC-6) -- beide
+                # Schluessel speisen sich aus derselben, in
+                # format_trend_tokens() EINMAL berechneten Menge, keine
+                # zweite Fensterauflösung hier.
+                _thunder_value = _tok.get("thunder_day_level")
+                _thunder_signals = _tok.get("thunder_day_carriers")
+            elif _zweig == "none":
+                _thunder_value = _ThunderLevel.NONE
+                _thunder_signals = None
+            # "plain": _thunder_value/_thunder_signals bleiben das Aggregat
+            # (unveraendert, wie ohne Stundenreihe/AC-4).
         row["cells"] = [
             format_outlook_value(
-                getattr(summary, col["field"], None),
-                {**col, "hail": _hail, "signals": _signals},
+                (_thunder_value if col.get("kind") == "ordinal"
+                 else getattr(summary, col["field"], None)),
+                {**col, "hail": _hail,
+                 "signals": (_thunder_signals if col.get("kind") == "ordinal"
+                             else _signals)},
             )
             for col in outlook_columns(metrics)
         ]

--- a/tests/helpers/trip_outlook_selection.py
+++ b/tests/helpers/trip_outlook_selection.py
@@ -149,19 +149,45 @@ def tages_summary(index: int, anteile: int = 1):
     )
 
 
-def outlook_rows(metrics: Optional[list[dict]] = None) -> list[dict]:
+def outlook_rows(
+    metrics: Optional[list[dict]] = None,
+    *,
+    trip_display_config: object = None,
+    report_type: str = "evening",
+    day_window_start_hour: Optional[int] = None,
+    day_window_end_hour: Optional[int] = None,
+    points_override: Optional[dict[int, list]] = None,
+    summary_override: Optional[dict[int, object]] = None,
+) -> list[dict]:
     """Die drei Ausblick-Zeilen, gebaut wie der Scheduler sie baut.
 
-    ``metrics`` geht 1:1 an ``build_outlook_row`` -- der Parameter, den
-    ``_build_stage_trend()`` (trip_report_scheduler.py:2161) mit dieser
-    Lieferung fuellt. ``name``/``note`` haengt der Scheduler danach an.
+    RED-Korrektur (#1841, AC-8): ``metrics`` ist NICHT der Parameter, den
+    ``trip_report_scheduler.py:2282`` fuellt -- das ist die COMPARE-
+    Konvention. Der bisherige Docstring behauptete das Gegenteil. Der
+    Zeitplaner reicht stattdessen die UNGEKOLLABIERTE
+    ``trip_display_config``/``report_type``/das Tagesfenster durch und
+    ueberlaesst ``build_outlook_row`` die Aufloesung (s. dortiger
+    Docstring). Ist ``trip_display_config`` gesetzt, geht dieser Helfer
+    denselben Weg; ``metrics`` bleibt dann unbenutzt (Vorrangregel in
+    ``build_outlook_row``). ``points_override``/``summary_override``
+    (Tagesindex -> Wert) spielen Tests eigene Punktreihen/Aggregate ein --
+    noetig fuer Geometrien, in denen Gehzeit-Aggregat und Tagesfenster
+    auseinanderfallen (#1841 Spec "Fixtur-Geometrie").
     """
     from output.renderers.email.outlook import build_outlook_row
 
     with utc_process_tz():
         zeilen = [
-            build_outlook_row(_summary(i), _points(i), _TAGE[i][0], TZ,
-                              metrics=metrics)
+            build_outlook_row(
+                (summary_override or {}).get(i, _summary(i)),
+                (points_override or {}).get(i, _points(i)),
+                _TAGE[i][0], TZ,
+                metrics=metrics if trip_display_config is None else None,
+                trip_display_config=trip_display_config,
+                report_type=report_type,
+                day_window_start_hour=day_window_start_hour,
+                day_window_end_hour=day_window_end_hour,
+            )
             for i in range(len(_TAGE))
         ]
     for i, zeile in enumerate(zeilen):

--- a/tests/tdd/test_vorschau_metrik_tagesfenster.py
+++ b/tests/tdd/test_vorschau_metrik_tagesfenster.py
@@ -1,0 +1,366 @@
+"""TDD RED -- #1841: 3-Tages-Vorschau liest die Gewitterspalte aus dem
+falschen Zeitfenster, sobald der Nutzer eine Ausblick-Spaltenauswahl
+gesetzt hat.
+
+SPEC: docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md (AC-1..9)
+KONTEXT: docs/context/fix-1841-ausblick-metrik-tagesfenster.md
+
+RED-Ursache (heute gemessen): ``build_outlook_row()``
+(``src/output/renderers/email/outlook.py:581-587``) baut die Gewitterzelle
+des Metrik-Zweigs im TRIP-Fall ueber ``getattr(summary, "thunder_level_max")``
+-- das auf die Gehzeit geklemmte Aggregat -- statt ueber das konfigurierte
+Tagesfenster (denselben geteilten Helfer ``resolve_thunder_day_branch()``,
+den #1671 fuer Kompaktmail/Klartext-Altpfad/Telegram liefert).
+
+Fixtur-Geometrie (Spec "Fixtur-Geometrie", PFLICHT): AC-1 und AC-2 brauchen
+ENTGEGENGESETZTE Zuschnitte, sonst liefern Aggregat und Tagesfenster
+denselben Wert und der jeweilige AC-Test prueft nichts. Beide Fixturen
+haben deshalb einen eigenen, vorangestellten Vorbedingungs-Test.
+
+PRUEFORT = WIRKORT: AC-1/AC-2/AC-3 rendern ueber
+``tests.helpers.trip_outlook_selection.render_trip_mail()`` --
+``TripReportFormatter.format_email()``, den echten Aufrufpfad inkl.
+``html.py:1364``/``plain.py:344``.
+
+KEIN MOCK-THEATER. Echte ``ForecastDataPoint``/``SegmentWeatherSummary``,
+echter Renderer-Aufruf. Kein Netz.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+# Pfadregel #1409: Pruefling relativ zur eigenen Testdatei aufloesen -- sonst
+# pruefte ein Worktree-Lauf die unveraenderte Hauptrepo-Kopie.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+for _pfad in (REPO_ROOT, REPO_ROOT / "src"):
+    if str(_pfad) not in sys.path:
+        sys.path.insert(0, str(_pfad))
+
+from app.models import ForecastDataPoint, SegmentWeatherSummary, ThunderLevel  # noqa: E402
+from output.renderers.email.compare_html import _fmt_thunder  # noqa: E402
+from output.renderers.email.helpers import format_trend_tokens  # noqa: E402
+from output.renderers.email.outlook import build_outlook_row  # noqa: E402
+from output.tokens.dto import HourlyValue  # noqa: E402
+from tests.helpers.trip_outlook_selection import (  # noqa: E402
+    display_config, html_outlook_body_rows, html_outlook_headers,
+    outlook_rows, plain_outlook_block, render_trip_mail,
+)
+
+_UTC = ZoneInfo("UTC")
+GEWITTER = {"metric_id": "thunder", "aggregation": "max"}
+DAY_START, DAY_END = 4, 19
+
+
+def _point(hour: int, level: ThunderLevel, signals=None) -> ForecastDataPoint:
+    """Ein Stundenpunkt (UTC) fuer den 20.7.2026 (Sommerzeit) -- Stunden 14
+    (Mitte) bzw. 0 (Mitternacht) bleiben unter BEIDEN moeglichen
+    Ortszeit-Verschiebungen (UTC direkt oder Europe/Berlin +1/+2) sicher
+    innerhalb bzw. ausserhalb des Tagesfensters 4-19."""
+    return ForecastDataPoint(
+        ts=datetime(2026, 7, 20, hour, 0, tzinfo=timezone.utc),
+        thunder_level=level, thunder_level_signals=signals,
+    )
+
+
+def _summary(level: ThunderLevel, signals=None) -> SegmentWeatherSummary:
+    return SegmentWeatherSummary(
+        temp_min_c=9.0, temp_max_c=18.0, wind_max_kmh=20.0, precip_sum_mm=0.0,
+        thunder_level_max=level, thunder_level_max_signals=signals,
+    )
+
+
+# AC-1: Gewitter um 14 Uhr (im Tagesfenster), Gehzeit-Aggregat sah es NICHT
+# (die Gehzeit war enger als das Fenster) -> Aggregat meldet NONE.
+AC1_POINTS = [_point(14, ThunderLevel.HIGH, signals=["cape"])]
+AC1_SUMMARY = _summary(ThunderLevel.NONE)
+# Variante ohne Traegerliste (AC-6 Zusatzfall).
+AC1_POINTS_OHNE_SIGNALE = [_point(14, ThunderLevel.HIGH)]
+
+# AC-2: Gewitter um 0 Uhr (ausserhalb des Tagesfensters), Gehzeit-Aggregat
+# sah es SEHR WOHL (die Gehzeit reichte in die Nacht hinein) -> HIGH.
+AC2_POINTS = [_point(0, ThunderLevel.HIGH, signals=["cape"])]
+AC2_SUMMARY = _summary(ThunderLevel.HIGH, signals=["cape"])
+
+
+# ═══════════════════ Fixtur-Vorbedingungen (KEIN AC) ═════════════════════
+# Zeigen, dass Aggregat und Tagesfenster-Stufe je Fixture verschiedene Werte
+# liefern -- sonst pruefte der zugehoerige AC-Test nichts (Spec
+# "Fixtur-Geometrie"). Beide muessen schon HEUTE gruen sein, unabhaengig
+# vom Fix: sie beschreiben nur die Testdaten.
+
+def test_vorbedingung_ac1_aggregat_und_tagesfenster_liefern_verschiedene_werte():
+    """Given die AC-1-Fixture / When Aggregat und der (bereits bestehende)
+    Tagesfenster-Token verglichen werden / Then unterscheiden sie sich:
+    das Aggregat meldet NONE, das Tagesfenster traegt ein Gewitter."""
+    row = build_outlook_row(
+        AC1_SUMMARY, AC1_POINTS, "Mo", _UTC,
+        day_window_start_hour=DAY_START, day_window_end_hour=DAY_END,
+    )
+    tok = format_trend_tokens(row)
+    assert AC1_SUMMARY.thunder_level_max == ThunderLevel.NONE
+    assert tok["thunder_day_token"] != "-", (
+        "Vorbedingung verletzt: die AC-1-Fixture zeigt im Tagesfenster kein "
+        "Gewitter -- Aggregat und Tagesfenster liefern denselben Wert, der "
+        "AC-1-Test koennte nichts pruefen."
+    )
+
+
+def test_vorbedingung_ac2_aggregat_und_tagesfenster_liefern_verschiedene_werte():
+    """Given die AC-2-Fixture (Gegenrichtung) / When Aggregat und
+    Tagesfenster-Token verglichen werden / Then unterscheiden sie sich:
+    das Aggregat traegt eine Stufe, das Tagesfenster ist leer."""
+    row = build_outlook_row(
+        AC2_SUMMARY, AC2_POINTS, "Mo", _UTC,
+        day_window_start_hour=DAY_START, day_window_end_hour=DAY_END,
+    )
+    tok = format_trend_tokens(row)
+    assert AC2_SUMMARY.thunder_level_max == ThunderLevel.HIGH
+    assert tok["thunder_day_token"] == "-", (
+        "Vorbedingung verletzt: die AC-2-Fixture zeigt im Tagesfenster ein "
+        "Gewitter -- Aggregat und Tagesfenster liefern denselben Wert, der "
+        "AC-2-Test koennte nichts pruefen."
+    )
+
+
+# ══════════════════════════════ AC-1, AC-2 ═══════════════════════════════
+
+def test_ac1_tagesgewitter_sichtbar_trotz_none_im_aggregat():
+    """AC-1: Given ein Trip mit gesetzter Spaltenauswahl (Gewitter), dessen
+    Stundenreihe im Tagesfenster ein Gewitter (14 Uhr, HIGH) zeigt, waehrend
+    das gehzeit-geklemmte Aggregat NONE meldet / When die Trip-Mail erzeugt
+    wird / Then nennt die Gewitterspalte die Stufe aus dem Tagesfenster --
+    nicht NONE. Nachweis in HTML UND Klartext, ueber den echten
+    Renderpfad (``render_trip_mail`` -> ``TripReportFormatter.format_email``).
+    """
+    dc = display_config(outlook_metrics=[GEWITTER])
+    row = build_outlook_row(
+        AC1_SUMMARY, AC1_POINTS, "Mo", _UTC,
+        trip_display_config=dc, report_type="evening",
+        day_window_start_hour=DAY_START, day_window_end_hour=DAY_END,
+    )
+    html, plain = render_trip_mail(dc, [row])
+    erwartet = _fmt_thunder(ThunderLevel.HIGH, None, ["cape"])
+
+    assert html_outlook_headers(html) == ["Tag", "Gewitter"], (
+        f"Testaufbau: unerwartete Kopfzeile {html_outlook_headers(html)!r}."
+    )
+    zeilen = html_outlook_body_rows(html)
+    zelle = zeilen[0][1] if zeilen else None
+    assert zelle == erwartet, (
+        f"HTML-Gewitterzelle {zelle!r} statt {erwartet!r} -- die Spalte "
+        "zeigt weiterhin das gehzeit-geklemmte Aggregat (NONE) statt der "
+        "Tagesfenster-Stufe (AC-1)."
+    )
+
+    block = plain_outlook_block(plain)
+    assert block is not None and f"Gewitter {erwartet}" in block, (
+        f"Klartext-Ausblick:\n{block}\nenthaelt nicht 'Gewitter {erwartet}' "
+        "-- dieselbe Ursache wie im HTML-Zweig (AC-1)."
+    )
+
+
+def test_ac2_kein_gewitter_statt_nachtstufe_bei_leerem_tagesfenster():
+    """AC-2: Given denselben Trip, dessen Aggregat eine Stufe traegt (HIGH),
+    waehrend die Stundenreihe im Tagesfenster leer ist (das Gewitter liegt
+    um 0 Uhr nachts) / When die Trip-Mail erzeugt wird / Then zeigt die
+    Gewitterspalte ausdruecklich 'kein Gewitter' (ThunderLevel.NONE) und
+    behauptet keine Tagesstufe."""
+    dc = display_config(outlook_metrics=[GEWITTER])
+    row = build_outlook_row(
+        AC2_SUMMARY, AC2_POINTS, "Mo", _UTC,
+        trip_display_config=dc, report_type="evening",
+        day_window_start_hour=DAY_START, day_window_end_hour=DAY_END,
+    )
+    html, _ = render_trip_mail(dc, [row])
+    erwartet = _fmt_thunder(ThunderLevel.NONE)
+
+    zeilen = html_outlook_body_rows(html)
+    zelle = zeilen[0][1] if zeilen else None
+    assert zelle == erwartet, (
+        f"HTML-Gewitterzelle {zelle!r} statt {erwartet!r} -- die Spalte "
+        "behauptet ein Tagesgewitter, das nur im Nachtfenster lag (AC-2)."
+    )
+
+
+def test_ac3_keine_nachtangabe_im_metrik_zweig():
+    """AC-3: Given denselben Trip aus AC-2 (Gewitter ausschliesslich im
+    Nachtfenster) / When die Trip-Mail erzeugt wird / Then enthaelt die
+    3-Tages-Vorschau KEINE Nachtangabe -- weder als eigene Spalte noch als
+    Zusatz in der Gewitterzelle (PO-Entscheid 2026-08-14, bewusste
+    Abweichung von #1653/#1671)."""
+    dc = display_config(outlook_metrics=[GEWITTER])
+    row = build_outlook_row(
+        AC2_SUMMARY, AC2_POINTS, "Mo", _UTC,
+        trip_display_config=dc, report_type="evening",
+        day_window_start_hour=DAY_START, day_window_end_hour=DAY_END,
+    )
+    html, plain = render_trip_mail(dc, [row])
+
+    zeilen = html_outlook_body_rows(html)
+    zelle = (zeilen[0][1] if zeilen else "").lower()
+    assert "nachts" not in zelle, (
+        f"HTML-Gewitterzelle {zelle!r} enthaelt eine Nachtangabe (AC-3)."
+    )
+    block = (plain_outlook_block(plain) or "").lower()
+    assert "nachts" not in block, (
+        f"Klartext-Ausblick enthaelt eine Nachtangabe:\n{block}\n(AC-3)"
+    )
+
+
+def test_ac4_ohne_stundenreihe_bleibt_die_zelle_zeichengleich():
+    """AC-4: Given einen Trip mit gesetzter Spaltenauswahl, dessen Punkte
+    ueberhaupt keine Gewitterstufen tragen (keine Stundenreihe) / When eine
+    Zeile gebaut wird / Then bleibt die Zelle zeichengleich zum Stand vor
+    dieser Aenderung (Zweig 'plain', Rueckfall auf das Aggregat).
+
+    Regressionsschutz: bleibt gruen, unabhaengig davon ob der Fix schon
+    implementiert ist -- der Nullfall ohne Stundenreihe ist gerade NICHT
+    von #1841 betroffen."""
+    dc = display_config(outlook_metrics=[GEWITTER])
+    summary = _summary(ThunderLevel.MED, signals=["blitzdichte"])
+    row = build_outlook_row(
+        summary, [], "Mo", _UTC,
+        trip_display_config=dc, report_type="evening",
+        day_window_start_hour=DAY_START, day_window_end_hour=DAY_END,
+    )
+    erwartet = [_fmt_thunder(ThunderLevel.MED, None, ["blitzdichte"])]
+    assert row.get("cells") == erwartet, (
+        f"Zelle {row.get('cells')!r} statt {erwartet!r} -- der Nullfall "
+        "ohne Stundenreihe muss unveraendert auf das Aggregat zurueckfallen "
+        "(AC-4)."
+    )
+
+
+def test_ac5_ortsvergleich_bleibt_byte_identisch():
+    """AC-5: Given einen Ortsvergleich (metrics=..., KEIN
+    trip_display_config) mit gesetzter Metrik-Auswahl und denselben
+    asymmetrischen Punkten wie AC-1 / When dessen Zeile gebaut wird / Then
+    zeigt die Zelle weiterhin ``summary.thunder_level_max`` -- unveraendert
+    (#1653 AC-6 bleibt in Kraft).
+
+    Regressionsschutz -- ist heute bereits gruen (der Metrik-Zweig kennt
+    noch gar keine Tagesfenster-Verzweigung) und MUSS es nach dem Fix
+    bleiben (Mutations-Gegenprobe M1: Diskriminator faelschlich auf
+    ``True``)."""
+    row = build_outlook_row(
+        AC1_SUMMARY, AC1_POINTS, "Mo", _UTC, metrics=[GEWITTER],
+        day_window_start_hour=DAY_START, day_window_end_hour=DAY_END,
+    )
+    erwartet = [_fmt_thunder(ThunderLevel.NONE)]
+    assert row["cells"] == erwartet, (
+        f"Compare-Zelle {row['cells']!r} statt {erwartet!r} -- der "
+        "Ortsvergleich darf sich durch diese Scheibe nicht aendern (AC-5)."
+    )
+
+
+def test_ac6_herkunft_stammt_aus_demselben_fenster_wie_die_stufe():
+    """AC-6: Given denselben Trip aus AC-1 (das Aggregat traegt KEINE
+    Herkunft) / When die Gewitterzelle eine Herkunft nennt / Then stammt
+    diese aus dem Tagesfenster -- nicht aus dem (hier leeren) Aggregat."""
+    dc = display_config(outlook_metrics=[GEWITTER])
+    assert AC1_SUMMARY.thunder_level_max_signals is None, (
+        "Testaufbau: das Aggregat darf keine Herkunft tragen, sonst "
+        "unterscheidet dieser Test die beiden Quellen nicht."
+    )
+    row = build_outlook_row(
+        AC1_SUMMARY, AC1_POINTS, "Mo", _UTC,
+        trip_display_config=dc, report_type="evening",
+        day_window_start_hour=DAY_START, day_window_end_hour=DAY_END,
+    )
+    erwartet = [_fmt_thunder(ThunderLevel.HIGH, None, ["cape"])]
+    assert row.get("cells") == erwartet, (
+        f"Zelle {row.get('cells')!r} statt {erwartet!r} -- sie muss die "
+        "Herkunft aus dem Tagesfenster nennen (AC-6)."
+    )
+
+
+def test_ac6_ohne_traegerliste_erscheint_die_stufe_ohne_herkunft():
+    """AC-6 Zusatzfall: traegt KEIN Datenpunkt im Tagesfenster eine
+    Traegerliste, erscheint die (korrekte) Tagesfenster-Stufe OHNE Herkunft
+    -- nie eine Herkunft aus einer anderen Rechnung (AC-10-Regel aus
+    #1680 S5a)."""
+    dc = display_config(outlook_metrics=[GEWITTER])
+    row = build_outlook_row(
+        AC1_SUMMARY, AC1_POINTS_OHNE_SIGNALE, "Mo", _UTC,
+        trip_display_config=dc, report_type="evening",
+        day_window_start_hour=DAY_START, day_window_end_hour=DAY_END,
+    )
+    erwartet = [_fmt_thunder(ThunderLevel.HIGH, None, None)]
+    assert row.get("cells") == erwartet, (
+        f"Zelle {row.get('cells')!r} statt {erwartet!r} -- ohne "
+        "Traegerliste darf keine Herkunft erscheinen (AC-6)."
+    )
+
+
+def test_ac7_trip_ohne_auswahl_bleibt_altpfad_unberuehrt():
+    """AC-7: Given einen Trip OHNE gesetzte Spaltenauswahl / When eine Zeile
+    gebaut wird / Then bleibt der Row-Dict OHNE 'cells' -- der Altpfad
+    (feste sieben Spalten inkl. Nachtangabe/Ampelfarben) bleibt in Kraft.
+
+    Regressionsschutz -- heute bereits gruen (Metrik-Zweig greift nur bei
+    aufgeloester Auswahl) und muss es bleiben."""
+    dc = display_config()  # outlook_metrics unberuehrt (Altbestand)
+    row = build_outlook_row(
+        AC2_SUMMARY, AC2_POINTS, "Mo", _UTC,
+        trip_display_config=dc, report_type="evening",
+        day_window_start_hour=DAY_START, day_window_end_hour=DAY_END,
+    )
+    assert "cells" not in row, (
+        f"Row {row!r} traegt 'cells', obwohl keine Spaltenauswahl gesetzt "
+        "ist -- der Metrik-Zweig darf ohne Auswahl nicht greifen (AC-7)."
+    )
+
+
+def test_ac8_helfer_baut_trip_zeilen_ueber_die_trip_konvention():
+    """AC-8: Given der Testhelfer ``outlook_rows()`` mit eigens
+    eingespeisten Punkten/Aggregat (AC-1-Geometrie) / When er ueber
+    ``trip_display_config``/``report_type``/Tagesfenster (NICHT ``metrics=``)
+    eine Zeile baut / Then zeigt die gebaute Zeile die Tagesfenster-Stufe --
+    derselbe Aufrufweg wie ``trip_report_scheduler.py:2282``.
+
+    Nachweis (Mutations-Gegenprobe M7): faellt der Helfer zurueck auf
+    ``metrics=``, zeigt die Zelle das (hier NONE-)Aggregat statt der
+    Tagesfenster-Stufe -- dieser Test wird rot."""
+    dc = display_config(outlook_metrics=[GEWITTER])
+    row = outlook_rows(
+        trip_display_config=dc, report_type="evening",
+        day_window_start_hour=DAY_START, day_window_end_hour=DAY_END,
+        points_override={0: AC1_POINTS}, summary_override={0: AC1_SUMMARY},
+    )[0]
+    erwartet = [_fmt_thunder(ThunderLevel.HIGH, None, ["cape"])]
+    assert row.get("cells") == erwartet, (
+        f"Zelle {row.get('cells')!r} statt {erwartet!r} -- der Helfer "
+        "liefert weiterhin die Compare-Zellen (Aggregat) statt der "
+        "Trip-Zellen (Tagesfenster); outlook_rows() nutzt noch nicht die "
+        "Trip-Konvention (AC-8)."
+    )
+
+
+def test_ac9_format_trend_tokens_liefert_zusaetzlich_thunder_day_level():
+    """AC-9: Given ein Stundenfenster mit einem Gewitter um 14 Uhr (HIGH) im
+    Tagesfenster (4-19) / When ``format_trend_tokens()`` aufgerufen wird /
+    Then traegt die Rueckgabe zusaetzlich ``thunder_day_level`` ==
+    ``ThunderLevel.HIGH`` -- additiv, ohne den bestehenden Schluessel
+    ``thunder_day_token`` ('hoch@14') zu veraendern (Bestandsschutz fuer
+    Telegram/Kompaktmail/Altpfad-Aufrufer)."""
+    stage = dict(
+        weekday="Mo", temp_lo=10, temp_hi=18, precip_mm=0.0, wind_dir="W",
+        wind_kmh=20, thunder="NONE",
+        hourly_precip=(), hourly_wind=(), hourly_gust=(),
+        hourly_thunder=(HourlyValue(hour=14, value=3.0),),
+        day_window_start_hour=DAY_START, day_window_end_hour=DAY_END,
+    )
+    tok = format_trend_tokens(stage)
+    assert tok["thunder_day_token"] == "hoch@14", (
+        "Testaufbau: Bestandsverhalten nicht wie erwartet, tatsaechlich "
+        f"{tok['thunder_day_token']!r}."
+    )
+    assert tok.get("thunder_day_level") == ThunderLevel.HIGH, (
+        "format_trend_tokens() liefert noch keinen (korrekten) "
+        "Rueckgabeschluessel 'thunder_day_level' -- AC-9 verlangt eine "
+        "zusaetzliche, additive Tagesfenster-STUFE neben dem bestehenden "
+        "String-Token 'thunder_day_token'."
+    )

--- a/tests/tdd/test_vorschau_metrik_tagesfenster.py
+++ b/tests/tdd/test_vorschau_metrik_tagesfenster.py
@@ -84,6 +84,17 @@ AC1_POINTS_OHNE_SIGNALE = [_point(14, ThunderLevel.HIGH)]
 AC2_POINTS = [_point(0, ThunderLevel.HIGH, signals=["cape"])]
 AC2_SUMMARY = _summary(ThunderLevel.HIGH, signals=["cape"])
 
+# M6-Gegenprobe (Adversary-Finding F001, HIGH): AC-1/AC-2 tragen je NUR EINEN
+# Stundenpunkt -- Tagesfenster- und 24h-Menge sind dort IDENTISCH, eine
+# Verwechslung der beiden Fenster kann darin nicht auffallen. Diese Fixture
+# hat ZWEI Punkte mit unterschiedlichen Stufen auf beiden Seiten der
+# Fenstergrenze: MED um 14 Uhr (im Tagesfenster), HIGH um 0 Uhr (ausserhalb)
+# -- Tagesfenster-Maximum (MED) und 24h-Maximum (HIGH) muessen sich
+# unterscheiden, sonst pruefte der Test wieder nichts (dieselbe Falle wie
+# bei AC-1/AC-2, nur auf der zweiten, unabhaengigen Achse).
+M6_POINTS = [_point(14, ThunderLevel.MED), _point(0, ThunderLevel.HIGH)]
+M6_SUMMARY = _summary(ThunderLevel.NONE)
+
 
 # ═══════════════════ Fixtur-Vorbedingungen (KEIN AC) ═════════════════════
 # Zeigen, dass Aggregat und Tagesfenster-Stufe je Fixture verschiedene Werte
@@ -363,4 +374,67 @@ def test_ac9_format_trend_tokens_liefert_zusaetzlich_thunder_day_level():
         "Rueckgabeschluessel 'thunder_day_level' -- AC-9 verlangt eine "
         "zusaetzliche, additive Tagesfenster-STUFE neben dem bestehenden "
         "String-Token 'thunder_day_token'."
+    )
+
+
+# ═══════════ Mutations-Gegenprobe M6 (Adversary-Finding F001, HIGH) ══════════
+# AC-1/AC-2 tragen je nur EINEN Stundenpunkt -- Tagesfenster- und 24h-Menge
+# sind dort identisch, eine Verwechslung der beiden Fenster (M6: "aus dem
+# 24h-Fenster statt dem Tagesfenster") kann darin nicht auffallen. Diese
+# zweite, unabhaengige Fixtur-Achse braucht mindestens zwei Punkte auf
+# beiden Seiten der Fenstergrenze mit UNTERSCHIEDLICHEN Stufen.
+
+def test_vorbedingung_m6_tagesfenster_max_und_24h_max_liefern_verschiedene_werte():
+    """Fixtur-Vorbedingung (KEIN AC): zeigt, dass fuer die M6-Fixture das
+    Tagesfenster-Maximum (MED, aus dem Punkt um 14 Uhr) und das 24h-Maximum
+    (HIGH, aus dem Punkt um 0 Uhr ausserhalb) verschieden sind -- sonst
+    pruefte der M6-Test nichts. Muss schon HEUTE gruen sein."""
+    from app.thunder_scale import thunder_ordinal
+
+    row = build_outlook_row(
+        M6_SUMMARY, M6_POINTS, "Mo", _UTC,
+        day_window_start_hour=DAY_START, day_window_end_hour=DAY_END,
+    )
+    tok = format_trend_tokens(row)
+    _24h_max = max(
+        (p.thunder_level for p in M6_POINTS if p.thunder_level is not None),
+        key=thunder_ordinal,
+    )
+    assert _24h_max == ThunderLevel.HIGH, (
+        "Testaufbau: das 24h-Maximum der M6-Fixture ist nicht HIGH."
+    )
+    assert tok["thunder_day_token"] == "mittel@14", (
+        "Vorbedingung verletzt: das Tagesfenster-Maximum der M6-Fixture "
+        f"({tok['thunder_day_token']!r}) muss MED ('mittel@14') sein, nicht "
+        "das 24h-Maximum HIGH -- sonst unterscheiden Tagesfenster und 24h-"
+        "Fenster nichts, und der M6-Test koennte die Verwechslung nicht "
+        "fangen."
+    )
+
+
+def test_m6_tagesfenster_stufe_kommt_aus_dem_tagesfenster_nicht_aus_24h():
+    """Mutations-Gegenprobe M6 (Spec-Tabelle): Given eine Stundenreihe mit
+    zwei Punkten -- MED um 14 Uhr (im Tagesfenster 4-19), HIGH um 0 Uhr
+    (ausserhalb) / When die Trip-Mail mit gesetzter Gewitterspalte erzeugt
+    wird / Then zeigt die Zelle die Stufe DES TAGESFENSTERS (MED) -- nicht
+    das 24-Stunden-Maximum (HIGH).
+
+    Eine Ein-Punkt-Fixtur (wie AC-1/AC-2) kann diese Verwechslung nicht
+    fangen, weil Tagesfenster- und 24h-Menge dort identisch sind
+    (Adversary-Finding F001, HIGH)."""
+    dc = display_config(outlook_metrics=[GEWITTER])
+    row = build_outlook_row(
+        M6_SUMMARY, M6_POINTS, "Mo", _UTC,
+        trip_display_config=dc, report_type="evening",
+        day_window_start_hour=DAY_START, day_window_end_hour=DAY_END,
+    )
+    html, _ = render_trip_mail(dc, [row])
+    erwartet = _fmt_thunder(ThunderLevel.MED)
+
+    zeilen = html_outlook_body_rows(html)
+    zelle = zeilen[0][1] if zeilen else None
+    assert zelle == erwartet, (
+        f"HTML-Gewitterzelle {zelle!r} statt {erwartet!r} -- zeigt "
+        "vermutlich das 24h-Maximum (HIGH) statt der Tagesfenster-Stufe "
+        "(MED) (Mutations-Gegenprobe M6)."
     )


### PR DESCRIPTION
Behebt #1841.

## Was der Nutzer merkt

Trip-Editor → **Wertebereiche → 3-Tages-Vorschau**: Wer dort die Spalte **Gewitter** wählt, bekommt die Stufe künftig aus dem **konfigurierten Tagesfenster** statt aus dem auf die Gehzeit geklemmten Aggregat — dieselbe Regel, die SMS bereits benutzt.

Vorher konnte ein reales Tagesgewitter verschwinden (falsch-negativ) oder ein nicht vorhandenes behauptet werden (falsch-positiv). Betroffen waren ausschließlich Trips **mit** gesetzter Spaltenauswahl.

**Keine Nachtangabe** in dieser Spalte — PO-Entscheid vom 2026-08-14: der Nutzer definiert das Tagesfenster gerade zu diesem Zweck.

## Ursache

#1720 S1 (gemerged 2026-08-14) hat den bis dahin compare-exklusiven Metrik-Renderpfad für den Trip geöffnet, ohne die Voraussetzung der damaligen Compare-Entscheidung mitzuprüfen: der Trip **hat** eine Stundenreihe, und sein Aggregat **ist** gehzeit-geklemmt.

🔴 Belegt, nicht hergeleitet: `feat_1680_s5a` hielt unter „Am Code gemessen" Punkt 8 (PO-freigegeben 2026-08-13) fest, der Metrik-Zweig sei compare-exklusiv, „der Trip ruft die Ausblick-Renderer immer mit `metrics=None`". **Einen Tag später** hob #1720 S1 genau diese Voraussetzung auf. Die Messung stimmte — entzogen wurde ihre Grundlage. Erratum in diesem PR nachgetragen.

## Änderung

| Datei | Was |
|---|---|
| `email/helpers.py` | `format_trend_tokens()` liefert **additiv** `thunder_day_level` (Stufe im Tagesfenster als `ThunderLevel`) und `thunder_day_carriers` (Rohliste der Träger). Beide aus den Mengen, die die Funktion **ohnehin schon** berechnet — **eine** Fensterauflösung, keine zweite |
| `email/outlook.py` | Metrik-Zweig ersetzt **nur** die Gewitterspalte (`kind == "ordinal"`) und **nur** im Trip-Fall (`trip_display_config` gesetzt); Zweigwahl über den geteilten `resolve_thunder_day_branch()` aus #1671 — vierter Aufrufer statt vierter eigener Auflösung (ADR-0055) |

**Produktivcode: +58/−3.** Budget wäre 250.

Der Diskriminator ist bewusst `trip_display_config` — **nicht** `report_type` (beim Trip immer gesetzt, sagt nichts über den Pfad) und **nicht** die Präsenz des Tagesfensters (genau die Falle, die `test_outlook_day_night_thunder_split.py:665` stellt).

## Unverändert (zugesichert und geprüft)

Ortsvergleich · Trips ohne Spaltenauswahl · Telegram · Kurzformat-Mail · Altpfad des Ausblicks.

## Nachweise

- **1769 Tests grün** über alle 89 Testdateien, die die geänderten Bausteine berühren, plus die 42 Wächter-Tests direkt unter `tests/`
- **Adversary VERIFIED** nach einem BROKEN-Durchgang (4 Runden). Alle **sieben** Mutationen der Spec-Gegenprobe greifen; M1/M2 (Trip/Compare-Trennung) in **beide** Richtungen
- **`briefing_mail_validator.py` Exit 0** gegen echt zugestellte Trip-Mail
- **`email_spec_validator.py` Exit 0** gegen echt zugestellte Ortsvergleich-Mail (nötig, weil `helpers.py` ein geteilter Renderer-Helfer ist)

### Der BROKEN-Durchgang ist der Kern dieses PR

Mutation **M6** („Stufe aus dem 24h-Fenster statt dem Tagesfenster") wurde zunächst von **keinem** der 81 Tests gefangen. Ursache war ein Fehler der **Spec**, nicht des Codes: sie nannte nur **eine** Fixtur-Achse (Gehzeit ↔ Tagesfenster), es gibt aber eine **zweite, unabhängige** (24h-Reihe ↔ Tagesfenster). Beide Fixturen trugen nur **einen** Stundenpunkt — damit sind beide Mengen identisch, die Filterung kann nicht wirken, ihr Ausfall nicht auffallen.

Dritte Fixture mit zwei Punkten ergänzt (tagsüber schwächer, nachts stärker), plus Vorbedingungs-Test, der beweist, dass die beiden Rechnungen dort überhaupt verschiedene Werte liefern. Gegenprobe: mit M6-Mutation wird genau ein Test rot, ohne sie sind alle grün.

**Der Produktivcode war die ganze Zeit korrekt** — es fehlte der Wächter dagegen, dass er es bleibt.

## Nebenbefunde, ausgegliedert

- **#1849** — die 3-Tages-Vorschau verliert bei gesetzter Spaltenauswahl **alle** Ampelfarben (`outlook.py`, `_otd()` ohne `bg=`). Betrifft alle Spalten, eigener Fix
- **#1197** — zwei Wächter-Befunde: `validate.py` meldet Erfolg, ohne etwas geprüft zu haben; `file_claim_gate.py` ist per Bash-Werkzeug umgehbar (zweiter dokumentierter Fall derselben Klasse)
- **#1196** — fünf vorbestehende Rote in `test_issue_1169_compare_alert_consumer.py`, per A/B als **nicht** von dieser Scheibe verursacht belegt. Auch nicht von #1594: mit dessen Vorgängerstand sind es **sieben** statt fünf

## Dokumentation nachgezogen

- `docs/reference/metric_output_matrix.md` behauptete an drei Stellen, der Trip-Ausblick habe keine wählbaren Spalten — seit #1720 S1 falsch
- `docs/specs/modules/feat_1680_s5a_gewitter_herkunft_ausblick.md` Punkt 8 als Erratum korrigiert, mit der Lehre statt nur der Korrektur

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKtVZP7cxKT9z8VPbkHTwQ
