### PR TITLE
feat(#1888): Kuerzel-Legende im Reiter Wetter-Metriken (E6 Scheibe B)

### DIFF
--- a/docs/context/fix-1888-e6b-kuerzel-legende.md
+++ b/docs/context/fix-1888-e6b-kuerzel-legende.md
@@ -1,0 +1,354 @@
+---
+issue: 1888
+epic: 1435
+etappe: E6
+scheibe: B
+schliesst: 1857
+voraussetzung: 1887
+created: 2026-08-16
+workflow: fix-1888-e6b-kuerzel-legende
+track: standard
+---
+
+# Context: fix-1888-e6b-kuerzel-legende
+
+## Request Summary
+
+Die Oberfläche zeigt SMS-Kürzel bei Wettergrößen bereits an (`K`, `D`, `FK`, `FD`, `N`, `FN`, …),
+erklärt aber nirgends, was sie bedeuten. Diese Scheibe ergänzt im Reiter „Wetter-Metriken" eine
+Legende, die Kürzel und Bedeutung aus **derselben Quelle wie die Marken** bezieht — als **ein**
+geteilter Baustein für Trip- **und** Ortsvergleich-Editor. Vorbild ist die bereits arbeitende
+Legende für amtliche Warnungen im selben Reiter.
+
+## Ausgangslage nach Scheibe A (#1887, gemerged in `8adc88d4`)
+
+Scheibe A hat die Trip-Kürzel ins Register geholt und die Tagesrichtungs-Kollision aufgelöst.
+**Folge für diese Scheibe: die Klartext-Bedeutungen existieren bereits** — es muss kein einziger
+Erklärtext neu erfunden werden.
+
+| Kürzel | metric_id | `label_de` (Registerwert) |
+|---|---|---|
+| `N` | `temperature_night` | Nacht-Tiefsttemperatur |
+| `K` | `temperature_day_low` | Tages-Tiefsttemperatur (Gehzeit) |
+| `D` | `temperature_day_high` | Tages-Höchsttemperatur (Gehzeit) |
+| `FN` | `wind_chill_night` | Gefühlte Nacht-Tiefsttemperatur |
+| `FK` | `wind_chill_day_low` | Gefühlte Tages-Tiefsttemperatur (Gehzeit) |
+| `FD` | `wind_chill_day_high` | Gefühlte Tages-Höchsttemperatur (Gehzeit) |
+
+Gemessen aus `src/app/metric_catalog.py` (Feld `sms_multi_symbols`, eingeführt `:76`).
+Damit beantwortet sich **AC-2** („warum drei Kürzel?") direkt aus vorhandenen Registerdaten.
+
+## Related Files
+
+### Frontend — Zielort
+
+| Datei | Relevanz |
+|---|---|
+| `frontend/src/lib/components/shared/WeatherMetricsTab.svelte` | **Zielkomponente.** Liegt bereits unter `shared/`, `context: 'route' \| 'vergleich'` (`:169`). Vorbild-Legende `:1210-1224` im Snippet `officialAlertsToggle` `:1189-1232` |
+| `.../shared/weather-metrics-tab/WeatherV2Reihenfolge.svelte` | Kürzel-Marke „Kurzform" je Metrik-Zeile; Prop `kuerzelById` `:54`, Nutzung `:87`/`:157`, Label-Render `:98` |
+| `.../shared/weather-metrics-tab/ThresholdMetricRow.svelte` | `<code>`-Kürzel, Prop `smsSymbol` `:21`, Render `:37` |
+| `.../shared/weather-metrics-tab/MultiSymbolMetricRow.svelte` | Mehrfach-Kürzel, Prop `symbols` `:11`, Render `:20-22` |
+| `.../shared/weather-metrics-tab/compareMetricSelection.ts` | Typ `CompareSelectionEntry` `:7-30` — trägt `label` **und** `sms_code` |
+| `.../shared/weather-metrics-tab/weatherMetricsTabSections.ts` | Abschnitts-Reihenfolge je Kontext |
+| `frontend/src/lib/types.ts` | `MetricEntry` `:159-165`/`:180-185` (`label` = `label_de`, `col_label`, `sms_code`) |
+
+### Frontend — Datenquellen im Scope der Zielkomponente
+
+| Kontext | Kürzel | Bedeutung/Label | Zeilen |
+|---|---|---|---|
+| `route` | `metricSymbols` (aus `/api/sms-symbols`) | `metricById` (aus `/api/metrics`, Feld `label`) | `:182-186` bzw. `:331-335` |
+| `vergleich` | `compareKuerzelById` | `compareMetricById` (Feld `label`) | `:1102-1106` bzw. `:1082-1096` |
+
+**Beide Paare liegen bereits im selben Scope und werden bereits gemeinsam an denselben
+Reihenfolge-Block gereicht** (`:1492-1502` route, `:1339` vergleich). Eine Legende dort braucht
+keine neue Ladelogik.
+
+### Backend — Quellen
+
+| Datei | Relevanz |
+|---|---|
+| `api/routers/config.py:30-69` | `/api/sms-symbols`; `metrics`-Eintrag = `{metric_id, sms_symbols}` — **kein `label`**; `hazards`-Eintrag hat `label` (`:66`) |
+| `api/routers/config.py:72+` | `/api/metrics`, serialisiert `label_de` als `label` (`:85`), filtert auf `selectable=true` |
+| `src/app/metric_catalog.py` | Register; `sms_multi_symbols` `:76`, `sms_code` `:69` |
+| `src/output/renderers/compare_metric_catalog.py:251-315` | `/api/compare/metrics`; `label` aus `get_metric(...).label_de` (`:286`/`:308`), `sms_code` (`:310`) |
+
+## Existing Patterns
+
+1. **Fail-soft-Legende** — `{#if smsSymbols}` … `{#each}` … `<code>Kürzel</code> Bedeutung`
+   (`WeatherMetricsTab.svelte:1210-1224`). Kein Kontext-Guard: die Warnungs-Legende erscheint in
+   **beiden** Kontexten. Genau dieses Muster verlangt AC-4 und AC-5.
+2. **Read-only-Serialisierung als eigener Endpunkt** — `/api/sms-symbols` wurde in #1318 AC-9
+   bewusst getrennt angelegt, damit Gefahrenarten nicht als wählbare Metriken missverstanden
+   werden (Docstring `api/routers/config.py:32-41`).
+3. **Kein zweites Vokabular im Frontend** — bereits durch einen Wächter erzwungen, siehe R3.
+
+## Dependencies
+
+- **Upstream:** `/api/sms-symbols`, `/api/metrics`, `/api/compare/metrics`; Register
+  `src/app/metric_catalog.py`. Alle drei Endpunkte werden von der Zielkomponente **heute schon**
+  geladen (`:461-466`, `:470`, `:499-527`).
+- **Downstream:** Sieben Mount-Punkte der Zielkomponente — `TripNewEditor` (2×),
+  `TripEditView`, `TripTabs`, `CompareTabs` (2×), `CompareNewEditor` (2×). Eine additive Legende
+  in der geteilten Komponente erreicht alle, ohne dass ein Mount angefasst wird.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1887_e6a_sms_kuerzel_register.md` — Scheibe A. Grenze ausdrücklich:
+  „**Keine Legende in der Oberfläche.** Das ist Scheibe B (#1888)" (`:481-485`).
+- `docs/specs/modules/fix_1435_e3b_sms_kuerzel.md` — E3b, Herkunft von `/api/sms-symbols`.
+- `docs/context/fix-1857-e6-temp-register.md` — Analyse und Messbelege der Gesamt-Etappe,
+  Scheiben-Zuschnitt `:334-339`, Scope-Schätzung Scheibe B `:346`.
+
+## Bestehende Tests (Ausgangspunkt und Wächter)
+
+| Datei | Was sie prüft | Art |
+|---|---|---|
+| `frontend/src/lib/components/shared/__tests__/officialAlertLegend.test.ts` | Struktur der Vorbild-Legende `:81-126`; Legende in **beiden** Kontexten `:213-292`; Ladepfad im Vergleich `:294-360`; **„keine zweite Liste"-Wächter** `:365-425` | Quelltext-/AST-Analyse, **kein DOM, kein Browser** |
+| `.../shared/__tests__/weather_metric_kuerzel_marken.test.ts` | Marken je Kontext aus der jeweiligen Registerquelle `:381-400`, `:443-490` | Quelltext-/AST-Analyse |
+| `frontend/e2e/kuerzel-marken-sichtbar.staging.spec.ts` | holt `/api/sms-symbols` (`:164`) und vergleicht mit den **gerenderten** Marken (`:417`ff) | Playwright, echter Browser |
+| `frontend/e2e/weather-metrics-editor-day-range-kuerzel.spec.ts:110-135` | Kürzel-Badges in „04 — Schwellwerte" | Playwright, echter Browser |
+
+## Risks & Considerations
+
+### R1 — Die Kürzel-Mengen sind je Kontext VERSCHIEDEN 🔴
+
+Nicht nur die Quelle unterscheidet sich, sondern der Inhalt:
+
+| | Trip (`/api/sms-symbols`) | Vergleich (`/api/compare/metrics`) |
+|---|---|---|
+| Schlüssel | `metric_id` | Compare-Key = Paar (metric_id, Auswertung) |
+| Kardinalität | mehrere Kürzel je Größe möglich (`thunder` → `TH`, `TH+`) | 0..1 Kürzel je Zeile, dafür **mehrere Zeilen mit demselben Kürzel** |
+| `N/K/D/FN/FK/FD` | vorhanden | **kommen dort gar nicht vor** |
+| `TF` | nicht vorhanden | vorhanden |
+
+**Folge für AC-2:** Die Zusicherung „der Nutzer erkennt, dass `FK`/`FD`/`FN` dieselbe Größe in
+verschiedenen Tagesrichtungen bezeichnen" ist **nur im Trip-Kontext einlösbar** — im Ortsvergleich
+existieren diese Kürzel nicht. AC-5 (Legende in beiden Flächen) bleibt gültig, aber mit je
+kontexteigenem **Inhalt**. Eine gemeinsame, fest verdrahtete Liste wäre in beiden Kontexten falsch.
+
+### R2 — Vorbestehende Kürzel-Kollision im Ortsvergleich 🔴
+
+`/api/compare/metrics` liefert `sms_code="D"` für **zwei** Zeilen (`temperature_max` und
+`temperature_min`) und `TF` für zwei weitere (`wind_chill` min/max). Gemessen und dokumentiert in
+`docs/context/fix-1857-e6-temp-register.md:260-261` (G4); Scheibe A hat das ausdrücklich **nicht**
+behoben (`fix_1887_e6a_sms_kuerzel_register.md:502-504`).
+
+Eine Legende, die pflichtgemäß dieselbe Quelle wie die Marken benutzt (AC-3), zeigt dort also
+`D` zweimal mit widersprüchlicher Bedeutung. **Entscheidungspunkt für die Spec** (Optionen in der
+Analyse-Phase zu bewerten, nicht hier vorwegzunehmen). Wichtig: Die Kollision ist nutzersichtbar
+falsch und damit nach der Nebenbefund-Triage (a) ein **eigenes Issue** wert — sie in dieser
+Scheibe mitzubeheben wäre Scope-Ausweitung.
+
+### R3 — Der „keine zweite Liste"-Wächter trifft diese Arbeit direkt
+
+`officialAlertLegend.test.ts:365-425` scannt **alle** Quellen unter `frontend/src` auf hartkodierte
+Kürzel-Zuordnungen. Eine Legende mit eigener Bedeutungstabelle im Frontend würde ihn rot machen.
+Das ist ein Verbündeter für AC-3, kein Hindernis — aber die Umsetzung muss von Anfang an über die
+vorhandenen `label`-Felder joinen.
+
+### R4 — `cape`/`CP` hat im Trip-Pfad kein erreichbares Label
+
+`/api/sms-symbols` führt `cape` mit Kürzel `CP`; `/api/metrics` filtert auf `selectable=true` und
+lässt `cape` weg (`src/app/metric_catalog.py:949-957`). Ein Join `metricSymbols × metricById` deckt
+damit 27 von 28 Kürzel-Größen ab.
+
+**Zu messen, nicht zu raten:** Wird `CP` überhaupt als Marke gerendert? Wenn nein, ist die Lücke
+folgenlos. Wenn ja, zeigt die Oberfläche ein Kürzel ohne Erklärung — dann verlangt AC-1 eine
+Lösung, und die saubere wäre ein `label`-Feld in `/api/sms-symbols` analog zu `hazards[].label`
+(`api/routers/config.py:66`). Das wären ~2 Zeilen Backend und bliebe im Sinne von AC-3
+**eine** Quelle. Der Ticket-Text schließt „Register- und Backend-Änderungen" aus — gemeint ist
+dort das Register (#1887); eine Serialisierungs-Ergänzung am Legenden-Datenpfad ist davon zu
+unterscheiden und in der Spec explizit zu entscheiden.
+
+### R5 — Nachweis-Schicht: der Vorbild-Test taugt nicht als Vorbild
+
+Die bestehende Legenden-Prüfung ist Quelltext-Analyse. AC-6 (Handy 320–899 px, vollständig
+lesbar) und AC-7 (Kontrast ≥ 4.5:1) sind so **nicht** belegbar — Präzedenzfall #1446: eine Tabelle
+mit `display:none` meldet per DOM-Abfrage fälschlich „sichtbar". Für diese beiden ACs ist ein
+echter Browser Pflicht; Muster liefert `frontend/e2e/kuerzel-marken-sichtbar.staging.spec.ts`.
+Erfahrungswert: der Nachweis kostet mehr als der Mechanismus — beim LoC-Budget doppelt ansetzen.
+
+### R6 — Platzierung muss beide Kontexte treffen
+
+Der einzige Block, den beide Kontexte teilen **und** der die Kürzel bereits erhält, ist der
+Reihenfolge-Block (`:1479-1512` route, `:1313-1345` vergleich). Die Kürzel-Marken erscheinen
+im Trip-Kontext zusätzlich in „04 — Schwellwerte" (`:1559-1730`), den es im Vergleich nicht gibt.
+Eine Legende am Reihenfolge-Block erreicht beide Flächen mit einem Baustein; ob sie damit nah
+genug an den Schwellwert-Marken steht, ist eine Design-Frage für die Spec.
+
+### R7 — Additiv in einer Komponente mit sieben Mount-Punkten
+
+`WeatherMetricsTab.svelte` ist 1991 Zeilen lang und wird siebenfach gemountet. Die Änderung ist
+rein additiv und fail-soft, aber ein Fehler wirkt überall. Regression-Absicherung der
+bestehenden Reiter gehört in die Testliste.
+
+## Scope Assessment (Intake: Standard Track, Summe 1)
+
+| | Schätzung |
+|---|---|
+| Produktiv-Dateien | 1 sicher (`WeatherMetricsTab.svelte`), +1 bedingt (`api/routers/config.py`, nur falls R4 greift) |
+| Produktiv-LoC | ~40–80 |
+| Test-Dateien | ~2–3 (Vitest-Struktur + Playwright für AC-6/AC-7) |
+| Test-LoC | ~120–180 |
+| Risiko | LOW–MEDIUM — reine Anzeige, aber zwei Kontexte mit verschiedenen Vokabularen |
+
+## Open Questions (in die Analyse-Phase, nicht hier entscheiden)
+
+- [ ] **F1:** Wird `CP` als Marke gerendert? (entscheidet R4 — Backend-Zeile ja/nein)
+- [ ] **F2:** Wie geht die Legende im Ortsvergleich mit doppelten Kürzeln um (R2)?
+- [ ] **F3:** Platzierung — nur am Reihenfolge-Block, oder zusätzlich bei „04 — Schwellwerte"? (R6)
+
+---
+
+# Analysis (Phase 2, 2026-08-16)
+
+## Type
+
+Feature-Ergänzung in der Oberfläche (Anzeige), rein additiv, fail-soft. Kein Schreibpfad,
+kein Versandpfad, keine Persistenz, keine Auth.
+
+## Was gemessen wurde (nicht gelesen)
+
+### M1 — `CP` ist die einzige Lücke, und sie ist folgenlos → **kein Backend-Anteil** ✅
+
+Auszählung über das Register (`_METRICS` × `SMS_SYMBOL_BY_METRIC`/`SMS_MULTI_SYMBOLS_BY_METRIC`):
+
+```
+Kuerzel-Groessen gesamt: 28
+davon NICHT in /api/metrics (selectable=False): 1
+   ('cape', ['CP'], 'Gewitterenergie (CAPE)')
+```
+
+Gegenprobe im Frontend: `grep -n "cape\|CP" WeatherMetricsTab.svelte weather-metrics-tab/*` →
+**keine Fundstelle**. `cape` hat im Reiter keine Zeile (die Zeilen stammen aus `/api/metrics`,
+das `selectable=False` herausfiltert) und erscheint deshalb auch nicht als Marke.
+
+**Folge:** Wird die Legende aus der Menge der **gerenderten** Größen gespeist statt aus dem rohen
+Kürzel-Katalog, entsteht kein Eintrag ohne Bedeutung. R4 entfällt, `/api/sms-symbols` bleibt
+unangetastet, die Scheibe bleibt **reines Frontend** — im Einklang mit der Ticket-Grenze
+„Register- und Backend-Änderungen sind #1887".
+
+Umgekehrt gilt: Eine Legende, die naiv über `smsSymbols.metrics` iteriert, produziert genau **einen**
+Eintrag `CP` ohne Label. Das ist die zu vermeidende Umsetzung und gehört als Zusicherung bewacht.
+
+### M2 — Die Kollision im Ortsvergleich löst sich über die Auswertung auf ✅
+
+Auszählung über `get_compare_metric_catalog()`:
+
+```
+Compare-Zeilen gesamt: 25 | mit sms_code: 25 | verschiedene Kuerzel: 23
+  D   -> ('temp_max_c', 'Temperatur', 'Maximum') / ('temp_min_c', 'Temperatur', 'Minimum')
+  TF  -> ('wind_chill_min_c', 'Gefühlte Temperatur', 'Minimum') / ('wind_chill_max_c', ..., 'Maximum')
+```
+
+Entscheidend: Der Compare-Katalog liefert **`label` UND `aggregation_label`** in derselben Antwort
+(`CompareSelectionEntry`, `compareMetricSelection.ts:7-30`). Eine Legende der Form
+`Kürzel — Label (Auswertung)` ist damit **eindeutig lesbar**, obwohl das Kürzel doppelt vorkommt:
+
+```
+D   Temperatur (Maximum)
+D   Temperatur (Minimum)
+```
+
+**Auflösung von F2:** Die Legende zeigt **beide** Zeilen, statt zu entdoppeln. Das ist die einzige
+Variante, die AC-3 einhält (dieselbe Quelle wie die Marken — und die Marken zeigen das Kürzel
+tatsächlich an beiden Zeilen). Sie macht die vorbestehende Doppelbelegung sichtbar, statt sie zu
+kaschieren.
+
+### M2b — Nachmessung: die **zugestellte** Vergleichs-SMS ist NICHT mehrdeutig ✅ Korrektur zu R2
+
+Die zunächst naheliegende Sorge („in der Vergleichs-SMS trägt `D` zwei verschiedene Werte") ist
+**falsch**. Gemessen in `src/output/renderers/comparison.py:647-650`:
+
+```python
+code = get_sms_code(catalog_id) if catalog_id else ""
+...
+code = f"{code}{_sms_aggregation_sign(metric_id)}"
+```
+
+Die Vergleichs-SMS hängt das Auswertungszeichen an: Temperatur-Maximum wird `D+`, Minimum `D-`.
+Die Doppelbelegung des rohen `sms_code` ist damit ein Merkmal des Katalogfeldes, **nicht** ein
+Defekt der Ausgabe. Kein eigenes Issue aus diesem Grund.
+
+**Aber:** Die Marken in der Oberfläche zeigen den rohen `sms_code` ohne Zeichen
+(`compareKuerzelById`, `:1102-1106`) — der Nutzer liest im Editor `D`, in seiner SMS aber `D+`.
+Das ist eine kleine, echte Lücke zwischen Anzeige und Zustellung, aber **nicht Gegenstand dieser
+Scheibe** (sie beträfe die Marken, nicht die Legende). Einordnung: Sammel-Eintrag in #1199 nach
+der Auslieferung, kein eigenes Issue.
+
+**Folge für die Legende:** Sie bleibt bei der Form der Marken (`D`, ohne Zeichen) — AC-3 verlangt
+dieselbe Quelle wie die Marken. Die Eindeutigkeit stellt der Text her: `D — Temperatur (Maximum)`.
+
+### M3 — AC-2 ist im Ortsvergleich strukturell nicht einlösbar 🔴 Ticket-Prämisse zu eng
+
+`N/K/D/FN/FK/FD` gehören zu den Größen `temperature_night`/`_day_low`/`_day_high` und
+`wind_chill_night`/`_day_low`/`_day_high`. Diese existieren **nur** im Trip-Pfad; der
+Compare-Katalog kennt stattdessen `temp_min_c`/`temp_max_c` und `wind_chill_min_c`/`_max_c`
+mit den Kürzeln `D` und `TF`.
+
+AC-2 („der Nutzer erkennt, dass `FK`/`FD`/`FN` dieselbe Größe in verschiedenen Tagesrichtungen
+bezeichnen") ist deshalb eine Zusicherung über den **Trip-Editor**. Im Ortsvergleich gäbe es
+nichts zu erkennen. AC-5 (Legende in beiden Flächen) bleibt unberührt gültig — nur der **Inhalt**
+ist je Kontext ein anderer. Das ist in der Spec zu präzisieren, sonst entsteht ein strukturell
+nie erfüllbares Kriterium.
+
+## Technical Approach (Empfehlung)
+
+### Ein Baustein, zwei Speisungen
+
+Die Legende entsteht als **ein** Snippet/eine Komponente in
+`frontend/src/lib/components/shared/WeatherMetricsTab.svelte` — der Datei, die beide Kontexte
+bereits teilen und die alle sieben Mount-Punkte versorgt. AC-5 ist damit strukturell erfüllt,
+ohne dass ein Mount angefasst wird.
+
+Gespeist wird sie je Kontext aus dem Paar, das im selben Scope **bereits** nebeneinanderliegt und
+schon heute gemeinsam an den Reihenfolge-Block gereicht wird:
+
+| Kontext | Kürzel | Bedeutung |
+|---|---|---|
+| `route` | `metricSymbols` (`:182-186`) | `metricById[...].label` (`:331-335`) |
+| `vergleich` | `compareKuerzelById` (`:1102-1106`) | `compareMetricById[...].label` + `.aggregation_label` (`:1082-1096`) |
+
+Keine neue Ladelogik, kein neuer Endpunkt, keine zweite Liste — damit hält AC-3 und der
+vorhandene Wächter `officialAlertLegend.test.ts:365-425` bleibt grün.
+
+### Platzierung
+
+Unmittelbar am **Reihenfolge-Block** (`:1479-1512` route, `:1313-1345` vergleich). Begründung:
+Es ist der einzige Block, den beide Kontexte teilen, er zeigt **alle** Größen (auch die
+abgewählten, Aus-Gruppe `WeatherV2Reihenfolge.svelte:174-178`) und er erhält `kuerzelById`
+bereits. Die zusätzlichen Marken in „04 — Schwellwerte" (nur `route`) sind eine Teilmenge und
+werden von derselben Legende miterklärt — AC-1 verlangt „dort im Reiter", nicht „neben jeder
+einzelnen Marke".
+
+### Fail-soft
+
+Muster der Warnungs-Legende: Guard auf die geladenen Daten (`{#if ...}`), kein Kontext-Guard.
+Fehlt die Quelle, entfällt die Legende still, der Reiter bleibt bedienbar (AC-4).
+
+## Nachweis-Strategie
+
+| AC | Schicht | Warum |
+|---|---|---|
+| AC-1, AC-2, AC-3, AC-5 | Kern (Vitest, Struktur/Datenfluss) | Zusicherung über Datenherkunft und Vorkommen in beiden Kontexten |
+| AC-4 | Kern | Guard-Verhalten bei fehlender Quelle |
+| **AC-6, AC-7** | **Live (Playwright, echter Browser)** | Sichtbarkeit bei 320–899 px und Kontrast sind per DOM-Abfrage nicht belegbar — Präzedenzfall #1446 |
+
+Zusätzlich als Mutations-Gegenprobe vorzusehen: Legende naiv über `smsSymbols.metrics` speisen
+(muss `CP` ohne Label erzeugen und rot werden, s. M1) sowie im Vergleichs-Kontext entdoppeln
+(muss rot werden, s. M2).
+
+## Auflösung der offenen Fragen
+
+- **F1 — beantwortet:** `CP` wird nicht als Marke gerendert; Legende aus der gerenderten Menge
+  speisen ⇒ **kein Backend-Anteil**, Scheibe bleibt reines Frontend.
+- **F2 — beantwortet:** Beide Zeilen zeigen, `Kürzel — Label (Auswertung)`; die vorbestehende
+  Doppelbelegung wird sichtbar gemacht, nicht behoben (eigenes Issue).
+- **F3 — beantwortet:** Am Reihenfolge-Block, dem einzigen von beiden Kontexten geteilten Ort mit
+  vollständiger Größen-Liste.
+
+## Neue offene Frage an den PO
+
+- [ ] **F4:** AC-2 gilt nach M3 nur für den Trip-Editor. Vorschlag: AC-2 ausdrücklich auf den
+      Trip-Editor beziehen und für den Ortsvergleich ein eigenes, dort erfüllbares Kriterium
+      formulieren (Kürzel + Größe + Auswertung sind ablesbar). Freigabe erfolgt mit der Spec.

--- a/docs/context/fix-1888-e6b-kuerzel-legende.md
+++ b/docs/context/fix-1888-e6b-kuerzel-legende.md
@@ -118,7 +118,7 @@ Nicht nur die Quelle unterscheidet sich, sondern der Inhalt:
 |---|---|---|
 | Schlüssel | `metric_id` | Compare-Key = Paar (metric_id, Auswertung) |
 | Kardinalität | mehrere Kürzel je Größe möglich (`thunder` → `TH`, `TH+`) | 0..1 Kürzel je Zeile, dafür **mehrere Zeilen mit demselben Kürzel** |
-| `N/K/D/FN/FK/FD` | vorhanden | **kommen dort gar nicht vor** |
+| Größen hinter `N/K/D/FN/FK/FD` | vorhanden | **kommen dort gar nicht vor** — Präzisierung: das Zeichen `D` erscheint im Compare-Katalog sehr wohl, aber für eine **andere** Größe (`temp_max_c`/`temp_min_c`); `K`/`N`/`FK`/`FD`/`FN` fehlen dort ganz |
 | `TF` | nicht vorhanden | vorhanden |
 
 **Folge für AC-2:** Die Zusicherung „der Nutzer erkennt, dass `FK`/`FD`/`FN` dieselbe Größe in
@@ -219,8 +219,26 @@ davon NICHT in /api/metrics (selectable=False): 1
    ('cape', ['CP'], 'Gewitterenergie (CAPE)')
 ```
 
-Gegenprobe im Frontend: `grep -n "cape\|CP" WeatherMetricsTab.svelte weather-metrics-tab/*` →
-**keine Fundstelle**. `cape` hat im Reiter keine Zeile (die Zeilen stammen aus `/api/metrics`,
+Gegenprobe im Frontend: **keine Fundstelle** für `cape` oder `CP` in
+`WeatherMetricsTab.svelte` und `weather-metrics-tab/*`.
+
+> ⚠️ **Zur Suchmethode — nicht `grep` benutzen.** Die erste Fassung dieser Gegenprobe stützte
+> sich auf `grep` und war damit wertlos: `grep` ist auf `WeatherMetricsTab.svelte` in dieser
+> Umgebung vollständig blind. Positivkontrolle, gemessen 2026-08-16:
+>
+> ```
+> grep -c .          WeatherMetricsTab.svelte              -> keine Ausgabe, exit 1
+> grep -c div        WeatherMetricsTab.svelte              -> keine Ausgabe, exit 1
+> grep -c .          weather-metrics-tab/kuerzelLegende.ts -> 66   (grep funktioniert hier)
+> awk 'END{print NR}' WeatherMetricsTab.svelte             -> 2062
+> awk '/kuerzelLegende/{n++} END{print n+0}'               -> 6
+> ```
+>
+> `grep -c .` zählt Zeilen mit irgendeinem Zeichen — null Treffer bei 2062 Zeilen ist ein
+> Werkzeugausfall, kein Suchergebnis. **Auf dieser Datei gilt „nichts gefunden" nur mit
+> danebenstehender Positivkontrolle.** Verlässlich sind `awk`, `sed -n`, `wc -l`, `od`,
+> `git diff` und der AST-Weg über `svelte/compiler`. Die obige Gegenprobe ist mit `awk`
+> wiederholt worden und hält (`cape` 0, `CP` 0, Positivkontrolle `kuerzelLegende` 6). `cape` hat im Reiter keine Zeile (die Zeilen stammen aus `/api/metrics`,
 das `selectable=False` herausfiltert) und erscheint deshalb auch nicht als Marke.
 
 **Folge:** Wird die Legende aus der Menge der **gerenderten** Größen gespeist statt aus dem rohen

--- a/docs/specs/modules/fix_1888_e6b_kuerzel_legende.md
+++ b/docs/specs/modules/fix_1888_e6b_kuerzel_legende.md
@@ -3,7 +3,7 @@ entity_id: fix_1888_e6b_kuerzel_legende
 type: feature
 created: 2026-08-16
 updated: 2026-08-16
-status: draft
+status: approved
 version: "1.1"
 tags: [frontend, weather-metrics-tab, sms, legende, compare, trip]
 workflow: fix-1888-e6b-kuerzel-legende
@@ -13,7 +13,9 @@ workflow: fix-1888-e6b-kuerzel-legende
 
 ## Approval
 
-- [ ] Approved
+- [x] Approved — PO, 2026-08-16 („go"). Freigegeben wurde ausdrücklich auch
+  die Teilung von AC-2 (Trip-Editor) und AC-2a (Ortsvergleich) gegenüber dem
+  Ticket-Text, begründet durch Messung M3 im Kontext-Dokument.
 
 ## Purpose
 

--- a/docs/specs/modules/fix_1888_e6b_kuerzel_legende.md
+++ b/docs/specs/modules/fix_1888_e6b_kuerzel_legende.md
@@ -1,0 +1,414 @@
+---
+entity_id: fix_1888_e6b_kuerzel_legende
+type: feature
+created: 2026-08-16
+updated: 2026-08-16
+status: draft
+version: "1.1"
+tags: [frontend, weather-metrics-tab, sms, legende, compare, trip]
+workflow: fix-1888-e6b-kuerzel-legende
+---
+
+# Fix #1888 — Etappe E6 Scheibe B: Legende für SMS-Kürzel im Reiter „Wetter-Metriken"
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Der Reiter „Wetter-Metriken" zeigt SMS-Kürzel (`K`, `D`, `FK`, `FD`, `N`, `FN`, …)
+neben jeder Größe an, erklärt aber nirgends, was sie bedeuten. Diese Scheibe
+ergänzt eine Legende, die Kürzel und Bedeutung aus **derselben Quelle wie die
+Marken selbst** bezieht — als **ein** geteilter Baustein für Trip- **und**
+Ortsvergleich-Editor, nach dem Vorbild der bereits arbeitenden Legende für
+amtliche Warnungen im selben Reiter (`officialAlertsToggle`,
+`WeatherMetricsTab.svelte:1210-1224`).
+
+## Source
+
+- **File:** `frontend/src/lib/components/shared/WeatherMetricsTab.svelte`
+- **Identifier:** Snippet `officialAlertsToggle` (`:1189-1226`, Vorbild-Legende
+  `:1210-1224`); Reihenfolge-Block route (`:1479-1507`, `<LayoutTab context="route">`);
+  Reihenfolge-Block vergleich (`:1313-1344`, `<LayoutTab context="vergleich">`)
+
+> **Schicht-Hinweis:** ausschließlich Frontend (SvelteKit). Kein Go-API-, kein
+> Python-Core-Anteil — Messung M1 (Kontext-Dokument) belegt, dass
+> `/api/sms-symbols` NICHT um ein `label`-Feld erweitert werden muss, weil die
+> einzige Lücke (`cape`/`CP`) im Reiter nie als Marke gerendert wird und die
+> Legende deshalb aus der Menge der **gerenderten** Größen gespeist wird, nicht
+> aus dem rohen Kürzel-Katalog.
+
+## Estimated Scope
+
+- **LoC:** ~40–80 Produktivcode (ein Snippet + zwei Aufrufstellen in derselben
+  Datei), ~120–180 Testcode (Vitest-Struktur für AC-1–AC-5 + Playwright für
+  AC-6/AC-7).
+- **Files:** 1 Produktivdatei geändert (`WeatherMetricsTab.svelte`), 0 neu;
+  ~2–3 Testdateien (1 Vitest-Struktur-/Datenfluss-Test, 1 Playwright-Test
+  gegen Staging, optional Erweiterung des bestehenden Sichtbarkeits-Tests).
+- **Effort:** low–medium. Der Produktivcode-Kern ist klein und additiv
+  (fail-soft, kein neuer State, keine neue Ladelogik); der Aufwand liegt im
+  Nachweis für zwei Kontexte mit unterschiedlichem Kürzel-Vokabular und in
+  der Live-Schicht für Sichtbarkeit/Kontrast. **Erfahrungswert (R5/#1446):
+  der Nachweis kostet mehr als der Mechanismus** — beim 250-Zeilen-LoC-Limit
+  des Workflows das Testbudget doppelt ansetzen.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `WeatherMetricsTab.svelte::metricSymbols` (`:182-186`) | READ (unverändert) | Kürzel-Quelle für Kontext `route`, aus `/api/sms-symbols` |
+| `WeatherMetricsTab.svelte::metricById` (`:331-335`) | READ (unverändert) | Bedeutungs-Quelle für Kontext `route`, Feld `label` aus `/api/metrics` |
+| `WeatherMetricsTab.svelte::compareKuerzelById` (`:1102-1106`) | READ (unverändert) | Kürzel-Quelle für Kontext `vergleich`, aus `/api/compare/metrics` |
+| `WeatherMetricsTab.svelte::compareMetricById` (`:1082-1096`) | READ (unverändert) | Bedeutungs-Quelle für Kontext `vergleich`, Felder `label` + `aggregation_label` |
+| `LayoutTab context="route"` Reihenfolge-Block (`:1479-1507`) | MODIFY (additiv) | Einbindungsort route — einzige Stelle mit vollständiger Größen-Liste (inkl. abgewählter) |
+| `LayoutTab context="vergleich"` Reihenfolge-Block (`:1313-1344`) | MODIFY (additiv) | Einbindungsort vergleich, analog |
+| `officialAlertLegend.test.ts::AC-9 „keine zweite Liste"` (`:365-425`) | READ (Wächter, muss grün bleiben) | Verbündeter gegen eine handgetippte Kürzel-Zuordnung im Frontend |
+| `/api/sms-symbols`, `/api/metrics`, `/api/compare/metrics` | READ (unverändert) | alle drei werden von der Zielkomponente heute bereits geladen — keine neue Ladelogik nötig |
+| `src/output/renderers/comparison.py:647-650` (`_sms_aggregation_sign`) | READ (unverändert, Python-Core) | erklärt, warum die zugestellte Vergleichs-SMS trotz doppeltem `sms_code` eindeutig ist (M2b) — kein Anteil dieser Scheibe, nur Kontext für die Legenden-Darstellung |
+
+## Implementation Details
+
+### Ein Baustein, zwei Speisungen
+
+Die Legende entsteht als **ein** Svelte-Snippet in `WeatherMetricsTab.svelte`
+— der Datei, die beide Kontexte bereits teilen und die alle sieben
+Mount-Punkte versorgt (`TripNewEditor` 2×, `TripEditView`, `TripTabs`,
+`CompareTabs` 2×, `CompareNewEditor` 2×). Kein neuer Endpunkt, keine neue
+Ladelogik, keine zweite Liste im Frontend.
+
+Gespeist wird sie je Kontext aus dem Paar, das im selben Scope **bereits**
+nebeneinanderliegt und schon heute gemeinsam an den jeweiligen
+Reihenfolge-Block gereicht wird (Prop `kuerzelById`, `:1502` route /
+`:1339` vergleich):
+
+| Kontext | Kürzel-Quelle | Bedeutungs-Quelle | Darstellung |
+|---|---|---|---|
+| `route` | `metricSymbols` (`:182-186`) | `metricById[...].label` (`:331-335`) | `Kürzel — Label` |
+| `vergleich` | `compareKuerzelById` (`:1102-1106`) | `compareMetricById[...].label` + `.aggregation_label` (`:1082-1096`) | `Kürzel — Label (Auswertung)` |
+
+Der Datenfluss iteriert je Kontext über die **gerenderten** Größen der
+Reihenfolge-Liste (route: `Object.values(catalog)` bzw. die dort bereits
+aufbereitete Metrik-Menge; vergleich: `compareCatalog`) — **nicht** über den
+rohen `smsSymbols.metrics`-Katalog. Das ist die entscheidende Zusicherung
+aus M1: `cape` (Kürzel `CP`, `selectable=False`) steht zwar in
+`smsSymbols.metrics`, wird aber nirgends im Reiter als Marke gerendert
+(`/api/metrics` filtert `selectable=true`). Eine Legende, die naiv über
+`smsSymbols.metrics` iteriert, erzeugt einen Eintrag `CP` ohne Bedeutung —
+das ist die zu vermeidende Umsetzung (s. „Mutations-Gegenprobe").
+
+### Platzierung
+
+Unmittelbar am **Reihenfolge-Block** (`:1479-1507` route, `:1313-1344`
+vergleich), analog zur Warnungs-Legende im selben Snippet-Muster. Begründung:
+es ist der einzige Block, den beide Kontexte teilen, er zeigt **alle**
+Größen inklusive der abgewählten (Aus-Gruppe,
+`WeatherV2Reihenfolge.svelte:174-178`), und er erhält `kuerzelById` bereits
+als Prop. Die zusätzlichen Marken in „04 — Schwellwerte" (nur `route`) sind
+eine Teilmenge und werden von derselben Legende miterklärt.
+
+### Fail-soft
+
+Muster der Warnungs-Legende (`{#if smsSymbols}` ohne Kontext-Guard,
+`:1210-1224`): Guard nur auf die geladenen Daten der jeweiligen Quelle
+(`route`: `metricSymbols`/`metricById` vorhanden; `vergleich`:
+`compareKuerzelById`/`compareMetricById` vorhanden). **Kein**
+`{#if context === ...}`-Guard — fehlt die Quelle, entfällt die Legende
+still, der Reiter bleibt bedienbar.
+
+### Doppelte Kürzel im Ortsvergleich — bewusst NICHT entdoppeln
+
+Gemessen (M2, Kontext-Dokument): 25 Compare-Zeilen, 23 verschiedene Kürzel.
+`D` steht auf zwei Zeilen (`temp_max_c`/„Maximum" und `temp_min_c`/„Minimum"),
+`TF` ebenso (`wind_chill_min_c`/„Minimum" und `wind_chill_max_c`/„Maximum").
+Die Legende zeigt im Kontext `vergleich` **beide** Zeilen in der Form
+`Kürzel — Label (Auswertung)`:
+
+```
+D   Temperatur (Maximum)
+D   Temperatur (Minimum)
+```
+
+Das ist die einzige Variante, die die Zusicherung „dieselbe Quelle wie die
+Marken" einhält — die Marken zeigen das Kürzel tatsächlich an beiden Zeilen
+(rohes `sms_code`, ohne Auswertungszeichen; s. `compareKuerzelById`,
+`:1102-1106`). Eine Entdopplung nach Kürzel würde diese Zusicherung brechen.
+
+**Nachmessung M2b (Kontext-Dokument):** Die vorbestehende Doppelbelegung des
+rohen `sms_code` ist **kein Defekt der zugestellten Ausgabe**. Die
+Vergleichs-SMS hängt in `src/output/renderers/comparison.py:647-650` ein
+Auswertungszeichen an (`code = f"{code}{_sms_aggregation_sign(metric_id)}"`)
+— Temperatur-Maximum wird `D+`, Minimum `D-`. Die zugestellte SMS ist damit
+eindeutig; die Doppelbelegung ist ein Merkmal des rohen Katalogfeldes, kein
+nutzersichtbarer Fehler. **Kein eigenes Issue** aus diesem Grund (Korrektur
+gegenüber einer früheren Einschätzung dieser Scheibe).
+
+Die Legende bildet bewusst das **Editor-Vokabular** ab, nicht das
+SMS-Vokabular: sie zeigt das Kürzel **ohne** `+`/`-` — genauso, wie die
+Marken es im Editor tun. Die Eindeutigkeit stellt dort die mitgezeigte
+Auswertung her (`D — Temperatur (Maximum)` vs. `D — Temperatur (Minimum)`),
+nicht das Vorzeichen. Diese Lücke zwischen Editor-Anzeige (`D`) und
+zugestellter SMS (`D+`/`D-`) betrifft die **Marken**, nicht die Legende, und
+wird in dieser Scheibe nicht angefasst (s. „Bewusste Grenzen").
+
+## Expected Behavior
+
+- **Input:** Ein Nutzer öffnet den Reiter „Wetter-Metriken" im Trip-Editor
+  oder im Ortsvergleich-Editor, mit mindestens einer aktivierten
+  SMS-kürzeltragenden Größe.
+- **Output:** Am Reihenfolge-Block erscheint eine Legende, die zu jeder
+  dort gelisteten Größe (inklusive abgewählter) ihr Kürzel und ihre
+  Bedeutung nennt — im Trip-Kontext `Kürzel — Label`, im
+  Ortsvergleich-Kontext `Kürzel — Label (Auswertung)`. Für Größen ohne
+  Kürzel entsteht kein Eintrag. Die Legende erscheint in **beiden**
+  Kontexten mit demselben Markup, aber je kontexteigenem Inhalt.
+- **Side effects:** Keine — reine Anzeige, kein Schreibpfad, keine
+  Persistenz, kein neuer Netzwerk-Call. Fehlt die Quelle (Ladefehler,
+  Katalog leer), entfällt die Legende still.
+
+## Acceptance Criteria
+
+- **AC-1:** Given der Reiter „Wetter-Metriken" im Trip- oder
+  Ortsvergleich-Editor mit geladenem Metrik-Katalog / When der Nutzer den
+  Reiter öffnet / Then zeigt eine Legende am Reihenfolge-Block zu jeder dort
+  gerenderten kürzeltragenden Größe ihr Kürzel und ihre Bedeutung im Klartext
+  an — keine Marke ohne zugehörigen Erklärtext bleibt unerklärt stehen.
+  - Test: Vitest-Struktur-/Datenfluss-Test prüft, dass jedes Kürzel aus
+    `metricSymbols`/`compareKuerzelById`, das tatsächlich im
+    Reihenfolge-Block landet, in der Legende mit einem nichtleeren Label
+    erscheint (`weather_metric_kuerzel_marken.test.ts`-Muster).
+
+- **AC-2:** Given im Trip-Editor die drei Kürzel-Paare `K`/`D`/`N` und
+  `FK`/`FD`/`FN` im Trip-Editor / When der Nutzer die Legende liest / Then
+  erkennt er anhand der Klartext-Bedeutungen (z. B. „Tages-Tiefsttemperatur
+  (Gehzeit)" für `K`, „Gefühlte Tages-Tiefsttemperatur (Gehzeit)" für `FK`),
+  dass `FK`/`FD`/`FN` dieselben drei Größen wie `K`/`D`/`N` in gefühlter
+  statt gemessener Form bezeichnen. **Diese Zusicherung gilt ausschließlich
+  für den Trip-Editor** — die Größen `temperature_night`/`_day_low`/`_day_high`
+  und `wind_chill_night`/`_day_low`/`_day_high` existieren strukturell nur im
+  Trip-Katalog (Messung M3, Kontext-Dokument); der Compare-Katalog kennt
+  stattdessen `temp_min_c`/`temp_max_c`/`wind_chill_min_c`/`wind_chill_max_c`
+  mit den Kürzeln `D`/`TF`. Ein entsprechendes Kriterium für den
+  Ortsvergleich steht in AC-2a.
+  - Test: Vitest-Test lädt die sechs Register-Labels aus `metricById` für
+    genau diese sechs `metric_id`s und prüft, dass die Legende sie allen
+    sechs zugehörigen Kürzeln zuordnet (Muster:
+    `weather_metric_kuerzel_marken.test.ts:381-400`).
+
+- **AC-2a:** Given der Ortsvergleich-Editor mit den Kürzeln
+  `D` (zwei Zeilen: Maximum/Minimum) und `TF` (zwei Zeilen: Minimum/Maximum)
+  / When der Nutzer die Legende liest / Then sind Kürzel, Größenname
+  (`label`) und Auswertung (`aggregation_label`) für jede der vier Zeilen
+  gemeinsam ablesbar — die Legende entdoppelt nicht nach Kürzel, sondern
+  zeigt beide Zeilen getrennt (`D — Temperatur (Maximum)` und
+  `D — Temperatur (Minimum)`), und zeigt das Kürzel dabei ohne
+  Auswertungszeichen (`D`, nicht `D+`/`D-`) — deckungsgleich mit der
+  Darstellung der Marken im selben Editor (s. M2b).
+  - Test: Vitest-Test prüft für den Kontext `vergleich`, dass die Legende
+    für `D` und `TF` je zwei Einträge mit unterschiedlicher Auswertung
+    enthält (nicht einen entdoppelten) und dass kein Eintrag ein
+    Auswertungszeichen (`+`/`-`) am Kürzel trägt.
+
+- **AC-3:** Given die Kürzel-Legende in beiden Kontexten / When ihre
+  Datenquelle geprüft wird / Then bezieht sie Kürzel UND Bedeutung
+  ausschließlich aus denselben Katalog-Objekten, die auch die Marken am
+  Reihenfolge-Block speisen (`metricSymbols`/`metricById` bzw.
+  `compareKuerzelById`/`compareMetricById`) — keine zweite, im Frontend
+  hartkodierte Zuordnung.
+  - Test: der bestehende Wächter `officialAlertLegend.test.ts:365-425`
+    („keine zweite Liste") bleibt grün, ohne angepasst zu werden; ergänzend
+    ein spezifischer Test, dass die neue Legende keinen Kürzel-String-Literal
+    außerhalb der beiden genannten Katalog-Objekte referenziert.
+
+- **AC-4:** Given eine der beiden Datenquellen (`metricSymbols`/`metricById`
+  bzw. `compareKuerzelById`/`compareMetricById`) ist nicht geladen (Ladefehler
+  oder leerer Katalog) / When der Reiter gerendert wird / Then entfällt die
+  Legende für den betroffenen Kontext still, ohne Fehlermeldung und ohne den
+  Reiter unbedienbar zu machen — analog zum Guard-Verhalten der
+  Warnungs-Legende (`{#if smsSymbols}`, kein Kontext-Guard).
+  - Test: Vitest-Test setzt die jeweilige Quelle auf `null`/leer und prüft,
+    dass kein Legenden-Markup gerendert wird, während der übrige Reiter
+    (Reihenfolge-Block selbst) weiterhin erscheint.
+
+- **AC-5:** Given die Legende ist als ein Snippet in `WeatherMetricsTab.svelte`
+  implementiert / When sie in beiden Kontexten (`route` und `vergleich`)
+  aufgerufen wird / Then teilen sich beide Aufrufstellen dasselbe Markup und
+  denselben Rendering-Code — es gibt keine zweite, kontexteigene
+  Legenden-Komponente oder -Implementierung.
+  - Test: Vitest-Test prüft strukturell (AST oder Quelltext-Scan), dass genau
+    ein Legenden-Snippet definiert und an beiden Reihenfolge-Blöcken
+    referenziert wird (Muster: `officialAlertLegend.test.ts:213-292`,
+    „Legende in beiden Kontexten").
+
+- **AC-6:** Given ein Bildschirm zwischen 320 px und 899 px Breite (Handy)
+  / When der Nutzer die Legende am Reihenfolge-Block aufruft / Then ist der
+  vollständige Legenden-Text jeder Zeile lesbar, ohne dass Kürzel oder
+  Bedeutung durch Layout-Überlauf, `display:none` oder horizontales
+  Abschneiden verdeckt werden.
+  - Test: **Playwright gegen Staging**, echter Browser bei Viewport-Breiten
+    zwischen 320 px und 899 px — DOM-Sichtbarkeit ist per Quelltext-Scan
+    nicht belegbar (Präzedenzfall #1446: eine Tabelle mit `display:none`
+    meldet per DOM-Abfrage fälschlich „sichtbar"). Muster:
+    `frontend/e2e/kuerzel-marken-sichtbar.staging.spec.ts`.
+
+- **AC-7:** Given die Legenden-Zeilen (Kürzel + Bedeutung) / When ihr
+  Text-Hintergrund-Kontrast gemessen wird / Then liegt er bei mindestens
+  WCAG-AA 4.5:1 — `--g-ink-4` darf für Kürzel, Labels oder Auswertung nicht
+  verwendet werden (Design-Leitprinzip, nur für Placeholder/Disabled
+  zulässig).
+  - Test: **Playwright gegen Staging**, echter Browser mit
+    Kontrast-Berechnung aus berechneten Style-Werten (`getComputedStyle`)
+    an den gerenderten Legenden-Zeilen. Auch dieser Nachweis ist im Kern
+    (Vitest, kein DOM) nicht führbar.
+
+## Known Limitations
+
+- **Die rohe Kürzel-Doppelbelegung im Ortsvergleich (`D`/`TF`, s. M2)
+  bleibt bestehen und wird nicht angefasst.** Gemessen (M2b) unschädlich
+  für die Zustellung — die Vergleichs-SMS hängt ein Auswertungszeichen an
+  (`comparison.py:647-650`) und ist eindeutig. Die Legende zeigt beide
+  Zeilen mit Auswertung, macht die Doppelbelegung des Katalogfelds damit
+  sichtbar, ohne dass darin ein zu behebender Fehler steckt.
+- **Lücke zwischen Marken-Anzeige und zugestellter SMS im Ortsvergleich
+  (neuer Nebenbefund, außerhalb dieser Scheibe):** Die Marken am
+  Reihenfolge-Block zeigen den rohen `sms_code` ohne Auswertungszeichen
+  (`compareKuerzelById`, `WeatherMetricsTab.svelte:1102-1106`) — der Nutzer
+  liest im Editor `D`, in seiner zugestellten SMS aber `D+`/`D-`. Betrifft
+  die Marken, nicht die neue Legende (die dasselbe Vokabular abbildet).
+  Einordnung nach Nebenbefund-Triage: Sammel-Eintrag in #1199 nach der
+  Auslieferung dieser Scheibe, kein eigenes Issue, nicht Teil dieses Scopes.
+- **`cape`/`CP` bleibt ohne Legenden-Eintrag**, weil die Größe im Reiter
+  nirgends als Marke gerendert wird (`selectable=False`, gefiltert durch
+  `/api/metrics`). Das ist gewollt (M1), keine Lücke.
+- **AC-6 und AC-7 sind nur gegen den Zielstand nach Merge (Staging) belegbar**
+  — vor Push existiert keine URL, gegen die Playwright laufen kann.
+
+## Zu messen, nicht zu raten
+
+Diese Spec übernimmt die Messungen M1–M3 und die Nachmessung M2b aus
+`docs/context/fix-1888-e6b-kuerzel-legende.md` unverändert. Vor der
+RED-Phase erneut zu verifizieren, nicht blind zu übernehmen:
+
+1. **`CP`-Nichtvorkommen (M1):** erneut per `grep -n "cape\|CP"` gegen den
+   dann aktuellen Stand von `WeatherMetricsTab.svelte` und
+   `weather-metrics-tab/*` prüfen — sollte zwischenzeitlich doch eine
+   `CP`-Marke gerendert werden, ist die Legenden-Quelle entsprechend zu
+   erweitern (Backend-Ergänzung, s. R4 im Kontext-Dokument), nicht diese
+   Spec blind umzusetzen.
+2. **Kürzel-Kardinalität im Ortsvergleich (M2):** erneut gegen
+   `get_compare_metric_catalog()` auszählen, ob weiterhin genau `D` und `TF`
+   doppelt vorkommen und keine dritte Kollision hinzugekommen ist.
+3. **Kürzel-Trennschärfe Trip/Vergleich (M3):** erneut prüfen, dass
+   `N/K/D/FN/FK/FD` weiterhin ausschließlich im Trip-Katalog existieren und
+   im Compare-Katalog nicht vorkommen — sonst wäre AC-2a hinfällig und AC-2
+   müsste neu gefasst werden.
+4. **Auswertungszeichen in der zugestellten SMS (M2b):** erneut prüfen,
+   dass `comparison.py` weiterhin ein Auswertungszeichen an `sms_code`
+   anhängt, bevor „die zugestellte Ausgabe ist eindeutig" als Begründung für
+   „Legende zeigt beide Zeilen, aber ohne eigenes Issue" trägt.
+
+## Bewusste Grenzen
+
+- **Kein Backend-Anteil.** `/api/sms-symbols` wird nicht um ein `label`-Feld
+  erweitert (anders als in R4 des Kontext-Dokuments erwogen) — Messung M1
+  zeigt, dass die einzige Lücke (`CP`) folgenlos bleibt, solange die Legende
+  aus den gerenderten Größen statt aus dem rohen Kürzel-Katalog speist.
+- **Keine Entdopplung der Ortsvergleich-Kürzel.** Bewusste Entscheidung
+  (M2/F2) — Entdopplung würde die Zusicherung „gleiche Quelle wie die
+  Marken" brechen. Die rohe Doppelbelegung des Katalogfelds `sms_code`
+  bleibt unangetastet — gemessen unschädlich für die zugestellte Ausgabe
+  (M2b), kein eigenes Issue.
+- **Kein Angleich der Marken-Anzeige an die zugestellte SMS.** Die Lücke
+  „Editor zeigt `D`, SMS zeigt `D+`/`D-`" ist ein eigenständiger, in dieser
+  Scheibe nicht zu behebender Befund (s. „Known Limitations").
+- **Keine zweite Legende bei „04 — Schwellwerte".** Nur der
+  Reihenfolge-Block bekommt die Legende — er ist der einzige von beiden
+  Kontexten geteilte Ort mit vollständiger Größen-Liste; „04 — Schwellwerte"
+  existiert nur im Trip-Kontext und zeigt eine Teilmenge, die von derselben
+  Legende bereits miterklärt wird.
+- **Register- und Katalog-Änderungen sind Scheibe A (#1887), bereits
+  gemerged.** Diese Scheibe fasst `metric_catalog.py` und verwandte
+  Python-Dateien nicht an.
+
+## Mutations-Gegenprobe
+
+Für jede neu bewachte Zusicherung mindestens eine gezielte Verfälschung, die
+ein Test fangen MUSS:
+
+1. **AC-1/AC-3:** Legende testweise über den rohen `smsSymbols.metrics`
+   speisen statt über die gerenderten Größen (`metricById`/`compareCatalog`)
+   → muss einen Legenden-Eintrag `CP` ohne zugehöriges Label erzeugen; der
+   AC-1-Test (jedes Kürzel hat ein nichtleeres Label) muss rot werden.
+2. **AC-2a:** Im Vergleichs-Kontext nach Kürzel entdoppeln (nur einen
+   `D`-Eintrag statt zwei rendern) → der AC-2a-Test (zwei Zeilen für `D` mit
+   unterschiedlicher Auswertung) muss rot werden.
+3. **AC-5:** Eine zweite, kontexteigene Legenden-Implementierung im
+   `vergleich`-Zweig einfügen (Copy-Paste statt Wiederverwendung des
+   Snippets) → der AC-5-Struktur-Test (genau ein Snippet, zweimal
+   referenziert) muss rot werden.
+4. **AC-4:** Den Fail-soft-Guard entfernen (Legende ohne `{#if}` immer
+   rendern) → der AC-4-Test (Legende entfällt bei fehlender Quelle) muss rot
+   werden, weil dann auch bei leerer Quelle ein (leeres/fehlerhaftes)
+   Legenden-Markup erscheint.
+
+## Betroffene Tests
+
+**Kern (Vitest, deterministisch) — AC-1 bis AC-5:**
+
+- `frontend/src/lib/components/shared/__tests__/weather_metric_kuerzel_legende.test.ts`
+  (neu) — Struktur- und Datenfluss-Test nach dem Muster von
+  `weather_metric_kuerzel_marken.test.ts:381-400,443-490`: prüft AC-1
+  (jedes gerenderte Kürzel hat ein Label), AC-2/AC-2a (Trip-Sechsergruppe
+  bzw. Vergleichs-Doppelzeilen ohne Auswertungszeichen), AC-3 (Quelle =
+  Marken-Quelle, kein Literal), AC-4 (Fail-soft-Guard), AC-5 (ein Snippet,
+  zwei Aufrufstellen).
+- `frontend/src/lib/components/shared/__tests__/officialAlertLegend.test.ts:365-425`
+  (bestehend, unverändert) — „keine zweite Liste"-Wächter muss grün bleiben;
+  ergänzend eine analoge Prüfung für die neue Legende in derselben oder
+  einer neuen Testdatei, falls der bestehende Scanner die neue Legende nicht
+  automatisch mit abdeckt (in der RED-Phase am Code zu verifizieren, nicht
+  hier zu behaupten).
+
+**Live (Playwright, echter Browser gegen Staging) — AC-6, AC-7:**
+
+- `frontend/e2e/kuerzel-legende-lesbar.staging.spec.ts` (neu, Muster:
+  `frontend/e2e/kuerzel-marken-sichtbar.staging.spec.ts`) — Viewport
+  320–899 px, vollständige Sichtbarkeit der Legenden-Zeilen (AC-6);
+  Kontrast-Berechnung an den gerenderten Legenden-Zeilen gegen WCAG-AA
+  4.5:1, `--g-ink-4` ausgeschlossen (AC-7).
+
+**Regression:**
+
+- `frontend/e2e/weather-metrics-editor-day-range-kuerzel.spec.ts:110-135` —
+  bestehender Kürzel-Badge-Test in „04 — Schwellwerte" muss unverändert
+  grün bleiben (additive Änderung darf ihn nicht berühren).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine.
+- **Rationale:** Kein neuer Architektur-Grundsatz. Die Wiederverwendung
+  eines geteilten Snippets für Trip- und Ortsvergleich-Editor folgt der
+  bestehenden, PO-bekräftigten Trip/Ortsvergleich-Code-Teilung
+  (`CLAUDE.md`, Epic #1230) und dem bereits etablierten Muster der
+  Warnungs-Legende — keine Abweichung, kein neues ADR nötig.
+
+## Changelog
+
+- 2026-08-16: Initial spec created. Übernimmt Messungen M1–M3 und die
+  Auflösung von F1–F3 aus `docs/context/fix-1888-e6b-kuerzel-legende.md`
+  unverändert. AC-2 auf den Trip-Editor präzisiert (Messung M3 zeigt
+  strukturelle Nichterfüllbarkeit im Ortsvergleich), AC-2a neu als
+  eigenständiges, im Ortsvergleich erfüllbares Kriterium ergänzt.
+- 2026-08-16 (Korrektur nach Nachmessung M2b): Frühere Fassung hatte die
+  Kürzel-Doppelbelegung im Ortsvergleich als „nutzersichtbar falsch" und
+  eigenes Issue wert eingestuft. Widerlegt durch Nachmessung in
+  `src/output/renderers/comparison.py:647-650` — die zugestellte
+  Vergleichs-SMS hängt ein Auswertungszeichen an (`D+`/`D-`) und ist
+  eindeutig; die Doppelbelegung ist ein Merkmal des rohen Katalogfelds, kein
+  Defekt der Ausgabe. Entsprechend angepasst: kein eigenes Issue mehr in
+  „Betroffene Tests"/Implementation Details; AC-2a und die Legenden-Regel
+  präzisiert (Kürzel ohne Auswertungszeichen, wie die Marken); neuer
+  Nebenbefund „Lücke zwischen Marken-Anzeige und zugestellter SMS" als
+  Sammel-Eintrag (#1199, nach Auslieferung) statt eigenem Issue in „Known
+  Limitations"/„Bewusste Grenzen" ergänzt.

--- a/docs/specs/modules/fix_1888_e6b_kuerzel_legende.md
+++ b/docs/specs/modules/fix_1888_e6b_kuerzel_legende.md
@@ -46,9 +46,27 @@ amtliche Warnungen im selben Reiter (`officialAlertsToggle`,
 - **LoC:** ~40–80 Produktivcode (ein Snippet + zwei Aufrufstellen in derselben
   Datei), ~120–180 Testcode (Vitest-Struktur für AC-1–AC-5 + Playwright für
   AC-6/AC-7).
-- **Files:** 1 Produktivdatei geändert (`WeatherMetricsTab.svelte`), 0 neu;
-  ~2–3 Testdateien (1 Vitest-Struktur-/Datenfluss-Test, 1 Playwright-Test
+- **Files:** 1 Produktivdatei geändert (`WeatherMetricsTab.svelte`) **+ 1 neu**
+  (`weather-metrics-tab/kuerzelLegende.ts`, s. Nachtrag unten);
+  ~2–3 Testdateien (1 Struktur-/Datenfluss-Test im Kern, 1 Playwright-Test
   gegen Staging, optional Erweiterung des bestehenden Sichtbarkeits-Tests).
+
+> **Nachtrag 2026-08-16 (RED-Phase, Tech-Lead-Entscheid — ACs unberührt):**
+> Die Ableitung der Legenden-Einträge zieht in ein eigenes Modul
+> `frontend/src/lib/components/shared/weather-metrics-tab/kuerzelLegende.ts`
+> mit `buildKuerzelLegende(kuerzelById, metricById) -> {kuerzel, bedeutung}[]`.
+> **Grund:** AC-1/AC-2/AC-2a sind Aussagen über Mengen und Texte („kein Kürzel
+> ohne Bedeutung", „`D` genau zweimal"). An der `.svelte`-Datei sind sie in der
+> Kern-Schicht nicht messbar — die Kataloge kommen über `$effect`/`onMount`,
+> und ein SSR-Test führt beides nie aus und wäre damit **strukturell immer
+> grün** (Falle aus #1717). Ohne diese Naht bliebe von AC-1/AC-2/AC-2a nur
+> Struktur-Prosa. Das Muster ist hausüblich: derselbe Ordner hält bereits
+> `channelMetricLayouts.ts`, `compareMetricSelection.ts`,
+> `compareMetricOrder.ts` und weitere Ableitungs-Module.
+> **Die Zusicherungen bleiben unberührt:** Die Legende selbst bleibt EIN
+> Snippet in `WeatherMetricsTab.svelte` (AC-5, durch Strukturtests erzwungen),
+> das Modul liefert nur die Ableitung aus den bereits vorhandenen Katalogen
+> (AC-3). Es entsteht kein zweites Vokabular und keine compare-eigene Kopie.
 - **Effort:** low–medium. Der Produktivcode-Kern ist klein und additiv
   (fail-soft, kein neuer State, keine neue Ladelogik); der Aufwand liegt im
   Nachweis für zwei Kontexte mit unterschiedlichem Kürzel-Vokabular und in
@@ -301,10 +319,15 @@ RED-Phase erneut zu verifizieren, nicht blind zu übernehmen:
 2. **Kürzel-Kardinalität im Ortsvergleich (M2):** erneut gegen
    `get_compare_metric_catalog()` auszählen, ob weiterhin genau `D` und `TF`
    doppelt vorkommen und keine dritte Kollision hinzugekommen ist.
-3. **Kürzel-Trennschärfe Trip/Vergleich (M3):** erneut prüfen, dass
-   `N/K/D/FN/FK/FD` weiterhin ausschließlich im Trip-Katalog existieren und
-   im Compare-Katalog nicht vorkommen — sonst wäre AC-2a hinfällig und AC-2
-   müsste neu gefasst werden.
+3. **Kürzel-Trennschärfe Trip/Vergleich (M3):** erneut prüfen, dass die
+   **Größen** `temperature_night`/`_day_low`/`_day_high` und
+   `wind_chill_night`/`_day_low`/`_day_high` weiterhin ausschließlich im
+   Trip-Katalog existieren — sonst wäre AC-2a hinfällig und AC-2 müsste neu
+   gefasst werden. Präzisierung (Nachprüfung RED-Phase): Das **Zeichen** `D`
+   kommt sehr wohl auch im Compare-Katalog vor, dort aber für eine andere
+   Größe (`temp_max_c`/`temp_min_c`); `K`/`N`/`FK`/`FD`/`FN` fehlen dort ganz.
+   Die Trennung AC-2 / AC-2a trägt dadurch unverändert — sie unterscheidet
+   Größen, nicht Zeichen.
 4. **Auswertungszeichen in der zugestellten SMS (M2b):** erneut prüfen,
    dass `comparison.py` weiterhin ein Auswertungszeichen an `sms_code`
    anhängt, bevor „die zugestellte Ausgabe ist eindeutig" als Begründung für

--- a/docs/specs/modules/fix_1888_e6b_kuerzel_legende.md
+++ b/docs/specs/modules/fix_1888_e6b_kuerzel_legende.md
@@ -180,7 +180,7 @@ wird in dieser Scheibe nicht angefasst (s. „Bewusste Grenzen").
     erscheint (`weather_metric_kuerzel_marken.test.ts`-Muster).
 
 - **AC-2:** Given im Trip-Editor die drei Kürzel-Paare `K`/`D`/`N` und
-  `FK`/`FD`/`FN` im Trip-Editor / When der Nutzer die Legende liest / Then
+  `FK`/`FD`/`FN` / When der Nutzer die Legende liest / Then
   erkennt er anhand der Klartext-Bedeutungen (z. B. „Tages-Tiefsttemperatur
   (Gehzeit)" für `K`, „Gefühlte Tages-Tiefsttemperatur (Gehzeit)" für `FK`),
   dass `FK`/`FD`/`FN` dieselben drei Größen wie `K`/`D`/`N` in gefühlter

--- a/frontend/src/lib/components/shared/WeatherMetricsTab.svelte
+++ b/frontend/src/lib/components/shared/WeatherMetricsTab.svelte
@@ -48,6 +48,11 @@
 		splitChannelMetricsForDisplay, mergeAllChannelLayoutsForSave,
 		type ChannelOverride,
 	} from './weather-metrics-tab/channelMetricLayouts.ts';
+	// Issue #1888 (E6 Scheibe B): Ableitung der Kuerzel-Legende — ein Datenfluss
+	// fuer beide Kontexte, gespeist aus denselben Katalogen wie die Marken.
+	import {
+		buildKuerzelLegende, type KuerzelLegendeEintrag,
+	} from './weather-metrics-tab/kuerzelLegende.ts';
 	import ThresholdMetricRow from './weather-metrics-tab/ThresholdMetricRow.svelte';
 	// Fix #1613: Mehrfach-Symbol-Metriken (temperature/temperature_night/wind_chill)
 	// haben keinen Schwellwert -- eigene, schlanke Zeile ohne Segmented-Control.
@@ -1125,6 +1130,23 @@
 		splitChannelMetricsForDisplay(materializedActiveMetricKeys, compareChannelPrimary(compareChannel))
 	);
 
+	// Issue #1888 (E6 Scheibe B): die Zeilen der Kuerzel-Legende, je Kontext aus
+	// GENAU den Quellen, die auch die Marken daneben speisen (AC-3) — und
+	// beschraenkt auf die Groessen, die der Reihenfolge-Block WIRKLICH zeigt.
+	// Adversary F001: `metricById`/`compareMetricById` ist der VOLLE Katalog
+	// (29 Groessen), der Block zeigt aber nur `active` + die Aus-Gruppe `off`
+	// (frische Tour: 9). Eine Legende aus dem vollen Katalog erklaerte Zeichen,
+	// die nirgends auf dem Schirm stehen. Die Aus-Gruppe gehoert dazu — sie
+	// wird gerendert (WeatherV2Reihenfolge.svelte:174-178).
+	const kuerzelLegendeRoute = $derived(buildKuerzelLegende(
+		[...activeChannelSections.active, ...activeChannelSections.off],
+		metricSymbols, metricById
+	));
+	const kuerzelLegendeVergleich = $derived(buildKuerzelLegende(
+		[...compareChannelSections.active, ...compareChannelSections.off],
+		compareKuerzelById, compareMetricById
+	));
+
 	// Copy-on-write auf den AKTIVEN Kanal-Reiter — Vorbild `editActiveChannel`
 	// (Z. 677-691). Ohne bestehenden Override startet der Eintrag als Klon der
 	// globalen Reihenfolge, nicht leer.
@@ -1223,6 +1245,24 @@
 			</div>
 		{/if}
 	</UiCard.Root>
+{/snippet}
+
+<!-- Issue #1888 (Etappe E6, Scheibe B): Legende zu den Kuerzel-Marken am
+     Reihenfolge-Block. EIN Snippet fuer beide Kontexte (AC-5) — der Inhalt ist
+     je Flaeche ein anderer, weil er aus der jeweils eigenen Katalog-Quelle
+     kommt (AC-3). Fail-soft wie die Warnungs-Legende darueber: ohne Zeilen
+     erscheint gar nichts, statt einer leeren Liste (AC-4). -->
+{#snippet kuerzelLegende(eintraege: KuerzelLegendeEintrag[])}
+	{#if eintraege.length}
+		<div data-testid="metric-kuerzel-legend" class="kuerzel-legende text-xs">
+			<p>So heißen diese Größen in SMS und Telegram-Kurzform:</p>
+			<ul class="legend-symbols">
+				{#each eintraege as eintrag, i (eintrag.kuerzel + ' ' + eintrag.bedeutung + ' ' + i)}
+					<li><code>{eintrag.kuerzel}</code> <span>{eintrag.bedeutung}</span></li>
+				{/each}
+			</ul>
+		</div>
+	{/if}
 {/snippet}
 
 {#if context === 'vergleich'}
@@ -1338,6 +1378,7 @@
 							onRestore={onCompareRestore}
 							kuerzelById={compareKuerzelById}
 						/>
+						{@render kuerzelLegende(kuerzelLegendeVergleich)}
 					</Card>
 				{/snippet}
 			</LayoutTab>
@@ -1501,6 +1542,7 @@
 							onRestore={onRestoreMetric}
 							kuerzelById={metricSymbols}
 						/>
+						{@render kuerzelLegende(kuerzelLegendeRoute)}
 					</Card>
 				{/snippet}
 			</LayoutTab>
@@ -1907,6 +1949,42 @@
 		display: flex;
 		justify-content: flex-end;
 		gap: var(--g-s-2);
+	}
+	/* Issue #1888 (E6 Scheibe B): Kuerzel-Legende am Reihenfolge-Block.
+	   Farbe bewusst --g-ink-muted (6.9:1 auf Weiss) und NICHT --g-ink-4
+	   (2.85:1) — Design-Leitprinzip: --g-ink-4 nur fuer Placeholder/Disabled,
+	   nie fuer Daten-Labels (AC-7, WCAG AA 4.5:1).
+	   Umbruch statt Ueberlauf: die Zeilen fliessen und brechen innerhalb der
+	   Karte, damit auch bei 320 px nichts abgeschnitten wird (AC-6). */
+	.kuerzel-legende {
+		color: var(--g-ink-muted);
+		line-height: 1.5;
+		padding: var(--g-s-2) var(--g-s-3) var(--g-s-3);
+	}
+	.kuerzel-legende p {
+		margin: 0 0 var(--g-s-1);
+	}
+	.kuerzel-legende .legend-symbols {
+		display: flex;
+		flex-wrap: wrap;
+		column-gap: var(--g-s-4);
+		row-gap: var(--g-s-1);
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+	.kuerzel-legende li {
+		display: flex;
+		gap: var(--g-s-1);
+		max-width: 100%;
+	}
+	.kuerzel-legende code {
+		flex: none;
+		font-weight: 600;
+	}
+	.kuerzel-legende li span {
+		min-width: 0;
+		overflow-wrap: anywhere;
 	}
 	/* Conflict 6 resolved: v2-CSS + #624-Klassen, ohne telegram-options */
 	.option-hint {

--- a/frontend/src/lib/components/shared/__tests__/metricKuerzelLegende.test.ts
+++ b/frontend/src/lib/components/shared/__tests__/metricKuerzelLegende.test.ts
@@ -1,0 +1,991 @@
+// TDD RED — Issue #1888 (Etappe E6, Scheibe B): Legende fuer die SMS-Kuerzel im
+// Reiter „Wetter-Metriken" — EIN geteilter Baustein fuer Trip UND Ortsvergleich.
+//
+// Spec: docs/specs/modules/fix_1888_e6b_kuerzel_legende.md
+//   AC-1  jedes gerenderte Kuerzel steht mit nichtleerem Erklaertext in der Legende
+//   AC-2  Trip: die sechs Temperatur-/Windchill-Groessen tragen ihr Registerlabel
+//   AC-2a Vergleich: `D`/`TF` je ZWEI Zeilen (Auswertung unterscheidet), Kuerzel ohne +/-
+//   AC-3  Quelle = Marken-Quelle, keine zweite Liste im Frontend
+//   AC-4  fehlende Quelle -> keine Legende (fail-soft), Reiter bleibt bedienbar
+//   AC-5  ein Snippet, an BEIDEN Reihenfolge-Bloecken gerendert
+// AC-6/AC-7 (Lesbarkeit 320-899 px, Kontrast >= 4.5:1) gehoeren NICHT hierher:
+// sie brauchen einen echten Browser gegen Staging (Praezedenzfall #1446).
+//
+// DREI SCHICHTEN, und alle drei sind noetig:
+//   (A) DATEN — AC-1/AC-2/AC-2a sind Aussagen ueber MENGEN und TEXTE („kein
+//       Kuerzel ohne Bedeutung", „`D` genau zweimal"). An einer .svelte-Datei
+//       sind sie nicht messbar: WeatherMetricsTab holt seine Kataloge in
+//       $effect/onMount, und SSR fuehrt beides nie aus — ein SSR-Test waere
+//       strukturell immer gruen (#1717). Deshalb verlangen diese Tests eine
+//       reine Ableitung `buildKuerzelLegende()` und fuettern sie mit dem
+//       ECHTEN Backend-Katalog (`uv run python3`, Muster
+//       corridor-editor/__tests__/compareMetricCatalogParity.test.ts).
+//       Kein Mock, kein erfundenes Fixture, keine hartkodierte Erwartungsliste.
+//   (B) STRUKTUR — dass die Legende im Reiter wirklich haengt, in BEIDEN
+//       Kontexten, aus den Marken-Quellen gespeist und fail-soft geschuetzt,
+//       wird am ECHTEN Svelte-5-AST geprueft (Muster officialAlertLegend.test.ts
+//       und weather_metric_kuerzel_marken.test.ts).
+//   (C) VERDRAHTUNG — Adversary F002: (A) und (B) zusammen bewachen die
+//       Zusicherung nur dort, wo der Code STEHT, nicht dort, wo er WIRKT.
+//       (A) ruft die Ableitung mit selbst sortierten Argumenten auf, (B)
+//       prueft nur die ERREICHBARKEIT der Bezeichner. Vertauscht man an der
+//       Aufrufstelle die Argumente, ist die Trip-Legende in Produktion leer —
+//       und beide Schichten bleiben gruen. Deshalb liest (C) den Quelltext
+//       der ECHTEN Aufrufstelle aus dem AST und fuehrt ihn gegen die echten
+//       Kataloge aus: Argumentreihenfolge inbegriffen, nichts nachgebaut.
+//
+// VERTRAG der Ableitung (neu: weather-metrics-tab/kuerzelLegende.ts):
+//   buildKuerzelLegende(gerenderteIds, kuerzelById, metricById)
+//       -> { kuerzel, bedeutung }[]
+//   * massgeblich ist `gerenderteIds` — die Groessen, die der Reihenfolge-
+//     Block WIRKLICH zeigt (aktive Zeilen + Aus-Gruppe). Weder der volle
+//     Backend-Katalog (Adversary F001: 29 Katalog- gegen 9 gerenderte
+//     Groessen in einer frischen Tour) noch der rohe Kuerzel-Katalog
+//     (Messung M1: `cape`/`CP` ist selectable=False und nie eine Marke).
+//   * je (Groesse, Kuerzel) ein Eintrag; Groessen ohne Kuerzel oder ohne Label
+//     entfallen.
+//   * `bedeutung` = Label, im Vergleich um die Auswertung ergaenzt.
+//   Alle drei Argumente liegen an beiden Aufrufstellen heute schon
+//   nebeneinander (route: activeChannelSections + metricSymbols + metricById ·
+//   vergleich: compareChannelSections + compareKuerzelById +
+//   compareMetricById) — keine neue Ladelogik, kein neuer Endpunkt.
+//
+// Pfadregel #1409: alles relativ zu DIESER Datei aufloesen — nie ueber einen
+// festen Hauptrepo-Pfad, sonst misst der Test aus dem Worktree die falsche Datei.
+//
+// Ausfuehren:
+//   cd frontend && node --import ./test-lib-loader.mjs --experimental-strip-types \
+//     --test src/lib/components/shared/__tests__/metricKuerzelLegende.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'svelte/compiler';
+import { toCompareSelectionEntries } from '../weather-metrics-tab/compareMetricSelection.ts';
+
+const HIER = dirname(fileURLToPath(import.meta.url));
+const SHARED = join(HIER, '..');
+const TAB = join(SHARED, 'WeatherMetricsTab.svelte');
+const BAUTEIL = join(SHARED, 'weather-metrics-tab', 'kuerzelLegende.ts');
+const BAUTEIL_SPEC = '../weather-metrics-tab/kuerzelLegende.ts';
+// __tests__ -> shared -> components -> lib -> src -> frontend -> repo
+const REPO = resolve(HIER, '..', '..', '..', '..', '..', '..');
+
+/** Anker der Legende — auch der Messpunkt des spaeteren Browser-Nachweises
+ *  (AC-6/AC-7). Ohne stabile Testid kann dort nichts gemessen werden. */
+const LEGENDE_TESTID = 'metric-kuerzel-legend';
+
+/** Die sechs Groessen aus AC-2. Ihre LABEL stehen bewusst NICHT hier — sie
+ *  werden zur Laufzeit aus dem Register gelesen (s. `tripMetricById`). */
+const SECHS = [
+	'temperature_night', 'temperature_day_low', 'temperature_day_high',
+	'wind_chill_night', 'wind_chill_day_low', 'wind_chill_day_high'
+];
+
+type Knoten = Record<string, any>;
+type Eintrag = { kuerzel: string; bedeutung: string };
+
+// ═══════════════════════════════════════════════════════════════════════════
+// (A) DATENSCHICHT — echte Backend-Kataloge, kein Fixture
+// ═══════════════════════════════════════════════════════════════════════════
+
+const PY = [
+	'import sys, json',
+	"sys.path.insert(0, 'src'); sys.path.insert(0, '.')",
+	'from api.routers.config import get_sms_symbols, get_metrics',
+	'from output.renderers.compare_metric_catalog import get_compare_metric_catalog',
+	"print(json.dumps({'sms': get_sms_symbols(), 'metrics': get_metrics(),"
+		+ " 'compare': get_compare_metric_catalog()}, ensure_ascii=False))"
+].join('\n');
+
+let katalogCache: Knoten | null = null;
+/** Die drei Katalog-Antworten, die der Reiter im Betrieb wirklich laedt. */
+function live(): Knoten {
+	if (!katalogCache) {
+		const stdout = execFileSync('uv', ['run', 'python3', '-c', PY], {
+			cwd: REPO, encoding: 'utf-8', maxBuffer: 32 * 1024 * 1024
+		});
+		katalogCache = JSON.parse(stdout.trim());
+	}
+	return katalogCache!;
+}
+
+/** `metricSymbols` — WeatherMetricsTab.svelte:182-186. */
+function tripKuerzelById(): Record<string, string[]> {
+	return Object.fromEntries(
+		(live().sms.metrics as Knoten[]).map((m) => [m.metric_id, m.sms_symbols])
+	);
+}
+
+/** `metricById` — WeatherMetricsTab.svelte:331-335 (Kategorien flachgezogen). */
+function tripMetricById(): Record<string, Knoten> {
+	const map: Record<string, Knoten> = {};
+	for (const ms of Object.values(live().metrics) as Knoten[][]) for (const m of ms) map[m.id] = m;
+	return map;
+}
+
+/** `compareKuerzelById`/`compareMetricById` — WeatherMetricsTab.svelte:1082-1106,
+ *  ueber die ECHTE Endpunkt-Abbildung `toCompareSelectionEntries()`. */
+function vergleichPaar(): { kuerzelById: Record<string, string[]>; metricById: Record<string, Knoten> } {
+	const kuerzelById: Record<string, string[]> = {};
+	const metricById: Record<string, Knoten> = {};
+	for (const e of toCompareSelectionEntries({ metrics: live().compare } as never)) {
+		if (e.sms_code) kuerzelById[e.metric] = [e.sms_code];
+		metricById[e.metric] = {
+			id: e.metric, label: e.label, aggregation_label: e.aggregation_label,
+			col_label: e.col_label, sms_code: e.sms_code
+		};
+	}
+	return { kuerzelById, metricById };
+}
+
+/** Die im Reihenfolge-Block gerenderte Menge des TRIPS. Genommen wird die
+ *  Anlege-Vorbelegung (`trip_default_enabled`) — das ist die Auswahl, die eine
+ *  frische Tour wirklich zeigt, und sie ist eine echte Teilmenge des Katalogs
+ *  (Adversary F001). Nichts hier ist getippt: die Ids kommen aus /api/metrics. */
+function gerendertRoute(zusaetzlich: string[] = []): string[] {
+	const metricById = tripMetricById();
+	const standard = Object.keys(metricById).filter((id) => metricById[id].trip_default_enabled);
+	return [...new Set([...standard, ...zusaetzlich])];
+}
+
+/** Die im Reihenfolge-Block gerenderte Menge des ORTSVERGLEICHS. Der
+ *  Vergleich hat keine Standard-Vorbelegung im Katalog; genommen wird deshalb
+ *  „alle Zeilen ausser einer" — die zurueckgehaltene Zeile ist die
+ *  Positivkontrolle dafuer, dass Nichtgerendertes auch nicht erklaert wird.
+ *  Zurueckgehalten wird eine Zeile mit EINDEUTIGEM Kuerzel (nicht `D`/`TF`),
+ *  sonst bliebe ihr Zeichen ueber die Schwesterzeile ohnehin sichtbar. */
+function gerendertVergleich(): string[] {
+	const { kuerzelById } = vergleichPaar();
+	const haeufigkeit = new Map<string, number>();
+	for (const ks of Object.values(kuerzelById)) {
+		for (const k of ks) haeufigkeit.set(k, (haeufigkeit.get(k) ?? 0) + 1);
+	}
+	const zurueck = Object.keys(kuerzelById).find(
+		(id) => (kuerzelById[id] ?? []).every((k) => haeufigkeit.get(k) === 1)
+	);
+	assert.ok(zurueck, 'Keine Vergleichszeile mit eindeutigem Kuerzel gefunden.');
+	return Object.keys(kuerzelById).filter((id) => id !== zurueck);
+}
+
+async function ableitung(): Promise<(
+	ids: string[] | null | undefined,
+	kuerzelById: Record<string, string[]> | null | undefined,
+	metricById: Record<string, Knoten> | null | undefined
+) => Eintrag[]> {
+	assert.ok(
+		existsSync(BAUTEIL),
+		`RED: die Ableitung \`${BAUTEIL_SPEC}\` gibt es noch nicht. Die Legende ` +
+			`braucht eine reine Funktion ` +
+			`\`buildKuerzelLegende(gerenderteIds, kuerzelById, metricById)\`, sonst sind ` +
+			`AC-1/AC-2/AC-2a (Mengen und Texte) im Kern nicht messbar — der Reiter laedt ` +
+			`seine Kataloge in $effect/onMount, unter SSR bleiben sie leer.`
+	);
+	const mod: Knoten = await import(BAUTEIL_SPEC);
+	assert.equal(
+		typeof mod.buildKuerzelLegende, 'function',
+		`${BAUTEIL_SPEC} exportiert kein \`buildKuerzelLegende\`.`
+	);
+	return mod.buildKuerzelLegende;
+}
+
+async function baue(
+	ids: string[] | null | undefined,
+	kuerzelById: Record<string, string[]> | null | undefined,
+	metricById: Record<string, Knoten> | null | undefined
+): Promise<Eintrag[]> {
+	return (await ableitung())(ids, kuerzelById, metricById);
+}
+
+/** Probe-Zeilen fuer die Guard-Auswertung (F004): ECHTE Kuerzel und Labels aus
+ *  dem Katalog, keine Platzhalter — sonst bestuende eine Bedingung, die am
+ *  Inhalt haengt (`eintraege[0].kuerzel === 'X'`), jede Probe mit demselben
+ *  Platzhalter. `variante` liefert zu derselben Anzahl andere Zeilen. */
+function probeEintraege(anzahl: number, variante = 0): Eintrag[] {
+	const kuerzelById = tripKuerzelById();
+	const metricById = tripMetricById();
+	const ids = Object.keys(metricById).filter((id) => (kuerzelById[id] ?? []).length > 0);
+	const quelle = variante === 0 ? ids : [...ids].reverse();
+	const zeilen: Eintrag[] = [];
+	// Reicht der Katalog fuer die geforderte Anzahl nicht, wird er wiederholt —
+	// die Bedingung soll an der ZAHL haengen, nicht an der Katalog-Groesse.
+	for (let i = 0; i < anzahl; i++) {
+		const id = quelle[i % quelle.length];
+		zeilen.push({ kuerzel: kuerzelById[id][0], bedeutung: String(metricById[id].label) });
+	}
+	return zeilen;
+}
+
+/** Erwartete Zuordnung Kuerzel -> Bedeutung fuer eine gerenderte Menge,
+ *  ausschliesslich aus den Katalogen berechnet (nicht aus dem Prueflingscode). */
+function erwarteteZuordnung(
+	ids: string[], kuerzelById: Record<string, string[]>, metricById: Record<string, Knoten>
+): Map<string, Set<string>> {
+	const erwartet = new Map<string, Set<string>>();
+	for (const id of ids) {
+		const label = String(metricById[id]?.label ?? '').trim();
+		if (!label) continue;
+		const auswertung = String(metricById[id]?.aggregation_label ?? '').trim();
+		const bedeutung = auswertung ? `${label} (${auswertung})` : label;
+		for (const k of kuerzelById[id] ?? []) {
+			if (!erwartet.has(k)) erwartet.set(k, new Set());
+			erwartet.get(k)!.add(bedeutung);
+		}
+	}
+	return erwartet;
+}
+
+describe('AC-1: kein Kuerzel bleibt ohne Erklaertext', () => {
+	test('Trip: die Legende deckt genau die Kuerzel der GERENDERTEN Groessen ab', async () => {
+		const kuerzelById = tripKuerzelById();
+		const metricById = tripMetricById();
+		const gerendert = gerendertRoute();
+		const erwartet = erwarteteZuordnung(gerendert, kuerzelById, metricById);
+
+		// Positivkontrolle 1 (Adversary F001): die gerenderte Menge ist eine echte
+		// TEILMENGE des Katalogs. Waeren beide gleich gross, koennte dieser Test
+		// eine Legende aus dem vollen Katalog nicht mehr von der richtigen
+		// unterscheiden.
+		assert.ok(
+			gerendert.length > 2 && gerendert.length < Object.keys(metricById).length,
+			`Messgrundlage weg: ${gerendert.length} gerenderte von ` +
+				`${Object.keys(metricById).length} Katalog-Groessen. Der Test braucht eine ` +
+				`echte Teilmenge — Lage neu bewerten, nicht den Test anpassen.`
+		);
+		// Positivkontrolle 2 (Messung M1): der ROHE Kuerzel-Katalog fuehrt Kuerzel,
+		// die keine gerenderte Groesse traegt — allen voran `CP` (`cape`,
+		// selectable=False).
+		const roh = new Set(Object.values(kuerzelById).flat());
+		const nieGerendert = [...roh].filter((k) => !erwartet.has(k));
+		assert.ok(
+			nieGerendert.length > 0,
+			`Messung M1 gilt nicht mehr: jedes Kuerzel des rohen Katalogs gehoert zu ` +
+				`einer gerenderten Groesse. Dann kann dieser Test die naive Speisung aus ` +
+				`\`smsSymbols.metrics\` nicht mehr von der richtigen unterscheiden.`
+		);
+
+		const eintraege = await baue(gerendert, kuerzelById, metricById);
+		assert.deepEqual(
+			[...new Set(eintraege.map((e) => e.kuerzel))].sort(),
+			[...erwartet.keys()].sort(),
+			`AC-1 FAIL: die Legende deckt nicht genau die Kuerzel der gerenderten ` +
+				`Groessen ab. Zu viel heisst: sie erklaert Zeichen, die im ` +
+				`Reihenfolge-Block gar nicht stehen (nicht gerendert waeren u.a. ` +
+				`${nieGerendert.join(', ')}). Zu wenig heisst: eine Marke bleibt ` +
+				`unaufloesbar.`
+		);
+		assert.deepEqual(
+			eintraege.filter((e) => !e.bedeutung?.trim()), [],
+			'AC-1 FAIL: Eintraege ohne Erklaertext — genau das entsteht, wenn die ' +
+				'Legende ueber den rohen Kuerzel-Katalog statt ueber die gerenderten ' +
+				'Groessen iteriert (Mutations-Gegenprobe 1 der Spec).'
+		);
+		for (const e of eintraege) {
+			assert.ok(
+				erwartet.get(e.kuerzel)?.has(e.bedeutung),
+				`AC-1 FAIL: "${e.kuerzel}" wird als ${JSON.stringify(e.bedeutung)} erklaert, ` +
+					`der Katalog kennt dafuer ${JSON.stringify([...(erwartet.get(e.kuerzel) ?? [])])}.`
+			);
+		}
+	});
+
+	test('Trip: eine NICHT gerenderte Groesse bekommt keinen Eintrag', async () => {
+		const kuerzelById = tripKuerzelById();
+		const metricById = tripMetricById();
+		const gerendert = gerendertRoute();
+		// Eine kuerzeltragende Groesse, die NICHT im Block steht, und deren Kuerzel
+		// keine gerenderte Groesse mitfuehrt — echte Daten, nichts erfunden.
+		const erwartet = erwarteteZuordnung(gerendert, kuerzelById, metricById);
+		const draussen = Object.keys(metricById).find(
+			(id) => !gerendert.includes(id) && (kuerzelById[id] ?? []).some((k) => !erwartet.has(k))
+		);
+		assert.ok(draussen, 'Keine nicht gerenderte Groesse mit eigenem Kuerzel gefunden.');
+		const fremd = (kuerzelById[draussen!] ?? []).filter((k) => !erwartet.has(k));
+
+		const eintraege = await baue(gerendert, kuerzelById, metricById);
+		const treffer = eintraege.filter((e) => fremd.includes(e.kuerzel));
+		assert.deepEqual(
+			treffer, [],
+			`AC-1 FAIL: die Legende erklaert ${JSON.stringify(fremd)} (Groesse ` +
+				`"${draussen}"), obwohl diese Groesse im Reihenfolge-Block nicht steht. ` +
+				`Genau so entsteht Rauschen: 20 von 29 Katalog-Groessen sind in einer ` +
+				`frischen Tour nicht gewaehlt (Adversary F001).`
+		);
+	});
+
+	test('Vergleich: jede gerenderte Zeile mit Kuerzel steht mit Bedeutung in der Legende', async () => {
+		const { kuerzelById, metricById } = vergleichPaar();
+		const gerendert = gerendertVergleich();
+		const eintraege = await baue(gerendert, kuerzelById, metricById);
+		const mitKuerzel = gerendert.filter((id) => (kuerzelById[id] ?? []).length > 0);
+		assert.equal(
+			eintraege.length, mitKuerzel.length,
+			`AC-1 FAIL: ${mitKuerzel.length} gerenderte Vergleichszeilen tragen ein ` +
+				`Kuerzel, die Legende zeigt ${eintraege.length} Eintraege.`
+		);
+		assert.deepEqual(
+			eintraege.filter((e) => !e.kuerzel?.trim() || !e.bedeutung?.trim()), [],
+			'AC-1 FAIL: leere Kuerzel oder leere Bedeutungen im Vergleich.'
+		);
+		// Die zurueckgehaltene Zeile darf nicht auftauchen.
+		const zurueck = Object.keys(kuerzelById).find((id) => !gerendert.includes(id));
+		const fremd = (kuerzelById[zurueck!] ?? []).filter(
+			(k) => !gerendert.some((id) => (kuerzelById[id] ?? []).includes(k))
+		);
+		assert.deepEqual(
+			eintraege.filter((e) => fremd.includes(e.kuerzel)), [],
+			`AC-1 FAIL: die Legende erklaert ${JSON.stringify(fremd)} (Zeile ` +
+				`"${zurueck}"), obwohl diese Zeile nicht gerendert wird.`
+		);
+	});
+});
+
+describe('AC-2: der Trip-Editor erklaert die sechs Temperatur-/Windchill-Groessen', () => {
+	test('jedes der sechs Kuerzel traegt sein Registerlabel', async () => {
+		const kuerzelById = tripKuerzelById();
+		const metricById = tripMetricById();
+		// Die sechs gehoeren nicht zur Anlege-Vorbelegung; die Zusicherung gilt
+		// fuer den Nutzer, der sie waehlt — also stehen sie hier im Block.
+		const eintraege = await baue(gerendertRoute(SECHS), kuerzelById, metricById);
+		const nachKuerzel = new Map(eintraege.map((e) => [e.kuerzel, e.bedeutung]));
+		for (const id of SECHS) {
+			const kuerzel = kuerzelById[id] ?? [];
+			assert.equal(
+				kuerzel.length, 1,
+				`Messung M3 gilt nicht mehr: ${id} traegt ${JSON.stringify(kuerzel)} statt ` +
+					`genau einem Kuerzel — AC-2 neu fassen, nicht den Test.`
+			);
+			// Der erwartete Text kommt aus DERSELBEN Quelle, aus der ihn auch die
+			// Komponente holt (/api/metrics -> label_de). Nichts hier ist getippt.
+			const label = metricById[id]?.label;
+			assert.ok(label, `Registerlabel fuer ${id} fehlt im Katalog — Scheibe A (#1887) pruefen.`);
+			assert.equal(
+				nachKuerzel.get(kuerzel[0]), label,
+				`AC-2 FAIL: Kuerzel "${kuerzel[0]}" (${id}) wird in der Legende als ` +
+					`${JSON.stringify(nachKuerzel.get(kuerzel[0]))} erklaert statt als ` +
+					`${JSON.stringify(label)}. Ohne diese Zuordnung erkennt der Nutzer nicht, ` +
+					`dass FK/FD/FN dieselben Groessen wie K/D/N in gefuehlter Form sind.`
+			);
+		}
+	});
+});
+
+describe('AC-2a: der Ortsvergleich entdoppelt nicht nach Kuerzel', () => {
+	test('`D` und `TF` bekommen je zwei Zeilen, unterschieden durch die Auswertung', async () => {
+		const { kuerzelById, metricById } = vergleichPaar();
+		const gerendert = gerendertVergleich();
+		const eintraege = await baue(gerendert, kuerzelById, metricById);
+		for (const kuerzel of ['D', 'TF']) {
+			const zeilen = gerendert.filter((k) => (kuerzelById[k] ?? []).includes(kuerzel));
+			// Positivkontrolle zu Messung M2 — ohne Doppelbelegung prueft der Rest nichts.
+			assert.equal(
+				zeilen.length, 2,
+				`Messung M2 gilt nicht mehr: "${kuerzel}" steht auf ${zeilen.length} ` +
+					`Katalogzeilen (${zeilen.join(', ')}). AC-2a neu fassen, nicht den Test.`
+			);
+			const treffer = eintraege.filter((e) => e.kuerzel === kuerzel);
+			assert.equal(
+				treffer.length, 2,
+				`AC-2a FAIL: "${kuerzel}" erscheint ${treffer.length}-mal statt zweimal. ` +
+					`Eine Entdopplung nach Kuerzel bricht die Zusicherung „dieselbe Quelle wie ` +
+					`die Marken" — die Marken zeigen das Kuerzel an BEIDEN Zeilen.`
+			);
+			for (const key of zeilen) {
+				const auswertung = String(metricById[key].aggregation_label ?? '');
+				assert.equal(
+					treffer.filter((t) => t.bedeutung.includes(auswertung)).length, 1,
+					`AC-2a FAIL: die Auswertung ${JSON.stringify(auswertung)} (${key}) ist in ` +
+						`der Legende nicht genau einmal ablesbar. Ohne sie sind die beiden ` +
+						`"${kuerzel}"-Zeilen nicht unterscheidbar: ` +
+						`${JSON.stringify(treffer.map((t) => t.bedeutung))}`
+				);
+			}
+		}
+		// Der Editor zeigt das ROHE Kuerzel; erst die zugestellte SMS haengt das
+		// Auswertungszeichen an (comparison.py:647-650, Messung M2b). Die Legende
+		// bildet das Editor-Vokabular ab — `D`, nicht `D+`/`D-`.
+		assert.deepEqual(
+			eintraege.filter((e) => /[+-]/.test(e.kuerzel)), [],
+			'AC-2a FAIL: Kuerzel mit Auswertungszeichen in der Vergleichs-Legende — ' +
+				'die Marken im selben Editor zeigen das Zeichen nicht.'
+		);
+	});
+});
+
+describe('AC-4: fehlende Quelle erzeugt keine Leerzeilen', () => {
+	test('leere oder halbe Datenlage liefert gar keine Eintraege', async () => {
+		const gerendert = gerendertRoute();
+		assert.deepEqual(await baue([], {}, {}), [], 'AC-4 FAIL: Eintraege ohne jede Quelle.');
+		assert.deepEqual(
+			await baue(gerendert, tripKuerzelById(), {}), [],
+			'AC-4 FAIL: Kuerzel ohne Bedeutungs-Katalog erzeugen Eintraege — die Legende ' +
+				'zeigte dann Kuerzel ohne Erklaerung (schlechter als keine Legende).'
+		);
+		assert.deepEqual(
+			await baue(gerendert, {}, tripMetricById()), [],
+			'AC-4 FAIL: Bedeutungen ohne Kuerzel-Katalog erzeugen Eintraege.'
+		);
+		assert.deepEqual(
+			await baue([], tripKuerzelById(), tripMetricById()), [],
+			'AC-4 FAIL: ohne gerenderte Groessen entstehen Eintraege — dann haengt die ' +
+				'Menge doch am vollen Katalog statt am Reihenfolge-Block (Adversary F001).'
+		);
+		assert.deepEqual(
+			await baue(null, null, null), [],
+			'AC-4 FAIL: die Ableitung wirft oder liefert bei fehlenden Quellen nicht [].'
+		);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// (B) STRUKTURSCHICHT — echter Svelte-5-AST von WeatherMetricsTab.svelte
+// ═══════════════════════════════════════════════════════════════════════════
+
+const QUELLE = readFileSync(TAB, 'utf-8');
+const AST: Knoten = parse(QUELLE, { modern: true });
+
+interface Bedingung { quelle: string; test: Knoten; negiert: boolean }
+
+/** Tiefensuche mit Elternkette UND den WIRKSAMEN {#if}-Bedingungen: im
+ *  {:else}-Zweig gilt die Bedingung NEGIERT, nicht etwa gar nicht. Genau
+ *  daran haengt die Kontext-Zuordnung — der Reiter ist ein einziges
+ *  `{#if context === 'vergleich'} … {:else} … {/if}` (:1228/:1422/:1824). */
+function gehe(
+	node: unknown,
+	besuch: (n: Knoten, eltern: Knoten[], bed: Bedingung[]) => void,
+	eltern: Knoten[] = [], bed: Bedingung[] = []
+): void {
+	if (node === null || typeof node !== 'object') return;
+	if (Array.isArray(node)) { node.forEach((n) => gehe(n, besuch, eltern, bed)); return; }
+	const n = node as Knoten;
+	if (n.type) besuch(n, eltern, bed);
+	const kette = n.type ? [...eltern, n] : eltern;
+	const test = n.type === 'IfBlock' && n.test ? QUELLE.slice(n.test.start, n.test.end) : null;
+	for (const key of Object.keys(n)) {
+		if (key === 'parent' || key === 'loc') continue;
+		const naechste = test === null || (key !== 'consequent' && key !== 'alternate')
+			? bed
+			: [...bed, { quelle: test, test: n.test, negiert: key === 'alternate' }];
+		gehe(n[key], besuch, kette, naechste);
+	}
+}
+
+/** Bezeichner UND Objekt-Eigenschaften eines Teilbaums (`m.sms_code` -> beide). */
+function geleseneNamen(subtree: unknown): Set<string> {
+	const namen = new Set<string>();
+	gehe(subtree, (n) => {
+		if (n.type === 'Identifier' && typeof n.name === 'string') namen.add(n.name);
+		if (n.type === 'MemberExpression' && !n.computed && n.property?.type === 'Identifier')
+			namen.add(n.property.name);
+	});
+	return namen;
+}
+
+/** Alle festen Texte eines Teilbaums: Zeichenketten-Literale und Markup-Text. */
+function festeTexte(subtree: unknown): string[] {
+	const out: string[] = [];
+	gehe(subtree, (n) => {
+		if (n.type === 'Literal' && typeof n.value === 'string') out.push(n.value.trim());
+		if (n.type === 'Text' && typeof n.data === 'string') out.push(n.data.trim());
+	});
+	return out.filter(Boolean);
+}
+
+function attributWert(n: Knoten, name: string): string | null {
+	for (const a of n.attributes ?? []) {
+		if (a.type !== 'Attribute' || a.name !== name) continue;
+		const v = Array.isArray(a.value) ? a.value : [a.value];
+		const literal = v.find((x: Knoten) => x?.type === 'Text');
+		return literal ? String(literal.data) : '';
+	}
+	return null;
+}
+
+function legendenElemente(): { knoten: Knoten; eltern: Knoten[]; bed: Bedingung[] }[] {
+	const treffer: { knoten: Knoten; eltern: Knoten[]; bed: Bedingung[] }[] = [];
+	gehe(AST.fragment, (n, eltern, bed) => {
+		if (n.type !== 'RegularElement' && n.type !== 'Component') return;
+		if (attributWert(n, 'data-testid') === LEGENDE_TESTID) treffer.push({ knoten: n, eltern, bed });
+	});
+	return treffer;
+}
+
+/** Die eine Legende — mit sprechendem Fehlschlag statt Absturz, solange es sie nicht gibt. */
+function dieLegende() {
+	const treffer = legendenElemente();
+	assert.equal(
+		treffer.length, 1,
+		`RED: es muss GENAU EIN Element mit data-testid="${LEGENDE_TESTID}" in ` +
+			`WeatherMetricsTab.svelte geben (gefunden: ${treffer.length}). Null bedeutet ` +
+			`keine Legende, mehr als eins bedeutet eine kontexteigene Kopie statt eines ` +
+			`geteilten Bausteins (AC-5).`
+	);
+	return treffer[0];
+}
+
+const istVergleich = (bed: Bedingung[]) =>
+	bed.some((b) => !b.negiert && /context\s*===\s*['"]vergleich['"]/.test(b.quelle));
+const istRoute = (bed: Bedingung[]) =>
+	bed.some((b) => b.negiert && /context\s*===\s*['"]vergleich['"]/.test(b.quelle));
+
+/** Alle `{@render <name>(…)}`-Stellen samt wirksamen Bedingungen. */
+function renderStellen(name: string): { knoten: Knoten; bed: Bedingung[] }[] {
+	const stellen: { knoten: Knoten; bed: Bedingung[] }[] = [];
+	gehe(AST.fragment, (n, _e, bed) => {
+		if (n.type === 'RenderTag' && QUELLE.slice(n.start, n.end).includes(name + '('))
+			stellen.push({ knoten: n, bed });
+	});
+	return stellen;
+}
+
+/** Namen, die eine Aufrufstelle erreicht: ihre Argumente plus — einen Schritt
+ *  tief — die Herleitung der dort genannten Bezeichner (Muster
+ *  weather_metric_kuerzel_marken.test.ts::kuerzelQuelle). */
+function erreichteNamen(stelle: Knoten): Set<string> {
+	const direkt = geleseneNamen(stelle);
+	const alle = new Set(direkt);
+	gehe(AST.instance?.content?.body, (n) => {
+		if (n.type !== 'VariableDeclarator') return;
+		const name = n.id?.type === 'Identifier' ? n.id.name : null;
+		if (!name || !direkt.has(name)) return;
+		for (const g of geleseneNamen(n.init)) alle.add(g);
+	});
+	return alle;
+}
+
+describe('AC-5: ein Snippet, an beiden Reihenfolge-Bloecken', () => {
+	test('die Legende steht genau einmal, in einem Snippet', () => {
+		const legende = dieLegende();
+		const snippet = legende.eltern.filter((e) => e.type === 'SnippetBlock').pop();
+		assert.ok(
+			snippet,
+			`AC-5 FAIL: das Legenden-Markup liegt in keinem {#snippet} — dann kann es ` +
+				`nicht an zwei Stellen wiederverwendet werden, ohne kopiert zu werden ` +
+				`(Vorbild: officialAlertsToggle, WeatherMetricsTab.svelte:1189-1226).`
+		);
+	});
+
+	test('dasselbe Snippet wird in BEIDEN Kontexten gerendert', () => {
+		const legende = dieLegende();
+		const snippet = legende.eltern.filter((e) => e.type === 'SnippetBlock').pop();
+		assert.ok(snippet, 'AC-5 FAIL: kein Snippet — s. Test darueber.');
+		const name = String(snippet!.expression?.name ?? '');
+		const stellen = renderStellen(name);
+		assert.ok(
+			stellen.some((s) => istVergleich(s.bed)),
+			`AC-5 FAIL: \`${name}\` wird im Ortsvergleich-Zweig nicht gerendert. ` +
+				`Gefundene Aufrufstellen: ${stellen.length}.`
+		);
+		assert.ok(
+			stellen.some((s) => istRoute(s.bed)),
+			`AC-5 FAIL: \`${name}\` wird im Trip-Zweig ({:else} von ` +
+				`\`context === 'vergleich'\`) nicht gerendert. Aufrufstellen: ${stellen.length}.`
+		);
+	});
+
+	test('beide Aufrufstellen haengen am Reihenfolge-Abschnitt', () => {
+		const legende = dieLegende();
+		const snippet = legende.eltern.filter((e) => e.type === 'SnippetBlock').pop();
+		assert.ok(snippet, 'AC-5 FAIL: kein Snippet — s. Test darueber.');
+		const name = String(snippet!.expression?.name ?? '');
+		for (const [flaeche, waehle] of [['Ortsvergleich', istVergleich], ['Trip', istRoute]] as const) {
+			const stelle = renderStellen(name).find((s) => waehle(s.bed));
+			assert.ok(stelle, `AC-5 FAIL: keine Aufrufstelle im ${flaeche}-Zweig.`);
+			assert.ok(
+				stelle!.bed.some((b) => !b.negiert && /sections\.includes\(\s*'reihenfolge'\s*\)/.test(b.quelle)),
+				`AC-5 FAIL: die ${flaeche}-Aufrufstelle haengt nicht am Reihenfolge-Abschnitt. ` +
+					`Nur dieser Block zeigt ALLE Groessen inklusive der abgewaehlten und ist ` +
+					`der einzige Ort, den beide Kontexte teilen. Bedingungen: ` +
+					`${JSON.stringify(stelle!.bed.map((b) => (b.negiert ? '!' : '') + b.quelle))}`
+			);
+		}
+	});
+});
+
+describe('AC-3: die Legende speist sich aus der Marken-Quelle, nicht aus einer zweiten Liste', () => {
+	const TRIP_QUELLEN = ['metricSymbols', 'smsSymbols', 'sms_symbols'];
+	const TRIP_BEDEUTUNG = ['metricById', 'catalog'];
+	const VERGLEICH_QUELLEN = ['compareKuerzelById', 'compareCatalog'];
+	const VERGLEICH_BEDEUTUNG = ['compareMetricById', 'compareCatalog'];
+
+	test('Trip-Aufrufstelle: Kuerzel UND Bedeutung aus den Trip-Katalogen', () => {
+		const legende = dieLegende();
+		const snippet = legende.eltern.filter((e) => e.type === 'SnippetBlock').pop();
+		assert.ok(snippet, 'AC-3 FAIL: kein Legenden-Snippet.');
+		const stelle = renderStellen(String(snippet!.expression?.name ?? '')).find((s) => istRoute(s.bed));
+		assert.ok(stelle, 'AC-3 FAIL: keine Trip-Aufrufstelle.');
+		const erreicht = erreichteNamen(stelle!.knoten);
+		assert.ok(
+			TRIP_QUELLEN.some((q) => erreicht.has(q)),
+			`AC-3 FAIL: die Trip-Legende erreicht keine der Kuerzel-Quellen ` +
+				`${TRIP_QUELLEN.join('/')} — sie zeigte dann andere Kuerzel als die Marken ` +
+				`daneben. Erreichbar: ${JSON.stringify([...erreicht].sort())}`
+		);
+		assert.ok(
+			TRIP_BEDEUTUNG.some((q) => erreicht.has(q)),
+			`AC-3 FAIL: die Trip-Legende erreicht weder \`metricById\` noch \`catalog\` — ` +
+				`ohne die Menge der GERENDERTEN Groessen bleibt nur der rohe Kuerzel-Katalog ` +
+				`als Quelle, und der bringt \`CP\` ohne Bedeutung mit (Messung M1). ` +
+				`Erreichbar: ${JSON.stringify([...erreicht].sort())}`
+		);
+		const fremd = VERGLEICH_QUELLEN.filter((q) => erreicht.has(q));
+		assert.deepEqual(fremd, [], `AC-3 FAIL: die Trip-Legende erreicht Vergleichs-Quellen (${fremd.join(', ')}).`);
+	});
+
+	test('Vergleichs-Aufrufstelle: Kuerzel UND Bedeutung aus den Compare-Katalogen', () => {
+		const legende = dieLegende();
+		const snippet = legende.eltern.filter((e) => e.type === 'SnippetBlock').pop();
+		assert.ok(snippet, 'AC-3 FAIL: kein Legenden-Snippet.');
+		const stelle = renderStellen(String(snippet!.expression?.name ?? '')).find((s) => istVergleich(s.bed));
+		assert.ok(stelle, 'AC-3 FAIL: keine Vergleichs-Aufrufstelle.');
+		const erreicht = erreichteNamen(stelle!.knoten);
+		for (const gruppe of [VERGLEICH_QUELLEN, VERGLEICH_BEDEUTUNG]) {
+			assert.ok(
+				gruppe.some((q) => erreicht.has(q)),
+				`AC-3 FAIL: die Vergleichs-Legende erreicht keine von ${gruppe.join('/')}. ` +
+					`Erreichbar: ${JSON.stringify([...erreicht].sort())}`
+			);
+		}
+		const fremd = ['metricSymbols', 'smsSymbols'].filter((q) => erreicht.has(q));
+		assert.deepEqual(
+			fremd, [],
+			`AC-3 FAIL: die Vergleichs-Legende erreicht die TRIP-Quelle (${fremd.join(', ')}). ` +
+				`Trip und Vergleich senden aus verschiedenen Tabellen — die Legende zeigte ` +
+				`Kuerzel, die der Vergleich nie sendet.`
+		);
+	});
+
+	test('im Legenden-Markup steht kein Kuerzel und kein Label als fester Text', () => {
+		const legende = dieLegende();
+		const snippet = legende.eltern.filter((e) => e.type === 'SnippetBlock').pop();
+		assert.ok(snippet, 'AC-3 FAIL: kein Legenden-Snippet.');
+		const verboten = new Set<string>([
+			...Object.values(tripKuerzelById()).flat(),
+			...Object.values(tripMetricById()).map((m) => String(m.label)),
+			...SECHS
+		]);
+		const treffer = festeTexte(snippet).filter((t) => verboten.has(t));
+		assert.deepEqual(
+			treffer, [],
+			`AC-3 FAIL: das Legenden-Snippet fuehrt feste Kuerzel/Labels ` +
+				`(${treffer.join(', ')}) — das ist die zweite Liste im Frontend, die der ` +
+				`Waechter officialAlertLegend.test.ts:395-415 fuer die Warnungs-Legende ` +
+				`bereits verbietet. Kuerzel und Bedeutung muessen aus den Katalogen kommen.`
+		);
+	});
+});
+
+describe('AC-4: der Guard haengt an den Daten, nicht am Kontext', () => {
+	test('die Legende steht unter einer Bedingung ueber ihrer eigenen Quelle', () => {
+		const legende = dieLegende();
+		const wirksam = legende.bed.filter((b) => !b.negiert);
+		assert.ok(
+			wirksam.length > 0,
+			'AC-4 FAIL: das Legenden-Markup steht in keinem {#if}. Ohne Katalog erschiene ' +
+				'eine leere Legende statt gar keiner (Vorbild: `{#if smsSymbols}`, :1210).'
+		);
+		const kontextGuard = legende.bed.find((b) => /\bcontext\b/.test(b.quelle));
+		assert.equal(
+			kontextGuard, undefined,
+			`AC-4/AC-5 FAIL: die Legende haengt an einer Kontext-Bedingung ` +
+				`(${kontextGuard?.quelle}) — sie muss in BEIDEN Flaechen erscheinen und nur ` +
+				`an der geladenen Quelle haengen.`
+		);
+		const inhalt = geleseneNamen(legende.knoten);
+		assert.ok(
+			wirksam.some((b) => [...geleseneNamen(b.test)].some((name) => inhalt.has(name))),
+			`AC-4 FAIL: die Bedingung prueft etwas anderes, als die Legende anzeigt ` +
+				`(Bedingungen ${JSON.stringify(wirksam.map((b) => b.quelle))}, Legende liest ` +
+				`${JSON.stringify([...inhalt])}). Dann kann trotz wahrer Bedingung eine leere ` +
+				`Legende erscheinen.`
+		);
+	});
+
+	// Adversary F003: der Test darueber prueft nur, ob die Bedingung denselben
+	// NAMEN liest wie der Inhalt — nicht, ob sie auf Leere prueft. Eine
+	// Tautologie wie `eintraege.length >= 0` liest denselben Namen, wird nie
+	// falsch und rendert bei leerer Quelle ein leeres Geruest (Intro-Satz plus
+	// leere Liste). Dieselbe Klasse wie F002: geprueft, wo der Code steht, nicht
+	// wo er wirkt. Also wird die Bedingung hier AUSGEFUEHRT — mit demselben
+	// Mechanismus wie Schicht C, gegen leere und nichtleere Daten.
+	test('die Bedingung wertet bei leerer Legende WIRKLICH falsch aus', () => {
+		const legende = dieLegende();
+		const snippet = legende.eltern.filter((e) => e.type === 'SnippetBlock').pop();
+		assert.ok(snippet, 'AC-4 FAIL: kein Legenden-Snippet.');
+		const parameter = ((snippet!.parameters ?? []) as Knoten[])
+			.map((p) => (p.type === 'Identifier' ? String(p.name) : null))
+			.filter((n): n is string => Boolean(n));
+		assert.ok(
+			parameter.length > 0,
+			'AC-4 FAIL: das Legenden-Snippet nimmt keinen benannten Parameter entgegen. ' +
+				'Dann laesst sich seine Bedingung nicht gegen leere und nichtleere Daten ' +
+				'ausfuehren — die Wirksamkeit des Guards bliebe ungeprueft, und genau das ' +
+				'ist der Zustand, den dieser Test beendet (F003).'
+		);
+		assert.ok(
+			legende.bed.length > 0,
+			'AC-4 FAIL: ueber dem Legenden-Markup steht keine Bedingung. Bei leerer Quelle ' +
+				'erschiene dann ein leeres Legenden-Geruest statt gar nichts.'
+		);
+		const ausdruck = legende.bed
+			.map((b) => (b.negiert ? `!(${b.quelle})` : `(${b.quelle})`))
+			.join(' && ');
+
+		/** Wertet die ECHTE Bedingung aus, mit den Snippet-Parametern auf die
+		 *  Probe-Daten gebunden. Ein Bezeichner, der nicht zum Legenden-Inhalt
+		 *  gehoert, fliegt als ReferenceError auf statt still durchzulaufen. */
+		function auswerten(eintraege: Eintrag[]): unknown {
+			const umgebung = Object.fromEntries(parameter.map((name) => [name, eintraege]));
+			try {
+				return new Function('u', `with (u) { return ${ausdruck}; }`)(umgebung);
+			} catch (e) {
+				return assert.fail(
+					`AC-4 FAIL: die Bedingung \`${ausdruck}\` laesst sich nicht gegen die Daten ` +
+						`der Legende ausfuehren: ${(e as Error).message}. Sie haengt dann an ` +
+						`etwas anderem als an dem Inhalt, den sie schuetzen soll.`
+				);
+			}
+		}
+
+		assert.ok(
+			!auswerten([]),
+			`AC-4 FAIL: die Bedingung \`${ausdruck}\` ist bei LEERER Legende WAHR. Der ` +
+				`Reiter zeigte dann ohne Katalog ein leeres Geruest (Intro-Satz plus leere ` +
+				`Liste) statt gar nichts. Eine namensgleiche, aber wirkungslose Bedingung ` +
+				`(\`length >= 0\`) besteht die Namensprobe darueber und faellt nur hier auf.`
+		);
+
+		// F004: zwei Probepunkte (0 und 1) reichen nicht — `length === 1` traf
+		// beide zufaellig und blieb ungefangen, obwohl die Legende damit im
+		// Betrieb praktisch nie erschiene (eine frische Tour rendert 9 Groessen).
+		// Geprueft wird deshalb eine REIHE von Groessen, ausdruecklich mit
+		// * mehr als einer Zeile (faengt `=== 1`),
+		// * der Zahl, die im Betrieb wirklich auftritt, und dem Doppelten davon
+		//   (faengt jede obere Schranke wie `>= 1 && <= 2` oder `< 20`),
+		// * einer Primzahl neben Vielfachen (faengt Rest-Bedingungen wie `% 3`).
+		const echteAnzahl = gerendertRoute().reduce(
+			(n, id) => n + (tripKuerzelById()[id] ?? []).length, 0
+		);
+		assert.ok(echteAnzahl > 2, `Messgrundlage weg: nur ${echteAnzahl} echte Legenden-Zeilen.`);
+		for (const anzahl of [...new Set([1, 2, 3, 4, 6, echteAnzahl, echteAnzahl * 2])]) {
+			assert.ok(
+				auswerten(probeEintraege(anzahl)),
+				`AC-4 FAIL: die Bedingung \`${ausdruck}\` ist bei ${anzahl} Zeilen FALSCH. ` +
+					`Die Legende erschiene dann nicht, obwohl Zeilen vorliegen — eine ` +
+					`Bedingung mit fester Zahl (\`=== 1\`) oder oberer Schranke faellt genau ` +
+					`hier auf. Im Betrieb entstehen ${echteAnzahl} Zeilen.`
+			);
+		}
+		// Und sie darf nicht am INHALT der Zeilen haengen, nur an ihrer Zahl:
+		// eine Bedingung wie `eintraege[0].kuerzel === 'X'` bestuende sonst jede
+		// Groessen-Probe, die zufaellig dieselben Daten benutzt.
+		for (const anzahl of [1, echteAnzahl]) {
+			assert.equal(
+				Boolean(auswerten(probeEintraege(anzahl, 1))),
+				Boolean(auswerten(probeEintraege(anzahl, 0))),
+				`AC-4 FAIL: die Bedingung \`${ausdruck}\` haengt bei ${anzahl} Zeilen am ` +
+					`INHALT der Zeilen, nicht an ihrer Zahl. Dann entscheidet ueber die ` +
+					`Sichtbarkeit der Legende, WELCHE Groessen der Nutzer gewaehlt hat.`
+			);
+		}
+	});
+
+	// F005: die Ausfuehrungsprobe darueber ist eine STICHPROBE, und jede endliche
+	// Stichprobe laesst sich umgehen — `eintraege.length && eintraege.length % 5
+	// !== 0` besteht alle geprueften Groessen [0,1,2,3,4,6,9,18] und waere bei 5,
+	// 10, 15 Zeilen trotzdem falsch. Ein Modulo-5-Punkt erzeugt eine
+	// Modulo-7-Luecke: Wettruesten ohne Ende.
+	//
+	// Deshalb hier keine weitere Stichprobe, sondern eine FORM-Pruefung, die die
+	// ganze Klasse schliesst. Verhalten und Form gemeinsam konvergieren: die
+	// Ausfuehrungsprobe allein ist per Stichprobe umgehbar (F005), die Form
+	// allein pruefte nur den Namen und nicht die Wirkung (F003).
+	test('die Bedingung ist ein schlichter Leere-Test — bewusst, nicht zufaellig', () => {
+		const legende = dieLegende();
+		const snippet = legende.eltern.filter((e) => e.type === 'SnippetBlock').pop();
+		assert.ok(snippet, 'AC-4 FAIL: kein Legenden-Snippet.');
+		const parameter = ((snippet!.parameters ?? []) as Knoten[])
+			.map((p) => (p.type === 'Identifier' ? String(p.name) : null))
+			.filter((n): n is string => Boolean(n));
+		assert.ok(parameter.length > 0, 'AC-4 FAIL: das Legenden-Snippet hat keinen benannten Parameter.');
+		assert.equal(
+			legende.bed.length, 1,
+			`AC-4 FAIL: ueber dem Legenden-Markup stehen ${legende.bed.length} Bedingungen ` +
+				`(${JSON.stringify(legende.bed.map((b) => (b.negiert ? '!' : '') + b.quelle))}). ` +
+				`Erwartet ist genau eine: der Leere-Test auf die Legenden-Zeilen.`
+		);
+		assert.equal(legende.bed[0].negiert, false, 'AC-4 FAIL: die Legende haengt in einem {:else}-Zweig.');
+
+		/** `<parameter>.length` — ohne Optional Chaining, ohne Index-Zugriff. */
+		function istLaenge(n: Knoten | null | undefined): boolean {
+			return !!n && n.type === 'MemberExpression' && !n.computed && !n.optional
+				&& n.object?.type === 'Identifier' && parameter.includes(String(n.object.name))
+				&& n.property?.type === 'Identifier' && n.property.name === 'length';
+		}
+		const istNull = (n: Knoten | null | undefined) => !!n && n.type === 'Literal' && n.value === 0;
+
+		const test = legende.bed[0].test as Knoten;
+		const schlicht =
+			istLaenge(test) ||
+			(test?.type === 'BinaryExpression' && (
+				(['>', '!==', '!='].includes(test.operator) && istLaenge(test.left) && istNull(test.right)) ||
+				(['<', '!==', '!='].includes(test.operator) && istNull(test.left) && istLaenge(test.right))
+			));
+
+		assert.ok(
+			schlicht,
+			`AC-4 FAIL: die Bedingung \`${legende.bed[0].quelle}\` ist kein schlichter ` +
+				`Leere-Test auf ${parameter.join('/')}. Erlaubt sind genau ` +
+				`\`${parameter[0]}.length\` und der Vergleich gegen 0 (\`> 0\`, \`!== 0\`) — ` +
+				`nichts sonst: keine weiteren Operanden, keine andere Konstante, kein Modulo, ` +
+				`kein Optional Chaining, kein zweiter Bezeichner.\n` +
+				`WARUM SO STRENG: die Ausfuehrungsprobe darueber ist eine Stichprobe ueber ` +
+				`einzelne Zeilenzahlen, und jede endliche Stichprobe hat Luecken — ` +
+				`\`length && length % 5 !== 0\` besteht sie und waere bei 5, 10, 15 Zeilen ` +
+				`trotzdem falsch (Adversary F005). Erst Form UND Verhalten zusammen schliessen ` +
+				`die Klasse. Die Schlichtheit ist damit eine bewusste Invariante, kein Zufall.\n` +
+				`WENN DU SIE AENDERN WILLST: nicht diesen Test aufweichen, sondern hier ` +
+				`bewusst die neue Schreibweise aufnehmen und begruenden, warum sie ` +
+				`ausschliesslich an der Leere haengt.`
+		);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// (C) VERDRAHTUNGSSCHICHT — die ECHTE Aufrufstelle, gegen echte Kataloge
+//
+// Adversary F002: Schicht (A) ruft die Ableitung mit selbst sortierten
+// Argumenten auf, Schicht (B) prueft nur, welche Bezeichner eine Aufrufstelle
+// ERREICHT — nicht, an welcher Stelle sie stehen. Vertauscht man an der
+// route-Aufrufstelle die Argumente, ist die Trip-Legende in Produktion leer,
+// und beide Schichten bleiben gruen. Die Zusicherung war dort geprueft, wo der
+// Code steht, nicht dort, wo er wirkt.
+//
+// Hier wird deshalb der Quelltext des `buildKuerzelLegende(...)`-Aufrufs aus
+// dem AST gelesen und AUSGEFUEHRT — mit der echten Funktion und den echten
+// Katalogen unter ihren echten Namen. Nichts daran ist nachgebaut: dreht
+// jemand die Argumente, aendert sich das Ergebnis dieses Aufrufs.
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** Quelltext des `buildKuerzelLegende(...)`-Aufrufs, der die Legende an DIESER
+ *  Aufrufstelle speist: Renderstelle -> uebergebener Bezeichner -> dessen
+ *  Deklaration -> der Aufruf darin. */
+function aufrufQuelltext(waehle: (bed: Bedingung[]) => boolean, flaeche: string): string {
+	const legende = dieLegende();
+	const snippet = legende.eltern.filter((e) => e.type === 'SnippetBlock').pop();
+	assert.ok(snippet, 'kein Legenden-Snippet.');
+	const stelle = renderStellen(String(snippet!.expression?.name ?? '')).find((s) => waehle(s.bed));
+	assert.ok(stelle, `keine ${flaeche}-Aufrufstelle der Legende.`);
+	const uebergeben = geleseneNamen(stelle!.knoten);
+	let quelltext: string | null = null;
+	gehe(AST.instance?.content?.body, (n) => {
+		if (n.type !== 'VariableDeclarator' || quelltext) return;
+		if (n.id?.type !== 'Identifier' || !uebergeben.has(n.id.name)) return;
+		gehe(n.init, (k) => {
+			if (quelltext) return;
+			if (k.type === 'CallExpression' && k.callee?.name === 'buildKuerzelLegende') {
+				quelltext = QUELLE.slice(k.start, k.end);
+			}
+		});
+	});
+	assert.ok(
+		quelltext,
+		`F002 FAIL: an der ${flaeche}-Aufrufstelle laesst sich kein ` +
+			`\`buildKuerzelLegende(...)\`-Aufruf finden (uebergeben: ` +
+			`${JSON.stringify([...uebergeben].sort())}). Ohne ihn kann dieser Test die ` +
+			`Argumentreihenfolge der echten Verdrahtung nicht pruefen.`
+	);
+	return quelltext!;
+}
+
+/** Fuehrt den Aufruf-Quelltext gegen echte Kataloge aus. Unbekannte Namen
+ *  fliegen als ReferenceError auf — eine Legende darf sich nur aus den
+ *  Quellen speisen, die auch die Marken speisen (AC-3). */
+async function fuehreAufrufAus(quelltext: string, umgebung: Knoten): Promise<Eintrag[]> {
+	const alle = { ...umgebung, buildKuerzelLegende: await ableitung() };
+	try {
+		return new Function('u', `with (u) { return ${quelltext}; }`)(alle) as Eintrag[];
+	} catch (e) {
+		assert.fail(
+			`F002 FAIL: der echte Aufruf \`${quelltext}\` laeuft nicht gegen die ` +
+				`Katalog-Quellen der Marken: ${(e as Error).message}. Bekannt sind hier ` +
+				`${JSON.stringify(Object.keys(alle).sort())}.`
+		);
+	}
+}
+
+describe('F002: die ECHTE Aufrufstelle liefert eine richtige Legende', () => {
+	test('Trip: der Aufruf aus der Komponente erklaert die gerenderten Kuerzel', async () => {
+		const kuerzelById = tripKuerzelById();
+		const metricById = tripMetricById();
+		const aktiv = gerendertRoute(SECHS);
+		const abgewaehlt = Object.keys(metricById).filter((id) => !aktiv.includes(id)).slice(0, 2);
+		const erwartet = erwarteteZuordnung([...aktiv, ...abgewaehlt], kuerzelById, metricById);
+
+		const eintraege = await fuehreAufrufAus(aufrufQuelltext(istRoute, 'Trip'), {
+			// Die Namen sind die der Komponente; die Werte sind echt. `active` und
+			// `off` sind beide gerendert (Aus-Gruppe, WeatherV2Reihenfolge:174-178).
+			activeChannelSections: { active: aktiv, off: abgewaehlt },
+			metricSymbols: kuerzelById,
+			metricById,
+			catalog: live().metrics,
+			smsSymbols: live().sms
+		});
+
+		assert.ok(
+			eintraege.length > 0,
+			`F002 FAIL: die Trip-Legende ist bei voll geladenen Katalogen LEER. Genau das ` +
+				`passiert, wenn an der Aufrufstelle die Argumente vertauscht sind — dem ` +
+				`Nutzer fehlt dann die ganze Legende, ohne dass irgendetwas rot wird. ` +
+				`Aufruf: ${aufrufQuelltext(istRoute, 'Trip')}`
+		);
+		assert.deepEqual(
+			[...new Set(eintraege.map((e) => e.kuerzel))].sort(),
+			[...erwartet.keys()].sort(),
+			`F002/F001 FAIL: die echte Verdrahtung liefert nicht die Kuerzel der ` +
+				`gerenderten Groessen. Zu viel heisst: die Menge haengt am vollen Katalog ` +
+				`(${Object.keys(metricById).length} Groessen) statt am Reihenfolge-Block ` +
+				`(${aktiv.length + abgewaehlt.length}).`
+		);
+		for (const e of eintraege) {
+			assert.ok(
+				erwartet.get(e.kuerzel)?.has(e.bedeutung),
+				`F002 FAIL: "${e.kuerzel}" wird als ${JSON.stringify(e.bedeutung)} erklaert, ` +
+					`der Katalog kennt ${JSON.stringify([...(erwartet.get(e.kuerzel) ?? [])])}.`
+			);
+		}
+	});
+
+	test('Vergleich: der Aufruf aus der Komponente erklaert die gerenderten Kuerzel', async () => {
+		const { kuerzelById, metricById } = vergleichPaar();
+		const aktiv = gerendertVergleich();
+		const erwartet = erwarteteZuordnung(aktiv, kuerzelById, metricById);
+
+		const eintraege = await fuehreAufrufAus(aufrufQuelltext(istVergleich, 'Vergleich'), {
+			compareChannelSections: { active: aktiv, off: [] },
+			compareKuerzelById: kuerzelById,
+			compareMetricById: metricById,
+			compareCatalog: toCompareSelectionEntries({ metrics: live().compare } as never)
+		});
+
+		assert.ok(
+			eintraege.length > 0,
+			'F002 FAIL: die Vergleichs-Legende ist bei geladenem Katalog LEER.'
+		);
+		assert.deepEqual(
+			[...new Set(eintraege.map((e) => e.kuerzel))].sort(),
+			[...erwartet.keys()].sort(),
+			'F002/F001 FAIL: die echte Verdrahtung liefert nicht die Kuerzel der ' +
+				'gerenderten Vergleichszeilen.'
+		);
+		// AC-2a an der echten Verdrahtung: `D` bleibt zweimal stehen.
+		assert.equal(
+			eintraege.filter((e) => e.kuerzel === 'D').length, 2,
+			'F002/AC-2a FAIL: die echte Verdrahtung entdoppelt `D` — die Marken zeigen ' +
+				'das Kuerzel an beiden Zeilen.'
+		);
+	});
+});

--- a/frontend/src/lib/components/shared/weather-metrics-tab/kuerzelLegende.ts
+++ b/frontend/src/lib/components/shared/weather-metrics-tab/kuerzelLegende.ts
@@ -1,0 +1,84 @@
+// Issue #1888 (Etappe E6, Scheibe B): Ableitung der Kuerzel-Legende im Reiter
+// „Wetter-Metriken" — EIN Datenfluss fuer Trip UND Ortsvergleich.
+// Spec: docs/specs/modules/fix_1888_e6b_kuerzel_legende.md (AC-1..AC-4)
+//
+// Warum ein eigenes Modul und nicht nur ein Snippet: AC-1/AC-2/AC-2a sind
+// Aussagen ueber MENGEN und TEXTE („kein Kuerzel ohne Bedeutung", „`D` genau
+// zweimal"). An der .svelte-Datei sind sie in der Kern-Schicht nicht messbar —
+// WeatherMetricsTab holt seine Kataloge in $effect/onMount, und SSR fuehrt
+// beides nie aus (ein SSR-Test waere strukturell immer gruen, #1717). Die
+// Legende SELBST bleibt ein Snippet in WeatherMetricsTab.svelte (AC-5).
+//
+// Hier steht bewusst KEIN Kuerzel und KEINE Bedeutung: die Funktion verknuepft
+// nur die beiden Katalog-Objekte, die der Aufrufer ohnehin an den
+// Reihenfolge-Block reicht. Eine eigene Zuordnung waere die zweite Liste im
+// Frontend, die AC-3 (und der Waechter officialAlertLegend.test.ts:395-415)
+// verbietet.
+
+/** Eine Legenden-Zeile: das Kuerzel, wie die Marke daneben es zeigt, und sein
+ *  Klartext. Das Kuerzel bleibt roh — im Ortsvergleich also `D`, nicht `D+`;
+ *  das Auswertungszeichen haengt erst die zugestellte SMS an
+ *  (src/output/renderers/comparison.py:647-650, Messung M2b). Eindeutig wird
+ *  die Zeile durch die mitgezeigte Auswertung, nicht durch ein Vorzeichen. */
+export interface KuerzelLegendeEintrag {
+	kuerzel: string;
+	bedeutung: string;
+}
+
+/** Bedeutungs-Seite: `label` immer, `aggregation_label` nur im Ortsvergleich
+ *  (GET /api/metrics liefert es nicht, GET /api/compare/metrics schon). */
+interface BedeutungsQuelle {
+	label?: string;
+	aggregation_label?: string;
+}
+
+/**
+ * Verknuepft die im Reihenfolge-Block gerenderten Groessen mit Kuerzel- und
+ * Bedeutungs-Katalog zu den Zeilen der Legende.
+ *
+ * Massgeblich ist `gerenderteIds` — die Liste, die der Block tatsaechlich
+ * zeigt (aktive Zeilen UND die Aus-Gruppe), NICHT der volle Backend-Katalog:
+ *
+ *   * Adversary F001: von 29 Katalog-Groessen stehen in einer frischen Tour
+ *     nur 9 im Block. Eine Legende aus dem vollen Katalog erklaerte 20
+ *     Zeichen, die nirgends auf dem Schirm stehen — Rauschen in einem
+ *     Werkzeug, das unter Zeitdruck gelesen wird.
+ *   * Messung M1: `cape` traegt das Kuerzel `CP`, ist aber `selectable=False`
+ *     und im Reiter nirgends eine Marke. Aus dem rohen Kuerzel-Katalog
+ *     gespeist entstuende dort ein Kuerzel ohne jede Bedeutung.
+ *
+ * Es wird NICHT nach Kuerzel entdoppelt: im Ortsvergleich steht `D` auf zwei
+ * Katalogzeilen (Temperatur Maximum/Minimum) und die Marken zeigen es an
+ * beiden — eine Entdopplung braeche die Zusicherung „dieselbe Quelle wie die
+ * Marken" (AC-2a/AC-3).
+ *
+ * Fail-soft (AC-4): fehlt eine der drei Seiten, entstehen gar keine Zeilen —
+ * lieber keine Legende als eine mit leeren Feldern.
+ *
+ * @param gerenderteIds Die Groessen des Reihenfolge-Blocks, in seiner Reihenfolge
+ *                      (route: `activeChannelSections.active` + `.off` ·
+ *                      vergleich: `compareChannelSections.active` + `.off`)
+ * @param kuerzelById   Kuerzel je Groesse (route: `metricSymbols` · vergleich: `compareKuerzelById`)
+ * @param metricById    Bedeutung je Groesse (route: `metricById` · vergleich: `compareMetricById`)
+ */
+export function buildKuerzelLegende(
+	gerenderteIds: string[] | null | undefined,
+	kuerzelById: Record<string, string[]> | null | undefined,
+	metricById: Record<string, BedeutungsQuelle> | null | undefined
+): KuerzelLegendeEintrag[] {
+	const eintraege: KuerzelLegendeEintrag[] = [];
+	const gesehen = new Set<string>();
+	for (const id of gerenderteIds ?? []) {
+		if (typeof id !== 'string' || gesehen.has(id)) continue;
+		gesehen.add(id);
+		const quelle = metricById?.[id];
+		const label = (quelle?.label ?? '').trim();
+		if (!label) continue;
+		const auswertung = (quelle?.aggregation_label ?? '').trim();
+		const bedeutung = auswertung ? `${label} (${auswertung})` : label;
+		for (const kuerzel of kuerzelById?.[id] ?? []) {
+			if (kuerzel) eintraege.push({ kuerzel, bedeutung });
+		}
+	}
+	return eintraege;
+}


### PR DESCRIPTION
Etappe E6 Scheibe B des Epics #1435. Setzt auf #1887 (Scheibe A) auf und schließt nach der Auslieferung **#1857**.

## Worum es geht

Der Reiter „Wetter-Metriken" zeigt SMS-Kürzel (`K`, `D`, `FK`, `FD`, `N`, `FN`, …) als Marken neben den Wettergrößen an, erklärte aber nirgends ihre Bedeutung. Anlass war die PO-Frage „wofür steht WC?", die weder Oberfläche noch Register beantworten konnten.

Diese Scheibe ergänzt eine Legende am Reihenfolge-Block — als **ein** geteiltes Snippet für Trip- **und** Ortsvergleich-Editor.

## Umfang

| | |
|---|---|
| Neu | `frontend/src/lib/components/shared/weather-metrics-tab/kuerzelLegende.ts` (84 Zeilen, Ableitung) |
| Geändert | `frontend/src/lib/components/shared/WeatherMetricsTab.svelte` (+78, rein additiv, fail-soft) |
| Tests | `frontend/src/lib/components/shared/__tests__/metricKuerzelLegende.test.ts` (991 Zeilen, 17 Tests) |

**Reines Frontend, kein Backend-Anteil.** Die Klartext-Bedeutungen lagen seit #1887 bereits im Register (`label_de`); `/api/sms-symbols` musste nicht erweitert werden. Begründung und Messung stehen in `docs/context/fix-1888-e6b-kuerzel-legende.md` (M1).

## Kernzusicherung

Kürzel **und** Bedeutung stammen aus denselben Katalog-Objekten wie die Marken:

| Kontext | Kürzel | Bedeutung |
|---|---|---|
| `route` | `metricSymbols` | `metricById[...].label` |
| `vergleich` | `compareKuerzelById` | `compareMetricById[...].label` + `.aggregation_label` |

Kein zweites Vokabular im Frontend. Der bestehende Wächter „keine zweite Liste" (`officialAlertLegend.test.ts:365-425`) bleibt unangetastet grün.

## Abweichung vom Ticket-Text (vom PO freigegeben)

AC-2 des Tickets („der Nutzer erkennt, dass `FK`/`FD`/`FN` dieselbe Größe in verschiedenen Tagesrichtungen bezeichnen") ist im Ortsvergleich **strukturell nicht erfüllbar** — diese Größen existieren nur im Trip-Katalog (Messung M3). AC-2 gilt deshalb für den Trip-Editor, **AC-2a** ist das Gegenstück für den Ortsvergleich. Freigabe des PO liegt vor (`docs/specs/modules/fix_1888_e6b_kuerzel_legende.md`, Abschnitt Approval).

## Adversary: fünf Runden, fünf behobene Befunde

Alle fünf wurden durch Mutations-Gegenproben gefunden, nicht durch Lesen:

- **F001 (HIGH)** — Die Legende speiste aus dem vollen Katalog (29 Größen) statt aus der gerenderten Menge (`active` + `off`). **Test und Prüfling teilten den blinden Fleck**, deshalb blieb eine frei erfundene Ghost-Metrik unbemerkt.
- **F002 (MEDIUM)** — Vertauschte Argumente an der Aufrufstelle machten die Trip-Legende in Produktion **komplett leer**, ohne dass ein Test rot wurde. Neue Testschicht liest den echten Aufruf aus dem AST und führt ihn aus.
- **F003 (MEDIUM)** — Der Guard-Test prüfte nur den Bezeichnernamen, nicht die Semantik; `{#if eintraege.length >= 0}` kam durch. Die Bedingung wird jetzt ausgeführt statt gelesen.
- **F004 (MEDIUM)** — Die Ausführungsprobe testete nur 0 und 1 Einträge; „genau ein Eintrag" bestand beides. Jetzt eine Reihe 0/1/2/3/4/6/9/18 mit echten Katalogwerten.
- **F005 (LOW)** — Jede endliche Stichprobe hat Lücken (Modulo-5 kam durch). Statt weiterer Probepunkte eine **Formprüfung**: die Bedingung muss ein schlichter Leere-Test sein. Form und Verhalten zusammen schließen die Klasse, statt sie um eine Stelle zu verschieben.

**Verdict Runde 5: VERIFIED.** 13 Mutationen nachgefahren, alle gefangen. Protokoll: `docs/artifacts/fix-1888-e6b-kuerzel-legende/adversary-dialog.md`.

Verbleibend **F006 (LOW)**: Die Formprüfung lehnt `>= 1` ab, obwohl semantisch gleichwertig — Stilrisiko ohne Produktionsbezug, im Protokoll als akzeptiertes Restrisiko dokumentiert, mit eingebautem Eskalationsweg in der Fehlermeldung.

## Testlage

- `metricKuerzelLegende.test.ts` 17 pass / 0 fail
- Bestandswächter `officialAlertLegend.test.ts` + `weather_metric_kuerzel_marken.test.ts` 28 pass / 0 fail, unangetastet
- voller `npm test`: 2657 Tests, 2652 pass, 0 fail, 5 skipped
- `npm run check` unverändert gegenüber der Basis (36 vorbestehende Fehler, keiner in den berührten Dateien)

## Noch offen

**AC-6** (Lesbarkeit 320–899 px, nichts abgeschnitten) und **AC-7** (Kontrast ≥ WCAG AA 4.5:1, `--g-ink-4` ausgeschlossen) sind im Kern nicht belegbar — Präzedenzfall #1446: eine Tabelle mit `display:none` meldet per DOM-Abfrage fälschlich „sichtbar". Beide werden per Playwright gegen Staging nachgewiesen, Anker `data-testid="metric-kuerzel-legend"`.

Vorbereitet ist das bereits: Die Legende nutzt `--g-ink-muted` (`#5c5a52`, rechnerisch 6,9:1 auf Weiß), `--g-ink-4` kommt nicht vor; die Liste bricht per `flex-wrap` und `overflow-wrap` innerhalb der Karte um.

Refs #1888, #1857, #1435

🤖 Generated with [Claude Code](https://claude.com/claude-code)
