### PR TITLE
fix(#1891): Sofortvergleich reicht user_id an load_all_locations durch

### DIFF
--- a/api/routers/compare.py
+++ b/api/routers/compare.py
@@ -25,6 +25,7 @@ def get_compare_metrics():
 @router.get("/api/compare")
 def run_comparison(
     location_ids: str = Query(..., description="Comma-separated location IDs, or '*' for all"),
+    user_id: str = Query(..., description="Session-User (vom Go-Proxy injiziert)"),
     target_date: Optional[str] = Query(None, description="YYYY-MM-DD, defaults to today/tomorrow based on time"),
     time_window_start: int = Query(9),
     time_window_end: int = Query(16),
@@ -35,7 +36,7 @@ def run_comparison(
     from app.profile import ActivityProfile
     from services.comparison_parallel import run_comparison_parallel
 
-    all_locations = load_all_locations()
+    all_locations = load_all_locations(user_id=user_id)
 
     if location_ids == '*':
         selected = all_locations

--- a/docs/context/fix-1891-compare-user-id.md
+++ b/docs/context/fix-1891-compare-user-id.md
@@ -1,0 +1,75 @@
+# Context: fix-1891-compare-user-id
+
+## Request Summary
+`GET /api/compare` lädt Orte unabhängig vom eingeloggten Nutzer immer über den
+Pseudo-Nutzer `"default"` — Verstoß gegen die Mandantentrennungs-Pflicht
+(CLAUDE.md). Fix: echte `user_id` aus dem Auth-Kontext (von Go injiziert)
+durchreichen, analog zu allen anderen authentifizierten Endpoints.
+
+## Related Files
+| File | Relevance |
+|------|-----------|
+| `api/routers/compare.py:26-38` | `run_comparison()` — ruft `load_all_locations()` ohne `user_id` auf. Fehlerort. |
+| `src/app/loader.py:1263` | `load_all_locations(user_id: str = "default")` — Default-Fallback, den der Router nie überschreibt. |
+| `internal/handler/proxy.go:75-102,140-158` | `CompareProxyHandler` + `appendUserID()` — Go injiziert den echten Nutzer bereits korrekt in den Query-String (Anti-Spoofing, entfernt clientseitige `user_id`-Werte). Keine Änderung nötig. |
+| `internal/router/router.go:156` | Route liegt im authentifizierten Block (`AuthMiddleware`, Cookie-Pflicht). |
+| `api/routers/preview.py:33,89` | Referenzmuster: `user_id: str = Query(..., description="Session-User (vom Go-Proxy injiziert)")` — Pflichtparameter, kein Default. Gleiches Muster in `gpx.py:25`, `internal.py:30,58`, `notify.py:21`, `validator.py:183,247,276`. |
+| `api/routers/scheduler.py:291` | Abweichendes, schwächeres Muster (`Query("default")`) — NICHT als Vorbild verwenden, da es denselben Fehler in abgeschwächter Form zeigt. |
+
+## Existing Patterns
+- 16 bestehende Endpoints reichen `user_id` bereits per `user_id: str = Query(...)` durch (Pflichtparameter ohne Default) — das ist das etablierte, sichere Muster für Go-proxied Endpoints hinter `AuthMiddleware`.
+- Von 8 Python-Aufrufstellen von `load_all_locations()` ist `compare.py:38` die **einzige** ohne `user_id`-Argument (alle anderen: `compare_preview_service.py:240`, `compare_radar_alert.py:92`, `scheduler_dispatch_service.py:419`, `compare_official_alert.py:90`, `dispatch_orchestrator.py:147,183`, `compare_alert.py:124`).
+- Go-Proxy-Seite ist bereits korrekt: `appendUserID()` entfernt clientseitig mitgeschickte `user_id`-Werte und setzt ausschließlich den authentifizierten Nutzer — kein Spoofing-Risiko auf Go-Seite.
+
+## Dependencies
+- **Upstream:** `internal/handler/proxy.go` (`CompareProxyHandler`) — reicht bereits `?user_id=...` an Python durch, sobald der Python-Router den Parameter akzeptiert, braucht Go **keine Änderung**.
+- **Downstream:** `run_comparison_parallel()` (`src/services/comparison_parallel.py`) erhält die bereits userbezogen gefilterte `selected`-Liste — keine Änderung nötig.
+
+## Existing Specs
+- Keine dedizierte Spec zu `/api/compare` gefunden; verwandt: `docs/adr/` zu Auth/Mandantentrennung (nicht einzeln durchsucht, Pattern ist im Code eindeutig etabliert).
+
+## Bestehende Tests, die brechen werden (Scope-relevant)
+Fünf Aufrufstellen (in 5 Dateien) rufen `GET /api/compare?location_ids=...` **ohne** `user_id`-Query-Parameter auf. Wird `user_id` zum Pflichtparameter (`Query(...)`, analog `preview.py`), schlagen sie mit HTTP 422 fehl, bis sie angepasst sind:
+- `tests/tdd/test_hail_flag_metrics_catalog_and_compare_api.py:103`
+- `tests/tdd/test_vorschau_anzeige_folgen_ortszone.py:477,521,597`
+- `tests/tdd/test_sport_aware_scoring.py:251`
+- `tests/unit/test_sofortvergleich_parallel.py:102-103` (Funktion `_abfrage()`, per Plan-Agent-Bewertung + Nachlese bestätigt)
+
+Alle stubben `load_all_locations` bereits mit `lambda *a, **kw: [...]` (nimmt beliebige Argumente an) — die Anpassung ist rein additiv (`&user_id=...` an die Aufruf-URL), keine Stub-Signatur-Änderung nötig.
+
+## Analysis
+
+### Type
+Bug (Verstoß gegen bestehende Mandantentrennungs-Pflicht, kein neues Feature).
+
+### Affected Files (with changes)
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `api/routers/compare.py` | MODIFY | `user_id: str = Query(...)` in Signatur von `run_comparison()` ergänzen, an `load_all_locations(user_id=user_id)` durchreichen. ~2-3 Zeilen. |
+| `tests/tdd/test_hail_flag_metrics_catalog_and_compare_api.py` | MODIFY | `&user_id=...` an Aufruf-URL ergänzen |
+| `tests/tdd/test_vorschau_anzeige_folgen_ortszone.py` | MODIFY | `&user_id=...` an 3 Aufruf-URLs ergänzen |
+| `tests/tdd/test_sport_aware_scoring.py` | MODIFY | `&user_id=...` an Aufruf-URL ergänzen |
+| `tests/unit/test_sofortvergleich_parallel.py` | MODIFY | `&user_id=...` in `_abfrage()` ergänzen |
+| neue Testdatei/-funktion (Name TDD-Phase) | CREATE | Zwei-Nutzer-Nachweis (Pflicht CLAUDE.md) + 422-Nachweis bei fehlendem `user_id` |
+
+### Scope Assessment
+- Files: 6 (1 Produktivcode, 5 Bestandstests) + 1 neue Testdatei
+- Estimated LoC: Produktivcode ~2-3 Zeilen; Testanpassungen ~8 Zeilen additiv; neuer Test ~40-60 Zeilen
+- Risk Level: LOW auf Produktivverkehr (siehe unten), MEDIUM auf Blast-Radius-Klassifikation (Mandantentrennung ist ein kritischer Pfad)
+
+### Technical Approach
+`user_id: str = Query(...)` als Pflichtparameter — konsistent mit 16 etablierten Endpoints, schließt den Fehler strukturell aus. Kein Default nötig: einziger Produktionsaufrufer ist `CompareProxyHandler` (Go), der `user_id` bereits zuverlässig injiziert. Keine CLI-, Cron- oder internen Python-Aufrufer von `run_comparison()`/`/api/compare` gefunden. Ein Default wie bei `scheduler.py:291` würde den Fehler nur abschwächen statt beheben.
+
+### Dependencies
+- Keine Sequenzabhängigkeit zu Go — `/api/compare` liegt bereits in der globalen `AuthMiddleware`-Gruppe (`router.go:37`), keine Ausnahme in der Public-Whitelist (`internal/middleware/auth.go:33-46`). Ohne gültige Session bekommt der Handler bereits 401, bevor `appendUserID` mit leerem `userID` aufgerufen würde. Dokumentiert in `test_selftest_auth_required.py:215`.
+- Python-Änderung ist eigenständig sicher deploybar.
+
+### Open Questions
+Keine — Plan-Agent-Bewertung (Standard-Track, Schritt 3) hat technischen Ansatz, Risiko, Scope und Testaufbau abschließend geklärt.
+
+## Risks & Considerations
+- **Pflicht- vs. Default-Parameter:** `user_id: str = Query(...)` (Pflicht, wie bei `preview.py`) ist konsistent mit der Mehrheit der authentifizierten Endpoints und schließt den Fehler strukturell aus (kein stiller Fallback mehr möglich). Abweichendes Muster `Query("default")` (`scheduler.py:291`) wird bewusst nicht übernommen.
+- **Zwei-Nutzer-Nachweis PFLICHT** (CLAUDE.md): Der Bugfix-Nachweis braucht einen Test mit zwei verschiedenen `user_id`-Werten und jeweils eigenen Orten — die 5 o.g. Bestandstests weisen nur *irgendeinen* `user_id`-Wert nach, nicht die Trennung selbst. Stub muss `user_id` tatsächlich AUSWERTEN (z.B. `lambda user_id=None, **kw: {"alice": ORTE_ALICE, "bob": ORTE_BOB}[user_id]`), nicht nur ignorieren.
+- **Test-Isolation:** Der neue Zwei-Nutzer-Test darf KEINEN `@pytest.mark.live`/`@pytest.mark.real_data_root`-Marker tragen — `tests/conftest.py` installiert die Daten-Isolation dort nicht, der Test würde sonst gegen den echten `data/users/`-Baum laufen statt gegen Fixtures.
+- **Nicht im Scope:** Der zweite Befund aus #1891 (kein Limit auf `location_ids`) ist laut PO-Entscheid abgetrennt und als Zeile in #1199 dokumentiert — hier nicht mitfixen.
+- **Nicht im Scope:** Go-Seite ist bereits korrekt, keine Änderung an `internal/`.

--- a/docs/specs/modules/compare_endpoint_user_id.md
+++ b/docs/specs/modules/compare_endpoint_user_id.md
@@ -1,0 +1,117 @@
+---
+entity_id: compare_endpoint_user_id
+type: module
+created: 2026-08-16
+updated: 2026-08-16
+status: draft
+version: "1.0"
+tags: [bugfix, security, mandantentrennung, compare]
+---
+
+# Compare-Endpoint: user_id-Pflichtparameter (Issue #1891)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`GET /api/compare` lädt Orte für den Sofortvergleich unabhängig vom eingeloggten
+Nutzer immer über den Pseudo-Nutzer `"default"`, weil `run_comparison()`
+`load_all_locations()` ohne `user_id`-Argument aufruft. Jeder eingeloggte Nutzer
+bekommt beim Sofortvergleich die Orte des `default`-Nutzers statt seiner eigenen —
+ein Cross-User-Datenleck und Verstoß gegen die in CLAUDE.md festgeschriebene
+Mandantentrennungs-Pflicht. Diese Spec beschreibt den Fix: `user_id` als
+Pflichtparameter aus dem Auth-Kontext (von Go injiziert) durchreichen, analog zu
+16 anderen bereits korrekt implementierten Endpoints.
+
+## Source
+
+- **File:** `api/routers/compare.py`
+- **Identifier:** `def run_comparison(...)` (Route `GET /api/compare`)
+
+> **Schicht-Hinweis:** Python-Core / Domain-Backend (`api/routers/compare.py`,
+> FastAPI Core über `api.main:app`). Keine Go-Änderung nötig — `internal/handler/proxy.go`
+> (`CompareProxyHandler` + `appendUserID()`) injiziert `user_id` bereits korrekt in
+> den Query-String, sobald der Python-Router den Parameter akzeptiert.
+
+## Estimated Scope
+
+- **LoC:** Produktivcode ~2-3 Zeilen; Testanpassungen ~8 Zeilen additiv (5 Bestandsdateien); neuer Test ~40-60 Zeilen
+- **Files:** 6 Bestandsdateien (1 Produktivcode, 5 Bestandstests) + 1 neue Testdatei
+- **Effort:** low-medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/app/loader.py::load_all_locations` | function | Nimmt `user_id`-Parameter bereits entgegen (Default `"default"`), muss nur mit echtem Wert aufgerufen werden |
+| `internal/handler/proxy.go::CompareProxyHandler` | Go handler | Injiziert echte `user_id` bereits korrekt per `appendUserID()` in den Query-String — keine Änderung nötig |
+| `internal/router/router.go` | Go router | Route liegt im authentifizierten Block (`AuthMiddleware`, Cookie-Pflicht) — kein anonymer Zugriff möglich |
+| `api/routers/preview.py` | module | Referenzmuster für `user_id: str = Query(..., description=...)` als Pflichtparameter |
+
+## Implementation Details
+
+`api/routers/compare.py`, Funktion `run_comparison()` (Zeilen 25-38):
+
+1. Signatur um `user_id: str = Query(..., description="Session-User (vom Go-Proxy injiziert)")` erweitern, analog `api/routers/preview.py:33`.
+2. Aufruf `all_locations = load_all_locations()` → `all_locations = load_all_locations(user_id=user_id)`.
+
+Kein Default-Wert (`Query(...)` statt z.B. `Query("default")`) — der einzige
+Produktionsaufrufer ist `CompareProxyHandler` (Go), der `user_id` bereits
+zuverlässig injiziert. Ein Default wie bei `api/routers/scheduler.py:291`
+(`Query("default")`) würde den Fehler nur abschwächen statt strukturell
+ausschließen und wird bewusst nicht übernommen.
+
+Fünf Bestandstests rufen `GET /api/compare` derzeit ohne `user_id`-Query-Parameter
+auf und brechen mit HTTP 422, sobald der Parameter Pflicht wird. Die Anpassung ist
+additiv (`&user_id=...` an die jeweilige Aufruf-URL) — alle stubben
+`load_all_locations` bereits mit `lambda *a, **kw: [...]`, keine
+Stub-Signatur-Änderung nötig:
+
+- `tests/tdd/test_hail_flag_metrics_catalog_and_compare_api.py:103`
+- `tests/tdd/test_vorschau_anzeige_folgen_ortszone.py:477,521,597`
+- `tests/tdd/test_sport_aware_scoring.py:251`
+- `tests/unit/test_sofortvergleich_parallel.py:102-103` (Funktion `_abfrage()`)
+
+## Expected Behavior
+
+- **Input:** `GET /api/compare?location_ids=...&user_id=<session-user>` (weitere
+  Query-Parameter wie `target_date`, `time_window_start/end`, `forecast_hours`,
+  `activity_profile` unverändert)
+- **Output:** Vergleichsergebnis (JSON) ausschließlich über die Orte des
+  übergebenen `user_id`; ohne `user_id` HTTP 422 (FastAPI-Validierungsfehler bei
+  fehlendem Pflichtparameter)
+- **Side effects:** keine — reine Lesezugriff-Filterung, keine Persistenzänderung
+
+## Acceptance Criteria
+
+- **AC-1:** Given zwei Nutzer alice und bob mit jeweils eigenen, unterschiedlichen Orten in ihrer Persistenz / When beide `GET /api/compare` mit ihrer jeweiligen `user_id` aufrufen / Then bekommt jeder Nutzer ausschließlich seine eigenen Orte in der Antwort — nicht die Orte des jeweils anderen Nutzers und nicht die Orte des `default`-Nutzers.
+  - Test: Zwei-Nutzer-Testfall (Kern-Schicht, ohne `live`/`real_data_root`-Marker) mit Stub für `load_all_locations`, der `user_id` tatsächlich auswertet (z.B. `lambda user_id=None, **kw: {"alice": [...], "bob": [...]}[user_id]`), und assertet, dass jede Antwort nur die zugehörigen Orte enthält.
+
+- **AC-2:** Given der Endpoint `GET /api/compare` erwartet `user_id` als Pflichtparameter / When ein Aufruf ohne `user_id`-Query-Parameter erfolgt / Then antwortet der Server mit HTTP 422 (FastAPI-Validierungsfehler), da kein stiller Fallback auf `"default"` mehr möglich ist.
+  - Test: Testfall ruft `GET /api/compare?location_ids=...` ohne `user_id` auf und prüft `response.status_code == 422`.
+
+- **AC-3:** Given ein Nutzer mit gültiger `user_id` ruft den Sofortvergleich auf / When `GET /api/compare?location_ids=...&user_id=<gueltige-id>` mit sonst unveränderten Parametern aufgerufen wird / Then bleibt die Response-Struktur (Felder, Format) identisch zum Verhalten vor dem Fix, nur mit korrekt dem Nutzer zugeordneten Orten.
+  - Test: Angepasste Bestandstests (5 Dateien, additiv um `&user_id=...` ergänzt) laufen weiterhin grün und prüfen weiterhin dieselben Response-Felder wie vor der Änderung.
+
+## Known Limitations
+
+- Der zweite in Issue #1891 gemeldete Befund (kein Limit auf die Anzahl der
+  `location_ids`) ist laut PO-Entscheid bewusst nicht Teil dieser Spec und als
+  Zeile im Sammel-Issue #1199 dokumentiert.
+- Go-Seite (`internal/handler/proxy.go`) wird nicht verändert — sie injiziert
+  `user_id` bereits korrekt; dieser Fix betrifft ausschließlich den Python-Core.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Bugfix-Konsistenz mit einem bereits etablierten, dokumentierten
+  Muster (`user_id: str = Query(...)` als Pflichtparameter, angewendet in 16
+  anderen authentifizierten Endpoints, z.B. `api/routers/preview.py`). Es wird
+  keine neue Architekturentscheidung getroffen, sondern eine bestehende inkonsequent
+  angewendete Regel nachträglich durchgesetzt.
+
+## Changelog
+
+- 2026-08-16: Initial spec created (Issue #1891)

--- a/tests/tdd/test_compare_endpoint_user_id_mandantentrennung.py
+++ b/tests/tdd/test_compare_endpoint_user_id_mandantentrennung.py
@@ -1,0 +1,128 @@
+"""TDD RED — Issue #1891: `GET /api/compare` missachtet die Mandantentrennung.
+
+Spec: docs/specs/modules/compare_endpoint_user_id.md
+
+`run_comparison()` (api/routers/compare.py) ruft `load_all_locations()` OHNE
+`user_id`-Argument auf. Da FastAPI nicht deklarierte Query-Parameter still
+verwirft, hat ein mitgeschicktes `&user_id=...` heute KEINE Wirkung: jeder
+eingeloggte Nutzer bekommt die Orte des Pseudo-Nutzers `"default"` statt seiner
+eigenen (Cross-User-Datenleck).
+
+RED-Ursachen (heute):
+- AC-1: der Loader-Stub wertet `user_id` echt aus; weil der Router den Parameter
+  nicht durchreicht, kommt `user_id=None` an -> beide Nutzer bekommen dieselbe
+  (leere) Ortsliste, also `{"error": "no_locations_found"}` statt der jeweils
+  eigenen Orte. Der Stub ist korrekt -- der Router reicht nicht durch.
+- AC-2: ein Aufruf ohne `user_id` liefert heute HTTP 200 statt HTTP 422, weil
+  `user_id` in der Signatur von `run_comparison()` gar nicht existiert.
+
+Kein Mock-Theater: `monkeypatch.setattr` ersetzt die Datenquellen durch echte,
+lokal konstruierte DTOs. Der Loader-Stub verhaelt sich wie die echte
+Persistenz (unterschiedliche Ortsliste je Nutzer), der Engine-Stub leitet sein
+Ergebnis aus den TATSAECHLICH uebergebenen Orten ab -- er kann die Trennung
+also nicht faelschlich bestaetigen.
+
+Kern-Schicht: bewusst OHNE `live`/`real_data_root`-Marker, damit die
+Daten-Isolation aus tests/conftest.py greift (kein Zugriff auf `data/users/`).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+TARGET_DATE = "2026-08-20"
+
+
+@pytest.fixture
+def client():
+    from fastapi.testclient import TestClient
+    from api.main import app
+    return TestClient(app)
+
+
+@pytest.fixture
+def zwei_nutzer_orte(monkeypatch):
+    """Zwei Nutzer mit je eigenen Orten -- der Loader-Stub wertet `user_id` aus.
+
+    Der Engine-Stub baut sein Ergebnis aus den ihm uebergebenen Orten; er kann
+    die Mandantentrennung damit nicht selbst herbeifuehren.
+    """
+    import app.loader as loader_mod
+    from app.user import ComparisonResult, LocationResult, SavedLocation
+    from services.comparison_engine import ComparisonEngine
+
+    orte = {
+        "alice": [SavedLocation(id="alice-huette", name="Alice-Huette",
+                                lat=46.6, lon=12.9, elevation_m=1900,
+                                timezone="Europe/Vienna")],
+        "bob": [SavedLocation(id="bob-pass", name="Bob-Pass",
+                              lat=42.3, lon=9.0, elevation_m=1500,
+                              timezone="Europe/Paris")],
+    }
+
+    monkeypatch.setattr(
+        loader_mod, "load_all_locations",
+        lambda user_id=None, **kw: orte.get(user_id, []),
+    )
+
+    def _engine_run(locations, time_window, target_date, **kwargs):
+        return ComparisonResult(
+            locations=[LocationResult(location=loc, score=1) for loc in locations],
+            time_window=time_window,
+            target_date=target_date,
+        )
+
+    monkeypatch.setattr(ComparisonEngine, "run", staticmethod(_engine_run))
+    return orte
+
+
+# =============================================================================
+# AC-1 — jeder Nutzer sieht ausschliesslich seine eigenen Orte
+# =============================================================================
+
+def test_ac1_compare_liefert_je_nutzer_nur_dessen_eigene_orte(client, zwei_nutzer_orte):
+    antworten = {}
+    for nutzer in ("alice", "bob"):
+        resp = client.get(
+            f"/api/compare?location_ids=*&user_id={nutzer}&target_date={TARGET_DATE}"
+        )
+        assert resp.status_code == 200, (
+            f"Compare-Aufruf fuer {nutzer!r} scheiterte: "
+            f"{resp.status_code} {resp.text}"
+        )
+        antworten[nutzer] = [o["id"] for o in (resp.json().get("locations") or [])]
+
+    assert antworten["alice"] == ["alice-huette"], (
+        "GET /api/compare?user_id=alice liefert nicht genau die Orte von alice, "
+        f"sondern {antworten['alice']!r} -- der Router reicht `user_id` nicht an "
+        "load_all_locations() durch (Issue #1891)"
+    )
+    assert antworten["bob"] == ["bob-pass"], (
+        "GET /api/compare?user_id=bob liefert nicht genau die Orte von bob, "
+        f"sondern {antworten['bob']!r} -- der Router reicht `user_id` nicht an "
+        "load_all_locations() durch (Issue #1891)"
+    )
+    assert "bob-pass" not in antworten["alice"], (
+        "Cross-User-Datenleck: alice sieht den Ort von bob"
+    )
+    assert "alice-huette" not in antworten["bob"], (
+        "Cross-User-Datenleck: bob sieht den Ort von alice"
+    )
+
+
+# =============================================================================
+# AC-2 — ohne `user_id` gibt es keine Antwort, sondern HTTP 422
+# =============================================================================
+
+def test_ac2_compare_ohne_user_id_antwortet_mit_422(client, zwei_nutzer_orte):
+    resp = client.get(f"/api/compare?location_ids=alice-huette&target_date={TARGET_DATE}")
+
+    assert resp.status_code == 422, (
+        "GET /api/compare ohne `user_id` muss HTTP 422 liefern (Pflichtparameter, "
+        f"kein stiller Fallback auf 'default'), bekam aber {resp.status_code}: "
+        f"{resp.text[:300]}"
+    )

--- a/tests/tdd/test_hail_flag_metrics_catalog_and_compare_api.py
+++ b/tests/tdd/test_hail_flag_metrics_catalog_and_compare_api.py
@@ -100,7 +100,7 @@ def test_ac10_compare_api_serialisiert_hail_flag_im_hourly_eintrag(client, monke
     monkeypatch.setattr(loader_mod, "load_all_locations", lambda *a, **kw: [ort])
     monkeypatch.setattr(ComparisonEngine, "run", staticmethod(lambda **kwargs: fixture_ergebnis))
 
-    resp = client.get("/api/compare?location_ids=hagel-testort")
+    resp = client.get("/api/compare?location_ids=hagel-testort&user_id=hagel-tester")
     assert resp.status_code == 200
     data = resp.json()
 

--- a/tests/tdd/test_sport_aware_scoring.py
+++ b/tests/tdd/test_sport_aware_scoring.py
@@ -248,7 +248,9 @@ class TestCompareAPI:
         WHEN: Called with activity_profile=wandern
         THEN: Returns 200 (not 422 validation error)
         """
-        resp = client.get("/api/compare?location_ids=*&activity_profile=wandern")
+        resp = client.get(
+            "/api/compare?location_ids=*&user_id=sport-tester&activity_profile=wandern"
+        )
         assert resp.status_code == 200
         data = resp.json()
         assert "locations" in data

--- a/tests/tdd/test_vorschau_anzeige_folgen_ortszone.py
+++ b/tests/tdd/test_vorschau_anzeige_folgen_ortszone.py
@@ -474,7 +474,7 @@ def test_ac3_sofortvergleich_ortszeit_ist_dem_servertag_bereits_voraus(client, m
         _anker(jetzt_utc, WELLINGTON_ZONE, D21)
         _uhr_eingefroren(jetzt_utc)
         servertag = date.today()
-        resp = client.get(f"/api/compare?location_ids={ort.id}")
+        resp = client.get(f"/api/compare?location_ids={ort.id}&user_id=zonen-tester")
 
     assert resp.status_code == 200, resp.text
     daten = resp.json()
@@ -518,7 +518,7 @@ def test_ac3_sofortvergleich_ortszeit_hinkt_dem_servertag_hinterher(client, monk
         _anker(jetzt_utc, PAGO_ZONE, D19)
         _uhr_eingefroren(jetzt_utc)
         servertag = date.today()
-        resp = client.get(f"/api/compare?location_ids={ort.id}")
+        resp = client.get(f"/api/compare?location_ids={ort.id}&user_id=zonen-tester")
 
     assert resp.status_code == 200, resp.text
     daten = resp.json()
@@ -594,7 +594,7 @@ def test_ac3_sofortvergleich_serverstunde_ueber_14_ortsstunde_darunter(client, m
             "oben, statt die Stundenschwelle ISOLIERT zu pruefen. Ortstag "
             f"{ortszeit.date()}, Servertag {jetzt_utc.date()}"
         )
-        resp = client.get(f"/api/compare?location_ids={ort.id}")
+        resp = client.get(f"/api/compare?location_ids={ort.id}&user_id=zonen-tester")
 
     assert resp.status_code == 200, resp.text
     daten = resp.json()

--- a/tests/unit/test_sofortvergleich_parallel.py
+++ b/tests/unit/test_sofortvergleich_parallel.py
@@ -100,7 +100,8 @@ def _abfrage(client):
     zusammen und die Zusicherung ist eindeutig."""
     ids = ",".join(o.id for o in ORTE)
     return client.get(
-        f"/api/compare?location_ids={ids}&target_date={ZIELDATUM.isoformat()}"
+        f"/api/compare?location_ids={ids}&user_id=parallel-tester"
+        f"&target_date={ZIELDATUM.isoformat()}"
         "&time_window_start=9&time_window_end=16"
     )
 


### PR DESCRIPTION
GET /api/compare ignorierte die eingeloggte user_id und lud immer die
Orte des Pseudo-Nutzers "default" -- Verstoss gegen die
Mandantentrennungs-Pflicht. user_id ist jetzt Pflichtparameter
(analog preview.py), an load_all_locations() durchgereicht. Der
zweite Befund aus #1891 (kein Limit auf location_ids) ist bewusst
nicht Teil dieses Fixes, siehe #1199.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
