### PR TITLE
fix(#1931): keine MQ-Warnung mehr bei leerer Heartbeat-URL fuer briefing_dispatch

### DIFF
--- a/docs/context/fix-1931-heartbeat-warn-spam.md
+++ b/docs/context/fix-1931-heartbeat-warn-spam.md
@@ -1,0 +1,60 @@
+# Context: #1931 — warnMissingHeartbeatOnce spammt infra bei jedem Prod-Neustart
+
+## Analysis
+
+### Type
+Bug
+
+### Symptom
+`infra` erhält bei jedem Prod-Neustart von `gregor-api` erneut die MQ-Nachricht
+"Heartbeat-URL für Job \"briefing_dispatch\" nicht konfiguriert" — 14× seit dem
+30.07.2026 (henemm-infra#149). Die zugrunde liegende Konfiguration
+(`HEARTBEAT_COMPARE_PRESETS` leer) ist inzwischen bewusst und dauerhaft so
+gewollt: Überwachung läuft seit #1898 stattdessen über den bestehenden
+"Gregor20 Core"-Heartbeat via `check-gregor20.sh` (Abschnitt 2 + 2b).
+
+### Root Cause
+- `internal/scheduler/scheduler.go:297-309` — `briefingDispatch()` ruft bei
+  jedem erfolgreichen Lauf `s.pingHeartbeat("briefing_dispatch",
+  s.heartbeatComparePresets)`.
+- `internal/scheduler/scheduler.go:694-698` — `pingHeartbeat` ruft bei leerer
+  URL `s.warnMissingHeartbeatOnce(jobName)`.
+- `internal/scheduler/scheduler.go:709-736` — `warnMissingHeartbeatOnce`
+  verwendet `sync.Once` **pro Prozesslaufzeit** (`s.onceMissingHB[jobName]`).
+  Der Once-Zustand ist In-Memory und überlebt keinen Neustart → jeder
+  Prod-Neustart erzeugt eine neue MQ-Nachricht.
+- `internal/config/config.go:19` — `HEARTBEAT_COMPARE_PRESETS` hat
+  `default:""`, ist in Prod absichtlich leer.
+
+### Affected Files (erwartete Änderung)
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `internal/scheduler/scheduler.go` | MODIFY | `briefingDispatch()` ruft für den Job `briefing_dispatch` bei leerer URL keine MQ-Warnung mehr aus |
+| `internal/scheduler/scheduler_test.go` | MODIFY | Bestehende Assertions zu `warnMissingHeartbeatOnce`/`pingHeartbeat` für `briefing_dispatch` anpassen, sofern sie das alte (spammende) Verhalten fixieren |
+
+### Bestehender Test aus #118 (Bestandsschutz)
+`scheduler_test.go` prüft seit #118 den *allgemeinen* Mechanismus
+(leere Heartbeat-URL → genau eine MQ-Notification, once-per-jobName). Dieser
+Mechanismus bleibt für andere Jobs gültig und wird NICHT entfernt — nur der
+konkrete Aufruf für `briefing_dispatch` mit der bewusst leeren
+`heartbeatComparePresets`-URL darf keine MQ-Warnung mehr auslösen.
+
+### Scope Assessment
+- Files: 2 (1 Produktivcode, 1 Test)
+- Estimated LoC: ~+15/-5
+- Risk Level: LOW (isolierte Funktion, kein Datenpfad, kein Nutzerbezug)
+
+### Technical Approach
+`briefingDispatch()` ruft für `briefing_dispatch` künftig **nicht mehr**
+`pingHeartbeat` (das den Warnpfad auslöst), sondern nur noch das normale
+GET, wenn eine URL konfiguriert ist — bei leerer URL wird für genau diesen
+Job kein `warnMissingHeartbeatOnce` mehr aufgerufen (nur noch ein Log-Eintrag,
+kein MQ-Versand). Die generische `pingHeartbeat`/`warnMissingHeartbeatOnce`-
+Maschinerie bleibt für andere, künftige Jobs unverändert nutzbar.
+
+### Dependencies
+Keine. Reiner Go-Scheduler-Code, kein Python-Core, kein Frontend.
+
+### Open Questions
+Keine — Ursache und Fix sind eindeutig, PO-Entscheidung (Konfiguration bleibt
+leer) liegt bereits als MQ-Nachricht von `infra` vor.

--- a/docs/specs/modules/fix_1931_heartbeat_warn_spam.md
+++ b/docs/specs/modules/fix_1931_heartbeat_warn_spam.md
@@ -1,0 +1,89 @@
+---
+entity_id: fix_1931_heartbeat_warn_spam
+type: module
+created: 2026-08-17
+updated: 2026-08-17
+status: draft
+version: "1.0"
+tags: [scheduler, heartbeat, bugfix]
+---
+
+# Fix #1931: warnMissingHeartbeatOnce spammt infra bei jedem Prod-Neustart
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+`briefingDispatch()` löst bei jedem erfolgreichen Lauf `pingHeartbeat("briefing_dispatch", s.heartbeatComparePresets)` aus. Da `HEARTBEAT_COMPARE_PRESETS` in Prod bewusst dauerhaft leer ist (Überwachung läuft stattdessen über den bestehenden "Gregor20 Core"-Heartbeat, #1898), löst dieser Aufruf bei jedem Prod-Neustart eine neue MQ-Warnung an `infra` aus (In-Memory-`sync.Once` überlebt keinen Neustart) — 14× seit dem 30.07.2026. Dieses Modul stellt sicher, dass der akzeptierte Zustand "briefing_dispatch ohne konfigurierte Heartbeat-URL" nur noch lokal geloggt, aber nicht mehr als MQ-Warnung an `infra` gemeldet wird — ohne den generischen `pingHeartbeat`/`warnMissingHeartbeatOnce`-Mechanismus für andere Jobs zu verändern.
+
+## Source
+
+- **File:** `internal/scheduler/scheduler.go`
+- **Identifier:** `func (s *Scheduler) briefingDispatch()` (Zeile ~297), `func (s *Scheduler) pingHeartbeat(jobName, url string)` (Zeile ~694), `func (s *Scheduler) warnMissingHeartbeatOnce(jobName string)` (Zeile ~711)
+
+## Estimated Scope
+
+- **LoC:** ~+15/-5
+- **Files:** 2
+- **Effort:** low
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `internal/config/config.go` (`HEARTBEAT_COMPARE_PRESETS`) | config | Liefert die (in Prod bewusst leere) `heartbeatComparePresets`-URL |
+| `s.notifier` (MQ-Sender-Function-Field) | internal collaborator | Wird vom generischen `warnMissingHeartbeatOnce` weiterhin für andere Jobs genutzt |
+
+## Scope
+
+### Affected Files
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `internal/scheduler/scheduler.go` | MODIFY | `briefingDispatch()` ruft bei leerer `heartbeatComparePresets`-URL nicht mehr `pingHeartbeat()` (und damit nicht mehr `warnMissingHeartbeatOnce`) auf, sondern schreibt nur einen lokalen Log-Eintrag. Bei gesetzter URL bleibt der bisherige Ping-Aufruf unverändert. |
+| `internal/scheduler/scheduler_test.go` | MODIFY | Neue/angepasste Assertions, die belegen, dass `briefing_dispatch` bei leerer URL keinen `notifier`-Aufruf mehr auslöst, während der generische Mechanismus (anderer `jobName`, leere URL) unverändert genau einmal pingt. |
+
+### Estimated Changes
+- Files: 2
+- LoC: +15/-5
+
+## Implementation Details
+
+`briefingDispatch()` prüft nach dem bestehenden "beide Teil-Jobs ok"-Gate zusätzlich, ob `s.heartbeatComparePresets` leer ist:
+
+- Ist die URL gesetzt → unverändertes Verhalten: `s.pingHeartbeat("briefing_dispatch", s.heartbeatComparePresets)` (HTTP-GET an BetterStack).
+- Ist die URL leer → **kein** Aufruf von `pingHeartbeat`/`warnMissingHeartbeatOnce` mehr für `briefing_dispatch`; stattdessen ein einzeiliger `log.Printf`, dass der Heartbeat für diesen Job absichtlich deaktiviert ist (Verweis auf #1898 im Kommentar).
+
+Der generische Pfad `pingHeartbeat` → `warnMissingHeartbeatOnce` (inkl. `sync.Once`-Semantik pro `jobName`) bleibt für alle anderen (auch künftige) Jobs unverändert bestehen — es wird kein Code aus diesen Funktionen entfernt, nur der Aufrufer `briefingDispatch()` verzweigt vor dem Aufruf.
+
+## Expected Behavior
+
+- **Input:** `briefingDispatch()` läuft erfolgreich durch (beide Teil-Jobs `status: ok`); `s.heartbeatComparePresets` ist leer (Prod-Normalfall).
+- **Output:** Kein Aufruf von `s.notifier(...)`, kein HTTP-Request an BetterStack. Ein lokaler Log-Eintrag markiert den Zustand als erwartet/akzeptiert.
+- **Side effects:** Keine MQ-Nachricht an `infra` mehr bei Prod-Neustarts für diesen Job. Andere Jobs (hypothetisch, aktuell keine weiteren Aufrufer von `pingHeartbeat` mit leerer URL) lösen bei leerer URL weiterhin genau eine MQ-Warnung pro Prozesslaufzeit aus.
+
+## Acceptance Criteria
+
+- **AC-1:** Given `briefingDispatch()` läuft mit leerer `heartbeatComparePresets`-URL und beide Teil-Jobs melden `status: ok` / When der Dispatch abgeschlossen ist / Then wurde `s.notifier` kein einziges Mal aufgerufen (0 Calls), auch nach mehrfachem Aufruf von `briefingDispatch()` im selben Prozess.
+  - Test: `sched.notifier` als zählende Test-Funktion injizieren, `sched.briefingDispatch()` mit leerer `HeartbeatComparePresets` und Erfolgs-Stubs für beide Teil-Endpunkte mehrfach aufrufen, Call-Count auf 0 prüfen.
+
+- **AC-2:** Given der generische `pingHeartbeat`-Mechanismus wird für einen anderen `jobName` als `briefing_dispatch` mit leerer URL aufgerufen (z. B. `another_job`) / When `pingHeartbeat(jobName, "")` ausgeführt wird / Then wird `s.notifier` genau einmal mit `recipient="infra"` aufgerufen (Bestandsschutz Issue #118).
+  - Test: bestehender/angepasster `TestPingHeartbeat_EmptyURL_TriggersNotifier`-artiger Test bleibt grün, ruft `sched.pingHeartbeat("another_job", "")` auf und prüft `len(calls) == 1` sowie `recipient == "infra"`.
+
+- **AC-3:** Given `briefingDispatch()` läuft mit gesetzter, nicht-leerer `heartbeatComparePresets`-URL / When beide Teil-Jobs `ok` melden / Then wird der Heartbeat wie bisher exakt einmal per HTTP-GET gepingt (unverändertes Verhalten, kein Regressions-Risiko für den konfigurierten Fall).
+  - Test: bestehender `TestBriefingDispatch_HeartbeatOnlyOnCompareOk` Subtest "both ok -> heartbeat pinged exactly once" bleibt unverändert grün.
+
+## Known Limitations
+
+- Der Fix ist gezielt auf `briefing_dispatch` beschränkt; sollte künftig ein weiterer Job dauerhaft ohne Heartbeat-URL betrieben werden sollen, braucht dieser Job denselben expliziten Leer-URL-Zweig (kein generischer Opt-out-Mechanismus wird hier eingeführt).
+- Der lokale Log-Eintrag bei leerer URL ersetzt keine aktive Überwachung — die Überwachung für `briefing_dispatch` läuft weiterhin ausschließlich über den externen "Gregor20 Core"-Heartbeat (`check-gregor20.sh`, #1898).
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Bugfix-Korrektur eines bereits getroffenen Betriebs-Entscheids (Überwachung via #1898 statt `HEARTBEAT_COMPARE_PRESETS`); kein neues Architektur-Muster, keine neue Entscheidungsfläche.
+
+## Changelog
+
+- 2026-08-17: Initial spec created

--- a/internal/scheduler/heartbeat_warn_spam_test.go
+++ b/internal/scheduler/heartbeat_warn_spam_test.go
@@ -1,0 +1,58 @@
+// Issue #1931 AC-1: briefing_dispatch mit bewusst leerer
+// heartbeatComparePresets-URL (Prod-Normalfall seit #1898) darf keine
+// MQ-Warnung mehr an infra ausloesen, auch nicht nach mehreren Laeufen im
+// selben Prozess.
+package scheduler
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/henemm/gregor-api/internal/config"
+)
+
+func TestBriefingDispatch_EmptyHeartbeatURL_DoesNotWarnInfra(t *testing.T) {
+	type call struct {
+		recipient string
+		subject   string
+	}
+	var mu sync.Mutex
+	var calls []call
+
+	triggerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"status":"ok","count":1}`)
+	}))
+	defer triggerServer.Close()
+
+	cfg := &config.Config{
+		PythonCoreURL:     triggerServer.URL,
+		SchedulerTimezone: "Europe/Vienna",
+		// HeartbeatComparePresets bewusst leer gelassen (Prod-Zustand, #1898).
+	}
+	sched, err := New(cfg, testStore(t))
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	sched.notifier = func(_, recipient, _, subject, _ string) error {
+		mu.Lock()
+		calls = append(calls, call{recipient, subject})
+		mu.Unlock()
+		return nil
+	}
+
+	sched.briefingDispatch()
+	sched.briefingDispatch()
+
+	mu.Lock()
+	n := len(calls)
+	got := append([]call(nil), calls...)
+	mu.Unlock()
+	if n != 0 {
+		t.Fatalf("expected 0 notifier calls for briefing_dispatch with empty "+
+			"heartbeat URL (accepted state since #1898), got %d: %v", n, got)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -305,6 +305,14 @@ func (s *Scheduler) briefingDispatch() {
 
 	if tripLR != nil && tripLR.Status == "ok" &&
 		compareLR != nil && compareLR.Status == "ok" {
+		// Issue #1931: HEARTBEAT_COMPARE_PRESETS ist in Prod bewusst dauerhaft
+		// leer (Ueberwachung laeuft stattdessen ueber den bestehenden
+		// "Gregor20 Core"-Heartbeat, #1898) — dafuer darf keine MQ-Warnung an
+		// infra mehr ausgeloest werden, nur noch ein lokaler Log-Hinweis.
+		if s.heartbeatComparePresets == "" {
+			log.Printf("[scheduler] briefing_dispatch: Heartbeat-URL absichtlich leer (#1898), kein MQ-Versand")
+			return
+		}
 		s.pingHeartbeat("briefing_dispatch", s.heartbeatComparePresets)
 	}
 }


### PR DESCRIPTION
## Summary
- `briefingDispatch()` löste bei jedem Prod-Neustart erneut eine MQ-Warnung an `infra` aus, weil `HEARTBEAT_COMPARE_PRESETS` bewusst dauerhaft leer ist (#1898, Überwachung läuft über `check-gregor20.sh`) und der `sync.Once`-Schutz nur pro Prozesslaufzeit gilt.
- Für `briefing_dispatch` mit leerer Heartbeat-URL wird jetzt nur noch lokal geloggt, keine MQ-Nachricht mehr verschickt. Der generische `pingHeartbeat`/`warnMissingHeartbeatOnce`-Mechanismus bleibt für andere Jobs unverändert (Bestandsschutz Issue #118).
- Adversary-Verifikation: VERIFIED, 3 Mutationen (M1-M3) alle mutation-proven gefangen.

Closes #1931

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./internal/scheduler/...` — 143 Tests grün
- [x] Adversary Mutations-Gegenprobe (3/3 gefangen)