### PR TITLE
fix(#1765,#1839 Scheibe A): Vorschau legt den Python-Core nicht mehr lahm

### DIFF
--- a/api/routers/internal.py
+++ b/api/routers/internal.py
@@ -27,7 +27,7 @@ router = APIRouter()
 
 
 @router.get("/api/_internal/trip/{trip_id}/loaded")
-async def loaded_trip(trip_id: str, user_id: str = Query(...)):
+def loaded_trip(trip_id: str, user_id: str = Query(...)):
     """Liefert den hydrierten Trip als JSON, inklusive der vom Loader
     auto-injizierten ``display_config``. Kanonische Serialisierung via
     ``_trip_to_dict`` — Datetimes als ISO-Strings, Enums als ``.value``.
@@ -53,7 +53,7 @@ def get_stage_weather_provider():
 
 
 @router.get("/api/_internal/trips/{trip_id}/stages-weather")
-async def stages_weather(
+def stages_weather(
     trip_id: str,
     user_id: str = Query(...),
     provider=Depends(get_stage_weather_provider),

--- a/api/routers/notify.py
+++ b/api/routers/notify.py
@@ -16,7 +16,7 @@ class TestRequest(BaseModel):
 
 
 @router.post("/api/notify/test")
-async def test_notify(
+def test_notify(
     req: TestRequest,
     user_id: str = Query(...),
 ):

--- a/api/routers/preview.py
+++ b/api/routers/preview.py
@@ -27,7 +27,7 @@ def _build_service(user_id: str) -> PreviewService:
 
 
 @router.get("/api/preview/{trip_id}/email", response_class=HTMLResponse)
-async def preview_email(
+def preview_email(
     trip_id: str,
     user_id: str = Query(..., description="Session-User (vom Go-Proxy injiziert)"),
     type: str = Query("morning", description="morning | evening"),
@@ -53,7 +53,7 @@ async def preview_email(
 
 
 @router.get("/api/preview/{trip_id}/sms")
-async def preview_sms(
+def preview_sms(
     trip_id: str,
     user_id: str = Query(...),
     type: str = Query("morning"),
@@ -83,7 +83,7 @@ async def preview_sms(
 
 
 @router.post("/api/preview/compare/{preset_id}")
-async def preview_compare(
+def preview_compare(
     preset_id: str,
     user_id: str = Query(..., description="Session-User (vom Go-Proxy injiziert)"),
     date: str | None = Query(None, description="ISO-Datum, default: heute"),
@@ -126,7 +126,7 @@ def _narrow_payload(subject: str, body: str, bubbles: list[str] | None = None) -
 
 
 @router.get("/api/preview/{trip_id}/telegram")
-async def preview_telegram(
+def preview_telegram(
     trip_id: str,
     user_id: str = Query(...),
     type: str = Query("morning"),

--- a/api/routers/validator.py
+++ b/api/routers/validator.py
@@ -164,7 +164,7 @@ def _determine_cascade_source(
 # ---------------------------------------------------------------------------
 
 @router.get("/api/_validator/format-metric")
-async def format_metric(
+def format_metric(
     unit: str = Query(..., description="Unit code: m, km, hPa, %, km/h, °C, mm"),
     value: float = Query(...),
     signed: bool = Query(False),
@@ -178,7 +178,7 @@ async def format_metric(
 # ---------------------------------------------------------------------------
 
 @router.get("/api/_validator/detector-thresholds")
-async def detector_thresholds(
+def detector_thresholds(
     trip: str = Query(..., description="Trip-ID"),
     user_id: str = Query(...),
 ):
@@ -241,7 +241,7 @@ class AlertPreviewBody(BaseModel):
 
 
 @router.post("/api/trips/{trip_id}/alert-preview")
-async def alert_preview(
+def alert_preview(
     trip_id: str,
     body: AlertPreviewBody,
     user_id: str = Query(...),
@@ -269,7 +269,7 @@ async def alert_preview(
 # ---------------------------------------------------------------------------
 
 @router.get("/api/_validator/metrics-for-channel")
-async def metrics_for_channel(
+def metrics_for_channel(
     trip: str = Query(..., description="Trip-ID"),
     channel: str = Query(..., description="email|telegram|sms"),
     report: str = Query(..., description="morning|evening"),
@@ -314,7 +314,7 @@ class CompareEmailPreviewBody(BaseModel):
 
 
 @router.post("/api/_validator/compare-email-preview")
-async def compare_email_preview(body: CompareEmailPreviewBody):
+def compare_email_preview(body: CompareEmailPreviewBody):
     """Rendert Compare-E-Mail HTML für den Validator.
 
     Spec: docs/specs/modules/issue_464_compare_email_preview_validator.md.
@@ -336,7 +336,7 @@ class SmsFidelityPreviewBody(BaseModel):
 
 
 @router.post("/api/_validator/sms-fidelity-preview")
-async def sms_fidelity_preview(body: SmsFidelityPreviewBody):
+def sms_fidelity_preview(body: SmsFidelityPreviewBody):
     """Rendert die SMS-Kurzform fuer die Metrik-Editor-Vorschau.
 
     Spec: docs/specs/modules/fix_923_sms_fidelity_backend.md.

--- a/docs/context/fix-1765-1839-vorschau-laufzeit.md
+++ b/docs/context/fix-1765-1839-vorschau-laufzeit.md
@@ -1,0 +1,448 @@
+# Context: Vorschau-Laufzeit (#1765 + #1839)
+
+**Workflow:** `fix-1765-1839-vorschau-laufzeit` · **Typ:** feature (Full Process) · **Erstellt:** 2026-08-15
+
+## Request Summary
+
+Die Vergleichs-Vorschau (#1765) lädt bei 3+ Orten nie, die Trip-Vorschau (#1839) bricht beim
+ersten (kalten) Aufruf nach 30 s mit 502 ab. PO-Vorgabe: **Ursache angehen, nicht Timeouts
+hochsetzen.** Die gemeinsame Wurzel #1539 (sequenzielle Orts-/Etappenverarbeitung) ist
+laut PO-Messung vom 2026-08-15 **nicht akut** (keine übersprungenen Scheduler-Ticks) und
+bleibt als Architektur-Ticket offen; die Vorschau-Tickets werden über eine Parallelisierung
+**des Vorschau-Pfads** angegangen — echter Teilschritt, ohne #1539s `[triage:po]`-Entscheidung
+vorwegzunehmen.
+
+## Drei trennbare Ursachen (gemessen am Code, nicht aus den Ticketkörpern übernommen)
+
+### U1 — Die Vorschau blockiert den einzigen Python-Prozess
+
+`api/routers/preview.py` deklariert alle vier Handler `async def` (Zeilen 30, 56, 86, 129),
+enthält aber **kein einziges `await`** (verifiziert per `grep -n "await\|async def"`). Die
+darunterliegenden Wetterabrufe sind synchrone `httpx.Client`-Aufrufe. Ein `async def`-Handler
+läuft bei Starlette **direkt im Event-Loop-Thread** — nicht im Threadpool, den `def`-Handler
+bekommen. Uvicorn läuft ohne `--workers` (ein Prozess, ein Loop).
+
+Folge: Während einer Vorschau ist der gesamte Python-Core taub. Der Go-Health-Handler gibt
+Python 2 s (`internal/handler/proxy.go:19`) → `python_core: unavailable`, `status: degraded`.
+**Das erklärt den unnötigen Neustart von `gregor-python-staging` am 2026-08-12 vollständig**
+(#1765, Kommentar 1) und macht `/api/health` als Ausfallsignal unbrauchbar.
+
+#### U1 ist eine Klasse von 13 Handlern, nicht ein Vorschau-Sonderfall
+
+Ausgezählt über den gesamten `api/`-Baum (AST, Dekorator `router.*`/`app.*`):
+
+| | Anzahl |
+|---|---|
+| Route-Handler `def` (laufen im Starlette-Threadpool — **richtig**) | **22** |
+| Route-Handler `async def` (laufen im Event-Loop) | **14** |
+| davon **ohne jedes `await`** ⇒ blockieren den Loop grundlos | **13** |
+
+Der Hausstil ist also bereits `def`; die 13 `async def`-Handler ohne `await` sind die Abweichung.
+Einziger berechtigter `async def`: `api/routers/gpx.py:23 parse_gpx` (Datei-Upload, nutzt `await`).
+
+**Zweifach gemessen, gleiches Ergebnis** — einmal statisch per AST über `api/**/*.py`, einmal
+zur Laufzeit an der fertig gebauten App (`app.routes` → `inspect.iscoroutinefunction`).
+Die Laufzeit-Zählung war nötig, weil eine reine AST-Zählung Dekorator-Formen übersehen kann
+(anders benannte Router-Variablen, `add_api_route`). Beide Wege nennen **dieselben 13 Handler**.
+
+#### Die Mechanik ist experimentell belegt, nicht nur hergeleitet
+
+Wegwerf-Experiment (zwei identische Mini-Apps, uvicorn im Thread, ohne Netz):
+
+| Aufbau | `/health` **während** laufender Arbeit |
+|---|---|
+| `async def` + blockierende Arbeit (heutiger Zustand) | **Timeout nach 2,02 s** |
+| `def` + identische blockierende Arbeit (Vorschlag) | **HTTP 200 nach 0,03 s** |
+
+Die 2,02 s sind genau die Grenze, die der Go-Health-Handler setzt
+(`internal/handler/proxy.go:19`). Damit ist die Wirkkette
+`async def ohne await` → Loop blockiert → `/health` stumm → `degraded` **geschlossen belegt**.
+Derselbe Aufbau ist zugleich der Bauplan für den U1-Test: deterministisch, netzfrei, ~7 s Laufzeit.
+
+Die 13 blockierenden Handler:
+
+| Datei:Zeile | Handler | Anmerkung |
+|---|---|---|
+| `api/routers/preview.py:30,56,86,129` | `preview_email`, `preview_sms`, `preview_compare`, `preview_telegram` | **gemeldetes Symptom** (#1765/#1839) |
+| `api/routers/internal.py:56` | `stages_weather` | Cockpit-Etappenwetter — nutzt **innen** einen `ThreadPoolExecutor` und blockiert dann den Loop beim Warten auf die Ergebnisse |
+| `api/routers/internal.py:30` | `loaded_trip` | |
+| `api/routers/validator.py:167,181,244,272,317,339` | u.a. `alert_preview`, `compare_email_preview` | Validator-Pfad |
+| `api/routers/notify.py:19` | `test_notify` | |
+
+⇒ Würde Scheibe A nur die vier Vorschau-Handler umstellen, bliebe der Core weiterhin durch
+das Cockpit-Etappenwetter und die Validator-Endpunkte taub. Die Reparatur ist mechanisch
+(das Wort `async` entfällt, es gibt kein `await`, das brechen könnte) — der Umfang der
+Klasse ist daher eher ein Argument dafür, sie **ganz** zu erledigen, als für eine Teilmenge.
+
+### U2 — Die Vorschau erbt die Wiederhol-Politik des Versands
+
+`preview_service.py:173` ruft `scheduler._fetch_weather(segments, provider=provider)`. Dort:
+`fail_fast` ist eine **lokale Variable**, hart auf `False`, kein Parameter
+(`trip_report_scheduler.py:1953`) → 3 Versuche je Segment mit `time.sleep`
+(`FETCH_RETRY_ATTEMPTS = 2`, `FETCH_RETRY_BACKOFF_SECONDS = 1`, Zeilen 73–74).
+Darunter die Provider mit `RETRY_ATTEMPTS = 5` und `wait_exponential(min=2, max=60)`.
+Für einen Nutzer, der auf einen Reiter starrt, ist das falsch dimensioniert — die Werte
+stammen aus dem asynchronen Versandpfad, wo Wartezeit unkritisch ist (PO-Einordnung in #1539).
+
+### U3 — Serielle Orts- bzw. Segmentschleife
+
+- Vergleich: `src/services/comparison_engine.py:127` `for loc in locations:` — je Ort bis zu
+  drei Netzabrufe (Forecast inkl. Gewitter-Anreicherung; optional Bergfex-Schnee; optional
+  amtliche Warnungen via `get_official_alerts_with_status`, Zeile 323).
+- Trip: `src/services/trip_report_scheduler.py:1954` `for segment in segments:` in
+  `_fetch_weather` (ab Zeile 1917). `segment_weather.py` selbst hat **keine** Ortsschleife —
+  es verarbeitet genau ein Segment je Aufruf (Netzabruf bei Zeile 195).
+
+### U4 — Der Vergleichspfad hat keinen Grundvorhersage-Cache (bekannt, zurückgestellt, **nicht** Teil dieses Workflows)
+
+Nachgeprüft, weil die Strategiebewertung eine Cache-Aufwärmung erwog:
+`get_shared_weather_cache()` / `WeatherCacheService` wird **ausschließlich** von
+`src/services/segment_weather.py:67` (Trip-Pfad) und zwei Renderern genutzt.
+Der Vergleichspfad (`comparison_engine.py:130` → `fetch_forecast_for_location` →
+`ForecastService.get_forecast`) konsultiert **keinen** Cache — `src/services/forecast.py`
+enthält kein einziges Vorkommen von „cache".
+
+Konsequenz für die Einordnung von #1765: Die Trip-Vorschau ist nur **kalt** langsam
+(#1839: >50 s kalt, 0,65 s warm — der Cache greift). Die Vergleichs-Vorschau ist
+**immer** kalt; „lädt nie" ist dort kein Erstaufruf-Problem, sondern der Dauerzustand.
+**Diese Ursache wird in diesem Workflow NICHT angegangen.** Drei Gründe, in dieser Reihenfolge:
+
+1. **Sie erklärt den gemeldeten Fehler nicht.** #1765 und #1839 beschreiben beide den
+   **ersten**, kalten Aufruf. Ein Cache wirkt strukturell erst ab dem zweiten.
+2. **Sie ist eine dokumentierte, bewusste Zurückstellung**, kein Versäumnis:
+   `docs/specs/modules/fix_1329_forecast_cache_budget.md:399-407` benennt sie wörtlich als
+   „bewusster Scope-Schnitt" und „Folge-Optimierungs-Ticket, kein Korrektheitsproblem".
+   Dieselbe Stelle (Zeilen 414-419) nennt `forecast.py` und `trip_forecast.py` als gleich
+   gelagerte Fälle. **Das angekündigte Folge-Ticket existiert bis heute nicht** (per
+   `gh issue list` gesucht) — gehört als Zeile ins Sammel-Issue #1199, nicht in diesen Workflow.
+3. **Der Nutzen wäre für den realistischen Anwendungsfall klein.** `ThunderWindowCache`
+   greift **regionsabhängig** (`src/providers/thunder_routing.py:33,47-49`): nur bei Routing
+   nach `FR` (Météo-France, `meteofrance.py:613`). Für `DE_ALPEN` — laut Kommentar in
+   `thunder_routing.py:33` ausdrücklich Deutschland, Alpenraum **und Österreich**, also der
+   Karnische Höhenweg — läuft die Anreicherung über `dwd.py`, und dort gibt es **keinen
+   Cache**. Der teuerste Einzelabruf (DWD-Gewitter, Budget 150 s) ist damit bei jedem Aufruf
+   voll exponiert, kalt wie warm.
+
+Was beim zweiten Aufruf innerhalb von 600 s tatsächlich entfällt, je Abrufgruppe:
+
+| Abrufgruppe je Ort | gecacht? | Fundstelle |
+|---|---|---|
+| Grundvorhersage (`ForecastService.get_forecast`) | **nein** | `comparison_engine.py:412-423`, `src/services/forecast.py` (0 Treffer „cache") |
+| Gewitter-Anreicherung | **nur bei FR-Routing** | `thunder_routing.py:47-49`; `meteofrance.py:613` (Cache) vs. `dwd.py`/`dwd_eu.py` (keiner) |
+| Bergfex-Schnee (optional) | **nein** | `comparison_engine.py:432-441` |
+| Amtliche Warnungen (optional) | **ja**, 1800 s | `official_alerts/warn_egress.py:38-39`, `geosphere_warn.py:37,53` |
+
+Nebenbei belegt: Ein Adapter, der Vergleichsorte in den geteilten Cache einhängt, existiert
+bereits für die Alarm-Prüfung (`src/services/compare_location_weather_source.py:145-156`) —
+ein späteres U4-Ticket hätte also einen Präzedenzfall, aber der Adapter liefert nur den
+schmalen Alarm-Ausschnitt (ein Tagesfenster, kein 96-h-Ausblick).
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `api/routers/preview.py` | **U1** — die vier `async def`-Handler ohne `await` |
+| `src/services/preview_service.py:173` | **U2** — Einstieg Trip-Vorschau, ruft `_fetch_weather` |
+| `src/services/compare_preview_service.py:163` | Einstieg Vergleichs-Vorschau, ruft `ComparisonEngine.run` |
+| `src/services/comparison_engine.py:127` | **U3** — Ortsschleife Vergleich |
+| `src/services/trip_report_scheduler.py:1917-1975` | **U2+U3** — `_fetch_weather`, Segmentschleife, Retry-Politik |
+| `src/services/segment_weather.py:195` | Netzabruf je Segment (Ein-Segment-Funktion) |
+| `src/services/stage_weather.py:173` | **Vorbild** — `ThreadPoolExecutor(max_workers=min(len(flat), 8))` über denselben Aufruf |
+| `src/providers/call_log.py:41-64` | **Risiko R1** — Quellenzuordnung über `inspect.stack()` |
+| `src/providers/thunder_enrichment.py:182` | Gewitter-Anreicherung je Ort |
+| `src/providers/dwd.py:119` / `meteofrance.py:114` / `dwd_eu.py` | Gewitter-Zeitbudgets 150 s / 45 s / 25 s |
+| `src/providers/thunder_window_cache.py:26,58,153` | Prozess-Singleton, `threading.Lock`, ausdrücklich für Parallelisierung gebaut |
+| `src/services/weather_cache.py:91,294` | Prozess-Singleton, `threading.Lock` |
+| `src/services/forecast_budget.py:175-215` | `fcntl.flock`, fail-open; `user_briefing` wird nie gedrosselt |
+| `internal/handler/preview_proxy.go:52,81` | Go-Timeouts 60 s (Vergleich) / 30 s (Trip) |
+| `internal/handler/proxy.go:19` | Health-Timeout 2 s → erklärt `degraded` |
+
+## Existing Patterns
+
+- **Parallelisierung ist im Repo bereits gelebt und spezifiziert:** `stage_weather.py:173`
+  nutzt `ThreadPoolExecutor` über `SegmentWeatherService.fetch_segment_weather()` mit
+  Best-effort je Segment (`_fetch_one`, Zeilen 52–57). Die Spec
+  `docs/specs/modules/stage_weather_python_endpoint.md:57` bezeichnet den Aufruf ausdrücklich
+  als „**parallel** via `ThreadPoolExecutor` (flach über alle (Stage,Segment)-Paare; I/O-bound,
+  threadsicher)". Dort war **kein neuer ADR nötig** (Zeile 128: ADR-0015 deckt es ab).
+- **Thread-Sicherheit wurde vorbereitet:** `thunder_window_cache.py:58-62` begründet den Lock
+  wörtlich damit, dass „die Orts-Schleife des Ortsvergleichs parallelisiert werden kann".
+
+## Dependencies
+
+**Upstream (was der Vorschau-Pfad nutzt):** `ForecastService`/`OpenMeteoProvider` →
+`_enrich_thunder` → `dwd`/`dwd_eu`/`meteofrance`; `BergfexScraper`;
+`get_official_alerts_with_status`; `ThunderWindowCache`, `WeatherCacheService`,
+`ForecastBudgetGate`, `call_log`.
+
+**Downstream (wer die zu ändernden Stellen sonst noch nutzt) — das ist der Blast Radius:**
+
+`_fetch_weather` (6 Produktiv-Aufrufer):
+`preview_service.py:173` (Vorschau) · `trip_command_processor.py:306` (Inbound-Befehle) ·
+`trip_report_scheduler.py:694`, `:1286`, `:2254`, `:2689` (**Versand + Alarme**)
+
+`ComparisonEngine.run` (3 Produktiv-Aufrufer):
+`compare_preview_service.py:163` (Vorschau) · `scheduler_dispatch_service.py:451`
+(**Versand**) · `api/routers/compare.py:71` (Vergleichsansicht im Frontend)
+
+⇒ Eine Änderung **innerhalb** dieser beiden Funktionen trifft Briefings und Alarme mit.
+Der Zuschnitt muss klären, ob die Nebenläufigkeit dort eingebaut oder auf den Vorschau-Pfad
+begrenzt wird (z.B. opt-in-Parameter mit Default = heutiges Verhalten).
+
+## Existing Specs
+
+| Spec | Bezug |
+|---|---|
+| `docs/specs/modules/stage_weather_python_endpoint.md` | **Vorbild** für die Parallelisierung (Zeilen 57, 122–124, 126–129) |
+| `docs/specs/modules/epic_140_output_vorschau.md` | Ursprungsspec der Vorschau-Endpunkte |
+| `docs/specs/modules/compare_channel_preview_dispatch.md` | Vergleichs-Vorschau + Versand |
+| `docs/specs/modules/fix_1329_forecast_cache_budget.md` | `ForecastBudgetGate` |
+| `docs/specs/modules/feat_1531_s1_dwd_gewittergroessen.md` | Herkunft des 150-s-Gewitterbudgets |
+| `docs/specs/modules/fix_1447_s2a_scheduler_ueberlappung_teilerfolg.md` | `skipped_since_last_run` — Wirkungsnachweis für #1539 |
+| ADR-0015 | Python ist Owner der Wetter-Domäne (deckt die Parallelisierung ab) |
+
+## Risks & Considerations
+
+- **R1 (still, hoch) — Die Diagnose-Zuordnung bricht unter Threads.**
+  `call_log.resolve_call_source()` (`src/providers/call_log.py:57-64`) leitet die Quelle aus
+  `inspect.stack()[:25]` **des aufrufenden Threads** ab. In einem `ThreadPoolExecutor` beginnt
+  der Stack beim Worker — alle Marker (`render_email_preview`, `_fetch_weather`, `compare`, …)
+  verschwinden, jeder Abruf landet als `"unbekannt"` im Journal (#338). **Kein bestehender Test
+  fängt das** (die Tests rufen im Hauptthread auf). Verdacht: Der Cockpit-Pfad über
+  `stage_weather.py` protokolliert deshalb **heute schon** „unbekannt" — vor der Umsetzung am
+  Journal nachmessen; trifft es zu, ist es ein belegter Vorfall statt einer Theorie.
+- **R2 — Höflichkeit gegenüber den Amtsdiensten.** DWD/Météo-France vertragen keinen
+  unbegrenzten Parallelabruf. Obergrenze setzen (Vorbild: `min(len(flat), 8)`).
+  `ForecastBudgetGate` hilft hier nicht: `user_briefing` wird nie gedrosselt
+  (`forecast_budget.py:64-65`).
+- **R3 — Reihenfolge-Stabilität.** Die Ortsreihenfolge im Vergleich ist fachlich festgelegt
+  (`docs/specs/modules/compare_location_order.md`, `tests/unit/test_compare_location_order.py`).
+  Parallele Abarbeitung darf die Ausgabereihenfolge nicht verändern.
+- **R4 — Fehlerverhalten je Ort.** Heute bricht ein Ortsfehler die Schleife nicht
+  (`try/except` je Ort). Best-effort-Semantik muss erhalten bleiben; `future.result()`
+  wirft sonst den ersten Fehler nach außen.
+- **R5 — Kein Test deckt Laufzeit oder Nebenläufigkeit ab.** Weder für `preview_proxy.go`
+  (30 s/60 s) noch für die Ortsschleife existieren Timeout- oder Lastszenarien. Der
+  Wirkungsnachweis muss neu gebaut werden — **am Wirkort**: dass `/health` **während** einer
+  laufenden Vorschau antwortet, ist die eigentliche Zusicherung von U1.
+- **R6 — Timeout-Leiter ist widersprüchlich** (Nebenbefund, keine Lösung):
+  Vergleichs-Vorschau Go 60 s == nginx 60 s (kein Puffer, Wettlauf); Trip-Vorschau Go 30 s,
+  obwohl nginx 60 s zuließe; der **Versand** desselben Rechenwegs darf 120 s
+  (`compare_preset.go:676`) bzw. 300 s (`proxy.go:277`). nginx setzt für gregor20 **kein**
+  `proxy_read_timeout` → Default 60 s (geprüft in `/etc/nginx/sites-available/gregor20.henemm.com`).
+
+## Korrekturen an den Ticketkörpern (am Code gemessen)
+
+- **#1539 nennt für `de_direct` 90 s.** Heute steht dort **150 s**
+  (`dwd.py:119 THUNDER_FETCH_DEADLINE_SECONDS = 150.0`, PO-Entscheid 2026-08-08 via #1531).
+  Der Worst Case je Ort ist seit dem Ticket **größer** geworden.
+- **#1765 nennt „~21 s pro Ort"** (gemessen 2026-08-12). Wegen der Budgetanhebung aus #1531
+  ist dieser Wert vor der Umsetzung **neu zu messen**, nicht zu übernehmen.
+- **#1765 vermutet den Single-Worker als Nebenaspekt** („prüfen, ob der Python-Core mehr als
+  einen Worker verträgt"). Gemessen ist der Grund präziser: nicht die Worker-Zahl, sondern
+  `async def` **ohne** `await` bei synchroner Arbeit. Ein `def`-Handler behebt es ohne
+  zusätzliche Prozesse.
+
+## Messungen am laufenden Staging-Dienst (2026-08-15)
+
+Fixtures: 3-Orte-Preset `cp-21e198c1b74020dd` (Innsbruck/Stubai/Zillertal — alle in `DE_ALPEN`),
+2-Orte-Preset temporär angelegt und danach gelöscht, Trip `e2e-1680-s5b-preview`.
+Rohdaten im Session-Scratchpad (`m1_health_log.txt`, `openmeteo_tail2000.jsonl`).
+
+| # | Messung | Ergebnis |
+|---|---|---|
+| M1 | `/health` während einer Vergleichs-Vorschau (3 Orte) | **74,5 s von 75,76 s nicht binnen 2 s erreichbar** — 25 Timeouts in Folge, erst der Poll nach Abschluss kam mit 200/0,30 s durch |
+| M2 | Vergleich, kalt / warm (3 Orte) | 75,76 s / **75,66 s** |
+| M2 | Vergleich, kalt / warm (2 Orte) | 50,14 s / **49,85 s** |
+| M2 | daraus Sekunden je Ort | **25,1–25,6 s** (Grenzkosten des 3. Ortes: 25,62 s) |
+| M3 | Trip kalt / warm | **121,14 s** / 0,69 s; ein dritter Aufruf Minuten später wieder 78,64 s |
+| M4 | Vergleich über nginx | **504 nach 60,02 s** |
+| M4 | Trip über nginx | **502 nach 30,02 s** |
+| M5 | Diagnose-Journal, letzte 2000 Zeilen | **7,4 % (148) `source: "unbekannt"`** |
+
+### Was die Messungen entscheiden
+
+- **(a) „~21 s pro Ort" ist widerlegt** — gemessen 25,1–25,6 s, rund 20 % höher. Passt zur
+  Anhebung des DWD-Gewitterbudgets von 90 s auf 150 s (#1531, 2026-08-08).
+- **(b) „>50 s kalt / 0,65 s warm"** — warm trifft (0,69 s), kalt ist mit **121 s** mehr als
+  doppelt so hoch wie das Ticket nahelegt.
+- **(c) „eine einzelne Vorschau kippt `/api/health`" ist bestätigt** — und stärker als
+  „kippt": der Dienst war praktisch die **gesamte** Aufrufdauer stumm.
+- **U4 unabhängig bestätigt:** Beim Vergleich sind kalt und warm **identisch** (75,76/75,66 s;
+  50,14/49,85 s). Es gibt dort keinen wirksamen Cache — auch `ThunderWindowCache` nicht, weil
+  die drei Testorte nach `DE_ALPEN` routen und damit über `dwd.py` laufen, das keinen Cache
+  hat. Die Regionsanalyse hat das vorhergesagt, die Messung bestätigt es.
+- **Die `call_log`-Falle ist belegt, nicht mehr theoretisch:** Ein `unbekannt`-Cluster
+  (2026-08-12T04:45:22–31 UTC) fällt zeitlich exakt mit einem
+  `GET /api/_internal/trips/…/stages-weather` zusammen — dem Endpunkt, der bereits heute einen
+  `ThreadPoolExecutor` nutzt. **Einschränkung des Messenden:** Ein zweites Cluster korreliert
+  stattdessen mit `/api/_validator/sms-fidelity-preview`; dort ist die Ursache eine fehlende
+  Marker-Abdeckung, keine Threading-Folge. `unbekannt` ist also nicht ausschließlich
+  Threading-bedingt.
+
+### Nachmessung N1/N2 — was die Trip-Vorschau wirklich tut (störungsfreies Fenster)
+
+Gemessen im Fenster 12:57:49–12:59:50 UTC, in dem laut `journalctl` **kein** fremder Request
+lief, und **vor** dem Staging-Neustart um 13:00:22 UTC.
+
+**N1 — 7 Segmentabrufe, nicht 3:**
+
+| # | Segment | Tag | Dauer |
+|---|---|---|---|
+| 1 | Start | heute | 12,27 s |
+| 2 | Ziel | heute | 12,12 s |
+| 3 | Nachtwetter (Segment 999) | heute | 24,60 s |
+| 4 | Start | +1 Tag | 25,38 s |
+| 5 | Ziel | +1 Tag | 25,90 s |
+| 6 | Start | +2 Tage | 10,06 s |
+| 7 | Ziel | +2 Tage | 10,13 s |
+
+Summe **120,46 s** von 121,14 s Gesamtdauer (Rest: abschließender ECMWF-Z500-Abruf für das
+Stabilitäts-Label plus Rendering). Mittel ~17,3 s, Spanne 10,1–25,9 s.
+
+Warum 7: Der Trip hat 3 Etappen à 2 Wegpunkte. Die Vorschau holt dieselben 2 Wegpunkte
+zusätzlich für **+1 und +2 Tage** (Gewitter-Vorhersage / Mehrtages-Trend) — 2 × 3 = 6 — plus
+**1 × Nachtwetter** = 7. **Kostentreiber ist nicht der HTTP-Abruf** (Antwort in < 50 ms),
+sondern die DWD-Gewitter-Anreicherung je Segment.
+
+**Konsequenz — die Sorge „Parallelisierung reicht nicht" ist widerlegt.** Parallelisiert
+läge die Gesamtzeit bei etwa dem langsamsten Einzelsegment, also **~26 s** — unter der
+30-s-Grenze des Go-Weiterleiters. **Aber die Reserve ist dünn** (~87 % des Budgets), was die
+Korrektur der Timeout-Leiter in Scheibe B als **Sicherheitsabstand** rechtfertigt, nicht als
+Ersatz für die Beschleunigung.
+
+**Offene Designfrage für Scheibe B** (vom Messenden ausdrücklich als nicht durch Messung
+beantwortbar markiert): Die 7 Abrufe verteilen sich über **mindestens drei getrennte Schritte**
+im Vorschau-Code (Hauptabruf heute, Gewitter-Vorhersage +1/+2 Tage, Nachtwetter). Ob sie in
+**einen** gemeinsamen Parallel-Pool passen oder mehrere Stellen umgebaut werden müssen, ist
+dort zu klären.
+
+**N2 — null Wiederholversuche.** Kein Treffer für „Weather fetch failed for segment … after
+N attempt(s)", keine Tenacity-Meldungen, jedes Segment genau einmal protokolliert, alle
+Abrufe `status:200, error:null` beim ersten Versuch.
+
+⇒ **U2 ist latenzseitig wirkungslos, solange die Wetterdienste gesund sind.** Die 121 s sind
+echte, einmalige Arbeit. Der Wert von U2 liegt woanders und ist entsprechend zu begründen:
+(a) es schafft die **vorschau-eigene Abruf-Nahtstelle**, ohne die Scheibe B nicht
+parallelisieren kann, ohne `_fetch_weather` (6 Aufrufer, 4 im Versand-/Alarmpfad) anzufassen;
+(b) bei einer **echten** Provider-Störung verdreifacht sich heute die Wartezeit der
+interaktiven Vorschau samt `sleep` — realer Fall, in dieser Messung nur nicht eingetreten.
+Einschränkung des Messenden: eine Momentaufnahme bei fehlerfreiem Provider kann Retries im
+Störungsfall nicht ausschließen, nur ihr Ausbleiben im Normalbetrieb belegen.
+
+**Nicht verwertbare Gegenprobe, ausdrücklich so gemeldet:** Ein zweiter Trip (`277aa63f`)
+antwortete in 0,15 s — aber nur, weil sein Datum außerhalb des DWD-Vorhersagehorizonts liegt
+und alle 6 Anfragen sofort mit HTTP 400 zurückkamen. Kein echter Abruf, kein Beleg.
+
+### Störung, die bei jeder Wiederholung mitzudenken ist
+
+Zwei **getrennte** Störquellen, beide vor jeder Wiederholungsmessung zu prüfen:
+
+1. **Staging-Neustart leert den Cache.** Der 78,64-s-Ausreißer beim dritten Trip-Aufruf ist
+   belegt erklärt: `gregor-python-staging.service` wurde um 13:00:22 UTC neu gestartet
+   (Staging-Auto-Deploy, PID-Wechsel im `journalctl` nachgewiesen). Das verwirft den
+   prozessweiten In-Memory-Cache vollständig — nach jedem Auto-Deploy ist der erste Aufruf
+   wieder kalt. Die zunächst genannte Vermutung „vermutlich Fremdlast" wurde vom Messenden
+   selbst **zurückgezogen und durch diesen Beleg ersetzt**.
+2. **Parallele Fremdnutzung** besteht unabhängig davon (ein fremdes Compare-Preset entstand
+   während der Messung im selben Nutzer). Weil der Python-Core ein Single-Worker ist,
+   verfälscht jeder fremde Vorschau-Aufruf die Zeitmessung nach oben. Als **Beobachtung**
+   gemeldet, nicht als Erklärung für einen bestimmten Messwert.
+
+## Analysis
+
+### Type
+**Bug** (beide Tickets `bug`, `priority:medium`, nutzersichtbares Fehlverhalten).
+
+### Technischer Ansatz
+
+**U1 — Entblockung (Scheibe A).** Die 13 `async def`-Handler ohne `await` werden zu `def`.
+Damit führt Starlette sie im Threadpool aus, der Event-Loop bleibt frei. Kein `await` ist
+vorhanden, das brechen könnte; `gpx.py:22 parse_gpx` bleibt `async def` (nutzt `await`).
+Der Threadpool ist nirgends konfiguriert → anyio-Default (40 Threads); genügt.
+
+**U2 — Vorschau-eigene Abrufpolitik (Scheibe A).** Statt `scheduler._fetch_weather()` mit
+seiner Versand-Retry-Leiter bekommt die Trip-Vorschau eine eigene, schlanke Abruffunktion in
+`preview_service.py`, die `fetch_segment_weather()` je Segment ohne Wiederhol-Schleife
+aufruft. Grund: Wartezeit ist im Versand unkritisch (PO-Einordnung #1539), in einer
+interaktiven Vorschau nicht.
+
+**U3 — Parallelisierung (Scheibe B), Variante V3 „außen".** Bewertet wurden drei Varianten:
+
+| | Ansatz | Bewertung |
+|---|---|---|
+| V1 | `ThreadPoolExecutor` **in** `_fetch_weather` / `ComparisonEngine.run` | verworfen — ändert Versand und Alarme sofort mit (9 Aufrufer) und nimmt die `[triage:po]`-Entscheidung aus #1539 vorweg |
+| V2 | Opt-in-Parameter, Default = heute | verworfen — baut einen toten Zweig in versandkritischen Code, den heute kein Aufrufer nutzt |
+| **V3** | Parallelisierung **außen**, nur im Vorschau-Pfad | **empfohlen** |
+
+Für den Trip ist V3 geradeaus (Parallelisierung um die in A neu entstandene Abruffunktion).
+Für den Vergleich wird `comparison_engine.py` **nicht angefasst**; stattdessen ruft
+`compare_preview_service.py` `ComparisonEngine.run(locations=[loc], …)` je Ort parallel auf
+und fügt die Ergebnisse indexiert zusammen.
+
+**Die Äquivalenz dieses Aufsplittens wurde nachgeprüft, nicht angenommen:**
+`time_window`, `target_date`, `forecast_hours`, `profile` und `official_alerts_enabled` sind
+**Parameter** von `run()` (`comparison_engine.py:98-105`), werden also nicht aus der
+Ortsmenge abgeleitet. Nach der Schleife findet nichts Ortsübergreifendes mehr statt — seit
+#1359 Scheibe 2 gibt es keine Score-Sortierung, `results` behält die Eingabereihenfolge
+(`comparison_engine.py:383-390`). Der Provider wird in `fetch_forecast_for_location` **je Ort**
+neu gebaut und geschlossen, es existiert also gar keine ortsübergreifende Dedup, die verloren
+gehen könnte. Als Nebengewinn erbt die Variante die vorhandene Fehlerbehandlung: `run()` fängt
+Ortsfehler bereits intern ab (`comparison_engine.py:369-381`) und wirft bei einem einzigen Ort
+nie nach außen — Best-effort bleibt ohne Zutun erhalten.
+
+### Affected Files
+
+| Datei | Änderung | Scheibe | Beschreibung |
+|---|---|---|---|
+| `api/routers/preview.py` | MODIFY | A | 4× `async def` → `def` |
+| `api/routers/internal.py` | MODIFY | A | 2× `async def` → `def` |
+| `api/routers/validator.py` | MODIFY | A | 6× `async def` → `def` |
+| `api/routers/notify.py` | MODIFY | A | 1× `async def` → `def` |
+| `src/services/preview_service.py` | MODIFY | A+B | eigene Abruffunktion (A), Parallelisierung (B) |
+| `tests/unit/…` (neu) | CREATE | A | U1-Test am Wirkort + Ratschen-Test |
+| `src/services/compare_preview_service.py` | MODIFY | B | `run()` je Ort parallel, indexierte Zusammenführung |
+| `src/providers/call_log.py` | MODIFY | B | `ContextVar`-Override vor der Stack-Inspektion |
+| `src/utils/timezone.py` | MODIFY | B | Lock um `_tf_instance` |
+| `tests/unit/…` (neu) | CREATE | B | Reihenfolge, Best-effort, `call_log` unter Threads |
+
+### Scope Assessment
+
+- Dateien: ~10 (A: 6, B: 5, teils überlappend)
+- Produktivcode geschätzt: **A ~30–40 LoC, B ~60–80 LoC** — zusammen unter dem 250er-Limit,
+  aber knapp genug, dass der Zähler vor Beginn von B geprüft gehört
+- Risk Level: **A = LOW** (mechanisch, kein `await` vorhanden), **B = MEDIUM**
+  (Nebenläufigkeit, aber mit Präzedenzfall und thread-sicher vorbereiteten Caches)
+
+### Beschlossene Gegenmaßnahmen für Scheibe B
+
+| Risiko | Gegenmaßnahme | Nachweis |
+|---|---|---|
+| Reihenfolge kippt | indexierte Vorbelegung (`[None] * len(items)`) statt Append bei Fertigstellung, wie `stage_weather.py:171` | `tests/unit/test_compare_location_order.py` (Compare); für Trip fehlt ein Äquivalent → neu |
+| Fehler eines Orts reißt alle mit | Compare: gratis über `run()`-je-Ort; Trip: Wrapper wie `stage_weather.py:52-57` | neuer Kern-Test |
+| `call_log` verliert die Quelle | `ContextVar`-Override in `resolve_call_source()` vor der Stack-Inspektion; die 11 Bestandsmarker bleiben als Rückfall | neuer Kern-Test mit 2 Workern |
+| `_tf_instance` doppelt geladen | Lock nach Vorbild `weather_cache.py` | Test mit 2 Threads + Aufrufzähler |
+| Météo-France-Kontingent | Parallelitätsgrad **niedriger als das Vorbild**: Vergleich `min(len(locations), 4)`, Trip `min(len(segments), 8)`, als benannte Konstante mit Verweis auf `decision_matrix.md` | Code-Review (nicht kern-testbar) |
+| Cache-Stampede bei gleichzeitigem Miss | **keine** — bewusst nur benannt (bereits dokumentierte offene Lücke) | — |
+
+Grundlage der Kontingent-Grenze: `docs/reference/decision_matrix.md:229-247` — Météo-France
+erlaubt **100 Anfragen/Minute auf ein gemeinsames Konto für alle Nutzer**, ohne aktive
+Drosselung (die Lücke ist dort selbst dokumentiert).
+
+### Open Questions
+
+- [ ] Bestätigt die Live-Messung, dass `/api/health` während einer echten Vorschau kippt?
+      (Die Mechanik ist netzfrei bewiesen; offen ist nur die Bestätigung am Dienst.)
+- [ ] Füllt der bestehende `stage_weather`-Threadpool das Diagnose-Journal heute schon mit
+      `source: "unbekannt"`? Falls ja, ist die `call_log`-Reparatur ein belegter Fang statt
+      einer Vorsichtsmaßnahme.
+- [ ] Liefert `SegmentWeatherService.fetch_segment_weather()` bei einem 96-h-Fenster
+      dieselbe Datenform wie der heutige direkte `get_forecast(hours_ahead=96)`? **Nur
+      relevant, falls U4 je angegangen wird** — für diesen Workflow nicht zu klären.
+
+## Zuschnitt (Intake-Empfehlung, PO-Freigabe 2026-08-15 „go")
+
+- **Scheibe A:** U1 + U2 — Vorschau blockiert den Prozess nicht mehr, eigene kurze
+  Wiederhol-/Zeitpolitik für den interaktiven Pfad. Kein Nebenläufigkeitsrisiko im Versandpfad.
+- **Scheibe B:** U3 — Parallelisierung nach dem Muster aus `stage_weather.py:173`; echter
+  Teilschritt Richtung #1539. R6 nur nachziehen, falls die dann gemessene Laufzeit es verlangt.

--- a/docs/specs/modules/fix_1765_1839_sa_vorschau_entblockung.md
+++ b/docs/specs/modules/fix_1765_1839_sa_vorschau_entblockung.md
@@ -12,7 +12,7 @@ tags: [bug, performance, preview, python-core, issue-1765, issue-1839]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-Freigabe („go") am 2026-08-15 auf AC-1 bis AC-4
 
 ## Purpose
 

--- a/docs/specs/modules/fix_1765_1839_sa_vorschau_entblockung.md
+++ b/docs/specs/modules/fix_1765_1839_sa_vorschau_entblockung.md
@@ -98,9 +98,20 @@ einzige verbleibende `async def`-Handler nutzt `await` tatsächlich.
 
 ### Nebenwirkung von Ä1 — Scheibe A führt erstmals echte Nebenläufigkeit im Anfragepfad ein
 
-Bevor der Umfang dieser Scheibe festgelegt wurde, sind alle `global`-Anweisungen in `src/`
-und `api/` durchgesehen worden, um zu prüfen, welcher geteilte, veränderliche Zustand von der
-neuen Nebenläufigkeit aus Ä1 betroffen sein könnte:
+Bevor der Umfang dieser Scheibe festgelegt wurde, ist **nach `global`-Anweisungen in `src/`
+und `api/` gesucht** worden, um zu prüfen, welcher geteilte, veränderliche Zustand von der
+neuen Nebenläufigkeit aus Ä1 betroffen sein könnte.
+
+**Reichweite dieser Suche — Korrektur nach Adversary-Lauf am 2026-08-15 (F002):** Hier stand
+zunächst, es seien „alle `global`-Anweisungen durchgesehen" worden und außer `_get_tf()` sei
+nichts Offenes zurückgeblieben. Diese Vollständigkeitsaussage ging zu weit und ist widerlegt.
+Eine Suche nach dem Schlüsselwort `global` findet **prinzipiell** eine ganze Klasse geteilten
+Zustands nicht: Dekorator-basierte Zwischenspeicher (`functools.lru_cache`, `functools.cache`),
+Klassenattribute und veränderliche Standardargumente kommen ohne `global` aus. Genau ein Fall
+dieser Klasse liegt im umgestellten Pfad (`_lookup_department_cached()`, Zeile unten) und wurde
+von der ursprünglichen Suche übersehen. Die Tabelle ist deshalb **kein** Vollständigkeitsbeweis,
+sondern eine Liste geprüfter Stellen — die beiden zuletzt aufgenommenen Zeilen stammen aus dem
+Adversary-Lauf, nicht aus der ursprünglichen Durchsicht.
 
 | Stelle | Zustand | Bewertung |
 |---|---|---|
@@ -110,9 +121,12 @@ neuen Nebenläufigkeit aus Ä1 betroffen sein könnte:
 | **`src/utils/timezone.py:23-29` `_get_tf()`** | **Lazy-Singleton OHNE Sperre** | **muss repariert werden → Ä3** |
 | `_warned_missing_key` in `src/services/official_alerts/vigilance.py:63`, `meteoalarm.py:496`, `meteo_forets.py:63` | „einmal warnen"-Merker ohne Sperre | unkritisch, **nicht** angefasst — schlimmstenfalls wird eine Warnung doppelt protokolliert |
 | `api/routers/webhook.py:57` `telegram_webhook`, `api/routers/scheduler.py:174` `trigger_inbound_telegram` | Lazy-Singletons ohne Sperre | **nicht** angefasst, bewusste Abgrenzung — diese Handler sind bereits heute `def` und damit schon vor Scheibe A nebenläufig erreichbar; Ä1 verursacht dieses Bestandsrisiko nicht und vergrößert es nicht |
+| `src/services/official_alerts/department_mapper.py:335-336` `_lookup_department_cached()` — **von der `global`-Suche strukturell nicht auffindbar** (`@functools.lru_cache`, kein `global`) | prozessweiter Zwischenspeicher ohne eigene Sperre | **geprüft, unkritisch — nicht angefasst.** Erreichbar aus dem umgestellten `preview_compare`: `comparison_engine.py:322` → `get_official_alerts_with_status()` (`official_alerts/base.py:90`) → `lookup_department()` (`department_mapper.py:376`, dort Zeile 411) → `_lookup_department_cached()`. Der Pfad ist im Normalfall aktiv (`official_alerts_enabled` steht auf `True`, `comparison_engine.py:104`). `lru_cache` ist in CPython intern abgesichert; ein Wettlauf führt zu **doppelter Berechnung**, nicht zu Datenverfälschung oder verfälschtem Cache-Inhalt — dieselbe Risikoklasse, die diese Spec bei `_get_tf()` (dort: zwei kurzzeitige `TimezoneFinder`-Instanzen) ohnehin als unkritisch einstuft und nur wegen der 12-MB-Größe repariert. Hier fehlt dieser Größen-Anlass. |
+| `src/app/egress_guard.py:139-140` `install_egress_guard()` (`_installed`, `_orig_*`) | Modul-Globals ohne Sperre | **geprüft, unkritisch — nicht angefasst.** Läuft einmalig in `lifespan()` (`api/main.py:96`), also **bevor** die Anwendung Anfragen annimmt; zur Laufzeit schreibt niemand mehr in diese Globals. Ä1 macht die Stelle nicht neu erreichbar. |
 
-Einzig `_get_tf()` ist ein echtes, durch Ä1 neu erreichbares Risiko und wird als Ä3 behoben.
-Alles andere ist entweder bereits abgesichert oder ein Bestandsrisiko außerhalb dieser Scheibe.
+`_get_tf()` bleibt das einzige durch Ä1 neu erreichbare Risiko, das **repariert** wird (→ Ä3).
+Alles andere ist entweder bereits abgesichert, ein Bestandsrisiko außerhalb dieser Scheibe oder
+— wie die beiden zuletzt aufgenommenen Zeilen — geprüft und in der Wirkung folgenlos.
 
 ### Ä3 — `_get_tf()` in `src/utils/timezone.py` gegen gleichzeitige Erstinitialisierung absichern
 
@@ -356,10 +370,17 @@ Mutationen ausschließlich per String-Ersetzung mit externer Sicherungskopie, ni
   eine Reparatur.** Vorher: „ein Aufruf legt alles lahm, dafür läuft nie etwas gleichzeitig".
   Nachher: „vieles läuft gleichzeitig". Der Tausch ist eindeutig richtig — die heutige
   Blockade ist der gemeldete, nutzersichtbare Fehler —, aber er verschiebt die Fehlerklasse
-  von **Blockade** zu **Nebenläufigkeit**. Die Tabelle unter „Nebenwirkung von Ä1" oben ist
-  der Beleg, dass diese Verschiebung vor Festlegung des Umfangs systematisch geprüft wurde
-  (alle `global`-Anweisungen in `src/` und `api/`) und außer `_get_tf()` (→ Ä3) nichts
-  Offenes zurückließ, das durch Ä1 neu erreichbar würde.
+  von **Blockade** zu **Nebenläufigkeit**. Die Tabelle unter „Nebenwirkung von Ä1" oben
+  listet die daraufhin geprüften Stellen. **Sie ist ausdrücklich kein Vollständigkeitsbeweis**
+  — hier stand bis zum Adversary-Lauf am 2026-08-15 die Behauptung, es seien „alle
+  `global`-Anweisungen in `src/` und `api/`" geprüft worden und außer `_get_tf()` (→ Ä3) sei
+  nichts Offenes zurückgeblieben. Das war widerlegbar und wurde widerlegt (F002): Die
+  Suchmethode („Schlüsselwort `global`") kann Dekorator-basierte Zwischenspeicher,
+  Klassenattribute und veränderliche Standardargumente prinzipiell nicht finden, und genau so
+  ein Fall liegt im umgestellten Pfad (`_lookup_department_cached()`, `@functools.lru_cache`).
+  Sachlich blieb es folgenlos — der Fall ist geprüft und unkritisch, siehe Tabelle —, aber die
+  **Aussage** war zu stark. Wer diese Scheibe fortschreibt, darf sich nicht darauf verlassen,
+  dass die Tabelle jeden geteilten Zustand im Anfragepfad kennt.
 - **Threadpool-Erschöpfung bei mehr als 40 gleichzeitigen langsamen Vorschauen.** Der
   anyio-Threadpool-Default liegt bei 40 Threads; eine 41. gleichzeitige langsame Vorschau
   würde warten müssen, bis ein Thread frei wird. Das ist gegenüber dem **heutigen** Zustand
@@ -460,3 +481,23 @@ Sitzungen), bevor ein Ergebnis als Befund gewertet wird.
   Retry-Status sowie die drei Festlegungen (a)/(b)/(c) für den Zuschnitt von Scheibe B; die
   `SegmentWeatherData`-Vertragsüberlegung (has_error statt Auslassen) ist dorthin
   übernommen, damit sie nicht verloren geht.
+- 2026-08-15: Korrektur nach Adversary-Lauf (Verdict AMBIGUOUS, zwei MEDIUM-Findings) —
+  **kein Produktivcode geändert**, beide Findings sind Aussage- bzw. Testdokumentations-Mängel.
+  **F002:** Die Vollständigkeitsaussage in „Nebenwirkung von Ä1" und unter „Risiken" („alle
+  `global`-Anweisungen in `src/`/`api/` durchgesehen, außer `_get_tf()` nichts Offenes") ist
+  **widerlegt** — die Suchmethode findet Dekorator-basierte Zwischenspeicher, Klassenattribute
+  und veränderliche Standardargumente prinzipiell nicht. Belegter Fall:
+  `_lookup_department_cached()` (`department_mapper.py:335-336`, `@functools.lru_cache`),
+  erreichbar aus dem umgestellten `preview_compare` über `comparison_engine.py:322` →
+  `get_official_alerts_with_status()` → `lookup_department()`, im Normalfall aktiv. Sachlich
+  unkritisch (`lru_cache` ist in CPython intern abgesichert; Wettlauf = doppelte Berechnung,
+  keine Datenverfälschung) — deshalb als **geprüft und unkritisch** in die Tabelle aufgenommen
+  statt repariert. Ebenfalls aufgenommen: `egress_guard.py:139-140` (`global`, aber einmalig in
+  `lifespan()` vor Annahme von Anfragen). Die zu weit gehende Aussage wurde **nicht
+  stillschweigend geglättet**, sondern an beiden Stellen ausdrücklich als widerlegt und
+  korrigiert markiert. **F001:** `tests/unit/test_route_handler_ohne_await.py` zählt `await`
+  rein per AST, ohne Erreichbarkeit im Kontrollfluss — ein Handler mit `if False: await …`
+  gefolgt von `time.sleep()` käme grün durch (Adversary-Sonde). Bewusst **nicht gelöst**
+  (kein Bestandsfall, Erreichbarkeitsanalyse unverhältnismäßig), sondern als Abschnitt
+  „Bekannte Grenze" im Docstring des Tests benannt, samt zweiter Verteidigungslinie
+  (`test_event_loop_bleibt_frei.py`, deckt aber nur die Vorschau-Handler ab).

--- a/docs/specs/modules/fix_1765_1839_sa_vorschau_entblockung.md
+++ b/docs/specs/modules/fix_1765_1839_sa_vorschau_entblockung.md
@@ -1,0 +1,462 @@
+---
+entity_id: fix_1765_1839_sa_vorschau_entblockung
+type: module
+created: 2026-08-15
+updated: 2026-08-15
+status: draft
+version: "1.0"
+tags: [bug, performance, preview, python-core, issue-1765, issue-1839]
+---
+
+# Vorschau-Entblockung: Handler ohne `await` + abgesicherte Zeitzonen-Lazy-Init (Scheibe A, #1765 + #1839)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Während eine E-Mail-, SMS-, Telegram- oder Vergleichs-Vorschau berechnet wird, ist der
+gesamte Python-Core heute **taub** — `/api/health` antwortet nicht, andere Nutzer bekommen
+keine Antwort, und ein einzelner langsamer Vorschau-Aufruf sieht von außen wie ein
+Dienstausfall aus (das hat am 2026-08-12 einen unnötigen Neustart von
+`gregor-python-staging` ausgelöst). Scheibe A beseitigt die **Ursache** dieser Blockade: 13
+Route-Handler sind als `async def` deklariert, obwohl sie kein `await` enthalten und damit
+im Event-Loop-Thread statt im Threadpool laufen.
+
+**Scheibe A macht die Vorschau NICHT schnell** — dazu siehe „Abgrenzung zu Scheibe B" unten.
+Sie sorgt dafür, dass eine laufende Vorschau den restlichen Dienst nicht mehr lahmlegt und
+beendet damit die Fehlalarme der Überwachung, die schon einmal zu einem unnötigen
+Dienstneustart geführt haben. **Das ist ein eigenständiger Gewinn, keine Vorstufe zu etwas
+Größerem** — Scheibe A liefert ihn vollständig und für sich genommen aus.
+
+Ä1 hat eine Nebenwirkung, die Teil der Spezifikation ist, nicht nur eine Randnotiz: Die 13
+Handler waren bisher als `async def` ohne `await` faktisch **serialisiert** — der blockierte
+Event-Loop ließ eine zweite gleichzeitige Vorschau-Anfrage erst beginnen, wenn die erste
+fertig war. Genau das ist der zu behebende Fehler. Sobald diese Handler `def` sind, laufen
+sie im Threadpool und damit **erstmals wirklich gleichzeitig** — jeder gemeinsame,
+veränderliche Zustand, der bisher durch die zufällige Serialisierung geschützt war, wird ab
+Ä1 tatsächlich parallel erreicht. Scheibe A umfasst deshalb eine zweite Änderung Ä3, die den
+einzigen dabei gefundenen ungeschützten Zustand absichert (siehe „Nebenwirkung von Ä1" unten).
+
+**Scheibe A besteht aus genau Ä1 + Ä3, sonst nichts.** Eine ursprünglich vorgesehene dritte
+Änderung (eigene Abrufpolitik für die Trip-Vorschau, vormals „Ä2") ist **vollständig nach
+Scheibe B verschoben** — Grund und Beleg dafür stehen in „Abgrenzung zu Scheibe B" unten.
+
+## Source
+
+- **File:** `api/routers/preview.py` · `api/routers/internal.py` · `api/routers/validator.py` ·
+  `api/routers/notify.py` (Ä1) · `src/utils/timezone.py` (Ä3)
+- **Identifier:** 13 Route-Handler (Liste unten) · `_get_tf()` (`src/utils/timezone.py:23`)
+
+## Estimated Scope
+
+- **LoC:** ~15 (Produktivcode, ohne Tests) — Ä1 ist reine Schlüsselwort-Entfernung, Ä3 ist
+  eine ~6-Zeilen-Ergänzung nach vorhandenem Muster (Lock-Import, Modul-Lock, doppelt geprüfte
+  Sperre)
+- **Files:** 5 Produktivdateien (4 Router + `timezone.py`) + neue Testdatei(en)
+- **Effort:** low (Ä1 ist mechanisch, kein `await` vorhanden, das brechen könnte; Ä3 kopiert
+  ein im Repo dreifach vorhandenes Muster wortgleich)
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| Starlette-Threadpool (anyio, Framework-Default) | Laufzeitverhalten | `def`-Handler laufen automatisch im Threadpool; keine Konfigurationsänderung nötig, siehe „Risiken" |
+| Doppelt-geprüfte-Sperre-Muster (`src/services/weather_cache.py:300-305` `get_shared_weather_cache()`, wortgleich in `src/providers/thunder_window_cache.py:158-163`, `src/services/radar_cache.py:115-119`) | pattern | Ä3 kopiert dieses im Repo dreifach vorhandene Muster für `_get_tf()`; kein neues Muster erfinden |
+
+## Implementation Details
+
+### Ä1 — 13 Route-Handler von `async def` zu `def`
+
+Kein einziger der folgenden Handler enthält ein `await` (zweifach gemessen: statisch per AST
+über den `api/`-Baum und zur Laufzeit an `app.routes` via `inspect.iscoroutinefunction`,
+Kontextdokument `docs/context/fix-1765-1839-vorschau-laufzeit.md`). Die Änderung ist in jedem
+Fall identisch: `async def` → `def`, keine weitere Anpassung im Funktionskörper.
+
+| Datei:Zeile | Handler |
+|---|---|
+| `api/routers/preview.py:30` | `preview_email` |
+| `api/routers/preview.py:56` | `preview_sms` |
+| `api/routers/preview.py:86` | `preview_compare` |
+| `api/routers/preview.py:129` | `preview_telegram` |
+| `api/routers/internal.py:30` | `loaded_trip` |
+| `api/routers/internal.py:56` | `stages_weather` |
+| `api/routers/validator.py:167` | `format_metric` |
+| `api/routers/validator.py:181` | `detector_thresholds` |
+| `api/routers/validator.py:244` | `alert_preview` |
+| `api/routers/validator.py:272` | `metrics_for_channel` |
+| `api/routers/validator.py:317` | `compare_email_preview` |
+| `api/routers/validator.py:339` | `sms_fidelity_preview` |
+| `api/routers/notify.py:19` | `test_notify` |
+
+**Nicht anfassen:** `api/routers/gpx.py:23 parse_gpx` — einziger Handler mit echtem `await`
+(`await file.read()`, Zeile 36) und bleibt deshalb `async def`.
+
+Nach Ä1 ist der Hausstil **einheitlich**: alle Route-Handler ohne `await` sind `def`, der
+einzige verbleibende `async def`-Handler nutzt `await` tatsächlich.
+
+### Nebenwirkung von Ä1 — Scheibe A führt erstmals echte Nebenläufigkeit im Anfragepfad ein
+
+Bevor der Umfang dieser Scheibe festgelegt wurde, sind alle `global`-Anweisungen in `src/`
+und `api/` durchgesehen worden, um zu prüfen, welcher geteilte, veränderliche Zustand von der
+neuen Nebenläufigkeit aus Ä1 betroffen sein könnte:
+
+| Stelle | Zustand | Bewertung |
+|---|---|---|
+| `src/services/weather_cache.py:300-305` `get_shared_weather_cache()` | doppelt geprüfte Sperre | sicher |
+| `src/providers/thunder_window_cache.py:158-163` `get_shared_thunder_window_cache()` | doppelt geprüfte Sperre | sicher |
+| `src/services/radar_cache.py:115-119` `get_shared_radar_cache()` | doppelt geprüfte Sperre | sicher |
+| **`src/utils/timezone.py:23-29` `_get_tf()`** | **Lazy-Singleton OHNE Sperre** | **muss repariert werden → Ä3** |
+| `_warned_missing_key` in `src/services/official_alerts/vigilance.py:63`, `meteoalarm.py:496`, `meteo_forets.py:63` | „einmal warnen"-Merker ohne Sperre | unkritisch, **nicht** angefasst — schlimmstenfalls wird eine Warnung doppelt protokolliert |
+| `api/routers/webhook.py:57` `telegram_webhook`, `api/routers/scheduler.py:174` `trigger_inbound_telegram` | Lazy-Singletons ohne Sperre | **nicht** angefasst, bewusste Abgrenzung — diese Handler sind bereits heute `def` und damit schon vor Scheibe A nebenläufig erreichbar; Ä1 verursacht dieses Bestandsrisiko nicht und vergrößert es nicht |
+
+Einzig `_get_tf()` ist ein echtes, durch Ä1 neu erreichbares Risiko und wird als Ä3 behoben.
+Alles andere ist entweder bereits abgesichert oder ein Bestandsrisiko außerhalb dieser Scheibe.
+
+### Ä3 — `_get_tf()` in `src/utils/timezone.py` gegen gleichzeitige Erstinitialisierung absichern
+
+`src/utils/timezone.py:23-29` lädt `TimezoneFinder` (~12 MB) beim ersten Aufruf und schreibt
+das Ergebnis in das ungeschützte Modul-Global `_tf_instance`:
+
+```python
+_tf_instance = None
+
+def _get_tf():
+    """Lazy singleton — TimezoneFinder loads ~12MB on first call."""
+    global _tf_instance
+    if _tf_instance is None:
+        from timezonefinder import TimezoneFinder
+        _tf_instance = TimezoneFinder()
+    return _tf_instance
+```
+
+Treffen zwei Threads gleichzeitig auf `_tf_instance is None` (z. B. zwei parallele
+Vorschau-Anfragen, die beide `tz_for_coords()` bzw. `location_tz()` aufrufen), sehen **beide**
+`None` und bauen je eine eigene `TimezoneFinder`-Instanz — ein kurzzeitiger 24-MB-Ausschlag,
+eine der beiden Instanzen wird kommentarlos verworfen. Keine Datenverfälschung (beide
+Instanzen liefern dieselbe Antwort), aber vermeidbar — und genau die Klasse Fehler, die eine
+neu eingeführte Nebenläufigkeit nicht unbeaufsichtigt mitliefern darf.
+
+Betroffen sind **beide** Vorschau-Pfade: Trip über `tz_for_coords()` →
+`preview_service.py:180`, Vergleich über `location_tz()` → `comparison_engine.py:155`. Die
+Funktion liegt also mitten im Vorschau-Pfad, nicht daneben.
+
+Reparatur — doppelt geprüfte Sperre, wortgleich zum Muster in
+`weather_cache.py:300-305` (kein neues Muster erfinden):
+
+```python
+from threading import Lock
+# ...
+_tf_instance = None
+_tf_lock = Lock()
+
+def _get_tf():
+    """Lazy singleton — TimezoneFinder loads ~12MB on first call.
+    Thread-safe (double-checked locking, Muster weather_cache.py:300-305)."""
+    global _tf_instance
+    if _tf_instance is None:
+        with _tf_lock:
+            if _tf_instance is None:
+                from timezonefinder import TimezoneFinder
+                _tf_instance = TimezoneFinder()
+    return _tf_instance
+```
+
+## Expected Behavior
+
+- **Input:** unverändert — dieselben Endpunkte, dieselben Query-/Body-Parameter wie heute.
+- **Output:** unverändert in Inhalt, Statuscode und Fehlerform (siehe AC-3). Verändert ist
+  ausschließlich, *wie* der Prozess während der Berechnung reagiert (Nebenläufigkeit).
+- **Side effects:** keine neuen fachlichen Seiteneffekte. Ä1 ändert nur die Ausführungsebene
+  (Threadpool statt Event-Loop), keine Logik. Ä3 ändert an der Rückgabe von `_get_tf()`
+  nichts — sie liefert weiterhin dieselbe (Prozess-weite) `TimezoneFinder`-Instanz, jetzt
+  aber garantiert nur eine statt gelegentlich zwei.
+
+## Abgrenzung zu Scheibe B
+
+Scheibe A entblockt nur den Prozess (Ä1) und sichert die dadurch neu entstehende
+Nebenläufigkeit ab (Ä3) — sie macht die Vorschau **nicht schnell genug**. Gemessen wurden
+25,1–25,6 s je Ort im Vergleich und 121 s kalt beim Trip. Nach Scheibe A reißt die
+Trip-Vorschau weiterhin die 30-s-Grenze des Go-Weiterleiters
+(`internal/handler/preview_proxy.go:81`) und der Vergleich bei 3 Orten weiterhin die
+60-s-Grenze von nginx — **das ist so beabsichtigt**, nicht ein offener Mangel dieser Scheibe.
+Die eigentliche Beschleunigung (U3, Parallelisierung der Orts-/Segmentschleife nach dem
+Vorbild `stage_weather.py:173`) ist Gegenstand einer eigenen, separaten Spec für Scheibe B
+und **nicht** Teil dieser Spezifikation.
+
+**Eine eigene, schlanke Abrufpolitik für die Trip-Vorschau (ursprünglich als „Ä2" für
+Scheibe A vorgesehen) gehört vollständig zu Scheibe B, nicht hierher.** Grund: Alle drei
+Codestellen, über die eine Trip-Vorschau tatsächlich Wetter abruft, wurden nachgemessen und
+nachgezählt (Kontextdokument, N1/N2, Fenster 12:57:49–12:59:50 UTC, störungsfrei):
+
+| Aufrufstelle | Segmente | Dauer (N1) | Wiederholversuche heute |
+|---|---|---|---|
+| `preview_service.py:173` (Hauptabruf, heutige Etappe) | 2 | 12,3 s / 12,1 s | bis zu 3, über `_fetch_weather` |
+| `preview_service.py:238` → `_build_stage_trend()` → `_fetch_weather` (`trip_report_scheduler.py:2254`), Ausblick +1/+2 Tage | 4 | 25,4 / 25,9 / 10,1 / 10,1 s | bis zu 3, über `_fetch_weather` |
+| `fetch_night_weather()` (`segment_weather.py:424`), Nachtwetter | 1 | 24,6 s | **keine** — direkter Aufruf, hatte nie eine Retry-Schleife |
+
+Mittel ~17,3 s, Summe 120,46 s von 121,14 s Gesamtzeit. Kostentreiber ist **nicht** der
+HTTP-Abruf (< 50 ms Antwortzeit), sondern die DWD-Gewitter-Anreicherung je Segment.
+
+Eine Vorschau-eigene Abrufpolitik, die nur die erste Zeile dieser Tabelle abdeckt (2 von 7
+Segmenten), träfe genau die **falschen** zwei — die vier Ausblicks-Segmente in Zeile 2 sind
+die langsamsten (25,4–25,9 s) und stellen den größten Teil der Gesamtzeit. Deshalb drei
+Festlegungen für Scheibe B statt eines Teil-Fixes in Scheibe A:
+
+- **(a) Scheibe B muss alle drei Aufrufstellen erfassen, sonst verfehlt sie ihr Ziel.** Eine
+  Nahtstelle, die 2 von 7 Abrufen abdeckt und ausgerechnet die vier langsamsten ausspart,
+  trägt weder die Beschleunigung noch die Retry-Straffung.
+- **(b) `_build_stage_trend()` ist geteilter Code zwischen Vorschau
+  (`preview_service.py:238`) und Versand (`trip_report_scheduler.py:1398`)** — sein interner
+  `_fetch_weather`-Aufruf verlangt dieselbe Vorsicht wie eine direkte Änderung an
+  `_fetch_weather` selbst (6 Produktiv-Aufrufer, 4 davon Versand/Alarme). Der Zuschnitt „außen"
+  (Parallelisierung/Retry-Straffung um den bestehenden Aufruf herum, ohne den geteilten
+  Funktionskörper zu verändern) ist entsprechend zu wählen — dasselbe Prinzip, das für
+  `ComparisonEngine.run()` bereits als Variante V3 „außen" gewählt wurde.
+- **(c) Die ~26-s-Schätzung unten gilt nur bei flacher Parallelisierung über alle sieben
+  Abrufe.** Bleiben die vier Ausblicks-Segmente seriell, landet die Trip-Vorschau weiterhin
+  bei über 100 s — die Beschleunigung fiele aus, unabhängig davon, was mit den übrigen drei
+  Abrufen passiert. Der Ausblickspfad ist damit keine Restarbeit, die man später nachreicht,
+  sondern eine **harte Voraussetzung** von Scheibe B.
+
+**Vertrags-Detail für Scheibe B, aus der Analyse dieser Spec übernommen:** Welche
+Umgestaltung Scheibe B auch wählt — ein gescheitertes Segment muss weiterhin ein
+`SegmentWeatherData`-Objekt mit `has_error=True` an seiner Position liefern
+(`trip_report_scheduler.py:2018-2026`), **nicht** ausgelassen werden. Sonst ändert sich die
+Länge/Form der Rückgabeliste gegenüber heute, und nachgelagerte Verarbeitung (Renderer,
+Fehlerbehandlung) bricht.
+
+- **Die Sorge „Parallelisierung allein reicht nicht" ist widerlegt** — unter Annahme (c).
+  Parallelisiert läge die Gesamtzeit bei etwa dem **langsamsten Einzelsegment**, also
+  **~26 s** — unter der 30-s-Grenze des Go-Weiterleiters.
+- **Aber die Reserve ist dünn** (~26 von 30 s, rund **87 %** des Budgets). Deshalb wird die
+  Timeout-Leiter in Scheibe B **doch** nachgezogen — nicht um einen Fehler zu verstecken,
+  sondern als Sicherheitsabstand, **nachdem** die Beschleunigung greift und die neue Laufzeit
+  bekannt ist. Reihenfolge: erst schneller, dann Luft schaffen. In **Scheibe A** bleibt die
+  Leiter unangetastet — sie jetzt anzuheben, während die Trip-Vorschau kalt noch 121 s
+  braucht, ließe den Nutzer **länger auf denselben Fehler** warten, messbar schlechter statt
+  besser.
+
+**U4 (fehlender Grundvorhersage-Cache im Vergleichspfad)** bleibt außen vor. Das ist eine
+dokumentierte, bewusste Zurückstellung aus
+`docs/specs/modules/fix_1329_forecast_cache_budget.md:399-407`, keine neue Entscheidung
+dieses Workflows.
+
+## Acceptance Criteria
+
+- **AC-1 (Kernzusicherung — der Dienst bleibt während einer Vorschau erreichbar):** Given eine
+  Vorschau (Trip- oder Vergleichs-) wird gerade im Python-Core berechnet / When während dieser
+  laufenden Berechnung `/api/health` aufgerufen wird / Then antwortet `/api/health`
+  durchgehend innerhalb von 2 Sekunden mit Erfolg — nicht erst nach Abschluss der Vorschau.
+  Heute gemessen: 74,5 von 75,8 Sekunden lang stumm (25 Timeouts in Folge).
+  - Test: Kern-Test mit einer künstlich langsamen Vorschau-Stub-Funktion; `/health` wird
+    nebenläufig aus einem zweiten Thread abgefragt, während die Vorschau läuft.
+
+- **AC-2 (Vollständigkeit der Klasse — kein blockierender Handler bleibt übrig):** Given die
+  vollständig gebaute FastAPI-Anwendung mit allen registrierten Routen / When jede Route
+  darauf geprüft wird, ob ihr Handler eine Koroutine ist (`inspect.iscoroutinefunction`) /
+  Then ist **kein** Route-Handler mehr eine Koroutine, mit genau einer Ausnahme: der
+  GPX-Upload-Handler, der weiterhin echtes `await` nutzt und deshalb `async def` bleiben darf.
+  - Test: Kern-Test iteriert `app.routes` und prüft die Eigenschaft an der laufenden
+    Anwendung, nicht am Quelltext — sonst würde nur die Schreibweise geprüft, nicht die
+    Wirkung.
+
+- **AC-3 (keine Verhaltensänderung der Vorschau-Inhalte):** Given dieselbe Anfrage an einen der
+  13 umgestellten Endpunkte mit denselben Eingaben und denselben Fixture-Daten wie vor der
+  Umstellung / When die Anfrage nach der Umstellung erneut gestellt wird / Then sind
+  Statuscode und Antwortkörper identisch — sowohl im Erfolgsfall als auch in den
+  Fehlerfällen 404 (nicht gefunden), 422 (ungültige Eingabe) und 503 (Wetterdaten nicht
+  verfügbar).
+  - Test: Bestehende Regressionssuite `tests/tdd/test_epic_140_preview_endpoints.py` (und
+    verwandte Preview-Tests) bleibt vollständig grün, ergänzt um einen Fehlerfall-Test je
+    Statuscode, falls die Bestandssuite eine der drei Fehlerformen noch nicht abdeckt.
+
+- **AC-4 (Zeitzonen-Datenbank wird bei gleichzeitigem Zugriff nur einmal geladen):** Given
+  zwei Threads rufen gleichzeitig zum allerersten Mal eine Funktion auf, die eine Zeitzone zu
+  Koordinaten auflöst (`tz_for_coords()` bzw. `location_tz()`) / When beide Aufrufe exakt
+  gleichzeitig auf den noch leeren Zustand treffen / Then wird die zugrunde liegende
+  Zeitzonen-Datenbank (`TimezoneFinder`) **genau einmal** aufgebaut, und beide Threads
+  erhalten dieselbe Instanz zurück.
+  - Test: Kern-Test mit zwei Threads und einer Barriere, die beide Threads erst gleichzeitig
+    auf `_tf_instance is None` treffen lässt (deterministisch, kein Zufalls-Timing); ein
+    Zähler auf der `TimezoneFinder`-Konstruktion muss danach exakt `1` sein. Ein Test, der
+    nur prüft, dass irgendeine Sperre *existiert*, zählt nicht — geprüft wird die Wirkung
+    (Aufrufzähler), nicht die Anwesenheit von `Lock()` im Quelltext.
+
+## Testplan
+
+**Schicht:** ausschließlich Kern (deterministisch, kein Netz, keine Live-Dienste,
+kein Staging-Zugriff) — passend zur Test-Politik dieses Repos. Mock-Theater
+(`Mock()`/`patch()`/`MagicMock`, die nur die eigene Annahme zurückspiegeln) und
+Dateiinhalt-Prüfungen (`assert "def " in datei.read_text()`) als Verhaltensnachweis sind
+verboten. Ein Test, der nur die Funktionssignatur im Quelltext prüft, ist wertlos — geprüft
+werden muss an der Stelle, an der die Zusicherung **wirkt**: der laufende Server-Thread
+(AC-1, AC-2) bzw. die tatsächliche Aufrufzahl der `TimezoneFinder`-Konstruktion (AC-4), nicht
+die Schreibweise im Quelltext.
+
+**Bauplan für AC-1 (bereits prototypisch nachgewiesen, netzfrei, ~7 s Laufzeit):** zwei
+identische Mini-Apps, uvicorn je in einem eigenen Thread gestartet — eine mit `async def` +
+blockierender Arbeit (heutiger Zustand, Kontrollgruppe), eine mit `def` + identischer
+blockierender Arbeit (Zielzustand). Während die blockierende Arbeit läuft, wird `/health`
+gepollt. Gemessen im Prototyp: `async def` → Timeout nach 2,02 s; `def` → HTTP 200 nach
+0,03 s. Dieser Aufbau ist der Bauplan für den RED-Test.
+
+**Alternative, plausibel aber NICHT verifiziert:** eine gemeinsame `FastAPI()`-Instanz mit
+**einem** `TestClient`, bei der der Vorschau-Dienst per Monkeypatch auf einen künstlich
+langsamen Stub zeigt und `/health` aus einem zweiten Thread nebenläufig abgefragt wird,
+während der erste Thread die langsame Vorschau anstößt. Diese Variante ist eleganter (eine
+App statt zwei), aber **ungeprüft** — sie wird hier als Option genannt, nicht als Vorgabe.
+
+**Falle, die im TDD-RED-Schritt explizit auszuschließen ist:** Werden **zwei** getrennte
+`TestClient`-Instanzen verwendet (eine für die Vorschau, eine für `/health`), bekommt jede
+ihren eigenen Event-Loop — die langsame Anfrage liefe dann isoliert vom `/health`-Aufruf, und
+der Test würde **still immer grün** sein, unabhängig davon, ob `async def` oder `def`
+verwendet wird. Das ist keine Randnotiz, sondern der Punkt, an dem der Test im RED-Schritt
+beweisen muss, dass er beim heutigen `async def`-Zustand tatsächlich rot wird.
+
+**Mutations-Gegenprobe (PFLICHT):** Mindestens diese zwei gezielten Verfälschungen müssen
+je mindestens einen Test rot machen:
+
+1. Ein Handler (z. B. `preview_email`) wird versuchsweise wieder zu `async def` gemacht →
+   AC-1- und/oder AC-2-Test muss rot werden.
+2. Die Sperre in `_get_tf()` wird versuchsweise wieder entfernt (Rückbau auf den
+   unverriegelten Lazy-Singleton von oben) → AC-4-Test muss rot werden (Konstruktions-Zähler
+   > 1 bei den beiden gleichzeitigen Aufrufen).
+
+Mutationen ausschließlich per String-Ersetzung mit externer Sicherungskopie, nie per
+`git checkout`/`stash`/`reset`.
+
+## Known Limitations
+
+- **Die Trip-Vorschau erbt weiterhin die volle Wiederhol-Politik des Versandpfads
+  (bis zu 3 Versuche mit `time.sleep`-Backoff je Segment über `_fetch_weather`).** Das ist
+  in dieser Scheibe unverändert und ausdrücklich **kein** Nebenbefund, sondern der harte
+  Kern von Scheibe B — siehe „Abgrenzung zu Scheibe B" für die vollständige
+  Aufrufstellen-Tabelle und die Begründung, warum eine Teillösung hier keinen Sinn ergäbe.
+- **Die Timeout-Leiter (R6) bleibt widersprüchlich** (Vergleichs-Vorschau Go 60 s == nginx
+  60 s ohne Puffer; Trip-Vorschau Go 30 s, obwohl nginx 60 s zuließe). Nachziehen ist
+  Scheibe B vorbehalten, nachdem die dort gemessene neue Laufzeit vorliegt.
+- **Der Starlette-Threadpool ist nirgends konfiguriert** (anyio-Default 40 Threads). Siehe
+  „Risiken".
+- **Zwei weitere ungeschützte Lazy-Singletons bleiben bewusst unangetastet:**
+  `api/routers/webhook.py:57` (`telegram_webhook`) und `api/routers/scheduler.py:174`
+  (`trigger_inbound_telegram`) haben dieselbe Bauform wie das reparierte `_get_tf()` — ohne
+  Sperre —, sind aber bereits **heute** `def`-Handler und damit schon vor Scheibe A
+  nebenläufig erreichbar. Ä1 verursacht dieses Bestandsrisiko nicht und vergrößert es nicht;
+  eine Reparatur ist ein eigenständiger Nebenbefund (→ #1199), kein Teil dieser Scheibe.
+- **Die `_warned_missing_key`-Merker** in `src/services/official_alerts/vigilance.py:63`,
+  `meteoalarm.py:496` und `meteo_forets.py:63` bleiben ebenfalls unangetastet — ungeschützt,
+  aber folgenlos: schlimmstenfalls wird eine Warnung im Log doppelt statt einmal geschrieben,
+  kein Datenverlust, keine falsche Nutzer-Ausgabe.
+
+## Risiken
+
+- **Die eigentliche Wirkung von Scheibe A ist eine Zustandsänderung des Systems, nicht nur
+  eine Reparatur.** Vorher: „ein Aufruf legt alles lahm, dafür läuft nie etwas gleichzeitig".
+  Nachher: „vieles läuft gleichzeitig". Der Tausch ist eindeutig richtig — die heutige
+  Blockade ist der gemeldete, nutzersichtbare Fehler —, aber er verschiebt die Fehlerklasse
+  von **Blockade** zu **Nebenläufigkeit**. Die Tabelle unter „Nebenwirkung von Ä1" oben ist
+  der Beleg, dass diese Verschiebung vor Festlegung des Umfangs systematisch geprüft wurde
+  (alle `global`-Anweisungen in `src/` und `api/`) und außer `_get_tf()` (→ Ä3) nichts
+  Offenes zurückließ, das durch Ä1 neu erreichbar würde.
+- **Threadpool-Erschöpfung bei mehr als 40 gleichzeitigen langsamen Vorschauen.** Der
+  anyio-Threadpool-Default liegt bei 40 Threads; eine 41. gleichzeitige langsame Vorschau
+  würde warten müssen, bis ein Thread frei wird. Das ist gegenüber dem **heutigen** Zustand
+  trotzdem eine klare Verbesserung: heute blockiert bereits **eine einzige** laufende
+  Vorschau den gesamten Prozess inklusive `/health`; nach Ä1 blockiert eine einzelne
+  Vorschau nur noch ihren eigenen Thread. Eine explizite Threadpool-Konfiguration ist nicht
+  Teil dieser Scheibe — bei nachgewiesener Erschöpfung (Monitoring, `/health` wird trotz Ä1
+  wieder langsam) ist das ein Folge-Nebenbefund für #1199, kein Grund, Scheibe A
+  zurückzuhalten.
+- **`call_log.resolve_call_source()` (R1 aus dem Kontextdokument) betrifft diese Scheibe
+  NICHT.** Ä1 verlagert Handler in den Threadpool, aber jeder Request läuft weiterhin in
+  genau einem Thread ohne parallele Unter-Tasks — anders als die künftige Scheibe-B-
+  Parallelisierung, die mehrere Orte/Segmente gleichzeitig in verschiedenen Threads
+  abarbeitet. Die Diagnose-Zuordnung über `inspect.stack()` bleibt in Scheibe A unverändert
+  intakt.
+
+## Verifikation auf Staging
+
+Nach dem Deploy wird derselbe Messaufbau wie M1 im Kontextdokument wiederholt: eine
+Trip- oder Vergleichs-Vorschau anstoßen und währenddessen `/api/health` **sekündlich** mit
+einer 2-Sekunden-Grenze pollen. Vor der Änderung: 25 Timeouts in Folge (74,5 von 75,8 s
+stumm). **Erwartung nach der Änderung: durchgehend HTTP 200**, kein einziger Timeout während
+der laufenden Vorschau.
+
+**Zwei getrennte Störquellen vor jeder Messung prüfen** (der zunächst vermutete
+78,64-s-Ausreißer bei warmem Cache ist inzwischen **belegt erklärt**, nicht mehr nur
+vermutet — `journalctl` zeigt einen PID-Wechsel von `gregor-python-staging.service` um
+13:00:22 UTC, also einen Auto-Deploy-Neustart genau in diesem Fenster):
+
+- **Ein Staging-Neustart leert den prozessweiten Cache.** Nach jedem Auto-Deploy (Cron
+  `*/5`) ist der erste Aufruf wieder kalt, unabhängig von einer vorherigen warmen Messung —
+  das war die tatsächliche Ursache des 78,64-s-Ausreißers, nicht Fremdlast.
+- **Parallele Fremdnutzung besteht davon unabhängig.** Staging wird parallel von anderen
+  Sitzungen genutzt, und der Python-Core läuft als Single-Worker-Prozess — ein fremder
+  Vorschau-Aufruf einer anderen Sitzung verfälscht jede Zeitmessung zusätzlich nach oben.
+
+Vor jeder Wiederholungsmessung deshalb **beides** prüfen: den Zeitpunkt des letzten
+Staging-Deploys (z. B. `systemctl status gregor-python-staging` bzw. `journalctl`) und
+Fremdlast (z. B. über `/api/scheduler/status` oder Rücksprache mit anderen aktiven
+Sitzungen), bevor ein Ergebnis als Befund gewertet wird.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine.
+- **Rationale:** Diese Änderung stellt einen bereits vorherrschenden Hausstil her, sie
+  eröffnet keine neue architektonische Weiche. Vor der Änderung sind 22 der 36 Route-Handler
+  im `api/`-Baum bereits `def` (laufen im Threadpool), 14 sind `async def` — die 13
+  `await`-losen `async def`-Handler sind die Abweichung, nicht die Mehrheit. Es existiert
+  auch kein bestehendes ADR zu Nebenläufigkeit/Prozessmodell des Python-Core, das dieser
+  Fix umgehen oder ablösen würde (geprüft: `docs/adr/README.md`, keine Treffer für
+  „async"/„Threadpool"/„Event-Loop"). Die Änderung berührt keine der in CLAUDE.md genannten
+  Entscheidungsflächen (Kanäle, Provider, Datenmodell/Persistenz, Auth, Editor-Paradigma,
+  Test-/Deploy-Strategie). Vorbild für diese Begründungsform: `stage_weather_python_endpoint.md:126-129`.
+  Ä3 wirft dieselbe Frage nicht neu auf: die doppelt geprüfte Sperre ist im Repo bereits
+  dreifach etabliertes Muster (`weather_cache.py`, `thunder_window_cache.py`,
+  `radar_cache.py`) — Ä3 wendet es auf einen vierten Fall an, führt kein neues Muster ein.
+
+## Changelog
+
+- 2026-08-15: Initial spec created (Scheibe A von #1765 + #1839; Wurzel #1539 bleibt offen
+  und wird nicht vorweggenommen)
+- 2026-08-15: Nachtrag — Ä3 (`_get_tf()` in `src/utils/timezone.py` gegen gleichzeitige
+  Erstinitialisierung absichern) und AC-5 ergänzt. Grund: Ä1 macht die 13 Handler erstmals
+  wirklich nebenläufig (vorher waren sie durch den blockierten Event-Loop unfreiwillig
+  serialisiert) — eine systematische Durchsicht aller `global`-Anweisungen in `src/`/`api/`
+  fand genau eine ungeschützte Stelle im Vorschau-Pfad (`_get_tf()`); alle anderen sind
+  bereits abgesichert oder liegen außerhalb dieser Scheibe (siehe „Known Limitations").
+- 2026-08-15: Nachtrag — Befund beim Abgleich mit der aktualisierten N1/N2-Nachmessung im
+  Kontextdokument: Ä2 (in ihrer engen Fassung, nur `preview_service.py:173`) deckt nur 2 der
+  7 Segment-Abrufe einer typischen Trip-Vorschau ab; die 4 Mehrtages-Ausblick-Segmente laufen
+  weiterhin über einen unveränderten, geteilten `_fetch_weather`-Aufruf in
+  `_build_stage_trend()` (`trip_report_scheduler.py:2254`). AC-3 entsprechend präzisiert
+  (Geltungsbereich benannt statt pauschal „die Trip-Vorschau"), Befund als eigener Punkt in
+  „Known Limitations" aufgenommen statt stillschweigend mitgezogen.
+- 2026-08-15: Korrektur — Ä2-Begründung war unbelegt und teils falsch: N2 misst 0
+  Wiederholversuche im störungsfreien Normalbetrieb (121 s echte Arbeit), Ä2 ist damit für
+  die heutige Latenz **wirkungslos**, nicht latenzverbessernd. Begründung in Purpose und
+  Ä2-Implementierungsdetails auf die tatsächliche, dreiteilige Reihenfolge umgestellt
+  (gemessen wirkungslos → strukturelle Nahtstelle für Scheibe B → bedingter
+  Robustheitsgewinn bei Störung). „Abgrenzung zu Scheibe B" um die N1-Segmentstruktur
+  (7 Abrufe, ~26 s parallelisiert, 87 % Budgetauslastung, offene Designfrage zu den drei
+  Abrufschritten) ergänzt. „Verifikation auf Staging" korrigiert: der 78,64-s-Ausreißer ist
+  durch einen Staging-Auto-Deploy-Neustart (PID-Wechsel 13:00:22 UTC, `journalctl`-belegt)
+  erklärt, nicht durch Fremdlast allein — beide Störquellen jetzt getrennt benannt. AC-3
+  inhaltlich unverändert (Aufrufzahl 1 vs. 3 bleibt die geprüfte Zusicherung).
+- 2026-08-15: Entscheidung — Ä2 vollständig aus Scheibe A entfernt und nach Scheibe B
+  verschoben (nicht nur eng belassen). Grund: Ä2 hatte nur noch die Nahtstellen-Begründung
+  für Scheibe B als tragende Rechtfertigung, deckte davon aber nur 2 der 7 tatsächlichen
+  Segment-Abrufe ab und ausgerechnet nicht die vier langsamsten (Ausblick +1/+2 Tage,
+  25,4–25,9 s) — die ~26-s-Schätzung für Scheibe B setzt flache Parallelisierung über alle
+  sieben Abrufe voraus, der Ausblickspfad ist also harte Voraussetzung, keine Restarbeit.
+  Scheibe A besteht jetzt aus genau Ä1 + Ä3 (~15 statt ~35–50 LoC, 5 statt 6
+  Produktivdateien). Entfernt: AC-3 (Retry-Zusicherung), die Ä2-Implementierungssektion, die
+  Ä2-Zeilen in Dependencies/Source/Estimated Scope, der Ä2-Known-Limitations-Punkt samt
+  Folge-Ticket-Vorschlag (die Lücke ist Kern von Scheibe B, kein Nebenbefund). AC-4 → AC-3,
+  AC-5 → AC-4 umnummeriert, Mutations-Gegenprobe auf zwei Punkte reduziert. „Abgrenzung zu
+  Scheibe B" trägt jetzt die vollständige Drei-Aufrufstellen-Tabelle mit Dauer und
+  Retry-Status sowie die drei Festlegungen (a)/(b)/(c) für den Zuschnitt von Scheibe B; die
+  `SegmentWeatherData`-Vertragsüberlegung (has_error statt Auslassen) ist dorthin
+  übernommen, damit sie nicht verloren geht.

--- a/src/utils/timezone.py
+++ b/src/utils/timezone.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
+from threading import Lock
 from typing import Iterable, Optional
 from zoneinfo import ZoneInfo
 
@@ -18,14 +19,18 @@ logger = logging.getLogger(__name__)
 UTC = ZoneInfo("UTC")
 
 _tf_instance = None
+_tf_lock = Lock()
 
 
 def _get_tf():
-    """Lazy singleton — TimezoneFinder loads ~12MB on first call."""
+    """Lazy singleton — TimezoneFinder loads ~12MB on first call.
+    Thread-safe (double-checked locking, Muster weather_cache.py:300-305)."""
     global _tf_instance
     if _tf_instance is None:
-        from timezonefinder import TimezoneFinder
-        _tf_instance = TimezoneFinder()
+        with _tf_lock:
+            if _tf_instance is None:
+                from timezonefinder import TimezoneFinder
+                _tf_instance = TimezoneFinder()
     return _tf_instance
 
 

--- a/tests/unit/test_event_loop_bleibt_frei.py
+++ b/tests/unit/test_event_loop_bleibt_frei.py
@@ -1,0 +1,312 @@
+"""AC-1 (#1765/#1839 Scheibe A): Der Python-Core bleibt waehrend einer laufenden
+Vorschau erreichbar.
+
+Spec: docs/specs/modules/fix_1765_1839_sa_vorschau_entblockung.md
+Kontext/Messung: docs/context/fix-1765-1839-vorschau-laufzeit.md (M1)
+
+Heute deklariert ``api/routers/preview.py`` seine Handler ``async def``, ohne ein
+einziges ``await`` zu enthalten. Starlette fuehrt solche Handler DIREKT im
+Event-Loop-Thread aus (statt im Threadpool) — waehrend der synchronen
+Wetterabrufe ist der gesamte Prozess taub. Auf Staging gemessen: ``/api/health``
+war 74,5 von 75,8 Sekunden nicht binnen 2 s erreichbar (25 Timeouts in Folge),
+der Go-Health-Handler meldete ``python_core: unavailable`` — das hat am
+2026-08-12 einen unnoetigen Neustart von ``gregor-python-staging`` ausgeloest.
+
+**Aufbau: echter uvicorn-Server in einem eigenen Thread, gebaut aus den ECHTEN
+Routern** (``api.routers.preview`` + ``api.routers.health``), abgefragt ueber
+echte HTTP-Verbindungen gegen ``127.0.0.1``.
+
+Warum NICHT ``TestClient``: Zwei getrennte ``TestClient``-Instanzen haetten je
+einen eigenen Event-Loop — die langsame Anfrage liefe isoliert und der Test
+waere STILL IMMER GRUEN, unabhaengig davon, ob der Handler ``async def`` oder
+``def`` ist. Genau diese Falle benennt die Spec im Testplan. Ein echter Server
+hat genau einen Loop, wie im Betrieb (uvicorn ohne ``--workers``).
+
+Ersetzt wird nur der **Vorschau-Dienst** (die teure, fremde Arbeit) durch einen
+kuenstlich langsamen Stub — der Handler selbst, seine Registrierung und der
+Server-Lauf sind die echten. Geprueft wird die Wirkung (antwortet ``/health``
+waehrend der Blockade?), nicht die Schreibweise im Quelltext.
+
+Netzfrei: alle Verbindungen gehen an ``127.0.0.1`` (vom Egress-Waechter
+ausdruecklich erlaubt), es wird kein Wetterdienst aufgerufen.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from contextlib import contextmanager
+
+import httpx
+import pytest
+import uvicorn
+from fastapi import FastAPI
+
+#: So lange haelt der Vorschau-Stub den Handler fest. Muss deutlich ueber der
+#: Health-Grenze liegen, damit die Health-Abfrage garantiert INNERHALB der
+#: Blockade stattfindet (wird zusaetzlich per Event nachgeprueft).
+BLOCK_SEKUNDEN = 5.0
+
+#: Dieselbe Grenze, die der Go-Health-Handler setzt
+#: (``internal/handler/proxy.go:19``) — darueber gilt Python als "unavailable".
+HEALTH_GRENZE_SEKUNDEN = 2.0
+
+
+def _freier_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@contextmanager
+def _laufender_server(app: FastAPI):
+    """Startet ``app`` in einem echten uvicorn-Server in einem eigenen Thread.
+
+    Ein Prozess, EIN Event-Loop — genau wie im Betrieb (uvicorn ohne
+    ``--workers``). Das ist der Punkt: ein zweiter Loop wuerde die Blockade
+    unsichtbar machen.
+    """
+    port = _freier_port()
+    server = uvicorn.Server(
+        uvicorn.Config(
+            app, host="127.0.0.1", port=port, log_level="error", lifespan="off",
+        )
+    )
+    thread = threading.Thread(target=server.run, name="uvicorn-core", daemon=True)
+    thread.start()
+
+    basis = f"http://127.0.0.1:{port}"
+    frist = time.monotonic() + 15
+    while time.monotonic() < frist:
+        try:
+            if httpx.get(f"{basis}/health", timeout=1.0).status_code == 200:
+                break
+        except httpx.HTTPError:
+            time.sleep(0.05)
+    else:
+        server.should_exit = True
+        pytest.fail("uvicorn-Testserver ist nicht innerhalb von 15 s hochgekommen")
+
+    try:
+        yield basis
+    finally:
+        server.should_exit = True
+        thread.join(timeout=15)
+
+
+@pytest.fixture
+def laufender_core():
+    """Echter Server mit den echten Health- und Vorschau-Routern."""
+    from api.routers import health, preview
+
+    app = FastAPI()
+    app.include_router(health.router)
+    app.include_router(preview.router)
+    with _laufender_server(app) as basis:
+        yield basis
+
+
+def _health_dauer(basis: str) -> float | None:
+    """Sekunden bis zur ``/health``-Antwort, oder ``None`` bei Zeitueberschreitung."""
+    beginn = time.monotonic()
+    try:
+        antwort = httpx.get(f"{basis}/health", timeout=HEALTH_GRENZE_SEKUNDEN)
+    except httpx.TimeoutException:
+        return None
+    assert antwort.status_code == 200, (
+        f"/health lieferte {antwort.status_code} statt 200: {antwort.text[:200]}"
+    )
+    return time.monotonic() - beginn
+
+
+class _LangsameVorschau:
+    """Steht fuer die echte, langsame Wetterarbeit (gemessen 25–121 s).
+
+    Kein Mock-Theater: Der Stub spiegelt keine Erwartung zurueck, er ersetzt
+    nur die Dauer. Die Zusicherung wird am Handler und am Server gemessen.
+    """
+
+    def __init__(self, gestartet: threading.Event) -> None:
+        self._gestartet = gestartet
+
+    def _blockieren(self):
+        self._gestartet.set()
+        time.sleep(BLOCK_SEKUNDEN)
+
+    def render_email_preview(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        self._blockieren()
+        return "<html>fertig</html>"
+
+    def render_all_channels(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        self._blockieren()
+        return {"subject": "s", "email_html": "<html/>", "telegram": "t",
+                "sms": "x", "sms_char_count": 1}
+
+
+@pytest.mark.parametrize(
+    "pfad, methode, ersetztes_attribut",
+    [
+        pytest.param(
+            "/api/preview/beliebig/email", "GET", "_build_service",
+            id="trip-vorschau",
+        ),
+        pytest.param(
+            "/api/preview/compare/preset-x", "POST", "ComparePreviewService",
+            id="vergleichs-vorschau",
+        ),
+    ],
+)
+def test_health_antwortet_waehrend_laufender_vorschau(
+    laufender_core, monkeypatch, pfad, methode, ersetztes_attribut,
+):
+    """AC-1: Waehrend eine Vorschau berechnet wird, antwortet ``/health``
+    binnen 2 s — nicht erst nach Abschluss der Vorschau.
+
+    ``/health`` ist der Python-Endpunkt, den der Go-Weiterleiter fuer
+    ``/api/health`` mit 2 s Frist abfragt (``internal/handler/proxy.go:19``).
+    """
+    from api.routers import preview
+
+    blockade_laeuft = threading.Event()
+    vorschau_fertig = threading.Event()
+    langsam = _LangsameVorschau(blockade_laeuft)
+    monkeypatch.setattr(
+        preview, ersetztes_attribut, lambda *a, **kw: langsam, raising=True,
+    )
+
+    ziel = f"{laufender_core}{pfad}"
+
+    def vorschau_anstossen():
+        try:
+            httpx.request(
+                methode, ziel, params={"user_id": "default"},
+                timeout=BLOCK_SEKUNDEN + 20,
+            )
+        except httpx.HTTPError:
+            pass
+        finally:
+            vorschau_fertig.set()
+
+    anfrage = threading.Thread(target=vorschau_anstossen, name="vorschau", daemon=True)
+    anfrage.start()
+    assert blockade_laeuft.wait(timeout=15), (
+        "Der Vorschau-Stub wurde nie erreicht — der Testaufbau misst nichts. "
+        f"Ziel war {methode} {ziel}."
+    )
+
+    dauer = _health_dauer(laufender_core)
+    noch_am_rechnen = not vorschau_fertig.is_set()
+    anfrage.join(timeout=BLOCK_SEKUNDEN + 25)
+
+    if dauer is None:
+        pytest.fail(
+            f"/health hat waehrend der laufenden Vorschau ({methode} {pfad}) "
+            f"nicht innerhalb von {HEALTH_GRENZE_SEKUNDEN} s geantwortet. Der "
+            "Vorschau-Handler ist 'async def' ohne 'await' und laeuft damit im "
+            "Event-Loop-Thread statt im Threadpool — der gesamte Python-Core ist "
+            "waehrend der Vorschau taub (Go meldet 'python_core: unavailable', "
+            "Staging-Messung M1: 74,5 von 75,8 s stumm). Abhilfe: 'async def' → "
+            "'def' (AC-1, Spec fix_1765_1839_sa_vorschau_entblockung.md)."
+        )
+
+    assert noch_am_rechnen, (
+        "Die Vorschau war bereits fertig, als /health antwortete — der Test "
+        "haette dann nichts ueber den blockierten Zustand ausgesagt. "
+        f"BLOCK_SEKUNDEN={BLOCK_SEKUNDEN} zu klein?"
+    )
+    assert dauer < HEALTH_GRENZE_SEKUNDEN, (
+        f"/health brauchte {dauer:.2f} s (Grenze {HEALTH_GRENZE_SEKUNDEN} s)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Kontrollgruppe — ABSICHTLICH schon in der RED-Phase gruen.
+#
+# Kein fehlgeschlagener RED-Test und kein Ersatz fuer den Test oben: Sie belegt,
+# dass der Messaufbau ueberhaupt zwischen beiden Zustaenden UNTERSCHEIDET. Ohne
+# sie waere ein still immer roter Aufbau (falscher Port, Server tot, Server zu
+# klein dimensioniert) von einem echten Befund nicht zu trennen — und nach der
+# Umstellung waere nicht belegt, dass 'def' die Ursache war und nicht ein
+# Zufall. Sie ist der im Spec-Testplan als verifiziert benannte Bauplan,
+# hier mit BEIDEN Armen im selben Lauf.
+# ---------------------------------------------------------------------------
+
+
+def _blockierender_router(gestartet: threading.Event, koroutine: bool):
+    from fastapi import APIRouter
+
+    router = APIRouter()
+
+    def arbeiten():
+        gestartet.set()
+        time.sleep(BLOCK_SEKUNDEN)
+        return {"ok": True}
+
+    if koroutine:
+        async def blockieren():  # kein 'await' — heutiger Zustand der 13 Handler
+            return arbeiten()
+    else:
+        def blockieren():
+            return arbeiten()
+
+    router.add_api_route("/blockieren", blockieren, methods=["GET"])
+    return router
+
+
+@pytest.mark.parametrize(
+    "koroutine, erwartet_stumm",
+    [
+        pytest.param(True, True, id="async-def-ohne-await-blockiert"),
+        pytest.param(False, False, id="def-blockiert-nicht"),
+    ],
+)
+def test_kontrollgruppe_der_messaufbau_unterscheidet_beide_zustaende(
+    koroutine, erwartet_stumm,
+):
+    """Identische blockierende Arbeit, einziger Unterschied: ``async def`` vs ``def``.
+
+    Erwartung (im Prototyp gemessen, Kontextdokument): ``async def`` → Timeout
+    nach ~2,02 s; ``def`` → HTTP 200 nach ~0,03 s.
+    """
+    from api.routers import health
+
+    gestartet = threading.Event()
+    app = FastAPI()
+    app.include_router(health.router)
+    app.include_router(_blockierender_router(gestartet, koroutine))
+
+    with _laufender_server(app) as basis:
+        fertig = threading.Event()
+
+        def anstossen():
+            try:
+                httpx.get(f"{basis}/blockieren", timeout=BLOCK_SEKUNDEN + 20)
+            except httpx.HTTPError:
+                pass
+            finally:
+                fertig.set()
+
+        anfrage = threading.Thread(target=anstossen, daemon=True)
+        anfrage.start()
+        assert gestartet.wait(timeout=15), "Blockierender Handler nie erreicht"
+
+        dauer = _health_dauer(basis)
+        noch_am_rechnen = not fertig.is_set()
+        anfrage.join(timeout=BLOCK_SEKUNDEN + 25)
+
+    assert noch_am_rechnen, "Arbeit war schon fertig — Messfenster verfehlt"
+    if erwartet_stumm:
+        assert dauer is None, (
+            f"/health antwortete nach {dauer:.2f} s, obwohl ein 'async def'-Handler "
+            "ohne 'await' den Event-Loop blockieren MUSS. Der Messaufbau kann "
+            "die Blockade nicht sehen — jedes gruene Ergebnis des Tests oben "
+            "waere damit wertlos."
+        )
+    else:
+        assert dauer is not None, (
+            "/health war stumm, obwohl der blockierende Handler ein 'def' ist und "
+            "damit im Threadpool laufen muss. Entweder ist der Messaufbau kaputt "
+            "oder Starlette verteilt 'def'-Handler nicht mehr in den Threadpool."
+        )
+        assert dauer < HEALTH_GRENZE_SEKUNDEN

--- a/tests/unit/test_preview_fehlerformen.py
+++ b/tests/unit/test_preview_fehlerformen.py
@@ -1,0 +1,155 @@
+"""AC-3 (#1765/#1839 Scheibe A): Die Fehlerformen der Vorschau-Endpunkte bleiben
+unveraendert.
+
+Spec: docs/specs/modules/fix_1765_1839_sa_vorschau_entblockung.md
+
+🔴 **Diese Datei ist ABSICHTLICH schon in der RED-Phase gruen** — sie ist kein
+fehlgeschlagener RED-Test und darf spaeter nicht dafuer gehalten werden. Ae1
+stellt 13 Handler von ``async def`` auf ``def`` um; das aendert nur die
+Ausfuehrungsebene (Threadpool statt Event-Loop), nicht die Logik. Diese Tests
+zementieren das Bestandsverhalten VOR der Umstellung, damit ein stiller
+Verhaltensbruch bei der Umstellung auffliegt.
+
+**Was die Bestandssuite schon abdeckt** (geprueft in
+``tests/tdd/test_epic_140_preview_endpoints.py`` und
+``tests/tdd/test_issue_363_signal_telegram_preview.py``):
+
+- **404** unbekannter Trip: abgedeckt fuer ``email``, ``sms``, ``telegram``.
+- **422** ungueltiger ``type``: abgedeckt fuer ``email`` (als ``400|422``),
+  ``telegram`` und ``signal``.
+- **503**: NICHT abgedeckt. Der Statuscode kommt dort ausschliesslich als
+  *geduldete* Alternative vor (``assert status_code in (200, 503)``, teils mit
+  ``pytest.skip``) — kein einziger Test erzwingt ihn oder prueft die
+  Zuordnung ``RuntimeError`` → 503.
+- **``POST /api/preview/compare/{preset_id}``**: gar keine Fehlerform-Tests
+  (kein Testtreffer auf den Pfad im gesamten Testbaum).
+
+Ergaenzt werden deshalb genau diese Luecken: 503 fuer die drei Trip-Kanaele und
+404/422/503 fuer den Vergleichs-Endpunkt.
+
+Der 503-Fall braucht eine gesteuerte Stoerung — ein echter Wetterdienst-Ausfall
+laesst sich offline nicht deterministisch herstellen. Der Ersatz wirft die
+Ausnahme, die der echte Dienst wirft; geprueft wird die Zuordnung im Router
+(``except RuntimeError`` → HTTP 503), also echter Produktivcode.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+class _StoerenderDienst:
+    """Steht fuer "Wetterdaten nicht verfuegbar" — die Ausnahme, die
+    ``PreviewService``/``ComparePreviewService`` in dem Fall werfen."""
+
+    MELDUNG = "Wetterdaten nicht verfuegbar (Testfall)"
+
+    def _stoeren(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        raise RuntimeError(self.MELDUNG)
+
+    render_email_preview = _stoeren
+    render_sms_preview = _stoeren
+    render_telegram_preview = _stoeren
+    render_all_channels = _stoeren
+
+
+@pytest.fixture
+def client():
+    from api.routers import preview
+
+    app = FastAPI()
+    app.include_router(preview.router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def gestoerter_trip_dienst(monkeypatch):
+    from api.routers import preview
+
+    monkeypatch.setattr(preview, "_build_service", lambda *a, **kw: _StoerenderDienst())
+
+
+@pytest.mark.parametrize(
+    "pfad",
+    ["/api/preview/gr221-mallorca/email",
+     "/api/preview/gr221-mallorca/sms",
+     "/api/preview/gr221-mallorca/telegram"],
+)
+def test_trip_vorschau_meldet_wetterausfall_als_503(client, gestoerter_trip_dienst, pfad):
+    """RuntimeError des Vorschau-Dienstes → HTTP 503 mit Klartext-Detail.
+
+    Bestandsluecke: die Suite duldet 503 heute nur, erzwingt ihn nirgends.
+    """
+    antwort = client.get(pfad, params={"user_id": "default", "type": "morning"})
+
+    assert antwort.status_code == 503, (
+        f"Erwarte 503 bei nicht verfuegbaren Wetterdaten, bekam "
+        f"{antwort.status_code}: {antwort.text[:200]}"
+    )
+    assert _StoerenderDienst.MELDUNG in antwort.text, (
+        "Die Fehlermeldung des Dienstes muss im 503-Detail durchgereicht werden "
+        f"(bekam: {antwort.text[:200]})"
+    )
+
+
+def test_vergleichs_vorschau_unbekanntes_preset_ist_404(client):
+    """Unbekanntes Preset → 404. Echter Dienst, kein Ersatz, kein Netz:
+    ``_load_preset`` wirft ``LookupError``, bevor irgendein Abruf startet."""
+    antwort = client.post(
+        "/api/preview/compare/gibt-es-nicht-4711", params={"user_id": "default"},
+    )
+
+    assert antwort.status_code == 404, (
+        f"Erwarte 404 fuer unbekanntes Preset, bekam {antwort.status_code}: "
+        f"{antwort.text[:200]}"
+    )
+    # Abgrenzung: der 404 muss aus dem HANDLER kommen (LookupError → 404), nicht
+    # von Starlettes Router ("Not Found") — sonst wuerde der Test auch bei einer
+    # geloeschten Route noch gruen sein.
+    assert antwort.json().get("detail") != "Not Found", (
+        "Der 404 stammt vom Router, nicht vom Handler — die Route "
+        "POST /api/preview/compare/{preset_id} existiert nicht (mehr)."
+    )
+
+
+def test_vergleichs_vorschau_ohne_user_id_ist_422(client):
+    """Fehlender Pflicht-Parameter ``user_id`` → 422 (FastAPI-Validierung).
+
+    Mandantentrennung: ohne Session-Kennung darf der Endpunkt gar nicht erst
+    rechnen, statt still auf ``"default"`` zu fallen (ADR-0003)."""
+    antwort = client.post("/api/preview/compare/irgendein-preset")
+
+    assert antwort.status_code == 422, (
+        f"Erwarte 422 ohne user_id, bekam {antwort.status_code}: "
+        f"{antwort.text[:200]}"
+    )
+
+
+def test_vergleichs_vorschau_meldet_wetterausfall_als_503(client, monkeypatch):
+    """RuntimeError im Vergleichs-Pfad → HTTP 503."""
+    from api.routers import preview
+
+    monkeypatch.setattr(
+        preview, "ComparePreviewService", lambda *a, **kw: _StoerenderDienst(),
+    )
+    antwort = client.post(
+        "/api/preview/compare/irgendein-preset", params={"user_id": "default"},
+    )
+
+    assert antwort.status_code == 503, (
+        f"Erwarte 503 bei nicht verfuegbaren Wetterdaten, bekam "
+        f"{antwort.status_code}: {antwort.text[:200]}"
+    )
+    assert _StoerenderDienst.MELDUNG in antwort.text
+
+
+def test_trip_vorschau_ohne_user_id_ist_422(client):
+    """Gegenstueck zum Vergleich: auch der Trip-Pfad verlangt ``user_id``."""
+    antwort = client.get("/api/preview/gr221-mallorca/email")
+
+    assert antwort.status_code == 422, (
+        f"Erwarte 422 ohne user_id, bekam {antwort.status_code}: "
+        f"{antwort.text[:200]}"
+    )

--- a/tests/unit/test_route_handler_ohne_await.py
+++ b/tests/unit/test_route_handler_ohne_await.py
@@ -1,0 +1,156 @@
+"""AC-2 (#1765/#1839 Scheibe A): Kein Route-Handler ist Koroutine ohne echtes ``await``.
+
+Spec: docs/specs/modules/fix_1765_1839_sa_vorschau_entblockung.md
+
+Ein ``async def``-Handler ohne ``await`` laeuft bei Starlette DIREKT im
+Event-Loop-Thread statt im Threadpool — waehrend seiner synchronen Arbeit ist
+der gesamte Python-Core taub (belegt in AC-1, ``test_event_loop_bleibt_frei.py``).
+
+Geprueft wird an der **fertig gebauten Anwendung** (``app.routes`` →
+``inspect.iscoroutinefunction``), nicht am Quelltext einer bestimmten Datei:
+Sonst wuerde nur die Schreibweise geprueft und ein per ``add_api_route``
+registrierter oder in einem neuen Modul angelegter Handler bliebe unbemerkt.
+
+Die Ausnahme ist bewusst als **Eigenschaft** formuliert, nicht als Dateiliste:
+Ein Handler darf genau dann Koroutine sein, wenn sein eigener Rumpf tatsaechlich
+``await``/``async for``/``async with`` verwendet. Eine Ausnahmeliste
+("alles in gpx.py ist erlaubt") wuerde erodieren, sobald dort ein zweiter,
+await-loser Handler entsteht.
+
+Bekannte Grenze — unerreichbares ``await`` (Adversary-Fund F001, 2026-08-15)
+---------------------------------------------------------------------------
+``_nutzt_echtes_await()`` zaehlt jeden ``await``-Knoten per AST, **ohne zu
+pruefen, ob er im Kontrollfluss ueberhaupt erreichbar ist**. Ein Handler der
+Bauform::
+
+    async def handler():
+        if False:
+            await asyncio.sleep(0)   # nie erreicht, macht den Test gruen
+        time.sleep(3)                # blockiert trotzdem den Event-Loop
+
+kommt hier **gruen** durch, obwohl er genau den Fehler enthaelt, den dieser
+Test verhindern soll. Der Adversary hat das mit einer echten Sonde belegt.
+
+Das wird hingenommen, nicht behoben: Keiner der 13 heute umgestellten Handler
+nutzt dieses Muster, und eine Erreichbarkeitsanalyse (konstante Bedingungen
+auswerten, toten Code erkennen) waere fuer diesen Wachzweck unverhaeltnismaessig
+aufwaendig und selbst wieder fehleranfaellig. Der Test soll einfach bleiben —
+die Grenze soll nur nicht unsichtbar sein.
+
+Zweite Verteidigungslinie ist ``tests/unit/test_event_loop_bleibt_frei.py``:
+Der misst an einem echten uvicorn-Server die **tatsaechliche** Blockade
+(``/health``-Antwortzeit waehrend einer laufenden Vorschau) und wuerde einen so
+gebauten Handler auffliegen lassen. Allerdings deckt er nur die
+**Vorschau-Handler** ab — fuer die Handler in ``validator``, ``internal`` und
+``notify`` gibt es diese zweite Linie nicht.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+
+from fastapi.routing import APIRoute
+
+
+def _nutzt_echtes_await(func) -> bool:
+    """Enthaelt der EIGENE Rumpf der Funktion ``await``/``async for``/``async with``?
+
+    Verschachtelte Funktionsdefinitionen werden bewusst uebersprungen — ein
+    ``await`` in einer inneren Koroutine rechtfertigt nicht, dass die aeussere
+    Route-Funktion selbst ``async def`` ist.
+    """
+    try:
+        quelle = textwrap.dedent(inspect.getsource(func))
+    except (OSError, TypeError):
+        return False
+    baum = ast.parse(quelle)
+    # ast.parse liefert Module → FunctionDef/AsyncFunctionDef als einziges Kind.
+    rumpf = baum.body[0].body if baum.body else []
+
+    gefunden = False
+
+    class _Sucher(ast.NodeVisitor):
+        def visit_Await(self, node):  # noqa: N802
+            nonlocal gefunden
+            gefunden = True
+
+        def visit_AsyncFor(self, node):  # noqa: N802
+            nonlocal gefunden
+            gefunden = True
+            self.generic_visit(node)
+
+        def visit_AsyncWith(self, node):  # noqa: N802
+            nonlocal gefunden
+            gefunden = True
+            self.generic_visit(node)
+
+        def visit_FunctionDef(self, node):  # noqa: N802
+            return  # verschachtelte Definition: nicht der eigene Rumpf
+
+        def visit_AsyncFunctionDef(self, node):  # noqa: N802
+            return
+
+    sucher = _Sucher()
+    for knoten in rumpf:
+        sucher.visit(knoten)
+    return gefunden
+
+
+def _fundstelle(func) -> str:
+    modul = getattr(func, "__module__", "?")
+    try:
+        zeile = func.__code__.co_firstlineno
+    except AttributeError:
+        zeile = "?"
+    return f"{modul}:{zeile} {getattr(func, '__qualname__', func)}"
+
+
+def test_kein_route_handler_ist_koroutine_ohne_await():
+    """AC-2: An der gebauten App ist kein Handler Koroutine, ausser er nutzt ``await``.
+
+    Heute (vor Ae1) sind das 13 Verstoesse in 4 Routern; ``gpx.parse_gpx``
+    (``await file.read()``) ist der einzige berechtigte ``async def``.
+    """
+    from api.main import app
+
+    verstoesse = []
+    berechtigt = []
+    for route in app.routes:
+        if not isinstance(route, APIRoute):
+            continue
+        endpoint = route.endpoint
+        if not inspect.iscoroutinefunction(endpoint):
+            continue
+        if _nutzt_echtes_await(endpoint):
+            berechtigt.append(_fundstelle(endpoint))
+            continue
+        verstoesse.append(f"  {_fundstelle(endpoint)}  ({', '.join(sorted(route.methods))} {route.path})")
+
+    assert not verstoesse, (
+        f"{len(verstoesse)} Route-Handler sind 'async def' OHNE jedes 'await' und "
+        "blockieren damit den Event-Loop waehrend ihrer synchronen Arbeit "
+        "(AC-2, Spec fix_1765_1839_sa_vorschau_entblockung.md).\n"
+        "Abhilfe: 'async def' → 'def', dann fuehrt Starlette sie im Threadpool aus.\n"
+        + "\n".join(sorted(verstoesse))
+        + f"\n\nBerechtigt (nutzen echtes await): {berechtigt or 'keine'}"
+    )
+
+
+def test_gpx_upload_bleibt_die_einzige_berechtigte_koroutine():
+    """Gegenprobe zur Ausnahme: ``parse_gpx`` nutzt echtes ``await`` und darf bleiben.
+
+    Ohne diesen Test koennte AC-2 auch dadurch 'erfuellt' werden, dass jemand
+    ``parse_gpx`` mit-umstellt und das ``await file.read()`` dabei zerbricht.
+    """
+    from api.routers.gpx import parse_gpx
+
+    assert inspect.iscoroutinefunction(parse_gpx), (
+        "parse_gpx muss 'async def' bleiben — es nutzt 'await file.read()'."
+    )
+    assert _nutzt_echtes_await(parse_gpx), (
+        "parse_gpx enthaelt kein 'await' mehr — dann darf es auch keine "
+        "Koroutine mehr sein (die Ausnahme in AC-2 haengt an der Eigenschaft, "
+        "nicht am Dateinamen)."
+    )

--- a/tests/unit/test_timezone_singleton_threadsicher.py
+++ b/tests/unit/test_timezone_singleton_threadsicher.py
@@ -1,0 +1,154 @@
+"""AC-4 (#1765/#1839 Scheibe A): ``TimezoneFinder`` wird auch bei gleichzeitigem
+Erstzugriff genau EINMAL gebaut.
+
+Spec: docs/specs/modules/fix_1765_1839_sa_vorschau_entblockung.md
+
+``src/utils/timezone.py`` haelt ``_tf_instance`` als Lazy-Singleton OHNE Sperre.
+Solange alle Vorschau-Handler ``async def`` ohne ``await`` waren, hat der
+blockierte Event-Loop sie unfreiwillig serialisiert — die Luecke war nie
+erreichbar. Ae1 (``async def`` → ``def``) laesst sie erstmals wirklich parallel
+laufen: Beide Vorschau-Pfade fuehren hierher (Trip ueber ``tz_for_coords()``,
+Vergleich ueber ``location_tz()``), und ``TimezoneFinder`` laedt ~12 MB.
+
+Geprueft wird die **Wirkung** — die tatsaechliche Zahl der Konstruktionen —,
+nicht die Anwesenheit eines ``Lock()`` im Quelltext.
+"""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+
+class _ZaehlenderFinder:
+    """Leichtgewichtiger Ersatz fuer ``TimezoneFinder`` (~12 MB) mit Zaehler.
+
+    Ersetzt wird ausschliesslich das TEURE, fremde Objekt — die zu pruefende
+    Logik (``_get_tf`` und der Weg dorthin) bleibt die echte. Die Zusicherung
+    lautet "genau eine Konstruktion", nicht "TimezoneFinder rechnet richtig".
+    """
+
+    aufbauten = 0
+    _zaehler_lock = threading.Lock()
+    #: Trifft ein zweiter Thread waehrend der Konstruktion ebenfalls hier ein,
+    #: gibt die Barriere sofort frei (= ungesicherter Fall). Bleibt er aus,
+    #: laeuft die Barriere in den Timeout — der gesicherte Fall wartet also
+    #: einmalig 1 s statt sich auf Zufalls-Timing zu verlassen.
+    treffpunkt = threading.Barrier(2)
+
+    def __init__(self) -> None:
+        with _ZaehlenderFinder._zaehler_lock:
+            _ZaehlenderFinder.aufbauten += 1
+        try:
+            _ZaehlenderFinder.treffpunkt.wait(timeout=1.0)
+        except threading.BrokenBarrierError:
+            pass  # allein angekommen — genau das ist der Zielzustand
+
+    def timezone_at(self, lat=None, lng=None):  # noqa: ANN001, ARG002
+        return "Europe/Vienna"
+
+
+@pytest.fixture
+def leerer_zeitzonen_zustand(monkeypatch):
+    """Setzt ``_tf_instance`` auf den Ausgangszustand (None) und stellt ihn
+    danach wieder her — sonst vergiftet dieser Test jeden Folgetest, der eine
+    Zeitzone aufloest."""
+    from utils import timezone as tz_modul
+    import timezonefinder
+
+    vorher = tz_modul._tf_instance
+    tz_modul._tf_instance = None
+    _ZaehlenderFinder.aufbauten = 0
+    _ZaehlenderFinder.treffpunkt = threading.Barrier(2)
+    monkeypatch.setattr(timezonefinder, "TimezoneFinder", _ZaehlenderFinder)
+    try:
+        yield tz_modul
+    finally:
+        tz_modul._tf_instance = vorher
+
+
+def test_gleichzeitiger_erstzugriff_baut_timezonefinder_genau_einmal(
+    leerer_zeitzonen_zustand,
+):
+    """AC-4: Zwei Threads treffen per Barriere garantiert gleichzeitig auf den
+    leeren Zustand; danach ist der Konstruktions-Zaehler exakt 1.
+
+    Die beiden Threads nehmen bewusst die zwei ECHTEN Einstiege der beiden
+    Vorschau-Pfade: ``tz_for_coords()`` (Trip, ``preview_service.py:180``) und
+    ``location_tz()`` (Vergleich, ``comparison_engine.py:155``).
+    """
+    tz_modul = leerer_zeitzonen_zustand
+    start = threading.Barrier(2)
+    ergebnisse: dict[str, object] = {}
+    fehler: list[BaseException] = []
+
+    def trip_pfad():
+        try:
+            start.wait(timeout=5)
+            ergebnisse["trip"] = tz_modul.tz_for_coords(47.2692, 11.4041)
+        except BaseException as e:  # noqa: BLE001
+            fehler.append(e)
+
+    def vergleichs_pfad():
+        try:
+            start.wait(timeout=5)
+            ort = SimpleNamespace(timezone=None, lat=47.2692, lon=11.4041)
+            ergebnisse["vergleich"] = tz_modul.location_tz(ort)
+        except BaseException as e:  # noqa: BLE001
+            fehler.append(e)
+
+    threads = [
+        threading.Thread(target=trip_pfad, name="trip"),
+        threading.Thread(target=vergleichs_pfad, name="vergleich"),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+        assert not t.is_alive(), f"Thread {t.name} haengt — Verklemmung in _get_tf()?"
+
+    assert not fehler, f"Ausnahme in einem der Threads: {fehler!r}"
+
+    assert _ZaehlenderFinder.aufbauten == 1, (
+        f"TimezoneFinder wurde {_ZaehlenderFinder.aufbauten}x gebaut statt genau 1x. "
+        "Zwei gleichzeitige Vorschau-Anfragen sehen beide '_tf_instance is None' und "
+        "laden je ~12 MB (kurzzeitig 24 MB), eine Instanz wird kommentarlos verworfen. "
+        "Abhilfe: doppelt gepruefte Sperre in _get_tf() nach dem Muster "
+        "services/weather_cache.py:300-305 (AC-4, Spec "
+        "fix_1765_1839_sa_vorschau_entblockung.md)."
+    )
+    assert str(ergebnisse["trip"]) == "Europe/Vienna"
+    assert str(ergebnisse["vergleich"]) == "Europe/Vienna"
+
+
+def test_beide_threads_erhalten_dieselbe_instanz(leerer_zeitzonen_zustand):
+    """AC-4, zweite Haelfte: ``... und beide Threads erhalten dieselbe Instanz``.
+
+    Der Zaehler allein wuerde eine Umsetzung durchlassen, die zwar nur einmal
+    baut, aber je Thread ein eigenes Objekt zurueckgibt (z.B. thread-lokaler
+    Speicher statt Prozess-Singleton).
+    """
+    tz_modul = leerer_zeitzonen_zustand
+    start = threading.Barrier(2)
+    instanzen: list[object] = []
+    sperre = threading.Lock()
+
+    def hole():
+        start.wait(timeout=5)
+        instanz = tz_modul._get_tf()
+        with sperre:
+            instanzen.append(instanz)
+
+    threads = [threading.Thread(target=hole) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+
+    assert len(instanzen) == 2, "Beide Threads muessen eine Instanz erhalten haben"
+    assert instanzen[0] is instanzen[1], (
+        "Die beiden Threads haben VERSCHIEDENE TimezoneFinder-Instanzen erhalten — "
+        "_get_tf() muss prozessweit dieselbe Instanz liefern (AC-4)."
+    )


### PR DESCRIPTION
## Was

13 Route-Handler waren als `async def` deklariert, enthalten aber **kein einziges `await`**. Starlette führt solche Handler direkt im Event-Loop-Thread aus statt im Threadpool — während der synchronen Wetterabrufe ist der gesamte Single-Worker-Prozess taub.

**Auf Staging gemessen:** `/health` war **74,5 von 75,8 s** nicht binnen 2 s erreichbar (25 Timeouts in Folge). Der Go-Health-Handler gibt Python genau 2 s (`internal/handler/proxy.go:19`) und meldet dann `python_core: unavailable`. Das hat am 2026-08-12 einen **unnötigen Neustart** von `gregor-python-staging` ausgelöst.

Die vier gemeldeten Vorschau-Handler waren nur die Stichprobe — betroffen sind auch das Cockpit-Etappenwetter und sechs Validator-Endpunkte. Zweifach ausgezählt: statisch per AST über `api/` und zur Laufzeit an `app.routes`.

## Änderungen (5 Produktivdateien, +21/−16)

- **Ä1:** 13× `async def` → `def`. `gpx.py parse_gpx` bleibt Koroutine (echtes `await file.read()`).
- **Ä3:** doppelt geprüfte Sperre um den `TimezoneFinder`-Lazy-Singleton (`src/utils/timezone.py`), Muster wortgleich zu `weather_cache.py:300-305`. Nötig, weil Ä1 **erstmals echte Gleichzeitigkeit** im Anfragepfad erzeugt — vorher serialisierte der blockierte Event-Loop unfreiwillig.

## Tests

| Datei | Zweck |
|---|---|
| `test_event_loop_bleibt_frei.py` | echter uvicorn-Server mit den echten Routern, `/health` nebenläufig während blockierter Vorschau — **mit Kontrollgruppe**, die im selben Lauf belegt, dass der Aufbau beide Zustände unterscheidet |
| `test_route_handler_ohne_await.py` | prüft an der **gebauten App**, nicht am Quelltext |
| `test_timezone_singleton_threadsicher.py` | zwei Threads mit Barriere, Konstruktionszähler muss exakt 1 sein |
| `test_preview_fehlerformen.py` | absichtlich schon vor der Änderung grün — deckt Lücken, die der Bestand offen ließ |

**Bewusst kein `TestClient`** für den Kerntest: zwei Instanzen hätten je einen eigenen Event-Loop, der Test wäre still immer grün.

Nebenfund: `503` war im Bestand nirgends erzwungen (nur als `assert status_code in (200, 503)` geduldet), und `POST /api/preview/compare/{id}` hatte **gar keine** Fehlerform-Tests.

## Adversary

Alle 4 AC per **Mutations-Gegenprobe** belegt (Handler zurück auf `async def` → rot; Sperre entfernt → rot; 503→500 → rot). Zwei MEDIUM-Findings, beide ohne Codeänderung nachgezogen:

- **F002:** Die Spec behauptete, „alle `global`-Anweisungen" seien geprüft. **Widerlegt** — `functools.lru_cache` kommt ohne `global` aus, ein solcher Fall liegt im umgestellten Pfad (`_lookup_department_cached()`). Sachlich unkritisch (CPython sichert `lru_cache` intern ab), aber die Aussage war zu stark und ist jetzt ausdrücklich als **kein** Vollständigkeitsbeweis korrigiert.
- **F001:** Der Rückfall-Wächter ließe ein unerreichbares `await` durch. Kein Bestandsfall; als bekannte Grenze im Docstring benannt statt überkonstruiert zu lösen.

## Was das NICHT behebt

**Die Vorschau bleibt langsam** — Vergleich 25,1–25,6 s je Ort, Trip kalt 121 s über 7 Segmentabrufe — und reißt weiterhin ihre Zeitgrenzen (nginx 60 s, Go 30 s). Das ist **Scheibe B**.

Beide Issues bleiben deshalb **offen**. Wurzel #1539 unberührt.

Refs #1765, #1839

🤖 Generated with [Claude Code](https://claude.com/claude-code)