### PR TITLE
docs(#1467 S4a): Freigabe-Haken in der Spec nachtragen

### DIFF
--- a/docs/specs/modules/rework_1467_s4a_amtlich.md
+++ b/docs/specs/modules/rework_1467_s4a_amtlich.md
@@ -12,7 +12,7 @@ tags: [alerts, trip, compare, epic-1458, issue-1467, s4a, amtlich]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO-„go" 2026-08-16 (Beleg: Workflow-State `rework-1467-s4a-amtlich`, `phase4_approved`)
 
 ## Purpose
 


### PR DESCRIPTION
Reiner Doku-Nachtrag. Die S4a-Spec war freigegeben (Workflow-State `phase4_approved`) und ist seit `b27eb3df` live, trug aber weiterhin `- [ ] Approved`. Gleiche Form wie bei der Vorgaenger-Scheibe S3.

Kein Code. Gefunden bei einem Doku-Audit nach dem Live-Gang von S4a — der Audit fand sonst keine durch S4a falsch gewordene Doku-Stelle.

Refs #1467

🤖 Generated with [Claude Code](https://claude.com/claude-code)