### PR TITLE
fix(#1708 A): Waechter gegen Wiederkehr der toten Trip-Ablage

### DIFF
--- a/api/routers/preview.py
+++ b/api/routers/preview.py
@@ -7,8 +7,9 @@ Endpoints:
 - GET /api/preview/{trip_id}/sms — liefert JSON {subject, token_line, char_count}
 
 Auth: user_id-Query-Param wird vom Go-Proxy aus der Session injiziert (Bug #199).
-Trip-Owner-Check: Loader-Pfad ist user-scoped (`data/users/<user>/trips/<id>.json`),
-damit gilt: wer fremde user_id schickt, kommt nicht an fremde Trips.
+Trip-Owner-Check: Loader-Pfad ist user-scoped (`data/users/<user>/briefings/<id>.json`,
+Issue #1250 Cutover, ADR-0023), damit gilt: wer fremde user_id schickt, kommt nicht an
+fremde Trips.
 """
 from __future__ import annotations
 

--- a/docs/adr/0031-persistenz-dateibasiert-data-users.md
+++ b/docs/adr/0031-persistenz-dateibasiert-data-users.md
@@ -13,7 +13,7 @@ Prozessgrenzen hinweg (Go-API ist der einzige Schreiber, Python liest).
 ## Entscheidung
 
 Persistenz ist ein dateibasierter JSON-Store unter `data/users/{user_id}/`
-(`user.json`, `trips/`, `briefings/` (kind=route|vergleich, ADR-0023), `gpx/`,
+(`user.json`, `briefings/` (kind=route|vergleich, ADR-0023), `gpx/`,
 `locations.json`, `alert_state/`, Snapshot-/Throttle-Dateien). Der Go-Store
 (`internal/store/`) ist die einzige Schreib-Autorität; Normalisierung beim
 Load (`normalizeTrip`, `NormalizeComparePreset`). Es gibt keine Datenbank.

--- a/docs/context/fix-1708-waechter-tote-trip-ablage.md
+++ b/docs/context/fix-1708-waechter-tote-trip-ablage.md
@@ -1,0 +1,280 @@
+# Context: fix-1708-waechter-tote-trip-ablage
+
+Issue: [#1708](https://github.com/henemm/gregor_zwanzig/issues/1708) — Scheibe A (Teilarbeit, schließt das Issue **nicht**)
+
+## Request Summary
+
+Seit #1250 Scheibe 7a (ADR-0023) leben Trips ausschließlich in `data/users/<uid>/briefings/<id>.json`.
+Der Pfad `data/users/<uid>/trips/<id>.json` ist toter Bestand, sieht aber vollständig und plausibel aus
+und hat nachweislich vier Fehlaussagen und zwei Datenänderungen ins Leere verursacht.
+Scheibe A errichtet den Wächter, der die Falle nicht neu entstehen lässt, und entfernt die
+Produktivstellen, die sie laufend neu herstellen.
+
+## Related Files
+
+### Go — Produktivcode (Scheibe A entfernt/ändert)
+
+| Datei:Zeile | Relevanz |
+|---|---|
+| `internal/store/trip.go:14-16` | `TripsDir()` bildet den toten Pfad. **Null Aufrufer im gesamten Repo** — weder Produktiv noch Test, nur Kommentar-Erwähnungen. Risikofreie Löschung. |
+| `internal/store/user.go:84` | `ProvisionUserDirs` legt `"trips"` für **jeden neuen Nutzer** an. Das ist die Stelle, die die Falle laufend neu herstellt. |
+
+### Go — Aufrufer und Mitbetroffene
+
+| Datei:Zeile | Relevanz |
+|---|---|
+| `internal/handler/auth.go:109`, `auth_oauth.go:220`, `auth_magic.go:222`, `passkey.go:568` | Die 4 Produktiv-Aufrufer von `ProvisionUserDirs` — alle vier Registrierungswege |
+| `internal/handler/profile_test.go:378,395` | ⚠️ **Zementiert den Bestand:** `TestRegisterCreatesUserDirs` assertiert per `os.Stat`, dass `trips/` nach Registrierung existiert. Wird beim Entfernen rot und muss mit umgestellt werden. |
+| `internal/scheduler/selftest.go:42` | Probt bereits gegen `briefings/`; nur die lokale Variable heißt noch `tripsDir`. Fehlendes Verzeichnis wird übersprungen (`:45-46`) — **kein** Fehlalarm zu erwarten. |
+| `internal/handler/delete_account_test.go:21`, `internal/store/store_trip_briefings_test.go:30,98` | Legen `trips/` selbst per `os.MkdirAll` an, unabhängig von `ProvisionUserDirs` — kein Bruch, aber Wächter-relevant (Scanfläche darf Testcode nicht treffen). |
+
+### Go — heutiger Lese-/Schreibpfad (Soll-Zustand, unverändert)
+
+`internal/store/briefing_subscription.go:19` `briefingsDir()` · `:25` `BriefingsDir()` ·
+`internal/store/trip.go:117` `LoadTrips` · `:178` `LoadTrip` · `:222` `SaveTrip` (Kommentar `:224`:
+„trips/<id>.json wird NICHT mehr angefasst (Rollback-Faehigkeit, AC-26)") · `:265` `DeleteTrip`
+
+### Python
+
+| Datei:Zeile | Relevanz |
+|---|---|
+| `src/app/loader.py:1155-1163` | `get_trips_dir()` — **kein Aufrufer** in `src/`, `api/`, `scripts/`, `.claude/`. Docstring begründet den Verbleib mit „Rollback-Fähigkeit, AC-26" und „historical per-user directory bootstrap". |
+| `src/app/loader.py:1166` | `get_briefings_dir()` — der lebende Pfad; Aufrufer in `loader.py:1409,1728,1771`, `src/services/preview_service.py:67`, `src/services/trip_report_scheduler.py:313`, `api/routers/validator.py:52` |
+| `tests/conftest.py:121-172` | autouse `_isolate_data_root` (#1133): setzt `app.loader._DATA_ROOT` auf ein tmp-Verzeichnis; alle Helfer folgen automatisch. Vergleicht zusätzlich den echten `data/users`-Baum vor/nach (#1265 Teil C). |
+
+### Python — die 17 Testdateien mit `get_trips_dir` (Scheibe **B**, hier nur zur Abgrenzung)
+
+Nur **12** rufen die Funktion wirklich auf; 5 nennen sie in Kommentaren
+(`test_bundle_791_847_844_alerts.py:72`, `test_issue_363_signal_telegram_preview.py:28`,
+`test_issue_818_radar_briefing_integration.py:97`, `test_issue_822_radar_nowcast_segment.py:101`,
+`test_loader_display_config_default.py:244`).
+
+Von den 12 sind die meisten **toter Aufräum-Code** (`unlink()`/`rmtree` auf eine nie geschriebene Datei):
+`test_feature_656_radar_nowcast.py:188,215,302` · `test_feature_660_convective_stage.py:234` ·
+`test_inbound_gate_errors.py:48` · `test_issue_612_report_on_demand.py:155,293,327` ·
+`test_issue_731_unified_commands.py:184` · `test_issue_882_pause_skip.py:69-72` ·
+`test_trip_command_processor.py:73` · `test_issue_1001_telegram_bubbles.py:437`
+
+**Verdachtsfälle „grün aus dem falschen Grund" (Scheibe B, echte Untersuchung nötig):**
+- `test_bug_338_openmeteo_call_counter.py:211` — `if not trip_file.exists(): pytest.skip(...)` → der Test **skippt vermutlich immer**
+- `test_issue_346_fixture_provider.py:29` — Existenz im toten Pfad steuert die **Fixture-Auswahl**
+- `test_issue_1001_telegram_bubbles.py:858-862` — schreibt eine F003-Fixture nach `trips/`, die nie gelesen wird
+
+**Legitime Ausnahme (bleibt):** `tests/test_briefing_route_cutover.py` — die Datei **beweist** den Cutover
+(AC-25 Lockvogel `:130,:149`; AC-26 Byte-Identität nach `save_trip` `:171-173,:184-186`). Sie braucht
+zwingend einen Zeiger auf `trips/`. Laut Issue soll dieser Zeiger dort **testlokal und unmissverständlich
+benannt** gebaut werden.
+
+## Existing Patterns
+
+### Wächter-/Ratschen-Bauart im Repo (Vorbilder)
+
+| Vorbild | Bauart |
+|---|---|
+| `tests/test_output_timezone_guard.py:101-103,148,526,680,696` | AST-Scan über Glob-Scanfläche; `KNOWN_VIOLATIONS: dict[str,str]` mit Schlüsselform `pfad::funktion::ordinal`; **zwei gekoppelte Tests** — „keine unlisted" + „Liste darf nur schrumpfen"; `test_scan_list_paths_all_exist` gegen stilles Grün |
+| `tests/test_success_status_guard.py:1996,2032,3228,3268,3293` | dieselbe Bauart + zweite Ausnahmeliste mit **Begründungspflicht**; Go-Ausschluss ist selbst getestet |
+| `tests/test_egress_inventory_drift.py:33-67,92` | **Go wird per Textsuche/Regex gelesen** und als Daten gegen die Python-Seite verglichen; Parser-Wirkungsnachweis `test_parser_ignores_commented_out_lines` |
+| `internal/handler/store_scope_guard_test.go:71,359,37,650` | Go-seitiger AST-Wächter mit Mindestdatei-Schwelle (`ssgMindestDateien = 50`) gegen stilles Grün und Ausnahmeventil mit Begründungspflicht |
+| `tests/test_guard_findings_survive_line_shifts.py:1-45` | Meta-Wächter: Schlüsselform muss Zeilenverschiebungen überstehen |
+
+**Wichtig:** Die drei Python-Wächter (`test_output_timezone_guard`, `test_success_status_guard`,
+`test_resolution_loss_guard`) schließen `internal/` **bewusst** aus ihrer Scanfläche aus. Für #1708 liegt
+die Falle aber auf **beiden** Seiten — der Wächter muss Go mitprüfen. Das Vorbild dafür ist
+`test_egress_inventory_drift.py` (Textparse von Go), nicht die AST-Wächter.
+
+Wächter-Tests liegen **direkt unter `tests/`**, nicht in `tests/tdd/`.
+
+## Dependencies
+
+- **Upstream:** `ADR-0023` (`docs/adr/0023-briefing-subscription-shared-model.md`) — beschließt
+  `briefings/<id>.json` als einzige Persistenz-Wahrheit für `kind="route"` und `kind="vergleich"`;
+  S7 ist der atomare Cutover von Lese- UND Schreibpfad in Go und Python.
+- **Downstream:** Alle vier Registrierungswege rufen `ProvisionUserDirs`; nach der Änderung entsteht
+  für neue Nutzer kein `trips/` mehr. Kein Produktivcode liest oder statet den Pfad.
+
+## Existing Specs
+
+- `docs/adr/0023-briefing-subscription-shared-model.md` — der Cutover-Beschluss
+- ⚠️ `docs/adr/0031-persistenz-dateibasiert-data-users.md:16` — listet `trips/` **weiterhin** als Bestandteil
+  des Nutzerverzeichnis-Layouts. Muss in Scheibe A mit korrigiert werden, sonst widerspricht das ADR dem Code.
+- Veraltete Prosa mit `get_trips_dir`: `docs/specs/modules/preview_service.md:35`,
+  `docs/specs/modules/issue_221_validator_observability_endpoints.md:47,76`,
+  `docs/features/weather_snapshot_service.md:96,143`
+
+## Risks & Considerations
+
+1. **Der Wächter ist der tragende Teil, nicht die Löschung.** Die Warnung existierte bereits als
+   Gedächtnisnotiz und wurde trotzdem zweimal in fünf Minuten umgangen. Eine Regel, die nur in einer Notiz
+   steht, wird umgangen; eine, die einen Test rot macht, nicht. Ein Wächter, der die Wiederkehr **nicht**
+   fängt, macht Scheibe A wertlos — die Löschung allein ist in einem Commit rückgängig gemacht.
+
+2. **Scanfläche vs. Testcode.** Der Wächter darf Produktivcode treffen, aber nicht die Tests, die
+   `trips/` legitim als Lockvogel anlegen (`test_briefing_route_cutover.py`,
+   `internal/store/store_trip_briefings_test.go:30,98`, `internal/handler/delete_account_test.go:21`).
+   Ein Wächter mit zu weiter Scanfläche wird sofort per Allowlist entschärft und ist dann wirkungslos.
+
+3. **Stilles Grün.** Ein Wächter, der wegen eines Pfad-Tippfehlers null Dateien scannt, ist grün und
+   schützt nichts. Beide Vorbilder lösen das explizit (Mindestdatei-Schwelle bzw. „Region gefunden"-Nachweis)
+   — das ist hier Pflicht, nicht Kür. Ebenso ein synthetischer Wirkungsnachweis: eine Datei, die den
+   verbotenen Pfad bildet, MUSS den Wächter rot machen.
+
+4. **Python-Seite in Scheibe A oder B?** `get_trips_dir()` hat keinen Produktivaufrufer, aber 12
+   Testdateien rufen sie auf. Ein Entfernen in Scheibe A zieht die gesamte Untersuchungsarbeit von
+   Scheibe B mit hinein (LoC-Limit, Risiko). Die etablierte Repo-Bauart erlaubt den sauberen Schnitt:
+   eine einzige dokumentierte Ausnahme im Wächter, gedeckt durch die „Liste darf nur schrumpfen"-Ratsche,
+   die Scheibe B dann zwingend abbaut. → Entscheidung gehört in `/20-analyse`.
+
+5. **`profile_test.go:395` ist ein Bestandszementierer.** Der Test prüft heute genau das, was wir abschaffen.
+   Er muss mit umgestellt werden — und die Umstellung muss so aussehen, dass sie das **neue** Soll prüft
+   (`trips/` entsteht NICHT), nicht bloß die Zeile löschen.
+
+6. **ADR-Konsistenz.** `ADR-0031:16` widerspricht nach der Änderung dem Code. `tests/test_adr_index_drift.py`
+   erzwingt Index↔Datei-Konsistenz, aber nicht Inhalt↔Code — die Korrektur muss bewusst passieren.
+
+## Analysis
+
+### Type
+
+**Bug** (Datenverlust-/Fehlentscheidungs-Risiko). Die Ursache ist bekannt und im Issue belegt;
+die Analyse galt der **Bauart des Wächters**, nicht der Ursachensuche.
+
+### Der entscheidende Messbefund
+
+`internal/store/user.go:84` baut den Pfad **nicht** in einem `filepath.Join`. Das Literal `"trips"`
+steht in einem `[]string{...}`-Slice; der Join passiert eine Zeile später mit der Schleifenvariablen `sub`.
+
+**Jede Erkennungsregel der Form „String-Literal `trips` innerhalb eines `filepath.Join`, das auch `users`
+enthält" übersieht genau die Stelle, die die Falle laufend neu herstellt.** Die Regel muss deshalb am
+reinen Literal binden, nicht am Ausdruckskontext.
+
+Gemessene Verteilung über 292 Produktivdateien (91 Go, 201 Python):
+
+| Ort | Treffer auf das Literal `"trips"` |
+|---|---|
+| Go-Produktivcode (`internal/`, `cmd/`, ohne `_test.go`) | **genau 2** — `internal/store/trip.go:15`, `internal/store/user.go:84` |
+| Python-Produktivcode (`src/`, `api/`) | **genau 1** — `src/app/loader.py:1163` |
+| Go-Testcode | 4 Dateien (alle legitim, s. o.) |
+| `scripts/` | 9 (Migrations-/Backfill-Archäologie, legitim) |
+
+### Affected Files (with changes)
+
+| File | Change Type | Description |
+|---|---|---|
+| `tests/test_trips_path_revival_guard.py` | **CREATE** | Der Wächter. Python-Test, liest **beide** Bäume — Go per Zeilen-/Textparse, Python per AST |
+| `internal/handler/profile_test.go` | MODIFY | `"trips"` aus der Positivschleife `:395`; **neuer** Test `TestRegisterCreatesNoLegacyTripsDir`, der das neue Soll prüft |
+| `internal/store/user.go` | MODIFY | `"trips"` aus der `ProvisionUserDirs`-Liste (Zeile 84) |
+| `internal/store/trip.go` | MODIFY | `TripsDir()` entfernen (Zeilen 14-16, null Aufrufer) |
+| `internal/scheduler/selftest.go` | MODIFY (optional) | lokale Variable `tripsDir` → `briefingsDir` (Zeilen 42,43,48,56) — sie probt längst gegen `briefings/` |
+| `docs/adr/0031-persistenz-dateibasiert-data-users.md` | MODIFY | `trips/` aus der Layout-Aufzählung (`:16`) streichen — zählt nicht auf LoC |
+| `docs/specs/modules/fix_1708_a_trips_pfad_waechter.md` | CREATE | Spec — zählt nicht auf LoC |
+
+### Scope Assessment
+
+- Dateien: 7 (davon 2 CREATE)
+- Geschätzte LoC: **+320 bis +360** zählbar — davon ~90 % Testcode
+- Risk Level: **LOW** für die Produktivänderung (null Aufrufer, ein einziger brechender Test),
+  **MEDIUM** für die Wächter-Wirksamkeit (ein Wächter, der nicht trifft, macht Scheibe A wertlos)
+
+### Technical Approach
+
+**Ein einziger Python-Wächter, der Go mitliest** (`tests/test_trips_path_revival_guard.py`), nicht zwei
+getrennte Wächter. Drei Gründe:
+
+1. **Nur der Python-Job ist ein Auslieferungs-Tor.** `.github/workflows/ci.yml:414` — `deploy: needs: [test, lint]`.
+   Der Job `go-test` (`:65`) steht **nicht** in `needs` (selbst nachgeprüft). Ein rein Go-seitiger Wächter
+   macht den PR rot, blockiert aber den Deploy nicht. Bei einer Regel, die zweimal in fünf Minuten umgangen
+   wurde, ist das ausschlaggebend.
+2. **Ein Go-Wächter sähe nur sein eigenes Paket.** Go-Tests laufen im Paketverzeichnis
+   (`internal/handler/store_scope_guard_test.go:359` liest `os.ReadDir(".")`). Ein Wächter in
+   `internal/store/` sähe `user.go` und `trip.go`, aber **nicht** `internal/handler/`, wo alle vier
+   `ProvisionUserDirs`-Aufrufer liegen und eine Wiederkehr genauso plausibel ist.
+3. **Zwei Wächter = zwei Regeldefinitionen, zwei Ratschen, zwei Stille-Grün-Absicherungen** — doppelte LoC
+   und genau die Driftklasse, gegen die `tests/test_egress_inventory_drift.py` gebaut wurde.
+
+Die Go-Regel braucht **keine** AST-Auflösung: beide Produktivformen sind schlichte String-Literale.
+Zeilenweiser Scan mit Abschnitt am ersten `//` — das Verfahren aus `test_egress_inventory_drift.py:44-61`.
+
+**Erkennungsregel** (Scanfläche per `rglob` berechnet, nie als abgeschriebene Dateiliste):
+
+```
+R1:  L == "trips"
+R2:  re.search(r"(?:^|/|\*/)trips(?:/|$)", L)  UND  ("*" in L oder "users" in L)
+```
+
+Gemessene Wirkung heute: **genau 3 Funde, null Falsch-Positive.** Ausdrücklich nicht getroffen und als
+Negativnachweis zu verankern: die 13 Routen-Strings `"/api/trips/…"` (`internal/router/router.go:141-167`),
+`"corrupt_trips.json"` (`internal/scheduler/briefing_health.go:374` — enthält `users` **und** `*`, aber
+`corrupt_trips` ist kein `trips`-Segment; eine Substring-Regel hätte hier falsch angeschlagen), die
+URL-Strings in `trip_report_scheduler.py:1707` / `trip_command_processor.py:1328`, und
+`internal/scheduler/selftest.go:42` (Variable heißt `tripsDir`, Literal ist `"briefings"` — der Wächter
+bindet an Literale, nicht an Bezeichner).
+
+**Kein Inline-Ausnahmeventil.** `store_scope_guard_test.go:653` erlaubt Stilllegung per Kommentar an der
+Fundzeile — das wird hier bewusst **nicht** übernommen: eine Ausnahme wäre dann in der Täterdatei
+unsichtbar mitzuschmuggeln. Ausnahmen ausschließlich als Restliste **in der Wächterdatei**, damit ein
+Reviewer sie sieht.
+
+**`scripts/` bleibt ausgeschlossen** (per Test festgeschrieben, Vorbild `test_success_status_guard.py:3293`):
+die 9 Treffer dort sind einmalige Migrations-Werkzeuge, deren Aufgabe der Altpfad *ist*. Sie in die
+Restliste zu nehmen hieße 9 Einträge, die nie schrumpfen — die Ratsche würde zur Dauereinrichtung, und
+genau so wird ein Wächter im Feld entschärft.
+
+### Bekannte Grenzen des Wächters (gehören in den Docstring)
+
+Konstante/Variable in ausgeschlossener Datei · Konkatenation (`"tri" + "ps"`) · Verzeichnisname aus
+Config/Env · Go-Rohstrings (Backticks) · Go-Blockkommentare werden nicht abgeschnitten (Falsch-Positiv-
+Richtung, harmlos) · Schema-Umbenennung auf einen anderen Namen · neuer Top-Level-Baum.
+**Keine davon ist versehentlich erreichbar** — alle erfordern bewusste Arbeit. Der reale Rückfall
+(jemand fügt `"trips"` wieder in die `ProvisionUserDirs`-Liste ein) wird getroffen.
+
+### Selbstnachweise gegen stilles Grün (sieben, alle Pflicht)
+
+1. Go-Scanfläche `>= 80` Dateien (heute 91), sonst Abbruch — Vorbild `store_scope_guard_test.go:37,381-384`
+2. Python-Scanfläche `>= 180` (heute 201)
+3. **Trägernachweis:** `internal/store/user.go`, `internal/store/trip.go`, `src/app/loader.py` müssen
+   *namentlich* in der gescannten Menge liegen. Eine reine Zählung fängt keinen Tippfehler, der nur einen
+   Teilbaum verliert — Vorbild `test_output_timezone_guard.py:659`
+4. **Positivnachweis Go** an synthetischen In-Memory-Strings (nie an echten Dateien, sonst meldet der
+   Wächter sich selbst): (a) die `filepath.Join`-Form, (b) **die Slice-Form** — (b) ist die wichtigere,
+   sie ist die Form, die die Falle real neu herstellt
+5. **Positivnachweis Python:** `get_data_dir(uid) / "trips"` und `root.glob("*/trips/*.json")`
+6. **Negativnachweis** an den realen Bestandsformen (Routen, URL, `corrupt_trips.json`, `briefings`) →
+   null Funde; dazu Go-Parserwirkung: Vollkommentarzeile → null Funde, Eintrag mit Inline-Kommentar → ein Fund
+7. **Ratschen-Selbstnachweis:** `test_known_violations_only_shrink` **plus** harte Obergrenze
+   `len(KNOWN_VIOLATIONS) <= 1`
+
+Schlüsselform der Restliste: `pfad::symbol::ordinal` (Hausnorm, `tests/test_guard_findings_survive_line_shifts.py:52`).
+
+### Reihenfolge — zwei echte ROTs
+
+| Schritt | Erwartung |
+|---|---|
+| **A** Wächter zuerst, Restliste = nur der Python-Eintrag | **ROT** — benennt `trip.go:15` und `user.go:84`, **bevor** irgendetwas gelöscht ist |
+| **B** `profile_test.go` umstellen | **ROT** — `trips/` entsteht noch. Zweiter, unabhängiger RED-Beleg |
+| **C** Produktivstellen entfernen | A und B werden grün |
+| **D** ADR-0031 korrigieren, Spec ablegen | zählt nicht auf LoC |
+
+Umgekehrte Reihenfolge (erst löschen) macht den Wächter **grün geboren** — dann ist unbewiesen, dass er
+überhaupt trifft. Genau dieser Wächter darf sich das nicht leisten.
+
+### Dependencies
+
+- Upstream: ADR-0023 (Cutover-Beschluss). Downstream: die vier Registrierungswege.
+- CI: `.github/workflows/ci.yml:414` `deploy: needs: [test, lint]` — der Wächter muss im `test`-Job laufen,
+  damit er ein Auslieferungs-Tor ist.
+
+### Open Questions (PO-Entscheidung)
+
+- [ ] **LoC-Override auf 400.** Geschätzt +320…+360, das 250er-Limit reißt. Bewusst: die sieben
+  Selbstnachweise sind hier nicht Kür, sie sind der Gegenstand. Wer kürzt, kürzt zuerst an den
+  Positiv-/Negativnachweisen — und liefert dann den Wächter aus, dessen Wirkung niemand geprüft hat.
+- [ ] **Eine dokumentierte Ausnahme für `get_trips_dir()`** statt Entfernung in Scheibe A. Neu gefunden:
+  `tests/tdd/test_issue_1133_testdata_cleanup.py:61` nutzt sie als **Sonde für AC-1 von #1133**
+  (Datenwurzel-Isolation) — das ist kein Aufräum-Code, sondern eine lebende Zusicherung, deren Umstellung
+  eine eigene Entscheidung braucht. Abbau erzwungen durch „nur schrumpfen" **plus** Obergrenze 1.
+
+## Abgrenzung: was Scheibe A NICHT umfasst
+
+- Die 12 Testdateien auf `briefings/` umstellen und je Datei belegen, warum sie heute grün ist → **Scheibe B**
+- Die 14 toten Produktivdateien unter `/var/lib/gregor/users/*/trips.TOT-legacy-1250-nicht-lesen`
+  archivieren und löschen → **Scheibe C** (schließt #1708)

--- a/docs/specs/modules/fix_1708_a_trips_pfad_waechter.md
+++ b/docs/specs/modules/fix_1708_a_trips_pfad_waechter.md
@@ -12,7 +12,7 @@ tags: [guard, ratsche, persistenz, issue-1708]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved (PO, 2026-08-16)
 
 ## Purpose
 
@@ -84,8 +84,21 @@ Per `rglob` **berechnet**, nie als abgeschriebene Dateiliste (sonst läuft eine 
 
 ### Gemessene Wirkung auf dem heutigen Bestand
 
-292 Produktivdateien (91 Go, 201 Python) → **genau 3 Funde, null Falsch-Positive**:
-`internal/store/trip.go:15`, `internal/store/user.go:84`, `src/app/loader.py:1163`.
+292 Produktivdateien (91 Go, 201 Python) → **4 Funde, null Falsch-Positive**:
+`internal/store/trip.go:15`, `internal/store/user.go:84`, `src/app/loader.py:1163`
+und `api/routers/preview.py:10`.
+
+**Der vierte Fund wurde erst beim RED-Lauf sichtbar** und ist ein echter Fang, kein Fehlalarm:
+Der Modul-Docstring von `api/routers/preview.py` behauptet in Zeile 10
+„Trip-Owner-Check: Loader-Pfad ist user-scoped (`data/users/<user>/trips/<id>.json`)".
+Das ist **inhaltlich falsch** — der `PreviewService` liest aus `briefings/`
+(`src/services/preview_service.py:18,67`, dessen eigener Docstring `:55-56` es korrekt beschreibt).
+Die Falschaussage steht ausgerechnet an der Stelle, die den Sicherheitsmechanismus für den
+Trip-Owner-Check erklärt — genau die Klasse plausibler, vollständig aussehender Fehlaussage über den
+Ablageort, die #1708 erzeugt hat.
+
+**Konsequenz:** keine zweite Ausnahme, keine Verschärfung von R1/R2. Docstrings vom Scan auszunehmen
+würde künftige Fänge dieser Art blind machen. Der Docstring wird richtiggestellt (AC-13).
 
 Nicht getroffen (alle real im Bestand, als Negativnachweis zu verankern): die 13 Routen-Strings
 `"/api/trips/…"` (`internal/router/router.go:141-167`), `"corrupt_trips.json"`
@@ -201,6 +214,13 @@ Umgekehrte Reihenfolge (erst löschen) macht den Wächter **grün geboren** — 
   Then nennt `docs/adr/0031-persistenz-dateibasiert-data-users.md:16` `trips/` nicht mehr als Bestandteil
   - Test: Sichtprüfung der ADR-Zeile im Review. Ohne diese Korrektur widerspricht das ADR dem Code, und die
     nächste Sitzung liest die alte Aussage als gültig — genau der Mechanismus, der #1708 erzeugt hat.
+
+- **AC-13:** Given der Modul-Docstring von `api/routers/preview.py` beschreibt den Ablageort, aus dem der
+  Trip-Owner-Check liest / When ein Entwickler ihn liest / Then nennt er `briefings/<id>.json` statt des
+  toten `trips/<id>.json`, und der Wächter meldet die Datei nicht mehr
+  - Test: `test_keine_unlisted_trips_pfad_funde` wird für diese Datei grün — der Wächter selbst ist der
+    Nachweis. Die Aussage ist heute falsch (`src/services/preview_service.py:18,67` liest über
+    `get_briefings_dir`), und sie steht an der Stelle, die den Sicherheitsmechanismus erklärt.
 
 ## Known Limitations
 

--- a/docs/specs/modules/fix_1708_a_trips_pfad_waechter.md
+++ b/docs/specs/modules/fix_1708_a_trips_pfad_waechter.md
@@ -1,0 +1,253 @@
+---
+entity_id: fix_1708_a_trips_pfad_waechter
+type: module
+created: 2026-08-16
+updated: 2026-08-16
+status: draft
+version: "1.0"
+tags: [guard, ratsche, persistenz, issue-1708]
+---
+
+# Wächter gegen die Wiederkehr der toten Trip-Ablage (#1708, Scheibe A)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Seit dem Cutover (ADR-0023) leben Trips ausschließlich in `data/users/<uid>/briefings/<id>.json`.
+Der Pfad `data/users/<uid>/trips/<id>.json` ist tot — aber er sieht vollständig und plausibel aus und hat
+nachweislich vier Fehlaussagen und zwei Datenänderungen ins Leere verursacht. Diese Scheibe errichtet den
+Test, der rot wird, sobald Produktivcode den toten Pfad wieder bildet, und entfernt die beiden Go-Stellen,
+die ihn laufend neu herstellen.
+
+**Der Wächter ist der Gegenstand, nicht die Löschung.** Die Warnung existierte bereits als Notiz und wurde
+trotzdem zweimal in fünf Minuten umgangen. Eine Regel, die nur in einer Notiz steht, wird umgangen; eine,
+die einen Test rot macht, nicht.
+
+## Source
+
+- **File:** `tests/test_trips_path_revival_guard.py` (neu)
+- **Identifier:** `test_keine_unlisted_trips_pfad_funde`, `test_known_violations_only_shrink`
+- **Mit geändert (Go-API-Schicht):** `internal/store/user.go`, `internal/store/trip.go`,
+  `internal/handler/profile_test.go`
+- **Ausdrücklich NICHT geändert (Python-Core):** `src/app/loader.py` — `get_trips_dir()` bleibt in dieser
+  Scheibe als einziger Ausnahmeeintrag bestehen (Begründung unter Known Limitations)
+
+## Estimated Scope
+
+- **LoC:** ~+340 bis +380 zählbar (≈ 90 % Testcode); LoC-Limit für diesen Workflow auf 500 angehoben
+- **Files:** 7 (2 CREATE, 4 MODIFY, 1 optional MODIFY)
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| ADR-0023 | Entscheidung | Beschließt `briefings/<id>.json` als einzige Persistenz-Wahrheit |
+| ADR-0031 | Entscheidung | Listet `trips/` bisher fälschlich als Teil des Nutzerverzeichnis-Layouts (`:16`) — wird korrigiert |
+| `tests/test_egress_inventory_drift.py` | Vorbild | Go-Quelltext per Zeilen-/Textparse als Daten lesen (`:44-61`), Parser-Wirkungsnachweis (`:92`) |
+| `tests/test_output_timezone_guard.py` | Vorbild | Restlisten-Schlüsselform, „nur schrumpfen"-Ratsche (`:696`), Scanflächen-Nachweis (`:659`) |
+| `tests/test_success_status_guard.py` | Vorbild | Harte Obergrenze für Ausnahmen (`:3268-3286`), getesteter Scanflächen-Ausschluss (`:3293`) |
+| `internal/store/briefingsDir()` | lebender Pfad | Das Ziel, auf das seit S7a gelesen und geschrieben wird |
+
+## Implementation Details
+
+### Warum die Regel am Literal bindet und nicht am Ausdruckskontext
+
+`internal/store/user.go:84` baut den Pfad **nicht** in einem `filepath.Join`. Das Literal steht in einem
+`[]string{"locations", "trips", "gpx", "weather_snapshots"}`-Slice; der Join passiert eine Zeile später mit
+der Schleifenvariablen `sub`. Eine Regel der Form „Literal `trips` innerhalb eines `filepath.Join`, das auch
+`users` enthält" übersieht **genau die Stelle, die die Falle laufend neu herstellt**.
+
+### Erkennungsregel
+
+Ein String-Literal `L` ist ein Fund, wenn:
+
+```
+R1:  L == "trips"
+R2:  re.search(r"(?:^|/|\*/)trips(?:/|$)", L)  UND  ("*" in L oder "users" in L)
+```
+
+- **Go:** zeilenweise, Zeile am ersten `//` abgeschnitten, dann `"([^"]*)"` extrahieren, R1/R2 anwenden
+- **Python:** `ast.walk` über `ast.Constant`(str) und `ast.JoinedStr`-Teile
+
+### Scanfläche
+
+Per `rglob` **berechnet**, nie als abgeschriebene Dateiliste (sonst läuft eine neue Datei unter
+`internal/` stillschweigend nicht mit):
+
+- Go: alle `*.go` unter `internal/` und `cmd/`, **ohne** `*_test.go`
+- Python: alle `*.py` unter `src/` und `api/`
+- Ausgeschlossen: `tests/`, `scripts/`, `frontend/`, `docs/`
+
+### Gemessene Wirkung auf dem heutigen Bestand
+
+292 Produktivdateien (91 Go, 201 Python) → **genau 3 Funde, null Falsch-Positive**:
+`internal/store/trip.go:15`, `internal/store/user.go:84`, `src/app/loader.py:1163`.
+
+Nicht getroffen (alle real im Bestand, als Negativnachweis zu verankern): die 13 Routen-Strings
+`"/api/trips/…"` (`internal/router/router.go:141-167`), `"corrupt_trips.json"`
+(`internal/scheduler/briefing_health.go:374` — enthält `users` **und** `*`, aber `corrupt_trips` ist kein
+`trips`-Segment; eine Substring-Regel hätte hier falsch angeschlagen), die URL-Strings in
+`trip_report_scheduler.py:1707` und `trip_command_processor.py:1328`, sowie
+`internal/scheduler/selftest.go:42` (Variable heißt `tripsDir`, Literal ist `"briefings"`).
+
+### Restliste
+
+Schlüsselform `pfad::symbol::ordinal` (Hausnorm, `tests/test_guard_findings_survive_line_shifts.py:52`).
+Genau ein Eintrag:
+
+```
+"src/app/loader.py::get_trips_dir::0":
+  "UEBERGANG #1708 Scheibe B — 12 Testdateien rufen sie; entfaellt mit deren
+   Umstellung auf get_briefings_dir(). KEINE Dauerausnahme."
+```
+
+**Kein Inline-Ausnahmeventil.** Anders als `internal/handler/store_scope_guard_test.go:653` erlaubt dieser
+Wächter keine Stilllegung per Kommentar an der Fundzeile — eine Ausnahme wäre sonst in der Täterdatei
+unsichtbar mitzuschmuggeln. Wer eine Ausnahme will, muss die Wächterdatei anfassen, und das sieht ein Reviewer.
+
+### Umsetzungsreihenfolge (zwei echte ROTs)
+
+| Schritt | Erwartung |
+|---|---|
+| A — Wächter zuerst, Restliste = nur der Python-Eintrag | **ROT**: benennt `trip.go:15` und `user.go:84`, bevor irgendetwas gelöscht ist |
+| B — `internal/handler/profile_test.go` umstellen | **ROT**: `trips/` entsteht noch. Zweiter, unabhängiger RED-Beleg |
+| C — `"trips"` aus `user.go:84`, `TripsDir()` aus `trip.go:14-16` | A und B werden grün |
+| D — `docs/adr/0031-…:16` korrigieren | zählt nicht auf LoC |
+
+Umgekehrte Reihenfolge (erst löschen) macht den Wächter **grün geboren** — dann ist unbewiesen, dass er
+überhaupt trifft.
+
+## Expected Behavior
+
+- **Input:** der Quelltextbestand unter `internal/`, `cmd/`, `src/`, `api/`
+- **Output:** Testlauf grün, solange kein Produktivcode den toten Pfad bildet; rot mit Nennung von
+  Datei, Symbol und Fundtext, sobald er es tut
+- **Side effects:** Neu registrierte Nutzer erhalten kein `trips/`-Verzeichnis mehr. Kein Produktivcode
+  liest oder schreibt dort — die Änderung ist für den laufenden Betrieb ohne Wirkung.
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine Go-Quelldatei enthält die Slice-Form `[]string{"locations", "trips", "gpx"}` mit
+  Verzeichnis-Join in einer Folgezeile / When der Wächter über diese Quelle läuft / Then meldet er genau
+  einen Fund mit dem Symbol, in dem das Literal steht
+  - Test: Der Erkenner wird gegen einen synthetischen Quelltext-String im Speicher aufgerufen (nicht gegen
+    eine echte Datei, sonst meldet der Wächter sich selbst) und muss den Fund liefern. Dies ist die Form,
+    die die Falle real neu herstellt — bliebe sie unerkannt, wäre der ganze Wächter wirkungslos.
+
+- **AC-2:** Given eine Go-Quelldatei bildet den Pfad als `filepath.Join(s.DataDir, "users", s.UserID, "trips")`
+  / When der Wächter läuft / Then meldet er genau einen Fund
+  - Test: synthetischer Quelltext-String, Erkenner liefert genau einen Fund.
+
+- **AC-3:** Given eine Python-Quelldatei bildet `get_data_dir(uid) / "trips"` oder
+  `root.glob("*/trips/*.json")` / When der Wächter läuft / Then meldet er je einen Fund
+  - Test: synthetischer Python-Quelltext, per AST gescannt, zwei Fälle je ein Fund.
+
+- **AC-4:** Given der Quelltext enthält die realen Bestandsformen `"/api/trips/{id}"`,
+  `"https://gregor20.henemm.com/trips/"`, `"corrupt_trips.json"` und `"briefings"` / When der Wächter läuft
+  / Then meldet er null Funde
+  - Test: jede der vier Formen einzeln gegen den Erkenner; jede muss null liefern. Verhindert, dass der
+    Wächter beim ersten Falsch-Positiv per Ausnahme entschärft wird.
+
+- **AC-5:** Given eine Go-Zeile besteht vollständig aus dem Kommentar `// filepath.Join(dir, "trips")` /
+  When der Wächter läuft / Then meldet er null Funde; und Given dieselbe Zeile trägt echten Code mit einem
+  Kommentar dahinter / Then meldet er genau einen Fund
+  - Test: beide Zeilenformen gegen den Go-Parser. Belegt, dass der Kommentar-Abschnitt wirkt und nicht
+    versehentlich echten Code verschluckt.
+
+- **AC-6:** Given die Scanfläche wird zur Laufzeit berechnet / When der Wächter startet / Then bricht er mit
+  verständlicher Meldung ab, wenn er weniger als 80 Go- oder weniger als 180 Python-Produktivdateien findet,
+  und ebenso, wenn `internal/store/user.go`, `internal/store/trip.go` oder `src/app/loader.py` nicht
+  namentlich in der gescannten Menge liegen
+  - Test: Untergrenzen und Trägernachweis werden als eigene Testfunktionen geprüft. Eine reine Zählung
+    fängt keinen Pfad-Tippfehler, der nur einen Teilbaum verliert — deshalb beides.
+
+- **AC-7:** Given die Restliste enthält einen Eintrag, dessen Fundstelle im Code nicht mehr existiert /
+  When der Wächter läuft / Then wird er rot; und Given jemand fügt der Restliste einen zweiten Eintrag hinzu
+  / Then wird er ebenfalls rot
+  - Test: „nur schrumpfen"-Ratsche und harte Obergrenze `len(KNOWN_VIOLATIONS) <= 1` als zwei getrennte
+    Tests. Ohne die Obergrenze könnte jeder künftige Fund mit zwei Zeilen stillgelegt werden — der Weg, auf
+    dem Wächter im Feld sterben.
+
+- **AC-8:** Given `tests/` und `scripts/` liegen bewusst außerhalb der Scanfläche / When der Wächter läuft /
+  Then werden die dortigen legitimen `trips`-Vorkommen nicht gemeldet, und dieser Ausschluss ist als eigener
+  Test festgeschrieben
+  - Test: eigener Test prüft, dass die Scanflächen-Berechnung keine Datei unter `tests/` oder `scripts/`
+    zurückgibt. Schützt `tests/test_briefing_route_cutover.py`, das den Cutover per Lockvogel-Datei beweist,
+    und die 9 Migrations-Skripte, deren Aufgabe der Altpfad ist.
+
+- **AC-9:** Given ein Nutzer registriert sich neu / When die Registrierung erfolgreich abschließt / Then
+  existiert unter seinem Nutzerverzeichnis **kein** `trips/`-Verzeichnis, während `locations/`, `gpx/` und
+  `weather_snapshots/` weiter angelegt werden
+  - Test: Go-Test `TestRegisterCreatesNoLegacyTripsDir` in `internal/handler/profile_test.go` — eigener,
+    benannter Test statt nur einer gelöschten Zeile, damit der Schutz im Lauf-Protokoll sichtbar bleibt.
+    Der Bestandstest `TestRegisterCreatesUserDirs` behält die drei übrigen Verzeichnisse als echte Zusicherung.
+
+- **AC-10:** Given ein Entwickler sucht die Methode `Store.TripsDir()` / When er den Go-Code durchsucht /
+  Then existiert sie nicht mehr, und der Go-Testlauf bleibt vollständig grün
+  - Test: `go build ./...` und `go test ./internal/...` laufen grün. Die Methode hat null Aufrufer im
+    gesamten Repo (nachgemessen), die Löschung kann nichts brechen.
+
+- **AC-11:** Given der Wächter soll ein Auslieferungs-Tor sein / When die CI läuft / Then wird er im Job
+  `test` gesammelt und ausgeführt
+  - Test: `uv run pytest tests/test_trips_path_revival_guard.py --collect-only` zeigt die Testfunktionen.
+    Begründung: `.github/workflows/ci.yml:414` — `deploy: needs: [test, lint]`; der Job `go-test` steht
+    **nicht** in `needs`. Ein rein Go-seitiger Wächter hätte den PR rot gemacht, aber den Deploy nicht blockiert.
+
+- **AC-12:** Given ADR-0031 beschreibt das Nutzerverzeichnis-Layout / When die Änderung ausgeliefert ist /
+  Then nennt `docs/adr/0031-persistenz-dateibasiert-data-users.md:16` `trips/` nicht mehr als Bestandteil
+  - Test: Sichtprüfung der ADR-Zeile im Review. Ohne diese Korrektur widerspricht das ADR dem Code, und die
+    nächste Sitzung liest die alte Aussage als gültig — genau der Mechanismus, der #1708 erzeugt hat.
+
+## Known Limitations
+
+### Bekannte Umgehungen des Wächters (gehören wörtlich in den Docstring)
+
+1. **Konstante/Variable** in einer ausgeschlossenen Datei, importiert in Produktivcode
+2. **Konkatenation/Formatierung:** `"tri" + "ps"`, `fmt.Sprintf("tri%s", "ps")`
+3. **Konfiguration/Umgebung:** Verzeichnisname aus `config.ini` oder Env
+4. **Go-Rohstrings** (Backticks) werden vom `"…"`-Regex nicht erfasst
+5. **Go-Blockkommentare** `/* … */` werden nicht abgeschnitten — Falsch-Positiv-Richtung, harmlos
+6. **Schema-Umbenennung:** ein wiederbelebter Altpfad namens `trip_files/` fällt per Bauart durch
+7. **Neuer Top-Level-Baum** außerhalb `internal/`, `cmd/`, `src/`, `api/`
+
+Keine davon ist versehentlich erreichbar — alle erfordern bewusste Arbeit. Der reale Rückfall (jemand fügt
+`"trips"` wieder in die `ProvisionUserDirs`-Liste ein) wird getroffen.
+
+### Weitere Grenzen
+
+- Der Python-Prozess bemerkt **nicht**, wenn eine Go-Datei syntaktisch kaputt ist — er sieht nur Text.
+  Abgefangen wird das durch die Scanflächen-Untergrenze und den Trägernachweis (AC-6), nicht durch einen Parser.
+- `src/app/loader.py:get_trips_dir()` bleibt in dieser Scheibe bestehen. Grund: 12 Testdateien rufen sie,
+  darunter zwei, die **kein** toter Aufräum-Code sind — `tests/tdd/test_issue_1133_testdata_cleanup.py:61`
+  nutzt sie als Sonde für die Datenwurzel-Isolation (#1133 AC-1), und
+  `tests/tdd/test_issue_346_fixture_provider.py:29` steuert über die Existenz im toten Pfad die
+  Fixture-Auswahl. Deren Umstellung ist Untersuchungsarbeit mit offenem Ausgang und gehört in Scheibe B.
+  Der Abbau ist durch AC-7 erzwungen: sobald `get_trips_dir` verschwindet, wird der Eintrag stale und der
+  Test rot; die Obergrenze von 1 verhindert, dass die Ausnahme sich vermehrt.
+
+### Nicht Teil dieser Scheibe
+
+- Die 12 Testdateien auf `briefings/` umstellen und je Datei belegen, warum sie heute grün ist → **Scheibe B**
+- Die 14 toten Produktivdateien unter `/var/lib/gregor/users/*/trips.TOT-legacy-1250-nicht-lesen`
+  archivieren und löschen → **Scheibe C** (schließt #1708)
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue; setzt ADR-0023 durch und korrigiert ADR-0031
+- **Rationale:** Die Entscheidung „`briefings/` ist die einzige Persistenz-Wahrheit" ist mit ADR-0023 bereits
+  getroffen. Diese Scheibe fügt keine neue Entscheidungsfläche hinzu, sondern macht die bestehende
+  durchsetzbar. ADR-0031 wird korrigiert, weil es dem Beschluss inhaltlich widerspricht.
+
+## Regel-Budget
+
+Neue Pflicht-Ratsche → Prüfdatum **2026-11-14** (+90 Tage). Am Prüfdatum gilt: kein nachweisbarer Fang und
+Restliste leer → Rückbau erwägen. Ersetzt keine bestehende Regel; die bisherige „Regel" war eine
+Gedächtnisnotiz ohne Durchsetzung — und wurde nachweislich zweimal in fünf Minuten umgangen.
+
+## Changelog
+
+- 2026-08-16: Initial spec created (#1708 Scheibe A)

--- a/docs/specs/modules/fix_1708_a_trips_pfad_waechter.md
+++ b/docs/specs/modules/fix_1708_a_trips_pfad_waechter.md
@@ -182,8 +182,14 @@ Umgekehrte Reihenfolge (erst löschen) macht den Wächter **grün geboren** — 
   When der Wächter läuft / Then wird er rot; und Given jemand fügt der Restliste einen zweiten Eintrag hinzu
   / Then wird er ebenfalls rot
   - Test: „nur schrumpfen"-Ratsche und harte Obergrenze `len(KNOWN_VIOLATIONS) <= 1` als zwei getrennte
-    Tests. Ohne die Obergrenze könnte jeder künftige Fund mit zwei Zeilen stillgelegt werden — der Weg, auf
-    dem Wächter im Feld sterben.
+    Tests. **Reichweite, präzise:** Die Obergrenze fängt *akzidentelles* Wachstum — jemand trägt einen
+    Fund ein und zieht die Zahl nicht mit. Gegen eine *koordinierte* Manipulation in einem Commit
+    (Wiederbelebung + passender Restlisten-Eintrag + angehobene Obergrenze) schützt sie **nicht**, weil
+    Liste und Schranke in derselben, editierbaren Datei liegen. Dagegen wirken zwei andere Dinge: der
+    unabhängige Go-Verhaltenstest `TestRegisterCreatesNoLegacyTripsDir`, der am Wirkort misst statt am
+    Quelltext (nachgewiesen: er fängt diesen Fall), und die Review-Pflicht — wer eine Ausnahme will, muss
+    die Wächterdatei anfassen, und das sieht ein Reviewer. Nachgewiesen durch Adversary-Mutation M7b
+    (#1708 A, 2026-08-16).
 
 - **AC-8:** Given `tests/` und `scripts/` liegen bewusst außerhalb der Scanfläche / When der Wächter läuft /
   Then werden die dortigen legitimen `trips`-Vorkommen nicht gemeldet, und dieser Ausschluss ist als eigener

--- a/internal/handler/profile_test.go
+++ b/internal/handler/profile_test.go
@@ -392,7 +392,7 @@ func TestRegisterCreatesUserDirs(t *testing.T) {
 
 	// THEN: User directories are created
 	base := filepath.Join(s.DataDir, "users", "newuser")
-	for _, sub := range []string{"locations", "trips", "gpx", "weather_snapshots"} {
+	for _, sub := range []string{"locations", "gpx", "weather_snapshots"} {
 		path := filepath.Join(base, sub)
 		info, err := os.Stat(path)
 		if err != nil {

--- a/internal/handler/profile_trips_guard_test.go
+++ b/internal/handler/profile_trips_guard_test.go
@@ -1,0 +1,42 @@
+package handler
+
+import (
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/henemm/gregor-api/internal/config"
+)
+
+// TDD (#1708 Scheibe A, ADR-0023): Seit dem Cutover leben Trips
+// ausschliesslich in data/users/<uid>/briefings/<id>.json. Ein frisch
+// registrierter Nutzer darf deshalb KEIN trips/-Verzeichnis mehr bekommen --
+// dessen Anlage widerspricht ADR-0023 und stellt die tote Ablage aus #1708
+// bei jeder Registrierung laufend neu her. Der Bestandstest
+// TestRegisterCreatesUserDirs behaelt die drei uebrigen Verzeichnisse
+// (locations/, gpx/, weather_snapshots/) als echte Zusicherung.
+func TestRegisterCreatesNoLegacyTripsDir(t *testing.T) {
+	s := newTestStore(t)
+	// Leere Config → dispatchVerificationMail bricht mangels SMTPHost sofort ab
+	// (kein Netz-Zugriff); dieser Test prüft nur die Verzeichnis-Anlage.
+	h := RegisterHandler(s, bcrypt.MinCost, config.Config{})
+
+	body := `{"username":"newuser2","password":"geheim123","email":"newuser2@beispiel.de"}`
+	req := httptest.NewRequest("POST", "/api/auth/register", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != 201 {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	base := filepath.Join(s.DataDir, "users", "newuser2")
+	tripsPath := filepath.Join(base, "trips")
+	if _, err := os.Stat(tripsPath); !os.IsNotExist(err) {
+		t.Errorf("#1708/ADR-0023: erwartet KEIN Legacy-Verzeichnis %s nach Registrierung, existiert aber (Stat-Fehler=%v)", tripsPath, err)
+	}
+}

--- a/internal/store/trip.go
+++ b/internal/store/trip.go
@@ -11,10 +11,6 @@ import (
 	"github.com/henemm/gregor-api/internal/model"
 )
 
-func (s *Store) TripsDir() string {
-	return filepath.Join(s.DataDir, "users", s.UserID, "trips")
-}
-
 // normalizeTrip coerces nil slice fields (Corridors, Stages, per-stage
 // Waypoints, AlertRules) to empty slices in place. Single source of truth
 // for both the read path (LoadTrip/LoadTrips) and the write path (SaveTrip).

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -81,7 +81,7 @@ func (s *Store) SaveUser(user model.User) error {
 // ProvisionUserDirs creates the standard subdirectories for a new user.
 func (s *Store) ProvisionUserDirs(id string) error {
 	base := s.UserDir(id)
-	for _, sub := range []string{"locations", "trips", "gpx", "weather_snapshots"} {
+	for _, sub := range []string{"locations", "gpx", "weather_snapshots"} {
 		if err := os.MkdirAll(filepath.Join(base, sub), 0755); err != nil {
 			return err
 		}

--- a/tests/test_trips_path_revival_guard.py
+++ b/tests/test_trips_path_revival_guard.py
@@ -1,0 +1,471 @@
+# doc-compliance-test
+"""Waechter gegen die Wiederkehr der toten Trip-Ablage (#1708, Scheibe A).
+
+Werkzeug-Klasse (CLAUDE.md-Ausnahme ``# doc-compliance-test``): dieser
+Laeufer liest Go- und Python-Produktivquellen als DATEN (String-Literale),
+nicht als Verhaltensnachweis auf Code-Strings im herkoemmlichen Sinn.
+
+Spec: ``docs/specs/modules/fix_1708_a_trips_pfad_waechter.md``.
+
+Seit dem Cutover (ADR-0023) leben Trips ausschliesslich in
+``data/users/<uid>/briefings/<id>.json``. Der Pfad
+``data/users/<uid>/trips/<id>.json`` ist tot -- aber er sieht vollstaendig
+und plausibel aus und hat nachweislich vier Fehlaussagen und zwei
+Datenaenderungen ins Leere verursacht (siehe Spec "Purpose"). Dieser
+Waechter wird rot, sobald Produktivcode den toten Pfad wieder bildet.
+
+## Erkennungsregel
+
+Ein String-Literal ``L`` ist ein Fund, wenn:
+
+    R1:  L == "trips"
+    R2:  re.search(r"(?:^|/|\\*/)trips(?:/|$)", L)  UND  ("*" in L oder "users" in L)
+
+Bewusst am LITERAL gebunden, nicht am Ausdruckskontext:
+``internal/store/user.go:84`` baut den Pfad NICHT in einem
+``filepath.Join`` -- das Literal steht in einem
+``[]string{"locations", "trips", "gpx", "weather_snapshots"}``-Slice, der
+Join passiert eine Zeile spaeter mit der Schleifenvariablen ``sub``. Eine
+Regel "Literal in einem Join, der auch 'users' enthaelt" uebersaehe genau
+diese Stelle -- deshalb feuert R1 auf das exakte Literal ``"trips"`` immer,
+unabhaengig vom umgebenden Ausdruck.
+
+## Bekannte Umgehungen des Waechters (gehoeren woertlich hierher)
+
+1. **Konstante/Variable** in einer ausgeschlossenen Datei, importiert in
+   Produktivcode.
+2. **Konkatenation/Formatierung:** ``"tri" + "ps"``,
+   ``fmt.Sprintf("tri%s", "ps")``.
+3. **Konfiguration/Umgebung:** Verzeichnisname aus ``config.ini`` oder Env.
+4. **Go-Rohstrings** (Backticks) werden vom ``"..."``-Regex nicht erfasst.
+5. **Go-Blockkommentare** ``/* ... */`` werden nicht abgeschnitten --
+   Falsch-Positiv-Richtung, harmlos.
+6. **Schema-Umbenennung:** ein wiederbelebter Altpfad namens ``trip_files/``
+   faellt per Bauart durch.
+7. **Neuer Top-Level-Baum** ausserhalb ``internal/``, ``cmd/``, ``src/``,
+   ``api/``.
+
+Keine davon ist versehentlich erreichbar -- alle erfordern bewusste Arbeit.
+Der reale Rueckfall (jemand fuegt ``"trips"`` wieder in die
+``ProvisionUserDirs``-Liste ein) wird getroffen.
+
+## Weitere Grenzen
+
+Der Python-Prozess bemerkt NICHT, wenn eine Go-Datei syntaktisch kaputt
+ist -- er sieht nur Text. Abgefangen wird das durch die
+Scanflaechen-Untergrenze und den Traegernachweis (AC-6), nicht durch einen
+Parser.
+
+Test-Politik: Kernschicht, keine Mocks. Pfadregel #1409: Pruefling relativ
+zu DIESER Testdatei aufgeloest, nie ueber einen festen Hauptrepo-Pfad --
+sonst misst der Test aus einem Worktree den falschen Baum.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+# Pfadregel #1409: Repo-Wurzel relativ zu DIESER Testdatei, nie fest verdrahtet.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+GO_ROOTS = ["internal", "cmd"]
+PY_ROOTS = ["src", "api"]
+
+MIN_GO_FILES = 80
+MIN_PY_FILES = 180
+
+CARRIER_FILES = {
+    "internal/store/user.go",
+    "internal/store/trip.go",
+    "src/app/loader.py",
+}
+
+# Restliste, Schluesselform "pfad::symbol::ordinal" (Hausnorm,
+# tests/test_guard_findings_survive_line_shifts.py:52). Genau EIN Eintrag --
+# kein Inline-Ausnahmeventil, jede Ausnahme muss hier stehen, sonst waere sie
+# in der Taeterdatei fuer einen Reviewer unsichtbar mitzuschmuggeln.
+KNOWN_VIOLATIONS: dict[str, str] = {
+    "src/app/loader.py::get_trips_dir::0": (
+        "UEBERGANG #1708 Scheibe B -- 12 Testdateien rufen sie; entfaellt mit "
+        "deren Umstellung auf get_briefings_dir(). KEINE Dauerausnahme."
+    ),
+}
+
+_TRIPS_SEGMENT_RE = re.compile(r"(?:^|/|\*/)trips(?:/|$)")
+_GO_STRING_LITERAL_RE = re.compile(r'"([^"]*)"')
+_GO_FUNC_DECL_RE = re.compile(r"^func\s+(?:\([^)]*\)\s+)?(\w+)\s*\(")
+
+
+def _is_finding(literal: str) -> bool:
+    """R1/R2 aus der Spec. Bindet am Literal, nicht am Ausdruckskontext."""
+    if literal == "trips":
+        return True
+    if _TRIPS_SEGMENT_RE.search(literal) and ("*" in literal or "users" in literal):
+        return True
+    return False
+
+
+def _scan_go_text(text: str) -> list[tuple[str, str, int]]:
+    """Liest Go-Quelltext zeilenweise. Gibt (symbol, literal, zeile) je Fund.
+
+    Zeile wird am ERSTEN ``//`` abgeschnitten (Vorbild:
+    tests/test_egress_inventory_drift.py:_parse_go_inventory) -- eine voll
+    auskommentierte Zeile zaehlt damit nicht, ein Inline-Kommentar hinter
+    echtem Code schon (AC-5).
+    """
+    results: list[tuple[str, str, int]] = []
+    current_symbol = "<module>"
+    for line_no, raw_line in enumerate(text.splitlines(), start=1):
+        code = raw_line.split("//", 1)[0]
+        m = _GO_FUNC_DECL_RE.match(code.strip())
+        if m:
+            current_symbol = m.group(1)
+        for literal in _GO_STRING_LITERAL_RE.findall(code):
+            if _is_finding(literal):
+                results.append((current_symbol, literal, line_no))
+    return results
+
+
+class _PySymbolScanner(ast.NodeVisitor):
+    """Traegt den umschliessenden Funktions-/Methodennamen waehrend des
+    Walks mit -- ``ast.walk`` allein kennt keine Elternbeziehung."""
+
+    def __init__(self) -> None:
+        self.stack: list[str] = ["<module>"]
+        self.results: list[tuple[str, str, int]] = []
+
+    def _visit_scope(self, node: ast.AST, name: str) -> None:
+        self.stack.append(name)
+        self.generic_visit(node)
+        self.stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_scope(node, node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_scope(node, node.name)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._visit_scope(node, node.name)
+
+    def _check(self, literal: str, lineno: int) -> None:
+        if _is_finding(literal):
+            self.results.append((self.stack[-1], literal, lineno))
+
+    def visit_Constant(self, node: ast.Constant) -> None:
+        if isinstance(node.value, str):
+            self._check(node.value, node.lineno)
+        self.generic_visit(node)
+
+    def visit_JoinedStr(self, node: ast.JoinedStr) -> None:
+        for part in node.values:
+            if isinstance(part, ast.Constant) and isinstance(part.value, str):
+                self._check(part.value, node.lineno)
+        self.generic_visit(node)
+
+
+def _scan_python_text(text: str) -> list[tuple[str, str, int]]:
+    tree = ast.parse(text)
+    scanner = _PySymbolScanner()
+    scanner.visit(tree)
+    return scanner.results
+
+
+def _go_scan_files() -> list[Path]:
+    """Scanflaeche PER RGLOB BERECHNET, nie als abgeschriebene Dateiliste."""
+    files: list[Path] = []
+    for root_name in GO_ROOTS:
+        root = REPO_ROOT / root_name
+        if not root.exists():
+            continue
+        for p in root.rglob("*.go"):
+            if p.name.endswith("_test.go"):
+                continue
+            files.append(p)
+    return sorted(files)
+
+
+def _py_scan_files() -> list[Path]:
+    files: list[Path] = []
+    for root_name in PY_ROOTS:
+        root = REPO_ROOT / root_name
+        if not root.exists():
+            continue
+        files.extend(sorted(root.rglob("*.py")))
+    return sorted(files)
+
+
+def _numbered_findings(
+    raw: list[tuple[str, str, int]], rel_path: str
+) -> dict[str, tuple[str, int]]:
+    """Gruppiert nach Symbol, ordnet nach Zeile, vergibt Ordinal 0..n-1
+    (Hausnorm: tests/test_output_timezone_guard.py Muster
+    ``for ordinal, lineno in enumerate(sorted(by_line))``)."""
+    by_symbol: dict[str, list[tuple[int, str]]] = {}
+    for symbol, literal, line in raw:
+        by_symbol.setdefault(symbol, []).append((line, literal))
+    numbered: dict[str, tuple[str, int]] = {}
+    for symbol, entries in by_symbol.items():
+        for ordinal, (line, literal) in enumerate(sorted(entries, key=lambda e: e[0])):
+            key = f"{rel_path}::{symbol}::{ordinal}"
+            numbered[key] = (literal, line)
+    return numbered
+
+
+def _all_go_findings() -> dict[str, tuple[str, int]]:
+    findings: dict[str, tuple[str, int]] = {}
+    for path in _go_scan_files():
+        rel = str(path.relative_to(REPO_ROOT))
+        raw = _scan_go_text(path.read_text(encoding="utf-8"))
+        findings.update(_numbered_findings(raw, rel))
+    return findings
+
+
+def _all_python_findings() -> dict[str, tuple[str, int]]:
+    findings: dict[str, tuple[str, int]] = {}
+    for path in _py_scan_files():
+        rel = str(path.relative_to(REPO_ROOT))
+        raw = _scan_python_text(path.read_text(encoding="utf-8"))
+        findings.update(_numbered_findings(raw, rel))
+    return findings
+
+
+def _all_violations() -> dict[str, tuple[str, int]]:
+    findings = _all_go_findings()
+    findings.update(_all_python_findings())
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# AC-1/AC-2: Go-Erkenner gegen synthetische Quellen (nicht gegen echte
+# Dateien -- sonst meldet der Waechter sich selbst).
+# ---------------------------------------------------------------------------
+
+
+def test_ac1_slice_literal_form_detected():
+    """AC-1: Slice-Form ``[]string{"locations", "trips", "gpx"}`` -> genau
+    ein Fund mit dem umschliessenden Symbol. Dies ist die Form, die die
+    Falle real neu herstellt (internal/store/user.go:84) -- bliebe sie
+    unerkannt, waere der ganze Waechter wirkungslos."""
+    src = (
+        "package store\n\n"
+        'func (s *Store) ProvisionUserDirs(id string) error {\n'
+        "\tbase := s.UserDir(id)\n"
+        '\tfor _, sub := range []string{"locations", "trips", "gpx", "weather_snapshots"} {\n'
+        "\t\tif err := os.MkdirAll(filepath.Join(base, sub), 0755); err != nil {\n"
+        "\t\t\treturn err\n"
+        "\t\t}\n"
+        "\t}\n"
+        "\treturn nil\n"
+        "}\n"
+    )
+    raw = _scan_go_text(src)
+    assert len(raw) == 1, f"Erwartet genau 1 Fund, bekommen: {raw}"
+    symbol, literal, _line = raw[0]
+    assert symbol == "ProvisionUserDirs"
+    assert literal == "trips"
+
+
+def test_ac2_filepath_join_form_detected():
+    """AC-2: ``filepath.Join(s.DataDir, "users", s.UserID, "trips")`` ->
+    genau ein Fund (das Literal "users" allein loest R2 NICHT aus)."""
+    src = (
+        "package store\n\n"
+        "func (s *Store) TripsDir() string {\n"
+        '\treturn filepath.Join(s.DataDir, "users", s.UserID, "trips")\n'
+        "}\n"
+    )
+    raw = _scan_go_text(src)
+    assert len(raw) == 1, f"Erwartet genau 1 Fund, bekommen: {raw}"
+    symbol, literal, _line = raw[0]
+    assert symbol == "TripsDir"
+    assert literal == "trips"
+
+
+# ---------------------------------------------------------------------------
+# AC-3: Python-Erkenner per AST gegen synthetische Quellen.
+# ---------------------------------------------------------------------------
+
+
+def test_ac3_python_division_form_detected():
+    """AC-3a: ``get_data_dir(uid) / "trips"`` -> genau ein Fund."""
+    src = (
+        "def get_trips_dir(user_id='default'):\n"
+        '    return get_data_dir(user_id) / "trips"\n'
+    )
+    raw = _scan_python_text(src)
+    assert len(raw) == 1, f"Erwartet genau 1 Fund, bekommen: {raw}"
+    symbol, literal, _line = raw[0]
+    assert symbol == "get_trips_dir"
+    assert literal == "trips"
+
+
+def test_ac3_python_glob_form_detected():
+    """AC-3b: ``root.glob("*/trips/*.json")`` -> genau ein Fund (das
+    Literal traegt kein exaktes "trips", sondern greift ueber R2 + "*")."""
+    src = (
+        "def cleanup(root):\n"
+        '    for f in root.glob("*/trips/*.json"):\n'
+        "        pass\n"
+    )
+    raw = _scan_python_text(src)
+    assert len(raw) == 1, f"Erwartet genau 1 Fund, bekommen: {raw}"
+    symbol, literal, _line = raw[0]
+    assert symbol == "cleanup"
+    assert literal == "*/trips/*.json"
+
+
+# ---------------------------------------------------------------------------
+# AC-4: reale Bestandsformen duerfen NICHT als Fund erkannt werden.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "literal",
+    [
+        "/api/trips/{id}",
+        "https://gregor20.henemm.com/trips/",
+        "corrupt_trips.json",
+        "briefings",
+    ],
+)
+def test_ac4_real_bestand_forms_are_not_findings(literal):
+    """AC-4: reale Bestandsformen (Routen-String, absolute URL,
+    ``corrupt_trips.json``, ``briefings``) -> null Funde je Form. Verhindert,
+    dass der Waechter beim ersten Falsch-Positiv per Ausnahme entschaerft
+    wird."""
+    assert not _is_finding(literal), (
+        f"{literal!r} wurde faelschlich als Fund erkannt -- Erkenner zu weit gefasst."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5: Kommentar-Abschnitt wirkt, ohne echten Code zu verschlucken.
+# ---------------------------------------------------------------------------
+
+
+def test_ac5_full_comment_line_is_not_a_finding():
+    """AC-5a: eine Zeile, die vollstaendig aus dem Kommentar
+    ``// filepath.Join(dir, "trips")`` besteht -> null Funde."""
+    src = '\t// filepath.Join(dir, "trips")\n'
+    raw = _scan_go_text(src)
+    assert raw == [], f"Auskommentierte Zeile faelschlich als Fund gemeldet: {raw}"
+
+
+def test_ac5_code_with_trailing_comment_is_a_finding():
+    """AC-5b: dieselbe Zeilenform, aber mit echtem Code VOR dem Kommentar
+    -> genau ein Fund. Belegt, dass der Kommentar-Abschnitt nur den
+    Kommentaranteil abschneidet, nicht die ganze Zeile verschluckt."""
+    src = 'x := filepath.Join(dir, "trips") // legacy path, siehe #1708\n'
+    raw = _scan_go_text(src)
+    assert len(raw) == 1, f"Erwartet 1 Fund trotz Trailing-Kommentar, bekommen: {raw}"
+
+
+# ---------------------------------------------------------------------------
+# AC-6: Scanflaechen-Untergrenzen und Traegernachweis.
+# ---------------------------------------------------------------------------
+
+
+def test_ac6_go_scan_area_minimum_file_count():
+    files = _go_scan_files()
+    assert len(files) >= MIN_GO_FILES, (
+        f"Nur {len(files)} Go-Produktivdateien unter {GO_ROOTS} gefunden "
+        f"(< {MIN_GO_FILES}) -- die Scanflaeche ist vermutlich falsch "
+        "berechnet (z.B. falscher Wurzelpfad)."
+    )
+
+
+def test_ac6_python_scan_area_minimum_file_count():
+    files = _py_scan_files()
+    assert len(files) >= MIN_PY_FILES, (
+        f"Nur {len(files)} Python-Produktivdateien unter {PY_ROOTS} gefunden "
+        f"(< {MIN_PY_FILES}) -- die Scanflaeche ist vermutlich falsch "
+        "berechnet (z.B. falscher Wurzelpfad)."
+    )
+
+
+def test_ac6_carrier_files_are_within_scan_area():
+    """Eine reine Zaehlung faengt keinen Pfad-Tippfehler, der nur einen
+    Teilbaum verliert -- deshalb zusaetzlich der namentliche Traegernachweis."""
+    scanned = {str(p.relative_to(REPO_ROOT)) for p in _go_scan_files()} | {
+        str(p.relative_to(REPO_ROOT)) for p in _py_scan_files()
+    }
+    missing = sorted(c for c in CARRIER_FILES if c not in scanned)
+    assert not missing, (
+        f"Traeger-Dateien fehlen in der berechneten Scanflaeche: {missing} "
+        "-- ein Pfad-Tippfehler haette diese Dateien lautlos aus dem Scan "
+        "genommen."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-7: Restliste darf nur schrumpfen, harte Obergrenze verhindert Wachstum.
+# ---------------------------------------------------------------------------
+
+
+def test_ac7_known_violations_only_shrink():
+    """Ein Eintrag, dessen Fundstelle der Scanner nicht mehr findet
+    (behoben oder verschoben), muss aus KNOWN_VIOLATIONS entfernt werden --
+    sonst bliebe die Liste eine Dauereinrichtung statt Fortschrittsnachweis."""
+    found = _all_violations()
+    stale = sorted(k for k in KNOWN_VIOLATIONS if k not in found)
+    assert not stale, (
+        "Diese Ausnahmen sind veraltet (der Scanner meldet die Stelle nicht "
+        f"mehr): {stale} -- aus KNOWN_VIOLATIONS entfernen (die Liste darf "
+        "nur schrumpfen)."
+    )
+
+
+def test_ac7_known_violations_hard_upper_bound():
+    """Ohne diese Obergrenze koennte jeder kuenftige Fund mit zwei Zeilen
+    stillgelegt werden -- der Weg, auf dem Waechter im Feld sterben."""
+    assert len(KNOWN_VIOLATIONS) <= 1, (
+        f"KNOWN_VIOLATIONS hat {len(KNOWN_VIOLATIONS)} Eintraege (> 1) -- "
+        "eine wachsende Ausnahmeliste ist die Hintertuer des Waechters."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-8: tests/ und scripts/ liegen ausserhalb der Scanflaeche.
+# ---------------------------------------------------------------------------
+
+
+def test_ac8_scan_area_excludes_tests_and_scripts():
+    """Schuetzt tests/test_briefing_route_cutover.py (Lockvogel-Datei fuer
+    den Cutover-Beweis) und die Migrations-Skripte, deren Aufgabe der
+    Altpfad ist -- deren legitime 'trips'-Vorkommen duerfen nicht gemeldet
+    werden."""
+    all_files = _go_scan_files() + _py_scan_files()
+    offenders = [p for p in all_files if "tests" in p.parts or "scripts" in p.parts]
+    assert not offenders, (
+        f"Scanflaeche enthaelt ausgeschlossene Verzeichnisse: {offenders}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Der Hauptwaechter.
+# ---------------------------------------------------------------------------
+
+
+def test_keine_unlisted_trips_pfad_funde():
+    """GIVEN der Quelltextbestand unter internal/, cmd/, src/, api/
+    WHEN ein String-Literal-Fund NICHT in KNOWN_VIOLATIONS steht
+    THEN ist das ein neuer/bestehender toter 'trips'-Pfad in Produktivcode
+    (#1708) -- der Test benennt Datei, Symbol und Fundtext.
+
+    Erwartung in der TDD-RED-Phase: ROT, benennt
+    internal/store/trip.go:15 (TripsDir) und internal/store/user.go:84
+    (ProvisionUserDirs). src/app/loader.py:1163 (get_trips_dir) ist ueber
+    KNOWN_VIOLATIONS gedeckt und erscheint NICHT in der Fehlermeldung.
+    """
+    found = _all_violations()
+    unlisted = {k: v for k, v in found.items() if k not in KNOWN_VIOLATIONS}
+    assert not unlisted, (
+        "Toter 'trips'-Pfad in Produktivcode gefunden (#1708) -- ADR-0023 "
+        "legt briefings/<id>.json als einzige Persistenz-Wahrheit fest. "
+        "Fundstellen (pfad::symbol::ordinal -> (literal, zeile)): "
+        f"{sorted(unlisted.items())}"
+    )


### PR DESCRIPTION
## Worum es geht — #1708 Scheibe A

Seit dem Cutover (ADR-0023) leben Trips ausschließlich in `data/users/<uid>/briefings/<id>.json`.
Der Pfad `data/users/<uid>/trips/<id>.json` ist toter Bestand — **er sieht aber aus wie die Wahrheit**
und hat nachweislich vier Fehlaussagen und zwei Datenänderungen ins Leere verursacht. Zwei Sitzungen
haben unabhängig voneinander dieselbe tote Datei gelesen, denselben Fehler gemacht und daraufhin
dasselbe Issue geschrieben.

Diese Scheibe errichtet den Wächter, der die Falle nicht neu entstehen lässt, und entfernt die
Stellen, die sie laufend neu herstellten. **#1708 bleibt offen** — Scheibe B (12 Testdateien) und
Scheibe C (Löschung der 14 toten Dateien) folgen.

## Der Befund, der die Bauart entschied

`internal/store/user.go:84` baut den Pfad **nicht** in einem `filepath.Join`. Das Literal steht in
einem `[]string{...}`-Slice, der Join passiert eine Zeile später mit der Schleifenvariablen.

Eine naheliegende Wächter-Regel — „Literal `trips` in einem Join, der auch `users` enthält" — hätte
**genau die Stelle übersehen, die die Falle laufend neu herstellte**. Die Regel bindet deshalb am
reinen String-Literal, nicht am Ausdruckskontext. Gemessen über 292 Produktivdateien: 4 Treffer,
null Falsch-Positive.

## Was der Wächter beim ersten Lauf fand

Einen vierten Fund, der nicht bestellt war: `api/routers/preview.py:10` behauptete, der
Trip-Owner-Check lese aus `data/users/<user>/trips/<id>.json`. Der `PreviewService` liest aus
`briefings/` (`src/services/preview_service.py:67`) — der Docstring der aufgerufenen Funktion sagt
es sogar korrekt, nur der Router-Docstring darüber war falsch. Dieselbe Fehlerklasse, die #1708
erzeugt hat, an der Stelle, die den Sicherheitsmechanismus erklärt.

Konsequenz: **keine** Ausnahme eingetragen, **keine** Regel entschärft — Docstrings vom Scan
auszunehmen würde künftige Fänge dieser Art blind machen. Der Docstring wurde richtiggestellt.

## Änderungen

| Datei | Was |
|---|---|
| `tests/test_trips_path_revival_guard.py` | **neu** — der Wächter, 17 Testfunktionen |
| `internal/store/user.go` | `"trips"` aus `ProvisionUserDirs` — neue Nutzer bekommen es nicht mehr |
| `internal/store/trip.go` | `TripsDir()` entfernt (null Aufrufer, unabhängig verifiziert) |
| `api/routers/preview.py` | Docstring richtiggestellt |
| `internal/handler/profile_trips_guard_test.go` | **neu** — `TestRegisterCreatesNoLegacyTripsDir`, misst am Wirkort |
| `internal/handler/profile_test.go` | `"trips"` aus der Positivschleife; die drei übrigen bleiben |
| `docs/adr/0031-…` | `trips/` aus der Layout-Aufzählung — widersprach sonst dem Code |

## Nachweis

**TDD-RED, zwei unabhängige Belege** — beide erzeugt, *bevor* etwas gelöscht wurde:
- Wächter rot, benennt `trip.go:15` und `user.go:84` namentlich (16 Erkenner-Nachweise im selben
  Lauf grün — sie messen synthetische Quelltexte und belegen, dass der Detektor feuert)
- Go-Verhaltenstest rot: `trips/` entstand bei der Registrierung noch

**Adversary: VERIFIED**, 9 von 10 gezielten Verfälschungen gefangen, darunter:
- Entfernen der Literal-Regel → rot (die kritischste Probe: sonst wäre der Wächter für die
  Slice-Form blind)
- `"trips"` real wieder einbauen → **zweifach** rot (Quelltext-Wächter *und* Registrierungs-Test)
- `"tri" + "ps"`-Konkatenation → vom Quelltext-Scan nicht gefangen (dokumentierte Grenze), vom
  Verhaltenstest schon — Verteidigung in Tiefe wirkt

Ein Finding (F001, HIGH) betraf die **Spec-Formulierung**, nicht den Code: Ich hatte behauptet, die
Obergrenze der Ausnahmeliste verhindere das Stilllegen künftiger Funde. Sie fängt nur Versehen — wer
Liste und Obergrenze in einem Zug ändert, kommt durch, weil beide in derselben Datei stehen. Die
Aussage ist auf das zurückgenommen, was sie leistet; benannt ist jetzt, was wirklich schützt: der
Verhaltenstest am Wirkort und die Review-Pflicht.

**Regression:** Go vollständig grün (15 Pakete), Wächter 17/17, `tests/test_briefing_route_cutover.py`
7/7 — letzteres wichtig, denn diese Datei legt bewusst Lockvogel-Dateien unter `trips/` an und beweist
den Cutover. Wäre sie rot, wäre zu viel entfernt worden.

## Nebenbefunde (gebucht, nicht hier behoben)

- #1199 — `deploy: needs: [test, lint]`; der Job `go-test` ist kein technisches Auslieferungs-Tor.
  Betrifft alle Go-seitigen Wächter.
- #1196 — `broad_test_run_gate.py` schlägt auf Prosa-Text an, in dem der Name des Python-Testläufers
  ohne Testpfad vorkommt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
