### PR TITLE
fix(#1738): /trips/new nutzt den geteilten VersandTab

### DIFF
--- a/docs/context/fix-1738-versand-tab-migration.md
+++ b/docs/context/fix-1738-versand-tab-migration.md
@@ -1,0 +1,161 @@
+# Context: fix-1738-versand-tab-migration
+
+**Issue:** #1738 — Premium-SMS-Schalter verschwindet auf `/trips/new`, wenn die SMS-Wetter-Metrik ausgeblendet wird
+**Track:** Full Process · **PO-Entscheid im Intake:** Weg 2 (`/trips/new` auf den geteilten `VersandTab` umstellen), nicht die kleine Entschachtelung.
+
+## Request Summary
+
+Auf der Trip-Anlage hängt der Premium-SMS-Schalter im Markup innerhalb von `{#if weatherVisible.sms}` — eine Anzeige-Einstellung für Wetter-Metriken versteckt damit den Zugang zum Satellitenkanal. Statt die Verschachtelung punktuell aufzulösen, soll `/trips/new` auf den geteilten `shared/VersandTab.svelte` umgestellt werden; damit fällt der Fall zusammen mit der Doppelpflege der Kanal-Logik weg (Teilungsregel, #1199).
+
+## Kernbefunde der Recherche
+
+### B1 — Der Bug ist breiter als das Issue beschreibt
+
+Nicht nur Premium-SMS ist betroffen. Alle drei Kanal-Blöcke hängen an ihrer jeweiligen Metrik-Sichtbarkeit:
+
+| Kanal | Gate | Datei:Zeile |
+|---|---|---|
+| E-Mail | `{#if weatherVisible.email}` | `edit/EditReportConfigSection.svelte:333` |
+| Telegram | `{#if weatherVisible.telegram}` | `edit/EditReportConfigSection.svelte:355` |
+| SMS | `{#if weatherVisible.sms}` | `edit/EditReportConfigSection.svelte:377` |
+| **Premium-SMS** | zusätzlich **innerhalb** des SMS-Blocks | `edit/EditReportConfigSection.svelte:401-427` |
+
+`weatherVisible = visibleChannels(weatherChannels)` (`:127`), Logik in `trip-detail/briefingChannelGating.ts:14-19`. Ohne `weatherChannels` sind alle sichtbar — deshalb tritt der Bug **nur** auf `/trips/new` auf (einziger Aufrufer, der `weatherChannels` mitgibt).
+
+Premium-SMS ist der schwerwiegendste Fall: doppelt verschachtelt und laut ADR-0049 ein eigenständiger, gleichrangiger Kanal, der mit normalem SMS nichts zu tun hat.
+
+### B2 — `VersandTab` funktioniert ohne persistiertes Trip (Intake-Unsicherheit entkräftet)
+
+Der `trip`-Prop ist optional (`shared/VersandTab.svelte:31`) und wird im gesamten Skript-Körper **einmal** benutzt: `computeTripEnd(trip)` (`:221`), das bei `undefined` null-sicher `null` liefert (`:208-220`). Kein API-Call, keine Persistenz-Abhängigkeit in der Komponente.
+
+**Präzedenzfall:** `compare-new/CompareNewEditor.svelte:420,502` fährt `VersandTab` bereits in einem Anlege-Flow ohne persistiertes Objekt — über einen reinen In-Memory-`$state` (`CompareWizardState`), ein einziger POST erst beim Aktivieren. Genau das Muster, das `/trips/new` braucht. Spec dazu: `docs/specs/modules/versand_tab_vergleich.md` (Doppel-Mount, **kein Self-Save**, zentrales `handleSave`).
+
+### B3 — Was bei einer 1:1-Substitution verlorenginge
+
+`VersandTab`/`VTBriefingChannels` haben Folgendes **nicht**:
+
+1. **`weatherChannels`-Gating** — `visibleChannels`/`hasNoActiveChannel`/`activeChannelLabels` und der Leerzustand-Banner `briefings-channel-empty` (gegated auf `weatherChannels`).
+2. **`syncSendFlags`-Write-Back** — `EditReportConfigSection` setzt beim Schreiben `send_email/telegram/sms := false`, wenn der jeweilige Wetter-Kanal aus ist (`briefingChannelGating.ts:49-61`, aufgerufen `:264-266`). `VersandTab`s `$effect` (`:127-148`) ist reiner Passthrough.
+3. **Mail-Inhalt-Karte** — `email_format` full/compact + `show_outlook`/`show_stage_stats`/`show_yesterday_comparison` (`EditReportConfigSection.svelte:435-514`). `VersandTab` rendert sie gar nicht.
+
+Zu 3 verifiziert: `shared/WeatherMetricsTab.svelte:1737` rendert die Mail-Inhalt-Karte hinter `{#if !createMode …}` — im Anlege-Flow also **nicht**. Auf `/trips/new` kommt sie heute ausschließlich aus dem `EditReportConfigSection` im Zeitplan-Tab. Ein reiner Komponententausch entfernt sie dort ersatzlos.
+
+Kein Gap dagegen bei: `profile.sms_allowed`-Hinweis, `channelConnectionStatus`/`channelContactLabel`/`premiumSmsChannelState` (bereits geteilte Imports), Kanalzähler inkl. Premium-SMS (`VersandTab.svelte:157-159`), Zeitplan (`VTSchedulePlan` ist bereits geteilt, #1286).
+
+### B4 — Doppel-Mount Desktop/Mobile
+
+`EditReportConfigSection` wird **zweimal simultan** gemountet: `trip-new/TripNewEditor.svelte:800` (Desktop) und `:1036` (Mobile). Die Umschaltung ist **CSS-only** (`display:none` per Breakpoint, `:1088-1109`) — beide Instanzen leben parallel im DOM.
+
+Gegenmuster in derselben Datei: `WeatherMetricsTab` (`:823`/`:1051`) hält per JS-Flag `isMobileViewport` bewusst nur **eine** Instanz — der Kommentar `:812-822` benennt genau diese Fehlerklasse (doppelte Kopie = doppelter unabhängiger Schreibpfad, Fix-Loop 4). Bei `EditReportConfigSection` fehlt das Gating; es fällt bisher nicht auf, weil `bind:reportConfig` two-way teilt statt über Callback-Rückkanal zu laufen. **Bei der Migration explizit gegenprüfen** — `versand_tab_vergleich.md` löst denselben Fall über „kein Self-Save".
+
+### B5 — `stubTrip.stages` ist leer
+
+`trip-new/TripNewEditor.svelte:86-93` hält einen `stubTrip` mit **fest verdrahtetem `stages: []`**, nie aus dem echten `stages`-State befüllt. `VersandTab`s `VTLaufzeitRoute` berechnet das Trip-Ende über `trip.stages` (`computeTripEnd`) — mit dem heutigen Stub bliebe die Laufzeit-Anzeige im Anlege-Flow leer.
+
+### B6 — Der Dedupe-Wächter wird gegenstandslos
+
+`shared/versand-tab/__tests__/channel_checkbox_dedupe_render.test.ts` SSR-rendert `EditReportConfigSection.svelte` **direkt per Pfad-Import** und vergleicht sie Feld für Feld mit `VTBriefingChannels`/`VersandTab` (Testids, Disabled-Zustände, Kanalzähler, Leerzustand). Zweck laut Dateikopf: zwei divergente Implementierungen synchron halten.
+
+Nach der Migration gibt es nur noch **eine** Implementierung — der Test bewacht dann nichts mehr. Er darf nicht einfach gestrichen werden, ohne dass klar ist, was danach die Positivkontrolle stellt (vgl. Lehre „Übergangs-Ausnahme ist oft die einzige Positivkontrolle").
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `frontend/src/lib/components/trip-new/TripNewEditor.svelte` | Migrationsziel; 2 Mounts (`:800`, `:1036`), `stubTrip` `:86-93`, `buildAndSave` `:335-364` |
+| `frontend/src/lib/components/trip-new/tripNewLogic.ts` | Tab-Freischaltung `:14-44`, `canSave` `:69-70`, `buildCreateTripPayload` `:117-156` |
+| `frontend/src/lib/components/edit/EditReportConfigSection.svelte` | Bug-Ort; bleibt bestehen (siehe „Lebende Aufrufer") |
+| `frontend/src/lib/components/shared/VersandTab.svelte` | Zielkomponente, 342 Z. |
+| `frontend/src/lib/components/shared/versand-tab/VTBriefingChannels.svelte` | Kanal-Block, Premium-SMS-Gating über Prop-Anwesenheit `:198` |
+| `frontend/src/lib/components/trip-detail/briefingChannelGating.ts` | `visibleChannels` `:14-19`, `syncSendFlags` `:49-61` |
+| `frontend/src/lib/components/shared/WeatherMetricsTab.svelte` | `:1737` `createMode`-Gate der Mail-Inhalt-Karte; `:1758` zweiter lebender Aufrufer |
+| `frontend/src/lib/components/compare-new/CompareNewEditor.svelte` | Präzedenz Anlege-Flow `:420`, `:502` |
+| `frontend/src/lib/components/compare/compareWizardState.svelte.ts` | Muster In-Memory-State vor erstem Save |
+
+### Lebende vs. tote Aufrufer von `EditReportConfigSection`
+
+| Aufrufer | Status |
+|---|---|
+| `trip-new/TripNewEditor.svelte:800,1036` | **lebend** — Migrationsziel |
+| `shared/WeatherMetricsTab.svelte:1758` | **lebend**, nur Mail-Inhalt (`showChannels={false} showSchedule={false}`) — Komponente kann daher **nicht gelöscht** werden |
+| `edit/TripEditView.svelte:203` | tot — nirgends gemountet |
+| `briefings-tab/BriefingsTab.svelte:40` | tot — importiert in `TripTabs.svelte:14`, im Template nie verwendet |
+
+Aufräumen der beiden toten Pfade gehört **nicht** in #1738 (eigenes Ticket).
+
+## Existing Specs & ADRs
+
+- `docs/specs/modules/versand_tab_route.md` — AC-7 fixiert Testids: `channel-email`, `channel-telegram`, `channel-sms`, `briefings-channel-empty`, `report-morning-time`, `report-evening-time`, `morning-master-switch`, `evening-master-switch`, `report-mail-content`
+- `docs/specs/modules/versand_tab_vergleich.md` — **das nächstliegende Vorbild**: Create-Fall, Doppel-Mount, kein Self-Save, Testid-Präfix parametrisierbar
+- `docs/specs/modules/feat_1717_s3_premium_sms_ui.md` — schaltet Premium-SMS heute in **beiden** Komponenten parallel frei; benennt unter „Abgrenzung" (`:41-44`) genau die Migration, die #1738 jetzt einlöst. **AC-1 sichert: schaltbarer Premium-SMS-Block erscheint nie im `vergleich`-Zweig** (Gating über Prop-Anwesenheit, nicht `context`-String) — muss erhalten bleiben
+- `docs/specs/modules/refactor_1286_shared_versandzeit.md` — hat den Zeitplan bereits geteilt (`VTSchedulePlan`)
+- `docs/adr/0049-premium-sms-vierter-kanal.md` — Premium-SMS eigener 4. Kanal, gelernte Rückadresse, Tier-Gate `premium`
+- Keine aktive `trip_new`-Spec; `issue_622_trip_new_progressive_editor.md` / `issue_661_trip_new_mobile.md` liegen im Archiv
+
+## Tests & Gates
+
+**Vitest**
+- `shared/versand-tab/__tests__/channel_checkbox_dedupe_render.test.ts` — importiert `EditReportConfigSection.svelte` per Pfad; wird durch die Migration gegenstandslos (B6)
+- `edit/__tests__/report_config_uses_shared_schedule.test.ts` — 4 von 6 Tests lesen `EditReportConfigSection.svelte` per `readFileSync`; überleben, solange die Datei existiert (tut sie, wegen `WeatherMetricsTab`)
+- `edit/issue_619_report_config_write.test.ts`, `edit/issue_693_email_config_cleanup.test.ts` — testen nur `reportConfigWrite.ts`, unberührt
+- `trip-new/__tests__/trip_new_editor_weather_metrics_wiring.test.ts` — Quelltext-Regex, erwartet **exakt 2** `WeatherMetricsTab`-Mounts; Mount-Struktur muss erhalten bleiben
+- `trip-new/__tests__/tripNewLogic.test.ts` — reine Logik, unberührt
+
+**Playwright**
+| Spec | fährt `/trips/new` an | in `ci_e2e_specs.txt` | Versand-Testids |
+|---|---|---|---|
+| `issue-661-trip-new-mobile.spec.ts` | ja | **ja** | nein |
+| `versandzeit-stundenwahl.spec.ts` (AC-4) | ja | nein | `report-morning-time` |
+| `trip-new-loads-without-effect-loop.spec.ts` | ja | nein | nein |
+| `trip-edit.spec.ts` | ja (nur Seeding) | nein | ⚠️ nutzt `wizard-next`/`wizard-save` — Verdacht auf Bestandsleiche, in der Spec-Phase gegenprüfen |
+| `versand-tab.spec.ts` | nein (`/trips/{id}`) | **ja** | ja — Referenz für einen korrekten VersandTab-E2E-Test |
+
+Der eigentliche Verhaltensnachweis für Kanäle auf `/trips/new` hängt damit **außerhalb** der CI-Ampel.
+
+**Gates**
+- Pendant-Sperre `.claude/hooks/pendant_gate.py` (`docs/specs/modules/feat_1481b_pendant_gate.md`, Prüfdatum 2026-11-03): blockiert **Neuanlagen** unter `trip-new/**` ohne `gz-eigenstaendig:`-Begründung. Ein Adapter für den unpersistierten State gehört daher nach `shared/**` — oder braucht eine Begründung.
+- Kein Wächtertest erzwingt heute, dass `/trips/new` keine eigene Kanal-Komponente hat. Die Teilungsregel ist dort nur als Prosa-Kommentar und Backlog-Buchung dokumentiert.
+
+## PO-Entscheidungen (2026-08-17, Phase 2)
+
+**E1 — Die Kanal-Kopplung fällt.** Alle vier Versandkanäle sind auf `/trips/new` künftig immer wählbar, unabhängig von der Metrik-Darstellung. Damit verschwindet der Bug für **alle vier** Kanäle, nicht nur Premium-SMS, und Anlage verhält sich wie Trip-Detail. `weatherChannels`-Gating, Leerzustand-Banner-Gating und `syncSendFlags` entfallen auf diesem Pfad. Bewusst in Kauf genommen: ein Kanal kann versendet werden, ohne dass für ihn Wetter-Metriken konfiguriert sind — im Trip-Detail heute bereits möglich. Begründung: „Keine Bevormundung — der Nutzer entscheidet, was wichtig ist" (CLAUDE.md); ein Versandkanal ist keine Metrik-Darstellung.
+
+**E2 — Die Mail-Inhalt-Karte bleibt im Zeitplan-Tab.** `EditReportConfigSection` bleibt dort gemountet, aber nur noch mit `showChannels={false} showSchedule={false}` — exakt das Muster, das `WeatherMetricsTab.svelte:1758` bereits benutzt. Der Bug verschwindet damit **strukturell**: der Kanal-Block kommt gar nicht mehr aus dieser Komponente. Kein Rückkanal-Umbau nötig, `bind:reportConfig` trägt weiter. `createMode` wird ausschließlich von `TripNewEditor` gesetzt (`WeatherMetricsTab.svelte:173` + Aufrufer `:825`, `:1053`) — Compare ist von dieser Entscheidung nicht berührt.
+
+## Analyse-Ergebnisse (Phase 2, technische Entscheidungen)
+
+### A1 — Doppel-Mount: XOR-Gate über `isMobileViewport`
+
+`VersandTab`s `$effect` (`:126-148`) hängt **nur** von lokalem `$state` ab, nicht vom eingehenden `reportConfig`-Prop (der wird einmalig in `onMount` `:91-124` gelesen). Daraus folgt: **keine** Endlosschleife wie bei `WeatherMetricsTab`, aber ein **Last-Write-Wins-Race** — beide Instanzen initialisieren `originalReportConfig` aus ihrem eigenen Mount-Snapshot und schreiben unabhängig zurück. Ein auf Mobile gesetzter Wert kann bei einem späteren Resize/Re-Mount still von der Desktop-Instanz aus veraltetem Snapshot überschrieben werden — Datenverlust ohne Fehlermeldung.
+
+`EditReportConfigSection` hat heute strukturell **denselben** Race (`:200-211` / `:224-267`, ebenfalls CSS-only doppelt gemountet). Er ist bisher nur nicht aufgefallen, nicht abwesend.
+
+**Entscheidung: XOR-Gate.** Zwei Präzedenzfälle sprechen dafür, beide im unmittelbaren Umfeld:
+- `TripNewEditor.svelte:823` / `:1051` macht es für `WeatherMetricsTab` bereits so — `isMobileViewport` ist in **derselben Datei** schon vorhanden (`:76-83`, `matchMedia('(max-width: 899px)')` + change-Listener). Anlass war Fix-Loop 4 / #1552 (`effect_update_depth_exceeded`).
+- `CompareNewEditor.svelte:393,402,490,494` gatet `VersandTab` **selbst** bereits per XOR.
+
+Der verbleibende Grenzfall (Resize mountet neu, lokaler State geht verloren) ist unkritisch, weil der Prop bei jedem Mount frisch aus dem aktuellen `reportConfig` initialisiert wird — Neu-Einlesen statt Überschreiben aus altem Snapshot.
+
+### A2 — Ersatz für den Dedupe-Wächter
+
+Nach der Migration existiert nur noch eine Kanal-Implementierung; `channel_checkbox_dedupe_render.test.ts` bewacht dann nichts mehr. Der Ersatz ist zugleich der zentrale RED-Test: `/trips/new` rendert die geteilte Komponente **und** alle vier Kanal-Zeilen — insbesondere Premium-SMS — bleiben sichtbar, wenn `display_config.channels` einen Kanal abwählt. Der alte Test darf erst fallen, wenn der neue rot war und dann grün wurde.
+
+### A3 — Laufzeit-Anzeige: `stubTrip.stages` befüllen
+
+`StageLocal` (`TripNewEditor.svelte:52-56`) hat **kein** `date`-Feld; `computeTripEnd` liest genau `s.date` (ISO). Mit dem heutigen `stages: []` zeigt `VTLaufzeitRoute` dauerhaft „endet —" (`VTLaufzeitRoute.svelte:25`, `tripEnd ?? '—'`) — kein Crash, sauber degradiert, aber unbefüllt.
+
+**Entscheidung: befüllen** über die bereits existierende Ableitung `buildCreateTripPayload(state).stages` (`tripNewLogic.ts:117-124`, nutzt intern `addDaysISO` `:107-115`). **Falle:** `stageDate()` (`tripNewLogic.ts:48-57`) liefert `dd.mm.` ohne Jahr — für `s.date` unbrauchbar, `computeTripEnd` bräche daran still.
+
+### A4 — `trip-edit.spec.ts` ist eine Bestandsleiche
+
+Die Testids `wizard-next`/`wizard-save` existieren nirgends mehr in `frontend/src/` (mit #622 abgeschafft); `trip-name-input` lebt nur noch in `edit/EditRouteSection.svelte:151`, eingebunden ausschließlich von der seit #616 nicht mehr gerouteten `TripEditView.svelte`. Der Spec steht **nicht** in `.github/ci_e2e_specs.txt`, hat keinen Skip-Marker — er läuft in CI nicht und wäre manuell strukturell rot.
+
+**Kein Blocker für #1738.** Nebenbefund → Sammel-Issue #1199 (kein nutzersichtbares Fehlverhalten, kein fälschlich blockierendes Gate).
+
+## Risks & Considerations
+
+- **Sicherheitskanal betroffen:** Premium-SMS ist auf der Hütte der einzige empfangbare Kanal. Eine Regression hier ist schwerer als der Bug selbst.
+- **Geteilte Komponente:** `VersandTab` bedient auch Trip-Detail und beide Compare-Editoren. Jede Änderung *an* `VersandTab` wirkt dort mit; Änderungen sollten möglichst im Aufrufer bleiben.
+- **AC-1 aus #1717** darf nicht reißen: Premium-SMS nie im `vergleich`-Zweig, Gating über Prop-Anwesenheit.
+- **Schreibpfad-Duplikat** durch Doppel-Mount ist eine dokumentierte Fehlerklasse dieses Editors (Fix-Loop 4).
+- Kein Datenverlust-Risiko am Versandpfad selbst: `report_config.send_premium_sms` wird weiter ausgewertet, es geht um Bedienbarkeit.

--- a/docs/specs/modules/fix_1738_trips_new_versand_tab.md
+++ b/docs/specs/modules/fix_1738_trips_new_versand_tab.md
@@ -1,0 +1,111 @@
+---
+entity_id: fix_1738_trips_new_versand_tab
+type: module
+created: 2026-08-17
+updated: 2026-08-17
+status: draft
+version: "1.0"
+tags: [trip-new, versand-tab, premium-sms, teilungsregel, issue-1738]
+---
+
+# Trip-Anlage nutzt den geteilten Versand-Baustein
+
+## Approval
+
+- [x] Approved (PO, 2026-08-17)
+
+## Purpose
+
+Auf `/trips/new` hängen die Versandkanäle im Markup innerhalb der Sichtbarkeits-Bedingung ihres jeweiligen Wetter-Metrik-Kanals — Premium-SMS zusätzlich noch innerhalb des SMS-Blocks. Wer die SMS-Wetter-Metrik abwählt, verliert damit den Schalter für den Satellitenkanal, ohne einen Hinweis zu sehen. Diese Spec stellt die Kanal- und Zeitplan-Fläche der Trip-Anlage auf den geteilten `VersandTab` um (Teilungsregel, #1199) und beseitigt die Kopplung damit strukturell für alle vier Kanäle.
+
+## Source
+
+- **Schicht:** Frontend / User-UI (SvelteKit)
+- **File:** `frontend/src/lib/components/trip-new/TripNewEditor.svelte`
+- **Identifier:** Zeitplan-Tab, Mounts bei `:800` (Desktop) und `:1036` (Mobile)
+
+## Estimated Scope
+
+- **LoC:** ~120–180 (Produktivcode), zzgl. Tests ~150–200
+- **Files:** 3 Produktivdateien (`TripNewEditor.svelte`, `tripNewLogic.ts`, ggf. `VersandTab.svelte`), 2–3 Testdateien
+- **Effort:** medium
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `shared/VersandTab.svelte` | Komponente | Zielkomponente, `context="route"` |
+| `shared/versand-tab/VTBriefingChannels.svelte` | Komponente | Kanal-Block inkl. Premium-SMS |
+| `shared/versand-tab/VTLaufzeitRoute.svelte` | Komponente | Laufzeit-Anzeige, braucht `tripEnd` |
+| `trip-new/tripNewLogic.ts` | Modul | `buildCreateTripPayload` liefert datierte Etappen |
+| `edit/EditReportConfigSection.svelte` | Komponente | bleibt für die Mail-Inhalt-Karte |
+| `docs/specs/modules/versand_tab_route.md` | Spec | Testids AC-7 |
+| `docs/specs/modules/feat_1717_s3_premium_sms_ui.md` | Spec | AC-1: Premium-SMS nie im `vergleich`-Zweig |
+| `docs/adr/0049-premium-sms-vierter-kanal.md` | ADR | Premium-SMS als eigener vierter Kanal |
+
+## Implementation Details
+
+Im Zeitplan-Tab von `TripNewEditor` tritt `VersandTab` (`context="route"`) an die Stelle des Kanal- und Zeitplan-Teils von `EditReportConfigSection`. `EditReportConfigSection` bleibt dort gemountet, aber nur noch für die Mail-Inhalt-Karte:
+
+```
+<VersandTab context="route" trip={stubTrip} bind:reportConfig onJump={switchTab} />
+<EditReportConfigSection bind:reportConfig mode="create"
+                         showChannels={false} showSchedule={false} />
+```
+
+Damit kommt der Kanal-Block gar nicht mehr aus der Komponente, in der die Verschachtelung sitzt — der Bug verschwindet strukturell statt durch eine punktuelle Entschachtelung.
+
+Beide Mounts (Desktop/Mobile) werden auf das bereits in derselben Datei vorhandene XOR-Gate `isMobileViewport` (`:76-83`) gelegt, wie es `WeatherMetricsTab` (`:823`/`:1051`) und `CompareNewEditor` für `VersandTab` selbst (`:393,402,490,494`) bereits tun.
+
+`stubTrip.stages` wird aus der bestehenden Ableitung `buildCreateTripPayload(state).stages` befüllt, damit `computeTripEnd` ein Datum findet. `stageDate()` ist dafür unbrauchbar (Format `dd.mm.` ohne Jahr).
+
+Das `weatherChannels`-Gating entfällt auf diesem Pfad ersatzlos (PO-Entscheid E1): kein `visibleChannels`, kein `syncSendFlags`, kein an `weatherChannels` gekoppelter Leerzustand.
+
+## Expected Behavior
+
+- **Input:** Nutzer legt unter `/trips/new` einen Trip an und wählt im Metriken-Tab Wetter-Kanäle ab bzw. im Zeitplan-Tab Versandkanäle an.
+- **Output:** Der Zeitplan-Tab zeigt alle vier Versandkanäle unabhängig von der Metrik-Auswahl; gesetzte Kanäle landen beim Speichern in `report_config`.
+- **Side effects:** `report_config.send_email/telegram/sms` wird nicht mehr still auf `false` zurückgesetzt, wenn der zugehörige Wetter-Kanal abgewählt ist.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein Nutzer legt unter `/trips/new` einen Trip an und hat im Metriken-Tab den Wetter-Kanal SMS abgewählt / When er den Zeitplan-Tab öffnet / Then ist die Premium-SMS-Zeile mitsamt ihrem Schalter sichtbar und bedienbar.
+  - Test: Render der Trip-Anlage mit `display_config.channels` ohne `sms`; die Premium-SMS-Checkbox ist im Zeitplan-Tab vorhanden und nicht deaktiviert.
+
+- **AC-2:** Given derselbe Nutzer mit abgewähltem Wetter-Kanal SMS / When er den Zeitplan-Tab öffnet / Then sind auch die Zeilen für E-Mail, Telegram und SMS sichtbar — die Sichtbarkeit eines Versandkanals hängt an keiner Metrik-Auswahl mehr.
+  - Test: Render mit je einem abgewählten Wetter-Kanal; alle vier Kanal-Zeilen bleiben in jeder Kombination vorhanden.
+
+- **AC-3:** Given ein Nutzer hat auf `/trips/new` den Premium-SMS-Schalter gesetzt / When er den Trip speichert / Then enthält der angelegte Trip `report_config.send_premium_sms = true`, unabhängig davon, welche Wetter-Kanäle aktiv sind.
+  - Test: Zustand setzen, Speicher-Payload prüfen; kein stilles Zurücksetzen durch ein Gating.
+
+- **AC-4:** Given die Trip-Anlage ist geöffnet / When der Zeitplan-Tab gerendert wird / Then stammt der Kanal-Block aus dem geteilten Baustein — die Kanal-Testids `channel-email`, `channel-telegram`, `channel-sms`, `channel-premium-sms` erscheinen dort genau einmal, nicht doppelt aus zwei Implementierungen.
+  - Test: Render des Zeitplan-Tabs; je Testid genau ein Treffer im Dokument.
+
+- **AC-5:** Given die Trip-Anlage wird auf einer schmalen und auf einer breiten Ansicht geöffnet / When der Zeitplan-Tab gerendert wird / Then existiert zu jedem Zeitpunkt genau eine Versand-Instanz im Dokument, nie zwei gleichzeitig.
+  - Test: Render unter beiden Viewport-Bedingungen; die Zahl der Versand-Instanzen ist jeweils exakt 1.
+
+- **AC-6:** Given ein Nutzer stellt auf `/trips/new` das Mail-Format oder einen Inhaltsbaustein ein / When er den Trip speichert / Then sind diese Einstellungen im angelegten Trip enthalten — die Mail-Inhalt-Karte bleibt im Anlege-Flow erreichbar.
+  - Test: Format `compact` und einen Inhaltsbaustein setzen, Speicher-Payload prüfen.
+
+- **AC-7:** Given ein Trip mit gesetztem Startdatum und mehreren Etappen wird angelegt / When der Zeitplan-Tab gerendert wird / Then zeigt die Laufzeit-Angabe das aus Startdatum und Etappenzahl abgeleitete Enddatum statt eines Platzhalters.
+  - Test: Startdatum + 3 Etappen setzen; die Laufzeit-Zeile nennt das erwartete Enddatum.
+
+- **AC-8:** Given der Ortsvergleich-Editor / When sein Versand-Bereich gerendert wird / Then erscheint dort weiterhin kein schaltbarer Premium-SMS-Block, sondern der feste Platzhalter — die Zusicherung aus #1717 AC-1 bleibt unberührt.
+  - Test: Render des Compare-Versandbereichs; keine bedienbare Premium-SMS-Checkbox.
+
+## Known Limitations
+
+- Ein Versandkanal kann künftig aktiv sein, ohne dass für ihn Wetter-Metriken konfiguriert sind. Das ist der bewusst gewählte PO-Entscheid E1 und entspricht dem Verhalten, das das Trip-Detail heute schon zeigt.
+- `EditReportConfigSection.svelte` bleibt bestehen (zweiter lebender Aufrufer: `WeatherMetricsTab.svelte:1758` für die Mail-Inhalt-Karte). Die Kanal-Verschachtelung bleibt als toter Zweig in der Datei stehen, ist aber von keinem Aufrufer mehr erreichbar, da beide verbleibenden Aufrufer `showChannels={false}` setzen.
+- `edit/TripEditView.svelte` und `briefings-tab/BriefingsTab.svelte` sind toter Bestand (nirgends gemountet). Ihr Rückbau gehört nicht in diese Scheibe.
+- `frontend/e2e/trip-edit.spec.ts` ist eine Bestandsleiche (referenziert den mit #622 abgeschafften Wizard, steht nicht in `.github/ci_e2e_specs.txt`). Nebenbefund → #1199.
+- Der bisherige Gleichhalte-Test `shared/versand-tab/__tests__/channel_checkbox_dedupe_render.test.ts` verliert seinen Gegenstand, sobald nur noch eine Implementierung existiert. Er darf erst entfallen, wenn die Tests zu AC-1/AC-2/AC-4 rot waren und dann grün wurden.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine neue nötig
+- **Rationale:** Die Entscheidung, Trip und Ortsvergleich möglichst viel Code teilen zu lassen, steht bereits in CLAUDE.md und Epic #1230; diese Scheibe löst nur eine bekannte, in #1199 gebuchte Abweichung ein. ADR-0049 (Premium-SMS als vierter Kanal) bleibt unverändert gültig und wird durch AC-8 geschützt.
+
+## Changelog
+
+- 2026-08-17: Initial spec created (Issue #1738, Track Full Process)

--- a/frontend/src/lib/components/edit/EditReportConfigSection.svelte
+++ b/frontend/src/lib/components/edit/EditReportConfigSection.svelte
@@ -11,6 +11,10 @@
 	} from '../shared/versand-tab/channelConnectionStatus';
 	import { channelContactLabel } from '../shared/versand-tab/channelContactLabel';
 	import { premiumSmsChannelState } from '../shared/versand-tab/premiumSmsChannelState';
+	// Issue #1738 Fix-Loop 1 (F001/F002): die Read-Modify-Write-Regel des
+	// report_config-Blobs steht als reine, pruefbare Funktion neben beiden
+	// Schreibern statt zweimal im jeweiligen Effect-Rumpf.
+	import { mergeReportConfig } from '../shared/versand-tab/mergeReportConfig.ts';
 	import { Dot } from '$lib/components/atoms';
 	import {
 		DEFAULT_DAILY_SUMMARY_METRICS,
@@ -228,42 +232,66 @@
 
 		// Original-Blob als Basis -> UI-Felder darueber mergen.
 		// So bleiben change_threshold_* und alle anderen unbekannten Felder erhalten.
-		const merged: Record<string, unknown> = {
-			...originalReportConfig,
-			enabled: morning_enabled || evening_enabled,
-			morning_enabled,
-			evening_enabled,
-			morning_time: toHHMMSS(morning_time),
-			evening_time: toHHMMSS(evening_time),
-			send_email,
-			send_telegram,
-			send_sms,
-			// Issue #1717 S3 — vierter Briefing-Kanal, gleicher Write-Back-Pfad.
-			send_premium_sms,
-			multi_day_trend_morning,
-			multi_day_trend_evening,
-			multi_day_trend_reports,
-			show_compact_summary,
-			wind_exposition_min_elevation_m,
-			// Issue #619: E-Mail-Elemente
-			show_stage_stats,
-			show_quick_take_tags,
-			show_stability,
-			show_highlights,
-			daily_summary_metrics: [...dailySummaryMetrics],
-			// Issue #664: Metriken-Überblick
-			show_metrics_summary,
-			// Issue #721/#723: Ausblick-Block
-			show_outlook,
-			// Issue #722: E-Mail-Format
-			email_format,
-			// Issue #785: Vortag-Vergleich
-			show_yesterday_comparison,
-		};
+		// Issue #1738: Basis ist der LEBENDE Blob (untrack -> kein Selbst-Trigger),
+		// nicht mehr nur der Mount-Schnappschuss. Seit /trips/new den geteilten
+		// VersandTab daneben mountet, schreiben zwei Komponenten in dasselbe
+		// report_config; der Schnappschuss ist veraltet, sobald der Nachbar etwas
+		// geaendert hat, und wuerde dessen Aenderung beim naechsten Lauf still
+		// ueberschreiben. originalReportConfig bleibt Rueckfall (erster Lauf,
+		// bevor onMount gelaufen ist).
+		// Issue #1738 Fix-Loop 1: Regel und Gating liegen in mergeReportConfig.ts —
+		// derselbe Helfer, den VersandTab.svelte benutzt. Zeitplan- und
+		// Kanal-Felder gehoeren dieser Instanz nur, wenn sie die zugehoerigen
+		// Bedienelemente auch zeigt. Sonst besitzt sie der Nachbar (VersandTab) —
+		// sie hier trotzdem mitzuschreiben waere ein zweiter, unabhaengiger
+		// Schreibpfad auf fremde Felder (Fehlerklasse Fix-Loop 4) und setzt z.B.
+		// einen frisch gesetzten Premium-SMS-Schalter beim naechsten
+		// Mail-Inhalt-Klick still zurueck.
+		const merged = mergeReportConfig({
+			snapshot: originalReportConfig as Record<string, unknown>,
+			live: untrack(() => reportConfig) as Record<string, unknown> | undefined,
+			own: {
+				show_compact_summary,
+				wind_exposition_min_elevation_m,
+				// Issue #619: E-Mail-Elemente
+				show_stage_stats,
+				show_quick_take_tags,
+				show_stability,
+				show_highlights,
+				daily_summary_metrics: [...dailySummaryMetrics],
+				// Issue #664: Metriken-Überblick
+				show_metrics_summary,
+				// Issue #721/#723: Ausblick-Block
+				show_outlook,
+				// Issue #722: E-Mail-Format
+				email_format,
+				// Issue #785: Vortag-Vergleich
+				show_yesterday_comparison,
+			},
+			showSchedule,
+			schedule: {
+				enabled: morning_enabled || evening_enabled,
+				morning_enabled,
+				evening_enabled,
+				morning_time: toHHMMSS(morning_time),
+				evening_time: toHHMMSS(evening_time),
+				multi_day_trend_morning,
+				multi_day_trend_evening,
+				multi_day_trend_reports,
+			},
+			showChannels,
+			channels: {
+				send_email,
+				send_telegram,
+				send_sms,
+				// Issue #1717 S3 — vierter Briefing-Kanal, gleicher Write-Back-Pfad.
+				send_premium_sms,
+			},
+		});
 
 		// Issue #617: verwaiste Kanäle (nicht Wetter-aktiv) auf false synchronisieren.
 		// syncSendFlags gibt merged unverändert zurück wenn weatherChannels undefined.
-		reportConfig = syncSendFlags(merged, weatherChannels) as ReportConfig;
+		reportConfig = syncSendFlags(merged, showChannels ? weatherChannels : undefined) as ReportConfig;
 	});
 
 	// --- VTSchedulePlan-Verdrahtung (Factory Pattern fuer Safari-Closure-Schutz,

--- a/frontend/src/lib/components/shared/VersandTab.svelte
+++ b/frontend/src/lib/components/shared/VersandTab.svelte
@@ -20,6 +20,10 @@
 	import VTSchedulePlan from './versand-tab/VTSchedulePlan.svelte';
 	import VTLaufzeitRoute from './versand-tab/VTLaufzeitRoute.svelte';
 	import VTLaufzeitVergleich from './versand-tab/VTLaufzeitVergleich.svelte';
+	// Issue #1738 Fix-Loop 1 (F001/F002): die Read-Modify-Write-Regel des
+	// report_config-Blobs steht als reine, pruefbare Funktion neben beiden
+	// Schreibern statt zweimal im jeweiligen Effect-Rumpf.
+	import { mergeReportConfig } from './versand-tab/mergeReportConfig.ts';
 	// Issue #1258 Scheibe S4 (E5): die komplette Alert-Zustellungs-Sektion des
 	// vergleich-Zweigs (Cooldown-/Quiet-Karten + Beispiel-Warnung) zog atomar
 	// in AlarmeTab.svelte um (Radar/Metrik-Level-Tabelle waren dort nie).
@@ -127,23 +131,34 @@
 		const multi_day_trend_reports: string[] = [];
 		if (multi_day_trend_morning) multi_day_trend_reports.push('morning');
 		if (multi_day_trend_evening) multi_day_trend_reports.push('evening');
-		const merged: Record<string, unknown> = {
-			...originalReportConfig,
-			enabled: morning_enabled || evening_enabled,
-			morning_enabled,
-			evening_enabled,
-			morning_time: toHHMMSS(morning_time),
-			evening_time: toHHMMSS(evening_time),
-			send_email,
-			send_telegram,
-			send_sms,
-			// Issue #1717 S3 — derselbe Write-Back-Pfad wie die drei darueber.
-			send_premium_sms,
-			telegram_style,
-			multi_day_trend_morning,
-			multi_day_trend_evening,
-			multi_day_trend_reports
-		};
+		// Issue #1738: Read-Modify-Write ueber den geteilten Helfer, Basis ist der
+		// LEBENDE Blob (untrack -> kein Selbst-Trigger) und nicht mehr nur der
+		// Mount-Schnappschuss. Seit /trips/new diese Komponente neben
+		// EditReportConfigSection auf dasselbe bind:reportConfig mountet, wuerde
+		// eine Zuweisung aus dem veralteten Schnappschuss jede Mail-Inhalt-
+		// Einstellung des Nachbarn (email_format, show_outlook, ...) und jedes
+		// unbekannte Bestandsfeld (change_threshold_*) still loeschen.
+		// originalReportConfig bleibt Rueckfall fuer den ersten Lauf vor onMount.
+		const merged = mergeReportConfig({
+			snapshot: originalReportConfig as Record<string, unknown>,
+			live: untrack(() => reportConfig) as Record<string, unknown> | undefined,
+			own: {
+				enabled: morning_enabled || evening_enabled,
+				morning_enabled,
+				evening_enabled,
+				morning_time: toHHMMSS(morning_time),
+				evening_time: toHHMMSS(evening_time),
+				send_email,
+				send_telegram,
+				send_sms,
+				// Issue #1717 S3 — derselbe Write-Back-Pfad wie die drei darueber.
+				send_premium_sms,
+				telegram_style,
+				multi_day_trend_morning,
+				multi_day_trend_evening,
+				multi_day_trend_reports
+			}
+		});
 		reportConfig = merged as ReportConfig;
 	});
 

--- a/frontend/src/lib/components/shared/versand-tab/__tests__/compare_versand_ohne_schaltbare_premium_sms.test.ts
+++ b/frontend/src/lib/components/shared/versand-tab/__tests__/compare_versand_ohne_schaltbare_premium_sms.test.ts
@@ -1,0 +1,81 @@
+// Regressionswaechter — Issue #1738, AC-8.
+// Spec: docs/specs/modules/fix_1738_trips_new_versand_tab.md — AC-8.
+//
+// ⚠️ DIESER TEST IST VON ANFANG AN GRUEN. Er sichert Bestand, kein neues
+// Verhalten: die Zusicherung aus #1717 AC-1 (Premium-SMS ist laut ADR-0049
+// ausschliesslich ein Trip-Briefing-Kanal, im Orts-Vergleich steht der feste
+// Platzhalter) darf durch die #1738-Migration nicht reissen.
+//
+// Warum er trotzdem hier steht: mit #1738 benutzt auch /trips/new denselben
+// geteilten Baustein. Wer den Premium-SMS-Schalter dort "einfach immer
+// sichtbar" macht, indem er das Prop-Gating in VTBriefingChannels aufweicht,
+// schaltet ihn damit zugleich in den drei Vergleichs-Mounts frei. Genau diese
+// Verwechslung faengt dieser Test.
+//
+// Ueberschneidet sich bewusst mit premium_sms_context_gating_render.test.ts
+// (#1717 AC-1) — dort ist es die Zusicherung selbst, hier die Gegenprobe zur
+// Migration.
+//
+// Pfadregel #1409: alle Pfade relativ zu DIESER Datei.
+//
+// Ausfuehrung:
+//   cd frontend && node --experimental-strip-types --test \
+//     src/lib/components/shared/versand-tab/__tests__/compare_versand_ohne_schaltbare_premium_sms.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { register } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// __tests__ -> versand-tab -> shared -> components -> lib -> src -> frontend
+const FRONTEND = path.resolve(HERE, '../../../../../..');
+
+register(
+	pathToFileURL(path.join(FRONTEND, 'test-svelte-ssr-hooks.mjs')).href,
+	pathToFileURL(FRONTEND + '/').href
+);
+
+const { render } = await import('svelte/server');
+const VersandTab = (
+	await import(
+		pathToFileURL(path.join(FRONTEND, 'src/lib/components/shared/VersandTab.svelte')).href
+	)
+).default;
+
+function renderVersand(context: 'route' | 'vergleich'): string {
+	return render(VersandTab, { props: { context } }).body;
+}
+
+/** Der schaltbare Premium-SMS-Block bringt Verbindungsstatus + Hinweis mit;
+ *  der feste Platzhalter hat beides nicht. */
+const SCHALTBAR = 'data-testid="channel-status-premium-sms"';
+const PLATZHALTER_TEXT = 'bald verfügbar';
+
+describe('AC-8: der Ortsvergleich behaelt seinen festen Premium-SMS-Platzhalter', () => {
+	test('vergleich_zeigt_keinen_schaltbaren_premium_sms_block', () => {
+		const vergleich = renderVersand('vergleich');
+
+		// Gegenprobe zuerst: im Trip-Briefing IST der schaltbare Block da. Ohne
+		// sie bliebe der Test auch dann gruen, wenn der Marker nirgends mehr
+		// entstuende — dann bewachte er nichts.
+		assert.ok(
+			renderVersand('route').includes(SCHALTBAR),
+			'AC-8 (Gegenprobe): Im Trip-Briefing muss der schaltbare Premium-SMS-Block existieren — ' +
+				'sonst prueft die Zusicherung unten nichts.'
+		);
+
+		assert.ok(
+			!vergleich.includes(SCHALTBAR),
+			'AC-8: Im Versand-Bereich des Ortsvergleichs ist ein schaltbarer Premium-SMS-Block ' +
+				'entstanden. Premium-SMS ist laut ADR-0049 ausschliesslich ein Trip-Briefing-Kanal ' +
+				'(#1717 AC-1).'
+		);
+		assert.ok(
+			vergleich.includes(PLATZHALTER_TEXT),
+			`AC-8: Der feste "${PLATZHALTER_TEXT}"-Hinweis fehlt im Ortsvergleich — der Kanal staende ` +
+				'dort ohne jede Erklaerung.'
+		);
+	});
+});

--- a/frontend/src/lib/components/shared/versand-tab/__tests__/merge_report_config_read_modify_write.test.ts
+++ b/frontend/src/lib/components/shared/versand-tab/__tests__/merge_report_config_read_modify_write.test.ts
@@ -1,0 +1,385 @@
+// Issue #1738 Fix-Loop 1 — Findings F001 (Replace statt Merge) und F002 (der
+// Schutzmechanismus war unbewacht).
+//
+// Warum dieser Test hier und nicht als Render-Test von /trips/new: der gesamte
+// bisherige Versand-Testbestand rendert ueber `svelte/server`s `render()`, und
+// dort laufen `$effect` und `onMount` NIE (im Repo dokumentiert in
+// shared/__tests__/weather_metrics_tab_create_mode_callback.test.ts:5). Die
+// Merge-Regel war damit nur dort geprueft, wo der Code steht — nicht dort, wo
+// sie wirkt: der Adversary nahm den Guard (M2) und den Live-Read (M3) wieder
+// heraus, ohne dass einer von 2677 Tests rot wurde.
+//
+// Geprueft wird deshalb die reine Funktion `../mergeReportConfig.ts`, die beide
+// Schreiber (VersandTab.svelte, EditReportConfigSection.svelte) benutzen —
+// inklusive der Abfolge ZWEIER Laeufe, also genau der Situation, die es auf
+// /trips/new erstmals gibt (beide Komponenten dauerhaft nebeneinander auf
+// demselben bind:reportConfig).
+//
+// Spec: docs/specs/modules/fix_1738_trips_new_versand_tab.md — AC-3, AC-6.
+// CLAUDE.md, Daten-Schema-Reworks: Read-Modify-Write mit Merge, niemals
+// Replace (BUG-DATALOSS-GR221).
+//
+// Pfadregel #1409: der Pruefling wird relativ zu DIESER Datei aufgeloest.
+//
+// Ausfuehrung:
+//   cd frontend && node --import ./test-lib-loader.mjs --experimental-strip-types \
+//     --test src/lib/components/shared/versand-tab/__tests__/merge_report_config_read_modify_write.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+
+import { mergeReportConfig } from '../mergeReportConfig.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const versandTabCode = readFileSync(join(HERE, '..', '..', 'VersandTab.svelte'), 'utf-8');
+const mailInhaltCode = readFileSync(
+	join(HERE, '..', '..', '..', 'edit', 'EditReportConfigSection.svelte'),
+	'utf-8'
+);
+
+/** Ein Write-Back-Lauf von VersandTab (Kanaele + Zeitplan gehoeren ihm immer).
+ *  Argumentform 1:1 wie in VersandTab.svelte. */
+function versandTabRun(
+	snapshot: Record<string, unknown>,
+	live: Record<string, unknown> | undefined,
+	own: Record<string, unknown>
+) {
+	return mergeReportConfig({ snapshot, live, own });
+}
+
+/** Ein Write-Back-Lauf von EditReportConfigSection auf /trips/new: Mail-Inhalt
+ *  gehoert ihm, Kanaele/Zeitplan NICHT (showChannels/showSchedule = false —
+ *  die zeigt dort der Nachbar VersandTab). Argumentform 1:1 wie in der
+ *  Komponente. */
+function mailInhaltRun(
+	snapshot: Record<string, unknown>,
+	live: Record<string, unknown> | undefined,
+	own: Record<string, unknown>,
+	channels: Record<string, unknown>,
+	schedule: Record<string, unknown>
+) {
+	return mergeReportConfig({
+		snapshot,
+		live,
+		own,
+		showSchedule: false,
+		schedule,
+		showChannels: false,
+		channels
+	});
+}
+
+describe('mergeReportConfig — Read-Modify-Write statt Replace', () => {
+	test('der lebende Blob schlaegt den veralteten Mount-Schnappschuss', () => {
+		// F001-Kern: der Schnappschuss stammt von onMount, der lebende Blob
+		// enthaelt bereits die Aenderung des Nachbarn. Wer nur den Schnappschuss
+		// als Basis nimmt, loescht sie.
+		const merged = mergeReportConfig({
+			snapshot: { email_format: 'full' },
+			live: { email_format: 'compact' },
+			own: { send_email: true }
+		});
+		assert.equal(merged.email_format, 'compact');
+	});
+
+	test('der Schnappschuss traegt den ersten Lauf, bevor onMount gelaufen ist', () => {
+		const merged = mergeReportConfig({
+			snapshot: { email_format: 'compact', change_threshold_wind: 7 },
+			live: undefined,
+			own: { send_email: true }
+		});
+		assert.equal(merged.email_format, 'compact');
+		assert.equal(merged.change_threshold_wind, 7);
+		assert.equal(merged.send_email, true);
+	});
+
+	test('eigene Felder gewinnen gegen Schnappschuss und lebenden Blob', () => {
+		const merged = mergeReportConfig({
+			snapshot: { send_premium_sms: false },
+			live: { send_premium_sms: false },
+			own: { send_premium_sms: true }
+		});
+		assert.equal(merged.send_premium_sms, true);
+	});
+
+	test('unbekannte Bestandsfelder ueberleben aus beiden Quellen', () => {
+		const merged = mergeReportConfig({
+			snapshot: { change_threshold_rain: 3 },
+			live: { change_threshold_wind: 11, custom_unknown_flag: 'x' },
+			own: { send_sms: true }
+		});
+		assert.equal(merged.change_threshold_rain, 3);
+		assert.equal(merged.change_threshold_wind, 11);
+		assert.equal(merged.custom_unknown_flag, 'x');
+	});
+
+	test('Kanal-Felder bleiben aussen vor, solange die Instanz keine Kanaele zeigt', () => {
+		// Gegenprobe zu Mutation M2: ohne diesen Guard schreibt die
+		// Mail-Inhalt-Karte fremde Kanal-Felder mit und setzt den Nachbarn zurueck.
+		const merged = mergeReportConfig({
+			snapshot: {},
+			live: { send_premium_sms: true, send_telegram: true },
+			own: { email_format: 'compact' },
+			showChannels: false,
+			channels: { send_premium_sms: false, send_telegram: false }
+		});
+		assert.equal(merged.send_premium_sms, true);
+		assert.equal(merged.send_telegram, true);
+	});
+
+	test('Kanal-Felder werden geschrieben, sobald die Instanz die Kanaele zeigt', () => {
+		// Positivkontrolle: der Guard darf den Schreibpfad nicht generell abwuergen
+		// (sonst waere der Test oben auch bei kaputtem Helfer gruen).
+		const merged = mergeReportConfig({
+			snapshot: {},
+			live: { send_premium_sms: true },
+			own: {},
+			showChannels: true,
+			channels: { send_premium_sms: false }
+		});
+		assert.equal(merged.send_premium_sms, false);
+	});
+
+	test('Zeitplan-Felder bleiben aussen vor, solange die Instanz keinen Zeitplan zeigt', () => {
+		const merged = mergeReportConfig({
+			snapshot: {},
+			live: { morning_time: '05:30:00', morning_enabled: true },
+			own: {},
+			showSchedule: false,
+			schedule: { morning_time: '07:00:00', morning_enabled: false }
+		});
+		assert.equal(merged.morning_time, '05:30:00');
+		assert.equal(merged.morning_enabled, true);
+	});
+
+	test('Zeitplan-Felder werden geschrieben, sobald die Instanz den Zeitplan zeigt', () => {
+		const merged = mergeReportConfig({
+			snapshot: {},
+			live: { morning_time: '05:30:00' },
+			own: {},
+			showSchedule: true,
+			schedule: { morning_time: '07:00:00' }
+		});
+		assert.equal(merged.morning_time, '07:00:00');
+	});
+});
+
+describe('/trips/new — zwei Schreiber auf demselben report_config (AC-3, AC-6)', () => {
+	test('Mail-Format ueberlebt einen nachfolgenden Kanal-Klick in VersandTab', () => {
+		// Reproduktion des gemeldeten Verlustpfads (F001), Nutzersicht:
+		// 1. Mail-Format auf "Kompakt" stellen, 2. danach Premium-SMS anhaken,
+		// 3. speichern -> beides muss im Blob stehen.
+		const mailSnapshot = { change_threshold_wind: 9 };
+		const versandSnapshot = { change_threshold_wind: 9 };
+
+		// Schritt 1: Mail-Inhalt-Karte schreibt email_format = compact.
+		const nachMailKlick = mailInhaltRun(
+			mailSnapshot,
+			{ change_threshold_wind: 9 },
+			{ email_format: 'compact', show_outlook: false },
+			{ send_email: true, send_premium_sms: false },
+			{ morning_time: '07:00:00' }
+		);
+		assert.equal(nachMailKlick.email_format, 'compact');
+
+		// Schritt 2: VersandTab schreibt Premium-SMS zurueck — sein eigener
+		// Schnappschuss ist zu diesem Zeitpunkt veraltet (kennt email_format nicht).
+		const nachKanalKlick = versandTabRun(versandSnapshot, nachMailKlick, {
+			send_email: true,
+			send_telegram: false,
+			send_sms: false,
+			send_premium_sms: true,
+			morning_time: '07:00:00'
+		});
+
+		assert.equal(
+			nachKanalKlick.email_format,
+			'compact',
+			'email_format darf durch den Kanal-Klick nicht verloren gehen (AC-6)'
+		);
+		assert.equal(nachKanalKlick.show_outlook, false, 'Inhaltsbaustein bleibt erhalten (AC-6)');
+		assert.equal(nachKanalKlick.send_premium_sms, true, 'Premium-SMS ist gesetzt (AC-3)');
+		assert.equal(nachKanalKlick.change_threshold_wind, 9, 'unbekanntes Bestandsfeld bleibt');
+	});
+
+	test('Premium-SMS ueberlebt einen nachfolgenden Klick in der Mail-Inhalt-Karte', () => {
+		// Die Gegenrichtung — dieselbe Fehlerklasse, andere Reihenfolge.
+		const nachKanalKlick = versandTabRun({}, {}, {
+			send_email: true,
+			send_telegram: false,
+			send_sms: false,
+			send_premium_sms: true
+		});
+
+		const nachMailKlick = mailInhaltRun(
+			{},
+			nachKanalKlick,
+			{ email_format: 'compact' },
+			{ send_email: true, send_telegram: false, send_sms: false, send_premium_sms: false },
+			{ morning_time: '07:00:00' }
+		);
+
+		assert.equal(nachMailKlick.send_premium_sms, true, 'Premium-SMS bleibt gesetzt (AC-3)');
+		assert.equal(nachMailKlick.email_format, 'compact');
+	});
+});
+
+// Die Aufrufstelle selbst ist ohne DOM-Harness nicht ausfuehrbar (siehe Kopf).
+// Source-Inspection-Muster wie in
+// trip-new/__tests__/trip_new_editor_weather_metrics_wiring.test.ts: geprueft
+// wird, dass beide Schreiber den Helfer mit den RICHTIGEN Argumenten fuettern —
+// ein korrekter Helfer, der den Mount-Schnappschuss als `live` bekommt, waere
+// exakt der Fehler F001 in neuem Gewand.
+describe('Verdrahtung: beide Schreiber uebergeben den lebenden Blob', () => {
+	test('VersandTab.svelte liest reportConfig live (untrack), nicht den Schnappschuss', () => {
+		const call = versandTabCode.match(/mergeReportConfig\(\{[\s\S]*?\n\t\t\}\)/);
+		assert.ok(call, 'VersandTab.svelte ruft mergeReportConfig nicht auf');
+		assert.match(
+			call[0],
+			/live:\s*untrack\(\(\)\s*=>\s*reportConfig\)/,
+			'VersandTab uebergibt keinen Live-Read von reportConfig als `live` — mit dem ' +
+				'veralteten onMount-Schnappschuss loescht der naechste Write-Back die ' +
+				'Mail-Inhalt-Einstellungen des Nachbarn (F001)'
+		);
+	});
+
+	test('EditReportConfigSection.svelte liest reportConfig live (untrack)', () => {
+		const call = mailInhaltCode.match(/mergeReportConfig\(\{[\s\S]*?\n\t\t\}\)/);
+		assert.ok(call, 'EditReportConfigSection.svelte ruft mergeReportConfig nicht auf');
+		assert.match(
+			call[0],
+			/live:\s*untrack\(\(\)\s*=>\s*reportConfig\)/,
+			'EditReportConfigSection uebergibt keinen Live-Read von reportConfig als `live` ' +
+				'— Kanal-/Zeitplanwerte des Nachbarn gingen sonst verloren (F001)'
+		);
+	});
+
+	test('EditReportConfigSection reicht die echten Sichtbarkeits-Flags durch', () => {
+		const call = mailInhaltCode.match(/mergeReportConfig\(\{[\s\S]*?\n\t\t\}\)/);
+		assert.ok(call, 'EditReportConfigSection.svelte ruft mergeReportConfig nicht auf');
+		// Kurzschreibweise `showSchedule,` / `showChannels,` = die Props selbst.
+		// Ein fest verdrahtetes `true` waere der zweite Schreibpfad auf fremde
+		// Felder, den der Guard gerade verhindern soll (Mutation M2).
+		assert.match(
+			call[0],
+			/\bshowSchedule,/,
+			'showSchedule wird nicht als Prop durchgereicht — Zeitplan-Felder wuerden auch ' +
+				'dann geschrieben, wenn diese Instanz gar keinen Zeitplan zeigt'
+		);
+		assert.match(
+			call[0],
+			/\bshowChannels,/,
+			'showChannels wird nicht als Prop durchgereicht — Kanal-Felder wuerden auch dann ' +
+				'geschrieben, wenn diese Instanz gar keine Kanaele zeigt (Mutation M2)'
+		);
+	});
+});
+
+// ── Finding F003: die Disjunktheit der Feldgruppen ──────────────────────────
+//
+// `own` wird IMMER geschrieben, `schedule`/`channels` nur bei gesetztem Flag.
+// Taucht ein Feld in beiden Gruppen auf, gewinnt fuer dieses eine Feld wieder
+// der unbedingte Pfad — also F001 zurueck, nur feldweise und noch leiser.
+// Heute sind beide Aufrufstellen disjunkt; unbewacht faellt die naechste
+// Feldverschiebung niemandem auf.
+//
+// Bewusst als Aufrufstellen-Pruefung und NICHT als Laufzeit-Wache in
+// mergeReportConfig(): eine Laufzeit-Wache lauft nur, wenn jemand die Funktion
+// aufruft — und die Aufrufstellen in den beiden .svelte-Dateien fuehrt kein
+// Test je aus (kein DOM-Harness, siehe Kopf). Sie wuerde die Ueberschneidung
+// genau dort verschlafen, wo sie entsteht, und dabei wie ein Schutz aussehen.
+
+/** Schluessel der obersten Ebene eines benannten Objekt-Arguments im
+ *  mergeReportConfig-Aufruf. Klammer-Zaehlung statt Regex, damit verschachtelte
+ *  Literale und Arrays nicht mitzaehlen. */
+function groupKeys(callText: string, group: string): string[] {
+	const at = callText.indexOf(`${group}: {`);
+	if (at === -1) return [];
+	const open = callText.indexOf('{', at);
+	let depth = 0;
+	let close = -1;
+	for (let i = open; i < callText.length; i++) {
+		if (callText[i] === '{') depth++;
+		else if (callText[i] === '}') {
+			depth--;
+			if (depth === 0) {
+				close = i;
+				break;
+			}
+		}
+	}
+	assert.ok(close > open, `Gruppe ${group} ist nicht geschlossen — Extraktor defekt`);
+	const keys: string[] = [];
+	let nested = 0;
+	for (const raw of callText.slice(open + 1, close).split('\n')) {
+		const line = raw.trim();
+		if (nested === 0 && !line.startsWith('//')) {
+			const m = line.match(/^([A-Za-z_$][\w$]*)\s*[:,]/);
+			if (m) keys.push(m[1]);
+		}
+		for (const ch of raw) {
+			if (ch === '{' || ch === '[') nested++;
+			else if (ch === '}' || ch === ']') nested--;
+		}
+	}
+	return keys;
+}
+
+function mergeCall(code: string, label: string): string {
+	const call = code.match(/mergeReportConfig\(\{[\s\S]*?\n\t\t\}\)/);
+	assert.ok(call, `${label} ruft mergeReportConfig nicht auf`);
+	return call[0];
+}
+
+describe('F003: unbedingte und bedingte Feldgruppen bleiben disjunkt', () => {
+	test('der Schluessel-Extraktor findet die Gruppen wirklich (Positivkontrolle)', () => {
+		// Ohne diese Kontrolle waeren die Disjunktheits-Tests unten auch dann
+		// gruen, wenn der Extraktor nichts findet — eine leere Menge ist mit
+		// jeder anderen disjunkt.
+		const call = mergeCall(mailInhaltCode, 'EditReportConfigSection.svelte');
+		const own = groupKeys(call, 'own');
+		const schedule = groupKeys(call, 'schedule');
+		const channels = groupKeys(call, 'channels');
+		assert.ok(own.includes('email_format'), `own-Gruppe nicht erkannt: ${own.join(',')}`);
+		assert.ok(
+			schedule.includes('morning_time'),
+			`schedule-Gruppe nicht erkannt: ${schedule.join(',')}`
+		);
+		assert.ok(
+			channels.includes('send_email'),
+			`channels-Gruppe nicht erkannt: ${channels.join(',')}`
+		);
+	});
+
+	test('EditReportConfigSection: kein Feld steht gleichzeitig in own und einer bedingten Gruppe', () => {
+		const call = mergeCall(mailInhaltCode, 'EditReportConfigSection.svelte');
+		const own = new Set(groupKeys(call, 'own'));
+		for (const group of ['schedule', 'channels']) {
+			const doppelt = groupKeys(call, group).filter((k) => own.has(k));
+			assert.deepEqual(
+				doppelt,
+				[],
+				`Feld(er) ${doppelt.join(', ')} stehen in own UND in ${group}. own wird immer ` +
+					`geschrieben — damit landet das Feld auch dann im Blob, wenn diese Instanz die ` +
+					`zugehoerigen Bedienelemente gar nicht zeigt, und ueberschreibt den Nachbarn (F001/F003).`
+			);
+		}
+	});
+
+	test('VersandTab: kein Feld steht gleichzeitig in own und einer bedingten Gruppe', () => {
+		const call = mergeCall(versandTabCode, 'VersandTab.svelte');
+		const own = new Set(groupKeys(call, 'own'));
+		assert.ok(own.has('send_email'), `own-Gruppe nicht erkannt: ${[...own].join(',')}`);
+		for (const group of ['schedule', 'channels']) {
+			const doppelt = groupKeys(call, group).filter((k) => own.has(k));
+			assert.deepEqual(
+				doppelt,
+				[],
+				`Feld(er) ${doppelt.join(', ')} stehen in own UND in ${group} (F003).`
+			);
+		}
+	});
+});

--- a/frontend/src/lib/components/shared/versand-tab/mergeReportConfig.ts
+++ b/frontend/src/lib/components/shared/versand-tab/mergeReportConfig.ts
@@ -1,0 +1,66 @@
+// mergeReportConfig — Issue #1738 Fix-Loop 1 (Findings F001/F002).
+//
+// EIN Ort fuer die Read-Modify-Write-Regel des `report_config`-Blobs. Beide
+// Schreiber rufen ihn auf: VersandTab.svelte (Kanaele + Zeitplan) und
+// EditReportConfigSection.svelte (Mail-Inhalt, dort je nach Props zusaetzlich
+// Kanaele/Zeitplan).
+//
+// Warum ueberhaupt eine eigene Datei: seit /trips/new beide Komponenten
+// DAUERHAFT NEBENEINANDER auf dasselbe `bind:reportConfig` mountet
+// (TripNewEditor.svelte, Zeitplan-Tab), schreiben zwei $effect-Laeufe
+// abwechselnd in denselben Blob. Jeder Lauf, der seine Basis aus einem
+// veralteten onMount-Schnappschuss nimmt und das Ergebnis komplett zuweist,
+// loescht still alles, was der Nachbar seither gesetzt hat — genau der
+// Replace-statt-Merge-Fehler, den CLAUDE.md (Daten-Schema-Reworks,
+// BUG-DATALOSS-GR221) verbietet.
+//
+// Der zweite Grund ist Pruefbarkeit: `$effect` und `onMount` laufen unter
+// `svelte/server`s `render()` NIE (im Repo dokumentiert in
+// shared/__tests__/weather_metrics_tab_create_mode_callback.test.ts:5), und ein
+// DOM-Harness gibt es im Frontend-Test-Setup nicht. Solange die Merge-Regel im
+// Effect-Rumpf steht, ist sie nur dort geprueft, wo der Code steht, nicht dort,
+// wo er wirkt (Finding F002). Als reine Funktion ist sie ohne Harness direkt
+// messbar — inklusive der Reihenfolge zweier aufeinanderfolgende Laeufe.
+//
+// Pure Funktion, kein Netz-/DOM-Zugriff — node:testbar.
+
+export interface ReportConfigMergeInput {
+	/** onMount-Schnappschuss des Blobs. Nur Rueckfall fuer den ersten Lauf,
+	 *  bevor `onMount` gelaufen ist — NIE alleinige Basis (siehe Modulkopf). */
+	snapshot?: Record<string, unknown> | null;
+	/** Der LEBENDE Blob des Parents, im Aufrufer per `untrack` gelesen (kein
+	 *  Selbst-Trigger). Absichtlich ein Pflichtfeld der Schnittstelle: laesst ein
+	 *  spaeterer Umbau ihn weg, ist das ein Typfehler und kein stiller
+	 *  Datenverlust. */
+	live: Record<string, unknown> | null | undefined;
+	/** Felder, die diese Instanz immer besitzt. */
+	own?: Record<string, unknown> | null;
+	/** Zeitplan-Felder — nur uebernommen, wenn `showSchedule`. */
+	schedule?: Record<string, unknown> | null;
+	/** Kanal-Felder — nur uebernommen, wenn `showChannels`. */
+	channels?: Record<string, unknown> | null;
+	/** Zeigt diese Instanz die Zeitplan-Bedienelemente? Sonst gehoeren die
+	 *  Felder dem Nachbarn und duerfen hier nicht geschrieben werden. */
+	showSchedule?: boolean;
+	/** Zeigt diese Instanz die Kanal-Bedienelemente? Sonst siehe oben. */
+	showChannels?: boolean;
+}
+
+/**
+ * Baut den neuen `report_config`-Blob nach Read-Modify-Write.
+ *
+ * Reihenfolge (spaeter gewinnt): Schnappschuss -> lebender Blob -> eigene
+ * Felder -> Zeitplan-Gruppe (nur mit `showSchedule`) -> Kanal-Gruppe (nur mit
+ * `showChannels`). Unbekannte Bestandsfelder (`change_threshold_*`) reisen
+ * durch beide Spreads mit und bleiben damit erhalten.
+ */
+export function mergeReportConfig(input: ReportConfigMergeInput): Record<string, unknown> {
+	const merged: Record<string, unknown> = {
+		...(input.snapshot ?? {}),
+		...(input.live ?? {}),
+		...(input.own ?? {})
+	};
+	if (input.showSchedule) Object.assign(merged, input.schedule ?? {});
+	if (input.showChannels) Object.assign(merged, input.channels ?? {});
+	return merged;
+}

--- a/frontend/src/lib/components/trip-new/TripNewEditor.svelte
+++ b/frontend/src/lib/components/trip-new/TripNewEditor.svelte
@@ -7,11 +7,12 @@
 	// Design: docs/design-requests/trip-anlegen-2026-06-06/screen-trip-new-v2-mobile.jsx
 	// Factory-Pattern für alle Event-Handler (Safari-Closure-Schutz, CLAUDE.md).
 
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { goto, beforeNavigate } from '$app/navigation';
 	import { api } from '$lib/api.js';
 	import { Eyebrow, Btn, Input, TopoBg } from '$lib/components/atoms';
 	import WeatherMetricsTab from '$lib/components/shared/WeatherMetricsTab.svelte';
+	import VersandTab from '$lib/components/shared/VersandTab.svelte';
 	import EditReportConfigSection from '$lib/components/edit/EditReportConfigSection.svelte';
 	import EditStagesPanelNew from '$lib/components/edit/EditStagesPanelNew.svelte';
 	import { AlertRulesEditor } from '$lib/components/organisms';
@@ -34,6 +35,28 @@
 		buildCreateTripPayload,
 	} from './tripNewLogic.ts';
 
+	// ── Test-Seam (Issue #1738, Muster `profileOverride` aus #1510) ──────────
+	// Der gesamte Anlege-Zustand lebt in internem `$state`; `isMobileViewport`
+	// entsteht sogar erst in `onMount`, das `svelte/server` nie ausfuehrt. Ohne
+	// Vorbelegung ist der Zeitplan-Tab serverseitig gar nicht erreichbar und die
+	// Ein-Instanz-Zusicherung (AC-5) nicht messbar. OHNE Uebergabe ist das
+	// Verhalten unveraendert — insbesondere kommt `isMobileViewport` dann
+	// weiterhin aus `matchMedia`.
+	interface TripNewStateOverride {
+		activeTab?: TabId;
+		isMobileViewport?: boolean;
+		channels?: { email: boolean; telegram: boolean; sms: boolean };
+		reportConfig?: ReportConfig;
+		name?: string;
+		startDate?: string;
+		stageNames?: string[];
+	}
+	let { stateOverride }: { stateOverride?: TripNewStateOverride } = $props();
+	// Einmal-Lesung beim Erzeugen (untrack, wie `profileOverride` in
+	// VTBriefingChannels.svelte) — die Vorbelegung ist ein Startwert, kein
+	// reaktiver Bezug.
+	const seed: TripNewStateOverride = untrack(() => stateOverride ?? {});
+
 	// ── Tab-Definitionen (1:1 TN_TAB_DEFS) ──────────────────────────────────
 	const TAB_DEFS: { id: TabId; label: string; lockHint: string | null; optional: boolean }[] = [
 		{ id: 'route',     label: 'Route',            lockHint: null,                             optional: false },
@@ -45,21 +68,25 @@
 	];
 
 	// ── Lokaler Anlege-State ──────────────────────────────────────────────────
-	let name = $state('');
+	let name = $state(seed.name ?? '');
 	let region = $state('');
-	let startDate = $state('');
+	let startDate = $state(seed.startDate ?? '');
 
 	interface StageLocal { id: number; name: string; gpx: { file: string; km: number; asc: number } | null; waypoints: Waypoint[] }
-	let stages = $state<StageLocal[]>([
-		{ id: 1, name: '', gpx: null, waypoints: [] },
-		{ id: 2, name: '', gpx: null, waypoints: [] },
-	]);
+	let stages = $state<StageLocal[]>(
+		seed.stageNames
+			? seed.stageNames.map((n, i) => ({ id: i + 1, name: n, gpx: null, waypoints: [] }))
+			: [
+					{ id: 1, name: '', gpx: null, waypoints: [] },
+					{ id: 2, name: '', gpx: null, waypoints: [] },
+				]
+	);
 	// Bug #708 — Etappen-Löschen mit Bestätigungs-Dialog
 	let pendingRemoveStageId = $state<number | null>(null);
 
 	let weatherMetrics = $state<WeatherConfigMetric[]>([]);
-	let channels = $state({ email: true, telegram: true, sms: false });
-	let reportConfig = $state<ReportConfig | undefined>(undefined);
+	let channels = $state(seed.channels ?? { email: true, telegram: true, sms: false });
+	let reportConfig = $state<ReportConfig | undefined>(seed.reportConfig);
 	let alertRules = $state<AlertRule[]>([]);
 	// Issue #674 — Aktivitätstyp aus WeatherMetricsTab übernehmen (Fahrrad/Wanderer).
 	let selectedActivity = $state<ActivityType | undefined>(undefined);
@@ -68,13 +95,16 @@
 	let wtVisited = $state(false);
 	let ztVisited = $state(false);
 
-	let activeTab = $state<TabId>('route');
+	let activeTab = $state<TabId>(seed.activeTab ?? 'route');
 
 	// Issue #932 — Viewport-Flag, damit das Aktivitätstyp-Dropdown nur EINMAL
 	// im DOM existiert (desktop XOR mobile). Spiegelt die CSS-Breakpoint-Grenze
 	// (≤899px = mobile) der .tn-mobile/.tn-desktop-Umschaltung.
-	let isMobileViewport = $state(false);
+	let isMobileViewport = $state(seed.isMobileViewport ?? false);
 	onMount(() => {
+		// Issue #1738: nur der Test-Seam schaltet die Viewport-Erkennung ab —
+		// ohne Uebergabe bleibt matchMedia die einzige Quelle.
+		if (seed.isMobileViewport !== undefined) return;
 		const mq = window.matchMedia('(max-width: 899px)');
 		isMobileViewport = mq.matches;
 		const onChange = (e: MediaQueryListEvent) => { isMobileViewport = e.matches; };
@@ -82,11 +112,16 @@
 		return () => mq.removeEventListener('change', onChange);
 	});
 
-	// Stub-Trip für WeatherMetricsTab (createMode — kein PUT)
+	// Stub-Trip für WeatherMetricsTab und VersandTab (createMode — kein PUT).
+	// Issue #1738: `stages` ist nicht mehr leer — VTLaufzeitRoute leitet das
+	// Trip-Ende über `computeTripEnd` aus `stage.date` (ISO) ab. Quelle ist
+	// dieselbe Datums-Arithmetik wie im Speicher-Payload (`stageDateISO` /
+	// `addDaysISO`, beide UTC + idx Tage); `stageDate()` liefert `dd.mm.` ohne
+	// Jahr und ist dafür unbrauchbar.
 	const stubTrip = $derived<Trip>({
 		id: '__new__',
 		name: name || 'Neue Tour',
-		stages: [],
+		stages: buildEditorStages(),
 		activity: selectedActivity,
 		display_config: { channels, metrics: weatherMetrics } as unknown as Trip['display_config'],
 		report_config: reportConfig,
@@ -291,6 +326,16 @@
 	function makeEtappenContinueHandler(target: TabId) {
 		return () => switchTab(target);
 	}
+
+	// ── Sprung aus dem geteilten VersandTab (Issue #1738) ─────────────────────
+	// VTLaufzeitRoute meldet den Sprungwunsch unter dem Trip-Detail-Tabnamen
+	// 'stages'; im Anlege-Flow heißt derselbe Tab 'etappen'.
+	function makeVersandJumpHandler() {
+		return function doJump(tab: string) {
+			if (tab === 'stages' || tab === 'etappen') switchTab('etappen');
+		};
+	}
+	const onVersandJump = makeVersandJumpHandler();
 
 	// ── Kanal-Änderung aus WeatherMetricsTab ──────────────────────────────────
 	function handleChannelsChange(c: { email: boolean; telegram: boolean; sms: boolean }) {
@@ -795,10 +840,21 @@
 			</div>
 
 		{:else if activeTab === 'zeitplan'}
-			<!-- Zeitplan-Tab: reuse EditReportConfigSection im create-Modus -->
+			<!-- Zeitplan-Tab — Issue #1738: Kanäle + Zeitplan + Laufzeit kommen aus
+			     dem geteilten VersandTab (context="route", Teilungsregel/Epic #1230).
+			     EditReportConfigSection bleibt nur noch für die Mail-Inhalt-Karte
+			     (showChannels/showSchedule=false, Muster WeatherMetricsTab.svelte).
+			     Damit hängt kein Versandkanal mehr an der Wetter-Metrik-Auswahl.
+			     Das isMobileViewport-Gate hält — wie bei WeatherMetricsTab unten —
+			     nur EINE Instanz im DOM: zwei gleichzeitig gemountete Instanzen
+			     halten je einen eigenen Schnappschuss von report_config und
+			     überschreiben sich gegenseitig (Last-Write-Wins, Fix-Loop 4). -->
+			{#if !isMobileViewport}
 			<div style="padding: 32px 40px 60px; max-width: 720px;">
-				<EditReportConfigSection bind:reportConfig mode="create" weatherChannels={channels} />
+				<VersandTab context="route" trip={stubTrip} bind:reportConfig onJump={onVersandJump} />
+				<EditReportConfigSection bind:reportConfig mode="create" showChannels={false} showSchedule={false} />
 			</div>
+			{/if}
 
 		{:else if activeTab === 'alerts'}
 			<!-- Alerts-Tab: reuse AlertRulesEditor mit bind:rules -->
@@ -1031,10 +1087,14 @@
 				</div>
 
 			{:else if activeTab === 'zeitplan'}
-				<!-- Mobile Zeitplan-Tab: Wrapper mit mobilem Padding -->
+				<!-- Mobile Zeitplan-Tab: Wrapper mit mobilem Padding.
+				     Issue #1738 — geteilter VersandTab, XOR zum Desktop-Mount oben. -->
+				{#if isMobileViewport}
 				<div style="padding: 16px 16px 60px;">
-					<EditReportConfigSection bind:reportConfig mode="create" weatherChannels={channels} />
+					<VersandTab context="route" trip={stubTrip} bind:reportConfig onJump={onVersandJump} />
+					<EditReportConfigSection bind:reportConfig mode="create" showChannels={false} showSchedule={false} />
 				</div>
+				{/if}
 
 			{:else if activeTab === 'alerts'}
 				<!-- Mobile Alerts-Tab: Wrapper mit mobilem Padding -->

--- a/frontend/src/lib/components/trip-new/__tests__/ssrRunesHook.mjs
+++ b/frontend/src/lib/components/trip-new/__tests__/ssrRunesHook.mjs
@@ -1,0 +1,54 @@
+// ESM-Hook-Ergaenzung fuer das SSR-Rendern GANZER Editor-Komponenten.
+//
+// `test-svelte-ssr-hooks.mjs` uebersetzt `.svelte`-Dateien. Fuer einen
+// Vollrender von `TripNewEditor.svelte` reicht das nicht: die Komponente zieht
+// ueber `$lib/components/ui/dialog` die Bibliothek `bits-ui` herein, und deren
+// ausgelieferte `*.svelte.js`-Module enthalten unkompilierte Runes
+// (`$state`, `$derived.by`). Node laedt sie sonst als reines JS und bricht mit
+// `ReferenceError: $state is not defined` ab.
+//
+// Dieser Hook uebersetzt genau solche Runen-Module mit `compileModule` des
+// echten Svelte-Compilers — kein Rune-Attrappen-Shim, der `$derived.by` eifrig
+// statt faul auswerten wuerde und die Bibliothek dadurch anders laufen liesse
+// als in der Anwendung.
+//
+// Zusaetzlich werden die SvelteKit-Laufzeit-Module `$app/*` aufloesbar gemacht;
+// ausserhalb von Vite existieren sie nicht. Navigation ist im Render nicht
+// beteiligt (`goto`/`beforeNavigate` werden nur in Event-Handlern aufgerufen).
+
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { compileModule } from 'svelte/compiler';
+
+const APP_STUBS = {
+	'$app/navigation':
+		'export function goto(){};export function beforeNavigate(){};' +
+		'export function afterNavigate(){};export function invalidateAll(){};' +
+		'export function pushState(){};export function replaceState(){}',
+	'$app/environment': 'export const browser=false;export const dev=false;export const building=false;',
+	'$app/stores':
+		'export const page={subscribe(run){run({url:new URL("http://localhost/trips/new"),params:{}});return()=>{}}};' +
+		'export const navigating={subscribe(run){run(null);return()=>{}}};'
+};
+
+export async function resolve(specifier, context, nextResolve) {
+	const stub = APP_STUBS[specifier];
+	if (stub) {
+		return { url: `data:text/javascript,${encodeURIComponent(stub)}`, shortCircuit: true };
+	}
+	return nextResolve(specifier, context);
+}
+
+export async function load(url, context, nextLoad) {
+	if (/\.svelte\.(js|ts)$/.test(url) && url.startsWith('file:')) {
+		const file = fileURLToPath(url);
+		if (existsSync(file)) {
+			const { js } = compileModule(readFileSync(file, 'utf-8'), {
+				generate: 'server',
+				filename: file
+			});
+			return { format: 'module', shortCircuit: true, source: js.code };
+		}
+	}
+	return nextLoad(url, context);
+}

--- a/frontend/src/lib/components/trip-new/__tests__/tripNewSsr.ts
+++ b/frontend/src/lib/components/trip-new/__tests__/tripNewSsr.ts
@@ -1,0 +1,136 @@
+// SSR-Renderharness fuer TripNewEditor.svelte (Issue #1738).
+//
+// Rendert die ECHTE Anlege-Komponente serverseitig (svelte/server `render`) —
+// keine Mocks, keine Quelltext-Greps. Vorbild:
+// shared/versand-tab/__tests__/channel_checkbox_dedupe_render.test.ts.
+//
+// TEST-SEAM (RED-Infrastruktur, Muster `profileOverride` aus #1510):
+// TripNewEditor haelt Tab-Auswahl, Wetter-Kanaele, Etappen und die
+// Viewport-Erkennung ausschliesslich in internem `$state`; `isMobileViewport`
+// entsteht sogar erst in `onMount`, das `svelte/server` nicht ausfuehrt. Ohne
+// Vorbelegung ist der Zeitplan-Tab im Test nicht erreichbar und AC-5
+// ("schmale UND breite Ansicht") gar nicht messbar. Diese Tests verlangen
+// deshalb eine optionale Prop `stateOverride` (Form s. TripNewStateOverride
+// unten); ohne Uebergabe bleibt das Verhalten unveraendert.
+//
+// Pfadregel #1409: alle Pfade relativ zu DIESER Datei.
+
+import { register } from 'node:module';
+import assert from 'node:assert/strict';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// __tests__ -> trip-new -> components -> lib -> src -> frontend
+export const FRONTEND = path.resolve(HERE, '../../../../..');
+
+// Reihenfolge: erst der Runen-/$app-Hook (bits-ui liefert unkompilierte
+// `*.svelte.js`-Runenmodule aus, `$app/*` existiert ausserhalb von Vite nicht),
+// danach der `.svelte`-Compiler-Hook.
+register(pathToFileURL(path.join(HERE, 'ssrRunesHook.mjs')).href, pathToFileURL(FRONTEND + '/').href);
+register(
+	pathToFileURL(path.join(FRONTEND, 'test-svelte-ssr-hooks.mjs')).href,
+	pathToFileURL(FRONTEND + '/').href
+);
+
+export interface TripNewStateOverride {
+	/** Offener Tab beim Rendern (Default 'route'). */
+	activeTab?: string;
+	/** Ersetzt die matchMedia-Erkennung, die sonst erst in onMount entsteht. */
+	isMobileViewport?: boolean;
+	/** Wetter-Kanaele aus dem Metriken-Tab (display_config.channels). */
+	channels?: { email: boolean; telegram: boolean; sms: boolean };
+	reportConfig?: Record<string, unknown>;
+	name?: string;
+	startDate?: string;
+	stageNames?: string[];
+}
+
+const { render } = await import('svelte/server');
+const TripNewEditor = (
+	await import(
+		pathToFileURL(path.join(FRONTEND, 'src/lib/components/trip-new/TripNewEditor.svelte')).href
+	)
+).default;
+
+/** Rendert /trips/new serverseitig mit vorbelegtem Anlege-Zustand. */
+export function renderTripNew(stateOverride: TripNewStateOverride): string {
+	return render(TripNewEditor, { props: { stateOverride } }).body;
+}
+
+/** Positivkontrolle: die Vorbelegung hat gegriffen, der gewuenschte Tab ist
+ *  wirklich offen. Ohne sie waere kein Befund unten von "der Harness kommt gar
+ *  nicht am Zeitplan-Tab an" zu unterscheiden. */
+export function assertTabOffen(html: string, tab: string): void {
+	for (const marker of ['trip-new-name-input-desktop', 'trip-new-name-input-mobile']) {
+		assert.ok(
+			!html.includes(`data-testid="${marker}"`),
+			`Vorbelegung stateOverride.activeTab="${tab}" wurde nicht beachtet — es rendert weiter ` +
+				`der Route-Tab (${marker} im Dokument). Ohne diese Prop ist der Zeitplan-Tab im ` +
+				'SSR-Test nicht erreichbar (s. TEST-SEAM im Kopf von tripNewSsr.ts).'
+		);
+	}
+}
+
+export function countTestid(html: string, testid: string): number {
+	return html.split(`data-testid="${testid}"`).length - 1;
+}
+
+/** `<input …>`-Tag direkt hinter dem gegebenen Testid. */
+export function checkboxInputTag(html: string, testid: string): string {
+	const mi = html.indexOf(`data-testid="${testid}"`);
+	assert.notEqual(mi, -1, `Testid "${testid}" fehlt im gerenderten Zeitplan-Tab.`);
+	const start = html.indexOf('<input', mi);
+	assert.notEqual(start, -1, `Kein <input> hinter Testid "${testid}".`);
+	return html.slice(start, html.indexOf('>', start) + 1);
+}
+
+/** true nur, wenn das boolsche Attribut im Tag gesetzt ist (Svelte-SSR rendert
+ *  es als `x=""` oder laesst es bei `false` ganz weg). */
+export function hatAttribut(inputTag: string, name: string): boolean {
+	return new RegExp(`\\b${name}(=""|(?=[\\s/>]))`).test(inputTag);
+}
+
+/** Sichtbarer Text (Tags + Svelte-Kommentaranker raus). */
+export function visibleText(html: string): string {
+	return html
+		.replace(/<!--[\s\S]*?-->/g, ' ')
+		.replace(/<[^>]*>/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+/** Aeusseres HTML des Elements mit dem gegebenen Testid (Tag-Nesting zaehlend). */
+export function outerHtml(html: string, testid: string): string {
+	const mi = html.indexOf(`data-testid="${testid}"`);
+	assert.notEqual(mi, -1, `Testid "${testid}" fehlt im gerenderten Dokument.`);
+	const start = html.lastIndexOf('<', mi);
+	const tag = /^<([a-zA-Z0-9-]+)/.exec(html.slice(start, start + 40))?.[1];
+	assert.ok(tag, `Kein Tag-Name vor Testid "${testid}".`);
+	const re = new RegExp(`<${tag}\\b[^>]*>|</${tag}>`, 'g');
+	re.lastIndex = start;
+	let depth = 0;
+	let m: RegExpExecArray | null;
+	while ((m = re.exec(html))) {
+		if (m[0].startsWith('</')) {
+			depth--;
+			if (depth === 0) return html.slice(start, m.index + m[0].length);
+		} else if (m[0].endsWith('/>')) {
+			if (m.index === start) return m[0];
+		} else {
+			depth++;
+		}
+	}
+	assert.fail(`Element zu Testid "${testid}" nicht geschlossen.`);
+}
+
+/** In welchem der beiden per CSS umgeschalteten Markup-Baeume steht das Testid?
+ *  Der Mobil-Inhaltsbaum ist der LETZTE `.tn-mobile`-Block des Dokuments
+ *  (TripNewEditor.svelte:834), alles davor gehoert zum Desktop-Baum. */
+export function bereichVon(html: string, testid: string): 'desktop' | 'mobil' {
+	const mi = html.indexOf(`data-testid="${testid}"`);
+	assert.notEqual(mi, -1, `Testid "${testid}" fehlt im gerenderten Dokument.`);
+	const mobileStart = html.lastIndexOf('class="tn-mobile');
+	assert.notEqual(mobileStart, -1, 'Mobil-Inhaltsbaum (.tn-mobile) nicht gefunden.');
+	return mi < mobileStart ? 'desktop' : 'mobil';
+}

--- a/frontend/src/lib/components/trip-new/__tests__/trip_new_versandkanaele_unabhaengig_von_metriken.test.ts
+++ b/frontend/src/lib/components/trip-new/__tests__/trip_new_versandkanaele_unabhaengig_von_metriken.test.ts
@@ -1,0 +1,166 @@
+// TDD RED — Issue #1738: "Premium-SMS-Schalter verschwindet auf /trips/new,
+// wenn die SMS-Wetter-Metrik ausgeblendet wird."
+// Spec: docs/specs/modules/fix_1738_trips_new_versand_tab.md — AC-1, AC-2, AC-3.
+//
+// NUTZERSICHT: Wer im Metriken-Tab einen Wetter-Kanal abwaehlt, verliert im
+// Zeitplan-Tab den Zugang zum zugehoerigen VERSAND-Kanal — bei Premium-SMS
+// doppelt verschachtelt (EditReportConfigSection.svelte:377 + :401). Premium-SMS
+// ist auf der Huette der einzige empfangbare Kanal (ADR-0049).
+//
+// Gemessen wird am ECHTEN serverseitigen Render der echten Anlege-Komponente
+// (svelte/server), nicht am Quelltext und nicht an einer Attrappe.
+// Renderharness + Test-Seam: ./tripNewSsr.mjs.
+//
+// RED heute:
+//   - Die Vorbedingung schlaegt fehl, solange TripNewEditor keine
+//     `stateOverride`-Prop hat: der Zeitplan-Tab ist im Test nicht erreichbar.
+//   - Danach bleiben AC-1/AC-2/AC-3 rot, weil die Kanal-Bloecke aus
+//     EditReportConfigSection kommen und dort in `{#if weatherVisible.*}`
+//     haengen; bei allen drei Wetter-Kanaelen aus ersetzt zusaetzlich der
+//     Leerzustand `briefings-channel-empty` den gesamten Zeitplan.
+//
+// Ausfuehrung:
+//   cd frontend && node --experimental-strip-types --test \
+//     src/lib/components/trip-new/__tests__/trip_new_versandkanaele_unabhaengig_von_metriken.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	renderTripNew,
+	assertTabOffen,
+	countTestid,
+	checkboxInputTag,
+	hatAttribut
+} from './tripNewSsr.ts';
+import { buildCreateTripPayload } from '../tripNewLogic.ts';
+
+type WetterKanaele = { email: boolean; telegram: boolean; sms: boolean };
+
+const KANAL_TESTIDS = ['channel-email', 'channel-telegram', 'channel-sms', 'channel-premium-sms'];
+
+/** /trips/new mit offenem Zeitplan-Tab, breite Ansicht. */
+function zeitplan(channels: WetterKanaele, reportConfig?: Record<string, unknown>): string {
+	const html = renderTripNew({
+		activeTab: 'zeitplan',
+		isMobileViewport: false,
+		channels,
+		reportConfig
+	});
+	assertTabOffen(html, 'zeitplan');
+	return html;
+}
+
+const ALLE_AN: WetterKanaele = { email: true, telegram: true, sms: true };
+
+// ─── AC-1 ────────────────────────────────────────────────────────────────────
+
+describe('AC-1: Premium-SMS bleibt erreichbar, wenn der Wetter-Kanal SMS abgewaehlt ist', () => {
+	test('premium_sms_zeile_ueberlebt_abgewaehlten_wetterkanal_sms', () => {
+		const ohneSms = zeitplan({ email: true, telegram: true, sms: false });
+
+		assert.equal(
+			countTestid(ohneSms, 'channel-premium-sms'),
+			1,
+			'AC-1: Mit abgewaehltem Wetter-Kanal SMS fehlt die Premium-SMS-Zeile im Zeitplan-Tab. ' +
+				'Eine Anzeige-Einstellung fuer Wetter-Metriken versteckt damit den einzigen Kanal, ' +
+				'der auf der Huette ankommt (ADR-0049).'
+		);
+	});
+
+	test('premium_sms_schaltbarkeit_haengt_nicht_an_der_metrik_auswahl', () => {
+		// Gegenprobe statt absoluter Behauptung: ob die Checkbox ueberhaupt
+		// anklickbar ist, entscheidet das Tarif-/Rueckadress-Profil — NICHT die
+		// Metrik-Auswahl. Also muss der Deaktiviert-Zustand in beiden Faellen
+		// derselbe sein.
+		const mitSms = zeitplan(ALLE_AN);
+		const ohneSms = zeitplan({ email: true, telegram: true, sms: false });
+
+		assert.equal(
+			hatAttribut(checkboxInputTag(ohneSms, 'channel-premium-sms'), 'disabled'),
+			hatAttribut(checkboxInputTag(mitSms, 'channel-premium-sms'), 'disabled'),
+			'AC-1: Die Bedienbarkeit des Premium-SMS-Schalters aendert sich mit der ' +
+				'Wetter-Metrik-Auswahl — sie darf nur vom Profil abhaengen.'
+		);
+	});
+});
+
+// ─── AC-2 ────────────────────────────────────────────────────────────────────
+
+describe('AC-2: alle vier Versandkanaele sind von jeder Metrik-Auswahl unabhaengig', () => {
+	const KOMBINATIONEN: Array<[string, WetterKanaele]> = [
+		['alle Wetter-Kanaele an', ALLE_AN],
+		['E-Mail abgewaehlt', { email: false, telegram: true, sms: true }],
+		['Telegram abgewaehlt', { email: true, telegram: false, sms: true }],
+		['SMS abgewaehlt', { email: true, telegram: true, sms: false }],
+		['alle abgewaehlt', { email: false, telegram: false, sms: false }]
+	];
+
+	for (const [name, channels] of KOMBINATIONEN) {
+		test(`alle_vier_kanalzeilen_vorhanden__${name.replace(/\W+/g, '_')}`, () => {
+			const html = zeitplan(channels);
+			for (const testid of KANAL_TESTIDS) {
+				assert.equal(
+					countTestid(html, testid),
+					1,
+					`AC-2 (${name}): Die Zeile "${testid}" fehlt im Zeitplan-Tab (oder steht doppelt ` +
+						'darin). Die Sichtbarkeit eines VERSAND-Kanals darf an keiner Metrik-Auswahl ' +
+						'haengen.'
+				);
+			}
+		});
+	}
+
+	test('zeitplan_bleibt_bedienbar_wenn_kein_wetterkanal_gewaehlt_ist', () => {
+		// Positivkontrolle zur Kombination "alle abgewaehlt": heute ersetzt der
+		// Leerzustand briefings-channel-empty den kompletten Zeitplan, der Nutzer
+		// kann die Sendezeit seines Kanals dann gar nicht mehr einstellen.
+		const html = zeitplan({ email: false, telegram: false, sms: false });
+		assert.equal(
+			countTestid(html, 'morning-master-switch'),
+			1,
+			'AC-2: Ohne aktive Wetter-Metrik-Kanaele verschwindet der Briefing-Zeitplan aus dem ' +
+				'Zeitplan-Tab — das Metrik-Gating darf den Versand-Bereich nicht mehr abschalten.'
+		);
+	});
+});
+
+// ─── AC-3 ────────────────────────────────────────────────────────────────────
+
+describe('AC-3: gesetzte Versandkanaele bleiben gesetzt, egal welche Wetter-Kanaele aktiv sind', () => {
+	test('angehakte_kanaele_werden_beim_rendern_nicht_still_zurueckgesetzt', () => {
+		const html = zeitplan(
+			{ email: false, telegram: false, sms: false },
+			{ send_email: true, send_telegram: true, send_sms: true, send_premium_sms: true }
+		);
+
+		for (const testid of KANAL_TESTIDS) {
+			assert.equal(
+				hatAttribut(checkboxInputTag(html, testid), 'checked'),
+				true,
+				`AC-3: "${testid}" ist in report_config eingeschaltet, wird aber nicht angehakt ` +
+					'gerendert. Der Nutzer sieht einen Kanal als aus, den er eingeschaltet hat — und ' +
+					'der Write-Back schreibt das "aus" anschliessend fest (syncSendFlags).'
+			);
+		}
+	});
+
+	test('speicher_payload_traegt_send_premium_sms_unabhaengig_von_den_wetterkanaelen', () => {
+		// Zweite Haelfte derselben Zusicherung, eine Ebene tiefer: der
+		// Speicher-Payload. Diese Haelfte ist heute bereits gruen — der
+		// Payload-Bauer hat nie auf Kanaele gefiltert. Sie steht hier als
+		// Gegenprobe, damit ein kuenftiges Gating im Speicherpfad auffliegt.
+		const payload = buildCreateTripPayload({
+			name: 'Karnischer Hoehenweg',
+			startDate: '2026-09-01',
+			stages: [{ id: 1, name: 'Etappe 1' }],
+			channels: { email: false, telegram: false, sms: false },
+			reportConfig: { send_premium_sms: true }
+		});
+
+		assert.equal(
+			payload.report_config?.send_premium_sms,
+			true,
+			'AC-3: send_premium_sms erreicht den angelegten Trip nicht, obwohl der Schalter gesetzt ist.'
+		);
+	});
+});

--- a/frontend/src/lib/components/trip-new/__tests__/trip_new_zeitplan_tab_nutzt_geteilten_versand_baustein.test.ts
+++ b/frontend/src/lib/components/trip-new/__tests__/trip_new_zeitplan_tab_nutzt_geteilten_versand_baustein.test.ts
@@ -1,0 +1,149 @@
+// TDD RED — Issue #1738, Struktur-Zusicherungen der Migration.
+// Spec: docs/specs/modules/fix_1738_trips_new_versand_tab.md — AC-4, AC-5, AC-6, AC-7.
+//
+// Die Trip-Anlage soll ihren Versand-Bereich aus dem geteilten Baustein
+// `shared/VersandTab.svelte` (context="route") beziehen statt aus einer zweiten
+// Kanal-Implementierung (Teilungsregel CLAUDE.md, Epic #1230, #1199). Gemessen
+// wird am serverseitigen Render der echten Anlege-Komponente — nicht am
+// Quelltext. Renderharness + Test-Seam: ./tripNewSsr.ts.
+//
+// RED heute:
+//   - AC-4: der Kanal-Block kommt aus EditReportConfigSection, die zweimal
+//     gleichzeitig gemountet ist (TripNewEditor.svelte:800/:1036, CSS-only
+//     umgeschaltet) — Testids stehen doppelt bzw. (metrik-gegated) gar nicht.
+//   - AC-5: `versand-tab` existiert auf /trips/new ueberhaupt nicht.
+//   - AC-6: `report-mail-content` steht doppelt im Dokument (derselbe
+//     Doppel-Mount) statt genau einmal.
+//   - AC-7: die Laufzeit-Anzeige gibt es nicht; `stubTrip.stages` ist zudem
+//     fest leer (TripNewEditor.svelte:86-93), sodass `computeTripEnd` auch nach
+//     dem Einbau kein Datum faende, wenn die Etappen nicht befuellt werden.
+//
+// Ausfuehrung:
+//   cd frontend && node --experimental-strip-types --test \
+//     src/lib/components/trip-new/__tests__/trip_new_zeitplan_tab_nutzt_geteilten_versand_baustein.test.ts
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	renderTripNew,
+	assertTabOffen,
+	countTestid,
+	outerHtml,
+	visibleText,
+	bereichVon,
+	type TripNewStateOverride
+} from './tripNewSsr.ts';
+
+const ALLE_AN = { email: true, telegram: true, sms: true };
+
+function zeitplan(extra: TripNewStateOverride = {}): string {
+	const html = renderTripNew({
+		activeTab: 'zeitplan',
+		isMobileViewport: false,
+		channels: ALLE_AN,
+		...extra
+	});
+	assertTabOffen(html, 'zeitplan');
+	return html;
+}
+
+// ─── AC-4 ────────────────────────────────────────────────────────────────────
+
+describe('AC-4: der Kanal-Block kommt aus genau EINER Implementierung', () => {
+	test('jede_kanal_testid_erscheint_genau_einmal_im_zeitplan_tab', () => {
+		const html = zeitplan();
+		for (const testid of [
+			'channel-email',
+			'channel-telegram',
+			'channel-sms',
+			'channel-premium-sms'
+		]) {
+			assert.equal(
+				countTestid(html, testid),
+				1,
+				`AC-4: "${testid}" steht ${countTestid(html, testid)}x im Zeitplan-Tab. Zwei Treffer ` +
+					'heissen zwei parallel lebende Kanal-Implementierungen bzw. Mounts — zwei ' +
+					'unabhaengige Schreibpfade auf dieselben report_config-Felder (Fehlerklasse ' +
+					'Fix-Loop 4).'
+			);
+		}
+	});
+});
+
+// ─── AC-5 ────────────────────────────────────────────────────────────────────
+
+describe('AC-5: genau eine Versand-Instanz im Dokument, in jeder Ansicht', () => {
+	const ANSICHTEN: Array<[string, boolean, 'desktop' | 'mobil']> = [
+		['breite Ansicht', false, 'desktop'],
+		['schmale Ansicht', true, 'mobil']
+	];
+
+	for (const [name, isMobileViewport, erwarteterBaum] of ANSICHTEN) {
+		test(`genau_eine_versand_instanz__${erwarteterBaum}`, () => {
+			const html = zeitplan({ isMobileViewport });
+
+			assert.equal(
+				countTestid(html, 'versand-tab'),
+				1,
+				`AC-5 (${name}): ${countTestid(html, 'versand-tab')} Versand-Instanzen im Dokument. ` +
+					'Zwei gleichzeitig gemountete Instanzen halten je einen eigenen Schnappschuss von ' +
+					'report_config und ueberschreiben sich gegenseitig (Last-Write-Wins, ohne ' +
+					'Fehlermeldung); null heisst, der Versand-Bereich fehlt ganz.'
+			);
+
+			assert.equal(
+				bereichVon(html, 'versand-tab'),
+				erwarteterBaum,
+				`AC-5 (${name}): Die einzige Versand-Instanz steht im falschen Markup-Baum. Die ` +
+					'beiden Baeume werden per CSS umgeschaltet — im falschen Baum ist der ' +
+					'Versand-Bereich in dieser Ansicht unsichtbar.'
+			);
+		});
+	}
+});
+
+// ─── AC-6 ────────────────────────────────────────────────────────────────────
+
+describe('AC-6: die Mail-Inhalt-Karte bleibt im Anlege-Flow erreichbar', () => {
+	test('mail_inhalt_karte_steht_genau_einmal_im_zeitplan_tab', () => {
+		const html = zeitplan();
+
+		assert.equal(
+			countTestid(html, 'report-mail-content'),
+			1,
+			`AC-6: Die Mail-Inhalt-Karte steht ${countTestid(html, 'report-mail-content')}x im ` +
+				'Zeitplan-Tab. Sie darf durch die Migration weder verschwinden (im Metriken-Tab ist ' +
+				'sie im createMode ausgeblendet, WeatherMetricsTab.svelte:1737) noch doppelt ' +
+				'erscheinen.'
+		);
+		assert.equal(
+			countTestid(html, 'report-email-format-switcher'),
+			1,
+			'AC-6: Die Format-Umschaltung full/compact fehlt (oder steht doppelt) — ohne sie ist ' +
+				'das Mail-Format beim Anlegen nicht einstellbar.'
+		);
+	});
+});
+
+// ─── AC-7 ────────────────────────────────────────────────────────────────────
+
+describe('AC-7: die Laufzeit-Angabe nennt das abgeleitete Enddatum', () => {
+	test('laufzeit_zeigt_enddatum_aus_startdatum_und_etappenzahl', () => {
+		const html = zeitplan({
+			name: 'Karnischer Hoehenweg',
+			startDate: '2026-09-01',
+			stageNames: ['Etappe 1', 'Etappe 2', 'Etappe 3']
+		});
+
+		const text = visibleText(outerHtml(html, 'briefings-laufzeit'));
+		assert.ok(
+			text.includes('03.09.2026'),
+			'AC-7: Die Laufzeit-Zeile nennt nicht das erwartete Enddatum 03.09.2026 (Start ' +
+				'01.09.2026 + 3 Etappen), sondern: "' +
+				text +
+				'". Ein "endet —" heisst, dass die Etappen den geteilten Baustein nicht datiert ' +
+				'erreichen — `stageDate()` (dd.mm. ohne Jahr) ist dafuer unbrauchbar, gebraucht wird ' +
+				'die ISO-Ableitung aus `buildCreateTripPayload`.'
+		);
+	});
+});


### PR DESCRIPTION
Behebt #1738 — der Premium-SMS-Schalter verschwand auf `/trips/new`, sobald die SMS-Wetter-Metrik abgewählt war.

## Der Bug war breiter als gemeldet

Nicht nur Premium-SMS: **alle vier** Kanäle hingen im Markup an der Sichtbarkeit ihres jeweiligen Wetter-Metrik-Kanals (`EditReportConfigSection.svelte:333/355/377`), Premium-SMS zusätzlich noch *innerhalb* des SMS-Blocks (`:401-427`). Eine Anzeige-Einstellung konnte damit den Zugang zum Satellitenkanal verbergen — dem einzigen, der auf der Hütte ankommt.

## Weg 2 statt Weg 1 (PO-Entscheid)

Statt die Verschachtelung punktuell aufzulösen, geht der Zeitplan-Tab auf den geteilten `VersandTab` (`context="route"`). Der Bug verschwindet damit **strukturell** — der Kanal-Block kommt gar nicht mehr aus der Komponente, in der die Verschachtelung sitzt. Zugleich fällt die in #1199 gebuchte Abweichung von der Teilungsregel weg.

`EditReportConfigSection` bleibt im Zeitplan-Tab, aber nur noch für die Mail-Inhalt-Karte (`showChannels={false} showSchedule={false}`) — sonst wäre sie im Anlege-Flow ersatzlos verschwunden (`WeatherMetricsTab:1737` blendet sie im `createMode` aus).

## Zwei Fehler, die erst der Umbau sichtbar machte

**Doppelter Schreibpfad (Desktop/Mobil).** Beide Mounts lagen CSS-geschaltet *gleichzeitig* im DOM und schrieben unabhängig in dasselbe `report_config` — ein auf dem Handy gesetzter Wert konnte später von der veralteten Desktop-Instanz überschrieben werden. Jetzt XOR-Gate über `isMobileViewport`, wie es `WeatherMetricsTab` (#1552, Fix-Loop 4) und `CompareNewEditor` bereits tun.

**Replace statt Merge (F001, CRITICAL).** `VersandTab` ersetzte `report_config` komplett aus seinem `onMount`-Schnappschuss. Solange er allein auf einer Seite stand, fiel das nie auf; mit der Mail-Inhalt-Karte daneben ging `email_format` und jedes client-unbekannte Feld (`change_threshold_*`) verloren. Die Merge-Logik liegt jetzt in `mergeReportConfig.ts` und wird von **beiden** Schreibern benutzt (Read-Modify-Write, vgl. BUG-DATALOSS-GR221).

## Adversary: 3 Runden, Verdict VERIFIED

| Finding | Schwere | Status |
|---|---|---|
| F001 Replace statt Merge | CRITICAL | behoben (Fix-Loop 1) |
| F002 Schutz unbewacht — alle `/trips/new`-Tests sind SSR-Renders, dort läuft kein `$effect` | HIGH | behoben (Fix-Loop 1) |
| F003 Disjunktheit der Feldgruppen unbewacht | MEDIUM | behoben (Fix-Loop 2) |

F002 ist der interessante Fall: Der Adversary nahm die Schutzvorkehrung gegen F001 wieder heraus — **kein Test wurde rot**. Die Zusicherung war nur dort geprüft, wo der Code steht, nicht dort, wo er wirkt. Deshalb liegt die Merge-Logik jetzt als reine Funktion vor.

**Mutations-Gegenproben: 9 Verfälschungen, alle gefangen** — je einmal in der Funktion *und* an der Aufrufstelle, plus eine Positivkontrolle, die den Prüfmechanismus selbst blind macht (sonst wäre die Disjunktheit gegen eine leere Menge trivial wahr).

## Abgedeckte Acceptance Criteria

- **AC-1/AC-2** Alle vier Kanal-Zeilen bleiben sichtbar, unabhängig von der Metrik-Auswahl
- **AC-3** Gesetztes `send_premium_sms` überlebt bis in den Speicher-Payload
- **AC-4** Jede Kanal-Testid genau einmal (keine zwei Implementierungen mehr)
- **AC-5** Genau eine Versand-Instanz pro Viewport
- **AC-6** Mail-Inhalt-Karte im Anlege-Flow erhalten
- **AC-7** Laufzeit zeigt Enddatum statt `endet —` (`stubTrip.stages` aus `buildCreateTripPayload`)
- **AC-8** Ortsvergleich bekommt weiterhin **keinen** schaltbaren Premium-SMS-Block (ADR-0049, #1717 AC-1)

## Bewusste Verhaltensänderung

Das `weatherChannels`-Gating samt `syncSendFlags` entfällt auf diesem Pfad (PO-Entscheid): Ein Versandkanal ist keine Metrik-Darstellung. Ein Kanal kann künftig aktiv sein, ohne dass für ihn Wetter-Metriken konfiguriert sind — genau wie das Trip-Detail sich heute schon verhält.

## Nachweise

- Tests: **2688 grün, 0 rot** (+13 neue); `svelte-check` unverändert auf Baseline (36 errors / 135 warnings)
- Spec: `docs/specs/modules/fix_1738_trips_new_versand_tab.md`
- Artefakte: RED-Lauf, GREEN-Läufe, Adversary-Protokoll (3 Runden), zwei Mutationsnachweise

## Nebenbefund für #1199

`frontend/e2e/trip-edit.spec.ts` ist eine Bestandsleiche — referenziert den mit #622 abgeschafften Wizard (`wizard-next`/`wizard-save`), steht nicht in `.github/ci_e2e_specs.txt`, wäre manuell strukturell rot. Kein Blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
