### PR TITLE
fix(#1657): Berührende und umschließende Warnfenster sind dieselbe amtliche Warnung

### DIFF
--- a/docs/context/fix-1657-warnung-identitaet.md
+++ b/docs/context/fix-1657-warnung-identitaet.md
@@ -1,0 +1,279 @@
+# Context: fix-1657-warnung-identitaet
+
+Issue: [#1657](https://github.com/henemm/gregor_zwanzig/issues/1657) — „Neu ausgestellte amtliche
+Warnung gilt als neu und geht erneut raus (Zeitraum ist Teil der Identitaet)"
+
+## Request Summary
+
+Dieselbe amtliche Gefahr (z. B. „Gewitterwarnung Kirchbach") erreicht den Nutzer mehrfach, weil
+der Melde-Schutz die zweite Fassung nicht als dieselbe Warnung erkennt. Am KHW-Trip `5f534011`
+am 2026-08-16 kamen zwei Meldungen mit **byte-identischem** Kurztext (`KHW403 AMT GELB1/3: TH
+So13-22, nur Ziel`) 30 Minuten auseinander an.
+
+## Ausgangslage: ein Teil des Issues ist bereits erledigt
+
+Der Issue-Text stammt vom 2026-08-09. Einen Tag spaeter wurde mit **#1685** (PO-Entscheidung
+2026-08-10, live in `main` seit `6cc189ef`/`fdf22069`) genau die dort gestellte Frage teilweise
+beantwortet: eine reine Fenster-Verschiebung oder -Verlaengerung **mit** zeitlicher Ueberlappung
+gilt seitdem als dieselbe Warnung und bleibt still — ausser bei Stufenerhoehung oder einer
+Vorverlegung des Beginns um >= 2h.
+
+Der im Issue-Body genannte Trentino-Fall („gleiches Ende, vier Stunden verschobener Beginn")
+ueberlappt und ist damit vom heutigen Stand erfasst. **Der Body beschreibt einen groesstenteils
+geschlossenen Zustand — der belastbare offene Fall ist der KHW-Vorfall aus dem Kommentar vom
+2026-08-16.**
+
+## Der verbleibende Befund
+
+### Aspekt 1 — aneinandergrenzende Fenster gelten als verschiedene Warnungen
+
+Die Ueberlappungspruefung ist **strikt** (`official_alerts.py:485`):
+
+```python
+if alert_vf < cand_vt and cand_vf < alert_vt:
+```
+
+Die beiden KHW-Meldungen trugen die Fenster `13:00–14:00Z` und `14:00–15:00Z`. Sie grenzen
+aneinander, ueberlappen aber nicht: `14:00 < 14:00` ist falsch. Es wird kein Kandidat gefunden,
+die Funktion faellt auf den exakten Schluesselvergleich zurueck (`_exact_match_verdict`,
+Zeile 464-466), findet unter dem neuen Schluessel nichts — und meldet.
+
+Im Docstring der Testfaelle ist dieser Fall als `ac6-kein-zeit-ueberlapp-meldet` mit
+`expect_report=True` **absichtlich** so festgehalten. Ob die Absicht den Fall
+„luekenlos aneinandergereihte Teilfenster derselben durchgehenden Warnung" mitgemeint hat,
+ist die zu klaerende Produktfrage.
+
+### Aspekt 2 — der Anzeigetext unterscheidet die Meldungen nicht
+
+`_tag_time()` (`official_alerts.py:1848-1870`) rendert ausschliesslich aus
+`alert.valid_from`/`alert.valid_to`. Beide KHW-Meldungen zeigten `So13-22` — das **grobe
+Gesamt-Warnfenster**, waehrend intern nach **stundenfeinen** Teilfenstern unterschieden wurde.
+
+Das ist ein eigenstaendiger Widerspruch: Dedup-Granularitaet und Anzeige-Granularitaet stammen
+nominell aus denselben zwei Feldern, liefern aber verschiedene Werte. **Offene Frage fuer die
+Analyse:** Auf welchem Objekt laeuft die Anzeige, wenn der Melde-Schluessel ein anderes,
+feineres Fenster traegt? Kandidat ist die Buendelung (`dedupe_official_alerts`,
+`_bundle_by_hazard_level`) bzw. die fensterbezogene Abfrage
+`get_official_alerts_for_location(..., window_start, window_end)` in `trip_alert.py:1480-1482`.
+
+Selbst wenn Aspekt 1 als „sachlich berechtigte zweite Meldung" entschieden wird, bleibt fuer den
+Nutzer eine ununterscheidbare Wiederholung stehen.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/output/renderers/alert/official_alerts.py:383-399` | `official_alert_state_key` — baut die Identitaet inkl. Zeitraum |
+| `src/output/renderers/alert/official_alerts.py:402-425` | `_identity_hazard_prefix` — Identitaet **ohne** Zeitraum, fuer die Kandidatensuche |
+| `src/output/renderers/alert/official_alerts.py:428-520` | `official_alert_revision_verdict` — **die zu aendernde Kernregel** (Ueberlappung, Eskalation, Vorverlegung >= 2h) |
+| `src/output/renderers/alert/official_alerts.py:523-534` | `official_alert_state_entry` — Schema des Gedaechtnis-Eintrags |
+| `src/output/renderers/alert/official_alerts.py:1848-1870` | `_tag_time` — Anzeige-Zeitraum (Aspekt 2) |
+| `src/services/trip_alert.py:1487-1511` | Trip-Aufrufstelle inkl. stiller Revision |
+| `src/services/trip_alert.py:1513-1528` | `_record_official_alert_state` — Schreib-Wrapper |
+| `src/services/compare_official_alert.py:255-284, 313-322` | Ortsvergleich-Pendant, strukturgleich gespiegelt |
+| `src/services/alert_briefing_anchor.py:312-342` | `record_official_alerts_reported` — geteilte Schreib-Logik |
+| `src/services/alert_state.py:36, 47-121` | Ablage + `reset()`, behaelt `official_alert:`-Eintraege beim Briefing-Reset (#1614) |
+
+## Existing Patterns
+
+- **Trip und Ortsvergleich teilen sich die drei Kernfunktionen** aus `official_alerts.py` —
+  dupliziert sind nur die Aufrufstellen. Eine Regelaenderung wirkt automatisch in beiden Flaechen;
+  das ist erwuenscht (Code-Teilung als Gate) und muss in beiden getestet werden.
+- **Fail-soft:** fehlen `valid_from`/`valid_to`, entscheidet allein der exakte Schluesseltreffer —
+  kein Interval-Vergleich. Alt-Eintraege ohne Zeitfelder werden uebersprungen.
+- **Zeitstempel immer ueber `_as_aware_utc` normalisieren**, bevor verglichen wird (Adversary F001
+  aus #1685: naiv-vs-aware wirft `TypeError`, und der Aufrufer faengt ihn nicht — der Trip
+  verliert dann **alle** amtlichen Warnungen des Laufs).
+- Stille Revision wird **sofort persistiert**, sonst vergleicht das dritte Kettenglied gegen das
+  veraltete erste Fenster.
+
+## Dependencies
+
+- **Upstream:** `services.official_alerts.base._as_aware_utc`; die Warnquellen (MeteoAlarm,
+  Vigilance, GeoSphere) liefern `valid_from`/`valid_to` teils naiv, teils aware;
+  `get_official_alerts_for_location(window_start, window_end)` schneidet fensterbezogen zu.
+- **Downstream:** `TripAlertService.check_official_alert_triggers`,
+  `CompareOfficialAlertService._detect`, alle vier Ausgabekanaele (E-Mail, Telegram, SMS,
+  Premium-SMS) haengen am Ergebnis.
+
+## Existing Specs
+
+- `docs/specs/modules/fix_1685_warnfenster_revision.md` — **die direkt vorausgehende
+  Entscheidung**, Pflichtlektuere vor jedem Regelvorschlag
+- `docs/specs/modules/fix_1614_briefing_warnfenster.md` — Doppelversand-Schutz nach Briefing
+- `docs/specs/modules/compare_official_alert_channels.md` — Ortsvergleich-Flaeche
+- `docs/adr/0016-amtliche-warnungen-additiver-typ.md`,
+  `docs/adr/0041-zustaendigkeit-warn-quellen-drei-muster.md`
+
+## Bestehende Zusicherungen, die gruen bleiben MUESSEN
+
+| Test | Zusicherung |
+|---|---|
+| `tests/tdd/test_alert_state_briefing_reset.py:704` | Eskalierte Warnung geht trotz bereits gemeldeter unveraenderter Fassung erneut raus |
+| `tests/tdd/test_alert_state_briefing_reset.py:344` | dasselbe Muster (AC-22b), aeltere Benennung |
+| `tests/tdd/test_alert_state_briefing_reset.py:480` | Praefix-Konsistenz zwischen Schluesselbau und `reset()`-Filter |
+| `tests/tdd/test_official_alert_revision_dedup.py:205` | Stufenerhoehung meldet trotz ueberlappendem Fenster (`ac5-stufe-gestiegen-meldet`) |
+| `tests/tdd/test_official_alert_revision_dedup.py:211` | PO-Regel aus #1685 insgesamt (parametrisiert) |
+| `tests/tdd/test_official_alert_revision_dedup.py:544, 615` | Mandantentrennung und Orts-Isolation im Ortsvergleich |
+| `tests/tdd/test_official_alert_dedup_timespan.py:254` | Massiv-Eskalation ohne Zeitraum kollabiert weiterhin |
+
+## Risks & Considerations
+
+- **🔴 Die gefaehrliche Richtung ist Unterdrueckung, nicht Wiederholung.** Wird die Identitaet zu
+  grob, verschwindet eine echte neue Gewitterwarnung. Auf dem KHW (Start 2026-08-20, Huette nur
+  per Satellit erreichbar) ist eine ausgebliebene Warnung ungleich schwerer als eine doppelte.
+  Jede Lockerung braucht eine ausdrueckliche Gegenprobe „neue Warnung nach Pause kommt durch".
+- **Der Fall `ac6-kein-zeit-ueberlapp-meldet` ist heute eine bewusst freigegebene Zusicherung.**
+  Ihn zu aendern heisst, eine bestehende AC zu revidieren — das braucht einen PO-Entscheid, keine
+  stille Umdeutung (vgl. das analoge Muster bei #1599/#1584).
+- **Zwei Aspekte, moeglicherweise zwei Tickets.** Aspekt 2 (Anzeige-Granularitaet) kann fachlich
+  unabhaengig sein und eine eigene Loesung brauchen. Zuschnitt in der Analyse festlegen.
+- **Parallelarbeit:** Sitzung `5c` bearbeitet #1714 am selben Melde-Gedaechtnis (Compare-Seite,
+  `record_official_alerts_reported`-Pendant). Abgesprochen: Aenderungen am Schluesselformat oder
+  Schreibpfad werden vorher gegenseitig angekuendigt.
+- Die Kernstelle traegt dichte Adversary-Regressionskommentare (F001–F007) aus #1685. Diese
+  Faelle sind bereits einmal teuer gelernt worden und duerfen nicht wegrefactort werden.
+
+---
+
+## Analysis
+
+### Type
+
+**Bug** — nutzersichtbares Fehlverhalten, an Produktionsdaten belegt.
+
+### Der Vorfall war groesser als gemeldet
+
+Gelesen aus `/var/lib/gregor/users/henning/alert_state/5f534011.json` (Produktion, nur lesend):
+
+**Kirchbach, 2026-08-16, Gewitter, durchgehend Stufe 2.0 — drei Meldungen:**
+
+| gemeldet (UTC) | Fenster | Ortszeit |
+|---|---|---|
+| 13:15:14 | `13:00–14:00Z` | 15:00–16:00 |
+| 13:45:02 | `14:00–15:00Z` | 16:00–17:00 |
+| 16:30:02 | `11:00–20:00Z` | 13:00–22:00 |
+
+**Obertilliach, 2026-08-11, Gewitter, Stufe 2.0 — dasselbe Muster, ebenfalls drei Meldungen:**
+
+| gemeldet (UTC) | Fenster |
+|---|---|
+| 14:30:14 | `15:00–16:00Z` |
+| 15:45:22 | `17:00–18:00Z` |
+| 17:45:09 | `13:00–19:00Z` |
+
+Zwei unabhaengige Vorfaelle im Abstand von fuenf Tagen, gleiche Form: mehrere schmale Fenster,
+danach ein breites Fenster, das sie umschliesst. **Das ist eine wiederkehrende Klasse, keine
+Stichprobe** — und die im Issue gemeldeten „zwei" Meldungen waren in Wahrheit drei.
+
+### Zwei bestaetigte Mechanismen, ein widerlegter
+
+**(a) Aneinandergrenzende Schmalfenster — BESTAETIGT** (durch Ausfuehrung gegen die echte
+Funktion). `official_alerts.py:485` prueft strikt `alert_vf < cand_vt and cand_vf < alert_vt`.
+Bei `14:00 < 14:00` ist das falsch, `candidates` bleibt leer (490), Rueckfall auf
+`_exact_match_verdict` (464-466), neuer Schluessel ⇒ meldet.
+
+**(b) Das Breitfenster kippt die Vorverlegungs-Ausnahme — BESTAETIGT** (numerisch am
+Kirchbach-Fall durchgerechnet). Das breite Fenster `11:00–20:00Z` ueberlappt beide Schmaleintraege,
+wird also als Kandidat gefunden. Der Tie-Break (493-496, max nach `last_reported_value`, dann
+`reported_at`) waehlt den zuletzt gemeldeten Schmaleintrag mit `valid_from = 14:00`. Zeile 498
+rechnet `14:00 − 11:00 = 3h ≥ 2h` und wertet das als **Vorverlegung** ⇒ meldet.
+
+Das breite Fenster **enthaelt** beide Kandidaten vollstaendig. Es ist keine frueher einsetzende
+Gefahr, sondern eine Zusammenfassung. **Die Ausnahme fuer „die Gefahr kommt frueher" misst hier
+einen Wechsel der Granularitaet.** Damit wendet (b) die #1685-Logik gegen ihren Zweck, statt sie
+nur zu umgehen — der schwerwiegendere der beiden Mechanismen.
+
+**(c) Anzeige-Granularitaet — WIDERLEGT als Buendelungs-Effekt.** Die Vermutung, eine Buendelung
+rendere fuer alle Meldungen den Zeitraum eines gemeinsamen Repraesentanten, haelt dem Code nicht
+stand: `dedupe_official_alerts` (270-323, Schluessel Zeile 315) und `_bundle_by_hazard_level`
+(537-612) fuehren `valid_from`/`valid_to` ausdruecklich als **Schluessel**, nicht als Aggregat
+(Docstring-Tabelle 567-570, abgesichert durch eine Adversary-Regression gegen Datenverlust).
+`render_official_alert_sms` (2007-2025) ruft `_tag_time(n.alert, tz)` **pro Notice einzeln** auf.
+Zwei Alerts mit verschiedenem Fenster koennen strukturell nicht auf einen gemeinsamen
+Anzeige-Zeitraum kollabieren.
+
+Der PO-Befund „beide Meldungen trugen `So13-22`" ist damit **nicht erklaert**. `So13-22` entspricht
+exakt dem breiten Fenster `11:00–20:00Z`, also der dritten Meldung. Offen bleibt, ob die ersten
+beiden Meldungen tatsaechlich einen anderen Text trugen (`So15-16`/`So16-17`) und die Beobachtung
+Meldungen zusammenzieht, oder ob der tatsaechlich versendete Alert ein anderer war als der fuer
+den State geprüfte. Zur Klaerung braeuchte es den rohen GeoSphere-Payload des Polls, der nicht im
+State-File liegt.
+
+### Affected Files (with changes)
+
+| Datei | Change Type | Beschreibung |
+|---|---|---|
+| `src/output/renderers/alert/official_alerts.py` | MODIFY | Nur `official_alert_revision_verdict` (428-520): Beruehrung als Ueberlapp, Containment-Sonderfall vor der Vorverlegungs-Pruefung |
+| `tests/tdd/test_official_alert_revision_dedup.py` | MODIFY | Revision von `ac6`, neue Faelle: Beruehrung, Containment, Zeitnaehe-Guard, Kirchbach/Obertilliach-Regression |
+| `tests/tdd/test_official_alert_dedup_timespan.py` | MODIFY (evtl.) | Abgrenzung „echte Luecke meldet weiterhin" |
+| `docs/specs/modules/fix_1657_warnfenster_identitaet.md` | CREATE | Spec analog zu `fix_1685_warnfenster_revision.md` |
+
+**Trip und Ortsvergleich teilen den Kern** — `compare_official_alert.py` braucht keine Aenderung,
+aber einen Isolationstest, der die Wirkung auch dort nachweist.
+
+### Scope Assessment
+
+- Dateien: 1 Produktionsdatei, 2–3 Testdateien, 1 Spec
+- Geschaetzte LoC: Produktion +20–35, Tests +80–150
+- Risk Level: **MEDIUM-HIGH** — schmale Aenderung an einer sicherheitsrelevanten Stelle
+
+### Technical Approach (Empfehlung der Strategie-Bewertung)
+
+Zwei Aenderungen, beide ausschliesslich in `official_alert_revision_verdict`:
+
+1. **Beruehrung zaehlt als Ueberlapp** — Zeile 485 `<` → `<=`. Schliesst (a) ohne willkuerliche
+   Toleranzspanne. Nur echte 0-Sekunden-Luecken werden erfasst; schon eine Sekunde Abstand bleibt
+   eine eigene Warnung.
+2. **Containment vor der Vorverlegungs-Pruefung** — neue Bedingung vor Zeile 498: umschliesst das
+   neue Fenster den Kandidaten vollstaendig (`alert_vf <= kand_vf and alert_vt >= kand_vt`), gilt
+   die ≥2h-Ausnahme **nicht**, sondern stille Revision. Schliesst (b).
+
+Durchgerechnet am Kirchbach-Fall ergibt die Kombination: **nur die erste Meldung geht raus**,
+die zweite und dritte werden still fortgeschrieben. Gleiches Ergebnis fuer Obertilliach.
+
+**Verworfene Richtungen:** Identitaet ohne Zeitraum (zu grob, verletzt AC-4 aus #1245 direkt —
+die gefaehrlichste Richtung). Praezisierung der Vorverlegung per Minimum statt Tie-Break (reicht
+rechnerisch nicht: `13:00 − 11:00 = 2h` bleibt exakt auf der Schwelle und meldet weiter).
+Fix im GeoSphere-Adapter (wirkt nur fuer eine Quelle, verletzt den geteilten Kern und zerstoert
+die Rohdatenspur, die fuer (c) noch gebraucht wird).
+
+### 🔴 Das Unterdrueckungs-Risiko des Containment-Fixes
+
+`AlertStateService.reset()` (`alert_state.py:47-121`) behaelt `official_alert:`-Eintraege ueber
+den Briefing-Reset hinweg (#1614), und es gibt **keine Bereinigung abgelaufener Eintraege anhand
+von `valid_to`**. Daraus folgt ein konkretes Schluck-Szenario:
+
+> Ein Alt-Eintrag von gestern (`10:00–11:00Z`) liegt unberuehrt im Gedaechtnis. Tage spaeter kommt
+> eine **voellig neue, unabhaengige** Gewitterwarnung derselben Region mit breitem Fenster
+> (`08:00–18:00Z`). Containment wuerde sie als stille Revision des Alt-Eintrags werten und
+> **nicht melden**.
+
+**Pflicht-Gegenmassnahme:** Containment nur anwenden, wenn der Kandidat zeitlich nahe ist
+(`reported_at` innerhalb eines engen Fensters). Sonst faellt der Fall auf `_exact_match_verdict`
+zurueck und meldet. Das braucht einen eigenen Adversary-Testfall, **bevor** die Richtung
+freigegeben wird.
+
+### Dependencies
+
+Unveraendert gegenueber dem Abschnitt oben. Betroffene Quelle in der Praxis: **GeoSphere**
+(Oesterreich) — als einzige koordinaten-scoped Quelle mit kurzer TTL strukturell fuer haeufig
+revidierte Fenster exponiert (`geosphere_warn.py:134-148`). Vigilance (12h-Bloecke) und MeteoAlarm
+(Bulletin-Ebene) arbeiten grob. Der Fix sitzt dennoch in der geteilten Identitaetsregel, damit er
+fuer kuenftige Quellen gleicher Form ebenfalls greift.
+
+### PO-Entscheidungen (2026-08-17, verbindlich)
+
+- [x] **Beruehrende Fenster gelten als dieselbe Warnung.** Der Touching-Teilfall von
+      `ac6-kein-zeit-ueberlapp-meldet` wird revidiert: „exakt aneinandergrenzend" ist kuenftig
+      dieselbe Warnung. **Unveraendert bleibt:** eine echte Luecke — schon eine Sekunde — ist eine
+      eigene, neue Warnung und meldet. Das ist die ausdrueckliche Grenze der Revision.
+- [x] **Zuschnitt: zwei Tickets.** #1657 loest die bestaetigten Mechanismen (a) und (b) und wird
+      damit fertig. Aspekt (c) (identischer Anzeigetext, mechanisch widerlegt, braucht zuerst
+      rohe GeoSphere-Payload-Evidenz) wird als eigenes Issue abgetrennt.
+- [x] **Zeitnaehe-Guard beim Containment: 6 Stunden.** Ein Bestandseintrag darf eine neue Warnung
+      nur dann still schlucken, wenn sein `reported_at` hoechstens 6h zurueckliegt. Aeltere
+      Eintraege zaehlen nicht als Kandidat fuer stille Revision — der Fall faellt dann auf
+      `_exact_match_verdict` zurueck und meldet. Begruendung: bei Kirchbach lagen zwischen erster
+      und letzter Meldung gut 3h; 6h deckt das mit Reserve ab, ohne das Unterdrueckungsfenster
+      unnoetig zu weiten.

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -305,17 +305,27 @@ Scheibe 3 (#1170). Scheduler: `POST /api/scheduler/compare-alert-checks`, Go-Cro
      - Neu (kein Eintrag): Alert sent, Eintrag angelegt
      - Stagnation (`|current - last| < threshold`): unterdrückt
      - Eskalation (`|current - last| >= threshold`): erneut Alert, Wert aktualisiert
-   - **Re-Alert-Logik (amtlicher Raum) seit #1685 (2026-08-11):** entscheidet
-     `official_alert_revision_verdict()` in `output/renderers/alert/official_alerts.py` —
-     **geteilt** von Trip (`trip_alert.check_official_alert_triggers`) und Ortsvergleich
-     (`compare_official_alert._detect`). Überlappt das Gültigkeitsfenster einer Warnung **echt**
-     mit dem eines gemeldeten Eintrags gleicher Identität + Gefahr, bleibt sie **still**;
+   - **Re-Alert-Logik (amtlicher Raum) seit #1685 (2026-08-11), präzisiert durch #1657
+     (2026-08-17):** entscheidet `official_alert_revision_verdict()` in
+     `output/renderers/alert/official_alerts.py` — **geteilt** von Trip
+     (`trip_alert.check_official_alert_triggers`) und Ortsvergleich
+     (`compare_official_alert._detect`). Überlappt das Gültigkeitsfenster einer Warnung mit
+     dem eines gemeldeten Eintrags gleicher Identität + Gefahr, bleibt sie **still**;
      Ausnahmen: Stufe gestiegen ODER Beginn **≥ 2 h früher** (PO-Entscheidung: ein früher
-     eintretendes Ereignis zwingt zum Umplanen). Aneinandergrenzende Fenster sind **keine**
-     Überlappung und bleiben zwei Warnungen — präzisiert #1245 AC-4 zu „T2 überlappt T1 nicht".
-     Bei stiller Revision wird fortgeschrieben (alter Schlüssel entfällt, `reported_at` bleibt
-     das Datum der tatsächlichen Meldung); ohne diese Fortschreibung meldete das dritte Glied
-     einer Revisionskette fälschlich erneut. Die **Anzeige** (`dedupe_official_alerts`) ist davon
+     eintretendes Ereignis zwingt zum Umplanen). **Seit #1657 zählt Berührung als
+     Überlappung** (`<=` statt `<`): aneinandergrenzende Fenster (A endet 14:00, B beginnt
+     14:00) gelten als dieselbe Warnung und bleiben still — das revidiert die vormalige
+     #1245-AC-4-Präzisierung „T2 überlappt T1 nicht". Nur eine echte Lücke, und sei sie nur
+     eine Sekunde, bleibt eigenständig und meldet weiterhin. Zusätzlich erkennt #1657
+     **Containment**: umschließt das neue Fenster einen Bestandskandidaten vollständig UND
+     ist dessen `reported_at` höchstens 6 h alt, entfällt die ≥2h-Vorverlegungs-Ausnahme —
+     der Fall gilt als reiner Granularitätswechsel und bleibt still (die
+     Eskalations-Ausnahme bei Stufenanstieg bleibt davon unberührt wirksam). Ist der
+     Kandidat älter als 6 h, greift Containment nicht — Schutz gegen einen nie bereinigten
+     Alt-Eintrag (#1614), der sonst eine echte neue Warnung verschlucken würde. Bei stiller
+     Revision wird fortgeschrieben (alter Schlüssel entfällt, `reported_at` bleibt das Datum
+     der tatsächlichen Meldung); ohne diese Fortschreibung meldete das dritte Glied einer
+     Revisionskette fälschlich erneut. Die **Anzeige** (`dedupe_official_alerts`) ist davon
      unberührt — beide Perioden bleiben in der Mail sichtbar.
    - **Reset seit #1460 T1 (2026-08-03, ADR-0043):** beim Briefing-Versand wird nur noch der
      Änderungs-Raum (`<feld>:<segment>`) gelöscht — der amtliche Raum überlebt den Reset, damit

--- a/docs/features/issue-816-alert-deviation-core.md
+++ b/docs/features/issue-816-alert-deviation-core.md
@@ -67,14 +67,19 @@ und werden dann wie vor #1685 allein über den exakten Schlüsseltreffer bewerte
 - **Stagnation:** `|current - last_reported| < threshold` → unterdrückt (keine E-Mail).
 - **Eskalation:** `|current - last_reported| >= threshold` → erneut Alert, Wert aktualisiert.
 
-**Re-Alert-Logik (amtliche Warnungen, #1685):** entscheidet
-`official_alert_revision_verdict()` — geteilt von Trip und Ortsvergleich. Überlappt das
-Gültigkeitsfenster einer Warnung **echt** mit dem eines bereits gemeldeten Eintrags gleicher
-Identität + Gefahr, bleibt sie **still**; Ausnahmen: die Stufe ist gestiegen ODER der Beginn
-liegt **≥ 2 h früher**. Aneinandergrenzende Fenster (A endet 22:00, B beginnt 22:00) gelten
-**nicht** als Überlappung und bleiben zwei Warnungen (#1245 AC-4, dort präzisiert zu „T2
-überlappt T1 nicht"). Bei stiller Revision wird der Eintrag fortgeschrieben — der alte
-Schlüssel entfällt, `reported_at` bleibt das Datum der **tatsächlichen** Meldung.
+**Re-Alert-Logik (amtliche Warnungen, #1685, präzisiert durch #1657 am 2026-08-17):**
+entscheidet `official_alert_revision_verdict()` — geteilt von Trip und Ortsvergleich.
+Überlappt das Gültigkeitsfenster einer Warnung mit dem eines bereits gemeldeten Eintrags
+gleicher Identität + Gefahr, bleibt sie **still**; Ausnahmen: die Stufe ist gestiegen ODER
+der Beginn liegt **≥ 2 h früher**. **Seit #1657 zählt Berührung als Überlappung:**
+aneinandergrenzende Fenster (A endet 22:00, B beginnt 22:00) gelten als dieselbe Warnung
+und bleiben still — das revidiert die vormalige #1245-AC-4-Präzisierung „T2 überlappt T1
+nicht"; nur eine echte Lücke bleibt eigenständig. #1657 erkennt außerdem **Containment**:
+umschließt das neue Fenster einen Bestandskandidaten vollständig und ist dessen
+`reported_at` höchstens 6 h alt, bleibt der Fall trotz früherem Beginn still (reiner
+Granularitätswechsel, Eskalation bei Stufenanstieg bleibt wirksam); bei einem älteren
+Kandidaten greift Containment nicht. Bei stiller Revision wird der Eintrag fortgeschrieben
+— der alte Schlüssel entfällt, `reported_at` bleibt das Datum der **tatsächlichen** Meldung.
 
 **Reset:** siehe Punkt 3 — er trifft **nur** den Δ-Raum, nicht die amtlichen Warnungen.
 

--- a/docs/specs/modules/fix_1657_warnfenster_identitaet.md
+++ b/docs/specs/modules/fix_1657_warnfenster_identitaet.md
@@ -1,0 +1,371 @@
+---
+entity_id: fix_1657_warnfenster_identitaet
+type: bugfix
+created: 2026-08-17
+updated: 2026-08-17
+status: draft
+version: "1.0"
+workflow: fix-1657-warnung-identitaet
+---
+
+# Fix #1657: Berührende und ineinander verschachtelte Warnfenster gelten als dieselbe amtliche Warnung
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Dieselbe amtliche Gefahr wird mehrfach gemeldet, wenn die Quelle sie zunächst in
+stundenfeinen Teilfenstern und später als ein zusammenfassendes, breiteres Fenster
+ausstellt (Kirchbach 2026-08-16: drei Meldungen für eine durchgehende Gewitterwarnung;
+Obertilliach 2026-08-11: dasselbe Muster). `official_alert_revision_verdict()`
+(#1685) erkennt Überlappung heute strikt und wertet ein umschließendes Breitfenster
+fälschlich als „Vorverlegung des Beginns" statt als reine Granularitäts-Änderung. Diese
+Spec schließt beide bestätigten Mechanismen — PO-Entscheidung 2026-08-17, Kontext-Doc
+`docs/context/fix-1657-warnung-identitaet.md` Abschnitt „PO-Entscheidungen".
+
+## Source
+
+- **File:** `src/output/renderers/alert/official_alerts.py`
+- **Identifier:** `official_alert_revision_verdict` (Zeile 428-520) — einzige zu
+  ändernde Funktion. `official_alert_state_key` (383-399) und
+  `_identity_hazard_prefix` (402-425) bleiben unverändert.
+- **Aufrufstellen (unverändert, nur Nachweispflicht):** `src/services/trip_alert.py:1487-1511`
+  (`check_official_alert_triggers`), `src/services/compare_official_alert.py:255-284`
+  (`_detect`) — beide teilen sich die geänderte Funktion, keine eigene Anpassung nötig.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `output.renderers.alert.official_alerts.official_alert_state_key` | function | Kanonische Schlüsselbildung, unverändert |
+| `output.renderers.alert.official_alerts._identity_hazard_prefix` | function | Kandidatensuche ohne Zeitraum-Parsing, unverändert |
+| `output.renderers.alert.official_alerts.dedupe_official_alerts` | function | Anzeige-Ebene, bewusst NICHT verändert — zwei Perioden bleiben dort weiterhin zwei Einträge |
+| `services.alert_state.AlertStateService` | class | Melde-Gedächtnis; `reset()` (`alert_state.py:47-121`) behält `official_alert:`-Einträge über den Briefing-Reset hinweg (#1614) — Grund für den Zeitnähe-Guard dieser Spec |
+| `services.trip_alert.TripAlertService.check_official_alert_triggers` | method | Trip-Lesepfad, ruft die geänderte Funktion unverändert auf (Zeile 1499) |
+| `services.compare_official_alert.CompareOfficialAlertService._detect` | method | Ortsvergleich-Lesepfad, ruft die geänderte Funktion unverändert auf (Zeile 268) |
+| `docs/specs/modules/fix_1685_warnfenster_revision.md` | spec | Direkter Vorgänger — führte Überlappungs-/Eskalations-/Vorverlegungs-Prüfung ein; diese Spec präzisiert genau zwei Teilregeln daraus, hebt sie nicht auf |
+| #1245 AC-4 | decision | Ursprung der Zeitraum-in-Identität-Regel; bleibt unverändert für echte, nicht berührende/nicht umschließende Perioden |
+| ADR-0040 | decision | „Eine gerissene Grenze wird einmal gemeldet, erneut erst bei Verschärfung" — bestätigt die Richtung dieser Spec |
+
+## Estimated Scope
+
+- **LoC:** ~35 (Produktivcode +20/-5, Tests +90/-10)
+- **Files:** 3 (1 Produktivdatei, 2 Testdateien)
+- **Effort:** medium
+
+### Affected Files
+
+| File | Change Type | Description |
+|------|-------------|--------------|
+| `src/output/renderers/alert/official_alerts.py` | MODIFY | `official_alert_revision_verdict`: (1) Überlappungsprüfung Zeile 485 von `<` auf `<=` (Berührung zählt), (2) neue Containment-Prüfung vor der Vorverlegungs-Ausnahme (Zeile 498) mit 6h-Zeitnähe-Guard auf `kandidat.reported_at` |
+| `tests/tdd/test_official_alert_revision_dedup.py` | MODIFY | Revision des Touching-Teilfalls von `ac6-kein-zeit-ueberlapp-meldet`, neue Fälle: Containment, Zeitnähe-Guard, Kirchbach-Regression, Obertilliach-Regression, Ortsvergleich-Parität, Stufenerhöhung-unter-Containment |
+| `tests/tdd/test_official_alert_dedup_timespan.py` | MODIFY (falls nötig) | Explizite Gegenprobe „echte Lücke bleibt eigene Warnung" bleibt grün |
+
+### Estimated Changes
+
+- Files: 1 Produktivdatei, 2 Testdateien
+- LoC: +20/-5 Produktivcode; +90/-10 Tests
+
+## Implementation Details
+
+### 1. Berührung zählt als Überlappung
+
+Zeile 485 heute:
+
+```python
+if alert_vf < cand_vt and cand_vf < alert_vt:
+```
+
+Künftig `<=` auf beiden Seiten:
+
+```python
+if alert_vf <= cand_vt and cand_vf <= alert_vt:
+```
+
+Ein Fenster, das exakt dort beginnt, wo das andere endet (`14:00–15:00Z` nach
+`13:00–14:00Z`), zählt jetzt als überlappender Kandidat. Eine echte Lücke — und sei sie
+nur eine Sekunde — bleibt außerhalb des `<=`-Bereichs und fällt weiter auf
+`_exact_match_verdict` zurück (meldet).
+
+### 2. Containment vor der Vorverlegungs-Prüfung, mit Zeitnähe-Guard
+
+Nach der Kandidaten-Auswahl (Tie-Break, Zeile 493-497) wird vor der bestehenden
+Eskalations-/Vorverlegungs-Prüfung (Zeile 498) geprüft, ob das neue Fenster den
+gewählten Kandidaten vollständig umschließt:
+
+```python
+is_containment = alert_vf <= kandidat_vf and alert_vt >= kandidat_vt
+```
+
+Ist das der Fall UND ist der Kandidat frisch (`reported_at` höchstens 6h alt), dann **entfällt die
+≥2h-Vorverlegungs-Ausnahme** — der Fall gilt als reiner Granularitätswechsel und wird
+still fortgeschrieben, es sei denn, die Stufe ist gestiegen. Die bestehende
+Eskalations-Bedingung (`alert.level > kandidat_level`) bleibt unter Containment
+unverändert wirksam — nur der Zeit-Vorverlegungs-Teil der Oder-Bedingung wird
+unterdrückt:
+
+```python
+escalated = alert.level > kandidat_level
+containment_greift = is_containment and kandidat_frisch   # reported_at <= 6h vor `now`
+vorverlegung = (not containment_greift) and (kandidat_vf - alert_vf) >= timedelta(hours=2)
+if escalated or vorverlegung:
+    return True, None, None
+# sonst: stille Revision wie bisher (merged_entry, stale_key)
+```
+
+> **Korrektur 2026-08-17 (in der GREEN-Phase gefunden).** Eine frühere Fassung dieses
+> Blocks trug den Frische-Guard als eigenen Nachsatz:
+> `if is_containment and not _kandidat_is_fresh(...): return _exact_match_verdict()`.
+> Das ist **falsch** und macht den freigegebenen, unveränderten Fall
+> `ac2-nur-verlaengert-still` (#1685 AC-2) rot: „nur verlängert" (gleicher Beginn,
+> späteres Ende) **ist** formal Containment, und wenn dessen `reported_at` älter als 6h
+> ist, hätte der Nachsatz einen bislang stillen Fall in eine Meldung gedreht — obwohl
+> Containment dort gar nichts entscheidet (Vorverlegung = 0h, der Fall wäre ohnehin
+> still). Der Guard darf **ausschliesslich** die Containment-Ausnahme unterdrücken und
+> keine Fälle umdrehen, die auch ohne Containment still wären. Die oben stehende Fassung
+> leistet genau das und ist die implementierte.
+
+Ist der Kandidat NICHT frisch (älter als 6h), greift Containment nicht — der Fall
+fällt auf `_exact_match_verdict` zurück und meldet. Das verhindert, dass ein
+Wochen alter, nie bereinigter State-Eintrag (`AlertStateService.reset()` behält
+`official_alert:`-Einträge über den Briefing-Reset hinweg, #1614) eine völlig neue,
+unabhängige Warnung derselben Region+Gefahr fälschlich verschluckt.
+
+### Nachgerechnet: Kirchbach 2026-08-16 (drei Fenster, alle Stufe 2.0)
+
+1. `13:00–14:00Z` (13:15:14) — kein Kandidat im leeren State → meldet. State: Eintrag mit `reported_at=13:15:14`.
+2. `14:00–15:00Z` (13:45:02) — Berührung mit Kandidat 1 (`14:00 <= 14:00`) zählt jetzt als Überlappung. Kein Containment (`14:00 <= 13:00` ist falsch). Keine Eskalation, keine Vorverlegung (`13:00 − 14:00` negativ) → still fortgeschrieben, `reported_at` bleibt `13:15:14` (übernommen vom Kandidaten, unverändertes #1685-Verhalten).
+3. `11:00–20:00Z` (16:30:02) — überlappt den einzigen verbliebenen State-Eintrag (`14:00–15:00Z`). Containment: `11:00 <= 14:00` und `20:00 >= 15:00` → ja. Guard: `16:30:02 − 13:15:14 = 3h15m`, innerhalb 6h → Containment greift. Keine Eskalation → still.
+
+**Ergebnis: genau eine Meldung** (Schritt 1).
+
+### Nachgerechnet: Obertilliach 2026-08-11 (drei Fenster, alle Stufe 2.0)
+
+1. `15:00–16:00Z` (14:30:14) — kein Kandidat → meldet.
+2. `17:00–18:00Z` (15:45:22) — geprüft gegen Kandidat 1 (`15:00–16:00Z`): `alert_vf=17:00 <= cand_vt=16:00`? **Nein** — echte Lücke von einer Stunde zwischen `16:00Z` und `17:00Z`. Kein Kandidat gefunden → `_exact_match_verdict` → **meldet als eigenständige, neue Warnung**.
+3. `13:00–19:00Z` (17:45:09) — überlappt/umschließt BEIDE bisherigen State-Einträge (Fenster 1 bleibt als verwaister Eintrag stehen, #1685 Known Limitation). Tie-Break wählt den mit höherem `reported_at` bei gleicher Stufe: Kandidat 2 (`17:00–18:00Z`, `reported_at=15:45:22`). Containment: `13:00 <= 17:00` und `19:00 >= 18:00` → ja. Guard: `17:45:09 − 15:45:22 = 2h`, innerhalb 6h → Containment greift. Keine Eskalation → still.
+
+**Ergebnis: GENAU ZWEI Meldungen** (Schritt 1 und Schritt 2) — nicht eine. Die zweite
+Meldung ist nach der neuen Regel weiterhin berechtigt, weil zwischen Fenster 1 und
+Fenster 2 eine echte, einstündige Lücke liegt (`16:00Z` bis `17:00Z`); erst das dritte,
+umschließende Fenster wird korrekt als stille Revision erkannt. Dieses Ergebnis ist
+absichtlich nicht auf „eine Meldung" geschönt — es ist die tatsächliche Konsequenz der
+PO-Regel „echte Lücke bleibt eigene Warnung".
+
+## Zu revidierende Zusicherung
+
+`tests/tdd/test_official_alert_revision_dedup.py`, Parametrisierung um Zeile 198-207,
+Fall `ac6-kein-zeit-ueberlapp-meldet`: deckt heute pauschal „kein Zeit-Überlapp ⇒
+meldet" ab, inklusive des Teilfalls „exakt aneinandergrenzend" (`alert_vf == cand_vt`).
+**Dieser Teilfall wird durch diese Spec revidiert** (PO-Entscheid 2026-08-17,
+Kontext-Doc Abschnitt „PO-Entscheidungen"): exakt aneinandergrenzende Fenster gelten
+künftig als dieselbe Warnung und bleiben still. Der andere Teilfall — eine echte Lücke,
+und sei sie nur eine Sekunde — bleibt unverändert bestehen und meldet weiterhin
+(nachgewiesen an Obertilliach Schritt 2 oben). Der Testfall wird in zwei getrennte
+Parametrisierungen aufgeteilt: `ac6-echte-luecke-meldet` (bleibt `expect_report=True`)
+und `ac6b-beruehrung-still` (neu, `expect_report=False`).
+
+### Nachtrag 2026-08-17 (in der RED-Phase gefunden): eine ZWEITE Fundstelle
+
+Die obige Angabe war unvollständig — dieselbe Zusicherung steht ein zweites Mal an
+anderer Stelle, gefunden beim Schreiben der Tests:
+
+`test_ac1_ac3_ac10_ac11_trip_checker_real_entry`, Teilfall `ac11` (vormals um Zeile
+539-541), prüft denselben Sachverhalt über den **echten Einstieg**
+`check_official_alert_triggers` statt über die reine Funktion:
+
+```python
+adjacent = _run_trip_chain("ac11", [(0, 0, 2), (8, 8, 2)])
+assert len(adjacent[1]) == 1, "AC-11: angrenzend/nicht-ueberlappend muss neu gemeldet werden"
+```
+
+Wegen `base_to == base_from + 8h` startet das zweite Fenster **exakt** bei `base_to` —
+das ist der Berührungsfall aus AC-1. #1685 AC-11 (Herkunft: #1245 AC-4) und #1657 AC-1
+können nicht beide gelten.
+
+**Entscheidung:** Die freigegebene Regel gilt an **beiden** Fundstellen — der PO hat am
+2026-08-17 die Regel freigegeben („berührende Fenster sind dieselbe Warnung"), nicht eine
+einzelne Codezeile. Die Assertion wird auf „meldet nicht erneut" umgestellt. Nutzen
+obendrein: AC-1 ist damit nicht nur an der reinen Funktion abgesichert, sondern auch am
+echten Trip-Einstieg — also dort, wo die Zusicherung tatsächlich wirkt.
+
+**Lehre für die Spec-Arbeit:** Die zuerst genannte Fundstelle war eine Stichprobe, keine
+Vollzählung. Bei „diese Zusicherung wird revidiert" ist die Klasse auszuzählen, nicht das
+zuerst gefundene Exemplar zu benennen.
+
+## Expected Behavior
+
+- **Input:** `official_alert_revision_verdict(alert, state, now=None)` — eine zu prüfende
+  `OfficialAlert` (mit `valid_from`/`valid_to`, `level`, Identitätsfeldern), das
+  Melde-Gedächtnis `state` (Schlüssel → Eintrag mit `last_reported_value`, `reported_at`,
+  `valid_from`, `valid_to`) und optional eine Referenzzeit für den 6h-Frische-Guard.
+- **Output:** unverändertes Tripel `(should_report, stale_key, merged_entry)`.
+  - `(True, None, None)` — melden: exakter Neuzugang, Stufenerhöhung, echte Lücke, echte
+    nicht umschließende Vorverlegung ≥2h, oder Containment mit veraltetem (>6h) Kandidaten.
+  - `(False, stale_key, merged_entry)` — stille Revision: Berührung, echte Überlappung ohne
+    Eskalation, oder Containment mit frischem Kandidaten. Der Aufrufer entfernt `stale_key`
+    aus dem State, legt `merged_entry` unter dem neuen Schlüssel ab und persistiert sofort.
+- **Side effects:** keine innerhalb der Funktion — sie ist rein und schreibt weder State noch
+  Dateien. Die Persistenz bleibt Sache der beiden Aufrufstellen (`trip_alert.py:1502-1508`,
+  `compare_official_alert.py:274-279`), deren Verhalten unverändert bleibt.
+
+## Test Plan
+
+### Test-Schicht
+
+Kern-Schicht (deterministisch): `official_alert_revision_verdict` ist eine reine
+Funktion über `dict`/`OfficialAlert`, kein Netz, kein Mock-Theater.
+
+**Zeit wird injiziert, nicht gemessen.** Jeder Test, der den 6h-Frische-Guard berührt
+(Test 4 und 5), reicht `now` explizit herein und setzt `reported_at` als festen Wert
+relativ dazu. Damit ist die 6h-Grenze exakt prüfbar; kein Test hängt an der Laufzeituhr.
+Das ist Pflicht, keine Stilfrage: Der Guard ist die einzige Sicherung dagegen, dass eine
+echte neue Warnung verschluckt wird — ein an der Grenze sporadisch rot werdender Test
+würde irgendwann als „flaky" abgetan und die Sicherung fiele still aus.
+
+### Automated Tests (TDD RED)
+
+- [ ] **Test 1** (Berührung, still): GIVEN im Melde-Gedächtnis steht eine Warnung mit
+  Fenster `13:00–14:00Z` GELB, WHEN dieselbe Identität+Gefahr mit exakt anschließendem
+  Fenster `14:00–15:00Z` GELB geprüft wird, THEN meldet der Checker sie NICHT erneut.
+- [ ] **Test 2** (echte Lücke, meldet): GIVEN dieselbe Ausgangslage wie Test 1, WHEN
+  das neue Fenster `14:00:01–15:00Z` geprüft wird (eine Sekunde Lücke), THEN meldet der
+  Checker die Warnung als eigenständige, neue Warnung.
+- [ ] **Test 3** (Containment, frisch, still): GIVEN im Melde-Gedächtnis stehen zwei
+  frische Schmaleinträge (`13:00–14:00Z`, `14:00–15:00Z`, `reported_at` vor wenigen
+  Minuten), WHEN ein breites Fenster `11:00–20:00Z` derselben Identität+Gefahr geprüft
+  wird, THEN meldet der Checker es NICHT erneut, obwohl der Beginn 3h früher liegt.
+- [ ] **Test 4** (Zeitnähe-Guard, meldet): GIVEN derselbe Containment-Fall wie Test 3,
+  aber der Bestandskandidat wurde vor mehr als 6h gemeldet (`reported_at` vor 7h), WHEN
+  das breite Fenster geprüft wird, THEN meldet der Checker es erneut als eigenständige
+  Warnung.
+- [ ] **Test 5** (Zeitnähe-Guard, Grenzfall still): GIVEN derselbe Containment-Fall wie
+  Test 3, aber der Bestandskandidat wurde vor genau 5h59min gemeldet, WHEN das breite
+  Fenster geprüft wird, THEN bleibt der Checker still (Guard-Grenze liegt bei >6h, nicht
+  ≥6h).
+- [ ] **Test 6** (Stufenerhöhung überlebt Containment): GIVEN derselbe Containment-Fall
+  wie Test 3, aber das breite Fenster trägt Stufe ORANGE statt GELB, WHEN es geprüft
+  wird, THEN meldet der Checker es trotz Containment erneut als Alarm.
+- [ ] **Test 7** (Vorverlegung ohne Containment meldet weiterhin): GIVEN im
+  Melde-Gedächtnis steht ein Fenster `14:00–22:00Z` GELB, WHEN ein NICHT umschließendes
+  Fenster `12:00–20:00Z` GELB geprüft wird (2h früherer Beginn, aber kein Containment
+  des Bestandskandidaten, da `12:00 <= 14:00` und `20:00 >= 22:00` NICHT beide gelten),
+  THEN meldet der Checker die Warnung erneut wie vor dieser Spec (#1685 AC-3
+  unverändert).
+- [ ] **Test 8** (Kirchbach-Regression): GIVEN die drei realen Fenster
+  `13:00–14:00Z`/13:15:14, `14:00–15:00Z`/13:45:02, `11:00–20:00Z`/16:30:02, alle Stufe
+  2.0, WHEN sie nacheinander geprüft werden, THEN meldet der Checker genau einmal
+  (beim ersten Fenster), die beiden folgenden bleiben still.
+- [ ] **Test 9** (Obertilliach-Regression, ZWEI Meldungen): GIVEN die drei realen
+  Fenster `15:00–16:00Z`/14:30:14, `17:00–18:00Z`/15:45:22, `13:00–19:00Z`/17:45:09,
+  alle Stufe 2.0, WHEN sie nacheinander geprüft werden, THEN meldet der Checker GENAU
+  ZWEI Mal (erstes und zweites Fenster, echte Lücke dazwischen), das dritte, umschließende
+  Fenster bleibt still.
+- [ ] **Test 10** (Ortsvergleich-Parität): GIVEN dieselbe Containment-Ausgangslage wie
+  Test 3, aber im Melde-Gedächtnis eines Ortsvergleichs-Orts
+  (`CompareOfficialAlertService._detect`), WHEN das breite Fenster für diesen Ort
+  geprüft wird, THEN verhält sich der Ortsvergleichs-Pfad identisch zum Trip-Pfad
+  (still).
+- [ ] **Test 11** (Stufenerhöhung bei reiner Überlappung, Regression #1685 AC-5): GIVEN
+  ein überlappendes, NICHT umschließendes Fenster derselben Identität+Gefahr mit
+  gestiegener Stufe, WHEN es geprüft wird, THEN meldet der Checker es weiterhin — wie
+  vor dieser Spec.
+- [ ] **Test 12** (Fail-soft unverändert, Regression): GIVEN eine Warnung ohne
+  `valid_from`/`valid_to` steht mit unverändertem Level im Melde-Gedächtnis, WHEN
+  dieselbe zeitlose Warnung erneut geprüft wird, THEN entscheidet weiterhin
+  ausschließlich der exakte Schlüsseltreffer, keine Containment- oder
+  Berührungsprüfung greift.
+
+## Acceptance Criteria
+
+- **AC-1:** Given im Melde-Gedächtnis steht eine amtliche Warnung mit Fenster `13:00–14:00Z` GELB, When dieselbe Identität+Gefahr mit exakt anschließendem Fenster `14:00–15:00Z` GELB geprüft wird, Then meldet der Checker sie NICHT erneut (Berührung zählt als Überlappung).
+  - Test: Test 1.
+
+- **AC-2:** Given dieselbe Ausgangslage wie AC-1, When das neue Fenster eine Sekunde später beginnt (`14:00:01–15:00Z`, echte Lücke), Then meldet der Checker die Warnung als eigenständige, neue Warnung — das ist die ausdrückliche Grenze der Revision.
+  - Test: Test 2.
+
+- **AC-3:** Given im Melde-Gedächtnis stehen zwei frische Schmalfenster derselben Identität+Gefahr (`reported_at` vor wenigen Minuten), When ein breites, beide vollständig umschließendes Fenster geprüft wird, Then meldet der Checker es NICHT erneut, obwohl sein Beginn früher liegt als der jüngste Kandidat.
+  - Test: Test 3.
+
+- **AC-4:** Given derselbe Containment-Fall wie AC-3, aber der Bestandskandidat wurde vor mehr als 6 Stunden gemeldet, When das breite Fenster geprüft wird, Then meldet der Checker es erneut als eigenständige Warnung (Zeitnähe-Guard verhindert das Verschlucken einer echten neuen Warnung durch einen veralteten State-Eintrag).
+  - Test: Test 4.
+
+- **AC-5:** Given derselbe Containment-Fall wie AC-3, aber die neue Warnung trägt eine höhere Stufe als der umschlossene Kandidat, When sie geprüft wird, Then meldet der Checker sie trotz Containment als Alarm — die Eskalations-Zusicherung aus #1685 bleibt unter Containment unverändert wirksam.
+  - Test: Test 6.
+
+- **AC-6:** Given im Melde-Gedächtnis steht ein Fenster mit spätem Beginn, When ein neues, NICHT umschließendes Fenster mit mindestens 2 Stunden früherem Beginn geprüft wird, Then meldet der Checker die Warnung erneut — die Vorverlegungs-Ausnahme aus #1685 bleibt für echte, nicht umschließende Vorverlegungen unverändert bestehen.
+  - Test: Test 7.
+
+- **AC-7 (Kirchbach-Regression):** Given die drei realen Kirchbach-Fenster vom 2026-08-16 (`13:00–14:00Z`, `14:00–15:00Z`, `11:00–20:00Z`, alle Stufe 2.0, in dieser Reihenfolge), When sie nacheinander geprüft werden, Then meldet der Checker genau EINMAL (beim ersten Fenster), die beiden folgenden Fenster bleiben still fortgeschrieben.
+  - Test: Test 8.
+
+- **AC-8 (Obertilliach-Regression, nachgerechnet):** Given die drei realen Obertilliach-Fenster vom 2026-08-11 (`15:00–16:00Z`, `17:00–18:00Z`, `13:00–19:00Z`, alle Stufe 2.0, in dieser Reihenfolge, mit einer echten einstündigen Lücke zwischen Fenster 1 und Fenster 2), When sie nacheinander geprüft werden, Then meldet der Checker GENAU ZWEIMAL (erstes und zweites Fenster), nur das dritte, umschließende Fenster bleibt still — nicht „genau einmal".
+  - Test: Test 9.
+
+- **AC-9 (Ortsvergleich-Parität):** Given dieselbe Containment-Ausgangslage wie AC-3, aber im Melde-Gedächtnis eines Ortsvergleichs-Orts statt eines Trips, When der Ortsvergleichs-Checker (`_detect`) das breite Fenster prüft, Then verhält er sich identisch zum Trip-Pfad — still, wie in AC-3.
+  - Test: Test 10.
+
+- **AC-10 (Regression, Fail-soft unverändert):** Given eine Warnung ohne `valid_from`/`valid_to` steht mit unverändertem Level im Melde-Gedächtnis, When dieselbe zeitlose Warnung erneut geprüft wird, Then entscheidet weiterhin ausschließlich der exakte Schlüsseltreffer — keine Berührungs- oder Containment-Prüfung greift bei fehlenden Zeitfeldern.
+  - Test: Test 12.
+
+## Non-Regression
+
+| Quelle | Zusicherung | Auswirkung dieser Spec |
+|---|---|---|
+| `test_official_alert_revision_dedup.py:205` (`ac5-stufe-gestiegen-meldet`) | Stufenerhöhung meldet trotz Überlappung | Unverändert, zusätzlich explizit unter Containment geprüft (AC-5) |
+| `test_official_alert_revision_dedup.py:198-207` (`ac6-kein-zeit-ueberlapp-meldet`) | **PRÄZISIERT (siehe „Zu revidierende Zusicherung")**: nur der Teilfall „echte Lücke" bleibt bestehen (AC-2), der Teilfall „Berührung" wird revidiert (AC-1) |
+| `test_official_alert_revision_dedup.py:544, 615` | Mandantentrennung und Orts-Isolation im Ortsvergleich | Unverändert — beide Prüfungen laufen weiter auf getrennten `AlertStateService`-Instanzen je Nutzer/Ort |
+| #1685 AC-3/AC-4 (Vorverlegung, kein Containment) | Echte Vorverlegung ≥2h ohne Containment meldet | Unverändert, AC-6 dieser Spec sichert das explizit ab (Test 7) |
+| `official_alerts.py:468-469` (Fail-soft) | Fehlende `valid_from`/`valid_to` ⇒ exakter Schlüsseltreffer entscheidet | Unverändert (AC-10) |
+| #1245 AC-1 / `dedupe_official_alerts` | Anzeige zeigt überlappende/berührende Perioden weiterhin getrennt | Unverändert — nur das Melde-Gedächtnis wird angefasst, nicht die Anzeige-Ebene |
+| ADR-0040 | „Eine gerissene Grenze wird einmal gemeldet, erneut erst bei Verschärfung" | Bestätigt und für Berührung/Containment präzisiert |
+
+## Nicht in dieser Scheibe
+
+- **Aspekt (c) — identischer Anzeigetext bei stundenfeinen Teilfenstern** (Kontext-Doc,
+  Abschnitt „Zwei bestätigte Mechanismen, ein widerlegter"): mechanisch widerlegt als
+  Bündelungs-Effekt, ungeklärt bleibt, ob der PO-Befund „beide Meldungen trugen `So13-22`"
+  auf einer anderen Ursache beruht. Braucht rohe GeoSphere-Payload-Evidenz zur Klärung —
+  eigenes Issue, PO-Entscheid 2026-08-17.
+- Aspekt (c) ist damit ausdrücklich NICHT durch diese Spec geschlossen, auch wenn die
+  Mechanik (a)/(b) behoben ist.
+
+## Known Limitations
+
+- **Verwaiste State-Einträge bleiben bestehen** (unverändert aus #1685): wird ein
+  Kandidat durch Tie-Break nicht ausgewählt (z.B. Fenster 1 im Obertilliach-Fall), bleibt
+  sein Schlüssel unverändert im Melde-Gedächtnis stehen. Harmlos für die Melde-Logik
+  (spätere Prüfungen wählen wieder per Tie-Break), aber ohne separate Bereinigung wächst
+  das Melde-Gedächtnis pro Identität+Gefahr unbegrenzt.
+- **Der 6h-Zeitnähe-Guard schützt nur den Containment-Zweig**, nicht die
+  Berührungs-Prüfung (Änderung 1) und nicht den bestehenden Überlappungs-/
+  Vorverlegungs-Zweig aus #1685. Ein Wochen alter, exakt berührender oder echt
+  überlappender State-Eintrag wird weiterhin als Kandidat gefunden — das ist
+  unverändertes #1685-Verhalten, nicht Teil dieser Scheibe.
+- **Der 6h-Guard braucht eine Referenzzeit — sie wird injizierbar geführt.** Die
+  Funktion erhält einen **optionalen** Parameter `now: datetime | None = None`; ist er
+  `None`, gilt `datetime.now(timezone.utc)`. Beide Aufrufstellen (`trip_alert.py:1499`,
+  `compare_official_alert.py:268`) bleiben dadurch **unverändert** — der Default greift.
+  Tests reichen `now` explizit herein und prüfen die 6h-Grenze damit exakt statt relativ
+  zur Laufzeituhr.
+
+  **Begründung (PO-Punkt 2026-08-17):** Ein Guard, dessen Testbarkeit an der Wanduhr
+  hängt, wird ausgerechnet an der Grenze unzuverlässig — und dieser Guard ist die
+  einzige Sicherung dagegen, dass eine echte neue Warnung verschluckt wird. Ein
+  sporadisch rot werdender Test an genau dieser Stelle wird erfahrungsgemäß irgendwann
+  als „flaky" abgetan, und damit fällt die Sicherung still aus. Der optionale Parameter
+  kostet nichts und macht AC-4 deterministisch prüfbar.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Chirurgische Präzisierung zweier Teilregeln innerhalb der bestehenden
+  #1685-Architektur (dieselbe Funktion, dieselbe Signatur, keine neue Grundsatz-
+  entscheidung zu Kanälen, Provider, Datenmodell, Auth oder Editor-Paradigma).
+  ADR-0040 deckt die Grundrichtung bereits ab.
+
+## Changelog
+
+- 2026-08-17: Initial spec created (Issue #1657, PO-Entscheidung 2026-08-17 aus dem Analyse-Dialog übernommen; Obertilliach-Regression eigenständig nachgerechnet, Ergebnis „zwei Meldungen" statt geschönter „eine Meldung").

--- a/docs/specs/modules/fix_1685_warnfenster_revision.md
+++ b/docs/specs/modules/fix_1685_warnfenster_revision.md
@@ -225,6 +225,11 @@ Mock-Theater. Testdatei nach Verhalten benannt (`test_naming_gate.py`).
 
 - **AC-11:** Given zwei aneinandergrenzende, NICHT überlappende Fenster derselben Identität+Gefahr+Stufe (A endet 22:00, B beginnt exakt 22:00), When B geprüft wird, Then meldet der Checker B als eigenständige, neue Warnung — Präzisierung von #1245 AC-4 zu „T2 überlappt T1 nicht".
   - Test: Test 11.
+  - **Präzisiert durch #1657 (2026-08-17):** Die Annahme „aneinandergrenzend = keine
+    Überlappung" wird revidiert — Berührung zählt seither als Überlappung und bleibt
+    still (`docs/specs/modules/fix_1657_warnfenster_identitaet.md` AC-1/AC-2). Diese AC-11
+    ist damit als Beschreibung des Ist-Zustands überholt; sie bleibt hier stehen, weil sie
+    die #1245-Herkunft der Regel dokumentiert.
 
 - **AC-12:** Given zwei getrennt gemeldete Perioden derselben Identität+Gefahr (überlappend oder aneinandergrenzend), When die Anzeige-Funktion `dedupe_official_alerts` läuft, Then zeigt sie weiterhin beide Perioden getrennt — die neue Regel wirkt ausschließlich im Melde-Gedächtnis, nicht in der Anzeige.
   - Test: Test 12.
@@ -238,7 +243,7 @@ Diese Änderung darf keine der folgenden bestehenden Zusicherungen brechen
 |---|---|---|
 | #1245 AC-1 | Zwei Perioden gleicher Region+Gefahr bleiben in `dedupe_official_alerts` **zwei Einträge** | Unverändert — AC-12 sichert das explizit ab, die Anzeige-Funktion wird nicht angefasst |
 | #1245 Known Limitation | Kein Interval-Merging: überlappende Perioden werden NICHT zu einem Gesamtzeitraum verschmolzen | Unverändert — die Fortschreibung ersetzt nur den State-EINTRAG (Melde-Gedächtnis), sie verschmilzt keine angezeigten Zeiträume |
-| **#1245 AC-4 — PRÄZISIERT** | Bisher: „Neue Periode T2 ≠ T1 erzeugt eigenen Zustands-Key ohne A zu überschreiben." Neu: „T2 **überlappt T1 nicht**" — nur dann bleiben beide State-Keys unabhängig; überlappt T2 T1 (ohne Eskalation/≥2h-Vorverlegung), wird T1 durch die Fortschreibung ersetzt. Der bewachende Test `tests/tdd/test_official_alert_dedup_timespan.py:271` (`TestAC4TriggerNewPeriodFiresIndependently`) nutzt Perioden, die exakt aneinandergrenzen (Periode B beginnt exakt dort, wo Periode A endet — `period_b_from = period_a_to`) und bleibt damit ohne Änderung grün, weil aneinandergrenzende Fenster nach dieser Spec (AC-11) weiterhin KEINE echte Überlappung sind. |
+| **#1245 AC-4 — PRÄZISIERT, seit #1657 (2026-08-17) ERNEUT PRÄZISIERT** | Bisher: „Neue Periode T2 ≠ T1 erzeugt eigenen Zustands-Key ohne A zu überschreiben." Diese Spec (#1685): „T2 **überlappt T1 nicht**" — nur dann bleiben beide State-Keys unabhängig; überlappt T2 T1 (ohne Eskalation/≥2h-Vorverlegung), wird T1 durch die Fortschreibung ersetzt. Der damalige Test `tests/tdd/test_official_alert_dedup_timespan.py:271` nutzte exakt aneinandergrenzende Perioden (`period_b_from = period_a_to`) als Gegenprobe für „keine echte Überlappung". **#1657 kippt genau diese Annahme:** Berührung zählt seither als Überlappung und bleibt still; die Testdatei wurde im Zuge von #1657 entsprechend angepasst (siehe `docs/specs/modules/fix_1657_warnfenster_identitaet.md`). |
 | #1245 AC-2/AC-3 | Eskalation am selben Zeitraum bzw. Massiv-Sperren kollabieren auf Maximum | Unverändert — betrifft `dedupe_official_alerts`, nicht die neue Melde-Entscheidung |
 | #1460 AC-20/AC-22 | `official_alert:`-Einträge überleben den Briefing-Reset | Unverändert — Fortschreibungs-Einträge tragen weiterhin denselben Präfix, `AlertStateService.reset()` behandelt sie identisch |
 | #1614 AC-1/AC-2 | Im Briefing gemeldete Warnung feuert im Alarm-Checker nicht erneut; Eskalation feuert weiterhin | Erweitert, nicht ersetzt — #1614 deckte den Doppelversand zwischen Briefing-Schreibpfad und Checker-Lesepfad ab, diese Spec deckt die Revision-Erkennung INNERHALB des Checkers selbst ab |
@@ -299,3 +304,6 @@ Diese Änderung darf keine der folgenden bestehenden Zusicherungen brechen
 ## Changelog
 
 - 2026-08-11: Initial spec created (Issue #1685, PO-Entscheidung 2026-08-10 aus dem Dialog übernommen).
+- 2026-08-17: Präzisiert durch #1657 — „aneinandergrenzend = keine Überlappung" (AC-11,
+  #1245-AC-4-Präzisierung) gilt nicht mehr; Berührung zählt jetzt als Überlappung. Details
+  und zusätzliche Containment-Regel: `docs/specs/modules/fix_1657_warnfenster_identitaet.md`.

--- a/src/output/renderers/alert/official_alerts.py
+++ b/src/output/renderers/alert/official_alerts.py
@@ -426,7 +426,7 @@ def _identity_hazard_prefix(alert: "OfficialAlert") -> str:
 
 
 def official_alert_revision_verdict(
-    alert: "OfficialAlert", state: dict,
+    alert: "OfficialAlert", state: dict, now: "datetime | None" = None,
 ) -> tuple[bool, Optional[str], Optional[dict]]:
     """Issue #1685: Melde-Entscheidung fuer eine amtliche Warnung, die eine
     reine Fenster-Revision einer bereits gemeldeten Warnung derselben
@@ -455,7 +455,23 @@ def official_alert_revision_verdict(
     triggers` faengt das NICHT ab, sodass der Trip fuer den Lauf ALLE amtlichen
     Warnungen verliert. Deshalb werden hier ALLE verglichenen Zeitpunkte --
     Kandidat UND `alert` selbst -- vor jedem Vergleich normalisiert, und der
-    Vergleich steht im selben geschuetzten Block wie das Parsen."""
+    Vergleich steht im selben geschuetzten Block wie das Parsen.
+
+    Issue #1657 (PO-Entscheidung 2026-08-17): zwei Praezisierungen.
+    (1) Beruehrung zaehlt als Ueberlappung -- ein Fenster, das exakt dort
+    beginnt, wo das andere endet, ist dieselbe durchgehende Gefahr in
+    stundenfeiner Ausgabe. Eine echte Luecke (und sei sie eine Sekunde)
+    bleibt eine eigenstaendige Warnung.
+    (2) Umschliesst das neue Fenster den gewaehlten Kandidaten vollstaendig,
+    ist das ein reiner Granularitaetswechsel und keine Vorverlegung -- die
+    >=2h-Vorverlegungs-Ausnahme entfaellt dann. Die Eskalations-Bedingung
+    bleibt davon unberuehrt. Ein 6h-Frische-Guard auf `reported_at` des
+    Kandidaten verhindert, dass ein alter, nie bereinigter State-Eintrag
+    (`AlertStateService.reset()` behaelt `official_alert:`-Eintraege ueber
+    den Briefing-Reset hinweg, #1614) eine echte neue Warnung verschluckt.
+    Referenzzeit `now` ist injizierbar (Default `datetime.now(timezone.utc)`),
+    damit die 6h-Grenze exakt und nicht gegen die Laufzeituhr geprueft wird --
+    beide Aufrufstellen bleiben dadurch unveraendert."""
     from services.official_alerts.base import _as_aware_utc
 
     key = official_alert_state_key(alert)
@@ -472,7 +488,7 @@ def official_alert_revision_verdict(
     alert_vt = _as_aware_utc(alert.valid_to)
 
     prefix = _identity_hazard_prefix(alert)
-    candidates: list[tuple[str, dict, datetime]] = []
+    candidates: list[tuple[str, dict, datetime, datetime]] = []
     for cand_key, entry in state.items():
         if not cand_key.startswith(prefix):
             continue
@@ -482,20 +498,52 @@ def official_alert_revision_verdict(
         try:
             cand_vf = _as_aware_utc(datetime.fromisoformat(vf_raw))
             cand_vt = _as_aware_utc(datetime.fromisoformat(vt_raw))
-            if alert_vf < cand_vt and cand_vf < alert_vt:
-                candidates.append((cand_key, entry, cand_vf))
+            # Issue #1657 AC-1: `<=` statt `<` -- Beruehrung zaehlt als
+            # Ueberlappung. Eine echte Luecke faellt weiterhin heraus (AC-2).
+            if alert_vf <= cand_vt and cand_vf <= alert_vt:
+                candidates.append((cand_key, entry, cand_vf, cand_vt))
         except (TypeError, ValueError):
             continue
 
     if not candidates:
         return _exact_match_verdict()
 
-    stale_key, kandidat, kandidat_vf = max(
+    stale_key, kandidat, kandidat_vf, kandidat_vt = max(
         candidates,
         key=lambda c: (c[1].get("last_reported_value", 0), c[1].get("reported_at") or ""),
     )
     kandidat_level = kandidat.get("last_reported_value", 0)
-    if alert.level > kandidat_level or (kandidat_vf - alert_vf) >= timedelta(hours=2):
+
+    # Issue #1657 AC-3/AC-4: Containment = das neue Fenster umschliesst den
+    # Kandidaten vollstaendig. Dann ist der frueher liegende Beginn eine
+    # Granularitaets-Aenderung, keine Vorverlegung. Der Guard laesst das nur
+    # fuer einen FRISCHEN Kandidaten gelten; ein Eintrag ohne verwertbaren
+    # `reported_at` gilt bewusst als NICHT frisch, damit im Zweifel gemeldet
+    # statt verschluckt wird. Das Parsen steht im selben geschuetzten Block
+    # wie die Normalisierung (Adversary F001: naiv-vs-aware wirft sonst
+    # `TypeError`, den der Aufrufer nicht abfaengt).
+    is_containment = alert_vf <= kandidat_vf and alert_vt >= kandidat_vt
+    kandidat_frisch = False
+    if is_containment:
+        try:
+            ref_now = _as_aware_utc(now) if now is not None else datetime.now(timezone.utc)
+            reported_raw = kandidat.get("reported_at") or ""
+            kandidat_reported = _as_aware_utc(datetime.fromisoformat(reported_raw))
+            kandidat_frisch = (ref_now - kandidat_reported) <= timedelta(hours=6)
+        except (TypeError, ValueError):
+            kandidat_frisch = False
+
+    # Der Guard unterdrueckt AUSSCHLIESSLICH die Containment-Ausnahme: nur ein
+    # FRISCHES Containment entschaerft die Vorverlegung. Ein veralteter
+    # Kandidat faellt damit auf das unveraenderte #1685-Verhalten zurueck
+    # (Vorverlegung >=2h meldet). Der Guard darf NICHT zusaetzlich stille
+    # Faelle umdrehen, die auch ohne Containment still waeren -- sonst wuerde
+    # z.B. "nur verlaengert" (#1685 AC-2, gleicher Beginn, spaeteres Ende) mit
+    # altem `reported_at` faelschlich erneut melden.
+    escalated = alert.level > kandidat_level
+    containment_greift = is_containment and kandidat_frisch
+    vorverlegung = (not containment_greift) and (kandidat_vf - alert_vf) >= timedelta(hours=2)
+    if escalated or vorverlegung:
         return True, None, None
 
     merged_entry = {

--- a/tests/tdd/test_official_alert_dedup_timespan.py
+++ b/tests/tdd/test_official_alert_dedup_timespan.py
@@ -291,8 +291,16 @@ class TestAC4TriggerNewPeriodFiresIndependently:
             now = datetime.now(timezone.utc)
             period_a_from = now - timedelta(hours=1)
             period_a_to = now + timedelta(hours=18)
-            period_b_from = period_a_to
-            period_b_to = period_a_to + timedelta(hours=24)
+            # Issue #1657 (AC-1): exakte Beruehrung zweier Zeitfenster
+            # (period_b_from == period_a_to) gilt seither als DIESELBE Warnung
+            # -- eine Verlaengerung, kein neuer Alarm. Siehe
+            # docs/specs/modules/fix_1657_warnfenster_identitaet.md.
+            # Dieser Test prueft bewusst den anderen Fall: zwei ECHT getrennte
+            # Zeitraeume. Die Stunde Abstand ist deshalb Absicht und kein
+            # Zufall -- sie entspricht der Fensterbreite, mit der dieser Test
+            # ohnehin rechnet, und haelt die Perioden klar auseinander.
+            period_b_from = period_a_to + timedelta(hours=1)
+            period_b_to = period_b_from + timedelta(hours=24)
 
             # Issue #1460 (P4): Die Tour muss BEIDE Perioden ueberhaupt
             # abdecken -- seit dem Etappen-Zeitfenster gehoert eine Warnung

--- a/tests/tdd/test_official_alert_revision_dedup.py
+++ b/tests/tdd/test_official_alert_revision_dedup.py
@@ -203,7 +203,12 @@ REVISION_CASES = [
     pytest.param(-2, -2, 0, True, id="ac3-exakt-2h-frueher-meldet"),
     pytest.param(-4, -4, 0, True, id="ac4-4h-frueher-meldet"),
     pytest.param(4, 5, 1, True, id="ac5-stufe-gestiegen-meldet"),
-    pytest.param(24, 24, 0, True, id="ac6-kein-zeit-ueberlapp-meldet"),
+    # Issue #1657 "Zu revidierende Zusicherung": der frueher pauschale Fall
+    # `ac6-kein-zeit-ueberlapp-meldet` zerfaellt in zwei Teilfaelle. Die echte
+    # Luecke bleibt eine eigenstaendige Warnung (#1657 AC-2), die exakte
+    # Beruehrung gilt kuenftig als dieselbe Warnung (#1657 AC-1).
+    pytest.param(24, 24, 0, True, id="ac6-echte-luecke-meldet"),
+    pytest.param(8, 8, 0, False, id="ac6b-beruehrung-still"),
 ]
 
 
@@ -536,9 +541,18 @@ def test_ac1_ac3_ac10_ac11_trip_checker_real_entry():
     assert chain[1] == [], f"Zweites Glied muss still bleiben: {chain[1]!r}"
     assert chain[2] == [], f"Drittes Glied muss (Fortschreibung) still bleiben: {chain[2]!r}"
 
+    # Issue #1657 AC-1 REVIDIERT diese Zusicherung am echten Einstieg: das
+    # zweite Fenster beginnt exakt dort, wo das erste endet (`base_to` ==
+    # `base_from + 8h`). #1685 AC-11 verlangte hier eine erneute Meldung,
+    # #1657 AC-1 verlangt Stille ("Beruehrung zaehlt als Ueberlappung").
+    # Beide Zusicherungen koennen nicht gleichzeitig gelten -- die freigegebene
+    # Spec fix_1657_warnfenster_identitaet.md gewinnt.
     adjacent = _run_trip_chain("ac11", [(0, 0, 2), (8, 8, 2)])
     assert len(adjacent[0]) == 1
-    assert len(adjacent[1]) == 1, f"AC-11: angrenzend/nicht-ueberlappend muss neu gemeldet werden: {adjacent[1]!r}"
+    assert adjacent[1] == [], (
+        f"#1657 AC-1: exakt angrenzendes Fenster darf am echten Einstieg NICHT "
+        f"erneut gemeldet werden: {adjacent[1]!r}"
+    )
 
 
 def test_ac13_mandantentrennung_fortschreibung_beruehrt_nur_den_eigenen_nutzer():
@@ -647,6 +661,517 @@ def test_ac14_compare_orts_isolation_keine_fortschreibung_ueber_die_location_id_
         _, per_loc_second = svc._detect(preset_id, [loc_a, loc_b])
         assert "loc-b-1685" in per_loc_second, f"Ort B muss trotz identischem Fenster neu gelten: {per_loc_second!r}"
         assert "loc-a-1685" not in per_loc_second, f"Ort A darf nicht erneut als neu gelten: {per_loc_second!r}"
+    finally:
+        oa_base._REGISTERED_SOURCES.clear()
+        oa_base._REGISTERED_SOURCES.extend(backup)
+        _clean_user(user_id)
+
+
+# =====================================================================
+# Issue #1657 -- Beruehrende und umschliessende Warnfenster sind dieselbe
+# amtliche Warnung. SPEC: docs/specs/modules/fix_1657_warnfenster_identitaet.md
+# KONTEXT: docs/context/fix-1657-warnung-identitaet.md
+#
+# Zeit wird INJIZIERT, nie gemessen: jeder Test, der den 6h-Frische-Guard
+# beruehrt, reicht `now` explizit herein und setzt `reported_at` als festen
+# Wert relativ dazu (Spec-Abschnitt "Test-Schicht"). Der Guard ist die
+# einzige Sicherung dagegen, dass eine echte neue Warnung verschluckt wird --
+# ein an der Grenze sporadisch roter Test wuerde als "flaky" abgetan und die
+# Sicherung fiele still aus.
+# =====================================================================
+
+R1657 = "Kartitsch-1657"
+
+
+def _entry_1657(alert: OfficialAlert, reported_at: datetime) -> dict:
+    """Melde-Gedaechtnis-Eintrag wie ihn `official_alert_state_entry` schreibt
+    -- hier mit explizit gesetztem `reported_at`, damit der 6h-Guard exakt
+    und nicht gegen die Laufzeituhr geprueft wird."""
+    return {
+        "last_reported_value": float(alert.level),
+        "reported_at": reported_at.isoformat(),
+        "valid_from": alert.valid_from.isoformat(),
+        "valid_to": alert.valid_to.isoformat(),
+    }
+
+
+def _verdict_round(state: dict, alert: OfficialAlert, reported_at: datetime, now: datetime) -> bool:
+    """Ein Prueflauf inklusive der Fortschreibung, die die BEIDEN echten
+    Aufrufstellen (`trip_alert.py:1499-1508`, `compare_official_alert.py:
+    268-279`) identisch ausfuehren: melden -> neuer Eintrag; stille Revision
+    -> `stale_key` raus, `merged_entry` unter dem neuen Schluessel rein."""
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    should_report, stale_key, merged_entry = official_alert_revision_verdict(alert, state, now=now)
+    if should_report:
+        state[official_alert_state_key(alert)] = _entry_1657(alert, reported_at)
+    elif merged_entry is not None:
+        del state[stale_key]
+        state[official_alert_state_key(alert)] = merged_entry
+    return should_report
+
+
+def _utc(day: int, hour: int, minute: int = 0, second: int = 0, *, month: int = 8) -> datetime:
+    return datetime(2026, month, day, hour, minute, second, tzinfo=timezone.utc)
+
+
+def _containment_state(now: datetime, kandidat_alter: timedelta) -> tuple[dict, datetime, datetime]:
+    """Zwei frische Schmaleintraege derselben Identitaet+Gefahr (`08:00-09:00Z`
+    und `09:00-10:00Z`). Der spaeter gemeldete gewinnt den Tie-Break; sein
+    Beginn liegt 4h nach dem des breiten Fensters `05:00-13:00Z`, damit die
+    #1685-Vorverlegungs-Ausnahme (>=2h) ohne die #1657-Containment-Regel
+    zwingend greifen wuerde."""
+    schmal_a = _mk_alert(_utc(16, 8), _utc(16, 9), 2, region=R1657)
+    schmal_b = _mk_alert(_utc(16, 9), _utc(16, 10), 2, region=R1657)
+    state = {
+        official_alert_state_key(schmal_a): _entry_1657(schmal_a, now - kandidat_alter - timedelta(minutes=30)),
+        official_alert_state_key(schmal_b): _entry_1657(schmal_b, now - kandidat_alter),
+    }
+    return state, _utc(16, 5), _utc(16, 13)
+
+
+def test_beruehrendes_folgefenster_meldet_nicht_erneut():
+    """Test 1/AC-1 (RED): `14:00-15:00Z` beginnt exakt dort, wo `13:00-14:00Z`
+    endet -- dieselbe durchgehende Gefahr in stundenfeiner Ausgabe. Heute
+    faellt der Fall durch `alert_vf < cand_vt` (strikt) aus der
+    Kandidatensuche und wird als voellig neue Warnung gemeldet."""
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    bestand = _mk_alert(_utc(16, 13), _utc(16, 14), 2, region=R1657)
+    bestand_key = official_alert_state_key(bestand)
+    state = {bestand_key: _entry_1657(bestand, _utc(16, 13, 15, 14))}
+    folge = _mk_alert(_utc(16, 14), _utc(16, 15), 2, region=R1657)
+
+    should_report, stale_key, merged_entry = official_alert_revision_verdict(folge, state)
+
+    assert should_report is False, (
+        "AC-1: exakt anschliessendes Fenster ist dieselbe amtliche Warnung und darf "
+        f"nicht erneut melden: {should_report!r}"
+    )
+    assert stale_key == bestand_key, f"Stille Revision muss den alten Schluessel markieren: {stale_key!r}"
+    assert merged_entry["valid_from"] == folge.valid_from.isoformat()
+    assert merged_entry["valid_to"] == folge.valid_to.isoformat()
+    assert merged_entry["reported_at"] == _utc(16, 13, 15, 14).isoformat(), (
+        f"Fortschreibung darf den urspruenglichen reported_at nicht veraendern: {merged_entry!r}"
+    )
+
+
+def test_eine_sekunde_luecke_bleibt_eine_eigenstaendige_warnung():
+    """Test 2/AC-2 (Non-Regression, gruen): die ausdrueckliche Grenze der
+    Revision. Eine Luecke von einer einzigen Sekunde macht die Warnung wieder
+    zu einer eigenstaendigen Warnung -- sonst waere `<=` ein Freibrief."""
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    bestand = _mk_alert(_utc(16, 13), _utc(16, 14), 2, region=R1657)
+    state = {official_alert_state_key(bestand): _entry_1657(bestand, _utc(16, 13, 15, 14))}
+    nach_luecke = _mk_alert(_utc(16, 14, 0, 1), _utc(16, 15), 2, region=R1657)
+
+    should_report, stale_key, merged_entry = official_alert_revision_verdict(nach_luecke, state)
+
+    assert should_report is True, (
+        f"AC-2: eine Sekunde echte Luecke bleibt eine eigenstaendige Warnung: {should_report!r}"
+    )
+    assert stale_key is None and merged_entry is None
+
+
+def test_umschliessendes_breitfenster_mit_frischem_kandidaten_bleibt_still():
+    """Test 3/AC-3 (RED): das breite Fenster `05:00-13:00Z` umschliesst beide
+    Schmaleintraege vollstaendig -- reiner Granularitaetswechsel derselben
+    Gefahr. Heute wertet die Funktion den 4h frueheren Beginn als
+    "Vorverlegung >=2h" (#1685) und meldet erneut."""
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    now = _utc(16, 16, 30, 2)
+    state, breit_vf, breit_vt = _containment_state(now, timedelta(minutes=10))
+    breit = _mk_alert(breit_vf, breit_vt, 2, region=R1657)
+
+    should_report, stale_key, merged_entry = official_alert_revision_verdict(breit, state, now=now)
+
+    assert should_report is False, (
+        "AC-3: umschliessendes Breitfenster mit frischem Kandidaten ist eine stille "
+        f"Granularitaets-Revision, keine Vorverlegung: {should_report!r}"
+    )
+    assert merged_entry is not None and stale_key in state, f"stale_key={stale_key!r}"
+
+
+def test_umschliessendes_breitfenster_mit_veraltetem_kandidaten_meldet():
+    """Test 4/AC-4 (RED): der 6h-Zeitnaehe-Guard. `AlertStateService.reset()`
+    behaelt `official_alert:`-Eintraege ueber den Briefing-Reset hinweg
+    (#1614) -- ohne Guard wuerde ein Wochen alter Eintrag eine voellig neue,
+    unabhaengige Warnung derselben Region+Gefahr verschlucken."""
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    now = _utc(16, 16, 30, 2)
+    state, breit_vf, breit_vt = _containment_state(now, timedelta(hours=7))
+    breit = _mk_alert(breit_vf, breit_vt, 2, region=R1657)
+
+    should_report, stale_key, merged_entry = official_alert_revision_verdict(breit, state, now=now)
+
+    assert should_report is True, (
+        "AC-4: Containment darf einen >6h alten Bestandskandidaten NICHT still "
+        f"fortschreiben -- sonst verschluckt ein Alt-Eintrag eine echte neue Warnung: {should_report!r}"
+    )
+    assert stale_key is None and merged_entry is None
+
+
+def test_containment_guard_grenze_liegt_bei_sechs_stunden_nicht_darunter():
+    """Test 5 (RED): Grenzfall des Guards -- 5h59min ist noch frisch. Die
+    Grenze liegt bei ">6h", nicht bei ">=6h" und nicht bei "5h"."""
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    now = _utc(16, 16, 30, 2)
+    state, breit_vf, breit_vt = _containment_state(now, timedelta(hours=5, minutes=59))
+    breit = _mk_alert(breit_vf, breit_vt, 2, region=R1657)
+
+    should_report, _stale_key, _merged = official_alert_revision_verdict(breit, state, now=now)
+
+    assert should_report is False, (
+        f"Guard-Grenze: 5h59min alter Kandidat ist noch frisch, Containment greift: {should_report!r}"
+    )
+
+
+def test_stufenerhoehung_meldet_trotz_containment():
+    """Test 6/AC-5 (Non-Regression, gruen): die Eskalations-Zusicherung aus
+    #1685 bleibt unter Containment wirksam.
+
+    Der Vorverlegungs-Abstand ist hier bewusst auf 1h30 gesetzt (Kandidat
+    `06:30-07:30Z` gegen Breitfenster `05:00-13:00Z`) -- damit traegt die
+    Meldung ALLEIN die gestiegene Stufe. Waere der Abstand >=2h, bliebe der
+    Test auch dann gruen, wenn die Eskalations-Bedingung ersatzlos entfiele,
+    und wuerde gar nichts bewachen. Kein `now`: der Eskalations-Zweig liegt
+    vor dem 6h-Guard und erreicht ihn nie."""
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    schmal_a = _mk_alert(_utc(16, 5, 30), _utc(16, 6, 30), 2, region=R1657)
+    schmal_b = _mk_alert(_utc(16, 6, 30), _utc(16, 7, 30), 2, region=R1657)
+    state = {
+        official_alert_state_key(schmal_a): _entry_1657(schmal_a, _utc(16, 5, 35)),
+        official_alert_state_key(schmal_b): _entry_1657(schmal_b, _utc(16, 6, 35)),
+    }
+    breit_orange = _mk_alert(_utc(16, 5), _utc(16, 13), 3, region=R1657)
+
+    should_report, stale_key, merged_entry = official_alert_revision_verdict(breit_orange, state)
+
+    assert should_report is True, (
+        f"AC-5: Stufenerhoehung ueberlebt Containment und meldet als Alarm: {should_report!r}"
+    )
+    assert stale_key is None and merged_entry is None
+
+
+def test_echte_vorverlegung_ohne_containment_meldet_weiterhin():
+    """Test 7/AC-6 (Non-Regression, gruen): `12:00-20:00Z` gegen Bestand
+    `14:00-22:00Z` -- 2h frueherer Beginn, aber KEIN Containment (das Ende
+    liegt frueher). Die #1685-Vorverlegungs-Ausnahme bleibt unangetastet."""
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    now = _utc(16, 12, 30)
+    bestand = _mk_alert(_utc(16, 14), _utc(16, 22), 2, region=R1657)
+    state = {official_alert_state_key(bestand): _entry_1657(bestand, now - timedelta(minutes=10))}
+    vorverlegt = _mk_alert(_utc(16, 12), _utc(16, 20), 2, region=R1657)
+
+    # Kein `now`: ohne Containment erreicht der Fall den 6h-Guard nie -- der
+    # Test muss schon vor der Implementierung gruen sein (Non-Regression).
+    should_report, stale_key, merged_entry = official_alert_revision_verdict(vorverlegt, state)
+
+    assert should_report is True, (
+        f"AC-6: echte Vorverlegung >=2h ohne Containment meldet wie vor dieser Spec: {should_report!r}"
+    )
+    assert stale_key is None and merged_entry is None
+
+
+def test_kirchbach_drei_fenster_melden_genau_einmal():
+    """Test 8/AC-7 (RED): die drei realen Kirchbach-Fenster vom 2026-08-16,
+    alle Stufe 2.0, in der realen Reihenfolge mit den realen Ausgabezeiten.
+    Der PO erhielt drei Meldungen fuer eine durchgehende Gewitterwarnung."""
+    state: dict = {}
+    fenster = [
+        (_utc(16, 13), _utc(16, 14), _utc(16, 13, 15, 14)),
+        (_utc(16, 14), _utc(16, 15), _utc(16, 13, 45, 2)),
+        (_utc(16, 11), _utc(16, 20), _utc(16, 16, 30, 2)),
+    ]
+    meldungen = [
+        _verdict_round(state, _mk_alert(vf, vt, 2, region=R1657), reported_at, reported_at)
+        for vf, vt, reported_at in fenster
+    ]
+
+    assert meldungen == [True, False, False], (
+        f"AC-7: Kirchbach muss GENAU EINMAL melden (erstes Fenster), danach still "
+        f"fortgeschrieben werden: {meldungen!r}"
+    )
+
+
+def test_obertilliach_drei_fenster_melden_genau_zweimal():
+    """Test 9/AC-8 (RED): Obertilliach 2026-08-11. Zwischen Fenster 1
+    (`15:00-16:00Z`) und Fenster 2 (`17:00-18:00Z`) liegt eine ECHTE
+    einstuendige Luecke -- Fenster 2 bleibt deshalb eine eigenstaendige
+    Warnung. Erst das dritte, umschliessende Fenster ist eine stille
+    Revision. Zwei Meldungen, nicht eine: das Ergebnis ist nachgerechnet,
+    nicht auf "genau einmal" geschoent."""
+    state: dict = {}
+    fenster = [
+        (_utc(11, 15), _utc(11, 16), _utc(11, 14, 30, 14)),
+        (_utc(11, 17), _utc(11, 18), _utc(11, 15, 45, 22)),
+        (_utc(11, 13), _utc(11, 19), _utc(11, 17, 45, 9)),
+    ]
+    meldungen = [
+        _verdict_round(state, _mk_alert(vf, vt, 2, region=R1657), reported_at, reported_at)
+        for vf, vt, reported_at in fenster
+    ]
+
+    assert meldungen == [True, True, False], (
+        f"AC-8: Obertilliach muss GENAU ZWEIMAL melden (echte Luecke zwischen Fenster 1 "
+        f"und 2), nur das dritte, umschliessende Fenster bleibt still: {meldungen!r}"
+    )
+
+
+def test_stufenerhoehung_bei_reiner_ueberlappung_meldet_weiterhin():
+    """Test 11 (Non-Regression #1685 AC-5, gruen): ueberlappendes, NICHT
+    umschliessendes Fenster mit gestiegener Stufe meldet wie bisher."""
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    now = _utc(16, 12)
+    bestand = _mk_alert(_utc(16, 10), _utc(16, 14), 2, region=R1657)
+    state = {official_alert_state_key(bestand): _entry_1657(bestand, now - timedelta(minutes=5))}
+    eskaliert = _mk_alert(_utc(16, 12), _utc(16, 16), 3, region=R1657)
+
+    should_report, stale_key, merged_entry = official_alert_revision_verdict(eskaliert, state)
+
+    assert should_report is True, f"Stufenerhoehung bei reiner Ueberlappung meldet: {should_report!r}"
+    assert stale_key is None and merged_entry is None
+
+
+def test_zeitlose_warnung_umgeht_beruehrungs_und_containment_pruefung():
+    """Test 12/AC-10 (Non-Regression, gruen): fehlen `valid_from`/`valid_to`,
+    entscheidet ausschliesslich der exakte Schluesseltreffer -- weder die neue
+    Beruehrungs- noch die neue Containment-Pruefung darf dort greifen."""
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    zeitlos = OfficialAlert(source="test-1657", hazard="wildfire", level=2,
+                            label="Waldbrand-Gefahr (#1657 AC-10)", region_label="Var-1657")
+    state = {official_alert_state_key(zeitlos): {
+        "last_reported_value": 2.0, "reported_at": "2026-08-16T05:01:19+00:00",
+    }}
+
+    should_report, stale_key, merged_entry = official_alert_revision_verdict(zeitlos, state)
+
+    assert should_report is False, f"Unveraenderte zeitlose Warnung darf nicht erneut melden: {should_report!r}"
+    assert stale_key is None and merged_entry is None
+
+
+# ---------------------------------------------------------------------
+# Adversary-Fix-Loop #1657 -- Mutations-Gegenprobe hatte drei unbewachte
+# Zweige gefunden (Protokoll: docs/artifacts/fix-1657-warnung-identitaet/
+# adversary-dialog.md, Runde 2). Die folgenden Tests schliessen sie. Jeder
+# traegt eine POSITIVKONTROLLE im selben Test: dieselbe Konstellation mit
+# genau einem umgestellten Merkmal muss das ANDERE Ergebnis liefern -- sonst
+# waere nicht belegt, dass die gepruefte Grenze das Ergebnis ueberhaupt traegt.
+# ---------------------------------------------------------------------
+
+F003_UNBRAUCHBARER_REPORTED_AT = [
+    pytest.param("__schluessel-fehlt__", id="reported_at-fehlt-ganz"),
+    pytest.param(None, id="reported_at-none"),
+    pytest.param("", id="reported_at-leerer-string"),
+    pytest.param("kein-zeitstempel", id="reported_at-unparsebar"),
+]
+
+
+@pytest.mark.parametrize("kaputter_wert", F003_UNBRAUCHBARER_REPORTED_AT)
+def test_f003_containment_mit_unbrauchbarem_reported_at_meldet_statt_zu_verschlucken(kaputter_wert):
+    """Adversary F003 (#1657 Fix-Loop, CRITICAL): der `except`-Zweig des
+    6h-Frische-Guards (`official_alerts.py:533-534`) war von KEINEM der 102
+    Tests bewacht -- die Mutation `kandidat_frisch = True` (Containment greift
+    ⇒ echte neue Warnung wird VERSCHLUCKT) blieb komplett gruen. Genau die
+    gefaehrliche Richtung an der Stelle, die die Spec "die einzige Sicherung
+    dagegen, dass eine echte neue Warnung verschluckt wird" nennt.
+
+    `test_f002_tie_break_und_merge_ueberleben_reported_at_null` erreicht den
+    Zweig nicht: dort ist `is_containment` in BEIDEN Teilfaellen `False`, der
+    Guard wird nie betreten.
+
+    Vier Ausfallarten eines migrierten/korrupten State-Eintrags (#1614 haelt
+    `official_alert:`-Eintraege ueber den Briefing-Reset hinweg): Schluessel
+    fehlt ganz, `None`, leerer String, unparsebarer Text. Erwartung jedes Mal:
+    NICHT frisch ⇒ Containment greift nicht ⇒ die #1685-Vorverlegungs-Ausnahme
+    bleibt wirksam ⇒ es wird gemeldet. Im Zweifel melden, nicht schlucken."""
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    now = _utc(16, 16, 30, 2)
+    schmal = _mk_alert(_utc(16, 8), _utc(16, 9), 2, region=R1657)
+    schmal_key = official_alert_state_key(schmal)
+    breit = _mk_alert(_utc(16, 5), _utc(16, 13), 2, region=R1657)
+
+    def _state(reported_at_wert) -> dict:
+        entry = {
+            "last_reported_value": 2.0,
+            "valid_from": schmal.valid_from.isoformat(),
+            "valid_to": schmal.valid_to.isoformat(),
+        }
+        if reported_at_wert != "__schluessel-fehlt__":
+            entry["reported_at"] = reported_at_wert
+        return {schmal_key: entry}
+
+    # POSITIVKONTROLLE: identische Fenster, nur mit BRAUCHBAREM, frischem
+    # `reported_at`. Sie beweist, dass `is_containment` hier tatsaechlich True
+    # ist und der Guard-Zweig ueberhaupt erreicht wird -- ohne sie koennte der
+    # Haupt-Assert auch aus einem ganz anderen Grund gruen sein.
+    kontroll_state = {schmal_key: _entry_1657(schmal, now - timedelta(minutes=10))}
+    kontrolle, _k_stale, _k_merged = official_alert_revision_verdict(breit, kontroll_state, now=now)
+    assert kontrolle is False, (
+        "Vorbedingung: mit frischem reported_at MUSS dieselbe Konstellation still bleiben "
+        f"(sonst prueft der Test unten gar nicht den Guard-Zweig): {kontrolle!r}"
+    )
+
+    should_report, stale_key, merged_entry = official_alert_revision_verdict(
+        breit, _state(kaputter_wert), now=now,
+    )
+
+    assert should_report is True, (
+        f"F003: Kandidat mit unbrauchbarem reported_at ({kaputter_wert!r}) darf NICHT als "
+        f"frisch gelten -- sonst verschluckt ein korrupter Alt-Eintrag eine echte neue "
+        f"Gewitterwarnung: {should_report!r}"
+    )
+    assert stale_key is None and merged_entry is None, (
+        f"Melden liefert kein stale_key/merged_entry: {stale_key!r} / {merged_entry!r}"
+    )
+
+
+def test_f001_beruehrung_aus_der_gegenrichtung_zaehlt_ebenfalls_als_ueberlappung():
+    """Adversary F001 (#1657 Fix-Loop, MEDIUM): die Ueberlappungsbedingung
+    `alert_vf <= cand_vt and cand_vf <= alert_vt` (`official_alerts.py:503`)
+    besteht aus zwei unabhaengigen Grenzen. Die erste war bewacht (Mutation
+    von 4 Tests gefangen), die ZWEITE nicht -- alle bisherigen
+    Beruehrungs-Tests legen das neue Fenster HINTER den Bestand.
+
+    Hier der umgekehrte Fall: das neue Fenster `13:00-14:00Z` endet exakt
+    dort, wo der Bestandskandidat `14:00-15:00Z` beginnt (die Behoerde
+    ergaenzt eine Stunde nach VORN). Auch das ist AC-1 -- dieselbe
+    durchgehende Gefahr, keine neue Warnung."""
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    bestand = _mk_alert(_utc(16, 14), _utc(16, 15), 2, region=R1657)
+    bestand_key = official_alert_state_key(bestand)
+    state = {bestand_key: _entry_1657(bestand, _utc(16, 13, 50))}
+    davor = _mk_alert(_utc(16, 13), _utc(16, 14), 2, region=R1657)
+
+    should_report, stale_key, merged_entry = official_alert_revision_verdict(davor, state)
+
+    assert should_report is False, (
+        "AC-1 (Gegenrichtung): ein Fenster, das exakt dort ENDET, wo der Bestand beginnt, "
+        f"ist dieselbe amtliche Warnung und darf nicht erneut melden: {should_report!r}"
+    )
+    assert stale_key == bestand_key, f"Stille Revision muss den alten Schluessel markieren: {stale_key!r}"
+
+    # POSITIVKONTROLLE: eine Sekunde echte Luecke davor -- Spiegelbild von
+    # test_eine_sekunde_luecke_bleibt_eine_eigenstaendige_warnung. Ohne sie
+    # waere nicht belegt, dass oben die BERUEHRUNG traegt und nicht etwa jedes
+    # beliebige frueher liegende Fenster still bliebe.
+    mit_luecke = _mk_alert(_utc(16, 12), _utc(16, 13, 59, 59), 2, region=R1657)
+    luecke_report, luecke_stale, luecke_merged = official_alert_revision_verdict(
+        mit_luecke, {bestand_key: _entry_1657(bestand, _utc(16, 13, 50))},
+    )
+    assert luecke_report is True, (
+        f"AC-2 (Gegenrichtung): eine Sekunde echte Luecke bleibt eigenstaendig: {luecke_report!r}"
+    )
+    assert luecke_stale is None and luecke_merged is None
+
+
+def test_f002_containment_greift_auch_bei_exakt_gleichem_fensterende():
+    """Adversary F002 (#1657 Fix-Loop, MEDIUM): die Gleichheitsgrenze
+    `alert_vt >= kandidat_vt` in `is_containment` (`official_alerts.py:525`)
+    war ungetestet -- die Verschaerfung auf `>` blieb gruen.
+
+    Konstellation, in der die Grenze das Ergebnis TATSAECHLICH kippt: der
+    Kandidat `08:00-13:00Z` endet exakt mit dem neuen Fenster `05:00-13:00Z`,
+    der Beginn liegt 3h frueher. Ohne Containment griffe die
+    #1685-Vorverlegungs-Ausnahme (>=2h) und meldete erneut; mit Containment
+    und frischem Kandidaten ist es ein reiner Granularitaetswechsel.
+
+    (Die Schwester-Grenze `alert_vf <= kandidat_vf` ist NICHT auf diese Weise
+    pruefbar -- s. Bericht: dort ist `<=` vs. `<` ein aequivalenter Mutant,
+    weil bei `alert_vf == kandidat_vf` die Vorverlegung ohnehin 0h betraegt
+    und Containment am Ergebnis nichts mehr aendern kann.)"""
+    from output.renderers.alert.official_alerts import official_alert_revision_verdict
+
+    now = _utc(16, 16, 30, 2)
+    kandidat = _mk_alert(_utc(16, 8), _utc(16, 13), 2, region=R1657)
+    kandidat_key = official_alert_state_key(kandidat)
+    state = {kandidat_key: _entry_1657(kandidat, now - timedelta(minutes=10))}
+    breit_gleiches_ende = _mk_alert(_utc(16, 5), _utc(16, 13), 2, region=R1657)
+
+    should_report, stale_key, merged_entry = official_alert_revision_verdict(
+        breit_gleiches_ende, state, now=now,
+    )
+
+    assert should_report is False, (
+        "AC-3: gleiches Fensterende zaehlt als vollstaendiges Umschliessen -- der 3h "
+        f"fruehere Beginn ist dann Granularitaet, keine Vorverlegung: {should_report!r}"
+    )
+    assert stale_key == kandidat_key and merged_entry is not None, (
+        f"Stille Revision erwartet: stale_key={stale_key!r} merged_entry={merged_entry!r}"
+    )
+
+    # POSITIVKONTROLLE: EINE SEKUNDE vor dem Kandidatenende -- damit ist das
+    # Umschliessen nicht mehr vollstaendig, die Vorverlegungs-Ausnahme lebt
+    # wieder auf. Beweist, dass oben die Gleichheitsgrenze das Ergebnis traegt.
+    knapp_kuerzer = _mk_alert(_utc(16, 5), _utc(16, 12, 59, 59), 2, region=R1657)
+    kontroll_report, kontroll_stale, kontroll_merged = official_alert_revision_verdict(
+        knapp_kuerzer, {kandidat_key: _entry_1657(kandidat, now - timedelta(minutes=10))}, now=now,
+    )
+    assert kontroll_report is True, (
+        "Eine Sekunde vor dem Kandidatenende ist KEIN Containment mehr -- die "
+        f"Vorverlegung >=2h muss dann wieder melden: {kontroll_report!r}"
+    )
+    assert kontroll_stale is None and kontroll_merged is None
+
+
+def test_compare_pfad_behandelt_containment_wie_der_trip_pfad(monkeypatch):
+    """Test 10/AC-9 (RED): Ortsvergleich-Paritaet ueber den echten Einstieg
+    `CompareOfficialAlertService._detect`. Beide Lesepfade teilen sich
+    dieselbe Funktion -- dieser Test beweist, dass der Compare-Pfad die
+    Containment-Regel tatsaechlich erbt und nicht nur der Trip-Pfad sie hat.
+
+    `reported_at` der vorbelegten Schmaleintraege steht auf der ECHTEN
+    Wanduhr minus 10 Minuten (nicht auf der eingefrorenen Compare-Zeit): der
+    Compare-Aufrufer reicht kein `now` herein, dort gilt der Default
+    `datetime.now(timezone.utc)`. So ist der Guard hier deterministisch
+    frisch, unabhaengig vom Kalendertag des Testlaufs."""
+    from app.config import Settings
+    from services.alert_state import AlertStateService
+    from services.compare_official_alert import CompareOfficialAlertService
+    from services.official_alerts import register_official_alert_source
+
+    user_id = _fresh_user("t1657-compare")
+    _clean_user(user_id)
+    oa_base, backup = _registered_sources_backup()
+    oa_base._REGISTERED_SOURCES.clear()
+    try:
+        frozen = datetime(2026, 8, 11, 6, 0, tzinfo=timezone.utc)
+        _freeze_compare_now(monkeypatch, frozen)
+        wall_now = datetime.now(timezone.utc)
+        breit = _mk_alert(frozen - timedelta(hours=1), frozen + timedelta(hours=7), 2, region=R1657)
+        schmal_a = _mk_alert(frozen + timedelta(hours=2), frozen + timedelta(hours=3), 2, region=R1657)
+        schmal_b = _mk_alert(frozen + timedelta(hours=3), frozen + timedelta(hours=4), 2, region=R1657)
+
+        loc = SavedLocation(id="loc-1657", name="Kartitsch-1657", lat=LAT, lon=LON, elevation_m=1000)
+        register_official_alert_source(_RevisableOfficialAlertSource(LAT, LON, breit))
+        preset_id = "preset-1657"
+        state_svc = AlertStateService(user_id=user_id)
+        state_svc.save(f"{preset_id}:{loc.id}", {
+            official_alert_state_key(schmal_a): _entry_1657(schmal_a, wall_now - timedelta(minutes=40)),
+            official_alert_state_key(schmal_b): _entry_1657(schmal_b, wall_now - timedelta(minutes=10)),
+        })
+
+        settings = Settings(smtp_host="dummy.invalid", smtp_user="dummy", smtp_pass="dummy",
+                            mail_to="dummy@example.com")
+        svc = CompareOfficialAlertService(settings=settings, user_id=user_id, mail_sink=lambda *a: None)
+
+        new_or_escalated, per_loc = svc._detect(preset_id, [loc])
+
+        assert new_or_escalated == [], (
+            f"AC-9: der Ortsvergleichs-Pfad muss das umschliessende Breitfenster genauso "
+            f"still fortschreiben wie der Trip-Pfad: {new_or_escalated!r}"
+        )
+        assert per_loc == {}, f"Kein Ort darf als neu gelten: {per_loc!r}"
     finally:
         oa_base._REGISTERED_SOURCES.clear()
         oa_base._REGISTERED_SOURCES.extend(backup)


### PR DESCRIPTION
official_alert_revision_verdict() wertete stundenfeine Teilfenster derselben
amtlichen Gefahr als eigenständige Warnungen — Kirchbach 2026-08-16 löste drei
Meldungen für eine durchgehende Gewitterwarnung aus.

Zwei Präzisierungen an der geteilten Funktion (Trip und Ortsvergleich):

1. Berührung zählt als Überlappung (`<=` statt `<`): ein Fenster, das exakt
   dort beginnt, wo das Bestandsfenster endet, ist dieselbe Warnung. Eine echte
   Lücke — und sei sie nur eine Sekunde — meldet weiterhin eigenständig.

2. Containment: umschließt das neue Fenster einen Bestandskandidaten
   vollständig, ist der frühere Beginn ein Granularitätswechsel, keine
   Vorverlegung — die >=2h-Vorverlegungs-Ausnahme entfällt. Ein 6h-Frische-Guard
   auf reported_at verhindert, dass ein nie bereinigter Alt-Eintrag (#1614)
   eine echte neue Warnung verschluckt. Die Eskalations-Ausnahme bei
   Stufenanstieg bleibt unter Containment unverändert wirksam.

Die Anzeige-Ebene (dedupe_official_alerts) bleibt bewusst unberührt — beide
Perioden bleiben in der Mail sichtbar.

Revidiert die Teilaussage "aneinandergrenzende Fenster sind keine Überlappung"
aus #1245 AC-4 / #1685 AC-11 an beiden Fundstellen (reine Funktion und echter
Trip-Einstieg check_official_alert_triggers).

Tests: 48 grün, alle 10 ACs benannt abgedeckt, dazu sieben Adversary-Findings
(F001-F007). Adversary-Verdict VERIFIED.

Refs #1657

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
