### PR TITLE
fix(#1871): Radar-Fixture-Zeitfenster-Klemmung gegen Mitternachts-Rückfall

### DIFF
--- a/docs/context/fix-1871-radarpfad-spaetankunft-zeitfenster.md
+++ b/docs/context/fix-1871-radarpfad-spaetankunft-zeitfenster.md
@@ -1,0 +1,88 @@
+# Kontext: #1871 — test_radarpfad_spaetankunft reproduzierbar rot 01:03–04:03 UTC
+
+## Analysis
+
+### Type
+Bug (Test-Fixture, kein Produktivcode)
+
+### Korrektur zum Ticket
+Das Issue nennt als Rot-Zone "04:00–06:00 UTC" und zitiert einen CI-Rot-Lauf um 05:29 UTC
+als Bestätigung. Beides ist widerlegt:
+- Nachgemessen (frischer Prozess je Datenpunkt, `freezegun`) ist die reale Rot-Zone
+  **01:03–04:03 UTC**.
+- Der zitierte CI-Rot-Lauf 05:29 UTC gehört laut `docs/specs/modules/fix_1851_alarm_tests_vorlaufsperre.md`
+  zum #1851-Vorlaufsperre-Mechanismus (`test_ac1_…`/`test_ac2a_…`/`test_ac3_…`), nicht zu
+  `test_radarpfad_spaetankunft_faellt_nicht_in_alle_segmente_vorbei`.
+
+### Root Cause (verifiziert, nicht spekuliert)
+
+`tests/unit/test_alarm_zeitfenster_ziel.py:398` in `_radar_mails_fuer_spaetankunft()`:
+
+```
+start_local = (arrival - timedelta(hours=4)).astimezone(dest_tz)
+```
+
+`_island_taugt()` (Zeile 323) erzwingt Ortsstunde `>= 1` für Reykjavik-Wahl, aber keine
+Obergrenze. Für Ankunft-Ortsstunden 1–3 (Reykjavik = UTC+0, keine DST) fällt
+`start_local = arrival - 4h` lokal auf den VORTAG zurück (z.B. Ankunft 02:27 → Start 22:27
+des Vortags). Beide Wegpunkte (W1 = `start_local`, W2 = `arrival_local`) werden als reine
+`HH:MM`-Strings (`arrival_calculated`, Zeilen 407/410) ohne Datumskontext auf denselben
+`date.today()`-Stage-Tag gelegt.
+
+Der Rollover-Mechanismus in `src/services/trip_segments.py:154-157` vergleicht diese reinen
+Uhrzeiten (`t < prev` = "strikt fallend = Tagesgrenze") und erhöht `day`, weil W1="22:27" >
+W2="02:27". Für ECHTE mehrtägige Treks ist das korrekt (#1091/#1098) — hier ist es ein
+Artefakt der Fixture-Konstruktion. Das Zielsegment landet auf dem Folgetag, „jetzt" liegt
+davor, kein Segment gilt aktiv, der Radar-Pfad nimmt den „alle Segmente vorbei"-Zweig — keine
+Mail, Test rot.
+
+**Kein Produktivcode-Bug** — `trip_segments.py:154-157` arbeitet wie spezifiziert.
+
+### Bestehender Wächter ist blind für genau diesen Fall (verifiziert)
+
+`test_radar_fixture_ist_zu_jeder_tageszeit_kein_mitternachtsfenster`
+(`tests/unit/test_alarm_zeitfenster_ziel.py:551`) iteriert 1440+3 Minuten und prüft
+ausschließlich drei Invarianten von `radar_fixture_window()`/`radar_fixture_tz()`/
+`radar_fixture_ort()`: `start_hour < end_hour`, `end_hour == Ortsstunde`, `Ortsdatum ==
+Etappendatum`. Er ruft `start_local` (Zeile 398) nie auf und prüft die W1-vs-W2-Wegpunktfolge
+nicht — eine andere Eigenschaft als die, an der der Fachtest hängt.
+
+**Zusätzlicher Fund:** Der KNOWN_VIOLATIONS-Kommentar in
+`tests/tdd/test_fixture_wallclock_ratchet.py:180-185` behauptet für genau diese Fixture, der
+1440-Minuten-Wächter sei „NICHT schwächer als die Ratsche, sondern stärker" und decke den
+Schutz vollständig ab. Das ist widerlegt — der Wächter deckt die Fensterwahl ab, nicht die
+W1-vs-W2-Sequenz. Der Kommentar sollte im Zuge dieses Fixes korrigiert werden, sonst bleibt
+eine falsche Sicherheitszusicherung im Code stehen.
+
+### Affected Files (with changes)
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `tests/unit/test_alarm_zeitfenster_ziel.py` | MODIFY | `start_local`-Berechnung auf lokalen Tagesbeginn klemmen statt naiv `arrival - 4h`; neue reine Funktion `radar_fixture_start_local()` (Pendant zu `radar_fixture_window/_tz/_ort`); Wächter `test_radar_fixture_ist_zu_jeder_tageszeit_kein_mitternachtsfenster` um die Invariante `start_hour_str <= arrival_hour_str` in derselben 1440er-Schleife erweitern |
+| `tests/tdd/test_fixture_wallclock_ratchet.py` | MODIFY | KNOWN_VIOLATIONS-Kommentar (Zeilen ~180-185) korrigieren: falsche „stärker als die Ratsche"-Behauptung entfernen/richtigstellen |
+
+### Scope Assessment
+- Files: 2
+- Estimated LoC: +30/-5 (überwiegend Kommentar-Korrektur + Klemm-Logik + Assertion-Erweiterung)
+- Risk Level: LOW — `_radar_mails_fuer_spaetankunft()` hat genau einen Aufrufer (Zeile 637, verifiziert per grep), keine Kollateralwirkung auf andere Testfälle
+
+### Technical Approach
+Klemmen statt Ausweichen: Wenn `arrival_local.hour < 4`, `start_local` auf lokalen
+Tagesbeginn (`00:00`) setzen statt `arrival - 4h` zu rechnen — analog zum Docstring-Titel von
+`test_fixture_wallclock_ratchet.py` ("…ohne sie auf einen Tagesbereich zu klemmen"), NICHT
+analog zum Auckland-Ausweichmuster (das löst eine andere Invariante: Fensterende vs.
+Ankunftsstunde). Da `_island_taugt()` `hour >= 1` erzwingt, ist `arrival_local.hour` im
+Bugfenster immer 1–3, `00:00 <= arrival_local` gilt garantiert, keine Grenzfälle bei Minute 0.
+
+Reihenfolge: (a) Klemm-Fix in der Fixture → Fachtest wird grün, (b) Wächter erweitern und per
+Mutations-Gegenprobe zeigen, dass ein Revert der Klemmung die erweiterte Assertion rot macht
+(Projekt-Pflicht Mutations-Gegenprobe).
+
+### Dependencies
+Keine Produktivcode-Abhängigkeiten. `radar_fixture_window/_tz/_ort` bleiben unverändert
+(andere Invariante, nicht wiederverwendbar für die W1-Klemmung).
+
+### Open Questions
+- [ ] Soll die Korrektur des KNOWN_VIOLATIONS-Kommentars in derselben Scheibe erfolgen oder
+      als eigener kleiner Nebenbefund? Empfehlung: gleiche Scheibe, da sonst eine widerlegte
+      Sicherheitszusicherung im Code stehen bleibt.

--- a/docs/specs/modules/fix_1871_radar_fixture_zeitfenster_klemmung.md
+++ b/docs/specs/modules/fix_1871_radar_fixture_zeitfenster_klemmung.md
@@ -1,0 +1,175 @@
+---
+entity_id: fix_1871_radar_fixture_zeitfenster_klemmung
+type: bugfix
+created: 2026-08-16
+updated: 2026-08-16
+status: draft
+version: "1.0"
+tags: [radar, test-fixture, zeitfenster, wanduhr]
+---
+
+# Radar-Fixture-Zeitfenster-Klemmung (#1871)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`test_radarpfad_spaetankunft_faellt_nicht_in_alle_segmente_vorbei` ist im Fenster
+01:03–04:03 UTC reproduzierbar rot, weil die Test-Fixture selbst (nicht der
+Produktivcode) einen Wegpunkt mit unklem Datumskontext auf den Vortag zurückrechnet.
+Diese Spec klemmt die Fixture-Zeitrechnung und erweitert den bestehenden
+1440-Minuten-Wächter, damit dieselbe Fixture-Klasse künftig zu jeder Tageszeit
+bewacht ist.
+
+## Source
+
+- **File:** `tests/unit/test_alarm_zeitfenster_ziel.py`
+- **Identifier:** `_radar_mails_fuer_spaetankunft`, `test_radar_fixture_ist_zu_jeder_tageszeit_kein_mitternachtsfenster`
+
+> **Schicht:** Python-Core-Testschicht (`tests/unit/`, `tests/tdd/`) — reiner Test-Fix,
+> kein Produktivcode betroffen (`src/services/trip_segments.py:154-157` arbeitet
+> spezifikationsgemäß).
+
+## Estimated Scope
+
+- **LoC:** ~30 (+25/-5, überwiegend Klemm-Logik + Assertion-Erweiterung + Kommentar-Korrektur)
+- **Files:** 2
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `radar_fixture_window/_tz/_ort` (`tests/unit/test_alarm_zeitfenster_ziel.py:302-369`) | Reine Hilfsfunktionen | Bleiben unverändert — andere Invariante (Fensterwahl), nicht wiederverwendbar für die W1-Klemmung |
+| `src/services/trip_segments.py:154-157` (Rollover-Mechanismus) | Produktivcode | Bleibt unverändert — arbeitet korrekt für echte mehrtägige Treks (#1091/#1098), die Fixture erzeugt hier nur ein Artefakt |
+| `KNOWN_VIOLATIONS` (`tests/tdd/test_fixture_wallclock_ratchet.py:209ff`) | Ratschen-Ausnahmeliste | Begründungskommentar zum Eintrag `_radar_mails_fuer_spaetankunft` wird korrigiert, Eintrag selbst bleibt bestehen |
+
+## Implementation Details
+
+### 1. Klemm-Fix in `_radar_mails_fuer_spaetankunft()` (Zeile 398)
+
+Bisher:
+```
+start_local = (arrival - timedelta(hours=4)).astimezone(dest_tz)
+```
+
+Neu: eine reine Funktion `radar_fixture_start_local(arrival_utc, heute)` analog zu
+`radar_fixture_window/_tz/_ort`, die bei `arrival_local.hour < 4` auf lokalen
+Tagesbeginn (`00:00` desselben Ortstags) klemmt statt `arrival - 4h` naiv zu
+rechnen, und sonst unverändert `arrival - 4h` liefert. Da `_island_taugt()`
+(Zeile 323) `hour >= 1` erzwingt, ist `arrival_local.hour` im Bugfenster
+garantiert 1–3 — die Klemmung liegt damit immer echt vor der Ankunft
+(`00:00 <= arrival_local`), keine Gleichstand-Grenzfälle bei Minute 0.
+
+`_radar_mails_fuer_spaetankunft()` ruft die neue Funktion anstelle der
+Inline-Rechnung auf.
+
+### 2. Wächter-Erweiterung (Zeile 551ff, `test_radar_fixture_ist_zu_jeder_tageszeit_kein_mitternachtsfenster`)
+
+Keine neue Testfunktion (vermeidet redundante zweite 1440er-Schleife). In der
+bestehenden Schleife über die 1440+3 synthetischen Zeitpunkte wird pro Fall
+zusätzlich `radar_fixture_start_local(arrival, heute)` berechnet und geprüft:
+
+```
+start_local.strftime("%H:%M") <= arrival_local.strftime("%H:%M")
+```
+
+als String-Vergleich auf denselben Formatstrings, die `_radar_mails_fuer_spaetankunft()`
+tatsächlich in `arrival_calculated` schreibt (Zeilen 407/410) — das ist genau
+die Wegpunktfolge (W1 <= W2), die der Rollover-Mechanismus in
+`trip_segments.py:154-157` interpretiert.
+
+### 3. Kommentar-Korrektur in `tests/tdd/test_fixture_wallclock_ratchet.py:184-185`
+
+Bisheriger Satz: „Der Schutz ist hier also NICHT schwaecher als die Ratsche,
+sondern staerker." ist sachlich falsch — der 1440-Minuten-Wächter deckte bis
+zu diesem Fix nur die Fensterwahl ab (`start_hour`/`end_hour`/Ortsdatum), nie
+die W1-vs-W2-Wegpunktfolge. Der Satz wird durch eine Formulierung ersetzt, die
+präzise beschreibt: der Wächter deckte ursprünglich nur die Fensterwahl ab;
+mit diesem Fix (#1871) prüft dieselbe Schleife zusätzlich `start_local <=
+arrival_local` und deckt damit auch die W1-vs-W2-Sequenz ab, die den Bug
+verursacht hat.
+
+## Expected Behavior
+
+- **Input:** Ankunftszeitpunkt `arrival_utc` (relativ zu `datetime.now()`, keine
+  gestellte Uhr), Ortsstunde 1–3 in Atlantic/Reykjavik (der bisherige Bugfall)
+  sowie alle anderen 1437 Minuten eines synthetischen Tages plus die 3
+  UTC-Mitternachts-Randminuten.
+- **Output:** `_radar_mails_fuer_spaetankunft()` liefert bei JEDER Ankunftsstunde
+  mindestens eine zugestellte Mail (Randfall-Guard greift, Zielsegment bleibt
+  aktiv). Der 1440+3-Wächter bestätigt für jeden synthetischen Fall
+  `start_local <= arrival_local` als Zeitstring.
+- **Side effects:** keine — reiner Test-/Fixture-Code, keine Produktivpfad-Änderung.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine Ankunft am Tagesziel mit Ortsstunde 1–3 in Atlantic/Reykjavik
+  (der bisher rote Zeitraum 01:03–04:03 UTC) / When `test_radarpfad_spaetankunft_faellt_nicht_in_alle_segmente_vorbei`
+  läuft (echte Wanduhr, kein `freeze_time`) / Then liefert `_radar_mails_fuer_spaetankunft()`
+  mindestens eine zugestellte Mail, der Test ist grün.
+  - Test: `freeze_time` (freezegun) auf einen Zeitpunkt innerhalb 01:03–04:03 UTC
+    gestellt (z.B. `2026-08-16T02:30:00`), **frischer Prozess je Datenpunkt**
+    (Zustand sickert sonst zwischen mehreren `pytest.main()`-Läufen im selben
+    Prozess durch — s. `reference_zeitmatrix_messen_frischer_prozess_je_datenpunkt`),
+    `tests/unit/test_alarm_zeitfenster_ziel.py::test_radarpfad_spaetankunft_faellt_nicht_in_alle_segmente_vorbei`
+    muss grün sein — vorher (ohne Klemm-Fix) bei diesem Zeitpunkt reproduzierbar rot.
+    Zusätzlich Randstellen 01:00/01:03/03:59/04:03 UTC gegenmessen.
+
+- **AC-2:** Given die 1440+3 synthetischen Zeitpunkte aus
+  `test_radar_fixture_ist_zu_jeder_tageszeit_kein_mitternachtsfenster` / When für
+  jeden Fall `radar_fixture_start_local(arrival, heute)` gegen
+  `arrival.astimezone(radar_fixture_tz(...))` verglichen wird / Then gilt für
+  ALLE 1443 Fälle `start_local.strftime("%H:%M") <= arrival_local.strftime("%H:%M")`
+  als Zeitstring-Vergleich.
+  - Test: `tests/unit/test_alarm_zeitfenster_ziel.py::test_radar_fixture_ist_zu_jeder_tageszeit_kein_mitternachtsfenster`
+    (erweitert um die neue Assertion) läuft ohne `AssertionError` über die volle
+    Schleife durch.
+
+- **AC-3 (Mutations-Gegenprobe, PFLICHT):** Given die Klemmung in
+  `radar_fixture_start_local()` wird per String-Ersetzung zurückgenommen (zurück
+  auf `arrival - timedelta(hours=4)` ohne `if arrival_local.hour < 4: ...`-Zweig)
+  / When beide Tests aus AC-1 und AC-2 erneut laufen / Then werden BEIDE rot —
+  nicht nur einer der beiden.
+  - Test: Adversary führt die Mutation an `radar_fixture_start_local()` mit
+    externer Sicherungskopie durch (keine `git checkout/stash/reset`), führt
+    `tests/unit/test_alarm_zeitfenster_ziel.py::test_radarpfad_spaetankunft_faellt_nicht_in_alle_segmente_vorbei`
+    UND `tests/unit/test_alarm_zeitfenster_ziel.py::test_radar_fixture_ist_zu_jeder_tageszeit_kein_mitternachtsfenster`
+    aus und dokumentiert, dass beide rot werden, bevor die Sicherungskopie
+    zurückgespielt wird.
+
+- **AC-4:** Given der KNOWN_VIOLATIONS-Kommentar in
+  `tests/tdd/test_fixture_wallclock_ratchet.py:184-185` behauptet aktuell fälschlich
+  vollständige Abdeckung durch den 1440-Minuten-Wächter / When der Kommentar auf
+  die tatsächliche, jetzt erweiterte Abdeckung korrigiert wird / Then enthält der
+  Kommentar keine Aussage mehr, die durch AC-1/AC-2 widerlegt ist (der Wächter
+  deckte vor diesem Fix nur die Fensterwahl ab, nicht die W1-vs-W2-Sequenz).
+  - Test: `# doc-compliance-test` — manuelle Prüfung, dass der Satz „Der Schutz ist
+    hier also NICHT schwaecher als die Ratsche, sondern staerker." in
+    `tests/tdd/test_fixture_wallclock_ratchet.py` durch eine sachlich korrekte
+    Formulierung ersetzt wurde (kein Verhaltenstest nötig, reine Doku-Korrektur).
+
+## Known Limitations
+
+- Die Klemmung greift nur, weil `_island_taugt()` `hour >= 1` erzwingt — bei
+  Ortsstunde 0 würde die Fixture ohnehin nach Auckland ausweichen
+  (`radar_fixture_ort`), dieser Fall ist von dieser Spec nicht betroffen und
+  bleibt unverändert.
+- `radar_fixture_start_local()` ist ausschließlich für diese eine Fixture gedacht
+  (`_radar_mails_fuer_spaetankunft`) — keine allgemeine Zeitfenster-Utility für
+  andere Radar-Tests.
+- Der KNOWN_VIOLATIONS-Eintrag selbst (Zeilen 173-185) bleibt bestehen, da die
+  Fixture weiterhin `jetzt`/`heute` referenziert (strukturell notwendig laut
+  bestehender Begründung) — nur die Abdeckungsaussage im Kommentar wird korrigiert.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reiner Test-Fixture-Fix ohne Berührung von Entscheidungsflächen
+  (Kanäle, Provider, Datenmodell, Auth, Editor-Paradigma, Test-/Deploy-Strategie).
+
+## Changelog
+
+- 2026-08-16: Initial spec created

--- a/tests/tdd/test_fixture_wallclock_ratchet.py
+++ b/tests/tdd/test_fixture_wallclock_ratchet.py
@@ -181,8 +181,11 @@ _HEUTE_TRAEGER = {"date", "datetime", "date_type", "datetime_type"}
 #    einzige Fix im ganzen Slice, der ueber ALLE 1440 Minuten eines Tages
 #    deterministisch bewacht wird —
 #    `test_radar_fixture_ist_zu_jeder_tageszeit_kein_mitternachtsfenster`
-#    iteriert 1440+3 synthetische Zeitpunkte, ohne gestellte Uhr. Der Schutz
-#    ist hier also NICHT schwaecher als die Ratsche, sondern staerker.
+#    iteriert 1440+3 synthetische Zeitpunkte, ohne gestellte Uhr. Urspruenglich
+#    deckte dieser Waechter nur die Fensterwahl ab (start_hour/end_hour/
+#    Ortsdatum) — NICHT die W1-vs-W2-Wegpunktfolge, die #1871 als Bug traf.
+#    Seit #1871 prueft dieselbe Schleife zusaetzlich `start_local <=
+#    arrival_local` und deckt damit auch die W1-vs-W2-Sequenz ab.
 #
 # 2) test_starkregen_kurzfristhinweis.py::_trip_with_segment_offset
 #    Die Pruefaussage IST die exakte Vorlaufzeit: 90 Minuten (jenseits von

--- a/tests/unit/test_alarm_zeitfenster_ziel.py
+++ b/tests/unit/test_alarm_zeitfenster_ziel.py
@@ -369,6 +369,21 @@ def radar_fixture_ort(arrival_utc: datetime, heute: date | None = None) -> tuple
     return AUCKLAND_LAT, AUCKLAND_LON
 
 
+def radar_fixture_start_local(arrival_utc: datetime, heute: date | None = None) -> datetime:
+    """Startzeitpunkt (W1) der Radar-Fixture — REINE Funktion, analog zu
+    ``radar_fixture_window/_tz/_ort``.
+
+    Klemmt auf lokalen Tagesbeginn (``00:00`` desselben Ortstags) statt
+    ``arrival - 4h`` naiv zu rechnen, wenn das ueber Mitternacht zurueck auf
+    den Vortag ueberschiessen wuerde (#1871).
+    """
+    dest_tz = radar_fixture_tz(arrival_utc, heute)
+    arrival_local = arrival_utc.astimezone(dest_tz)
+    if arrival_local.hour < 4:
+        return arrival_local.replace(hour=0, minute=0, second=0, microsecond=0)
+    return arrival_local - timedelta(hours=4)
+
+
 def _radar_mails_fuer_spaetankunft() -> list:
     """Baut einen Trip mit Spaetankunft RELATIV ZUM TAGESFENSTER und laesst den
     echten ``check_radar_alerts()`` darueber laufen. Gibt die zugestellten
@@ -395,7 +410,7 @@ def _radar_mails_fuer_spaetankunft() -> list:
     dest_tz = radar_fixture_tz(arrival, heute)
     start_hour, end_hour = radar_fixture_window(arrival, heute)
     arrival_local = arrival.astimezone(dest_tz)
-    start_local = (arrival - timedelta(hours=4)).astimezone(dest_tz)
+    start_local = radar_fixture_start_local(arrival, heute)
 
     trip_id = f"radar-{uuid.uuid4().hex[:8]}"
     stage = Stage(
@@ -604,6 +619,17 @@ def test_radar_fixture_ist_zu_jeder_tageszeit_kein_mitternachtsfenster():
             f"F004: Ortsdatum {lokal.date()} != Etappendatum {heute} bei "
             f"{arrival.isoformat()} ({tz}) — check_radar_alerts() sucht die "
             "Etappe ueber date.today() und faende sie nicht."
+        )
+
+        # #1871: radar_fixture_start_local() klemmt W1 (start_local) so, dass
+        # es NIE nach W2 (arrival_local) faellt — sonst kollabiert das
+        # Zielsegment (Ende <= Start) und der Radar-Pfad faellt still aus der
+        # Ueberwachung.
+        start_local = radar_fixture_start_local(arrival, heute)
+        assert start_local.strftime("%H:%M") <= lokal.strftime("%H:%M"), (
+            f"F1871: start_local={start_local.strftime('%H:%M')} liegt NACH "
+            f"arrival_local={lokal.strftime('%H:%M')} bei {arrival.isoformat()} "
+            f"({tz}) — W1 nach W2 laesst das Zielsegment kollabieren."
         )
 
 


### PR DESCRIPTION
## Summary
- Test-Fixture-Fehler behoben: test_radarpfad_spaetankunft_faellt_nicht_in_alle_segmente_vorbei war reproduzierbar rot im Fenster 01:03-04:03 UTC (Korrektur zum Issue, das fälschlich 04:00-06:00 UTC nannte)
- Ursache: start_local = arrival - 4h ohne Klemmung fiel bei Ankunft-Ortsstunden 1-3 (Reykjavik) auf den Vortag zurück, der Rollover-Mechanismus in trip_segments.py (korrekt, kein Produktivcode-Bug) interpretierte das als echten Tageswechsel
- Neue reine Funktion radar_fixture_start_local() klemmt auf lokalen Tagesbeginn statt naiv 4h zurückzurechnen
- Bestehender 1440-Minuten-Wächter um die W1<=W2-Invariante erweitert; widerlegter "vollständig abgedeckt"-Kommentar korrigiert

## Test plan
- [x] tests/unit/test_alarm_zeitfenster_ziel.py + tests/tdd/test_fixture_wallclock_ratchet.py: 48 passed
- [x] Erweiterter Regressionslauf (368 Tests über verwandte Alarm-/Zeitfenster-/Trip-Pfade): 0 failed
- [x] Zeitmatrix per freeze_time, frischer Prozess je Datenpunkt, 01:00/01:03/02:30/03:59/04:03 UTC: alle grün
- [x] Adversary-Dialog VERIFIED, Pflicht-Mutations-Gegenprobe bestanden (2 unabhängige Mutationen, beide Tests korrekt rot)
- [x] Kein Produktivcode berührt (src/services/trip_segments.py unverändert)

Refs #1871 (Issue wird erst nach bestandenem Post-Deploy-Selftest manuell geschlossen, nicht automatisch beim Merge)

🤖 Generated with Claude Code