### PR TITLE
fix(#1197): staging_gate klassifiziert frontend/e2e/ nicht mehr als Programmcode

### DIFF
--- a/.claude/hooks/_e2e_paths.py
+++ b/.claude/hooks/_e2e_paths.py
@@ -223,7 +223,16 @@ def _detect_scope_from_git_diff(base, target, repo_dir) -> str:
     has_frontend = False
     has_backend = False
     for path in changed:
-        if path.startswith("frontend/"):
+        # Playwright-Testinfrastruktur (Specs, Setup, Configs, Fixtures,
+        # Helfer) — kein ausgelieferter Produktivcode, wird von keinem
+        # laufenden Dienst geladen, also kein Deploy-Drift-Risiko. Symmetrisch
+        # zur bereits bestehenden tests/-Ausnahme weiter unten. MUSS vor dem
+        # generischen frontend/-Zweig stehen, sonst greift dieser zuerst
+        # (#1197: e2e-only-Diff wurde fälschlich frontend-only und blockte den
+        # Deploy-Gate).
+        if path.startswith("frontend/e2e/"):
+            pass
+        elif path.startswith("frontend/"):
             has_frontend = True
         elif (
             path.startswith("src/")

--- a/docs/context/fix-1197-staging-gate-e2e-testfile-scope.md
+++ b/docs/context/fix-1197-staging-gate-e2e-testfile-scope.md
@@ -1,0 +1,65 @@
+# Context: fix-1197-staging-gate-e2e-testfile-scope
+
+## Request Summary
+Deploy-Gate (`staging_gate.py`, indirekt auch `prod_selftest.py`) stuft Playwright-E2E-Testdateien unter `frontend/e2e/**` fälschlich als echten Frontend-Code ein und verlangt dadurch nach reinen Doku-/Tooling-Merges eine volle Staging-Verifikation, obwohl CLAUDE.md dafür eine Ausnahme vorsieht. Auslöser: PO-Fund vom 2026-08-15 in Issue #1197 (Kommentar https://github.com/henemm/gregor_zwanzig/issues/1197#issuecomment-... zu Commits e58863e9..fe78d473).
+
+## Related Files
+| File | Relevance |
+|------|-----------|
+| `.claude/hooks/_e2e_paths.py` (`_detect_scope_from_git_diff`, Z.206-258) | Geteilte Klassifikationsfunktion — hier liegt der Bug. `frontend/`-Präfix zieht `has_frontend=True`, auch für `frontend/e2e/*.spec.ts` |
+| `.claude/hooks/staging_gate.py` (`gate_check`, Z.495-624) | Ruft `_detect_scope_from_git_diff` sowohl direkt (Z.202) als auch in der Ancestor-Relaxierung (Z.621) auf — Aufrufer #1 des Bugs |
+| `.claude/hooks/prod_selftest.py` (Z.673) | Ruft dieselbe Funktion für den Post-Deploy-Scope auf — Aufrufer #2, gleiche Schieflage möglich |
+| `.claude/hooks/e2e_commit_gate.py` (`detect_scope`, Z.66-120) | **Separate, eigenständige Kopie** derselben Klassifikationslogik für den Pre-Commit-Pfad (`/e2e-verify`). Hat denselben `frontend/`-Präfix-Bug, ist aber NICHT vom gemeldeten Vorfall betroffen (der lief über den Deploy-Pfad `staging_gate.py`). Bewusst außerhalb des Scopes dieses Fixes — siehe Risks. |
+| `tests/tdd/test_issue_1121_git_diff_returncode.py` | Zeigt das Test-Pattern: echtes Temp-Git-Repo, Hook-Dateien reinkopiert, keine Mocks. Wird als Vorlage für den neuen Test übernommen |
+| `docs/specs/modules/fix_1197_deploy_gate_ancestor_scope.md` | Vorgänger-Spec (AC-3 dort: "Zuwachs enthält Datei unter `frontend/` → Exit 1"). Unsere Änderung wirkt UNTERHALB dieser Logik (in der Klassifikationsfunktion selbst) und verändert, was als "Datei unter `frontend/`" im Sinne von echtem Code zählt |
+
+## Existing Patterns
+- **`tests/` bereits ausgenommen:** Die Funktion behandelt `path.startswith("tests/")` schon heute als Nicht-Code (Zeile 241) — dieselbe Begründung (Testinfrastruktur, kein Produktivcode, kein Deploy-Drift-Risiko) gilt symmetrisch für `frontend/e2e/`.
+- **Fail-closed bei Unsicherheit:** Jede unbekannte/neue Pfad-Klasse fällt konservativ auf `has_backend=True` bzw. `has_frontend=True` (Else-Zweig, Zeile 249-250). Die Lösung muss diese Fail-closed-Haltung für echten Frontend-Code (`frontend/src/`, `frontend/static/` etc.) unverändert lassen — nur `frontend/e2e/` wird neu ausgenommen.
+- **Präzedenz im selben Sammel-Issue:** Mehrere vorherige Fixes in #1197 (Ancestor-Scope, Verdict-Merge, prod_selftest-Internal-URL-Skip) folgten demselben Muster: eigene Spec unter `docs/specs/modules/fix_1197_*.md`, Prüfdatum +90 Tage, Adversary-Runde, Live-Kommentar im Issue nach Deploy.
+
+## Dependencies
+- **Upstream:** `_git_diff_names()` (liefert die geänderten Pfade als Liste; bei git-Fehler `None` → fail-closed `"backend"`, unverändert zu lassen).
+- **Downstream:** `staging_gate.gate_check()` (Deploy-Hard-Gate, entscheidet Exit 0/1 für `deploy-gregor-prod.sh`) und `prod_selftest.py` (Post-Deploy-Verdict-Klassifikation). Eine zu breite Ausnahme hier würde also den Deploy-Gate für ALLE Sessions aufweichen — daher eng auf `frontend/e2e/` fassen, nicht auf ganz `frontend/`.
+
+## Existing Specs
+- `docs/specs/modules/fix_1197_deploy_gate_ancestor_scope.md` — Ancestor+Scope-Relaxierung (2026-07-16), definiert das aktuelle Verhalten bei gestapelten Commits.
+- `docs/specs/modules/fix_1382_deploy_gate_evidence.md` — Grundlogik der commit-getaggten Attestation.
+- `docs/specs/modules/fix_1197_prod_selftest_internal_url_skip.md` — Schwester-Fix im selben Issue (analoges Muster: bekannte Nicht-Risiko-Klasse von der strikten Prüfung ausnehmen).
+
+## Risks & Considerations
+- **Nicht in Scope, aber gleiche Bug-Klasse:** `e2e_commit_gate.py::detect_scope()` (Pre-Commit-Pfad) hat dieselbe `frontend/`-Präfix-Schwäche, ist aber eine separate Funktion und nicht Teil des gemeldeten Vorfalls. Wird NICHT mitgeändert (Scope-Disziplin) — als möglicher Nebenbefund für #1199/#1197 notieren, falls die Adversary-Runde ihn aufwirft.
+- **Zu breite Ausnahme wäre ein Sicherheitsloch:** Nur `frontend/e2e/` (Playwright-Testspecs, nicht ausgeliefert) darf ausgenommen werden — nicht `frontend/` pauschal. Ein echter Frontend-Code-Change muss weiterhin `has_frontend=True` auslösen.
+- **Zwei Aufrufstellen in `staging_gate.py`:** sowohl der direkte Scope-Detect (Z.202) als auch die Ancestor-Relaxierung (Z.621) nutzen dieselbe Funktion — ein Fix an der Quelle wirkt auf beide, muss aber für beide getestet werden (AC-Abdeckung).
+- **Konsistenz mit AC-3 der Vorgänger-Spec:** Deren AC-3 sagt "Datei unter `frontend/` → Block". Das bleibt für echten Frontend-Code weiterhin korrekt; nur die Definition von "Datei unter `frontend/`, die als Code zählt" wird präzisiert. Die neue Spec sollte das explizit referenzieren, damit kein scheinbarer Widerspruch entsteht.
+
+## Prüfdatum-Registrierung
+Nach Live-Deploy: Eintrag in `docs/reference/gates_und_ratschen.md` Prüfdatum-Tabelle (Zeile ~181) ergänzen, analog zu den bisherigen #1197-Fixes.
+
+## Analysis
+
+### Type
+Bug (Kategorie c — fälschlich blockierendes Gate). Bestätigt durch bug-intake-Agent: Root Cause exakt wie vermutet, Zeile 226-227 in `_e2e_paths.py::_detect_scope_from_git_diff` — jede Datei mit Präfix `frontend/` zieht `has_frontend=True`, ohne Ausnahme für Testverzeichnisse (im Gegensatz zu `tests/`, Zeile 241).
+
+### Affected Files (with changes)
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `.claude/hooks/_e2e_paths.py` | MODIFY | `frontend/e2e/`-Präfix in den bestehenden neutralen `elif`-Block aufnehmen (dort wo `tests/` bereits steht), strukturell konsistent mit dem Backend-Test-Präzedenzfall, inkl. erklärendem Kommentar |
+| `tests/tdd/test_e2e_frontend_scope_neutral.py` (neu, Name TBD in Spec-Phase) | CREATE | Kern-Schicht-Tests gegen echtes Temp-Git-Repo (kein Mock), Vorbild `test_issue_1121_git_diff_returncode.py` / `test_scope_tests_neutral.py` |
+| `docs/specs/modules/fix_1197_deploy_gate_ancestor_scope.md` | MODIFY (klein) | AC-3 um klarstellenden Verweis auf die neue Ausnahme ergänzen, damit kein scheinbarer Widerspruch entsteht |
+
+### Scope Assessment
+- Files: 3 (1 Produktivdatei, 1 neue Testdatei, 1 Spec-Ergänzung)
+- Estimated LoC: Produktivcode ~3-6 Zeilen; Tests ~80-150 Zeilen (mehrere Szenarien)
+- Risk Level: LOW für die Änderung selbst (eng gefasste Verzeichnis-Ausnahme, durch Grep verifiziert: `frontend/e2e/` enthält ausschließlich `*.spec.ts`, `*.setup.ts`, `playwright.*.config.ts`, Shell-Skripte, Fixtures und Test-Helfer — kein Import von dort in `frontend/src/**` produktiv). Blast Radius bleibt HOCH eingestuft, weil die Funktion von zwei Deploy-Gate-Aufrufern geteilt wird — daher weiterhin volle Spec+Adversary-Pflicht.
+
+### Technical Approach
+Reine Verzeichnis-Präfix-Ergänzung (`frontend/e2e/`) im bestehenden neutralen `elif`-Zweig neben `tests/` — kein Playwright-Config-Parsing nötig (`testDir: 'e2e'` ist stabil per Konvention in `frontend/playwright.config.ts` verankert). Verzeichnis-Präfix statt Datei-Endungs-Filter, damit auch Helfer/Fixtures/Configs in `frontend/e2e/` mit abgedeckt sind (sonst blockten reine Testinfra-Änderungen weiter).
+
+### Dependencies
+- Downstream unverändert: `staging_gate.py` (Zeile 202, 621) und `prod_selftest.py` (Zeile 673) profitieren beide automatisch von der Korrektur an der Quelle.
+- `fix_1197_deploy_gate_ancestor_scope.md` AC-3 braucht einen klarstellenden Verweis (kein Widerspruch, nur Präzisierung "Code" vs. "Testcode").
+- `e2e_commit_gate.py::detect_scope()` hat denselben Bug unabhängig dupliziert, ist aber ein separater Pre-Commit-Pfad ohne direkten Deploy-Block-Effekt — als Known Limitation in der neuen Spec vermerken, nicht mitfixen.
+
+### Open Questions
+- [ ] Keine offenen Fragen — Ansatz ist eindeutig, durch zwei unabhängige Agenten (bug-intake, Plan) bestätigt.

--- a/docs/reference/gates_und_ratschen.md
+++ b/docs/reference/gates_und_ratschen.md
@@ -189,6 +189,7 @@ Verfahren, Abbruchgrenze).
 | Test-Pfadregel-Ratsche (#1409) | 2026-10-27 | — |
 | Frontend-Browser-Gate (#1558) | 2026-11-05 | #1552 (Kernseite unbedienbar bei grüner Ampel) |
 | 6. Check `e2e` (#1771 S2) | 2026-11-11 | offen — Kriterium: eine Regression, die die anderen fünf durchlassen |
+| staging_gate — `frontend/e2e/` nicht als Code klassifiziert (#1197) | 2026-11-15 | Live erlebt 2026-08-15 (PR-Stack #1736/#1852/#1881/#1882), Fix folgt |
 
 Am Prüfdatum gilt: kein nachweisbarer Fang → **Rückbau**. Wirkmodell:
 `docs/analysis/backlog-spirale-2026-07.md`.

--- a/docs/specs/modules/fix_1197_deploy_gate_ancestor_scope.md
+++ b/docs/specs/modules/fix_1197_deploy_gate_ancestor_scope.md
@@ -34,7 +34,10 @@ Log weist die Ancestor-Relaxierung aus.
 
 **AC-3:** Given dieselbe Ancestor-Konstellation, aber der Zuwachs C..HEAD enthält
 mindestens eine Datei unter `frontend/`, When `gate_check` läuft, Then Exit 1
-(keine Relaxierung bei echtem Frontend-Code).
+(keine Relaxierung bei echtem Frontend-Code). Präzisierung durch
+`docs/specs/modules/fix_1197_staging_gate_e2e_scope.md`: „Datei unter `frontend/`"
+meint ausgelieferten Produktivcode (`frontend/src/`, `frontend/static/` usw.),
+nicht die Playwright-Testinfrastruktur unter `frontend/e2e/`.
 
 **AC-4:** Given dieselbe Ancestor-Konstellation, aber der Zuwachs C..HEAD enthält
 mindestens eine Datei unter `src/`, `api/`, `internal/` oder `cmd/`, When

--- a/docs/specs/modules/fix_1197_staging_gate_e2e_scope.md
+++ b/docs/specs/modules/fix_1197_staging_gate_e2e_scope.md
@@ -1,0 +1,228 @@
+---
+entity_id: fix_1197_staging_gate_e2e_scope
+type: bugfix
+created: 2026-08-15
+updated: 2026-08-15
+status: draft
+workflow: fix-1197-staging-gate-e2e-testfile-scope
+---
+
+# Deploy-Gate: Frontend-E2E-Testdateien nicht als Programmcode klassifizieren
+
+- **Issue:** #1197 (Sammel-Gate-Audit), Scheibe „Frontend-E2E-Testdateien werden als Programmcode gezählt"
+- **Typ:** Gate-Fix (Kategorie c — fälschlich blockierendes Gate)
+- **Prüfdatum (Regel-Budget):** 2026-11-15
+- **Vorgänger-Spec:** `docs/specs/modules/fix_1197_deploy_gate_ancestor_scope.md` (Ancestor+docs-only-Relaxierung von `staging_gate.gate_check`) — dort definiert AC-3 "Zuwachs enthält Datei unter `frontend/` → Block". Diese Spec präzisiert UNTERHALB dieser Logik, was als "Datei unter `frontend/`" im Sinne von echtem, ausgeliefertem Code zählt; das Verhalten von AC-3 der Vorgänger-Spec bleibt für echten Frontend-Code unverändert korrekt.
+
+## Approval
+
+- [ ] Approved
+
+## Problem
+
+`.claude/hooks/_e2e_paths.py::_detect_scope_from_git_diff` (Zeile 206-258) ist die
+gemeinsame Scope-Klassifikationsfunktion für den Deploy-Gate (`staging_gate.py`,
+Aufruf Zeile 202 direkt und Zeile 621 in der Ancestor-Relaxierung) sowie für
+`prod_selftest.py` (Aufruf Zeile 673). Sie behandelt **jede** Datei mit Präfix
+`frontend/` als `has_frontend=True` (Zeile 226-227) — auch Playwright-E2E-
+Testdateien unter `frontend/e2e/**` (Specs, Setup-Dateien, Configs, Fixtures,
+Test-Helfer), die keinen ausgelieferten Produktivcode darstellen. Backend-Tests
+unter `tests/` sind in derselben Funktion bereits als Nicht-Code ausgenommen
+(Zeile 241), Frontend-E2E-Tests haben kein analoges Pendant.
+
+**Live erlebt am 2026-08-15:** PR-Stack #1736/#1852/#1881/#1882 änderte u.a.
+`frontend/e2e/trip-preview-thunder-origin.staging.spec.ts` (Umbenennung). Der
+Scope wurde dadurch `frontend-only` statt `docs-only` klassifiziert, obwohl kein
+Produktivcode betroffen war. Der Deploy-Gate (`staging_gate.py`, aufgerufen von
+`deploy-gregor-prod.sh`) blockte daraufhin mit der irreführenden Meldung
+„vermutlich hat eine parallele Sitzung deployt" — der eigentliche Grund war die
+falsche Scope-Klassifikation, nicht eine parallele Sitzung.
+
+## Purpose
+
+`_detect_scope_from_git_diff` liefert korrekt `docs-only` (statt `frontend-only`
+oder `full-stack`), wenn ein Diff ausschließlich `frontend/e2e/`-Dateien betrifft,
+ohne die Fail-closed-Klassifikation für echten Frontend-Code (`frontend/src/`
+etc.) oder Backend-Code aufzuweichen. Dadurch greifen die CLAUDE.md-Regeln für
+reine Doku-/Tooling-Änderungen (kein Deploy-Zwang, Ancestor-Relaxierung) auch
+dann korrekt, wenn ein PR-Stack nur Playwright-Testinfrastruktur ändert.
+
+## Source
+
+- **File:** `.claude/hooks/_e2e_paths.py`
+- **Identifier:** `def _detect_scope_from_git_diff(base, target, repo_dir) -> str` (Zeile 206-258)
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `.claude/hooks/staging_gate.py::gate_check` | caller | Ruft die Funktion Zeile 202 (direkte Scope-Ermittlung) und Zeile 621 (Ancestor-Relaxierung) auf — Deploy-Hard-Gate für `deploy-gregor-prod.sh`; profitiert automatisch von der Korrektur an der Quelle |
+| `.claude/hooks/prod_selftest.py` | caller | Ruft dieselbe Funktion Zeile 673 für den Post-Deploy-Scope auf; profitiert automatisch von der Korrektur |
+| `.claude/hooks/e2e_commit_gate.py::detect_scope` | separater Pfad, NICHT geändert | Eigenständige Kopie derselben Klassifikationslogik für den Pre-Commit-Pfad (`/e2e-verify`), hat denselben `frontend/`-Präfix-Bug, aber anderer Aufrufer und nicht Teil des gemeldeten Vorfalls — siehe Known Limitations |
+| `docs/specs/modules/fix_1197_deploy_gate_ancestor_scope.md` | Vorgänger-Spec | AC-3 dort bleibt für echten Frontend-Code gültig; wird um einen klarstellenden Halbsatz ergänzt |
+
+## Scope
+
+### Affected Files
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `.claude/hooks/_e2e_paths.py` | MODIFY | `_detect_scope_from_git_diff`: `frontend/e2e/`-Präfix als zusätzliche Bedingung im bestehenden neutralen `elif`-Block (analog `tests/`, Zeile 241) aufnehmen — Prüfung MUSS vor der generischen `path.startswith("frontend/")`-Bedingung greifen, damit `frontend/e2e/*` NICHT `has_frontend=True` setzt, während `frontend/src/...` etc. weiterhin `has_frontend=True` setzt |
+| `tests/tdd/test_e2e_frontend_scope_neutral.py` (neu) | CREATE | Kern-Schicht-Tests gegen echtes Temp-Git-Repo (kein Mock), Vorbild `tests/tdd/test_issue_1121_git_diff_returncode.py` und `tests/tdd/test_scope_tests_neutral.py` |
+| `docs/specs/modules/fix_1197_deploy_gate_ancestor_scope.md` | MODIFY (klein) | AC-3 um einen kurzen klarstellenden Halbsatz/Verweis auf diese Spec ergänzen (keine Verhaltensänderung an AC-3 selbst, nur Präzisierung: "Datei unter `frontend/`" meint ausgelieferten Code, nicht `frontend/e2e/`) |
+
+### Estimated Changes
+- Files: 3
+- LoC: +~10/-0 (Produktivcode ~3-6 Zeilen inkl. Kommentar; Tests ~80-150 Zeilen; Spec-Ergänzung ~2-3 Zeilen — Doku/Tests zählen laut CLAUDE.md nicht ins LoC-Limit)
+
+## Implementation Details
+
+Aktuelle Struktur der Schleife in `_detect_scope_from_git_diff` (Zeile 223-250):
+
+```
+for path in changed:
+    if path.startswith("frontend/"):
+        has_frontend = True
+    elif (backend-Präfixe: src/, api/, internal/, cmd/):
+        has_backend = True
+    elif (neutral: docs/, .claude/, .md, README, .gitignore, tests/, openspec.yaml):
+        pass
+    else:
+        has_backend = True
+```
+
+Der `if path.startswith("frontend/")`-Zweig steht VOR dem neutralen `elif`-Block
+und greift daher für jede `frontend/`-Datei zuerst — auch für `frontend/e2e/*`.
+Die Reihenfolge der Bedingungen in der Schleife muss so geändert werden, dass
+`frontend/e2e/` VOR dem generischen `frontend/`-Zweig geprüft wird (z.B. als
+eigene `if`-Bedingung vor dem bestehenden `if path.startswith("frontend/")`, die
+bei Treffer `continue`/`pass` auslöst, oder durch Umsortierung der `elif`-Kette
+so, dass `frontend/e2e/` zuerst abgefragt wird). `frontend/src/`, `frontend/static/`
+und alle anderen `frontend/`-Unterpfade bleiben unverändert `has_frontend=True`.
+
+Verzeichnis-Präfix (`frontend/e2e/`), nicht Datei-Endungs-Filter: durch Grep
+verifiziert, `frontend/e2e/` enthält ausschließlich `*.spec.ts`,
+`*.staging.setup.ts`, `playwright.*.config.ts` (u.a. `frontend/playwright.config.ts`
+fixiert `testDir: 'e2e'` stabil), Shell-Skripte (`ci-stack.sh`, `e2e-env.sh`,
+`start-preview.sh`), Test-Fixtures (`.gpx`) und Test-Helfer (`helpers.ts`,
+`apiProxyTarget.ts`, `prodUrlGuard.ts`) — kein Import von dort in produktiven
+`frontend/src/**`-Code. Ein Verzeichnis-Präfix statt Endungs-Filter erfasst auch
+Helfer/Fixtures/Configs mit, sonst blockten reine Testinfra-Änderungen weiter.
+
+Ein erklärender Kommentar analog zum bestehenden `tests/`-Kommentarblock
+(Zeile 241-247) sollte die Begründung (Testinfrastruktur, kein Produktivcode,
+kein Deploy-Drift-Risiko, symmetrisch zu `tests/`) im Code festhalten.
+
+## Test Plan
+
+### Automated Tests (TDD RED)
+
+Kern-Schicht, deterministisch: echtes temporäres Git-Repo (`git init`, echte
+Commits mit echten Dateipfaden), Hook-Dateien aus dem aktuellen Arbeitsverzeichnis
+(Worktree) in das Temp-Repo kopiert — **kein Mock** von `subprocess`/git, analog
+`tests/tdd/test_issue_1121_git_diff_returncode.py` und
+`tests/tdd/test_scope_tests_neutral.py`. Neue Datei
+`tests/tdd/test_e2e_frontend_scope_neutral.py`.
+
+- [ ] Test 1 (AC-1): GIVEN ein Commit ändert ausschließlich eine Datei unter
+      `frontend/e2e/` (z.B. `frontend/e2e/foo.spec.ts`) WHEN
+      `_detect_scope_from_git_diff` läuft THEN Rückgabe `docs-only`
+- [ ] Test 2 (AC-2): GIVEN ein Commit ändert sowohl `frontend/e2e/foo.spec.ts`
+      als auch `frontend/src/routes/+page.svelte` WHEN
+      `_detect_scope_from_git_diff` läuft THEN Rückgabe `frontend-only`
+      (keine Verwässerung bei echtem Frontend-Code)
+- [ ] Test 3 (AC-3): GIVEN ein Commit ändert sowohl `frontend/e2e/foo.spec.ts`
+      als auch eine Backend-Datei (`src/app/cli.py`) WHEN
+      `_detect_scope_from_git_diff` läuft THEN Rückgabe `backend`, NICHT
+      `full-stack`
+- [ ] Test 4 (AC-4): GIVEN ein Commit ändert `frontend/e2e/foo.spec.ts` sowie
+      `docs/README.md` und `tests/tdd/test_bar.py` WHEN
+      `_detect_scope_from_git_diff` läuft THEN Rückgabe `docs-only`
+- [ ] Test 5 (AC-5): GIVEN ein Ancestor-Commit ist mit VERIFIED-Attestation
+      getaggt und der Zuwachs zum HEAD enthält ausschließlich
+      `frontend/e2e/*`-Änderungen WHEN `staging_gate.gate_check` end-to-end
+      läuft THEN Exit 0 (Ancestor-Relaxierung greift korrekt)
+- [ ] Test 6 (AC-6): GIVEN ein Commit ändert ausschließlich echten Frontend-Code
+      (`frontend/src/lib/foo.ts`), KEINE `frontend/e2e/`-Datei WHEN
+      `_detect_scope_from_git_diff` läuft THEN Rückgabe weiterhin
+      `frontend-only` (Regressionsschutz, Bestandsverhalten unverändert)
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Diff enthält ausschließlich Dateien unter `frontend/e2e/`
+  (z.B. `frontend/e2e/foo.spec.ts`, `frontend/e2e/helpers.ts`), When
+  `_detect_scope_from_git_diff` auf diesem Diff läuft, Then liefert die Funktion
+  `docs-only`.
+  - Test: `test_e2e_frontend_scope_neutral.py::test_ac1_e2e_only_is_docs_only`
+    gegen echtes Temp-Git-Repo mit committeter `frontend/e2e/foo.spec.ts`.
+
+- **AC-2:** Given ein Diff enthält sowohl eine Datei unter `frontend/e2e/` als
+  auch eine Datei unter `frontend/src/` (echter Frontend-Code), When
+  `_detect_scope_from_git_diff` läuft, Then liefert die Funktion weiterhin
+  `frontend-only` (keine Verwässerung bei echtem Frontend-Code).
+  - Test: `test_ac2_e2e_plus_frontend_src_is_frontend_only` mit beiden Pfaden im
+    selben Commit.
+
+- **AC-3:** Given ein Diff enthält sowohl eine Datei unter `frontend/e2e/` als
+  auch eine Backend-Datei (`src/`, `api/`, `internal/` oder `cmd/`), When
+  `_detect_scope_from_git_diff` läuft, Then liefert die Funktion weiterhin
+  `backend`, NICHT `full-stack`.
+  - Test: `test_ac3_e2e_plus_backend_is_backend_not_full_stack` mit
+    `frontend/e2e/foo.spec.ts` + `src/app/cli.py` im selben Commit.
+
+- **AC-4:** Given ein Diff enthält eine Datei unter `frontend/e2e/` zusammen mit
+  Dateien unter `docs/` und `tests/`, When `_detect_scope_from_git_diff` läuft,
+  Then liefert die Funktion `docs-only`.
+  - Test: `test_ac4_e2e_plus_docs_plus_tests_is_docs_only` mit allen drei Pfad-
+    Klassen im selben Commit.
+
+- **AC-5:** Given ein Ancestor-Commit trägt eine VERIFIED-Attestation und der
+  Zuwachs zum HEAD enthält ausschließlich Änderungen unter `frontend/e2e/`,
+  When `staging_gate.gate_check` (bzw. dessen `--detect-scope`/Ancestor-Pfad)
+  end-to-end gegen ein echtes Temp-Repo läuft, Then liefert `gate_check` Exit 0
+  (Ancestor-Relaxierung greift jetzt korrekt, keine irreführende
+  Parallel-Sitzungs-Meldung mehr).
+  - Test: `test_ac5_gate_check_ancestor_relaxation_with_e2e_only_increment`
+    reproduziert den Live-Vorfall vom 2026-08-15 (PR-Stack #1736/#1852/#1881/#1882)
+    im Kleinformat.
+
+- **AC-6:** Given ein Diff enthält ausschließlich echten Frontend-Code unter
+  `frontend/src/` (keine `frontend/e2e/`-Datei), When
+  `_detect_scope_from_git_diff` läuft, Then liefert die Funktion weiterhin
+  `frontend-only` — keine Regression am Bestandsverhalten.
+  - Test: `test_ac6_frontend_src_only_still_frontend_only_no_regression`.
+
+## Test-Politik
+
+Ausschließlich echte temporäre Git-Repos mit echten Commits (`git init`,
+`git add`, `git commit`) — kein Mock von `subprocess`, `git`, oder der
+Klassifikationsfunktion selbst. Vorbild: `tests/tdd/test_issue_1121_git_diff_returncode.py`
+(Hook-Dateien werden aus dem aktuellen Arbeitsverzeichnis/Worktree in das
+Temp-Repo kopiert, nicht aus dem Hauptrepo hartkodiert — sonst falsches Grün aus
+dem Worktree) und `tests/tdd/test_scope_tests_neutral.py` (Muster für das
+bereits bestehende `tests/`-Pendant dieser Ausnahme). Getestet wird
+Verhalten der echten Funktion gegen echte Dateipfade in echten Commits, nicht
+Dateiinhalt-Checks.
+
+## Known Limitations
+
+- `e2e_commit_gate.py::detect_scope()` (Pre-Commit-Pfad für `/e2e-verify`) hat
+  dieselbe `frontend/`-Präfix-Schwäche unabhängig dupliziert, ist aber eine
+  separate Funktion mit anderem Aufrufer und war nicht Teil des gemeldeten
+  Vorfalls (der lief über den Deploy-Pfad `staging_gate.py`). Wird in diesem Fix
+  bewusst NICHT mitgeändert (Scope-Disziplin) — als möglicher Folge-Befund für
+  #1199/#1197 zu notieren, falls die Adversary-Runde ihn aufwirft.
+- Der Ancestor-Walk in `staging_gate.gate_check` ist auf eine feste Obergrenze
+  an Commits begrenzt (siehe Vorgänger-Spec); dieser Fix ändert daran nichts.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Bugfix-Korrektur einer bestehenden Klassifikationsfunktion
+  (Verzeichnis-Präfix-Ausnahme analog zum bereits bestehenden `tests/`-Präzedenzfall
+  in derselben Funktion) — keine neue Architekturentscheidung, kein neues
+  Entscheidungsfeld (Kanäle, Provider, Datenmodell, Auth, Editor-Paradigma,
+  Test-/Deploy-Strategie) betroffen.
+
+## Changelog
+
+- 2026-08-15: Initial spec created

--- a/tests/tdd/test_e2e_frontend_scope_neutral.py
+++ b/tests/tdd/test_e2e_frontend_scope_neutral.py
@@ -1,0 +1,231 @@
+"""
+TDD RED — Frontend-E2E-Testdateien (`frontend/e2e/**`) neutral klassifizieren (#1197).
+
+Spec: docs/specs/modules/fix_1197_staging_gate_e2e_scope.md (AC-1..AC-6)
+
+Beweist aus Werkzeug-Sicht (echtes Temp-Git-Repo, KEINE subprocess-/git-Mocks):
+- Ein Diff, der nur `frontend/e2e/`-Dateien berührt, ist `docs-only` statt
+  `frontend-only` (Live-Vorfall 2026-08-15: PR-Stack #1736/#1852/#1881/#1882
+  blockierte den Deploy-Gate fälschlich).
+- Gemischte Diffs (`frontend/e2e/`+`frontend/src/`, `frontend/e2e/`+Backend,
+  `frontend/e2e/`+`docs/`+`tests/`) bleiben korrekt klassifiziert.
+- Echter Frontend-Code (`frontend/src/`) ohne `frontend/e2e/`-Anteil bleibt
+  unverändert `frontend-only` (Regressionsschutz).
+- End-to-End: die Ancestor-Relaxierung in `staging_gate.gate_check` lässt einen
+  reinen `frontend/e2e/`-Zuwachs über einem verifizierten Ancestor durch.
+
+Mock-frei: pro Fall ein echtes `git init`-Repo, echte Dateien, echtes
+`git add`/`commit`, dann die echte Funktion bzw. der echte Gate gegen dieses
+Repo laufen lassen. Direktimport der Hook-Module aus dem AKTUELLEN
+Arbeitsverzeichnis (Worktree), nicht aus dem Hauptrepo hartkodiert.
+"""
+import importlib.util
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOKS_DIR = REPO_ROOT / ".claude" / "hooks"
+
+# HOOKS_DIR muss in sys.path[0] liegen, damit staging_gate's internes
+# `import _e2e_paths` die Worktree-Version trifft (Konvention aus
+# test_scope_tests_neutral.py, Issue #648-Kontaminierungsfalle).
+sys.path.insert(0, str(HOOKS_DIR))
+
+_e2e = None
+_sg = None
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _ensure_modules():
+    global _e2e, _sg
+    if _e2e is None:
+        _e2e = _load_module(HOOKS_DIR / "_e2e_paths.py", "e2e_paths_wt1197_e2e_scope")
+    if _sg is None:
+        _sg = _load_module(HOOKS_DIR / "staging_gate.py", "staging_gate_wt1197_e2e_scope")
+
+
+def _git(repo, *args):
+    subprocess.run(
+        ["git", *args],
+        cwd=str(repo), check=True,
+        capture_output=True, text=True,
+    )
+
+
+def _init_repo(repo):
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Test")
+
+
+def _write(repo, relpath, content="x\n"):
+    p = repo / relpath
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+    return p
+
+
+def _committed_scope(repo, paths):
+    """Temp-Repo mit Basis-Commit + Ziel-Commit; ruft die echte
+    _detect_scope_from_git_diff() gegen HEAD~1..HEAD auf."""
+    _ensure_modules()
+    _init_repo(repo)
+    _write(repo, "README.md", "base\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-q", "-m", "base")
+    for rel in paths:
+        _write(repo, rel)
+        _git(repo, "add", rel)
+    _git(repo, "commit", "-q", "-m", "change")
+    return _e2e._detect_scope_from_git_diff("HEAD~1", "HEAD", repo)
+
+
+# ---------------------------------------------------------------------------
+# AC-1: Diff enthält ausschließlich Dateien unter frontend/e2e/ -> docs-only
+# ---------------------------------------------------------------------------
+
+def test_ac1_e2e_only_is_docs_only(tmp_path):
+    assert _committed_scope(
+        tmp_path,
+        ["frontend/e2e/foo.spec.ts", "frontend/e2e/helpers.ts"],
+    ) == "docs-only", (
+        "Ein Diff, der ausschliesslich frontend/e2e/-Dateien aendert, muss "
+        "docs-only liefern (Live-Vorfall 2026-08-15)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2: frontend/e2e/ + frontend/src/ -> weiterhin frontend-only
+# ---------------------------------------------------------------------------
+
+def test_ac2_e2e_plus_frontend_src_is_frontend_only(tmp_path):
+    assert _committed_scope(
+        tmp_path,
+        ["frontend/e2e/foo.spec.ts", "frontend/src/routes/+page.svelte"],
+    ) == "frontend-only", (
+        "Echter Frontend-Code (frontend/src/) darf durch die e2e-Ausnahme "
+        "nicht verwaessert werden."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3: frontend/e2e/ + Backend-Datei -> weiterhin backend, NICHT full-stack
+# ---------------------------------------------------------------------------
+
+def test_ac3_e2e_plus_backend_is_backend_not_full_stack(tmp_path):
+    assert _committed_scope(
+        tmp_path,
+        ["frontend/e2e/foo.spec.ts", "src/app/cli.py"],
+    ) == "backend", (
+        "frontend/e2e/ + Backend-Code darf NICHT full-stack ergeben, weil "
+        "frontend/e2e/ nicht als has_frontend zaehlt."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4: frontend/e2e/ + docs/ + tests/ -> docs-only
+# ---------------------------------------------------------------------------
+
+def test_ac4_e2e_plus_docs_plus_tests_is_docs_only(tmp_path):
+    assert _committed_scope(
+        tmp_path,
+        ["frontend/e2e/foo.spec.ts", "docs/README.md", "tests/tdd/test_bar.py"],
+    ) == "docs-only", (
+        "frontend/e2e/ zusammen mit anderen bereits neutralen Pfadklassen "
+        "(docs/, tests/) muss docs-only bleiben."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-6: nur echter Frontend-Code, KEINE frontend/e2e/-Datei -> weiterhin
+# frontend-only (Regressionsschutz, Bestandsverhalten unveraendert).
+# ---------------------------------------------------------------------------
+
+def test_ac6_frontend_src_only_still_frontend_only_no_regression(tmp_path):
+    assert _committed_scope(
+        tmp_path,
+        ["frontend/src/lib/foo.ts"],
+    ) == "frontend-only", (
+        "Regressionsschutz: echter Frontend-Code ohne frontend/e2e/-Anteil "
+        "muss unveraendert frontend-only bleiben."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5: End-to-End -- staging_gate.gate_check Ancestor-Relaxierung laesst
+# einen reinen frontend/e2e/-Zuwachs ueber einem verifizierten Ancestor durch.
+#
+# Reproduziert den Live-Vorfall vom 2026-08-15 im Kleinformat: ein Ancestor-
+# Commit ist VERIFIED attestiert, der Zuwachs zum HEAD aendert ausschliesslich
+# eine Datei unter frontend/e2e/. Vor dem Fix klassifiziert die Ancestor-Logik
+# diesen Zuwachs als frontend-only (Bug) -> kein Relax -> Exit 1. Nach dem Fix
+# liefert dieselbe Berechnung docs-only -> Relax -> Exit 0.
+#
+# Pattern uebernommen aus test_staging_gate_ancestor_scope.py (#1197 Vorgaenger-
+# Fix): ehrlicher Location-Seam (_shared_repo_dir/_verified_repo_dir per
+# monkeypatch auf das echte tmp-Repo umgebogen), keine Mocks der Git-Logik.
+# scope_override="frontend-only" simuliert den (vor diesem Fix) falsch
+# berechneten Gesamt-Scope des Deploys, damit der fruehe docs-only-Skip in
+# gate_check NICHT vorzeitig greift und der Kontrollfluss verlaesslich in die
+# Ancestor-Attestations-Aufloesung fuehrt, deren Zuwachs-Scope (C..HEAD)
+# unabhaengig davon real per git berechnet wird.
+# ---------------------------------------------------------------------------
+
+def _iso(hours_ago: float = 0.0) -> str:
+    return (datetime.now(timezone.utc) - timedelta(hours=hours_ago)).isoformat()
+
+
+def _write_attestation(shared: Path, sha: str, *, scope: str = "frontend-only") -> None:
+    out = shared / ".claude" / "e2e_verified" / f"{sha}.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(
+        json.dumps(
+            {
+                "verified_commit": sha,
+                "staging_verdict": "VERIFIED: alles gut",
+                "findings": [],
+                "verified_at": _iso(),
+                "scope": scope,
+                "environment": "staging",
+            }
+        )
+    )
+
+
+def test_ac5_gate_check_ancestor_relaxation_with_e2e_only_increment(tmp_path, monkeypatch):
+    _ensure_modules()
+    _init_repo(tmp_path)
+    _write(tmp_path, "src/app.py", "x = 1\n")
+    _write(tmp_path, "frontend/src/main.ts", "// app\n")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "product (attested)")
+    base = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=str(tmp_path),
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+    _write(tmp_path, "frontend/e2e/trip-preview-renamed.staging.spec.ts", "// e2e\n")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "e2e-only increment (renamed spec)")
+
+    _write_attestation(tmp_path, base, scope="frontend-only")
+    monkeypatch.setattr(_sg, "_shared_repo_dir", lambda: tmp_path)
+    monkeypatch.setattr(_sg, "_verified_repo_dir", lambda: tmp_path)
+    monkeypatch.delenv("GZ_SKIP_E2E_GATE", raising=False)
+
+    rc = _sg.gate_check(None, "frontend-only", expected_commit=None)
+    assert rc == 0, (
+        "Ein reiner frontend/e2e/-Zuwachs ueber einem verifizierten Ancestor "
+        "muss die Ancestor-Relaxierung durchlassen (Exit 0) -- reproduziert "
+        "den Live-Vorfall vom 2026-08-15."
+    )


### PR DESCRIPTION
_detect_scope_from_git_diff behandelte Playwright-E2E-Testdateien unter
frontend/e2e/** wie ausgelieferten Frontend-Code, obwohl sie analog zu
tests/ reine Testinfrastruktur sind. Das blockierte den Deploy-Gate nach
reinen Doku-/Tooling-Merges faelschlich (Live-Vorfall 2026-08-15,
PR-Stack #1736/#1852/#1881/#1882). frontend/e2e/ wird jetzt symmetrisch
zu tests/ als Nicht-Code behandelt, echter Frontend-Code bleibt
unveraendert erkannt.

Adversary VERIFIED (HOLDS), 6/6 AC bewiesen, 3/3 Pflicht-Mutationen
gefangen. 259 Tests gruen (6 neu + 253 Regression).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
