### PR TITLE
feat(#1467 S4b-1): quellenuebergreifende Alarm-Entdopplung nach Ereignis-Identitaet

### DIFF
--- a/docs/adr/0021-shared-deviation-alert-engine.md
+++ b/docs/adr/0021-shared-deviation-alert-engine.md
@@ -186,3 +186,21 @@ dieser Scheibe (Scheibe 2, #1169).
   eigener Aufruf unmittelbar NACH dem Baustein, `is_silenced` bleibt
   Compare-eigen und außerhalb. Kein neues Architekturprinzip. Details:
   `docs/specs/modules/rework_1467_s4a_amtlich.md`.
+- **Nachtrag (Issue #1467 S4b, 2026-08-16):** seit dieser Scheibe existiert eine
+  **quellenübergreifende** Ereignis-Identität-Prüfung — `services/alert_gate.py::
+  check_event_identity_gate()` —, als **letzte, gemeinsame** Stufe für Nowcast-
+  UND amtliche Trip-Alarme (`trip_alert.py::check_radar_alerts`,
+  `_send_official_alert_only`). Anders als die bisherigen Stufen (Ruhezeit,
+  Sperrzeit, Tages-Obergrenze), die je Quelle in getrennten Töpfen laufen,
+  entdoppelt diese Stufe **über beide Quellen hinweg**: gleiche Gefahrenklasse
+  (T2-Kanon, EINE Klasse `wet`) + gleicher Ortsbezug + überlappendes Zeitfenster
+  ⇒ nur die erste Meldung geht raus, außer eine echte Verschärfung (V2,
+  strukturell erster Zweig) oder eine wesentliche zeitliche Erweiterung (V1-
+  Ausnahme) durchbricht die Unterdrückung. Der amtliche Pfad protokolliert für
+  diesen EINEN neuen Grund (`REASON_EVENT_DUPLICATE`) erstmals eine
+  Unterdrückung — die Aussage aus dem S3-Nachtrag zur
+  Unterdrückungs-Protokollierung bleibt für Ruhezeit/Tageslimit unverändert
+  gültig (der amtliche Pfad protokolliert dafür weiterhin nichts). Kein neues
+  Architekturprinzip: derselbe geteilte-Baustein-Ansatz aus diesem ADR,
+  erstmals angewandt auf einen Vergleich ÜBER Quellen hinweg statt innerhalb
+  einer Quelle. Details: `docs/specs/modules/rework_1467_s4b_entdopplung.md`.

--- a/docs/context/rework-1467-s4b-entdopplung.md
+++ b/docs/context/rework-1467-s4b-entdopplung.md
@@ -1,0 +1,240 @@
+# Context: rework-1467-s4b-entdopplung
+
+Erhoben am 2026-08-16 für Issue #1467 Scheibe S4b (= #1744 Scheibe B).
+Alle Zeilenangaben gegen `origin/main` @ `5ddb46e7`.
+
+## Request Summary
+
+Alarme sollen **quellenübergreifend nach Ereignis-Identität** entdoppelt werden: gleiche
+Gefahrenart + gleicher Ortsbezug + überlappendes Zeitfenster ⇒ **eine** Meldung. Auslöser ist ein
+gemessener Fall vom 2026-08-12: Radar-Nowcast „Gewitter in 8 Min" (16:22) und amtliche Warnung
+„GELB Gewitter" (16:30) zum selben Gewitter, beide zugestellt — die Sperrzeiten liegen in
+getrennten Töpfen je **Quelle** und können einander konstruktionsbedingt nicht sehen.
+
+S4b ist die letzte Scheibe von #1467 und **schließt das Issue**.
+
+## Kernbefund: Die drei Bestandteile der Ereignis-Identität existieren heute in je drei
+## unvereinbaren Ausdrucksformen
+
+Es sind **sechs** Alarmpfade (drei Alarmarten × zwei Flächen), nicht vier.
+
+| Bestandteil | Änderungsalarm (Δ) | Radar-Nowcast | Amtliche Warnung |
+|---|---|---|---|
+| **Gefahrenart** | `WeatherChange.metric: str` — Summary-Feldnamen wie `thunder_level_max`, `gust_max_kmh` (`app/models.py:548`) | **kein Textfeld**; nur `NowcastResult.is_convective: bool` + `intensity_label` (Freitext, Anzeige) (`radar_service.py:84,87`) | `OfficialAlert.hazard: str` ohne Enum — `"thunderstorm"`, `"flood"`, `"wildfire_risk"`, quellenabhängig (`official_alerts/models.py:21`) |
+| **Ortsbezug** | `WeatherChange.segment_id` (Trip) bzw. `location_id` (Compare) (`app/models.py:555`) | `segment_id` + Korridor-km `km_from`/`km_to` (`notification_service.py:172-185`) bzw. `loc.id` | `OfficialAlert.region_label` — **Freitext der fremden Quelle, eigene Geografie** (`official_alerts/models.py:27`) |
+| **Zeitfenster** | `occurred_at: datetime\|None` — **Zeitpunkt** (`app/models.py:560`) | `onset_minutes`/`onset_time` — **Zeitpunkt**; der 60-Min-Horizont steckt nur in `radar_service.py:62`, nicht im Objekt | `valid_from`/`valid_to` — echtes **Intervall** (`official_alerts/models.py:24-25`) |
+
+**Es gibt keine Umrechnung zwischen diesen Ausdrucksformen** — weder
+`thunder_level_max` ↔ `is_convective=True` ↔ `"thunderstorm"`, noch Korridor-km/Segment-ID ↔
+`region_label`. Koordinaten dienen nur dem Abruf und werden nirgends als gemeinsamer Schlüssel
+abgelegt.
+
+**Es gibt kein gemeinsames Ereignis-Objekt vor dem Versand.** Die sechs Pfade konvergieren erst
+**nach** der Melde-Entscheidung auf `NotificationResult` (`notification_service.py:113-144`).
+Bis dahin trägt jeder Pfad seine eigene Nutzlast (`List[WeatherChange]` /
+`RadarAlertRequest` / `list[tuple[OfficialAlert, list[str]]]` und die drei Compare-Pendants).
+
+## Messung am produktiven Alarmprotokoll (2026-08-16)
+
+Quelle: `/var/lib/gregor/users/{default,henning,steffi}/alert_log.json`, 260 Einträge gesamt.
+Auswertbar sind nur die **41 Einträge mit `reason`-Feld** — das Feld existiert erst seit S1, das
+Messfenster ist damit **13 Tage** (2026-08-03 bis 2026-08-16), an allen 13 Tagen gab es Alarme.
+
+**Der gemeldete Fall ist im Protokoll wiedergefunden:** `5f534011`, 2026-08-11 14:22 UTC
+`nowcast` mit Metrik `thunder`, **+8,2 Minuten** später `official_alert` mit Hazard
+`thunderstorm`. Das ist exakt der Vorfall aus der Issue-Meldung (16:22/16:30 Ortszeit).
+
+| Konstellation (gleiche Entität, ≤ 60 Min) | Anzahl in 13 Tagen |
+|---|---|
+| **Quellenübergreifend**, verschiedene `reason` | **6** — davon 4× `nowcast`↔`official_alert`, 2× `forecast_change`↔`official_alert` |
+| **Gleiche Quelle**, identische Gefahrenart-Menge | **3** — 2× `forecast_change`/`thunder` (+45 / +60 Min), 1× `official_alert`/`thunderstorm` (+30 Min) |
+
+Also rund **eine Doppelmeldung alle 1,5 Tage**. Bemerkenswert: die Doppelung tritt auch
+**innerhalb derselben Quelle** auf — der amtliche Fall (+30 Min bei identischer Hazard-Menge) ist
+die Kehrseite der bewusst cooldown-freien Eskalation.
+
+**Das Vokabular-Problem ist empirisch belegt**, nicht nur im Code:
+
+| `reason` | Gefahrenart steht in | gemessene Werte |
+|---|---|---|
+| `forecast_change` | `metrics[].metric_id` (`hazards` immer leer) | `thunder` ×17, `cape` ×3, `gust` ×2, `temperature` ×1 |
+| `nowcast` | `metrics[].metric_id` (`hazards` immer leer) | `precipitation` ×5, `thunder` ×1 |
+| `official_alert` | `hazards` (`metrics` immer leer) | `thunderstorm` ×11, `extreme_heat` ×4 |
+
+Dasselbe Gewitter heißt je nach Pfad `thunder`, `precipitation`, `cape` oder `thunderstorm` — in
+zwei verschiedenen Feldern. Eine Entdopplung braucht also zwingend eine Zuordnungstabelle; ein
+String-Vergleich findet die gemessenen Paare **nicht**.
+
+## Related Files
+
+| Datei | Relevanz |
+|------|-----------|
+| `src/services/alert_gate.py` (374 Z.) | Geteilter Baustein aus S3/S4a: `check_nowcast_gate` (L114-158, Ruhezeit→Sperrzeit→Tageslimit), `check_official_alert_gate` (L161-214, Ruhezeit→Tageslimit, **kein** Cooldown-Parameter), `check_briefing_imminent` (L256-357), `record_nowcast_sent` (L360-374). Wahrscheinlicher Einhängepunkt für S4b. |
+| `src/services/trip_alert.py` (1624 Z.) | Drei Trip-Pfade: Δ `check_and_send_alerts():303`, Radar `check_radar_alerts():1057`, amtlich `check_official_alert_triggers():1450`. Enthält den **einzigen bestehenden Cross-Alarmart-Guard** (s.u.). |
+| `src/services/compare_alert.py` (591) | Compare-Δ: `_evaluate_one_location():427`, Versand `:279` |
+| `src/services/compare_radar_alert.py` (294) | Compare-Nowcast: `_detect_triggered_locations():262`, Versand `:204` |
+| `src/services/compare_official_alert.py` (342) | Compare-amtlich: `_detect():271`, Versand `:192` |
+| `src/services/throttle_store.py` | Sperrzeiten je `(scope, key)`, Datei `throttle_state.json` je Nutzer. Reale Scopes: `trip`, `radar`, `compare_preset`, `compare_radar` (bewusst eigener Scope, Docstring L44-50). |
+| `src/services/alert_state.py` | Melde-Gedächtnis je Entität, `alert_state/<entity_id>.json`, Schema `{"<metric>:<segment_id>": {...}}`. `reset()` beim Briefing-Versand schont den `official_alert:`-Präfixraum (L73-100). |
+| `src/services/alert_log.py` | Protokoll mit `entity_id`/`entity_type` (seit S1). `append_suppressed_entry()` (L253-326) schreibt Unterdrückungen — **nur** für die beiden Nowcast-Pfade. |
+| `src/output/renderers/alert/official_alerts.py` | `dedupe_official_alerts()` — das **etablierte Dedup-Muster**, aber nur *innerhalb* der amtlichen Warnungen. |
+| `src/output/renderers/alert/…format_segment_reference()` | Ergebnis von #1744 Scheibe A: gemeinsame **Anzeige**-Formatierung des Ortsbezugs. |
+
+## Existing Patterns
+
+**Muster 1 — `dedupe_official_alerts()` (kanonisch, aus #1217/#1218/#1245).**
+Identitäts-Präzedenz `dedup_id > region_label > label`; Schlüssel
+`(ident, hazard, valid_from, valid_to)`; unterschiedliche Zeiträume bleiben bewusst getrennt, nur
+exakte Dubletten kollabieren, das höchste Level gewinnt. Dazu die Regel „nie doppelt" (#1086): je
+Gefahrenart wird die **beste Quelle behalten**, nicht über Quellen hinweg gemerged.
+Einschränkung: wirkt nur zwischen mehreren *amtlichen* Quellen, nicht über die drei Alarmarten.
+
+**Muster 2 — Doppel-Alert-Guard `trip_alert.py:1081-1099` (aus #818 AC-4).**
+Der einzige real existierende quellenübergreifende Guard: Der Radar-Pfad liest gezielt die
+`AlertStateService`-Schlüssel `precip:<segment_id>` und `thunder_level_max:<segment_id>` — vom
+**Änderungsalarm desselben Trips** geschrieben — und unterdrückt den Radar-Alarm, wenn sie jünger
+als `cooldown_min` sind. Aber: Trip-intern, fest verdrahtete Schlüsselnamen, liest den State
+direkt statt über `alert_gate.py`, **kein Compare-Pendant**. Verallgemeinerbar, nicht
+wiederverwendbar wie er ist.
+
+**Muster 3 — Gate-Bausteine aus S3/S4a.** `GateResult(allowed, reason)` als NamedTuple, `reason`
+ist eine `alert_log`-Konstante; Prüfungen brechen bei der ersten Stufe ab; Zusicherungen werden als
+**Eigenschaft des Funktionstyps** gebaut (S4a AC-3: `check_official_alert_gate` kennt strukturell
+keinen Cooldown-Parameter), nicht als Disziplin der Aufrufstelle.
+
+## Dependencies
+
+- **Upstream:** `DeviationAlertEngine` (ADR-0021), `OfficialAlertSource`-Quellen (ADR-0016/0039),
+  `radar_service` (INCA/GeoSphere), `ThrottleStore`, `AlertStateService`, `alert_daily_limit`,
+  `is_quiet_hours`.
+- **Downstream:** `NotificationService` (sechs Versand-Einstiegspunkte), `alert_log` und dessen
+  Leseseite `read_undelivered()` (Anzeige-Dedup-Fenster 2 Min, `alert_log.py:337`), Go-Zählung
+  `AlertCountByTrip()`, Cockpit/Frontend-Anzeige der Alarme.
+
+## Existing Specs
+
+- `docs/specs/modules/rework_1467_s1_alarm_kennung.md` — eine Kennung `entity_id` + `entity_type`
+  ∈ {trip, compare}. **Jede Entdopplung muss auf diesem Kennungsschema aufsetzen.**
+- `docs/specs/modules/rework_1467_s2_aenderungsalarm.md` — Δ-Pfad vereinheitlicht; Pausiert-/
+  Archiviert-Riegel `is_silenced` bleibt Compare-eigen.
+- `docs/specs/modules/rework_1467_s3_nowcast.md` — Nowcast auf `check_nowcast_gate`;
+  Unterdrückungsgründe protokolliert **nur** für Nowcast (AC-9).
+- `docs/specs/modules/rework_1467_s4a_amtlich.md` — amtlicher Pfad auf `check_official_alert_gate`.
+- `docs/specs/modules/fix_1744_alarm_format_angleichen.md` — Scheibe A: **nur** gemeinsame
+  Anzeige-Formatierung, ausdrücklich „Nicht Gegenstand: die quellenübergreifende Entdopplung".
+- ADRs: 0009 (Δ-Wächter), 0013 (threshold = Δ-Sensitivität), 0016 (amtlich additiv),
+  0021 (gemeinsame Engine, 5 Nachträge), 0039 (MeteoAlarm, drei Zustände strikt trennen),
+  0043 (Empfindlichkeitsstufe als einziger Regler, symmetrisch), 0046 (Kanal-Schwelle regelt
+  **wie**, nicht **ob**).
+
+## Risks & Considerations
+
+1. **„Alarm bleibt aus" ist die gefährliche Fehlerrichtung.** Vierfach dokumentiert (#1233/F002,
+   S2 Z.353f., rework_1460_t1, S4a AC-3): Die amtliche Eskalation bleibt **cooldown-frei**. Eine
+   Entdopplung darf keine getarnte Zeitsperre werden — eine echte GELB→ORANGE-Verschärfung muss
+   durchkommen. Symmetrisch gilt das für den Nowcast: ein Δ-Alarm um 16:00 darf „Gewitter in 8 Min"
+   um 16:22 nicht schlucken.
+2. **S4a hat die Gegenrichtung ausdrücklich an S4b übergeben** (Known Limitations): Ein amtlicher
+   Alarm schreibt weiterhin in den `"trip"`-Sperrtopf und kann so einen nachfolgenden
+   Änderungsalarm drosseln. Das ist mit **Ereignis-Identität** zu ersetzen — nicht mit einer neuen
+   Zeitsperre.
+3. **Der Ortsbezug ist der teuerste Teil.** Scheibe A hat nur das Rendering vereinheitlicht; das
+   Δ-/Onset-Datenmodell trägt die Segment-Kennung **nicht als strukturiertes Feld**. S4b muss
+   entweder auf dem Ausgabetext von `format_segment_reference()` aufsetzen (fragil, Anzeigeschicht
+   als Identitätsquelle) oder strukturierte Felder nachziehen. Und selbst dann bleibt
+   `region_label` die Geografie einer **fremden Quelle** — Segment-ID ↔ Warnregion ist keine
+   Gleichsetzung, sondern eine Zuordnung mit eigener Unsicherheit.
+4. **Zeitpunkt vs. Intervall.** „Überlappendes Zeitfenster" ist zwischen einem Onset-Zeitpunkt und
+   einem Gültigkeitsintervall nicht definiert, solange der Nowcast-Horizont nicht im Objekt steckt.
+5. **Drei getrennte Gedächtnisräume** (`<metrik>:<segment>` / kein dokumentierter Nowcast-Schlüssel
+   / `official_alert:<ident>:<hazard>:<valid_from>:<valid_to>`) müssen für einen Identitätsvergleich
+   erstmals zueinander in Beziehung gesetzt werden, ohne das `reset()`-Verhalten beim
+   Briefing-Versand zu brechen (`official_alert:` überlebt den Reset bewusst).
+6. **Umfang.** Sechs Pfade, ein neues Identitäts-Konzept, Datenmodell-Erweiterung: sprengt das
+   250-Zeilen-Budget deutlich. S4b braucht selbst einen Zuschnitt.
+7. **Mandantentrennung:** mit zwei verschiedenen Nutzern testen (alle Zustandsdateien liegen unter
+   `get_data_dir(user_id)`).
+8. **Trip/Compare-Teilungsregel:** eine Compare-eigene Zweitfassung der Entdopplung wäre ein
+   Verstoß.
+
+## Analysis
+
+### Type
+Feature (Rework mit bewussten Verhaltensänderungen)
+
+### Der Ortsbezug ist billiger als befürchtet — selbst am Code geprüft
+
+Die Risiko-Einschätzung oben (Punkt 3: „teuerstes Teilproblem") ist nach eigener Nachprüfung
+**zu pessimistisch**. Alle drei Trip-Alarmarten führen bereits dieselbe Segment-Kennung mit:
+
+- **Nowcast:** `active.segment_id` steht an der Entscheidungsstelle zur Verfügung
+  (`trip_alert.py:1069`, `:1085`) und geht als `normalize_segment_id(active.segment_id)` in den
+  Versand (`:1149`). Der Kommentar dort sagt den Zweck ausdrücklich: *„Issue #1744 A1: … nur
+  zusaetzlich mit ihrer Kennung, damit der Nowcast denselben Ort benennt wie die amtliche
+  Warnung."*
+- **Amtlich:** `str(segment.segment_id)` wird je Koordinaten-Gruppe an die Warnung angehängt
+  (`trip_alert.py:1423`, `:1432`) — die Zuordnung Warnung→Segment läuft über den
+  **Abruf-Koordinaten-Cluster**, nicht über den Freitext `region_label`.
+- **Δ-Alarm:** `WeatherChange.segment_id` (`app/models.py:555`).
+- **Compare:** durchgängig `loc.id` (`compare_radar_alert.py:273`, `compare_official_alert.py:244`).
+
+`normalize_segment_id()` (`output/renderers/alert/segments.py:17-29`) ist reines
+`str(value).strip() or None` — die rohe und die normalisierte Form sind wertgleich. **Einzige
+Bruchstelle:** leere Kennung wird zu `None` (amtlich: bleibt `""`). Ortsbezug-Vergleich =
+nicht-leere Schnittmenge der Segment-/Ortskennungen; bei fehlender Kennung darf **kein** Match
+entstehen (fail-soft Richtung „senden").
+
+Damit braucht S4b **kein neues Datenmodell** — nur einen Gefahrenart-Kanon, ein
+Zeitfenster-Prädikat und eine Registerabfrage.
+
+### Technischer Ansatz (Empfehlung)
+
+Neue Funktion **`check_event_identity_gate()` in `src/services/alert_gate.py`** — Verallgemeinerung
+des heute schon existierenden, aber Trip-internen und fest verdrahteten Doppel-Alert-Guards
+(`trip_alert.py:1081-1099`). Fügt sich als **letzte** Stufe in die bestehende `GateResult`-Kette
+(Ruhezeit → Sperrzeit → Tageslimit → Ereignis-Identität), `reason` als neue `alert_log`-Konstante.
+
+Verworfen: (a) ein normalisiertes Ereignis-Objekt vor dem Versand für alle sechs Pfade — baut die
+Datenflüsse vor der `NotificationResult`-Konvergenz um, hohes Risiko in der Fehlerrichtung „Alarm
+bleibt aus", und unnötig, da die Identitätsbestandteile an den Versandstellen bereits nativ
+vorliegen. (c) nur das eine gemessene Paar hart verdrahten — lässt Compare und Starkregen sofort
+als Folgebug liegen.
+
+**Gefahrenart-Kanon:** Nur zwei Klassen sind nötig, weil der Nowcast strukturell nur zwei
+kennt (`is_convective: bool` + Intensität): *konvektiv/Gewitter* (`thunder`, `cape`,
+`is_convective=True`, `thunderstorm`) und *Niederschlag* (`precipitation`, `flood`). Alles andere
+kann mit einem Nowcast gar nicht kollidieren.
+
+**Zeitfenster:** Punkt gegen Intervall → `punkt ∈ [valid_from − 60, valid_to + 60]` mit der
+bestehenden Konstante `NOWCAST_HORIZON_MIN = 60` (`radar_service.py:65`). Punkt gegen Punkt →
+Differenz ≤ vorhandener `cooldown_minutes`. Fehlender Zeitbezug → kein Match → senden.
+
+**Eskalations-Bypass:** erster Zweig mit `return`, vor jeder Unterdrückungslogik. Vorbild
+existiert: `official_alert_revision_verdict()` (`output/renderers/alert/official_alerts.py`).
+
+### Scope Assessment
+
+| Teilscheibe | Inhalt | Python | Tests | Schließt #1467? |
+|---|---|---|---|---|
+| **S4b-1** | `check_event_identity_gate()` + Kanon + Zeitprädikat, verdrahtet in **beide** Trip-Richtungen (`check_radar_alerts`, `check_official_alert_triggers`) | ~90–120 | ~180–220 | **ja** |
+| **S4b-2** | Ortsvergleich-Parität — derselbe Baustein, zweite Verdrahtung | ~40–60 | ~100–140 | nein (Folge-Issue) |
+| **S4b-3** | Δ-Alarm als dritte Richtung + restliche Gefahrenarten | offen | offen | nein (optional) |
+
+Risk Level: **HIGH** (Alarmpfad, Fehlerrichtung „Alarm bleibt aus"). S4b-1 sprengt das
+250-Zeilen-Budget und braucht `loc_limit_override`.
+
+### Risiko-Absicherung (strukturell, nicht per Disziplin)
+
+- Eskalations-Test als erster Zweig mit `return` — die Funktion kennt keinen Weg, eine
+  Verschärfung zu blockieren (Muster aus S4a AC-3).
+- Fail-soft bei fehlenden/unvergleichbaren Daten fällt **immer** Richtung „senden".
+- `alert_state.reset()` schont den `official_alert:`-Präfixraum bewusst (`alert_state.py:73-100`) —
+  für das neue Register ist ausdrücklich zu entscheiden, ob es den Briefing-Reset überlebt.
+- Mutations-Gegenprobe muss zeigen, welcher Test rot wird, wenn der Eskalations-Bypass entfällt.
+
+### Open Questions (PO-Entscheidung, gehen in die Spec)
+- [ ] Wer gewinnt bei gleichem Ereignis: zeitliche Priorität (wer zuerst meldet) oder feste
+      Quellen-Hierarchie? Offener Punkt dabei: die amtliche Warnung trägt ein **längeres**
+      Gültigkeitsintervall als der 60-Minuten-Nowcast.
+- [ ] Verschärfung durchbricht die Entdopplung — bestätigt?
+- [ ] Kanalübergreifend statt je Kanal — bestätigt?

--- a/docs/specs/modules/rework_1467_s4b_entdopplung.md
+++ b/docs/specs/modules/rework_1467_s4b_entdopplung.md
@@ -1,0 +1,803 @@
+---
+entity_id: rework_1467_s4b_entdopplung
+type: refactor
+created: 2026-08-16
+updated: 2026-08-16
+status: draft
+version: "1.0"
+tags: [alerts, trip, epic-1458, issue-1467, issue-1744, s4b, s4b-1, entdopplung]
+---
+
+# Quellenübergreifende Alarm-Entdopplung nach Ereignis-Identität — Trip-Fläche (Issue #1467 Scheibe S4b-1, = #1744 Scheibe B, Epic #1458 Teil 4b)
+
+## Approval
+
+- [x] Approved — PO-Freigabe 2026-08-16 (inkl. Entscheid: EINE Gefahrenklasse `wet` statt zwei; `loc_limit_override` bewilligt)
+
+## Purpose
+
+Ein und dasselbe Gewitter löst heute zwei unabhängige Alarme aus: einen
+Radar-Nowcast und — Minuten später — eine amtliche Warnung. Beide werden
+zugestellt, weil ihre Sperrzeiten in getrennten Töpfen je **Quelle** liegen
+und einander konstruktionsbedingt nicht sehen können. Gemessen am
+Produktivprotokoll (13 Tage, 2026-08-03 bis 2026-08-16): der auslösende
+Vorfall (`5f534011`, 2026-08-11 14:22 UTC, Nowcast `thunder` gefolgt von
+amtlich `thunderstorm` nach +8,2 Min) ist real wiedergefunden, und
+quellenübergreifende Doppelungen dieser Art treten im Schnitt alle 1,5 Tage
+auf (6 Fälle in 13 Tagen).
+
+Diese Scheibe führt einen geteilten Baustein `check_event_identity_gate()`
+ein, der **nach Ereignis-Identität** — gleiche Gefahrenklasse + gleicher
+Ortsbezug + überlappendes Zeitfenster — entdoppelt, bevor eine zweite
+Meldung für dasselbe Ereignis rausgeht. Sie ist die letzte von drei
+Teilscheiben aus #1744 Scheibe B und **schließt Issue #1467**.
+
+**Scope dieser Teilscheibe (S4b-1):** ausschließlich die **Trip-Fläche**,
+**beide Richtungen** — `check_radar_alerts()` (Nowcast) und
+`check_official_alert_triggers()`/`_send_official_alert_only()` (amtlich)
+in `src/services/trip_alert.py`. Der Baustein wird von Anfang an
+**entitätsparametrisiert** gebaut (Trip/Compare-Teilungsregel), damit die
+Ortsvergleich-Verdrahtung (S4b-2, eigenes Folge-Issue) reine Zusatz-Aufrufe
+ohne neue Logik ist.
+
+**Leitsatz, unverändert aus S1–S4a übernommen:** Der gefährlichste Fehler
+ist der ausbleibende Alarm. Jede Unsicherheit in dieser Scheibe — fehlender
+Zeitbezug, fehlende Ortskennung, unbekannte Gefahrenart — entscheidet sich
+**immer** Richtung Zustellung, nie Richtung Unterdrückung.
+
+## Source
+
+- **File:** `src/services/alert_gate.py`
+- **Identifier:** neue Funktionen `check_event_identity_gate`,
+  `resolve_hazard_class`, `record_event_identity`
+
+Betroffene Schicht: ausschließlich **Python-Core** (`src/services/`,
+`src/output/renderers/alert/`). Kein Go-Code, kein Frontend-Code.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `rework_1467_s4a_amtlich` | module | Vorgänger-Scheibe (live) — liefert `check_official_alert_gate`, `GateResult`-Muster, Aufrufstellen-Positionen in `_send_official_alert_only`; diese Scheibe fügt eine **weitere**, letzte Stufe an dieselben Aufrufstellen an |
+| `rework_1467_s3_nowcast` | module | liefert `check_nowcast_gate`, `record_nowcast_sent`, das Protokoll-Muster `append_suppressed_entry` (bisher Nowcast-only) |
+| `rework_1467_s1_alarm_kennung` | module | `entity_id`/`entity_type` ∈ {trip, compare} — Ereignis-Identität setzt auf dieser Kennung auf |
+| `fix_1744_alarm_format_angleichen` | module | liefert `format_segment_reference`, `normalize_segment_id` (`output/renderers/alert/segments.py`) — die Ortsbezug-Normalisierung dieser Scheibe verwendet dieselbe Funktion, keine zweite |
+| `services.alert_urgency` | module | geteilte Dringlichkeits-Skala `"LOW"`/`"MODERATE"`/`"HIGH"` — die Eskalations-Prüfung (V2) vergleicht auf dieser bestehenden Skala, keine neue Rangfolge |
+| `services.alert_state.AlertStateService` | module | Melde-Gedächtnis-Ablage; das neue Ereignis-Identität-Register liegt in derselben Datei wie das amtliche Melde-Gedächtnis, eigener Schlüssel-Präfix |
+| `services.radar_service.NOWCAST_HORIZON_MIN` | module | bestehende Konstante (60 Min) — Puffer für Punkt-gegen-Intervall-Überlappung UND Schwelle für „wesentlich darüber hinaus" (V1); keine neue Konstante |
+| `output.renderers.alert.official_alerts.dedupe_official_alerts` / `official_alert_revision_verdict` | module | bleiben unverändert zuständig für amtlich-gegen-amtlich (gleiche und verschiedene Quellen) — außerhalb des Scopes dieser Scheibe |
+| `trip_alert.py` Doppel-Alert-Guard (`:1081-1099`) | module | bleibt unverändert bestehen (T7-Entscheidung, s. Implementation Details) — deckt Nowcast-gegen-Änderungsalarm ab, eine andere Paarung als diese Scheibe |
+| `alert_log` | module | neue Konstante `REASON_EVENT_DUPLICATE`; `append_suppressed_entry` wird erstmals auch vom amtlichen Pfad aufgerufen |
+| `alert_channel_threshold.split_by_threshold` | module | bleibt unverändert NACH dem neuen Gate — Kanal-Schwelle entscheidet WIE, das Gate entscheidet OB (ADR-0046, V3) |
+
+## Estimated Scope
+
+- **LoC produktiv:** ~180–230 (`alert_gate.py` neue Funktionen ~90–120,
+  `alert_urgency.py` +1 Vergleichs-Helfer ~8–12, `alert_log.py` +1 Konstante,
+  `alert_state.py` reiner Docstring-Zusatz (keine Logikänderung, s.
+  Implementation Details), `trip_alert.py`-Verdrahtung an zwei Stellen
+  inkl. Batch-Filterung im amtlichen Pfad ~60–90).
+- **LoC Tests:** ~350–500 — **sprengt das 250er-Budget deutlich**,
+  `loc_limit_override` erforderlich (analog S4a, dort auf 1000
+  angehoben; hier schlanker, weil nur EIN Baustein + zwei Aufrufstellen
+  statt zwei vollständige Pfad-Umbauten). Begründung: kritischer
+  Alarmpfad, zwei Richtungen, Mutations-Gegenprobe zu V1 UND V2 PFLICHT,
+  Mandantentrennungs-Nachweis, Batch-Teilunterdrückung.
+- **Files:** 0 neu, 5 produktiv geändert (`alert_gate.py`,
+  `alert_urgency.py`, `alert_log.py`, `alert_state.py` [Docstring],
+  `trip_alert.py`), 1 ADR-Nachtrag, ~4–5 Testdateien geändert/neu.
+- **Effort:** high.
+- **Risiko:** HOCH — kritischer Alarmpfad, quellenübergreifende Logik ohne
+  Präzedenz, Fehlerrichtung „Alarm bleibt aus" ist per Definition am
+  schwersten zu bemerken (die Meldung fehlt einfach).
+
+## Implementation Details
+
+### Gefahrenart-Kanon (T2) — EINE Klasse, PO-Entscheid 2026-08-16
+
+Die real vorkommenden `OfficialAlert.hazard`-Werte wurden im Code
+nachgeprüft (`grep hazard=` über `src/services/official_alerts/*.py`):
+
+`wind_gust`, `rain`, `snow`, `black_ice`, `thunderstorm`, `extreme_heat`,
+`extreme_cold`, `wildfire_risk`, `flood`, `access_ban` — zehn Werte aus
+sechs Quellen (`geosphere_warn.py`, `vigilance.py`, `meteoalarm.py`,
+`meteo_forets.py`, `massif_closure.py`, `dpc.py`).
+
+**Kanon:**
+
+| Klasse | Nowcast-Signal | amtliche Hazards |
+|---|---|---|
+| `"wet"` (Niederschlag/Gewitter) | `is_convective` — **beide** Werte | `"thunderstorm"`, `"flood"`, `"rain"` |
+
+Alle anderen amtlichen Hazards (`wind_gust`, `snow`, `black_ice`,
+`extreme_heat`, `extreme_cold`, `wildfire_risk`, `access_ban`) fallen in
+**keine** Klasse und werden nie entdoppelt (AC-4).
+
+**Warum EINE Klasse und nicht zwei (konvektiv vs. Niederschlag):** Der
+ursprüngliche Zuschnitt trennte nach `is_convective`. Die Messung am
+Produktivprotokoll widerlegt das als Identitätskriterium — es ist eine
+Momentaufnahme der Radarzelle, nicht die Ereignis-Identität. Am 2026-08-11
+erzeugte **eine** Gewitterlage auf Trip `5f534011` sechs Alarme für dieselbe
+Etappe: 14:22 Radar/konvektiv, 14:30 amtlich `thunderstorm`, 15:07
+Radar/nicht-konvektiv, 15:45 amtlich, 17:45 amtlich, 17:52
+Radar/nicht-konvektiv. Dieselbe Zelle wurde also mal als Gewitter, mal als
+Regen eingestuft (`alert_log.register_pairs_for_nowcast()` bildet
+`is_convective` genau darauf ab, `alert_log.py:95-105`). Mit zwei getrennten
+Klassen liefen drei der vier gemessenen quellenübergreifenden Paare
+aneinander vorbei — die Scheibe hätte von sechs Meldungen etwa vier übrig
+gelassen statt zwei.
+
+Die Trennschärfe kommt stattdessen aus den übrigen drei Bedingungen:
+dieselbe Etappe, überlappendes Zeitfenster, und die beiden Ausnahmen (V1
+Abdeckungs-Vorbehalt, V2 Eskalation). **`rain` ist mit dieser Entscheidung
+Teil des Kanons** — damit entfällt die zuvor benannte `rain`-vs-`flood`-Lücke.
+
+**Preis, der benannt gehört:** Ein rein stratiformer Landregen-Nowcast kann
+unterdrückt werden, wenn für dieselbe Etappe eine überlappende amtliche
+Gewitterwarnung bereits gemeldet wurde. Fachlich vertretbar — der Nutzer
+wurde für diesen Ort und Zeitraum bereits vor Niederschlag gewarnt, nur
+unter dem Wort „Gewitter". Umgekehrt gilt dasselbe.
+
+```python
+# src/services/alert_gate.py
+HAZARD_CLASS_WET = "wet"
+_WET_HAZARDS = frozenset({"thunderstorm", "flood", "rain"})
+
+
+def resolve_hazard_class(
+    *, is_convective: Optional[bool] = None, hazard: Optional[str] = None,
+) -> Optional[str]:
+    """T2-Kanon. Genau EIN Identifikationsweg pro Aufrufer: Nowcast liefert
+    `is_convective`, amtlich liefert `hazard`. Unbekannter/anderer Hazard
+    -> None (keine Klasse, nie entdoppelt).
+
+    Ein Nowcast ist IMMER Niederschlag — `is_convective` unterscheidet nur
+    die Erscheinungsform derselben Zelle, nicht das Ereignis (PO-Entscheid
+    2026-08-16, Messung s.o.)."""
+    if is_convective is not None:
+        return HAZARD_CLASS_WET
+    if hazard in _WET_HAZARDS:
+        return HAZARD_CLASS_WET
+    return None
+```
+
+### Ortsbezug (T3) — kein neues Datenmodell nötig
+
+Alle drei Trip-Alarmarten führen bereits dieselbe Segment-Kennung:
+Nowcast `normalize_segment_id(active.segment_id)` (`trip_alert.py:1149`),
+amtlich `str(segment.segment_id)` je Koordinaten-Cluster
+(`trip_alert.py:1423/1432`). `normalize_segment_id()`
+(`output/renderers/alert/segments.py:17-29`) ist reines
+`str(value).strip() or None` — roh und normalisiert sind wertgleich.
+Ortsbezug-Match = nicht-leere Schnittmenge der Segment-ID-Mengen.
+`region_label` wird **nicht** verwendet (Freitext einer fremden Quelle,
+keine Geografie-Gleichsetzung mit Segment-IDs).
+
+**Bruchstelle (AC-5):** eine leere/fehlende Kennung erzeugt **nie** ein
+Match — sonst würde „kein Ort bekannt" auf „jeden Ort" passen und ein
+Ereignis ohne Ortsangabe könnte fälschlich ein völlig anderswo laufendes
+Ereignis unterdrücken.
+
+### Zeitfenster (T4) — drei Vergleichsfälle, nur einer end-to-end verdrahtet
+
+Punkt (Nowcast-Onset) und Intervall (`valid_from`/`valid_to`) sind
+unterschiedliche Repräsentationen; die Vergleichsfunktion behandelt alle
+drei Kombinationen, aber nur **Punkt-gegen-Intervall** ist über die beiden
+Aufrufstellen dieser Scheibe erreichbar (der gemessene Kernfall):
+
+- **Punkt gegen Intervall:** Überlappung mit Puffer
+  `NOWCAST_HORIZON_MIN` (60) — `punkt ∈ [valid_from − 60min, valid_to + 60min]`.
+- **Punkt gegen Punkt:** Differenz ≤ `cooldown_minutes` (bereits vorhandener
+  Trip-Parameter, s. `trip_alert.py:998-1002`). Über die beiden
+  verdrahteten Aufrufstellen dieser Scheibe nicht erreichbar (ein zweiter
+  Nowcast innerhalb des Cooldowns wird bereits von `check_nowcast_gate`s
+  Sperrzeit-Stufe abgefangen, bevor die neue Stufe erreicht wird) — bleibt
+  in der Matching-Funktion als Vollständigkeits-/Vorbereitungsfall für
+  S4b-2/S4b-3, isoliert getestet, nicht Teil des End-to-End-Nachweises.
+- **Intervall gegen Intervall:** echte Überlappung
+  (`alert_vf < cand_vt and cand_vf < alert_vt`, analog
+  `official_alert_revision_verdict`). Ebenfalls nicht end-to-end
+  erreichbar in S4b-1 (amtlich-gegen-amtlich bleibt vollständig bei
+  `dedupe_official_alerts`/`official_alert_revision_verdict`, s.
+  Nicht-Ziele) — isoliert getestet.
+
+**Fehlender/unvergleichbarer Zeitbezug ⇒ kein Match ⇒ senden** (AC-7,
+fail-soft, gleiche Richtung wie `official_alert_revision_verdict` bei
+fehlendem `valid_from`/`valid_to`).
+
+### Die Kernregel (V1) und ihre Ausnahme
+
+„Wer zuerst meldet, gewinnt" — die zweite Meldung wird unterdrückt, **außer**
+ihr Zeitfenster reicht wesentlich über das der ersten hinaus. „Wesentlich" =
+mehr als `NOWCAST_HORIZON_MIN` (60 Min) über das bereits abgedeckte Ende
+hinaus — dieselbe Konstante wie der Überlappungs-Puffer, keine neue Zahl.
+Begründung (PO, 2026-08-16): eine amtliche Warnung gilt oft bis in den
+Abend, ein Nowcast deckt nur 60 Minuten. Fiele die amtliche Warnung nach
+einem vorangegangenen Nowcast ersatzlos weg, wüsste der Wanderer nicht,
+dass die Lage stundenlang kritisch bleibt — und sie käme auch nicht
+nachträglich, weil `official_alert_revision_verdict()` sie beim nächsten
+Lauf als bereits gesehen führt (eigener State-Raum, von dieser Scheibe
+unberührt).
+
+„Abgedecktes Ende" einer registrierten Meldung:
+
+```python
+def _covered_until(point_at, window_end) -> Optional[datetime]:
+    if point_at is not None:
+        return point_at + timedelta(minutes=NOWCAST_HORIZON_MIN)
+    return window_end
+```
+
+### Eskalation durchbricht immer (V2) — struktureller erster Zweig
+
+Nach dem Auffinden eines passenden Registereintrags (gleiche Klasse,
+überlappender Ort, überlappende Zeit) ist die Eskalationsprüfung der
+**erste** Zweig mit eigenem `return` — noch vor der V1-Ausnahme
+(Zeitfenster-Erweiterung) und vor der eigentlichen Unterdrückung. Vorbild:
+`official_alert_revision_verdict()`
+(`output/renderers/alert/official_alerts.py:428-520`), die dasselbe Muster
+für amtlich-gegen-amtlich bereits umsetzt. Vergleichen wird auf der
+bestehenden Dringlichkeits-Skala `services.alert_urgency`
+(`"LOW"`/`"MODERATE"`/`"HIGH"`), die beide Quellen bereits an den
+Aufrufstellen berechnen (`_radar_urgency` in `check_radar_alerts`,
+`_official_urgency` in `_send_official_alert_only`) — kein neuer
+Wertebereich. `alert_urgency.py` bekommt dafür einen kleinen öffentlichen
+Vergleichs-Helfer (wiederverwendet die bestehende `_RANK`-Tabelle, keine
+zweite Rangfolge — Wiederholungsklasse #1481):
+
+```python
+# src/services/alert_urgency.py
+def exceeds(a: str, b: str) -> bool:
+    """Echtes Groesser-als auf der bestehenden LOW/MODERATE/HIGH-Skala."""
+    return _RANK.get(a, 0) > _RANK.get(b, 0)
+```
+
+```python
+# src/services/alert_gate.py — Kernablauf (vereinfacht)
+def check_event_identity_gate(*, ..., severity, ...) -> GateResult:
+    if hazard_class is None:
+        return _ALLOWED  # T2: keine Klasse, kein Match möglich
+    match = _find_matching_entry(state, hazard_class, segment_ids,
+                                  point_at, window_start, window_end,
+                                  cooldown_minutes)
+    if match is None:
+        return _ALLOWED  # kein Vorgänger, oder kein Zeit-/Ortsbezug
+    if alert_urgency.exceeds(severity, match["severity"]):
+        return _ALLOWED  # V2 — ERSTER Zweig, bricht IMMER durch
+    if _covers_materially_more(match, point_at, window_start, window_end):
+        return _ALLOWED  # V1-Ausnahme
+    return GateResult(False, alert_log.REASON_EVENT_DUPLICATE)
+```
+
+### Kanalübergreifend, nicht je Kanal (V3)
+
+Der neue Gate-Aufruf steht **vor** `alert_channel_threshold.split_by_threshold()`
+(`trip_alert.py:1167`/`:1519`) an beiden Aufrufstellen — ein Ergebnis für
+die ganze Entität, danach entscheidet die Kanal-Schwelle nur noch, auf
+welchem Weg eine bereits freigegebene Meldung geht (ADR-0046: die Schwelle
+regelt WIE, nie OB).
+
+### Aufrufstellen — letzte Stufe vor dem Versand
+
+| Pfad | Position | Bestehende Stufen davor |
+|---|---|---|
+| `check_radar_alerts()` (Nowcast) | unmittelbar vor `self._notification_service.send_radar_alert(...)` (`:1172`), nach `_radar_urgency` (`:1163`) | `check_nowcast_gate` (`:1008`) → Briefing-Vergleich (`:1075`) → Doppel-Alert-Guard (`:1081-1099`, **bleibt unverändert**, s. T7 unten) |
+| `_send_official_alert_only()` (amtlich) | unmittelbar vor `self._notification_service.send_official_alert(...)` (`:1522`), nach `_official_urgency` (`:1515`) — **pro Alert**, s. Batch-Filterung | `check_official_alert_gate` (`:1496`) → `_is_briefing_imminent` (`:1507`) |
+
+Die Ereignis-Identität steht bewusst zuletzt: sie ist die teuerste Prüfung
+(Register-Scan + Zeit-/Ortsvergleich), ein durch billigere Stufen ohnehin
+gesperrter Alarm soll sie nicht mehr durchlaufen.
+
+### Batch-Filterung im amtlichen Pfad (Bruchstelle, eigenes AC)
+
+`_send_official_alert_only()` verschickt heute **alle** `official_notices`
+eines Laufs in **einer** Nachricht; `_official_urgency` ist die höchste
+Dringlichkeit über die ganze Liste. Ein blindes Gate über die ganze Liste
+wäre falsch in **beide** Richtungen:
+
+- alles durchlassen, weil ein Teil neu ist → die Nowcast-Dublette bleibt
+  bestehen (Zweck verfehlt);
+- alles sperren, weil ein Teil ein Duplikat ist → eine zweite, echte
+  Warnung im selben Lauf (z. B. `extreme_heat` neben duplikat
+  `thunderstorm`) würde mit verschluckt — genau die Fehlerrichtung „Alarm
+  bleibt aus", die diese Scheibe nicht erzeugen darf.
+
+Deshalb wird **pro Alert** geprüft und gefiltert, `_official_urgency` **nach**
+dem Filtern aus der verbleibenden Liste neu berechnet; bleibt die Liste
+leer, wird nichts verschickt und nichts gebucht (AC-17).
+
+### Register — Ablage im bestehenden `AlertStateService`
+
+Neuer Schlüssel-Präfix `EVENT_IDENTITY_KEY_PREFIX = "event_identity:"` in
+`alert_state.py` (analog `OFFICIAL_ALERT_KEY_PREFIX`). Ein Eintrag je
+erfolgreich zugestellter Meldung (Nowcast **oder** amtlich — dasselbe
+Register für beide Richtungen, das ist, was „quellenübergreifend"
+technisch bedeutet: wer zuerst zustellt, schreibt; wer zweiter ist, liest
+denselben Eintrag):
+
+```json
+"event_identity:wet:3,4:2026-08-11T14:22:00+00:00": {
+  "hazard_class": "wet",
+  "segment_ids": ["3", "4"],
+  "severity": "HIGH",
+  "point_at": "2026-08-11T14:22:00+00:00",
+  "window_start": null,
+  "window_end": null,
+  "reported_at": "2026-08-11T14:22:03+00:00"
+}
+```
+
+Matching scannt per `startswith("event_identity:<hazard_class>:")` (analog
+`_identity_hazard_prefix()` in `official_alerts.py:402-425`) und prüft je
+Kandidat Segment-Schnittmenge + Zeitüberlappung. `record_event_identity()`
+wird **ausschließlich nach erfolgreicher Zustellung** aufgerufen (F001-
+Symmetrie zu `record_nowcast_sent`).
+
+**Reset-Verhalten (T5, kein Logik-Eingriff nötig):**
+`AlertStateService.reset()` (`alert_state.py:73-100`) behält **nur**
+Schlüssel mit Präfix `official_alert:` und verwirft alles andere. Ein
+neuer Präfix `event_identity:` profitiert davon **automatisch** — er wird
+beim Briefing-Reset mitgelöscht, **ohne Code-Änderung** an `reset()`
+selbst. Das ist beabsichtigt (T5: „nach einem Briefing ist der
+Informationsstand neu gesetzt, ein alter Nowcast-Eintrag darf eine
+spätere amtliche Warnung nicht mehr unterdrücken"). Die einzige Änderung
+an `alert_state.py` ist ein **Docstring-Zusatz** bei `reset()`, der diese
+Wechselwirkung ausdrücklich festhält — sonst könnte ein künftiger Umbau,
+der einen zweiten Präfix „aus Symmetrie" schont, dieses Verhalten
+versehentlich umdrehen. AC-14 sichert das explizit mit einem eigenen Test
+ab, nicht nur mit dem Docstring.
+
+### Beobachtbarkeit (T6) — bewusste Erweiterung ggü. S4a E3
+
+`append_suppressed_entry()` (`alert_log.py:253-326`) ist heute laut
+Docstring „ausschließlich die beiden Nowcast-Pfade". Diese Scheibe
+erweitert das **gezielt** um die Ereignis-Identität-Unterdrückung im
+amtlichen Pfad — aber **nur** dafür, nicht für Ruhezeit/Tageslimit. Das
+bleibt exakt die S4a-E3-Invariante: der bestehende Wächter
+`test_ac9_amtlicher_alarm_bekommt_keinen_unterdrueckungs_grund` bleibt
+für Ruhezeit/Tageslimit unverändert grün (AC-16 grenzt das ausdrücklich
+ab). Neuer Aufruf im amtlichen Pfad:
+
+```python
+alert_log.append_suppressed_entry(
+    self._user_id, entity_id=trip.id, entity_type="trip",
+    reason=alert_log.REASON_OFFICIAL_ALERT,
+    gate_reason=alert_log.REASON_EVENT_DUPLICATE,
+    effective_channels=effective_channels,
+)
+```
+
+Begründung (T6): hier fallen bewusst Meldungen weg — ohne Protokoll-Spur
+kann niemand nachweisen, dass die Entdopplung korrekt statt fehlerhaft
+arbeitet, und ein Fehler in genau dieser Funktion ist per Definition
+unsichtbar („Alarm bleibt aus" hinterlässt sonst keine Spur).
+
+### T7 — Der bestehende Doppel-Alert-Guard bleibt unverändert bestehen
+
+`trip_alert.py:1081-1099` (aus #818 AC-4) prüft Nowcast gegen den
+Δ-Zustand desselben Trips (`precip:<segment_id>`,
+`thunder_level_max:<segment_id>` — vom **Änderungsalarm** geschrieben).
+Das ist eine **andere Paarung** als diese Scheibe: S4b-1 verdoppelt
+ausschließlich Nowcast↔amtlich; der Änderungsalarm-Pfad
+(`check_and_send_alerts()`, `:171`) wird von dieser Scheibe nicht
+angefasst (Δ als dritte Richtung ist S4b-3, optional, s. Nicht-Ziele).
+Der Doppel-Alert-Guard ist also weiterhin der **einzige** Schutz gegen
+Nowcast↔Δ-Dubletten und bleibt deshalb unverändert bestehen — zwei
+Mechanismen nebeneinander sind hier richtig, weil sie unterschiedliche
+Paarungen abdecken, nicht dieselbe zweimal (AC-13 sichert das als
+Regression ab, damit ein künftiges Aufräumen ihn nicht versehentlich für
+„redundant" hält und entfernt).
+
+## Invarianten
+
+- **Der gefährlichste Fehler ist der ausbleibende Alarm.** Jede
+  Unsicherheit (fehlender Zeitbezug, fehlende Ortskennung, unbekannte
+  Gefahrenart, unbekanntes/altes Registerformat) entscheidet fail-soft
+  Richtung Zustellung.
+- **Die Eskalationsprüfung (V2) ist strukturell der erste Zweig** nach dem
+  Auffinden eines Kandidaten — vor der V1-Ausnahme, vor der Unterdrückung.
+- **Kanalübergreifend (V3):** der Gate-Aufruf steht vor
+  `split_by_threshold()`, nicht danach und nicht je Kanal.
+- **Ereignis-Identität ist die letzte Stufe** an beiden Aufrufstellen —
+  nach allen bestehenden billigeren Prüfungen.
+- **Die amtliche Eskalation bleibt cooldown-frei** (S4a AC-3): der neue
+  Gate-Aufruf fügt eine Prüfung NACH `check_official_alert_gate` hinzu,
+  ändert aber nicht dessen Signatur — kein Cooldown-Parameter wandert
+  durch die Hintertür zurück.
+- **Register-Schreiben ausschließlich nach erfolgreicher Zustellung**
+  (F001-Symmetrie, wie `record_nowcast_sent`).
+- **Der Doppel-Alert-Guard (`trip_alert.py:1081-1099`) bleibt unverändert**
+  — andere Paarung (Nowcast↔Δ statt Nowcast↔amtlich).
+- **`append_suppressed_entry` wird im amtlichen Pfad NUR für
+  `REASON_EVENT_DUPLICATE` aufgerufen**, nicht für Ruhezeit/Tageslimit
+  (S4a E3 bleibt für diese beiden Gründe unverändert gültig).
+- Mandantentrennung: jeder Teil mit ZWEI verschiedenen Nutzern verifiziert,
+  `user_id` nie auf `"default"` zurückfallen lassen.
+- Bestandsdaten: Read-Modify-Write mit Merge, nie Replace; ein Register-
+  Eintrag in unbekanntem/altem Format führt nie zu einer Unterdrückung.
+- Datenbeschaffung wird NICHT fusioniert — Nowcast und amtliche Quellen
+  bleiben technisch eigenständige Abrufe.
+- Testpolitik: kein Mock-Theater, keine Dateiinhalt-Checks als
+  Verhaltensnachweis.
+- Testdateien nach VERHALTEN benennen, nie nach Issue-Nummer.
+
+## Nicht-Ziele (ausdrücklich)
+
+- **Ortsvergleich-Parität (S4b-2, eigenes Folge-Issue).** Der Baustein
+  wird entitätsparametrisiert gebaut, aber `compare_radar_alert.py` und
+  `compare_official_alert.py` werden von dieser Scheibe **nicht**
+  angefasst.
+- **Änderungsalarm als dritte Prüfrichtung (S4b-3, optional).** Der
+  bestehende Doppel-Alert-Guard bleibt die einzige Absicherung für
+  Nowcast↔Δ; eine echte Ereignis-Identität-Integration des
+  Änderungsalarms ist eine eigene Scheibe.
+- **Weitere Gefahrenarten über den `wet`-Kanon hinaus** (S4b-3, optional) —
+  Wind, Hitze, Kälte, Schnee, Glatteis, Waldbrand, Zugangssperre.
+- **Amtlich-gegen-amtlich bleibt vollständig bei
+  `dedupe_official_alerts`/`official_alert_revision_verdict`.** Diese
+  Scheibe fügt dort keine zweite Dedup-Ebene ein.
+- **Datenbeschaffung wird nicht fusioniert.**
+- **`region_label` wird nicht als Ortsbezug verwendet** — Freitext einer
+  fremden Geografie, keine Gleichsetzung mit Segment-IDs.
+- Kein neuer Go-Endpunkt, kein neuer Cron-Job, kein Frontend-Code.
+
+## Reihenfolge der Arbeit
+
+1. `resolve_hazard_class`, `alert_urgency.exceeds`, `_covered_until`,
+   `_find_matching_entry` als reine Funktionen zuerst, isoliert getestet
+   (alle drei Zeitvergleichsfälle, auch die zwei nicht end-to-end
+   erreichbaren).
+2. `check_event_identity_gate` + `record_event_identity` zusammenbauen,
+   Register-Schema fixieren.
+3. **Nowcast-Pfad zuerst** verdrahten (Regressionstest: Kernfall
+   Nowcast→amtlich, 8,2 Min Abstand, amtlich wird unterdrückt).
+4. **Amtlicher Pfad** verdrahten inkl. Batch-Filterung (Regressionstest:
+   umgekehrte Reihenfolge amtlich→Nowcast, PLUS der Teilunterdrückung-Fall
+   mit zwei Hazards im selben Lauf).
+5. V1-Ausnahme (Zeitfenster-Erweiterung) und V2 (Eskalation) je mit
+   eigenem Mutations-Gegenprobe-Test.
+6. Reset-Regressionstest (AC-14), Mandantentrennung (AC-18), Doppel-
+   Alert-Guard-Regression (AC-13) zuletzt, wenn das Verhalten feststeht.
+7. ADR-Nachtrag zuletzt.
+
+## Risiken
+
+| | Risiko (aus Nutzersicht) | Gegenmittel |
+|---|---|---|
+| **R-A** | Batch-Filterung falsch verdrahtet: ein echter zweiter Alarm im selben Lauf wird mit der Dublette zusammen verschluckt. | Eigener AC-17-Test mit ZWEI verschiedenen Hazards im selben Lauf, einer davon Duplikat. |
+| **R-B** | Eskalationsprüfung fällt bei einem Refactor an den falschen Platz (nach statt vor der V1-Ausnahme) und eine echte Verschärfung bleibt aus. | Mutations-Gegenprobe PFLICHT (AC-10, Gegenprobe-Unterpunkt). |
+| **R-C** | Ein künftiger Umbau von `alert_state.reset()` schont den neuen Präfix „aus Symmetrie zu `official_alert:`" und die Entdopplung wirkt über Briefings hinweg fälschlich fort. | AC-14 mit explizitem Vorher/Nachher-Test, Docstring-Verweis in `reset()`. |
+| **R-D** | Zwei Mechanismen (Doppel-Alert-Guard + neues Gate) laufen künftig versehentlich gegeneinander oder einer wird für redundant gehalten und entfernt, wodurch Nowcast↔Δ ungeschützt bleibt. | AC-13 als explizite Regression, T7-Begründung in der Spec. |
+| **R-E** | Ein leeres/unbekanntes Registerformat (Altdaten, korrupte Datei) wird als Match interpretiert und unterdrückt fälschlich. | AC-19 fail-soft-Test mit kaputtem/fremdem Registereintrag. |
+
+## Wächter, die mitziehen müssen
+
+| Test | Warum |
+|---|---|
+| `tests/tdd/test_nowcast_suppression_logging.py::test_ac9_amtlicher_alarm_bekommt_keinen_unterdrueckungs_grund` | bleibt für Ruhezeit/Tageslimit unverändert grün (S4a E3) — NICHT anfassen, AC-16 grenzt die Erweiterung sauber ab |
+| `tests/tdd/test_alert_gate.py` | bekommt `check_event_identity_gate`-Fälle dazu; bestehende `check_nowcast_gate`/`check_official_alert_gate`-Fälle bleiben unverändert grün |
+| `tests/tdd/test_issue_1088_official_alert_triggers.py` | Trip-Amtlich-Auslöser, plus der neue Kernfall-Regressionstest |
+| Nowcast-Regressionstests (bestehende Radar-Alert-Suiten) | Doppel-Alert-Guard-Verhalten (T7) muss identisch bleiben |
+
+## Test-Plan
+
+Kern-Schicht (deterministisch, kein Netz), sofern nicht anders vermerkt.
+
+| AC | Datei | Schicht |
+|---|---|---|
+| AC-1 bis AC-3 (Baustein-Struktur, Register) | `tests/tdd/test_alert_gate.py` (neu, `check_event_identity_gate`) | Kern |
+| AC-4 (Gefahrenart-Kanon, Nicht-Kanon-Hazards) | `tests/tdd/test_alert_gate.py` (neu, `resolve_hazard_class`) | Kern |
+| AC-4b inkl. Gegenprobe (eine Klasse `wet`, Kreuzprobe konvektiv/nicht-konvektiv) | `tests/tdd/test_alert_gate.py` | Kern |
+| AC-5 (Ortsbezug, Bruchstelle) | `tests/tdd/test_alert_gate.py` | Kern |
+| AC-6, AC-7 (Zeitfenster Punkt-Intervall, fail-soft) | `tests/tdd/test_alert_gate.py` | Kern |
+| AC-8, AC-9 inkl. Gegenprobe (V1 Kernregel + Ausnahme) | `tests/tdd/test_alert_gate.py` | Kern |
+| AC-10 inkl. Gegenprobe (V2 Eskalation) | `tests/tdd/test_alert_gate.py` | Kern |
+| AC-11 (kanalübergreifend, V3) | `tests/tdd/test_issue_1088_official_alert_triggers.py` (neuer Fall, Aufruf-Reihenfolge) | Kern |
+| AC-12 (letzte Stufe, Aufrufreihenfolge) | `tests/tdd/test_issue_1088_official_alert_triggers.py`, Nowcast-Äquivalent | Kern |
+| AC-13 (Doppel-Alert-Guard-Regression, T7) | bestehende Radar-Doppel-Alert-Guard-Tests, unverändert + 1 neuer Fall | Kern |
+| AC-14 (Reset erfasst neuen Präfix) | `tests/tdd/test_alert_state_reset.py` (Bestand, ergänzt) | Kern |
+| AC-15 (Beobachtbarkeit Nowcast) | bestehende Nowcast-Suppression-Log-Tests, ergänzt | Kern |
+| AC-16 (Beobachtbarkeit amtlich, Abgrenzung zu S4a E3) | `tests/tdd/test_nowcast_suppression_logging.py` (ergänzt) | Kern |
+| AC-17 (Batch-Filterung, Teilunterdrückung) | `tests/tdd/test_issue_1088_official_alert_triggers.py` (neuer Fall) | Kern |
+| AC-18 (Mandantentrennung) | `tests/tdd/test_alert_gate.py` (zwei Nutzer-Kontexte) | Kern |
+| AC-19 (fail-soft bei unbekanntem Registerformat) | `tests/tdd/test_alert_gate.py` | Kern |
+| AC-20 (amtliche Eskalation bleibt cooldown-frei, Regression zu S4a) | `tests/tdd/test_alert_gate.py` (Signatur-Inspektion `check_official_alert_gate` unverändert) | Kern |
+| AC-21 (ADR-Nachtrag) | `# doc-compliance-test` bzw. `tests/test_adr_index_drift.py` | Kern |
+
+Live-E2E: keine eigenen Live-Marker-Tests — echte quellenübergreifende
+Doppelungen sind nicht auf Bestellung provozierbar. Staging-Nachweis über
+gezielt gesetzte Registereinträge (analog S4a: vorbelegte Zustandsdateien),
+nicht über „auf ein echtes Gewitter warten".
+
+## Acceptance Criteria
+
+**Baustein-Struktur**
+
+- **AC-1:** Given die neue Funktion `check_event_identity_gate` in
+  `src/services/alert_gate.py`, When sowohl der Nowcast-Trip-Pfad
+  (`check_radar_alerts`) als auch der amtliche Trip-Pfad
+  (`_send_official_alert_only`) je eine Meldung vor dem Versand prüfen,
+  Then rufen beide dieselbe Funktion auf — nicht zwei eigene Prüfungen —
+  und ihr Rückgabewert ist eine echte `GateResult`-Instanz, nicht nur ein
+  Objekt mit gleichnamigen Attributen.
+  - Test: Aufrufzähler (Spion) auf `check_event_identity_gate`, mindestens
+    1 Aufruf je Pfad und Lauf mit zutreffender Gefahrenklasse; zusätzlich
+    `isinstance(ergebnis, GateResult)` auf dem Rückgabewert.
+
+- **AC-2:** Given eine erfolgreich zugestellte Meldung (Nowcast oder
+  amtlich), When der Versand abgeschlossen ist, Then legt
+  `record_event_identity` genau EINEN Registereintrag unter dem Präfix
+  `event_identity:<hazard_class>:` in `AlertStateService` ab, mit
+  Gefahrenklasse, Ortskennungen, Zeitbezug, Dringlichkeit und Zeitpunkt.
+  - Test: Zustellung simulieren, `AlertStateService.load(entity_id)` nach
+    dem Lauf enthält genau einen neuen `event_identity:`-Schlüssel mit
+    allen Pflichtfeldern.
+
+- **AC-3:** Given einen fehlgeschlagenen Zustellversuch (kein Kanal
+  erreichbar), When der Lauf beendet ist, Then wurde KEIN Registereintrag
+  angelegt — Registrierung ausschließlich nach erfolgreicher Zustellung
+  (F001-Symmetrie zu `record_nowcast_sent`).
+  - Test: alle Kanäle unerreichbar simulieren, Register-Snapshot vor/nach
+    dem Lauf identisch.
+
+**Gefahrenart-Kanon (T2)**
+
+- **AC-4:** Given eine amtliche Warnung mit `hazard` außerhalb der Klasse
+  `wet` (`"extreme_heat"`, `"wildfire_risk"`, `"access_ban"`,
+  `"wind_gust"`, `"snow"`, `"black_ice"`, `"extreme_cold"`) UND einen
+  zeitlich/örtlich überlappenden Nowcast-Registereintrag, When
+  `check_event_identity_gate` geprüft wird, Then wird die Warnung NICHT
+  unterdrückt — `resolve_hazard_class` liefert `None`, die Prüfung greift
+  für diese Gefahrenart nie.
+  - Test: für jeden der sieben genannten Hazard-Werte einen Fall mit
+    künstlich passendem Nowcast-Registereintrag, Zustellung erfolgt in
+    allen sieben Fällen.
+
+- **AC-4b:** Given einen registrierten Nowcast-Eintrag mit
+  `is_convective=True` (Klasse `wet`), When eine amtliche Warnung mit
+  `hazard="rain"` ODER `hazard="flood"` desselben Orts und überlappenden
+  Zeitfensters eintrifft, Then wird sie unterdrückt — und ebenso im
+  umgekehrten Fall (Nowcast mit `is_convective=False` gegen amtliches
+  `thunderstorm`). Die Radar-Einstufung konvektiv/nicht-konvektiv trennt
+  KEINE Ereignisse (PO-Entscheid 2026-08-16).
+  - Test: vier Fälle über Kreuz — `is_convective` ∈ {True, False} ×
+    `hazard` ∈ {`"thunderstorm"`, `"rain"`}, alle vier `allowed=False`.
+  - Mutations-Gegenprobe (Pflicht): `resolve_hazard_class` wieder auf zwei
+    Klassen aufspalten (`"convective"`/`"precipitation"`) MUSS diesen Test
+    rot machen.
+
+**Ortsbezug (T3)**
+
+- **AC-5:** Given zwei Meldungen gleicher Gefahrenklasse und
+  überlappenden Zeitfensters, aber deren Segment-Kennungen sich NICHT
+  überschneiden (disjunkte Mengen) ODER bei denen eine der beiden
+  Kennungen leer/`None` ist, When `check_event_identity_gate` geprüft
+  wird, Then entsteht KEIN Match — beide Meldungen werden zugestellt.
+  Eine leere Kennung erzeugt in keinem Fall ein Match.
+  - Test: (a) disjunkte Segment-Mengen, (b) eine Seite ohne Segment-
+    Kennung — beide Fälle liefern `allowed=True`.
+
+**Zeitfenster (T4)**
+
+- **AC-6:** Given den Kernfall dieser Scheibe — einen bereits registrierten
+  Nowcast-Eintrag (Gefahrenklasse `wet`, Segment `3`, Onset 14:22 UTC), When
+  8,2 Minuten später eine amtliche Warnung derselben Klasse und
+  desselben Segments eintrifft, deren Gültigkeitsfenster den Onset-Punkt
+  (mit 60-Min-Puffer) überlappt, Then wird die amtliche Warnung
+  unterdrückt (Reproduktion des gemessenen Falls `5f534011`,
+  2026-08-11).
+  - Test: Nowcast-Eintrag vorbelegen, amtliche Warnung 8,2 Min später mit
+    überlappendem Fenster auslösen, `allowed=False`,
+    `reason=REASON_EVENT_DUPLICATE`.
+
+- **AC-7:** Given eine Meldung ohne vergleichbaren Zeitbezug (fehlendes
+  `valid_from`/`valid_to` bei amtlich, fehlender Onset bei Nowcast) ODER
+  einen Registereintrag mit unparsbarem Zeitfeld, When
+  `check_event_identity_gate` geprüft wird, Then entsteht KEIN Match —
+  die Meldung wird zugestellt (fail-soft, gleiche Richtung wie
+  `official_alert_revision_verdict`).
+  - Test: je ein Fall mit fehlendem Zeitbezug auf jeder Seite,
+    `allowed=True` in beiden Fällen.
+
+**V1 — zeitliche Priorität mit Abdeckungs-Vorbehalt**
+
+- **AC-8:** Given eine bereits registrierte Meldung, When eine zweite
+  Meldung derselben Klasse/desselben Orts eintrifft, deren Zeitfenster
+  vollständig innerhalb des bereits abgedeckten Fensters liegt (keine
+  Eskalation, keine wesentliche Erweiterung), Then wird sie unterdrückt.
+  - Test: zweite Meldung mit identischer/kleinerer Dringlichkeit und
+    Zeitfenster ⊆ bereits abgedecktem Fenster, `allowed=False`.
+
+- **AC-9:** Given eine bereits registrierte Nowcast-Meldung (abgedeckt
+  bis Onset+60 Min), When eine amtliche Warnung derselben Klasse/desselben
+  Orts eintrifft, deren `valid_to` mehr als 60 Minuten über das bereits
+  abgedeckte Ende hinausreicht — auch OHNE höhere Dringlichkeit —, Then
+  wird sie zugestellt (neue Information, V1-Ausnahme).
+  - Test: Nowcast-Eintrag abgedeckt bis T, amtliche Warnung mit
+    `valid_to = T + 90min`, gleiche Dringlichkeit, `allowed=True`.
+  - Mutations-Gegenprobe (Pflicht): die Schwelle `NOWCAST_HORIZON_MIN`
+    durch eine deutlich größere Zahl ersetzen (z. B. `600`) MUSS diesen
+    Test rot machen.
+
+**V2 — Verschärfung durchbricht immer**
+
+- **AC-10:** Given eine bereits registrierte Meldung niedrigerer
+  Dringlichkeit (`"MODERATE"`), When eine zweite Meldung derselben
+  Klasse/desselben Orts mit HÖHERER Dringlichkeit (`"HIGH"`) eintrifft —
+  UNABHÄNGIG davon, ob ihr Zeitfenster das bereits abgedeckte wesentlich
+  erweitert oder nicht —, Then wird sie zugestellt.
+  - Test: zweite Meldung mit höherer Dringlichkeit UND Zeitfenster
+    vollständig innerhalb des abgedeckten Fensters (die V1-Ausnahme
+    greift hier NICHT, nur die Eskalation), `allowed=True`.
+  - Mutations-Gegenprobe (PFLICHT): den Eskalations-Zweig entfernen bzw.
+    hinter die V1-Ausnahme verschieben MUSS diesen Test rot machen — das
+    ist die Absicherung gegen die gefährlichste Fehlerrichtung „Alarm
+    bleibt aus" bei einer echten Verschärfung.
+
+**V3 — kanalübergreifend**
+
+- **AC-11:** Given eine durch `check_event_identity_gate` unterdrückte
+  amtliche Warnung, When man die Kanal-Aufteilung
+  (`alert_channel_threshold.split_by_threshold`) für diesen Lauf
+  betrachtet, Then wird sie für KEINEN Kanal aufgerufen — die
+  Entdopplung entscheidet VOR der Kanal-Schwelle, nicht je Kanal danach.
+  - Test: Aufrufzähler auf `split_by_threshold`, bleibt bei 0, wenn das
+    Gate unterdrückt; wird aufgerufen, wenn das Gate freigibt.
+
+**Reihenfolge**
+
+- **AC-12:** Given beide Trip-Aufrufstellen, When man ihre
+  Aufrufreihenfolge zur Laufzeit beobachtet, Then läuft
+  `check_event_identity_gate` in beiden Pfaden als LETZTE Stufe —
+  Nowcast: nach `check_nowcast_gate`, Briefing-Vergleich UND
+  Doppel-Alert-Guard; amtlich: nach `check_official_alert_gate` UND
+  `_is_briefing_imminent`.
+  - Test: Aufruf-Sequenz-Spionage in beiden Pfaden, ein reiner
+    Quellcode-Grep genügt nicht — entscheidend ist die Laufzeit-Reihenfolge.
+
+**T7 — Doppel-Alert-Guard bleibt bestehen**
+
+- **AC-13:** Given einen Trip mit zugestelltem Änderungsalarm (Δ) für
+  ein Segment, When innerhalb des Cooldowns ein Nowcast-Alarm für
+  dasselbe Segment/dieselbe Gefahrenart ansteht, Then bleibt er weiterhin
+  durch den bestehenden Doppel-Alert-Guard (`trip_alert.py:1081-1099`)
+  unterdrückt — unverändert gegenüber vor dieser Scheibe, unabhängig vom
+  neuen `check_event_identity_gate`.
+  - Test: bestehende Doppel-Alert-Guard-Fälle unverändert grün ausführen;
+    zusätzlich ein Fall, der zeigt, dass das neue Gate hierfür gar nicht
+    zuständig ist (kein Registereintrag für Δ-Alarme).
+
+**Register-Reset (T5)**
+
+- **AC-14:** Given einen Trip mit einem `event_identity:`-Registereintrag
+  UND einem `official_alert:`-Eintrag, When
+  `AlertStateService.reset(entity_id)` beim Briefing-Versand läuft, Then
+  ist der `event_identity:`-Eintrag danach verschwunden, der
+  `official_alert:`-Eintrag bleibt unverändert erhalten (bestehendes
+  Verhalten aus #1460).
+  - Test: beide Eintragstypen vorbelegen, `reset()` aufrufen, Datei danach
+    enthält nur noch den `official_alert:`-Schlüssel.
+
+**Beobachtbarkeit (T6)**
+
+- **AC-15:** Given eine durch `check_event_identity_gate` unterdrückte
+  Nowcast-Meldung, When der Lauf beendet ist, Then enthält
+  `alert_log.json` (`not_delivered`) genau einen Eintrag mit
+  `reason=REASON_NOWCAST` und `gate_reason=REASON_EVENT_DUPLICATE`.
+  - Test: Unterdrückung erzwingen, Protokoll-Eintrag prüfen.
+
+- **AC-16:** Given eine durch `check_event_identity_gate` unterdrückte
+  amtliche Warnung, When der Lauf beendet ist, Then enthält
+  `alert_log.json` (`not_delivered`) genau einen Eintrag mit
+  `reason=REASON_OFFICIAL_ALERT` und `gate_reason=REASON_EVENT_DUPLICATE`
+  — UND: eine durch Ruhezeit oder Tageslimit (nicht durch
+  Ereignis-Identität) unterdrückte amtliche Warnung erzeugt weiterhin
+  KEINEN Protokoll-Eintrag (S4a E3 bleibt für diese beiden Gründe
+  unverändert gültig).
+  - Test: zwei Fälle im selben Testmodul — (a) Ereignis-Identität-
+    Unterdrückung erzeugt einen Eintrag, (b) Ruhezeit-Unterdrückung
+    erzeugt keinen; bestehender S4a-Wächter bleibt zusätzlich unverändert
+    grün.
+
+**Batch-Filterung (Bruchstelle)**
+
+- **AC-17:** Given einen Lauf mit zwei amtlichen Warnungen für denselben
+  Trip — eine davon ein Duplikat eines bereits registrierten
+  Nowcast-Ereignisses (`thunderstorm` → Klasse `wet`), die andere eine
+  eigenständige Warnung anderer Gefahrenart (`extreme_heat`, keine
+  Klasse) —, When `_send_official_alert_only` läuft, Then wird NUR die
+  duplizierte Warnung unterdrückt, die andere wird zugestellt — beide in
+  getrennter Betrachtung, nicht als Alles-oder-Nichts-Entscheidung über
+  den ganzen Lauf.
+  - Test: beide Warnungen im selben Lauf auslösen, zugestellte Nachricht
+    enthält ausschließlich `extreme_heat`, Protokoll zeigt einen
+    `not_delivered`-Eintrag für `thunderstorm`.
+
+**Mandantentrennung**
+
+- **AC-18:** Given zwei verschiedene Nutzer mit je einem Trip gleicher
+  Kennung, deren Registereinträge unabhängig geführt werden, When Nutzer
+  A einen Nowcast-Eintrag registriert und Nutzer B unabhängig davon eine
+  amtliche Warnung derselben Klasse/desselben Segments auslöst, Then
+  wirkt A's Registereintrag NICHT auf B — B erhält seine Warnung, ohne
+  Rückfall auf `"default"`.
+  - Test: zwei Datenverzeichnisse (`user_id` A/B), gleiche Trip-Kennung,
+    A registriert, B's amtliche Warnung geht trotzdem durch.
+
+**Bestandsdaten / fail-soft**
+
+- **AC-19:** Given einen Registereintrag mit unbekanntem/kaputtem Format
+  (fehlendes `severity`-Feld, unparsbares Zeitfeld, aus einer künftigen
+  Schema-Version), When `check_event_identity_gate` diesen Eintrag als
+  Kandidat prüft, Then wird er wie „kein Match" behandelt — die neue
+  Meldung wird zugestellt, kein Absturz.
+  - Test: Registereintrag mit fehlenden/kaputten Feldern vorbelegen,
+    neue Meldung auslösen, `allowed=True`, kein Exception-Durchbruch.
+
+**Regression zu S4a**
+
+- **AC-20:** Given die Funktionssignatur von `check_official_alert_gate`
+  nach Abschluss dieser Scheibe, When man sie inspiziert, Then ist sie
+  UNVERÄNDERT gegenüber S4a — kein Cooldown-/Sperrzeit-Parameter wurde
+  nachträglich ergänzt. Die neue Ereignis-Identität-Prüfung ist ein
+  EIGENER, nachgelagerter Aufruf, keine Erweiterung des Gates selbst.
+  - Test: `inspect.signature(check_official_alert_gate)` unverändert
+    gegenüber dem S4a-Stand (Diff der Parameterliste ist leer).
+
+**Dokumentation**
+
+- **AC-21:** Given den ADR-0021-Nachtrag aus S4a (#1467), When diese
+  Scheibe abgeschlossen ist, Then trägt ADR-0021 einen weiteren,
+  datierten Nachtrag mit Bezug auf „#1467" und „S4b", der festhält, dass
+  seit dieser Scheibe eine quellenübergreifende Ereignis-Identität-Prüfung
+  als letzte, gemeinsame Stufe für Nowcast und amtliche Trip-Alarme
+  existiert — ohne die S4a-Aussage zur Unterdrückungs-Protokollierung zu
+  widerrufen (die gilt weiterhin für Ruhezeit/Tageslimit, s. AC-16).
+  - Test: `# doc-compliance-test` — ADR-0021 enthält nach Abschluss einen
+    Nachtrag-Absatz mit Bezug auf „#1467" und „S4b", datiert nach dem
+    2026-08-16.
+
+## Known Limitations
+
+- **Ein stratiformer Landregen-Nowcast kann von einer amtlichen
+  Gewitterwarnung unterdrückt werden** (und umgekehrt), weil der Kanon
+  beide zur Klasse `wet` zählt. Bewusster PO-Entscheid 2026-08-16: die
+  Radar-Einstufung konvektiv/nicht-konvektiv ist eine Momentaufnahme der
+  Zelle, kein Ereignis-Unterscheidungsmerkmal (Messung s. Implementation
+  Details). Die Trennschärfe liegt bei Ort, Zeitfenster und den beiden
+  Ausnahmen V1/V2.
+- **Punkt-gegen-Punkt und Intervall-gegen-Intervall bleiben in dieser
+  Scheibe isoliert getestet, nicht end-to-end verdrahtet** — über die
+  beiden Trip-Aufrufstellen ist nur Punkt-gegen-Intervall real
+  erreichbar. S4b-2/S4b-3 könnten das ändern.
+- **Ortsvergleich bleibt vollständig außerhalb dieser Scheibe** — der
+  Baustein ist entitätsparametrisiert vorbereitet, aber nicht verdrahtet
+  (S4b-2).
+- **Änderungsalarm (Δ) als dritte Prüfrichtung bleibt offen** (S4b-3,
+  optional) — der bestehende, weniger generische Doppel-Alert-Guard
+  bleibt die einzige Absicherung für diese Paarung.
+- **Ein Rückbau des Bausteins (Baustein → wieder getrennte Prüfungen) ist
+  mit Verhaltenstests grundsätzlich nicht vollständig fangbar** — der
+  strukturelle Schutz liegt teilweise außerhalb dieser Spec (Code-Review).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue — ADR-0021 (geteilter Auswertungskern) bekommt
+  einen weiteren Nachtrag, im Anschluss an den S4a-Nachtrag.
+- **Rationale:** Die quellenübergreifende Ereignis-Identität-Prüfung ist
+  konsequente Fortsetzung des in ADR-0021 etablierten Musters — ein
+  geteilter Baustein statt N eigenständiger Prüfketten je Quelle. Neu
+  ggü. S3/S4a ist, dass der Baustein hier erstmals **quellenübergreifend**
+  vergleicht (nicht nur je Quelle dieselbe Prüfkette anwendet), und dafür
+  ein eigenes, wenn auch kleines, Datenmodell (das Ereignis-Identität-
+  Register) einführt — kein neues Architekturprinzip, aber ein neuer
+  Baustein-Typ innerhalb des bestehenden Prinzips.
+
+## Changelog
+
+- 2026-08-16: Initiale Spec. V1–V3 (fachlich) und T1–T7 (technisch) nach
+  PO-Vorgabe vom 2026-08-16 (`docs/context/rework-1467-s4b-entdopplung.md`)
+  zugeschnitten. Gefahrenart-Kanon und Ortsbezug-Aufwand gegen den
+  tatsächlichen Code verifiziert (Ortsbezug ist billiger als in der
+  ursprünglichen Risiko-Einschätzung angenommen, kein neues Datenmodell
+  nötig). Zeilenangaben gegen `origin/main` @ `5ddb46e7`, verifiziert.

--- a/docs/specs/modules/rework_1467_s4b_entdopplung.md
+++ b/docs/specs/modules/rework_1467_s4b_entdopplung.md
@@ -629,10 +629,22 @@ nicht über „auf ein echtes Gewitter warten".
   - Test: zweite Meldung mit höherer Dringlichkeit UND Zeitfenster
     vollständig innerhalb des abgedeckten Fensters (die V1-Ausnahme
     greift hier NICHT, nur die Eskalation), `allowed=True`.
-  - Mutations-Gegenprobe (PFLICHT): den Eskalations-Zweig entfernen bzw.
-    hinter die V1-Ausnahme verschieben MUSS diesen Test rot machen — das
-    ist die Absicherung gegen die gefährlichste Fehlerrichtung „Alarm
-    bleibt aus" bei einer echten Verschärfung.
+  - Mutations-Gegenprobe (PFLICHT): den Eskalations-Zweig **entfernen**
+    MUSS diesen Test rot machen — das ist die Absicherung gegen die
+    gefährlichste Fehlerrichtung „Alarm bleibt aus" bei einer echten
+    Verschärfung.
+  - **Nachtrag 2026-08-16 (Adversary-Befund, Präzisierung):** Die
+    ursprüngliche Fassung verlangte zusätzlich, dass ein **Verschieben**
+    des Eskalations-Zweigs hinter die V1-Ausnahme den Test rot macht. Das
+    ist bei der gebauten Codeform nicht erfüllbar — und zwar, weil sie
+    **stärker** ist als gefordert: V2 und V1 sind zwei unabhängige,
+    seiteneffektfreie Ausstiege (`return _ALLOWED`,
+    `alert_gate.py:605-609`). Ihre Reihenfolge ist verhaltensgleich, V1
+    kann V2 gar nicht überstimmen. Eine Reihenfolge-Abhängigkeit, die man
+    testen könnte, existiert nicht mehr. Wird der Baustein später so
+    umgebaut, dass einer der beiden Zweige einen Seiteneffekt bekommt,
+    lebt die Reihenfolge-Anforderung wieder auf und braucht dann einen
+    eigenen Test.
 
 **V3 — kanalübergreifend**
 

--- a/src/services/alert_gate.py
+++ b/src/services/alert_gate.py
@@ -33,13 +33,16 @@ ein fehlgeschlagener Versuch darf weder Budget noch Sperrzeit verbrauchen
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
-from typing import Callable, NamedTuple, Optional
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Iterable, NamedTuple, Optional
 from zoneinfo import ZoneInfo
 
+import services.alert_urgency as alert_urgency
 from services import alert_daily_limit, alert_log
 from services.alert_briefing_anchor import last_briefing_at
+from services.alert_state import AlertStateService
 from services.deviation_alert_engine import DeviationAlertEngine
+from services.radar_service import NOWCAST_HORIZON_MIN
 from services.throttle_store import ThrottleStore
 from utils.timezone import local_fmt
 
@@ -372,3 +375,280 @@ def record_nowcast_sent(
     """
     alert_daily_limit.increment(user_id, now, zone)
     _resolve_store(user_id, throttle_store).record(throttle_scope, throttle_key, now)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Issue #1467 Scheibe S4b-1 — quellenuebergreifende Ereignis-Identitaet
+# SPEC: docs/specs/modules/rework_1467_s4b_entdopplung.md
+#
+# `check_event_identity_gate()` ist die LETZTE Stufe an beiden Trip-
+# Aufrufstellen (Nowcast `check_radar_alerts`, amtlich
+# `_send_official_alert_only`) -- nach allen bestehenden, billigeren
+# Pruefungen. Sie entdoppelt EIN UND DASSELBE Ereignis, wenn es ueber ZWEI
+# verschiedene Quellen gemeldet wird (Nowcast und amtliche Warnung), anhand
+# von Gefahrenklasse + Ortsbezug + ueberlappendem Zeitfenster. Anders als
+# `check_nowcast_gate()`/`check_official_alert_gate()` ist sie
+# entitaetsparametrisiert von Anfang an (Trip UND Compare, S4b-2 haengt nur
+# noch an).
+# ═══════════════════════════════════════════════════════════════════════════
+
+# T2-Kanon (PO-Entscheid 2026-08-16): EINE Gefahrenklasse statt zwei. Die
+# Messung am Produktivprotokoll (Spec Implementation Details) zeigt, dass die
+# Radar-Einstufung konvektiv/nicht-konvektiv nur die Erscheinungsform
+# DERSELBEN Zelle unterscheidet, nicht das Ereignis -- eine Aufspaltung in
+# zwei Klassen liesse drei von vier gemessenen quellenuebergreifenden Paaren
+# aneinander vorbeilaufen.
+HAZARD_CLASS_WET = "wet"
+_WET_HAZARDS = frozenset({"thunderstorm", "flood", "rain"})
+
+
+def resolve_hazard_class(
+    *, is_convective: Optional[bool] = None, hazard: Optional[str] = None,
+) -> Optional[str]:
+    """T2-Kanon. Genau EIN Identifikationsweg pro Aufrufer: Nowcast liefert
+    `is_convective`, amtlich liefert `hazard`. Unbekannter/anderer Hazard
+    -> None (keine Klasse, nie entdoppelt, AC-4).
+
+    Ein Nowcast ist IMMER Niederschlag — `is_convective` unterscheidet nur
+    die Erscheinungsform derselben Zelle, nicht das Ereignis (PO-Entscheid
+    2026-08-16, Messung s. Spec Implementation Details T2, AC-4b)."""
+    if is_convective is not None:
+        return HAZARD_CLASS_WET
+    if hazard in _WET_HAZARDS:
+        return HAZARD_CLASS_WET
+    return None
+
+
+def _parse_event_ts(raw: object) -> Optional[datetime]:
+    """Fail-soft (AC-7/AC-19): ein fehlendes oder unparsbares Zeitfeld liefert
+    `None` statt zu knallen — der Aufrufer behandelt `None` als "kein
+    Zeitbezug", nie als Absturz."""
+    if raw is None:
+        return None
+    try:
+        ts = datetime.fromisoformat(str(raw))
+    except (TypeError, ValueError):
+        return None
+    return ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
+
+
+def _covered_until(
+    point_at: Optional[datetime], window_end: Optional[datetime],
+) -> Optional[datetime]:
+    """"Abgedecktes Ende" einer Meldung (V1): ein Zeitpunkt deckt sich selbst
+    plus den Nowcast-Horizont ab, ein Intervall bis zu seinem Ende. Gilt fuer
+    BEIDE Seiten des Vergleichs (Registereintrag UND neue Meldung) -- dieselbe
+    Funktion, damit die V1-Ausnahme symmetrisch bleibt."""
+    if point_at is not None:
+        return point_at + timedelta(minutes=NOWCAST_HORIZON_MIN)
+    return window_end
+
+
+def _times_overlap(
+    entry_point_at: Optional[datetime],
+    entry_window_start: Optional[datetime],
+    entry_window_end: Optional[datetime],
+    point_at: Optional[datetime],
+    window_start: Optional[datetime],
+    window_end: Optional[datetime],
+    cooldown_minutes: Optional[int],
+) -> bool:
+    """T4 — drei Vergleichsfaelle (Spec Implementation Details).
+
+    Punkt gegen Punkt: Differenz <= `cooldown_minutes` (Vollstaendigkeits-
+    fall, ueber die Trip-Aufrufstellen dieser Scheibe nicht end-to-end
+    erreichbar). Punkt gegen Intervall: Ueberlappung mit `NOWCAST_HORIZON_MIN`-
+    Puffer auf der Punkt-Seite -- der gemessene Kernfall (AC-6). Intervall
+    gegen Intervall: echte Ueberlappung ohne Puffer, analog
+    `official_alert_revision_verdict()`.
+
+    Fehlt einer Seite jeder vergleichbare Zeitbezug -> kein Match, fail-soft
+    (AC-7)."""
+    if entry_point_at is not None and point_at is not None:
+        limit_min = (
+            cooldown_minutes if cooldown_minutes is not None else NOWCAST_HORIZON_MIN
+        )
+        return abs((point_at - entry_point_at).total_seconds()) <= limit_min * 60
+
+    if entry_point_at is not None:
+        entry_start = entry_point_at - timedelta(minutes=NOWCAST_HORIZON_MIN)
+        entry_end = entry_point_at + timedelta(minutes=NOWCAST_HORIZON_MIN)
+    elif entry_window_start is not None and entry_window_end is not None:
+        entry_start, entry_end = entry_window_start, entry_window_end
+    else:
+        return False
+
+    if point_at is not None:
+        new_start = point_at - timedelta(minutes=NOWCAST_HORIZON_MIN)
+        new_end = point_at + timedelta(minutes=NOWCAST_HORIZON_MIN)
+    elif window_start is not None and window_end is not None:
+        new_start, new_end = window_start, window_end
+    else:
+        return False
+
+    return entry_start < new_end and new_start < entry_end
+
+
+def _find_matching_entry(
+    state: dict,
+    hazard_class: str,
+    segment_ids: list,
+    point_at: Optional[datetime],
+    window_start: Optional[datetime],
+    window_end: Optional[datetime],
+    cooldown_minutes: Optional[int],
+) -> Optional[dict]:
+    """Scannt das Register nach einem Kandidaten derselben Gefahrenklasse
+    (T3/T4). Fail-soft ueberall (AC-7/AC-19): ein einzelner kaputter
+    Registereintrag (fehlende Felder, unparsbare Zeit) wird uebersprungen,
+    nie zum Absturz -- die naechsten Kandidaten werden trotzdem geprueft.
+
+    AC-5 (Bruchstelle): eine leere Segment-Menge -- auf der neuen ODER der
+    registrierten Seite -- erzeugt NIE ein Match."""
+    new_segments = {s for s in (segment_ids or []) if s}
+    if not new_segments:
+        return None
+
+    prefix = f"event_identity:{hazard_class}:"
+    for key, entry in state.items():
+        if not isinstance(key, str) or not key.startswith(prefix):
+            continue
+        if not isinstance(entry, dict):
+            continue
+        try:
+            entry_segments = {s for s in (entry.get("segment_ids") or []) if s}
+            if not entry_segments or new_segments.isdisjoint(entry_segments):
+                continue
+
+            entry_point_at = _parse_event_ts(entry.get("point_at"))
+            entry_window_start = _parse_event_ts(entry.get("window_start"))
+            entry_window_end = _parse_event_ts(entry.get("window_end"))
+            if not _times_overlap(
+                entry_point_at, entry_window_start, entry_window_end,
+                point_at, window_start, window_end, cooldown_minutes,
+            ):
+                continue
+
+            severity = entry["severity"]
+            covered_until = _covered_until(entry_point_at, entry_window_end)
+            if covered_until is None:
+                continue
+            return {"severity": severity, "covered_until": covered_until}
+        except (KeyError, TypeError, ValueError):
+            # AC-19: ein kaputter/unbekannter Registereintrag zaehlt fail-soft
+            # als "kein Match" -- nicht als Absturz.
+            continue
+    return None
+
+
+def _covers_materially_more(
+    entry_covered_until: datetime,
+    point_at: Optional[datetime],
+    window_end: Optional[datetime],
+) -> bool:
+    """V1-Ausnahme (AC-9): reicht die neue Meldung "wesentlich" -- mehr als
+    `NOWCAST_HORIZON_MIN` -- ueber das bereits abgedeckte Ende des
+    Registereintrags hinaus, kommt sie durch. Dieselbe `_covered_until()`
+    wie oben, jetzt auf die neue Meldung angewendet -- symmetrische
+    Definition von "abgedeckt"."""
+    new_covered_until = _covered_until(point_at, window_end)
+    if new_covered_until is None:
+        return False
+    return new_covered_until > entry_covered_until + timedelta(minutes=NOWCAST_HORIZON_MIN)
+
+
+def check_event_identity_gate(
+    *,
+    user_id: str,
+    entity_id: str,
+    hazard_class: Optional[str],
+    segment_ids: Iterable[str],
+    severity: str,
+    now: datetime,
+    point_at: Optional[datetime] = None,
+    window_start: Optional[datetime] = None,
+    window_end: Optional[datetime] = None,
+    cooldown_minutes: Optional[int] = None,
+) -> GateResult:
+    """Darf diese Meldung raus, oder ist sie ein quellenuebergreifendes
+    Duplikat einer bereits gemeldeten Meldung (Issue #1467 Scheibe S4b-1)?
+
+    Reiner Lesevorgang (AC-3) -- Registrierung ist ausschliesslich Sache von
+    `record_event_identity()`, aufgerufen NACH erfolgreicher Zustellung
+    (F001-Symmetrie zu `record_nowcast_sent`).
+
+    `hazard_class=None` (T2: Gefahrenart ausserhalb des `wet`-Kanons) laesst
+    IMMER durch (AC-4) -- die Pruefung greift fuer diese Gefahrenart
+    strukturell nie, ohne das Register ueberhaupt zu lesen.
+
+    Reihenfolge nach Fund eines Kandidaten, strukturell fest (Spec V1/V2):
+
+        Eskalation (V2, IMMER zuerst) -> V1-Ausnahme -> Unterdrueckung
+
+    Die Eskalationspruefung ist der ERSTE Zweig mit eigenem `return` -- vor
+    der V1-Ausnahme und vor der eigentlichen Unterdrueckung. Eine echte
+    Verschaerfung (hoehere Dringlichkeit) muss IMMER durchkommen, auch wenn
+    ihr Zeitfenster das bereits abgedeckte NICHT wesentlich erweitert
+    (AC-10) -- das ist die Absicherung gegen die gefaehrlichste
+    Fehlerrichtung "Alarm bleibt aus"."""
+    if hazard_class is None:
+        return _ALLOWED
+
+    state = AlertStateService(user_id=user_id).load(entity_id)
+    match = _find_matching_entry(
+        state, hazard_class, list(segment_ids or []),
+        point_at, window_start, window_end, cooldown_minutes,
+    )
+    if match is None:
+        return _ALLOWED
+
+    if alert_urgency.exceeds(severity, match["severity"]):
+        return _ALLOWED  # V2 — struktureller erster Zweig, bricht IMMER durch
+
+    if _covers_materially_more(match["covered_until"], point_at, window_end):
+        return _ALLOWED  # V1-Ausnahme
+
+    logger.debug(
+        "Ereignis-Identitaet unterdrueckt (%s) fuer %s/%s", hazard_class,
+        entity_id, user_id,
+    )
+    return GateResult(False, alert_log.REASON_EVENT_DUPLICATE)
+
+
+def record_event_identity(
+    *,
+    user_id: str,
+    entity_id: str,
+    hazard_class: str,
+    segment_ids: Iterable[str],
+    severity: str,
+    now: datetime,
+    point_at: Optional[datetime] = None,
+    window_start: Optional[datetime] = None,
+    window_end: Optional[datetime] = None,
+) -> None:
+    """Legt GENAU EINEN Registereintrag an (AC-2) -- AUSSCHLIESSLICH nach
+    erfolgreicher Zustellung aufzurufen (F001-Symmetrie zu
+    `record_nowcast_sent`). Read-Modify-Write mit Merge (CLAUDE.md): laedt
+    den vollen Zustand der Entitaet, ergaenzt den neuen Schluessel, schreibt
+    alles zurueck -- bestehende Eintraege (amtliches Melde-Gedaechtnis,
+    Doppel-Alert-Guard) bleiben unangetastet.
+
+    Registerschluessel `event_identity:<hazard_class>:<segment_ids>:<now>`
+    (analog `_identity_hazard_prefix()` in `official_alerts.py`) -- eindeutig
+    je Meldung, damit spaetere Registrierungen einander nicht ueberschreiben."""
+    segments = sorted({s for s in (segment_ids or []) if s})
+    key = f"event_identity:{hazard_class}:{','.join(segments)}:{now.isoformat()}"
+
+    service = AlertStateService(user_id=user_id)
+    state = service.load(entity_id)
+    state[key] = {
+        "hazard_class": hazard_class,
+        "segment_ids": segments,
+        "severity": severity,
+        "point_at": point_at.isoformat() if point_at is not None else None,
+        "window_start": window_start.isoformat() if window_start is not None else None,
+        "window_end": window_end.isoformat() if window_end is not None else None,
+        "reported_at": now.isoformat(),
+    }
+    service.save(entity_id, state)

--- a/src/services/alert_log.py
+++ b/src/services/alert_log.py
@@ -50,6 +50,10 @@ REASON_COOLDOWN = "cooldown"
 # Issue #1461 S3b-2a: Kanal war eingeschaltet, die Meldung lag aber unter der
 # dort eingestellten Dringlichkeits-Schwelle.
 REASON_BELOW_THRESHOLD = "below_channel_threshold"
+# Issue #1467 S4b-1: quellenuebergreifende Ereignis-Identitaet
+# (`services.alert_gate.check_event_identity_gate`) hat dieselbe Meldung
+# bereits ueber eine ANDERE Quelle gesehen (Nowcast <-> amtlich).
+REASON_EVENT_DUPLICATE = "event_duplicate"
 
 # Ausloeser der Meldung selbst (`reason` des Eintrags).
 REASON_FORECAST_CHANGE = "forecast_change"

--- a/src/services/alert_state.py
+++ b/src/services/alert_state.py
@@ -35,6 +35,14 @@ logger = logging.getLogger("alert_state")
 # official_alerts.py) baut seine Schlüssel damit, `reset()` schneidet daran.
 OFFICIAL_ALERT_KEY_PREFIX = "official_alert:"
 
+# Issue #1467 S4b-1 (T5): Schluesselraum der quellenuebergreifenden
+# Ereignis-Identitaet-Pruefung (`services.alert_gate.record_event_identity`/
+# `check_event_identity_gate`). BEWUSST OHNE eigenen Schutz in `reset()` --
+# der bestehende Filter dort behaelt NUR `official_alert:`-Schluessel und
+# verwirft automatisch jeden anderen Praefix, auch diesen neuen. Siehe
+# Docstring von `reset()`.
+EVENT_IDENTITY_KEY_PREFIX = "event_identity:"
+
 
 class AlertStateService:
     """Lädt/speichert/löscht das Alert-Melde-Gedächtnis pro Trip (mandantengetrennt)."""
@@ -82,6 +90,19 @@ class AlertStateService:
 
         Bleibt nach dem Schnitt kein amtlicher Eintrag übrig, verschwindet die
         Datei wie bisher vollständig.
+
+        Issue #1467 S4b-1 (T5): der Filter unten behält NUR den
+        ``official_alert:``-Präfixraum -- jeder andere Präfix, auch der
+        neuere ``event_identity:`` (Ereignis-Identität-Register, s.
+        ``EVENT_IDENTITY_KEY_PREFIX`` oben), wird beim Briefing-Reset
+        AUTOMATISCH mitgelöscht, ohne dass dieser Code je angefasst wurde.
+        Das ist beabsichtigt: nach einem Briefing ist der Informationsstand
+        neu, ein alter Nowcast-Registereintrag darf eine spätere amtliche
+        Warnung nicht mehr unterdrücken. Ein künftiger Umbau, der einen
+        zweiten Präfix "aus Symmetrie zu ``official_alert:``" schonen will,
+        würde dieses Verhalten versehentlich umdrehen -- AC-14
+        (``docs/specs/modules/rework_1467_s4b_entdopplung.md``) sichert
+        genau das mit einem eigenen Test ab.
         """
         path = self._path(entity_id)
         try:

--- a/src/services/alert_urgency.py
+++ b/src/services/alert_urgency.py
@@ -60,6 +60,15 @@ def highest_urgency(*urgencies: str) -> str:
     return max(urgencies, key=lambda u: _RANK.get(u, 0))
 
 
+def exceeds(a: str, b: str) -> bool:
+    """Echtes Groesser-als auf der bestehenden LOW/MODERATE/HIGH-Skala
+    (Issue #1467 S4b-1, V2-Eskalation). Nutzt dieselbe `_RANK`-Tabelle wie
+    `highest_urgency()`/`meets_or_exceeds()` -- keine zweite Rangfolge
+    (Wiederholungs-Klasse #1481). Unbekannte Werte gelten konservativ als
+    niedrigste Stufe."""
+    return _RANK.get(a, 0) > _RANK.get(b, 0)
+
+
 def meets_or_exceeds(urgency: str, threshold: str) -> bool:
     """Rangvergleich fuer die Kanal-Schwelle (#1461 S3b-2a): erreicht/uebertrifft
     `urgency` den `threshold`? Nutzt dieselbe `_RANK`-Tabelle wie

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -20,9 +20,12 @@ from services import alert_channel_threshold, alert_daily_limit, alert_log
 from services.alert_briefing_anchor import record_alert_anchor_rejected
 import services.alert_urgency as alert_urgency
 from services.alert_gate import (
+    check_event_identity_gate,
     check_nowcast_gate,
     check_official_alert_gate,
+    record_event_identity,
     record_nowcast_sent,
+    resolve_hazard_class,
 )
 from services.deviation_alert_engine import DeviationAlertEngine
 from services.notification_service import (
@@ -1168,6 +1171,39 @@ class TripAlertService:
                 effective_channels, _radar_urgency, trip.alert_channel_thresholds,
             )
 
+            # Issue #1467 S4b-1: quellenuebergreifende Ereignis-Identitaet --
+            # LETZTE Stufe vor dem Versand (AC-12), kanaluebergreifend (V3,
+            # daher NACH der Kanal-Schwelle oben berechnet, aber VOR dem
+            # eigentlichen Versand geprueft). Ein Nowcast ist immer Klasse
+            # 'wet' (T2, AC-4b) -- `resolve_hazard_class` bekommt hier NIE
+            # `None`.
+            _identity_gate = check_event_identity_gate(
+                user_id=self._user_id, entity_id=trip.id,
+                hazard_class=resolve_hazard_class(is_convective=_radar_request.is_convective),
+                segment_ids=(
+                    [_radar_request.segment_id] if _radar_request.segment_id else []
+                ),
+                severity=_radar_urgency, now=now_utc, point_at=_onset_dt,
+            )
+            if not _identity_gate.allowed:
+                logger.debug(
+                    f"Radar alert suppressed ({_identity_gate.reason}) for trip {trip.id}"
+                )
+                try:
+                    alert_log.append_suppressed_entry(
+                        self._user_id, entity_id=trip.id, entity_type="trip",
+                        reason=alert_log.REASON_NOWCAST, gate_reason=_identity_gate.reason,
+                        effective_channels=effective_channels,
+                    )
+                except Exception as e:
+                    logger.error(
+                        "Radar alert: Unterdrueckungs-Protokoll (Ereignis-"
+                        "Identitaet) fuer Trip %s fehlgeschlagen (%s) — der "
+                        "Alarm blieb aus, nur der Protokoll-Eintrag fehlt.",
+                        trip.id, e,
+                    )
+                continue
+
             # Best-Effort-Zustellung über NotificationService (Issue #1023)
             result = self._notification_service.send_radar_alert(
                 trip=trip,
@@ -1214,6 +1250,19 @@ class TripAlertService:
                 throttle_key=trip.id, now=datetime.now(timezone.utc),
                 zone=anchor_tz(trip, now_utc),
                 throttle_store=self._throttle_store,
+            )
+            # Issue #1467 S4b-1 (AC-2/AC-3, F001-Symmetrie): NUR nach
+            # erfolgreicher Zustellung -- ein spaeterer amtlicher Alarm
+            # fuer dasselbe Ereignis findet diesen Eintrag ueber
+            # `check_event_identity_gate()`.
+            record_event_identity(
+                user_id=self._user_id, entity_id=trip.id,
+                hazard_class=resolve_hazard_class(is_convective=_radar_request.is_convective),
+                segment_ids=(
+                    [_radar_request.segment_id] if _radar_request.segment_id else []
+                ),
+                severity=_radar_urgency, point_at=_onset_dt,
+                now=datetime.now(timezone.utc),
             )
             sent += 1
 
@@ -1509,6 +1558,49 @@ class TripAlertService:
             return False
 
         effective_channels = self._effective_alert_channels(trip)
+
+        # Issue #1467 S4b-1: Ereignis-Identitaet PRO Alert (Batch-Filterung,
+        # AC-17) -- ein Gate-Aufruf ueber die GANZE Liste waere in beide
+        # Richtungen falsch: alles durchlassen liesse die Nowcast-Dublette
+        # bestehen, alles sperren wuerde eine zweite, eigenstaendige Warnung
+        # im selben Lauf mit verschlucken (Fehlerrichtung "Alarm bleibt
+        # aus"). `_official_urgency` wird deshalb ERST NACH dem Filtern aus
+        # der verbleibenden Liste neu berechnet. Letzte Stufe vor dem Versand
+        # (AC-12), kanaluebergreifend (V3: VOR `split_by_threshold`, AC-11).
+        _filtered_notices = []
+        for _alert, _segment_ids in official_notices:
+            _hazard_class = resolve_hazard_class(hazard=_alert.hazard)
+            _severity = alert_urgency.urgency_from_official_level(_alert.level)
+            _identity_gate = check_event_identity_gate(
+                user_id=self._user_id, entity_id=trip.id,
+                hazard_class=_hazard_class, segment_ids=_segment_ids,
+                severity=_severity, now=now_utc,
+                window_start=_alert.valid_from, window_end=_alert.valid_to,
+            )
+            if _identity_gate.allowed:
+                _filtered_notices.append((_alert, _segment_ids))
+                continue
+            logger.debug(
+                f"Official alert suppressed ({_identity_gate.reason}) for trip {trip.id}"
+            )
+            try:
+                alert_log.append_suppressed_entry(
+                    self._user_id, entity_id=trip.id, entity_type="trip",
+                    reason=alert_log.REASON_OFFICIAL_ALERT,
+                    gate_reason=_identity_gate.reason,
+                    effective_channels=effective_channels,
+                )
+            except Exception as e:
+                logger.error(
+                    "Official alert: Unterdrueckungs-Protokoll (Ereignis-"
+                    "Identitaet) fuer Trip %s fehlgeschlagen (%s) — der "
+                    "Alarm blieb aus, nur der Protokoll-Eintrag fehlt.",
+                    trip.id, e,
+                )
+        if not _filtered_notices:
+            return False
+        official_notices = _filtered_notices
+
         # Issue #1461 S3b-2a: dieselbe Naht wie in `_send_alert()` -- die
         # Schwelle filtert nur den Versand, `effective_channels` bleibt ROH
         # fuers Protokoll (rote Linie #638).
@@ -1548,6 +1640,24 @@ class TripAlertService:
             alert_daily_limit.increment(
                 self._user_id, now_utc, anchor_tz(trip, now_utc),
             )
+            # Issue #1467 S4b-1 (AC-2/AC-3, F001-Symmetrie): NUR nach
+            # erfolgreicher Zustellung -- ein spaeterer Nowcast fuer dasselbe
+            # Ereignis findet diesen Eintrag ueber
+            # `check_event_identity_gate()`. Hazards ausserhalb des
+            # `wet`-Kanons (hazard_class=None) werden bewusst NICHT
+            # registriert -- ein Registereintrag ohne Klasse kaeme nie zum
+            # Zuge (kein Praefix-Match moeglich).
+            for _alert, _segment_ids in official_notices:
+                _hazard_class = resolve_hazard_class(hazard=_alert.hazard)
+                if _hazard_class is None:
+                    continue
+                record_event_identity(
+                    user_id=self._user_id, entity_id=trip.id,
+                    hazard_class=_hazard_class, segment_ids=_segment_ids,
+                    severity=alert_urgency.urgency_from_official_level(_alert.level),
+                    window_start=_alert.valid_from, window_end=_alert.valid_to,
+                    now=datetime.now(timezone.utc),
+                )
         return result.sent
 
     def _effective_alert_channels(self, trip: "Trip") -> set[str]:

--- a/tests/tdd/test_alert_gate.py
+++ b/tests/tdd/test_alert_gate.py
@@ -32,6 +32,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from app.loader import save_location
 
 from tests.helpers.nowcast_gate_fixtures import (
@@ -383,3 +385,673 @@ def test_ac15_tageslimit_wirkt_nicht_ueber_die_nutzergrenze():
     finally:
         clean_uid(a)
         clean_uid(b)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Issue #1467 Scheibe S4b-1 — quellenuebergreifende Ereignis-Identitaet
+# SPEC: docs/specs/modules/rework_1467_s4b_entdopplung.md
+#
+# ``check_event_identity_gate``/``record_event_identity``/
+# ``resolve_hazard_class`` existieren heute nicht -- RED-Grund fuer JEDEN
+# Test unten ist ein ``ImportError``, solange die Bausteine fehlen. Sobald
+# sie existieren, pruefen die Tests das tatsaechliche Verhalten (echte
+# ``AlertStateService``-Dateien auf Platte, kein Mock).
+#
+# Angenommene Signaturen (von diesen Tests VORGEGEBEN, nicht im Quellcode
+# gesehen -- die Implementierung muss sie erfuellen):
+#
+#     resolve_hazard_class(*, is_convective=None, hazard=None) -> str | None
+#     check_event_identity_gate(
+#         *, user_id, entity_id, hazard_class, segment_ids, severity, now,
+#         point_at=None, window_start=None, window_end=None,
+#         cooldown_minutes=None,
+#     ) -> GateResult
+#     record_event_identity(
+#         *, user_id, entity_id, hazard_class, segment_ids, severity, now,
+#         point_at=None, window_start=None, window_end=None,
+#     ) -> None
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+# ─────────────── Gefahrenart-Kanon (T2) — AC-4 + AC-4b ──────────────────────
+
+
+def test_ac4_resolve_hazard_class_kennt_nowcast_immer_als_wet():
+    """AC-4b (Baustein): ``resolve_hazard_class(is_convective=...)`` liefert
+    in BEIDEN Faellen (True/False) dieselbe Klasse ``HAZARD_CLASS_WET`` — ein
+    Nowcast ist immer Niederschlag, ``is_convective`` unterscheidet nur die
+    Erscheinungsform derselben Zelle (PO-Entscheid 2026-08-16, s. Spec
+    Implementation Details T2).
+
+    RED heute: ImportError."""
+    from services.alert_gate import HAZARD_CLASS_WET, resolve_hazard_class
+
+    assert resolve_hazard_class(is_convective=True) == HAZARD_CLASS_WET
+    assert resolve_hazard_class(is_convective=False) == HAZARD_CLASS_WET
+
+
+@pytest.mark.parametrize("hazard", ["thunderstorm", "flood", "rain"])
+def test_ac4b_amtliche_wet_hazards_erhalten_dieselbe_klasse(hazard):
+    """AC-4b: alle drei amtlichen ``wet``-Hazards (``thunderstorm``, ``flood``,
+    ``rain``) muessen auf dieselbe Klasse abbilden wie der Nowcast — sonst
+    liefe die quellenuebergreifende Entdopplung fuer diese Paare ins Leere."""
+    from services.alert_gate import HAZARD_CLASS_WET, resolve_hazard_class
+
+    assert resolve_hazard_class(hazard=hazard) == HAZARD_CLASS_WET
+
+
+@pytest.mark.parametrize("hazard", [
+    "wind_gust", "snow", "black_ice", "extreme_heat",
+    "extreme_cold", "wildfire_risk", "access_ban",
+])
+def test_ac4_nicht_wet_hazards_bekommen_keine_klasse(hazard):
+    """AC-4: die sieben Hazards ausserhalb des ``wet``-Kanons liefern ``None``
+    — ``resolve_hazard_class`` kennt keine andere Klasse, die Ereignis-
+    Identitaet greift fuer diese Gefahrenarten grundsaetzlich nie."""
+    from services.alert_gate import resolve_hazard_class
+
+    assert resolve_hazard_class(hazard=hazard) is None
+
+
+def test_ac4_check_event_identity_gate_laesst_hazard_class_none_immer_durch():
+    """AC-4 (integriert): ``hazard_class=None`` lässt IMMER durch, egal was im
+    Register steht — ``resolve_hazard_class`` hat vorher schon entschieden,
+    dass es fuer diese Gefahrenart keinen Kandidaten geben kann."""
+    from services.alert_gate import check_event_identity_gate
+
+    uid = fresh_uid("s4b-ac4")
+    clean_uid(uid)
+    try:
+        ergebnis = check_event_identity_gate(
+            user_id=uid, entity_id="trip-ac4", hazard_class=None,
+            segment_ids=["1"], severity="HIGH",
+            now=datetime.now(timezone.utc),
+        )
+        assert ergebnis.allowed is True
+        assert ergebnis.reason is None
+    finally:
+        clean_uid(uid)
+
+
+@pytest.mark.parametrize("is_convective,hazard", [
+    (True, "thunderstorm"), (True, "rain"),
+    (False, "thunderstorm"), (False, "rain"),
+])
+def test_ac4b_kreuzprobe_konvektiv_und_niederschlag_entdoppeln_sich_gegenseitig(
+    is_convective, hazard,
+):
+    """AC-4b (Kreuzprobe, Pflicht laut Spec) + Mutations-Gegenprobe.
+
+    GIVEN einen registrierten Nowcast-Eintrag mit ``is_convective=<param>``
+    WHEN  eine amtliche Warnung mit ``hazard=<param>`` desselben Orts und
+          ueberlappenden Zeitfensters eintrifft
+    THEN  wird sie unterdrueckt (``allowed=False``) — in ALLEN vier
+          Kombinationen. Die Radar-Einstufung konvektiv/nicht-konvektiv
+          trennt KEINE Ereignisse (PO-Entscheid 2026-08-16).
+
+    Mutations-Gegenprobe (Pflicht laut AC-4b): wuerde ``resolve_hazard_class``
+    wieder auf zwei Klassen (``"convective"``/``"precipitation"``﻿) aufgespalten,
+    lieferten ``is_convective=False``+``hazard="thunderstorm"`` bzw.
+    ``is_convective=True``+``hazard="rain"`` UNTERSCHIEDLICHE Klassen — kein
+    Registereintrag matcht mehr, die amtliche Warnung ginge faelschlich durch
+    (``allowed=True``), und genau diese zwei der vier Parametrisierungen
+    werden dann rot.
+
+    RED heute: ImportError."""
+    from services.alert_gate import (
+        check_event_identity_gate, record_event_identity, resolve_hazard_class,
+    )
+
+    uid = fresh_uid("s4b-ac4b")
+    clean_uid(uid)
+    try:
+        onset = datetime.now(timezone.utc) - timedelta(minutes=8, seconds=12)
+        record_event_identity(
+            user_id=uid, entity_id="trip-ac4b",
+            hazard_class=resolve_hazard_class(is_convective=is_convective),
+            segment_ids=["7"], severity="HIGH", point_at=onset, now=onset,
+        )
+
+        ergebnis = check_event_identity_gate(
+            user_id=uid, entity_id="trip-ac4b",
+            hazard_class=resolve_hazard_class(hazard=hazard),
+            segment_ids=["7"], severity="HIGH",
+            window_start=onset - timedelta(minutes=10),
+            window_end=onset + timedelta(minutes=45),
+            now=datetime.now(timezone.utc),
+        )
+
+        assert ergebnis.allowed is False, (
+            f"is_convective={is_convective} gegen hazard={hazard!r} muss "
+            f"entdoppeln: {ergebnis!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+# ─────────────────── Baustein-Struktur — AC-1 (Teil) / AC-2 / AC-3 ──────────
+
+
+def test_ac1_check_event_identity_gate_liefert_eine_echte_gateresult_instanz():
+    """AC-1 (Typ-Nachweis): der Rueckgabewert ist eine echte ``GateResult``-
+    Instanz, nicht nur ein Objekt mit gleichnamigen Attributen. Der zweite
+    Teil von AC-1 (beide Trip-Pfade rufen DENSELBEN Baustein, per
+    Aufrufzaehler) steht end-to-end in
+    ``tests/tdd/test_issue_1088_official_alert_triggers.py`` — dort sind
+    echte Trip-/Versand-Fixtures ohnehin vorhanden, ein zweiter Nachbau hier
+    waere doppelte Testinfrastruktur ohne zusaetzliche Aussagekraft."""
+    from services.alert_gate import GateResult, check_event_identity_gate
+
+    uid = fresh_uid("s4b-ac1")
+    clean_uid(uid)
+    try:
+        ergebnis = check_event_identity_gate(
+            user_id=uid, entity_id="trip-ac1", hazard_class="wet",
+            segment_ids=["1"], severity="HIGH",
+            now=datetime.now(timezone.utc),
+        )
+        assert isinstance(ergebnis, GateResult), (
+            f"Erwartet eine echte GateResult-Instanz, erhalten: {type(ergebnis)!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_ac2_record_event_identity_legt_genau_einen_registereintrag_an():
+    """AC-2: eine erfolgreich zugestellte Meldung legt GENAU EINEN
+    Registereintrag unter dem Praefix ``event_identity:<hazard_class>:`` an,
+    mit Gefahrenklasse, Ortskennungen, Zeitbezug, Dringlichkeit und
+    Zeitpunkt."""
+    from services.alert_gate import record_event_identity
+    from services.alert_state import EVENT_IDENTITY_KEY_PREFIX, AlertStateService
+
+    uid = fresh_uid("s4b-ac2")
+    clean_uid(uid)
+    try:
+        now = datetime.now(timezone.utc)
+        record_event_identity(
+            user_id=uid, entity_id="trip-ac2", hazard_class="wet",
+            segment_ids=["3", "4"], severity="HIGH", point_at=now, now=now,
+        )
+
+        state = AlertStateService(user_id=uid).load("trip-ac2")
+        neue = {k: v for k, v in state.items() if k.startswith(EVENT_IDENTITY_KEY_PREFIX)}
+        assert len(neue) == 1, (
+            f"Erwartet genau EINEN neuen event_identity:-Schluessel, "
+            f"gefunden {len(neue)}: {sorted(state)!r}"
+        )
+        (eintrag,) = neue.values()
+        assert eintrag["hazard_class"] == "wet"
+        assert set(eintrag["segment_ids"]) == {"3", "4"}
+        assert eintrag["severity"] == "HIGH"
+        assert "reported_at" in eintrag
+    finally:
+        clean_uid(uid)
+
+
+def test_ac3_check_event_identity_gate_ist_rein_lesend_kein_registereintrag():
+    """AC-3 (Baustein-Ebene, F001-Symmetrie): ein reiner Freigabe-Check darf
+    NIE selbst einen Registereintrag anlegen — Registrierung ist
+    ausschliesslich Sache von ``record_event_identity()``, aufgerufen NACH
+    erfolgreicher Zustellung (analog ``record_nowcast_sent``). Der
+    End-to-End-Nachweis fuer eine technisch gescheiterte Zustellung liegt
+    im AC-11/AC-17-Umfeld von ``test_issue_1088_official_alert_triggers.py``."""
+    from services.alert_gate import check_event_identity_gate
+    from services.alert_state import AlertStateService
+
+    uid = fresh_uid("s4b-ac3")
+    clean_uid(uid)
+    try:
+        vorher = AlertStateService(user_id=uid).load("trip-ac3")
+        check_event_identity_gate(
+            user_id=uid, entity_id="trip-ac3", hazard_class="wet",
+            segment_ids=["1"], severity="HIGH",
+            point_at=datetime.now(timezone.utc), now=datetime.now(timezone.utc),
+        )
+        nachher = AlertStateService(user_id=uid).load("trip-ac3")
+        assert vorher == nachher == {}, (
+            f"check_event_identity_gate() darf selbst NIE einen "
+            f"Registereintrag anlegen: vorher={vorher!r} nachher={nachher!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_ac13_aenderungsalarm_guard_eintraege_erzeugen_keinen_event_identity_key():
+    """AC-13 (T7-Ergaenzung): ein Aenderungsalarm-Guard-Eintrag
+    (``precip:<segment>``/``thunder_level_max:<segment>``, geschrieben vom
+    Δ-Pfad) erzeugt KEINEN ``event_identity:``-Registereintrag — der neue
+    Baustein ist fuer diese Paarung strukturell nicht zustaendig (T7:
+    Nowcast↔Δ bleibt allein Sache des bestehenden Doppel-Alert-Guards,
+    ``trip_alert.py:1081-1099``). Der Bestandsschutz des Guards selbst bleibt
+    unveraendert in
+    ``tests/tdd/test_issue_818_radar_briefing_integration.py::
+    test_ac4_double_alert_guard_suppresses_radar_when_forecast_recent``
+    (hier NICHT erneut nachgebaut)."""
+    from services.alert_state import EVENT_IDENTITY_KEY_PREFIX, AlertStateService
+
+    uid = fresh_uid("s4b-ac13")
+    clean_uid(uid)
+    try:
+        AlertStateService(user_id=uid).save("trip-ac13", {
+            "precip:1": {
+                "last_reported_value": 5.0,
+                "reported_at": datetime.now(timezone.utc).isoformat(),
+            },
+        })
+        state = AlertStateService(user_id=uid).load("trip-ac13")
+        event_keys = [k for k in state if k.startswith(EVENT_IDENTITY_KEY_PREFIX)]
+        assert event_keys == [], (
+            f"Ein Aenderungsalarm-Guard-Eintrag darf keinen event_identity:-"
+            f"Schluessel erzeugen (andere Paarung, T7): {event_keys!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+# ───────────────────────── Ortsbezug (T3) — AC-5 ─────────────────────────────
+
+
+def test_ac5_disjunkte_segment_mengen_erzeugen_kein_match():
+    """AC-5: gleiche Gefahrenklasse, ueberlappendes Zeitfenster, aber
+    DISJUNKTE Segment-Mengen -> kein Match, die neue Meldung wird
+    zugestellt."""
+    from services.alert_gate import check_event_identity_gate, record_event_identity
+
+    uid = fresh_uid("s4b-ac5a")
+    clean_uid(uid)
+    try:
+        now = datetime.now(timezone.utc)
+        record_event_identity(
+            user_id=uid, entity_id="trip-ac5a", hazard_class="wet",
+            segment_ids=["1", "2"], severity="HIGH", point_at=now, now=now,
+        )
+        ergebnis = check_event_identity_gate(
+            user_id=uid, entity_id="trip-ac5a", hazard_class="wet",
+            segment_ids=["9"], severity="HIGH",
+            window_start=now - timedelta(minutes=10),
+            window_end=now + timedelta(minutes=30),
+            now=now + timedelta(minutes=5),
+        )
+        assert ergebnis.allowed is True, (
+            f"Disjunkte Segment-Mengen duerfen NICHT als Match zaehlen: {ergebnis!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_ac5_leere_segment_kennung_erzeugt_niemals_ein_match():
+    """AC-5 (Bruchstelle): eine leere/fehlende Segment-Kennung auf EINER Seite
+    darf niemals ein Match erzeugen — sonst passte "kein Ort bekannt" auf
+    "jeden Ort"."""
+    from services.alert_gate import check_event_identity_gate, record_event_identity
+
+    uid = fresh_uid("s4b-ac5b")
+    clean_uid(uid)
+    try:
+        now = datetime.now(timezone.utc)
+        record_event_identity(
+            user_id=uid, entity_id="trip-ac5b", hazard_class="wet",
+            segment_ids=[], severity="HIGH", point_at=now, now=now,
+        )
+        ergebnis = check_event_identity_gate(
+            user_id=uid, entity_id="trip-ac5b", hazard_class="wet",
+            segment_ids=["3"], severity="HIGH",
+            window_start=now - timedelta(minutes=10),
+            window_end=now + timedelta(minutes=30),
+            now=now + timedelta(minutes=5),
+        )
+        assert ergebnis.allowed is True, (
+            f"Ein Registereintrag ohne Segment-Kennung darf kein Match "
+            f"erzeugen: {ergebnis!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+# ────────────────────── Zeitfenster (T4) — AC-6 / AC-7 ───────────────────────
+
+
+def test_ac6_kernfall_nowcast_gefolgt_von_amtlicher_warnung_8_2_min_spaeter():
+    """AC-6: Reproduktion des gemessenen Falls ``5f534011`` (2026-08-11,
+    14:22 UTC Nowcast, +8,2 Min amtliche Warnung, s. Spec Purpose).
+
+    GIVEN ein registrierter Nowcast-Eintrag (Klasse 'wet', Segment '3', Onset
+          14:22 UTC)
+    WHEN  8,2 Min spaeter eine amtliche Warnung derselben Klasse/desselben
+          Segments eintrifft, deren Fenster den Onset-Punkt (mit 60-Min-
+          Puffer) ueberlappt UND das abgedeckte Ende NICHT wesentlich
+          ueberschreitet (keine V1-Ausnahme) UND keine hoehere Dringlichkeit
+          traegt (keine V2-Eskalation)
+    THEN  wird sie unterdrueckt."""
+    from services.alert_gate import check_event_identity_gate, record_event_identity
+    from services.alert_log import REASON_EVENT_DUPLICATE
+
+    uid = fresh_uid("s4b-ac6")
+    clean_uid(uid)
+    try:
+        onset = datetime(2026, 8, 11, 14, 22, 0, tzinfo=timezone.utc)
+        record_event_identity(
+            user_id=uid, entity_id="trip-ac6", hazard_class="wet",
+            segment_ids=["3"], severity="HIGH", point_at=onset, now=onset,
+        )
+        amtlich_zeit = onset + timedelta(minutes=8, seconds=12)
+        ergebnis = check_event_identity_gate(
+            user_id=uid, entity_id="trip-ac6", hazard_class="wet",
+            segment_ids=["3"], severity="HIGH",
+            window_start=onset - timedelta(minutes=10),
+            window_end=onset + timedelta(minutes=45),
+            now=amtlich_zeit,
+        )
+        assert ergebnis.allowed is False
+        assert ergebnis.reason == REASON_EVENT_DUPLICATE, (
+            f"Erwartet {REASON_EVENT_DUPLICATE!r}, erhalten {ergebnis.reason!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_ac7_neue_meldung_ohne_zeitbezug_erzeugt_kein_match():
+    """AC-7 (fail-soft, erste Seite): fehlt der neuen Meldung jeder
+    vergleichbare Zeitbezug (weder ``point_at`` noch ``window_start``/
+    ``window_end``), entsteht kein Match — die Meldung wird zugestellt."""
+    from services.alert_gate import check_event_identity_gate, record_event_identity
+
+    uid = fresh_uid("s4b-ac7a")
+    clean_uid(uid)
+    try:
+        onset = datetime.now(timezone.utc)
+        record_event_identity(
+            user_id=uid, entity_id="trip-ac7a", hazard_class="wet",
+            segment_ids=["1"], severity="HIGH", point_at=onset, now=onset,
+        )
+        ergebnis = check_event_identity_gate(
+            user_id=uid, entity_id="trip-ac7a", hazard_class="wet",
+            segment_ids=["1"], severity="HIGH", now=onset + timedelta(minutes=5),
+        )
+        assert ergebnis.allowed is True, (
+            f"Ohne vergleichbaren Zeitbezug darf keine Unterdrueckung "
+            f"entstehen: {ergebnis!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_ac7_unparsbares_zeitfeld_im_registereintrag_erzeugt_kein_match():
+    """AC-7 (fail-soft, zweite Seite): ein Registereintrag mit unparsbarem
+    ``point_at`` darf nicht zum Absturz fuehren UND erzeugt fail-soft kein
+    Match — die neue Meldung wird zugestellt."""
+    from services.alert_gate import check_event_identity_gate
+    from services.alert_state import AlertStateService
+
+    uid = fresh_uid("s4b-ac7b")
+    clean_uid(uid)
+    try:
+        now = datetime.now(timezone.utc)
+        AlertStateService(user_id=uid).save("trip-ac7b", {
+            "event_identity:wet:1:kaputt": {
+                "hazard_class": "wet", "segment_ids": ["1"], "severity": "HIGH",
+                "point_at": "nicht-geparst-2026-13-99", "window_start": None,
+                "window_end": None, "reported_at": now.isoformat(),
+            },
+        })
+        ergebnis = check_event_identity_gate(
+            user_id=uid, entity_id="trip-ac7b", hazard_class="wet",
+            segment_ids=["1"], severity="HIGH", point_at=now, now=now,
+        )
+        assert ergebnis.allowed is True, (
+            f"Ein unparsbares Zeitfeld im Register darf kein Match erzeugen "
+            f"(fail-soft): {ergebnis!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+# ──────────── V1 — zeitliche Prioritaet + Abdeckungs-Vorbehalt — AC-8/AC-9 ───
+
+
+def test_ac8_zweite_meldung_vollstaendig_innerhalb_des_abgedeckten_fensters():
+    """AC-8: keine Eskalation, keine wesentliche Erweiterung -> die zweite
+    Meldung wird unterdrueckt (Intervall-gegen-Intervall-Fall, isoliert
+    getestet, s. Spec T4)."""
+    from services.alert_gate import check_event_identity_gate, record_event_identity
+
+    uid = fresh_uid("s4b-ac8")
+    clean_uid(uid)
+    try:
+        now = datetime.now(timezone.utc)
+        record_event_identity(
+            user_id=uid, entity_id="trip-ac8", hazard_class="wet",
+            segment_ids=["2"], severity="MODERATE",
+            window_start=now, window_end=now + timedelta(hours=2), now=now,
+        )
+        ergebnis = check_event_identity_gate(
+            user_id=uid, entity_id="trip-ac8", hazard_class="wet",
+            segment_ids=["2"], severity="MODERATE",
+            window_start=now + timedelta(minutes=30),
+            window_end=now + timedelta(hours=1),
+            now=now + timedelta(minutes=10),
+        )
+        assert ergebnis.allowed is False, (
+            f"Ein vollstaendig abgedecktes Fenster ohne Eskalation muss "
+            f"unterdrueckt werden: {ergebnis!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_ac9_valid_to_reicht_wesentlich_ueber_das_abgedeckte_ende_hinaus():
+    """AC-9 (V1-Ausnahme) + Mutations-Gegenprobe (PFLICHT laut Spec).
+
+    GIVEN ein registrierter Nowcast-Eintrag (abgedeckt bis Onset+60 Min)
+    WHEN  eine amtliche Warnung derselben Klasse/desselben Orts eintrifft,
+          deren ``valid_to`` MEHR ALS 60 Min ueber das abgedeckte Ende
+          hinausreicht — OHNE hoehere Dringlichkeit
+    THEN  wird sie zugestellt (neue Information).
+
+    Mutations-Gegenprobe: wird ``NOWCAST_HORIZON_MIN`` durch eine deutlich
+    groessere Zahl (z. B. 600) ersetzt, deckt das verfaelschte Fenster
+    ``covered_until + 600min`` das hier verwendete ``valid_to`` (nur +90 Min
+    ueber ``covered_until``) weiterhin ab — die V1-Ausnahme greift dann
+    NICHT mehr, ``allowed`` wird ``False`` statt ``True``, und dieser Test
+    wird rot."""
+    from services.alert_gate import check_event_identity_gate, record_event_identity
+
+    uid = fresh_uid("s4b-ac9")
+    clean_uid(uid)
+    try:
+        onset = datetime.now(timezone.utc)
+        record_event_identity(
+            user_id=uid, entity_id="trip-ac9", hazard_class="wet",
+            segment_ids=["4"], severity="MODERATE", point_at=onset, now=onset,
+        )
+        # covered_until = onset + NOWCAST_HORIZON_MIN (60 Min)
+        ergebnis = check_event_identity_gate(
+            user_id=uid, entity_id="trip-ac9", hazard_class="wet",
+            segment_ids=["4"], severity="MODERATE",  # keine hoehere Dringlichkeit
+            window_start=onset,
+            window_end=onset + timedelta(minutes=150),  # 90 Min ueber covered_until
+            now=onset + timedelta(minutes=5),
+        )
+        assert ergebnis.allowed is True, (
+            f"Ein Fenster, das wesentlich ueber das abgedeckte Ende "
+            f"hinausreicht, muss durchkommen (V1-Ausnahme): {ergebnis!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+# ─────────────── V2 — Verschaerfung durchbricht immer — AC-10 ───────────────
+
+
+def test_ac10_hoehere_dringlichkeit_durchbricht_auch_ohne_zeitliche_erweiterung():
+    """AC-10 (V2-Eskalation) + Mutations-Gegenprobe (PFLICHT laut Spec).
+
+    GIVEN eine registrierte Meldung mit Dringlichkeit MODERATE
+    WHEN  eine zweite Meldung derselben Klasse/desselben Orts mit HOEHERER
+          Dringlichkeit (HIGH) eintrifft, deren Zeitfenster VOLLSTAENDIG
+          innerhalb des abgedeckten Fensters liegt (die V1-Ausnahme greift
+          hier ausdruecklich NICHT — nur die Eskalation)
+    THEN  wird sie zugestellt.
+
+    Mutations-Gegenprobe: wird der Eskalations-Zweig entfernt oder HINTER
+    die V1-Ausnahme verschoben, prueft die Funktion zuerst "wesentlich mehr
+    abgedeckt?" — das Zeitfenster liegt hier bewusst VOLLSTAENDIG innerhalb
+    des abgedeckten Fensters, die V1-Ausnahme greift also nicht, und ohne den
+    strukturell ERSTEN Eskalations-Zweig bliebe die Warnung faelschlich
+    unterdrueckt (``allowed=False``). Dieser Test wird dann rot — das ist die
+    Absicherung gegen die gefaehrlichste Fehlerrichtung "Alarm bleibt aus"
+    bei einer echten Verschaerfung."""
+    from services.alert_gate import check_event_identity_gate, record_event_identity
+
+    uid = fresh_uid("s4b-ac10")
+    clean_uid(uid)
+    try:
+        now = datetime.now(timezone.utc)
+        record_event_identity(
+            user_id=uid, entity_id="trip-ac10", hazard_class="wet",
+            segment_ids=["5"], severity="MODERATE",
+            window_start=now, window_end=now + timedelta(hours=3), now=now,
+        )
+        ergebnis = check_event_identity_gate(
+            user_id=uid, entity_id="trip-ac10", hazard_class="wet",
+            segment_ids=["5"], severity="HIGH",  # Eskalation
+            window_start=now + timedelta(minutes=30),
+            window_end=now + timedelta(hours=1),  # vollstaendig innerhalb
+            now=now + timedelta(minutes=10),
+        )
+        assert ergebnis.allowed is True, (
+            f"Eine echte Verschaerfung muss IMMER durchkommen, auch ohne "
+            f"zeitliche Erweiterung: {ergebnis!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+# ───────────────────────── Mandantentrennung — AC-18 ────────────────────────
+
+
+def test_ac18_registereintrag_von_nutzer_a_wirkt_nicht_auf_nutzer_b():
+    """AC-18: zwei verschiedene Nutzer, gleiche Trip-Kennung, unabhaengig
+    gefuehrte Register — Nutzer A registriert einen Nowcast, Nutzer B erhaelt
+    seine amtliche Warnung trotzdem (kein Rueckfall auf ``"default"``)."""
+    from services.alert_gate import check_event_identity_gate, record_event_identity
+
+    a, b = fresh_uid("s4b-ac18-a"), fresh_uid("s4b-ac18-b")
+    clean_uid(a)
+    clean_uid(b)
+    try:
+        onset = datetime.now(timezone.utc)
+        record_event_identity(
+            user_id=a, entity_id="trip-geteilt", hazard_class="wet",
+            segment_ids=["9"], severity="HIGH", point_at=onset, now=onset,
+        )
+        ergebnis_b = check_event_identity_gate(
+            user_id=b, entity_id="trip-geteilt", hazard_class="wet",
+            segment_ids=["9"], severity="HIGH",
+            window_start=onset - timedelta(minutes=10),
+            window_end=onset + timedelta(minutes=30),
+            now=onset + timedelta(minutes=5),
+        )
+        assert ergebnis_b.allowed is True, (
+            f"Nutzer B (user_id={b!r}) darf durch den Registereintrag von "
+            f"Nutzer A (user_id={a!r}) nicht beeinflusst werden: {ergebnis_b!r}"
+        )
+    finally:
+        clean_uid(a)
+        clean_uid(b)
+
+
+# ─────────────────── Bestandsdaten / fail-soft — AC-19 ──────────────────────
+
+
+def test_ac19_registereintrag_mit_fehlendem_severity_feld_wird_wie_kein_match_behandelt():
+    """AC-19: ein Registereintrag ohne ``severity`` (kaputtes/altes/kuenftiges
+    Schema) darf nicht zum Absturz fuehren und zaehlt fail-soft NICHT als
+    Match — die neue Meldung wird zugestellt."""
+    from services.alert_gate import check_event_identity_gate
+    from services.alert_state import AlertStateService
+
+    uid = fresh_uid("s4b-ac19")
+    clean_uid(uid)
+    try:
+        onset = datetime.now(timezone.utc)
+        AlertStateService(user_id=uid).save("trip-ac19", {
+            f"event_identity:wet:6:{onset.isoformat()}": {
+                "hazard_class": "wet", "segment_ids": ["6"],
+                # 'severity' fehlt bewusst — kaputtes/altes Format
+                "point_at": onset.isoformat(), "window_start": None,
+                "window_end": None, "reported_at": onset.isoformat(),
+            },
+        })
+        ergebnis = check_event_identity_gate(
+            user_id=uid, entity_id="trip-ac19", hazard_class="wet",
+            segment_ids=["6"], severity="HIGH",
+            point_at=onset + timedelta(minutes=5), now=onset + timedelta(minutes=5),
+        )
+        assert ergebnis.allowed is True, (
+            f"Ein kaputter Registereintrag darf nicht als Match zaehlen "
+            f"(fail-soft, kein Absturz): {ergebnis!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+# ─────────────────────── Regression zu S4a — AC-20 ───────────────────────────
+
+
+def test_ac20_check_official_alert_gate_signatur_bleibt_ohne_cooldown_parameter():
+    """AC-20 (Regression zu S4a, HEUTE SCHON GRUEN — kein RED-Nachweis): die
+    Funktionssignatur von ``check_official_alert_gate`` bleibt durch S4b-1
+    UNVERAENDERT — kein Cooldown-/Sperrzeit-Parameter wandert nachtraeglich
+    hinein. Die neue Ereignis-Identitaet-Pruefung ist ein EIGENER,
+    nachgelagerter Aufruf, keine Erweiterung des Gates selbst."""
+    import inspect
+
+    from services.alert_gate import check_official_alert_gate
+
+    params = set(inspect.signature(check_official_alert_gate).parameters)
+    verbotene = {"cooldown_minutes", "cooldown", "throttle_scope", "throttle_key"}
+    getroffen = params & verbotene
+    assert not getroffen, (
+        f"check_official_alert_gate hat einen Cooldown-aehnlichen Parameter "
+        f"bekommen: {getroffen!r} (voller Parametersatz: {sorted(params)!r})"
+    )
+
+
+# ───────────────────────── Dokumentation — AC-21 ─────────────────────────────
+
+
+def test_ac21_adr_0021_traegt_einen_datierten_s4b_nachtrag():
+    """AC-21. ``# doc-compliance-test`` (Ausnahme von der
+    Dateiinhalt-Regel, CLAUDE.md). GIVEN den bestehenden ADR-0021-Nachtrag
+    aus S4a (#1467), WHEN diese Scheibe abgeschlossen ist, THEN traegt
+    ADR-0021 einen weiteren, datierten Nachtrag mit Bezug auf '#1467' UND
+    'S4b', der die neue quellenuebergreifende Ereignis-Identitaet-Pruefung
+    festhaelt, ohne die S4a-Aussage zur Unterdrueckungs-Protokollierung zu
+    widerrufen.
+
+    RED heute: der Nachtrag fehlt noch."""
+    from pathlib import Path
+
+    adr_path = (
+        Path(__file__).resolve().parents[2]
+        / "docs" / "adr" / "0021-shared-deviation-alert-engine.md"
+    )
+    text = adr_path.read_text(encoding="utf-8")
+
+    assert "S4b" in text, (
+        f"ADR-0021 muss einen Nachtrag mit Bezug auf 'S4b' tragen: {adr_path}"
+    )
+    assert "#1467" in text, (
+        f"ADR-0021 muss den Nachtrag auf '#1467' beziehen: {adr_path}"
+    )
+    # Der neue Nachtrag muss NACH dem S4a-Nachtrag stehen (Reihenfolge =
+    # Chronologie der Nachtraege in diesem ADR).
+    s4a_pos = text.find("Issue #1467 S4a")
+    s4b_pos = text.find("Issue #1467 S4b")
+    assert s4a_pos != -1, "Der bestehende S4a-Nachtrag darf nicht verschwinden"
+    assert s4b_pos != -1 and s4b_pos > s4a_pos, (
+        f"Der neue S4b-Nachtrag muss NACH dem S4a-Nachtrag stehen "
+        f"(s4a_pos={s4a_pos}, s4b_pos={s4b_pos})"
+    )

--- a/tests/tdd/test_alert_gate.py
+++ b/tests/tdd/test_alert_gate.py
@@ -709,6 +709,48 @@ def test_ac5_leere_segment_kennung_erzeugt_niemals_ein_match():
         clean_uid(uid)
 
 
+def test_ac5_leere_segment_kennung_der_neuen_meldung_erzeugt_niemals_ein_match():
+    """AC-5 (Bruchstelle, zweite Richtung, Fix-Loop F002): ein Registereintrag
+    MIT echter Segment-Kennung gegen eine NEUE Meldung OHNE Segment-Kennung
+    (``segment_ids=[]``) darf ebenfalls NIE ein Match erzeugen — die
+    Bruchstelle gilt fuer BEIDE Seiten, nicht nur den Registereintrag.
+
+    Der vorhandene Test oben deckt nur die Richtung „Registereintrag ohne
+    Kennung, neue Meldung MIT Kennung" ab. Der Adversary hat den fail-soft-
+    Wächter am ANDEREN Ende (`if not new_segments: return None` in
+    `_find_matching_entry`, `alert_gate.py`) per Wildcard-Match ersetzt, und
+    keiner der 87 Tests wurde davon rot — obwohl der Pfad produktiv
+    erreichbar ist: `trip_alert.py` liefert bei fehlendem `segment_id` eine
+    leere Liste an `check_event_identity_gate()` weiter (Nowcast-Pfad).
+
+    Mutations-Gegenprobe (Pflicht): den fruehen Ausstieg bei leerer neuer
+    Segment-Menge durch einen Wildcard-Match (jede Segment-Menge, auch eine
+    leere, matcht) ersetzen MUSS diesen Test rot machen."""
+    from services.alert_gate import check_event_identity_gate, record_event_identity
+
+    uid = fresh_uid("s4b-f002")
+    clean_uid(uid)
+    try:
+        now = datetime.now(timezone.utc)
+        record_event_identity(
+            user_id=uid, entity_id="trip-f002", hazard_class="wet",
+            segment_ids=["3"], severity="HIGH", point_at=now, now=now,
+        )
+        ergebnis = check_event_identity_gate(
+            user_id=uid, entity_id="trip-f002", hazard_class="wet",
+            segment_ids=[], severity="HIGH",
+            window_start=now - timedelta(minutes=10),
+            window_end=now + timedelta(minutes=30),
+            now=now + timedelta(minutes=5),
+        )
+        assert ergebnis.allowed is True, (
+            f"Eine neue Meldung OHNE Segment-Kennung darf gegen einen "
+            f"Registereintrag MIT Kennung kein Match erzeugen: {ergebnis!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
 # ────────────────────── Zeitfenster (T4) — AC-6 / AC-7 ───────────────────────
 
 

--- a/tests/tdd/test_alert_state_briefing_reset.py
+++ b/tests/tdd/test_alert_state_briefing_reset.py
@@ -1081,3 +1081,87 @@ def test_record_official_alerts_reported_mit_leerer_liste_ist_ein_no_op():
         )
     finally:
         _clean_user(user_id)
+
+
+# ══════════ Issue #1467 Scheibe S4b-1 — AC-14 (Register-Reset, T5) ═══════════
+# SPEC: docs/specs/modules/rework_1467_s4b_entdopplung.md
+#
+# Zwei getrennte Testfunktionen (laut Spawn-Auftrag bewusst getrennt):
+#  * Regression (heute schon gruen, KEIN RED-Nachweis) -- Bestandsverhalten
+#    von reset() bleibt unveraendert: nur der 'official_alert:'-Praefix
+#    ueberlebt, alles andere faellt weg -- unabhaengig davon, WAS sonst noch
+#    im Melde-Gedaechtnis steht.
+#  * RED -- der neue Praefix 'event_identity:' existiert als Konstante noch
+#    nicht (ImportError). Sobald er existiert, braucht reset() laut Spec
+#    KEINE Logik-Aenderung (der bestehende Filter behaelt schon heute NUR
+#    OFFICIAL_ALERT_KEY_PREFIX-Eintraege) -- dieser Test beweist, dass genau
+#    das auch fuer den neuen Praefix zutrifft.
+
+
+def test_s4b_ac14_regression_reset_beruehrt_bestehende_official_alert_eintraege_nicht():
+    """#1467 S4b-1 AC-14 (Regressionstest, KEIN RED-Nachweis -- heute schon
+    gruen). Bestandsverhalten aus S4a/#1460 bleibt unveraendert: reset()
+    schont den 'official_alert:'-Praefix, unabhaengig davon, was sonst noch
+    im Melde-Gedaechtnis steht. Bewusst OHNE Bezug auf den neuen
+    'event_identity:'-Praefix -- der wird im zweiten Testfall unten (RED)
+    separat abgesichert."""
+    from services.alert_state import OFFICIAL_ALERT_KEY_PREFIX, AlertStateService
+
+    user_id = _fresh_user("s4b-ac14-reg")
+    _clean_user(user_id)
+    try:
+        trip_id = "trip-1467-s4b-ac14-reg"
+        official_key = f"{OFFICIAL_ALERT_KEY_PREFIX}region:Gailtal:thunderstorm:x:y"
+        official_value = {"last_reported_value": 3.0, "reported_at": "2026-08-11T14:22:03+00:00"}
+        other_key = "irgendein_anderer_schluessel:1"
+
+        svc = AlertStateService(user_id=user_id)
+        svc.save(trip_id, {official_key: official_value, other_key: {"x": 1}})
+
+        svc.reset(trip_id)
+
+        after = AlertStateService(user_id=user_id).load(trip_id)
+        assert after == {official_key: official_value}, (
+            f"Bestandsverhalten: nur der official_alert:-Eintrag darf "
+            f"ueberleben: {after!r}"
+        )
+    finally:
+        _clean_user(user_id)
+
+
+def test_s4b_ac14_neuer_event_identity_praefix_wird_vom_reset_erfasst():
+    """#1467 S4b-1 AC-14 (RED-Nachweis). Der NEUE Praefix 'event_identity:'
+    muss beim Briefing-Reset MITGELOESCHT werden -- ein alter
+    Nowcast-Registereintrag darf eine spaetere amtliche Warnung nach einem
+    neuen Briefing nicht mehr unterdruecken (T5).
+
+    RED-Ursache (heute): EVENT_IDENTITY_KEY_PREFIX existiert noch nicht in
+    services.alert_state -> ImportError."""
+    from services.alert_state import (
+        EVENT_IDENTITY_KEY_PREFIX, OFFICIAL_ALERT_KEY_PREFIX, AlertStateService,
+    )
+
+    user_id = _fresh_user("s4b-ac14-neu")
+    _clean_user(user_id)
+    try:
+        trip_id = "trip-1467-s4b-ac14-neu"
+        event_key = f"{EVENT_IDENTITY_KEY_PREFIX}wet:3:2026-08-11T14:22:00+00:00"
+        official_key = f"{OFFICIAL_ALERT_KEY_PREFIX}region:Gailtal:thunderstorm:x:y"
+        event_value = {"hazard_class": "wet", "reported_at": "2026-08-11T14:22:03+00:00"}
+        official_value = {"last_reported_value": 3.0, "reported_at": "2026-08-11T14:22:03+00:00"}
+
+        svc = AlertStateService(user_id=user_id)
+        svc.save(trip_id, {event_key: event_value, official_key: official_value})
+
+        svc.reset(trip_id)
+
+        after = AlertStateService(user_id=user_id).load(trip_id)
+        assert event_key not in after, (
+            f"Der event_identity:-Eintrag muss den Briefing-Reset NICHT "
+            f"ueberleben: {sorted(after)!r}"
+        )
+        assert after.get(official_key) == official_value, (
+            f"Der official_alert:-Eintrag muss unveraendert erhalten bleiben: {after!r}"
+        )
+    finally:
+        _clean_user(user_id)

--- a/tests/tdd/test_issue_1088_official_alert_triggers.py
+++ b/tests/tdd/test_issue_1088_official_alert_triggers.py
@@ -21,6 +21,7 @@ RED-Ursache (heute, vor der Implementierung):
 """
 from __future__ import annotations
 
+import json
 import shutil
 import uuid
 from datetime import date, datetime, timedelta, timezone
@@ -671,3 +672,407 @@ class TestAC7SmsWithoutParity:
             assert sms_after == sms_before, "SMS-Ausgabe darf sich durch official_notices NICHT verändern"
         finally:
             _clean_user(user_id)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Issue #1467 Scheibe S4b-1 — Verdrahtung der Ereignis-Identitaet in BEIDE
+# Trip-Richtungen (Nowcast + amtlich).
+# SPEC: docs/specs/modules/rework_1467_s4b_entdopplung.md
+#
+# ``services.alert_gate.check_event_identity_gate``/``record_event_identity``
+# existieren heute nicht -- RED-Grund ist durchgaengig ein ``ImportError``
+# beim Aufbau der Spione. ``trip_alert.py`` importiert seine Gate-Bausteine
+# per ``from services.alert_gate import (...)`` (benannter Import) -- ein
+# Patch auf ``services.alert_gate.check_event_identity_gate`` waere an den
+# Aufrufstellen WIRKUNGSLOS. Gepatcht wird deshalb der Name im
+# Modul-Namespace von ``services.trip_alert`` selbst (Erwartung an die
+# Implementierung: sie importiert die neue Funktion genau so, wie es die
+# bestehenden Bausteine bereits tun).
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _order_spy(monkeypatch, module, name: str, order: list, label: str):
+    """Haengt einen Aufruf-Reihenfolge-Spion an ``module.<name>`` -- delegiert
+    unveraendert an die Originalfunktion, zeichnet aber ZUERST das Label auf.
+    Kein Mock: die reale Implementierung laeuft unveraendert mit."""
+    original = getattr(module, name)
+
+    def _wrapped(*args, **kwargs):
+        order.append(label)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(module, name, _wrapped)
+
+
+class TestS4bEventIdentityWiring:
+    """AC-1 (Verdrahtungsteil), AC-11, AC-12, AC-17."""
+
+    def test_ac1_beide_trip_pfade_rufen_denselben_baustein_auf(self, monkeypatch):
+        """AC-1 (Verdrahtungsteil): sowohl der Nowcast-Trip-Pfad
+        (``check_radar_alerts``) als auch der amtliche Trip-Pfad
+        (``_send_official_alert_only``) rufen fuer eine Meldung der Klasse
+        'wet' DENSELBEN ``check_event_identity_gate``-Baustein auf --
+        mindestens 1x je Pfad und Lauf mit zutreffender Gefahrenklasse.
+
+        RED heute: ImportError beim Aufbau des Spions."""
+        import services.trip_alert as trip_alert_mod
+        from services.alert_gate import GateResult
+        from services.alert_gate import check_event_identity_gate as _real_identity
+        from services.official_alerts import OfficialAlert, register_official_alert_source
+        from services.trip_alert import TripAlertService
+        from tests.helpers.nowcast_gate_fixtures import (
+            CountingFrameSource, make_trip, settings_email_only, trip_alert_service,
+        )
+
+        results: list = []
+
+        def _spy(*args, **kwargs):
+            ergebnis = _real_identity(*args, **kwargs)
+            results.append(ergebnis)
+            return ergebnis
+
+        monkeypatch.setattr(trip_alert_mod, "check_event_identity_gate", _spy)
+
+        uid = _fresh_user("s4b-ac1")
+        _clean_user(uid)
+        oa_base, backup = _registered_sources_backup()
+        oa_base._REGISTERED_SOURCES.clear()
+        try:
+            # ── Nowcast-Pfad ──
+            trip_nowcast = make_trip("trip-s4b-ac1-nowcast")
+            raus = trip_alert_service(
+                uid, settings_email_only(), CountingFrameSource(onset_minutes=8),
+                lambda s, b: None,
+            ).check_radar_alerts()
+            assert raus == 1, f"Voraussetzung: der Nowcast muss zustellen ({raus!r})"
+            assert len(results) >= 1, (
+                "check_event_identity_gate wurde im Nowcast-Pfad nicht gerufen"
+            )
+            assert isinstance(results[-1], GateResult), (
+                f"Rueckgabewert muss eine echte GateResult-Instanz sein: "
+                f"{type(results[-1])!r}"
+            )
+            results.clear()
+
+            # ── amtlicher Pfad ──
+            trip_amtlich = _minimal_trip("trip-s4b-ac1-amtlich")
+            _save_cached(uid, trip_amtlich.id, [_data(1, precip_sum_mm=2.0)])
+            alert = OfficialAlert(
+                source="tdd-s4b-ac1", hazard="thunderstorm", level=3,
+                label="AC-1-Warnung",
+            )
+            register_official_alert_source(_CountingOfficialAlertSource(LAT, LON, alert))
+            svc = TripAlertService(user_id=uid, mail_sink=lambda s, b: None)
+            notices = svc.check_official_alert_triggers(trip_amtlich)
+            assert len(notices) == 1, "Voraussetzung: die amtliche Warnung muss neu sein"
+
+            sent = svc._send_official_alert_only(trip_amtlich, notices)
+            assert sent is True, f"Voraussetzung: der amtliche Versand muss gelingen ({sent!r})"
+            assert len(results) >= 1, (
+                "check_event_identity_gate wurde im amtlichen Pfad nicht gerufen"
+            )
+            assert isinstance(results[-1], GateResult), (
+                f"Rueckgabewert muss eine echte GateResult-Instanz sein: "
+                f"{type(results[-1])!r}"
+            )
+        finally:
+            oa_base._REGISTERED_SOURCES.clear()
+            oa_base._REGISTERED_SOURCES.extend(backup)
+            _clean_user(uid)
+
+    def test_ac12_nowcast_pfad_ruft_das_gate_als_letzte_stufe_vor_dem_versand(
+        self, monkeypatch,
+    ):
+        """AC-12 (Nowcast-Aequivalent): ``check_event_identity_gate`` laeuft
+        NACH ``check_nowcast_gate`` UND VOR dem tatsaechlichen Versand
+        (``mail_sink``) -- beobachtet zur LAUFZEIT ueber eine echte
+        Aufruf-Sequenz, ein reiner Quellcode-Grep genuegt laut Spec nicht.
+
+        RED heute: ImportError beim Patchen von ``check_event_identity_gate``."""
+        import services.trip_alert as trip_alert_mod
+        from services.alert_gate import check_event_identity_gate as _real_identity
+        from tests.helpers.nowcast_gate_fixtures import (
+            CountingFrameSource, make_trip, settings_email_only, trip_alert_service,
+        )
+
+        order: list[str] = []
+        _order_spy(monkeypatch, trip_alert_mod, "check_nowcast_gate", order, "check_nowcast_gate")
+
+        def _spy_identity(*args, **kwargs):
+            order.append("check_event_identity_gate")
+            return _real_identity(*args, **kwargs)
+
+        monkeypatch.setattr(trip_alert_mod, "check_event_identity_gate", _spy_identity)
+
+        uid = _fresh_user("s4b-ac12-nowcast")
+        _clean_user(uid)
+        try:
+            trip = make_trip("trip-s4b-ac12-nowcast")
+
+            def _mail_sink(subject, body):
+                order.append("mail_sink")
+
+            raus = trip_alert_service(
+                uid, settings_email_only(), CountingFrameSource(onset_minutes=8), _mail_sink,
+            ).check_radar_alerts()
+
+            assert raus == 1, f"Voraussetzung: der Nowcast muss zustellen ({raus!r})"
+            assert order == ["check_nowcast_gate", "check_event_identity_gate", "mail_sink"], (
+                f"Falsche Aufruf-Reihenfolge: {order!r}"
+            )
+        finally:
+            _clean_user(uid)
+
+    def test_ac12_amtlicher_pfad_ruft_das_gate_als_letzte_stufe_vor_dem_versand(
+        self, monkeypatch,
+    ):
+        """AC-12: ``check_event_identity_gate`` laeuft NACH
+        ``check_official_alert_gate`` UND NACH ``_is_briefing_imminent``, VOR
+        dem tatsaechlichen Versand -- gleiche Beobachtungsmethode wie oben.
+
+        ``_is_briefing_imminent`` ist eine gebundene Methode -- der Spion
+        sitzt auf einer echten Unterklasse (kein Mock, Vorbild
+        ``_RecordingScheduler`` in test_alert_state_briefing_reset.py), die
+        an ``super()`` delegiert.
+
+        RED heute: ImportError beim Patchen von ``check_event_identity_gate``."""
+        import services.trip_alert as trip_alert_mod
+        from services.alert_gate import check_event_identity_gate as _real_identity
+        from services.official_alerts import OfficialAlert, register_official_alert_source
+        from services.trip_alert import TripAlertService
+
+        order: list[str] = []
+        _order_spy(
+            monkeypatch, trip_alert_mod, "check_official_alert_gate", order,
+            "check_official_alert_gate",
+        )
+
+        def _spy_identity(*args, **kwargs):
+            order.append("check_event_identity_gate")
+            return _real_identity(*args, **kwargs)
+
+        monkeypatch.setattr(trip_alert_mod, "check_event_identity_gate", _spy_identity)
+
+        class _RecordingTripAlertService(TripAlertService):
+            def _is_briefing_imminent(self, trip, now_utc):
+                order.append("_is_briefing_imminent")
+                return super()._is_briefing_imminent(trip, now_utc)
+
+        uid = _fresh_user("s4b-ac12-amtlich")
+        _clean_user(uid)
+        oa_base, backup = _registered_sources_backup()
+        oa_base._REGISTERED_SOURCES.clear()
+        try:
+            trip = _minimal_trip("trip-s4b-ac12-amtlich")
+            _save_cached(uid, trip.id, [_data(1, precip_sum_mm=2.0)])
+            alert = OfficialAlert(
+                source="tdd-s4b-ac12", hazard="thunderstorm", level=3,
+                label="AC-12-Warnung",
+            )
+            register_official_alert_source(_CountingOfficialAlertSource(LAT, LON, alert))
+
+            def _mail_sink(subject, body):
+                order.append("mail_sink")
+
+            svc = _RecordingTripAlertService(user_id=uid, mail_sink=_mail_sink)
+            notices = svc.check_official_alert_triggers(trip)
+            assert len(notices) == 1, "Voraussetzung: die amtliche Warnung muss neu sein"
+
+            sent = svc._send_official_alert_only(trip, notices)
+
+            assert sent is True, f"Voraussetzung: der amtliche Versand muss gelingen ({sent!r})"
+            assert order == [
+                "check_official_alert_gate", "_is_briefing_imminent",
+                "check_event_identity_gate", "mail_sink",
+            ], f"Falsche Aufruf-Reihenfolge: {order!r}"
+        finally:
+            oa_base._REGISTERED_SOURCES.clear()
+            oa_base._REGISTERED_SOURCES.extend(backup)
+            _clean_user(uid)
+
+    def test_ac11_unterdrueckte_amtliche_warnung_ruft_split_by_threshold_fuer_keinen_kanal_auf(
+        self, monkeypatch,
+    ):
+        """AC-11 (V3, kanaluebergreifend): wird die amtliche Warnung durch
+        ``check_event_identity_gate`` unterdrueckt, wird
+        ``alert_channel_threshold.split_by_threshold()`` fuer KEINEN Kanal
+        aufgerufen. Gegenprobe im selben Test: eine andere Gefahrenart (keine
+        Klasse) desselben Trips geht durch das Gate hindurch --
+        ``split_by_threshold()`` WIRD aufgerufen.
+
+        ``trip_alert.py`` importiert ``alert_channel_threshold`` als MODUL
+        (``from services import alert_channel_threshold``, kein benannter
+        Funktions-Import) -- ein Patch auf das echte Modulattribut wirkt hier
+        also direkt an der Aufrufstelle.
+
+        RED heute: ImportError bei ``record_event_identity``."""
+        import services.alert_channel_threshold as threshold_mod
+        from services.alert_gate import record_event_identity
+        from services.official_alerts import OfficialAlert, register_official_alert_source
+        from services.trip_alert import TripAlertService
+
+        calls: list = []
+        original = threshold_mod.split_by_threshold
+
+        def _spy(*args, **kwargs):
+            calls.append(args)
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(threshold_mod, "split_by_threshold", _spy)
+
+        uid = _fresh_user("s4b-ac11")
+        _clean_user(uid)
+        oa_base, backup = _registered_sources_backup()
+        oa_base._REGISTERED_SOURCES.clear()
+        try:
+            now = datetime.now(timezone.utc)
+            record_event_identity(
+                user_id=uid, entity_id="trip-s4b-ac11", hazard_class="wet",
+                segment_ids=["1"], severity="HIGH", point_at=now, now=now,
+            )
+
+            trip = _minimal_trip("trip-s4b-ac11")
+            _save_cached(uid, trip.id, [_data(1, precip_sum_mm=2.0)])
+            alert = OfficialAlert(
+                source="tdd-s4b-ac11", hazard="thunderstorm", level=3,
+                label="AC-11-Warnung", valid_from=now - timedelta(minutes=5),
+                valid_to=now + timedelta(minutes=30),
+            )
+            register_official_alert_source(_CountingOfficialAlertSource(LAT, LON, alert))
+
+            svc = TripAlertService(user_id=uid, mail_sink=lambda s, b: None)
+            notices = svc.check_official_alert_triggers(trip)
+            assert len(notices) == 1, "Voraussetzung: die Warnung muss als NEU erkannt werden"
+
+            sent = svc._send_official_alert_only(trip, notices)
+
+            assert sent is False, (
+                f"Voraussetzung: die Ereignis-Identitaet muss die Warnung "
+                f"unterdruecken ({sent!r})"
+            )
+            assert calls == [], (
+                f"split_by_threshold() darf bei einer unterdrueckten Warnung "
+                f"fuer KEINEN Kanal aufgerufen werden: {calls!r}"
+            )
+
+            # Gegenprobe: eine andere Gefahrenart (keine Klasse) desselben
+            # Trips geht durch -- split_by_threshold() WIRD gerufen.
+            calls.clear()
+            alert2 = OfficialAlert(
+                source="tdd-s4b-ac11b", hazard="extreme_heat", level=3,
+                label="AC-11-Gegenprobe",
+            )
+            register_official_alert_source(_CountingOfficialAlertSource(LAT, LON, alert2))
+            notices2 = svc.check_official_alert_triggers(trip)
+            hazards2 = {a.hazard for a, _seg in notices2}
+            assert "extreme_heat" in hazards2, (
+                f"Voraussetzung: die Gegenprobe-Warnung muss neu sein: {notices2!r}"
+            )
+
+            sent2 = svc._send_official_alert_only(trip, notices2)
+            assert sent2 is True, f"Gegenprobe: der Versand muss gelingen ({sent2!r})"
+            assert len(calls) >= 1, (
+                "Gegenprobe: split_by_threshold() muss bei einer freigegebenen "
+                "Warnung aufgerufen werden, wurde aber 0x gerufen"
+            )
+        finally:
+            oa_base._REGISTERED_SOURCES.clear()
+            oa_base._REGISTERED_SOURCES.extend(backup)
+            _clean_user(uid)
+
+    def test_ac17_batch_mit_zwei_amtlichen_warnungen_unterdrueckt_nur_das_duplikat(self):
+        """AC-17 (Batch-Filterung, Bruchstelle).
+
+        GIVEN zwei amtliche Warnungen im selben Lauf -- eine ein Duplikat
+              eines bereits registrierten Nowcast-Ereignisses (thunderstorm
+              -> Klasse 'wet'), die andere eigenstaendig (extreme_heat, keine
+              Klasse)
+        WHEN  ``_send_official_alert_only`` laeuft
+        THEN  wird NUR die duplizierte Warnung unterdrueckt, die andere wird
+              zugestellt -- beide in getrennter Betrachtung, nicht als
+              Alles-oder-Nichts-Entscheidung ueber den ganzen Lauf.
+
+        RED heute: ImportError bei ``record_event_identity``."""
+        from services.alert_gate import record_event_identity
+        from services.alert_log import REASON_EVENT_DUPLICATE, REASON_OFFICIAL_ALERT
+        from services.official_alerts import OfficialAlert, register_official_alert_source
+        from services.trip_alert import TripAlertService
+
+        uid = _fresh_user("s4b-ac17")
+        _clean_user(uid)
+        oa_base, backup = _registered_sources_backup()
+        oa_base._REGISTERED_SOURCES.clear()
+        try:
+            now = datetime.now(timezone.utc)
+            record_event_identity(
+                user_id=uid, entity_id="trip-s4b-ac17", hazard_class="wet",
+                segment_ids=["1"], severity="HIGH", point_at=now, now=now,
+            )
+
+            trip = _minimal_trip("trip-s4b-ac17")
+            _save_cached(uid, trip.id, [_data(1, precip_sum_mm=2.0)])
+
+            duplikat = OfficialAlert(
+                source="tdd-s4b-ac17-dup", hazard="thunderstorm", level=3,
+                label="AC-17-Duplikat", valid_from=now - timedelta(minutes=5),
+                valid_to=now + timedelta(minutes=30),
+            )
+            eigenstaendig = OfficialAlert(
+                source="tdd-s4b-ac17-eigen", hazard="extreme_heat", level=3,
+                label="AC-17-Eigenstaendig",
+            )
+            register_official_alert_source(_CountingOfficialAlertSource(LAT, LON, duplikat))
+            register_official_alert_source(_CountingOfficialAlertSource(LAT, LON, eigenstaendig))
+
+            mail_calls: list = []
+            svc = TripAlertService(
+                user_id=uid,
+                mail_sink=lambda subject, body: mail_calls.append((subject, body)),
+            )
+            notices = svc.check_official_alert_triggers(trip)
+            hazards = {a.hazard for a, _seg in notices}
+            assert hazards == {"thunderstorm", "extreme_heat"}, (
+                f"Voraussetzung: beide Warnungen muessen als NEU erkannt werden: {notices!r}"
+            )
+
+            sent = svc._send_official_alert_only(trip, notices)
+
+            assert sent is True, (
+                f"Die eigenstaendige Warnung muss trotz Teil-Unterdrueckung "
+                f"zugestellt werden ({sent!r})"
+            )
+            assert len(mail_calls) == 1, (
+                f"Erwartet genau 1 Mail-Versand (nur die eigenstaendige "
+                f"Warnung), erhalten: {len(mail_calls)}"
+            )
+            _, body = mail_calls[0]
+            from output.renderers.alert.official_alerts import _display_label
+
+            assert _display_label(eigenstaendig) in body, (
+                f"Die eigenstaendige Warnung (extreme_heat) muss im Body "
+                f"stehen: {body!r}"
+            )
+            assert _display_label(duplikat) not in body, (
+                f"Das Duplikat (thunderstorm) darf NICHT im Body stehen: {body!r}"
+            )
+
+            log_path = DATA_ROOT / uid / "alert_log.json"
+            log = json.loads(log_path.read_text())
+            passend = [
+                e for e in log.get("not_delivered", [])
+                if isinstance(e, dict) and e.get("entity_id") == trip.id
+                and e.get("reason") == REASON_OFFICIAL_ALERT
+                and any(
+                    item.get("reason") == REASON_EVENT_DUPLICATE
+                    for item in e.get("channels_not_sent", [])
+                    if isinstance(item, dict)
+                )
+            ]
+            assert len(passend) == 1, (
+                f"Erwartet GENAU EINEN not_delivered-Eintrag mit gate_reason="
+                f"{REASON_EVENT_DUPLICATE!r} fuer das Duplikat: {log!r}"
+            )
+        finally:
+            oa_base._REGISTERED_SOURCES.clear()
+            oa_base._REGISTERED_SOURCES.extend(backup)
+            _clean_user(uid)

--- a/tests/tdd/test_issue_1088_official_alert_triggers.py
+++ b/tests/tdd/test_issue_1088_official_alert_triggers.py
@@ -721,7 +721,7 @@ class TestS4bEventIdentityWiring:
         from services.official_alerts import OfficialAlert, register_official_alert_source
         from services.trip_alert import TripAlertService
         from tests.helpers.nowcast_gate_fixtures import (
-            CountingFrameSource, make_trip, settings_email_only, trip_alert_service,
+            CountingFrameSource, make_trip, save_trip, settings_email_only, trip_alert_service,
         )
 
         results: list = []
@@ -740,6 +740,7 @@ class TestS4bEventIdentityWiring:
         try:
             # ── Nowcast-Pfad ──
             trip_nowcast = make_trip("trip-s4b-ac1-nowcast")
+            save_trip(trip_nowcast, uid)
             raus = trip_alert_service(
                 uid, settings_email_only(), CountingFrameSource(onset_minutes=8),
                 lambda s, b: None,
@@ -792,7 +793,7 @@ class TestS4bEventIdentityWiring:
         import services.trip_alert as trip_alert_mod
         from services.alert_gate import check_event_identity_gate as _real_identity
         from tests.helpers.nowcast_gate_fixtures import (
-            CountingFrameSource, make_trip, settings_email_only, trip_alert_service,
+            CountingFrameSource, make_trip, save_trip, settings_email_only, trip_alert_service,
         )
 
         order: list[str] = []
@@ -808,6 +809,7 @@ class TestS4bEventIdentityWiring:
         _clean_user(uid)
         try:
             trip = make_trip("trip-s4b-ac12-nowcast")
+            save_trip(trip, uid)
 
             def _mail_sink(subject, body):
                 order.append("mail_sink")
@@ -1056,7 +1058,15 @@ class TestS4bEventIdentityWiring:
                 f"Das Duplikat (thunderstorm) darf NICHT im Body stehen: {body!r}"
             )
 
-            log_path = DATA_ROOT / uid / "alert_log.json"
+            # Issue #1467 S4b-1 Test-Fix: DATA_ROOT ist eine Modul-Konstante
+            # (Zeile 49), die am isolierten `app.loader._DATA_ROOT` der
+            # autouse-Fixture `_isolate_data_root` (tests/conftest.py)
+            # vorbeizeigt -- ueber `get_data_dir()` liest dieser Test denselben
+            # Pfad, den `alert_log.append_suppressed_entry()`/`append_entry()`
+            # tatsaechlich beschrieben haben.
+            from app.loader import get_data_dir
+
+            log_path = get_data_dir(uid) / "alert_log.json"
             log = json.loads(log_path.read_text())
             passend = [
                 e for e in log.get("not_delivered", [])
@@ -1071,6 +1081,121 @@ class TestS4bEventIdentityWiring:
             assert len(passend) == 1, (
                 f"Erwartet GENAU EINEN not_delivered-Eintrag mit gate_reason="
                 f"{REASON_EVENT_DUPLICATE!r} fuer das Duplikat: {log!r}"
+            )
+        finally:
+            oa_base._REGISTERED_SOURCES.clear()
+            oa_base._REGISTERED_SOURCES.extend(backup)
+            _clean_user(uid)
+
+    def test_ac3_nowcast_gescheiterte_zustellung_registriert_keinen_event_identity_eintrag(
+        self,
+    ):
+        """F001 (Fix-Loop, Adversary CRITICAL) -- AC-3-Verdrahtungsteil,
+        Nowcast-Pfad. Vorbild:
+        `test_ac13_gescheiterte_zustellung_bucht_weder_sperrzeit_noch_
+        tageszaehler` (test_alert_gate.py, S3).
+
+        Der isolierte Baustein-Test `test_ac3_check_event_identity_gate_
+        ist_rein_lesend_kein_registereintrag` (test_alert_gate.py) prueft
+        nur, dass `check_event_identity_gate()` selbst nie schreibt --
+        offen blieb, OB der Aufrufer `record_event_identity()` ueberhaupt
+        an die erfolgreiche Zustellung bindet. Der Adversary hat genau
+        diese Bindung im Nowcast-Pfad aufgeloest (Registrierung VOR den
+        Erfolgs-Guard `if not delivered: continue` verschoben) und alle 87
+        Tests blieben gruen -- ein nicht zugestellter Nowcast haette einen
+        Phantom-Eintrag hinterlassen, an dem eine spaeter eintreffende
+        amtliche Warnung zum selben Ereignis faelschlich unterdrueckt
+        wuerde, obwohl der Nutzer nie etwas bekommen hat.
+
+        GIVEN einen Trip ohne erreichbaren Kanal
+        WHEN  `check_radar_alerts()` einen faelligen Nowcast findet
+        THEN  scheitert die Zustellung UND es entsteht KEIN
+              `event_identity:`-Registereintrag.
+
+        Mutations-Gegenprobe (Pflicht): `record_event_identity()` im
+        Nowcast-Pfad VOR den Erfolgs-Guard verschieben MUSS diesen Test rot
+        machen."""
+        from services.alert_state import AlertStateService, EVENT_IDENTITY_KEY_PREFIX
+        from tests.helpers.nowcast_gate_fixtures import (
+            CountingFrameSource, make_trip, save_trip, settings_no_channel_reachable,
+            trip_alert_service,
+        )
+
+        uid = _fresh_user("s4b-f001-nowcast")
+        _clean_user(uid)
+        try:
+            trip = make_trip("trip-s4b-f001-nowcast")
+            save_trip(trip, uid)
+            raus = trip_alert_service(
+                uid, settings_no_channel_reachable(),
+                CountingFrameSource(onset_minutes=8), lambda s, b: None,
+            ).check_radar_alerts()
+            assert raus == 0, (
+                f"Voraussetzung: ohne erreichbaren Kanal darf kein Nowcast "
+                f"als zugestellt gelten ({raus!r})"
+            )
+            state = AlertStateService(user_id=uid).load(trip.id)
+            event_keys = [k for k in state if k.startswith(EVENT_IDENTITY_KEY_PREFIX)]
+            assert event_keys == [], (
+                f"Eine gescheiterte Nowcast-Zustellung darf keinen "
+                f"event_identity:-Eintrag hinterlassen: {event_keys!r}"
+            )
+        finally:
+            _clean_user(uid)
+
+    def test_ac3_amtlich_gescheiterte_zustellung_registriert_keinen_event_identity_eintrag(
+        self,
+    ):
+        """F001 (Fix-Loop, Adversary CRITICAL) -- AC-3-Verdrahtungsteil,
+        amtlicher Pfad. Analog zum Nowcast-Gegenstueck oben: der Adversary
+        hat `record_event_identity()` auch im amtlichen Pfad vor den
+        Erfolgs-Guard `if result.sent:` verschoben, ohne dass ein Test rot
+        wurde.
+
+        GIVEN eine amtliche Warnung der Klasse 'wet' (thunderstorm) UND
+              keinen erreichbaren Kanal
+        WHEN  `_send_official_alert_only()` laeuft
+        THEN  scheitert die Zustellung UND es entsteht KEIN
+              `event_identity:`-Registereintrag.
+
+        Mutations-Gegenprobe (Pflicht): `record_event_identity()` im
+        amtlichen Pfad VOR `if result.sent:` verschieben MUSS diesen Test
+        rot machen."""
+        from services.alert_state import AlertStateService, EVENT_IDENTITY_KEY_PREFIX
+        from services.official_alerts import OfficialAlert, register_official_alert_source
+        from services.trip_alert import TripAlertService
+        from tests.helpers.nowcast_gate_fixtures import settings_no_channel_reachable
+
+        uid = _fresh_user("s4b-f001-amtlich")
+        _clean_user(uid)
+        oa_base, backup = _registered_sources_backup()
+        oa_base._REGISTERED_SOURCES.clear()
+        try:
+            trip = _minimal_trip("trip-s4b-f001-amtlich")
+            _save_cached(uid, trip.id, [_data(1, precip_sum_mm=2.0)])
+            alert = OfficialAlert(
+                source="tdd-f001-amtlich", hazard="thunderstorm", level=3,
+                label="F001-Warnung",
+            )
+            register_official_alert_source(_CountingOfficialAlertSource(LAT, LON, alert))
+            svc = TripAlertService(
+                user_id=uid, settings=settings_no_channel_reachable(),
+                mail_sink=lambda s, b: None,
+            )
+            notices = svc.check_official_alert_triggers(trip)
+            assert len(notices) == 1, "Voraussetzung: die Warnung muss als neu erkannt werden"
+
+            sent = svc._send_official_alert_only(trip, notices)
+            assert sent is False, (
+                f"Voraussetzung: ohne erreichbaren Kanal darf nichts als "
+                f"zugestellt gelten ({sent!r})"
+            )
+
+            state = AlertStateService(user_id=uid).load(trip.id)
+            event_keys = [k for k in state if k.startswith(EVENT_IDENTITY_KEY_PREFIX)]
+            assert event_keys == [], (
+                f"Eine gescheiterte amtliche Zustellung darf keinen "
+                f"event_identity:-Eintrag hinterlassen: {event_keys!r}"
             )
         finally:
             oa_base._REGISTERED_SOURCES.clear()

--- a/tests/tdd/test_nowcast_suppression_logging.py
+++ b/tests/tdd/test_nowcast_suppression_logging.py
@@ -28,7 +28,7 @@ Kein Netz.
 """
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
@@ -643,3 +643,131 @@ def test_ac9_amtlicher_alarm_bekommt_keinen_unterdrueckungs_grund():
         base._REGISTERED_SOURCES.extend(quellen)
         clean_uid(kontrolle)
         clean_uid(gesperrt)
+
+
+# ═══ Issue #1467 Scheibe S4b-1 — Ereignis-Identitaet-Unterdrueckung (T6) ═════
+# SPEC: docs/specs/modules/rework_1467_s4b_entdopplung.md, AC-15/AC-16
+#
+# `record_event_identity`/`check_event_identity_gate` existieren heute
+# nicht -> ImportError. Diese Erweiterung von append_suppressed_entry() auf
+# den amtlichen Pfad ist bewusst NUR fuer REASON_EVENT_DUPLICATE gedacht --
+# der bestehende Waechter oben (test_ac9_amtlicher_alarm_bekommt_keinen_
+# unterdrueckungs_grund) bleibt fuer Ruhezeit/Tageslimit unveraendert gruen,
+# weil `suppression_reasons()`/`_gate_reasons_in_log()` NUR die drei
+# S3/S4a-Gate-Gruende zaehlen (REASON_EVENT_DUPLICATE ist bewusst NICHT in
+# dieser Menge, s. Helper oben) — AC-16 grenzt das explizit ab.
+
+
+def test_ac15_trip_nowcast_protokolliert_ereignis_identitaet_unterdrueckung():
+    """AC-15 (Beobachtbarkeit Nowcast, Erweiterung ggu. S3): ein durch
+    ``check_event_identity_gate`` unterdrueckter Trip-Nowcast erzeugt GENAU
+    EINEN Protokoll-Eintrag mit ``reason=REASON_NOWCAST`` und
+    ``gate_reason=REASON_EVENT_DUPLICATE``.
+
+    RED heute: ImportError (``services.alert_gate.record_event_identity``
+    fehlt)."""
+    from services.alert_gate import record_event_identity
+    from services.alert_log import REASON_EVENT_DUPLICATE
+
+    uid, trip_id = fresh_uid("s4b-ac15"), "trip-1467s4b-ac15"
+    clean_uid(uid)
+    try:
+        write_user_tier(uid, "premium")
+        now = datetime.now(timezone.utc)
+        # Bereits registrierte amtliche Warnung derselben Klasse/desselben
+        # Segments ("1", s. trip_segments.py::segment_id=i+1 fuer die
+        # Einzeletappe von make_trip()) -- der nachfolgende Nowcast gilt als
+        # Duplikat.
+        record_event_identity(
+            user_id=uid, entity_id=trip_id, hazard_class="wet",
+            segment_ids=["1"], severity="HIGH",
+            window_start=now - timedelta(minutes=10),
+            window_end=now + timedelta(hours=4), now=now,
+        )
+        assert _run_trip(uid, trip_id) == 0, (
+            "Voraussetzung: die Ereignis-Identitaet muss den Nowcast unterdruecken"
+        )
+        unterdrueckt = entries_for(uid, trip_id, bucket="not_delivered")
+        passend = [
+            e for e in unterdrueckt
+            if any(
+                item.get("reason") == REASON_EVENT_DUPLICATE
+                for item in e.get("channels_not_sent", [])
+                if isinstance(item, dict)
+            )
+        ]
+        assert len(passend) == 1, (
+            f"Erwartet GENAU EINEN Protokoll-Eintrag mit gate_reason="
+            f"{REASON_EVENT_DUPLICATE!r}, gefunden {len(passend)}: {read_log(uid)!r}"
+        )
+    finally:
+        clean_uid(uid)
+
+
+def test_ac16_amtliche_ereignis_identitaet_unterdrueckung_erzeugt_protokoll_eintrag():
+    """AC-16 (a): eine durch ``check_event_identity_gate`` unterdrueckte
+    amtliche Warnung erzeugt GENAU EINEN Protokoll-Eintrag mit
+    ``reason=REASON_OFFICIAL_ALERT`` und ``gate_reason=REASON_EVENT_DUPLICATE``
+    -- bewusste Erweiterung ggu. S4a E3, wo der amtliche Pfad NIE
+    protokollierte.
+
+    RED heute: ImportError (``record_event_identity``)."""
+    from services.alert_gate import record_event_identity
+    from services.alert_log import REASON_EVENT_DUPLICATE, REASON_OFFICIAL_ALERT
+    from services.official_alerts import OfficialAlert, register_official_alert_source
+    from services.trip_alert import TripAlertService
+    from services.weather_snapshot import WeatherSnapshotService
+
+    uid = fresh_uid("s4b-ac16")
+    clean_uid(uid)
+    quellen = list(base_mod()._REGISTERED_SOURCES)
+    base_mod()._REGISTERED_SOURCES.clear()
+    try:
+        now = datetime.now(timezone.utc)
+        record_event_identity(
+            user_id=uid, entity_id="trip-s4b-ac16", hazard_class="wet",
+            segment_ids=["1"], severity="HIGH", point_at=now, now=now,
+        )
+        trip = gust_alert_trip("trip-s4b-ac16")
+        WeatherSnapshotService(user_id=uid).save_dated(
+            trip.id, date.today(), [weather(1, precip_sum_mm=2.0)],
+        )
+        alert = OfficialAlert(
+            source="tdd-s4b-ac16", hazard="thunderstorm", level=3,
+            label="AC-16-Warnung", valid_from=now - timedelta(minutes=5),
+            valid_to=now + timedelta(minutes=30), region_label="AC16-Region",
+        )
+        register_official_alert_source(_FakeOfficialSource([alert]))
+
+        svc = TripAlertService(user_id=uid, mail_sink=lambda s, b: None)
+        notices = svc.check_official_alert_triggers(trip)
+        assert len(notices) == 1, "Voraussetzung: die Warnung muss als neu erkannt werden"
+
+        sent = svc._send_official_alert_only(trip, notices)
+        assert sent is False, f"Voraussetzung: die Warnung muss unterdrueckt werden ({sent!r})"
+
+        unterdrueckt = entries_for(uid, trip.id, bucket="not_delivered")
+        passend = [
+            e for e in unterdrueckt
+            if e.get("reason") == REASON_OFFICIAL_ALERT
+            and any(
+                item.get("reason") == REASON_EVENT_DUPLICATE
+                for item in e.get("channels_not_sent", [])
+                if isinstance(item, dict)
+            )
+        ]
+        assert len(passend) == 1, (
+            f"Erwartet GENAU EINEN Protokoll-Eintrag mit reason="
+            f"{REASON_OFFICIAL_ALERT!r} und gate_reason={REASON_EVENT_DUPLICATE!r}: "
+            f"{read_log(uid)!r}"
+        )
+    finally:
+        base_mod()._REGISTERED_SOURCES.clear()
+        base_mod()._REGISTERED_SOURCES.extend(quellen)
+        clean_uid(uid)
+
+
+def base_mod():
+    import services.official_alerts.base as base
+
+    return base

--- a/tests/tdd/test_nowcast_suppression_logging.py
+++ b/tests/tdd/test_nowcast_suppression_logging.py
@@ -729,6 +729,16 @@ def test_ac16_amtliche_ereignis_identitaet_unterdrueckung_erzeugt_protokoll_eint
             segment_ids=["1"], severity="HIGH", point_at=now, now=now,
         )
         trip = gust_alert_trip("trip-s4b-ac16")
+        # Issue #1467 S4b-1 Test-Fix: `gust_alert_trip()` ist fuer die
+        # Aenderungsalarm-Tests gebaut und setzt bewusst
+        # `official_alert_triggers_enabled = False` (Zeile 162 der
+        # gemeinsamen Helferfunktion, tests/helpers/alert_log_fixtures.py) --
+        # das wuerde `check_official_alert_triggers()` fuer JEDEN Trip
+        # blockieren, unabhaengig vom Ereignis-Identitaets-Gate, das dieser
+        # Test eigentlich prueft. Nur auf DIESER Instanz zurueckgesetzt, die
+        # geteilte Helferfunktion bleibt unveraendert (andere Tests haengen
+        # an ihrem Bestandsverhalten).
+        trip.official_alert_triggers_enabled = None
         WeatherSnapshotService(user_id=uid).save_dated(
             trip.id, date.today(), [weather(1, precip_sum_mm=2.0)],
         )


### PR DESCRIPTION
Scheibe S4b-1 von #1467 (= #1744 Scheibe B). Letzte Scheibe des Issues.

## Problem

Ein und dasselbe Gewitter loeste bisher zwei Alarme aus: einen Radar-Nowcast und
Minuten spaeter die amtliche Warnung. Beide gingen raus, weil die Sperrzeiten je
**Quelle** in getrennten Toepfen liegen und einander konstruktionsbedingt nicht
sehen koennen.

Gemessen am Produktivprotokoll (13 Tage): 6 quellenuebergreifende Doppelmeldungen,
rund eine alle anderthalb Tage. Der gemeldete Vorfall ist reproduziert
(`5f534011`, 2026-08-11 14:22 UTC Nowcast, +8,2 Min amtliche Warnung). An einem
einzigen Gewitternachmittag gingen sechs Alarme fuer dieselbe Etappe raus.

## Loesung

Neuer geteilter Baustein `check_event_identity_gate()` in `alert_gate.py` als
**letzte** Stufe der bestehenden Gate-Kette, verdrahtet in beide Trip-Pfade
(Nowcast und amtlich). Entdoppelt nach gleicher Gefahrenklasse + ueberlappenden
Segment-Kennungen + ueberlappendem Zeitfenster.

**Eine Gefahrenklasse `wet`** statt zwei (PO-Entscheid): Die Radar-Einstufung
konvektiv/nicht-konvektiv ist eine Momentaufnahme der Zelle, kein
Ereignis-Unterscheidungsmerkmal — dieselbe Gewitterlage erscheint mal als
`thunder`, mal als `precipitation`. Amtliches `rain` faellt damit mit in den Kanon.

## Zwei strukturelle Zusicherungen gegen "Alarm bleibt aus"

- Eine **Eskalation bricht immer durch** — eigener, unabhaengiger Ausstieg, der von
  der Abdeckungsregel nicht ueberstimmt werden kann.
- Jede **Unsicherheit entscheidet Richtung Zustellung**: fehlender Zeitbezug,
  fehlende Ortskennung, unbekannte Gefahrenart, kaputter Registereintrag.

## Nachweis

- **Adversary VERIFIED**, 22/22 ACs, zwei Runden. 14 Mutations-Gegenproben gefangen.
- Zwei Testluecken fand erst die Gegenprobe — Registrierung-vor-Zustellung und die
  zweite Richtung der leeren Segment-Kennung — beide mit Wiring-Tests geschlossen,
  ohne Produktionscode anzufassen.
- 90 Tests gruen in den vier Kern-Dateien, 121 in den angrenzenden Alarm-Suiten.

Spec: `docs/specs/modules/rework_1467_s4b_entdopplung.md` (PO-Freigabe 2026-08-16)