### PR TITLE
fix(#1708 B2): toten trips-Pfad aus Loader und Testschicht entfernen

### DIFF
--- a/docs/context/fix-1708-b2-trips-pfad-rueckbau.md
+++ b/docs/context/fix-1708-b2-trips-pfad-rueckbau.md
@@ -19,7 +19,7 @@ Ausnahme. Die Go-Seite ist bereits leer.
 
 `get_trips_dir()` hat **keinen Produktivaufrufer**. Belegt:
 `grep -rn "get_trips_dir" src/ api/ internal/ cmd/ scripts/ .claude/` liefert nur die
-Definition. Positivkontrolle mit demselben Befehl auf `get_briefings_dir`: 12 Treffer,
+Definition. Positivkontrolle mit demselben Befehl auf `get_briefings_dir`: 11 Treffer,
 echte Aufrufer u. a. in `src/services/trip_report_scheduler.py:315`,
 `src/services/preview_service.py:18`, `api/routers/validator.py:23`. Die Suchmethode ist
 nicht blind.

--- a/docs/context/fix-1708-b2-trips-pfad-rueckbau.md
+++ b/docs/context/fix-1708-b2-trips-pfad-rueckbau.md
@@ -1,0 +1,278 @@
+# Context: fix-1708-b2-trips-pfad-rueckbau
+
+Issue #1708, Scheibe B2. Erhoben 2026-08-16 durch drei parallele Explore-Agenten,
+Befunde am Code bzw. am Testlauf gemessen (nicht aus Dokumentation abgeleitet).
+
+## Request Summary
+
+Der Pfad `data/users/<uid>/trips/<id>.json` ist tote Ablage (seit #1250 Scheibe 7a,
+ADR-0023). Scheibe A hat den Produktivcode gesaeubert und einen Quelltext-Waechter
+gebaut. B2 soll den Rest raeumen: `get_trips_dir()` aus `src/app/loader.py` entfernen,
+die verbliebenen Testaufrufer umstellen, die eine Waechter-Ausnahme streichen.
+
+## Ausgangslage, gemessen
+
+`uv run pytest tests/test_trips_path_revival_guard.py` = 17 Tests gruen. Der Scanner
+findet im gesamten Produktivbestand (91 Go-Dateien, 202 Python-Dateien) **genau einen**
+Fund: `src/app/loader.py::get_trips_dir::0` (Zeile 1163) — deckungsgleich mit der einen
+Ausnahme. Die Go-Seite ist bereits leer.
+
+`get_trips_dir()` hat **keinen Produktivaufrufer**. Belegt:
+`grep -rn "get_trips_dir" src/ api/ internal/ cmd/ scripts/ .claude/` liefert nur die
+Definition. Positivkontrolle mit demselben Befehl auf `get_briefings_dir`: 12 Treffer,
+echte Aufrufer u. a. in `src/services/trip_report_scheduler.py:315`,
+`src/services/preview_service.py:18`, `api/routers/validator.py:23`. Die Suchmethode ist
+nicht blind.
+
+`get_trips_dir()` (`loader.py:1155`) und `get_briefings_dir()` (`loader.py:1166`)
+unterscheiden sich **ausschliesslich** im Verzeichnisnamen: gleiche Signatur, gleicher
+Default, kein `mkdir`, kein Seiteneffekt. Die im Docstring behauptete Rolle „historical
+per-user directory bootstrap" hat kein Code-Gegenstueck — der Bootstrap sass in Go
+(`internal/store/user.go`, in Scheibe A bereinigt).
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/app/loader.py:1155` | `get_trips_dir()` — das Ziel. Schema-relevante Datei, loest Backup-Hook aus |
+| `tests/test_trips_path_revival_guard.py:91` | die eine `KNOWN_VIOLATIONS`-Ausnahme; :409 Stale-Ratsche; :422 Obergrenze |
+| `tests/test_briefing_route_cutover.py` | K1 — die legitime Ausnahme, **darf nicht umgebogen werden** |
+| `tests/tdd/test_issue_731_unified_commands.py:403` | **einziger inhaltlicher Fund** — Zusicherung am toten Pfad |
+| `tests/tdd/test_issue_1001_telegram_bubbles.py:858` | echter Fixture-Schreiber, aber heute uebersprungen |
+| `tests/conftest.py:81` | spiegelt `data/users/*/trips/*.json` -> `briefings/` fuer `real_data_root`-Tests |
+| `tests/test_stillgelegte_testdateien.py:108` | B1-Sonde AC-6, nimmt den Wegfall bereits vorweg |
+
+## Klassifizierung der 17 Testdateien
+
+Positivkontrolle: `grep -rn 'get_trips_dir' tests/` trifft in allen 17 Dateien.
+**9 Dateien rufen echt auf**, 7 nennen den Namen nur in Kommentar/Docstring/Variablenname.
+Der Waechter-Kommentar behauptet „12 Testdateien" — gemessen sind es 9.
+
+### K1 — echte Fixture-Schreiber am toten Pfad (2 Dateien)
+
+- **`tests/test_briefing_route_cutover.py`** (Aufrufe :110, :130, :149, :171) — laeuft
+  gruen, 7 Tests, keine Marker, keine Skips, nicht in `ci_tdd_excludes.txt`.
+  🔴 **Umbiegen auf `get_briefings_dir()` waere hier falsch.** :130/:149/:171 legen
+  absichtlich eine abweichende Alt-Version am Legacy-Pfad an, um zu beweisen, dass
+  `load_all_trips`/`load_trip` sie ignorieren und `save_trip` sie byte-unveraendert laesst
+  (AC-25/AC-26 des Cutovers). Umbiegen zerstoert die Aussage. Richtig: literale
+  Pfadbildung ueber `loader.get_data_dir(uid) / "trips"`. Nur :110 ist ein Ausreisser —
+  dort wird `briefings/` umstaendlich als `get_trips_dir(...).parent / "briefings"`
+  konstruiert und kann direkt auf `get_briefings_dir(uid)`.
+- **`tests/tdd/test_issue_1001_telegram_bubbles.py:858`** — echter Schreiber
+  (`mkdir` + `write_text`). Umbiegen ist hier korrekt. Laeuft heute **nicht**:
+  `@pytest.mark.skipif(not _LIVE_CREDS_AVAILABLE)` (:881). Liefe er, waere er
+  vermutlich schon rot, weil der Leser aus `briefings/` liest.
+
+### K2 — greift ins Leere (7 Dateien, 10 Stellen)
+
+Alle laufen unter der autouse-Isolation (`tests/conftest.py:120 _isolate_data_root`) in
+einer leeren tmp-Wurzel; `save_trip` schreibt seit #1250 nach `briefings/`. Diese Zeilen
+finden nie etwas.
+
+`test_issue_731_unified_commands.py:184,403` · `test_issue_612_report_on_demand.py:155,293,327` ·
+`test_inbound_gate_errors.py:48` · `test_trip_command_processor.py:73` ·
+`test_issue_882_pause_skip.py:69` · `test_feature_656_radar_nowcast.py:188,215,302` ·
+`test_feature_660_convective_stage.py:234` · `test_issue_1001_telegram_bubbles.py:437`
+
+🔴 **Genau eine dieser Stellen hat Substanz: `test_issue_731_unified_commands.py:403`** —
+`assert not (trips/<id>.json).exists()` soll beweisen, dass WEITER nicht nach
+`users/default/` schreibt. Am toten Pfad kann die Zusicherung **nie** fehlschlagen; ein
+echtes Leck nach `users/default/briefings/` bliebe ungefangen. Umbiegen auf
+`get_briefings_dir()` ist dort eine **Verhaltensaenderung und kann rot werden**.
+
+Alle uebrigen sind No-Op-Aufraeumung (teardown, `rmtree`, `finally:`) — ersatzlos streichen
+oder mitziehen, dann raeumen sie tatsaechlich auf.
+
+### K3 — nur Kommentar/Variablenname (7 Dateien, 0 Aufrufe)
+
+`test_stillgelegte_testdateien.py` · `test_trips_path_revival_guard.py` ·
+`test_issue_1133_testdata_cleanup.py` · `test_loader_display_config_default.py` ·
+`test_issue_818_radar_briefing_integration.py:97` ·
+`test_issue_822_radar_nowcast_segment.py:101` · `test_bundle_791_847_844_alerts.py:72`
+
+Die letzten drei stehen in `.github/ci_tdd_excludes.txt` (auf `origin/main` nachgeprueft,
+Zeilen 61/77/78) — sie laufen derzeit nicht auf CI. Fuer B2 ohne Belang, da ohne Aufruf.
+**Alle 9 echt aufrufenden Dateien laufen auf CI.**
+
+Gegenprobe zur Fremdmessung einer Parallelsitzung (#1697): `818`/`822` legen ihre Trips
+aktiv per `_save_trip_direct`/`save_trip` an, und `trips_dir` ist dort ein reiner
+Variablenname auf `get_briefings_dir(user_id)` (818:102, 822:105). Kein Widerspruch.
+
+## Risks & Considerations
+
+### R1 — Der Waechter verliert seine einzige Positivkontrolle am echten Bestand
+
+**Der wichtigste Befund.** Heute ist `test_ac7_known_violations_only_shrink` (:409-419)
+der einzige Test, der beweist, dass der Scanner auf **echten** Dateien ueberhaupt etwas
+zurueckliefert — er verlangt, dass der Ausnahme-Schluessel in `found` auftaucht. Alle
+anderen Positivkontrollen (AC-1/AC-2/AC-3, :248-318) laufen gegen **synthetische**
+Quellstrings; AC-6 prueft nur Pfad-Mitgliedschaft.
+
+Wird die Ausnahme in B2 gestrichen, ist `KNOWN_VIOLATIONS` leer, `stale` trivial `[]` —
+und **kein Test misst den Scanner mehr am echten Bestand**. Ein Scanner, der auf realen
+Dateien lautlos nichts mehr liefert (verschluckter Lesefehler, kaputte Pfadaufloesung),
+waere danach vollstaendig gruen. Das ist dieselbe Fehlerklasse, die #1708 ueberhaupt
+erzeugt hat.
+
+Erschwerend: nach B2 gibt es im Produktivbestand **null** `trips`-Fundstellen. Die
+Hausnorm fuer Trefferkraft-Nachweise (`tests/test_success_status_guard.py:1762`,
+`tests/test_resolution_loss_guard.py:818`) fuehrt eine spec-verankerte Liste **erwarteter
+echter Fundstellen** — die gibt es hier per Definition nicht mehr. Der Nachweis muss
+anders gebaut werden, z. B. Scanner gegen eine reale Datei im Dateisystem statt gegen
+synthetische Strings.
+
+### R2 — Ausnahme und Funktion muessen im selben Commit fallen
+
+`test_ac7_known_violations_only_shrink` wird rot, sobald der Scanner die gelistete Stelle
+nicht mehr findet. `get_trips_dir()` entfernen **und** `KNOWN_VIOLATIONS` leeren gehoeren
+in einen Commit. Die Obergrenze `<= 1` (:422) bleibt bei 0 gueltig, keine Anpassung noetig.
+`CARRIER_FILES` bleibt ebenfalls unveraendert: der Eintrag `src/app/loader.py` belegt nur,
+dass `src/` gescannt wird — Positivkontrolle: `internal/store/trip.go` steht dort seit
+Scheibe A ohne Funde und der Test ist gruen.
+
+### R3 — `tests/conftest.py:81` haengt am Verzeichnisnamen, nicht an der Funktion
+
+Die Session-Fixture spiegelt `data/users/*/trips/*.json` -> `briefings/` fuer
+`real_data_root`-Tests. Wird der Quell-Fixture-Baum `tests/fixtures/data_root/users/*/trips/`
+angefasst, laufen `test_issue_363_signal_telegram_preview` und
+`test_issue_1001::TestAC7PreviewEndpointBubbles` ins 404. **Nicht Teil von B2**, aber die
+Spiegelung darf nicht versehentlich mitgerissen werden.
+
+### R4 — Zuschnitt und LoC
+
+Der mechanische Teil ist klein (9 Dateien, ueberwiegend Zeilenloeschung). Teuer sind zwei
+Nachweise: der Trefferkraft-Ersatz (R1) und die Frage, ob `test_issue_731:403` nach dem
+Umbiegen rot wird — das waere ein echter Produktivbefund und muesste eigenstaendig
+behandelt werden. LoC-Limit 250, Nachweis erfahrungsgemaess teurer als der Mechanismus.
+
+## Dependencies
+
+- **Upstream:** `get_data_dir()` (`loader.py:1133`, oeffentlich) — bleibt und traegt die
+  testlokale Legacy-Pfadbildung fuer `test_briefing_route_cutover.py`.
+- **Downstream:** kein Produktivcode. Nur die 9 Testdateien und der Waechter.
+- **Parallelsitzung:** `gregor-zwanzig-dd` (#1697) aendert eine Zeile in
+  `test_issue_818_radar_briefing_integration.py` (`test_ac7_mandantentrennung_isolated`)
+  und holt `818`/`822` aus `ci_tdd_excludes.txt`. Abgesprochen: diese Zeile bleibt
+  unangetastet; wer zuerst fertig ist, mergt, der andere rebased.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1708_a_trips_pfad_waechter.md` — Scheibe A, Waechter-Bauart
+- `docs/specs/modules/fix_1708_b1_tote_fixture_befunde.md` — Scheibe B1
+- `docs/adr/` — ADR-0023 (Cutover auf `briefings/`)
+
+## Analysis
+
+### Type
+
+Bug — stillgelegte Zusicherungen und toter Code, kein neues Verhalten.
+
+### R4 aufgeloest: `test_issue_731_unified_commands.py:403` traegt am lebenden Pfad
+
+**Gemessen, nicht vermutet.** Betroffen ist `TestAC10UserIsolation.test_weiter_only_affects_own_trip`
+(:392-405): zwei reale Nutzer A/B bekommen je einen deaktivierten Trip, `WEITER` laeuft als
+Nutzer A durch `TripCommandProcessor().process(...)`, danach wird geprueft, dass
+`users/default/` unberuehrt bleibt.
+
+| Messung | Ergebnis |
+|---|---|
+| A — Bestand (`get_trips_dir`) | gruen |
+| B — umgestellt auf `get_briefings_dir` | gruen, Gesamtdatei 18/18 |
+
+Gegenprobe gegen falsches Gruen, zweifach: (1) Assertion umgedreht zu
+`assert default_trip.exists()` auf dem briefings-Pfad -> **rot**, das Verzeichnis ist
+wirklich leer und kein Vergleichsfehler. (2) Ad-hoc-Nachstellung ausserhalb pytest zeigt,
+dass `briefings/<UserA>` und `briefings/<UserB>` nach dem `WEITER`-Aufruf **existieren**,
+`briefings/default` und die Legacy-`trips/` dagegen nicht. Der Testkoerper erreicht den
+echten Schreibpfad; die Negativpruefung ist eine echte Kontrollgruppe neben zwei
+tatsaechlich beschriebenen Verzeichnissen.
+
+**Folge:** Kein Cross-User-Leck. Das Umbiegen ist gefahrlos und macht die Zusicherung
+erstmals wirksam — vorher bewachte sie ein Verzeichnis, in das seit #1250 Scheibe 7a
+niemand mehr schreibt. Kein eigenes Issue noetig; die Reparatur ist Teil von B2.
+Die im Planungsentwurf vorgesehene Rueckfalloption (`xfail` + eigenes Issue, falls die
+Umstellung rot wird) entfaellt damit ersatzlos.
+
+### R1 geloest: Trefferkraft-Nachweis ueber umgebogene Scan-Wurzel
+
+**Gewaehlter Ansatz:** Der Test legt in `tmp_path` zwei echte Dateien mit echten
+Verstoessen an — `internal/store/user.go` in Slice-Form und `src/app/loader.py` in
+Divisions-Form — biegt `REPO_ROOT` per `monkeypatch.setattr` auf diesen Baum um, ruft
+`_all_violations()` und erwartet **beide** Schluessel.
+
+Traegt, weil `REPO_ROOT` ein Modul-Global ist (:72) und `_go_scan_files()`/`_py_scan_files()`
+ihn bei **jedem Aufruf** als Global aufloesen (`REPO_ROOT / root_name`, :181/:194) — nicht
+als Signaturparameter, aber deshalb per `monkeypatch` umbiegbar, ohne den Scanner
+anzufassen.
+
+Mutationsprobe, alle drei gefangen:
+
+| Verfaelschung | Wirkung |
+|---|---|
+| `_py_scan_files()`/`_go_scan_files()` liefern `[]` | Fund fehlt -> rot |
+| Wurzel-/Join-Berechnung kaputt (hartkodiert statt `REPO_ROOT`) | Fund fehlt -> rot |
+| `_is_finding` immer `False` / Regex kaputt | Fund fehlt -> rot |
+
+Prueft an echten Bytes, echter Wurzelaufloesung, echter Erkennung — Pruefort = Wirkort.
+**Zugewinn gegenueber dem Ist-Zustand:** Die verlorene Kontrolle bewies nur die
+Python-Seite (die Go-Seite war produktiv schon leer). Der neue Nachweis deckt beide
+Sprachpfade ab.
+
+Verworfene Ansaetze: **B** (Scanner gegen echte Repo-Datei mit bekanntem Inhalt) ist nach
+B2 gegenstandslos — es gibt dann keine `trips`-Fundstelle mehr, und die abgeschwaechte
+Variante dopplet nur `test_ac6_carrier_files_are_within_scan_area` (:390-401).
+**C** (Datei waehrend des Laufs ins Repo schreiben) rekonstruiert live im Produktivbaum
+genau das Muster, das der Waechter bekaempft, und ist bei parallelen Worktrees riskant —
+ohne Vorteil gegenueber `tmp_path`. **D** (`get_trips_dir()` behalten) loest genau das ein,
+was der Ausnahme-Eintrag als „KEINE Dauerausnahme" (:93) ausschliesst.
+
+### Affected Files
+
+| Datei | Aenderung | Beschreibung |
+|---|---|---|
+| `src/app/loader.py` | MODIFY | `get_trips_dir()` (:1155-1163) entfernen |
+| `tests/test_trips_path_revival_guard.py` | MODIFY | `KNOWN_VIOLATIONS` leeren; Trefferkraft-Nachweis ergaenzen |
+| `tests/test_briefing_route_cutover.py` | MODIFY | :110 -> `get_briefings_dir`; :130/:149/:171 auf literale Pfadbildung ueber `get_data_dir(uid) / "trips"` |
+| `tests/tdd/test_issue_731_unified_commands.py` | MODIFY | :403/:405 auf `get_briefings_dir` (macht die Zusicherung wirksam); :184 Aufraeumung |
+| `tests/tdd/test_issue_1001_telegram_bubbles.py` | MODIFY | :858 Fixture-Schreiber umbiegen; :437 Aufraeumung |
+| `tests/tdd/test_issue_612_report_on_demand.py` | MODIFY | :155/:293/:327 Aufraeumung, Import |
+| `tests/tdd/test_feature_656_radar_nowcast.py` | MODIFY | :188/:215/:302 `finally:`-Aufraeumung |
+| `tests/tdd/test_inbound_gate_errors.py` | MODIFY | :48 teardown, Import |
+| `tests/tdd/test_trip_command_processor.py` | MODIFY | :73 teardown, Import |
+| `tests/tdd/test_issue_882_pause_skip.py` | MODIFY | :69 rmtree, Import |
+| `tests/tdd/test_feature_660_convective_stage.py` | MODIFY | :234 `finally:`-Aufraeumung |
+
+### Scope Assessment
+
+- Dateien: 11 (1 Produktiv, 10 Test)
+- Geschaetzte LoC: ~115 im ungünstigen Fall (Wegfall ~-10 · 9 Testdateien ~35 ·
+  Ausnahme + Docstring ~10 · Trefferkraft-Nachweis ~30, doppelt gerechnet ~60)
+- Budget 250 — **keine weitere Teilung noetig**
+- Risiko: **LOW**. Kein Produktivverhalten aendert sich; `get_trips_dir()` hat keinen
+  Produktivaufrufer. Die einzige inhaltliche Zusicherung wurde gemessen und traegt.
+
+### Reihenfolge (ein Commit)
+
+1. 9 Testdateien umstellen — **muss vor oder mit** der Entfernung, sonst bricht die
+   Testsammlung an `NameError`/`ImportError`
+2. `get_trips_dir()` entfernen
+3. `KNOWN_VIOLATIONS` leeren
+4. Trefferkraft-Nachweis ergaenzen
+
+(2)+(3)+(4) muessen atomar sein (R2), sonst wird `test_ac7_known_violations_only_shrink`
+zwischenzeitlich rot und es entstuende eine Luecke, in der kein Test echte Dateien prueft.
+Da alles in ein Commit passt, ist das die einfachste Garantie.
+
+### Open Questions
+
+Keine offenen technischen Fragen. Beide Kernfragen sind empirisch beantwortet.
+
+## Nebenbefunde (nicht Teil von B2)
+
+- `internal/store/briefing_subscription.go:12,15,24` — Kommentare verweisen auf das
+  entfernte `TripsDir()`. Sachlich veraltet, ohne Laufzeitwirkung.
+- `internal/scheduler/selftest.go:42` — Variable heisst `tripsDir`, zeigt auf `briefings`.
+- `tests/test_stillgelegte_testdateien.py:116-118` — AC-6-Docstring begruendet die
+  Methodenwahl mit „conftest.py ruft an mehreren Stellen get_trips_dir()"; das stimmt
+  nicht (`grep` liefert dort nichts). Methodenwahl bleibt gueltig, Begruendung ist falsch.

--- a/docs/specs/modules/fix_1708_b2_trips_pfad_rueckbau.md
+++ b/docs/specs/modules/fix_1708_b2_trips_pfad_rueckbau.md
@@ -115,7 +115,7 @@ unten).
 
 `src/app/loader.py:1155-1163` fällt vollständig. Gemessen: kein Produktivaufrufer
 (`grep -rn "get_trips_dir" src/ api/ internal/ cmd/ scripts/ .claude/` liefert nur die
-Definition; Positivkontrolle mit `get_briefings_dir` auf demselben Befehl: 12 Treffer, echte
+Definition; Positivkontrolle mit `get_briefings_dir` auf demselben Befehl: 11 Treffer, echte
 Aufrufer). Die Funktion unterscheidet sich von `get_briefings_dir()` ausschließlich im
 Verzeichnisnamen — kein `mkdir`, kein sonstiger Seiteneffekt.
 

--- a/docs/specs/modules/fix_1708_b2_trips_pfad_rueckbau.md
+++ b/docs/specs/modules/fix_1708_b2_trips_pfad_rueckbau.md
@@ -1,0 +1,300 @@
+---
+entity_id: fix_1708_b2_trips_pfad_rueckbau
+type: module
+created: 2026-08-16
+updated: 2026-08-16
+status: draft
+version: "1.1"
+tags: [tests, issue-1708, trips-pfad, rueckbau]
+---
+
+# Fix #1708 B2 — Toten `trips/`-Pfad aus Testdateien und Loader entfernen
+
+## Approval
+
+- [x] Approved — Product Owner, 2026-08-16 („approved")
+
+## Purpose
+
+Der Pfad `data/users/<uid>/trips/<id>.json` ist seit #1250 Scheibe 7a (ADR-0023) tot;
+Scheibe A hat den Produktivcode bereits gesäubert. B2 räumt den Rest: Neun Testdateien
+rufen den toten Pfad noch real auf und wirken dadurch entweder wirkungslos (No-Op-Aufräumung
+ins Leere) oder — in einem Fall — verlieren eine echte Zusicherung an eine Adresse, die nie
+beschrieben wird. `get_trips_dir()` fällt aus `src/app/loader.py`, ebenso die eine
+Wächter-Ausnahme, die genau diese Funktion bisher deckte. Zusätzlich werden alle verbliebenen
+Kommentar-/Docstring-Stellen korrigiert, die `get_trips_dir()` fälschlich als existierend oder
+als tatsächlichen Ablageort von Trip-Daten beschreiben — genau diese Fehlerklasse (falsche
+Doku über Datenpfade) hat #1708 überhaupt erzeugt (Beleg: Scheibe A fand in
+`api/routers/preview.py:10` einen Docstring, der einen aus `trips/` lesenden Owner-Check
+behauptete, während der Code längst aus `briefings/` las).
+
+Scheibe B2 ist **Teilarbeit** und schließt #1708 **nicht**. Sie baut auf B1 auf (stillgelegte
+Tests am toten Pfad reaktiviert) und wird von C gefolgt (14 tote Bestandsdateien löschen,
+schließt #1708).
+
+## Source
+
+- **File:** `src/app/loader.py:1155-1163` (`get_trips_dir()` — das Entfernungsziel)
+- **File:** `tests/test_trips_path_revival_guard.py:91` (`KNOWN_VIOLATIONS`-Eintrag), `:459-462` (Docstring-Erwartung)
+- **File:** `tests/test_briefing_route_cutover.py` (Ausnahme — bleibt am Legacy-Pfad)
+- **File:** `tests/tdd/test_issue_731_unified_commands.py:403`
+- **File:** `tests/tdd/test_issue_1001_telegram_bubbles.py:858,437`
+- **File:** `tests/tdd/test_issue_612_report_on_demand.py:155,293,327`
+- **File:** `tests/tdd/test_inbound_gate_errors.py:48`
+- **File:** `tests/tdd/test_trip_command_processor.py:73`
+- **File:** `tests/tdd/test_issue_882_pause_skip.py:69`
+- **File:** `tests/tdd/test_feature_656_radar_nowcast.py:188,215,302`
+- **File:** `tests/tdd/test_feature_660_convective_stage.py:234`
+- **File:** `tests/tdd/test_issue_818_radar_briefing_integration.py:97,102` (Doku-Hygiene, siehe AC-7)
+- **File:** `tests/tdd/test_issue_822_radar_nowcast_segment.py:101,105` (Doku-Hygiene, siehe AC-7)
+- **File:** `tests/tdd/test_bundle_791_847_844_alerts.py:72` (Doku-Hygiene, siehe AC-7)
+- **File:** `tests/tdd/test_issue_363_signal_telegram_preview.py:28` (Doku-Hygiene, siehe AC-7)
+- **File:** `tests/tdd/test_loader_display_config_default.py:244` (Doku-Hygiene, siehe AC-7)
+- **File:** `tests/tdd/test_issue_1133_testdata_cleanup.py:41,58,60,62,63` (Doku-Hygiene, siehe AC-7)
+
+Schicht: **Python-Core / Domain-Backend** (`src/app/loader.py`, schema-relevant — löst den
+Pre-Snapshot-Backup-Hook aus) plus **Testschicht** (`tests/`). Kein Go-Code betroffen — die
+Go-Seite des Wächters ist bereits leer (gemessen, siehe Dependencies).
+
+## Estimated Scope
+
+- **LoC:** ~140 im ungünstigen Fall (Wegfall `get_trips_dir()` ~-10 · 9 Testdateien
+  Umstellung/Aufräumung ~35 · Ausnahme+Docstring im Wächter ~10 · Trefferkraft-Nachweis ~30 ·
+  Doku-Hygiene in 6 zusätzlichen Dateien + Wächter-Docstring ~25, Puffer für Nacharbeit
+  aufgerundet ~30)
+- **Files:** 17 (1 Produktiv, 16 Test — davon 6 ausschließlich Doku-Hygiene ohne Code-Änderung)
+- **Effort:** medium — mechanischer Teil klein, teuer ist der Trefferkraft-Nachweis (siehe R1
+  im Kontextdokument) und die Prüfung, ob `test_issue_731:403` nach der Umstellung grün bleibt
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/app/loader.py:1166` `get_briefings_dir()` | Funktion | der lebende Pfad, auf den umgestellt wird |
+| `src/app/loader.py:1133` `get_data_dir()` | Funktion | öffentlich, bleibt bestehen; trägt die testlokale Legacy-Pfadbildung in `test_briefing_route_cutover.py` |
+| `tests/test_trips_path_revival_guard.py:91` `KNOWN_VIOLATIONS` | Konstante | die eine Ausnahme, die im selben Commit wie `get_trips_dir()` entfällt |
+| `tests/test_trips_path_revival_guard.py:72` `REPO_ROOT` | Modul-Global | Scan-Wurzel; per `monkeypatch` umbiegbar, trägt den neuen Trefferkraft-Nachweis |
+| `tests/test_trips_path_revival_guard.py:409-419` `test_ac7_known_violations_only_shrink` | Test | einzige heutige Positivkontrolle am echten Bestand; wird durch den neuen Nachweis ersetzt |
+| `tests/conftest.py:81` | Fixture-Spiegelung | spiegelt `trips/` → `briefings/` für `real_data_root`-Tests — **Invariante, bleibt unangetastet** |
+| `tests/tdd/test_issue_818_radar_briefing_integration.py::test_ac7_mandantentrennung_isolated` (~:585) | Test | gehört Parallelsitzung #1697 — **Invariante, bleibt unangetastet**, nur Zeile 97/102 derselben Datei sind unser Gegenstand |
+| `.github/ci_tdd_excludes.txt` | Liste | betrifft B2 nicht direkt (die CI-ausgeschlossenen K3-Dateien haben keinen echten Aufruf) |
+
+## Implementation Details
+
+### Der gemeinsame Umbau
+
+Neun Testdateien rufen `get_trips_dir()` heute real auf. Zwei Gruppen, unterschiedliche
+Behandlung:
+
+**K1 — echte Fixture-Schreiber (2 Dateien):**
+- `tests/test_briefing_route_cutover.py` — **Ausnahme, nicht auf `get_briefings_dir()`
+  umbiegen.** Nur Zeile 110 (dort wird `briefings/` umständlich als
+  `get_trips_dir(...).parent / "briefings"` konstruiert) wechselt auf
+  `get_briefings_dir(uid)`. Die Zeilen 130/149/171 legen absichtlich eine abweichende
+  Alt-Version am Legacy-Pfad an, um zu beweisen, dass `load_all_trips`/`load_trip` sie
+  ignorieren und `save_trip` sie byte-unverändert lässt — sie bilden den Legacy-Pfad
+  weiterhin **testlokal literal** über `loader.get_data_dir(uid) / "trips"`.
+- `tests/tdd/test_issue_1001_telegram_bubbles.py:858` — echter Schreiber (`mkdir` +
+  `write_text`), wird auf `get_briefings_dir()` umgebogen.
+
+**K2 — greift ins Leere, reine No-Op-Aufräumung (7 Dateien, 10 Stellen):** alle laufen unter
+der autouse-Isolation (`tests/conftest.py:120 _isolate_data_root`) in einer leeren
+tmp-Wurzel; `save_trip` schreibt seit #1250 nach `briefings/`. Diese Stellen finden nie
+etwas und räumen entsprechend nie etwas auf. Ersatzlos streichen oder auf
+`get_briefings_dir()` umziehen, je nachdem was die Datei lesbarer macht:
+`test_issue_612_report_on_demand.py:155,293,327` · `test_inbound_gate_errors.py:48` ·
+`test_trip_command_processor.py:73` · `test_issue_882_pause_skip.py:69` ·
+`test_feature_656_radar_nowcast.py:188,215,302` · `test_feature_660_convective_stage.py:234` ·
+`test_issue_1001_telegram_bubbles.py:437`.
+
+Ausnahme innerhalb K2: `test_issue_731_unified_commands.py:403` (plus die zugehörige
+Aufräumung `:184`) ist **kein** No-Op — sie ist der einzige inhaltliche Fund unter K2 (siehe
+unten).
+
+### `get_trips_dir()` entfernen
+
+`src/app/loader.py:1155-1163` fällt vollständig. Gemessen: kein Produktivaufrufer
+(`grep -rn "get_trips_dir" src/ api/ internal/ cmd/ scripts/ .claude/` liefert nur die
+Definition; Positivkontrolle mit `get_briefings_dir` auf demselben Befehl: 12 Treffer, echte
+Aufrufer). Die Funktion unterscheidet sich von `get_briefings_dir()` ausschließlich im
+Verzeichnisnamen — kein `mkdir`, kein sonstiger Seiteneffekt.
+
+### `KNOWN_VIOLATIONS` leeren, im selben Commit
+
+`test_ac7_known_violations_only_shrink` (`test_trips_path_revival_guard.py:409-419`)
+verlangt heute, dass der Scanner exakt den Ausnahme-Schlüssel
+`src/app/loader.py::get_trips_dir::0` findet. Entfernt man `get_trips_dir()` ohne die
+Ausnahme zu leeren, wird dieser Test rot. Beides muss daher **im selben Commit** landen. Die
+Obergrenze `<= 1` (`:422`) bleibt bei 0 Funden gültig, keine Anpassung nötig. Der
+Ausnahme-Kommentar selbst (`:92-93`, behauptet fälschlich „12 Testdateien", gemessen sind es
+9) verschwindet mit dem Eintrag und braucht keine eigene Korrektur.
+
+### Trefferkraft-Nachweis ergänzen
+
+Mit leerer `KNOWN_VIOLATIONS` verliert der Wächter seine einzige Positivkontrolle am echten
+Bestand — kein Test würde mehr beweisen, dass der Scanner auf realen Dateien überhaupt etwas
+zurückliefert (ein verschluckter Lesefehler oder eine kaputte Pfadauflösung wäre danach
+lautlos grün). Ersatz: ein neuer Test legt in `tmp_path` zwei echte Verstoß-Dateien an — eine
+Go-Datei mit Slice-Zugriff, eine Python-Datei mit Divisions-Form, beide dem realen
+Scan-Muster nachgebildet — biegt `REPO_ROOT` per `monkeypatch.setattr` auf diesen
+temporären Baum um und erwartet, dass der Scanner **beide** Funde meldet. Trägt, weil
+`REPO_ROOT` ein Modul-Global ist, das die Scan-Funktionen bei jedem Aufruf neu aus dem
+globalen Zustand auflösen (nicht als Signaturparameter) — deshalb per `monkeypatch` umbiegbar,
+ohne den Scanner selbst anzufassen. Deckt beide Sprachpfade ab (die verlorene Kontrolle bewies
+nur die Python-Seite).
+
+Zusätzlich wird die Docstring-Erwartung von `test_keine_unlisted_trips_pfad_funde()`
+(`:459-462`) angepasst: sie beschreibt heute noch die RED-Phase aus Scheibe A („src/app/loader.py:1163
+(get_trips_dir) ist über KNOWN_VIOLATIONS gedeckt und erscheint NICHT in der Fehlermeldung") —
+nach B2 gibt es die Funktion gar nicht mehr, die Formulierung muss das widerspiegeln statt eine
+überholte Deckungs-Aussage stehen zu lassen.
+
+### `test_issue_731_unified_commands.py:403` wirksam machen
+
+`TestAC10UserIsolation.test_weiter_only_affects_own_trip` (`:392-405`) lässt zwei reale
+Nutzer A/B je einen deaktivierten Trip anlegen, führt `WEITER` als Nutzer A aus und prüft
+danach, dass `users/default/` unberührt bleibt. Am toten `trips/`-Pfad kann diese Prüfung nie
+fehlschlagen — ein echtes Leck nach `users/default/briefings/` bliebe ungefangen. Die
+Umstellung auf `get_briefings_dir()` macht die Zusicherung erstmals wirksam.
+
+### Doku-Hygiene — verbliebene Erwähnungen korrigieren
+
+Sechs weitere Testdateien rufen `get_trips_dir()` nicht auf, beschreiben die Funktion aber in
+Kommentar oder Docstring als existierend bzw. als den Ort, an dem Trip-Daten tatsächlich
+liegen. Nach dem Wegfall der Funktion sind diese Stellen sachlich falsch und werden korrigiert
+(Formulierung auf „existiert nicht mehr"/„entfernter Altbestand" bzw. Präteritum umgestellt,
+kein Code-Verhalten ändert sich):
+
+- `tests/tdd/test_issue_818_radar_briefing_integration.py:97` (Docstring) und `:102`
+  (Variablenname `trips_dir`, zeigt bereits auf `get_briefings_dir()`). **Ausschließlich**
+  diese zwei Stellen sind unser Gegenstand — `test_ac7_mandantentrennung_isolated`
+  (~Zeile 585) gehört Parallelsitzung #1697 und bleibt unangetastet.
+- `tests/tdd/test_issue_822_radar_nowcast_segment.py:101` (Kommentar) und `:105`
+  (Variablenname `trips_dir`, gleiches Muster).
+- `tests/tdd/test_bundle_791_847_844_alerts.py:72` (Docstring, beschreibt `get_trips_dir()`
+  aktuell als den Pfad, den auch `TripAlertService` liest).
+- `tests/tdd/test_issue_363_signal_telegram_preview.py:28` (Kommentar, bezeichnet die reale
+  committete Fixture `data/users/default/trips/gr221-mallorca.json` als „echten
+  get_trips_dir()-Pfad" — die physische Fixture-Datei selbst gehört zu Scheibe C und wird hier
+  nicht angefasst, nur die Beschreibung).
+- `tests/tdd/test_loader_display_config_default.py:244` (Kommentar, bereits korrekt im
+  Sinne von „liest seit dem Cutover get_briefings_dir(), nicht mehr get_trips_dir()" — wird
+  geprüft, ob nach dem Wegfall noch eine Anpassung nötig ist, da die Funktion dann nicht mehr
+  existiert statt nur nicht mehr gelesen zu werden).
+- `tests/tdd/test_issue_1133_testdata_cleanup.py:41,58,60,62,63` (Docstring von
+  `test_ac1_fixture_isolation_path_resolution_and_roundtrip` — beschreibt den Wegfall von
+  `get_trips_dir()` bereits vorausschauend im Futur; nach B2 auf Präteritum/Ist-Zustand
+  umstellen).
+
+## Expected Behavior
+
+- **Input:** ein regulärer Testlauf (`uv run pytest <datei>`) der 16 betroffenen Testdateien
+  sowie `tests/test_trips_path_revival_guard.py`, ohne Marker-Override
+- **Output:** die 9 real aufrufenden Dateien greifen auf `get_briefings_dir()` zu bzw. haben
+  ihre wirkungslose Aufräumung ersatzlos verloren — mit der einen dokumentierten Ausnahme
+  `test_briefing_route_cutover.py`, deren drei Stellen weiterhin testlokal den Legacy-Pfad
+  bilden. `get_trips_dir()` existiert nicht mehr. Der Wächter-Scanner hat keine tote Ausnahme
+  mehr und weist stattdessen aktiv nach, dass er auf echten Dateien noch Funde liefert. Sechs
+  weitere Dateien ohne Code-Änderung beschreiben `get_trips_dir()` nicht mehr als existierend.
+- **Side effects:** keine Änderung an Produktivverhalten — `get_trips_dir()` hatte keinen
+  Produktivaufrufer. Kein Schreibzugriff auf den echten `data/users/`-Baum während der Tests.
+
+## Acceptance Criteria
+
+- **AC-1:** Given neun Testdateien rufen heute den toten Pfad `get_trips_dir()` wirklich auf
+  (ein echter Fixture-Schreiber, acht reine Aufräum-/Prüfstellen) / When diese Dateien
+  umgestellt werden / Then greift keine dieser neun Dateien mehr auf `get_trips_dir()` zu —
+  entweder weil sie jetzt `get_briefings_dir()` verwendet, oder weil die wirkungslose
+  Aufräumung ersatzlos entfernt wurde, sodass sie tatsächlich aufräumt statt ins Leere zu
+  greifen.
+  - Test: `grep -rn "get_trips_dir" tests/` liefert nach der Umstellung in diesen neun Dateien
+    keine echten Aufrufe mehr (Kommentare/Docstrings ausgenommen).
+
+- **AC-2:** Given `tests/test_briefing_route_cutover.py` legt absichtlich eine abweichende
+  Alt-Version am toten Pfad an, um zu beweisen, dass der lebende Lesepfad sie ignoriert und der
+  Schreibpfad sie unangetastet lässt / When B2 abgeschlossen ist / Then bildet diese Datei den
+  Legacy-Pfad weiterhin testlokal selbst, nur die Ermittlung des lebenden Pfads wechselt auf
+  `get_briefings_dir()`; alle 7 Tests der Datei laufen unverändert grün.
+  - Test: die bestehenden 7 Tests der Datei laufen nach der Änderung ohne Anpassung ihrer
+    Erwartungen grün durch.
+
+- **AC-3:** Given `get_trips_dir()` in `src/app/loader.py` hat gemessen keinen
+  Produktivaufrufer / When die Funktion entfernt wird / Then läuft der Produktivbetrieb
+  unverändert weiter, und keine Datei außerhalb der Testschicht referenziert die Funktion mehr.
+  - Test: eine erneute Suche über den Produktivbestand (`src/`, `api/`, `internal/`, `cmd/`,
+    `scripts/`, `.claude/`) nach dem Funktionsnamen liefert keinen Treffer mehr.
+
+- **AC-4:** Given der Wächter-Test `test_ac7_known_violations_only_shrink` verlangt heute
+  genau den Ausnahme-Eintrag für `get_trips_dir()` im Scan-Ergebnis / When `get_trips_dir()`
+  entfernt und der Ausnahme-Eintrag im selben Commit gestrichen wird / Then bleibt dieser Test
+  grün, weil Funktion und Ausnahme gemeinsam verschwinden — kein Zwischenzustand, in dem nur
+  eines von beiden geändert ist.
+  - Test: der bestehende Wächter-Testlauf nach dem Commit ist vollständig grün, ohne die
+    Erwartung `<= 1` anzuheben.
+
+- **AC-5:** Given nach dem Leeren der Ausnahme-Liste gibt es keinen Test mehr, der beweist,
+  dass der Wächter-Scanner auf echten Dateien überhaupt etwas findet / When ein neuer Test
+  zwei echte Verstoß-Dateien (eine im Go-, eine im Python-Muster) in einen eigens dafür
+  angelegten Verzeichnisbaum legt und den Scanner darauf ansetzt / Then meldet der Scanner für
+  beide Dateien einen Fund — ein Scanner, der auf echten Dateien nichts mehr findet, muss
+  diesen Testlauf rot machen, nicht grün durchlaufen lassen.
+  - Test: der neue Nachweis-Test schlägt fehl, sobald die Fund-Erkennung des Scanners
+    absichtlich außer Kraft gesetzt wird (Mutationsprobe).
+
+- **AC-6:** Given die Zusicherung in `test_issue_731_unified_commands.py:403` prüfte bisher
+  am toten Pfad, dass ein `WEITER`-Befehl von Nutzer A keine Daten unter `users/default/`
+  hinterlässt, und konnte dort nie fehlschlagen / When die Zusicherung auf den lebenden
+  `briefings/`-Pfad umgestellt wird / Then bleibt der Test grün — es gibt kein Cross-User-Leck
+  — und dieselbe Prüfung würde jetzt tatsächlich fehlschlagen, wenn ein Leck entstünde.
+  - Test: der Test läuft nach der Umstellung grün; eine Gegenprobe mit umgedrehter Erwartung
+    (Datei müsste existieren) schlägt fehl, was belegt, dass die Prüfung wirklich etwas misst
+    und nicht nur ins Leere greift.
+
+- **AC-7:** Given `get_trips_dir()` existiert nach dieser Scheibe nicht mehr / When jemand die
+  verbliebenen Erwähnungen des Namens im Testbestand durchsieht / Then beschreibt keine
+  Kommentar- oder Docstring-Stelle die Funktion mehr als existierend oder als den Ort, an dem
+  Trip-Daten tatsächlich liegen; verbliebene Nennungen (etwa der historische Fund-Beleg in
+  `test_trips_path_revival_guard.py`) benennen sie ausdrücklich als entfernten Altbestand.
+  - Test: eine Durchsicht der sechs in Source/Implementation Details gelisteten Doku-Stellen
+    plus der Wächter-Docstring bei `:459-462` zeigt für jede, dass der Text nach der Änderung
+    nicht mehr im Präsens behauptet, die Funktion existiere oder werde aktuell gelesen.
+
+## Known Limitations
+
+- **Ein-Commit-Regel:** Entfernung von `get_trips_dir()`, Leeren von `KNOWN_VIOLATIONS` und
+  Ergänzung des Trefferkraft-Nachweises müssen atomar in einem Commit landen. Ein
+  Zwischenzustand ließe `test_ac7_known_violations_only_shrink` vorübergehend rot laufen und
+  öffnete eine Lücke, in der kein Test den Scanner am echten Bestand prüft.
+- **Reihenfolge:** die neun real aufrufenden Testdateien müssen vor oder mit der Entfernung
+  von `get_trips_dir()` umgestellt sein, sonst bricht die Testsammlung an einem
+  Namens-/Importfehler. Die sechs reinen Doku-Hygiene-Dateien (AC-7) haben keine
+  Reihenfolge-Abhängigkeit, da sie die Funktion nicht aufrufen.
+- **`tests/conftest.py:81`** (Spiegelung `data/users/*/trips/*.json` → `briefings/` für
+  `real_data_root`-Tests) ist **nicht Teil dieser Scheibe** und darf nicht versehentlich
+  mitgerissen werden — sie hängt am Verzeichnisnamen im Fixture-Baum, nicht an der Funktion.
+- **`test_ac7_mandantentrennung_isolated`** (~`test_issue_818_radar_briefing_integration.py:585`)
+  gehört Parallelsitzung #1697 und bleibt unangetastet — nur die Docstring-Zeile 97 und der
+  Variablenname bei 102 derselben Datei sind Gegenstand dieser Scheibe (AC-7).
+- **Nicht Teil von B2:** die 14 toten Bestandsdateien unter
+  `data/users/*/trips/*.json.TOT-legacy-1250-nicht-lesen` sowie die reale Fixture-Datei
+  `data/users/default/trips/gr221-mallorca.json` selbst — nur deren fehlerhafte Beschreibung
+  in `test_issue_363_signal_telegram_preview.py:28` wird korrigiert. Das Löschen der Datei
+  gehört zu Scheibe C, die #1708 schließt.
+- Wird beim Umstellen ein weiterer echter Fehlschlag sichtbar (über `test_issue_731:403`
+  hinaus), ist das ein eigenständiger Befund — er wird gemeldet und nicht durch Abschwächen
+  der Erwartung beseitigt.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Es wird keine Grundsatzentscheidung geändert. ADR-0023 (Cutover
+  `trips/` → `briefings/`) wird bestätigt und zu Ende geführt, nicht revidiert — B2 entfernt
+  lediglich die letzten toten Verweise auf den bereits abgelösten Pfad, inklusive der Doku, die
+  ihn noch als existierend beschreibt.
+
+## Changelog
+
+- 2026-08-16: Initial spec created (#1708 Scheibe B2)
+- 2026-08-16: AC-7 (Doku-Hygiene) ergänzt nach Team-Lead-Entscheidung — Wegfall von
+  `get_trips_dir()` macht sechs weitere Kommentar-/Docstring-Stellen sachlich falsch; Affected
+  Files und Estimated Scope entsprechend erweitert.

--- a/src/app/loader.py
+++ b/src/app/loader.py
@@ -1152,17 +1152,6 @@ def get_locations_dir(user_id: str = "default") -> Path:
     return get_data_dir(user_id) / "locations"
 
 
-def get_trips_dir(user_id: str = "default") -> Path:
-    """Get the (legacy, pre-Cutover) trips directory for a user.
-
-    Issue #1250 Scheibe 7a: load_all_trips/load_trip/save_trip no longer
-    read/write here (see get_briefings_dir) -- this stays as a reference to
-    the old location (Rollback-Fähigkeit, AC-26) and for the historical
-    per-user directory bootstrap.
-    """
-    return get_data_dir(user_id) / "trips"
-
-
 def get_briefings_dir(user_id: str = "default") -> Path:
     """Get the briefings directory for a user (Issue #1250 Cutover, ADR-0023).
     Seit S7a leben route-Entitäten (Trips) hier; seit S7b (AC-31) leben auch

--- a/tests/tdd/test_bundle_791_847_844_alerts.py
+++ b/tests/tdd/test_bundle_791_847_844_alerts.py
@@ -69,9 +69,11 @@ def _make_waypoint(name: str, lat: float, lon: float, arrival_hhmm: str) -> Wayp
 def _save_trip_direct(trip: Trip, user_id: str) -> None:
     """Schreibt Trip-JSON direkt — umgeht Naismith-Compute-on-Save.
 
-    Issue #1133: get_trips_dir() folgt dem autouse-isolierten Daten-Root,
-    denselben Pfad, unter dem TripAlertService via app.loader.load_all_trips()
-    liest — statt des modulweiten DATA_ROOT-Konstante (echter Baum).
+    Issue #1133: get_briefings_dir() (get_trips_dir() ist seit #1708
+    Scheibe B2 entfernter Altbestand) folgt dem autouse-isolierten
+    Daten-Root, denselben Pfad, unter dem TripAlertService via
+    app.loader.load_all_trips() liest — statt des modulweiten
+    DATA_ROOT-Konstante (echter Baum).
     """
     import json
     from app.loader import get_briefings_dir

--- a/tests/tdd/test_feature_656_radar_nowcast.py
+++ b/tests/tdd/test_feature_656_radar_nowcast.py
@@ -184,8 +184,8 @@ def test_ac3_now_command_returns_nowcast_under_10s():
         )
         assert "uelle" in body or "Quelle" in body
     finally:
-        from app.loader import get_trips_dir
-        p = get_trips_dir() / f"{_TRIP_ID}.json"
+        from app.loader import get_briefings_dir
+        p = get_briefings_dir() / f"{_TRIP_ID}.json"
         if p.exists():
             p.unlink()
 
@@ -211,8 +211,8 @@ def test_ac3_now_command_without_today_stage_gives_clear_message():
         body = result.confirmation_body.lower()
         assert any(kw in body for kw in ("etappe", "standort", "position", "heute"))
     finally:
-        from app.loader import get_trips_dir
-        p = get_trips_dir() / f"{_TRIP_ID}.json"
+        from app.loader import get_briefings_dir
+        p = get_briefings_dir() / f"{_TRIP_ID}.json"
         if p.exists():
             p.unlink()
 
@@ -298,7 +298,7 @@ def test_ac4_check_radar_alerts_sends_once_then_throttles():
         assert len(radar_entries) == 1
         assert radar_entries[0].get("severity") == "HIGH"
     finally:
-        from app.loader import get_trips_dir
-        p = get_trips_dir() / f"{_TRIP_ID}.json"
+        from app.loader import get_briefings_dir
+        p = get_briefings_dir() / f"{_TRIP_ID}.json"
         if p.exists():
             p.unlink()

--- a/tests/tdd/test_feature_660_convective_stage.py
+++ b/tests/tdd/test_feature_660_convective_stage.py
@@ -230,7 +230,7 @@ def test_ac4_radar_alert_convective_marked_once_then_throttles():
         assert "Gewitter" in blob
     finally:
         EmailOutput.send = original_send
-        from app.loader import get_trips_dir
-        p = get_trips_dir() / f"{_TRIP_ID}.json"
+        from app.loader import get_briefings_dir
+        p = get_briefings_dir() / f"{_TRIP_ID}.json"
         if p.exists():
             p.unlink()

--- a/tests/tdd/test_inbound_gate_errors.py
+++ b/tests/tdd/test_inbound_gate_errors.py
@@ -14,7 +14,7 @@ from datetime import date, timedelta
 
 import pytest
 
-from app.loader import get_trips_dir, save_trip
+from app.loader import get_briefings_dir, save_trip
 from app.trip import Stage, Trip, Waypoint
 from services.inbound_email_reader import InboundEmailReader
 
@@ -45,7 +45,7 @@ def _make_trip() -> Trip:
 @pytest.fixture(autouse=True)
 def cleanup():
     yield
-    trip_path = get_trips_dir() / f"{_TRIP_ID}.json"
+    trip_path = get_briefings_dir() / f"{_TRIP_ID}.json"
     if trip_path.exists():
         trip_path.unlink()
 

--- a/tests/tdd/test_issue_1001_telegram_bubbles.py
+++ b/tests/tdd/test_issue_1001_telegram_bubbles.py
@@ -433,8 +433,8 @@ def _make_ac4_trip():
 
 @pytest.fixture
 def _clean_ac4_user():
-    from app.loader import get_trips_dir
-    d = get_trips_dir(_AC4_USER)
+    from app.loader import get_briefings_dir
+    d = get_briefings_dir(_AC4_USER)
     shutil.rmtree(d, ignore_errors=True)
     yield
     shutil.rmtree(d, ignore_errors=True)
@@ -499,8 +499,10 @@ def _ac7_client():
 @pytest.mark.real_data_root
 class TestAC7PreviewEndpointBubbles:
     """Issue #1133: liest das echte, committete Trip-Fixture data/users/default/
-    trips/gr221-mallorca.json über PreviewService (echter get_trips_dir()-Pfad,
-    kein Test-User) — bewusstes Opt-out aus der autouse-Isolation."""
+    trips/gr221-mallorca.json über PreviewService -- per tests/conftest.py nach
+    briefings/ gespiegelt (get_trips_dir() ist seit #1708 Scheibe B2 entfernter
+    Altbestand und lag hier nie im Lesepfad; PreviewService liest ohnehin aus
+    briefings/), kein Test-User — bewusstes Opt-out aus der autouse-Isolation."""
 
     def test_telegram_preview_endpoint_returns_bubbles_alongside_body(self, _ac7_client):
         resp = _ac7_client.get(
@@ -853,9 +855,9 @@ def _f003_trip_and_log():
     import json as _json
     from datetime import timedelta
 
-    from app.loader import get_trips_dir
+    from app.loader import get_briefings_dir
 
-    trips_dir = get_trips_dir(_F003_USER)
+    trips_dir = get_briefings_dir(_F003_USER)
     trips_dir.mkdir(parents=True, exist_ok=True)
     future = (date.today() + timedelta(days=5)).isoformat()
     trip_path = trips_dir / f"{_F003_TRIP_ID}.json"

--- a/tests/tdd/test_issue_1133_testdata_cleanup.py
+++ b/tests/tdd/test_issue_1133_testdata_cleanup.py
@@ -38,7 +38,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 def test_ac1_fixture_isolation_path_resolution_and_roundtrip(tmp_path, monkeypatch):
     """AC-1: Given die neue autouse-Fixture ist aktiv (kein real_data_root-
-    Marker) / When ein Test get_trips_dir()/save_trip() ohne data_dir=
+    Marker) / When ein Test get_briefings_dir()/save_trip() ohne data_dir=
     aufruft / Then landet die Datei ausschliesslich im temporaeren
     Fixture-Root, und der echte data/users/-Baum bleibt unveraendert.
 
@@ -55,10 +55,11 @@ def test_ac1_fixture_isolation_path_resolution_and_roundtrip(tmp_path, monkeypat
     Fix haengt er ausschliesslich vom (unabhaengigen) Fixture-Root ab.
 
     #1708 B1 (AC-6): die Sonde haengt hier bewusst an get_briefings_dir(),
-    nicht mehr an get_trips_dir() -- save_trip() schreibt bereits seit dem
-    #1250-Cutover (ADR-0023) nach briefings/, nicht mehr nach trips/.
-    get_trips_dir() faellt in Scheibe B2 komplett weg; die Sonde muss das
-    ueberstehen (Nachweis: tests/test_stillgelegte_testdateien.py::
+    nicht an get_trips_dir() -- save_trip() schreibt bereits seit dem
+    #1250-Cutover (ADR-0023) nach briefings/, nicht nach trips/.
+    get_trips_dir() ist seit #1708 Scheibe B2 vollstaendig entfernter
+    Altbestand; die Sonde uebersteht das (Nachweis:
+    tests/test_stillgelegte_testdateien.py::
     test_ac6_isolationssonde_uebersteht_wegfall_von_get_trips_dir, ruft
     diese Funktion mit per monkeypatch entferntem get_trips_dir auf).
     """

--- a/tests/tdd/test_issue_363_signal_telegram_preview.py
+++ b/tests/tdd/test_issue_363_signal_telegram_preview.py
@@ -25,8 +25,10 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 # Issue #1133: die gesamte Datei liest das echte, committete Trip-Fixture
-# data/users/default/trips/gr221-mallorca.json (echter get_trips_dir()-Pfad)
-# — bewusstes Opt-out aus der autouse-Isolation für das gesamte Modul.
+# data/users/default/trips/gr221-mallorca.json -- per tests/conftest.py nach
+# briefings/ gespiegelt (get_trips_dir() ist seit #1708 Scheibe B2 entfernter
+# Altbestand und lag hier nie im Lesepfad) — bewusstes Opt-out aus der
+# autouse-Isolation für das gesamte Modul.
 pytestmark = pytest.mark.real_data_root
 
 TRIP_ID = "gr221-mallorca"

--- a/tests/tdd/test_issue_612_report_on_demand.py
+++ b/tests/tdd/test_issue_612_report_on_demand.py
@@ -17,7 +17,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
-from app.loader import get_trips_dir, save_trip
+from app.loader import get_briefings_dir, save_trip
 from app.trip import Stage, Trip, Waypoint
 from services.trip_command_processor import InboundMessage, TripCommandProcessor
 
@@ -152,7 +152,7 @@ def _save_user_trip() -> Trip:
 
 
 def _cleanup_user_trip() -> None:
-    trip_path = get_trips_dir(_TEST_USER_ID) / f"{_TEST_TRIP_ID}.json"
+    trip_path = get_briefings_dir(_TEST_USER_ID) / f"{_TEST_TRIP_ID}.json"
     if trip_path.exists():
         trip_path.unlink()
     user_dir = Path("data/users") / _TEST_USER_ID
@@ -290,7 +290,7 @@ class TestF002ReportTypeCaseInsensitive:
 
     def teardown_method(self):
         _cleanup_user_trip()
-        default_path = get_trips_dir("default") / f"{_TEST_TRIP_ID}.json"
+        default_path = get_briefings_dir("default") / f"{_TEST_TRIP_ID}.json"
         if default_path.exists():
             default_path.unlink()
 
@@ -324,7 +324,7 @@ class TestAC5InvalidReportType:
     def teardown_method(self):
         _cleanup_user_trip()
         # Default-User-Trip aufräumen
-        default_path = get_trips_dir("default") / f"{_TEST_TRIP_ID}.json"
+        default_path = get_briefings_dir("default") / f"{_TEST_TRIP_ID}.json"
         if default_path.exists():
             default_path.unlink()
 

--- a/tests/tdd/test_issue_731_unified_commands.py
+++ b/tests/tdd/test_issue_731_unified_commands.py
@@ -25,7 +25,7 @@ sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
 from app.loader import (  # noqa: E402
-    get_snapshots_dir, get_trips_dir, load_all_trips, save_trip,
+    get_briefings_dir, get_snapshots_dir, load_all_trips, save_trip,
 )
 from app.models import TripReportConfig  # noqa: E402
 from app.trip import Stage, Trip, Waypoint  # noqa: E402
@@ -181,7 +181,7 @@ def _today_name() -> str:
 def cleanup():
     yield
     for u in (_USER_A, _USER_B, _USER_DEFAULT):
-        for d in (get_trips_dir(u), get_snapshots_dir(u)):
+        for d in (get_briefings_dir(u), get_snapshots_dir(u)):
             p = d / f"{_TRIP_ID}.json"
             if p.exists():
                 p.unlink()
@@ -400,6 +400,6 @@ class TestAC10UserIsolation:
         assert _load_trip(_USER_B).report_config.enabled is False, \
             "Nutzer B darf NICHT verändert werden (AC-10)"
         # Kein versehentliches Schreiben nach users/default/
-        default_trip = get_trips_dir(_USER_DEFAULT) / f"{_TRIP_ID}.json"
+        default_trip = get_briefings_dir(_USER_DEFAULT) / f"{_TRIP_ID}.json"
         assert not default_trip.exists(), \
             "WEITER darf nicht nach users/default/ schreiben (AC-10)"

--- a/tests/tdd/test_issue_818_radar_briefing_integration.py
+++ b/tests/tdd/test_issue_818_radar_briefing_integration.py
@@ -94,9 +94,10 @@ def _make_active_trip(trip_id: str) -> Trip:
 def _save_trip_direct(trip: Trip, user_id: str) -> None:
     """Schreibt Trip-JSON direkt — umgeht Naismith Compute-on-Save.
 
-    Issue #1133: get_trips_dir() folgt dem autouse-isolierten Daten-Root,
-    denselben Pfad, unter dem TripAlertService via app.loader.load_all_trips()
-    liest.
+    Issue #1133: get_briefings_dir() (get_trips_dir() ist seit #1708
+    Scheibe B2 entfernter Altbestand) folgt dem autouse-isolierten
+    Daten-Root, denselben Pfad, unter dem TripAlertService via
+    app.loader.load_all_trips() liest.
     """
     from app.loader import get_briefings_dir
     trips_dir = get_briefings_dir(user_id)

--- a/tests/tdd/test_issue_822_radar_nowcast_segment.py
+++ b/tests/tdd/test_issue_822_radar_nowcast_segment.py
@@ -98,9 +98,11 @@ def _save_trip_direct(trip, user_id: str) -> None:
     """
     import json
 
-    # Issue #1133: get_trips_dir() folgt dem autouse-isolierten Daten-Root,
-    # denselben Pfad, unter dem TripAlertService via app.loader.load_all_trips()
-    # liest — statt der modulweiten DATA_ROOT-Konstante (echter Baum).
+    # Issue #1133: get_briefings_dir() (get_trips_dir() ist seit #1708
+    # Scheibe B2 entfernter Altbestand) folgt dem autouse-isolierten
+    # Daten-Root, denselben Pfad, unter dem TripAlertService via
+    # app.loader.load_all_trips() liest — statt der modulweiten
+    # DATA_ROOT-Konstante (echter Baum).
     from app.loader import get_briefings_dir
     trips_dir = get_briefings_dir(user_id)
     trips_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/tdd/test_issue_882_pause_skip.py
+++ b/tests/tdd/test_issue_882_pause_skip.py
@@ -19,7 +19,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
-from app.loader import get_trips_dir, save_trip  # noqa: E402
+from app.loader import get_briefings_dir, save_trip  # noqa: E402
 from app.models import TripReportConfig  # noqa: E402
 from app.trip import Stage, Trip, Waypoint  # noqa: E402
 from services.trip_command_processor import InboundMessage, TripCommandProcessor  # noqa: E402
@@ -66,7 +66,7 @@ def _msg(text: str) -> InboundMessage:
 
 @pytest.fixture(autouse=True)
 def clean_user_dir():
-    trips_dir = get_trips_dir(_USER)
+    trips_dir = get_briefings_dir(_USER)
     shutil.rmtree(trips_dir, ignore_errors=True)
     yield
     shutil.rmtree(trips_dir, ignore_errors=True)

--- a/tests/tdd/test_loader_display_config_default.py
+++ b/tests/tdd/test_loader_display_config_default.py
@@ -240,8 +240,8 @@ class TestLoadAllTripsResilience:
         (trips_dir / "bad-date.json").write_text(json.dumps(bad_data))
 
         # Pfad-Helper auf tmp_path umbiegen (Issue #1250 Scheibe 7a:
-        # load_all_trips liest seit dem Cutover get_briefings_dir(), nicht
-        # mehr get_trips_dir()).
+        # load_all_trips liest seit dem Cutover get_briefings_dir() --
+        # get_trips_dir() ist seit #1708 Scheibe B2 entfernter Altbestand).
         monkeypatch.setattr(
             loader_mod,
             "get_briefings_dir",

--- a/tests/tdd/test_trip_command_processor.py
+++ b/tests/tdd/test_trip_command_processor.py
@@ -8,7 +8,7 @@ from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
-from app.loader import get_data_dir, get_snapshots_dir, get_trips_dir, save_trip
+from app.loader import get_briefings_dir, get_data_dir, get_snapshots_dir, save_trip
 from app.trip import Stage, Trip, Waypoint
 from services.trip_command_processor import (
     CommandResult,
@@ -70,7 +70,7 @@ def _save_test_trip(**kwargs) -> Trip:
 
 def _cleanup_test_trip(trip_id: str = _TRIP_ID) -> None:
     """Remove test trip file and command log entries."""
-    trip_path = get_trips_dir() / f"{trip_id}.json"
+    trip_path = get_briefings_dir() / f"{trip_id}.json"
     if trip_path.exists():
         trip_path.unlink()
 

--- a/tests/test_briefing_route_cutover.py
+++ b/tests/test_briefing_route_cutover.py
@@ -105,9 +105,16 @@ def _full_trip_dict(trip_id: str, name: str = "Test-Tour", kind: str | None = "r
 
 
 def _briefings_dir(user_id: str) -> Path:
-    """Analog `loader.get_trips_dir` (loader.py:1006) -- vor S7a existiert
-    kein eigener Loader-Helper fuer `briefings/` (s. Anker-Liste im Auftrag)."""
-    return loader.get_trips_dir(user_id).parent / "briefings"
+    return loader.get_briefings_dir(user_id)
+
+
+def _legacy_trips_dir(user_id: str) -> Path:
+    """Bildet den toten #1708-Pfad ``trips/`` bewusst testlokal literal ueber
+    ``get_data_dir()`` (der frühere Loader-Helfer ``get_trips_dir()`` ist seit
+    #1708 Scheibe B2 entfernter Altbestand, existiert also nicht mehr) --
+    diese Datei belegt (AC-25/AC-26), dass der lebende Lesepfad diesen Pfad
+    ignoriert und save_trip ihn byte-unveraendert laesst."""
+    return loader.get_data_dir(user_id) / "trips"
 
 
 def _write_json(path: Path, data: dict) -> None:
@@ -127,7 +134,7 @@ def test_load_all_trips_reads_briefings_dir_not_trips_dir():
     trip_id = "gr20-2026"
 
     _write_json(_briefings_dir(uid) / f"{trip_id}.json", _full_trip_dict(trip_id, name="Briefings-Version"))
-    _write_json(loader.get_trips_dir(uid) / f"{trip_id}.json", _full_trip_dict(trip_id, name="Alt-Trips-Version"))
+    _write_json(_legacy_trips_dir(uid) / f"{trip_id}.json", _full_trip_dict(trip_id, name="Alt-Trips-Version"))
 
     loaded = loader.load_all_trips(uid)
 
@@ -146,7 +153,7 @@ def test_load_trip_by_id_reads_briefings_dir_not_trips_dir():
     root = loader.get_data_root()
 
     _write_json(_briefings_dir(uid) / f"{trip_id}.json", _full_trip_dict(trip_id, name="Briefings-Via-ID"))
-    _write_json(loader.get_trips_dir(uid) / f"{trip_id}.json", _full_trip_dict(trip_id, name="Alt-Via-ID"))
+    _write_json(_legacy_trips_dir(uid) / f"{trip_id}.json", _full_trip_dict(trip_id, name="Alt-Via-ID"))
 
     trip = loader.load_trip(trip_id, data_dir=str(root), user_id=uid)
 
@@ -168,7 +175,7 @@ def test_save_trip_writes_briefings_and_leaves_trips_file_untouched():
     uid = "cutover-route-d"
     trip_id = "vanoise-2026"
 
-    trips_dir = loader.get_trips_dir(uid)
+    trips_dir = _legacy_trips_dir(uid)
     _write_json(trips_dir / f"{trip_id}.json", _full_trip_dict(trip_id, name="Alt-Version"))
     original_bytes = (trips_dir / f"{trip_id}.json").read_bytes()
 

--- a/tests/test_stillgelegte_testdateien.py
+++ b/tests/test_stillgelegte_testdateien.py
@@ -108,16 +108,23 @@ def test_ac3_alarm_segment_eigenschaft_ist_zeitunabhaengig():
 def test_ac6_isolationssonde_uebersteht_wegfall_von_get_trips_dir(tmp_path):
     """AC-6: Die Isolationssonde in test_issue_1133_testdata_cleanup.py
     (:57-75) muss den Wegfall von get_trips_dir() in Scheibe B2 ueberstehen
-    -- das gelingt nur, wenn sie stattdessen get_briefings_dir() befragt.
+    -- das gelingt nur, weil sie get_briefings_dir() befragt statt
+    get_trips_dir().
 
     Gewaehlter Weg (gleichwertig zur im Auftrag skizzierten
     Subprozess/`-p`-Variante -- ein conftest-freies Vorschalt-Skript waere
-    hier fragiler als der direkte Verhaltensbeweis, und conftest.py selbst
-    ruft an mehreren Stellen get_trips_dir() zur Session-Fixture-Zeit, was
-    ein sauberes Vorschalten erschweren wuerde): get_trips_dir() wird per
-    monkeypatch.delattr aus app.loader entfernt, danach wird die betroffene
-    Sondenfunktion direkt aufgerufen. Heute wirft das AttributeError, weil
-    Teil A der Sonde (:61-69) get_trips_dir() direkt aufruft -> rot.
+    hier fragiler als der direkte Verhaltensbeweis): get_trips_dir() wird
+    per monkeypatch.delattr aus app.loader entfernt (raising=False, da die
+    Funktion seit #1708 Scheibe B2 ohnehin nicht mehr existiert), danach
+    wird die betroffene Sondenfunktion direkt aufgerufen. Zum Zeitpunkt
+    dieses B1-Nachweises rief Teil A der Sonde (:61-69) noch get_trips_dir()
+    direkt auf und brach dabei mit AttributeError ab -- seit der
+    B1-Umstellung der Sonde auf get_briefings_dir() (und seit B2 dem
+    tatsaechlichen Wegfall der Funktion aus app.loader) bleibt dieser Test
+    gruen, weil kein Aufruf mehr auf den entfernten Attributnamen trifft.
+    (Korrektur der urspruenglichen, sachlich falschen Begruendung ueber
+    conftest.py -- ``grep get_trips_dir tests/conftest.py`` liefert keinen
+    Treffer, die Session-Fixture ruft die Funktion nie auf.)
     """
     import app.loader as loader
     from tests.tdd.test_issue_1133_testdata_cleanup import (

--- a/tests/test_trips_path_revival_guard.py
+++ b/tests/test_trips_path_revival_guard.py
@@ -64,6 +64,7 @@ from __future__ import annotations
 
 import ast
 import re
+import sys
 from pathlib import Path
 
 import pytest
@@ -84,15 +85,11 @@ CARRIER_FILES = {
 }
 
 # Restliste, Schluesselform "pfad::symbol::ordinal" (Hausnorm,
-# tests/test_guard_findings_survive_line_shifts.py:52). Genau EIN Eintrag --
-# kein Inline-Ausnahmeventil, jede Ausnahme muss hier stehen, sonst waere sie
-# in der Taeterdatei fuer einen Reviewer unsichtbar mitzuschmuggeln.
-KNOWN_VIOLATIONS: dict[str, str] = {
-    "src/app/loader.py::get_trips_dir::0": (
-        "UEBERGANG #1708 Scheibe B -- 12 Testdateien rufen sie; entfaellt mit "
-        "deren Umstellung auf get_briefings_dir(). KEINE Dauerausnahme."
-    ),
-}
+# tests/test_guard_findings_survive_line_shifts.py:52). Leer seit #1708
+# Scheibe B2 -- get_trips_dir() (der einzige je gelistete Eintrag) ist aus
+# src/app/loader.py entfernt, die Ausnahme entfaellt im selben Commit
+# (KEINE Dauerausnahme, siehe frueherer Kommentar hier).
+KNOWN_VIOLATIONS: dict[str, str] = {}
 
 _TRIPS_SEGMENT_RE = re.compile(r"(?:^|/|\*/)trips(?:/|$)")
 _GO_STRING_LITERAL_RE = re.compile(r'"([^"]*)"')
@@ -433,6 +430,62 @@ def test_ac7_known_violations_hard_upper_bound():
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# AC-5 (#1708 B2): Trefferkraft-Nachweis -- der Scanner muss auf ECHTEN
+# Dateien noch etwas finden. Mit leerer KNOWN_VIOLATIONS (seit B2) gibt es
+# sonst keinen Test mehr, der das belegt -- ein Scanner, der lautlos []
+# liefert (verschluckter Lesefehler, kaputte Pfadaufloesung), waere
+# vollstaendig unbemerkt gruen.
+# ---------------------------------------------------------------------------
+
+
+def test_trefferkraft_scanner_detects_real_violations_on_disk(tmp_path, monkeypatch):
+    """AC-5 (#1708 B2): legt zwei echte Verstoss-Dateien in tmp_path an --
+    eine Go-Datei im Slice-Muster (dem Muster, das die Falle real herstellte,
+    internal/store/user.go:84) und eine Python-Datei im Divisions-Muster
+    (dem Muster des inzwischen entfernten get_trips_dir()) -- und biegt
+    REPO_ROOT per monkeypatch auf diesen temporaeren Baum um. Traegt, weil
+    REPO_ROOT ein Modul-Global ist, das _go_scan_files()/_py_scan_files() bei
+    JEDEM Aufruf neu aufloesen (:181/:194), nicht als Signaturparameter --
+    deshalb per monkeypatch umbiegbar, ohne den Scanner selbst anzufassen.
+    Deckt beide Sprachpfade ab; die verlorene KNOWN_VIOLATIONS-Kontrolle
+    bewies nur die Python-Seite."""
+    go_dir = tmp_path / "internal" / "store"
+    go_dir.mkdir(parents=True)
+    (go_dir / "user.go").write_text(
+        "package store\n\n"
+        'func (s *Store) ProvisionUserDirs(id string) error {\n'
+        "\tbase := s.UserDir(id)\n"
+        '\tfor _, sub := range []string{"locations", "trips", "gpx"} {\n'
+        "\t\tos.MkdirAll(filepath.Join(base, sub), 0755)\n"
+        "\t}\n"
+        "\treturn nil\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    py_dir = tmp_path / "src" / "app"
+    py_dir.mkdir(parents=True)
+    (py_dir / "loader.py").write_text(
+        "def get_trips_dir(user_id='default'):\n"
+        '    return get_data_dir(user_id) / "trips"\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(sys.modules[__name__], "REPO_ROOT", tmp_path)
+
+    findings = _all_violations()
+
+    assert findings == {
+        "internal/store/user.go::ProvisionUserDirs::0": ("trips", 5),
+        "src/app/loader.py::get_trips_dir::0": ("trips", 2),
+    }, (
+        "Der Scanner findet auf echten Dateien nicht mehr die erwarteten "
+        f"zwei Verstoesse: {findings} -- ein Scanner, der auf realem "
+        "Bestand nichts (mehr) liefert, muss diesen Test rot machen."
+    )
+
+
 def test_ac8_scan_area_excludes_tests_and_scripts():
     """Schuetzt tests/test_briefing_route_cutover.py (Lockvogel-Datei fuer
     den Cutover-Beweis) und die Migrations-Skripte, deren Aufgabe der
@@ -456,10 +509,11 @@ def test_keine_unlisted_trips_pfad_funde():
     THEN ist das ein neuer/bestehender toter 'trips'-Pfad in Produktivcode
     (#1708) -- der Test benennt Datei, Symbol und Fundtext.
 
-    Erwartung in der TDD-RED-Phase: ROT, benennt
+    Erwartung in der TDD-RED-Phase (Scheibe A): ROT, benannte
     internal/store/trip.go:15 (TripsDir) und internal/store/user.go:84
-    (ProvisionUserDirs). src/app/loader.py:1163 (get_trips_dir) ist ueber
-    KNOWN_VIOLATIONS gedeckt und erscheint NICHT in der Fehlermeldung.
+    (ProvisionUserDirs). Seit #1708 Scheibe B2 existiert
+    ``src/app/loader.py::get_trips_dir`` nicht mehr (entfernter Altbestand)
+    -- KNOWN_VIOLATIONS ist leer, es gibt keinen Fund mehr zu decken.
     """
     found = _all_violations()
     unlisted = {k: v for k, v in found.items() if k not in KNOWN_VIOLATIONS}

--- a/tests/test_trips_pfad_rueckbau.py
+++ b/tests/test_trips_pfad_rueckbau.py
@@ -1,0 +1,290 @@
+"""RED-Nachweise fuer #1708 Scheibe B2 -- toten `trips/`-Pfad aus Testdateien
+und Loader entfernen.
+
+Spec: ``docs/specs/modules/fix_1708_b2_trips_pfad_rueckbau.md``.
+Context: ``docs/context/fix-1708-b2-trips-pfad-rueckbau.md``.
+
+Seit #1250 Scheibe 7a (ADR-0023) leben Trips ausschliesslich in
+``data/users/<uid>/briefings/<id>.json``. ``get_trips_dir()``
+(``src/app/loader.py:1155``) ist tot -- kein Produktivaufrufer, aber neun
+Testdateien rufen sie noch real auf und wirken dadurch entweder wirkungslos
+oder verlieren eine echte Zusicherung an eine Adresse, die nie beschrieben
+wird (AC-6).
+
+Fuenf Nachweise, in Wichtigkeitsreihenfolge:
+
+- N1 (AC-3): ``get_trips_dir`` faellt aus ``src/app/loader.py``.
+- N2 (AC-4): die eine Waechter-Ausnahme dafuer wird leer.
+- N3 (AC-1): keine Testdatei ruft die Funktion mehr echt auf (AST, nicht
+  Textvergleich -- eine Nennung in Kommentar/Docstring/String ist kein
+  Aufruf).
+- N4 (AC-5): der wichtigste und schwierigste Nachweis. Mit blindem Scanner
+  (``_py_scan_files``/``_go_scan_files`` liefern ``[]``) UND leerer
+  ``KNOWN_VIOLATIONS`` muss mindestens einer der inhaltlichen
+  Waechter-Tests rot werden -- sonst misst kein Test mehr, ob der Scanner
+  auf echten Dateien ueberhaupt etwas findet (R1 im Kontextdokument). Die
+  drei AC-6/AC-8-Scanflaechen-Sanity-Tests sind ausdruecklich NICHT Teil
+  dieses Nachweises -- sie schuetzen eine andere Eigenschaft (Dateizahl,
+  Traeger-Mitgliedschaft), nicht die Fund-Erkennung selbst.
+- N5 (AC-6): die Cross-User-Zusicherung in
+  ``tests/tdd/test_issue_731_unified_commands.py::TestAC10UserIsolation
+  .test_weiter_only_affects_own_trip`` zielt heute auf den toten
+  ``trips/``-Pfad und kann dort nie fehlschlagen.
+
+Test-Politik: Kernschicht, keine Mocks -- ``monkeypatch`` auf echte
+Modul-Globals biegt echten Code um, ersetzt ihn nicht. Pfadregel #1409:
+Pruefling relativ zu DIESER Testdatei aufgeloest, nie ueber einen festen
+Hauptrepo-Pfad.
+"""
+from __future__ import annotations
+
+import ast
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+
+# Pfadregel #1409: Repo-Wurzel relativ zu DIESER Testdatei.
+_TESTS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _TESTS_DIR.parent
+
+
+def _load_guard():
+    """Den Waechter als eigenstaendiges Modul laden -- ueber seinen
+    Dateipfad (Hausnorm: tests/test_guard_findings_survive_line_shifts.py),
+    damit ein Worktree-Lauf zwingend die Worktree-Fassung misst."""
+    path = _TESTS_DIR / "test_trips_path_revival_guard.py"
+    assert path.exists(), f"Waechter-Datei fehlt: {path}"
+    spec = importlib.util.spec_from_file_location(
+        "gz_guard_trips_path_revival_b2", path
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# N1 (AC-3): get_trips_dir() faellt aus src/app/loader.py
+# ---------------------------------------------------------------------------
+
+
+def test_get_trips_dir_removed_from_loader():
+    from app import loader
+
+    assert not hasattr(loader, "get_trips_dir"), (
+        "src.app.loader.get_trips_dir existiert noch -- AC-3 verlangt die "
+        "vollstaendige Entfernung. Code reference: src/app/loader.py:1155-1163"
+    )
+
+
+# ---------------------------------------------------------------------------
+# N2 (AC-4): die eine Waechter-Ausnahme wird leer, im selben Commit
+# ---------------------------------------------------------------------------
+
+
+def test_known_violations_guard_exception_emptied():
+    guard = _load_guard()
+    assert guard.KNOWN_VIOLATIONS == {}, (
+        f"KNOWN_VIOLATIONS ist nicht leer: {guard.KNOWN_VIOLATIONS} -- der "
+        "Eintrag fuer get_trips_dir muss im selben Commit wie die Funktion "
+        "selbst fallen (AC-4). Code reference: "
+        "tests/test_trips_path_revival_guard.py:90-95"
+    )
+
+
+# ---------------------------------------------------------------------------
+# N3 (AC-1): keine Testdatei ruft get_trips_dir() noch echt auf
+# ---------------------------------------------------------------------------
+
+
+def _real_calls_to(tree: ast.AST, target_name: str) -> list[ast.Call]:
+    """Echte ``ast.Call``-Aufrufe einer Funktion mit gegebenem Namen --
+    unterscheidet einen Aufruf von einer blossen Namensnennung in
+    Kommentar/Docstring/String (dort erscheint der Name gar nicht im Baum
+    als Call, sondern hoechstens als ``ast.Constant``)."""
+    calls: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = None
+        if isinstance(func, ast.Name):
+            name = func.id
+        elif isinstance(func, ast.Attribute):
+            name = func.attr
+        if name == target_name:
+            calls.append(node)
+    return calls
+
+
+def test_no_test_file_still_calls_get_trips_dir():
+    """N3/AC-1: ueber alle .py-Dateien unter tests/ -- eine echte AST-Pruefung,
+    kein Textvergleich (verboten waere z.B. ``assert 'get_trips_dir' not in
+    text``, das traefe auch Kommentare/Docstrings, die AC-7 bewusst als
+    Altbestands-Hinweis stehen laesst)."""
+    offenders: dict[str, int] = {}
+    for path in sorted(_TESTS_DIR.rglob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        tree = ast.parse(text, filename=str(path))
+        calls = _real_calls_to(tree, "get_trips_dir")
+        if calls:
+            offenders[str(path.relative_to(_REPO_ROOT))] = len(calls)
+
+    assert not offenders, (
+        "Echte Aufrufe von get_trips_dir() in "
+        f"{len(offenders)} Testdatei(en) (AC-1 verlangt: keine mehr nach der "
+        f"Umstellung auf get_briefings_dir()): {sorted(offenders.items())}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# N4 (AC-5): blinder Scanner MUSS die Waechter-Suite roet machen
+# ---------------------------------------------------------------------------
+
+# Diese Waechter-Tests pruefen den Scanner ausschliesslich gegen
+# SYNTHETISCHE Quellstrings (AC-1..AC-5 des Waechters) oder gegen die
+# Scanflaeche selbst (Dateizahl/Traeger-Mitgliedschaft, AC-6/AC-8) -- sie
+# haengen nicht an KNOWN_VIOLATIONS/_all_violations() und wuerden mit
+# blindem Scanner aus einem ANDEREN Grund rot (AC-6 zaehlt z.B. direkt
+# len(_go_scan_files())) bzw. gar nicht betroffen sein. Sie gehoeren nicht
+# zum Trefferkraft-Nachweis dieses Tickets und werden bewusst ausgeschlossen,
+# damit die Ausschlussliste selbst kein Verhalten faelscht.
+_GUARD_TESTS_UNRELATED_TO_TREFFERKRAFT = frozenset(
+    {
+        "test_ac1_slice_literal_form_detected",
+        "test_ac2_filepath_join_form_detected",
+        "test_ac3_python_division_form_detected",
+        "test_ac3_python_glob_form_detected",
+        "test_ac4_real_bestand_forms_are_not_findings",
+        "test_ac5_full_comment_line_is_not_a_finding",
+        "test_ac5_code_with_trailing_comment_is_a_finding",
+        "test_ac6_go_scan_area_minimum_file_count",
+        "test_ac6_python_scan_area_minimum_file_count",
+        "test_ac6_carrier_files_are_within_scan_area",
+        "test_ac8_scan_area_excludes_tests_and_scripts",
+    }
+)
+
+
+def _call_with_supported_fixtures(func, *, tmp_path, monkeypatch) -> None:
+    """Ruft eine Waechter-Testfunktion mit genau den Fixtures auf, die sie
+    per Signatur verlangt -- unterstuetzt werden nur ``tmp_path`` und
+    ``monkeypatch`` (die einzigen, die der kuenftige Trefferkraft-Test laut
+    Kontextdokument braucht)."""
+    sig = inspect.signature(func)
+    kwargs = {}
+    for name in sig.parameters:
+        if name == "tmp_path":
+            kwargs["tmp_path"] = tmp_path
+        elif name == "monkeypatch":
+            kwargs["monkeypatch"] = monkeypatch
+        else:
+            raise TypeError(
+                f"{func.__name__} braucht die nicht unterstuetzte Fixture "
+                f"{name!r} -- Nachweis kann diese Funktion nicht generisch "
+                "aufrufen."
+            )
+    func(**kwargs)
+
+
+def test_blinded_scanner_must_fail_the_guard_suite(monkeypatch, tmp_path):
+    """N4/AC-5: GIVEN der Scanner ist blind gemacht (_py_scan_files/
+    _go_scan_files liefern []) UND KNOWN_VIOLATIONS ist leer (der Zielzustand
+    von N2) / WHEN die inhaltlichen Waechter-Tests (test_keine_unlisted_
+    trips_pfad_funde, test_ac7_known_violations_*) laufen / THEN muss
+    mindestens einer davon rot werden -- ein Scanner, der auf echten Dateien
+    lautlos nichts mehr liefert, darf nicht unbemerkt bleiben (R1).
+
+    HEUTE ist dieser Nachweis rot aus dem richtigen Grund: keiner der drei
+    heutigen Kandidaten haengt an den Datei-Sammelfunktionen in einer Weise,
+    die bei leerer KNOWN_VIOLATIONS auffiele -- ``found = {}``,
+    ``KNOWN_VIOLATIONS = {}``, beide Pruefungen sind dann trivial erfuellt.
+    Erst der kuenftige Trefferkraft-Test (legt echte Verstoss-Dateien in
+    tmp_path an, biegt REPO_ROOT per monkeypatch um) haengt zusaetzlich an
+    _all_violations() -> _py_scan_files()/_go_scan_files() und wird bei
+    Blindheit rot, weil er echte Funde erwartet, aber keine bekommt. Die
+    Kandidatenliste wird dynamisch aus dem Waechter-Modul gelesen (nicht
+    hier abgeschrieben), damit dieser Nachweis den kuenftigen Test
+    automatisch mit erfasst.
+    """
+    guard = _load_guard()
+    monkeypatch.setattr(guard, "KNOWN_VIOLATIONS", {})
+    monkeypatch.setattr(guard, "_py_scan_files", lambda: [])
+    monkeypatch.setattr(guard, "_go_scan_files", lambda: [])
+
+    candidates = [
+        (name, obj)
+        for name, obj in sorted(vars(guard).items())
+        if name.startswith("test_")
+        and name not in _GUARD_TESTS_UNRELATED_TO_TREFFERKRAFT
+        and callable(obj)
+        and getattr(obj, "pytestmark", None) is None
+    ]
+    assert candidates, (
+        "Kein einziger Waechter-Test wurde als Trefferkraft-Kandidat erkannt "
+        "-- Namensmuster oder Ausschlussliste in diesem Nachweis pruefen."
+    )
+
+    failures = []
+    for name, func in candidates:
+        try:
+            _call_with_supported_fixtures(
+                func, tmp_path=tmp_path, monkeypatch=monkeypatch
+            )
+        except AssertionError:
+            failures.append(name)
+
+    assert failures, (
+        "Mit blindem Scanner (_py_scan_files/_go_scan_files liefern []) UND "
+        f"leerer KNOWN_VIOLATIONS bleiben ALLE Kandidaten gruen: "
+        f"{[n for n, _ in candidates]} -- kein Test misst mehr, ob der "
+        "Scanner auf echten Dateien ueberhaupt etwas findet (Kontextdokument "
+        "R1). Nach B2 muss der neue Trefferkraft-Nachweis (AC-5) hier "
+        "auffallen und diese Assertion gruen machen."
+    )
+
+
+# ---------------------------------------------------------------------------
+# N5 (AC-6): Cross-User-Zusicherung zielt heute auf den toten Pfad
+# ---------------------------------------------------------------------------
+
+
+def _function_calls(tree: ast.AST, class_name: str, func_name: str) -> set[str]:
+    """Namen aller ``ast.Call``-Aufrufe INNERHALB einer bestimmten Methode
+    einer Klasse -- Aufrufe in anderen Funktionen (auch Helfern, die diese
+    Methode selbst aufruft) zaehlen nicht mit, nur der direkte Methodenkoerper."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == func_name:
+                    return {
+                        c.func.id if isinstance(c.func, ast.Name) else c.func.attr
+                        for c in ast.walk(item)
+                        if isinstance(c, ast.Call)
+                        and isinstance(c.func, (ast.Name, ast.Attribute))
+                    }
+    raise AssertionError(f"{class_name}.{func_name} nicht gefunden in {tree!r}")
+
+
+def test_cross_user_assertion_targets_live_briefings_path():
+    """N5/AC-6: GIVEN TestAC10UserIsolation.test_weiter_only_affects_own_trip
+    prueft, dass ein WEITER von Nutzer A nichts unter users/default/
+    hinterlaesst / WHEN die Pruefstelle inspiziert wird / THEN muss sie den
+    LEBENDEN Pfad (get_briefings_dir) ansprechen -- am toten get_trips_dir
+    kann diese Zusicherung nie fehlschlagen (ein echtes Leck nach
+    users/default/briefings/ bliebe ungefangen, Kontextdokument R4/AC-6)."""
+    path = _TESTS_DIR / "tdd" / "test_issue_731_unified_commands.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    calls = _function_calls(
+        tree, "TestAC10UserIsolation", "test_weiter_only_affects_own_trip"
+    )
+
+    assert "get_briefings_dir" in calls, (
+        "TestAC10UserIsolation.test_weiter_only_affects_own_trip prueft die "
+        "Cross-User-Zusicherung nicht gegen get_briefings_dir() (lebender "
+        f"Pfad) -- gefundene Aufrufe im Methodenkoerper: {sorted(calls)}. "
+        "Solange nur get_trips_dir() (toter Pfad seit #1250 Scheibe 7a) "
+        "geprueft wird, kann diese Zusicherung nie fehlschlagen (AC-6). "
+        "Code reference: tests/tdd/test_issue_731_unified_commands.py:403"
+    )


### PR DESCRIPTION
Scheibe B2 von #1708. Räumt den toten Ablagepfad `data/users/<uid>/trips/` aus der Testschicht und entfernt `get_trips_dir()` aus `src/app/loader.py`.

## Was hier eigentlich gefunden wurde

Der mechanische Teil war klein. Zwei Befunde standen vorher nirgends:

**1. Eine Schutzzusage bewachte ein leeres Verzeichnis.** `test_issue_731_unified_commands.py:403` prüft, dass ein `WEITER`-Befehl von Nutzer A keine Daten bei einem fremden Nutzer hinterlässt — am toten Pfad, wo nie jemand schreibt. Sie konnte gar nicht fehlschlagen. Am lebenden `briefings/`-Pfad trägt sie: gemessen, **kein Leck**. Der Adversary hat zusätzlich ein echtes Leck simuliert (`_resume_trip` schreibt zusätzlich nach `get_briefings_dir("default")`) — der Test wird exakt an Zeile 403 rot, mit dem echten Pfad in der Fehlermeldung.

**2. Der Wächter aus Scheibe A hätte seine einzige echte Positivkontrolle verloren.** Bisher belegte nur `test_ac7_known_violations_only_shrink` über die Ausnahme, dass der Scanner auf echten Dateien überhaupt etwas findet; alle übrigen Kontrollen laufen gegen selbstgebaute Textschnipsel. Nach dem Streichen wäre ein Scanner, der auf realen Dateien lautlos nichts mehr liefert, vollständig grün gewesen — genau die Fehlerklasse, die #1708 erzeugt hat. Ersatz: zwei echte Verstoßdateien im tmp-Baum, `REPO_ROOT` per monkeypatch umgebogen, **beide** Sprachpfade. Das ist mehr als die verlorene Kontrolle leistete, die nur Python abdeckte.

## Bewusste Ausnahme

`tests/test_briefing_route_cutover.py` bleibt am Altpfad (neuer Helfer `_legacy_trips_dir`). Sie legt dort absichtlich eine abweichende Alt-Version an, um zu beweisen, dass der Lesepfad sie ignoriert und `save_trip` sie byte-unverändert lässt. Umbiegen hätte den Cutover-Beweis zerstört. Ihre 7 Tests laufen unverändert.

## Nachweis

- **TDD RED:** 5 unabhängige Nachweise, alle rot vor dem Fix, jeder aus dem inhaltlich richtigen Grund
- **GREEN:** 174 passed, 19 skipped — mit gesperrten Sockets identisch
- **Adversary VERIFIED:** 2 Runden, **8 Mutationen, 8 gefangen, 0 ungefangen**. Beide Atomizitäts-Zwischenzustände fangen; das Löschen des neuen Trefferkraft-Tests macht den RED-Nachweis N4 sofort rot
- Produktiv: **-11 Zeilen**, kein Verhaltensänderung im Betrieb
- Spec: `docs/specs/modules/fix_1708_b2_trips_pfad_rueckbau.md` (7 ACs, PO-freigegeben)

## Doku-Hygiene

Sieben Stellen behaupteten, die Funktion existiere oder sei der Ort echter Trip-Daten. Eine davon (`test_stillgelegte_testdateien.py`) war schon vor diesem Ticket sachlich falsch — die Begründung ist jetzt durch eine nachprüfbare Gegenprobe ersetzt.

## Offen nach diesem PR

**Scheibe C:** die 14 toten Bestandsdateien archivieren und löschen. Schließt #1708.

🤖 Generated with [Claude Code](https://claude.com/claude-code)