### PR TITLE
docs(#1708 A): Doku nennt nicht mehr den toten trips/-Pfad

### DIFF
--- a/docs/features/weather_snapshot_service.md
+++ b/docs/features/weather_snapshot_service.md
@@ -93,7 +93,10 @@ Folgt dem bestehenden Persistence-Pattern von `alert_throttle.json`:
    Timeseries — das haelt die Snapshot-Dateien klein (~1-2 KB pro Trip)
 2. **Ein Snapshot pro Trip** (nicht pro Stage/Segment) — wird bei jedem Report ueberschrieben
 3. **Multiuser via `user_id` Parameter** — folgt bestehendem Pattern aus `loader.py`:
-   `get_data_dir(user_id="default")`, `get_trips_dir(user_id="default")`, etc.
+   `get_data_dir(user_id="default")`, `get_briefings_dir(user_id="default")`, etc.
+   (Stand zum Schreibzeitpunkt hieß der Trip-Helfer `get_trips_dir`; seit
+   ADR-0023 / #1250 S7a ist `get_briefings_dir` der lebende Pfad, `trips/`
+   ist toter Bestand.)
 4. **Keine Historisierung** — nur der letzte Snapshot wird gespeichert.
    Fuer History koennte spaeter ein Timestamp ins Filename (z.B. `{trip_id}_{date}.json`)
 
@@ -120,6 +123,10 @@ Deserialisierung:
 
 ### Bestehendes Multi-Tenant Layout (Referenz)
 
+> Stand zum Schreibzeitpunkt (vor dem Cutover ADR-0023 / #1250 S7a,
+> 2026-07-15). Trips liegen seither unter `briefings/<id>.json`;
+> `trips/` ist toter Bestand (Issue #1708).
+
 ```
 data/users/{user_id}/
 ├── alert_throttle.json
@@ -127,7 +134,7 @@ data/users/{user_id}/
 ├── gpx/
 ├── locations/
 │   └── {location_id}.json
-├── trips/
+├── briefings/                   ← Trips (seit ADR-0023 / #1250 S7a; war `trips/`)
 │   └── {trip_id}.json
 └── weather_snapshots/           ← NEU
     └── {trip_id}.json
@@ -140,8 +147,8 @@ data/users/{user_id}/
 def get_data_dir(user_id: str = "default") -> Path:
     return Path("data/users") / user_id
 
-def get_trips_dir(user_id: str = "default") -> Path:
-    return get_data_dir(user_id) / "trips"
+def get_briefings_dir(user_id: str = "default") -> Path:
+    return get_data_dir(user_id) / "briefings"
 
 # NEU:
 def get_snapshots_dir(user_id: str = "default") -> Path:

--- a/docs/project/known_issues.md
+++ b/docs/project/known_issues.md
@@ -336,6 +336,12 @@ getriggertes Alerting (kein `sync.Once`, damit ein späterer Re-Onset nicht vers
 optional eine Recovery-Notiz (Priorität `normal`). Kein neuer BetterStack-Heartbeat (Quota
 erschöpft).
 
+> **Korrektur 2026-08-16 (#1708):** `probeDataWritable()` traversiert seit dem
+> Persistenz-Cutover (ADR-0023 / #1250 S7a, 2026-07-15) `users/<id>/briefings/`,
+> nicht mehr `users/<id>/trips/` (`internal/scheduler/selftest.go:13-15,42`).
+> Der Fix-Text oben beschreibt den Stand zum Implementierungszeitpunkt
+> (2026-07-08, vor dem Cutover) und wurde nicht nachgezogen.
+
 ### Files Changed
 
 - `internal/scheduler/selftest.go` (NEU) — `probeDataWritable(dataDir string) error`

--- a/docs/reference/api_contract.md
+++ b/docs/reference/api_contract.md
@@ -736,7 +736,7 @@ Feld-Definitionen und Validierungsregeln: massgeblich sind die Go-Structs in
 
 ## 10.5) Trip Model and Activity Types (Issue #674)
 
-Trip-Daten werden als JSON unter `data/users/{userID}/trips/{trip_id}.json` gespeichert. Das Kernmodell definiert Etappen, Wegpunkte und Konfiguration.
+Trip-Daten werden als JSON unter `data/users/{userID}/briefings/{trip_id}.json` gespeichert (seit ADR-0023 / #1250 S7a; `trips/` ist toter Bestand, Issue #1708). Das Kernmodell definiert Etappen, Wegpunkte und Konfiguration.
 
 ### Trip DTO
 
@@ -1334,7 +1334,7 @@ Triggers immediate test briefing send for one trip. Returns success/failure base
 
 **Multi-Tenant Behavior:**
 - `user_id` query parameter determines which user's data (trip, email config) is used
-- Trip must exist in `data/users/{user_id}/trips/` directory
+- Trip must exist in `data/users/{user_id}/briefings/` directory (seit ADR-0023 / #1250 S7a; `trips/` ist toter Bestand, Issue #1708)
 - Email sent to `settings.mail_to` for that user (set via `/api/auth/profile`)
 - Default `user_id="default"` provided for backwards compatibility (e.g. test-mode without auth)
 

--- a/docs/specs/modules/feat_1728_s1_temp_aufloesung.md
+++ b/docs/specs/modules/feat_1728_s1_temp_aufloesung.md
@@ -476,7 +476,7 @@ keine Änderung nötig).
   - Test: `TripReportFormatter().format_email().email_compact`, Parsing der Kachel-Zeile; dritter der drei Wirkort-Nachweise für DEC-5 (nicht `build_metrics_summary_pills()` direkt aufrufen).
 
 - **AC-8:** Given ein gespeicherter Bestands-Trip mit `temperature: {enabled: true, aggregations: ["min"]}` und **ohne** explizite Einträge für `temperature_day_low`/`temperature_day_high` / When der Trip geladen und das Abend-Briefing als SMS erzeugt wird / Then enthält die SMS `K`, aber kein `D` — die Bestands-Ableitung wirkt im Ladepfad (`loader.py`), nicht nur im Katalog-Default.
-  - Test: Roundtrip mit echtem Bestands-JSON-Fixture (Format wie `data/users/<uid>/trips/*.json`), Rendering-Assertion.
+  - Test: Roundtrip mit echtem Bestands-JSON-Fixture (Format wie `data/users/<uid>/briefings/*.json`, seit ADR-0023 / #1250 S7a; die versionierte Fixture-Quelle liegt unter `tests/fixtures/data_root/.../trips/` und wird von der Session-Fixture nach `briefings/` gespiegelt), Rendering-Assertion.
 
 - **AC-9:** Given ein gespeicherter Bestands-Trip mit `wind_chill: {enabled: true}` (impliziter Default `["min","max"]`) und ohne explizite Tagesrichtungs-Einträge / When der Trip geladen und das Briefing erzeugt wird / Then enthält die SMS `FK` **und** `FD` — der Default-Fall (16 von 17 Bestandstrips) verliert keine Tagesrichtung.
   - Test: wie AC-8, Default-Fall statt Einzelauswahl.
@@ -484,7 +484,7 @@ keine Änderung nötig).
 - **AC-10:** Given ein geladener Bestands-Trip ohne explizite Tagesrichtungs-Einträge / When der Trip ohne inhaltliche Änderung erneut gespeichert wird / Then enthält die gespeicherte Datei weiterhin **keine** expliziten Einträge für die vier neuen IDs, und alle übrigen `display_config`-Felder bleiben unverändert (Merge, kein Replace, kein Zurückschreiben abgeleiteter Einträge).
   - Test: Load → Save-Roundtrip gegen ein Fixture-Verzeichnis, Diff der gespeicherten JSON gegen das Original abzüglich absichtlicher Änderungen.
 
-- **AC-11:** Given `data/users/default/trips/gr221-mallorca.json` (`temperature: ["min","max","avg"]`, `wind_chill: ["min"]`) / When der Trip geladen und das Abend-Briefing als SMS erzeugt wird / Then enthält die SMS `K` **und** `D` (der entfallende Mittelwert kostet keine Tagesrichtung) sowie `FK`, aber **nicht** `FD`.
+- **AC-11:** Given `data/users/default/briefings/gr221-mallorca.json` (seit ADR-0023 / #1250 S7a; die Fixture-Quelle liegt unter `tests/fixtures/data_root/.../trips/gr221-mallorca.json` und wird testseitig nach `briefings/` gespiegelt — `load_trip` liest ausschließlich dort) (`temperature: ["min","max","avg"]`, `wind_chill: ["min"]`) / When der Trip geladen und das Abend-Briefing als SMS erzeugt wird / Then enthält die SMS `K` **und** `D` (der entfallende Mittelwert kostet keine Tagesrichtung) sowie `FK`, aber **nicht** `FD`.
   - Test: Rendering direkt gegen die reale Bestandsdatei (kein synthetisches Fixture), vollständige Token-Assertion für alle sechs Temperatur-Symbole (inkl. `N`/`FN`/`WC` unverändert).
 
 - **AC-12:** Given zwei verschiedene Nutzer mit entgegengesetzter Auswahl (Nutzer A: nur `temperature_day_high` und `wind_chill_day_low`; Nutzer B: nur `temperature_day_low` und `wind_chill_day_high`) / When beide ihr Abend-Briefing erzeugen / Then wirkt jeweils nur die eigene Auswahl — keine Vermischung über `user_id`-Grenzen.

--- a/docs/specs/modules/fix_1660a_temp_trennung.md
+++ b/docs/specs/modules/fix_1660a_temp_trennung.md
@@ -316,7 +316,7 @@ Katalog-Default (`default_enabled=True`) mitführt.
   - Test: SMS-Rendering mit `aggregations=["avg"]`, Assertion auf beide Symbole abwesend; dazu ein E-Mail-Rendering, das den Mittelwert-Pill weiterhin nachweist (DEC-1, kein stiller Totalverlust der Größe über alle Kanäle).
 
 - **AC-8:** Given ein gespeicherter Bestands-Trip mit aktivierter „Gefühlter Temperatur" und **ohne** `wind_chill_night`-Eintrag / When der Trip geladen und das Abend-Briefing erzeugt wird / Then erscheint `FN` genau wie vor der Änderung, und ein anschließender Config-Save erhält alle übrigen `display_config`-Felder (Merge, kein Replace, kein Zurückschreiben des abgeleiteten Eintrags).
-  - Test: Roundtrip mit echtem Bestands-JSON-Fixture (Format wie `data/users/<uid>/trips/*.json`); geprüft wird sowohl das gerenderte Token als auch die gespeicherte Datei nach dem Save.
+  - Test: Roundtrip mit echtem Bestands-JSON-Fixture (Format wie `data/users/<uid>/briefings/*.json`, seit ADR-0023 / #1250 S7a); geprüft wird sowohl das gerenderte Token als auch die gespeicherte Datei nach dem Save.
 
 - **AC-9:** Given ein gespeicherter Bestands-Trip mit **deaktivierter** „Gefühlter Temperatur" / When der Trip geladen wird / Then ist „Gefühlte Nacht-Tiefsttemperatur" abgeleitet AUS — es taucht kein neues Token unangefordert im Briefing auf.
   - Test: Ableitung beide Richtungen, zusätzlich der Fall „Metrikliste komplett leer" (Altbestand ohne `display_config`) — dort wird **kein** Eintrag erfunden.

--- a/docs/specs/modules/issue_221_validator_observability_endpoints.md
+++ b/docs/specs/modules/issue_221_validator_observability_endpoints.md
@@ -44,7 +44,7 @@ und nicht für Frontend/Endbenutzer.
 | `src.formatters.trip_report.TripReportFormatter.format_email` | aufgerufen | SSoT-Renderer für Endpoint #2 (`report_type="alert"`, `changes=…`). |
 | `src.services.trip_alert.TripAlertService._select_change_detector` | aufgerufen | Kanonische Detector-Auswahllogik für Endpoint #3 (alert_rules > display_config > report_config > defaults). |
 | `src.services.weather_change_detection.WeatherChangeDetectionService` | konsumiert | Endpoint #3 liest `_thresholds`-Dict des gewählten Detectors. |
-| `src.app.loader._parse_trip` + `get_trips_dir` | aufgerufen | User-scoped Trip-Lookup für Endpoint #2 + #3 via Helper `_load_trip_for_validator` (Begründung siehe Implementation Details). |
+| `src.app.loader._parse_trip` + `get_briefings_dir` | aufgerufen | User-scoped Trip-Lookup für Endpoint #2 + #3 via Helper `_load_trip_for_validator` (Begründung siehe Implementation Details; seit ADR-0023 / #1250 S7a `briefings/<id>.json`, nicht mehr `trips/`). |
 | `src.app.models.WeatherChange, SegmentWeatherData, SegmentWeatherSummary, TripSegment, NormalizedTimeseries, ForecastMeta, Provider` | konsumiert | DTOs für Stub-Konstruktion im Body von Endpoint #2. |
 | `internal/middleware/auth.go::AuthMiddleware` | genutzt | Globale `gz_session`-Cookie-Auth — `_validator/`- und `alert-preview`-Pfade NICHT auf die Whitelist. |
 | `internal/handler/proxy.go::appendUserID` | genutzt | Anti-Spoofing-Pattern (Bug #199) — Go-Proxy injiziert authentifizierten `user_id` als Query-Param. |
@@ -73,7 +73,8 @@ Auto-Transformationen aus, die für Validator-Beobachtung problematisch sind:
 Lösung im Router:
 
 - **`_load_trip_raw(user_id, trip_id) → dict | None`**: liest die JSON-Datei via
-  `get_trips_dir(user_id)` direkt (kein Parsing, keine Migration).
+  `get_briefings_dir(user_id)` direkt (kein Parsing, keine Migration; seit
+  ADR-0023 / #1250 S7a, nicht mehr `get_trips_dir`).
 - **`_load_trip_for_validator(user_id, trip_id) → Trip | None`**: ruft
   `_load_trip_raw` und delegiert an `_parse_trip`. **Wenn** `data["stages"]` leer
   ist, wird **nur dann** ein einzelner Placeholder-Stage injiziert (mit einem

--- a/docs/specs/modules/preview_service.md
+++ b/docs/specs/modules/preview_service.md
@@ -32,7 +32,7 @@ Detail-Spec: `docs/specs/_archive/modules/epic_140_output_vorschau.md` (Master).
 | Entity | Type | Purpose |
 |--------|------|---------|
 | `app.config.Settings` | bestehend | User-Profil-Routing |
-| `app.loader.load_trip` / `get_trips_dir` | bestehend | Trip-File laden |
+| `app.loader.load_trip` / `get_briefings_dir` | bestehend | Trip-File laden (seit ADR-0023 / #1250 S7a `briefings/<id>.json`, nicht mehr `trips/`) |
 | `services.trip_report_scheduler.TripReportSchedulerService` | bestehend | Pipeline-Helper (Segments, Wetter) |
 | `formatters.trip_report.TripReportFormatter` | bestehend | Email-Render |
 
@@ -54,7 +54,7 @@ class PreviewService:
 ## Acceptance Criteria
 
 - **AC-1:** Given gültiger Trip + Stage am Zieldatum / When `render_email_preview` läuft / Then liefert es das `email_html` aus `TripReportFormatter.format_email()`
-- **AC-2:** Given Trip-ID nicht in `data/users/<user>/trips/` / When der Service aufgerufen wird / Then `FileNotFoundError`
+- **AC-2:** Given Trip-ID nicht in `data/users/<user>/briefings/` (seit ADR-0023 / #1250 S7a; vorher `trips/`) / When der Service aufgerufen wird / Then `FileNotFoundError`
 - **AC-3:** Given Trip ohne Stage am Zieldatum / When der Service aufgerufen wird / Then `LookupError` mit "Keine Stage am ..." Meldung. Abgrenzung (Issue #990): existiert am Zieldatum eine Stage, hat sie aber weniger als 2 Wegpunkte, wirft der Service ebenfalls `LookupError`, jedoch mit einem Text, der das Wort „waypoints" enthält — dieser Fall ist von „keine Stage am Datum" zu unterscheiden. Details: `docs/specs/_archive/modules/fix_990_preview_empty_waypoints.md`.
 - **AC-4:** Given Wetter-Provider liefert keine Daten (Rate-Limit etc.) / When der Service aufgerufen wird / Then `RuntimeError`
 - **AC-5:** Given `report_type` weder "morning" noch "evening" / When der Service aufgerufen wird / Then `ValueError`


### PR DESCRIPTION
Nachtrag zu #1708 Scheibe A (live seit `05086722`).

Der Wächter aus Scheibe A scannt `docs/` bewusst nicht — dort stand die Falle deshalb weiter. Mehrere **aktive** Dokumente beschrieben `data/users/<uid>/trips/<id>.json` bzw. `get_trips_dir()` als aktuellen Ablage- oder Lesepfad, obwohl seit ADR-0023 ausschließlich `briefings/<id>.json` gilt. Genau die Fehlerklasse, die #1708 erzeugt hat: eine plausible Beschreibung, die auf einen toten Pfad zeigt.

Der wichtigste Fund war `docs/reference/api_contract.md` — die Single Source of Truth für DTOs und Datenformate.

| Datei | Was |
|---|---|
| `docs/reference/api_contract.md` | Trip-Model (§10.5) und Multi-Tenant-Abschnitt |
| `docs/specs/modules/preview_service.md` | Dependencies + AC-2 |
| `docs/specs/modules/issue_221_validator_observability_endpoints.md` | Dependencies + Implementation Details |
| `docs/features/weather_snapshot_service.md` | Layout- und Loader-Abschnitte |
| `docs/specs/modules/feat_1728_s1_temp_aufloesung.md`, `fix_1660a_temp_trennung.md` | Unterscheidung Fixture-Quelle vs. Lesepfad präzisiert |
| `docs/project/known_issues.md` | Korrekturvermerk zu `probeDataWritable()` |

**Jede Korrektur ist am Code belegt**, nicht angenommen — z. B. `src/services/preview_service.py:18,67` und `api/routers/validator.py:23,52` für die `get_briefings_dir`-Nutzung, `internal/scheduler/selftest.go:42` für den Selbsttest-Pfad.

**Bewusst unverändert:** historische Aussagen, die `trips/` korrekt als Vorher-Zustand beschreiben (Forensik zu BUG-DATALOSS-GR221, BUG-1264-CUTOVER-DEPLOY), alle `/api/trips/…`-Routenpfade (die heißen weiterhin so), und `docs/specs/_archive/`.

Reine Doku-Änderung, kein Code — Staging- und Prod-Schritt entfallen nach der Ausnahmeregel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)