### PR TITLE
fix(#1750): Zustell-Hinweis im Briefing trennt Fehler von Absicht

### DIFF
--- a/docs/context/fix-1750-sperrzeit-wortwahl.md
+++ b/docs/context/fix-1750-sperrzeit-wortwahl.md
@@ -1,0 +1,157 @@
+# Context: fix-1750-sperrzeit-wortwahl
+
+Issue: [#1750](https://github.com/henemm/gregor_zwanzig/issues/1750) „Sperrzeiten in E-Mail ergeben keinen Sinn"
+Mit-erledigt: [#1800](https://github.com/henemm/gregor_zwanzig/issues/1800) (zweite Frage — Anzeige/Wortwahl)
+Erhoben: 2026-08-15 · Basis `origin/main` `57e36375`
+
+## Request Summary
+
+Der Briefing-Abschnitt „NICHT BEI DIR ANGEKOMMEN" ist für den Nutzer nicht deutbar: er nennt
+`premium_sms` als Rohnamen, und die beiden Sperrgründe heißen dort „Ruhezeit" und „Sperrzeit" —
+zwei im Deutschen fast gleichbedeutende Wörter für völlig verschiedene Sachverhalte, die
+zudem **keiner** Beschriftung in der Oberfläche entsprechen. Zusätzlich steht die Frage im
+Raum, ob unterdrückte Regenradar-Meldungen dort überhaupt gelistet werden sollen.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/output/renderers/email/undelivered_hint.py` | **Der Prüfling.** `_CHANNEL_LABELS:31`, `_REASON_LABELS:35-42`, `_TRIGGER_LABELS:45-49`, `_line():80-86` |
+| `src/output/renderers/email/html.py:61,1636` | Aufrufer 1 — Trip-HTML |
+| `src/output/renderers/email/plain.py:45,360` | Aufrufer 2 — Trip-Klartext |
+| `src/output/renderers/email/compact.py:38,285` | Aufrufer 3 — Kurzfassung, `ascii_safe=True` |
+| `src/output/renderers/email/compare_html.py:1668` | Aufrufer 4 — Vergleichs-HTML |
+| `src/output/renderers/comparison.py:40,396` | **Aufrufer 5 — im Modul-Docstring nicht erwähnt** (Vergleichs-Klartext) |
+| `src/services/alert_log.py:45-59,131-135,359-380,383-449` | Grund-Konstanten, `_channels_not_sent`, `_missed_channels`, `read_undelivered` |
+| `src/services/alert_gate.py:143-156` | Einzige Stelle, die `quiet_hours`/`cooldown`/`daily_limit` als Grund erzeugt |
+| `src/services/trip_alert.py:1026`, `src/services/compare_radar_alert.py:162` | Einzige zwei Stellen, die eine Unterdrückung überhaupt protokollieren — **beide Radar** |
+| `src/services/alert_briefing_anchor.py:233-251` | Zeitfenster: seit dem letzten Briefing; ohne Anker leere Liste |
+| `frontend/src/lib/components/alerts-tab/AlertCooldownCard.svelte:11` | Beschriftung in der Oberfläche: **„Cooldown"** |
+| `frontend/src/lib/components/alerts-tab/AlertQuietHoursCard.svelte:32` | Beschriftung in der Oberfläche: **„Stille Stunden"** |
+| `src/output/renderers/alert/render.py:200-206` | Alarm-Mail nennt dieselbe Sperre **„Cooldown"** |
+| `tests/tdd/test_alert_undelivered_hint.py` | 26 Tests, Hauptabsicherung des Bausteins |
+| `tests/tdd/test_alert_channel_threshold.py:1018,1023` · `tests/tdd/test_compare_alert_channel_threshold.py:1043` | Einzige Tests, die Grund-Wortlaute wörtlich festnageln (`"unter Schwelle"`, `"Versand fehlgeschlagen"`, `"Schwelle"`) |
+
+## Messung am Produktivkonto (2026-08-15, `/var/lib/gregor/users/henning/alert_log.json`)
+
+| Quelle | Menge | Auslöser | Nicht-Zustell-Gründe | Kanäle |
+|---|---|---|---|---|
+| `not_delivered` | 56 Vorfälle (09.08.–13.08.) | **100 % `nowcast`** | 96× `quiet_hours`, 18× `cooldown` | email 56, telegram 56, **premium_sms 2** |
+| `entries` | 49 Kanal-Einträge | `forecast_change`, `official_alert`, `nowcast` | 42× `channel_disabled` (wird beim Lesen verworfen), 7× `below_channel_threshold` | sms 29, **premium_sms 19**, telegram 1 |
+
+Sichtbar wird davon: 56 Radar-Vorfälle + 7 Schwellen-Fälle (SMS). Die `premium_sms`-Einträge
+tragen heute ausschließlich `channel_disabled` (unsichtbar) bzw. `cooldown` (2 sichtbar) —
+die Rohnamen-Zeile aus der Meldung ist damit reproduziert.
+
+Ist-Ausgabe des Bausteins (nachgestellt mit echten Werten, `render_undelivered_plain`):
+
+```
+NICHT BEI DIR ANGEKOMMEN
+
+  11.08. 17:45 · Amtliche Warnung · SMS nicht zugestellt (unter Schwelle)
+  11.08. 17:37 · Regenradar · E-Mail, Telegram, premium_sms nicht zugestellt (Sperrzeit)
+  11.08. 16:52 · Regenradar · E-Mail, Telegram nicht zugestellt (Ruhezeit)
+```
+
+## Die drei Befunde
+
+### B1 — `premium_sms` hat keinen deutschen Namen (Spec-Verstoß, nicht nur Lücke)
+
+`_CHANNEL_LABELS:31` kennt drei Kanäle; `alert_log._ALL_CHANNELS:59` kennt seit #1701 vier.
+Der Rückfall `.get(c, c)` (`:83`) schreibt den technischen Schlüssel in die Nutzerzeile.
+ADR-0049 legt die Außen-Schreibweise **„Premium-SMS"** fest; `feat_1701` §D4 hat dasselbe
+Mapping bereits in `notification_service.py` nachgetragen — `undelivered_hint.py` wurde dabei
+übersehen und wird in keiner Premium-SMS-Spec genannt.
+
+**Zweite, noch ungedeckte Hälfte:** `_REASON_LABELS` kennt die Premium-SMS-Sperrcodes
+`premium_sms_no_reply_address` / `premium_sms_reply_address_stale`
+(`src/output/channels/premium_sms.py:41-42`) ebenfalls nicht. Träte einer auf, stünde dort
+`Premium-SMS nicht zugestellt (premium_sms_no_reply_address)` — das verletzt AC-5 aus
+`feat_1461_s3b2a_kanal_schwelle.md` („verständlicher, deutscher Grund — **kein interner
+Bezeichner**") wörtlich. Am Produktivkonto heute nicht aufgetreten, also latent.
+
+### B2 — Drei Wörter für zwei Sachverhalte, keines davon deckungsgleich
+
+| Sachverhalt | Oberfläche (dort stellt der Nutzer es ein) | Alarm-Mail | Briefing-Abschnitt |
+|---|---|---|---|
+| Uhrzeitfenster ohne Alarme | **„Stille Stunden"** | — | **„Ruhezeit"** |
+| Mindestabstand zwischen zwei Alarmen | **„Cooldown"** | **„Cooldown"** | **„Sperrzeit"** |
+
+Der Nutzer stellt „Stille Stunden" ein und liest „Ruhezeit"; er stellt „Cooldown" ein und liest
+„Sperrzeit". Kein Wort in der Mail führt zu der Einstellung zurück, die den Fall verursacht hat —
+das ist die eigentliche Unverständlichkeit, nicht bloß die Ähnlichkeit der zwei Wörter.
+
+Fachlich (Quelle: `docs/specs/_archive/modules/issue_181_alert_cooldown_quiet_hours.md`):
+`quiet_hours` = Zeitfenster „HH:MM–HH:MM" in Ortszeit, in dem nichts gesendet wird;
+`cooldown` = Mindestabstand in Minuten seit der letzten **zugestellten** Meldung derselben Sache.
+
+### B3 — Die Liste kann per Konstruktion fast nur Regenradar enthalten
+
+`quiet_hours`/`cooldown`/`daily_limit` werden ausschließlich über `append_suppressed_entry()`
+protokolliert, und das rufen genau zwei Stellen — beide Radar (`trip_alert.py:1026`,
+`compare_radar_alert.py:162`). Der Vorhersage-Änderungs- und der Amtliche-Warnung-Pfad brechen
+bei einer Unterdrückung mit `return False` ab, **ohne** zu protokollieren (`trip_alert.py:247`,
+`compare_alert.py:159`) — in `alert_log.py:281-284` als Lücke O3 ausgewiesen.
+
+Die 100-%-Radar-Quote ist damit kein Zufall der letzten Woche, sondern strukturell. Wer nach
+Auslöser filtert, leert den Abschnitt heute praktisch vollständig — mit Ausnahme der
+`below_channel_threshold`-Fälle aus dem `entries`-Zweig.
+
+## Existing Patterns
+
+- **Grund-basierte Filterung gibt es schon:** `channel_disabled` wird beim Lesen verworfen
+  (`alert_log.py:376`), weil ein abgeschalteter Kanal kein Vorfall ist. Ein Filter für B3
+  hätte hier sein Vorbild — und dieselbe Stelle.
+- **Wortlisten sind nicht dupliziert:** Die deutschen Gründe existieren genau einmal
+  (`undelivered_hint.py:35-42`). Kein Klassen-Problem über mehrere Dateien.
+- Der Baustein bedient bewusst Trip **und** Ortsvergleich (kein `trip_`/`compare_`-Präfix,
+  Teilungs-Invariante, Pendant-Sperre #1481 B).
+
+## Dependencies
+
+- **Upstream:** `services.alert_log.read_undelivered()` → `alert_briefing_anchor.undelivered_since_last_briefing()` → `notification_service.py:336` (Trip) bzw. `scheduler_dispatch_service.py:472` (Compare)
+- **Downstream:** fünf Render-Pfade (s.o.). Kein Go-, kein Frontend-, kein API-Verbraucher.
+
+## Existing Specs
+
+| Spec | Rolle |
+|---|---|
+| `docs/specs/modules/feat_1461_s3b1_briefing_sichtbarkeit.md` (v1.2, PO-go 2026-08-05) | Leitspec des Abschnitts. AC-1 nennt „SMS" wörtlich, AC-2 „alle drei Kanalnamen", AC-6 Deckelung auf 5 Zeilen |
+| `docs/specs/modules/feat_1461_s3b2a_kanal_schwelle.md` | **AC-5: deutscher Grund, kein interner Bezeichner** — die Regel, gegen die B1 verstößt |
+| `docs/specs/modules/feat_1459_alert_protokoll.md` (v1.5) | Schema + Grund-Katalog O2, `reason` bewusst freier String |
+| `docs/adr/0049-premium-sms-vierter-kanal.md` | Kanalname `premium_sms`, Außen-Schreibweise „Premium-SMS" |
+| `docs/specs/_archive/modules/issue_181_alert_cooldown_quiet_hours.md` | Ursprungsdefinition beider Sperren |
+
+**Kein Dokument legt die deutschen Wortlaute der Gründe fest** — sie stehen nur im Code. Eine
+Umbenennung berührt daher keine freigegebene Zusicherung außer AC-5 (die sie erfüllt, nicht bricht).
+
+## Risks & Considerations
+
+1. **Wächter-Loch:** „Ruhezeit", „Sperrzeit" und „Tageslimit" sind heute von **keinem** Test
+   als Zeichenkette geprüft — sie ließen sich wortlos ändern, ohne dass etwas rot wird. Nur
+   „unter Schwelle" und „Versand fehlgeschlagen" sind abgesichert. Der Fix muss diese Lücke
+   mitschließen, sonst bewacht auch die neue Wortwahl nichts.
+2. **Renderer-Commit-Gate #811:** `undelivered_hint.py` liegt in `src/output/renderers/email/`
+   → Commit blockt bis `tests/tdd/test_issue_811_mode_matrix.py` grün **und** ein
+   `briefing_mail_validator.py`-Lauf gegen eine echt zugestellte Staging-Mail bestanden ist.
+3. **Fünf Aufrufer, nicht vier** — der Modul-Docstring ist unvollständig. Ein Nachweis, der nur
+   die vier genannten Pfade prüft, lässt den Compare-Klartext (`comparison.py:396`) ungeprüft.
+4. **Testliterale:** `_CHANNEL_LABELS`-Wortlaute sind load-bearing
+   (`test_alert_undelivered_hint.py:397-399,448,623`) — ein Umbenennen von „E-Mail"/„Telegram"/
+   „SMS" bricht diese Tests. Ein reines *Hinzufügen* von `premium_sms` bricht nichts.
+5. **Dedup-Fenster gleitend:** `DEDUP_WINDOW = 2 Min` gruppiert gegen `gruppen[-1]["at"]`, nicht
+   gegen den Gruppenstart — eine dichte Radar-Kette (alle 7-8 Min am Produktivkonto) verschmilzt
+   NICHT, aber eine dichtere schon; `trigger` gewinnt dabei der jüngste Eintrag. Nicht Teil
+   dieses Fixes, aber beim Nachweis zu beachten.
+6. **B3 ist eine Produktentscheidung, keine technische.** Filtert man nach Auslöser, verschwindet
+   die Information über unterdrücktes Radar vollständig — das kollidiert mit dem Grundsatz, dass
+   der Nutzer entscheidet, was für ihn wichtig ist. Alternativen (zusammenfassen statt streichen,
+   nach Grund statt nach Auslöser filtern) gehören in die Spec-Freigabe.
+
+## Offene PO-Entscheidungen (für `/30-write-spec`)
+
+- **E1 Wortwahl:** Mail übernimmt die Oberflächen-Wörter („Stille Stunden" / „Cooldown")?
+  Oder beide Seiten bekommen neue, selbsterklärende deutsche Wörter (Frontend dann im Scope)?
+  Oder die Mail beschreibt statt zu benennen?
+- **E2 Umfang der Liste:** Radar-Unterdrückungen weiter einzeln listen, zusammenfassen
+  („12× Regenradar während der Stillen Stunden") oder ganz weglassen?

--- a/docs/specs/modules/feat_1461_s3b1_briefing_sichtbarkeit.md
+++ b/docs/specs/modules/feat_1461_s3b1_briefing_sichtbarkeit.md
@@ -10,6 +10,15 @@ tags: [alerts, briefing, email, epic-1458, issue-1461]
 
 # Briefing zeigt, welche Alarme nicht angekommen sind (#1461 S3b-1)
 
+> **Teilweise überholt durch #1750/#1800 (2026-08-15):** Die Sammelüberschrift
+> „NICHT BEI DIR ANGEKOMMEN" entfällt ersatzlos, ersetzt durch zwei eigenständige Blöcke
+> „FEHLGESCHLAGEN — da ist etwas schiefgegangen" (Fehler) und „ZURÜCKGEHALTEN — so hast du es
+> eingestellt" (Absicht). Die Deckelung aus AC-6 (5 Zeilen) gilt seither **je Block**, nicht mehr
+> über die Gesamtliste — siehe die Notiz direkt bei AC-6. Details, Wortlaute und Begründung:
+> `docs/specs/modules/fix_1750_zustell_hinweis_klartext.md`. Die übrige Beschreibung dieser Spec
+> (Lesefunktion, Zeitanker, Renderer-Einbindung, Entdoppelung, AC-1 bis AC-5, AC-7 bis AC-17)
+> bleibt unverändert gültig.
+
 ## Approval
 
 - [x] Approved — PO, 2026-08-05 („go"). Deckelung bei 5 Zeilen ohne Widerspruch übernommen.
@@ -73,6 +82,11 @@ und verworfen.
 | Umfang | **beide** Fälle — Totalausfall **und** Teilausfall („E-Mail kam an, SMS nicht") |
 | Kanäle | **nur E-Mail.** Telegram-Kurzform und SMS bleiben unberührt |
 | Deckelung | **5 Zeilen**, darunter „und N weitere" — *zur Freigabe vorgelegt* |
+
+> **Fortgeschrieben durch #1750 (2026-08-15):** Die Zeile „5 Zeilen" bezog sich hier auf die
+> Gesamtliste unter einer Sammelüberschrift. Seit
+> `docs/specs/modules/fix_1750_zustell_hinweis_klartext.md` gilt derselbe Zahlenwert
+> (`MAX_LINES_PER_BLOCK`) **je Block** getrennt (Fehlgeschlagen/Zurückgehalten) — s. Notiz bei AC-6.
 
 Abgeleitet (Routine, keine Rückfrage): „E-Mail" heißt **beide** Mail-Formate (`full` und
 `compact`); Trip und Ortsvergleich bekommen **denselben** Baustein (Teilungs-Gate).
@@ -148,6 +162,13 @@ NICHT BEI DIR ANGEKOMMEN
   … und 2 weitere
 ```
 
+> **Überholt durch #1750 (2026-08-15):** Dieses Beispiel zeigt noch die Sammelüberschrift
+> „NICHT BEI DIR ANGEKOMMEN" und die Formulierung „SMS nicht zugestellt". Seit
+> `docs/specs/modules/fix_1750_zustell_hinweis_klartext.md` gibt es diese Überschrift nicht mehr
+> — stattdessen „FEHLGESCHLAGEN — da ist etwas schiefgegangen" bzw. „ZURÜCKGEHALTEN — so hast du
+> es eingestellt", ohne die Formulierung „nicht zugestellt". Die hier gezeigte Zeitform
+> `TT.MM. HH:MM` bleibt unverändert gültig.
+
 Zeitform `TT.MM. HH:MM` statt „Gestern/Heute" (v1.2, Begründung aus der GREEN-Phase): „Gestern"
 hinge vom Erzeugungszeitpunkt ab und bräche damit die Reinheit des Renderers — gleiche Eingabe
 müsste sonst nicht mehr die gleiche Ausgabe liefern. Zusätzlich verlangt AC-15, dass außer dem
@@ -201,6 +222,12 @@ Zeitstempel keine Ziffer in der Zeile steht; ein Wortpräfix macht diese Prüfun
   erreicht / When das Briefing erzeugt wird / Then stehen die fünf jüngsten als Zeilen da,
   gefolgt von einem Hinweis, wie viele weitere es sind.
   - Test: Acht Vorfälle anlegen; fünf Zeilen plus „und 3 weitere" nachweisen.
+  - ⚠️ **Abgelöst durch #1750 (2026-08-15)** (`docs/specs/modules/fix_1750_zustell_hinweis_klartext.md`
+    AC-12, E6): Die Deckelung gilt nicht mehr über die Gesamtliste, sondern **je Block** getrennt
+    (`MAX_LINES_PER_BLOCK`) — ein zurückgehaltener Vorfall wird von der Deckelung des
+    Fehlgeschlagen-Blocks nicht mehr verdrängt und umgekehrt. Der hier beschriebene Test (acht
+    Vorfälle in einer gemeinsamen Liste) ist als Konstruktion überholt; der Nachweis erfolgt jetzt
+    block-getrennt. Ursprünglicher AC-Wortlaut bleibt zur Historie unverändert stehen.
 
 - **AC-7:** Given ein Nutzer bekommt zum ersten Mal ein Briefing, nachdem diese Funktion
   ausgeliefert wurde, und sein Protokoll enthält alte nicht zugestellte Meldungen /
@@ -314,6 +341,12 @@ Zeitstempel keine Ziffer in der Zeile steht; ein Wortpräfix macht diese Prüfun
 
 ## Changelog
 
+- 2026-08-15: **AC-6 abgelöst durch #1750/#1800**
+  (`docs/specs/modules/fix_1750_zustell_hinweis_klartext.md`) — Sammelüberschrift
+  „NICHT BEI DIR ANGEKOMMEN" entfällt ersatzlos zugunsten zweier Blöcke „FEHLGESCHLAGEN"/
+  „ZURÜCKGEHALTEN"; die 5-Zeilen-Deckelung gilt seither je Block statt über die Gesamtliste.
+  Historischer AC-Wortlaut und das alte Klartext-Beispiel bleiben zur Nachvollziehbarkeit
+  unverändert stehen, mit Fortschreibungs-Notizen versehen.
 - 2026-08-05 (v1.2): AC-17 ergänzt — der **Klartext-Teil** der Ortsvergleichs-Mail bekommt den
   Abschnitt ebenfalls. In der GREEN-Phase war er ausgelassen worden, weil die Dateiliste
   `comparison.py` nicht nannte und AC-11 nur HTML prüft. Beide Fassungen werden zugestellt; der

--- a/docs/specs/modules/fix_1750_zustell_hinweis_klartext.md
+++ b/docs/specs/modules/fix_1750_zustell_hinweis_klartext.md
@@ -1,0 +1,455 @@
+---
+entity_id: fix_1750_zustell_hinweis_klartext
+type: bugfix
+created: 2026-08-15
+updated: 2026-08-15
+status: draft
+version: "1.0"
+tags: [alerts, briefing, email, epic-1458, issue-1750, issue-1800]
+---
+
+# Briefing-Hinweis "nicht angekommen" wird verständlich (#1750, #1800)
+
+## Approval
+
+- [x] Approved — PO, 2026-08-15 („freigabe"). Ausdrücklich mitfreigegeben: die Änderung an
+  AC-6 aus `feat_1461_s3b1_briefing_sichtbarkeit.md` (Deckelung 5 Zeilen gilt ab jetzt JE BLOCK
+  statt für die Gesamtliste) und die ASCII-Faltung `ZURUeCKGEHALTEN` in der Kurzfassung.
+  Beleg: Gesprächsverlauf zu #1750, Entscheidungen E1–E7 im Kontext-Dokument.
+
+## Purpose
+
+Der Briefing-Abschnitt „NICHT BEI DIR ANGEKOMMEN" nennt heute den technischen Kanalnamen
+`premium_sms` roh, verwendet für Sperrgründe die Wörter „Ruhezeit"/„Sperrzeit", die zu **keiner**
+Beschriftung in der Oberfläche passen, und behauptet mit „nicht zugestellt" pauschal einen
+Fehler — obwohl vier von sechs Gründen planmäßige, vom Nutzer selbst eingestellte
+Unterdrückungen sind. Diese Spec trennt „hier ist etwas schiefgegangen" (Fehler) von „das hast
+du dir so eingestellt" (Absicht) in zwei eigene Blöcke, übernimmt für die zwei Sperrgründe die
+Wörter aus der Oberfläche, ergänzt den fehlenden Premium-SMS-Kanalnamen und fasst wiederholte
+gleichartige Vorfälle zu einer Zeile zusammen — damit eine echte zweite amtliche Warnung nicht
+mehr hinter Regenradar-Zeilen aus der Deckelung fällt (gemessener Schaden, Mail vom 11.08.).
+
+## Source
+
+- **Datei (geändert, einzige Produktivdatei):**
+  `src/output/renderers/email/undelivered_hint.py`
+- **Identifier:** `_CHANNEL_LABELS`, `_REASON_LABELS`, `_line()`, `render_undelivered_plain()`,
+  `render_undelivered_html()`, Modul-Docstring (fünfter Aufrufer nachtragen)
+- **Schicht:** Python-Core (`src/output/renderers/email/`). Keine Go-Änderung, keine
+  Frontend-Änderung, keine Änderung an `src/services/alert_log.py` oder
+  `src/services/alert_gate.py`.
+- **Fünf Aufrufer (unverändert in Signatur, nur der Inhalt ändert sich):**
+  `src/output/renderers/email/html.py:1636`, `plain.py:360`, `compact.py:285`,
+  `compare_html.py:1668`, **`src/output/renderers/comparison.py:396`** (Vergleichs-Klartext —
+  im heutigen Modul-Docstring nicht genannt, wird mit dieser Änderung nachgetragen).
+- **Testdateien (geändert, keine neue Datei):** `tests/tdd/test_alert_undelivered_hint.py`
+  (Haupt-Suite + neue Wächter-Tests), `tests/tdd/test_alert_channel_threshold.py`,
+  `tests/tdd/test_compare_alert_channel_threshold.py` (beide importieren `_hint_lines`/
+  `LINE_MARKER` aus der Haupt-Suite und ein Testliteral, s. „Implementation Details").
+
+## Estimated Scope
+
+- **LoC:** ~150–190 Produktivcode (eine Datei) · ~350–450 Testcode (drei bestehende Dateien
+  angepasst, keine neue Testdatei — neue Fälle ergänzen `test_alert_undelivered_hint.py`)
+- **Files:** 1 Produktivdatei geändert, 3 Testdateien geändert, 0 neu
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `feat_1459_alert_protokoll` | liest (unverändert) | `REASON_*`-Konstanten, `_ALL_CHANNELS` als SSoT für die Katalog-Wächter |
+| `feat_1461_s3b1_briefing_sichtbarkeit` | ändert AC-6 | Deckelung „5 Zeilen" gilt ab dieser Spec je Block, nicht mehr gesamt (PO-Entscheidung E6) |
+| `feat_1461_s3b2a_kanal_schwelle` | erfüllt AC-5 | „deutscher Grund, kein interner Bezeichner" — B1/B2 aus dem Kontext-Dokument beheben genau diesen Verstoß |
+| ADR-0049 (Premium-SMS vierter Kanal) | befolgt | Außen-Schreibweise „Premium-SMS" |
+| Issue #1701 (Premium-SMS D5) | liest | `blocked_reason_codes` → Sperrcodes `premium_sms_no_reply_address`/`premium_sms_reply_address_stale` aus `src/output/channels/premium_sms.py:41-42` |
+| `src/output/renderers/email/design_tokens.py` | nutzt (nur bestehende Tokens) | `G_BOX_DANGER_BG`/`G_DANGER` (Failed, unverändert), `G_BOX_INFO_BG`/`G_INFO` (Withheld, neu verwendet) |
+| Pendant-Sperre #1481 B | befolgt | Datei bleibt ohne `trip_`/`compare_`-Präfix, bedient Trip **und** Ortsvergleich |
+
+## Implementation Details
+
+### Datenfluss bleibt unverändert
+
+`services.alert_log.read_undelivered()` liefert weiterhin genau die Vorfälle, die bereits über
+das `DEDUP_WINDOW` (2 Min, protokoll-zeit-basiert) zusammengefasst sind — **daran wird nichts
+geändert**. Alles Neue in dieser Spec (Blockaufteilung, Wortlaute, Wiederholungs-Zusammenfassung,
+Deckelung je Block) ist reine **Anzeigelogik** in `undelivered_hint.py`, so wie schon heute
+`MAX_UNDELIVERED_LINES` dort und nicht in `alert_log.py` sitzt.
+
+### Neue/geänderte Modulkonstanten
+
+Überschriften und Deckelung (Ersatz für `UNDELIVERED_HEADING`/`MAX_UNDELIVERED_LINES`):
+
+```python
+HEADING_FAILED = "FEHLGESCHLAGEN — da ist etwas schiefgegangen"
+HEADING_WITHHELD = "ZURÜCKGEHALTEN — so hast du es eingestellt"
+# UNDELIVERED_HEADING entfaellt ersatzlos (E1)
+
+MAX_LINES_PER_BLOCK = 5   # gleicher Wert wie vorher, jetzt JE BLOCK ausgewertet
+
+_CHANNEL_LABELS = {
+    "email": "E-Mail", "telegram": "Telegram", "sms": "SMS",
+    "premium_sms": "Premium-SMS",   # NEU (B1)
+}
+```
+
+Grund-Wortlaute (drei bestehende Einträge unverändert im Wortlaut, vier neu/geändert):
+
+```python
+_REASON_LABELS = {
+    "delivery_failed": "Versand fehlgeschlagen",                    # unveraendert
+    "quiet_hours": "Stille Stunden",                                # NEU, war "Ruhezeit"
+    "daily_limit": "Tageslimit",                                    # unveraendert
+    "cooldown": "Cooldown",                                         # NEU, war "Sperrzeit"
+    "below_channel_threshold": "unter deiner Schwelle",             # NEU, war "unter Schwelle"
+    "premium_sms_no_reply_address": "keine Rueckadresse gelernt",   # NEU (B1)
+    "premium_sms_reply_address_stale": "Rueckadresse veraltet",     # NEU (B1)
+}
+```
+
+Einsortierung je Grund in einen der zwei Blöcke (E2-Tabelle als Code):
+
+```python
+_REASON_BLOCK = {
+    "delivery_failed": "failed",
+    "premium_sms_no_reply_address": "failed",
+    "premium_sms_reply_address_stale": "failed",
+    "quiet_hours": "withheld",
+    "cooldown": "withheld",
+    "daily_limit": "withheld",
+    "below_channel_threshold": "withheld",
+    # unbekannter Code -> _REASON_BLOCK.get(reason, "failed"): E2 letzte Zeile
+}
+```
+
+`_REASON_LABELS`/`_REASON_BLOCK` bekommen KEINEN Eintrag für `channel_disabled` — der Grund
+erreicht diesen Baustein weiterhin gar nicht (`alert_log.py:376` filtert ihn beim Lesen heraus,
+unverändert).
+
+### Wortwahl-Begründung (Pflichtangabe der PO-Entscheidung)
+
+„Stille Stunden" und „Cooldown" sind exakt die Beschriftungen, unter denen der Nutzer diese
+Werte in der Oberfläche einstellt (`frontend/src/lib/components/alerts-tab/
+AlertQuietHoursCard.svelte:32` bzw. `AlertCooldownCard.svelte:11`); „Cooldown" steht zusätzlich
+bereits so in der Alarm-Mail (`src/output/renderers/alert/render.py:201`). Die Mail führt damit
+zur selben Einstellung zurück, die den Fall verursacht hat — das war vorher bei keinem der zwei
+Wörter der Fall.
+
+### Zeilenformat (E3)
+
+`_line()` verliert die Formulierung „nicht zugestellt" komplett; die Blocküberschrift trägt die
+Aussage jetzt:
+
+```
+{wann} · {worum} · {kanäle} · {grund}
+```
+
+Bei genau einem Vorfall bleibt das die einzige Form (kein „(1×)"-Suffix).
+
+### Blockaufteilung + Reihenfolge
+
+Je Rendering werden die gelesenen Vorfälle nach `_REASON_BLOCK` (Mehrheits-/Vereinigungs-Regel:
+enthält `inc.reasons` mindestens einen Grund mit Block `"failed"`, zählt der ganze Vorfall als
+`failed` — ein Vorfall mit gemischten Gründen ist damit nie „nur halb ein Fehler") in zwei Listen
+sortiert. Jeder Block wird nur gerendert, wenn seine Liste nicht leer ist. **Reihenfolge, wenn
+beide vorhanden sind: Fehlgeschlagen vor Zurückgehalten** — die dringlichere, handlungsrelevante
+Information zuerst, konsistent mit der bestehenden Rot-vor-Neutral-Konvention des Bausteins.
+
+### Wiederholungen zusammenfassen (E5)
+
+Innerhalb eines Blocks werden Vorfälle mit identischem **Fünftupel**
+`(inc.metrics, inc.hazards, inc.trigger, frozenset(inc.reasons), frozenset(inc.channels))` zu
+einer Zeile zusammengefasst. `inc.metrics`/`inc.hazards`/`inc.trigger` sind bewusst die
+**zugrundeliegenden Werte**, aus denen `_subject()` den angezeigten Text ableitet — **nicht**
+der angezeigte Text selbst. Das ist keine kosmetische Feinheit: zwei amtliche Warnungen mit
+unterschiedlicher Gefahrenart rendern beide als „Amtliche Warnung" (`_subject()` gibt bei jedem
+`hazards`/`official_alert`-Vorfall denselben generischen Text zurück), sind aber **unterschiedliche
+reale Ereignisse**. Eine Gruppierung nach angezeigtem Text würde genau den Fehler, den diese Spec
+behebt, an anderer Stelle neu einführen: eine echte zweite Warnung verschwände hinter einem
+Zähler statt hinter einer Deckelung. Deshalb AC-10.
+
+Format bei `n > 1`: `{spanne} · {worum} ({n}×) · {kanäle} · {grund}`. Zeitspanne = ältester bis
+jüngster Zeitpunkt der Gruppe:
+
+- gleicher Kalendertag: `TT.MM. HH:MM–HH:MM` (ein Datum), z. B. `11.08. 04:07–17:37`
+- Spanne über Mitternacht: `TT.MM. HH:MM–TT.MM. HH:MM` (Datum an beiden Enden), z. B.
+  `10.08. 23:50–11.08. 00:15`
+
+Sortierung innerhalb eines Blocks bleibt „jüngster Vorfall zuerst" (bestehende Zusicherung aus
+`feat_1461_s3b1`); für eine zusammengefasste Zeile zählt dafür das jüngste Einzelmitglied der
+Gruppe. (Das Beispiel in der PO-Vorgabe demonstriert Blocktrennung, Zeilenformat, Zähler- und
+Zeitspannen-Schreibweise — nicht zwingend die exakte Zeilen-Reihenfolge für dieses synthetische
+Beispiel; s. „Bekannte Grenzen".)
+
+### Deckelung je Block (E6, Änderung an `feat_1461_s3b1` AC-6)
+
+`MAX_LINES_PER_BLOCK` wird **separat für jeden der beiden Blöcke** ausgewertet (vorher: eine
+gemeinsame Grenze über die ganze Liste). Rest-Hinweis „und N weitere" bleibt wortgleich, erscheint
+aber gegebenenfalls in **beiden** Blöcken unabhängig. Bewusste Abweichung von der bisherigen
+PO-Freigabe 2026-08-05 (galt für die Gesamtliste): so kann ein echter Fehler nie von planmäßigen
+Unterdrückungen verdrängt werden — genau das ist am 11.08. mit der zweiten amtlichen Warnung
+passiert.
+
+### Farbgebung (E7)
+
+Der Block „Fehlgeschlagen" bleibt der bestehende Danger-Kasten (`G_BOX_DANGER_BG`/`G_DANGER`,
+unverändert). Der Block „Zurückgehalten" verwendet das bereits vorhandene neutrale Tokenpaar
+`G_BOX_INFO_BG`/`G_INFO` (bislang für den Compact-Summary-Akzent genutzt, hier zweitverwendet —
+kein neues Token). Inhaltszeilen bleiben in beiden Blöcken `G_INK` (Design-Leitprinzip: kein
+`G_INK_FAINT` für Inhalt).
+
+### ASCII-Sicherheit (Nebenbedingung 2)
+
+`render_undelivered_plain(..., ascii_safe=True)` faltet weiterhin auf reines ASCII
+(`str.isascii()`). Die zwei neu hinzukommenden Sonderzeichen bekommen dieselbe explizite
+Vorbehandlung wie die bestehenden `"·"`/`"…"` (Zeile vor `fold_ascii()`):
+`.replace("–", "-").replace("×", "x")` — Halbgeviertstrich der Zeitspanne wird zum ASCII-Bindestrich,
+das Multiplikationszeichen des Zählers zum Buchstaben `x` (z. B. `12x` statt `12×`).
+
+**Gemessen 2026-08-15** (`fold_ascii` auf den neuen Zeichen, damit die Umsetzung nicht rät):
+
+| Zeichen | `fold_ascii` allein | Bewertung |
+|---|---|---|
+| `—` (Geviertstrich, in beiden Überschriften) | `-` | trägt schon, kein eigener Replace nötig |
+| `–` (Halbgeviertstrich, Zeitspanne) | `-` | trägt schon; der Replace bleibt trotzdem, weil er die Absicht sichtbar macht (gleiche Bauform wie bei `·`/`…`) |
+| `×` (Zähler) | **`*`** | **trägt NICHT** — ohne den Replace stünde `12*` in der Kurzfassung. Der Replace ist hier keine Kosmetik, sondern Pflicht |
+| `Ü` (in `ZURÜCKGEHALTEN`) | `Ue` | bindende Digraph-Regel (`docs/reference/sms_format.md:27`) — die Kurzfassung zeigt `ZURUeCKGEHALTEN`, konsistent mit jedem anderen Umlaut dort |
+
+### Fünf Aufrufer bleiben signaturgleich
+
+`has_undelivered()`, `render_undelivered_plain()`, `render_undelivered_html()` behalten Name und
+Parameter — nur ihr Ergebnis-Text ändert sich intern. Keiner der fünf Aufrufer muss angefasst
+werden; der Modul-Docstring wird um den fünften Aufrufer (`comparison.py`) korrigiert.
+
+### Testinfrastruktur-Anpassung (Nebenbedingung 4)
+
+`LINE_MARKER = "nicht zugestellt"` (`test_alert_undelivered_hint.py:91`) verliert seinen Anker,
+weil die Formulierung aus der Zeile verschwindet (E3). Ersatz: `_hint_lines()` sammelt alle
+nicht-leeren, mit zwei Leerzeichen eingerückten Zeilen (bestehende Konvention) zwischen einer der
+beiden neuen Überschriften (`HEADING_FAILED`/`HEADING_WITHHELD`) und der nächsten Leerzeile —
+Rückgabe bleibt eine flache Liste aus **beiden** Blöcken, damit bestehende Aufrufer, die nur
+`len(zeilen)`/Inhalt prüfen, unverändert funktionieren. Betroffen sind alle drei Testdateien
+(`test_alert_undelivered_hint.py` selbst sowie die beiden Importeure
+`test_alert_channel_threshold.py`, `test_compare_alert_channel_threshold.py`) — beide Importeure
+ziehen `_hint_lines`/`LINE_MARKER` per `from tests.tdd.test_alert_undelivered_hint import ...`,
+eine lokale Änderung genügt.
+
+Testliterale, die zusätzlich mitgezogen werden müssen: `test_alert_channel_threshold.py:1018`
+(`"unter Schwelle"` → `"unter deiner Schwelle"` enthält den alten String NICHT mehr als
+zusammenhängendes Teilwort, Assertion muss auf den neuen Wortlaut umgestellt werden),
+`test_alert_channel_threshold.py:1023` (verbietet `"Versand fehlgeschlagen"` — bleibt gültig,
+unverändert). `test_compare_alert_channel_threshold.py:1043` erwartet nur die lose Teilzeichenkette
+`"Schwelle"` — bleibt ohne Änderung erfüllt, da `"unter deiner Schwelle"` sie weiterhin enthält.
+
+## Expected Behavior
+
+- **Input:** Alarm-Protokoll des Nutzers (unverändertes Schema), Briefing-Zeitzone — identisch zu
+  `feat_1461_s3b1`.
+- **Output:** Null, ein oder zwei Blöcke in HTML- und Klartext-Mail (Trip `full`, Trip `compact`,
+  Ortsvergleich HTML **und** Klartext). Jede Zeile trägt Zeitpunkt/Zeitspanne, Anlass (ggf. mit
+  Wiederholungszähler), Kanäle mit deutschem Namen, deutschen Grund.
+- **Side effects:** Keine. Reine Umformulierung/Umsortierung bestehender Eingabedaten; am
+  Alarm-Protokoll, am Versandverhalten und an `alert_briefing_anchor` ändert sich nichts.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Protokoll enthält sowohl einen `delivery_failed`- als auch einen
+  `quiet_hours`-Vorfall seit dem letzten Briefing / When das Briefing gerendert wird / Then
+  enthält der Text beide Überschriften „FEHLGESCHLAGEN — da ist etwas schiefgegangen" und
+  „ZURÜCKGEHALTEN — so hast du es eingestellt", und die erste Überschrift steht im Text vor der
+  zweiten.
+  - Test: Zwei reale Protokolleinträge mit den genannten Gründen anlegen, Briefing über den
+    echten Versandpfad erzeugen, Position beider Überschriften im erzeugten Klartext vergleichen.
+
+- **AC-2:** Given ein Protokoll enthält ausschließlich einen `cooldown`-Vorfall (keinen
+  fehlgeschlagenen) / When das Briefing gerendert wird / Then erscheint ausschließlich die
+  Überschrift „ZURÜCKGEHALTEN — so hast du es eingestellt" — „FEHLGESCHLAGEN" kommt im Text
+  nicht vor.
+  - Test: Ein Protokolleintrag mit Grund `cooldown`, Briefing rendern, beide Überschriften-Strings
+    auf An-/Abwesenheit prüfen.
+
+- **AC-3:** Given seit dem letzten Briefing wurde jede Meldung auf jedem eingeschalteten Kanal
+  zugestellt / When das Briefing erzeugt wird / Then enthält es keinen der beiden neuen
+  Blöcke — auch keine Überschrift, keine Zeile.
+  - Test: Protokoll nur mit vollständig zugestellten Einträgen; weder „FEHLGESCHLAGEN" noch
+    „ZURÜCKGEHALTEN" kommt im erzeugten Text vor (Regressionstest zu `feat_1461_s3b1` AC-3).
+
+- **AC-4:** Given ein Vorfall betrifft den Kanal `premium_sms` (z. B. Grund `cooldown`) / When
+  die Briefing-Zeile erzeugt wird / Then nennt sie den Kanal als „Premium-SMS" — der rohe Wert
+  `premium_sms` kommt als eigenständiges Wort nicht vor.
+  - Test: Protokolleintrag mit `channels_not_sent=[{premium_sms, cooldown}]`, Zeile im erzeugten
+    Text prüfen: „Premium-SMS" vorhanden, `"premium_sms"` (klein, mit Unterstrich) nicht.
+
+- **AC-5:** Given ein Vorfall trägt den Grund `quiet_hours` / When die Zeile erzeugt wird / Then
+  steht darin „Stille Stunden" — weder „Ruhezeit" noch der rohe Code kommen vor.
+  - Test: Protokolleintrag mit Grund `quiet_hours` (Nowcast-Pfad, `append_suppressed_entry`),
+    Briefing rendern, Wortlaut in der Zeile prüfen.
+
+- **AC-6:** Given ein Vorfall trägt den Grund `cooldown` / When die Zeile erzeugt wird / Then
+  steht darin „Cooldown" — weder „Sperrzeit" noch der rohe Code kommen vor.
+  - Test: Protokolleintrag mit Grund `cooldown`, Briefing rendern, Wortlaut in der Zeile prüfen.
+
+- **AC-7:** Given ein einzelner nicht zugestellter Vorfall liegt vor / When die Zeile erzeugt
+  wird / Then hat sie exakt die Form `{wann} · {worum} · {kanäle} · {grund}` ohne die
+  Formulierung „nicht zugestellt" und ohne Klammern um den Grund.
+  - Test: Ein Vorfall, erzeugte Zeile per Trennzeichen `·` in vier Teile zerlegen, jeden Teil
+    gegen die erwarteten Werte prüfen; `"nicht zugestellt"` kommt im ganzen Mailtext nicht vor.
+
+- **AC-8:** Given ein Protokolleintrag trägt einen Grund-Code, der in keinem der beiden
+  Wortlisten-Wörterbücher vorkommt (simuliert künftigen, noch nicht katalogisierten Code) / When
+  das Briefing gerendert wird / Then erscheint die Zeile im Block „FEHLGESCHLAGEN", nicht im
+  Block „ZURÜCKGEHALTEN".
+  - Test: Protokolldatei mit `channels_not_sent=[{email, "unbekannter_code_x"}]` real anlegen,
+    Briefing rendern, Position der resultierenden Zeile relativ zu den zwei Überschriften prüfen.
+
+- **AC-9:** Given zwölf Regenradar-Vorfälle mit identischem Register-Paar, identischen Gründen
+  (`quiet_hours`) und identischen Kanälen (E-Mail, Telegram) liegen über mehrere Stunden verteilt
+  vor / When das Briefing gerendert wird / Then steht dafür genau eine Zeile mit „(12×)" im
+  Anlass-Teil und einer Zeitspanne vom ältesten bis zum jüngsten Zeitpunkt.
+  - Test: Zwölf reale Protokolleinträge (Radar-Pfad, gleiches Register-Paar) mit Zeitstempeln über
+    mehrere Stunden anlegen, Briefing rendern, genau eine Zeile im Withheld-Block mit „(12×)" und
+    beiden Randzeitpunkten nachweisen.
+
+- **AC-10:** Given zwei amtliche Warnungen mit unterschiedlicher Gefahrenart (`hazards`), aber
+  gleichem angezeigtem Anlasstext „Amtliche Warnung", gleichem Kanal und gleichem Grund
+  (`below_channel_threshold`) liegen vor / When das Briefing gerendert wird / Then stehen dafür
+  **zwei** separate Zeilen, nicht eine zusammengefasste mit „(2×)".
+  - Test: Zwei Protokolleinträge mit `hazards=["thunderstorm"]` bzw. `hazards=["flood"]` (oder
+    vergleichbar unterschiedlich), sonst identischem Kanal/Grund; Anzahl der Zeilen im
+    Withheld-Block muss zwei sein — Kern-Anti-Regressions-Test gegen den in E5 beschriebenen
+    Fehlschluss.
+
+- **AC-11:** Given eine Gruppe wiederholter Vorfälle beginnt an einem Kalendertag und endet am
+  nächsten / When die zusammengefasste Zeile erzeugt wird / Then trägt die Zeitspanne an beiden
+  Enden ein Datum (`TT.MM. HH:MM–TT.MM. HH:MM`).
+  - Test: Zwei gruppierbare Vorfälle mit Zeitstempeln 23:50 und 00:15 des Folgetags anlegen,
+    erzeugte Zeitspannen-Zeichenkette gegen das Muster mit zwei Datumsangaben prüfen.
+
+- **AC-12:** Given seit dem letzten Briefing liegen sechs unterschiedliche (nicht gruppierbare)
+  fehlgeschlagene Vorfälle **und** ein zurückgehaltener Vorfall vor / When das Briefing gerendert
+  wird / Then zeigt der Block „FEHLGESCHLAGEN" fünf Zeilen plus „und 1 weitere", **und** der
+  zurückgehaltene Vorfall erscheint vollständig im Block „ZURÜCKGEHALTEN" — er wird von der
+  Deckelung des anderen Blocks nicht verdrängt.
+  - Test: Sechs `delivery_failed`-Einträge (verschiedene Anlässe, keine E5-Gruppierung möglich)
+    plus einen `cooldown`-Eintrag real anlegen, Briefing rendern; Withheld-Zeile im Text
+    nachweisen (reproduziert direkt den am 11.08. gemeldeten Schaden — vorher hätte sie gefehlt).
+
+- **AC-13:** Given ein Vorfall wurde wegen einer fehlenden Premium-SMS-Rückadresse
+  (`premium_sms_no_reply_address`) bzw. einer veralteten Rückadresse
+  (`premium_sms_reply_address_stale`) blockiert / When die Zeile erzeugt wird / Then nennt sie
+  „keine Rückadresse gelernt" bzw. „Rückadresse veraltet" und steht im Block „FEHLGESCHLAGEN".
+  - Test: Zwei Protokolleinträge über `blocked_reason_codes={"premium_sms": <Code>}` (via
+    `alert_log.append_entry`) real anlegen, Briefing rendern, Wortlaut UND Blockzugehörigkeit je
+    Fall prüfen.
+
+- **AC-14:** Given je ein Vorfall aus jedem Block liegt vor / When die HTML-Mail gerendert wird /
+  Then trägt der Kasten des Blocks „FEHLGESCHLAGEN" die Hex-Werte von `G_BOX_DANGER_BG`/
+  `G_DANGER`, der Kasten des Blocks „ZURÜCKGEHALTEN" die Hex-Werte von `G_BOX_INFO_BG`/`G_INFO`,
+  und keiner der beiden Inhaltszeilen-Stile enthält den Hex-Wert von `G_INK_FAINT` (`#9c9a90`).
+  - Test: `render_undelivered_html(...)` aufrufen und die vier Hex-Werte je Kasten per
+    Substring-Suche im erwarteten `<div>`-Ausschnitt nachweisen; `#9c9a90` wird **im Rückgabewert
+    dieses Bausteins** verneint, NICHT in der ganzen Briefing-Mail — `G_INK_FAINT` ist dort an
+    sechs weiteren Stellen legitim in Gebrauch (`html.py`, gemessen 2026-08-15), eine Prüfung
+    gegen die Gesamtausgabe wäre strukturell nie erfüllbar.
+
+- **AC-15:** Given eine zusammengefasste Zeile mit Zeitspanne und Wiederholungszähler liegt vor /
+  When die Kurzfassungs-Mail (`compact.py`, `ascii_safe=True`) gerendert wird / Then ist der
+  erzeugte Text vollständig `str.isascii()`, der Halbgeviertstrich der Spanne erscheint als `-`
+  und das Multiplikationszeichen des Zählers als `x`.
+  - Test: Gruppierbare Vorfälle mit Zeitspanne über zwei Zeitpunkte real anlegen,
+    `render_undelivered_plain(..., ascii_safe=True)` aufrufen, `str.isascii()` und die
+    konkreten Ersatzzeichen im Text prüfen.
+
+- **AC-16:** Given ein und dieselbe Protokoll-Lage mit Vorfällen in beiden Blöcken / When Trip
+  HTML, Trip Klartext (`full`), Trip Kurzfassung, Ortsvergleich HTML **und** Ortsvergleich
+  Klartext (`comparison.py`) gerendert werden / Then enthalten **alle fünf** Ausgaben beide
+  Blöcke mit denselben deutschen Wortlauten.
+  - Test: Dieselbe Protokolldatei über alle fünf Renderpfade rendern (inkl. des bisher im
+    Docstring fehlenden `comparison.py`-Pfads), je Ausgabe beide Überschriften und mindestens
+    eine Beispiel-Formulierung („Premium-SMS", „Stille Stunden") nachweisen.
+
+- **AC-17:** Given für jeden Kanal aus `services.alert_log._ALL_CHANNELS` (Single Source of
+  Truth) liegt ein Vorfall vor, der genau diesen Kanal betrifft / When das Briefing gerendert
+  wird / Then erscheint für jeden Kanal sein deutsches Label aus `_CHANNEL_LABELS`, und keiner
+  der vier rohen Kanalnamen (`email`, `telegram`, `sms`, `premium_sms`) kommt als eigenständiges,
+  klein geschriebenes Wort im erzeugten Text vor.
+  - Test: Wächter-Test parametrisiert über `alert_log._ALL_CHANNELS`, baut je Kanal einen realen
+    Protokolleintrag, rendert das Briefing, prüft am erzeugten Text (nicht am Wörterbuch) sowohl
+    das erwartete deutsche Label als auch die Abwesenheit des rohen Kanalnamens per
+    Wortgrenzen-Suche (verhindert Fehlalarm durch `"sms"` als Teilstring von `"Premium-SMS"`).
+
+- **AC-18:** Given für jede `REASON_*`-Konstante aus `services.alert_log` (außer
+  `REASON_CHANNEL_DISABLED` und den drei Auslöser-Konstanten `REASON_FORECAST_CHANGE`/
+  `REASON_NOWCAST`/`REASON_OFFICIAL_ALERT`) sowie für jeden Sperrcode aus
+  `output.channels.premium_sms` (`BLOCK_REASON_NO_REPLY_ADDRESS`,
+  `BLOCK_REASON_REPLY_ADDRESS_STALE`) liegt ein Vorfall mit genau diesem Grund vor / When das
+  Briefing gerendert wird / Then erscheint für jeden Grund ein deutsches Label, und die Zeile
+  steht im laut Einsortierungs-Tabelle (E2) richtigen Block.
+  - Test: Wächter-Test parametrisiert über die SSoT-Konstanten, baut je Grund einen realen
+    Protokolleintrag, rendert das Briefing, prüft am erzeugten Text sowohl das deutsche Label als
+    auch die Blockzugehörigkeit (Position relativ zu `HEADING_FAILED`/`HEADING_WITHHELD`).
+
+## Nachweis
+
+**Renderer-Commit-Gate #811 (un-überspringbar):** `undelivered_hint.py` liegt unter
+`src/output/renderers/email/` — der Commit blockt, bis im aktiven Workflow beide frisch
+vorliegen: (1) `uv run pytest tests/tdd/test_issue_811_mode_matrix.py` grün, (2) ein
+erfolgreicher Lauf von `uv run python3 .claude/hooks/briefing_mail_validator.py` gegen eine echt
+zugestellte Staging-Mail mit Marker-Header `X-GZ-Mail-Type: trip-briefing`.
+
+„E2E bestanden" darf für dieses Feature erst nach Exit 0 des Validators behauptet werden — gegen
+echte Zustellung ins Stalwart-Test-Postfach, kein Mock, kein Gmail.
+
+## Nicht in dieser Scheibe
+
+- **O3 — Protokoll-Lücke bei Vorhersage-Änderung und amtlicher Warnung** (`alert_log.py:281-284`,
+  `trip_alert.py:247`, `compare_alert.py:159`): diese beiden Pfade protokollieren ihre
+  Unterdrückungen weiterhin **gar nicht**. Diese Spec kann nur anzeigen, was im Protokoll steht —
+  sie erzeugt keine neuen Schreibstellen. Eigener Befund, nicht Teil von #1750/#1800.
+- Änderungen an der Oberfläche (Alarme-Tab). Die Mail folgt der Oberflächen-Wortwahl, nicht
+  umgekehrt — keine Frontend-Datei wird angefasst.
+- Änderungen an `DEDUP_WINDOW`, `alert_log.append_entry()`/`append_suppressed_entry()` oder dem
+  Protokoll-Schema.
+- Neue Konfigurierbarkeit für den Nutzer (z. B. Blöcke ein-/ausblendbar machen). Beide Blöcke sind
+  unbedingt, kein Setting.
+- Sichtbarkeit in Telegram-/SMS-Kurznachrichten. AC-10 aus `feat_1461_s3b1` (Zeichenidentität
+  ungeachtet vorliegender Vorfälle) bleibt unverändert Ziel dieser Spec (hier als AC weitergeführt
+  über die Kurzfassungs-ASCII-Prüfung); eine **neue** Sichtbarkeit dort wird nicht eingeführt.
+- Neue Design-Tokens. `G_BOX_INFO_BG`/`G_INFO` sind bereits vorhanden und werden nur
+  zweitverwendet.
+
+## Known Limitations
+
+- **Sortierreihenfolge bei verschränkten Einzel-/Gruppen-Zeitstempeln:** Wenn eine zusammengefasste
+  Zeile eine Zeitspanne trägt, die einen einzelnen (nicht gruppierten) Vorfall zeitlich umschließt,
+  ist die exakte Zeilen-Reihenfolge zwischen beiden nicht Gegenstand eines eigenen ACs — es gilt
+  „jüngster Vorfall zuerst", wobei für eine Gruppe deren jüngstes Mitglied zählt. Das
+  Beispiel in der PO-Vorgabe illustriert Format und Blocktrennung, nicht zwingend eine
+  bindende Zeilen-Reihenfolge für exakt dieses synthetische Beispiel.
+- **Unbekannter Grund-Code zeigt weiterhin den rohen Code als Wortlaut** — es gibt strukturell
+  keine deutsche Übersetzung für einen Code, den niemand kennt. AC-8 sorgt nur dafür, dass er im
+  richtigen (roten) Block landet, nicht dafür, dass er hübsch aussieht. Die Katalog-Wächter
+  (AC-17/AC-18) machen diesen Fall für alle heute bekannten Codes unerreichbar, garantieren aber
+  nichts für künftig neu eingeführte Codes vor dem nächsten Testlauf.
+- **Innerhalb eines Blocks bleibt die Deckelung bei 5 Zeilen** (E6 ändert nur die Reichweite der
+  Deckelung — Block statt Gesamtliste — nicht ihre Höhe). Bei mehr als 5 nicht gruppierbaren
+  Vorfällen in einem Block greift weiterhin „und N weitere".
+- **E5-Gruppierung wirkt nur innerhalb eines Blocks.** Da der Grund den Block eindeutig bestimmt
+  (`_REASON_BLOCK`), können zwei Vorfälle mit identischem Fünftupel nie in unterschiedlichen
+  Blöcken landen — eine block-übergreifende Sonderregel ist nicht nötig.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Wortwahl und Layout eines Briefing-Bausteins verschieben keine
+  Entscheidungsfläche (Kanäle, Provider, Datenmodell/Persistenz, Auth, Editor-Paradigma,
+  Test-/Deploy-Strategie). Der Kanalname „Premium-SMS" ist bereits durch ADR-0049 festgelegt und
+  wird hier nur an einer bislang übersehenen Stelle nachgezogen.
+
+## Changelog
+
+- 2026-08-15 (v1.0): Initial spec created, auf Basis von
+  `docs/context/fix-1750-sperrzeit-wortwahl.md`. Ändert AC-6 aus
+  `feat_1461_s3b1_briefing_sichtbarkeit.md` (Deckelung jetzt je Block statt gesamt, PO-begründet)
+  und erfüllt AC-5 aus `feat_1461_s3b2a_kanal_schwelle.md` (deutscher Grund statt interner
+  Bezeichner) auch für `premium_sms`.

--- a/docs/specs/modules/fix_1750_zustell_hinweis_klartext.md
+++ b/docs/specs/modules/fix_1750_zustell_hinweis_klartext.md
@@ -102,8 +102,8 @@ _REASON_LABELS = {
     "daily_limit": "Tageslimit",                                    # unveraendert
     "cooldown": "Cooldown",                                         # NEU, war "Sperrzeit"
     "below_channel_threshold": "unter deiner Schwelle",             # NEU, war "unter Schwelle"
-    "premium_sms_no_reply_address": "keine Rueckadresse gelernt",   # NEU (B1)
-    "premium_sms_reply_address_stale": "Rueckadresse veraltet",     # NEU (B1)
+    "premium_sms_no_reply_address": "keine Rückadresse gelernt",    # NEU (B1)
+    "premium_sms_reply_address_stale": "Rückadresse veraltet",      # NEU (B1)
 }
 ```
 
@@ -448,6 +448,12 @@ echte Zustellung ins Stalwart-Test-Postfach, kein Mock, kein Gmail.
 
 ## Changelog
 
+- 2026-08-15 (v1.0a): Redaktionelle Angleichung ohne Bedeutungsänderung — der
+  Beispiel-Codeblock schrieb `"keine Rueckadresse gelernt"`/`"Rueckadresse veraltet"` in
+  ASCII, während das verbindliche AC-13 „Rückadresse" mit Umlaut zusichert. Der Codeblock
+  folgt jetzt dem AC. Aufgefallen in der TDD-RED-Phase; die Kurzfassung faltet den Umlaut
+  ohnehin über `fold_ascii` (s. Messtabelle oben), eine ASCII-Schreibweise im Label wäre also
+  auch fachlich falsch gewesen.
 - 2026-08-15 (v1.0): Initial spec created, auf Basis von
   `docs/context/fix-1750-sperrzeit-wortwahl.md`. Ändert AC-6 aus
   `feat_1461_s3b1_briefing_sichtbarkeit.md` (Deckelung jetzt je Block statt gesamt, PO-begründet)

--- a/src/output/renderers/email/undelivered_hint.py
+++ b/src/output/renderers/email/undelivered_hint.py
@@ -1,9 +1,10 @@
-"""Briefing-Abschnitt "was hat dich nicht erreicht" (Issue #1461 S3b-1).
+"""Briefing-Abschnitt "was hat dich nicht erreicht" (Issue #1461 S3b-1,
+Wortlaut/Blockaufteilung seit #1750/#1800).
 
 Bauform 1:1 nach ``unavailable_hint.py`` (#1348) und ``outlook_state_hint.py``
 (#1349): eine Pruefunktion, eine HTML-Fassung, eine Klartext-Fassung —
-eingebunden in ``html.py``, ``plain.py``, ``compact.py`` und
-``compare_html.py``.
+eingebunden in ``html.py``, ``plain.py``, ``compact.py``, ``compare_html.py``
+und ``comparison.py`` (Vergleichs-Klartext, #1750 im Docstring nachgetragen).
 
 Bewusst im Briefing-/E-Mail-Renderer-Bereich (nicht in ``renderers/alert/``):
 es ist ein Briefing-Baustein, kein Alarm-Renderer — so bleibt das
@@ -13,6 +14,12 @@ Ortsvergleich (Teilungs-Invariante, Pendant-Sperre #1481 B).
 
 Reine Funktionen: die Vorfaelle kommen als expliziter Parameter herein
 (``services.alert_log.read_undelivered()``), hier wird nichts nachgeladen.
+
+#1750: EIN Sammel-Block wird zu ZWEI eigenstaendigen Bloecken --
+"FEHLGESCHLAGEN" (echter Fehler) vor "ZURUECKGEHALTEN" (Nutzer-Absicht,
+z.B. Stille Stunden/Cooldown). Wiederholte, inhaltlich identische Vorfaelle
+werden je Block zu einer Zeile zusammengefasst (E5); die Deckelung
+``MAX_LINES_PER_BLOCK`` gilt seither JE BLOCK statt fuer die Gesamtliste.
 """
 from __future__ import annotations
 
@@ -23,22 +30,43 @@ from zoneinfo import ZoneInfo
 if TYPE_CHECKING:
     from services.alert_log import UndeliveredIncident
 
-UNDELIVERED_HEADING = "NICHT BEI DIR ANGEKOMMEN"
+HEADING_FAILED = "FEHLGESCHLAGEN — da ist etwas schiefgegangen"
+HEADING_WITHHELD = "ZURÜCKGEHALTEN — so hast du es eingestellt"
 
-# PO-Entscheidung 2026-08-05: hoechstens fuenf Zeilen, darunter "und N weitere".
-MAX_UNDELIVERED_LINES = 5
+# PO-Entscheidung 2026-08-05, angepasst 2026-08-15 (#1750 E6): hoechstens
+# fuenf Zeilen, jetzt JE BLOCK statt fuer die Gesamtliste ausgewertet.
+MAX_LINES_PER_BLOCK = 5
 
-_CHANNEL_LABELS = {"email": "E-Mail", "telegram": "Telegram", "sms": "SMS"}
+_CHANNEL_LABELS = {
+    "email": "E-Mail", "telegram": "Telegram", "sms": "SMS",
+    "premium_sms": "Premium-SMS",
+}
 
-# O2 aus #1459. `channel_disabled` fehlt bewusst — ein abgeschalteter Kanal
-# ist kein Vorfall und erreicht diesen Baustein gar nicht erst.
+# O2 aus #1459 + die beiden Premium-SMS-Sperrcodes aus #1701 (#1750 B1).
+# `channel_disabled` fehlt bewusst — ein abgeschalteter Kanal ist kein
+# Vorfall und erreicht diesen Baustein gar nicht erst.
 _REASON_LABELS = {
     "delivery_failed": "Versand fehlgeschlagen",
-    "quiet_hours": "Ruhezeit",
+    "quiet_hours": "Stille Stunden",
     "daily_limit": "Tageslimit",
-    "cooldown": "Sperrzeit",
-    # Issue #1461 S3b-2a: Kanal-Schwelle unterschreitet, Kanal war eingeschaltet.
-    "below_channel_threshold": "unter Schwelle",
+    "cooldown": "Cooldown",
+    "below_channel_threshold": "unter deiner Schwelle",
+    "premium_sms_no_reply_address": "keine Rückadresse gelernt",
+    "premium_sms_reply_address_stale": "Rückadresse veraltet",
+}
+
+# #1750 E2: Einsortierung je Grund in einen der zwei Bloecke. Ein Vorfall mit
+# mehreren Gruenden zaehlt als "failed", sobald EINER seiner Gruende
+# "failed" ist (siehe `_incident_block`); ein unbekannter Code faellt per
+# `.get(reason, "failed")` ebenfalls auf "failed".
+_REASON_BLOCK = {
+    "delivery_failed": "failed",
+    "premium_sms_no_reply_address": "failed",
+    "premium_sms_reply_address_stale": "failed",
+    "quiet_hours": "withheld",
+    "cooldown": "withheld",
+    "daily_limit": "withheld",
+    "below_channel_threshold": "withheld",
 }
 
 _TRIGGER_LABELS = {
@@ -75,63 +103,177 @@ def _subject(inc: "UndeliveredIncident") -> str:
     return _TRIGGER_LABELS.get(inc.trigger, "Alarm")
 
 
-def _line(inc: "UndeliveredIncident", tz: ZoneInfo) -> str:
-    """Eine Vorfall-Zeile: Zeitpunkt · worum es ging · welcher Kanal · warum."""
+def _incident_block(inc: "UndeliveredIncident") -> str:
+    """"failed" oder "withheld" (E2, Vereinigungsregel): enthaelt
+    ``inc.reasons`` mindestens einen Grund mit Block "failed", zaehlt der
+    ganze Vorfall als "failed" — nie "nur halb ein Fehler"."""
+    return "failed" if any(
+        _REASON_BLOCK.get(r, "failed") == "failed" for r in inc.reasons
+    ) else "withheld"
+
+
+def _split_blocks(incidents: Sequence) -> tuple[list, list]:
+    failed = [inc for inc in incidents if _incident_block(inc) == "failed"]
+    withheld = [inc for inc in incidents if _incident_block(inc) == "withheld"]
+    return failed, withheld
+
+
+def _group_key(inc: "UndeliveredIncident") -> tuple:
+    """#1750 E5: die ZUGRUNDELIEGENDEN Werte, nicht der angezeigte Text —
+    zwei amtliche Warnungen mit unterschiedlichem ``hazards`` rendern beide
+    als "Amtliche Warnung", sind aber verschiedene reale Ereignisse (AC-10)."""
+    return (inc.metrics, inc.hazards, inc.trigger,
+            frozenset(inc.reasons), frozenset(inc.channels))
+
+
+def _group(incidents: Sequence) -> list[list]:
+    """Wiederholungen zusammenfassen (E5): identisches Fuenftupel -> eine
+    Gruppe. ``incidents`` liegt bereits "juengster zuerst" vor — der erste
+    Treffer je Schluessel ist damit automatisch das juengste Mitglied, die
+    Zeilen-Reihenfolge braucht dafuer kein weiteres Sortieren."""
+    reihenfolge: list = []
+    gruppen: dict = {}
+    for inc in incidents:
+        key = _group_key(inc)
+        if key not in gruppen:
+            reihenfolge.append(key)
+            gruppen[key] = []
+        gruppen[key].append(inc)
+    return [gruppen[k] for k in reihenfolge]
+
+
+def _kanaele(inc: "UndeliveredIncident") -> str:
+    return ", ".join(_CHANNEL_LABELS.get(c, c) for c in inc.channels)
+
+
+def _gruende(inc: "UndeliveredIncident") -> str:
+    return ", ".join(_REASON_LABELS.get(r, r) for r in inc.reasons)
+
+
+def _zeitspanne(alt, neu, tz: ZoneInfo) -> str:
+    """Aeltester bis juengster Zeitpunkt einer Gruppe (E5). Gleicher
+    Kalendertag (Ortszeit): ein Datum; ueber Mitternacht: Datum an beiden
+    Enden (AC-11)."""
+    from utils.timezone import local_dt, local_fmt
+
+    gleicher_tag = local_dt(alt, tz).date() == local_dt(neu, tz).date()
+    start = local_fmt(alt, tz, "%d.%m. %H:%M")
+    ende = local_fmt(neu, tz, "%H:%M" if gleicher_tag else "%d.%m. %H:%M")
+    return f"{start}–{ende}"
+
+
+def _row(gruppe: Sequence, tz: ZoneInfo) -> str:
+    """Eine Zeile ohne "nicht zugestellt", ohne Klammern um den Grund (E3):
+    ``{wann} · {worum} · {kanaele} · {grund}``, bei ``n > 1``
+    ``{spanne} · {worum} ({n}×) · {kanaele} · {grund}`` (E5)."""
     from utils.timezone import local_fmt
 
-    wann = local_fmt(inc.at, tz, "%d.%m. %H:%M")
-    kanaele = ", ".join(_CHANNEL_LABELS.get(c, c) for c in inc.channels)
-    gruende = ", ".join(_REASON_LABELS.get(r, r) for r in inc.reasons)
-    return f"{wann} · {_subject(inc)} · {kanaele} nicht zugestellt ({gruende})"
+    fuehrend = gruppe[0]
+    if len(gruppe) == 1:
+        wann = local_fmt(fuehrend.at, tz, "%d.%m. %H:%M")
+        worum = _subject(fuehrend)
+    else:
+        zeitpunkte = [inc.at for inc in gruppe]
+        wann = _zeitspanne(min(zeitpunkte), max(zeitpunkte), tz)
+        worum = f"{_subject(fuehrend)} ({len(gruppe)}×)"
+    return f"{wann} · {worum} · {_kanaele(fuehrend)} · {_gruende(fuehrend)}"
 
 
 def _rest_hinweis(anzahl: int) -> str:
     return f"und {anzahl} weitere"
 
 
+def _rows_and_rest(incidents: Sequence, tz: ZoneInfo) -> tuple[list[str], int]:
+    """Zeilen (nach E5-Gruppierung, gedeckelt auf ``MAX_LINES_PER_BLOCK``)
+    plus Anzahl der dadurch verdraengten Zeilen (E6, JE BLOCK)."""
+    gruppen = _group(incidents)
+    gezeigt = gruppen[:MAX_LINES_PER_BLOCK]
+    verdraengt = gruppen[MAX_LINES_PER_BLOCK:]
+    return [_row(g, tz) for g in gezeigt], len(verdraengt)
+
+
 def render_undelivered_plain(
     incidents: Sequence, *, tz: ZoneInfo, ascii_safe: bool = False,
 ) -> str:
-    """Klartext-Fassung. ``ascii_safe=True`` (compact.py) liefert garantiert
-    reines ASCII (``str.isascii()``) — inklusive Umlaut-Faltung ueber
-    ``fold_ascii`` (SSoT, #1253), damit der Block nicht davon abhaengt, dass
-    der Aufrufer noch einmal darueberfaltet."""
+    """Klartext-Fassung: FEHLGESCHLAGEN vor ZURUECKGEHALTEN (#1750), jeder
+    Block nur wenn er Vorfaelle hat. ``ascii_safe=True`` (compact.py) liefert
+    garantiert reines ASCII (``str.isascii()``) — inklusive Umlaut-Faltung
+    ueber ``fold_ascii`` (SSoT, #1253) sowie der expliziten Vorbehandlung von
+    Halbgeviertstrich/Multiplikationszeichen (AC-15: ``fold_ascii`` allein
+    macht aus "×" ein "*", nicht ein "x")."""
     from utils.ascii_fold import fold_ascii
 
-    zeilen = [UNDELIVERED_HEADING, ""]
-    zeilen += [f"  {_line(inc, tz)}" for inc in incidents[:MAX_UNDELIVERED_LINES]]
-    rest = len(incidents) - MAX_UNDELIVERED_LINES
-    if rest > 0:
-        zeilen.append(f"  … {_rest_hinweis(rest)}")
-    text = "\n".join(zeilen)
+    failed, withheld = _split_blocks(incidents)
+    bloecke: list[list[str]] = []
+    for heading, teil in ((HEADING_FAILED, failed), (HEADING_WITHHELD, withheld)):
+        if not teil:
+            continue
+        zeilen, rest = _rows_and_rest(teil, tz)
+        block = [heading] + [f"  {z}" for z in zeilen]
+        if rest > 0:
+            block.append(f"  … {_rest_hinweis(rest)}")
+        bloecke.append(block)
+
+    ausgabe: list[str] = []
+    for i, block in enumerate(bloecke):
+        if i > 0:
+            ausgabe.append("")
+        ausgabe.extend(block)
+    text = "\n".join(ausgabe)
     if not ascii_safe:
         return text
-    return fold_ascii(text.replace("·", "-").replace("…", "..."))
+    text = text.replace("·", "-").replace("…", "...")
+    text = text.replace("–", "-").replace("×", "x")
+    return fold_ascii(text)
 
 
-def render_undelivered_html(incidents: Sequence, *, tz: ZoneInfo) -> str:
-    """Hochkontrastiger Danger-Box-Baustein, Token ``G_BOX_DANGER_BG``/
-    ``G_DANGER`` — bewusst KEIN ``G_INK_FAINT`` (Design-Leitprinzip:
-    Lesbarkeit unter Zeitdruck). Jede Vorfall-Zeile ist ein eigenes Element."""
-    from output.renderers.email.design_tokens import (
-        FONT_UI, G_BOX_DANGER_BG, G_DANGER, G_INK,
+def _render_block_html(
+    heading: str, incidents: Sequence, tz: ZoneInfo, *,
+    bg: str, border: str, ink: str, font: str,
+) -> str:
+    """Jede Vorfall-Zeile ist ein eigenes Element (wie ``render_undelivered_html``
+    vor #1750) -- die 4px Abstand je Zeile tragen zur Lesbarkeit unter
+    Zeitdruck bei (Design-Leitprinzip)."""
+    zeilen, rest = _rows_and_rest(incidents, tz)
+    inhalt = "".join(
+        f'<div style="margin:4px 0 0 0;color:{ink};font-size:13px;">'
+        f'{_html.escape(z)}</div>'
+        for z in zeilen
     )
-
-    zeilen = "".join(
-        f'<div style="margin:4px 0 0 0;color:{G_INK};font-size:13px;">'
-        f'{_html.escape(_line(inc, tz))}</div>'
-        for inc in incidents[:MAX_UNDELIVERED_LINES]
-    )
-    rest = len(incidents) - MAX_UNDELIVERED_LINES
     if rest > 0:
-        zeilen += (
-            f'<div style="margin:4px 0 0 0;color:{G_INK};font-size:13px;">'
+        inhalt += (
+            f'<div style="margin:4px 0 0 0;color:{ink};font-size:13px;">'
             f'… {_rest_hinweis(rest)}</div>'
         )
     return (
-        f'<div style="background:{G_BOX_DANGER_BG};'
-        f'border-left:4px solid {G_DANGER};padding:12px;margin:8px 20px;'
-        f'border-radius:4px;font-family:{FONT_UI};">'
-        f'<strong style="color:{G_DANGER};font-size:14px;">'
-        f'{UNDELIVERED_HEADING}</strong>{zeilen}</div>'
+        f'<div style="background:{bg};border-left:4px solid {border};'
+        f'padding:12px;margin:8px 20px;border-radius:4px;font-family:{font};'
+        f'color:{ink};font-size:13px;">'
+        f'<strong style="color:{border};font-size:14px;">{heading}</strong>'
+        f'{inhalt}</div>'
     )
+
+
+def render_undelivered_html(incidents: Sequence, *, tz: ZoneInfo) -> str:
+    """Zwei Kaesten (#1750): FEHLGESCHLAGEN bleibt der bestehende
+    Danger-Kasten (``G_BOX_DANGER_BG``/``G_DANGER``), ZURUECKGEHALTEN nutzt
+    das bereits vorhandene neutrale Tokenpaar ``G_BOX_INFO_BG``/``G_INFO``
+    (E7) — bewusst KEIN ``G_INK_FAINT`` fuer Inhalt (Design-Leitprinzip:
+    Lesbarkeit unter Zeitdruck)."""
+    from output.renderers.email.design_tokens import (
+        FONT_UI, G_BOX_DANGER_BG, G_BOX_INFO_BG, G_DANGER, G_INFO, G_INK,
+    )
+
+    failed, withheld = _split_blocks(incidents)
+    teile = []
+    if failed:
+        teile.append(_render_block_html(
+            HEADING_FAILED, failed, tz,
+            bg=G_BOX_DANGER_BG, border=G_DANGER, ink=G_INK, font=FONT_UI,
+        ))
+    if withheld:
+        teile.append(_render_block_html(
+            HEADING_WITHHELD, withheld, tz,
+            bg=G_BOX_INFO_BG, border=G_INFO, ink=G_INK, font=FONT_UI,
+        ))
+    return "".join(teile)

--- a/tests/tdd/test_alert_channel_threshold.py
+++ b/tests/tdd/test_alert_channel_threshold.py
@@ -1015,10 +1015,10 @@ def test_f001_below_threshold_grund_im_echten_delta_wetter_dispatch(monkeypatch)
         f"F001: genau eine Vorfall-Zeile im naechsten Briefing erwartet, "
         f"gefunden {zeilen!r}\n--- Klartext-Mail ---\n{report.email_plain}"
     )
-    assert "unter Schwelle" in zeilen[0], (
-        "F001: die Briefing-Zeile muss den WORTLAUT 'unter Schwelle' zeigen "
-        f"(nicht den technischen Ersatzgrund 'Versand fehlgeschlagen'): "
-        f"{zeilen[0]!r}"
+    assert "unter deiner Schwelle" in zeilen[0], (
+        "F001: die Briefing-Zeile muss den WORTLAUT 'unter deiner Schwelle' "
+        f"zeigen (#1750; nicht den technischen Ersatzgrund "
+        f"'Versand fehlgeschlagen'): {zeilen[0]!r}"
     )
     assert "Versand fehlgeschlagen" not in zeilen[0], (
         f"F001: 'Versand fehlgeschlagen' waere die falsche technische "

--- a/tests/tdd/test_alert_undelivered_hint.py
+++ b/tests/tdd/test_alert_undelivered_hint.py
@@ -39,23 +39,30 @@ Testpolitik (CLAUDE.md "Test-Politik: Zwei Schichten"):
 Pfadregel #1409: ``REPO_ROOT`` wird relativ zu DIESER Datei aufgeloest.
 
 ────────────────────────────────────────────────────────────────────────────
-Der Anzeige-Vertrag, den diese Tests festschreiben (Spec "Beispiel-Ausgabe"):
+Der Anzeige-Vertrag, den diese Tests festschreiben — seit #1750 (SPEC
+docs/specs/modules/fix_1750_zustell_hinweis_klartext.md) zwei eigenstaendige
+Bloecke statt einer Sammelueberschrift:
 
-    NICHT BEI DIR ANGEKOMMEN
+    FEHLGESCHLAGEN — da ist etwas schiefgegangen
 
-      05.08. 18:42 · Gewitter · SMS nicht zugestellt
+      05.08. 18:42 · Gewitter · SMS · Versand fehlgeschlagen
+
+    ZURÜCKGEHALTEN — so hast du es eingestellt
+
+      05.08. 06:15 · Wind · SMS · Stille Stunden
       … und 3 weitere
 
-* Ueberschrift: ``UNDELIVERED_HEADING``
-* je Vorfall EINE Zeile, erkennbar am Marker ``"nicht zugestellt"``
-  (im ganzen Repo sonst nirgends im Ausgabetext, gemessen)
-* die Zeile nennt Zeitpunkt (Briefing-Zeitzone), Anlass, Kanaele, Grund
-* Deckelung bei ``MAX_UNDELIVERED_LINES`` = 5, darunter "und N weitere"
+* zwei Ueberschriften ``HEADING_FAILED``/``HEADING_WITHHELD`` — die fruehere
+  Sammelueberschrift ``UNDELIVERED_HEADING`` ist ersatzlos entfallen
+* je Vorfall EINE Zeile im Format ``{wann} · {worum} · {kanaele} · {grund}``;
+  die Formulierung "nicht zugestellt" kommt seit #1750 nirgends mehr vor
+* Deckelung bei ``MAX_LINES_PER_BLOCK`` = 5, JE BLOCK getrennt ausgewertet
+  (vorher ueber die Gesamtliste) — "und N weitere" kann daher unabhaengig in
+  beiden Bloecken erscheinen
 
-Die STRUKTUR je Zeile wird am Klartext-Teil geprueft (dort gibt die Spec ein
-woertliches Beispiel vor); fuer HTML wird die Anwesenheit aller vier Angaben
-und die Zeilen-ANZAHL geprueft, nicht das Markup — sonst schriebe der Test das
-HTML-Geruest fest statt der Zusicherung.
+Die STRUKTUR je Zeile wird am Klartext-Teil geprueft; fuer HTML wird die
+Anwesenheit aller vier Angaben und die Zeilen-ANZAHL geprueft, nicht das
+Markup — sonst schriebe der Test das HTML-Geruest fest statt der Zusicherung.
 ────────────────────────────────────────────────────────────────────────────
 """
 from __future__ import annotations
@@ -82,12 +89,32 @@ from tests.helpers.alert_log_fixtures import (
     weather,
 )
 
+# SSoT-Konstanten fuer die Katalog-Waechter AC-17/AC-18 (#1750): NICHT gegen
+# das Wortlisten-Woerterbuch in `undelivered_hint.py` selbst pruefen, sondern
+# gegen dieselben Quellen, aus denen auch die Produktivseite schoepft.
+from services.alert_log import _ALL_CHANNELS as _SSOT_CHANNELS
+from services.alert_log import (
+    REASON_BELOW_THRESHOLD,
+    REASON_COOLDOWN,
+    REASON_DAILY_LIMIT,
+    REASON_DELIVERY_FAILED,
+    REASON_QUIET_HOURS,
+)
+from output.channels.premium_sms import (
+    BLOCK_REASON_NO_REPLY_ADDRESS,
+    BLOCK_REASON_REPLY_ADDRESS_STALE,
+)
+
 # Pfadregel #1409: Pruefling relativ zur Testdatei — nie ueber einen festen
 # Hauptrepo-Pfad, sonst pruefte dieser Test aus dem Worktree die unveraenderte
 # Hauptrepo-Kopie und meldete falsches Gruen.
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-# Zeilen-Marker des Hinweis-Abschnitts (s. Modul-Docstring).
+# Alt-Marker des Hinweis-Abschnitts (s. Modul-Docstring, vor #1750). Seit
+# #1750 (E3) verschwindet die Formulierung "nicht zugestellt" aus jeder
+# Zeile -- der Marker traegt fuer `_hint_lines()` keine Bedeutung mehr
+# (s. dort). Bleibt stehen: nichts im Repo importiert ihn (gemessen), ein
+# Entfernen waere reines Aufraeumen ohne Nutzen fuer #1750.
 LINE_MARKER = "nicht zugestellt"
 
 ALL_CHANNELS = ("email", "telegram", "sms")
@@ -276,19 +303,103 @@ def _trip_tz():
 # ═══════════════════════════ Text-Auswertung ══════════════════════════════
 
 
-def _heading() -> str:
-    from output.renderers.email.undelivered_hint import UNDELIVERED_HEADING
-    return UNDELIVERED_HEADING
+def _heading_present(text: str) -> bool:
+    """Ob IRGENDEINE der beiden #1750-Block-Ueberschriften im Text steht --
+    Ersatz fuer die alte einzelne ``UNDELIVERED_HEADING`` (entfaellt
+    ersatzlos, #1750 E1). Fuer "muss vorhanden sein"/"darf nicht vorhanden
+    sein" genuegt block-unabhaengig zu wissen, ob UEBERHAUPT ein Abschnitt
+    gerendert wurde -- welcher der beiden Bloecke es ist, pruefen die
+    #1750-eigenen Tests gezielt ueber ``HEADING_FAILED``/``HEADING_WITHHELD``."""
+    from output.renderers.email.undelivered_hint import (
+        HEADING_FAILED, HEADING_WITHHELD,
+    )
+    return HEADING_FAILED in text or HEADING_WITHHELD in text
+
+
+# Rest-Hinweis ("… und N weitere" / ASCII "... und N weitere") -- inhaltliches
+# Merkmal statt Layout-Position (#1750-Nachbesserung, ersetzt den Leerzeilen-Trick).
+_REST_HINWEIS_RE = re.compile(r"^(?:…|\.\.\.)\s*und\s+\d+\s+weitere$")
+
+
+def _known_headings() -> set[str]:
+    """Alle vier Formen der Block-Ueberschriften (Unicode + ASCII-gefaltet)
+    -- zusaetzliche Block-Grenze fuer ``_block_lines``, neben der Leerzeile."""
+    from output.renderers.email.undelivered_hint import (
+        HEADING_FAILED, HEADING_WITHHELD,
+    )
+    from utils.ascii_fold import fold_ascii
+
+    return {HEADING_FAILED, HEADING_WITHHELD,
+            fold_ascii(HEADING_FAILED), fold_ascii(HEADING_WITHHELD)}
+
+
+def _block_lines(text: str, heading: str) -> list[str]:
+    """Inhalts-Zeilen EINES Blocks: ab der Ueberschriften-Zeile bis zur
+    naechsten Leerzeile oder der naechsten Block-Ueberschrift, ohne die
+    Ueberschrift selbst (#1750 Nebenbedingung 4). Der Rest-Hinweis zaehlt
+    nicht mit (erkannt an ``_REST_HINWEIS_RE``)."""
+    zeilen = text.splitlines()
+    try:
+        start = zeilen.index(heading)
+    except ValueError:
+        return []
+    grenzen = _known_headings()
+    ergebnis: list[str] = []
+    for line in zeilen[start + 1:]:
+        stripped = line.strip()
+        if stripped == "" or stripped in grenzen:
+            break
+        if _REST_HINWEIS_RE.match(stripped):
+            continue
+        ergebnis.append(stripped)
+    return ergebnis
+
+
+def _hint_lines_ascii(text: str) -> list[str]:
+    """Wie ``_hint_lines``, aber gegen die ASCII-gefaltete Ueberschrift (fuer
+    ``compact.py``/``ascii_safe=True``): der Geviertstrich in
+    ``HEADING_FAILED``/``HEADING_WITHHELD`` wird dort zu ``-`` gefaltet
+    (#1750 AC-15) -- ein Abgleich gegen die Unicode-Konstante faende in
+    reinem ASCII-Text nie einen Treffer."""
+    from output.renderers.email.undelivered_hint import (
+        HEADING_FAILED, HEADING_WITHHELD,
+    )
+    from utils.ascii_fold import fold_ascii
+
+    return (_block_lines(text, fold_ascii(HEADING_FAILED))
+            + _block_lines(text, fold_ascii(HEADING_WITHHELD)))
+
+
+def _heading_present_ascii(text: str) -> bool:
+    """ASCII-Pendant zu ``_heading_present`` (s. dort)."""
+    from output.renderers.email.undelivered_hint import (
+        HEADING_FAILED, HEADING_WITHHELD,
+    )
+    from utils.ascii_fold import fold_ascii
+
+    return fold_ascii(HEADING_FAILED) in text or fold_ascii(HEADING_WITHHELD) in text
 
 
 def _hint_lines(text: str) -> list[str]:
-    """Die Vorfall-Zeilen des Hinweis-Abschnitts (Marker s. Modul-Docstring)."""
-    return [line.strip() for line in text.splitlines() if LINE_MARKER in line]
+    """Flache Liste aller Vorfall-Zeilen ueber BEIDE #1750-Bloecke (#1750
+    Nebenbedingung 4) -- Rueckgabeform bewusst unveraendert (flache Liste,
+    ``len()``/Inhalt pruefbar) fuer die Bestandsaufrufer in
+    ``test_alert_channel_threshold.py`` und
+    ``test_compare_alert_channel_threshold.py``."""
+    from output.renderers.email.undelivered_hint import (
+        HEADING_FAILED, HEADING_WITHHELD,
+    )
+    return _block_lines(text, HEADING_FAILED) + _block_lines(text, HEADING_WITHHELD)
 
 
 def _html_as_text(html: str) -> str:
-    """HTML auf Text reduzieren — jedes Element auf eine eigene Zeile."""
-    return re.sub(r"<[^>]+>", "\n", html)
+    """HTML auf Text reduzieren -- jedes Element auf eine eigene Zeile. Ein
+    einzelner Tag-Uebergang ohne Text dazwischen (z.B. Ueberschrift direkt
+    gefolgt vom naechsten Element) erzeugt dabei KEINE Phantom-Leerzeile
+    mehr; erst mehrere unmittelbar aufeinanderfolgende Tag-Enden (echtes
+    Element-Ende, z.B. Kasten-Ende) bleiben als EINE Leerzeile erhalten."""
+    text = re.sub(r"<[^>]+>", "\n", html)
+    return re.sub(r"\n{2,}", lambda m: "\n\n" if len(m.group()) > 2 else "\n", text)
 
 
 def _local_hhmm(moment: datetime) -> str:
@@ -401,7 +512,7 @@ def test_ac1_teilausfall_zeile_nennt_zeit_groesse_kanal_und_grund(monkeypatch):
 
     # Dieselbe Zusicherung im HTML-Teil derselben Mail.
     html_text = _html_as_text(report.email_html)
-    assert _heading() in html_text, "AC-1: Die HTML-Mail traegt keine Ueberschrift."
+    assert _heading_present(html_text), "AC-1: Die HTML-Mail traegt keine Ueberschrift."
     assert len(_hint_lines(html_text)) == 1, (
         f"AC-1: Die HTML-Mail muss genau eine Vorfall-Zeile tragen, gefunden "
         f"{_hint_lines(html_text)!r}"
@@ -484,7 +595,7 @@ def test_ac3_alles_zugestellt_erzeugt_keinen_abschnitt(monkeypatch):
 
     for teil, name in ((report.email_plain, "Klartext"),
                        (_html_as_text(report.email_html), "HTML")):
-        assert _heading() not in teil, (
+        assert not _heading_present(teil), (
             f"AC-3: Ohne fehlende Zustellung darf im {name}-Teil keine "
             f"Ueberschrift stehen."
         )
@@ -526,7 +637,7 @@ def test_ac3_abgeschalteter_kanal_ist_kein_vorfall(monkeypatch):
     recorder.install(monkeypatch)
     report = _run_trip_briefing(recorder, uid, trip)
 
-    assert _heading() not in report.email_plain, (
+    assert not _heading_present(report.email_plain), (
         "AC-3: Ein vom Nutzer ABGESCHALTETER Kanal ist keine fehlgeschlagene "
         "Zustellung — es darf kein Abschnitt erscheinen.\n"
         f"--- Klartext-Mail ---\n{report.email_plain}"
@@ -575,7 +686,7 @@ def test_ac4_bereits_ausgewiesener_vorfall_erscheint_nicht_erneut(monkeypatch):
         "AC-4: Ein bereits ausgewiesener Vorfall darf im darauffolgenden "
         f"Briefing nicht erneut erscheinen: {_hint_lines(zweites.email_plain)!r}"
     )
-    assert _heading() not in zweites.email_plain, (
+    assert not _heading_present(zweites.email_plain), (
         "AC-4: Im zweiten Briefing darf auch die Ueberschrift nicht mehr stehen."
     )
 
@@ -639,7 +750,7 @@ def test_ac6_deckelung_fuenf_zeilen_plus_und_drei_weitere(monkeypatch):
     THEN  stehen die FUENF JUENGSTEN als Zeilen da, gefolgt von einem Hinweis,
           wie viele weitere es sind.
     """
-    from output.renderers.email.undelivered_hint import MAX_UNDELIVERED_LINES
+    from output.renderers.email.undelivered_hint import MAX_LINES_PER_BLOCK
 
     uid = _uid("ac6")
     trip = _trip(f"trip-ac6-{uuid.uuid4().hex[:6]}")
@@ -648,10 +759,15 @@ def test_ac6_deckelung_fuenf_zeilen_plus_und_drei_weitere(monkeypatch):
     zeitpunkte = [jetzt - timedelta(hours=n) for n in range(1, 9)]
     _seed(uid, entity_id=trip.id, letztes_briefing=jetzt - timedelta(hours=24),
           not_delivered=[
-              _entry(entity_id=trip.id, sent_at=t, metrics=(("thunder", "max"),),
+              # #1750 E5: unterschiedliche Register-Paare (Index im
+              # Metrik-Namen), damit die acht Vorfaelle NICHT zu einer Zeile
+              # zusammengefasst werden -- E5 gruppiert nach identischem
+              # Fuenftupel, diese Deckelungs-Pruefung braucht ACHT
+              # EIGENSTAENDIGE Zeilen, keine Wiederholung.
+              _entry(entity_id=trip.id, sent_at=t, metrics=((f"thunder{i}", "max"),),
                      reason="forecast_change", channels_sent=(),
                      not_sent=(("sms", "delivery_failed"),))
-              for t in zeitpunkte
+              for i, t in enumerate(zeitpunkte)
           ])
 
     recorder = _ReportRecorder()
@@ -659,8 +775,8 @@ def test_ac6_deckelung_fuenf_zeilen_plus_und_drei_weitere(monkeypatch):
     report = _run_trip_briefing(recorder, uid, trip)
 
     zeilen = _hint_lines(report.email_plain)
-    assert MAX_UNDELIVERED_LINES == 5, (
-        f"Die Deckelung ist auf 5 Zeilen freigegeben, ist {MAX_UNDELIVERED_LINES}"
+    assert MAX_LINES_PER_BLOCK == 5, (
+        f"Die Deckelung ist auf 5 Zeilen freigegeben, ist {MAX_LINES_PER_BLOCK}"
     )
     assert len(zeilen) == 5, (
         f"AC-6: Bei acht Vorfaellen erwartet 5 Zeilen, gefunden {len(zeilen)}: "
@@ -721,7 +837,7 @@ def test_ac7_erstes_briefing_ohne_anker_zeigt_keine_altlasten(monkeypatch):
         "AC-7: Beim ersten Briefing nach der Auslieferung darf keine "
         f"Alt-Meldung erscheinen: {_hint_lines(report.email_plain)!r}"
     )
-    assert _heading() not in report.email_plain, (
+    assert not _heading_present(report.email_plain), (
         "AC-7: Auch die Ueberschrift darf nicht erscheinen."
     )
     assert last_briefing_at(user_id=uid, entity_id=trip.id, entity_type="trip") is not None, (
@@ -809,11 +925,11 @@ def test_ac9_abschnitt_erscheint_in_full_und_compact(monkeypatch):
     assert kompakt.email_html == "", (
         "Voraussetzung: das compact-Format erzeugt kein HTML"
     )
-    assert len(_hint_lines(kompakt.email_plain)) == 1, (
+    assert len(_hint_lines_ascii(kompakt.email_plain)) == 1, (
         "AC-9 (compact): Der Abschnitt MUSS auch im Kurzformat der Mail "
         f"stehen.\n--- compact ---\n{kompakt.email_plain}"
     )
-    assert _heading() in kompakt.email_plain, (
+    assert _heading_present_ascii(kompakt.email_plain), (
         "AC-9 (compact): Die Ueberschrift fehlt."
     )
     assert kompakt.email_plain.isascii(), (
@@ -945,7 +1061,7 @@ def test_ac11_ortsvergleich_zeigt_vorfall_unter_der_preset_kennung(tmp_path):
     html = _run_compare_briefing(uid, _compare_preset(uid, preset_id), tmp_path)
     text = _html_as_text(html)
 
-    assert _heading() in text, (
+    assert _heading_present(text), (
         "AC-11: Die Ortsvergleichs-Mail traegt keine Hinweis-Ueberschrift."
     )
     zeilen = _hint_lines(text)
@@ -1075,7 +1191,7 @@ def test_ac17_ortsvergleich_klartext_zeigt_den_abschnitt_ebenfalls(tmp_path, mon
         recorder, uid, _compare_preset(uid, preset_id), tmp_path,
     )
 
-    assert _heading() in text, (
+    assert _heading_present(text), (
         "AC-17: Der Klartext-Teil der Vergleichs-Mail traegt keine "
         f"Hinweis-Ueberschrift.\n--- Klartext ---\n{text}"
     )
@@ -1113,7 +1229,7 @@ def test_ac17_ortsvergleich_klartext_ohne_vorfaelle_ohne_abschnitt(tmp_path, mon
         recorder, uid, _compare_preset(uid, preset_id), tmp_path,
     )
 
-    assert _heading() not in text, (
+    assert not _heading_present(text), (
         "AC-17: Ohne fehlende Zustellung darf im Klartext-Teil keine "
         f"Ueberschrift stehen.\n--- Klartext ---\n{text}"
     )
@@ -1280,7 +1396,7 @@ def test_ac14_kaputte_protokolldatei_laesst_das_briefing_vollstaendig(monkeypatc
     assert _hint_lines(kaputt.email_plain) == [], (
         "AC-14: Bei kaputter Protokolldatei darf kein Abschnitt erscheinen."
     )
-    assert _heading() not in kaputt.email_plain
+    assert not _heading_present(kaputt.email_plain)
     assert _ohne_uhrzeiten(kaputt.email_plain) == _ohne_uhrzeiten(heil.email_plain), (
         "AC-14: Das Briefing muss bei kaputter Protokolldatei VOLLSTAENDIG "
         "rausgehen — der Klartext-Teil unterscheidet sich vom Lauf mit "
@@ -1305,7 +1421,7 @@ def test_ac14_fehlende_protokolldatei_laesst_das_briefing_vollstaendig(monkeypat
     rec = _ReportRecorder()
     rec.install(monkeypatch)
     ohne_datei = _run_trip_briefing(rec, uid, trip)
-    assert _heading() not in ohne_datei.email_plain, (
+    assert not _heading_present(ohne_datei.email_plain), (
         "AC-14: Ohne Protokolldatei darf kein Abschnitt erscheinen."
     )
 
@@ -1321,7 +1437,7 @@ def test_ac14_fehlende_protokolldatei_laesst_das_briefing_vollstaendig(monkeypat
     rec2 = _ReportRecorder()
     rec2.install(monkeypatch)
     mit_vorfall = _run_trip_briefing(rec2, uid2, trip2)
-    assert _heading() in mit_vorfall.email_plain, (
+    assert _heading_present(mit_vorfall.email_plain), (
         "AC-14 (Nicht-Leerlauf): derselbe Aufbau MIT Vorfall muss den Abschnitt "
         "sehr wohl zeigen — sonst prueft die Abwesenheits-Zusicherung nichts."
     )
@@ -1442,7 +1558,7 @@ def test_ac16_alarmversand_bleibt_kanal_und_zahlgleich(monkeypatch):
         f"AC-16: Der Alarm-Betreff hat sich geaendert: {mails_mit[0][0]!r} vs. "
         f"{mails_ohne[0][0]!r}"
     )
-    assert _heading() not in mails_mit[0][1], (
+    assert not _heading_present(mails_mit[0][1]), (
         "AC-16: Der Briefing-Hinweis darf NICHT in der Alarm-Mail auftauchen."
     )
     assert _ohne_uhrzeiten(mails_mit[0][1]) == _ohne_uhrzeiten(mails_ohne[0][1]), (
@@ -1593,4 +1709,674 @@ def test_lesefunktion_liest_nur_die_eigene_kennung(entity_type):
     )
     assert len(vorfaelle) == 1, (
         f"Gleiche Kennung, anderer Typ darf nicht mitgelesen werden: {vorfaelle!r}"
+    )
+
+
+# ════════════════════════════════════════════════════════════════════════
+# Issue #1750/#1800 -- "Briefing-Hinweis 'nicht angekommen' wird verstaendlich"
+# SPEC: docs/specs/modules/fix_1750_zustell_hinweis_klartext.md (AC-1 .. AC-18)
+# Loest feat_1461_s3b1 fuer denselben Baustein ab (EIN Block -> ZWEI,
+# ``UNDELIVERED_HEADING`` entfaellt). Praefix ``test_1750_ac<N>_...``.
+# SEITENEFFEKT (Nebenbedingung 4): ``_hint_lines()`` liest ab jetzt ueber
+# ``HEADING_FAILED``/``HEADING_WITHHELD``, die es produktiv noch NICHT gibt
+# -- jeder Bestandstest, der ``_hint_lines()`` ruft, wird dadurch SCHON JETZT
+# rot (ImportError), beabsichtigt, s. Bericht an den PO.
+# ════════════════════════════════════════════════════════════════════════
+
+
+def _neu(praefix: str):
+    """Neuer Nutzer + Trip + 'jetzt' fuer einen #1750-Testfall."""
+    uid = _uid(f"1750-{praefix}")
+    trip = _trip(f"trip-1750-{praefix}-{uuid.uuid4().hex[:6]}")
+    return uid, trip, _jetzt()
+
+
+def _render_1750(monkeypatch, uid, trip, jetzt, *, entries=(), not_delivered=(), anker_h=6):
+    """Protokoll seeden, ECHTEN Briefing-Pfad ausfuehren, Klartext liefern."""
+    _seed(uid, entity_id=trip.id, letztes_briefing=jetzt - timedelta(hours=anker_h),
+          entries=list(entries), not_delivered=list(not_delivered))
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+    return _run_trip_briefing(recorder, uid, trip).email_plain
+
+
+def _incident(trip_id, jetzt, *, vor_h=2, not_sent, trigger="forecast_change",
+              metrics=(("gust", "max"),), hazards=()):
+    return _entry(entity_id=trip_id, sent_at=jetzt - timedelta(hours=vor_h),
+                  metrics=metrics, hazards=hazards, reason=trigger,
+                  channels_sent=(), not_sent=not_sent)
+
+
+# ══════════════════════════════════ AC-1 ══════════════════════════════════
+
+
+def test_1750_ac1_beide_bloecke_erscheinen_failed_vor_withheld(monkeypatch):
+    """AC-1: delivery_failed + quiet_hours seit dem letzten Briefing -> beide
+    Ueberschriften, FEHLGESCHLAGEN vor ZURUECKGEHALTEN."""
+    from output.renderers.email.undelivered_hint import (
+        HEADING_FAILED, HEADING_WITHHELD,
+    )
+
+    uid, trip, jetzt = _neu("ac1")
+    text = _render_1750(
+        monkeypatch, uid, trip, jetzt,
+        entries=[_incident(trip.id, jetzt, vor_h=3,
+                            not_sent=(("sms", "delivery_failed"),))],
+        not_delivered=[_incident(trip.id, jetzt, trigger="nowcast",
+                                  metrics=(("precipitation", "sum"),),
+                                  not_sent=(("email", "quiet_hours"),))],
+    )
+    assert HEADING_FAILED in text and HEADING_WITHHELD in text, (
+        f"AC-1: beide Ueberschriften erwartet.\n{text}"
+    )
+    assert text.index(HEADING_FAILED) < text.index(HEADING_WITHHELD), (
+        f"AC-1: FEHLGESCHLAGEN muss vor ZURUECKGEHALTEN stehen.\n{text}"
+    )
+
+
+# ══════════════════════════════════ AC-2 ══════════════════════════════════
+
+
+def test_1750_ac2_nur_cooldown_zeigt_ausschliesslich_withheld(monkeypatch):
+    """AC-2: ausschliesslich ein cooldown-Vorfall -> nur ZURUECKGEHALTEN,
+    FEHLGESCHLAGEN kommt im Text nicht vor."""
+    from output.renderers.email.undelivered_hint import (
+        HEADING_FAILED, HEADING_WITHHELD,
+    )
+
+    uid, trip, jetzt = _neu("ac2")
+    text = _render_1750(monkeypatch, uid, trip, jetzt, not_delivered=[
+        _incident(trip.id, jetzt, not_sent=(("sms", "cooldown"),)),
+    ])
+    assert HEADING_WITHHELD in text, f"AC-2: ZURUECKGEHALTEN fehlt.\n{text}"
+    assert HEADING_FAILED not in text, f"AC-2: FEHLGESCHLAGEN darf nicht erscheinen.\n{text}"
+
+
+# ══════════════════════════════════ AC-3 ══════════════════════════════════
+
+
+def test_1750_ac3_alles_zugestellt_zeigt_keinen_der_beiden_bloecke(monkeypatch):
+    """AC-3 (Regression zu feat_1461_s3b1 AC-3): alles auf jedem
+    eingeschalteten Kanal zugestellt -> keiner der beiden Bloecke."""
+    from output.renderers.email.undelivered_hint import (
+        HEADING_FAILED, HEADING_WITHHELD,
+    )
+
+    uid, trip, jetzt = _neu("ac3")
+    text = _render_1750(monkeypatch, uid, trip, jetzt, entries=[_entry(
+        entity_id=trip.id, sent_at=jetzt - timedelta(hours=2),
+        metrics=(("gust", "max"),), reason="forecast_change",
+        channels_sent=("email", "sms", "telegram", "premium_sms"), not_sent=(),
+    )])
+    assert HEADING_FAILED not in text and HEADING_WITHHELD not in text, (
+        f"AC-3: ohne fehlende Zustellung darf kein Block erscheinen.\n{text}"
+    )
+
+
+# ══════════════════════════════════ AC-4 ══════════════════════════════════
+
+
+def test_1750_ac4_premium_sms_erscheint_als_premium_sms(monkeypatch):
+    """AC-4: Kanal ``premium_sms`` -> 'Premium-SMS' -- der rohe Wert kommt
+    als eigenstaendiges Wort nicht vor."""
+    uid, trip, jetzt = _neu("ac4")
+    text = _render_1750(monkeypatch, uid, trip, jetzt, not_delivered=[
+        _incident(trip.id, jetzt, not_sent=(("premium_sms", "cooldown"),)),
+    ])
+    assert "Premium-SMS" in text, f"AC-4: 'Premium-SMS' fehlt.\n{text}"
+    assert not re.search(r"\bpremium_sms\b", text), (
+        f"AC-4: roher Kanalname als eigenstaendiges Wort im Text: {text!r}"
+    )
+
+
+# ═══════════════════════════════ AC-5 / AC-6 ══════════════════════════════
+
+
+@pytest.mark.parametrize("reason,neu_wort,altes_wort", [
+    ("quiet_hours", "Stille Stunden", "Ruhezeit"),
+    ("cooldown", "Cooldown", "Sperrzeit"),
+])
+def test_1750_ac5_ac6_sperrgrund_uebernimmt_oberflaechen_wortlaut(
+    monkeypatch, reason, neu_wort, altes_wort,
+):
+    """AC-5/AC-6: ``quiet_hours`` -> 'Stille Stunden' (nicht 'Ruhezeit'),
+    ``cooldown`` -> 'Cooldown' (nicht 'Sperrzeit') -- die Woerter aus der
+    Oberflaeche (AlertQuietHoursCard/AlertCooldownCard), nicht die alten
+    Mail-eigenen Begriffe. Der rohe Code darf zusaetzlich nicht vorkommen."""
+    uid, trip, jetzt = _neu(f"ac56-{reason}")
+    text = _render_1750(monkeypatch, uid, trip, jetzt, not_delivered=[
+        _incident(trip.id, jetzt, not_sent=(("sms", reason),)),
+    ])
+    assert neu_wort in text, f"AC-5/6: {neu_wort!r} fehlt.\n{text}"
+    assert altes_wort not in text, (
+        f"AC-5/6: das alte Wort {altes_wort!r} darf nicht mehr vorkommen.\n{text}"
+    )
+    assert reason not in text.replace(neu_wort, ""), (
+        f"AC-5/6: der rohe Code {reason!r} darf nicht zusaetzlich vorkommen.\n{text}"
+    )
+
+
+# ══════════════════════════════════ AC-7 ══════════════════════════════════
+
+
+def test_1750_ac7_zeilenformat_vier_teile_ohne_klammern(monkeypatch):
+    """AC-7: Zeilenform ``{wann} · {worum} · {kanaele} · {grund}`` -- ohne
+    'nicht zugestellt' und ohne Klammern um den Grund."""
+    from output.renderers.email.undelivered_hint import HEADING_FAILED
+
+    uid, trip, jetzt = _neu("ac7")
+    vorfall = jetzt - timedelta(hours=2)
+    text = _render_1750(monkeypatch, uid, trip, jetzt, not_delivered=[
+        _entry(entity_id=trip.id, sent_at=vorfall, metrics=(("gust", "max"),),
+               reason="forecast_change", channels_sent=(),
+               not_sent=(("sms", "delivery_failed"),)),
+    ])
+    zeilen = _block_lines(text, HEADING_FAILED)
+    assert len(zeilen) == 1, f"AC-7: eine Zeile erwartet, gefunden {zeilen!r}"
+    teile = [t.strip() for t in zeilen[0].split("·")]
+    assert len(teile) == 4, f"AC-7: vier '·'-Teile erwartet: {zeilen[0]!r}"
+    assert _local_hhmm(vorfall) in teile[0], f"AC-7: Zeitpunkt fehlt: {teile[0]!r}"
+    assert (teile[1], teile[2], teile[3]) == ("Böen", "SMS", "Versand fehlgeschlagen"), (
+        f"AC-7: Anlass/Kanal/Grund falsch: {teile!r}"
+    )
+    assert "(" not in zeilen[0] and "nicht zugestellt" not in text, (
+        f"AC-7: keine Klammern, keine alte Formulierung erlaubt: {zeilen[0]!r}"
+    )
+
+
+# ══════════════════════════════════ AC-8 ══════════════════════════════════
+
+
+def test_1750_ac8_unbekannter_grund_landet_im_block_fehlgeschlagen(monkeypatch):
+    """AC-8: Grund-Code aus keinem der beiden Woerterbuecher -> Block
+    FEHLGESCHLAGEN, nicht ZURUECKGEHALTEN."""
+    from output.renderers.email.undelivered_hint import (
+        HEADING_FAILED, HEADING_WITHHELD,
+    )
+
+    uid, trip, jetzt = _neu("ac8")
+    text = _render_1750(monkeypatch, uid, trip, jetzt, not_delivered=[
+        _incident(trip.id, jetzt, not_sent=(("email", "unbekannter_code_x"),)),
+    ])
+    assert HEADING_FAILED in text and HEADING_WITHHELD not in text, (
+        f"AC-8: unbekannter Grund muss FEHLGESCHLAGEN zeigen, nicht "
+        f"ZURUECKGEHALTEN.\n{text}"
+    )
+    assert any("unbekannter_code_x" in z for z in _block_lines(text, HEADING_FAILED)), (
+        f"AC-8: Zeile mit dem unbekannten Grund fehlt im Block FEHLGESCHLAGEN.\n{text}"
+    )
+
+
+# ══════════════════════════════════ AC-9 ══════════════════════════════════
+
+
+def test_1750_ac9_zwoelf_gleichartige_vorfaelle_werden_zu_einer_zeile(monkeypatch):
+    """AC-9: 12 Regenradar-Vorfaelle mit identischem Register-Paar/Grund/
+    Kanaelen ueber Stunden verteilt -> EINE Zeile '(12×)' mit Zeitspanne vom
+    aeltesten bis zum juengsten Zeitpunkt."""
+    from output.renderers.email.undelivered_hint import HEADING_WITHHELD
+
+    uid, trip, jetzt = _neu("ac9")
+    zeitpunkte = [jetzt - timedelta(minutes=20 * n) for n in range(12)]
+    text = _render_1750(monkeypatch, uid, trip, jetzt, not_delivered=[
+        _entry(entity_id=trip.id, sent_at=t, metrics=(("precipitation", "sum"),),
+               reason="nowcast", channels_sent=(),
+               not_sent=(("email", "quiet_hours"), ("telegram", "quiet_hours")))
+        for t in zeitpunkte
+    ])
+    zeilen = _block_lines(text, HEADING_WITHHELD)
+    assert len(zeilen) == 1, f"AC-9: eine Zeile erwartet, gefunden {zeilen!r}\n{text}"
+    assert "(12×)" in zeilen[0], f"AC-9: Zaehler '(12×)' fehlt: {zeilen[0]!r}"
+    assert _local_hhmm(zeitpunkte[-1]) in zeilen[0] and _local_hhmm(zeitpunkte[0]) in zeilen[0], (
+        f"AC-9: Zeitspanne unvollstaendig: {zeilen[0]!r}"
+    )
+
+
+# ══════════════════════════════════ AC-10 ═════════════════════════════════
+
+
+def test_1750_ac10_unterschiedliche_gefahrenart_bleibt_getrennt(monkeypatch):
+    """AC-10 (Kern-Anti-Regression zu E5): zwei amtliche Warnungen mit
+    unterschiedlichem ``hazards``, gleichem Text 'Amtliche Warnung' -> ZWEI
+    Zeilen, keine Zusammenfassung zu '(2×)' (Gruppierung nach ``hazards``,
+    nicht nach dem angezeigten Text)."""
+    from output.renderers.email.undelivered_hint import HEADING_WITHHELD
+
+    uid, trip, jetzt = _neu("ac10")
+    text = _render_1750(monkeypatch, uid, trip, jetzt, not_delivered=[
+        _incident(trip.id, jetzt, vor_h=3, trigger="official_alert", metrics=(),
+                  hazards=("thunderstorm",),
+                  not_sent=(("sms", "below_channel_threshold"),)),
+        _incident(trip.id, jetzt, vor_h=2, trigger="official_alert", metrics=(),
+                  hazards=("flood",), not_sent=(("sms", "below_channel_threshold"),)),
+    ])
+    zeilen = _block_lines(text, HEADING_WITHHELD)
+    assert len(zeilen) == 2, (
+        f"AC-10: zwei Warnungen muessen zwei Zeilen bleiben, gefunden {zeilen!r}\n{text}"
+    )
+    assert all("Amtliche Warnung" in z for z in zeilen) and not any("×" in z for z in zeilen), (
+        f"AC-10: falscher Inhalt (Zaehler oder Text): {zeilen!r}"
+    )
+
+
+# ══════════════════════════════════ AC-11 ═════════════════════════════════
+
+
+def test_1750_ac11_zeitspanne_ueber_mitternacht_traegt_zwei_daten(monkeypatch):
+    """AC-11: Gruppe 23:50/00:15 Ortszeit -> Zeitspanne mit Datum an BEIDEN
+    Enden (``TT.MM. HH:MM–TT.MM. HH:MM``)."""
+    from output.renderers.email.undelivered_hint import HEADING_WITHHELD
+
+    tz = _trip_tz()
+    alt = datetime(2026, 6, 10, 23, 50, tzinfo=tz).astimezone(timezone.utc)
+    neu = datetime(2026, 6, 11, 0, 15, tzinfo=tz).astimezone(timezone.utc)
+    uid, trip, _ = _neu("ac11")
+    _seed(uid, entity_id=trip.id, letztes_briefing=alt - timedelta(hours=1), not_delivered=[
+        _entry(entity_id=trip.id, sent_at=t, metrics=(("precipitation", "sum"),),
+               reason="nowcast", channels_sent=(), not_sent=(("email", "quiet_hours"),))
+        for t in (alt, neu)
+    ])
+    recorder = _ReportRecorder()
+    recorder.install(monkeypatch)
+    text = _run_trip_briefing(recorder, uid, trip).email_plain
+
+    zeilen = _block_lines(text, HEADING_WITHHELD)
+    assert len(zeilen) == 1, f"AC-11 Voraussetzung: eine Zeile erwartet: {zeilen!r}\n{text}"
+    assert re.search(r"\d{2}\.\d{2}\. \d{2}:\d{2}[–-]\d{2}\.\d{2}\. \d{2}:\d{2}", zeilen[0]), (
+        f"AC-11: Zeitspanne ohne zwei Daten: {zeilen[0]!r}"
+    )
+
+
+# ══════════════════════════════════ AC-12 ═════════════════════════════════
+
+
+def test_1750_ac12_failed_deckelung_verdraengt_withheld_nicht(monkeypatch):
+    """AC-12 (reproduziert den Schaden vom 11.08.): 6 verschiedene
+    fehlgeschlagene Vorfaelle + 1 zurueckgehaltener -> FEHLGESCHLAGEN
+    gedeckelt auf 5 + 'und 1 weitere', ZURUECKGEHALTEN unverdraengt."""
+    from output.renderers.email.undelivered_hint import (
+        HEADING_FAILED, HEADING_WITHHELD,
+    )
+
+    uid, trip, jetzt = _neu("ac12")
+    metriken = [("gust", "max"), ("gust", "avg"), ("thunder", "max"),
+                ("wind", "max"), ("precipitation", "sum"), ("precipitation", "max")]
+    failed = [
+        _incident(trip.id, jetzt, vor_h=n + 1, metrics=(m,),
+                  not_sent=(("sms", "delivery_failed"),))
+        for n, m in enumerate(metriken)
+    ]
+    withheld = _incident(trip.id, jetzt, vor_h=10, metrics=(("temperature", "max"),),
+                          not_sent=(("sms", "cooldown"),))
+    text = _render_1750(monkeypatch, uid, trip, jetzt, anker_h=24,
+                         not_delivered=failed + [withheld])
+
+    failed_zeilen = _block_lines(text, HEADING_FAILED)
+    withheld_zeilen = _block_lines(text, HEADING_WITHHELD)
+    assert len(failed_zeilen) == 5 and re.search(r"und\s+1\s+weitere", text), (
+        f"AC-12: FEHLGESCHLAGEN muss 5 Zeilen + Resthinweis zeigen: {failed_zeilen!r}\n{text}"
+    )
+    assert len(withheld_zeilen) == 1, (
+        f"AC-12: ZURUECKGEHALTEN darf durch die andere Deckelung nicht "
+        f"verdraengt werden: {withheld_zeilen!r}\n{text}"
+    )
+
+
+# ══════════════════════════════════ AC-13 ═════════════════════════════════
+
+
+def test_1750_ac13_premium_sms_sperrcodes_deutsch_und_im_block_failed(monkeypatch):
+    """AC-13: ``premium_sms_no_reply_address``/``premium_sms_reply_address_
+    stale`` -> 'keine Rückadresse gelernt'/'Rückadresse veraltet' (Umlaut wie
+    in der freigegebenen AC, s. Bericht an den PO), Block FEHLGESCHLAGEN."""
+    from output.renderers.email.undelivered_hint import (
+        HEADING_FAILED, HEADING_WITHHELD,
+    )
+    from services import alert_log
+    from services.alert_briefing_anchor import record_briefing_sent
+
+    faelle = {
+        BLOCK_REASON_NO_REPLY_ADDRESS: "keine Rückadresse gelernt",
+        BLOCK_REASON_REPLY_ADDRESS_STALE: "Rückadresse veraltet",
+    }
+    for code, erwartet in faelle.items():
+        uid, trip, jetzt = _neu(f"ac13-{code[-6:]}")
+        record_briefing_sent(user_id=uid, entity_id=trip.id, entity_type="trip",
+                              at=jetzt - timedelta(hours=6))
+        alert_log.append_entry(
+            uid, entity_id=trip.id, entity_type="trip", changes_count=1,
+            severity="MODERATE", metrics=[("gust", "max")], hazards=[],
+            reason="forecast_change", effective_channels={"premium_sms"},
+            sent_channels=[], blocked_reason_codes={"premium_sms": code},
+        )
+        recorder = _ReportRecorder()
+        recorder.install(monkeypatch)
+        text = _run_trip_briefing(recorder, uid, trip).email_plain
+
+        assert erwartet in text, f"AC-13: {erwartet!r} fehlt fuer {code!r}.\n{text}"
+        failed_block = "\n".join(_block_lines(text, HEADING_FAILED))
+        withheld_block = "\n".join(_block_lines(text, HEADING_WITHHELD))
+        assert erwartet in failed_block, (
+            f"AC-13: {erwartet!r} steht nicht im Block FEHLGESCHLAGEN: {text!r}"
+        )
+        assert erwartet not in withheld_block, (
+            f"AC-13: {erwartet!r} steht faelschlich im Block ZURUECKGEHALTEN: {text!r}"
+        )
+
+
+# ══════════════════════════════════ AC-14 ═════════════════════════════════
+
+
+def test_1750_ac14_html_farbwerte_je_block_ohne_ink_faint_im_baustein():
+    """AC-14: FEHLGESCHLAGEN-Kasten traegt ``G_BOX_DANGER_BG``/``G_DANGER``,
+    ZURUECKGEHALTEN-Kasten ``G_BOX_INFO_BG``/``G_INFO``; ``G_INK_FAINT``
+    steht in keinem der beiden -- geprueft am Rueckgabewert selbst, nicht an
+    der Gesamtmail (dort 6x legitim in Gebrauch)."""
+    from output.renderers.email.design_tokens import (
+        G_BOX_DANGER_BG, G_BOX_INFO_BG, G_DANGER, G_INFO, G_INK_FAINT,
+    )
+    from output.renderers.email.undelivered_hint import (
+        HEADING_FAILED, HEADING_WITHHELD, render_undelivered_html,
+    )
+    from services.alert_log import UndeliveredIncident
+
+    tz = _trip_tz()
+    jetzt = datetime.now(timezone.utc)
+    incidents = [
+        UndeliveredIncident(at=jetzt - timedelta(hours=2), channels=("sms",),
+                             reasons=("delivery_failed",), metrics=(("gust", "max"),),
+                             hazards=(), trigger="forecast_change"),
+        UndeliveredIncident(at=jetzt - timedelta(hours=3), channels=("email",),
+                             reasons=("cooldown",), metrics=(("thunder", "max"),),
+                             hazards=(), trigger="forecast_change"),
+    ]
+    html = render_undelivered_html(incidents, tz=tz)
+
+    assert HEADING_FAILED in html and HEADING_WITHHELD in html, (
+        f"AC-14 Voraussetzung: beide Ueberschriften muessen im HTML stehen.\n{html}"
+    )
+    # Split an der Block-GRENZE (zwei aufeinanderfolgende Kasten-<div>s auf
+    # oberster Ebene), nicht an der Position des Ueberschriftstextes: die
+    # style-Attribute stehen syntaktisch VOR ihm (gueltiges HTML) -- ein
+    # Split an ``html.index(HEADING_WITHHELD)`` zerschnitte mitten im Kasten.
+    kasten_marker = '<div style="background:'
+    zweiter_kasten = html.index(kasten_marker, html.index(kasten_marker) + 1)
+    failed_teil, withheld_teil = html[:zweiter_kasten], html[zweiter_kasten:]
+    assert G_BOX_DANGER_BG in failed_teil and G_DANGER in failed_teil, (
+        f"AC-14: FEHLGESCHLAGEN-Kasten traegt nicht seine Danger-Farben.\n{failed_teil}"
+    )
+    assert G_BOX_INFO_BG in withheld_teil and G_INFO in withheld_teil, (
+        f"AC-14: ZURUECKGEHALTEN-Kasten traegt nicht seine Info-Farben.\n{withheld_teil}"
+    )
+    assert G_INK_FAINT not in html, (
+        f"AC-14: '{G_INK_FAINT}' (G_INK_FAINT) darf im Rueckgabewert nirgends "
+        f"stehen.\n{html}"
+    )
+
+
+# ══════════════════════════════════ AC-15 ═════════════════════════════════
+
+
+def test_1750_ac15_kurzfassung_ascii_zeitspanne_und_zaehler():
+    """AC-15: zusammengefasste Zeile, ``ascii_safe=True`` -> vollstaendig
+    ``str.isascii()``, Halbgeviertstrich als '-', Multiplikationszeichen des
+    Zaehlers als 'x'."""
+    from output.renderers.email.undelivered_hint import render_undelivered_plain
+    from services.alert_log import UndeliveredIncident
+
+    tz = _trip_tz()
+    aelter = datetime(2026, 6, 10, 14, 0, tzinfo=timezone.utc)
+    gemeinsam = dict(channels=("email", "telegram"), reasons=("quiet_hours",),
+                      metrics=(), hazards=(), trigger="nowcast")
+    incidents = [
+        UndeliveredIncident(at=aelter + timedelta(hours=3), **gemeinsam),
+        UndeliveredIncident(at=aelter, **gemeinsam),
+    ]
+    text = render_undelivered_plain(incidents, tz=tz, ascii_safe=True)
+
+    assert text.isascii(), f"AC-15: Kurzfassung muss reines ASCII sein: {text!r}"
+    assert "(2x)" in text, f"AC-15: Zaehler muss als '(2x)' erscheinen: {text!r}"
+    assert "×" not in text and "–" not in text, (
+        f"AC-15: weder '×' noch '–' duerfen uebrig sein: {text!r}"
+    )
+
+
+# ══════════════════════════════════ AC-16 ═════════════════════════════════
+
+
+def test_1750_ac16_alle_fuenf_renderpfade_zeigen_beide_bloecke(monkeypatch, tmp_path):
+    """AC-16: Trip HTML/Klartext(full)/Kurzfassung + Ortsvergleich HTML/
+    Klartext (``comparison.py``, bisher im Docstring fehlend) zeigen ALLE
+    FUENF beide Bloecke mit denselben Wortlauten."""
+    from output.renderers.email.undelivered_hint import (
+        HEADING_FAILED, HEADING_WITHHELD,
+    )
+
+    jetzt = _jetzt()
+
+    def _bloecke(entity_id, entity_type):
+        return {"entries": [], "not_delivered": [
+            _entry(entity_id=entity_id, entity_type=entity_type,
+                   sent_at=jetzt - timedelta(hours=3), metrics=(("gust", "max"),),
+                   reason="forecast_change", channels_sent=(),
+                   not_sent=(("premium_sms", "delivery_failed"),)),
+            _entry(entity_id=entity_id, entity_type=entity_type,
+                   sent_at=jetzt - timedelta(hours=2),
+                   metrics=(("precipitation", "sum"),), reason="nowcast",
+                   channels_sent=(), not_sent=(("sms", "quiet_hours"),)),
+        ]}
+
+    ergebnisse = {}
+    for fmt in ("full", "compact"):
+        uid = _uid(f"1750-ac16-{fmt}")
+        trip = _trip(f"trip-1750-ac16-{fmt}-{uuid.uuid4().hex[:6]}", email_format=fmt)
+        _seed(uid, entity_id=trip.id, letztes_briefing=jetzt - timedelta(hours=6),
+              **_bloecke(trip.id, "trip"))
+        recorder = _ReportRecorder()
+        recorder.install(monkeypatch)
+        ergebnisse[fmt] = _run_trip_briefing(recorder, uid, trip)
+
+    uid_cmp = _uid("1750-ac16-cmp")
+    preset_id = f"cp-1750-ac16-{uuid.uuid4().hex[:6]}"
+    _setup_compare_locations(uid_cmp)
+    _seed(uid_cmp, entity_id=preset_id, entity_type="compare",
+          letztes_briefing=jetzt - timedelta(hours=6), **_bloecke(preset_id, "compare"))
+    cmp_recorder = _CompareMailRecorder()
+    cmp_recorder.install(monkeypatch)
+    cmp_html, cmp_text = _run_compare_briefing_texts(
+        cmp_recorder, uid_cmp, _compare_preset(uid_cmp, preset_id), tmp_path,
+    )
+
+    ausgaben = {
+        "Trip HTML": (_html_as_text(ergebnisse["full"].email_html), False),
+        "Trip Klartext (full)": (ergebnisse["full"].email_plain, False),
+        "Trip Kurzfassung": (ergebnisse["compact"].email_plain, True),
+        "Ortsvergleich HTML": (_html_as_text(cmp_html), False),
+        "Ortsvergleich Klartext (comparison.py)": (cmp_text, False),
+    }
+    for name, (text, ascii_mode) in ausgaben.items():
+        if ascii_mode:
+            assert "FEHLGESCHLAGEN" in text and "ZURUeCKGEHALTEN" in text and text.isascii(), (
+                f"AC-16: {name} muss beide ASCII-Ueberschriften tragen.\n{text}"
+            )
+        else:
+            assert HEADING_FAILED in text and HEADING_WITHHELD in text, (
+                f"AC-16: {name} muss beide Bloecke tragen.\n{text}"
+            )
+        assert "Premium-SMS" in text and "Stille Stunden" in text, (
+            f"AC-16: {name} muss beide Beispiel-Wortlaute zeigen.\n{text}"
+        )
+
+
+# ══════════════════════════════════ AC-17 ═════════════════════════════════
+
+_CHANNEL_EXPECTED_LABEL = {
+    "email": "E-Mail", "telegram": "Telegram", "sms": "SMS",
+    "premium_sms": "Premium-SMS",
+}
+
+
+@pytest.mark.parametrize("channel", _SSOT_CHANNELS)
+def test_1750_ac17_jeder_ssot_kanal_hat_deutsches_label(monkeypatch, channel):
+    """AC-17 (Katalog-Waechter, parametrisiert ueber
+    ``services.alert_log._ALL_CHANNELS``): jeder SSoT-Kanal erscheint mit
+    deutschem Label, der rohe Name nicht als eigenstaendiges Wort."""
+    uid, trip, jetzt = _neu(f"ac17-{channel}")
+    text = _render_1750(monkeypatch, uid, trip, jetzt, not_delivered=[
+        _incident(trip.id, jetzt, not_sent=((channel, "delivery_failed"),)),
+    ])
+    erwartet = _CHANNEL_EXPECTED_LABEL[channel]
+    assert erwartet in text, f"AC-17: Kanal {channel!r} muss als {erwartet!r} erscheinen.\n{text}"
+    assert not re.search(rf"\b{re.escape(channel)}\b", text), (
+        f"AC-17: roher Kanalname {channel!r} als eigenstaendiges Wort im Text.\n{text}"
+    )
+
+
+# ══════════════════════════════════ AC-18 ═════════════════════════════════
+
+# Sollmenge: alle O2-Gruende (ohne REASON_CHANNEL_DISABLED und die drei
+# Ausloeser-Konstanten) PLUS die beiden Premium-SMS-Sperrcodes.
+_REASON_EXPECTATION = {
+    REASON_DELIVERY_FAILED: ("Versand fehlgeschlagen", "failed"),
+    REASON_QUIET_HOURS: ("Stille Stunden", "withheld"),
+    REASON_DAILY_LIMIT: ("Tageslimit", "withheld"),
+    REASON_COOLDOWN: ("Cooldown", "withheld"),
+    REASON_BELOW_THRESHOLD: ("unter deiner Schwelle", "withheld"),
+    BLOCK_REASON_NO_REPLY_ADDRESS: ("keine Rückadresse gelernt", "failed"),
+    BLOCK_REASON_REPLY_ADDRESS_STALE: ("Rückadresse veraltet", "failed"),
+}
+
+
+@pytest.mark.parametrize("reason", sorted(_REASON_EXPECTATION))
+def test_1750_ac18_jeder_ssot_grund_hat_label_im_richtigen_block(monkeypatch, reason):
+    """AC-18 (Katalog-Waechter, parametrisiert ueber die ``REASON_*``-
+    Konstanten aus ``services.alert_log`` sowie ``BLOCK_REASON_*`` aus
+    ``output.channels.premium_sms``): jeder SSoT-Grund erscheint deutsch UND
+    im laut E2 richtigen Block."""
+    from output.renderers.email.undelivered_hint import (
+        HEADING_FAILED, HEADING_WITHHELD,
+    )
+
+    erwartet, block = _REASON_EXPECTATION[reason]
+    kanal = "premium_sms" if reason.startswith("premium_sms_") else "sms"
+    uid, trip, jetzt = _neu(f"ac18-{reason[:16]}")
+    text = _render_1750(monkeypatch, uid, trip, jetzt, not_delivered=[
+        _incident(trip.id, jetzt, not_sent=((kanal, reason),)),
+    ])
+
+    assert erwartet in text, f"AC-18: Grund {reason!r} muss als {erwartet!r} erscheinen.\n{text}"
+    ziel = HEADING_FAILED if block == "failed" else HEADING_WITHHELD
+    andere = HEADING_WITHHELD if block == "failed" else HEADING_FAILED
+    ziel_block = "\n".join(_block_lines(text, ziel))
+    andere_block = "\n".join(_block_lines(text, andere))
+    assert erwartet in ziel_block, (
+        f"AC-18: Grund {reason!r} steht nicht im erwarteten Block ({block!r}): {text!r}"
+    )
+    assert erwartet not in andere_block, (
+        f"AC-18: Grund {reason!r} steht faelschlich auch im anderen Block: {text!r}"
+    )
+
+
+# ═══════════════════ Adversary-Findings F001 / F002 / F003 / F004 ═════════
+# docs/artifacts/fix-1750-sperrzeit-wortwahl/adversary-dialog.md: Runde 1
+# fing 12 von 14 Mutationen nicht (M9, M12); Runde 3 deckte an genau diesen
+# Tests zwei engere Nachbar-Luecken auf (Q1a -> F003, Q1b -> F004).
+
+
+def test_1750_f001_html_mehrere_vorfaelle_im_block_bleiben_eigene_elemente():
+    """F001 (M9): drei Vorfaelle im selben HTML-Block muessen drei eigene
+    ``<div>``-Elemente ergeben -- nicht bloss irgendwo als Text im Kasten
+    vorkommen. Reproduziert den am 11.08. real eingebauten Fehler (Zeilen per
+    ``join()`` ohne Tag-Trenner zusammengezogen), den alle 85 Bestandstests
+    nicht sahen, weil sie nur die Klartext-Fassung pruefen.
+
+    F003-Nachtrag (Runde 3): geprueft wird das VOLLSTAENDIGE Style-Attribut,
+    nicht nur Praefix + Elementanzahl -- jede Zeile muss ihren eigenen
+    Block-Abstand (``margin:4px 0 0 0``) tragen und darf keine
+    ``display:``/``float:``-Regel enthalten, die die Zeilen wieder optisch
+    zusammenzieht (Design-Leitprinzip: Lesbarkeit unter Zeitdruck)."""
+    from output.renderers.email.undelivered_hint import render_undelivered_html
+    from services.alert_log import UndeliveredIncident
+
+    tz = _trip_tz()
+    jetzt = datetime.now(timezone.utc)
+    gemeinsam = dict(channels=("sms",), reasons=("delivery_failed",), hazards=(),
+                      trigger="forecast_change")
+    incidents = [
+        UndeliveredIncident(at=jetzt - timedelta(hours=i), metrics=(m,), **gemeinsam)
+        for i, m in enumerate((("gust", "max"), ("thunder", "max"),
+                                ("precipitation", "sum")), start=1)
+    ]
+    html = render_undelivered_html(incidents, tz=tz)
+
+    zeilen = re.findall(r'<div style="([^"]*)">([^<]*)</div>', html)
+    stile = [stil for stil, _ in zeilen]
+    texte = [text for _, text in zeilen]
+    assert len(zeilen) == 3, (
+        f"F001: drei Vorfaelle im selben Block muessen drei eigene "
+        f"<div>-Elemente ergeben, gefunden {len(zeilen)}.\n{html}"
+    )
+    assert len(set(texte)) == 3, (
+        f"F001: die drei Elemente muessen inhaltlich unterscheidbar bleiben, "
+        f"nicht zu einem Text zusammengezogen.\n{texte}"
+    )
+    for stil in stile:
+        assert stil.startswith("margin:4px 0 0 0;"), (
+            f"F003: jede Zeile muss ihren eigenen Block-Abstand tragen.\n{stil!r}"
+        )
+        assert "display:" not in stil and "float:" not in stil, (
+            f"F003: kein Stil darf die Zeilen optisch in eine Zeile ziehen "
+            f"(display/float).\n{stil!r}"
+        )
+
+
+@pytest.mark.parametrize(
+    "reasons, ziel_name, anderer_name",
+    [
+        (("delivery_failed", "cooldown"), "FEHLGESCHLAGEN", "ZURUECKGEHALTEN"),
+        (("quiet_hours", "cooldown"), "ZURUECKGEHALTEN", "FEHLGESCHLAGEN"),
+    ],
+    ids=["f002_gemischt_failed_und_withheld", "f004_mehrere_ausschliesslich_withheld"],
+)
+def test_1750_f002_f004_vereinigungsregel_beide_richtungen(reasons, ziel_name, anderer_name):
+    """F002 (M12) + F004 (Q1b), eine Zusicherung in beide Richtungen: Fall 1
+    -- mindestens EIN ``failed``-Grund (real erzeugbar ueber verschiedene
+    Kanaele EINES Alarm-Laufs bzw. die ``DEDUP_WINDOW``-Vereinigung in
+    ``alert_log.read_undelivered()``) -> der GANZE Vorfall zaehlt als
+    ``failed``, nie 'nur halb ein Fehler'. Fall 2 -- AUSSCHLIESSLICH
+    ``withheld``-Gruende, auch MEHRERE verschiedene (z.B. Stille Stunden UND
+    Cooldown auf unterschiedlichen Kanaelen desselben Vorfalls, ebenso real)
+    -> muss VOLLSTAENDIG im Block ZURUECKGEHALTEN bleiben. Eine 'mehr als ein
+    Grund => failed'-Mutation waere im Einzelgrund-Fall (AC-2) unsichtbar, da
+    ``any()``/laengenbasierte Heuristiken bei genau einem Element
+    uebereinstimmen -- erst der Mehrgrund-Fall trennt sie (Spec
+    'Blockaufteilung + Reihenfolge')."""
+    from output.renderers.email.undelivered_hint import (
+        HEADING_FAILED, HEADING_WITHHELD, render_undelivered_plain,
+    )
+    from services.alert_log import UndeliveredIncident
+
+    tz = _trip_tz()
+    jetzt = datetime.now(timezone.utc)
+    incidents = [
+        UndeliveredIncident(
+            at=jetzt - timedelta(hours=1), channels=("email", "sms"),
+            reasons=reasons, metrics=(("gust", "max"),),
+            hazards=(), trigger="forecast_change",
+        ),
+    ]
+    text = render_undelivered_plain(incidents, tz=tz)
+
+    headings = {"FEHLGESCHLAGEN": HEADING_FAILED, "ZURUECKGEHALTEN": HEADING_WITHHELD}
+    ziel, anderer = headings[ziel_name], headings[anderer_name]
+
+    assert ziel in text, (
+        f"Vorfall mit reasons={reasons!r} muss im Block {ziel_name} stehen.\n{text}"
+    )
+    assert anderer not in text, (
+        f"Vorfall mit reasons={reasons!r} darf NICHT im Block {anderer_name} "
+        f"erscheinen (Vereinigungsregel).\n{text}"
+    )
+    assert len(_block_lines(text, ziel)) == 1, (
+        f"Genau eine Zeile im Block {ziel_name} erwartet.\n{text}"
     )


### PR DESCRIPTION
Behebt #1750 und den offenen Anzeige-Teil von #1800.

## Problem

Der Briefing-Abschnitt „NICHT BEI DIR ANGEKOMMEN" war für den Nutzer nicht deutbar:

- `premium_sms` erschien als technischer Rohname (verletzt AC-5 aus `feat_1461_s3b2a`: „deutscher Grund, kein interner Bezeichner")
- „Ruhezeit"/„Sperrzeit" entsprachen **keiner** Beschriftung in der Oberfläche — dort heißen dieselben Einstellungen „Stille Stunden" und „Cooldown"
- „nicht zugestellt" behauptete pauschal einen Fehler, obwohl vier von sechs Gründen planmäßige, vom Nutzer selbst eingestellte Unterdrückungen sind

**Gemessener Schaden am Produktivkonto:** Am 11.08. lagen neun Vorfälle im Briefing-Fenster; angezeigt wurden die fünf jüngsten. Herausgefallen sind dabei **zwei amtliche Warnungen** (10:15 und 16:30 Ortszeit) hinter Regenradar-Zeilen. Die häufige, belanglose Sorte verdrängte die seltene, wichtige.

Strukturelle Ursache: `quiet_hours`/`cooldown`/`daily_limit` werden nur an zwei Stellen überhaupt protokolliert — beide Radar (`trip_alert.py:1026`, `compare_radar_alert.py:162`). Die Liste kann deshalb praktisch nichts anderes enthalten.

## Lösung

```
FEHLGESCHLAGEN — da ist etwas schiefgegangen
  11.08. 06:10 · Böen · Premium-SMS · keine Rückadresse gelernt

ZURÜCKGEHALTEN — so hast du es eingestellt
  11.08. 17:45 · Amtliche Warnung · SMS · unter deiner Schwelle
  11.08. 16:30 · Amtliche Warnung · SMS · unter deiner Schwelle
  11.08. 04:00–05:17 · Regenradar (12×) · E-Mail, Telegram · Stille Stunden
```

- Zwei eigenständige Blöcke, jeder nur bei Vorfällen. `UNDELIVERED_HEADING` entfällt ersatzlos.
- Gründe heißen wie die Einstellungen in der Oberfläche; `premium_sms` → „Premium-SMS" (ADR-0049).
- Deckelung **je Block** statt über die Gesamtliste — löst AC-6 aus `feat_1461_s3b1` ab (PO-Freigabe 2026-08-15), damit ein echter Fehler nie von planmäßigen Unterdrückungen verdrängt wird.
- Wiederholungen zu einer Zeile zusammengefasst; gruppiert wird über die **zugrundeliegenden Werte**, nicht über den Anzeigetext — zwei amtliche Warnungen verschiedener Gefahrenart bleiben getrennt.

## Nachweis

- **129 Tests grün** (drei Testdateien + Renderer-Gate `test_issue_811_mode_matrix.py`)
- **Adversary VERIFIED** nach vier Runden: 16 Mutationen, 16 gefangen. Produktivcode über alle Runden byte-identisch (`md5 bec12ef1`) — alle Nachbesserungen betrafen Tests, nicht Code. F001–F004 geschlossen, F005 (LOW) gebucht in #1199.
- **Zwei Katalog-Wächter** schließen die Fehlerklasse: jeder Kanal aus `alert_log._ALL_CHANNELS` und jeder Grund-Code braucht ein deutsches Label und eine Blockzuordnung — geprüft am erzeugten Mailtext, nicht am Wörterbuch. Vorher ließen sich „Ruhezeit" und „Sperrzeit" wortlos ändern, ohne dass ein Test rot wurde.
- **Volllauf** ohne neue Rote. Vier Fehlschläge per A/B gegen den unveränderten Renderer als vorbestehend belegt (Umgebung, Zeitfenster-Familie, Netzzugriff).
- Briefing-Mail-Validator bestanden.

## Zuschnitt

Eine Produktivdatei (`src/output/renderers/email/undelivered_hint.py`, +192/−50, Grenze 250). Keine Änderung an `alert_log.py`, `alert_gate.py`, Frontend oder Go. Die Protokoll-Lücke O3 (Wetteränderungs- und Amtliche-Warnung-Pfad protokollieren Unterdrückungen gar nicht) ist ausdrücklich **nicht** Teil dieser Scheibe.

Spec: `docs/specs/modules/fix_1750_zustell_hinweis_klartext.md` (v1.0a, 18 ACs, PO-freigegeben)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kiKur8ctBrDKtBAxHBWTk