### PR TITLE
docs(#1851): Alarm-Test-Vorbedingung in critical_lessons aufnehmen

### DIFF
--- a/docs/reference/critical_lessons.md
+++ b/docs/reference/critical_lessons.md
@@ -25,3 +25,31 @@ Import-Richtung bleibt Engine ← Aufrufer, sonst entsteht ein Zyklus über die
 Official-Alerts-Kette. Kein `architecture_guard`-Wächter vorhanden; Regel gilt
 per Konvention.
 Quelle: `docs/specs/_archive/modules/issue_1034_official_alerts_foundation.md` (§189).
+
+## Alarm-Tests: die Vorbedingung „kein Briefing fällig" gehört in die Fixture
+
+Ein Test, der zusichert „Alarm wird zugestellt", muss den Trip so bauen, dass
+**kein geplantes Briefing fällig ist** — sonst greift die Vorlaufsperre aus
+#1594 (`src/services/trip_alert.py:241` → `src/services/alert_gate.py:200` →
+`trip_briefing_due_at`), der Alarm wird planmäßig durch das Briefing **ersetzt**
+(ADR-0009), und der Test scheitert an einer nirgends ausgesprochenen Annahme.
+Weil die Vorgabezeiten 07:00/18:00 Ortszeit bei drei Stunden Fälligkeitsfenster
+gelten, hängt das Ergebnis sonst an der Wanduhr: rot von 07–10 und 18–21 Uhr
+Ortszeit, grün dazwischen.
+
+Praktisch: `report_config.enabled = False` setzen (wird produktiv nur in
+`trip_report_scheduler.py:171` und `:891` gelesen, beide im Briefing-Pfad, nie
+im Alarmpfad). **Vor jeder solchen „Aus"-Flagge zählen, wo sie gelesen wird** —
+sonst macht der Fix den Test grün, indem er ihn entkernt.
+
+Gegenprobe, die etwas taugt: die Bedingung **herstellen** statt abwarten — eine
+Variante mit fälligem Briefing (Briefingzeit aus der *aktuellen* Ortsstunde
+abgeleitet) darf keinen Alarm liefern, die neutralisierte muss einen liefern.
+Beide Varianten brauchen die aktuelle Ortsstunde; setzt nur eine sie, wacht die
+Zusicherung nur drei von 24 Stunden.
+
+Kein Wächter vorhanden: eine Verhaltensänderung im Alarmpfad kann bestehende
+Alarm-Tests kippen, und die CI-Ampel misst das nur zu ihrer Laufzeit — #1594
+kippte drei Tests, ohne dass es auffiel, weil die eigene Ampel abends lief.
+Quelle: #1851 / `docs/specs/modules/fix_1851_alarm_tests_vorlaufsperre.md`;
+Nebenbefund gebucht in #1199.


### PR DESCRIPTION
Reine Doku-Ergänzung, ein Abschnitt in `docs/reference/critical_lessons.md`.

Bei #1851 wurde bewusst **kein** Wächter gebaut (so in der Spec festgehalten, Regel-Budget: kein Zuwachs). Damit gehört die Regel genau dorthin, wo diese Datei laut ihrem eigenen Kopf zuständig ist: „Regeln, die weder ein Test noch ein Hook noch CLAUDE.md/ADR absichert, aber dauerhaft gelten."

Inhalt:
- Alarm-Tests müssen den Trip so bauen, dass **kein Briefing fällig** ist — sonst greift die Vorlaufsperre aus #1594 und der Alarm wird planmäßig durch das Briefing ersetzt (ADR-0009). Ohne diese Vorbedingung hängt das Testergebnis an der Wanduhr: rot von 07–10 und 18–21 Uhr Ortszeit.
- Die Warnung, die beim Fix selbst entscheidend war: **vor dem Setzen einer „Aus"-Flagge zählen, wo sie gelesen wird** — sonst wird der Test grün, weil er entkernt ist statt repariert.
- Wie eine Gegenprobe aussieht, die etwas taugt: die Bedingung **herstellen** statt abwarten, und zwar in **beiden** Varianten — sonst wacht die Zusicherung nur drei von 24 Stunden.

Kein Code, kein Test, keine CI-Datei berührt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoXrQwyCuBDmq2VHF3631n