### PR TITLE
fix(#1861,#1865): Alarm-Mail-Datenblock unterscheidbar + verstaendlicher Text

### DIFF
--- a/docs/context/fix-1861-1865-alarm-mail-klarheit.md
+++ b/docs/context/fix-1861-1865-alarm-mail-klarheit.md
@@ -1,0 +1,67 @@
+# Context: fix-1861-1865-alarm-mail-klarheit
+
+## Request Summary
+Zwei PO-Bug-Reports (heute, 2026-08-15) zur Abweichungs-Alarm-Mail (`deviation-alert`): (#1861) bei mehreren Ereignissen derselben Metrik sind die Zeilen ununterscheidbar ("Gewitter · Schwelle 1" 3×); (#1865) die Datenblock-Zeile "Alarm-Schwelle 1 / Änderung über ✗" ist ein unverständliches Textfragment.
+
+## Related Files
+| File | Relevance |
+|------|-----------|
+| `src/output/renderers/alert/render.py` | Zentrale Renderer-Funktionen für beide Bugs: `_datablock_single` (Zeile 375-400, #1865-Fragment), Multi-Event-Zweig in `render_email` (Zeile 492-531, #1861-Ununterscheidbarkeit), `_h1`/`render_subject` (Betreff-Wortlaut) |
+| `src/output/renderers/alert/model.py` | `AlertEvent` trägt bereits `occurred_at`, `km_from`/`km_to`, `segment_id` (Zeile 12-33) — Differenzierungs-Daten sind vorhanden, werden im Multi-Zweig nur nicht gerendert. `over_thr`/`side_label` (Zeile 110-119) — Kern der #958-Korrektur, NICHT anfassen |
+| `src/output/renderers/alert/project.py` | `to_alert_message()` befüllt `segment_id`/`km_from`/`km_to` je Event aus dem passenden Segment (Zeile 66-99) — Quelle für den #1861-Differenzierer |
+| `src/services/notification_service.py`, `radar_alert_service.py`, `validator_render_service.py` | Aufrufer von `render_email`/`render_subject`/`render_telegram` — reine Konsumenten, keine eigene Wortlaut-Logik |
+| `tests/tdd/test_alert_bundle_958ff.py` (Zeile 123-150) | Fixiert AC-2 aus #958: exakt der jetzt bemängelte Text `"Änderung über ✗"` — **muss beim Fix mitgezogen werden**, nicht einfach gelöscht |
+| `tests/tdd/test_issue_1169_compare_alert_consumer.py` (Zeile 750-765) | Weitere Fixierung derselben Wortlaute für den Compare-Alarm-Pfad (nutzt denselben Renderer) |
+| `docs/design-requests/alert-mail-vorschlaege/Gregor 20 - Alert Mail Vorschläge.html` | Original-Design-Vorlage (Claude Design). Zeigt Row2-Muster `"Alarm-Schwelle 800" / "jetzt darunter ✓"` als vollständigen Satz — Vorlage deckt den Multi-Event-Gleichname-Fall (#1861) NICHT ab |
+
+## Existing Patterns
+- **Single-Event-Datenblock** (`_datablock_single`) hat bereits eine 3. Zeile "Wo & wann" mit `_location_of((e,), location_label)` + `occurred_at` — genau dieses Muster fehlt im Multi-Event-Zweig.
+- **Reihenfolge nach Schwere** (Issue #978): Multi-Event-Zeilen sind bereits nach `severity()` sortiert (`_sorted(msg)`) — reine Text-Ergänzung ändert die Sortierung nicht.
+- Betreff-Kurzform (`_sms_subject`/render_telegram) hat dasselbe Ununterscheidbarkeits-Problem wie #1861 (KHW-SMS "TH1 TH0 TH0" aus dem Issue-Text) — Scope-Frage für Analyse: nur E-Mail oder auch SMS/Telegram?
+
+## Dependencies
+- Upstream: `AlertEvent`/`AlertMessage` (model.py), `get_metric()` (Katalog für Einheit), `segments.format_alert_location` (Ortssprache, s. #1744)
+- Downstream: E-Mail (Trip + Compare via `to_multi_point_alert_message`), Telegram, SMS — alle vier Renderer-Funktionen (`render_subject/email/telegram/sms`) sind kanal-konsistent (Issue #978-Vorgabe); Wortlautänderung an einer Stelle zieht ggf. Konsistenz-Erwartung an den anderen Kanälen nach sich
+
+## Existing Specs
+- Kein dediziertes Entity-Spec für `alert/render.py` gefunden; Design-Referenz ist die o.g. Claude-Design-Vorlage + `docs/adr/` (ADR-0011 kanonisches AlertMessage-Modell, s. Docstring model.py)
+
+## Risks & Considerations
+- **#958-Regressionsgefahr:** Die aktuell bemängelte Zeile "Änderung über ✗" wurde in #958 GEZIELT eingeführt, um einen semantischen Bug zu fixen (`über`/`unter` verglich bei Δ-Metriken fälschlich Absolutwert mit Δ-Schwelle — bei steigender Nullgradgrenze stand dort "unter"). Der Fix darf NICHT zur alten Absolutwert-Semantik zurück, sondern muss nur den TEXT der bereits korrekten `side_label()`/`over_thr()`-Werte verständlicher fassen.
+- **Gebundene Tests:** `test_alert_bundle_958ff.py` und `test_issue_1169_compare_alert_consumer.py` fixieren den exakten aktuellen Wortlaut — beide müssen im selben Workflow aktualisiert werden, sonst bricht `touched_tests_gate.py`.
+- **Renderer-Commit-Gate (#811):** `alert/render.py` ist eine Mail-Inhalts-Datei → Commit erfordert grünen `test_issue_811_mode_matrix.py` + erfolgreichen `briefing_mail_validator.py`-Lauf (bzw. den für Alarm-Mails zuständigen Validator prüfen — laut Memory ist `radar_alert_mail_validator` für `mail_type="official-alert"` ein No-Op; für `"deviation-alert"` muss das in der Analyse-Phase verifiziert werden).
+- **#1861-Differenzierer offen:** Model hat `occurred_at` (nur HH:MM, kein Datum) und `segment_id`/`km_from`/`km_to`. Bei mehrtägigen Alarmen kann `occurred_at` allein missverständlich sein (gleiche Uhrzeit an verschiedenen Tagen). Empfehlung für Analyse-Phase: Segment/km als primären Differenzierer nutzen (analog Single-Event-Zeile "Wo & wann"), `occurred_at` ergänzend.
+- **Scope-Grenze:** SMS-Kurzform (`-TH1 -TH0 -TH0` aus #1861) hat dasselbe Ununterscheidbarkeits-Problem, aber SMS ist hart zeichenlimitiert (GSM-7, Token-Format). Muss in der Analyse explizit entschieden werden: Teil dieser Scheibe oder bewusst ausgeklammert (Token-Format-Erweiterung wäre größerer Eingriff).
+
+## Analysis
+
+### Type
+Bug (2 zusammengehörige PO-Reports, ein Slice/Commit).
+
+### Affected Files (with changes)
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/output/renderers/alert/render.py` | MODIFY | Neuer gemeinsamer Helper `_where_when(e, location_label=None)` (extrahiert aus `_datablock_single`-Zeile-3-Logik) für #1861-Differenzierer im Multi-Zweig von `render_email` (Zeile 504-519) **und** Telegram-Multi-Zweig (Zeile ~610-615, Konsistenz-Vorgabe #978); Wortlaut-Fix `_datablock_single` Zeile 388-391 für #1865 (vollständiger Satz statt Fragment, `over_thr()`/`side_label()`-Aufrufe unverändert) |
+| `tests/tdd/test_alert_bundle_958ff.py` | MODIFY | Zeile 144/148 — neuer Wortlaut statt `"Änderung über ✗"`, AC-2-Beschreibung anpassen |
+| `tests/tdd/test_issue_1169_compare_alert_consumer.py` | MODIFY | Zeile 750-765 — identischer String-Block für den Compare-Alarm-Pfad |
+| ggf. weitere Testdateien mit `"Änderung über/unter"`/`"Alarm-Schwelle"`-Assertions | MODIFY | Vor Implementierung per `grep -rn "Änderung über\|Änderung unter" tests/` vollständig erfassen — nicht von den zwei oben genannten verallgemeinern |
+
+### Scope Assessment
+- Files: 1 Quelldatei + 2-4 Testdateien
+- Estimated LoC: ~30-40 (Helper-Extraktion + zwei Wortlaut-Stellen + Test-Anpassungen)
+- Risk Level: LOW (reines Text-Templating, `over_thr()`/`side_label()`-Semantik aus #958 bleibt unberührt)
+
+### Technical Approach
+- **#1861:** Multi-Event-Zeilen bekommen einen Orts-/Zeit-Zusatz aus bereits vorhandenen `AlertEvent`-Feldern (`segment_id`/`km_from`/`km_to`/`occurred_at`) — analog zur bestehenden "Wo & wann"-Zeile im Single-Event-Pfad, über gemeinsamen Helper statt Duplikat-Logik. Telegram-Multi-Zweig zieht aus Kanal-Konsistenz-Gründen (Präzedenz #978) mit; SMS bewusst **ausgeklammert** (strukturell anders: `_sms_token` hängt bereits `@HH` an, hartes GSM-7-Zeichenlimit — eigenes Ticket bei Bedarf).
+- **#1865:** Nur der Text um die bereits korrekten `over_thr()`/`side_label()`-Werte wird zum vollständigen Satz (z. B. „jetzt darüber ✗"/„jetzt darunter ✓" analog Design-Vorlage, oder „Wert liegt über/unter ✗/✓"). Exakter deutscher Wortlaut wird in `/30-write-spec` als AC formuliert und dem PO zur Freigabe vorgelegt — keine Logikänderung an `over_thr()`/`side_label()` (#958-Invariante).
+
+### Dependencies
+- Ein Slice für beide Bugs (dieselbe Datei, dieselben zwei Pflicht-Test-Updates fallen so oder so an — zwei separate Renderer-Gate-Läufe wären Mehraufwand ohne Nutzen).
+- Renderer-Commit-Gate #811 greift (`alert/render.py` matched das `radar_alert_files`-Pattern in `renderer_mail_gate.py:56`), verlangt `test_issue_811_mode_matrix.py` grün + einen `radar_alert_validation.yaml`-Nachweis.
+- **Korrektur zur strategischen Bewertung des Plan-Agenten:** dessen Aussage „`briefing_mail_validator.py:574` behandelt `deviation-alert` aktiv" ist **falsch** — nachgemessen (`briefing_mail_validator.py:574-580`): `mail_type in ("compare", "deviation-alert")` liefert dort explizit `(False, ["... falscher Validator, uebersprungen"])`, ist also selbst ein No-Op-Fail, kein aktiver Check. Und `radar_alert_mail_validator.py:105-108` validiert nur `mail_type == "radar-alert"` (Nowcast/Onset), für `deviation-alert` ebenfalls No-Op (Exit 0 ohne Inhaltsprüfung, wie bereits für `official-alert` in `[[project_issue_1216_alert_mail_vorlage]]` dokumentiert). **Es gibt keinen aktiven Inhalts-Validator für `deviation-alert`-Mails** — der einzige echte Korrektheits-Nachweis für den neuen Wortlaut kommt aus den (angepassten) deterministischen Unit-/TDD-Tests, nicht aus einem Live-Mail-Validator-Lauf. Bekannte, bereits dokumentierte Gate-Lücke (kein neuer Handlungsbedarf in dieser Scheibe).
+
+### Open Questions
+- [x] Braucht #1861 einen Differenzierer? → Ja, Segment/km + Uhrzeit aus vorhandenen Feldern.
+- [x] SMS mitziehen? → Nein, eigenes Ticket bei Bedarf.
+- [x] Gefährdet der #1865-Fix die #958-Korrektheit? → Nein, wenn nur der Text um `over_thr()`/`side_label()` geändert wird.
+- [ ] Exakter deutscher Wortlaut beider Zeilen — wird als AC in `/30-write-spec` formuliert und PO-freigegeben.

--- a/docs/specs/modules/fix_1861_1865_alarm_mail_klarheit.md
+++ b/docs/specs/modules/fix_1861_1865_alarm_mail_klarheit.md
@@ -1,0 +1,234 @@
+---
+entity_id: fix_1861_1865_alarm_mail_klarheit
+type: bugfix
+created: 2026-08-15
+updated: 2026-08-15
+status: draft
+workflow: fix-1861-1865-alarm-mail-klarheit
+---
+
+# Abweichungs-Alarm-Mail: unterscheidbare Mehrfach-Ereignisse + verständlicher Datenblock-Text
+
+## Approval
+
+- [x] Approved
+
+## Purpose
+
+Zwei PO-Bug-Reports (2026-08-15) zur Abweichungs-Alarm-Mail (`deviation-alert`):
+**#1861** — bei mehreren Ereignissen DERSELBEN Metrik (z. B. drei Gewitter-Treffer für
+unterschiedliche Etappen/Zeitfenster) sind die Datenblock-Zeilen in `render_email()`s
+Multi-Event-Zweig ununterscheidbar ("Gewitter · Schwelle 1" dreimal identisch), obwohl
+`AlertEvent` bereits `segment_id`/`occurred_at` je Ereignis trägt. **#1865** — die
+Einzel-Event-Datenblock-Zeile "Alarm-Schwelle 1" / "Änderung über ✗" ist ein
+unverständliches Textfragment statt eines vollständigen Satzes. Beide Bugs sitzen in
+derselben Quelldatei und derselben fachlichen Fläche (Alarm-Mail-Datenblock) — ein
+Slice, ein Commit.
+
+## Source
+
+- **File:** `src/output/renderers/alert/render.py`
+- **Identifier:** `render_email` (Multi-Event-Zweig, #1861), `render_telegram`
+  (Multi-Event-Zweig, #1861, Kanalkonsistenz), `_datablock_single` (#1865), neu:
+  `_where_when`
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `output.renderers.alert.model.AlertEvent` (`segment_id`, `km_from`/`km_to`, `occurred_at`) | Datenmodell | Bereits vorhandene Differenzierungs-Felder für #1861 — keine Modelländerung nötig |
+| `output.renderers.alert.model.over_thr` / `side_label` | Funktion | #958-Kernsemantik — bleibt UNVERÄNDERT, nur der Text um ihre Rückgabewerte ändert sich (#1865) |
+| `output.renderers.alert.render._location_of` / `output.renderers.alert.segments.format_alert_location` | Funktion | Bestehende Ortssprache (Issue #1744) — Basis für den neuen `_where_when()`-Helper, wird NICHT verändert |
+| `tests/tdd/test_alert_bundle_958ff.py` (AC-2) | Test | Fixiert aktuell exakt den zu ändernden #1865-Wortlaut — muss mitgezogen werden |
+| `tests/tdd/test_issue_1169_compare_alert_consumer.py` (Zeile ~747-766) | Test | Fixiert denselben Wortlaut für den Compare-Alarm-Pfad — muss mitgezogen werden |
+| `tests/tdd/test_issue_1170_compare_alert_config.py` (AC-7) | Test | Regressionsschutz: Compare-Bündel-Pfad (kein `segment_id`) darf durch den #1861-Differenzierer NICHT verändert werden — bleibt unverändert grün |
+
+## Scope
+
+### Affected Files
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/output/renderers/alert/render.py` | MODIFY | Neuer Helper `_where_when(e)` (Segment-/km-Referenz + Uhrzeit, extrahiert aus der bestehenden "Wo & wann"-Logik in `_datablock_single`); Einsatz im Multi-Event-Zweig von `render_email` (Zeile ~504-519) UND `render_telegram` (Zeile ~592-601), NUR wenn `e.segment_id` gesetzt ist (Trip-Pfad); Wortlaut-Fix in `_datablock_single` Zeile 388-391 (#1865) — `over_thr()`/`side_label()`-Aufrufe unverändert, nur der gebaute Satz ändert sich |
+| `tests/tdd/test_alert_bundle_958ff.py` | MODIFY | AC-2 (Zeile ~127-150): neuer Wortlaut statt `"Änderung über ✗"`, Docstring/Assertion-Text angepasst |
+| `tests/tdd/test_issue_1169_compare_alert_consumer.py` | MODIFY | Zeile ~747-766: identischer String-Block für den Compare-Einzel-Event-Pfad nachgezogen |
+| `tests/tdd/test_alert_multi_event_where_when.py` | CREATE | Neue Tests für #1861 (Differenzierung Multi-Event-E-Mail + Telegram bei gleicher Metrik) — Namensregel: nach Verhalten benannt, nicht nach Issue-Nummer |
+| `tests/tdd/test_issue_1170_compare_alert_config.py` | MODIFY | Nachtrag 2026-08-16 (Adversary F002): EINE zusätzliche Assertion in `test_ac7_single_location_two_metrics_no_per_row_location_prefix` (`"km 0" not in plain`), die die #1861-Abgrenzung zum Compare-Bündelpfad tatsächlich bewacht — Zusicherung verschärft, nicht gelockert |
+
+**Grep-Nachweis (vollständige Erfassung, Kontext-Dokument-Auflage):** `grep -rn "Änderung über\|Änderung unter" tests/` liefert 6 Treffer in 6 Dateien; geprüft wurden alle. `test_change_detection.py`, `test_official_alert_channel_threshold.py`, `test_issue_1004_startzeit_ssot.py`, `test_bug_alert_ignores_weather_tab_disable.py` nutzen den String "Alarm-Schwelle" nur als allgemeinen Begriff (Docstrings/Kommentare, Kaskaden-/Persistenz-/Sichtbarkeits-Tests) — sie prüfen NICHT den gerenderten Zeilentext und sind von diesem Fix nicht betroffen. Nur `test_alert_bundle_958ff.py` und `test_issue_1169_compare_alert_consumer.py` fixieren den tatsächlich gerenderten String.
+
+### Estimated Changes
+- Files: 4 (1 modifiziert im Renderer, 2 modifizierte Testdateien, 1 neue Testdatei)
+- LoC: ca. +40/-15 in `render.py` (Helper-Extraktion, zwei Einsatzstellen, Wortlaut-Fix); Test-LoC zusätzlich, zählt gegen das separate 500er-Test-Budget (CLAUDE.md, Workflow-Tools v3), nicht gegen die 250 Prod-LoC
+
+## Implementation Details
+
+**1. `#1865` — vollständiger Satz statt Fragment (`_datablock_single`, Zeile 388-391):**
+`over_thr()`/`side_label()` bleiben BYTE-IDENTISCH in ihrer Logik. Nur der gebaute Satz
+ändert sich, z. B. über eine lokale Zuordnung `{"über": "darüber", "unter": "darunter"}`,
+angewendet auf den (unveränderten) Rückgabewert von `side_label(e)`:
+```
+mark = "✓" if not over_thr(e) else "✗"
+row2 = (f"Alarm-Schwelle {_val(e, e.threshold)}", f"jetzt {ADVERB[side_label(e)]} {mark}")
+```
+Ergebnis (Plain, Label:Wert): `"Alarm-Schwelle 10,0 mm: jetzt darüber ✗"` /
+`"... jetzt darunter ✓"` — orientiert an der Design-Vorlage
+(`docs/design-requests/alert-mail-vorschlaege/Gregor 20 - Alert Mail Vorschläge.html`,
+Gut-Fall `"jetzt darunter ✓"`), symmetrisch auf den Schlecht-Fall übertragen. Der exakte
+Wortlaut ist Teil der ACs unten und wird dem PO wörtlich vorgelegt.
+
+**2. `#1861` — Differenzierer im Multi-Event-Zweig, neuer Helper `_where_when`:**
+Extrahiert aus der bestehenden Zeile-3-Logik von `_datablock_single`
+(`_location_of((e,), location_label) + " · " + occurred_at`), OHNE `location_label`-
+Parameter (der wird im Multi-Zweig nicht gebraucht, s. Punkt 3):
+```
+def _where_when(e: AlertEvent) -> str:
+    when = _location_of((e,), None)
+    if e.occurred_at:
+        when += f" · {e.occurred_at}"
+    return when
+```
+`_datablock_single` Zeile 396-398 wird auf diesen Helper umgestellt (mit dem bisherigen
+`location_label`-Argument weiterhin durchgereicht — dafür bleibt der Helper-Aufruf dort
+`_location_of((e,), location_label)` direkt, NICHT über `_where_when`, da `_where_when`
+bewusst ohne `location_label`-Parameter gebaut ist, s. u.). Byte-identisches Verhalten
+für den Single-Event-Pfad ist Regressionsvoraussetzung (AC-4).
+
+Im Multi-Event-Zweig von `render_email` und `render_telegram` wird der Zusatz **nur
+ergänzt, wenn `e.segment_id` gesetzt ist** (Trip-Pfad, Issue #1744). Begründung: der
+Compare-Bündelpfad (`to_multi_point_alert_message`) setzt `segment_id` NIE und `km_from`/
+`km_to` konstant auf `0.0` (project.py Zeile ~220) — ein ungefilterter Einsatz von
+`_where_when()` würde dort sinnlose Zusätze wie `"km 0–0"` in jede Zeile schreiben und
+die #1170-Regressions-Invariante (AC-7, `test_issue_1170_compare_alert_config.py`)
+gefährden. Die Bedingung `e.segment_id is not None` trifft exakt den PO-Bug-Report-Fall
+(Trip-Pfad, KHW Segment 4-6) und lässt den Compare-Pfad unangetastet.
+
+`render_email` (über-Schwelle-Zeile, analog unter-Schwelle):
+```
+where_when = f" · {_where_when(e)}" if e.segment_id else ""
+label = f"{loc_prefix}{_label(e)}{where_when} · Schwelle {_num(e, e.threshold)}{threshold_suffix}"
+```
+`render_telegram` (Kanalkonsistenz, Issue #978-Präzedenz):
+```
+where_when = f" {_where_when(e)}" if e.segment_id else ""
+# in der metric_line-Zusammenstellung je Event ergänzt
+```
+
+**Betreff (`render_subject`) ist NICHT Teil dieser Scheibe** — siehe Known Limitations.
+
+## Expected Behavior
+
+- **Input:** `AlertMessage` mit ≥2 `AlertEvent`s derselben `metric_id`, `segment_id`
+  gesetzt (Trip-Pfad), unterschiedlichen `segment_id`- und/oder `occurred_at`-Werten.
+- **Output:** `render_email()`/`render_telegram()` liefern für jedes Event eine
+  eigenständige, vom PO lesbare Zeile mit Segment-/Zeit-Bezug statt identischer Zeilen;
+  `_datablock_single()`s "Alarm-Schwelle"-Zeile ist ein vollständiger Satz.
+- **Side effects:** keine — reines Text-Templating, kein Zustand, kein I/O.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine `deviation-alert`-E-Mail mit drei `AlertEvent`s derselben Metrik
+  (`metric_id="thunder"`), `segment_id` gesetzt auf `"4"`, `"5"`, `"6"` (Trip-Pfad,
+  Reproduktion des PO-Bug-Reports "3x Gewitter Segment 4-6") / When `render_email()` den
+  Multi-Event-Datenblock rendert / Then sind die drei resultierenden Zeilen paarweise
+  UNTERSCHIEDLICHE Strings UND jede Zeile enthält den Segment-Bezug ihres jeweiligen
+  Events (z. B. "Segment 4"/"Segment 5"/"Segment 6").
+  - Test: `tests/tdd/test_alert_multi_event_where_when.py` — `AlertMessage` mit den drei
+    o. g. Events bauen, `render_email()` aufrufen, Plain-Text-Zeilen extrahieren und
+    paarweise auf Ungleichheit prüfen (kein reiner Dateiinhalt-Check der Quelle, sondern
+    der tatsächlich gerenderten Ausgabe). Zweite Sub-Prüfung: zwei Events mit
+    IDENTISCHEM `segment_id`, aber unterschiedlichem `occurred_at` — auch hier müssen die
+    Zeilen sich unterscheiden (Uhrzeit als Differenzierer bei gleicher Etappe).
+
+- **AC-2:** Given dieselbe Fixture wie AC-1 / When `render_telegram()` die Multi-Event-
+  Metrik-Zeile rendert / Then enthält die Zeile für jedes Event denselben Segment-/Zeit-
+  Bezug wie in der E-Mail (Kanalkonsistenz, Issue #978-Präzedenz) UND die drei
+  Teilangaben sind paarweise unterscheidbar.
+  - Test: `tests/tdd/test_alert_multi_event_where_when.py` — gleiche Fixture,
+    `render_telegram()` aufrufen, `metric_line` auf die drei Segment-Referenzen prüfen.
+
+- **AC-3:** Given ein einzelnes `AlertEvent` (Bug-Report-Werte aus #958/#1865,
+  `threshold=400.0`, `value_from=2855.0`, `value_to=3285.0`, `cmp="unter"`) / When
+  `render_email()` den Einzel-Event-Datenblock rendert / Then zeigt die "Alarm-Schwelle"-
+  Zeile den vollständigen, verständlichen Text `"jetzt darüber ✗"` statt des Fragments
+  `"Änderung über ✗"` — sowohl in html als auch in plain.
+  - Test: `tests/tdd/test_alert_bundle_958ff.py::test_ac2_render_email_change_wording_and_datablock`
+    (angepasst) — Assertion auf den neuen Wortlaut in beiden Repräsentationen; ergänzend
+    `tests/tdd/test_issue_1169_compare_alert_consumer.py` (Compare-Einzel-Event-Pfad,
+    Zeile ~747-766) auf denselben neuen Wortlaut nachgezogen — diese Datei läuft NUR mit
+    `-m "email"` (Marker, s. AC-6), sonst wird sie still deselektiert.
+
+- **AC-4 (Regressionsschutz #958):** Given dieselben Events wie im bestehenden
+  `over_thr()`-Test (steigende UND fallende Richtung, gleicher Betrag) / When
+  `over_thr()`/`side_label()` unverändert aufgerufen werden / Then liefern beide exakt
+  dieselben Rückgabewerte wie vor diesem Fix — die #1865-Textänderung darf NUR die
+  Formulierung um diese Werte herum betreffen, nicht ihre Berechnung.
+  - Test: bestehender Test in `test_alert_bundle_958ff.py` (Δ-Semantik, steigend/fallend)
+    bleibt UNVERÄNDERT und grün; zusätzlich neue Assertion in
+    `tests/tdd/test_alert_multi_event_where_when.py`, dass `over_thr()`/`side_label()`
+    für die AC-1/AC-2-Fixture-Events dieselben Werte liefern wie vor der Änderung
+    (Funktionsaufruf, kein Text-Vergleich).
+
+- **AC-5 (Regressionsschutz #1170):** Given den bestehenden Compare-Bündel-Fall (ein
+  einzelner Vergleichs-Ort, zwei Metriken, `segment_id` nie gesetzt) / When
+  `render_email()` den Multi-Event-Datenblock rendert / Then bleibt die Ausgabe
+  UNVERÄNDERT (kein `"km 0–0"`- oder sonstiger neuer Zusatz) — der #1861-Differenzierer
+  greift nur bei gesetztem `segment_id` (Trip-Pfad).
+  - Test: `tests/tdd/test_issue_1170_compare_alert_config.py::test_ac7_single_location_two_metrics_no_per_row_location_prefix`
+    bleibt grün. **Nachtrag 2026-08-16 (Adversary-Finding F002):** der Test wurde um EINE
+    Assertion ERWEITERT (`"km 0" not in plain`) — die Zusicherung wird dadurch nicht
+    gelockert, sondern erst wirksam bewacht. Bis dahin prüfte er nur den alten
+    Ortsname-Präfix; eine Mutation, die `render._per_event_where_when()` bedingungslos
+    `True` liefern lässt, schrieb `"km 0–0"` in jede Compare-Zeile und ließ ihn trotzdem
+    grün. Gegenprobe nachgemessen: mit der Assertion ist die Mutation rot.
+
+- **AC-6 (gebundene Tests grün):** Given den vollständigen geänderten Renderer / When die
+  ZWEI folgenden Aufrufe ausgeführt werden / Then sind alle fünf Dateien grün
+  (Renderer-Commit-Gate #811-Vorbedingung):
+  1. `uv run pytest tests/tdd/test_alert_bundle_958ff.py tests/tdd/test_issue_1170_compare_alert_config.py tests/tdd/test_alert_multi_event_where_when.py tests/tdd/test_issue_811_mode_matrix.py`
+  2. `uv run pytest tests/tdd/test_issue_1169_compare_alert_consumer.py -m "email" --disable-socket --allow-hosts=127.0.0.1,::1`
+  - Test: die o. g. `pytest`-Aufrufe selbst (benannte Dateien, keine Volllauf-Sperre
+    betroffen).
+  - **Warum ZWEI Aufrufe (Adversary-Finding F001):** `test_issue_1169_compare_alert_consumer.py`
+    trägt `pytestmark = pytest.mark.email` (Zeile 73) und wird vom Default-`addopts`
+    (`pyproject.toml:65`) STILL deselektiert — im ersten Aufruf mitgelistet, liefe sie mit
+    **0 gesammelten Tests** durch und der AC-6-Nachweis für diese Datei wäre vakuos. Sie
+    braucht deshalb ihren eigenen Aufruf MIT `-m "email"`; ein gemeinsamer Aufruf mit
+    `-m "email"` scheidet aus, weil dann umgekehrt die vier ungemarkerten Dateien
+    deselektiert würden. `--disable-socket --allow-hosts=127.0.0.1,::1` hält den Lauf
+    offline (Egress-Wächter, #1755). Von den 6 Tests der Datei sind 5 (AC-1/2/3/4/6)
+    **vorbestehend rot** — am unveränderten `render.py` gegengemessen; für AC-6 gebunden
+    ist nur `test_ac7_trip_alert_rendering_unchanged` (Golden-Master der Plain-Mail).
+
+## Known Limitations
+
+- **SMS bewusst ausgeklammert.** `_sms_token()` hängt bereits `@HH` an und unterliegt
+  einem harten GSM-7-Zeichenlimit — ein Segment-Zusatz würde eine eigene
+  Token-Format-Erweiterung erfordern (größerer Eingriff). Eigenes Ticket bei Bedarf.
+- **`render_subject()` (Betreff) bewusst ausgeklammert.** Der Multi-Event-Betreff
+  (`top3`-Auswahl in `render_subject`, Zeile ~335-339) zeigt bereits unterschiedliche
+  WERTE je Event (z. B. "Gewitter 1, Gewitter 0"), aber keinen Segment-/Zeit-Bezug — bei
+  IDENTISCHEN Werten (z. B. zwei Events mit `value_to=0`) bleibt der Betreff weiterhin
+  ununterscheidbar. Aus dieser Spec ausgeklammert, weil der PO-Bug-Report sich primär auf
+  den Mailkörper bezieht und der Betreff einer Längenbegrenzung durch die
+  Top-3-Auswahl unterliegt (eigene Format-Entscheidung nötig). Eigenes Ticket bei Bedarf.
+- **Zwei Events mit IDENTISCHEM `segment_id` UND IDENTISCHEM `occurred_at`** (echte
+  Zeitgleichheit) bleiben weiterhin ununterscheidbar — das ist eine seltene
+  Datenkonstellation (eher ein Dedup-Thema auf einer vorgelagerten Stufe) und kein
+  bekannter PO-Bug-Report-Fall.
+- **Compare-Bündel-Multi-Point-Pfad (`location_label` je Event) bleibt unverändert.**
+  Auch dort könnten zwei Events derselben Metrik an verschiedenen Orten mit identischem
+  Wert theoretisch ununterscheidbar sein — aus dieser Spec ausgeklammert (kein
+  PO-Bug-Report dafür, Risiko einer #1170-Regression bei ungeprüfter Erweiterung).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Text-/Templating-Korrektur innerhalb eines bestehenden Renderers,
+  keine der in `docs/adr/README.md` genannten Entscheidungsflächen (Kanal/Provider,
+  Datenmodell/Persistenz, Auth, Editor-Paradigma, Test-/Deploy-Strategie). `AlertEvent`/
+  `AlertMessage` (ADR-0011, kanonisches Modell) bleiben unverändert; `over_thr()`/
+  `side_label()` (ADR-0013-Kontext, #958) bleiben in ihrer Semantik unverändert.
+
+## Changelog
+
+- 2026-08-15: Initial spec created

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -20,7 +20,7 @@ from .model import (
     AlertEvent, AlertMessage, CorridorEvent, OnsetEvent, arrow, delta_pct,
     km_span, over_thr, severity, side_label,
 )
-from .segments import format_alert_location
+from .segments import _renderable_segment_ids, format_alert_location
 
 
 def _sorted(msg: AlertMessage) -> list[AlertEvent]:
@@ -115,6 +115,29 @@ def _location_of(events, location_label: str | None = None) -> str:
 
 def _km_str(msg: AlertMessage) -> str:
     return _location_of(msg.events, msg.location_label)
+
+
+def _where_when(e: AlertEvent) -> str:
+    """Ort + Uhrzeit EINES Ereignisses (Issue #1861) — bewusst OHNE
+    `location_label`-Parameter: der Multi-Event-Zweig fuehrt den Ortsnamen
+    bereits als `loc_prefix`, und der Compare-Buendelpfad wird gar nicht erst
+    hier hindurchgeschickt (`segment_id`-Bedingung an der Aufrufstelle)."""
+    when = _location_of((e,))
+    if e.occurred_at:
+        when += f" · {e.occurred_at}"
+    return when
+
+
+def _per_event_where_when(evs) -> bool:
+    """Darf der Multi-Event-Zweig je Ereignis einen Ort-/Zeit-Zusatz tragen?
+
+    Nur wenn JEDES Ereignis eine verwertbare Segment-Kennung hat (Issue #1744
+    AC-7, "alles oder nichts"): traegt eines keine, nennt die Mail eine
+    Teilliste und verschweigt eine tatsaechlich betroffene Etappe. Der
+    Compare-Buendelpfad (`to_multi_point_alert_message`) setzt `segment_id`
+    nie und faellt damit hier heraus (#1170-Invariante).
+    """
+    return bool(_renderable_segment_ids([e.segment_id for e in evs]))
 
 
 def _km_str_onset(e: OnsetEvent) -> str:
@@ -372,6 +395,11 @@ def _verdict_single(e: AlertEvent) -> str:
     )
 
 
+# Issue #1865: aus dem Fragment "Änderung über ✗" wird ein vollstaendiger
+# Satz. side_label() selbst bleibt unveraendert (#958-Kernsemantik).
+_SIDE_ADVERB = {"über": "darüber", "unter": "darunter"}
+
+
 def _datablock_single(e: AlertEvent, location_label: str | None = None) -> list[tuple[str, str]]:
     """3 (label, value)-Zeilen: Wert-Vergleich / Schwellwert-Status / Wo & wann.
 
@@ -388,7 +416,7 @@ def _datablock_single(e: AlertEvent, location_label: str | None = None) -> list[
     mark = "✓" if not over_thr(e) else "✗"
     row2 = (
         f"Alarm-Schwelle {_val(e, e.threshold)}",
-        f"Änderung {side_label(e)} {mark}",
+        f"jetzt {_SIDE_ADVERB[side_label(e)]} {mark}",
     )
     # Issue #1744 A1 (AC-6): DIESELBE Aufloesung wie im Betreff — vorher stand
     # hier ein dritter, eigener km-Bauer (`_km_str_events`), weshalb der
@@ -501,6 +529,9 @@ def render_email(msg: AlertMessage) -> tuple[str, str]:
         # Einheit -- ausser bei "%", wo sie zur Unterscheidung mitgefuehrt
         # wird (exaktes Vorbild Design-Vorlage Zeilen 220-233).
         data_rows = []
+        # Issue #1861: mehrere Ereignisse DERSELBEN Metrik waren als Zeilen
+        # ununterscheidbar — Segment-/Zeit-Bezug je Zeile behebt das.
+        with_where_when = _per_event_where_when(evs)
         for e in evs:
             unit = _unit_display(e)
             unit_suffix = f" {unit}" if unit else ""
@@ -510,10 +541,12 @@ def render_email(msg: AlertMessage) -> tuple[str, str]:
             # Trip-Fall (location_label immer None) bleibt unverändert (leerer
             # Prefix, AC-7-Invariante).
             loc_prefix = f"{e.location_label} · " if e.location_label else ""
+            where_when = f" · {_where_when(e)}" if with_where_when else ""
             if over_thr(e):
                 threshold_suffix = " %" if unit == "%" else ""
                 data_rows.append((
-                    f"{loc_prefix}{_label(e)} · Schwelle {_num(e, e.threshold)}{threshold_suffix}",
+                    f"{loc_prefix}{_label(e)}{where_when} · "
+                    f"Schwelle {_num(e, e.threshold)}{threshold_suffix}",
                     f"{_num(e, e.value_from)} {arrow(e)} {_num(e, e.value_to)}"
                     f"{unit_suffix} {side_label(e)}",
                 ))
@@ -522,7 +555,7 @@ def render_email(msg: AlertMessage) -> tuple[str, str]:
                 # Schwellen-Zahl, Wert mit neutralem Pfeil, kein über/unter-Suffix
                 # (Design-Vorlage Zeilen 231-234).
                 data_rows.append((
-                    f"{loc_prefix}{_label(e)} · unter Schwelle",
+                    f"{loc_prefix}{_label(e)}{where_when} · unter Schwelle",
                     f"{_num(e, e.value_from)} → {_num(e, e.value_to)}{unit_suffix}",
                 ))
         km = _km_str(msg)
@@ -593,8 +626,12 @@ def render_telegram(msg: AlertMessage) -> str:
         # bereits in der fetten Kopfzeile), keine Einheiten ausser "%";
         # severity-absteigende Reihenfolge, kanal-konsistent mit Betreff/
         # E-Mail-Datenblock.
+        # Issue #1861: derselbe Ort-/Zeit-Zusatz wie im E-Mail-Datenblock
+        # (Kanalkonsistenz, Issue #978-Praezedenz).
+        with_where_when = _per_event_where_when(evs)
         metric_line = " · ".join(
-            f"{_label(e)} {_num(e, e.value_from)}→{_num(e, e.value_to)}"
+            f"{_label(e)}{f' {_where_when(e)}' if with_where_when else ''} "
+            f"{_num(e, e.value_from)}→{_num(e, e.value_to)}"
             f"{'%' if _unit_display(e) == '%' else ''}"
             for e in evs
         )

--- a/tests/tdd/test_alert_bundle_958ff.py
+++ b/tests/tdd/test_alert_bundle_958ff.py
@@ -128,7 +128,9 @@ def test_ac2_render_email_change_wording_and_datablock():
     """AC-2: Given dasselbe Event (Bug-Report-Werte) / When render_email() die
     Single-Metrik-Verdict-Pill und den Datenblock rendert / Then enthält der
     Verdict-Text 'Änderung über deiner Alarm-Schwelle (400 m)' (nicht mehr
-    'jetzt über Schwelle 400 m') und der Datenblock zeigt 'Änderung über ✗'
+    'jetzt über Schwelle 400 m') und der Datenblock zeigt den vollstaendigen
+    Satz 'jetzt darüber ✗' (#1865-Fix — Fragment 'Änderung über ✗' war
+    unverstaendlich, over_thr()/side_label() selbst bleiben unveraendert)
     in der Alarm-Schwelle-Zeile — in html UND plain."""
     from output.renderers.alert.model import AlertEvent, AlertMessage
     from output.renderers.alert.render import render_email
@@ -145,8 +147,12 @@ def test_ac2_render_email_change_wording_and_datablock():
             f"Verdikt-Text fehlt oder ist noch die alte Formulierung "
             f"('jetzt über Schwelle ...'): {content!r}"
         )
-        assert "Änderung über ✗" in content, (
-            f"Datenblock-Zeile 'Alarm-Schwelle' zeigt nicht 'Änderung über ✗': {content!r}"
+        assert "jetzt darüber ✗" in content, (
+            f"Datenblock-Zeile 'Alarm-Schwelle' zeigt nicht den vollstaendigen "
+            f"Satz 'jetzt darüber ✗' (#1865): {content!r}"
+        )
+        assert "Änderung über ✗" not in content, (
+            f"Altes Fragment 'Änderung über ✗' (#1865-Bug) noch vorhanden: {content!r}"
         )
 
 

--- a/tests/tdd/test_alert_multi_event_where_when.py
+++ b/tests/tdd/test_alert_multi_event_where_when.py
@@ -1,0 +1,158 @@
+"""
+TDD-RED: #1861/#1865 — Abweichungs-Alarm-Mail unterscheidbare Mehrfach-
+Ereignisse + verstaendlicher Datenblock-Text.
+
+Spec: docs/specs/modules/fix_1861_1865_alarm_mail_klarheit.md (AC-1, AC-2, AC-4).
+AC-3 (Wortlaut-Fix) und der Teil von AC-4, der bestehende Bestandstests grün
+haelt, liegen in tests/tdd/test_alert_bundle_958ff.py und
+tests/tdd/test_issue_1169_compare_alert_consumer.py (dort angepasst). AC-5
+(Compare-Regressionsschutz) liegt unveraendert in
+tests/tdd/test_issue_1170_compare_alert_config.py. AC-6 ist der gebuendelte
+pytest-Lauf selbst.
+
+KEINE Mocks — echte Renderer-/Modell-Aufrufe.
+"""
+from __future__ import annotations
+
+
+def _three_thunder_events_trip_path():
+    """3 AlertEvents derselben Metrik ('thunder'), Trip-Pfad (segment_id
+    gesetzt auf '4'/'5'/'6', analog dem PO-Bug-Report 'KHW 403 Segment 4-6,
+    3x Gewitter'). Alle drei liegen ueber der Schwelle."""
+    from output.renderers.alert.model import AlertEvent, AlertMessage
+
+    # over_thr() ist Δ-Semantik (#958): abs(value_to - value_from) >= threshold.
+    # Alle drei Deltas liegen bewusst >= 40, damit alle Zeilen denselben
+    # Formatierungszweig (ueber Schwelle) durchlaufen und sich NUR durch den
+    # #1861-Differenzierer unterscheiden, nicht durch unterschiedliche Zweige.
+    # value_to STEIGEND ABFALLEND gewaehlt (90/80/70), damit die severity-
+    # absteigende Ausgabereihenfolge (#978/#982, render.py::_sorted) mit der
+    # Segmentreihenfolge 4,5,6 uebereinstimmt -- sonst prueft die positionale
+    # zip()-Zuordnung in test_ac1_multi_event_email_rows_are_distinguishable_by_segment
+    # die falsche Zeile (gefunden vom Developer-Agenten beim Implementieren).
+    e4 = AlertEvent(metric_id="thunder", value_from=30.0, value_to=90.0, threshold=40.0,
+                     cmp="über", occurred_at="10:00", km_from=6.0, km_to=8.0, segment_id="4")
+    e5 = AlertEvent(metric_id="thunder", value_from=30.0, value_to=80.0, threshold=40.0,
+                     cmp="über", occurred_at="12:00", km_from=8.0, km_to=10.0, segment_id="5")
+    e6 = AlertEvent(metric_id="thunder", value_from=30.0, value_to=70.0, threshold=40.0,
+                     cmp="über", occurred_at="14:00", km_from=10.0, km_to=12.0, segment_id="6")
+    return AlertMessage(trip_short="KHW 403", stand_at="09:00", events=(e4, e5, e6), source=None)
+
+
+def _two_same_segment_different_time_events():
+    """2 AlertEvents derselben Metrik, DEMSELBEN Segment, aber
+    unterschiedlicher Uhrzeit — Differenzierer muss auf occurred_at
+    ausweichen, wenn das Segment allein nicht unterscheidet."""
+    from output.renderers.alert.model import AlertEvent, AlertMessage
+
+    # Beide Deltas >= 40 (over_thr()-Δ-Semantik, #958) -- beide Zeilen
+    # durchlaufen denselben Formatierungszweig, unterscheiden sich also NUR
+    # durch die Uhrzeit, nicht durch den Schwellen-Status.
+    e_morning = AlertEvent(metric_id="thunder", value_from=30.0, value_to=75.0, threshold=40.0,
+                            cmp="über", occurred_at="09:00", km_from=6.0, km_to=8.0, segment_id="4")
+    e_afternoon = AlertEvent(metric_id="thunder", value_from=30.0, value_to=85.0, threshold=40.0,
+                              cmp="über", occurred_at="13:00", km_from=6.0, km_to=8.0, segment_id="4")
+    return AlertMessage(trip_short="KHW 403", stand_at="09:00",
+                         events=(e_morning, e_afternoon), source=None)
+
+
+def _multi_event_data_lines(plain: str) -> list[str]:
+    """Extrahiert die Datenblock-Zeilen (nach der Leerzeile hinter dem
+    Verdict-Text, vor der Footer-Leerzeile) aus der Plain-Mail."""
+    parts = plain.split("\n\n")
+    # Layout: [h1, verdict, datablock..., footer(+corridor)] -- Datenblock ist
+    # der dritte Abschnitt (Index 2) bei render_email().
+    return [line for line in parts[2].split("\n") if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# AC-1: Multi-Event-E-Mail unterscheidet gleichnamige Metriken
+# ---------------------------------------------------------------------------
+
+def test_ac1_multi_event_email_rows_are_distinguishable_by_segment():
+    """AC-1: Given eine deviation-alert-E-Mail mit drei AlertEvents derselben
+    Metrik ('thunder'), segment_id gesetzt auf '4'/'5'/'6' (Trip-Pfad,
+    Reproduktion PO-Bug-Report #1861 'KHW 403 Segment 4-6, 3x Gewitter') /
+    When render_email() den Multi-Event-Datenblock rendert / Then sind die
+    drei resultierenden Zeilen paarweise UNTERSCHIEDLICHE Strings UND jede
+    Zeile enthaelt den Segment-Bezug ihres jeweiligen Events."""
+    from output.renderers.alert.render import render_email
+
+    msg = _three_thunder_events_trip_path()
+    _html, plain = render_email(msg)
+    lines = _multi_event_data_lines(plain)
+
+    assert len(lines) == 3, f"Erwartet 3 Datenblock-Zeilen, bekommen: {lines!r}"
+    assert len(set(lines)) == 3, (
+        f"#1861: Zeilen sind NICHT paarweise unterscheidbar (identische Zeilen "
+        f"trotz unterschiedlicher Ereignisse): {lines!r}"
+    )
+    for expected_segment, line in zip(("Segment 4", "Segment 5", "Segment 6"), lines):
+        assert expected_segment in line, (
+            f"Zeile traegt nicht den erwarteten Segment-Bezug '{expected_segment}': {line!r}"
+        )
+
+
+def test_ac1_same_segment_different_time_still_distinguishable():
+    """AC-1 (Zusatz): Given zwei Events derselben Metrik UND desselben
+    Segments, aber unterschiedlicher Uhrzeit / When render_email() rendert /
+    Then unterscheiden sich die beiden Zeilen dennoch (Uhrzeit als
+    Differenzierer, wenn das Segment allein nicht reicht)."""
+    from output.renderers.alert.render import render_email
+
+    msg = _two_same_segment_different_time_events()
+    _html, plain = render_email(msg)
+    lines = _multi_event_data_lines(plain)
+
+    assert len(lines) == 2, f"Erwartet 2 Datenblock-Zeilen, bekommen: {lines!r}"
+    assert lines[0] != lines[1], (
+        f"Zeilen mit identischem Segment aber unterschiedlicher Uhrzeit sind "
+        f"nicht unterscheidbar: {lines!r}"
+    )
+    assert "09:00" in lines[0] or "09:00" in lines[1], lines
+    assert "13:00" in lines[0] or "13:00" in lines[1], lines
+
+
+# ---------------------------------------------------------------------------
+# AC-2: Telegram-Multi-Event zieht mit (Kanalkonsistenz, Issue #978)
+# ---------------------------------------------------------------------------
+
+def test_ac2_multi_event_telegram_rows_are_distinguishable_by_segment():
+    """AC-2: Given dieselbe Fixture wie AC-1 / When render_telegram() die
+    Multi-Event-Metrik-Zeile rendert / Then enthaelt die Zeile fuer jedes
+    Event denselben Segment-Bezug wie in der E-Mail UND die drei
+    Teilangaben sind paarweise unterscheidbar."""
+    from output.renderers.alert.render import render_telegram
+
+    msg = _three_thunder_events_trip_path()
+    telegram_text = render_telegram(msg)
+    metric_line = telegram_text.split("\n")[-1]
+
+    for segment in ("Segment 4", "Segment 5", "Segment 6"):
+        assert segment in metric_line, (
+            f"Telegram-Metrik-Zeile traegt nicht '{segment}': {metric_line!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 (Regressionsschutz #958): over_thr()/side_label() unveraendert
+# ---------------------------------------------------------------------------
+
+def test_ac4_over_thr_and_side_label_unaffected_by_where_when_fix():
+    """AC-4: Given dieselben Events wie in AC-1/AC-2 / When over_thr()/
+    side_label() aufgerufen werden / Then liefern sie weiterhin die fachlich
+    korrekte Delta-Semantik aus #958 (alle drei Events liegen ueber der
+    Schwelle, side_label == 'über') — der #1861-Differenzierer aendert NUR
+    den gerenderten Text, nicht diese Berechnung."""
+    from output.renderers.alert.model import over_thr, side_label
+
+    msg = _three_thunder_events_trip_path()
+    for e in msg.events:
+        assert over_thr(e) is True, (
+            f"Event segment_id={e.segment_id!r}: over_thr() muss True liefern "
+            f"(value_to={e.value_to} > threshold={e.threshold}), bekommen: {over_thr(e)!r}"
+        )
+        assert side_label(e) == "über", (
+            f"Event segment_id={e.segment_id!r}: side_label() muss 'über' liefern, "
+            f"bekommen: {side_label(e)!r}"
+        )

--- a/tests/tdd/test_issue_1169_compare_alert_consumer.py
+++ b/tests/tdd/test_issue_1169_compare_alert_consumer.py
@@ -710,9 +710,14 @@ def test_ac7_trip_alert_rendering_unchanged():
     """AC-7 Regressions-Schutz (Golden Master, analog test_issue_1168's
     Charakterisierungstests): der Trip-Pfad über `to_alert_message()` setzt
     `location_label` nie und liefert exakt dieselbe Ausgabe wie vor dieser
-    Scheibe. Erwartungswerte sind das HEUTIGE (vor #1169), tatsächlich
+    Scheibe (#1169). Erwartungswerte sind das HEUTIGE (vor #1169), tatsächlich
     ausgeführte Rendering-Ergebnis — dieser Test ist bereits heute grün und
     MUSS es nach der Implementierung bleiben.
+
+    Ausnahme (#1861/#1865, nachgezogen): die "Alarm-Schwelle"-Datenblock-Zeile
+    wechselt von Fragment ("Änderung über ✗") zu vollstaendigem Satz ("jetzt
+    darüber ✗") — reine Textaenderung, `over_thr()`/`side_label()` bleiben
+    unveraendert (#958-Invariante). Alle anderen Zeilen bleiben byte-identisch.
     """
     from output.renderers.alert.project import to_alert_message
     from output.renderers.alert.render import render_email, render_subject, render_telegram
@@ -749,7 +754,7 @@ def test_ac7_trip_alert_rendering_unchanged():
         "Niedersch +800% seit dem Briefing\n\n"
         "↑ +800 % · Änderung über deiner Alarm-Schwelle (10,0 mm)\n\n"
         "Niedersch · mm: 2,0 mm ↑ 18,0 mm +800 %\n"
-        "Alarm-Schwelle 10,0 mm: Änderung über ✗\n"
+        "Alarm-Schwelle 10,0 mm: jetzt darüber ✗\n"
         "Wo & wann: Segment 1\n\n"
         "Stand: heute 14:00 · verglichen mit dem letzten Briefing"
         # Issue #1241: geteilte Herkunfts-Fußzeile (deviation-alert). Zeile 2

--- a/tests/tdd/test_issue_1170_compare_alert_config.py
+++ b/tests/tdd/test_issue_1170_compare_alert_config.py
@@ -416,3 +416,15 @@ def test_ac7_single_location_two_metrics_no_per_row_location_prefix():
     assert location_name in plain, (
         f"Einzel-Ort-Kontext (Footer/Where) fehlt komplett:\n{plain}"
     )
+    # Issue #1861 (Adversary-Finding F002): der neue per-Ereignis-Ort-/Zeit-
+    # Zusatz im Mehr-Metrik-Zweig darf den Compare-Buendelpfad NICHT treffen.
+    # Dessen Ereignisse tragen als `segment_id` die Orts-ID ("loc-a") — keine
+    # verwertbare Etappen-Kennung —, weshalb `_where_when()` auf die km-Spanne
+    # zurueckfiele und jede Zeile ein sinnloses "km 0–0" bekaeme (der Punkt hat
+    # keinen km-Kontext). Die Bedingung dafuer sitzt in
+    # `render._per_event_where_when()`; ohne diese Assertion bliebe der Test
+    # gruen, wenn sie bedingungslos True lieferte.
+    assert "km 0" not in plain, (
+        f"Compare-Buendelpfad zeigt eine km-Angabe, obwohl der Punkt keinen "
+        f"km-Kontext hat (#1861-Zusatz greift faelschlich):\n{plain}"
+    )


### PR DESCRIPTION
#1861: Mehrere Alarm-Ereignisse derselben Metrik (E-Mail + Telegram) waren
identisch und ununterscheidbar. Neuer Helper _where_when() ergaenzt Segment-
und Zeitbezug je Zeile, sobald alle Ereignisse eine verwertbare Segment-
Kennung tragen (Trip-Pfad); der Compare-Buendelpfad bleibt unveraendert.

#1865: Die Datenblock-Zeile "Alarm-Schwelle X / Aenderung ueber/unter #"
war ein unverstaendliches Textfragment. Wird jetzt zu "jetzt darueber/
darunter #" -- over_thr()/side_label() (Kernsemantik aus #958) bleiben
unveraendert.

Adversary VERIFIED nach einer Fix-Runde (F001: AC-6-Testaufruf ohne
Marker-Option fuer eine pytest.mark.email-Datei war vakuos; F002:
Regressionswaechter fuer den Compare-Pfad bewachte die neue Erweiterung
nicht -- beide behoben, mit Mutationsprobe nachgemessen).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
