### PR TITLE
fix(#1488 B): Gewitter-Wörter MED/HIGH in Mail auf Deutsch (mittel/hoch)

### DIFF
--- a/docs/context/fix-1488-sb-gewitter-mailwort.md
+++ b/docs/context/fix-1488-sb-gewitter-mailwort.md
@@ -1,0 +1,85 @@
+# Context + Analyse: #1488 Scheibe B — Gewitterwort in der Mail-Textfassung
+
+## Request Summary
+Die Mail-Textfassung (Trip-Briefing) zeigt für Gewitter-Stufen `MED`/`HIGH` (englisch) statt
+`mittel`/`hoch` — kanonisch ist `THUNDER_LABEL_DE` (`kein`/`leicht`/`mittel`/`hoch`,
+`src/output/metric_format.py:246-251`). Quelle der englischen Wörter: `_THUNDER_MAP`
+(`src/output/renderers/email/helpers.py:872-902`). Schließt #1488 (Scheibe A war
+`d519f4c5`/PR #1902, entfernte die wirkungslose Alarm-Absolutregel im Editor).
+
+## Related Files
+| File | Relevance |
+|------|-----------|
+| `src/output/renderers/email/helpers.py:872-902` | `_THUNDER_MAP` — die Wortquelle. `plain`-Feld trägt `⚡MED`/`⚡HIGH`, muss `⚡mittel`/`⚡hoch` werden |
+| `src/output/renderers/email/helpers.py:918-1085` | `format_trend_tokens()` — baut `tok["thunder_plain"]` aus `_THUNDER_MAP`; Docstring nennt an `:931-935` ebenfalls `'MED'/'HIGH'` (stale) |
+| `src/output/renderers/email/outlook.py:382,386` | Konsument 1 — Klartext-Ausblickzeile, Fallback-Zweig `"plain"` |
+| `src/output/renderers/email/compact.py:104,106` | Konsument 2 — Kompaktformat-Zeile, gleicher Fallback-Zweig |
+| `src/output/renderers/narrow.py:603,605` | Konsument 3 — Telegram/SMS-Trendblock, gleicher Fallback-Zweig |
+| `src/output/renderers/email/thunder_branch.py:50-79` | `resolve_thunder_day_branch()` — geteilte Zweigwahl aller drei Aufrufer, s. Analyse unten |
+| `src/output/metric_format.py:246-251` | `THUNDER_LABEL_DE` — kanonische deutsche Stufenwörter (bereits Ziel für andere Konsumenten, z. B. `narrow.py:278-280`) |
+| `src/services/weather_change_detection.py:814-816` | Kommentar nennt veraltete Ordinalskala `MED=1/HIGH=2` (fehlt `LOW`, seit #1474 vierstufig) |
+| `src/services/alert_preset.py:75-77` | Gleicher veralteter Skalen-Kommentar `NONE=0/MED=1/HIGH=2` |
+| `tests/tdd/test_alert_sensitivity_levels.py:6-10` | Docstring nennt dieselbe veraltete Dreier-Skala |
+| `tests/tdd/test_day_comparison_service.py:8` | dito |
+| `tests/integration/test_friendly_format_email_and_alerts.py:717` | dito (zu verifizieren, ob Zeile noch aktuell) |
+
+## Existing Patterns
+- **Geteilte Quelle statt Kopien** ist bereits etabliertes Muster hier: `resolve_thunder_day_branch()`
+  (#1671) zentralisierte die Zweigwahl für alle drei Renderer; `THUNDER_LABEL_DE`
+  (`metric_format.py`) ist bereits die kanonische deutsche Wortquelle für `narrow.py:278-280`
+  und den Ampel-/HTML-Pfad. Der naheliegende Fix: `_THUNDER_MAP["plain"]` aus `THUNDER_LABEL_DE`
+  ableiten statt eine vierte Kopie zu pflegen — genau das Muster, das Scheibe A bereits einmal
+  angewendet hat (Entfernen/Vereinheitlichen statt Umbenennen).
+- Renderer-Commit-Gate + `briefing_mail_validator.py` sind Pflicht vor „E2E bestanden"
+  (`docs/reference/gates_und_ratschen.md`), weil dies eine Mail-Inhalts-Datei betrifft.
+
+## Analyse: welcher Zweig feuert wirklich?
+
+`resolve_thunder_day_branch()` (`thunder_branch.py:50-79`) hat drei Ausgänge:
+- `"day"` — Tagesfenster trägt einen Token → Wort kommt aus dem **Token selbst**
+  (`_thunder_token_parts()` zerlegt z. B. `leicht@5(hoch@15)`), **nicht** aus `_THUNDER_MAP`.
+  Diese Wörter sind bereits deutsch (`THUNDER_LABEL_DE`-Werte fließen in den Token ein).
+- `"none"` — Stundenreihe vorhanden, Tagesfenster leer → `_THUNDER_MAP["NONE"]["plain"]` = `"⚡–"`.
+  Enthält kein `MED`/`HIGH`, unkritisch.
+- `"plain"` — **keine Stundenreihe** (`stage.get("hourly_thunder")` leer) → Rückfall auf
+  `tok["thunder_plain"]`, das volle 24h-Aggregat aus `_THUNDER_MAP[level]["plain"]`.
+  **Hier — und nur hier — kann `⚡MED`/`⚡HIGH` in einer zugestellten Mail erscheinen.**
+
+Dieser dritte Zweig ist **kein toter Code**: er greift bei jeder Etappe ohne stündliche
+Gewitterdaten (z. B. Fallback-Provider ohne stündliche Auflösung, `docs/reference/decision_matrix.md`).
+Erreichbarkeit ist damit gegeben — anders als bei Scheibe A, wo die Absolutregel nie griff.
+
+**Konsequenz für den Zuschnitt:** Der Fix muss an der Quelle (`_THUNDER_MAP["MED"/"HIGH"]["plain"]`)
+ansetzen, nicht an den drei Aufrufer-Stellen — die lesen nur `tok["thunder_plain"]` durch.
+Eine Änderung in `_THUNDER_MAP` wirkt automatisch in allen drei Renderern.
+
+## Tote Felder (Positivbefund über Grep, kein Konsument außerhalb `helpers.py`)
+`thunder_word`, `thunder_sms`, `thunder_sq_color`, `thunder_word_color` (und die zugehörigen
+`_THUNDER_MAP`-Keys `"word"`, `"sms"`, `"sq_color"`, `"word_color"`) werden nirgends außerhalb
+von `helpers.py` gelesen — bestätigt per `grep -rn` über `src/`, `api/`. Empfehlung: in dieser
+Scheibe entfernen statt weiter mitzupflegen (reduziert vier Wortkopien auf eine echte).
+
+## Dependencies
+- Upstream: `_THUNDER_MAP` wird nur mit dem `"plain"`-Feld tatsächlich konsumiert (über
+  `format_trend_tokens()`); die übrigen Felder sind Sackgassen (s. o.).
+- Downstream: drei Trip-Briefing-Renderer (`outlook.py`, `compact.py`, `narrow.py`) — alle über
+  denselben `tok["thunder_plain"]`-Zugriff im `"plain"`-Zweig betroffen. Kein Ortsvergleich-Konsument
+  (`format_trend_tokens()` wird von Compare-Renderern nicht aufgerufen — geprüft per Grep).
+
+## Existing Specs
+- Kein bestehendes Spec-Modul für `_THUNDER_MAP`/Trend-Tokens. Vorlage: `docs/specs/modules/fix_1488_sa_gewitter_absolutregel.md` (Scheibe A) als Formatvorbild, neue Spec-Datei für Scheibe B nötig.
+
+## Risks & Considerations
+- **Renderer-Commit-Gate**: Änderung an `helpers.py`/`outlook.py`/`compact.py`/`narrow.py` löst
+  Modus-Matrix-Test + `briefing_mail_validator.py` aus — vor „E2E bestanden" Pflicht.
+- **Positivkontrolle nötig**: sicherstellen, dass der `"day"`-Zweig (Token-Wörter) unverändert
+  bleibt — der Fix darf nur das `plain`-Feld in `_THUNDER_MAP` betreffen, nicht die Token-Zerlegung.
+- **Stale-Kommentar-Cleanup ist eine andere Baustelle als die Wortkorrektur**: die Kommentare in
+  `weather_change_detection.py`/`alert_preset.py`/Testdateien beziehen sich auf die *Ordinalskala*
+  (fehlendes `LOW` seit #1474), nicht auf die MED/HIGH-Wörter selbst — inhaltlich getrennter,
+  aber laut Vorgänger-Session (#1488-Memory) bewusst mitgezogener Nebenaufwand. Nur Kommentartext
+  ändern, keine Verhaltensänderung.
+- **Test-Nachweis**: `THUNDER_LABEL_DE` ist bereits die Zielquelle — Fix sollte `_THUNDER_MAP["plain"]`
+  daraus ableiten (`f"⚡{THUNDER_LABEL_DE[level]}"`), damit künftige Stufenänderungen an einer Stelle
+  greifen. Reproduktion des Bugs: Stage ohne `hourly_thunder` mit `thunder=MED` erzeugen → aktuell
+  `⚡MED`, nach Fix `⚡mittel`.

--- a/docs/specs/modules/fix_1488_sb_gewitter_mailwort.md
+++ b/docs/specs/modules/fix_1488_sb_gewitter_mailwort.md
@@ -1,0 +1,181 @@
+---
+entity_id: fix_1488_sb_gewitter_mailwort
+type: bugfix
+created: 2026-08-16
+updated: 2026-08-16
+status: draft
+version: "1.0"
+tags: [gewitter, mail-renderer, trip-briefing, backend]
+---
+
+# #1488 Scheibe B — Gewitterwort in der Mail-Textfassung (schließt #1488)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Die Trip-Briefing-Mail-Textfassung zeigt für Gewitter-Stufen englisch `⚡MED`/`⚡HIGH`
+statt der kanonischen deutschen Wörter `⚡mittel`/`⚡hoch`. Kanonische Quelle ist bereits
+`THUNDER_LABEL_DE` (`src/output/metric_format.py:246-251`); die Wortquelle für den
+betroffenen Fallback-Zweig kopiert die Wörter jedoch noch selbst, teils veraltet
+englisch. Scheibe B zieht diesen Zweig auf die kanonische Quelle und schließt damit
+#1488 endgültig ab (Scheibe A, `d519f4c5`/PR #1902, entfernte bereits die wirkungslose
+Gewitter-Alarm-Absolutregel im Editor — ein separater Bedienflächen-Bug).
+
+## Source
+
+- **File:** `src/output/renderers/email/helpers.py`
+- **Identifier:** `_THUNDER_MAP` (Modul-Konstante) / `format_trend_tokens()`
+
+> Schicht: **Python-Core / Backend-Renderer** (`src/output/renderers/...`, FastAPI-Core,
+> Trip-Briefing-Mailversand). Kein Go- und kein Frontend-Code betroffen.
+
+## Estimated Scope
+
+- **LoC:** ~130 (touched) — Kernänderung ~30 Zeilen, Kommentarkorrekturen ~6 Zeilen,
+  neuer Testfall ~90 Zeilen
+- **Files:** 7 (2 Kernänderung, 4 reine Kommentarkorrektur, 1 neue Testdatei)
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `THUNDER_LABEL_DE` (`src/output/metric_format.py:246-251`) | Konstante | kanonische deutsche Stufenwörter — neue Ableitungsquelle für `_THUNDER_MAP["plain"]`/`["word"]` |
+| `resolve_thunder_day_branch()` (`src/output/renderers/email/thunder_branch.py:54-79`) | Funktion | wählt den `"plain"`-Zweig, der von diesem Fix betroffen ist — bleibt unverändert, ist nur Konsument der korrigierten Werte |
+| `format_trend_tokens()` (`helpers.py:905-…`) | Funktion | einzige Erzeugungsstelle des betroffenen Dict; von allen drei Renderern aufgerufen |
+| `outlook.py:382,386` / `compact.py:104,106` / `narrow.py:603,605` | Renderer | lesen `tok["thunder_plain"]` im `"plain"`-Zweig — keine eigene Änderung nötig, Fix wirkt automatisch durch |
+| `tests/tdd/test_thunder_low_output_channels.py::test_ac11_trend_block_zeigt_leicht` (#1474 AC-11) | Bestandstest | harter Konsument von `tokens["thunder_word"]` — Feld bleibt bestehen und wird ebenfalls korrigiert, nicht gelöscht (Abweichung von der Ausgangsanalyse, s. „Known Limitations") |
+
+## Implementation Details
+
+**1. `_THUNDER_MAP` in `helpers.py:872-902`:** `"plain"` und `"word"` für alle vier
+Stufen aus `THUNDER_LABEL_DE` ableiten statt hartkodierter Strings, damit künftige
+Stufenänderungen an einer Stelle greifen (dasselbe Muster wie `narrow.py:278-280`):
+
+```python
+from output.metric_format import THUNDER_LABEL_DE, ThunderLevel
+
+_THUNDER_MAP = {
+    "NONE": {"word": THUNDER_LABEL_DE[ThunderLevel.NONE], "plain": "⚡–"},
+    "LOW":  {"word": THUNDER_LABEL_DE[ThunderLevel.LOW],
+             "plain": f"⚡{THUNDER_LABEL_DE[ThunderLevel.LOW]}"},
+    "MED":  {"word": THUNDER_LABEL_DE[ThunderLevel.MED],
+             "plain": f"⚡{THUNDER_LABEL_DE[ThunderLevel.MED]}"},
+    "HIGH": {"word": THUNDER_LABEL_DE[ThunderLevel.HIGH],
+             "plain": f"⚡{THUNDER_LABEL_DE[ThunderLevel.HIGH]}"},
+}
+```
+
+`"plain": "⚡–"` bei `NONE` bleibt Sonderfall (kein Wort, Gedankenstrich) — unverändert,
+kein Bug dort.
+
+**2. Tote Felder entfernen:** Die Keys `"sms"`, `"sq_color"`, `"word_color"` fallen aus
+allen vier `_THUNDER_MAP`-Einträgen weg. In `format_trend_tokens()` (Rückgabe-Dict,
+`helpers.py:1074-1078`) entfallen entsprechend `"thunder_sms"`, `"thunder_sq_color"`,
+`"thunder_word_color"`. `"thunder_word"` **bleibt erhalten** (s. Known Limitations).
+
+**3. Docstring korrigieren** (`helpers.py:931-935`): Zeilen zu `thunder_sq_color`,
+`thunder_word_color`, `thunder_sms` streichen; `thunder_word`/`thunder_plain`-Beispiele
+auf die deutschen Wörter (`'kein' / 'leicht' / 'mittel' / 'hoch'` bzw.
+`'⚡–' / '⚡leicht' / '⚡mittel' / '⚡hoch'`) korrigieren.
+
+**4. Kommentarkorrektur (reine Textänderung, keine Verhaltensänderung)** — veraltete
+Dreier-Skala `NONE=0/MED=1/HIGH=2` auf die seit #1474 gültige Vierer-Skala
+`NONE=0/LOW=1/MED=2/HIGH=3` korrigieren:
+- `src/services/weather_change_detection.py:814-816`
+- `src/services/alert_preset.py:75-77`
+- `tests/tdd/test_alert_sensitivity_levels.py:6`
+- `tests/tdd/test_day_comparison_service.py:8`
+- `tests/integration/test_friendly_format_email_and_alerts.py:717` (Zeile verifiziert, kein Drift)
+
+## Expected Behavior
+
+- **Input:** Etappe ohne stündliche Gewitterdaten (`stage["hourly_thunder"]` leer)
+  mit `thunder="MED"` bzw. `"HIGH"`, gerendert in Outlook-Klartext, Kompaktformat-Mail
+  oder Telegram/SMS-Trendblock.
+- **Output:** `⚡mittel` bzw. `⚡hoch` statt bisher `⚡MED`/`⚡HIGH`. Der `"day"`-Zweig
+  (Etappe MIT stündlicher Gewitterreihe und gesetztem Tagesfenster-Token) ist von der
+  Änderung nicht betroffen — er liest weiterhin aus dem Token, nicht aus `_THUNDER_MAP`.
+- **Side effects:** keine. Kein Ortsvergleich-Konsument (`format_trend_tokens()` wird
+  von Compare-Renderern nicht aufgerufen — per Grep verifiziert, Compare bleibt
+  unberührt).
+
+## Acceptance Criteria
+
+- **AC-1:** Given eine Etappe ohne stündliche Gewitterdaten (`hourly_thunder` leer)
+  mit Stufe `MED` bzw. `HIGH`, When die Mail-Textfassung über die drei produktiven
+  Renderer-Funktionen (`render_outlook_plain`/`_compact_thunder_field`/den
+  Telegram-Trendblock) gerendert wird, Then zeigt die Ausgabe `⚡mittel` bzw. `⚡hoch`
+  statt `⚡MED`/`⚡HIGH`.
+  - Test: neuer Testfall in `tests/tdd/test_trend_plain_branch_shows_german_thunder_words.py`,
+    ruft alle drei produktiven Renderer-Funktionen direkt mit einer Stage ohne
+    `hourly_thunder` auf (kein Dateiinhalt-Check, echte Renderfunktionen).
+
+- **AC-2 (Positivkontrolle):** Given eine Etappe MIT stündlicher Gewitterreihe, die im
+  Tagesfenster eine Stufe trägt (`resolve_thunder_day_branch()` liefert `"day"`), When
+  dieselben drei Renderer aufgerufen werden, Then bleibt das gerenderte Wort unverändert
+  aus dem Tages-Token abgeleitet (`_thunder_token_parts()`) — der `"day"`-Zweig liest
+  weiterhin nicht aus `_THUNDER_MAP`.
+  - Test: derselbe neue Testfall, Gegenprobe im selben Testlauf mit gesetztem
+    `hourly_thunder` und passendem Tagesfenster-Token.
+
+- **AC-3 (Erreichbarkeit belegt, kein toter Zweig):** Given `stage.get("hourly_thunder")`
+  ist leer und `thunder="HIGH"`, When `resolve_thunder_day_branch()` direkt ausgewertet
+  wird, Then liefert sie `"plain"` — der reproduzierbare Beleg, dass dieser Zweig für
+  Etappen ohne stündliche Gewitterdaten tatsächlich greift.
+  - Test: Teil desselben neuen Testfalls, direkter Aufruf von
+    `resolve_thunder_day_branch()` ohne Umweg über die Renderer.
+
+- **AC-4 (Bestandsschutz #1474 AC-11):** Given der bestehende Test
+  `test_thunder_low_output_channels.py::test_ac11_trend_block_zeigt_leicht`, When
+  Scheibe B umgesetzt ist, Then liefert `format_trend_tokens(...)["thunder_word"]` bei
+  `ThunderLevel.LOW` weiterhin exakt `"leicht"` — das Feld wird korrigiert (aus
+  `THUNDER_LABEL_DE` abgeleitet), nicht gelöscht, und der Bestandstest bleibt
+  unverändert grün.
+  - Test: bestehender Test `tests/tdd/test_thunder_low_output_channels.py`, unverändert
+    lauffähig, CI-Lauf als Beleg.
+
+- **AC-5 (tote Felder restlos entfernt):** Given `_THUNDER_MAP` nach dem Fix, When
+  `format_trend_tokens()` für eine beliebige Stufe aufgerufen wird, Then enthält das
+  zurückgegebene Dict keine Schlüssel `thunder_sms`, `thunder_sq_color`,
+  `thunder_word_color` mehr.
+  - Test: neuer Testfall (gleiche Datei wie AC-1), prüft
+    `{"thunder_sms", "thunder_sq_color", "thunder_word_color"} & tokens.keys() == set()`
+    plus vollständiger Lauf der bestehenden Trend-Testsuite (kein KeyError, keine
+    Regression).
+
+## Known Limitations
+
+- **Abweichung von der Ausgangsanalyse:** Das Analyse-Dokument
+  (`docs/context/fix-1488-sb-gewitter-mailwort.md`) stufte `thunder_word` als toten
+  Nebeneffekt ein („kein Konsument außerhalb `helpers.py`", per Grep über `src/`/`api/`).
+  Gegenprüfung ergab einen Konsumenten außerhalb dieses Bereichs: der Bestandstest
+  `tests/tdd/test_thunder_low_output_channels.py:73-85` liest
+  `format_trend_tokens(...)["thunder_word"]` direkt als AC-11-Nachweis für #1474
+  („E-Mail Trend-Block" ist einer von sechs geprüften Render-Einstiegspunkten für die
+  Stufe „leicht"). Lösung: `thunder_word` **bleibt erhalten** und wird — konsistent mit
+  `thunder_plain` — aus `THUNDER_LABEL_DE` abgeleitet, statt gelöscht zu werden. Damit
+  bleibt der #1474-Test unverändert grün, und die (vorher unreachable, aber latent
+  falsche) `MED`/`HIGH`-Werte in `thunder_word` werden als Nebeneffekt korrekt.
+  `thunder_sms`, `thunder_sq_color`, `thunder_word_color` sind dagegen per Grep über
+  `src/` UND `tests/` bestätigt konsumentenlos und werden wie geplant entfernt.
+- Für eine Etappe mit stündlicher Gewitterreihe, aber leerem Tagesfenster
+  (`resolve_thunder_day_branch()` → `"none"`), bleibt `_THUNDER_MAP["NONE"]["plain"]`
+  (`"⚡–"`) unverändert — kein Wort, kein MED/HIGH-Bug, nicht Teil dieser Scheibe.
+- Ortsvergleich (Compare) ist von dieser Änderung nicht betroffen — `format_trend_tokens()`
+  wird von keinem Compare-Renderer aufgerufen (per Grep verifiziert). Keine Teilungsfrage
+  Trip/Compare hier, da kein Compare-Pendant existiert.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue
+- **Rationale:** Reine Bugfix-Konsolidierung auf eine bereits bestehende kanonische
+  Quelle (`THUNDER_LABEL_DE`). Kein neues Architekturprinzip, kein neuer
+  Entscheidungsraum.
+
+## Changelog
+
+- 2026-08-16: Initial spec created (spec-writer, Workflow `fix-1488-sb-gewitter-mailwort`)

--- a/src/output/renderers/email/helpers.py
+++ b/src/output/renderers/email/helpers.py
@@ -34,6 +34,7 @@ from app.models import (
 from utils.geo import degrees_to_compass
 from utils.timezone import local_dt, local_fmt, local_hour
 
+from output.metric_format import THUNDER_LABEL_DE
 from output.renderers.day_window import DAY_WINDOW_END_HOUR, DAY_WINDOW_START_HOUR
 from output.renderers.email.design_tokens import FONT_DATA
 
@@ -870,34 +871,23 @@ def shorten_stage_name(name: str, max_len: int = 25) -> str:
 
 # Issue #623: Shared trend-token function — single source of truth for all channels.
 _THUNDER_MAP = {
+    # NONE zeigt bewusst kein Wort, sondern einen Gedankenstrich (Issue #1488 B).
     "NONE": {
-        "word": "kein",
-        "sq_color": "#9a958a",
-        "word_color": "#6b675c",
+        "word": THUNDER_LABEL_DE[ThunderLevel.NONE],
         "plain": "⚡–",
-        "sms": None,
     },
-    # Issue #1474: neue Stufe "leicht" (LOW), Farbe zwischen NONE und MED.
+    # Issue #1474: neue Stufe "leicht" (LOW).
     "LOW": {
-        "word": "leicht",
-        "sq_color": "#c9a45a",
-        "word_color": "#8c6d2a",
-        "plain": "⚡leicht",
-        "sms": "GEW-LOW",
+        "word": THUNDER_LABEL_DE[ThunderLevel.LOW],
+        "plain": f"⚡{THUNDER_LABEL_DE[ThunderLevel.LOW]}",
     },
     "MED": {
-        "word": "MED",
-        "sq_color": "#c08a1a",
-        "word_color": "#8c3e1a",
-        "plain": "⚡MED",
-        "sms": "GEW-MED",
+        "word": THUNDER_LABEL_DE[ThunderLevel.MED],
+        "plain": f"⚡{THUNDER_LABEL_DE[ThunderLevel.MED]}",
     },
     "HIGH": {
-        "word": "HIGH",
-        "sq_color": "#a83232",
-        "word_color": "#a83232",
-        "plain": "⚡HIGH",
-        "sms": "GEW-HIGH",
+        "word": THUNDER_LABEL_DE[ThunderLevel.HIGH],
+        "plain": f"⚡{THUNDER_LABEL_DE[ThunderLevel.HIGH]}",
     },
 }
 
@@ -928,11 +918,8 @@ def format_trend_tokens(stage: dict) -> dict:
             wind_str        — 'W20' / '20'
             wind_highlight  — bool (wind_kmh > 30)
             wind_risk       — bool (wind_kmh >= 50)
-            thunder_word    — 'kein' / 'leicht' / 'MED' / 'HIGH'
-            thunder_sq_color — HTML hex for ampel square
-            thunder_word_color — HTML hex for word text
-            thunder_plain   — '⚡–' / '⚡MED' / '⚡HIGH'
-            thunder_sms     — 'GEW-MED' / 'GEW-HIGH' / None (absent for NONE)
+            thunder_word    — 'kein' / 'leicht' / 'mittel' / 'hoch'
+            thunder_plain   — '⚡–' / '⚡leicht' / '⚡mittel' / '⚡hoch'
             precip_token    — '{erst}@{h}({peak}@{h})' or '-' (#640)
             wind_token      — '{v}@{h}(...)' or '-' (#640)
             gust_token      — '{v}@{h}(...)' or '-' (#640)
@@ -1072,10 +1059,7 @@ def format_trend_tokens(stage: dict) -> dict:
         "wind_highlight": wind_highlight,
         "wind_risk": wind_risk,
         "thunder_word": t_data["word"],
-        "thunder_sq_color": t_data["sq_color"],
-        "thunder_word_color": t_data["word_color"],
         "thunder_plain": t_data["plain"],
-        "thunder_sms": t_data["sms"],
         # Issue #640: @-time tokens (single source of truth)
         "precip_token": precip_token,
         "wind_token": wind_token,

--- a/src/services/alert_preset.py
+++ b/src/services/alert_preset.py
@@ -73,8 +73,8 @@ _COL: Final[dict[str, int]] = {
 
 # ─────────────── Issue #1460 (P1b): Niveau statt Sprunggroesse ──────────────
 #
-# Gefahrenstufen-Groessen (aktuell nur THUNDER_LEVEL, Skala NONE=0/MED=1/
-# HIGH=2) lassen sich nicht ueber eine Delta-Zahl steuern: "Mittelstufe
+# Gefahrenstufen-Groessen (aktuell nur THUNDER_LEVEL, Skala NONE=0/LOW=1/
+# MED=2/HIGH=3) lassen sich nicht ueber eine Delta-Zahl steuern: "Mittelstufe
 # erreicht" und "Hoechststufe von der Mittelstufe erreicht" sind derselbe
 # Sprung (1), sollen aber unterschiedlich melden. Massgeblich ist deshalb das
 # erreichte (Verschaerfung) bzw. verlassene (Entwarnung) NIVEAU.

--- a/src/services/weather_change_detection.py
+++ b/src/services/weather_change_detection.py
@@ -812,7 +812,8 @@ class WeatherChangeDetectionService:
                 new_value = thunder_ordinal(new_value)
             comparison = _ALERT_METRIC_COMPARISON[rule.metric]
             # Issue #222 F003: THUNDER_LEVEL uses >= for above (user intent
-            # "ab Stufe MED alarmieren" — threshold=1.0 must match MED=1).
+            # "ab Stufe X alarmieren" — the threshold must match the level
+            # itself; scale NONE=0/LOW=1/MED=2/HIGH=3 since #1474).
             # Other numeric metrics keep strict > to avoid spurious noise.
             if rule.metric == AlertMetric.THUNDER_LEVEL:
                 triggered = (

--- a/tests/integration/test_friendly_format_email_and_alerts.py
+++ b/tests/integration/test_friendly_format_email_and_alerts.py
@@ -714,7 +714,7 @@ class TestThunderEnumAlerts:
         assert len(changes) == 0
 
     def test_thunder_high_to_none_detected(self):
-        """Thunder HIGH→NONE (ordinal 2→0, threshold 1.0) → decrease detected."""
+        """Thunder HIGH→NONE (ordinal 3→0, threshold 1.0) → decrease detected."""
         from services.weather_change_detection import WeatherChangeDetectionService
 
         cached = _make_segment_weather(

--- a/tests/tdd/test_alert_sensitivity_levels.py
+++ b/tests/tdd/test_alert_sensitivity_levels.py
@@ -3,7 +3,7 @@ Gefahrenstufen-Groessen ueber das erreichte NIVEAU, nicht ueber die Sprunggroess
 
 SPEC: docs/specs/modules/rework_1460_t1_relevanzfilter.md v1.2 (AC-4 .. AC-19)
 
-Zielsemantik (Ordinalwerte NONE=0 / MED=1 / HIGH=2) — beide Richtungen melden,
+Zielsemantik (Ordinalwerte NONE=0 / LOW=1 / MED=2 / HIGH=3) — beide Richtungen melden,
 symmetrisch je Stufe (PO-go 2026-08-03):
 
     sensibel   -> Verschaerfung: `neu > alt`               Entwarnung: `neu < alt`

--- a/tests/tdd/test_day_comparison_service.py
+++ b/tests/tdd/test_day_comparison_service.py
@@ -5,7 +5,7 @@ Kein Mock: Tests bauen echte SegmentWeatherData-Objekte.
 
 AC-1: compare() gibt DayComparison mit einem Eintrag pro heutigem Segment zurück
 AC-2: Niederschlag weniger = BETTER, delta = heute - gestern
-AC-3: ThunderLevel-Ordinal-Vergleich (NONE=0, MED=1, HIGH=2)
+AC-3: ThunderLevel-Ordinal-Vergleich (NONE=0, LOW=1, MED=2, HIGH=3)
 AC-4: Segment-ID fehlt in yesterday-Liste → alle Directions MISSING
 AC-5: Temperatur ist neutral → direction immer EQUAL, delta gesetzt
 

--- a/tests/tdd/test_kompaktmail_ausblick_tagesfenster.py
+++ b/tests/tdd/test_kompaktmail_ausblick_tagesfenster.py
@@ -355,7 +355,10 @@ def test_unzerlegbarer_tagestoken_faellt_auf_kein_gewitter_zurueck():
 # ``_kompakt_ausblick_zeile()`` -- KEIN zweiter Aufruf desselben Codes zur
 # Testlaufzeit (Spec AC-5, Begruendung woertlich aus
 # tests/tdd/test_trip_outlook_parity.py).
-_AC5_ALT_ZEILE_SOLL = "Mi  Alte Etappe                9-21C   1.5mm NW22  TMED"
+# Issue #1488 Scheibe B: Sollwert neu aufgezeichnet -- das Aggregatwort kommt
+# jetzt aus THUNDER_LABEL_DE ("mittel" statt "MED"). Geprueft bleibt die
+# Zweigwahl (Rueckfall auf `thunder_plain` ohne Stundenreihe), nicht das Vokabular.
+_AC5_ALT_ZEILE_SOLL = "Mi  Alte Etappe                9-21C   1.5mm NW22  Tmittel"
 
 _AC5_ALT_ZEILE = dict(
     weekday="Mi", name="Alte Etappe", note=None,

--- a/tests/tdd/test_outlook_day_night_thunder_split.py
+++ b/tests/tdd/test_outlook_day_night_thunder_split.py
@@ -602,7 +602,8 @@ class TestPlainDayWordComesFromDayToken:
         row = self._first_row(render_outlook_plain([
             _stage(hourly_thunder=(), thunder="MED"),
         ]))
-        assert row.endswith("⚡MED"), f"Got: {row!r}"
+        # Issue #1488 B: Aggregatwort kommt aus THUNDER_LABEL_DE ("mittel").
+        assert row.endswith("⚡mittel"), f"Got: {row!r}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tdd/test_trend_plain_branch_shows_german_thunder_words.py
+++ b/tests/tdd/test_trend_plain_branch_shows_german_thunder_words.py
@@ -1,0 +1,129 @@
+"""TDD RED — Issue #1488 Scheibe B.
+
+SPEC: docs/specs/modules/fix_1488_sb_gewitter_mailwort.md AC-1..AC-3, AC-5
+
+Der `"plain"`-Zweig von `resolve_thunder_day_branch()` (Etappe OHNE stuendliche
+Gewitterreihe) liest `tok["thunder_plain"]` aus `_THUNDER_MAP`
+(`output.renderers.email.helpers`), das fuer die Stufen MED/HIGH noch die
+englischen Woerter `'⚡MED'`/`'⚡HIGH'` traegt statt der kanonischen deutschen
+Woerter aus `THUNDER_LABEL_DE` (`'⚡mittel'`/`'⚡hoch'`). Alle drei produktiven
+Renderer (Klartext-Ausblick, Kompaktformat, Telegram-Trendblock) rufen
+denselben `tok["thunder_plain"]`-Wert ab -- kein Test-Zwischenlayer, jede
+Assertion prueft eine tatsaechlich gerenderte Ausgabe (ADR-0025 Entscheidung 5).
+
+RED-Ursache (heute, vor der Implementierung):
+- `_THUNDER_MAP["MED"]["plain"]` == "⚡MED" (nicht "⚡mittel")
+- `_THUNDER_MAP["HIGH"]["plain"]` == "⚡HIGH" (nicht "⚡hoch")
+- `format_trend_tokens()` liefert noch die toten Felder `thunder_sms`,
+  `thunder_sq_color`, `thunder_word_color`
+
+Keine Mocks, kein Dateiinhalt-Check.
+"""
+from __future__ import annotations
+
+
+def _stage_ohne_stundenreihe(thunder: str) -> dict:
+    return dict(
+        weekday="Mo", name="Etappe Gewitter", temp_lo=10, temp_hi=18,
+        precip_mm=0.0, wind_dir="W", wind_kmh=10, thunder=thunder, note=None,
+        hourly_precip=(), hourly_wind=(), hourly_gust=(), hourly_thunder=(),
+    )
+
+
+# ────────── AC-1 + AC-3: "plain"-Zweig zeigt deutsches Wort, ist erreichbar ──
+
+def test_ac1_ac3_plain_zweig_zeigt_deutsche_gewitterworte():
+    from output.renderers.email.compact import _compact_thunder_field
+    from output.renderers.email.helpers import format_trend_tokens
+    from output.renderers.email.outlook import render_outlook_plain
+    from output.renderers.email.thunder_branch import resolve_thunder_day_branch
+    from output.renderers.narrow import _outlook_lines
+
+    for level, deutsches_wort in (("MED", "mittel"), ("HIGH", "hoch")):
+        stage = _stage_ohne_stundenreihe(level)
+        tok = format_trend_tokens(stage)
+
+        # AC-3: der Zweig ist erreichbar -- kein toter Code
+        branch = resolve_thunder_day_branch(tok, stage)
+        assert branch == "plain", (
+            f"resolve_thunder_day_branch() liefert {branch!r} statt 'plain' "
+            f"fuer eine Etappe ohne hourly_thunder -- AC-3 unbelegt."
+        )
+
+        # AC-1: Klartext-Ausblick (outlook.py)
+        plain_text = render_outlook_plain([stage])
+        assert f"⚡{deutsches_wort}" in plain_text, (
+            f"Klartext-Ausblick zeigt bei thunder={level!r} nicht "
+            f"'⚡{deutsches_wort}'. Ausgabe: {plain_text!r}"
+        )
+        assert level not in plain_text, (
+            f"Klartext-Ausblick zeigt bei thunder={level!r} noch das "
+            f"englische Wort {level!r}. Ausgabe: {plain_text!r}"
+        )
+
+        # AC-1: Kompaktformat (compact.py)
+        compact_field = _compact_thunder_field(tok, stage)
+        assert compact_field == f"⚡{deutsches_wort}", (
+            f"Kompaktformat zeigt bei thunder={level!r} nicht "
+            f"'⚡{deutsches_wort}', erhalten {compact_field!r}"
+        )
+
+        # AC-1: Telegram/SMS-Trendblock (narrow.py)
+        telegram_text = "\n".join(_outlook_lines([stage]))
+        assert f"⚡{deutsches_wort}" in telegram_text, (
+            f"Telegram-Trendblock zeigt bei thunder={level!r} nicht "
+            f"'⚡{deutsches_wort}'. Ausgabe: {telegram_text!r}"
+        )
+        assert level not in telegram_text, (
+            f"Telegram-Trendblock zeigt bei thunder={level!r} noch das "
+            f"englische Wort {level!r}. Ausgabe: {telegram_text!r}"
+        )
+
+
+# ────────── AC-2 (Positivkontrolle): "day"-Zweig bleibt unveraendert ────────
+
+def test_ac2_positivkontrolle_day_zweig_unveraendert():
+    """Bewusst KEIN RED-Test -- Gegenprobe, dass der tokenbasierte 'day'-Zweig
+    von dieser Scheibe nicht angefasst wird. Muss vor UND nach der
+    Implementierung gruen bleiben.
+    """
+    from output.renderers.email.helpers import format_trend_tokens
+    from output.renderers.email.outlook import render_outlook_plain
+    from output.renderers.email.thunder_branch import resolve_thunder_day_branch
+    from output.tokens.dto import HourlyValue
+
+    stage = dict(
+        weekday="Di", name="Etappe Tagesgewitter", temp_lo=10, temp_hi=18,
+        precip_mm=0.0, wind_dir="W", wind_kmh=10, thunder="HIGH", note=None,
+        hourly_precip=(), hourly_wind=(), hourly_gust=(),
+        # 12 Uhr liegt im Tagesfenster (4-19, day_window.py); Stufe 2 = "mittel"
+        # in _TREND_THUNDER_LABELS.
+        hourly_thunder=(HourlyValue(hour=12, value=2.0),),
+    )
+    tok = format_trend_tokens(stage)
+    branch = resolve_thunder_day_branch(tok, stage)
+    assert branch == "day", (
+        f"Testaufbau fehlerhaft -- Positivkontrolle braucht den 'day'-Zweig, "
+        f"erhalten {branch!r}."
+    )
+    assert tok["thunder_day_token"] != "-"
+
+    plain_text = render_outlook_plain([stage])
+    assert "mittel" in plain_text, (
+        f"Der 'day'-Zweig muss unveraendert das Tageswort aus dem Token "
+        f"zeigen (nicht aus _THUNDER_MAP). Ausgabe: {plain_text!r}"
+    )
+
+
+# ────────── AC-5: tote Felder restlos entfernt ──────────────────────────────
+
+def test_ac5_tote_felder_entfernt():
+    from output.renderers.email.helpers import format_trend_tokens
+
+    tokens = format_trend_tokens(_stage_ohne_stundenreihe("HIGH"))
+    tote_felder = {"thunder_sms", "thunder_sq_color", "thunder_word_color"}
+    vorhanden = tote_felder & tokens.keys()
+    assert not vorhanden, (
+        f"format_trend_tokens() liefert noch tote Felder: {vorhanden}. "
+        f"AC-5 verlangt, dass sie entfernt sind."
+    )


### PR DESCRIPTION
Mail-Trend-Tokens zeigten bisher englische Kürzel (MED/HIGH) statt der
deutschen Sicherheitswörter. Tote Felder (SMS-Token, Ampel-Farben) aus
der Thunder-Map entfernt, thunder_word/thunder_plain nutzen jetzt
THUNDER_LABEL_DE als Single Source of Truth. Schließt #1488 zusammen
mit Scheibe A (46ff82c2).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
