### PR TITLE
fix(#1866): Datei-Claim-Gate — Freigabeweg, Aktivitäts-Verfall, docs/**-Ausnahme

### DIFF
--- a/.claude/hooks/file_claim_gate.py
+++ b/.claude/hooks/file_claim_gate.py
@@ -17,8 +17,15 @@ CLAUDE.md -> Parallele Sessions). Verwaiste Belegungen (Worktree existiert laut
 `git worktree list` nicht mehr, ODER seit STALE_AFTER_SECONDS nicht aufgefrischt) zaehlen
 nicht als belegt.
 
-Notausgang: `export GZ_FILE_CLAIM_OVERRIDE=1` (einmalig pro Session, falls die Belegung
-nachweislich ein Irrtum ist).
+Freigabeweg (Issue #1866): `python3 .claude/hooks/file_claim_gate.py --release <pfad>` bzw.
+`--release-session <name>` -- der `export GZ_FILE_CLAIM_OVERRIDE=1`-Notausgang ist strukturell
+unerreichbar (jeder PreToolUse-Aufruf ist ein eigener Kindprozess) und wird nicht mehr als
+Weg beworben; die env-Pruefung bleibt im Code bestehen, schadet nicht.
+
+Aktivitaets-Verfall (#1866): ein sonst blockierender Claim gilt zusaetzlich als beendet, wenn
+die Datei im belegenden Worktree byte-identisch mit `origin/main` ist UND `git status
+--porcelain` fuer den Pfad dort nichts meldet -- lockert nur zusaetzlich, verschaerft nie
+(jeder Fehler beim Zusatz-Check -> nicht verfallen).
 
 Regel-Budget: Pruefdatum 2026-11-11 -- danach deaktiviert sich das Gate selbst;
 Entscheidung (behalten/entfernen) faellt im Gate-Audit #1197.
@@ -164,9 +171,152 @@ def _acquire_lock(lock_path: Path):
             return None
 
 
+def _claim_expired_by_activity(entry: dict, rel_path: str, main_root: Path) -> bool:
+    """Zusaetzlicher Verfall (#1866): nur relevant, wenn die bestehende Logik den Claim
+    ohnehin als blockierend einstufen wuerde -- lockert nur zusaetzlich, verschaerft nie.
+    Sicherheitsrichtung: JEDER Fehler (Git-Befehl schlaegt fehl, Worktree nicht auffindbar,
+    origin/main nicht aufloesbar, Timeout) -> False (nicht verfallen)."""
+    session = entry.get("session", "")
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(main_root), "worktree", "list", "--porcelain"],
+            capture_output=True, text=True, timeout=5, check=True,
+        )
+    except Exception:
+        return False
+
+    wt_path = None
+    for line in out.stdout.splitlines():
+        if line.startswith("worktree "):
+            path = line[len("worktree "):].strip()
+            if Path(path).name == session:
+                wt_path = Path(path)
+                break
+    if wt_path is None:
+        return False
+
+    try:
+        status = subprocess.run(
+            ["git", "-C", str(wt_path), "status", "--porcelain", "--", rel_path],
+            capture_output=True, text=True, timeout=5, check=True,
+        )
+        if status.stdout.strip():
+            return False  # lokale (un)staged Aenderung -> nicht verfallen
+
+        origin = subprocess.run(
+            ["git", "-C", str(wt_path), "show", f"origin/main:{rel_path}"],
+            capture_output=True, timeout=5, check=True,
+        )
+        local_content = (wt_path / rel_path).read_bytes()
+        return origin.stdout == local_content
+    except Exception:
+        return False
+
+
+def _load_registry_strict(path: Path) -> dict:
+    """Wie _load_registry, aber OHNE Fail-Open (#1866 F001): eine fehlende Datei bleibt {}
+    (unveraendertes Verhalten), eine EXISTIERENDE, aber kaputte Registry wirft weiter --
+    _load_registry() selbst bleibt fuer den Haupt-Hook-Pfad bewusst fail-open (Docstring
+    dort) und wird hier NICHT angetastet; nur --release/--release-session brauchen laut
+    Spec (AC-1) eine von 'kein aktiver Claim' unterscheidbare Fehlermeldung."""
+    if not path.exists():
+        return {}
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _handle_release(rel_path: str, main_root: Path) -> int:
+    """CLI-Freigabeweg (#1866): entfernt genau einen Registry-Eintrag. Gleiches Locking wie
+    der Hook-Pfad. Kein Crash, kein irrefuehrendes "gelöscht" wenn kein Claim existiert."""
+    registry_path = main_root / ".claude" / REGISTRY_NAME
+    lock_fh = _acquire_lock(registry_path.with_suffix(".lock"))
+    if lock_fh is None:
+        sys.stderr.write("DATEI-CLAIM-GATE: Lock nicht verfuegbar, --release abgebrochen.\n")
+        return 1
+    try:
+        try:
+            registry = _load_registry_strict(registry_path)
+        except Exception as exc:
+            sys.stderr.write(
+                f"DATEI-CLAIM-GATE: Registry beschaedigt/nicht lesbar ({registry_path}): {exc}\n"
+            )
+            return 2
+        entry = registry.pop(rel_path, None)
+        if entry is None:
+            sys.stdout.write(f"DATEI-CLAIM-GATE: kein aktiver Claim fuer {rel_path}.\n")
+            return 1
+        _save_registry(registry_path, registry)
+        sys.stdout.write(
+            f"DATEI-CLAIM-GATE: Belegung fuer {rel_path} entfernt "
+            f"(Session: {entry.get('session', '?')}, Branch: {entry.get('branch', '?')}, "
+            f"Belegt seit: {entry.get('claimed_at', '?')}).\n"
+        )
+        return 0
+    except Exception as exc:
+        sys.stderr.write(f"DATEI-CLAIM-GATE: --release fehlgeschlagen: {exc}\n")
+        return 2
+    finally:
+        try:
+            fcntl.flock(lock_fh, fcntl.LOCK_UN)
+        except Exception:
+            pass
+        lock_fh.close()
+
+
+def _handle_release_session(session: str, main_root: Path) -> int:
+    """CLI-Freigabeweg (#1866): entfernt ALLE Eintraege einer Session. Gleiches Locking wie
+    der Hook-Pfad. Kein Treffer -> klare "nichts zu tun"-Meldung, kein Fehler."""
+    registry_path = main_root / ".claude" / REGISTRY_NAME
+    lock_fh = _acquire_lock(registry_path.with_suffix(".lock"))
+    if lock_fh is None:
+        sys.stderr.write("DATEI-CLAIM-GATE: Lock nicht verfuegbar, --release-session abgebrochen.\n")
+        return 1
+    try:
+        try:
+            registry = _load_registry_strict(registry_path)
+        except Exception as exc:
+            sys.stderr.write(
+                f"DATEI-CLAIM-GATE: Registry beschaedigt/nicht lesbar ({registry_path}): {exc}\n"
+            )
+            return 2
+        matched = sorted(p for p, e in registry.items() if e.get("session") == session)
+        if not matched:
+            sys.stdout.write(
+                f"DATEI-CLAIM-GATE: keine Belegungen fuer Session {session} gefunden, nichts zu tun.\n"
+            )
+            return 0
+        for p in matched:
+            del registry[p]
+        _save_registry(registry_path, registry)
+        sys.stdout.write(
+            f"DATEI-CLAIM-GATE: {len(matched)} Belegung(en) fuer Session {session} entfernt: "
+            f"{', '.join(matched)}.\n"
+        )
+        return 0
+    except Exception as exc:
+        sys.stderr.write(f"DATEI-CLAIM-GATE: --release-session fehlgeschlagen: {exc}\n")
+        return 2
+    finally:
+        try:
+            fcntl.flock(lock_fh, fcntl.LOCK_UN)
+        except Exception:
+            pass
+        lock_fh.close()
+
+
 def main() -> int:
     if date.today() > EXPIRY:
         return 0  # Pruefdatum erreicht (Regel-Budget) -> Gate inaktiv, Entscheidung: #1197
+
+    argv = sys.argv[1:]
+    if len(argv) >= 2 and argv[0] in ("--release", "--release-session"):
+        main_root = _find_main_repo_root()
+        if main_root is None:
+            sys.stderr.write("DATEI-CLAIM-GATE: Hauptrepo nicht aufloesbar, Freigabe abgebrochen.\n")
+            return 1
+        if argv[0] == "--release":
+            return _handle_release(argv[1], main_root)
+        return _handle_release_session(argv[1], main_root)
 
     if os.environ.get(OVERRIDE_ENV) == "1":
         return 0
@@ -188,6 +338,14 @@ def main() -> int:
     if rel_path is None:
         return 0
 
+    # #1878: geteilte Referenz-/Feature-Doku wird nie beansprucht. Getrennte
+    # Zweige machen eine Doppelaenderung beim Mergen ohnehin als Konflikt
+    # sichtbar, und bei Prosa ist der trivial aufzuloesen -- die Sperre kostet
+    # dort viel und verhindert wenig. docs/specs/** bleibt beansprucht: eine
+    # Spec gehoert waehrend eines laufenden Workflows genau einer Session.
+    if rel_path.startswith("docs/") and not rel_path.startswith("docs/specs/"):
+        return 0
+
     session = _session_id()
     registry_path = main_root / ".claude" / REGISTRY_NAME
     lock_fh = _acquire_lock(registry_path.with_suffix(".lock"))
@@ -205,7 +363,10 @@ def main() -> int:
             still_fresh = age < STALE_AFTER_SECONDS
             other_still_active = _worktree_still_exists(entry.get("session", ""), main_root)
 
-            if not same_session and still_fresh and other_still_active:
+            if (
+                not same_session and still_fresh and other_still_active
+                and not _claim_expired_by_activity(entry, rel_path, main_root)
+            ):
                 sys.stderr.write(
                     "DATEI-CLAIM-GATE (PO-Wunsch 2026-08-13, Kollisionsvermeidung zwischen Sessions):\n"
                     f"{rel_path} ist gerade von einer anderen aktiven Session belegt:\n"
@@ -214,8 +375,8 @@ def main() -> int:
                     "\n"
                     "-> Erst per SendMessage mit dieser Session abstimmen, dann weitermachen.\n"
                     "-> Falls die Belegung ein Irrtum ist (Datei laengst wieder frei, Registry nur\n"
-                    "   nicht aktualisiert): einmalig `export GZ_FILE_CLAIM_OVERRIDE=1` setzen und\n"
-                    "   erneut versuchen.\n"
+                    f"   nicht aktualisiert): `python3 .claude/hooks/file_claim_gate.py --release {rel_path}`\n"
+                    "   ausfuehren und erneut versuchen.\n"
                     f"(Verwaist automatisch nach {STALE_AFTER_SECONDS // 3600}h ohne Auffrischung "
                     f"oder wenn der Worktree weg ist. Pruefdatum dieses Gates: {EXPIRY.isoformat()}.)\n"
                 )

--- a/docs/context/fix-1866-claim-freigabeweg.md
+++ b/docs/context/fix-1866-claim-freigabeweg.md
@@ -1,0 +1,41 @@
+# Context: fix-1866-claim-freigabeweg
+
+## Request Summary
+Issue #1866: Der dokumentierte Notausgang des Datei-Claim-Gates (`export GZ_FILE_CLAIM_OVERRIDE=1`)
+ist unerreichbar, weil das Gate als eigener Prozess läuft und das `export` einer Bash-Tool-Aufrufs
+den Hook-Prozess nicht erreicht. Der einzige wirksame Ort (`.claude/settings.local.json`) ist durch
+`edit_gate.py` (Plugin, Orchestrator-Domäne) gesperrt. PO-Entscheid aus der Intake-Runde: Vorschlag
+1 (`--release`-CLI-Befehl) und Vorschlag 2 (Verfall an Aktivität statt nur an der Uhr) umsetzen,
+Vorschlag 3 (`edit_gate` differenzieren) **nicht** — das liegt im Plugin-Repo `agent-os-openspec`,
+nicht in diesem Repo, und wird durch Vorschlag 1 ohnehin überflüssig.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `.claude/hooks/file_claim_gate.py` | Das Gate selbst — einziger zu ändernder Ort. Liegt im Projekt-Repo (nicht im Plugin), keine Kollisionsgefahr mit `agent-os-openspec`. Aktuell 243 Zeilen, **keine Tests**. |
+| `.claude/settings.json:109-117` | Hook-Registrierung: `PreToolUse` auf Matcher `Write\|Edit`, ruft `file_claim_gate.py` ohne Argumente auf (liest stdin-JSON). Ein CLI-Aufruf mit `--release` läuft **außerhalb** dieses Hook-Pfads, als normaler Bash-Befehl. |
+| `.claude/file_claims.json` | Die geteilte Registry (worktree-übergreifend im Hauptrepo). Aktuell 114 Einträge, 7 aktive Sessions. |
+
+## Existing Patterns
+
+- **Fail-open überall:** Jeder Fehlerpfad in `file_claim_gate.py` gibt `0` zurück (nie blockieren wegen eigenem Defekt). Diese Eigenschaft muss der neue `--release`-Pfad übernehmen — ein Fehler beim Release darf nie eine Exception nach oben werfen, die den Bash-Aufruf abbrechen lässt, aber auch nie eine bestehende, tatsächlich aktive Belegung stillschweigend löschen.
+- **Locking:** `_acquire_lock()` mit `fcntl.flock`, 2s Timeout, dann fail-open. Der neue Release-Pfad muss dasselbe Lock verwenden (gleiche Registry-Datei, gleichzeitige Hook-Läufe anderer Sessions möglich).
+- **Session-Kennung:** Worktree-Ordnername (`_session_id()`), nicht der freie Anzeigename der Claude-Session — bereits als Falle dokumentiert (`SendMessage` an den Anzeigenamen scheitert, siehe Issue-Text). Der `--release`-Befehl arbeitet daher über den **Registry-Key** (Datei-Pfad) bzw. den **Worktree-Ordnernamen**, nicht über Anzeigenamen.
+- **`bash_gate.py` (Plugin):** blockiert `python3 -c` und Schreib-Indikatoren (`sed -i`, `>`, `open(`, …) auf Pfaden, die `\.claude/hooks/[^\s]*\.py` matchen — aber **nur wenn zusätzlich ein Schreib-Indikator vorliegt**. Ein reiner Skript-Aufruf `python3 .claude/hooks/file_claim_gate.py --release <pfad>` (kein `-c`, kein Redirect) hat keinen Schreib-Indikator und läuft ungeblockt durch. Geprüft am aktuellen Plugin-Stand 3.11.4.
+
+## Dependencies
+- **Upstream:** `hook_utils.find_project_root()` (Plugin) für die Hauptrepo-Auflösung — nur Import, kein Änderungsbedarf.
+- **Downstream:** Keine anderen Skripte rufen `file_claim_gate.py` derzeit direkt auf (kein Treffer bei `grep -rl file_claim`). Der neue CLI-Modus ist rein additiv.
+
+## Existing Specs
+Keine vorhandene Spec zu diesem Gate (PO-Feature vom 2026-08-13, nicht spezifiziert dokumentiert).
+
+## Risks & Considerations
+- **Vorschlag 2 (Aktivitäts-Verfall)** braucht Git-Vergleiche (Worktree-Pfad ermitteln, Datei-Inhalt im Worktree vs. `origin/main`, Status auf saubere Arbeitskopie für den Pfad). Jeder Git-Fehler muss konservativ in Richtung "nicht automatisch verfallen" auflösen (bestehendes Blockier-Verhalten bleibt bestehen) — nicht in Richtung "freigeben", sonst higher Blast Radius als der bestehende Bug.
+- **`--release` ohne Zugriffsschutz:** Jede Session kann jede Belegung lösen. Das ist beabsichtigt (Zweck des Befehls ist genau die Behebung fremder Fehlbelegungen), aber die Ausgabe muss die gelöschte Belegung (Session, Branch, Zeitpunkt) nennen, damit der Vorgang nachvollziehbar bleibt (kein stiller Eingriff).
+- **Kein Test vorhanden:** Neue Logik (`--release`, `--release-session`, Aktivitäts-Verfall) braucht neue Tests. Ort: `tests/unit/` (Hooks sind reine Python-Skripte, Kern-Schicht ohne Netz — passt zur deterministischen Schicht der Zwei-Schichten-Testpolitik).
+- **Regel-Budget-Prüfdatum** des Gates selbst (2026-11-11) bleibt unverändert; dieser Fix ändert nichts daran.
+
+## Next Step
+Weiter mit `/30-write-spec`.

--- a/docs/specs/modules/fix_1866_claim_gate_freigabeweg.md
+++ b/docs/specs/modules/fix_1866_claim_gate_freigabeweg.md
@@ -1,0 +1,211 @@
+---
+entity_id: fix_1866_claim_gate_freigabeweg
+type: bugfix
+created: 2026-08-15
+updated: 2026-08-15
+status: draft
+workflow: fix-1866-claim-freigabeweg
+---
+
+# Datei-Claim-Gate: wirksamer Freigabeweg (`--release`) + Aktivitäts-Verfall
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Das Datei-Claim-Gate (`.claude/hooks/file_claim_gate.py`) blockiert Edit/Write bei
+Kollision mit einer anderen aktiven Session und wirbt in seiner Blockade-Meldung für
+`export GZ_FILE_CLAIM_OVERRIDE=1` als Notausgang. Dieser Notausgang ist strukturell
+unerreichbar: der Hook läuft als eigener Kindprozess pro `PreToolUse`-Aufruf, ein `export`
+in einem Bash-Tool-Aufruf setzt die Variable nur für den Bash-Prozess, nicht für den
+nächsten Hook-Lauf. Der einzige tatsächlich wirksame Ort — `.claude/settings.local.json` —
+ist durch `edit_gate.py` (Plugin `agent-os-openspec`, nicht dieses Repo) gesperrt. Issue
+#1866 dokumentiert den konkreten Auslöser: eine Datei war im belegenden Worktree seit über
+einer Stunde bitgleich mit `origin/main` gemergt, der Claim blockierte trotzdem weiter,
+weil die reine Zeit-/Worktree-Verfallslogik das nicht erkennt, und der beworbene
+Notausgang griff nicht.
+
+Dieser Fix schafft einen tatsächlich wirksamen, nachvollziehbaren Freigabeweg
+(`--release`/`--release-session` als CLI-Aufruf außerhalb des Hook-Pfads) und lässt
+Claims zusätzlich automatisch verfallen, wenn die beanspruchte Datei im belegenden
+Worktree nachweislich unverändert und deckungsgleich mit `origin/main` ist — exakt der im
+Issue beschriebene Fall.
+
+## Source
+
+- **File:** `.claude/hooks/file_claim_gate.py`
+- **Identifier:** `def main`, neu: `def _handle_release`, `def _handle_release_session`,
+  `def _claim_expired_by_activity`
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `hook_utils.find_project_root` (Plugin `agent-os-openspec`, `/home/hem/agent-os-openspec/core/hooks`) | Funktion | Hauptrepo-Auflösung — bereits genutzt, keine Änderung |
+| `.claude/settings.json` (`PreToolUse`-Hook-Registrierung, Zeilen 109-117) | Konfiguration | Ruft `file_claim_gate.py` ohne Argumente über stdin-JSON auf; der neue `--release`-Pfad läuft davon unabhängig als normaler Bash-Befehl — keine Änderung an dieser Registrierung nötig |
+| `bash_gate.py` (Plugin) | Wächter | Bereits geprüft (siehe Kontext-Dokument): ein reiner Skriptaufruf `python3 .claude/hooks/file_claim_gate.py --release <pfad>` ohne `-c`/Redirect hat keinen Schreib-Indikator und läuft ungeblockt durch — keine Änderung nötig |
+| `.claude/file_claims.json` | Datei (Registry) | Geteilte Belegungs-Registry im Hauptrepo, worktree-übergreifend sichtbar — Ziel der Lösch-Operation |
+| `git worktree list --porcelain`, `git diff`, `git status --porcelain`, `git show origin/main:<pfad>` | externe Befehle | Neu benötigt für den Aktivitäts-Verfall-Check |
+
+## Scope
+
+### Affected Files
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `.claude/hooks/file_claim_gate.py` | MODIFY | CLI-Argument-Parsing (`--release <pfad>`, `--release-session <name>`), Release-Logik mit gleichem Locking wie der Hook-Pfad, Aktivitäts-Verfall-Check (`_claim_expired_by_activity`), Einbindung in die bestehende Kollisions-Prüfung, neue Blockade-Meldung |
+| `tests/unit/test_file_claim_gate_release.py` | CREATE | Kern-Schicht-Tests für `--release`, `--release-session`, Fehlerfälle (nicht belegt, Registry defekt) |
+| `tests/unit/test_file_claim_gate_activity_expiry.py` | CREATE | Kern-Schicht-Tests für den Aktivitäts-Verfall (echtes Temp-Git-Repo + echter `git worktree add`), inkl. Gegenprobe (abweichender Inhalt / lokale Änderung blockiert weiterhin) |
+
+### Estimated Changes
+- Files: 3 (1 modifiziert, 2 neu)
+- LoC: ca. +90/-10 in `file_claim_gate.py` (CLI-Parsing, Release-Funktionen, Aktivitäts-Check, neue Meldung); Test-LoC zusätzlich, zählt gegen das separate 500er-Test-Budget (CLAUDE.md, Workflow-Tools v3), nicht gegen die 250 Prod-LoC
+
+## Implementation Details
+
+**1. `--release <pfad>` (repo-relativ):**
+- Lock auf `file_claims.json.lock` wie im bestehenden Hook-Pfad (`_acquire_lock`), Lock-Timeout unverändert.
+- Existiert im geladenen Registry-Dict kein Eintrag für `<pfad>`: klare Meldung auf stdout/stderr ("kein aktiver Claim für `<pfad>`"), Exit-Code so gewählt, dass das Aufrufer-Skript den Fall von einem echten Fehler unterscheiden kann (kein Crash, kein irreführendes "gelöscht").
+- Existiert ein Eintrag: vor dem Löschen dessen Inhalt (Session, Branch, `claimed_at`) merken, Eintrag aus dem Dict entfernen, Registry atomar speichern (bestehendes `_save_registry`-Muster: `.tmp` + `replace`), danach die gemerkten Details ausgeben.
+- Jeder Fehler (Registry nicht lesbar, kein Lock zu bekommen, Schreibfehler) darf nicht crashen und darf keinen Erfolg vortäuschen — klare Fehlermeldung, von der "kein Claim vorhanden"-Meldung unterscheidbar.
+
+**2. `--release-session <name>`:** gleiches Lock-/Lade-/Speicher-Muster; entfernt alle Registry-Einträge, deren `session`-Feld `<name>` entspricht; meldet die Anzahl und die betroffenen Pfade. Kein Treffer → klare "nichts zu tun"-Meldung, kein Fehler.
+
+**3. Aktivitäts-Verfall (`_claim_expired_by_activity`):** wird zusätzlich zur bestehenden
+Prüfung (`still_fresh`, `other_still_active`) in den Kollisionspfad von `main()` eingebaut.
+Ein Claim gilt als beendet, wenn ALLE folgenden Bedingungen im belegenden Worktree
+(`entry["session"]` als Worktree-Ordnername, aufgelöst über `git worktree list
+--porcelain`, analog zu `_worktree_still_exists`) zutreffen:
+  - Der aktuelle Inhalt der Datei im belegenden Worktree ist byte-identisch mit dem
+    Inhalt derselben Datei in `origin/main` (`git show origin/main:<pfad>` im
+    Worktree-Kontext, verglichen gegen die lokale Datei — nicht nur "kein Diff zu HEAD",
+    weil ein lokaler Commit ohne Push denselben Effekt hätte).
+  - `git status --porcelain -- <pfad>` im belegenden Worktree meldet für genau diesen
+    Pfad nichts (kein staged/unstaged/untracked Zustand).
+
+  Sicherheitsrichtung: Jeder Fehler bei diesem Zusatz-Check (Worktree-Pfad nicht
+  auflösbar, Git-Befehl schlägt fehl, Timeout, `origin/main` nicht auflösbar) liefert
+  `False` (nicht verfallen) — die bestehende Zeit-/Worktree-Logik bleibt dann unverändert
+  maßgeblich. Der Check wird NUR ausgewertet, wenn die bestehende Logik den Claim ohnehin
+  als aktiv und blockierend einstufen würde (`not same_session and still_fresh and
+  other_still_active`) — er lockert nur zusätzlich, verschärft nie.
+
+**4. Neue Blockade-Meldung:** Der bestehende Text ab `"DATEI-CLAIM-GATE ..."` in `main()`
+ersetzt den Absatz zu `export GZ_FILE_CLAIM_OVERRIDE=1` durch einen Hinweis auf den
+tatsächlich wirksamen Weg: den `--release`-Befehl direkt aufrufen (mit Pfad-Platzhalter,
+analog zum bisherigen Stil). Die `OVERRIDE_ENV`-Prüfung im Code (`os.environ.get(...) ==
+"1"`) bleibt unverändert bestehen (schadet nicht) — nur die Meldung darf sie nicht mehr
+als DEN Ausweg bewerben.
+
+## Expected Behavior
+
+- **Input:** CLI-Aufruf `python3 .claude/hooks/file_claim_gate.py --release <pfad>` bzw.
+  `--release-session <name>`, ausgeführt aus einer beliebigen Session/einem beliebigen
+  Worktree heraus; alternativ der bestehende stdin-JSON-Hook-Aufruf ohne Argumente.
+- **Output:** Bei `--release`/`--release-session`: Klartext-Meldung mit den Details der
+  gelöschten Belegung (oder klare "nichts zu tun"-Meldung). Bei blockierendem Kollisions-Fall:
+  neue Meldung mit `--release`-Hinweis statt `export`-Hinweis.
+- **Side effects:** `.claude/file_claims.json` wird bei `--release`/`--release-session`
+  verändert (Eintrag/Einträge entfernt); bei Aktivitäts-Verfall wird der bestehende
+  Kollisions-Eintrag NICHT automatisch aus der Registry gelöscht (nur die Blockade
+  entfällt für diesen Aufruf) — die nächste `main()`-Ausführung schreibt ohnehin einen
+  frischen Eintrag für die aufrufende Session.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Registry-Eintrag für `<pfad>` existiert (Session A, Branch B,
+  `claimed_at` T) / When `python3 .claude/hooks/file_claim_gate.py --release <pfad>`
+  aufgerufen wird / Then ist der Eintrag aus `file_claims.json` entfernt UND die Ausgabe
+  nennt Session A, Branch B und `claimed_at` T.
+  - Test: `tests/unit/test_file_claim_gate_release.py` — echte temporäre
+    `file_claims.json` mit einem vorbereiteten Eintrag anlegen, Skript per `subprocess.run`
+    mit `--release <pfad>` aufrufen (nicht die interne Funktion importieren und mocken),
+    danach die Registry-Datei erneut laden und prüfen, dass der Schlüssel fehlt, UND die
+    stdout/stderr-Ausgabe auf die drei Detail-Werte prüfen.
+
+- **AC-2:** Given `<pfad>` hat KEINEN Registry-Eintrag / When `--release <pfad>`
+  aufgerufen wird / Then bricht der Aufruf nicht mit Exception/Traceback ab UND die
+  Ausgabe unterscheidet sich erkennbar von der Erfolgsmeldung aus AC-1 (kein
+  irreführendes "gelöscht").
+  - Test: `tests/unit/test_file_claim_gate_release.py` — Aufruf gegen eine leere bzw.
+    Registry ohne den fraglichen Schlüssel, Exit-Code und Ausgabetext prüfen.
+
+- **AC-3:** Given zwei Registry-Einträge mit `session=X` und ein dritter mit
+  `session=Y` / When `--release-session X` aufgerufen wird / Then sind genau die beiden
+  `X`-Einträge aus `file_claims.json` entfernt UND der `Y`-Eintrag ist unverändert
+  vorhanden.
+  - Test: `tests/unit/test_file_claim_gate_release.py` — Registry mit drei Einträgen
+    vorbereiten, Aufruf, Registry danach laden und Schlüsselmenge vergleichen.
+
+- **AC-4:** Given ein Hauptrepo mit Commit auf `origin/main`, ein per `git worktree add`
+  angelegter Worktree (Session-Name = Worktree-Ordnername) mit einem Registry-Eintrag für
+  eine Datei, deren Inhalt im Worktree byte-identisch mit `origin/main` ist und für die
+  `git status --porcelain` im Worktree nichts meldet, UND der Eintrag ist nach der
+  bestehenden Zeit-/Worktree-Logik noch "frisch" und der Worktree existiert noch / When
+  eine andere Session denselben Pfad editiert (stdin-JSON-Hook-Aufruf ohne Argumente) /
+  Then blockiert der Aufruf NICHT (Exit 0, keine Kollisionsmeldung) — Reproduktion des
+  Auslöser-Falls aus Issue #1866.
+  - Test: `tests/unit/test_file_claim_gate_activity_expiry.py` — echtes Temp-Git-Repo,
+    echter Commit, echter `git worktree add`-Linked-Worktree (Vorbild:
+    `tests/tdd/test_validator_log_shared_repo_path.py`, Funktion
+    `_setup_main_with_worktree`); KEIN Mock von Git-Befehlen oder der Registry-Datei.
+
+- **AC-5 (Gegenprobe zu AC-4):** Given denselben Aufbau wie AC-4, ABER die Datei im
+  belegenden Worktree weicht entweder inhaltlich von `origin/main` ab ODER hat eine
+  lokale (unstaged/staged/untracked) Änderung für genau diesen Pfad / When eine andere
+  Session denselben Pfad editiert / Then blockiert der Aufruf weiterhin (Exit 2,
+  bestehende Kollisionsmeldung) — belegt, dass der Aktivitäts-Check nicht zu weit greift.
+  - Test: `tests/unit/test_file_claim_gate_activity_expiry.py` — zwei Varianten: (a)
+    Datei im Worktree lokal verändert und nicht committet, (b) Datei im Worktree
+    committet, aber `origin/main` zeigt eine ältere/andere Fassung (kein Push).
+
+- **AC-6:** Given die bestehende Kollision (Session A blockiert Session B, weder
+  zeitlich noch per Aktivität verfallen) / When die Blockade-Meldung ausgegeben wird /
+  Then enthält sie einen konkreten Hinweis auf `--release <pfad>` als Ausweg UND wirbt
+  NICHT mehr für `export GZ_FILE_CLAIM_OVERRIDE=1` als DEN wirksamen Weg (die Env-Var
+  darf im Code weiter geprüft werden, aber die Meldung darf sie nicht mehr als
+  Haupt-Ausweg nennen).
+  - Test: `tests/unit/test_file_claim_gate_release.py` — echten Kollisionsfall (zwei
+    unterschiedliche Sessions, frischer Claim, Worktree existiert) über stdin-JSON
+    auslösen, stderr-Text auf Vorkommen von `--release` UND auf Nicht-Vorkommen von
+    `GZ_FILE_CLAIM_OVERRIDE` als beworbenem Ausweg prüfen (Text-Assertion auf
+    Verhaltens-Output des Prozesses, kein Dateiinhalt-Check des Quellcodes).
+
+## Known Limitations
+
+- **`edit_gate.py` (Vorschlag 3 aus Issue #1866) wird bewusst NICHT angefasst.** Das
+  liegt im Plugin-Repo `agent-os-openspec`, nicht in `gregor_zwanzig` — Änderungen dort
+  würden alle Repos betreffen, die dieses Plugin nutzen, und liegen außerhalb des
+  Zuschnitts dieses Fixes. Zusätzlich wird die Differenzierung durch Vorschlag 1
+  überflüssig: der Freigabeweg führt nach diesem Fix über `--release`, nicht mehr über
+  eine Änderung an `.claude/settings.local.json`, die `edit_gate.py` ohnehin sperrt.
+- **`--release` hat keinen Zugriffsschutz:** jede Session kann jede fremde Belegung
+  lösen. Das ist beabsichtigt (Zweck ist genau die Behebung von Fehlbelegungen), die
+  Nachvollziehbarkeit entsteht ausschließlich über die ausführliche Ausgabe (Session,
+  Branch, Zeitpunkt) — es gibt keine Protokollierung darüber hinaus (kein Audit-Log).
+- **Aktivitäts-Verfall prüft nur den EINEN beanspruchten Pfad**, nicht den gesamten
+  Worktree-Zustand — eine Datei kann verfallen, während der Worktree insgesamt noch
+  aktiv an anderen Dateien arbeitet. Das ist beabsichtigt: die Granularität des Gates
+  ist ohnehin "eine Datei" (siehe Docstring des bestehenden Codes), der Verfall folgt
+  derselben Granularität.
+- **`git show origin/main:<pfad>` setzt einen aktuellen `origin/main`-Stand voraus** (d.h.
+  ein vorheriges `git fetch`); ist der lokale `origin/main`-Tracking-Branch veraltet, kann
+  der Aktivitäts-Check fälschlich "nicht identisch" ergeben (fail-closed, also die
+  sicherere Richtung) statt fälschlich freizugeben — das ist im Sinne der geforderten
+  Sicherheitsrichtung akzeptabel, aber ein bekanntes Verhalten, kein Fehler.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Das Datei-Claim-Gate ist ein internes Tooling-Gate (Workflow-Absicherung
+  zwischen parallelen Claude-Sessions), keine der in `docs/adr/README.md` genannten
+  Entscheidungsflächen (Kanal/Provider/Framework, Datenmodell/Persistenz-Prinzip,
+  Test-/Deploy-Strategie, bewusste Produktgrenze). Es handelt sich um eine lokale
+  Implementierungsentscheidung im Sinne des ADR-Leitfadens ("Kleine, lokale
+  Implementierungsentscheidungen gehören nicht hierher"). Das Gate selbst trägt bereits
+  ein eigenes Regel-Budget-Prüfdatum (2026-11-11, unverändert durch diesen Fix).
+
+## Changelog
+
+- 2026-08-15: Initial spec created

--- a/tests/unit/test_file_claim_gate_activity_expiry.py
+++ b/tests/unit/test_file_claim_gate_activity_expiry.py
@@ -1,0 +1,265 @@
+"""TDD RED (Issue #1866, Fix-Workflow fix-1866-claim-freigabeweg):
+
+Der Aktivitaets-Verfall (`_claim_expired_by_activity`) fuer das
+Datei-Claim-Gate existiert noch nicht -- ein Claim bleibt aktuell blockierend,
+auch wenn die beanspruchte Datei im belegenden Worktree nachweislich
+unveraendert und deckungsgleich mit `origin/main` ist (genau der Ausloeser-
+Fall aus Issue #1866). Details:
+docs/specs/modules/fix_1866_claim_gate_freigabeweg.md.
+
+Kein Mock-Theater: echtes Temp-Git-Repo, echter Commit, echter
+`git worktree add`-Linked-Worktree, echte `git`-Subprozessaufrufe --
+KEIN Mock von Git-Befehlen oder der Registry-Datei. Vorbild fuer den
+Repo+Worktree-Aufbau: tests/tdd/test_validator_log_shared_repo_path.py,
+Funktion `_setup_main_with_worktree`.
+
+Pfadregel (#1409): der Pruefling wird relativ zur eigenen Testdatei
+aufgeloest (`parents[2]` = Repo-Root bei `tests/unit/<datei>.py`).
+
+Getestete AC: AC-4 (Aktivitaets-Verfall entblockt den Auslöser-Fall),
+AC-5 (Gegenprobe -- lokale Aenderung bzw. Abweichung von origin/main
+blockiert weiterhin).
+
+Hinweis zur RED-Erwartung: AC-4 ist vor der Implementierung ROT (die
+Aktivitaets-Pruefung existiert noch nicht, der Claim blockiert weiterhin).
+Die AC-5-Gegenprobe-Tests pruefen ein Verhalten, das schon HEUTE gilt
+(unveraenderte Zeit-/Worktree-Logik blockiert immer) UND nach der
+Implementierung weiterhin gelten MUSS -- sie sind deshalb bereits vor der
+Implementierung gruen (echte Gegenprobe, keine Zementierung von
+Bestandsverhalten: sie pruefen genau die Grenze, die AC-4 NICHT
+ueberschreiten darf, PO-Regel „Grüner Test in RED zementiert Bestand" gilt
+hier nicht, weil AC-5 bewusst als Nicht-Regressions-Schranke fuer AC-4
+spezifiziert ist).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / ".claude" / "hooks" / "file_claim_gate.py"
+
+_CLAIMED_PATH = "some/file.py"
+_BASELINE_CONTENT = "content-v1\n"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True,
+    )
+
+
+def _run(cwd: Path, stdin_text: str) -> subprocess.CompletedProcess:
+    """Ruft file_claim_gate.py wie der PreToolUse-Hook auf (stdin-JSON, keine
+    CLI-Argumente). `CLAUDE_PROJECT_DIR` wird entfernt, damit
+    `_find_main_repo_root()` das isolierte Temp-Repo findet, nicht das echte
+    Projekt-Repo."""
+    env = os.environ.copy()
+    env.pop("CLAUDE_PROJECT_DIR", None)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT)],
+        cwd=str(cwd),
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env=env,
+    )
+
+
+def _registry_path(main: Path) -> Path:
+    return main / ".claude" / "file_claims.json"
+
+
+def _write_registry(main: Path, data: dict) -> None:
+    reg = _registry_path(main)
+    reg.parent.mkdir(parents=True, exist_ok=True)
+    reg.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _setup_main_with_worktree(tmp_path: Path, create_origin_ref: bool = True) -> tuple[Path, Path]:
+    """Echtes Hauptrepo mit `refs/remotes/origin/main` + echter Linked-
+    Worktree ('session-a') per `git worktree add`. Der Worktree traegt
+    dieselbe Datei wie das Hauptrepo (repo-relativ `some/file.py`), Inhalt
+    zunaechst identisch mit origin/main -- Tests veraendern den Worktree-
+    Zustand danach je nach Szenario (AC-4: unveraendert, AC-5: lokal
+    geaendert bzw. committet-aber-abweichend-von-origin).
+
+    `create_origin_ref=False` (Fail-Closed-Test): `refs/remotes/origin/main`
+    wird bewusst NICHT angelegt -- `git show origin/main:<pfad>` schlaegt
+    dann mit Nicht-Null-Exit fehl und durchlaeuft real den zweiten
+    `except Exception:`-Zweig in `_claim_expired_by_activity`."""
+    main = tmp_path / "main"
+    main.mkdir()
+    _git(main, "init", "-b", "main-line")
+    _git(main, "config", "user.email", "t@t.de")
+    _git(main, "config", "user.name", "Test")
+
+    target = main / _CLAIMED_PATH
+    target.parent.mkdir(parents=True)
+    target.write_text(_BASELINE_CONTENT)
+    (main / "README.md").write_text("# baseline\n")
+    _git(main, "add", "-A")
+    _git(main, "commit", "-m", "baseline")
+
+    if create_origin_ref:
+        head_sha = _git(main, "rev-parse", "HEAD").stdout.strip()
+        _git(main, "update-ref", "refs/remotes/origin/main", head_sha)
+
+    wt_parent = tmp_path / "worktrees"
+    wt_parent.mkdir(parents=True, exist_ok=True)
+    wt = wt_parent / "session-a"
+    _git(main, "worktree", "add", str(wt), "-b", "wt-branch")
+
+    return main, wt
+
+
+def _fresh_collision_registry_entry() -> dict:
+    return {
+        "session": "session-a",
+        "branch": "wt-branch",
+        "claimed_at_epoch": time.time(),
+        "claimed_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _stdin_for(main: Path) -> str:
+    file_path = str(main / _CLAIMED_PATH)
+    return json.dumps({"tool_input": {"file_path": file_path}})
+
+
+# ---------------------------------------------------------------------------
+# AC-4: unveraendert + deckungsgleich mit origin/main -> Claim gilt als
+# verfallen, kein Block (Reproduktion des Ausloeser-Falls aus Issue #1866)
+# ---------------------------------------------------------------------------
+
+def test_unchanged_and_identical_to_origin_main_does_not_block(tmp_path):
+    main, wt = _setup_main_with_worktree(tmp_path)
+    # Worktree-Datei bleibt unveraendert (== origin/main), kein lokaler Diff.
+    status = _git(wt, "status", "--porcelain", "--", _CLAIMED_PATH).stdout
+    assert status == "", (
+        f"Testvoraussetzung: Worktree-Datei muss sauber sein (kein lokaler Diff). "
+        f"status={status!r}"
+    )
+
+    _write_registry(main, {_CLAIMED_PATH: _fresh_collision_registry_entry()})
+
+    result = _run(main, _stdin_for(main))
+
+    assert result.returncode == 0, (
+        f"AC-4: unveraenderte, mit origin/main deckungsgleiche Datei im belegenden "
+        f"Worktree muss den Claim als verfallen behandeln (kein Block). "
+        f"returncode={result.returncode} stderr={result.stderr!r}"
+    )
+    assert "gerade von einer anderen aktiven Session belegt" not in result.stderr, (
+        f"AC-4: darf keine Kollisionsmeldung ausgeben. stderr={result.stderr!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5 (Gegenprobe a): lokale, nicht committete Aenderung im belegenden
+# Worktree -> weiterhin blockierend
+# ---------------------------------------------------------------------------
+
+def test_local_uncommitted_change_still_blocks(tmp_path):
+    main, wt = _setup_main_with_worktree(tmp_path)
+
+    (wt / _CLAIMED_PATH).write_text("content-v1-changed-locally\n")
+    status = _git(wt, "status", "--porcelain", "--", _CLAIMED_PATH).stdout
+    assert status.strip() != "", (
+        f"Testvoraussetzung: lokale Aenderung muss git status als schmutzig zeigen. "
+        f"status={status!r}"
+    )
+
+    _write_registry(main, {_CLAIMED_PATH: _fresh_collision_registry_entry()})
+
+    result = _run(main, _stdin_for(main))
+
+    assert result.returncode == 2, (
+        f"AC-5(a): eine lokale unstaged Aenderung im belegenden Worktree darf den "
+        f"Aktivitaets-Verfall NICHT ausloesen -- weiterhin blockierend. "
+        f"returncode={result.returncode} stderr={result.stderr!r}"
+    )
+    assert "gerade von einer anderen aktiven Session belegt" in result.stderr, (
+        f"AC-5(a): die bestehende Kollisionsmeldung muss weiterhin erscheinen. "
+        f"stderr={result.stderr!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5 (Gegenprobe b): committete Aenderung im belegenden Worktree, aber
+# origin/main zeigt eine aeltere/andere Fassung (kein Push) -> weiterhin
+# blockierend
+# ---------------------------------------------------------------------------
+
+def test_committed_change_diverging_from_origin_main_still_blocks(tmp_path):
+    main, wt = _setup_main_with_worktree(tmp_path)
+
+    (wt / _CLAIMED_PATH).write_text("content-v2-committed-not-pushed\n")
+    _git(wt, "add", "-A")
+    _git(wt, "commit", "-m", "local change, not pushed")
+    status = _git(wt, "status", "--porcelain", "--", _CLAIMED_PATH).stdout
+    assert status == "", (
+        f"Testvoraussetzung: nach dem Commit muss der Worktree fuer diesen Pfad "
+        f"sauber sein. status={status!r}"
+    )
+
+    _write_registry(main, {_CLAIMED_PATH: _fresh_collision_registry_entry()})
+
+    result = _run(main, _stdin_for(main))
+
+    assert result.returncode == 2, (
+        f"AC-5(b): eine committete, aber gegenueber origin/main abweichende Fassung "
+        f"im belegenden Worktree darf den Aktivitaets-Verfall NICHT ausloesen -- "
+        f"weiterhin blockierend. returncode={result.returncode} stderr={result.stderr!r}"
+    )
+    assert "gerade von einer anderen aktiven Session belegt" in result.stderr, (
+        f"AC-5(b): die bestehende Kollisionsmeldung muss weiterhin erscheinen. "
+        f"stderr={result.stderr!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fail-Closed-Nachweis: fehlende `origin/main`-Ref laesst `git show
+# origin/main:<pfad>` real fehlschlagen -> zweiter except-Zweig in
+# `_claim_expired_by_activity` wird durchlaufen -> False (nicht verfallen)
+# -> Kollisionsfall blockiert weiterhin (Adversary-Finding: Sicherheitsrichtung
+# war bislang nicht durch einen Test erzwungen, der den Zweig real erreicht)
+# ---------------------------------------------------------------------------
+
+def test_missing_origin_main_ref_still_blocks(tmp_path):
+    main, wt = _setup_main_with_worktree(tmp_path, create_origin_ref=False)
+    # Worktree-Datei bleibt unveraendert, kein lokaler Diff -- wie AC-4, aber
+    # OHNE origin/main-Ref. Ohne den Fail-Closed-Zweig wuerde ein fehlerhafter
+    # `git show`-Aufruf sonst faelschlich "identisch" (leerer stdout ==
+    # leerer stdout) statt "nicht verfallen" liefern.
+    status = _git(wt, "status", "--porcelain", "--", _CLAIMED_PATH).stdout
+    assert status == "", (
+        f"Testvoraussetzung: Worktree-Datei muss sauber sein (kein lokaler Diff). "
+        f"status={status!r}"
+    )
+    origin_ref = _git(main, "for-each-ref", "refs/remotes/origin/main")
+    assert origin_ref.stdout.strip() == "", (
+        f"Testvoraussetzung: refs/remotes/origin/main darf NICHT existieren. "
+        f"stdout={origin_ref.stdout!r}"
+    )
+
+    _write_registry(main, {_CLAIMED_PATH: _fresh_collision_registry_entry()})
+
+    result = _run(main, _stdin_for(main))
+
+    assert result.returncode == 2, (
+        f"Fehlende origin/main-Ref muss den Fail-Closed-Zweig in "
+        f"_claim_expired_by_activity real durchlaufen (git show origin/main:... "
+        f"schlaegt fehl) -> nicht verfallen -> weiterhin blockierend. "
+        f"returncode={result.returncode} stderr={result.stderr!r}"
+    )
+    assert "gerade von einer anderen aktiven Session belegt" in result.stderr, (
+        f"die bestehende Kollisionsmeldung muss weiterhin erscheinen. "
+        f"stderr={result.stderr!r}"
+    )

--- a/tests/unit/test_file_claim_gate_docs_exemption.py
+++ b/tests/unit/test_file_claim_gate_docs_exemption.py
@@ -1,0 +1,135 @@
+"""TDD (Issue #1878, mitgezogen in Fix-Workflow fix-1866-claim-freigabeweg):
+
+`docs/**` (ausser `docs/specs/**`) ist vom Datei-Claim-Gate ausgenommen -- geteilte
+Referenz-/Feature-Doku wird nie beansprucht. `docs/specs/**` bleibt weiterhin
+beansprucht: eine Spec gehoert waehrend eines laufenden Workflows genau einer Session.
+
+Kein Mock-Theater: `.claude/hooks/file_claim_gate.py` wird per `subprocess.run()`
+aufgerufen (nicht importiert/gepatcht), gegen eine echte temporaere `file_claims.json`
+in einem echten Temp-Git-Repo mit echtem `git worktree add`-Linked-Worktree. Kern-Schicht
+(kein Netz, kein Live-Dienst) -- alle Operationen sind lokal und deterministisch.
+
+Pfadregel (#1409): der Pruefling wird relativ zur eigenen Testdatei aufgeloest
+(`parents[2]` = Repo-Root bei `tests/unit/<datei>.py`), NIE ueber einen
+hartcodierten Hauptrepo-Pfad.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / ".claude" / "hooks" / "file_claim_gate.py"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True,
+    )
+
+
+def _run(cwd: Path, stdin_text: str) -> subprocess.CompletedProcess:
+    """Ruft file_claim_gate.py wie der PreToolUse-Hook auf (stdin-JSON, keine
+    CLI-Argumente). `CLAUDE_PROJECT_DIR` wird entfernt, damit
+    `_find_main_repo_root()` das isolierte Temp-Repo findet, nicht das echte
+    Projekt-Repo."""
+    env = os.environ.copy()
+    env.pop("CLAUDE_PROJECT_DIR", None)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT)],
+        cwd=str(cwd),
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env=env,
+    )
+
+
+def _write_registry(main: Path, data: dict) -> None:
+    reg = main / ".claude" / "file_claims.json"
+    reg.parent.mkdir(parents=True, exist_ok=True)
+    reg.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _setup_collision_repo(tmp_path: Path, claimed_rel_path: str) -> tuple[Path, Path]:
+    """Hauptrepo + echter, per `git worktree add` angelegter Worktree ('session-a')
+    mit einer bereits beanspruchten Datei -- identischer Aufbau wie die AC-6-Tests
+    in test_file_claim_gate_release.py, damit `_worktree_still_exists` eine ECHTE,
+    noch existierende fremde Session sieht."""
+    main = tmp_path / "repo"
+    main.mkdir()
+    _git(main, "init", "-b", "main-line")
+    _git(main, "config", "user.email", "t@t.de")
+    _git(main, "config", "user.name", "Test")
+
+    target = main / claimed_rel_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("content\n")
+    _git(main, "add", "-A")
+    _git(main, "commit", "-m", "baseline")
+
+    wt = tmp_path / "worktrees" / "session-a"
+    wt.parent.mkdir(parents=True)
+    _git(main, "worktree", "add", str(wt), "-b", "wt-branch")
+
+    return main, target
+
+
+def _fresh_collision_registry_entry() -> dict:
+    return {
+        "session": "session-a",
+        "branch": "wt-branch",
+        "claimed_at_epoch": time.time(),
+        "claimed_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# #1878 Fall 1: geteilte Referenz-/Feature-Doku ist ausgenommen -- geht durch
+# ---------------------------------------------------------------------------
+
+def test_docs_reference_file_bypasses_claim_gate(tmp_path):
+    claimed_rel_path = "docs/reference/api_contract.md"
+    main, target = _setup_collision_repo(tmp_path, claimed_rel_path)
+    _write_registry(main, {claimed_rel_path: _fresh_collision_registry_entry()})
+
+    stdin_json = json.dumps({"tool_input": {"file_path": str(target)}})
+    result = _run(main, stdin_json)
+
+    assert result.returncode == 0, (
+        f"#1878: docs/** (ausser docs/specs/**) muss vom Claim-Gate ausgenommen sein, "
+        f"auch bei einer bestehenden fremden Belegung -- kein Block. "
+        f"returncode={result.returncode} stderr={result.stderr!r}"
+    )
+    assert "gerade von einer anderen aktiven Session belegt" not in result.stderr, (
+        f"#1878: darf keine Kollisionsmeldung ausgeben. stderr={result.stderr!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1878 Fall 2 (Gegenprobe): docs/specs/** bleibt beansprucht -- blockiert weiterhin
+# ---------------------------------------------------------------------------
+
+def test_docs_specs_file_still_blocks(tmp_path):
+    claimed_rel_path = "docs/specs/modules/irgendwas.md"
+    main, target = _setup_collision_repo(tmp_path, claimed_rel_path)
+    _write_registry(main, {claimed_rel_path: _fresh_collision_registry_entry()})
+
+    stdin_json = json.dumps({"tool_input": {"file_path": str(target)}})
+    result = _run(main, stdin_json)
+
+    assert result.returncode == 2, (
+        f"#1878 Gegenprobe: docs/specs/** darf NICHT von der Ausnahme erfasst werden -- "
+        f"eine Spec gehoert waehrend eines laufenden Workflows genau einer Session. "
+        f"returncode={result.returncode} stderr={result.stderr!r}"
+    )
+    assert "gerade von einer anderen aktiven Session belegt" in result.stderr, (
+        f"#1878 Gegenprobe: die bestehende Kollisionsmeldung muss weiterhin erscheinen. "
+        f"stderr={result.stderr!r}"
+    )

--- a/tests/unit/test_file_claim_gate_release.py
+++ b/tests/unit/test_file_claim_gate_release.py
@@ -1,0 +1,283 @@
+"""TDD RED (Issue #1866, Fix-Workflow fix-1866-claim-freigabeweg):
+
+Der Freigabeweg fuer das Datei-Claim-Gate (`--release <pfad>`,
+`--release-session <name>`) existiert noch nicht. Die Blockade-Meldung wirbt
+noch fuer `export GZ_FILE_CLAIM_OVERRIDE=1` als Notausgang, der strukturell
+unerreichbar ist (Details: docs/specs/modules/fix_1866_claim_gate_freigabeweg.md).
+
+Kein Mock-Theater: `.claude/hooks/file_claim_gate.py` wird per
+`subprocess.run()` aufgerufen (nicht importiert/gepatcht), gegen eine echte
+temporaere `file_claims.json` in einem echten Temp-Git-Repo. Kern-Schicht
+(kein Netz, kein Live-Dienst) -- alle Operationen sind lokal und
+deterministisch.
+
+Pfadregel (#1409): der Pruefling wird relativ zur eigenen Testdatei
+aufgeloest (`parents[2]` = Repo-Root bei `tests/unit/<datei>.py`), NIE ueber
+einen hartcodierten Hauptrepo-Pfad -- sonst testet dieser Test aus einem
+Worktree heraus die unveraenderte Hauptrepo-Kopie.
+
+Getestete AC: AC-1, AC-2, AC-3, AC-6 (AC-4/AC-5 in
+test_file_claim_gate_activity_expiry.py).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / ".claude" / "hooks" / "file_claim_gate.py"
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True,
+    )
+
+
+def _run(args: list[str], cwd: Path, stdin_text: str = "") -> subprocess.CompletedProcess:
+    """Ruft file_claim_gate.py als echten Subprozess auf. `CLAUDE_PROJECT_DIR`
+    wird bewusst entfernt, damit `_find_main_repo_root()` NICHT das echte
+    Projekt-Repo statt des isolierten Temp-Repos findet (hook_utils.py prueft
+    diese Var vor jeder cwd-basierten Aufloesung)."""
+    env = os.environ.copy()
+    env.pop("CLAUDE_PROJECT_DIR", None)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *args],
+        cwd=str(cwd),
+        input=stdin_text,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env=env,
+    )
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main-line")
+    _git(repo, "config", "user.email", "t@t.de")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "README.md").write_text("# baseline\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "baseline")
+    return repo
+
+
+def _registry_path(repo: Path) -> Path:
+    return repo / ".claude" / "file_claims.json"
+
+
+def _write_registry(repo: Path, data: dict) -> None:
+    reg = _registry_path(repo)
+    reg.parent.mkdir(parents=True, exist_ok=True)
+    reg.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _load_registry(repo: Path) -> dict:
+    return json.loads(_registry_path(repo).read_text(encoding="utf-8"))
+
+
+def _setup_collision_repo(tmp_path: Path) -> tuple[Path, Path]:
+    """Hauptrepo + ein echter, per `git worktree add` angelegter Worktree mit
+    dem Ordnernamen 'session-a' -- damit `_worktree_still_exists` (bestehende
+    Logik) eine ECHTE, noch existierende fremde Session sieht und der
+    Kollisionsfall in main() tatsaechlich (weiterhin) blockiert. AC-6 prueft
+    nur den Meldungstext dieses echten Blockadefalls, nicht die
+    Blockade-Entscheidung selbst."""
+    main = tmp_path / "repo"
+    main.mkdir()
+    _git(main, "init", "-b", "main-line")
+    _git(main, "config", "user.email", "t@t.de")
+    _git(main, "config", "user.name", "Test")
+
+    target = main / "some" / "collide.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("content\n")
+    _git(main, "add", "-A")
+    _git(main, "commit", "-m", "baseline")
+
+    wt = tmp_path / "worktrees" / "session-a"
+    wt.parent.mkdir(parents=True)
+    _git(main, "worktree", "add", str(wt), "-b", "wt-branch")
+
+    return main, target
+
+
+# ---------------------------------------------------------------------------
+# AC-1: --release <pfad> entfernt den Eintrag und nennt Session/Branch/Zeit
+# ---------------------------------------------------------------------------
+
+def test_release_removes_entry_and_reports_details(tmp_path):
+    repo = _init_repo(tmp_path)
+    claimed_at = "2026-08-14T10:00:00+00:00"
+    _write_registry(repo, {
+        "some/file.py": {
+            "session": "session-a",
+            "branch": "feature-a",
+            "claimed_at_epoch": time.time() - 100,
+            "claimed_at": claimed_at,
+        }
+    })
+
+    result = _run(["--release", "some/file.py"], cwd=repo)
+    combined = result.stdout + result.stderr
+
+    assert "session-a" in combined, (
+        f"AC-1: Ausgabe muss die Session des geloeschten Eintrags nennen. "
+        f"combined={combined!r} returncode={result.returncode}"
+    )
+    assert "feature-a" in combined, (
+        f"AC-1: Ausgabe muss den Branch des geloeschten Eintrags nennen. combined={combined!r}"
+    )
+    assert claimed_at in combined, (
+        f"AC-1: Ausgabe muss claimed_at des geloeschten Eintrags nennen. combined={combined!r}"
+    )
+
+    registry = _load_registry(repo)
+    assert "some/file.py" not in registry, (
+        f"AC-1: der Eintrag muss nach --release aus file_claims.json entfernt sein. "
+        f"registry={registry!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2: --release <pfad> ohne bestehenden Eintrag crasht nicht und taeuscht
+# keinen Erfolg vor
+# ---------------------------------------------------------------------------
+
+def test_release_without_existing_claim_reports_clearly_without_crash(tmp_path):
+    repo = _init_repo(tmp_path)
+    _write_registry(repo, {})
+
+    result = _run(["--release", "some/other-file.py"], cwd=repo)
+    combined = result.stdout + result.stderr
+
+    assert "Traceback" not in combined, (
+        f"AC-2: darf nicht mit unbehandelter Exception abbrechen. combined={combined!r}"
+    )
+    assert "kein aktiver Claim" in combined, (
+        f"AC-2: muss klar melden, dass fuer den Pfad kein aktiver Claim existiert "
+        f"('kein aktiver Claim'-Wortlaut aus der Spec). combined={combined!r}"
+    )
+    assert "some/other-file.py" in combined, (
+        f"AC-2: die Meldung muss den angefragten Pfad nennen. combined={combined!r}"
+    )
+    # Darf NICHT wie die Erfolgsmeldung aus AC-1 aussehen (keine erfundenen
+    # Session/Branch-Details einer nicht existierenden Belegung).
+    assert "session-a" not in combined and "feature-a" not in combined, (
+        f"AC-2: darf keine Belegungs-Details vortaeuschen, wenn keiner existiert. "
+        f"combined={combined!r}"
+    )
+
+    registry = _load_registry(repo)
+    assert registry == {}, f"AC-2: Registry darf unveraendert bleiben. registry={registry!r}"
+
+
+# ---------------------------------------------------------------------------
+# F001 (Adversary-Finding, HIGH): --release auf eine KAPUTTE Registry darf
+# NICHT dieselbe "kein aktiver Claim"-Meldung/Exit-Code wie AC-2 liefern --
+# beides waere fuer den Aufrufer nicht unterscheidbar (Spec AC-1 verlangt
+# explizit eine unterscheidbare Fehlermeldung).
+# ---------------------------------------------------------------------------
+
+def test_release_with_corrupt_registry_is_distinguishable_from_no_claim(tmp_path):
+    repo = _init_repo(tmp_path)
+    reg = _registry_path(repo)
+    reg.parent.mkdir(parents=True, exist_ok=True)
+    reg.write_text("{ not valid json", encoding="utf-8")
+
+    corrupt_result = _run(["--release", "some/other-file.py"], cwd=repo)
+
+    combined = corrupt_result.stdout + corrupt_result.stderr
+    assert "Traceback" not in combined, (
+        f"F001: darf nicht mit unbehandelter Exception abbrechen. combined={combined!r}"
+    )
+    assert "kein aktiver Claim" not in combined, (
+        f"F001: darf NICHT wie die 'kein aktiver Claim'-Meldung (AC-2, leere/fehlende Registry) "
+        f"aussehen -- eine kaputte Registry ist ein anderer Fall. combined={combined!r}"
+    )
+    assert "beschaedigt" in combined or "nicht lesbar" in combined, (
+        f"F001: muss erkennbar auf eine defekte/unlesbare Registry hinweisen. combined={combined!r}"
+    )
+    assert corrupt_result.returncode != 1, (
+        f"F001: Exit-Code muss sich von AC-2 ('kein aktiver Claim', Exit 1) unterscheiden. "
+        f"returncode={corrupt_result.returncode}"
+    )
+    assert reg.read_text(encoding="utf-8") == "{ not valid json", (
+        "F001: die kaputte Registry-Datei darf durch den fehlgeschlagenen --release-Versuch "
+        "nicht ueberschrieben werden."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3: --release-session X entfernt NUR die X-Eintraege
+# ---------------------------------------------------------------------------
+
+def test_release_session_removes_only_matching_entries(tmp_path):
+    repo = _init_repo(tmp_path)
+    now = time.time()
+    _write_registry(repo, {
+        "a/one.py": {"session": "sess-x", "branch": "bx", "claimed_at_epoch": now, "claimed_at": "t1"},
+        "a/two.py": {"session": "sess-x", "branch": "bx", "claimed_at_epoch": now, "claimed_at": "t2"},
+        "b/three.py": {"session": "sess-y", "branch": "by", "claimed_at_epoch": now, "claimed_at": "t3"},
+    })
+
+    result = _run(["--release-session", "sess-x"], cwd=repo)
+    combined = result.stdout + result.stderr
+
+    assert "2" in combined, (
+        f"AC-3: Ausgabe muss die Anzahl der entfernten Eintraege (2) nennen. combined={combined!r}"
+    )
+    assert "a/one.py" in combined and "a/two.py" in combined, (
+        f"AC-3: Ausgabe muss die betroffenen Pfade nennen. combined={combined!r}"
+    )
+
+    registry = _load_registry(repo)
+    assert set(registry.keys()) == {"b/three.py"}, (
+        f"AC-3: nur sess-x-Eintraege duerfen entfernt werden, sess-y bleibt unveraendert. "
+        f"registry={registry!r}"
+    )
+    assert registry["b/three.py"]["session"] == "sess-y", (
+        f"AC-3: der verbleibende Eintrag darf nicht veraendert sein. registry={registry!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-6: Blockade-Meldung wirbt fuer --release, nicht mehr fuer
+# GZ_FILE_CLAIM_OVERRIDE als DEN wirksamen Ausweg
+# ---------------------------------------------------------------------------
+
+def test_blocking_message_advertises_release_not_env_override(tmp_path):
+    main, target = _setup_collision_repo(tmp_path)
+    _write_registry(main, {
+        "some/collide.py": {
+            "session": "session-a",
+            "branch": "wt-branch",
+            "claimed_at_epoch": time.time(),
+            "claimed_at": datetime.now(timezone.utc).isoformat(),
+        }
+    })
+
+    stdin_json = json.dumps({"tool_input": {"file_path": str(target)}})
+    result = _run([], cwd=main, stdin_text=stdin_json)
+
+    assert result.returncode == 2, (
+        f"Testvoraussetzung fuer AC-6: ein echter, frischer Kollisionsfall mit "
+        f"existierendem Fremd-Worktree muss weiterhin blockieren. "
+        f"returncode={result.returncode} stderr={result.stderr!r}"
+    )
+    assert "--release" in result.stderr, (
+        f"AC-6: die Blockade-Meldung muss auf `--release <pfad>` als wirksamen Ausweg "
+        f"verweisen. stderr={result.stderr!r}"
+    )
+    assert "GZ_FILE_CLAIM_OVERRIDE" not in result.stderr, (
+        f"AC-6: die Blockade-Meldung darf GZ_FILE_CLAIM_OVERRIDE nicht mehr als "
+        f"Haupt-Ausweg bewerben (der env-Check im Code darf bestehen bleiben, nur "
+        f"die Meldung nicht mehr dafuer werben). stderr={result.stderr!r}"
+    )


### PR DESCRIPTION
Der dokumentierte Notausgang (export GZ_FILE_CLAIM_OVERRIDE=1) ist strukturell
unerreichbar, weil der Hook als eigener Prozess pro PreToolUse-Aufruf läuft.
Neuer Weg: `--release <pfad>` / `--release-session <name>` als CLI-Aufruf,
der die geteilte Registry direkt bearbeitet.

Zusätzlich verfällt ein Claim automatisch, wenn die Datei im belegenden
Worktree byte-identisch mit origin/main und ohne lokale Änderung ist — der
Auslöser-Fall aus #1866. Jeder Fehler beim Zusatz-Check bleibt fail-closed
(nicht verfallen).

Adversary-Findings behoben:
- F001: kaputte Registry wurde bei --release wie "kein Claim" behandelt,
  jetzt unterscheidbare Fehlermeldung (_load_registry_strict)
- F002: Fail-Closed-Pfade in _claim_expired_by_activity waren ungetestet,
  jetzt per fehlendem origin/main-Ref abgesichert + Mutationsgegenprobe

Scope-Erweiterung (User bestätigt, #1878): docs/** (außer docs/specs/**)
wird nie beansprucht — Prosa-Konflikte werden beim Mergen sichtbar und sind
trivial aufzulösen, die Sperre kostete dort viel und verhinderte wenig.

Closes #1866

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XkcADMkLBm15RZTFCusycW
