### PR TITLE
feat(#1856 E7): Waechter gegen neue Metrik-Listen — die Ratsche aus dem Epic-Zielbild

### DIFF
--- a/docs/context/fix-1856-e7-listen-waechter.md
+++ b/docs/context/fix-1856-e7-listen-waechter.md
@@ -1,0 +1,244 @@
+# Context: #1856 — #1435 E7: Wächter gegen neue Metrik-Listen
+
+**Workflow:** `fix-1856-e7-listen-waechter` · **Track:** Full Process (Score 5) · **Basis:** `origin/main` = `ad1e6a87`
+**Erstellt:** 2026-08-15 · **Termin (PO):** E7 und E6 bis 20.08., E7 zuerst
+
+## Request Summary
+
+Die im Epic #1435 seit 31.07. zugesagte Ratsche bauen: jede Liste, die etwas je Wettergröße
+festlegt, muss mit der Register-Kennung geschlüsselt sein, und ein Wächter meldet jede Kennung,
+die das Register nicht kennt — beim Namen. E7 macht Abweichungen **sichtbar und fest**; die
+Abweichungen selbst behebt E6.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/app/metric_catalog.py:675` | `SMS_SYMBOL_BY_METRIC` — 1:1-Abbildung, wird **zusätzlich für Schwellwerte** gelesen (#624) |
+| `src/app/metric_catalog.py:710` | `SMS_MULTI_SYMBOLS_BY_METRIC` — die ungeprüfte Liste aus AC-1. **Liegt im Register-Modul selbst**, nicht in `sms_trip.py` wie im Issue behauptet |
+| `src/app/metric_catalog.py:~665` | `SMS_SYMBOL_GRAMMAR` — dritte Kürzel-Tabelle (`TH:`, `NS24+`, `WD:`, `PT:`) |
+| `src/app/metric_catalog.py` | `COMPACT_LABEL_EXCEPTIONS` — **Vorbild für AC-5**: Ausnahmeliste, Wert = Begründungssatz, Wächter besteht auf lesbarer Begründung |
+| `src/app/metric_catalog.py` | `_kurzform_kuerzel()` — die bereits existierende zentrale Auflösung „welches Kürzel benennt diese Größe" |
+| `tests/unit/test_sms_token_symbol_register_ratchet.py` | **415 Zeilen**, E3b-Ratsche. Vier Prüfstellen, `EXEMPT_FORECAST_FIELDS` + `EXEMPT_METRIC_IDS`. Muss nach AC-7 **erweitert, nicht ersetzt** werden |
+| `tests/unit/test_telegram_kuerzel_folgt_register.py` | **460 Zeilen**, #1719 S4. Direktes Vorbild — und Quelle des Zielkonflikts unten |
+| `api/routers/config.py:44-57` | `/api/sms-symbols` — löst beide Tabellen auf, Mehrfach hat Vorrang. Deckt die Frontend-Listen ab |
+| `tests/tdd/test_repo_path_hardcoding_ratchet.py` | Vorbild für AST-Auflösung im Wächterbau (#1409) |
+
+## Existing Patterns
+
+- **Bauprinzipien der E3b-Ratsche** (im Docstring, aus zwei grünen Wächtern entstanden, die nie
+  etwas prüften): kein Regex über Quelltext · keine handgepflegte Symbolliste · **Nichtstun ist
+  kein Bestehen** (Trefferzahl `> 0` behaupten) · Prüfling aus **diesem** Arbeitsbaum (#1409).
+  AC-3 und AC-4 schreiben genau diese Prinzipien fort.
+- **Ausnahmeliste mit Pflicht-Begründung**: `COMPACT_LABEL_EXCEPTIONS` — Schlüssel = Kennung,
+  Wert = Begründungssatz; ein Eintrag ohne Satz ist keine Ausnahme. Muster aus `gz-eigenstaendig`
+  (#1481 B) und `gz-main-path` (#1409).
+- **Schlüssel ist das Datenfeld, nicht das Symbol** (E3b, `EXEMPT_FORECAST_FIELDS`): so kann eine
+  Umbenennung des Symbols die Ausnahme nicht versehentlich mitschleppen.
+
+## Dependencies
+
+- **Upstream:** `app.metric_catalog.get_all_metrics()` / `get_sms_code()` — 28 Register-Einträge.
+- **Downstream:** Der Wächter läuft im CI-Ampel-Job `test`. Zu scharf ⇒ blockiert jeden Commit;
+  zu lasch ⇒ folgenlos. Kein Produktivcode wird geändert (das ist E6).
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1435_e3b_sms_kuerzel.md` — AC-9 ist die bestehende Ratsche (AC-7-Bezug)
+- `docs/specs/modules/fix_1719_s4_kuerzel_vereinheitlichung.md` — siehe Zielkonflikt
+- `docs/adr/` — ADR-0011 trägt den E3b-Nachtrag
+
+## Risks & Considerations
+
+### R1 — Zielkonflikt: die im Issue gemeldeten „Widersprüche" sind teils **entschieden**
+
+`test_telegram_kuerzel_folgt_register.py` hält wörtlich fest:
+
+> Das Soll-Kürzel ist das, was die Trip-SMS **tatsächlich sendet** — nicht `sms_code` allein: bei
+> `temperature_night` führt das Register `TN`, gesendet wird aber `N` … Genau diese zwei Fälle
+> sind der Kern des gemeldeten Defekts, sie dürfen also **nicht wegdefiniert werden**.
+
+Die Mehrfach-Kürzel tragen im Code je eine ausdrückliche PO-Entscheidung: `WC` (#1450),
+`TH+:` (#1482), `N`→`temperature_night` (#1484), `FN`→`wind_chill_night` (#1660). Die Semantik
+lautet laut `_kurzform_kuerzel()`: **das erste Kürzel benennt die Größe, die weiteren benennen
+Auswertungen** (Tagestiefst/-höchst). „Drei Kürzel für eine Metrik" ist also nicht per se Abdrift.
+
+⇒ Der Wächter darf nicht blind „Register ≠ gesendet" melden, sonst ist er entweder unpassierbar
+oder seine Ausnahmeliste besteht aus allem. Die Spec muss **trennen**: was ist entschiedene
+Mehrfach-Zuordnung (→ AC-5-Ausnahme mit Ticket-Bezug), was echte Abdrift (→ E6). Genau diese
+Trennung ist der Wert, den E7 für E6 liefert.
+
+### R2 — AC-2 ist die eigentliche Schwierigkeit und hat im Repo zwei einschlägige Fehlschläge
+
+Die Umkehrfrage („welche Liste legt etwas je Wettergröße fest, ohne das Register zu fragen?")
+verlangt einen Scan über unbekannte Strukturen. Zwei belegte Muster im Projekt:
+
+- **#1667 S1:** Ein AST-Wächter, der erlaubte Schreibweisen **aufzählt**, wurde dreimal trivial
+  umgangen (Zwischenvariable, Liste, Tupel). Behoben war die demonstrierte *Form*, nicht die
+  *Klasse*. Was funktionierte: Aufzählung entfernen, stattdessen die Elternkette fragen.
+- **Prüfskript-Falle:** Wer eine Struktur nicht versteht, darf **nicht Entwarnung geben**.
+  „Ich finde nichts" ≠ „es gibt nichts". Plausibilitätsprüfung der Struktur **vor** der Auswertung.
+
+Dazu die Gegenkraft aus #1667: **Falsch-Positive sind schlimmer als eine Restlücke** — ein
+Wächter, der harmlose Listen meldet, wird abgeschaltet.
+
+### R3 — Der Katalog-Wächter-Blindfleck (#1703 S1, F001)
+
+Liest der Wächter sein Soll aus derselben Quelle wie der Prüfling, kann er Fehler **in** dieser
+Quelle prinzipiell nicht sehen. **Soll-Menge** („welche Metriken gibt es?") darf gerechnet werden;
+**Soll-Zuordnung** („welches Kürzel gehört zu welcher Metrik?") braucht getippte Werte, sonst ist
+sie eine Tautologie. Für AC-6 (Mutationsprobe je Liste) ist das die entscheidende Unterscheidung.
+
+### R4 — Umfang der Klasse
+
+Grobe Stichprobe (10 von 28 Kennungen, nur Zeilenanfang-Muster) findet bereits **12 Backend-Dateien**
+mit Metrik-Kennungen als dict-Schlüssel — u.a. `channel_layout.py`, `email/helpers.py`,
+`metric_format.py`, `hazard_symbols.py`, `official_alerts.py`, `compare_hourly_metric_ids.py`.
+Das Epic nennt ~60 handgepflegte Listen. Die vollständige Auszählung ist Aufgabe von Phase 2.
+
+### R5b — Die Analyse-Agenten haben nicht getragen
+
+Von vier Agenten (drei Explore/Haiku, ein Plan/Sonnet) hat **einer** berichtet, und der in der
+Kernfrage falsch: Er meldete „KEINE Dateien gefunden" und „Single Source of Truth: AKTIV, kein
+Drift-Risiko erkannt" — die Gegenmessung ergab **vier** Dateien mit eigenen Metrik-Listen ohne
+Register-Import. Sämtliche belastbaren Zahlen dieser Analyse stammen aus eigener Messung.
+Konsequenz für Phase 6: Der Adversary-Lauf muss die Zahlen selbst nachrechnen, nicht übernehmen.
+
+### R5 — LoC-Budget
+
+Vergleichsmaß: E3b-Ratsche 415 Zeilen, Telegram-Wächter 460 Zeilen. Das getrennte Test-Budget
+(500) dürfte reichen, das Produktiv-Budget (250) wird kaum berührt — E7 ändert keinen
+Produktivcode. Ausnahmelisten könnten im Katalog-Modul landen (dann Produktiv-LoC).
+
+---
+
+# Analysis (Phase 2, 2026-08-15)
+
+## Type
+
+**Feature** (Wächterbau). Label am Ticket ist `bug`, aber die Fehlerklasse ist bereits diagnostiziert;
+gebaut wird die im Epic zugesagte Ratsche. Kein Produktivcode-Fix — der ist E6.
+
+## Befund 1 — eine Prämisse des Tickets ist am Code widerlegt
+
+#1856 behauptet, `TF` und `TN` erschienen „in **keiner** Nachricht". Gemessen:
+
+| Ausgabeweg | Quelle des Kürzels | `wind_chill` | Beleg |
+|---|---|---|---|
+| Trip-SMS | `SMS_MULTI_SYMBOLS_BY_METRIC` | `FK` `FD` `WC` | `sms_trip.py` |
+| **Vergleichs-SMS** | **`get_sms_code()`** | **`TF`** | `comparison.py:647`, Docstring: „AUSSCHLIESSLICH aus dem zentralen Katalog" |
+| **Alarm-SMS** | **`get_sms_code()`** | **`TF`** | `alert/render.py:93` |
+
+`TF` und `TN` sind also **live** — in zwei von drei SMS-Wegen. Bestätigt durch die Tabelle in
+`docs/specs/modules/fix_1719_s4_kuerzel_vereinheitlichung.md` Zeile 70.
+
+**Es liegen nicht drei widersprüchliche Kürzel für eine Metrik vor, sondern zwei Ausgabewege
+nebeneinander** — im Epic-Zielbild genau die Unterscheidung „Eigenschaft der Größe" (Register)
+gegen „Vorliebe einer Ausgabe" (lokal). Die Messung im Ticket sah nur den Trip-Weg.
+
+⇒ **AC-1 muss umformuliert werden.** In der Ticket-Lesart („meldet jede Abweichung, schlägt heute
+für `temperature`, `wind_chill`, `temperature_night` an") meldet der Wächter drei **korrekte**
+Zustände als Fehler; AC-5 nähme sie alle in die Ausnahmeliste auf, und AC-1 bewachte nichts.
+Vorschlag zur Freigabe → siehe „Offene Fragen".
+
+## Befund 2 — der erste Fang, noch vor dem Wächter
+
+`src/output/renderers/channel_layout.py:60`, `METRIC_PRIORITY` (25 Einträge, entscheidet, welche
+fünf Größen bei knappem Platz in den `primary`-Bucket kommen): **`temperature_night` und
+`wind_chill_night` fehlen.** Beide seit #1484/#1660 eigenständig wählbar. Zeile 131 liest
+`METRIC_PRIORITY.get(metric, 0)` ⇒ Priorität 0, hinter `cloud_high` (10) und `confidence` (8).
+Die Datei importiert **nichts** aus `metric_catalog`.
+
+Das ist der Fang-Beleg, den das Regel-Budget bei Einführung verlangt.
+
+## Befund 3 — die Kandidatenmenge, beide Richtungen gemessen
+
+AST-Scan über `src/` + `api/`, 843 dict-Literale, **0 nicht auflösbar**:
+
+| Richtung | Rohtreffer | davon Quote 100 % | Bedeutung |
+|---|---|---|---|
+| Register-Kennung als **Schlüssel** | 23 | **12** | Eigenschaft/Vorliebe je Größe |
+| Register-Kennung als **Wert** | 65 | **6** | Übersetzung **ins** Register |
+
+Die 100-%-Schwelle trennt in beiden Richtungen sauber: Auf der Werteseite bleiben genau die sechs
+echten Übersetzungstabellen (`FRONTEND_TO_HOURLY_METRIC_ID`, `_SUMMARY_KEY_TO_CATALOG_ID`,
+`RENDERER_TO_TRIP_METRIC_ID`, `_COL_KEY_TO_METRIC_ID`, `_FALLBACK_COL_KEY_TO_METRIC_ID`,
+`_AMPEL_KEY_TO_METRIC_ID`); die übrigen 59 sind Rauschen aus Datensatz-Literalen
+(`{"id": "snow_depth", "field": "snow_depth_cm", …}`). `FRONTEND_TO_RENDERER_METRIC_ID` (3/26)
+fällt korrekt heraus — es übersetzt Frontend→Renderer, nicht ins Register.
+
+**Falsch-Positiv-Prüfstein:** `HAZARD_SMS_SYMBOLS` (`output/tokens/hazard_symbols.py:15`, 10 Schlüssel
+`rain`, `snow`, `thunderstorm`, `wind_gust`, …) ist das Vokabular der amtlichen Warnungen und sieht
+strukturell aus wie eine Metrik-Liste. Quote gegen das Register: **0/10** ⇒ die Regel lässt sie
+korrekt in Ruhe.
+
+## Befund 4 — die Trennregel allein reicht nicht (Umgehungsprobe)
+
+Gemessen, welche Register-Listen in **anderen Formen als dict-Literalen** existieren:
+
+| Form | Anzahl | Beispiel |
+|---|---|---|
+| `set` (nur Register-Kennungen) | 7 | `email/helpers.py:1336` (7 Kennungen) |
+| `list` | 10 | `metric_catalog.py:925` (14 Kennungen) |
+| `tuple` | 10 | `metric_catalog.py:620` (14 Kennungen) |
+| `if metric_id == "…"`-Ketten | 32 | `email/helpers.py:735` |
+| dict-Comprehension | 93 | `loader.py:658` |
+
+Ein Wächter, der nur `ast.Dict` prüft, sieht **keine** davon. Das ist die #1667-Falle in Reinform:
+eine Form aufzählen, alles andere entkommt — und diese Formen sind real belegt, nicht theoretisch.
+
+**Bewertung:** Die vier Sammlungs-Literale (dict/set/list/tuple) sind eine **geschlossene** Menge —
+sie aufzuzählen ist etwas anderes als das Aufzählen von Schreibweisen in #1667. Compare-Ketten und
+Comprehensions sind dagegen eine offene Klasse und gehören als benannte Known Limitation in die Spec,
+nicht in eine Behauptung von Vollständigkeit.
+
+## Befund 5 — die Weichenstellung, an der man sich verrechnet
+
+`_METRICS` hat **28** Einträge, `get_all_metrics()` nur **25** — der Filter entfernt
+`selectable=False`: `cape`, `confidence`, `temperature_cold`. Wer gegen die wählbare Menge prüft,
+meldet diese drei fälschlich als „Kennung, die das Register nicht kennt". (Mir selbst im ersten
+Anlauf passiert.) Der Wächter muss gegen `_METRICS` prüfen.
+
+Verwandt: das `selectable=False`-Kollateralschaden-Muster.
+
+## Scope Assessment
+
+| | |
+|---|---|
+| Dateien | 1 neu (`tests/unit/test_metrik_listen_register_ratchet.py`), 1 geändert (E3b-Ratsche, AC-1/AC-7), ggf. Ausnahmeliste |
+| LoC | ~350–450 **Test**-Budget (Vergleich: E3b 415 Z., Telegram-Wächter 460 Z.); Produktiv nur, falls die Ausnahmeliste in `metric_catalog.py` liegt |
+| Risiko | **MEDIUM–HIGH** |
+
+**Risikobegründung:** Die CI-Ampel ruft `uv run pytest` **ohne Pfadangabe** auf
+(`.github/workflows/ci.yml:58`, nur `--ignore=tests/red/` + tdd-Ausschlüsse). Ein neuer Wächter unter
+`tests/unit/` läuft ab Merge automatisch mit und blockiert bei Rot **jeden** PR, auch die anderer
+Sessions. Er muss am Tag der Einführung grün sein ⇒ jeder heutige Fund gehört in die AC-5-Liste,
+einschließlich der beiden fehlenden Größen aus Befund 2.
+
+## Technical Approach (Empfehlung)
+
+1. **Erkennung ohne Namensmuster und ohne Positivliste:** Eine Sammlung gilt als Register-Liste, wenn
+   **alle** ihre konstanten String-Elemente (dict-Schlüssel, dict-Werte, set/list/tuple-Elemente)
+   Register-Kennungen sind und es mindestens zwei sind. Keine Namensheuristik (`_X_TO_Y`), kein
+   Verzeichnis-Filter — beides wäre umgehbar und würde die Klasse verfehlen.
+2. **Geprüft wird Gültigkeit, nicht Zuordnung** (AC-4): Jede Kennung existiert in `_METRICS`.
+   Das ist auf alle Formen anwendbar und fängt Tippfehler und gelöschte Metriken.
+3. **Vollständigkeit** nur dort, wo sie fachlich gilt — für `METRIC_PRIORITY` heißt das: jede
+   **wählbare** Größe hat einen Eintrag. Das ist die Prüfung, die Befund 2 fängt.
+4. **AC-1 als Existenz- und Eindeutigkeitsprüfung** statt als Gleichheitsprüfung (siehe Offene Fragen).
+5. **Ausnahmeliste nach dem Muster `COMPACT_LABEL_EXCEPTIONS`**: Schlüssel = Fundstelle, Wert =
+   Begründungssatz mit Ticket-Bezug; ein Eintrag ohne Satz ist keine Ausnahme. Darf nur schrumpfen
+   (eigener Test).
+6. **Bauprinzipien der E3b-Ratsche übernehmen**: echter Import statt Regex · Trefferzahl behaupten
+   (`> 0`) · Prüfling aus **diesem** Arbeitsbaum (#1409).
+
+## Open Questions (PO-Freigabe nötig)
+
+- [ ] **AC-1:** Die Ticket-Lesart („Abweichung Register ↔ gesendet melden") würde drei entschiedene
+      Zustände als Fehler melden. Vorschlag: AC-1 prüft stattdessen (a) jede Kennung in
+      `SMS_MULTI_SYMBOLS_BY_METRIC` existiert im Register, (b) kein Kürzel ist zweimal vergeben,
+      (c) jede Größe mit Kürzel im einen Weg hat auch eines im anderen. Einverstanden?
+- [ ] **Umfang von AC-2:** Sammlungs-Literale (dict/set/list/tuple) werden bewacht;
+      `if`-Ketten und Comprehensions als Known Limitation benannt. Oder soll E7 größer werden?
+- [ ] **Befund 2** (`METRIC_PRIORITY`): in die AC-5-Ausnahmeliste mit E6-Bezug — oder ist das
+      nutzersichtbar genug für einen sofortigen Fix in E7?

--- a/docs/specs/modules/fix_1856_e7_metrik_listen_waechter.md
+++ b/docs/specs/modules/fix_1856_e7_metrik_listen_waechter.md
@@ -1,0 +1,567 @@
+---
+entity_id: fix_1856_e7_metrik_listen_waechter
+type: bugfix
+created: 2026-08-15
+updated: 2026-08-15
+status: draft
+version: "1.0"
+tags: [metric-catalog, ratchet, ast-guard, test-only, register]
+workflow: fix-1856-e7-listen-waechter
+---
+
+# Fix #1435 Etappe E7 — Wächter gegen neue Metrik-Listen
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Das Epic #1435 hat seit dem 31.07. ein Zielbild formuliert, aber nie gebaut:
+„Keine Liste darf ein eigenes Vokabular erfinden. Jede Liste, die etwas je
+Wettergröße festlegt, wird mit der Register-Kennung geschlüsselt, und ein
+Wächter meldet jede Kennung, die das Register nicht kennt — beim Namen."
+Anlass war die PO-Frage, wofür `WC` bei den Wettermetriken steht — weder
+Oberfläche noch Register geben Auskunft, weil eine Liste (die
+Mehrfach-Kürzel-Tabelle `SMS_MULTI_SYMBOLS_BY_METRIC`) am bestehenden
+Wächter aus E3b vorbeiläuft. E7 baut diese Ratsche. **Sie behebt nichts** —
+gefundene Abweichungen werden mit E6 behoben, direkt im Anschluss.
+
+## Hintergrund: die drei bekannten Kürzel-Abweichungen (Dokumentation, keine Prüfung)
+
+Die PO-Frage „wofür steht `WC`?" führte zu drei gemessenen Abweichungen
+zwischen dem, was die Trip-SMS tatsächlich sendet, und dem Register-Kürzel
+(`get_sms_code()`): `temperature` sendet `K`/`D` statt `D` (PO-Entscheid
+#1415), `wind_chill` sendet `FK`/`FD`/`WC` statt `TF` (#1415/#1450),
+`temperature_night` sendet `N` statt `TN` (#1484). Alle drei sind
+**getroffene Entscheidungen**, keine Fehler — Grund ist, dass zwei
+Ausgabewege nebeneinander existieren: Trip-SMS liest
+`SMS_MULTI_SYMBOLS_BY_METRIC`/`SMS_SYMBOL_BY_METRIC`, Vergleichs-SMS
+(`comparison.py:647`) und Alarm-SMS (`alert/render.py:93`) lesen
+`get_sms_code()` direkt. `TF`/`TN` erscheinen entgegen einer früheren
+Ticket-Behauptung **nicht** in „keiner Nachricht" — sie sind live in zwei
+von drei SMS-Wegen.
+
+**Diese drei Fakten stehen hier zur Einordnung, nicht als Ergebnis einer
+automatisierten Prüfung.** Ein Wächter, der die beiden Ausgabewege direkt
+gegeneinander vergleicht („Parität"), wurde erwogen und verworfen (s.
+„Verworfene Alternativen") — er wäre fast tautologisch gewesen. AC-1 prüft
+stattdessen zwei andere, tatsächlich scharfe Eigenschaften (s. u.).
+
+## Source
+
+> **Schicht-Hinweis:** ausschließlich Testschicht (`tests/unit/`), keine
+> Produktivcode-Änderung. Der neue Wächter liest `src/app/metric_catalog.py`
+> als Soll-Quelle und scannt `src/` + `api/` als Prüfmenge, ändert daran aber
+> nichts.
+
+- **File:** `tests/unit/test_sms_token_symbol_register_ratchet.py` (Erweiterung, nicht Ersetzung — s. AC-7)
+- **File (neu):** `tests/unit/test_metrik_listen_register_ratchet.py`
+- **Identifier (Soll-Quelle, gelesen):** `app.metric_catalog._METRICS`, `get_all_metrics()`, `get_sms_code()`, `SMS_MULTI_SYMBOLS_BY_METRIC`, `SMS_SYMBOL_BY_METRIC`, `_kurzform_kuerzel()`
+
+## Estimated Scope
+
+- **LoC:** ~380–480 **Test**-Budget (Vergleichsmaß: E3b-Ratsche 415 Zeilen,
+  Telegram-Wächter 460 Zeilen). Passt ins getrennte Test-Budget (500) ohne
+  Override-Anfrage. **0 Zeilen Produktivcode** — Registrierung und
+  Ausnahmelisten liegen im Testfile, wie bereits `EXEMPT_FORECAST_FIELDS`/
+  `EXEMPT_METRIC_IDS` in der bestehenden Ratsche.
+- **Files:** 1 neue Testdatei, 1 bestehende Testdatei erweitert, 0
+  Produktivdateien geändert.
+- **Effort:** medium — die Erkennungslogik (AC-2) ist der eigentliche
+  Aufwand; sie muss eine geschlossene Klasse (vier Sammlungsformen) robust
+  behandeln, ohne bei jeder heute schon vorhandenen, harmlosen Liste
+  Fehlalarm zu geben (Falsch-Positiv-Prüfstein `HAZARD_SMS_SYMBOLS`, s. u.).
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `app.metric_catalog._METRICS` (28 Einträge) | READ (Soll-Menge) | **Nicht** `get_all_metrics()` (25) — der Filter entfernt `selectable=False` (`cape`, `confidence`, `temperature_cold`), die sonst fälschlich als „unbekannte Kennung" gemeldet würden |
+| `app.metric_catalog.get_all_metrics()` (25 Einträge) | READ (Soll-Menge für Vollständigkeit) | Nur für den opt-in Vollständigkeits-Check (s. AC-4) — dort geht es um „jede *wählbare* Größe", nicht um jede Registereinheit |
+| `app.metric_catalog.get_sms_code()`, `_kurzform_kuerzel()` | READ | Soll-Kürzel je Metrik; `_kurzform_kuerzel()` ist die bereits produktiv genutzte Auflösung „welches Kürzel benennt die Größe" (auch von `/api/sms-symbols` verwendet) — AC-1 nutzt sie, statt sie ein zweites Mal im Test nachzubauen |
+| `app.metric_catalog.SMS_MULTI_SYMBOLS_BY_METRIC` | READ (Prüfling AC-1) | Die ungeprüfte Liste, die den Anlassfall auslöste |
+| `output.renderers.channel_layout.METRIC_PRIORITY` (Zeile 60) | READ (Beispiel-Registrierung, Befund 2) | Fehlen `temperature_night`/`wind_chill_night` — der Fang-Beleg dieser Etappe (s. Regel-Budget) |
+| `output.tokens.hazard_symbols.HAZARD_SMS_SYMBOLS` (Zeile 15) | READ (Falsch-Positiv-Prüfstein) | Vokabular amtlicher Warnungen, sieht strukturell wie eine Metrik-Liste aus, Quote gegen das Register 0/10 — muss unauffällig bleiben |
+| `ast` (Python-Standardbibliothek) | intern | Erkennung über echten Syntaxbaum statt Regex — Bauprinzip aus E3b/#1409 |
+| `tests/unit/test_sms_token_symbol_register_ratchet.py` | ERWEITERT | bekommt eine fünfte Prüfstelle (AC-1); die vier bestehenden bleiben unverändert (AC-7) |
+
+## Implementation Details
+
+### Zwei Stufen, unabhängig voneinander
+
+Die beiden Fragen dürfen nicht aneinanderhängen — sonst senkt ein einzelner
+Tippfehler die berechnete Quote einer Liste unter die Erkennungsschwelle,
+die Liste fällt aus der Prüfmenge, und der Wächter schweigt genau dort, wo
+er reden sollte. Das ist der subtilste Konstruktionsfehler dieses Entwurfs
+und wird deshalb architektonisch ausgeschlossen, nicht nur vermieden:
+
+**Stufe 1 — Entdeckung (AC-2/AC-3), bei jedem Lauf frisch berechnet.**
+Ein AST-Scan über `src/` + `api/` sucht Sammlungs-Literale (`dict`, `set`,
+`list`, `tuple` — eine geschlossene Menge, s. „Verworfene Alternativen").
+Eine Sammlung gilt als **Register-Liste**, wenn:
+
+- sie mindestens **zwei** konstante String-Elemente hat (Mindestgröße gegen
+  Zufallstreffer — eine einzelne zufällig passende Zeichenkette beweist
+  nichts), und
+- **alle** ihre konstanten String-Elemente Register-Kennungen sind (Element
+  ∈ `{m.id für m in _METRICS}`). Bei `dict`-Literalen zählen Schlüssel und
+  Werte **getrennt** — eine Übersetzungstabelle *ins* Register (z. B.
+  `{"snow_depth": "sd", ...}` im Sinne eines fremden Schlüssels) hat die
+  Kennungen als Werte, nicht als Schlüssel.
+
+Ist eine so gefundene Sammlung **nicht** in der Registrierung aus Stufe 2
+verzeichnet, ist das ein Fund: der Test wird rot, nennt Datei:Zeile und —
+soweit ermittelbar — den Namen der Sammlung.
+
+**Stufe 2 — Gültigkeitsprüfung (AC-4/AC-6), fest verdrahtete
+Registrierung.** Eine gepflegte, im Testfile lebende Tabelle (Modul + Name
++ eine Funktion, die die tatsächlich verwendeten Kennungen liefert) der
+bekannten Register-Listen. Für **jede** registrierte Liste gilt
+unabhängig von ihrer in Stufe 1 berechneten Quote:
+
+```python
+@dataclass(frozen=True)
+class RegisteredList:
+    ist: Callable[[], set[str]]          # tatsaechlich verwendete Kennungen
+    ort: str                             # "datei.py:zeile Name" fuer Meldungen
+    soll_vollstaendig: Optional[Callable[[], set[str]]] = None
+    fehlend_erlaubt: frozenset[str] = frozenset()  # nur bei soll_vollstaendig
+
+REGISTERED_LISTS: dict[str, RegisteredList] = {
+    # Schluesselseite: die Kennung STEHT als dict-Schluessel/Element.
+    "channel_layout.METRIC_PRIORITY": RegisteredList(
+        ist=lambda: set(METRIC_PRIORITY.keys()),
+        ort="src/output/renderers/channel_layout.py:60",
+        soll_vollstaendig=lambda: {m.id for m in get_all_metrics()},
+        # Befund #1856 (Etappe E7): temperature_night/wind_chill_night
+        # fehlen. Behoben in E6, nicht hier. Darf nur schrumpfen.
+        fehlend_erlaubt=frozenset({"temperature_night", "wind_chill_night"}),
+    ),
+    # Werteseite: die Kennung steht als dict-WERT, der Schluessel ist
+    # bewusst fremdes Vokabular (hier: Frontend-Metrik-ID) und wird NIE
+    # gegen das Register geprueft -- nur die Werte durchlaufen die
+    # Gueltigkeitspruefung.
+    "trip_metric_map.FRONTEND_TO_HOURLY_METRIC_ID": RegisteredList(
+        ist=lambda: set(FRONTEND_TO_HOURLY_METRIC_ID.values()),
+        ort="<Fundstelle aus AC-2-Scan>",
+    ),
+    # ... weitere Fundstellen aus dem AC-2-Scan, s. "Vollstaendigkeit der
+    # Registrierung" unten.
+}
+```
+
+Jede Kennung in `ist()` muss in `_METRICS` stehen (**Gültigkeit**) — das ist
+auf jede der vier Sammlungsformen anwendbar und fängt Tippfehler und
+gelöschte Metriken. **🔴 Diese Prüfung hängt bewusst nicht an der Quote aus
+Stufe 1** — sie läuft über die Registrierung, komplett unabhängig davon, ob
+der Scan die Liste heute (noch) als „100 % Quote" einstufen würde.
+
+**Schlüsselseite und Werteseite bekommen unterschiedliche Prüfungen, nie
+eine gemeinsame.** Schlüsselseite (12 Listen, Stand Kandidatenmessung
+dieser Etappe): alle Schlüssel sind gültige Kennungen. Werteseite (6
+Listen — die Übersetzungstabellen, s. „Vollständigkeit der Registrierung"
+unten): alle **Werte** sind gültige Kennungen; die Schlüssel sind
+absichtlich fremdes Vokabular (`col_key`, `frontend_key` o. Ä.) und dürfen
+**niemals** gegen das Register geprüft werden — das wäre eine falsche
+Zusicherung, keine strengere. Macht zusammen **18** registrierte Listen.
+Eine gemeinsame **Erkennung** (Stufe 1, „Element ∈ Register-Kennungen") ist
+für beide Seiten richtig; eine gemeinsame **Validierung** wäre falsch.
+
+### Vollständigkeit — begründete, opt-in Erweiterung von AC-4 (Designentscheidung)
+
+Der Team-Auftrag zu dieser Spec beschreibt zwei Stufen (Entdeckung,
+Gültigkeit). Das Ticket-AC-4 prüft nur eine Richtung: „steht eine
+**vorhandene** Kennung nicht im Register?" Befund 2 (`METRIC_PRIORITY`
+fehlen zwei wählbare Größen) ist die **umgekehrte** Richtung: eine gültige
+Kennung **fehlt** in einer Liste, die fachlich alle wählbaren Größen führen
+sollte. Ohne eine Prüfung dieser Richtung bliebe Befund 2 eine bloße
+Beobachtung dieser Spec-Analyse, nicht ein Fund, den der Wächter selbst
+reproduzierbar macht — und das Regel-Budget verlangt einen echten,
+nachprüfbaren Fang.
+
+Deshalb bekommt die Registrierung aus Stufe 2 ein **optionales** Feld
+`soll_vollstaendig`: nur Listen, bei denen Vollständigkeit fachlich gilt
+(wie `METRIC_PRIORITY` — sie entscheidet die Top-5-Anzeige für **alle**
+wählbaren Größen), tragen es. Das ist dieselbe Gültigkeitsprüfung aus
+Stufe 2, nur in beide Richtungen gelesen — keine dritte, universelle Stufe.
+Listen ohne dieses Feld (die meisten) werden weiterhin ausschließlich auf
+„keine ungültige Kennung" geprüft. `fehlend_erlaubt` folgt demselben Muster
+wie `EXEMPT_METRIC_IDS`: Ticket-Bezug, darf nur schrumpfen, eigener Test
+(AC-5).
+
+### Fluchtventil
+
+Kommentar `# gz-fremdvokabular: <Begründung>` (mindestens 15 sinnvolle
+Zeichen) in den ersten 20 Zeilen um die Fundstelle — Muster von
+`gz-eigenstaendig` (#1481 B) und `gz-main-path` (#1409). Im heutigen
+Bestand kommt der Fall nicht vor (`HAZARD_SMS_SYMBOLS` fällt bereits über
+die 0/10-Quote korrekt heraus), die Möglichkeit gehört trotzdem
+dokumentiert, nicht stillschweigend ausgeschlossen — eine kleine, zufällig
+voll-quotierte Liste ohne Register-Bezug ist theoretisch möglich.
+
+### Vollständigkeit der Registrierung (Implementierungsschritt, nicht Teil der Spec-Festlegung)
+
+Welche konkreten Listen heute in Stufe 2 eingetragen werden müssen, ergibt
+sich erst aus dem tatsächlichen Lauf des AC-2-Scans zum Implementierungs-
+zeitpunkt (Prinzip 3 „Nichtstun ist kein Bestehen" verlangt, dass der Scan
+läuft, nicht dass diese Spec seine Ausgabe vorwegnimmt). Nach der
+Kandidatenmessung dieser Etappe sind es **18** Listen: **12** auf der
+Schlüsselseite (Register-Kennung als dict-Schlüssel bzw. Element von
+`set`/`list`/`tuple`) — darunter `METRIC_PRIORITY` (s. o.),
+`SMS_MULTI_SYMBOLS_BY_METRIC` und `SMS_SYMBOL_BY_METRIC` (deren
+Eindeutigkeit zusätzlich über die erweiterte E3b-Ratsche geprüft wird, s.
+AC-1/AC-7) — und **6** auf der Werteseite, die sechs Übersetzungstabellen
+aus der Kandidatenmessung (`FRONTEND_TO_HOURLY_METRIC_ID`,
+`_SUMMARY_KEY_TO_CATALOG_ID`, `RENDERER_TO_TRIP_METRIC_ID`,
+`_COL_KEY_TO_METRIC_ID`, `_FALLBACK_COL_KEY_TO_METRIC_ID`,
+`_AMPEL_KEY_TO_METRIC_ID`).
+
+### Verworfene Alternativen
+
+- **Namensmuster (`_X_TO_Y` = Übersetzungstabelle).** Widerlegt durch
+  `_id_to_sms_symbol` (5/5 Quote) und `_METRIC_ID_TO_ENTRY_ATTR`
+  (15/15 Quote) — beide heißen wie eine Übersetzungstabelle, sind aber
+  echte Register-Listen. Das Namensmuster hätte den Verstoß freigesprochen.
+- **Richtung allein (Kennung als Schlüssel vs. als Wert).**
+  `_METRIK_KLARTEXT` (5/24) und `_PARAM_TO_FIELD` (4/19) sind auf der
+  Schlüsselseite fremd — Richtung ist nur ein Sonderfall der Quote, kein
+  eigenständig tragfähiges Kriterium.
+- **Reine Positivliste (nur Stufe 2, ohne Stufe 1).** Löst AC-4/AC-6, aber
+  AC-2 gar nicht — eine neue, ungeschlüsselte Liste bliebe unsichtbar, bis
+  jemand sie von Hand einträgt. Genau diese Lücke soll E7 schließen.
+- **Formaufzählung ohne Grenze.** `if`-Ketten und Comprehensions wurden
+  erwogen, aber verworfen — s. Known Limitations.
+- **AC-1 wörtlich („Mehrfach-Tabelle folgt dem Register").** Die
+  Ticket-Fassung würde `SMS_MULTI_SYMBOLS_BY_METRIC` direkt gegen
+  `get_sms_code()` vergleichen und für jede Abweichung eine Ausnahme
+  verlangen. Die drei heute existierenden Abweichungen sind aber
+  **entschieden** (#1415/#1450/#1484) — nach dem ersten Lauf, an dem alle
+  drei in die Ausnahmeliste wandern, findet diese Prüfung strukturell
+  nichts mehr, weil die Tabelle genau dafür existiert, gewollte
+  Abweichungen zu halten. Erfüllt das Regel-Budget-Kriterium „mindestens
+  ein Fang, der sonst entgangen wäre" nach dem ersten Lauf nicht mehr.
+- **Parität zwischen den Wegen** (jede Größe mit Kürzel im Trip-SMS-Weg hat
+  auch eines im Register-Weg, und umgekehrt). Gemessen: nur `confidence`
+  (kein `sms_code` im Register) und `temperature_cold` (kein Trip-SMS-
+  Kürzel) weichen ab, beide `selectable=False` und damit ohnehin bewusst
+  außerhalb der nutzersichtbaren Kürzel-Welt. Die Prüfung wäre nahezu
+  tautologisch und bräuchte sofort zwei Ausnahmen, ohne einen echten Fehler
+  abzudecken.
+
+## Expected Behavior
+
+- **Input:** Der Wächter läuft als Teil von `uv run pytest tests/unit/` —
+  bei jedem Commit-Gate-Lauf, in der CI-Ampel ohne Pfadangabe (`test`-Job).
+- **Output:** Grün, solange (a) jede registrierte Liste nur gültige
+  Kennungen führt (bzw. bei `soll_vollstaendig` nur dokumentiert fehlende),
+  und (b) kein neues, ungeschlüsseltes Vokabular im Scan auftaucht. Rot mit
+  konkreter Datei:Zeile- und Kennungsangabe sonst.
+- **Side effects:** keine — reiner Lesezugriff auf Quelltext und Register,
+  kein Produktivverhalten wird berührt.
+
+## Acceptance Criteria
+
+- **AC-1:** Given die Tabelle der Mehrfach-Kürzel
+  (`SMS_MULTI_SYMBOLS_BY_METRIC`, `src/app/metric_catalog.py:710`) und die
+  Einzel-Kürzel-Tabelle (`SMS_SYMBOL_BY_METRIC`) / When der erweiterte
+  Kürzel-Wächter läuft / Then prüft er zwei getrennte Eigenschaften:
+
+  **(a) Gültigkeit — braucht keinen eigenen Test.** Jede Kennung in
+  `SMS_MULTI_SYMBOLS_BY_METRIC` muss im Register existieren. Die Tabelle
+  hat Quote 5/5 (alle fünf Schlüssel sind gültige Metrik-Kennungen) und ist
+  damit ohnehin eine der in Stufe 2 registrierten Listen (AC-2/AC-4) — die
+  Prüfung fällt dort automatisch an und wird für AC-1 nicht doppelt gebaut.
+
+  **(b) Eindeutigkeit je Ausgabeweg** — kein Kürzel bezeichnet zwei
+  **verschiedene** Größen. Zwei getrennte Prüfungen, nie gemischt:
+  - **Trip-SMS-Weg:** für jede Metrik-Kennung aus der Vereinigung von
+    `SMS_SYMBOL_BY_METRIC.keys()` und `SMS_MULTI_SYMBOLS_BY_METRIC.keys()`
+    wird über die **bestehende** `_kurzform_kuerzel()` genau ein Kürzel
+    ermittelt (nicht neu nachgebaut). Erst danach — nach **Metrik-Kennung**
+    gruppiert, nicht nach Kürzel-Wert — wird geprüft, ob zwei
+    verschiedenen Kennungen dasselbe Kürzel zugewiesen ist.
+  - **Register-Weg:** für jede Metrik in `_METRICS` wird `sms_code`
+    genommen; dieselbe Eindeutigkeitsprüfung, unabhängig vom Trip-SMS-Weg.
+
+  🔴 **Fallstrick, gemessen und zu vermeiden:** Gruppiert man stattdessen
+  nach dem rohen Kürzel-**Wert**, erscheint `TH` zweimal — einmal aus
+  `SMS_SYMBOL_BY_METRIC["thunder"]` (`"TH:"`), einmal aus
+  `SMS_MULTI_SYMBOLS_BY_METRIC["thunder"][0]` (`"TH:"`) —, beide Male aber
+  für **dieselbe** Größe `thunder`. Das ist bereits bekannt und an anderer
+  Stelle abgesichert (`tests/tdd/test_sms_snow_symbols.py:647`,
+  `test_ac2_thunder_appears_once_with_two_symbols_no_duplicate` — der
+  `/api/sms-symbols`-Endpunkt dedupliziert genau diesen Fall). Wer hier
+  nach Kürzel statt nach Metrik-Kennung gruppiert, meldet beim ersten Lauf
+  einen Fehler, der keiner ist.
+
+  Beide Prüfungen sind **heute grün** (nachgemessen: Register-Weg 27
+  geprüfte Kürzel, 0 Kollisionen; Trip-SMS-Weg 26 geprüfte Kürzel — nur
+  `confidence` und `temperature_cold`, beide `selectable=False`, führen gar
+  kein Trip-SMS-Kürzel —, ebenfalls 0 Kollisionen).
+
+  🔴 **Zweiter Fallstrick, gemessen:** Das Register hat 28 Einträge, aber nur
+  **27** Kürzel — `confidence` führt einen **leeren** `sms_code` (bewusst: die
+  Größe ist `selectable=False` und erscheint laut PO-Entscheid #710 nie als
+  wählbare Metrik). Die Eindeutigkeitsprüfung muss leere Kürzel **überspringen**,
+  nicht gruppieren. Sonst gilt: sobald eine zweite Größe ohne Kürzel hinzukommt,
+  meldet der Wächter zwei leere Zeichenketten als „Kollision" — ein Fehlalarm,
+  der keine echte Doppelvergabe ist. Das ist gewollt: AC-1
+  bewacht eine **künftige** Copy-Paste-Kollision, nicht die drei bekannten
+  Abweichungen aus dem „Hintergrund"-Abschnitt oben — die sind Ergebnis
+  einer PO-Entscheidung, nicht Ergebnis einer Prüfung, und brauchen deshalb
+  **keine** vorbefüllte Ausnahmeliste. Eine **vierte**, neue,
+  unbegründete Kollision macht den Wächter trotzdem sofort rot.
+  - **Formulierungs-Korrektur 2026-08-15 (zweiter Durchgang,
+    Team-Lead-Rückmeldung):** Eine erste Fassung dieser AC verglich das
+    über `_kurzform_kuerzel()` ermittelte führende Kürzel direkt gegen
+    `get_sms_code()` und verlangte für jede Abweichung einen
+    Ausnahme-Eintrag. Das ist verworfen (s. „Verworfene Alternativen",
+    „Parität zwischen den Wegen") — eine solche Prüfung wäre nach dem
+    ersten Lauf strukturell taub: Sie fängt genau die drei heute bekannten
+    Fälle, danach nie wieder etwas, weil `SMS_MULTI_SYMBOLS_BY_METRIC` und
+    `SMS_SYMBOL_BY_METRIC` genau dafür existieren, gewollte Abweichungen zu
+    halten. Die jetzige Eindeutigkeitsprüfung bleibt dagegen dauerhaft
+    scharf, weil sie nichts Bekanntes ausnimmt.
+  - Test: zwei neue, eng verwandte Testfunktionen in
+    `tests/unit/test_sms_token_symbol_register_ratchet.py` (fünfte
+    Prüfstelle im Sinne von AC-7), eine je Ausgabeweg. Keine neue
+    Ausnahmeliste nötig, da beide Prüfungen heute kollisionsfrei sind.
+
+- **AC-2:** Given eine **neu angelegte** Sammlung (`dict`/`set`/`list`/
+  `tuple`) irgendwo unter `src/` oder `api/`, deren konstante
+  String-Elemente (bei `dict`: Schlüssel und Werte getrennt gezählt)
+  vollständig aus Register-Kennungen bestehen und mindestens zwei sind /
+  When sie **nicht** in der Registrierung aus Stufe 2 verzeichnet ist /
+  Then meldet der AST-Scan sie mit Datei:Zeile und — soweit ermittelbar —
+  Name. Die Frage ist umgekehrt gestellt: nicht „kenne ich diese Liste?",
+  sondern „welche Liste legt etwas je Wettergröße fest, ohne registriert zu
+  sein?".
+  - Test: `tests/unit/test_metrik_listen_register_ratchet.py` — AST-Scan
+    über `src/` + `api/`, Ergebnis-Set gegen `REGISTERED_LISTS.keys()`
+    abgeglichen. Falsch-Positiv-Gegenprobe: `HAZARD_SMS_SYMBOLS`
+    (0/10-Quote) taucht **nicht** im Fund-Set auf.
+
+- **AC-3:** Given der AST-Scan aus AC-2 / When er über `src/` + `api/`
+  läuft / Then behauptet er seine eigene Trefferzahl — findet er
+  **weniger** als eine bekannte Mindestzahl an Sammlungen, die das Muster
+  erfüllen (Erkennungs- **und** Registrierungsseite je einzeln, jeweils
+  `> 0`), schlägt der Test fehl statt grün durchzulaufen. Nichtstun ist
+  kein Bestehen (Bauprinzip 3 aus E3b).
+  - Test: `tests/unit/test_metrik_listen_register_ratchet.py::test_scan_hat_pruefmaterial`
+    — `assert len(gefundene_kandidaten) > 0` und
+    `assert len(REGISTERED_LISTS) > 0`.
+
+- **AC-4:** Given eine der in Stufe 2 registrierten Listen, unabhängig von
+  der in Stufe 1 berechneten Quote / When eine ihrer Kennungen **nicht** in
+  `_METRICS` steht (Tippfehler oder gelöschte Metrik) / Then meldet der
+  Wächter sie namentlich mit Datei:Zeile, statt sie stillschweigend zu
+  überspringen. **Erweiterung (Designentscheidung, s. Implementation
+  Details „Vollständigkeit"):** Trägt eine Registrierung zusätzlich
+  `soll_vollstaendig`, prüft dieselbe Testfunktion auch die umgekehrte
+  Richtung — fehlt eine wählbare Größe (`get_all_metrics()`) in der Liste
+  und steht sie nicht in `fehlend_erlaubt`, ist das ebenfalls ein Fund.
+  - Test: parametrisiert über `REGISTERED_LISTS`; Fixture mit absichtlich
+    verfälschter, lokaler Kopie (Tippfehler-Kennung eingefügt) beweist die
+    Existenzrichtung, Fixture mit entferntem `fehlend_erlaubt`-Eintrag für
+    `METRIC_PRIORITY` beweist die Vollständigkeitsrichtung (s. AC-6 für den
+    protokollierten Mutationsnachweis am echten Code).
+
+- **AC-5:** Given der neue Wächter / When er eine bestehende Abweichung
+  findet, die in dieser Etappe **nicht** behoben wird / Then steht sie in
+  einer kommentierten Ausnahmeliste mit Ticket-Bezug — nicht als stiller
+  Filter. Die Liste darf nur schrumpfen. Konkretes Beispiel: `#1856`,
+  `METRIC_PRIORITY` (`channel_layout.py:60`) fehlen `temperature_night`
+  und `wind_chill_night` (seit #1484/#1660 eigenständig wählbar, nie
+  nachgezogen) — Eintrag `fehlend_erlaubt={"temperature_night",
+  "wind_chill_night"}` mit Kommentarverweis auf #1856/E6.
+  - Test: `test_ausnahmeliste_nur_schrumpft` — vergleicht die Größe jedes
+    `fehlend_erlaubt`-Sets je Registrierung (aktuell nur `METRIC_PRIORITY`)
+    gegen einen im Test hartcodierten Vorzustand (Stand dieser Spec);
+    zusätzlich Begründungslängen-Check (≥ 15 sinnvolle Zeichen je
+    Kommentar, Muster `pendant_gate.py`). AC-1 selbst braucht keine
+    Ausnahmeliste (s. dort) — dieser Test prüft ausschließlich die
+    Vollständigkeits-Ausnahmen aus AC-4.
+
+- **AC-6:** Given eine registrierte Liste wird gezielt verfälscht
+  (Mutationsprobe) / When der Wächter läuft / Then wird er rot und benennt
+  die betroffene Kennung sowie die Fundstelle. Pflicht **für jede** neu
+  bewachte Liste einzeln — parametrisiert über die Registrierung, nicht als
+  Einzelfunktionen (sonst platzt das Zeilenbudget beim Wachsen der
+  Registrierung).
+  - Test: protokollierter Nachweis nach dem Muster „Wirksamkeitsnachweis
+    der Ratsche" aus E3b — für **eine** repräsentative Registrierung
+    (`METRIC_PRIORITY`) wird in einer lokalen, nicht committeten Kopie (1)
+    eine gültige Kennung durch einen Tippfehler ersetzt UND (2) der
+    `fehlend_erlaubt`-Eintrag entfernt; beide Läufe werden protokolliert
+    (rot, Kennung benannt), die Verfälschung danach zurückgenommen. Die
+    **automatisierte** Parametrisierung über `REGISTERED_LISTS` deckt alle
+    übrigen Einträge strukturell ab (dieselbe Prüffunktion, andere Daten) —
+    sie ersetzt nicht den protokollierten Einzelnachweis, ergänzt ihn.
+  - **Katalog-Wächter-Blindfleck beachtet:** Die Soll-Menge (`_METRICS`,
+    28 Kennungen) darf berechnet werden, die Soll-**Zuordnung** (welches
+    Kürzel zu welcher Metrik gehört) nicht — deshalb prüft AC-1
+    `_kurzform_kuerzel()` gegen `get_sms_code()`, zwei getippte,
+    unabhängig gepflegte Werte, keine Tautologie.
+
+- **AC-7:** Given die bestehende Ratsche
+  `tests/unit/test_sms_token_symbol_register_ratchet.py` (E3b, 415 Zeilen)
+  / When E7 fertig ist / Then ist sie **erweitert, nicht ersetzt** — ihre
+  vier bisherigen Prüfstellen (`test_ratchet_inspects_the_code_of_this_worktree`,
+  `test_ratchet_actually_has_material_to_check`,
+  `test_wintersport_token_symbols_match_register`,
+  `test_sms_symbol_by_metric_matches_register`) bleiben unverändert
+  wirksam; eine fünfte kommt hinzu (AC-1).
+  - Test: Diff-Review im PR zeigt ausschließlich Ergänzungen an der
+    bestehenden Datei (neue Funktion + neue Ausnahmeliste), keine Löschung
+    oder inhaltliche Änderung der vier bestehenden Testfunktionen.
+
+## Regel-Budget
+
+Prüfdatum **2026-11-15**. Der neue Wächter ersetzt keinen bestehenden,
+sondern erweitert die E3b-Ratsche um eine zweite, umgekehrt gestellte
+Frage. **Fang-Kriterium:** mindestens eine Abweichung oder neue
+ungeschlüsselte Liste, die er fängt und die den anderen Wächtern entgangen
+wäre.
+
+**Fang-Beleg bei Einführung:** `src/output/renderers/channel_layout.py:60`,
+`METRIC_PRIORITY` (25 Einträge) entscheidet, welche fünf Größen bei knappem
+Platz in den `primary`-Bucket kommen (Zeile 131:
+`METRIC_PRIORITY.get(pair[1], 0)`). `temperature_night` und
+`wind_chill_night` fehlen — beide seit #1484/#1660 eigenständig wählbar,
+nie nachgezogen. Ohne Eintrag Priorität 0, hinter `cloud_high` (10) und
+`confidence` (8). Die Datei importiert nichts aus `metric_catalog` — kein
+anderer heute laufender Wächter hätte das gefangen. Behoben wird das in
+**E6**; hier dient es als Beleg, dass die Vollständigkeits-Erweiterung aus
+AC-4 einen echten, bis heute unentdeckten Fehler mechanisch reproduziert
+(nicht nur dokumentiert), sobald der `fehlend_erlaubt`-Eintrag probeweise
+entfernt wird (s. AC-6).
+
+**Risiko, das dieses Budget einordnet:** Die CI-Ampel ruft `uv run pytest`
+**ohne Pfadangabe** auf (`.github/workflows/ci.yml:58`). Ein neuer Wächter
+unter `tests/unit/` läuft ab Merge automatisch mit und blockiert bei Rot
+**jeden** PR, auch die anderer Sessions — der Wächter muss am Tag der
+Einführung grün sein. **Eingeschränkt gegenüber einer früheren Fassung
+dieser Spec:** AC-1 selbst braucht dafür **keine** vorbefüllte
+Ausnahmeliste mehr (beide Eindeutigkeitsprüfungen sind heute kollisionsfrei
+— s. AC-1). Atomar in einer Lieferung kommen müssen weiterhin die
+`soll_vollstaendig`-Registrierungen aus AC-4 mit ihren `fehlend_erlaubt`-
+Einträgen — konkret `METRIC_PRIORITY` mit `{"temperature_night",
+"wind_chill_night"}` (AC-5). Ohne diesen Eintrag wäre der Wächter am Tag
+der Einführung rot.
+
+## Nicht in dieser Etappe
+
+- **Die gefundenen Abweichungen selbst beheben** — das ist **E6**, direkt
+  im Anschluss (#1435). E7 macht sie nur sichtbar und schreibt sie fest.
+- **Die sieben Vokabulare vereinheitlichen** — ausdrücklich nicht
+  vorgesehen (#1435, „Ausdrücklich NICHT vorgeschlagen").
+- **Frontend-Listen** — soweit sie über `/api/sms-symbols` aus dem Backend
+  lesen, sind sie bereits gedeckt; ein separater Frontend-Wächter ist nicht
+  nötig (Muster aus E3b).
+- **Go-Seite.**
+- **`if metric_id == "..."`-Ketten und dict-Comprehensions** — s. Known
+  Limitations.
+
+## Known Limitations
+
+- **`if`-Ketten (32 gemessen) und dict-Comprehensions (93 gemessen) werden
+  nicht erfasst.** Die vier Sammlungs-Literale (`dict`/`set`/`list`/
+  `tuple`) sind eine geschlossene Menge — sie aufzuzählen ist etwas anderes
+  als das Aufzählen von *Schreibweisen* innerhalb einer Form. `if`-Ketten
+  und Comprehensions sind dagegen eine offene Klasse. Wer sie mitnehmen
+  will, landet in derselben Aufzählungsfalle, an der ein früherer
+  AST-Wächter dieses Repos dreimal gescheitert ist (Zwischenvariable, dann
+  Liste und Tupel-Rückgabe umgingen die Erkennung trivial) —
+  dokumentiert in `docs/specs/modules/fix_1667_s1_fixture_wanduhr.md`
+  (Issue #1667 Scheibe S1). Gelöst wurde es dort durch ein **strukturelles**
+  Muster (Elternkette fragen: „fließt der Wert in einen Aufruf/Dict-Wert/
+  return?") statt durch Aufzählung von Schreibweisen. Diese Etappe geht das
+  Risiko bewusst nicht ein, solange die geschlossene Vier-Formen-Menge noch
+  nicht ausgeschöpft ist — eine strukturelle Lösung für `if`-Ketten wäre
+  eine eigene, größere Folge-Etappe.
+- **Eine vollständig fremd benannte, inhaltlich aber per-Metrik geführte
+  Liste** (Quote 0 %) bleibt unsichtbar. Bewusste Grenze: Falsch-Positive
+  sind schlimmer als eine Restlücke — ein Wächter, der harmlose Listen
+  meldet (wie `HAZARD_SMS_SYMBOLS`, wäre die Quote-Schwelle niedriger),
+  wird abgeschaltet.
+- **Vollständigkeit wird nur dort geprüft, wo ein Registrierungseintrag es
+  ausdrücklich verlangt (`soll_vollstaendig`).** Das ist eine bewusste,
+  begründete Erweiterung über die im Ticket wörtlich beschriebenen ACs
+  hinaus (s. Implementation Details) — sie deckt nur die Listen ab, die
+  jemand als „muss vollständig sein" registriert hat, nicht jede denkbare
+  Register-Liste automatisch. Eine Liste, die fachlich Vollständigkeit
+  bräuchte, aber nie mit diesem Flag registriert wurde, bleibt bezüglich
+  fehlender Einträge unbewacht — nur bezüglich ungültiger Einträge.
+- **Go-Seite und Frontend** sind nicht Gegenstand: beide lesen über
+  `/api/metrics` bzw. `/api/sms-symbols` aus dem Backend.
+- **Eigenschaftslisten als Liste von Datensätzen** (`[{"id": "snow_depth",
+  "field": "…", "unit": "…"}, …]`) statt als flaches Wörterbuch bleiben für
+  die Quote-Regel unsichtbar — jeder einzelne Datensatz liegt bei
+  33–50 % Quote, weit unter der 100-%-Schwelle aus Stufe 1. Diese Form
+  existiert real (`src/output/renderers/compare_metric_catalog.py:77-159`,
+  `src/output/renderers/email/compare_html.py:316-374`). AC-2 spricht im
+  Ticket wörtlich von „Wörterbuch mit Metrik-Kennungen als Schlüssel" — die
+  Lücke liegt damit außerhalb des Ticket-Wortlauts. Sie zu schließen wäre
+  eine Erweiterung dieses Auftrags (eine fünfte Sammlungsform:
+  „Liste von Datensätzen mit einem Kennungs-Feld"), kein Bestandteil von
+  E7.
+
+## Test-Plan (AC-Mapping)
+
+| AC | Testdatei | Testfunktion (Name kann bei Implementierung leicht variieren) |
+|---|---|---|
+| AC-1 | `test_sms_token_symbol_register_ratchet.py` | 5. Prüfstelle: zwei Eindeutigkeitsprüfungen (Trip-SMS-Weg, Register-Weg), Gültigkeit läuft über AC-4 mit |
+| AC-2 | `test_metrik_listen_register_ratchet.py` | AST-Scan vs. `REGISTERED_LISTS`, inkl. `HAZARD_SMS_SYMBOLS`-Gegenprobe |
+| AC-3 | `test_metrik_listen_register_ratchet.py` | `test_scan_hat_pruefmaterial` (Trefferzahl `> 0` auf beiden Seiten) |
+| AC-4 | `test_metrik_listen_register_ratchet.py` | parametrisiert über `REGISTERED_LISTS`, Existenz- und (opt-in) Vollständigkeitsrichtung |
+| AC-5 | `test_metrik_listen_register_ratchet.py` | `test_ausnahmeliste_nur_schrumpft` + Begründungslängen-Check |
+| AC-6 | `test_metrik_listen_register_ratchet.py` | protokollierter Mutationsnachweis (`METRIC_PRIORITY`, zwei Verfälschungen) + parametrisierte Struktur |
+| AC-7 | `test_sms_token_symbol_register_ratchet.py` | PR-Diff-Review: vier bestehende Funktionen unverändert |
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine.
+- **Rationale:** Reine Testschicht, keine Produktivcode-Änderung, keine der
+  ADR-Trigger-Flächen aus CLAUDE.md (Kanäle, Provider, Datenmodell/
+  Persistenz, Auth, Editor-Paradigma, Test-/Deploy-Strategie) betroffen.
+  Die Registerherrschaft über Renderer-Vokabulare ist bereits etablierte
+  Praxis (ADR-0011, fortgeführt in E1a/E1b/E3a/E3b) — E7 baut das dort
+  zugesagte Werkzeug, ändert aber keine Architektur-Entscheidung.
+
+## Changelog
+
+- 2026-08-15: Initial spec created. Analyse aus
+  `docs/context/fix-1856-e7-listen-waechter.md` übernommen, AC-1 gemäß
+  Befund 1 umformuliert (Existenz/Eindeutigkeit statt Gleichheit,
+  PO-Entscheide #1415/#1450/#1484/#1660 referenziert), Vollständigkeits-
+  prüfung für `METRIC_PRIORITY` als begründete, opt-in Erweiterung von AC-4
+  ergänzt, um Befund 2 zu einem mechanisch nachweisbaren Fang zu machen
+  (Regel-Budget). Quellenangabe zur Aufzählungsfalle korrigiert: das
+  vorgelegte Briefing zitierte `fix_1396_s2_store_scope_guard.md` (Go-
+  Store-Scope-Wächter, anderes Thema) — die tatsächliche, durch Memory und
+  Dateiinhalt bestätigte Quelle ist #1667 S1 /
+  `fix_1667_s1_fixture_wanduhr.md`.
+- 2026-08-15 (zweiter Durchgang): AC-1 grundlegend überarbeitet nach
+  Team-Lead-Rückmeldung. Der direkte Vergleich „führendes Kürzel gegen
+  Register-Kürzel" (erste Fassung) ist verworfen — er wäre nach dem ersten
+  Lauf strukturell taub gewesen (fängt die drei bekannten, entschiedenen
+  Abweichungen einmalig, danach nichts mehr). AC-1 prüft jetzt zwei
+  getrennte Eigenschaften: Gültigkeit (fällt aus AC-2/AC-4 automatisch an,
+  kein Sonderfall) und Eindeutigkeit je Ausgabeweg (Trip-SMS-Weg,
+  Register-Weg, je für sich, nach Metrik-Kennung gruppiert — sonst
+  Fehlalarm bei `thunder`/`TH`, s. `test_sms_snow_symbols.py:647`). Beide
+  Prüfungen sind heute nachgemessen grün, brauchen also **keine**
+  vorbefüllte Ausnahmeliste — das CI-Ampel-Atomaritätsrisiko im
+  Regel-Budget-Abschnitt betrifft dadurch nur noch AC-4/AC-5
+  (`METRIC_PRIORITY`), nicht mehr AC-1. Die drei bekannten Kürzel-
+  Abweichungen sind in einen neuen Abschnitt „Hintergrund" gewandert —
+  dort als Dokumentation einer PO-Entscheidung, nicht als Ergebnis einer
+  Prüfung. „Parität zwischen den Wegen" als weitere verworfene Alternative
+  ergänzt (gemessen: fast tautologisch, nur `confidence`/`temperature_cold`
+  betroffen). Registrierung auf 18 Listen präzisiert (12 Schlüsselseite +
+  6 Werteseite, mit expliziter Regel: Werteseiten-Schlüssel werden nie
+  gegen das Register geprüft). Known Limitation „Datensatz-Listen"
+  ergänzt (`compare_metric_catalog.py:77-159`,
+  `email/compare_html.py:316-374` — Quote 33–50 % je Datensatz, für die
+  Quote-Regel unsichtbar, außerhalb des Ticket-Wortlauts von AC-2).

--- a/docs/specs/modules/fix_1856_e7_metrik_listen_waechter.md
+++ b/docs/specs/modules/fix_1856_e7_metrik_listen_waechter.md
@@ -13,7 +13,7 @@ workflow: fix-1856-e7-listen-waechter
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-Freigabe 2026-08-15 („go"), inkl. der geänderten AC-1-Fassung
 
 ## Purpose
 
@@ -158,13 +158,35 @@ Stufe 1** — sie läuft über die Registrierung, komplett unabhängig davon, ob
 der Scan die Liste heute (noch) als „100 % Quote" einstufen würde.
 
 **Schlüsselseite und Werteseite bekommen unterschiedliche Prüfungen, nie
-eine gemeinsame.** Schlüsselseite (12 Listen, Stand Kandidatenmessung
-dieser Etappe): alle Schlüssel sind gültige Kennungen. Werteseite (6
-Listen — die Übersetzungstabellen, s. „Vollständigkeit der Registrierung"
+eine gemeinsame.** Schlüsselseite: alle Schlüssel sind gültige Kennungen.
+Werteseite (die Übersetzungstabellen, s. „Vollständigkeit der Registrierung"
 unten): alle **Werte** sind gültige Kennungen; die Schlüssel sind
 absichtlich fremdes Vokabular (`col_key`, `frontend_key` o. Ä.) und dürfen
 **niemals** gegen das Register geprüft werden — das wäre eine falsche
-Zusicherung, keine strengere. Macht zusammen **18** registrierte Listen.
+Zusicherung, keine strengere.
+
+🔴 **Zahlenstand nach der Umsetzung (2026-08-15, am Code nachgemessen).** Die
+Planungszahl **18** in einer früheren Fassung dieses Absatzes war zu niedrig:
+Sie zählte nur Wörterbücher. Die Regel erfasst aber alle vier Sammlungsformen
+(`dict`/`set`/`list`/`tuple`). Verbindlich ist:
+
+| Zahl | Bedeutung |
+|---|---|
+| **42** | registrierte Listen = Fundstellen des Scans, in **12 von 200** Dateien |
+| 40 | davon in `_BESTAND`; die übrigen 2 sind Laufzeit-Einträge (`METRIC_PRIORITY`, `HOURLY_EXCLUSION_REASON` — s. Known Limitations) |
+| 47 | Rohtreffer **ohne** den `in`-Ausschluss (fünf `if metric_id in (…)`-Vergleiche, keine Listen) |
+| 34 | eigenständige Sammlungen nach Namensgruppierung (`WEATHER_TEMPLATES` 7→1, `_ALERT_METRIC_TO_CATALOG_ID` 2→1, `_DERIVED_METRIC_RULES` 2→1) |
+
+Stand **nach #1728 Scheibe 1** (`c18f8eb7`, 2026-08-15), am Code nachgemessen.
+Vor dieser Scheibe lauteten dieselben vier Zahlen 40 / 39 / 45 / 33; #1728 hat
+vier Größen ergänzt (Register 28 → 32, wählbar 25 → 29) und dabei zwei
+Fundstellen in `loader._DERIVED_METRIC_RULES` sowie eine umbenannte,
+gewachsene Liste (`_NIGHT_SCALAR_IDS` → `VISIBILITY_GATE_IDS`) hinterlassen.
+Der Wächter hat alle drei gemeldet — das ist sein erster Fang im Betrieb.
+
+Alle vier Zahlen sind gültig, meinen aber **verschiedene Zähleinheiten** — sie
+wurden in der Umsetzung gegeneinander verwechselt (Adversary-Finding F003).
+Wer sie zitiert, nennt die Einheit mit.
 Eine gemeinsame **Erkennung** (Stufe 1, „Element ∈ Register-Kennungen") ist
 für beide Seiten richtig; eine gemeinsame **Validierung** wäre falsch.
 
@@ -493,6 +515,39 @@ der Einführung rot.
   Register-Liste automatisch. Eine Liste, die fachlich Vollständigkeit
   bräuchte, aber nie mit diesem Flag registriert wurde, bleibt bezüglich
   fehlender Einträge unbewacht — nur bezüglich ungültiger Einträge.
+- **Zur Laufzeit berechnete Sammlungen sieht der AST nicht — zwei
+  Registrierungen lesen deshalb das echte Objekt statt des Quelltexts.**
+  `_literal` löst jede Registrierung über ihren Namen im Quelltext auf und
+  sieht damit nur, was dort **literal** steht. Für **40 der 42**
+  Registrierungen bleibt es dabei; **zwei** lesen bewusst den Laufzeitstand:
+
+  | Registrierung | Warum Laufzeit |
+  |---|---|
+  | `channel_layout.METRIC_PRIORITY` | Für die Vollständigkeitsrichtung (`soll_vollstaendig`) zählt der Stand zur Laufzeit, nicht die Schreibweise. |
+  | `compare_hourly_metric_ids.HOURLY_EXCLUSION_REASON` | #1728 Scheibe 1 trägt **vier der sieben** Schlüssel per Schleife nach (`compare_hourly_metric_ids.py:84-96`). Literal gelesen prüfte die Registrierung 3 von 7 — und da Stufe 1 Schleifen ohnehin nicht sieht, entkäme ein Tippfehler in genau den vier neuen Kennungen **beiden** Stufen. |
+
+  Gemessen (A/B an einer Kopie, `wind_chill_day_high` → `wind_chill_day_hihg`
+  **nur** in der Schleife, das Literal bleibt heil): literal gelesen 3
+  Kennungen sichtbar / **0 Befunde**, zur Laufzeit 7 Kennungen sichtbar /
+  **1 Befund** mit Namensnennung.
+
+  **Warum nicht alle Registrierungen so:** Laufzeit-Lesen setzt voraus, dass
+  sich der Prüfling **importieren** lässt. Der Wirksamkeitsnachweis dieses
+  Wächters (AC-2/AC-3) arbeitet aber mit erfundenen Wegwerf-Modulen — die
+  lassen sich scannen, aber nicht sinnvoll importieren. Läse alles zur
+  Laufzeit, wäre der Wächter nur noch gegen den Bestand prüfbar, und genau
+  daran sind in E3a zwei Wächter gescheitert (grün, ohne je etwas geprüft zu
+  haben). Der Regelfall bleibt literal; Laufzeit-Lesen ist die je Fundstelle
+  begründete Ausnahme. Mechanisch festgehalten:
+  `test_per_schleife_nachgetragene_schluessel_werden_mitgeprueft` wird rot,
+  sobald `HOURLY_EXCLUSION_REASON` wieder literal gelesen wird (gemessen:
+  Rückfall auf `_registriere` sieht 3 statt 7 Kennungen ⇒ Zusicherung
+  `literal < ist` verletzt).
+
+  **Restlücke, bewusst offen:** eine **neue**, zur Laufzeit aufgebaute
+  Sammlung an anderer Stelle bleibt unsichtbar — Stufe 1 findet sie nicht,
+  und ohne Fundstelle registriert sie niemand. Das Laufzeit-Lesen schließt
+  die Lücke also je Eintrag, nicht als Klasse.
 - **Go-Seite und Frontend** sind nicht Gegenstand: beide lesen über
   `/api/metrics` bzw. `/api/sms-symbols` aus dem Backend.
 - **Eigenschaftslisten als Liste von Datensätzen** (`[{"id": "snow_depth",

--- a/tests/helpers/metrik_listen_scan.py
+++ b/tests/helpers/metrik_listen_scan.py
@@ -1,0 +1,459 @@
+"""Erkennungs-Kern der Metrik-Listen-Ratsche (Issue #1856, Epic #1435 E7).
+
+SPEC: docs/specs/modules/fix_1856_e7_metrik_listen_waechter.md
+
+Stufe 1 — Entdeckung (``scanne_register_listen``): AST-Scan ueber
+``dict``/``set``/``list``/``tuple``. Eine Sammlung gilt als Register-Liste,
+wenn sie >= 2 verschiedene konstante String-Elemente hat und ALLE davon
+Register-Kennungen sind. Bei ``dict`` zaehlen Schluessel und Werte getrennt —
+eine Uebersetzungstabelle INS Register traegt die Kennungen als Werte.
+
+Stufe 2 — Gueltigkeit (``REGISTERED_LISTS``, ``pruefe_registrierte_liste``):
+jede registrierte Liste wird ueber ihren NAMEN aufgeloest und ihre Kennungen
+UNGEFILTERT gegen ``_METRICS`` geprueft.
+
+🔴 Stufe 2 haengt bewusst nicht an der Quote aus Stufe 1. Haengte sie daran,
+kippte ein einzelner Tippfehler die Liste aus der Prueffmenge — und der
+Waechter schwiege genau dort, wo er reden soll. ``_literal`` gibt deshalb
+zurueck, was im Quelltext STEHT, nicht was das Register kennt.
+
+Bauprinzipien (E3b-Ratsche): echter AST statt Regex · Soll-Kennungen aus dem
+Register statt von Hand · Nichtstun ist kein Bestehen · Pruefling aus DIESEM
+Arbeitsbaum (#1409, ``parents[2]``).
+
+Grenzen (Spec „Known Limitations"):
+
+* ``if metric_id == "…"``-Ketten und Comprehensions bleiben unsichtbar. Dazu
+  zaehlt ``if metric_id in ("wind", "gust")``: ein Tupel rechts von ``in``
+  ordnet nichts je Groesse ZU, es prueft Zugehoerigkeit — keine Festlegung im
+  Sinne von AC-2. Wuerde es gemeldet, braeuchten fuenf harmlose Stellen ein
+  Fluchtventil, und eine Ausnahmeliste aus Rauschen entwertet die echten
+  Eintraege. Ausgeschlossen wird strukturell (Elternknoten ``ast.Compare``
+  mit ``ast.In``), nicht per Namensheuristik.
+* Quote 0 % bleibt unsichtbar (Pruefstein ``HAZARD_SMS_SYMBOLS``, 0/10):
+  Falsch-Positive sind schlimmer als eine Restluecke.
+* ``_literal`` sieht nur Literale, keine zur Laufzeit berechnete Sammlung.
+  Zwei Registrierungen lesen deshalb das ECHTE Objekt statt des Literals:
+  ``METRIC_PRIORITY`` (dort zaehlt der Laufzeitstand fuer die
+  Vollstaendigkeit) und ``HOURLY_EXCLUSION_REASON`` (#1728 S1 traegt vier von
+  sieben Schluesseln per Schleife nach). Die uebrigen 40 bleiben literal —
+  Laufzeit-Lesen fuer alle hiesse, den Wirksamkeitsnachweis gegen ERFUNDENE
+  Eingaben aufzugeben: eine Wegwerf-Datei laesst sich scannen, aber nicht
+  importieren.
+* Sind bei einem ``dict`` BEIDE Seiten vollstaendig Kennungen, meldet Stufe 1
+  nur die Schluesselseite (``_scanne_datei`` bricht nach der ersten
+  qualifizierenden Seite ab). Bewusst so: keine reale Registrierung hat diese
+  Form, und zwei Fundstellen je Sammlung verdoppelten die Registrierung jeder
+  gewoehnlichen Tabelle. Wer eine solche Tabelle anlegt, registriert die
+  Werteseite ausdruecklich — Stufe 2 prueft sie dann unabhaengig vom Scan.
+
+Regel-Budget (CLAUDE.md): Pruefdatum 2026-11-15.
+"""
+from __future__ import annotations
+
+import ast
+import io
+import re
+import tokenize
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable, Iterator, Mapping, Optional
+
+from app.metric_catalog import _METRICS, get_all_metrics
+from output.renderers.channel_layout import METRIC_PRIORITY
+from output.renderers.compare_hourly_metric_ids import HOURLY_EXCLUSION_REASON
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Soll-Menge: alle 32 Registereinheiten (28 vor #1728 S1). NICHT
+#: ``get_all_metrics()`` (29) — dessen ``selectable=False``-Filter wirft
+#: ``cape``, ``confidence`` und ``temperature_cold`` weg, die dann
+#: faelschlich als unbekannt gaelten.
+KENNUNGEN: frozenset[str] = frozenset(m.id for m in _METRICS)
+
+MARKER = "gz-fremdvokabular:"
+MINDEST_BEGRUENDUNG = 15
+MINDEST_ELEMENTE = 2
+TICKET = re.compile(r"#\d+")
+
+
+@dataclass(frozen=True)
+class Fundstelle:
+    """Eine Sammlung, die nach Wettergroesse schluesselt."""
+
+    datei: Path
+    zeile: int
+    seite: str                          # "schluessel" | "wert" | "element"
+    kennungen: tuple[str, ...]
+    name: Optional[str] = None
+    freigestellt: Optional[str] = None  # Begruendung aus dem Fluchtventil
+
+    @property
+    def schluessel(self) -> str:
+        """Registrierungs-Schluessel: Modulname + Name der Sammlung."""
+        return f"{self.datei.stem}.{self.name}"
+
+    def __str__(self) -> str:
+        try:
+            pfad = self.datei.resolve().relative_to(REPO_ROOT).as_posix()
+        except ValueError:
+            pfad = str(self.datei)
+        return f"{pfad}:{self.zeile} {self.name or '<unbenannt>'} [{self.seite}]"
+
+def _seiten(knoten: ast.AST) -> list[tuple[str, list[str]]]:
+    """Die getrennt zu zaehlenden Seiten einer Sammlung."""
+    def konstant(teile: Iterable[Optional[ast.expr]]) -> list[str]:
+        return [t.value for t in teile
+                if isinstance(t, ast.Constant) and isinstance(t.value, str)]
+    if isinstance(knoten, ast.Dict):
+        return [("schluessel", konstant(knoten.keys)),
+                ("wert", konstant(knoten.values))]
+    if isinstance(knoten, (ast.Set, ast.List, ast.Tuple)):
+        return [("element", konstant(knoten.elts))]
+    return []
+
+def _benennung(baum: ast.AST) -> dict[int, tuple[str, int]]:
+    """Knoten-Id -> (Name, Zeile). Steigt durch Sammlungen, Aufrufe und
+    ``lambda`` hindurch ab, damit auch verschachtelte Listen einen sprechenden
+    Namen tragen (``WEATHER_TEMPLATES['wandern']['metrics']``)."""
+    treffer: dict[int, tuple[str, int]] = {}
+
+    def vergib(knoten: ast.AST, name: str, zeile: int) -> None:
+        treffer.setdefault(id(knoten), (name, zeile))
+        if isinstance(knoten, ast.Dict):
+            for schl, wert in zip(knoten.keys, knoten.values):
+                if schl is not None:
+                    vergib(wert, f"{name}[{ast.unparse(schl)}]", wert.lineno)
+        elif isinstance(knoten, (ast.List, ast.Tuple, ast.Set)):
+            for nr, teil in enumerate(knoten.elts):
+                vergib(teil, f"{name}[{nr}]", teil.lineno)
+        elif isinstance(knoten, ast.Call):
+            for arg in knoten.args:
+                vergib(arg, name, arg.lineno)
+            for kw in knoten.keywords:
+                vergib(kw.value, name if kw.arg is None else f"{name}.{kw.arg}",
+                       kw.value.lineno)
+        elif isinstance(knoten, ast.Lambda):
+            vergib(knoten.body, name, knoten.body.lineno)
+
+    for anw in ast.walk(baum):
+        ziel = None
+        if (isinstance(anw, ast.Assign) and len(anw.targets) == 1
+                and isinstance(anw.targets[0], ast.Name)):
+            ziel = anw.targets[0].id
+        elif isinstance(anw, ast.AnnAssign) and isinstance(anw.target, ast.Name):
+            ziel = anw.target.id
+        if ziel is not None and anw.value is not None:
+            vergib(anw.value, ziel, anw.lineno)
+    return treffer
+
+def _mitglieds_operanden(baum: ast.AST) -> set[int]:
+    """Ids der Literale rechts von ``in``/``not in`` — Zugehoerigkeitspruefung,
+    keine Festlegung je Groesse (s. Modul-Docstring, Grenzen)."""
+    ids: set[int] = set()
+    for knoten in ast.walk(baum):
+        if isinstance(knoten, ast.Compare) and any(
+                isinstance(op, (ast.In, ast.NotIn)) for op in knoten.ops):
+            ids.update(id(v) for v in knoten.comparators)
+    return ids
+
+def _kommentare(quelltext: str) -> dict[int, tuple[str, bool]]:
+    """Zeile -> (Kommentartext, steht allein auf der Zeile)."""
+    zeilen = quelltext.splitlines()
+    gefunden: dict[int, tuple[str, bool]] = {}
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(quelltext).readline):
+            if tok.type == tokenize.COMMENT:
+                nr, spalte = tok.start
+                vorspann = zeilen[nr - 1][:spalte] if nr <= len(zeilen) else ""
+                gefunden[nr] = (tok.string, not vorspann.strip())
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        return {}
+    return gefunden
+
+def _begruendung(kommentar: str) -> Optional[str]:
+    if MARKER not in kommentar:
+        return None
+    text = kommentar.split(MARKER, 1)[1].strip()
+    return text if len(text) >= MINDEST_BEGRUENDUNG else None
+
+def _freistellung(kommentare: dict[int, tuple[str, bool]],
+                  von: int, bis: int) -> Optional[str]:
+    """``# gz-fremdvokabular:`` AN der Fundstelle oder im zusammenhaengenden
+    Kommentarblock DIREKT darueber — nicht als Umgebungsfenster. Sonst stellte
+    ein Kommentar alles frei, was zufaellig in der Naehe steht (in
+    ``metric_catalog.py`` liegen sieben Register-Listen dicht beieinander)."""
+    for nr in range(von, bis + 1):
+        eintrag = kommentare.get(nr)
+        if eintrag and (grund := _begruendung(eintrag[0])):
+            return grund
+    nr = von - 1
+    while (eintrag := kommentare.get(nr)) is not None and eintrag[1]:
+        if grund := _begruendung(eintrag[0]):
+            return grund
+        nr -= 1
+    return None
+
+def _python_dateien(wurzeln: Iterable[Path | str]) -> Iterator[Path]:
+    """``wurzeln`` sind Verzeichnisse ODER einzelne Dateien."""
+    for wurzel in wurzeln:
+        pfad = Path(wurzel)
+        if pfad.is_dir():
+            yield from sorted(pfad.rglob("*.py"))
+        elif pfad.suffix == ".py":
+            yield pfad
+
+def _scanne_datei(pfad: Path) -> list[Fundstelle]:
+    quelltext = pfad.read_text(encoding="utf-8")
+    baum = ast.parse(quelltext, filename=str(pfad))
+    namen, bedingungen = _benennung(baum), _mitglieds_operanden(baum)
+    kommentare = _kommentare(quelltext)
+    funde: list[Fundstelle] = []
+    for knoten in ast.walk(baum):
+        if id(knoten) in bedingungen:
+            continue
+        for seite, strings in _seiten(knoten):
+            kennungen = set(strings)
+            if len(kennungen) < MINDEST_ELEMENTE or not kennungen <= KENNUNGEN:
+                continue
+            name, zeile = namen.get(id(knoten), (None, knoten.lineno))
+            funde.append(Fundstelle(
+                datei=pfad, zeile=zeile, seite=seite,
+                kennungen=tuple(sorted(kennungen)), name=name,
+                freigestellt=_freistellung(kommentare, min(zeile, knoten.lineno),
+                                           knoten.end_lineno or knoten.lineno)))
+            break  # Schluesselseite hat Vorrang vor der Wertseite
+    return funde
+
+def scanne_register_listen(wurzeln: Iterable[Path | str]) -> list[Fundstelle]:
+    """Alle Sammlungen unter ``wurzeln``, die nach Wettergroesse schluesseln —
+    einschliesslich der registrierten und der freigestellten."""
+    funde: list[Fundstelle] = []
+    for pfad in _python_dateien(wurzeln):
+        funde.extend(_scanne_datei(pfad))
+    return funde
+
+
+@dataclass(frozen=True)
+class RegisteredList:
+    """Eine bekannte Register-Liste und wie ihre Kennungen zu lesen sind."""
+
+    ist: Callable[[], set[str]]
+    ort: str
+    soll_vollstaendig: Optional[Callable[[], set[str]]] = None
+    fehlend_erlaubt: frozenset[str] = frozenset()
+    begruendung: str = ""
+
+_CACHE: dict[Path, tuple[dict[int, tuple[str, int]], ast.AST]] = {}
+
+def _literal(pfad: Path, name: str, seite: str) -> tuple[list[str], int]:
+    """Die konstanten Strings der benannten Sammlung — UNGEFILTERT.
+
+    Aufgeloest wird ueber den NAMEN, nie ueber die Quote aus Stufe 1: nur so
+    faellt ein Tippfehler auf, statt die Liste aus der Prueffmenge zu kippen.
+    Steht derselbe Name mehrfach in einer Datei (zwei Funktionen, dieselbe
+    lokale Tabelle), werden ALLE Vorkommen zusammengefasst — sonst bliebe das
+    zweite unter demselben Schluessel ungeprueft.
+    """
+    if pfad not in _CACHE:
+        baum = ast.parse(pfad.read_text(encoding="utf-8"), filename=str(pfad))
+        _CACHE[pfad] = (_benennung(baum), baum)
+    namen, baum = _CACHE[pfad]
+    strings: list[str] = []
+    zeile: Optional[int] = None
+    for knoten in ast.walk(baum):
+        treffer = namen.get(id(knoten))
+        if treffer is None or treffer[0] != name:
+            continue
+        for gefunden, gelesen in _seiten(knoten):
+            if gefunden == seite:
+                strings += gelesen
+                zeile = treffer[1] if zeile is None else zeile
+    if zeile is None:
+        raise LookupError(f"{name!r} ({seite}) steht nicht mehr in {pfad.name} "
+                          "— umbenannt oder geloescht?")
+    return strings, zeile
+
+# Alle Fundstellen des AC-2-Scans (nachgemessen 2026-08-15 NACH #1728 S1:
+# 42 in 12 von 200 Dateien; ohne den ``in``-Ausschluss waeren es 47). Hier
+# stehen 40 davon, die beiden uebrigen (``METRIC_PRIORITY``,
+# ``HOURLY_EXCLUSION_REASON``) stehen unten als Laufzeit-Eintraege — zusammen
+# 42 Registrierungen fuer 42 Fundstellen, 1:1; eigenstaendige Sammlungen 34
+# (``WEATHER_TEMPLATES`` 7, ``_ALERT_METRIC_TO_CATALOG_ID`` 2 und
+# ``_DERIVED_METRIC_RULES`` 2 Zeilen gehoeren je zu einer).
+# Datei, Name, geprueffte Seite — je Fundstelle EINE Zeile; die Aufloesung
+# macht ``_literal`` generisch. Die Seite ist fachlich verschieden:
+# "schluessel"/"element" = die Kennung STEHT dort; "wert" = Uebersetzung INS
+# Register, deren Schluessel bewusst fremdes Vokabular sind (``col_key``,
+# ``frontend_key``) und deshalb NIE geprueft werden.
+_R = "src/output/renderers/"
+_BESTAND: tuple[tuple[str, str, str], ...] = (
+    ("src/app/loader.py", "report_config.daily_summary_metrics", "element"),
+    # #1728 S1: je Regel-Zeile eine Fundstelle. Registriert sind nur die beiden
+    # Nacht-Zeilen — sie fuehren ausschliesslich Kennungen. Die vier
+    # Tagesrichtungs-Zeilen ([2]..[5]) tragen daneben "min"/"max" und bleiben
+    # damit BEIDEN Stufen verborgen: Stufe 1 verlangt Quote 100 %, und Stufe 2
+    # meldete das Auswertungswort als unbekannte Kennung, wuerde man sie
+    # eintragen. Das ist die bekannte Quote-Grenze (s. Modul-Docstring), keine
+    # Aussage darueber, dass dort nichts stehen koennte.
+    ("src/app/loader.py", "_DERIVED_METRIC_RULES[0]", "element"),
+    ("src/app/loader.py", "_DERIVED_METRIC_RULES[1]", "element"),
+    ("src/app/metric_catalog.py", "SMS_NULLFORM_METRIC_IDS", "element"),
+    ("src/app/metric_catalog.py", "_SMS_SYMBOL_METRIC_IDS", "element"),
+    ("src/app/metric_catalog.py", "SMS_SYMBOL_GRAMMAR", "schluessel"),
+    ("src/app/metric_catalog.py", "SMS_MULTI_SYMBOLS_BY_METRIC", "schluessel"),
+    ("src/app/metric_catalog.py", "COMPACT_LABEL_EXCEPTIONS", "schluessel"),
+    ("src/app/metric_catalog.py", "WEATHER_TEMPLATES['alpen-trekking']['metrics']", "element"),
+    ("src/app/metric_catalog.py", "WEATHER_TEMPLATES['wandern']['metrics']", "element"),
+    ("src/app/metric_catalog.py", "WEATHER_TEMPLATES['skitouren']['metrics']", "element"),
+    ("src/app/metric_catalog.py", "WEATHER_TEMPLATES['wintersport']['metrics']", "element"),
+    ("src/app/metric_catalog.py", "WEATHER_TEMPLATES['radtour']['metrics']", "element"),
+    ("src/app/metric_catalog.py", "WEATHER_TEMPLATES['wassersport']['metrics']", "element"),
+    ("src/app/metric_catalog.py", "WEATHER_TEMPLATES['allgemein']['metrics']", "element"),
+    ("src/app/models.py", "daily_summary_metrics.default_factory", "element"),
+    # #1728 S1 hat ``_NIGHT_SCALAR_IDS`` in ``VISIBILITY_GATE_IDS`` umbenannt
+    # und von 2 auf 6 Kennungen erweitert (die vier Tagesrichtungen kamen
+    # hinzu) — dieselbe Liste, legitim gewachsen. Der alte Name meldete sich
+    # als "zeigt ins Leere"; genau dafuer loest Stufe 2 ueber den Namen auf.
+    (_R + "channel_layout.py", "VISIBILITY_GATE_IDS", "element"),
+    (_R + "compare_hourly_metric_ids.py", "FRONTEND_TO_HOURLY_METRIC_ID", "wert"),
+    (_R + "compare_hourly_metric_ids.py", "HOURLY_EXCLUDED_METRIC_IDS", "element"),
+    (_R + "compare_hourly_metric_ids.py", "HOURLY_DEFAULT_METRIC_IDS", "element"),
+    (_R + "compare_metric_ids.py", "RENDERER_TO_TRIP_METRIC_ID", "wert"),
+    (_R + "email/compare_html.py", "_HOUR_FMT_OVERRIDES", "schluessel"),
+    (_R + "email/compare_html.py", "_HOUR_SEV_OVERRIDES", "schluessel"),
+    (_R + "email/helpers.py", "NO_HOURLY_COLUMN_METRIC_IDS", "element"),
+    (_R + "email/helpers.py", "_AMPEL_KEY_TO_METRIC_ID", "wert"),
+    (_R + "email/helpers.py", "_AMPEL_CAPABLE_METRIC_IDS", "element"),
+    (_R + "email/helpers.py", "_PILL_CATALOG_ORDER", "element"),
+    (_R + "email/helpers.py", "_PILL_CLASS1", "element"),
+    (_R + "email/helpers.py", "_PILL_CLASS2", "element"),
+    (_R + "email/helpers.py", "_id_to_sms_symbol", "schluessel"),
+    (_R + "email/helpers.py", "_AGGREGATION_PILL_METRICS", "schluessel"),
+    (_R + "email/helpers.py", "_DAY_WINDOW_PILL_IDS", "element"),
+    (_R + "email/html.py", "_COL_KEY_TO_METRIC_ID", "wert"),
+    (_R + "email/html.py", "_FALLBACK_COL_KEY_TO_METRIC_ID", "wert"),
+    ("src/services/compare_alert.py", "_SUMMARY_KEY_TO_CATALOG_ID", "wert"),
+    ("src/services/day_comparison.py", "_METRIC_ID_TO_ENTRY_ATTR", "schluessel"),
+    ("src/services/day_comparison.py", "_DIRECTION_WORDS", "schluessel"),
+    ("src/services/day_comparison.py", "_DISPLAY_SALIENCE_OVERRIDES", "schluessel"),
+    ("src/services/weather_change_detection.py",
+     "_ALERT_METRIC_TO_CATALOG_ID[AlertMetric.TEMPERATURE_MIN]", "element"),
+    ("src/services/weather_change_detection.py",
+     "_ALERT_METRIC_TO_CATALOG_ID[AlertMetric.SNOW_LINE]", "element"),
+)
+
+def _registriere(pfad_rel: str, name: str, seite: str) -> RegisteredList:
+    pfad = REPO_ROOT / pfad_rel
+    try:
+        ort = f"{pfad_rel}:{_literal(pfad, name, seite)[1]}"
+    except LookupError:
+        ort = pfad_rel
+    return RegisteredList(ist=lambda: set(_literal(pfad, name, seite)[0]), ort=ort)
+
+REGISTERED_LISTS: dict[str, RegisteredList] = {
+    f"{Path(pfad).stem}.{name}": _registriere(pfad, name, seite)
+    for pfad, name, seite in _BESTAND
+}
+
+# Sondereintrag: die einzige Liste, bei der auch VOLLSTAENDIGKEIT fachlich
+# gilt — sie entscheidet die Top-5-Anzeige fuer ALLE waehlbaren Groessen
+# (channel_layout.py:143, ``METRIC_PRIORITY.get(pair[1], 0)``). Gelesen wird
+# hier das echte Objekt statt des Literals: bei dieser einen zaehlt der Stand
+# zur Laufzeit.
+REGISTERED_LISTS["channel_layout.METRIC_PRIORITY"] = RegisteredList(
+    ist=lambda: set(METRIC_PRIORITY),
+    ort="src/output/renderers/channel_layout.py:60",
+    soll_vollstaendig=lambda: {m.id for m in get_all_metrics()},
+    fehlend_erlaubt=frozenset({
+        "temperature_night", "wind_chill_night",
+        "temperature_day_low", "temperature_day_high",
+        "wind_chill_day_low", "wind_chill_day_high",
+    }),
+    begruendung=(
+        "Befund #1856 (Epic #1435, Etappe E7): alle sechs Groessen sind "
+        "eigenstaendig waehlbar (Nachtfenster seit #1484/#1660 A, die vier "
+        "Tagesrichtungen seit #1728 Scheibe 1), stehen aber nicht in "
+        "METRIC_PRIORITY und liegen ueber ``.get(pair[1], 0)`` "
+        "(channel_layout.py:143) daher auf Prioritaet 0 — bei knappem Platz "
+        "fallen sie als erste heraus. #1728 S1 haelt das fuer folgenlos, weil "
+        "``VISIBILITY_GATE_IDS`` sie in ``render_for_channel`` (Zeile 107) "
+        "vorher wegfiltert; ``auto_distribute`` filtert sie NICHT, weshalb die "
+        "Bewertung offen ist. Entschieden und behoben wird sie in E6, nicht "
+        "hier — E7 macht sie nur mechanisch reproduzierbar. Die Ausnahme darf "
+        "nur schrumpfen; gewachsen ist sie allein um die vier neuen Groessen "
+        "aus #1728, nicht um neue Nachsicht bei bestehenden."
+    ),
+)
+
+# Zweiter Laufzeit-Eintrag: #1728 S1 traegt vier der sieben Schluessel per
+# Schleife nach (compare_hourly_metric_ids.py:84-96). ``_literal`` saehe nur
+# die drei literalen — ein Tippfehler in genau den vier neuen Kennungen
+# entkaeme damit BEIDEN Stufen (Stufe 1 sieht die Schleife ohnehin nicht).
+# Deshalb hier das echte Objekt. Bewacht wird die Fundstelle in ihrem
+# Endzustand, nicht ihre Schreibweise.
+REGISTERED_LISTS["compare_hourly_metric_ids.HOURLY_EXCLUSION_REASON"] = (
+    RegisteredList(
+        ist=lambda: set(HOURLY_EXCLUSION_REASON),
+        ort="src/output/renderers/compare_hourly_metric_ids.py:69",
+    )
+)
+
+def _ort_passt(fund: Fundstelle, ort: str) -> bool:
+    """Schuetzt gegen gleiche Modulnamen in verschiedenen Verzeichnissen."""
+    return fund.datei.resolve().as_posix().endswith(ort.rsplit(":", 1)[0])
+
+def unregistrierte_register_listen(
+        wurzeln: Iterable[Path | str]) -> list[Fundstelle]:
+    """Die Fundstellen, die weder registriert noch freigestellt sind."""
+    offen: list[Fundstelle] = []
+    for fund in scanne_register_listen(wurzeln):
+        reg = REGISTERED_LISTS.get(fund.schluessel)
+        if fund.freigestellt or (reg is not None and _ort_passt(fund, reg.ort)):
+            continue
+        offen.append(fund)
+    return offen
+
+def pruefe_registrierte_liste(schluessel: str, reg: RegisteredList) -> list[str]:
+    """Befund-Zeilen zu einer registrierten Liste; leere Liste = in Ordnung."""
+    try:
+        ist = set(reg.ist())
+    except LookupError as fehler:
+        return [f"{schluessel}: {fehler} Die Registrierung zeigt ins Leere."]
+    befunde = [
+        f"{schluessel}: {kennung!r} ist keine Register-Kennung — Tippfehler "
+        f"oder geloeschte Groesse? Fundstelle {reg.ort}"
+        for kennung in sorted(ist - KENNUNGEN)
+    ]
+    if reg.soll_vollstaendig is not None:
+        befunde += [
+            f"{schluessel}: {kennung!r} ist waehlbar, fehlt in dieser Liste "
+            f"aber und steht in keiner Ausnahme. Fundstelle {reg.ort}"
+            for kennung in sorted(
+                set(reg.soll_vollstaendig()) - ist - set(reg.fehlend_erlaubt))
+        ]
+    text = reg.begruendung.strip()
+    if reg.fehlend_erlaubt and (
+            len(text) < MINDEST_BEGRUENDUNG or not TICKET.search(text)):
+        befunde.append(
+            f"{schluessel}: die Ausnahme {sorted(reg.fehlend_erlaubt)!r} traegt "
+            f"keine Begruendung mit Ticket-Bezug (mind. {MINDEST_BEGRUENDUNG} "
+            f"Zeichen und eine '#N'-Nummer) — {text!r}. Ein stiller Filter ist "
+            "keine Ausnahme.")
+    return befunde
+
+def finde_kuerzel_kollisionen(kuerzel: Mapping[str, str]) -> list[str]:
+    """Kuerzel, die zwei VERSCHIEDENE Groessen bezeichnen (AC-1).
+
+    Gruppiert wird nach Metrik-Kennung (Schluessel), nicht nach Kuerzel-Wert —
+    ``TH`` steht zweimal fuer dieselbe Groesse ``thunder``. Leere Kuerzel
+    werden uebersprungen, nicht gruppiert: ``confidence`` fuehrt bewusst
+    keines (#710), und zwei Luecken sind keine Doppelvergabe.
+    """
+    nach_wert: dict[str, list[str]] = {}
+    for kennung, wert in sorted(kuerzel.items()):
+        if wert and wert.strip():
+            nach_wert.setdefault(wert, []).append(kennung)
+    return [f"{wert!r} bezeichnet {len(kenn)} verschiedene Groessen: "
+            + ", ".join(kenn)
+            for wert, kenn in sorted(nach_wert.items()) if len(kenn) > 1]

--- a/tests/unit/test_metrik_listen_register_ratchet.py
+++ b/tests/unit/test_metrik_listen_register_ratchet.py
@@ -1,0 +1,492 @@
+"""Ratsche: keine Liste unter ``src/``/``api/`` erfindet ein eigenes Vokabular.
+
+SPEC: docs/specs/modules/fix_1856_e7_metrik_listen_waechter.md — AC-2..AC-6.
+
+Umgekehrt gestellte Frage gegenueber der E3b-Ratsche
+(``test_sms_token_symbol_register_ratchet.py``): nicht "kenne ich diese
+Liste?", sondern "welche Liste legt etwas je Wettergroesse fest, OHNE
+registriert zu sein?".
+
+Der Erkennungs-Kern liegt in ``tests/helpers/metrik_listen_scan.py``
+(Testschicht, kein Produktivcode) — nur so ist er gegen ERFUNDENE Eingaben
+pruefbar. Genau darauf kommt es an: im heutigen Bestand ist alles
+registriert, ein Waechter, der ausschliesslich den Bestand sieht, ist gruen,
+ohne je etwas geprueft zu haben (in Etappe E3a sind zwei Waechter genau so
+gescheitert).
+
+Vertrag des Kerns (Phase GREEN baut ihn):
+
+  KENNUNGEN                        frozenset der 32 ``_METRICS``-Ids — NICHT
+                                   ``get_all_metrics()`` (29, filtert
+                                   ``selectable=False`` weg)
+  Fundstelle                       datei, zeile, seite ("schluessel"|"wert"|
+                                   "element"), kennungen, name, freigestellt
+  scanne_register_listen(wurzeln)  alle erkannten Sammlungen; ``wurzeln``
+                                   sind Verzeichnisse ODER einzelne Dateien
+  unregistrierte_register_listen(wurzeln)
+                                   davon die weder registrierten noch per
+                                   ``# gz-fremdvokabular: …`` freigestellten
+  RegisteredList                   frozen dataclass: ist, ort,
+                                   soll_vollstaendig, fehlend_erlaubt,
+                                   begruendung
+  REGISTERED_LISTS                 dict[str, RegisteredList]
+  pruefe_registrierte_liste(schluessel, reg) -> list[str]
+                                   Befund-Zeilen (leer = in Ordnung); prueft
+                                   Gueltigkeit, Vollstaendigkeit UND die
+                                   Begruendung der Ausnahmen (AC-4/AC-5)
+  finde_kuerzel_kollisionen(...)   AC-1, geprueft in der E3b-Ratsche
+
+Bauprinzipien, uebernommen aus der E3b-Ratsche: kein Regex ueber Quelltext
+(echter AST) · keine handgepflegte Kennungs-Liste (das Soll kommt aus dem
+Register) · Nichtstun ist kein Bestehen (Trefferzahl behaupten) · der
+Pruefling stammt aus DIESEM Arbeitsbaum (#1409).
+
+Regel-Budget (CLAUDE.md): Pruefdatum 2026-11-15.
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+import app.metric_catalog as katalog_mod
+from app.metric_catalog import _METRICS, get_all_metrics
+from output.renderers.channel_layout import METRIC_PRIORITY
+from tests.helpers.metrik_listen_scan import (
+    KENNUNGEN, REGISTERED_LISTS, RegisteredList, _literal, _registriere,
+    pruefe_registrierte_liste, scanne_register_listen,
+    unregistrierte_register_listen,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCAN_WURZELN = (REPO_ROOT / "src", REPO_ROOT / "api")
+
+# Falsch-Positiv-Pruefstein: das Vokabular der amtlichen Warnungen sieht
+# strukturell aus wie eine Metrik-Liste, hat gegen das Register aber Quote
+# 0/10. Ein Waechter, der SIE meldet, wird abgeschaltet.
+HAZARD_DATEI = REPO_ROOT / "src" / "output" / "tokens" / "hazard_symbols.py"
+# Gegenstueck: hier MUSS der Scan anschlagen, sonst misst die Gegenprobe nichts.
+POSITIV_DATEI = REPO_ROOT / "src" / "output" / "renderers" / "channel_layout.py"
+
+MP_SCHLUESSEL = "channel_layout.METRIC_PRIORITY"
+HER_SCHLUESSEL = "compare_hourly_metric_ids.HOURLY_EXCLUSION_REASON"
+HER_DATEI = REPO_ROOT / "src/output/renderers/compare_hourly_metric_ids.py"
+# Die vier Schluessel, die #1728 S1 dort per Schleife nachtraegt statt literal.
+HER_NACHGETRAGEN = frozenset({
+    "temperature_day_low", "temperature_day_high",
+    "wind_chill_day_low", "wind_chill_day_high",
+})
+
+# AC-5: Vorzustand zum Stand der Spec (2026-08-15). Die Ausnahmeliste darf nur
+# SCHRUMPFEN — waechst sie, muss jemand diese Zeile bewusst aendern.
+#
+# 2 -> 6 am 2026-08-15, bewusst angehoben: #1728 Scheibe 1 (``c18f8eb7``) hat
+# das Register von 28 auf 32 Groessen erweitert; die vier neuen
+# Tagesrichtungen (``temperature_day_low/_high``, ``wind_chill_day_low/_high``)
+# fehlen in ``METRIC_PRIORITY`` aus DEMSELBEN Grund wie die beiden
+# Nachtfenster-Skalare. Die Regel „darf nur schrumpfen" bewacht Nachsicht
+# gegenueber BESTEHENDEN Groessen — kommen Groessen hinzu, ist begruendetes
+# Wachstum zulaessig.
+#
+# 🔴 Festgehalten wird die MENGE, nicht nur ihre Groesse. Die Spec beschreibt
+# den Groessenvergleich; er allein laesst offen, dass jemand einen Eintrag
+# gegen einen anderen TAUSCHT — bei 6 statt 2 Eintraegen ist das kein
+# Randfall mehr. Der Groessenvergleich bleibt (AC-5), der Mengenvergleich
+# kommt hinzu; beides zusammen ist "darf nur schrumpfen" im Wortsinn.
+VORZUSTAND_FEHLEND_ERLAUBT: dict[str, frozenset[str]] = {
+    MP_SCHLUESSEL: frozenset({
+        "temperature_night", "wind_chill_night",
+        "temperature_day_low", "temperature_day_high",
+        "wind_chill_day_low", "wind_chill_day_high",
+    }),
+}
+
+# ---------------------------------------------------------------------------
+# Wegwerf-Module: der Waechter wird gegen ERFUNDENE Faelle geprueft, nicht nur
+# gegen den (vollstaendig registrierten) Bestand.
+# ---------------------------------------------------------------------------
+WEGWERF_SCHLUESSELSEITE = '''"""Wegwerf-Modul der Wirksamkeitsprobe."""
+WICHTIGKEIT = {
+    "temperature": 95,
+    "wind": 90,
+    "gust": 88,
+}
+'''
+
+WEGWERF_WERTESEITE = '''"""Wegwerf-Modul der Wirksamkeitsprobe."""
+SPALTE_ZU_GROESSE = {
+    "tmax": "temperature",
+    "vmax": "wind",
+}
+'''
+
+WEGWERF_TIPPFEHLER = '''"""Wegwerf-Modul der Wirksamkeitsprobe."""
+WICHTIGKEIT = {"temperature": 95, "temperatuer": 90, "wind": 88}
+'''
+
+WEGWERF_FLUCHTVENTIL = '''"""Wegwerf-Modul der Wirksamkeitsprobe."""
+# gz-fremdvokabular: Zufallstreffer, hier stehen Dateinamen, keine Groessen.
+FREIGESTELLT = ("temperature", "wind")
+
+NICHT_FREIGESTELLT = ("gust", "thunder")
+'''
+
+
+def _wegwerf_modul(tmp_path: Path, quelltext: str) -> Path:
+    pfad = tmp_path / "wegwerf_liste.py"
+    pfad.write_text(quelltext, encoding="utf-8")
+    return pfad
+
+
+def _zeile_von(quelltext: str, anfang: str) -> int:
+    for nr, zeile in enumerate(quelltext.splitlines(), start=1):
+        if zeile.startswith(anfang):
+            return nr
+    raise AssertionError(f"{anfang!r} steht nicht im Wegwerf-Modul")
+
+
+# ---------------------------------------------------------------------------
+# Selbstpruefung des Waechters (AC-3, Bauprinzipien 3 und 4)
+# ---------------------------------------------------------------------------
+
+def test_waechter_liest_das_register_dieses_arbeitsbaums():
+    """#1409: laege die Soll-Quelle im Hauptrepo, meldete ein Worktree-Lauf
+    falsches Gruen — geprueft wuerde dann eine fremde Kopie."""
+    katalog = Path(katalog_mod.__file__).resolve()
+    assert str(katalog).startswith(str(REPO_ROOT)), (
+        f"Das Register kommt aus {katalog}, erwartet unterhalb {REPO_ROOT}."
+    )
+
+
+def test_scan_hat_pruefmaterial():
+    """Nichtstun ist kein Bestehen: beide Seiten behaupten ihre Trefferzahl."""
+    gefunden = scanne_register_listen(SCAN_WURZELN)
+
+    assert len(gefunden) > 0, (
+        "Der AST-Scan findet unter src/ + api/ keine einzige Register-Liste — "
+        "er prueft praktisch nichts. Eigene Messung zum Stand dieser Etappe "
+        "(2026-08-15 nach #1728 S1, dict/set/list/tuple, Mindestgroesse 2): "
+        "42 Fundstellen in 12 von 200 Dateien — 47 waeren es ohne den "
+        "strukturellen ``in``-Ausschluss (s. Modul-Docstring des Scan-Kerns, "
+        "Grenzen)."
+    )
+    assert len(REGISTERED_LISTS) > 0, (
+        "REGISTERED_LISTS ist leer — dann ist jede Gueltigkeitspruefung aus "
+        "AC-4/AC-6 leer und der Waechter gruen, ohne etwas zu bewachen."
+    )
+    assert any(reg.soll_vollstaendig for reg in REGISTERED_LISTS.values()), (
+        "Keine einzige Registrierung prueft Vollstaendigkeit — die "
+        "Rueckrichtung aus AC-4 (fehlende Groesse in einer Liste, die alle "
+        "waehlbaren fuehren muss) ist dann unbewacht."
+    )
+    # Befund 5 der Analyse: `get_all_metrics()` filtert `selectable=False` weg.
+    # Wer dagegen prueft, meldet drei GUELTIGE Kennungen als unbekannt.
+    assert KENNUNGEN == {m.id for m in _METRICS}, (
+        f"Soll-Menge weicht von _METRICS ab: "
+        f"{sorted({m.id for m in _METRICS} ^ set(KENNUNGEN))!r}"
+    )
+    assert {"cape", "confidence", "temperature_cold"} <= KENNUNGEN, (
+        "Gegen get_all_metrics() geprueft statt gegen _METRICS."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2: die umgekehrt gestellte Frage
+# ---------------------------------------------------------------------------
+
+def test_keine_unregistrierte_register_liste_unter_src_und_api():
+    """Die Ratsche selbst: jede Liste, die etwas je Wettergroesse festlegt,
+    ist registriert (Stufe 2) oder ausdruecklich freigestellt."""
+    offen = unregistrierte_register_listen(SCAN_WURZELN)
+
+    assert not offen, (
+        "Diese Sammlungen schluesseln nach Wettergroesse, sind aber weder in "
+        "REGISTERED_LISTS eingetragen noch mit '# gz-fremdvokabular: …' "
+        "freigestellt:\n"
+        + "\n".join(f"  - {f}  {sorted(f.kennungen)!r}" for f in offen)
+    )
+
+
+@pytest.mark.parametrize(
+    "quelltext, anfang, seite, erwartete_kennungen",
+    [
+        (WEGWERF_SCHLUESSELSEITE, "WICHTIGKEIT", "schluessel",
+         {"temperature", "wind", "gust"}),
+        (WEGWERF_WERTESEITE, "SPALTE_ZU_GROESSE", "wert",
+         {"temperature", "wind"}),
+    ],
+    ids=["schluesselseite", "werteseite"],
+)
+def test_scan_meldet_eine_erfundene_unregistrierte_liste(
+    tmp_path, quelltext, anfang, seite, erwartete_kennungen,
+):
+    """Der eigentliche Wirksamkeitsnachweis fuer AC-2. Im Bestand ist alles
+    registriert — ohne diesen Fall belegt die gruene Ratsche oben nichts.
+
+    Die Werteseite ist kein Nebenfall: eine Uebersetzungstabelle INS Register
+    (fremder Schluessel, Kennung als Wert) muss genauso gefunden werden,
+    sonst entkommt jede neue Tabelle durch blosses Umdrehen.
+    """
+    pfad = _wegwerf_modul(tmp_path, quelltext)
+
+    gefunden = scanne_register_listen([pfad])
+    assert len(gefunden) == 1, (
+        f"Erwartet genau eine Fundstelle, bekommen: {gefunden!r}"
+    )
+    fund = gefunden[0]
+    assert fund.seite == seite
+    assert set(fund.kennungen) == erwartete_kennungen
+    assert fund.zeile == _zeile_von(quelltext, anfang)
+    assert fund.name == anfang
+
+    offen = unregistrierte_register_listen([pfad])
+    assert len(offen) == 1, (
+        "Eine erfundene, nirgends registrierte Liste bleibt unbeanstandet — "
+        f"der Waechter kann AC-2 nicht erfuellen. Gemeldet: {offen!r}"
+    )
+    meldung = str(offen[0])
+    assert "wegwerf_liste.py" in meldung and str(fund.zeile) in meldung, (
+        f"Die Meldung nennt nicht Datei:Zeile: {meldung!r}"
+    )
+    assert anfang in meldung, f"Die Meldung nennt den Namen nicht: {meldung!r}"
+
+
+def test_fluchtventil_stellt_nur_die_kommentierte_fundstelle_frei(tmp_path):
+    """``# gz-fremdvokabular:`` verhindert nichts — es macht die Entscheidung
+    zitierbar. Zwei Sammlungen, eine kommentiert: gemeldet wird genau die
+    andere (sonst waere der Test durch Nichtstun gruen).
+
+    🔴 Der Kommentar gehoert an DIE Fundstelle, die er freistellt — an die
+    Zeile bzw. unmittelbar darueber. Die Spec sagt "in den ersten 20 Zeilen um
+    die Fundstelle"; als Fenster von +/-20 Zeilen gelesen, stellte EIN
+    Kommentar alles frei, was zufaellig in der Naehe steht (in
+    ``metric_catalog.py`` liegen sieben Register-Listen dicht beieinander).
+    Diese Testfassung schliesst diese Lesart aus.
+    """
+    pfad = _wegwerf_modul(tmp_path, WEGWERF_FLUCHTVENTIL)
+
+    gefunden = scanne_register_listen([pfad])
+    assert len(gefunden) == 2, (
+        f"Beide Sammlungen muessen gefunden werden: {gefunden!r}"
+    )
+    freigestellt = [f for f in gefunden if f.freigestellt]
+    assert [f.name for f in freigestellt] == ["FREIGESTELLT"], (
+        f"Falsche Fundstelle freigestellt: {gefunden!r}"
+    )
+    assert len(freigestellt[0].freigestellt.strip()) >= 15, (
+        "Eine Freistellung ohne lesbare Begruendung ist keine Freistellung."
+    )
+
+    offen = unregistrierte_register_listen([pfad])
+    assert [f.name for f in offen] == ["NICHT_FREIGESTELLT"], (
+        f"Gemeldet werden muss genau die unkommentierte Sammlung: {offen!r}"
+    )
+
+
+def test_gleicher_modulname_erbt_keine_registrierung(tmp_path, monkeypatch):
+    """Der Registrierungs-Schluessel ist ``modulname.sammlung`` — im Repo gibt
+    es ``models.py`` zweimal unter ``src/`` (``app/``, registriert;
+    ``services/official_alerts/``, nicht). Ohne den Ortsabgleich in
+    ``_ort_passt`` erbte die zweite Datei die Registrierung der ersten, und
+    eine neue Liste dort bliebe stumm."""
+    for ordner in ("app", "fremd"):
+        (tmp_path / ordner).mkdir()
+        (tmp_path / ordner / "models.py").write_text(
+            WEGWERF_SCHLUESSELSEITE, encoding="utf-8")
+    monkeypatch.setitem(
+        REGISTERED_LISTS, "models.WICHTIGKEIT",
+        RegisteredList(ist=lambda: {"temperature"}, ort="app/models.py:2"))
+
+    offen = unregistrierte_register_listen([tmp_path])
+
+    assert [f.datei.parent.name for f in offen] == ["fremd"], (
+        "Gemeldet werden muss genau die gleichnamige Sammlung im NICHT "
+        f"registrierten Verzeichnis: {offen!r}")
+
+
+def test_hazard_symbols_bleiben_unauffaellig():
+    """Falsch-Positive sind schlimmer als eine Restluecke: ``HAZARD_SMS_SYMBOLS``
+    (Quote 0/10) darf nicht anschlagen. Die Gegenprobe an ``channel_layout.py``
+    zeigt im selben Test, dass der Scan ueberhaupt etwas sieht — sonst waere
+    'findet nichts' der Beweis fuer 'es gibt nichts'."""
+    assert HAZARD_DATEI.exists() and POSITIV_DATEI.exists()
+
+    harmlos = scanne_register_listen([HAZARD_DATEI])
+    assert harmlos == [], (
+        "Das Vokabular der amtlichen Warnungen wurde als Register-Liste "
+        f"gemeldet: {harmlos!r}"
+    )
+
+    positiv = scanne_register_listen([POSITIV_DATEI])
+    assert positiv, (
+        "Der Scan findet nicht einmal METRIC_PRIORITY (25 Kennungen) — die "
+        "Gegenprobe oben ist damit wertlos."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4/AC-5/AC-6: Gueltigkeit, Vollstaendigkeit, Ausnahmen
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("schluessel", sorted(REGISTERED_LISTS))
+def test_registrierte_liste_ist_in_ordnung(schluessel):
+    """AC-4: jede Kennung existiert im Register; traegt die Registrierung
+    ``soll_vollstaendig``, fehlt auch keine waehlbare Groesse. AC-5: eine
+    ``fehlend_erlaubt``-Ausnahme ohne Begruendungssatz mit Ticket-Bezug ist
+    keine Ausnahme (Wirksamkeit s. ``test_ausnahme_ohne_begruendung...``)."""
+    befunde = pruefe_registrierte_liste(schluessel, REGISTERED_LISTS[schluessel])
+    assert befunde == [], "\n".join(befunde)
+
+
+def test_verfaelschte_kennung_wird_namentlich_gemeldet():
+    """AC-6, Existenzrichtung. Ohne diesen Fall belegt der gruene Lauf oben
+    nicht, dass die Pruefung ueberhaupt zubeisst."""
+    echt = set(METRIC_PRIORITY)
+    verfaelscht = (echt - {"temperature"}) | {"temperatuer"}
+    reg = RegisteredList(
+        ist=lambda: verfaelscht, ort="src/output/renderers/channel_layout.py:60",
+    )
+
+    befunde = pruefe_registrierte_liste(MP_SCHLUESSEL, reg)
+
+    assert befunde, (
+        "Eine Kennung, die das Register nicht kennt, blieb unbeanstandet."
+    )
+    text = "\n".join(befunde)
+    assert "temperatuer" in text, (
+        f"Die Meldung nennt die falsche Kennung nicht: {text!r}"
+    )
+    assert "channel_layout.py:60" in text, (
+        f"Die Meldung nennt die Fundstelle nicht: {text!r}"
+    )
+
+
+def test_tippfehler_in_einer_ast_gelesenen_liste_wird_gemeldet(tmp_path):
+    """AC-4, Existenzrichtung fuer die 40 ueber ``_literal`` AST-gelesenen
+    Registrierungen: der Test darueber baut eine ``RegisteredList`` von Hand
+    und trifft mit ``METRIC_PRIORITY`` eine der beiden, die ``_literal`` NICHT
+    durchlaufen. 🔴 Zugleich Nachweis der Stufen-Trennung — Quote 2/3,
+    Stufe 1 findet die Liste deshalb nicht (erste Zusicherung). Filtert
+    ``_literal`` seine Ausgabe auf ``KENNUNGEN`` (die von der Spec verworfene
+    Kopplung an Stufe 1), faellt der Tippfehler weg und dieser Test wird rot.
+    """
+    pfad = _wegwerf_modul(tmp_path, WEGWERF_TIPPFEHLER)
+    assert scanne_register_listen([pfad]) == [], (
+        "Stufe 1 darf diese Liste (Quote 2/3) gerade NICHT finden — sonst "
+        "misst der Test die Unabhaengigkeit der beiden Stufen nicht.")
+    reg = _registriere(str(pfad), "WICHTIGKEIT", "schluessel")
+    text = "\n".join(pruefe_registrierte_liste("wegwerf.WICHTIGKEIT", reg))
+
+    assert "temperatuer" in text, (
+        "Der Tippfehler in einer AST-gelesenen Registrierung blieb "
+        f"unbeanstandet — Stufe 2 haengt an der Quote aus Stufe 1: {text!r}")
+    assert "wegwerf_liste.py" in text, f"Ohne Fundstelle unbrauchbar: {text!r}"
+
+
+def test_per_schleife_nachgetragene_schluessel_werden_mitgeprueft():
+    """Gegenstueck zum Test darueber: ``HOURLY_EXCLUSION_REASON`` fuehrt drei
+    Schluessel literal, die vier restlichen traegt #1728 S1 per Schleife nach
+    (``compare_hourly_metric_ids.py:84-96``). Wer hier ``_literal`` liest,
+    prueft 3 von 7 und schweigt ausgerechnet ueber die NEUEN Kennungen —
+    Stufe 1 sieht die Schleife ohnehin nicht, ein Tippfehler dort entkaeme
+    also beiden Stufen. Diese eine Registrierung liest deshalb das echte
+    Objekt; faellt sie je auf ``_registriere`` zurueck, wird dieser Test rot.
+    """
+    literal = set(_literal(HER_DATEI, "HOURLY_EXCLUSION_REASON", "schluessel")[0])
+    ist = set(REGISTERED_LISTS[HER_SCHLUESSEL].ist())
+
+    assert literal < ist, (
+        f"Die Registrierung sieht nur {sorted(ist)!r} — nicht mehr als das "
+        f"Literal {sorted(literal)!r}. Dann liest sie wieder den Quelltext."
+    )
+    assert ist - literal == set(HER_NACHGETRAGEN), (
+        f"Zur Laufzeit kommen {sorted(ist - literal)!r} hinzu, erwartet waren "
+        f"{sorted(HER_NACHGETRAGEN)!r}. Aendert sich der Schleifen-Nachtrag, "
+        "gehoert diese Zeile bewusst nachgezogen."
+    )
+
+
+def test_entfernte_ausnahme_macht_die_luecke_in_metric_priority_sichtbar():
+    """AC-6, Vollstaendigkeitsrichtung — zugleich der Fang-Beleg dieser Etappe
+    (Regel-Budget): ``METRIC_PRIORITY`` fehlen sechs waehlbare Groessen — die
+    beiden Nachtfenster-Skalare (seit #1484/#1660 A) und die vier
+    Tagesrichtungen (seit #1728 Scheibe 1). Die Datei importiert nichts aus
+    ``metric_catalog`` — kein anderer Waechter haette das gefangen. Behoben
+    wird es in E6, hier wird es mechanisch reproduzierbar.
+
+    Die vier neuen sind der erste echte Fang des Waechters im Betrieb: sie
+    entstanden NACH seiner Einfuehrung und wurden nicht von Hand entdeckt.
+    """
+    reg = REGISTERED_LISTS[MP_SCHLUESSEL]
+    assert reg.soll_vollstaendig is not None, (
+        f"{MP_SCHLUESSEL} traegt kein soll_vollstaendig — die "
+        "Vollstaendigkeitsrichtung ist dort unbewacht."
+    )
+    assert pruefe_registrierte_liste(MP_SCHLUESSEL, reg) == [], (
+        "Mit dokumentierter Ausnahme muss die Registrierung still sein "
+        "(sonst ist der Waechter am Tag der Einfuehrung rot)."
+    )
+
+    ohne_ausnahme = replace(reg, fehlend_erlaubt=frozenset())
+    text = "\n".join(pruefe_registrierte_liste(MP_SCHLUESSEL, ohne_ausnahme))
+
+    luecke = {
+        "temperature_night", "wind_chill_night",
+        "temperature_day_low", "temperature_day_high",
+        "wind_chill_day_low", "wind_chill_day_high",
+    }
+    for fehlend in sorted(luecke):
+        assert fehlend in text, (
+            f"{fehlend!r} fehlt in METRIC_PRIORITY, wird aber nicht gemeldet: "
+            f"{text!r}"
+        )
+    assert {m.id for m in get_all_metrics()} >= luecke, (
+        "Alle sechs Groessen sind waehlbar — sonst waere der Fang keiner."
+    )
+
+
+def test_ausnahme_ohne_begruendung_ist_keine_ausnahme():
+    """AC-5: Muster ``COMPACT_LABEL_EXCEPTIONS``/``gz-eigenstaendig`` — ein
+    Eintrag ohne lesbaren Satz mit Ticket-Bezug wird gemeldet."""
+    reg = REGISTERED_LISTS[MP_SCHLUESSEL]
+
+    for kaputt, warum in (
+        (replace(reg, begruendung=""), "leere Begruendung"),
+        (replace(reg, begruendung="s.o."), "zu kurze Begruendung"),
+        (replace(reg, begruendung="Wird spaeter einmal nachgezogen werden."),
+         "Begruendung ohne Ticket-Bezug"),
+    ):
+        befunde = pruefe_registrierte_liste(MP_SCHLUESSEL, kaputt)
+        assert befunde, f"{warum} blieb unbeanstandet ({kaputt.begruendung!r})"
+        assert MP_SCHLUESSEL in "\n".join(befunde)
+
+
+def test_ausnahmeliste_darf_nur_schrumpfen():
+    """AC-5: waechst sie, muss jemand ``VORZUSTAND_FEHLEND_ERLAUBT`` bewusst
+    aendern — kein stiller Filter."""
+    for schluessel in sorted(VORZUSTAND_FEHLEND_ERLAUBT):
+        assert schluessel in REGISTERED_LISTS, (
+            f"{schluessel!r} steht im Vorzustand, aber nicht in "
+            "REGISTERED_LISTS — der Vorzustand bewacht ein Phantom."
+        )
+
+    for schluessel, reg in sorted(REGISTERED_LISTS.items()):
+        if not reg.fehlend_erlaubt:
+            continue
+        assert schluessel in VORZUSTAND_FEHLEND_ERLAUBT, (
+            f"{schluessel!r} hat eine neue Ausnahmeliste "
+            f"({sorted(reg.fehlend_erlaubt)!r}), die nirgends festgehalten "
+            "ist. Ausnahmen werden eingetragen, nicht eingeschmuggelt."
+        )
+        erlaubt = VORZUSTAND_FEHLEND_ERLAUBT[schluessel]
+        assert len(reg.fehlend_erlaubt) <= len(erlaubt), (
+            f"{schluessel!r}: Ausnahmeliste gewachsen von {len(erlaubt)} auf "
+            f"{len(reg.fehlend_erlaubt)} ({sorted(reg.fehlend_erlaubt)!r})."
+        )
+        assert reg.fehlend_erlaubt <= erlaubt, (
+            f"{schluessel!r}: {sorted(reg.fehlend_erlaubt - erlaubt)!r} steht "
+            "neu in der Ausnahmeliste, ohne dass der Vorzustand es kennt. "
+            "Gleich viele Eintraege heisst nicht dieselben — ein Tausch waere "
+            "sonst eine stille neue Ausnahme."
+        )

--- a/tests/unit/test_sms_token_symbol_register_ratchet.py
+++ b/tests/unit/test_sms_token_symbol_register_ratchet.py
@@ -413,3 +413,115 @@ def test_legacy_snow_symbols_are_absent_from_all_tables(legacy_symbol: str):
         "Erwartet werden die Registerwerte SD (Schneehoehe), NS24+ "
         "(Neuschnee), SL (Schneefallgrenze)."
     )
+
+
+# ---------------------------------------------------------------------------
+# Fuenfte Pruefstelle — Issue #1856 (#1435 Etappe E7), AC-1/AC-7.
+# SPEC: docs/specs/modules/fix_1856_e7_metrik_listen_waechter.md
+#
+# Kein Kuerzel bezeichnet zwei VERSCHIEDENE Groessen. Zwei Ausgabewege, zwei
+# getrennte Pruefungen, nie gemischt: die Trip-SMS liest
+# SMS_SYMBOL_BY_METRIC/SMS_MULTI_SYMBOLS_BY_METRIC, Vergleichs- und Alarm-SMS
+# lesen `get_sms_code()` direkt (comparison.py:647, alert/render.py:93).
+#
+# Die vier Pruefstellen oberhalb bleiben unveraendert (AC-7) — auch ihre
+# Import-Zeilen. Der Kollisions-Kern wird deshalb LOKAL importiert: er lebt in
+# `tests/helpers/metrik_listen_scan.py`, damit er gegen erfundene Eingaben
+# pruefbar ist (dritte Funktion unten); ein Modul-Import wuerde diese Datei
+# bei jedem Fehler dort komplett unauffuehrbar machen.
+#
+# NICHT geprueft wird Gleichheit zwischen den Wegen: die drei Abweichungen
+# (temperature K/D, wind_chill FK/FD/WC, temperature_night N) sind
+# PO-Entscheide (#1415/#1450/#1484), eine Gleichheitspruefung waere nach dem
+# ersten Lauf taub. Gueltigkeit faellt ueber AC-2/AC-4 an.
+# ---------------------------------------------------------------------------
+
+def _kuerzel_trip_sms_weg() -> dict[str, str]:
+    """Metrik-Kennung -> das Kuerzel, das die Trip-Kurzform sendet.
+
+    Gruppiert nach KENNUNG, nicht nach Kuerzel-Wert: 'TH:' steht sowohl in
+    SMS_SYMBOL_BY_METRIC als auch in SMS_MULTI_SYMBOLS_BY_METRIC, beide Male
+    fuer dieselbe Groesse `thunder` (dedupliziert auch von /api/sms-symbols,
+    s. tests/tdd/test_sms_snow_symbols.py). Wer nach Wert gruppiert, meldet
+    beim ersten Lauf eine Kollision, die keine ist.
+    """
+    from app.metric_catalog import (
+        _METRICS, _kurzform_kuerzel, SMS_MULTI_SYMBOLS_BY_METRIC,
+    )
+    codes = {m.id: m.sms_code for m in _METRICS}
+    ids = set(SMS_SYMBOL_BY_METRIC) | set(SMS_MULTI_SYMBOLS_BY_METRIC)
+    kuerzel = {mid: _kurzform_kuerzel(mid, codes[mid]) for mid in ids}
+    return {mid: k for mid, k in kuerzel.items() if k}
+
+
+def test_trip_sms_kuerzel_bezeichnen_je_genau_eine_groesse():
+    """AC-1(b), Trip-SMS-Weg."""
+    from tests.helpers.metrik_listen_scan import finde_kuerzel_kollisionen
+
+    kuerzel = _kuerzel_trip_sms_weg()
+    assert len(kuerzel) >= 20, (
+        f"Nur {len(kuerzel)} Kuerzel geprueft — zu wenig, die Pruefung misst "
+        f"nichts. Gemessen zum Stand der Spec: 26. {kuerzel!r}"
+    )
+    assert kuerzel.get("thunder") == "TH", (
+        "Fuer `thunder` steht nicht genau ein Kuerzel — vermutlich wurde nach "
+        f"Kuerzel-Wert statt nach Metrik-Kennung gruppiert: {kuerzel!r}"
+    )
+
+    kollisionen = finde_kuerzel_kollisionen(kuerzel)
+    assert kollisionen == [], (
+        "Ein Kuerzel der Trip-Kurzform bezeichnet zwei verschiedene "
+        "Wettergroessen:\n" + "\n".join(kollisionen)
+    )
+
+
+def test_register_kuerzel_bezeichnen_je_genau_eine_groesse():
+    """AC-1(b), Register-Weg (Vergleichs-SMS, Alarm-SMS)."""
+    from app.metric_catalog import _METRICS
+    from tests.helpers.metrik_listen_scan import finde_kuerzel_kollisionen
+
+    kuerzel = {m.id: m.sms_code for m in _METRICS if m.sms_code}
+    assert len(kuerzel) >= 25, (
+        f"Nur {len(kuerzel)} Register-Kuerzel geprueft — zu wenig. Gemessen "
+        f"zum Stand der Spec: 27 von 28 Groessen ({kuerzel!r})"
+    )
+
+    kollisionen = finde_kuerzel_kollisionen(kuerzel)
+    assert kollisionen == [], (
+        "Ein Register-Kuerzel (`sms_code`) bezeichnet zwei verschiedene "
+        "Wettergroessen:\n" + "\n".join(kollisionen)
+    )
+
+
+def test_kollisionspruefung_beisst_zu_und_ueberspringt_leere_kuerzel():
+    """Wirksamkeitsnachweis fuer AC-1: beide Pruefungen oben sind heute gruen
+    (0 Kollisionen) — ohne diesen Fall belegten sie nur, dass sie durchlaufen.
+
+    Zugleich der gemessene zweite Fallstrick: `confidence` fuehrt einen LEEREN
+    `sms_code` (selectable=False, PO-Entscheid #710). Leere Kuerzel duerfen
+    nicht gruppiert werden, sonst meldet der Waechter zwei Luecken als
+    Doppelvergabe, sobald eine zweite kuerzellose Groesse hinzukommt.
+    """
+    from tests.helpers.metrik_listen_scan import finde_kuerzel_kollisionen
+
+    befunde = finde_kuerzel_kollisionen({
+        "erfundene_groesse_a": "XY",
+        "erfundene_groesse_b": "XY",
+        "erfundene_groesse_c": "YZ",
+        "ohne_kuerzel_eins": "",
+        "ohne_kuerzel_zwei": "",
+    })
+    text = "\n".join(befunde)
+
+    assert len(befunde) == 1, (
+        f"Erwartet genau eine gemeldete Doppelvergabe, bekommen: {befunde!r}"
+    )
+    for kennung in ("erfundene_groesse_a", "erfundene_groesse_b"):
+        assert kennung in text, (
+            f"Die Doppelvergabe von 'XY' nennt {kennung!r} nicht: {text!r}"
+        )
+    for unbeteiligt in ("erfundene_groesse_c", "ohne_kuerzel_eins",
+                        "ohne_kuerzel_zwei"):
+        assert unbeteiligt not in text, (
+            f"{unbeteiligt!r} ist keine Kollision, wird aber gemeldet: {text!r}"
+        )


### PR DESCRIPTION
Setzt **Etappe E7 von #1435** um — die Ratsche, die im Epic-Zielbild seit dem 31.07. beschrieben, aber nie gebaut wurde. E1 bis E5 sind live, das hier war der unerledigte Rest.

> „Keine Liste darf ein eigenes Vokabular erfinden. Jede Liste, die etwas je Wettergröße festlegt, wird mit der Register-Kennung geschlüsselt, und ein Wächter meldet jede Kennung, die das Register nicht kennt — beim Namen."

## Was der Wächter tut

**Zwei Stufen, die bewusst nicht voneinander abhängen.**

Die **Entdeckung** durchsucht `src/` und `api/` nach Sammlungen (`dict`/`set`/`list`/`tuple`), deren sämtliche konstanten Strings Register-Kennungen sind. Ist eine davon nicht registriert, wird der Wächter rot und nennt Datei, Zeile und Namen.

Die **Gültigkeitsprüfung** deckt 42 Registrierungen in 12 Dateien ab: Jede Kennung muss in `_METRICS` stehen. Sie hängt ausdrücklich **nicht** an der Quote aus Stufe 1 — sonst kippt ein Tippfehler die Liste aus der eigenen Prüfmenge, und der Wächter schwiege genau dort, wo er greifen soll.

## Erster Fang — noch vor dem Merge

Nach dem Rebase auf `origin/main` wurde der Wächter rot. **#1728 S1** (`c18f8eb7`) hatte vier neue wählbare Größen eingeführt (`temperature_day_low/high`, `wind_chill_day_low/high`; Register 28 → 32) und dabei drei Listen angelegt, die niemand nachgezogen hat:

| Fundstelle | Liste |
|---|---|
| `src/app/loader.py:759/760` | `_DERIVED_METRIC_RULES[0]` und `[1]` |
| `src/output/renderers/channel_layout.py:75` | `VISIBILITY_GATE_IDS` (die umbenannte, von 2 auf 6 gewachsene `_NIGHT_SCALAR_IDS`) |

Zusätzlich fehlen die vier neuen Größen in `METRIC_PRIORITY` — **derselbe Befund wie bei `temperature_night`/`wind_chill_night`**, nur wenige Stunden alt statt Monate. Alle drei Listen sind jetzt registriert, die vier Größen stehen mit Ticket-Bezug in der Ausnahmeliste. Behoben wird das in **E6**, wie für alle Funde dieser Etappe vereinbart.

## Adversary: drei Runden, zwei echte Befunde

Zehn gezielte Mutationen, acht sofort gefangen, **zwei nicht**:

- **F001 (HIGH)** — die Stufen-Trennung war für 39 von 40 Listen unbewacht. Der Mutationsnachweis lief über `METRIC_PRIORITY`, ausgerechnet den einen Eintrag, der `_literal()` gar nicht durchläuft. Baute man die verbotene Kopplung ein, blieben **alle 63 Tests grün**. Der neue Test legt eine Wegwerf-Liste mit Quote 2/3 an — Stufe 1 findet sie also **nicht**, was der Test ausdrücklich zusichert — und verlangt, dass Stufe 2 den Tippfehler trotzdem meldet.
- **F002** — `_ort_passt()` war ungetestet, obwohl `models.py` real zweimal unter `src/` liegt.

Die Nachkontrolle fuhr dieselben Mutationen erneut: beide jetzt gefangen. Die Kernfunktionen sind über alle drei Runden **byte-identisch**, über die gesamte Historie **0 gelöschte Zeilen**. Verdict **VERIFIED**.

## Eine Lücke, die erst #1728 sichtbar machte

`HOURLY_EXCLUSION_REASON` liest jetzt das Laufzeitobjekt statt des Literals. Vier der sieben Schlüssel trägt #1728 per Schleife nach; der literale Scan sah sie nicht. A/B gemessen mit einem Tippfehler ausschließlich in der nachgetragenen Zeile:

```
ALT (Literal):   sieht 3 Kennungen  →  0 Befunde   ← Tippfehler entkommt
NEU (Laufzeit):  sieht 7 Kennungen  →  1 Befund
```

Die alte Mechanik war dort nicht ungenau, sondern **stumm**. Ein zusätzlicher Test hält das gegen stilles Zurückdrehen fest.

## Bewusste Grenzen

Benannt statt wegdefiniert, alle im Docstring und in der Spec:

- `if metric_id in (…)`-Ketten und dict-Comprehensions werden nicht erfasst. Die vier Sammlungsformen sind eine geschlossene Menge, Fallunterscheidungen sind es nicht — wer sie mitnimmt, landet in der Aufzählungsfalle.
- Eigenschaftslisten in Datensatz-Form (`[{"id": …, "field": …}]`) bleiben unsichtbar.
- 40 von 42 Registrierungen lesen weiterhin Literale. Laufzeit-Lesen setzt Importierbarkeit voraus — die haben die Wegwerf-Module der Wirksamkeitsnachweise gerade nicht.
- Fünf `in`-Vergleiche werden **strukturell ausgeschlossen**: Ein Tupel rechts von `in` ordnet nichts zu, es prüft Zugehörigkeit. Sonst bräuchten fünf harmlose Stellen eine Ausnahme, und eine Ausnahmeliste aus Rauschen entwertet die echten Einträge.

## Zwei Punkte für E6 und #1728

1. **Die `auto_distribute`-Frage.** #1728 hält die `METRIC_PRIORITY`-Lücke für folgenlos, weil `VISIBILITY_GATE_IDS` in `render_for_channel` filtert. `auto_distribute` filtert **nicht** (`channel_layout.py:143`, `METRIC_PRIORITY.get(pair[1], 0)`), und `loader._parse_display_config` ruft genau die auf. Ob die Lücke wirkt, ist damit offen — die Ausnahme-Begründung sagt deshalb „Bewertung offen, entschieden wird in E6" statt eine Richtung zu behaupten.
2. **Doku-Nachlauf:** `docs/reference/metric_output_matrix.md` nennt an zwei Stellen den alten Namen `_NIGHT_SCALAR_IDS` mit veralteter Zeilennummer. Nicht in diesem PR korrigiert — die Datei ist vom Datei-Claim-Gate für die #1728-Session gesperrt.

## Umfang

**Kein Produktivcode.** Eine neue Hilfsdatei (`tests/helpers/metrik_listen_scan.py`, 459 Zeilen), eine neue Testdatei (492), die bestehende E3b-Ratsche um 112 Zeilen erweitert bei **0 gelöschten** (AC-7). Test-Budget nach PO-Freigabe 1090.

68 Tests grün, 1375 `tests/unit` grün mit Egress-Sperre.

**Regel-Budget:** Prüfdatum 2026-11-15. Fang-Kriterium bereits bei Einführung erfüllt — siehe „Erster Fang".

Bezug: #1435 (Epic) · Anlass aus #1680 S5b · Fund betrifft #1728 S1 · Behebung folgt in E6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TV7pMEHLUFMF7hnue9izr1
