### PR TITLE
fix(#1708 Scheibe C): Cleanup-Script + Prod-Selftest-Waechter fuer tote trips-Ablage

### DIFF
--- a/.claude/hooks/prod_selftest.py
+++ b/.claude/hooks/prod_selftest.py
@@ -807,9 +807,18 @@ def run_selftest(
     if menu_finding["status"] == "FAIL":
         verdict = "FAIL"
 
+    # Phase 5: Tote-Trips-Wächter (additiv, #1708 Scheibe C)
+    dead_trips_finding = check_dead_trips_guard()
+    dead_trips_line = (
+        f"\n## Tote-Trips-Wächter (#1708 Scheibe C)\n\n"
+        f"Status: **{dead_trips_finding['status']}** — {dead_trips_finding['detail']}\n"
+    )
+    if dead_trips_finding["status"] == "FAIL":
+        verdict = "FAIL"
+
     report_content = _render_full_report(
         workflow, head, health_msg, verdict, probes, unusable_findings
-    ) + menu_line
+    ) + menu_line + dead_trips_line
     _write_report(report_path, report_content)
 
     _log(f"Verdict={verdict} (Bericht: {report_path})")
@@ -863,6 +872,53 @@ def _load_bot_commands() -> list[dict] | None:
         return None  # BOT_COMMANDS nicht gefunden
     except Exception:  # noqa: BLE001
         return None
+
+
+def check_dead_trips_guard(users_root: Path = Path("/var/lib/gregor/users")) -> dict:
+    """Additive Phase 5 (#1708 Scheibe C): sucht per `sudo -n find` nach
+    verbliebenen `trips`/`trips.TOT-legacy-…`-Ordnern unter `users_root/*/`.
+
+    Fund -> FAIL, kein Fund -> PASS. Ist der Check selbst nicht ausführbar
+    (sudo-/find-Fehler, z.B. weil users_root nicht existiert) -> SKIPPED,
+    fail-open analog `_check_bot_menu_prod()` bei fehlendem Token — eine
+    unabhängige Nicht-Prüfbarkeit darf keinen Prod-Deploy blockieren.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "sudo", "-n", "find", str(users_root), "-maxdepth", "2",
+                "-type", "d", "(", "-name", "trips", "-o", "-name", "trips.TOT-legacy-*", ")",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {
+            "check": "dead_trips_guard",
+            "status": "SKIPPED",
+            "detail": f"find nicht ausführbar: {exc}",
+        }
+
+    if result.returncode != 0:
+        return {
+            "check": "dead_trips_guard",
+            "status": "SKIPPED",
+            "detail": f"find fehlgeschlagen (Exit {result.returncode}): {result.stderr.strip()}",
+        }
+
+    found = [line for line in result.stdout.splitlines() if line.strip()]
+    if found:
+        return {
+            "check": "dead_trips_guard",
+            "status": "FAIL",
+            "detail": f"tote trips-Ablage gefunden: {', '.join(found)}",
+        }
+    return {
+        "check": "dead_trips_guard",
+        "status": "PASS",
+        "detail": f"keine trips/trips.TOT-legacy-…-Ordner unter {users_root}",
+    }
 
 
 def main() -> int:

--- a/docs/context/fix-1708-c-tote-ablage-loeschen.md
+++ b/docs/context/fix-1708-c-tote-ablage-loeschen.md
@@ -1,0 +1,186 @@
+# Context: #1708 Scheibe C — tote Trip-Ablage archivieren und löschen
+
+## Request Summary
+
+Die tote `trips/`-Ablage (Alt-Pfad vor #1250 Scheibe 7a, seit Scheibe A/B produktivcodeseitig
+tot) steht als Bestand noch an **drei** Datenwurzeln. Scheibe C sichert (tar.gz) und löscht sie
+je Wurzel, mit einem Prod-Selftest-Wächter, der ein Wiederauftauchen meldet. Schließt #1708.
+
+## Gemessener Ist-Stand (2026-08-17, vor jeder Änderung)
+
+Das Issue nennt nur die Prod-Wurzel und "14 Dateien". Nachmessung ergibt drei Wurzeln mit
+unterschiedlichem Zustand:
+
+| Wurzel | Verzeichnisname | Zustand | Dateien |
+|---|---|---|---|
+| **Prod** `/var/lib/gregor/users/*/` | `trips.TOT-legacy-1250-nicht-lesen` | umbenannt 2026-08-10 (Sofortmaßnahme, reversibel) | **15** (4 Nutzer: default, henning, steffi, validator-issue110) |
+| **Staging** `/var/lib/gregor-staging/users/*/` | `trips` (Originalname) | **nie markiert** | 1 Datei (`validator-issue110/staging-validator-rolling.json`) + ~34 leere Verzeichnisse (E2E-Testnutzer) |
+| **Lokal** (Repo-Checkout) `data/users/*/trips/` | `trips` (Originalname, untracked) | **nie markiert** | 9 Dateien (`default`: 1, `validator-issue110`: 8) — je Worktree eigener Stand |
+
+Prod-Dateiliste (mit Größe/mtime):
+```
+default/trips.TOT-legacy-1250-nicht-lesen/gr221-mallorca.json               12178  2026-07-15
+validator-issue110/…/ortler-2025.json                                        709  2026-07-15
+validator-issue110/…/dachstein-2023.json                                     491  2026-07-15
+validator-issue110/…/rofan-2025.json                                         386  2026-07-15
+validator-issue110/…/khw-402.json                                           1658  2026-07-15
+validator-issue110/…/venediger-2024.json                                     818  2026-07-15
+validator-issue110/…/stubai-2024.json                                       1129  2026-07-15
+validator-issue110/…/gardasee-2024.json                                      613  2026-07-15
+validator-issue110/…/zillertal-2025.json                                     383  2026-07-15
+steffi/…/34ab4f37.json                                                     11143  2026-07-15
+henning/…/5f534011.json.bak-datumsfix-20260628-201416                     25542  2026-06-24
+henning/…/gr221-mallorca.json                                             13379  2026-07-15
+henning/…/74de939c.json                                                   20440  2026-07-15
+henning/…/5f534011.json                                                   27483  2026-08-10
+henning/…/14f1aafd.json                                                   16517  2026-07-15
+```
+
+**Wichtig:** Staging- und lokale Verzeichnisse tragen den unauffälligen Originalnamen `trips/` —
+nur Prod ist mit `.TOT-legacy-…` als tot markiert. Genau dort greift die Falle noch, die #1708
+beschreibt: eine Sitzung, die auf Staging oder in einem Worktree schnell nachsieht, sieht ein
+plausibel benanntes Verzeichnis.
+
+## Related Files
+
+| File | Relevance |
+|------|-----------|
+| `scripts/cleanup_1265_prod_testdata.py` | **Vorbild-Muster** für Scheibe C: `--root`/`--backup-dir`/`--execute`, Dry-Run-Default, tar.gz-Backup vor jeder Löschung, Idempotenz (zweiter Lauf → 0 Aktionen), Sanity-Check auf erwartete echte Konten vor dem Löschen |
+| `scripts/cleanup_1133_testdata.py` | Zweites Vorbild, gleiche Bauart |
+| `.claude/hooks/data_schema_backup.py` | Bestehende Backup-Konvention: `.backups/data-pre-rework-<ts>.tar.gz`, Retention 20 |
+| `.claude/hooks/prod_selftest.py` | Post-Deploy-Selftest — Ort für den neuen Wächter (PO-Entscheid: Prod-Selftest, nicht Infra-Monitoring). `run_selftest()` hat vier Phasen (Commit-Attestation, Health, AC-Attestation, Bot-Menü); ein fünfter Filesystem-Check passt als weitere additive Phase analog Phase 4 (Bot-Menü-Check, additiv, kann `verdict = "FAIL"` setzen) |
+| `docs/reference/operations_playbook.md` | Abschnitt "Testdaten-Cleanup" (#1133) und "Compare-Metrik-Auswahl" (#1373 S2 B) dokumentieren dasselbe Backup+Execute-Muster — hier ergänzen |
+| `tests/test_trips_path_revival_guard.py` | Scheibe-A-Wächter — prüft **Quellcode** auf `"trips"`-Literale, keine Überschneidung mit Datenbestand. Bleibt unverändert |
+| `tests/test_briefing_route_cutover.py` | Nutzt `tmp_path`, nicht das echte `data/users` des Repos — vom lokalen Löschen nicht betroffen |
+
+## Existing Patterns
+
+- **Backup-vor-Löschen ist Standard**, nicht neu zu erfinden: `cleanup_1265_prod_testdata.py`,
+  `cleanup_1133_testdata.py`, `migrate_1244_null_lists.py`, `migrate_1373_compare_active_metrics_format.py`
+  — alle: `--root <pfad> [--execute]`, Dry-Run meldet Kandidaten ohne zu schreiben, `--execute`
+  schreibt zuerst `tar.gz` nach `.backups/`, dann erst die Löschung/Änderung. Exit 1 bei
+  Backup-Fehlschlag oder fehlendem `--root`.
+- **Sanity-Check vor Löschung**: `cleanup_1265` bricht ab (kein Backup, keine Löschung), wenn die
+  vier echten Konten unter `--root` fehlen — Indiz für falsches Zielverzeichnis. Für Scheibe C
+  sinnvoll übertragbar: vor dem Löschen prüfen, dass `briefings/` (der lebende Pfad) für jeden
+  betroffenen Nutzer existiert — sonst fehlt die Gegenprobe, dass die toten Daten wirklich
+  redundant sind.
+- **Selftest-Erweiterung additiv**: Phase 4 (Bot-Menü-Check) in `prod_selftest.py` zeigt das
+  Muster für einen zusätzlichen, additiven Check, der bei Fehlschlag `verdict = "FAIL"` setzt,
+  ohne die bestehenden vier Phasen anzufassen.
+
+## Dependencies
+
+- **Upstream:** Scheibe A (`05086722`, Quellcode-Wächter) und Scheibe B1/B2 (`6962e880`,
+  `5ab7c957`, Loader/Testschicht-Rückbau) — beide live. Ohne sie wäre Löschen der Daten
+  gefährlich (noch aktive Schreiber). Jetzt: **null** Produktivaufrufer für `trips/`-Pfade.
+- **Downstream:** keine — der Pfad ist tot, nichts liest ihn.
+- **Betroffene Prozesse:** `deploy-gregor-prod.sh` (Schritt 4b ruft `prod_selftest.py` auf, läuft
+  als User `hem`, NOPASSWD-sudo bestätigt) — der neue Filesystem-Check läuft im selben Kontext.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1708_a_trips_pfad_waechter.md` — Scheibe A, nennt "14 toten
+  Produktivdateien" als offenen Punkt (jetzt widerlegt: 15, plus zwei weitere Wurzeln)
+- `docs/context/fix-1708-waechter-tote-trip-ablage.md` — Ursprungs-Context
+
+## Risks & Considerations
+
+- **Irreversible Löschung in Produktion.** Das Backup muss vor der Löschung verifiziert
+  existieren (nicht nur "geschrieben", sondern lesbar/entpackbar) — Lehre aus
+  BUG-DATALOSS-GR221 (#102): kein Pre-Snapshot existierte, Recovery war Zufall.
+- **Drei unterschiedliche Nutzer/Rechte-Kontexte**: Prod-Dateien gehören `hem`/`claude-gregor`
+  (rws-Gruppenrechte, per `sudo` lesbar), Staging analog, lokal `hem` direkt. Das
+  Cleanup-Script muss in allen drei Kontexten lauffähig sein — ggf. `sudo` für Prod/Staging.
+- **Idempotenz**: ein zweiter Lauf nach erfolgreicher Löschung darf nicht fehlschlagen (Ordner
+  existiert nicht mehr → 0 Aktionen, kein Fehler) — Konvention aus `cleanup_1265`.
+- **Der neue Selftest-Wächter darf nicht fail-closed auf Nicht-Erreichbarkeit reagieren**, wenn
+  `sudo find` aus irgendeinem Grund fehlschlägt (z. B. Rechte-Änderung) — sonst blockiert er
+  Prod-Deploys aus einem unabhängigen Grund. Fehlerbehandlung analog Bot-Menü-Check
+  (`SKIPPED` bei Nicht-Prüfbarkeit, `FAIL` nur bei echtem Fund).
+- **Staging-Verzeichnis enthält ~34 leere `trips/`-Ordner** von E2E-Testnutzern (kein Inhalt,
+  aber ebenfalls tot) — gehören mit ins Löschziel, sonst bleibt die Falle für zukünftige
+  Staging-Sichtungen an ~34 Stellen stehen.
+
+## Analysis
+
+### Type
+Feature (kein Bug — Aufräum-/Löschauftrag mit begleitendem Wächter)
+
+### Bestätigt durch Explore-Agent
+- **Kein Produktionscode** referenziert noch `users/<id>/trips` als Verzeichnis — die Treffer sind
+  ausschließlich Kommentare (die die entfernte Funktion nur erwähnen) und Tests, die selbst
+  temporäre `trips`-Ordner anlegen, um einen **Negativ-Nachweis** zu führen ("wird nicht mehr
+  gelesen"). `src/services/preview_service.py:67-68` hat eine irreführend benannte Variable
+  `trips_dir`, die aber auf den lebenden `briefings/`-Pfad zeigt — kein toter Pfad, kein Blocker,
+  ggf. spätere Kür (nicht Teil dieser Scheibe).
+- **Testmuster für Cleanup-Skripte** etabliert: `tests/tdd/test_prod_testdata_cleanup.py`,
+  `tests/tdd/test_issue_1133_testdata_cleanup.py`, `tests/test_cleanup_admin_prod_purge.py` —
+  alle testen `run_cleanup(users_root, backup_dir, execute=)` gegen `tmp_path`, decken Dry-Run
+  (nichts geschrieben), Execute (Backup vor Löschung, Assertion auf `.tar.gz`), Idempotenz
+  (zweiter Lauf: 0 Aktionen) und Sanity-Abbruch ab.
+- **`prod_selftest.py`-Testort**: gemeinsamer Loader `_load_prod_selftest_module()` in
+  `tests/tdd/conftest.py:122-127` (bewusst zentralisiert) — dort docken neue Tests für Phase 5 an.
+  Zusätzlich Subprozess-Testmuster in `tests/tdd/test_prod_selftest_730.py:53`.
+- **sudo-Konvention**: einziger Präzedenzfall `.claude/hooks/auto_restart_server.py:82`
+  (`subprocess.run(["sudo", "systemctl", "restart", ...])`, kein sichtbarer Timeout). Kein
+  dedizierter Helper im Repo.
+- **`prod_selftest.py` wird nicht importiert von CI**, nur per `python3 .claude/hooks/prod_selftest.py`
+  im Deploy-Ablauf (`.claude/commands/70-deploy.md`) und per `importlib.util.spec_from_file_location`
+  in Tests (kein Package-Import, da unter `.claude/hooks/`, nicht `src/`/`api/`).
+
+### Technischer Ansatz (Plan-Agent, übernommen)
+- **EIN wiederverwendbares Script** (`scripts/cleanup_1708c_dead_trips.py`, `--root`), analog
+  `cleanup_1265_prod_testdata.py`, aber **Muster-Liste** statt Einzel-Positivliste:
+  Zielordnernamen `["trips", "trips.TOT-legacy-1250-nicht-lesen"]` je User, ein Lauf deckt beide
+  Namen ab. Iteriert über `users_root.iterdir()`, löscht **nur den Unterordner**, nie
+  `users/<id>/` selbst (Staging hat ~34 sonst leere User-Hüllen, die bestehen bleiben müssen).
+- **Sanity-Check zweistufig**: (a) erwartete echte Accounts müssen unter `--root` existieren
+  (Verwechslungsschutz falscher Pfad, wie im 1265-Vorbild), (b) mtime-Check: keine Datei in einem
+  Zielordner darf neuer sein als der Cutover-Zeitpunkt (#1250 Scheibe 7a) — sonst Abbruch statt
+  Löschung, als zweite Verteidigungslinie zusätzlich zum bereits durch Scheibe A/B abgesicherten
+  Code-Pfad.
+- **sudo bewusst NICHT im Script** — Script bleibt stdlib-only, wird von außen mit
+  `sudo -n python3 scripts/cleanup_1708c_dead_trips.py --root ... --execute` aufgerufen (kein
+  `uv run` unter sudo, PATH/venv-Risiko vermieden).
+- **Backup-Default vom Vorbild übernehmen**: `users_root.parent / ".backups"` — landet bei Prod
+  automatisch unter `/var/lib/gregor/.backups` (außerhalb Repo), bei Staging analog, lokal unter
+  `data/.backups` im Worktree (gitignored). Nachprüfpunkt: Backup-Dateien nach sudo-Lauf ggf.
+  root:root-Owner — Rechte nach dem Lauf kontrollieren.
+
+### Kritischer Reihenfolge-Punkt (Plan-Agent)
+`prod_selftest.py` läuft bei **jedem** Prod-Deploy (Pflichtschritt 4b). Eine scharfe Phase 5
+("kein `trips`/`trips.TOT-…` mehr vorhanden") darf **nicht** im selben Deploy live gehen, der den
+Cleanup-Code ausliefert — sonst blockiert der erste Selftest-Lauf genau diesen Deploy, weil die
+Prod-Löschung zu dem Zeitpunkt noch nicht stattgefunden hat (Sync passiert vor der manuellen
+Löschung). **Konsequenz für die Spec:** Cleanup gegen Prod ist ein **expliziter, dokumentierter
+manueller Schritt unmittelbar vor** `deploy-gregor-prod.sh` — nicht automatisiert im Deploy-Ablauf
+selbst (kein destruktives Datenskript in einem Hook). Reihenfolge: (a) PR mit Script + Tests +
+Wächter-Code mergen, Staging validieren (dort auch der Staging-Cleanup ausführen); (b) vor dem
+eigentlichen Prod-Deploy-Schritt manuell den Prod-Cleanup laufen lassen, Ergebnis verifizieren
+(0 verbleibende Ordner); (c) erst danach `deploy-gregor-prod.sh` → Selftest mit scharfer Phase 5
+läuft gegen bereits bereinigten Bestand.
+
+### Affected Files (with changes)
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `scripts/cleanup_1708c_dead_trips.py` | CREATE | Backup+Löschung, `--root`/`--backup-dir`/`--execute`, Muster-Liste, Sanity-Checks |
+| `tests/test_cleanup_1708c_dead_trips.py` | CREATE | Kern-Tests gegen `tmp_path`: Dry-Run, Execute+Backup, Idempotenz, Sanity-Abbruch, beide Namensmuster |
+| `.claude/hooks/prod_selftest.py` | MODIFY | Additive Phase 5: Filesystem-Check auf verbleibende `trips`/`trips.TOT-…`-Ordner unter `/var/lib/gregor/users/*/` |
+| `tests/tdd/test_prod_selftest_1708c.py` (Name vorläufig) | CREATE | Test für Phase 5, angedockt an `_load_prod_selftest_module()` |
+| `docs/reference/operations_playbook.md` | MODIFY (docs) | Kurzer Absatz: Cleanup-Ablauf + manueller Reihenfolge-Hinweis vor Prod-Deploy |
+
+### Scope Assessment
+- Files: 5 (2 neu Code + 2 neu Test + 1 Modify + 1 Doku)
+- Estimated LoC: Script ~180-220, Kern-Test ~120-150, `prod_selftest.py`-Erweiterung ~30-50 + Test ~40-60 → **Kern-Summe ~230-280, knapp am 250er-LoC-Limit** — im Blick behalten, ggf. `loc_limit_override` nötig
+- Risk Level: **HIGH** (irreversible Prod-Löschung), Mechanismus selbst aber Standard-Pattern (Low Unsicherheit)
+
+### Dependencies
+- Upstream: Scheibe A (`05086722`) + B1/B2 (`6962e880`, `5ab7c957`) — beide live, Voraussetzung erfüllt
+- Downstream: keine
+- Kein Codepfad ist von der Löschung betroffen (Explore-Agent bestätigt: 0 Produktivaufrufer)
+
+### Open Questions
+- [x] Reichweite: alle drei Wurzeln (PO-Entscheid)
+- [x] Wächter-Ort: Prod-Selftest (PO-Entscheid)
+- [ ] Manuelle Reihenfolge (Cleanup vor scharfer Selftest-Phase) — geht als AC in die Spec, keine weitere Rückfrage nötig

--- a/docs/reference/operations_playbook.md
+++ b/docs/reference/operations_playbook.md
@@ -6,6 +6,44 @@ Details stehen hier — bei Bedarf gezielt nachlesen.
 
 ---
 
+## Tote trips-Ablage archivieren und löschen (#1708 Scheibe C)
+
+`users/<id>/trips/` bzw. `users/<id>/trips.TOT-legacy-1250-nicht-lesen/` ist seit #1250
+Scheibe 7a (2026-07-15) durch `briefings/` abgelöst und seit #1708 Scheibe A/B
+produktivcodeseitig ohne Leser/Schreiber. `scripts/cleanup_1708c_dead_trips.py` sichert
+(tar.gz) und löscht diesen Alt-Bestand je Wurzel — Dry-Run per Default, `--execute` schreibt
+zuerst ein Backup, danach erst die Löschung:
+
+```bash
+python3 scripts/cleanup_1708c_dead_trips.py --root <users_root>              # Dry-Run
+python3 scripts/cleanup_1708c_dead_trips.py --root <users_root> --execute    # Backup + Löschung
+```
+
+`prod_selftest.py` prüft in Phase 5 (`check_dead_trips_guard`), ob unter
+`/var/lib/gregor/users/*/` noch ein `trips`- oder `trips.TOT-legacy-…`-Ordner existiert, und
+läuft bei **jedem** Prod-Deploy. Daraus folgt eine verbindliche Reihenfolge — die Prod-Löschung
+ist ein **manueller** Schritt, der vor dem ersten Deploy mit scharfer Phase 5 liegen muss,
+sonst schlägt der erste Selftest-Lauf nach dem Merge fehl:
+
+1. **lokal** bereinigen — `data/users/*/trips/` im eigenen Worktree-Checkout
+   (`--root data/users --execute`), unabhängig von Prod/Staging.
+2. **Staging** validieren — Cleanup-Lauf gegen `/var/lib/gregor-staging/users` ausführen und
+   Ergebnis (0 verbleibende Ordner) verifizieren.
+3. **Prod-Cleanup** (manuell, **vor** dem eigentlichen Deploy-Schritt): `sudo -n python3
+   scripts/cleanup_1708c_dead_trips.py --root /var/lib/gregor/users --execute` ausführen,
+   Ergebnis verifizieren.
+4. Erst danach `deploy-gregor-prod.sh` ausführen — der darin laufende Selftest trifft mit
+   scharfer Phase 5 auf bereits bereinigten Bestand und meldet PASS.
+
+**Rollback:** Jeder `--execute`-Lauf schreibt vor der Löschung ein `tar.gz`-Backup nach
+`backup_dir / cleanup-1708c-<timestamp>.tar.gz` (Default `backup_dir`:
+`users_root.parent / .backups`). Wiederherstellen mit `tar xzf <backup_path> -C <ziel>`.
+
+Details (Muster-Liste statt Positivliste, Konten-Check vs. informative Zeit-Warnung,
+Idempotenz): Spec `docs/specs/modules/fix_1708_c_tote_ablage_loeschen.md`.
+
+---
+
 ## E2E-Verifikation (`/e2e-verify`) — Detailablauf
 
 Die echte "funktioniert es wirklich"-Verifikation läuft **nach** dem Push gegen die

--- a/docs/specs/modules/fix_1708_c_tote_ablage_loeschen.md
+++ b/docs/specs/modules/fix_1708_c_tote_ablage_loeschen.md
@@ -1,0 +1,338 @@
+---
+entity_id: fix_1708_c_tote_ablage_loeschen
+type: feature
+created: 2026-08-17
+updated: 2026-08-17
+status: draft
+version: "1.1"
+tags: [cleanup, issue-1708, trips-pfad, prod-selftest]
+---
+
+# Fix #1708 Scheibe C — tote Trip-Ablage archivieren und löschen
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Der Alt-Pfad `users/<id>/trips/*.json` (seit #1250 Scheibe 7a, 2026-07-15, durch
+`briefings/` abgelöst und seit Scheibe A/B produktivcodeseitig vollständig tot — 0
+Leser/Schreiber) steht noch als **Datenbestand** an drei Wurzeln (Prod, Staging, lokal).
+Scheibe C sichert (tar.gz) und löscht ihn je Wurzel über ein wiederverwendbares
+Cleanup-Script, ergänzt einen additiven Prod-Selftest-Wächter gegen ein Wiederauftauchen
+und schließt damit #1708.
+
+## Source
+
+- **File:** `scripts/cleanup_1708c_dead_trips.py` (neu — das Cleanup-Script)
+- **File:** `.claude/hooks/prod_selftest.py` (Erweiterung — additive Phase 5)
+- **Identifier:** `run_cleanup(users_root, backup_dir, execute=)` (Script-Kernfunktion,
+  Vertrag analog `scripts/cleanup_1265_prod_testdata.py::run_cleanup`)
+- **Identifier:** `run_selftest(...)` (Phase 5 wird dort additiv ergänzt, analog Phase 4
+  `_check_bot_menu_prod()`)
+
+Schicht: **Python-Core / Tooling** — beide Dateien liegen außerhalb von `src/`/`api/`
+(Script unter `scripts/`, Hook unter `.claude/hooks/`), kein Frontend-, Go- oder
+FastAPI-Domain-Code betroffen.
+
+## Estimated Scope
+
+- **LoC:** ~230–280 (Script ~180–220, Kern-Tests ~120–150, `prod_selftest.py`-Erweiterung
+  ~30–50 + zugehöriger Test ~40–60) — knapp am 250er-LoC-Limit, ggf.
+  `loc_limit_override` nötig
+- **Files:** 5 (2 neu Code+Test-Script-Paar, 1 Modify Hook, 1 neu Test für Hook, 1 Modify
+  Doku)
+- **Effort:** high (Mechanismus ist Standard-Pattern, aber Risiko-Level HIGH wegen
+  irreversibler Prod-Löschung und drei unterschiedlicher Rechte-Kontexte)
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `scripts/cleanup_1265_prod_testdata.py` | Script (Vorbild) | Referenz-Muster: `--root`/`--backup-dir`/`--execute`, Dry-Run-Default, tar.gz-Backup vor Löschung, Sanity-Check auf erwartete echte Konten, Idempotenz |
+| `scripts/cleanup_1133_testdata.py` | Script (Vorbild) | Zweites Referenz-Muster, gleiche Bauart |
+| `.claude/hooks/data_schema_backup.py` | Hook | Bestehende Backup-Konvention (`.tar.gz` nach `.backups/`), auf die sich der Standard-Ablageort `users_root.parent / ".backups"` beruft |
+| `.claude/hooks/prod_selftest.py::run_selftest` | Funktion | Ort der neuen additiven Phase 5, direkt nach Phase 4 (Bot-Menü-Check) |
+| `tests/tdd/conftest.py::_load_prod_selftest_module` | Fixture | zentraler Loader, an den der neue Phase-5-Test andockt |
+| Scheibe A (`05086722`) + B1/B2 (`6962e880`, `5ab7c957`) | Vorarbeit, live | Voraussetzung: null Produktivaufrufer für `trips/`-Pfade — ohne sie wäre Löschen der Daten gefährlich |
+
+## Implementation Details
+
+### Cleanup-Script (`scripts/cleanup_1708c_dead_trips.py`)
+
+Ein einziges, wiederverwendbares Script für alle drei Wurzeln (Prod, Staging, lokal),
+analog `cleanup_1265_prod_testdata.py`, aber mit **Muster-Liste** statt Einzel-User-
+Positivliste, da die drei Wurzeln unterschiedliche Nutzerbestände haben:
+
+- `TARGET_DIR_NAMES = ["trips", "trips.TOT-legacy-1250-nicht-lesen"]` — je iteriertem
+  `users_root.iterdir()`-Eintrag (`users/<id>/`) wird geprüft, ob einer dieser beiden
+  Namen als Unterordner existiert.
+- Gelöscht wird **ausschließlich der gefundene Unterordner**, nie `users/<id>/` selbst
+  (Staging hat ~34 sonst leere User-Hüllen, die bestehen bleiben müssen, auch wenn ihr
+  `trips/`-Unterordner entfernt wird).
+- CLI-Vertrag identisch zum Vorbild: `--root <pfad>` (Pflicht, kein Default wie beim
+  1265-Vorbild, um Verwechslung auszuschließen), `--backup-dir <pfad>` (Default
+  `users_root.parent / ".backups"`), `--execute` (ohne Flag: Dry-Run).
+- **sudo bewusst nicht im Script** — stdlib-only (`argparse`, `shutil`, `tarfile`,
+  `pathlib`), von außen mit `sudo -n python3 scripts/cleanup_1708c_dead_trips.py --root
+  ... --execute` aufgerufen, wo Dateien anderem Owner gehören (Prod/Staging).
+
+### Sanity-Check vor jeder Löschung (Abbruch) und Zeit-Warnung (informativ)
+
+1. **Konten-Check (Abbruch):** eine Liste erwarteter echter Accounts (analog
+   `REAL_ACCOUNTS` im 1265-Vorbild, für diesen Kontext parametrisierbar da die drei
+   Wurzeln unterschiedliche Konten haben — mindestens `default` muss überall vorhanden
+   sein) muss unter `--root` existieren. Fehlt eines, bricht der Lauf ab: kein Backup,
+   keine Löschung, Fehlermeldung nennt den vermutlich falschen Pfad. Dies ist die
+   einzige Prüfung mit Blockadewirkung.
+2. **Zeit-Warnung (informativ, KEIN Abbruch):** Dateien innerhalb eines gefundenen
+   Zielordners mit einer mtime nach dem Referenzdatum **2026-07-15** (#1250 Scheibe 7a,
+   ADR-0023) werden gezählt und im Dry-Run-/Execute-Bericht als Warnzeile ausgegeben
+   (`WARNUNG: N Datei(en) neuer als 2026-07-15 in <Zielordner> — erwarteter Fund, kein
+   Blocker`). Der Lauf bricht dadurch **nicht** ab, Backup und Löschung laufen bei
+   `--execute` regulär weiter, sofern der Konten-Check bestanden wurde.
+
+   Ein harter Abbruch an dieser Stelle wurde geprüft und bewusst verworfen: die reale
+   Prod-Datei `henning/trips.TOT-legacy-1250-nicht-lesen/5f534011.json` (mtime
+   2026-08-10) wurde nachweislich zweimal von fehlgeleiteten Sitzungen beschrieben
+   (2026-06-28 „Datumsfix", 2026-08-10 ~21:00 „13 Etappendaten verschoben"), **weil**
+   sie fälschlich für den lebenden Pfad gehalten wurde — das ist genau die Fehlerklasse,
+   die #1708 beschreibt, kein Indiz dafür, dass der Pfad tatsächlich noch lebt. Ein
+   Abbruch-Check, der diesen Fund als „verdächtig, vielleicht doch live" wertet, würde
+   den einzigen Lauf blockieren, für den das Script gebaut ist. Der eigentliche Schutz
+   gegen „Pfad ist doch noch live" ist bereits durch Scheibe A+B erbracht (0
+   Produktivaufrufer, per Explore-Agent bestätigt); die Zeit-Warnung liefert dem PO
+   zusätzliche Sichtbarkeit, ist aber keine zweite Verteidigungslinie mit
+   Blockadewirkung.
+
+Der Konten-Check läuft vor dem Backup — ein Abbruch schreibt nichts. Die Zeit-Warnung
+wird unabhängig davon berechnet und erscheint sowohl im Dry-Run- als auch im
+Execute-Bericht, verhindert aber weder Backup noch Löschung.
+
+### Backup-vor-Löschung
+
+Bei `--execute` und mindestens einem geplanten Löschziel: zuerst `tar.gz`-Backup nach
+`backup_dir / f"cleanup-1708c-<timestamp>.tar.gz"` (Inhalt: die betroffenen
+`users/<id>/trips*`-Unterordner, nicht die gesamte `users_root`), danach erst
+`shutil.rmtree()` je gefundenem Zielordner. Backup-Fehler (z. B. Schreibrechte) beendet
+den Lauf mit Exit 1, ohne dass gelöscht wird.
+
+### Idempotenz
+
+Ein zweiter Lauf nach erfolgreicher Löschung findet keine `trips`/`trips.TOT-legacy-…`-
+Unterordner mehr — `total_planned == 0`, kein Backup, keine Aktion, Exit 0. Kein Fehler
+bei bereits bereinigtem Bestand.
+
+### Prod-Selftest-Wächter — additive Phase 5
+
+In `.claude/hooks/prod_selftest.py::run_selftest`, unmittelbar nach Phase 4
+(Bot-Menü-Check, analoge Struktur): ein Filesystem-Check über
+`sudo -n find /var/lib/gregor/users -maxdepth 2 -type d \( -name trips -o -name
+'trips.TOT-legacy-*' \)`.
+
+- **Fund** (mindestens ein Verzeichnis) → `verdict = "FAIL"`, Finding im Bericht.
+- **Kein Fund** → `status = "PASS"`, kein Einfluss auf `verdict`.
+- **Check selbst nicht ausführbar** (sudo-Fehler, `find` nicht verfügbar, Timeout) →
+  `status = "SKIPPED"`, **kein** Einfluss auf `verdict` — fail-open bei
+  Nicht-Prüfbarkeit, analog `_check_bot_menu_prod()` bei fehlendem Token. Ein
+  unabhängiger Rechte-/Infra-Fehler darf keinen Prod-Deploy blockieren, der mit der
+  eigentlichen Prüfung nichts zu tun hat.
+
+### Reihenfolge — Wächter darf nicht im selben Deploy scharf gehen wie der Cleanup-Code
+
+`prod_selftest.py` läuft bei **jedem** Prod-Deploy (Schritt 4b, Pflicht). Würde Phase 5
+im selben Deploy live gehen, der das Cleanup-Script ausliefert, würde der erste
+Selftest-Lauf genau diesen Deploy blockieren — die Prod-Löschung selbst ist ein
+**manueller** Schritt, der zeitlich **nach** dem Code-Sync, aber **vor** dem Selftest-
+Aufruf liegt, und zum Zeitpunkt des ersten Deploys naturgemäß noch nicht stattgefunden
+hat.
+
+Verbindliche Reihenfolge:
+
+1. PR mit Script + Kern-Tests + Wächter-Code (Phase 5) mergen.
+2. Staging validieren: dort den Cleanup-Lauf gegen `/var/lib/gregor-staging/users`
+   ausführen (`--execute`), Ergebnis verifizieren.
+3. **Vor** dem eigentlichen Prod-Deploy-Schritt (`deploy-gregor-prod.sh`): den
+   Prod-Cleanup manuell laufen lassen (`sudo -n python3
+   scripts/cleanup_1708c_dead_trips.py --root /var/lib/gregor/users --execute`),
+   Ergebnis verifizieren (0 verbleibende Ordner).
+4. Erst danach `deploy-gregor-prod.sh` ausführen — der darin laufende Selftest mit
+   scharfer Phase 5 trifft auf bereits bereinigten Bestand und meldet PASS.
+
+Diese Reihenfolge wird in `docs/reference/operations_playbook.md` dokumentiert (kurzer
+Absatz, Verweis aus dem Cleanup-Abschnitt).
+
+### Lokale Wurzel
+
+`data/users/*/trips/` im aktuellen Worktree-Checkout wird mit demselben Script
+bereinigt (`--root data/users --execute`), unabhängig von Prod/Staging — je Worktree
+eigener Stand, keine Reihenfolge-Abhängigkeit zu Schritt 2/3.
+
+### Affected Files
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `scripts/cleanup_1708c_dead_trips.py` | CREATE | Backup+Löschung, `--root`/`--backup-dir`/`--execute`, Muster-Liste `["trips", "trips.TOT-legacy-1250-nicht-lesen"]`, Konten-Check (Abbruch) + Zeit-Warnung (informativ), Idempotenz |
+| `tests/test_cleanup_1708c_dead_trips.py` | CREATE | Kern-Tests gegen `tmp_path`: Dry-Run (nichts geschrieben), Execute+Backup-Nachweis, Idempotenz, Sanity-Abbruch (Konten-Check), Zeit-Warnung ohne Abbruch, beide Namensmuster gleichzeitig in einem Root |
+| `.claude/hooks/prod_selftest.py` | MODIFY | Additive Phase 5 nach Phase 4: `_check_dead_trips_prod()` + Verdrahtung in `run_selftest`, analog Bot-Menü-Check |
+| `tests/tdd/test_prod_selftest_1708c_dead_trips_guard.py` | CREATE | Test für Phase 5, angedockt an `_load_prod_selftest_module()`: FAIL bei Fund, PASS bei keinem Fund, SKIPPED bei Nicht-Prüfbarkeit (kein Einfluss auf Gesamt-Verdict) |
+| `docs/reference/operations_playbook.md` | MODIFY (docs) | Neuer Absatz im Cleanup-Abschnitt: Reihenfolge lokal → Staging → Prod-Cleanup manuell → erst dann Deploy mit scharfer Phase 5 |
+
+## Expected Behavior
+
+- **Input:** `python3 scripts/cleanup_1708c_dead_trips.py --root <pfad> [--backup-dir
+  <pfad>] [--execute]`, ausgeführt gegen eine der drei Wurzeln (lokal direkt, Prod/
+  Staging via `sudo -n`); nachgelagert `prod_selftest.py` als Teil von Schritt 4b des
+  Deploy-Ablaufs.
+- **Output:** Dry-Run listet gefundene `trips`/`trips.TOT-legacy-…`-Unterordner ohne zu
+  schreiben, inklusive etwaiger Zeit-Warnzeilen. `--execute` schreibt zuerst ein
+  lesbares/entpackbares `tar.gz`-Backup, löscht danach exakt diese Unterordner (nie
+  `users/<id>/` selbst), meldet Backup-Pfad + Aktionszahl + Zeit-Warnungen. Fehlt ein
+  erwartetes echtes Konto, bricht der Lauf ohne Backup/Löschung ab; eine Zeit-Warnung
+  allein bricht **nicht** ab. Ein zweiter Lauf nach erfolgreicher Löschung meldet 0
+  Aktionen. `prod_selftest.py` Phase 5 meldet nach dem Prod-Cleanup PASS; vor dem
+  Cleanup (oder bei einem späteren Wiederauftauchen) FAIL; bei technischer
+  Nicht-Prüfbarkeit SKIPPED ohne Einfluss auf das Gesamt-Verdict.
+- **Side effects:** unwiderrufliche Löschung von Verzeichnissen unter den drei
+  Datenwurzeln (abgesichert durch vorheriges Backup); keine Änderung an
+  Produktivverhalten, da der Pfad seit Scheibe A/B keinen Leser/Schreiber mehr hat.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein `users/<id>/`-Verzeichnis enthält entweder einen Unterordner
+  `trips` oder `trips.TOT-legacy-1250-nicht-lesen` / When das Cleanup-Script gegen die
+  Wurzel läuft / Then erkennt es beide Namensmuster gleichwertig als Löschziel, ohne
+  eine Einzel-User-Positivliste zu benötigen.
+  - Test: ein `tmp_path`-Root mit einem User im Namensmuster A und einem zweiten im
+    Namensmuster B — beide werden im Dry-Run-Ergebnis als Kandidaten gelistet.
+
+- **AC-2:** Given ein User-Verzeichnis `users/<id>/` enthält neben `trips/` weitere
+  Unterordner (z. B. `briefings/`) / When der Cleanup-Lauf mit `--execute` läuft / Then
+  wird ausschließlich der `trips`- bzw. `trips.TOT-legacy-…`-Unterordner entfernt,
+  `users/<id>/` selbst und alle Geschwister-Unterordner bleiben unangetastet.
+  - Test: nach `--execute` existiert `users/<id>/` weiterhin und `users/<id>/briefings/`
+    ist unverändert vorhanden, nur der Trips-Unterordner ist verschwunden.
+
+- **AC-3:** Given kein `--execute`-Flag wird übergeben / When das Script gegen einen
+  Root mit Löschkandidaten läuft / Then wird nichts geschrieben oder gelöscht (weder
+  Backup noch Zielordner); erst mit `--execute` wird zuerst ein `tar.gz`-Backup
+  geschrieben und danach gelöscht.
+  - Test: Dry-Run-Lauf gefolgt von Dateisystem-Prüfung (Zielordner und `.backups/`
+    unverändert/nicht vorhanden); Execute-Lauf gefolgt von Prüfung, dass das
+    `.tar.gz` vor der Löschung existiert und mit `tarfile.open()` lesbar ist.
+
+- **AC-4:** Given unter `--root` fehlt mindestens eines der erwarteten echten Konten /
+  When ein Lauf mit `--execute` gestartet wird / Then bricht der Lauf ohne Backup und
+  ohne Löschung ab, mit einer Fehlermeldung, die auf ein vermutlich falsches
+  `--root` hinweist.
+  - Test: `tmp_path`-Root ohne das erwartete Konto `default` — nach dem Lauf existiert
+    kein `.tar.gz`, kein Zielordner wurde entfernt, Exit-Code ≠ 0.
+
+- **AC-5:** Given ein Zielordner unter `--root` enthält eine Datei mit einer mtime nach
+  dem Referenzdatum 2026-07-15 (#1250 Scheibe 7a) — wie real bei
+  `henning/trips.TOT-legacy-1250-nicht-lesen/5f534011.json` (mtime 2026-08-10) — / When
+  ein Lauf (Dry-Run oder `--execute`) startet / Then wird die Datei als Warnzeile im
+  Bericht ausgegeben, der Lauf bricht dadurch **nicht** ab und löscht bei `--execute`
+  regulär weiter, sofern der Konten-Check aus AC-4 bestanden wurde. Ein harter Abbruch
+  an dieser Stelle würde den einzigen für dieses Script vorgesehenen Prod-Lauf
+  fälschlich blockieren.
+  - Test: `tmp_path`-Root mit einer künstlich auf ein Datum nach 2026-07-15 gesetzten
+    mtime in einer Datei innerhalb eines Zielordners, Konten-Check besteht — Lauf mit
+    `--execute` schreibt ein Backup und löscht den Zielordner (`actions > 0`), das
+    Ergebnis-Dict enthält eine Warnliste mit genau dieser Datei.
+
+- **AC-6:** Given ein Cleanup-Lauf mit `--execute` hat einen Zielordner bereits
+  erfolgreich entfernt / When das Script ein zweites Mal mit denselben Argumenten
+  läuft / Then werden 0 Aktionen gemeldet, kein neues Backup geschrieben, kein Fehler
+  ausgelöst.
+  - Test: zwei aufeinanderfolgende `run_cleanup(..., execute=True)`-Aufrufe gegen
+    denselben `tmp_path`-Root; der zweite Aufruf liefert `actions == 0` und
+    `backup_path is None`.
+
+- **AC-7:** Given das Cleanup-Script ist als reines stdlib-Programm implementiert /
+  When es mit `sudo -n python3 scripts/cleanup_1708c_dead_trips.py --root ... --execute`
+  gegen Prod oder Staging aufgerufen wird / Then läuft es ohne `uv run` und ohne
+  venv-Abhängigkeit durch (kein `import` außerhalb der Standardbibliothek).
+  - Test: statische Prüfung der Imports in `scripts/cleanup_1708c_dead_trips.py` gegen
+    eine Liste erlaubter stdlib-Module (kein `requests`, kein Projekt-internes Paket).
+
+- **AC-8:** Given `.claude/hooks/prod_selftest.py::run_selftest` durchläuft die
+  bestehenden vier Phasen / When eine neue additive Phase 5 (Filesystem-Check auf
+  verbleibende `trips`/`trips.TOT-legacy-…`-Ordner unter `/var/lib/gregor/users/*/`)
+  ergänzt wird / Then setzt ein Fund `verdict = "FAIL"`, kein Fund lässt das
+  Gesamt-Verdict unverändert (analog zum bestehenden Bot-Menü-Check in Phase 4), und
+  Nicht-Prüfbarkeit (`sudo`/`find`-Fehler) meldet `status = "SKIPPED"` ohne
+  Verdict-Einfluss.
+  - Test: drei Fälle über `_load_prod_selftest_module()` — gemocktes `find` liefert
+    einen Treffer (Verdict wird zu `FAIL`), liefert keinen Treffer (Verdict
+    unverändert), schlägt mit Nicht-Null-Exit fehl (Status `SKIPPED`, Verdict
+    unverändert).
+
+- **AC-9:** Given die Prod-Löschung muss zeitlich vor dem ersten Deploy mit scharfer
+  Phase 5 liegen, weil `prod_selftest.py` bei jedem Prod-Deploy läuft und der
+  Code-Sync vor jeder manuellen Aktion passiert / When der Liefer-Ablauf für Scheibe C
+  durchgeführt wird / Then folgt er der Reihenfolge: (1) PR mergen inkl. Phase-5-Code,
+  (2) Staging-Cleanup ausführen und verifizieren, (3) Prod-Cleanup **manuell** vor
+  `deploy-gregor-prod.sh` ausführen und verifizieren (0 verbleibende Ordner), (4) erst
+  danach `deploy-gregor-prod.sh` ausführen, dessen Selftest-Lauf mit scharfer Phase 5
+  gegen bereits bereinigten Bestand PASS meldet.
+  - Test: kein automatisierter Testnachweis möglich (Ablauf-Disziplin, keine
+    Code-Zusicherung) — Nachweis über `docs/reference/operations_playbook.md`
+    (dokumentierter Absatz, AC-10) plus manuelle Bestätigung im Deploy-Protokoll
+    (`docs/artifacts/<workflow>/prod-selftest.md` zeigt PASS für Phase 5 nach
+    Schritt 3).
+
+- **AC-10:** Given es gibt bisher keine dokumentierte Reihenfolge für Cleanup-Scripte
+  mit begleitendem Selftest-Wächter / When Scheibe C abgeschlossen ist / Then enthält
+  `docs/reference/operations_playbook.md` einen Absatz, der die Reihenfolge lokal →
+  Staging → Prod-Cleanup (manuell, vor Deploy) → Deploy mit scharfer Phase 5 explizit
+  beschreibt.
+  - Test: `docs/reference/operations_playbook.md` enthält nach der Änderung einen
+    Abschnitt, der auf `scripts/cleanup_1708c_dead_trips.py` verweist und die vier
+    Schritte in dieser Reihenfolge nennt (Doku-Nachweis, `# doc-compliance-test`
+    zulässig für den reinen Vorhandensein-Check).
+
+## Known Limitations
+
+- **Prod-Cleanup ist ein manueller, nicht automatisierter Schritt** (siehe AC-9) —
+  bewusst kein destruktives Datenskript in einem Hook oder Deploy-Ablauf. Ein
+  vergessener manueller Schritt lässt Phase 5 einmalig FAIL melden; das ist beabsichtigt
+  (Sicherheitsnetz, kein Bug).
+- **Zeit-Warnung ist informativ, kein Blocker** (siehe AC-5) — geprüft am realen
+  Prod-Bestand: `henning/trips.TOT-legacy-1250-nicht-lesen/5f534011.json` hat mtime
+  2026-08-10 (zweimal von fehlgeleiteten Sitzungen beschrieben — 2026-06-28
+  „Datumsfix", 2026-08-10 ~21:00 „13 Etappendaten verschoben" — WEIL der Pfad
+  fälschlich für lebend gehalten wurde; exakt die Wirkung, die #1708 beschreibt). Ein
+  harter Abbruch an dieser Stelle hätte den einzigen für dieses Script vorgesehenen
+  Prod-Lauf blockiert. Der eigentliche Schutz gegen „Pfad ist doch noch live" bleibt
+  der Konten-Check (AC-4) plus die durch Scheibe A+B bereits bestätigte
+  Code-Pfad-Schließung (0 Produktivaufrufer).
+- **Staging enthält ~34 leere `trips/`-Ordner** von E2E-Testnutzern (kein Inhalt) —
+  werden vom selben Lauf mit entfernt, sind aber im Dry-Run-Bericht nicht separat von
+  gefüllten Ordnern unterschieden (beide erscheinen als Löschkandidat).
+- **Referenzdatum 2026-07-15 ist hart im Script verankert** (Zeit-Warnung) — sollte
+  #1250 rückwirkend korrigiert werden müssen, ist das eine bewusste Code-Änderung, kein
+  Konfigurationswert. Da die Warnung nicht blockiert, hat eine falsche Referenz keine
+  betriebliche Auswirkung, nur eine ungenaue Warnmeldung.
+- **Backup-Retention nicht Teil dieser Scheibe** — anders als `data_schema_backup.py`
+  (Retention 20) rotiert `cleanup_1708c_dead_trips.py` seine Backups nicht automatisch;
+  das folgt dem Vorbild `cleanup_1265_prod_testdata.py`, das ebenfalls keine Rotation
+  hat.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Es wird keine Grundsatzentscheidung geändert oder neu getroffen.
+  ADR-0023 (Cutover `trips/` → `briefings/`) wird zu Ende geführt — Scheibe C entfernt
+  lediglich den letzten toten Datenbestand am bereits abgelösten Pfad. Der
+  Selftest-Wächter folgt dem bestehenden additiven Phasen-Muster in
+  `prod_selftest.py`, keine neue Architekturentscheidung.
+
+## Changelog
+
+- 2026-08-17: Initial spec created (#1708 Scheibe C, letzte Scheibe, schließt das Issue)
+- 2026-08-17: AC-5 von hartem Abbruch auf informative Zeit-Warnung umgebaut (Team-Lead-
+  Befund: die reale Prod-Datei `henning/…/5f534011.json` (mtime 2026-08-10) hätte den
+  einzigen für dieses Script vorgesehenen Prod-Lauf blockiert). Konten-Check (AC-4)
+  bleibt die einzige Prüfung mit Abbruch-Wirkung.

--- a/scripts/cleanup_1708c_dead_trips.py
+++ b/scripts/cleanup_1708c_dead_trips.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Bereinigungs-Script für Issue #1708 Scheibe C — entfernt die tote
+`trips`/`trips.TOT-legacy-…`-Ablage unter `users/<id>/` (seit #1250
+Scheibe 7a durch `briefings/` abgelöst, seit Scheibe A/B produktivcodeseitig
+ohne Leser/Schreiber).
+
+Spec: docs/specs/modules/fix_1708_c_tote_ablage_loeschen.md. Vorbild:
+`scripts/cleanup_1265_prod_testdata.py` (Dry-Run-Default, --execute,
+tar.gz-Backup vor Löschung). Anders als das Vorbild arbeitet dieses Script
+mit einer Muster-Liste statt einer Einzel-User-Positivliste, da die drei
+Wurzeln (Prod/Staging/lokal) unterschiedliche Nutzerbestände haben, und
+sichert nur die betroffenen `trips*`-Unterordner statt der gesamten
+`users_root`.
+
+Usage:
+    python3 scripts/cleanup_1708c_dead_trips.py --root <users_root> \\
+        [--backup-dir <path>] [--execute]
+
+stdlib-only — läuft ohne `uv run`/venv per `sudo -n python3 ...` gegen
+Prod/Staging, wo Dateien anderem Owner gehören.
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+import tarfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Beide Namensmuster gelten gleichwertig als Löschziel (Spec Implementation
+# Details, "Cleanup-Script").
+TARGET_DIR_NAMES = ["trips", "trips.TOT-legacy-1250-nicht-lesen"]
+
+# Referenzdatum #1250 Scheibe 7a / ADR-0023 — Dateien mit neuerer mtime lösen
+# nur eine informative Warnung aus, keinen Abbruch (Spec AC-5).
+CUTOVER_DATE = datetime(2026, 7, 15)
+
+# Konten-Check (Abbruch-Wirkung, Spec AC-4): mindestens `default` muss unter
+# --root existieren, sonst zeigt --root vermutlich auf das falsche
+# Verzeichnis.
+REQUIRED_ACCOUNTS = ("default",)
+
+
+def _plan_targets(users_root: Path) -> list[Path]:
+    """Gefundene `trips`/`trips.TOT-legacy-…`-Unterordner je `users/<id>/`."""
+    if not users_root.is_dir():
+        return []
+    targets = []
+    for user_dir in sorted(users_root.iterdir()):
+        if not user_dir.is_dir():
+            continue
+        for name in TARGET_DIR_NAMES:
+            candidate = user_dir / name
+            if candidate.is_dir():
+                targets.append(candidate)
+    return targets
+
+
+def _missing_required_accounts(users_root: Path) -> list[str]:
+    return [name for name in REQUIRED_ACCOUNTS if not (users_root / name).is_dir()]
+
+
+def _time_warnings(targets: list[Path]) -> list[str]:
+    """Dateien innerhalb eines Zielordners mit mtime nach CUTOVER_DATE —
+    informativ, kein Abbruch (Spec AC-5)."""
+    warnings = []
+    for target in targets:
+        for path in target.rglob("*"):
+            if path.is_file() and datetime.fromtimestamp(path.stat().st_mtime) > CUTOVER_DATE:
+                warnings.append(str(path))
+    return warnings
+
+
+def _make_backup(targets: list[Path], users_root: Path, backup_dir: Path) -> Path:
+    """Sichert nur die betroffenen `trips*`-Unterordner, nicht die gesamte
+    `users_root` (Spec-Vorgabe, weicht vom 1265-Vorbild ab)."""
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup_path = backup_dir / f"cleanup-1708c-{timestamp}.tar.gz"
+    with tarfile.open(backup_path, "w:gz") as tar:
+        for target in targets:
+            arcname = str(target.relative_to(users_root.parent))
+            tar.add(target, arcname=arcname)
+    return backup_path
+
+
+def run_cleanup(users_root: Path, backup_dir: Path, execute: bool = False) -> dict:
+    """Kern-Funktion (Test-Vertrag): Dry-Run meldet Kandidaten ohne zu
+    schreiben; Execute sichert per tar.gz-Backup, löscht dann exakt die
+    gefundenen `trips*`-Unterordner. Konten-Check bricht vor jedem Schreiben
+    ab; die Zeit-Warnung blockiert nicht. Idempotent (zweiter Lauf: 0
+    Aktionen, kein Backup)."""
+    users_root = Path(users_root)
+    backup_dir = Path(backup_dir)
+
+    targets = _plan_targets(users_root)
+
+    result: dict = {
+        "would_remove": [str(t) for t in targets],
+        "time_warnings": _time_warnings(targets),
+        "actions": 0,
+        "backup_path": None,
+        "error": None,
+    }
+
+    if not execute:
+        return result
+
+    missing_accounts = _missing_required_accounts(users_root)
+    if missing_accounts:
+        result["error"] = (
+            f"Abbruch: {users_root} enthält nicht die erwarteten Konten "
+            f"({', '.join(missing_accounts)} fehlen) — falsches --root? "
+            "Kein Backup geschrieben, nichts gelöscht."
+        )
+        return result
+
+    if not targets:
+        return result
+
+    backup_path = _make_backup(targets, users_root, backup_dir)
+    result["backup_path"] = str(backup_path)
+    print(f"Backup geschrieben: {backup_path} (Restore: tar xzf {backup_path} -C <ziel>)")
+
+    actions = 0
+    for target in targets:
+        shutil.rmtree(target)
+        actions += 1
+    result["actions"] = actions
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--backup-dir", type=Path, default=None)
+    parser.add_argument("--execute", action="store_true")
+    args = parser.parse_args(argv)
+
+    users_root = args.root.resolve()
+    if not users_root.exists() or not users_root.is_dir():
+        print(f"Error: --root existiert nicht oder ist kein Verzeichnis: {users_root}", file=sys.stderr)
+        return 1
+    backup_dir = (args.backup_dir or (users_root.parent / ".backups")).resolve()
+
+    result = run_cleanup(users_root, backup_dir, execute=args.execute)
+
+    print(f"Root: {users_root}")
+    print(f"Kandidaten ({len(result['would_remove'])}): {result['would_remove']}")
+    for warning in result["time_warnings"]:
+        print(f"WARNUNG: Datei neuer als 2026-07-15 (#1250 Scheibe 7a): {warning}")
+
+    if not args.execute:
+        print("Dry-run: nichts geschrieben (--execute zum Ausführen).")
+        return 0
+
+    if result.get("error"):
+        print(f"Error: {result['error']}", file=sys.stderr)
+        return 1
+
+    if result["backup_path"]:
+        print(f"Backup: {result['backup_path']}")
+    print(f"Aktionen: {result['actions']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tdd/test_attestation_findings_typsicher.py
+++ b/tests/tdd/test_attestation_findings_typsicher.py
@@ -412,6 +412,17 @@ def test_prod_selftest_survives_mixed_findings_without_crash(tmp_path, monkeypat
     monkeypatch.setattr(mod, "REPO_DIR", root)
     recorder = _HealthOkRecorder(mod)
     monkeypatch.setattr(mod, "_http_get", recorder)
+    # Phase 5 (#1708 Scheibe C) sonst als echter sudo-find-Aufruf gegen
+    # /var/lib/gregor/users — nicht Gegenstand dieses Bugs (AC-5).
+    monkeypatch.setattr(
+        mod,
+        "check_dead_trips_guard",
+        lambda **kwargs: {
+            "check": "dead_trips_guard",
+            "status": "SKIPPED",
+            "detail": "stub (Test #1689 AC-5)",
+        },
+    )
 
     valid_finding = {
         "ac": "AC-1",

--- a/tests/tdd/test_prod_selftest_1708c_dead_trips_guard.py
+++ b/tests/tdd/test_prod_selftest_1708c_dead_trips_guard.py
@@ -1,0 +1,161 @@
+"""TDD RED — Issue #1708 Scheibe C: Prod-Selftest-Wächter gegen
+Wiederauftauchen der toten trips-Ablage (AC-8).
+
+Spec: docs/specs/modules/fix_1708_c_tote_ablage_loeschen.md, AC-8.
+
+Muster wie `check_bot_menu` (Phase 4, test_issue_671_bot_menu_autoset.py):
+eine eigenständige, per Parameter testbare Funktion statt vollem
+`run_selftest`-Rundlauf (Commit-Attestation/Health wären sonst nötig, um sie
+zu erreichen). Kein Mock -- echter `sudo -n find`-Subprozess gegen tmp_path
+(NOPASSWD-sudo auf diesem Host bestätigt, #1708 Context-Dokument).
+
+Abgedeckte Fälle (RED-Phase):
+    FAIL   -- ein `trips`- oder `trips.TOT-legacy-...`-Ordner existiert noch.
+    PASS   -- keiner der beiden Namen existiert.
+    SKIPPED -- der Check selbst ist nicht durchführbar (hier: Root existiert
+               nicht -> `find` liefert einen Fehler statt eines leeren
+               Ergebnisses) -- fail-open, kein Verdict-Einfluss.
+
+Heute ROT: `check_dead_trips_guard` existiert in prod_selftest.py noch
+nicht -> AttributeError.
+"""
+from __future__ import annotations
+
+from tests.tdd.conftest import (
+    _init_evidence_free_repo,
+    _load_prod_selftest_module,
+    _make_e2e_verified,
+)
+
+
+def test_fail_when_legacy_trips_dir_still_exists(tmp_path):
+    """Given `users/henning/trips.TOT-legacy-1250-nicht-lesen/` existiert
+    noch / When der Wächter gegen diesen Root läuft / Then meldet er FAIL
+    mit dem Fundpfad im Detail."""
+    mod = _load_prod_selftest_module()
+    assert hasattr(mod, "check_dead_trips_guard"), (
+        "AC-8 verletzt: prod_selftest.check_dead_trips_guard fehlt"
+    )
+
+    users_root = tmp_path / "users"
+    legacy = users_root / "henning" / "trips.TOT-legacy-1250-nicht-lesen"
+    legacy.mkdir(parents=True)
+
+    finding = mod.check_dead_trips_guard(users_root=users_root)
+
+    assert finding.get("status") == "FAIL", f"erwartet FAIL, war: {finding!r}"
+    assert "henning" in finding.get("detail", ""), (
+        f"Fundpfad fehlt im Detail: {finding!r}"
+    )
+
+
+def test_fail_when_plain_trips_dir_still_exists(tmp_path):
+    """Given `users/default/trips/` (Originalname, wie auf Staging/lokal)
+    existiert noch / When der Wächter läuft / Then FAIL -- beide
+    Namensmuster werden gleichwertig erkannt."""
+    mod = _load_prod_selftest_module()
+
+    users_root = tmp_path / "users"
+    (users_root / "default" / "trips").mkdir(parents=True)
+
+    finding = mod.check_dead_trips_guard(users_root=users_root)
+
+    assert finding.get("status") == "FAIL", f"erwartet FAIL, war: {finding!r}"
+
+
+def test_pass_when_neither_name_pattern_exists(tmp_path):
+    """Given `users/default/` enthält nur `briefings/` (lebender Pfad) /
+    When der Wächter läuft / Then PASS."""
+    mod = _load_prod_selftest_module()
+
+    users_root = tmp_path / "users"
+    (users_root / "default" / "briefings").mkdir(parents=True)
+
+    finding = mod.check_dead_trips_guard(users_root=users_root)
+
+    assert finding.get("status") == "PASS", f"erwartet PASS, war: {finding!r}"
+
+
+def test_skipped_when_check_itself_is_not_executable(tmp_path):
+    """Given der übergebene Root existiert nicht (find kann nicht laufen) /
+    When der Wächter läuft / Then SKIPPED statt FAIL -- eine unabhängige
+    Nicht-Prüfbarkeit darf keinen Prod-Deploy blockieren (fail-open, analog
+    `check_bot_menu` ohne Token)."""
+    mod = _load_prod_selftest_module()
+
+    nonexistent = tmp_path / "does-not-exist" / "users"
+
+    finding = mod.check_dead_trips_guard(users_root=nonexistent)
+
+    assert finding.get("status") == "SKIPPED", f"erwartet SKIPPED, war: {finding!r}"
+
+
+def test_verdict_becomes_fail_when_guard_fails(tmp_path, monkeypatch):
+    """Given `run_selftest` durchläuft die additive Phase 5 / When der
+    Wächter FAIL meldet / Then wird das Gesamt-Verdict TATSÄCHLICH FAIL --
+    echter End-to-End-Lauf von `run_selftest`, nicht nur eine
+    `inspect.getsource`-String-Suche (Adversary-Finding F001, Runde 1: die
+    reine Quelltext-Suche fängt nicht, wenn die Verdict-Zuweisungszeile
+    entfernt wird -- der volle Regressionslauf blieb dabei komplett grün)."""
+    mod = _load_prod_selftest_module()
+    root = tmp_path / "repo"
+    head = _init_evidence_free_repo(root)
+    monkeypatch.setattr(mod, "REPO_DIR", root)
+    monkeypatch.setattr(
+        mod, "_http_get", lambda url, follow_redirects=False: (200, b'{"status": "ok"}', "")
+    )
+    monkeypatch.setattr(
+        mod,
+        "check_dead_trips_guard",
+        lambda **kwargs: {
+            "check": "dead_trips_guard",
+            "status": "FAIL",
+            "detail": "test-fund (F001-Gegenprobe)",
+        },
+    )
+
+    e2e_path = _make_e2e_verified(tmp_path, verified_commit=head)
+    workflow_name = "fix-1708c-ac8-verdict-fail"
+    report_path = root / "docs" / "artifacts" / workflow_name / "prod-selftest.md"
+
+    rc = mod.run_selftest(e2e_path, workflow_name, scope="backend", explicit_path=True)
+
+    assert rc == 1, f"FAIL-Fund des Wächters muss Exit 1 liefern, bekam {rc}"
+    content = report_path.read_text()
+    assert "**Verdict: FAIL**" in content, (
+        f"Gesamt-Verdict muss FAIL sein, wenn check_dead_trips_guard FAIL meldet:\n{content}"
+    )
+
+
+def test_verdict_unchanged_when_guard_passes(tmp_path, monkeypatch):
+    """Gegenprobe zu F001: meldet der Wächter PASS, bleibt das sonst
+    erfolgreiche Gesamt-Verdict PASS -- Phase 5 darf keinen falschen FAIL
+    erzeugen."""
+    mod = _load_prod_selftest_module()
+    root = tmp_path / "repo"
+    head = _init_evidence_free_repo(root)
+    monkeypatch.setattr(mod, "REPO_DIR", root)
+    monkeypatch.setattr(
+        mod, "_http_get", lambda url, follow_redirects=False: (200, b'{"status": "ok"}', "")
+    )
+    monkeypatch.setattr(
+        mod,
+        "check_dead_trips_guard",
+        lambda **kwargs: {
+            "check": "dead_trips_guard",
+            "status": "PASS",
+            "detail": "keine Funde (F001-Gegenprobe)",
+        },
+    )
+
+    e2e_path = _make_e2e_verified(tmp_path, verified_commit=head)
+    workflow_name = "fix-1708c-ac8-verdict-pass"
+    report_path = root / "docs" / "artifacts" / workflow_name / "prod-selftest.md"
+
+    rc = mod.run_selftest(e2e_path, workflow_name, scope="backend", explicit_path=True)
+
+    assert rc == 0, f"PASS-Wächter darf das Gesamt-Verdict nicht auf FAIL ziehen, bekam Exit {rc}"
+    content = report_path.read_text()
+    assert "**Verdict: PASS**" in content, (
+        f"Gesamt-Verdict muss PASS bleiben, wenn check_dead_trips_guard PASS meldet:\n{content}"
+    )

--- a/tests/tdd/test_selftest_auth_redirect.py
+++ b/tests/tdd/test_selftest_auth_redirect.py
@@ -239,6 +239,17 @@ class TestAC5AllLoginRedirectsMustNotYieldPassVerdict:
                     "detail": "stub (RED-Test #1353)",
                 },
             )
+            # Phase 5 (#1708 Scheibe C) sonst als echter sudo-find-Aufruf
+            # gegen /var/lib/gregor/users — nicht Gegenstand dieses Bugs.
+            monkeypatch.setattr(
+                mod,
+                "check_dead_trips_guard",
+                lambda **kwargs: {
+                    "check": "dead_trips_guard",
+                    "status": "SKIPPED",
+                    "detail": "stub (RED-Test #1353)",
+                },
+            )
 
             head = mod._head_sha()
             e2e_data = {

--- a/tests/tdd/test_selftest_auth_required.py
+++ b/tests/tdd/test_selftest_auth_required.py
@@ -148,6 +148,17 @@ def _run_selftest_with_routes(mod, monkeypatch, tmp_path, routes, findings, work
                 "detail": "stub (Test #1367)",
             },
         )
+        # Phase 5 (#1708 Scheibe C) sonst als echter sudo-find-Aufruf gegen
+        # /var/lib/gregor/users — nicht Gegenstand dieses Bugs.
+        monkeypatch.setattr(
+            mod,
+            "check_dead_trips_guard",
+            lambda **kwargs: {
+                "check": "dead_trips_guard",
+                "status": "SKIPPED",
+                "detail": "stub (Test #1367)",
+            },
+        )
 
         e2e_data = {
             "verified_commit": mod._head_sha(),

--- a/tests/test_cleanup_1708c_dead_trips.py
+++ b/tests/test_cleanup_1708c_dead_trips.py
@@ -1,0 +1,268 @@
+"""TDD RED — Issue #1708 Scheibe C: tote trips-Ablage archivieren + löschen.
+
+Spec: docs/specs/modules/fix_1708_c_tote_ablage_loeschen.md
+Context: docs/context/fix-1708-c-tote-ablage-loeschen.md
+
+Abgedeckte ACs (RED-Phase):
+    AC-1: beide Namensmuster (`trips`, `trips.TOT-legacy-1250-nicht-lesen`)
+          werden gleichwertig erkannt -- `scripts/cleanup_1708c_dead_trips.py`
+          existiert noch nicht -> ImportError.
+    AC-2: nur der Trips-Unterordner wird entfernt, `users/<id>/` und
+          Geschwister-Unterordner bleiben unangetastet.
+    AC-3: Dry-Run schreibt nichts; --execute sichert per tar.gz VOR der
+          Löschung.
+    AC-4: Sanity-Abbruch (Konten-Check) -- fehlt das erwartete Konto
+          `default`, bricht der Lauf ohne Backup/Löschung ab.
+    AC-5: Zeit-Warnung ist informativ, blockiert NICHT (siehe Spec-Abschnitt
+          "Sanity-Check ... und Zeit-Warnung" -- bewusst kein Abbruch, weil
+          die reale Prod-Datei henning/.../5f534011.json eine mtime nach dem
+          Referenzdatum trägt und trotzdem gelöscht werden muss).
+    AC-6: zweiter --execute-Lauf ist idempotent (0 Aktionen, kein Backup).
+    AC-7: Script ist stdlib-only (kein Drittanbieter-/Projekt-Import).
+
+Alle Fixtures liegen ausschließlich in tmp_path. KEINE Berührung von
+/home/hem/gregor_zwanzig/data oder produktiven Datenwurzeln.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import tarfile
+from datetime import datetime, timedelta
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "cleanup_1708c_dead_trips.py"
+
+CUTOVER = datetime(2026, 7, 15)
+
+
+def _build_root(tmp_path: Path, *, second_pattern: bool = True) -> Path:
+    """Baut einen Fixture-Baum mit beiden Namensmustern, einem echten Konto
+    (`default`) und einem Geschwister-Unterordner (`briefings`), der stehen
+    bleiben muss."""
+    users_root = tmp_path / "users"
+
+    default_dir = users_root / "default"
+    (default_dir / "trips").mkdir(parents=True)
+    (default_dir / "trips" / "gr221-mallorca.json").write_text("{}")
+    (default_dir / "briefings").mkdir(parents=True)
+    (default_dir / "briefings" / "5f534011.json").write_text("{}")
+
+    if second_pattern:
+        henning_dir = users_root / "henning"
+        (henning_dir / "trips.TOT-legacy-1250-nicht-lesen").mkdir(parents=True)
+        (henning_dir / "trips.TOT-legacy-1250-nicht-lesen" / "gr221-mallorca.json").write_text("{}")
+
+    return users_root
+
+
+# ===========================================================================
+# AC-1: beide Namensmuster
+# ===========================================================================
+
+
+def test_ac1_dry_run_detects_both_name_patterns(tmp_path):
+    """Given ein users_root mit `trips` bei einem User und
+    `trips.TOT-legacy-1250-nicht-lesen` bei einem anderen / When das Script
+    im Dry-Run läuft / Then werden beide als Löschkandidaten gemeldet, ohne
+    eine Einzel-User-Positivliste.
+
+    Heute ROT: `scripts/cleanup_1708c_dead_trips.py` existiert nicht ->
+    ImportError.
+    """
+    from scripts.cleanup_1708c_dead_trips import run_cleanup  # noqa: PLC0415
+
+    users_root = _build_root(tmp_path)
+    result = run_cleanup(users_root, tmp_path / "backups", execute=False)
+
+    candidates = result.get("would_remove", [])
+    assert any("default" in str(c) and "trips" in str(c) for c in candidates), (
+        f"AC-1 verletzt: `trips` bei default nicht als Kandidat erkannt: {result}"
+    )
+    assert any("henning" in str(c) and "TOT-legacy" in str(c) for c in candidates), (
+        f"AC-1 verletzt: `trips.TOT-legacy-...` bei henning nicht erkannt: {result}"
+    )
+    assert not (tmp_path / "backups").exists(), "Dry-Run darf kein Backup schreiben"
+
+
+# ===========================================================================
+# AC-2: nur der Unterordner, nie users/<id>/ selbst
+# ===========================================================================
+
+
+def test_ac2_execute_removes_only_trips_subdir_leaves_siblings_and_user_dir(tmp_path):
+    """Given `default/` enthält `trips/` UND `briefings/` / When --execute
+    läuft / Then existiert `default/` danach weiterhin, `briefings/` ist
+    unverändert, nur `trips/` ist verschwunden."""
+    from scripts.cleanup_1708c_dead_trips import run_cleanup  # noqa: PLC0415
+
+    users_root = _build_root(tmp_path, second_pattern=False)
+    run_cleanup(users_root, tmp_path / "backups", execute=True)
+
+    assert (users_root / "default").is_dir(), (
+        "AC-2 verletzt: users/default/ selbst wurde entfernt"
+    )
+    assert not (users_root / "default" / "trips").exists(), (
+        "AC-2 verletzt: trips/ wurde nicht entfernt"
+    )
+    assert (users_root / "default" / "briefings" / "5f534011.json").exists(), (
+        "AC-2 verletzt: Geschwister-Unterordner briefings/ wurde angetastet"
+    )
+
+
+# ===========================================================================
+# AC-3: Dry-Run schreibt nichts, Execute sichert VOR dem Löschen
+# ===========================================================================
+
+
+def test_ac3_dry_run_writes_nothing_execute_backs_up_before_delete(tmp_path):
+    """Given ein Root mit einem Löschkandidaten / When Dry-Run läuft / Then
+    bleibt alles unverändert. When danach --execute läuft / Then existiert
+    ein lesbares tar.gz-Backup, das den Zielordner enthält, bevor er entfernt
+    wurde."""
+    from scripts.cleanup_1708c_dead_trips import run_cleanup  # noqa: PLC0415
+
+    users_root = _build_root(tmp_path, second_pattern=False)
+    backup_dir = tmp_path / "backups"
+
+    run_cleanup(users_root, backup_dir, execute=False)
+    assert (users_root / "default" / "trips").exists(), "Dry-Run darf nicht löschen"
+    assert not backup_dir.exists() or not any(backup_dir.iterdir()), (
+        "Dry-Run darf kein Backup schreiben"
+    )
+
+    result = run_cleanup(users_root, backup_dir, execute=True)
+    backups = list(backup_dir.glob("*.tar.gz"))
+    assert backups, f"AC-3 verletzt: kein tar.gz-Backup geschrieben: {result}"
+    with tarfile.open(backups[0]) as tar:
+        names = tar.getnames()
+    assert any("gr221-mallorca.json" in n for n in names), (
+        f"AC-3 verletzt: Backup enthält nicht die Trip-Datei: {names}"
+    )
+    assert not (users_root / "default" / "trips").exists(), (
+        "AC-3 verletzt: nach --execute muss der Zielordner entfernt sein"
+    )
+
+
+# ===========================================================================
+# AC-4: Sanity-Abbruch (Konten-Check)
+# ===========================================================================
+
+
+def test_ac4_missing_required_account_aborts_without_backup_or_delete(tmp_path):
+    """Given unter --root fehlt das erwartete Konto `default` / When
+    --execute läuft / Then bricht der Lauf ohne Backup und ohne Löschung ab,
+    Exit-relevanter Fehler wird im Ergebnis gemeldet."""
+    from scripts.cleanup_1708c_dead_trips import run_cleanup  # noqa: PLC0415
+
+    users_root = tmp_path / "users"
+    (users_root / "irgendwer" / "trips").mkdir(parents=True)  # kein "default"
+    backup_dir = tmp_path / "backups"
+
+    result = run_cleanup(users_root, backup_dir, execute=True)
+
+    assert result.get("error"), f"AC-4 verletzt: kein Fehler gemeldet: {result}"
+    assert (users_root / "irgendwer" / "trips").exists(), (
+        "AC-4 verletzt: trotz fehlendem Konto wurde gelöscht"
+    )
+    assert not backup_dir.exists() or not any(backup_dir.iterdir()), (
+        "AC-4 verletzt: trotz fehlendem Konto wurde ein Backup geschrieben"
+    )
+
+
+# ===========================================================================
+# AC-5: Zeit-Warnung ist informativ, blockiert NICHT
+# ===========================================================================
+
+
+def test_ac5_newer_mtime_logs_warning_but_does_not_block_execute(tmp_path):
+    """Given eine Datei im Zielordner trägt eine mtime NACH dem
+    Referenzdatum 2026-07-15 (wie real `henning/.../5f534011.json`,
+    mtime 2026-08-10 -- zweimal fehlgeleitet beschrieben, siehe Spec) / When
+    --execute läuft / Then wird eine Warnung gemeldet, aber Backup UND
+    Löschung laufen trotzdem regulär durch (kein Abbruch)."""
+    from scripts.cleanup_1708c_dead_trips import run_cleanup  # noqa: PLC0415
+
+    users_root = _build_root(tmp_path, second_pattern=False)
+    newer_file = users_root / "default" / "trips" / "gr221-mallorca.json"
+    newer_ts = (CUTOVER + timedelta(days=26)).timestamp()  # 2026-08-10
+    os.utime(newer_file, (newer_ts, newer_ts))
+
+    result = run_cleanup(users_root, tmp_path / "backups", execute=True)
+
+    assert result.get("time_warnings"), (
+        f"AC-5 verletzt: keine Zeit-Warnung trotz neuerer mtime gemeldet: {result}"
+    )
+    assert not (users_root / "default" / "trips").exists(), (
+        "AC-5 verletzt: Zeit-Warnung hat die Löschung blockiert -- das ist "
+        "explizit NICHT gewollt (Spec-Begründung: reale Prod-Datei würde "
+        "sonst nie gelöscht)"
+    )
+    assert not result.get("error"), (
+        f"AC-5 verletzt: Zeit-Warnung darf keinen Abbruch-Fehler erzeugen: {result}"
+    )
+
+
+# ===========================================================================
+# AC-6: Idempotenz
+# ===========================================================================
+
+
+def test_ac6_second_run_is_idempotent_zero_actions(tmp_path):
+    """Given ein erster --execute-Lauf hat den Zielordner entfernt / When das
+    Script ein zweites Mal mit denselben Argumenten läuft / Then werden 0
+    Aktionen gemeldet, kein neues Backup, kein Fehler."""
+    from scripts.cleanup_1708c_dead_trips import run_cleanup  # noqa: PLC0415
+
+    users_root = _build_root(tmp_path, second_pattern=False)
+    backup_dir = tmp_path / "backups"
+
+    run_cleanup(users_root, backup_dir, execute=True)
+    backups_after_first = set(backup_dir.glob("*.tar.gz"))
+
+    second = run_cleanup(users_root, backup_dir, execute=True)
+
+    assert second.get("actions", -1) == 0, (
+        f"AC-6 verletzt: zweiter Lauf ist nicht idempotent: {second}"
+    )
+    assert set(backup_dir.glob("*.tar.gz")) == backups_after_first, (
+        "AC-6 verletzt: zweiter Lauf hat ein neues Backup geschrieben"
+    )
+    assert not second.get("error"), f"AC-6 verletzt: zweiter Lauf meldet Fehler: {second}"
+
+
+# ===========================================================================
+# AC-7: stdlib-only
+# ===========================================================================
+
+
+_ALLOWED_STDLIB = {
+    "__future__", "argparse", "ast", "dataclasses", "datetime", "json",
+    "os", "pathlib", "shutil", "sys", "tarfile", "typing",
+}
+
+
+def test_ac7_script_imports_only_stdlib():
+    """Given das Cleanup-Script muss ohne `uv run`/venv per
+    `sudo -n python3 ...` lauffähig sein / When seine Top-Level-Imports
+    statisch geprüft werden / Then referenziert keiner ein
+    Drittanbieter- oder Projekt-internes Paket.
+
+    Heute ROT: SCRIPT_PATH existiert nicht -> FileNotFoundError.
+    """
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(SCRIPT_PATH))
+
+    top_level_modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                top_level_modules.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            top_level_modules.add(node.module.split(".")[0])
+
+    disallowed = top_level_modules - _ALLOWED_STDLIB
+    assert not disallowed, (
+        f"AC-7 verletzt: Nicht-stdlib-Imports gefunden: {disallowed}"
+    )

--- a/tests/test_operations_playbook_1708c_reihenfolge_doku.py
+++ b/tests/test_operations_playbook_1708c_reihenfolge_doku.py
@@ -1,0 +1,43 @@
+# doc-compliance-test
+"""TDD RED — Issue #1708 Scheibe C, AC-10: Reihenfolge-Doku im
+Operations-Playbook.
+
+Spec: docs/specs/modules/fix_1708_c_tote_ablage_loeschen.md, AC-10.
+
+Reiner Vorhandensein-Nachweis (Ausnahme laut CLAUDE.md-Testpolitik
+ausdrücklich für `# doc-compliance-test` zulässig): das Playbook muss die
+Reihenfolge lokal -> Staging -> Prod-Cleanup (manuell, vor Deploy) -> Deploy
+mit scharfer Phase 5 nennen und auf das Cleanup-Script verweisen.
+
+Heute ROT: der Absatz existiert noch nicht.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLAYBOOK = REPO_ROOT / "docs" / "reference" / "operations_playbook.md"
+
+
+def test_playbook_documents_1708c_cleanup_order():
+    text = PLAYBOOK.read_text(encoding="utf-8")
+
+    assert "cleanup_1708c_dead_trips.py" in text, (
+        "AC-10 verletzt: Playbook verweist nicht auf das Cleanup-Script"
+    )
+    assert "trips.TOT-legacy" in text or "trips" in text.lower(), (
+        "AC-10 verletzt: Playbook nennt die betroffene Ablage nicht"
+    )
+
+    # Die vier Reihenfolge-Schritte müssen alle im selben Abschnitt genannt
+    # sein (grobe Reihenfolge-Prüfung: jeder Marker kommt NACH dem vorigen).
+    markers = ["lokal", "Staging", "Prod-Cleanup", "deploy-gregor-prod.sh"]
+    positions = [text.find(m) for m in markers]
+    assert all(p != -1 for p in positions), (
+        f"AC-10 verletzt: nicht alle Reihenfolge-Marker gefunden: "
+        f"{dict(zip(markers, positions))}"
+    )
+    assert positions == sorted(positions), (
+        f"AC-10 verletzt: Reihenfolge-Marker stehen nicht in der richtigen "
+        f"Abfolge: {dict(zip(markers, positions))}"
+    )


### PR DESCRIPTION
Archiviert (tar.gz) und loescht die tote Trip-Datenablage (users/<id>/trips/*.json
bzw. trips.TOT-legacy-1250-nicht-lesen/, seit #1250 Scheibe 7a durch briefings/
abgeloest, seit Scheibe A/B produktivcodeseitig ohne Leser/Schreiber) ueber ein
wiederverwendbares Script fuer alle drei Datenwurzeln (Prod/Staging/lokal).
Additive Phase 5 in prod_selftest.py meldet kuenftig ein Wiederauftauchen.

Letzte Scheibe von #1708, schliesst das Issue nach Prod-Cleanup + Deploy.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
