### PR TITLE
fix(#1897): Verwaister Briefing-Slot wird nachgeholt statt still verschluckt

### DIFF
--- a/docs/context/fix-1897-verwaister-briefing-slot.md
+++ b/docs/context/fix-1897-verwaister-briefing-slot.md
@@ -1,0 +1,283 @@
+# Context: fix-1897-verwaister-briefing-slot
+
+Issue: [#1897](https://github.com/henemm/gregor_zwanzig/issues/1897) · `bug` · `priority:high` · `session:khw`
+Phase 1 (Context Generation), erhoben 2026-08-16.
+
+## Request Summary
+
+Ein Briefing-Versand, der mitten im Lauf durch ein hartes Prozessende abbricht (Deploy,
+SIGKILL, OOM, Crash), hinterlässt im Slot-Speicher einen Claim mit `outcome: null`. Dieser
+Claim zählt heute als „erledigt". Folge sind zwei nutzersichtbare Defekte: das Briefing wird
+für den restlichen Ortstag **nicht nachgeholt**, und die Alarm-Vorlauf-Sperre aus #1594
+**hebt auf**, obwohl nie ein Briefing kam. Beide Defekte gehen durch dieselbe Methode
+`BriefingSlotStore.is_recorded()`.
+
+## Belegter Vorfall (Produktion, 2026-08-16, Trip KHW `5f534011`)
+
+Die Prod-Datei `/var/lib/gregor/users/henning/briefing_slots.json` trägt 8 Einträge, davon
+**zwei mit `outcome: null`** — und genau an diesen beiden Tagen fehlt das Briefing:
+
+| local_day | slot | recorded_at | outcome |
+|---|---|---|---|
+| 2026-08-14 | evening | 16:00:00.28 UTC | **null** |
+| 2026-08-15 | morning | 05:00:00.30 UTC | `sent` |
+| 2026-08-15 | evening | 16:00:00.21 UTC | `sent` |
+| 2026-08-16 | morning | 05:00:00.24 UTC | **null** |
+
+Der Vorfall ist also kein Einzelfall, sondern ein Muster mit mindestens zwei Vorkommen.
+
+Zwei ergänzend gemessene Fakten, die den Zuschnitt tragen:
+
+1. **Der Nachhol-Takt existiert bereits.** Der Go-Cron-Eintrag `briefing_dispatch` läuft
+   `0 * * * *` (`internal/scheduler/scheduler.go:141`). Bei `NACHHOL_FENSTER_STUNDEN = 3`
+   (`src/services/trip_report_scheduler.py:106`) hätte es am 16.08. um 08:00 und 09:00
+   Ortszeit zwei weitere Gelegenheiten gegeben. Verhindert hat sie allein der verbrannte
+   Slot — es braucht **keinen neuen Auslöser**, nur eine korrekte Fälligkeits-Antwort.
+2. **Der Briefing-Anker war im Vorfall nicht gesetzt.** `_anchor_and_reset()` steht erst
+   nach dem Versandaufruf (`trip_report_scheduler.py:1521-1527`, beide Zweige). Ein
+   Prozessende davor schreibt ihn nicht. Damit bleibt Bedingung 2 von
+   `check_briefing_imminent()` („noch nicht versucht") korrekt — sobald Bedingung 1 wieder
+   stimmt, greift die Alarm-Sperre im Crash-Fall wieder wie beabsichtigt.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/services/briefing_slots.py:68-80` | `is_recorded()` — der Wirkort beider Defekte. Zählt jeden gefundenen Eintrag als erledigt, ohne `outcome` anzusehen (`:78`). |
+| `src/services/briefing_slots.py:82-101` | `reserve()` — schreibt den Claim mit `outcome=None` **vor** dem Versand. Findet `_find` einen Bestandseintrag, wird nicht reserviert (`:92-93`) — ein verwaister Claim blockiert also auch die Neu-Reservierung. |
+| `src/services/briefing_slots.py:103-132` | `record_outcome()` / `release()` — die beiden Abschlusswege, die bei hartem Prozessende ausbleiben. |
+| `src/services/briefing_slots.py:136-144` | `_eintrag()` — Schema. **Trägt bereits `recorded_at`**; für eine zeitbasierte Verwaisungs-Erkennung ist kein neues Feld und keine Bestandsdaten-Migration nötig (an den 8 Prod-Einträgen bestätigt). |
+| `src/services/trip_report_scheduler.py:539-558` | `_collect_due_trips()` — Wirkort von **Defekt 1**: `is_recorded()` filtert den Slot für den Rest des Ortstags heraus (`:553-556`). |
+| `src/services/trip_report_scheduler.py:180-201` | `trip_briefing_due_at()` — Wirkort von **Defekt 2**: dieselbe `is_recorded()`-Frage (`:196-199`) beendet das Fälligkeits-Prädikat. Der Kommentar `:191-195` sichert ausdrücklich das Gegenteil zu („Nach einem GESCHEITERTEN Versand trägt er nicht"). |
+| `src/services/trip_report_scheduler.py:560-599` | `_dispatch_due_item()` — reserve-then-release. Der Docstring `:565-568` benennt den Crash-Fall bereits, zieht aber keine Konsequenz. |
+| `src/services/trip_report_scheduler.py:94` | `VERMERK_AUSGAENGE = {"sent", "no_stage", "no_weather", "no_channels"}` — die vier Ausgänge, die einen Vermerk setzen dürfen. |
+| `src/services/alert_gate.py:200-300` | `check_briefing_imminent()` — die UND-Bedingung aus #1594. Bedingung 1 fällt weg, sobald `briefing_due_at` False liefert. |
+| `src/services/alert_briefing_anchor.py:215-230` | `last_briefing_at()` — Bedingung 2 der Sperre, im Crash-Fall korrekt leer (s. o.). |
+
+## Existing Patterns
+
+- **TTL + Aktivitätsprüfung ist das etablierte Verwaisungs-Muster im Repo.**
+  `.claude/hooks/file_claim_gate.py:45,362-383`: `STALE_AFTER_SECONDS = 4 * 60 * 60`, Alter
+  gegen `claimed_at_epoch`, **plus** eine zweite Prüfung („Claim ist offensichtlich beendet"),
+  die nicht allein auf der Uhr beruht.
+- **Es gibt im Repo KEINE persistierte Prozess- oder Startkennung** — keine Boot-ID, kein
+  `run_id`, keine PID im Zustand, und in `api/main.py:88-101` (FastAPI-`lifespan`) auch
+  keinen Recovery-Schritt, der beim Start alte Zustandsdateien aufräumt. Die im Issue als
+  „naheliegend" genannte Prozesskennung wäre also Neuland; die Ablaufzeit-Variante nutzt
+  Vorhandenes.
+- **Fail-closed-Fehlerrichtung ist für diesen Speicher bewusst gewählt** (Modul-Docstring
+  `briefing_slots.py:13-18`): „nicht geschrieben" heißt Doppelversand an echte Empfänger
+  inklusive kostenpflichtiger Premium-SMS. Jede Lockerung muss diese Richtung respektieren.
+- **In-Memory-Overlap-Schutz auf Go-Seite:** `internal/scheduler/scheduler.go:87-92,460-489`
+  benutzt `TryLock()` je Job — ein zweiter Tick wird übersprungen, nicht gestapelt. Relevant
+  als Randbedingung: zwei gleichzeitige Briefing-Läufe desselben Nutzers sind dadurch
+  unwahrscheinlich, aber nicht prozessübergreifend ausgeschlossen.
+
+## Dependencies
+
+- **Upstream (was der Store benutzt):** `services/file_lock.acquire_exclusive`
+  (Sidecar-Sperre, 2 s), `utils.timezone.local_dt`, `app.loader.get_data_dir`,
+  `briefing_log.json` (Rückwärts-Ableitung nur solange `briefing_slots.json` fehlt).
+- **Downstream (was vom Store abhängt):** ausschließlich `trip_report_scheduler.py` —
+  bestätigt per Volltextsuche, `BriefingSlotStore` hat genau drei Aufrufstellen
+  (`:181`, `:541`, `:583`). Über `trip_briefing_due_at` hängt indirekt `trip_alert.py:732-738`
+  daran. **Der Ortsvergleichs-Pfad benutzt den Store heute NICHT** (`compare_alert.py`,
+  `compare_official_alert.py` rufen `check_briefing_imminent` mit einem eigenen Prädikat).
+- **Go-Seite unberührt:** `internal/handler/cockpit.go` liest `briefing_log.json`, nicht
+  `briefing_slots.json`.
+
+## Existing Specs
+
+| Pfad | Relevanz |
+|---|---|
+| `docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md` | Ursprungs-Spec des Slot-Speichers: Schema, Fälligkeitsfenster, Outcome-Wahl (vier Ausgänge setzen den Vermerk, `channels_unreachable` und Ausnahmen nicht). Muss um die Verwaisungs-Regel ergänzt/abgelöst werden. |
+| `docs/specs/modules/fix_1724_faelligkeit_in_der_ortszone.md` | Vorgänger: Fälligkeit in der Ortszone. |
+| `docs/specs/modules/fix_1851_alarm_tests_vorlaufsperre.md` | Dokumentiert das 3-Stunden-Nachholfenster im Alarm-Zusammenhang. |
+| `docs/adr/0051-drei-zeitbegriffe-zone-an-den-daten.md` | Regel 3: kein Systemuhr-Rückfall, Zeitpunkt ist Pflicht-Parameter. Bindend für jede neue Ablauf-Prüfung. |
+| `docs/adr/0044-kalendertage-folgen-der-ortszeit.md` | `local_day` folgt der Ortszeit; Umstellungstage haben nicht 24 h. |
+| `docs/context/fix-1725-faelligkeit-idempotenz.md` | Kontext-Dokument des Vorgängers (reserve-then-release, fail-closed). |
+
+## Bestehende Tests (Ausgangslage)
+
+| Datei | Umfang | Was sie bewacht |
+|---|---|---|
+| `tests/tdd/test_briefing_slot_idempotenz.py` | 18 Tests (T1–T15) | Fenster, Schlüssel-Vollständigkeit, Outcome-Wahl, Rückwärts-Ableitung, On-Demand-Abgrenzung, fail-closed ohne Sperre. |
+| `tests/tdd/test_trip_alert_briefing_imminent.py` | 10+ Tests, u. a. R6 (`:529`) | R6: ein **gescheiterter** Versand darf das Nachholfenster nicht in Alarmstille verwandeln — nächster Nachbar der hier geplanten Änderung. |
+| `tests/tdd/test_briefing_faelligkeit_ortszone.py` | ~8 Tests | Fälligkeit in der Ortszone. |
+| `tests/helpers/briefing_imminent_fixtures.py` | Helfer | `briefing_versand_gescheitert()`, `trip_briefing_vermerk_setzen()`, `zustand_schnappschuss()` — wiederverwendbar für die RED-Phase. |
+
+**Selbst nachgeprüft:** Kein bestehender Test erwartet, dass ein Eintrag mit `outcome: null`
+als erledigt gilt. Die Tests fahren über eine echte Scheduler-Unterklasse und setzen dabei
+stets einen Ausgang; die einzige direkte `reserve()`-Nutzung (`:979-983`) ruft unmittelbar
+`record_outcome(..., "sent")`. Die Änderung zementiert also kein Bestandsverhalten weg —
+umgekehrt heißt das aber auch: **das Fehlverhalten ist heute von keinem Test abgedeckt.**
+
+## Risks & Considerations
+
+1. **Doppelversand ist die teure Fehlerrichtung.** Eine zu großzügige Verwaisungs-Regel
+   lässt einen noch laufenden Versand ein zweites Mal starten — an echte Empfänger,
+   inklusive kostenpflichtiger Premium-SMS. Die Ablauffrist muss länger sein als jeder
+   legitime Versandlauf und kürzer als der Abstand zweier Cron-Ticks (1 h), sonst wirkt sie
+   nicht.
+2. **`is_recorded()` beantwortet heute zwei verschiedene Fragen** — „darf ich neu senden?"
+   (`_collect_due_trips`) und „ist das Briefing raus, sodass der Alarm wieder darf?"
+   (`trip_briefing_due_at`). Ein offener Claim ist auf die erste Frage „nein, außer er ist
+   verwaist" und auf die zweite „nein, es kam nichts raus". Die Zusammenlegung beider Fragen
+   in einer Methode ist die eigentliche Wurzel; der Zuschnitt muss entscheiden, ob getrennt
+   wird oder ob eine Antwort für beide Wirkorte genügt.
+3. **Nachhol-Semantik am Fensterende.** Wird ein verwaister Claim freigegeben, greift wieder
+   das reguläre 3-Stunden-Fenster. Ein um 07:00 abgebrochenes Morgen-Briefing kommt also um
+   08:00 — ein um 09:30 abgebrochenes gar nicht mehr. Das ist vertretbar, muss aber in der
+   Spec als bewusste Grenze stehen (das Issue nennt `NACHHOL_FENSTER_STUNDEN` ausdrücklich
+   als Prüfpunkt).
+4. **Gleichzeitigkeit.** Zwei Läufe dürfen einen verwaisten Claim nicht beide übernehmen.
+   Die Übernahme muss innerhalb derselben `_update()`-Sperre geschehen wie die Reservierung,
+   nicht als getrennter Lese-dann-Schreib-Schritt.
+5. **ADR-0051 Regel 3:** die Ablaufprüfung braucht einen übergebenen Zeitpunkt, keinen
+   `datetime.now()`-Rückfall — sonst ist sie im Test nicht steuerbar und verletzt die
+   bestehende Zeit-Entscheidung.
+6. **Abgrenzung Ortsvergleich:** der Compare-Pfad benutzt den Store noch nicht (#1777 ist
+   die offene Scheibe dafür). Die Projektregel „Trip und Ortsvergleich teilen Code" ist
+   gewahrt, indem die Korrektur **im geteilten Store** sitzt und nicht im Trip-Scheduler —
+   dann trägt sie automatisch, sobald #1777 den Vergleich anschließt.
+7. **Der auslösende Deploy-Zeitpunkt gehört nicht hierher** (henemm-infra). Dieses Issue
+   bleibt unabhängig davon gültig, weil Crash/OOM/Neustart jederzeit eintreten können.
+
+---
+
+# Analysis (Phase 2)
+
+## Type
+
+**Bug.** Root Cause aus dem Issue durch eine unabhängige Gegenrede (`analysis-challenger`)
+geprüft und in der Mechanik **bestätigt**; zwei von ihr benannte Lücken sind mit den
+Produktions-Journalen nachträglich geschlossen worden.
+
+## Was die Journale zusätzlich belegen
+
+**(1) Die Reihenfolge Claim → Alarm-Gate ist belegt, nicht nur plausibel.**
+Am 14.08. entstand der Claim um 16:00:00.28 UTC (`Generating evening report for trip: KHW 403`),
+der Alarm-Lauf erkannte die Änderung erst um 16:00:38.92 und sendete 16:00:40.61 — also
+rund 38 s **nach** dem Claim. Der Alarm-Lauf lief 40,5 s über 4 Trips; seine Gate-Prüfung für
+KHW kann nicht vor dem Claim gelegen haben.
+
+**(2) Der 14.08. belegt auch Defekt 2, nicht nur Defekt 1.** Der Alarm ging um 16:00:40 raus,
+**bevor** der Deploy um 16:00:56 den Dienst stoppte — also im Normalbetrieb, nicht im
+Abschaltfenster. Das Muster hat damit zwei vollständige Vorkommen (14.08. und 16.08.), nicht
+nur eines.
+
+**(3) Der teuerste Einzelwert: ein legitimer Briefing-Versand dauert real bis zu 5 Minuten.**
+Gemessen über 22 Versandläufe des Trips KHW, 05.–15.08.:
+
+| Zeitraum | kürzester | längster |
+|---|---|---|
+| 05.–10.08. | 54 s | 93 s |
+| 11.–15.08. | 218 s | **319 s** (11.08. abends) |
+
+Damit ist die Untergrenze für eine Verwaisungs-Frist **gemessen** und nicht geschätzt: sie
+muss deutlich über 319 s liegen.
+
+**(4) Ein bisher unbenannter Nebeneffekt derselben Wurzel.** Der Claim öffnet die Alarm-Sperre
+nicht erst nach einem Absturz, sondern **schon in dem Moment, in dem der Versand beginnt** —
+und der dauert real 1 bis 5 Minuten. In genau diesem Fenster prüft der parallel laufende
+Alarm-Lauf sein Gate. Am 14.08. (16:00:40) und 16.08. (05:01:42) ist deshalb ein separater
+Alarm rausgegangen, obwohl #1594 ihn dem Briefing überlassen wollte. Am 15.08. blieb es aus,
+weil der Alarm-Lauf zufällig 0,074 s brauchte und damit **vor** dem Claim fertig war
+(`trip_alert: Lauf beendet nach 0.074s`, 05:00:00.255 gegen Claim 05:00:00.307). Ob ein
+Alarm doppelt rausgeht, hängt heute an einem Wettlauf von Millisekunden.
+
+## Entwurfsentscheidung
+
+Die tragende Einsicht ist bestätigt (`briefing_slots.py:92-93`): **der Doppelversand-Schutz
+sitzt in `reserve()`, nicht in `is_recorded()`.** Eine Lockerung von `is_recorded()` fasst den
+teuren Pfad also gar nicht an; das Risiko konzentriert sich allein auf die Frage, wann
+`reserve()` einen fremden offenen Claim übernehmen darf.
+
+Die Strategie-Bewertung empfahl daraufhin **eine** Bedeutung für `is_recorded()`
+(„`outcome` gesetzt"). Diese Empfehlung wird **nicht übernommen** — sie übersieht eine
+Kopplung, die der Code selbst als Gefahr benennt: `_collect_due_trips` speist über
+`dispatch_orchestrator.py:66-67` die Menge `due_trip_ids_now`, an der
+`_process_pending_markers` die #1012-Nachliefer-Marker verfallen lässt. Der Docstring
+`trip_report_scheduler.py:531-537` warnt wörtlich, „eine unehrlich lange Liste legte den
+Nachliefermechanismus lautlos still". Genau das entstünde: ein Trip mit frisch offenem Claim
+stünde wieder in der Liste, `reserve()` verweigerte danach den Versand — und der Marker wäre
+verfallen.
+
+**Die beiden Wirkorte stellen tatsächlich zwei verschiedene Fragen:**
+
+| Wirkort | Frage | Richtige Antwort bei offenem Claim |
+|---|---|---|
+| `_collect_due_trips` (`:553`) | „Wird jetzt ein Versand stattfinden?" | **frisch:** nein (läuft ja gerade) · **verwaist:** ja |
+| `trip_briefing_due_at` (`:196`) | „Steht für diesen Slot noch ein Briefing aus?" | **immer ja** — es kam nichts raus |
+
+Daraus folgt der Entwurf (drei Zustände statt zwei, Frist als Modul-Attribut wie
+`LOCK_TIMEOUT_SECONDS`):
+
+1. **`is_recorded(...)` = „abgeschlossen"** — Eintrag mit gesetztem `outcome`, plus die
+   bestehende Rückwärts-Ableitung aus `briefing_log.json` (unverändert). Aufrufer:
+   `trip_briefing_due_at`. Ein offener Claim heißt: Briefing steht aus, die Alarm-Sperre hält.
+2. **Eine zweite, ausdrücklich benannte Frage = „abgeschlossen ODER lebendig in Arbeit"** —
+   offener Claim jünger als `CLAIM_TTL`. Aufrufer: `_collect_due_trips`. Hält die
+   Fälligkeitsliste ehrlich und den Nachliefer-Marker heil.
+3. **`reserve(..., moment)` übernimmt** einen offenen Claim, der älter als `CLAIM_TTL` ist
+   (neues `recorded_at`, `outcome` bleibt `null`); ein jüngerer blockiert weiter wie heute.
+   Punkte 2 und 3 benutzen **dieselbe** interne Regel — Prüfort = Wirkort.
+
+Verworfene Alternative: „verwaist, wenn `recorded_at` in einer früheren Cron-Stunde liegt".
+Ein Claim von 12:59:58 gälte zwei Sekunden später als tot — weit unter jeder gemessenen
+Versanddauer.
+
+### `CLAIM_TTL`
+
+- **Untergrenze (gemessen):** > 319 s, der längste reale Einzelversand (11.08. abends).
+- **Obergrenze (abgeleitet):** < 1 h, der Cron-Abstand (`internal/scheduler/scheduler.go:141`)
+  — darüber wirkt die Frist nie, weil der nächste Übernahme-Versuch erst dann stattfindet.
+- **Gewählt: 900 s (15 min)** — knapp dreifacher Abstand zum gemessenen Maximum, und da der
+  nächste Reserve-Versuch ohnehin erst zur vollen Stunde kommt, verhält sich jeder Wert
+  zwischen 10 und 50 Minuten am nächsten Tick identisch. Als Modul-Attribut zur Laufzeit
+  lesbar, damit Tests die Frist unterschreiten können.
+
+## Affected Files
+
+| Datei | Änderung | Beschreibung |
+|---|---|---|
+| `src/services/briefing_slots.py` | MODIFY | `CLAIM_TTL`; `is_recorded()` = „abgeschlossen"; zweites Prädikat „abgeschlossen oder lebendig"; `reserve(..., moment)` mit Übernahme verwaister Claims |
+| `src/services/trip_report_scheduler.py` | MODIFY | `_collect_due_trips` fragt das zweite Prädikat; `_dispatch_due_item` reicht `now_utc` an `reserve()` durch; Kommentar `:191-195` richtigstellen |
+| `src/services/dispatch_orchestrator.py` | MODIFY | `now_utc` durch `dispatch_one` an `_dispatch_due_item` reichen |
+| `tests/tdd/test_briefing_slot_idempotenz.py` | MODIFY | Outcome-Semantik, TTL-Grenzfall frisch/verwaist, Übernahme |
+| `tests/tdd/test_trip_alert_briefing_imminent.py` | MODIFY | Alarm-Sperre hält bei offenem Claim (Defekt 2, Nutzersicht) |
+| `docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md` | MODIFY | Verwaisungs-Regel nachtragen |
+
+## Scope Assessment
+
+- Dateien: 6 (3 Produktiv, 2 Test, 1 Spec)
+- Geschätzte LoC: Produktiv ~55–80, Test ~90–140 → **~145–220**, unter dem 250er-Limit,
+  aber ohne Reserve. Wird es enger, ist die Kürzung des Nachweises **nicht** der Ausweg —
+  dann Rückfrage beim PO.
+- Risiko: **MEDIUM** (der Doppelversand-Pfad wird berührt, aber nur um eine Alters-Bedingung
+  ergänzt, unter derselben bestehenden Sperre)
+
+## Risiken
+
+1. **Doppelversand bei zu knapper Frist** — durch die Messung (319 s gegen 900 s) entschärft.
+2. **Zugestellt, aber nicht vermerkt:** stirbt der Prozess zwischen erfolgreichem Versand und
+   `record_outcome()`, wäre der Claim verwaist, obwohl die Mail draußen ist. Gegenmittel ohne
+   neues Datenfeld: `briefing_log.json` trägt den Eintrag bereits **vor** dem Anker
+   (`trip_report_scheduler.py:1623`) — die Übernahme muss diesen Nachweis prüfen. Der Leser
+   dafür existiert schon (`_log_bezeugt_versand`).
+3. **Gleichzeitigkeit:** Altersprüfung und Übernahme müssen in **derselben** `_op`-Closure
+   unter der bestehenden Sidecar-Sperre liegen, sonst können zwei Läufe denselben verwaisten
+   Claim übernehmen.
+4. **Bewusste Folge, die der PO kennen muss:** Die Alarm-Sperre hält künftig auch während der
+   1–5 Minuten, die ein Versand dauert, und nach einem abgebrochenen Versand bis zum
+   Nachhol-Versuch der nächsten Stunde. Eine Änderungsmeldung kann dadurch bis zu einer Stunde
+   später kommen — dafür kommt sie im nachgeholten Briefing an, statt dass das Briefing ganz
+   ausfällt. Das ist die in ADR-0009/#1594 bereits getroffene Entscheidung („ERSETZT, nicht
+   verschluckt"), hier nur konsequent angewendet.
+5. **Nicht in diesem Zuschnitt:** der auslösende Deploy-Zeitpunkt (henemm-infra) und der
+   Ortsvergleichs-Pfad (#1777, benutzt den Store noch nicht).
+
+## Open Questions
+
+Keine blockierenden. Die Frist ist gemessen begründet, beide Defekte gehören in einen
+Zuschnitt (eine halbe Behebung ließe genau das ausfallende Briefing ungefixt).

--- a/docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md
+++ b/docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md
@@ -66,6 +66,27 @@ festen Zone und war damit zufällig umstellungs-immun.
 | `tests/tdd/test_briefing_slot_idempotenz.py` | CREATE | T1–T14, Verhaltensname statt Issue-Nummer (`test_naming_gate.py`) |
 | `tests/tdd/test_briefing_faelligkeit_ortszone.py` | MODIFY | AC-7-Test (`:312-348`) wird von „0 Treffer / 2 Treffer" auf „1 Treffer / 1 Treffer" umgeschrieben — planmäßiges RED dieser Datei ist Teil des Vorhabens |
 
+### Nachtrag #1897 (2026-08-16) — Verwaisungs-Regel, MODIFY
+
+Ein Vermerk mit `outcome: null` zählte bislang als erledigt, sobald er nur *existierte*
+(`is_recorded()`, siehe oben). Stirbt der Prozess hart (Deploy, SIGKILL, OOM, Crash) zwischen
+`reserve()` und `record_outcome()`, blieb genau ein solcher Vermerk zurück — das Briefing fiel
+für den Rest des Ortstags aus, und die Alarm-Vorlauf-Sperre aus #1594 hob sich fälschlich auf,
+obwohl nie ein Briefing zugestellt wurde. Real eingetreten auf Trip KHW `5f534011` am 14.08. und
+16.08.2026. Behoben und spezifiziert in
+`docs/specs/modules/fix_1897_verwaister_briefing_slot.md`.
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `src/services/briefing_slots.py` | MODIFY | `CLAIM_TTL` (900 s) als Modul-Attribut; `reserve(..., moment)` übernimmt einen fremden Vermerk mit `outcome: null`, dessen `recorded_at` älter als `CLAIM_TTL` ist (neues `recorded_at`, `outcome` bleibt `null`), innerhalb derselben Sperren-Closure wie die bestehende Prüfung; ein zweites, eigenständiges Prädikat „abgeschlossen ODER lebendig in Arbeit" tritt neben `is_recorded()`. |
+| `src/services/trip_report_scheduler.py` | MODIFY | `_collect_due_trips()` nutzt das neue zweite Prädikat (Alter zählt); `trip_briefing_due_at()` bleibt bei `is_recorded()` (Alter zählt nicht — die Alarm-Sperre muss halten, solange kein `outcome` gesetzt ist). |
+| `src/services/dispatch_orchestrator.py` | MODIFY | `dispatch_one()` reicht `now_utc` als `moment` an `reserve()` durch. |
+
+Präzisiert diese Spec, löst sie **nicht** ab: Der Doppelversand-Schutz bleibt in `reserve()`,
+fail-closed bleibt die Fehlerrichtung (AC-13 gilt unverändert fort) — ergänzt wird einzig, dass
+ein hinreichend alter offener Vermerk (`outcome: null`, älter als `CLAIM_TTL`) keine dauerhafte
+Blockade mehr ist, sondern beim nächsten Lauf übernommen und der Versand nachgeholt wird.
+
 ### Estimated Changes
 
 - Files: 5 (3 Produktivcode, 2 Tests)
@@ -480,3 +501,6 @@ Skelett verschieben, Vermerk nach `_send_trip_report_outcome` statt in den Wrapp
 
 - 1.0 (2026-08-11): Initial spec created, aus `docs/context/fix-1725-faelligkeit-idempotenz.md`
   auf Basis der Vorlage `fix_1724_faelligkeit_in_der_ortszone.md`.
+- 2026-08-16: Scope-Nachtrag zu #1897 (Verwaisungs-Regel) ergänzt — präzisiert diese Spec,
+  löst sie nicht ab. Siehe „Nachtrag #1897" unter Scope sowie
+  `docs/specs/modules/fix_1897_verwaister_briefing_slot.md`.

--- a/docs/specs/modules/fix_1897_verwaister_briefing_slot.md
+++ b/docs/specs/modules/fix_1897_verwaister_briefing_slot.md
@@ -214,3 +214,5 @@ Begründung, gemessen an 22 realen Versandläufen des Trips KHW (05.–15.08.202
 ## Changelog
 
 - 2026-08-16: Initial spec created (Issue #1897)
+- 2026-08-16: Implementiert. Adversary-Verdict VERIFIED. 23 Tests über 9 Acceptance Criteria
+  (AC-1 bis AC-9).

--- a/docs/specs/modules/fix_1897_verwaister_briefing_slot.md
+++ b/docs/specs/modules/fix_1897_verwaister_briefing_slot.md
@@ -12,7 +12,7 @@ tags: [briefing, alert-gate, idempotenz, bugfix]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO, 2026-08-16 ('go')
 
 ## Purpose
 

--- a/docs/specs/modules/fix_1897_verwaister_briefing_slot.md
+++ b/docs/specs/modules/fix_1897_verwaister_briefing_slot.md
@@ -1,0 +1,216 @@
+---
+entity_id: fix-1897-verwaister-briefing-slot
+type: module
+created: 2026-08-16
+updated: 2026-08-16
+status: draft
+version: "1.0"
+tags: [briefing, alert-gate, idempotenz, bugfix]
+---
+
+# Verwaister Briefing-Slot nach hartem Prozessende (#1897)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Ein Briefing-Versand, der durch ein hartes Prozessende (Deploy, SIGKILL, OOM, Crash) mitten im
+Lauf abbricht, hinterlässt im Slot-Speicher einen Claim mit `outcome: null`, der heute fälschlich
+als „erledigt" zählt. In Produktion (Trip KHW `5f534011`) ist das am 14.08.2026 (evening) und
+16.08.2026 (morning) tatsächlich eingetreten: das Briefing blieb für den Rest des Ortstags aus,
+und die Alarm-Vorlauf-Sperre aus #1594 hob sich fälschlich auf, obwohl nie ein Briefing kam.
+
+## Source
+
+- **File:** `src/services/briefing_slots.py`
+- **Identifier:** `class BriefingSlotStore` — Methoden `is_recorded()`, `reserve()`,
+  `record_outcome()`, `release()`
+
+Zusätzlich betroffen (Aufrufer, dieselbe Schicht):
+
+- **File:** `src/services/trip_report_scheduler.py`
+- **Identifier:** `_collect_due_trips()`, `trip_briefing_due_at()`, `_dispatch_due_item()`
+
+- **File:** `src/services/dispatch_orchestrator.py`
+- **Identifier:** `dispatch_one()` — reicht `now_utc` an `_dispatch_due_item()` durch
+
+> **Schicht-Hinweis:** Alle drei Dateien liegen im Python-Core (`src/services/...`, FastAPI-Domäne).
+> Es gibt keine Go- oder Frontend-Beteiligung: `internal/handler/cockpit.go` liest ausschließlich
+> `briefing_log.json`, nicht `briefing_slots.json`, und der Go-Cron-Takt
+> (`internal/scheduler/scheduler.go:141`) bleibt unverändert — der Nachhol-Mechanismus existiert
+> bereits, es braucht keinen neuen Auslöser.
+
+## Estimated Scope
+
+- **LoC:** ~145–220 (Produktiv ~55–80, Test ~90–140) — unter dem 250er-Workflow-Limit, aber ohne
+  Reserve. Wird es enger, ist Kürzung des Nachweises **nicht** der Ausweg, sondern Rückfrage beim PO.
+- **Files:** 6 (3 Produktiv, 2 Test, 1 Spec-Nachtrag)
+- **Effort:** medium — Risiko MEDIUM, weil der Doppelversand-Pfad (`reserve()`) berührt wird,
+  aber nur um eine Alters-Bedingung unter der bestehenden Sperre ergänzt, nicht neu aufgebaut.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `BriefingSlotStore` (`src/services/briefing_slots.py`) | module | Persistenter Slot-Speicher (`briefing_slots.json`), Doppelversand-Schutz via `reserve()` unter Sidecar-Sperre; wird um `CLAIM_TTL`, Übernahme-Logik und ein zweites Prädikat erweitert. |
+| `check_briefing_imminent` (#1594, `src/services/alert_gate.py:200-300`) | function | UND-Bedingung der Alarm-Vorlauf-Sperre; Bedingung 1 hängt an `trip_briefing_due_at()`, dessen Antwort sich mit dieser Spec ändert (offener Claim = „Briefing steht noch aus"). |
+| `_process_pending_markers` (#1012, `src/services/trip_report_scheduler.py`) | function | Nachliefer-Marker-Mechanismus; liest über `dispatch_orchestrator.py:66-67` dieselbe `due_trip_ids_now`-Menge, die `_collect_due_trips()` liefert. Eine unehrlich lange oder kurze Liste legt diesen Mechanismus lautlos still — daher das zweite, eigenständige Prädikat statt einer Vereinheitlichung mit `is_recorded()`. |
+| Briefing-Anker (`src/services/alert_briefing_anchor.py:215-230`, `last_briefing_at()`) | function | Bedingung 2 der Alarm-Sperre; wird von `_anchor_and_reset()` erst **nach** dem Versandaufruf gesetzt (`trip_report_scheduler.py:1521-1527`) und bleibt daher im Crash-Fall korrekt leer — unverändert durch diese Spec. |
+
+## Implementation Details
+
+**Drei Zustände statt zwei.** Ein Eintrag im Slot-Speicher ist heute entweder „nicht vorhanden"
+oder „erledigt" (jeder gefundene Eintrag zählt, `briefing_slots.py:78`). Neu werden drei Zustände
+unterschieden:
+
+1. **Abgeschlossen** — `outcome` ist gesetzt, also nicht `null`. In der Praxis ist das immer
+   einer der vier Werte aus `VERMERK_AUSGAENGE` (`trip_report_scheduler.py:94`: `sent`,
+   `no_stage`, `no_weather`, `no_channels`); die Regel prüft aber bewusst nur „gesetzt" und
+   nicht die Zugehörigkeit zu dieser Menge — sonst entschiede der Speicher über die
+   Ausgangs-Auswahl des Schedulers mit und ein künftiger fünfter Ausgang fiele still auf
+   „nicht erledigt" zurück. Dazu die bestehende Rückwärts-Ableitung aus `briefing_log.json`
+   (unverändert).
+2. **Lebendig in Arbeit** — `outcome: null`, `recorded_at` jünger als `CLAIM_TTL` gegenüber dem
+   übergebenen Zeitpunkt. Ein Versand läuft real oder ist so kürzlich gestartet, dass er noch
+   laufen kann.
+3. **Verwaist** — `outcome: null`, `recorded_at` älter als `CLAIM_TTL`. Der Prozess ist mit hoher
+   Wahrscheinlichkeit hart beendet worden, bevor er abschließen konnte.
+
+**Die beiden Wirkorte stellen unterschiedliche Fragen und bekommen unterschiedliche Antworten:**
+
+| Wirkort | Frage | Antwort bei offenem Claim (Zustand 2/3) |
+|---|---|---|
+| `_collect_due_trips()` (`trip_report_scheduler.py:553`) | „Wird jetzt ein Versand stattfinden?" | **lebendig:** nein (läuft ja gerade, Trip fehlt in der Fälligkeitsliste) · **verwaist:** ja (Trip steht wieder in der Liste) |
+| `trip_briefing_due_at()` (`trip_report_scheduler.py:196`) | „Steht für diesen Slot noch ein Briefing aus (Alarm-Sperre)?" | **immer ja**, unabhängig vom Alter — solange `outcome` nicht gesetzt ist, kam nichts raus, die Alarm-Sperre aus #1594 muss halten |
+
+Konkret:
+
+- **`is_recorded(...)` wird zu „abgeschlossen"** — nur `outcome`-gesetzte Einträge (und die
+  Rückwärts-Ableitung) zählen. Aufrufer: `trip_briefing_due_at()`.
+- **Ein zweites, eigenständig benanntes Prädikat = „abgeschlossen ODER lebendig in Arbeit"** —
+  zusätzlich Einträge mit `outcome: null` und `recorded_at` jünger als `CLAIM_TTL`. Aufrufer:
+  `_collect_due_trips()`. Hält die Fälligkeitsliste ehrlich gegenüber `_process_pending_markers`
+  (#1012) und lässt offene Nachliefer-Marker nicht verfallen.
+- **`reserve(..., moment)` bekommt einen Pflicht-Zeitparameter** (ADR-0051 Regel 3, kein
+  `datetime.now()`-Rückfall) und übernimmt einen fremden offenen Claim, wenn dessen `recorded_at`
+  älter als `CLAIM_TTL` gegenüber `moment` ist: neues `recorded_at`, `outcome` bleibt `null`. Ein
+  jüngerer Claim blockiert weiter wie heute (`_find` verweigert die Reservierung,
+  `briefing_slots.py:92-93`).
+- **Altersprüfung und Übernahme MÜSSEN in derselben Sperren-Closure liegen** — der bestehenden
+  `_update()`-Operation unter der Sidecar-Datei-Sperre (`services/file_lock.acquire_exclusive`).
+  Ein getrennter Lese-dann-Schreib-Schritt (erst Alter prüfen, dann später schreiben) würde zwei
+  gleichzeitigen Läufen erlauben, denselben verwaisten Claim beide für sich zu beanspruchen —
+  genau der teure Doppelversand-Pfad, den `reserve()` heute schon verhindert.
+- **`_dispatch_due_item()` reicht `now_utc` durch** an `reserve()`; `dispatch_orchestrator.py`
+  reicht denselben Zeitpunkt von `dispatch_one()` weiter — ein einziger, konsistenter Moment pro
+  Lauf statt mehrerer `now()`-Aufrufe.
+- **Zugestellt-aber-nicht-vermerkt-Fall:** Stirbt der Prozess zwischen erfolgreichem Versand und
+  `record_outcome()`, ist die Mail bereits draußen, obwohl der Claim verwaist erscheint.
+  `briefing_log.json` erhält den Eintrag bereits **vor** dem Anker
+  (`trip_report_scheduler.py:1623`); die Übernahme-Logik nutzt den bestehenden Leser
+  `_log_bezeugt_versand`, um in diesem Fall den Claim direkt als `sent` abzuschließen statt einen
+  Doppelversand auszulösen.
+
+**`CLAIM_TTL` als Modul-Attribut**, analog zu `LOCK_TIMEOUT_SECONDS`, zur Laufzeit lesbar (damit
+Tests die Frist unterschreiten können):
+
+```python
+CLAIM_TTL = 900  # Sekunden (15 min)
+```
+
+Begründung, gemessen an 22 realen Versandläufen des Trips KHW (05.–15.08.2026):
+
+- **Untergrenze:** > 319 s — der längste real gemessene Einzelversand (11.08. abends,
+  Zeitraum 11.–15.08.: 218–319 s; Zeitraum 05.–10.08.: 54–93 s).
+- **Obergrenze:** < 1 h — der Abstand zweier Cron-Ticks (`internal/scheduler/scheduler.go:141`,
+  `0 * * * *`); darüber wirkt die Frist nie, weil der nächste Übernahme-Versuch ohnehin erst zur
+  vollen Stunde stattfindet.
+- **Gewählt: 900 s** — knapp dreifacher Abstand zum gemessenen Maximum. Da der nächste
+  Reserve-Versuch ohnehin erst zur vollen Stunde erfolgt, verhält sich jeder Wert zwischen 10 und
+  50 Minuten am nächsten Tick identisch; 900 s liegt komfortabel in dieser Zone.
+
+## Expected Behavior
+
+- **Input:** Zeitstempel des Lauf-Moments (`now_utc`), Trip-ID, Slot-Schlüssel (`local_day`, `slot`),
+  bestehender Zustand von `briefing_slots.json`.
+- **Output:** korrekte Fälligkeits-Antwort an `_collect_due_trips()` und `trip_briefing_due_at()`
+  gemäß den drei Zuständen; bei Übernahme eines verwaisten Claims ein aktualisierter Eintrag mit
+  neuem `recorded_at` und `outcome: null`, gefolgt vom Versand.
+- **Side effects:** Schreibzugriff auf `briefing_slots.json` unter Sidecar-Datei-Sperre; bei
+  Übernahme eines Claims, der laut `briefing_log.json` bereits zugestellt wurde, direkter Abschluss
+  mit `outcome: sent` statt erneutem Versand.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Morgen-Briefing wurde um 07:00 Ortszeit begonnen und der Prozess endete davor hart, sodass ein Vermerk ohne Ausgang zurückbleibt / When der nächste stündliche Lauf um 08:00 Ortszeit läuft / Then wird das Briefing verschickt und der Vermerk trägt danach den Ausgang `sent`.
+  - Test: Nutzersicht-Test über die reale Scheduler-Unterklasse (Muster aus `tests/tdd/test_briefing_slot_idempotenz.py`): Claim mit `outcome: null` und `recorded_at` älter als `CLAIM_TTL` vorbereiten, Lauf mit `now_utc = 08:00` ausführen, prüfen dass der Versandkanal aufgerufen wurde und `record_outcome` mit `"sent"` geschrieben wurde — nicht per Dateiinhalt-Grep, sondern über den beobachtbaren Versandaufruf.
+
+- **AC-2:** Given für einen Trip steht ein Briefing im Fälligkeitsfenster an und es liegt ein Vermerk ohne Ausgang vor, weil der Versand läuft oder abgebrochen ist / When im selben Zeitraum ein Änderungs-Alarm ausgewertet wird / Then wird der Alarm nicht als eigenständige Nachricht verschickt, weil das Briefing noch aussteht.
+  - Test: `check_briefing_imminent()` (#1594) mit offenem Claim (`outcome: null`, beliebiges Alter) und geänderten Wetterdaten aufrufen; prüfen, dass die Alarm-Sperre greift und kein separater Alarm-Versand ausgelöst wird — Nachbar zu R6 in `tests/tdd/test_trip_alert_briefing_imminent.py`.
+
+- **AC-3:** Given ein Vermerk ohne Ausgang ist jünger als `CLAIM_TTL`, der Versand läuft also noch / When ein zweiter Lauf denselben Slot reservieren will / Then verweigert die Reservierung und es findet kein zweiter Versand statt.
+  - Test: Claim mit `recorded_at = now - 100s` (< `CLAIM_TTL`) setzen, den Versand über die reale Scheduler-Unterklasse anstoßen; prüfen, dass `reserve()` `False` liefert (keine Ausnahme, fail-closed wie heute) und kein zweiter Versandaufruf am Kanal ankommt.
+
+- **AC-4:** Given ein Vermerk ohne Ausgang ist älter als `CLAIM_TTL` / When ein Lauf denselben Slot reservieren will / Then wird der Vermerk übernommen, sein Zeitstempel auf den neuen Zeitpunkt gesetzt, und der Versand findet statt.
+  - Test: Claim mit `recorded_at = now - 1000s` (> `CLAIM_TTL`) setzen, `reserve(..., moment=now)` aufrufen, prüfen dass die Reservierung gelingt, `recorded_at` auf `now` aktualisiert wird und der anschließende Versand ausgeführt wird.
+
+- **AC-5:** Given ein Vermerk ohne Ausgang ist älter als `CLAIM_TTL`, aber das Briefing-Protokoll weist für denselben Trip, dieselbe Slot-Art und denselben Ortstag einen regulären Versand aus / When ein Lauf den Slot reservieren will / Then findet kein erneuter Versand statt.
+  - Test: verwaisten Claim (`outcome: null`, älter als `CLAIM_TTL`) UND einen passenden `briefing_log.json`-Eintrag (`_log_bezeugt_versand` liefert True) vorbereiten; `reserve(..., moment=now)` aufrufen; prüfen, dass kein Versandkanal-Aufruf erfolgt und der Claim stattdessen direkt mit `outcome: sent` abgeschlossen wird.
+
+- **AC-6:** Given ein Vermerk ohne Ausgang ist jünger als `CLAIM_TTL` / When die Fälligkeitsliste zusammengestellt wird / Then steht der Trip nicht darin, sodass ein offener Nachliefer-Marker aus #1012 nicht verfällt.
+  - Test: Claim jünger als `CLAIM_TTL` vorbereiten, offenen #1012-Nachliefer-Marker für denselben Trip setzen, `_collect_due_trips()` aufrufen; prüfen dass der Trip fehlt UND dass der Marker nach dem Lauf weiterhin offen ist (nicht durch `_process_pending_markers` verfallen).
+
+- **AC-7:** Given zwei Läufe versuchen im selben Augenblick, denselben verwaisten Vermerk zu übernehmen / When beide reservieren wollen / Then übernimmt genau einer, der andere sendet nicht.
+  - Test: Gleichzeitigkeit über `threading.Barrier` erzwingen, niemals über Wartezeiten oder die Uhr — zwei Threads rufen `reserve(..., moment=now)` auf denselben verwaisten Claim gleichzeitig auf (synchronisiert per Barrier direkt vor dem Aufruf), Assertion dass genau ein Thread die Reservierung erhält und nur ein Versandaufruf protokolliert wird.
+
+- **AC-8:** Given Bestandseinträge, die vor dieser Änderung geschrieben wurden / When sie gelesen werden / Then verhalten sich abgeschlossene Vermerke unverändert und es ist keine Datenmigration nötig.
+  - Test: Fixture mit den vier Prod-Vermerk-Formen (`sent`, `no_stage`, `no_weather`, `no_channels`) aus dem bestehenden Schema (`_eintrag()`, `briefing_slots.py:136-144`, trägt bereits `recorded_at`) ohne jede Migration einlesen; prüfen, dass `is_recorded()` für alle vier weiterhin `True` liefert und kein Schreibzugriff zur Migration erfolgt.
+
+- **AC-9:** Given der Abbruch geschah so spät, dass beim nächsten stündlichen Lauf das dreistündige Nachhol-Fenster bereits vorbei ist / When dieser Lauf läuft / Then wird das Briefing nicht mehr nachgeholt und die Alarm-Sperre gilt für diesen Slot nicht mehr.
+  - Test: verwaisten Claim mit `recorded_at` außerhalb von `NACHHOL_FENSTER_STUNDEN = 3` (`trip_report_scheduler.py:106`) vorbereiten, Lauf mit passendem `now_utc` ausführen; prüfen dass `_collect_due_trips()` den Trip nicht mehr liefert UND dass `check_briefing_imminent()` für diesen Slot keine Sperre mehr meldet (Alarm darf wieder eigenständig raus).
+
+## Known Limitations
+
+- **Nachhol-Grenze am Fensterende (AC-9).** Ein verwaister Claim wird nach der Übernahme wieder
+  dem regulären 3-Stunden-Fenster (`NACHHOL_FENSTER_STUNDEN`) unterworfen. Ein um 07:00
+  abgebrochenes Morgen-Briefing kommt beim 08:00-Lauf nach, ein um 09:30 abgebrochenes gar nicht
+  mehr für diesen Slot. Das ist eine bewusste, im Kontext-Dokument geprüfte Grenze, kein
+  unentdeckter Defekt.
+- **Mögliche Verzögerung einer Änderungsmeldung um bis zu eine Stunde.** Die Alarm-Sperre hält
+  künftig auch während der 1–5 Minuten, die ein realer Versand dauert, und nach einem
+  abgebrochenen Versand bis zum nächsten Nachhol-Versuch. Eine Änderungsmeldung kann dadurch bis
+  zu einer Stunde später ankommen. Das ist keine neue Nebenwirkung, sondern die konsequente
+  Anwendung der bereits getroffenen Entscheidung aus ADR-0009/#1594 („ersetzt, nicht
+  verschluckt").
+- **Der Ortsvergleichs-Pfad ist nicht betroffen.** `compare_alert.py` und
+  `compare_official_alert.py` rufen `check_briefing_imminent()` mit einem eigenen Prädikat auf und
+  benutzen `BriefingSlotStore` heute nicht (#1777 ist die offene Scheibe, die den Vergleich
+  anschließen würde). Die Korrektur sitzt bewusst im geteilten Store statt im Trip-Scheduler, damit
+  sie automatisch trägt, sobald #1777 umgesetzt ist.
+- **Der auslösende Deploy-Zeitpunkt wird hier nicht behandelt.** Ob und wie Deploys den Prozess
+  während eines laufenden Versands beenden, ist eine Frage der Infrastruktur (`henemm-infra`) und
+  bleibt getrennt — dieses Fix bleibt unabhängig davon gültig, weil Crash/OOM/Neustart jederzeit
+  eintreten können, nicht nur bei Deploys.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine (neue) — ADR-0051 und ADR-0044 werden eingehalten, nicht abgelöst.
+- **Rationale:** ADR-0051 Regel 3 verlangt, dass jede neue Ablaufprüfung einen übergebenen
+  Zeitpunkt als Pflicht-Parameter nimmt statt auf `datetime.now()` zurückzufallen — genau so ist
+  `reserve(..., moment)` und die Verwaisungs-Prüfung in dieser Spec entworfen, damit Tests die
+  `CLAIM_TTL`-Grenze deterministisch über `threading.Barrier` und feste Zeitpunkte statt über
+  Wartezeiten oder die Systemuhr steuern können. ADR-0044 (Kalendertage folgen der Ortszeit) ist
+  unberührt, weil die Slot-Schlüssel (`local_day`, `slot`) unverändert bleiben — nur die
+  Zustandslogik innerhalb eines Slots wird um eine Alters-Dimension ergänzt. Die
+  Entscheidung von #1725 (`fix_1725_faelligkeit_und_idempotenz.md`: reserve-then-release,
+  fail-closed, vier Ausgänge setzen den Vermerk) wird dadurch **präzisiert, nicht abgelöst**: der
+  Doppelversand-Schutz bleibt in `reserve()`, fail-closed bleibt die Fehlerrichtung — ergänzt wird
+  einzig, dass ein hinreichend alter offener Claim keine dauerhafte Blockade mehr ist. Die
+  #1725-Spec wird als eigener Scope-Eintrag (`docs/specs/modules/fix_1725_faelligkeit_und_idempotenz.md`,
+  MODIFY) um die Verwaisungs-Regel nachgetragen.
+
+## Changelog
+
+- 2026-08-16: Initial spec created (Issue #1897)

--- a/src/services/briefing_slots.py
+++ b/src/services/briefing_slots.py
@@ -41,6 +41,14 @@ logger = logging.getLogger("briefing_slots")
 #: wartet die vollen 2 s (Spec, Known Limitations zu T13).
 LOCK_TIMEOUT_SECONDS = file_lock.LOCK_TIMEOUT_SECONDS
 
+#: Issue #1897: Frist, nach der ein Vermerk OHNE Ausgang als verwaist gilt --
+#: der schreibende Prozess ist dann mit hoher Wahrscheinlichkeit hart beendet
+#: worden (Deploy, SIGKILL, OOM). Wie ``LOCK_TIMEOUT_SECONDS`` zur LAUFZEIT als
+#: Modul-Attribut gelesen, damit Tests die Frist unterschreiten koennen.
+#: Untergrenze aus 22 realen Versandlaeufen (laengster Einzelversand 319 s),
+#: Obergrenze der Cron-Abstand von einer Stunde -- 900 s liegt mittig.
+CLAIM_TTL = 900  # Sekunden (15 min)
+
 _STATE_FILENAME = "briefing_slots.json"
 _LOCK_SUFFIX = ".lock"
 _BRIEFING_LOG_FILENAME = "briefing_log.json"
@@ -69,36 +77,122 @@ class BriefingSlotStore:
         self, trip_id: str, slot: str, local_day: date,
         zone: Optional[ZoneInfo] = None,
     ) -> bool:
-        """Liegt ein Vermerk vor?
+        """Ist der Slot ABGESCHLOSSEN?
+
+        Issue #1897: abgeschlossen heisst ``outcome`` gesetzt -- ein Vermerk
+        ohne Ausgang zaehlt NICHT mehr, denn dann kam beim Nutzer nichts an.
+        Geprueft wird bewusst nur „gesetzt" und nicht die Zugehoerigkeit zu
+        ``VERMERK_AUSGAENGE``: sonst entschiede dieser Speicher ueber die
+        Ausgangs-Auswahl des Schedulers mit und ein kuenftiger fuenfter Ausgang
+        fiele still auf „nicht erledigt" zurueck.
 
         Schliesst die Rueckwaerts-Ableitung aus ``briefing_log.json`` ein
         (AC-9) — die greift aber nur, solange dieser Speicher noch keine
         eigene Datei hat (s. :meth:`_log_bezeugt_versand`).
         """
-        if self._find(self._load(), trip_id, slot, local_day) is not None:
+        eintrag = self._find(self._load(), trip_id, slot, local_day)
+        if eintrag is not None and eintrag.get("outcome") is not None:
             return True
+        return self._log_bezeugt_versand(trip_id, slot, local_day, zone)
+
+    def is_recorded_or_claimed(
+        self, trip_id: str, slot: str, local_day: date,
+        zone: Optional[ZoneInfo] = None, *, moment: datetime,
+    ) -> bool:
+        """Ist der Slot abgeschlossen ODER LEBENDIG in Arbeit? (Issue #1897)
+
+        Das zweite, eigenstaendige Praedikat fuer ``_collect_due_trips`` — es
+        beantwortet „wird jetzt ein Versand stattfinden?". Ein Vermerk ohne
+        Ausgang, dessen ``recorded_at`` juenger als :data:`CLAIM_TTL` ist,
+        gehoert zu einem laufenden Versand und haelt den Trip aus der
+        Faelligkeitsliste; ein verwaister bringt ihn zurueck.
+
+        Bewusst NICHT mit :meth:`is_recorded` vereinheitlicht: dort lautet die
+        Frage „steht noch ein Briefing aus?" (Alarm-Sperre #1594), und die
+        Antwort haengt allein am Ausgang, nicht am Alter.
+
+        Args:
+            moment: Zeitpunkt des Laufs (UTC) — PFLICHT, kein
+                ``datetime.now()``-Rueckfall (ADR-0051 Regel 3).
+        """
+        eintrag = self._find(self._load(), trip_id, slot, local_day)
+        if eintrag is not None:
+            if eintrag.get("outcome") is not None:
+                return True
+            return not self._ist_verwaist(eintrag, moment)
         return self._log_bezeugt_versand(trip_id, slot, local_day, zone)
 
     def reserve(
         self, trip_id: str, slot: str, local_day: date,
-        zone: Optional[ZoneInfo] = None,
+        zone: Optional[ZoneInfo] = None, *, moment: datetime,
     ) -> bool:
-        """``True`` nur bei FRISCHER Reservierung.
+        """``True`` nur bei FRISCHER Reservierung oder UEBERNAHME (#1897).
 
-        ``False`` bei bestehendem Vermerk, beim Rollout-Nachweis aus
+        ``False`` bei abgeschlossenem Vermerk, bei einem lebendigen Claim
+        (juenger als :data:`CLAIM_TTL`), beim Rollout-Nachweis aus
         ``briefing_log.json`` (AC-9) UND bei nicht erhaltener Sperre (AC-13).
+
+        Ein VERWAISTER Claim (``outcome: null``, aelter als :data:`CLAIM_TTL`)
+        wird uebernommen: ``recorded_at`` wandert auf ``moment``, ``outcome``
+        bleibt ``null``. Bezeugt ``briefing_log.json`` fuer diesen Ortstag
+        jedoch bereits einen regulaeren Versand, starb der Prozess ZWISCHEN
+        Versand und ``record_outcome`` — dann wird der Claim direkt mit
+        ``sent`` abgeschlossen und NICHT uebernommen (sonst ginge das Briefing
+        ein zweites Mal an echte Empfaenger, Premium-SMS inklusive).
+
+        🔴 Alterspruefung und Uebernahme liegen zusammen in EINER
+        :meth:`_update`-Closure, also unter derselben Sidecar-Sperre. Ein
+        getrennter Lese-dann-Schreib-Schritt liesse zwei gleichzeitige Laeufe
+        denselben verwaisten Claim beide beanspruchen — genau der teure
+        Doppelversand-Pfad, den diese Methode verhindert.
+
+        Args:
+            moment: Zeitpunkt des Laufs (UTC) — PFLICHT, kein
+                ``datetime.now()``-Rueckfall (ADR-0051 Regel 3).
         """
+        stand = {"reserviert": False}
+
         def _op(data: dict) -> bool:
-            if self._find(data, trip_id, slot, local_day) is not None:
-                return False
+            eintrag = self._find(data, trip_id, slot, local_day)
+            if eintrag is not None:
+                if eintrag.get("outcome") is not None:
+                    return False
+                if not self._ist_verwaist(eintrag, moment):
+                    return False
+                if self._log_traegt_versand(trip_id, slot, local_day, zone):
+                    eintrag["outcome"] = "sent"
+                    return True  # schreiben, aber NICHT reserviert
+                eintrag["recorded_at"] = moment.isoformat()
+                stand["reserviert"] = True
+                return True
             if self._log_bezeugt_versand(trip_id, slot, local_day, zone):
                 return False
             data.setdefault("entries", []).append(
-                self._eintrag(trip_id, slot, local_day, None)
+                self._eintrag(trip_id, slot, local_day, None, moment)
             )
+            stand["reserviert"] = True
             return True
 
-        return self._update(_op)
+        return self._update(_op) and stand["reserviert"]
+
+    # --- Alters-Dimension (Issue #1897) ---
+
+    def _ist_verwaist(self, eintrag: dict, moment: datetime) -> bool:
+        """Ist dieser Vermerk OHNE Ausgang aelter als :data:`CLAIM_TTL`?
+
+        ``CLAIM_TTL`` wird hier als Modul-Attribut zur LAUFZEIT gelesen — eine
+        lokale Bindung machte die Frist fuer Tests unerreichbar.
+
+        Ein unlesbarer oder fehlender ``recorded_at`` gilt als NICHT verwaist:
+        fail-closed wie ueberall in diesem Speicher — lieber ein ausgelassener
+        Slot als ein Doppelversand.
+        """
+        recorded_at = self._parse(eintrag.get("recorded_at"))
+        if recorded_at is None:
+            return False
+        if recorded_at.tzinfo is None:
+            recorded_at = recorded_at.replace(tzinfo=timezone.utc)
+        return (moment - recorded_at).total_seconds() > CLAIM_TTL
 
     def record_outcome(
         self, trip_id: str, slot: str, local_day: date, outcome: str,
@@ -134,12 +228,20 @@ class BriefingSlotStore:
     # --- Schluessel ---
 
     @staticmethod
-    def _eintrag(trip_id: str, slot: str, local_day: date, outcome: Optional[str]) -> dict:
+    def _eintrag(
+        trip_id: str, slot: str, local_day: date, outcome: Optional[str],
+        moment: Optional[datetime] = None,
+    ) -> dict:
+        """``moment`` ist der Lauf-Zeitpunkt (Issue #1897): ``recorded_at``
+        traegt ihn, damit die Verwaisungs-Frist gegen DENSELBEN Zeitstrahl
+        misst, den der Aufrufer benutzt. Ohne ``moment`` (``record_outcome``,
+        wo der Ausgang die Frist ohnehin beendet) bleibt es bei der Systemuhr.
+        """
         return {
             "trip_id": trip_id,
             "slot": slot,
             "local_day": local_day.isoformat(),
-            "recorded_at": datetime.now(tz=timezone.utc).isoformat(),
+            "recorded_at": (moment or datetime.now(tz=timezone.utc)).isoformat(),
             "outcome": outcome,
         }
 
@@ -198,6 +300,20 @@ class BriefingSlotStore:
         """
         if self._path.exists():
             return False
+        return self._log_traegt_versand(trip_id, slot, local_day, zone)
+
+    def _log_traegt_versand(
+        self, trip_id: str, slot: str, local_day: date, zone: Optional[ZoneInfo],
+    ) -> bool:
+        """Der reine Protokoll-Blick OHNE die Existenz-Bedingung — derselbe
+        Leser, den :meth:`_log_bezeugt_versand` benutzt.
+
+        Issue #1897 braucht ihn getrennt: beim Uebernahme-Versuch existiert
+        ``briefing_slots.json`` per Definition (der verwaiste Vermerk steht
+        drin), die Existenz-Bedingung schwiege dort also immer. Genau in diesem
+        Fall — Prozess gestorben ZWISCHEN Versand und ``record_outcome`` — ist
+        die Mail aber bereits draussen und darf nicht erneut rausgehen.
+        """
         pfad = self._dir / _BRIEFING_LOG_FILENAME
         if not pfad.exists():
             return False

--- a/src/services/dispatch_orchestrator.py
+++ b/src/services/dispatch_orchestrator.py
@@ -66,7 +66,7 @@ class TripDispatchStrategy:
         due_trip_ids_now = {trip.id for trip, _, _ in due}
         self._sent += self._service._process_pending_markers(now_utc, due_trip_ids_now)
 
-    def dispatch_one(self, item) -> None:
+    def dispatch_one(self, item, now_utc: "datetime") -> None:
         trip, report_type, local_day = item
         try:
             # Issue #1725: NICHT direkt `_send_trip_report_outcome` -- der
@@ -74,7 +74,12 @@ class TripDispatchStrategy:
             # und gibt ihn je nach Ausgang frei. Er ist bewusst die EINZIGE
             # Stelle, die den Vermerk anfasst: die On-Demand-Pfade rufen
             # weiterhin `_send_trip_report_outcome` und bleiben unberuehrt.
-            outcome = self._service._dispatch_due_item(trip, report_type, local_day)
+            # Issue #1897: `now_utc` ist DER Zeitpunkt dieses Laufs, nicht eine
+            # frische Uhrabfrage -- er entscheidet in `reserve`, ob ein Vermerk
+            # ohne Ausgang zu einem laufenden Versand gehoert oder verwaist ist.
+            outcome = self._service._dispatch_due_item(
+                trip, report_type, local_day, now_utc=now_utc,
+            )
             if outcome is None:
                 # Kein Versandversuch (Slot bereits vermerkt oder Sperre nicht
                 # zu bekommen). Weder gesendet noch technisch fehlgeschlagen --
@@ -158,7 +163,10 @@ class CompareDispatchStrategy:
             now_utc, self._all_locations or [],
         )
 
-    def dispatch_one(self, item) -> None:
+    def dispatch_one(self, item, now_utc: "datetime | None" = None) -> None:
+        # `now_utc` gehoert zur geteilten Strategie-Schnittstelle (Issue #1897,
+        # Trip-Seite). Der Compare-Pfad traegt seinen Tagesbezug bereits im
+        # `item` (`target_date`, `tage_ab_ortstag`) und braucht ihn nicht.
         from app.loader import load_all_locations
         from services.scheduler_dispatch_service import _dispatch_due_preset
 
@@ -227,7 +235,7 @@ def run_briefing_dispatch(
     strategy.pre_pass(now_utc, due)
 
     for i, item in enumerate(due):
-        strategy.dispatch_one(item)
+        strategy.dispatch_one(item, now_utc)
         # 2s Pause zwischen aufeinanderfolgenden Mails (nicht nach der
         # letzten) -- Rate-Limit-Schutz: Trip seit #766, Compare seit
         # 2026-07-16 (#1207, drei Kanaele pro Preset seit #1270). Beide 2.0s.

--- a/src/services/trip_report_scheduler.py
+++ b/src/services/trip_report_scheduler.py
@@ -193,6 +193,10 @@ def trip_briefing_due_at(
         # bereits zugestellten Briefing. Nach einem GESCHEITERTEN Versand
         # traegt er nicht (reserve-then-release, `:565-571`); dort endet die
         # Sperre ueber den Briefing-Anker (`check_briefing_imminent`, R6).
+        # Issue #1897: `is_recorded` heisst ABGESCHLOSSEN. Ein Vermerk ohne
+        # Ausgang (hart beendeter Prozess) beendet das Fenster NICHT mehr --
+        # solange nichts rausging, muss die Alarm-Sperre halten, unabhaengig
+        # vom Alter des Vermerks.
         if store.is_recorded(
             trip.id, report_type, vor_ort.date(), zone=vor_ort.tzinfo,
         ):
@@ -550,8 +554,12 @@ class TripReportSchedulerService:
                 if not stunde <= vor_ort.hour < stunde + NACHHOL_FENSTER_STUNDEN:
                     continue
                 ortstag = vor_ort.date()
-                if store.is_recorded(
+                # Issue #1897: hier zaehlt „wird jetzt ein Versand
+                # stattfinden?" -- ein LEBENDIGER Vermerk (Versand laeuft) haelt
+                # den Trip aus der Liste, ein VERWAISTER bringt ihn zurueck.
+                if store.is_recorded_or_claimed(
                     trip.id, report_type, ortstag, zone=vor_ort.tzinfo,
+                    moment=now_utc,
                 ):
                     continue
                 due.append((trip, report_type, ortstag))
@@ -559,6 +567,7 @@ class TripReportSchedulerService:
 
     def _dispatch_due_item(
         self, trip: "Trip", report_type: str, local_day: date,
+        *, now_utc: datetime,
     ) -> Optional[str]:
         """Versand EINES faelligen Slots, abgesichert durch den Vermerk (#1725).
 
@@ -572,6 +581,11 @@ class TripReportSchedulerService:
         Legacy-CLI) vom Vermerk unberuehrt, ohne dass ein zusaetzliches Flag
         noetig waere (AC-12) -- sie rufen `_send_trip_report_outcome` direkt.
 
+        Issue #1897: `now_utc` ist der Lauf-Zeitpunkt und wird an `reserve`
+        durchgereicht -- EIN Moment pro Lauf, keine zweite Zeitabfrage. Er
+        entscheidet, ob ein Vermerk ohne Ausgang zu einem laufenden Versand
+        gehoert (blockiert) oder verwaist ist (wird uebernommen).
+
         Returns:
             Den Ausgang des Versandversuchs -- oder `None`, wenn gar keiner
             stattfand (Slot bereits vermerkt oder Sperre nicht zu bekommen,
@@ -581,7 +595,9 @@ class TripReportSchedulerService:
         from services.trip_day import trip_tz
 
         store = BriefingSlotStore(self._user_id)
-        if not store.reserve(trip.id, report_type, local_day, zone=trip_tz(trip)):
+        if not store.reserve(
+            trip.id, report_type, local_day, zone=trip_tz(trip), moment=now_utc,
+        ):
             logger.warning(
                 "Slot %s/%s am %s nicht reservierbar -- kein Versandversuch",
                 trip.id, report_type, local_day,

--- a/tests/tdd/test_briefing_anchor_survives_dispatch_failure.py
+++ b/tests/tdd/test_briefing_anchor_survives_dispatch_failure.py
@@ -357,7 +357,10 @@ def test_ac3_versandfehler_zaehlt_weiterhin_als_fehlschlag_und_wird_protokollier
     with caplog.at_level(logging.ERROR, logger="dispatch_orchestrator"):
         # Issue #1725: `collect_due` liefert (trip, report_type, ORTSTAG) —
         # das dritte Glied des Idempotenz-Schluessels.
-        strategy.dispatch_one((trip, "morning", stage_date(LAT, LON)))
+        # Issue #1897: `dispatch_one` reicht den Lauf-Zeitpunkt durch.
+        strategy.dispatch_one(
+            (trip, "morning", stage_date(LAT, LON)), _zeitpunkt_ortsstunde(7),
+        )
 
     assert strategy.result() == (0, 1), (
         "Ein Versandfehler muss weiterhin als fehlgeschlagener Lauf zaehlen "
@@ -1238,7 +1241,9 @@ def test_gelingender_regulaerer_versand_macht_den_vermerk_gegenstandslos(monkeyp
         f"zustellen (Doppel-Nachricht): {zugestellt!r} (#1662 AC-5)"
     )
 
-    strategy.dispatch_one((trip, "morning", stage_date(LAT, LON)))
+    strategy.dispatch_one(
+        (trip, "morning", stage_date(LAT, LON)), _zeitpunkt_ortsstunde(7),
+    )
 
     assert len(zugestellt) == 1, (
         f"Der Nutzer muss genau EINE Nachricht bekommen, erhalten: "
@@ -1277,7 +1282,9 @@ def test_erneut_gescheiterter_regulaerer_versand_haelt_den_vermerk_am_leben():
     # Issue #1725: dritte Stelle = Ortstag (Idempotenz-Schluessel).
     due = [(trip, "morning", stage_date(LAT, LON))]
     strategy.pre_pass(now_utc=_zeitpunkt_ortsstunde(7), due=due)
-    strategy.dispatch_one((trip, "morning", stage_date(LAT, LON)))
+    strategy.dispatch_one(
+        (trip, "morning", stage_date(LAT, LON)), _zeitpunkt_ortsstunde(7),
+    )
 
     assert strategy.result() == (0, 1), (
         f"Vorbedingung: der Lauf muss als gescheitert zaehlen, erhalten: "

--- a/tests/tdd/test_briefing_faelligkeit_ortszone.py
+++ b/tests/tdd/test_briefing_faelligkeit_ortszone.py
@@ -129,7 +129,8 @@ def _lauf(scheduler, now_utc: datetime) -> set[tuple[str, str, date]]:
     """
     gesammelt = list(scheduler._collect_due_trips(now_utc))
     for trip, report_type, ortstag in gesammelt:
-        scheduler._dispatch_due_item(trip, report_type, ortstag)
+        # Issue #1897: derselbe Lauf-Zeitpunkt wandert bis in `reserve`.
+        scheduler._dispatch_due_item(trip, report_type, ortstag, now_utc=now_utc)
     return {(t.id, rt, tag) for t, rt, tag in gesammelt}
 
 
@@ -445,7 +446,7 @@ def test_ac7_sommerzeit_umstellung_liefert_genau_ein_briefing():
         while t < ende.astimezone(timezone.utc):
             gesammelt = list(scheduler._collect_due_trips(t))
             for trip, report_type, ortstag in gesammelt:
-                scheduler._dispatch_due_item(trip, report_type, ortstag)
+                scheduler._dispatch_due_item(trip, report_type, ortstag, now_utc=t)
             if ("korsika", "morning") in [(x.id, rt) for x, rt, _ in gesammelt]:
                 n += 1
             t += timedelta(hours=1)

--- a/tests/tdd/test_briefing_slot_faelligkeit_und_alarmsperre.py
+++ b/tests/tdd/test_briefing_slot_faelligkeit_und_alarmsperre.py
@@ -1,0 +1,422 @@
+"""TDD RED — #1897: Faelligkeitsliste und Alarm-Vorlauf-Sperre bei offenem
+Briefing-Vermerk.
+
+SPEC: docs/specs/modules/fix_1897_verwaister_briefing_slot.md (AC-2, AC-6,
+AC-9). AC-1/AC-3/AC-4/AC-5/AC-7/AC-8 stehen in
+``test_briefing_slot_verwaister_claim.py``, dort auch die vollstaendige Liste
+der neuen Schnittstellen-Namen.
+
+Die beiden Wirkorte stellen VERSCHIEDENE Fragen (Spec, „Implementation
+Details"):
+
+* ``_collect_due_trips()`` — „wird jetzt ein Versand stattfinden?" Ein
+  LEBENDIGER Vermerk (juenger als ``CLAIM_TTL``) haelt den Trip aus der Liste,
+  ein VERWAISTER bringt ihn zurueck. Praedikat:
+  ``BriefingSlotStore.is_recorded_or_claimed(..., moment=...)``.
+* ``trip_briefing_due_at()`` / ``check_briefing_imminent()`` — „steht fuer
+  diesen Slot noch ein Briefing aus?" Solange ``outcome`` nicht gesetzt ist,
+  kam nichts raus: die Alarm-Sperre aus #1594 muss halten, UNABHAENGIG vom
+  Alter des Vermerks. Praedikat: ``is_recorded()``, ab jetzt „abgeschlossen".
+
+Nachbar zu R6 in ``test_trip_alert_briefing_imminent.py`` — dieselben
+mock-freien Bausteine (``tests/helpers/briefing_imminent_fixtures.py``),
+dieselbe Messnaht: gezaehlte Wetterabrufe, 0 = vor dem Abruf gesperrt.
+
+Die Uhr wird eingefroren, weil ``check_and_send_alerts()`` seinen Zeitpunkt
+konstruktionsbedingt selbst holt (Begruendung wie im Kopf von AC-5/R6 der
+Nachbardatei); alle geprueften Entscheidungen bekommen ihren Zeitpunkt
+trotzdem als PARAMETER. Ortszone des Trips ist ``Atlantic/Reykjavik``
+(ganzjaehrig UTC+0), Ortsstunde = UTC-Stunde.
+
+Pfadregel #1409: alles relativ zu DIESER Datei bzw. ueber ``app.loader``.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+for _p in (str(ROOT), str(ROOT / "src")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from app.loader import get_data_dir  # noqa: E402
+from services import briefing_slots  # noqa: E402
+from services.briefing_slots import BriefingSlotStore  # noqa: E402
+
+from tests.helpers.briefing_imminent_fixtures import (  # noqa: E402
+    TRIP_ZONE,
+    fresh_uid,
+    load_trip_obj,
+    ortstag,
+    trip_change_alert_run,
+    write_trip,
+    write_user_tier,
+)
+
+TRIP = "t-1897"
+SLOT_STUNDE = 7
+ABEND_STUNDE = 18
+TAG_DER_MESSUNG = datetime(2026, 3, 15, tzinfo=timezone.utc)
+
+
+def _ttl() -> int:
+    """``CLAIM_TTL`` zur LAUFZEIT — nie als getippte Zahl im Test."""
+    return briefing_slots.CLAIM_TTL
+
+
+def _slot(minuten: int = 0) -> datetime:
+    return TAG_DER_MESSUNG.replace(hour=SLOT_STUNDE) + timedelta(minutes=minuten)
+
+
+def _nutzer(kennung: str) -> str:
+    """Eigene, sprechende Kennung je Fall (Mandantentrennung, nie ``default``).
+    Aufraeumen ist nicht noetig: ``_isolate_data_root`` gibt jedem Test einen
+    frischen Daten-Baum."""
+    user_id = fresh_uid(kennung)
+    write_user_tier(user_id)
+    return user_id
+
+
+def _offener_vermerk(user_id: str, local_day: date, recorded_at: datetime) -> None:
+    """Der Zustand, den ein HART BEENDETER Versandprozess hinterlaesst: ein
+    Eintrag im Bestandsschema mit ``outcome: null``.
+
+    Bewusst roh geschrieben statt ueber ``reserve(..., moment=...)`` — so misst
+    der Test das gemeldete FEHLVERHALTEN und nicht bloss eine fehlende
+    Signatur.
+    """
+    pfad = get_data_dir(user_id) / "briefing_slots.json"
+    pfad.parent.mkdir(parents=True, exist_ok=True)
+    pfad.write_text(json.dumps({"entries": [{
+        "trip_id": TRIP, "slot": "morning", "local_day": local_day.isoformat(),
+        "recorded_at": recorded_at.isoformat(), "outcome": None,
+    }]}, indent=2), encoding="utf-8")
+
+
+def _scheduler(user_id: str):
+    """Echter ``TripReportSchedulerService``, bei dem nur die zwei Naehte zum
+    Netz ersetzt sind — Versand und Wetterabruf. Beide durch echte
+    Implementierungen mit echten DTOs, kein Mock."""
+    from app.models import SegmentWeatherData, SegmentWeatherSummary
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    class _OhneNetz(TripReportSchedulerService):
+        versandversuche: list = []
+
+        def _send_trip_report_outcome(self, trip, report_type, **kwargs):
+            type(self).versandversuche.append((trip.id, report_type))
+            return "sent"
+
+        def _fetch_weather(self, segments, provider=None):
+            # Alle Abschnitte weiterhin ohne Daten -> der #1012-Marker wird
+            # hochgezaehlt statt weggeraeumt (`_bump_pending_marker_attempts`).
+            return [
+                SegmentWeatherData(
+                    segment=s, timeseries=None, aggregated=SegmentWeatherSummary(),
+                    fetched_at=datetime.now(timezone.utc), provider="test",
+                    has_error=True,
+                )
+                for s in segments
+            ]
+
+    _OhneNetz.versandversuche = []
+    return _OhneNetz(user_id=user_id)
+
+
+def _marker(user_id: str) -> dict | None:
+    from services.trip_report_scheduler import _load_pending_entries
+
+    pfad = get_data_dir(user_id) / "pending_briefings.json"
+    for eintrag in _load_pending_entries(pfad).get("entries", []):
+        if eintrag.get("trip_id") == TRIP:
+            return eintrag
+    return None
+
+
+def _faellige_ids(scheduler, now_utc: datetime) -> set:
+    return {trip.id for trip, _, _ in scheduler._collect_due_trips(now_utc)}
+
+
+def _steht_aus(user_id: str, trip, moment: datetime) -> bool:
+    """``trip_briefing_due_at()`` DIREKT — ohne die Abtastung darueber.
+
+    🔴 ``check_briefing_imminent()`` tastet dieses Praedikat ueber ein Fenster
+    von ``BRIEFING_VORLAUF_MINUTEN`` ab und meldet „gesperrt", sobald IRGENDEIN
+    Abtastpunkt ``True`` liefert. Ein Vermerk altert waehrend dieses Fensters
+    mit — eine altersabhaengige Antwort kann also weiter hinten zufaellig
+    richtig herauskommen, obwohl vorne die falsche Frage gestellt wurde. Deshalb
+    wird das Praedikat zusaetzlich an EINEM Zeitpunkt direkt befragt (Adversary
+    F004).
+    """
+    from services.trip_report_scheduler import trip_briefing_due_at
+
+    return trip_briefing_due_at(trip, moment, user_id=user_id)
+
+
+def _sperre_greift(user_id: str, trip, now_utc: datetime) -> bool:
+    """``check_briefing_imminent()`` (#1594) mit dem ECHTEN Trip-Praedikat —
+    genau so verdrahtet wie im Produktivpfad (``trip_alert.py``)."""
+    from services.alert_gate import check_briefing_imminent
+
+    return check_briefing_imminent(
+        user_id=user_id, entity_id=trip.id, entity_type="trip",
+        now=now_utc, zone=TRIP_ZONE,
+        briefing_due_at=lambda moment: _steht_aus(user_id, trip, moment),
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — offener Vermerk haelt die Alarm-Vorlauf-Sperre
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "vermerk, erwartet_gesperrt",
+    [("offen_jung", True), ("offen_verwaist", True), ("abgeschlossen", False)],
+)
+def test_ac2_offener_vermerk_haelt_die_alarm_sperre(
+    vermerk, erwartet_gesperrt, monkeypatch,
+):
+    """AC-2.
+
+    GIVEN fuer einen Trip steht ein Briefing im Faelligkeitsfenster an und es
+    liegt ein Vermerk ohne Ausgang vor, weil der Versand laeuft oder
+    abgebrochen ist
+    WHEN im selben Zeitraum ein Aenderungs-Alarm ausgewertet wird
+    THEN wird der Alarm nicht als eigenstaendige Nachricht verschickt, weil das
+    Briefing noch aussteht.
+
+    Beide Alter werden geprueft: ``outcome: null`` heisst „es kam nichts raus",
+    unabhaengig davon, ob der Versand noch laeuft oder abgebrochen ist. Der
+    dritte Fall ist die Gegenprobe — mit gesetztem Ausgang ist das Briefing
+    zugestellt, der Alarm muss regulaer rausgehen. Ohne ihn bewiese „0 Abrufe"
+    nur, dass irgendetwas den Lauf stoppt.
+
+    Kein Briefing-Anker: ein hart beendeter Prozess setzt ihn nie
+    (``_anchor_and_reset`` laeuft erst NACH dem Versandaufruf) — genau deshalb
+    haengt die Sperre hier allein am Vermerk.
+
+    🔴 ``CLAIM_TTL`` wird fuer diesen Fall hochgesetzt (Adversary F004): der
+    „junge" Vermerk muss ueber das GESAMTE Abtastfenster von
+    ``check_briefing_imminent()`` jung bleiben. Sonst altert er waehrend der
+    Abtastung ueber die Frist hinaus, und ein Praedikat, das faelschlich aufs
+    ALTER statt auf den AUSGANG sieht, kippt weiter hinten zufaellig auf das
+    erwartete Ergebnis zurueck — die Zusicherung waere blind. Die Frist wirkt
+    hier ausserdem nirgends sonst: der Alarm-Lauf fragt allein ``is_recorded``.
+
+    RED-Charakter: Fehlernachweis — heute zaehlt der offene Vermerk als
+    erledigt, der Trip gilt als nicht mehr faellig, die Sperre faellt und der
+    Alarm geht raus, obwohl nie ein Briefing kam.
+    """
+    from freezegun import freeze_time
+
+    monkeypatch.setattr(briefing_slots, "CLAIM_TTL", 2 * 60 * 60)
+    jetzt = _slot(5)
+    with freeze_time(jetzt):
+        uid = _nutzer(f"1897-ac2-{vermerk}")
+        write_trip(uid, TRIP, morgen_stunde=SLOT_STUNDE, abend_stunde=ABEND_STUNDE)
+        tag = ortstag(TRIP_ZONE)
+        if vermerk == "abgeschlossen":
+            BriefingSlotStore(uid).record_outcome(TRIP, "morning", tag, "sent")
+        else:
+            alter = 60 if vermerk == "offen_jung" else _ttl() * 2
+            _offener_vermerk(uid, tag, jetzt - timedelta(seconds=alter))
+        abrufe = trip_change_alert_run(uid, TRIP)
+
+    if erwartet_gesperrt:
+        assert abrufe == 0, (
+            f"Vermerk '{vermerk}': ohne gesetzten Ausgang hat der Nutzer kein "
+            f"Briefing bekommen — der Aenderungsalarm muss schweigen und darf "
+            f"kein Wetter abrufen, es waren {abrufe} Abrufe."
+        )
+    else:
+        assert abrufe >= 1, (
+            f"Vermerk '{vermerk}': das Briefing ist zugestellt, der Alarm muss "
+            f"regulaer pruefen — es waren {abrufe} Abrufe. Ohne diese "
+            f"Gegenprobe misst der Test die Sperre gar nicht."
+        )
+
+
+@pytest.mark.parametrize(
+    "vermerk, steht_aus",
+    [("offen_jung", True), ("offen_verwaist", True), ("abgeschlossen", False)],
+)
+def test_ac2_faelligkeits_praedikat_fragt_nach_dem_ausgang_nicht_nach_dem_alter(
+    vermerk, steht_aus,
+):
+    """AC-2, an seinem WIRKORT statt an der Abtastung darueber.
+
+    GIVEN ein Vermerk ohne Ausgang liegt vor — einmal jung (Versand laeuft),
+    einmal verwaist (Prozess hart beendet)
+    WHEN ``trip_briefing_due_at()`` an EINEM Zeitpunkt befragt wird
+    THEN meldet es in BEIDEN Faellen „steht noch aus", und nur der
+    abgeschlossene Vermerk beendet die Faelligkeit.
+
+    Die Spec teilt die beiden Praedikate nach der FRAGE auf: hier „steht noch
+    ein Briefing aus?" (allein der Ausgang), in ``_collect_due_trips()`` „wird
+    jetzt ein Versand stattfinden?" (Ausgang UND Alter). Vertauscht man die
+    beiden an ihren Wirkorten, ist genau das kaputt — und ueber
+    ``check_briefing_imminent()`` allein bleibt es unsichtbar, weil dessen
+    Abtastfenster den Kipppunkt der Alters-Antwort ueberdeckt (Adversary F004).
+
+    Der dritte Fall ist die Gegenprobe: ohne ihn waere „True" auch von einem
+    Praedikat erfuellt, das immer True liefert.
+    """
+    from freezegun import freeze_time
+
+    jetzt = _slot(5)
+    with freeze_time(jetzt):
+        uid = _nutzer(f"1897-ac2-direkt-{vermerk}")
+        write_trip(uid, TRIP, morgen_stunde=SLOT_STUNDE, abend_stunde=ABEND_STUNDE)
+        tag = ortstag(TRIP_ZONE)
+        if vermerk == "abgeschlossen":
+            BriefingSlotStore(uid).record_outcome(TRIP, "morning", tag, "sent")
+        else:
+            alter = 60 if vermerk == "offen_jung" else _ttl() * 2
+            _offener_vermerk(uid, tag, jetzt - timedelta(seconds=alter))
+        ergebnis = _steht_aus(uid, load_trip_obj(uid, TRIP), jetzt)
+
+    assert ergebnis is steht_aus, (
+        f"Vermerk '{vermerk}': die Faelligkeit dieses Slots haengt allein am "
+        f"AUSGANG des Vermerks, nicht an seinem Alter — erwartet "
+        f"{steht_aus}, gemeldet {ergebnis}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-6 — lebendiger Vermerk: Trip nicht faellig, Nachliefer-Marker ueberlebt
+# ---------------------------------------------------------------------------
+
+def test_ac6_lebendiger_vermerk_haelt_den_trip_aus_der_faelligkeitsliste():
+    """AC-6.
+
+    GIVEN ein Vermerk ohne Ausgang ist juenger als ``CLAIM_TTL``
+    WHEN die Faelligkeitsliste zusammengestellt wird
+    THEN steht der Trip nicht darin, sodass ein offener Nachliefer-Marker aus
+    #1012 nicht verfaellt.
+
+    Zwei Zusicherungen, weil eine allein nichts beweist:
+    * Der Trip fehlt in ``_collect_due_trips()`` — sonst raeumte
+      ``_process_pending_markers`` den Marker ersatzlos weg (`:658-668`).
+    * Der VERWAISTE Vermerk bringt denselben Trip zurueck in die Liste. Ohne
+      diese Gegenprobe waere die erste Haelfte auch von einer Regel erfuellt,
+      die JEDEN offenen Vermerk blockieren laesst — also vom heutigen Fehler.
+
+    RED-Charakter: die Gegenprobe ist Fehlernachweis (heute blockiert der
+    verwaiste Vermerk die Faelligkeit dauerhaft); die erste Haelfte ist
+    Mutations-Waechter fuer die neu eingezogene Alters-Dimension.
+    """
+    from freezegun import freeze_time
+
+    jetzt = _slot(30)
+    with freeze_time(jetzt):
+        uid = _nutzer("1897-ac6-lebendig")
+        write_trip(uid, TRIP, morgen_stunde=SLOT_STUNDE, abend_stunde=ABEND_STUNDE)
+        tag = ortstag(TRIP_ZONE)
+        _offener_vermerk(uid, tag, jetzt - timedelta(seconds=60))
+
+        scheduler = _scheduler(uid)
+        trip = load_trip_obj(uid, TRIP)
+        segmente = scheduler._convert_trip_to_segments(trip, tag)
+        assert segmente, "Testaufbau prueft nichts: der Trip braucht Abschnitte"
+        scheduler._write_pending_marker(
+            trip, "morning", tag, [str(s.segment_id) for s in segmente],
+        )
+
+        assert BriefingSlotStore(uid).is_recorded_or_claimed(
+            TRIP, "morning", tag, moment=jetzt,
+        ) is True, (
+            "Ein Vermerk ohne Ausgang, der juenger als CLAIM_TTL ist, gehoert "
+            "zu einem laufenden Versand — die Faelligkeitsliste muss ihn "
+            "beruecksichtigen."
+        )
+        faellig = _faellige_ids(scheduler, jetzt)
+        assert TRIP not in faellig, (
+            f"Waehrend ein Versand laeuft, darf der Trip nicht in der "
+            f"Faelligkeitsliste stehen, gefunden: {faellig}"
+        )
+
+        scheduler._process_pending_markers(jetzt, faellig)
+        marker = _marker(uid)
+        assert marker is not None and marker.get("attempts") == 1, (
+            "Der offene Nachliefer-Marker aus #1012 muss den Lauf ueberleben "
+            f"(Versuchszaehler +1), gefunden: {marker!r}. Steht der Trip "
+            "faelschlich in der Faelligkeitsliste, verfaellt er ersatzlos."
+        )
+
+        anderer = _nutzer("1897-ac6-verwaist")
+        write_trip(anderer, TRIP, morgen_stunde=SLOT_STUNDE, abend_stunde=ABEND_STUNDE)
+        _offener_vermerk(anderer, tag, jetzt - timedelta(seconds=_ttl() * 2))
+        assert TRIP in _faellige_ids(_scheduler(anderer), jetzt), (
+            "Gegenprobe: ein verwaister Vermerk muss den Trip ZURUECK in die "
+            "Faelligkeitsliste bringen — sonst bleibt das Briefing aus."
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-9 — jenseits des Nachhol-Fensters endet beides: Nachholung und Sperre
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "minuten_nach_slot, im_fenster", [(150, True), (210, False)],
+)
+def test_ac9_nachhol_fenster_begrenzt_nachholung_und_sperre(
+    minuten_nach_slot, im_fenster,
+):
+    """AC-9.
+
+    GIVEN der Abbruch geschah so spaet, dass beim naechsten stuendlichen Lauf
+    das dreistuendige Nachhol-Fenster bereits vorbei ist
+    WHEN dieser Lauf laeuft
+    THEN wird das Briefing nicht mehr nachgeholt und die Alarm-Sperre gilt fuer
+    diesen Slot nicht mehr.
+
+    Beide Wirkorte in einem Fall, weil sie zusammen die Grenze bilden: der
+    Scheduler holt nicht mehr nach UND der Alarm darf wieder eigenstaendig
+    raus — schwiege er weiter, waere die Meldung verschluckt statt ersetzt
+    (Fehlerklasse #1555/#1584).
+
+    Der Lauf 150 Minuten nach dem Slot (Ortsstunde 9, ``7 <= 9 < 10``) ist die
+    Gegenprobe: dort MUESSEN Nachholung und Sperre noch greifen. Ohne sie
+    bewiese der 210-Minuten-Fall nur, dass irgendetwas gar nicht laeuft.
+
+    RED-Charakter: die Gegenprobe ist Fehlernachweis (heute laesst der offene
+    Vermerk den Slot als erledigt gelten, also weder Nachholung noch Sperre);
+    der Fall ausserhalb des Fensters ist Mutations-Waechter — rot, sobald die
+    Uebernahme eines verwaisten Vermerks das Fenster ``NACHHOL_FENSTER_STUNDEN``
+    umgeht und ein Briefing Stunden zu spaet nachschiebt.
+    """
+    from freezegun import freeze_time
+
+    jetzt = _slot(minuten_nach_slot)
+    with freeze_time(jetzt):
+        uid = _nutzer(f"1897-ac9-{minuten_nach_slot}")
+        write_trip(uid, TRIP, morgen_stunde=SLOT_STUNDE, abend_stunde=ABEND_STUNDE)
+        _offener_vermerk(uid, ortstag(TRIP_ZONE), _slot(120))
+
+        trip = load_trip_obj(uid, TRIP)
+        faellig = _faellige_ids(_scheduler(uid), jetzt)
+        gesperrt = _sperre_greift(uid, trip, jetzt)
+
+    if im_fenster:
+        assert TRIP in faellig, (
+            "Ortsstunde 9 liegt im Nachhol-Fenster — der verwaiste Slot muss "
+            f"nachgeholt werden, gefunden: {faellig}"
+        )
+        assert gesperrt is True, (
+            "Solange das Briefing noch nachgeholt wird, haelt die Alarm-Sperre."
+        )
+    else:
+        assert TRIP not in faellig, (
+            "Ortsstunde 10 liegt DREI Stunden hinter dem 07:00-Slot und damit "
+            f"ausserhalb des Nachhol-Fensters, gefunden: {faellig}"
+        )
+        assert gesperrt is False, (
+            "Ausserhalb des Nachhol-Fensters kommt kein Briefing mehr — der "
+            "Alarm muss wieder eigenstaendig rausgehen, sonst schweigt er ohne "
+            "Ersatz."
+        )

--- a/tests/tdd/test_briefing_slot_idempotenz.py
+++ b/tests/tdd/test_briefing_slot_idempotenz.py
@@ -216,7 +216,8 @@ def _lauf(scheduler, now_utc: datetime) -> list[tuple[str, str]]:
     """
     gesammelt = list(scheduler._collect_due_trips(now_utc))
     for trip, report_type, ortstag in gesammelt:
-        scheduler._dispatch_due_item(trip, report_type, ortstag)
+        # Issue #1897: derselbe Lauf-Zeitpunkt wandert bis in `reserve`.
+        scheduler._dispatch_due_item(trip, report_type, ortstag, now_utc=now_utc)
     return [(t.id, rt) for t, rt, _ in gesammelt]
 
 
@@ -655,11 +656,12 @@ def test_t8_ausnahme_nimmt_die_reservierung_zurueck():
         "slot-t8-ausnahme", ausnahme=RuntimeError("Kanal wirft"),
     )
 
-    trip, report_type, ortstag = scheduler._collect_due_trips(
-        _zeitpunkt(PARIS, date(2026, 8, 20), 7)
-    )[0]
+    lauf_zeitpunkt = _zeitpunkt(PARIS, date(2026, 8, 20), 7)
+    trip, report_type, ortstag = scheduler._collect_due_trips(lauf_zeitpunkt)[0]
     with pytest.raises(RuntimeError):
-        scheduler._dispatch_due_item(trip, report_type, ortstag)
+        scheduler._dispatch_due_item(
+            trip, report_type, ortstag, now_utc=lauf_zeitpunkt,
+        )
 
     assert ("korsika", "morning") in _sammlung(
         scheduler, _zeitpunkt(PARIS, date(2026, 8, 20), 8)
@@ -891,7 +893,7 @@ def test_t11_ortsvergleich_kennt_keinen_vermerk(monkeypatch):
     protokoll: list = []
 
     class _MitgeschriebenerVergleich(orchestrator.CompareDispatchStrategy):
-        def dispatch_one(self, item) -> None:
+        def dispatch_one(self, item, now_utc=None) -> None:
             protokoll.append(item[0].get("id"))
 
     monkeypatch.setitem(orchestrator._STRATEGY, "vergleich", _MitgeschriebenerVergleich)
@@ -976,7 +978,7 @@ def test_t12_on_demand_schreibt_keinen_vermerk_und_liest_keinen(caplog):
     )
 
     # b) Ein bestehender Vermerk macht den Test-Knopf nicht tot.
-    assert store.reserve("korsika", "evening", ortstag), (
+    assert store.reserve("korsika", "evening", ortstag, moment=jetzt), (
         "Testaufbau prueft nichts: die Reservierung muss frisch gelingen."
     )
     store.record_outcome("korsika", "evening", ortstag, "sent")
@@ -1251,9 +1253,8 @@ def test_t13_ohne_sperre_wird_nicht_gesendet(monkeypatch):
 
     monkeypatch.setattr(briefing_slots, "LOCK_TIMEOUT_SECONDS", 0.05, raising=False)
 
-    trip, report_type, ortstag = scheduler._collect_due_trips(
-        _zeitpunkt(PARIS, date(2026, 8, 20), 7)
-    )[0]
+    lauf_zeitpunkt = _zeitpunkt(PARIS, date(2026, 8, 20), 7)
+    trip, report_type, ortstag = scheduler._collect_due_trips(lauf_zeitpunkt)[0]
 
     verzeichnis = get_data_dir("slot-t13")
     verzeichnis.mkdir(parents=True, exist_ok=True)
@@ -1261,7 +1262,9 @@ def test_t13_ohne_sperre_wird_nicht_gesendet(monkeypatch):
     fd = os.open(sperrdatei, os.O_CREAT | os.O_RDWR, 0o644)
     try:
         fcntl.flock(fd, fcntl.LOCK_EX)
-        ergebnis = scheduler._dispatch_due_item(trip, report_type, ortstag)
+        ergebnis = scheduler._dispatch_due_item(
+            trip, report_type, ortstag, now_utc=lauf_zeitpunkt,
+        )
     finally:
         fcntl.flock(fd, fcntl.LOCK_UN)
         os.close(fd)

--- a/tests/tdd/test_briefing_slot_verwaister_claim.py
+++ b/tests/tdd/test_briefing_slot_verwaister_claim.py
@@ -1,0 +1,689 @@
+"""TDD RED — #1897: verwaister Briefing-Slot nach hartem Prozessende.
+
+SPEC: docs/specs/modules/fix_1897_verwaister_briefing_slot.md (AC-1, AC-3,
+AC-4, AC-5, AC-7, AC-8). AC-2/AC-6/AC-9 stehen in
+``test_briefing_slot_faelligkeit_und_alarmsperre.py``.
+
+Ausgangslage (real eingetreten, Trip KHW ``5f534011``, 14.08. abends und
+16.08. morgens): ein Versandprozess wird mitten im Lauf hart beendet. Zurueck
+bleibt in ``briefing_slots.json`` ein Vermerk mit ``outcome: null``, den
+``is_recorded()`` heute als „erledigt" zaehlt — das Briefing bleibt fuer den
+Rest des Ortstags aus.
+
+────────────────────────────────────────────────────────────────────────────
+Schnittstellen-Entscheidungen (die GREEN-Phase richtet sich danach)
+────────────────────────────────────────────────────────────────────────────
+1. ``services.briefing_slots.CLAIM_TTL = 900`` — MODUL-Attribut, zur Laufzeit
+   gelesen (Muster ``LOCK_TIMEOUT_SECONDS``). Kein Test schreibt die Zahl 900.
+2. ``BriefingSlotStore.reserve(trip_id, slot, local_day, zone=None, *, moment:
+   datetime) -> bool`` — ``moment`` ist PFLICHT und keyword-only (ADR-0051
+   Regel 3, kein ``datetime.now()``-Rueckfall).
+3. ``BriefingSlotStore.is_recorded_or_claimed(trip_id, slot, local_day,
+   zone=None, *, moment: datetime) -> bool`` — das zweite, eigenstaendige
+   Praedikat („abgeschlossen ODER lebendig in Arbeit") fuer
+   ``_collect_due_trips``. ``is_recorded()`` bedeutet ab jetzt ausschliesslich
+   „abgeschlossen" (``outcome`` gesetzt) plus Rueckwaerts-Ableitung.
+4. ``TripReportSchedulerService._dispatch_due_item(trip, report_type,
+   local_day, *, now_utc: datetime)`` — reicht denselben Lauf-Zeitpunkt an
+   ``reserve()`` durch.
+
+────────────────────────────────────────────────────────────────────────────
+RED-Charakter je Test
+────────────────────────────────────────────────────────────────────────────
+Der verwaiste Vermerk wird NICHT ueber die neue Schnittstelle aufgebaut,
+sondern als roher Datei-Zustand geschrieben — genau so, wie ihn ein hart
+beendeter Prozess hinterlaesst. Dadurch scheitern AC-1 und AC-5 heute am
+gemeldeten FEHLVERHALTEN (kein Versand), nicht bloss an einer fehlenden
+Signatur. AC-3/AC-4/AC-7/AC-8 nageln zusaetzlich die neue Schnittstelle fest
+und sind heute rot, weil ``reserve(..., moment=...)`` sie nicht kennt.
+
+Kein Mock-Theater: Speicher, Sperre, Schluesselbildung, Faelligkeitsfenster
+und Sammellauf laufen ECHT. Ersetzt ist an genau einer Stelle die Naht zum
+Netz — ``_send_trip_report_outcome`` — durch eine echte Unterklasse, die einen
+der dokumentierten Ausgaenge zurueckgibt und ihre Aufrufe mitschreibt.
+
+Zeit ist durchgehend PARAMETER (feste UTC-Zeitpunkte); die Ortszone des Trips
+ist ``Atlantic/Reykjavik`` (ganzjaehrig UTC+0), Ortsstunde = UTC-Stunde.
+Pfadregel #1409: alles relativ zu DIESER Datei bzw. ueber ``app.loader``.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+for _p in (str(ROOT), str(ROOT / "src")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from app.loader import get_briefings_dir, get_data_dir, load_all_trips  # noqa: E402
+from services import briefing_slots  # noqa: E402
+from services.briefing_slots import BriefingSlotStore  # noqa: E402
+
+REYKJAVIK = (64.13, -21.90)  # Atlantic/Reykjavik, ganzjaehrig UTC+0
+TRIP = "khw-1897"
+TAG = date(2026, 8, 20)
+SLOT_STUNDE = 7
+ABEND_STUNDE = 18
+
+# Die vier Ausgaenge, die einen Slot abschliessen (`trip_report_scheduler.py:94`).
+VERMERK_AUSGAENGE = ("sent", "no_stage", "no_weather", "no_channels")
+
+
+def _ttl() -> int:
+    """``CLAIM_TTL`` zur LAUFZEIT — nie als getippte Zahl im Test."""
+    return briefing_slots.CLAIM_TTL
+
+
+def _uhr(stunde: int, minute: int = 0) -> datetime:
+    return datetime(TAG.year, TAG.month, TAG.day, stunde, minute, tzinfo=timezone.utc)
+
+
+def _schreibe_trip(user_id: str) -> None:
+    """Echter Trip in ``briefings/`` (Cutover-Lesepfad #1250)."""
+    lat, lon = REYKJAVIK
+    stages = [
+        {
+            "id": f"{TRIP}-s{i}", "name": f"Etappe {i}",
+            "date": (TAG + timedelta(days=i - 1)).isoformat(),
+            "waypoints": [
+                {"id": f"{TRIP}-wp{i}a", "name": "Start",
+                 "lat": lat, "lon": lon, "elevation_m": 300},
+                {"id": f"{TRIP}-wp{i}b", "name": "Ziel",
+                 "lat": lat + 0.05, "lon": lon + 0.05, "elevation_m": 700},
+            ],
+        }
+        for i in range(3)
+    ]
+    ordner = get_briefings_dir(user_id)
+    ordner.mkdir(parents=True, exist_ok=True)
+    (ordner / f"{TRIP}.json").write_text(json.dumps({
+        "id": TRIP, "name": "Karnischer Hoehenweg", "kind": "route",
+        "stages": stages,
+        "report_config": {
+            "trip_id": TRIP, "enabled": True,
+            "morning_time": f"{SLOT_STUNDE:02d}:00:00",
+            "evening_time": f"{ABEND_STUNDE:02d}:00:00",
+            "send_email": True,
+        },
+    }), encoding="utf-8")
+
+
+def _trip_obj(user_id: str):
+    for trip in load_all_trips(user_id=user_id):
+        if trip.id == TRIP:
+            return trip
+    raise AssertionError(f"Trip {TRIP!r} nicht ladbar fuer {user_id!r}")
+
+
+def _vermerk_datei(user_id: str) -> Path:
+    return get_data_dir(user_id) / "briefing_slots.json"
+
+
+def _offener_vermerk(user_id: str, recorded_at: datetime, slot: str = "morning") -> Path:
+    """Genau der Zustand, den ein HART BEENDETER Versandprozess hinterlaesst:
+    ein Eintrag im Bestandsschema (`_eintrag()`, `briefing_slots.py:136-144`)
+    mit ``outcome: null``.
+
+    Bewusst roh geschrieben statt ueber die neue ``reserve(..., moment=...)``:
+    so misst der Test das gemeldete FEHLVERHALTEN und nicht bloss eine
+    fehlende Signatur.
+    """
+    pfad = _vermerk_datei(user_id)
+    pfad.parent.mkdir(parents=True, exist_ok=True)
+    pfad.write_text(json.dumps({"entries": [{
+        "trip_id": TRIP, "slot": slot, "local_day": TAG.isoformat(),
+        "recorded_at": recorded_at.isoformat(), "outcome": None,
+    }]}, indent=2), encoding="utf-8")
+    return pfad
+
+
+def _briefing_log(user_id: str, sent_at: datetime, slot: str = "morning") -> None:
+    """Ein regulaerer Protokoll-Eintrag — der Nachweis, dass die Mail trotz
+    verwaistem Vermerk bereits draussen ist (`_log_bezeugt_versand`)."""
+    pfad = get_data_dir(user_id) / "briefing_log.json"
+    pfad.parent.mkdir(parents=True, exist_ok=True)
+    pfad.write_text(json.dumps({"entries": [{
+        "trip_id": TRIP, "kind": slot, "sent_at": sent_at.isoformat(),
+        "channels": ["email"],
+    }]}), encoding="utf-8")
+
+
+def _zaehlende_klasse():
+    """Echter ``TripReportSchedulerService``, bei dem AUSSCHLIESSLICH die Naht
+    zum Netz ersetzt ist (Muster aus ``test_briefing_slot_idempotenz.py``)."""
+    from services.trip_report_scheduler import TripReportSchedulerService
+
+    class _MitProtokoll(TripReportSchedulerService):
+        versandversuche: list = []
+
+        def _send_trip_report_outcome(self, trip, report_type, **kwargs):
+            type(self).versandversuche.append((trip.id, report_type))
+            return "sent"
+
+    _MitProtokoll.versandversuche = []
+    return _MitProtokoll
+
+
+def _scheduler(user_id: str):
+    return _zaehlende_klasse()(user_id=user_id)
+
+
+def _voller_lauf(user_id: str, now_utc: datetime, monkeypatch) -> list:
+    """Der ECHTE Versandlauf ueber den geteilten Orchestrator — dieselbe Kette,
+    die der stuendliche Cron-Tick faehrt (``run_briefing_dispatch`` →
+    ``collect_due`` → ``pre_pass`` → ``dispatch_one``).
+
+    Bewusst NICHT ``_collect_due_trips`` + ``_dispatch_due_item`` von Hand: der
+    Lauf-Zeitpunkt muss laut Spec vom Orchestrator bis in ``reserve()``
+    durchgereicht werden; ein handgebauter Lauf saehe eine gerissene
+    Durchreichung nicht.
+    """
+    from services import trip_report_scheduler as trs
+    from services.dispatch_orchestrator import run_briefing_dispatch
+
+    from tests.helpers.briefing_imminent_fixtures import settings_email_only
+
+    klasse = _zaehlende_klasse()
+    monkeypatch.setattr(trs, "TripReportSchedulerService", klasse)
+    run_briefing_dispatch("route", user_id, now_utc, settings=settings_email_only())
+    return list(klasse.versandversuche)
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — der abgebrochene Slot wird beim naechsten stuendlichen Lauf nachgeholt
+# ---------------------------------------------------------------------------
+
+def test_ac1_verwaister_vermerk_wird_beim_naechsten_lauf_nachgeholt(monkeypatch):
+    """AC-1.
+
+    GIVEN das Morgen-Briefing wurde um 07:00 Ortszeit begonnen und der Prozess
+    endete hart, sodass ein Vermerk ohne Ausgang zurueckbleibt
+    WHEN der naechste stuendliche Lauf um 08:00 Ortszeit laeuft
+    THEN wird das Briefing verschickt und der Vermerk traegt danach den
+    Ausgang ``sent``.
+
+    Gemessen am beobachtbaren Versandaufruf, nicht per Dateiinhalt-Grep. Dass
+    der Ausgang wirklich gesetzt wurde, zeigt der dritte Lauf: waere er es
+    nicht, ginge das Briefing um 09:00 ein zweites Mal raus.
+
+    RED-Charakter: Fehlernachweis — heute zaehlt jeder gefundene Eintrag als
+    „erledigt" (`briefing_slots.py:78`), der 08:00-Lauf sendet nichts.
+    """
+    user = "u1897-ac1"
+    _schreibe_trip(user)
+    _offener_vermerk(user, _uhr(SLOT_STUNDE))
+
+    versuche = _voller_lauf(user, _uhr(SLOT_STUNDE + 1), monkeypatch)
+
+    assert versuche == [(TRIP, "morning")], (
+        "Der 07:00-Versand ist hart abgebrochen — der 08:00-Lauf muss das "
+        f"Briefing nachholen, protokolliert wurde {versuche}."
+    )
+    assert BriefingSlotStore(user).is_recorded(TRIP, "morning", TAG) is True, (
+        "Nach dem nachgeholten Versand muss der Vermerk einen Ausgang tragen "
+        "(`sent`) — sonst ist der Slot weiterhin offen."
+    )
+    assert _voller_lauf(user, _uhr(SLOT_STUNDE + 2), monkeypatch) == [], (
+        "Der 09:00-Lauf liegt noch im Nachhol-Fenster: mit gesetztem Ausgang "
+        "darf das Briefing kein zweites Mal rausgehen."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3 — ein junger Vermerk blockiert weiter (kein Doppelversand)
+# ---------------------------------------------------------------------------
+
+def test_ac3_junger_vermerk_verweigert_die_reservierung(monkeypatch):
+    """AC-3.
+
+    GIVEN ein Vermerk ohne Ausgang ist juenger als ``CLAIM_TTL``, der Versand
+    laeuft also noch
+    WHEN ein zweiter Lauf denselben Slot reservieren will
+    THEN verweigert die Reservierung und es findet kein zweiter Versand statt.
+
+    Fail-closed wie heute: ``False``, keine Ausnahme.
+
+    RED-Charakter: Mutations-Waechter — heute gruen (jeder Eintrag blockiert),
+    rot wegen der fehlenden Pflicht-Zeit in ``reserve``. NACH der Umsetzung
+    bewacht er die teuerste Verfaelschung: eine Uebernahme-Regel ohne
+    Altersgrenze wuerde hier doppelt an echte Empfaenger senden.
+    """
+    user = "u1897-ac3"
+    _schreibe_trip(user)
+    jetzt = _uhr(SLOT_STUNDE, 2)
+    _offener_vermerk(user, jetzt - timedelta(seconds=_ttl() // 9))
+
+    scheduler = _scheduler(user)
+    assert BriefingSlotStore(user).reserve(
+        TRIP, "morning", TAG, moment=jetzt,
+    ) is False, (
+        "Ein Vermerk ohne Ausgang, der juenger als CLAIM_TTL ist, gehoert zu "
+        "einem laufenden Versand — die Reservierung muss verweigert werden."
+    )
+    assert scheduler._dispatch_due_item(
+        _trip_obj(user), "morning", TAG, now_utc=jetzt,
+    ) is None, "Ohne Reservierung darf kein Versandversuch stattfinden."
+    assert scheduler.versandversuche == [], (
+        f"Kein zweiter Versandaufruf erlaubt, protokolliert: "
+        f"{scheduler.versandversuche}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 — Uebernahme des verwaisten Vermerks samt frischem Zeitstempel
+# ---------------------------------------------------------------------------
+
+def test_ac4_verwaister_vermerk_wird_mit_neuem_zeitstempel_uebernommen():
+    """AC-4.
+
+    GIVEN ein Vermerk ohne Ausgang ist aelter als ``CLAIM_TTL``
+    WHEN ein Lauf denselben Slot reservieren will
+    THEN wird der Vermerk uebernommen, sein Zeitstempel auf den neuen
+    Zeitpunkt gesetzt, und der Versand findet statt.
+
+    Der erneuerte Zeitstempel wird VERHALTENSSEITIG nachgewiesen, nicht per
+    Dateiinhalt: unmittelbar nach der Uebernahme ist der Vermerk wieder „jung"
+    — eine Reservierung knapp VOR Ablauf der neuen Frist muss scheitern.
+    Bliebe ``recorded_at`` stehen, waere der Vermerk dort laengst wieder
+    verwaist und ein dritter Lauf uebernaehme ihn (Doppelversand).
+
+    RED-Charakter: Fehlernachweis fuer die Uebernahme (heute blockiert der
+    alte Vermerk dauerhaft) — rot heute mangels ``moment``-Parameter.
+    """
+    user = "u1897-ac4"
+    _schreibe_trip(user)
+    jetzt = _uhr(SLOT_STUNDE + 1)
+    _offener_vermerk(user, jetzt - timedelta(seconds=_ttl() * 2))
+    store = BriefingSlotStore(user)
+
+    assert store.reserve(TRIP, "morning", TAG, moment=jetzt) is True, (
+        "Ein Vermerk ohne Ausgang, der aelter als CLAIM_TTL ist, stammt aus "
+        "einem hart beendeten Prozess und muss uebernommen werden."
+    )
+    assert store.reserve(
+        TRIP, "morning", TAG, moment=jetzt + timedelta(seconds=_ttl() - 1),
+    ) is False, (
+        "Nach der Uebernahme muss `recorded_at` auf den neuen Zeitpunkt "
+        "stehen — knapp vor Ablauf der Frist ist der Vermerk noch jung. "
+        "Bleibt der alte Zeitstempel stehen, uebernimmt ihn der naechste Lauf "
+        "sofort erneut."
+    )
+
+    zweiter = "u1897-ac4b"
+    _schreibe_trip(zweiter)
+    _offener_vermerk(zweiter, jetzt - timedelta(seconds=_ttl() * 2))
+    scheduler = _scheduler(zweiter)
+    assert scheduler._dispatch_due_item(
+        _trip_obj(zweiter), "morning", TAG, now_utc=jetzt,
+    ) == "sent", "Nach der Uebernahme muss der Versand tatsaechlich laufen."
+    assert scheduler.versandversuche == [(TRIP, "morning")]
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — zugestellt, aber nicht vermerkt: kein zweiter Versand
+# ---------------------------------------------------------------------------
+
+def test_ac5_bereits_zugestelltes_briefing_wird_nicht_erneut_versendet():
+    """AC-5.
+
+    GIVEN ein Vermerk ohne Ausgang ist aelter als ``CLAIM_TTL``, aber das
+    Briefing-Protokoll weist fuer denselben Trip, dieselbe Slot-Art und
+    denselben Ortstag einen regulaeren Versand aus
+    WHEN ein Lauf den Slot reservieren will
+    THEN findet kein erneuter Versand statt.
+
+    Der Prozess starb zwischen erfolgreichem Versand und ``record_outcome()``
+    — die Mail ist draussen, der Vermerk sieht verwaist aus. Der Claim wird
+    stattdessen direkt abgeschlossen; ``is_recorded()`` beweist das, denn die
+    Rueckwaerts-Ableitung schweigt hier (``briefing_slots.json`` existiert
+    bereits, `briefing_slots.py:199`).
+
+    RED-Charakter: Fehlernachweis fuer die Folge-Gefahr der Uebernahme — eine
+    Uebernahme-Regel ohne diesen Protokoll-Blick sendet das Briefing ein
+    zweites Mal an echte Empfaenger inklusive kostenpflichtiger Premium-SMS.
+    """
+    user = "u1897-ac5"
+    _schreibe_trip(user)
+    jetzt = _uhr(SLOT_STUNDE + 1)
+    _briefing_log(user, _uhr(SLOT_STUNDE, 4))
+    _offener_vermerk(user, _uhr(SLOT_STUNDE))
+    store = BriefingSlotStore(user)
+
+    assert store.reserve(TRIP, "morning", TAG, moment=jetzt) is False, (
+        "Das Protokoll bezeugt den Versand dieses Ortstags — der verwaiste "
+        "Vermerk darf NICHT uebernommen werden."
+    )
+    assert store.is_recorded(TRIP, "morning", TAG) is True, (
+        "Der Vermerk muss stattdessen direkt als `sent` abgeschlossen werden; "
+        "bliebe er offen, versuchte es jeder folgende Lauf erneut."
+    )
+    scheduler = _scheduler(user)
+    assert scheduler._dispatch_due_item(
+        _trip_obj(user), "morning", TAG, now_utc=jetzt,
+    ) is None
+    assert scheduler.versandversuche == [], (
+        f"Kein zweiter Versand, protokolliert: {scheduler.versandversuche}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-7 — zwei gleichzeitige Laeufe, genau eine Uebernahme
+# ---------------------------------------------------------------------------
+
+def test_ac7_gleichzeitige_uebernahme_gelingt_genau_einmal(monkeypatch):
+    """AC-7.
+
+    GIVEN zwei Laeufe versuchen im selben Augenblick, denselben verwaisten
+    Vermerk zu uebernehmen
+    WHEN beide reservieren wollen
+    THEN uebernimmt genau einer, der andere sendet nicht.
+
+    Gleichzeitigkeit ausschliesslich ueber ``threading.Barrier`` — keine
+    Wartezeit, keine Systemuhr.
+
+    🔴 Die Schranke liegt am GEFAHRENPUNKT: unmittelbar vor dem Erwerb der
+    Sidecar-Sperre in ``_update()`` (Adversary F003). Vor
+    ``_dispatch_due_item`` gesetzt taugte sie nicht — der Test-Versand kehrt
+    sofort zurueck, der gewinnende Thread lief deshalb meist komplett durch
+    (reserve → Versand → ``record_outcome``), bevor der zweite ueberhaupt bis
+    zu seinem Sperren-Erwerb kam. Der Test war damit gruen aus
+    Scheduling-Zufall, nicht weil der Code absichert: eine Fassung, die
+    Alterspruefung und Uebernahme trennt, kam ungestraft durch.
+
+    Ersetzt ist NICHT die Sperre — die echte ``acquire_exclusive`` laeuft
+    danach unveraendert, ebenso Speicher, Schluesselbildung und Versandkette.
+    Synchronisiert wird allein der EINSPRUNG-Zeitpunkt, und nur beim ersten
+    Sperren-Erwerb je Thread: der Gewinner nimmt die Sperre fuer
+    ``record_outcome`` gleich noch einmal und liefe sonst gegen eine Schranke,
+    an der niemand mehr wartet.
+
+    🔴 Zweite Haelfte derselben Luecke: der Test-Versand kehrte bisher SOFORT
+    zurueck, der Gewinner setzte den Ausgang also noch bevor der Verlierer
+    seine Reservierung ueberhaupt versuchte — dann rettete ihn die
+    Ausgangs-Pruefung statt der Alters-Pruefung, und die eigentliche Zusicherung
+    blieb ungeprueft. Ein echter Versand dauert Sekunden bis Minuten (die
+    ``CLAIM_TTL``-Begruendung nennt 319 s als laengsten gemessenen Einzellauf).
+    Der Versand haelt hier deshalb an, bis der andere Lauf mit seiner
+    Reservierung durch ist — laufen BEIDE in den Versand, wartet keiner mehr auf
+    den anderen und die Wartezeit laeuft ab; genau dann meldet der Test die zwei
+    Versandaufrufe.
+
+    🔴 Ausnahmen aus Threads meldet pytest nur als WARNUNG. Sie werden deshalb
+    eingesammelt und ausdruecklich assertiert — ohne das waere der Test blind.
+
+    RED-Charakter: Mutations-Waechter — rot, sobald Alterspruefung und
+    Uebernahme in ZWEI Schritte zerfallen (erst lesen, dann schreiben): dann
+    beanspruchen beide Laeufe denselben Vermerk und das Briefing geht doppelt
+    raus.
+    """
+    user = "u1897-ac7"
+    _schreibe_trip(user)
+    jetzt = _uhr(SLOT_STUNDE + 1)
+    _offener_vermerk(user, jetzt - timedelta(seconds=_ttl() * 2))
+
+    from services.trip_day import trip_tz
+
+    schranke = threading.Barrier(2)
+    anderer_fertig = threading.Event()
+    ergebnisse: list = []
+    fehler: list = []
+
+    class _MitLaufendemVersand(_zaehlende_klasse()):
+        def _send_trip_report_outcome(self, trip, report_type, **kwargs):
+            ausgang = super()._send_trip_report_outcome(trip, report_type, **kwargs)
+            anderer_fertig.wait(timeout=5)
+            return ausgang
+
+    scheduler = _MitLaufendemVersand(user_id=user)
+    trip = _trip_obj(user)
+    trip_tz(trip)  # Zonen-Aufloesung vorwaermen — nicht Teil des Rennens
+
+    echte_sperre = briefing_slots.acquire_exclusive
+    eigener_stand = threading.local()
+
+    def _sperre_nach_schranke(fd, timeout):
+        if not getattr(eigener_stand, "sync", False):
+            eigener_stand.sync = True
+            schranke.wait(timeout=15)
+        return echte_sperre(fd, timeout)
+
+    monkeypatch.setattr(briefing_slots, "acquire_exclusive", _sperre_nach_schranke)
+
+    def _versuch() -> None:
+        try:
+            ergebnisse.append(
+                scheduler._dispatch_due_item(trip, "morning", TAG, now_utc=jetzt)
+            )
+        except BaseException as exc:  # noqa: BLE001 - bewusst alles einsammeln
+            fehler.append(exc)
+        finally:
+            anderer_fertig.set()
+
+    threads = [threading.Thread(target=_versuch) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert fehler == [], f"Ausnahme in einem der beiden Laeufe: {fehler!r}"
+    assert ergebnisse.count("sent") == 1 and ergebnisse.count(None) == 1, (
+        f"Genau ein Lauf darf den verwaisten Vermerk uebernehmen, "
+        f"Ergebnisse: {ergebnisse!r}"
+    )
+    assert scheduler.versandversuche == [(TRIP, "morning")], (
+        f"Genau ein Versandaufruf erlaubt, protokolliert: "
+        f"{scheduler.versandversuche}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Frist-Mechanik — die drei Zusicherungen der Spec an ihrem Wirkort
+# (Adversary F002 Laufzeit-Lesen, F001 Grenzfall, F005 Zeitstempel)
+# ---------------------------------------------------------------------------
+
+
+def test_claim_ttl_wird_zur_laufzeit_gelesen(monkeypatch):
+    """``CLAIM_TTL`` ist ein MODUL-Attribut und wird bei jeder Pruefung neu
+    gelesen — eine beim Import gebundene lokale Konstante machte jede
+    Test-Verkuerzung der Frist still wirkungslos (Adversary F002).
+
+    Gemessen am Verhalten: DERSELBE Vermerk, DERSELBE Zeitpunkt, nur die Frist
+    wird gesenkt — und aus „laufender Versand" wird „verwaist". Bindet der Code
+    die Frist beim Import, bleibt die zweite Antwort ``False``.
+    """
+    user = "u1897-ttl-laufzeit"
+    _schreibe_trip(user)
+    jetzt = _uhr(SLOT_STUNDE + 1)
+    alter = _ttl() // 3
+    _offener_vermerk(user, jetzt - timedelta(seconds=alter))
+    store = BriefingSlotStore(user)
+
+    assert store.reserve(TRIP, "morning", TAG, moment=jetzt) is False, (
+        "Testaufbau prueft nichts: der Vermerk muss unter der REGULAEREN Frist "
+        "noch als lebendig gelten."
+    )
+    monkeypatch.setattr(briefing_slots, "CLAIM_TTL", alter // 2)
+    assert store.reserve(TRIP, "morning", TAG, moment=jetzt) is True, (
+        "Mit gesenkter Frist ist derselbe Vermerk verwaist — wird CLAIM_TTL "
+        "nicht zur Laufzeit gelesen, bleibt die Frist unerreichbar und jeder "
+        "TTL-Test misst nur noch den Vorgabewert."
+    )
+
+
+@pytest.mark.parametrize("versatz, uebernommen", [(0, False), (1, True)])
+def test_grenzfall_exakt_ttl_gilt_noch_nicht_als_verwaist(versatz, uebernommen):
+    """Grenzfall der Frist (Adversary F001): „exakt ``CLAIM_TTL`` alt" ist NOCH
+    NICHT verwaist, erst eine Sekunde darueber.
+
+    Fail-closed wie ueberall in diesem Speicher — auf der Kippe lieber ein
+    ausgelassener Slot als ein Doppelversand. Ohne diese Zusicherung waere der
+    Wechsel von ``>`` auf ``>=`` ein unbemerkter Schritt in die teure Richtung.
+    """
+    user = f"u1897-ttl-grenze-{versatz}"
+    _schreibe_trip(user)
+    jetzt = _uhr(SLOT_STUNDE + 1)
+    _offener_vermerk(user, jetzt - timedelta(seconds=_ttl() + versatz))
+
+    assert BriefingSlotStore(user).reserve(
+        TRIP, "morning", TAG, moment=jetzt,
+    ) is uebernommen, (
+        f"Ein Vermerk, der exakt CLAIM_TTL plus {versatz} s alt ist, muss "
+        f"{'uebernommen werden' if uebernommen else 'blockieren'}."
+    )
+
+
+def test_neuer_vermerk_traegt_den_lauf_zeitpunkt():
+    """Ein FRISCH angelegter Vermerk bekommt sein ``recorded_at`` vom
+    uebergebenen Lauf-Zeitpunkt, nicht von der Systemuhr (Adversary F005).
+
+    Sonst maesse die Verwaisungs-Frist gegen einen anderen Zeitstrahl als den
+    des Aufrufers — der Vermerk waere je nach Abstand der beiden Uhren sofort
+    verwaist (Doppelversand) oder nie (dauerhafter Ausfall).
+
+    Verhaltensseitig gemessen, nicht per Dateiinhalt: die Frist wird von BEIDEN
+    Seiten angefahren. Ein Rueckfall auf die Systemuhr verschiebt den
+    Kipppunkt und laesst eine der beiden Zusicherungen scheitern, egal in
+    welche Richtung die Uhren auseinanderliegen.
+    """
+    user = "u1897-neuer-vermerk"
+    _schreibe_trip(user)
+    jetzt = _uhr(SLOT_STUNDE)
+    store = BriefingSlotStore(user)
+
+    assert store.reserve(TRIP, "morning", TAG, moment=jetzt) is True, (
+        "Ohne Vermerk und ohne Protokoll muss die erste Reservierung gelingen."
+    )
+    assert store.reserve(
+        TRIP, "morning", TAG, moment=jetzt + timedelta(seconds=_ttl()),
+    ) is False, (
+        "Gemessen vom uebergebenen Lauf-Zeitpunkt aus ist der Vermerk nach "
+        "genau CLAIM_TTL noch lebendig — traegt er stattdessen die Systemuhr, "
+        "liegt der Kipppunkt woanders."
+    )
+    assert store.reserve(
+        TRIP, "morning", TAG, moment=jetzt + timedelta(seconds=_ttl() + 1),
+    ) is True, (
+        "Eine Sekunde spaeter ist derselbe Vermerk verwaist — bleibt er "
+        "blockiert, misst die Frist gegen einen fremden Zeitstrahl."
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-8 — Bestandsvermerke bleiben abgeschlossen, ohne Migration
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("ausgang", VERMERK_AUSGAENGE)
+def test_ac8_bestandsvermerke_bleiben_abgeschlossen(ausgang: str):
+    """AC-8.
+
+    GIVEN Bestandseintraege, die vor dieser Aenderung geschrieben wurden
+    WHEN sie gelesen werden
+    THEN verhalten sich abgeschlossene Vermerke unveraendert und es ist keine
+    Datenmigration noetig.
+
+    Der Zeitstempel liegt bewusst ZEHN TAGE zurueck: eine Verwaisungs-Regel,
+    die nur aufs Alter schaut und ``outcome`` uebersieht, uebernaehme diese
+    Eintraege und sendete jedes abgeschlossene Briefing erneut. Genau das
+    faengt die dritte Zusicherung.
+
+    „Keine Migration" wird als Byte-Gleichheit der Speicherdatei vor/nach dem
+    Lesen gemessen — es geht um einen ausgebliebenen SCHREIBVORGANG, nicht um
+    einen Textbeleg fuer Verhalten.
+
+    RED-Charakter: Mutations-Waechter — heute strukturell erfuellt, rot wegen
+    der beiden neuen Signaturen; danach bewacht er die Alters-Dimension gegen
+    den teuersten Fehlgriff.
+    """
+    user = f"u1897-ac8-{ausgang}"
+    _schreibe_trip(user)
+    jetzt = _uhr(SLOT_STUNDE + 1)
+    pfad = _offener_vermerk(user, jetzt - timedelta(days=10))
+    daten = json.loads(pfad.read_text(encoding="utf-8"))
+    daten["entries"][0]["outcome"] = ausgang
+    pfad.write_text(json.dumps(daten, indent=2), encoding="utf-8")
+    vorher = pfad.read_bytes()
+
+    store = BriefingSlotStore(user)
+    assert store.is_recorded(TRIP, "morning", TAG) is True, (
+        f"Ausgang '{ausgang}' schliesst den Slot ab — `is_recorded` muss ihn "
+        "unveraendert als erledigt melden."
+    )
+    assert store.is_recorded_or_claimed(
+        TRIP, "morning", TAG, moment=jetzt,
+    ) is True, (
+        f"Auch das Faelligkeits-Praedikat muss den abgeschlossenen Ausgang "
+        f"'{ausgang}' kennen — sonst sammelt der Scheduler den Slot erneut ein."
+    )
+    assert store.reserve(TRIP, "morning", TAG, moment=jetzt) is False, (
+        f"Ein zehn Tage alter, mit '{ausgang}' abgeschlossener Vermerk ist "
+        "NICHT verwaist — wer nur aufs Alter sieht, sendet ihn erneut."
+    )
+    assert pfad.read_bytes() == vorher, (
+        "Bestandsdaten duerfen beim Lesen nicht umgeschrieben werden — es gibt "
+        "keine Migration."
+    )
+
+
+def test_ac8_unbekannter_ausgang_schliesst_den_slot_ebenfalls_ab():
+    """AC-8, Ergaenzung: „abgeschlossen" heisst ``outcome`` GESETZT, nicht
+    ``outcome`` aus einer bekannten Menge.
+
+    GIVEN ein Vermerk traegt einen Ausgang, den dieser Speicher nicht kennt —
+    einen kuenftigen fuenften Wert des Schedulers
+    WHEN die beiden Praedikate ihn lesen
+    THEN gilt der Slot als abgeschlossen und wird nicht uebernommen.
+
+    Die Spec begruendet das ausdruecklich („Implementation Details", Zustand 1):
+    pruefte der Speicher die Zugehoerigkeit zu ``VERMERK_AUSGAENGE``, entschiede
+    er ueber die Ausgangs-Auswahl des Schedulers mit — und ein neuer fuenfter
+    Ausgang fiele still auf „nicht erledigt" zurueck, also GENAU in den Fehler,
+    den Issue #1897 behebt: ein zugestelltes Briefing ginge erneut raus.
+
+    ``test_ac8_bestandsvermerke_bleiben_abgeschlossen`` kann das nicht sehen —
+    es ist ueber ``VERMERK_AUSGAENGE`` parametrisiert und faehrt damit nur die
+    vier Werte, fuer die beide Lesarten dasselbe Ergebnis liefern. Dieser Fall
+    fuehrt deshalb einen ERFUNDENEN Ausgang ein; dass er wirklich unbekannt
+    ist, wird gegen die echte Menge des Schedulers gemessen, nicht angenommen.
+
+    Der Zeitstempel liegt weit jenseits von ``CLAIM_TTL``: so zeigt jede der
+    drei Zusicherungen, dass der AUSGANG entscheidet und nicht das Alter.
+    """
+    from services.trip_report_scheduler import VERMERK_AUSGAENGE as ECHTE_MENGE
+
+    fremder = "onboard_error"
+    assert fremder not in ECHTE_MENGE, (
+        f"Testaufbau prueft nichts: '{fremder}' ist inzwischen ein bekannter "
+        f"Ausgang ({sorted(ECHTE_MENGE)}) — es braucht einen anderen."
+    )
+
+    user = "u1897-ac8-fremder-ausgang"
+    _schreibe_trip(user)
+    jetzt = _uhr(SLOT_STUNDE + 1)
+    pfad = _offener_vermerk(user, jetzt - timedelta(seconds=_ttl() * 10))
+    daten = json.loads(pfad.read_text(encoding="utf-8"))
+    daten["entries"][0]["outcome"] = fremder
+    pfad.write_text(json.dumps(daten, indent=2), encoding="utf-8")
+
+    store = BriefingSlotStore(user)
+    assert store.is_recorded(TRIP, "morning", TAG) is True, (
+        f"Ein gesetzter Ausgang schliesst den Slot ab, auch wenn dieser "
+        f"Speicher ihn nicht kennt ('{fremder}') — sonst haelt die Alarm-Sperre "
+        "fuer einen bereits erledigten Slot weiter."
+    )
+    assert store.is_recorded_or_claimed(
+        TRIP, "morning", TAG, moment=jetzt,
+    ) is True, (
+        f"Auch das Faelligkeits-Praedikat muss '{fremder}' als Abschluss "
+        "lesen — sonst sammelt der Scheduler den Slot erneut ein."
+    )
+    assert store.reserve(TRIP, "morning", TAG, moment=jetzt) is False, (
+        f"Ein mit '{fremder}' abgeschlossener Vermerk ist NICHT verwaist, egal "
+        "wie alt er ist — wer nur bekannte Ausgaenge gelten laesst, sendet das "
+        "Briefing ein zweites Mal an echte Empfaenger."
+    )

--- a/tests/tdd/test_dispatch_orchestrator.py
+++ b/tests/tdd/test_dispatch_orchestrator.py
@@ -162,7 +162,7 @@ def test_compare_pauses_between_presets_but_not_after_the_last():
         def pre_pass(self, hour, due):
             return None
 
-        def dispatch_one(self, item):
+        def dispatch_one(self, item, now_utc=None):
             self.dispatch_times.append(time.monotonic())
 
     user_id = _fresh_user_id("delay")


### PR DESCRIPTION
## Problem

Ein Briefing-Versand, den ein hartes Prozessende (Deploy, SIGKILL, OOM) mitten im Lauf abbricht, hinterliess im Slot-Speicher einen Vermerk mit `outcome: null`, den `is_recorded()` als "erledigt" zaehlte.

Folge: das Briefing blieb fuer den Rest des Ortstags aus — **und** die Alarm-Vorlauf-Sperre aus #1594 hob sich auf, der Nutzer bekam also einen Alarm, obwohl nie ein Briefing kam. Real eingetreten auf Trip KHW `5f534011` am 14.08. (evening) und 16.08. (morning).

## Loesung

Drei Zustaende statt zwei:

| Zustand | Bedingung | Verhalten |
|---|---|---|
| abgeschlossen | `outcome` gesetzt | zaehlt als erledigt |
| lebendig in Arbeit | offen, juenger als `CLAIM_TTL` (900 s) | Versand laeuft, blockiert |
| verwaist | offen, aelter als `CLAIM_TTL` | wird uebernommen und nachgeholt |

**Die beiden Wirkorte bekommen bewusst verschiedene Praedikate:** `trip_briefing_due_at()` fragt "steht noch ein Briefing aus?" (`is_recorded`, Alter egal — die Alarm-Sperre muss halten), `_collect_due_trips()` fragt "findet jetzt ein Versand statt?" (`is_recorded_or_claimed`, Alter entscheidet).

**Doppelversand-Schutz:** Alterspruefung und Uebernahme liegen in EINER `_update()`-Closure unter derselben Sidecar-Sperre. Bezeugt `briefing_log.json` fuer den Ortstag bereits einen Versand (Prozess starb zwischen Versand und `record_outcome`), wird der Vermerk direkt mit `sent` abgeschlossen statt erneut gesendet — sonst ginge das Briefing ein zweites Mal an echte Empfaenger inklusive kostenpflichtiger Premium-SMS.

`reserve()` und `is_recorded_or_claimed()` nehmen `moment` als Pflicht-Keyword ohne `datetime.now()`-Rueckfall (ADR-0051 Regel 3); ein einziger Zeitpunkt wandert vom Orchestrator bis in die Reservierung.

## Nachweis

23 Tests ueber AC-1..AC-9, Adversary-Verdict **VERIFIED** nach 4 Runden.

Bemerkenswert: die Runden deckten **keinen Logikfehler** auf, sondern sechs Stellen, an denen eine Zusicherung im Code korrekt, aber von keinem Test bewacht war:

- Doppelversand-Schutz — Gegenprobe vorher 0 von 20 gefangen, jetzt 5 von 5 (die Thread-Schranke lag vor dem Versand statt am Sperren-Erwerb)
- Wirkort-Zuordnung der beiden Praedikate — vertauscht wurde vorher kein Test rot, weil die 60-Minuten-Abtastung der Alarm-Sperre den Kipppunkt ueberdeckte
- Grenzfall exakt `CLAIM_TTL`, Laufzeit-Lesbarkeit der Frist, Zeitstempel-Herkunft bei Neuanlage, unbekannter fuenfter Ausgang

Regressionslauf ueber 102 Dateien: 2488 gruen. Nach Rebase auf `origin/main`: 124 gruen in den beruehrten Dateien.

## Scope

Produktivcode ausschliesslich in den drei Spec-Dateien (`briefing_slots.py`, `trip_report_scheduler.py`, `dispatch_orchestrator.py`), +157 Zeilen. `#1725` wird **praezisiert, nicht abgeloest** — Doppelversand-Schutz bleibt in `reserve()`, fail-closed bleibt die Fehlerrichtung; die #1725-Spec traegt den Nachtrag.

Spec: `docs/specs/modules/fix_1897_verwaister_briefing_slot.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
