### PR TITLE
fix: /next-ticket-Cache aus .claude/ nach docs/artifacts/ verlegen

### DIFF
--- a/.claude/commands/next-ticket.md
+++ b/.claude/commands/next-ticket.md
@@ -19,7 +19,7 @@ neu bewerten:
 - **Innerhalb derselben Sitzung:** Stehen Ergebnisse aus Schritt 2/3 bereits im
   Gesprächsverlauf dieser Sitzung (kein `/clear` dazwischen, keine `workflow.py finish`
   seither), diese direkt wiederverwenden statt die Befehle erneut auszuführen.
-- **Über Sitzungsstarts hinweg (Cache-Datei):** `.claude/next_ticket_cache.json`
+- **Über Sitzungsstarts hinweg (Cache-Datei):** `docs/artifacts/next_ticket_cache.json`
   (worktree-lokal, gitignored) prüfen. Ist die Datei jünger als 5 Minuten:
   ```bash
   gh issue list --repo henemm/gregor_zwanzig --state open --json number,updatedAt --limit 300 \


### PR DESCRIPTION
## Summary
- `/next-ticket` schrieb seinen Kurzzeit-Cache nach `.claude/next_ticket_cache.json` — dorthin darf laut stehender PO-Regel nicht geschrieben werden, jeder Aufruf endete im Berechtigungsdialog statt im Cache
- Verlegt nach `docs/artifacts/next_ticket_cache.json` (bereits gitignored, beherbergt schon die übrigen Workflow-Artefakte)

## Hintergrund
Dieser Fix (Commit `b6674c94`) entstand in einer früheren Sitzung, wurde aber nie gemerged — die zugehörige Aufräum-PR #1867 hat inzwischen bereits die dadurch wirkungslos gewordene Berechtigungszeile `Edit(.claude/next_ticket_cache.json)` aus `.claude/settings.json` entfernt. Dadurch stand `main` zuletzt in einem inkonsistenten Zwischenzustand: die Pfad-Korrektur selbst fehlte noch, die (dafür nötige) Berechtigung war aber schon weg — `/next-ticket` ist auf `main` aktuell für jede Session ohne Cache-Möglichkeit.

## Test plan
- [x] Nur eine Textstelle in `.claude/commands/next-ticket.md` geändert (Cache-Pfad), kein Code
- [x] Neuer Pfad `docs/artifacts/` ist bereits gitignored und wird von anderen Workflow-Artefakten genutzt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DoL9wmkYgSCbYCKGQ2feVD