### PR TITLE
fix(#1697): Radar-Waechter-Tests zurueck in die CI-Ampel

### DIFF
--- a/.github/ci_tdd_excludes.txt
+++ b/.github/ci_tdd_excludes.txt
@@ -74,8 +74,6 @@ tests/tdd/test_issue_685_selftest_menu_gate.py
 tests/tdd/test_issue_695_test_briefing_send.py
 tests/tdd/test_issue_764_compare_forecast_hours_consume.py
 tests/tdd/test_issue_816_alert_deviation.py
-tests/tdd/test_issue_818_radar_briefing_integration.py
-tests/tdd/test_issue_822_radar_nowcast_segment.py
 tests/tdd/test_issue_833_gate.py
 tests/tdd/test_issue_883_acute_danger_override.py
 tests/tdd/test_issue_995_scheduler_pause.py

--- a/docs/context/fix-1697-radar-waechter-in-ci.md
+++ b/docs/context/fix-1697-radar-waechter-in-ci.md
@@ -1,0 +1,165 @@
+# Context: fix-1697-radar-waechter-in-ci
+
+## Request Summary
+
+#1697 verlangt, dass der Ortstag-vs-Servertag-Fix für den Radar-/NowCast-Alarmpfad
+in CI nachgewiesen wird. Der eigentliche Bug ist bereits behoben (Kern-Fix
+2026-08-11, Briefing-Pfad via #1724, Muster-A-Restliste via #1727 S5d auf null).
+Was fehlt: die beiden dafür geschriebenen Wächter laufen nicht in CI —
+
+- `tests/tdd/test_issue_818_radar_briefing_integration.py`
+- `tests/tdd/test_issue_822_radar_nowcast_segment.py`
+
+stehen in `.github/ci_tdd_excludes.txt:77-78`. Ziel: beide Dateien aus der
+Ausschlussliste holen, ohne dass CI dadurch flackert oder — schlimmer — real
+Mail/Telegram/SMS versendet.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `tests/tdd/test_issue_818_radar_briefing_integration.py` | Ziel-Testdatei 1, 607 Zeilen, 8 AC-Tests (AC-1..AC-7) |
+| `tests/tdd/test_issue_822_radar_nowcast_segment.py` | Ziel-Testdatei 2, 868 Zeilen, 8 AC-Tests (AC-1..AC-8) |
+| `.github/ci_tdd_excludes.txt` | Ratsche — Zeilen 77-78 sind der Eintrag, den es zu entfernen gilt |
+| `src/services/trip_alert.py` | `check_radar_alerts()` (:909ff), `_effective_alert_channels()` (:1553-1591), Konstruktor mit `mail_sink`-DI-Naht (:140/150/164) |
+| `src/services/notification_service.py` | `_dispatch_alert_message()` (:1429-1547) — Versand-Fanout, `mail_sink`-Prüfung (:1432) |
+| `docs/specs/_archive/modules/issue_818_radar_briefing_integration.md` | Original-Spec, AC-7 fordert ausdrücklich "Kein Mock" (:132) |
+| `docs/specs/_archive/modules/issue_822_radar_nowcast_segment.md` | Original-Spec zu Datei 2 |
+
+## Existing Patterns
+
+- **`mail_sink`-DI-Naht** (`trip_alert.py:140`, Docstring: *"Optional callable(subject, body) — captures mail calls in tests (DI seam for AC-4/AC-6; replaces SMTP when set)"*). Ein einfacher Callable, **kein** `unittest.mock`-Objekt — vereinbar mit der "Kein Mock"-Forderung der Original-Spec. Wird durchgereicht bis `notification_service.py:1432`: ist `mail_sink is not None`, wird `EmailOutput(...).send(...)` komplett umgangen.
+- **Referenz-Vorlage im selben File**: `test_ac6_radar_throttle_via_alert_state_cooldown()` (818:500-553) setzt `mail_sink=lambda subject, body: captured.append((subject, body))` und ist damit sauber — kein Netzzugriff.
+- **Referenz-Vorlage in Batch 4 bereits saniert**: `tests/tdd/test_feature_656_radar_nowcast.py:270-294` kombiniert Dummy-`Settings(smtp_host="test.invalid", ...)` **und** `mail_sink=...`.
+- **`_effective_alert_channels()`** (`trip_alert.py:1553-1591`): liefert `{"email"}` als Legacy-Default, wenn `trip.alert_channels is None` und `report_config.send_email=True`. Genau dieser Legacy-Pfad löst in 818 den ungewollten Versand aus.
+- **In 822 bereits sicher**: `test_ac8_mandantentrennung_isolated()` (822:799-868) setzt `report_config = TripReportConfig(..., send_email=False, send_telegram=False, alert_on_changes=False)` — kein Kanal aktiv, kein Egress-Risiko. Nur 818s AC-7 hat die Lücke.
+
+## Konkreter Befund: der defekte Test
+
+`test_ac7_mandantentrennung_isolated()` (818:560-608) konstruiert
+`TripAlertService(throttle_hours=2, user_id=uid_a, radar_service=RadarNowcastService(frame_source=_wet_frames))`
+**ohne** `mail_sink` und **ohne** Dummy-`settings=`. Der zugrundeliegende Trip
+kommt aus `_make_active_trip()` (818:66-89) mit `report_config.send_email=True`
+und `trip.alert_channels=None` → `_effective_alert_channels()` liefert `{"email"}`.
+`self._settings = Settings().with_user_profile(user_id)` lädt die reale
+Host-`.env`-Konfiguration; ist dort ein SMTP-Host hinterlegt, sendet
+`EmailOutput(...).send(...)` real. Ziel-IP `178.104.143.19` in meinem
+Testlauf (mit `--allow-hosts=127.0.0.1,::1` geblockt, Test blieb trotzdem
+grün — die Verbindungs-Exception wird irgendwo verschluckt, das selbst ist
+ein zweiter, kleinerer Fund, s. Risiken).
+
+**Reparatur-Ansatz** (Muster aus AC-6 übernehmen): `mail_sink=lambda subject, body: None`
+(oder sammelnd wie AC-6) im Konstruktor von `svc_a` ergänzen. Kein Dummy-`settings=`
+nötig, da die Sink-Prüfung in `notification_service.py:1432` vor dem
+`EmailOutput`-Aufbau greift.
+
+**premium_sms-Risiko geprüft und ausgeschlossen**: `_dispatch_alert_message()`
+sendet den premium_sms-Kanal ohne vorgeschaltetes `can_send_*()`-Gate
+(`notification_service.py:1533-1547`) — der schärfste Kandidat für
+ungewolltes Egress. Grep über beide Zieldateien zeigt: `alert_channels`
+wird in keiner Fixture je explizit gesetzt, `premium_sms` kommt in keiner
+der beiden Dateien vor. Das Risiko betrifft nur den Legacy-`{"email"}`-Default
+in AC-7/818.
+
+## Dependencies
+
+- **Upstream:** `RadarNowcastService(frame_source=_wet_frames)` (Test-Stub für Wetterdaten, bereits injiziert) · `Settings` (SMTP/Telegram/SMS-Konfiguration, aus Host-`.env` wenn nicht überschrieben) · `TripReportConfig`/`Trip.alert_channels` (Kanalauswahl)
+- **Downstream:** CI-Ampel (`test`-Check der 6 Pflicht-Checks) — sobald die Dateien aus der Ausschlussliste sind, laufen sie bei jedem PR mit.
+
+## Existing Specs
+
+- `docs/specs/_archive/modules/issue_818_radar_briefing_integration.md` (AC-7, "Kein Mock"-Klausel Zeile 132)
+- `docs/specs/_archive/modules/issue_822_radar_nowcast_segment.md`
+- `docs/specs/_archive/tests/issue_822_radar_nowcast_segment_tests.md`
+- `docs/specs/modules/fix_1752_radar_folgt_alarm_kanaelen.md` — Kanal-Resolver-Kontext, gleicher Codepfad
+- `docs/specs/modules/fix_1697_ortstag_statt_servertag.md` — der ursprüngliche Ortstag-Fix, referenziert direkt über dem Versand-Codeabschnitt (`trip_alert.py:931`)
+
+## Warum ausgeschlossen — keine dokumentierte Einzelbegründung
+
+`.github/ci_tdd_excludes.txt` nennt 818/822 nicht namentlich. Sie gehören zur
+Pauschal-Charge "28 Runner-rote" aus Commit `2c7217ef` (2026-08-07): "haengen an
+Server-Umgebung/.env/Creds — lokal im Haupt-Checkout kaschiert das der
+Host-Zustand" — ohne Datei-Aufschlüsselung. `docs/analysis/1196-tdd-excludes-sanierung-2026-08-06.md`
+enthält ebenfalls keinen 818/822-spezifischen Eintrag. Die oben gefundene
+Egress-Lücke in AC-7/818 ist die einzige belastbare Spur und passt exakt zum
+dokumentierten Muster von Batch 4 (`can_send_email()` nur mit Host-`.env` True).
+
+## PR #1913 — bereits gemerged, keine Kollision
+
+`origin/rework-1467-s4b-entdopplung` ist bereits Merge-Commit `edeb6ba3` auf
+`origin/main` (Feature-Commit `99e65c7f`, `+110` in `trip_alert.py`). Fügt eine
+neue Gate-Stufe `check_event_identity_gate()` + `record_event_identity(...)`
+in `check_radar_alerts()` ein, zwischen Kanal-Split und `send_radar_alert(...)`
+(~`trip_alert.py:1174-1206`). Berührt **nicht** den Versandpfad/die
+`mail_sink`-Naht selbst. `git diff origin/main...origin/rework-1467-s4b-entdopplung -- src/services/trip_alert.py`
+ist leer, weil main den Branch bereits enthält — der aktuelle Arbeitsstand
+(`f9bc1a34`) ist also bereits die richtige Basis, kein Rebase nötig.
+
+## Risks & Considerations
+
+- **Der eigentliche Fund ist ein Egress-Risiko, kein reiner CI-Flake.** Der
+  fehlende `mail_sink` in AC-7/818 hätte auf einem Runner ohne Socket-Sperre
+  real gesendet, wenn dort produktive SMTP-Creds in der Umgebung lägen — das
+  ist der Klasse #1477 zuzuordnen (Test-Gate für unbenannte/ungestubbte Sende-Tests).
+- **Verschluckte Exception in meinem Vorab-Lauf**: `--allow-hosts` blockierte
+  den Verbindungsversuch, der Test blieb trotzdem grün. Das deutet auf ein
+  breites `try/except` im Versandpfad — sollte in der Spec/im Adversary-Dialog
+  benannt werden (nicht Teil des Haupt-Fixes, aber beobachtungswürdig).
+- **Marker/Deselektion**: Beide Dateien tragen **keine** Pytest-Marker
+  (kein `pytest.mark.live`/`staging` modulweit) — Streichen aus der
+  Ausschlussliste holt sie tatsächlich in die reguläre Kollektion.
+  `--collect-only` nach der Änderung als Nachweis einplanen (Lehre aus #1708 B1:
+  ungezählte Skips bleiben sonst unsichtbar grün).
+- **#1708 B2 (`gregor-zwanzig-b4`)**: hatte dieselben zwei Dateien wegen
+  `trips_dir`-Variablennamen/Kommentaren auf der Liste. Abgestimmt: b4 behält
+  die reine Umbenennung in B2, dieser Workflow ändert nur, was für CI-Tauglichkeit
+  nötig ist (die `mail_sink`-Ergänzung in AC-7).
+- **CI-Runner ist Schiedsrichter, nicht der lokale Lauf.** Laut Kopf der
+  Ausschlussliste waren 28 von 34 zuvor entfernten Einträgen auf dem Runner rot,
+  obwohl sie lokal grün liefen. Der `/e2e-verify`- bzw. CI-Lauf nach dem Push
+  ist der eigentliche Nachweis, nicht dieser Vorab-Lauf.
+- **Zuschnitt-Frage:** Schließt diese Scheibe #1697? Empfehlung ja — der Kern-Bug,
+  der Briefing-Pfad und die Muster-A-Restliste sind bereits erledigt; alles
+  andere aus der ursprünglichen "Betroffene Stellen"-Tabelle ist inzwischen
+  #1727 S5e zugeordnet.
+
+## Analysis
+
+### Type
+
+**Bug** — ein Test-Gate ist unbewacht (fehlender CI-Nachweis) UND einer der
+beiden ausgeschlossenen Tests hat einen eigenen Defekt (ungestubbter
+Real-Versand). Keine neue Funktionalität, kein Feature.
+
+### Affected Files (with changes)
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `tests/tdd/test_issue_818_radar_briefing_integration.py` | MODIFY | `mail_sink`-DI-Naht in `test_ac7_mandantentrennung_isolated()` (:560-608) ergänzen, Muster von `test_ac6_...` (:500-553) übernehmen |
+| `.github/ci_tdd_excludes.txt` | MODIFY | Zeilen 77-78 (818/822-Einträge) entfernen |
+| `tests/tdd/test_issue_822_radar_nowcast_segment.py` | keine | bereits sicher (`send_email=False` explizit in AC-8), nur Aufnahme in CI |
+
+### Scope Assessment
+
+- Files: 2 geändert (818-Testdatei, Ausschlussliste), 1 unverändert mit-aufgenommen
+- Geschätzt: +2/−2 LoC in `ci_tdd_excludes.txt`, +1 Zeile in der 818-Testdatei
+- Risk Level: **LOW** — Änderung ist minimal und lokalisiert; das eigentliche Risiko (CI-Runner-Verhalten) liegt nicht in der Änderungsgröße, sondern darin, ob der Runner die Dateien tatsächlich grün durchlässt (Host-Zustand kaschiert das lokal laut Kopf der Ausschlussliste)
+
+### Technical Approach
+
+1. `test_ac7_mandantentrennung_isolated()` in 818 bekommt `mail_sink=lambda subject, body: None` (oder sammelnd analog AC-6) an der `TripAlertService(...)`-Konstruktion — verhindert den realen `EmailOutput`-Versand, ohne die "Kein Mock"-Klausel der Original-Spec zu verletzen (Callable, keine Mock-Library).
+2. Beide Dateizeilen aus `.github/ci_tdd_excludes.txt` entfernen.
+3. Nachweis: `--collect-only` auf beiden Dateien (Marker-Deselektion ausschließen, Lehre aus #1708 B1), dann lokaler Lauf, dann — als eigentlicher Schiedsrichter — der CI-Runner nach Push.
+4. Spec-AC muss explizit die Egress-Freiheit als Zusicherung benennen (nicht nur "Test läuft grün"), sonst prüft der Adversary am falschen Ort (Lehre: Barriere muss am Gefahrenpunkt liegen).
+
+### Dependencies
+
+Keine Produktivcode-Abhängigkeiten. Downstream ausschließlich die CI-Ampel
+(`test`-Check). Kein Rebase nötig (PR #1913 bereits in `main` enthalten,
+Versandpfad unberührt).
+
+### Open Questions
+
+- [x] Kollidiert #1913 mit dem Versandpfad? — Nein, geprüft, gemergt, unberührt.
+- [x] Kollidiert #1708 B2? — Nein, abgestimmt mit `gregor-zwanzig-b4`.
+- [ ] Schließt diese Scheibe #1697? — Empfehlung ja, PO-Entscheidung in Spec-Freigabe einholen.

--- a/docs/specs/modules/fix_1697_radar_waechter_in_ci.md
+++ b/docs/specs/modules/fix_1697_radar_waechter_in_ci.md
@@ -1,0 +1,95 @@
+---
+entity_id: fix_1697_radar_waechter_in_ci
+type: bugfix
+created: 2026-08-16
+updated: 2026-08-16
+status: draft
+workflow: fix-1697-radar-waechter-in-ci
+---
+
+# Radar-Wächter-Tests zurück in die CI-Ampel (#1697)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Zwei Wächter-Testdateien für die Radar-Alarm-Kette (#818, #822) sind aktuell in
+`.github/ci_tdd_excludes.txt` von der CI-Kollektion ausgeschlossen und laufen dadurch bei
+keinem `test`-Check mit. Der eigentliche Bug aus #1697 ("Alarm-Pfad fragt den Server-Tag
+statt den Ortstag ab") ist bereits am 2026-08-11 behoben — offen ist nur noch der im Issue
+geforderte Nachweis, dass beide Regressionswächter dauerhaft in der CI-Ampel laufen, ohne
+dabei reale E-Mails an Produktiv-Empfänger zu versenden.
+
+## Source
+
+- **File:** `tests/tdd/test_issue_818_radar_briefing_integration.py`
+- **Identifier:** `def test_ac7_mandantentrennung_isolated`
+- **File:** `.github/ci_tdd_excludes.txt`
+- **Identifier:** Zeilen 77-78 (Ausschlusseinträge für beide Dateien)
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `src/services/trip_alert.py::TripAlertService` | module | Stellt die `mail_sink`-DI-Naht bereit, die den Egress-Fix trägt |
+| `src/services/notification_service.py` | module | Baut ohne `mail_sink` einen echten `EmailOutput(...).send(...)` auf realer SMTP-Konfiguration |
+| `.github/workflows/*` (`test`-Check) | ci | Kollektiert `tests/tdd/` abzüglich der Excludes-Liste — Zielort dieses Fixes |
+
+## Scope
+
+### Affected Files
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `tests/tdd/test_issue_818_radar_briefing_integration.py` | MODIFY | `mail_sink`-Parameter in `test_ac7_mandantentrennung_isolated()` (Zeile ~585-589) ergänzen, exakt nach dem Muster von `test_ac6_radar_throttle_via_alert_state_cooldown()` (Zeile 500-553): ein `lambda subject, body: captured.append((subject, body))` als Callable, kein `unittest.mock` |
+| `.github/ci_tdd_excludes.txt` | MODIFY | Beide Einträge (Zeilen 77-78) entfernen |
+| `tests/tdd/test_issue_822_radar_nowcast_segment.py` | keine Code-Änderung | wird durch das Entfernen aus der Excludes-Liste automatisch mit-kollektiert; `test_ac8_mandantentrennung_isolated()` (799-868) setzt bereits `send_email=False, send_telegram=False, alert_on_changes=False` — kein Egress-Risiko |
+
+### Estimated Changes
+- Files: 2 (Code + Excludes-Liste), 1 Datei ohne Änderung
+- LoC: +3/-2
+
+## Implementation Details
+
+`test_ac7_mandantentrennung_isolated()` konstruiert aktuell `TripAlertService(...)` ohne den
+`mail_sink`-Parameter, den `trip_alert.py:140` bereits vorsieht ("Optional
+callable(subject, body) — captures mail calls in tests"). Da der zugrundeliegende Trip
+`report_config.send_email=True` und `alert_channels=None` hat, liefert
+`_effective_alert_channels()` (`trip_alert.py:1553-1591`) den Legacy-Default `{"email"}`, und
+`notification_service.py:1432-1440` baut ohne Sink einen echten `EmailOutput(...).send(...)`
+auf — Egress-Risiko der Klasse #1477.
+
+Fix: `mail_sink=lambda subject, body: captured.append((subject, body))` an beiden
+`TripAlertService(...)`-Konstruktionsstellen in dieser Testfunktion ergänzen (Zeile ~585-589),
+identisch zur bereits korrekten Bauform in `test_ac6_...`. Danach die zwei Zeilen aus
+`.github/ci_tdd_excludes.txt` streichen. Keine Produktivcode-Änderung nötig.
+
+`test_issue_822_radar_nowcast_segment.py` benötigt keine Code-Änderung — die Streichung aus
+der Excludes-Liste genügt, da das Datei-Äquivalent bereits ohne aktive Kanäle testet.
+
+## Test Plan
+
+### Automated Tests (TDD RED)
+- [ ] Test 1 (Egress-Guard, Erweiterung von `test_ac7_mandantentrennung_isolated`): GIVEN eine `TripAlertService`-Instanz mit gesetztem `mail_sink`-Callable und einem Trip mit `send_email=True` WHEN `check_radar_alerts()` einen Alert für `uid_a` auslöst THEN landet der Versand ausschließlich im `captured`-Callback (Egress-Nachweis über den DI-Seam), es wird kein `smtplib`/`EmailOutput`-Sende-Call gegen echte SMTP-Konfiguration ausgelöst.
+- [ ] Test 2 (Collector-Nachweis, `--collect-only`): GIVEN beide Zeilen für #818 und #822 sind aus `ci_tdd_excludes.txt` entfernt WHEN `uv run pytest tests/tdd/test_issue_818_radar_briefing_integration.py tests/tdd/test_issue_822_radar_nowcast_segment.py --collect-only -q` läuft THEN meldet der Collector eine Testanzahl > 0 für beide Dateien (keine stille Marker-Deselektion, da beide Dateien modulweit markerlos sind).
+
+## Acceptance Criteria
+
+- **AC-1:** Given `test_ac7_mandantentrennung_isolated()` läuft mit gesetztem `mail_sink`-Callable (Muster von `test_ac6_...` übernommen) / When `check_radar_alerts()` für `uid_a` einen Radar-Alert auslöst / Then wird der Mailversand ausschließlich über den DI-Callback abgefangen — es entsteht kein realer `EmailOutput(...).send(...)`-Aufruf gegen die produktive SMTP-Konfiguration der Host-`.env` (Egress-Nachweis, nicht bloß „Test besteht grün").
+- **AC-2:** Given `.github/ci_tdd_excludes.txt` enthält nach dem Fix keine Zeile mehr für `test_issue_818_radar_briefing_integration.py` und `test_issue_822_radar_nowcast_segment.py` / When `uv run pytest tests/tdd/test_issue_818_radar_briefing_integration.py tests/tdd/test_issue_822_radar_nowcast_segment.py --collect-only -q` ausgeführt wird / Then zeigt die Ausgabe für beide Dateien zusammen eine Testanzahl größer 0 — kein modulweiter Marker deselektiert die Dateien still aus der CI-Kollektion.
+- **AC-3:** Given beide Dateien sind aus der Excludes-Liste entfernt und der Egress-Fix in AC-1 ist umgesetzt / When `uv run pytest tests/tdd/test_issue_818_radar_briefing_integration.py tests/tdd/test_issue_822_radar_nowcast_segment.py -v` lokal läuft / Then bestehen alle 15 Tests beider Dateien grün (bereits vorab gemessen: 15/15), sodass die Dateien im nächsten CI-`test`-Check ohne Exclude-Eintrag mitlaufen.
+
+## Known Limitations
+
+- Bei einem lokalen Vorab-Lauf mit `--allow-hosts=127.0.0.1,::1` blieb `test_ac7_mandantentrennung_isolated` trotz geblockter Netzwerkverbindung grün — die Socket-Connect-Exception wird offenbar irgendwo im Versandpfad verschluckt statt sichtbar zu scheitern. Das ist ein separater, kleinerer Fund und kein Teil dieses Fixes: Der hier umgesetzte Fix behebt die Egress-**Ursache** (kein realer Versandaufbau mehr durch die `mail_sink`-Naht), nicht die verschluckte Exception selbst. Der Fund gehört in das rollierende Sammel-Issue #1199.
+- Diese Scheibe schließt #1697 vollständig ab: Der Kern-Bug (Server-Tag statt Ortstag), der Briefing-Pfad und die Muster-A-Restliste des Zeitzonen-Wächters sind bereits vor diesem Workflow erledigt (siehe `docs/context/fix-1697-radar-waechter-in-ci.md`). Mit Umsetzung dieser Spec kann Issue #1697 geschlossen werden. Alle weiteren, nicht hier abgedeckten Zeitzonen-/Radar-Themen gehören zu #1727 S5e.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Testinfrastruktur-Änderung (DI-Naht-Nutzung + CI-Excludes-Pflege), keine Entscheidungsfläche im Sinne der ADR-Pflicht (Kanäle, Provider, Datenmodell, Auth, Editor-Paradigma, Test-/Deploy-Strategie bleiben unverändert).
+
+## Changelog
+
+- 2026-08-16: Initial spec created

--- a/tests/tdd/test_issue_818_radar_briefing_integration.py
+++ b/tests/tdd/test_issue_818_radar_briefing_integration.py
@@ -558,11 +558,19 @@ def test_ac6_radar_throttle_via_alert_state_cooldown():
 # AC-7: Mandantentrennung — REGRESSION-GUARD
 # --------------------------------------------------------------------------
 
-def test_ac7_mandantentrennung_isolated():
+def test_ac7_mandantentrennung_isolated(caplog):
     """AC-7: REGRESSION-GUARD — Lauf unter uid_a berührt data/users/uid_b/ nicht.
 
     Kann vor Implementierung bereits grün sein.
+
+    #1697 Egress-Guard: ohne `mail_sink` baut notification_service.py einen
+    echten `EmailOutput(...).send()` auf — SMTP-Egress gegen die (ggf.
+    produktive) Host-Konfiguration statt eines DI-Seams. `smtp_host=
+    "test.invalid"` (RFC 2606, garantiert nicht auflösbar) macht den
+    Fehlversuch DNS-seitig sofort sichtbar, ohne echtes Netz zu benötigen
+    und unabhängig davon, ob eine Host-`.env` echte SMTP-Creds bereitstellt.
     """
+    from app.config import Settings
     from services.trip_alert import TripAlertService
     from services.radar_service import RadarNowcastService
 
@@ -582,12 +590,39 @@ def test_ac7_mandantentrennung_isolated():
         dir_b = _data_root_users() / uid_b
         files_before = {p: p.stat().st_mtime for p in dir_b.rglob("*") if p.is_file()}
 
-        # Lauf unter uid_a
-        svc_a = TripAlertService(
-            throttle_hours=2, user_id=uid_a,
-            radar_service=RadarNowcastService(frame_source=_wet_frames),
+        # #1697 Egress-Guard: Dummy-SMTP macht can_send_email() deterministisch
+        # True, unabhängig von Host-.env (Muster aus test_feature_656).
+        settings = Settings(
+            smtp_host="test.invalid", smtp_user="u", smtp_pass="p",
+            mail_to="x@example.com",
         )
-        svc_a.check_radar_alerts()
+        assert settings.can_send_email() is True, (
+            "AC-7: Dummy-SMTP-Settings müssen can_send_email() deterministisch "
+            "True liefern, unabhängig von Host-.env (Adversary-Finding F002)."
+        )
+
+        # Lauf unter uid_a
+        captured: list = []
+        with caplog.at_level("ERROR"):
+            svc_a = TripAlertService(
+                throttle_hours=2, user_id=uid_a,
+                radar_service=RadarNowcastService(frame_source=_wet_frames),
+                settings=settings,
+                mail_sink=lambda subject, body: captured.append((subject, body)),
+            )
+            svc_a.check_radar_alerts()
+
+        assert len(captured) == 1, (
+            "AC-7: mail_sink muss für den ausgelösten Radar-Alert genau einmal "
+            "aufgerufen werden — sonst prüft die Egress-Guard-Assertion nur einen "
+            "vacuous pass (Adversary-Finding F001)."
+        )
+
+        assert "Radar alert email failed" not in caplog.text, (
+            "AC-7 Egress-Guard (#1697): ohne mail_sink versucht der Alarm "
+            "echten SMTP-Versand (EmailOutput) statt des DI-Seams zu "
+            f"nutzen — Fehlerlog: {caplog.text}"
+        )
 
         # uid_b-Dateien müssen unberührt bleiben
         for p in dir_b.rglob("*"):

--- a/tests/tdd/test_issue_818_radar_briefing_integration.py
+++ b/tests/tdd/test_issue_818_radar_briefing_integration.py
@@ -286,6 +286,7 @@ def test_ac2_unannounced_rain_triggers_radar_alert():
     RED-Treiber: check_radar_alerts sendet Alert, aber der Body enthält den neuen
     Text "im Briefing nicht angekündigt" noch nicht → AssertionError.
     """
+    from app.config import Settings
     from services.trip_alert import TripAlertService
     from services.radar_service import RadarNowcastService
 
@@ -303,6 +304,10 @@ def test_ac2_unannounced_rain_triggers_radar_alert():
         svc = TripAlertService(
             throttle_hours=2, user_id=uid,
             radar_service=RadarNowcastService(frame_source=_wet_frames),
+            settings=Settings(
+                smtp_host="test.invalid", smtp_user="u", smtp_pass="p",
+                mail_to="x@example.com",
+            ),
             mail_sink=lambda subject, body: captured.append((subject, body)),
         )
 
@@ -332,6 +337,7 @@ def test_ac3_missing_snapshot_fallback_sends_alert():
     Schützt vor Regression: Briefing-Check darf fehlenden Snapshot nicht als
     "kein Regen" interpretieren. Kann vor Implementierung bereits grün sein.
     """
+    from app.config import Settings
     from services.trip_alert import TripAlertService
     from services.radar_service import RadarNowcastService
 
@@ -347,6 +353,10 @@ def test_ac3_missing_snapshot_fallback_sends_alert():
         svc = TripAlertService(
             throttle_hours=2, user_id=uid,
             radar_service=RadarNowcastService(frame_source=_wet_frames),
+            settings=Settings(
+                smtp_host="test.invalid", smtp_user="u", smtp_pass="p",
+                mail_to="x@example.com",
+            ),
             mail_sink=lambda subject, body: captured.append((subject, body)),
         )
 
@@ -508,6 +518,7 @@ def test_ac6_radar_throttle_via_alert_state_cooldown():
 
     Teil 2: Zweiter Lauf innerhalb Cooldown → kein Alert (unverändert).
     """
+    from app.config import Settings
     from services.trip_alert import TripAlertService
     from services.radar_service import RadarNowcastService
     from services.throttle_store import ThrottleStore
@@ -519,10 +530,16 @@ def test_ac6_radar_throttle_via_alert_state_cooldown():
         trip_id = f"tdd-818-ac6-{uuid.uuid4().hex[:6]}"
         _save_trip_direct(_make_active_trip(trip_id), uid)
 
+        settings = Settings(
+            smtp_host="test.invalid", smtp_user="u", smtp_pass="p",
+            mail_to="x@example.com",
+        )
+
         captured: list = []
         svc = TripAlertService(
             throttle_hours=2, user_id=uid,
             radar_service=RadarNowcastService(frame_source=_wet_frames),
+            settings=settings,
             mail_sink=lambda subject, body: captured.append((subject, body)),
         )
 
@@ -544,6 +561,7 @@ def test_ac6_radar_throttle_via_alert_state_cooldown():
         svc2 = TripAlertService(
             throttle_hours=2, user_id=uid,
             radar_service=RadarNowcastService(frame_source=_wet_frames),
+            settings=settings,
             mail_sink=lambda subject, body: captured.append((subject, body)),
         )
         count2 = svc2.check_radar_alerts()

--- a/tests/tdd/test_issue_822_radar_nowcast_segment.py
+++ b/tests/tdd/test_issue_822_radar_nowcast_segment.py
@@ -472,6 +472,7 @@ def test_ac4_mail_body_contains_segment_label_and_cooldown():
     Kein SMTP nötig (mail_sink fängt Body ab). Kein Mock.
     """
     import math
+    from app.config import Settings
     from services.trip_alert import TripAlertService
     from services.radar_service import RadarNowcastService
 
@@ -512,6 +513,10 @@ def test_ac4_mail_body_contains_segment_label_and_cooldown():
         svc = TripAlertService(
             throttle_hours=2, user_id=uid,
             radar_service=RadarNowcastService(frame_source=_wet_frames),
+            settings=Settings(
+                smtp_host="test.invalid", smtp_user="u", smtp_pass="p",
+                mail_to="x@example.com",
+            ),
             mail_sink=_sink,
         )
         svc.clear_radar_throttle(trip_id)
@@ -624,6 +629,7 @@ def test_ac6_cooldown_display_reflects_trip_setting():
 
     Kein SMTP (mail_sink), kein Mock.
     """
+    from app.config import Settings
     from services.trip_alert import TripAlertService
     from services.radar_service import RadarNowcastService
 
@@ -661,6 +667,10 @@ def test_ac6_cooldown_display_reflects_trip_setting():
         svc_90 = TripAlertService(
             throttle_hours=2, user_id=uid_90,
             radar_service=RadarNowcastService(frame_source=_wet_frames),
+            settings=Settings(
+                smtp_host="test.invalid", smtp_user="u", smtp_pass="p",
+                mail_to="x@example.com",
+            ),
             mail_sink=_sink_90,
         )
         svc_90.clear_radar_throttle(trip_id_90)
@@ -690,6 +700,10 @@ def test_ac6_cooldown_display_reflects_trip_setting():
         svc_2h = TripAlertService(
             throttle_hours=2, user_id=uid_2h,
             radar_service=RadarNowcastService(frame_source=_wet_frames),
+            settings=Settings(
+                smtp_host="test.invalid", smtp_user="u", smtp_pass="p",
+                mail_to="x@example.com",
+            ),
             mail_sink=_sink_2h,
         )
         svc_2h.clear_radar_throttle(trip_id_2h)


### PR DESCRIPTION
## Summary
- Zwei Regressionswaechter-Testdateien fuer die Radar-Alarm-Kette (#818, #822) liefen wegen Eintraegen in `.github/ci_tdd_excludes.txt` nicht im CI-`test`-Check mit.
- Vor dem Entfernen der Excludes wurde ein Egress-Risiko geschlossen: `test_ac7_mandantentrennung_isolated` baute ohne `mail_sink` einen echten `EmailOutput(...).send()`-Aufruf gegen die produktive SMTP-Konfiguration auf, statt den bereits vorhandenen DI-Seam zu nutzen.
- Adversary-Dialog (4 Runden, zuletzt Freshness-Refresh ohne Code-Aenderung) bestaetigt VERIFIED; Mutationsproben (mail_sink entfernt, Doppel-Realversand simuliert) fangen den Egress-Fix strukturell.

## Test plan
- [x] `uv run pytest tests/tdd/test_issue_818_radar_briefing_integration.py tests/tdd/test_issue_822_radar_nowcast_segment.py -v` — 15 passed
- [x] `uv run pytest ... --collect-only -q` — Collector-Nachweis 7+8=15 Tests, keine stille Marker-Deselektion
- [x] Volle Python-Suite CI-Parity lokal: 9348 passed, 2 failed (beide vorbestehend, unabhaengig von diesem Change, bereits in #1196 dokumentiert)
- [x] Adversary Verdict: VERIFIED (4 Runden, docs/artifacts/fix-1697-radar-waechter-in-ci/adversary-dialog.md)

Bezug: #1697

🤖 Generated with [Claude Code](https://claude.com/claude-code)