### PR TITLE
fix(#1896): CIN-Baender fuer ICON auf ECMWF TM 852 umstellen

### DIFF
--- a/docs/context/fix-1896-cin-eichung-icon.md
+++ b/docs/context/fix-1896-cin-eichung-icon.md
@@ -1,0 +1,279 @@
+# Context: fix-1896-cin-eichung-icon
+
+Issue: [#1896](https://github.com/henemm/gregor_zwanzig/issues/1896) — „Gewitter: CIN-Baender fuer ICON
+ungeeicht (US-MLCIN-100hPa-Werte auf 50-hPa-Mischschicht)"
+Erstellt: 2026-08-16 · Track: Full Process (Intake-Summe 5)
+
+## Request Summary
+
+Die vier CIN-Baender, mit denen wir die aus CAPE abgeleitete Gewitterstufe daempfen, stammen aus
+US-Vorhersagepraxis fuer **MLCIN ueber 100 hPa** (pseudoadiabatisch, negativ gezaehlt). Unsere CIN-Werte
+kommen aber ausschliesslich aus **ICON** (DWD), das ueber **50 hPa** mischt, **reversibel** und **ohne
+Entrainment** rechnet. Dieselbe Zahl bedeutet damit je Modell etwas anderes — dieselbe Fehlerklasse wie
+ADR-0048 („CAPE != CAPE"), eine Ebene tiefer. Das Ticket soll die Baender fuer ICON eichen, und zwar
+**vorrangig ueber publizierte Werte** (PO-Vorgabe 2026-08-16: keine Grundlagenforschung).
+
+## Ist-Stand im Code (gemessen 2026-08-16)
+
+`src/output/metric_format.py:325-376` — `_gedaempft_durch_cin(basis, cin_jkg)`:
+
+| Bedingung (Code) | Zeile | Wirkung |
+|---|---|---|
+| `cin_jkg is None` | 368 | Notbremse: hoechstens `LOW` |
+| `betrag < 25` | 370 | keine Daempfung |
+| `betrag < 50` | 372 | genau eine Stufe herunter |
+| `betrag <= 100` | 374 | Deckel auf `LOW` |
+| sonst | 376 | `NONE` — CAPE traegt nichts bei |
+
+🔴 **Praezisierung gegenueber dem Ticket-Text:** Der Code kennt **drei** Grenzen (25/50/100), nicht vier.
+Die im Ticket und im Docstring genannte **200** kommt im Code nicht vor — sie stammt aus der
+SPC-STP-Formel (`(mlCIN + 200)/150`) und ist dort nur die Belegquelle fuer „darueber kein Beitrag".
+Zu eichen sind also **drei Zahlen**.
+
+Die Werte sind **inline** verdrahtet, es gibt keine benannten Konstanten.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/output/metric_format.py:325-376` | die zu eichende Funktion, Schwellen inline |
+| `src/output/metric_format.py:416` | einziger Aufrufer (`_signal_levels`), daempft das CAPE-Signal |
+| `src/providers/thunder_enrichment.py:44,135,148,151` | Feldmapping `cin_ml` → `convective_inhibition_jkg`; Fusion |
+| `src/providers/dwd.py:92,206,240` | ICON-D2 liefert `cin_ml` **positiv**; Sentinel `-999.9` → `None` |
+| `src/providers/dwd_eu.py:70,97,117,267` | ICON-EU, identischer Filter, teilt die Sentinel-Konstante |
+| `src/app/models.py:173` | `convective_inhibition_jkg: Optional[float]` |
+| `scripts/eichung_cape_schwelle.py` | **wiederverwendbares Eichwerkzeug** aus #1592 (Historical Forecast API) |
+| `src/app/model_registry.py` | Ablageort geeichter Tabellen (`CAPE_THRESHOLDS_JKG`) |
+| `tests/tdd/test_cape_cin_pairing.py` | ~18 Tests, Bandgrenzen fest verdrahtet (u. a. `-24.9/-25.0/-49.9/-99.9/-100.0/-100.1`) |
+
+## Datenlage: wer liefert ueberhaupt CIN?
+
+| Provider | Modell | CIN |
+|---|---|---|
+| `dwd.py` | ICON-D2 | ja, `cin_ml`, positiver Betrag |
+| `dwd_eu.py` | ICON-EU | ja, `cin_ml`, positiver Betrag |
+| Meteo-France / AROME | AROME | **nein** — strukturell `None` → Notbremse `LOW` |
+
+Daraus folgt ein wichtiger Zuschnitt-Vorteil gegenueber #1592: Die Eichung betrifft **nur ICON**, es gibt
+kein Mehr-Modell-Problem. Sie betrifft aber **beide** ICON-Endpoints, und ob D2 und EU dieselben Baender
+tragen duerfen, ist offen (ADR-0048 sagt: Schwellen nicht ueber Modellgrenzen tragen — D2 und EU sind
+zwei Modelle).
+
+Reale gemessene ICON-Werte im Repo: **7,29 J/kg** (ICON-D2, Karnischer Hoehenweg,
+`tests/tdd/test_dwd_thunder_new_signals_fetch.py:31`), **104,47 J/kg** (ICON-EU, Abruzzen,
+`tests/tdd/test_dwd_eu_thunder_energy_signals_fetch.py:17`). Auf **46 %** der ICON-D2-Gitterpunkte liefert
+das Feld den Sentinel `-999.9` („kein Ausloesepunkt gefunden") — dort wirkt nicht die Eichung, sondern die
+Notbremse.
+
+## Existing Patterns
+
+- **Beleg-Muster (#1679):** publizierte Werte uebernehmen, Quelle im Docstring + in der Spec-Dependencies-
+  Tabelle + im Gesamtkonzept hinterlegen. Kein neuer ADR noetig, wenn ADR-0048 den Rahmen schon setzt.
+- **Eich-Muster (#1592):** wenn nichts Publiziertes existiert — einmaliges Skript gegen die Open-Meteo
+  Historical Forecast API, Konvektionssaison April–September, feste Referenzpunkte je Gebiet, Ergebnis als
+  **statisches Literal** committen (kein Laufzeit-Abruf). Vorlage: `scripts/eichung_cape_schwelle.py`.
+- **Daempfungs-Invariante (Gesamtkonzept 3.7, Rasmussen & Blanchard 1998):** CIN ist Ausloese-Filter, kein
+  Schweremass — die Funktion darf **ausschliesslich daempfen, nie anheben**. Gilt unveraendert weiter.
+
+## Dependencies
+
+- **Upstream:** `dwd.py` / `dwd_eu.py` (Rohwert + Sentinel-Filter), `thunder_enrichment.py` (Fusion)
+- **Downstream:** die fusionierte Gewitterstufe erreicht **alle vier Kanaele** —
+  E-Mail (`renderers/email/html.py:210`), SMS (`sms_trip.py:321`, `narrow.py:212`,
+  `compact_summary.py:599`), Trip-Report (`trip_report.py:588-684`), Ortsvergleich
+  (`comparison.py:342`) — und darueber die Gewitteralarme.
+
+## Existing Specs
+
+| Spec | Inhalt |
+|---|---|
+| `docs/specs/modules/feat_1679_cin_paarung_cape_leiter.md` | fuehrt die CIN-Paarung ein, AC-1…AC-8, Belegtabelle Penn State/SPC |
+| `docs/specs/modules/fix_1760_cin_vorzeichen.md` | Vorzeichen-Fix; Abschnitt „Known Limitations" Z. 97-107 haelt die fehlende ICON-Eichung fest — **die dieses Ticket abloest** |
+| `docs/specs/modules/feat_1531_s1_dwd_gewittergroessen.md` | Abruf von `lpi_max` / `cin_ml` |
+| `docs/features/gewitter-gesamtkonzept.md:308-450` (3.5/3.7) | bindender fachlicher Rahmen, nennt die Eckpunkte -25/-50/-100/-200 |
+| `docs/adr/0048-modellabhaengige-schwellen-statt-einer-zahl.md` | „Feste Schwellen werden nie ueber Modellgrenzen getragen" |
+
+## Risks & Considerations
+
+1. **Der Ausgang haengt an der Literaturlage.** Findet die Recherche keine publizierten Baender fuer eine
+   ICON-artige CIN-Definition, ist die Alternative eine eigene Eichung — deutlich groesserer Zuschnitt.
+   Die Entscheidung darueber gehoert vor die Spec, nicht in sie.
+2. **Perzentil-Eichung passt fuer CIN nicht ohne Weiteres.** #1592 eichte CAPE ueber das 95. Perzentil, weil
+   CAPE ein Schweremass ist. CIN ist ein Filter — ein Perzentil-Ansatz muesste die US-Baender ueber
+   **gleiche Ueberschreitungshaeufigkeit** in die ICON-Welt uebersetzen und braucht dafuer eine
+   Referenzverteilung in der US-Definition (Kandidat: GFS ueber dieselbe API).
+3. **Erreichbarkeit vor Schwere.** Vor jeder Zahlendiskussion ist zur Laufzeit zu belegen, dass
+   `_gedaempft_durch_cin` mit echten ICON-Werten ueberhaupt feuert (nach #1760 sollte es, aber #1488 hat
+   gezeigt, dass „im Code vorhanden" nicht „wirksam" heisst). Positivkontrolle noetig.
+4. **Bestandstests sind auf die alten Grenzen geeicht.** `test_cape_cin_pairing.py` prueft Werte dicht an
+   25/50/100. Neue Baender machen diese Tests rot. Regel: **Messwert neu verankern, nicht die Erwartung
+   abschwaechen** (Lehre aus #1678).
+5. **Beide ICON-Endpoints.** Ob ICON-D2 und ICON-EU dieselben Baender tragen duerfen, ist nach ADR-0048
+   begruendungspflichtig, nicht selbstverstaendlich.
+6. **Nutzersichtbare Wirkung.** Andere Baender verschieben Gewitterstufen auf allen vier Kanaelen und damit
+   das Alarmverhalten. Die Richtung der Verschiebung (mehr oder weniger Daempfung) muss vor der Freigabe
+   beziffert sein.
+
+## Analysis (Phase 2, 2026-08-16)
+
+### Type
+
+Feature (Feineichung einer belegten Schwelle) — kein Bug. Das heutige Verhalten ist nicht defekt, es ist
+**schlechter belegt als moeglich**.
+
+### Befund 1 — Literatur: kein exakter Treffer, aber ein besserer Beleg
+
+Vollstaendiger Rechercheverlauf inklusive Ausschlussliste: Scratchpad `cin-literatur.md`.
+
+| Fund | CIN-Definition | Trifft ICON? |
+|---|---|---|
+| **ECMWF TM 852 (Groenemeijer, Pucik, Tsonevsky, Bechtold 2019, ESSL)** — Hemmung markiert ab **50 J/kg**, Kontur „starker Deckel" bei **100 J/kg** | MLCIN ueber **50 hPa**, pseudoadiabatisch, ohne Entrainment | Mischschichttiefe **ja**, Entrainment **ja**, Adiabatik **nein** (2 von 3) |
+| heutige Baender 25/50/100 (Penn State/COMET, SPC) | MLCIN ueber **100 hPa**, pseudoadiabatisch | Mischschichttiefe **nein**, Adiabatik **nein** (1 von 3) |
+| DWD-Glossar „>100 = starker Deckel" | Definition nicht genannt | **kein Beleg** — Publikumserklaerung ohne Parzelangabe |
+| Thompson et al. 2007, CIN <= 250 (Effective Inflow Layer) | US-Konvention, pseudoadiabatisch | **nein** |
+
+Ausdruecklich geprueft und ausgeschlossen: Huntrieser et al. 1997 (ICONs eigene Quelle — belegt nur die
+50-hPa-Wahl, keine Schwellen), Pucik et al. 2015 (rechnet gar kein CIN), Taszarek et al. 2021 ERA5
+(behandelt CIN nicht), DWD-ICON-D2-Datenbankbeschreibung (nur GRIB-Feldname), ECMWF-Confluence
+(deckungsgleich mit TM852).
+
+**Richtung der Restabweichung, belegt:** reversibel gerechnete CIN ist betragsmaessig **groesser** als
+pseudoadiabatische (TM852 Abschnitt 4.3.3 qualitativ; Murdzek et al. 2021, J. Atmos. Sci. 78(10),
+quantitativ: Differenzen > 100 J/kg im Realfall, bis ~5x in Idealsimulation, fallabhaengig bis „fast
+identisch"). **Kein fester Umrechnungsfaktor.** Folge: TM852-Werte 1:1 auf ICON angewandt daempfen
+tendenziell **zu frueh**.
+
+**Richtung der Mischschichttiefe auf CIN: unbelegt.** Fuer CAPE dreifach institutionell belegt („je tiefer
+die Mischschicht, desto weniger CAPE"), fuer CIN sagt keine dieser Quellen etwas; die einzigen Fundstellen
+sind zwei einander widersprechende Blogs. Die **Netto**-Richtung gegenueber den heutigen Werten ist damit
+unbestimmt — nicht „hebt sich auf", sondern schlicht offen.
+
+🔴 **Einzelbeleg-Risiko:** Die Aussage „ICON rechnet CIN reversibel" — Grundlage des gesamten Tickets —
+stuetzt sich allein auf **TM852 Table 1**. Der ICON-Quellcode ist oeffentlich nicht auffindbar, die
+COSMO-Physikdoku enthaelt zu CAPE_ML/CIN_ML nichts. Das ist tragfaehig, muss aber als Einzelbeleg
+dokumentiert werden.
+
+### Befund 2 — Eigene Eichung ist derzeit nicht durchfuehrbar
+
+Vollstaendige Messung: Scratchpad `cin-messung.md`.
+
+Die Open-Meteo Historical Forecast API liefert `convective_inhibition` fuer `icon_d2`/`icon_eu` **erst ab
+2026-06-26/27** (Binaersuche); davor durchgaengig `null`. Gegenprobe: fuer Mai 2025 lieferte `cape` im
+selben Abruf 336/336 Stunden, `cin` 0/336 — das Feld fehlt selektiv im Archiv, nicht der Abruf. Die
+Repo-Fixtures (`tests/fixtures/dwd/*cin_ml*`) sind zwei Einzelzeitschritte ohne Zeitreihe.
+
+**Konsequenz:** Eine Saison-Klimatologie nach dem #1592-Muster ist fruehestens nach der Konvektionssaison
+2027 moeglich. Der im Ticket vorgesehene Fallback „notfalls eigene Eichung" faellt fuer diesen Durchgang
+aus. Publizierte Werte zu uebernehmen ist nicht nur PO-Vorgabe, sondern die einzige heute machbare Option.
+
+Nebenbefund: Open-Meteo liefert `convective_inhibition` bereits als **Betrag** (Sentinel exakt `-1000.0`),
+unser Produktivpfad nutzt dagegen den DWD-Direktabruf. Gleiches Modell, gleiche Definition — die Messung
+ist damit repraesentativ, aber nicht bitgleich unsere Datenquelle.
+
+### Befund 3 — Wirkungsmessung: alles haengt am 25er-Band
+
+Ersatzfenster 2026-06-27 bis 2026-08-14 (49 Tage Hochsommer, **keine** Saison), Referenzpunkte aus
+`scripts/eichung_cape_schwelle.py` plus Karnischer Hoehenweg, nur Stunden mit CAPE >= 1000 J/kg:
+
+| Modell | n | keine Daempfung | −1 Stufe | Deckel LOW | CAPE ganz aus |
+|---|---|---|---|---|---|
+| ICON-D2 | 106 | 81,1 % | 15,1 % | 2,8 % | 0,9 % |
+| ICON-EU | 315 | 78,7 % | 12,4 % | 7,9 % | 1,0 % |
+
+Die Daempfung greift nur in rund einem Fuenftel der Gewitterstunden, und der Loewenanteil davon ist das
+**25er-Band** — genau das Band, das in der ICON-nahen Quelle nicht existiert. Der **100er-Deckel steht in
+beiden Quellenwelten** (US-Praxis wie ESSL) und ist damit der robusteste Punkt der Leiter. Das Band „CAPE
+traegt gar nichts mehr bei" ist mit < 1 % praktisch bedeutungslos.
+
+Einschraenkung: Einzelne Ort/Modell-Zellen haben nur 6–10 Konvektionsstunden; nur die gepoolten Werte
+tragen eine Aussage. ICON-D2 deckt Korsika und Stockholm gitterbedingt nicht ab.
+
+### Technical Approach (Empfehlung)
+
+Die Baender auf die TM852-Semantik abbilden, **ohne eine Zahl zu erfinden**:
+
+| CIN-Betrag | heute | neu | Beleg |
+|---|---|---|---|
+| < 50 | ab 25 gedaempft | keine Daempfung | TM852: Hemmung beginnt bei 50 |
+| 50 – 100 | Deckel LOW | **eine Stufe herunter** | TM852: „hatched where CIN > 50" |
+| > 100 | NONE | **hoechstens LOW** | TM852: Kontur „starker Deckel" bei 100 |
+| — | — | **NONE entfaellt** | fuer die staerkste Daempfung existiert in der ICON-nahen Quelle kein Beleg |
+| `None` | hoechstens LOW | **unveraendert** | Notbremse, nicht Teil der Eichung |
+
+Diese Abbildung ist bewusst die **zurueckhaltendere Lesart**: Weil ICON reversibel rechnet und dadurch fuer
+dieselbe Lage hoehere Zahlen liefert als die pseudoadiabatisch kalibrierten 50/100, wuerde eine
+1:1-Uebernahme zu frueh daempfen. Indem 50 nur eine Stufe nimmt statt sofort auf LOW zu deckeln, wirkt die
+**Struktur** dieser belegten Verzerrung entgegen — statt eines erfundenen Korrekturfaktors.
+
+Erwartete Wirkung: Daempfung greift in 3,8 % (D2) bzw. 8,9 % (EU) der Gewitterstunden statt in 19 % / 21 %.
+Weniger Daempfung heisst hoehere Gewitterstufe — die sichere Fehlerrichtung fuer ein Briefing, nach dem am
+Berg ueber einen Passuebergang entschieden wird.
+
+**Eine Leiter fuer beide ICON-Modelle** trotz ADR-0048: D2 und EU teilen denselben ICON-Code und damit
+dieselbe CIN-Definition. Der gemessene Anteilsunterschied ist ein Gebiets-, kein Definitionsunterschied —
+anders als bei CAPE, wo verschiedene Modellfamilien verschiedene Parzelvarianten rechnen. Diese Begruendung
+gehoert in die Spec, weil ADR-0048 sie sonst verbietet.
+
+### Affected Files
+
+| Datei | Aenderung | Beschreibung |
+|---|---|---|
+| `src/output/metric_format.py` | MODIFY | drei Vergleiche in `_gedaempft_durch_cin`; Docstring auf TM852 umstellen, Known-Limitation-Absatz abloesen |
+| `tests/tdd/test_cape_cin_pairing.py` | MODIFY | Bandgrenzen-Tests neu verankern (Messwerte **nicht** abschwaechen), Tests fuer den Wegfall des NONE-Bandes |
+| `docs/features/gewitter-gesamtkonzept.md` | MODIFY | Abschnitte 3.5/3.7 auf die neue Belegquelle umstellen |
+| `docs/specs/modules/fix_1760_cin_vorzeichen.md` | MODIFY | Known Limitation als abgeloest markieren (Verweis auf #1896) |
+| `docs/specs/modules/fix_1896_cin_baender_icon.md` | CREATE | Spec dieses Tickets |
+
+### Scope Assessment
+
+- Dateien: 5 (davon 2 mit Produktiv-/Testcode)
+- Geschaetztes LoC-Delta (nur zaehlende Dateien): **+150 / −80**, realistisch bis **~300** — der Nachweis
+  kostet hier mehr als der Mechanismus (Regel: Nachweisaufwand doppelt ansetzen). Das **LoC-Limit 250 kann
+  reissen**; falls ja, wird ein Override beim PO angefragt, nicht selbst gesetzt.
+- Risiko: **MEDIUM** — kleiner Eingriff, aber nutzersichtbar auf allen vier Kanaelen und im Alarmverhalten
+
+### Befund 4 — Erreichbarkeit zur Laufzeit belegt, aber gebietsabhaengig
+
+Vollstaendiger Nachweis: Scratchpad `cin-erreichbarkeit.md` (Skripte und Rohausgaben daneben).
+
+**Aufrufkette im Betrieb** (kein toter Code): `preview_service.py:169` `_build_report` — dieselbe Methode
+wie der Versandpfad — → `trip_report_scheduler.py:1917` `_fetch_weather()` (auch `:694`/`:1286` im echten
+Versand) → `segment_weather.py:195` → `openmeteo.py:1204` `_enrich_thunder()` → `thunder_enrichment.py`
+→ `metric_format.py:416` → `_gedaempft_durch_cin()`.
+
+**Positivkontrolle Karnischer Hoehenweg** (46.40 N / 12.52 O, DE_ALPEN → ICON-D2), echter Lauf:
+`basis=MED, cin_jkg=26.07 -> ergebnis=LOW`. Ein echter ICON-Messwert daempft nachweislich eine Stufe.
+**Gegenprobe** mit 5/40/80/500 J/kg: alle vier Baender liefern unterschiedliche Ergebnisse — der Nachweis
+kann etwas zeigen.
+
+**Negativkontrolle GR20/Korsika** (FR → `fr_direct`/Meteo-France): 0 von 72 Datenpunkten mit CIN, 144 von
+144 Aufrufen mit `cin_jkg=None`. `meteofrance.py` fuehrt kein `cin_ml` (grep: 0 Treffer) und faellt auf
+einen Sammelpfad zurueck, der nur die Blitzdichte fuellt.
+
+🔴 **Zwei Reichweiten-Aussagen, die den Nutzen des Tickets begrenzen:**
+
+1. **Auf dem GR20 wirkt die Eichung gar nicht.** Dort greift ausschliesslich die von den Baendern
+   unabhaengige Notbremse „hoechstens LOW". Die Eichung wirkt auf dem Karnischen Hoehenweg und im
+   ICON-EU-Gebiet.
+2. **Auch im ICON-Gebiet ist CIN oft gar nicht da:** am Karnischen Hoehenweg **13 von 72** Datenpunkten mit
+   echtem Wert. In den uebrigen ~82 % greift ebenfalls die Notbremse. Die Notbremse deckelt damit **haeufiger**
+   als saemtliche Baender zusammen — sie ist aber nicht Gegenstand dieses Tickets (siehe Open Questions).
+
+Nebenbefund ohne Produktionsfehler: ein erster Messlauf zeigte faelschlich CIN fuer Korsika, weil ohne
+geladene `.env` der Meteo-France-Schluessel fehlte, der Abruf mit 401 scheiterte und die ADR-0047-Vertretung
+(`fr_direct` → `eu_direct`) einsprang. Die Vertretung funktioniert also — sie darf nur nicht als „Korsika
+bekommt manchmal CIN" missverstanden werden.
+
+### Open Questions
+
+- [x] Erreichbarkeit belegt (Befund 4)
+- [ ] Soll die heute unmoegliche echte ICON-Klimatologie-Eichung als Folge-Issue mit Pruefdatum
+      (Konvektionssaison 2027) angelegt werden? — PO-Entscheidung
+- [ ] Die Notbremse „CIN unbekannt ⇒ hoechstens LOW" greift in ~82 % der Stunden am Karnischen Hoehenweg
+      und zu 100 % auf dem GR20 — deutlich haeufiger als jedes Band. Ist der pauschale Deckel bei
+      **unbekannter** Hemmung in dieser Haeufigkeit noch gewollt? Eigenes Ticket, nicht Teil von #1896. —
+      PO-Entscheidung
+
+## Next
+
+`/30-write-spec` — Baender werden dort per ACs zur Freigabe vorgelegt.

--- a/docs/features/gewitter-gesamtkonzept.md
+++ b/docs/features/gewitter-gesamtkonzept.md
@@ -252,13 +252,32 @@ konsistenten Korridor, darunter zwei Primärquellen:
 | **ECMWF** Forecast User Guide | ab **50 J/kg** wird CAPE auf Karten grau maskiert — eine **Darstellungs**schwelle, keine Kausalregel | belegt |
 | **DWD** | „Je größer die CIN-Werte sind, desto unwahrscheinlicher ist die Auslöse von Gewittern" — **ohne Zahl** | qualitativ |
 
-⇒ Belegte Eckpunkte sind **−25 / −50 / −100 / −200 J/kg**. Vorschlag für die Paarung:
-schwächer als −25 → CAPE zählt voll · −25 bis −50 → leicht gedämpft · −50 bis −100 → stark
-gedämpft, nur mit kräftigem Auslöser · unter −100 → kein Beitrag.
+🔴 **Ersetzt am 2026-08-16 (#1896).** Alle Quellen oben beziehen sich auf **MLCIN über 100 hPa,
+pseudoadiabatisch** — eine andere Rechnung als die unsrige. Unsere CIN-Werte kommen
+ausschließlich aus **ICON** (DWD), das über **50 hPa** mischt, **reversibel** und **ohne
+Entrainment** rechnet. Dieselbe Zahl bedeutet damit etwas anderes (dieselbe Fehlerklasse wie
+ADR-0048 „CAPE ≠ CAPE", eine Ebene tiefer). Maßgeblich ist seither die ICON-nächste publizierte
+Quelle:
+
+| Quelle | Aussage | CIN-Definition |
+|---|---|---|
+| **ECMWF TM 852** (Groenemeijer, Púčik, Tsonevsky, Bechtold 2019, ESSL), Figure 2 | „CIN (hatched areas where CIN > 50 J/kg, contour at CIN = 100 J/kg)" | MLCIN über **50 hPa**, ohne Entrainment, pseudoadiabatisch — trifft **zwei von drei** Bestandteilen der ICON-Definition (die US-Quellen oben nur einen) |
+
+⇒ Belegte Eckpunkte sind seither **50 / 100 J/kg** (Beträge, s. Schritt 2). Der vierte Eckpunkt
+−200 der SPC-STP-Formel entfällt: er war im Code nie implementiert, und für die stärkste
+denkbare Dämpfung kennt die ICON-nahe Quelle oberhalb von 100 keinen Stützpunkt.
+
+🔴 **Richtung der verbleibenden Abweichung, belegt:** reversibel gerechnete CIN ist
+betragsmäßig **größer** als pseudoadiabatische (TM 852 Abschnitt 4.3.3 qualitativ; Murdzek,
+Markowski, Richardson, Kumjian 2021, *J. Atmos. Sci.* 78(10) quantitativ). Ein fester
+Umrechnungsfaktor existiert nicht — 50/100 1:1 übernommen dämpft also eher **zu früh**. Dem
+begegnet die **Struktur** der Kaskade (50 nimmt nur eine Stufe), nicht eine erfundene
+Korrekturzahl. Eine echte ICON-Eichung bleibt offen (Archivlücke, frühestens nach der
+Konvektionssaison 2027).
 
 🔴 **Korrektur einer verbreiteten Angabe:** Die kursierenden Werte „CIN > −10 = frei
 auslösbar" und „genau −50 als Schaltschwelle" sind **so nicht belegt** — sie klingen präzise,
-haben aber keine Quelle. Die tatsächlich belegten Grenzen sind die vier oben.
+haben aber keine Quelle.
 
 🔴 **Gegenbefund, der mitgeschrieben gehört:** Rasmussen & Blanchard (1998), die
 meistzitierte Klimatologie dazu, findet **CIN als eigenständigen Schwere-Prädiktor nur schwach**
@@ -318,7 +337,7 @@ ersetzt die heutige Fassung aus 3.1.
 | **Blitzdichte** (Frankreich inkl. Korsika, Blitze/km²/3 h) | < 0,003 | ≥ 0,003 | ≥ 0,015 | ≥ 0,075 | ECMWF; **oberste Grenze interpoliert** |
 | **Blitzpotenzial ICON-D2** (J/kg) | < 1 | ≥ 1 | ≥ 30 | ≥ 50 | Bína et al., COSMO-D2 — **alle drei belegt** |
 | **Blitzpotenzial ICON-EU** (J/kg) | eigene Leiter — **zu eichen** (Rang 7), bis dahin nicht gleichwertig | | | | Faktor 235 gemessen |
-| **CAPE, gepaart mit Hemmung** | s. Schritt 2 | | | | NWS/SPC + Penn State |
+| **CAPE, gepaart mit Hemmung** | s. Schritt 2 | | | | CAPE: NWS/SPC · Hemmung: ECMWF TM 852 (#1896) |
 | **Superzellen-Index** (Betrag, 1/s) | < 0,0003 | — | ≥ 0,0003 | ≥ 0,003 | DWD publiziert |
 | **Radar-Beobachtung** | nicht konvektiv | — | konvektiv | — | #1419 §4 |
 | **Updraft-Helizität** | trägt vorerst **nichts** bei — keine übertragbare Schwelle | | | | — |
@@ -338,13 +357,20 @@ AC-4/AC-5/AC-6, adversary-VERIFIED per Mutationsprobe) legen den Randwert jeweil
 dämpfende** Band — Tabelle unten entsprechend präzisiert, an der fachlichen Bedeutung ändert sich
 nichts.
 
+🔴 **Neueichung 2026-08-16 (#1896):** Die Bänder stehen seither auf der ICON-nächsten Quelle
+ECMWF TM 852 (Herleitung s. 3.5). Verglichen wird der **Betrag** der Hemmung — ICON liefert
+`cin_ml` positiv, US-Modelle negativ (#1760). Das Band „kein Beitrag" ist **ersatzlos
+entfallen**; der Randwert gehört weiterhin ins stärker dämpfende Band. Das oberste Band ist
+bewusst **kein reiner Deckel**, sondern die stärkere von „eine Stufe herunter" und „höchstens
+leicht" — sonst wäre die Kaskade an der 100er-Naht nicht monoton und *mehr* Hemmung ergäbe
+*mehr* Gewitter (Adversary-Befund F001, 2026-08-16).
+
 | Hemmung (CIN) | Bedeutung | CAPE darf höchstens |
 |---|---|---|
-| über −25 J/kg (d. h. `cin > -25`) | schwacher Deckel | **voll wirken** — Leiter 1000 / 2500 / 4000 J/kg |
-| −50 bis −25 J/kg (d. h. `-50 < cin <= -25`) | moderat | **eine Stufe weniger** |
-| −100 bis −50 J/kg (d. h. `-100 <= cin <= -50`) | großer Deckel | **höchstens „leicht"** (heutiges Verhalten) |
-| unter −100 J/kg (d. h. `cin < -100`) | Deckel hält | **kein Beitrag** |
-| Hemmung unbekannt | keine Aussage | **höchstens „leicht"** — die heutige Notbremse bleibt als sicherer Rückfall |
+| Betrag unter 50 J/kg | keine nennenswerte Hemmung | **voll wirken** — Leiter 1000 / 2500 / 4000 J/kg |
+| Betrag 50 bis einschließlich 100 J/kg | Deckel | **eine Stufe weniger** |
+| Betrag über 100 J/kg | starker Deckel | **höchstens „leicht"** — und nie weniger gedämpft als im Band darunter (die stärkere beider Dämpfungen gewinnt; eine Basis „leicht" fällt also auf „kein") |
+| Hemmung unbekannt | keine Aussage | **höchstens „leicht"** — die Notbremse bleibt als sicherer Rückfall |
 
 ⚠️ **Ausdrücklich:** Die Hemmung ist ein **Auslöse-Filter**, kein Schweremaß. Rasmussen &
 Blanchard (1998) zeigen, dass CIN die Schwere nur schwach vorhersagt — sie darf die Stufe

--- a/docs/specs/modules/fix_1760_cin_vorzeichen.md
+++ b/docs/specs/modules/fix_1760_cin_vorzeichen.md
@@ -96,6 +96,14 @@ steigt nirgends — die Dämpfung dämpft ausschließlich.
 
 ## Known Limitations (bewusst NICHT in dieser Scheibe)
 
+> ✅ **Abgelöst am 2026-08-16 durch #1896** (`fix_1896_cin_baender_icon.md`). Die unten
+> festgehaltene Nicht-Eichung ist erledigt: Die Bänder stehen seither auf der ICON-nächsten
+> publizierten Quelle (ECMWF TM 852, 50-hPa-Mischschicht ohne Entrainment) — 25/50/100 wurde zu
+> 50/100, das Band „kein Beitrag" entfiel ersatzlos. Der Text unten bleibt als Historie stehen;
+> die verbleibende Einschränkung (Adiabatik: ICON reversibel, TM 852 pseudoadiabatisch —
+> Richtung belegt, Betrag unbekannt) ist in der Spec von #1896 dokumentiert. Der dort genannte
+> Verweis auf #1678 ist überholt: die Feineichung lief unter #1896.
+
 🔴 **Die Bänder sind für ICON nicht geeicht.** Die Beträge 25/50/100/200 stammen aus US-Praxis für
 **MLCIN über 100 hPa**; ICON mischt über **50 hPa** (ICON-Code Z. 2701-2702: *„Depth of mixed
 surface layer: 50hPa following Huntrieser, 1997"*), rechnet **reversibel** statt pseudoadiabatisch

--- a/docs/specs/modules/fix_1896_cin_baender_icon.md
+++ b/docs/specs/modules/fix_1896_cin_baender_icon.md
@@ -12,7 +12,7 @@ tags: [gewitter, cin, icon, schwellen, eichung]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO, 2026-08-16 ('go')
 
 ## Purpose
 
@@ -79,8 +79,15 @@ Neue Kaskade in `_gedaempft_durch_cin()`:
 cin_jkg is None      -> hoechstens LOW        (Notbremse, UNVERAENDERT)
 betrag < 50          -> keine Daempfung       (TM852: Hemmung beginnt bei 50)
 betrag <= 100        -> eine Stufe herunter   (TM852: "hatched where CIN > 50")
-betrag > 100         -> hoechstens LOW        (TM852: Kontur "starker Deckel")
+betrag > 100         -> die STAERKERE von     (TM852: Kontur "starker Deckel")
+                        „eine Stufe herunter" und „Deckel LOW"
 ```
+
+Das oberste Band ist bewusst **nicht** ein reiner Deckel bei LOW, sondern die staerkere der beiden
+Daempfungen. Ein reiner Deckel waere an der 100er-Naht nicht monoton: eine Basis LOW faellt im Band darunter
+auf NONE, wuerde aber bei *mehr* Hemmung wieder auf LOW angehoben — mehr Hemmung ergaebe mehr Gewitter
+(Adversary-Befund F001, 2026-08-16). Die staerkere-von-beiden-Regel schliesst diese Naht (AC-9), ohne an
+den Baendern selbst etwas zu aendern: bei Basis HIGH und MED ist das Ergebnis unveraendert LOW.
 
 Das Band `NONE` („CAPE traegt gar nichts mehr bei") **entfaellt ersatzlos**. Begruendung: Es ist die
 staerkste denkbare Daempfung und braeuchte den staerksten Beleg; die ICON-nahe Quelle kennt oberhalb von
@@ -136,10 +143,18 @@ rechnen. ADR-0048 verbietet das Tragen einer Schwelle ueber **Modellgrenzen**; h
   die Stufe hoechstens LOW.
   - Test: Fusion mit 104,47 und 767,8 J/kg; Ergebnis LOW statt wie bisher NONE.
 
-- **AC-4:** Given einen beliebig grossen CIN-Betrag / When die Gewitterstufe fusioniert wird / Then wird das
-  CAPE-Signal **nie** vollstaendig auf NONE gesetzt, solange die Basis mindestens LOW ist — das frühere
-  Band „CAPE traegt gar nichts bei" existiert nicht mehr.
-  - Test: Fusion mit 101, 200, 1000 und 10000 J/kg bei Basis HIGH/MED/LOW; Ergebnis nie unter LOW.
+- **AC-4:** Given einen beliebig grossen CIN-Betrag / When die Gewitterstufe fusioniert wird / Then schaltet
+  die Hemmung das CAPE-Signal **nicht mehr basis-unabhaengig** ab: bei Basis HIGH und MED ist das Ergebnis
+  mindestens LOW. Eine Basis LOW darf weiterhin um ihre eine Stufe auf NONE sinken — das ist die normale
+  Ein-Stufen-Daempfung aus AC-2, nicht das abgeschaffte Band.
+  - Test: Fusion mit 101, 200, 1000 und 10000 J/kg bei Basis HIGH und MED; Ergebnis mindestens LOW. Bei
+    Basis LOW: Ergebnis NONE, und zwar **denselben** Wert wie im Band darunter (siehe AC-9).
+
+- **AC-9:** Given zwei CIN-Betraege, von denen einer groesser ist / When beide mit derselben Basisstufe
+  gedaempft werden / Then ist das Ergebnis beim groesseren Betrag **niemals hoeher** als beim kleineren —
+  mehr Hemmung fuehrt nie zu mehr Gewitter.
+  - Test: monoton fallende Gegenprobe ueber alle vier Basisstufen mit einer aufsteigenden Wertereihe, die
+    die Bandnaehte ausdruecklich einschliesst (49,9 / 50,0 / 99,9 / 100,0 / 100,1 / 200 / 10000).
 
 - **AC-5:** Given einen Datenpunkt, dessen CIN unbekannt ist (`None`, strukturell der Fall im
   Meteo-France-Gebiet, sowie nach dem Filtern des DWD-Fehlwerts -999,9) / When die Gewitterstufe fusioniert
@@ -208,3 +223,5 @@ rechnen. ADR-0048 verbietet das Tragen einer Schwelle ueber **Modellgrenzen**; h
 ## Changelog
 
 - 2026-08-16: Initial spec created (#1896)
+- 2026-08-16: AC-4 auf ihre Absicht zugespitzt und AC-9 (Monotonie) ergaenzt, nach Adversary-Befund F001 —
+  das oberste Band ist die staerkere der beiden Daempfungen statt eines reinen Deckels. PO-Freigabe 'go'.

--- a/docs/specs/modules/fix_1896_cin_baender_icon.md
+++ b/docs/specs/modules/fix_1896_cin_baender_icon.md
@@ -1,0 +1,210 @@
+---
+entity_id: fix_1896_cin_baender_icon
+type: module
+created: 2026-08-16
+updated: 2026-08-16
+status: draft
+version: "1.0"
+tags: [gewitter, cin, icon, schwellen, eichung]
+---
+
+# CIN-Baender fuer ICON auf die naechstliegende belegte Quelle umstellen (#1896)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Die Konvektionshemmung CIN daempft die aus CAPE abgeleitete Gewitterstufe. Die dafuer benutzten Baender
+stammen aus US-Vorhersagepraxis fuer eine CIN-Definition, die ICON nicht verwendet. Diese Spec stellt sie
+auf die naechstliegende publizierte Quelle um, die fuer europaeische Modelle und fuer ICONs
+Mischschichttiefe gilt — und loest damit die als „Known Limitation" festgehaltene Nicht-Eichung aus #1760
+ab.
+
+## Source
+
+- **File:** `src/output/metric_format.py` (Python-Core / Domain-Backend)
+- **Identifier:** `_gedaempft_durch_cin()` (Z. 325–376), aufgerufen aus `_signal_levels()` (Z. 416)
+
+## Ausgangslage (gemessen 2026-08-16)
+
+| CIN-Betrag | heutiges Verhalten | Herkunft der Zahl |
+|---|---|---|
+| < 25 | keine Daempfung | Penn State/COMET, SPC — **MLCIN ueber 100 hPa, pseudoadiabatisch** |
+| 25 – < 50 | eine Stufe herunter | dieselbe US-Quelle |
+| 50 – 100 | Deckel auf `LOW` | dieselbe US-Quelle |
+| > 100 | `NONE` — CAPE traegt nichts bei | dieselbe US-Quelle |
+| `None` | Notbremse: hoechstens `LOW` | Bestandsverhalten, unabhaengig von der Eichung |
+
+ICON rechnet CIN ueber eine **50-hPa**-Mischschicht, **reversibel**, **ohne Entrainment**. Dieselbe Zahl
+bedeutet damit etwas anderes als in der Quelle der Baender — dieselbe Fehlerklasse wie ADR-0048
+(„CAPE != CAPE"), eine Ebene tiefer.
+
+## Belegte Grundlage der Aenderung
+
+**Primaerquelle:** Groenemeijer, P., Pucik, T., Tsonevsky, I., Bechtold, P. (2019): *An overview of CAPE and
+CIN provided by NWP models for operational forecasting*, ECMWF Technical Memorandum No. 852, Figure 2:
+*"CIN (hatched areas where CIN > 50 J/kg, contour at CIN = 100 J/kg)"*.
+https://www.ecmwf.int/en/elibrary/81131
+
+Warum diese Quelle besser passt als die heutige:
+
+| Eigenschaft | ICON | TM852 / ESSL | heutige US-Quelle |
+|---|---|---|---|
+| Mischschichttiefe | 50 hPa | **50 hPa** ✅ | 100 hPa ❌ |
+| Entrainment | keines | **keines** ✅ | keines ✅ |
+| Adiabatik | reversibel | pseudoadiabatisch ❌ | pseudoadiabatisch ❌ |
+
+TM852 trifft **zwei von drei** Definitionsbestandteilen, die heutige Quelle nur **einen**. TM852 ist zudem
+europaeische operationelle Praxis (ESSL fuer ECMWF) statt US-Praxis.
+
+**Richtung der verbleibenden Abweichung, belegt:** Reversibel gerechnete CIN ist betragsmaessig **groesser**
+als pseudoadiabatische — qualitativ TM852 Abschnitt 4.3.3, quantitativ Murdzek, S.S., Markowski, P.M.,
+Richardson, Y.P., Kumjian, M.R. (2021), *J. Atmos. Sci.* 78(10) (Differenzen > 100 J/kg im Realfall, bis
+~5x in Idealsimulation, fallabhaengig bis „fast identisch"). **Ein fester Umrechnungsfaktor existiert
+nicht.** Eine 1:1-Uebernahme von 50/100 wuerde deshalb tendenziell **zu frueh** daempfen — dem begegnet
+diese Spec ueber die **Struktur** der Kaskade, nicht ueber eine erfundene Korrekturzahl (siehe unten).
+
+**Ausgeschlossen und dokumentiert** (kein verwertbarer Beleg): Huntrieser et al. 1997 (ICONs eigene Quelle
+fuer die 50 hPa — nennt keine Schwellen), Pucik et al. 2015 (rechnet kein CIN), Taszarek et al. 2021 ERA5
+(behandelt CIN nicht), DWD-ICON-D2-Datenbankbeschreibung (nur GRIB-Feldname), DWD-Glossar (keine
+Definition). Vollstaendige Suchspur: `docs/context/fix-1896-cin-eichung-icon.md`.
+
+## Implementation Details
+
+Neue Kaskade in `_gedaempft_durch_cin()`:
+
+```
+cin_jkg is None      -> hoechstens LOW        (Notbremse, UNVERAENDERT)
+betrag < 50          -> keine Daempfung       (TM852: Hemmung beginnt bei 50)
+betrag <= 100        -> eine Stufe herunter   (TM852: "hatched where CIN > 50")
+betrag > 100         -> hoechstens LOW        (TM852: Kontur "starker Deckel")
+```
+
+Das Band `NONE` („CAPE traegt gar nichts mehr bei") **entfaellt ersatzlos**. Begruendung: Es ist die
+staerkste denkbare Daempfung und braeuchte den staerksten Beleg; die ICON-nahe Quelle kennt oberhalb von
+100 keinen weiteren Stuetzpunkt. Der bisherige vierte Eckpunkt 200 stammt aus der SPC-STP-Formel und ist im
+Code ohnehin nie implementiert gewesen.
+
+Ein Grenzwert gehoert weiterhin ins **staerker** daempfende Band (`<= 100` faellt in „eine Stufe").
+
+**Warum 50 nur eine Stufe nimmt statt sofort auf `LOW` zu deckeln:** Weil ICON reversibel rechnet und fuer
+dieselbe Wetterlage hoehere Zahlen liefert als die pseudoadiabatisch kalibrierten 50/100, ist die 1:1-Lesart
+nachweislich zu streng. Die zurueckhaltendere Abbildung wirkt dieser belegten Verzerrung entgegen, ohne eine
+Zahl zu erfinden. Sie ist zugleich die sichere Fehlerrichtung: weniger Daempfung heisst hoehere
+Gewitterstufe, und ein Briefing, nach dem am Berg ueber einen Passuebergang entschieden wird, darf eher zu
+viel als zu wenig warnen.
+
+**Eine Leiter fuer beide ICON-Modelle** (ICON-D2 und ICON-EU) trotz ADR-0048: Beide teilen denselben
+ICON-Code und damit dieselbe CIN-Definition. Der gemessene Anteilsunterschied ist ein Gebiets-, kein
+Definitionsunterschied — anders als bei CAPE, wo verschiedene Modellfamilien verschiedene Parzelvarianten
+rechnen. ADR-0048 verbietet das Tragen einer Schwelle ueber **Modellgrenzen**; hier liegt keine vor.
+
+## Expected Behavior
+
+- **Input:** `basis: ThunderLevel` (aus der CAPE-Leiter), `cin_jkg: Optional[float]` (Betrag oder
+  vorzeichenbehaftet; die Funktion vergleicht weiterhin `abs()`)
+- **Output:** `ThunderLevel`, nie hoeher als `basis`
+- **Side effects:** keine. Wirkt sich ueber die fusionierte Gewitterstufe auf alle vier Kanaele (E-Mail,
+  Telegram, SMS, Premium-SMS), den Ortsvergleich und die Gewitteralarme aus.
+
+**Gemessene Wirkung** (Fenster 2026-06-27 – 2026-08-14, nur Stunden mit CAPE >= 1000 J/kg):
+
+| Modell | n | Daempfung greift heute | Daempfung greift neu |
+|---|---|---|---|
+| ICON-D2 | 106 | 18,9 % | 3,8 % |
+| ICON-EU | 315 | 21,3 % | 8,9 % |
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Datenpunkt mit CAPE oberhalb der HIGH-Stufe und einem ICON-CIN-Betrag unter 50 J/kg
+  (z. B. der real gemessene ICON-D2-Wert 26,07 J/kg vom Karnischen Hoehenweg) / When die Gewitterstufe
+  fusioniert wird / Then bleibt die aus CAPE abgeleitete Stufe **unveraendert** — sie wird nicht mehr wie
+  bisher um eine Stufe gesenkt.
+  - Test: Fusion ueber `thunder_level_from_signals()` mit dem echten Messwert; Vergleich der ausgegebenen
+    Stufe gegen die CAPE-Leiter ohne Hemmung.
+
+- **AC-2:** Given ein Datenpunkt mit CAPE-Stufe HIGH und einem CIN-Betrag zwischen 50 und einschliesslich
+  100 J/kg / When die Gewitterstufe fusioniert wird / Then wird sie um **genau eine** Stufe gesenkt (HIGH
+  wird MED) und nicht auf LOW gedeckelt.
+  - Test: Fusion mit 50,0 / 75,0 / 100,0 J/kg fuer die Basen HIGH, MED und LOW; jeweils genau ein
+    Leitersprung nach unten, LOW faellt auf NONE.
+
+- **AC-3:** Given ein Datenpunkt mit CAPE-Stufe HIGH und einem CIN-Betrag ueber 100 J/kg (z. B. der real
+  gemessene ICON-EU-Wert 104,47 J/kg aus den Abruzzen) / When die Gewitterstufe fusioniert wird / Then ist
+  die Stufe hoechstens LOW.
+  - Test: Fusion mit 104,47 und 767,8 J/kg; Ergebnis LOW statt wie bisher NONE.
+
+- **AC-4:** Given einen beliebig grossen CIN-Betrag / When die Gewitterstufe fusioniert wird / Then wird das
+  CAPE-Signal **nie** vollstaendig auf NONE gesetzt, solange die Basis mindestens LOW ist — das frühere
+  Band „CAPE traegt gar nichts bei" existiert nicht mehr.
+  - Test: Fusion mit 101, 200, 1000 und 10000 J/kg bei Basis HIGH/MED/LOW; Ergebnis nie unter LOW.
+
+- **AC-5:** Given einen Datenpunkt, dessen CIN unbekannt ist (`None`, strukturell der Fall im
+  Meteo-France-Gebiet, sowie nach dem Filtern des DWD-Fehlwerts -999,9) / When die Gewitterstufe fusioniert
+  wird / Then greift unveraendert die Notbremse „hoechstens LOW".
+  - Test: Fusion mit `cin_jkg=None` bei Basis HIGH; Ergebnis LOW. Zusaetzlich ueber den Provider-Pfad, dass
+    der Fehlwert -999,9 weiterhin vor der Funktion zu `None` gefiltert wird.
+
+- **AC-6:** Given eine beliebige Kombination aus Basisstufe und CIN-Wert / When gedaempft wird / Then ist
+  das Ergebnis **niemals hoeher** als die Basis — die Hemmung daempft ausschliesslich und hebt nie an
+  (Rasmussen & Blanchard 1998, Gesamtkonzept 3.7).
+  - Test: parametrisierte Gegenprobe ueber alle vier Basisstufen und eine Wertereihe von 0 bis 10000 J/kg
+    inklusive `None`; Ordinalvergleich Ergebnis <= Basis.
+
+- **AC-7:** Given denselben CIN-Betrag / When er einmal aus ICON-D2 und einmal aus ICON-EU stammt / Then
+  fuehrt er zur **gleichen** Daempfung — beide Modelle teilen eine Baenderleiter.
+  - Test: Fusion mit identischem Wert ueber beide Provider-Pfade (`dwd`/`dwd_eu`); identische Ausgabestufe.
+
+- **AC-8:** Given das positive Vorzeichen, mit dem ICON `cin_ml` liefert, und das negative der US-Modelle /
+  When derselbe Betrag einmal positiv und einmal negativ hereinkommt / Then ist das Ergebnis identisch — die
+  Betragslogik aus #1760 bleibt wirksam.
+  - Test: Parameterpaare (+x / −x) fuer x in 10, 49, 50, 100, 150; jeweils gleiche Ausgabestufe.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|---|---|---|
+| `src/providers/dwd.py` / `dwd_eu.py` | upstream | liefern `cin_ml` (positiver Betrag), filtern -999,9 zu `None` |
+| `src/providers/thunder_enrichment.py` | upstream | Feldmapping und Fusion, einziger produktiver Einstieg |
+| `docs/features/gewitter-gesamtkonzept.md` 3.5/3.7 | doc | fachlicher Rahmen, muss auf die neue Belegquelle umgestellt werden |
+| `docs/specs/modules/fix_1760_cin_vorzeichen.md` | doc | dessen Known Limitation wird durch diese Spec abgeloest |
+| `docs/adr/0048-modellabhaengige-schwellen-statt-einer-zahl.md` | adr | Rahmen fuer die „eine Leiter fuer beide ICON-Modelle"-Begruendung |
+
+## Estimated Scope
+
+- **LoC:** ~+150 / −80 in zaehlenden Dateien, realistisch bis ~300 (der Nachweis kostet mehr als der
+  Mechanismus). Reisst das Limit 250, wird ein Override beim PO angefragt.
+- **Files:** 5 (2 mit Code, 3 Dokumentation)
+- **Effort:** medium
+
+## Known Limitations
+
+- 🔴 **Keine echte ICON-Eichung.** Diese Spec waehlt die naechstliegende publizierte Quelle; sie behauptet
+  nicht, an ICON-Daten geeicht zu sein. Die verbleibende Abweichung ist die Adiabatik (reversibel statt
+  pseudoadiabatisch), Richtung belegt, Betrag unbekannt.
+- 🔴 **Eine eigene Klimatologie-Eichung ist derzeit unmoeglich.** Die Open-Meteo Historical Forecast API
+  fuehrt `convective_inhibition` fuer ICON erst ab 2026-06-26/27; davor durchgaengig leer (Gegenprobe: CAPE
+  im selben Abruf vollstaendig). Eine Saisonmessung nach dem #1592-Muster ist fruehestens nach der
+  Konvektionssaison 2027 moeglich.
+- 🔴 **Einzelbeleg.** Dass ICON CIN reversibel rechnet, stuetzt sich allein auf TM852 Table 1; ICON-Quellcode
+  und COSMO-Physikdoku geben dazu oeffentlich nichts her.
+- **Die Wirkungsmessung ist ein 49-Tage-Hochsommerfenster**, keine Saison. Sie beziffert Groessenordnungen.
+- **Reichweite:** Auf dem GR20 (Meteo-France-Gebiet) wirkt die Eichung nicht — dort fehlt CIN strukturell
+  und es greift allein die Notbremse. Auch am Karnischen Hoehenweg trugen nur 13 von 72 Datenpunkten einen
+  echten CIN-Wert.
+- **Nicht Gegenstand dieser Spec:** dass die Notbremse bei unbekanntem CIN haeufiger deckelt als saemtliche
+  Baender zusammen. Als offene Frage im Kontextdokument vermerkt.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue — ADR-0048 traegt den Rahmen
+- **Rationale:** ADR-0048 verbietet, feste Schwellen ueber **Modellgrenzen** zu tragen. Genau das korrigiert
+  diese Spec: Sie ersetzt eine aus fremder Modellwelt uebernommene Leiter durch die naechstliegende, fuer
+  ICONs Mischschichttiefe belegte. Die Anwendung derselben Leiter auf ICON-D2 und ICON-EU ist keine
+  Modellgrenze im Sinne des ADR (gleicher Modellcode, gleiche CIN-Definition) und ist oben begruendet.
+
+## Changelog
+
+- 2026-08-16: Initial spec created (#1896)

--- a/src/output/metric_format.py
+++ b/src/output/metric_format.py
@@ -325,41 +325,45 @@ _THUNDER_JE_ORDINAL = {thunder_ordinal(stufe): stufe for stufe in ThunderLevel}
 def _gedaempft_durch_cin(
     basis: ThunderLevel, cin_jkg: Optional[float]
 ) -> ThunderLevel:
-    """Daempft eine CAPE-Stufe anhand der Konvektionshemmung CIN (Issue #1679).
+    """Daempft eine CAPE-Stufe anhand der Konvektionshemmung CIN (#1679;
+    Baender auf ICON umgestellt mit #1896).
 
-    Vier belegte Baender (Penn State/COMET, SPC -- Gesamtkonzept 3.7 Schritt 2):
-    schwacher Deckel (Betrag < 25) laesst die Leiter voll zaehlen, moderat
-    (25 <= Betrag < 50) nimmt genau eine Stufe, grosser Deckel
-    (50 <= Betrag <= 100) deckelt auf LOW, darueber traegt CAPE nichts mehr bei.
-    Ein Grenzwert gehoert dabei immer ins staerker daempfende Band.
+    Drei Baender aus der ICON-naechsten publizierten Quelle -- ECMWF Technical
+    Memorandum No. 852 (Groenemeijer, Pucik, Tsonevsky, Bechtold 2019), Fig. 2:
+    *"CIN (hatched areas where CIN > 50 J/kg, contour at CIN = 100 J/kg)"*.
+    Betrag < 50 laesst die Leiter voll zaehlen, bis EINSCHLIESSLICH 100 faellt
+    genau eine Stufe, darueber greift die STAERKERE von "eine Stufe" und
+    "Deckel LOW"; der Grenzwert gehoert immer ins staerker daempfende Band.
+    Das oberste Band ist bewusst kein reiner Deckel: ein absoluter Deckel
+    neben einem relativen Band ist an der 100er-Naht nicht monoton -- eine
+    Basis LOW faellt bei 100 auf NONE und wuerde bei MEHR Hemmung wieder auf
+    LOW angehoben (Adversary-Befund F001). Ein Band "CAPE traegt gar nichts
+    bei" gibt es NICHT -- dafuer kennt die Quelle keinen Stuetzpunkt.
 
-    Unbekanntes CIN (``None``, strukturell der Fall bei Meteo-France/AROME;
-    ebenso der DWD-Fehlwert -999,9 "kein Ausloesepunkt gefunden", der VOR
-    dieser Funktion zu ``None`` gefiltert wird, `dwd.py:206`/`:240`,
-    `dwd_eu.py:261`) faellt auf die Bestands-Notbremse "hoechstens LOW"
-    zurueck -- NICHT auf "kein Deckel": eine fehlende Hemmungsangabe ist
-    keine schwache Hemmung.
+    Warum 50 nur EINE Stufe nimmt statt auf LOW zu deckeln: TM 852 rechnet
+    pseudoadiabatisch, ICON reversibel, und reversible CIN ist betragsmaessig
+    GROESSER (TM 852 Abschnitt 4.3.3; Murdzek, Markowski, Richardson, Kumjian
+    2021, J. Atmos. Sci. 78(10)) -- ohne festen Umrechnungsfaktor. Die
+    1:1-Lesart wuerde zu frueh daempfen; dem begegnet die STRUKTUR der Kaskade.
 
-    Vorzeichen der Eingabe ist MODELLABHAENGIG, GRIB2 (Parameter 0/7/7 der
-    WMO-Registry) legt keines fest -- nur Name und Einheit (J/kg) sind
-    standardisiert. Der DWD (ICON-D2/ICON-EU) liefert ``cin_ml`` als
-    POSITIVEN Betrag: ICON-Quellcode
-    `src/atm_phy_nwp/mo_opt_nwp_diagnostics.f90:3957-3958`, Kommentar
-    ``! make CIN positive``, gefolgt von ``ABS(...)``. GFS/US-Modelle
-    liefern dagegen negativ -- die US-Literatur (Penn State/SPC), aus der
-    die vier Baender oben stammen, bezieht sich auf **MLCIN ueber 100 hPa**
-    negativ gezaehlt. Deshalb vergleicht diese Funktion den BETRAG der
-    Hemmung, nicht ihr Vorzeichen (Issue #1760) -- ein reiner
-    Vorzeichenvergleich (``cin_jkg > -25``) waere fuer JEDEN positiven
-    ICON-Wert immer wahr und die Daempfung wuerde nie feuern.
+    Unbekanntes CIN (``None``, strukturell bei Meteo-France/AROME; ebenso der
+    DWD-Fehlwert -999,9, VOR dieser Funktion zu ``None`` gefiltert,
+    `dwd.py:206`/`:240`, `dwd_eu.py:261`) faellt auf die Notbremse "hoechstens
+    LOW" -- NICHT auf "kein Deckel": eine fehlende Hemmungsangabe ist keine
+    schwache Hemmung.
 
-    🔴 Bekannte Einschraenkung (Issue #1760 Known Limitations): die Baender
-    selbst sind fuer ICON NICHT geeicht. ICON mischt CIN ueber **50 hPa**
-    (ICON-Code Z. 2701-2702, "Depth of mixed surface layer: 50hPa following
-    Huntrieser, 1997"), reversibel, ohne Entrainment (ECMWF TM 852,
-    Groenemeijer et al. 2019) -- eine andere Rechnung als die US-MLCIN, aus
-    der -25/-50/-100/-200 stammen. Die Schwellen liegen in der richtigen
-    Groessenordnung, sind aber keine ICON-Eichung (Feineichung: #1678).
+    Vorzeichen ist MODELLABHAENGIG, GRIB2 (Parameter 0/7/7 der WMO-Registry)
+    legt keines fest. Der DWD (ICON-D2/ICON-EU) liefert ``cin_ml`` POSITIV:
+    `src/atm_phy_nwp/mo_opt_nwp_diagnostics.f90:3957-3958`, ``! make CIN
+    positive`` gefolgt von ``ABS(...)``; GFS/US-Modelle liefern negativ.
+    Deshalb vergleicht diese Funktion den BETRAG (Issue #1760).
+
+    🔴 Verbleibende Einschraenkung (#1896, loest die des #1760 ab): naechste
+    belegte Quelle, KEINE ICON-Eichung. TM 852 teilt mit ICON die 50-hPa-
+    Mischschicht und den Verzicht auf Entrainment, nicht die Adiabatik --
+    Richtung belegt (s.o.), Betrag unbekannt; "ICON rechnet reversibel" fusst
+    allein auf TM 852 Table 1. Eigene Eichung fruehestens nach der Saison 2027
+    (Archivluecke, s. `fix_1896_cin_baender_icon.md`).
 
     CIN ist Ausloese-Filter, kein Schweremass (Rasmussen & Blanchard 1998) --
     diese Funktion daempft deshalb ausschliesslich und hebt nie an.
@@ -367,13 +371,12 @@ def _gedaempft_durch_cin(
     if cin_jkg is None:
         return min(basis, ThunderLevel.LOW, key=thunder_ordinal)
     betrag = abs(cin_jkg)
-    if betrag < 25:
-        return basis
     if betrag < 50:
-        return _THUNDER_JE_ORDINAL[max(thunder_ordinal(basis) - 1, 0)]
+        return basis
+    eine_stufe = _THUNDER_JE_ORDINAL[max(thunder_ordinal(basis) - 1, 0)]
     if betrag <= 100:
-        return min(basis, ThunderLevel.LOW, key=thunder_ordinal)
-    return ThunderLevel.NONE
+        return eine_stufe
+    return min(eine_stufe, ThunderLevel.LOW, key=thunder_ordinal)
 
 
 def _signal_levels(

--- a/tests/tdd/test_cape_cin_pairing.py
+++ b/tests/tdd/test_cape_cin_pairing.py
@@ -4,8 +4,21 @@ SPEC: docs/specs/modules/feat_1679_cin_paarung_cape_leiter.md
 
 Testet AC-1 bis AC-8 der CAPE-Leiter (1000/2500/4000 J/kg, NWS/SPC, regions-/
 modellskaliert ueber `model_registry.cape_ladder_thresholds_jkg()`), gepaart
-mit der Konvektionshemmung CIN (`dp.convective_inhibition_jkg`, #1531) in vier
-belegten Baendern (Penn State/COMET, SPC: -25/-50/-100/-200 J/kg).
+mit der Konvektionshemmung CIN (`dp.convective_inhibition_jkg`, #1531).
+
+🔴 Issue #1896 (SPEC: docs/specs/modules/fix_1896_cin_baender_icon.md) stellt die
+CIN-Baender auf die ICON-nahe Quelle ECMWF TM 852 um (frueher 25/50/100 plus
+Band "CAPE traegt nichts bei"):
+
+    None            -> hoechstens LOW   (Notbremse, UNVERAENDERT)
+    Betrag < 50     -> keine Daempfung
+    Betrag <= 100   -> genau eine Stufe herunter
+    Betrag > 100    -> hoechstens LOW   (Band NONE entfaellt ersatzlos)
+
+Die Tests, die die ALTEN Grenzen festschrieben, sind darauf neu verankert --
+am neuen Sollwert, nicht abgeschwaecht. Eichungsunabhaengige Zusicherungen
+(Notbremse `None`, Sentinel-Filter -999,9, Vorzeichen-Symmetrie #1760,
+"daempft nie nach oben") bleiben unveraendert bestehen.
 
 RED-Ursache (heute):
 - `app.model_registry.cape_ladder_thresholds_jkg()` existiert noch nicht ->
@@ -127,16 +140,34 @@ def test_ac2_cape_ladder_thresholds_jkg_unbekannte_kombination_liefert_none(
 
 # ────────────── AC-3 — schwacher Deckel: CAPE zaehlt voll, erreicht HIGH ──
 
-@pytest.mark.parametrize("cin", [0.0, -10.0, -24.9])
+@pytest.mark.parametrize("cin", [0.0, -10.0, -26.07, -49.9])
 def test_ac3_schwacher_deckel_cape_erreicht_med_unveraendert(cin):
-    """AC-3: CIN im Band 'schwacher Deckel' (>= -25) daempft NICHT -- CAPE
-    im MED-Bereich der vollen Leiter (>= 2500) liefert MED, unabhaengig vom
-    genauen CIN-Wert innerhalb des Bandes.
+    """AC-3 (#1896 AC-1, neu verankert): CIN unterhalb von 50 J/kg daempft
+    NICHT -- CAPE im MED-Bereich der vollen Leiter (>= 2500) liefert MED.
+    -26,07 ist der real gemessene ICON-D2-Wert vom Karnischen Hoehenweg
+    (Kontextdokument Befund 4); er lag bisher im 25er-Band und nahm eine
+    Stufe. Die Obergrenze 49,9 ersetzt die alte 24,9.
     """
     ergebnis = _call_cape(2600.0, cin)
     assert ergebnis == MED, (
-        f"CAPE 2600 J/kg mit CIN={cin} (schwacher Deckel) muss MED liefern, "
-        f"erhalten {ergebnis!r}"
+        f"CAPE 2600 J/kg mit CIN={cin} (unter 50 J/kg, keine Hemmung) muss "
+        f"MED liefern, erhalten {ergebnis!r}"
+    )
+
+
+def test_1896_ac1_echter_icon_d2_wert_26_07_laesst_die_cape_leiter_unveraendert():
+    """#1896 AC-1: der real gemessene ICON-D2-Wert 26,07 J/kg (Karnischer
+    Hoehenweg, 46.40N/12.52O) liefert ueber die FUSION dieselbe Stufe wie ein
+    Datenpunkt ganz ohne Hemmung -- er senkt sie nicht mehr um eine Stufe.
+    Prueft am Wirkort (`thunder_level_from_signals()`) und vergleicht gegen
+    die ungehemmte Leiter statt gegen eine hart notierte Stufe.
+    """
+    ohne_hemmung = _call_cape(4500.0, 0.0)
+    mit_26_07 = _call_cape(4500.0, 26.07)
+    assert ohne_hemmung == HIGH, "Vorbedingung: CAPE 4500 J/kg ist HIGH"
+    assert mit_26_07 == ohne_hemmung, (
+        f"CIN=26,07 J/kg (real gemessen, ICON-D2) muss die CAPE-Stufe "
+        f"unveraendert lassen ({ohne_hemmung!r}), erhalten {mit_26_07!r}"
     )
 
 
@@ -159,43 +190,53 @@ def test_ac3_schwacher_deckel_cape_erreicht_high_kern_regressionsanker():
 
 # ────────────── AC-4 — moderater Deckel: eine Stufe weniger ───────────────
 
-@pytest.mark.parametrize("cin", [-25.0, -40.0, -49.9])
-def test_ac4_moderater_deckel_eine_stufe_weniger_von_high(cin):
-    """AC-4: CIN im Band 'moderat' (-50 bis -25) daempft CAPE um GENAU eine
-    Stufe -- CAPE im HIGH-Bereich der vollen Leiter liefert MED, nicht HIGH
-    und nicht LOW.
+@pytest.mark.parametrize("cin", [-50.0, -75.0, -100.0])
+@pytest.mark.parametrize(
+    "cape, erwartet", [(4500.0, MED), (2600.0, LOW), (1100.0, NONE)],
+    ids=["basis_high", "basis_med", "basis_low"],
+)
+def test_ac4_moderater_deckel_eine_stufe_weniger_von_high(cin, cape, erwartet):
+    """AC-4 (#1896 AC-2, neu verankert): CIN von 50 bis EINSCHLIESSLICH
+    100 J/kg nimmt GENAU eine Stufe -- fuer jede Basisstufe der vollen Leiter.
+    HIGH wird MED (nicht LOW, wie es die alten Baender taten), MED wird LOW,
+    LOW faellt auf NONE.
+
+    Der Grenzwert 100,0 liegt im staerker daempfenden Band ("<= 100"), 50,0
+    ist die untere, inklusive Kante.
     """
-    ergebnis = _call_cape(4500.0, cin)
-    assert ergebnis == MED, (
-        f"CAPE 4500 J/kg (volle Leiter: HIGH) mit CIN={cin} (moderat) muss "
-        f"MED liefern (eine Stufe weniger), erhalten {ergebnis!r}"
+    ergebnis = _call_cape(cape, cin)
+    assert ergebnis == erwartet, (
+        f"CAPE {cape} J/kg mit CIN={cin} (Band 50..100) muss {erwartet!r} "
+        f"liefern (genau eine Stufe herunter), erhalten {ergebnis!r}"
     )
 
 
 def test_ac4_moderater_deckel_boden_bei_none_nicht_negativ():
-    """AC-4 Bodenfall: CAPE im LOW-Bereich der vollen Leiter mit moderatem
-    CIN liefert NONE (eine Stufe unter LOW), nicht LOW und keinen Fehler.
+    """AC-4 Bodenfall (#1896 AC-2): CAPE im LOW-Bereich der vollen Leiter mit
+    CIN im Band 50..100 liefert NONE (eine Stufe unter LOW), nicht LOW und
+    keinen Fehler.
 
     Gegenprobe (Spec): Wuerde 'eine Stufe weniger' faelschlich als
     'hoechstens LOW' (statt relativ zur Basisstufe) interpretiert, laege
     dieser Fall weiterhin bei LOW statt NONE.
     """
-    ergebnis = _call_cape(1000.0, -30.0)
+    ergebnis = _call_cape(1000.0, -75.0)
     assert ergebnis == NONE, (
-        f"CAPE 1000 J/kg (volle Leiter: LOW) mit CIN=-30.0 (moderat) muss "
-        f"NONE liefern (eine Stufe unter LOW, Boden erreicht), erhalten "
-        f"{ergebnis!r}"
+        f"CAPE 1000 J/kg (volle Leiter: LOW) mit CIN=-75.0 muss NONE liefern "
+        f"(eine Stufe unter LOW, Boden erreicht), erhalten {ergebnis!r}"
     )
 
 
 # ────── AC-5 — grosser Deckel + unbekannt: hoechstens LOW (Regression) ────
 
-@pytest.mark.parametrize("cin", [-50.0, -75.0, -99.9, None])
+@pytest.mark.parametrize("cin", [None])
 def test_ac5_grosser_deckel_und_unbekannt_hoechstens_low(cin):
-    """AC-5 (wichtigster Regressionstest): CIN im Band 'grosser Deckel'
-    (-100 bis -50) ODER unbekannt (`None`) daempft CAPE auf hoechstens LOW --
-    identisch zum Verhalten VOR dieser Aenderung (`feat_1474` AC-6), jetzt
-    aber nur noch fuer diese beiden Faelle statt generell.
+    """AC-5 (#1896 AC-5, Notbremse UNVERAENDERT): unbekanntes CIN (`None`)
+    daempft CAPE auf hoechstens LOW -- identisch zum Verhalten VOR dieser
+    Aenderung (`feat_1474` AC-6). Die frueher hier mitgepruefte Bandreihe
+    -50/-75/-99,9 gehoert seit #1896 ins Band "eine Stufe herunter" und wird
+    in `test_ac4_moderater_deckel_eine_stufe_weniger_von_high` geprueft --
+    die Notbremse selbst ist von der Eichung unberuehrt.
 
     Gegenprobe (Spec): Laege `cin_jkg=None` versehentlich im Band
     'schwacher Deckel' (z.B. durch ein `or 0`-Muster), wuerde CAPE bei
@@ -211,29 +252,33 @@ def test_ac5_grosser_deckel_und_unbekannt_hoechstens_low(cin):
 
 # ────────────── AC-6 — Deckel haelt: kein Beitrag ─────────────────────────
 
-@pytest.mark.parametrize("cin", [-100.1, -150.0, -200.0])
+@pytest.mark.parametrize("cin", [-100.1, -104.47, -767.8])
 def test_ac6_deckel_haelt_kein_beitrag_unabhaengig_von_cape_hoehe(cin):
-    """AC-6: CIN unter -100 J/kg ('Deckel haelt') laesst CAPE NICHTS
-    beitragen -- unabhaengig davon, wie hoch CAPE liegt.
-
-    Gegenprobe (Spec): Wuerde 'kein Beitrag' faelschlich als 'hoechstens
-    LOW' (statt NONE) umgesetzt, laege das Ergebnis bei LOW statt NONE.
+    """AC-6 (#1896 AC-3, neu verankert): CIN ueber 100 J/kg deckelt auf
+    hoechstens LOW -- das frueher hier gepruefte Band "CAPE traegt gar nichts
+    bei" (NONE) entfaellt ersatzlos, weil TM 852 oberhalb von 100 keinen
+    weiteren Stuetzpunkt kennt. -104,47 ist der real gemessene ICON-EU-Wert
+    aus den Abruzzen (`test_dwd_eu_thunder_energy_signals_fetch.py:17`),
+    -767,8 der Bestands-Extremwert dieser Datei. Selbst bei extremem CAPE
+    (10000 J/kg) bleibt LOW stehen.
     """
     ergebnis = _call_cape(10000.0, cin)
-    assert ergebnis == NONE, (
-        f"CAPE 10000 J/kg (extrem) mit CIN={cin} (Deckel haelt) muss NONE "
-        f"liefern, erhalten {ergebnis!r}"
+    assert ergebnis == LOW, (
+        f"CAPE 10000 J/kg (extrem) mit CIN={cin} (ueber 100 J/kg) muss LOW "
+        f"liefern (nicht NONE -- das Band entfaellt), erhalten {ergebnis!r}"
     )
 
 
 def test_ac6_grenzwert_minus_100_liegt_noch_im_grossen_deckel_nicht_haelt():
-    """AC-6 Grenzfall: CIN=-100.0 EXAKT liegt noch im Band 'grosser Deckel'
-    (>= -100), NICHT im Band 'haelt' (< -100) -- Grenze ist inklusiv am
-    schwaecheren Ende, exklusiv am staerkeren."""
+    """AC-6 Grenzfall (#1896 AC-2/AC-3): CIN=-100.0 EXAKT gehoert ins
+    staerker daempfende der beiden angrenzenden Baender -- also noch in
+    "eine Stufe herunter" (`<= 100`), NICHT in "hoechstens LOW" (`> 100`).
+    Aus Basis HIGH wird damit MED.
+    """
     ergebnis = _call_cape(4500.0, -100.0)
-    assert ergebnis == LOW, (
-        f"CIN=-100.0 (exakt) muss noch als 'grosser Deckel' gelten (LOW), "
-        f"nicht als 'haelt' (NONE) -- erhalten {ergebnis!r}"
+    assert ergebnis == MED, (
+        f"CIN=-100.0 (exakt) muss noch 'eine Stufe herunter' bedeuten (MED "
+        f"aus HIGH), nicht den Deckel LOW -- erhalten {ergebnis!r}"
     )
 
 
@@ -327,19 +372,16 @@ def test_ac8_thunder_level_from_signals_ohne_cin_parameter_bricht_mit_typeerror(
 @pytest.mark.parametrize(
     "cin_positiv, erwartet",
     [
-        # 7.29 J/kg: Betrag < 25 -- schwacher Deckel, CAPE zaehlt VOLL.
+        # 7.29 J/kg (ICON-D2, KHW): Betrag < 50 -- keine Hemmung, CAPE voll.
         (7.29, HIGH),
-        # 104.47 J/kg: Betrag > 100 -- nach der Tabelle in
-        # docs/features/gewitter-gesamtkonzept.md ("unter -100 J/kg: Deckel
-        # haelt, kein Beitrag") liegt das NEGATIVE Pendant -104.47 ebenfalls
-        # in diesem Band, nicht im Band "grosser Deckel" (-100 bis -50).
-        # Die Spec-Prosa zu AC-1 nennt hierfuer "hoechstens 'leicht'" --
-        # das ist mit NONE (schwaecher als LOW) technisch weiterhin erfuellt
-        # ("hoechstens" = Obergrenze), aber NICHT das Band "grosser Deckel"
-        # selbst. S. Bericht: Unstimmigkeit in der Spec-Illustration.
-        (104.47, NONE),
-        # 767.8 J/kg: Betrag weit > 100 -- ebenfalls "Deckel haelt".
-        (767.8, NONE),
+        # 26.07 J/kg (ICON-D2, KHW, Positivkontrolle #1896 Befund 4): seit
+        # #1896 ebenfalls unter 50 -- keine Daempfung mehr (vorher eine Stufe).
+        (26.07, HIGH),
+        # 104.47 J/kg (ICON-EU, Abruzzen): Betrag > 100 -- Deckel auf LOW.
+        # Bis #1896 lag dieser Wert im inzwischen entfallenen NONE-Band.
+        (104.47, LOW),
+        # 767.8 J/kg: Betrag weit ueber 100 -- ebenfalls Deckel LOW.
+        (767.8, LOW),
     ],
 )
 def test_1760_ac1_ac5_positiver_cin_daempft_fusionierte_stufe_echte_dwd_werte(
@@ -387,8 +429,10 @@ def test_1760_ac3_gefilterter_sentinel_faellt_ueber_fuse_auf_hoechstens_low():
     Gegenprobe (Mutation): Wird der Sentinel-Filter in `dwd.py`/`dwd_eu.py`
     entfernt und ein rohes -999.9 erreicht `convective_inhibition_jkg`
     unveraendert, liefert `_gedaempft_durch_cin()` (Betrag 999.9 > 100)
-    zwar IMMER NOCH `NONE` -- das ist der Fund, den die Mutations-Gegenprobe
-    im Bericht dokumentiert, s. dort.
+    zwar IMMER NOCH den staerksten Deckel -- das ist der Fund, den die
+    Mutations-Gegenprobe im Bericht dokumentiert, s. dort. (Seit #1896 ist
+    dieser staerkste Deckel LOW statt NONE; der Fund bleibt derselbe, den
+    Filter selbst prueft `test_1760_f001_...` weiter unten.)
     """
     from app.model_registry import cape_ladder_thresholds_jkg
     from app.models import ForecastDataPoint
@@ -547,4 +591,168 @@ def test_1760_ac6_daempfung_hebt_die_stufe_nie_ueber_die_basis(cin_positiv):
     assert thunder_ordinal(ergebnis) <= thunder_ordinal(HIGH), (
         f"CIN={cin_positiv} (positiv) darf die Stufe NIE ueber HIGH heben, "
         f"erhalten {ergebnis!r}"
+    )
+
+
+# ===========================================================================
+# Issue #1896 -- CIN-Baender auf die ICON-nahe Quelle ECMWF TM 852 umgestellt
+# (Groenemeijer, Pucik, Tsonevsky, Bechtold 2019, Figure 2). Das Band "CAPE
+# traegt gar nichts bei" (NONE) entfaellt ersatzlos.
+# SPEC: docs/specs/modules/fix_1896_cin_baender_icon.md
+#
+# AC-1/AC-2/AC-3/AC-5 sind oben an den bestehenden Bandtests neu verankert.
+# Hier stehen die ACs, fuer die es keinen Bestandstest gab.
+# ===========================================================================
+
+# CAPE-Werte der nominalen Leiter (1000/2500/4000) je Basisstufe -- die Basis
+# wird NICHT behauptet, sondern im Test gegen den ungehemmten Lauf geprueft.
+_CAPE_JE_BASIS = {NONE: 500.0, LOW: 1100.0, MED: 2600.0, HIGH: 4500.0}
+
+
+@pytest.mark.parametrize("cin", [101.0, 200.0, 1000.0, 10000.0])
+@pytest.mark.parametrize("basis", [HIGH, MED])
+def test_1896_ac4_beliebig_grosses_cin_setzt_das_cape_signal_nie_auf_none(
+    basis, cin,
+):
+    """#1896 AC-4 (zugespitzt nach Adversary-Befund F001): die Hemmung
+    schaltet das CAPE-Signal nicht mehr basis-unabhaengig ab -- bei Basis HIGH
+    und MED bleibt fuer JEDEN Betrag ueber 100 J/kg mindestens LOW stehen.
+
+    Basis LOW ist bewusst NICHT hier: sie darf um ihre eine Stufe auf NONE
+    sinken (normale Ein-Stufen-Daempfung aus AC-2), s. den Test darunter.
+    Geprueft am Wirkort (Fusion `thunder_level_from_signals()`).
+    """
+    ergebnis = _call_cape(_CAPE_JE_BASIS[basis], cin)
+    assert thunder_ordinal(ergebnis) >= thunder_ordinal(LOW), (
+        f"Basis {basis!r} mit CIN={cin} darf nie unter LOW fallen -- das Band "
+        f"'CAPE traegt nichts bei' existiert seit #1896 nicht mehr, erhalten "
+        f"{ergebnis!r}"
+    )
+
+
+@pytest.mark.parametrize("cin", [101.0, 200.0, 1000.0, 10000.0])
+def test_1896_ac4_basis_low_faellt_ueber_100_auf_denselben_wert_wie_darunter(cin):
+    """#1896 AC-4/AC-9: eine Basis LOW ergibt oberhalb von 100 J/kg NONE --
+    und zwar DENSELBEN Wert wie im Band darunter (50..100). Ein reiner Deckel
+    auf LOW wuerde sie hier wieder anheben; genau diese Naht ist der
+    Adversary-Befund F001.
+    """
+    darunter = _call_cape(_CAPE_JE_BASIS[LOW], 75.0)
+    ergebnis = _call_cape(_CAPE_JE_BASIS[LOW], cin)
+    assert darunter == NONE, "Vorbedingung: Basis LOW faellt im Band 50..100 auf NONE"
+    assert ergebnis == darunter, (
+        f"Basis LOW mit CIN={cin} (ueber 100) muss {darunter!r} liefern -- "
+        f"denselben Wert wie im Band darunter, nicht mehr; erhalten "
+        f"{ergebnis!r}"
+    )
+
+
+@pytest.mark.parametrize("basis", [NONE, LOW, MED, HIGH])
+def test_1896_ac9_mehr_hemmung_ergibt_nie_mehr_gewitter_ueber_die_bandnaehte(
+    basis,
+):
+    """#1896 AC-9 (Adversary-Befund F001): ueber eine aufsteigende Wertereihe,
+    die die Bandnaehte ausdruecklich einschliesst, faellt das Ergebnis monoton
+    -- ein groesserer CIN-Betrag liefert NIE eine hoehere Stufe als ein
+    kleinerer.
+
+    RED-Ursache: das oberste Band war ein ABSOLUTER Deckel auf LOW, das
+    mittlere rechnet RELATIV zur Basis. An der 100er-Naht ueberholen sie sich:
+    Basis LOW faellt bei 100,0 auf NONE, wird bei 100,1 aber wieder auf LOW
+    angehoben -- mehr Hemmung ergaebe mehr Gewitter.
+
+    Geprueft am Wirkort (Fusion `thunder_level_from_signals()`).
+    """
+    reihe = [49.9, 50.0, 99.9, 100.0, 100.1, 200.0, 10000.0]
+    cape = _CAPE_JE_BASIS[basis]
+    stufen = [_call_cape(cape, cin) for cin in reihe]
+    for (cin_klein, stufe_klein), (cin_gross, stufe_gross) in zip(
+        zip(reihe, stufen), zip(reihe[1:], stufen[1:]),
+    ):
+        assert thunder_ordinal(stufe_gross) <= thunder_ordinal(stufe_klein), (
+            f"Basis {basis!r}: CIN={cin_gross} liefert {stufe_gross!r}, aber "
+            f"das kleinere CIN={cin_klein} nur {stufe_klein!r} -- mehr Hemmung "
+            f"darf nie mehr Gewitter ergeben (ganze Reihe: "
+            f"{list(zip(reihe, stufen))!r})"
+        )
+
+
+@pytest.mark.parametrize(
+    "cin", [None, 0.0, 10.0, 49.9, 50.0, 100.0, 100.1, 500.0, 10000.0],
+)
+@pytest.mark.parametrize("basis", [NONE, LOW, MED, HIGH])
+def test_1896_ac6_daempfung_liefert_nie_mehr_als_die_ungehemmte_basis(
+    basis, cin,
+):
+    """#1896 AC-6: ueber alle vier Basisstufen und die ganze Wertereihe
+    (inklusive `None`) gilt Ergebnis <= Basis -- die Hemmung daempft
+    ausschliesslich und hebt nie an (Rasmussen & Blanchard 1998,
+    Gesamtkonzept 3.7); eichungsunabhaengig. Die Basis stammt aus DEMSELBEN
+    Fusionsaufruf ohne Hemmung, nicht aus einer hart notierten Stufe.
+    """
+    cape = _CAPE_JE_BASIS[basis]
+    ungehemmt = _call_cape(cape, 0.0)
+    ergebnis = _call_cape(cape, cin)
+    assert thunder_ordinal(ergebnis) <= thunder_ordinal(ungehemmt), (
+        f"CAPE {cape} J/kg (ungehemmt {ungehemmt!r}) mit CIN={cin!r} liefert "
+        f"{ergebnis!r} -- die Hemmung darf die Stufe NIE anheben"
+    )
+
+
+@pytest.mark.parametrize(
+    "betrag, erwartet",
+    [(10.0, HIGH), (49.0, HIGH), (50.0, MED), (100.0, MED), (150.0, LOW)],
+)
+def test_1896_ac8_gleicher_betrag_mit_beiden_vorzeichen_daempft_identisch(
+    betrag, erwartet,
+):
+    """#1896 AC-8: derselbe Betrag positiv (ICON-Konvention) und negativ
+    (US-Modelle) liefert dasselbe Ergebnis -- die Betragslogik aus #1760
+    bleibt wirksam. Zusaetzlich wird das ERGEBNIS am neuen Band festgemacht:
+    ein Test, der nur `positiv == negativ` prueft, waere auch mit den alten
+    Baendern gruen und bewiese fuer #1896 nichts.
+    """
+    positiv = _call_cape(4500.0, betrag)
+    negativ = _call_cape(4500.0, -betrag)
+    assert positiv == negativ == erwartet, (
+        f"CIN=+{betrag} und CIN=-{betrag} muessen beide {erwartet!r} liefern "
+        f"(Basis HIGH, TM-852-Baender), erhalten positiv={positiv!r}, "
+        f"negativ={negativ!r}"
+    )
+
+
+def test_1896_ac7_icon_d2_und_icon_eu_teilen_eine_cin_baenderleiter():
+    """#1896 AC-7: derselbe CIN-Betrag fuehrt bei ICON-D2 und ICON-EU zur
+    GLEICHEN Daempfung -- beide teilen denselben ICON-Code und damit dieselbe
+    CIN-Definition (Spec, Abgrenzung zu ADR-0048).
+
+    Gemessen am Produktionspfad `_fuse_thunder_levels()` mit den echten,
+    getrennt kalibrierten CAPE-Leitern beider Modelle -- kein Netz, kein
+    Mock. Der Provider-Unterschied (`dwd.py`/`dwd_eu.py`) endet fachlich beim
+    Rohwert `cin_ml`: beide liefern denselben positiven Betrag in dasselbe
+    Feld (`convective_inhibition_jkg`), und die Baender wirken erst dahinter
+    -- ein HTTP-Abruf wuerde hier nur die Providerschicht doppelt testen.
+    Geprueft wird nicht nur Gleichheit (die waere auch mit den alten Baendern
+    erfuellt), sondern die neue Sollstufe LOW fuer 104,47 J/kg.
+    """
+    from app.model_registry import cape_ladder_thresholds_jkg
+    from app.models import ForecastDataPoint
+    from providers.thunder_enrichment import _fuse_thunder_levels
+
+    ts = datetime.now(timezone.utc)
+    ergebnisse = {}
+    for model_id in ("icon_d2", "icon_eu"):
+        ladder = cape_ladder_thresholds_jkg(model_id, "DE_ALPEN")
+        assert ladder is not None, f"Vorbedingung: {model_id}/DE_ALPEN kalibriert"
+        dp = ForecastDataPoint(
+            ts=ts, thunder_level=None, cape_jkg=ladder[2] + 500.0,
+            convective_inhibition_jkg=104.47,
+        )
+        _fuse_thunder_levels([dp], ladder, None)
+        ergebnisse[model_id] = dp.thunder_level
+
+    assert ergebnisse["icon_d2"] == ergebnisse["icon_eu"] == LOW, (
+        f"CIN=104,47 J/kg (real gemessen, ICON-EU/Abruzzen) muss bei BEIDEN "
+        f"ICON-Modellen dieselbe Stufe LOW ergeben (eine Baenderleiter), "
+        f"erhalten {ergebnisse!r}"
     )


### PR DESCRIPTION
Löst die Known Limitation aus #1760 ab. Bezug: #1896, #1678, #1419 (E1b), ADR-0048.

## Problem

Die Bänder der CIN-Dämpfung (25/50/100) stammen aus US-Vorhersagepraxis für **MLCIN über 100 hPa**, pseudoadiabatisch. ICON mischt über **50 hPa**, rechnet **reversibel** und **ohne Entrainment** — dieselbe Zahl bedeutet dort etwas anderes. Dieselbe Fehlerklasse wie ADR-0048 („CAPE != CAPE"), eine Ebene tiefer.

## Lösung

Umstellung auf ECMWF Technical Memorandum 852 (Groenemeijer, Púčik, Tsonevsky, Bechtold 2019, ESSL für ECMWF), Figure 2: *"CIN (hatched areas where CIN > 50 J/kg, contour at CIN = 100 J/kg)"* — gerechnet über dieselbe 50-hPa-Mischschicht wie ICON.

| CIN-Betrag | vorher | nachher |
|---|---|---|
| < 50 | ab 25 gedämpft | keine Dämpfung |
| 50 – 100 | Deckel auf LOW | eine Stufe herunter |
| > 100 | NONE | stärkere von „eine Stufe" und „Deckel LOW" |
| `None` | höchstens LOW | unverändert (Notbremse) |

Das Band „CAPE trägt gar nichts bei" entfällt — für die stärkste Dämpfung gibt es in der ICON-nahen Quelle keinen Beleg.

**Warum das oberste Band kein reiner Deckel ist:** Sonst fällt eine Basis LOW im Band darunter auf NONE, würde aber bei *mehr* Hemmung wieder auf LOW angehoben — mehr Hemmung ergäbe mehr Gewitter. Adversary-Befund F001, behoben und durch AC-9 (Monotonie) abgesichert.

## Belege

- **Literatur:** TM852 trifft 2 von 3 Definitionsmerkmalen (Mischschichttiefe, Entrainment), die alte US-Quelle nur 1. Ausgeschlossen und dokumentiert: Huntrieser 1997, Púčik 2015, Taszarek 2021, DWD-Datenbankbeschreibung.
- **Verbleibende Abweichung:** Adiabatik. Reversibel gerechnete CIN ist betragsmäßig größer (TM852 4.3.3; Murdzek et al. 2021, J. Atmos. Sci. 78(10)) — kein fester Umrechnungsfaktor. Dem begegnet die *Struktur* der Kaskade, keine erfundene Korrekturzahl.
- **Wirkungsmessung** (2026-06-27 – 2026-08-14, Stunden mit CAPE ≥ 1000): Dämpfung greift bei ICON-D2 in 3,8 % statt 18,9 %, bei ICON-EU in 8,9 % statt 21,3 %.
- **Erreichbarkeit** zur Laufzeit belegt: echter Lauf am Karnischen Höhenweg, `basis=MED, cin=26,07 -> LOW`, mit Positiv- und Negativkontrolle.

## Verifikation

- `tests/tdd/test_cape_cin_pairing.py`: **103 passed** (vorher 99)
- Kollateral: **193 passed** über 19 abhängige Dateien
- Adversary: 2 Verifikationsläufe, 4 Runden, **VERDICT VERIFIED**; 13 Mutationen, alle gefangen
- Produktiv-LoC: +39 (Limit 250)

Spec: `docs/specs/modules/fix_1896_cin_baender_icon.md` (PO-freigegeben, AC-1…AC-9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
