### PR TITLE
fix(#1714): Ortsvergleich-Briefing vermerkt gezeigte amtliche Warnungen

### DIFF
--- a/docs/context/fix-1714-compare-alert-dedup.md
+++ b/docs/context/fix-1714-compare-alert-dedup.md
@@ -1,0 +1,132 @@
+# Context: fix-1714-compare-alert-dedup
+
+## Request Summary
+Das Ortsvergleich-Briefing zeigt amtliche Warnungen an, vermerkt sie aber nicht im
+Melde-Gedächtnis. Der unabhängige Ortsvergleich-Prüfer (Alarm-Checker, alle 15 Min) kennt
+diese Warnungen deshalb nicht als „bereits gemeldet" und verschickt dieselbe, unveränderte
+Warnung kurz darauf erneut als eigenständigen Alarm. Der Trip-Pfad hat diese Lücke bereits
+seit #1614 geschlossen — der Ortsvergleich-Pfad bekam das Gegenstück nie.
+
+## Related Files
+| File | Relevance |
+|------|-----------|
+| `src/services/scheduler_dispatch_service.py` (`send_one_compare_preset`, ~L350-580) | Versendet das Compare-Briefing. Ruft `NotificationService.send_compare_report(...)` **ohne den Rückgabewert zu erfassen** und danach `_anchor_and_reset()`. Genau hier fehlt der Aufruf von `record_official_alerts_reported` — das exakte Analogon zu `trip_report_scheduler.py:1638-1645`. |
+| `src/services/alert_briefing_anchor.py` (`record_official_alerts_reported`, L312-343) | DIE geteilte Schreib-Logik fürs Melde-Gedächtnis (`official_alert:`-Namensraum). Signatur: `(*, user_id, entity_id, alerts)`. Fail-soft No-Op bei leerer Liste. Für Compare ist `entity_id = f"{preset_id}:{loc.id}"` (bereits das etablierte Kennungs-Schema für Compare-Anker, s. `_anchor_and_reset`). |
+| `src/services/compare_official_alert.py` (`_record_state`, L313-322; `_detect`, L221-260) | Der ALARM-CHECKER-seitige Lesepfad. `_detect()` lädt State über `AlertStateService(user_id).load(f"{preset_id}:{loc_id}")` und entscheidet über `official_alert_revision_verdict()`, ob eine Warnung neu/eskaliert ist. `_record_state` ist eine **eigene Inline-Kopie** derselben Schreib-Logik wie `record_official_alerts_reported` — schreibt aber nur NACH eigenem Alarmversand, nie aus dem Briefing-Pfad. Genau diese fehlende zweite Schreibquelle ist der Bug. |
+| `src/services/comparison_engine.py` (`run_comparison_parallel`, L300-340ff.) | Liefert `result.locations: list[LocationResult]`, jedes Element trägt `.official_alerts: list[OfficialAlert]` (leer wenn `official_alerts_enabled=False` oder Fetch-Fehler) und `.location.id`. Das ist die Quelle für die im Briefing gezeigten Warnungen je Ort. |
+| `src/services/notification_service.py` (`send_compare_report`, L956ff., `NotificationResult`, L114ff.) | Gibt `NotificationResult` mit `.sent: bool` zurück — aktuell am Aufrufort verworfen. Muss erfasst werden, um (analog Trip) nur bei tatsächlichem Versand zu vermerken. |
+| `src/services/trip_report_scheduler.py` (L1629-1646) | Vorbild-Pfad (Trip-Seite, #1614 Teil 1): `if result.sent and not on_demand: ... record_official_alerts_reported(user_id=..., entity_id=trip.id, alerts=all_official_alerts)` — direkt VOR `_anchor_and_reset()`. |
+| `tests/tdd/test_alert_state_briefing_reset.py` | Test-Vorbild für die Trip-Seite: u. a. `test_briefing_meldet_unveraenderte_amtliche_warnung_danach_nicht_erneut`, `test_eskalierte_warnung_wird_trotz_bereits_gemeldeter_unveraenderter_warnung_weiterhin_gemeldet`, `test_ad_hoc_abruf_schreibt_das_melde_gedaechtnis_amtlicher_warnungen_nicht`, `test_fehlgeschlagener_versand_schreibt_das_melde_gedaechtnis_nicht`. Diese Namen/Fälle 1:1 auf Compare spiegeln (neue Testdatei oder Ergänzung, TDD-RED entscheidet Ablage). |
+
+## Existing Patterns
+- **Geteilter Schreibbaustein statt Kopie** (#1467 S2 AG5, PO-Vorgabe „verwende zwingend den
+  gleichen Code"): `record_official_alerts_reported` und `reset_alert_memory` sind bereits die
+  EINE Fassung für Trip UND Compare — nur der Aufruf-Ort im Compare-Briefing-Pfad fehlt.
+- **`on_demand` schützt Ad-hoc-Abrufe** (#1007/#1467 S2 AG5): sowohl Trip als auch Compare
+  dürfen bei Handversand (`on_demand=True`) das Melde-Gedächtnis nicht anfassen. Die neue
+  Schreibung muss `not on_demand` genauso gaten wie `_anchor_and_reset()` es bereits tut.
+- **Vor `_anchor_and_reset()`, im try-Block, nur bei `result.sent`**: Trip-Vorbild platziert
+  den Record-Aufruf VOR dem Anker/Reset, gated auf tatsächlichen Versand — Fehlerpfad
+  (Exception im Versand) darf nichts vermerken, sonst gälte eine nie zugestellte Warnung
+  fälschlich als „gemeldet".
+- **Kennungs-Schema Compare**: `f"{preset_id}:{loc.id}"` durchgängig für Alarm-State UND
+  Delta-Anker (NICHT `preset_id` allein — das ist reserviert für die Briefing-Protokoll-Kennung,
+  s. `briefing_entity_id=preset_id` in `_anchor_and_reset`).
+
+## Dependencies
+- Upstream: `send_one_compare_preset()` wird von zwei Stellen gerufen — dem Daily-Loop
+  (`run_compare_presets_daily`, `on_demand` je nach Aufruf) und dem Einzelversand
+  (`send_compare_preset`, IMMER `on_demand=True`, s. Docstring L590-593). Der Fix wirkt also
+  automatisch nicht bei Handversand — korrekt nach Vorbild.
+- Downstream: `compare_official_alert.py::_detect()` liest denselben State-Namensraum
+  (`AlertStateService(user_id).load(f"{preset_id}:{loc_id}")`) über
+  `official_alert_revision_verdict()`. Kein Code-Wechsel dort nötig — der Fix liefert dem
+  Lesepfad nur zusätzliche Einträge.
+
+## Existing Specs
+- `docs/specs/modules/fix_1614_briefing_warnfenster.md` — Trip-seitiges Vorbild (#1614 Teil 1),
+  ACs dort sind die Vorlage für die Compare-Spiegelung laut Issue-Text.
+- `docs/specs/modules/rework_1467_s4b_entdopplung.md` — Ereignis-Identität-Entdopplung
+  (anderer Mechanismus, thematisch benachbart, **kein** Überschneidungscode).
+
+## Analysis
+
+### Type
+Bug (nutzersichtbares Fehlverhalten — Doppelversand derselben amtlichen Warnung).
+
+Kein Subagenten-Dispatch nötig: Der Standard-Track kombiniert Context+Analyse (CLAUDE.md), und
+die Kontext-Phase hat bereits den vollständigen, direkt am Code verifizierten Befund geliefert
+(exakte Zeilen, exakter Vorbild-Pfad, exaktes Kennungs-Schema) — ein Re-Dispatch würde nur
+dieselbe bereits gelesene Quelle erneut durchsuchen.
+
+### Affected Files (with changes)
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/services/scheduler_dispatch_service.py` | MODIFY | `send_one_compare_preset`: Rückgabewert von `NotificationService.send_compare_report(...)` erfassen (aktuell verworfen). Direkt danach, noch im try-Block, vor `_anchor_and_reset()`: bei `send_result.sent and not on_demand` je Ort mit gezeigten `official_alerts` `record_official_alerts_reported(user_id=..., entity_id=f"{preset_id}:{loc.id}", alerts=...)` aufrufen — analog `trip_report_scheduler.py:1638-1645`, aber PRO ORT statt einmal aggregiert (Compare-Kennung ist ortsbezogen). |
+| `tests/tdd/test_compare_official_alert_briefing_reset.py` (neu) | CREATE | Spiegelt die relevanten Fälle aus `tests/tdd/test_alert_state_briefing_reset.py` auf den Compare-Pfad: unveränderte Warnung nach Briefing nicht erneut gemeldet · eskalierte Warnung trotzdem gemeldet · `on_demand=True` fasst das Melde-Gedächtnis nicht an · fehlgeschlagener Versand (Exception im try-Block) schreibt nichts · zwei Nutzer bleiben getrennt (Mandantentrennung, CLAUDE.md-Pflicht) · zwei Orte im selben Preset — ein still übersprungener Ort verliert sein Melde-Gedächtnis nicht (R3-Analogie). |
+
+### Scope Assessment
+- Files: 2 (1 MODIFY, 1 CREATE)
+- Estimated LoC: production ~15-20 (Rückgabewert erfassen + Schleife über Orte + Gate),
+  Tests ~150-220 (6 Fallgruppen, mehrere davon brauchen echten Preset-/Location-Fixture-Aufbau
+  wie im Trip-Vorbild)
+- Risk Level: MEDIUM — kein neuer Mechanismus (reine Verdrahtung eines bereits geteilten,
+  produktiv erprobten Bausteins), aber Service-Schnittstelle mit Mandanten-Zustand und
+  koordinierter Parallel-Arbeit an derselben Datei-Familie (#1657, Schlüsselformat)
+
+### Technical Approach
+1. `send_result = NotificationService(settings, user_id).send_compare_report(...)` — Rückgabewert
+   binden statt verwerfen.
+2. Direkt danach, noch innerhalb des bestehenden `try`-Blocks (Fehlerpfad bleibt dadurch
+   automatisch ausgeschlossen — Exception springt vorher in den `except`-Zweig):
+   ```python
+   if send_result.sent and not on_demand:
+       from services.alert_briefing_anchor import record_official_alerts_reported
+       for loc_result in result.locations:
+           if loc_result.official_alerts:
+               record_official_alerts_reported(
+                   user_id=user_id,
+                   entity_id=f"{preset_id}:{loc_result.location.id}",
+                   alerts=loc_result.official_alerts,
+               )
+   ```
+3. Kein Eingriff in `compare_official_alert.py` (`_detect`/`_record_state` unverändert) — die
+   Refactoring-Frage aus dem Issue („Kopie durch geteilte Fassung ersetzen?") wird NICHT
+   mitgezogen, um die Scheibe minimal und den Blast Radius auf den Briefing-Aufrufpfad
+   beschränkt zu halten.
+4. Reihenfolge zu `_anchor_and_reset()`: VOR dem Aufruf, wie im Trip-Vorbild kommentiert
+   („VOR write_anchor_and_reset_memory, damit ein Exception-Pfad dort das Record nicht
+   verschluckt" — Reihenfolge-Invariante 1:1 übernehmen).
+
+### Dependencies
+Siehe Context-Abschnitt oben — keine neuen Abhängigkeiten, nur ein zusätzlicher Aufruf eines
+bereits vorhandenen, geteilten Bausteins.
+
+### Open Questions
+- [ ] Test-Dateiname/-Ablage: neue Datei vs. Ergänzung in einer bestehenden Compare-Testdatei —
+  wird in TDD-RED entschieden, nicht spec-relevant.
+- [ ] Aus dem Issue übernommene, aber bewusst NICHT in dieser Scheibe behandelte Frage: soll
+  `compare_official_alert.py::_record_state` künftig an `record_official_alerts_reported`
+  delegieren (Teilungsregel, CLAUDE.md)? Empfehlung: separates Nebenbefund-Ticket (#1199), nicht
+  Teil der Akzeptanz hier — Scope-Disziplin vor Perfektionismus.
+
+## Risks & Considerations
+- **Geteilter Zustand mit Parallel-Arbeit an #1657** (koordiniert, andere Session): #1657 ändert
+  möglicherweise das Schlüsselformat in `official_alert_state_key()`
+  (`valid_from`/`valid_to`-Anteil). Diese Scheibe ändert den Schlüssel NICHT, nur die
+  Schreibhäufigkeit/-quelle — sollte orthogonal sein. Vor Commit an genau dieser Funktion:
+  Rücksprache halten (bereits zugesagt).
+- **Kein neuer State-Namensraum, keine Migration** — reine Verdrahtung, kein Schema-Rework.
+- **Zwei Aufrufstellen von `send_one_compare_preset`**: Fix muss in der GEMEINSAMEN Funktion
+  sitzen (nicht an einer der beiden Call-Sites), sonst gilt er nur für einen Pfad.
+- **Mandantentrennung**: `record_official_alerts_reported` nimmt `user_id` explizit entgegen —
+  `send_one_compare_preset` hat bereits `user_id` als Parameter. Test mit zwei Nutzern PFLICHT
+  (CLAUDE.md-Vorgabe).
+- **Batch-Teilfilterung nicht betroffen**: Diese Scheibe schreibt nur das Melde-Gedächtnis nach
+  erfolgreichem Briefing-Versand — die im Issue erwähnte Frage „darf eine gesunde Warnung nicht
+  mit einem Duplikat zusammen verschluckt werden" betrifft den ALARM-Checker-Batch-Pfad
+  (`compare_official_alert.py`), der hier unverändert bleibt.
+- **Kein Anlass, `_record_state` in `compare_official_alert.py` durch den geteilten Baustein zu
+  ersetzen** — das im Issue als „zu prüfen" genannte Refactoring ist optional, nicht
+  Teil der Akzeptanz. Bei Zeitdruck: nur verdrahten, Kopie unangetastet lassen; die Spec-Phase
+  entscheidet verbindlich.

--- a/docs/specs/modules/fix_1714_compare_alert_briefing_reset.md
+++ b/docs/specs/modules/fix_1714_compare_alert_briefing_reset.md
@@ -1,0 +1,184 @@
+---
+entity_id: fix_1714_compare_alert_briefing_reset
+type: bugfix
+created: 2026-08-17
+updated: 2026-08-17
+status: draft
+workflow: fix-1714-compare-alert-dedup
+---
+
+# Fix #1714: Ortsvergleich-Briefing vermerkt gezeigte amtliche Warnungen nicht im Melde-Gedächtnis
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Das Ortsvergleich-Briefing (`send_one_compare_preset`) zeigt amtliche Warnungen im
+versendeten Bericht an, schreibt sie aber nie ins Melde-Gedächtnis
+(`official_alert:`-Namensraum). Der unabhängige, alle 15 Minuten laufende
+Ortsvergleich-Alarm-Checker (`compare_official_alert.py`) kennt diese Warnungen deshalb
+nicht als „bereits gemeldet" und verschickt dieselbe, unveränderte Warnung kurz danach
+erneut als eigenständigen Alarm. Der Trip-Pfad hat exakt diese Lücke bereits seit #1614
+Teil 1 geschlossen (`trip_report_scheduler.py:1638-1645`, ruft den geteilten Baustein
+`record_official_alerts_reported()` aus `alert_briefing_anchor.py` auf). Diese Spec
+verdrahtet das fehlende Compare-Gegenstück — kein neuer Mechanismus, reine Nutzung eines
+bereits geteilten, produktiv erprobten Bausteins.
+
+## Source
+
+- **File:** `src/services/scheduler_dispatch_service.py`
+- **Identifier:** `send_one_compare_preset` (Zeile 350, Versandblock ab Zeile 546)
+
+## Estimated Scope
+
+- **LoC:** ~15-20 Produktivcode, ~150-220 Tests
+- **Files:** 2 (1 MODIFY, 1 CREATE)
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `services.alert_briefing_anchor.record_official_alerts_reported` | function | Bereits bestehende, geteilte Schreib-Logik fürs Melde-Gedächtnis (`official_alert:`-Namensraum). Signatur `(*, user_id, entity_id, alerts)`, fail-soft No-Op bei leerer `alerts`-Liste. Wird hier nur ZUSÄTZLICH aufgerufen, nicht verändert. |
+| `services.notification_service.NotificationService.send_compare_report` | method | Liefert `NotificationResult` mit `.sent: bool`. Rückgabewert wird am Aufrufort aktuell verworfen und muss erfasst werden. |
+| `services.comparison_parallel.run_comparison_parallel` (Ergebnis `result.locations`) | data | Liefert je Ort ein `LocationResult` mit `.official_alerts: list[OfficialAlert]` und `.location.id` — Quelle für die im Briefing tatsächlich gezeigten Warnungen. |
+| `services.compare_official_alert._detect` | function (Lesepfad, unverändert) | Lädt denselben State-Namensraum über `AlertStateService(user_id).load(f"{preset_id}:{loc_id}")` — profitiert automatisch von den neuen Einträgen, kein eigener Code-Wechsel nötig. |
+
+## Implementation Details
+
+Tatsächliche Code-Struktur in `send_one_compare_preset` (verifiziert, weicht leicht vom
+Trip-Vorbild-Muster ab): der `try`-Block (Zeile 546-569) umschließt AUSSCHLIESSLICH den
+`send_compare_report`-Aufruf. Der `except`-Zweig (570-575) vermerkt den Fehlschlag,
+ruft `_anchor_and_reset()` für den Fehlerfall auf und wirft weiter (`raise`). Erst NACH
+dem try/except, im ungestörten Erfolgspfad, steht der zweite, unbedingte
+`_anchor_and_reset()`-Aufruf (Zeile 577). Ein Exception-Pfad erreicht Zeile 577 nie —
+genau deshalb muss die neue Record-Logik VOR diese Zeile, nicht in den `try`-Block
+selbst (der an dieser Stelle bereits verlassen ist):
+
+```python
+try:
+    send_result = NotificationService(settings, user_id).send_compare_report(
+        subject=subject, html_body=html_body, text_body=text_body,
+        telegram_text=..., sms_text=..., recipients=empfaenger,
+        effective_channels=..., compare_hourly_enabled=opts.hourly_enabled,
+        mail_sink=mail_sink, sms_sink=sms_sink, telegram_sink=telegram_sink,
+    )
+except Exception as exc:
+    record_briefing_dispatch_failure(...)
+    _anchor_and_reset()
+    raise
+
+if send_result.sent and not on_demand:
+    from services.alert_briefing_anchor import record_official_alerts_reported
+    for loc_result in result.locations:
+        if loc_result.official_alerts:
+            record_official_alerts_reported(
+                user_id=user_id,
+                entity_id=f"{preset_id}:{loc_result.location.id}",
+                alerts=loc_result.official_alerts,
+            )
+
+_anchor_and_reset()
+```
+
+- `send_result` (statt `result` — der Name `result` ist bereits durch das
+  Comparison-Engine-Ergebnis aus `run_comparison_parallel` belegt).
+- Kennungs-Schema pro Ort: `f"{preset_id}:{loc_result.location.id}"` — identisch zum
+  bereits etablierten Anker-Kennungs-Schema in `_anchor_and_reset()` (Zeile 526), NICHT
+  `preset_id` allein (das ist für die Briefing-Protokoll-Kennung reserviert).
+- `on_demand`-Gate zwingend: Handversand (`send_compare_preset`, immer
+  `on_demand=True`) darf das Melde-Gedächtnis nicht anfassen (#1007/#1467 S2 AG5,
+  identisch zum Trip-Ad-hoc-Pfad).
+- `send_result.sent`-Gate zwingend: ein fehlgeschlagener oder kanalloser Versand darf
+  eine nie zugestellte Warnung nicht fälschlich als „gemeldet" markieren.
+- **Kein Eingriff in `compare_official_alert.py`** (`_detect`/`_record_state` bleiben
+  unverändert) — die im Issue erwähnte Refactoring-Frage („Kopie durch geteilte Fassung
+  ersetzen") ist explizit NICHT Teil dieser Scheibe (Nebenbefund für #1199).
+- **Kein Eingriff in `official_alert_state_key()`** — das Schlüsselformat bleibt
+  unangetastet (Koordination mit paralleler #1657-Arbeit an derselben Datei-Familie).
+
+## Expected Behavior
+
+- **Input:** Ein Compare-Preset wird über `send_one_compare_preset` versendet
+  (Daily-Loop oder Einzelversand), mindestens ein Ort trägt gezeigte amtliche
+  Warnungen (`loc_result.official_alerts`).
+- **Output:** Bei erfolgreichem, nicht-ad-hoc Versand wird für jeden Ort mit gezeigten
+  Warnungen ein Eintrag im Melde-Gedächtnis (`official_alert:`-Namensraum,
+  `AlertStateService`) unter der Kennung `f"{preset_id}:{loc.id}"` geschrieben.
+- **Side effects:** Der nächste Lauf von `compare_official_alert.py::_detect()` für
+  denselben Ort liest diesen Eintrag und unterdrückt eine unveränderte Warnung als
+  Doppelmeldung — bereits bestehende Lesepfad-Logik, kein Code-Wechsel dort nötig.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Compare-Briefing wurde erfolgreich (`send_result.sent=True`,
+  `on_demand=False`) mit einer amtlichen Warnung für einen Ort versendet, When der
+  nächste Lauf von `compare_official_alert.py` für denselben Ort mit unveränderter
+  Warnung (gleiches Level) läuft, Then meldet der Checker diese Warnung NICHT erneut
+  als eigenständigen Alarm.
+  - Test: `test_briefing_meldet_unveraenderte_amtliche_warnung_danach_nicht_erneut` (Compare-Spiegelung des Trip-Vorbilds) — Kern-Regressionsschutz gegen den im Issue beschriebenen Doppelversand.
+
+- **AC-2:** Given dieselbe Ausgangslage wie AC-1 (Warnung bereits im Melde-Gedächtnis
+  vermerkt), When die Warnung danach auf ein höheres Level eskaliert, Then meldet
+  `compare_official_alert.py` die eskalierte Warnung weiterhin als neuen Trigger.
+  - Test: `test_eskalierte_warnung_wird_trotz_bereits_gemeldeter_unveraenderter_warnung_weiterhin_gemeldet` — verhindert stille Unterdrückung echter Verschärfung durch den neuen Doppelversand-Schutz.
+
+- **AC-3:** Given ein Handversand über `send_compare_preset` (immer `on_demand=True`,
+  #1007) liefert dieselbe amtliche Warnung, When der Versand abgeschlossen ist, Then
+  bleibt das Melde-Gedächtnis für den betroffenen Ort unverändert — kein neuer Eintrag
+  im `official_alert:`-Namensraum.
+  - Test: `test_ad_hoc_abruf_schreibt_das_melde_gedaechtnis_amtlicher_warnungen_nicht` — bestehende Read-only-Garantie für Handversand darf durch die neue Schreiblogik nicht verletzt werden.
+
+- **AC-4:** Given der Versand des Compare-Briefings schlägt fehl (Exception aus
+  `NotificationService.send_compare_report`, `except`-Zweig greift), When
+  `send_one_compare_preset` durchläuft, Then wird für keinen Ort ein Eintrag im
+  Melde-Gedächtnis geschrieben — eine nie zugestellte Warnung bleibt für den
+  Alarm-Checker weiterhin meldepflichtig.
+  - Test: `test_fehlgeschlagener_versand_schreibt_das_melde_gedaechtnis_nicht` — verhindert, dass ein fehlgeschlagener Versand eine Warnung fälschlich als „gemeldet" stumm schaltet.
+
+- **AC-5:** Given zwei verschiedene Nutzer (`user_id`) mit je einem Preset und je einer
+  identischen amtlichen Warnung für denselben Ort, When für Nutzer A das Briefing
+  erfolgreich versendet wird, Then bleibt das Melde-Gedächtnis von Nutzer B davon
+  vollständig unberührt.
+  - Test: `test_zwei_nutzer_bleiben_im_melde_gedaechtnis_getrennt` — Mandantentrennung, CLAUDE.md-Pflicht bei jedem nutzerbezogenen, datenbewegenden Pfad.
+
+- **AC-6:** Given ein Preset mit zwei Orten, von denen nur EINER eine amtliche Warnung
+  im Briefing zeigt, When das Briefing erfolgreich versendet wird, Then wird
+  ausschließlich für den Ort mit gezeigter Warnung ein Eintrag geschrieben — ein
+  bestehender Melde-Gedächtnis-Eintrag des anderen Ortes bleibt unverändert, nicht
+  überschrieben oder gelöscht.
+  - Test: `test_zwei_orte_im_preset_beeinflussen_sich_im_melde_gedaechtnis_nicht_gegenseitig` — R3-Analogie aus `write_anchor_and_reset_memory`-Docstring, verhindert versehentliches Cross-Orts-Überschreiben.
+
+- **AC-7:** Given ein Preset, dessen Briefing für keinen Ort amtliche Warnungen zeigt
+  (leere `official_alerts`-Liste je Ort), When das Briefing erfolgreich versendet wird,
+  Then löst der neue Codepfad KEINEN Schreibzugriff auf das Melde-Gedächtnis aus.
+  - Test: `test_preset_ohne_gezeigte_warnungen_loest_keinen_schreibzugriff_aus` — Fail-soft No-Op, spiegelt das bestehende Leer-Listen-Verhalten von `record_official_alerts_reported` selbst; kein unnötiger State-Write.
+
+## Known Limitations
+
+- **Kein Eingriff in `compare_official_alert.py::_record_state`.** Die dort bestehende
+  Inline-Kopie derselben Schreib-Logik bleibt unangetastet — ein mögliches Refactoring
+  zur Vereinheitlichung ist im Issue als offene Frage genannt, aber bewusst nicht Teil
+  dieser Scheibe (Empfehlung: Nebenbefund-Issue #1199).
+- **Kein Eingriff in das Schlüsselformat.** `official_alert_state_key()` wird von
+  dieser Spec nicht verändert — eine parallele Session arbeitet zeitgleich an #1657 an
+  genau dieser Funktion; diese Scheibe ändert nur die Schreibhäufigkeit/-quelle, nicht
+  das Schlüsselformat selbst.
+- **Zwei Aufrufstellen von `send_one_compare_preset`.** Der Fix sitzt in der
+  gemeinsamen Funktion (Daily-Loop `run_compare_presets_daily` UND Einzelversand
+  `send_compare_preset`) — wirkt dadurch für den Daily-Loop-Pfad automatisch, für den
+  Einzelversand-Pfad greift korrekt das `on_demand`-Gate (kein Schreibzugriff dort).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Verdrahtung eines bereits bestehenden, geteilten Bausteins
+  (`record_official_alerts_reported`, eingeführt mit #1614 Teil 1) an eine bislang
+  fehlende Aufrufstelle — kein neuer Mechanismus, kein neues Datenmodell, keine neue
+  Architekturentscheidung.
+
+## Changelog
+
+- 2026-08-17: Initial spec created.

--- a/src/services/scheduler_dispatch_service.py
+++ b/src/services/scheduler_dispatch_service.py
@@ -544,7 +544,7 @@ def send_one_compare_preset(
     # ausschliesslich den Versandaufruf (AC-10), danach fliegt die Ausnahme
     # unveraendert weiter.
     try:
-        NotificationService(settings, user_id).send_compare_report(
+        send_result = NotificationService(settings, user_id).send_compare_report(
             subject=subject,
             html_body=html_body,
             text_body=text_body,
@@ -573,6 +573,20 @@ def send_one_compare_preset(
         )
         _anchor_and_reset()
         raise
+
+    # Issue #1714: im Briefing gezeigte amtliche Warnungen als „gemeldet"
+    # vermerken, damit der unabhaengige Checker sie nicht kurz darauf erneut
+    # als eigenen Alarm verschickt (Trip-Gegenstueck seit #1614 Teil 1).
+    if send_result.sent and not on_demand:
+        from services import alert_briefing_anchor
+
+        for loc_result in result.locations:
+            if loc_result.official_alerts:
+                alert_briefing_anchor.record_official_alerts_reported(
+                    user_id=user_id,
+                    entity_id=f"{preset_id}:{loc_result.location.id}",
+                    alerts=loc_result.official_alerts,
+                )
 
     _anchor_and_reset()
 

--- a/tests/tdd/test_compare_alert_dedup_briefing_reset.py
+++ b/tests/tdd/test_compare_alert_dedup_briefing_reset.py
@@ -1,0 +1,624 @@
+"""TDD RED — Issue #1714: Ortsvergleich-Briefing vermerkt gezeigte amtliche
+Warnungen nicht im Melde-Gedaechtnis (`official_alert:`-Namensraum).
+
+SPEC: docs/specs/modules/fix_1714_compare_alert_briefing_reset.md (AC-1..AC-7)
+Trip-Vorbild: `tests/tdd/test_alert_state_briefing_reset.py` (Issue #1614 Teil 1),
+`record_official_alerts_reported` selbst bleibt unveraendert (bereits produktiv).
+
+RED-Ursache (heute): `send_one_compare_preset`
+(`services/scheduler_dispatch_service.py`) ruft `record_official_alerts_reported`
+an keiner Stelle auf. Alle Tests unten muessen deshalb heute rot sein — entweder
+weil der `official_alert:`-Eintrag im Melde-Gedaechtnis fehlt (AC-1, AC-5, AC-6),
+oder weil der unabhaengige Checker eine unveraenderte Warnung erneut meldet
+(AC-1 als Kern-Regressionsschutz).
+
+Testpolitik: kein Mock-Theater. Alle Naehte sind entweder echte, kleine
+Implementierungen desselben Protokolls (Vergleichs-Engine, Wetterquelle des
+Δ-Anker-Schreibers, amtliche Warnquelle) oder echte Zustands-Dateien auf
+Platte — Haus-Muster aus `test_compare_briefing_anchor_and_memory_reset.py`
+und `test_compare_official_alert.py`.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from app.config import Settings
+from app.models import ForecastDataPoint, SegmentWeatherSummary, ThunderLevel
+from app.user import SavedLocation
+from services.official_alerts.models import OfficialAlert
+
+from tests.helpers.compare_briefings import write_compare_briefings
+
+TARGET_DATE = date.today()
+
+_NOW = datetime.now(timezone.utc)
+_VALID_FROM = _NOW - timedelta(hours=1)
+_VALID_TO = _NOW + timedelta(hours=23, minutes=59)
+
+# Versand-Sicherheit (#1477): `Settings(...)` faellt bei fehlenden Feldern
+# still auf die Prod-`.env` im Worktree zurueck — alle Transport-Felder daher
+# ausdruecklich auf unbrauchbare Werte gesetzt.
+_NO_TRANSPORT_FIELDS: dict = {
+    "smtp_host": "dummy.invalid", "smtp_user": "dummy", "smtp_pass": "dummy",
+    "mail_to": "tdd-1714-dummy@example.invalid",
+    "test_smtp_host": "dummy.invalid", "test_smtp_user": "dummy",
+    "test_smtp_pass": "dummy", "test_mail_from": "tdd-1714-dummy@example.invalid",
+    "telegram_bot_token": "", "telegram_chat_id": "",
+    "telegram_test_bot_token": "", "telegram_test_chat_id": "",
+    "sms_gateway_url": "", "seven_api_key": "", "sms_to": "",
+}
+
+_BROKEN_EMAIL_FIELDS: dict = {
+    "smtp_host": "", "smtp_user": "", "smtp_pass": "",
+    "mail_to": "tdd-1714-dummy@example.invalid",
+    "telegram_bot_token": "", "telegram_chat_id": "",
+    "telegram_test_bot_token": "", "telegram_test_chat_id": "",
+    "sms_gateway_url": "", "seven_api_key": "", "sms_to": "",
+}
+
+
+def _settings_email_only() -> Settings:
+    return Settings(**_NO_TRANSPORT_FIELDS)
+
+
+def _settings_email_broken() -> Settings:
+    """Echte, unvollstaendige SMTP-Konfiguration -- `EmailOutput` wirft den
+    echten `OutputConfigError`, ohne je Netz zu benutzen (AC-4)."""
+    settings = Settings(**_BROKEN_EMAIL_FIELDS)
+    assert settings.can_send_email() is False
+    assert settings.can_send_telegram() is False
+    assert settings.can_send_sms() is False
+    return settings
+
+
+def _location(loc_id: str, name: str, lat: float, lon: float) -> SavedLocation:
+    return SavedLocation(id=loc_id, name=name, lat=lat, lon=lon, elevation_m=1000)
+
+
+def _point(point_id: str, name: str, lat: float, lon: float, precip_sum_mm: float):
+    """Echtes `PointWeatherData`-DTO (kein Mock)."""
+    from services.point_weather import PointWeatherData
+
+    return PointWeatherData(
+        id=point_id, name=name, lat=lat, lon=lon, timeseries=None,
+        aggregated=SegmentWeatherSummary(precip_sum_mm=precip_sum_mm),
+        fetched_at=datetime.now(timezone.utc), provider="tdd-1714",
+    )
+
+
+class _ScriptedWeatherSource:
+    """Echte `LocationWeatherSource`-Implementierung (kein Mock) fuer den
+    Δ-Anker-Schreiber, netzfrei."""
+
+    def __init__(self, values: dict[str, float], names: dict[str, str]) -> None:
+        self.values = dict(values)
+        self._names = dict(names)
+        self.fetch_calls: list[str] = []
+
+    def fetch(self, point_id: str, lat: float, lon: float,
+              start_hour: int | None = None, end_hour: int | None = None,
+              target_date=None, tage_ab_ortstag=None):
+        self.fetch_calls.append(point_id)
+        return _point(point_id, self._names.get(point_id, point_id), lat, lon,
+                      precip_sum_mm=self.values.get(point_id, 0.0))
+
+
+def _preset(preset_id: str, location_ids: list[str], **extra) -> dict:
+    preset = {
+        "id": preset_id, "name": preset_id, "location_ids": list(location_ids),
+        "schedule": "daily", "weekday": 4, "profil": "ALLGEMEIN",
+        "hour_from": 9, "hour_to": 16,
+        "empfaenger": ["tdd-1714-dummy@example.invalid"],
+        "letzter_versand": None, "top_ort_letzter_versand": None,
+        "created_at": "2026-08-17T00:00:00Z", "kind": "vergleich",
+    }
+    preset.update(extra)
+    return preset
+
+
+def _dp(hour: int) -> ForecastDataPoint:
+    return ForecastDataPoint(
+        ts=datetime(TARGET_DATE.year, TARGET_DATE.month, TARGET_DATE.day, hour, 0),
+        t2m_c=22.0, wind_chill_c=21.0, wind10m_kmh=11.0, gust_kmh=19.0,
+        precip_1h_mm=0.0, cloud_total_pct=35, uv_index=5.0,
+        thunder_level=ThunderLevel.NONE, pop_pct=10, visibility_m=9000,
+    )
+
+
+def _official_alert(*, hazard="thunderstorm", level=2, region="Testregion",
+                     vf=None, vt=None) -> OfficialAlert:
+    return OfficialAlert(
+        source="test-1714", hazard=hazard, level=level, label="Testwarnung",
+        valid_from=vf or _VALID_FROM, valid_to=vt or _VALID_TO,
+        region_label=region,
+    )
+
+
+def _install_comparison_engine_seam(monkeypatch, alerts_by_loc: dict | None = None) -> None:
+    """Ersetzt NUR die teure Upstream-Abhaengigkeit `ComparisonEngine.run`
+    durch eine echte Unterklasse mit festen Werten — Haus-Muster aus
+    `test_compare_briefing_anchor_and_memory_reset.py`. `alerts_by_loc`
+    (#1714, neu) laesst je Ort steuern, welche amtlichen Warnungen im
+    Briefing GEZEIGT werden — genau die Menge, die die neue Record-Logik
+    ans Melde-Gedaechtnis melden soll."""
+    import services.comparison_engine as ce_mod
+    from app.user import ComparisonResult, LocationResult
+
+    alerts_by_loc = alerts_by_loc or {}
+    original = ce_mod.ComparisonEngine
+
+    class _FixedEngine(original):  # echte Unterklasse, kein Mock
+        @staticmethod
+        def run(*args, **kwargs):
+            locations = kwargs.get("locations")
+            if locations is None and args:
+                locations = args[0]
+            return ComparisonResult(
+                locations=[
+                    LocationResult(
+                        location=loc, score=90 - 5 * i, temp_max=22.0 + i, temp_min=12.0,
+                        wind_max=11.0, gust_max=19.0, cloud_avg=35, sunny_hours=6,
+                        official_alerts=list(alerts_by_loc.get(loc.id, [])),
+                        hourly_data=[_dp(9), _dp(12), _dp(15)],
+                    )
+                    for i, loc in enumerate(list(locations or []))
+                ],
+                time_window=kwargs.get("time_window", (9, 16)),
+                target_date=kwargs.get("target_date", TARGET_DATE),
+                created_at=datetime(TARGET_DATE.year, TARGET_DATE.month, TARGET_DATE.day, 4, 0),
+            )
+
+    monkeypatch.setattr(ce_mod, "ComparisonEngine", _FixedEngine)
+
+
+def _install_anchor_weather_seam(monkeypatch, source: _ScriptedWeatherSource) -> None:
+    """Der Δ-Anker-Schreiber (`_write_compare_alert_snapshots`) baut sich seine
+    Wetterquelle selbst (Netz). Hier wird die KLASSE im Quellmodul durch eine
+    gleichwertige, netzfreie Implementierung ersetzt."""
+    import services.compare_location_weather_source as clws_mod
+
+    class _SourceFactory:
+        def __new__(cls, *args, **kwargs):
+            return source
+
+    monkeypatch.setattr(clws_mod, "CompareLocationWeatherSource", _SourceFactory)
+
+
+class _FakeOfficialAlertSource:
+    """Echte Quelle (kein Mock), strukturelles Subtyping — Muster
+    `test_compare_official_alert.py`."""
+
+    def __init__(self, lat, lon, alerts):
+        self._lat, self._lon, self._alerts = lat, lon, alerts
+        self.fetch_calls = 0
+
+    @property
+    def name(self) -> str:
+        return "test-1714-source"
+
+    def covers(self, lat, lon) -> bool:
+        return abs(lat - self._lat) < 0.05 and abs(lon - self._lon) < 0.05
+
+    def fetch(self, lat, lon):
+        self.fetch_calls += 1
+        return list(self._alerts)
+
+
+def _sources_backup():
+    import services.official_alerts.base as b
+    return b, list(b._REGISTERED_SOURCES)
+
+
+def _memory_state(user_id: str, preset_id: str, loc_id: str) -> dict:
+    from services.alert_state import AlertStateService
+
+    return AlertStateService(user_id=user_id).load(f"{preset_id}:{loc_id}")
+
+
+@pytest.fixture
+def compare_env(tmp_path, monkeypatch):
+    """Isoliertes Arbeitsverzeichnis (Muster
+    `test_compare_briefing_anchor_and_memory_reset.py::compare_env`)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data" / "users").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+# ══════════════════════════════════ AC-1 ═════════════════════════════════════
+
+
+def test_briefing_meldet_unveraenderte_amtliche_warnung_danach_nicht_erneut(
+    compare_env, monkeypatch,
+):
+    """AC-1 — Kern-Regressionsschutz gegen den im Issue beschriebenen
+    Doppelversand.
+
+    GIVEN ein Compare-Briefing wurde erfolgreich mit einer amtlichen Warnung
+          fuer einen Ort versendet.
+    WHEN  der naechste Lauf von `compare_official_alert.py` fuer denselben
+          Ort mit unveraenderter Warnung (gleiches Level) laeuft.
+    THEN  meldet der Checker diese Warnung NICHT erneut als eigenstaendigen
+          Alarm.
+    """
+    from app.loader import get_data_root, save_location
+    from services.compare_official_alert import CompareOfficialAlertService
+    from services.official_alerts import register_official_alert_source
+    from services.scheduler_dispatch_service import send_one_compare_preset
+
+    uid = f"tdd-1714-ac1-{uuid.uuid4().hex[:6]}"
+    preset_id = f"cp-1714-ac1-{uuid.uuid4().hex[:6]}"
+    loc = _location("loc-1714-a", "Alpenort", 47.0, 11.0)
+    save_location(loc, user_id=uid)
+    write_compare_briefings(get_data_root() / "users" / uid, [_preset(preset_id, [loc.id])])
+
+    alert = _official_alert()
+    settings = _settings_email_only()
+    _install_comparison_engine_seam(monkeypatch, {loc.id: [alert]})
+    _install_anchor_weather_seam(monkeypatch, _ScriptedWeatherSource({loc.id: 5.0}, {loc.id: loc.name}))
+
+    mail_calls: list = []
+    send_one_compare_preset(
+        _preset(preset_id, [loc.id]), settings, uid, str(compare_env / "data"),
+        all_locations_cache=[loc], target_date=TARGET_DATE, tage_ab_ortstag=0,
+        mail_sink=lambda subject, body: mail_calls.append(subject),
+    )
+    assert mail_calls, "Vorbedingung: der Briefing-Versand muss ausgeloest werden"
+
+    state = _memory_state(uid, preset_id, loc.id)
+    assert any(k.startswith("official_alert:") for k in state), (
+        f"Nach erfolgreichem Versand fehlt der official_alert:-Eintrag im "
+        f"Melde-Gedaechtnis: {list(state)!r} (AC-1)"
+    )
+
+    b, backup = _sources_backup()
+    b._REGISTERED_SOURCES.clear()
+    try:
+        register_official_alert_source(_FakeOfficialAlertSource(loc.lat, loc.lon, [alert]))
+        checker_mails: list = []
+        sent = CompareOfficialAlertService(
+            settings=settings, user_id=uid,
+            mail_sink=lambda subject, body: checker_mails.append(subject),
+        ).check_all_compare_presets()
+
+        assert sent == 0, (
+            f"Eine bereits im Briefing gemeldete, unveraenderte Warnung darf "
+            f"der unabhaengige Checker nicht erneut als eigenen Alarm melden, "
+            f"erhalten: {sent} Zustellung(en) (AC-1)"
+        )
+        assert checker_mails == [], f"Unerwarteter Alarm-Versand: {checker_mails!r} (AC-1)"
+    finally:
+        b._REGISTERED_SOURCES.clear()
+        b._REGISTERED_SOURCES.extend(backup)
+
+
+# ══════════════════════════════════ AC-2 ═════════════════════════════════════
+
+
+def test_eskalierte_warnung_wird_trotz_bereits_gemeldeter_unveraenderter_warnung_weiterhin_gemeldet(
+    compare_env, monkeypatch,
+):
+    """AC-2 — Eskalations-Gegenprobe zu AC-1.
+
+    GIVEN dieselbe Ausgangslage wie AC-1 (Warnung bereits im Melde-Gedaechtnis
+          vermerkt).
+    WHEN  die Warnung danach auf ein hoeheres Level eskaliert.
+    THEN  meldet der Checker die eskalierte Warnung weiterhin als neuen
+          Trigger — der neue Doppelversand-Schutz darf eine echte
+          Verschaerfung nicht stumm schalten.
+    """
+    from app.loader import get_data_root, save_location
+    from services.compare_official_alert import CompareOfficialAlertService
+    from services.official_alerts import register_official_alert_source
+    from services.scheduler_dispatch_service import send_one_compare_preset
+
+    uid = f"tdd-1714-ac2-{uuid.uuid4().hex[:6]}"
+    preset_id = f"cp-1714-ac2-{uuid.uuid4().hex[:6]}"
+    loc = _location("loc-1714-b", "Bergort", 47.5, 11.5)
+    save_location(loc, user_id=uid)
+    write_compare_briefings(get_data_root() / "users" / uid, [_preset(preset_id, [loc.id])])
+
+    alert = _official_alert(level=2)
+    settings = _settings_email_only()
+    _install_comparison_engine_seam(monkeypatch, {loc.id: [alert]})
+    _install_anchor_weather_seam(monkeypatch, _ScriptedWeatherSource({loc.id: 5.0}, {loc.id: loc.name}))
+
+    send_one_compare_preset(
+        _preset(preset_id, [loc.id]), settings, uid, str(compare_env / "data"),
+        all_locations_cache=[loc], target_date=TARGET_DATE, tage_ab_ortstag=0,
+        mail_sink=lambda subject, body: None,
+    )
+    state = _memory_state(uid, preset_id, loc.id)
+    assert any(k.startswith("official_alert:") for k in state), (
+        "Vorbedingung: der Briefing-Versand muss die Warnung vermerken"
+    )
+
+    escalated = _official_alert(level=3, vf=alert.valid_from, vt=alert.valid_to)
+
+    b, backup = _sources_backup()
+    b._REGISTERED_SOURCES.clear()
+    try:
+        register_official_alert_source(_FakeOfficialAlertSource(loc.lat, loc.lon, [escalated]))
+        checker_mails: list = []
+        sent = CompareOfficialAlertService(
+            settings=settings, user_id=uid,
+            mail_sink=lambda subject, body: checker_mails.append(subject),
+        ).check_all_compare_presets()
+
+        assert sent == 1, (
+            f"Eine echte Eskalation muss trotz bereits gemeldeter unveraenderter "
+            f"Warnung weiterhin gemeldet werden, erhalten: {sent} (AC-2)"
+        )
+        assert len(checker_mails) == 1
+    finally:
+        b._REGISTERED_SOURCES.clear()
+        b._REGISTERED_SOURCES.extend(backup)
+
+
+# ══════════════════════════════════ AC-3 ═════════════════════════════════════
+
+
+def test_ad_hoc_abruf_schreibt_das_melde_gedaechtnis_amtlicher_warnungen_nicht(
+    compare_env, monkeypatch,
+):
+    """AC-3 — Handversand (#1007) bleibt read-only fuers Melde-Gedaechtnis."""
+    from app.loader import get_data_root, save_location
+    from services.scheduler_dispatch_service import send_one_compare_preset
+
+    uid = f"tdd-1714-ac3-{uuid.uuid4().hex[:6]}"
+    preset_id = f"cp-1714-ac3-{uuid.uuid4().hex[:6]}"
+    loc = _location("loc-1714-c", "Talort", 48.0, 12.0)
+    save_location(loc, user_id=uid)
+    write_compare_briefings(get_data_root() / "users" / uid, [_preset(preset_id, [loc.id])])
+
+    alert = _official_alert()
+    settings = _settings_email_only()
+    _install_comparison_engine_seam(monkeypatch, {loc.id: [alert]})
+    _install_anchor_weather_seam(monkeypatch, _ScriptedWeatherSource({loc.id: 5.0}, {loc.id: loc.name}))
+
+    before = _memory_state(uid, preset_id, loc.id)
+    send_one_compare_preset(
+        _preset(preset_id, [loc.id]), settings, uid, str(compare_env / "data"),
+        all_locations_cache=[loc], target_date=TARGET_DATE, tage_ab_ortstag=0,
+        mail_sink=lambda subject, body: None,
+        on_demand=True,
+    )
+    after = _memory_state(uid, preset_id, loc.id)
+
+    assert after == before == {}, (
+        f"Ein Handversand (on_demand=True) darf das Melde-Gedaechtnis nicht "
+        f"anfassen (#1007), gefunden: {after!r} (AC-3)"
+    )
+
+    # Positive Gegenprobe (Muster Trip-Vorbild): derselbe Aufbau OHNE
+    # Ad-hoc-Kennzeichen MUSS den Eintrag setzen. Ohne diese Gegenprobe waere
+    # die leere Erwartung oben auch dann erfuellt, wenn die neue Record-Logik
+    # ueberhaupt nie verdrahtet worden waere.
+    send_one_compare_preset(
+        _preset(preset_id, [loc.id]), settings, uid, str(compare_env / "data"),
+        all_locations_cache=[loc], target_date=TARGET_DATE, tage_ab_ortstag=0,
+        mail_sink=lambda subject, body: None,
+        on_demand=False,
+    )
+    regular = _memory_state(uid, preset_id, loc.id)
+    assert any(k.startswith("official_alert:") for k in regular), (
+        f"Gegenprobe: der REGULAERE Versand (on_demand=False) muss die Warnung "
+        f"vermerken, gefunden: {list(regular)!r} (AC-3)"
+    )
+
+
+# ══════════════════════════════════ AC-4 ═════════════════════════════════════
+
+
+def test_fehlgeschlagener_versand_schreibt_das_melde_gedaechtnis_nicht(
+    compare_env, monkeypatch,
+):
+    """AC-4 — ein gescheiterter Versand darf eine nie zugestellte Warnung
+    nicht faelschlich als 'gemeldet' vermerken."""
+    from app.loader import get_data_root, save_location
+    from output.channels.base import OutputConfigError
+    from services.scheduler_dispatch_service import send_one_compare_preset
+
+    uid = f"tdd-1714-ac4-{uuid.uuid4().hex[:6]}"
+    preset_id = f"cp-1714-ac4-{uuid.uuid4().hex[:6]}"
+    loc = _location("loc-1714-d", "Fehlerort", 48.5, 12.5)
+    save_location(loc, user_id=uid)
+    write_compare_briefings(get_data_root() / "users" / uid, [_preset(preset_id, [loc.id])])
+
+    alert = _official_alert()
+    settings = _settings_email_broken()
+    _install_comparison_engine_seam(monkeypatch, {loc.id: [alert]})
+    _install_anchor_weather_seam(monkeypatch, _ScriptedWeatherSource({loc.id: 5.0}, {loc.id: loc.name}))
+
+    with pytest.raises(OutputConfigError):
+        send_one_compare_preset(
+            _preset(preset_id, [loc.id]), settings, uid, str(compare_env / "data"),
+            all_locations_cache=[loc], target_date=TARGET_DATE, tage_ab_ortstag=0,
+        )
+
+    state = _memory_state(uid, preset_id, loc.id)
+    assert not any(k.startswith("official_alert:") for k in state), (
+        f"Ein gescheiterter Versand darf keinen official_alert:-Eintrag "
+        f"hinterlassen: {list(state)!r} (AC-4)"
+    )
+
+    # Positive Gegenprobe: derselbe Ort/dieselbe Warnung, aber ein GELINGENDER
+    # Versand MUSS den Eintrag setzen. Ohne sie waere die leere Erwartung oben
+    # auch dann erfuellt, wenn die neue Record-Logik nie verdrahtet worden waere.
+    working_settings = _settings_email_only()
+    send_one_compare_preset(
+        _preset(preset_id, [loc.id]), working_settings, uid, str(compare_env / "data"),
+        all_locations_cache=[loc], target_date=TARGET_DATE, tage_ab_ortstag=0,
+        mail_sink=lambda subject, body: None,
+    )
+    regular = _memory_state(uid, preset_id, loc.id)
+    assert any(k.startswith("official_alert:") for k in regular), (
+        f"Gegenprobe: ein GELINGENDER Versand mit derselben Warnung muss den "
+        f"Eintrag setzen, gefunden: {list(regular)!r} (AC-4)"
+    )
+
+
+# ══════════════════════════════════ AC-5 ═════════════════════════════════════
+
+
+def test_zwei_nutzer_bleiben_im_melde_gedaechtnis_getrennt(compare_env, monkeypatch):
+    """AC-5 — Mandantentrennung (CLAUDE.md-Pflicht)."""
+    from app.loader import get_data_root, save_location
+    from services.scheduler_dispatch_service import send_one_compare_preset
+
+    uid_a = f"tdd-1714-ac5-a-{uuid.uuid4().hex[:6]}"
+    uid_b = f"tdd-1714-ac5-b-{uuid.uuid4().hex[:6]}"
+    preset_id = f"cp-1714-ac5-{uuid.uuid4().hex[:6]}"
+    loc = _location("loc-1714-e", "Zwillingsort", 46.9, 10.9)
+    save_location(loc, user_id=uid_a)
+    save_location(loc, user_id=uid_b)
+    write_compare_briefings(get_data_root() / "users" / uid_a, [_preset(preset_id, [loc.id])])
+    write_compare_briefings(get_data_root() / "users" / uid_b, [_preset(preset_id, [loc.id])])
+
+    alert = _official_alert()
+    settings = _settings_email_only()
+    _install_comparison_engine_seam(monkeypatch, {loc.id: [alert]})
+    _install_anchor_weather_seam(monkeypatch, _ScriptedWeatherSource({loc.id: 5.0}, {loc.id: loc.name}))
+
+    send_one_compare_preset(
+        _preset(preset_id, [loc.id]), settings, uid_a, str(compare_env / "data"),
+        all_locations_cache=[loc], target_date=TARGET_DATE, tage_ab_ortstag=0,
+        mail_sink=lambda subject, body: None,
+    )
+
+    state_a = _memory_state(uid_a, preset_id, loc.id)
+    state_b = _memory_state(uid_b, preset_id, loc.id)
+    assert any(k.startswith("official_alert:") for k in state_a), (
+        f"Vorbedingung: Nutzer A muss den Eintrag erhalten: {list(state_a)!r}"
+    )
+    assert state_b == {}, (
+        f"Der erfolgreiche Versand fuer Nutzer A darf das Melde-Gedaechtnis von "
+        f"Nutzer B nicht beruehren, gefunden: {state_b!r} (AC-5)"
+    )
+
+
+# ══════════════════════════════════ AC-6 ═════════════════════════════════════
+
+
+def test_zwei_orte_im_preset_beeinflussen_sich_im_melde_gedaechtnis_nicht_gegenseitig(
+    compare_env, monkeypatch,
+):
+    """AC-6 — R3-Analogie: kein Cross-Orts-Ueberschreiben."""
+    from app.loader import get_data_root, save_location
+    from output.renderers.alert.official_alerts import (
+        official_alert_state_entry,
+        official_alert_state_key,
+    )
+    from services.alert_state import AlertStateService
+    from services.scheduler_dispatch_service import send_one_compare_preset
+
+    uid = f"tdd-1714-ac6-{uuid.uuid4().hex[:6]}"
+    preset_id = f"cp-1714-ac6-{uuid.uuid4().hex[:6]}"
+    loc_warn = _location("loc-1714-f1", "Warnort", 47.1, 11.1)
+    loc_quiet = _location("loc-1714-f2", "Ruhigort", 47.2, 11.2)
+    save_location(loc_warn, user_id=uid)
+    save_location(loc_quiet, user_id=uid)
+    write_compare_briefings(
+        get_data_root() / "users" / uid,
+        [_preset(preset_id, [loc_warn.id, loc_quiet.id])],
+    )
+
+    # Vorbestehender Melde-Gedaechtnis-Eintrag am ruhigen Ort, zu einer
+    # ANDEREN Warnung gehoerend als die am Warnort gezeigte — darf nicht
+    # angefasst werden (echtes Cross-Orts-Ueberschreiben, nicht nur ein
+    # fremder State-Key).
+    existing_alert = _official_alert(hazard="snow", level=1, region="Andere Region")
+    existing_key = official_alert_state_key(existing_alert)
+    existing_entry = official_alert_state_entry(existing_alert, "2026-08-01T00:00:00+00:00")
+    AlertStateService(user_id=uid).save(
+        f"{preset_id}:{loc_quiet.id}", {existing_key: dict(existing_entry)}
+    )
+
+    alert = _official_alert()
+    settings = _settings_email_only()
+    _install_comparison_engine_seam(monkeypatch, {loc_warn.id: [alert]})  # loc_quiet: []
+    source = _ScriptedWeatherSource(
+        {loc_warn.id: 5.0, loc_quiet.id: 3.0},
+        {loc_warn.id: loc_warn.name, loc_quiet.id: loc_quiet.name},
+    )
+    _install_anchor_weather_seam(monkeypatch, source)
+
+    send_one_compare_preset(
+        _preset(preset_id, [loc_warn.id, loc_quiet.id]), settings, uid, str(compare_env / "data"),
+        all_locations_cache=[loc_warn, loc_quiet], target_date=TARGET_DATE, tage_ab_ortstag=0,
+        mail_sink=lambda subject, body: None,
+    )
+
+    state_warn = _memory_state(uid, preset_id, loc_warn.id)
+    state_quiet = _memory_state(uid, preset_id, loc_quiet.id)
+    assert any(k.startswith("official_alert:") for k in state_warn), (
+        f"Der Ort mit gezeigter Warnung muss einen Eintrag erhalten: {list(state_warn)!r}"
+    )
+    assert state_quiet == {existing_key: existing_entry}, (
+        f"Der bestehende Eintrag des anderen Ortes darf nicht ueberschrieben "
+        f"oder geloescht werden, gefunden: {state_quiet!r} (AC-6)"
+    )
+
+
+# ══════════════════════════════════ AC-7 ═════════════════════════════════════
+
+
+def test_preset_ohne_gezeigte_warnungen_loest_keinen_schreibzugriff_aus(
+    compare_env, monkeypatch,
+):
+    """AC-7 — Fail-soft No-Op, kein unnoetiger State-Write."""
+    import services.alert_briefing_anchor as anchor_mod
+    from app.loader import get_data_root, save_location
+    from services.scheduler_dispatch_service import send_one_compare_preset
+
+    uid = f"tdd-1714-ac7-{uuid.uuid4().hex[:6]}"
+    preset_id = f"cp-1714-ac7-{uuid.uuid4().hex[:6]}"
+    loc = _location("loc-1714-g", "Klarort", 47.3, 11.3)
+    save_location(loc, user_id=uid)
+    write_compare_briefings(get_data_root() / "users" / uid, [_preset(preset_id, [loc.id])])
+
+    calls: list = []
+    original = anchor_mod.record_official_alerts_reported
+
+    def _spy(*, user_id, entity_id, alerts):
+        calls.append((user_id, entity_id, list(alerts)))
+        return original(user_id=user_id, entity_id=entity_id, alerts=alerts)
+
+    monkeypatch.setattr(anchor_mod, "record_official_alerts_reported", _spy)
+
+    settings = _settings_email_only()
+    _install_comparison_engine_seam(monkeypatch, {})  # keine Warnungen an keinem Ort
+    _install_anchor_weather_seam(monkeypatch, _ScriptedWeatherSource({loc.id: 5.0}, {loc.id: loc.name}))
+
+    send_one_compare_preset(
+        _preset(preset_id, [loc.id]), settings, uid, str(compare_env / "data"),
+        all_locations_cache=[loc], target_date=TARGET_DATE, tage_ab_ortstag=0,
+        mail_sink=lambda subject, body: None,
+    )
+
+    assert calls == [], (
+        f"Ein Briefing ohne gezeigte amtliche Warnungen darf die Record-Funktion "
+        f"kein einziges Mal aufrufen: {calls!r} (AC-7)"
+    )
+    state = _memory_state(uid, preset_id, loc.id)
+    assert not any(k.startswith("official_alert:") for k in state), (
+        f"Kein official_alert:-Eintrag erwartet: {list(state)!r} (AC-7)"
+    )
+
+    # Positive Gegenprobe: derselbe Aufbau MIT gezeigter Warnung MUSS die
+    # Record-Funktion genau einmal aufrufen. Ohne sie waere `calls == []` auch
+    # dann erfuellt, wenn der Spy nie einen echten Aufruf sehen wuerde (z.B.
+    # weil die neue Record-Logik nie verdrahtet worden waere).
+    _install_comparison_engine_seam(monkeypatch, {loc.id: [_official_alert()]})
+    send_one_compare_preset(
+        _preset(preset_id, [loc.id]), settings, uid, str(compare_env / "data"),
+        all_locations_cache=[loc], target_date=TARGET_DATE, tage_ab_ortstag=0,
+        mail_sink=lambda subject, body: None,
+    )
+    assert len(calls) == 1, (
+        f"Gegenprobe: ein Briefing MIT gezeigter Warnung muss die Record-Funktion "
+        f"genau einmal aufrufen, gefunden: {calls!r} (AC-7)"
+    )

--- a/tests/tdd/test_compare_alert_dedup_briefing_reset.py
+++ b/tests/tdd/test_compare_alert_dedup_briefing_reset.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import uuid
 from datetime import date, datetime, timedelta, timezone
-from pathlib import Path
 
 import pytest
 


### PR DESCRIPTION
## Summary
- Das Ortsvergleich-Briefing (`send_one_compare_preset`) zeigte amtliche Wetterwarnungen an, vermerkte sie aber nie im Melde-Gedächtnis (`official_alert:`-Namensraum) — dadurch meldete der unabhängige, alle 15 Minuten laufende Compare-Alarm-Checker dieselbe, unveränderte Warnung kurz danach nochmal als eigenständigen Alarm.
- Verdrahtet den bereits bestehenden, im Trip-Pfad produktiv erprobten Baustein `record_official_alerts_reported()` (aus #1614 Teil 1, unverändert) zusätzlich für den Compare-Pfad.
- Kein Eingriff in `compare_official_alert.py` oder `official_alert_state_key()`.

## Test plan
- [x] 7/7 neue Tests grün (`tests/tdd/test_compare_alert_dedup_briefing_reset.py`, AC-1 bis AC-7)
- [x] Regressionslauf: 27 abhängige Compare-Dispatch-Testdateien (~608 Tests) — keine Regression
- [x] Adversary-Verdict: VERIFIED (5 Mutationsproben, 4 gefangen; 1 nicht-blockierendes Finding F001 für #1199 vorgemerkt — `send_result.sent`-Gate aktuell strukturell unreachable, kein AC-Bruch)
- [x] CI-Ampel abwarten vor Merge
- [ ] Staging-Validierung + Prod-Selftest (nach Merge)

Bezieht sich auf #1714 — Issue wird erst nach bestandenem Post-Deploy-Selftest geschlossen, nicht automatisch bei diesem Merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)