### PR TITLE
fix: tote Berechtigungsregel fuer verlegten next-ticket-Cache entfernen

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,8 +7,7 @@
       "Bash",
       "WebSearch",
       "WebFetch",
-      "Monitor",
-      "Edit(.claude/next_ticket_cache.json)"
+      "Monitor"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
Einzeiler in `.claude/settings.json`.

## Warum

`/next-ticket` schrieb seinen Kurzzeit-Cache nach `.claude/next_ticket_cache.json`. Dorthin darf laut stehender PO-Regel nicht geschrieben werden — jeder Aufruf endete im Berechtigungsdialog statt im Cache.

Der frühere Versuch, das über eine Berechtigungsregel zu lösen, griff zu kurz: `settings.json` erlaubte `Edit(...)`, die Datei muss beim ersten Mal aber per `Write` angelegt werden.

Mit `b6674c94` liegt der Cache jetzt in `docs/artifacts/` — dort, wo die übrigen Workflow-Artefakte schon liegen, und bereits gitignored. Damit zeigt die Berechtigungsregel ins Leere und gewährt nichts mehr; dieser PR entfernt sie.

## Änderung

```diff
       "Monitor",
-      "Edit(.claude/next_ticket_cache.json)"
+      "Monitor"
```

Kein Code, kein Test, keine CI-Datei. `jq -e '.permissions.allow'` nach der Änderung: `["Bash", "WebSearch", "WebFetch", "Monitor"]` — gültiges JSON, vier Einträge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoXrQwyCuBDmq2VHF3631n