### PR TITLE
feat(#1678): eigene belegte LPI-Schwellenleiter fuer ICON-EU (EU_REST)

### DIFF
--- a/docs/context/feat-1678-lpi-eu-schwellenleiter.md
+++ b/docs/context/feat-1678-lpi-eu-schwellenleiter.md
@@ -1,0 +1,211 @@
+# Context: feat-1678-lpi-eu-schwellenleiter
+
+Issue #1678 — eigene Schwellenleiter für `lpi_con_max` (ICON-EU, Gebiet `EU_REST`).
+Epic #1419 Rang 7 / Entscheidung E1b. Erstellt 2026-08-16 (Phase 1).
+
+## Request Summary
+
+Das Gebiet `EU_REST` (ICON-EU, `lpi_con_max`) wird heute mit der Interim-Leiter
+5 / 20 / 50 J/kg bewertet — derselben Größenordnung wie die belegte ICON-D2-Leiter,
+obwohl es eine andere physikalische Größe ist. Gemessen ergibt das bis zu Faktor 51
+häufigere Einstufungen. Gesucht ist eine eigene, **belegte** Leiter für `EU_REST`.
+
+## Zwei Befunde, die den im Ticket vorgeschlagenen Weg umstoßen
+
+### 1. Der Open-Meteo-Eichweg ist nicht gangbar (gemessen, nicht vermutet)
+
+Das Ticket und `docs/features/gewitter-gesamtkonzept.md` Abschnitt 4.4 setzen voraus,
+Open-Meteos Historical Forecast / Previous Runs API liefere die ICON-EU-Läufe, die
+Eichung sei „sofort rechenbar". Das trifft für LPI **nicht** zu:
+
+- Open-Meteo lädt LPI **ausschließlich** für ICON-D2, und dort das Feld `lpi`:
+  `Sources/App/Icon/IconVariableDownloadable.swift:184-185` —
+  `case .lightning_potential: return domain == .iconD2 ? ("lpi", …) : nil // only in icon d2`.
+  Für `iconEu` liefert die Variablenauflösung `nil`; `lpi_con_max` kommt im ganzen
+  Open-Meteo-Repository nicht vor. Die Filter sind gezielt gesetzt — direkt darüber
+  (`:182-183`) wird `cin_ml` für `iconEu` **sehr wohl** geladen.
+- Bestätigt in der Doku (<https://open-meteo.com/en/docs/dwd-api>): „lightning potential
+  and updraft are only in ICON D2".
+- ⇒ Ein Perzentil-Abgleich `lpi_con_max` ↔ `lpi` über Open-Meteo ist unmöglich: die
+  ICON-EU-Seite des Vergleichs existiert dort nicht, und Warten hilft nicht.
+- Passt zum eigenen Code: `lpi_con_max` kommt bei uns direkt von `opendata.dwd.de`
+  (GRIB2, `src/providers/dwd_eu.py:77`, `:205-217`) — Open-Meteo ist an diesem Pfad
+  nicht beteiligt.
+
+### 2. Eine publizierte Leiter existiert — aus genau der DWD-Arbeit, die die Größe eingeführt hat
+
+**Schröder, Göcke, Köhler (2022), „Subgrid scale Lightning Potential Index for ICON with
+parameterized convection", Reports on ICON Issue 010, DOI 10.5676/DWD_pub/nwv/icon_010.**
+
+Tabelle 3 (S. 15) — Kalibrierung gegen LINET-Blitzbeobachtung, 366 Vorhersagen 03/2019–02/2020:
+
+| p | LFD [day⁻¹km⁻¹] | **LPI (subgrid) [J/kg]** | MLPI [J/kg] |
+|---|---|---|---|
+| 1/3 | 0,0381 | **7,14** | 4,92 |
+| 0,5 | 0,0809 | **11,78** | 10,99 |
+| 1 | 0,2557 | **23,81** | 27,72 |
+
+⚠️ **Wichtige Lesart — das ist KEINE Schwere-Leiter.** Die drei Werte sind drei
+*alternative* Kalibrierungen **derselben** Ja/Nein-Frage („blitzt es in dieser Gitterzelle
+in dieser Stunde?") bei unterschiedlich angesetzter Trefferwahrscheinlichkeit `p`
+(Bericht S. 14, Gl. 2/3): bei p=1 ist die Fläche mit Schwellenüberschreitung im
+Jahresmittel **gleich groß** wie die beobachtete Blitzfläche, bei p=1/3 dreimal so groß
+(empfindlicher, mehr Fehlalarm). Sie als (leicht, mittel, hoch) zu übernehmen wäre eine
+Fehldeutung der Quelle — das ist der zentrale Klärungspunkt für Phase 2.
+
+Belegt ist damit **die unterste Sprosse**: „ab hier blitzt es überhaupt" liegt für
+subgrid-LPI bei **7,14 J/kg** (empfindlich) bis **23,81 J/kg** (flächentreu) — gegenüber
+**1 J/kg** bei aufgelöstem LPI (ICON-D2, ASR 2022). Für die oberen zwei Sprossen gibt es
+für `lpi_con_max` **keine** publizierte Entsprechung.
+
+### 3. `lpi_con_max` ist belegt eine andere Größe als `lpi`
+
+DWD Database Reference Manual, Kap. 6.5:
+- `LPI`: „calculated as a vertical integral of the squared updraft velocity weighted by a
+  function that essentially contains the graupel concentration … **the LPI can be
+  calculated only in a convection-permitting model setup**".
+- `LPI_CON_MAX`: „… based on Lynn and Yair (2010) and Lopez (2016) … **only that the
+  updraft velocity and hydrometeors are taken from the Bechtold-Tiedke convection
+  scheme**. The variable contains the maximum since the last output."
+
+Gleiche Einheit, gleiche Formelstruktur, **andere Eingangsgrößen** (approximierte
+Hydrometeore). Bestätigt die Annahme im Gesamtkonzept 4.3 („verschiedene Physik") und
+widerlegt den Kommentar in `src/providers/dwd_eu.py:90-95` („fachlich dieselbe Größe").
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/app/model_registry.py:145-167` | `LPI_THRESHOLDS_JKG` (DE_ALPEN 1/30/50, EU_REST 5/20/50 interim) + `lpi_thresholds_jkg(region)`. **Der zu ändernde Ort.** |
+| `src/providers/thunder_enrichment.py:121,171-178,243` | Einziger Produktivaufrufer: holt die Leiter je Region und reicht sie an `_fuse_thunder_levels()` |
+| `src/providers/thunder_enrichment.py:95-146` | `_fuse_thunder_levels(...)` — `lpi_low, lpi_med, lpi_high = lpi_thresholds or (None,None,None)`, gibt sie als `lpi_low_min/med_min/high_min` weiter |
+| `src/providers/dwd_eu.py:77,87,97,205-217` | Abruf `lpi_con_max` von `opendata.dwd.de`, `FORECAST_HOURS = 1..24`, URL-Template |
+| `src/providers/dwd_eu.py:100-108` | Mappt `lpi_con_max` → internes Feld `lpi` (derselbe Signalschlüssel wie ICON-D2 — der Ursprung der Gleichsetzung) |
+| `src/providers/thunder_routing.py:63-67` | `_REGIONS` first-match-wins: FR → `fr_direct`, DE_ALPEN → `de_direct`, EU_REST (ganze Welt) → `eu_direct` |
+| `src/output/metric_format.py:295,524` | Ausgabeseite, verweist auf die Leiter |
+| `scripts/eichung_cape_schwelle.py` | Vorbild-Muster #1592 (einmaliges Eichskript → statische Tabelle) — **hier NICHT anwendbar**, s.o. |
+| `docs/features/gewitter-gesamtkonzept.md:509-617` | Abschnitte 4.1–4.5: Messung, Ursachenanalyse, Meteoalarm-Prinzip |
+
+## Existing Specs
+
+- `docs/specs/modules/feat_1679_lpi_schwellen_region_tabelle.md` — legte die Gebietstabelle an
+- `docs/specs/modules/feat_1679_cin_paarung_cape_leiter.md`
+- `docs/specs/modules/fix_1592_s1_cape_modellschwelle.md` — Vorbild-Muster (CAPE)
+- `docs/context/gewitter-1679-lpi-schwellen.md`
+
+## Wächter / Tests
+
+| Test | Zusicherung |
+|---|---|
+| `tests/tdd/test_lpi_threshold_region_table.py:69-77` | **Nagelt die Zahlen fest**: `LPI_THRESHOLDS_JKG` hat GENAU 2 Einträge, `DE_ALPEN == (1.0,30.0,50.0)`, `EU_REST == (5.0,20.0,50.0)`, kein `FR`. **Muss mit dieser Arbeit angepasst werden.** |
+| `tests/tdd/test_lpi_threshold_region_table.py:91-178,252-259` | Lookup-Verhalten: unbekannte/fehlende Region → `None`, `FR` → `None` |
+| `tests/tdd/test_thunder_potential_level_classification.py:29-39` | Einstufung liest die Leiter aus der Registry (nicht hartkodiert) |
+| `tests/tdd/test_thunder_ladder_shared_across_signals.py:34-41,106-109` | Dieselbe Leiter über mehrere Signale |
+| `tests/tdd/test_thunder_enrichment_fuses_level_shared_path.py:399-500` | Fusion nutzt die EU_REST-Leiter |
+| `tests/tdd/test_thunder_origin_*.py` (7 Dateien) | Herkunftsanzeige führt die Leiter mit — Ausgabe an neun Orten |
+
+## Dependencies
+
+- **Upstream:** `providers.thunder_routing.thunder_region_for()` liefert die Region; `dwd_eu` liefert den Rohwert
+- **Downstream:** `_fuse_thunder_levels()` → `thunder_level` → alle neun Gewitter-Ausgabeorte (Trip-Briefing, Ortsvergleich, Ausblick, SMS-Kürzel, Herkunftsanzeige) **und die Gewitter-Alarme**
+
+## Risks & Considerations
+
+1. **Zahlen sind heute festgenagelt** (`test_lpi_threshold_region_table.py:76`) — der Test ist Teil der Arbeit, nicht Kollateralschaden.
+2. **Direkte Alarmwirkung** — aber **nicht** auf den beiden Haupttouren: Der Karnische
+   Höhenweg (≈46,6 N / 12,8 O) fällt ins DE_ALPEN-Rechteck (43,17–58,09 N / −3,95–20,35 O),
+   GR20/Korsika (≈42,2 N / 9,07 O) ins FR-Rechteck (41,3–51,1 N / −5,2–9,7 O, dort
+   Blitzdichte statt LPI). `EU_REST` trifft v.a. Nord-, Ost- und Südeuropa — die Wirkung
+   ist real, liegt aber außerhalb der heute gefahrenen Touren. Eine höhere Leiter senkt
+   dort die Alarmhäufigkeit.
+3. **Auflösungslücke im Beleg.** Schröder et al. kalibrierten auf **ICON-20** (≈20 km, ICON-EU-EPS Member 1), nicht auf das deterministische ICON-EU mit 6,5 km. Übertragung ist plausibel, aber nicht belegt — gehört als Known Limitation in die Spec.
+4. **Aggregationsfenster:** Das Manual nennt für `LPI_CON_MAX` χ = 1, 3 **oder** 6 h je nach Vorhersagestunde. Wir holen nur `FORECAST_HOURS = 1..24` (`dwd_eu.py:87`) und haben am GRIB-Kopf 60 min gemessen (`dwd_eu.py:42-45`) — Risiko im genutzten Bereich gering, sollte aber als Invariante festgehalten werden.
+5. **Interner Feldschlüssel bleibt geteilt:** `dwd_eu.py:108` bildet `lpi_con_max` auf dasselbe interne Feld `lpi` ab wie ICON-D2. Die Unterscheidung hängt allein an der Region — solange `_REGIONS` first-match-wins bleibt, trägt das; ein Umbau dort würde die Leiterwahl still falsch machen.
+6. **Kein Eichskript nötig.** Der ursprünglich geplante Aufwand (Saison-Klimatologie) entfällt — was bleibt, ist eine belegte Tabellenzeile plus Herleitungsdokumentation. Das verschiebt den Schwerpunkt von „rechnen" zu „richtig lesen und begründen".
+
+---
+
+## Analysis (Phase 2)
+
+### Type
+Feature (Kalibrierungs-Änderung an einer Datentabelle, kein Bug — die Interim-Leiter war
+in #1679 bewusst so gesetzt).
+
+### Zwei harte Randbedingungen aus dem Code
+
+1. **Die Leiter ist eine STÄRKE-Skala, keine Sicherheits-Skala.** `ThunderLevel`
+   kein/leicht/mittel/hoch beschreibt, wie stark das Gewitter ist; möglich/wahrscheinlich/
+   akut ist eine andere Achse (PO-Korrektur 2026-08-03 zu #1474). Sprossen aus
+   Trefferwahrscheinlichkeiten zu bilden, ohne das zu benennen, würde beide Achsen
+   vermischen.
+2. **Alles-oder-nichts:** `metric_format.py:423-426` — ist auch nur EINE der drei Sprossen
+   `None`, trägt das Blitzpotenzial **gar kein** Signal zur Fusion bei. Die naheliegende
+   ehrliche Lösung „nur die belegte unterste Sprosse setzen, oben `None`"
+   (Muster der CAPE-Deckelung) ist damit **nicht** billig zu haben — sie hieße, LPI
+   verstummt in ganz `EU_REST`. Es müssen drei Zahlen sein.
+
+### Was belegt ist — und was nicht
+
+Sauber vergleichbar sind nur die **Nachweisschwellen** („blitzt es überhaupt"):
+ICON-D2 aufgelöster LPI **> 1 J/kg** (ASR 2022, Grundlage der DE_ALPEN-Leiter) ↔
+ICON-EU subgrid-LPI **7,14 J/kg** (Schröder et al. 2022, Tab. 3, empfindlichste
+Kalibrierung). Die unterste Sprosse ist damit belegt ableitbar.
+
+Für die oberen zwei Sprossen gibt es für `lpi_con_max` **keine** publizierte Entsprechung.
+Die DE_ALPEN-Werte 30/50 stammen aus COSMO-D2-Verifikation auf 2,2 km — ein anderes
+Kalibrierziel, nicht übertragbar.
+
+### Drei Kandidaten für die Leiter
+
+| | leicht | mittel | hoch | Herkunft | Wirkung ggü. heute (5/20/50) |
+|---|---|---|---|---|---|
+| **A** „Tabelle 3 wörtlich" | 7,14 | 11,78 | 23,81 | alle drei publiziert | mittel und hoch **sinken** → **mehr** Über-Einstufung. Verfehlt das Ticketziel. Zudem sind die drei Werte dieselbe Ja/Nein-Frage bei verschiedener Fehlalarm-Toleranz — als Stärke-Sprossen gelesen wäre das ein Achsen-Mix. |
+| **B** „Nachweis → flächentreu → Sättigung" **(empfohlen)** | 7,14 | 23,81 | 86,16 | p=1/3 (Nachweis) · p=1 (Modellfläche = beobachtete Blitzfläche) · `LPI_c` (Sättigungskonstante) — alle drei Zahlen aus derselben Arbeit | alle drei Sprossen **steigen** → weniger Über-Einstufung in `EU_REST`. Richtung stimmt. |
+| **C** „Verhältnis-Übertragung" | 7,14 | 214 | 357 | D2-Leiter × 7,14 (Nachweis-Verhältnis) | „hoch" praktisch unerreichbar (Bericht: LPI > 100 J/kg ist selten) — stille Fähigkeitsverluste. Zudem widerlegt die eigene Messung die Linearitäts-Annahme: das Missverhältnis schrumpft von 51× (bei 5) auf 8,7× (bei 50). |
+
+**Empfehlung B.** Sie nutzt ausschließlich Zahlen aus der DWD-Arbeit, die die Größe
+eingeführt hat, ist monoton, bewegt alle Sprossen in die vom Ticket geforderte Richtung
+und macht die Spannweite der Größe explizit: 7,14 = „hier fängt es an", 23,81 = „so viel
+Fläche wie tatsächlich Blitze beobachtet werden", 86,16 = „oberes Ende des sinnvollen
+Wertebereichs".
+
+**Ehrlich dazugesagt (Known Limitations der Spec):**
+- Nur die unterste Sprosse ist als *Schwelle* publiziert. 23,81 ist als
+  Kalibrierungspunkt publiziert, aber nicht als Stärke-Sprosse; 86,16 ist eine
+  Formelkonstante, keine publizierte Schwelle. Beides ist **Interpretation** — belegt in
+  der Herleitung, nicht in der Zielsetzung der Quelle.
+- Kalibriert wurde auf **ICON-20** (≈20 km, ICON-EU-EPS Member 1), nicht auf das
+  deterministische ICON-EU mit 6,5 km.
+
+### Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/app/model_registry.py:145-158` | MODIFY | `EU_REST`-Zeile + Herleitungs-Kommentar mit Quellenangabe |
+| `tests/tdd/test_lpi_threshold_region_table.py:69-77` | MODIFY | Nagelt heute `(5.0, 20.0, 50.0)` fest |
+| `tests/tdd/test_lpi_eu_rest_ladder.py` | CREATE | Verhaltens-Nachweis: ein `EU_REST`-Datenpunkt, der heute `hoch` bekommt, bekommt nach der Änderung `mittel`/`leicht` |
+| `src/providers/dwd_eu.py:90-95` | MODIFY | Kommentar „fachlich dieselbe Größe" ist am DWD-Handbuch widerlegt |
+| `docs/features/gewitter-gesamtkonzept.md:563-581` | MODIFY | Abschnitt 4.4 behauptet einen Open-Meteo-Eichweg, den es für LPI nicht gibt |
+
+### Scope Assessment
+- Dateien: 5 (2 Code, 2 Test, 2 Doku — Doku zählt nicht aufs LoC-Limit)
+- Geschätzt: **+80 / −15 LoC** (davon ~50 Test)
+- Risiko: **MEDIUM** — kleine Änderung, aber direkte Alarmwirkung in `EU_REST`
+
+### Technischer Ansatz
+Reine Tabellen-Änderung. Kein Eichskript, kein neuer Mechanismus, keine
+Schnittstellen-Änderung — `lpi_thresholds_jkg()` und die Alles-oder-nichts-Regel bleiben
+unangetastet. Der Nachweis muss am **Wirkort** geführt werden (Einstufung eines
+Datenpunkts über `thunder_level_from_signals`), nicht nur am Tabelleneintrag.
+
+### Open Questions
+- [ ] Leiter-Kandidat B bestätigen (Freigabe kommt mit den ACs in Phase 3)
+
+## Quellen
+
+- <https://www.dwd.de/EN/ourservices/reports_on_icon/pdf_einzelbaende/2022_10.pdf> (Schröder et al. 2022)
+- <https://www.dwd.de/DWD/forschung/nwv/fepub/icon_database_main.pdf> (Database Reference Manual)
+- <https://www.dwd.de/DE/fachnutzer/forschung_lehre/numerische_wettervorhersage/nwv_aenderungen/_functions/DownloadBox_modellaenderungen/icon/pdf_2022/pdf_icon_global_23_11_2022.pdf> (Modelländerung 23.11.2022: LPI_CON_CI_MAX → LPI_CON_MAX für ICON-EU)
+- <https://github.com/open-meteo/open-meteo/blob/main/Sources/App/Icon/IconVariableDownloadable.swift> (LPI nur ICON-D2)
+- <https://asr.copernicus.org/articles/19/29/2022/> (COSMO-D2 LPI, Basis der DE_ALPEN-Leiter)
+- <https://nhess.copernicus.org/articles/12/1969/2012/> (Klein Tank et al. 2012, einheitliche Wiederkehrperioden — Meteoalarm-Methodik)

--- a/docs/features/gewitter-gesamtkonzept.md
+++ b/docs/features/gewitter-gesamtkonzept.md
@@ -571,14 +571,24 @@ ein sicheres Zeichen, dass im dünnen Ausläufer der Verteilung gerechnet wurde.
 **Der Grund ist die Datenbasis, nicht das Verfahren:** eine einzelne, ruhige Wetterlage ist
 keine Klimatologie. Nötig ist mindestens **eine Konvektionssaison (April–September)**.
 
-🟢 **Und dafür braucht es kein eigenes Archiv:** Open-Meteo stellt mit der **Historical
-Forecast API / Previous Runs API** genau diese historischen Modellläufe bereit. Die Eichung ist
-damit **sofort rechenbar** und nicht, wie zuvor angenommen, durch wochenlanges Sammeln
-blockiert. Das verschiebt die Feineichung (Rang 7) nach vorn.
+🔴 **Korrektur (Issue #1678, 2026-08-16): der hier zuvor vorgeschlagene Weg über die Open-Meteo
+Historical Forecast API ist NICHT gangbar.** Open-Meteo lädt LPI ausschließlich für ICON-D2 und
+dort das Feld `lpi` (`Sources/App/Icon/IconVariableDownloadable.swift:184-185`:
+`return domain == .iconD2 ? ("lpi", …) : nil // only in icon d2`). `lpi_con_max` (ICON-EU) kommt
+dort **nicht** vor — die ICON-EU-Seite eines Historical-Vergleichs existiert nicht und entsteht
+auch durch Warten nicht. Diese Grenze gilt nur für LPI; für CAPE (Abschnitt 3.4b, #1592) trifft
+sie nicht zu, dort liefert Open-Meteo beide Modelle.
 
-⇒ **Antwort auf E1b: ja, ICON-EU braucht eine eigene Leiter** — aber sie wird nicht geraten,
-sondern aus gesammelten Daten geeicht. Bis dahin darf die ICON-EU-Stufe nicht so behandelt
-werden, als wäre sie mit der ICON-D2-Stufe gleichbedeutend.
+⇒ **Tatsächlich gewählte Lösung:** statt einer selbst gerechneten Eichung eine **publizierte
+Leiter** aus der DWD-Arbeit, die `LPI_CON_MAX` für ICON-EU eingeführt hat (Schröder, Göcke,
+Köhler 2022, "Subgrid scale Lightning Potential Index for ICON with parameterized convection",
+Reports on ICON Issue 010): **7,14 / 23,81 / 86,16 J/kg** statt der Interim-Werte 5/20/50 (Details
+und Herleitung jeder Sprosse: `docs/specs/modules/feat_1678_lpi_eu_schwellenleiter.md`). Nur die
+unterste Sprosse ist dort als Schwelle publiziert, die beiden oberen sind belegte Interpretation
+derselben Arbeit — schwächer als eine echte Klimatologie-Eichung, aber ohne die oben belegte
+Datenlücke umsetzbar.
+
+⇒ **Antwort auf E1b: ja, ICON-EU braucht eine eigene Leiter** — sie steht seit #1678 fest.
 
 ### 4.5 Die Lösung steht bei den Wetterdiensten — Bedeutung harmonisieren, nicht Zahlen
 
@@ -843,14 +853,18 @@ genannten Lücken (Rang 2/3/4/7/10) sind davon unberührt und bleiben offen.
 umgesetzt — Issue **#1679**, adversary-VERIFIED, Spec
 `docs/specs/modules/feat_1679_lpi_schwellen_region_tabelle.md`: `app.model_registry.LPI_THRESHOLDS_JKG`
 liefert DE_ALPEN (ICON-D2) jetzt die belegte 1/30/50-Leiter (Bína et al.), EU_REST (ICON-EU)
-bleibt bewusst auf dem Interim-Wert 5/20/50 bis #1678. Die beiden ANDEREN Teile von Rang 2 — CAPE-
+blieb bis dahin bewusst auf dem Interim-Wert 5/20/50. Die beiden ANDEREN Teile von Rang 2 — CAPE-
 Ladder 1000/2500/4000 statt binär und die CIN-Paarung −25/−50/−100/−200 — sind davon NICHT
 betroffen und bleiben offen (CIN hängt zusätzlich an #1531). Rang 2 ist damit nur **teilweise**
-erledigt — die weiterhin offenen Ränge sind 2 (CAPE-Ladder/CIN-Rest), 3, 4, 7, 10.
+erledigt — die weiterhin offenen Ränge sind 2 (CAPE-Ladder/CIN-Rest), 3, 4, 10.
 
-Zur Eichung selbst (Rang 7): Abschnitt 4.4 stellt bereits richtig, dass die Historical
-Forecast API die Eichung **sofort rechenbar** macht — kein wochenlanges Sammeln nötig, keine
-Abhängigkeit von #1531 (das andere Felder holt). Tracking-Ticket: **#1678**.
+🟢 **Dritter Nachtrag, 2026-08-16:** Rang 7 (Feineichung EU_REST) ist jetzt ebenfalls umgesetzt —
+Issue **#1678**, Spec `docs/specs/modules/feat_1678_lpi_eu_schwellenleiter.md`: EU_REST trägt
+seither die belegte Leiter 7,14/23,81/86,16 J/kg (Schröder/Göcke/Köhler 2022) statt der
+Interim-Werte 5/20/50. Der in Abschnitt 4.4 zuvor vorgeschlagene Weg über die Open-Meteo
+Historical Forecast API erwies sich als nicht gangbar (Open-Meteo liefert LPI nur für ICON-D2) —
+Details und die Korrektur dort. Rang 8 (`sdi_2`) ist damit nicht mehr durch fehlende Eichung
+blockiert.
 
 | Rang | Scheibe | Warum hier | Stand |
 |---|---|---|---|
@@ -861,7 +875,7 @@ Abhängigkeit von #1531 (das andere Felder holt). Tracking-Ticket: **#1678**.
 | **4** | **Herkunft mitführen** — die Stufe trägt sichtbar, worauf sie beruht | Macht im Ortsvergleich erkennbar, dass Korsika und Alpen auf verschiedenen Größen fußen | 🟡 **Scheiben 1–4 live (2026-08-12/13)** — Ortsvergleich (PR #1780), Trip-Kurzzusammenfassung + GEWITTER-Kommando (PR #1797), Pille + Timeline + GLANCE + Ortsvergleich-Stundentabelle (PR #1806), Trip-Stundentabelle inkl. strukturell mit-vererbter Telegram-rich-Ansicht (#1680 S4). Ticket **#1680** bleibt offen für Mehrtages-Ausblick und Gewitter-Vorschau; Go-DTO und Frontend sind ersatzlos entfallen (kein Verbraucher). Hier stand bis 2026-08-10 fälschlich „✅ E1": das markierte nur die Entscheidung, nicht die Umsetzung |
 | **5** | ✅ **CAPE unsichtbar gemacht** (`selectable=False`, **#1585**) | **Umgesetzt und live** (2026-08-10): CAPE (`cape_jkg`) ist an jeder Nutzerkontakt-Stelle unsichtbar (Trip-Editor, E-Mail, SMS, Ortsvergleich inkl. Alt-Vergleich, Aktivitäts-Vorlagen, Wertebereichs-Korridor, jede Alarmwirkung inkl. #1592 Delta-Alarm) und bleibt ausschließlich interne Zutat der Fusion. Adversary-VERIFIED | ✅ erledigt |
 | **6** | **Radar hebt die Stufe an** | Beseitigt den Widerspruch aus Abschnitt 5 | ✅ E3 |
-| **7** | **Feineichung je Quelle** (E1b): eigene Leiter für `lpi_con_max`, kalibriert auf gleiche Überschreitungshäufigkeit | Sofort rechenbar über die Historical Forecast API (4.4) — unabhängig von #1531 | 🔴 offen, Ticket **#1678** |
+| **7** | ✅ **Feineichung je Quelle** (E1b): eigene Leiter für `lpi_con_max` | EU_REST bekommt eine belegte, publizierte Leiter (Schröder/Göcke/Köhler 2022) statt der Interim-Werte 5/20/50 — die zunächst vorgesehene Eichung über die Historical Forecast API (4.4) war nicht gangbar | ✅ erledigt — **#1678** |
 | **8** | **`sdi_2` einhängen** | Publizierte DWD-Schwelle vorhanden; erst sinnvoll, wenn die Skala geeicht ist | nach Rang 7 |
 | **9** | **Amtliche Warnung + Änderungsalarm zusammenführen** (E5); Radar-Nowcast bleibt eigener Kanal | Unabhängig von der Signalkette | ✅ E5 |
 | **10** | **Deutschland an den Meteoalarm-Feed** — `MeteoAlarmFeedSource("DE")` | Der Weg läuft produktiv für IT/AT und ist kontingentfrei. Offen: Punkt→Zone-Auflösung für DE, und 13,5 MB je Abruf ohne gzip | ✅ E6 |

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -3476,6 +3476,16 @@ function corridorInside(value, min, max) {
 
 ## Changelog
 
+- 2026-08-16: Issue #1678 — `EU_REST` (ICON-EU, `lpi_con_max`) bekommt eine eigene, belegte
+  LPI-Schwellenleiter **(7,14 / 23,81 / 86,16 J/kg)** und löst damit den Interim-Wert 5/20/50
+  ab, den #1679 dort bewusst stehen ließ. Quelle aller drei Sprossen: Schröder/Göcke/Köhler
+  (2022), Reports on ICON Issue 010 — die DWD-Arbeit, mit der `LPI_CON_MAX` für ICON-EU
+  eingeführt wurde. Grund: `lpi_con_max` ist eine andere Diagnostik als ICON-D2s `lpi`
+  (Konvektionsparametrisierung statt aufgelöster Strömung). `DE_ALPEN` bleibt bei 1/30/50,
+  `FR` weiterhin ohne LPI-Signal. Kein DTO-/Feld-Wechsel, nur die interne Schwellenquelle
+  (`app.model_registry.LPI_THRESHOLDS_JKG`). Nutzersichtbar: Orte in Nord-, Ost- und
+  Südeuropa werden seltener hochgestuft. Siehe
+  `docs/specs/modules/feat_1678_lpi_eu_schwellenleiter.md`.
 - 2026-08-11: Issue #1745 Scheibe A — Premium-SMS als vierter Kanal in der Alarm-Kanal-Auswahl
   (Alarme-Reiter, Trip UND Ortsvergleich). **Keine DTO-/Feld-Änderung** — `alert_channels.premium_sms`
   und `alert_channel_thresholds.premium_sms` (s. Abschnitte unten) existieren bereits seit #1701 S2b;

--- a/docs/specs/modules/feat_1678_lpi_eu_schwellenleiter.md
+++ b/docs/specs/modules/feat_1678_lpi_eu_schwellenleiter.md
@@ -1,0 +1,198 @@
+---
+entity_id: feat_1678_lpi_eu_schwellenleiter
+type: feature
+created: 2026-08-16
+updated: 2026-08-16
+status: draft
+version: "1.0"
+tags: [gewitter, lpi, icon-eu, model-registry, thunder-fusion, issue-1678]
+---
+
+# ICON-EU bekommt eine eigene, belegte LPI-Schwellenleiter statt der Interim-Werte 5/20/50 (Issue #1678)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Das Gebiet `EU_REST` (ICON-EU, Feld `lpi_con_max`) wird heute mit der Interim-Leiter
+5/20/50 J/kg bewertet — Zahlen in derselben Größenordnung wie die belegte ICON-D2-Leiter
+(1/30/50), obwohl es sich um eine **andere physikalische Größe** handelt. Gemessen führt
+das zu bis zu 51× häufigeren Einstufungen bei gleicher Wetterlage (Gesamtkonzept 4.3).
+Diese Arbeit ersetzt die Interim-Zeile durch eine Leiter, deren drei Werte aus der
+DWD-Veröffentlichung stammen, die die Größe eingeführt hat.
+
+**Der im Issue vorgeschlagene Weg (Eichskript nach Muster #1592 gegen die Open-Meteo
+Historical Forecast API) entfällt** — er ist nicht gangbar und auch nicht nötig,
+s. Abschnitt „Verworfene Alternativen".
+
+## Source
+
+- **File:** `src/app/model_registry.py`
+- **Identifier:** `LPI_THRESHOLDS_JKG` / `lpi_thresholds_jkg()`
+
+Schicht: **Python-Core / Domain-Backend** (`src/app/`, `src/providers/`, `src/output/`).
+Keine Go-, keine Frontend-Beteiligung — die Leiter wirkt ausschließlich serverseitig in
+der Gewitter-Fusion.
+
+## Estimated Scope
+
+- **LoC:** ~+80 / −15 (davon ~50 Test)
+- **Files:** 4 Code/Test + 2 Doku
+- **Effort:** low (Mechanik) / medium (Begründungspflicht)
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/providers/thunder_routing.py` `_REGIONS` | liest | liefert `EU_REST` als Gebietsnamen (first-match-wins) |
+| `src/providers/thunder_enrichment.py` `_fuse_thunder_levels()` | Konsument | löst die Leiter je Reihe auf und reicht sie durch |
+| `src/output/metric_format.py` `_signal_levels()` | Konsument | wendet die drei Sprossen auf `lightning_potential_lpi_jkg` an |
+| `src/providers/dwd_eu.py` | Datenquelle | holt `lpi_con_max` von `opendata.dwd.de`, mappt auf Feld `lpi` |
+
+## Implementation Details
+
+### Die neue Leiter
+
+```python
+LPI_THRESHOLDS_JKG: Dict[str, Tuple[float, float, float]] = {
+    "DE_ALPEN": (1.0, 30.0, 50.0),    # unveraendert (Issue #1679, Bina et al. 2022)
+    "EU_REST":  (7.14, 23.81, 86.16), # NEU (Issue #1678, Schroeder et al. 2022)
+}
+```
+
+### Herleitung jeder einzelnen Sprosse
+
+Quelle für alle drei Zahlen: **Schröder, Göcke, Köhler (2022), „Subgrid scale Lightning
+Potential Index for ICON with parameterized convection", Reports on ICON Issue 010,
+DOI 10.5676/DWD_pub/nwv/icon_010** — die DWD-Arbeit, mit der `LPI_CON_MAX` am 23.11.2022
+für ICON-EU eingeführt wurde.
+
+| Sprosse | Wert | Herleitung |
+|---|---|---|
+| leicht | **7,14** | Tab. 3, p=1/3: empfindlichste kalibrierte Nachweisschwelle („blitzt es überhaupt"). Direkte Entsprechung zu ICON-D2s Nachweisschwelle LPI > 1 J/kg, aus der die unterste DE_ALPEN-Sprosse gebildet wurde. **Die einzige als Schwelle publizierte Sprosse.** |
+| mittel | **23,81** | Tab. 3, p=1: Punkt, an dem die Fläche mit Schwellenüberschreitung im Jahresmittel **gleich groß** ist wie die von LINET beobachtete Blitzfläche. Ab hier ist das Signal nicht mehr vorsorglich überzeichnet. |
+| hoch | **86,16** | `LPI_c` = 86,16 J/kg, Sättigungskonstante der Arbeit; oberes Ende des sinnvollen Wertebereichs („for LPI > 100 J/kg the effect of KOI is not significant anymore"). |
+
+Warum überhaupt eine eigene Leiter: `lpi_con_max` ist laut DWD Database Reference Manual
+Kap. 6.5 eine andere Diagnostik als `lpi` — gleiche Formelstruktur, aber Aufwind und
+Hydrometeore stammen aus dem Bechtold-Tiedtke-Konvektionsschema (Hydrometeore nach
+Lopez 2016 approximiert) statt aus aufgelöster Strömung: *„the LPI can be calculated only
+in a convection-permitting model setup"*.
+
+### Verworfene Alternativen (mit Grund)
+
+1. **Eichskript gegen die Open-Meteo Historical Forecast API** (der im Issue und im
+   Gesamtkonzept 4.4 vorgeschlagene Weg): **nicht gangbar.** Open-Meteo lädt LPI
+   ausschließlich für ICON-D2 und dort das Feld `lpi`
+   (`Sources/App/Icon/IconVariableDownloadable.swift:184-185`:
+   `return domain == .iconD2 ? ("lpi", …) : nil // only in icon d2`). `lpi_con_max` kommt
+   dort nicht vor; die ICON-EU-Seite des Vergleichs existiert nicht und entsteht auch
+   durch Warten nicht.
+2. **Nur die belegte unterste Sprosse setzen, oben `None`** (analog zur CAPE-Deckelung):
+   **wirkungsverkehrend.** `metric_format.py:423-426` verlangt alle drei Sprossen; ist eine
+   `None`, trägt das Blitzpotenzial **gar kein** Signal bei — LPI verstummte in ganz
+   `EU_REST`.
+3. **Tabelle 3 wörtlich als Leiter (7,14 / 11,78 / 23,81):** senkt mittel und hoch und
+   verschlimmert damit genau die Über-Einstufung, die dieses Ticket behebt. Zudem sind die
+   drei p-Werte drei Kalibrierungen **derselben** Ja/Nein-Frage bei unterschiedlicher
+   Fehlalarm-Toleranz — als Stärke-Sprossen gelesen vermischte das die Achse „Stärke"
+   (kein/leicht/mittel/hoch) mit der Achse „Sicherheit" (möglich/wahrscheinlich/akut),
+   die laut PO-Korrektur zu #1474 strikt getrennt bleiben.
+4. **Verhältnis-Übertragung der D2-Leiter (× 7,14 → 214/357):** „hoch" wäre praktisch
+   unerreichbar; die Linearitäts-Annahme ist durch die eigene Messung widerlegt (das
+   Missverhältnis schrumpft von 51× bei Schwelle 5 auf 8,7× bei Schwelle 50).
+
+## Expected Behavior
+
+- **Input:** `thunder_region_for(lat, lon) == "EU_REST"` und ein Datenpunkt mit
+  `lightning_potential_lpi_jkg` (aus ICON-EU `lpi_con_max`).
+- **Output:** `thunder_level` des Datenpunkts, gebildet über die neue Leiter.
+- **Side effects:** Keine. Kein neuer Mechanismus, keine Signatur-Änderung, kein
+  Persistenz-Schema betroffen. Die Alles-oder-nichts-Regel und die
+  Kein-stiller-Rückfall-Regel bleiben unangetastet.
+
+## Acceptance Criteria
+
+Alle Stufen-ACs werden am **Wirkort** geprüft — ein Datenpunkt läuft durch die produktive
+Fusion (`thunder_level_from_signals()`) mit der aus `lpi_thresholds_jkg("<Gebiet>")`
+aufgelösten Leiter. Geprüft wird die entstehende Stufe, **nie** der Tabelleninhalt.
+
+- **AC-1:** Given ein Datenpunkt im Gebiet `EU_REST` mit Blitzpotenzial 60 J/kg / When die
+  Gewitterstufe über die produktive Fusion gebildet wird / Then ist sie `MED` — heute ist
+  sie `HIGH`, weil 60 die alte Hoch-Schwelle 50 überschreitet; die neue Hoch-Sprosse liegt
+  bei 86,16.
+  - Test: 60 J/kg durch die Fusion, erwartete Blitzpotenzial-Stufe `MED`.
+
+- **AC-2:** Given ein Datenpunkt im Gebiet `EU_REST` mit Blitzpotenzial 21 J/kg / When die
+  Gewitterstufe gebildet wird / Then ist sie `LOW` — heute ist sie `MED`, weil 21 die alte
+  Mittel-Schwelle 20 überschreitet; die neue Mittel-Sprosse liegt bei 23,81.
+  - Test: 21 J/kg durch die Fusion, erwartete Blitzpotenzial-Stufe `LOW`.
+
+- **AC-3:** Given ein Datenpunkt im Gebiet `EU_REST` mit Blitzpotenzial 6 J/kg / When die
+  Gewitterstufe gebildet wird / Then ist sie `NONE` („kein Gewitter") — heute ist sie `LOW`,
+  weil 6 die alte Nachweisschwelle 5 überschreitet; die neue liegt bei 7,14.
+  - Test: 6 J/kg durch die Fusion, erwartete Blitzpotenzial-Stufe `NONE`.
+
+- **AC-4:** Given ein Datenpunkt im Gebiet `EU_REST` mit Blitzpotenzial 90 J/kg / When die
+  Gewitterstufe gebildet wird / Then ist sie `HIGH` — die oberste Sprosse bleibt erreichbar
+  und wird nicht zur toten Zusicherung. (Bewusst kein RED-Nachweis: dieser Wert ergibt vor
+  und nach der Änderung `HIGH`; der Test bewacht, dass das Anheben der Sprosse die Stufe
+  nicht abschafft.)
+  - Test: 90 J/kg durch die Fusion, erwartete Blitzpotenzial-Stufe `HIGH`.
+
+- **AC-5:** Given dieselben vier Blitzpotenzial-Werte (6, 21, 60, 90 J/kg) / When sie im
+  Gebiet `DE_ALPEN` statt `EU_REST` bewertet werden / Then ergeben sie unverändert `LOW`,
+  `LOW`, `HIGH`, `HIGH` nach der Leiter 1/30/50 — die ICON-D2-Einstufung bleibt von dieser
+  Arbeit unberührt.
+  - Test: dieselbe Fusion, nur mit `lpi_thresholds_jkg("DE_ALPEN")`.
+
+- **AC-6:** Given das Gebiet `FR` / When ein Datenpunkt dort mit gesetztem Blitzpotenzial
+  durch die Fusion läuft / Then trägt das Blitzpotenzial **kein** Signal bei (kein Eintrag
+  `blitzpotenzial`), weil `lpi_thresholds_jkg("FR")` weiterhin `None` liefert — FR bewertet
+  Blitzdichte, nicht LPI.
+  - Test: Fusion eines FR-Datenpunkts; geprüft wird die Abwesenheit des
+    Blitzpotenzial-Signals, nicht nur der `None`-Rückgabewert der Registry.
+
+- **AC-7:** Given die Registry / When `LPI_THRESHOLDS_JKG` gelesen wird / Then trägt sie
+  genau die zwei Gebiete `DE_ALPEN` (1,0 / 30,0 / 50,0) und `EU_REST` (7,14 / 23,81 /
+  86,16), je Gebiet streng monoton steigend, und kein `FR`.
+  - Test: Bestandsprüfung der Tabelle inklusive Monotonie beider Zeilen (ersetzt die heute
+    auf 5/20/50 festgenagelte Zusicherung in
+    `tests/tdd/test_lpi_threshold_region_table.py:69-77`).
+
+## Known Limitations
+
+1. **Nur die unterste Sprosse ist als Schwelle publiziert.** 23,81 ist als
+   Kalibrierungspunkt publiziert, aber nicht als Stärke-Sprosse; 86,16 ist eine
+   Formelkonstante der Arbeit, keine publizierte Warnschwelle. Beide oberen Sprossen sind
+   damit **belegte Interpretation**, nicht belegte Zielsetzung der Quelle. Eine bessere
+   Ableitung bräuchte eine eigene Klimatologie aus DWD-GRIB-Läufen über eine
+   Konvektionssaison — bewusst nicht Teil dieser Arbeit (PO-Vorgabe: kein
+   Grundlagenforschungs-Aufwand).
+2. **Auflösungslücke:** Schröder et al. kalibrierten auf ICON-20 (≈20 km, ICON-EU-EPS
+   Member 1), nicht auf das deterministische ICON-EU mit 6,5 km. Der Bericht macht keine
+   Aussage zur Auflösungsabhängigkeit der Schwellen.
+3. **Aggregationsfenster:** Das DWD-Handbuch nennt für `LPI_CON_MAX` χ = 1, 3 oder 6 h je
+   nach Vorhersagestunde. Wir holen nur `FORECAST_HOURS = 1..24` (`dwd_eu.py:87`) und haben
+   am GRIB-Kopf 60 min gemessen (`dwd_eu.py:42-45`) — im genutzten Bereich also 1 h. Eine
+   spätere Ausweitung des Vorhersagehorizonts verschöbe die Leiter still nach oben.
+4. **Die Unterscheidung hängt allein an der Region.** `dwd_eu.py:108` bildet `lpi_con_max`
+   auf dasselbe interne Feld `lpi` ab wie ICON-D2; nur `_REGIONS` (first-match-wins)
+   trennt die Leitern. Ein Umbau dort würde die Leiterwahl still falsch machen.
+5. **Keine der beiden Haupttouren ist betroffen:** Karnischer Höhenweg (≈46,6 N / 12,8 O)
+   liegt in `DE_ALPEN`, GR20/Korsika (≈42,2 N / 9,07 O) in `FR`. `EU_REST` betrifft Nord-,
+   Ost- und Südeuropa.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue — die Grundsatzentscheidung „je Quelle eine eigene Leiter,
+  geeicht auf dieselbe Bedeutung" ist mit ADR-0048 („CAPE ≠ CAPE") und Issue #1679 bereits
+  getroffen. Diese Arbeit füllt die dort ausgelassene Zeile.
+- **Rationale:** Kein neuer Mechanismus, keine geänderte Schnittstelle, keine neue
+  Datenquelle — ausschließlich belegte Werte in eine bestehende Tabelle.
+
+## Changelog
+
+- 2026-08-16: Initial spec created (Issue #1678)

--- a/docs/specs/modules/feat_1678_lpi_eu_schwellenleiter.md
+++ b/docs/specs/modules/feat_1678_lpi_eu_schwellenleiter.md
@@ -12,7 +12,7 @@ tags: [gewitter, lpi, icon-eu, model-registry, thunder-fusion, issue-1678]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved (PO, 2026-08-16)
 
 ## Purpose
 

--- a/src/app/model_registry.py
+++ b/src/app/model_registry.py
@@ -142,18 +142,38 @@ def cape_threshold_jkg(model_id: Optional[str], region: Optional[str]) -> Option
     return CAPE_THRESHOLDS_JKG.get((model_id, region))
 
 
-# Blitzpotenzial-Schwellen je Gebiet (Issue #1679). Belegt: Bina et al.,
-# Atmospheric Research 2022 / ASR Copernicus 2022, COSMO-D2 (2,2 km,
-# dieselbe Modellfamilie wie ICON-D2): "skilful forecast ... for LPI
-# thresholds 30, 40 and 50 J/kg", Nachweisschwelle "LPI > 1 J/kg".
-# EU_REST: UNVERAENDERTER Interim-Wert (5/20/50) -- ICON-EU (lpi_con_max)
-# liefert strukturell deutlich hoehere Werte als ICON-D2 (Faktor 51x am
-# unteren Ende, Issue #1678); eine eigene, eingemessene Leiter folgt dort.
+# Blitzpotenzial-Schwellen je Gebiet (Issue #1679, EU_REST-Leiter #1678).
+# DE_ALPEN belegt: Bina et al., Atmospheric Research 2022 / ASR Copernicus
+# 2022, COSMO-D2 (2,2 km, dieselbe Modellfamilie wie ICON-D2): "skilful
+# forecast ... for LPI thresholds 30, 40 and 50 J/kg", Nachweisschwelle
+# "LPI > 1 J/kg".
+#
+# EU_REST (Issue #1678): eigene Leiter, weil `lpi_con_max` (ICON-EU) eine
+# ANDERE physikalische Groesse ist als `lpi` (ICON-D2) -- gleiche
+# Formelstruktur, aber Aufwind und Hydrometeore stammen aus dem
+# Bechtold-Tiedtke-Konvektionsschema statt aus aufgeloester Stroemung (DWD
+# Database Reference Manual Kap. 6.5: "the LPI can be calculated only in a
+# convection-permitting model setup"). Quelle aller drei Sprossen:
+# Schroeder, Goecke, Koehler (2022), "Subgrid scale Lightning Potential
+# Index for ICON with parameterized convection", Reports on ICON Issue 010,
+# DOI 10.5676/DWD_pub/nwv/icon_010 -- die DWD-Arbeit, mit der `LPI_CON_MAX`
+# am 23.11.2022 fuer ICON-EU eingefuehrt wurde:
+#   7,14  = Tab. 3, p=1/3, empfindlichste kalibrierte Nachweisschwelle
+#           ("blitzt es ueberhaupt") -- die einzige als Schwelle publizierte
+#           Sprosse, direkte Entsprechung zur ICON-D2-Nachweisschwelle > 1.
+#   23,81 = Tab. 3, p=1, Punkt an dem die Flaeche mit Schwellenueberschreitung
+#           im Jahresmittel gleich gross ist wie die von LINET beobachtete
+#           Blitzflaeche.
+#   86,16 = `LPI_c`, Saettigungskonstante der Arbeit; oberes Ende des
+#           sinnvollen Wertebereichs.
+# Die beiden oberen Sprossen sind damit belegte INTERPRETATION, nicht
+# publizierte Warnschwellen der Quelle (Spec Known Limitations #1).
+#
 # FR bekommt bewusst KEINEN Eintrag -- AROME liefert dort Blitzdichte,
 # kein LPI (thunder_routing._REGIONS).
 LPI_THRESHOLDS_JKG: Dict[str, Tuple[float, float, float]] = {
     "DE_ALPEN": (1.0, 30.0, 50.0),
-    "EU_REST": (5.0, 20.0, 50.0),
+    "EU_REST": (7.14, 23.81, 86.16),
 }
 
 

--- a/src/providers/dwd_eu.py
+++ b/src/providers/dwd_eu.py
@@ -98,10 +98,16 @@ THUNDER_PARAMS = ("lpi_con_max", "cape_ml", "cape_con", "cin_ml")
 
 # Abrufname beim Dienst -> INTERNER Signalname des gemeinsamen Protokolls.
 # `lpi_con_max` ist der externe Parametername; nach aussen liefert dieser
-# Provider unter demselben Signalschluessel `lpi` wie ICON-D2, weil es
-# fachlich dieselbe Groesse (Blitzpotenzial in J/kg) ist. Dadurch greift die
-# bestehende Zeile in `thunder_enrichment._SIGNAL_ZU_FELD` unveraendert und
-# der gemeinsame Anschluss muss fuer S2c NICHT angefasst werden (Spec AC-9).
+# Provider unter demselben Signalschluessel `lpi` wie ICON-D2 -- NICHT weil
+# es fachlich dieselbe Groesse waere (ist es nicht, s. `model_registry.py`
+# Kommentar zu `LPI_THRESHOLDS_JKG`: `lpi_con_max` stammt aus dem
+# Bechtold-Tiedtke-Konvektionsschema, `lpi` aus aufgeloester Stroemung),
+# sondern weil die Unterscheidung ausschliesslich ueber das GEBIET laeuft
+# (`thunder_routing._REGIONS`, first-match-wins) und `lpi_thresholds_jkg()`
+# je Gebiet die eigene, dafuer geeichte Leiter auswaehlt (Issue #1678).
+# Dadurch greift die bestehende Zeile in `thunder_enrichment._SIGNAL_ZU_FELD`
+# unveraendert und der gemeinsame Anschluss musste fuer S2c NICHT angefasst
+# werden (Spec AC-9).
 # `cape_ml`/`cape_con`/`cin_ml` behalten ihren Abrufnamen 1:1 als Signalname
 # -- keine Umbenennung noetig, weil es dieselben Groessen wie bei ICON-D2 sind.
 _SIGNAL_KEYS: Dict[str, str] = {

--- a/tests/tdd/test_lpi_eu_rest_ladder.py
+++ b/tests/tdd/test_lpi_eu_rest_ladder.py
@@ -1,0 +1,188 @@
+"""TDD RED — Issue #1678: ICON-EU bekommt eine eigene, belegte
+LPI-Schwellenleiter statt der Interim-Werte 5/20/50.
+
+SPEC: docs/specs/modules/feat_1678_lpi_eu_schwellenleiter.md
+
+Deckt AC-1 bis AC-6 der Spec ab (AC-7 -- Bestandsprüfung der Registry-Tabelle
+-- liegt in `tests/tdd/test_lpi_threshold_region_table.py`). Geprüft wird am
+WIRKORT: ein Datenpunkt läuft durch die produktive Fusion
+(`output.metric_format.thunder_level_from_signals()`) mit der aus
+`app.model_registry.lpi_thresholds_jkg("<Gebiet>")` aufgelösten Leiter --
+NIE der Tabelleninhalt allein.
+
+RED-Ursache (heute): `LPI_THRESHOLDS_JKG["EU_REST"]` ist noch `(5.0, 20.0,
+50.0)` (Interim), die Spec verlangt `(7.14, 23.81, 86.16)`
+(Schroeder/Goecke/Koehler 2022). Damit fallen 60/21/6 J/kg heute noch auf die
+ALTEN Schwellen und ergeben `HIGH`/`MED`/`LOW` statt der geforderten
+`MED`/`LOW`/`NONE`.
+
+Keine Mocks: reine Funktionsaufrufe, kein Netz.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.model_registry import lpi_thresholds_jkg
+from app.models import ThunderLevel
+from output.metric_format import thunder_level_from_signals, thunder_signal_carriers
+
+NONE = ThunderLevel.NONE
+LOW = ThunderLevel.LOW
+MED = ThunderLevel.MED
+HIGH = ThunderLevel.HIGH
+
+
+def _fusion_nur_lpi(value, region):
+    """Ruft `thunder_level_from_signals()` NUR mit dem LPI-Signal gesetzt auf
+    -- Wettercode/Blitzdichte/CAPE bleiben `None`, die Leiter kommt aus der
+    Registry (`lpi_thresholds_jkg()`), nicht als hartkodiertes Tupel."""
+    lpi_low, lpi_med, lpi_high = lpi_thresholds_jkg(region) or (None, None, None)
+    return thunder_level_from_signals(
+        wettercode_level=None, lightning_density=None, cape_jkg=None,
+        lightning_potential_jkg=value,
+        cape_threshold_jkg=None, cape_med_min=None, cape_high_min=None,
+        cin_jkg=None,
+        lpi_low_min=lpi_low, lpi_med_min=lpi_med, lpi_high_min=lpi_high,
+    )
+
+
+# ────────────── AC-1 — 60 J/kg in EU_REST ergibt MED (heute HIGH) ─────────
+
+def test_ac1_eu_rest_60_jkg_ergibt_med():
+    """AC-1: 60 J/kg im Gebiet EU_REST muss ueber die neue Leiter (7,14 /
+    23,81 / 86,16) `MED` ergeben.
+
+    HEUTE (RED-Ursache): die alte Interim-Leiter (5/20/50) klassifiziert 60
+    als `HIGH` (60 >= 50) -- dieser Test schlaegt fehl, bis die Registry auf
+    `(7.14, 23.81, 86.16)` umgestellt ist.
+    """
+    ergebnis = _fusion_nur_lpi(60.0, "EU_REST")
+    assert ergebnis == MED, (
+        f"60 J/kg im Gebiet EU_REST muss ueber die neue Leiter MED ergeben, "
+        f"erhalten {ergebnis!r}"
+    )
+
+
+# ────────────── AC-2 — 21 J/kg in EU_REST ergibt LOW (heute MED) ──────────
+
+def test_ac2_eu_rest_21_jkg_ergibt_low():
+    """AC-2: 21 J/kg im Gebiet EU_REST muss ueber die neue Leiter `LOW`
+    ergeben.
+
+    HEUTE (RED-Ursache): die alte Interim-Leiter klassifiziert 21 als `MED`
+    (21 >= 20) -- dieser Test schlaegt fehl, bis die neue Mittel-Sprosse
+    23,81 gilt.
+    """
+    ergebnis = _fusion_nur_lpi(21.0, "EU_REST")
+    assert ergebnis == LOW, (
+        f"21 J/kg im Gebiet EU_REST muss ueber die neue Leiter LOW ergeben, "
+        f"erhalten {ergebnis!r}"
+    )
+
+
+# ────────────── AC-3 — 6 J/kg in EU_REST ergibt NONE (heute LOW) ──────────
+
+def test_ac3_eu_rest_6_jkg_ergibt_none():
+    """AC-3: 6 J/kg im Gebiet EU_REST muss ueber die neue Leiter `NONE`
+    ("kein Gewitter") ergeben -- NICHT verwechseln mit "kein Signal": das
+    LPI-Signal ist aktiv geprueft, liegt aber unter der untersten Sprosse
+    7,14 (`metric_format._signal_levels()` setzt den Eintrag `blitzpotenzial`
+    trotzdem, solange Wert UND alle drei Sprossen `not None` sind).
+
+    HEUTE (RED-Ursache): die alte Interim-Leiter klassifiziert 6 als `LOW`
+    (6 >= 5) -- dieser Test schlaegt fehl, bis die neue Nachweisschwelle
+    7,14 gilt.
+    """
+    ergebnis = _fusion_nur_lpi(6.0, "EU_REST")
+    assert ergebnis == NONE, (
+        f"6 J/kg im Gebiet EU_REST muss ueber die neue Leiter NONE ergeben, "
+        f"erhalten {ergebnis!r}"
+    )
+    # Gegenprobe: das Signal ist trotzdem AKTIV (nicht abwesend) -- es traegt
+    # nur die Stufe NONE, weil 6 unter der untersten Sprosse liegt.
+    lpi_low, lpi_med, lpi_high = lpi_thresholds_jkg("EU_REST")
+    traeger = thunder_signal_carriers(
+        wettercode_level=None, lightning_density=None, cape_jkg=None,
+        lightning_potential_jkg=6.0,
+        cape_threshold_jkg=None, cape_med_min=None, cape_high_min=None,
+        cin_jkg=None,
+        lpi_low_min=lpi_low, lpi_med_min=lpi_med, lpi_high_min=lpi_high,
+    )
+    assert traeger == [], (
+        "Bei fusionierter Stufe NONE darf KEIN Traeger genannt werden "
+        f"(kein Gewitter hat keine Herkunft), erhalten {traeger!r}"
+    )
+
+
+# ────────────── AC-4 — 90 J/kg in EU_REST ergibt HIGH (heute BEREITS gruen)
+
+def test_ac4_eu_rest_90_jkg_ergibt_high():
+    """AC-4: 90 J/kg im Gebiet EU_REST muss ueber die neue Leiter `HIGH`
+    ergeben -- die oberste Sprosse (86,16) bleibt erreichbar.
+
+    ACHTUNG -- KEIN RED-Nachweis: 90 J/kg ergibt SOWOHL mit der alten
+    Interim-Leiter (90 >= 50) ALS AUCH mit der neuen (90 >= 86,16) `HIGH`.
+    Dieser Test ist heute bereits gruen und bleibt es nach der
+    Implementierung -- er bewacht, dass das Anheben der Hoch-Sprosse die
+    Stufe nicht unerreichbar macht (Spec AC-4 / Known Limitations 1).
+    """
+    ergebnis = _fusion_nur_lpi(90.0, "EU_REST")
+    assert ergebnis == HIGH, (
+        f"90 J/kg im Gebiet EU_REST muss HIGH ergeben, erhalten {ergebnis!r}"
+    )
+
+
+# ────────────── AC-5 — DE_ALPEN bleibt unberuehrt (heute BEREITS gruen) ───
+
+@pytest.mark.parametrize(
+    "wert, erwartet",
+    [
+        (6.0, LOW),
+        (21.0, LOW),
+        (60.0, HIGH),
+        (90.0, HIGH),
+    ],
+)
+def test_ac5_de_alpen_leiter_bleibt_unveraendert(wert, erwartet):
+    """AC-5: dieselben vier Blitzpotenzial-Werte (6/21/60/90 J/kg) ergeben im
+    Gebiet DE_ALPEN unverändert LOW/LOW/HIGH/HIGH nach der Leiter 1/30/50 --
+    die ICON-D2-Einstufung ist von dieser Arbeit UNBERUEHRT.
+
+    ACHTUNG -- KEIN RED-Nachweis: DE_ALPEN wird von dieser Spec nicht
+    veraendert. Regressionswaechter -- schlaegt an, wenn eine kuenftige
+    Aenderung versehentlich DE_ALPEN statt EU_REST trifft.
+    """
+    ergebnis = _fusion_nur_lpi(wert, "DE_ALPEN")
+    assert ergebnis == erwartet, (
+        f"{wert} J/kg im Gebiet DE_ALPEN muss unveraendert {erwartet.name} "
+        f"ergeben, erhalten {ergebnis!r}"
+    )
+
+
+# ────────────── AC-6 — FR traegt kein Blitzpotenzial-Signal (heute BEREITS gruen)
+
+def test_ac6_fr_traegt_kein_blitzpotenzial_signal():
+    """AC-6: im Gebiet FR liefert `lpi_thresholds_jkg("FR")` weiterhin `None`
+    (FR bewertet Blitzdichte, nicht LPI) -- ein Datenpunkt MIT gesetztem
+    Blitzpotenzial traegt deshalb in der Fusion KEIN `blitzpotenzial`-Signal,
+    nicht nur der Registry-Rueckgabewert ist `None`.
+
+    ACHTUNG -- KEIN RED-Nachweis: FR ist von dieser Spec nicht betroffen.
+    Regressionswaechter gegen den "Alles-oder-nichts"-Verstoss, den die Spec
+    unter "Verworfene Alternativen" Punkt 2 ausschliesst.
+    """
+    region = "FR"
+    assert lpi_thresholds_jkg(region) is None, (
+        "Vorbedingung: FR darf keine LPI-Leiter haben"
+    )
+    traeger = thunder_signal_carriers(
+        wettercode_level=None, lightning_density=None, cape_jkg=None,
+        lightning_potential_jkg=88.2,
+        cape_threshold_jkg=None, cape_med_min=None, cape_high_min=None,
+        cin_jkg=None,
+        lpi_low_min=None, lpi_med_min=None, lpi_high_min=None,
+    )
+    assert "blitzpotenzial" not in traeger, (
+        f"FR darf trotz gesetztem Blitzpotenzial-Wert KEIN "
+        f"'blitzpotenzial'-Signal tragen, erhalten {traeger!r}"
+    )

--- a/tests/tdd/test_lpi_threshold_region_table.py
+++ b/tests/tdd/test_lpi_threshold_region_table.py
@@ -73,7 +73,9 @@ def test_ac1_lpi_thresholds_table_has_exactly_two_entries():
         f"gefunden {len(LPI_THRESHOLDS_JKG)}: {sorted(LPI_THRESHOLDS_JKG)}"
     )
     assert LPI_THRESHOLDS_JKG.get("DE_ALPEN") == (1.0, 30.0, 50.0)
-    assert LPI_THRESHOLDS_JKG.get("EU_REST") == (5.0, 20.0, 50.0)
+    # Issue #1678: EU_REST bekommt die belegte Schroeder/Goecke/Koehler-Leiter
+    # (7.14/23.81/86.16) statt der Interim-Werte (5.0/20.0/50.0).
+    assert LPI_THRESHOLDS_JKG.get("EU_REST") == (7.14, 23.81, 86.16)
     assert "FR" not in LPI_THRESHOLDS_JKG, (
         "FR darf KEINEN Eintrag haben -- AROME liefert Blitzdichte, kein LPI"
     )
@@ -83,7 +85,7 @@ def test_ac1_lpi_thresholds_table_has_exactly_two_entries():
     "region, erwartet",
     [
         ("DE_ALPEN", (1.0, 30.0, 50.0)),
-        ("EU_REST", (5.0, 20.0, 50.0)),
+        ("EU_REST", (7.14, 23.81, 86.16)),  # Issue #1678: neue Leiter
         ("FR", None),
         (None, None),
     ],
@@ -159,11 +161,16 @@ def test_ac3_marker_lpi_thresholds_jkg_eu_rest_existiert_heute_noch_nicht():
     HEUTE (RED-Ursache): `model_registry.lpi_thresholds_jkg` existiert noch
     nicht -> `AttributeError`, bevor die `assert`-Zeile ueberhaupt erreicht
     wird.
+
+    Issue #1678: der Lookup existiert inzwischen (#1679 GREEN), der erwartete
+    Wert ist deshalb auf die neue EU_REST-Leiter (7.14/23.81/86.16)
+    umgestellt -- sonst wuerde dieser Test nach der #1678-Implementierung
+    faelschlich ROT, obwohl er nur die Existenz des Lookups belegen soll.
     """
     import app.model_registry as model_registry
 
     ergebnis = model_registry.lpi_thresholds_jkg("EU_REST")
-    assert ergebnis == (5.0, 20.0, 50.0)
+    assert ergebnis == (7.14, 23.81, 86.16)
 
 
 # ────────────── AC-4 — unbekannte/fehlende Region: kein Signal, kein Fallback
@@ -265,7 +272,8 @@ def test_ac6_lpi_thresholds_jkg_fr_liefert_none():
     "name, lat, lon, erwartete_region, erwartete_leiter",
     [
         ("Mayrhofen/Zillertal", 47.16, 11.87, "DE_ALPEN", (1.0, 30.0, 50.0)),
-        ("Abisko/Nordschweden", 68.35, 18.83, "EU_REST", (5.0, 20.0, 50.0)),
+        # Issue #1678: neue EU_REST-Leiter statt der Interim-Werte 5/20/50.
+        ("Abisko/Nordschweden", 68.35, 18.83, "EU_REST", (7.14, 23.81, 86.16)),
     ],
 )
 def test_f001_schwellen_fuer_reihe_loest_gebiet_aus_echten_koordinaten_auf(
@@ -276,8 +284,9 @@ def test_f001_schwellen_fuer_reihe_loest_gebiet_aus_echten_koordinaten_auf(
     Leiter -- wie die AC-2/AC-3-Tests -- von Hand vorzugeben.
 
     Warum noetig: die bisherigen Produktionspfad-Tests arbeiten mit
-    LPI-Rohwerten, die in BEIDEN Leitern (DE_ALPEN 1/30/50, EU_REST 5/20/50)
-    dieselbe Stufe ergeben. Eine fest verdrahtete oder vertauschte Region in
+    LPI-Rohwerten, die in BEIDEN Leitern (DE_ALPEN 1/30/50, EU_REST seit
+    Issue #1678 7,14/23,81/86,16) dieselbe Stufe ergeben. Eine fest
+    verdrahtete oder vertauschte Region in
     `_schwellen_fuer_reihe()` bliebe dort strukturell unsichtbar (Mutation 5
     des Adversary: "NICHT GEFANGEN"). Hier trennen die beiden Koordinaten die
     Leitern eindeutig.
@@ -313,3 +322,34 @@ def test_f001_schwellen_fuer_reihe_loest_gebiet_aus_echten_koordinaten_auf(
         f"eine fest verdrahtete oder vertauschte Gebiets-Aufloesung"
     )
     assert cape_schwelle is None
+
+
+# ────────────── AC-7 (Issue #1678) — Bestandspruefung inkl. Monotonie ─────
+
+def test_ac7_lpi_thresholds_jkg_traegt_genau_zwei_gebiete_streng_monoton():
+    """AC-7 (Issue #1678): `LPI_THRESHOLDS_JKG` traegt GENAU die zwei Gebiete
+    `DE_ALPEN` (1,0/30,0/50,0) und `EU_REST` (7,14/23,81/86,16), je Gebiet
+    streng monoton steigend (`low < med < high`), und kein `FR`.
+
+    Ersetzt die bis Issue #1679 auf 5/20/50 festgenagelte Zusicherung
+    (Spec `feat_1678_lpi_eu_schwellenleiter.md` AC-7).
+
+    HEUTE (RED-Ursache): `EU_REST` ist noch `(5.0, 20.0, 50.0)` -- die
+    Wertepruefung schlaegt fehl, bis die Registry auf `(7.14, 23.81, 86.16)`
+    umgestellt ist. Die Monotonie- und Vollstaendigkeits-Zusicherungen sind
+    schon heute erfuellt.
+    """
+    from app.model_registry import LPI_THRESHOLDS_JKG
+
+    assert set(LPI_THRESHOLDS_JKG) == {"DE_ALPEN", "EU_REST"}, (
+        f"Erwartet genau die Gebiete DE_ALPEN und EU_REST, kein FR, "
+        f"gefunden {sorted(LPI_THRESHOLDS_JKG)}"
+    )
+    assert LPI_THRESHOLDS_JKG["DE_ALPEN"] == (1.0, 30.0, 50.0)
+    assert LPI_THRESHOLDS_JKG["EU_REST"] == (7.14, 23.81, 86.16)
+
+    for region, (low, med, high) in LPI_THRESHOLDS_JKG.items():
+        assert low < med < high, (
+            f"Leiter fuer {region} ist nicht streng monoton steigend: "
+            f"({low}, {med}, {high})"
+        )

--- a/tests/tdd/test_thunder_enrichment_fuses_level_shared_path.py
+++ b/tests/tdd/test_thunder_enrichment_fuses_level_shared_path.py
@@ -447,9 +447,13 @@ def test_1680_herkunft_teilt_die_ueberschreib_bedingung_der_stufe():
         cape_jkg=None, lightning_potential_lpi_jkg=None,
         thunder_level_signals=["cape"],
     )
+    # Issue #1678: EU_REST-Hoch-Sprosse jetzt 86,16 J/kg (zuvor 50) -- 90.0
+    # statt der frueheren 60.0, damit die Gegenprobe-Vorbedingung "ergibt
+    # HIGH" unveraendert erhalten bleibt (dieser Test prueft die
+    # Herkunfts-Kopplung, nicht die Leiter selbst).
     laut = ForecastDataPoint(
         ts=ts, thunder_level=None, lightning_density_per_km2_3h=None,
-        cape_jkg=None, lightning_potential_lpi_jkg=60.0,
+        cape_jkg=None, lightning_potential_lpi_jkg=90.0,
         thunder_level_signals=["cape"],
     )
 
@@ -462,7 +466,7 @@ def test_1680_herkunft_teilt_die_ueberschreib_bedingung_der_stufe():
         f"{stumm.thunder_level_signals!r}"
     )
     assert laut.thunder_level == ThunderLevel.HIGH, (
-        f"Gegenprobe-Vorbedingung: 60 J/kg Blitzpotenzial muessen ueber die "
+        f"Gegenprobe-Vorbedingung: 90 J/kg Blitzpotenzial muessen ueber die "
         f"EU_REST-Leiter 'hoch' ergeben, erhalten {laut.thunder_level!r}"
     )
     assert laut.thunder_level_signals == ["blitzpotenzial"], (

--- a/tests/tdd/test_thunder_origin_compare.py
+++ b/tests/tdd/test_thunder_origin_compare.py
@@ -230,7 +230,10 @@ def test_ac7_eu_rest_nennt_nur_blitzpotenzial_ohne_eichungshinweis():
     das Blitzpotenzial (unbelegte Interim-Schwelle), When die Herkunft
     erscheint, Then steht dort ausschliesslich "Blitzpotenzial" -- kein
     Eichungs-Hinweis, keine Bewertung (ADR-0007/ADR-0048)."""
-    html, _ = _mail(_ort("Nordort", 60.0, 25.0, [_dp(14, lpi=60.0)], modell="icon_eu"))
+    # Issue #1678: EU_REST-Hoch-Sprosse jetzt 86,16 J/kg (zuvor 50) -- 90.0
+    # statt der frueheren 60.0, damit der Ort weiterhin "hoch" erreicht
+    # (dieser Test prueft die Herkunfts-Anzeige, nicht die Leiter selbst).
+    html, _ = _mail(_ort("Nordort", 60.0, 25.0, [_dp(14, lpi=90.0)], modell="icon_eu"))
     assert _html_zellen(html)[0] == "hoch · Blitzpotenzial", (
         f"EU_REST-LPI wird genannt wie jede andere Zutat -- ohne Zusatz zur "
         f"Guete der Eichung: {_html_zellen(html)[0]!r}")
@@ -241,6 +244,9 @@ def test_ac10_tagesmaximum_vereinigt_die_zutaten_mehrerer_stunden():
     Hoechststufe ueber unterschiedliche Zutaten (14 Uhr CAPE, 18 Uhr
     Blitzpotenzial), When die Vergleichsmatrix gerendert wird, Then nennt sie
     BEIDE -- nicht nur die der ersten passenden Stunde."""
+    # Issue #1678 geprueft und AUSGESCHLOSSEN: Zweiort (47.0, 12.0) loest zu
+    # DE_ALPEN auf (thunder_region_for), dessen Leiter unveraendert 1/30/50
+    # ist -- 60.0 J/kg bleibt dort unabhaengig von #1678 HIGH.
     html, _ = _mail(_ort("Zweiort", 47.0, 12.0,
                          [_dp(14, cape=1500.0, cin=5.0), _dp(18, lpi=60.0)]))
     assert _teile(_html_zellen(html)[0]) == ("hoch", {"CAPE", "Blitzpotenzial"}), (

--- a/tests/tdd/test_thunder_potential_level_classification.py
+++ b/tests/tdd/test_thunder_potential_level_classification.py
@@ -4,8 +4,11 @@ SPEC: docs/specs/modules/feat_1474c_blitzpotenzial_stufen.md
 
 `thunder_level_from_signals()` bekommt einen VIERTEN Parameter
 `lightning_potential_jkg` (DWD-Blitzpotenzial, J/kg) mit einer EIGENEN
-Schwellentabelle (5 / 20 / 50 J/kg) -- eine andere Groesse auf einer anderen
-Skala als die Blitzdichte (#1419 Abs. 3.1, ADR-0025).
+Schwellentabelle -- eine andere Groesse auf einer anderen Skala als die
+Blitzdichte (#1419 Abs. 3.1, ADR-0025). Die Tabelle selbst kommt seit
+Issue #1679 gebietsabhaengig aus `app.model_registry.lpi_thresholds_jkg()`;
+diese Datei prueft weiterhin am Gebiet EU_REST, dessen Leiter seit Issue
+#1678 7,14/23,81/86,16 J/kg traegt (zuvor Interim-Werte 5/20/50).
 
 RED-Ursache (heute): `thunder_level_from_signals()` kennt den Parameter
 `lightning_potential_jkg` noch nicht -> jeder Aufruf mit diesem Keyword
@@ -55,32 +58,37 @@ def _fusion(**kwargs):
 @pytest.mark.parametrize(
     "wert, erwartet",
     [
-        (4.9, NONE),
-        (5.0, LOW),
-        (19.9, LOW),
-        (20.0, MED),
-        (49.9, MED),
-        (50.0, HIGH),
-        # PO-Messwerte 2026-08-02 (Spec Abschnitt AC-1):
+        # Issue #1678: EU_REST traegt seither die belegte Leiter
+        # 7,14/23,81/86,16 J/kg (Schroeder/Goecke/Koehler 2022) statt der
+        # Interim-Werte 5/20/50 -- jede Sprosse von beiden Seiten bewacht.
+        (7.13, NONE),
+        (7.14, LOW),
+        (23.80, LOW),
+        (23.81, MED),
+        (86.15, MED),
+        (86.16, HIGH),
+        # PO-Messwerte 2026-08-02 (Spec Abschnitt AC-1, weiterhin gueltig --
+        # 88.2 liegt ueber der neuen Hoch-Sprosse 86.16 wie zuvor ueber 50):
         (88.2, HIGH),  # GR20 / Refuge de Petra Piana -- reales Gewitter
         (0.9, NONE),   # Zillertal, ruhiges Wetter
     ],
 )
 def test_ac1_blitzpotenzial_dreiteilung_nach_po_tabelle(wert, erwartet):
     """AC-1: NUR das Blitzpotenzial-Signal gesetzt (Wettercode, Blitzdichte,
-    CAPE alle None) -- die Schwellen 5/20/50 J/kg entscheiden allein.
+    CAPE alle None) -- die EU_REST-Leiter (7,14/23,81/86,16 J/kg seit
+    Issue #1678) entscheidet allein.
 
     Gegenprobe (Spec): liest die Implementierung faelschlich die
     Blitzdichte-Schwellen (0,003/0,015/0,075) statt der eigenen
-    Blitzpotenzial-Schwellen, liefert bereits 4,9 J/kg faelschlich HIGH
-    (weit ueber 0,075) -- dieser Test faengt das, weil 4,9 hier NONE
+    Blitzpotenzial-Schwellen, liefert bereits 7,13 J/kg faelschlich HIGH
+    (weit ueber 0,075) -- dieser Test faengt das, weil 7,13 hier NONE
     erwartet.
     """
     ergebnis = _fusion(lightning_potential_jkg=wert)
     erwartet_name = erwartet.name if erwartet is not None else None
     assert ergebnis == erwartet, (
         f"Blitzpotenzial {wert} J/kg muss {erwartet_name} liefern "
-        f"(Schwellen 5/20/50), erhalten {ergebnis!r}"
+        f"(Schwellen 7,14/23,81/86,16), erhalten {ergebnis!r}"
     )
 
 
@@ -106,7 +114,7 @@ def test_ac3_kein_signal_liefert_none_aktiv_geprueft_liefert_thunderlevel_none()
         f"erhalten {kein_signal!r}"
     )
     assert aktiv_und_unauffaellig == NONE, (
-        f"lightning_potential_jkg=0.0 (aktiv geprueft, unter 5 J/kg) muss "
+        f"lightning_potential_jkg=0.0 (aktiv geprueft, unter der untersten Sprosse) muss "
         f"ThunderLevel.NONE liefern, erhalten {aktiv_und_unauffaellig!r}"
     )
     assert kein_signal != aktiv_und_unauffaellig, (


### PR DESCRIPTION
## Was sich ändert

`EU_REST` (ICON-EU, `lpi_con_max`) bekommt eine eigene, belegte LPI-Schwellenleiter und löst damit den Interim-Wert ab, den #1679 dort bewusst stehen ließ.

| Sprosse | alt | neu | Herleitung |
|---|---|---|---|
| leicht | 5 | **7,14** | Tab. 3, p=1/3 — empfindlichste kalibrierte Nachweisschwelle |
| mittel | 20 | **23,81** | Tab. 3, p=1 — Modellfläche = beobachtete Blitzfläche im Jahresmittel |
| hoch | 50 | **86,16** | `LPI_c`, Sättigungskonstante der Arbeit |

Quelle aller drei Sprossen: **Schröder, Göcke, Köhler (2022), „Subgrid scale Lightning Potential Index for ICON with parameterized convection", Reports on ICON Issue 010, DOI 10.5676/DWD_pub/nwv/icon_010** — die DWD-Arbeit, mit der `LPI_CON_MAX` am 23.11.2022 für ICON-EU eingeführt wurde.

`DE_ALPEN` (1/30/50) und `FR` (kein LPI-Signal) bleiben unberührt.

## Warum nicht der im Issue vorgeschlagene Weg

Das Issue und `gewitter-gesamtkonzept.md` Abschnitt 4.4 setzten voraus, die Open-Meteo Historical Forecast API liefere die ICON-EU-Läufe für eine Eichung nach Muster #1592. **Das gilt für CAPE, nicht für LPI:** Open-Meteo lädt Blitzpotenzial ausschließlich für ICON-D2 und dort das Feld `lpi` —

```swift
case .lightning_potential:
    return domain == .iconD2 ? ("lpi", "single-level", nil) : nil // only in icon d2
```

`lpi_con_max` kommt dort überhaupt nicht vor; die ICON-EU-Seite des Vergleichs existiert nicht und entsteht auch durch Warten nicht. Abschnitt 4.4 ist entsprechend korrigiert.

Ebenfalls korrigiert: der Kommentar in `dwd_eu.py`, `lpi_con_max` und `lpi` seien „fachlich dieselbe Größe" — am DWD Database Reference Manual Kap. 6.5 widerlegt (*„the LPI can be calculated only in a convection-permitting model setup"*; bei `LPI_CON_MAX` stammen Aufwind und Hydrometeore aus dem Bechtold-Tiedtke-Schema).

## Kollateral bewusst behandelt

Vier Tests aus fremden Issues (#1474c/#1680) nutzten 60 J/kg nur als Vehikel, um „hoch" auszulösen. Statt ihre Erwartung auf „mittel" abzuschwächen — was fremde ACs still aufweichen würde — wandert der Messwert auf 90 J/kg, oberhalb der neuen Hoch-Sprosse. Nur `test_thunder_potential_level_classification.py`, das die Leiter selbst prüft, bekam neue Erwartungswerte.

Jede `lpi=60.0`-Fundstelle im Testbestand wurde über `thunder_region_for(lat, lon)` zur Laufzeit eingeordnet, nicht anhand von Ortsnamen — alle übrigen liegen bei (47.0, 12.0) und damit in `DE_ALPEN`.

## Nachweis

- Kern-Tests: 271 grün über alle 39 `test_thunder_*`-Dateien
- Adversary: **VERIFIED**, 2 Runden, 7/7 AC belegt, 0 Findings
- Mutations-Gegenprobe: alle 5 Pflicht-Mutationen von Tests gefangen (Sprosse verschieben, Monotonie brechen, `EU_REST` entfernen, `DE_ALPEN` verfälschen, `>=` → `>`)

## Bekannte Grenzen (in der Spec festgehalten)

- Nur die unterste Sprosse ist als *Schwelle* publiziert; 23,81 ist ein publizierter Kalibrierungspunkt, 86,16 eine Formelkonstante — die oberen zwei Sprossen sind belegte Auslegung.
- Schröder et al. kalibrierten auf ICON-20 (≈20 km), nicht auf das deterministische ICON-EU mit 6,5 km.

## Wirkung

Orte in Nord-, Ost- und Südeuropa werden seltener hochgestuft. Karnischer Höhenweg (`DE_ALPEN`) und GR20 (`FR`) sind nicht betroffen.

Spec: `docs/specs/modules/feat_1678_lpi_eu_schwellenleiter.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
