### PR TITLE
fix(#1849): Ausblick-Metrikzweig faerbt Zellen wieder mit Ampelfarben

### DIFF
--- a/docs/context/fix-1849-ausblick-ampelfarben.md
+++ b/docs/context/fix-1849-ausblick-ampelfarben.md
@@ -1,0 +1,84 @@
+# Context: fix-1849-ausblick-ampelfarben
+
+## Request Summary
+Issue #1849: Setzt ein Nutzer im Trip-Editor eine Spaltenauswahl für die
+3-Tages-Vorschau, verliert die Ausblick-Tabelle in der Trip-Mail sämtliche
+Ampelfarben (nicht nur bei Gewitter, bei jeder Spalte). PO-Entscheid
+2026-08-15: Standard-Track, Ortsvergleich wird **mitgefärbt** (bisher schon
+farblos, aber nicht absichtlich) — das löst `#1653` AC-6 ab, soweit AC-6
+Farblosigkeit implizierte.
+
+## Related Files
+| File | Relevance |
+|------|-----------|
+| `src/output/renderers/email/outlook.py` | Enthält beide Zweige: Metrik-Zweig `render_outlook_table()` (`:128-152`, **kein** `bg=`, `return` vor jeder Färbelogik) und Altpfad (`:189-297`, färbt über `_outlook_cell_bg()`/`_catalog_thresholds()`/`_THUNDER_LEVEL_BG`). `build_outlook_row()` (`:609-618`) schreibt `row["cells"]` bereits als **fertig formatierte Strings** — die Rohwerte zum Einfärben existieren im Renderer danach nicht mehr, müssen zusätzlich mitgegeben werden. `_THUNDER_LEVEL_BG` (Gewitter-Sonderfarben, LOW bewusst kein `tone_css`-Ton) ist lokal in `render_outlook_table()` definiert, für den Metrik-Zweig aktuell nicht erreichbar. |
+| `src/output/renderers/compare_outlook_metric_ids.py` | `outlook_columns()` (`:105-141`) baut die Spaltenbeschreibung aus der Auswahl — trägt aktuell `label`/`field`/`unit`/`decimals`/`kind`/`aggregation_label`, **kein** `metric_id` (würde für Schwellen-Lookup gebraucht). `format_outlook_value()` formatiert die Zellentexte. |
+| `src/output/renderers/compare_metric_catalog.py` | Compare-Katalog-Zeilen tragen `metric_id`/`aggregation` (#1373) — `metric_id`-Werte (z.B. `"wind"`, `"gust"`, `"precipitation"`, `"rain_probability"`, `"thunder"`) sind identisch zu den Strings, die `_catalog_thresholds()` in `outlook.py` bereits benutzt. Keine Übersetzung nötig. |
+| `src/app/metric_catalog.py` | `MetricDefinition.display_thresholds: dict` (`yellow`/`orange`/`red`). 10 von den relevanten Katalogeinträgen tragen Schwellen; `snow_depth` z.B. **nicht** (`display_thresholds == {}`) — bleibt dann farblos. **Korrektur:** `temperature` HAT Schwellen (`yellow:28/orange:31/red:34` + Kälte-Varianten) und wird korrekt gefärbt, ursprünglich fälschlich als schwellenloses Beispiel genannt. |
+| `src/output/metric_format.py` | `thunder_ampel_band(level)` (`:265-275`, ADR-0025: **einzige Quelle** Stufe→Ampelband) liefert `green`/`yellow`/`orange`/`red`, `None` bei `None`. `NONE`-Stufe würde `"green"` liefern — der Altpfad zeigt bei `NONE` aber **keinen** Hintergrund (kein `_THUNDER_LEVEL_BG`-Eintrag für `NONE`). Muss beim Einfärben bewusst abgefangen werden, sonst neuer grüner Teppich. |
+| `src/output/renderers/email/design_tokens.py` | `tone_css(band)` — einzige Quelle für die Hex-Werte je Ampelband (#1801 S1). |
+| `src/output/renderers/email/compare_html.py:1242` | Ruft `render_outlook_table(rows, show_acc=False, metrics=outlook_metrics)` — derselbe Metrik-Zweig, jede Änderung dort wirkt automatisch auch hier (Ortsvergleich). |
+| `docs/specs/modules/fix_1653_ausblick_tag_nacht_trennung.md` (AC-6, Z.337-345) | Verlangt „Compare-Ausgabe bleibt byte-identisch" — bezieht sich laut Testverweis (`test_trip_outlook_parity.py`/`test_compare_outlook*.py`) auf `cells`/`format_outlook_value` (Zellen-**Text**), nicht auf HTML-Hintergrundfarben. Kein bestehender Test prüft volle HTML-Byte-Gleichheit inkl. `background:`. AC-6 wird durch diesen Fix fachlich abgelöst (Farbe kommt jetzt dazu), der Text bleibt unverändert. |
+
+## Existing Patterns
+- **Geteilte Ampel-Quelle:** Numerische Spalten färben über `_outlook_cell_bg(val, thresholds)` + `_catalog_thresholds(metric_id)` (liest `MetricDefinition.display_thresholds`), Gewitter-Spalte über eine feste `_THUNDER_LEVEL_BG`-Tabelle (LOW = eigener heller Gelbton außerhalb des Ampel-Vokabulars, MED/HIGH aus `tone_css()`). Beide Wege existieren nur im Altpfad.
+- **Trip/Compare-Teilung:** `render_outlook_table()`/`build_outlook_row()` sind der geteilte Baustein für Trip UND Ortsvergleich (Epic #1301 B4) — eine Änderung im Metrik-Zweig gilt automatisch für beide, wie von der Trip/Compare-Teilungs-Invariante gefordert (keine einseitige Sonderlocke ohne dokumentierte Begründung).
+- **Katalog statt Hartcodierung:** #1377 Scheibe B hat den Altpfad bereits auf zentrale Katalog-Schwellen umgestellt (`_catalog_thresholds()`), das ist das Muster, das der Metrik-Zweig übernehmen sollte, statt eine zweite Schwellen-Quelle zu erfinden.
+
+## Dependencies
+- **Upstream:** `app.metric_catalog.get_metric().display_thresholds`, `output.metric_format.thunder_ampel_band()`, `output.renderers.email.design_tokens.tone_css()`, `output.renderers.compare_outlook_metric_ids.outlook_columns()`/`format_outlook_value()`.
+- **Downstream:** `html.py` (Trip-Mail), `compare_html.py` (Ortsvergleich-Mail) — beide rufen `render_outlook_table()` mit `metrics=` sobald eine Auswahl gesetzt ist. `plain.py`/`comparison.py` rufen `render_outlook_plain()` — dort gibt es (ANSI-frei) ohnehin keine Farbe, betrifft dieses Issue nicht.
+
+## Existing Specs
+- `docs/specs/modules/epic_1301_b4_compare_outlook.md` — Ursprungsspec des geteilten Ausblick-Bausteins (AC-1..AC-3, AC-6, AC-8).
+- `docs/specs/modules/fix_1653_ausblick_tag_nacht_trennung.md` — AC-6 betroffen (s.o.), Text bleibt unverändert.
+- `docs/specs/modules/fix_1841_vorschau_metrik_tagesfenster.md` — jüngster Vorgänger-Fix im selben Modul (Gewitter-Datenquelle statt -Färbung), zeigt das etablierte Diskriminator-Muster `trip_display_config`.
+- `docs/specs/modules/issue_1361_1368_ausblick_konfigurierbar.md` — Ursprungsspec der Spaltenauswahl (`compare_outlook_metric_ids.py`).
+
+## Analysis
+
+### Type
+Bug (nutzersichtbares Fehlverhalten, kein Feature).
+
+### Affected Files (with changes)
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/output/renderers/compare_outlook_metric_ids.py` | MODIFY | `outlook_columns()` (`:105-141`) Rückgabedict um `"metric_id"` ergänzen (additiv, ~1 Zeile). |
+| `src/output/renderers/email/outlook.py` | MODIFY | Neue Modul-Helper `_metric_column_bg(col, raw)`; `build_outlook_row()` (`:609-618`) List-Comprehension → Schleife, füllt `row["cell_bg"]` parallel zu `row["cells"]`; `render_outlook_table()` Metrik-Zweig (`:128-152`) liest `stage.get("cell_bg")` und reicht es an `_otd(..., bg=...)` durch. Import von `severity_for`/`thunder_ampel_band` aus `output.metric_format`. Altpfad (`:60-98`, `:189-297`) bleibt unangetastet. ~30-40 LoC. |
+| `tests/tdd/test_trip_outlook_metric_selection.py` bzw. `test_compare_outlook.py` | MODIFY | Neue Fälle: Farbzuweisung Trip UND Compare, NONE-Fall (kein grüner Teppich), fehlende Schwellen (snow_depth bleibt farblos), LOW-Sonderfarbe. ~60-120 LoC. |
+
+### Scope Assessment
+- Files: 2 Produktivdateien + 1-2 Testdateien
+- Estimated LoC: Produktiv ~30-40 (Budget 250), Test ~60-120 (Budget 500)
+- Risk Level: LOW — additive Dict-Keys (`metric_id`, `cell_bg`), gegrepte Aufrufer (`compare_html.py:1168`, `trip_report_scheduler.py:2313`, `outlook.py` intern) lesen selektiv, kein Volldict-Vergleich außer `test_trip_outlook_parity.py:177`, der im unveränderten `metrics is None`-Zweig läuft (kein Konflikt).
+
+### Technical Approach
+Bestätigt durch Plan/Sonnet-Subagent (unabhängige Prüfung, Dateien gelesen):
+
+**Wiederverwendbare SSoT-Bausteine bereits vorhanden** (kein Neubau):
+- `severity_for(metric_id, value)` (`src/output/metric_format.py:130`) — liest `get_metric(metric_id).display_thresholds`, liefert `"green"/"yellow"/"orange"/"red"/None`. Deckt „keine Schwellen im Katalog" (z.B. `snow_depth`) bereits über `None` ab — **besser als der ursprünglich erwogene `_catalog_thresholds()`/`_outlook_cell_bg()`-Nachbau**, weil es die echte SSoT ist (auch von `helpers._level_from_thresholds` genutzt, Issue #1377 Scheibe A).
+- `thunder_ampel_band(level)` (`src/output/metric_format.py:265`, ADR-0025-SSoT) — `NONE` → `"green"`.
+
+**Drei Änderungsschritte:**
+1. `outlook_columns()`: `"metric_id": metric_id` zum Rückgabedict ergänzen.
+2. `build_outlook_row()`: pro Spalte den ohnehin berechneten Rohwert an `_metric_column_bg(col, raw)` geben — `kind=="ordinal"` → `thunder_ampel_band(raw)` (Band `"green"`/NONE → `""` kein Hintergrund; `"yellow"`/LOW → eigener Hellgelbton `#fbe6c3` wie Altpfad, NICHT `tone_css('yellow')`; `"orange"/"red"` → `tone_css(band)[0]`); `kind=="enum"` (Niederschlagsart) → immer farblos; sonst → `severity_for(col["metric_id"], raw)`, `None`/`"green"` → `""`, sonst `tone_css(band)[0]`. Ergebnis parallel als `row["cell_bg"]`.
+3. `render_outlook_table()` Metrik-Zweig: `cell_bg` konsumieren, an `_otd(..., bg=...)` reichen.
+
+Altpfad bleibt komplett unangetastet (separater Codepfad, `metrics is None`) — Byte-Identitäts-Zusicherung (Docstring `outlook.py:10-14`) bleibt automatisch gewahrt.
+
+**Reihenfolge:** `outlook_columns()` → `_metric_column_bg()` (isoliert testbar) → `build_outlook_row()` → `render_outlook_table()` Metrik-Zweig → Gate #811 (`test_issue_811_mode_matrix.py` + beide Mail-Validatoren).
+
+### Dependencies
+Bestätigt: `outlook_columns`/`build_outlook_row`/`format_outlook_value`/`display_thresholds` werden außerhalb von `outlook.py` nur von `compare_html.py:1168` und `trip_report_scheduler.py:2313` gelesen — beide selektiv (`c["label"]`, `col["field"]`, `col.get("kind")`), kein Konflikt mit additiven Keys.
+
+### Open Questions
+- [x] Ortsvergleich mitfärben? → Ja (PO-Entscheid 2026-08-15).
+- [ ] LOW-Sonderfarbe (`#fbe6c3`) im Metrik-Zweig identisch zum Altpfad übernehmen, statt `tone_css('yellow')` zu nutzen? → Empfehlung: ja, für visuelle Konsistenz zwischen beiden Pfaden — als AC festhalten.
+
+## Risks & Considerations
+- **Rohwerte fehlen im Renderer.** `render_outlook_table()` bekommt nur `stage["cells"]` (fertige Strings). Um Schwellen anzuwenden, muss entweder `build_outlook_row()` zusätzlich Rohwerte/`metric_id` je Zelle mitgeben (z.B. `row["cell_bg"]` direkt vorberechnet) oder der Renderer bekommt Rohwerte separat. Vorberechnung in `build_outlook_row()` ist näher am Altpfad-Muster (dort passiert die Farbentscheidung auch beim Zeilenbau, nicht erst beim Rendern) — zu klären in der Spec.
+- **`_THUNDER_LEVEL_BG` ist lokal.** Muss entweder auf Modulebene gehoben oder dupliziert werden, damit Metrik- und Altpfad dieselbe Farbzuordnung nutzen (ADR-0025 verlangt eine Quelle für Stufe→Band, nicht zwingend für Band→Hex, aber Konsistenz ist hier klar erwünscht).
+- **NONE-Sonderfall:** `thunder_ampel_band(NONE)` liefert `"green"` — ohne Abfangen bekäme die Vorschau bei „kein Gewitter" plötzlich einen grünen Hintergrund, den der Altpfad nie hatte. Empfehlung: bei `NONE` keine `bg` setzen (Altpfad-Parität).
+- **Fehlende Schwellen bleiben farblos.** Für `metric_id`s ohne `display_thresholds` (z.B. `snow_depth`) gibt es keine Ampelfarbe — das ist Bestandsverhalten (N/D im Altpfad auch immer `bg=""`), keine Regression, aber im AC explizit zu benennen, damit es nicht als Lücke gemeldet wird.
+- **Renderer-Commit-Gate (#811):** `outlook.py` liegt unter den Mail-Inhalts-Pfaden — Commit braucht `test_issue_811_mode_matrix.py` grün + erfolgreichen `briefing_mail_validator.py`-Lauf.
+- **Zwei Mail-Validatoren:** Trip-Briefing (`briefing_mail_validator.py`) UND Ortsvergleich (`email_spec_validator.py`) sind beide betroffen, weil derselbe Renderer beide Mail-Arten bedient — beide vor „E2E bestanden" laufen lassen (analog #1841-Lehre: „`helpers.py` ⇒ BEIDE Mail-Validatoren").

--- a/docs/specs/modules/fix_1653_ausblick_tag_nacht_trennung.md
+++ b/docs/specs/modules/fix_1653_ausblick_tag_nacht_trennung.md
@@ -342,6 +342,16 @@ bisher nie durch).
     bzw. `test_compare_outlook*.py`) bleibt grün, ergänzt um einen Lauf mit
     Tag+Nacht-Gewitterdaten, der zeigt, dass `cells`/`format_outlook_value`
     unverändert bleiben.
+  - **Erratum 2026-08-15 (#1849):** „byte-identisch" galt für den
+    Zellen-**Text**, nicht für den Zellen-**Hintergrund**. Fix #1849 behebt
+    einen eigenständigen Bug im selben Metrik-Zweig — dort fehlte jede
+    Ampelfärbung, sobald eine Spaltenauswahl gesetzt war. Seit #1849 füllt
+    `build_outlook_row()` zusätzlich `row["cell_bg"]`, und
+    `render_outlook_table()` nutzt diesen Wert für `bg=` an `_otd()`
+    (`src/output/renderers/email/outlook.py`, Helfer `_metric_column_bg()`).
+    Der hier beschriebene AC-6-Textvergleich bleibt gültig; ein reiner
+    Text-Diff sieht den Hintergrundfarben-Unterschied ohnehin nicht. Details:
+    `docs/specs/modules/fix_1849_ausblick_ampelfarben.md`.
 
 - **AC-7:** Given Niederschlag-, Wind- und Böen-Tokens, weiterhin über
   genau einen unveränderten Aufruf von `render_threshold_peak_value()`

--- a/docs/specs/modules/fix_1849_ausblick_ampelfarben.md
+++ b/docs/specs/modules/fix_1849_ausblick_ampelfarben.md
@@ -1,0 +1,112 @@
+---
+entity_id: fix_1849_ausblick_ampelfarben
+type: bugfix
+created: 2026-08-15
+updated: 2026-08-15
+status: approved
+version: "1.0"
+tags: [ausblick, ampelfarben, metrik-zweig, issue-1849]
+---
+
+# Ausblick-Ampelfärbung bei Spaltenauswahl (#1849)
+
+## Approval
+
+- [x] Approved
+
+## Purpose
+
+Setzt ein Nutzer im Trip-Editor oder Ortsvergleich-Editor eine Spaltenauswahl für die 3-Tages-Vorschau, verliert die Ausblick-Tabelle in der Mail sämtliche Ampelfarben (jede Spalte, nicht nur Gewitter). Dieser Fix bringt die Hintergrundfärbung des Metrik-Zweigs in `render_outlook_table()` auf Parität mit dem unveränderten Altpfad (feste sieben Spalten ohne Auswahl), für Trip **und** Ortsvergleich gleichermaßen (Trip/Compare-Teilungs-Invariante).
+
+## Source
+
+- **File:** `src/output/renderers/email/outlook.py`
+- **Identifier:** `render_outlook_table()` (Metrik-Zweig, Z.128-152), `build_outlook_row()` (Z.609-618)
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `severity_for(metric_id, value)` — `src/output/metric_format.py:130` | function | SSoT für numerisches Ampelband aus `MetricDefinition.display_thresholds`; liefert `None` bei fehlenden Schwellen |
+| `thunder_ampel_band(level)` — `src/output/metric_format.py:265` | function | SSoT (ADR-0025) für Gewitterstufe → Ampelband (`green`/`yellow`/`orange`/`red`) |
+| `tone_css(band)` — `src/output/renderers/email/design_tokens.py:88` | function | Einzige Quelle für Hex-Werte je Ampelband, liefert `(bg, fg)`-Tupel |
+| `get_metric(metric_id)` — `src/app/metric_catalog.py` | function | Katalog-Zugriff, indirekt über `severity_for` |
+| `outlook_columns(metrics)` — `src/output/renderers/compare_outlook_metric_ids.py:105` | function | Baut Spaltenbeschreibung aus der Auswahl, bekommt zusätzlich `metric_id` |
+
+## Scope
+
+### Affected Files
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/output/renderers/compare_outlook_metric_ids.py` | MODIFY | `outlook_columns()` (Z.105-141): Rückgabedict um `"metric_id": metric_id` ergänzen (additiv, ~1 Zeile). |
+| `src/output/renderers/email/outlook.py` | MODIFY | Neue Modul-Helper-Funktion `_metric_column_bg(col, raw)`; `build_outlook_row()` (Z.609-618): List-Comprehension für `row["cells"]` zu einer Schleife umbauen, die parallel `row["cell_bg"]` befüllt; `render_outlook_table()` Metrik-Zweig (Z.128-152): `stage.get("cell_bg")` lesen und an `_otd(..., bg=...)` durchreichen. Altpfad (Z.60-98, Z.189-297) bleibt unangetastet. ~30-40 LoC. |
+| `tests/tdd/test_trip_outlook_metric_selection.py` bzw. `tests/tdd/test_compare_outlook.py` | MODIFY | Neue Testfälle: Farbzuweisung Trip UND Compare, NONE-Fall, fehlende Schwellen, LOW-Sonderfarbe, Niederschlagsart farblos, Altpfad-Parität. ~60-120 LoC. |
+
+### Estimated Changes
+- Files: 2 Produktivdateien + 1-2 Testdateien
+- LoC: +90/-10 (Produktiv ~30-40, Test ~60-120)
+
+## Implementation Details
+
+`outlook_columns()` ergänzt pro Spalte `"metric_id": metric_id` im Rückgabedict (additive Erweiterung, bestehende Aufrufer wie `compare_html.py:1168` und `trip_report_scheduler.py:2313` lesen Dict-Keys selektiv).
+
+`build_outlook_row()` baut `row["cells"]` bisher über eine List-Comprehension aus `format_outlook_value(raw, {**col, ...})`. Diese Comprehension wird zu einer Schleife, die zusätzlich `row["cell_bg"]` parallel füllt — je Spalte ein `_metric_column_bg(col, raw)`-Aufruf mit demselben `raw`-Rohwert, der ohnehin für `format_outlook_value()` berechnet wird (kein zweiter Rohwert-Zugriff nötig).
+
+`_metric_column_bg(col, raw)` (neuer Modul-Helper in `outlook.py`, oberhalb von `build_outlook_row()`):
+
+- `col["kind"] == "ordinal"` (Gewitter): `band = thunder_ampel_band(raw)`. `band in (None, "green")` → `""` (kein Hintergrund; deckt sowohl "keine Aussage" als auch NONE-Stufe ab — Altpfad-Parität, kein grüner Teppich). `band == "yellow"` (LOW) → `"background:#fbe6c3;"` (identisch zum Altpfad-Hellgelbton, NICHT `tone_css('yellow')`). `band in ("orange", "red")` → `f"background:{tone_css(band)[0]};"`.
+- `col["kind"] == "enum"` (Niederschlagsart): immer `""` — kein Altpfad-Vorbild für eine gefärbte Niederschlagsart-Spalte.
+- sonst (numerische Spalten): `band = severity_for(col["metric_id"], raw)`. `band in (None, "green")` → `""` (deckt sowohl fehlende Katalog-Schwellen als auch den grünen Bereich ab). Sonst → `f"background:{tone_css(band)[0]};"`.
+
+`render_outlook_table()` Metrik-Zweig konsumiert `stage.get("cell_bg")` (Liste parallel zu `stage["cells"]`) und reicht den Wert je Zelle an die bestehende `_otd(content, *, bg="", align="center")`-Funktion durch (Signatur existiert bereits, der Metrik-Zweig nutzt `bg` bisher nicht).
+
+Der Altpfad (`metrics is None`, Z.60-98 Helper-Funktionen und Z.189-297 Zeilenbau) bleibt vollständig unangetastet — kein Import, keine Zeile wird dort geändert.
+
+## Expected Behavior
+
+- **Input:** Trip- oder Compare-Vorschau mit gesetzter Spaltenauswahl (`metrics` != `None` an `render_outlook_table()`), Rohwerte je Tag/Spalte aus `SegmentWeatherSummary`.
+- **Output:** HTML-Ausblick-Tabelle, deren `<td>`-Zellen bei numerischen Spalten über Katalog-Schwelle, bei Gewitter ab LOW und niemals bei Niederschlagsart einen `background:`-Hintergrund tragen — analog zum Altpfad.
+- **Side effects:** keine (reine Renderer-Funktionen, kein Netz-/Fetch-Zugriff).
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine Trip-Vorschau mit gesetzter Spaltenauswahl, die eine numerische Metrik mit Katalog-Schwellen enthält (z.B. Wind) / When ein Tageswert die `orange`-Schwelle dieser Metrik überschreitet / Then trägt die zugehörige `<td>`-Zelle `background:{tone_css('orange')[0]}`.
+  - Test: `render_outlook_table()` mit `metrics=[Wind-Auswahl]` und einem Tag mit Wind-Rohwert über der Katalog-`orange`-Schwelle aufrufen, HTML-Output auf `background:` im erwarteten Hex-Wert an der Windspalte prüfen (kein Dateiinhalt-Check, tatsächlicher Renderer-Output).
+
+- **AC-2:** Given eine Ortsvergleich-Vorschau mit gesetzter Spaltenauswahl (identische Metrik wie AC-1) / When derselbe Tageswert über der Schwelle liegt / Then trägt die Ortsvergleich-Ausgabe dieselbe Hintergrundfarbe wie die Trip-Ausgabe.
+  - Test: `render_outlook_table(rows, show_acc=False, metrics=[Wind-Auswahl])` (Compare-Aufrufweg über `compare_html.py`-Pfad) mit demselben Rohwert wie AC-1 aufrufen, Ergebnis-Hex mit AC-1 vergleichen — beweist die geteilte Code-Nutzung, nicht nur Parität durch Zufall.
+
+- **AC-3:** Given eine Gewitterspalte in der Auswahl / When der Tageswert Stufe NONE ist / Then trägt die Zelle KEINEN Hintergrund (`bg=""`), obwohl `thunder_ampel_band(NONE)` technisch `"green"` liefert.
+  - Test: `_metric_column_bg({"kind": "ordinal"}, ThunderLevel.NONE)` bzw. Renderer-Aufruf mit einem NONE-Tag prüfen, dass die Gewitterzelle keinen `background:`-Stil trägt.
+
+- **AC-4:** Given eine Gewitterspalte in der Auswahl / When der Tageswert Stufe LOW ist / Then trägt die Zelle exakt `background:#fbe6c3;` (Altpfad-Hellgelbton), NICHT `tone_css('yellow')`.
+  - Test: Renderer-Aufruf mit LOW-Tag, Hex-Wert der Gewitterzelle auf `#fbe6c3` prüfen und gegen den Rückgabewert von `tone_css('yellow')[0]` abgrenzen (muss ungleich sein).
+
+- **AC-5:** Given eine Gewitterspalte in der Auswahl / When der Tageswert Stufe MED oder HIGH ist / Then trägt die Zelle `background:{tone_css('orange')[0]}` bzw. `background:{tone_css('red')[0]}`.
+  - Test: Renderer-Aufruf je einmal mit MED- und HIGH-Tag, Hex-Werte gegen `tone_css('orange')[0]`/`tone_css('red')[0]` prüfen.
+
+- **AC-6:** Given eine numerische Spalte ohne `display_thresholds` im Katalog (z.B. `snow_depth`, Schneehöhe — `get_metric("snow_depth").display_thresholds == {}`) / When ein beliebiger Tageswert vorliegt / Then bleibt die Zelle farblos (`bg=""`) — kein Fehler, kein Absturz.
+  - Test: `render_outlook_table()` mit `metrics=[Schneehöhe-Auswahl]` und beliebigem Wert (auch hohem, z.B. 150 cm) aufrufen, Ergebnis enthält keinen `background:`-Stil an der Schneehöhe-Spalte, kein Exception-Wurf.
+  - **Korrektur (TDD-RED-Phase):** Die ursprüngliche Spec-Fassung nannte `temperature` als Beispiel — falsch, `temperature` trägt `display_thresholds={"yellow":28,"orange":31,"red":34,...}` und würde bei hohen Werten sehr wohl gefärbt. `snow_depth` (`display_thresholds == {}`) ist die tatsächlich schwellenlose Metrik; `severity_from_thresholds()` liefert dafür `None` (nicht `"green"`), s. `src/output/metric_format.py:141-174`.
+
+- **AC-7:** Given eine Niederschlagsart-Spalte (`kind=="enum"`) in der Auswahl / When ein beliebiger Tageswert vorliegt / Then bleibt die Zelle immer farblos, unabhängig vom Wert.
+  - Test: Renderer-Aufruf mit verschiedenen Niederschlagsart-Werten, Ergebnis prüft durchgängig `bg=""` an dieser Spalte.
+
+- **AC-8:** Given eine Trip- oder Compare-Vorschau OHNE gesetzte Spaltenauswahl (`metrics=None`) / When `render_outlook_table()` gerendert wird / Then bleibt die HTML-Ausgabe byte-identisch zum Verhalten vor diesem Fix (Altpfad unverändert).
+  - Test: bestehender Parity-Test (`test_trip_outlook_parity.py` bzw. äquivalent) mit `metrics=None` weiterhin grün; zusätzlich expliziter Vergleich der Ausgabe vor/nach diesem Fix bei identischem Input im Altpfad-Zweig.
+
+## Known Limitations
+
+- `docs/specs/modules/fix_1653_ausblick_tag_nacht_trennung.md` AC-6 verlangte „Compare-Ausgabe bleibt byte-identisch" bezogen auf den Metrik-Zweig. Diese Zusicherung galt nachweislich nur für den Zellen-**Text** (`cells`/`format_outlook_value`) — kein bestehender Test prüft volle HTML-Byte-Gleichheit inklusive `background:`-Stilen. Mit diesem Fix bekommt der Metrik-Zweig erstmals Hintergrundfarben; AC-6 wird dadurch fachlich abgelöst (Text bleibt unverändert, Hintergrund kommt neu dazu). Dieser Fix ist **keine** Regression von #1653 AC-6, falls er später fälschlich so gemeldet werden sollte.
+- Metriken ohne `display_thresholds` im Katalog (z.B. `snow_depth`) bleiben dauerhaft farblos — Bestandsverhalten, keine Lücke dieses Fixes. `temperature` HAT Schwellen und wird bei hohen/niedrigen Werten korrekt gefärbt (Korrektur ggü. Erstfassung dieser Spec).
+- `plain.py`/`comparison.py` (Klartext-Renderer über `render_outlook_plain()`) sind von diesem Fix nicht betroffen — dort gibt es ohnehin keine ANSI-/HTML-Farbe.
+- **Renderer-Commit-Gate (#811):** `outlook.py` liegt unter den Mail-Inhalts-Pfaden. Vor Commit MÜSSEN `tests/tdd/test_issue_811_mode_matrix.py` grün sein UND ein erfolgreicher Lauf von `.claude/hooks/briefing_mail_validator.py` (Trip-Briefing) sowie `.claude/hooks/email_spec_validator.py` (Ortsvergleich) vorliegen, bevor „E2E bestanden" gesagt werden darf — beide Mail-Validatoren, weil derselbe Renderer beide Mail-Arten bedient.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reiner Bugfix, der bestehende SSoT-Bausteine (`severity_for`, `thunder_ampel_band`, `tone_css`, ADR-0025) auf einen zweiten, bisher ungefärbten Codepfad anwendet — keine neue Grundsatzentscheidung.
+
+## Changelog
+
+- 2026-08-15: Initial spec created

--- a/src/output/renderers/compare_outlook_metric_ids.py
+++ b/src/output/renderers/compare_outlook_metric_ids.py
@@ -127,6 +127,7 @@ def outlook_columns(metrics: object) -> list[dict]:
             continue
         columns.append({
             "label": catalog["label"],
+            "metric_id": metric_id,
             "field": field,
             "unit": catalog.get("unit", ""),
             "decimals": catalog.get("decimals", 0),

--- a/src/output/renderers/email/outlook.py
+++ b/src/output/renderers/email/outlook.py
@@ -135,10 +135,13 @@ def render_outlook_table(
         body = ""
         for stage in rows:
             cells = stage.get("cells") or []
+            # Issue #1849: Ampel-Hintergruende parallel zu den Zellentexten.
+            cell_bg = stage.get("cell_bg") or []
             body += (
                 '<tr>' + _otd(stage.get("weekday", "–"))
                 + "".join(
-                    _otd(_html.escape(cells[i] if i < len(cells) else "–"))
+                    _otd(_html.escape(cells[i] if i < len(cells) else "–"),
+                         bg=cell_bg[i] if i < len(cell_bg) else "")
                     for i in range(len(columns))
                 )
                 + '</tr>'
@@ -413,6 +416,31 @@ def render_outlook_plain(
 # build_outlook_row — extrahiert aus trip_report_scheduler.py (Z.1460-1488, AC-3)
 # ---------------------------------------------------------------------------
 
+def _metric_column_bg(col: dict, raw: object) -> str:
+    """Zell-Hintergrund einer Ausblick-Metrikspalte (#1849).
+
+    Ampelband aus den SSoT-Helfern (``severity_for``/``thunder_ampel_band``),
+    Hex-Wert aus ``tone_css`` -- dieselben Quellen wie der Altpfad. ``green``
+    faerbt bewusst NICHT (Altpfad-Paritaet, kein gruener Teppich), und die
+    Gewitterstufe LOW traegt den abweichenden Altpfad-Hellgelbton
+    (``_THUNDER_LEVEL_BG``), nicht ``tone_css('yellow')``.
+    """
+    from output.metric_format import severity_for, thunder_ampel_band
+
+    kind = col.get("kind")
+    if kind == "enum":
+        return ""
+    if kind == "ordinal":
+        band = thunder_ampel_band(raw)
+        if band == "yellow":
+            return "background:#fbe6c3;"
+    else:
+        band = severity_for(col.get("metric_id"), raw)
+    if band in (None, "green"):
+        return ""
+    return f"background:{tone_css(band)[0]};"
+
+
 def build_outlook_row(
     summary: "SegmentWeatherSummary",
     points: list["ForecastDataPoint"],
@@ -606,15 +634,21 @@ def build_outlook_row(
                 _thunder_signals = None
             # "plain": _thunder_value/_thunder_signals bleiben das Aggregat
             # (unveraendert, wie ohne Stundenreihe/AC-4).
-        row["cells"] = [
-            format_outlook_value(
-                (_thunder_value if col.get("kind") == "ordinal"
-                 else getattr(summary, col["field"], None)),
+        # Issue #1849: Zellentext UND Zell-Hintergrund entstehen aus DEMSELBEN
+        # Rohwert -- eine zweite Rohwert-Aufloesung koennte fuer die
+        # Gewitterspalte am oben (#1841) aufgeloesten Tagesfenster vorbeigehen.
+        cells: list[str] = []
+        cell_bg: list[str] = []
+        for col in outlook_columns(metrics):
+            ordinal = col.get("kind") == "ordinal"
+            raw = _thunder_value if ordinal else getattr(summary, col["field"], None)
+            cells.append(format_outlook_value(
+                raw,
                 {**col, "hail": _hail,
-                 "signals": (_thunder_signals if col.get("kind") == "ordinal"
-                             else _signals)},
-            )
-            for col in outlook_columns(metrics)
-        ]
+                 "signals": _thunder_signals if ordinal else _signals},
+            ))
+            cell_bg.append(_metric_column_bg(col, raw))
+        row["cells"] = cells
+        row["cell_bg"] = cell_bg
 
     return row

--- a/tests/tdd/test_outlook_metric_ampelfarben.py
+++ b/tests/tdd/test_outlook_metric_ampelfarben.py
@@ -1,0 +1,252 @@
+"""TDD RED — #1849: Ausblick-Metrikzweig verliert alle Ampelfarben bei
+Spaltenauswahl.
+
+SPEC: docs/specs/modules/fix_1849_ausblick_ampelfarben.md AC-1..AC-8
+KONTEXT: docs/context/fix-1849-ausblick-ampelfarben.md
+
+Getroffen wird ausschliesslich der Metrik-Zweig von ``render_outlook_table()``
+(``metrics is not None``) -- direkt ueber ``build_outlook_row()`` +
+``render_outlook_table()``, dem echten Aufrufpfad von Trip (``show_acc=True``)
+UND Ortsvergleich (``show_acc=False``, ``compare_html.py:1242``). Der Altpfad
+(``metrics=None``) wird von diesem Fix nicht angefasst -- AC-8 belegt das nur
+noch als Regressionswaechter, nicht als RED-Demonstration.
+
+RED-Erwartung: AC-1, AC-2, der LOW/MED/HIGH-Teil von AC-3/AC-4/AC-5 sowie der
+Wind-Teil der gemischten Faelle in AC-6/AC-7 scheitern -- der Metrik-Zweig
+setzt heute (``outlook.py:128-152``) fuer KEINE Zelle ein ``background:``.
+Die "bleibt farblos"-Teilaussagen von AC-3 (NONE)/AC-6 (snow_depth)/AC-7
+(precip_type) sind bereits heute wahr (nichts ist gefaerbt); sie werden
+deshalb NICHT isoliert getestet, sondern zusammen mit einer gefaerbten Spalte
+im selben Testfall gefordert, damit jeder Testfall insgesamt rot ist.
+
+Kern-Schicht, deterministisch. Kein Mock-Framework, kein Netz.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+# Pfadregel #1409: Pruefling relativ zur eigenen Testdatei aufloesen.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+for _pfad in (REPO_ROOT, REPO_ROOT / "src"):
+    if str(_pfad) not in sys.path:
+        sys.path.insert(0, str(_pfad))
+
+from app.models import PrecipType, SegmentWeatherSummary, ThunderLevel  # noqa: E402
+from output.renderers.email.design_tokens import tone_css  # noqa: E402
+from output.renderers.email.outlook import (  # noqa: E402
+    _metric_column_bg, build_outlook_row, render_outlook_table,
+)
+
+TZ = ZoneInfo("Europe/Berlin")
+
+# Auswahl-Bausteine im Neuformat (#1373), identisch zu den Katalog-Paaren aus
+# compare_metric_catalog.py.
+WIND = {"metric_id": "wind", "aggregation": "max"}          # yellow30/orange50/red70
+SNOW = {"metric_id": "snow_depth", "aggregation": "max"}    # display_thresholds == {}
+GEWITTER = {"metric_id": "thunder", "aggregation": "max"}   # ordinal
+NIEDERSCHLAGSART = {"metric_id": "precip_type", "aggregation": "max"}  # enum
+
+
+def _summary(**overrides) -> SegmentWeatherSummary:
+    """Minimal-Fixture: alle Felder sind Optional mit Default None."""
+    return SegmentWeatherSummary(**overrides)
+
+
+def _row(summary: SegmentWeatherSummary, metrics: list[dict], weekday: str = "Mo") -> dict:
+    """Row-Dict wie ``aggregate_stage``/``summarize_points`` es lieferten --
+    ``points=[]`` ist unschaedlich, die Stundenreihen sind fuer diese Tests
+    ohne Bedeutung (kein Trip-Tagesfenster im Spiel, #1841 bleibt unberuehrt)."""
+    return build_outlook_row(summary, [], weekday, TZ, metrics=metrics)
+
+
+def _cell_styles(table_html: str) -> list[str]:
+    """``style``-Attribute aller ``<td>``-Zellen der Ausblick-Tabelle, in
+    Dokumentreihenfolge (Index 0 = Wochentags-Zelle)."""
+    return re.findall(r'<td style="([^"]*)"', table_html)
+
+
+def _bg_of(style: str) -> str:
+    """Der ``background:...;``-Teil eines Zellenstils, oder ``""`` wenn keiner
+    gesetzt ist. ``bg`` wird in ``_otd()`` immer als ERSTER Bestandteil des
+    ``style``-Attributs eingefuegt (outlook.py:87-98)."""
+    if not style.startswith("background:"):
+        return ""
+    return style[: style.index(";") + 1]
+
+
+# ══════════════════ AC-1 / AC-2 — numerische Spalte ueber Schwelle ══════════
+
+def test_ac1_numerische_spalte_ueber_schwelle_bekommt_ampelfarbe_im_trip():
+    """AC-1: Wind 55 km/h liegt zwischen der orange- (50) und der red-Schwelle
+    (70) aus dem Katalog (``get_metric("wind").display_thresholds``) -- die
+    Windspalte muss ``background:{tone_css('orange')[0]};`` tragen.
+    """
+    row = _row(_summary(wind_max_kmh=55.0), [WIND])
+    html = render_outlook_table([row], show_acc=True, metrics=[WIND])
+
+    styles = _cell_styles(html)
+    assert len(styles) == 2, f"Erwartet Wochentag + 1 Metrikspalte: {styles!r}"
+    assert _bg_of(styles[1]) == f"background:{tone_css('orange')[0]};", (
+        f"Windspalte (55 km/h, orange-Schwelle 50) traegt {styles[1]!r} -- "
+        "der Metrik-Zweig faerbt heute KEINE Zelle (AC-1)."
+    )
+
+
+def test_ac2_ortsvergleich_bekommt_dieselbe_farbe_wie_der_trip():
+    """AC-2: derselbe Rohwert liefert ueber den Compare-Aufrufweg
+    (``show_acc=False``, wie ``compare_html.py:1242``) dieselbe Farbe wie
+    AC-1 -- Beweis fuer den geteilten Codepfad, nicht nur zufaellige
+    Parallelitaet.
+    """
+    row = _row(_summary(wind_max_kmh=55.0), [WIND])
+
+    trip_html = render_outlook_table([row], show_acc=True, metrics=[WIND])
+    compare_html = render_outlook_table([row], show_acc=False, metrics=[WIND])
+
+    trip_bg = _bg_of(_cell_styles(trip_html)[1])
+    compare_bg = _bg_of(_cell_styles(compare_html)[1])
+    assert compare_bg == trip_bg == f"background:{tone_css('orange')[0]};", (
+        f"Trip-Hintergrund {trip_bg!r} vs. Compare-Hintergrund {compare_bg!r} "
+        "-- beide muessen identisch sein (AC-2)."
+    )
+
+
+# ══════════════ AC-3 / AC-4 / AC-5 — Gewitterstufen NONE..HIGH ══════════════
+
+def test_ac3_ac4_ac5_gewitterspalte_folgt_der_ampelband_zuordnung_je_stufe():
+    """AC-3: NONE bleibt farblos (kein gruener Teppich trotz
+    ``thunder_ampel_band(NONE) == "green"``).
+    AC-4: LOW traegt exakt ``background:#fbe6c3;`` (Altpfad-Hellgelbton),
+    NICHT ``tone_css('yellow')``.
+    AC-5: MED/HIGH tragen ``tone_css('orange')``/``tone_css('red')``.
+    """
+    stufen = ["NONE", "LOW", "MED", "HIGH"]
+    rows = [
+        _row(_summary(thunder_level_max=getattr(ThunderLevel, stufe)), [GEWITTER],
+             weekday=f"T{i}")
+        for i, stufe in enumerate(stufen)
+    ]
+    html = render_outlook_table(rows, show_acc=True, metrics=[GEWITTER])
+
+    styles = _cell_styles(html)
+    # Zwei Zellen je Zeile (Wochentag, Gewitter) -- Gewitterspalte ist Index 1
+    # jeder Zeile: 1, 3, 5, 7.
+    gewitter_bg = [_bg_of(styles[i]) for i in (1, 3, 5, 7)]
+
+    erwartet = [
+        "",  # NONE
+        "background:#fbe6c3;",  # LOW -- Altpfad-Hellgelbton, kein tone_css('yellow')
+        f"background:{tone_css('orange')[0]};",  # MED
+        f"background:{tone_css('red')[0]};",  # HIGH
+    ]
+    assert gewitter_bg == erwartet, (
+        f"Gewitter-Hintergruende {gewitter_bg!r} statt {erwartet!r} fuer die "
+        "Stufen NONE/LOW/MED/HIGH (AC-3/AC-4/AC-5). Vorsicht bei tone_css('yellow') "
+        f"({tone_css('yellow')[0]!r}) statt des LOW-Sonderfarbtons #fbe6c3."
+    )
+
+
+# ═══════════════ AC-6 / AC-7 — dauerhaft farblose Spalten ═══════════════════
+
+def test_ac6_metrik_ohne_katalogschwellen_bleibt_farblos_trotz_hohem_wert():
+    """AC-6: ``snow_depth`` hat ``display_thresholds == {}``
+    (``severity_from_thresholds`` liefert dafuer ``None``, NICHT "green" --
+    metric_format.py:141-174). Selbst ein hoher Wert (150 cm) darf keine
+    Farbe erzeugen und keinen Fehler werfen.
+
+    Gemeinsam mit einer gefaerbten Windspalte getestet, damit dieser
+    Testfall insgesamt rot ist (der farblose Teil allein waere schon heute
+    gruen, da der Metrik-Zweig aktuell ueberhaupt nichts faerbt).
+    """
+    auswahl = [WIND, SNOW]
+    row = _row(_summary(wind_max_kmh=80.0, snow_depth_cm=150.0), auswahl)
+    html = render_outlook_table([row], show_acc=True, metrics=auswahl)
+
+    styles = _cell_styles(html)
+    assert len(styles) == 3, f"Erwartet Wochentag + 2 Metrikspalten: {styles!r}"
+    assert _bg_of(styles[1]) == f"background:{tone_css('red')[0]};", (
+        f"Windspalte (80 km/h, red-Schwelle 70) traegt {styles[1]!r} statt rot."
+    )
+    assert _bg_of(styles[2]) == "", (
+        f"Schneehoehe-Spalte (150 cm, keine Katalog-Schwellen) traegt "
+        f"{styles[2]!r} -- muesste farblos bleiben (AC-6)."
+    )
+
+
+def test_ac7_niederschlagsart_bleibt_immer_farblos():
+    """AC-7: die Enum-Spalte "Niederschlagsart" (``kind=="enum"``) hat kein
+    Altpfad-Vorbild fuer eine Faerbung und bleibt fuer JEDEN Wert farblos --
+    geprueft mit zwei verschiedenen Werten, gemeinsam mit einer gefaerbten
+    Windspalte (Begruendung wie AC-6)."""
+    auswahl = [WIND, NIEDERSCHLAGSART]
+    for wert in (PrecipType.RAIN, PrecipType.SNOW):
+        row = _row(_summary(wind_max_kmh=80.0, precip_type_dominant=wert), auswahl)
+        html = render_outlook_table([row], show_acc=True, metrics=auswahl)
+        styles = _cell_styles(html)
+
+        assert _bg_of(styles[1]) == f"background:{tone_css('red')[0]};", (
+            f"Windspalte traegt {styles[1]!r} statt rot (Vorbedingung fuer "
+            f"einen insgesamt roten Testfall, Wert={wert!r})."
+        )
+        assert _bg_of(styles[2]) == "", (
+            f"Niederschlagsart-Spalte (Wert={wert!r}) traegt {styles[2]!r} -- "
+            "muss immer farblos bleiben (AC-7)."
+        )
+
+
+def test_ac7_enum_zweig_greift_vor_der_numerischen_auswertung():
+    """AC-7, Mutations-Waechter (Adversary F001): der ``enum``-Zweig darf nicht
+    nur ZUFAELLIG dasselbe liefern wie sein numerischer Nachbar. Der einzige
+    echte Enum-Katalogeintrag (``precip_type``) hat leere
+    ``display_thresholds`` und bliebe auch ohne den Zweig farblos -- an echten
+    Daten faellt ein entfernter ``enum``-Zweig deshalb nicht auf.
+
+    Geprueft wird darum die reine Funktion mit einer gueltigen, im
+    Produktivpfad so nicht vorkommenden Kombination: ``kind="enum"`` mit einer
+    ``metric_id``, die sehr wohl Katalog-Schwellen hat (``wind``). Der erste
+    Assert stellt sicher, dass derselbe Wert im numerischen Zweig tatsaechlich
+    faerbt -- ohne ihn wuerde der zweite nichts beweisen.
+    """
+    numerisch = _metric_column_bg({"kind": "range", "metric_id": "wind"}, 80.0)
+    assert numerisch == f"background:{tone_css('red')[0]};", (
+        f"Vorbedingung verletzt: derselbe Wert traegt im numerischen Zweig "
+        f"{numerisch!r} statt rot -- der Enum-Vergleich unten wuerde dann "
+        "nichts unterscheiden."
+    )
+    assert _metric_column_bg({"kind": "enum", "metric_id": "wind"}, 80.0) == "", (
+        "kind=='enum' muss VOR der numerischen Auswertung greifen und "
+        "unabhaengig von vorhandenen Katalog-Schwellen farblos bleiben (AC-7)."
+    )
+
+
+# ═══════════════════ AC-8 — Altpfad bleibt unveraendert ═════════════════════
+
+def test_ac8_altpfad_ohne_auswahl_faerbt_weiterhin_wie_bisher():
+    """AC-8: ``metrics=None`` (Altbestand, keine Spaltenauswahl) durchlaeuft
+    den unangetasteten Altpfad -- dessen Faerbelogik (``_outlook_cell_bg``/
+    ``_THUNDER_LEVEL_BG``) bleibt exakt wie vor diesem Fix.
+
+    🔴 Regressionswaechter, kein RED-Beweis: der Altpfad wird von diesem Fix
+    nicht veraendert, dieser Test ist schon vor der Implementierung gruen
+    (analog test_trip_outlook_parity.py:96/117). Er sichert ab, dass der neue
+    Metrik-Zweig-Code den Altpfad nicht versehentlich mitreisst.
+    """
+    row = _row(_summary(wind_max_kmh=55.0, thunder_level_max=ThunderLevel.MED),
+               metrics=None)
+    html = render_outlook_table([row], show_acc=True, metrics=None)
+
+    # Altpfad-Spalten: Tag, N, D, R, PR, Wind, Böen, Gew, ACC -- Wind ist
+    # Index 5, Gewitter Index 7 (outlook.py:154-167).
+    styles = _cell_styles(html)
+    assert len(styles) == 9, f"Erwartet die neun festen Altpfad-Spalten: {styles!r}"
+    assert _bg_of(styles[5]) == f"background:{tone_css('orange')[0]};", (
+        f"Altpfad-Windspalte (55 km/h) traegt {styles[5]!r} -- der Altpfad "
+        "darf sich durch diesen Fix nicht aendern (AC-8)."
+    )
+    assert _bg_of(styles[7]) == f"background:{tone_css('orange')[0]};", (
+        f"Altpfad-Gewitterspalte (MED) traegt {styles[7]!r} -- unveraendert "
+        "erwartet (AC-8)."
+    )


### PR DESCRIPTION
Setzt ein Nutzer im Trip- oder Ortsvergleich-Editor eine Spaltenauswahl fuer
die 3-Tages-Vorschau, verlor die Ausblick-Tabelle bislang saemtliche
Ampelfarben -- der Metrik-Zweig in render_outlook_table() baute Zellen ohne
jede Hintergrundfarbe.

Neuer Helper _metric_column_bg() nutzt die bestehenden SSoT-Quellen
(severity_for/thunder_ampel_band, tone_css): numerische Spalten faerben ab
Katalog-Schwelle, Gewitter ab LOW (eigener Hellgelbton #fbe6c3, MED/HIGH ueber
tone_css), Niederschlagsart bleibt immer farblos, NONE bleibt farblos trotz
thunder_ampel_band(NONE)=="green". Trip UND Ortsvergleich teilen denselben
Codepfad und werden beide gefaerbt. Der Altpfad (keine Auswahl) bleibt
unveraendert.

Loest docs/specs/modules/fix_1653_ausblick_tag_nacht_trennung.md AC-6
fachlich ab (galt nur fuer Zellentext, nicht Hintergrund).

Adversary-Verdict: VERIFIED nach einem Fix-Loop (Finding F001: enum-Zweig
war durch keinen Test von seinem numerischen Nachbarzweig unterscheidbar --
neuer Test schliesst die Luecke ohne Produktivcode-Aenderung).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AKtVZP7cxKT9z8VPbkHTwQ
