### PR TITLE
fix(#1488 A): Gewitter-Alarmregel im Modus Absolut entfaellt

### DIFF
--- a/.github/ci_e2e_specs.txt
+++ b/.github/ci_e2e_specs.txt
@@ -136,6 +136,7 @@ e2e/dnd-helper-finalize-wait.spec.ts
 e2e/email-preview-header.spec.ts
 e2e/epic-138-block-b.spec.ts
 e2e/font-weights.spec.ts
+e2e/gewitter-absolutregel-gesperrt.spec.ts
 e2e/issue-1059-trip-resume-error-feedback.spec.ts
 e2e/issue-1071-tier-change-request.spec.ts
 e2e/issue-1093-unit.spec.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
       # alle den storageState (login() in helpers.ts:97-106 kehrt sofort
       # zurueck, wenn die Sitzung schon steht), holen sich also keinen
       # eigenen Login -- nachgemessen in denselben 3 Zyklen, 0 unexpected.
-      E2E_MIN_SPECS: 45     # Ratsche: Zahl DATEIEN auf der Positivliste -- EXAKT, nicht mindestens (Kern-Test)
+      E2E_MIN_SPECS: 46     # Ratsche: Zahl DATEIEN auf der Positivliste -- EXAKT, nicht mindestens (Kern-Test)
       E2E_MIN_EXECUTED_HAUPT: 224      # Hauptlauf: 44 Dateien + global.setup -- exakt belegt, kein Puffer
       E2E_MIN_EXECUTED_RATELIMIT: 3    # Zweitlauf: bug-703 (2 Faelle) + global.setup -- exakt belegt, kein Puffer
     steps:

--- a/docs/context/fix-1488-gewitterstufen.md
+++ b/docs/context/fix-1488-gewitterstufen.md
@@ -1,0 +1,304 @@
+# Context: fix-1488-gewitterstufen
+
+Issue: [#1488](https://github.com/henemm/gregor_zwanzig/issues/1488) — Gewitterstufen im Frontend:
+drei Wortkopien, Alarm-Editor um eine Stufe verschoben — EINE geteilte Quelle für Trip, Vergleich
+und Alarme. Epic: [#1419](https://github.com/henemm/gregor_zwanzig/issues/1419).
+Track: **Full Process** (Intake-Score 5: Scope High · Blast Radius High · Unsicherheit Medium).
+
+## Request Summary
+
+Die Gewitterstufen-Skala hat seit #1474 vier Stufen (kein/leicht/mittel/hoch). Das Frontend
+führt an mehreren Stellen eigene Wortkopien, die diesen Umbau nicht mitgemacht haben. Die
+schwerwiegendste beschriftet eine **Alarm**-Einstellung falsch. Ziel laut PO: eine geteilte
+Wortquelle für Trip, Ortsvergleich und Alarme — plus (Umfangserweiterung 2026-08-04) die
+englisch gebliebene Mail-Textfassung.
+
+## 🔴🔴 Der gemessene Kern: die Fläche ist falsch beschriftet UND wirkungslos
+
+Das Issue beschreibt „um eine Stufe verschoben". Gemessen ist es etwas anderes — und schlimmer.
+
+### Befund 1: Die Gewitter-Alarmschwelle wird nie ausgewertet
+
+Der einzige produktive Auslösepfad ist `TripAlertService.check_and_send_alerts()`
+(`src/services/trip_alert.py:447`) → `_select_change_detector()` (`trip_alert.py:366-381`).
+Diese Methode baut die `AlertEvaluationConfig` **ausschließlich** aus
+`trip.display_config.metric_alert_levels` — `trip.alert_rules` wird dort **gar nicht gelesen**.
+Für `AlertMetric.THUNDER_LEVEL` erzeugt `_PRESET_TABLE` (`src/services/alert_preset.py:50`)
+dabei **immer** `kind=AlertRuleKind.DELTA`, nie `ABSOLUTE` — unabhängig von der
+Empfindlichkeitsstufe.
+
+`_detect_absolute_changes()` mit dem `>=`-Stufenvergleich
+(`weather_change_detection.py:808-821`) läuft für andere Metriken (z. B. `WIND_GUST`)
+produktiv durch, wird für **Gewitter aber nie mit einer Regel gefüttert**.
+
+Wofür `trip.alert_rules` tatsächlich noch dient (alle 7 Fundstellen geprüft): Kanal-Routing
+(`_effective_alert_channels`, `trip_alert.py:1547-1595`) und als Prüf-Gate
+„wird der Trip überhaupt gecheckt" (`has_active_rules`, `trip_alert.py:444-447`).
+Positivkontrolle für den lebenden Pfad: `tests/tdd/test_alert_channel_threshold.py:113`
+nutzt `metric_alert_levels`, nicht `alert_rules`.
+
+### Befund 2: Das Produkt hat die Entscheidung längst getroffen — die Sperre hat ein Loch
+
+`frontend/src/lib/components/shared/alarme-tab/alertRuleDefaults.ts:45-50` führt
+`DELTA_ONLY_METRICS` — und `'thunder_level'` **steht bereits darin**. Die Guard greift aber
+nur im Zweig `mode === 'both'` (Z.75-80, Rückfall auf eine reine Delta-Regel), **nicht** im
+Zweig `mode === 'absolute'` (Z.61-66). `ModeCard.svelte` zeigt zudem für jede Metrik alle drei
+Modus-Karten ohne Sperre.
+
+Ein Nutzer kann also „Absolut" + „MITTEL"/„HOCH" wählen; die Regel wird über Go
+(`SyncAlertRules`) klaglos persistiert und beeinflusst Kanal-Routing und Prüf-Gate — aber
+**nie** die Schwellenauswertung. Die falsche Beschriftung ist damit das sichtbare Symptom
+eines Lecks in einer bereits bestehenden Absicht, nicht eine fehlende Beschriftung.
+
+### Befund 3: Wäre sie wirksam, wäre sie zusätzlich falsch beschriftet
+
+**Was das Backend tut** (`src/services/weather_change_detection.py:808-821`): Eine Alarm-Regel
+für `thunder_level` mit `comparison="above"` löst aus, sobald
+`thunder_ordinal(aktuelle_stufe) >= rule.threshold`. Die Ordinalskala ist seit #1474
+`NONE=0 · LOW=1 · MED=2 · HIGH=3` (`src/app/thunder_scale.py:42-57`).
+
+**Was die Oberfläche anbietet** (`frontend/src/lib/components/alert-rules-editor/AlertRuleRow.svelte:178-179`):
+
+```svelte
+<option value={1.0}>MITTEL</option>
+<option value={2.0}>HOCH</option>
+```
+
+| Nutzer wählt | gespeichert | löst tatsächlich aus ab | Oberfläche behauptet |
+|---|---|---|---|
+| „MITTEL" | 1.0 | **leicht** | mittel |
+| „HOCH" | 2.0 | **mittel** | hoch |
+| *(nicht wählbar)* | 3.0 | hoch | — |
+
+Beide angebotenen Stufen alarmieren also **eine Stufe früher** als beschriftet, und die
+tatsächlich höchste Gefahrenstufe lässt sich überhaupt nicht einstellen. Die
+View-Mode-Beschriftung derselben Fläche (`alertMetricLabels.ts:58-62`,
+`thunderLevelLabel()`) hat denselben Versatz und wirft zusätzlich 2.0 und 3.0 zusammen
+(`>= 2.0 → 'HOCH'`).
+
+**Ein Kommentar im Backend behauptet weiterhin die alte Welt:**
+`weather_change_detection.py:814-816` („threshold=1.0 must match MED=1") und
+`alert_preset.py:75-76` beschreiben die Drei-Stufen-Skala von vor #1474. Sie sind die
+wahrscheinliche Ursache dafür, dass die Frontend-Beschriftung nie nachgezogen wurde.
+
+## Related Files
+
+### Frontend — die vier Wortquellen
+
+| Datei:Zeile | Zustand | Erreichbar über |
+|---|---|---|
+| `lib/components/alert-rules-editor/AlertRuleRow.svelte:178-179` | 🔴 **falsch, 2 von 4 Stufen** (Edit-Mode-Auswahl) | `/trips/new` → Alarm-Regeln |
+| `lib/utils/alertMetricLabels.ts:58-62` `thunderLevelLabel()` | 🔴 **falsch, 3 Stufen, Versatz** (View-Mode-Text) | dieselbe Fläche |
+| `lib/components/shared/WeatherMetricsTab.svelte:1629-1634` | ✅ inhaltlich richtig (`leicht 1.0 / mittel 2.0 / hoch 3.0`), aber weiterhin **lokale** Liste | `/trips/{id}?tab=weather`, `/compare/{id}?tab=wetter-metriken` |
+| `lib/components/shared/corridor-editor/CorridorEditor.svelte:374,386` (+ `CorridorEditorMobile.svelte:245,361`) | ✅ **Vorbild** — rendert `ordinalLabels` live aus dem Backend-Katalog | Wertebereiche-Tab, beide Kontexte |
+
+Weitere Fundstellen ohne Nutzerschaden: `corridorEditorState.ts:407` `ORDINAL_ENUM`
+(internes Enum, positionell benutzt — driftet still), `TablePreview.svelte:36-39`
+(kosmetische Mockdaten), `alertChannelState.ts:97-100` (**nicht** thunder-spezifisch,
+allgemeine Kanal-Dringlichkeit — kein Kandidat).
+
+**Tot / nicht gemountet:** `trip-detail/AlertsPreviewCard.svelte:29` (kein Importer),
+`edit/TripEditView.svelte` (kein Importer außer einem Test) — beide konsumieren
+`thunderLevelLabel()`, sind aber im Browser nicht erreichbar.
+
+### Backend — die kanonischen Quellen
+
+| Datei:Zeile | Inhalt |
+|---|---|
+| `src/app/models.py:35-44` | `ThunderLevel` — NONE/LOW/MED/HIGH |
+| `src/app/thunder_scale.py:42-57`, `:65-91` | `thunder_ordinal()` und `thunder_label_value()` — bewusst zwei Funktionen (ADR-0025 Entscheidung 3) |
+| `src/output/metric_format.py:246-251` | `THUNDER_LABEL_DE` — kein/leicht/mittel/hoch |
+| `src/output/metric_format.py:257-262` | `_THUNDER_AMPEL_BAND` — grün/gelb/orange/rot |
+| `src/output/renderers/compare_metric_catalog.py:105-115` | `ordinalLabels: ["kein","leicht","mittel","hoch"]`, ausgeliefert über `GET /api/compare/metrics` (`api/routers/compare.py:11-22`, **kein** `context`-Parameter) |
+| `src/services/alert_preset.py:102-106` | `ORDINAL_LEVEL_BOUNDS` — Empfindlichkeitsstufen (andere Achse, s. u.) |
+
+### Backend — die englisch gebliebene Mail-Textfassung
+
+`src/output/renderers/email/helpers.py:872-902` `_THUNDER_MAP` (Zeilen gegenüber dem
+Issue-Text verschoben):
+
+| Stufe | `plain` heute | kanonisch (`THUNDER_LABEL_DE`) |
+|---|---|---|
+| NONE | `⚡–` | kein |
+| LOW | `⚡leicht` | ✅ |
+| MED | **`⚡MED`** | mittel |
+| HIGH | **`⚡HIGH`** | hoch |
+
+Konsumenten von `thunder_plain`, alle **nutzersichtbar**: `email/outlook.py:386`
+(Mailtext-Trendzeile), `email/compact.py:106` (Kompakt-Textfassung), `narrow.py:605`
+(schmale Ausgabe / Telegram).
+Die Schlüssel `word` und `sms` (`"MED"`/`"GEW-MED"`) haben **keinen** Produktivkonsumenten
+(einziger Treffer: `tests/tdd/test_thunder_low_output_channels.py:82`);
+`sq_color`/`word_color` sind tote Schlüssel.
+Der bereits richtige HTML-Pfad zum Abgleich: `email/helpers.py:621-643` `ampel_dot()` über
+`thunder_ampel_band()`.
+
+## Existing Patterns
+
+**Vorbild 1 — Katalog live gegenlesen:**
+`frontend/src/lib/components/shared/corridor-editor/__tests__/compareMetricCatalogParity.test.ts:38-51`
+ruft den Backend-Katalog per `execFileSync('uv', ['run','python3', …])` auf, statt eine
+Erwartungsliste abzuschreiben. Der CI-Job `frontend-test` hat `uv` dafür bereits eingerichtet.
+
+**Vorbild 2 — Produktivquelle statt Kopie prüfen:**
+`frontend/src/lib/components/shared/weather-metrics-tab/__tests__/thunderThresholdLevels.test.ts:49-70`
+liest das `levels={[...]}`-Array real aus `WeatherMetricsTab.svelte`. Es entstand für **exakt
+denselben Bugtyp** (Rest der alten Drei-Stufen-Skala) — in `AlertRuleRow.svelte` wurde er nie
+nachgezogen.
+
+**Vorbild 3 — Katalogdurchreichung in beide Kontexte:**
+`compareMetricCatalogLoader.ts:47-74` (`buildCompareMetricDefs`) und `:131-166`
+(`buildRouteMetricDefsFromCatalog`) liefern die vier `ordinalLabels` bereits **für beide**
+Kontexte korrekt durch. Die im Issue vermutete „Weiche, die den Trip-Kontext ausschließt"
+existiert dort **nicht** — sie betrifft den Wertebereiche-Tab, der ohnehin schon richtig ist.
+Der Alarm-Editor zieht seine Wörter schlicht gar nicht aus diesem Loader.
+
+## Dependencies
+
+- **Upstream:** `ThunderLevel` → `thunder_scale.py` → `metric_format.py` /
+  `compare_metric_catalog.py` → `GET /api/compare/metrics` → `compareMetricCatalogLoader.ts`
+- **Downstream:** Alarm-Auswertung `_detect_absolute_changes`
+  (`weather_change_detection.py:788-826`); Mail-/Telegram-Renderer (`outlook.py`,
+  `compact.py`, `narrow.py`) — Änderungen dort ziehen das **Renderer-Commit-Gate** und die
+  Pflicht-Mail-Validatoren nach sich.
+
+## Zwei Achsen, die nicht verwechselt werden dürfen
+
+| Achse | Wo eingestellt | Was sie tut | Quelle |
+|---|---|---|---|
+| **Alarm-Regel-Schwelle** (`AlertRule.threshold`, `comparison="above"`) | `/trips/new` → Alarm-Regeln (`AlertRuleRow`) | absoluter Vergleich `ordinal >= threshold` | `weather_change_detection.py:808-821` |
+| **Empfindlichkeitsstufe** (entspannt/standard/sensibel) | `?tab=alarme` (`AlarmeTab` → `AlertMetricLevelRow`) | Sprung-Alarm gegen den letzten Briefing-Stand | `alert_preset.py:102-106`, ADR-0043 |
+| **Erwähnungs-/SMS-Schwelle** | `?tab=weather` (`WeatherMetricsTab`) | ab wann erwähnen | `WeatherMetricsTab.svelte:1629` |
+| **Wertebereich** (`corridors[].notify`) | Wertebereiche-Tab | **keine Alarmwirkung mehr** (ADR-0043) | Katalog `ordinalLabels` |
+
+ADR-0043 hat dem Wertebereich die Alarmwirkung entzogen und die Empfindlichkeitsstufe zum
+einzigen Alarm-Regler erklärt. **Die Messung zeigt: die Alarm-Regel-Schwelle für Gewitter ist
+ebenfalls entwertet** (Befund 1) — nur hat niemand die Bedienfläche dazu entfernt.
+
+### Zwei Alarm-Systeme nebeneinander
+
+| System | Route | Komponente | Zeigt für Gewitter | Wirkt? |
+|---|---|---|---|---|
+| **Empfindlichkeitsstufe** | `/trips/{id}?tab=alarme`, `/compare/{id}?tab=alarme` | `AlarmeTab` → `AlertMetricLevelRow` | `off / entspannt / standard / sensibel` (generisch für alle Metriken), Schwelle als Zahl | ✅ **ja** — der einzige wirksame Regler |
+| **Alarm-Regeln (Alt)** | nur `/trips/new` | `AlertRulesEditor` → `AlertRuleRow` | Auswahl `MITTEL` (1.0) / `HOCH` (2.0) | 🔴 **nein** (Befund 1) |
+
+Ein Nutzer stellt bei der Trip-Anlage also etwas ein, das er später an derselben Stelle nie
+wiederfindet **und** das nie etwas auslöst.
+
+## Existing Specs & ADRs
+
+- `docs/context/feat-1480-thunder-scale-guard.md` — Vollmessung des Bestands: **15 lokale
+  Kopien im Produktivcode, 13 Test-Doubles (7 veraltet, 1 rot)**. Die dortige Empfehlung
+  „Vorsanierung reißt das LoC-Limit" gilt für #1488 unverändert ⇒ Scheiben.
+- ADR-0043 — Empfindlichkeitsstufe als einziger Alarm-Regler
+- ADR-0025 — zwei getrennte Thunder-Skalen (Ordnung vs. Renderwert)
+- ADR-0011 — ein Backend-Renderer für Alarme
+- `docs/specs/modules/fix_1474b_gewitterschwelle_cockpit.md` — der Vorgänger, der den
+  Trip-Teil gerichtet hat
+
+## Test-Doubles, die beim Fix mitgezogen werden müssen
+
+`ordinalLabels: ['kein','leicht','mittel','hoch']` hartkodiert in 5 Dateien / 6 Vorkommen:
+`corridorEditorState.test.ts:52`, `compareMetricCatalogParity.test.ts:71` und `:126`,
+`routeCorridorPoolCatalogExpansion.test.ts:78`,
+`alarme_tab_alert_metrics_from_catalog.test.ts:42`, `compareMetricSelection.test.ts:45`.
+
+Zusätzlich: `frontend/src/lib/utils/alertMetricLabels.test.ts:22-30` zementiert die falsche
+Beschriftung (`thunderLevelLabel(2.0) === 'HOCH'`), und
+`tests/tdd/test_compare_metric_catalog_endpoint.py:220-228` erwartet noch drei Labels — steht
+auf `.github/ci_tdd_excludes.txt:24` und läuft deshalb nicht auf CI.
+
+## Testwege für den geforderten Browser-Nachweis
+
+- Playwright-Specs: `frontend/e2e/*.spec.ts`, Login über Setup-Projekt
+  (`global.setup.ts:22-51`, `storageState` in `playwright/.auth/admin.json`)
+- CI-Job `e2e` fährt gegen einen **lokal gebauten Stack** (`localhost:4173`), nicht gegen
+  Staging; Staging-Specs tragen `.staging.spec.ts`
+- **Positivliste `.github/ci_e2e_specs.txt`** (45 Zeilen): ein neuer Spec läuft nur auf CI,
+  wenn er dort eingetragen ist; `E2E_MIN_SPECS: 45` prüft die Zeilenzahl **exakt**, geprüft
+  von `tests/unit/test_e2e_positivliste_ratschen_bindung.py`
+- ⚠️ `frontend/e2e/alert-rules-editor.spec.ts` navigiert nach `/trips/{id}/edit` — seit #616
+  nur noch ein Redirect auf eine nicht mehr geroutete Komponente. **Nicht als Vorlage nehmen.**
+
+## Risks & Considerations
+
+1. 🔴 **Umdeutung bestehender Regeln.** Wird die Beschriftung richtiggestellt, ohne die
+   gespeicherten Werte anzufassen, ändert sich für Bestandsnutzer nichts an der Wirkung —
+   ihre Regel alarmiert weiter ab „leicht", heißt aber jetzt auch so. Wird stattdessen der
+   Wert umgerechnet, ändert sich die Alarmhäufigkeit still. Beides ist vertretbar, aber es
+   ist eine **PO-Entscheidung**, keine Implementierungsdetailfrage.
+2. 🔴 **Mail-Renderer-Änderung zieht Pflicht-Validatoren.** `_THUNDER_MAP` liegt in
+   `email/helpers.py` ⇒ Renderer-Commit-Gate, Modus-Matrix-Test und
+   `briefing_mail_validator.py` gegen echt zugestellte Staging-Mail.
+3. **LoC-Limit 250.** Frontend-Sanierung + Mail-Textfassung + Test-Nachzug + Browser-Spec
+   überschreiten das Budget deutlich ⇒ Scheiben (Vorschlag in der Analyse).
+4. **Der Nachweis kostet mehr als der Fix.** Die reine Korrektur ist zweistellig in Zeilen;
+   Browser-Spec, Positivlisten-Ratsche und Test-Nachzug sind der Hauptteil.
+5. **Nicht in diesen Zug gehört** der Wächter gegen neue Kopien — das ist #1480, das laut
+   PO-Entscheidung **nach** #1488 kommt.
+
+## Backend-Tests und stale Kommentare, die mitgezogen werden müssen
+
+Alarm-Auslösung für `thunder_level` (`tests/unit/test_issue_222_alert_rules_detection.py`):
+
+| Test:Zeile | threshold | Zustand |
+|---|---|---|
+| `test_ac9_thunder_level_med_at_threshold_fires:273-292` | 1.0 | 🔴 Docstring behauptet „MED (ordinal=1)"; die Zusicherung **unterscheidet nicht** zwischen „ab leicht" und „ab mittel" — bleibt bei jeder Lesart grün. Muss inhaltlich ergänzt werden (Fall `NONE→LOW` fehlt), nicht nur umbenannt |
+| `test_ac9_thunder_level_high_with_threshold_2_fires:294-319` | 3.0 | ✅ für #1474 nachgezogen (Testname irreführend, Wert ist 3.0) |
+| `test_ac1_absolute_thunder_high_fires_once:369-383` | 2.0 | ✅ konsistent, prüft die MED-Grenze aber nicht |
+| `test_ac2_absolute_thunder_below_threshold_no_fire:385-399` | 3.0 | ✅ für #1474 nachgezogen |
+
+Stale Kommentare mit der alten Drei-Stufen-Skala (vollständiger Lauf über `src/ api/ tests/`):
+`weather_change_detection.py:814-816`, `alert_preset.py:75-77` (Produktivcode);
+`tests/tdd/test_alert_sensitivity_levels.py:6`, `tests/tdd/test_day_comparison_service.py:8`
+(widerspricht der korrigierten Stelle `:178-179` in derselben Datei),
+`tests/integration/test_friendly_format_email_and_alerts.py:717`.
+
+**Kein serverseitiger Wertebereich für `threshold`:** `src/app/models.py:1136-1152`
+(reines Dataclass, keine Constraints) und `internal/model/trip.go:56-67` (kein Tag);
+`validateTrip()` (`internal/handler/trip.go:89-107`) prüft Alarm-Regeln für **keine** Metrik.
+`3.0` wäre über die API persistierbar — nur das Bedienelement bietet es nicht an.
+
+## DOM-Testbarkeit (für die Browser-Nachweise)
+
+| Fläche | Locator | Zustand |
+|---|---|---|
+| Empfindlichkeitsstufe | `alert-metric-row-{metric}`, `alert-level-{metric}-{stufe}`, `alert-threshold-{metric}` | ✅ vollständig |
+| SMS-Schwelle Gewitter | `threshold-metric-row-thunder`, `threshold-level-thunder-{leicht\|mittel\|hoch}` | ✅ Stufenwort steht im Button-Text |
+| Alarm-Regel-Auswahl (Alt) | `alert-rule-threshold` (Edit-Modus) | ✅ Auswahl adressierbar; View-Modus hat **kein** eigenes testid, nur `.threshold` innerhalb `alert-rule-row` |
+
+Kein Spec auf der Positivliste `.github/ci_e2e_specs.txt` fasst heute die Gewitter-Stufennamen
+an. `frontend/e2e/alert-rules-editor.spec.ts` (AC-10) prüft genau diese Auswahl — zielt aber auf
+die seit #616 nicht mehr geroutete `/trips/[id]/edit` und steht folgerichtig nicht auf der Liste.
+Staging-Specs (`.staging.spec.ts`) sind von der Positivliste ausgenommen; Basis-URL über
+`GZ_SVELTE_BASE`, Zugänge über `GZ_VALIDATOR_*` (nginx) und `GZ_AUTH_*` (App).
+
+## Open Questions
+
+- [ ] **PO-Entscheid: beschriften oder entfernen?** Messung sagt: die Fläche wirkt nicht, und
+      `DELTA_ONLY_METRICS` enthält `thunder_level` bereits. Empfehlung: Absolut-Modus für
+      Gewitter konsequent sperren (Loch schließen) statt zwei falsche Wörter zu korrigieren.
+- [ ] **PO: Was passiert mit bereits gespeicherten wirkungslosen Regeln?** Still liegenlassen
+      (sie tun ohnehin nichts, beeinflussen aber Kanal-Routing und Prüf-Gate) oder beim Laden
+      auf eine Delta-Regel normalisieren?
+- [ ] **PO: Zuschnitt** — Frontend-Sanierung und Mail-Textfassung als zwei Scheiben?
+## ✅ Erreichbarkeit — Laufzeit-Nachweis (Playwright/Chromium gegen Staging, 2026-08-16)
+
+Kein Code-Scan, sondern real durchgeklickt auf `https://staging.gregor20.henemm.com`
+(Basic-Auth `GZ_VALIDATOR_*` + App-Login; **nichts angelegt**, Trip-Zahl vor/nach unverändert 4,
+einziger Netzaufruf mit Seiteneffekt war der zustandslose `POST /api/gpx/parse`).
+
+| Geprüft | Ergebnis |
+|---|---|
+| **Positivkontrolle** — Namensfeld auf `/trips/new` (`trip-new-name-input-desktop`) | ✅ gefunden und befüllbar ⇒ Suchweg funktioniert |
+| `/trips/new` → Alarm-Regeln → Metrik „Gewitter" → Schwellwert-Auswahl | 🔴 **bestätigt**: Optionstexte wörtlich `["MITTEL","HOCH"]`, Werte `["1","2"]` |
+| Bestehender Trip `?tab=alarme`, Metrik Gewitter | Sensitivitäts-Buttons (Aus/Entspannt/Standard/Sensibel) + Schwellwert-Anzeige **`Δ ≥ 1`**; Volltextsuche nach „MITTEL"/„HOCH" auf der Seite: **kein Treffer** |
+| `/trips/{id}/edit` | leitet real auf `/trips/{id}` um ⇒ Alt-Route bestätigt tot |
+
+**Nicht geprüft (Lücken):** mobile Ansicht; Ortsvergleich `/compare/…?tab=alarme` — Code deutet
+auf denselben geteilten `AlarmeTab`-Pfad wie bestehende Trips (also ebenfalls kein MITTEL/HOCH),
+das ist aber Lektüre, kein Laufzeit-Nachweis.
+
+**Nebenbefund** (nicht Teil dieses Tickets): Die Schwellwert-Anzeige zeigt für Gewitter `Δ ≥ 1`
+— konsistent damit, dass `_PRESET_TABLE` für `THUNDER_LEVEL` eine Delta-Regel erzeugt, aber
+erklärungsbedürftig für den Nutzer. Kandidat für den Sammel-Eintrag #1199.

--- a/docs/specs/modules/fix_1488_sa_gewitter_absolutregel.md
+++ b/docs/specs/modules/fix_1488_sa_gewitter_absolutregel.md
@@ -162,13 +162,21 @@ entfernen — die Funktion fällt sonst auf einen nicht mehr existierenden Impor
     neuer Fall `expandRules > mode=absolute + thunder_level → fällt auf delta zurück
     (Bugfix #1488 AC-3)`.
 
-- **AC-4:** Given ein Bestandstrip hat bereits eine gespeicherte Gewitter-Alarmregel
-  im Modus „Absolut" (z. B. Schwelle 1.0), When der Trip unverändert über die API
-  gelesen wird, Then ist die gespeicherte Regel byte-identisch zu der, die gespeichert
-  wurde — kein automatisches Umschreiben, kein Datenverlust.
-  - Test: `frontend/e2e/fix-1488-gewitter-absolutregel-gesperrt.spec.ts`,
-    Testfall „Bestandsregel überlebt PUT→GET unverändert" (reiner API-Roundtrip,
-    kein UI nötig; legt einen Testtrip an und räumt ihn im `finally` wieder ab).
+- **AC-4:** ~~Bestandsregel überlebt PUT→GET unverändert~~ — **gestrichen (PO 2026-08-16)**,
+  weil in der RED-Phase gemessen wurde, dass die Given-Bedingung nicht herstellbar ist:
+  Der Go-Store normalisiert `alert_rules` bei **jedem** Laden und Speichern
+  (`internal/store/trip.go:206` und `:238` → `model.SyncAlertRules`;
+  `internal/model/trip.go:383` setzt hart `rule.Kind = AlertRuleKindDelta`, Regeln zu
+  nicht-aktiven Metriken entfallen ganz). Einen Bestandstrip mit `kind='absolute'` gibt
+  es im Go-Pfad nicht — weder über die API noch per Datei auf Platte.
+  Ein Test dafür würde nicht Scheibe A prüfen, sondern fremdes Serververhalten
+  festschreiben, und wäre in RED grün. Beleg:
+  `docs/artifacts/fix-1488-gewitterstufen/red_ac4_go_store_normalizes_alert_rules.txt`.
+  Der Befund selbst ist in [#1895](https://github.com/henemm/gregor_zwanzig/issues/1895)
+  nachgetragen. Die Zusicherung „Scheibe A fügt keinen Umschreibe-Code hinzu" bleibt als
+  Unterlassung unter „Was darf sich NICHT ändern" bestehen — dort, wo sie hingehört.
+  **Der zugehörige Testfall ist in Phase 6 aus
+  `frontend/e2e/gewitter-absolutregel-gesperrt.spec.ts` zu entfernen.**
 
 - **AC-5:** Given die Empfindlichkeitsstufen-Fläche für Gewitter (`?tab=alarme`),
   When Scheibe A umgesetzt ist, Then zeigt diese Fläche unverändert weiterhin die
@@ -210,9 +218,11 @@ entfernen — die Funktion fällt sonst auf einen nicht mehr existierenden Impor
 
 ## Was darf sich NICHT ändern
 
-- **Bestandsdaten:** kein Trip mit vorhandenen `alert_rules` wird beim Laden,
-  Speichern oder Anzeigen automatisch umgeschrieben. Scheibe A fügt keinen
-  Migrations- oder Normalisierungscode für gespeicherte Regeln hinzu.
+- **Bestandsdaten:** Scheibe A fügt **keinen** Migrations- oder Normalisierungscode für
+  gespeicherte Regeln hinzu und ändert die bestehende serverseitige Behandlung nicht.
+  ⚠️ Präzisierung nach der Messung (s. gestrichenes AC-4): „unangetastet" wäre falsch —
+  der Go-Store normalisiert `alert_rules` schon heute bei jedem Laden und Speichern.
+  Die PO-Vorgabe lautet, dass **wir** daran nichts ändern, nicht dass nichts geschieht.
 - **Empfindlichkeitsstufen-Fläche** (`?tab=alarme`, `AlarmeTab` →
   `AlertMetricLevelRow`) bleibt vollständig unberührt — kein Datei-Zugriff, kein
   Verhaltensunterschied.

--- a/docs/specs/modules/fix_1488_sa_gewitter_absolutregel.md
+++ b/docs/specs/modules/fix_1488_sa_gewitter_absolutregel.md
@@ -1,0 +1,322 @@
+---
+entity_id: fix_1488_sa_gewitter_absolutregel
+type: bugfix
+created: 2026-08-16
+updated: 2026-08-16
+status: draft
+version: "1.0"
+tags: [gewitter, alarm-regeln, trip-new, frontend]
+---
+
+# #1488 Scheibe A — Absolut-Modus für Gewitter-Alarmregeln entfernen
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Beim Anlegen einer Tour (`/trips/new` → Alarmregeln) kann ein Nutzer für die Metrik
+„Gewitter" eine Regel im Modus „Absolut" mit Schwelle „MITTEL"/„HOCH" anlegen. Diese
+Einstellung wird gespeichert, aber vom Alarm-Dienst **nie ausgewertet** — für Gewitter
+zählt ausschließlich die Empfindlichkeitsstufe (`?tab=alarme`). Die Bedienfläche
+verspricht also eine Wirkung, die es nicht gibt, und wäre zusätzlich falsch beschriftet.
+
+Scheibe A schließt das bereits vorhandene Guard-Loch (`DELTA_ONLY_METRICS` kennt
+`thunder_level` schon, greift aber nur im Modus „Beides", nicht im Modus „Absolut")
+und entfernt die dazugehörige Bedienfläche und die veraltete Wortquelle. Bestandsdaten
+bleiben unangetastet — sie tun heute nichts und sollen weiterhin nichts tun.
+
+PO-Entscheidung (2026-08-16): **entfernen statt umbenennen.**
+
+## Source
+
+- **File:** `frontend/src/lib/components/alert-rules-editor/alertRuleDefaults.ts`
+- **Identifier:** `function expandRules()`
+
+> Schicht: **Frontend / User-UI** (`frontend/src/lib/components/...`, SvelteKit,
+> produktive Oberfläche auf `/trips/new`). Kein Go- oder Python-Code betroffen —
+> Scheibe A ändert ausschließlich Frontend-Dateien.
+
+## Estimated Scope
+
+- **LoC:** ~215–250 (touched lines, s. Tabelle unten) — **eng am Limit, s. „Offene Punkte"**
+- **Files:** 8 (6 geändert, 1 gelöschter Testblock in einer Bestandsdatei, 1 neue Datei)
+- **Effort:** medium (Fix selbst klein, Browser-Nachweis dominiert)
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `DELTA_ONLY_METRICS` (`alertRuleDefaults.ts:46-51`) | Konstante | bereits vorhandene Guard-Liste, wird um den `absolute`-Zweig ergänzt |
+| `ModeCard.svelte` | Komponente | rendert die drei Modus-Karten; bekommt hier keine eigene Logik — die Sperre sitzt im Aufrufer `AlertRuleRow.svelte` |
+| `AlertRulesEditor.svelte` → `AlertRuleRow.svelte` | Komponente | einziger produktiver Konsument von `expandRules()` und `thunderLevelLabel()` im erreichbaren Code |
+| `AlertsPreviewCard.svelte` (tot, s. u.) | Komponente | zweiter, aber unerreichbarer Konsument von `thunderLevelLabel()` — durch die Löschung der Funktion **erzwungen** mitgezogen (sonst bricht `svelte-check`) |
+| ADR-0043 | Architektur-Entscheidung | Empfindlichkeitsstufe ist der einzige Alarm-Regler — diese Scheibe vollzieht das für Gewitter in der Bedienfläche nach, ohne ADR-0043 selbst zu ändern |
+
+## Scope
+
+### Affected Files
+
+| File | Change Type | ~LoC (touched) | Warum |
+|------|-------------|----------------|-------|
+| `frontend/src/lib/components/alert-rules-editor/alertRuleDefaults.ts` | MODIFY | +10 | Guard im `mode==='absolute'`-Zweig, analog zum bestehenden `both`-Zweig |
+| `frontend/src/lib/components/alert-rules-editor/alertRuleDefaults.test.ts` | MODIFY | +24 | 2 neue RED→GREEN-Tests für den geschlossenen Guard |
+| `frontend/src/lib/components/alert-rules-editor/AlertRuleRow.svelte` | MODIFY | ~23 | Thunder-Sonderfall im Threshold-Feld entfernen, „Absolut"-ModeCard für `DELTA_ONLY_METRICS` ausblenden, Editmodus-Guard beim Metrik-Wechsel/Altregel-Öffnen, `valueText` vereinfacht |
+| `frontend/src/lib/utils/alertMetricLabels.ts` | MODIFY | -9 | `thunderLevelLabel()` ersatzlos gelöscht |
+| `frontend/src/lib/utils/alertMetricLabels.test.ts` | MODIFY | -11 | die 3 Tests, die den falschen Zustand zementierten, gelöscht |
+| `frontend/src/lib/components/trip-detail/AlertsPreviewCard.svelte` | MODIFY (erzwungen) | -2 | einziger zweiter Aufrufer von `thunderLevelLabel()` — Spezialfall entfernt, fällt auf den generischen Label-Pfad zurück. **Keine** weitere Bereinigung dieser toten Datei (s. Abgrenzung, Scheibe A2) |
+| `frontend/e2e/alert-rules-editor.spec.ts` | MODIFY | -38 | AC-10 (Zeilen 292–329) gelöscht — kodiert exakt das entfernte Verhalten (Select mit MITTEL/HOCH). Rest der Datei (20 weitere Tests gegen die tote Route `/trips/[id]/edit`) bleibt unangetastet — eigenständiges Aufräumen außerhalb dieser Scheibe (s. Abgrenzung) |
+| `frontend/e2e/fix-1488-gewitter-absolutregel-gesperrt.spec.ts` | CREATE | ~100 | Pflicht-Browser-Nachweis (PO-Vorgabe), s. Testplan — **regulärer CI-Spec, kein `.staging.spec.ts`** |
+| `.github/ci_e2e_specs.txt` | MODIFY | +1 | Aufnahme des neuen Specs in die CI-Positivliste, damit der Nachweis dauerhaft automatisch läuft |
+
+### Estimated Changes
+
+- Files: 9
+- LoC: ca. +135 / −114 (touched ≈ 249 von 250 — **siehe „Offene Punkte"**)
+
+## Implementation Details
+
+**1. Guard in `expandRules()` schließen** (analog Zeile 77-82, bereits vorhanden für `mode==='both'`):
+
+```ts
+if (mode === 'absolute') {
+	if (DELTA_ONLY_METRICS.has(rule.metric)) {
+		// #1488 Scheibe A: dieselbe Behandlung wie im 'both'-Zweig — eine
+		// Delta-only-Metrik darf nie als kind='absolute' persistiert werden.
+		const { pair_id: _pid, ...rest } = rule;
+		return [{ ...rest, kind: 'delta', threshold: deltaThreshold, delta_window: deltaWindow }];
+	}
+	const { pair_id: _pid, delta_window: _dw, ...rest } = rule;
+	return [{ ...rest, kind: 'absolute', threshold: absThreshold }];
+}
+```
+
+**2. `AlertRuleRow.svelte`:**
+
+- Thunder-Sonderfall im Threshold-Feld (Zeilen 172-180, `<option value={1.0}>MITTEL</option>` etc.)
+  ersatzlos entfernen — das Feld fällt für `thunder_level` auf die normale
+  `editMode`-Kette (`both`/`delta`/`absolute`) zurück.
+- „Absolut"-ModeCard (Zeilen 140-143) in `{#if !DELTA_ONLY_METRICS.has(draft.metric)}`
+  einpacken — für Delta-only-Metriken bleiben nur „Änderung" und „Beides" wählbar.
+- Neuer Guard, weil `editMode` sowohl beim Metrik-Wechsel im Select als auch beim
+  Öffnen einer Altregel mit `kind='absolute'` (`startEdit()`) auf `'absolute'`
+  hängen bleiben könnte, obwohl die zugehörige Karte nicht mehr existiert:
+
+```ts
+$effect(() => {
+	if (editing && DELTA_ONLY_METRICS.has(draft.metric) && editMode === 'absolute') {
+		editMode = 'delta';
+	}
+});
+```
+
+- `valueText` verliert den Thunder-Sonderfall (Zeilen 55-59 → 1 Zeile):
+  `let valueText = $derived(\`${rule.threshold} ${info?.unit ?? ''}\`.trim());`
+  Für eine bestehende Altregel zeigt der View-Modus damit z. B. „≥ 1" statt der
+  falschen Wörter — ehrlich, auch wenn (noch) kein Stufenwort. Live erreichbar ist
+  das ohnehin nicht (s. „Was darf sich NICHT ändern").
+
+**3. `alertMetricLabels.ts`:** `thunderLevelLabel()` (Zeilen 54-62) komplett löschen.
+
+**4. `AlertsPreviewCard.svelte` (erzwungene Mini-Änderung, KEINE Vollsanierung):**
+Zeile 29 `if (key === 'thunder_level') return \`Gewitter ${thunderLevelLabel(...)}\`;`
+entfernen — die Funktion fällt sonst auf einen nicht mehr existierenden Import.
+`metricLabel()` nutzt danach für alle Metriken denselben generischen Pfad
+(Zeilen 30-31). Die Datei bleibt ansonsten unverändert und weiterhin tot
+(kein Importer außer dem Barrel-Export, s. Abgrenzung Scheibe A2).
+
+## Expected Behavior
+
+- **Input:** Nutzer öffnet `/trips/new`, navigiert zu Alarmregeln, wählt/bearbeitet
+  eine Regel mit Metrik „Gewitter".
+- **Output:** Modus-Auswahl zeigt nur „Änderung" und „Beides" (Δ-Rückfall), keine
+  „Absolut"-Karte, kein MITTEL/HOCH-Select. Für alle anderen Metriken (z. B. Böen)
+  ändert sich nichts.
+- **Side effects:** keine — es wird nichts migriert, nichts automatisch umgeschrieben,
+  kein Backend-Code berührt.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Nutzer legt einen neuen Trip an und öffnet im Bereich
+  „Alarmregeln" eine Regel zur Metrik „Gewitter" im Bearbeiten-Modus, When er sich
+  die Modus-Auswahl ansieht, Then wird ihm dort keine „Absolut"-Karte mehr angeboten
+  und der Schwellwert-Select mit den Optionen „MITTEL"/„HOCH" existiert nicht mehr im DOM.
+  - Test: `frontend/e2e/fix-1488-gewitter-absolutregel-gesperrt.spec.ts`,
+    Testfall „Gewitter: keine Absolut-Karte, kein MITTEL/HOCH-Select" (echter Browser
+    im CI-`e2e`-Job, `/trips/new`).
+
+- **AC-2:** Given derselbe Bereich, When der Nutzer stattdessen die Metrik „Böen"
+  bearbeitet, Then wird ihm die „Absolut"-Karte weiterhin angeboten und bleibt
+  anklickbar — die Sperre gilt ausschließlich für Delta-only-Metriken, nicht
+  metrikübergreifend.
+  - Test: derselbe Testfall wie AC-1, Positivkontrolle im selben Testlauf (sonst wäre
+    „nicht gefunden" wertlos, s. PO-Vorgabe).
+
+- **AC-3:** Given eine Regel wird dennoch mit Metrik „Gewitter" und Modus „Absolut"
+  angefordert (z. B. per direktem API-Aufruf oder aus Alt-Code), When die Regel intern
+  über `expandRules()` expandiert wird, Then erzeugt das System keine Regel mit
+  `kind='absolute'` für Gewitter, sondern fällt auf eine Δ-Regel zurück — analog zum
+  bereits bestehenden Verhalten im Modus „Beides".
+  - Test: `frontend/src/lib/components/alert-rules-editor/alertRuleDefaults.test.ts`,
+    neuer Fall `expandRules > mode=absolute + thunder_level → fällt auf delta zurück
+    (Bugfix #1488 AC-3)`.
+
+- **AC-4:** Given ein Bestandstrip hat bereits eine gespeicherte Gewitter-Alarmregel
+  im Modus „Absolut" (z. B. Schwelle 1.0), When der Trip unverändert über die API
+  gelesen wird, Then ist die gespeicherte Regel byte-identisch zu der, die gespeichert
+  wurde — kein automatisches Umschreiben, kein Datenverlust.
+  - Test: `frontend/e2e/fix-1488-gewitter-absolutregel-gesperrt.spec.ts`,
+    Testfall „Bestandsregel überlebt PUT→GET unverändert" (reiner API-Roundtrip,
+    kein UI nötig; legt einen Testtrip an und räumt ihn im `finally` wieder ab).
+
+- **AC-5:** Given die Empfindlichkeitsstufen-Fläche für Gewitter (`?tab=alarme`),
+  When Scheibe A umgesetzt ist, Then zeigt diese Fläche unverändert weiterhin die
+  vier Stufen (Aus/Entspannt/Standard/Sensibel) — sie ist von dieser Änderung nicht
+  betroffen.
+  - Test: Regressionsschutz durch Unterlassung (kein Datei aus dieser Fläche wird
+    angefasst) + bestehender Test `alarme_tab_alert_metrics_from_catalog.test.ts`
+    muss nach der Änderung weiterhin grün laufen (kein neuer Test nötig).
+
+## Abgrenzung — ausdrücklich NICHT in Scheibe A
+
+- **Scheibe A2 (Kandidat, separates Ticket/Sammel-Eintrag):**
+  - Vollständige Löschung der toten Dateien `AlertsPreviewCard.svelte` (117 Zeilen)
+    und `TripEditView.svelte` (217 Zeilen) samt Barrel-Export (`trip-detail/index.ts:8`)
+    und der vier content-check-Tests, die auf `TripEditView.svelte` lesen
+    (`bug_596.test.ts`, Teile von `issue_523_suggested_flag_cleanup.test.ts` und
+    `issue_503_etappen_waypoints.test.ts`). Der bereits vorhandene Wächtertest
+    `deadTripOverviewComponentsRemoved.test.ts` wäre die richtige Stelle, die Liste
+    zu erweitern. **Nicht in Scheibe A**, weil nur die in dieser Spec genannte
+    Mini-Änderung an `AlertsPreviewCard.svelte` durch das Löschen von
+    `thunderLevelLabel()` erzwungen ist — die Vollsanierung ist eigenständige Arbeit
+    und hätte das LoC-Budget gesprengt.
+  - Lokale Stufenliste in `WeatherMetricsTab.svelte:1629-1634` auf den Backend-Katalog
+    umstellen (Vorbild: `CorridorEditor.svelte`).
+  - Die drei toten E2E-Dateien, die vollständig auf die tote Route
+    `/trips/[id]/edit` zielen (`frontend/e2e/alert-rules-editor.spec.ts` minus AC-10,
+    `issue-284-alert-rules-restyle.spec.ts`, `issue-687-alert-editor-soll-ist.spec.ts`)
+    — insgesamt ~1200 Zeilen. Scheibe A entfernt nur den einen Test, der das
+    entfernte Verhalten kodiert; die Route war schon vor dieser Scheibe tot
+    (`bug-274-safe-area-insets.spec.ts`-Kommentar in `.github/ci_e2e_specs.txt:76-78`
+    belegt das unabhängig).
+- **Scheibe B (schließt #1488):** Mail-Textfassung `_THUNDER_MAP`
+  (`⚡MED`/`⚡HIGH` → `⚡mittel`/`⚡hoch`) in `email/helpers.py`, veraltete
+  Backend-Kommentare (`weather_change_detection.py:814-816`, `alert_preset.py:75-77`
+  u. a.), zieht Renderer-Commit-Gate + Mail-Validatoren nach sich.
+- **#1480** (Wächter gegen neue Kopien) — kommt laut PO-Entscheidung nach #1488.
+- **Umdeutung/Migration bestehender Regeln** — PO-Entscheidung 2026-08-16: Bestandsdaten
+  bleiben unangetastet, keine Migration.
+
+## Was darf sich NICHT ändern
+
+- **Bestandsdaten:** kein Trip mit vorhandenen `alert_rules` wird beim Laden,
+  Speichern oder Anzeigen automatisch umgeschrieben. Scheibe A fügt keinen
+  Migrations- oder Normalisierungscode für gespeicherte Regeln hinzu.
+- **Empfindlichkeitsstufen-Fläche** (`?tab=alarme`, `AlarmeTab` →
+  `AlertMetricLevelRow`) bleibt vollständig unberührt — kein Datei-Zugriff, kein
+  Verhaltensunterschied.
+- **Andere Metriken behalten den Absolut-Modus.** Nur die vier Metriken in
+  `DELTA_ONLY_METRICS` (`thunder_level`, `temperature_change`, `wind_change`,
+  `precipitation_change`) verlieren die „Absolut"-Karte — das war für die anderen
+  drei bereits im Modus „Beides" so und wird hier nur auf den Modus „Absolut"
+  ausgeweitet (derselbe Guard, keine neue Metrik betroffen als `thunder_level`
+  im engeren Sinn des Issues).
+
+## Testwege für den Browser-Nachweis
+
+- **Reachability, laufzeit-bestätigt heute (2026-08-16):** `/trips/new` →
+  Alarmregeln benötigt den vollständigen Progressive-Tab-Unlock-Pfad: Name+Datum
+  (`trip-new-name-input-mobile`/`-desktop` + `trip-new-date-input`) → je Etappe GPX
+  hochladen (`etDone`, schaltet `wegpunkte`+`metriken` frei) → Tab „Wetter-Metriken"
+  besuchen (`wtVisited`, schaltet `zeitplan` frei) → Tab „Briefing-Zeitplan" besuchen
+  (`ztVisited`, schaltet `alerts` frei) → Tab „Alerts". Bereits als funktionierendes
+  Muster vorhanden: `frontend/e2e/issue-776-metrics-toggle.spec.ts::openNewTripZeitplan()`
+  (mobile Viewport, `.tn-mobile input[type="file"][accept=".gpx"]`-Schleife,
+  `frontend/e2e/fixtures/test-trip.gpx`) — **wiederverwenden/adaptieren**, nicht neu
+  erfinden. Der Klick auf „Alerts" ist der einzige zusätzliche Schritt.
+- **Kein Trip-Anlegen nötig:** GPX-Upload löst nur den zustandslosen
+  `POST /api/gpx/parse` aus (staging-bestätigt, s. `docs/context/fix-1488-gewitterstufen.md`
+  „Erreichbarkeit"-Abschnitt) — der Nachweis darf also **ohne** `Speichern`-Klick
+  auskommen: keine Testdaten, kein Cleanup nötig für den UI-Testfall.
+- **🔴 Regulärer CI-Spec, ausdrücklich KEIN `.staging.spec.ts`.** Ein Staging-Spec läuft
+  nur, wenn ihn jemand von Hand startet — er belegt den Fix einmal und bewacht ihn danach
+  nie wieder. Genau das ist der Fehlertyp, den dieses Ticket behebt (eine Zusicherung, die
+  niemand prüft, driftet still). Der Nachweis gehört deshalb in die automatische Kette.
+- **Kosten der Aufnahme, am CI gemessen (nicht geschätzt):** Ein Eintrag in
+  `.github/ci_e2e_specs.txt` genügt. Die Ratsche prüft
+  `N=$(wc -l < /tmp/e2e-specs.txt); [ "$N" -ge "$E2E_MIN_SPECS" ]`
+  (`.github/workflows/ci.yml:299-303`) — also **mindestens**, nicht exakt, entgegen dem
+  Kommentar bei `E2E_MIN_SPECS: 45` (`ci.yml:232`), der „EXAKT" behauptet. Die Liste führt
+  heute 45 Nicht-Kommentarzeilen; 46 ist grün, eine Anhebung der Konstante ist **nicht
+  nötig**. `E2E_MIN_EXECUTED_HAUPT: 224` prüft ebenfalls `>=` — zusätzliche Testfälle
+  erhöhen die Zahl und blockieren nicht. Beide Konstanten sollten dennoch mitgezogen
+  werden, damit die Ratsche ihren Zweck behält (Empfehlung, kein Blocker).
+- **⚠️ Offenes Umsetzungsrisiko:** Das oben genannte Vorbild
+  `issue-776-metrics-toggle.spec.ts` steht **nicht** auf der Positivliste — der
+  `/trips/new`-Pfad mit GPX-Upload ist im CI-Stack also **unerprobt**. Der Implementierer
+  muss belegen, dass er dort trägt (`POST /api/gpx/parse` gegen den lokalen Stack), statt
+  es anzunehmen. Trägt er nicht, ist das ein Befund für die Analyse — **nicht** der Anlass,
+  auf einen Staging-only-Spec auszuweichen.
+- **Aufnahmekriterium Filter B** der Positivliste verlangt 3× hintereinander grün gegen den
+  isolierten CI-Stack. Das gehört in den Nachweis der Implementierungsphase.
+- **Locators, bereits vorhanden:** `alert-rules-editor-add`, `alert-rule-row`,
+  `alert-rule-kebab-trigger`, `alert-rule-edit-btn`, `alert-rule-metric`
+  (Select für die Metrik), `mode-card-{absolute|delta|both}` (fehlt/vorhanden =
+  die eigentliche Zusicherung). `alert-rule-threshold` verschwindet für
+  `thunder_level` komplett — dessen Abwesenheit ist Teil der Zusicherung, nicht
+  nur ein Nebenbefund.
+- **`frontend/e2e/alert-rules-editor.spec.ts` AC-10:** wird gelöscht, weil sie
+  exakt das MITTEL/HOCH-Select-Verhalten prüft, das diese Scheibe entfernt — sie
+  lief zwar schon vorher nicht auf CI (nicht auf der Positivliste, tote Route),
+  soll aber nicht mit einer nachweislich falschen Zusicherung im Repo stehen bleiben.
+
+## Known Limitations
+
+- Für eine bestehende (unreachable) Gewitter-Altregel im Modus „Absolut" zeigt der
+  View-Modus von `AlertRuleRow.svelte` nach dieser Änderung nur noch die nackte
+  Zahl (z. B. „≥ 1") statt eines Stufenworts. Das ist kein Rückschritt (vorher war
+  das Wort schlicht falsch) und ohnehin nicht live erreichbar — die korrekte
+  Wort-Anzeige über den Backend-Katalog ist Scheibe A2/B.
+- Die Guard-Erweiterung betrifft alle vier Einträge von `DELTA_ONLY_METRICS`, also neben
+  `thunder_level` auch `temperature_change`/`wind_change`/`precipitation_change`. **Gemessen
+  und dem PO vorgelegt (2026-08-16): für alle vier ist die Sperre folgenlos** — keine von
+  ihnen wertet heute eine absolute Schwelle aus (`_PRESET_TABLE`, `alert_preset.py:47-58`,
+  erzeugt für **jede** Zeile `AlertRuleKind.DELTA`; der reale Detektor liest
+  `trip.alert_rules` nicht, `trip_alert.py:366-381`). Kein Rückschritt.
+- 🔴 **Bewusst in Kauf genommene Ungleichheit (PO-Entscheid „eng", 2026-08-16):** Der Modus
+  „Absolut" ist seit #946 für **alle** Metriken nur noch eine Kanal-Auswahl — die dort
+  eingetragene Schwelle löst nirgends mehr etwas aus, auch nicht bei `wind_gust`,
+  `precipitation_sum`, `temperature_min`/`_max`, `snow_line`. Nach dieser Scheibe
+  verschwindet die Absolut-Karte bei Gewitter, bleibt bei Böen aber stehen, obwohl sie
+  dort genauso wenig tut. Das ist der Preis dafür, diese Scheibe klein und beweisbar
+  folgenlos zu halten. Belege: `tests/tdd/test_issue_816_alert_deviation.py:740-750`
+  (Kommentar: „dieser Routing-Pfad wurde abgeschafft, `metric_alert_levels` ist jetzt die
+  einzige Quelle"), `tests/tdd/test_issue_638_alerts_redesign.py:479-528`.
+  **Aufgeräumt wird das in [#1895](https://github.com/henemm/gregor_zwanzig/issues/1895)**
+  (angelegt 2026-08-16) — nicht hier, weil dieselbe Regel heute noch die Kanalzuordnung
+  trägt und ihr Rückbau einen eigenen Entwurf braucht.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue
+- **Rationale:** Diese Scheibe vollzieht ADR-0043 („Empfindlichkeitsstufe ist der
+  einzige Alarm-Regler") für Gewitter in der Bedienfläche nach, ändert ADR-0043
+  selbst aber nicht. Kein neues Architekturprinzip, kein neuer Entscheidungsraum.
+
+## Offene Punkte
+
+- **LoC-Budget reicht voraussichtlich nicht.** Die Schätzung liegt bei ~249 von 250
+  berührten Zeilen — mit einem bewusst schlanken Browser-Nachweis. Erfahrungswert im
+  Projekt: der **Nachweis** kostet regelmäßig mehr als der Eingriff, und der
+  GPX-Upload-Pfad ist im CI unerprobt (s. Testwege). Der Eingriff selbst ist klein
+  (~40 Zeilen); alles darüber ist Beweisführung, die nicht gekürzt werden darf —
+  Browser-Nachweis und Guard-Tests sind beide PO-Pflichtvorgaben.
+  **Empfehlung an den PO: das Limit vorab auf 400 anheben**
+  (`workflow.py set-field loc_limit_override 400`), statt mitten in der Umsetzung
+  zwischen Budget und Beweis wählen zu müssen. Ohne diese Anhebung ist mit einem
+  Abbruch am Limit zu rechnen.
+
+## Changelog
+
+- 2026-08-16: Initial spec created (spec-writer, Workflow `fix-1488-gewitterstufen`)

--- a/frontend/e2e/alert-rules-editor.spec.ts
+++ b/frontend/e2e/alert-rules-editor.spec.ts
@@ -289,44 +289,10 @@ test.describe('Issue #223: AlertRulesEditor', () => {
 		}
 	});
 
-	// Issue #319: Kebab-Trigger öffnen vor Edit-Klick
-	test('AC-10: THUNDER_LEVEL — View zeigt "HOCH", Edit zeigt Select mit MITTEL/HOCH', async ({
-		page,
-		request
-	}) => {
-		const id = tripId('ac10');
-		await createTrip(request, id, [
-			{
-				id: 'r1',
-				kind: 'absolute',
-				metric: 'thunder_level',
-				threshold: 2.0,
-				unit: '',
-				severity: 'critical',
-				enabled: true
-			}
-		]);
-		try {
-			await page.goto(`/trips/${id}/edit`);
-			await page.locator('[data-testid="edit-tabs"] [data-value="alarmregeln"]').click();
-			const row = page.locator('[data-testid="alert-rule-row"]').first();
-			await expect(row).toContainText('HOCH');
-			await expect(row).not.toContainText('> 2');
-
-			await page.locator('[data-testid="alert-rule-kebab-trigger"]').first().click();
-			await page.locator('[data-testid="alert-rule-edit-btn"]').first().click();
-			const select = page.locator('[data-testid="alert-rule-threshold"]').first();
-			await expect(select).toBeVisible();
-			// Tag-Name verifizieren: select (nicht number-input)
-			const tag = await select.evaluate((el) => el.tagName.toLowerCase());
-			expect(tag).toBe('select');
-			await expect(select.locator('option')).toHaveCount(2);
-			await expect(select.locator('option', { hasText: 'MITTEL' })).toHaveCount(1);
-			await expect(select.locator('option', { hasText: 'HOCH' })).toHaveCount(1);
-		} finally {
-			await deleteTrip(request, id);
-		}
-	});
+	// #1488 Scheibe A: AC-10 („THUNDER_LEVEL — View zeigt HOCH, Edit zeigt Select
+	// mit MITTEL/HOCH") ist entfallen. Der Testfall kodierte exakt das Verhalten,
+	// das diese Scheibe entfernt: den Absolut-Modus fuer Gewitter samt der
+	// falsch beschrifteten Stufenwoerter.
 });
 
 test.describe('Issue #297: AlertRulesEditor — mode=both mit zwei Threshold-Feldern', () => {

--- a/frontend/e2e/gewitter-absolutregel-gesperrt.spec.ts
+++ b/frontend/e2e/gewitter-absolutregel-gesperrt.spec.ts
@@ -1,0 +1,145 @@
+// E2E — #1488 Scheibe A: der Absolut-Modus ist fuer Gewitter gesperrt.
+//
+// Spec: docs/specs/modules/fix_1488_sa_gewitter_absolutregel.md (AC-1, AC-2)
+//
+// Gemessener Bug (docs/context/fix-1488-gewitterstufen.md, Befund 1+3): auf
+// `/trips/new` -> Alarmregeln laesst sich fuer die Metrik „Gewitter" eine Regel
+// im Modus „Absolut" mit den Schwellen „MITTEL"/„HOCH" anlegen. Der Alarm-Dienst
+// wertet diese Schwelle nie aus, und beide Woerter alarmieren eine Stufe frueher
+// als beschriftet. Die Bedienflaeche verspricht eine Wirkung, die es nicht gibt.
+//
+// Regulaerer CI-Spec (kein `.staging.spec.ts`) und auf `.github/ci_e2e_specs.txt`
+// — ein von Hand gestarteter Staging-Spec belegt den Fix einmal und bewacht ihn
+// danach nie wieder; genau dieser Fehlertyp ist der Gegenstand des Tickets.
+
+import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import * as path from 'node:path';
+
+const MOBILE = { width: 390, height: 844 };
+
+// Locator fuer eine Modus-Karte. ModeCard.svelte:58-60 wechselt die testid je
+// nach Auswahl (`mode-card-absolute` <-> `mode-card-absolute-selected`) — ein
+// exakter Testid-Vergleich wuerde die ausgewaehlte Karte uebersehen und
+// „nicht vorhanden" melden, obwohl sie dasteht.
+function modeCard(scope: ReturnType<Page['locator']>, mode: 'absolute' | 'delta' | 'both') {
+	return scope.locator(`[data-testid="mode-card-${mode}"], [data-testid="mode-card-${mode}-selected"]`);
+}
+
+// `/trips/new` bis zum Alerts-Tab durchklicken. Uebernommen aus dem bereits
+// funktionierenden `issue-776-metrics-toggle.spec.ts::openNewTripZeitplan()`
+// (mobiler Pfad, Progressive-Tab-Unlock) — einziger zusaetzlicher Schritt ist
+// der Klick auf „Alerts". Kein Trip wird angelegt: der GPX-Upload loest nur den
+// zustandslosen `POST /api/gpx/parse` aus.
+async function openNewTripAlerts(page: Page) {
+	await page.setViewportSize(MOBILE);
+	await page.goto('/trips/new');
+	await page.getByTestId('trip-new-name-input-mobile').fill('#1488 Gewitter-Alarmregel');
+	await page.getByTestId('trip-new-date-input').fill(new Date().toISOString().slice(0, 10));
+
+	const tabbar = page.getByTestId('tn-mobile-tabbar');
+	await tabbar.getByRole('tab', { name: /Etappen/ }).click({ force: true });
+
+	const gpx = path.resolve('./e2e/fixtures/test-trip.gpx');
+	// IMMER den ersten verbleibenden offenen Datei-Input frisch aufloesen: eine
+	// Etappe mit gesetztem GPX verliert ihren Input komplett aus dem DOM
+	// (TripNewEditor.svelte `{#if s.gpx}`), ein fixierter Index zeigt danach
+	// ins Leere.
+	const stageCount = await page.locator('.tn-mobile input[type="file"][accept=".gpx"]').count();
+	for (let i = 0; i < stageCount; i++) {
+		const input = page.locator('.tn-mobile input[type="file"][accept=".gpx"]').first();
+		await Promise.all([
+			page.waitForResponse((r) => r.url().includes('/api/gpx/parse'), { timeout: 30_000 }).catch(() => null),
+			input.setInputFiles(gpx)
+		]);
+		await page.waitForTimeout(600);
+	}
+
+	await tabbar.getByRole('tab', { name: /Wetter/ }).click({ force: true });
+	await tabbar.getByRole('tab', { name: /Zeitplan/ }).click({ force: true });
+	await tabbar.getByRole('tab', { name: /Alerts/ }).click({ force: true });
+
+	// Harter Surface-Check: ohne den waere jedes spaetere `toHaveCount(0)`
+	// bedeutungslos (leerer DOM zaehlt auch 0). AlertRulesEditor wird sowohl im
+	// .tn-desktop- als auch im .tn-mobile-Baum gemountet — daher scopen.
+	const editor = page.locator('.tn-mobile').getByTestId('alert-rules-editor');
+	await expect(editor).toBeVisible({ timeout: 15_000 });
+	return editor;
+}
+
+// Legt eine Default-Regel an (wind_gust/absolut) und oeffnet ihren Edit-Modus.
+async function openFirstRuleEditor(page: Page, editor: ReturnType<Page['locator']>) {
+	await editor.getByTestId('alert-rules-editor-add').click();
+	await editor.getByTestId('alert-rule-kebab-trigger').first().click();
+	await editor.getByTestId('alert-rule-edit-btn').first().click();
+	const edit = editor.getByTestId('alert-rule-edit').first();
+	await expect(edit).toBeVisible();
+	return edit;
+}
+
+test.describe('#1488 Scheibe A: Absolut-Modus fuer Gewitter gesperrt', () => {
+	test('Böen: Absolut-Karte bleibt vorhanden und waehlbar (AC-2 Positivkontrolle)', async ({ page }) => {
+		const editor = await openNewTripAlerts(page);
+		const edit = await openFirstRuleEditor(page, editor);
+
+		// Default-Regel ist wind_gust (newDefaultRule) — keine Delta-only-Metrik.
+		await expect(edit.getByTestId('alert-rule-metric')).toHaveValue('wind_gust');
+		await expect(modeCard(edit, 'absolute')).toHaveCount(1);
+		await expect(modeCard(edit, 'absolute')).toBeEnabled();
+		await modeCard(edit, 'absolute').click();
+		await expect(edit.locator('[data-testid="mode-card-absolute-selected"]')).toHaveCount(1);
+	});
+
+	test('Gewitter: keine Absolut-Karte, kein MITTEL/HOCH-Select (AC-1)', async ({ page }) => {
+		const editor = await openNewTripAlerts(page);
+		const edit = await openFirstRuleEditor(page, editor);
+
+		// Positivkontrolle im selben Testfall: bei Böen steht die Absolut-Karte da.
+		await expect(modeCard(edit, 'absolute')).toHaveCount(1);
+
+		await edit.getByTestId('alert-rule-metric').selectOption('thunder_level');
+		// Gegenprobe, dass die Modus-Auswahl nach dem Metrik-Wechsel ueberhaupt
+		// noch gerendert wird — sonst waere die Abwesenheit der Absolut-Karte nur
+		// die Abwesenheit der ganzen Zeile.
+		await expect(modeCard(edit, 'delta')).toHaveCount(1);
+
+		// AC-1a: keine „Absolut"-Karte mehr fuer Gewitter.
+		// AC-1b: der Schwellwert-Select mit MITTEL/HOCH existiert nicht mehr im DOM.
+		// Beide als SOFT-Assertion: eine harte wuerde den Testfall an der ersten
+		// Stelle abbrechen, und die zweite Zusicherung bliebe im RED-Lauf
+		// ungemessen — „nicht ausgefuehrt" saehe dann aus wie „erfuellt".
+		await expect.soft(modeCard(edit, 'absolute')).toHaveCount(0);
+		await expect.soft(edit.locator('option', { hasText: /^MITTEL$/ })).toHaveCount(0);
+		await expect.soft(edit.locator('option', { hasText: /^HOCH$/ })).toHaveCount(0);
+
+		// AC-1c: der Modus darf nach dem Wechsel nicht auf der verschwundenen
+		// „Absolut"-Auswahl haengenbleiben. Ohne diese Zusicherung faengt KEIN
+		// Test die Entfernung des editMode-Guards (in der GREEN-Phase per
+		// Mutation gemessen, s. gegenprobe_mutation_editmode_guard.log) — der
+		// Nutzer saehe dann eine Schwelle, die beim Speichern still durch die
+		// Δ-Vorgabe ersetzt wird.
+		await expect.soft(edit.locator('[data-testid="mode-card-delta-selected"]')).toHaveCount(1);
+
+		// AC-1d: die Sperre haengt an DELTA_ONLY_METRICS, nicht am Namen
+		// 'thunder_level'. Ohne eine ZWEITE Delta-only-Metrik bliebe eine
+		// Verengung des Guards auf `draft.metric !== 'thunder_level'` unbemerkt
+		// (Adversary-Fund F001) — dann saehe der Nutzer bei
+		// „Temperatur (Änderung)" weiterhin eine anklickbare Absolut-Karte,
+		// deren Schwelle expandRules() beim Speichern still zu kind='delta'
+		// umschreibt. Genau dieses „sichtbar, aber wirkungslos" ist der Gegen-
+		// stand des Tickets. `temperature_change` gewaehlt, weil im selben
+		// Select erreichbar: kein zweiter Seitenaufbau, kein weiterer
+		// GPX-Durchlauf, damit der billigste der drei verbleibenden Faelle.
+		await edit.getByTestId('alert-rule-metric').selectOption('temperature_change');
+		await expect.soft(modeCard(edit, 'delta')).toHaveCount(1);
+		await expect.soft(modeCard(edit, 'absolute')).toHaveCount(0);
+	});
+});
+
+// AC-4 („Bestandsregel ueberlebt PUT→GET unveraendert") ist per PO-Entscheid
+// vom 2026-08-16 gestrichen und der zugehoerige Testfall hier entfernt: der
+// Go-Store normalisiert `alert_rules` bei jedem Laden und Speichern
+// (internal/store/trip.go:206/:238 -> model.SyncAlertRules), die Given-Bedingung
+// ist also gar nicht herstellbar. Der Befund ist in #1895 nachgetragen; die
+// Zusicherung „Scheibe A fuegt keinen Umschreibe-Code hinzu" bleibt eine
+// Unterlassung, kein Testfall.

--- a/frontend/src/lib/components/alert-rules-editor/AlertRuleRow.svelte
+++ b/frontend/src/lib/components/alert-rules-editor/AlertRuleRow.svelte
@@ -15,10 +15,7 @@
 	import { Btn, Pill } from '$lib/components/atoms';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { Select } from '$lib/components/ui/select';
-	import {
-		ALERT_METRIC_LABELS,
-		thunderLevelLabel
-	} from '$lib/utils/alertMetricLabels';
+	import { ALERT_METRIC_LABELS } from '$lib/utils/alertMetricLabels';
 	import { DELTA_ONLY_METRICS, expandRules, type AlertRuleMode } from './alertRuleDefaults';
 	import ModeCard from './ModeCard.svelte';
 	import { effectiveAlertChannels, toggleAlertChannel } from './alertChannels';
@@ -52,16 +49,25 @@
 
 	let info = $derived(ALERT_METRIC_LABELS[rule.metric]);
 	let editChannels = $derived(effectiveAlertChannels(draft, activeChannels));
-	let valueText = $derived(
-		rule.metric === 'thunder_level'
-			? thunderLevelLabel(rule.threshold)
-			: `${rule.threshold} ${info?.unit ?? ''}`.trim()
-	);
+	// #1488 Scheibe A: kein Thunder-Sonderfall mehr — die Stufenwoerter MITTEL/HOCH
+	// waren falsch beschriftet und ihre Schwelle wird nie ausgewertet.
+	let valueText = $derived(`${rule.threshold} ${info?.unit ?? ''}`.trim());
 
 	// Issue #179: Hinweistext wenn 'both' bei Delta-only Metrik auf 'delta' zurueckfaellt.
 	let deltaOnlyHint = $derived(
 		editing && editMode === 'both' && DELTA_ONLY_METRICS.has(draft.metric)
 	);
+
+	// #1488 Scheibe A: fuer Delta-only-Metriken gibt es keine 'Absolut'-Karte mehr.
+	// editMode koennte trotzdem auf 'absolute' stehen — beim Metrik-Wechsel im
+	// Select ebenso wie beim Oeffnen einer Altregel mit kind='absolute' via
+	// startEdit(). Ohne diesen Guard haenge der Modus auf einer Auswahl, die der
+	// Nutzer weder sieht noch abwaehlen kann.
+	$effect(() => {
+		if (editing && DELTA_ONLY_METRICS.has(draft.metric) && editMode === 'absolute') {
+			editMode = 'delta';
+		}
+	});
 
 	// Alle bekannten Metrics fuer das Select im Edit-Mode
 	const METRIC_OPTIONS: AlertMetric[] = [
@@ -126,21 +132,20 @@
 		onSave([{ ...rule, enabled: checked }]);
 	}
 
-	function onThunderChange(e: Event) {
-		// Number-Coercion: Select liefert Strings — wir wollen number im draft
-		draft.threshold = parseFloat((e.target as HTMLSelectElement).value);
-	}
 </script>
 
 {#if info}
 	{#if editing}
 		<div class="alert-rule-edit" data-testid="alert-rule-edit">
 			<div class="mode-selector" role="radiogroup" aria-label="Alarm-Modus">
-				<ModeCard
-					mode="absolute"
-					selected={editMode === 'absolute'}
-					onSelect={() => (editMode = 'absolute')}
-				/>
+				<!-- #1488 Scheibe A: Delta-only-Metriken kennen keinen Absolut-Modus. -->
+				{#if !DELTA_ONLY_METRICS.has(draft.metric)}
+					<ModeCard
+						mode="absolute"
+						selected={editMode === 'absolute'}
+						onSelect={() => (editMode = 'absolute')}
+					/>
+				{/if}
 				<ModeCard
 					mode="delta"
 					selected={editMode === 'delta'}
@@ -169,16 +174,7 @@
 					{/each}
 				</Select>
 
-				{#if draft.metric === 'thunder_level'}
-					<Select
-						value={draft.threshold}
-						onchange={onThunderChange}
-						data-testid="alert-rule-threshold"
-					>
-						<option value={1.0}>MITTEL</option>
-						<option value={2.0}>HOCH</option>
-					</Select>
-				{:else if editMode === 'both'}
+				{#if editMode === 'both'}
 					<!-- Issue #297 AC-3: drei Felder bei mode='both' — abs + delta + zeitfenster. -->
 					<input
 						type="number"

--- a/frontend/src/lib/components/alert-rules-editor/__tests__/deltaOnlyMetricsAbsolutGesperrt.test.ts
+++ b/frontend/src/lib/components/alert-rules-editor/__tests__/deltaOnlyMetricsAbsolutGesperrt.test.ts
@@ -1,0 +1,68 @@
+// Unit-Tests — #1488 Scheibe A, AC-3: expandRules() darf fuer eine Delta-only-
+// Metrik NIE eine Regel mit kind='absolute' erzeugen, auch nicht im Modus
+// 'absolute'.
+//
+// Spec: docs/specs/modules/fix_1488_sa_gewitter_absolutregel.md (AC-3)
+//
+// Warum eine eigene Datei statt einer Erweiterung von
+// `../alertRuleDefaults.test.ts`: der Edit-Gate laesst in der RED-Phase nur
+// Testverzeichnisse zu (`__tests__/`, `tests/`, `e2e/`), keine co-lokierten
+// `*.test.ts` unter `src/` (openspec.yaml -> strict_code_gate).
+//
+// Warum die PRODUKTIVE Menge `DELTA_ONLY_METRICS` importiert statt einer
+// abgeschriebenen Liste: `../alertRuleDefaults.test.ts:61-65` fuehrt eine
+// lokale Kopie, die `thunder_level` nicht enthaelt — genau die Drift, die
+// diesen Bug ueberhaupt erst hat durchrutschen lassen.
+//
+// Ausfuehrung:
+//   cd frontend && npm test -- \
+//     src/lib/components/alert-rules-editor/__tests__/deltaOnlyMetricsAbsolutGesperrt.test.ts
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+	newDefaultRule,
+	expandRules,
+	DELTA_ONLY_METRICS
+} from '../alertRuleDefaults.ts';
+import type { AlertRule } from '$lib/types';
+
+test('expandRules > mode=absolute + thunder_level → fällt auf delta zurück (Bugfix #1488 AC-3)', () => {
+	const base: AlertRule = { ...newDefaultRule(), metric: 'thunder_level', threshold: 2 };
+	const result = expandRules(base, 'absolute', 2, 1, '6h');
+
+	assert.equal(result.length, 1, 'thunder_level bei mode=absolute muss genau 1 Regel liefern');
+	assert.equal(
+		result[0].kind,
+		'delta',
+		"Gewitter darf nie als kind='absolute' persistiert werden — die absolute " +
+			'Schwelle wird vom Alarm-Dienst nie ausgewertet (#1488 Befund 1)'
+	);
+	assert.equal(result[0].metric, 'thunder_level');
+	assert.equal(result[0].threshold, 1, 'Rueckfall muss die Δ-Schwelle nutzen, nicht die Absolut-Schwelle');
+	assert.equal(result[0].delta_window, '6h', 'Δ-Regel braucht ein Zeitfenster');
+	assert.strictEqual(result[0].pair_id, undefined, 'Rueckfall-Regel darf kein pair_id tragen');
+});
+
+test('expandRules > mode=absolute + jede Delta-only-Metrik → nie kind=absolute (Bugfix #1488 AC-3)', () => {
+	// Positivkontrolle zuerst: eine NICHT delta-only Metrik behaelt den
+	// Absolut-Modus. Ohne sie waere "kind !== 'absolute'" auch dann erfuellt,
+	// wenn expandRules() den absolute-Zweig fuer ALLE Metriken verloeren haette.
+	const boeen = expandRules({ ...newDefaultRule(), metric: 'wind_gust' }, 'absolute', 80, 20, '6h');
+	assert.equal(boeen.length, 1);
+	assert.equal(boeen[0].kind, 'absolute', 'wind_gust muss den Absolut-Modus behalten');
+	assert.equal(boeen[0].threshold, 80);
+
+	assert.ok(DELTA_ONLY_METRICS.size >= 4, 'DELTA_ONLY_METRICS darf nicht leer laufen');
+	for (const metric of DELTA_ONLY_METRICS) {
+		const result = expandRules({ ...newDefaultRule(), metric }, 'absolute', 80, 20, '6h');
+		assert.equal(result.length, 1, `Delta-only-Metrik "${metric}" muss genau 1 Regel liefern`);
+		assert.equal(
+			result[0].kind,
+			'delta',
+			`Delta-only-Metrik "${metric}" darf bei mode=absolute nicht kind='absolute' erzeugen`
+		);
+		assert.equal(result[0].delta_window, '6h', `Δ-Regel fuer "${metric}" braucht ein Zeitfenster`);
+	}
+});

--- a/frontend/src/lib/components/alert-rules-editor/alertRuleDefaults.ts
+++ b/frontend/src/lib/components/alert-rules-editor/alertRuleDefaults.ts
@@ -30,7 +30,8 @@ export function newDefaultRule(): AlertRule {
 // und liefert das Array, das an AlertRulesEditor.updateRules(index, ...)
 // weitergereicht wird.
 //
-//   mode='absolute'                  -> [rule mit kind='absolute', threshold=absThreshold]
+//   mode='absolute' (Standard-Metrik) -> [rule mit kind='absolute', threshold=absThreshold]
+//   mode='absolute' (Delta-only)     -> [rule mit kind='delta'] (Guard greift, #1488)
 //   mode='delta'                     -> [rule mit kind='delta', threshold=deltaThreshold,
 //                                        delta_window=deltaWindow]
 //   mode='both' (Standard-Metrik)    -> [absolute (orig-ID, pair_id),
@@ -60,6 +61,13 @@ export function expandRules(
 	deltaWindow: string = '6h'
 ): AlertRule[] {
 	if (mode === 'absolute') {
+		if (DELTA_ONLY_METRICS.has(rule.metric)) {
+			// #1488 Scheibe A (AC-3): dieselbe Behandlung wie im 'both'-Zweig — eine
+			// Delta-only-Metrik darf nie als kind='absolute' persistiert werden, weil
+			// der Alarm-Dienst deren absolute Schwelle nie auswertet.
+			const { pair_id: _pid, ...rest } = rule;
+			return [{ ...rest, kind: 'delta', threshold: deltaThreshold, delta_window: deltaWindow }];
+		}
 		// F001: pair_id + delta_window explizit entfernen — beim Mode-Wechsel von
 		// 'both'/'delta' nach 'absolute' duerfen diese Felder nicht ueberleben.
 		const { pair_id: _pid, delta_window: _dw, ...rest } = rule;

--- a/frontend/src/lib/components/trip-detail/AlertsPreviewCard.svelte
+++ b/frontend/src/lib/components/trip-detail/AlertsPreviewCard.svelte
@@ -9,8 +9,7 @@
 		ALERT_METRIC_LABELS,
 		ALERT_SEVERITY_TONE,
 		SEVERITY_LABEL_DE,
-		normalizeAlertMetric,
-		thunderLevelLabel
+		normalizeAlertMetric
 	} from '$lib/utils/alertMetricLabels';
 
 	interface Props {
@@ -26,7 +25,7 @@
 		const key = normalizeAlertMetric(rule.metric);
 		const meta = key ? ALERT_METRIC_LABELS[key] : undefined;
 		if (!meta) return rule.metric;
-		if (key === 'thunder_level') return `Gewitter ${thunderLevelLabel(rule.threshold)}`;
+		// #1488 Scheibe A: kein thunder_level-Sonderfall mehr — generischer Pfad.
 		const unit = meta.unit ? ` ${meta.unit}` : '';
 		return `${meta.label_de} ${meta.comparison} ${rule.threshold}${unit}`;
 	}

--- a/frontend/src/lib/utils/alertMetricLabels.test.ts
+++ b/frontend/src/lib/utils/alertMetricLabels.test.ts
@@ -13,22 +13,13 @@ import assert from 'node:assert/strict';
 import {
 	ALERT_METRIC_LABELS,
 	ALERT_SEVERITY_TONE,
-	thunderLevelLabel,
 	normalizeAlertMetric,
 } from './alertMetricLabels.ts';
 import type { AlertMetric } from '$lib/types';
 
-test('thunderLevelLabel: threshold 2.0 → HOCH (AC-6)', () => {
-	assert.equal(thunderLevelLabel(2.0), 'HOCH');
-});
-
-test('thunderLevelLabel: threshold 1.0 → MITTEL', () => {
-	assert.equal(thunderLevelLabel(1.0), 'MITTEL');
-});
-
-test('thunderLevelLabel: threshold 0.5 → KEINE (sub-MITTEL)', () => {
-	assert.equal(thunderLevelLabel(0.5), 'KEINE');
-});
+// #1488 Scheibe A: die drei `thunderLevelLabel`-Faelle sind entfallen — sie
+// zementierten die falschen Stufenwoerter MITTEL/HOCH; die Funktion selbst ist
+// mit dem Absolut-Modus fuer Gewitter geloescht worden.
 
 test('ALERT_SEVERITY_TONE: critical → danger (AC-6)', () => {
 	assert.equal(ALERT_SEVERITY_TONE['critical'], 'danger');

--- a/frontend/src/lib/utils/alertMetricLabels.ts
+++ b/frontend/src/lib/utils/alertMetricLabels.ts
@@ -51,15 +51,9 @@ export const SEVERITY_LABEL_DE: Record<AlertSeverity, string> = {
 	critical: 'Kritisch'
 };
 
-/**
- * Wandelt einen THUNDER_LEVEL-Threshold (1.0 / 2.0) in einen menschenlesbaren
- * Label fuer die AlertRow-Anzeige. >=2.0 → "HOCH", >=1.0 → "MITTEL", sonst "KEINE".
- */
-export function thunderLevelLabel(threshold: number): string {
-	if (threshold >= 2.0) return 'HOCH';
-	if (threshold >= 1.0) return 'MITTEL';
-	return 'KEINE';
-}
+// #1488 Scheibe A: `thunderLevelLabel()` ersatzlos entfernt. Die Stufenwoerter
+// MITTEL/HOCH alarmierten eine Stufe frueher als beschriftet und gehoerten zu
+// einer Absolut-Schwelle, die der Alarm-Dienst fuer Gewitter nie auswertet.
 
 // Bug #317 — Legacy-AlertMetric-IDs auf aktuelle AlertMetric-Enum-Werte abbilden.
 // Spec: docs/specs/modules/bug_317_alert_rules_editor_metrics.md


### PR DESCRIPTION
## Worum es geht

Beim Anlegen einer Tour konnte man fuer Gewitter eine Alarmschwelle `MITTEL` / `HOCH` einstellen. Diese Einstellung hat **nie etwas ausgeloest** — und war zusaetzlich falsch beschriftet.

**Laufzeit-bestaetigt** (Playwright gegen Staging, nichts angelegt): Auf `/trips/new` bot das Auswahlfeld woertlich `["MITTEL","HOCH"]` mit den Werten `["1","2"]`.

| Nutzer waehlte | gespeichert | haette ausgeloest ab | Oberflaeche behauptete |
|---|---|---|---|
| „MITTEL" | 1.0 | leicht | mittel |
| „HOCH" | 2.0 | mittel | hoch |
| *(nicht waehlbar)* | 3.0 | hoch | — |

Beides ist ohnehin theoretisch: Der Detektor (`trip_alert.py:366-381`) baut seine Konfiguration ausschliesslich aus `metric_alert_levels`; `_PRESET_TABLE` (`alert_preset.py:47-58`) erzeugt fuer `THUNDER_LEVEL` immer `kind=DELTA`. Die Schwelle wurde nie gelesen.

## Was sich aendert

`DELTA_ONLY_METRICS` enthielt `thunder_level` **bereits** — die Guard griff aber nur im Modus „beides", nicht im Modus „absolut". Diese Luecke ist geschlossen. Damit entfallen:

- die Modus-Karte „Absolut" fuer Delta-only-Metriken
- der `MITTEL`/`HOCH`-Select
- `thunderLevelLabel()` samt der Tests, die den falschen Zustand festhielten

Unterm Strich **weniger** Code: +45 / −91 Zeilen.

## Was sich NICHT aendert

- Bestandsdaten: kein Migrations- oder Normalisierungscode. (Der Go-Store normalisiert `alert_rules` ohnehin bei jedem Laden/Speichern — deshalb wurde AC-4 gestrichen, s.u.)
- Die Empfindlichkeitsstufen-Flaeche (`?tab=alarme`) bleibt unberuehrt
- Andere Metriken behalten den Absolut-Modus

## Nachweis

- **Browser-Test** `frontend/e2e/gewitter-absolutregel-gesperrt.spec.ts`, aufgenommen in die CI-Positivliste (Filter B erfuellt: 3x hintereinander gruen gegen den isolierten Stack, je frischer Stack und geloeschte Datenwurzel)
- **Positivkontrolle** im selben Lauf: Boeen behaelt die Absolut-Karte — ohne sie waere „nicht gefunden" wertlos
- **Zweite Delta-only-Metrik** (`temperature_change`) bewacht gegen Verengung des Guards auf einen einzelnen Namen
- Voller Frontend-Unit-Lauf: `# pass 2635 # fail 0`; `svelte-check` unter Baseline
- **Adversary VERIFIED**, 4 Mutationen. Die eine ungefangene (Guard auf `thunder_level` verengt) wurde als F001 geschlossen und in beide Richtungen belegt.

## Entscheidungen

- **PO 2026-08-16: entfernen statt umbenennen.** Zwei falsche Woerter durch vier richtige zu ersetzen haette eine Bedienflaeche verschoenert, die nichts tut.
- **Zuschnitt eng** auf `DELTA_ONLY_METRICS`. Gemessen folgenlos fuer alle vier Eintraege.
- **AC-4 gestrichen:** Die Given-Bedingung (Bestandstrip mit `kind='absolute'`) ist nicht herstellbar — `internal/store/trip.go:206`+`:238` normalisieren bei jedem Laden und Speichern.

## Folgearbeit

- **#1895** — der Modus „Absolut" loest seit #946 fuer **keine** Metrik mehr aus, traegt aber noch die Kanalzuordnung. Deshalb bleibt die Karte bei Boeen vorerst stehen, obwohl sie dort genauso wenig tut.
- **Scheibe B** (schliesst #1488): Mail-Textfassung `⚡MED`/`⚡HIGH` → `⚡mittel`/`⚡hoch`
- **Scheibe A2:** lokale Stufenliste in `WeatherMetricsTab.svelte` auf den Backend-Katalog; Vollsanierung der toten Dateien
- **#1197** — zwei Testinfrastruktur-Befunde gebucht (E2E-Proxy zeigt per Default auf Staging; `isAuthFileValid()` prueft nur das Ablaufdatum)

Spec: `docs/specs/modules/fix_1488_sa_gewitter_absolutregel.md` · Messung: `docs/context/fix-1488-gewitterstufen.md`

Teil von #1488 (Scheibe A) — schliesst das Issue **nicht**, das tut Scheibe B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
