### PR TITLE
feat(#1467 S4a): gemeinsame Freigabe-Steuerung fuer amtliche Alarme

### DIFF
--- a/docs/adr/0021-shared-deviation-alert-engine.md
+++ b/docs/adr/0021-shared-deviation-alert-engine.md
@@ -112,8 +112,9 @@ dieser Scheibe (Scheibe 2, #1169).
   Scope `compare_radar`). Das **Alert-Log** ist ebenfalls kein Trip-Sonderweg
   mehr: beide Nowcast-Pfade protokollieren jetzt auch, WARUM eine Meldung
   unterdrückt wurde (`REASON_QUIET_HOURS`/`REASON_COOLDOWN`/
-  `REASON_DAILY_LIMIT`) — Änderungs- und amtlicher Alarm bewusst weiterhin
-  nicht (offene Lücke O3 in `feat_1459_alert_protokoll.md`). Kein neues
+  `REASON_DAILY_LIMIT`) —
+  Änderungs- und amtlicher Alarm bewusst weiterhin nicht
+  (offene Lücke O3 in `feat_1459_alert_protokoll.md`). Kein neues
   Architekturprinzip: das bestehende aus diesem ADR wird auf den letzten noch
   abweichenden Pfad angewandt. Details:
   `docs/specs/modules/rework_1467_s3_nowcast.md`.
@@ -162,3 +163,26 @@ dieser Scheibe (Scheibe 2, #1169).
   Eine Unterdrückung durch diese Stufe erzeugt **keinen** Protokolleintrag (Lücke
   O3 aus dem vorigen Nachtrag bleibt bewusst offen). Details:
   `docs/specs/modules/fix_1594_alarm_vorlauf_sperre.md`.
+- **Nachtrag (Issue #1467 S4a, 2026-08-16):** was der Nachtrag zu #1467 S3 für die
+  beiden **Nowcast**-Pfade vollzogen hat, gilt jetzt auch für die beiden
+  **amtlichen** Pfade. `trip_alert.py::_send_official_alert_only` und
+  `compare_official_alert.py::_check_one_preset` führten bis dahin je eine eigene
+  Inline-Prüfkette; beide laufen seit dieser Scheibe über denselben geteilten
+  Ablauf-Baustein `services/alert_gate.py::check_official_alert_gate()` mit der
+  festen Reihenfolge Ruhezeit → Tages-Obergrenze. Der Satz zur
+  Unterdrückungs-Protokollierung aus dem S3-Nachtrag bleibt unverändert richtig
+  (der amtliche Pfad protokolliert weiterhin keine Gründe); überholt ist allein,
+  was er zusätzlich implizierte — dass der amtliche Pfad keinen geteilten
+  Ablauf-Baustein nutzt.
+  Zwei bewusste Verhaltensänderungen: (1) Der amtliche **Trip**-Pfad **liest** den
+  geteilten Sperrzeit-Topf `"trip"` nicht mehr — ein zugestellter Änderungsalarm
+  verschluckte bis dahin bis zu 120 Minuten lang jede amtliche Eskalation;
+  **geschrieben** wird der Topf weiterhin, die harmlose Gegenrichtung bleibt
+  also zu. Der Baustein kennt deshalb **keinen** Cooldown-Parameter: die
+  Zusicherung ist eine Eigenschaft des Funktionstyps, nicht eine Disziplin der
+  Aufrufstelle. (2) Der **Ortsvergleich** prüft die Tages-Obergrenze jetzt VOR dem
+  Warnungs-Abruf statt danach — ein erschöpftes Kontingent kostet keinen
+  Fremd-Abruf mehr. `check_briefing_imminent()` bleibt in beiden Pfaden ein
+  eigener Aufruf unmittelbar NACH dem Baustein, `is_silenced` bleibt
+  Compare-eigen und außerhalb. Kein neues Architekturprinzip. Details:
+  `docs/specs/modules/rework_1467_s4a_amtlich.md`.

--- a/docs/context/rework-1467-s4a-amtlich.md
+++ b/docs/context/rework-1467-s4a-amtlich.md
@@ -1,0 +1,324 @@
+# Context: rework-1467-s4a-amtlich
+
+Issue **#1467** Scheibe **S4a** (Teilarbeit — schliesst #1467 **nicht**; das tut erst S4b).
+Erhoben 2026-08-16 am Stand `098226ae`.
+
+## Request Summary
+
+Die beiden **amtlichen** Alarmpfade (offizielle Wetterwarnungen: Ortsvergleich und Trip) sollen
+durch denselben Freigabe-Baustein laufen wie die Nowcast-Pfade seit S3, und die drei wortgleichen
+Compare-Helfer sollen zu einem werden. Zielmarke: **Verhalten unveraendert**, ausser wo ein
+Akzeptanzkriterium ausdruecklich etwas anderes sagt.
+
+## Ist-Stand (gemessen, nicht aus dem Issue uebernommen)
+
+Die Tabelle im Issue-Kopf stammt vom 2026-08-02 und ist ueberholt: `is_silenced`,
+`check_briefing_imminent`, `alert_daily_limit`, `effective_compare_channels`, `alert_log` und
+`alert_channel_threshold` sind **bereits geteilt**. Was fehlt, ist der gemeinsame **Ablauf**.
+
+### Stufenvergleich der beiden amtlichen Pfade
+
+| Stufe | Ortsvergleich (`compare_official_alert.py`) | Trip (`trip_alert.py::_send_official_alert_only`) |
+|---|---|---|
+| Stilllegungs-Riegel | `:100` `is_silenced(preset)` | **fehlt** (Trips kennen das Konzept nicht) |
+| Ruhezeit | `:128` | `:1485` |
+| Briefing-Vorlauf-Sperre | `:144` | `:1491` |
+| Zeit-Cooldown | **keiner** (bewusst, `:10-19`) | `:1494` — Scope **`"trip"`**, geteilt mit dem Aenderungsalarm (`:246`) |
+| Tages-Obergrenze | `:164` — **NACH** dem Abruf | `:1497` — **VOR** allem |
+| *Datenbeschaffung* | `:159` `_detect()` | entfaellt (Warnungen kommen als Parameter herein) |
+| Kanal-Aufloesung | `:169` | `:1503` |
+| Schwellwert-Filter | `:179` | `:1511` |
+| Versand | `:182` | `:1514` |
+| Protokollierung | `:190` `append_entry` | `:1523` `append_entry` |
+| Zustand + Zaehler | `:207-208` | `:1538-1542` |
+
+### Wortgleiche Doppelungen
+
+| Helfer | Fundstellen | Befund |
+|---|---|---|
+| `_load_presets()` | `compare_alert.py:592`, `compare_radar_alert.py:294`, `compare_official_alert.py:336` | **byte-identisch**, 3 Zeilen |
+| `_notification_service_for()` | `compare_alert.py:576`, `compare_radar_alert.py:274`, `compare_official_alert.py:322` | strukturgleich, Unterschied **nur** im Warntext (`"Compare-Alert:"` / `"(Radar)"` / `"(amtlich)"`) |
+
+Ein geteilter Helfer fuer beides existiert **nicht**. `scheduler_dispatch_service._load_presets_for_dispatch()`
+hat eine andere Signatur und ist kein Ersatz.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/alert_gate.py` (318 Z.) | **Die Vorlage.** `check_nowcast_gate` (Ruhezeit → Sperrzeit → Tages-Obergrenze, `GateResult(allowed, reason)`), `check_briefing_imminent`, `record_nowcast_sent` |
+| `src/services/compare_official_alert.py` (338 Z.) | Ortsvergleich-Pfad; enthaelt `_day_window_end()` `:276` |
+| `src/services/trip_alert.py` (1616 Z.) | Trip-Pfad, `_send_official_alert_only` ab `:1478`, `_is_throttled_with_cooldown` `:743` |
+| `src/services/compare_alert.py` (595 Z.) | Traegt zwei der drei Doppelungen |
+| `src/services/compare_radar_alert.py` (296 Z.) | Traegt zwei der drei Doppelungen; **von Struktur-Waechtern per Ordinal verankert** |
+| `src/services/alert_log.py` | `append_entry`, `append_suppressed_entry`, `REASON_*` `:47-49` |
+| `src/services/alert_daily_limit.py` | `is_allowed(user_id, now, zone, reason=None)`, `increment(user_id, now, zone)` |
+| `src/services/compare_alert_guard.py` (54 Z.) | `is_silenced(preset)` |
+| `src/services/compare_alert_channels.py` | `effective_compare_channels`, `effective_compare_telegram_style` |
+
+## Existing Patterns
+
+- **Hausmuster S2 AG1 / S3:** Ein neuer geteilter Baustein bekommt **sofort beide** Verbraucher.
+  Ein Baustein mit genau einem Aufrufer waere keine Entdopplung, sondern eine weitere Fassung.
+- **`GateResult`-Muster:** Abbruch bei der ersten zutreffenden Stufe, Grund als `REASON_*`-Konstante
+  zurueck; die Aufrufstelle entscheidet, ob sie ihn protokolliert.
+- **Zaehler-Invariante:** `alert_daily_limit.increment()` und `throttle_store.record()` laufen erst
+  **nach** erfolgreicher Zustellung (`record_nowcast_sent`, `alert_gate.py:304`).
+- **Trip/Compare-Teilungsregel:** eine Compare-eigene Zweitfassung eines Trip-Bausteins ist ein Verstoss.
+
+## Dependencies
+
+- **Upstream:** `ThrottleStore`, `AlertStateService`, `DeviationAlertEngine.is_quiet_hours`,
+  `alert_daily_limit`, `alert_log`, `official_alerts.get_official_alerts_for_location`,
+  `compare_slot_scheduler.presets_due_for_hour`, `output.renderers.day_window.resolve_configured_window`
+- **Downstream:** die `*/15`-Scheduler-Endpunkte, `NotificationService.send_official_alert` /
+  `send_multi_location_official_alert`, das Alarm-Protokoll (Go liest es: `internal/store/log.go`)
+
+## Existing Specs & ADRs
+
+| Dokument | Was daraus bindet |
+|---|---|
+| `docs/specs/modules/rework_1467_s3_nowcast.md` | Vorgaenger-Spec, 16 ACs. Struktur und AC-Zuschnitt sind die Vorlage |
+| `docs/specs/modules/issue_1216_slice2_compare_official_alert.md` | Ursprungs-Spec des Ortsvergleich-Pfads |
+| `docs/specs/modules/compare_official_alert_channels.md` | Kanal-/Schwellenverhalten des amtlichen Alarms |
+| `docs/specs/modules/fix_1685_warnfenster_revision.md` | stille Fenster-Revision — darf nicht brechen |
+| `docs/adr/0021-shared-deviation-alert-engine.md` | Grundsatz + **drei Nachtraege**; Nachtrag 2 sagt heute ausdruecklich „Aenderungs- und amtlicher Alarm bewusst nicht" — S4a macht diesen Satz falsch und muss ihn als **vierten Nachtrag** korrigieren, kein neues ADR |
+| `docs/adr/0035-ein-tagesfenster-fuer-trip-und-ortsvergleich.md` | ein Tagesfenster, wirksam auf Anzeige **und** Bewertung |
+| `docs/context/rework-1460-alerts-relevanzfilter.md` | Ursprungsanalyse; amtlicher Pfad in Z. 49, 65–67, 76, 99–102, 223–224 |
+
+## Waechter, die mitziehen muessen
+
+| Test | Warum |
+|---|---|
+| `tests/tdd/test_alert_gate.py` | `test_ac11_ruhezeit_stoppt_vor_der_sperrzeit_pruefung`, `test_ac11_sperrzeit_stoppt_vor_der_tages_obergrenze` — die Reihenfolge-Waechter |
+| `tests/tdd/test_nowcast_suppression_logging.py` | **`test_ac9_amtlicher_alarm_bekommt_keinen_unterdrueckungs_grund`** — bewacht heute ausdruecklich, dass der amtliche Pfad **keine** Unterdrueckungs-Gruende protokolliert. Wenn S4a das aendert, ist dieser Waechter zu **ersetzen**, nicht zu loeschen |
+| `tests/tdd/test_compare_official_alert_briefing_imminent.py` | `test_ac4_sperre_greift_vor_dem_warnungs_abruf` — Sperre vor der Datenbeschaffung |
+| `tests/tdd/test_compare_official_alert.py` | AC-1 bis AC-8 des Ortsvergleich-Pfads |
+| `tests/tdd/test_issue_1088_official_alert_triggers.py` | Trip-Ausloeser |
+| `tests/test_success_status_guard.py`, `tests/test_resolution_loss_guard.py` | verankern `compare_radar_alert.py` per `datei::funktion::ordinal` — ein zusaetzlicher Aufruf verschiebt die Zaehlung. **Schluessel nachziehen, Waechter nicht aufweichen** |
+
+## Risks & Considerations
+
+**R1 — „Alarm bleibt aus" ist der gefaehrlichste Fehler.** Jede Angleichung, die eine Stufe
+hinzufuegt, kann eine echte Warnung unterdruecken. Jede Stufe braucht einen Test, der belegt, dass
+sie **nur** in dem Fall greift, fuer den sie gedacht ist.
+
+**R2 — Der Trip-amtliche Cooldown teilt sich den Topf mit dem Aenderungsalarm.**
+`trip_alert.py:1494` und `:246` benutzen beide `ThrottleStore`-Scope `"trip"`. Ein Aenderungsalarm
+um 16:00 unterdrueckt damit heute eine amtliche GELB→ORANGE-Verschaerfung um 16:20 — genau die
+Wirkung, die das Issue fuer den Ortsvergleich ausdruecklich ausschliesst. **Das ist kein Umbau,
+sondern eine Entscheidung** (siehe unten).
+
+**R3 — Der Ortsvergleich prueft die Tages-Obergrenze nach dem Abruf.** Ein erschoepftes Kontingent
+kostet trotzdem einen Warnungs-Abruf. Vorziehen aendert das Kontingent-Verhalten nicht, aber die
+Zahl der Fremd-Abrufe — und damit potentiell die Fehlerbilder bei Quellen-Ausfall.
+
+**R4 — `_day_window_end()` ist Compare-eigen ohne Trip-Pendant** (`compare_official_alert.py:276`).
+Zwei Beobachtungen: (a) Bei einem normalen Fenster (4–19) liefert die Methode nach 19:00 Ortszeit
+ein **nullbreites** Fenster `[now, now]` — beabsichtigt laut Docstring („statt abends taub"), aber
+nirgends von einem Test gehalten. (b) Sie ruft `self._load_presets()` **innerhalb** der Ortsschleife
+(`:239` → `:291`), liest also je Ort alle Presets neu.
+
+**R5 — Waechter-Ordinale.** `compare_radar_alert.py` ist per Ordinal verankert; das war schon in S3
+eine Known Limitation (R6 dort).
+
+**R6 — Mandantentrennung.** Beide Pfade sind nutzerbezogen; Pflicht-Nachweis mit **zwei**
+verschiedenen Nutzern.
+
+**R7 — Bestandsdaten.** Alarm-Protokoll und `alert_state` muessen altlesbar bleiben;
+Read-Modify-Write mit Merge.
+
+## Zu entscheiden (gehoert in die Akzeptanzkriterien, nicht in einen Nebeneffekt)
+
+1. **Trip-amtlicher Cooldown** — bleibt er im geteilten `"trip"`-Topf (Status quo, Eskalation kann
+   unterdrueckt werden), bekommt er einen eigenen Scope, oder faellt er wie beim Ortsvergleich weg?
+2. **Tages-Obergrenze beim Ortsvergleich vor den Abruf ziehen** — ja/nein.
+3. **Unterdrueckungs-Gruende protokollieren** — S3 hat das ausdruecklich auf die Nowcast-Pfade
+   begrenzt und einen Waechter dafuer gebaut. Zieht S4a den amtlichen Pfad nach?
+4. **Stilllegungs-Riegel beim Trip** — Trips kennen kein `is_silenced`. Bleibt das so?
+
+---
+
+# Analysis (Phase 2, 2026-08-16)
+
+## Type
+
+**Feature/Rework** — Umbau mit zwei bewussten Verhaltensaenderungen, kein Bugfix-Workflow.
+
+## Die vier Entscheidungen — jetzt mit Belegen
+
+### E1 — Trip-amtlicher Cooldown: BELEGT, und schlimmer als vermutet
+
+- `trip_alert.py:1494` liest Scope `"trip"` (`:763-765`).
+- **Genau zwei** Schreibstellen im Modul: `:358` (Aenderungsalarm) und `:1539` (amtlich) —
+  **beide** Scope `"trip"`, beide auf `trip.id`. Radar/Nowcast nutzt `"radar"` (`:53`), ist nicht beteiligt.
+- **Kein Eskalations-Umweg.** `_send_official_alert_only` prueft den Cooldown unbedingt vor allem
+  Versand-Code; `official_alert_revision_verdict` entscheidet nur, *welche* Warnungen als neu/eskaliert
+  gelten, und fasst den ThrottleStore nicht an.
+- **Default-Cooldown = 120 Minuten** (`trip.alert_cooldown_minutes` Default `None` →
+  `throttle_hours * 60`, `throttle_hours=2` als Konstruktor-Default `trip_alert.py:133`).
+
+⇒ Ein Aenderungsalarm unterdrueckt eine amtliche GELB→ORANGE-Verschaerfung **bis zu zwei Stunden**.
+Das ist die Wirkung, die das Issue fuer den Ortsvergleich ausdruecklich ausschliesst.
+
+**Wichtige Unterscheidung, die der erste Entwurf uebersehen hat:** Lesen und Schreiben sind
+getrennt zu entscheiden.
+
+| | heute | „ersatzlos streichen" | **Empfehlung** |
+|---|---|---|---|
+| amtlich **liest** `"trip"` | ja | nein | **nein** |
+| amtlich **schreibt** `"trip"` | ja | nein | **ja (bleibt)** |
+| Folge fuer die Eskalation | wird verschluckt | kommt durch | **kommt durch** |
+| Folge fuer die Aenderungsalarm-Menge | unveraendert | **steigt** | **unveraendert** |
+
+Nur das Lesen zu streichen behebt die gefaehrliche Richtung („Alarm bleibt aus") und laesst die
+harmlose Richtung („Alarm kommt zusaetzlich") unangetastet. Die harmlose Richtung ist ohnehin der
+Gegenstand von S4b (#1744 B: Entdopplung nach Ereignis-Identitaet) — dort wird sie mit dem richtigen
+Werkzeug geloest, nicht mit einer pauschalen Zeitsperre.
+
+### E2 — Tages-Obergrenze vor den Abruf: JA, mit echtem Nutzen
+
+- `official_alerts/warn_egress.py:38-44` — TTL-Cache (30 min Erfolg / 60 s Fehler / 24 h „nicht abgedeckt").
+- `official_alerts/meteoalarm_budget.py` — echter Tageskontingent-Zaehler,
+  `DEFAULT_DAILY_BUDGET = 100`, Ruecknahme via `x-ratelimit-reset`.
+- **Das Kontingent-Problem ist real und produktiv belegt:** `docs/specs/modules/warn_service_consumption.md:22-28`
+  („liefert in Prod dauerhaft HTTP 429"), `fix_1397_meteoalarm_coverage_budget.md` (gemessen ~160
+  Abrufe / rollierende 24 h).
+
+⇒ Ein Abruf bei erschoepftem Tageslimit ist bei Cache-Treffer folgenlos, bei Cache-Fehltreffer aber
+ein echter Netz-Aufruf gegen ein knappes, produktiv bereits erschoepftes Kontingent.
+
+⚠️ **Korrektur zur Phase-1-Darstellung:** Der Trip ruft die Warnungen ebenfalls **vor** seiner
+Kontingent-Pruefung ab (`trip_alert.py:479` liegt vor `:1497`). Die Reihenfolge *innerhalb*
+`_send_official_alert_only` ist zwar frueher, der teure Abruf aber nicht. Die Asymmetrie zwischen
+beiden Pfaden ist damit kleiner als in Phase 1 beschrieben — das Vorziehen beim Trip waere ein
+anderer, groesserer Umbau an einer anderen Stelle und ist **Nicht-Ziel** dieser Scheibe.
+
+### E3 — Unterdrueckungsgruende beim amtlichen Pfad protokollieren: NEIN in S4a
+
+`tests/tdd/test_nowcast_suppression_logging.py:637-640` verbietet es mit harter Gleichheit
+(`_gate_reasons_in_log(gesperrt) == set()`), Schwester-Test `:577-579` fuer den Aenderungsalarm.
+Der Waechter wuerde brechen. Er ist **8 Tage alt und PO-freigegeben** (S3, AC-9) und haelt einen
+bewusst gezogenen Geltungsbereich. Ihn in derselben Scheibe zu ersetzen, die den Pfad umbaut,
+vermischt zwei Fragen. ⇒ Geltungsbereich bleibt Nowcast-only, Waechter bleibt unveraendert gruen.
+
+### E4 — Trip-„stillgelegt": KEINE Aenderung, es ist Absicht
+
+Trip **hat** `paused_at`/`archived_at` (`app/trip.py:200-201`), aber `trip_alert.py` prueft beide
+**nicht** (0 Treffer im Modul). `trip_report_scheduler.py:882-888` sagt warum, woertlich:
+
+> Issue #995: … NUR hier — NICHT in `load_all_trips()`, sonst wuerde der Alert-Dispatch
+> (`trip_alert.py`) faelschlich mit unterdrueckt.
+
+Ein pausierter Trip pausiert also den **Briefing-Versand**, nicht den Alarm. Ein `schedule`-Feld
+wie beim Preset gibt es beim Trip gar nicht. ⇒ `is_silenced` bleibt **ausserhalb** des geteilten
+Gates und Compare-eigen. Eigener Test, der das festhaelt (sonst zieht es der naechste „Vereinheitlicher" hinein).
+
+## Technical Approach
+
+**Neue Funktion in `src/services/alert_gate.py`:**
+
+```python
+def check_official_alert_gate(
+    *, user_id: str, quiet_from: Optional[str], quiet_to: Optional[str],
+    context_label: str, now: datetime, zone: ZoneInfo,
+) -> GateResult:
+```
+
+Zwei Stufen, Abbruch bei der ersten: **Ruhezeit → Tages-Obergrenze**. **Kein
+`cooldown_minutes`-Parameter.** Rueckgabetyp `GateResult` wird wiederverwendet.
+
+**Warum keine Erweiterung von `check_nowcast_gate` um ein Flag:** `ThrottleStore.is_throttled()`
+behandelt ein falsy `cooldown_minutes` heute schon als „nie gedrosselt" — mechanisch wuerde ein Flag
+funktionieren. Es macht die Invariante „amtlich hat keinen Cooldown" aber zur **Disziplin des
+Aufrufers** („vergiss nicht `None` zu uebergeben") statt zur Eigenschaft der Funktion. Bei einer
+Zusicherung, deren Verletzung „Warnung bleibt aus" bedeutet, ist das der falsche Tausch.
+
+**Aufrufstellen:**
+
+| Pfad | faellt weg | tritt an die Stelle |
+|---|---|---|
+| `compare_official_alert.py::_check_one_preset` | `:120-136` (Ruhezeit inline), `:163-166` (Tageslimit inline) | ein `check_official_alert_gate(...)` **nach** `is_silenced` (`:100`) und **vor** `_detect()` (`:159`) |
+| `trip_alert.py::_send_official_alert_only` | `:1485-1487` (Ruhezeit), `:1494-1496` (**Cooldown-Lesen**), `:1497-1501` (Tageslimit) | ein `check_official_alert_gate(...)` nach `_is_briefing_imminent` (`:1491`) |
+
+`check_briefing_imminent` bleibt in beiden Pfaden ein **eigener** Aufruf (seit #1594 geteilt,
+unveraendert). `_throttle_store.record("trip", …)` bei `trip_alert.py:1539` **bleibt** (siehe E1).
+`_is_throttled_with_cooldown` bleibt als Methode bestehen — weiter genutzt vom Aenderungsalarm
+(`:246`) und von `get_time_until_next_alert`.
+
+**Geteilter Compare-Helfer:** neues Modul `src/services/compare_preset_access.py` mit
+`load_compare_alert_presets(user_id)` und
+`notification_service_for_preset(settings, user_id, preset, *, log_label)`. Die drei Bestandsmethoden
+werden Ein-Zeiler-Wrapper (`log_label` traegt die einzige echte Abweichung — dasselbe Muster wie
+`context_label` in `alert_gate.py`). Kein Verstoss gegen die Teilungsregel: ein Trip-Pendant
+existiert nicht und wird nicht gebraucht.
+
+## Affected Files
+
+| Datei | Aenderung | Beschreibung |
+|---|---|---|
+| `src/services/alert_gate.py` | MODIFY | `check_official_alert_gate` (2 Stufen, ohne Cooldown) |
+| `src/services/compare_official_alert.py` | MODIFY | Gate-Aufruf vor `_detect()`; Helfer werden Wrapper |
+| `src/services/trip_alert.py` | MODIFY | Gate-Aufruf; Cooldown-**Lesen** entfaellt, Schreiben bleibt |
+| `src/services/compare_preset_access.py` | CREATE | geteilter Preset-/Notification-Helfer |
+| `src/services/compare_alert.py` | MODIFY | zwei Methoden → Wrapper |
+| `src/services/compare_radar_alert.py` | MODIFY | zwei Methoden → Wrapper |
+| `docs/adr/0021-shared-deviation-alert-engine.md` | MODIFY | **Nachtrag 4** — Nachtrag 2 („amtlicher Alarm bewusst nicht") wird sachlich falsch |
+| `tests/tdd/test_alert_gate.py` | MODIFY | Stufen + Reihenfolge der neuen Funktion |
+| `tests/tdd/test_compare_official_alert*.py` | MODIFY | Reihenfolge Limit-vor-Abruf, `is_silenced` ausserhalb |
+| `tests/tdd/test_issue_1088_official_alert_triggers.py` | MODIFY | **Regression: Eskalation trotz juengerem Aenderungsalarm** |
+| `tests/test_success_status_guard.py`, `tests/test_resolution_loss_guard.py` | MODIFY | Ordinal-Anker nachziehen (Assertion nicht aufweichen) |
+
+## Scope Assessment
+
+- Dateien: 6 produktiv (1 neu) + 1 ADR + ~6 Testdateien
+- **Produktiv: ~150–180 hinzugefuegte/geaenderte Zeilen** → passt in 250
+- **Tests: ~700–900 Zeilen** → **sprengt das Standard-Testbudget von 500**
+- Risiko: **HOCH** — kritischer Alarmpfad, zwei bewusste Verhaltensaenderungen
+
+## Reihenfolge der Arbeit
+
+1. `check_official_alert_gate` + eigene Tests **zuerst**, bevor ein Aufrufer angefasst wird.
+2. **Trip zuerst** (der heiklere Fall): erst der Regressionstest „Aenderungsalarm um T, amtliche
+   Eskalation um T+15 min wird zugestellt" mit echt befuelltem `ThrottleStore`-Scope `"trip"`, dann der Umbau.
+3. Dann Compare (nur Reihenfolge-Wechsel, profitiert von der geschaerften Test-Vorlage).
+4. Ordinal-Waechter **nach jedem** der beiden Umbauten laufen lassen, nicht erst am Ende.
+5. Preset-Helfer zum Schluss (reine Strukturverschiebung, faesst dieselben Dateien noch einmal an).
+6. ADR-Nachtrag zuletzt, wenn das Verhalten feststeht.
+
+## Risiken (aus Nutzersicht formuliert)
+
+- **R-A:** Ist die Zonenaufloesung oder der Zaehlerstand im neuen Gate falsch, bleibt der Lauf
+  **komplett stumm** — vorher waere wenigstens der Abruf gelaufen und die Symptome sichtbar gewesen.
+  Gegenmittel: Nachweis bei Zaehlerstand 0 **und** Limit-1.
+- **R-B:** Bleibt `_is_throttled_with_cooldown` versehentlich im amtlichen Aufrufpfad, bekommt der
+  Nutzer die Eskalation weiterhin nicht. Gegenmittel: Regressionstest aus Schritt 2.
+- **R-C:** Zieht jemand `is_silenced` spaeter „vereinheitlichend" ins Gate, aendert sich das
+  Trip-Verhalten still. Gegenmittel: Test, der `is_silenced` ausdruecklich **ausserhalb** nachweist.
+- **R-D:** Ein rot gewordener Ordinal-Waechter, der „korrigiert" statt verstanden wird, kann eine
+  echte verlorene Fehlerbehandlung durchwinken — dann bleibt bei einem defekten Ortsdatensatz die
+  Fehlermeldung aus.
+- **R-E:** `_day_window_end()` wird **nicht angefasst**. Wandert es beim Umbau versehentlich mit,
+  verliert der Nutzer nach 19 Uhr Ortszeit Warnungen (nullbreites Fenster, R4a).
+
+## Open Questions (PO)
+
+- [ ] E1: nur das **Lesen** des Trip-Cooldowns streichen (Empfehlung) oder Lesen **und** Schreiben?
+- [ ] Test-Budget von 500 auf **900** anheben — sonst muss S4a in zwei Lieferungen zerfallen.
+
+## Nicht-Ziele (ausdruecklich)
+
+- **#1599** (Tagesfenster-Obergrenze: Anzeige zaehlt Stunde 19 mit, der Alarm nicht) ist eine offene
+  **Bedeutungsfrage** mit drei gleichwertigen Auswegen und widerspricht einer bereits freigegebenen
+  AC aus #1584. S4a entscheidet sie **nicht** und darf ihr Ergebnis nicht vorwegnehmen.
+- **#1744 Scheibe B** (Entdopplung nach Ereignis-Identitaet ueber Quellen hinweg) ist S4b.
+- **Datenbeschaffung wird nicht fusioniert.** Radar- und amtliche Quellen bleiben technisch
+  eigenstaendig; zusammengelegt wird die Ablaufsteuerung.
+- Compare-eigen bleiben: Orte statt Etappen, transponierte Uebersicht, Compare-Mail-Template,
+  Buendelung aller getriggerten Orte in EINE Nachricht, Empfaenger als Preset-Attribut, Ortszeit-Bezug.
+- Kein Vorgriff auf #1714, #1697, #1695 (offene Alarm-Issues in derselben Flaeche).
+- **Der Trip-Warnungsabruf wird nicht vorgezogen** (`trip_alert.py:479`) — er sitzt im Sammel-Lauf
+  ueber alle Trips, an ganz anderer Stelle; das waere ein eigener Umbau. → Sammel-Issue #1199.
+- **`_day_window_end()` wird nicht angefasst.** Sein Abendverhalten (nullbreites Fenster nach
+  Fensterende) ist heute von keinem Test gehalten — das ist ein Befund, kein Auftrag. → #1199.
+- **Unterdrueckungsgruende bleiben Nowcast-only** (E3); der S3-Waechter bleibt unveraendert.

--- a/docs/reference/critical_lessons.md
+++ b/docs/reference/critical_lessons.md
@@ -30,7 +30,7 @@ Quelle: `docs/specs/_archive/modules/issue_1034_official_alerts_foundation.md` (
 
 Ein Test, der zusichert „Alarm wird zugestellt", muss den Trip so bauen, dass
 **kein geplantes Briefing fällig ist** — sonst greift die Vorlaufsperre aus
-#1594 (`src/services/trip_alert.py:241` → `src/services/alert_gate.py:200` →
+#1594 (`src/services/trip_alert.py:241` → `src/services/alert_gate.py:256` →
 `trip_briefing_due_at`), der Alarm wird planmäßig durch das Briefing **ersetzt**
 (ADR-0009), und der Test scheitert an einer nirgends ausgesprochenen Annahme.
 Weil die Vorgabezeiten 07:00/18:00 Ortszeit bei drei Stunden Fälligkeitsfenster

--- a/docs/specs/modules/rework_1467_s4a_amtlich.md
+++ b/docs/specs/modules/rework_1467_s4a_amtlich.md
@@ -1,0 +1,497 @@
+---
+entity_id: rework_1467_s4a_amtlich
+type: refactor
+created: 2026-08-16
+updated: 2026-08-16
+status: draft
+version: "1.0"
+tags: [alerts, trip, compare, epic-1458, issue-1467, s4a, amtlich]
+---
+
+# Amtlicher Alarmpfad: gemeinsame Freigabe-Steuerung für Trip und Ortsvergleich (Issue #1467 Scheibe S4a, Epic #1458 Teil 4a)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Der amtliche Alarmpfad (offizielle Wetterwarnung, z. B. GELB→ORANGE) läuft heute für Trip
+und Ortsvergleich durch zwei eigenständige, an mehreren Stellen unbegründet abweichende
+Prüfketten (`compare_official_alert.py::_check_one_preset` bzw.
+`trip_alert.py::_send_official_alert_only`). Diese Scheibe zieht beide auf denselben
+geteilten Freigabe-Baustein `src/services/alert_gate.py`, den S3 bereits für den
+Nowcast-Pfad eingeführt hat (`check_nowcast_gate`). Sie ist damit die **vierte** von vier
+Scheiben in #1467 — genauer: ihr **erster** Teil (S4a); die Entdopplung nach
+Ereignis-Identität (#1744 Scheibe B) folgt als S4b und schließt #1467 erst dann.
+
+Zwei nutzersichtbare Wirkungen sind bewusst gewollt (PO-Entscheidungen E1/E2,
+2026-08-16), der Rest der Scheibe hält Verhalten unverändert:
+
+- **E1 (Kernfall):** Der amtliche Trip-Pfad liest den geteilten `ThrottleStore`-Scope
+  `"trip"` künftig nicht mehr. Heute unterdrückt ein zugestellter Änderungsalarm eine
+  nachfolgende amtliche Eskalation für denselben Trip bis zu 120 Minuten — das ist die
+  Wirkung, die das Issue für den Ortsvergleich ausdrücklich ausschließt und die dieser
+  Umbau für den Trip nachzieht. Geschrieben wird der Topf weiterhin (siehe Invarianten).
+- **E2:** Der Ortsvergleich prüft die Tages-Obergrenze künftig VOR statt nach dem
+  Warnungs-Abruf — ein erschöpftes Kontingent kostet dann keinen Fremd-Abruf mehr gegen
+  eine Datenquelle, die produktiv bereits an ihr Tageslimit stößt (belegt in
+  `docs/specs/modules/warn_service_consumption.md:22-28`,
+  `docs/specs/modules/fix_1397_meteoalarm_coverage_budget.md`).
+
+Zusätzlich werden die drei wortgleichen Compare-Helfer (`_load_presets()` und
+`_notification_service_for()` in `compare_alert.py`, `compare_radar_alert.py`,
+`compare_official_alert.py`) zu einer gemeinsamen Fassung zusammengeführt.
+
+**Leitsatz, unverändert aus S1–S3 übernommen:** Der gefährlichste Fehler ist der
+ausbleibende Alarm. Zielmarke ist „Verhalten unverändert", außer den ausdrücklich in
+dieser Spec benannten Änderungen E1/E2.
+
+## Source
+
+- **File:** `src/services/alert_gate.py`
+- **Identifier:** neue Funktion `check_official_alert_gate`
+
+Betroffene Schicht: ausschließlich **Python-Core** (`src/services/`). Kein Go-Code, kein
+Frontend-Code.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `rework_1467_s3_nowcast` | module | Vorgänger-Scheibe (live) — liefert `alert_gate.py`, `GateResult`-Muster, `check_briefing_imminent`; diese Scheibe erweitert dieselbe Datei um eine zweite, unabhängige Funktion |
+| `rework_1467_s2_aenderungsalarm` | module | liefert `compare_alert_guard.is_silenced`, `compare_alert_channels.effective_compare_channels`, beide hier unangetastet |
+| `ThrottleStore` | module | Sperrzeit-Ablage; Scope `"trip"` bleibt Schreibziel des amtlichen Trip-Pfads, wird aber nicht mehr gelesen |
+| `alert_daily_limit` | module | Tages-Obergrenze für amtliche Alarme, geteilter Zähler über Trip und Ortsvergleich |
+| `alert_log` | module | `append_entry`, `REASON_*`-Konstanten — bleiben für den amtlichen Pfad unbenutzt (E3) |
+| `DeviationAlertEngine.is_quiet_hours` | module | Ruhezeit-Prüfung, wird vom neuen Baustein unverändert durchgereicht |
+| `fix_1594_alarm_vorlauf_sperre` | module | `check_briefing_imminent()` — bleibt in beiden Pfaden ein eigener, unveränderter Aufruf |
+| `compare_alert_guard.is_silenced` | module | Stilllegungs-Riegel, bleibt Compare-eigen und außerhalb des geteilten Gates |
+| `NotificationService` | module | Kanal-Fan-out — unverändert |
+| `official_alerts.get_official_alerts_for_location` | module | Warnungs-Abruf; beim Ortsvergleich künftig NACH dem Gate statt davor |
+
+## Estimated Scope
+
+- **LoC produktiv:** ~150–180 (Baustein `check_official_alert_gate` ~40–60,
+  `compare_official_alert.py`-Umbau ~+10–20, `trip_alert.py`-Umbau netto ~−15,
+  neues Modul `compare_preset_access.py` ~40–60, drei Wrapper-Umbauten in
+  `compare_alert.py`/`compare_radar_alert.py`/`compare_official_alert.py` ~−10 je Datei,
+  ADR-Nachtrag zählt nicht mit). Passt unter das 250er-Budget.
+- **LoC Tests:** ~700–900, **Budget vom PO auf 1000 angehoben** (Begründung: zwei
+  kritische Pfade × zwei bewusste Verhaltensänderungen × Mandantentrennungs-Nachweis).
+- **Files:** 1 neu (`compare_preset_access.py`), 5 produktiv geändert
+  (`alert_gate.py`, `compare_official_alert.py`, `trip_alert.py`, `compare_alert.py`,
+  `compare_radar_alert.py`), 1 ADR-Nachtrag, ~6 Testdateien geändert/neu.
+- **Effort:** high.
+- **Risiko:** HOCH — kritischer amtlicher Alarmpfad, zwei bewusste
+  Verhaltensänderungen gleichzeitig in zwei unterschiedlichen Consumern.
+
+## Implementation Details
+
+### Neuer Baustein: `check_official_alert_gate`
+
+```python
+def check_official_alert_gate(
+    *, user_id: str, quiet_from: Optional[str], quiet_to: Optional[str],
+    context_label: str, now: datetime, zone: ZoneInfo,
+) -> GateResult:
+```
+
+Zwei Stufen, Abbruch bei der ersten: **Ruhezeit → Tages-Obergrenze**. Die Funktion kennt
+**keinen** Cooldown-Parameter — anders als bei `check_nowcast_gate` (S3) ist das hier kein
+Implementierungsdetail, sondern die zentrale Zusicherung dieser Scheibe: ein amtlicher
+Alarm kann strukturell nicht an einem Cooldown scheitern, weil die Funktion gar keinen
+kennt (AC-3). `GateResult` (aus S3) wird unverändert wiederverwendet.
+
+### Aufrufstellen
+
+| Pfad | fällt weg | tritt an die Stelle |
+|---|---|---|
+| `compare_official_alert.py::_check_one_preset` | `:120-136` (Ruhezeit inline), `:163-166` (Tageslimit inline, bisher NACH `_detect()`) | ein `check_official_alert_gate(...)` **an der Stelle der bisherigen Ruhezeit-Prüfung** — also nach `is_silenced` (`:100`), **vor** `check_briefing_imminent` (`:144`) und **vor** `_detect()` (`:159`) — E2 |
+| `trip_alert.py::_send_official_alert_only` | `:1485-1487` (Ruhezeit), `:1494-1496` (**Cooldown-Lesen**, Scope `"trip"`), `:1497-1501` (Tageslimit) | ein `check_official_alert_gate(...)` **an der Stelle der bisherigen Ruhezeit-Prüfung** (`:1485`), also **vor** `_is_briefing_imminent` (`:1491`) — E1 |
+
+**Die Ruhezeit bleibt in beiden Pfaden die erste Stufe.** Das ist keine Feinheit: `trip_alert.py`
+hält bei `:1487-1490` ausdrücklich fest, dass die Briefing-Sperre aus #1594 „dieselbe Stufe wie im
+Aenderungspfad, gleiche Position (nach der Ruhezeit)" einnimmt. Ein Gate-Aufruf **nach** der
+Briefing-Sperre würde diese Festlegung still umdrehen. Der Baustein tritt deshalb dorthin, wo heute
+die Ruhezeit steht — nicht dahinter.
+
+**Folge, die ausdrücklich genannt gehört:** Weil die Tages-Obergrenze im Baustein steckt, wandert
+sie damit in beiden Pfaden **vor** die Briefing-Sperre. Das ist wirkungsfrei, weil `is_allowed()`
+rein lesend ist — gebucht wird ausschließlich über `increment()`, und das läuft unverändert erst
+nach erfolgreicher Zustellung (AC-15).
+
+`check_briefing_imminent` bleibt in beiden Pfaden ein **eigener** Aufruf, unmittelbar nach dem
+Gate (seit #1594 geteilt). `_throttle_store.record("trip", …)` bei `trip_alert.py:1539`
+**bleibt bestehen** — nur das Lesen (`:1494`) entfällt, das Schreiben nicht (E1,
+Begründung: die harmlose Richtung „ein Änderungsalarm weniger" bleibt unangetastet,
+weil das richtige Werkzeug dafür S4b/#1744 B ist, nicht eine pauschale Zeitsperre).
+`_is_throttled_with_cooldown` bleibt als Methode bestehen — weiter genutzt vom
+Änderungsalarm (`:246`) und von `get_time_until_next_alert`.
+
+### Geteilter Compare-Helfer
+
+Neues Modul `src/services/compare_preset_access.py`:
+
+```python
+def load_compare_alert_presets(user_id: str) -> list[ComparePreset]: ...
+
+def notification_service_for_preset(
+    settings, user_id: str, preset: ComparePreset, *, log_label: str,
+) -> NotificationService: ...
+```
+
+Die drei Bestandsmethoden `_load_presets()` und `_notification_service_for()` in
+`compare_alert.py`, `compare_radar_alert.py`, `compare_official_alert.py` werden
+Ein-Zeiler-Wrapper. `log_label` trägt die einzige echte Abweichung zwischen den drei
+Aufrufern (`"Compare-Alert:"` / `"Compare-Alert (Radar):"` / `"Compare-Alert
+(amtlich):"`) — dasselbe Parametermuster wie `context_label` in `alert_gate.py`.
+
+## Invarianten
+
+- **Der gefährlichste Fehler ist der ausbleibende Alarm.** Zielmarke: Verhalten
+  unverändert außer E1 (Trip-Cooldown-Lesen entfällt) und E2 (Ortsvergleich prüft
+  Tageslimit vor dem Abruf).
+- **Reihenfolge im Baustein ist fest:** Ruhezeit → Tages-Obergrenze, Abbruch beim ersten
+  Treffer. Kein dritter Parameter, keine dritte Stufe.
+- **`check_official_alert_gate` kennt keinen Cooldown-Parameter** — die Zusicherung ist
+  eine Eigenschaft des Funktionstyps, nicht eine Disziplin der Aufrufstelle.
+- **Der amtliche Trip-Pfad schreibt weiterhin in den `"trip"`-Sperrzeit-Topf**
+  (`trip_alert.py:1539` bleibt unverändert bestehen) — nur das Lesen entfällt.
+- **Zähler-Reihenfolge:** Tageszähler-Erhöhung und Sperrzeit-Schreiben laufen NIEMALS vor
+  der erfolgreichen Zustellung.
+- **`is_silenced` bleibt außerhalb des geteilten Gates**, Compare-eigen, und wirkt
+  weiterhin VOR allem anderen im Ortsvergleich-Pfad.
+- **Trips prüfen `paused_at`/`archived_at` im Alarmpfad weiterhin nicht** (Absicht seit
+  #995) — ein pausierter Trip pausiert nur den Briefing-Versand, nicht den Alarm.
+- **Der amtliche Pfad protokolliert keine Unterdrückungsgründe** — der S3-Wächter
+  `tests/tdd/test_nowcast_suppression_logging.py::test_ac9_amtlicher_alarm_bekommt_keinen_unterdrueckungs_grund`
+  bleibt unverändert grün.
+- **`_day_window_end()` (`compare_official_alert.py:276`) wird nicht angefasst** — kein
+  Zeichen Diff.
+- Mandantentrennung: jeder Teil mit ZWEI verschiedenen Nutzern verifiziert, `user_id`
+  nie auf `"default"` zurückfallen lassen.
+- Datenbeschaffung wird NICHT fusioniert — Trip und Ortsvergleich holen weiterhin
+  getrennt amtliche Warnungen.
+- Bestandsdaten: Read-Modify-Write mit Merge, nie Replace.
+- Testpolitik: kein Mock-Theater, keine Dateiinhalt-Checks als Verhaltensnachweis
+  (Ausnahme: `# doc-compliance-test` für den ADR-Nachtrag-Nachweis, AC-19).
+- Testdateien nach VERHALTEN benennen, nie nach Issue-Nummer.
+
+## Nicht-Ziele (ausdrücklich)
+
+- **#1599** (Tagesfenster-Obergrenze: Anzeige zählt Stunde 19 mit, der Alarm nicht) ist
+  eine offene Bedeutungsfrage mit drei gleichwertigen Auswegen. S4a entscheidet sie
+  **nicht** und darf ihr Ergebnis nicht vorwegnehmen.
+- **#1744 Scheibe B** (Entdopplung nach Ereignis-Identität über Quellen hinweg) ist S4b
+  und schließt #1467. S4a schließt #1467 **nicht**.
+- **Datenbeschaffung wird nicht fusioniert.** Radar- und amtliche Quellen bleiben
+  technisch eigenständig; zusammengelegt wird nur die Ablaufsteuerung.
+- **Der Trip-Warnungsabruf wird nicht vorgezogen** (`trip_alert.py:479`) — er sitzt im
+  Sammel-Lauf über alle Trips, an ganz anderer Stelle; das wäre ein eigener Umbau.
+  → Sammel-Issue #1199.
+- **`_day_window_end()` wird nicht angefasst.** Ihr Abendverhalten (nullbreites Fenster
+  nach Fensterende) ist heute von keinem Test gehalten — das ist ein Befund, kein
+  Auftrag dieser Scheibe. → #1199.
+- **Unterdrückungsgründe bleiben Nowcast-only** (E3) — der amtliche Pfad protokolliert
+  weiterhin keine, der S3-Wächter bleibt unverändert.
+- Compare-eigen bleiben: Orte statt Etappen, transponierte Übersicht,
+  Compare-Mail-Template, Bündelung aller getriggerten Orte in EINE Nachricht,
+  Empfänger als Preset-Attribut, Ortszeit-Bezug.
+- Kein Vorgriff auf #1714, #1697, #1695 (offene Alarm-Issues in derselben Fläche).
+- Kein neuer Go-Endpunkt, kein neuer Cron-Job. Kein Frontend-Code.
+
+## Reihenfolge der Arbeit
+
+1. `check_official_alert_gate` + eigene Tests **zuerst**, bevor ein Aufrufer angefasst
+   wird.
+2. **Trip zuerst** (der heiklere Fall): erst der Regressionstest „Änderungsalarm um T,
+   amtliche Eskalation um T+15 min wird zugestellt" mit echt befülltem
+   `ThrottleStore`-Scope `"trip"`, dann der Umbau.
+3. Dann Compare (Reihenfolge-Wechsel Tageslimit-vor-Abruf), profitiert von der
+   geschärften Test-Vorlage aus Schritt 2.
+4. Ordinal-Wächter **nach jedem** der beiden Umbauten laufen lassen, nicht erst am Ende.
+5. Preset-Helfer zum Schluss (reine Strukturverschiebung, fasst dieselben Dateien noch
+   einmal an).
+6. ADR-Nachtrag zuletzt, wenn das Verhalten feststeht.
+
+## Risiken
+
+| | Risiko (aus Nutzersicht) | Gegenmittel |
+|---|---|---|
+| **R-A** | Ist die Zonenauflösung oder der Zählerstand im neuen Gate falsch, bleibt der Lauf komplett stumm — vorher wäre wenigstens der Abruf gelaufen und die Symptome sichtbar gewesen. | Nachweis bei Zählerstand 0 **und** Limit-1 (AC-7, AC-15). |
+| **R-B** | Bleibt `_is_throttled_with_cooldown` versehentlich im amtlichen Aufrufpfad, bekommt der Nutzer die Eskalation weiterhin nicht. | Regressionstest aus Reihenfolge-Schritt 2 (AC-4, Mutations-Gegenprobe). |
+| **R-C** | Zieht jemand `is_silenced` später „vereinheitlichend" ins Gate, ändert sich das Trip-Verhalten still (Trips kennen `is_silenced` gar nicht). | Test, der `is_silenced` ausdrücklich **außerhalb** des Gates nachweist (AC-9). |
+| **R-D** | Ein rot gewordener Ordinal-Wächter, der „korrigiert" statt verstanden wird, kann eine echte verlorene Fehlerbehandlung durchwinken — dann bleibt bei einem defekten Ortsdatensatz die Fehlermeldung aus. | Wächter-Lauf nach jedem Umbau-Schritt, Diff-Review der Wächter-Datei selbst (AC-18). |
+| **R-E** | `_day_window_end()` wird nicht angefasst — wandert sie beim Umbau versehentlich mit, verliert der Nutzer nach 19 Uhr Ortszeit Warnungen (nullbreites Fenster). | Diff-Nachweis „keine Änderung" (AC-17). |
+
+## Wächter, die mitziehen müssen
+
+| Test | Warum |
+|---|---|
+| `tests/tdd/test_alert_gate.py` | bekommt die neuen Reihenfolge-Fälle für `check_official_alert_gate` dazu; bestehende `check_nowcast_gate`-Fälle bleiben unverändert grün |
+| `tests/tdd/test_nowcast_suppression_logging.py::test_ac9_amtlicher_alarm_bekommt_keinen_unterdrueckungs_grund` | bleibt **unverändert** grün (E3) — NICHT anfassen |
+| `tests/tdd/test_compare_official_alert_briefing_imminent.py::test_ac4_sperre_greift_vor_dem_warnungs_abruf` | Sperre-vor-Abruf-Reihenfolge, jetzt um Tageslimit-vor-Abruf ergänzt |
+| `tests/tdd/test_compare_official_alert.py` | AC-1 bis AC-8 des Ortsvergleich-Pfads, Messpunkte für die neue Reihenfolge nachziehen |
+| `tests/tdd/test_issue_1088_official_alert_triggers.py` | Trip-Auslöser, plus der neue Kernfall-Regressionstest (AC-4) |
+| `tests/test_success_status_guard.py`, `tests/test_resolution_loss_guard.py` | verankern `compare_radar_alert.py`/`compare_alert.py`/`compare_official_alert.py` per `datei::funktion::ordinal` — Schlüssel nachziehen, Assertion nicht aufweichen |
+
+## Test-Plan
+
+Kern-Schicht (deterministisch, kein Netz), sofern nicht anders vermerkt.
+
+| AC | Datei | Schicht |
+|---|---|---|
+| AC-1, AC-2, AC-3 (Baustein-Struktur) | `tests/tdd/test_alert_gate.py` | Kern |
+| AC-4 (Kernfall) | `tests/tdd/test_issue_1088_official_alert_triggers.py` (neuer Fall) | Kern |
+| AC-5, AC-6 (Gegenprobe, Änderungsalarm-Regression) | `tests/tdd/test_trip_alert_cooldown_scope.py` (neu) | Kern |
+| AC-7, AC-8 (Ortsvergleich Tageslimit vor Abruf) | `tests/tdd/test_compare_official_alert_daily_limit_order.py` (neu) | Kern |
+| AC-9 (is_silenced außerhalb) | `tests/tdd/test_compare_official_alert.py` (Bestand, ergänzt) | Kern |
+| AC-10 (paused_at ungeprüft) | `tests/tdd/test_issue_1088_official_alert_triggers.py` (neuer Fall) | Kern |
+| AC-11 (keine Protokollierung) | `tests/tdd/test_nowcast_suppression_logging.py` (Bestand, unverändert grün) | Kern |
+| AC-12 (check_briefing_imminent eigenständig) | `tests/tdd/test_compare_official_alert_briefing_imminent.py` (Bestand, ergänzt) | Kern |
+| AC-13, AC-14 (geteilter Compare-Helfer) | `tests/tdd/test_compare_preset_access.py` (neu) | Kern |
+| AC-15 (Zähler-Invariante) | `tests/tdd/test_alert_gate.py` (neuer Fall) | Kern |
+| AC-16 (Mandantentrennung) | `tests/tdd/test_alert_gate.py` (neu, zwei Nutzer-Kontexte) | Kern |
+| AC-17 (`_day_window_end` unverändert) | `tests/tdd/test_compare_official_alert.py` (Diff-Nachweis + Verhaltensfall) | Kern |
+| AC-18 (Ordinal-Wächter) | `tests/test_success_status_guard.py`, `tests/test_resolution_loss_guard.py` gezielt laufen lassen | Kern |
+| AC-19 (ADR-Nachtrag) | `tests/test_adr_index_drift.py` bzw. gezielter `# doc-compliance-test` | Kern |
+
+Live-E2E: keine eigenen Live-Marker-Tests vorgesehen — echte amtliche Eskalationen sind
+nicht auf Bestellung provozierbar. Staging-Nachweis erfolgt über den ausgelieferten Code
+mit gezielt gesetzten Zustandsdateien (ThrottleStore-Scope `"trip"` vorbelegen,
+Tageszähler vorbelegen), nicht über „auf eine echte Warnung warten".
+
+## Acceptance Criteria
+
+**Struktur des geteilten Bausteins**
+
+- **AC-1:** Given die neue Funktion `check_official_alert_gate` in
+  `src/services/alert_gate.py`, When der Ortsvergleich-amtliche Pfad
+  (`compare_official_alert.py::_check_one_preset`) UND der Trip-amtliche Pfad
+  (`trip_alert.py::_send_official_alert_only`) je einen amtlichen Alarm prüfen, Then
+  rufen beide dieselbe Funktion auf — nicht zwei eigene Inline-Prüfungen wie vor dieser
+  Scheibe.
+  - Test: Aufrufzähler (Spion) auf `check_official_alert_gate`, für jeden Pfad
+    mindestens 1 Aufruf je Lauf.
+
+- **AC-2:** Given eine Konstellation, in der sowohl Ruhezeit als auch Tages-Obergrenze
+  gleichzeitig zuträfen, When `check_official_alert_gate` geprüft wird, Then stoppt der
+  Ablauf an der Ruhezeit — die Tages-Obergrenze-Prüfung wird für diesen Aufruf gar nicht
+  erst erreicht.
+  - Test: Ruhezeit AN + Tageslimit erschöpft gleichzeitig, Aufrufzähler der
+    Tageslimit-Prüfung bleibt bei 0.
+  - Mutations-Gegenprobe (Pflicht): Reihenfolge im Baustein vertauschen (Tages-Obergrenze
+    vor Ruhezeit) MUSS diesen Test rot machen.
+
+- **AC-3:** Given die Funktionssignatur von `check_official_alert_gate`, When man die
+  Parameterliste inspiziert, Then existiert kein Parameter, der einen Cooldown oder eine
+  Sperrzeit an die Funktion übergibt — die Zusicherung „amtlich hat keinen Cooldown" ist
+  eine Eigenschaft der Funktion, nicht eine Disziplin der Aufrufstelle.
+  - Test: `inspect.signature(check_official_alert_gate)`, kein Parametername enthält
+    „cooldown"/„throttle"/„sperr".
+
+**Der Kernfall: Trip-Cooldown-Lesen entfällt (E1)**
+
+- **AC-4 (Kernfall):** Given ein Trip, für den um Zeitpunkt T ein Änderungsalarm
+  zugestellt wurde (er hat den `ThrottleStore`-Scope `"trip"` für diesen Trip befüllt),
+  When 15 Minuten später (T+15) eine amtliche Warnung für denselben Trip von GELB auf
+  ORANGE eskaliert, Then wird die Eskalation zugestellt — vor dieser Scheibe wäre sie bis
+  zu 120 Minuten unterdrückt worden, weil der amtliche Pfad denselben Sperrzeit-Topf
+  gelesen hat.
+  - Test: `ThrottleStore`-Scope `"trip"` mit einem frischen Eintrag zu T vorbelegen
+    (simuliert den zugestellten Änderungsalarm), amtliche GELB→ORANGE-Eskalation zu T+15
+    auslösen, Zustellung erfolgt auf mindestens einem Kanal.
+  - Mutations-Gegenprobe (Pflicht): das Lesen von Scope `"trip"` im amtlichen Pfad wieder
+    einbauen (Zeile `trip_alert.py:1494` reaktivieren) MUSS diesen Test rot machen.
+
+- **AC-5 (Gegenprobe zu AC-4, harmlose Richtung bleibt zu):** Given derselbe Trip, dessen
+  amtlicher Alarm aus AC-4 gerade erfolgreich zugestellt wurde, When man danach den
+  Zustand des `ThrottleStore`-Scopes `"trip"` betrachtet, Then enthält er einen neuen
+  Eintrag für diesen Trip — das Schreibverhalten des amtlichen Pfads ist unverändert
+  (`trip_alert.py:1539` bleibt bestehen), sodass ein nachfolgender Änderungsalarm für
+  denselben Trip innerhalb des Cooldowns wie bisher unterdrückt bleibt.
+  - Test: amtlichen Alarm zustellen, `ThrottleStore`-Snapshot davor/danach vergleichen —
+    neuer Eintrag Scope `"trip"`/`trip.id`; anschließend einen Änderungsalarm-Check für
+    denselben Trip simulieren, er bleibt unterdrückt (unverändert gegenüber vor der
+    Scheibe).
+
+- **AC-6 (Regression, Änderungsalarm-Drosselung unverändert):** Given den
+  Änderungsalarm-Pfad selbst (`trip_alert.py:246`), When identische
+  Drosselungs-Szenarien vor und nach dieser Scheibe durchlaufen werden, Then bleibt sein
+  Zustellverhalten unverändert — diese Scheibe rührt nur den amtlichen Lesezugriff an,
+  nicht den Änderungsalarm-Pfad selbst.
+  - Test: bestehende Änderungsalarm-Cooldown-Tests unverändert und grün ausführen; kein
+    neuer Testfall nötig, aber der Lauf ist Teil des Nachweises dieser Scheibe.
+
+**Ortsvergleich: Tages-Obergrenze vor dem Abruf (E2)**
+
+- **AC-7:** Given einen Ortsvergleich-Nutzer, dessen Tages-Obergrenze für amtliche Alarme
+  bereits erreicht ist, When für ein Preset dieses Nutzers eine neue amtliche Warnung
+  anstünde, Then wird KEIN Warnungs-Abruf (`get_official_alerts_for_location`)
+  ausgelöst — nachweisbar am Aufrufzähler der Abruf-Naht, nicht nur am Ausbleiben der
+  Zustellung.
+  - Test: Tageszähler auf das Limit vorbelegen, Lauf ausführen, Aufrufzähler der
+    Abruf-Naht bleibt bei 0.
+  - Mutations-Gegenprobe (Pflicht): die Reihenfolge zurücktauschen (Abruf vor Gate) MUSS
+    diesen Test rot machen.
+
+- **AC-8:** Given einen Ortsvergleich-Nutzer mit freiem Kontingent, When für ein Preset
+  eine neue oder eskalierte amtliche Warnung eintritt, Then wird sie unverändert
+  zugestellt — das Vorziehen der Prüfung ändert nichts am Zustellergebnis bei freiem
+  Kontingent.
+  - Test: Kontingent frei, neue bzw. eskalierte Warnung simulieren, Zustellung erfolgt
+    auf mindestens einem Kanal.
+
+**Was außerhalb des Gates bleibt**
+
+- **AC-9:** Given ein stillgelegtes Ortsvergleich-Preset (`is_silenced(preset) ==
+  True`), When der amtliche Ortsvergleich-Lauf für dieses Preset durchläuft, Then wird
+  `check_official_alert_gate` gar nicht erst erreicht — der Stilllegungs-Riegel wirkt
+  weiterhin VOR allem anderen und bleibt außerhalb des geteilten Bausteins.
+  - Test: Preset stilllegen, Lauf ausführen, Aufrufzähler von
+    `check_official_alert_gate` für dieses Preset bleibt bei 0.
+
+- **AC-10:** Given einen pausierten Trip (`paused_at` gesetzt), When der amtliche
+  Trip-Alarmpfad für diesen Trip läuft, Then wird der amtliche Alarm trotzdem geprüft und
+  bei Zutreffen zugestellt — Trips prüfen `paused_at` im Alarmpfad weiterhin nicht
+  (Absicht seit #995), nur der Briefing-Versand pausiert, nicht der Alarm.
+  - Test: `paused_at` auf dem Trip setzen, amtlichen Eskalations-Trigger auslösen,
+    Zustellung erfolgt trotz gesetzter Pause.
+
+- **AC-11:** Given einen amtlichen Alarm (Ortsvergleich oder Trip), der am neuen Gate an
+  Ruhezeit oder Tages-Obergrenze scheitert, When der Lauf beendet ist, Then entsteht dafür
+  KEIN Protokolleintrag mit den Unterdrückungsgründen `REASON_QUIET_HOURS` /
+  `REASON_DAILY_LIMIT` — der bestehende Wächter
+  `tests/tdd/test_nowcast_suppression_logging.py::test_ac9_amtlicher_alarm_bekommt_keinen_unterdrueckungs_grund`
+  bleibt unverändert grün.
+  - Test: bestehenden Wächter unverändert ausführen (Fortbestand des grünen Zustands als
+    Nachweis) plus einen gezielten Aufruf des amtlichen Trip-Pfads mit erzwungener
+    Unterdrückung, Protokoll enthält keinen neuen Grund-Eintrag.
+
+- **AC-12:** Given beide amtlichen Pfade, When man ihre Aufrufreihenfolge zur Laufzeit
+  beobachtet, Then läuft `check_official_alert_gate` als ERSTE Stufe (dort, wo bisher die
+  Ruhezeit-Prüfung stand) und `check_briefing_imminent` unmittelbar danach als weiterhin
+  eigener Aufruf — die Ruhezeit bleibt damit vor der Briefing-Sperre, wie es
+  `trip_alert.py:1487-1490` seit #1594 ausdrücklich festhält, und die Briefing-Sperre wird
+  NICHT in `check_official_alert_gate` verschmolzen.
+  - Test: Aufruf-Sequenz-Spionage weist in BEIDEN Pfaden die Reihenfolge
+    `check_official_alert_gate` → `check_briefing_imminent` nach; ein reiner Quellcode-Grep
+    genügt nicht als Nachweis, entscheidend ist die Laufzeit-Reihenfolge.
+  - Mutations-Gegenprobe (Pflicht): die beiden Aufrufe vertauschen (Briefing-Sperre vor dem
+    Gate) MUSS diesen Test rot machen — sonst bewacht er die Reihenfolge nicht, sondern nur
+    das Vorhandensein beider Aufrufe.
+
+- **AC-12b:** Given einen amtlichen Alarm, bei dem gleichzeitig die Tages-Obergrenze
+  erschöpft ist UND ein Briefing unmittelbar bevorsteht, When der Lauf durchläuft, Then
+  wird nichts zugestellt und der Tageszähler bleibt unverändert — das Vorziehen der
+  Tages-Obergrenze vor die Briefing-Sperre ist wirkungsfrei, weil die Prüfung rein lesend
+  ist und erst `increment()` nach erfolgreicher Zustellung bucht.
+  - Test: beide Bedingungen gleichzeitig herstellen, Zähler-Snapshot vor/nach dem Lauf
+    vergleichen, exakte Gleichheit; zusätzlich derselbe Fall mit freiem Kontingent, der
+    ebenfalls nichts zustellt (Briefing-Sperre greift), aber aus dem anderen Grund.
+
+**Geteilter Compare-Helfer**
+
+- **AC-13:** Given die drei Compare-Alarmpfade (Änderungsalarm, Nowcast, amtlich), When
+  jeder von ihnen seine Presets lädt und seinen Notification-Service aufbaut, Then rufen
+  alle drei denselben Helfer (`compare_preset_access.load_compare_alert_presets` /
+  `notification_service_for_preset`) auf — die drei Bestandsmethoden sind Ein-Zeiler-
+  Wrapper geworden, keine eigenständigen Implementierungen mehr.
+  - Test: Aufrufzähler auf die neuen Helferfunktionen, je Pfad mindestens 1 Aufruf pro
+    Lauf.
+
+- **AC-14:** Given die drei Compare-Alarmpfade lösen im selben Lauf je eine Warnung für
+  dasselbe Preset aus, When man die drei zugestellten Warntexte vergleicht, Then bleibt
+  jeder Text weiterhin unterscheidbar (Präfix „Compare-Alert:" / „Compare-Alert
+  (Radar):" / „Compare-Alert (amtlich):") — die Zusammenlegung ändert die Struktur, nicht
+  den Nutzertext.
+  - Test: alle drei Pfade in einem Lauf auslösen, drei zugestellte Nachrichten, drei
+    unterschiedliche, den Alarmtyp benennende Präfixe.
+
+**Zähler-Invariante, Mandantentrennung, Unveränderlichkeit**
+
+- **AC-15:** Given einen amtlichen Alarm-Versuch, bei dem die tatsächliche Zustellung
+  fehlschlägt (kein Kanal erreichbar), When der Lauf beendet ist, Then sind weder der
+  Tageszähler noch — beim Trip — der `"trip"`-Sperrzeit-Eintrag für diese Entität
+  erhöht bzw. gesetzt worden.
+  - Test: alle Kanäle unerreichbar simulieren, Zähler-Snapshot vor/nach dem Lauf
+    vergleichen, exakte Gleichheit.
+
+- **AC-16:** Given zwei verschiedene Nutzer mit je einem Trip bzw. Ortsvergleich-Preset
+  gleicher Kennung, deren Tages-Obergrenze für amtliche Alarme unabhängig geführt wird,
+  When Nutzer A sein Kontingent ausschöpft und Nutzer B unabhängig davon eine eigene
+  amtliche Warnung auslöst, Then wirkt die Sperre von A nicht auf B — B erhält seine
+  Warnung, ohne dass ein Rückfall auf `"default"` stattfindet.
+  - Test: zwei Datenverzeichnisse (`user_id` A/B), gleiche Preset-/Trip-Kennung, A's
+    Kontingent erschöpfen, B's amtliche Warnung geht trotzdem durch.
+
+- **AC-17:** Given `compare_official_alert.py::_day_window_end()`, When man ihren
+  Quellcode vor und nach dieser Scheibe vergleicht, Then ist sie textidentisch
+  unverändert — ihr Verhalten (auch das nullbreite Fenster nach Fensterende) bleibt exakt
+  wie vor der Scheibe.
+  - Test: Diff der Methode gegen den Stand vor der Scheibe ist leer; zusätzlich ein
+    Verhaltensfall, der ein Fenster nach 19 Uhr Ortszeit prüft und das bekannte
+    nullbreite Ergebnis unverändert bestätigt.
+
+- **AC-18:** Given `tests/test_success_status_guard.py` und
+  `tests/test_resolution_loss_guard.py`, die `compare_radar_alert.py`,
+  `compare_alert.py` und `compare_official_alert.py` per
+  `datei::funktion::ordinal` verankern, When diese Scheibe abgeschlossen ist, Then laufen
+  beide Wächter unverändert grün — eine durch den Umbau verschobene Ordinal-Zählung wurde
+  über nachgezogene Schlüssel aufgefangen, keine Assertion wurde aufgeweicht.
+  - Test: beide Wächterdateien gezielt ausführen, Exit 0; Diff der Wächterdateien zeigt
+    ausschließlich Schlüssel-/Ordinal-Anpassungen, keine geänderten Erwartungswerte.
+
+**Dokumentation**
+
+- **AC-19:** Given den bestehenden ADR-0021-Nachtrag zu #1467 S3, der wörtlich festhält
+  „Änderungs- und amtlicher Alarm bewusst weiterhin nicht" (bezogen auf
+  Unterdrückungs-Protokollierung), When diese Scheibe abgeschlossen ist, Then trägt
+  ADR-0021 einen neuen, datierten Nachtrag mit Bezug auf #1467 S4a, der festhält, dass
+  BEIDE amtlichen Pfade seit dieser Scheibe über denselben geteilten Ablauf-Baustein
+  laufen wie zuvor nur die Nowcast-Pfade — ohne den bestehenden Satz zur
+  Unterdrückungs-Protokollierung zu widerrufen (der bleibt laut E3 unverändert richtig).
+  - Test: `# doc-compliance-test` — ADR-0021 enthält nach dem Abschluss dieser Scheibe
+    einen Nachtrag-Absatz mit Bezug auf „#1467" und „S4a", datiert nach dem 2026-08-16.
+
+## Known Limitations
+
+- **#1599 bleibt offen.** Diese Scheibe entscheidet die Tagesfenster-Obergrenzenfrage
+  nicht und darf ihr Ergebnis nicht vorwegnehmen.
+- **Die harmlose Richtung aus E1 bleibt bestehen.** Ein amtlicher Alarm kann weiterhin
+  einen nachfolgenden Änderungsalarm für denselben Trip unterdrücken (unverändertes
+  Schreibverhalten, AC-5). Das richtige Werkzeug dafür — Entdopplung nach
+  Ereignis-Identität statt einer pauschalen Zeitsperre — liefert S4b (#1744 B), nicht
+  diese Scheibe.
+- **Der Trip-Warnungsabruf bleibt vor seiner eigenen Kontingent-Prüfung
+  (`trip_alert.py:479` vor `:1497`).** Die Asymmetrie zum Ortsvergleich (E2) wird durch
+  diese Scheibe kleiner, aber nicht beseitigt — ein Vorziehen des Trip-Abrufs wäre ein
+  eigener, größerer Umbau an anderer Stelle. → Sammel-Issue #1199.
+- **Ein Rückbau der Entdopplung (Baustein → wieder zwei getrennte Fassungen) ist mit
+  Verhaltenstests grundsätzlich nicht fangbar** — beide Fassungen könnten sich weiterhin
+  identisch verhalten. Der strukturelle Schutz liegt außerhalb dieser Spec (Code-Review).
+- **Struktur-Wächter können nach der Umsetzung nachzuziehen sein** — bei verschobener
+  Ordinal-Zählung sind die Wächter-Schlüssel anzupassen, nicht die Wächter selbst
+  aufzuweichen (R-D).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue — ADR-0021 (geteilter Auswertungskern) bekommt einen weiteren
+  Nachtrag. Der bisherige Nachtrag zu #1467 S3 hält fest: „Änderungs- und amtlicher Alarm
+  bewusst weiterhin nicht [protokollieren Unterdrückungsgründe]" — dieser Satz zur
+  Protokollierung bleibt unverändert richtig (E3). Was er heute zusätzlich impliziert
+  (dass der amtliche Pfad keinen geteilten Ablauf-Baustein nutzt), wird durch diese
+  Scheibe sachlich überholt und im neuen Nachtrag korrigiert.
+- **Rationale:** Die Ablaufsteuerung bleibt im Muster von ADR-0021 — der amtliche Pfad
+  zieht auf denselben geteilten Baustein wie der Nowcast-Pfad (S3), statt zwei
+  eigenständige Prüfketten fortzuführen. Kein neues Architekturprinzip, nur konsequente
+  Anwendung des bestehenden auf den letzten noch abweichenden Pfad.
+
+## Changelog
+
+- 2026-08-16: Initiale Spec. Vier Entscheidungen E1–E4 nach PO-Vorgabe vom 2026-08-16
+  (`docs/context/rework-1467-s4a-amtlich.md`) zugeschnitten, geteilter Baustein von
+  Anfang an mit beiden amtlichen Pfaden verdrahtet. Test-Budget vom PO auf 1000 Zeilen
+  angehoben. Zeilenangaben gegen den Ist-Stand vom 2026-08-16, Commit `098226ae`,
+  verifiziert.

--- a/src/services/alert_gate.py
+++ b/src/services/alert_gate.py
@@ -158,6 +158,62 @@ def check_nowcast_gate(
     return _ALLOWED
 
 
+def check_official_alert_gate(
+    *,
+    user_id: str,
+    quiet_from: Optional[str],
+    quiet_to: Optional[str],
+    context_label: str,
+    now: datetime,
+    zone: ZoneInfo,
+) -> GateResult:
+    """Darf fuer diese Entitaet jetzt ein AMTLICHER Alarm rausgehen?
+    (Issue #1467 Scheibe S4a)
+
+    EIN Baustein fuer BEIDE amtlichen Pfade — den Trip-Zweig
+    (`trip_alert.py::_send_official_alert_only`) und den Vergleichs-Zweig
+    (`compare_official_alert.py::_check_one_preset`).
+
+    Feste Reihenfolge, Abbruch bei der ERSTEN zutreffenden Stufe:
+
+        Ruhezeit  ->  Tages-Obergrenze
+
+    🔴 KEIN Cooldown-Parameter, und das ist hier kein Weglassen aus
+    Sparsamkeit: „ein amtlicher Alarm scheitert nie an einer Sperrzeit" ist
+    eine Eigenschaft des Funktionstyps, nicht eine Disziplin der Aufrufstelle
+    (AC-3). Der Trip-Pfad las bis S4a den geteilten Sperrzeit-Topf `"trip"`
+    mit — ein zugestellter Aenderungsalarm verschluckte damit bis zu 120
+    Minuten lang jede amtliche Eskalation (E1). Geschrieben wird der Topf
+    weiterhin, nur gelesen nicht mehr.
+
+    Die Tages-Obergrenze prueft rein lesend (`is_allowed`); gebucht wird
+    ausschliesslich per `alert_daily_limit.increment()` nach erfolgreicher
+    Zustellung — beide Aufrufstellen behalten diese Buchung an ihrer Stelle
+    (AC-15). Deshalb ist es wirkungsfrei, dass die Obergrenze mit diesem
+    Baustein in beiden Pfaden VOR die Briefing-Sperre wandert (AC-12b).
+
+    `is_quiet_hours()` wird UNVERAENDERT durchgereicht, wie bei
+    `check_nowcast_gate()`: kein eigenes `try/except` an dieser Aufrufstelle.
+
+    Der Grund im `GateResult` ist Diagnose, kein Protokoll-Auftrag: der
+    amtliche Pfad schreibt weiterhin KEINE Unterdrueckungsgruende ins
+    `alert_log` (E3, Geltungsbereich bleibt Nowcast-only).
+    """
+    if DeviationAlertEngine.is_quiet_hours(
+        now, quiet_from, quiet_to, zone, context_label=context_label
+    ):
+        logger.debug("Amtlicher Alarm unterdrueckt (Ruhezeit) fuer %s", context_label)
+        return GateResult(False, alert_log.REASON_QUIET_HOURS)
+
+    if not alert_daily_limit.is_allowed(user_id, now, zone):
+        logger.debug(
+            "Amtlicher Alarm unterdrueckt (Tages-Obergrenze) fuer %s", context_label
+        )
+        return GateResult(False, alert_log.REASON_DAILY_LIMIT)
+
+    return _ALLOWED
+
+
 def _naechste_faelligkeit(
     now: datetime,
     briefing_due_at: Callable[[datetime], bool],

--- a/src/services/compare_alert.py
+++ b/src/services/compare_alert.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from app.config import Settings
-from app.loader import compare_preset_to_dict, load_all_locations, load_compare_presets
+from app.loader import load_all_locations
 from services import alert_channel_threshold, alert_daily_limit, alert_log
 import services.alert_urgency as alert_urgency
 from services.alert_gate import check_briefing_imminent
@@ -31,6 +31,10 @@ from services.compare_alert_channels import (
 )
 from services.compare_alert_guard import is_silenced
 from services.compare_location_weather_source import CompareLocationWeatherSource
+from services.compare_preset_access import (
+    load_compare_alert_presets,
+    notification_service_for_preset,
+)
 from services.compare_slot_scheduler import presets_due_for_hour
 from services.compare_weather_snapshot import CompareWeatherSnapshotService
 from services.deviation_alert_engine import DeviationAlertEngine
@@ -574,22 +578,14 @@ class CompareAlertService:
         )
 
     def _notification_service_for(self, preset: dict) -> NotificationService:
-        """Empfänger kommen AUSSCHLIESSLICH aus den Konto-Settings des Nutzers
-        (Muster `trip_alert.py:125`). Issue #1452: `preset.empfaenger` ist inert —
-        ein preset-eigenes Override stellte an eine Adresse zu, die der Nutzer
-        in seinem Konto nie hinterlegt hat.
-
-        Fehlt `mail_to`, wird das laut gemeldet (statt stillem Skip); der Lauf
-        läuft für die übrigen Presets weiter (Spec AC-4)."""
-        if not self._settings.mail_to:
-            logger.warning(
-                "Compare-Alert: Nutzer %s hat keine Empfaenger-Adresse (mail_to) "
-                "in den Konto-Settings — Preset %s kann keine E-Mail zustellen.",
-                self._user_id, preset.get("id", ""),
-            )
-        return NotificationService(self._settings, self._user_id)
+        """Dünner Wrapper (Issue #1467 S4a) auf den geteilten Helfer
+        `compare_preset_access.notification_service_for_preset`."""
+        return notification_service_for_preset(
+            self._settings, self._user_id, preset, log_label="Compare-Alert:",
+        )
 
     def _load_presets(self) -> list[dict]:
-        # Issue #1250 Scheibe 1: zentraler Loader statt rohem json.loads.
-        return [compare_preset_to_dict(p) for p in load_compare_presets(user_id=self._user_id)]
+        """Dünner Wrapper (Issue #1467 S4a) auf den geteilten Helfer
+        `compare_preset_access.load_compare_alert_presets`."""
+        return load_compare_alert_presets(self._user_id)
 

--- a/src/services/compare_official_alert.py
+++ b/src/services/compare_official_alert.py
@@ -25,7 +25,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from app.config import Settings
-from app.loader import compare_preset_to_dict, load_all_locations, load_compare_presets
+from app.loader import load_all_locations
 from output.renderers.alert.official_alerts import (
     dedupe_official_alerts,
     official_alert_revision_verdict,
@@ -34,15 +34,18 @@ from output.renderers.alert.official_alerts import (
 )
 from services import alert_channel_threshold, alert_daily_limit, alert_log
 import services.alert_urgency as alert_urgency
-from services.alert_gate import check_briefing_imminent
+from services.alert_gate import check_briefing_imminent, check_official_alert_gate
 from services.alert_state import AlertStateService
 from services.compare_alert_channels import (
     effective_compare_channels,
     effective_compare_telegram_style,
 )
 from services.compare_alert_guard import is_silenced
+from services.compare_preset_access import (
+    load_compare_alert_presets,
+    notification_service_for_preset,
+)
 from services.compare_slot_scheduler import presets_due_for_hour
-from services.deviation_alert_engine import DeviationAlertEngine
 from services.notification_service import NotificationService
 from services.official_alerts import get_official_alerts_for_location
 from utils.timezone import first_resolvable_tz
@@ -125,14 +128,25 @@ class CompareOfficialAlertService:
         )
         # #1233: Ruhezeit unterdrueckt frueh -> kein State-Verbrauch der Warnung,
         # damit sie nach Ende der Ruhezeit noch als "neu" zugestellt wird (AC-2).
-        if DeviationAlertEngine.is_quiet_hours(
-            datetime.now(timezone.utc),
-            preset.get("alert_quiet_from"),
-            preset.get("alert_quiet_to"),
-            zone,
+        #
+        # Issue #1467 S4a: Ruhezeit UND Tages-Obergrenze stehen seither im
+        # geteilten Baustein `check_official_alert_gate` — demselben, den auch
+        # der amtliche Trip-Pfad ruft. Die Tages-Obergrenze wandert damit VOR
+        # `_detect()` (E2): ein erschoepftes Kontingent kostet keinen
+        # Warnungs-Abruf mehr gegen eine Quelle, die produktiv ohnehin an ihrem
+        # Tagesbudget haengt. Rein lesend — gebucht wird weiterhin erst nach
+        # erfolgreicher Zustellung (`alert_daily_limit.increment`, AC-15).
+        # `is_silenced` bleibt bewusst AUSSERHALB des Bausteins (AC-9): Trips
+        # kennen den Riegel nicht, und ein pausierter Trip soll weiter
+        # alarmieren (#995).
+        if not check_official_alert_gate(
+            user_id=self._user_id,
+            quiet_from=preset.get("alert_quiet_from"),
+            quiet_to=preset.get("alert_quiet_to"),
             context_label=preset_id,
-        ):
-            logger.debug(f"Compare official alert quiet hours active for preset {preset_id}")
+            now=datetime.now(timezone.utc),
+            zone=zone,
+        ).allowed:
             return False
 
         # Issue #1594: dieselbe Stufe wie im Vergleichs-Aenderungspfad, gleiche
@@ -161,10 +175,6 @@ class CompareOfficialAlertService:
             return False
 
         now = datetime.now(timezone.utc)
-        if not alert_daily_limit.is_allowed(self._user_id, now, zone):
-            logger.debug(f"Compare official alert suppressed: daily limit for preset {preset_id}")
-            return False
-
         notification_service = self._notification_service_for(preset)
         effective_channels = self._effective_channels(preset)
         # Issue #1461 S3b-2b: die Dringlichkeit wird VOR dem Versand
@@ -320,19 +330,13 @@ class CompareOfficialAlertService:
         return effective_compare_channels(preset, self._settings, self._user_id)
 
     def _notification_service_for(self, preset: dict) -> NotificationService:
-        """Empfaenger ausschliesslich aus den Konto-Settings (Muster
-        `compare_alert.py::_notification_service_for`). Issue #1452:
-        `preset.empfaenger` ist inert; fehlt `mail_to`, wird laut gemeldet, der
-        Lauf bricht aber nicht ab (Spec AC-4)."""
-        if not self._settings.mail_to:
-            logger.warning(
-                "Compare-Alert (amtlich): Nutzer %s hat keine Empfaenger-Adresse "
-                "(mail_to) in den Konto-Settings — Preset %s kann keine E-Mail "
-                "zustellen.",
-                self._user_id, preset.get("id", ""),
-            )
-        return NotificationService(self._settings, self._user_id)
+        """Duenner Wrapper (Issue #1467 S4a) auf den geteilten Helfer
+        `compare_preset_access.notification_service_for_preset`."""
+        return notification_service_for_preset(
+            self._settings, self._user_id, preset, log_label="Compare-Alert (amtlich):",
+        )
 
     def _load_presets(self) -> list[dict]:
-        # Issue #1250 Scheibe 1: zentraler Loader statt rohem json.loads.
-        return [compare_preset_to_dict(p) for p in load_compare_presets(user_id=self._user_id)]
+        """Duenner Wrapper (Issue #1467 S4a) auf den geteilten Helfer
+        `compare_preset_access.load_compare_alert_presets`."""
+        return load_compare_alert_presets(self._user_id)

--- a/src/services/compare_preset_access.py
+++ b/src/services/compare_preset_access.py
@@ -1,0 +1,53 @@
+"""Geteilter Preset-/Empfaenger-Zugriff der drei Ortsvergleich-Alarmpfade
+(Issue #1467 Scheibe S4a).
+
+SPEC: docs/specs/modules/rework_1467_s4a_amtlich.md
+
+`_load_presets()` lag bis S4a byte-identisch dreifach im Baum
+(`compare_alert.py`, `compare_radar_alert.py`, `compare_official_alert.py`),
+`_notification_service_for()` strukturgleich dreifach. Beide wohnen jetzt
+hier; die drei Bestandsmethoden sind Ein-Zeiler-Wrapper.
+
+`log_label` traegt den EINZIGEN echten Unterschied zwischen den drei
+Aufrufern — dasselbe Parametermuster wie `context_label` in `alert_gate.py`.
+Er bleibt Pflicht-Parameter mit ohne Vorbelegung: an ihm erkennt der Nutzer im
+Protokoll, WELCHER seiner drei Ortsvergleich-Alarme keine Empfaengeradresse
+hat (AC-14). Ein gemeinsames Label waere eine stille Verschlechterung.
+"""
+from __future__ import annotations
+
+import logging
+
+from app.config import Settings
+from app.loader import compare_preset_to_dict, load_compare_presets
+from services.notification_service import NotificationService
+
+logger = logging.getLogger("compare_preset_access")
+
+
+def load_compare_alert_presets(user_id: str) -> list[dict]:
+    """Alle Ortsvergleich-Presets dieses Nutzers als Dicts.
+
+    Issue #1250 Scheibe 1: zentraler Loader statt rohem `json.loads`.
+    """
+    return [compare_preset_to_dict(p) for p in load_compare_presets(user_id=user_id)]
+
+
+def notification_service_for_preset(
+    settings: Settings, user_id: str, preset: dict, *, log_label: str,
+) -> NotificationService:
+    """Empfaenger ausschliesslich aus den Konto-Settings des Nutzers (Muster
+    `trip_alert.py:125`). Issue #1452: `preset.empfaenger` ist inert — ein
+    preset-eigenes Override stellte an eine Adresse zu, die der Nutzer in
+    seinem Konto nie hinterlegt hat.
+
+    Fehlt `mail_to`, wird das laut gemeldet (statt stillem Skip); der Lauf
+    laeuft fuer die uebrigen Presets weiter (Spec AC-4).
+    """
+    if not settings.mail_to:
+        logger.warning(
+            "%s Nutzer %s hat keine Empfaenger-Adresse (mail_to) in den "
+            "Konto-Settings — Preset %s kann keine E-Mail zustellen.",
+            log_label, user_id, preset.get("id", ""),
+        )
+    return NotificationService(settings, user_id)

--- a/src/services/compare_radar_alert.py
+++ b/src/services/compare_radar_alert.py
@@ -24,7 +24,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from app.config import Settings
-from app.loader import compare_preset_to_dict, load_all_locations, load_compare_presets
+from app.loader import load_all_locations
 from services import alert_channel_threshold, alert_log
 import services.alert_urgency as alert_urgency
 from services.alert_gate import check_nowcast_gate, record_nowcast_sent
@@ -32,6 +32,10 @@ from utils.timezone import first_resolvable_tz
 from services.alert_state import AlertStateService
 from services.compare_alert_channels import effective_compare_channels
 from services.compare_alert_guard import is_silenced
+from services.compare_preset_access import (
+    load_compare_alert_presets,
+    notification_service_for_preset,
+)
 from services.notification_service import NotificationService
 from services.trip_alert import radar_alert_due
 
@@ -272,18 +276,11 @@ class CompareRadarAlertService:
             state_svc.save(entity_id, state)
 
     def _notification_service_for(self, preset: dict) -> NotificationService:
-        """Empfänger ausschliesslich aus den Konto-Settings — Muster
-        `compare_alert.py::_notification_service_for`. Issue #1452:
-        `preset.empfaenger` ist inert; fehlt `mail_to`, wird laut gemeldet, der
-        Lauf bricht aber nicht ab (Spec AC-4)."""
-        if not self._settings.mail_to:
-            logger.warning(
-                "Compare-Alert (Radar): Nutzer %s hat keine Empfaenger-Adresse "
-                "(mail_to) in den Konto-Settings — Preset %s kann keine E-Mail "
-                "zustellen.",
-                self._user_id, preset.get("id", ""),
-            )
-        return NotificationService(self._settings, self._user_id)
+        """Dünner Wrapper (Issue #1467 S4a) auf den geteilten Helfer
+        `compare_preset_access.notification_service_for_preset`."""
+        return notification_service_for_preset(
+            self._settings, self._user_id, preset, log_label="Compare-Alert (Radar):",
+        )
 
     def _get_radar_service(self):
         if self._radar_service is None:
@@ -292,5 +289,6 @@ class CompareRadarAlertService:
         return self._radar_service
 
     def _load_presets(self) -> list[dict]:
-        # Issue #1250 Scheibe 1: zentraler Loader statt rohem json.loads.
-        return [compare_preset_to_dict(p) for p in load_compare_presets(user_id=self._user_id)]
+        """Dünner Wrapper (Issue #1467 S4a) auf den geteilten Helfer
+        `compare_preset_access.load_compare_alert_presets`."""
+        return load_compare_alert_presets(self._user_id)

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -19,7 +19,11 @@ from app.models import SegmentWeatherData, WeatherChange
 from services import alert_channel_threshold, alert_daily_limit, alert_log
 from services.alert_briefing_anchor import record_alert_anchor_rejected
 import services.alert_urgency as alert_urgency
-from services.alert_gate import check_nowcast_gate, record_nowcast_sent
+from services.alert_gate import (
+    check_nowcast_gate,
+    check_official_alert_gate,
+    record_nowcast_sent,
+)
 from services.deviation_alert_engine import DeviationAlertEngine
 from services.notification_service import (
     NotificationResult,
@@ -1476,28 +1480,32 @@ class TripAlertService:
     def _send_official_alert_only(self, trip: "Trip", official_notices: list) -> bool:
         """Issue #1088: Standalone-Versand einer amtlichen Warnung ohne Wetter-Delta.
 
-        Reproduziert nur die generischen Sicherheits-Gates (QuietHours, Throttle/
-        Cooldown, Tageslimit) — NICHT die weather-delta-spezifischen Gates
+        Reproduziert nur die generischen Sicherheits-Gates (QuietHours,
+        Tageslimit) — NICHT die weather-delta-spezifischen Gates
         (has_active_rules, _filter_significant_changes), da ein eigenständiger
         amtlicher Trigger laut PO-Entscheidung unabhängig vom Wetter-Delta feuern soll.
+
+        Issue #1467 S4a: die beiden verbliebenen Stufen stehen im geteilten
+        Baustein `check_official_alert_gate` — derselbe, den auch der amtliche
+        Ortsvergleich-Pfad ruft. Die Sperrzeit ist dabei ersatzlos ENTFALLEN
+        (E1): sie las den Topf `"trip"`, den der Änderungsalarm befüllt, und
+        verschluckte damit bis zu 120 Minuten lang jede amtliche Eskalation.
+        Geschrieben wird der Topf weiterhin (s. unten) — nur gelesen nicht mehr.
         """
         now_utc = datetime.now(timezone.utc)
-        if self._is_quiet_hours(trip, now_utc):
-            logger.debug(f"Official alert suppressed: quiet hours active for trip {trip.id}")
+        if not check_official_alert_gate(
+            user_id=self._user_id,
+            quiet_from=trip.alert_quiet_from, quiet_to=trip.alert_quiet_to,
+            context_label=trip.id, now=now_utc, zone=anchor_tz(trip, now_utc),
+        ).allowed:
             return False
         # Issue #1594: dieselbe Stufe wie im Aenderungspfad, gleiche Position
         # (nach der Ruhezeit) — die Warnung erscheint im Briefing, das
         # unmittelbar folgt (AC-16), statt zusaetzlich als eigene Nachricht.
+        # Bleibt ein EIGENER Aufruf nach dem Gate (#1467 S4a AC-12), nicht in
+        # den Baustein verschmolzen.
         if self._is_briefing_imminent(trip, now_utc):
             logger.debug(f"Official alert suppressed: briefing imminent for trip {trip.id}")
-            return False
-        if self._is_throttled_with_cooldown(trip):
-            logger.debug(f"Official alert throttled for trip {trip.id}")
-            return False
-        if not alert_daily_limit.is_allowed(
-            self._user_id, now_utc, anchor_tz(trip, now_utc),
-        ):
-            logger.debug(f"Official alert suppressed: daily limit reached for trip {trip.id}")
             return False
 
         effective_channels = self._effective_alert_channels(trip)

--- a/tests/helpers/official_alert_gate_fixtures.py
+++ b/tests/helpers/official_alert_gate_fixtures.py
@@ -1,0 +1,246 @@
+"""Gemeinsame Bausteine der amtlichen Freigabe-Tests (Issue #1467 S4a).
+
+SPEC: docs/specs/modules/rework_1467_s4a_amtlich.md
+
+Baut auf den Bestands-Helfern auf: ``briefing_imminent_fixtures`` liefert
+Trips/Presets/Orte auf Platte, die echte Warnquellen-Registry und die
+Zustands-Schnappschuesse; ``nowcast_gate_fixtures`` liefert Tageszaehler und
+Sperrzeit. Neu ist nur, was dort fehlt.
+
+Mock-frei: kein ``Mock()``/``patch()``/``MagicMock``. Die Aufzeichner rufen die
+ECHTE Fassung auf; die Warnquelle ist ein echtes strukturelles Subtyp-Objekt der
+Quellen-Registry. Pfadregel #1409: alles ueber ``app.loader``.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import date as date_type
+from datetime import datetime, timedelta, timezone
+
+from tests.helpers.briefing_imminent_fixtures import (  # noqa: F401  (Re-Export)
+    TRIP_LAT, TRIP_LON, TRIP_ZONE, load_trip_obj, nur_diese_warnquelle,
+    settings_email_only,
+)
+
+
+class gate_spion:
+    """Zeichnet die LAUFZEIT-Reihenfolge benannter Funktionsaufrufe auf.
+
+    🔴 Warum der Name an MEHREREN Stellen getauscht wird:
+    ``from services.alert_gate import f`` bindet ``f`` im VERBRAUCHENDEN Modul
+    zur Import-Zeit — ein Tausch allein im Ursprungsmodul bliebe dann wirkungslos
+    und der Test still blind. Ein Tausch NUR im Verbraucher waere umgekehrt
+    blind, wenn dieser erst im Methodenrumpf importiert (so macht es
+    ``trip_alert.py`` heute mit ``check_briefing_imminent``). Deshalb: Ursprung
+    UND jede bestehende Bindung desselben Objekts in ``sys.modules``. Wer erst
+    WAEHREND der Aufzeichnung importiert, zieht ohnehin die getauschte Fassung.
+
+    Jeder zaehlende Test fuehrt zusaetzlich einen Kontroll-Lauf, in dem der
+    Zaehler beweisbar hochgeht — sonst waere „0" auch die Antwort einer toten Naht.
+    """
+
+    NAMEN = ("check_official_alert_gate", "check_briefing_imminent")
+    MODUL = "services.alert_gate"
+
+    def __init__(self, namen=None, *, modulname: str | None = None) -> None:
+        self._namen = tuple(namen) if namen else self.NAMEN
+        self._modulname = modulname or self.MODUL
+        self.aufrufe: list[str] = []
+
+    def _stellen(self, name: str, wert) -> list:
+        """Alle Namensraeume, in denen ``name`` an ``wert`` gebunden ist."""
+        treffer = [self._ursprung]
+        for modul in list(sys.modules.values()):
+            if modul is None or modul is self._ursprung:
+                continue
+            try:
+                if getattr(modul, name, None) is wert:
+                    treffer.append(modul)
+            except Exception:  # pragma: no cover - lazy __getattr__ o.ae.
+                continue
+        return treffer
+
+    def __enter__(self) -> "gate_spion":
+        import importlib
+
+        self._ursprung = importlib.import_module(self._modulname)
+        self._originale: dict = {}
+        self._wrapper: dict = {}
+        for name in self._namen:
+            original = getattr(self._ursprung, name)  # fehlt -> AttributeError
+            self._originale[name] = original
+
+            def _bauen(name=name, original=original):
+                def _aufzeichnend(*args, **kwargs):
+                    self.aufrufe.append(name)
+                    return original(*args, **kwargs)
+                _aufzeichnend.__name__ = name
+                return _aufzeichnend
+
+            self._wrapper[name] = _bauen()
+            for modul in self._stellen(name, original):
+                setattr(modul, name, self._wrapper[name])
+        return self
+
+    def __exit__(self, *exc) -> bool:
+        for name, original in self._originale.items():
+            for modul in self._stellen(name, self._wrapper[name]):
+                setattr(modul, name, original)
+        return False
+
+    def zaehle(self, name: str) -> int:
+        return self.aufrufe.count(name)
+
+    def reihenfolge(self) -> list[str]:
+        return list(self.aufrufe)
+
+
+class zaehlende_tagesgrenze:
+    """Zaehlt Aufrufe der Tages-Obergrenze — echte Fassung, echtes Ergebnis.
+
+    ``alert_gate.py`` ruft ``alert_daily_limit.is_allowed(...)`` ueber das
+    MODUL-Objekt auf (``from services import alert_daily_limit``); der Tausch des
+    Modulattributs wirkt deshalb an der Aufrufstelle.
+    """
+
+    def __init__(self) -> None:
+        self.aufrufe = 0
+
+    def __enter__(self) -> "zaehlende_tagesgrenze":
+        from services import alert_daily_limit
+
+        self._modul = alert_daily_limit
+        self._original = alert_daily_limit.is_allowed
+
+        def _aufzeichnend(*args, **kwargs):
+            self.aufrufe += 1
+            return self._original(*args, **kwargs)
+
+        alert_daily_limit.is_allowed = _aufzeichnend
+        return self
+
+    def __exit__(self, *exc) -> bool:
+        self._modul.is_allowed = self._original
+        return False
+
+
+class StufenWarnquelle:
+    """Echte Warnquelle (strukturelles Subtyping) mit steuerbarer Warnstufe —
+    dasselbe Ereignis einmal GELB (2), einmal ORANGE (3).
+
+    Identitaet (``source``/``hazard``/``region_label``) bleibt ueber beide Stufen
+    gleich; nur so wertet ``official_alert_revision_verdict()`` den zweiten
+    Abruf als ESKALATION statt als neue Warnung.
+    """
+
+    def __init__(self, lat: float = TRIP_LAT, lon: float = TRIP_LON, *,
+                 hazard: str = "wind", region_label: str = "Testregion-S4a") -> None:
+        self._lat, self._lon = lat, lon
+        self._hazard, self._region_label = hazard, region_label
+        self.level = 2
+        self.fetch_calls = 0
+
+    @property
+    def name(self) -> str:
+        return "test-1467s4a-stufenquelle"
+
+    def covers(self, lat: float, lon: float) -> bool:
+        return abs(lat - self._lat) < 0.15 and abs(lon - self._lon) < 0.15
+
+    def fetch(self, lat: float, lon: float, **kwargs) -> list:
+        from services.official_alerts.models import OfficialAlert
+
+        self.fetch_calls += 1
+        jetzt = datetime.now(timezone.utc)
+        return [OfficialAlert(
+            source="test-1467s4a", hazard=self._hazard, level=self.level,
+            label=f"Sturmwarnung Stufe {self.level}", region_label=self._region_label,
+            valid_from=jetzt - timedelta(hours=1), valid_to=jetzt + timedelta(hours=12))]
+
+
+def schnappschuss_speichern(user_id: str, trip_id: str, *,
+                            lat: float = TRIP_LAT, lon: float = TRIP_LON) -> None:
+    """Wetter-Schnappschuss des Trips auf Platte.
+
+    ``check_official_alert_triggers()`` liest die Segment-Koordinaten
+    AUSSCHLIESSLICH aus dem Schnappschuss (``_get_cached_weather``) — ohne ihn
+    bleibt jede Warnquelle unerreichbar und der Test gruen aus falschem Grund.
+    """
+    from app.models import (
+        ForecastMeta, GPXPoint, NormalizedTimeseries, Provider, SegmentWeatherData,
+        SegmentWeatherSummary, TripSegment,
+    )
+    from services.weather_snapshot import WeatherSnapshotService
+
+    jetzt = datetime.now(timezone.utc)
+    segment = TripSegment(
+        segment_id=1,
+        start_point=GPXPoint(lat=lat, lon=lon, elevation_m=1000, distance_from_start_km=0.0),
+        end_point=GPXPoint(lat=lat + 0.1, lon=lon + 0.1, elevation_m=1200,
+                           distance_from_start_km=6.0),
+        start_time=jetzt - timedelta(hours=1), end_time=jetzt + timedelta(hours=3),
+        duration_hours=4.0, distance_km=6.0, ascent_m=200, descent_m=0)
+    daten = SegmentWeatherData(
+        segment=segment,
+        timeseries=NormalizedTimeseries(
+            meta=ForecastMeta(provider=Provider.OPENMETEO, model="test", grid_res_km=1.0),
+            data=[]),
+        aggregated=SegmentWeatherSummary(precip_sum_mm=2.0),
+        fetched_at=jetzt, provider="openmeteo")
+    WeatherSnapshotService(user_id=user_id).save_dated(trip_id, date_type.today(), [daten])
+
+
+def gelb_ins_melde_gedaechtnis(user_id: str, trip_id: str, quelle: StufenWarnquelle) -> int:
+    """Runde 1 der Eskalation: GELB wird erkannt und ins Melde-Gedaechtnis
+    geschrieben — ohne Versand, ueber die echten Produktivfassungen.
+    Returns die Anzahl erkannter Warnungen (Aufbau-Nachweis)."""
+    from services.trip_alert import TripAlertService
+
+    quelle.level = 2
+    with nur_diese_warnquelle(quelle):
+        dienst = TripAlertService(settings=settings_email_only(), throttle_hours=2,
+                                  user_id=user_id)
+        gelb = dienst.check_official_alert_triggers(load_trip_obj(user_id, trip_id))
+        if gelb:
+            dienst._record_official_alert_state(trip_id, gelb)
+    return len(gelb)
+
+
+def trip_amtlicher_lauf(user_id: str, *, quelle, settings=None) -> tuple[int, list]:
+    """Echter ``check_all_trips()``-Lauf mit lokaler Warnquelle — bewusst der
+    oeffentliche Sammel-Einstieg, damit der amtliche Versand durch dieselbe Kette
+    laeuft wie im Betrieb. Returns ``(versendete Alarme, mail_sink-Rufe)``."""
+    from services.trip_alert import TripAlertService
+
+    mails: list = []
+    with nur_diese_warnquelle(quelle):
+        ergebnis = TripAlertService(
+            settings=settings or settings_email_only(), throttle_hours=2, user_id=user_id,
+            mail_sink=lambda subject, body: mails.append((subject, body)),
+        ).check_all_trips()
+    return ergebnis.alerts_sent, mails
+
+
+def trip_amtlicher_direktlauf(user_id: str, trip_id: str, *,
+                              settings=None, level: int = 3) -> tuple[bool, list]:
+    """Echter ``_send_official_alert_only()``-Lauf — DIE Aufrufstelle, an der der
+    geteilte Baustein einsortiert wird.
+
+    Fuer Reihenfolge-Nachweise (AC-12) bewusst der Direktaufruf: der
+    Sammel-Einstieg wuerde die Briefing-Sperre zusaetzlich aus dem Aenderungspfad
+    rufen und die aufgezeichnete Reihenfolge verrauschen.
+    """
+    from services.official_alerts.models import OfficialAlert
+    from services.trip_alert import TripAlertService
+
+    mails: list = []
+    dienst = TripAlertService(
+        settings=settings or settings_email_only(), throttle_hours=2, user_id=user_id,
+        mail_sink=lambda subject, body: mails.append((subject, body)))
+    jetzt = datetime.now(timezone.utc)
+    warnung = OfficialAlert(
+        source="test-1467s4a", hazard="wind", level=level, label="Sturmwarnung",
+        region_label="Testregion-S4a",
+        valid_from=jetzt - timedelta(hours=1), valid_to=jetzt + timedelta(hours=12))
+    return bool(dienst._send_official_alert_only(
+        load_trip_obj(user_id, trip_id), [(warnung, ["1"])])), mails

--- a/tests/tdd/test_alert_quiet_hours_robustness.py
+++ b/tests/tdd/test_alert_quiet_hours_robustness.py
@@ -1013,8 +1013,14 @@ _QUIET_CALL_NAMES = {"is_quiet_hours", "_is_quiet_hours"}
 # Leere und die Sicherung 1 unten (mindestens eine Aufrufstelle gefunden)
 # wuerde ihn zu Recht als Testfehler melden. `trip_alert.py` bleibt in der
 # Liste: dort rufen der Aenderungs- und der amtliche Pfad weiterhin selbst.
+#
+# Issue #1467 S4a: aus demselben Grund faellt jetzt `compare_official_alert.py`
+# aus der Liste — die Ruhezeit-Aufrufstelle des amtlichen Ortsvergleichs ist in
+# `check_official_alert_gate()` umgezogen, also in `alert_gate.py`, das bereits
+# in der Liste steht und die Aufrufstelle damit weiter bewacht. `trip_alert.py`
+# bleibt: der Aenderungspfad ruft `_is_quiet_hours()` dort unveraendert selbst
+# (der amtliche Trip-Pfad fragt jetzt ebenfalls ueber den Baustein).
 _GUARDED_FILES = [
-    "compare_official_alert.py",
     "alert_gate.py",
     "trip_alert.py",
     "compare_alert.py",

--- a/tests/tdd/test_compare_alert_recipient_settings.py
+++ b/tests/tdd/test_compare_alert_recipient_settings.py
@@ -113,7 +113,16 @@ def _preset(preset_id: str, location_ids: list[str], **extra) -> dict:
 def _recorded_settings(module):
     """Zeichnet die Settings auf, mit denen der Dienst seinen
     `NotificationService` tatsaechlich baut — echte Subklasse, die das echte
-    Verhalten weiterfuehrt (kein Mock)."""
+    Verhalten weiterfuehrt (kein Mock).
+
+    Issue #1467 S4a: die drei Compare-Alarmpfade bauen ihren
+    `NotificationService` seither im geteilten Helfer
+    `services.compare_preset_access`; die Aufzeichnung sitzt deshalb DORT.
+    Das uebergebene `module` (der jeweilige Alarmdienst) wird weiterhin
+    mitgetauscht — nur so faellt auf, wenn einer der drei doch wieder eine
+    eigene Fassung baut. Der Messpunkt wandert mit der Naht, die Zusicherung
+    bleibt dieselbe."""
+    from services import compare_preset_access
     from services.notification_service import NotificationService as _Real
 
     recorded: list[dict] = []
@@ -128,12 +137,16 @@ def _recorded_settings(module):
             })
             super().__init__(settings, user_id)
 
-    original = module.NotificationService
-    module.NotificationService = _Recording
+    ziele = [m for m in (module, compare_preset_access)
+             if getattr(m, "NotificationService", None) is not None]
+    originale = [m.NotificationService for m in ziele]
+    for m in ziele:
+        m.NotificationService = _Recording
     try:
         yield recorded
     finally:
-        module.NotificationService = original
+        for m, original in zip(ziele, originale):
+            m.NotificationService = original
 
 
 def _assert_settings_recipient(recorded: list[dict], expected: str, label: str) -> None:

--- a/tests/tdd/test_compare_official_alert_daily_limit_order.py
+++ b/tests/tdd/test_compare_official_alert_daily_limit_order.py
@@ -1,0 +1,252 @@
+"""TDD RED — Ortsvergleich (amtlich): die Tages-Obergrenze prueft VOR dem
+Warnungs-Abruf (Issue #1467 S4a, AC-7, AC-8, AC-17).
+
+SPEC:    docs/specs/modules/rework_1467_s4a_amtlich.md
+KONTEXT: docs/context/rework-1467-s4a-amtlich.md
+
+Heute steht die Tages-Obergrenze in ``compare_official_alert.py:164`` — also
+NACH ``_detect()`` (``:159``). Ein erschoepftes Kontingent kostet damit
+trotzdem einen vollstaendigen Warnungs-Abruf gegen eine Quelle, die produktiv
+bereits an ihr Tageslimit stoesst (``warn_service_consumption.md:22-28``:
+„liefert in Prod dauerhaft HTTP 429"; ``fix_1397_meteoalarm_coverage_budget.md``:
+gemessen ~160 Abrufe je rollierender 24 h bei Tagesbudget 100).
+
+Gemessen wird an der ABRUF-Naht, nicht am Ausbleiben der Zustellung: eine
+Sperre, die erst nach dem Abruf greift, sieht fuer den Nutzer gleich aus, kostet
+aber weiter Kontingent — genau der Unterschied, den E2 herstellt. Die Zaehl-Naht
+liegt doppelt: ``_detect()`` (die Methode, die ``get_official_alerts_for_location``
+ruft) UND die Quelle selbst (``fetch_calls``); jeder Test fuehrt einen
+Kontroll-Lauf, in dem beide beweisbar hochgehen.
+
+Mock-frei: echte Presets/Orte auf Platte, echte Warnquelle in der Registry
+(kein Netz), echter Tageszaehler; die zaehlende Unterklasse ruft die ECHTE
+Fassung (``super()._detect(...)``) auf. Pfadregel #1409.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+for _p in (str(ROOT), str(ROOT / "src")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tests.helpers.briefing_imminent_fixtures import (  # noqa: E402
+    LOCATION_ZONE, FakeOfficialAlertSource, clean_uid, compare_preset, fresh_uid,
+    nur_diese_warnquelle, ruhezeit_woanders, settings_email_only, stunde_versetzt,
+    write_location, write_presets, write_user_tier,
+)
+from tests.helpers.nowcast_gate_fixtures import (  # noqa: E402
+    read_daily_counter, seed_daily_counter,
+)
+
+PRESET = "cp-1467s4a-limit"
+ORT = "loc-1467s4a-limit"
+
+
+@pytest.fixture
+def nutzer():
+    vergeben: list[str] = []
+
+    def _neu(kennung: str, tier: str = "free") -> str:
+        user_id = fresh_uid(f"s4a-limit-{kennung}")
+        clean_uid(user_id)
+        write_user_tier(user_id, tier)
+        write_location(user_id, ORT)
+        vergeben.append(user_id)
+        return user_id
+
+    yield _neu
+    for user_id in vergeben:
+        clean_uid(user_id)
+
+
+def _preset_schreiben(user_id: str) -> None:
+    write_presets(user_id, [compare_preset(
+        PRESET,
+        morgen_stunde=stunde_versetzt(5, zone=LOCATION_ZONE),  # Briefing weit weg
+        quiet=ruhezeit_woanders(), location_ids=[ORT],
+    )])
+
+
+class _Abruflauf:
+    def __init__(self, detect_aufrufe: int, quellen_abrufe: int, sent: int, mails: list):
+        self.detect_aufrufe = detect_aufrufe
+        self.quellen_abrufe = quellen_abrufe
+        self.sent = sent
+        self.mails = mails
+
+    def __repr__(self) -> str:  # pragma: no cover - nur fuer Fehlermeldungen
+        return (f"<Lauf detect={self.detect_aufrufe} quelle={self.quellen_abrufe} "
+                f"sent={self.sent} mails={len(self.mails)}>")
+
+
+def _lauf_mit_abrufzaehlern(user_id: str) -> _Abruflauf:
+    """Echter ``check_all_compare_presets()``-Lauf mit gezaehlter Abruf-Naht.
+
+    Die Unterklasse ersetzt nichts — sie zaehlt und delegiert an die echte
+    Fassung; der Abruf laeuft damit wirklich durch
+    ``get_official_alerts_for_location()``.
+    """
+    from services.compare_official_alert import CompareOfficialAlertService
+
+    class _Zaehlend(CompareOfficialAlertService):
+        detect_aufrufe = 0
+
+        def _detect(self, preset_id, locs, sources=None):
+            type(self).detect_aufrufe += 1
+            return super()._detect(preset_id, locs, sources)
+
+    _Zaehlend.detect_aufrufe = 0
+    mails: list = []
+    quelle = FakeOfficialAlertSource()
+    with nur_diese_warnquelle(quelle):
+        sent = _Zaehlend(
+            settings=settings_email_only(), user_id=user_id,
+            mail_sink=lambda subject, body: mails.append((subject, body)),
+        ).check_all_compare_presets()
+    return _Abruflauf(_Zaehlend.detect_aufrufe, quelle.fetch_calls, sent, mails)
+
+
+# ════ AC-7: erschoepftes Kontingent kostet keinen Warnungs-Abruf mehr ═══════
+
+
+def test_ac7_erschoepftes_tageslimit_loest_keinen_warnungs_abruf_aus(nutzer):
+    """AC-7: Ist die Tages-Obergrenze erreicht, wird ``_detect()`` — und damit
+    ``get_official_alerts_for_location`` — gar nicht mehr gerufen.
+
+    Der Kontroll-Nutzer mit freiem Kontingent belegt im selben Test, dass beide
+    Zaehler hochgehen koennen; ohne ihn koennte „0 Abrufe" auch heissen, dass
+    die Naht tot ist.
+
+    Mutations-Gegenprobe (Pflicht): die Reihenfolge zurueckdrehen (Abruf vor
+    Gate) MUSS diesen Test rot machen.
+
+    ROT HEUTE: die Tages-Obergrenze steht bei ``:164``, also NACH ``_detect()``
+    (``:159``) — der Abruf laeuft, das Kontingent wird trotzdem verbraucht.
+    """
+    erschoepft = nutzer("ac7-voll")
+    _preset_schreiben(erschoepft)
+    seed_daily_counter(erschoepft, 2)  # free -> Limit 2
+
+    frei = nutzer("ac7-frei")
+    _preset_schreiben(frei)
+    seed_daily_counter(frei, 0)
+
+    lauf_voll = _lauf_mit_abrufzaehlern(erschoepft)
+    lauf_frei = _lauf_mit_abrufzaehlern(frei)
+
+    assert lauf_frei.detect_aufrufe >= 1 and lauf_frei.quellen_abrufe >= 1, (
+        f"Kontroll-Lauf: bei freiem Kontingent MUSS abgerufen werden, sonst "
+        f"messen die Zaehler eine tote Naht — {lauf_frei!r}")
+    assert lauf_voll.detect_aufrufe == 0, (
+        f"Bei erschoepftem Tageslimit darf die Warnungs-Erkennung gar nicht "
+        f"laufen, es waren {lauf_voll.detect_aufrufe} Aufrufe")
+    assert lauf_voll.quellen_abrufe == 0, (
+        f"Bei erschoepftem Tageslimit darf keine Warnquelle abgefragt werden, "
+        f"es waren {lauf_voll.quellen_abrufe} Abrufe")
+    assert (lauf_voll.sent, lauf_voll.mails) == (0, []), (
+        f"Bei erschoepftem Tageslimit darf nichts zugestellt werden: {lauf_voll!r}")
+
+
+# ═════ AC-8: bei freiem Kontingent aendert das Vorziehen gar nichts ═════════
+
+
+def test_ac8_freies_kontingent_stellt_unveraendert_zu(nutzer):
+    """AC-8 (Regressionswaechter): Mit freiem Kontingent wird die neue bzw.
+    eskalierte amtliche Warnung unveraendert zugestellt — und der Tageszaehler
+    genau um eins erhoeht.
+
+    Gegenrichtung zu Risiko R-A: eine falsch verdrahtete Zone oder ein falsch
+    gelesener Zaehlerstand im neuen Gate liesse den Lauf komplett stumm werden,
+    und zwar OHNE dass ueberhaupt noch ein Abruf Symptome hinterliesse.
+    """
+    uid = nutzer("ac8")
+    _preset_schreiben(uid)
+    seed_daily_counter(uid, 0)
+
+    lauf = _lauf_mit_abrufzaehlern(uid)
+
+    assert lauf.sent >= 1 and len(lauf.mails) >= 1, (
+        f"Bei freiem Kontingent muss zugestellt werden: {lauf!r}")
+    assert read_daily_counter(uid) == 1, (
+        f"Nach erfolgreicher Zustellung muss der Tageszaehler auf 1 stehen, "
+        f"steht auf {read_daily_counter(uid)}")
+
+
+# ══════════ AC-17: ``_day_window_end()`` bleibt komplett unberuehrt ═════════
+
+#: SHA-256 des Quelltexts von ``CompareOfficialAlertService._day_window_end``,
+#: erhoben am 2026-08-16 gegen den Stand VOR dieser Scheibe (Basis ``098226ae``).
+#: Ein einziges geaendertes Zeichen — auch Einrueckung oder Kommentar — bricht
+#: diesen Waechter. Genau das ist gewollt: die Methode ist ausdruecklich
+#: Nicht-Ziel (R-E), und ihr Abendverhalten haelt sonst kein Test.
+DAY_WINDOW_END_HASH_VOR_S4A = (
+    "01c0741eba359d1d9aab55c017c609c88deb5fac3d65b8844d96cc8807beae99"
+)
+
+
+def _day_window_end_hash() -> str:
+    import hashlib
+    import inspect
+
+    from services.compare_official_alert import CompareOfficialAlertService
+
+    quelltext = inspect.getsource(CompareOfficialAlertService._day_window_end)
+    return hashlib.sha256(quelltext.encode("utf-8")).hexdigest()
+
+
+def test_ac17_day_window_end_bleibt_zeichengleich_unveraendert():
+    """AC-17 (Regressionswaechter): ``_day_window_end()`` ist textidentisch
+    unveraendert.
+
+    Wandert die Methode beim Umbau versehentlich mit — etwa weil jemand ihre
+    Preset-Suche auf den neuen geteilten Helfer umstellt —, verliert der Nutzer
+    nach Fensterende Ortszeit seine Warnungen (nullbreites Fenster, R-E). Der
+    Hash ist hier kein Dateiinhalt-Check als Verhaltensnachweis, sondern die von
+    AC-17 verlangte Unveraenderlichkeits-Zusicherung; der Verhaltensfall
+    darunter traegt die fachliche Aussage.
+    """
+    assert _day_window_end_hash() == DAY_WINDOW_END_HASH_VOR_S4A, (
+        f"``_day_window_end()`` wurde veraendert — ausdrueckliches Nicht-Ziel "
+        f"dieser Scheibe. Erwartet {DAY_WINDOW_END_HASH_VOR_S4A!r}, erhalten "
+        f"{_day_window_end_hash()!r}")
+
+
+def test_ac17_fenster_nach_fensterende_bleibt_nullbreit(nutzer):
+    """AC-17 (Verhaltensfall): Liegt das Ende des Tagesfensters bereits hinter
+    dem Abrufzeitpunkt, liefert ``_day_window_end()`` unveraendert ``now`` — ein
+    nullbreites Fenster ``[now, now]``.
+
+    Der Zeitpunkt wird als PARAMETER uebergeben statt die Systemuhr zu stellen:
+    so ist der Fall zu jeder Tageszeit derselbe, und ein Rueckfall auf die
+    Systemuhr im Pruefling wuerde sichtbar.
+    """
+    from app.loader import load_all_locations
+    from services.compare_official_alert import CompareOfficialAlertService
+
+    uid = nutzer("ac17")
+    _preset_schreiben(uid)
+
+    dienst = CompareOfficialAlertService(settings=settings_email_only(), user_id=uid)
+    ort = next(loc for loc in load_all_locations(user_id=uid) if loc.id == ORT)
+
+    # 20:30 Ortszeit (Europe/Vienna) — nach dem ADR-0035-Default-Fensterende 19.
+    abends_lokal = (datetime.now(timezone.utc).astimezone(LOCATION_ZONE)
+                    .replace(hour=20, minute=30, second=0, microsecond=0))
+    abends = abends_lokal.astimezone(timezone.utc)
+
+    ende = dienst._day_window_end(PRESET, ort, abends)
+    assert ende == abends, (
+        f"Nach dem Fensterende muss auf ``now`` geklemmt werden (nullbreites "
+        f"Fenster), erhalten {ende.isoformat()} fuer now={abends.isoformat()}")
+
+    mittags = abends_lokal.replace(hour=10, minute=0).astimezone(timezone.utc)
+    ende_mittags = dienst._day_window_end(PRESET, ort, mittags)
+    assert ende_mittags > mittags + timedelta(hours=1), (
+        f"Mitten im Tagesfenster muss ein echtes, breites Fenster entstehen, "
+        f"erhalten {ende_mittags.isoformat()} fuer now={mittags.isoformat()}")

--- a/tests/tdd/test_compare_preset_access.py
+++ b/tests/tdd/test_compare_preset_access.py
@@ -1,0 +1,232 @@
+"""TDD RED — Der geteilte Preset-/Notification-Helfer der drei
+Ortsvergleich-Alarmpfade (Issue #1467 S4a, AC-13, AC-14) und der ADR-Nachtrag
+(AC-19).
+
+SPEC:    docs/specs/modules/rework_1467_s4a_amtlich.md
+KONTEXT: docs/context/rework-1467-s4a-amtlich.md
+
+Zwei Helfer liegen heute dreifach im Baum: ``_load_presets()``
+(``compare_alert.py:592``, ``compare_radar_alert.py:294``,
+``compare_official_alert.py:336`` — byte-identisch) und
+``_notification_service_for()`` (``:576``/``:274``/``:322`` — strukturgleich).
+``services/compare_preset_access.py`` fuehrt beide zusammen; ``log_label``
+traegt den einzigen echten Unterschied.
+
+Zu AC-14 ausdruecklich: die Spec spricht von „drei unterscheidbaren Texten mit
+diesen Praefixen". Gemessen an der Fundstelle sind diese Praefixe die
+LOG-Warnung bei fehlender Empfaengeradresse, nicht der Nutzertext der Alarmmail
+(die Alarmtexte unterscheiden sich ohnehin ueber ganz andere Renderer). Geprueft
+wird deshalb genau das Beobachtbare, das die Zusammenlegung einebnen wuerde.
+
+Mock-frei: echte Dienste, echte Presets auf Platte, echte Log-Aufzeichnung ueber
+``caplog``; der Aufrufzaehler ruft die ECHTE Fassung auf. Pfadregel #1409.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+for _p in (str(ROOT), str(ROOT / "src")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tests.helpers.briefing_imminent_fixtures import (  # noqa: E402
+    LOCATION_ZONE, clean_uid, compare_preset, fresh_uid, ruhezeit_woanders,
+    settings_email_only, stunde_versetzt, write_location, write_presets,
+    write_user_tier,
+)
+from tests.helpers.official_alert_gate_fixtures import gate_spion  # noqa: E402
+
+HELFER_MODUL = "services.compare_preset_access"
+LADEN = "load_compare_alert_presets"
+DIENST = "notification_service_for_preset"
+
+PRESET = "cp-1467s4a-helfer"
+ORT = "loc-1467s4a-helfer"
+
+#: Die drei Alarmtyp-Praefixe, an denen der Nutzer im Protokoll erkennt, WELCHER
+#: seiner drei Ortsvergleich-Alarme keine Empfaengeradresse hat.
+PRAEFIXE = {
+    "aenderung": "Compare-Alert:",
+    "radar": "Compare-Alert (Radar):",
+    "amtlich": "Compare-Alert (amtlich):",
+}
+
+
+@pytest.fixture
+def nutzer():
+    vergeben: list[str] = []
+
+    def _neu(kennung: str, tier: str = "premium") -> str:
+        user_id = fresh_uid(f"s4a-helfer-{kennung}")
+        clean_uid(user_id)
+        write_user_tier(user_id, tier)
+        write_location(user_id, ORT)
+        write_presets(user_id, [compare_preset(
+            PRESET, morgen_stunde=stunde_versetzt(5, zone=LOCATION_ZONE),
+            quiet=ruhezeit_woanders(), location_ids=[ORT])])
+        vergeben.append(user_id)
+        return user_id
+
+    yield _neu
+    for user_id in vergeben:
+        clean_uid(user_id)
+
+
+def _die_drei_dienste(user_id: str, settings) -> dict:
+    from services.compare_alert import CompareAlertService
+    from services.compare_official_alert import CompareOfficialAlertService
+    from services.compare_radar_alert import CompareRadarAlertService
+
+    return {
+        "aenderung": CompareAlertService(settings=settings, user_id=user_id),
+        "radar": CompareRadarAlertService(settings=settings, user_id=user_id),
+        "amtlich": CompareOfficialAlertService(settings=settings, user_id=user_id),
+    }
+
+
+def _settings_ohne_empfaenger():
+    """Vollstaendig konstruierte ``Settings`` OHNE ``mail_to``.
+
+    Bewusst jedes Feld gesetzt (auch die leeren): ein weggelassenes Feld faellt
+    bei pydantic still auf die Prod-``.env`` zurueck — genau so gingen am
+    2026-08-03 echte Telegram-Nachrichten an den Produktiv-Chat des PO (#1477).
+    """
+    from app.config import Settings
+
+    return Settings(
+        smtp_host="dummy.invalid", smtp_user="dummy", smtp_pass="dummy", mail_to="",
+        telegram_bot_token="", telegram_chat_id="", seven_api_key="", sms_to="")
+
+
+# ══════════ AC-13: alle drei Pfade rufen denselben geteilten Helfer ═════════
+
+
+def test_ac13_alle_drei_compare_pfade_rufen_denselben_helfer(nutzer):
+    """AC-13: Die drei Bestandsmethoden ``_load_presets()`` und
+    ``_notification_service_for()`` sind Ein-Zeiler-Wrapper geworden — jeder
+    Pfad laeuft je Aufruf genau einmal durch den geteilten Helfer.
+
+    Gezaehlt wird an der geteilten Fassung, nicht an den Wrappern: nur so faellt
+    auf, wenn EINER der drei seine eigene Implementierung behaelt. Der
+    Aufbau-Nachweis belegt, dass die Wrapper Brauchbares liefern — ein Helfer,
+    der immer ``[]`` zurueckgibt, wuerde die Zaehler ebenso befriedigen.
+
+    ROT HEUTE: ``ModuleNotFoundError`` — ``services/compare_preset_access.py``
+    gibt es nicht.
+    """
+    from services.compare_preset_access import (  # noqa: F401
+        load_compare_alert_presets, notification_service_for_preset,
+    )
+
+    uid = nutzer("ac13")
+    dienste = _die_drei_dienste(uid, settings_email_only())
+
+    with gate_spion(namen=(LADEN, DIENST), modulname=HELFER_MODUL) as spion:
+        geladen = {name: d._load_presets() for name, d in dienste.items()}
+        gebaut = {name: d._notification_service_for(geladen[name][0])
+                  for name, d in dienste.items()}
+
+    for name, presets in geladen.items():
+        assert [p.get("id") for p in presets] == [PRESET], (
+            f"Aufbau-Nachweis: {name} muss {PRESET!r} laden, geladen: {presets!r}")
+        assert gebaut[name] is not None, (
+            f"Aufbau-Nachweis: {name} muss einen Notification-Service liefern")
+
+    assert spion.zaehle(LADEN) == 3, (
+        f"Alle drei Pfade muessen ueber ``{LADEN}`` laden — gezaehlt: "
+        f"{spion.zaehle(LADEN)} ({spion.reihenfolge()!r})")
+    assert spion.zaehle(DIENST) == 3, (
+        f"Alle drei Pfade muessen ueber ``{DIENST}`` bauen — gezaehlt: "
+        f"{spion.zaehle(DIENST)} ({spion.reihenfolge()!r})")
+
+
+# ═══ AC-14: die drei Alarmtypen bleiben in der Meldung unterscheidbar ═══════
+
+
+def test_ac14_die_drei_alarmtypen_melden_weiterhin_unterscheidbar(nutzer, caplog):
+    """AC-14: Fehlt die Empfaengeradresse, meldet jeder der drei Pfade das mit
+    SEINEM Alarmtyp-Praefix — die Zusammenlegung aendert die Struktur, nicht den
+    Text.
+
+    Ohne diese Zusicherung waere die naheliegende Vereinfachung („ein Label fuer
+    alle") eine stille Verschlechterung: der Nutzer saehe drei gleichlautende
+    Meldungen und wuesste nicht mehr, welcher seiner drei Ortsvergleich-Alarme
+    keine Adresse hat.
+
+    ROT HEUTE: ``ModuleNotFoundError`` beim Helfer-Import — die Zusicherung
+    gehoert zu dem Umbau, der sie gefaehrdet.
+    """
+    from services.compare_preset_access import (  # noqa: F401
+        notification_service_for_preset,
+    )
+
+    uid = nutzer("ac14")
+    dienste = _die_drei_dienste(uid, _settings_ohne_empfaenger())
+    preset = dienste["amtlich"]._load_presets()[0]
+
+    meldungen: dict[str, list[str]] = {}
+    for name, dienst in dienste.items():
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            dienst._notification_service_for(preset)
+        meldungen[name] = [r.getMessage() for r in caplog.records]
+
+    for name, praefix in PRAEFIXE.items():
+        passend = [m for m in meldungen[name] if m.startswith(praefix)]
+        assert passend, (
+            f"Der {name}-Pfad muss seine Meldung mit {praefix!r} kennzeichnen, "
+            f"protokolliert: {meldungen[name]!r}")
+        assert uid in passend[0] and PRESET in passend[0], (
+            f"Die Meldung muss Nutzer und Preset benennen: {passend[0]!r}")
+
+    erste = {name: msgs[0] for name, msgs in meldungen.items() if msgs}
+    assert len(set(erste.values())) == 3, (
+        f"Die drei Meldungen muessen unterscheidbar bleiben: {erste!r}")
+
+
+# ══════════════════════ AC-19: der ADR-0021-Nachtrag ═══════════════════════
+
+#: Der Satz aus dem #1467-S3-Nachtrag, der laut E3 unveraendert richtig bleibt.
+S3_SATZ = "Änderungs- und amtlicher Alarm bewusst weiterhin nicht"
+
+
+def test_ac19_adr_0021_traegt_einen_nachtrag_zu_s4a():
+    """AC-19: ADR-0021 traegt nach dieser Scheibe einen datierten Nachtrag mit
+    Bezug auf #1467 S4a — und der bestehende Satz zur
+    Unterdrueckungs-Protokollierung bleibt darin unangetastet.
+
+    Nachtrag 2 impliziert heute, dass der amtliche Pfad KEINEN geteilten
+    Ablauf-Baustein nutzt; diese Scheibe macht das sachlich falsch. Eine
+    dokumentierte Entscheidung wird nie still ueberholt (ADR-Regel, CLAUDE.md).
+
+    # doc-compliance-test — hier ist der Dokumententext ausdruecklich der
+    Pruefgegenstand, nicht ein Ersatz fuer einen Verhaltensnachweis.
+
+    ROT HEUTE: es gibt keinen S4a-Nachtrag.
+    """
+    adr = ROOT / "docs" / "adr" / "0021-shared-deviation-alert-engine.md"
+    assert adr.exists(), f"ADR-0021 nicht gefunden unter {adr}"
+    text = adr.read_text(encoding="utf-8")
+
+    nachtraege = [z for z in text.splitlines()
+                  if "Nachtrag" in z and "#1467" in z and "S4a" in z]
+    assert nachtraege, (
+        "ADR-0021 braucht einen Nachtrag mit Bezug auf '#1467' und 'S4a', der "
+        "festhaelt, dass BEIDE amtlichen Pfade seit dieser Scheibe ueber "
+        "denselben geteilten Ablauf-Baustein laufen.")
+
+    datumsangaben = [date.fromisoformat(t) for z in nachtraege
+                     for t in re.findall(r"\d{4}-\d{2}-\d{2}", z)]
+    assert any(d >= date(2026, 8, 16) for d in datumsangaben), (
+        f"Der S4a-Nachtrag muss auf den 2026-08-16 oder spaeter datiert sein, "
+        f"gefunden: {datumsangaben!r} in {nachtraege!r}")
+    assert S3_SATZ in text, (
+        f"Der Satz zur Unterdrueckungs-Protokollierung aus dem S3-Nachtrag "
+        f"bleibt laut E3 richtig und darf nicht entfernt werden: {S3_SATZ!r}")

--- a/tests/tdd/test_official_alert_cooldown_entkopplung.py
+++ b/tests/tdd/test_official_alert_cooldown_entkopplung.py
@@ -1,0 +1,377 @@
+"""TDD RED — Der amtliche Trip-Alarm liest die Sperrzeit des Aenderungsalarms
+nicht mehr (Issue #1467 S4a, AC-4 bis AC-6, AC-10, AC-11, AC-15).
+
+SPEC:    docs/specs/modules/rework_1467_s4a_amtlich.md
+KONTEXT: docs/context/rework-1467-s4a-amtlich.md
+
+Kernfall (E1): ``trip_alert.py:1494`` liest heute den ``ThrottleStore``-Scope
+``"trip"`` — denselben Topf, den der Aenderungsalarm bei ``:358`` befuellt. Ein
+Aenderungsalarm um 16:00 verschluckt damit eine amtliche GELB→ORANGE-
+Verschaerfung um 16:15, bis zu zwei Stunden lang (Default-Cooldown 120 min).
+Genau diese Wirkung schliesst das Issue fuer den Ortsvergleich aus.
+
+Lesen und Schreiben werden getrennt entschieden und hier getrennt bewacht: das
+**Lesen** faellt weg (AC-4), das **Schreiben** bleibt (AC-5). Ohne AC-5 koennte
+ein Umbau „aus Symmetriegruenden" auch das Schreiben entfernen; die Menge der
+Aenderungsalarme stiege still.
+
+Mock-frei: echte Trips auf Platte, echter ``ThrottleStore``, echte Warnquelle in
+der Registry (kein Netz), Versand ueber die ``mail_sink``-DI-Naht. #1409.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+for _p in (str(ROOT), str(ROOT / "src")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tests.helpers.briefing_imminent_fixtures import (  # noqa: E402
+    TRIP_ZONE, clean_uid, fresh_uid, protokoll_eintraege, ruhezeit_woanders,
+    stunde_versetzt, trip_change_alert_run, write_trip, write_user_tier,
+)
+from tests.helpers.nowcast_gate_fixtures import (  # noqa: E402
+    read_daily_counter, read_throttle_state, record_throttle,
+    settings_no_channel_reachable, suppression_reasons,
+)
+from tests.helpers.official_alert_gate_fixtures import (  # noqa: E402
+    StufenWarnquelle, gelb_ins_melde_gedaechtnis, schnappschuss_speichern,
+    trip_amtlicher_lauf,
+)
+
+TRIP, SCOPE_TRIP = "trip-1467s4a", "trip"
+
+#: Produktiv-Default des Aenderungsalarm-Cooldowns (``throttle_hours=2``).
+#: Ausdruecklich gesetzt, damit die Sperre real ausgewertet wird statt in einen
+#: 0-Kurzschluss zu laufen.
+COOLDOWN_MINUTEN = 120
+
+#: Abstand Aenderungsalarm (T) -> amtliche Eskalation (T+15): deutlich INNERHALB
+#: des Cooldowns, sonst bewiese der Test nur, dass eine abgelaufene Sperre nicht
+#: sperrt.
+ESKALATION_NACH_MINUTEN = 15
+
+
+@pytest.fixture
+def nutzer():
+    vergeben: list[str] = []
+
+    def _neu(kennung: str, tier: str = "premium") -> str:
+        user_id = fresh_uid(f"s4a-{kennung}")
+        clean_uid(user_id)
+        write_user_tier(user_id, tier)
+        vergeben.append(user_id)
+        return user_id
+
+    yield _neu
+    for user_id in vergeben:
+        clean_uid(user_id)
+
+
+def _trip_schreiben(user_id: str, **kwargs) -> None:
+    """Trip mit Briefing-Zeiten weit ausserhalb des 60-Minuten-Vorlaufs (#1594)
+    — sonst misst der Test die Briefing-Sperre statt der Sperrzeit."""
+    kwargs.setdefault("morgen_stunde", stunde_versetzt(5, zone=TRIP_ZONE))
+    kwargs.setdefault("abend_stunde", stunde_versetzt(9, zone=TRIP_ZONE))
+    kwargs.setdefault("quiet", ruhezeit_woanders(zone=TRIP_ZONE))
+    kwargs.setdefault("cooldown_minutes", COOLDOWN_MINUTEN)
+    write_trip(user_id, TRIP, **kwargs)
+    schnappschuss_speichern(user_id, TRIP)
+
+
+def _aenderungsalarm_zugestellt_um(user_id: str, vor_minuten: int) -> datetime:
+    """Genau die Spur eines zugestellten Aenderungsalarms — ueber den ECHTEN
+    ``ThrottleStore`` (``trip_alert.py:358`` schreibt Scope ``"trip"``)."""
+    moment = datetime.now(timezone.utc) - timedelta(minutes=vor_minuten)
+    record_throttle(user_id, SCOPE_TRIP, TRIP, moment)
+    return moment
+
+
+def _sperrzeit_eintrag(user_id: str):
+    return (read_throttle_state(user_id).get(SCOPE_TRIP) or {}).get(TRIP)
+
+
+# ═══════════ AC-4 (Kernfall): Eskalation kommt trotz Sperrzeit an ═══════════
+
+
+def test_ac4_amtliche_eskalation_kommt_trotz_juengerem_aenderungsalarm_an(nutzer):
+    """AC-4: Um T wurde ein Aenderungsalarm zugestellt (Topf ``"trip"``
+    befuellt). Um T+15 verschaerft sich dieselbe amtliche Warnung von GELB (2)
+    auf ORANGE (3) — die Eskalation MUSS zugestellt werden.
+
+    Der Aufbau faehrt die echte Eskalationslogik: Runde 1 schreibt GELB ins
+    Melde-Gedaechtnis, Runde 2 liefert dieselbe Warnung eine Stufe hoeher;
+    ``official_alert_revision_verdict()`` entscheidet selbst, dass es eine
+    Eskalation ist. Eine handgesetzte Zustandsdatei uebersprange diese
+    Entscheidung und messe am Pruefling vorbei.
+
+    Mutations-Gegenprobe (Pflicht): das Lesen von Scope ``"trip"`` im amtlichen
+    Pfad wieder einbauen MUSS diesen Test rot machen.
+
+    ROT HEUTE: ``trip_alert.py:1494`` liest denselben Topf und bricht ab.
+    """
+    uid = nutzer("ac4")
+    _trip_schreiben(uid)
+    quelle = StufenWarnquelle()
+
+    erkannt = gelb_ins_melde_gedaechtnis(uid, TRIP, quelle)
+    assert erkannt == 1, (
+        f"Aufbau-Nachweis: GELB muss zuerst erkannt und ins Melde-Gedaechtnis "
+        f"geschrieben werden, erkannt: {erkannt}")
+
+    _aenderungsalarm_zugestellt_um(uid, ESKALATION_NACH_MINUTEN)
+    assert _sperrzeit_eintrag(uid) is not None, (
+        f"Aufbau-Nachweis: Topf 'trip' muss befuellt sein: {read_throttle_state(uid)!r}")
+
+    quelle.level = 3
+    gesendet, mails = trip_amtlicher_lauf(uid, quelle=quelle)
+
+    assert gesendet >= 1, (
+        f"Die amtliche GELB→ORANGE-Eskalation {ESKALATION_NACH_MINUTEN} Minuten "
+        f"nach einem Aenderungsalarm MUSS zugestellt werden — der amtliche Pfad "
+        f"darf dessen Sperrzeit-Topf nicht mehr lesen. Zugestellt: {gesendet}, "
+        f"Mails: {len(mails)}")
+    assert len(mails) >= 1, f"Zustellung auf mindestens einem Kanal: {mails!r}"
+
+
+def test_ac4_gegenprobe_ohne_sperrzeit_bleibt_die_zustellung_unveraendert(nutzer):
+    """AC-4 (Gegenprobe): Derselbe Ablauf OHNE vorbelegte Sperrzeit stellt
+    ebenfalls zu. Trennt „Sperrzeit wirkt nicht" von „Aufbau kaputt" — ohne diese
+    Haelfte waere der Test oben auch dann rot, wenn Schnappschuss, Warnquelle
+    oder Eskalation gar nicht traegen.
+    """
+    uid = nutzer("ac4-frei")
+    _trip_schreiben(uid)
+    quelle = StufenWarnquelle()
+
+    assert gelb_ins_melde_gedaechtnis(uid, TRIP, quelle) == 1
+    assert _sperrzeit_eintrag(uid) is None, (
+        f"Aufbau-Nachweis: hier darf KEINE Sperrzeit stehen: "
+        f"{read_throttle_state(uid)!r}")
+
+    quelle.level = 3
+    gesendet, mails = trip_amtlicher_lauf(uid, quelle=quelle)
+    assert gesendet >= 1 and len(mails) >= 1, (
+        f"Ohne Sperrzeit muss unveraendert zugestellt werden: gesendet={gesendet}, "
+        f"Mails={len(mails)}")
+
+
+# ══════ AC-5: das SCHREIBEN bleibt — die harmlose Richtung bleibt zu ═══════
+
+
+def test_ac5_amtlicher_alarm_schreibt_weiterhin_in_den_trip_sperrzeit_topf(nutzer):
+    """AC-5: Nach der zugestellten Eskalation steht ein NEUER Eintrag im Topf
+    ``"trip"`` — ``trip_alert.py:1539`` bleibt bestehen.
+
+    Gemessen am Zeitstempel, nicht an blosser Anwesenheit: der Topf war vor dem
+    Lauf bereits befuellt (Aenderungsalarm zu T). „Neuer Eintrag" heisst also
+    „juenger als der vorbelegte" — ein Test auf „Schluessel vorhanden" waere
+    schon vor dem Lauf gruen und bewachte nichts.
+
+    ROT HEUTE: der Lauf stellt gar nicht zu (AC-4), es gibt keinen neuen Eintrag.
+    """
+    uid = nutzer("ac5")
+    _trip_schreiben(uid)
+    quelle = StufenWarnquelle()
+    assert gelb_ins_melde_gedaechtnis(uid, TRIP, quelle) == 1
+
+    vorher_moment = _aenderungsalarm_zugestellt_um(uid, ESKALATION_NACH_MINUTEN)
+    vorher = _sperrzeit_eintrag(uid)
+
+    quelle.level = 3
+    gesendet, mails = trip_amtlicher_lauf(uid, quelle=quelle)
+    nachher = _sperrzeit_eintrag(uid)
+
+    assert (gesendet, len(mails)) >= (1, 1), (
+        f"Voraussetzung: die Eskalation muss zugestellt werden — sonst kann "
+        f"nichts gebucht worden sein: gesendet={gesendet}, Mails={len(mails)}")
+    assert nachher is not None, (
+        f"Der amtliche Pfad MUSS weiter in den Topf 'trip' schreiben: "
+        f"{read_throttle_state(uid)!r}")
+    assert nachher != vorher, (
+        f"Der Eintrag muss NEU sein, nicht der vorbelegte: vorher={vorher!r}, "
+        f"nachher={nachher!r}")
+    assert datetime.fromisoformat(nachher) > vorher_moment, (
+        f"Der neue Eintrag muss nach {vorher_moment} liegen, steht auf {nachher!r}")
+
+
+def test_ac5_nachfolgender_aenderungsalarm_bleibt_wie_bisher_gesperrt(nutzer):
+    """AC-5 (zweite Haelfte, Regressionswaechter): Weil das Schreiben bleibt,
+    bleibt die harmlose Richtung zu — ein Aenderungsalarm NACH dem amtlichen
+    Alarm ist innerhalb des Cooldowns weiterhin gesperrt.
+
+    Gemessen an der Wetterabruf-Naht (``_fetch_fresh_weather``): 0 Abrufe heisst
+    „vor dem Abruf gesperrt". Der Kontroll-Nutzer beweist, dass der Zaehler
+    hochgehen kann — ohne ihn misst „0" moeglicherweise eine tote Naht.
+    """
+    uid = nutzer("ac5-folge")
+    _trip_schreiben(uid)
+    quelle = StufenWarnquelle()
+    assert gelb_ins_melde_gedaechtnis(uid, TRIP, quelle) == 1
+
+    quelle.level = 3
+    gesendet, mails = trip_amtlicher_lauf(uid, quelle=quelle)
+    assert (gesendet, len(mails)) >= (1, 1), (
+        f"Voraussetzung: die amtliche Warnung muss zugestellt werden: "
+        f"gesendet={gesendet}, Mails={len(mails)}")
+
+    abrufe_gesperrt = trip_change_alert_run(uid, TRIP)
+
+    kontrolle = nutzer("ac5-kontrolle")
+    _trip_schreiben(kontrolle)
+    abrufe_frei = trip_change_alert_run(kontrolle, TRIP)
+
+    assert abrufe_frei >= 1, (
+        f"Kontroll-Lauf: ohne Sperrzeit MUSS der Aenderungsalarm bis zum "
+        f"Wetterabruf kommen ({abrufe_frei} Abrufe)")
+    assert abrufe_gesperrt == 0, (
+        f"Der amtliche Alarm muss den nachfolgenden Aenderungsalarm wie bisher "
+        f"sperren, es waren {abrufe_gesperrt} Wetterabrufe")
+
+
+# ══ AC-6: der Aenderungsalarm-Pfad selbst bleibt vollstaendig unangetastet ══
+
+
+def test_ac6_aenderungsalarm_drosselung_unveraendert(nutzer):
+    """AC-6 (Regressionswaechter): Der Aenderungsalarm-Pfad
+    (``trip_alert.py:246``) drosselt unveraendert — frische Sperrzeit sperrt,
+    keine und abgelaufene lassen durch. Wuerde jemand
+    ``_is_throttled_with_cooldown`` „aufraeumend" mit entfernen, verloere der
+    Aenderungsalarm still seine Drosselung.
+    """
+    gesperrt = nutzer("ac6-gesperrt")
+    _trip_schreiben(gesperrt)
+    _aenderungsalarm_zugestellt_um(gesperrt, ESKALATION_NACH_MINUTEN)
+
+    frei = nutzer("ac6-frei")
+    _trip_schreiben(frei)
+
+    abgelaufen = nutzer("ac6-abgelaufen")
+    _trip_schreiben(abgelaufen)
+    _aenderungsalarm_zugestellt_um(abgelaufen, COOLDOWN_MINUTEN + 30)
+
+    assert trip_change_alert_run(gesperrt, TRIP) == 0, (
+        "Frische Sperrzeit muss den Aenderungsalarm vor dem Wetterabruf stoppen")
+    assert trip_change_alert_run(frei, TRIP) >= 1, (
+        "Ohne Sperrzeit muss der Aenderungsalarm unveraendert durchlaufen")
+    assert trip_change_alert_run(abgelaufen, TRIP) >= 1, (
+        f"Eine {COOLDOWN_MINUTEN + 30} Minuten alte Sperrzeit ist abgelaufen")
+
+
+# ══════ AC-10: ein pausierter Trip alarmiert weiterhin (Absicht #995) ══════
+
+
+def test_ac10_pausierter_trip_alarmiert_amtlich_weiter(nutzer):
+    """AC-10 (Regressionswaechter): Ein Trip mit gesetztem ``paused_at`` bekommt
+    seine amtliche Warnung trotzdem.
+
+    Trips kennen den Stilllegungs-Riegel des Ortsvergleichs nicht — Absicht seit
+    #995 (``trip_report_scheduler.py:882-888``: die Pause gilt NUR fuer den
+    Briefing-Versand, nicht fuer den Alarm-Dispatch). Wuerde jemand
+    ``is_silenced`` beim Vereinheitlichen in den Baustein ziehen, verstummte der
+    Alarm dieser Trips still (Risiko R-C).
+    """
+    uid = nutzer("ac10")
+    _trip_schreiben(uid, paused_at="2026-08-01T00:00:00Z")
+    quelle = StufenWarnquelle()
+    assert gelb_ins_melde_gedaechtnis(uid, TRIP, quelle) == 1
+
+    quelle.level = 3
+    gesendet, mails = trip_amtlicher_lauf(uid, quelle=quelle)
+    assert gesendet >= 1 and len(mails) >= 1, (
+        f"Ein pausierter Trip pausiert nur den Briefing-Versand, nicht den Alarm "
+        f"(#995): gesendet={gesendet}, Mails={len(mails)}")
+
+
+# ═══ AC-11: der amtliche Pfad protokolliert keine Unterdrueckungsgruende ═══
+
+
+def test_ac11_unterdrueckter_amtlicher_alarm_bekommt_keinen_grund_ins_protokoll(nutzer):
+    """AC-11 (Regressionswaechter, E3): Scheitert der amtliche Trip-Alarm an der
+    Ruhezeit, entsteht KEIN Protokolleintrag mit einem Unterdrueckungsgrund.
+
+    S3 hat die Grund-Protokollierung ausdruecklich auf die Nowcast-Pfade
+    begrenzt. Der neue Baustein liefert einen ``GateResult.reason`` — die
+    Versuchung, ihn „weil er doch da ist" mitzuschreiben, ist genau die
+    Grenzverschiebung, die diese Scheibe NICHT vornimmt.
+    """
+    uid = nutzer("ac11")
+    jetzt = datetime.now(timezone.utc).astimezone(TRIP_ZONE)
+    ruhezeit_jetzt = ((jetzt - timedelta(minutes=30)).strftime("%H:%M"),
+                      (jetzt + timedelta(minutes=30)).strftime("%H:%M"))
+    _trip_schreiben(uid, quiet=ruhezeit_jetzt)
+    quelle = StufenWarnquelle()
+    assert gelb_ins_melde_gedaechtnis(uid, TRIP, quelle) == 1
+
+    protokoll_vorher = protokoll_eintraege(uid)
+    quelle.level = 3
+    gesendet, mails = trip_amtlicher_lauf(uid, quelle=quelle)
+    neue = protokoll_eintraege(uid)[len(protokoll_vorher):]
+
+    assert (gesendet, mails) == (0, []), (
+        f"Voraussetzung: die Ruhezeit muss unterdruecken: gesendet={gesendet}, "
+        f"Mails={mails!r}")
+    gruende: set = set()
+    for eintrag in neue:
+        gruende |= suppression_reasons(eintrag)
+    assert gruende == set(), (
+        f"Der amtliche Pfad darf keine Unterdrueckungsgruende protokollieren "
+        f"(E3, Geltungsbereich bleibt Nowcast-only): {gruende!r} in {neue!r}")
+
+
+# ═══ AC-15: gebucht wird ausschliesslich nach erfolgreicher Zustellung ═════
+
+
+def test_ac15_gescheiterte_zustellung_bucht_weder_zaehler_noch_sperrzeit(nutzer):
+    """AC-15 (Regressionswaechter): Ist kein Kanal erreichbar, bleiben
+    Tageszaehler UND Sperrzeit-Eintrag exakt unveraendert; der Kontroll-Nutzer
+    belegt, dass beide Buchungen ueberhaupt stattfinden (die erste Haelfte allein
+    waere auch von einer Fassung erfuellt, die NIE bucht).
+
+    Zielt auf Risiko R-A: der Umbau verschiebt die Reihenfolge der Stufen;
+    wandert dabei ``increment()`` vor den Versand, zaehlen gescheiterte Versuche
+    als verbraucht und der Nutzer verliert Kontingent, ohne je eine Warnung
+    gesehen zu haben.
+    """
+    stumm = nutzer("ac15-stumm", tier="free")
+    _trip_schreiben(stumm)
+    quelle_stumm = StufenWarnquelle()
+    assert gelb_ins_melde_gedaechtnis(stumm, TRIP, quelle_stumm) == 1
+    zaehler_vorher = read_daily_counter(stumm, zone=TRIP_ZONE)
+    sperrzeit_vorher = read_throttle_state(stumm)
+
+    quelle_stumm.level = 3
+    gesendet, mails = trip_amtlicher_lauf(
+        stumm, quelle=quelle_stumm, settings=settings_no_channel_reachable())
+
+    assert (gesendet, mails) == (0, []), (
+        f"Ohne erreichbaren Kanal darf nichts als versendet gelten: "
+        f"gesendet={gesendet}, Mails={mails!r}")
+    assert read_daily_counter(stumm, zone=TRIP_ZONE) == zaehler_vorher, (
+        f"Tageszaehler trotz gescheiterter Zustellung erhoeht: {zaehler_vorher} "
+        f"-> {read_daily_counter(stumm, zone=TRIP_ZONE)}")
+    assert read_throttle_state(stumm) == sperrzeit_vorher, (
+        f"Sperrzeit trotz gescheiterter Zustellung gebucht: {sperrzeit_vorher!r} "
+        f"-> {read_throttle_state(stumm)!r}")
+
+    ok = nutzer("ac15-ok", tier="free")
+    _trip_schreiben(ok)
+    quelle_ok = StufenWarnquelle()
+    assert gelb_ins_melde_gedaechtnis(ok, TRIP, quelle_ok) == 1
+    quelle_ok.level = 3
+    gesendet_ok, mails_ok = trip_amtlicher_lauf(ok, quelle=quelle_ok)
+
+    assert (gesendet_ok, len(mails_ok)) >= (1, 1), (
+        f"Kontroll-Lauf: mit erreichbarem Kanal muss zugestellt werden: "
+        f"gesendet={gesendet_ok}, Mails={len(mails_ok)}")
+    assert read_daily_counter(ok, zone=TRIP_ZONE) == 1, (
+        f"Nach erfolgreicher Zustellung muss der Tageszaehler auf 1 stehen, "
+        f"steht auf {read_daily_counter(ok, zone=TRIP_ZONE)}")
+    assert (read_throttle_state(ok).get(SCOPE_TRIP) or {}).get(TRIP), (
+        f"Nach erfolgreicher Zustellung muss die Sperrzeit gebucht sein: "
+        f"{read_throttle_state(ok)!r}")

--- a/tests/tdd/test_official_alert_gate.py
+++ b/tests/tdd/test_official_alert_gate.py
@@ -1,0 +1,351 @@
+"""TDD RED — Der geteilte Freigabe-Baustein des amtlichen Alarms
+(Issue #1467 S4a, AC-1 bis AC-3, AC-9, AC-12, AC-12b, AC-16).
+
+SPEC:    docs/specs/modules/rework_1467_s4a_amtlich.md
+KONTEXT: docs/context/rework-1467-s4a-amtlich.md
+
+``check_official_alert_gate`` existiert heute nicht; beide amtlichen Pfade
+fuehren je eine eigene Inline-Kette (``compare_official_alert.py`` Ruhezeit
+``:128`` / Tageslimit ``:164`` NACH dem Abruf; ``trip_alert.py`` Ruhezeit
+``:1485`` / Sperrzeit ``:1494`` / Tageslimit ``:1497``).
+
+RED-Grund AC-1/2/3/9: ``ImportError``. RED-Grund AC-12: die aufgezeichnete
+Laufzeit-Reihenfolge enthaelt heute nur ``check_briefing_imminent``.
+
+Mock-frei: echte Presets/Orte/Trips auf Platte, echte Zustandsdateien, echte
+Warnquellen-Registry ohne Netz. Pfadregel #1409.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+for _p in (str(ROOT), str(ROOT / "src")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tests.helpers.briefing_imminent_fixtures import (  # noqa: E402
+    LOCATION_ZONE, TRIP_ZONE, clean_uid, compare_official_versand_lauf, compare_preset,
+    fresh_uid, ruhezeit_woanders, stunde_versetzt, write_location, write_presets,
+    write_trip, write_user_tier,
+)
+from tests.helpers.nowcast_gate_fixtures import (  # noqa: E402
+    read_daily_counter, seed_daily_counter,
+)
+from tests.helpers.official_alert_gate_fixtures import (  # noqa: E402
+    gate_spion, trip_amtlicher_direktlauf, zaehlende_tagesgrenze,
+)
+
+GATE = "check_official_alert_gate"
+BRIEFING = "check_briefing_imminent"
+PRESET, ORT, TRIP = "cp-1467s4a", "loc-1467s4a", "trip-1467s4a-gate"
+
+
+def _nah() -> int:
+    """Ortsstunde im 60-Minuten-Vorlauf der Briefing-Sperre (#1594)."""
+    return stunde_versetzt(1, zone=LOCATION_ZONE)
+
+
+def _ruhezeit_jetzt(zone, puffer: int = 20) -> tuple[str, str]:
+    """Fenster in der ORTSZONE des Gegenstands (dort wertet ``is_quiet_hours()``
+    seit #1726 aus), das „jetzt" umschliesst."""
+    jetzt = datetime.now(timezone.utc).astimezone(zone)
+    return ((jetzt - timedelta(minutes=puffer)).strftime("%H:%M"),
+            (jetzt + timedelta(minutes=puffer)).strftime("%H:%M"))
+
+
+@pytest.fixture
+def nutzer():
+    vergeben: list[str] = []
+
+    def _neu(kennung: str, tier: str = "premium") -> str:
+        user_id = fresh_uid(f"s4a-gate-{kennung}")
+        clean_uid(user_id)
+        write_user_tier(user_id, tier)
+        write_location(user_id, ORT)
+        vergeben.append(user_id)
+        return user_id
+
+    yield _neu
+    for user_id in vergeben:
+        clean_uid(user_id)
+
+
+def _preset_schreiben(user_id: str, **kwargs) -> None:
+    kwargs.setdefault("morgen_stunde", stunde_versetzt(5, zone=LOCATION_ZONE))
+    kwargs.setdefault("quiet", ruhezeit_woanders())
+    kwargs.setdefault("location_ids", [ORT])
+    write_presets(user_id, [compare_preset(PRESET, **kwargs)])
+
+
+def _trip_schreiben(user_id: str, **kwargs) -> None:
+    kwargs.setdefault("morgen_stunde", stunde_versetzt(5, zone=TRIP_ZONE))
+    kwargs.setdefault("abend_stunde", stunde_versetzt(9, zone=TRIP_ZONE))
+    kwargs.setdefault("quiet", ruhezeit_woanders(zone=TRIP_ZONE))
+    kwargs.setdefault("cooldown_minutes", 0)
+    write_trip(user_id, TRIP, **kwargs)
+
+
+# ══════════════ AC-1: BEIDE amtlichen Pfade rufen denselben Baustein ════════
+
+
+def test_ac1_beide_amtlichen_pfade_rufen_denselben_baustein(nutzer):
+    """AC-1: Ortsvergleich-amtlich UND Trip-amtlich rufen je Lauf mindestens
+    einmal ``check_official_alert_gate``. Ein Baustein mit nur EINEM Aufrufer
+    waere keine Entdopplung, sondern eine dritte Fassung (Hausmuster S2 AG1/S3)
+    — deshalb beides in EINEM Test.
+
+    ROT HEUTE: ``ImportError``.
+    """
+    from services.alert_gate import check_official_alert_gate  # noqa: F401
+
+    vergleich = nutzer("ac1-compare")
+    _preset_schreiben(vergleich)
+    with gate_spion() as spion_v:
+        compare_official_versand_lauf(vergleich)
+
+    trip = nutzer("ac1-trip")
+    _trip_schreiben(trip)
+    with gate_spion() as spion_t:
+        trip_amtlicher_direktlauf(trip, TRIP)
+
+    assert spion_v.zaehle(GATE) >= 1, (
+        f"Ortsvergleich muss den geteilten Baustein rufen: {spion_v.reihenfolge()!r}")
+    assert spion_t.zaehle(GATE) >= 1, (
+        f"Trip muss den geteilten Baustein rufen: {spion_t.reihenfolge()!r}")
+
+
+# ═══════════ AC-2: Ruhezeit stoppt VOR der Tages-Obergrenze ════════════════
+
+
+def test_ac2_ruhezeit_stoppt_vor_der_tages_obergrenze(nutzer):
+    """AC-2: Treffen Ruhezeit UND erschoepfte Tages-Obergrenze gleichzeitig zu,
+    haelt der Baustein an der Ruhezeit an.
+
+    Zwei unabhaengige Zeugen: der gemeldete ``reason`` (waere bei vertauschter
+    Reihenfolge ``REASON_DAILY_LIMIT``) und der Aufrufzaehler. Der
+    Kontroll-Aufruf belegt, dass der Zaehler hochgeht — sonst waere „0" die
+    Antwort einer toten Naht.
+
+    Mutations-Gegenprobe (Pflicht): Reihenfolge im Baustein vertauschen MUSS
+    diesen Test rot machen. ROT HEUTE: ``ImportError``.
+    """
+    from services.alert_gate import check_official_alert_gate
+    from services.alert_log import REASON_DAILY_LIMIT, REASON_QUIET_HOURS
+
+    uid = nutzer("ac2", tier="free")  # Limit 2
+    seed_daily_counter(uid, 2)
+    quiet_from, quiet_to = _ruhezeit_jetzt(LOCATION_ZONE)
+
+    with zaehlende_tagesgrenze() as zaehler:
+        ergebnis = check_official_alert_gate(
+            user_id=uid, quiet_from=quiet_from, quiet_to=quiet_to,
+            context_label=PRESET, now=datetime.now(timezone.utc), zone=LOCATION_ZONE)
+
+    assert ergebnis.allowed is False, f"Ruhezeit muss sperren: {ergebnis!r}"
+    assert ergebnis.reason == REASON_QUIET_HOURS, (
+        f"Der Grund muss die ERSTE zutreffende Stufe sein: {ergebnis.reason!r}")
+    assert zaehler.aufrufe == 0, (
+        f"Tages-Obergrenze darf bei aktiver Ruhezeit nicht geprueft werden, "
+        f"{zaehler.aufrufe}x gerufen")
+
+    frei_von, frei_bis = ruhezeit_woanders()
+    with zaehlende_tagesgrenze() as kontrolle:
+        ergebnis_limit = check_official_alert_gate(
+            user_id=uid, quiet_from=frei_von, quiet_to=frei_bis,
+            context_label=PRESET, now=datetime.now(timezone.utc), zone=LOCATION_ZONE)
+    assert kontrolle.aufrufe >= 1, (
+        f"Kontroll-Aufruf: ohne Ruhezeit MUSS geprueft werden ({kontrolle.aufrufe})")
+    assert ergebnis_limit.reason == REASON_DAILY_LIMIT, (
+        f"Erschoepftes Tagesbudget muss sperren: {ergebnis_limit.reason!r}")
+
+
+def test_ac2_freie_bahn_wird_durchgelassen(nutzer):
+    """AC-2 (Gegenprobe): Ohne Ruhezeit und mit freiem Tagesbudget laesst der
+    Baustein durch und nennt keinen Grund. Ohne diese Haelfte waere ein
+    Baustein, der ALLES sperrt, formal AC-konform — Risiko R-A: der Lauf bliebe
+    komplett stumm, ohne dass ein Abruf noch Symptome hinterliesse.
+
+    ROT HEUTE: ``ImportError``.
+    """
+    from services.alert_gate import check_official_alert_gate
+
+    uid = nutzer("ac2-frei", tier="free")
+    quiet_from, quiet_to = ruhezeit_woanders()
+    ergebnis = check_official_alert_gate(
+        user_id=uid, quiet_from=quiet_from, quiet_to=quiet_to,
+        context_label=PRESET, now=datetime.now(timezone.utc), zone=LOCATION_ZONE)
+
+    assert ergebnis.allowed is True, f"Ohne Sperre muss durchgelassen werden: {ergebnis!r}"
+    assert ergebnis.reason is None, f"Kein Sperrgrund erwartet: {ergebnis.reason!r}"
+
+
+# ═══ AC-3: „amtlich hat keinen Cooldown" ist Eigenschaft der Funktion ═══════
+
+
+def test_ac3_baustein_kennt_keinen_cooldown_parameter():
+    """AC-3: Die Parameterliste enthaelt keinen Cooldown-/Sperrzeit-Parameter.
+
+    Kein Stil-, sondern ein Sicherheitskriterium: haette die Funktion einen,
+    muesste jede Aufrufstelle daran denken, ``None`` zu uebergeben — und die
+    Verletzung dieser Disziplin bedeutet „amtliche Warnung bleibt aus". Die
+    zweite Haelfte verlangt die Stufen-Parameter, sonst waere eine Funktion ohne
+    jeden Parameter formal AC-konform.
+
+    ROT HEUTE: ``ImportError``.
+    """
+    import inspect
+
+    from services.alert_gate import check_official_alert_gate
+
+    namen = list(inspect.signature(check_official_alert_gate).parameters)
+    verboten = [n for n in namen
+                if any(t in n.lower() for t in ("cooldown", "throttle", "sperr"))]
+
+    assert verboten == [], (
+        f"Kein Cooldown-/Sperrzeit-Parameter erlaubt — gefunden {verboten!r} "
+        f"(alle: {namen!r})")
+    for pflicht in ("user_id", "quiet_from", "quiet_to", "now", "zone"):
+        assert pflicht in namen, f"Pflicht-Parameter {pflicht!r} fehlt: {namen!r}"
+
+
+# ══════ AC-9: der Stilllegungs-Riegel bleibt AUSSERHALB des Bausteins ══════
+
+
+def test_ac9_stillgelegtes_preset_erreicht_den_baustein_gar_nicht(nutzer):
+    """AC-9: Bei einem stillgelegten Preset (``is_silenced``) wird
+    ``check_official_alert_gate`` gar nicht erst gerufen.
+
+    Risiko R-C: zieht jemand ``is_silenced`` spaeter „vereinheitlichend" in den
+    Baustein, aendert sich still das TRIP-Verhalten — Trips kennen das Konzept
+    nicht, und ein pausierter Trip soll weiter alarmieren (#995, s. AC-10). Der
+    Kontroll-Nutzer belegt, dass der Zaehler hier hochgeht.
+
+    ROT HEUTE: ``ImportError``.
+    """
+    from services.alert_gate import check_official_alert_gate  # noqa: F401
+
+    still = nutzer("ac9-still")
+    _preset_schreiben(still, paused_at="2026-08-01T00:00:00Z")
+    with gate_spion() as spion_still:
+        compare_official_versand_lauf(still)
+
+    aktiv = nutzer("ac9-aktiv")
+    _preset_schreiben(aktiv)
+    with gate_spion() as spion_aktiv:
+        compare_official_versand_lauf(aktiv)
+
+    assert spion_aktiv.zaehle(GATE) >= 1, (
+        f"Kontroll-Lauf: aktives Preset MUSS den Baustein erreichen: "
+        f"{spion_aktiv.reihenfolge()!r}")
+    assert spion_still.zaehle(GATE) == 0, (
+        f"Stillgelegtes Preset darf den Baustein nicht erreichen — der Riegel "
+        f"wirkt VOR allem anderen: {spion_still.reihenfolge()!r}")
+
+
+# ════════ AC-12: Gate VOR der Briefing-Sperre, in BEIDEN Pfaden ═══════════
+
+
+def test_ac12_gate_laeuft_vor_der_briefing_sperre_in_beiden_pfaden(nutzer):
+    """AC-12: In BEIDEN amtlichen Pfaden laeuft ``check_official_alert_gate``
+    als erste Stufe und ``check_briefing_imminent`` unmittelbar danach — als
+    weiterhin EIGENER Aufruf, nicht in den Baustein verschmolzen.
+
+    ``trip_alert.py:1487-1490`` haelt seit #1594 fest, dass die Briefing-Sperre
+    „dieselbe Stufe wie im Aenderungspfad, gleiche Position (nach der Ruhezeit)"
+    einnimmt. Weil die Ruhezeit jetzt IM Baustein sitzt, wuerde ein Gate-Aufruf
+    NACH der Briefing-Sperre diese Festlegung still umdrehen. Gemessen zur
+    LAUFZEIT — ein Quellcode-Grep saehe beide Aufrufe und koennte ihre
+    Reihenfolge nicht belegen.
+
+    Mutations-Gegenprobe (Pflicht): die beiden Aufrufe vertauschen MUSS diesen
+    Test rot machen. ROT HEUTE: aufgezeichnet wird nur ``check_briefing_imminent``.
+    """
+    from services.alert_gate import check_official_alert_gate  # noqa: F401
+
+    vergleich = nutzer("ac12-compare")
+    _preset_schreiben(vergleich)
+    with gate_spion() as spion_v:
+        compare_official_versand_lauf(vergleich)
+
+    trip = nutzer("ac12-trip")
+    _trip_schreiben(trip)
+    with gate_spion() as spion_t:
+        trip_amtlicher_direktlauf(trip, TRIP)
+
+    assert spion_v.reihenfolge()[:2] == [GATE, BRIEFING], (
+        f"Ortsvergleich: erwartet {[GATE, BRIEFING]!r}, aufgezeichnet "
+        f"{spion_v.reihenfolge()!r}")
+    assert spion_t.reihenfolge()[:2] == [GATE, BRIEFING], (
+        f"Trip: erwartet {[GATE, BRIEFING]!r}, aufgezeichnet "
+        f"{spion_t.reihenfolge()!r}")
+
+
+def test_ac12b_erschoepftes_kontingent_und_briefing_lassen_den_zaehler_in_ruhe(nutzer):
+    """AC-12b (Regressionswaechter): Tages-Obergrenze UND Briefing-Vorlauf
+    gleichzeitig — nichts wird zugestellt, der Tageszaehler bleibt exakt gleich.
+    Das belegt, dass das Vorziehen der Tages-Obergrenze VOR die Briefing-Sperre
+    wirkungsfrei ist (``is_allowed()`` rein lesend, gebucht wird per
+    ``increment()`` erst nach erfolgreicher Zustellung).
+
+    Der zweite Fall (freies Kontingent, Briefing steht an) stellt aus dem
+    ANDEREN Grund nichts zu; ohne ihn liessen sich die Gruende nicht trennen.
+    """
+    beides = nutzer("ac12b-beides", tier="free")
+    seed_daily_counter(beides, 2)
+    _preset_schreiben(beides, morgen_stunde=_nah())
+    vorher_b = read_daily_counter(beides)
+    sent_b, mails_b = compare_official_versand_lauf(beides)
+
+    nur_briefing = nutzer("ac12b-briefing", tier="free")
+    seed_daily_counter(nur_briefing, 0)
+    _preset_schreiben(nur_briefing, morgen_stunde=_nah())
+    vorher_n = read_daily_counter(nur_briefing)
+    sent_n, mails_n = compare_official_versand_lauf(nur_briefing)
+
+    assert (sent_b, mails_b) == (0, []), (
+        f"Erschoepftes Kontingent + Briefing: nichts darf raus ({sent_b}, {mails_b!r})")
+    assert read_daily_counter(beides) == vorher_b, (
+        f"Gesperrter Lauf darf den Zaehler nicht aendern: {vorher_b} -> "
+        f"{read_daily_counter(beides)}")
+    assert (sent_n, mails_n) == (0, []), (
+        f"Freies Kontingent, aber Briefing steht an: Sperre greift "
+        f"({sent_n}, {mails_n!r})")
+    assert read_daily_counter(nur_briefing) == vorher_n, (
+        f"Auch die Briefing-Sperre darf nichts buchen: {vorher_n} -> "
+        f"{read_daily_counter(nur_briefing)}")
+
+
+# ════════════════════════ AC-16: Mandantentrennung ════════════════════════
+
+
+def test_ac16_erschoepftes_kontingent_wirkt_nicht_ueber_die_nutzergrenze(nutzer):
+    """AC-16 (Regressionswaechter): Zwei Nutzer mit DERSELBEN Preset-Kennung —
+    das erschoepfte Tagesbudget von A darf B nicht sperren.
+
+    Risiko R-A in seiner haesslichsten Form: faellt die Nutzer-Aufloesung im
+    neuen Baustein still auf ``"default"`` zurueck, teilen sich alle Nutzer einen
+    Zaehler; der erste erschoepft ihn, alle uebrigen bleiben stumm — ohne jede
+    Fehlermeldung. Nachweis mit ZWEI Datenverzeichnissen ist Pflicht (CLAUDE.md).
+    """
+    a, b = nutzer("ac16-a", tier="free"), nutzer("ac16-b", tier="free")
+    for uid in (a, b):
+        _preset_schreiben(uid)  # gleiche Preset-Kennung
+    seed_daily_counter(a, 2)
+    seed_daily_counter(b, 0)
+
+    sent_a, mails_a = compare_official_versand_lauf(a)
+    sent_b, mails_b = compare_official_versand_lauf(b)
+
+    assert (sent_a, mails_a) == (0, []), (
+        f"A hat sein Tagesbudget aufgebraucht: sent={sent_a}, Mails={mails_a!r}")
+    assert sent_b >= 1 and len(mails_b) >= 1, (
+        f"Das Tagesbudget von A darf B — gleiche Kennung, anderes Konto — NICHT "
+        f"sperren: sent={sent_b}, Mails={len(mails_b)}")
+    assert read_daily_counter(a) == 2 and read_daily_counter(b) == 1, (
+        f"Zaehlerstaende: A={read_daily_counter(a)} (erwartet 2), "
+        f"B={read_daily_counter(b)} (erwartet 1)")


### PR DESCRIPTION
## Was

Trip und Ortsvergleich pruefen amtliche Warnungen jetzt ueber denselben Baustein `check_official_alert_gate` (Ruhezeit → Tages-Obergrenze, Abbruch bei der ersten Stufe) statt ueber zwei auseinandergelaufene Inline-Ketten.

## Zwei bewusste Verhaltensaenderungen

- **E1 (Trip):** Das Lesen der Aenderungsalarm-Sperrzeit entfaellt im amtlichen Pfad. Eine amtliche Eskalation kann nicht mehr bis zu 120 Minuten ausbleiben, nur weil kurz zuvor ein harmloser Aenderungsalarm zugestellt wurde. Das Schreiben in den `"trip"`-Topf bleibt bestehen — die harmlose Richtung bleibt unveraendert gedrosselt.
- **E2 (Ortsvergleich):** Die Tages-Obergrenze wird vor dem Warnungs-Abruf geprueft statt danach. Wirkungsfrei fuer das Zustellergebnis, weil erst `increment()` nach erfolgreicher Zustellung bucht.

`check_official_alert_gate` kennt strukturell **keinen** Cooldown-Parameter — die Zusicherung ist eine Eigenschaft des Funktionstyps, nicht eine Disziplin der Aufrufstelle (AC-3).

## Struktur

Neu: `src/services/compare_preset_access.py` buendelt Preset-Laden und NotificationService-Aufbau der drei Compare-Alarmpfade; die Bestandsmethoden sind Ein-Zeiler-Wrapper, `log_label` traegt die einzige echte Abweichung.

Unangetastet: `is_silenced` bleibt Compare-eigen und ausserhalb des Bausteins, `_day_window_end()` textidentisch, Unterdrueckungsgruende bleiben Nowcast-only.

## Nachweis

- **Adversary VERIFIED**, 19/19 ACs mit eigener Rot/Gruen-Evidenz. Acht Mutations-Gegenproben, alle von Tests gefangen — darunter zweimal unabhaengig der Kernfall (Cooldown-Lesen reaktivieren → rot) und die Buchungs-Reihenfolge (`increment()` vor Zustellung → rot).
- **Volllauf offline:** 9401 passed, 105 skipped, 11 xfailed. Der eine Fehlschlag (`test_issue_1014_live_optin.py`) ist eine reihenfolgebedingte Test-Isolationsluecke im Telegram-Fixture, isoliert gruen, Ursache reproduziert und in #1196 gebucht — nicht von dieser Scheibe verursacht.
- **Scope:** 6 Produktivdateien (1 neu), LoC +131/250.

## Offen

S4a schliesst #1467 **nicht** — das tut erst S4b (#1744 Scheibe B, Entdopplung nach Ereignis-Identitaet).

Refs #1467

🤖 Generated with [Claude Code](https://claude.com/claude-code)