### PR TITLE
fix(#1765 B1b): Versand und Sofortvergleich verarbeiten Orte gleichzeitig

### DIFF
--- a/api/routers/compare.py
+++ b/api/routers/compare.py
@@ -33,7 +33,7 @@ def run_comparison(
 ):
     from app.loader import load_all_locations
     from app.profile import ActivityProfile
-    from services.comparison_engine import ComparisonEngine
+    from services.comparison_parallel import run_comparison_parallel
 
     all_locations = load_all_locations()
 
@@ -68,12 +68,19 @@ def run_comparison(
         except ValueError:
             pass  # Invalid profile → default to allgemein
 
-    result = ComparisonEngine.run(
+    # Issue #1765 Scheibe B1b: die Orte werden gleichzeitig statt nacheinander
+    # gerechnet (ein Engine-Lauf JE ORT) -- sonst riss der Sofortvergleich ab
+    # drei Orten die 60-Sekunden-Grenze zwischen Go-API und nginx. Alle uebrigen
+    # Parameter unveraendert; ``comparison_engine.py`` bleibt unangetastet.
+    # ``call_source`` MUSS ausdruecklich gesetzt werden: ein ThreadPoolExecutor
+    # reicht den ContextVar-Kontext nicht an seine Arbeiter weiter.
+    result = run_comparison_parallel(
         locations=selected,
         time_window=(time_window_start, time_window_end),
         target_date=td,
         forecast_hours=forecast_hours,
         profile=profile,
+        call_source="vergleich",
     )
 
     # Convert to JSON-serializable dict

--- a/docs/context/fix-1765-b1b-versand-parallel.md
+++ b/docs/context/fix-1765-b1b-versand-parallel.md
@@ -1,0 +1,232 @@
+# Context: #1765 B1b — Versand + Sofortvergleich parallel
+
+**Workflow:** `fix-1765-b1b-versand-parallel` · **Issue:** #1765 (B1b schliesst es) ·
+**Erstellt:** 2026-08-16 · **Basis:** `098226ae` (B1 live)
+
+## Request Summary
+
+Die beiden verbliebenen Aufrufstellen von `ComparisonEngine.run()` — **Versand**
+(`src/services/scheduler_dispatch_service.py:451`, laeuft auch unbeaufsichtigt per Cron)
+und **Sofortvergleich** (`api/routers/compare.py:71`) — auf den in Scheibe B1 gelieferten,
+signaturgleichen Baustein `run_comparison_parallel()` umstellen. Damit verarbeiten alle
+drei Wege die Orte gleichzeitig statt nacheinander; der 60-s-nginx-Timeout aus #1765
+faellt auch fuer Versand (gemeldet: 504 bei 4 Orten) und Sofortvergleich.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/comparison_parallel.py` | Der Baustein (B1, live). Signaturgleich zu `ComparisonEngine.run` + keyword-only `call_source`. `MAX_PARALLEL_LOCATIONS = 4` (Z.42) |
+| `src/services/scheduler_dispatch_service.py:350-572` | `send_one_compare_preset()` — Versandpfad, **Aufrufstelle 1** (Z.451) |
+| `api/routers/compare.py:26-77` | `run_comparison()` (`GET /api/compare`) — **Aufrufstelle 2** (Z.71), bereits plain `def` |
+| `src/services/compare_preview_service.py:144,170-178` | Vorlage: so ruft B1 den Baustein auf (`call_source="vergleich"`, lokaler Import) |
+| `src/services/official_alerts/warn_egress.py:296-379` | `cached_fetch()` — geteilter Kern **aller 7** Amtswarn-Quellen, **ohne Sperre** |
+| `src/services/official_alerts/meteoalarm.py:280-322,768` | `_country_store()`/`_merge_into_store()` — Read-Modify-Write **ohne Sperre**, Schluessel `country:slot:page` deckt **AT** und IT |
+| `src/services/comparison_engine.py:319-335` | Ruft `get_official_alerts_with_status()` **je Ort** — der Weg, ueber den die Amtswarn-Caches nebenlaeufig erreicht werden |
+| `src/services/dispatch_orchestrator.py:229` | Presets werden weiterhin **sequentiell** dispatcht — diese Scheibe parallelisiert nur *innerhalb* eines Presets |
+
+## Dependencies
+
+- **Upstream (was wir benutzen):** `run_comparison_parallel()` → `ComparisonEngine.run(locations=[ein_ort])`
+  je Worker-Thread → Provider-Registry (seit `28b40448` gesperrt), Wetter-/Radar-/Gewitter-Caches
+  (gesperrt), Zeitzonen-Singleton (gesperrt), **Amtswarn-Quellen (NICHT gesperrt)**.
+- **Downstream (was uns benutzt):** Versand → `_dispatch_due_preset()` → `CompareDispatchStrategy.dispatch_one()`
+  → `run_briefing_dispatch()`; Cron-Endpunkt `POST /api/scheduler/compare-presets-daily`
+  (stuendlich), Einzelversand `POST /api/scheduler/compare-presets/{id}/send`.
+  Sofortvergleich → Go-Proxy `internal/router/router.go:156` (Timeout 60 s, Auth-Block).
+
+## Existing Patterns
+
+- **Ortsreihenfolge:** beide Wege garantieren die **konfigurierte** Reihenfolge
+  (`comparison_engine.py:383-386` bzw. `comparison_parallel.py:99-100`, Ergebnis landet ueber
+  den Index). `result.locations` ist **nicht** score-sortiert.
+- **Fehlerform:** einzelner Ortsfehler → `LocationResult(error=…)` an seiner Position;
+  **alle** Orte scheitern → erste Ausnahme wird erneut geworfen (AC-8 aus B1).
+- **Aufruf-Journal:** `call_source` muss explizit gesetzt werden — ein `ThreadPoolExecutor`
+  reicht den `ContextVar`-Kontext nicht weiter (`providers/call_log.py:58-84`).
+- **Lazy-Init-Absicherung:** doppelt geprüfte Sperre **plus separates Fertig-Flag**
+  (`src/providers/base.py:191-282`) — das Vorbild aus B1.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1765_b1_compare_vorschau_parallel.md` — Scheibe B1 (Baustein, AC-1…AC-9)
+- `docs/specs/modules/fix_1765_1839_sa_vorschau_entblockung.md` — Scheibe A (13 Handler `async def` → `def`)
+- `docs/context/fix-1765-compare-vorschau-parallel.md` — Analyse B1
+- `docs/reference/decision_matrix.md:231-254` — Meteo-France: 100 Anfragen/Min, geteiltes Konto, ungedrosselt
+
+## Risks & Considerations
+
+### R1 — Amtswarn-Caches: WIDERLEGT, kein Handlungsbedarf ✅
+
+**Ursprungsverdacht (aus dem Bestandsscan):** ungesicherter Read-Modify-Write in
+`meteoalarm._merge_into_store()` koenne bei paralleler Ortsverarbeitung Warnungen
+verschlucken. Daraus entstand Issue #1890.
+
+**Nachgemessen am laufenden System — der Verdacht traegt nicht.** `_REGISTERED_SOURCES`
+enthaelt zur Laufzeit sieben Quellen; `MeteoAlarmSource` (die Klasse mit diesem Code) ist
+**nicht darunter** — sie wird seit #1445 S3 nicht mehr registriert (`__init__.py:31-34`:
+„Code bleibt bestehen, dient nur noch dem Aequivalenznachweis"). Im Produktivcode nirgends
+instanziiert, nur in Tests. Der aktive AT/IT-Pfad ist `meteoalarm_feed.py`.
+
+Suche nach Iteration ueber veraenderlichen Modul-Zustand (`.items()`/`.values()`/`.keys()`/
+`del`/`.pop()`/`.setdefault()`/`.update()`) ueber alle 7 registrierten Quellen plus
+`warn_egress.py` und `base.py`: **null Treffer**; Positivkontrolle gegen das tote
+`meteoalarm.py` mit demselben Muster: 8 Treffer. `cached_fetch()` macht nur
+`cache.get(key)` (Z.351) und `cache[key] = {…}` (Z.375) — unter der GIL atomar.
+
+Ebenfalls ausgeraeumt: die `ContextVar` `_fetch_failure_sink` (`warn_egress.py:55`) wird in
+`base.py:146` **im selben Worker-Thread** gesetzt und gelesen (jeder Ort laeuft komplett in
+seinem Thread) — korrekt isoliert. Und `MeteoAlarmBudgetGate` (100 Abrufe/Tag) haengt
+ausschliesslich am toten `meteoalarm.py`; der aktive Feed-Pfad kennt kein Budget-Gate, ein
+doppelter Abruf kann dort also kein Kontingent reissen.
+
+**Rest:** bei zeitgleichem Cache-Miss auf denselben Schluessel entstehen redundante
+HTTP-Abrufe (`meteoalarm_feed._cache` schluesselt auf `country`, also ein Eintrag fuer alle
+AT-Orte). Reine Hoeflichkeit gegenueber dem Fremddienst, kein Datenverlust — als Zeile in
+**#1199** gebucht. #1890 geschlossen.
+
+⚠️ **Merksatz:** Ein Bestandsscan liefert Verdachtsstellen, keine Befunde. Zwischen „im Code
+steht ungesicherter gemeinsamer Zustand" und „dieser Zustand ist auf dem Live-Pfad
+erreichbar" liegt eine Messung. Eine grobe Sperre um `cached_fetch()` waere hier ausserdem
+schaedlich gewesen — sie haette die Parallelitaet aus B1 wieder serialisiert.
+
+### R2 — ENTSCHAERFT: die Bestands-Tests brauchen keine Anpassung ✅
+
+**Nachgemessen** (`grep -n "score\|temp_max"` ueber alle sieben Dateien): Die gestaffelten
+Werte erscheinen **ausschliesslich in den Definitionszeilen** der Fake-Engines
+(`channel_fanout.py:158-159`, `failed_tally.py:168-169`, `anchor_survives:148`,
+`anchor_and_memory_reset:257`) — **keine einzige Assertion** liest `.score` oder
+`.temp_max`. Ausserdem fuehren fast alle Presets dieser Tests nur **einen** Ort, womit `i`
+ohnehin 0 bleibt wie bisher.
+
+⇒ **Kein Test wird rot, keine Anpassung noetig.** Die urspruengliche Einschaetzung
+(„sieben Tests muessen nachgezogen werden") war zu pessimistisch.
+
+**Was stattdessen bleibt — der eigentliche Befund:** Diese Tests bewachen die
+Orts-Staffelung **gar nicht**. Waere der Swap fehlerhaft und alle Orte bekaemen identische
+Wetterwerte, faenge das **kein** Bestands-Test. Das ist kein Blocker, sondern die
+Begruendung fuer AC-4 (s. Spec): der Nachweis, dass jeder Ort im Versandpfad seine
+**eigenen** Werte in die Mail bekommt, muss neu gebaut werden.
+
+Details zur Patch-Mechanik: vier Dateien nutzen Direktzuweisung statt `monkeypatch`
+(`mail_marker:118`, `fixed_window:108`, `test_issue_1040_alerts_toggle:302`,
+`test_issue_764_compare_forecast_hours_consume:118`). Unkritisch, weil die Zuweisung **vor**
+dem Thread-Start und der Reset **nach** dessen Abschluss liegt. Keine der insgesamt 14
+gefundenen Fake-Engines haelt gemeinsamen veraenderlichen Zustand — alle bauen ihr Ergebnis
+rein aus den Aufrufargumenten.
+
+### R2-alt — urspruengliche Annahme (widerlegt, zur Nachvollziehbarkeit)
+
+`_run_one_location()` ruft `ce_mod.ComparisonEngine.run(locations=[EIN Ort])`. Die
+Fake-Engines der Bestands-Tests bauen ihre Werte aber ueber `enumerate(locations)` mit
+gestaffelten Groessen (`score=90-7*i`, `temp_max=22.0+i`) — gedacht fuer **einen** Aufruf mit
+der vollen Liste. Nach dem Swap ist `i` bei jedem Aufruf 0 ⇒ **alle Orte bekommen identische
+Werte**. Kein bestehender Assert prueft diese Werte, die Tests bleiben also gruen, waehrend
+ihr Mail-Inhalt nicht mehr das prueft, was er zu pruefen vorgibt.
+
+Betroffen: `test_compare_dispatch_failed_tally.py:185`, `test_compare_dispatch_mail_marker.py:118`,
+`test_compare_dispatch_fixed_window.py:108`, `test_compare_dispatch_channel_fanout.py:175`,
+`test_compare_briefing_anchor_survives_dispatch_failure.py:159`,
+`test_compare_briefing_anchor_and_memory_reset.py:268` (Modul-Attribut-Patch) sowie
+`test_versandpfade_folgen_ortszone.py:676` (Klassen-Patch, bleibt gueltig, da `target_date`
+ortsunabhaengig ist).
+
+Zwei der sechs patchen **ohne** `monkeypatch` (direkte Zuweisung mit `finally`-Reset) —
+das ueberlebt einen Thread-Abbruch nicht sauber.
+
+### R3 — Neue Test-Stubs brauchen Thread-Sicherheit
+
+Die sechs vorhandenen Fake-Engines sind zustandslos pro Aufruf, daher aktuell kein Rennen.
+Jeder **neue** Test mit gemeinsamem Aufruf-Zaehler/Protokoll braucht ab jetzt eine Sperre —
+sonst wiederholt sich das B1-Muster (gruener Test, abgestuerzter Worker-Thread; pytest
+meldet Thread-Ausnahmen nur als **Warnung**).
+
+### R4 — Cron-Ueberlagerung ueber Nutzer hinweg (aus dem Issue uebernommen)
+
+Der Cron-Endpunkt laeuft je `user_id` bereits nebeneinander. Mit Ortsparallelitaet
+addieren sich die Abrufe **ueber Nutzer hinweg** gegen das gemeinsame, ungedrosselte
+Meteo-France-Kontingent (100/Min). Presets werden innerhalb eines Laufs weiterhin
+sequentiell abgearbeitet (`dispatch_orchestrator.py:229`), die Obergrenze je Preset ist 4.
+
+### R5 — `top_ort` ist unkritisch, aber nutzersichtbar persistiert
+
+`top_ort = result.locations[0].location.name` (Z.460) ist der **erste konfigurierte** Ort,
+nicht der Sieger. Beide Wege garantieren dieselbe Reihenfolge ⇒ der Swap aendert nichts.
+Der Wert wird als `top_ort_letzter_versand` persistiert und als API-Feld `winner`
+zurueckgegeben (im Frontend derzeit nirgends gerendert). Braucht laut Issue trotzdem einen
+eigenen Nachweis im Versandpfad.
+
+### R6 — `GET /api/compare` ignoriert den `user_id` (Nebenbefund, eigenes Issue)
+
+Die Go-API haengt den echten `user_id` an (`internal/handler/proxy.go:73-101`), aber
+`run_comparison()` hat keinen `user_id`-Parameter und ruft `load_all_locations()` **ohne
+Argument** → Rueckfall auf den `"default"`-Nutzer. Verstoss gegen die Mandantentrennungs-
+Pflicht. **Nicht Teil dieser Scheibe**, aber relevant: ein Fix wuerde dieselbe Aufrufstelle
+anfassen. Der Endpunkt hat ausserdem **kein Limit** auf die Ortsanzahl.
+
+### R7 — Ausserhalb der Engine ist nichts reihenfolgeabhaengig
+
+`first_resolvable_tz(locations, …)` (Z.441) und `target_date` werden **vor** dem
+Engine-Aufruf ausgewertet. Die Δ-Anker `f"{preset_id}:{loc.id}"` (Z.514-527) bilden eine
+**Menge**. `_write_compare_alert_snapshots()` (Z.611-667) bleibt eine sequentielle Schleife
+und schreibt je Ort eine **eigene** Datei. `letzter_versand` wird nur im Erfolgsfall
+geschrieben (Z.570). Kein Handlungsbedarf.
+
+## Analysis
+
+### Type
+Bug (Fortsetzung von #1765; B1b schliesst das Ticket)
+
+### Affected Files
+
+| Datei | Aenderung | Beschreibung |
+|---|---|---|
+| `src/services/scheduler_dispatch_service.py` | MODIFY | Z.451 `ComparisonEngine.run(…)` → `run_comparison_parallel(…, call_source="vergleich")`, lokaler Import |
+| `api/routers/compare.py` | MODIFY | Z.71 dieselbe Ersetzung |
+| `tests/unit/test_compare_versand_parallel.py` | CREATE | Nachweis Versandpfad (Gleichzeitigkeit, Reihenfolge, `top_ort`, Ortswerte, Fehlerformen) |
+| `tests/unit/test_sofortvergleich_parallel.py` | CREATE | Nachweis Sofortvergleich |
+
+**Keine** Aenderung an den 14 Bestands-Test-Dateien mit Engine-Stub (gemessen, s. R2).
+**Keine** Aenderung an `comparison_engine.py` und `comparison_parallel.py`.
+
+### Scope Assessment
+
+- Produktiv: 2 Dateien, **~12 LoC**
+- Test: 2 neue Dateien, **~350-450 LoC** (Erfahrungswert aus B1: Testanteil ×3-4, weil bei
+  Nebenlaeufigkeit jedes Kriterium einen eigenen Aufbau braucht, der sich nicht teilen laesst)
+- **LoC-Limit 250 wird gerissen** → Override auf 500 noetig, PO-Freigabe erforderlich
+- Risiko: **MEDIUM** — Mechanismus in B1 bewiesen und live, aber erstmals auf einem
+  unbeaufsichtigten, zustandsschreibenden Pfad
+
+### Technical Approach
+
+Reiner Aufrufweg-Tausch, kein neuer Mechanismus. `run_comparison_parallel()` ist
+signaturgleich; `call_source="vergleich"` wird explizit gesetzt, weil ein
+`ThreadPoolExecutor` den `ContextVar`-Kontext nicht an seine Worker vererbt und die
+Stack-Marker-Liste (`call_log.py:43-55`) im Worker-Thread ins Leere liefe.
+
+Der Nachweis ist die eigentliche Arbeit und folgt den in B1 bewaehrten Regeln:
+Gleichzeitigkeit ueber `threading.Barrier`, **nie** ueber Wanduhr-Dauer; Pflichtmutation
+`max_workers=1` (muss rot werden); Thread-Ausnahmen einsammeln und den Test daran scheitern
+lassen (pytest meldet sie sonst nur als Warnung).
+
+### Dependencies
+
+Keine neuen. `run_comparison_parallel` ist seit `098226ae` live und auf dem Vorschau-Pfad
+in Betrieb.
+
+### Open Questions
+
+- [x] Amtswarn-Sperren noetig? → **Nein**, R1 widerlegt
+- [x] Bestands-Tests anpassen? → **Nein**, R2 gemessen
+- [x] Cron-Ueberlagerung drosseln? → **Nein**: 2 Nutzer in der Produktions-Datenwurzel,
+      Presets laufen sequentiell (`dispatch_orchestrator.py:229`), Obergrenze 4 je Preset
+      ⇒ hoechstens 8 gleichzeitige Ortsverarbeitungen gegen 100 Anfragen/Minute
+- [ ] LoC-Override auf 500 — braucht PO-Freigabe
+
+## Entscheidung nach der Nachmessung
+
+R1 ist widerlegt (s.o.), damit entfaellt die Frage nach einer vorgezogenen Scheibe.
+**B1b laeuft unveraendert weiter.** Der Arbeitsschwerpunkt liegt auf R2 (die sieben
+Bestands-Tests, deren Fake-Engines nach dem Swap still identische Werte liefern) und R3
+(Thread-Sicherheit neuer Test-Stubs) — nicht auf zusaetzlichen Sperren im Produktivcode.

--- a/docs/specs/modules/fix_1765_b1b_versand_sofortvergleich_parallel.md
+++ b/docs/specs/modules/fix_1765_b1b_versand_sofortvergleich_parallel.md
@@ -3,7 +3,7 @@ entity_id: fix_1765_b1b_versand_sofortvergleich_parallel
 type: module
 created: 2026-08-16
 updated: 2026-08-16
-status: draft
+status: approved
 version: "1.0"
 tags: [issue-1765, ortsvergleich, nebenlaeufigkeit, versand]
 ---
@@ -12,7 +12,7 @@ tags: [issue-1765, ortsvergleich, nebenlaeufigkeit, versand]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO, 2026-08-16 (ACs + LoC-Override auf 500)
 
 ## Purpose
 

--- a/docs/specs/modules/fix_1765_b1b_versand_sofortvergleich_parallel.md
+++ b/docs/specs/modules/fix_1765_b1b_versand_sofortvergleich_parallel.md
@@ -141,14 +141,53 @@ result = run_comparison_parallel(
   - Test: `threading.Barrier` wie AC-1, ueber den echten Router (`TestClient`); geprueft
     wird die Ortsreihenfolge im JSON-Antwortkoerper.
 
-- **AC-8:** Given ein Versand mit mehreren Orten / When die Wetterabrufe laufen / Then
-  traegt jeder Abruf im Aufruf-Journal die Quelle `vergleich`, auch aus dem Worker-Thread
-  - Test: `resolve_call_source()` innerhalb der Fake-Engine auslesen und je Ort pruefen.
-    Pflichtmutation: `call_source` weglassen muss den Test rot machen.
+- **AC-8:** Given ein Versand **oder ein Sofortvergleich** mit mehreren Orten / When die
+  Wetterabrufe laufen / Then traegt jeder Abruf im Aufruf-Journal die Quelle `vergleich`,
+  auch aus dem Worker-Thread
+  - Test: `resolve_call_source()` innerhalb der Fake-Engine auslesen und je Ort pruefen —
+    **je einmal fuer BEIDE Aufrufstellen** (`scheduler_dispatch_service.py` und
+    `api/routers/compare.py`, letzteres ueber den echten Router).
+    Pflichtmutation: `call_source` weglassen muss den Test rot machen — **an jeder der
+    beiden Stellen einzeln**.
+
+  ⚠️ Diese Formulierung ist die Korrektur eines Spec-Fehlers (Adversary-Finding F001,
+  CRITICAL): AC-8 war urspruenglich nur auf „Given ein Versand" zugeschnitten, waehrend die
+  Implementation Details `call_source` ohne Einschraenkung fuer **beide** Aufrufstellen
+  verlangen. Die Mutation „`call_source` am Sofortvergleich entfernen" liess daraufhin die
+  gesamte Suite gruen — die Zusicherung war nur an einer von zwei Wirkstellen geprueft.
 
 - **AC-9:** Given die Bestands-Testsuite des Versandpfads / When die Umstellung erfolgt ist
-  / Then bleiben alle 14 Testdateien mit Engine-Stub unveraendert gruen
-  - Test: Die betroffenen Dateien werden benannt ausgefuehrt; keine Datei wird angepasst.
+  / Then bleiben die Bestands-Testdateien mit Engine-Stub gruen, mit **genau einer benannten
+  Ausnahme** (s.u.)
+  - Test: Die betroffenen Dateien werden benannt ausgefuehrt; ausser der benannten Ausnahme
+    wird keine Datei angepasst.
+
+  **Benannte Ausnahme — `tests/tdd/test_vorschau_anzeige_folgen_ortszone.py`:** Die Sonde
+  `_leeres_vergleichsergebnis()` (Z.425-430) liefert `ComparisonResult(locations=[])` — also
+  **null** Ortsergebnisse fuer **einen** angeforderten Ort. Das widerspricht dem Vertrag der
+  Engine, die in `comparison_engine.py:127` ueber `for loc in locations:` je Ort **genau
+  ein** Ergebnis anhaengt (Z.143/337/378); ein leeres `locations` bei nicht-leerer Ortsliste
+  kann die echte Engine nicht erzeugen. Seriell fiel das nie auf (der Router iterierte ueber
+  eine leere Liste); parallel liest `comparison_parallel._run_one_location` (Z.83)
+  `result.locations[0]` und laeuft in einen `IndexError`.
+
+  **Korrektur:** der Stub liefert ein `LocationResult` fuer den angeforderten Ort. Die
+  Zusicherung der drei betroffenen Tests (`target_date` folgt dem **Ortstag**, nicht der
+  Serveruhr) bleibt woertlich unveraendert.
+
+  **Gegenprobe (korrigiert):** Die Verfaelschung muss am **Wirkort** ansetzen, nicht in der
+  Sonde. Das `target_date` der Sonde zu verfaelschen bleibt folgenlos — `api/routers/compare.py`
+  baut den Antwortwert aus dem selbst berechneten `td`, **nicht** aus `result.target_date`;
+  der Sondenwert erreicht die Zusicherung nie. (Der Docstring der Sonde behauptete das
+  Gegenteil und war schon vor dieser Scheibe falsch.) Gueltig ist stattdessen die
+  Verfaelschung in der Produktion:
+  `local_now = local_dt(datetime.now(timezone.utc), zone)` → `local_now = datetime.now()`
+  ⇒ genau die drei korrigierten Tests werden rot. Damit ist belegt, dass die Stub-Korrektur
+  Vertragstreue herstellt und nicht gruen faerbt.
+
+  **Bewusst nicht gewaehlt:** `comparison_parallel.py` gegen ein leeres Engine-Ergebnis zu
+  haerten. Das haette Robustheit gegen einen vertraglich ausgeschlossenen Fall in
+  gemeinsam genutzten Live-Code gebaut und wuerde kuenftig echte Fehler verdecken.
 
 ## Known Limitations
 

--- a/docs/specs/modules/fix_1765_b1b_versand_sofortvergleich_parallel.md
+++ b/docs/specs/modules/fix_1765_b1b_versand_sofortvergleich_parallel.md
@@ -1,0 +1,178 @@
+---
+entity_id: fix_1765_b1b_versand_sofortvergleich_parallel
+type: module
+created: 2026-08-16
+updated: 2026-08-16
+status: draft
+version: "1.0"
+tags: [issue-1765, ortsvergleich, nebenlaeufigkeit, versand]
+---
+
+# #1765 B1b — Versand + Sofortvergleich verarbeiten Orte gleichzeitig
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Die beiden verbliebenen Aufrufwege des Ortsvergleichs — **Versand** (auch per Cron) und
+**Sofortvergleich** — verarbeiten ihre Orte nacheinander und reissen dadurch die
+60-Sekunden-Grenze von nginx (gemeldet: 504 bei vier Orten). Beide werden auf den in
+Scheibe B1 gelieferten, bereits live laufenden Baustein `run_comparison_parallel()`
+umgestellt. Damit ist #1765 vollstaendig behoben.
+
+## Source
+
+- **File:** `src/services/scheduler_dispatch_service.py`
+- **Identifier:** `send_one_compare_preset()` (Z.451)
+- **File:** `api/routers/compare.py`
+- **Identifier:** `run_comparison()` (Z.71)
+
+Schicht: **Python-Core** (`src/services/`, `api/routers/`). Kein Go-, kein Frontend-Anteil.
+
+## Estimated Scope
+
+- **LoC:** ~12 produktiv, ~350-450 Test (Erfahrungswert B1: Testanteil ×3-4)
+- **Files:** 2 geaendert, 2 neu (Tests)
+- **Effort:** medium
+
+**Das LoC-Limit von 250 wird gerissen** — Override auf 500 noetig. Grund ist nicht der
+Mechanismus (12 Zeilen), sondern der Nachweis: bei Nebenlaeufigkeit braucht jedes Kriterium
+einen eigenen Aufbau (Treffpunkt-Sperre, gedrehte Fertigstellung, echter Aufrufweg), der
+sich zwischen den Kriterien nicht teilen laesst.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `src/services/comparison_parallel.py` | nutzt | Der Baustein. Signaturgleich, seit `098226ae` live |
+| `src/services/comparison_engine.py` | unberuehrt | Wird vom Baustein je Ort aufgerufen |
+| `src/providers/call_log.py` | nutzt | `call_source` muss explizit gesetzt werden |
+| `src/services/dispatch_orchestrator.py` | unberuehrt | Presets bleiben sequentiell (Z.229) |
+
+## Implementation Details
+
+Beide Stellen sind ein reiner Aufrufweg-Tausch, kein neuer Mechanismus:
+
+```python
+# src/services/scheduler_dispatch_service.py — statt ComparisonEngine.run(...)
+from services.comparison_parallel import run_comparison_parallel
+
+result = run_comparison_parallel(
+    locations=locations,
+    time_window=resolve_compare_time_window(preset),
+    target_date=target_date,
+    forecast_hours=COMPARE_FORECAST_HOURS,
+    profile=profile,
+    official_alerts_enabled=preset.get("official_alerts_enabled", True),
+    call_source="vergleich",
+)
+```
+
+```python
+# api/routers/compare.py — analog, ohne official_alerts_enabled (Default True)
+result = run_comparison_parallel(
+    locations=selected,
+    time_window=(time_window_start, time_window_end),
+    target_date=td,
+    forecast_hours=forecast_hours,
+    profile=profile,
+    call_source="vergleich",
+)
+```
+
+`call_source` MUSS explizit gesetzt werden: ein `ThreadPoolExecutor` vererbt den
+`ContextVar`-Kontext nicht an seine Worker, und die Stack-Marker-Liste
+(`call_log.py:43-55`) liefe im Worker-Thread ins Leere.
+
+## Expected Behavior
+
+- **Input:** unveraendert — ein Preset (Versand) bzw. `location_ids` (Sofortvergleich)
+- **Output:** unveraendert — dasselbe `ComparisonResult`, dieselbe Mail, dieselbe JSON-Antwort
+- **Side effects:** unveraendert — `letzter_versand`/`top_ort_letzter_versand` nur im
+  Erfolgsfall, Δ-Anker je Ort, Alarm-Schnappschuesse. Neu ist allein, dass die
+  Wetterabrufe der Orte gleichzeitig laufen (hoechstens 4).
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Preset mit drei Orten / When der Versand laeuft / Then werden die drei
+  Orte gleichzeitig verarbeitet, nicht nacheinander
+  - Test: Die Fake-Engine laesst jeden Ort an einer `threading.Barrier` (Parteien = 3,
+    Zeitschranke) warten. Seriell erreicht der zweite Ort den Treffpunkt nie ⇒ Zeitschranke
+    ⇒ rot. Pflichtmutation: `MAX_PARALLEL_LOCATIONS = 1` muss den Test rot machen.
+
+- **AC-2:** Given ein Preset mit drei Orten, deren Verarbeitung in umgekehrter Reihenfolge
+  fertig wird / When die Vergleichsmail erzeugt wird / Then stehen die Orte darin in der
+  **konfigurierten** Reihenfolge, nicht in der Fertigstellungsreihenfolge
+  - Test: Fake-Engine mit gestaffelten Wartezeiten (letzter Ort zuerst fertig); geprueft
+    wird die Ortsreihenfolge im **gerenderten Mailtext**, nicht im Zwischenobjekt.
+
+- **AC-3:** Given ein Preset mit drei Orten, deren Verarbeitung in umgekehrter Reihenfolge
+  fertig wird / When der Versand abgeschlossen ist / Then ist der persistierte `top_ort` der
+  **erste konfigurierte** Ort
+  - Test: `top_ort_letzter_versand` aus `briefings/<preset_id>.json` nach dem Lauf lesen und
+    gegen den ersten konfigurierten Ort pruefen. Deckt die Luecke, dass `top_ort` aus
+    `result.locations[0]` stammt (`scheduler_dispatch_service.py:460`).
+
+- **AC-4:** Given ein Preset mit drei Orten mit unterschiedlichen Wetterwerten / When die
+  Vergleichsmail erzeugt wird / Then traegt **jeder** Ort seine eigenen Werte, nicht die
+  eines anderen Orts
+  - Test: Fake-Engine liefert je Ort einen ortsabhaengigen Wert (nachgeschlagen ueber
+    `loc.id`, **nicht** ueber den Aufrufindex); geprueft wird die Zuordnung Ort→Wert im
+    gerenderten Mailtext. Schliesst die gemessene Luecke, dass **kein** Bestands-Test die
+    Orts-Staffelung bewacht.
+
+- **AC-5:** Given ein Preset mit drei Orten, bei dem genau einer scheitert / When der
+  Versand laeuft / Then wird die Mail trotzdem versandt und traegt den Fehler an der
+  Position des gescheiterten Orts
+  - Test: Fake-Engine wirft nur fuer einen bestimmten Ort; geprueft wird, dass die Mail
+    zugestellt wurde und die beiden anderen Orte ihre Werte tragen.
+
+- **AC-6:** Given ein Preset, bei dem **alle** Orte mit einer Ausnahme scheitern / When der
+  Versand laeuft / Then schlaegt der Versand mit derselben Fehlerform fehl wie vor der
+  Umstellung, und `letzter_versand` wird **nicht** geschrieben
+  - Test: Fake-Engine wirft fuer jeden Ort; geprueft wird, dass die Ausnahme den Aufrufer
+    erreicht und `briefings/<preset_id>.json` keinen neuen `letzter_versand` traegt.
+
+- **AC-7:** Given ein Sofortvergleich ueber drei Orte / When `GET /api/compare` aufgerufen
+  wird / Then werden die Orte gleichzeitig verarbeitet und die Antwort listet sie in der
+  angeforderten Reihenfolge
+  - Test: `threading.Barrier` wie AC-1, ueber den echten Router (`TestClient`); geprueft
+    wird die Ortsreihenfolge im JSON-Antwortkoerper.
+
+- **AC-8:** Given ein Versand mit mehreren Orten / When die Wetterabrufe laufen / Then
+  traegt jeder Abruf im Aufruf-Journal die Quelle `vergleich`, auch aus dem Worker-Thread
+  - Test: `resolve_call_source()` innerhalb der Fake-Engine auslesen und je Ort pruefen.
+    Pflichtmutation: `call_source` weglassen muss den Test rot machen.
+
+- **AC-9:** Given die Bestands-Testsuite des Versandpfads / When die Umstellung erfolgt ist
+  / Then bleiben alle 14 Testdateien mit Engine-Stub unveraendert gruen
+  - Test: Die betroffenen Dateien werden benannt ausgefuehrt; keine Datei wird angepasst.
+
+## Known Limitations
+
+- **Thundering Herd** bei Warnquellen mit gemeinsamem Schluessel (AT/IT ueber
+  `meteoalarm_feed._cache`, FR ueber `vigilance`/`dpc`): bei zeitgleichem Cache-Miss
+  entstehen redundante Abrufe. Kein Datenverlust, keine falsche Anzeige. Gebucht in #1199
+  (Herkunft #1890, dort widerlegt und geschlossen).
+- **Cron-Ueberlagerung ueber Nutzer hinweg** ist gemessen unkritisch: 2 Nutzer in der
+  Produktions-Datenwurzel, Presets sequentiell, 4 Orte je Preset ⇒ hoechstens 8 gleichzeitige
+  Ortsverarbeitungen gegen 100 Anfragen/Minute (Meteo-France).
+- Bei **zwei zeitgleichen, verschiedenen** systemischen Stoerungen entscheidet der erste
+  konfigurierte Ort ueber die Fehlerart (Einreichungs-, nicht Fertigstellungsreihenfolge) —
+  uebernommen aus B1, unveraendert.
+- `GET /api/compare` ignoriert weiterhin den `user_id` (#1891) und kennt keine Obergrenze
+  fuer die Ortsanzahl. **Nicht** Teil dieser Scheibe.
+- Der Vergleichspfad hat weiterhin keinen Grundvorhersage-Cache (Zurueckstellung aus #1329).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Die Entscheidung fuer parallele Ortsverarbeitung im Vergleichspfad wurde in
+  Scheibe B1 getroffen und ist dort dokumentiert. B1b haengt lediglich zwei weitere
+  Aufrufstellen an denselben Baustein — keine neue Entscheidungsflaeche.
+
+## Changelog
+
+- 2026-08-16: Initial spec created

--- a/src/services/scheduler_dispatch_service.py
+++ b/src/services/scheduler_dispatch_service.py
@@ -395,7 +395,8 @@ def send_one_compare_preset(
         render_compare_email, render_compare_sms, render_compare_telegram,
     )
     from services.compare_preview_service import order_locations_by_ids
-    from services.comparison_engine import COMPARE_FORECAST_HOURS, ComparisonEngine
+    from services.comparison_engine import COMPARE_FORECAST_HOURS
+    from services.comparison_parallel import run_comparison_parallel
     from services.notification_service import NotificationService
     from services.report_config_resolver import (
         resolve_compare_render_options, resolve_compare_time_window,
@@ -448,13 +449,21 @@ def send_one_compare_preset(
     # dieselbe Quelle wie der Trip-Zweig (day_window.resolve_configured_window).
     # Die deprecateten Preset-Werte hour_from/hour_to bleiben wirkungslos —
     # nur noch zur Bestandswahrung persistiert (#1361 Befund 1).
-    result = ComparisonEngine.run(
+    # Issue #1765 Scheibe B1b: die Orte werden gleichzeitig statt nacheinander
+    # gerechnet (ein Engine-Lauf JE ORT) -- sonst riss der Versand ab drei Orten
+    # die 60-Sekunden-Grenze zwischen Go-API und nginx. Alle uebrigen Parameter
+    # unveraendert; ``comparison_engine.py`` bleibt unangetastet.
+    # ``call_source`` MUSS ausdruecklich gesetzt werden: ein ThreadPoolExecutor
+    # reicht den ContextVar-Kontext nicht an seine Arbeiter weiter, die
+    # Stack-Marker des Aufruf-Journals liefen im Worker-Thread ins Leere.
+    result = run_comparison_parallel(
         locations=locations,
         time_window=resolve_compare_time_window(preset),
         target_date=target_date,
         forecast_hours=COMPARE_FORECAST_HOURS,  # Issue #1305: geteilte Konstante statt 48 fest
         profile=profile,
         official_alerts_enabled=preset.get("official_alerts_enabled", True),  # Issue #1040
+        call_source="vergleich",
     )
 
     top_ort = result.locations[0].location.name if result.locations else None

--- a/tests/tdd/test_vorschau_anzeige_folgen_ortszone.py
+++ b/tests/tdd/test_vorschau_anzeige_folgen_ortszone.py
@@ -422,12 +422,24 @@ def client():
     return TestClient(app)
 
 
-def _leeres_vergleichsergebnis(target_date: date) -> ComparisonResult:
-    """Minimaler, echter ``ComparisonResult`` OHNE Orte -- die Sonde
-    interessiert sich nur fuer das ``target_date``, mit dem ``run_comparison``
-    die Engine aufruft bzw. das direkt im JSON-Response landet
-    (``api/routers/compare.py:120``)."""
-    return ComparisonResult(locations=[], time_window=(9, 16), target_date=target_date)
+def _vergleichsergebnis(**kwargs) -> ComparisonResult:
+    """Minimaler, echter ``ComparisonResult`` -- JE angefordertem Ort GENAU EIN
+    ``LocationResult``, so wie es die echte Engine tut
+    (``comparison_engine.py:127`` haengt in ``for loc in locations:`` je Ort
+    eines an). Die Sonde interessiert sich nur fuer das ``target_date``, mit dem
+    ``run_comparison`` die Engine aufruft bzw. das direkt im JSON-Response
+    landet (``api/routers/compare.py:120``).
+
+    Issue #1765 B1b: gab vorher ``locations=[]`` zurueck -- null Ergebnisse fuer
+    einen angeforderten Ort, was die echte Engine nie erzeugt. Seriell fiel das
+    nicht auf (der Router iterierte ueber eine leere Liste), bei einem
+    Engine-Lauf JE ORT laeuft ein solcher Doppelgaenger in einen IndexError.
+    Die Zusicherung der drei Tests bleibt unveraendert."""
+    return ComparisonResult(
+        locations=[LocationResult(location=loc) for loc in kwargs["locations"]],
+        time_window=(9, 16),
+        target_date=kwargs.get("target_date"),
+    )
 
 
 def test_ac3_sofortvergleich_ortszeit_ist_dem_servertag_bereits_voraus(client, monkeypatch):
@@ -454,7 +466,7 @@ def test_ac3_sofortvergleich_ortszeit_ist_dem_servertag_bereits_voraus(client, m
     monkeypatch.setattr(loader_mod, "load_all_locations", lambda *a, **kw: [ort])
     monkeypatch.setattr(
         ComparisonEngine, "run",
-        staticmethod(lambda **kwargs: _leeres_vergleichsergebnis(kwargs.get("target_date"))),
+        staticmethod(_vergleichsergebnis),
     )
 
     jetzt_utc = datetime(2026, 8, 20, 13, 0, tzinfo=timezone.utc)
@@ -498,7 +510,7 @@ def test_ac3_sofortvergleich_ortszeit_hinkt_dem_servertag_hinterher(client, monk
     monkeypatch.setattr(loader_mod, "load_all_locations", lambda *a, **kw: [ort])
     monkeypatch.setattr(
         ComparisonEngine, "run",
-        staticmethod(lambda **kwargs: _leeres_vergleichsergebnis(kwargs.get("target_date"))),
+        staticmethod(_vergleichsergebnis),
     )
 
     jetzt_utc = datetime(2026, 8, 20, 0, 30, tzinfo=timezone.utc)
@@ -562,7 +574,7 @@ def test_ac3_sofortvergleich_serverstunde_ueber_14_ortsstunde_darunter(client, m
     monkeypatch.setattr(loader_mod, "load_all_locations", lambda *a, **kw: [ort])
     monkeypatch.setattr(
         ComparisonEngine, "run",
-        staticmethod(lambda **kwargs: _leeres_vergleichsergebnis(kwargs.get("target_date"))),
+        staticmethod(_vergleichsergebnis),
     )
 
     jetzt_utc = datetime(2026, 8, 20, 14, 30, tzinfo=timezone.utc)

--- a/tests/unit/test_compare_versand_parallel.py
+++ b/tests/unit/test_compare_versand_parallel.py
@@ -1,0 +1,455 @@
+"""AC-1..AC-6/AC-8 (#1765 Scheibe B1b): Der VERSAND eines Vergleichs-Presets
+verarbeitet seine Orte GLEICHZEITIG und liefert dabei dieselbe Mail wie zuvor.
+
+Spec: docs/specs/modules/fix_1765_b1b_versand_sofortvergleich_parallel.md
+
+RED-Grund: ``send_one_compare_preset`` ruft ``ComparisonEngine.run()`` mit der
+VOLLEN Ortsliste auf (scheduler_dispatch_service.py:451) -- ein Aufruf,
+nacheinander abgearbeitet. AC-1 (Treffpunkt) und AC-5 (ein Ort scheitert
+systemisch) sind damit heute rot.
+
+Pruefort = Wirkort: es laeuft der ECHTE ``send_one_compare_preset`` mit dem
+ECHTEN Renderer; ersetzt sind nur die teuren Naehte -- Wetter-Engine (echte
+Subklasse, kein Mock), Δ-Anker-Schnappschuss (holt Live-Nowcast) und Transport
+(die im Bestand etablierte ``mail_sink``-Naht, Vorbild
+tests/tdd/test_compare_dispatch_channel_fanout.py). Geprueft wird der
+ZUGESTELLTE Mailkoerper, nicht das ``ComparisonResult``-Zwischenobjekt.
+Gleichzeitigkeit ueber ``threading.Barrier``, NIE ueber Wanduhr-Dauer (Muster:
+tests/unit/test_comparison_parallel.py:110-137).
+"""
+from __future__ import annotations
+
+import json
+import re
+import threading
+import time
+import uuid
+from datetime import date, datetime
+from html import unescape
+from pathlib import Path
+
+import pytest
+
+from app.config import Settings
+from app.models import ForecastDataPoint, ThunderLevel
+from app.user import SavedLocation
+
+WORKTREE = Path(__file__).resolve().parents[2]
+ZIELDATUM = date(2026, 7, 8)
+# Endlich, damit ein serieller Lauf in die Sperre laeuft statt den Testlauf
+# haengen zu lassen -- und gross genug fuer echte Parallelitaet.
+ZEITSCHRANKE = 5.0
+PRESET_ID = "cp-1765-b1b"
+ORTE = [
+    SavedLocation(id="ort-a", name="Alphastadt", lat=47.2, lon=11.0, elevation_m=1000),
+    SavedLocation(id="ort-b", name="Bravoberg", lat=46.5, lon=11.3, elevation_m=1100),
+    SavedLocation(id="ort-c", name="Charliedorf", lat=46.0, lon=12.0, elevation_m=1200),
+]
+# Unverwechselbare, sonst nirgends vorkommende Werte: so ist die Zuordnung
+# Ort->Wert im gerenderten Mailkoerper eindeutig nachweisbar (AC-4).
+TEMP_JE_ORT = {"ort-a": 31.0, "ort-b": 42.0, "ort-c": 53.0}
+MARKER_JE_ORT = {"ort-a": "31", "ort-b": "42", "ort-c": "53"}
+# Fertigstellung gegen die Einreichung gedreht: der ZUERST konfigurierte Ort
+# braucht am laengsten. Ohne diese Drehung waere auch ein Anhaengen bei
+# Fertigstellung zufaellig richtig.
+VERZOEGERUNG = {"ort-a": 0.30, "ort-b": 0.15, "ort-c": 0.0}
+
+
+def _stundenpunkt(stunde: int) -> ForecastDataPoint:
+    """Fuer alle Orte identisch -- die Stundentabellen duerfen die
+    Wert-Zuordnung der Uebersicht (AC-4) nicht verrauschen."""
+    return ForecastDataPoint(
+        ts=datetime(2026, 7, 8, stunde, 0), t2m_c=20.0, wind_chill_c=19.0,
+        wind10m_kmh=8.0, gust_kmh=19.0, precip_1h_mm=0.0, cloud_total_pct=35,
+        uv_index=5.0, thunder_level=ThunderLevel.NONE, pop_pct=10, visibility_m=9000,
+    )
+
+
+def _settings() -> Settings:
+    """E-Mail sendefaehig ohne Netz -- die Sink-Naht ersetzt den Transport
+    vollstaendig. ``_env_file=None`` haelt den Test vom Zufallsinhalt einer
+    lokalen .env fern (#1477)."""
+    return Settings(
+        smtp_host="dummy.invalid", smtp_user="dummy", smtp_pass="dummy",
+        mail_to="dummy@example.invalid", _env_file=None,
+    )
+
+
+def _preset(user_id: str) -> dict:
+    return {
+        "id": PRESET_ID, "name": "Urlaubsorte", "user_id": user_id,
+        "location_ids": [o.id for o in ORTE], "schedule": "daily",
+        "profil": "ALLGEMEIN", "hour_from": 9, "hour_to": 16,
+        "forecast_hours": 48, "created_at": "2026-07-01T00:00:00Z",
+        "kind": "vergleich",
+    }
+
+
+class _Postfach:
+    """Zugestellte Mails (kein Mock): die Sink-Naht bekommt Betreff und den
+    fertig gerenderten HTML-Koerper."""
+
+    def __init__(self) -> None:
+        self.zugestellt: list[dict] = []
+
+    def __call__(self, **kwargs) -> None:
+        self.zugestellt.append(kwargs)
+
+    @property
+    def koerper(self) -> str:
+        assert self.zugestellt, "Es wurde keine Vergleichsmail zugestellt"
+        return self.zugestellt[0]["body"]
+
+
+@pytest.fixture
+def versand_umgebung(tmp_path, monkeypatch):
+    """Isolierter Daten-Root ueber BEIDE Zugriffsformen, damit kein Test am
+    echten data/users/ vorbeischreibt (Muster
+    tests/tdd/test_compare_dispatch_channel_fanout.py:113-138). Legt die
+    Briefing-Datei an, in die ``save_compare_preset_status`` schreibt."""
+    from app import loader as app_loader
+
+    daten = tmp_path / "data"
+    daten.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(app_loader, "_DATA_ROOT", str(daten))
+    try:
+        from src.app import loader as src_loader
+
+        monkeypatch.setattr(src_loader, "_DATA_ROOT", str(daten))
+    except ImportError:  # pragma: no cover
+        pass
+
+    user_id = f"b1b-{uuid.uuid4().hex[:8]}"
+    briefing = daten / "users" / user_id / "briefings" / f"{PRESET_ID}.json"
+    briefing.parent.mkdir(parents=True, exist_ok=True)
+    briefing.write_text(
+        json.dumps({"id": PRESET_ID, "kind": "vergleich", "name": "Urlaubsorte"}),
+        encoding="utf-8",
+    )
+    return user_id, daten, briefing
+
+
+@pytest.fixture
+def thread_fehler():
+    """pytest meldet eine Ausnahme in einem Worker-Thread nur als WARNUNG -- ein
+    Test kann gruen sein, waehrend ein Thread abstuerzt (in genau diesem
+    Themenstrang schon passiert). Hier wird sie zum Testfehler."""
+    gesammelt: list = []
+    alt = threading.excepthook
+    threading.excepthook = gesammelt.append
+    yield gesammelt
+    threading.excepthook = alt
+    assert not gesammelt, (
+        "Ausnahme(n) in Worker-Threads -- pytest haette sie nur als Warnung "
+        f"gemeldet: {[(e.exc_type, e.exc_value) for e in gesammelt]}"
+    )
+
+
+def _engine_naht(monkeypatch, haken):
+    """Die teure Wetter-Naht durch eine echte Subklasse ersetzen. ``haken(ort)``
+    erzwingt Treffpunkt, Verzoegerung oder Ortsfehler. Die Werte kommen ueber
+    ``loc.id`` -- NICHT ueber den Aufrufindex (AC-4): ein index-basierter Stub
+    saehe nach dem Umbau bei jedem Aufruf nur noch Index 0 und verloere die
+    Orts-Staffelung still."""
+    import services.comparison_engine as ce_mod
+    import services.scheduler_dispatch_service as sds_mod
+    from app.user import ComparisonResult, LocationResult
+
+    # Pfadregel #1409: aus dem Worktree darf nicht die Hauptrepo-Kopie geprueft
+    # werden -- sonst meldet dieser Test falsches Gruen.
+    assert Path(sds_mod.__file__).resolve().is_relative_to(WORKTREE), sds_mod.__file__
+
+    class _StubEngine(ce_mod.ComparisonEngine):  # echte Subklasse, kein Mock
+        @staticmethod
+        def run(*args, **kwargs):
+            orte = list(kwargs["locations"] if "locations" in kwargs else args[0])
+            teile = []
+            for ort in orte:
+                haken(ort)
+                teile.append(LocationResult(
+                    location=ort, score=50, temp_max=TEMP_JE_ORT[ort.id],
+                    temp_min=5.0, wind_max=8.0, gust_max=19.0, cloud_avg=35,
+                    sunny_hours=6, official_alerts=[],
+                    hourly_data=[_stundenpunkt(9), _stundenpunkt(12)],
+                ))
+            return ComparisonResult(
+                locations=teile, time_window=kwargs.get("time_window", (9, 16)),
+                target_date=kwargs.get("target_date", ZIELDATUM),
+                created_at=datetime(2026, 7, 8, 4, 0),
+            )
+
+    monkeypatch.setattr(ce_mod, "ComparisonEngine", _StubEngine)
+    # Δ-Anker-Schnappschuesse holen echtes Nowcast-Wetter (Netz) -- im Kern
+    # neutralisiert, nicht Pruefgegenstand (#1169, best-effort Nachlauf).
+    monkeypatch.setattr(sds_mod, "_write_compare_alert_snapshots", lambda *a, **k: None)
+
+
+def _versand(user_id: str, daten: Path, postfach: _Postfach) -> tuple:
+    from services.scheduler_dispatch_service import send_one_compare_preset
+
+    return send_one_compare_preset(
+        _preset(user_id), _settings(), user_id, str(daten),
+        all_locations_cache=list(ORTE), target_date=ZIELDATUM, tage_ab_ortstag=0,
+        mail_sink=postfach,
+    )
+
+
+def _drehung(fertig: list[str], erreicht: list[str]):
+    """Haken: alle Orte starten gemeinsam, danach gestaffelt fertig. Seriell
+    kann der Treffpunkt nicht zustande kommen und die Drehung entsteht nicht --
+    sie wird deshalb erst gefordert, wenn sie moeglich ist (``erreicht``)."""
+    treffpunkt = threading.Barrier(len(ORTE))
+    sperre = threading.Lock()
+
+    def haken(ort):
+        try:
+            treffpunkt.wait(timeout=ZEITSCHRANKE)
+            with sperre:
+                erreicht.append(ort.id)
+        except threading.BrokenBarrierError:
+            pass
+        time.sleep(VERZOEGERUNG[ort.id])
+        with sperre:
+            fertig.append(ort.id)
+
+    return haken
+
+
+_TAG = re.compile(r"<[^>]+>")
+
+
+def _tabellenzeilen(html: str) -> list[list[str]]:
+    """Zellinhalte je Tabellenzeile des ZUGESTELLTEN Mailkoerpers."""
+    zeilen = []
+    for roh in re.findall(r"<tr\b.*?</tr>", html, re.S):
+        zellen = [
+            unescape(_TAG.sub(" ", z)).replace("\xa0", " ").strip()
+            for z in re.findall(r"<t[dh]\b.*?</t[dh]>", roh, re.S)
+        ]
+        if zellen:
+            zeilen.append(zellen)
+    return zeilen
+
+
+def _kopfzeile(html: str) -> list[str]:
+    """Die Zeile der Uebersichtstabelle, die ALLE Ortsnamen fuehrt -- ihre
+    Spaltenfolge ist die im Mailkoerper sichtbare Ortsreihenfolge."""
+    for zellen in _tabellenzeilen(html):
+        if all(o.name in " ".join(zellen) for o in ORTE):
+            return zellen
+    raise AssertionError(
+        "Keine Tabellenzeile im zugestellten Mailkoerper fuehrt alle Orte "
+        f"{[o.name for o in ORTE]}"
+    )
+
+
+def _spalte_je_ort(html: str) -> dict[str, int]:
+    kopf = _kopfzeile(html)
+    return {o.id: min(i for i, z in enumerate(kopf) if o.name in z) for o in ORTE}
+
+
+def test_ac1_versand_verarbeitet_die_orte_gleichzeitig(
+    versand_umgebung, monkeypatch, thread_fehler
+):
+    """AC-1: Drei Orte melden sich an einer Treffpunkt-Sperre an. Nacheinander
+    verarbeitet erreicht der zweite Ort den Treffpunkt nie -- die Sperre laeuft
+    in ihre Zeitschranke und KEIN Ort kommt durch. Uhrunabhaengig.
+    Pflichtmutation: ``MAX_PARALLEL_LOCATIONS = 1`` muss den Test rot machen."""
+    user_id, daten, _ = versand_umgebung
+    treffpunkt = threading.Barrier(len(ORTE))
+    durch: list[str] = []
+    sperre = threading.Lock()
+
+    def am_treffpunkt(ort):
+        try:
+            treffpunkt.wait(timeout=ZEITSCHRANKE)
+        except threading.BrokenBarrierError:
+            return
+        with sperre:
+            durch.append(ort.id)
+
+    _engine_naht(monkeypatch, am_treffpunkt)
+    postfach = _Postfach()
+    _versand(user_id, daten, postfach)
+
+    assert sorted(durch) == [o.id for o in ORTE], (
+        f"Nur {sorted(durch)} von {[o.id for o in ORTE]} erreichten den "
+        "Treffpunkt -- der Versand berechnet die Orte nacheinander statt "
+        "gleichzeitig (AC-1). Erwartet: send_one_compare_preset ruft "
+        "run_comparison_parallel(..., call_source='vergleich') statt "
+        "ComparisonEngine.run (scheduler_dispatch_service.py:451)."
+    )
+    assert all(o.name in postfach.koerper for o in ORTE), (
+        f"AC-1 verlangt eine VOLLSTAENDIGE Mail: {postfach.koerper[:400]!r}"
+    )
+
+
+def test_ac2_mail_zeigt_die_konfigurierte_ortsreihenfolge(
+    versand_umgebung, monkeypatch, thread_fehler
+):
+    """AC-2: Bei gedrehter Fertigstellungsreihenfolge stehen die Orte im
+    ZUGESTELLTEN Mailkoerper trotzdem in der konfigurierten Reihenfolge."""
+    user_id, daten, _ = versand_umgebung
+    fertig: list[str] = []
+    erreicht: list[str] = []
+
+    _engine_naht(monkeypatch, _drehung(fertig, erreicht))
+    postfach = _Postfach()
+    _versand(user_id, daten, postfach)
+
+    if len(erreicht) == len(ORTE):  # gleichzeitig -- erst dann gibt es Drehung
+        assert fertig == ["ort-c", "ort-b", "ort-a"], (
+            f"Vorbedingung verletzt: Fertigstellung {fertig} ist nicht gegen "
+            "die Einreichung gedreht -- ohne Drehung prueft die Zusicherung nichts."
+        )
+    spalten = _spalte_je_ort(postfach.koerper)
+    assert sorted(spalten, key=spalten.get) == [o.id for o in ORTE], (
+        "AC-2: Die Vergleichsmail muss die Orte in der KONFIGURIERTEN "
+        f"Reihenfolge zeigen, geliefert wurden die Spalten {spalten} bei "
+        f"Fertigstellung {fertig}."
+    )
+
+
+def test_ac3_persistierter_top_ort_ist_der_erste_konfigurierte(
+    versand_umgebung, monkeypatch, thread_fehler
+):
+    """AC-3: ``top_ort`` stammt aus ``result.locations[0]``
+    (scheduler_dispatch_service.py:460) -- auch bei gedrehter Fertigstellung
+    muss der ERSTE KONFIGURIERTE Ort in ``briefings/<preset_id>.json`` landen."""
+    user_id, daten, briefing = versand_umgebung
+    fertig: list[str] = []
+
+    _engine_naht(monkeypatch, _drehung(fertig, []))
+    top_ort, _ = _versand(user_id, daten, _Postfach())
+
+    gespeichert = json.loads(briefing.read_text(encoding="utf-8"))
+    assert gespeichert.get("top_ort_letzter_versand") == ORTE[0].name, (
+        "AC-3: persistiert wurde top_ort_letzter_versand="
+        f"{gespeichert.get('top_ort_letzter_versand')!r}, erwartet der erste "
+        f"konfigurierte Ort {ORTE[0].name!r} (Fertigstellung war {fertig})."
+    )
+    assert top_ort == ORTE[0].name, f"Rueckgabewert top_ort={top_ort!r}"
+
+
+def test_ac4_jeder_ort_traegt_in_der_mail_seine_eigenen_werte(
+    versand_umgebung, monkeypatch, thread_fehler
+):
+    """AC-4: Jeder Ort bekommt seinen EIGENEN Wert (nachgeschlagen ueber
+    ``loc.id``) -- geprueft wird die Zuordnung Ort->Wert im zugestellten
+    Mailkoerper. Schliesst die gemessene Luecke, dass KEIN Bestands-Test die
+    Orts-Staffelung des Versandpfads bewacht."""
+    user_id, daten, _ = versand_umgebung
+    fertig: list[str] = []
+
+    _engine_naht(monkeypatch, _drehung(fertig, []))
+    postfach = _Postfach()
+    _versand(user_id, daten, postfach)
+
+    spalten = _spalte_je_ort(postfach.koerper)
+    breite = len(_kopfzeile(postfach.koerper))
+    treffer = [
+        z for z in _tabellenzeilen(postfach.koerper)
+        if len(z) == breite
+        and all(any(m in zelle for zelle in z[1:]) for m in MARKER_JE_ORT.values())
+    ]
+    assert treffer, (
+        f"Keine Uebersichtszeile fuehrt die Ortswerte {list(MARKER_JE_ORT.values())} "
+        f"-- gerenderte Zeilen: {_tabellenzeilen(postfach.koerper)[:6]}"
+    )
+    zuordnung = {
+        ort_id: MARKER_JE_ORT[ort_id] in treffer[0][spalte]
+        for ort_id, spalte in spalten.items()
+    }
+    assert all(zuordnung.values()), (
+        "AC-4: In der zugestellten Mail traegt nicht jeder Ort seinen eigenen "
+        f"Wert. Spalten {spalten}, erwartet {MARKER_JE_ORT}, gerenderte Zeile "
+        f"{treffer[0]}, Treffer je Ort {zuordnung}."
+    )
+
+
+def test_ac5_ein_gescheiterter_ort_reisst_die_mail_nicht_mit(
+    versand_umgebung, monkeypatch, thread_fehler
+):
+    """AC-5: Genau ein Ort scheitert mit einer Ausnahme. Die Mail geht trotzdem
+    raus und die beiden anderen Orte tragen ihre Werte.
+
+    RED heute: seriell laeuft EIN Engine-Aufruf ueber alle drei Orte -- die
+    Ausnahme des mittleren Orts reisst den gesamten Versand mit, es wird gar
+    keine Mail zugestellt."""
+    user_id, daten, _ = versand_umgebung
+
+    def scheitert_in_der_mitte(ort):
+        if ort.id == "ort-b":
+            raise RuntimeError("Wetterdaten nicht abrufbar")
+
+    _engine_naht(monkeypatch, scheitert_in_der_mitte)
+    postfach = _Postfach()
+    _versand(user_id, daten, postfach)
+
+    assert len(postfach.zugestellt) == 1, (
+        "AC-5: Ein einzelner gescheiterter Ort darf den Versand nicht "
+        f"verhindern -- zugestellt wurden {len(postfach.zugestellt)} Mails."
+    )
+    for ort in (ORTE[0], ORTE[2]):
+        assert ort.name in postfach.koerper and MARKER_JE_ORT[ort.id] in postfach.koerper, (
+            f"AC-5: {ort.name} muss seine Werte behalten "
+            f"({MARKER_JE_ORT[ort.id]} fehlt): {postfach.koerper[:400]!r}"
+        )
+
+
+def test_ac6_systemischer_ausfall_behaelt_fehlerform_und_schreibt_nichts(
+    versand_umgebung, monkeypatch, thread_fehler
+):
+    """AC-6: Scheitern ALLE Orte, schlaegt der Versand mit derselben Fehlerform
+    fehl wie vor der Umstellung (die Ausnahme erreicht den Aufrufer) und
+    ``letzter_versand`` wird NICHT geschrieben."""
+    user_id, daten, briefing = versand_umgebung
+
+    def scheitert_immer(ort):
+        raise RuntimeError("Wetterdienst nicht erreichbar")
+
+    _engine_naht(monkeypatch, scheitert_immer)
+    postfach = _Postfach()
+
+    with pytest.raises(RuntimeError, match="nicht erreichbar"):
+        _versand(user_id, daten, postfach)
+
+    assert not postfach.zugestellt, (
+        f"AC-6: Ohne jeden Ortswert darf keine Mail rausgehen, es waren "
+        f"{len(postfach.zugestellt)}."
+    )
+    gespeichert = json.loads(briefing.read_text(encoding="utf-8"))
+    assert "letzter_versand" not in gespeichert, (
+        "AC-6: Nach einem systemischen Ausfall darf kein letzter_versand "
+        f"persistiert werden, gefunden: {gespeichert.get('letzter_versand')!r}"
+    )
+
+
+def test_ac8_jeder_ortsabruf_traegt_die_quelle_vergleich(
+    versand_umgebung, monkeypatch, thread_fehler
+):
+    """AC-8: Die Diagnose-Quelle wird dort ausgelesen, wo das Journal sie sieht
+    -- im Thread, der den Abruf ausfuehrt. Nach dem Umbau taucht dort keiner der
+    11 Stack-Marker mehr auf; nur ein ausdrueckliches ``call_source='vergleich'``
+    ueberlebt den Threadwechsel. Pflichtmutation: ``call_source`` am Aufruf
+    weglassen muss den Test rot machen."""
+    from providers.call_log import resolve_call_source
+
+    user_id, daten, _ = versand_umgebung
+    gesehen: dict[str, str] = {}
+    sperre = threading.Lock()
+
+    def merkt_die_quelle(ort):
+        with sperre:
+            gesehen[ort.id] = resolve_call_source()
+
+    _engine_naht(monkeypatch, merkt_die_quelle)
+    _versand(user_id, daten, _Postfach())
+
+    assert gesehen == {o.id: "vergleich" for o in ORTE}, (
+        f"AC-8: Im Verarbeitungs-Thread jedes Ortes wurde {gesehen} als Quelle "
+        "aufgeloest -- erwartet ueberall 'vergleich'. Der Versand muss "
+        "call_source='vergleich' ausdruecklich setzen (ein ThreadPoolExecutor "
+        "reicht den ContextVar-Kontext nicht an seine Arbeiter weiter)."
+    )

--- a/tests/unit/test_sofortvergleich_parallel.py
+++ b/tests/unit/test_sofortvergleich_parallel.py
@@ -1,0 +1,217 @@
+"""AC-7 (#1765 Scheibe B1b): Der SOFORTVERGLEICH ``GET /api/compare``
+verarbeitet seine Orte GLEICHZEITIG und antwortet in der angeforderten
+Ortsreihenfolge.
+
+Spec: docs/specs/modules/fix_1765_b1b_versand_sofortvergleich_parallel.md
+
+RED-Grund: ``run_comparison()`` ruft ``ComparisonEngine.run()`` mit der VOLLEN
+Ortsliste auf (api/routers/compare.py:71) -- ein Aufruf, nacheinander
+abgearbeitet. Der Treffpunkt-Test laeuft damit heute in seine Zeitschranke.
+
+Pruefort = Wirkort: der ECHTE Router laeuft unter ``TestClient``, geprueft wird
+der JSON-Antwortkoerper. Ersetzt ist nur die teure Wetter-Naht (echte
+Subklasse, kein Mock) und die Ortsquelle (Haus-Muster
+tests/tdd/test_hail_flag_metrics_catalog_and_compare_api.py:100).
+"""
+from __future__ import annotations
+
+import threading
+import time
+from datetime import date, datetime
+from pathlib import Path
+
+import pytest
+
+from app.user import SavedLocation
+
+WORKTREE = Path(__file__).resolve().parents[2]
+ZIELDATUM = date(2026, 7, 8)
+ZEITSCHRANKE = 5.0  # s -- endlich, damit ein serieller Lauf in die Sperre
+#                     laeuft statt den Testlauf haengen zu lassen.
+ORTE = [
+    SavedLocation(id="sv-a", name="Alphastadt", lat=47.2, lon=11.0, elevation_m=1000),
+    SavedLocation(id="sv-b", name="Bravoberg", lat=46.5, lon=11.3, elevation_m=1100),
+    SavedLocation(id="sv-c", name="Charliedorf", lat=46.0, lon=12.0, elevation_m=1200),
+]
+
+
+@pytest.fixture
+def client():
+    import api.routers.compare as compare_mod
+    from fastapi.testclient import TestClient
+
+    from api.main import app
+
+    # Pfadregel #1409: aus dem Worktree darf nicht die Hauptrepo-Kopie geprueft
+    # werden -- sonst meldet dieser Test falsches Gruen.
+    assert Path(compare_mod.__file__).resolve().is_relative_to(WORKTREE), (
+        compare_mod.__file__
+    )
+    return TestClient(app)
+
+
+@pytest.fixture
+def thread_fehler():
+    """pytest meldet eine Ausnahme in einem Worker-Thread nur als WARNUNG -- ein
+    Test kann gruen sein, waehrend ein Thread abstuerzt. Hier wird sie zum
+    Testfehler."""
+    gesammelt: list = []
+    alt = threading.excepthook
+    threading.excepthook = gesammelt.append
+    yield gesammelt
+    threading.excepthook = alt
+    assert not gesammelt, (
+        "Ausnahme(n) in Worker-Threads -- pytest haette sie nur als Warnung "
+        f"gemeldet: {[(e.exc_type, e.exc_value) for e in gesammelt]}"
+    )
+
+
+def _naht(monkeypatch, haken):
+    """Ortsquelle und Wetter-Naht ersetzen; ``haken(ort)`` erzwingt Treffpunkt
+    bzw. Verzoegerung. Der Wert kommt ueber ``loc.id``, nicht ueber den
+    Aufrufindex."""
+    import app.loader as loader_mod
+    import services.comparison_engine as ce_mod
+    from app.user import ComparisonResult, LocationResult
+
+    monkeypatch.setattr(loader_mod, "load_all_locations", lambda *a, **kw: list(ORTE))
+
+    class _StubEngine(ce_mod.ComparisonEngine):  # echte Subklasse, kein Mock
+        @staticmethod
+        def run(*args, **kwargs):
+            orte = list(kwargs["locations"] if "locations" in kwargs else args[0])
+            teile = []
+            for ort in orte:
+                haken(ort)
+                teile.append(LocationResult(location=ort, score=50, temp_max=20.0))
+            return ComparisonResult(
+                locations=teile, time_window=kwargs.get("time_window", (9, 16)),
+                target_date=kwargs.get("target_date", ZIELDATUM),
+                created_at=datetime(2026, 7, 8, 4, 0),
+            )
+
+    monkeypatch.setattr(ce_mod, "ComparisonEngine", _StubEngine)
+
+
+def _abfrage(client):
+    """Die Orte werden in DERSELBEN Reihenfolge angefordert, in der die
+    Ortsquelle sie fuehrt -- der Endpunkt filtert ueber die Quelle
+    (api/routers/compare.py:44), 'angefordert' und 'aufgeloest' fallen damit
+    zusammen und die Zusicherung ist eindeutig."""
+    ids = ",".join(o.id for o in ORTE)
+    return client.get(
+        f"/api/compare?location_ids={ids}&target_date={ZIELDATUM.isoformat()}"
+        "&time_window_start=9&time_window_end=16"
+    )
+
+
+def test_ac7_sofortvergleich_verarbeitet_die_orte_gleichzeitig(
+    client, monkeypatch, thread_fehler
+):
+    """AC-7 (Gleichzeitigkeit): Drei Orte melden sich an einer Treffpunkt-Sperre
+    an. Nacheinander verarbeitet erreicht der zweite Ort den Treffpunkt nie --
+    die Sperre laeuft in ihre Zeitschranke und KEIN Ort kommt durch.
+    Uhrunabhaengig.
+
+    Pflichtmutation: ``MAX_PARALLEL_LOCATIONS = 1`` muss diesen Test rot
+    machen."""
+    treffpunkt = threading.Barrier(len(ORTE))
+    durch: list[str] = []
+    sperre = threading.Lock()
+
+    def am_treffpunkt(ort):
+        try:
+            treffpunkt.wait(timeout=ZEITSCHRANKE)
+        except threading.BrokenBarrierError:
+            return
+        with sperre:
+            durch.append(ort.id)
+
+    _naht(monkeypatch, am_treffpunkt)
+    antwort = _abfrage(client)
+
+    assert antwort.status_code == 200, antwort.text
+    assert sorted(durch) == [o.id for o in ORTE], (
+        f"Nur {sorted(durch)} von {[o.id for o in ORTE]} erreichten den "
+        "Treffpunkt -- GET /api/compare berechnet die Orte nacheinander statt "
+        "gleichzeitig (AC-7). Erwartet: run_comparison ruft "
+        "run_comparison_parallel(..., call_source='vergleich') statt "
+        "ComparisonEngine.run (api/routers/compare.py:71)."
+    )
+    assert [e["id"] for e in antwort.json()["locations"]] == [o.id for o in ORTE]
+
+
+def test_ac7_antwort_folgt_der_angeforderten_reihenfolge(
+    client, monkeypatch, thread_fehler
+):
+    """AC-7 (Reihenfolge): Der zuerst angeforderte Ort braucht am laengsten,
+    der zuletzt angeforderte am kuerzesten -- die Fertigstellung ist damit
+    gegen die Einreichung gedreht. Die Antwort muss trotzdem der angeforderten
+    Reihenfolge folgen. Seriell entsteht die Drehung nicht; sie wird deshalb
+    erst gefordert, wenn sie moeglich ist (Treffpunkt erreicht)."""
+    treffpunkt = threading.Barrier(len(ORTE))
+    verzoegerung = {"sv-a": 0.30, "sv-b": 0.15, "sv-c": 0.0}
+    fertig: list[str] = []
+    erreicht: list[str] = []
+    sperre = threading.Lock()
+
+    def gedreht(ort):
+        try:
+            treffpunkt.wait(timeout=ZEITSCHRANKE)
+            with sperre:
+                erreicht.append(ort.id)
+        except threading.BrokenBarrierError:
+            pass
+        time.sleep(verzoegerung[ort.id])
+        with sperre:
+            fertig.append(ort.id)
+
+    _naht(monkeypatch, gedreht)
+    antwort = _abfrage(client)
+
+    assert antwort.status_code == 200, antwort.text
+    if len(erreicht) == len(ORTE):  # gleichzeitig -- erst dann ist die Drehung da
+        assert fertig == ["sv-c", "sv-b", "sv-a"], (
+            f"Vorbedingung verletzt: Fertigstellungsreihenfolge {fertig} ist "
+            "nicht gegen die Einreichungsreihenfolge gedreht -- ohne Drehung "
+            "prueft die eigentliche Zusicherung nichts."
+        )
+    geliefert = [e["id"] for e in antwort.json()["locations"]]
+    assert geliefert == [o.id for o in ORTE], (
+        "AC-7: Die JSON-Antwort muss die Orte in der angeforderten Reihenfolge "
+        f"listen, geliefert wurde {geliefert} bei Fertigstellung {fertig}."
+    )
+
+
+def test_ac8_jeder_ortsabruf_traegt_die_quelle_vergleich(
+    client, monkeypatch, thread_fehler
+):
+    """AC-8 (zweite Wirkstelle): AC-8 gilt fuer BEIDE Aufrufstellen -- der
+    Versandpfad ist in tests/unit/test_compare_versand_parallel.py bewacht, hier
+    der Sofortvergleich ueber den ECHTEN Router.
+
+    Die Quelle wird dort ausgelesen, wo das Journal sie sieht: im Thread, der den
+    Abruf ausfuehrt. Dort taucht keiner der 11 Stack-Marker mehr auf (auch nicht
+    ``compare``, denn die Router-Frames bleiben im aufrufenden Thread) -- nur ein
+    ausdrueckliches ``call_source='vergleich'`` ueberlebt den Threadwechsel.
+    Pflichtmutation: ``call_source`` in api/routers/compare.py:83 weglassen muss
+    DIESEN Test rot machen; die Mutation am Versandpfad darf ihn NICHT roetten."""
+    from providers.call_log import resolve_call_source
+
+    gesehen: dict[str, str] = {}
+    sperre = threading.Lock()
+
+    def merkt_die_quelle(ort):
+        with sperre:
+            gesehen[ort.id] = resolve_call_source()
+
+    _naht(monkeypatch, merkt_die_quelle)
+    antwort = _abfrage(client)
+
+    assert antwort.status_code == 200, antwort.text
+    assert gesehen == {o.id: "vergleich" for o in ORTE}, (
+        f"AC-8: Im Verarbeitungs-Thread jedes Ortes wurde {gesehen} als Quelle "
+        "aufgeloest -- erwartet ueberall 'vergleich'. GET /api/compare muss "
+        "call_source='vergleich' ausdruecklich setzen (ein ThreadPoolExecutor "
+        "reicht den ContextVar-Kontext nicht an seine Arbeiter weiter)."
+    )


### PR DESCRIPTION
Scheibe **B1b** zu #1765 — die beiden verbliebenen Aufrufwege des Ortsvergleichs verarbeiten ihre Orte jetzt gleichzeitig. Damit ist der gemeldete Fehler auf allen drei Wegen behoben (Vorschau kam mit B1, `098226ae`).

## Was sich aendert

| Aufrufweg | Datei | vorher |
|---|---|---|
| Versand (auch per Cron) | `src/services/scheduler_dispatch_service.py:451` | seriell, 504 bei 4 Orten |
| Sofortvergleich | `api/routers/compare.py:71` | seriell |

Beide rufen statt `ComparisonEngine.run(...)` jetzt `run_comparison_parallel(...)` — den Baustein aus Scheibe B1, der seit `098226ae` auf dem Vorschau-Pfad live ist. `call_source="vergleich"` wird an beiden Stellen ausdruecklich gesetzt: ein `ThreadPoolExecutor` vererbt den `ContextVar`-Kontext nicht an seine Worker.

**Wirksam sind ~6 Zeilen.** `comparison_parallel.py` und `comparison_engine.py` bleiben unangetastet (per Diff gegen `origin/main` nachgewiesen).

## Verhaltensaenderung, die AC-5 festhaelt

Ein einzelner nicht erreichbarer Ort verhindert den Versand **nicht mehr**. Vorher riss seine Ausnahme den gesamten Lauf mit und es ging **gar keine** Mail raus; jetzt traegt die Mail den Fehler an der Position des betroffenen Orts. Das war in der roten Phase ein echter Vorher/Nachher-Nachweis (Test vorher rot).

## Nachweis

9 Akzeptanzkriterien. Gleichzeitigkeit ueber `threading.Barrier`, **nicht** ueber Wanduhr-Dauer — seriell erreicht der zweite Ort den Treffpunkt nie, der Test kann also nicht zufaellig gruen werden.

**Adversary: VERIFIED** nach einem Fix-Loop. Sein Finding F001 (CRITICAL) deckte einen **Spec-Fehler** auf, keinen Codefehler: AC-8 war nur fuer den Versand formuliert, waehrend `call_source` fuer beide Aufrufstellen gilt — die Mutation am Sofortvergleich blieb daraufhin von der gesamten Suite ungefangen. Spec nachgezogen, Test ergaenzt, beide Wirkstellen einzeln bewacht (per Kreuzprobe belegt). Dass die Auswertung wirklich im Worker-Thread laeuft, ist per Thread-ID gemessen, nicht angenommen.

Gefangene Mutationen:

| Verfaelschung | Reaktion |
|---|---|
| `MAX_PARALLEL_LOCATIONS` 4→1 | AC-1 **und** AC-7 rot |
| `call_source` je Stelle einzeln entfernt | jeweils genau der zustaendige Test rot |
| Ergebnisliste gedreht | AC-2, AC-3, beide AC-7 rot |
| `official_alerts_enabled` entfernt | Bestandstest rot |
| `top_ort` aus `locations[-1]` | AC-3 rot |

Nicht gefangen: `forecast_hours` am Sofortvergleich — gehoert zu keinem AC dieser Scheibe, gebucht als F002 in #1199.

## AC-9-Ausnahme (begruendet in der Spec)

Die Sonde `_leeres_vergleichsergebnis()` in `tests/tdd/test_vorschau_anzeige_folgen_ortszone.py` lieferte **null** Ortsergebnisse fuer **einen** angeforderten Ort und widersprach damit dem Engine-Vertrag (`comparison_engine.py:127` haengt je Ort genau ein Ergebnis an). Seriell fiel das nie auf, parallel laeuft es in einen `IndexError`. Der Stub liefert jetzt ein Ergebnis je Ort; die drei Zusicherungen sind **woertlich unveraendert**, und dass es keine Gruenfaerberei ist, belegt eine Gegenprobe am Wirkort (Zonen-Aufloesung im Router zerstoert ⇒ genau diese drei Tests rot).

**Bewusst nicht gewaehlt:** `comparison_parallel.py` gegen ein leeres Ergebnis haerten — das haette Robustheit gegen einen vertraglich ausgeschlossenen Fall in geteilten Live-Code gebaut und wuerde kuenftig echte Fehler verdecken.

## Bewusste Grenzen

- **Thundering Herd** bei Warnquellen mit gemeinsamem Schluessel: bei zeitgleichem Cache-Miss redundante Abrufe. Kein Datenverlust, keine falsche Anzeige. In #1199 gebucht (Herkunft: #1890, dort widerlegt und geschlossen — der vermutete Race sass in nicht registriertem Code).
- **Cron-Ueberlagerung** gemessen unkritisch: 2 Nutzer in der Produktions-Datenwurzel, Presets sequentiell, 4 Orte je Preset ⇒ hoechstens 8 gleichzeitige Ortsverarbeitungen gegen 100 Anfragen/Minute.
- `GET /api/compare` ignoriert weiterhin den `user_id` (**#1891**) und kennt keine Obergrenze fuer die Ortsanzahl — nicht Teil dieser Scheibe.

## Bezug

Gehoert zu #1765 (Scheibe B1b). Das Issue wird **nicht** automatisch geschlossen — erst nach Prod-Deploy und Selftest-Exit 0, wie der Liefer-Workflow es verlangt.

Spec: `docs/specs/modules/fix_1765_b1b_versand_sofortvergleich_parallel.md`
Analyse: `docs/context/fix-1765-b1b-versand-parallel.md`
Adversary-Protokoll: `docs/artifacts/fix-1765-b1b-versand-parallel/adversary-dialog.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSheEB4rVo82LiK3oSuvKh
