### PR TITLE
fix(#1765 B1): Vergleichs-Vorschau verarbeitet Orte gleichzeitig statt nacheinander

### DIFF
--- a/docs/context/fix-1765-compare-vorschau-parallel.md
+++ b/docs/context/fix-1765-compare-vorschau-parallel.md
@@ -1,0 +1,398 @@
+# Context: Vergleichs-Vorschau parallelisieren (#1765, Scheibe B1)
+
+**Erstellt:** 2026-08-15 · **Workflow:** `fix-1765-compare-vorschau-parallel` · **Track:** Full Process
+
+## Request Summary
+
+Die Vergleichs-Vorschau (`POST /api/preview/compare/{preset_id}`) verarbeitet Orte seriell
+(~25 s je Ort) und reißt bei 3+ Orten die 60-s-Grenze. Scheibe B1 parallelisiert die
+Ortsverarbeitung nach dem Vorbild `stage_weather.py:173` und schließt damit **#1765**.
+Der Trip-Pfad (#1839) folgt getrennt als B2.
+
+## Verhältnis zum Bestandsdokument
+
+`docs/context/fix-1765-1839-vorschau-laufzeit.md` ist die gemeinsame Ursachen- und
+Messgrundlage beider Scheiben (U1–U4, Laufzeitmessungen, Risiken R1–R6, Variantenbewertung
+V1/V2/V3). **Es bleibt gültig und wird hier nicht wiederholt.** Dieses Dokument trägt nur
+das, was für B1 neu gemessen wurde — einschließlich **zweier Korrekturen** an den dort
+notierten Annahmen.
+
+### Korrektur 1: `_tf_instance` ist bereits abgesichert — fällt aus B1 raus
+
+Die Gegenmaßnahmen-Tabelle des Bestandsdokuments (Zeile 417-426) führt „`_tf_instance`
+doppelt geladen → Lock nach Vorbild `weather_cache.py`" als offene Aufgabe für Scheibe B.
+**Das ist erledigt.** `src/utils/timezone.py:21-34` nutzt heute doppelt geprüftes Sperren
+(`_tf_lock`), ausdrücklich nach dem Muster `weather_cache.py:294-305`; der Regressionstest
+`tests/unit/test_timezone_singleton_threadsicher.py:72-124` erzwingt per `threading.Barrier`,
+dass zwei gleichzeitige Erstzugriffe genau **eine** Instanz erzeugen. `_get_tf()` darf
+unverändert aus dem Pool heraus aufgerufen werden.
+
+### Korrektur 2: Der Reihenfolge-Nachweis existiert **nicht** am Wirkort
+
+Dieselbe Tabelle verbucht „Reihenfolge kippt → `tests/unit/test_compare_location_order.py`
+(Compare)" als vorhandene Absicherung. **Das trifft nicht zu.** Der Test baut
+`ComparisonResult`-Objekte **von Hand** (`_result()`, Zeile 85-91) und prüft ausschließlich
+die vier Renderer-Oberflächen (`test_compare_location_order.py:134,160,213`). Die Stelle, an
+der eine Parallelisierung die Reihenfolge kippen würde — das Zusammenführen der
+Ortsergebnisse —, liegt **davor** und ist ungeprüft. Es existiert **kein** Test, der nach
+einem echten `ComparisonEngine.run()` mit mehreren Orten die Reihenfolge von
+`ComparisonResult.locations` behauptet. Der Nachweis für B1 ist **neu zu bauen**, nicht
+vorhanden.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/compare_preview_service.py:163` | **Änderungsort** — einziger `ComparisonEngine.run()`-Aufruf des Vorschaupfads, innerhalb `_prepare()` (129-178) |
+| `src/services/comparison_engine.py:127` | Ortsschleife `for loc in locations` — **bleibt unangetastet** (Variante V3 „außen") |
+| `src/services/comparison_engine.py:387-391` | Konstruktion des `ComparisonResult` **nach** der Schleife |
+| `src/app/user.py:117-164` | `LocationResult` — rein ortsspezifisch, 25 Felder |
+| `src/app/user.py:168-189` | `ComparisonResult` — 4 Felder + 2 Properties (Merge-Analyse unten) |
+| `src/services/stage_weather.py:52-57, 164-183` | **Vorbild** — Wrapper `_fetch_one`, flache Liste, `[None] * len(flat)`, `future_to_idx` |
+| `src/providers/call_log.py:41-53, 56-64` | **R1** — 11 Marker, `inspect.stack()[:25]` des ausführenden Threads |
+| `src/services/official_alerts/warn_egress.py:55-57` | **ContextVar-Vorbild im Repo** — „ContextVar isoliert korrekt ueber Threads/Tasks" |
+| `src/services/official_alerts/dpc.py:52,160-165` | **neues Risiko R7** — fixer nationaler Cache-Key (Italien), ungelockt |
+| `src/services/official_alerts/vigilance.py:57-58,93-94` | **neues Risiko R7** — fixer Cache-Key `"national"` (Frankreich), ungelockt |
+| `src/services/official_alerts/meteoalarm_budget.py:228-263` | Tageskontingent, `fcntl`-gesichert — begrenzt den Schaden aus R7 |
+| `src/services/scheduler_dispatch_service.py:451` | zweite Call-Site (**Versand**) — Zuschnittfrage |
+| `api/routers/compare.py:25-77` | dritte Call-Site (**Sofortvergleich**, öffentlich) — Zuschnittfrage |
+| `internal/handler/preview_proxy.go:52` | Go-Timeout Vergleichs-Vorschau 60 s == nginx 60 s |
+
+## Merge-Analyse: was beim Zusammenführen von N Teilergebnissen passiert
+
+Der Vorschaudienst hat **keine eigene Ortsschleife** — er ruft `ComparisonEngine.run()`
+**einmal** mit der vollen Liste auf (`compare_preview_service.py:163`). „Außen"
+parallelisieren heißt deshalb: N Aufrufe `run(locations=[loc])` und N `ComparisonResult`
+zu einem zusammenführen. Feld für Feld am Code geprüft:
+
+| Feld | Merge-Verhalten | Begründung |
+|---|---|---|
+| `locations` | **positionstreu** zusammensetzen | einzige Stelle, an der die konfigurierte Reihenfolge lebt (`user.py:175`); Fertigstellungsreihenfolge ist bei ~25 s/Ort zufällig |
+| `time_window` | trivial — bei allen N identisch | `run()`-Parameter (`comparison_engine.py:98`), nicht aus Orten abgeleitet |
+| `target_date` | trivial — bei allen N identisch | `run()`-Parameter (`comparison_engine.py:100`) |
+| `created_at` | **explizit einmal setzen**, vor dem Start der Parallel-Aufrufe | `field(default_factory=datetime.now)` (`user.py:171`) — heute ein Zeitstempel je Lauf, bei N Aufrufen N verschiedene. „Nimm den ersten" hinge an der Einreichungsreihenfolge. Verbraucht in `output/renderers/comparison.py:216` („Erstellt: …") |
+| `winner` | **kein Merge-Code** | `@property` (`user.py:180-184`), live aus `self.locations`: erster fehlerfreier Ort in konfigurierter Reihenfolge — keine ortsübergreifende Bewertung |
+| `valid_locations` | **kein Merge-Code** | `@property` (`user.py:186-189`), reiner Filter |
+
+**Fazit:** Genau **zwei** Merge-Entscheidungen — Reihenfolge und `created_at`. Es gibt kein
+gespeichertes Aggregat über alle Orte; die Score-Sortierung ist seit #1359 entfernt
+(`comparison_engine.py:383-386`).
+
+## Äquivalenz von `run(locations=[loc])` je Ort — am Code geprüft
+
+- `run()` ist `@staticmethod`, `ComparisonEngine` hat **keine** Instanzattribute
+  (`comparison_engine.py:97`). `settings` und `results` sind lokal je Aufruf (`:121-125`).
+- **Fehler je Ort sind bereits gekapselt:** `comparison_engine.py:130-147` (Fetch) und
+  `:369-381` (alles übrige) fangen intern ab und erzeugen `LocationResult(error=…)`.
+  `run()` wirft für einen Ortsfehler **nie** nach außen ⇒ die Best-effort-Semantik ist gratis;
+  ein Wrapper wie `stage_weather.py:52-57` schützt nur noch gegen Unerwartetes **vor** der
+  Schleife (z. B. `Settings()`-Konstruktion).
+- **Provider werden ohnehin je Ort neu gebaut und geschlossen** (`comparison_engine.py:414`
+  über `get_provider()`, `providers/base.py:238`; `close()` bei `:425-426`) ⇒ keine
+  Wiederverwendung geht verloren.
+- Mehrkosten: `Settings()` wird N- statt einmal konstruiert (`:121-124`) — rein lesend.
+
+## Existing Patterns
+
+**Das Vorbild** (`src/services/stage_weather.py:170-183`) — vollständig zu übernehmen:
+
+```python
+flat = [(stage.id, seg) for stage in stages for seg in segments_by_stage[stage.id]]
+fetched: list[Optional[SegmentWeatherData]] = [None] * len(flat)
+if flat:
+    with ThreadPoolExecutor(max_workers=min(len(flat), 8)) as executor:
+        future_to_idx = {executor.submit(_fetch_one, …): idx for idx, … in enumerate(flat)}
+        for future, idx in future_to_idx.items():
+            fetched[idx] = future.result()
+```
+
+Vier Bestandteile: flache Liste vor dem Pool · Deckel `min(len, N)` · **indexierte
+Vorbelegung** statt Append bei Fertigstellung · dünner Wrapper `_fetch_one`
+(`stage_weather.py:52-57`) als Fehler-Grenze. Spezifiziert in
+`docs/specs/modules/stage_weather_python_endpoint.md:57`.
+
+**ContextVar-Vorbild** (`src/services/official_alerts/warn_egress.py:55-57`):
+`contextvars.ContextVar(..., default=None)` mit Getter/Setter-Paar. Kommentar dort:
+„ContextVar isoliert korrekt ueber Threads/Tasks."
+
+⚠️ **`ThreadPoolExecutor` vererbt den contextvars-Kontext NICHT automatisch** (anders als
+asyncio). Der Übergang muss explizit erfolgen — `contextvars.copy_context().run(...)` im
+Worker oder Wert manuell durchreichen. Wer die ContextVar nur im Hauptthread setzt und im
+Worker liest, bekommt still den Default zurück.
+
+## Dependencies
+
+**Upstream:** `ComparisonEngine.run` → `fetch_forecast_for_location` → `ForecastService` /
+`OpenMeteoProvider` → `_enrich_thunder` (`dwd`/`dwd_eu`/`meteofrance`) · `BergfexScraper` ·
+`get_official_alerts_with_status` · `ThunderWindowCache` · `call_log`.
+
+**Downstream — `ComparisonEngine.run()` hat DREI unabhängige Produktiv-Aufrufstellen:**
+
+| Call-Site | Weg | Grenze | von B1 erfasst? |
+|---|---|---|---|
+| `compare_preview_service.py:163` | Vorschau (der gemeldete Fall) | Go 60 s == nginx 60 s (`preview_proxy.go:52`) | **ja** |
+| `scheduler_dispatch_service.py:451` | Versand (`POST /api/scheduler/compare-presets/{id}/send`, auch Cron-Loop `:145`) | nginx 60 s | offen — s. Zuschnittfrage |
+| `api/routers/compare.py:71` | Sofortvergleich `GET /api/compare` (Rest der NiceGUI-Zeit, **öffentlich** über `router.go:156` erreichbar, bewusst nicht entfernt) | Go 60 s == nginx 60 s (`proxy.go:77`) | offen — s. Zuschnittfrage |
+
+Alle drei durchlaufen dieselbe serielle Schleife `comparison_engine.py:127` und reißen bei
+3+ Orten dieselbe Wand. **Geteilt ist heute nur `order_locations_by_ids()`**
+(`compare_preview_service.py:242-254`, genutzt auch in `scheduler_dispatch_service.py:100-102,421`)
+— die Call-Sites selbst sind unabhängig voneinander.
+
+## Existing Specs
+
+| Spec | Bezug |
+|---|---|
+| `docs/specs/modules/stage_weather_python_endpoint.md:57,126-129` | **Vorbild**; hält fest: kein neuer ADR nötig, ADR-0015 deckt es ab |
+| `docs/specs/modules/compare_location_order.md` | Zusicherung: `ComparisonResult.locations` in Eingabereihenfolge, alle vier Oberflächen folgen ihr |
+| `docs/specs/modules/fix_1765_1839_sa_vorschau_entblockung.md:190-258` | Scheibe A, Abgrenzung zu B |
+| `docs/specs/modules/compare_channel_preview_dispatch.md` | Vergleichs-Vorschau + Versand |
+| `docs/specs/modules/fix_1329_forecast_cache_budget.md:399-407` | U4 (fehlender Cache) — **bewusst zurückgestellt, nicht Teil von B1** |
+
+**ADR:** kein neues nötig. ADR-0015 (Python ist Owner der Wetter-Domäne) deckt die
+Parallelisierung ab — derselbe Präzedenzfall wie beim Stage-Weather-Endpunkt. Ein eigenes
+ADR zu Nebenläufigkeit existiert nicht (`docs/adr/README.md` ohne Treffer für
+„async"/„Threadpool"/„Event-Loop"). **Aber:** griffe die Umsetzung **innerhalb**
+`comparison_engine.py` ein (Variante V1, träfe Versand und Alarme mit), wäre das eine
+Vorwegnahme aus #1539 und ADR-würdig. V3 „außen" braucht das nicht.
+
+## Bestehende Verträge, die B1 nicht brechen darf
+
+| Nachweis | Zusicherung |
+|---|---|
+| `tests/unit/test_preview_fehlerformen.py:97,117,130` | 404 / 422 / 503 des Vorschau-Endpunkts bleiben formgleich |
+| `tests/unit/test_event_loop_bleibt_frei.py:147-221` | **Scheibe-A-Ratsche:** `/health` bleibt während einer laufenden Vergleichs-Vorschau erreichbar |
+| `tests/unit/test_compare_location_order.py` | Renderer-Reihenfolge über alle vier Oberflächen |
+| `docs/specs/modules/compare_location_order.md` | Ausgabereihenfolge = konfigurierte Preset-Reihenfolge |
+
+🔴 **Ein Vertrag muss bewusst abgelöst werden:**
+`tests/tdd/test_compare_preview_service.py:285-311` sichert zu, dass `ComparisonEngine.run`
+**genau einmal** je `render_all_channels()` läuft (`calls.count == 1`), verankert als AC-7 im
+Docstring `compare_preview_service.py:52-55`. Nach der Parallelisierung sind es N Aufrufe —
+der Test wird rot. Die B1-Spec muss diesen Vertrag ausdrücklich ersetzen (Zusicherung neu
+formulieren: *ein* Engine-Lauf **je Ort**, nicht *ein* Lauf je Ort**menge**), sonst blockiert
+eine Bestandsratsche zu Recht. Weitere Tests derselben Datei (`:332,371,400`) prüfen die
+Durchreichung von `time_window`/`forecast_hours` und müssen nach dem Umbau **je Ort**
+weiterhin greifen — sie sind der Nachweis, dass die Parameter beim Aufteilen nicht verloren
+gehen.
+
+## Risks & Considerations
+
+- **R1 (belegt) — `call_log` verliert die Quelle im Threadpool.**
+  `resolve_call_source()` (`call_log.py:56-64`) liest `inspect.stack()[:25]` des
+  **ausführenden** Threads; im Worker fehlen alle 11 Marker (`call_log.py:41-53`), das Journal
+  bucht `"unbekannt"`. Kein Bestandstest prüft die Auflösung aus einem fremden Thread
+  (geprüft: `test_bug_338_openmeteo_call_counter.py:152,175,199` rufen im Hauptthread auf).
+  Belegt statt vermutet: Das Diagnose-Journal zeigt 7,4 % `unbekannt` mit einem Cluster beim
+  bereits parallelisierten `stages-weather`. **Gegenmaßnahme:** ContextVar-Override **vor**
+  der Stack-Inspektion, Marker als Rückfall — plus expliziter Kontext-Übergang in den Worker.
+- **R3 — Reihenfolge.** Indexierte Vorbelegung; Nachweis **neu** (s. Korrektur 2). Der Test
+  muss die Fertigstellungsreihenfolge künstlich gegen die Einreichungsreihenfolge drehen,
+  sonst prüft er nichts.
+- **R7 (neu) — Thundering Herd bei national geschlüsselten Warndiensten.**
+  `dpc.py:52` (Italien) und `vigilance.py:57-58` (Frankreich) cachen mit **einem festen
+  Schlüssel für alle Orte**, ungelockt nach „check-then-act" (`warn_egress.py:351,375,436…`).
+  Solange die Orte seriell liefen, war der zweite Ort ein Cache-Treffer. Parallel sehen alle
+  gleichzeitig einen Miss und lösen **redundante** Abrufe gegen denselben nationalen Endpunkt
+  aus — gegen ein budgetiertes Tageskontingent (`meteoalarm_budget.py:228-263`, `fcntl`-fest,
+  begrenzt den Schaden). Keine Datenkorruption, aber eine Lastspitze, die es vorher nicht gab.
+  Betrifft FR-/IT-Orte, für den Karnischen Höhenweg (AT/DE) nicht. Dieselbe Lücke ist für den
+  Kachel-Cache dokumentiert: `decision_matrix.md:246-254` nennt sie ausdrücklich als „bislang
+  folgenlos, weil alle Aufrufer sequentiell liefen".
+- **R2 — Höflichkeit gegenüber den Amtsdiensten.** Météo-France: **100 Anfragen/Minute auf
+  ein gemeinsames Konto für alle Nutzer**, keine aktive Drosselung
+  (`decision_matrix.md:231-254`). Parallelitätsgrad deshalb **unter** dem Vorbild ansetzen
+  (Vorbild `min(len, 8)` → hier `min(len(locations), 4)`), als benannte Konstante mit Verweis.
+- **R6 — Timeout-Leiter** (Go 60 s == nginx 60 s, kein Puffer) bleibt Sache von B2; bei 3–4
+  Orten parallel liegt die Laufzeit bei ~26 s und damit deutlich unter der Wand.
+- **Bereits erledigt, kein Risiko mehr:** `_tf_instance` (s. Korrektur 1) ·
+  `ThunderWindowCache` (`thunder_window_cache.py:58-62`, Lock ausdrücklich für die
+  Parallelisierung der Ortsschleife gebaut) · `WeatherCacheService`
+  (`weather_cache.py:91`, Instanz-Lock) · `lru_cache` in `department_mapper.py:335`
+  (intern gelockt) · `meteoalarm_budget.py` (`fcntl`) · Provider-Registry
+  `providers/base.py:190` (idempotente Writes unter dem GIL).
+
+## Gates, die bei den Änderungsdateien greifen
+
+| Gate | greift? |
+|---|---|
+| `touched_tests_gate.py` | **ja** — `compare_preview_service.py` → `tests/unit/test_compare_channel_metrics_reach_the_renderer.py`, `test_compare_mail_blocks.py`; `call_log.py` → `test_diagnostics_path_resolution.py`, `test_radar_nowcast_cache_sharing.py` (Letzteres ein Fehltreffer: „call_log" ist dort nur eine lokale Variable) |
+| `pendant_gate.py` | **nein** bei Änderungen an Bestandsdateien — nur bei **Neuanlagen** in den einseitigen Bereichen. Relevant nur, falls B1 eine neue compare-only-Datei anlegt |
+| `renderer_mail_gate.py` | **nein** — keine der Änderungsdateien fällt unter `_MAIL_PATTERNS` |
+| `architecture_guard.py` / `domain_pattern_guard.py` | laufen mit, schlagen aber nur bei neuen Wettermetrik-Berechnungen an — B1 führt keine ein |
+
+## Analysis
+
+### Type
+
+Bug (#1765) — nutzersichtbares Fehlverhalten, Ursache gemessen, Behebung ist eine
+Umstrukturierung ohne fachliche Verhaltensänderung.
+
+### Zuschnitt-Entscheidung (Tech-Lead-Entscheid 2026-08-15, vom PO delegiert)
+
+**Geteilter Baustein bauen, aber in diesem Schnitt nur die Vorschau umstellen.**
+Zwei Schnitte, beide unter #1765; **erst der zweite schließt das Ticket.**
+
+| | dieser Schnitt (B1) | Folgeschnitt (B1b) |
+|---|---|---|
+| Baustein `comparison_parallel.py` | **bauen**, an neutraler Stelle | benutzen |
+| `call_log`-ContextVar | **bauen** | — |
+| Call-Site A (Vorschau) | **umstellen** | — |
+| Call-Site B (Versand) | — | umstellen + `top_ort`-Nachweis |
+| Call-Site C (Sofortvergleich) | — | umstellen |
+| Cron-Lastfrage (unten) | entfällt | dort zu entscheiden |
+| schließt #1765 | nein | **ja** |
+
+**Warum nicht alles in einem Schnitt** — obwohl der Ticketkommentar vom 2026-08-12 den Befund
+ausdrücklich auf „jeder Weg, der die Ortsschleife synchron hinter nginx durchläuft" erweitert
+(mit gemessenem 504 im Versand bei vier Orten) und die Mechanik in allen drei Fällen
+nachweislich identisch ist: Die **Betriebsrisiken der drei Pfade sind es nicht.**
+
+| | Vorschau (A) | Versand (B) |
+|---|---|---|
+| Auslöser | interaktiv, ein Mensch | Cron, unbeaufsichtigt |
+| Gleichzeitigkeit | eine Sitzung | mehrere Nutzer (s.u.) |
+| schreibt Zustand | nein | `letzter_versand`, Alarm-Anker, Snapshots |
+| Fehlerfolge | Nutzer sieht Fehler, lädt neu | Briefing falsch/ausgefallen, unbemerkt |
+| auf Staging prüfbar | direkt, in Sekunden | nur mit Aufwand |
+
+Nebenläufigkeit wird nicht gleichzeitig in einen beaufsichtigten und einen unbeaufsichtigten
+Pfad eingeführt — der unbeaufsichtigte bekommt sie, wenn der beaufsichtigte sie nachweislich
+trägt. Der Baustein wird deshalb **sofort geteilt** angelegt (nicht in
+`compare_preview_service.py`), damit B1b nur noch Call-Sites umhängt und nichts umbaut.
+
+Zwei Nebenwirkungen stützen die Reihenfolge: (1) Das Cron-Lastrisiko entsteht ausschließlich
+in B — es stellt sich in B1b, dann mit Betriebsdaten aus A statt mit einer Schätzung.
+(2) Die `call_log`-Reparatur wirkt sofort **prozessweit**, nicht nur im Vergleich: der Mangel
+ist mit 7,4 % `unbekannt` belegt und stammt aus dem bereits parallelen `stage_weather`-Pfad.
+
+**Für B1b vorgemerkt — Cron-Überlagerung.** Der Cron-Endpunkt
+`POST /api/scheduler/compare-presets-daily` (`api/routers/scheduler.py:186-201`) ist `def`
+und läuft **heute schon** je `user_id` nebeneinander im Starlette-Threadpool. Kommt dort die
+Ortsparallelität hinzu, addieren sich die gleichzeitigen Außenanfragen **über Nutzer hinweg**.
+Für Météo-France (100 Anfragen/Minute, gemeinsames Konto, ungedrosselt) fängt die Deckelung
+je Preset das nicht ab. Die tatsächliche Gleichzeitigkeit mehrerer FR-Presets am selben
+Cron-Tick ist eine Betriebsfrage, aus dem Code **nicht** ablesbar — in B1b zu entscheiden,
+nicht hier zu schätzen.
+
+### Technischer Ansatz
+
+**Neues Modul `src/services/comparison_parallel.py`** (nicht in `comparison_engine.py`, nicht
+in `compare_preview_service.py`). Grund für die eigene Datei: Die Zusicherung
+„`comparison_engine.py` unangetastet" wird so mechanisch prüfbar statt argumentativ, und der
+Baustein liegt neutral genug, dass Versand und Sofortvergleich ohne Umweg andocken.
+
+```python
+def run_comparison_parallel(
+    locations, time_window, target_date,
+    forecast_hours=COMPARE_FORECAST_HOURS, profile=None,
+    official_alerts_enabled=True, *, call_source=None,
+) -> ComparisonResult
+```
+
+Ablauf nach dem Vorbild `stage_weather.py:170-183`:
+
+1. `created_at = datetime.now()` **einmal**, vor dem Start der Futures.
+2. `fetched: list[Optional[LocationResult]] = [None] * len(locations)`.
+3. `ThreadPoolExecutor(max_workers=min(len(locations), MAX_PARALLEL_LOCATIONS))`,
+   `future_to_idx`-Abbildung — **indexierte Rückgabe**, kein Append bei Fertigstellung.
+4. Worker-Wrapper je Ort: setzt die `call_log`-Quelle im **eigenen** Thread, ruft
+   `ComparisonEngine.run(locations=[loc], …)` mit den unveränderten Parametern auf und gibt
+   `result.locations[0]` zurück. Fehler werden wie in `stage_weather.py:52-57` gekapselt.
+5. `ComparisonResult(locations=fetched, time_window=…, target_date=…, created_at=created_at)`.
+
+`MAX_PARALLEL_LOCATIONS = 4` als benannte Konstante mit Verweis auf
+`decision_matrix.md:231-254` — **bewusst unter** dem Vorbild (`min(len, 8)`), weil das
+Météo-France-Konto geteilt und ungedrosselt ist.
+
+**🔴 Korrektur an der Strategie-Vorlage: ContextVar, nicht durchgereichter Parameter.**
+Die Strategiebewertung schlug vor, die Quelle als Funktionsargument bis zu
+`resolve_call_source()` durchzureichen, und hielt das für den billigeren Weg. Am Code
+gegengeprüft: `resolve_call_source()` hat genau **zwei** Aufrufer —
+`src/providers/openmeteo.py:558` (Thin-Wrapper der Provider-Instanz) und `call_log.py:84`
+(modulintern). Der Aufruf liegt also **tief im Provider**, nicht im Wrapper. Ein Parameter
+müsste durch `ComparisonEngine.run` → `fetch_forecast_for_location` → `get_provider` →
+`OpenMeteoProvider` gereicht werden — genau den Bestandscode anfassen, den der Zuschnitt
+„außen" unberührt lassen soll.
+
+Die ContextVar ist deshalb hier die **kleinere** Änderung, und sie braucht **kein**
+`copy_context()`: Der Worker setzt sie in seinem **eigenen** Thread, bevor er `run()` aufruft;
+`resolve_call_source()` liest sie tief unten aus demselben Thread. Nötig ist ein
+Context-Manager mit `reset(token)` — `ThreadPoolExecutor` verwendet Threads wieder, ein nicht
+zurückgesetzter Wert würde in den nächsten Task lecken. Vorbild inklusive Setter/Getter-Paar:
+`warn_egress.py:55-57,60-66`. Umfang: ContextVar + Override-Prüfung **vor** der
+Stack-Inspektion + Context-Manager, die 11 Bestandsmarker bleiben Rückfall.
+
+### Affected Files
+
+| Datei | Änderung | Begründung |
+|---|---|---|
+| `src/services/comparison_parallel.py` | **CREATE** | geteilter Baustein: Executor, indexierte Rückgabe, `created_at`-Fixierung, Quellen-Override je Worker |
+| `src/providers/call_log.py` | MODIFY | ContextVar + Context-Manager, Prüfung **vor** `inspect.stack()`; Marker bleiben Rückfall |
+| `src/services/compare_preview_service.py:163` | MODIFY | Call-Site A → Baustein |
+| `tests/tdd/test_compare_preview_service.py:285-311` | MODIFY | AC-7-Vertrag ablösen: ein Engine-Lauf **je Ort** statt einer je Ortsmenge |
+| `tests/unit/test_comparison_parallel.py` | **CREATE** | Nachweise (a),(b),(d),(e) am Baustein |
+| `tests/unit/test_call_source_ueber_threadgrenze.py` | **CREATE** | Nachweis (c) — Quellenauflösung im Worker-Thread |
+
+`comparison_engine.py`: **unangetastet** — mechanisch prüfbar.
+`scheduler_dispatch_service.py:451` und `api/routers/compare.py:71`: **nicht in diesem
+Schnitt** (B1b) — sie behalten ihren heutigen `ComparisonEngine.run()`-Aufruf unverändert.
+
+### Scope Assessment
+
+| | Produktivcode | Test |
+|---|---|---|
+| Baustein `comparison_parallel.py` | ~40 LoC | |
+| `call_log`-ContextVar + Context-Manager | ~15 LoC | |
+| Call-Site A umstellen | ~10 LoC | |
+| Nachweise (a),(b),(c),(d),(e) | | ~120–150 LoC |
+| AC-7-Vertrag umbauen (Ersatz, kein Neubau) | | ~20–30 LoC |
+| **Summe** | **~65 LoC** | **~140–180 LoC** |
+
+**Gesamt ~205–245 LoC — unter dem 250er-Limit, ohne Override.** Der Nachweis (f)
+(`top_ort` im Versandpfad) entfällt hier und gehört zu B1b.
+Treiber ist auch so der **Nachweis**, nicht der Mechanismus.
+Risk Level: **MEDIUM** (neue Nebenläufigkeit; Mechanik belegt äquivalent, Gegenmaßnahmen
+bekannt, aber ausschließlich im interaktiven Pfad).
+
+### Nachweise, die den Umbau bewachen müssen
+
+| Nachweis | Fängt |
+|---|---|
+| (a) Ergebnisreihenfolge bei **künstlich gedrehter** Fertigstellungsreihenfolge | Reihenfolge kippt — der eigentliche Wirkort, heute ungeprüft (s. Korrektur 2) |
+| (b) ein Ortsfehler reißt die anderen nicht mit | Best-effort-Semantik |
+| (c) Quellenauflösung überlebt den Threadwechsel (≥2 Worker) | `call_log` wird blind — belegter Bestandsmangel |
+| (d) `created_at` ist **ein** Zeitstempel für den ganzen Lauf | Zeitstempel hängt sonst am Zufall |
+| (e) `time_window`/`forecast_hours` kommen bei **jedem** Ort an | Parameterverlust beim Aufteilen |
+| ~~(f) `top_ort` im Versandpfad~~ | **B1b**, nicht dieser Schnitt — s. Risiko unten |
+
+### Risiko für B1b: `top_ort` hängt am Merge
+
+`scheduler_dispatch_service.py:460` liest `top_ort = result.locations[0].location.name` —
+**nicht** `result.winner`. Der Wert geht in die API-Antwort und in
+`save_compare_preset_status()`. Heute ist er durch die serielle Verarbeitung deterministisch;
+nach dem Umbau hängt seine Korrektheit an der Merge-Reihenfolge. Das ist der Grund, warum die
+Reihenfolge im Versandpfad **einen eigenen** Nachweis braucht und nicht in (a) aufgeht: in
+der Vorschau ist die Reihenfolge Darstellung, im Versand ist sie ein Feldwert.
+Das Verhalten selbst (erster konfigurierter Ort, nicht bester Score) wird **beibehalten** —
+es ist Bestand seit #1359 und nicht Gegenstand dieses Tickets.
+
+### Open Questions
+
+Beide Zuschnittfragen wurden am 2026-08-15 vom PO an den Tech Lead delegiert und oben
+entschieden (zwei Schnitte; Cron-Lastfrage nach B1b verlagert, weil sie dort erstmals
+auftritt). Für diesen Schnitt bleibt **keine** offene Frage.
+
+Für **B1b** vorzumerken:
+- [ ] Cron-Überlagerung mehrerer Nutzer gegen das Météo-France-Kontingent — benannte Grenze
+      oder eigenes Kontingent-Gate? Dann mit Betriebsdaten aus B1 zu entscheiden.
+- [ ] `top_ort`-Nachweis im Versandpfad (Risiko oben).
+
+## Nicht in diesem Workflow
+
+- **U4** (fehlender Grundvorhersage-Cache im Vergleichspfad) — dokumentierte Zurückstellung
+  aus `fix_1329_forecast_cache_budget.md:399-407`; hilft dem gemeldeten Kaltstart strukturell
+  ohnehin nicht.
+- **#1839 / Trip-Pfad** — Scheibe B2, eigener Workflow.
+- **#1539** (Wurzel: sequenzielle Verarbeitung generell) — unberührt.
+- **Timeout-Leiter** (R6) — B2, erst nach gemessener neuer Laufzeit.

--- a/docs/specs/modules/fix_1765_b1_compare_vorschau_parallel.md
+++ b/docs/specs/modules/fix_1765_b1_compare_vorschau_parallel.md
@@ -1,0 +1,393 @@
+---
+entity_id: fix_1765_b1_compare_vorschau_parallel
+type: module
+created: 2026-08-15
+updated: 2026-08-15
+status: draft
+version: "1.0"
+tags: [bug, performance, preview, python-core, issue-1765]
+---
+
+# Vergleichs-Vorschau parallelisieren (Scheibe B1, #1765)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Die Vergleichs-Vorschau (`POST /api/preview/compare/{preset_id}`) berechnet die Orte eines
+Presets heute nacheinander (~25 Sekunden je Ort) und reißt dadurch bei drei oder mehr Orten
+die 60-Sekunden-Zeitgrenze zwischen Go-API und nginx — der Nutzer bekommt keine Vorschau,
+sondern einen Timeout-Fehler. Diese Spec stellt ausschließlich diesen einen Aufrufweg auf
+gleichzeitige Ortsverarbeitung um, nach dem bereits im Repo bewährten Vorbild der
+Etappen-Wetter-Berechnung. Ein neuer, geteilter Baustein entsteht dabei so, dass die beiden
+verbleibenden Aufrufwege (Versand, Sofortvergleich) ihn in einer Folgescheibe nur noch
+benutzen müssen, statt ihn selbst zu bauen.
+
+**Diese Scheibe schließt Issue #1765 NICHT.** Sie ist die erste von zwei Scheiben unter
+derselben Nummer — Begründung im Abschnitt „Abgrenzung — was diese Scheibe NICHT umfasst".
+
+## Source
+
+- **File:** `src/services/compare_preview_service.py:163` (Änderungsort) ·
+  `src/providers/call_log.py` (Änderungsort) · `src/services/comparison_engine.py:127`
+  (Vorbild-Referenz, **bleibt unangetastet**)
+- **Identifier:** neues Modul `src/services/comparison_parallel.py`, Funktion
+  `run_comparison_parallel(...)`
+
+## Estimated Scope
+
+- **LoC:** ~65 Produktivcode (Baustein ~40, `call_log`-Erweiterung ~15, Umstellung der
+  Aufrufstelle ~10) + ~140–180 Testcode (Nachweise + Umbau des abgelösten Vertrags) —
+  Gesamt ~205–245 LoC, unter dem 250er-Limit ohne Override
+- **Files:** 2 neue Produktivdateien-Anteile (1 neue Datei, 1 geänderte Bestandsdatei) + 1
+  geänderte Aufrufstelle + 2 neue Testdateien + 1 geänderte Bestandstestdatei
+- **Effort:** medium — die Mechanik ist am Code als äquivalent zum heutigen Verhalten geprüft
+  (Kontextdokument, Abschnitt „Äquivalenz von `run(locations=[loc])` je Ort"), der Aufwand
+  liegt im Nachweis, nicht im Mechanismus
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `stage_weather.py:170-183` (`compute_stage_weather`) | Vorbild im Repo | Executor-Aufbau, indexierte Vorbelegung statt Append, dünner Fehler-Wrapper je Einheit — vollständig zu übernehmen |
+| `official_alerts/warn_egress.py:55-57` (`_fetch_failure_sink`) | Vorbild im Repo | ContextVar-Muster mit Getter/Setter-Paar für threadübergreifende Werte |
+| `src/services/comparison_engine.py` (`ComparisonEngine.run`) | unverändert genutzt | `@staticmethod`, keine Instanzattribute — pro Ort einzeln aufrufbar ohne Änderung an der Engine selbst (am Code geprüft, Kontextdokument) |
+| Scheibe A (#1765/#1839, bereits ausgeliefert, Commit `62f066bf`) | vorausgesetzter Zustand | Die Zusicherung „`/api/health` bleibt während einer laufenden Vorschau erreichbar" ist bereits hergestellt (13 Handler `def` statt `async def`); diese Scheibe darf sie nicht wieder aufheben, stellt sie aber nicht selbst her |
+| `docs/reference/decision_matrix.md:231-254` | Betriebsdaten | Begründet die Parallelitätsgrenze `MAX_PARALLEL_LOCATIONS = 4` (Météo-France: geteiltes, ungedrosseltes Konto) |
+
+## Implementation Details
+
+### Neues Modul `src/services/comparison_parallel.py`
+
+Eine neutrale, geteilte Datei — bewusst **nicht** in `comparison_engine.py` und **nicht** in
+`compare_preview_service.py`, damit „`comparison_engine.py` bleibt unangetastet" mechanisch
+nachprüfbar ist und die künftigen Aufrufer (Versand, Sofortvergleich) andocken können, ohne
+etwas umzubauen.
+
+```
+def run_comparison_parallel(
+    locations, time_window, target_date,
+    forecast_hours=COMPARE_FORECAST_HOURS, profile=None,
+    official_alerts_enabled=True, *, call_source=None,
+) -> ComparisonResult
+```
+
+Ablauf, fünf Schritte, nach dem Vorbild `stage_weather.py:170-183`:
+
+1. `created_at = datetime.now()` **einmal**, bevor die parallele Verarbeitung startet.
+2. `fetched: list[Optional[LocationResult]] = [None] * len(locations)` — eine vorbelegte
+   Liste in Ortsreihenfolge, kein Anhängen bei Fertigstellung.
+3. `ThreadPoolExecutor(max_workers=min(len(locations), MAX_PARALLEL_LOCATIONS))` mit einer
+   `future → Index`-Zuordnung; das Ergebnis jedes Orts landet über seinen Index, unabhängig
+   davon, in welcher Reihenfolge die Berechnungen fertig werden.
+4. Ein dünner Wrapper je Ort: setzt die Diagnose-Quelle für den eigenen Verarbeitungspfad,
+   ruft `ComparisonEngine.run(locations=[loc], …)` mit den unveränderten Parametern auf und
+   gibt `result.locations[0]` zurück. Ein Fehler bei einem Ort wird — wie in
+   `stage_weather.py:52-57` — abgefangen, statt die anderen Orte mitzureißen. Das ist zum
+   großen Teil bereits Bestand: `ComparisonEngine.run()` fängt Ortsfehler heute schon intern
+   ab und liefert dafür ein `LocationResult(error=…)` statt zu werfen — der Wrapper schützt
+   nur zusätzlich gegen Unerwartetes davor (z. B. bei der internen Konfigurationsauflösung).
+5. Zusammenführen: `ComparisonResult(locations=fetched, time_window=…, target_date=…,
+   created_at=created_at)`.
+
+`MAX_PARALLEL_LOCATIONS = 4` als benannte Konstante, mit Kommentar-Verweis auf
+`decision_matrix.md:231-254` — bewusst niedriger als das Vorbild (`min(len, 8)`), weil das
+Météo-France-Konto von allen Nutzern gemeinsam genutzt und nicht aktiv gedrosselt wird.
+
+### `src/providers/call_log.py` — Diagnose-Quelle über den Verarbeitungspfad-Wechsel hinweg
+
+Die Diagnose-Funktion, die jedem Wetter-Abruf im Journal eine Quelle wie `"vergleich"` oder
+`"briefing"` zuordnet, liest heute die Namen der aufrufenden Funktionen aus dem Aufruf-Stapel
+desjenigen Verarbeitungspfads, der den Abruf tatsächlich ausführt. Bei paralleler
+Ortsverarbeitung ist das nicht mehr derselbe Pfad, der die ursprüngliche Anfrage
+entgegengenommen hat — die bisherigen 11 Namens-Marker (`"vergleich"`, `"vorschau"`, …)
+tauchen dort nicht mehr auf, und das Journal verzeichnet fälschlich `"unbekannt"`. Dieser
+Mangel ist bereits heute belegt (7,4 % `"unbekannt"` im Diagnose-Journal, Cluster beim
+bereits parallelisierten Etappen-Wetter-Pfad) und wird mit dieser Scheibe behoben —
+prozessweit, nicht nur für den Vergleich.
+
+Ergänzung: ein Override-Wert, der gezielt für den jeweiligen Verarbeitungspfad gesetzt werden
+kann, samt zugehörigem „Zurücksetzen"-Mechanismus, und eine Prüfung dieses Override-Werts
+**vor** der bisherigen Stapel-Inspektion. Die 11 Bestandsmarker bleiben als Rückfall
+bestehen — Aufrufer, die keinen Override setzen, verhalten sich unverändert wie heute. Der
+Baustein aus `comparison_parallel.py` setzt den Override-Wert für die Quelle `"vergleich"`,
+bevor er `ComparisonEngine.run()` für den jeweiligen Ort aufruft, und setzt ihn danach wieder
+zurück — sonst könnte ein wiederverwendeter Verarbeitungspfad den Wert in eine spätere,
+fachlich andere Anfrage hinein „vererben".
+
+Vorbild im Repo: `official_alerts/warn_egress.py:55-57` — dort existiert bereits ein Wert
+genau dieser Bauart für einen anderen Zweck, mit dem Kommentar „isoliert korrekt über
+Threads/Tasks". Wichtig, weil hier abweichend vom sonst üblichen Fall: der genutzte
+Ausführungs-Mechanismus (`ThreadPoolExecutor`) reicht einen gesetzten Override-Wert **nicht**
+automatisch an die Arbeits-Einheiten weiter — anders als bei manchen anderen
+Nebenläufigkeits-Mechanismen im Repo. Jeder Wrapper aus Schritt 4 muss den Wert deshalb selbst
+in seinem eigenen Verarbeitungspfad setzen, nicht der aufrufende Code vorab.
+
+### `src/services/compare_preview_service.py:163` — einzige umgestellte Aufrufstelle
+
+Der bisherige einzelne Aufruf `ComparisonEngine.run(locations=locations, …)` innerhalb von
+`_prepare()` wird durch `run_comparison_parallel(locations=locations, …, call_source="vergleich")`
+ersetzt. Alle übrigen Parameter (Tagesfenster, Vorhersage-Horizont, Profil, Status der
+amtlichen Warnungen) werden unverändert durchgereicht. Die vier öffentlichen Methoden
+(`render_all_channels`, `render_email_preview`, `render_telegram_preview`,
+`render_sms_preview`) rufen weiterhin gemeinsam `_prepare()` auf und bleiben dadurch
+unverändert — nur was innerhalb von `_prepare()` passiert, ändert sich.
+
+## Expected Behavior
+
+- **Input:** unverändert — derselbe Endpunkt, dieselben Preset- und Ortsdaten wie heute.
+- **Output:** inhaltlich unverändert (dieselben Metriken, dieselbe Ortsreihenfolge, dieselben
+  Fehlerformen). Verändert ist ausschließlich die Laufzeit bei mehreren Orten: bei 3–4 Orten
+  fällt sie von der Summe aller Einzelzeiten (~75 s bei drei Orten) auf ungefähr die Zeit des
+  langsamsten einzelnen Orts (~26 s).
+- **Side effects:** keine neuen fachlichen Seiteneffekte. Eine bereits bestehende
+  Diagnose-Verzerrung (Journal-Einträge ohne erkennbare Quelle) wird behoben statt vergrößert.
+
+## Korrekturen am Kontextdokument (bereits eingearbeitet)
+
+Zwei Annahmen aus dem gemeinsamen Ursachendokument (`docs/context/fix-1765-1839-vorschau-laufzeit.md`)
+sind für diese Scheibe geprüft und korrigiert worden — beide Korrekturen sind in den
+Abschnitten oben bereits berücksichtigt, hier nur zur Nachvollziehbarkeit festgehalten:
+
+1. **Die Zeitzonen-Datenbank-Ladung war als offene Aufgabe für diese Scheibe vermerkt — ist
+   aber bereits erledigt.** Sie wurde mit Scheibe A (#1765/#1839, `src/utils/timezone.py:21-34`)
+   gegen gleichzeitigen Erstzugriff abgesichert und ist mit einem eigenen Regressionstest
+   belegt. Diese Scheibe muss dort nichts mehr tun.
+2. **Der vermeintlich vorhandene Nachweis, dass die Ortsreihenfolge bei Parallelverarbeitung
+   erhalten bleibt, existiert an der Stelle, an der er wirken müsste, nicht.** Der bestehende
+   Test baut die Vergleichsergebnisse von Hand und prüft nur die vier Ausgabe-Oberflächen —
+   nicht die Stelle, an der eine Parallelisierung die Reihenfolge tatsächlich kippen würde
+   (das Zusammenführen der Einzelergebnisse). Dieser Nachweis wird mit dieser Scheibe **neu**
+   gebaut (AC-2 unten).
+
+Messgrundlage für beide Korrekturen sowie für alle Zahlen in dieser Spec:
+`docs/context/fix-1765-compare-vorschau-parallel.md`.
+
+## Ein abzulösender Bestandsvertrag
+
+`tests/tdd/test_compare_preview_service.py:285-311` sichert heute zu, dass die
+Wetter-Berechnung (`ComparisonEngine.run`) bei einem Vorschau-Aufruf **genau einmal** läuft,
+unabhängig davon, wie viele Orte das Preset enthält (`calls.count == 1`). Diese Zusicherung
+ist im Docstring von `compare_preview_service.py:52-55` als „AC-7" verankert („EIN
+Engine-Lauf, ALLE Kanäle fertig gerendert in EINER Antwort").
+
+**Nach dieser Scheibe stimmt „genau einmal je Aufruf" nicht mehr — es läuft einmal je Ort.**
+Der Test wird ohne Anpassung rot. Das ist beabsichtigt und wird hier ausdrücklich als neue
+Zusicherung festgehalten, nicht stillschweigend übergangen:
+
+- **Alte Zusicherung:** ein Vorschau-Aufruf löst genau eine Wetter-Berechnung aus.
+- **Neue Zusicherung:** ein Vorschau-Aufruf löst genau eine Wetter-Berechnung **je Ort** aus
+  (parallel statt nacheinander), deren Ergebnisse zu **einer** Antwort mit allen Kanälen
+  zusammengeführt werden. Der Teil der ursprünglichen Zusicherung, der dem Nutzer tatsächlich
+  etwas nützt — alle Kanäle in einer Antwort, kein zusätzlicher Kanalwechsel-Aufruf — bleibt
+  unverändert bestehen und wird durch AC-7 unten weiterhin geprüft.
+
+Der Test bei `:285-311` wird entsprechend umgebaut: Statt `calls.count == 1` prüft er
+`calls.count == len(locations)` (im dortigen Fall: 2 Orte → 2 Läufe). Der Docstring-Verweis
+„AC-7" in `compare_preview_service.py:52-55` wird auf die neue Zusicherung umformuliert.
+
+Die übrigen Tests derselben Datei (`:332`, `:371`, `:400`), die prüfen, dass Tagesfenster und
+Vorhersage-Horizont korrekt bei der Engine ankommen, nutzen durchweg Presets mit **einem**
+Ort — bei einem Ort ist „einmal je Ort" identisch zu „einmal insgesamt", diese Tests bleiben
+unverändert bestehen und müssen nach dem Umbau weiterhin grün sein. Sie sind der Nachweis,
+dass beim Aufteilen der Ortsliste in parallele Einzelaufrufe kein Parameter verloren geht.
+
+## Abgrenzung — was diese Scheibe NICHT umfasst
+
+**Diese Scheibe schließt #1765 nicht.** `ComparisonEngine.run()` hat drei unabhängige
+Aufrufstellen im Produktivsystem; diese Scheibe stellt genau eine davon um.
+
+| Aufrufweg | Grenze | in dieser Scheibe? |
+|---|---|---|
+| Vergleichs-Vorschau (`compare_preview_service.py:163`) | interaktiv, ein Nutzer sieht den Fehler sofort | **ja** |
+| Versand (`scheduler_dispatch_service.py:451`, auch der tägliche Cron-Lauf) | läuft unbeaufsichtigt, schreibt Zustand (letzter Versand, Alarm-Anker) | **nein — Folgescheibe B1b** |
+| Sofortvergleich (`api/routers/compare.py:71`, öffentlich erreichbar) | interaktiv, aber eigener Aufrufweg | **nein — Folgescheibe B1b** |
+
+Der Grund für den Zuschnitt in zwei Scheiben: Die drei Aufrufwege sind technisch identisch
+betroffen, aber ihre Betriebsrisiken unterscheiden sich grundlegend. Die Vorschau läuft in
+einer einzelnen, beaufsichtigten Sitzung — schlägt etwas fehl, sieht der Nutzer sofort einen
+Fehler und lädt neu. Der Versand läuft unbeaufsichtigt per Cron, unter Umständen für mehrere
+Nutzer gleichzeitig, und schreibt dauerhaften Zustand — ein Fehler dort fällt niemandem sofort
+auf und kann ein falsches oder ausgefallenes Briefing bedeuten. Eine neu eingeführte
+Nebenläufigkeit wird deshalb zuerst im beaufsichtigten, risikoärmeren Pfad erprobt; der
+unbeaufsichtigte Pfad bekommt sie erst, wenn der beaufsichtigte sie nachweislich trägt. Der
+geteilte Baustein (`comparison_parallel.py`) wird bereits jetzt so gebaut, dass die
+Folgescheibe die beiden übrigen Aufrufwege nur noch umhängen muss, statt selbst etwas
+umzubauen.
+
+**Ebenfalls nicht Teil dieser Scheibe:**
+
+- Der Nachweis, dass im Versandpfad der „oberste Ort" (`scheduler_dispatch_service.py:460`)
+  nach dem Umbau weiterhin korrekt ist — dieser Wert wird direkt aus der Merge-Reihenfolge
+  gelesen und braucht deshalb einen eigenen Nachweis im Versandpfad selbst (Folgescheibe).
+- Die Frage, ob mehrere gleichzeitig laufende Nutzer-Presets im täglichen Cron-Lauf zusammen
+  mit der neuen Ortsparallelität das gemeinsame, ungedrosselte Météo-France-Kontingent
+  überlasten können — das lässt sich aus dem Code allein nicht beantworten und wird in der
+  Folgescheibe mit echten Betriebsdaten aus dieser Scheibe entschieden.
+- Änderungen an `comparison_engine.py` selbst — die Ortsschleife dort bleibt unangetastet.
+- U4 (fehlender Grundvorhersage-Cache im Vergleichspfad) — dokumentierte, separate
+  Zurückstellung, hilft dem hier behandelten Problem strukturell ohnehin nicht.
+- Die Timeout-Grenzen zwischen Go-API und nginx (heute 60 s ohne Puffer) — bei 3–4 parallel
+  verarbeiteten Orten liegt die neue Laufzeit bei rund 26 s, deutlich darunter; ein Nachziehen
+  der Grenzen ist hier nicht nötig.
+- Der Trip-Vorschau-Pfad (#1839) — eigener, getrennter Workflow.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Orts-Vergleich mit drei oder mehr Orten, dessen Vorschau bisher wegen
+  der Zeitgrenze fehlschlug / When die Vorschau (E-Mail, Telegram oder SMS) für dieses Preset
+  angefordert wird / Then liefert die Vorschau innerhalb der Zeitgrenze ein vollständiges
+  Ergebnis für alle Orte zurück, statt mit einem Zeitüberschreitungs-Fehler abzubrechen.
+
+- **AC-2:** Given ein Orts-Vergleich mit mehreren Orten, bei dem absichtlich der zuerst
+  konfigurierte Ort am längsten und der zuletzt konfigurierte Ort am kürzesten braucht, bis
+  seine Wetterdaten vorliegen / When die Vorschau berechnet wird / Then erscheinen die Orte im
+  Ergebnis trotzdem in der ursprünglich konfigurierten Reihenfolge, nicht in der Reihenfolge,
+  in der ihre Berechnung fertig wurde.
+
+- **AC-3:** Given ein Orts-Vergleich, bei dem für genau einen von mehreren Orten die
+  Wetterdaten nicht abrufbar sind / When die Vorschau berechnet wird / Then zeigen die
+  übrigen Orte trotzdem ihre vollständigen Wetterdaten, und nur der betroffene Ort erscheint
+  mit einer Fehlermeldung — ein einzelner fehlerhafter Ort darf die Vorschau der anderen Orte
+  nicht verhindern.
+
+- **AC-4:** Given eine Vergleichs-Vorschau mit mehreren Orten, deren Wetterdaten gleichzeitig
+  in getrennten Verarbeitungspfaden abgerufen werden / When jeder dieser Abrufe im internen
+  Diagnose-Journal aufgezeichnet wird / Then trägt jeder Eintrag weiterhin korrekt „Vergleich"
+  als Herkunft, statt als „unbekannt" verzeichnet zu werden — die Umstellung auf gleichzeitige
+  Verarbeitung darf die Nachvollziehbarkeit im Diagnose-Journal nicht verschlechtern.
+
+- **AC-5:** Given eine Vergleichs-Vorschau mit mehreren Orten wird einmal ausgelöst / When alle
+  Orte gleichzeitig berechnet werden / Then trägt das fertige Ergebnis genau einen
+  „Erstellt am"-Zeitstempel für den gesamten Lauf — nicht einen eigenen Zeitstempel je Ort.
+
+- **AC-6:** Given ein Orts-Vergleich-Preset mit einem bestimmten Tagesfenster und einem
+  bestimmten Vorhersage-Zeitraum / When die Vorschau für mehrere Orte gleichzeitig berechnet
+  wird / Then rechnet **jeder einzelne** Ort mit exakt demselben Tagesfenster und demselben
+  Vorhersage-Zeitraum wie zuvor — keiner der Orte darf beim Aufteilen der Arbeit ein falsches
+  oder fehlendes Fenster bekommen.
+
+- **AC-7 (unverändert bleibt):** Given ein Orts-Vergleich mit mehreren Orten in einer vom
+  Nutzer festgelegten Reihenfolge / When die Vorschau als E-Mail, als Telegram-Nachricht, als
+  SMS-Text und in der Weboberfläche dargestellt wird / Then erscheinen die Orte in allen vier
+  Darstellungen weiterhin in genau der vom Nutzer festgelegten Reihenfolge — unverändert
+  gegenüber dem heutigen Verhalten.
+
+- **AC-8 (unverändert bleibt):** Given eine Anfrage an die Vergleichs-Vorschau, die heute mit
+  „Preset nicht gefunden", „ungültige Eingabe" oder „Wetterdaten aktuell nicht verfügbar"
+  beantwortet wird / When dieselbe Anfrage nach dieser Umstellung erneut gestellt wird / Then
+  bleibt die Fehlermeldung in Form und Inhalt identisch zu vorher.
+
+- **AC-9 (unverändert bleibt, Scheibe-A-Ratsche):** Given eine Vergleichs-Vorschau mit
+  mehreren Orten wird gerade berechnet / When währenddessen der allgemeine
+  Erreichbarkeits-Check des Dienstes aufgerufen wird / Then antwortet dieser weiterhin sofort
+  und erfolgreich — die neue gleichzeitige Ortsverarbeitung darf die mit Scheibe A bereits
+  hergestellte Erreichbarkeit während einer laufenden Vorschau nicht wieder aufheben.
+
+## Testplan
+
+**Schicht:** ausschließlich Kern (deterministisch, kein Netz, keine Live-Dienste) — passend
+zur Test-Politik dieses Repos. Mock-Theater (`Mock()`/`patch()`/`MagicMock`, die nur die
+eigene Annahme zurückspiegeln) und Dateiinhalt-Prüfungen als Verhaltensnachweis sind
+verboten. Für AC-2 ist eine künstliche, unterschiedlich lange Verzögerung je Ort **legitim
+und notwendig** — nur so lässt sich die Fertigstellungsreihenfolge gezielt gegen die
+Einreichungsreihenfolge drehen; ohne diese Drehung würde der Test auch bei falscher
+Merge-Logik zufällig grün sein.
+
+**Neue Testdateien:**
+
+- `tests/unit/test_comparison_parallel.py` — Nachweise für AC-2 (Reihenfolge bei gedrehter
+  Fertigstellung, gestubbte `ComparisonEngine.run`), AC-3 (ein Ortsfehler reißt die anderen
+  nicht mit), AC-5 (genau ein `created_at` für den gesamten Lauf), AC-6 (Tagesfenster und
+  Vorhersage-Zeitraum kommen bei jedem Ort einzeln geprüft an, nicht nur beim ersten).
+- `tests/unit/test_call_source_ueber_threadgrenze.py` — Nachweis für AC-4: mindestens zwei
+  gleichzeitig laufende Verarbeitungspfade, jeder protokolliert einen Abruf; geprüft wird die
+  tatsächlich im Journal verzeichnete Quelle je Eintrag, nicht die bloße Anwesenheit der
+  Override-Funktion im Quelltext.
+
+**Geänderte Bestandsdatei:**
+
+- `tests/tdd/test_compare_preview_service.py:285-311` — Umbau der abgelösten Zusicherung
+  (`calls.count == 1` → `calls.count == len(locations)`), wie oben unter „Ein abzulösender
+  Bestandsvertrag" beschrieben. Die Tests bei `:332`, `:371`, `:400` bleiben unverändert und
+  müssen nach dem Umbau weiterhin grün sein (Ein-Ort-Presets — dort ist „je Ort" identisch zu
+  „insgesamt").
+
+**Wirkungs-Nachweis für AC-1 — über eine Treffpunkt-Sperre, NICHT über die Uhr.**
+Der naheliegende Test („Gesamtdauer liegt nahe der längsten Einzeldauer statt nahe der
+Summe") misst Wanduhr-Zeit und wäre auf einem ausgelasteten CI-Läufer flakeanfällig: er
+würde gelegentlich rot, ohne dass etwas kaputt ist, und träfe damit genau die Sorte
+Testfehler, die man später ignoriert statt untersucht.
+
+Stattdessen wird die **Gleichzeitigkeit selbst** geprüft, deterministisch und uhrunabhängig:
+Der Nachweis nutzt eine Treffpunkt-Sperre (`threading.Barrier(n)`) — jeder der n Orte meldet
+sich beim Betreten seiner Berechnung an und wartet, bis **alle** n angekommen sind. Läuft die
+Verarbeitung nacheinander, erreicht der zweite Ort den Treffpunkt nie, weil der erste dort
+noch wartet: die Sperre läuft in ihre Zeitschranke und der Test wird rot. Läuft sie
+gleichzeitig, lösen alle n den Treffpunkt gemeinsam auf und der Test wird grün. Es gibt
+keinen Zwischenzustand, der zufällig grün werden könnte. Dasselbe Muster ist im Repo bereits
+erprobt: `tests/unit/test_timezone_singleton_threadsicher.py:72-124`.
+
+Zusätzlich zu prüfen: Bei **einem** Ort und bei einer **leeren** Ortsliste darf der Baustein
+nicht in eine Sperre laufen und muss sich wie heute verhalten (`min(len(locations), 4)` mit
+`len == 0` ist ein ungültiger Wert für die Arbeiterzahl — der Fall muss abgefangen sein,
+Vorbild `stage_weather.py:172` prüft `if flat:` vor dem Aufbau des Executors).
+
+**Mutations-Gegenprobe (PFLICHT im TDD-RED-Schritt):** mindestens diese Verfälschungen
+müssen je mindestens einen Test rot machen:
+
+1. Die indexierte Rückgabe (`fetched[idx] = …`) wird versuchsweise durch ein Anhängen bei
+   Fertigstellung ersetzt → AC-2-Test muss rot werden.
+2. Die Fehlerkapselung je Ort im Wrapper wird versuchsweise entfernt → AC-3-Test muss rot
+   werden (ein Ortsfehler wirft dann durch und reißt den gesamten Lauf mit).
+3. Das Setzen der Diagnose-Quelle im jeweiligen Verarbeitungspfad wird versuchsweise
+   weggelassen → AC-4-Test muss rot werden (Journal verzeichnet „unbekannt" statt
+   „Vergleich").
+4. `created_at` wird versuchsweise je Ort statt einmal vor dem Start berechnet → AC-5-Test
+   muss rot werden.
+5. Der Executor wird versuchsweise auf einen einzigen Arbeiter gesetzt (`max_workers=1`,
+   also faktisch wieder nacheinander) → der AC-1-Test muss rot werden. Diese Mutation ist
+   die wichtigste: Sie prüft, ob der Nachweis die **Wirkung** bewacht (gleichzeitige
+   Verarbeitung) oder nur das Vorhandensein von Code, der so aussieht.
+
+Mutationen ausschließlich per String-Ersetzung mit externer Sicherungskopie, nie per
+`git checkout`/`stash`/`reset`.
+
+## Known Limitations
+
+- **Thundering-Herd-Risiko bei den national geschlüsselten Warndiensten für Frankreich und
+  Italien wird in dieser Scheibe NICHT behoben, nur benannt.** Die amtlichen Warndienste für
+  Italien und Frankreich cachen ihre Ergebnisse heute mit einem einzigen, für alle Orte
+  gemeinsamen Schlüssel, ungesichert gegen gleichzeitigen Zugriff. Solange die Orte
+  nacheinander verarbeitet wurden, traf in der Regel nur der erste Ort auf einen leeren
+  Zwischenspeicher, alle folgenden Orte fanden bereits ein Ergebnis vor. Bei gleichzeitiger
+  Verarbeitung sehen mehrere Orte denselben leeren Zwischenspeicher gleichzeitig und lösen
+  redundante Abrufe gegen denselben amtlichen Dienst aus — gegen ein Tageskontingent, das
+  zwar begrenzt und dagegen abgesichert ist, aber dadurch schneller ausgeschöpft würde als
+  nötig. Betrifft nur Orte in Frankreich und Italien, nicht den Karnischen Höhenweg
+  (Österreich/Deutschland). Kein Datenverlust und keine falsche Anzeige — eine unnötige
+  Lastspitze. Details: Kontextdokument, Risiko R7.
+- **Die Cron-Überlagerungsfrage (mehrere Nutzer-Presets gleichzeitig gegen dasselbe
+  Météo-France-Kontingent) ist aus dem Code allein nicht beantwortbar** und wird bewusst der
+  Folgescheibe überlassen, in der sie erstmals auftritt (Versandpfad).
+- **`comparison_engine.py` bleibt unverändert.** Die Ortsschleife dort läuft weiterhin
+  nacheinander innerhalb eines einzelnen Aufrufs mit genau einem Ort — die Parallelität
+  entsteht ausschließlich außerhalb, im neuen Baustein.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine.
+- **Rationale:** ADR-0015 (Python-Core ist Owner der Wetter-Domäne) deckt diese
+  Parallelisierung ab — derselbe Präzedenzfall wie bei der bereits umgesetzten
+  Etappen-Wetter-Parallelisierung (`docs/specs/modules/stage_weather_python_endpoint.md:126-129`).
+  Es existiert kein eigenes ADR zu Nebenläufigkeit im Python-Core, das dieser Fix umgehen oder
+  ablösen würde. Die Umsetzung „außen" (neuer Baustein, `comparison_engine.py` unangetastet)
+  vermeidet bewusst eine Änderung innerhalb der Engine selbst, die Versand und Alarme
+  mitträfe und damit ADR-würdig wäre.
+
+## Changelog
+
+- 2026-08-15: Initial spec created (Scheibe B1 von #1765; schließt das Ticket nicht — Scheibe
+  B1b folgt für Versand und Sofortvergleich)

--- a/docs/specs/modules/fix_1765_b1_compare_vorschau_parallel.md
+++ b/docs/specs/modules/fix_1765_b1_compare_vorschau_parallel.md
@@ -12,7 +12,7 @@ tags: [bug, performance, preview, python-core, issue-1765]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-Freigabe („Go") am 2026-08-15 auf die neun Acceptance Criteria
 
 ## Purpose
 
@@ -46,6 +46,24 @@ derselben Nummer — Begründung im Abschnitt „Abgrenzung — was diese Scheib
 - **Effort:** medium — die Mechanik ist am Code als äquivalent zum heutigen Verhalten geprüft
   (Kontextdokument, Abschnitt „Äquivalenz von `run(locations=[loc])` je Ort"), der Aufwand
   liegt im Nachweis, nicht im Mechanismus
+
+**🔴 Nachtrag 2026-08-15 — die Schätzung oben ist überholt. Gemessen wurden 215 Zeilen
+Produktivcode (geschätzt 65, Faktor 3,3) und 732 Zeilen Testcode (geschätzt 140–180,
+Faktor ~4,5).** Die Abweichung ist erklärbar, war aber nicht vorhergesehen:
+
+| Ursache | trifft |
+|---|---|
+| Der abgelöste Bestandsvertrag saß an **drei** Stellen statt an einer (RED-Nachtrag) | Testcode |
+| F001 (Adversary) verlangte eine **eigene Wirkort-Testdatei** über den echten Router — `test_compare_vorschau_systemfehler.py`, 207 Zeilen | Testcode |
+| F002 (Adversary) verlangte einen Vorrang-Test, der zuvor niemandem fehlte | Testcode |
+| Docstrings und die Begründung der Fehler-Einordnung im Baustein selbst | Produktivcode |
+
+**Lehre für künftige Schätzungen dieser Art:** Nicht die Schätzung des Mechanismus lag
+daneben, sondern die des Nachweises — um ein Vielfaches. Wo Nebenläufigkeit im Spiel ist,
+braucht **jeder einzelne** Nachweis einen eigenen Aufbau (Treffpunkt-Sperre, gedrehte
+Fertigstellung, echter Router), der sich zwischen den Kriterien nicht teilen lässt. Der
+Faustwert „der Nachweis kostet mehr als der Mechanismus" ist hier zu niedrig gegriffen;
+realistisch ist **Faktor 3–4 auf den Testanteil**.
 
 ## Dependencies
 
@@ -116,6 +134,13 @@ Baustein aus `comparison_parallel.py` setzt den Override-Wert für die Quelle `"
 bevor er `ComparisonEngine.run()` für den jeweiligen Ort aufruft, und setzt ihn danach wieder
 zurück — sonst könnte ein wiederverwendeter Verarbeitungspfad den Wert in eine spätere,
 fachlich andere Anfrage hinein „vererben".
+
+**Name festgelegt (RED-Phase 2026-08-15):** Der Mechanismus heißt
+`providers.call_log.override_call_source(quelle)` und ist ein **Context-Manager**
+(`with`-Block mit automatischem Zurücksetzen am Ende). Die RED-Tests fordern genau diesen
+Namen und diese Bauform — eine abweichende Umsetzung lässt die AC-4-Tests rot. Die Spec hatte
+zuvor nur „Override-Wert samt Zurücksetzen-Mechanismus" beschrieben, ohne Namen; die
+Festlegung stammt aus der Testphase, nicht aus der Freigabe.
 
 Vorbild im Repo: `official_alerts/warn_egress.py:55-57` — dort existiert bereits ein Wert
 genau dieser Bauart für einen anderen Zweck, mit dem Kommentar „isoliert korrekt über
@@ -193,6 +218,23 @@ Vorhersage-Horizont korrekt bei der Engine ankommen, nutzen durchweg Presets mit
 Ort — bei einem Ort ist „einmal je Ort" identisch zu „einmal insgesamt", diese Tests bleiben
 unverändert bestehen und müssen nach dem Umbau weiterhin grün sein. Sie sind der Nachweis,
 dass beim Aufteilen der Ortsliste in parallele Einzelaufrufe kein Parameter verloren geht.
+
+**🔴 Nachtrag aus der RED-Phase (2026-08-15): der Vertrag sitzt an DREI Stellen, nicht an
+einer.** Beim Schreiben der Tests kamen zwei weitere Fundstellen derselben Zusicherung ans
+Licht, die diese Spec zunächst übersehen hatte. Beide gehören zu Presets mit **zwei** Orten
+und werden mit der Umstellung ebenfalls rot:
+
+| Stelle | Zusicherung heute | nach dem Umbau |
+|---|---|---|
+| `:231` | `calls.count == 1` (Preset mit 2 Orten) | `== len(locations)` |
+| `:232` | beide Orte kommen in **einem** Engine-Aufruf an (`locations_seen[0] == ["loc-ibk","loc-bz"]`) | jeder Aufruf sieht **genau einen** Ort — Prüfung auf die Vereinigung über alle Aufrufe umstellen, Reihenfolge erhalten |
+| `:277` | `calls.count == 1` (Preset mit 2 Orten) | `== len(locations)` |
+
+Die Unterscheidung, die diese Spec ursprünglich zu grob getroffen hatte, lautet **nicht**
+„`:285-311` gegen den Rest", sondern: **jede** Stelle mit einem Mehr-Ort-Preset trägt den
+abgelösten Vertrag, **jede** Stelle mit einem Ein-Ort-Preset nicht. Wer nur die in dieser
+Spec zuerst genannte Zeile umbaut, läuft in eine berechtigte Blockade des
+Commit-Gates `touched_tests_gate.py`.
 
 ## Abgrenzung — was diese Scheibe NICHT umfasst
 
@@ -375,6 +417,31 @@ Mutationen ausschließlich per String-Ersetzung mit externer Sicherungskopie, ni
 - **`comparison_engine.py` bleibt unverändert.** Die Ortsschleife dort läuft weiterhin
   nacheinander innerhalb eines einzelnen Aufrufs mit genau einem Ort — die Parallelität
   entsteht ausschließlich außerhalb, im neuen Baustein.
+- 🔴 **AC-9 ist im Kern NICHT eigenständig nachgewiesen — der Beleg gehört auf Staging.**
+  Der zugeordnete Test `tests/unit/test_event_loop_bleibt_frei.py:160` stammt **unverändert**
+  aus Scheibe A (`git diff` gegen den Abzweigpunkt ist leer). Er ersetzt
+  `preview.ComparePreviewService` **vollständig** durch einen Schlaf-Stub und prüft damit nur,
+  dass der Router-Handler `def` bleibt und Starlette ihn in den Threadpool legt — den neuen
+  `ThreadPoolExecutor` berührt er nie. Er kann eine Regression, die **gerade** durch die neue,
+  verschachtelte Nebenläufigkeit entstünde, strukturell nicht sehen. Das ist erneut
+  Prüfort ≠ Wirkort, diesmal geerbt statt neu gebaut.
+  **Bewusst nicht durch einen weiteren Kern-Test geschlossen:** Ein Kern-Test müsste den
+  Threadpool erneut nachbauen und würde wieder nur den Nachbau prüfen. Der Wirkort ist der
+  laufende Dienst. **Verbindliche Folge: Die Staging-Verifikation dieser Scheibe MUSS
+  `/api/health` WÄHREND einer echten Vergleichs-Vorschau mit 3+ Orten abfragen** und das
+  Ergebnis in der Attestation festhalten. Ohne diese Messung gilt AC-9 als unbelegt, nicht
+  als erfüllt.
+- **Grenze der Systemfehler-Erkennung (Adversary-Runde 3, 2026-08-15).** Scheitern **alle**
+  Orte mit einer Ausnahme, gilt die Störung als systemisch und die Ausnahme des Orts mit dem
+  **niedrigsten Index** wird weitergereicht (→ 503). Werfen dabei verschiedene Orte
+  Ausnahmen **verschiedenen Typs** — zwei zeitgleiche, voneinander unabhängige systemische
+  Ursachen —, entscheidet damit der erste konfigurierte Ort über die Fehlerart; ein
+  `ValueError` dort ergäbe 422 statt 503. Kein AC fordert für diesen Fall eine Antwort, und
+  vor dem Umbau konnte er nicht auftreten (ein Engine-Lauf für alle Orte kannte nur *einen*
+  Fehler). **Nicht zufällig, sondern deterministisch:** Die Einsammel-Schleife iteriert über
+  `future_to_idx.items()` — Einreichungsreihenfolge, nicht Fertigstellungsreihenfolge. Über
+  fünf Wiederholungsläufe mit gedrehter Fertigstellung kam stets dieselbe Ausnahme heraus.
+  Die Fehlermeldung an den Nutzer schwankt also nicht zwischen zwei Aufrufen.
 
 ## Architektur-Entscheidung (ADR)
 

--- a/src/providers/call_log.py
+++ b/src/providers/call_log.py
@@ -12,10 +12,12 @@ aufgelöst über `app.loader.get_data_root()` (#1633).
 """
 from __future__ import annotations
 
+import contextvars
 import json
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Iterator, List, Optional, Tuple
 
 # Test-Override (Path) oder None. Issue #1633: der Pfad wird bei JEDEM Zugriff
 # über `diagnostics_path()` aufgelöst, nie beim Import — eine Modul-Konstante mit
@@ -53,8 +55,46 @@ _CALL_SOURCE_MARKERS: List[Tuple[str, str]] = [
 ]
 
 
+# Issue #1765 Scheibe B1: ausdruecklich gesetzte Quelle des AKTUELLEN
+# Verarbeitungspfads. Die Marker-Liste oben liest den Aufruf-Stapel des
+# AUSFUEHRENDEN Threads -- wandert die Arbeit in einen eigenen Thread
+# (ThreadPoolExecutor), taucht dort keiner der 11 Marker mehr auf und das
+# Journal bucht faelschlich "unbekannt" (belegt: 7,4 % der Eintraege).
+# ``ContextVar`` isoliert korrekt ueber Threads/Tasks (Vorbild:
+# official_alerts/warn_egress.py:55-57): ein neuer Thread startet mit leerem
+# Kontext, ein anderswo aktiver Override faerbt also nicht auf ihn ab.
+_call_source_override: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "gz_call_source_override", default=None
+)
+
+
+@contextmanager
+def override_call_source(source: str) -> Iterator[None]:
+    """Setzt die Diagnose-Quelle fuer den aktuellen Verarbeitungspfad und nimmt
+    sie am Ende des Blocks wieder zurueck.
+
+    Das Zuruecksetzen ist Pflicht, nicht Kosmetik: ein ``ThreadPoolExecutor``
+    verwendet seine Threads wieder -- ein stehengebliebener Wert vererbte die
+    Quelle in eine spaetere, fachlich ANDERE Anfrage.
+    """
+    token = _call_source_override.set(source)
+    try:
+        yield
+    finally:
+        _call_source_override.reset(token)
+
+
 def resolve_call_source() -> str:
-    """Issue #338: Diagnose-Quelle aus den Aufrufer-Frame-Namen ableiten."""
+    """Issue #338: Diagnose-Quelle aus den Aufrufer-Frame-Namen ableiten.
+
+    Issue #1765 B1: Ein ausdruecklich gesetzter Override (``override_call_source``)
+    geht VOR -- er ist die einzige Quelle, die einen Threadwechsel ueberlebt.
+    Ohne Override bleibt es unveraendert bei den 11 Namens-Markern.
+    """
+    override = _call_source_override.get()
+    if override is not None:
+        return override
+
     import inspect
 
     names = [f.function for f in inspect.stack()[:25]]

--- a/src/services/compare_preview_service.py
+++ b/src/services/compare_preview_service.py
@@ -3,7 +3,8 @@
 SPEC: docs/specs/modules/compare_channel_preview_dispatch.md (Scheiben S2/S4)
 
 Loest das Preset + die ECHTEN Orte des Nutzers auf, laesst die
-``ComparisonEngine`` genau EINMAL je Aufruf laufen und rendert daraus die
+``ComparisonEngine`` genau EINMAL JE ORT laufen (seit #1765 B1 gleichzeitig,
+ueber ``comparison_parallel.run_comparison_parallel``) und rendert daraus die
 fertigen Kanal-Payloads (E-Mail/Telegram/SMS) — kein Versand, keine
 Persistenz. Ersetzt fachlich den Validator-Stub
 (`validator_render_service.render_compare_email_preview`, hartcodierter Ort
@@ -49,9 +50,10 @@ class ComparePreviewService:
         user_id: str,
         target_date: str | date | None = None,
     ) -> dict:
-        """Sammel-Einstieg (ADR-0011): EIN Engine-Lauf, ALLE Kanaele fertig
-        gerendert in EINER Antwort — der Kanalwechsel im Vorschau-Tab braucht
-        damit keinen weiteren Request (AC-7).
+        """Sammel-Einstieg (ADR-0011): EIN Engine-Lauf JE ORT (seit #1765 B1
+        gleichzeitig statt nacheinander), ALLE Kanaele fertig gerendert in EINER
+        Antwort — der Kanalwechsel im Vorschau-Tab braucht damit keinen weiteren
+        Request (AC-7).
         """
         from output.renderers.comparison import render_compare_sms, render_compare_telegram
         from services.scheduler_dispatch_service import build_compare_preset_subject
@@ -133,12 +135,13 @@ class ComparePreviewService:
         user_id: str,
         target_date: str | date | None,
     ) -> dict:
-        """Preset + echte Orte laden und die ComparisonEngine EINMAL laufen
-        lassen. Alle Kanal-Renderer eines Aufrufs sitzen auf demselben
-        ``ComparisonResult`` (AC-7).
+        """Preset + echte Orte laden und die ComparisonEngine EINMAL JE ORT
+        laufen lassen (gleichzeitig, #1765 B1). Alle Kanal-Renderer eines
+        Aufrufs sitzen auf demselben ``ComparisonResult`` (AC-7).
         """
         from app.loader import _parse_activity_profile
-        from services.comparison_engine import COMPARE_FORECAST_HOURS, ComparisonEngine
+        from services.comparison_engine import COMPARE_FORECAST_HOURS
+        from services.comparison_parallel import run_comparison_parallel
         from services.report_config_resolver import (
             resolve_compare_render_options, resolve_compare_time_window,
         )
@@ -160,13 +163,18 @@ class ComparePreviewService:
         # wie der echte Versand (scheduler_dispatch_service.py). Der geteilte Bezug
         # auf COMPARE_FORECAST_HOURS ersetzt den bisherigen Kommentar-Appell durch
         # Struktur — Divergenz ist strukturell ausgeschlossen (#1297).
-        result = ComparisonEngine.run(
+        # Issue #1765 Scheibe B1: die Orte werden gleichzeitig statt nacheinander
+        # gerechnet (ein Engine-Lauf JE ORT) -- sonst riss die Vorschau ab drei
+        # Orten die 60-Sekunden-Grenze zwischen Go-API und nginx. Alle uebrigen
+        # Parameter unveraendert; ``comparison_engine.py`` bleibt unangetastet.
+        result = run_comparison_parallel(
             locations=locations,
             time_window=resolve_compare_time_window(preset),
             target_date=resolved_date,
             forecast_hours=COMPARE_FORECAST_HOURS,
             profile=profile,
             official_alerts_enabled=preset.get("official_alerts_enabled", True),
+            call_source="vergleich",
         )
         return {
             "preset": preset,

--- a/src/services/comparison_parallel.py
+++ b/src/services/comparison_parallel.py
@@ -1,0 +1,167 @@
+"""
+Service: run_comparison_parallel -- die Orte eines Vergleichs GLEICHZEITIG rechnen.
+
+Scheibe B1 von Issue #1765. Die Vergleichs-Vorschau verarbeitete die Orte eines
+Presets nacheinander (~25 s je Ort) und riss ab drei Orten die 60-Sekunden-Grenze
+zwischen Go-API und nginx. Dieser Baustein legt die Parallelitaet AUSSERHALB der
+Engine an: ``ComparisonEngine.run()`` bleibt unveraendert und wird je Ort einmal
+mit genau diesem einen Ort aufgerufen.
+
+Bewusst ein eigenes, neutrales Modul (weder in ``comparison_engine.py`` noch in
+``compare_preview_service.py``): so ist "die Engine bleibt unangetastet"
+mechanisch nachpruefbar, und die uebrigen Aufrufwege (Versand, Sofortvergleich)
+koennen in der Folgescheibe andocken, ohne etwas umzubauen.
+
+Vorbild im Repo: ``services/stage_weather.py:170-183`` (Executor-Aufbau,
+indexierte Vorbelegung statt Anhaengen, duenner Fehler-Wrapper je Einheit).
+
+Spec: docs/specs/modules/fix_1765_b1_compare_vorschau_parallel.md
+"""
+from __future__ import annotations
+
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import nullcontext
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, List, Optional, cast
+
+from app.user import ComparisonResult, LocationResult
+from services.comparison_engine import COMPARE_FORECAST_HOURS
+
+if TYPE_CHECKING:
+    from datetime import date
+
+    from app.profile import ActivityProfile
+    from app.user import SavedLocation
+
+logger = logging.getLogger(__name__)
+
+# Bewusst niedriger als das Vorbild (``min(len, 8)`` in stage_weather.py): das
+# Meteo-France-Konto wird von allen Nutzern GEMEINSAM genutzt und ist nicht
+# aktiv gedrosselt -- siehe docs/reference/decision_matrix.md:231-254.
+MAX_PARALLEL_LOCATIONS = 4
+
+
+def _run_one_location(
+    loc: "SavedLocation",
+    *,
+    time_window: tuple[int, int],
+    target_date: "date",
+    forecast_hours: int,
+    profile: Optional["ActivityProfile"],
+    official_alerts_enabled: bool,
+    call_source: Optional[str],
+) -> LocationResult:
+    """Ein Ort, ein Engine-Lauf.
+
+    Faengt bewusst NICHTS ab: ``ComparisonEngine.run()`` fasst einen echten
+    Ortsfehler bereits selbst in ein ``LocationResult(error=...)`` und wirft
+    dafuer NICHT (comparison_engine.py:128-147 und :369-381). Was hier dennoch
+    als Ausnahme herauskommt, ist per Definition kein Ortsfehler, sondern
+    systemisch (z.B. die ``Settings()``-Konstruktion VOR der Ortsschleife,
+    comparison_engine.py:121). Ob daraus ein Ortsfehler wird (AC-3) oder der
+    ganze Lauf abbricht (AC-8), entscheidet erst der Einsammler in
+    ``run_comparison_parallel`` -- nur dort ist bekannt, ob ALLE Orte
+    betroffen sind.
+
+    Die Diagnose-Quelle wird hier gesetzt, nicht beim Aufrufer: ein
+    ``ThreadPoolExecutor`` reicht den Kontext NICHT an seine Arbeiter weiter.
+    """
+    import services.comparison_engine as ce_mod
+    from providers.call_log import override_call_source
+
+    quelle = override_call_source(call_source) if call_source else nullcontext()
+    with quelle:
+        result = ce_mod.ComparisonEngine.run(
+            locations=[loc],
+            time_window=time_window,
+            target_date=target_date,
+            forecast_hours=forecast_hours,
+            profile=profile,
+            official_alerts_enabled=official_alerts_enabled,
+        )
+    return result.locations[0]
+
+
+def run_comparison_parallel(
+    locations: List["SavedLocation"],
+    time_window: tuple[int, int],
+    target_date: "date",
+    forecast_hours: int = COMPARE_FORECAST_HOURS,
+    profile: Optional["ActivityProfile"] = None,
+    official_alerts_enabled: bool = True,
+    *,
+    call_source: Optional[str] = None,
+) -> ComparisonResult:
+    """Wie ``ComparisonEngine.run()``, nur werden die Orte gleichzeitig statt
+    nacheinander berechnet. Signatur, Parameter und Ergebnisform sind identisch.
+
+    Die Ortsreihenfolge des Ergebnisses ist die KONFIGURIERTE, nicht die
+    Fertigstellungsreihenfolge: jedes Teilergebnis landet ueber seinen Index.
+
+    Raises:
+        Exception: die erste aufgefangene Ausnahme, wenn JEDER Ort mit einer
+            Ausnahme scheitert -- das ist eine systemische Stoerung und behaelt
+            damit die Fehlerform von vor der Parallelisierung (AC-8).
+    """
+    locations = list(locations)
+    # EIN Zeitstempel fuer den gesamten Lauf, vor dem Start -- nicht je Ort und
+    # nicht aus einem Teilergebnis (das haenge sonst an der Fertigstellung).
+    # Naive UTC statt nackter Prozessuhr (Hausnorm #1345): genau so lesen die
+    # Renderer das Feld (``local_stamp`` -> ``utils.timezone._as_utc``), und
+    # ``tests/test_output_timezone_guard.py`` verbietet ``datetime.now()`` ohne
+    # Zeitzone im Entscheidungs-/Ausgabepfad.
+    created_at = datetime.now(timezone.utc).replace(tzinfo=None)
+    fetched: List[Optional[LocationResult]] = [None] * len(locations)
+    fehler: List[tuple[int, Exception]] = []
+    if locations:  # ``min(0, 4)`` waere ein ungueltiges ``max_workers``
+        with ThreadPoolExecutor(
+            max_workers=min(len(locations), MAX_PARALLEL_LOCATIONS)
+        ) as executor:
+            future_to_idx = {
+                executor.submit(
+                    _run_one_location,
+                    loc,
+                    time_window=time_window,
+                    target_date=target_date,
+                    forecast_hours=forecast_hours,
+                    profile=profile,
+                    official_alerts_enabled=official_alerts_enabled,
+                    call_source=call_source,
+                ): idx
+                for idx, loc in enumerate(locations)
+            }
+            for future, idx in future_to_idx.items():
+                try:
+                    fetched[idx] = future.result()
+                except Exception as exc:  # noqa: BLE001 -- Einordnung folgt unten
+                    logger.warning(
+                        "run_comparison_parallel: Ort %r fehlgeschlagen",
+                        getattr(locations[idx], "id", idx), exc_info=True,
+                    )
+                    fehler.append((idx, exc))
+
+    # AC-8 (Fehlerformen unveraendert): scheitert JEDER Ort mit einer Ausnahme,
+    # ist die Stoerung systemisch -- vor der Parallelisierung lief die Engine
+    # EINMAL fuer alle Orte, eine solche Ausnahme schlug bis zum Router durch
+    # und wurde dort zu HTTP 503 (api/routers/preview.py:99-110). N
+    # gleichlautende Ortsfehler in einer 200er-Antwort waeren eine ANDERE
+    # Fehlerform. Bei genau EINEM Ort gilt dasselbe: einen echten Ortsfehler
+    # haette ``run()`` selbst abgefangen (s. ``_run_one_location``).
+    if fehler and len(fehler) == len(locations):
+        raise fehler[0][1]
+    # Teilausfall bleibt Ortsfehler (AC-3): der betroffene Ort erscheint MIT
+    # Fehlermeldung an SEINER Position, die uebrigen behalten ihre Daten.
+    for idx, exc in fehler:
+        fetched[idx] = LocationResult(
+            location=locations[idx], error=str(exc) or type(exc).__name__,
+        )
+
+    # ``fetched`` ist danach luecklos besetzt: jeder Index traegt entweder das
+    # Engine-Ergebnis oder ein LocationResult mit gesetztem ``error``.
+    return ComparisonResult(
+        locations=cast(List[LocationResult], fetched),
+        time_window=time_window,
+        target_date=target_date,
+        created_at=created_at,
+    )

--- a/tests/tdd/test_compare_preview_service.py
+++ b/tests/tdd/test_compare_preview_service.py
@@ -21,6 +21,7 @@ Die Renderer selbst bleiben echt (reine Funktionen, kein Netz).
 """
 from __future__ import annotations
 
+import threading
 import uuid
 from datetime import date, datetime
 
@@ -107,6 +108,13 @@ class _EngineCalls:
         self.count = 0
         self.locations_seen: list[list[SavedLocation]] = []
         self.kwargs_seen: list[dict] = []
+        # #1765 B1 (AC-4): die im Journal landende Diagnose-Quelle, aufgeloest
+        # im AUSFUEHRENDEN Thread -- genau so, wie log_api_call sie sieht.
+        self.sources_seen: list[str] = []
+        # #1765 B1: die Naht wird jetzt aus mehreren Threads GLEICHZEITIG
+        # bedient (ein Engine-Lauf je Ort) -- ohne Sperre koennte ein
+        # Zaehler-Inkrement verloren gehen und der Test zufaellig rot werden.
+        self.lock = threading.Lock()
 
 
 def _install_recording_engine(monkeypatch, calls: _EngineCalls) -> None:
@@ -129,9 +137,14 @@ def _install_recording_engine(monkeypatch, calls: _EngineCalls) -> None:
             if locations is None and args:
                 locations = args[0]
             locations = list(locations or [])
-            calls.count += 1
-            calls.locations_seen.append(locations)
-            calls.kwargs_seen.append(dict(kwargs))
+            from providers.call_log import resolve_call_source
+
+            source = resolve_call_source()
+            with calls.lock:
+                calls.count += 1
+                calls.locations_seen.append(locations)
+                calls.kwargs_seen.append(dict(kwargs))
+                calls.sources_seen.append(source)
             return ComparisonResult(
                 locations=[
                     LocationResult(
@@ -228,10 +241,23 @@ def test_email_preview_shows_real_preset_locations_not_stub(compare_env, monkeyp
         "'Vorschau-Ort' (validator_render_service.py:147) statt der Orte des Nutzers."
     )
     assert "preview-1" not in html, "Stub-Orts-ID 'preview-1' darf in der Vorschau nicht vorkommen"
-    assert calls.count == 1, f"Genau ein Engine-Lauf erwartet, waren {calls.count}"
-    assert [loc.id for loc in calls.locations_seen[0]] == ["loc-ibk", "loc-bz"], (
+    # Abgeloester Vertrag (#1765 B1): frueher EIN Engine-Lauf mit beiden Orten,
+    # jetzt ein Lauf JE ORT (parallel). Geprueft wird die Vereinigung ueber alle
+    # Aufrufe -- deren REIHENFOLGE ist die (nichtdeterministische) Startfolge der
+    # Threads und taugt nicht mehr als Zusicherung; die konfigurierte Reihenfolge
+    # wird deshalb dort geprueft, wo sie wirkt: in der gerenderten Vorschau.
+    assert calls.count == len(locations), (
+        f"Genau ein Engine-Lauf je Ort erwartet ({len(locations)}), waren {calls.count}"
+    )
+    assert sorted(loc.id for aufruf in calls.locations_seen for loc in aufruf) == [
+        "loc-bz", "loc-ibk",
+    ], (
         "Der Service muss die im Preset konfigurierten Orte an die "
-        f"ComparisonEngine reichen, uebergeben wurden: {calls.locations_seen[0]!r}"
+        f"ComparisonEngine reichen, uebergeben wurden: {calls.locations_seen!r}"
+    )
+    assert html.index("Innsbruck") < html.index("Bozen"), (
+        "Die im Preset konfigurierte Ortsreihenfolge muss in der Vorschau "
+        "erhalten bleiben (kein Sortieren nach Fertigstellung)"
     )
 
 
@@ -274,23 +300,35 @@ def test_telegram_preview_renders_real_preset_locations(compare_env, monkeypatch
         f"sein, war aber: {text[:300]!r}"
     )
     assert "Vorschau-Ort" not in text, "Stub-Ort darf in der Telegram-Vorschau nicht vorkommen"
-    assert calls.count == 1, f"Genau ein Engine-Lauf erwartet, waren {calls.count}"
+    # #1765 B1: ein Engine-Lauf JE ORT (parallel) statt einem je Ortsmenge.
+    assert calls.count == len(locations), (
+        f"Genau ein Engine-Lauf je Ort erwartet ({len(locations)}), waren {calls.count}"
+    )
 
 
 # ---------------------------------------------------------------------------
-# Test 8 (AC-7) — EIN Aufruf, EIN Engine-Lauf, alle drei Kanaele gefuellt
+# Test 8 (AC-7) — EIN Aufruf, EIN Engine-Lauf JE ORT, alle drei Kanaele gefuellt
 # ---------------------------------------------------------------------------
 
 
-def test_single_preview_call_runs_engine_once_and_fills_all_channels(compare_env, monkeypatch):
+def test_single_preview_call_runs_engine_once_per_location_and_fills_all_channels(
+    compare_env, monkeypatch
+):
     """GIVEN ein Preset mit zwei Orten
     WHEN die Preview-Einstiegsfunktion EINMAL aufgerufen wird
-    THEN wird ComparisonEngine.run genau einmal ausgefuehrt UND die Antwort
-    traegt email_html, telegram und sms gleichzeitig gefuellt.
+    THEN laeuft ComparisonEngine.run genau einmal JE ORT (parallel statt
+    nacheinander, #1765 Scheibe B1) UND die Antwort traegt email_html, telegram
+    und sms gleichzeitig gefuellt.
 
-    Aufruf-Zaehler ueber eine echte Subklasse (kein Verhaltens-Mock).
-    RED: services.compare_preview_service existiert nicht — es gibt heute
-    keinen Einstieg, der alle Kanaele in einer Antwort liefert (ADR-0011)."""
+    Abgeloester Vertrag: bis #1765 B1 lautete die Zusicherung `calls.count == 1`
+    ("ein Engine-Lauf je Ortsmenge"). Die Parallelisierung ruft die Engine je
+    Ort einzeln auf (`run(locations=[loc])`); der Teil der Zusicherung, der dem
+    Nutzer nuetzt — alle Kanaele in EINER Antwort, kein zusaetzlicher
+    Kanalwechsel-Aufruf —, bleibt unveraendert und wird unten weiter geprueft.
+    Spec: docs/specs/modules/fix_1765_b1_compare_vorschau_parallel.md
+    ("Ein abzuloesender Bestandsvertrag").
+
+    Aufruf-Zaehler ueber eine echte Subklasse (kein Verhaltens-Mock)."""
     user_id = compare_env
     locations = [
         _location("loc-ibk", "Innsbruck", 47.27, 11.39),
@@ -306,9 +344,17 @@ def test_single_preview_call_runs_engine_once_and_fills_all_channels(compare_env
         "cp-1270-c", user_id=user_id, target_date=TARGET_DATE.isoformat()
     )
 
-    assert calls.count == 1, (
-        "AC-7: Ein Vorschau-Aufruf darf die Wetter-Berechnung genau EINMAL "
-        f"ausloesen (ein ComparisonEngine.run), gezaehlt wurden {calls.count}."
+    assert calls.count == len(locations), (
+        "AC-7 (neu, #1765 B1): Ein Vorschau-Aufruf loest genau eine "
+        f"Wetter-Berechnung JE ORT aus ({len(locations)} Orte -> "
+        f"{len(locations)} ComparisonEngine.run), gezaehlt wurden {calls.count}."
+    )
+    # AC-4 (#1765 B1) am Wirkort: in den Worker-Threads steht keiner der 11
+    # Bestandsmarker mehr im Stack -- ohne durchgereichte Quelle buchte das
+    # Diagnose-Journal jeden Abruf dieser Vorschau als "unbekannt".
+    assert calls.sources_seen == ["vergleich"] * len(locations), (
+        "AC-4: Jeder Orts-Lauf muss die Diagnose-Quelle 'vergleich' tragen, "
+        f"aufgeloest wurde: {calls.sources_seen}"
     )
     email_html = _flatten_text(_field(payload, "email_html"))
     telegram = _flatten_text(_field(payload, "telegram"))

--- a/tests/unit/test_call_source_ueber_threadgrenze.py
+++ b/tests/unit/test_call_source_ueber_threadgrenze.py
@@ -1,0 +1,181 @@
+"""AC-4 (#1765 Scheibe B1): die Diagnose-Quelle ueberlebt den Threadwechsel.
+
+Spec: docs/specs/modules/fix_1765_b1_compare_vorschau_parallel.md
+
+``resolve_call_source()`` (src/providers/call_log.py:56-64) liest die
+Funktionsnamen aus dem Aufruf-Stapel des AUSFUEHRENDEN Threads. Sobald die Orte
+eines Vergleichs in eigenen Threads berechnet werden, taucht dort keiner der 11
+Bestandsmarker (call_log.py:41-53) mehr auf und das Journal bucht "unbekannt"
+(belegt: 7,4 % im Diagnose-Journal, Cluster beim bereits parallelen
+stage_weather-Pfad).
+
+RED-Grund: ``providers.call_log.override_call_source`` existiert nicht
+(ImportError). Der Name wird hier festgelegt: ein Context-Manager mit
+Zuruecksetzen, Vorbild ``official_alerts/warn_egress.py:84-96``.
+
+Geprueft wird die im Journal TATSAECHLICH VERZEICHNETE Quelle je Eintrag --
+nicht die Anwesenheit einer Funktion im Quelltext.
+"""
+from __future__ import annotations
+
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+WORKTREE = Path(__file__).resolve().parents[2]
+ZEITSCHRANKE = 5.0  # Sekunden
+BASIS = "https://api.open-meteo.com/v1/"
+
+
+@pytest.fixture
+def journal(tmp_path, monkeypatch):
+    """Diagnose-Journal auf eine Wegwerf-Datei umlenken; liefert einen Leser
+    (Endpunkt -> verzeichnete Quelle)."""
+    from providers import call_log
+
+    # Pfadregel #1409: der Pruefling muss aus DIESEM Checkout stammen.
+    assert Path(call_log.__file__).resolve().is_relative_to(WORKTREE), call_log.__file__
+    pfad = tmp_path / "openmeteo_calls.jsonl"
+    monkeypatch.setattr(call_log, "DIAGNOSTICS_PATH", pfad)
+
+    def lesen() -> dict[str, str]:
+        zeilen = pfad.read_text().splitlines() if pfad.exists() else []
+        eintraege = [json.loads(z) for z in zeilen]
+        return {e["endpoint"]: e["source"] for e in eintraege}
+
+    return lesen
+
+
+def test_ac4_gleichzeitige_threads_verzeichnen_ihre_quelle_im_journal(journal):
+    """AC-4: Zwei Threads laufen per Treffpunkt-Sperre garantiert gleichzeitig
+    und protokollieren je einen Abruf innerhalb des Quellen-Overrides. Beide
+    Eintraege muessen "vergleich" tragen -- im Worker-Stack steht keiner der 11
+    Bestandsmarker, ohne Override buchte das Journal "unbekannt"."""
+    from providers.call_log import log_api_call, override_call_source
+
+    treffpunkt = threading.Barrier(2)
+
+    def ortsberechnung(nummer: int) -> None:
+        treffpunkt.wait(timeout=ZEITSCHRANKE)
+        with override_call_source("vergleich"):
+            log_api_call(f"{BASIS}ort-{nummer}", 200)
+
+    threads = [threading.Thread(target=ortsberechnung, args=(n,)) for n in (1, 2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=ZEITSCHRANKE * 2)
+        assert not t.is_alive(), "Thread haengt -- Treffpunkt nicht aufgeloest?"
+
+    assert journal() == {f"{BASIS}ort-1": "vergleich", f"{BASIS}ort-2": "vergleich"}, (
+        f"AC-4: Das Journal verzeichnete {journal()} statt fuer JEDEN Eintrag "
+        "'vergleich'. Im Worker-Stack fehlen die 11 Namens-Marker -- die Quelle "
+        "muss im jeweiligen Thread gesetzt und VOR der Stapel-Inspektion "
+        "geprueft werden."
+    )
+
+
+def test_ohne_override_greifen_die_bestandsmarker_weiter(journal):
+    """Rueckwaerts-Vertrag: Threads OHNE eigenen Override verhalten sich
+    unveraendert wie heute -- die 11 Namens-Marker bleiben der Rueckfall, ohne
+    Marker bleibt es bei "unbekannt". Zusaetzlich geprueft: ein in einem ANDEREN
+    Verarbeitungspfad aktiver Override faerbt nicht auf sie ab."""
+    from providers.call_log import log_api_call, override_call_source
+
+    def render_email_preview() -> None:  # Bestandsmarker -> "vorschau"
+        log_api_call(f"{BASIS}mit-marker", 200)
+
+    def namenloser_pfad() -> None:  # kein Marker -> "unbekannt"
+        log_api_call(f"{BASIS}ohne-marker", 200)
+
+    with override_call_source("vergleich"):  # in einem FREMDEN Pfad aktiv
+        for ziel in (render_email_preview, namenloser_pfad):
+            t = threading.Thread(target=ziel)
+            t.start()
+            t.join(timeout=ZEITSCHRANKE)
+            assert not t.is_alive(), f"Thread {ziel.__name__} haengt"
+
+    assert journal() == {
+        f"{BASIS}mit-marker": "vorschau",
+        f"{BASIS}ohne-marker": "unbekannt",
+    }, (
+        f"Das Journal verzeichnete {journal()}. Wer keinen eigenen Override "
+        "setzt, muss die Quelle unveraendert ueber die Bestandsmarker "
+        "(call_log.py:41-53) bekommen -- ein fremder Override darf nicht "
+        "abfaerben."
+    )
+
+
+def test_override_geht_dem_bestandsmarker_vor(journal):
+    """Vorrang-Regel (Spec: "Pruefung dieses Override-Werts VOR der bisherigen
+    Stapel-Inspektion"). Anlass: Adversary-Finding F002 — vertauschte man die
+    Reihenfolge, blieb KEINER der 18 Tests rot, weil in keinem Szenario
+    gleichzeitig ein Override aktiv UND ein Bestandsmarker im Stapel stand.
+
+    Genau das wird hier hergestellt: der Aufruf laeuft aus einer Funktion
+    ``_fetch_weather`` heraus (Bestandsmarker -> "briefing", call_log.py:53).
+    Ohne Vorrang gewaenne der Marker und das Journal buchte die parallele
+    Vergleichs-Berechnung als "briefing" — eine falsche Herkunft, nicht bloss
+    eine fehlende."""
+    from providers.call_log import log_api_call, override_call_source, resolve_call_source
+
+    def _fetch_weather(mit_override: bool) -> str:  # Bestandsmarker -> "briefing"
+        if not mit_override:
+            log_api_call(f"{BASIS}nur-marker", 200)
+            return resolve_call_source()
+        with override_call_source("vergleich"):
+            log_api_call(f"{BASIS}marker-und-override", 200)
+            return resolve_call_source()
+
+    assert _fetch_weather(False) == "briefing", (
+        "Vorbedingung: ohne Override MUSS der Bestandsmarker '_fetch_weather' "
+        "greifen — sonst prueft dieser Test keinen Vorrang, sondern nichts."
+    )
+
+    assert _fetch_weather(True) == "vergleich", (
+        "Der ausdruecklich gesetzte Override muss VOR der Stapel-Inspektion "
+        "geprueft werden — sonst ueberdeckt ein beliebiger Bestandsmarker im "
+        "Aufrufstapel die tatsaechliche Herkunft."
+    )
+    assert journal() == {
+        f"{BASIS}nur-marker": "briefing",
+        f"{BASIS}marker-und-override": "vergleich",
+    }, (
+        f"Am Wirkort (Diagnose-Journal) verzeichnet: {journal()}. Der Eintrag "
+        "innerhalb des Overrides muss 'vergleich' tragen, obwohl '_fetch_weather' "
+        "im Stapel steht."
+    )
+
+
+def test_quelle_wird_nach_dem_bereich_zurueckgesetzt(journal):
+    """Ein ``ThreadPoolExecutor`` verwendet seine Threads wieder: bleibt der
+    Override nach dem Bereich stehen, erbt eine spaetere, fachlich ANDERE
+    Anfrage die Quelle "vergleich". Beide Aufgaben laufen hier nachweislich im
+    SELBEN Thread -- ohne diese Vorbedingung bewiese der Test nichts."""
+    from providers.call_log import log_api_call, override_call_source
+
+    def mit_override() -> int:
+        with override_call_source("vergleich"):
+            log_api_call(f"{BASIS}im-bereich", 200)
+        return threading.get_ident()
+
+    def danach() -> int:
+        log_api_call(f"{BASIS}nach-dem-bereich", 200)
+        return threading.get_ident()
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        erster = pool.submit(mit_override).result(timeout=ZEITSCHRANKE)
+        zweiter = pool.submit(danach).result(timeout=ZEITSCHRANKE)
+
+    assert erster == zweiter, "Vorbedingung: beide Aufgaben muessen denselben Thread nutzen"
+    eintraege = journal()
+    assert eintraege.get(f"{BASIS}im-bereich") == "vergleich"
+    assert eintraege.get(f"{BASIS}nach-dem-bereich") == "unbekannt", (
+        "Der Override wurde nach dem Bereich nicht zurueckgesetzt -- der "
+        "wiederverwendete Thread vererbt "
+        f"{eintraege.get(f'{BASIS}nach-dem-bereich')!r} in eine spaetere, "
+        "fachlich andere Anfrage (Spec: reset(token), Vorbild warn_egress.py:95)."
+    )

--- a/tests/unit/test_compare_vorschau_systemfehler.py
+++ b/tests/unit/test_compare_vorschau_systemfehler.py
@@ -1,0 +1,207 @@
+"""AC-8/AC-3 (#1765 Scheibe B1) am WIRKORT: systemische Stoerung vs. Ortsfehler.
+
+Spec: docs/specs/modules/fix_1765_b1_compare_vorschau_parallel.md
+Anlass: Adversary-Finding F001 (HIGH, Verdict BROKEN) —
+docs/artifacts/fix-1765-compare-vorschau-parallel/adversary-dialog.md
+
+``ComparisonEngine.run()`` fasst einen echten ORTSFEHLER bereits selbst in ein
+``LocationResult(error=...)`` und wirft dafuer nicht (comparison_engine.py:
+128-147, :369-381). Was als AUSNAHME herauskommt, ist deshalb per Definition
+systemisch (z.B. die ``Settings()``-Konstruktion vor der Ortsschleife) — vor
+der Parallelisierung schlug so etwas bis zum Router durch und wurde dort zu
+HTTP 503 (api/routers/preview.py:99-110). Ein breiter Ausnahmefang je Ort
+machte daraus eine 200er-Antwort mit N gleichlautenden Ortsfehlern: andere
+Form, anderer Inhalt, AC-8 verletzt.
+
+🔴 **Warum eine eigene Datei und nicht
+``test_preview_fehlerformen.py::test_vergleichs_vorschau_meldet_wetterausfall_als_503``:**
+jener Test ersetzt die GESAMTE ``ComparePreviewService``-Klasse durch einen
+stoerenden Ersatz und erreicht ``run_comparison_parallel`` nie — er bewacht die
+Zuordnung im Router, nicht die neue Nahtstelle. Hier laeuft der ECHTE Dienst
+mit echten Preset-/Ortsdaten; substituiert wird ausschliesslich die teure
+Engine-Naht (braucht Live-Wetter, in der Kern-Schicht verboten), und zwar per
+echter Subklasse, kein Mock.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.loader import get_data_dir, save_location
+from app.models import ForecastDataPoint, ThunderLevel
+from app.user import SavedLocation
+
+from tests.helpers.compare_briefings import write_compare_briefings
+
+WORKTREE = Path(__file__).resolve().parents[2]
+ZIELDATUM = date(2026, 7, 8)
+AUSFALL = "Wetterdaten aktuell nicht verfuegbar (Testfall)"
+ORTE = [
+    ("loc-ibk", "Innsbruck", 47.27, 11.39),
+    ("loc-bz", "Bozen", 46.50, 11.35),
+    ("loc-muc", "Muenchen", 48.14, 11.58),
+]
+
+
+def _dp(hour: int) -> ForecastDataPoint:
+    return ForecastDataPoint(
+        ts=datetime(ZIELDATUM.year, ZIELDATUM.month, ZIELDATUM.day, hour, 0),
+        t2m_c=22.0, wind_chill_c=21.0, wind10m_kmh=11.0, gust_kmh=19.0,
+        precip_1h_mm=0.0, cloud_total_pct=35, uv_index=5.0,
+        thunder_level=ThunderLevel.NONE, pop_pct=10, visibility_m=9000,
+    )
+
+
+@pytest.fixture
+def preset_mit_drei_orten(tmp_path, monkeypatch):
+    """Isolierter Daten-Root mit drei ECHTEN Orten + Preset; liefert
+    ``(preset_id, user_id)``. Muster: tests/tdd/test_compare_preview_service.py."""
+    from app import loader as app_loader
+
+    data_root = tmp_path / "data"
+    data_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(app_loader, "_DATA_ROOT", str(data_root))
+    try:
+        from src.app import loader as src_loader
+
+        monkeypatch.setattr(src_loader, "_DATA_ROOT", str(data_root))
+    except ImportError:  # pragma: no cover — Alias-Modul immer vorhanden
+        pass
+    user_id = f"f001-{uuid.uuid4().hex[:8]}"
+    for loc_id, name, lat, lon in ORTE:
+        save_location(
+            SavedLocation(id=loc_id, name=name, lat=lat, lon=lon, elevation_m=1000),
+            user_id=user_id,
+        )
+    preset_id = "cp-f001"
+    write_compare_briefings(get_data_dir(user_id), [{
+        "id": preset_id, "name": "Urlaubsorte", "user_id": user_id,
+        "location_ids": [loc_id for loc_id, *_ in ORTE],
+        "schedule": "daily", "profil": "ALLGEMEIN",
+        "empfaenger": ["gregor-test@henemm.com"],
+        "created_at": "2026-07-01T00:00:00Z",
+    }])
+    return preset_id, user_id
+
+
+@pytest.fixture
+def client():
+    import services.comparison_parallel as pruefling
+    from api.routers import preview
+
+    # Pfadregel #1409: der Pruefling muss aus DIESEM Checkout stammen -- sonst
+    # misst dieser Test aus dem Worktree die unveraenderte Hauptrepo-Kopie und
+    # meldet falsches Gruen.
+    assert Path(pruefling.__file__).resolve().is_relative_to(WORKTREE), pruefling.__file__
+    app = FastAPI()
+    app.include_router(preview.router)
+    return TestClient(app)
+
+
+def _engine_scheitert_bei(monkeypatch, ids: set[str]) -> None:
+    """Engine-Naht durch eine echte Subklasse ersetzen, die fuer die genannten
+    Orte WIRFT — das Muster einer Stoerung AUSSERHALB der ortsinternen
+    Fehlerbehandlung (ein Ortsfehler kaeme als ``LocationResult(error=...)``)."""
+    import services.comparison_engine as ce_mod
+    from app.user import ComparisonResult, LocationResult
+
+    class ScheiterndeEngine(ce_mod.ComparisonEngine):  # echte Subklasse, kein Mock
+        @staticmethod
+        def run(*args, **kwargs):
+            orte = list(kwargs.get("locations") or (args[0] if args else []))
+            for ort in orte:
+                if ort.id in ids:
+                    raise RuntimeError(AUSFALL)
+            return ComparisonResult(
+                locations=[
+                    LocationResult(
+                        location=o, score=90, temp_max=22.0, temp_min=12.0,
+                        wind_max=11.0, gust_max=19.0, cloud_avg=35, sunny_hours=6,
+                        official_alerts=[], hourly_data=[_dp(9), _dp(12), _dp(15)],
+                    )
+                    for o in orte
+                ],
+                time_window=kwargs.get("time_window", (4, 19)),
+                target_date=kwargs.get("target_date", ZIELDATUM),
+                created_at=datetime(2026, 7, 8, 4, 0),
+            )
+
+    monkeypatch.setattr(ce_mod, "ComparisonEngine", ScheiterndeEngine)
+
+
+def _vorschau(client, preset_id: str, user_id: str):
+    return client.post(
+        f"/api/preview/compare/{preset_id}",
+        params={"user_id": user_id, "date": ZIELDATUM.isoformat()},
+    )
+
+
+def _blockzeile(telegram: str, ortsname: str) -> str:
+    """Die Inhaltszeile des Ortsblocks (Renderer: Name als eigene Zeile, danach
+    entweder ``   Fehler: …`` oder die Werte-Zellen)."""
+    zeilen = telegram.splitlines()
+    assert ortsname in zeilen, f"Ort {ortsname!r} fehlt in der Vorschau:\n{telegram}"
+    return zeilen[zeilen.index(ortsname) + 1]
+
+
+def test_systemische_stoerung_bleibt_ein_503(client, preset_mit_drei_orten, monkeypatch):
+    """AC-8: JEDER Ort scheitert mit derselben Ausnahme (Wetterdienst komplett
+    weg / Konfigurationsfehler) → der echte Vorschau-Pfad antwortet wie vor der
+    Parallelisierung mit HTTP 503 und der durchgereichten Meldung — nicht mit
+    200 und N eingebetteten Ortsfehlern."""
+    preset_id, user_id = preset_mit_drei_orten
+    _engine_scheitert_bei(monkeypatch, {loc_id for loc_id, *_ in ORTE})
+
+    antwort = _vorschau(client, preset_id, user_id)
+
+    assert antwort.status_code == 503, (
+        "AC-8: Eine Stoerung, die ALLE Orte trifft, ist systemisch und muss die "
+        "bisherige Fehlerform behalten (RuntimeError → 503). Bekommen: "
+        f"{antwort.status_code} — {antwort.text[:300]}"
+    )
+    assert AUSFALL in antwort.text, (
+        f"Die Meldung des Dienstes muss im 503-Detail stehen: {antwort.text[:300]}"
+    )
+
+
+def test_ein_ort_von_dreien_scheitert_liefert_weiter_200(
+    client, preset_mit_drei_orten, monkeypatch
+):
+    """AC-3: Scheitert nur EIN Ort mit einer Ausnahme, bleibt es beim heutigen
+    Verhalten — 200, die uebrigen Orte vollstaendig, der betroffene mit Fehler
+    AN SEINER POSITION. Die 503-Regel aus AC-8 darf hier nicht greifen."""
+    preset_id, user_id = preset_mit_drei_orten
+    _engine_scheitert_bei(monkeypatch, {"loc-bz"})
+
+    antwort = _vorschau(client, preset_id, user_id)
+
+    assert antwort.status_code == 200, (
+        "AC-3: Ein einzelner gescheiterter Ort darf die Vorschau der anderen "
+        f"nicht verhindern. Bekommen: {antwort.status_code} — {antwort.text[:300]}"
+    )
+    nutzlast = antwort.json()
+    telegram, html = nutzlast["telegram"], nutzlast["email_html"]
+    zeilen = telegram.splitlines()
+    assert [n for n in ("Innsbruck", "Bozen", "Muenchen") if n in zeilen] == [
+        "Innsbruck", "Bozen", "Muenchen",
+    ] and zeilen.index("Innsbruck") < zeilen.index("Bozen") < zeilen.index("Muenchen"), (
+        f"Alle drei Orte muessen in konfigurierter Reihenfolge erscheinen:\n{telegram}"
+    )
+    assert AUSFALL in _blockzeile(telegram, "Bozen"), (
+        f"Der gescheiterte Ort braucht seine Fehlermeldung an seiner Position:\n{telegram}"
+    )
+    for name in ("Innsbruck", "Muenchen"):
+        zeile = _blockzeile(telegram, name)
+        assert "Fehler" not in zeile and "22" in zeile, (
+            f"AC-3: {name} muss seine VOLLSTAENDIGEN Werte behalten (temp_max=22), "
+            f"geliefert wurde: {zeile!r}\n{telegram}"
+        )
+    assert "Innsbruck" in html and "Muenchen" in html, (
+        "Auch die E-Mail-Vorschau derselben Antwort muss die gesunden Orte zeigen"
+    )

--- a/tests/unit/test_comparison_parallel.py
+++ b/tests/unit/test_comparison_parallel.py
@@ -1,0 +1,298 @@
+"""AC-1/2/3/5/6 (#1765 Scheibe B1): ``run_comparison_parallel`` berechnet die
+Orte eines Vergleichs GLEICHZEITIG und fuehrt sie POSITIONSTREU zusammen.
+
+Spec: docs/specs/modules/fix_1765_b1_compare_vorschau_parallel.md
+
+RED-Grund: ``src/services/comparison_parallel.py`` existiert nicht
+(ModuleNotFoundError in jedem Test).
+
+Kein Mock-Theater: substituiert wird ausschliesslich die teure Naht
+``ComparisonEngine.run`` (braucht Live-Wetter, in der Kern-Schicht verboten) --
+durch eine echte Subklasse, die ihr Ergebnis AUS den uebergebenen Orten baut
+(Haus-Muster: tests/tdd/test_compare_preview_service.py:112-162). Die
+Gleichzeitigkeit wird ueber eine Treffpunkt-Sperre nachgewiesen, NICHT ueber
+Wanduhr-Zeitmessung (Muster: tests/unit/test_timezone_singleton_threadsicher.py:72-124).
+"""
+from __future__ import annotations
+
+import threading
+import time
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from app.user import SavedLocation
+
+WORKTREE = Path(__file__).resolve().parents[2]
+ZIELDATUM = date(2026, 7, 8)
+ZEITSCHRANKE = 5.0  # Sekunden -- grosszuegig, aber endlich: ein serieller Lauf
+#                     laeuft in die Sperre statt den Testlauf haengen zu lassen.
+
+
+def _jetzt() -> datetime:
+    """Schranken-Zeitbasis fuer AC-5: naive UTC, wie die Hausnorm #1345 sie fuer
+    ``ComparisonResult.created_at`` vorschreibt (``utils.timezone._as_utc``
+    deutet naive Werte als UTC, die Renderer rechnen sie darueber in Ortszeit
+    um). NICHT ``datetime.now()``: die Root-conftest fixiert die Prozesszone auf
+    ``America/St_Johns`` (-2:30), eine Schranke aus der Prozessuhr wuerde also
+    die ZEITZONE messen statt die Zusicherung -- und der Pruefling darf sie
+    nicht benutzen (tests/test_output_timezone_guard.py verbietet die nackte
+    Umgebungsuhr im Entscheidungs-/Ausgabepfad)."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _ort(nummer: int) -> SavedLocation:
+    return SavedLocation(
+        id=f"loc-{nummer}", name=f"Ort {nummer}",
+        lat=47.0 + nummer, lon=11.0 + nummer, elevation_m=1000,
+    )
+
+
+class _Protokoll:
+    """Aufrufprotokoll der Engine-Naht (uebergebene Orte + Keyword-Argumente
+    je Aufruf), threadsicher gesammelt."""
+
+    def __init__(self) -> None:
+        self.aufrufe: list[tuple[list[SavedLocation], dict]] = []
+        self._sperre = threading.Lock()
+
+    def vermerke(self, orte, kwargs) -> None:
+        with self._sperre:
+            self.aufrufe.append((orte, kwargs))
+
+    def ids_je_aufruf(self) -> list[list[str]]:
+        return [[o.id for o in orte] for orte, _ in self.aufrufe]
+
+
+def _baustein(monkeypatch, protokoll: _Protokoll, haken=None, stempel=None):
+    """Pruefling laden und die Engine-Naht durch eine echte Subklasse ersetzen.
+    ``haken(ort)`` erzwingt Gleichzeitigkeit, Verzoegerung oder Ortsfehler,
+    ``stempel`` setzt ein abweichendes ``created_at`` je Teilergebnis."""
+    import services.comparison_engine as ce_mod
+    from app.user import ComparisonResult, LocationResult
+
+    import services.comparison_parallel as modul  # RED: existiert noch nicht
+
+    # Pfadregel #1409: aus einem Worktree darf nicht die Hauptrepo-Kopie
+    # geprueft werden -- sonst meldet dieser Test falsches Gruen.
+    assert Path(modul.__file__).resolve().is_relative_to(WORKTREE), modul.__file__
+
+    class StubEngine(ce_mod.ComparisonEngine):  # echte Subklasse, kein Mock
+        @staticmethod
+        def run(*args, **kwargs):
+            orte = list(kwargs["locations"] if "locations" in kwargs else args[0])
+            protokoll.vermerke(orte, dict(kwargs))
+            for ort in orte:
+                if haken is not None:
+                    haken(ort)
+            return ComparisonResult(
+                locations=[
+                    LocationResult(location=o, score=50, temp_max=20.0) for o in orte
+                ],
+                time_window=kwargs.get("time_window", (4, 19)),
+                target_date=kwargs.get("target_date", ZIELDATUM),
+                created_at=stempel if stempel is not None else datetime.now(),
+            )
+
+    monkeypatch.setattr(ce_mod, "ComparisonEngine", StubEngine)
+    if hasattr(modul, "ComparisonEngine"):  # Modul-Level-Import des Prueflings
+        monkeypatch.setattr(modul, "ComparisonEngine", StubEngine)
+    return modul
+
+
+def _lauf(modul, orte, **extra):
+    return modul.run_comparison_parallel(
+        locations=orte, time_window=(4, 19), target_date=ZIELDATUM, **extra
+    )
+
+
+def test_ac1_alle_orte_werden_gleichzeitig_berechnet(monkeypatch):
+    """AC-1: Drei Orte melden sich an einer Treffpunkt-Sperre an. Nacheinander
+    verarbeitet erreicht der zweite Ort den Treffpunkt nie -- die Sperre laeuft
+    in ihre Zeitschranke und KEIN Ort kommt durch. Uhrunabhaengig, kein
+    Zwischenzustand, der zufaellig gruen werden koennte."""
+    orte = [_ort(i) for i in range(3)]
+    treffpunkt = threading.Barrier(len(orte))
+    durch: list[str] = []
+    sperre = threading.Lock()
+
+    def am_treffpunkt(ort):
+        treffpunkt.wait(timeout=ZEITSCHRANKE)
+        with sperre:
+            durch.append(ort.id)
+
+    ergebnis = _lauf(_baustein(monkeypatch, _Protokoll(), haken=am_treffpunkt), orte)
+
+    assert sorted(durch) == [o.id for o in orte], (
+        f"Nur {sorted(durch)} von {[o.id for o in orte]} erreichten den Treffpunkt "
+        "-- die Orte werden nacheinander statt gleichzeitig berechnet (AC-1). "
+        "Erwartet: ThreadPoolExecutor, max_workers=min(len(locations), 4), "
+        "Vorbild services/stage_weather.py:170-183."
+    )
+    assert [lr.location.id for lr in ergebnis.locations] == [o.id for o in orte]
+    assert all(lr.error is None for lr in ergebnis.locations), (
+        "AC-1 verlangt ein VOLLSTAENDIGES Ergebnis fuer alle Orte: "
+        f"{[(lr.location.id, lr.error) for lr in ergebnis.locations]}"
+    )
+
+
+def test_ac2_reihenfolge_bleibt_bei_gedrehter_fertigstellung(monkeypatch):
+    """AC-2: Der ZUERST konfigurierte Ort braucht am laengsten, der ZULETZT
+    konfigurierte am kuerzesten -- die Fertigstellungsreihenfolge ist damit
+    gezielt gegen die Einreichungsreihenfolge gedreht. Ohne diese Drehung waere
+    auch ein Anhaengen bei Fertigstellung zufaellig richtig."""
+    orte = [_ort(i) for i in range(3)]
+    start = threading.Barrier(len(orte))
+    verzoegerung = {"loc-0": 0.30, "loc-1": 0.15, "loc-2": 0.0}
+    fertig: list[str] = []
+    sperre = threading.Lock()
+
+    def gedreht(ort):
+        start.wait(timeout=ZEITSCHRANKE)  # alle starten gemeinsam
+        time.sleep(verzoegerung[ort.id])
+        with sperre:
+            fertig.append(ort.id)
+
+    ergebnis = _lauf(_baustein(monkeypatch, _Protokoll(), haken=gedreht), orte)
+
+    assert fertig == ["loc-2", "loc-1", "loc-0"], (
+        f"Vorbedingung verletzt: Fertigstellungsreihenfolge {fertig} ist nicht "
+        "gegen die Einreichungsreihenfolge gedreht -- ohne Drehung prueft die "
+        "eigentliche Zusicherung nichts."
+    )
+    assert [lr.location.id for lr in ergebnis.locations] == [o.id for o in orte], (
+        "AC-2: Die Orte muessen in der konfigurierten Reihenfolge erscheinen, "
+        f"nicht in Fertigstellungsreihenfolge -- geliefert wurde "
+        f"{[lr.location.id for lr in ergebnis.locations]}. Erwartet: indexierte "
+        "Vorbelegung (fetched[idx] = ...), kein Anhaengen."
+    )
+
+
+def test_ac3_ein_ortsfehler_reisst_die_anderen_nicht_mit(monkeypatch):
+    """AC-3: Genau ein Ort scheitert unerwartet. Die uebrigen behalten ihre
+    vollstaendigen Daten, der betroffene erscheint MIT Fehler AN SEINER
+    POSITION -- die Listenlaenge bleibt gleich."""
+    orte = [_ort(i) for i in range(3)]
+
+    def scheitert_in_der_mitte(ort):
+        if ort.id == "loc-1":
+            raise RuntimeError("Wetterdaten nicht abrufbar")
+
+    ergebnis = _lauf(
+        _baustein(monkeypatch, _Protokoll(), haken=scheitert_in_der_mitte), orte
+    )
+
+    assert [lr.location.id for lr in ergebnis.locations] == [o.id for o in orte], (
+        "AC-3: Der gescheiterte Ort muss an seiner Position erscheinen, nicht "
+        f"ausgelassen werden -- geliefert: {[lr.location.id for lr in ergebnis.locations]}"
+    )
+    assert ergebnis.locations[1].error, "Der gescheiterte Ort braucht eine Fehlermeldung"
+    assert [ergebnis.locations[0].error, ergebnis.locations[2].error] == [None, None], (
+        "AC-3: Ein einzelner fehlerhafter Ort darf die anderen nicht mitreissen"
+    )
+    assert [ergebnis.locations[0].temp_max, ergebnis.locations[2].temp_max] == [20.0, 20.0], (
+        "AC-3: Die uebrigen Orte muessen ihre VOLLSTAENDIGEN Daten behalten"
+    )
+
+
+def test_ac4_der_baustein_setzt_die_quelle_im_worker_des_ortes(monkeypatch):
+    """AC-4 am WIRKORT statt nur am Mechanismus. Die Mutations-Gegenprobe zeigte:
+    laesst man den Quellen-Override IM BAUSTEIN weg, bleibt jeder Test gruen --
+    test_call_source_ueber_threadgrenze.py prueft ``override_call_source``
+    isoliert, nicht seine Verdrahtung. Hier wird die Quelle genauso ausgelesen,
+    wie das Diagnose-Journal sie sieht: aus dem Thread, der den Abruf ausfuehrt.
+    Ohne Override steht dort keiner der 11 Bestandsmarker -> "unbekannt"."""
+    from providers.call_log import resolve_call_source
+
+    orte = [_ort(i) for i in range(2)]
+    gesehen: dict[str, str] = {}
+    sperre = threading.Lock()
+
+    def merkt_die_quelle(ort):
+        with sperre:
+            gesehen[ort.id] = resolve_call_source()
+
+    _lauf(
+        _baustein(monkeypatch, _Protokoll(), haken=merkt_die_quelle),
+        orte,
+        call_source="vergleich",
+    )
+
+    assert gesehen == {o.id: "vergleich" for o in orte}, (
+        f"AC-4: Im Worker-Thread jedes Ortes wurde {gesehen} als Quelle "
+        "aufgeloest -- der Baustein muss ``override_call_source(call_source)`` "
+        "IM JEWEILIGEN Thread setzen (ein ThreadPoolExecutor reicht den Kontext "
+        "nicht weiter)."
+    )
+
+
+def test_ac5_genau_ein_zeitstempel_fuer_den_ganzen_lauf(monkeypatch):
+    """AC-5: ``created_at`` wird EINMAL vor dem Start gesetzt -- weder aus einem
+    Teilergebnis uebernommen (haenge sonst an der Fertigstellungsreihenfolge)
+    noch je Ort bzw. nach dem Lauf berechnet."""
+    orte = [_ort(i) for i in range(2)]
+    teil_stempel = datetime(2000, 1, 1, 0, 0)
+    erster_eintritt: list[datetime] = []
+    sperre = threading.Lock()
+
+    def bremst(ort):
+        with sperre:
+            if not erster_eintritt:
+                erster_eintritt.append(_jetzt())
+        time.sleep(0.2)
+
+    modul = _baustein(monkeypatch, _Protokoll(), haken=bremst, stempel=teil_stempel)
+    vorher = _jetzt()
+    ergebnis = _lauf(modul, orte)
+
+    assert ergebnis.created_at != teil_stempel, (
+        "AC-5: created_at wurde aus einem Ortsergebnis uebernommen -- der Wert "
+        "haengt dann an der Einreichungs-/Fertigstellungsreihenfolge."
+    )
+    assert vorher <= ergebnis.created_at <= erster_eintritt[0], (
+        f"AC-5: created_at ({ergebnis.created_at}) muss EINMAL vor dem Start der "
+        f"parallelen Verarbeitung gesetzt werden -- der erste Ortslauf begann "
+        f"{erster_eintritt[0]}, der Aufruf startete {vorher}."
+    )
+
+
+def test_ac6_tagesfenster_und_horizont_kommen_bei_jedem_ort_an(monkeypatch):
+    """AC-6: JEDER Ort rechnet mit demselben Tagesfenster und Vorhersage-
+    Zeitraum -- geprueft je Ort, nicht aggregiert und nicht nur am ersten."""
+    orte = [_ort(i) for i in range(3)]
+    erwartet = {"time_window": (6, 20), "forecast_hours": 72, "official_alerts_enabled": False}
+    protokoll = _Protokoll()
+    modul = _baustein(monkeypatch, protokoll)
+
+    modul.run_comparison_parallel(locations=orte, target_date=ZIELDATUM, **erwartet)
+
+    assert sorted(protokoll.ids_je_aufruf()) == [[o.id] for o in orte], (
+        "Jeder Ort braucht GENAU EINEN eigenen Engine-Lauf, gesehen wurde: "
+        f"{protokoll.ids_je_aufruf()}"
+    )
+    gesehen = {
+        ort_liste[0].id: {k: kw.get(k) for k in erwartet}
+        for ort_liste, kw in protokoll.aufrufe
+    }
+    assert gesehen == {o.id: erwartet for o in orte}, (
+        f"AC-6: nicht jeder Ort bekam {erwartet}, sondern {gesehen} -- beim "
+        "Aufteilen der Ortsliste darf kein Parameter verloren gehen."
+    )
+
+
+@pytest.mark.parametrize("anzahl", [0, 1])
+def test_leere_und_ein_ort_liste_laufen_ohne_sperre_durch(monkeypatch, anzahl):
+    """Randfaelle: ``min(len(locations), 4)`` ist bei LEERER Liste ein
+    ungueltiger ``max_workers``-Wert (ValueError) -- abzufangen wie im Vorbild
+    (stage_weather.py:172 ``if flat:``). Ein Ort darf in keine Sperre laufen."""
+    orte = [_ort(i) for i in range(anzahl)]
+    protokoll = _Protokoll()
+
+    ergebnis = _lauf(_baustein(monkeypatch, protokoll), orte)
+
+    assert [lr.location.id for lr in ergebnis.locations] == [o.id for o in orte]
+    assert len(protokoll.aufrufe) == anzahl, (
+        f"{anzahl} Ort(e) -> {anzahl} Engine-Laeufe, gezaehlt: {len(protokoll.aufrufe)}"
+    )
+    assert ergebnis.time_window == (4, 19) and ergebnis.target_date == ZIELDATUM


### PR DESCRIPTION
## Was und warum

Die Vergleichs-Vorschau (`POST /api/preview/compare/{preset_id}`) berechnete die Orte eines Presets **nacheinander** (~25 s je Ort) und riss bei 3+ Orten die 60-s-Grenze zwischen Go-API und nginx — der Nutzer sah nie eine Vorschau. Parallelisiert liegt die Laufzeit bei etwa der des langsamsten Einzelorts.

## Zuschnitt: NUR die Vorschau — #1765 bleibt offen

`ComparisonEngine.run()` hat **drei** unabhängige Aufrufstellen. Diese Scheibe stellt genau eine um:

| Aufrufweg | Betriebsrisiko | hier? |
|---|---|---|
| Vorschau (`compare_preview_service.py:163`) | interaktiv, Nutzer sieht Fehler sofort | **ja** |
| Versand (`scheduler_dispatch_service.py:451`, auch Cron) | unbeaufsichtigt, schreibt Zustand | nein — **B1b** |
| Sofortvergleich (`api/routers/compare.py:71`, öffentlich) | interaktiv, eigener Weg | nein — **B1b** |

Begründung: Nebenläufigkeit wird nicht gleichzeitig in einen beaufsichtigten und einen unbeaufsichtigten, zustandsschreibenden Pfad eingeführt. Der Baustein liegt deshalb von vornherein neutral (`src/services/comparison_parallel.py`), damit B1b nur noch Aufrufstellen umhängt.

`src/services/comparison_engine.py` bleibt **unangetastet** — mechanisch geprüft (`git diff origin/main -- …` leer, vom Adversary unabhängig bestätigt).

## Zwei Adversary-Findings

**F001 (HIGH, AC-8 verletzt).** Ein breites `except Exception` im Worker hätte **jede** Störung in einen Fehlertext je Ort verwandelt — auch einen Totalausfall der Wetterdienste, der bisher als `503` beim Nutzer ankam. `ComparisonEngine.run()` fängt echte Ortsfehler bereits selbst ab; was als Ausnahme herauskommt, ist per Definition systemisch. Jetzt werden Ausnahmen beim Einsammeln mit ihrem Index mitgeführt; scheitern **alle** Orte, wird die des niedrigsten Index erneut geworfen.

Der Bestandstest, der genau das absichern sollte (`test_preview_fehlerformen.py:130`), ersetzt die **gesamte** `ComparePreviewService`-Klasse durch eine Attrappe und erreicht den geänderten Code nie — Prüfort ≠ Wirkort. Neuer Nachweis über den echten Router: `tests/unit/test_compare_vorschau_systemfehler.py`.

**F002 (MEDIUM).** Die Vorrangregel „Override vor Stack-Inspektion" stand nur im Kommentar. Vertauschen der Prüfreihenfolge machte **0 von 18** Tests rot. Jetzt erzwungen.

## Nebenbei repariert

`call_log.resolve_call_source()` liest `inspect.stack()` des **ausführenden** Threads. Im Threadpool verschwinden alle 11 Marker und das Diagnose-Journal bucht `"unbekannt"` — belegt mit 7,4 % aus dem bereits parallelen `stage_weather`-Pfad. Der ContextVar-Override behebt das **prozessweit**, nicht nur für den Vergleich. Wer keinen Override setzt, verhält sich unverändert.

## Nachweislage

**Adversary VERIFIED**, 3 Runden, 10 Kriterien bestätigt. **9 Mutationen, alle gefangen** — darunter `max_workers=1` (täuscht Parallelität vor) und die Wiedereinführung beider Findings.

Der Gleichzeitigkeits-Nachweis läuft über eine `threading.Barrier`, **nicht** über Wanduhr-Zeitmessung: Läuft die Verarbeitung seriell, erreicht der zweite Ort den Treffpunkt nie und der Test läuft in die Zeitschranke. Kein Zwischenzustand, der zufällig grün werden kann.

**Regression:** `tests/unit/` 1493 grün · `tests/test_*.py` (42 Wächter) 348 grün · `tests/tdd/` 3 rot, alle vorbestehend und per Baseline-Gegenprobe gegen `origin/main` belegt (Env-Kollision, Netz-Timeout gegen Staging, `test_staging_gate.py` steht in `ci_tdd_excludes.txt`).

## Bewusste Grenzen (in der Spec benannt, nicht behoben)

- **Thundering Herd** bei den national geschlüsselten Warndiensten für FR/IT (`dpc.py`, `vigilance.py` cachen mit einem festen Schlüssel für alle Orte, ungelockt). Parallel entstehen redundante Abrufe gegen ein Tageskontingent. Kein Datenverlust, keine falsche Anzeige. AT/DE nicht betroffen.
- **Zwei zeitgleiche, verschiedene systemische Ursachen:** der erste konfigurierte Ort entscheidet über die Fehlerart. Deterministisch (Einreichungs-, nicht Fertigstellungsreihenfolge — über 5 Läufe gemessen), aber theoretisch `422` statt `503`. Vor dem Umbau konnte der Fall nicht auftreten.
- 🔴 **AC-9 (`/api/health` während laufender Vorschau) ist im Kern nur mittelbar belegt** — der zuständige Test stammt unverändert aus Scheibe A und ersetzt den ganzen Dienst durch eine Attrappe. **Die Staging-Verifikation MUSS `/api/health` während einer echten Vorschau mit 3+ Orten messen**; ohne diese Messung gilt AC-9 als unbelegt.

## Aufwand, ehrlich

Geschätzt 65 Produktiv- + 140–180 Testzeilen. Tatsächlich **215 + 732**. Nicht der Mechanismus war unterschätzt, sondern der Nachweis — bei Nebenläufigkeit braucht jedes Kriterium einen eigenen Aufbau, der sich nicht teilen lässt. Als Faustwert (Faktor 3–4 auf den Testanteil) in der Spec festgehalten.

Spec: `docs/specs/modules/fix_1765_b1_compare_vorschau_parallel.md` · Analyse: `docs/context/fix-1765-compare-vorschau-parallel.md`

Refs #1765

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSU1on9gyRdvj3MRv8e9yd
