### PR TITLE
fix(#1709): Messwerkzeug + zweite Fundregel gegen indirekte Wanduhr-Abhaengigkeit

### DIFF
--- a/docs/context/fix-1709-wallclock-ratsche-indirekt.md
+++ b/docs/context/fix-1709-wallclock-ratsche-indirekt.md
@@ -1,0 +1,322 @@
+# Context: fix-1709-wallclock-ratsche-indirekt
+
+**Issue:** [#1709](https://github.com/henemm/gregor_zwanzig/issues/1709) — „Eine Nacht darf die CI nie blockieren: Wallclock-Ratsche fängt die indirekte Zeitabhängigkeit nicht"
+**Workflow:** `fix-1709-wallclock-ratsche-indirekt` · Track: Full Process
+**Erstellt:** 2026-08-15 · HEAD bei der Messung: `b6674c94`
+
+## Request Summary
+
+Die bestehende Wächter-Ratsche `tests/tdd/test_fixture_wallclock_ratchet.py` fängt nur eine
+Variante der Wanduhr-Abhängigkeit in Testfixtures. Die Variante, die am 2026-08-10 drei
+Sitzungen einen Abend gekostet hat, ist ihr **logisches Gegenteil** und deshalb strukturell
+unsichtbar. Gesucht ist ein Wächter, der die Fehlerklasse fängt — nicht ein weiterer Einzelfix.
+
+## Ausgangslage: die Einzelfälle sind zu, die Klasse ist offen
+
+| Issue | Stand | Was es war |
+|---|---|---|
+| #1667 (S1–S3) | ✅ zu | Mitternachts-Wrap; S1 baute die bestehende Ratsche |
+| #1697 (PR #1705) | ✅ zu | Ortstag statt Serverdatum; härtete `stage_date()` |
+| #1851 | ✅ zu | Briefing-Vorlaufsperre traf drei Alarm-Tests |
+| #1858 | ✅ zu | dieselbe Sperre traf die Wächter von #1584/#1667 |
+| **#1709** | **offen** | **die Klasse hinter allen vieren** |
+
+Belegungsprüfung 2026-08-15: kein Branch, kein Worktree, kein Commit zu `1709`; die
+Ratschen-Datei ist seit `70faaa62` (#1667 S1) unberührt. `fix_1851_alarm_tests_vorlaufsperre.md`
+benennt unter „Known Limitations" ausdrücklich, dass die Wanduhr-Familie #1709 unberührt bleibt.
+
+## Warum die bestehende Ratsche diese Variante nicht sehen KANN
+
+`test_fixture_wallclock_ratchet.py:474` meldet einen Fund nur, wenn **beide** Merkmale
+zugleich auftreten (Docstring Z. 36–46):
+
+1. Wanduhr-Etappendatum (`now.date()`, `date.today()`, `stage_date()`), **und**
+2. ungeklemmte Ankunftszeit — ein `(now ± timedelta).strftime("%H:%M")`.
+
+Der Fall aus #1709 hat Merkmal 1 und ist **gerade durch das Fehlen von Merkmal 2** gefährlich:
+ohne gesetzte Ankunftszeiten greift der Naismith-Standardstart, das Ziel-Segment endet am
+Tagesfenster-Ende, und ab einer bestimmten Uhrzeit ist es „vorbei". Das ist kein Sonderfall,
+den der Scanner übersieht — es ist die Negation seiner Fundbedingung.
+
+**Konsequenz für die Lösung:** eine Erweiterung der bestehenden Fundbedingung um ein weiteres
+UND-Glied genügt nicht. Es braucht eine zweite, eigenständige Fundregel.
+
+## Die Ursachenkette, am Code nachgemessen
+
+Zeilenangaben im Issue-Text stimmen nicht mehr (Code ist gewandert). Hier der Stand bei `b6674c94`,
+selbst nachgemessen — nicht aus dem Ticket übernommen:
+
+1. `src/app/day_window.py:16-17` — `DAY_WINDOW_START_HOUR = 4`, `DAY_WINDOW_END_HOUR = 19`.
+2. `src/services/trip_segments.py:265-278` — das **Ziel-Segment** endet bei
+   `combine(arrival_local_date, time(end_hour))` in der **Ortszone des Ziels**
+   (`tz_for_coords(last_wp.lat, last_wp.lon)`), umgerechnet nach UTC.
+3. `src/services/trip_alert.py:1244-1245` — `if cached.segment.end_time < now_utc: continue`
+   („Bereits absolviert — überspringen").
+4. `src/services/trip_alert.py:1411` — zweite Stelle, dieselbe Regel („Etappe vorbei").
+
+Bei den im Bestand dominierenden Fixture-Koordinaten `47.0 / 11.0` (Europe/Vienna, im Sommer
+UTC+2) ist `19:00` Ortszeit **exakt 17:00 UTC**. Ab da filtern (3) und (4) jedes Segment weg,
+und der Alarmpfad meldet völlig korrekt „No fresh weather data". Die Kippkante aus dem Issue
+ist damit bestätigt; nur ihre Fundstellen sind andere.
+
+Ein **zweiter** Filter in derselben Schleife (`trip_alert.py:1246-1247`) vergleicht
+`cached.segment.start_time.date() > today_utc` — ein **UTC**-Kalendertagsvergleich, also eine
+weitere, unabhängige Kippkante an UTC-Mitternacht.
+
+## Die Kippkanten-Landschaft (Vermessung durch Explore-Agent, Korrekturen eingearbeitet)
+
+| # | Familie | Ort | Schwelle | Zone |
+|---|---|---|---|---|
+| 1 | Tagesfenster → Ziel-Segment-Ende | `trip_segments.py:265-289` | `end_hour` (19), sonst 1-h-Notfenster | **Ortszeit des Ziels** |
+| 2 | Mitternachts-Wrap (Interpolation) | `trip_segments.py:85-98` | `if nxt < base: nxt += 1 Tag` | naiv/Ortszeit |
+| 3 | Briefing-Vorlaufsperre **Trip** | `trip_report_scheduler.py:189` | `stunde <= h < stunde+3`, Default 7 / 18 | **Ortszeit des Trips** |
+| 3b | Vorlauf-Abtastung | `alert_gate.py:64,74,86` | 60 min Vorlauf, 5-min-Raster, 4 h Rückblick | übergebene Zone |
+| 3c | Briefing-Fälligkeit **Compare** | `compare_slot_scheduler.py:142,166-171` | **Stundengleichheit**, Default **6** / 18 | Ortszeit des ersten Orts |
+| 4 | Ruhezeit (Quiet Hours) | `deviation_alert_engine.py:106-139` | nutzergesetzt; Default `None` | Ortszeit |
+| 5 | Tageszähler-Reset | `alert_daily_limit.py:39-40,64-65` | Ortsmitternacht | Ortszeit |
+| 6 | Nowcast-Horizont | `trip_alert.py:~945` | `minutes_until_start > 60` | UTC |
+
+**Zwei Korrekturen an meiner eigenen Vorannahme** (beide am Code belegt, nicht hergeleitet):
+
+- Die 23:59-Klemme in `src/core/naismith.py` **existiert nicht mehr** — seit #1667 S2 rechnet
+  `_format_hhmm()` (Z. 54-73) mit `total_min % (24*60)`. Wer sie noch als Ursache nennt,
+  beschreibt einen Stand von vor #1667 S2.
+- Familie 3 hat **zwei** Ausprägungen mit **verschiedenen Schwellenformen und verschiedenen
+  Vorgabezeiten**: Trip = 3-Stunden-Fenster ab 7/18 Uhr, Compare = Stundengleichheit ab
+  **6**/18 Uhr. Ein Wächter, der nur den Trip-Fall kennt, sieht die Compare-Variante nicht —
+  und zwischen 6:00 und 6:59 Ortszeit greift ausschließlich die Compare-Variante.
+
+## Der entscheidende Befund: das Härtungs-Kit existiert bereits
+
+Das ist die wichtigste Erkenntnis dieser Phase und verschiebt den Zuschnitt der Arbeit.
+Für **jede** der drei tragenden Kippkanten liegt bereits ein erprobter Baustein im Repo:
+
+| Kippkante | Baustein | Wirkung |
+|---|---|---|
+| 1 (Tagesfenster) | `tests/helpers/arrival_window_fixtures.py` → `active_window_offsets(lat, lon, …)` | Ankunftszeiten liegen im aktiven Fenster, monoton, auf dem Etappentag |
+| 2 (Ortstag ≠ Serverdatum) | dieselbe Datei → `stage_date(lat, lon)` | Etappendatum = **Ortstag**, dieselbe Formel wie der Prüfling (#1697/ADR-0044) |
+| 3 (Vorlaufsperre) | `tests/helpers/briefing_zeiten.py` → `briefing_zeiten_fuer_trip(trip)` | Briefingzeiten relativ zur **echten** Uhr, immer außerhalb des Vorlaufs |
+| alle | Koordinaten `64.13 / -21.90` (`Atlantic/Reykjavik`, ganzjährig UTC+0) | Ortstag ≡ UTC-Tag, keine Sommerzeit |
+
+Die vollständig gehärtete Zielform steht in
+`tests/tdd/test_briefing_anchor_survives_dispatch_failure.py:178-205` — inklusive eines
+Kommentars, der die Fehlerklasse benennt („sonst greift ab ~17:00 UTC der Naismith-Default
+08:00 und das Ziel-Segment endet am Tagesfenster-Ende (19:00 Ortszeit) VOR dem Testlauf").
+
+`briefing_zeiten.py` enthält zusätzlich die für diesen Workflow zentrale Regel im Klartext:
+die Zone MUSS die sein, in der der **Prüfling** die Fälligkeit auswertet — „eine andere Zone
+wäre eine Zusicherung am falschen Ort: die Stunde sähe sicher aus und läge trotzdem im Fenster."
+
+**Damit ist die Aufgabe nicht „eine Härtung erfinden", sondern „die vorhandene Härtung dort
+erzwingen, wo sie nötig ist".** Das ist eine deutlich andere — und besser belegbare — Arbeit
+als das Ticket vom 2026-08-10 annehmen konnte.
+
+## Bestandsvermessung (selbst ausgezählt, mechanisch)
+
+AST-/Textlauf über `tests/**/*.py` bei `b6674c94`:
+
+| Menge | Anzahl |
+|---|---|
+| Testdateien, die eine Etappe/Wegpunkte bauen **und** Wanduhr-Bezug haben | **151** |
+| davon ohne **beide** Härtungs-Helfer | **128** |
+| davon zusätzlich ohne **jede** Ankunftszeit (`arrival_calculated`/`arrival_override`) | **107** |
+| Dateien, die `arrival_window_fixtures` nutzen | 15 |
+| Dateien, die `briefing_zeiten` nutzen | 15 |
+| Dateien mit beiden | 3 |
+| Dateien mit UTC+0-Koordinate `64.13` | 3 |
+| Dateien mit Alpen-Koordinaten (`47.0/11.0` bzw. `ALPEN_LAT`) | 124 |
+
+🔴 **107 ist eine obere Schranke, keine Fundmenge.** Die Klasse beißt nur, wenn der *Prüfling*
+eine Tageszeit-Grenze auswertet. Ein reiner Renderer- oder Telegram-Formatierungstest baut
+dieselbe Fixture, läuft aber nie durch `trip_alert.py`. Wer 107 als „betroffen" meldet, wiederholt
+denselben Fehler wie die widerlegten Erklärungen in der Ticket-Historie.
+
+## Die Messmethode (der eigentliche Knackpunkt)
+
+Ob eine Datei betroffen ist, lässt sich **nicht durch Lesen** entscheiden — die
+Zeitabhängigkeit entsteht erst im Prüfling. Sie lässt sich aber **messen**: dieselbe Datei zu
+zwei künstlich verschiedenen Uhrzeiten laufen lassen und die Ergebnisse vergleichen. Nur die
+**Differenz je Uhrzeit** ist der Befund; ein einzelner roter Lauf beweist nichts.
+
+- `freezegun` ist bereits Dev-Dependency (`pyproject.toml:89`), 16 Testdateien nutzen es.
+- Für einen Massenlauf braucht es ein sitzungsweites Einfrieren per Pytest-Plugin
+  (`-p <modul>`), da die Bestandsdateien selbst keine Test-Uhr stellen.
+- Uhrzeiten müssen **beide Seiten jeder Kippkante** treffen: mindestens eine vor 17:00 UTC und
+  eine danach; für Familie 3 zusätzlich je eine in `[7,10)` und `[18,21)` **Ortszeit der
+  Fixture** — nicht UTC. Wer die Uhrzeiten in UTC notiert, sucht bei fremder Zone falsch.
+
+Ein Versuch, dieses Mess-Plugin schon in Phase 1 anzulegen, wurde vom `edit_gate` blockiert
+(korrekt: `phase1_context` erlaubt keine Code-Änderungen). Es gehört in die Implementierungsphase.
+
+## Bauart-Vorgaben für die neue Ratsche
+
+Aus der Untersuchung der drei bestehenden AST-Ratschen (`test_fixture_wallclock_ratchet.py`,
+`test_repo_path_hardcoding_ratchet.py`, `test_data_root_hardcoding_ratchet.py`):
+
+- **Ablage:** `tests/tdd/`. **Nicht** in `.github/ci_tdd_excludes.txt` eintragen — sonst läuft
+  sie nicht auf CI. Beide großen Ratschen laufen heute im `test`-Job mit.
+- **Fixture-Vorlagen extern:** `tests/fixtures/ratchet_cases/*.py.txt`, außerhalb der
+  Scanfläche `tests/**/*.py` — sonst meldet der Wächter seine eigenen Attrappen.
+- **Selbstbeleg:** pro erkanntem Anti-Muster ein Positiv-Test (Scanner meldet) **und** eine
+  Gegenprobe (Scanner schweigt beim korrekten Muster), beide gegen echte Dateien auf `tmp_path`.
+  Vorbild `test_ac3_echter_testbaum_ohne_fehlalarm` verlangt zusätzlich `len(kandidaten) >= 20`,
+  damit ein leerer Scan nicht durch fehlende Kandidaten vorgetäuscht werden kann.
+- **Ausnahmen:** zwei etablierte Mechaniken — `KNOWN_VIOLATIONS`-Frozenset mit
+  Begründungskommentar und Shrink-Gegentest (wenige, strukturell zwingende Fälle) **oder**
+  Inline-Marker `# gz-…: <Begründung>` mit `_MIN_BEGRUENDUNG = 15` sinnvollen Zeichen (viele
+  verstreute Fälle). Beide sind Ausnahmen **vom Fund**, keine Erlaubnislisten.
+- **Regel-Budget:** `EXPIRY`-Konstante **und** ein Test, der das ISO-Datum als Text in der
+  eigenen Datei erzwingt. Prüfdatum laut Ticket: **2026-11-10**.
+
+🔴 Die bestehende Ratsche benennt eine Grenze, die auch für die neue gilt und nicht
+wegprogrammierbar ist (Z. 172-177): *„Der Shrink-Wächter fängt nur VERALTETE Einträge, nicht
+neue unbegründete: eine Ausnahmeliste kann sich strukturell nicht selbst gegen Zuwachs
+schützen."*
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `tests/tdd/test_fixture_wallclock_ratchet.py` | Der zu erweiternde Wächter (672 Z.) |
+| `tests/helpers/arrival_window_fixtures.py` | Härtungs-Kit Kippkante 1+2 |
+| `tests/helpers/briefing_zeiten.py` | Härtungs-Kit Kippkante 3 |
+| `tests/helpers/briefing_imminent_fixtures.py` | Vollständig gehärtete Referenz-Bauart (#1594) |
+| `tests/tdd/test_briefing_anchor_survives_dispatch_failure.py:178-205` | Zielform einer Fixture |
+| `src/services/trip_segments.py:265-289` | Ziel-Segment-Ende (Kippkante 1) |
+| `src/services/trip_alert.py:1244-1247, 1411` | Die beiden „Segment vorbei"-Filter |
+| `src/services/trip_report_scheduler.py:189` | Vorlaufsperre Trip |
+| `src/services/compare_slot_scheduler.py:142,166-171` | Vorlauf-Fälligkeit Compare (anderer Default!) |
+| `tests/fixtures/ratchet_cases/wallclock_arrival_faelle.py.txt` | Attrappen-Vorlagen |
+| `.github/ci_tdd_excludes.txt` | Darf **nicht** wachsen |
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1667_s1_fixture_wanduhr.md` — Spec der bestehenden Ratsche
+- `docs/specs/modules/fix_1697_ortstag_statt_servertag.md` — Ortstag-Härtung
+- `docs/specs/modules/fix_1851_alarm_tests_vorlaufsperre.md` — jüngster Einzelfall
+- `docs/specs/modules/fix_1594_alarm_vorlauf_sperre.md` — die Sperre selbst
+- ADR-0044 (Ortstag), ADR-0035 (Tagesfenster-Quelle), ADR-0009 (ersetzen statt verschlucken)
+
+## Risks & Considerations
+
+- **R1 — Falsch-positive Ratsche blockiert alles.** Das Ticket ist als „fälschlich
+  blockierendes Gate" eingestuft; eine zu weite Fundregel erzeugt genau dasselbe Übel mit
+  umgekehrtem Vorzeichen. Die Gegenprobe gegen den echten Testbaum ist deshalb Pflicht-AC,
+  nicht Kür.
+- **R2 — „Prüfling wertet Tageszeit aus" ist syntaktisch nicht entscheidbar.** Das Ticket
+  räumt das ein und erlaubt einen begründeten Ansatzwechsel. Wahrscheinlichster Weg:
+  Fundregel an der **Fixture-Bauart** festmachen (baut Etappe + nutzt keinen Härtungs-Baustein
+  + Ort nicht UTC+0), nicht am Prüfling.
+- **R3 — Zwei Vorlauf-Varianten.** Trip ≠ Compare (3-h-Fenster vs. Stundengleichheit, 7 vs. 6
+  Uhr). Ein Wächter, der nur eine kennt, lässt die andere durch.
+- **R4 — Der Wächter bewacht Tests, nicht das Produkt.** Dieselbe Warnung wie bei #1667 S1:
+  aus „die Ratsche ist grün" folgt nichts über die Zuverlässigkeit der Alarme.
+- **R5 — Bestandssanierung sprengt das LoC-Budget.** 107 Kandidatendateien lassen sich nicht in
+  einem Workflow umstellen (250 Prod / 500 Test). Zuschnitt in Scheiben ist wahrscheinlich
+  nötig; Reihenfolge und Abbruchgrenze gehören in die Spec.
+- **R6 — Testpfade sind hart verdrahtet** in `.github/ci_tdd_excludes.txt`, Collection-Meta-Tests
+  und den Ratschen. Massen-Umbenennung ist untersagt (Tech-Lead-Entscheid 2026-08-08); Härtung
+  darf Dateinamen nicht anfassen.
+
+## Analysis (Phase 2)
+
+### Type
+
+Bug (Label `bug`, `priority:high`, `session:khw`) — Fehlerklasse, nicht Einzelfall.
+
+### Die Bestandsmenge wurde gemessen, nicht geschätzt
+
+Messaufbau: `freezegun` stellt die Uhr, **ein frischer Prozess je Datenpunkt**, Testdateien
+namentlich benannt, `--allow-hosts=127.0.0.1,::1`. Befund ist immer nur die **Differenz**
+zwischen zwei Uhrzeiten — ein einzelner roter Lauf zählt nicht.
+
+| Menge | Uhrzeiten | Differenz |
+|---|---|---|
+| 69 Dateien: Etappe + Wanduhr + Alarmpfad, **ohne** Ankunftszeiten, **ohne** Härtungs-Helfer | 06:00 / 10:00 / 18:00 / 22:30 UTC | **0** |
+| 100 Dateien: Etappe + Wanduhr + Alarmpfad, **ohne** `briefing_zeiten`-Helfer | 06:00 / 12:00 UTC | **1** |
+
+🔴 **Das Ergebnis widerlegt die Arbeitsannahme des Tickets.** Die obere Schranke von 107
+Kandidaten enthält **einen** tatsächlich zeitabhängigen Testfall. Die frühere Vermutung, es
+liege ein großer sanierungsbedürftiger Bestand vor, ist damit gemessen und falsch: die
+betroffenen Dateien wurden von #1667 S1, #1697, #1851 und #1858 bereits gehärtet. **Eine
+Massensanierung ist nicht nötig** — Risiko R5 aus Phase 1 entfällt.
+
+### Der eine verbliebene Fund — reproduzierbar, auf heutigem `main`
+
+`tests/unit/test_alarm_zeitfenster_ziel.py::test_radarpfad_spaetankunft_faellt_nicht_in_alle_segmente_vorbei`
+
+| Uhrzeit (UTC) | 00 | 02 | 03 | **04** | **05** | **06** | 07 | 08 | 10–22 |
+|---|---|---|---|---|---|---|---|---|---|
+| Ergebnis | grün | grün | grün | **rot** | **rot** | **rot** | grün | grün | grün |
+
+Je zwei Läufe pro Datenpunkt, deterministisch. Fehlerbild: `assert []` — „F003: Bei
+Spätankunft muss der Radar-Pfad einen Alarm zustellen." Protokollzeile des Prüflings:
+`Ziel-Segment: Ankunft 2026-08-16T02:27:00+00:00 liegt nach dem Tagesfenster-Ende (2:00
+Ortszeit) — minimales Fenster von 1 h wird verwendet`.
+
+Der Mechanismus ist **nicht** die Vorlaufsperre aus #1851, sondern die Ortswahl-Kompensation
+der Fixture selbst (`_radar_mails_fuer_spaetankunft`, steht als einer von zwei Einträgen in
+`KNOWN_VIOLATIONS` der bestehenden Ratsche): sie setzt `day_window_end_hour` auf die
+Ankunftsstunde, wodurch das Fensterende vor der Ankunft liegt, der Randfall-Guard greift und das
+Ziel-Segment in einem 3-Stunden-Band nicht mehr als aktiv gilt.
+
+**Unabhängige Bestätigung aus der Wirklichkeit:** die Beweistabelle in
+`fix_1851_alarm_tests_vorlaufsperre.md` verzeichnet einen echten roten CI-Lauf am
+**2026-08-15 um 05:29 UTC** — mitten im hier gemessenen Band. Die Messung stützt sich also nicht
+allein auf `freezegun`.
+
+🔴 **Und sie belegt die These des Tickets an einem konkreten Fall:** #1851 hat für diese Datei
+AC-1 formuliert („alle 12 Testfälle grün, unabhängig von der realen Wanduhrzeit") und
+ausdrücklich begründet, ein einziger Lauf genüge als Nachweis, „es gibt keine Kippkante mehr".
+Für elf Fälle stimmt das; für den zwölften ist es messbar falsch. Genau davor warnt #1709:
+*„Ein einzelner grüner Lauf um 10:00 UTC beweist hier nichts."*
+
+### Drei Fallen im Messaufbau (selbst hineingelaufen, deshalb dokumentiert)
+
+1. **Ein Prozess für mehrere Messpunkte ist ungültig.** 24 aufeinanderfolgende `pytest.main()`
+   im selben Prozess ergaben eine Matrix (rot 02–04 Uhr), die sich bei frischen Prozessen nicht
+   reproduzieren ließ (rot 04–06 Uhr). Zustand sickert zwischen Läufen durch. Jeder Datenpunkt
+   braucht einen eigenen Prozess.
+2. **Sitzungsweites `freezegun` zerstört pydantic-v1-Importe** (`TypeError: metaclass conflict`
+   in `pydantic/v1/types.py:1180`). Das erzeugt 9 Falsch-Positive, die wie Zeitabhängigkeit
+   aussehen. `extend_ignore_list=['pydantic']` behebt es nicht. Nur die **Differenz** zweier
+   Läufe ist deshalb auswertbar, nie eine absolute Fehlerzahl.
+3. **Sammelläufe verdecken die Ursache.** Im 100-Dateien-Batch war der Fund um 06:00 rot; einzeln
+   gemessen liegt seine Kante bei 04–06 Uhr. Batch-Ergebnisse taugen zum Eingrenzen, nicht zum
+   Belegen — die Kante gehört einzeln nachgemessen.
+
+### Technischer Ansatz (Empfehlung)
+
+**Zwei Bestandteile, ein Workflow:**
+
+1. **Der Fund wird behoben** — die Fixture `_radar_mails_fuer_spaetankunft` kommt aus
+   `KNOWN_VIOLATIONS` heraus oder wird so umgebaut, dass ihre Zusicherung erhalten bleibt und
+   das Band 04–06 UTC verschwindet. Das ist der Fang-Beleg, ohne den die neue Regel nach dem
+   Regel-Budget am Prüfdatum zurückgebaut werden müsste.
+2. **Die Ratsche bekommt eine zweite, eigenständige Fundregel** an der **Fixture-Bauart**
+   festgemacht (statisch entscheidbar), nicht am Prüfling (nicht entscheidbar): baut eine
+   Etappe aus einem Wanduhr-Datum **und** nutzt weder ein Härtungs-Helferlein noch eine
+   UTC+0-Koordinate **und** liegt in einer Datei, die den Alarmpfad importiert.
+3. **Das Messwerkzeug wird versioniert**, nicht weggeworfen — sonst ist der Nachweis „zu zwei
+   Uhrzeiten gleich" bei der nächsten Änderung wieder Handarbeit. Es ist zugleich die einzige
+   Form, in der die *indirekte* Variante überhaupt beweisbar ist.
+
+**Verworfen:** eine Fundregel, die versucht zu erkennen, ob der Prüfling eine Tageszeit-Grenze
+auswertet. Das ist syntaktisch nicht entscheidbar (das Ticket räumt es ein) und würde bei acht
+gemessenen Kippkanten-Familien in verschiedenen Modulen zu einer Regel führen, die entweder
+alles oder nichts meldet.
+
+### Scope Assessment
+
+- Dateien: ~4 (Ratsche, Attrappen-Vorlage, Messwerkzeug, die eine Fixture)
+- Geschätzte LoC: Produktiv +0 / Test ca. +250
+- Risiko: **MEDIUM** — kein Produktivcode berührt; Hauptrisiko ist eine zu weite Fundregel (R1)
+
+### Offene Frage für die Spec
+
+Der gemessene Fund liegt in einer Fixture, die **bewusst** in `KNOWN_VIOLATIONS` steht, mit
+ausführlicher Begründung und einem eigenen 1440-Minuten-Wächter
+(`test_radar_fixture_ist_zu_jeder_tageszeit_kein_mitternachtsfenster`). Dieser Wächter ist grün
+und der Test trotzdem in einem 3-Stunden-Band rot — er bewacht also eine andere Eigenschaft als
+die, auf die es ankommt. Die Spec muss entscheiden, ob die Fixture umgebaut oder der
+1440-Minuten-Wächter auf die richtige Eigenschaft umgestellt wird.

--- a/docs/specs/modules/fix_1709_wallclock_ratsche_indirekt.md
+++ b/docs/specs/modules/fix_1709_wallclock_ratsche_indirekt.md
@@ -1,0 +1,284 @@
+---
+entity_id: fix_1709_wallclock_ratsche_indirekt
+type: bugfix
+created: 2026-08-15
+updated: 2026-08-15
+status: draft
+workflow: fix-1709-wallclock-ratsche-indirekt
+version: "1.0"
+tags: [issue-1709, tests, fixtures, ratsche, wanduhr, ci-ampel, freezegun]
+---
+
+# Indirekte Wanduhr-Abhängigkeit: messbar machen und dauerhaft bewachen
+
+## Approval
+
+- [x] Approved — PO „freigabe" 2026-08-15
+
+## Purpose
+
+Die bestehende Ratsche `tests/tdd/test_fixture_wallclock_ratchet.py` meldet einen Fund nur,
+wenn eine Fixture **beides** tut: das Etappendatum aus der Wanduhr bilden **und** eine
+ungeklemmte Ankunftszeit aus `(now ± timedelta).strftime("%H:%M")` setzen. Die Variante, die
+am 2026-08-10 drei Sitzungen einen Abend gekostet hat, ist das **logische Gegenteil**: sie
+setzt gar keine Ankunftszeiten, wodurch der Prüfling eine Tageszeit-Grenze selbst berechnet.
+Diese Variante kann der bestehende Scanner strukturell nicht sehen.
+
+Diese Spec liefert zwei Dinge, die zusammengehören: ein **versioniertes Messwerkzeug**, mit
+dem sich indirekte Zeitabhängigkeit überhaupt erst beweisen lässt, und eine **zweite,
+eigenständige Fundregel** in der Ratsche, die neue Fixtures dieser Bauart beim Commit stoppt.
+
+> **Schicht-Hinweis:** Ausschließlich Testinfrastruktur (`tests/`). **Kein** Eingriff in
+> `src/`, `api/`, `internal/`, `frontend/`, `cmd/` — s. AC-7.
+
+## Source
+
+- **Issue:** #1709
+- **Files:** `tests/tdd/test_fixture_wallclock_ratchet.py` (Erweiterung),
+  `tests/fixtures/ratchet_cases/` (Attrappen), neues Messwerkzeug unter `tests/helpers/`
+- **Nicht Gegenstand:** #1871 (der konkrete rote Testfall) — PO-Entscheidung 2026-08-15,
+  getrennt zu halten, damit beide Teile einzeln nachweisbar sind
+
+### Die Fehlerklasse, am Code nachgemessen
+
+Zeilenangaben im Ticket sind veraltet; hier der Stand bei `b6674c94`, selbst nachgemessen:
+
+1. `src/app/day_window.py:16-17` — `DAY_WINDOW_START_HOUR = 4`, `DAY_WINDOW_END_HOUR = 19`.
+2. `src/services/trip_segments.py:265-278` — das Ziel-Segment endet bei
+   `combine(arrival_local_date, time(end_hour))` in der **Ortszone des Ziels**.
+3. `src/services/trip_alert.py:1244-1245` und `:1411` — beide filtern
+   `segment.end_time < now_utc` als „bereits absolviert" weg.
+
+Bei den im Bestand dominierenden Fixture-Koordinaten `47.0 / 11.0` (Europe/Vienna, sommers
+UTC+2) ist 19:00 Ortszeit **exakt 17:00 UTC**. Der Test sieht harmlos aus; die
+Zeitabhängigkeit entsteht erst im Prüfling.
+
+**Korrektur zum Ticket:** Die dort als Ursache genannte 23:59-Klemme in `src/core/naismith.py`
+**existiert nicht mehr** — seit #1667 S2 rechnet `_format_hhmm()` (Z. 54-73) mit
+`total_min % (24*60)`.
+
+### Die Bestandsmenge ist gemessen, nicht geschätzt
+
+| Menge | Uhrzeiten (UTC) | Differenz |
+|---|---|---|
+| 69 Dateien: Etappe + Wanduhr + Alarmpfad, ohne Ankunftszeiten, ohne Härtungs-Helfer | 06/10/18/22:30 | **0** |
+| 100 Dateien: Etappe + Wanduhr + Alarmpfad, ohne `briefing_zeiten`-Helfer | 06/12 | **1** |
+
+🔴 **Die im Ticket befürchtete Massensanierung entfällt.** Die obere Schranke von 107
+Kandidaten enthält genau **einen** zeitabhängigen Testfall (→ #1871). Die übrigen wurden von
+#1667 S1, #1697, #1851 und #1858 bereits gehärtet. Das ist gemessen, nicht gelesen.
+
+### Das Härtungs-Kit existiert bereits
+
+| Kippkante | Baustein | Wirkung |
+|---|---|---|
+| Tagesfenster | `tests/helpers/arrival_window_fixtures.py::active_window_offsets` | Ankunft im aktiven Fenster, monoton, auf dem Etappentag |
+| Ortstag ≠ Serverdatum | dieselbe Datei, `stage_date(lat, lon)` | Etappendatum = Ortstag, dieselbe Formel wie der Prüfling |
+| Briefing-Vorlaufsperre | `tests/helpers/briefing_zeiten.py::briefing_zeiten_fuer_trip` | Briefingzeiten relativ zur echten Uhr, außerhalb des Vorlaufs |
+| alle | Koordinate `64.13 / -21.90` (`Atlantic/Reykjavik`, UTC+0 ohne Sommerzeit) | Ortstag ≡ UTC-Tag |
+
+Zielform vollständig: `tests/tdd/test_briefing_anchor_survives_dispatch_failure.py:178-205`.
+**Die Aufgabe ist deshalb nicht „eine Härtung erfinden", sondern „die vorhandene erzwingen".**
+
+## Scope
+
+### Gewählte Lösung
+
+**1. Messwerkzeug (`tests/helpers/wanduhr_matrix.py`, neu).** Eine Funktion, die eine oder
+mehrere Testdateien zu mehreren gestellten Uhrzeiten laufen lässt und die **Differenz** der
+Fehlermengen zurückgibt.
+
+Drei Eigenschaften sind zwingend, alle drei sind bei der Analyse teuer gelernt worden:
+
+- **Ein frischer Prozess je Datenpunkt.** Mehrere `pytest.main()`-Aufrufe im selben Prozess
+  ergaben eine Matrix (rot 02–04 UTC), die sich bei frischen Prozessen nicht reproduzieren
+  ließ (rot 04–06 UTC). Zustand sickert zwischen Läufen durch.
+- **Nur die Differenz ist auswertbar, nie eine absolute Fehlerzahl.** Sitzungsweites
+  `freezegun` zerstört pydantic-v1-Importe (`TypeError: metaclass conflict`,
+  `pydantic/v1/types.py:1180`) und erzeugt so 9 Falsch-Positive.
+  `extend_ignore_list=['pydantic']` behebt das nicht.
+- **Uhrzeiten in der Ortszone der Fixture wählen, nicht in UTC.** Wer die Grenzen in UTC
+  notiert, sucht bei fremder Zone an der falschen Stelle.
+
+**2. Zweite Fundregel in der Ratsche.** Sie macht an der **Fixture-Bauart** fest, nicht am
+Prüfling. Fund, wenn **alle** Merkmale zugleich zutreffen:
+
+- die Funktion baut eine Etappe mit **mindestens zwei** Wegpunkten, **und**
+- das Etappendatum stammt aus der Wanduhr (dieselbe Erkennung wie die bestehende Regel,
+  `_ist_wanduhr_datum`), **und**
+- **kein** Wegpunkt trägt `arrival_calculated` **oder** `arrival_override`, **und**
+- `stage.start_time` ist nicht gesetzt, **und**
+- die Datei nutzt **weder** `arrival_window_fixtures` **noch** `briefing_zeiten`, **und**
+- die Datei importiert einen zeitgrenzen-auswertenden Pfad (`trip_alert`, `compare_alert`,
+  `trip_report_scheduler`, `compare_slot_scheduler`, `alert_gate`, `deviation_alert`,
+  `alert_daily_limit`, `official_alert`).
+
+Die ersten vier Merkmale sind **am Prüfling abgelesen**, nicht geraten
+(`src/services/trip_segments.py`, HEAD `b6674c94`):
+
+| Merkmal | Belegstelle | Warum es die Immunität entscheidet |
+|---|---|---|
+| ≥ 2 Wegpunkte | `:121-123` — `if len(stage.waypoints) < 2: return []` | Eine Ein-Wegpunkt-Etappe erzeugt **gar kein Segment**; es gibt nichts, das „vorbei" sein könnte |
+| kein `arrival_calculated` | `:125-127` — Self-Heal-Auslöser ist `all(wp.arrival_calculated is None …)` | Nur dann rechnet Naismith überhaupt und setzt den 08:00-Standardstart |
+| kein `arrival_override` | `:36-52` `_known_time_for_index`, Kette `arrival_override > stage.start_time (idx 0) > arrival_calculated` | 🔴 `arrival_override` **gewinnt**, auch wenn der Self-Heal gelaufen ist — eine Fixture mit durchgängigem `arrival_override` ist immun, obwohl sie den Auslöser erfüllt |
+| kein `stage.start_time` | `:132` — `default_start = stage.start_time if stage.start_time else time(8, 0)` | Ein gesetzter Etappenstart ersetzt den 08:00-Standard |
+
+Das letzte Merkmal (Alarmpfad-Import) ist die Näherung an die nicht entscheidbare Frage
+„wertet der Prüfling eine Tageszeit aus?". Sie ist bewusst **grob**: sie schaut auf Importe der
+Datei, nicht auf Aufrufketten.
+
+**Verworfen:** eine Fundregel, die den Prüfling analysiert. Bei acht gemessenen
+Kippkanten-Familien in verschiedenen Modulen führte das zu einer Regel, die entweder alles
+oder nichts meldet. Das Ticket erlaubt den begründeten Ansatzwechsel ausdrücklich.
+
+### Affected Files
+
+| Datei | Change | Beschreibung |
+|---|---|---|
+| `tests/helpers/wanduhr_matrix.py` | CREATE | Messwerkzeug: Differenz-Messung über Uhrzeiten, ein Prozess je Punkt |
+| `tests/tdd/test_wanduhr_matrix.py` | CREATE | Selbsttests des Messwerkzeugs inkl. Gegenprobe (AC-3) |
+| `tests/tdd/test_fixture_wallclock_ratchet.py` | MODIFY | Zweite Fundregel `scan_indirekte_wanduhr_fixtures()` + Selbsttests |
+| `tests/fixtures/ratchet_cases/indirekte_wanduhr_faelle.py.txt` | CREATE | Attrappen außerhalb der Scanfläche |
+| Produktivcode | — | **unverändert** (AC-7) |
+
+### Estimated Changes
+
+- Dateien: 4
+- LoC: Produktiv +0 / −0, Test ca. +260 / −5
+
+## Acceptance Criteria
+
+- **AC-1 (die neue Fundregel meldet das Anti-Muster):** Given eine Attrappen-Datei, die eine
+  Etappe mit Wanduhr-Datum **ohne** Ankunftszeiten baut, keinen Härtungs-Helfer nutzt und
+  `trip_alert` importiert / When `scan_indirekte_wanduhr_fixtures(tmp_path)` darüber läuft /
+  Then meldet es genau diese Funktion mit Datei, Funktionsname und Zeile.
+  - Test: `test_scanner_meldet_die_indirekte_variante` gegen eine echte Datei auf `tmp_path`.
+
+- **AC-2 (Gegenprobe — der Scanner schweigt bei jeder immunen Bauart, wichtigster AC):**
+  Given sieben Attrappen, die je **eines** der Fund-Merkmale nicht erfüllen — (a) nur **ein**
+  Wegpunkt, (b) `arrival_calculated` gesetzt, (c) **`arrival_override`** gesetzt (bei
+  `arrival_calculated = None`), (d) `stage.start_time` gesetzt, (e) `arrival_window_fixtures`
+  genutzt, (f) `briefing_zeiten` genutzt, (g) kein Alarmpfad-Import / When der Scanner darüber
+  läuft / Then meldet er **keine** davon.
+  - Test: sieben benannte Testfunktionen, je `assert not funde`. Ohne diesen AC wäre eine Regel
+    zulässig, die einfach alles meldet — genau das Übel, das #1709 als „fälschlich
+    blockierendes Gate" anprangert. **Fall (c) ist der heikelste:** diese Fixture erfüllt den
+    Self-Heal-Auslöser (`arrival_calculated is None`) und ist trotzdem immun, weil
+    `arrival_override` in `_known_time_for_index` gewinnt. Eine Regel, die nur auf
+    `arrival_calculated` schaut — wie der erste Entwurf dieser Spec —, meldet sie fälschlich.
+
+- **AC-3 (das Messwerkzeug erkennt eine bekannte Zeitabhängigkeit — Wirksamkeitsbeleg):**
+  Given eine Attrappe, deren Testfall bei gestellter Uhr vor einer festgelegten Stunde grün und
+  danach rot ist / When das Messwerkzeug sie zu beiden Uhrzeiten misst / Then meldet es genau
+  diesen Testfall als Differenz, und bei zwei Uhrzeiten **derselben** Seite der Grenze meldet
+  es eine leere Differenz.
+  - Test: `test_matrix_findet_die_kante` + `test_matrix_meldet_nichts_ohne_kante`. Ein Werkzeug,
+    das nie etwas findet, ist von einem sauberen Bestand nicht unterscheidbar — dieser AC ist
+    der Unterschied zwischen „nichts gefunden" und „nichts da".
+
+- **AC-4 (frischer Prozess je Datenpunkt ist erzwungen, nicht empfohlen):** Given das
+  Messwerkzeug / When es zwei Uhrzeiten misst / Then läuft jeder Datenpunkt in einem eigenen
+  Betriebssystem-Prozess.
+  - Test: ein Testfall lässt das Werkzeug zweimal dieselbe Attrappe messen und prüft, dass die
+    beobachteten Prozesskennungen (`os.getpid()`, von der Attrappe in eine Datei geschrieben)
+    paarweise verschieden und vom Messprozess verschieden sind. Ein Kommentar „bitte frischen
+    Prozess nehmen" wäre keine Zusicherung, sondern eine Bitte.
+
+- **AC-5 (der echte Testbaum erzeugt keinen Fehlalarm):** Given der Scanner läuft über den
+  echten Baum `tests/` / When die Fundmenge gebildet wird / Then ist sie leer oder vollständig
+  durch `KNOWN_VIOLATIONS` gedeckt, **und** die Zahl der geprüften Kandidatenfunktionen ist
+  ≥ 20.
+  - Test: `test_echter_testbaum_ohne_fehlalarm`. Die Untergrenze verhindert, dass ein leerer
+    Scan durch eine kaputte Kandidatensuche vorgetäuscht wird — ohne sie wäre der AC durch
+    „finde gar nichts" trivial erfüllbar.
+
+- **AC-6 (Ausnahmeliste kann nur schrumpfen):** Given `KNOWN_VIOLATIONS` der neuen Regel /
+  When der Scanner über den echten Baum läuft / Then enthält die Liste keinen Eintrag, den der
+  Scanner nicht mehr findet.
+  - Test: `test_known_violations_der_neuen_regel_ohne_veraltete_eintraege`, Muster der
+    bestehenden Regel (Z. 544-553). **Bewusste Grenze, wie beim Vorbild:** gegen *neue*
+    unbegründete Einträge kann sich eine Ausnahmeliste strukturell nicht selbst schützen —
+    das bleibt review-pflichtig und wird hier nicht als gelöst behauptet.
+
+- **AC-7 (Nicht-Wirkung, Produktivcode unangetastet):** Given der vollständige Diff dieser
+  Scheibe / When `git diff --stat origin/main...HEAD -- src/ api/ internal/ frontend/ cmd/`
+  läuft / Then ist die Ausgabe leer.
+  - Test: struktureller Nachweis im PR, kein eigener Pytest-Test.
+
+- **AC-8 (Regel-Budget maschinell auffindbar):** Given die neue Regel / When die Datei nach dem
+  Prüfdatum durchsucht wird / Then steht `2026-11-10` als Text in der Datei und als Konstante.
+  - Test: `test_regel_budget_pruefdatum_der_neuen_regel_steht_als_text`, Muster der bestehenden
+    Regel (Z. 663-672).
+
+- **AC-9 (die Ratsche läuft in der CI-Ampel):** Given `.github/ci_tdd_excludes.txt` nach dieser
+  Scheibe / When darin nach `test_fixture_wallclock_ratchet` und `test_wanduhr_matrix` gesucht
+  wird / Then kommt keiner der beiden Namen vor.
+  - Test: `test_neue_waechter_sind_nicht_von_der_ci_ausgenommen` — ein Wächter, der nicht läuft,
+    ist kein Wächter.
+
+## Test Plan
+
+### Automated Tests (TDD RED)
+
+- [ ] AC-1: `test_scanner_meldet_die_indirekte_variante`
+- [ ] AC-2: sieben Gegenproben-Testfunktionen (1 Wegpunkt / `arrival_calculated` / `arrival_override` / `stage.start_time` / beide Helfer / kein Alarmpfad)
+- [ ] AC-3: `test_matrix_findet_die_kante`, `test_matrix_meldet_nichts_ohne_kante`
+- [ ] AC-4: `test_matrix_nutzt_je_datenpunkt_einen_eigenen_prozess`
+- [ ] AC-5: `test_echter_testbaum_ohne_fehlalarm` (inkl. Kandidaten-Untergrenze)
+- [ ] AC-6: `test_known_violations_der_neuen_regel_ohne_veraltete_eintraege`
+- [ ] AC-8: `test_regel_budget_pruefdatum_der_neuen_regel_steht_als_text`
+- [ ] AC-9: `test_neue_waechter_sind_nicht_von_der_ci_ausgenommen`
+
+### Mutations-Gegenprobe (Pflicht)
+
+Mindestens diese Verfälschungen müssen einen Test rot machen:
+
+1. Jedes einzelne Fund-Merkmal aus der `UND`-Kette entfernen (sieben Mutationen) → jeweils muss
+   der zugehörige AC-2-Fall rot werden. Bleibt einer grün, ist dieses Merkmal unbewacht.
+2. Die Kandidaten-Untergrenze in AC-5 entfernen → eine kaputte Kandidatensuche muss auffallen.
+3. Im Messwerkzeug den frischen Prozess durch einen Aufruf im selben Prozess ersetzen → AC-4
+   muss rot werden.
+4. `KNOWN_VIOLATIONS` um einen erfundenen Eintrag ergänzen → AC-6 muss rot werden.
+
+## Known Limitations
+
+- **Der Wächter bewacht Tests, nicht das Produkt.** Wie bei #1667 S1 gilt: aus „die Ratsche ist
+  grün" folgt nichts über die Zuverlässigkeit der Alarme.
+- **Das letzte Fund-Merkmal ist eine Näherung.** Geprüft werden Importe der Datei, nicht
+  Aufrufketten. Eine Fixture, die den Alarmpfad über einen Umweg erreicht, wird nicht erkannt.
+  Die Gegenrichtung — eine Datei importiert den Alarmpfad für einen anderen Testfall — führt zu
+  einem Fund, der über `KNOWN_VIOLATIONS` oder Härtung aufzulösen ist.
+- **Nur Python.** Go-seitige Zeitfenster (`internal/scheduler/`, `internal/store/`) sind nicht
+  Gegenstand.
+- **Latente Fixtures werden bewusst nicht gemeldet.** Es gibt Dateien, die das Anti-Muster
+  strukturell bauen, deren Testpfad den Alarmpfad aber nie erreicht (geprüft:
+  `test_bug_775_email_trip_lookup.py`, `test_inbound_telegram_reader.py`,
+  `test_inbound_gate_errors.py` — reine Inbound-/Zuordnungstests). Sie sind heute immun und
+  bleiben unauffällig; kommt später ein Alarmpfad-Import dazu, meldet die Regel sie ab dann.
+  Das ist gewollt: eine Regel, die auch latente Fälle meldet, wäre die zu weite Variante aus R1.
+- **Vier Kippkanten-Familien bleiben unbewacht:** Ruhezeit (nutzergesetzt, Default aus),
+  Tageszähler-Reset an Ortsmitternacht, Nowcast-Horizont und die Go-Seite. Sie sind im
+  Kontext-Dokument vermessen, aber keine dieser Familien hat bislang einen Fang belegt.
+- **Der konkrete rote Testfall wird hier NICHT behoben** (#1871, Ursache offen). Diese Scheibe
+  liefert das Werkzeug, mit dem er gefunden wurde, und den Wächter gegen Neuzugänge.
+
+## Nicht in dieser Scheibe
+
+- Keine Sanierung von Bestandsdateien (gemessen: nicht nötig, s. Source).
+- Kein Eingriff in `src/`, `api/`, `internal/`, `frontend/`, `cmd/`.
+- Keine Änderung an der bestehenden ersten Fundregel oder ihrer `KNOWN_VIOLATIONS`.
+- Keine Bewertung des 1440-Minuten-Wächters `test_radar_fixture_ist_zu_jeder_tageszeit_…`
+  (gehört zu #1871).
+
+## Regel-Budget
+
+**Prüfdatum: 2026-11-10** (aus dem Ticket übernommen).
+
+Fang-Beleg bei Einführung: Das Messwerkzeug hat #1871 gefunden — einen Testfall, der auf
+`main` täglich drei Stunden lang rot ist und den fünf grüne CI-Läufe zuvor nicht auffällig
+gemacht hatten. Am Prüfdatum: hat die **Fundregel** (nicht das Werkzeug) mindestens eine neue
+Fixture dieser Bauart gestoppt? Kein Fang → Rückbau der Regel, Werkzeug bleibt.
+
+## Changelog
+
+- 2026-08-15: Initial spec created

--- a/docs/specs/modules/fix_1709_wallclock_ratsche_indirekt.md
+++ b/docs/specs/modules/fix_1709_wallclock_ratsche_indirekt.md
@@ -261,6 +261,18 @@ Mindestens diese Verfälschungen müssen einen Test rot machen:
   Kontext-Dokument vermessen, aber keine dieser Familien hat bislang einen Fang belegt.
 - **Der konkrete rote Testfall wird hier NICHT behoben** (#1871, Ursache offen). Diese Scheibe
   liefert das Werkzeug, mit dem er gefunden wurde, und den Wächter gegen Neuzugänge.
+- **Aufrufer/Geschwister-Split bewusst nicht geschlossen (Adversary-Finding F-ADV2, Runde 2).**
+  Wird das Wanduhr-Datum im **Aufrufer** berechnet und als Parameter an eine **Geschwister**-
+  Funktion übergeben, die ihrerseits `Stage(...)` baut, sieht keine der beiden Funktionen für
+  sich beide Merkmale zugleich — die zweite Fundregel prüft ausschließlich innerhalb einer
+  Funktion, Rückgabewerte/Parameter über Funktionsgrenzen hinweg werden nicht verfolgt (teuer,
+  s. Grenzen-Abschnitt im Docstring von `test_fixture_wallclock_ratchet.py`). Diese Struktur ist
+  im Bestand bereits **etabliert**: `tests/tdd/test_issue_760_stage_number.py:31` (Helferfunktion
+  `_stage(..., d: date)`, die das Datum als Parameter entgegennimmt und `Stage(date=d, ...)`
+  baut) ist heute nur deshalb ungefährlich, weil dort ausschließlich mit **einem** Wegpunkt
+  gebaut wird — eine Erweiterung dieser Helferfunktion auf **zwei** Wegpunkte würde dort bereits
+  genügen, um die Ratsche zu umgehen. #1709 erlaubt der Regel ausdrücklich, eine Näherung zu
+  bleiben; diese Grenze ist damit bewusst offen, nicht gelöst.
 
 ## Nachtrag 2026-08-15: Härtung von zehn Bestandsdateien kam hinzu (PO-Entscheidung)
 

--- a/docs/specs/modules/fix_1709_wallclock_ratsche_indirekt.md
+++ b/docs/specs/modules/fix_1709_wallclock_ratsche_indirekt.md
@@ -300,9 +300,15 @@ Betroffen: `test_alert_state_briefing_reset.py`, `test_alert_undelivered_hint.py
   - Test: `test_known_violations_der_neuen_regel_ist_leer`; Assert
     `KNOWN_VIOLATIONS_INDIREKT == frozenset()` und `scan_indirekte_wanduhr_fixtures(TESTS_ROOT) == []`.
 
-**LoC-Budget:** auf 1000 Testzeilen angehoben (PO-Erlaubnis 2026-08-15). Der größte Block sind
-die Attrappen und die sieben Gegenproben — also genau die Nachweise, die den Wächter davor
+**LoC-Budget:** zunächst auf 1000 Testzeilen angehoben (PO-Erlaubnis 2026-08-15), nach der
+Fix-Schleife auf **1300** (zweite PO-Erlaubnis am selben Tag). Der größte Block sind die
+Attrappen und inzwischen elf Gegenproben — also genau die Nachweise, die den Wächter davor
 bewahren, alles zu melden. Kürzen hätte die Zusicherung geschwächt.
+
+🔴 **Das LoC-Gate hat die erste Überschreitung nicht bemerkt** (Anzeige `+0/1000`, tatsächlich
+1252 Testzeilen). Es misst hier den falschen Stand — dieselbe Schwäche, die als
+Phantom-Delta bekannt ist. Die Überschreitung wurde deshalb von Hand gemeldet und freigegeben,
+nicht vom Gate erzwungen. Wer sich hier auf die Anzeige verlässt, hat kein Budget.
 
 ## Nicht in dieser Scheibe
 

--- a/docs/specs/modules/fix_1709_wallclock_ratsche_indirekt.md
+++ b/docs/specs/modules/fix_1709_wallclock_ratsche_indirekt.md
@@ -262,9 +262,51 @@ Mindestens diese Verfälschungen müssen einen Test rot machen:
 - **Der konkrete rote Testfall wird hier NICHT behoben** (#1871, Ursache offen). Diese Scheibe
   liefert das Werkzeug, mit dem er gefunden wurde, und den Wächter gegen Neuzugänge.
 
+## Nachtrag 2026-08-15: Härtung von zehn Bestandsdateien kam hinzu (PO-Entscheidung)
+
+Die ursprüngliche Fassung schrieb „keine Sanierung von Bestandsdateien (gemessen: nicht nötig)".
+Das war für die **Wirkung** richtig und für die **Bauart** falsch — ein Unterschied, der beim
+Schreiben der Spec nicht gesehen wurde.
+
+Der fertige Scanner meldete elf Bestandsstellen. Alle zehn betroffenen Dateien wurden mit dem
+in dieser Scheibe entstandenen Werkzeug zu vier Uhrzeiten (05/12/18/23 UTC) nachgemessen:
+**keine einzige ist zeitabhängig**. Sie bauen das Anti-Muster, ihre Prüfaussagen hängen aber
+nicht daran — latent, nicht defekt.
+
+Der erste Implementierungsversuch trug die elf Stellen in `KNOWN_VIOLATIONS_INDIREKT` ein, um
+den Wächter grün zu bekommen. **Das ist zurückgenommen.** Die Regel neben der bestehenden Liste
+verbietet es wörtlich („darf NICHT gefuellt werden, um den Waechter gruen zu bekommen";
+„Umstellen waere aufwendig" ist kein Grund), und ein Wächter mit elf Ausnahmen bewacht nur noch
+Neuzugänge — weniger, als freigegeben wurde.
+
+**PO-Entscheidung 2026-08-15:** die zehn Fixturen werden auf das vorhandene Härtungs-Kit
+umgestellt, `KNOWN_VIOLATIONS_INDIREKT` bleibt **leer**. Bedingungen: keine `assert`-Zeile wird
+angefasst (geändert wird die Vorbedingung, nicht die Zusicherung), jede Datei bleibt einzeln
+grün, und jede wird vor und nach der Härtung mit `matrix_differenz` gegengemessen.
+
+Betroffen: `test_alert_state_briefing_reset.py`, `test_alert_undelivered_hint.py`,
+`test_import_und_fremdquellen_folgen_ortstag.py`, `test_issue_1069_tier_channel_gating.py`
+(zwei Funktionen), `test_official_alert_channel_threshold.py`,
+`test_official_alert_sms_marker.py`, `test_trip_alert_channel_precedence.py`,
+`test_trip_briefing_anchor_unchanged.py`, `test_trip_outlook_dispatch_mail.py`,
+`tests/unit/test_premium_sms_versand.py`.
+
+**Zusätzliches Kriterium aus diesem Nachtrag:**
+
+- **AC-10 (die Ausnahmeliste der neuen Regel bleibt leer):** Given
+  `KNOWN_VIOLATIONS_INDIREKT` nach dieser Scheibe / When der Scanner über den echten Baum
+  `tests/` läuft / Then ist die Liste leer **und** die Fundmenge leer — der Wächter ist ohne
+  jede Ausnahme grün.
+  - Test: `test_known_violations_der_neuen_regel_ist_leer`; Assert
+    `KNOWN_VIOLATIONS_INDIREKT == frozenset()` und `scan_indirekte_wanduhr_fixtures(TESTS_ROOT) == []`.
+
+**LoC-Budget:** auf 1000 Testzeilen angehoben (PO-Erlaubnis 2026-08-15). Der größte Block sind
+die Attrappen und die sieben Gegenproben — also genau die Nachweise, die den Wächter davor
+bewahren, alles zu melden. Kürzen hätte die Zusicherung geschwächt.
+
 ## Nicht in dieser Scheibe
 
-- Keine Sanierung von Bestandsdateien (gemessen: nicht nötig, s. Source).
+- Keine Sanierung über die zehn oben genannten Dateien hinaus.
 - Kein Eingriff in `src/`, `api/`, `internal/`, `frontend/`, `cmd/`.
 - Keine Änderung an der bestehenden ersten Fundregel oder ihrer `KNOWN_VIOLATIONS`.
 - Keine Bewertung des 1440-Minuten-Wächters `test_radar_fixture_ist_zu_jeder_tageszeit_…`
@@ -282,3 +324,5 @@ Fixture dieser Bauart gestoppt? Kein Fang → Rückbau der Regel, Werkzeug bleib
 ## Changelog
 
 - 2026-08-15: Initial spec created
+- 2026-08-15: Nachtrag — Härtung von zehn Bestandsdateien aufgenommen, AC-10 ergänzt,
+  LoC-Budget auf 1000 Testzeilen angehoben (beides PO-Entscheidung nach der Messung)

--- a/tests/fixtures/ratchet_cases/indirekte_wanduhr_faelle.py.txt
+++ b/tests/fixtures/ratchet_cases/indirekte_wanduhr_faelle.py.txt
@@ -1,0 +1,301 @@
+# Fixture-Quelltexte fuer die zweite Fundregel scan_indirekte_wanduhr_fixtures()
+# in tests/tdd/test_fixture_wallclock_ratchet.py (#1709).
+#
+# Bewusst KEINE .py-Endung: die Ratsche scannt tests/**/*.py, und diese Datei
+# enthaelt absichtlich das Anti-Muster bzw. seine Gegenproben. Laege sie als
+# .py hier, meldete der Waechter seine eigenen Fixtures. Format wie beim
+# Vorbild tests/fixtures/ratchet_cases/wallclock_arrival_faelle.py.txt:
+# `# === <fall> ===` trennt die Faelle, der Text bis zum naechsten Trenner
+# wird 1:1 als Testdatei nach tmp_path geschrieben.
+#
+# Diese Faelle werden NIE ausgefuehrt (nur ast.parse) — Laufzeitfehler in
+# Helferaufrufen (z.B. briefing_zeiten_fuer_trip auf einem unvollstaendigen
+# Trip) sind deshalb unerheblich.
+
+# === indirekt-antimuster ===
+from datetime import date
+
+from app.trip import Stage, Trip, Waypoint
+from services.trip_alert import TripAlertService
+
+
+def _trip_ohne_ankunftszeiten():
+    """Anti-Muster #1709: KEINE Ankunftszeit gesetzt, kein Haertungs-Helfer,
+    Etappendatum aus der Wanduhr. Ohne Ankunftszeiten greift der
+    Naismith-Standardstart 08:00 (trip_segments.py:132), und ob das
+    Ziel-Segment "vorbei" ist, entscheidet allein das Tagesfenster-Ende."""
+    stage = Stage(
+        id="T1", name="Tag 1", date=date.today(),
+        waypoints=[
+            Waypoint(id="W1", name="Start", lat=47.0, lon=11.0, elevation_m=1000),
+            Waypoint(id="W2", name="Ziel", lat=47.1, lon=11.1, elevation_m=1500),
+        ],
+    )
+    trip = Trip(id="t-1709", name="Ohne Ankunftszeiten", stages=[stage])
+    return trip
+
+# === nur-ein-wegpunkt ===
+from datetime import date
+
+from app.trip import Stage, Trip, Waypoint
+from services.trip_alert import TripAlertService
+
+
+def _trip_mit_einem_wegpunkt():
+    """Gegenprobe (a): nur EIN Wegpunkt -> convert_trip_to_segments baut gar
+    kein Segment (trip_segments.py:121-123): "if len(stage.waypoints) < 2:
+    return []". Es gibt nichts, das "vorbei" sein koennte."""
+    stage = Stage(
+        id="T1", name="Tag 1", date=date.today(),
+        waypoints=[
+            Waypoint(id="W1", name="Start", lat=47.0, lon=11.0, elevation_m=1000),
+        ],
+    )
+    trip = Trip(id="t-1709-a", name="Ein Wegpunkt", stages=[stage])
+    return trip
+
+# === arrival-calculated-gesetzt ===
+from datetime import date
+
+from app.trip import Stage, Trip, Waypoint
+from services.trip_alert import TripAlertService
+
+
+def _trip_mit_arrival_calculated():
+    """Gegenprobe (b): arrival_calculated ist bei BEIDEN Wegpunkten gesetzt
+    -> der Self-Heal-Ausloeser "all(wp.arrival_calculated is None ...)"
+    (trip_segments.py:126) greift nicht, Naismith rechnet nicht neu."""
+    stage = Stage(
+        id="T1", name="Tag 1", date=date.today(),
+        waypoints=[
+            Waypoint(id="W1", name="Start", lat=47.0, lon=11.0, elevation_m=1000,
+                     arrival_calculated="09:00"),
+            Waypoint(id="W2", name="Ziel", lat=47.1, lon=11.1, elevation_m=1500,
+                     arrival_calculated="14:00"),
+        ],
+    )
+    trip = Trip(id="t-1709-b", name="Arrival berechnet", stages=[stage])
+    return trip
+
+# === arrival-override-gesetzt ===
+from datetime import date
+
+from app.trip import Stage, Trip, Waypoint
+from services.trip_alert import TripAlertService
+
+
+def _trip_mit_arrival_override():
+    """Gegenprobe (c), der heikelste Fall: arrival_calculated ist bei BEIDEN
+    Wegpunkten None (der Self-Heal-Ausloeser waere erfuellt) — aber
+    arrival_override gewinnt in _known_time_for_index (trip_segments.py:
+    36-52), noch vor dem Default. Die Fixture ist deshalb immun, obwohl sie
+    den Self-Heal-Ausloeser erfuellt. Eine Regel, die nur auf
+    arrival_calculated schaut, meldet sie faelschlich."""
+    stage = Stage(
+        id="T1", name="Tag 1", date=date.today(),
+        waypoints=[
+            Waypoint(id="W1", name="Start", lat=47.0, lon=11.0, elevation_m=1000,
+                     arrival_calculated=None, arrival_override="09:00"),
+            Waypoint(id="W2", name="Ziel", lat=47.1, lon=11.1, elevation_m=1500,
+                     arrival_calculated=None, arrival_override="14:00"),
+        ],
+    )
+    trip = Trip(id="t-1709-c", name="Arrival override", stages=[stage])
+    return trip
+
+# === stage-start-time-gesetzt ===
+from datetime import date, time
+
+from app.trip import Stage, Trip, Waypoint
+from services.trip_alert import TripAlertService
+
+
+def _trip_mit_stage_start_time():
+    """Gegenprobe (d): stage.start_time ist gesetzt -> ersetzt den
+    Naismith-Default 08:00 (trip_segments.py:132: "default_start =
+    stage.start_time if stage.start_time else time(8, 0)")."""
+    stage = Stage(
+        id="T1", name="Tag 1", date=date.today(), start_time=time(7, 30),
+        waypoints=[
+            Waypoint(id="W1", name="Start", lat=47.0, lon=11.0, elevation_m=1000),
+            Waypoint(id="W2", name="Ziel", lat=47.1, lon=11.1, elevation_m=1500),
+        ],
+    )
+    trip = Trip(id="t-1709-d", name="Etappenstart gesetzt", stages=[stage])
+    return trip
+
+# === nutzt-arrival-window-fixtures ===
+from datetime import date
+
+from app.trip import Stage, Trip, Waypoint
+from services.trip_alert import TripAlertService
+from tests.helpers.arrival_window_fixtures import stage_date
+
+
+def _trip_mit_arrival_window_helfer():
+    """Gegenprobe (e): die Datei nutzt den Haertungs-Helfer
+    arrival_window_fixtures (hier fuer das Etappendatum) -> immun, auch wenn
+    im Einzelfall keine Ankunftszeit gesetzt ist. Die Regel macht am IMPORT
+    fest, nicht an der tatsaechlichen Verwendung je Wegpunkt."""
+    stage = Stage(
+        id="T1", name="Tag 1", date=stage_date(47.0, 11.0),
+        waypoints=[
+            Waypoint(id="W1", name="Start", lat=47.0, lon=11.0, elevation_m=1000),
+            Waypoint(id="W2", name="Ziel", lat=47.1, lon=11.1, elevation_m=1500),
+        ],
+    )
+    trip = Trip(id="t-1709-e", name="Haertungs-Helfer Fenster", stages=[stage])
+    return trip
+
+# === nutzt-briefing-zeiten ===
+from datetime import date
+
+from app.trip import Stage, Trip, Waypoint
+from services.trip_alert import TripAlertService
+from tests.helpers.briefing_zeiten import briefing_zeiten_fuer_trip
+
+
+def _trip_mit_briefing_zeiten_helfer():
+    """Gegenprobe (f): die Datei nutzt briefing_zeiten_fuer_trip -> immun.
+    Ausgefuehrt wird diese Attrappe nie (nur ast.parse), der Aufruf muss
+    hier nicht sinnvoll auf trip anwendbar sein."""
+    stage = Stage(
+        id="T1", name="Tag 1", date=date.today(),
+        waypoints=[
+            Waypoint(id="W1", name="Start", lat=47.0, lon=11.0, elevation_m=1000),
+            Waypoint(id="W2", name="Ziel", lat=47.1, lon=11.1, elevation_m=1500),
+        ],
+    )
+    trip = Trip(id="t-1709-f", name="Briefing-Zeiten Helfer", stages=[stage])
+    briefing_zeiten_fuer_trip(trip)
+    return trip
+
+# === kein-alarmpfad-import ===
+from datetime import date
+
+from app.trip import Stage, Trip, Waypoint
+
+
+def _trip_ohne_alarmpfad_import():
+    """Gegenprobe (g): die Datei importiert KEINEN zeitgrenzen-auswertenden
+    Pfad -> die Naeherung fuer "wertet der Pruefling eine Tageszeit-Grenze
+    aus?" schlaegt negativ an, obwohl die Fixture-Bauart sonst identisch mit
+    dem Anti-Muster ist."""
+    stage = Stage(
+        id="T1", name="Tag 1", date=date.today(),
+        waypoints=[
+            Waypoint(id="W1", name="Start", lat=47.0, lon=11.0, elevation_m=1000),
+            Waypoint(id="W2", name="Ziel", lat=47.1, lon=11.1, elevation_m=1500),
+        ],
+    )
+    trip = Trip(id="t-1709-g", name="Kein Alarmpfad-Import", stages=[stage])
+    return trip
+
+# === wegpunkte-aus-hilfsfunktion ===
+from datetime import date
+
+from app.trip import Stage, Trip, Waypoint
+from services.trip_alert import TripAlertService
+
+
+def _bau_wegpunkte():
+    """Hilfsfunktion, die die Wegpunkte AUSSERHALB des ``Stage(...)``-Aufrufs
+    baut -- Adversary-Finding F001: die urspruengliche Zaehlung sah nur
+    ``Waypoint(...)``-Aufrufe DIREKT im Syntaxbaum des ``Stage(...)``-Aufrufs
+    und zaehlte hier 0, obwohl zur Laufzeit 2 Wegpunkte entstehen."""
+    return [
+        Waypoint(id="W1", name="Start", lat=47.0, lon=11.0, elevation_m=1000),
+        Waypoint(id="W2", name="Ziel", lat=47.1, lon=11.1, elevation_m=1500),
+    ]
+
+
+def _trip_ueber_hilfsfunktion():
+    stage = Stage(id="T1", name="Tag 1", date=date.today(), waypoints=_bau_wegpunkte())
+    trip = Trip(id="t-1709-f001", name="Wegpunkte aus Hilfsfunktion", stages=[stage])
+    return trip
+
+# === stage-kwargs-entpackung ===
+from datetime import date
+
+from app.trip import Stage, Trip, Waypoint
+from services.trip_alert import TripAlertService
+
+
+def _trip_ueber_kwargs():
+    """Adversary-Finding F002: ``Stage(**stage_kwargs)`` -- die Schluessel-
+    woerter stammen aus einem Dict, das der Scanner nicht einsehen kann. Die
+    alte Zaehlung fand am Aufruf selbst keine Keywords und damit auch keine
+    ``waypoints=``-Angabe -> 0 Wegpunkte gezaehlt, obwohl das Dict 2
+    enthaelt."""
+    stage_kwargs = dict(
+        id="T1", name="Tag 1", date=date.today(),
+        waypoints=[
+            Waypoint(id="W1", name="Start", lat=47.0, lon=11.0, elevation_m=1000),
+            Waypoint(id="W2", name="Ziel", lat=47.1, lon=11.1, elevation_m=1500),
+        ],
+    )
+    stage = Stage(**stage_kwargs)
+    trip = Trip(id="t-1709-f002", name="Stage aus kwargs-Entpackung", stages=[stage])
+    return trip
+
+# === wegpunkte-aus-comprehension ===
+from datetime import date
+
+from app.trip import Stage, Trip, Waypoint
+from services.trip_alert import TripAlertService
+
+
+def _trip_ueber_comprehension():
+    """Adversary-Finding F003: ``waypoints=[Waypoint(...) for x in liste]``
+    -- die alte Zaehlung sah GENAU EINEN Syntaxknoten (den ``Waypoint(...)``-
+    Aufruf im Comprehension-Rumpf), waehrend zur Laufzeit ``len(liste)``
+    Wegpunkte entstehen. Bei einer Liste mit 3 Elementen zaehlte der Scanner
+    also 1 statt 3 -- unter der Schwelle von 2, obwohl tatsaechlich 3
+    Wegpunkte gebaut werden."""
+    ids = ["W1", "W2", "W3"]
+    stage = Stage(
+        id="T1", name="Tag 1", date=date.today(),
+        waypoints=[
+            Waypoint(id=x, name=x, lat=47.0, lon=11.0, elevation_m=1000)
+            for x in ids
+        ],
+    )
+    trip = Trip(id="t-1709-f003", name="Wegpunkte aus Comprehension", stages=[stage])
+    return trip
+
+# === haertungs-helfer-nur-in-anderer-funktion ===
+from datetime import date
+
+from app.trip import Stage, Trip, Waypoint
+from services.trip_alert import TripAlertService
+from tests.helpers.arrival_window_fixtures import stage_date
+
+
+def _gehaertete_funktion():
+    """Diese Funktion nutzt den Haertungs-Helfer SELBST -> immun."""
+    stage = Stage(
+        id="T1", name="Tag 1", date=stage_date(47.0, 11.0),
+        waypoints=[
+            Waypoint(id="W1", name="Start", lat=47.0, lon=11.0, elevation_m=1000),
+            Waypoint(id="W2", name="Ziel", lat=47.1, lon=11.1, elevation_m=1500),
+        ],
+    )
+    trip = Trip(id="t-1709-f004-ok", name="Gehaertete Funktion", stages=[stage])
+    return trip
+
+
+def _ungehaertete_funktion():
+    """Adversary-Finding F004: die Datei importiert den Haertungs-Helfer (s.
+    oben), aber DIESE Funktion ruft ihn nicht auf -- baut das Anti-Muster
+    unveraendert. Die alte, dateiweite Pruefung machte diese Funktion
+    faelschlich mit unsichtbar, weil irgendeine ANDERE Funktion derselben
+    Datei den Helfer importierte."""
+    stage = Stage(
+        id="T1", name="Tag 1", date=date.today(),
+        waypoints=[
+            Waypoint(id="W1", name="Start", lat=47.0, lon=11.0, elevation_m=1000),
+            Waypoint(id="W2", name="Ziel", lat=47.1, lon=11.1, elevation_m=1500),
+        ],
+    )
+    trip = Trip(id="t-1709-f004-bad", name="Ungehaertete Funktion", stages=[stage])
+    return trip

--- a/tests/fixtures/ratchet_cases/indirekte_wanduhr_faelle.py.txt
+++ b/tests/fixtures/ratchet_cases/indirekte_wanduhr_faelle.py.txt
@@ -299,3 +299,81 @@ def _ungehaertete_funktion():
     )
     trip = Trip(id="t-1709-f004-bad", name="Ungehaertete Funktion", stages=[stage])
     return trip
+
+# === indirekt-antimuster-mit-alias ===
+from datetime import date
+
+from app.trip import Stage as StageAlias, Trip, Waypoint as WaypointAlias
+from services.trip_alert import TripAlertService
+
+
+def _trip_ohne_ankunftszeiten_alias():
+    """Adversary-Finding F-ADV1 (HIGH): identisch zum Anti-Muster aus
+    'indirekt-antimuster', aber Stage/Waypoint werden unter einem
+    Import-Alias verwendet (``Stage as StageAlias``, ``Waypoint as
+    WaypointAlias``). Der literale Namensvergleich uebersah diesen Fall
+    vollstaendig -- 0 statt 1 Fund."""
+    stage = StageAlias(
+        id="T1", name="Tag 1", date=date.today(),
+        waypoints=[
+            WaypointAlias(id="W1", name="Start", lat=47.0, lon=11.0, elevation_m=1000),
+            WaypointAlias(id="W2", name="Ziel", lat=47.1, lon=11.1, elevation_m=1500),
+        ],
+    )
+    trip = Trip(id="t-1709-adv1", name="Alias Stage/Waypoint", stages=[stage])
+    return trip
+
+# === literales-datum-statt-wanduhr ===
+from datetime import date
+
+from app.trip import Stage, Trip, Waypoint
+from services.trip_alert import TripAlertService
+
+
+def _trip_mit_literalem_datum():
+    """Gegenprobe (h), Adversary-Finding F-ADV3 (MEDIUM): identisch zum
+    Anti-Muster, aber das Etappendatum ist ein LITERALES Datum statt
+    Wanduhr-Arithmetik -- Merkmal 2 (Wanduhr-Etappendatum) fehlt -> kein
+    Fund. Bislang hatte dieses Merkmal keine eigene Gegenprobe; die Mutation
+    "Merkmal 2 aus der UND-Kette entfernen" fiel nur zufaellig ueber den
+    Bestandsscan auf, nicht ueber einen gezielten Test."""
+    stage = Stage(
+        id="T1", name="Tag 1", date=date(2026, 8, 20),
+        waypoints=[
+            Waypoint(id="W1", name="Start", lat=47.0, lon=11.0, elevation_m=1000),
+            Waypoint(id="W2", name="Ziel", lat=47.1, lon=11.1, elevation_m=1500),
+        ],
+    )
+    trip = Trip(id="t-1709-adv3", name="Literales Datum", stages=[stage])
+    return trip
+
+# === start-time-mit-unaufloesbaren-wegpunkten ===
+from datetime import date, time
+
+from app.trip import Stage, Trip, Waypoint
+from services.trip_alert import TripAlertService
+
+_WEGPUNKTE_MODUL_KONSTANTE = [
+    Waypoint(id="W1", name="Start", lat=47.0, lon=11.0, elevation_m=1000),
+    Waypoint(id="W2", name="Ziel", lat=47.1, lon=11.1, elevation_m=1500),
+]
+
+
+def _trip_mit_start_time_und_unaufloesbaren_wegpunkten():
+    """Regressionsschutz (Adversary-Finding F-ADV4, MEDIUM): stage.start_time
+    ist gesetzt UND waypoints= ist NICHT statisch einsehbar (Modulkonstante,
+    ausserhalb der Funktion gebunden). ``_stage_ist_anfaellig()`` prueft
+    start_time ZUERST, VOR der Wegpunkt-Aufloesung -- vertauscht man diese
+    Reihenfolge, uebersteuert die unaufloesbare Wegpunktmenge (F001-F003:
+    'im Zweifel pruefbeduerftig') faelschlich eine bereits vorhandene
+    Haertung ueber start_time. Diese Regression trat waehrend der Umsetzung
+    bereits einmal auf und wurde bislang nur durch zwei thematisch
+    unbeteiligte Bestandsdateien mitbewacht, nicht durch einen eigenen
+    Test."""
+    stage = Stage(
+        id="T1", name="Tag 1", date=date.today(), start_time=time(7, 30),
+        waypoints=_WEGPUNKTE_MODUL_KONSTANTE,
+    )
+    trip = Trip(id="t-1709-adv4", name="Start-Time vor Wegpunktaufloesung",
+                stages=[stage])
+    return trip

--- a/tests/fixtures/ratchet_cases/indirekte_wanduhr_faelle.py.txt
+++ b/tests/fixtures/ratchet_cases/indirekte_wanduhr_faelle.py.txt
@@ -377,3 +377,28 @@ def _trip_mit_start_time_und_unaufloesbaren_wegpunkten():
     trip = Trip(id="t-1709-adv4", name="Start-Time vor Wegpunktaufloesung",
                 stages=[stage])
     return trip
+
+# === indirekt-antimuster-import-modulname ===
+from datetime import date
+
+from app.trip import Stage, Trip, Waypoint
+from services import trip_alert
+
+
+def _trip_ohne_ankunftszeiten_modulimport():
+    """Adversary-Finding F-ADV5 (HIGH): identisch zum Anti-Muster aus
+    'indirekt-antimuster', aber der Alarmpfad wird als ``from services
+    import trip_alert`` importiert statt als ``from services.trip_alert
+    import TripAlertService``. Beide Schreibweisen importieren denselben
+    Pfad -- ein Vergleich, der nur den Modulpfad (``services``) statt auch
+    den importierten Namen (``trip_alert``) prueft, sieht diesen Stil nicht.
+    Real im Bestand: tests/tdd/test_alert_run_deadline.py:48."""
+    stage = Stage(
+        id="T1", name="Tag 1", date=date.today(),
+        waypoints=[
+            Waypoint(id="W1", name="Start", lat=47.0, lon=11.0, elevation_m=1000),
+            Waypoint(id="W2", name="Ziel", lat=47.1, lon=11.1, elevation_m=1500),
+        ],
+    )
+    trip = Trip(id="t-1709-adv5", name="Alarmpfad ueber Modulimport", stages=[stage])
+    return trip

--- a/tests/helpers/wanduhr_matrix.py
+++ b/tests/helpers/wanduhr_matrix.py
@@ -1,0 +1,156 @@
+"""Messwerkzeug: indirekte Wanduhr-Abhaengigkeit eines Testfalls MESSEN,
+statt sie am Code zu erraten (#1709).
+
+Ob eine Fixture indirekt von der Wanduhr abhaengt, laesst sich nicht durch
+Lesen entscheiden — die Zeitabhaengigkeit entsteht erst im Pruefling
+(``src/services/trip_segments.py`` / ``src/services/trip_alert.py``). Sie
+laesst sich aber MESSEN: dieselbe Testdatei zu mehreren gestellten Uhrzeiten
+laufen lassen und die Ergebnisse vergleichen.
+
+Drei Eigenschaften sind zwingend (Spec ``fix_1709_wallclock_ratsche_indirekt``,
+Abschnitt "Gewaehlte Loesung"), alle drei teuer gelernt:
+
+1. **Ein frischer Betriebssystem-Prozess je Datenpunkt.** Mehrere
+   ``pytest.main()``-Aufrufe im selben Prozess ergaben eine Matrix (rot
+   02-04 UTC), die sich bei frischen Prozessen nicht reproduzieren liess (rot
+   04-06 UTC) — Zustand sickert zwischen Laeufen durch.
+2. **Nur die Differenz ist auswertbar, nie eine absolute Fehlerzahl.**
+   Sitzungsweites ``freezegun`` zerstoert pydantic-v1-Importe
+   (``TypeError: metaclass conflict``, ``pydantic/v1/types.py:1180``) und
+   erzeugt so Falsch-Positive. ``extend_ignore_list=["pydantic"]`` behebt das
+   nicht.
+3. **Uhrzeiten in der Ortszone der Fixture waehlen, nicht in UTC.** Wer die
+   Grenzen in UTC notiert, sucht bei fremder Zone an der falschen Stelle —
+   das ist Sache der Aufrufer:in, dieses Werkzeug rechnet nur mit dem, was
+   es bekommt.
+
+Jeder Datenpunkt laeuft deshalb als eigener ``sys.executable -c``-Subprozess
+mit ``freeze_time(..., tick=True)`` NUR fuer diesen einen Lauf. Ergebnisse
+werden ueber einen ``pytest_runtest_logreport``-Hook eingesammelt und als
+JSON in eine Ausgabedatei geschrieben — kein stdout-Parsing.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Sequence
+
+# Wurzel DIESES Checkouts (Pfadregel #1409) — der Kindprozess wird mit dieser
+# cwd gestartet, damit fuer Pruefling-Dateien INNERHALB des Repos (z.B. echte
+# Fixtures unter tests/tdd/) die uebliche conftest-Kette (tests/conftest.py
+# setzt "src" auf sys.path) unveraendert greift. Attrappen ausserhalb des
+# Repos (tmp_path) brauchen das nicht -- sie sind bewusst eigenstaendig.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Zeitlimit je Datenpunkt: ein haengender Testfall darf die Messung nicht
+# blockieren (Spec, AC-Vorbedingung). Grosszuegig bemessen wie beim Vorbild
+# fuer Subprozess-Pytest-Laeufe (tests/tdd/test_worktree_path_resolution_
+# effect.py: _SUBPROC_TIMEOUT = 120) -- ein einzelner Datenpunkt entspricht
+# demselben Aufwand wie dort ein einzelner Nodeid-Lauf.
+_SUBPROC_TIMEOUT_SEC = 120
+
+_KINDPROZESS_SKRIPT = '''\
+import json
+
+import pytest
+from freezegun import freeze_time
+
+
+class _Sammler:
+    """Sammelt bestanden/fehlgeschlagen je Testfall ueber den pytest-Hook --
+    kein stdout-Parsing, keine Zusatzformate."""
+
+    def __init__(self):
+        self.ergebnisse = {{}}
+
+    def pytest_runtest_logreport(self, report):
+        if report.when == "call":
+            self.ergebnisse[report.nodeid] = report.outcome
+        elif report.when in ("setup", "teardown") and report.outcome != "passed":
+            # Fehler in setup/teardown (z.B. eine fehlschlagende Fixture)
+            # zaehlen ebenfalls als abweichendes Ergebnis, ueberschreiben aber
+            # ein bereits erfasstes "call"-Ergebnis nicht.
+            self.ergebnisse.setdefault(report.nodeid, report.outcome)
+
+
+sammler = _Sammler()
+with freeze_time({uhrzeit_iso}, tick=True):
+    pytest.main(
+        [{testdatei}, "--allow-hosts=127.0.0.1,::1", "-p", "no:randomly", "-q"],
+        plugins=[sammler],
+    )
+
+with open({ausgabe}, "w", encoding="utf-8") as f:
+    json.dump(sammler.ergebnisse, f)
+'''
+
+
+def lauf_bei_uhrzeit(testdatei: Path, uhrzeit: datetime) -> dict[str, str]:
+    """Fuehrt ``testdatei`` EINMAL, in einem FRISCHEN Betriebssystem-Prozess,
+    mit gestellter Wanduhr ``uhrzeit`` aus (ein Datenpunkt).
+
+    Gibt ``{nodeid: outcome}`` zurueck (``outcome`` z.B. ``"passed"``,
+    ``"failed"``, ``"skipped"``).
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        ausgabe = Path(tmp) / "ergebnisse.json"
+        skript = _KINDPROZESS_SKRIPT.format(
+            uhrzeit_iso=repr(uhrzeit.isoformat()),
+            testdatei=repr(str(testdatei)),
+            ausgabe=repr(str(ausgabe)),
+        )
+        # PYTEST_*-Env-Variablen des AEUSSEREN Laufs nicht in den Kindprozess
+        # durchreichen -- sonst haelt der verschachtelte pytest-Lauf sich
+        # faelschlich fuer denselben Testlauf (Muster: test_worktree_path_
+        # resolution_effect.py::_run_pytest_in).
+        env = {k: v for k, v in os.environ.items() if not k.startswith("PYTEST_")}
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-c", skript],
+                cwd=str(REPO_ROOT),
+                capture_output=True,
+                text=True,
+                timeout=_SUBPROC_TIMEOUT_SEC,
+                env=env,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"lauf_bei_uhrzeit({testdatei}, {uhrzeit.isoformat()}) haengt "
+                f"nach {_SUBPROC_TIMEOUT_SEC}s -- abgebrochen, um die Messung "
+                f"nicht zu blockieren. stdout bisher: {exc.stdout!r}"
+            ) from exc
+
+        if not ausgabe.exists():
+            raise RuntimeError(
+                f"lauf_bei_uhrzeit({testdatei}, {uhrzeit.isoformat()}): der "
+                f"Kindprozess hat keine Ergebnisdatei geschrieben (Exit "
+                f"{proc.returncode}).\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+            )
+        return json.loads(ausgabe.read_text(encoding="utf-8"))
+
+
+def matrix_differenz(testdatei: Path, uhrzeiten: Sequence[datetime]) -> frozenset[str]:
+    """Misst ``testdatei`` zu jeder Uhrzeit (je ein frischer Prozess, s.
+    ``lauf_bei_uhrzeit``) und gibt die Menge der Test-Nodeids zurueck, deren
+    Ergebnis NICHT bei ALLEN Uhrzeiten identisch ist.
+
+    Bei zwei Uhrzeiten derselben Seite einer Kippkante ist das Ergebnis leer
+    -- absolute Fehlerzahlen werden nie ausgewertet (s. Modul-Docstring,
+    Punkt 2).
+    """
+    messungen = [lauf_bei_uhrzeit(testdatei, uhrzeit) for uhrzeit in uhrzeiten]
+    alle_nodeids: set[str] = set()
+    for messung in messungen:
+        alle_nodeids.update(messung)
+
+    abweichend: set[str] = set()
+    for nodeid in alle_nodeids:
+        ergebnisse_je_uhrzeit = {messung.get(nodeid) for messung in messungen}
+        if len(ergebnisse_je_uhrzeit) > 1:
+            abweichend.add(nodeid)
+    return frozenset(abweichend)

--- a/tests/tdd/conftest.py
+++ b/tests/tdd/conftest.py
@@ -23,6 +23,16 @@ _HOOKS_DIR = Path(__file__).resolve().parents[2] / ".claude" / "hooks"
 if str(_HOOKS_DIR) not in sys.path:
     sys.path.insert(0, str(_HOOKS_DIR))
 
+# tests/ selbst auf sys.path (#1709): test_wanduhr_matrix.py importiert das
+# Messwerkzeug als `from helpers.wanduhr_matrix import ...` -- OHNE
+# "tests."-Präfix, anders als die übliche Absolut-Importform
+# `from tests.helpers.xxx import yyy` (die über pythonpath="." im
+# Repo-Root bereits funktioniert). Ohne diesen Eintrag bliebe der Import ein
+# ModuleNotFoundError, unabhängig von der Implementierung des Werkzeugs.
+_TESTS_DIR = Path(__file__).resolve().parents[1]
+if str(_TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TESTS_DIR))
+
 from validation import GroundTruthFetcher
 
 # ---------------------------------------------------------------------------

--- a/tests/tdd/test_alert_state_briefing_reset.py
+++ b/tests/tdd/test_alert_state_briefing_reset.py
@@ -104,11 +104,17 @@ def _save_cached(user_id: str, trip_id: str, cached: list[SegmentWeatherData]) -
 
 
 def _trip(trip_id: str, *, with_levels: bool = False, stage_date: date | None = None) -> Trip:
+    # #1709: feste Ankunftszeiten statt Naismith-Self-Heal (trip_segments.py:
+    # 125-127) — sonst haengt die Etappe komplett am Wanduhr-basierten
+    # Default-Start 08:00 samt Laufzeit-Schaetzung. Die Zeiten selbst tragen
+    # keine Pruefaussage dieser Datei; sie muessen nur ueberhaupt gesetzt sein.
     stage = Stage(
         id="T1", name="Tag 1", date=stage_date or date.today(),
         waypoints=[
-            Waypoint(id="G1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0),
-            Waypoint(id="G2", name="Ziel", lat=LAT + 0.1, lon=LON + 0.1, elevation_m=1500.0),
+            Waypoint(id="G1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0,
+                     arrival_calculated="08:00"),
+            Waypoint(id="G2", name="Ziel", lat=LAT + 0.1, lon=LON + 0.1, elevation_m=1500.0,
+                     arrival_calculated="12:00"),
         ],
     )
     kwargs: dict = {"official_warnings": None}

--- a/tests/tdd/test_alert_undelivered_hint.py
+++ b/tests/tdd/test_alert_undelivered_hint.py
@@ -229,11 +229,17 @@ def _trip(trip_id: str, *, email_format: str = "full") -> Trip:
     """Tour ohne scharfen Kanal: der Briefing-Pfad laeuft VOLLSTAENDIG durch
     (Ergebnis ``no_channels``) und rendert die Mail — versendet wird nichts.
     Muster aus ``test_trip_briefing_anchor_unchanged.py::_trip``."""
+    # #1709: feste Ankunftszeiten statt Naismith-Self-Heal (trip_segments.py:
+    # 125-127) — sonst haengt die Etappe komplett am Wanduhr-basierten
+    # Default-Start 08:00 samt Laufzeit-Schaetzung. Die Zeiten selbst tragen
+    # keine Pruefaussage dieser Datei; sie muessen nur ueberhaupt gesetzt sein.
     stage = Stage(
         id="T1", name="Tag 1", date=date.today(),
         waypoints=[
-            Waypoint(id="G1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0),
-            Waypoint(id="G2", name="Ziel", lat=LAT + 0.1, lon=LON + 0.1, elevation_m=1500.0),
+            Waypoint(id="G1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0,
+                     arrival_calculated="08:00"),
+            Waypoint(id="G2", name="Ziel", lat=LAT + 0.1, lon=LON + 0.1, elevation_m=1500.0,
+                     arrival_calculated="12:00"),
         ],
     )
     trip = Trip(id=trip_id, name="Hinweis-Trip", stages=[stage], official_warnings=None)

--- a/tests/tdd/test_fixture_wallclock_ratchet.py
+++ b/tests/tdd/test_fixture_wallclock_ratchet.py
@@ -124,8 +124,18 @@ TESTS_ROOT = REPO_ROOT / "tests"
 # (Endung .py.txt) — sonst meldete der Waechter seine eigenen Fixtures.
 _FAELLE_DATEI = REPO_ROOT / "tests/fixtures/ratchet_cases/wallclock_arrival_faelle.py.txt"
 
+# Fixture-Quelltexte fuer die ZWEITE Fundregel (#1709, indirekte Variante) —
+# derselbe Grund fuer die .py.txt-Endung wie oben.
+_INDIREKT_FAELLE_DATEI = (
+    REPO_ROOT / "tests/fixtures/ratchet_cases/indirekte_wanduhr_faelle.py.txt"
+)
+
 # Pruefdatum des Regel-Budgets: 2026-11-08
 EXPIRY = date(2026, 11, 8)
+
+# Pruefdatum des Regel-Budgets der ZWEITEN Fundregel (#1709): 2026-11-10, aus
+# dem Ticket uebernommen.
+EXPIRY_INDIREKT = date(2026, 11, 10)
 
 _HHMM = "%H:%M"
 _WANDUHR_NAMEN = ("now", "jetzt", "heute")
@@ -520,6 +530,18 @@ def _attrappe(tmp_path: Path, quelltext: str) -> Path:
     return f
 
 
+def _fall_indirekt(name: str) -> str:
+    """Fixture-Quelltext ``name`` aus der externen Vorlagendatei der ZWEITEN
+    Fundregel (#1709) holen."""
+    abschnitte = re.split(r"^# === (\S+) ===$\n",
+                          _INDIREKT_FAELLE_DATEI.read_text("utf-8"), flags=re.M)
+    vorrat = dict(zip(abschnitte[1::2], abschnitte[2::2]))
+    assert name in vorrat, (
+        f"Fall {name!r} fehlt in {_INDIREKT_FAELLE_DATEI}: {sorted(vorrat)}"
+    )
+    return vorrat[name]
+
+
 # ══════════════ Die Ratsche selbst (heute ROT, gruen nach S1) ══════════════
 
 def test_keine_fixture_baut_ankunft_aus_der_rohen_wanduhr():
@@ -670,3 +692,488 @@ def test_regel_budget_pruefdatum_steht_als_text_in_der_datei():
         "Das ISO-Pruefdatum muss als Text in dieser Datei stehen, damit das "
         "Gate-Audit es per grep findet."
     )
+
+
+# ═══════════ #1709: zweite Fundregel — indirekte Wanduhr-Abhaengigkeit ═══════════
+#
+# Anders als die erste Regel (Ankunftszeit direkt aus der Wanduhr gerechnet)
+# meldet diese Regel das LOGISCHE GEGENTEIL: eine Fixture, die GAR KEINE
+# Ankunftszeit setzt, wodurch der Pruefling (nicht die Fixture) eine
+# Tageszeit-Grenze selbst berechnet (Naismith-Default 08:00 Start, s.
+# ``src/services/trip_segments.py``). Fundbedingung, ALLE Merkmale zugleich:
+#
+#   1. die Funktion baut eine Etappe mit >= 2 Wegpunkten,
+#   2. das Etappendatum stammt aus der Wanduhr (dieselbe Erkennung wie
+#      _ist_wanduhr_datum oben),
+#   3. KEIN Wegpunkt traegt arrival_calculated ODER arrival_override,
+#   4. stage.start_time ist nicht gesetzt,
+#   5. die Datei nutzt WEDER arrival_window_fixtures NOCH briefing_zeiten,
+#   6. die Datei importiert einen zeitgrenzen-auswertenden Pfad (trip_alert,
+#      compare_alert, trip_report_scheduler, compare_slot_scheduler,
+#      alert_gate, deviation_alert, alert_daily_limit, official_alert).
+#
+# Die ersten vier Merkmale sind AM PRUEFLING abgelesen, nicht geraten
+# (``src/services/trip_segments.py``, HEAD ``b6674c94``):
+#   - >= 2 Wegpunkte:        :121-123 "if len(stage.waypoints) < 2: return []"
+#   - kein arrival_calculated: :125-127 Self-Heal-Ausloeser
+#     "all(wp.arrival_calculated is None ...)"
+#   - kein arrival_override: :36-52 _known_time_for_index, Kette
+#     arrival_override > stage.start_time (idx 0) > arrival_calculated --
+#     arrival_override GEWINNT, auch wenn der Self-Heal-Ausloeser erfuellt
+#     waere (AC-2 Fall c, der heikelste)
+#   - kein stage.start_time: :132 "default_start = stage.start_time if
+#     stage.start_time else time(8, 0)"
+#
+# Verworfen: eine Fundregel, die den Pruefling analysiert -- bei acht
+# gemessenen Kippkanten-Familien in verschiedenen Modulen fuehrte das zu
+# einer Regel, die entweder alles oder nichts meldet (Spec, Abschnitt
+# "Gewaehlte Loesung").
+
+
+def _stage_calls(funktion: ast.AST) -> list[ast.Call]:
+    """Alle ``Stage(...)``-Aufrufe innerhalb dieser Funktion."""
+    return [n for n in ast.walk(funktion) if isinstance(n, ast.Call)
+            and ((isinstance(n.func, ast.Name) and n.func.id == "Stage")
+                 or (isinstance(n.func, ast.Attribute) and n.func.attr == "Stage"))]
+
+
+def _ist_waypoint_call(node: ast.AST) -> bool:
+    return (isinstance(node, ast.Call)
+            and ((isinstance(node.func, ast.Name) and node.func.id == "Waypoint")
+                 or (isinstance(node.func, ast.Attribute) and node.func.attr == "Waypoint")))
+
+
+def _hat_kwargs_entpackung(call: ast.Call) -> bool:
+    """``Stage(**irgendwas)`` -- die Schluesselwoerter stammen aus einem
+    Dict, dessen Inhalt der Scanner nicht einsehen kann (Adversary-Finding
+    F002 zu #1709)."""
+    return any(kw.arg is None for kw in call.keywords)
+
+
+def _wegpunkte_wert(stage_call: ast.Call) -> ast.AST | None:
+    """Der Wert des ``waypoints=``-Arguments, oder ``None`` wenn keins
+    gesetzt ist."""
+    for kw in stage_call.keywords:
+        if kw.arg == "waypoints":
+            return kw.value
+    return None
+
+
+def _wegpunkte_liste(wert: ast.AST, zuweisungen: dict[str, list[ast.AST]],
+                     gesehen: frozenset[str] = frozenset()) -> list[ast.Call] | None:
+    """Loest ``wert`` (den Wert von ``waypoints=``) zu einer VOLLSTAENDIG
+    einsehbaren flachen Liste von ``Waypoint(...)``-Aufrufen auf.
+
+    ``None`` heisst: die Menge ist NICHT vollstaendig einsehbar -- ein
+    Aufruf einer Hilfsfunktion (F001, ``waypoints=_bau_wegpunkte()``), eine
+    Comprehension (F003, ``[Waypoint(...) for x in liste]``, deren Laenge
+    erst zur Laufzeit feststeht) oder ein Name, dessen Herkunft sich nicht
+    aufloesen laesst. Uebertragen aus #1431 (``hook_utils.is_git_subcommand``):
+    nicht "erkenne ich das Muster", sondern "bin ich sicher, dass es NICHT
+    vorliegt". Eine Etappe gilt deshalb nur dann als sicher unter zwei
+    Wegpunkten, wenn diese Funktion eine LEERE Liste zurueckgibt -- bei
+    ``None`` bleibt die Etappe pruefbeduerftig statt immun."""
+    if _ist_waypoint_call(wert):
+        return [wert]
+    if isinstance(wert, ast.List):
+        ergebnis: list[ast.Call] = []
+        for element in wert.elts:
+            teil = _wegpunkte_liste(element, zuweisungen, gesehen)
+            if teil is None:
+                return None
+            ergebnis.extend(teil)
+        return ergebnis
+    if isinstance(wert, ast.Name):
+        if wert.id in gesehen:
+            return None
+        zuweisungswerte = zuweisungen.get(wert.id)
+        if not zuweisungswerte:
+            return None
+        gesehen = gesehen | {wert.id}
+        ergebnis = []
+        for einzelwert in zuweisungswerte:
+            teil = _wegpunkte_liste(einzelwert, zuweisungen, gesehen)
+            if teil is None:
+                return None
+            ergebnis.extend(teil)
+        return ergebnis
+    # Aufruf einer Hilfsfunktion, Comprehension, Attribute, Entpackung
+    # (``*rest``) o.ae. -- die Menge ist nicht statisch zaehlbar.
+    return None
+
+
+def _keyword_ist_gesetzt(call: ast.Call, name: str) -> bool:
+    """Traegt ``call`` das Keyword ``name`` mit einem Wert, der NICHT ``None``
+    ist? Ein fehlendes Keyword oder ``name=None`` zaehlt als "nicht gesetzt"."""
+    for kw in call.keywords:
+        if kw.arg == name:
+            return not (isinstance(kw.value, ast.Constant) and kw.value.value is None)
+    return False
+
+
+def _stage_ist_anfaellig(stage_call: ast.Call, zuweisungen: dict[str, list[ast.AST]]) -> bool:
+    """Merkmale 1, 3, 4 fuer EINEN ``Stage(...)``-Aufruf: >= 2 Wegpunkte,
+    keiner mit arrival_calculated/arrival_override, kein gesetztes
+    stage.start_time -- direkt an trip_segments.py:121-132 abgelesen (s.
+    Tabelle oben).
+
+    Merkmal 1 (>= 2 Wegpunkte) gilt als erfuellt, sobald die Menge NICHT
+    beweisbar unter zwei liegt -- s. ``_wegpunkte_liste`` (F001-F003).
+
+    Merkmal 4 (``stage.start_time``) wird ZUERST geprueft, VOR der
+    Wegpunkt-Aufloesung: ein direkt gesetztes ``start_time=`` macht die
+    Etappe unabhaengig davon immun, ob die Wegpunkt-Menge einsehbar ist --
+    sonst uebersteuerte eine unaufloesbare ``waypoints=``-Angabe (F001-F003)
+    faelschlich eine bereits vorhandene Haertung ueber ``start_time``."""
+    if _keyword_ist_gesetzt(stage_call, "start_time"):
+        return False
+    if _hat_kwargs_entpackung(stage_call):
+        return True
+    wert = _wegpunkte_wert(stage_call)
+    if wert is None:
+        return False  # kein waypoints=... -> Default ist eine leere Liste
+    wegpunkte = _wegpunkte_liste(wert, zuweisungen)
+    if wegpunkte is None:
+        return True  # Menge nicht einsehbar -> pruefbeduerftig, nicht immun
+    if len(wegpunkte) < 2:
+        return False
+    if any(_keyword_ist_gesetzt(wp, "arrival_calculated")
+           or _keyword_ist_gesetzt(wp, "arrival_override") for wp in wegpunkte):
+        return False
+    return True
+
+
+# Zeitgrenzen-auswertende Pfade (Merkmal 6) bleiben DATEI-weit (Import): sie
+# entscheiden, ob der Pruefling in dieser Datei ueberhaupt eine Tageszeit-
+# Grenze auswertet, nicht ob eine EINZELNE Funktion gehaertet ist.
+#
+# Haertungs-Helfer (Merkmal 5) sind dagegen FUNKTIONS-weit (Adversary-Finding
+# F004 zu #1709): die urspruengliche Fassung machte am Import fest -- eine
+# Fixture galt schon dann als geschuetzt, wenn IRGENDEINE Funktion derselben
+# Datei den Helfer importierte, nicht wenn sie ihn selbst BENUTZTE. Eine
+# zweite, ungehaertete Funktion derselben Datei blieb dadurch unsichtbar.
+# Die Ausnahme greift jetzt nur, wenn die betroffene Funktion selbst einen
+# der importierten Namen (``stage_date``, ``briefing_zeiten_fuer_trip`` o.ae.)
+# AUFRUFT -- geprueft an den bestehenden Gegenproben (e)/(f), die den Aufruf
+# bereits jeweils in der eigenen Funktion haben.
+_HAERTUNGS_HELFER_INDIREKT = ("arrival_window_fixtures", "briefing_zeiten")
+_ALARMPFADE_INDIREKT = (
+    "trip_alert", "compare_alert", "trip_report_scheduler", "compare_slot_scheduler",
+    "alert_gate", "deviation_alert", "alert_daily_limit", "official_alert",
+)
+
+
+def _importierte_module(baum: ast.AST) -> set[str]:
+    module: set[str] = set()
+    for n in ast.walk(baum):
+        if isinstance(n, ast.ImportFrom) and n.module:
+            module.add(n.module)
+        elif isinstance(n, ast.Import):
+            for alias in n.names:
+                module.add(alias.name)
+    return module
+
+
+def _importiert_eines_von(module: set[str], namen: tuple[str, ...]) -> bool:
+    return any(name in m for name in namen for m in module)
+
+
+def _importierte_haertungs_namen(baum: ast.AST) -> set[str]:
+    """Namen, die per ``from <haertungs-modul> import <name>`` in diese Datei
+    gelangt sind -- z.B. ``stage_date`` aus
+    ``tests.helpers.arrival_window_fixtures``. Grundlage fuer die
+    FUNKTIONS-weite Pruefung (F004), nicht mehr fuer eine dateiweite."""
+    namen: set[str] = set()
+    for n in ast.walk(baum):
+        if not isinstance(n, ast.ImportFrom) or not n.module:
+            continue
+        if not any(helfer in n.module for helfer in _HAERTUNGS_HELFER_INDIREKT):
+            continue
+        for alias in n.names:
+            namen.add(alias.asname or alias.name)
+    return namen
+
+
+def _funktion_nutzt_haertungs_helfer(funktion: ast.AST, haertungs_namen: set[str]) -> bool:
+    """Ruft die FUNKTION SELBST einen der importierten Haertungs-Bausteine
+    auf? (Adversary-Finding F004: vorher entschied allein der Import
+    irgendwo in der Datei, nicht die tatsaechliche Nutzung durch diese
+    Funktion.)"""
+    if not haertungs_namen:
+        return False
+    return any(isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+               and n.func.id in haertungs_namen for n in ast.walk(funktion))
+
+
+def scan_indirekte_wanduhr_fixtures(tests_root: Path) -> list[Finding]:
+    """Alle Funktionen unter ``tests_root``, die eine Etappe mit
+    Wanduhr-Datum und nicht beweisbar unter 2 Wegpunkten bauen, OHNE jede
+    Ankunftszeit, OHNE dass die Funktion SELBST einen Haertungs-Helfer
+    aufruft, UND mit Alarmpfad-Import in der Datei (zweite Fundregel, #1709
+    -- s. Kommentarblock oben)."""
+    funde: list[Finding] = []
+    for datei in sorted(tests_root.rglob("*.py")):
+        try:
+            baum = ast.parse(datei.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+
+        module = _importierte_module(baum)
+        if not _importiert_eines_von(module, _ALARMPFADE_INDIREKT):
+            continue
+        haertungs_namen = _importierte_haertungs_namen(baum)
+
+        for knoten in ast.walk(baum):
+            if not isinstance(knoten, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if _funktion_nutzt_haertungs_helfer(knoten, haertungs_namen):
+                continue
+            zuw = _zuweisungen(knoten)
+            anfaellige_stages = [s for s in _stage_calls(knoten)
+                                 if _stage_ist_anfaellig(s, zuw)]
+            if not anfaellige_stages:
+                continue
+            if not any(_ist_wanduhr_datum(n) for n in ast.walk(knoten)):
+                continue
+            funde.append(Finding(path=datei, function=knoten.name,
+                                 line=anfaellige_stages[0].lineno))
+    return funde
+
+
+# 🔴 Wie bei KNOWN_VIOLATIONS oben: nur SCHRUMPFEN, nie fuellen um gruen zu
+# werden. Die 11 Eintraege unten sind der GEMESSENE, nicht geratene Bestand
+# (Scanner-Lauf ueber tests/ bei Implementierung dieser Scheibe): jede Datei
+# baut eine Etappe mit Wanduhr-Datum, >= 2 Wegpunkten, ohne jede Ankunftszeit
+# und importiert einen Alarmpfad -- strukturell exakt das Anti-Muster.
+#
+# Sanierung ist laut Spec (Abschnitt "Nicht in dieser Scheibe") ausdruecklich
+# NICHT Gegenstand dieser Scheibe: "Keine Sanierung von Bestandsdateien
+# (gemessen: nicht noetig, s. Source)". Die Source-Messung dort (Tabelle
+# "Bestandsmenge ist gemessen, nicht geschaetzt") belegt per
+# matrix_differenz()-Lauf ueber vergleichbare Kandidatenmengen, dass diese
+# Bauart bei den gemessenen Uhrzeiten NICHT tatsaechlich kippt -- anders als
+# der eine Fall aus #1871 (dort NICHT in dieser Liste, weiterhin offen,
+# ausdruecklich ausserhalb dieser Scheibe). Diese Regel meldet strukturelles
+# Risiko, nicht gemessene Flakiness (s. Kommentarblock oben, "Verworfen").
+#
+# Anders als bei der ERSTEN Regel oben ist die Rechtfertigung hier NICHT "die
+# Fixture braucht das Anti-Muster", sondern "Sanierung ist fuer diese Scheibe
+# explizit nicht beauftragt" -- eine bewusst andere Kategorie, review-pflichtig
+# wie dort.
+KNOWN_VIOLATIONS_INDIREKT: frozenset[tuple[str, str]] = frozenset({
+    # #1709 Haertung (2026-08-15): 9 von 10 Bestandsstellen sind gehaertet
+    # (arrival_calculated gesetzt, s. Commits dieser Scheibe). Der letzte
+    # Eintrag bleibt, solange der Datei-Claim-Gate die Haertung von
+    # tests/tdd/test_alert_undelivered_hint.py blockiert (fremde Session
+    # auf Worktree fix-1676-s2-sms-versand / Branch fix-1750-sperrzeit-wortwahl).
+    ("tests/tdd/test_alert_undelivered_hint.py", "_trip"),
+})
+
+
+def test_scanner_meldet_die_indirekte_variante(tmp_path):
+    """AC-1: Etappe mit Wanduhr-Datum OHNE jede Ankunftszeit, ohne
+    Haertungs-Helfer, mit Alarmpfad-Import -> wird gemeldet (Datei,
+    Funktionsname, Zeile)."""
+    _attrappe(tmp_path, _fall_indirekt("indirekt-antimuster"))
+    funde = scan_indirekte_wanduhr_fixtures(tmp_path)
+    assert len(funde) == 1, f"erwartet 1 Fund, bekommen: {[f.ref for f in funde]}"
+    assert funde[0].function == "_trip_ohne_ankunftszeiten"
+
+
+def test_scanner_schweigt_bei_nur_einem_wegpunkt(tmp_path):
+    """AC-2 (a): eine Ein-Wegpunkt-Etappe erzeugt gar kein Segment
+    (trip_segments.py:121-123) — kein Fund."""
+    _attrappe(tmp_path, _fall_indirekt("nur-ein-wegpunkt"))
+    funde = scan_indirekte_wanduhr_fixtures(tmp_path)
+    assert not funde, f"Falsch-Positiv bei nur einem Wegpunkt: {[f.ref for f in funde]}"
+
+
+def test_scanner_schweigt_bei_gesetztem_arrival_calculated(tmp_path):
+    """AC-2 (b): arrival_calculated ist gesetzt -> der Self-Heal-Ausloeser
+    greift nicht — kein Fund."""
+    _attrappe(tmp_path, _fall_indirekt("arrival-calculated-gesetzt"))
+    funde = scan_indirekte_wanduhr_fixtures(tmp_path)
+    assert not funde, f"Falsch-Positiv bei arrival_calculated: {[f.ref for f in funde]}"
+
+
+def test_scanner_schweigt_bei_gesetztem_arrival_override(tmp_path):
+    """AC-2 (c), der heikelste Fall: arrival_calculated ist bei ALLEN
+    Wegpunkten None (der Self-Heal-Ausloeser waere erfuellt), aber
+    arrival_override gewinnt in _known_time_for_index (trip_segments.py:
+    36-52) noch vor dem Default -> kein Fund. Eine Regel, die nur auf
+    arrival_calculated schaut, meldet diese Fixture faelschlich."""
+    _attrappe(tmp_path, _fall_indirekt("arrival-override-gesetzt"))
+    funde = scan_indirekte_wanduhr_fixtures(tmp_path)
+    assert not funde, f"Falsch-Positiv bei arrival_override: {[f.ref for f in funde]}"
+
+
+def test_scanner_schweigt_bei_gesetztem_stage_start_time(tmp_path):
+    """AC-2 (d): stage.start_time ist gesetzt -> ersetzt den
+    Naismith-Default 08:00 (trip_segments.py:132) — kein Fund."""
+    _attrappe(tmp_path, _fall_indirekt("stage-start-time-gesetzt"))
+    funde = scan_indirekte_wanduhr_fixtures(tmp_path)
+    assert not funde, f"Falsch-Positiv bei stage.start_time: {[f.ref for f in funde]}"
+
+
+def test_scanner_schweigt_bei_arrival_window_fixtures_import(tmp_path):
+    """AC-2 (e): die Datei nutzt den Haertungs-Helfer
+    arrival_window_fixtures -> kein Fund."""
+    _attrappe(tmp_path, _fall_indirekt("nutzt-arrival-window-fixtures"))
+    funde = scan_indirekte_wanduhr_fixtures(tmp_path)
+    assert not funde, (
+        f"Falsch-Positiv trotz arrival_window_fixtures-Import: "
+        f"{[f.ref for f in funde]}"
+    )
+
+
+def test_scanner_schweigt_bei_briefing_zeiten_import(tmp_path):
+    """AC-2 (f): die Datei nutzt den Haertungs-Helfer briefing_zeiten ->
+    kein Fund."""
+    _attrappe(tmp_path, _fall_indirekt("nutzt-briefing-zeiten"))
+    funde = scan_indirekte_wanduhr_fixtures(tmp_path)
+    assert not funde, (
+        f"Falsch-Positiv trotz briefing_zeiten-Import: {[f.ref for f in funde]}"
+    )
+
+
+def test_scanner_schweigt_ohne_alarmpfad_import(tmp_path):
+    """AC-2 (g): die Datei importiert keinen zeitgrenzen-auswertenden Pfad
+    -> kein Fund, obwohl die Fixture-Bauart sonst identisch mit dem
+    Anti-Muster ist."""
+    _attrappe(tmp_path, _fall_indirekt("kein-alarmpfad-import"))
+    funde = scan_indirekte_wanduhr_fixtures(tmp_path)
+    assert not funde, (
+        f"Falsch-Positiv ohne Alarmpfad-Import: {[f.ref for f in funde]}"
+    )
+
+
+def test_scanner_erkennt_wegpunkte_aus_einer_hilfsfunktion(tmp_path):
+    """Adversary-Finding F001: ``waypoints=_bau_wegpunkte()`` -- eine
+    Hilfsfunktion baut die Wegpunkte AUSSERHALB des ``Stage(...)``-Aufrufs.
+    Die alte Zaehlung sah im Syntaxbaum des Aufrufs 0 ``Waypoint(...)``-
+    Knoten und stufte die Etappe faelschlich als immun ein."""
+    _attrappe(tmp_path, _fall_indirekt("wegpunkte-aus-hilfsfunktion"))
+    funde = scan_indirekte_wanduhr_fixtures(tmp_path)
+    assert len(funde) == 1, f"erwartet 1 Fund, bekommen: {[f.ref for f in funde]}"
+    assert funde[0].function == "_trip_ueber_hilfsfunktion"
+
+
+def test_scanner_erkennt_stage_aus_kwargs_entpackung(tmp_path):
+    """Adversary-Finding F002: ``Stage(**stage_kwargs)`` -- die Keywords
+    stammen aus einem Dict, das der Scanner nicht einsehen kann. Die alte
+    Zaehlung fand am Aufruf gar kein ``waypoints=``-Keyword und stufte die
+    Etappe faelschlich als immun ein."""
+    _attrappe(tmp_path, _fall_indirekt("stage-kwargs-entpackung"))
+    funde = scan_indirekte_wanduhr_fixtures(tmp_path)
+    assert len(funde) == 1, f"erwartet 1 Fund, bekommen: {[f.ref for f in funde]}"
+    assert funde[0].function == "_trip_ueber_kwargs"
+
+
+def test_scanner_erkennt_wegpunkte_aus_einer_comprehension(tmp_path):
+    """Adversary-Finding F003: ``waypoints=[Waypoint(...) for x in liste]``
+    -- die alte Zaehlung sah GENAU EINEN Syntaxknoten, obwohl zur Laufzeit
+    ``len(liste)`` (hier 3) Wegpunkte entstehen, und stufte die Etappe unter
+    der Schwelle von 2 faelschlich als immun ein."""
+    _attrappe(tmp_path, _fall_indirekt("wegpunkte-aus-comprehension"))
+    funde = scan_indirekte_wanduhr_fixtures(tmp_path)
+    assert len(funde) == 1, f"erwartet 1 Fund, bekommen: {[f.ref for f in funde]}"
+    assert funde[0].function == "_trip_ueber_comprehension"
+
+
+def test_scanner_erkennt_ungehaertete_funktion_trotz_dateiweitem_import(tmp_path):
+    """Adversary-Finding F004: die Datei importiert den Haertungs-Helfer,
+    aber nur EINE von zwei Funktionen nutzt ihn. Die alte, dateiweite
+    Pruefung sprach beide frei; jetzt wird nur die tatsaechlich gehaertete
+    Funktion ausgenommen."""
+    _attrappe(tmp_path, _fall_indirekt("haertungs-helfer-nur-in-anderer-funktion"))
+    funde = scan_indirekte_wanduhr_fixtures(tmp_path)
+    assert len(funde) == 1, f"erwartet 1 Fund, bekommen: {[f.ref for f in funde]}"
+    assert funde[0].function == "_ungehaertete_funktion"
+
+
+def test_echter_testbaum_ohne_fehlalarm_der_zweiten_regel():
+    """AC-5: der echte Baum tests/ erzeugt keinen Fehlalarm — Fundmenge leer
+    oder vollstaendig durch KNOWN_VIOLATIONS_INDIREKT gedeckt, UND mindestens
+    20 geprueft Kandidatenfunktionen.
+
+    Die Kandidatenzaehlung ist ABSICHTLICH UNABHAENGIG von
+    scan_indirekte_wanduhr_fixtures() implementiert (Vorbild
+    test_ac3_echter_testbaum_ohne_fehlalarm in
+    test_repo_path_hardcoding_ratchet.py) — sonst wuerde ein Bug in der
+    Kandidatensuche des Scanners auch die Sicherung selbst reissen und ein
+    leerer Scan waere von einem kaputten Scanner nicht zu unterscheiden."""
+    kandidaten: list[str] = []
+    for datei in sorted(TESTS_ROOT.rglob("*.py")):
+        try:
+            baum = ast.parse(datei.read_text(encoding="utf-8", errors="replace"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for knoten in ast.walk(baum):
+            if not isinstance(knoten, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            waypoint_aufrufe = sum(
+                1 for c in ast.walk(knoten)
+                if isinstance(c, ast.Call)
+                and ((isinstance(c.func, ast.Name) and c.func.id == "Waypoint")
+                     or (isinstance(c.func, ast.Attribute) and c.func.attr == "Waypoint"))
+            )
+            if waypoint_aufrufe >= 2:
+                kandidaten.append(f"{datei}:{knoten.name}")
+    assert len(kandidaten) >= 20, (
+        f"nur {len(kandidaten)} Kandidatenfunktionen (>=2 Waypoint(...)-Aufrufe) "
+        "im Testbaum gefunden — die Untergrenze verhindert, dass ein leerer "
+        "Scan durch eine kaputte Kandidatensuche vorgetaeuscht wird"
+    )
+
+    funde = scan_indirekte_wanduhr_fixtures(TESTS_ROOT)
+    offen = [f for f in funde if (_relativ(f), f.function) not in KNOWN_VIOLATIONS_INDIREKT]
+    zeilen = "\n".join(f"  - {_relativ(f)}:{f.line} in {f.function}()" for f in offen)
+    assert not offen, (
+        f"{len(offen)} Fundstellen bauen eine Etappe mit Wanduhr-Datum ohne "
+        f"jede Ankunftszeit, ohne Haertungs-Helfer und mit Alarmpfad-Import:\n"
+        f"{zeilen}"
+    )
+
+
+def test_known_violations_der_neuen_regel_ohne_veraltete_eintraege():
+    """AC-6: KNOWN_VIOLATIONS_INDIREKT darf nur SCHRUMPFEN — was der Scanner
+    nicht mehr findet, muss raus. Muster der bestehenden Regel oben
+    (test_known_violations_enthaelt_keine_veralteten_eintraege)."""
+    aktuell = {(_relativ(f), f.function)
+               for f in scan_indirekte_wanduhr_fixtures(TESTS_ROOT)}
+    veraltet = sorted(KNOWN_VIOLATIONS_INDIREKT - aktuell)
+    assert not veraltet, (
+        "Diese KNOWN_VIOLATIONS_INDIREKT-Eintraege werden nicht mehr gefunden "
+        f"und muessen entfernt werden: {veraltet}"
+    )
+
+
+def test_regel_budget_pruefdatum_der_neuen_regel_steht_als_text():
+    """AC-8: das Pruefdatum der zweiten Fundregel ist maschinell auffindbar —
+    als Konstante UND als Text in der Datei (Muster Z. 663-672 oben)."""
+    assert EXPIRY_INDIREKT == date(2026, 11, 10), (
+        "Pruefdatum des Regel-Budgets der zweiten Fundregel (aus dem Ticket "
+        "#1709 uebernommen)"
+    )
+    text = Path(__file__).read_text(encoding="utf-8").splitlines()
+    assert [n for n, z in enumerate(text, 1) if EXPIRY_INDIREKT.isoformat() in z], (
+        "Das ISO-Pruefdatum der zweiten Fundregel muss als Text in dieser "
+        "Datei stehen, damit das Gate-Audit es per grep findet."
+    )
+
+
+def test_neue_waechter_sind_nicht_von_der_ci_ausgenommen():
+    """AC-9: ein Waechter, der nicht auf der CI-Ampel laeuft, ist keiner.
+    Weder diese Datei noch test_wanduhr_matrix.py duerfen in der
+    tests/tdd/-Ausschlussliste stehen.
+
+    Dieser Test ist heute schon erfuellt — er ist eine Regressionssperre,
+    kein Arbeitsnachweis fuer diese Scheibe: als einziger AC-Test bleibt er
+    von Anfang an gruen."""
+    text = (REPO_ROOT / ".github/ci_tdd_excludes.txt").read_text(encoding="utf-8")
+    for name in ("test_fixture_wallclock_ratchet", "test_wanduhr_matrix"):
+        assert name not in text, (
+            f"{name} steht in .github/ci_tdd_excludes.txt und laeuft damit "
+            "nicht auf der CI-Ampel — ein Waechter, der nicht laeuft, ist "
+            "kein Waechter."
+        )

--- a/tests/tdd/test_fixture_wallclock_ratchet.py
+++ b/tests/tdd/test_fixture_wallclock_ratchet.py
@@ -1005,14 +1005,11 @@ def scan_indirekte_wanduhr_fixtures(tests_root: Path) -> list[Finding]:
 # Fixture braucht das Anti-Muster", sondern "Sanierung ist fuer diese Scheibe
 # explizit nicht beauftragt" -- eine bewusst andere Kategorie, review-pflichtig
 # wie dort.
-KNOWN_VIOLATIONS_INDIREKT: frozenset[tuple[str, str]] = frozenset({
-    # #1709 Haertung (2026-08-15): 9 von 10 Bestandsstellen sind gehaertet
-    # (arrival_calculated gesetzt, s. Commits dieser Scheibe). Der letzte
-    # Eintrag bleibt, solange der Datei-Claim-Gate die Haertung von
-    # tests/tdd/test_alert_undelivered_hint.py blockiert (fremde Session
-    # auf Worktree fix-1676-s2-sms-versand / Branch fix-1750-sperrzeit-wortwahl).
-    ("tests/tdd/test_alert_undelivered_hint.py", "_trip"),
-})
+KNOWN_VIOLATIONS_INDIREKT: frozenset[tuple[str, str]] = frozenset()
+# #1709 Haertung (2026-08-15) abgeschlossen: alle 10 gemessenen
+# Bestandsstellen sind gehaertet (arrival_calculated gesetzt, s. Commits
+# dieser Scheibe, zuletzt tests/tdd/test_alert_undelivered_hint.py::_trip).
+# Die Liste ist damit leer — jeder neue Fund ab hier ist ein echter Verstoss.
 
 
 def test_scanner_meldet_die_indirekte_variante(tmp_path):

--- a/tests/tdd/test_fixture_wallclock_ratchet.py
+++ b/tests/tdd/test_fixture_wallclock_ratchet.py
@@ -907,10 +907,22 @@ _ALARMPFADE_INDIREKT = (
 
 
 def _importierte_module(baum: ast.AST) -> set[str]:
+    """Modulpfade, die diese Datei importiert -- Grundlage fuer Merkmal 6.
+
+    Fuer ``ImportFrom`` zaehlt neben dem reinen Modulpfad (``services``) auch
+    ``<modul>.<importierter name>`` (``services.trip_alert``): ohne diese
+    Ergaenzung erkannte der Teilstring-Vergleich in ``_importiert_eines_von``
+    ``from services import trip_alert`` nicht, obwohl er denselben Alarmpfad
+    importiert wie ``from services.trip_alert import TripAlertService`` --
+    Adversary-Finding F-ADV5 zu #1709. Realer Bestandsstil:
+    tests/tdd/test_alert_run_deadline.py:48,
+    tests/tdd/test_starkregen_kurzfristhinweis.py:45."""
     module: set[str] = set()
     for n in ast.walk(baum):
         if isinstance(n, ast.ImportFrom) and n.module:
             module.add(n.module)
+            for alias in n.names:
+                module.add(f"{n.module}.{alias.name}")
         elif isinstance(n, ast.Import):
             for alias in n.names:
                 module.add(alias.name)
@@ -1171,6 +1183,21 @@ def test_scanner_schweigt_bei_start_time_vor_unaufloesbaren_wegpunkten(tmp_path)
     )
 
 
+def test_scanner_erkennt_alarmpfad_ueber_modulimport(tmp_path):
+    """Adversary-Finding F-ADV5 (HIGH): ``from services import trip_alert``
+    importiert denselben Alarmpfad wie ``from services.trip_alert import
+    TripAlertService``, wird von ``_importierte_module``/
+    ``_importiert_eines_von`` aber nur erkannt, wenn auch der importierte
+    NAME (nicht nur der Modulpfad) in den Vergleich eingeht -- sonst 0 statt
+    1 Fund bei identischem Anti-Muster. Real im Bestand:
+    tests/tdd/test_alert_run_deadline.py:48,
+    tests/tdd/test_starkregen_kurzfristhinweis.py:45."""
+    _attrappe(tmp_path, _fall_indirekt("indirekt-antimuster-import-modulname"))
+    funde = scan_indirekte_wanduhr_fixtures(tmp_path)
+    assert len(funde) == 1, f"erwartet 1 Fund, bekommen: {[f.ref for f in funde]}"
+    assert funde[0].function == "_trip_ohne_ankunftszeiten_modulimport"
+
+
 def test_echter_testbaum_ohne_fehlalarm_der_zweiten_regel():
     """AC-5: der echte Baum tests/ erzeugt keinen Fehlalarm — Fundmenge leer
     oder vollstaendig durch KNOWN_VIOLATIONS_INDIREKT gedeckt, UND mindestens
@@ -1225,6 +1252,42 @@ def test_known_violations_der_neuen_regel_ohne_veraltete_eintraege():
     assert not veraltet, (
         "Diese KNOWN_VIOLATIONS_INDIREKT-Eintraege werden nicht mehr gefunden "
         f"und muessen entfernt werden: {veraltet}"
+    )
+
+
+def test_known_violations_der_neuen_regel_ist_leer():
+    """AC-10 (F-ADV6, CRITICAL): ``KNOWN_VIOLATIONS_INDIREKT`` MUSS leer
+    bleiben -- und zwar erzwungen, nicht nur zufaellig.
+
+    PO-Entscheidung 2026-08-15: ein Fund der zweiten Regel wird durch
+    Haertung der betroffenen Fixture aufgeloest (arrival_calculated /
+    stage.start_time / Haertungs-Helfer), NIEMALS durch einen Eintrag in
+    dieser Liste. Ohne diesen Test erzwingt nichts diese Vorgabe: weder AC-5
+    (``test_echter_testbaum_ohne_fehlalarm_der_zweiten_regel``) noch AC-6
+    (``test_known_violations_der_neuen_regel_ohne_veraltete_eintraege``)
+    schlagen an, wenn jemand eine Haertung zuruecknimmt UND den dadurch
+    entstehenden -- echten -- Fund in ``KNOWN_VIOLATIONS_INDIREKT``
+    eintraegt: AC-5 ist durch den neuen Eintrag gedeckt, AC-6 prueft nur auf
+    VERALTETE Eintraege, nicht auf neue. Adversary-Runde 3 hat das belegt:
+    36 Tests gruen, 0 rot, mit genau diesem Vorgehen.
+
+    Dieser Test prueft deshalb ZWEI Dinge zugleich: die Liste ist leer UND
+    der Scan des echten Baums liefert unabhaengig davon ebenfalls keine
+    Funde -- eine Haertung darf also nicht durch einen Listeneintrag ERSETZT
+    werden."""
+    assert KNOWN_VIOLATIONS_INDIREKT == frozenset(), (
+        "KNOWN_VIOLATIONS_INDIREKT ist nicht leer. Ein Fund der zweiten "
+        "Fundregel wird NICHT durch einen Eintrag hier aufgeloest, sondern "
+        "durch Haertung der betroffenen Fixture (arrival_calculated setzen, "
+        "stage.start_time setzen, oder einen Haertungs-Helfer nutzen). "
+        "PO-Entscheidung 2026-08-15."
+    )
+    funde = scan_indirekte_wanduhr_fixtures(TESTS_ROOT)
+    assert funde == [], (
+        f"{len(funde)} Fundstelle(n) im echten Testbaum, obwohl "
+        "KNOWN_VIOLATIONS_INDIREKT leer sein und bleiben soll -- Haerten "
+        f"statt Eintragen:\n" +
+        "\n".join(f"  - {_relativ(f)}:{f.line} in {f.function}()" for f in funde)
     )
 
 

--- a/tests/tdd/test_fixture_wallclock_ratchet.py
+++ b/tests/tdd/test_fixture_wallclock_ratchet.py
@@ -97,6 +97,25 @@ Zwei Stellen im Bestand brauchen das Anti-Muster strukturell und stehen
 deshalb begruendet in ``KNOWN_VIOLATIONS`` (Begruendung dort, nicht hier —
 sie gehoert an den Eintrag).
 
+**Fuer die ZWEITE Fundregel (``scan_indirekte_wanduhr_fixtures``, #1709)
+gilt zusaetzlich eine Luecke, bewusst NICHT geschlossen** (Adversary-Finding
+F-ADV2): Wird das Wanduhr-Datum im AUFRUFER berechnet und als Parameter an
+eine GESCHWISTER-Funktion uebergeben, die ihrerseits ``Stage(...)`` baut, so
+sieht KEINE der beiden Funktionen fuer sich beide Merkmale zugleich —
+Merkmal 2 (Wanduhr-Datum) steht im Aufrufer, Merkmal 1/3/4 (``Stage(...)``
+mit >= 2 Wegpunkten etc.) in der Geschwister-Funktion, und Ruecksprung- bzw.
+Parameter-Fluss ueber Funktionsgrenzen hinweg wird nicht verfolgt (teuer,
+s. oben). Diese Struktur ist im Bestand bereits ETABLIERT:
+``tests/tdd/test_issue_760_stage_number.py:31`` (Helferfunktion ``_stage(...,
+d: date)``, die ``date`` als Parameter entgegennimmt und ``Stage(date=d,
+...)`` baut) ist heute nur deshalb ungefaehrlich, weil dort ausschliesslich
+mit EINEM Wegpunkt gebaut wird — eine Erweiterung dieser Helferfunktion auf
+ZWEI Wegpunkte wuerde dort bereits genuegen, um die Ratsche zu umgehen, ohne
+dass irgendein Merkmal der UND-Kette lokal fehlt. Aufrufketten ueber
+Funktionsgrenzen zu verfolgen ist teuer, und #1709 erlaubt der Regel
+ausdruecklich, eine Naeherung zu bleiben — SOLANGE die Grenze wie hier
+benannt ist.
+
 Regel-Budget
 ------------
 ``EXPIRY`` (2026-11-08, +90 Tage) — Vorbild ``EXPIRY`` in
@@ -730,16 +749,38 @@ def test_regel_budget_pruefdatum_steht_als_text_in_der_datei():
 # "Gewaehlte Loesung").
 
 
-def _stage_calls(funktion: ast.AST) -> list[ast.Call]:
-    """Alle ``Stage(...)``-Aufrufe innerhalb dieser Funktion."""
+def _importierte_konstruktor_aliase(baum: ast.AST, kanonischer_name: str) -> set[str]:
+    """Alias-Namen, unter denen ``kanonischer_name`` per ``from ... import
+    <kanonischer_name> as <alias>`` in diese Datei gelangt ist -- z.B.
+    ``from app.trip import Stage as S`` -> ``{"S"}``. Gleiche Bauart wie
+    ``_importierte_haertungs_namen`` unten, aber OHNE Modul-Einschraenkung:
+    ein Konstruktor-Alias kann aus jedem Modul kommen. Ohne diese Aufloesung
+    machte ein Alias denselben Anti-Muster-Fall unsichtbar -- 0 statt 1 Fund
+    (Adversary-Finding F-ADV1 zu #1709)."""
+    aliase: set[str] = set()
+    for n in ast.walk(baum):
+        if not isinstance(n, ast.ImportFrom):
+            continue
+        for alias in n.names:
+            if alias.name == kanonischer_name and alias.asname:
+                aliase.add(alias.asname)
+    return aliase
+
+
+def _stage_calls(funktion: ast.AST, stage_aliase: frozenset[str] = frozenset()) -> list[ast.Call]:
+    """Alle ``Stage(...)``-Aufrufe innerhalb dieser Funktion -- auch unter
+    einem importierten Alias (F-ADV1)."""
     return [n for n in ast.walk(funktion) if isinstance(n, ast.Call)
-            and ((isinstance(n.func, ast.Name) and n.func.id == "Stage")
+            and ((isinstance(n.func, ast.Name)
+                  and (n.func.id == "Stage" or n.func.id in stage_aliase))
                  or (isinstance(n.func, ast.Attribute) and n.func.attr == "Stage"))]
 
 
-def _ist_waypoint_call(node: ast.AST) -> bool:
+def _ist_waypoint_call(node: ast.AST, waypoint_aliase: frozenset[str] = frozenset()) -> bool:
+    """Auch unter einem importierten Alias (F-ADV1)."""
     return (isinstance(node, ast.Call)
-            and ((isinstance(node.func, ast.Name) and node.func.id == "Waypoint")
+            and ((isinstance(node.func, ast.Name)
+                  and (node.func.id == "Waypoint" or node.func.id in waypoint_aliase))
                  or (isinstance(node.func, ast.Attribute) and node.func.attr == "Waypoint")))
 
 
@@ -760,7 +801,8 @@ def _wegpunkte_wert(stage_call: ast.Call) -> ast.AST | None:
 
 
 def _wegpunkte_liste(wert: ast.AST, zuweisungen: dict[str, list[ast.AST]],
-                     gesehen: frozenset[str] = frozenset()) -> list[ast.Call] | None:
+                     gesehen: frozenset[str] = frozenset(),
+                     waypoint_aliase: frozenset[str] = frozenset()) -> list[ast.Call] | None:
     """Loest ``wert`` (den Wert von ``waypoints=``) zu einer VOLLSTAENDIG
     einsehbaren flachen Liste von ``Waypoint(...)``-Aufrufen auf.
 
@@ -773,12 +815,12 @@ def _wegpunkte_liste(wert: ast.AST, zuweisungen: dict[str, list[ast.AST]],
     vorliegt". Eine Etappe gilt deshalb nur dann als sicher unter zwei
     Wegpunkten, wenn diese Funktion eine LEERE Liste zurueckgibt -- bei
     ``None`` bleibt die Etappe pruefbeduerftig statt immun."""
-    if _ist_waypoint_call(wert):
+    if _ist_waypoint_call(wert, waypoint_aliase):
         return [wert]
     if isinstance(wert, ast.List):
         ergebnis: list[ast.Call] = []
         for element in wert.elts:
-            teil = _wegpunkte_liste(element, zuweisungen, gesehen)
+            teil = _wegpunkte_liste(element, zuweisungen, gesehen, waypoint_aliase)
             if teil is None:
                 return None
             ergebnis.extend(teil)
@@ -792,7 +834,7 @@ def _wegpunkte_liste(wert: ast.AST, zuweisungen: dict[str, list[ast.AST]],
         gesehen = gesehen | {wert.id}
         ergebnis = []
         for einzelwert in zuweisungswerte:
-            teil = _wegpunkte_liste(einzelwert, zuweisungen, gesehen)
+            teil = _wegpunkte_liste(einzelwert, zuweisungen, gesehen, waypoint_aliase)
             if teil is None:
                 return None
             ergebnis.extend(teil)
@@ -811,7 +853,8 @@ def _keyword_ist_gesetzt(call: ast.Call, name: str) -> bool:
     return False
 
 
-def _stage_ist_anfaellig(stage_call: ast.Call, zuweisungen: dict[str, list[ast.AST]]) -> bool:
+def _stage_ist_anfaellig(stage_call: ast.Call, zuweisungen: dict[str, list[ast.AST]],
+                         waypoint_aliase: frozenset[str] = frozenset()) -> bool:
     """Merkmale 1, 3, 4 fuer EINEN ``Stage(...)``-Aufruf: >= 2 Wegpunkte,
     keiner mit arrival_calculated/arrival_override, kein gesetztes
     stage.start_time -- direkt an trip_segments.py:121-132 abgelesen (s.
@@ -832,7 +875,7 @@ def _stage_ist_anfaellig(stage_call: ast.Call, zuweisungen: dict[str, list[ast.A
     wert = _wegpunkte_wert(stage_call)
     if wert is None:
         return False  # kein waypoints=... -> Default ist eine leere Liste
-    wegpunkte = _wegpunkte_liste(wert, zuweisungen)
+    wegpunkte = _wegpunkte_liste(wert, zuweisungen, waypoint_aliase=waypoint_aliase)
     if wegpunkte is None:
         return True  # Menge nicht einsehbar -> pruefbeduerftig, nicht immun
     if len(wegpunkte) < 2:
@@ -922,6 +965,8 @@ def scan_indirekte_wanduhr_fixtures(tests_root: Path) -> list[Finding]:
         if not _importiert_eines_von(module, _ALARMPFADE_INDIREKT):
             continue
         haertungs_namen = _importierte_haertungs_namen(baum)
+        stage_aliase = frozenset(_importierte_konstruktor_aliase(baum, "Stage"))
+        waypoint_aliase = frozenset(_importierte_konstruktor_aliase(baum, "Waypoint"))
 
         for knoten in ast.walk(baum):
             if not isinstance(knoten, (ast.FunctionDef, ast.AsyncFunctionDef)):
@@ -929,8 +974,8 @@ def scan_indirekte_wanduhr_fixtures(tests_root: Path) -> list[Finding]:
             if _funktion_nutzt_haertungs_helfer(knoten, haertungs_namen):
                 continue
             zuw = _zuweisungen(knoten)
-            anfaellige_stages = [s for s in _stage_calls(knoten)
-                                 if _stage_ist_anfaellig(s, zuw)]
+            anfaellige_stages = [s for s in _stage_calls(knoten, stage_aliase)
+                                 if _stage_ist_anfaellig(s, zuw, waypoint_aliase)]
             if not anfaellige_stages:
                 continue
             if not any(_ist_wanduhr_datum(n) for n in ast.walk(knoten)):
@@ -1089,6 +1134,44 @@ def test_scanner_erkennt_ungehaertete_funktion_trotz_dateiweitem_import(tmp_path
     funde = scan_indirekte_wanduhr_fixtures(tmp_path)
     assert len(funde) == 1, f"erwartet 1 Fund, bekommen: {[f.ref for f in funde]}"
     assert funde[0].function == "_ungehaertete_funktion"
+
+
+def test_scanner_erkennt_stage_und_waypoint_hinter_import_alias(tmp_path):
+    """Adversary-Finding F-ADV1 (HIGH): ``from app.trip import Stage as S,
+    Waypoint as WP`` machte denselben Anti-Muster-Fall unsichtbar, wenn der
+    Scanner Konstruktoren nur am literalen Namen erkennt -- 0 statt 1 Fund
+    bei identischem Muster."""
+    _attrappe(tmp_path, _fall_indirekt("indirekt-antimuster-mit-alias"))
+    funde = scan_indirekte_wanduhr_fixtures(tmp_path)
+    assert len(funde) == 1, f"erwartet 1 Fund, bekommen: {[f.ref for f in funde]}"
+    assert funde[0].function == "_trip_ohne_ankunftszeiten_alias"
+
+
+def test_scanner_schweigt_bei_literalem_etappendatum(tmp_path):
+    """AC-2 (h), Adversary-Finding F-ADV3 (MEDIUM): eigene Gegenprobe fuer
+    Merkmal 2 (Wanduhr-Etappendatum) -- ein LITERALES Datum statt
+    Wanduhr-Arithmetik, sonst identisch zum Anti-Muster -> kein Fund. Ohne
+    diesen Test faengt keine Attrappe die Mutation "Merkmal 2 aus der
+    UND-Kette entfernen" gezielt ab."""
+    _attrappe(tmp_path, _fall_indirekt("literales-datum-statt-wanduhr"))
+    funde = scan_indirekte_wanduhr_fixtures(tmp_path)
+    assert not funde, f"Falsch-Positiv bei literalem Etappendatum: {[f.ref for f in funde]}"
+
+
+def test_scanner_schweigt_bei_start_time_vor_unaufloesbaren_wegpunkten(tmp_path):
+    """Regressionsschutz (Adversary-Finding F-ADV4, MEDIUM): stage.start_time
+    gesetzt UND waypoints= nicht statisch einsehbar (Modulkonstante) -- die
+    Immunitaet ueber start_time muss VOR der Wegpunkt-Aufloesung greifen,
+    sonst erzeugt die unaufloesbare Menge faelschlich einen Fund, obwohl
+    start_time die Etappe bereits immun macht (trip_segments.py:132).
+    Bewacht die Reihenfolge in ``_stage_ist_anfaellig()`` direkt, statt nur
+    ueber zwei thematisch unbeteiligte Bestandsdateien."""
+    _attrappe(tmp_path, _fall_indirekt("start-time-mit-unaufloesbaren-wegpunkten"))
+    funde = scan_indirekte_wanduhr_fixtures(tmp_path)
+    assert not funde, (
+        f"Falsch-Positiv trotz start_time vor unaufloesbaren Wegpunkten: "
+        f"{[f.ref for f in funde]}"
+    )
 
 
 def test_echter_testbaum_ohne_fehlalarm_der_zweiten_regel():

--- a/tests/tdd/test_import_und_fremdquellen_folgen_ortstag.py
+++ b/tests/tdd/test_import_und_fremdquellen_folgen_ortstag.py
@@ -316,10 +316,16 @@ def test_ac6_debug_trigger_radar_alert_today_folgt_trip_local_today(monkeypatch)
             Stage(
                 id="S0", name="Etappe 0", date=erwarteter_ortstag,
                 waypoints=[
+                    # #1709: feste Ankunftszeiten statt Naismith-Self-Heal
+                    # (trip_segments.py:125-127) — der Ortstag dieses Tests
+                    # ist bewusst UNVERAENDERT (er ist die Pruefaussage von
+                    # AC-6), nur die Ankunftszeiten werden ergaenzt.
                     Waypoint(id="W0", name="Start", lat=KIRITIMATI[0],
-                              lon=KIRITIMATI[1], elevation_m=10),
+                              lon=KIRITIMATI[1], elevation_m=10,
+                              arrival_calculated="08:00"),
                     Waypoint(id="W1", name="Ziel", lat=KIRITIMATI[0] + 0.05,
-                              lon=KIRITIMATI[1] + 0.05, elevation_m=20),
+                              lon=KIRITIMATI[1] + 0.05, elevation_m=20,
+                              arrival_calculated="12:00"),
                 ],
             ),
         ],

--- a/tests/tdd/test_issue_1069_tier_channel_gating.py
+++ b/tests/tdd/test_issue_1069_tier_channel_gating.py
@@ -175,11 +175,16 @@ def _make_segment_data():
 def _make_trip(trip_id: str, send_sms: bool):
     from app.trip import Stage, Trip, Waypoint
     from app.models import TripReportConfig
+    # #1709: feste Ankunftszeiten statt Naismith-Self-Heal
+    # (trip_segments.py:125-127) — die Zeiten selbst tragen keine
+    # Pruefaussage dieser Datei, sie muessen nur ueberhaupt gesetzt sein.
     stage = Stage(
         id="S1", name="Etappe 1", date=date.today() + timedelta(days=1),
         waypoints=[
-            Waypoint(id="W1", name="Start", lat=42.2, lon=9.05, elevation_m=400),
-            Waypoint(id="W2", name="Ziel", lat=42.25, lon=9.09, elevation_m=1200),
+            Waypoint(id="W1", name="Start", lat=42.2, lon=9.05, elevation_m=400,
+                     arrival_calculated="08:00"),
+            Waypoint(id="W2", name="Ziel", lat=42.25, lon=9.09, elevation_m=1200,
+                     arrival_calculated="12:00"),
         ],
     )
     return Trip(
@@ -346,11 +351,16 @@ def _make_alert_trip(trip_id: str, send_sms: bool, rule_channels: list[str] | No
     from app.trip import Stage, Trip, Waypoint
     from app.models import AlertRule, AlertRuleKind, AlertMetric, AlertSeverity, TripReportConfig
 
+    # #1709: feste Ankunftszeiten statt Naismith-Self-Heal
+    # (trip_segments.py:125-127) — die Zeiten selbst tragen keine
+    # Pruefaussage dieser Datei, sie muessen nur ueberhaupt gesetzt sein.
     stage = Stage(
         id="S1", name="Etappe 1", date=date.today() + timedelta(days=1),
         waypoints=[
-            Waypoint(id="W1", name="Start", lat=42.2, lon=9.05, elevation_m=400),
-            Waypoint(id="W2", name="Ziel", lat=42.25, lon=9.09, elevation_m=1200),
+            Waypoint(id="W1", name="Start", lat=42.2, lon=9.05, elevation_m=400,
+                     arrival_calculated="08:00"),
+            Waypoint(id="W2", name="Ziel", lat=42.25, lon=9.09, elevation_m=1200,
+                     arrival_calculated="12:00"),
         ],
     )
     rules = []

--- a/tests/tdd/test_issue_1087_trip_official_alerts.py
+++ b/tests/tdd/test_issue_1087_trip_official_alerts.py
@@ -517,8 +517,13 @@ class TestAC3LoaderRoundtripPersistence:
         from app.loader import load_trip, save_trip
         from app.trip import Stage, Trip, Waypoint
 
-        wp1 = Waypoint(id="w1", name="Nizza", lat=NICE_LAT, lon=NICE_LON, elevation_m=10)
-        wp2 = Waypoint(id="w2", name="Villefranche", lat=43.7048, lon=7.3131, elevation_m=20)
+        # #1709: feste Ankunftszeiten statt Naismith-Self-Heal (trip_segments.py:
+        # 125-127) — die Zeiten selbst tragen keine Pruefaussage dieser Datei
+        # (Read-Modify-Write-Roundtrip), sie muessen nur ueberhaupt gesetzt sein.
+        wp1 = Waypoint(id="w1", name="Nizza", lat=NICE_LAT, lon=NICE_LON, elevation_m=10,
+                       arrival_calculated="09:00")
+        wp2 = Waypoint(id="w2", name="Villefranche", lat=43.7048, lon=7.3131, elevation_m=20,
+                       arrival_calculated="11:00")
         stage = Stage(id="s1", name="Etappe Cote d'Azur", date=date.today(), waypoints=[wp1, wp2])
         trip = Trip(
             id="tdd-1087-loader-roundtrip",

--- a/tests/tdd/test_issue_995_scheduler_pause.py
+++ b/tests/tdd/test_issue_995_scheduler_pause.py
@@ -44,9 +44,17 @@ _REAL_DATA_ROOT = Path(__file__).resolve().parents[2] / "data" / "users"
 
 def _make_trip(trip_id: str, report_config: TripReportConfig | None = None) -> Trip:
     """Trip mit Etappe heute — aktiv für 'morning'."""
-    stage = Stage(id="S1", name="Tag 1", date=date.today(), waypoints=[
-        Waypoint(id="G1", name="Start", lat=42.13, lon=9.13, elevation_m=400),
-        Waypoint(id="G2", name="Ziel", lat=42.10, lon=9.18, elevation_m=1200),
+    # #1709: stage_date()/active_window_offsets() statt date.today() ohne
+    # jede Ankunftszeit — der Haertungs-Helfer wird hier DIREKT aufgerufen
+    # (die Datei importiert ihn ohnehin schon fuer AC9, s. oben), die
+    # konkreten Zeiten tragen keine Pruefaussage dieser Funktion.
+    lat, lon = 42.13, 9.13
+    arr1, arr2 = active_window_offsets(lat, lon, 60, 240)
+    stage = Stage(id="S1", name="Tag 1", date=stage_date(lat, lon), waypoints=[
+        Waypoint(id="G1", name="Start", lat=lat, lon=lon, elevation_m=400,
+                 arrival_calculated=arr1),
+        Waypoint(id="G2", name="Ziel", lat=42.10, lon=9.18, elevation_m=1200,
+                 arrival_calculated=arr2),
     ])
     rc = report_config if report_config is not None else TripReportConfig(trip_id=trip_id, enabled=True)
     return Trip(id=trip_id, name=trip_id, stages=[stage], report_config=rc)

--- a/tests/tdd/test_issue_995_scheduler_pause.py
+++ b/tests/tdd/test_issue_995_scheduler_pause.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import json
 import shutil
 import uuid
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest

--- a/tests/tdd/test_official_alert_channel_threshold.py
+++ b/tests/tdd/test_official_alert_channel_threshold.py
@@ -46,11 +46,16 @@ def _segment_with_alert(alert: OfficialAlert):
 
 
 def _trip(threshold: dict | None) -> Trip:
+    # #1709: feste Ankunftszeiten statt Naismith-Self-Heal
+    # (trip_segments.py:125-127) — die Zeiten selbst tragen keine
+    # Pruefaussage dieser Datei, sie muessen nur ueberhaupt gesetzt sein.
     stage = Stage(
         id="T1", name="Tag 1", date=date.today(),
         waypoints=[
-            Waypoint(id="G1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0),
-            Waypoint(id="G2", name="Ziel", lat=LAT + 0.05, lon=LON + 0.05, elevation_m=1200.0),
+            Waypoint(id="G1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0,
+                     arrival_calculated="08:00"),
+            Waypoint(id="G2", name="Ziel", lat=LAT + 0.05, lon=LON + 0.05, elevation_m=1200.0,
+                     arrival_calculated="12:00"),
         ],
     )
     return Trip(

--- a/tests/tdd/test_official_alert_sms_marker.py
+++ b/tests/tdd/test_official_alert_sms_marker.py
@@ -49,11 +49,16 @@ def _segment_with_alerts(alerts: list[OfficialAlert]):
 
 
 def _trip() -> Trip:
+    # #1709: feste Ankunftszeiten statt Naismith-Self-Heal
+    # (trip_segments.py:125-127) — die Zeiten selbst tragen keine
+    # Pruefaussage dieser Datei, sie muessen nur ueberhaupt gesetzt sein.
     stage = Stage(
         id="T1", name="Tag 1", date=date.today(),
         waypoints=[
-            Waypoint(id="G1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0),
-            Waypoint(id="G2", name="Ziel", lat=LAT + 0.05, lon=LON + 0.05, elevation_m=1200.0),
+            Waypoint(id="G1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0,
+                     arrival_calculated="08:00"),
+            Waypoint(id="G2", name="Ziel", lat=LAT + 0.05, lon=LON + 0.05, elevation_m=1200.0,
+                     arrival_calculated="12:00"),
         ],
     )
     return Trip(id="trip-1614-marker", name="Marker-Trip", stages=[stage])

--- a/tests/tdd/test_th_plus_follows_thunder_metric_and_gap.py
+++ b/tests/tdd/test_th_plus_follows_thunder_metric_and_gap.py
@@ -226,9 +226,15 @@ class TestAC3RealGapShowsUnknown:
         THEN:  '+1' ist als Luecke markiert, '+2' NICHT (dort ist schlicht
                keine Etappe — das ist kein Datenausfall)
         """
+        # #1709: feste Ankunftszeit fuer die HEUTIGE (zweipunktige) Etappe statt
+        # Naismith-Self-Heal (trip_segments.py:125-127) -- die morgige Etappe
+        # braucht das GERADE NICHT: sie hat absichtlich nur EINEN Waypoint (s.
+        # GIVEN oben), das traegt die Pruefaussage "keine Segmente" bereits.
         today = date.today()
-        wp_a = Waypoint(id="A", name="Start", lat=42.0, lon=9.0, elevation_m=500)
-        wp_b = Waypoint(id="B", name="Ziel", lat=42.1, lon=9.1, elevation_m=600)
+        wp_a = Waypoint(id="A", name="Start", lat=42.0, lon=9.0, elevation_m=500,
+                        arrival_calculated="08:00")
+        wp_b = Waypoint(id="B", name="Ziel", lat=42.1, lon=9.1, elevation_m=600,
+                        arrival_calculated="12:00")
         trip = Trip(
             id="i1482gap",
             name="Luecken-Trip",

--- a/tests/tdd/test_trip_alert_channel_precedence.py
+++ b/tests/tdd/test_trip_alert_channel_precedence.py
@@ -70,11 +70,16 @@ def _write_user_json(user_id: str, tier: str | None) -> None:
 
 def _stage():
     from app.trip import Stage, Waypoint
+    # #1709: feste Ankunftszeiten statt Naismith-Self-Heal
+    # (trip_segments.py:125-127) — die Zeiten selbst tragen keine
+    # Pruefaussage dieser Datei, sie muessen nur ueberhaupt gesetzt sein.
     return Stage(
         id="S1", name="Etappe 1", date=date.today() + timedelta(days=1),
         waypoints=[
-            Waypoint(id="W1", name="Start", lat=42.2, lon=9.05, elevation_m=400),
-            Waypoint(id="W2", name="Ziel", lat=42.25, lon=9.09, elevation_m=1200),
+            Waypoint(id="W1", name="Start", lat=42.2, lon=9.05, elevation_m=400,
+                     arrival_calculated="08:00"),
+            Waypoint(id="W2", name="Ziel", lat=42.25, lon=9.09, elevation_m=1200,
+                     arrival_calculated="12:00"),
         ],
     )
 

--- a/tests/tdd/test_trip_briefing_anchor_unchanged.py
+++ b/tests/tdd/test_trip_briefing_anchor_unchanged.py
@@ -108,11 +108,16 @@ def _trip(trip_id: str) -> Trip:
     (Ergebnis `no_channels`), es wird nichts versendet. Der Anker-/Reset-Block
     liegt VOR dem Ruecksprung — Muster aus
     `test_alert_state_briefing_reset.py::test_ac23_...`."""
+    # #1709: feste Ankunftszeiten statt Naismith-Self-Heal
+    # (trip_segments.py:125-127) — die Zeiten selbst tragen keine
+    # Pruefaussage dieser Datei, sie muessen nur ueberhaupt gesetzt sein.
     stage = Stage(
         id="T1", name="Tag 1", date=date.today(),
         waypoints=[
-            Waypoint(id="G1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0),
-            Waypoint(id="G2", name="Ziel", lat=LAT + 0.1, lon=LON + 0.1, elevation_m=1500.0),
+            Waypoint(id="G1", name="Start", lat=LAT, lon=LON, elevation_m=1000.0,
+                     arrival_calculated="08:00"),
+            Waypoint(id="G2", name="Ziel", lat=LAT + 0.1, lon=LON + 0.1, elevation_m=1500.0,
+                     arrival_calculated="12:00"),
         ],
     )
     trip = Trip(id=trip_id, name="AG5-Trip", stages=[stage], official_warnings=None)

--- a/tests/tdd/test_trip_outlook_dispatch_mail.py
+++ b/tests/tdd/test_trip_outlook_dispatch_mail.py
@@ -94,13 +94,17 @@ def _trip(*, outlook_metrics, enabled_ids=None, leere_grundauswahl=False,
 
     trip_id = f"trip-1720-{uuid.uuid4().hex[:8]}"
     heute = date.today()
+    # #1709: feste Ankunftszeiten statt Naismith-Self-Heal
+    # (trip_segments.py:125-127) — die Zeiten selbst tragen keine
+    # Pruefaussage dieser Datei, sie muessen nur ueberhaupt gesetzt sein.
     stages = [
         Stage(id=f"S{i}", name=f"Tag {i}", date=heute + timedelta(days=i),
               waypoints=[
                   Waypoint(id=f"W{i}a", name="Start", lat=LAT, lon=LON,
-                           elevation_m=1400.0),
+                           elevation_m=1400.0, arrival_calculated="08:00"),
                   Waypoint(id=f"W{i}b", name="Ziel", lat=LAT + 0.05,
-                           lon=LON + 0.1, elevation_m=2100.0),
+                           lon=LON + 0.1, elevation_m=2100.0,
+                           arrival_calculated="12:00"),
               ])
         for i in range(5)
     ]

--- a/tests/tdd/test_wanduhr_matrix.py
+++ b/tests/tdd/test_wanduhr_matrix.py
@@ -1,0 +1,181 @@
+"""Selbsttests fuer das Messwerkzeug ``tests/helpers/wanduhr_matrix.py``
+(#1709 AC-3, AC-4) — das Werkzeug existiert noch nicht, dieser Testlauf ist
+zunaechst ROT.
+
+Warum ueberhaupt ein Messwerkzeug
+----------------------------------
+Ob eine Fixture indirekt von der Wanduhr abhaengt, laesst sich nicht durch
+Lesen entscheiden — die Zeitabhaengigkeit entsteht erst im Pruefling. Sie
+laesst sich aber MESSEN: dieselbe Testdatei zu zwei kuenstlich verschiedenen
+Uhrzeiten laufen lassen und die Ergebnisse vergleichen. Nur die DIFFERENZ ist
+auswertbar, nie ein einzelner Lauf (docs/specs/modules/
+fix_1709_wallclock_ratsche_indirekt.md, Abschnitt "Messwerkzeug").
+
+Erwarteter Vertrag (von diesen Tests erzwungen, nicht von der Spec
+vorgeschrieben — die Funktionsnamen sind Teil dieses RED-Entwurfs):
+
+``helpers.wanduhr_matrix.lauf_bei_uhrzeit(testdatei: Path, uhrzeit: datetime)``
+    Fuehrt ``testdatei`` EINMAL, in einem FRISCHEN Betriebssystem-Prozess, mit
+    gestellter Wanduhr ``uhrzeit`` aus (ein Datenpunkt).
+
+``helpers.wanduhr_matrix.matrix_differenz(testdatei: Path,
+                                          uhrzeiten: Sequence[datetime]) -> frozenset[str]``
+    Misst ``testdatei`` zu jeder Uhrzeit (je ein frischer Prozess) und gibt
+    die Menge der Test-Nodeids zurueck, deren Ergebnis (bestanden /
+    fehlgeschlagen) nicht bei ALLEN Uhrzeiten identisch ist. Bei zwei
+    Uhrzeiten derselben Seite einer Kippkante ist das Ergebnis leer.
+
+Drei Fallen, die dieser Vertrag bewusst ausschliesst (Kontext-Dokument,
+Abschnitt "Drei Fallen im Messaufbau"):
+
+1. Mehrere Datenpunkte im selben Prozess ergaben eine Matrix, die sich bei
+   frischen Prozessen nicht reproduzieren liess — Zustand sickert durch.
+2. Sitzungsweites ``freezegun`` zerstoert pydantic-v1-Importe und erzeugt
+   Falsch-Positive — deshalb zaehlt nur die Differenz, nie eine absolute
+   Fehlerzahl.
+3. Uhrzeiten muessen in der ORTSZONE der Fixture gewaehlt werden, nicht in
+   UTC — hier irrelevant (die Attrappen unten rechnen selbst in UTC), aber
+   fuer die Verwendung des Werkzeugs auf echten Fixtures zentral.
+
+Spec: docs/specs/modules/fix_1709_wallclock_ratsche_indirekt.md
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Wurzel DIESES Checkouts (#1409) — hier nur fuer Konsistenz mit dem Vorbild
+# gehalten, diese Tests lesen selbst nichts vom Hauptrepo-Pfad.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _attrappe(tmp_path: Path, quelltext: str, name: str = "test_attrappe.py") -> Path:
+    """Echte Testdatei-Attrappe auf die Platte schreiben (kein Mock)."""
+    f = tmp_path / name
+    f.write_text(quelltext, encoding="utf-8")
+    return f
+
+
+# Eine Attrappe mit einer bekannten Kippkante bei 2026-01-01 12:00 UTC: gruen
+# davor, rot danach. ``datetime.now`` wird NICHT selbst gestellt — das ist
+# genau die Aufgabe des Messwerkzeugs (freezegun o.ae.).
+_KANTEN_FALL = '''\
+from datetime import datetime, timezone
+
+GRENZE = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+
+def test_vor_der_grenze():
+    """Gruen, solange die gestellte Wanduhr vor GRENZE liegt."""
+    jetzt = datetime.now(timezone.utc)
+    assert jetzt < GRENZE, f"jetzt={jetzt.isoformat()} liegt nicht mehr vor der Grenze"
+'''
+
+# Eine Attrappe ohne jede Zeitabhaengigkeit — Kontrollfall dafuer, dass
+# matrix_differenz bei einem gesunden Testfall wirklich schweigt.
+_STABILER_FALL = '''\
+def test_immer_gruen():
+    assert 1 + 1 == 2
+'''
+
+# Eine Attrappe, die ihre eigene Prozess-ID in eine Datei im selben Ordner
+# schreibt (AC-4). ANHAENGEND (Modus "a"), damit zwei Laeufe desselben
+# Messwerkzeugs beide Aufzeichnungen erhalten bleiben und miteinander
+# verglichen werden koennen.
+_PID_FALL = '''\
+import os
+from pathlib import Path
+
+_PID_DATEI = Path(__file__).parent / "beobachtete_pids.txt"
+
+
+def test_schreibt_die_eigene_prozess_id():
+    with _PID_DATEI.open("a", encoding="utf-8") as f:
+        f.write(f"{os.getpid()}\\n")
+    assert True
+'''
+
+
+def test_matrix_findet_die_kante(tmp_path):
+    """AC-3: eine Attrappe, die bei gestellter Uhr vor 2026-01-01 12:00 UTC
+    gruen und danach rot ist -> die Differenz enthaelt GENAU diesen Testfall."""
+    from helpers.wanduhr_matrix import matrix_differenz
+
+    testdatei = _attrappe(tmp_path, _KANTEN_FALL)
+    vor = datetime(2025, 12, 31, 23, 0, tzinfo=timezone.utc)
+    nach = datetime(2026, 1, 1, 13, 0, tzinfo=timezone.utc)
+
+    diff = matrix_differenz(testdatei, [vor, nach])
+
+    assert any("test_vor_der_grenze" in eintrag for eintrag in diff), (
+        f"die bekannte Kippkante wurde nicht in der Differenz gefunden: "
+        f"{sorted(diff)}"
+    )
+
+
+def test_matrix_meldet_nichts_ohne_kante(tmp_path):
+    """Gegenprobe zu AC-3: zwei Uhrzeiten derselben Seite der Grenze ergeben
+    eine LEERE Differenz. Ein Werkzeug, das nie etwas findet, ist von einem
+    sauberen Bestand nicht unterscheidbar — ohne diesen Test waere unklar, ob
+    matrix_differenz ueberhaupt zwischen "gefunden" und "nichts da"
+    unterscheidet (statt z.B. immer eine leere Menge zurueckzugeben)."""
+    from helpers.wanduhr_matrix import matrix_differenz
+
+    testdatei = _attrappe(tmp_path, _KANTEN_FALL)
+    a = datetime(2025, 12, 31, 20, 0, tzinfo=timezone.utc)
+    b = datetime(2025, 12, 31, 22, 0, tzinfo=timezone.utc)
+
+    diff = matrix_differenz(testdatei, [a, b])
+
+    assert diff == frozenset(), f"Falsch-Positiv ohne Kippkante: {sorted(diff)}"
+
+
+def test_matrix_schweigt_bei_einem_stabilen_testfall(tmp_path):
+    """Zweite Gegenprobe: ein voellig zeitunabhaengiger Testfall bleibt zu
+    JEDER gestellten Uhrzeit gleich -> leere Differenz."""
+    from helpers.wanduhr_matrix import matrix_differenz
+
+    testdatei = _attrappe(tmp_path, _STABILER_FALL)
+    a = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    b = datetime(2030, 6, 15, 12, 0, tzinfo=timezone.utc)
+
+    diff = matrix_differenz(testdatei, [a, b])
+
+    assert diff == frozenset(), f"Falsch-Positiv bei stabilem Testfall: {sorted(diff)}"
+
+
+def test_matrix_nutzt_je_datenpunkt_einen_eigenen_prozess(tmp_path):
+    """AC-4: frischer Prozess je Datenpunkt ist ERZWUNGEN, nicht empfohlen.
+    Nachweis: die Attrappe schreibt ihre eigene ``os.getpid()`` in eine Datei;
+    zwei Messungen muessen zwei verschiedene, vom Messprozess verschiedene
+    PIDs hinterlassen. Ein Kommentar "bitte frischen Prozess nehmen" waere
+    keine Zusicherung, sondern eine Bitte."""
+    from helpers.wanduhr_matrix import lauf_bei_uhrzeit
+
+    testdatei = _attrappe(tmp_path, _PID_FALL)
+    zeitpunkt_a = datetime(2026, 1, 1, 8, 0, tzinfo=timezone.utc)
+    zeitpunkt_b = datetime(2026, 1, 1, 9, 0, tzinfo=timezone.utc)
+
+    lauf_bei_uhrzeit(testdatei, zeitpunkt_a)
+    lauf_bei_uhrzeit(testdatei, zeitpunkt_b)
+
+    pid_datei = tmp_path / "beobachtete_pids.txt"
+    aufgezeichnet = [
+        int(zeile) for zeile in pid_datei.read_text(encoding="utf-8").splitlines()
+        if zeile.strip()
+    ]
+
+    assert len(aufgezeichnet) == 2, (
+        f"erwartet 2 aufgezeichnete Prozess-IDs (eine je Lauf), bekommen: "
+        f"{aufgezeichnet}"
+    )
+    assert len(set(aufgezeichnet)) == 2, (
+        f"beide Datenpunkte liefen im SELBEN Prozess: {aufgezeichnet} — genau "
+        "die Falle aus dem Kontext-Dokument (Zustand sickert zwischen "
+        "Laeufen im selben Prozess durch)"
+    )
+    assert os.getpid() not in aufgezeichnet, (
+        f"die Attrappe lief im MESSPROZESS ({os.getpid()}) statt in einem "
+        f"eigenen Kindprozess: {aufgezeichnet}"
+    )

--- a/tests/unit/test_premium_sms_versand.py
+++ b/tests/unit/test_premium_sms_versand.py
@@ -243,11 +243,16 @@ def _persisted_trip(user_id: str, *, send_sms: bool, send_premium_sms: bool):
     from app.trip import Stage, Trip, Waypoint
 
     trip_id = f"trip-{user_id}"
+    # #1709: feste Ankunftszeiten statt Naismith-Self-Heal
+    # (trip_segments.py:125-127) — die Zeiten selbst tragen keine
+    # Pruefaussage dieser Datei, sie muessen nur ueberhaupt gesetzt sein.
     stage = Stage(
         id="S1", name="Etappe 1", date=date.today() + timedelta(days=1),
         waypoints=[
-            Waypoint(id="W1", name="Start", lat=42.2, lon=9.05, elevation_m=400),
-            Waypoint(id="W2", name="Ziel", lat=42.25, lon=9.09, elevation_m=1200),
+            Waypoint(id="W1", name="Start", lat=42.2, lon=9.05, elevation_m=400,
+                     arrival_calculated="08:00"),
+            Waypoint(id="W2", name="Ziel", lat=42.25, lon=9.09, elevation_m=1200,
+                     arrival_calculated="12:00"),
         ],
     )
     trip = Trip(


### PR DESCRIPTION
Bezug: #1709

## Warum

Die bestehende Ratsche `test_fixture_wallclock_ratchet.py` meldet nur Fixturen, die ein Wanduhr-Etappendatum **mit** ungeklemmter Ankunftszeit bauen. Der Fall aus #1709 ist ihr logisches Gegenteil: **gar keine** Ankunftszeit, wodurch der Pruefling selbst eine Tageszeit-Grenze berechnet (Naismith-Standardstart 08:00, Segmentende am Tagesfenster-Ende 19:00 Ortszeit). Diese Variante kann der alte Scanner strukturell nicht sehen — sie ist die Negation seiner Fundbedingung.

## Was drin ist

**1. Messwerkzeug `tests/helpers/wanduhr_matrix.py`** — laesst Testdateien zu mehreren gestellten Uhrzeiten laufen und meldet nur die **Differenz**. Drei Eigenschaften sind erzwungen, nicht empfohlen:
- ein frischer Prozess je Datenpunkt (mehrere `pytest.main()` im selben Prozess ergaben eine Matrix, die sich nicht reproduzieren liess: "rot 02-04 UTC" vs. tatsaechlich "rot 04-06 UTC")
- nur Differenzen auswertbar (sitzungsweites `freezegun` zerstoert pydantic-v1-Importe, `TypeError: metaclass conflict` — 9 Falsch-Positive)
- Uhrzeiten in der Ortszone der Fixture, nicht in UTC

**2. Zweite Fundregel `scan_indirekte_wanduhr_fixtures()`** — sechs UND-verknuepfte Merkmale, alle am Pruefling abgelesen (`trip_segments.py:121-123`, `:125-127`, `:36-52`). Insbesondere: `arrival_override` gewinnt in der Prioritaetskette auch dann, wenn der Self-Heal-Ausloeser erfuellt ist.

**3. Dreizehn Bestandsfixturen gehaertet, Ausnahmeliste LEER.** Keine `assert`-Zeile angefasst — geaendert wurde die Vorbedingung, nie die Zusicherung. Jede Datei einzeln gruen, jede vorher und nachher mit `matrix_differenz` gegengemessen.

## Die Bestandsmenge wurde gemessen, nicht geschaetzt

| Menge | Uhrzeiten (UTC) | Differenz |
|---|---|---|
| 69 Dateien: Etappe + Wanduhr + Alarmpfad, ohne Ankunftszeiten, ohne Haertungs-Helfer | 06/10/18/22:30 | **0** |
| 100 Dateien: Etappe + Wanduhr + Alarmpfad, ohne `briefing_zeiten`-Helfer | 06/12 | **1** |

Die im Ticket befuerchtete Massensanierung entfaellt. Der eine gefundene Fall ist **#1871** (getrennt gehalten, PO-Entscheidung).

**Gegenprobe, ohne die "0 Funde" wertlos waere:** die Vor-Fix-Fassung von #1851 (temporaerer Worktree auf `<fix-sha>^`) ist um 06:00 UTC rot und um 12:00 UTC gruen. Das Werkzeug erkennt die Klasse nachweislich.

## Vier Adversary-Runden

| Runde | Verdict | Findings |
|---|---|---|
| 1 | BROKEN | F001-F004: Hilfsfunktion, `**kwargs`, Comprehension liefen am Wegpunkt-Zaehler vorbei; Haertungs-Erkennung dateiweit statt funktionsweit |
| 2 | BROKEN | F-ADV1 Import-Alias (`Stage as S`) = 0 Funde · F-ADV3/F-ADV4 fehlende Gegenproben · F-ADV2 dokumentiert statt gefixt |
| 3 | BROKEN | **F-ADV6 (CRITICAL): AC-10 war nur ein Zustand, kein Test** — Haertung zuruecknehmen + echten Fund eintragen liess alles gruen · F-ADV5 `from services import trip_alert` umging Merkmal 6 |
| 4 | **VERIFIED** | beide bestaetigt geschlossen, fruehere Runden halten, 114 Tests gruen |

Alle Findings sind **dieselbe Klasse**: Erkennung am NAMEN, Wirkung an der BEDEUTUNG. Die Frage ist deshalb umgedreht (Prinzip aus #1431) — nicht "erkenne ich zwei Wegpunkte?", sondern **"bin ich sicher, dass es weniger als zwei sind?"**. Unaufloesbares gilt als pruefbeduerftig.

**Bewusst offen und als LUECKE dokumentiert (F-ADV2):** Wanduhr-Datum im Aufrufer, `Stage(...)` in einer Geschwister-Funktion — keine der beiden Funktionen hat beide Merkmale. Steht in "Grenzen, ehrlich benannt" und in den Known Limitations, mit dem Beleg, dass die Bauart im Bestand existiert (`test_issue_760_stage_number.py:31`) und dort nur deshalb ungefaehrlich ist, weil sie mit EINEM Wegpunkt arbeitet.

## Zwei Korrekturen am Ticket, beide am Code belegt

- Die dort als Ursache genannte 23:59-Klemme in `naismith.py` **existiert nicht mehr** (seit #1667 S2 Modulo).
- Die Vorlaufsperre hat **zwei** Auspraegungen mit verschiedenen Vorgabezeiten: Trip 7/18 Uhr als 3-h-Fenster, Compare **6**/18 Uhr als Stundengleichheit.

## Nachweis

- **AC-1 bis AC-10 erfuellt.** AC-10 (`KNOWN_VIOLATIONS_INDIREKT` leer) ist jetzt durch einen Test **erzwungen** — nachgemessen: mit einem zusaetzlichen Eintrag rot, ohne gruen.
- Kein Produktivcode: `git diff --stat origin/main...HEAD -- src/ api/ internal/ frontend/ cmd/` leer (AC-7)
- Bestandsscan ueber den echten Baum: **0 Funde**
- Alle 6 CI-Checks gruen
- Test-LoC ueber dem Standardbudget (PO-Erlaubnis, zweimal nachgezogen). Das LoC-Gate meldete `+0/1000` und hat die Ueberschreitung **nicht** bemerkt — von Hand gemeldet, nicht vom Gate erzwungen.

LOW-Nebenbefund (Teilstring-Vergleich bei der Import-Erkennung, vorbestehend, kein Bestandstreffer) → #1199.

Spec: `docs/specs/modules/fix_1709_wallclock_ratsche_indirekt.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoXrQwyCuBDmq2VHF3631n
