### PR TITLE
fix(#1765 B1): Anbieter-Verzeichnis gegen gleichzeitigen Erstzugriff sichern

### DIFF
--- a/src/providers/base.py
+++ b/src/providers/base.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime
+from threading import Lock
 from typing import TYPE_CHECKING, Optional, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
@@ -189,6 +190,35 @@ class ProviderRequestError(ProviderError):
 # Provider registry - lazy loading to avoid circular imports
 _PROVIDER_FACTORIES: dict[str, type] = {}
 
+#: Sperre + SEPARATES Fertig-Flag fuer das einmalige, threadsichere Fuellen der
+#: Registry. Die frueher hier stehende Pruefung ``if not _PROVIDER_FACTORIES``
+#: genuegt NICHT: sie meldet "schon geladen", sobald der ERSTE Anbieter
+#: eingetragen ist -- waehrend ``_load_providers()`` die uebrigen noch
+#: importiert. Seriell war die Luecke nie erreichbar; seit die
+#: Vergleichs-Vorschau ihre Orte gleichzeitig verarbeitet (#1765 B1), schlug sie
+#: auf Staging bei JEDEM ersten Aufruf nach einem Dienst-Neustart zu: Ort 1
+#: laedt, Ort 2 sieht "nicht leer", ueberspringt das Laden und findet
+#: ``openmeteo`` nicht -> "Unknown provider: openmeteo. Available: geosphere".
+#: Muster 1:1 wie services/weather_cache.py:294-305 und utils/timezone.py:25-34.
+_registry_lock = Lock()
+_providers_loaded = False
+
+
+def _ensure_providers_loaded() -> None:
+    """Fuellt die Registry genau einmal prozessweit (doppelt gepruefte Sperre).
+
+    Die zweite Bedingung (``not _PROVIDER_FACTORIES``) haelt das bisherige
+    Verhalten fuer den Fall aufrecht, dass die Registry nachtraeglich geleert
+    wurde (Test-Isolation): eine geleerte Registry gilt NICHT auf ewig als
+    "geladen", sondern wird neu gefuellt.
+    """
+    if _providers_loaded and _PROVIDER_FACTORIES:
+        return
+    with _registry_lock:
+        if _providers_loaded and _PROVIDER_FACTORIES:
+            return
+        _load_providers()
+
 
 def register_provider(name: str, factory: type) -> None:
     """
@@ -225,9 +255,8 @@ def get_provider(name: str) -> WeatherProvider:
         from providers.fixture import FixtureProvider
         return FixtureProvider(fixture_dir)
 
-    # Lazy import providers to populate registry
-    if not _PROVIDER_FACTORIES:
-        _load_providers()
+    # Lazy import providers to populate registry (threadsicher, s. o.)
+    _ensure_providers_loaded()
 
     if name not in _PROVIDER_FACTORIES:
         available = ", ".join(_PROVIDER_FACTORIES.keys()) or "none"
@@ -239,7 +268,17 @@ def get_provider(name: str) -> WeatherProvider:
 
 
 def _load_providers() -> None:
-    """Load all available providers."""
+    """Load all available providers.
+
+    Setzt das Fertig-Flag am ENDE selbst -- also erst, wenn ALLE Anbieter
+    eingetragen sind. Bewusst hier und nicht beim Aufrufer: so wirkt es auch
+    fuer die Bestands-Tests, die diese Funktion direkt aufrufen, um danach
+    einen eigenen Anbieter in die Registry zu haengen (z.B.
+    tests/tdd/test_compare_alert_day_window.py:209). Wuerde das Flag dort
+    ungesetzt bleiben, wuerde der naechste ``get_provider()``-Aufruf erneut
+    laden und die eingehaengten Test-Anbieter ueberschreiben.
+    """
+    global _providers_loaded
     # Import providers to trigger registration
     try:
         from providers.geosphere import GeoSphereProvider
@@ -287,9 +326,13 @@ def _load_providers() -> None:
     # from providers.met import METProvider
     # register_provider("met", METProvider)
 
+    _providers_loaded = True
+
 
 def available_providers() -> list[str]:
     """Return list of available provider names."""
-    if not _PROVIDER_FACTORIES:
-        _load_providers()
+    # Dieselbe doppelt gepruefte Sperre wie in get_provider(): sonst koennte
+    # ein gleichzeitiger Aufruf waehrend des Erstladens eine UNVOLLSTAENDIGE
+    # Liste zurueckgeben (z.B. nur ["geosphere"]).
+    _ensure_providers_loaded()
     return list(_PROVIDER_FACTORIES.keys())

--- a/tests/unit/test_provider_registry_threadsicher.py
+++ b/tests/unit/test_provider_registry_threadsicher.py
@@ -1,0 +1,245 @@
+"""Die Anbieter-Registry wird auch bei gleichzeitigem Erstzugriff VOLLSTAENDIG
+gefuellt, bevor ein Thread in ihr nachschlaegt (#1765 B1, Staging-Regression).
+
+Auf Staging gemessen (Stand 4451e39d, Preset cp-21e198c1b74020dd, 3 Orte): Der
+ERSTE Vergleichs-Vorschau-Aufruf nach einem Dienst-Neustart lieferte fuer zwei
+der drei Orte ``Fehler: [Unknown provider: openmeteo. Available: geosphere]
+Provider not found``; der zweite Aufruf (Dienst warm) war vollstaendig.
+Ursache ist ein Check-then-Act-Rennen in ``src/providers/base.py``: ``if not
+_PROVIDER_FACTORIES: _load_providers()`` meldet "schon geladen", sobald der
+ERSTE Anbieter (``geosphere``) eingetragen ist -- die uebrigen (``openmeteo``
+& Co.) folgen erst danach. Seriell war das nie ausloesbar; erst die
+Parallelisierung der Vergleichs-Vorschau (#1765 B1) macht es real.
+
+Geprueft wird die WIRKUNG -- ob ein gleichzeitig zugreifender Thread den
+Anbieter tatsaechlich bekommt --, nicht die Anwesenheit eines ``Lock()`` im
+Quelltext. Muster wie tests/unit/test_timezone_singleton_threadsicher.py.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+
+@pytest.fixture
+def kalte_registry(monkeypatch):
+    """Versetzt die Anbieter-Registry in den Zustand direkt nach einem
+    Dienst-Neustart (leer, nie geladen) und stellt sie danach wieder her.
+
+    Das Fertig-Flag MUSS hier mit zurueckgesetzt werden -- eine geleerte
+    Registry mit gesetztem Flag waere fuer alle Folgetests dauerhaft "geladen"
+    und damit leer.
+    """
+    from providers import base as basis
+
+    # tests/conftest.py::_use_fixture_provider setzt GZ_TEST_FIXTURE_DIR fuer
+    # jeden nicht-live-Test. ``get_provider("openmeteo")`` gibt damit VOR jeder
+    # Registry-Pruefung den FixtureProvider zurueck -- der Pruefling waere nie
+    # erreicht und dieser Test immer gruen, auch ohne Fix.
+    monkeypatch.delenv("GZ_TEST_FIXTURE_DIR", raising=False)
+
+    vorher_registry = dict(basis._PROVIDER_FACTORIES)
+    vorher_flag = basis._providers_loaded
+    basis._PROVIDER_FACTORIES.clear()
+    basis._providers_loaded = False
+    try:
+        yield basis
+    finally:
+        basis._PROVIDER_FACTORIES.clear()
+        basis._PROVIDER_FACTORIES.update(vorher_registry)
+        basis._providers_loaded = vorher_flag
+
+
+def _ladefenster_aufreissen(basis, monkeypatch):
+    """Haelt das Zeitfenster zwischen der ERSTEN und der zweiten Registrierung
+    offen -- ohne diese Verbreiterung ist das Rennen zu schnell und der Test
+    waere auch ohne Fix zufaellig gruen.
+
+    Returns:
+        ``(erste_eingetragen, freigabe)`` -- ``erste_eingetragen`` ist gesetzt,
+        sobald genau EIN Anbieter in der Registry steht (der Moment, in dem
+        ``if not _PROVIDER_FACTORIES`` faelschlich "gefuellt" meldet).
+        ``freigabe`` laesst den ladenden Thread weiterlaufen; bleibt sie aus
+        (gesicherter Fall: die anderen Threads haengen an der Sperre), laeuft
+        er nach 1 s in die Zeitschranke.
+    """
+    echtes_register = basis.register_provider
+    erste_eingetragen = threading.Event()
+    freigabe = threading.Event()
+
+    def langsam_registrieren(name, factory):
+        echtes_register(name, factory)
+        if not erste_eingetragen.is_set():
+            erste_eingetragen.set()
+            freigabe.wait(timeout=1.0)
+
+    monkeypatch.setattr(basis, "register_provider", langsam_registrieren)
+    return erste_eingetragen, freigabe
+
+
+def _threads_starten_und_abwarten(ziele):
+    """Startet die Threads, wartet ab -- und laesst eine Ausnahme in einem
+    Thread den TEST scheitern. Ohne das Einsammeln wuerde pytest sie nur als
+    Warnung zeigen und der Test bliebe gruen, obwohl ein Thread abgestuerzt
+    ist.
+    """
+    abstuerze: list[tuple[str, BaseException]] = []
+    sperre = threading.Lock()
+
+    def umhuellt(name, ziel):
+        def lauf():
+            try:
+                ziel()
+            except BaseException as e:  # noqa: BLE001
+                with sperre:
+                    abstuerze.append((name, e))
+
+        return lauf
+
+    threads = [threading.Thread(target=umhuellt(n, z), name=n) for n, z in ziele]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=20)
+        assert not t.is_alive(), (
+            f"Thread {t.name} haengt -- Verklemmung beim Laden der Registry?"
+        )
+    assert not abstuerze, (
+        "Ausnahme in einem gleichzeitig laufenden Thread: "
+        f"{[(n, repr(e)) for n, e in abstuerze]}"
+    )
+
+
+def test_gleichzeitiger_erstzugriff_findet_jeden_anbieter(
+    kalte_registry, monkeypatch
+):
+    """Drei Threads (= drei Orte einer Vergleichs-Vorschau) greifen zeitgleich
+    auf die kalte Registry zu; KEINER darf ``ProviderNotFoundError`` sehen.
+
+    Thread "ort1" startet das Laden, "ort2"/"ort3" setzen exakt in dem Moment
+    auf, in dem erst ein einziger Anbieter eingetragen ist.
+    """
+    basis = kalte_registry
+    erste_eingetragen, freigabe = _ladefenster_aufreissen(basis, monkeypatch)
+
+    ergebnisse: dict[str, object] = {}
+    fehler: dict[str, BaseException] = {}
+    sperre = threading.Lock()
+
+    def hole(schluessel: str, wartet: bool):
+        def lauf():
+            try:
+                if wartet:
+                    assert erste_eingetragen.wait(timeout=10), (
+                        "Das Laden der Registry hat nie begonnen"
+                    )
+                anbieter = basis.get_provider("openmeteo")
+                with sperre:
+                    ergebnisse[schluessel] = anbieter
+            except BaseException as e:  # noqa: BLE001
+                with sperre:
+                    fehler[schluessel] = e
+            finally:
+                if wartet:
+                    freigabe.set()
+
+        return lauf
+
+    _threads_starten_und_abwarten(
+        [
+            ("ort1", hole("ort1", wartet=False)),
+            ("ort2", hole("ort2", wartet=True)),
+            ("ort3", hole("ort3", wartet=True)),
+        ]
+    )
+
+    assert not fehler, (
+        "Gleichzeitig zugreifende Orte bekamen keinen Anbieter: "
+        f"{ {k: repr(v) for k, v in fehler.items()} }. Genau das war die auf "
+        "Staging gemessene Regression ('Unknown provider: openmeteo. "
+        "Available: geosphere') beim ersten Vorschau-Aufruf nach einem "
+        "Dienst-Neustart. Abhilfe: doppelt gepruefte Sperre mit separatem "
+        "Fertig-Flag in providers/base.py -- 'Registry nicht leer' ist NICHT "
+        "'Registry fertig geladen'."
+    )
+    assert set(ergebnisse) == {"ort1", "ort2", "ort3"}
+    for schluessel, anbieter in ergebnisse.items():
+        assert anbieter.name == "openmeteo", (
+            f"{schluessel} bekam '{anbieter.name}' statt 'openmeteo'"
+        )
+
+
+def test_gleichzeitiger_erstzugriff_liefert_vollstaendige_anbieterliste(
+    kalte_registry, monkeypatch
+):
+    """``available_providers()`` darf waehrend des Erstladens keine
+    UNVOLLSTAENDIGE Liste zurueckgeben (dieselbe Luecke, zweite Fundstelle).
+
+    Ohne Sperre sieht der zweite Thread nur den bereits eingetragenen ersten
+    Anbieter -- die Liste waere ``["geosphere"]``.
+    """
+    basis = kalte_registry
+    erste_eingetragen, freigabe = _ladefenster_aufreissen(basis, monkeypatch)
+
+    listen: dict[str, list[str]] = {}
+
+    def lader():
+        basis.available_providers()
+
+    def mitleser():
+        try:
+            assert erste_eingetragen.wait(timeout=10)
+            listen["mitleser"] = basis.available_providers()
+        finally:
+            freigabe.set()
+
+    _threads_starten_und_abwarten([("lader", lader), ("mitleser", mitleser)])
+
+    assert "openmeteo" in listen.get("mitleser", []), (
+        "Ein gleichzeitiger Aufruf sah nur eine TEILWEISE gefuellte Registry: "
+        f"{listen.get('mitleser')}. Genau diese Teilliste erschien auf Staging "
+        "im Fehlertext ('Available: geosphere')."
+    )
+
+
+def test_registry_wird_bei_gleichzeitigem_erstzugriff_genau_einmal_geladen(
+    kalte_registry, monkeypatch
+):
+    """Gegenprobe zur naheliegenden Billig-Loesung: Ein Fix, der bei jedem
+    Fehlschlag einfach nachlaedt (``if name not in _PROVIDER_FACTORIES:
+    _load_providers()``), bekaeme die Tests oben ebenfalls gruen -- und wuerde
+    bei jedem Kaltstart die Anbieter-Module mehrfach gleichzeitig importieren.
+    Hier wird die Zahl der Ladevorgaenge selbst geprueft: genau EINER.
+    """
+    basis = kalte_registry
+    erste_eingetragen, freigabe = _ladefenster_aufreissen(basis, monkeypatch)
+
+    echtes_laden = basis._load_providers
+    ladevorgaenge: list[int] = []
+
+    def zaehlendes_laden():
+        ladevorgaenge.append(1)
+        echtes_laden()
+
+    monkeypatch.setattr(basis, "_load_providers", zaehlendes_laden)
+
+    def erster():
+        basis.get_provider("openmeteo")
+
+    def spaeter():
+        try:
+            assert erste_eingetragen.wait(timeout=10)
+            basis.get_provider("openmeteo")
+        finally:
+            freigabe.set()
+
+    _threads_starten_und_abwarten(
+        [("erster", erster), ("zweiter", spaeter), ("dritter", spaeter)]
+    )
+
+    assert len(ladevorgaenge) == 1, (
+        f"Die Registry wurde {len(ladevorgaenge)}x geladen statt genau 1x -- "
+        "gleichzeitige Erstzugriffe importieren die Anbieter-Module mehrfach."
+    )


### PR DESCRIPTION
## Auf Staging gemessene Regression aus PR #1885

Bei der Staging-Verifikation von Stand `4451e39d` (Preset `cp-21e198c1b74020dd`, 3 Orte):

| | 1. Aufruf nach Dienst-Neustart | 2. Aufruf, Dienst warm |
|---|---|---|
| Innsbruck | Daten | Daten |
| Stubai | **`Fehler: Unknown provider: openmeteo. Available: geosphere`** | Daten |
| Zillertal | **derselbe Fehler** | Daten |

Nutzersichtbar: Nach **jedem** Neustart — also nach jedem Deploy — liefert der erste Ortsvergleich allen Orten außer dem ersten einen Fehler statt Wetterdaten. Beim zweiten Versuch ist alles normal. Also genau die Sorte Fehler, die man für einen Zufall hält.

## Ursache: Check-then-Act, dessen Prüfbedingung ein Stellvertreter ist

`src/providers/base.py`, `get_provider()`:

```python
if not _PROVIDER_FACTORIES:   # Thread B sieht "nicht leer" — geosphere ist schon drin
    _load_providers()         # …also überspringt B das Laden
if name not in _PROVIDER_FACTORIES:   # …aber openmeteo fehlt noch, A importiert gerade
    raise ProviderNotFoundError
```

`_load_providers()` registriert die Anbieter **nacheinander**. Wer währenddessen vorbeikommt, sieht ein halb gefülltes Verzeichnis und hält es für vollständig. Geprüft wurde ein **Stellvertreter** (Dict nicht leer) statt des Zustands selbst („Laden abgeschlossen"). Seriell konnte das nie auftreten — erst die Parallelisierung aus #1885 macht es real.

**Eine frühere Bestandsaufnahme hatte genau diese Stelle untersucht und als „unschädlich, weil idempotent" eingestuft.** Idempotent sind die *Einträge*; der halb gefüllte *Zwischenzustand* ist es nicht.

## Warum kein Test es gefunden hat

Alle Kern-Tests der Parallelisierung — und der Adversary-Lauf — ersetzen `ComparisonEngine.run` durch einen Stub. Das Rennen entsteht **dahinter**, im echten Anbieter-Pfad. Kein Stub, kein Rennen. Gefunden hat es ausschließlich die Messung am laufenden System.

## Fix

Doppelt geprüfte Sperre mit **separatem Fertig-Flag**, Muster aus `weather_cache.py:294-305` und `timezone.py:25-34`.

Zwei bewusste Feinheiten:
- Das Flag wird **am Ende von `_load_providers()` selbst** gesetzt, nicht beim Aufrufer — sechs Bestands-Tests rufen die Funktion direkt auf und hängen danach eigene Anbieter ein.
- Bedingung `_providers_loaded and _PROVIDER_FACTORIES`, damit eine nachträglich geleerte Registry nicht auf ewig als „geladen" gilt.

`available_providers()` hatte dieselbe Lücke (nur Test-Aufrufer, deshalb auf Staging unsichtbar) und ist mitgefixt.

## Nachweis

`tests/unit/test_provider_registry_threadsicher.py` — 3 Tests, `threading.Barrier` gegen eine kalt gesetzte Registry.

**Vier Mutationen, alle gefangen:**

| Mutation | Ergebnis |
|---|---|
| alte Prüfung in `get_provider` | 2 von 3 rot, mit **exakt der Staging-Meldung** |
| alte Prüfung in `available_providers` | 1 rot, Mitleser sah `['geosphere']` |
| **Sperre da, aber ohne Flag** | **alle 3 rot** — belegt, dass das *Flag* wirkt, nicht die bloße Anwesenheit eines `Lock()` |
| `_providers_loaded = True` entfernt | 1 rot, jeder Thread lädt erneut |

Zusätzlich eine **Kaltstart-Gegenprobe in einem frischen Prozess**: In der Suite liegen die Anbieter-Module bereits in `sys.modules`, und die Sperre ist nicht reentrant — ein Verklemmen zur Importzeit fiele in der Suite nie auf.

**Nebenbefund über die Testinfrastruktur:** pytest meldet eine Ausnahme in einem Worker-Thread nur als **Warnung** — ein Test kann grün sein, während ein Thread abstürzt. Genau das passierte beim ersten Mutationslauf. Der Thread-Helfer sammelt Ausnahmen jetzt ein und lässt den Test daran scheitern.

**Regression:** `tests/unit/` 1502 grün · 41 Wächter-Dateien direkt unter `tests/` 345 grün.

Refs #1765

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSU1on9gyRdvj3MRv8e9yd
