### PR TITLE
fix(#1914): Radar-Alarm respektiert trip-/preset-konfigurierten telegram_style

### DIFF
--- a/docs/context/fix-1914-radar-telegram-style.md
+++ b/docs/context/fix-1914-radar-telegram-style.md
@@ -1,0 +1,73 @@
+# Context: fix-1914-radar-telegram-style
+
+## Request Summary
+Der Radar-/Starkregen-Nowcast-Alarm ignoriert den trip- bzw. preset-konfigurierten `telegram_style` (z. B. `"kurzform"`) und rendert auf Telegram immer im reichen Format — sowohl im Trip-Pfad als auch im Ortsvergleich-Pfad, während Abweichungs- und amtlicher Alarm den Stil korrekt anwenden.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `src/services/notification_service.py:1263-1272` | `send_radar_alert()` (Trip) — Signatur hat **keinen** `telegram_style`-Parameter |
+| `src/services/notification_service.py:1295-1303` | Aufruf von `_dispatch_alert_message()` innerhalb `send_radar_alert()` — `telegram_style` wird nicht übergeben, Default `"rich"` (Zeile 1316) greift |
+| `src/services/notification_service.py:749-758` | `send_multi_location_radar_alert()` (Compare) — Signatur hat **keinen** `telegram_style`-Parameter |
+| `src/services/notification_service.py:807-815` | Aufruf von `_dispatch_alert_message()` innerhalb `send_multi_location_radar_alert()` — `telegram_style` wird nicht übergeben |
+| `src/services/notification_service.py:1305-1319` | `_dispatch_alert_message()` — zentraler Dispatcher, Parameter `telegram_style: str = "rich"` (Zeile 1316), Kurzstil-Zweig ab Zeile ~1448 |
+| `src/services/trip_alert.py:1208-1215` | Aufrufstelle Trip-Radar — `send_radar_alert(...)` ohne `telegram_style=` |
+| `src/services/trip_alert.py:108-118` | `_trip_telegram_style(trip)` — bestehender Auflöser, Default `"rich"` |
+| `src/services/compare_radar_alert.py:204-207` | Aufrufstelle Compare-Radar — `send_multi_location_radar_alert(...)` ohne `telegram_style=`; lokale Variable heißt `preset` (dict, Zeile 184 `notification_service_for(preset)`) |
+| `src/services/compare_alert_channels.py:49-58` | `effective_compare_telegram_style(preset)` — bestehender Auflöser für Compare, liest `preset["display_config"]["telegram_style"]`, Default `"rich"` |
+| `src/services/compare_official_alert.py:56-65` | `_effective_telegram_style()` — dünner Wrapper auf obigen Auflöser (ADR-0021) |
+
+## Existing Patterns
+
+Vier funktionierende Vorbilder in derselben Datei zeigen exakt das benötigte Muster (Parameter in Signatur + Durchreichen an `_dispatch_alert_message()` + Übergabe an der Aufrufstelle):
+
+- **Trip-Abweichung:** `notification_service.py:628-667` `send_deviation_alert()` — Parameter `telegram_style: str = "rich"` (Zeile 636), durchgereicht Zeile 666. Aufrufer `trip_alert.py:~1372-1381`, `telegram_style=_trip_telegram_style(trip)` auf ~1379.
+- **Trip-amtlich:** `send_official_alert()` (`notification_service.py:817ff`, Param ~824). Aufrufer `trip_alert.py:~1614-1620`, `telegram_style=` auf ~1619.
+- **Compare-Abweichung:** `send_multi_location_deviation_alert()` (`notification_service.py:691ff`, Param ~697). Aufrufer `compare_alert.py:~279-289`, `telegram_style = effective_compare_telegram_style(preset)` auf ~232, übergeben auf ~288.
+- **Compare-amtlich:** `send_multi_location_official_alert()` (`notification_service.py:1046ff`, Param ~1052) → `_dispatch_compare_official_telegram` (~1179, Param ~1182). Aufrufer `compare_official_alert.py:~192-198`, `_effective_telegram_style(preset)` als 5. Positionsargument auf ~195.
+
+Der Fix für den Radar-Pfad folgt strukturell demselben Muster — kein neuer Auflöser nötig, beide (`_trip_telegram_style`, `effective_compare_telegram_style`) existieren bereits.
+
+## Dependencies
+
+- **Upstream:** `ReportConfig.telegram_style` (Trip, `src/app/models.py:1084`, Default `"rich"`) bzw. `preset["display_config"]["telegram_style"]` (Compare) — beide bereits persistiert und im Frontend editierbar (`VTBriefingChannels.svelte`, `AlarmeTab.svelte`).
+- **Downstream:** `_dispatch_alert_message()` steuert damit den Telegram-Renderzweig (Kurzstil vs. reich, ab `notification_service.py:~1448`).
+
+## Existing Specs
+Keine dedizierte Spec zu `telegram_style` selbst; Ursprung ist Issue #1260 S3 (Feature-Einführung `kurzform`). ADR-0021 legt fest, dass Rendering/Versand zwischen Trip und Ortsvergleich geteilt bleiben — das begründet, warum beide Pfade (Trip UND Compare) in einem Fix behoben werden.
+
+## Risks & Considerations
+
+- **Zuschnitt muss beide Flächen umfassen:** Trip- und Compare-Radar-Pfad haben symmetrisch dieselbe Lücke. Nur einen zu fixen erzeugt eine neue, gegen die Projektregel „Trip/Compare teilen Code" verstoßende Asymmetrie.
+- **Testlücke:** Kein bestehender Test prüft `telegram_style` am Radar-Pfad (weder Trip noch Compare) — Tests müssen an der Aufrufstelle (`trip_alert.py`/`compare_radar_alert.py`) ansetzen, nicht nur am `NotificationService`-Baustein (Lehre aus #1467: Bausteintests allein beweisen die Verdrahtung nicht).
+- **Bewusst ausgeklammerter Nebenbefund:** `send_location_deviation_alert` (`notification_service.py:669-689`) reicht `telegram_style` beim Delegieren an `send_multi_location_deviation_alert` ebenfalls nicht durch — hat aktuell keinen produktiven Aufrufer (kein Treffer außerhalb `notification_service.py`), daher kein akutes Nutzer-Symptom. Gehört bei Bedarf in Sammel-Issue #1199, nicht in diesen Fix.
+- **Nicht Teil dieses Fixes:** #1916 (Alarm-Vergleichsbasis) und #1657 (Dedup-Anzeige-Granularität) sind Nachbar-Befunde derselben KHW-Analyse, aber andere Codepfade.
+
+## Analysis
+
+### Type
+Bug
+
+### Affected Files (with changes)
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/services/notification_service.py` | MODIFY | `telegram_style: str = "rich"` zu `send_radar_alert()` (~1263) und `send_multi_location_radar_alert()` (~749) ergänzen, an `_dispatch_alert_message()` durchreichen (~1295, ~807) |
+| `src/services/trip_alert.py` | MODIFY | Aufrufstelle ~1208-1215: `telegram_style=_trip_telegram_style(trip)` ergänzen |
+| `src/services/compare_radar_alert.py` | MODIFY | Aufrufstelle ~204-207: `telegram_style=effective_compare_telegram_style(preset)` ergänzen |
+| `tests/tdd/test_compare_radar_alert.py` bzw. neue Testdatei | CREATE/MODIFY | Test an der Aufrufstelle (nicht nur Baustein), der die Verdrahtung Trip-Radar → Kurzstil beweist |
+| `tests/tdd/test_compare_alert_telegram_per_location.py` bzw. Compare-Pendant | MODIFY | Analoger Test für Compare-Radar → Kurzstil |
+
+### Scope Assessment
+- Files: 3 Produktivdateien, 2 Testdateien (neu oder erweitert)
+- Estimated LoC: Produktiv ~6-8 LoC (2× Signatur, 2× Durchreichen, 2× Aufrufer); Test ~50-70 LoC
+- Risk Level: LOW — additiver optionaler Parameter mit Default `"rich"`, kein bestehender Test erwartet Rich-Verhalten als Assertion am Radar-Pfad (geprüft: `test_compare_radar_alert.py`, `test_multi_location_onset_alert.py`, `test_compare_alert_telegram_per_location.py`, `test_alert_sms_location_positions.py` — keine `assert_called_with`-Signaturbindung)
+
+### Technical Approach
+Option A (Parameter durchreichen, analog den vier bestehenden Geschwistermethoden) statt Option B (Style zentral aus `AlertMessage` ableiten) — Option B würde die bewusste Architekturtrennung aufweichen, wonach der geteilte Dispatcher `_dispatch_alert_message()` Trip/Compare-agnostisch bleibt (`AlertMessage` kennt weder Trip noch Preset). Option A ist minimal-invasiv und strikt konsistent mit dem bestehenden Muster. Reihenfolge: 1) Signatur+Durchreichen Trip-Radar, 2) Signatur+Durchreichen Compare-Radar, 3) Aufrufer `trip_alert.py`, 4) Aufrufer `compare_radar_alert.py` — TDD: erst Trip rot/grün, dann Compare rot/grün.
+
+### Dependencies
+Keine neuen Abhängigkeiten. Beide Auflöser (`_trip_telegram_style`, `effective_compare_telegram_style`) existieren bereits und werden unverändert wiederverwendet.
+
+### Open Questions
+Keine offenen Fragen — Ansatz ist eindeutig durch vier funktionierende Vorbilder in derselben Datei vorgegeben.

--- a/docs/specs/modules/feat_1260_telegram_kurzstil.md
+++ b/docs/specs/modules/feat_1260_telegram_kurzstil.md
@@ -2,7 +2,7 @@
 entity_id: feat_1260_telegram_kurzstil
 type: feature
 created: 2026-07-15
-updated: 2026-07-15
+updated: 2026-08-16
 status: draft
 version: "1.0"
 tags: [telegram, sms, notification, dispatch, multi-user]
@@ -176,6 +176,11 @@ bleibt unverändert; eine neue kleine Hilfsfunktion `_effective_telegram_style(p
 
 ## Known Limitations
 
+- **Nachtrag (2026-08-16, Fix #1914):** Der Regen-/Radar-Nowcast-Alarm gehörte nicht zu den
+  vier oben genannten Scope-Pfaden und respektierte `telegram_style` deshalb nicht — er
+  renderte auf Telegram immer im reichen Format, unabhängig vom konfigurierten Stil. Behoben in
+  `docs/specs/modules/fix_1914_radar_telegram_style.md` (Trip- und Ortsvergleich-Pfad, gleiches
+  Durchreiche-Muster wie die vier hier beschriebenen Dispatch-Stellen).
 - Im Kurzstil entfallen die Telegram-Inline-Knöpfe/Aktionen (z.B. Weiterblättern, PAUSE/SKIP) —
   inhärent zu „SMS-Stil = eine Zeile ohne Bedienelemente". Bewusster Kompromiss, kein Bug.
 - Reguläre Ortsvergleich-Briefings und -Abweichungs-/Radar-Alarme bleiben E-Mail-only (kein
@@ -215,3 +220,7 @@ keine Mocks als Verhaltensnachweis — echte Fixture-Trips/-Presets, echte Rende
 ## Changelog
 
 - 2026-07-15: Initial spec created — Issue #1260
+- 2026-08-16: Known Limitations um Nachtrag zu Fix #1914 ergänzt (Radar-/Nowcast-Alarm
+  respektierte `telegram_style` nicht — war kein Scope-Pfad dieser Spec, jetzt in
+  `fix_1914_radar_telegram_style.md` behoben; reine Cross-Reference, kein Verhaltensinhalt
+  dieser Spec geändert)

--- a/docs/specs/modules/fix_1914_radar_telegram_style.md
+++ b/docs/specs/modules/fix_1914_radar_telegram_style.md
@@ -1,0 +1,258 @@
+---
+entity_id: fix_1914_radar_telegram_style
+type: module
+created: 2026-08-16
+updated: 2026-08-16
+status: draft
+version: "1.0"
+tags: [radar, nowcast, alarm, telegram, telegram_style, trip, compare]
+---
+
+<!-- Issue #1914 -- Kontext-Grundlage: docs/context/fix-1914-radar-telegram-style.md
+     (Analyse bereits abgeschlossen, Basis-Commit siehe Workflow-State
+     fix-1914-radar-telegram-style). Formatvorbild:
+     docs/specs/modules/fix_1752_radar_folgt_alarm_kanaelen.md (gleiches Thema:
+     Radar-Alarm folgt trip-/preset-konfiguriertem Verhalten). -->
+
+# Radar-Alarm folgt dem konfigurierten Telegram-Stil (Trip + Ortsvergleich)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Der Radar-/Starkregen-Nowcast-Alarm ignoriert den trip- bzw. preset-konfigurierten
+`telegram_style` (z. B. `"kurzform"`) und rendert auf Telegram **immer** im reichen
+Emoji-/Mehrzeilen-Format — sowohl im Trip-Pfad als auch im Ortsvergleich-Pfad. Abweichungs-
+und amtlicher Alarm wenden den konfigurierten Stil bereits korrekt an; Radar ist die letzte
+verbliebene Ausnahme unter den vier Alarmarten. Diese Spec schließt diese Lücke, indem der
+Radar-Pfad dasselbe Muster übernimmt, das die drei Geschwistermethoden bereits nutzen.
+
+## Bewusst nicht in dieser Spec
+
+- **`send_location_deviation_alert`** (`notification_service.py:669-689`) hat dieselbe
+  Fehlerklasse — reicht `telegram_style` beim Delegieren an
+  `send_multi_location_deviation_alert` ebenfalls nicht durch. Hat aktuell **keinen
+  produktiven Aufrufer** (kein Treffer außerhalb `notification_service.py`), daher kein
+  akutes Nutzer-Symptom. Gehört bei Bedarf in das Sammel-Issue #1199, nicht in diesen Fix.
+- **Ein neuer Auflöser für `telegram_style`.** Beide benötigten Auflöser existieren bereits
+  und werden unverändert wiederverwendet: `_trip_telegram_style(trip)`
+  (`trip_alert.py:108-118`) und `effective_compare_telegram_style(preset)`
+  (`compare_alert_channels.py:49-58`).
+- **#1916 (Alarm-Vergleichsbasis) und #1657 (Dedup-Anzeige-Granularität)** — Nachbar-Befunde
+  derselben KHW-Analyse, aber andere Codepfade.
+
+## Source
+
+- **File:** `src/services/notification_service.py`
+- **Identifier:** `NotificationService.send_radar_alert()`,
+  `NotificationService.send_multi_location_radar_alert()`,
+  `NotificationService._dispatch_alert_message()` (Zielsenke, unverändert)
+
+Betroffene Stellen (Zeilen nachgemessen gegen den aktuellen Arbeitsstand):
+
+| Datei | Zeile(n) | Heute | Nach dieser Spec |
+|---|---|---|---|
+| `src/services/notification_service.py` | `send_radar_alert()`, Signatur ~1263-1272 | kein `telegram_style`-Parameter | neuer Parameter `telegram_style: str = "rich"` |
+| `src/services/notification_service.py` | `send_radar_alert()`, Aufruf `_dispatch_alert_message()` ~1295-1303 | `telegram_style` wird nicht übergeben — Default `"rich"` von `_dispatch_alert_message()` (Zeile 1316) greift immer | `telegram_style=telegram_style` wird durchgereicht |
+| `src/services/notification_service.py` | `send_multi_location_radar_alert()`, Signatur ~749-758 | kein `telegram_style`-Parameter | neuer Parameter `telegram_style: str = "rich"` |
+| `src/services/notification_service.py` | `send_multi_location_radar_alert()`, Aufruf `_dispatch_alert_message()` ~807-815 | `telegram_style` wird nicht übergeben | `telegram_style=telegram_style` wird durchgereicht |
+| `src/services/trip_alert.py` | Aufrufstelle ~1208-1215 | `send_radar_alert(...)` ohne `telegram_style=` | `telegram_style=_trip_telegram_style(trip)` ergänzt |
+| `src/services/compare_radar_alert.py` | Aufrufstelle ~204-207 | `send_multi_location_radar_alert(...)` ohne `telegram_style=` | `telegram_style=effective_compare_telegram_style(preset)` ergänzt |
+
+`_dispatch_alert_message()` selbst (`notification_service.py:1305-1319`, Parameter
+`telegram_style: str = "rich"` bereits vorhanden auf Zeile 1316) bleibt unverändert — sie ist
+bereits die geteilte Zielsenke, an die alle vier Alarmarten denselben Parameter reichen.
+
+> **Schicht-Hinweis:** Alle vier betroffenen Dateien liegen im Python-Core
+> (`src/services/`) — kein Frontend-, kein Go-API-Code betroffen.
+
+## Estimated Scope
+
+- **LoC (Produktivcode):** ≈ 6-8 (2× Signatur-Parameter, 2× Durchreichen im Aufruf, 2×
+  Übergabe an der Aufrufstelle).
+- **LoC (Tests):** ≈ 50-70 (zwei neue oder erweiterte Testfälle an den Aufrufstellen, siehe
+  Testplan).
+- **Files:** 3 Produktivdateien (MODIFY), 2 Testdateien (CREATE/MODIFY).
+- **Effort:** low. Additiver, optionaler Parameter mit Default `"rich"` — strukturell identisch
+  zu vier bereits funktionierenden Geschwistermethoden in derselben Datei.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `NotificationService.send_deviation_alert()` (`notification_service.py:628-667`) | Vorbild, unverändert | Trip-Abweichungsalarm — identisches Muster: Parameter `telegram_style: str = "rich"`, durchgereicht an `_dispatch_alert_message()` |
+| `NotificationService.send_official_alert()` (`notification_service.py:817ff`) | Vorbild, unverändert | Trip-amtlicher Alarm — identisches Muster |
+| `NotificationService.send_multi_location_deviation_alert()` (`notification_service.py:691ff`) | Vorbild, unverändert | Compare-Abweichungsalarm — identisches Muster |
+| `NotificationService.send_multi_location_official_alert()` → `_dispatch_compare_official_telegram` (`notification_service.py:1046ff`, `:1179ff`) | Vorbild, unverändert | Compare-amtlicher Alarm — identisches Muster |
+| `TripAlertService._trip_telegram_style(trip)` (`trip_alert.py:108-118`) | bestehender Auflöser, unverändert wiederverwendet | Liest `trip.report_config.telegram_style`, Default `"rich"` |
+| `effective_compare_telegram_style(preset)` (`compare_alert_channels.py:49-58`) | bestehender Auflöser, unverändert wiederverwendet | Liest `preset["display_config"]["telegram_style"]`, Default `"rich"` |
+| `NotificationService._dispatch_alert_message()` (`notification_service.py:1305-1319`) | Zielsenke, unverändert | Steuert bereits den Kurzstil-/Rich-Renderzweig ab `telegram_style` (Kurzstil-Zweig ab ~1448) |
+| ADR-0021 (geteilte Rendering/Versand-Engine Trip/Compare) | ADR, keine Änderung | Begründet, warum Trip- UND Compare-Pfad symmetrisch in einer Spec behoben werden |
+
+## Implementation Details
+
+Option A (Parameter durchreichen, analog den vier bestehenden Geschwistermethoden) statt
+Option B (Style zentral aus `AlertMessage` ableiten). Option B würde die bewusste
+Architekturtrennung aufweichen, wonach der geteilte Dispatcher `_dispatch_alert_message()`
+Trip/Compare-agnostisch bleibt (`AlertMessage` kennt weder Trip noch Preset). Option A ist
+minimal-invasiv und strikt konsistent mit dem bestehenden Muster.
+
+```
+# notification_service.py — send_radar_alert()
+def send_radar_alert(
+    self,
+    trip: "Trip",
+    *,
+    request: RadarAlertRequest,
+    source: str,
+    cooldown_display: str,
+    effective_channels: set[str],
+    mail_sink: Optional[object] = None,
+    telegram_style: str = "rich",          # NEU
+) -> NotificationResult:
+    ...
+    return self._dispatch_alert_message(
+        ...,
+        telegram_style=telegram_style,      # NEU: durchgereicht statt Default
+    )
+
+# notification_service.py — send_multi_location_radar_alert()
+def send_multi_location_radar_alert(
+    self,
+    entities: list[tuple[str, object, "NowcastResult"]],
+    effective_channels: set[str],
+    *,
+    tz: Optional[ZoneInfo] = None,
+    stand_at: Optional[str] = None,
+    mail_sink: Optional[object] = None,
+    cooldown_display: Optional[str] = None,
+    telegram_style: str = "rich",           # NEU
+) -> NotificationResult:
+    ...
+    return self._dispatch_alert_message(
+        ...,
+        telegram_style=telegram_style,       # NEU: durchgereicht statt Default
+    )
+
+# trip_alert.py — Aufrufstelle ~1208-1215
+result = self._notification_service.send_radar_alert(
+    trip=trip,
+    request=_radar_request,
+    source=radar_svc.source_label(result.source),
+    cooldown_display=cooldown_display,
+    effective_channels=_radar_allowed,
+    mail_sink=self._mail_sink,
+    telegram_style=_trip_telegram_style(trip),   # NEU
+)
+
+# compare_radar_alert.py — Aufrufstelle ~204-207
+notif_result = notification_service.send_multi_location_radar_alert(
+    entities=entities, effective_channels=allowed, mail_sink=self._mail_sink,
+    cooldown_display=_format_cooldown_display(cooldown_minutes),
+    telegram_style=effective_compare_telegram_style(preset),   # NEU
+)
+```
+
+Reihenfolge: 1) Signatur + Durchreichen Trip-Radar (`send_radar_alert`), 2) Signatur +
+Durchreichen Compare-Radar (`send_multi_location_radar_alert`), 3) Aufrufer `trip_alert.py`,
+4) Aufrufer `compare_radar_alert.py` — TDD: erst Trip rot/grün, dann Compare rot/grün.
+
+## Expected Behavior
+
+- **Input:** Ein Trip hat `report_config.telegram_style` bzw. ein Ortsvergleich-Preset hat
+  `display_config.telegram_style` auf `"kurzform"` gesetzt. Ein Regenradar-/Nowcast-Alarm wird
+  ausgelöst (Trip-Pfad über `check_radar_alerts()`, Compare-Pfad über den Multi-Location-Radar-
+  Versand).
+- **Output:** Die Telegram-Nachricht des Radar-Alarms kommt im konfigurierten Stil an — im
+  Kurzstil-Format bei `"kurzform"`, im reichen Format bei `"rich"`/Default — genau wie bei
+  Abweichungs- und amtlichem Alarm bereits heute. Andere Kanäle (E-Mail, SMS, Premium-SMS)
+  sind von `telegram_style` unberührt, da der Parameter ausschließlich den Telegram-Renderzweig
+  in `_dispatch_alert_message()` steuert.
+- **Side effects:** Keine. Rein additiver, optionaler Parameter mit Default `"rich"` — kein
+  Schema-Wechsel, keine Migration, kein bestehender Test erwartet Rich-Verhalten als feste
+  Assertion am Radar-Pfad.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Trip hat `report_config.telegram_style` auf `"kurzform"` gesetzt / When
+  für diesen Trip ein Radar-/Nowcast-Alarm ausgelöst wird / Then kommt die Telegram-Nachricht
+  im Kurzstil-Format an, nicht im reichen Emoji-/Mehrzeilen-Format.
+  - Prüfort: Aufrufstelle `trip_alert.py` (`check_radar_alerts()` bzw. `send_radar_alert()`
+    aus dem Trip-Kontext heraus), nicht nur der `NotificationService`-Baustein isoliert — Lehre
+    aus Issue #1467: ein Bausteintest allein beweist die Verdrahtung nicht.
+  - Test: neuer/erweiterter Test in `tests/unit/` oder `tests/tdd/` am Trip-Radar-Alarmpfad.
+  - Mutation: `telegram_style=_trip_telegram_style(trip)` wird an der Aufrufstelle wieder
+    entfernt bzw. der Parameter in `send_radar_alert()` nicht an `_dispatch_alert_message()`
+    durchgereicht — die Telegram-Nachricht bliebe trotz `"kurzform"` im reichen Format.
+
+- **AC-2:** Given ein Trip hat `report_config.telegram_style` auf `"rich"` gesetzt (oder das
+  Feld ist unbesetzt und der Default greift) / When für diesen Trip ein Radar-/Nowcast-Alarm
+  ausgelöst wird / Then bleibt die Telegram-Nachricht im reichen Format — Regressionsschutz für
+  den unveränderten Bestandsfall.
+  - Prüfort: dieselbe Aufrufstelle wie AC-1 (Trip-Radar-Pfad), Gegenprobe zu AC-1.
+  - Test: neuer/erweiterter Test in `tests/unit/` oder `tests/tdd/` am Trip-Radar-Alarmpfad.
+  - Mutation: der neue Parameter bekommt fälschlich einen anderen Default als `"rich"` oder
+    wird an der Aufrufstelle hart auf `"kurzform"` verdrahtet — Rich-Trips erhielten dann
+    fälschlich Kurzstil.
+
+- **AC-3:** Given ein Ortsvergleich-Preset hat `display_config.telegram_style` auf
+  `"kurzform"` gesetzt / When für dieses Preset ein Multi-Location-Radar-Alarm ausgelöst wird
+  / Then kommt die Telegram-Nachricht im Kurzstil-Format an.
+  - Prüfort: Aufrufstelle `compare_radar_alert.py` (der Multi-Location-Radar-Versandpfad),
+    nicht nur der `NotificationService`-Baustein isoliert — dieselbe Lehre aus #1467 wie bei
+    AC-1.
+  - Test: neuer/erweiterter Test in `tests/unit/` oder `tests/tdd/` am Compare-Radar-Alarmpfad.
+  - Mutation: `telegram_style=effective_compare_telegram_style(preset)` wird an der Aufrufstelle
+    wieder entfernt bzw. `send_multi_location_radar_alert()` reicht den Parameter nicht an
+    `_dispatch_alert_message()` durch — die Telegram-Nachricht bliebe trotz `"kurzform"` im
+    reichen Format.
+
+- **AC-4:** Given ein Ortsvergleich-Preset hat `display_config.telegram_style` auf `"rich"`
+  gesetzt (oder das Feld ist unbesetzt und der Default greift) / When für dieses Preset ein
+  Multi-Location-Radar-Alarm ausgelöst wird / Then bleibt die Telegram-Nachricht im reichen
+  Format — Regressionsschutz für den unveränderten Bestandsfall im Ortsvergleich.
+  - Prüfort: dieselbe Aufrufstelle wie AC-3 (Compare-Radar-Pfad), Gegenprobe zu AC-3.
+  - Test: neuer/erweiterter Test in `tests/unit/` oder `tests/tdd/` am Compare-Radar-Alarmpfad.
+  - Mutation: der neue Parameter bekommt fälschlich einen anderen Default als `"rich"` oder
+    wird an der Aufrufstelle hart auf `"kurzform"` verdrahtet — Rich-Presets erhielten dann
+    fälschlich Kurzstil.
+
+## Testplan
+
+**Pflicht: Tests setzen an den Aufrufstellen an, nicht nur am Baustein.** Ein Test, der
+ausschließlich `NotificationService.send_radar_alert()`/`send_multi_location_radar_alert()`
+direkt mit `telegram_style=...` aufruft, beweist nur, dass der Parameter innerhalb der
+Methode funktioniert — nicht, dass `trip_alert.py` bzw. `compare_radar_alert.py` ihn beim
+tatsächlichen Alarmauslösen auch tatsächlich befüllen. Genau diese Verdrahtungslücke war die
+Fehlerursache in #1467 (87 grüne Bausteintests ließen „buchen vor zustellen" durch, weil kein
+Test die Aufrufstelle prüfte). Für AC-1/AC-2 muss der Test daher über den Trip-Alarmpfad
+(`TripAlertService.check_radar_alerts()` oder eine äquivalente Stelle, die
+`send_radar_alert()` produktiv aufruft) laufen; für AC-3/AC-4 über den Compare-Alarmpfad
+(`compare_radar_alert.py`s Versandfunktion). Die tatsächlich gerenderte Telegram-Nachricht
+(bzw. der an `_dispatch_alert_message()`/den Telegram-Transport übergebene `telegram_style`-
+Wert) ist der beobachtbare Nachweis, nicht ein reiner Signatur-Check.
+
+## Known Limitations
+
+- **`send_location_deviation_alert` bleibt unbehoben** (siehe „Bewusst nicht in dieser
+  Spec") — kein produktiver Aufrufer, daher kein Nutzer-Symptom; Nebenbefund-Kandidat für
+  #1199.
+- **Kein neuer Auflöser.** Beide Auflöser (`_trip_telegram_style`,
+  `effective_compare_telegram_style`) sind bewusst unverändert — eine dritte, radar-eigene
+  Ableitung wäre die Art von Doppelarbeit, die die Projektregel „Trip/Compare teilen Code"
+  verbietet.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue.
+- **Rationale:** Diese Spec wendet ein bereits etabliertes Muster (Parameter-Durchreichen an
+  die geteilte Zielsenke `_dispatch_alert_message()`, ADR-0021) symmetrisch auf die letzte noch
+  abweichende Alarmart (Radar) an — keine neue Architekturentscheidung, keine Abweichung von
+  einer bestehenden.
+
+## Changelog
+
+- 2026-08-16: Initial spec erstellt — Issue #1914 (Radar-Alarm folgt dem konfigurierten
+  Telegram-Stil, Trip- und Ortsvergleich-Pfad).

--- a/src/services/compare_radar_alert.py
+++ b/src/services/compare_radar_alert.py
@@ -30,7 +30,10 @@ import services.alert_urgency as alert_urgency
 from services.alert_gate import check_nowcast_gate, record_nowcast_sent
 from utils.timezone import first_resolvable_tz
 from services.alert_state import AlertStateService
-from services.compare_alert_channels import effective_compare_channels
+from services.compare_alert_channels import (
+    effective_compare_channels,
+    effective_compare_telegram_style,
+)
 from services.compare_alert_guard import is_silenced
 from services.compare_preset_access import (
     load_compare_alert_presets,
@@ -204,6 +207,7 @@ class CompareRadarAlertService:
         notif_result = notification_service.send_multi_location_radar_alert(
             entities=entities, effective_channels=allowed, mail_sink=self._mail_sink,
             cooldown_display=_format_cooldown_display(cooldown_minutes),
+            telegram_style=effective_compare_telegram_style(preset),
         )
         # Issue #1459: gemischt konvektive/nicht-konvektive Orte ergeben BEIDE
         # Register-Paare in EINEM Eintrag.

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -755,6 +755,7 @@ class NotificationService:
         stand_at: Optional[str] = None,
         mail_sink: Optional[object] = None,
         cooldown_display: Optional[str] = None,
+        telegram_style: str = "rich",
     ) -> NotificationResult:
         """Gebündelter Onset-Alert-Versand für MEHRERE gleichzeitig auslösende
         Vergleichs-Orte EINES Compare-Presets (Issue #1041 Slice 1a).
@@ -812,6 +813,7 @@ class NotificationService:
             target_name=target_name,
             radar_mode=True,
             alert_tz=alert_tz,
+            telegram_style=telegram_style,
         )
 
     def send_official_alert(
@@ -1269,6 +1271,7 @@ class NotificationService:
         cooldown_display: str,
         effective_channels: set[str],
         mail_sink: Optional[object] = None,
+        telegram_style: str = "rich",
     ) -> NotificationResult:
         """Radar-Onset-Alert: rendern und über konfigurierte Kanäle versenden."""
         onset_event = OnsetEvent(
@@ -1300,6 +1303,7 @@ class NotificationService:
             target_name=trip.id,
             radar_mode=True,
             alert_tz=alert_tz,
+            telegram_style=telegram_style,
         )
 
     def _dispatch_alert_message(

--- a/src/services/trip_alert.py
+++ b/src/services/trip_alert.py
@@ -1212,6 +1212,7 @@ class TripAlertService:
                 cooldown_display=cooldown_display,
                 effective_channels=_radar_allowed,
                 mail_sink=self._mail_sink,
+                telegram_style=_trip_telegram_style(trip),
             )
             # Issue #1459: Protokoll VOR dem Zustellbarkeits-Guard; die
             # Ziel-Liste (`entries` vs. `not_delivered`) entscheidet

--- a/tests/tdd/test_compare_radar_alert_telegram_style.py
+++ b/tests/tdd/test_compare_radar_alert_telegram_style.py
@@ -182,10 +182,20 @@ def _telegram_only_settings() -> Settings:
     """Nur Telegram sendebereit — `effective_compare_channels()` nimmt zwar
     immer `"email"` auf, aber ohne SMTP-Konfiguration schlaegt der E-Mail-
     Versuch lediglich fehl (Best-Effort, `_log_error`) und beeinflusst die
-    Telegram-Assertions nicht."""
+    Telegram-Assertions nicht.
+
+    `telegram_test_chat_id` ist BEWUSST identisch zu `telegram_chat_id`
+    gesetzt: die Herkunftssperre (`TelegramOutput._guard_code_origin()`,
+    Issue #1476, `src/app/origin_guard.py`) verlangt aus jedem
+    Nicht-Prod-/Staging-Checkout eine konfigurierte Test-Chat-ID, sonst
+    `OutputConfigError` VOR jedem HTTP-Request. Ohne dieses Feld lief der
+    Test nur lokal (per zufaelligem `.env`-Wert), nicht auf dem
+    GitHub-Actions-Runner (kein `.env`) -- die Guard-Ausnahme verschwand
+    silent im breiten `except Exception` von `_dispatch_alert_message()`."""
     return Settings().model_copy(update={
         "smtp_host": None, "smtp_user": None, "smtp_pass": None, "mail_to": None,
         "telegram_bot_token": "test-token-1914-cmp", "telegram_chat_id": "99999",
+        "telegram_test_chat_id": "99999",
         "sms_gateway_url": None, "seven_api_key": None, "sms_to": None,
     })
 

--- a/tests/tdd/test_compare_radar_alert_telegram_style.py
+++ b/tests/tdd/test_compare_radar_alert_telegram_style.py
@@ -1,0 +1,303 @@
+"""TDD RED — Issue #1914: Radar-Alarm folgt dem konfigurierten Telegram-Stil
+(Ortsvergleich-Pfad).
+
+Deckt AC-3/AC-4 der Spec `docs/specs/modules/fix_1914_radar_telegram_style.md`
+ab: `CompareRadarAlertService.check_all_compare_presets()` ->
+`send_multi_location_radar_alert()` reicht heute `telegram_style` NICHT
+durch — die Telegram-Nachricht eines Multi-Location-Radar-Alarms kommt
+deshalb immer im reichen HTML-Format an, auch wenn
+`preset["display_config"]["telegram_style"] == "kurzform"` gesetzt ist.
+
+Pflicht (Lehre #1467): der Test laeuft ueber die tatsaechliche Aufrufstelle
+(`CompareRadarAlertService.check_all_compare_presets()`), NICHT nur direkt
+gegen `NotificationService.send_multi_location_radar_alert(telegram_style=
+...)` — sonst beweist er nur den Baustein, nicht die Verdrahtung ueber
+`compare_radar_alert.py`.
+
+RED-Ursache: der `send_multi_location_radar_alert()`-Aufruf in
+`compare_radar_alert.py::_check_one_preset()` kennt `telegram_style` noch
+nicht (AC-3 schlaegt fehl: die Telegram-Nachricht kommt trotz `"kurzform"`
+als reiche HTML-Bubble an). AC-4 ist der Regressionsschutz fuer den
+unveraenderten Bestandsfall (rich/Default) und darf bereits heute gruen sein.
+
+Fixtures/Helfer (Vorbild `test_compare_radar_alert.py`): echte Preset-/
+Locations-Dateien unter `data/users/<user_id>/` (eindeutige tdd-1914-*-IDs,
+Cleanup per try/finally), echter `frame_source`-DI-Seam von
+`RadarNowcastService` (`radar_service.py:84-89`, kein Mock der
+Provider-Kette). Telegram wird ueber einen echten lokalen HTTP-Stub
+beobachtet (Vorbild `test_telegram_kurzstil_trip_alert.py::_TelegramStub`,
+`monkeypatch.setattr(telegram_mod, "TELEGRAM_API_BASE", ...)`) — kein
+`Mock()`/`patch()` des Verhaltens selbst.
+
+SPEC: docs/specs/modules/fix_1914_radar_telegram_style.md
+"""
+from __future__ import annotations
+
+import http.server
+import json
+import shutil
+import socket
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from app.config import Settings
+from app.loader import save_location
+from app.user import SavedLocation
+
+import output.channels.telegram as tg_module
+
+from tests.helpers.compare_briefings import write_compare_briefings
+
+
+def _data_root_users() -> Path:
+    """Funktion statt Konstante (#1595) — Vorbild
+    `test_compare_radar_alert.py::_data_root_users`."""
+    from app.loader import get_data_root
+
+    return get_data_root() / "users"
+
+
+def _clean_user(user_id: str) -> None:
+    d = _data_root_users() / user_id
+    if d.exists():
+        shutil.rmtree(d)
+
+
+def _location(loc_id: str, name: str, lat: float, lon: float) -> SavedLocation:
+    return SavedLocation(id=loc_id, name=name, lat=lat, lon=lon, elevation_m=1000)
+
+
+def _radar_preset(
+    preset_id: str, location_ids: list[str], empfaenger: list[str], *,
+    telegram_style: str,
+) -> dict:
+    """Direktes Compare-Preset-Dict (Vorbild
+    `test_compare_radar_alert.py::_radar_preset`), zusaetzlich mit
+    `send_telegram=True` + `display_config.telegram_style` — genau die zwei
+    Felder, die `effective_compare_channels()`/`effective_compare_telegram_
+    style()` fuer diesen Test auswerten."""
+    return {
+        "id": preset_id,
+        "name": preset_id,
+        "user_id": "default",
+        "location_ids": location_ids,
+        # Issue #1467 S2 AG6: aktiver Zeitplan noetig, sonst gilt das Preset
+        # als pausiert und schweigt in allen Alarm-Pfaden.
+        "schedule": "daily",
+        "weekday": 4,
+        "profil": "ALLGEMEIN",
+        "hour_from": 9,
+        "hour_to": 16,
+        "empfaenger": empfaenger,
+        "letzter_versand": None,
+        "top_ort_letzter_versand": None,
+        "created_at": "2026-07-10T00:00:00Z",
+        "radar_alert_enabled": True,
+        "send_telegram": True,
+        "display_config": {"telegram_style": telegram_style},
+    }
+
+
+def _write_preset_file(user_id: str, presets: list[dict]) -> Path:
+    return write_compare_briefings(_data_root_users() / user_id, presets)
+
+
+def _wet_frame(onset_minutes: int, *, is_convective: bool = False, rate: float = 0.6) -> list:
+    """Ein einzelner nasser `RadarFrame` `onset_minutes` in der Zukunft —
+    echtes DTO (kein Mock), Vorbild `test_compare_radar_alert.py::_wet_frame`."""
+    from providers.brightsky import RadarFrame
+
+    ts = datetime.now(timezone.utc) + timedelta(minutes=onset_minutes)
+    return [RadarFrame(timestamp=ts, precip_mm_h=rate, is_convective=is_convective)]
+
+
+class _CoordFrameSource:
+    """Echter (kein `Mock()`/`patch()`), aufrufbarer `frame_source`-
+    Doppelgaenger fuer `RadarNowcastService(frame_source=...)` — liefert je
+    nach (lat, lon) einen vorab festgelegten `RadarFrame`-Satz."""
+
+    def __init__(self, by_coord: dict[tuple[float, float], list]) -> None:
+        self._by_coord = by_coord
+
+    def __call__(self, lat: float, lon: float) -> list:
+        return self._by_coord.get((round(lat, 4), round(lon, 4)), [])
+
+
+# ---------------------------------------------------------------------------
+# Echter lokaler Telegram-Bot-API-Stub (kein Mock) — Vorbild
+# test_telegram_kurzstil_trip_alert.py::_TelegramStub.
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class _TelegramStub:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        sent = self.sent
+        counter = {"mid": 4000}
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(length)
+                try:
+                    payload = json.loads(body.decode())
+                except ValueError:
+                    payload = {}
+                sent.append(payload)
+                counter["mid"] += 1
+                resp = json.dumps(
+                    {"ok": True, "result": {"message_id": counter["mid"]}}
+                ).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(resp)
+
+            def log_message(self, *args):  # noqa: D401
+                pass
+
+        self.port = _free_port()
+        self._server = http.server.HTTPServer(("127.0.0.1", self.port), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def stop(self) -> None:
+        self._server.shutdown()
+
+
+def _telegram_only_settings() -> Settings:
+    """Nur Telegram sendebereit — `effective_compare_channels()` nimmt zwar
+    immer `"email"` auf, aber ohne SMTP-Konfiguration schlaegt der E-Mail-
+    Versuch lediglich fehl (Best-Effort, `_log_error`) und beeinflusst die
+    Telegram-Assertions nicht."""
+    return Settings().model_copy(update={
+        "smtp_host": None, "smtp_user": None, "smtp_pass": None, "mail_to": None,
+        "telegram_bot_token": "test-token-1914-cmp", "telegram_chat_id": "99999",
+        "sms_gateway_url": None, "seven_api_key": None, "sms_to": None,
+    })
+
+
+# ===========================================================================
+# AC-3: display_config.telegram_style="kurzform" -> Kurzstil-Telegram
+# ===========================================================================
+
+
+class TestAC3CompareRadarAlertTelegramKurzstil:
+    def test_kurzform_compare_radar_path_sends_plaintext_no_parse_mode(self, monkeypatch) -> None:
+        """RED: `check_all_compare_presets()` reicht `telegram_style` noch
+        nicht bis zu `send_multi_location_radar_alert()`/
+        `_dispatch_alert_message()` durch — die Telegram-Nachricht kommt
+        trotz `"kurzform"` als reiche HTML-Bubble (parse_mode="HTML") an."""
+        from services.compare_radar_alert import CompareRadarAlertService
+        from services.radar_service import RadarNowcastService
+
+        uid = "tdd-1914-cmp-ac3"
+        _clean_user(uid)
+        tg_stub = _TelegramStub()
+        try:
+            monkeypatch.setattr(tg_module, "TELEGRAM_API_BASE", tg_stub.base_url)
+
+            loc = _location("loc-a", "Zermatt-Kurzstil", 46.0207, 7.7491)
+            save_location(loc, user_id=uid)
+            preset_id = "cp-1914-ac3"
+            _write_preset_file(uid, [
+                _radar_preset(
+                    preset_id, ["loc-a"], ["gregor-test@henemm.com"],
+                    telegram_style="kurzform",
+                ),
+            ])
+
+            frame_source = _CoordFrameSource({(46.0207, 7.7491): _wet_frame(8)})
+            radar_service = RadarNowcastService(frame_source=frame_source)
+
+            service = CompareRadarAlertService(
+                settings=_telegram_only_settings(), user_id=uid,
+                radar_service=radar_service,
+            )
+            sent = service.check_all_compare_presets()
+
+            assert sent == 1, f"Erwartete genau 1 Alarm-Lauf, erhalten: {sent}"
+            assert len(tg_stub.sent) == 1, (
+                f"Erwartete genau 1 Telegram-Nachricht, erhalten: {len(tg_stub.sent)}"
+            )
+            payload = tg_stub.sent[0]
+            assert "parse_mode" not in payload, (
+                "RED: Kurzstil-Redirect muss parse_mode=None nutzen (kein "
+                f"Schluessel im Payload); gefunden parse_mode="
+                f"{payload.get('parse_mode')!r} — die Verdrahtung von "
+                "telegram_style durch check_all_compare_presets() -> "
+                "send_multi_location_radar_alert() -> _dispatch_alert_message() "
+                "fehlt noch."
+            )
+            assert "reply_markup" not in payload, (
+                "RED: Kurzstil darf keine Inline-Knoepfe (reply_markup) senden."
+            )
+            assert "<b>" not in (payload.get("text") or ""), (
+                "RED: Kurzstil-Body enthaelt HTML-Tags — es ist noch die reiche "
+                f"Telegram-Radar-Warnung: {payload.get('text')!r}"
+            )
+        finally:
+            tg_stub.stop()
+            _clean_user(uid)
+
+
+# ===========================================================================
+# AC-4: display_config.telegram_style="rich"/Default -> Regressionsschutz
+# ===========================================================================
+
+
+class TestAC4CompareRadarAlertTelegramRichRegression:
+    def test_rich_compare_radar_path_still_sends_html(self, monkeypatch) -> None:
+        """Regressionsschutz — darf bereits vor der Implementierung gruen
+        sein: der heutige (fehlerhafte) Default-Pfad rendert IMMER rich."""
+        from services.compare_radar_alert import CompareRadarAlertService
+        from services.radar_service import RadarNowcastService
+
+        uid = "tdd-1914-cmp-ac4"
+        _clean_user(uid)
+        tg_stub = _TelegramStub()
+        try:
+            monkeypatch.setattr(tg_module, "TELEGRAM_API_BASE", tg_stub.base_url)
+
+            loc = _location("loc-b", "Zermatt-Rich", 46.0207, 7.7491)
+            save_location(loc, user_id=uid)
+            preset_id = "cp-1914-ac4"
+            _write_preset_file(uid, [
+                _radar_preset(
+                    preset_id, ["loc-b"], ["gregor-test@henemm.com"],
+                    telegram_style="rich",
+                ),
+            ])
+
+            frame_source = _CoordFrameSource({(46.0207, 7.7491): _wet_frame(8)})
+            radar_service = RadarNowcastService(frame_source=frame_source)
+
+            service = CompareRadarAlertService(
+                settings=_telegram_only_settings(), user_id=uid,
+                radar_service=radar_service,
+            )
+            sent = service.check_all_compare_presets()
+
+            assert sent == 1, f"Erwartete genau 1 Alarm-Lauf, erhalten: {sent}"
+            assert len(tg_stub.sent) == 1
+            assert tg_stub.sent[0].get("parse_mode") == "HTML", (
+                "Regression: rich/Default muss den reichen HTML-Compare-Radar-"
+                f"Alarm unveraendert senden; gefunden parse_mode="
+                f"{tg_stub.sent[0].get('parse_mode')!r}."
+            )
+        finally:
+            tg_stub.stop()
+            _clean_user(uid)

--- a/tests/tdd/test_radar_alert_telegram_style.py
+++ b/tests/tdd/test_radar_alert_telegram_style.py
@@ -107,10 +107,25 @@ class _TelegramStub:
 
 def _telegram_only_settings() -> Settings:
     """Nur Telegram sendebereit (kein E-Mail-/SMS-Versuch — vereinfacht die
-    Assertions auf den einen relevanten Kanal)."""
+    Assertions auf den einen relevanten Kanal).
+
+    `telegram_test_chat_id` ist BEWUSST identisch zu `telegram_chat_id`
+    gesetzt: die Herkunftssperre (`TelegramOutput._guard_code_origin()`,
+    Issue #1476, `src/app/origin_guard.py`) verlangt aus jedem
+    Nicht-Prod-/Staging-Checkout (jeder Worktree UND jeder CI-Runner) eine
+    konfigurierte Test-Chat-ID, sonst `OutputConfigError` — VOR jedem HTTP-
+    Request, ausserhalb des `try`/`except` in `send()`. Ohne dieses Feld lief
+    der Test hier nur, weil das lokale Dev-`.env` zufaellig
+    `GZ_TELEGRAM_TEST_CHAT_ID` setzt (per `env_file=".env"` in
+    `Settings.model_config`) -- der GitHub-Actions-Runner hat kein `.env` und
+    die leere Default-Chat-ID liess die Guard-Ausnahme silent in
+    `_dispatch_alert_message()`s breitem `except Exception` verschwinden
+    (`sent_channels.append("telegram")` steht VOR dem `try`, also zaehlte der
+    Kanal trotzdem als "zugestellt")."""
     return Settings().model_copy(update={
         "smtp_host": None, "smtp_user": None, "smtp_pass": None, "mail_to": None,
         "telegram_bot_token": "test-token-1914", "telegram_chat_id": "99999",
+        "telegram_test_chat_id": "99999",
         "sms_gateway_url": None, "seven_api_key": None, "sms_to": None,
     })
 

--- a/tests/tdd/test_radar_alert_telegram_style.py
+++ b/tests/tdd/test_radar_alert_telegram_style.py
@@ -1,0 +1,223 @@
+"""TDD RED — Issue #1914: Radar-Alarm folgt dem konfigurierten Telegram-Stil
+(Trip-Pfad).
+
+Deckt AC-1/AC-2 der Spec `docs/specs/modules/fix_1914_radar_telegram_style.md`
+ab: `TripAlertService.check_radar_alerts()` -> `send_radar_alert()` reicht
+heute `telegram_style` NICHT durch — die Telegram-Nachricht eines
+Radar-/Nowcast-Alarms kommt deshalb immer im reichen HTML-Format an, auch
+wenn `trip.report_config.telegram_style == "kurzform"` gesetzt ist.
+
+Pflicht (Lehre #1467): der Test laeuft ueber die tatsaechliche Aufrufstelle
+(`TripAlertService.check_radar_alerts()`), NICHT nur direkt gegen
+`NotificationService.send_radar_alert(telegram_style=...)` — sonst beweist er
+nur den Baustein, nicht die Verdrahtung ueber `trip_alert.py`.
+
+RED-Ursache: `send_radar_alert()`/`_dispatch_alert_message()`-Aufruf darin
+kennen `telegram_style` noch nicht (AC-1 schlaegt fehl: die Telegram-Nachricht
+kommt trotz `"kurzform"` als reiche HTML-Bubble an). AC-2 ist der
+Regressionsschutz fuer den unveraenderten Bestandsfall (rich/Default) und
+darf bereits heute gruen sein.
+
+Wiederverwendete Fixtures/Helfer (Vorbild `test_952_onset_alert_e2e.py`, das
+denselben Import-Weg bereits nutzt): `_GuaranteedWetRadar` (echter
+`RadarNowcastService`-DI-Seam, kein Mock), `_trip_with_active_segment`
+(garantiert aktives Segment JETZT), `_clean_user` — alle aus
+`test_952_onset_alert_fidelity.py`. Der lokale Telegram-HTTP-Stub ist die aus
+`test_telegram_kurzstil_trip_alert.py` bekannte `_TelegramStub`-Bauart (echter
+lokaler HTTP-Server, `monkeypatch.setattr(telegram_mod, "TELEGRAM_API_BASE",
+...)`) — kein `Mock()`/`patch()` des Verhaltens selbst.
+
+SPEC: docs/specs/modules/fix_1914_radar_telegram_style.md
+"""
+from __future__ import annotations
+
+import http.server
+import json
+import socket
+import threading
+
+from app.config import Settings
+from app.models import TripReportConfig
+
+import output.channels.telegram as tg_module
+
+from tests.tdd.test_952_onset_alert_fidelity import (
+    _GuaranteedWetRadar,
+    _clean_user,
+    _trip_with_active_segment,
+)
+
+
+# ---------------------------------------------------------------------------
+# Echter lokaler Telegram-Bot-API-Stub (kein Mock) — Vorbild
+# test_telegram_kurzstil_trip_alert.py::_TelegramStub.
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class _TelegramStub:
+    """Lokaler HTTP-Stub für die Telegram-Bot-API. Zeichnet jede sendMessage-
+    Nutzlast (text/parse_mode/reply_markup) auf und antwortet mit ok:true."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        sent = self.sent
+        counter = {"mid": 3000}
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(length)
+                try:
+                    payload = json.loads(body.decode())
+                except ValueError:
+                    payload = {}
+                sent.append(payload)
+                counter["mid"] += 1
+                resp = json.dumps(
+                    {"ok": True, "result": {"message_id": counter["mid"]}}
+                ).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(resp)
+
+            def log_message(self, *args):  # noqa: D401
+                pass
+
+        self.port = _free_port()
+        self._server = http.server.HTTPServer(("127.0.0.1", self.port), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def stop(self) -> None:
+        self._server.shutdown()
+
+
+def _telegram_only_settings() -> Settings:
+    """Nur Telegram sendebereit (kein E-Mail-/SMS-Versuch — vereinfacht die
+    Assertions auf den einen relevanten Kanal)."""
+    return Settings().model_copy(update={
+        "smtp_host": None, "smtp_user": None, "smtp_pass": None, "mail_to": None,
+        "telegram_bot_token": "test-token-1914", "telegram_chat_id": "99999",
+        "sms_gateway_url": None, "seven_api_key": None, "sms_to": None,
+    })
+
+
+def _trip_with_telegram_style(trip_id: str, telegram_style: str):
+    config = TripReportConfig(
+        trip_id=trip_id, send_email=False, send_sms=False, send_telegram=True,
+        alert_on_changes=True, telegram_style=telegram_style,
+    )
+    return _trip_with_active_segment(trip_id, config)
+
+
+# ===========================================================================
+# AC-1: telegram_style="kurzform" am Trip-Radar-Pfad -> Kurzstil-Telegram
+# ===========================================================================
+
+
+class TestAC1RadarAlertTelegramKurzstil:
+    def test_kurzform_trip_radar_path_sends_plaintext_no_parse_mode(self, monkeypatch) -> None:
+        """RED: `check_radar_alerts()` reicht `telegram_style` noch nicht bis
+        zu `send_radar_alert()`/`_dispatch_alert_message()` durch — die
+        Telegram-Nachricht kommt trotz `"kurzform"` als reiche HTML-Bubble
+        (parse_mode="HTML") an statt als Plaintext ohne parse_mode."""
+        uid = "tdd-1914-ac1"
+        trip_id = "trip-1914-ac1"
+        _clean_user(uid)
+        tg_stub = _TelegramStub()
+        try:
+            monkeypatch.setattr(tg_module, "TELEGRAM_API_BASE", tg_stub.base_url)
+
+            trip = _trip_with_telegram_style(trip_id, "kurzform")
+            from app.loader import save_trip
+            save_trip(trip, user_id=uid)
+
+            from services.trip_alert import TripAlertService
+            svc = TripAlertService(
+                settings=_telegram_only_settings(), throttle_hours=0, user_id=uid,
+                radar_service=_GuaranteedWetRadar(
+                    onset_minutes=12, intensity_label="leichter Regen",
+                    is_convective=False,
+                ),
+            )
+
+            result = svc.check_radar_alerts()
+
+            assert result == 1, f"check_radar_alerts() sollte 1 Alert liefern, war {result}"
+            assert len(tg_stub.sent) == 1, (
+                f"Erwartete genau 1 Telegram-Nachricht, erhalten: {len(tg_stub.sent)}"
+            )
+            payload = tg_stub.sent[0]
+            assert "parse_mode" not in payload, (
+                "RED: Kurzstil-Redirect muss parse_mode=None nutzen (kein "
+                f"Schluessel im Payload); gefunden parse_mode="
+                f"{payload.get('parse_mode')!r} — die Verdrahtung von "
+                "telegram_style durch check_radar_alerts() -> send_radar_alert() "
+                "-> _dispatch_alert_message() fehlt noch."
+            )
+            assert "reply_markup" not in payload, (
+                "RED: Kurzstil darf keine Inline-Knoepfe (reply_markup) senden."
+            )
+            assert "<b>" not in (payload.get("text") or ""), (
+                "RED: Kurzstil-Body enthaelt HTML-Tags — es ist noch die reiche "
+                f"Telegram-Radar-Warnung: {payload.get('text')!r}"
+            )
+        finally:
+            tg_stub.stop()
+            _clean_user(uid)
+
+
+# ===========================================================================
+# AC-2: telegram_style="rich"/Default am Trip-Radar-Pfad -> Regressionsschutz
+# ===========================================================================
+
+
+class TestAC2RadarAlertTelegramRichRegression:
+    def test_rich_trip_radar_path_still_sends_html(self, monkeypatch) -> None:
+        """Regressionsschutz — darf bereits vor der Implementierung gruen
+        sein: der heutige (fehlerhafte) Default-Pfad rendert IMMER rich."""
+        uid = "tdd-1914-ac2"
+        trip_id = "trip-1914-ac2"
+        _clean_user(uid)
+        tg_stub = _TelegramStub()
+        try:
+            monkeypatch.setattr(tg_module, "TELEGRAM_API_BASE", tg_stub.base_url)
+
+            trip = _trip_with_telegram_style(trip_id, "rich")
+            from app.loader import save_trip
+            save_trip(trip, user_id=uid)
+
+            from services.trip_alert import TripAlertService
+            svc = TripAlertService(
+                settings=_telegram_only_settings(), throttle_hours=0, user_id=uid,
+                radar_service=_GuaranteedWetRadar(
+                    onset_minutes=12, intensity_label="leichter Regen",
+                    is_convective=False,
+                ),
+            )
+
+            result = svc.check_radar_alerts()
+
+            assert result == 1, f"check_radar_alerts() sollte 1 Alert liefern, war {result}"
+            assert len(tg_stub.sent) == 1
+            assert tg_stub.sent[0].get("parse_mode") == "HTML", (
+                "Regression: rich/Default muss den reichen HTML-Radar-Alarm "
+                f"unveraendert senden; gefunden parse_mode="
+                f"{tg_stub.sent[0].get('parse_mode')!r}."
+            )
+        finally:
+            tg_stub.stop()
+            _clean_user(uid)


### PR DESCRIPTION
## Summary
- Radar-/Starkregen-Nowcast-Alarm ignorierte bisher den trip-/preset-konfigurierten `telegram_style` (z.B. "kurzform") und rendert auf Telegram immer im reichen Format — Trip- UND Ortsvergleich-Pfad betroffen.
- `send_radar_alert()`/`send_multi_location_radar_alert()` in `NotificationService` reichen `telegram_style` jetzt durch, analog den drei bereits funktionierenden Geschwistermethoden (Abweichung, amtlich).

## Test plan
- [x] AC-1/AC-2 (Trip): `tests/tdd/test_radar_alert_telegram_style.py` — 2/2 grün
- [x] AC-3/AC-4 (Compare): `tests/tdd/test_compare_radar_alert_telegram_style.py` — 2/2 grün
- [x] Regression: Kern-Suite 878/878 grün
- [x] Adversary Verification: VERIFIED, 5/5 Pflicht-Mutationen gefangen

Closes #1914

🤖 Generated with [Claude Code](https://claude.com/claude-code)