### PR TITLE
test(#1708 B1): stillgelegte Tests am toten trips-Pfad reaktiviert

### DIFF
--- a/docs/context/fix-1708-b1-tote-fixture-befunde.md
+++ b/docs/context/fix-1708-b1-tote-fixture-befunde.md
@@ -1,0 +1,272 @@
+# Context: fix-1708-b1-tote-fixture-befunde
+
+Issue: **#1708 Scheibe B1** (Teilarbeit — schliesst #1708 nicht; das tut Scheibe C).
+Vorgaenger: Scheibe A (`05086722` + Doku-PR #1907), beide in `origin/main`.
+
+## Request Summary
+
+Drei Testdateien haengen am toten Pfad `data/users/<uid>/trips/<id>.json`. Fuer jede ist zu
+**belegen**, warum sie heute gruen bzw. still ist, und das dahinterliegende Deckungsloch zu
+schliessen. Nicht "Pfad umschreiben" — die drei Faelle sind drei verschiedene Fehlerbilder.
+
+## Gemessener Befund je Datei
+
+### A. `tests/tdd/test_bug_338_openmeteo_call_counter.py` — laeuft NIRGENDS
+
+Zwei unabhaengige Ausschluesse uebereinander:
+
+| # | Mechanismus | Beleg |
+|---|---|---|
+| 1 | `pytestmark = pytest.mark.live` auf **Modulebene** deselektiert die ganze Datei | `test_bug_338_openmeteo_call_counter.py:24` · gemessen: `uv run pytest <datei> --collect-only` → **`no tests collected (6 deselected)`** |
+| 2 | AC-2 steigt zusaetzlich per `pytest.skip` aus, wenn `get_trips_dir("henning")/"5f534011.json"` fehlt | `:211-213` (einziger `skip` der Datei) |
+
+Die Datei steht **nicht** auf `.github/ci_tdd_excludes.txt` (87 Zeilen, kein Treffer) — der
+Ausschluss ist damit unsichtbar. `/e2e-verify` faehrt nur `tests/tdd/test_issue_686_telegram_functional_live.py`
+(`.claude/commands/e2e-verify.md:114`), also auch nicht diese Datei.
+
+Der einzige Aufrufer ist ein Wrapper: `tests/tdd/test_issue_338_go_geosphere_counter.py:84-114`
+(`test_ac3_existing_six_tests_still_green`) startet die Datei im Subprozess mit `-o addopts=`,
+um die Marker-Filterung zu neutralisieren, und prueft `returncode == 0`. Der Wrapper traegt
+selbst `@pytest.mark.live` (`:84`) — laeuft also ebenfalls in keinem regulaeren Lauf. Und selbst
+wenn er liefe: ein **geskippter** Test liefert Exit 0. Der Wrapper kann den Skip aus (2) also
+grundsaetzlich nicht sehen.
+
+`henning/5f534011` existiert in **keiner** Testfixture (weder unter `trips/` noch `briefings/`) —
+der Skip aus (2) feuert damit auch im Live-Lauf immer.
+
+**Verlorene Zusicherung:** AC-2 — dass `PreviewService.render_email_preview` `source == "vorschau"`
+liefert (nicht `"briefing"`), obwohl intern `_fetch_weather` laeuft. Plus die uebrigen 5 Tests
+der Datei, die pauschal mit deselektiert werden.
+
+### B. `tests/tdd/test_issue_346_fixture_provider.py` — skippt deterministisch
+
+Gemessen: `uv run pytest <datei> -q -rs` → `9 passed, 1 skipped`, Grund
+`SKIPPED [1] :121: Kein echter Test-Trip in data/users vorhanden`.
+
+`_find_test_trip()` (`:24-32`) sucht `henning/5f534011` und `default/gr221-mallorca` **im toten
+Pfad** via `get_trips_dir(uid)`. Unter der autouse-Isolation (`tests/conftest.py:121`) zeigt die
+Datenwurzel auf ein leeres tmp-Verzeichnis → `(None, None)` → Skip. Das passiert bei **jedem**
+Lauf, auch schon vor der Umbenennung der Produktivablage.
+
+**Verlorene Zusicherung:** AC-6 (`:117`) — dass `render_email_preview` mit gesetztem
+`GZ_TEST_FIXTURE_DIR` **offline** laeuft und keinen einzigen echten Open-Meteo-Call ausloest.
+Das ist die Kernzusage des gesamten FixtureProvider-Features; sie ist unbewacht.
+
+### C. `tests/tdd/test_issue_1133_testdata_cleanup.py` — gruen, aber falsch verankert
+
+Gemessen: `13 passed`, keine Skips. Der Test ist **nicht** aus falschem Grund gruen.
+
+`get_trips_dir()` dient dort als **Sonde** fuer die Datenwurzel-Isolation (`:57-75`, ein Test,
+AC-1): Teil A prueft, dass der Pfad absolut ist und nicht in den Repo-Baum zeigt; Teil B macht
+einen echten `save_trip()`-Roundtrip. Der Beweis haengt nicht an `trips` — jedes ueber
+`app.loader` aufgeloeste Unterverzeichnis der Datenwurzel leistet dasselbe.
+
+**Risiko:** Faellt `get_trips_dir()` in Scheibe B2 weg, faellt der Isolationsbeweis mit — es sei
+denn, die Sonde wird vorher auf `get_briefings_dir()` umgehaengt.
+
+## Der gemeinsame Untergrund: die Referenz-Fixturen liegen selbst im toten Pfad
+
+`tests/fixtures/data_root/users/*/trips/*.json` — **9 versionierte Trip-Dateien**
+(`default/gr221-mallorca.json`, 8x `validator-issue110/*`). Kein einziges `briefings/`-Verzeichnis
+dort.
+
+`tests/conftest.py:52-91` (`_materialize_real_data_root_fixtures`, Session-autouse) kopiert sie in
+den **echten** `<repo>/data/`-Baum und spiegelt danach jede `*/trips/*.json` zusaetzlich nach
+`*/briefings/<id>.json` (`:83-91`, ADR-0023). Der tote Pfad ist hier also **kein Leichnam, sondern
+die Saatgutquelle** des Spiegels — eine Umstellung muss Quelle und Spiegellogik zusammen anfassen.
+
+In den **isolierten** tmp-Wurzeln passiert diese Materialisierung nicht. Deshalb findet B nie etwas,
+und deshalb hilft es dort nicht, den Suchpfad auf `briefings/` zu drehen — der Test muss seine
+Fixture selbst anlegen.
+
+## Related Files
+
+| Datei | Relevanz |
+|------|-----------|
+| `tests/tdd/test_bug_338_openmeteo_call_counter.py` | Fall A — Modul-`live` + Skip, 6 Tests laufen nirgends |
+| `tests/tdd/test_issue_338_go_geosphere_counter.py:84-114` | Wrapper, der A's Gruenheit behauptet; selbst `live`, blind fuer Skips |
+| `tests/tdd/test_issue_346_fixture_provider.py` | Fall B — AC-6 skippt deterministisch |
+| `tests/tdd/test_issue_1133_testdata_cleanup.py:57-75` | Fall C — Isolationssonde, muss umgehaengt werden |
+| `tests/conftest.py:52-91` | Materialisierung + `trips/`→`briefings/`-Spiegel |
+| `tests/conftest.py:121-146` | `_isolate_data_root`; steigt bei `live`/`real_data_root` aus |
+| `tests/fixtures/data_root/users/*/trips/*.json` | 9 Referenz-Trips, liegen im toten Pfad |
+| `src/app/loader.py:1155` `get_trips_dir()` | toter Pfad; faellt in B2 |
+| `src/app/loader.py:1166` `get_briefings_dir()` | der lebende Ersatz |
+| `tests/test_trips_path_revival_guard.py:91` | traegt genau **einen** Ausnahmeeintrag fuer `get_trips_dir()` |
+| `.github/ci_tdd_excludes.txt` | 87 Zeilen; keine der drei Dateien steht drin |
+
+## Existing Patterns
+
+- **Trip-Fixture nach `briefings/` schreiben:** Vorbild `tests/conftest.py:83-91` — `kind`-Default
+  setzen, dann `get_briefings_dir(uid)/<id>.json`. Auch `tests/test_briefing_route_cutover.py:108-110`
+  leitet `briefings` aus der Datenwurzel ab.
+- **Marker auf Funktionsebene, nicht aufs Modul** — Lehre aus #1667 S2: ein Modul-`live` reisst
+  unschuldige Waechter mit und schaltet zusaetzlich die Daten-Isolation ab.
+- **Ausschluss sichtbar machen:** wer eine Datei aus dem regulaeren Lauf nimmt, traegt sie in
+  `.github/ci_tdd_excludes.txt` ein — sonst ist die Stilllegung unsichtbar.
+
+## Dependencies
+
+- **Upstream:** `app.loader.get_data_root/get_briefings_dir`, `tests/conftest.py`-Fixtures
+  (`_materialize_real_data_root_fixtures`, `_isolate_data_root`), `services.preview_service`,
+  `providers.fixture`/`providers.call_log`.
+- **Downstream:** `tests/tdd/test_issue_338_go_geosphere_counter.py` (Subprozess-Wrapper auf A);
+  Scheibe **B2** haengt an C (Sonde umhaengen) und an der Fixture-Quelle, bevor `get_trips_dir()`
+  entfernt werden kann.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1708_a_trips_pfad_waechter.md` — Scheibe A, definiert die Ausnahmeliste
+- `docs/specs/_archive/modules/bug_338_openmeteo_call_counter.md` + `_archive/tests/…_tests.md`
+- `docs/specs/_archive/tests/issue_346_fixture_provider_tests.md`
+- `docs/adr/` — ADR-0023 (Cutover `trips/` → `briefings/`)
+
+## Risks & Considerations
+
+1. **Ein reaktivierter Test kann echt rot werden.** #338 AC-2 und #346 AC-6 laufen seit ihrer
+   Entstehung nie. Wird die Zusicherung heute verletzt, ist das ein **Befund**, kein Grund, den
+   Test wieder abzuschwaechen. Kernschicht-Regel: sofort fixen oder loeschen — nicht liegenlassen.
+2. **Modul-`live` bei A entfernen aendert die Laufzeit-Schicht.** 6 Tests kommen neu in den
+   Commit-Gate-Lauf. Sie duerfen dann keine echten API-Calls machen — der FixtureProvider-Modus
+   (`GZ_TEST_FIXTURE_DIR`) ist der vorgesehene Weg. Ob alle 6 offline laufen, ist zu messen, nicht
+   anzunehmen.
+3. **Fixture-Quelle anfassen beruehrt Fremdtests.** Die 9 Dateien unter
+   `tests/fixtures/data_root/users/*/trips/` speisen den Spiegel in `conftest.py`. Wer sie
+   verschiebt, muss die Spiegellogik mitziehen, sonst laufen unbeteiligte `real_data_root`-Tests
+   ins Leere.
+4. **Gruener Testlauf beweist nichts.** Fuer jeden reparierten Test ist per Mutations-Gegenprobe
+   zu zeigen, dass er die Zusicherung **am Wirkort** bewacht — sonst ist der Skip nur durch ein
+   trivial gruenes Assert ersetzt.
+5. **LoC-Limit 250.** Drei Testdateien + ggf. Fixture-Umzug + Gegenproben; der Nachweis kostet
+   mehr als der Eingriff. Zuschnitt eng halten.
+6. **Kein Produktivcode in B1.** `get_trips_dir()` bleibt bis B2 stehen; die Wächter-Ausnahme
+   bleibt unangetastet.
+
+---
+
+# Analysis
+
+## Type
+
+**Bug** — Tests, die eine Zusicherung tragen sollen, laufen nicht bzw. skippen still. Kein
+Produktivfehler gefunden (siehe Befund 3 unten).
+
+## Die drei Befunde, alle gemessen
+
+### Befund 1 — `test_bug_338` ist doppelt stillgelegt, und der Wrapper kann es nicht sehen
+
+`pytestmark = pytest.mark.live` (`:24`) ⇒ `no tests collected (6 deselected)`. Nicht auf
+`.github/ci_tdd_excludes.txt`, nicht in `/e2e-verify` (`.claude/commands/e2e-verify.md:114` faehrt
+nur `test_issue_686_…`). Der einzige Aufrufer `test_issue_338_go_geosphere_counter.py:84-114`
+prueft `returncode == 0` eines Subprozesses mit `-o addopts=` — ein **geskippter** Test liefert
+Exit 0, der Wrapper ist fuer den Skip aus `:211-213` konstruktionsbedingt blind. Der Wrapper traegt
+selbst `@pytest.mark.live` (`:84`), laeuft also ebenfalls nie.
+
+**Tatsaechlicher Zustand, wenn man sie laufen laesst** (`-o addopts= --timeout=180`):
+`4 passed, 1 failed, 1 skipped`. Mit dem Standard-Timeout 30 s zusaetzlich instabil
+(`2 failed/3 passed`, dann `3 failed/2 passed`) — Timeout-Artefakte echter Netzaufrufe
+(`src/providers/dwd.py:227` braucht laenger als 30 s).
+
+### Befund 2 — die Begruendung des Marker-Waechters ist zirkulaer
+
+`tests/tdd/test_pytest_collection_and_timeout_safety.py:155-162` haelt den Modul-Marker per
+`_C2_KEEP_MODULE_LIVE` aktiv fest, Begruendung: „6 Voll-Dialer-Dateien (per Probe/Code 100 %
+Netzcall)" (#1211 Scheibe 2c).
+
+Nachgemessen mit `--disable-socket --allow-hosts=127.0.0.1,::1`:
+
+| Test | braucht Netz? |
+|---|---|
+| `test_ac1_fetch_forecast_appends_one_jsonl_line` | **ja** |
+| `test_ac2_alarm_path_sets_source_alarm` | nein (scheitert an der Uhr, s. Befund 3) |
+| `test_ac2_trend_path_sets_source_trend` | **nein** — passed ohne Socket |
+| `test_ac2_preview_path_sets_source_vorschau` | unbekannt (skippt) |
+| `test_ac3_unwritable_log_target_is_swallowed` | **ja** |
+| `test_ac4_analyze_script_breaks_down_by_source_endpoint_hour` | **nein** — reine Dateiarbeit |
+
+„100 % Netzcall" ist damit widerlegt. Schwerer wiegt: die Messung von damals lief **mit** gesetztem
+`live`-Marker — und `tests/conftest.py:25-29` entzieht `live`-Tests genau den Offline-Fixture-Modus.
+Der Marker stellt die Bedingung her, mit der er begruendet wird. Ohne ihn setzt
+`tests/conftest.py:33` `GZ_TEST_FIXTURE_DIR` automatisch und `tests/conftest.py:143-146` gibt die
+Datenwurzel-Isolation zurueck — beide Defekte der Datei haengen an derselben Zeile.
+
+### Befund 3 — der eine harte Fehler ist Zeitabhaengigkeit, kein Produktivfehler
+
+`test_ac2_alarm_path_sets_source_alarm` scheitert deterministisch in 0,5 s ohne Netz:
+`Erwartete source 'alarm' aus _fetch_fresh_weather, sah: set()`.
+
+Ursache: `src/services/trip_alert.py:1247-1249` ueberspringt Segmente mit
+`cached.segment.end_time < now_utc`. Der Helfer `_make_segment()`
+(`test_bug_338_openmeteo_call_counter.py:39-52`) baut das Segment fest auf **06:00–14:00 UTC des
+laufenden Tages**. Gemessen um 15:15 UTC ⇒ `continue` ⇒ kein Provider-Aufruf ⇒ leeres Log.
+
+**Kippkante 14:00 UTC** — vormittags gruen, nachmittags rot. Der Alarm-Pfad selbst ist intakt; die
+`source`-Zuordnung `("_fetch_fresh_weather", "alarm")` steht unveraendert in
+`src/providers/call_log.py:47`. Der Schwestertest Trend ist nicht betroffen, weil
+`_make_trend_trip()` (`:74-86`) ein Datum in der Zukunft setzt statt einer Tageszeit.
+
+### Befund 4 — `test_issue_346` AC-6 skippt deterministisch, nicht zufaellig
+
+`_find_test_trip()` (`:24-32`) sucht ueber `get_trips_dir(uid)` und findet unter der
+autouse-Isolation nie etwas ⇒ `(None, None)` ⇒ Skip an `:121`. Betroffen ist **AC-6**
+(`:117-143`): dass `render_email_preview` mit `GZ_TEST_FIXTURE_DIR` offline laeuft und **keinen**
+echten Open-Meteo-Call ausloest. Das ist die Kernzusage des FixtureProvider-Features.
+
+Den Pfad auf `briefings/` umzubiegen genuegt **nicht** — die isolierte tmp-Wurzel enthaelt
+ueberhaupt keine Fixturen (`_materialize_real_data_root_fixtures`, `tests/conftest.py:52-91`,
+schreibt nur in den echten Baum). Der Test muss seine Fixture selbst anlegen. Vorbild:
+`tests/test_briefing_route_cutover.py` (gemessen: 7 passed).
+
+### Befund 5 — `test_issue_1133` ist korrekt gruen, aber falsch verankert
+
+`13 passed`, keine Skips. `get_trips_dir()` dient dort an genau einer Stelle (`:57-75`, AC-1) als
+Sonde fuer die Datenwurzel-Isolation. Der Beweis haengt nicht an `trips`; er faellt aber mit
+Scheibe B2, wenn er nicht vorher auf `get_briefings_dir()` (`src/app/loader.py:1166`) umgehaengt
+wird.
+
+## Affected Files (with changes)
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `tests/tdd/test_bug_338_openmeteo_call_counter.py` | MODIFY | Modul-`live` faellt; Marker nur noch auf die Tests, die nachweislich waehlen, mit Begruendung an der Zeile. Zeitabhaengigkeit in `_make_segment()` beseitigen (Segment relativ zu `now` im Fenster). AC-2-Vorschau baut seine Trip-Fixture selbst unter `get_briefings_dir()`. |
+| `tests/tdd/test_pytest_collection_and_timeout_safety.py` | MODIFY | Eintrag von `_C2_KEEP_MODULE_LIVE` (`:161`) nach `_C2_SPLIT_FILES` mit exakter Erwartungszahl; Begruendung am Eintrag ersetzt die widerlegte „100 % Netzcall"-Aussage. |
+| `tests/tdd/test_issue_338_go_geosphere_counter.py` | MODIFY | Wrapper `:84-114`: `-o addopts=` wird nach dem Split ueberfluessig; Exit-Code-Pruefung um eine Skip-Erkennung ergaenzen, damit sie nicht weiter blind ist. |
+| `tests/tdd/test_issue_346_fixture_provider.py` | MODIFY | `_find_test_trip()` ersetzen: Fixture selbst unter `get_briefings_dir()` anlegen statt im toten Pfad suchen. AC-6 laeuft damit. |
+| `tests/tdd/test_issue_1133_testdata_cleanup.py` | MODIFY | Sonde `:57-75` von `get_trips_dir()` auf `get_briefings_dir()` umhaengen, Beweiskraft (absolut + ausserhalb Repo-Baum + Roundtrip) unveraendert. |
+
+**Nicht angefasst in B1:** `src/app/loader.py` (`get_trips_dir()` faellt erst in B2), die
+Waechter-Ausnahme in `tests/test_trips_path_revival_guard.py:91`, die 9 Referenz-Fixturen unter
+`tests/fixtures/data_root/users/*/trips/` samt Spiegellogik (`tests/conftest.py:83-91`) — die
+gehoeren zu B2, weil sie den Produktiv-Lesepfad und Fremdtests beruehren.
+
+## Scope Assessment
+
+- Files: **5** (alle unter `tests/`)
+- Estimated LoC: **+150 / -40** — davon rund die Haelfte Nachweis (RED-Tests, Gegenproben)
+- Risk Level: **MEDIUM** — 6 bisher stillgelegte Tests kommen in den Commit-Gate-Lauf; jeder
+  Fehlschlag dort ist ein Befund, kein Grund zum Abschwaechen
+
+## Technical Approach
+
+1. **Zuerst den Ausschluss aufheben, dann die Tests reparieren** — solange die Datei deselektiert
+   ist, beweist kein gruener Lauf etwas. Reihenfolge: Marker splitten → messen, was rot wird →
+   jede Roete einzeln als Befund behandeln.
+2. **Marker auf Funktionsebene, mit Begruendung an der Zeile.** Lehre aus #1667 S2. Wer eine
+   Datei stilllegt, traegt sie ausserdem in `.github/ci_tdd_excludes.txt` ein.
+3. **Zeitabhaengigkeit an der Quelle beheben:** `_make_segment()` konstruiert das Fenster relativ
+   zu `now_utc`, sodass `start_time.date() <= heute` und `end_time > now` zu **jeder** Tageszeit
+   gelten. Nicht die Erwartung abschwaechen — den Messwert neu verankern.
+4. **Fixturen selbst anlegen statt suchen.** Beide Faelle (338 AC-2-Vorschau, 346 AC-6) schreiben
+   ihren Trip nach `get_briefings_dir(uid)/<id>.json` in der isolierten Wurzel. Damit ist der Test
+   unabhaengig von jedem Bestand — das ist der eigentliche Fix, nicht der Pfadwechsel.
+5. **Sonde umhaengen, nicht loeschen** (1133).
+6. **Mutations-Gegenprobe je repariertem Test:** die bewachte Eigenschaft verfaelschen und
+   nachweisen, dass der Test rot wird. Ein Skip durch ein trivial gruenes Assert zu ersetzen waere
+   derselbe Fehler in neuer Form.
+
+## Open Questions
+
+Keine offenen Fragen an den PO. Eine Entscheidung wird bewusst korrigiert und ist in der Spec zu
+begruenden: die Einstufung von `test_bug_338_openmeteo_call_counter.py` als „Voll-Dialer" aus
+#1211 Scheibe 2c ist durch Messung widerlegt (Befund 2). Das ist keine ADR-Ebene, sondern eine
+Test-Schicht-Einstufung in einem Codekommentar — sie wird ersetzt, nicht still umgangen.

--- a/docs/context/fix-1708-b1-tote-fixture-befunde.md
+++ b/docs/context/fix-1708-b1-tote-fixture-befunde.md
@@ -184,6 +184,15 @@ Nachgemessen mit `--disable-socket --allow-hosts=127.0.0.1,::1`:
 | `test_ac3_unwritable_log_target_is_swallowed` | **ja** |
 | `test_ac4_analyze_script_breaks_down_by_source_endpoint_hour` | **nein** — reine Dateiarbeit |
 
+**Praezisierung (2026-08-16, nach der GREEN-Messung):** Die Spalte oben ist irrefuehrend, weil sie
+**mit** gesetztem Modul-Marker gemessen wurde — also mit echtem `OpenMeteoProvider`. Dass Trend
+ohne Socket besteht, liegt daran, dass `_log_api_call` den Eintrag **auch beim gescheiterten
+Aufruf** schreibt; die Zusicherung wird dabei echt geprueft. Schaltet man den Marker ab, liefert
+`get_provider("openmeteo")` den `FixtureProvider` — und der ruft `call_log` **nirgends** auf
+(`src/providers/fixture.py`, verifiziert). Dann steht ueberhaupt kein Eintrag im Log und die drei
+Quellen-Tests scheitern, unabhaengig vom Netz. Richtig gelesen heisst die Tabelle also: „braucht
+einen echten Provider-**Aufrufversuch**", nicht „braucht eine erreichbare Gegenstelle".
+
 „100 % Netzcall" ist damit widerlegt. Schwerer wiegt: die Messung von damals lief **mit** gesetztem
 `live`-Marker — und `tests/conftest.py:25-29` entzieht `live`-Tests genau den Offline-Fixture-Modus.
 Der Marker stellt die Bedingung her, mit der er begruendet wird. Ohne ihn setzt

--- a/docs/specs/modules/fix_1708_b1_tote_fixture_befunde.md
+++ b/docs/specs/modules/fix_1708_b1_tote_fixture_befunde.md
@@ -12,7 +12,7 @@ tags: [tests, issue-1708, trips-pfad, stillgelegte-tests]
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved (PO, 2026-08-16, 'go' auf alle 8 ACs)
 
 ## Purpose
 

--- a/docs/specs/modules/fix_1708_b1_tote_fixture_befunde.md
+++ b/docs/specs/modules/fix_1708_b1_tote_fixture_befunde.md
@@ -1,0 +1,216 @@
+---
+entity_id: fix_1708_b1_tote_fixture_befunde
+type: module
+created: 2026-08-16
+updated: 2026-08-16
+status: draft
+version: "1.0"
+tags: [tests, issue-1708, trips-pfad, stillgelegte-tests]
+---
+
+# Fix #1708 B1 — Stillgelegte Tests am toten `trips/`-Pfad reaktivieren
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Drei Testdateien haengen am toten Pfad `data/users/<uid>/trips/<id>.json`. Sie tragen
+Zusicherungen, die sie nicht bewachen — eine Datei laeuft in **keinem** Lauf, in einer weiteren
+skippt der zentrale Test immer. Diese Scheibe macht die betroffenen Tests wieder wirksam und
+belegt fuer jeden einzeln, warum er heute still ist.
+
+Scheibe B1 ist **Teilarbeit** und schliesst #1708 **nicht**. Es folgen B2 (restliche Testdateien
+umstellen, `get_trips_dir()` entfernen) und C (tote Dateien loeschen, schliesst #1708).
+
+## Source
+
+- **File:** `tests/tdd/test_bug_338_openmeteo_call_counter.py`
+- **File:** `tests/tdd/test_issue_346_fixture_provider.py`
+- **File:** `tests/tdd/test_issue_1133_testdata_cleanup.py`
+- **File:** `tests/tdd/test_pytest_collection_and_timeout_safety.py`
+- **File:** `tests/tdd/test_issue_338_go_geosphere_counter.py`
+- **Identifier:** Testfunktionen und Modul-Marker der genannten Dateien
+
+Schicht: ausschliesslich **Testschicht** (`tests/`). Kein Produktivcode in dieser Scheibe —
+`src/app/loader.py::get_trips_dir()` faellt erst in B2, die Waechter-Ausnahme in
+`tests/test_trips_path_revival_guard.py:91` bleibt unangetastet.
+
+## Estimated Scope
+
+- **LoC:** ~150 hinzugefuegt / ~40 entfernt (rund die Haelfte Nachweis: RED-Tests, Gegenproben)
+- **Files:** 5
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `tests/conftest.py:18-33` `_use_fixture_provider` | Fixture | setzt `GZ_TEST_FIXTURE_DIR` fuer jeden nicht-`live`-Test; `live` entzieht ihn |
+| `tests/conftest.py:121-146` `_isolate_data_root` | Fixture | isolierte Datenwurzel; steigt bei `live`/`real_data_root` aus |
+| `src/app/loader.py:1166` `get_briefings_dir()` | Funktion | der lebende Pfad, auf den umgestellt wird |
+| `src/services/trip_alert.py:1247-1249` | Produktivcode | Zeitfenster-Guard, an dem der Alarm-Test heute scheitert (nur lesend) |
+| `src/providers/call_log.py:47` | Produktivcode | Stack-Zuordnung `_fetch_fresh_weather` → `"alarm"` (nur lesend) |
+| `tests/test_briefing_route_cutover.py` | Test | Vorbildmuster: Trip-Fixture in der isolierten `briefings/`-Wurzel |
+| `.github/ci_tdd_excludes.txt` | Liste | macht Stilllegungen sichtbar |
+
+## Implementation Details
+
+### Der gemeinsame Fehler
+
+Alle drei Dateien suchen Trip-Bestand, statt ihn anzulegen. In der isolierten Datenwurzel gibt es
+keinen Bestand — also skippen sie. Den Suchpfad von `trips/` auf `briefings/` umzubiegen behebt das
+**nicht**; die Tests muessen ihre Fixture selbst schreiben.
+
+```
+# falsch (heute):   Bestand suchen, sonst skip
+uid, tid = _find_test_trip()          # sucht in get_trips_dir() -> immer leer
+if not uid: pytest.skip(...)
+
+# richtig:          Fixture selbst anlegen, kein Skip moeglich
+path = get_briefings_dir(uid) / f"{tid}.json"
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps(trip_dict))   # trip_dict enthaelt "kind": "route"
+```
+
+### Datei A — `test_bug_338_openmeteo_call_counter.py`
+
+Drei getrennte Eingriffe:
+
+1. **Modul-Marker faellt.** `pytestmark = pytest.mark.live` (`:24`) wird entfernt. Marker kommen
+   nur noch an die Tests, die im Fixture-Modus **nachweislich** Netz brauchen — je Test mit
+   Begruendung in derselben Zeile. Die Zugehoerigkeit wird gemessen
+   (`--disable-socket --allow-hosts=127.0.0.1,::1`), nicht geschaetzt.
+2. **Zeitabhaengigkeit beseitigen.** `_make_segment()` (`:39-52`) baut das Segment fest auf
+   06:00–14:00 UTC des laufenden Tages; `trip_alert.py:1247-1249` ueberspringt es danach. Der
+   Helfer konstruiert das Fenster kuenftig relativ zu `now_utc`, sodass zu jeder Tageszeit gilt:
+   `start_time.date() <= heute` **und** `end_time > now_utc`.
+3. **AC-2-Vorschau baut seine Fixture selbst** (`:199-241`) statt `get_trips_dir("henning")` zu
+   befragen und zu skippen.
+
+### Datei B — `test_pytest_collection_and_timeout_safety.py`
+
+`_C2_KEEP_MODULE_LIVE` (`:155-162`) haelt den Modul-Marker aktiv fest. Die Begruendung
+(„Voll-Dialer, per Probe/Code 100 % Netzcall", #1211 Scheibe 2c) ist widerlegt: gemessen laufen
+`test_ac2_trend_path_sets_source_trend` und `test_ac4_analyze_script_breaks_down_by_source_endpoint_hour`
+**ohne Socket** durch. Zusaetzlich war die Messung von damals zirkulaer — sie lief mit gesetztem
+`live`-Marker, und genau dieser Marker entzieht den Offline-Fixture-Modus (`conftest.py:25-29`).
+
+Der Eintrag wandert nach `_C2_SPLIT_FILES` mit exakter Erwartungszahl. Die neue Begruendung nennt
+den Messweg, damit die naechste Sitzung sie nachpruefen kann statt sie zu glauben.
+
+### Datei C — `test_issue_338_go_geosphere_counter.py`
+
+`test_ac3_existing_six_tests_still_green` (`:84-114`) prueft `returncode == 0`. Ein geskippter Test
+liefert ebenfalls 0 — der Waechter ist fuer genau den Fall blind, der hier vorlag. Er wird um eine
+Skip-Erkennung ergaenzt (Subprozess-Ausgabe auf `skipped` pruefen bzw. `-W error` / `--strict`
+gleichwertig) und verliert nach dem Marker-Split sein `-o addopts=`, weil die Zieltests dann reguleaer
+laufen.
+
+### Datei D — `test_issue_346_fixture_provider.py`
+
+`_find_test_trip()` (`:24-32`) faellt ersatzlos; AC-6 (`:117-143`) legt seine Trip-Fixture selbst
+unter `get_briefings_dir()` an. Die Zusicherung selbst — Vorschau im Fixture-Modus loest **null**
+echte Open-Meteo-Calls aus — bleibt unveraendert.
+
+### Datei E — `test_issue_1133_testdata_cleanup.py`
+
+Die Isolationssonde (`:57-75`, AC-1) wird von `get_trips_dir()` auf `get_briefings_dir()`
+umgehaengt. Beide Beweisteile bleiben: Teil A (absoluter Pfad, ausserhalb des Repo-Baums), Teil B
+(echter `save_trip()`-Roundtrip).
+
+## Expected Behavior
+
+- **Input:** ein regulaerer Testlauf (`uv run pytest <datei>`) ohne Marker-Override, zu beliebiger
+  Tageszeit, mit isolierter Datenwurzel und ohne vorhandenen Trip-Bestand
+- **Output:** die betroffenen Tests werden gesammelt, laufen und pruefen ihre Zusicherung; kein
+  Test skippt mangels Datenbestand
+- **Side effects:** keine. Kein Schreibzugriff auf den echten `data/users/`-Baum, keine Mails,
+  kein Versand. Netzzugriff nur in den Tests, die nachweislich Netz brauchen und dafuer markiert
+  sind.
+
+## Acceptance Criteria
+
+- **AC-1:** Given `tests/tdd/test_bug_338_openmeteo_call_counter.py` traegt keinen Modul-weiten
+  `live`-Marker mehr / When ein Standardlauf `uv run pytest tests/tdd/test_bug_338_openmeteo_call_counter.py --collect-only -q` ausgefuehrt wird /
+  Then werden Tests gesammelt statt `no tests collected (6 deselected)` gemeldet, und jeder noch
+  `live`-markierte Test traegt eine Begruendung in seiner Markerzeile.
+  - Test: Kollektions-Test vergleicht die gesammelte Anzahl im Standardlauf gegen 0 und prueft, dass
+    die Datei im Standardlauf ueberhaupt erscheint.
+
+- **AC-2:** Given ein Test ist weiterhin `live`-markiert / When er mit
+  `--disable-socket --allow-hosts=127.0.0.1,::1` im Fixture-Modus ausgefuehrt wird / Then scheitert
+  er nachweislich an fehlendem Netzzugriff — ein Test, der offline besteht, darf den Marker nicht
+  tragen.
+  - Test: Messlauf ueber alle verbliebenen `live`-Tests der Datei; ein offline bestehender Test mit
+    Marker ist ein Fehlschlag.
+
+- **AC-3:** Given die Systemzeit liegt nach 14:00 UTC / When
+  `test_ac2_alarm_path_sets_source_alarm` ausgefuehrt wird / Then besteht er und findet mindestens
+  einen Log-Eintrag mit `source == "alarm"` — die heutige Kippkante um 14:00 UTC verschwindet.
+  - Test: derselbe Test wird mit zwei verschiedenen gesetzten Uhrzeiten ausgefuehrt (eine vor, eine
+    nach der alten Kippkante) und besteht beide Male.
+
+- **AC-4:** Given es existiert kein Trip-Bestand in der isolierten Datenwurzel / When
+  `test_ac2_preview_path_sets_source_vorschau` ausgefuehrt wird / Then legt der Test seine
+  Trip-Fixture unter `get_briefings_dir()` selbst an, skippt nicht und belegt `source == "vorschau"`.
+  - Test: Testlauf meldet fuer diesen Test weder `skipped` noch einen Zugriff auf `get_trips_dir`.
+
+- **AC-5:** Given es existiert kein Trip-Bestand in der isolierten Datenwurzel / When
+  `tests/tdd/test_issue_346_fixture_provider.py` ausgefuehrt wird / Then skippt **kein** Test der
+  Datei, und AC-6 belegt, dass `render_email_preview` im Fixture-Modus null echte
+  Open-Meteo-Calls ausloest.
+  - Test: Lauf mit `-rs` meldet null `SKIPPED`; die Call-Log-Pruefung des AC-6-Tests bleibt in Kraft.
+
+- **AC-6:** Given `get_trips_dir()` wird in Scheibe B2 entfernt / When
+  `tests/tdd/test_issue_1133_testdata_cleanup.py` ausgefuehrt wird / Then besteht der
+  Isolationsbeweis unveraendert, weil die Sonde ueber `get_briefings_dir()` laeuft.
+  - Test: AC-1 der Datei prueft weiterhin absoluten Pfad, Lage ausserhalb des Repo-Baums und
+    `save_trip()`-Roundtrip — jetzt ueber den lebenden Pfad.
+
+- **AC-7:** Given ein Zieltest des Subprozess-Wrappers skippt / When
+  `test_ac3_existing_six_tests_still_green` ausgefuehrt wird / Then schlaegt der Wrapper fehl statt
+  den Exit-Code 0 eines Skips als Beweis zu nehmen.
+  - Test: Gegenprobe — ein kuenstlich skippender Zieltest macht den Wrapper rot.
+
+- **AC-8:** Given `tests/tdd/test_pytest_collection_and_timeout_safety.py` fuehrt
+  `test_bug_338_openmeteo_call_counter.py` nicht mehr als Voll-Dialer / When der
+  Kollektions-Waechter laeuft / Then ist die erwartete Testzahl der Datei exakt festgeschrieben und
+  wird rot, sobald jemand den Modul-Marker zurueckholt.
+  - Test: der bestehende Waechter mit aktualisiertem Eintrag; Gegenprobe durch Wiedereinsetzen des
+    Modul-Markers.
+
+## Known Limitations
+
+- **Abgrenzung gemessen:** von 41 Testdateien mit Modul-weitem `pytestmark = pytest.mark.live`
+  beruehrt **genau eine** zusaetzlich den toten `trips/`-Pfad —
+  `test_bug_338_openmeteo_call_counter.py`. Die Doppel-Stilllegung ist ein Einzelfall, die Scheibe
+  muss dafuer nicht erweitert werden. Ob es unter den uebrigen 40 Dateien Stilllegungen aus
+  anderen Gruenden gibt, ist hier nicht untersucht.
+- Diese Scheibe beruehrt die 9 Referenz-Fixturen unter `tests/fixtures/data_root/users/*/trips/`
+  und die Spiegellogik in `tests/conftest.py:83-91` **nicht**. Sie speisen den Produktiv-Lesepfad
+  fremder Tests und gehoeren nach B2.
+- `src/app/loader.py::get_trips_dir()` bleibt bestehen; erst B2 entfernt sie samt der einen
+  Waechter-Ausnahme.
+- AC-2 legt die Marker-Zugehoerigkeit per Messung fest. Welche Tests nach dem Wegfall des
+  Modul-Markers im Fixture-Modus noch Netz brauchen, ist heute nicht sicher bekannt — die heutige
+  Messung entstand unter dem Marker, der den Fixture-Modus abschaltet. Die Zahl in AC-1/AC-8 wird
+  in der RED-Phase gemessen und dort festgeschrieben.
+- Wird beim Reaktivieren ein weiterer echter Fehlschlag sichtbar, ist das ein Befund. Er wird
+  gemeldet und nicht durch Abschwaechen der Erwartung beseitigt; ob er in dieser Scheibe behoben
+  oder als eigenes Issue gefuehrt wird, entscheidet sein Umfang.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Es wird keine Grundsatzentscheidung geaendert. Korrigiert wird eine
+  Test-Schicht-Einstufung aus #1211 Scheibe 2c, die als Codekommentar in
+  `test_pytest_collection_and_timeout_safety.py:155-162` steht: die Einstufung von
+  `test_bug_338_openmeteo_call_counter.py` als „Voll-Dialer, 100 % Netzcall" ist durch Messung
+  widerlegt. Die Korrektur wird an der Stelle begruendet, nicht still vorgenommen. ADR-0023
+  (Cutover `trips/` → `briefings/`) wird bestaetigt, nicht beruehrt.
+
+## Changelog
+
+- 2026-08-16: Initial spec created (#1708 Scheibe B1)

--- a/tests/tdd/test_bug_338_openmeteo_call_counter.py
+++ b/tests/tdd/test_bug_338_openmeteo_call_counter.py
@@ -21,8 +21,6 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.live
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -36,14 +34,23 @@ def _make_location(lat: float = 47.27, lon: float = 11.39):
 
 
 def _make_segment(lat: float = 47.27, lon: float = 11.39):
+    """#1708 B1 AC-3: Fenster relativ zu ``now`` statt fest auf 06:00-14:00 UTC
+    -- sonst ueberspringt trip_alert.py:1247-1249 das Segment ausserhalb dieses
+    Fensters (Kippkante 14:00 UTC). start liegt 1h VOR now (start.date() bleibt
+    auch um 00:xx UTC <= heute), end liegt 7h NACH now (end > now zu jeder
+    Uhrzeit) -- die vom Alarm-Pfad geprüfte Eigenschaft gilt so unabhaengig von
+    der Tageszeit.
+    """
     from app.models import GPXPoint, TripSegment
-    now = datetime.now(timezone.utc).replace(hour=6, minute=0, second=0, microsecond=0)
+    now = datetime.now(timezone.utc)
+    start = now - timedelta(hours=1)
+    end = now + timedelta(hours=7)
     return TripSegment(
         segment_id=1,
         start_point=GPXPoint(lat=lat, lon=lon, elevation_m=800),
         end_point=GPXPoint(lat=lat + 0.05, lon=lon + 0.05, elevation_m=1200),
-        start_time=now,
-        end_time=now + timedelta(hours=8),
+        start_time=start,
+        end_time=end,
         duration_hours=8.0,
         distance_km=12.0,
         ascent_m=500,
@@ -98,6 +105,15 @@ def _read_jsonl(path: Path):
 # AC-1: Erfolgreicher/429-fetch_forecast() haengt genau eine JSONL-Zeile an
 # ---------------------------------------------------------------------------
 
+# #1708 B1: `enrich_ensemble=False` (direkter Aufruf, kein Fallback-Pfad) --
+# gemessen mit `@pytest.mark.disable_socket` 2026-08-16: die primaere
+# httpx-Anfrage wirft eine pytest-socket-eigene RuntimeError-Unterklasse
+# (SocketBlockedError/SocketConnectBlockedError), die httpx NICHT als
+# httpx.RequestError erkennt (`_make_request`s `except httpx.RequestError`
+# in providers/openmeteo.py greift nicht) -- der Aufruf propagiert unge-
+# loggt. Ohne einen zweiten (Ensemble-)Aufruf, der das breiter faengt
+# (s. test_ac2_trend/test_ac2_preview), bleibt AC-1 offline unbeweisbar.
+@pytest.mark.live
 def test_ac1_fetch_forecast_appends_one_jsonl_line(tmp_path, monkeypatch):
     """
     AC-1: Ein echter fetch_forecast()-Aufruf (200 ODER 429) protokolliert genau
@@ -149,6 +165,19 @@ def test_ac1_fetch_forecast_appends_one_jsonl_line(tmp_path, monkeypatch):
 # AC-2: Quellen-Bestimmung — alarm (Alarm-Pfad) und trend (Mehrtages-Trend)
 # ---------------------------------------------------------------------------
 
+# #1708 B1: `_fetch_fresh_weather` ruft `fetch_segment_weather(..., enrich_
+# ensemble=False, ...)` -- bewusst (Bug #288, Quotenschutz im Alarm-Pfad).
+# Gemessen mit `@pytest.mark.disable_socket` 2026-08-16: OHNE die
+# Ensemble-Anreicherung gibt es keinen zweiten (breiter gefangenen)
+# Aufrufversuch, der den Log-Eintrag noch retten koennte (Befund identisch
+# zu test_ac1 -- der primaere httpx-Call wirft eine von httpx nicht als
+# RequestError erkannte pytest-socket-Exception und propagiert ungeloggt
+# bis trip_report_scheduler.py:1989). test_ac2_trend/test_ac2_preview
+# koennen offline bestehen, WEIL sie (anders als hier) mit `enrich_
+# ensemble=True` zusaetzlich einen Ensemble-Spread-Aufruf ausloesen, dessen
+# `except Exception` (statt `except httpx.RequestError`) auch diese
+# Exception faengt und protokolliert -- dieser Fallback fehlt hier absichtlich.
+@pytest.mark.live
 def test_ac2_alarm_path_sets_source_alarm(tmp_path, monkeypatch):
     """
     AC-2 (Alarm): Ein Abruf aus dem echten Alarm-Pfad
@@ -172,13 +201,39 @@ def test_ac2_alarm_path_sets_source_alarm(tmp_path, monkeypatch):
     )
 
 
+@pytest.mark.disable_socket  # #1708 B1: offline beweiskraeftig, s. Docstring
 def test_ac2_trend_path_sets_source_trend(tmp_path, monkeypatch):
     """
     AC-2 (Trend): Ein Abruf aus dem echten Mehrtages-Trend-Pfad
     TripReportSchedulerService._build_stage_trend liefert source == "trend".
+
+    #1708 B1: statt echtem Netz oder FixtureProvider (der NIE loggt, s.
+    providers/fixture.py) erzwingt dieser Test einen echten OpenMeteoProvider
+    UND sperrt jeden Socket (`@pytest.mark.disable_socket`). Gemessen
+    2026-08-16: der primaere Forecast-Call scheitert ungeloggt (httpx
+    erkennt die pytest-socket-Exception nicht als RequestError), ABER
+    `_build_stage_trend` loest mit dem Default `enrich_ensemble=True`
+    zusaetzlich einen Ensemble-Spread-Aufruf aus (`_fetch_ensemble_spread`,
+    providers/openmeteo.py:706), dessen `except Exception` (breiter als
+    `except httpx.RequestError`) JEDE Exception faengt und ueber
+    `_log_api_call` protokolliert -- mit `source == "trend"`, weil der
+    Stack weiterhin `_build_stage_trend` traegt. Deterministisch (Millise-
+    kunden, kein Netz), weil `enrich_ensemble=True` hier IMMER gesetzt ist.
+
+    Adversary F002 (#1708 B1): `@pytest.mark.disable_socket` ist hier keine
+    Nebensaechlichkeit, sondern schuetzt vor einem ZWEITEN, teureren
+    Netzpfad. Gemessen OHNE den Marker: gelingt der primaere Forecast-Call
+    (echtes Netz erreichbar), ruft `fetch_forecast()` im Erfolgsfall
+    `_enrich_thunder()` (providers/openmeteo.py:1209) -> `providers.
+    thunder_enrichment.enrich_thunder()` -> `providers/dwd.py` auf -- eine
+    ECHTE DWD-Radar-Dekompression, die im Adversary-Lauf ~30s dauerte und
+    damit fast exakt an den pytest-timeout(30s) stiess. Mit gesperrtem
+    Socket wird dieser Pfad nie erreicht (der primaere Call scheitert schon
+    vorher), das ist Teil der Absicherung, nicht nur der Ensemble-Fallback.
     """
     import providers.openmeteo as om
 
+    monkeypatch.delenv("GZ_TEST_FIXTURE_DIR", raising=False)  # echter Provider statt FixtureProvider (der nie loggt)
     log_path = tmp_path / "openmeteo_calls.jsonl"
     monkeypatch.setattr(om, "DIAGNOSTICS_PATH", log_path, raising=False)
 
@@ -196,22 +251,39 @@ def test_ac2_trend_path_sets_source_trend(tmp_path, monkeypatch):
     )
 
 
+@pytest.mark.disable_socket  # #1708 B1: offline beweiskraeftig, s. Docstring (Muster wie test_ac2_trend)
 def test_ac2_preview_path_sets_source_vorschau(tmp_path, monkeypatch):
     """
     AC-2 (Vorschau, F002-Fix): Ein Abruf aus dem echten Vorschau-Pfad
     PreviewService.render_email_preview liefert source == "vorschau"
     (NICHT "briefing"), obwohl intern _fetch_weather laeuft.
 
-    Echter Trip henning/5f534011 (KHW 403), echte Pipeline, kein Mock.
+    #1708 B1: die Trip-Fixture wird selbst in der isolierten Datenwurzel
+    angelegt statt im toten trips/-Pfad gesucht (dort ist sie unter
+    Isolation nie vorhanden -- der Test skippte deshalb IMMER). Kopiert das
+    committete Referenz-Trip gr221-mallorca nach briefings/ -- Vorbild
+    tests/tdd/test_epic_140_preview_endpoints.py::_seed_trip_fixture.
+
+    Socket-Sperre + echter Provider wie bei test_ac2_trend_path_sets_
+    source_trend (identischer Mechanismus: PreviewService._build_report
+    ruft _fetch_weather() mit Default enrich_ensemble=True, dessen
+    Ensemble-Spread-Fallback breiter faengt als der primaere Forecast-Call
+    und den Log-Eintrag liefert). Gemessen 2026-08-16, offline gruen.
     """
+    import shutil
     import providers.openmeteo as om
-    from app.loader import get_trips_dir
+    from app.loader import get_briefings_dir
 
-    trip_id, user_id = "5f534011", "henning"
-    trip_file = get_trips_dir(user_id) / f"{trip_id}.json"
-    if not trip_file.exists():
-        pytest.skip(f"Echter Trip {user_id}/{trip_id} nicht vorhanden")
+    trip_id, user_id = "gr221-mallorca", "b1-preview-proof"
+    src = (
+        REPO_ROOT / "tests" / "fixtures" / "data_root" / "users"
+        / "default" / "trips" / f"{trip_id}.json"
+    )
+    dst = get_briefings_dir(user_id) / f"{trip_id}.json"
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
 
+    monkeypatch.delenv("GZ_TEST_FIXTURE_DIR", raising=False)  # echter Provider statt FixtureProvider (der nie loggt)
     log_path = tmp_path / "openmeteo_calls.jsonl"
     monkeypatch.setattr(om, "DIAGNOSTICS_PATH", log_path, raising=False)
 
@@ -240,6 +312,15 @@ def test_ac2_preview_path_sets_source_vorschau(tmp_path, monkeypatch):
 # AC-3: Schreibfehler beim Logging wird geschluckt, fetch laeuft weiter
 # ---------------------------------------------------------------------------
 
+# #1708 B1: direkter Aufruf mit `enrich_ensemble=False` -- derselbe Befund
+# wie bei test_ac1 (gemessen 2026-08-16 mit @pytest.mark.disable_socket):
+# ohne Ensemble-Fallback bleibt der Log-Nachweis offline unerreichbar, UND
+# die eigentliche Zusicherung (Schreibfehler wird geschluckt, KEIN
+# FileNotFoundError/NotADirectoryError propagiert) wuerde durch die
+# zusaetzliche Socket-Exception verfaelscht (isinstance-Check schlaegt auf
+# die SocketBlockedError an statt auf die zu pruefende Schreibfehler-
+# Behandlung).
+@pytest.mark.live
 def test_ac3_unwritable_log_target_is_swallowed(tmp_path, monkeypatch):
     """
     AC-3: Ist das Diagnose-Ziel nicht beschreibbar, schluckt _log_api_call die

--- a/tests/tdd/test_issue_1133_testdata_cleanup.py
+++ b/tests/tdd/test_issue_1133_testdata_cleanup.py
@@ -42,7 +42,7 @@ def test_ac1_fixture_isolation_path_resolution_and_roundtrip(tmp_path, monkeypat
     aufruft / Then landet die Datei ausschliesslich im temporaeren
     Fixture-Root, und der echte data/users/-Baum bleibt unveraendert.
 
-    Teil A prueft reine Pfad-Auflösung (kein Schreiben): get_trips_dir()
+    Teil A prueft reine Pfad-Auflösung (kein Schreiben): get_briefings_dir()
     muss auf einen absoluten Pfad AUSSERHALB des Repos zeigen — das
     Erkennungsmerkmal fuer eine aktive Fixture-Isolation. Schlaegt fehl,
     weil get_data_dir() aktuell immer den relativen "data/users"-Pfad
@@ -53,24 +53,32 @@ def test_ac1_fixture_isolation_path_resolution_and_roundtrip(tmp_path, monkeypat
     den echten Baum niemals verschmutzen). Vor dem Fix haengt der
     geschriebene Pfad vom (versehentlich sicheren) chdir-Ziel ab; nach dem
     Fix haengt er ausschliesslich vom (unabhaengigen) Fixture-Root ab.
+
+    #1708 B1 (AC-6): die Sonde haengt hier bewusst an get_briefings_dir(),
+    nicht mehr an get_trips_dir() -- save_trip() schreibt bereits seit dem
+    #1250-Cutover (ADR-0023) nach briefings/, nicht mehr nach trips/.
+    get_trips_dir() faellt in Scheibe B2 komplett weg; die Sonde muss das
+    ueberstehen (Nachweis: tests/test_stillgelegte_testdateien.py::
+    test_ac6_isolationssonde_uebersteht_wegfall_von_get_trips_dir, ruft
+    diese Funktion mit per monkeypatch entferntem get_trips_dir auf).
     """
-    from app.loader import get_trips_dir, save_trip
+    from app.loader import get_briefings_dir, save_trip
     from app.trip import Trip
 
     # --- Teil A: Pfad-Auflösung, kein Schreiben ---------------------------
-    trips_dir = get_trips_dir("tdd-1133-proof")
-    assert trips_dir.is_absolute(), (
-        f"AC-1 verletzt: get_trips_dir() liefert relativen Pfad {trips_dir!r} "
-        "— autouse-Fixture existiert noch nicht"
+    briefings_dir = get_briefings_dir("tdd-1133-proof")
+    assert briefings_dir.is_absolute(), (
+        f"AC-1 verletzt: get_briefings_dir() liefert relativen Pfad "
+        f"{briefings_dir!r} — autouse-Fixture existiert noch nicht"
     )
-    assert not str(trips_dir.resolve()).startswith(str(REPO_ROOT)), (
-        f"AC-1 verletzt: get_trips_dir() zeigt weiterhin auf den echten "
-        f"Repo-Baum: {trips_dir}"
+    assert not str(briefings_dir.resolve()).startswith(str(REPO_ROOT)), (
+        f"AC-1 verletzt: get_briefings_dir() zeigt weiterhin auf den echten "
+        f"Repo-Baum: {briefings_dir}"
     )
 
     # --- Teil B: echter Roundtrip, sicher via chdir -------------------------
     real_trip_path = (
-        REPO_ROOT / "data" / "users" / "tdd-1133-proof" / "trips"
+        REPO_ROOT / "data" / "users" / "tdd-1133-proof" / "briefings"
         / "tdd-1133-proof.json"
     )
     assert not real_trip_path.exists(), (
@@ -79,7 +87,7 @@ def test_ac1_fixture_isolation_path_resolution_and_roundtrip(tmp_path, monkeypat
 
     monkeypatch.chdir(tmp_path)
     cwd_relative_path = (
-        tmp_path / "data" / "users" / "tdd-1133-proof" / "trips"
+        tmp_path / "data" / "users" / "tdd-1133-proof" / "briefings"
         / "tdd-1133-proof.json"
     )
     trip = Trip(id="tdd-1133-proof", name="RED-Proof", stages=[])

--- a/tests/tdd/test_issue_338_go_geosphere_counter.py
+++ b/tests/tdd/test_issue_338_go_geosphere_counter.py
@@ -19,6 +19,7 @@ Geosphere-Instrumentierung sowie die analyze-Skript-Erweiterung noch fehlen.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from datetime import datetime
@@ -39,6 +40,21 @@ def _read_jsonl(path: Path):
     if not path.exists():
         return []
     return [json.loads(ln) for ln in path.read_text().splitlines() if ln.strip()]
+
+
+def subprozess_lauf_ist_beweiskraeftig(proc: "subprocess.CompletedProcess") -> bool:
+    """#1708 B1 AC-7: Exit-Code 0 allein beweist nichts -- ein komplett
+    uebersprungener Lauf liefert ebenfalls Exit 0 (Befund #1708 B1: genau das
+    verdeckte den Skip aus test_bug_338_openmeteo_call_counter.py:211-213
+    bisher). Beweiskraeftig ist nur ein Lauf mit returncode 0, OHNE einen
+    einzigen Skip und mit mindestens einem tatsaechlich ausgefuehrten Test.
+    """
+    if proc.returncode != 0:
+        return False
+    if re.search(r"\bskipped\b", proc.stdout, re.IGNORECASE):
+        return False
+    match = re.search(r"(\d+) passed", proc.stdout)
+    return bool(match) and int(match.group(1)) > 0
 
 
 # ---------------------------------------------------------------------------
@@ -81,23 +97,40 @@ def test_ac2_geosphere_clouds_logs_source_geosphere_clouds(tmp_path, monkeypatch
 # AC-3: Die 6 bestehenden Tests aus bd8e1e2 bleiben grün (Konsolidierung)
 # ---------------------------------------------------------------------------
 
-@pytest.mark.live  # Dialt real bzw. fail-soft-Fetch (#1211 Scheibe 2c) -- nur via -m live
+@pytest.mark.live  # Dialt real bzw. fail-soft-Fetch (#1211 Scheibe 2c) -- nur via -m live.
+# #1708 B1: weiterhin berechtigt -- `-o addopts=` neutralisiert die
+# Marker-Filterung im Subprozess, 3 der 6 Zieltests (ac1, ac2_alarm, ac3)
+# brauchen echten Netzzugriff -- sie rufen mit `enrich_ensemble=False` ohne
+# den Ensemble-Spread-Fallback, der bei den anderen 3 (ac2_trend,
+# ac2_preview, ac4) den Offline-Log-Nachweis traegt (gemessen 2026-08-16,
+# Details s. test_bug_338_openmeteo_call_counter.py). Ein Standardlauf ohne
+# Marker wuerde also entweder haengen/timeouten (kein Netz im
+# deterministischen Kern) oder faelschlich "beweiskraeftig" aussehen, ohne
+# echten Netzzugriff gehabt zu haben.
 def test_ac3_existing_six_tests_still_green():
     """
     AC-3: Nach der Konsolidierung der Logging-Logik in `providers.call_log`
     müssen die 6 bestehenden Tests aus tests/tdd/test_bug_338_openmeteo_call_counter.py
     weiterhin grün sein (identisches Verhalten).
 
-    Wir führen sie als Sub-Prozess aus und prüfen den Exit-Code.
+    Wir führen sie als Sub-Prozess aus und prüfen mit
+    `subprozess_lauf_ist_beweiskraeftig` (#1708 B1 AC-7), dass der Lauf
+    tatsaechlich etwas bewiesen hat -- ein reiner Exit-Code-0-Check waere
+    auch bei einem komplett uebersprungenen Lauf gruen (Befund #1708 B1).
 
-    Scheibe 2c (#1211) Vakuum-Test-Fix: die Zieldatei traegt selbst
-    `pytestmark = pytest.mark.live`, daher deselektiert die geerbte
+    Scheibe 2c (#1211) Vakuum-Test-Fix: die Zieldatei trug frueher selbst
+    `pytestmark = pytest.mark.live`, daher deselektierte die geerbte
     pyproject-addopts (`-m 'not email and not live and not staging'`) ALLE
     6 Zieltests -- ohne `-o addopts=` lief dieser Subprozess bislang mit
     Exit 5 (no tests collected) durch: Zieltests wurden deselektiert, Lauf
     verifizierte nichts (Adversary F002, #1211-2c, empirisch korrigiert).
     `-o addopts=` neutralisiert die Marker-Filterung, damit die 6 Tests
-    tatsaechlich ausgefuehrt werden.
+    tatsaechlich ausgefuehrt werden -- das gilt nach #1708 B1 unveraendert,
+    weil der Modul-Marker der Zieldatei durch 6 Funktions-Marker ersetzt
+    wurde (3 live + 3 disable_socket/offline), die `-o addopts=` weiterhin
+    fuer die live-markierten neutralisiert (die 3 disable_socket-Tests
+    laufen ohnehin, unabhaengig von addopts, da das ein eigener Mechanismus
+    von pytest-socket ist).
     """
     existing = REPO_ROOT / "tests" / "tdd" / "test_bug_338_openmeteo_call_counter.py"
     assert existing.exists(), f"Bestehende Testdatei fehlt: {existing}"
@@ -108,9 +141,10 @@ def test_ac3_existing_six_tests_still_green():
         capture_output=True,
         text=True,
     )
-    assert proc.returncode == 0, (
+    assert subprozess_lauf_ist_beweiskraeftig(proc), (
         "Die 6 bestehenden bd8e1e2-Tests müssen nach der call_log-Konsolidierung "
-        f"grün bleiben.\nSTDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}"
+        f"grün bleiben (nicht nur Exit 0 -- kein Skip, mindestens 1 passed).\n"
+        f"STDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}"
     )
 
 

--- a/tests/tdd/test_issue_346_fixture_provider.py
+++ b/tests/tdd/test_issue_346_fixture_provider.py
@@ -21,16 +21,6 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 FIXTURE_DIR = str(REPO_ROOT / "fixtures" / "openmeteo")
 
 
-def _find_test_trip() -> tuple[str | None, str | None]:
-    """Ersten vorhandenen echten Trip finden (Alpen bevorzugt für Plausibilität)."""
-    from app.loader import get_trips_dir
-
-    for uid, tid in (("henning", "5f534011"), ("default", "gr221-mallorca")):
-        if (get_trips_dir(uid) / f"{tid}.json").exists():
-            return uid, tid
-    return None, None
-
-
 # ---------- AC-1: Protocol-Erfüllung ----------
 
 def test_ac1_fixture_provider_satisfies_protocol():
@@ -115,10 +105,23 @@ def test_ac5_timestamps_restamped_to_today():
 # ---------- AC-6: PreviewService rendert ohne echten Open-Meteo-Call ----------
 
 def test_ac6_preview_renders_without_real_api_call(monkeypatch, tmp_path):
-    """AC-6: render_email_preview läuft mit gesetzter ENV-Var offline (kein open-meteo-Call)."""
-    uid, tid = _find_test_trip()
-    if not uid:
-        pytest.skip("Kein echter Test-Trip in data/users vorhanden")
+    """AC-6: render_email_preview läuft mit gesetzter ENV-Var offline (kein open-meteo-Call).
+
+    #1708 B1: die Trip-Fixture wird selbst in der isolierten Datenwurzel
+    angelegt statt im toten trips/-Pfad gesucht (dort ist sie unter Isolation
+    nie vorhanden -- der Test skippte deshalb IMMER, unabhaengig vom
+    Bestand). Kopiert das committete Referenz-Trip gr221-mallorca nach
+    briefings/ -- Vorbild
+    tests/tdd/test_epic_140_preview_endpoints.py::_seed_trip_fixture.
+    """
+    import shutil
+    from app.loader import get_briefings_dir
+
+    uid, tid = "b1-346-preview-proof", "gr221-mallorca"
+    src = REPO_ROOT / "tests" / "fixtures" / "data_root" / "users" / "default" / "trips" / f"{tid}.json"
+    dst = get_briefings_dir(uid) / f"{tid}.json"
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
 
     monkeypatch.setenv("GZ_TEST_FIXTURE_DIR", FIXTURE_DIR)
 

--- a/tests/tdd/test_pytest_collection_and_timeout_safety.py
+++ b/tests/tdd/test_pytest_collection_and_timeout_safety.py
@@ -23,6 +23,18 @@ Erweiterung Scheibe 2c (#1211c): 10 Dateien mit bislang modul-weitem
 Netz-Sperre-Probe-gruene Tests + 2 aus test_issue_338 kommen in die
 Standard-Selektion zurueck); 6 Voll-Dialer-Dateien bleiben unveraendert
 modul-live. Spec: docs/specs/modules/rework_1211c_live_feinschnitt.md
+
+#1708 B1 (2026-08-16): test_bug_338_openmeteo_call_counter.py wandert von
+den 6 Voll-Dialern (_C2_KEEP_MODULE_LIVE) nach _C2_SPLIT_FILES. Erste
+Messung (nur `--disable-socket`) ergab faelschlich 5 live/1 offline -- nach
+Ruecksprache und gezielter Nachmessung je Test (`@pytest.mark.disable_socket`
++ erzwungener echter Provider statt FixtureProvider) zeigte sich: 3 Tests
+(ac2_trend, ac2_preview, ac4) bestehen offline beweiskraeftig, weil
+`_build_stage_trend`/`_build_report` mit Default `enrich_ensemble=True`
+einen Ensemble-Spread-Fallback ausloesen, dessen `except Exception` breiter
+faengt als der primaere Forecast-Call und den Log-Eintrag liefert. Die
+verbleibenden 3 (ac1, ac2_alarm, ac3) rufen mit `enrich_ensemble=False`
+direkt/ohne diesen Fallback und bleiben live. Nur noch 5 Voll-Dialer-Dateien.
 """
 from __future__ import annotations
 
@@ -147,19 +159,42 @@ _C2_SPLIT_FILES = (
     ("tests/tdd/test_go_api_setup.py", 5, "live"),
     ("tests/tdd/test_snowgrid.py", 1, "live"),
     ("tests/tdd/test_issue_338_go_geosphere_counter.py", 2, "live"),
+    # #1708 B1: von _C2_KEEP_MODULE_LIVE hierher verschoben -- die dortige
+    # Begruendung ("Voll-Dialer, 100% Netzcall", #1211 Scheibe 2c) war
+    # zirkulaer gemessen (unter dem eigenen live-Marker, der den
+    # Offline-Fixture-Modus abschaltet, conftest.py:25-29).
+    #
+    # Erste Nachmessung (nur `--disable-socket -o addopts=`) ergab
+    # faelschlich nur 1 offline-faehigen Test (ac4) -- diese Messung deckte
+    # nicht auf, dass der Fixture-Modus die eigentliche Ursache war (siehe
+    # #1708-B1-Ruecksprache). Zweite, gezielte Messung je Einzeltest (echter
+    # Provider erzwungen via `monkeypatch.delenv("GZ_TEST_FIXTURE_DIR")` +
+    # `@pytest.mark.disable_socket` statt globalem CLI-Flag) zeigt: 3 Tests
+    # bestehen offline beweiskraeftig -- ac2_trend/ac2_preview (Default
+    # `enrich_ensemble=True` loest zusaetzlich zum primaeren Forecast-Call
+    # einen Ensemble-Spread-Fallback aus, dessen `except Exception` breiter
+    # faengt als `except httpx.RequestError` und darum trotz gesperrtem
+    # Socket protokolliert) sowie ac4 (reine Dateiarbeit). Die restlichen 3
+    # (ac1, ac2_alarm, ac3) rufen mit `enrich_ensemble=False` (Bug #288,
+    # Quotenschutz) OHNE diesen Fallback -- der primaere Call scheitert dort
+    # ungeloggt (httpx erkennt die pytest-socket-Exception nicht als
+    # `httpx.RequestError`) und bleibt live. Details je Test:
+    # test_bug_338_openmeteo_call_counter.py.
+    ("tests/tdd/test_bug_338_openmeteo_call_counter.py", 3, "live"),
 )
 _C2_SPLIT_PATHS = tuple(f for f, _, _ in _C2_SPLIT_FILES)
 
-# Scheibe 2c: 6 Voll-Dialer-Dateien (per Probe/Code 100% Netzcall) behalten
+# Scheibe 2c: 5 Voll-Dialer-Dateien (per Probe/Code 100% Netzcall) behalten
 # ihren Modul-Marker unveraendert -- Regressions-Waechter gegen
-# versehentliches Mit-Zurueckholen.
+# versehentliches Mit-Zurueckholen. test_bug_338_openmeteo_call_counter.py
+# ist #1708 B1 nach _C2_SPLIT_FILES gewandert (dort feingeschnitten, ein
+# Test bleibt im Standardlauf).
 _C2_KEEP_MODULE_LIVE = (
     "tests/integration/test_snapshot_plausibility.py",
     "tests/tdd/test_geosphere_parsing.py",
     "tests/integration/test_segment_weather_metrics.py",
     "tests/integration/test_segment_weather_cache.py",
     "tests/integration/test_cli_wintersport.py",
-    "tests/tdd/test_bug_338_openmeteo_call_counter.py",
 )
 
 # addopts liefert bereits ein "-q" -> Quiet-Level 2 -> kompaktes "pfad: N"-Format
@@ -472,29 +507,37 @@ def test_811_gate_test_skips_when_hook_missing(tmp_path):
 def test_c2_returned_tests_in_default_selection(
     default_collect, live_collect, c2_split_total_collect,
 ):
-    """GIVEN die 10 Scheibe-2c-teilgeschnittenen Dateien (74 Netz-Sperre-Probe-
-    gruene Tests + 2 aus test_issue_338, je Datei feinsortiert) WHEN
-    Standardlauf und `-m live`-Lauf gemeinsam betrachtet werden THEN zeigt
-    jede Datei im Standardlauf mindestens die erwartete Mindestzahl UND
+    """GIVEN die 11 Scheibe-2c/#1708-B1-teilgeschnittenen Dateien (74
+    Netz-Sperre-Probe-gruene Tests + 2 aus test_issue_338 + 3 aus
+    test_bug_338, je Datei feinsortiert) WHEN Standardlauf und `-m
+    live`-Lauf gemeinsam betrachtet werden THEN zeigt jede Datei im
+    Standardlauf EXAKT die erwartete Zahl (#1708 B1 Adversary F001: eine
+    Untergrenze faengt eine Verkleinerung des Tabellenwerts nicht) UND
     Standardlauf + `-m live` == marker-neutraler Gesamt-Count
-    (Partitionsnachweis, Muster test_b3_partial_files_partition) (AC-1/AC-5).
-    Schlaegt heute fehl, weil alle 10 Dateien noch den kompletten
+    (Partitionsnachweis, Muster test_b3_partial_files_partition) (AC-1/AC-5/AC-8).
+    Schlaegt heute fehl, weil alle 11 Dateien noch den kompletten
     Modul-Marker tragen -- der Standardlauf zeigt fuer jede 0 Tests statt
-    der erwarteten Mindestzahl."""
+    der erwarteten Zahl."""
     assert c2_split_total_collect.returncode == 0, c2_split_total_collect.stderr
 
     default_counts = _collected_counts(default_collect.stdout)
     marker_counts = {"live": _collected_counts(live_collect.stdout)}
     total_counts = _full_id_counts(c2_split_total_collect.stdout, _C2_SPLIT_PATHS)
 
-    for f, min_standard, marker in _C2_SPLIT_FILES:
+    for f, expected_standard, marker in _C2_SPLIT_FILES:
         std_n = default_counts.get(f, 0)
         marker_n = marker_counts[marker].get(f, 0)
         total_n = total_counts.get(f, 0)
         assert total_n > 0, f"{f}: marker-neutraler Gesamt-Count ist 0 -- Collect kaputt?"
-        assert std_n >= min_standard, (
-            f"{f}: Standardlauf zeigt {std_n} Tests, erwartet mindestens "
-            f"{min_standard} zurueckgeholte Tests."
+        # #1708 B1 Adversary F001: EXAKT statt `>=` -- eine Untergrenze faengt
+        # die eigentliche Mutation nicht (Tabellenwert runter auf 1 bei real 3
+        # gesammelten Tests blieb gruen). Gemessen 2026-08-16: `==` haelt fuer
+        # ALLE bestehenden Eintraege (kein zweiter, laxerer Waechter auf
+        # derselben Konstante noetig) -- die Tabellenwerte SIND bereits die
+        # exakten Standardlauf-Counts, nicht bloss Untergrenzen.
+        assert std_n == expected_standard, (
+            f"{f}: Standardlauf zeigt {std_n} Tests, erwartet EXAKT "
+            f"{expected_standard} zurueckgeholte Tests."
         )
         assert std_n + marker_n == total_n, (
             f"{f}: Standardlauf ({std_n}) + `-m {marker}` ({marker_n}) muss den "
@@ -504,14 +547,16 @@ def test_c2_returned_tests_in_default_selection(
 
 
 def test_c2_full_live_files_stay_excluded(default_collect):
-    """GIVEN die 6 Voll-Dialer-Dateien (per Netz-Sperre-Probe bzw. Code-Beleg
+    """GIVEN die 5 Voll-Dialer-Dateien (per Netz-Sperre-Probe bzw. Code-Beleg
     100% Netzcall: snapshot_plausibility, geosphere_parsing,
-    segment_weather_metrics, segment_weather_cache, cli_wintersport, bug_338)
-    WHEN der Standardlauf sammelt THEN bleiben alle 6 unveraendert bei 0
+    segment_weather_metrics, segment_weather_cache, cli_wintersport)
+    WHEN der Standardlauf sammelt THEN bleiben alle 5 unveraendert bei 0
     gesammelten Tests -- kein versehentliches Mit-Zurueckholen (AC-2,
     Regressions-Waechter, Muster test_offline_files_remain_in_default_selection).
     Darf schon heute gruen sein -- die Dateien tragen bereits ihren
-    Modul-Marker und sind davon durch Scheibe 2c nicht betroffen."""
+    Modul-Marker und sind davon durch Scheibe 2c nicht betroffen. bug_338
+    ist #1708 B1 nach _C2_SPLIT_FILES gewandert (test_c2_returned_tests_
+    in_default_selection deckt sie jetzt ab)."""
     assert default_collect.returncode == 0, default_collect.stderr
     default_counts = _collected_counts(default_collect.stdout)
     leaked = {

--- a/tests/test_stillgelegte_testdateien.py
+++ b/tests/test_stillgelegte_testdateien.py
@@ -1,0 +1,178 @@
+"""
+TDD RED Tests fuer #1708 Scheibe B1 -- stillgelegte Tests am toten
+`trips/`-Pfad reaktivieren.
+
+Jeder Test mappt auf ein AC aus
+docs/specs/modules/fix_1708_b1_tote_fixture_befunde.md und muss HEUTE rot
+sein. Kein Mock/patch/MagicMock, keine Dateiinhalt-Checks als
+Verhaltensnachweis -- alle Subprozess-Laeufe verankern sich relativ zur
+eigenen Testdatei, nie ueber einen festen Hauptrepo-Pfad.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from freezegun import freeze_time
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_ac1_bug338_wird_im_standardlauf_gesammelt():
+    """AC-1: test_bug_338_openmeteo_call_counter.py traegt heute einen
+    modul-weiten @pytest.mark.live-Marker (:24) -- ein Standardlauf
+    deselektiert dadurch alle 6 Tests. Nach dem Marker-Split auf
+    Funktionsebene muss die Datei im Standardlauf (normale addopts, kein
+    Marker-Override) erscheinen.
+    """
+    target = REPO_ROOT / "tests" / "tdd" / "test_bug_338_openmeteo_call_counter.py"
+    proc = subprocess.run(
+        ["uv", "run", "pytest", str(target), "--collect-only", "-q"],
+        cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=180,
+    )
+    match = re.search(r"test_bug_338_openmeteo_call_counter\.py:\s*(\d+)", proc.stdout)
+    collected = int(match.group(1)) if match else 0
+
+    if not match:
+        # Heute (Modul-`live`-Marker aktiv) deselektiert der Standardlauf ALLE
+        # 6 Tests -- pytest liefert dafuer exit 5 ("no tests collected") und
+        # unterdrueckt unter dem doppelten -q (addopts bringt bereits eines
+        # mit) sogar die Zusammenfassungszeile, stdout bleibt leer. Das ist
+        # der erwartete RED-Grund. Jeder ANDERE returncode bei leerem stdout
+        # waere ein Werkzeugfehler (uv/pytest nicht startbar) statt einer
+        # Aussage ueber den Marker -- getrennt gemeldet, damit die naechste
+        # Sitzung beide Faelle sofort auseinanderhalten kann.
+        assert proc.returncode == 5, (
+            "Kein Kollektionsergebnis im stdout UND unerwarteter Exit-Code -- "
+            "das deutet auf einen Werkzeugfehler (uv/pytest nicht startbar) "
+            f"hin, nicht auf den Marker-Defekt. returncode={proc.returncode}\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+
+    assert collected > 0, (
+        "AC-1 verletzt: Standardlauf sammelt keinen einzigen Test aus der "
+        f"Datei (Modul-`live`-Marker deselektiert alles, returncode="
+        f"{proc.returncode}). stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+
+
+def test_ac5_issue346_kein_test_skippt_mangels_trip_bestand():
+    """AC-5: `_find_test_trip()` (test_issue_346_fixture_provider.py:24-32)
+    sucht im toten `trips/`-Pfad und findet unter der isolierten
+    Datenwurzel nie etwas -- AC-6 der Datei skippt deshalb bei jedem Lauf
+    (`:121`). Nach dem Fix (Fixture selbst unter get_briefings_dir()
+    anlegen) darf kein Test der Datei mehr skippen.
+    """
+    target = REPO_ROOT / "tests" / "tdd" / "test_issue_346_fixture_provider.py"
+    proc = subprocess.run(
+        ["uv", "run", "pytest", str(target), "-q", "-rs"],
+        cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=180,
+    )
+    assert "SKIPPED" not in proc.stdout, (
+        f"AC-5 verletzt: ein Test der Datei skippt mangels Trip-Bestand:\n{proc.stdout}"
+    )
+
+
+def test_ac3_alarm_segment_eigenschaft_ist_zeitunabhaengig():
+    """AC-3: Die vom Alarm-Pfad (src/services/trip_alert.py:1247-1249)
+    gepruefte Eigenschaft -- `segment.end_time > now_utc` UND
+    `segment.start_time.date() <= now_utc.date()` -- muss fuer das von
+    `_make_segment()` gebaute Segment zu JEDER Tageszeit gelten, nicht nur
+    vormittags. `_make_segment()` baut das Fenster heute fest auf
+    06:00-14:00 UTC; um 23:00 UTC ist end_time bereits verstrichen -> rot.
+
+    Zwei feste, eingefrorene Zeitpunkte -- der Test selbst darf nicht
+    zeitabhaengig sein, das ist genau der Defekt, den wir beheben.
+    """
+    from tests.tdd.test_bug_338_openmeteo_call_counter import _make_segment
+
+    for frozen in ("2026-08-16T02:00:00+00:00", "2026-08-16T23:00:00+00:00"):
+        with freeze_time(frozen):
+            now_utc = datetime.now(timezone.utc)
+            segment = _make_segment()
+            assert segment.end_time > now_utc, (
+                f"AC-3 verletzt bei {frozen}: end_time {segment.end_time} liegt "
+                f"nicht nach now_utc {now_utc} -- trip_alert.py:1248 wuerde das "
+                "Segment ueberspringen"
+            )
+            assert segment.start_time.date() <= now_utc.date(), (
+                f"AC-3 verletzt bei {frozen}: start_time.date() "
+                f"{segment.start_time.date()} liegt nach now_utc.date() "
+                f"{now_utc.date()}"
+            )
+
+
+def test_ac6_isolationssonde_uebersteht_wegfall_von_get_trips_dir(tmp_path):
+    """AC-6: Die Isolationssonde in test_issue_1133_testdata_cleanup.py
+    (:57-75) muss den Wegfall von get_trips_dir() in Scheibe B2 ueberstehen
+    -- das gelingt nur, wenn sie stattdessen get_briefings_dir() befragt.
+
+    Gewaehlter Weg (gleichwertig zur im Auftrag skizzierten
+    Subprozess/`-p`-Variante -- ein conftest-freies Vorschalt-Skript waere
+    hier fragiler als der direkte Verhaltensbeweis, und conftest.py selbst
+    ruft an mehreren Stellen get_trips_dir() zur Session-Fixture-Zeit, was
+    ein sauberes Vorschalten erschweren wuerde): get_trips_dir() wird per
+    monkeypatch.delattr aus app.loader entfernt, danach wird die betroffene
+    Sondenfunktion direkt aufgerufen. Heute wirft das AttributeError, weil
+    Teil A der Sonde (:61-69) get_trips_dir() direkt aufruft -> rot.
+    """
+    import app.loader as loader
+    from tests.tdd.test_issue_1133_testdata_cleanup import (
+        test_ac1_fixture_isolation_path_resolution_and_roundtrip as sonde,
+    )
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.delattr(loader, "get_trips_dir", raising=False)
+        with pytest.MonkeyPatch.context() as sonde_mp:
+            try:
+                sonde(tmp_path, sonde_mp)
+            except (AttributeError, ImportError) as exc:
+                pytest.fail(
+                    "AC-6 verletzt: die Isolationssonde bricht ab, sobald "
+                    f"get_trips_dir() fehlt (Scheibe B2) -- {exc}"
+                )
+
+
+def test_ac7_subprozess_wrapper_ist_blind_fuer_uebersprungene_zieltests(tmp_path):
+    """AC-7: Der Subprozess-Wrapper (test_ac3_existing_six_tests_still_green)
+    prueft heute nur returncode == 0 und ist damit blind fuer einen
+    uebersprungenen Zieltest -- ein Skip liefert ebenfalls Exit 0.
+
+    Nachweis: eine winzige, garantiert skippende Testdatei wird exakt wie
+    der heutige Wrapper (`-o addopts=`) im Subprozess ausgefuehrt; das
+    liefert HEUTE returncode == 0 trotz Skip. Die gewuenschte Zukunft
+    prueft eine noch fehlende Hilfsfunktion
+    `subprozess_lauf_ist_beweiskraeftig(proc)`, die einen solchen Lauf
+    ablehnen soll. Sie existiert in test_issue_338_go_geosphere_counter.py
+    noch nicht -> ImportError -> legitimes RED.
+    """
+    from tests.tdd.test_issue_338_go_geosphere_counter import (
+        subprozess_lauf_ist_beweiskraeftig,
+    )
+
+    skip_datei = tmp_path / "test_garantiert_skip.py"
+    skip_datei.write_text(
+        "import pytest\n\n"
+        "def test_der_immer_skippt():\n"
+        "    pytest.skip('absichtlicher Skip fuer AC-7-Nachweis')\n"
+    )
+
+    proc = subprocess.run(
+        ["uv", "run", "pytest", str(skip_datei), "-q", "-o", "addopts="],
+        cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=180,
+    )
+    assert proc.returncode == 0, (
+        "Praebedingung verletzt: heutige Wrapper-Logik sollte bei einem Skip "
+        f"Exit 0 liefern, bekam {proc.returncode}\n{proc.stdout}\n{proc.stderr}"
+    )
+    assert "skipped" in proc.stdout.lower(), (
+        f"Praebedingung verletzt: Subprozess-Ausgabe sollte einen Skip melden:\n{proc.stdout}"
+    )
+
+    assert not subprozess_lauf_ist_beweiskraeftig(proc), (
+        "AC-7 verletzt: die Wrapper-Pruefung haette diesen skip-only Lauf als "
+        "NICHT beweiskraeftig ablehnen muessen"
+    )


### PR DESCRIPTION
Scheibe B1 von #1708. **Teilarbeit — schliesst #1708 nicht** (das tut Scheibe C).

## Der Befund

Drei Testdateien hingen am toten Pfad `data/users/<uid>/trips/<id>.json`. Der gemeinsame Fehler war
nicht der Pfad, sondern die Bauart: **die Tests suchen Trip-Bestand, statt ihn anzulegen.** Jeder
Testlauf laeuft in einer leeren, isolierten Datenwurzel — also finden sie nie etwas und steigen
still aus. Den Suchpfad auf `briefings/` umzubiegen haette daran nichts geaendert.

Gemessen, nicht vermutet:

| Datei | Zustand vorher |
|---|---|
| `test_bug_338_openmeteo_call_counter.py` | lief in **keinem** Lauf — `no tests collected (6 deselected)` durch Modul-`live`; nicht auf `ci_tdd_excludes.txt`, also unsichtbar; `/e2e-verify` faehrt sie auch nicht |
| `test_issue_346_fixture_provider.py` | AC-6 skippte deterministisch — die Kernzusage „Vorschau loest keinen echten Open-Meteo-Call aus" war unbewacht |
| `test_issue_1133_testdata_cleanup.py` | korrekt gruen, aber am sterbenden Pfad verankert |

Der Waechter, der die Gruenheit der ersten Datei behauptete
(`test_issue_338_go_geosphere_counter.py:84`), prueft `returncode == 0` — ein **geskippter** Test
liefert ebenfalls 0. Er war fuer genau den Fall konstruktionsbedingt blind, und er ist selbst
`live`-markiert.

## Zwei Funde, die vorher nirgends standen

1. **Der Alarm-Test war zeitabhaengig.** `_make_segment()` baute ein festes Fenster 06:00–14:00 UTC;
   `trip_alert.py:1247-1249` ueberspringt abgelaufene Segmente. Kippkante **14:00 UTC** — vormittags
   gruen, nachmittags rot. Der Alarm-Pfad selbst ist intakt.
2. **Die Begruendung des Marker-Waechters war zirkulaer.** `_C2_KEEP_MODULE_LIVE` hielt den Marker
   fest mit „100 % Netzcall" (#1211 2c). Diese Messung lief **mit** gesetztem Marker — und der
   entzieht `conftest.py:25-29` genau den Offline-Fixture-Modus. Der Marker stellte die Bedingung
   her, mit der er begruendet wurde.

## Was sich aendert

- Modul-`live` faellt. Marker jetzt auf Funktionsebene, **je Test gemessen** mit
  `--disable-socket --allow-hosts=127.0.0.1,::1`, Begruendung an der Zeile.
- **3 von 6 Tests laufen jetzt offline im deterministischen Kern** (vorher 0). Die drei uebrigen
  brauchen ehrlich einen echten Aufrufversuch: `_fetch_fresh_weather` laeuft bewusst mit
  `enrich_ensemble=False` (Quotenschutz #288), womit der Zusatzaufruf fehlt, der bei Trend und
  Vorschau den Protokolleintrag rettet.
- Zeitfenster relativ zu `now_utc` — die 14:00-UTC-Kippkante ist weg.
- Beide Skip-Faelle legen ihre Fixture selbst unter `get_briefings_dir()` an.
- Isolationssonde in #1133 auf `get_briefings_dir()` umgehaengt — ueberlebt damit Scheibe B2.
- Neuer Beweiskraft-Check lehnt Skip-only-Laeufe ab.
- Kollektions-Waechter prueft **exakt** statt Untergrenze (Adversary F001).

Kein Produktivcode. Nur `tests/` und Doku.

## Nachweis

- **TDD RED:** 5 Nachweise, alle rot vor dem Fix
- **GREEN:** 44 passed, 9 deselected, 0 failed — identisch mit gesperrten Sockets (25 passed in 2,0 s)
- **Adversary VERIFIED:** 2 Runden, 8/8 ACs, **8 Mutationen**. 6 werden gefangen; F001 (Untergrenze
  statt exakter Zahl) wurde behoben und die Mutation `3 -> 1` danach unabhaengig als rot
  nachgemessen (`assert 3 == 1`)
- Spec: `docs/specs/modules/fix_1708_b1_tote_fixture_befunde.md`

## Offen (nicht in dieser Scheibe)

- **B2:** restliche Testdateien umstellen, `get_trips_dir()` entfernen, Waechter-Ausnahme streichen
- **C:** die 14 toten Dateien archivieren und loeschen — **schliesst #1708**
- Nebenbefund fuer #1199: der `FixtureProvider` ruft den Aufruf-Zaehler nie auf. Fachlich richtig
  (Fixture-Abrufe verbrauchen kein Kontingent), aber dadurch ist die Herkunfts-Protokollierung
  offline prinzipiell nicht pruefbar — das ist der eigentliche Grund fuer die alte
  „Voll-Dialer"-Einstufung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
