### PR TITLE
fix(#1935, #1779): Alarm-Nachricht nennt den Aenderungsbetrag und den Ort statt Schwellwert und km-Spanne

### DIFF
--- a/docs/context/fix-1935-1779-alarm-nachricht-klarheit.md
+++ b/docs/context/fix-1935-1779-alarm-nachricht-klarheit.md
@@ -1,0 +1,197 @@
+# Context: fix-1935-1779-alarm-nachricht-klarheit
+
+Issues: **#1935** (Alarm Message: Formulierung unklar) + **#1779** (E-Mail zur Alarm-Schwelle
+schwer verständlich) — dieselbe Beanstandung des PO, fünf Tage auseinander, #1935 mit
+konkreteren Belegen.
+
+## Request Summary
+
+Der Text eines Abweichungs-Alarms ist für den Empfänger nicht entzifferbar: die E-Mail-Zeile
+„Alarm-Schwelle 1000 m · jetzt darüber ✗" liest sich als Aussage über den **Messwert**,
+gemeint ist aber die **Änderungshöhe**. Zusätzlich benennen E-Mail, Alarm-SMS und
+Briefing-SMS denselben Ort/Abschnitt jeweils anders (Segmentname vs. Kilometerspanne vs.
+Etappenkürzel ohne Trip).
+
+## Der beobachtete Fall (aus #1935)
+
+| Kanal | Ist-Ausgabe |
+|---|---|
+| E-Mail Verdict-Chip | `↓ -80 % · Änderung über deiner Alarm-Schwelle (1000 m)` |
+| E-Mail Datenzeile 1 | `Sichtweite · m` → `1400 m ↓ 280 m -80 %` |
+| E-Mail Datenzeile 2 | `Alarm-Schwelle 1000 m` → `jetzt darüber ✗` |
+| E-Mail Datenzeile 3 | `Wo & wann` → `🏁 Ziel` |
+| Alarm-SMS | `KHW 403 km12-12: -VS280` |
+| Briefing-SMS (anderer Pfad) | `E10: …` |
+
+## Root Cause (Kandidat, in Phase 2 zu härten)
+
+`threshold` ist per ADR-0013 / #958 **immer** eine Δ-Auslöseschwelle, nie ein Absolutwert:
+
+```python
+# src/output/renderers/alert/model.py:116-121
+def over_thr(e: AlertEvent) -> bool:
+    return abs(e.value_to - e.value_from) >= e.threshold
+```
+
+`|1400 − 280| = 1120 ≥ 1000` → Alarm. Die Datenzeile formuliert diese Tatsache aber zweimal
+so, dass sie auf den **Wert** zeigt statt auf die **Änderung**:
+
+- **Label** `Alarm-Schwelle 1000 m` — `_val()` hängt die Metrik-Einheit an, wodurch die Zahl
+  wie eine Sichtweiten-Grenze aussieht statt wie ein Änderungsbetrag.
+- **Wert** `jetzt darüber ✗` — „jetzt" zeigt zeitlich auf den aktuellen Messwert (280 m), der
+  aber **unter** 1000 liegt. Der Leser sieht 280, liest „jetzt darüber" und findet den
+  Widerspruch.
+
+Der Verdict-Chip direkt darüber sagt es korrekt („**Änderung** über deiner Alarm-Schwelle").
+Chip und Datenzeile widersprechen sich also innerhalb derselben Mail.
+
+## Related Files
+
+| Datei | Relevanz |
+|---|---|
+| `src/output/renderers/alert/render.py:403-428` (`_datablock_single`) | Erzeugt die drei Datenzeilen inkl. `jetzt darüber ✗` (Z. 417-420) |
+| `src/output/renderers/alert/render.py:389-400` (`_verdict_single`, `_SIDE_ADVERB`) | Verdict-Chip; Ergebnis des Vorgänger-Fixes #1865 |
+| `src/output/renderers/alert/render.py:527-575` | Mehr-Ereignis-Zweig — eigene, abweichende Wortlaut-Bauform (`Schwelle N` / `über`) |
+| `src/output/renderers/alert/render.py:687-760` (`render_sms`) | SMS-Kopf `{trip} km{a}-{b}: `; ruft die gemeinsame Ortsauflösung **nie** auf |
+| `src/output/renderers/alert/render.py:655-671` (`_sms_token`) | Token `-VS280`: Vorzeichen + Kürzel + `value_to`; kein Von-Wert, keine Schwelle |
+| `src/output/renderers/alert/model.py:105-145` | `over_thr`/`side_label`/`delta_pct`/`km_span` — Kernsemantik, #958 |
+| `src/output/renderers/alert/segments.py` | „Eine Ortssprache für alle Alarme" (`format_alert_location`) — von E-Mail/Betreff/Telegram genutzt, von SMS nicht |
+| `src/output/renderers/sms_trip.py:47-55, 690` (`_sms_stage_prefix`) | Briefing-SMS-Präfix `E10:` — **anderer** Renderer, anderes Wire-Format |
+| `src/output/channels/premium_sms.py:19` | Premium-SMS übernimmt `sms_text` unverändert — kein eigener Text |
+
+## Existing Patterns
+
+- **ADR-0011:** genau *ein* Backend-Renderer je Alarm, vier Kanal-Ausgaben daraus. Eine
+  Wortlaut-Änderung an einer Stelle wirkt daher auf alle vier Kanäle — das ist der Hebel.
+- Premium-SMS ist kein eigener Textpfad, sondern derselbe String über einen anderen Transport.
+- Ortsauflösung ist bereits vereinheitlicht (`segments.py`) — **außer** in `render_sms`.
+
+## Dependencies
+
+- **Upstream:** `AlertEvent`/`AlertMessage` (`alert/model.py`), Metrik-Register (`get_metric`
+  für Einheit und Kürzel), `reference_at` aus #1916.
+- **Downstream:** `notification_service.py`, `radar_alert_service.py`, Compare-Alarm-Pfad
+  (`project.py`), Premium-SMS-Kanal.
+
+## Existing Specs / ADRs
+
+| Dokument | Was es festlegt |
+|---|---|
+| `docs/adr/0013-alert-threshold-ist-delta-sensitivitaet.md` | `threshold` = Δ-Empfindlichkeit, **kein** Absolut-Referenzwert |
+| `docs/adr/0011-alert-render-single-backend-renderer.md` | Ein Backend-Renderer, Registry als Single Source |
+| `docs/specs/modules/fix_1861_1865_alarm_mail_klarheit.md` | Vorgänger-Fix genau dieser Zeile (aus „Änderung über ✗" wurde „jetzt darüber ✗") |
+| `docs/specs/modules/fix_1744_alarm_format_angleichen.md` AC-5 | Kurznachricht nennt „**keinen** Ortsbezug", ≤140 Zeichen — PO-Entscheid 2026-08-04 |
+| `docs/reference/sms_format.md` (v2.28) | Token-Zeile und Kürzel-Register, `{Name}:`-Präfix-Regel |
+| `docs/specs/modules/sms_trip_formatter.md` | Briefing-SMS: eine Nachricht je Etappe, Trip-Name im Format nicht vorgesehen |
+
+## Analysis
+
+### Type
+Bug (nutzersichtbare Fehlinformation im Wortlaut) mit Feature-Anteil (Kurznachricht wird um
+Angaben erweitert, die es heute nicht gibt).
+
+### Gemessene Ist-Ausgabe (Fall A: Sicht 1.400 → 280 m, Schwelle 1.000, Ziel-Etappe)
+
+```
+Betreff:  [KHW 403] 🏁 Ziel · ↓ Sicht: 1.400 m→280 m
+E-Mail:   Sicht -80% seit dem Briefing
+          ↓ -80 % · Änderung über deiner Alarm-Schwelle (1.000 m)
+          Sicht · m:              1.400 m ↓ 280 m -80 %
+          Alarm-Schwelle 1.000 m: jetzt darüber ✗
+          Wo & wann:              🏁 Ziel
+Telegram: KHW 403 · 🏁 Ziel · ↓ Sicht
+          Sicht · Schwelle 1.000 m · 1.400 m ↓ 280 m · Änderung über
+SMS:      KHW 403 km12-12: -VS280            (23 von 140 Zeichen)
+```
+
+### Bestätigter Root Cause
+
+Die Zeile `Alarm-Schwelle 1.000 m: jetzt darüber ✗` behauptet zwei Dinge, die beide auf den
+**Messwert** zeigen — Einheit „m" am Schwellwert und das Zeitwort „jetzt" —, während die
+Tatsache dahinter die **Änderungshöhe** ist (`|1400−280| = 1120 ≥ 1000`). Der Leser sieht in
+derselben Mail den aktuellen Wert 280 und die Aussage „jetzt darüber", was einander
+widerspricht. Der Verdict-Chip eine Zeile höher formuliert es korrekt („**Änderung** über").
+
+### Weiterer Befund (nicht gemeldet, aus der Messung)
+
+Betreff und Telegram lassen im Mehr-Ereignis-Fall die **Einheit** weg (`Böen 80`,
+`Sicht 280`), die E-Mail führt sie mit (`80 km/h`, `280 m`). Ursache: `render.py:358-361` und
+`643-648` hängen die Einheit nur an, wenn sie `%` ist, `543-544` hängt sie immer an. „Böen 80"
+ist ohne die E-Mail nicht interpretierbar — dieselbe Klasse von Verständlichkeitslücke.
+
+### SMS-Längenbudget
+
+Fall A nutzt **23 von 140 Zeichen**; 117 sind frei. Die Kürze der Kurznachricht ist also
+keine Budget-Folge. Achtung: der Segmenttext wird für SMS ASCII-gefaltet — `🏁 Ziel` würde
+naiv zu `:checkered_flag: Ziel` (21 Zeichen). Emoji muss **entfernt**, nicht transliteriert
+werden.
+
+### Was der Wortlaut heute bindet
+
+| Datei | Bindung |
+|---|---|
+| `tests/tdd/test_issue_1169_compare_alert_consumer.py::test_ac7_trip_alert_rendering_unchanged` | **byte-genauer** Vergleich der ganzen Plain-Mail — härtester Treffer |
+| `tests/tdd/test_alert_bundle_958ff.py` | `test_ac2_…` (Verdict + „jetzt darüber ✗"), `test_ac10_…` (Mehr-Ereignis-Zeile) |
+| `tests/tdd/test_978_deviation_line_readability.py` | 4 Tests binden `„· Schwelle N"` und `„20 ↑ 80 km/h"` |
+| `tests/tdd/test_957_alert_mail_literal_structure.py` | `✓`/`✗` in der Schwellen-Zeile, `„2 über Schwelle"` |
+| `tests/tdd/test_alert_sms_location_positions.py` (3×), `tests/tdd/test_multi_location_onset_alert.py` (1×) | binden den SMS-Kopf `{trip} km{a}-{b}: ` — **gemeinsam für Trip-Δ, Trip-Radar, Compare-Radar und Onset** |
+
+**Keine** Hook-/Gate-Prüfung erzwingt den Alarm-Wortlaut (`renderer_mail_gate.py` verlangt nur
+einen frischen Nachweis, die Mail-Validatoren sind für `deviation-alert` No-Op). **Keine**
+Duplikate im Frontend (Abwesenheit per `grep` **und** `awk` positiv abgesichert).
+
+### Technical Approach (Empfehlung)
+
+1. **E-Mail-Datenzeile 2 auf die Änderung umstellen** — Label nennt den Änderungsbetrag, der
+   Wert stellt ihn der Schwelle gegenüber:
+   `Änderung 1.120 m` → `über Alarm-Schwelle 1.000 m ✗` (bzw. `unter … ✓`).
+   Damit verschwindet „jetzt" und die Einheit sitzt an der Zahl, für die sie gilt.
+2. **Mehr-Ereignis-Zweig analog**: `… · Änderung 50 · Schwelle 40` statt `… · Schwelle 40`.
+3. **Alarm-SMS**: Kopf bekommt denselben Ortstext wie die E-Mail (emoji-frei gefaltet), Token
+   bekommt den Von-Wert: `KHW 403 Ziel: -VS1400>280`. Der Kopf-Bauer wird dabei **nur** im
+   Δ-Pfad geändert, nicht im gemeinsamen Radar-/Onset-Zweig — sonst brechen vier Testfamilien
+   ohne fachlichen Grund.
+4. Der Trip-Name im Briefing-SMS (`E10:`) bleibt außen vor — anderer Renderer, anderes
+   Wire-Format, eigenes Längenbudget.
+
+### Scope Assessment
+- Produktivcode: 1–2 Dateien (`alert/render.py`, ggf. `alert/segments.py`)
+- Tests: 6 bestehende Dateien anzupassen, 1 neue Verhaltens-Testdatei
+- Geschätzt: +180 / −60 LoC (Tests dominieren) → **LoC-Limit 250 wird knapp**, Anhebung auf 500 einplanen
+- Risk Level: **MEDIUM** — Wortlaut ist breit gebunden, aber kein Gate und kein Frontend hängt daran
+
+### Dependencies
+Upstream `alert/model.py` (`over_thr`, ADR-0013), Metrik-Register (Einheit/Kürzel).
+Downstream `notification_service.py`, `radar_alert_service.py`, Compare-Alarm (`project.py`),
+Premium-SMS (übernimmt `sms_text` unverändert).
+
+### Open Questions (PO)
+- [ ] Neue Formulierung der Schwellen-Zeile bestätigen
+- [ ] Darf die Alarm-SMS die Etappe nennen (kippt #1744 AC-5 / PO-Entscheid 04.08.)?
+- [ ] Soll die Alarm-SMS den Von-Wert tragen?
+- [ ] `E10:`-Thema und Einheiten-Fund: eigene Tickets oder mit hinein?
+
+## Risks & Considerations
+
+1. **Widerspruch zu einer freigegebenen PO-Entscheidung.** #1744 AC-5 hält fest, dass die
+   Alarm-SMS keinen Ortsbezug trägt. Faktisch trägt sie `km12-12`, also *doch* einen — nur
+   den unbrauchbarsten. „Keinen Ortsbezug" meinte offenbar „keinen Segmentnamen". Wenn die
+   SMS künftig die Etappe nennen soll, ist das eine **Rücknahme** dieser Festlegung und
+   gehört ausdrücklich in die Spec, nicht still in den Code.
+2. **Der PO-Vorschlag aus #1935 („Schwelle war 1.000 m, daher der Alert") ist fachlich
+   nicht deckungsgleich** mit ADR-0013: 1000 ist kein Sichtweiten-Grenzwert, sondern der
+   Änderungsbetrag, ab dem gemeldet wird. Ein Fix, der die Zahl als Grenzwert darstellt,
+   wäre falsch — der Text muss die Δ-Bedeutung *sichtbar machen*, nicht ihr folgen.
+3. **Längenbudget SMS:** 140 Zeichen sind hart. Etappenname + Von-Wert + Schwelle passen
+   nicht alle zusätzlich hinein; es braucht eine Priorisierung, keine Addition.
+4. **Zwei Renderer, zwei Formate.** Das `E10:`-Thema (Briefing-SMS ohne Trip-Namen) liegt in
+   einem anderen Wire-Format mit eigenem Längenbudget. Kandidat für eine eigene Scheibe.
+5. **Golden-Tests binden den Wortlaut.** Mindestens `test_alert_bundle_958ff.py`,
+   `test_957_alert_mail_literal_structure.py`, `test_978_deviation_line_readability.py`,
+   `test_alert_location_vocabulary.py`, `test_alert_sms_location_positions.py` fixieren
+   Formulierung bzw. Ortssprache und ziehen mit.
+6. **Commit-Gates:** `renderer_mail_gate.py` + Mail-Validatoren laufen bei jeder Änderung an
+   `src/output/renderers/alert/*.py`.
+7. **Regression-Gefahr Ortsvergleich:** derselbe Renderer bedient den Compare-Alarm
+   (`location_positions`-Pfad, #1467 S2 AG3b). Änderungen am SMS-Kopf dürfen den
+   kopflosen Compare-Zweig nicht zurückbringen.

--- a/docs/specs/modules/fix_1744_alarm_format_angleichen.md
+++ b/docs/specs/modules/fix_1744_alarm_format_angleichen.md
@@ -217,7 +217,11 @@ der Zusicherung, nicht die Zusicherung.
   - Test: die bestehenden Golden-Vergleiche des Ortsvergleichs laufen unverändert grün
     (`tests/tdd/test_issue_1169_compare_alert_consumer.py`).
 
-- **AC-5:** Given ein Trip-Abweichungs- oder Nowcast-Alarm / When die Kurznachricht (SMS und
+> Abgelöst durch fix_1935_1779_alarm_nachricht_klarheit.md, AC-5/AC-6
+> (PO-Entscheid 2026-08-17) — AC-5 dieser Spec gilt nicht mehr für den Trip-Δ-Pfad.
+
+- **AC-5 (ABGELÖST für den Trip-Δ-Pfad, s. Hinweis oben):** Given ein Trip-Abweichungs- oder
+  Nowcast-Alarm / When die Kurznachricht (SMS und
   Premium-SMS) über `render_sms` gerendert wird / Then nennt sie weiterhin **keinen** Ortsbezug
   und bleibt innerhalb von 140 Zeichen — der PO-Entscheid vom 2026-08-04 bleibt unangetastet.
   - Test: Kurznachricht für einen Trip-Alarm mit Ziel-Segment rendern; sie darf weder `Ziel`

--- a/docs/specs/modules/fix_1861_1865_alarm_mail_klarheit.md
+++ b/docs/specs/modules/fix_1861_1865_alarm_mail_klarheit.md
@@ -220,6 +220,26 @@ where_when = f" {_where_when(e)}" if e.segment_id else ""
   Wert theoretisch ununterscheidbar sein — aus dieser Spec ausgeklammert (kein
   PO-Bug-Report dafür, Risiko einer #1170-Regression bei ungeprüfter Erweiterung).
 
+## Teilweise abgelöst (2026-08-17)
+
+Diese Spec legt in ihrer **Implementation Details**-Sektion den Wortlaut der Datenzeile als
+`"Alarm-Schwelle {threshold}: jetzt {über|unter} {✓|✗}"` fest (Zeile 73-74, AC-2/AC-3 in
+Acceptance Criteria). **Diese Festlegung wird abgelöst durch**
+`docs/specs/modules/fix_1935_1779_alarm_nachricht_klarheit.md` (Issues #1935/#1779,
+PO-Entscheid 2026-08-17).
+
+**Begründung:** Das Zeitwort „jetzt" und die Einheit direkt am Schwellwert-Label lesen sich
+wie ein Absolutwert-Vergleich („der heutige Wert ist 1.400 m, und 1.400 > 1.000, also über"),
+während die tatsächliche Tatsache dahinter eine Δ-Aussage ist: „die Änderung von 280 bis
+1.400 m beträgt 1.120 m, und 1.120 >= 1.000, also über der Schwelle" (ADR-0013).
+Der neue Wortlaut heißt `"Änderung {über|unter} Alarm-Schwelle {threshold} {✓|✗}"` und
+macht die Δ-Semantik explizit sichtbar.
+
+**Was gültig bleibt:** Alle anderen Festlegungen dieser Spec bleiben bestehen: die
+Differenzierung von Multi-Event-Zeilen durch `segment_id`/`occurred_at` (AC-1, #1861),
+die Kanalkonsistenz zwischen E-Mail und Telegram (AC-2), der Regressionsschutz für
+Compare-Bündel-Pfade (AC-5), die unveränderten `over_thr()`/`side_label()`-Semantik (AC-4).
+
 ## Architektur-Entscheidung (ADR)
 
 - **ADR-Nr.:** keine

--- a/docs/specs/modules/fix_1935_1779_alarm_nachricht_klarheit.md
+++ b/docs/specs/modules/fix_1935_1779_alarm_nachricht_klarheit.md
@@ -1,0 +1,367 @@
+---
+entity_id: fix_1935_1779_alarm_nachricht_klarheit
+type: bugfix
+created: 2026-08-17
+updated: 2026-08-17
+status: draft
+workflow: fix-1935-1779-alarm-nachricht-klarheit
+---
+
+# Alarm-Nachricht klar formulieren: Änderungsbetrag statt Messwert, Ortsbezug statt Kilometerspanne (#1935, #1779)
+
+## Approval
+
+- [ ] Approved
+
+## Purpose
+
+Der Abweichungs-Alarm ist auf zwei Wegen unnötig schwer lesbar, beide vom PO gemeldet
+(#1779 und fünf Tage später erneut, konkreter, als #1935): (1) Die E-Mail-Datenzeile
+`Alarm-Schwelle 1.000 m: jetzt darüber ✗` behauptet fälschlich etwas über den **Messwert**
+(280 m), obwohl `threshold` per ADR-0013 immer eine **Δ-Auslöseschwelle** ist — der
+Verdict-Chip eine Zeile höher sagt es bereits richtig, wodurch dieselbe Mail sich selbst
+widerspricht. (2) Die Alarm-SMS nennt den Ort als nutzlose Kilometerspanne
+(`km12-12`) statt der Etappen-/Zielsprache, die E-Mail und Betreff längst sprechen, und
+führt den Trip-Namen mit, obwohl der auf einer Kurznachricht an den Trip-Teilnehmer
+selbst keine Information trägt. Diese Spec macht in beiden Fällen sichtbar, WAS sich
+geändert hat und WO — ohne die zugrundeliegende Δ-Semantik (#958/ADR-0013) anzurühren.
+
+## Source
+
+- **File:** `src/output/renderers/alert/render.py`
+- **Identifier:** `_datablock_single` (E-Mail-Einzelereignis-Datenzeile), `render_email`
+  (Multi-Event-Zweig, Zeilen ~552-559), `render_subject` (Multi-Event-Top-3),
+  `render_telegram` (Multi-Event-Zeile), `render_sms`, `_sms_token`,
+  `_render_sms_onset`, `_render_sms_corridor_only`, `_ascii`
+
+Schicht: **Python-Core** (Renderer). Keine Go-Änderung, keine Frontend-Änderung.
+
+## Estimated Scope
+
+- **LoC:** ca. +60/-30 in `render.py`; Test-LoC deutlich höher (6 Bestandsdateien
+  angepasst + 1 neue Verhaltens-Testdatei) — zählt gegen das separate 500er-Test-Budget
+  (CLAUDE.md), nicht gegen die 250 Prod-LoC. `loc_limit_override` einplanen.
+- **Files:** 1 Produktivdatei, 6 Bestands-Testdateien, 1 neue Testdatei
+- **Effort:** medium — Wortlaut ist breit gebunden (Golden-Tests), aber kein Gate und
+  kein Frontend hängt am Text; klar abgegrenzter Renderer, ADR-0011 (ein Backend-Renderer
+  für alle vier Kanäle) macht die Änderung an einer Stelle für alle Kanäle wirksam.
+
+## Dependencies
+
+| Entity | Type | Purpose |
+|--------|------|---------|
+| `output.renderers.alert.model.over_thr` / `side_label` / `delta_pct` | Funktion | #958-Kernsemantik (ADR-0013) — bleibt UNVERÄNDERT, nur der Text um ihre Rückgabewerte ändert sich |
+| `output.renderers.alert.segments.format_alert_location` / `_km_str` | Funktion | bestehende, gemeinsame Ortssprache (#1744 AC-3) — wird für die SMS-Kopfzeile erstmals genutzt, nicht verändert |
+| `app.metric_catalog.get_sms_code` / `get_metric` | Funktion | Kürzel (`VS`, `G`, …) und Einheit für Token bzw. Betreff/Telegram-Einheitensuffix |
+| `utils.ascii_fold.fold_ascii` | Funktion | ASCII/GSM-7-Faltung der SMS — MUSS für Alarm-Ortstexte um eine Emoji-Entfernung ERGÄNZT werden (AC-7), sonst entsteht `:checkered_flag:` |
+| `docs/adr/0013-alert-threshold-ist-delta-sensitivitaet.md` | ADR | bleibt inhaltlich bindend — nur der Textträger ändert sich |
+| `docs/specs/modules/fix_1744_alarm_format_angleichen.md` AC-5 | Spec | **wird durch diese Spec abgelöst** (s. u.) |
+| `docs/specs/modules/fix_1861_1865_alarm_mail_klarheit.md` | Spec | Vorgänger-Fix derselben Zeile — Ausgangspunkt (`Alarm-Schwelle N: jetzt darüber ✗`) |
+
+## Implementation Details
+
+### E1 — E-Mail-Einzelereignis-Datenzeile: Änderungsbetrag statt Messwert
+
+`_datablock_single()`s zweite Zeile (`render.py:403-428`) zeigt heute Label
+`Alarm-Schwelle {threshold}` und Wert `jetzt {über|unter} {✓|✗}`. Beides zeigt auf den
+Messwert (Einheit am Schwellwert, Zeitwort „jetzt"), obwohl die dahinterstehende Tatsache
+`abs(value_to - value_from) >= threshold` eine Aussage über die **Änderung** ist. Neu:
+Label nennt den tatsächlichen Änderungsbetrag, Wert stellt ihn der Schwelle gegenüber:
+
+```
+row2 = (
+    f"Änderung {_val(e, abs(e.value_to - e.value_from))}",
+    f"{side_label(e)} Alarm-Schwelle {_val(e, e.threshold)} {mark}",
+)
+```
+
+`over_thr()`/`side_label()`/`mark` bleiben unverändert — nur der gebaute Satz ändert sich.
+`_SIDE_ADVERB` (`über`→`darüber`) entfällt ersatzlos, weil „jetzt" (das Zeitwort, das auf
+den Messwert zeigte) nicht mehr vorkommt. Ergebnis am Fall aus #1935:
+`Änderung 1.120 m: über Alarm-Schwelle 1.000 m ✗` (bzw. `Änderung 100 m: unter
+Alarm-Schwelle 1.000 m ✓`) — deckungsgleich mit dem Verdict-Chip eine Zeile höher
+(`_verdict_single`, unverändert: `Änderung über deiner Alarm-Schwelle (1.000 m)`).
+
+### E2 — E-Mail-Mehrereignis-Zweig: Änderungsbetrag zusätzlich zur Schwelle
+
+Die über-Schwelle-Zeile im Multi-Event-Zweig (`render_email:552-559`) nennt heute nur die
+Schwelle, nicht den Änderungsbetrag — dieselbe Ambiguität wie E1, nur im gebündelten Fall.
+Label wird um `Änderung {Δ}` ergänzt (vor `Schwelle`, analog zur Reihenfolge in E1):
+
+```
+delta_suffix = " %" if unit == "%" else ""
+label = f"{loc_prefix}{_label(e)}{where_when} · Änderung {_num(e, e.threshold and abs(e.value_to - e.value_from))}{delta_suffix} · Schwelle {_num(e, e.threshold)}{threshold_suffix}"
+```
+
+Am Fixture aus `test_978_deviation_line_readability.py` (Böen 20→80, Schwelle 40, Δ=60):
+neues Label `Böen · Änderung 60 · Schwelle 40` statt bisher `Böen · Schwelle 40`. Die
+gedämpfte Unter-Schwelle-Zeile (`render_email:560-567`, Issue #980) nennt schon heute
+keine Zahl und bleibt unverändert — sie hat den Root-Cause-Bug nicht. Telegram-Multi-Zeile
+(`render_telegram:643-648`) nennt „Schwelle" bewusst gar nicht (steht in der fetten
+Kopfzeile, `test_metric_line_has_no_schwelle_word`) — bleibt unverändert, dort besteht
+keine Ambiguität.
+
+### E5 — Einheiten in Betreff und Telegram nachziehen
+
+`render_subject`s Top-3-Auswahl (`:358-361`) und `render_telegram`s Multi-Zeile
+(`:643-648`) hängen die Einheit heute nur bei `%` an (`Böen 80` statt `Böen 80 km/h`),
+während der E-Mail-Zweig sie immer anhängt. Beide Stellen werden auf „immer mit Einheit"
+umgestellt — dieselbe Regel wie in `_val()`/E-Mail bereits gilt.
+
+### E3/E4 — Alarm-SMS: Ortsbezug statt km-Spanne, Von-Wert im Token, kein Trip-Name
+
+Betrifft ausschließlich den **Trip-Δ-Pfad** von `render_sms()` (den `else`-Zweig ohne
+`location_positions`, ohne `multi_location`, ohne `msg.location_label` — der einzige
+Zweig, der heute `{trip} km{a}-{b}: ` baut) sowie — nur für den Trip-Namen, NICHT für die
+Ortsauflösung — `_render_sms_onset`. `_render_sms_corridor_only` ist seit `8f2053f9`
+(#1460 P1a) toter Code (unerreichbar in Produktion) und trägt in dieser Spec **keine**
+Verhaltenszusicherung — s. „Known Limitations".
+
+**Kopf (nur Trip-Δ-Pfad):** statt `{trip} km{a}-{b}: ` die gemeinsame Ortsauflösung
+`_km_str(msg)` (dieselbe Funktion, die Betreff/E-Mail/Telegram schon nutzen), Emoji vorher
+entfernt (nicht transliteriert, s. AC-7), kein Trip-Name mehr:
+
+```
+loc = _ascii_alert_location(_km_str(msg))   # neuer Schritt: Emoji-Entfernung vor fold_ascii
+head = f"{loc}: "
+```
+
+**Token (nur Trip-Δ-Pfad, `_sms_token()` NUR wenn `location_positions is None`):** statt
+`{sign}{code}{value_to}` neu `{sign}{code}{value_from}>{value_to}` — der Von-Wert macht
+den Ausschlag lesbar, ohne dass der Empfänger den letzten Mailstand kennen muss. Der
+Ortsvergleich-Zweig (`location_positions` gesetzt) behält sein heutiges Token
+byte-identisch (Regressions-Invariante, s. u.) — die Positionszahl-Kodierung von #1467 S2
+AG3b bleibt unangetastet.
+
+Am Fall aus #1935 (Sicht 1.400→280 m, Schwelle 1.000, Ziel-Segment): Kopf `Ziel: `,
+Token `-VS1400>280` → **`Ziel: -VS1400>280`**. Mehr-Ereignis-Beispiel (Segmente 2, 3 und
+Ziel, Böen 30→80 @15:xx, Sicht 1.400→280 @14:xx):
+**`Segment 2-3, Ziel: +G30>80@15 -VS1400>280@14`**.
+
+**Kopf-Trip-Name (E4, zwei Zweige, nur Namensentfernung, keine Ortsauflösungs-Änderung):**
+
+- `render_sms()` Trip-Δ-Zweig: s. o. (Ortsauflösung UND Namensentfernung zusammen).
+- `_render_sms_onset` (Trip-Radar/Onset): Kopf verliert `{trip} `, bleibt sonst
+  `km{a}-{b}: ` — **außer** das führende Event trägt `location_label` (gebündelter
+  Ortsvergleich-Onset, `to_multi_location_onset_alert_message`, `OnsetEvent.location_label`
+  gesetzt); dort ist `msg.trip_short` in Wahrheit der Orts-Sammelname (z. B.
+  „Zermatt, Chamoni") und bleibt unangetastet (E4-Ausnahme, AC-10). Die Trip/Compare-
+  Weiche selbst ist AC-12 (s. u.) — ein Test, der beide Fälle gegeneinanderstellt, statt
+  nur den Trip-Fall isoliert zu prüfen.
+
+`_render_sms_corridor_only` bekommt in dieser Spec **keine** Zusicherung: der Pfad ist
+laut `docs/specs/modules/fix_1744_alarm_format_angleichen.md` („Was sich ausdrücklich
+NICHT ändert") seit #1460 P1a unerreichbar. Eine Namensentfernung dort wäre unbewacht —
+niemand könnte sie am Verhalten nachweisen. Wird der Pfad im Zuge der Implementierung
+ohnehin mitgezogen (z. B. weil derselbe Helper wiederverwendet wird), ist das erlaubt,
+aber kein AC dieser Spec deckt ihn ab.
+
+### E6 — Ausdrücklich NICHT in dieser Spec
+
+Die Trip-Briefing-SMS (`src/output/renderers/sms_trip.py`, Präfix `E10:`) — anderer
+Renderer, anderes Wire-Format, eigenes Längenbudget. PO-Entscheid: bleibt konsequent bei
+der Etappe ohne Trip-Namen, also unverändert.
+
+## Was sich ausdrücklich NICHT ändert (Invarianten)
+
+- **Δ-Semantik von `over_thr()`/`side_label()`/`delta_pct()`** (ADR-0013, #958) — nur die
+  Darstellung ändert sich, nicht die Berechnung.
+- **Ortsvergleich-Pfade in `render_sms()`:** `location_positions` gesetzt (Compare-
+  Änderungspfad, #1467 S2 AG3b) bleibt kopflos und mit unverändertem Token-Format;
+  `multi_location`/`msg.location_label`-Zweige (Compare-Punkt-/Bündel-Alert) bleiben
+  byte-identisch — dort ist `trip_short` bereits der Orts-Sammelname, kein Trip-Name.
+- **Amtliche-Warnung-SMS** (`render_official_alert_sms`, `KHW403 AMT GELB1/3: …`) —
+  anderer Renderer, geregelt in `docs/specs/modules/sms_official_alert_tokens.md`.
+  **Bewusst offene Rest-Inkonsistenz:** sie trägt weiterhin ihren eigenen Kurz-Ortsbezug
+  nach eigenem Format, während die Trip-Δ-SMS jetzt dieselbe Ortssprache wie E-Mail/Betreff
+  spricht. Vorschlag für eine spätere Entscheidung: entweder die amtliche Warn-SMS auf
+  `format_alert_location` umstellen (eigene Spec, prüft `sms_official_alert_tokens.md`
+  AC-Kollisionen) oder die Abweichung dokumentiert stehen lassen, weil beide SMS-Typen
+  unterschiedliche Absender-Systeme (DWD-Warnstufen vs. Δ-Alarm) sind und ihre Kürze aus
+  verschiedenen Gründen entsteht.
+- **Trip-Briefing-SMS** (`sms_trip.py`, `E10:`) — s. E6.
+- **SMS-Längenbudget:** weiterhin ≤140 Zeichen, ASCII/GSM-7-kodierbar (die vorhandene
+  Kürzungslogik in `render_sms()` — Token-für-Token bis zum Limit, dann `+N` — bleibt
+  strukturell unverändert; der Von-Wert im Token macht einzelne Token länger, das
+  bestehende Kürzungsverfahren fängt das ab).
+
+## Abgelöste Festlegungen
+
+Diese Spec hebt **AC-5 der Spec `fix_1744_alarm_format_angleichen.md`** auf: „Kurznachricht
+nennt weiterhin keinen Ortsbezug" (PO-Entscheid 2026-08-04). Faktisch trug die SMS auch
+vorher schon einen Ortsbezug (`km12-12`) — nur den unbrauchbarsten; „keinen Ortsbezug"
+meinte im damaligen Kontext offenbar „keinen Segmentnamen". Der neue PO-Entscheid vom
+2026-08-17 nimmt das ausdrücklich zurück: die Alarm-SMS bekommt denselben Ortstext wie
+E-Mail/Betreff. **Scope der Spec-Writer-Rolle:** diese Datei ändert `fix_1744_...md` nicht
+selbst (Spec-Writer schreibt nur die neue Spec); die Implementierung MUSS dort einen
+Kurzvermerk ergänzen (`> Abgelöst durch fix_1935_1779_alarm_nachricht_klarheit.md, AC-5/AC-6
+(PO-Entscheid 2026-08-17) — AC-5 dieser Spec gilt nicht mehr für den Trip-Δ-Pfad.`).
+
+## Migration bestehender Tests
+
+| Datei | Was heute bindet | Warum sie mitgezogen werden muss |
+|---|---|---|
+| `tests/tdd/test_issue_1169_compare_alert_consumer.py::test_ac7_trip_alert_rendering_unchanged` | **byte-genauer** Plain-Vergleich der ganzen Trip-Mail, u. a. `"Alarm-Schwelle 10,0 mm: jetzt darüber ✗"` | Zeile ändert sich per E1 zu `"Änderung 16,0 mm: über Alarm-Schwelle 10,0 mm ✗"`; alle anderen Zeilen bleiben byte-identisch (Golden-Master-Charakter des Tests bleibt erhalten, nur der betroffene Ausschnitt wird nachgezogen — kein Löschen). |
+| `tests/tdd/test_alert_bundle_958ff.py` (`test_ac2_…`) | `"jetzt darüber ✗"` als vollständiger Zielsatz (#1865-Fix) | Bindet exakt die Zeile, die E1 ersetzt — wird auf `"über Alarm-Schwelle … ✗"` umgestellt. |
+| `tests/tdd/test_alert_bundle_958ff.py` (`test_ac10_…`) | Mehr-Ereignis-Zeile ohne Änderungsbetrag | Wird um die Änderung-Betrag-Assertion aus E2 ergänzt. |
+| `tests/tdd/test_978_deviation_line_readability.py` (4 Tests) | `"Böen · Schwelle 40"`, `"20 ↑ 80 km/h"` | Label-Literal wird zu `"Böen · Änderung 60 · Schwelle 40"` (E2); der Wert-Teil `"20 ↑ 80 km/h"` bleibt unverändert (nicht Teil dieser Spec). |
+| `tests/tdd/test_957_alert_mail_literal_structure.py` | `✓`/`✗`-Marker, `"2 über Schwelle"` | Beide Literale bleiben **unverändert** (der Marker und der Zähler-Text sind nicht Teil von E1/E2) — Test bleibt grün, keine Anpassung nötig, aber als Nachweis in der QA-Runde explizit gegenlaufen lassen. |
+| `tests/tdd/test_alert_sms_location_positions.py` (`test_regression_trip_deviation_alert_sms_text_unchanged`, `test_regression_trip_radar_alert_sms_text_unchanged`) | Goldstrings `"ProbeTrip km12-18: +R30"`, `"ProbeTrip km5-18: R!12"` | Beide ändern sich ABSICHTLICH per E3/E4 zu `"Segment 1: +R2>30"` bzw. `"km5-18: R!12"` (Trip-Radar behält km-Fallback, verliert nur den Namen). `test_regression_compare_radar_alert_sms_text_unchanged` (`"Zermatt, Chamoni km0-0: R!8"`) bleibt **unverändert grün** — das ist die E4-Ausnahme (Compare-Bündel-Onset, `location_label` gesetzt) und die stärkste Positivkontrolle dafür, dass die Trip/Compare-Unterscheidung in `_render_sms_onset` funktioniert. |
+| `tests/tdd/test_multi_location_onset_alert.py::test_single_onset_telegram_sms_byte_identical` | `EXPECTED_SMS = 'GR20-Test km5-18: R!12'` | Ändert sich zu `'km5-18: R!12'` (Trip-Radar-Pfad, `location_label=None`) — der Test selbst bleibt bestehen (er heißt seit #1041 „byte_identical" auf ein Vorher, das per dieser Spec nachgezogen wird), nicht löschen. |
+
+Kein Test wird ohne fachlichen Grund gelöscht: jeder gebundene String, der nur den alten,
+nachweislich missverständlichen Wortlaut zementiert hätte, wird auf den neuen Wortlaut
+umgestellt — die Zusicherung dahinter (Byte-Gleichheit / Regression) bleibt erhalten.
+
+## Expected Behavior
+
+- **Input:** dieselben `AlertEvent`/`AlertMessage`-Objekte wie heute (kein Modellfeld
+  ändert sich); Trip-Δ-Alarm, Trip-Radar/Onset-Alarm, reiner Schwellen-Alarm,
+  Ortsvergleich-Alarm (alle Spielarten).
+- **Output:** E-Mail-Datenblock (Einzel- und Mehrereignis) nennt den Änderungsbetrag statt
+  eines missverständlichen Messwert-Bezugs; Betreff/Telegram führen die Einheit immer;
+  Trip-Δ-Alarm-SMS nennt denselben Ortstext wie E-Mail/Betreff, ohne Trip-Namen, mit
+  Von-Wert im Token; Trip-Radar/Onset-SMS verliert nur den Trip-Namen.
+- **Side effects:** keine — reines Text-Templating, kein Zustand, kein I/O, keine
+  Auslöselogik, kein Kanal-Routing.
+
+## Acceptance Criteria
+
+- **AC-1:** Given ein einzelnes `AlertEvent` mit `value_from=1400.0`, `value_to=280.0`,
+  `threshold=1000.0`, `metric_id="visibility"` (Fall aus #1935) / When `render_email()` den
+  Datenblock rendert / Then lautet die zweite Datenzeile (Label:Wert) „Änderung 1.120 m:
+  über Alarm-Schwelle 1.000 m ✗" — weder das Wort „jetzt" noch die Einheit direkt am
+  Schwellwert-Label kommen mehr vor, sowohl in `html` als auch in `plain`.
+  - Test: `AlertEvent`/`AlertMessage` mit den o. g. Werten bauen, `render_email()`
+    aufrufen, die zweite Datenzeile aus `plain` extrahieren (Zeilenweise Split, nicht
+    Substring-Suche im Volltext) und auf den exakten Wortlaut prüfen; dieselbe Prüfung auf
+    dem `html`-Rückgabewert (Zellinhalt der zweiten `<table>`-Zeile).
+
+- **AC-2:** Given denselben Fall wie AC-1, aber mit `cmp`/Werten, die unter der Schwelle
+  bleiben (`value_from=280.0`, `value_to=380.0`, `threshold=1000.0`) / When die Datenzeile
+  gerendert wird / Then lautet sie „Änderung 100 m: unter Alarm-Schwelle 1.000 m ✓".
+  - Test: dieselbe Bauform wie AC-1, invertierter Fall — beweist, dass die Umstellung
+    symmetrisch für den unter-Schwelle-Fall gilt und nicht nur für den gemeldeten Fehlerfall.
+
+- **AC-3:** Given eine E-Mail mit genau einem `AlertEvent` / When Verdict-Chip
+  (`_verdict_single`) UND zweite Datenzeile (`_datablock_single`) gerendert werden / Then
+  nennen beide denselben Änderungs-Bezug: dieselbe Richtung (über/unter), denselben
+  Schwellwert-Text und keine widersprüchliche Aussage über den Messwert — eine Mail sagt
+  intern nicht zweierlei über dieselbe Tatsache.
+  - Test: für mindestens zwei Fixtures (über- und unter-Schwelle) beide Texte extrahieren
+    und programmatisch prüfen, dass beide dasselbe `side_label(e)`-Wort und denselben
+    `_val(e, e.threshold)`-String enthalten — kein reiner Blick auf den einen String isoliert.
+
+- **AC-4:** Given eine `AlertMessage` mit drei `AlertEvent`s derselben Metrik über der
+  Schwelle (Böen 20→80, Schwelle 40) / When `render_email()` den Mehr-Ereignis-Datenblock
+  rendert / Then enthält die zugehörige Datenzeile sowohl den Änderungsbetrag (`60`) als
+  auch die Schwelle (`40`), unterscheidbar als zwei verschiedene Zahlen in derselben Zeile.
+  - Test: `_multi_msg()`-artige Fixture (analog `test_978_deviation_line_readability.py`)
+    bauen, `render_email()` aufrufen, Zeile extrahieren und auf beide Zahlen prüfen.
+
+- **AC-5:** Given ein Trip-Δ-Alarm (kein Ortsvergleich) für das Ziel-Segment, Sicht
+  1.400→280 m, Schwelle 1.000 m / When `render_sms()` (ohne `location_positions`) rendert
+  / Then lautet der Kopf der Kurznachricht „Ziel: " — derselbe Ortstext, den
+  `format_alert_location` für dasselbe Ereignis in der Betreffzeile liefert — und **nicht**
+  mehr der Trip-Name oder eine Kilometerspanne.
+  - Test: dieselbe `AlertMessage` durch `render_subject()` UND `render_sms()` schicken und
+    prüfen, dass der Ortsteil aus `render_subject()` als Präfix in `render_sms()`
+    wiederkehrt (Kanalkonsistenz, keine zwei Ortssprachen).
+
+- **AC-6:** Given denselben Fall wie AC-5 / When das Token gerendert wird / Then enthält es
+  Von- UND Bis-Wert im Format `{Vorzeichen}{Kürzel}{Von}>{Bis}`, z. B. `-VS1400>280` — der
+  reine Bis-Wert-Token von heute (`-VS280`) kommt nicht mehr vor.
+  - Test: `render_sms()`-Ergebnis auf das exakte Token-Muster per Regex prüfen
+    (`[+-][A-Z]{1,2}\d+>\d+`) und den Von-Wert `1400` sowie den Bis-Wert `280` konkret
+    nachweisen.
+
+- **AC-7:** Given ein Trip-Δ-Alarm für das Ziel-Segment (Ortstext enthält 🏁) / When
+  `render_sms()` den Kopf rendert / Then steht dort „Ziel" ohne das Emoji-Zeichen und
+  **ohne** dessen Transliteration (`:checkered_flag:` darf nicht vorkommen) — das Emoji
+  wird entfernt, nicht ASCII-gefaltet.
+  - Test: `render_sms()` für ein Ziel-Segment-Ereignis aufrufen und sowohl auf Abwesenheit
+    von `:checkered_flag:` als auch auf Anwesenheit von `Ziel` im Kopf prüfen; zusätzlich
+    Längen-Assertion, dass der Kopf dadurch NICHT künstlich länger wird als der reine
+    Textname.
+
+- **AC-8:** Given denselben Trip-Δ-Alarm über mehrere Segmente (2, 3, Ziel) mit je einem
+  Ereignis / When `render_sms()` rendert / Then trägt der Kopf die zusammengefasste
+  Segment-Sprache (`format_segment_reference`, z. B. „Segment 2-3, Ziel"), ASCII-gefaltet
+  (Gedankenstrich zu Bindestrich), und jedes Token trägt weiterhin seinen eigenen Von/Bis-
+  Wert nach AC-6.
+  - Test: Bündel-`AlertMessage` mit drei Ereignissen bauen, `render_sms()` aufrufen, Kopf
+    und beide Token per Regex/Substring gegen das Golden-Beispiel aus dieser Spec prüfen.
+
+- **AC-9 (Regressionsschutz):** Given ein Ortsvergleich-Änderungsalarm mit
+  `location_positions` gesetzt / When `render_sms()` rendert / Then bleibt die Ausgabe
+  **byte-identisch** zu heute — kein Kopf, Token-Format unverändert (kein Von-Wert, keine
+  `>`-Notation) — die Positionszahl-Kodierung aus #1467 S2 AG3b bleibt unangetastet.
+  - Test: `tests/tdd/test_alert_sms_location_positions.py::test_k1_*`/`test_k2_*`/`test_k3_*`/`test_k4_*`
+    bleiben **unverändert** grün (keine Anpassung an diesen vier Tests).
+
+- **AC-10 (Regressionsschutz):** Given ein Ortsvergleich-Bündel-Radar-Alarm (zwei Orte,
+  `OnsetEvent.location_label` gesetzt) / When `render_sms()` über `_render_sms_onset`
+  rendert / Then bleibt die Ausgabe byte-identisch zu heute (`"Zermatt, Chamoni km0-0:
+  R!8"`) — der Orts-Sammelname in `trip_short` ist kein Trip-Name und bleibt stehen.
+  - Test: `tests/tdd/test_alert_sms_location_positions.py::test_regression_compare_radar_alert_sms_text_unchanged`
+    bleibt unverändert grün.
+
+- **AC-11 (Regressionsschutz Betreff/Telegram):** Given eine Mehr-Ereignis-Nachricht mit
+  einer Nicht-Prozent-Metrik / When `render_subject()` und `render_telegram()` rendern /
+  Then führen beide die Einheit am Wert (z. B. „80 km/h" statt „80"), Prozent-Metriken
+  bleiben unverändert mit angehängtem `%`.
+  - Test: `_multi_msg()`-Fixture durch beide Renderer schicken und die Einheit im
+    resultierenden Top-3-/Metrik-Text nachweisen.
+
+- **AC-12:** Given zwei `AlertMessage`s über `_render_sms_onset` — eine mit
+  `OnsetEvent.location_label=None` (echter Trip-Radar/Onset-Alarm, `trip_short` ist der
+  Trip-Kurzname) und eine mit gesetztem `location_label` (Ortsvergleich-Bündel-Onset,
+  `trip_short` ist der Orts-Sammelname) — ansonsten identisch aufgebaut (gleiche
+  `onset_minutes`, `km_from`/`km_to`) / When `render_sms()` beide rendert / Then enthält
+  **nur** die zweite Nachricht den Wert von `trip_short` im Kopf; die erste beginnt direkt
+  mit der km-Spanne (`km{a}-{b}: `) ohne Trip-Namen davor. Die Zusicherung ist der
+  **Vergleich** der beiden Ergebnisse, nicht die isolierte Prüfung des Trip-Falls.
+  - Test: neuer Test in der Verhaltens-Testdatei — beide Fixtures aus derselben
+    Basis-`AlertMessage`/`OnsetEvent` ableiten (nur `location_label` unterscheidet sich),
+    `render_sms()` auf beide anwenden und gegeneinanderstellen: Trip-Fall beginnt mit
+    `"km"`, Compare-Fall beginnt mit dem Sammelnamen-Text UND enthält `trip_short`
+    vollständig. Würde die Weiche fehlen oder verkehrt herum stehen, behielte entweder der
+    Trip-Fall fälschlich den Namen oder der Compare-Fall (AC-10) verlöre ihn — beide
+    Regressionen werden durch den direkten Vergleich sichtbar, nicht nur durch einen
+    isolierten Golden-String je Fall.
+
+## Known Limitations
+
+- **Amtliche-Warnung-SMS bleibt inkonsistent zur Trip-Δ-SMS** (eigener Ortsbezug, eigenes
+  Format) — bewusst offen, s. „Was sich ausdrücklich NICHT ändert".
+- **Trip-Briefing-SMS (`E10:`) bleibt außen vor** — anderer Renderer, eigenes Ticket bei
+  Bedarf (s. E6).
+- **`_render_sms_corridor_only` bleibt ohne Zusicherung.** Der Pfad ist seit `8f2053f9`
+  (#1460 P1a) toter Code (`docs/specs/modules/fix_1744_alarm_format_angleichen.md`, „Was
+  sich ausdrücklich NICHT ändert") — unerreichbar in Produktion. Diese Spec fordert dort
+  **keine** Verhaltensänderung, und **kein** AC deckt ihn ab; wird er im Zuge der
+  Implementierung dennoch mitgezogen (z. B. gemeinsame Helper-Nutzung), ist das erlaubt,
+  aber unbewacht — toter Code darf keine Zusicherung tragen, die niemand einlösen kann.
+- **Von-Wert im SMS-Token kann bei langen Fließkommazahlen das Längenbudget stärker
+  belasten** als bisher; die bestehende Token-Kürzungslogik (bis zum Limit, dann `+N`)
+  fängt das strukturell ab, macht im Extremfall aber ein Ereignis mehr zum „+1"-Rest als
+  vorher. Kein bekannter PO-Bug-Report dafür, kein eigenes AC.
+
+## Architektur-Entscheidung (ADR)
+
+- **ADR-Nr.:** keine
+- **Rationale:** Reine Text-/Templating-Korrektur innerhalb des bestehenden,
+  kanonischen Alert-Renderers (ADR-0011). `AlertEvent`/`AlertMessage`/`over_thr`/
+  `side_label` (ADR-0013-Kontext, #958) bleiben unverändert. Die Rücknahme von
+  `fix_1744_alarm_format_angleichen.md` AC-5 ist ein PO-Entscheid zum Wortlaut, keine
+  neue Entscheidungsfläche im Sinne von `docs/adr/README.md` (Kanal, Provider,
+  Datenmodell/Persistenz, Auth, Editor-Paradigma, Test-/Deploy-Strategie) — dokumentiert
+  im Abschnitt „Abgelöste Festlegungen" oben, kein eigenes ADR nötig.
+
+## Changelog
+
+- 2026-08-17: Initial spec created
+- 2026-08-17: AC-12 ergänzt (Trip/Compare-Weiche in `_render_sms_onset` explizit
+  zugesichert, nicht nur über AC-10 negativ abgeleitet); `_render_sms_corridor_only`
+  aus der aktiven Änderungsliste genommen und ausdrücklich als unbewachter toter Code
+  markiert (Known Limitations) — Koordinator-Feedback.

--- a/docs/specs/modules/fix_alert_bundle_958ff.md
+++ b/docs/specs/modules/fix_alert_bundle_958ff.md
@@ -487,6 +487,28 @@ vollständige Liste — die TDD-RED-Phase muss weitere Fälle aufdecken:
 - `tests/tdd/test_trip_alert_profile.py:122-166` — **bewusster** Soll-Bruch
   (siehe AC-8/AC-9), kein Kollateralschaden.
 
+## Teilweise abgelöst (2026-08-17)
+
+Diese Spec legt in ihrer **Implementation Details**-Sektion (#958, Zeile 116-120) den
+Wortlaut für den Datenblock-Wert fest: `"Änderung {über|unter} {mark}"` (dabei das
+Zeitwort „jetzt" und die Einheit direkt am Schwellwert beibehaltend: `"jetzt über ✗"` als
+Vorher-Zustand). **Diese Wortlaut-Festlegung wird abgelöst durch**
+`docs/specs/modules/fix_1935_1779_alarm_nachricht_klarheit.md` (Issues #1935/#1779,
+PO-Entscheid 2026-08-17), die denselben Text neu als
+`"Änderung {über|unter} Alarm-Schwelle {threshold} {mark}"` definiert.
+
+**Begründung:** Das Zeitwort „jetzt" und die Einheit direkt am Schwellwert-Label
+täuschen einen Absolutwert-Vergleich vor, während die tatsächliche Logik (ADR-0013,
+`over_thr() = abs(value_to - value_from) >= threshold`) eine Δ-Aussage ist. Der neue
+Wortlaut nennt explizit die Schwelle und den Vergleich-Bezug (Änderung vs. Schwelle),
+nicht nur die Richtung.
+
+**Was gültig bleibt:** Alle anderen Festlegungen dieser Spec bleiben bestehen: die
+Δ-Semantik von `over_thr()`/`side_label()`/`delta_pct()` (AC-1, #958), die
+Nullgradgrenze-Konsolidierung (#959), die Gefiltert/Gedämpft/Sortiert-Regel für
+Multi-Event-Nachrichten (#980/#981/#982), die Outlook-kompatiblen Tabellen-Rows
+(#986), alle Regressionsschutz-ACs und Bestandstest-Migrationen.
+
 ## Architektur-Entscheidung (ADR)
 
 - **ADR-Nr.:** Vorschlag `ADR-0013` — „Alert-Renderer: `threshold` ist immer

--- a/src/output/renderers/alert/render.py
+++ b/src/output/renderers/alert/render.py
@@ -5,6 +5,7 @@ der Metrik-Registry. Unicode-Pfeile NUR Email/Telegram; SMS rein ASCII/GSM-7.
 """
 from __future__ import annotations
 
+import unicodedata
 from datetime import datetime, timezone
 
 from app.metric_catalog import (
@@ -71,6 +72,17 @@ def _num(e: AlertEvent, value: float) -> str:
         return f"{n:,}".replace(",", ".") if abs(n) >= 1000 else str(n)
     int_part, _, frac_part = f"{rounded:,.{decimals}f}".partition(".")
     return f"{int_part.replace(',', '.')},{frac_part}"
+
+
+def _unit_suffix(e: AlertEvent) -> str:
+    """Einheiten-Suffix fuer Betreff/Telegram (Issue #1935/#1779 E5): immer
+    angehaengt (nicht mehr nur bei '%') -- dieselbe Regel wie im E-Mail-Zweig
+    (`_val()`). '%' klebt ohne Leerzeichen am Wert, alle anderen Einheiten mit
+    einem Leerzeichen davor (Katalog-Konvention, z.B. '80 km/h')."""
+    unit = _unit_display(e)
+    if not unit:
+        return ""
+    return unit if unit == "%" else f" {unit}"
 
 
 def _unit_display(e: AlertEvent) -> str:
@@ -320,11 +332,21 @@ def _render_telegram_onset(msg: AlertMessage) -> str:
 
 
 def _render_sms_onset(msg: AlertMessage, limit: int = 140) -> str:
+    """Issue #1935/#1779 (E4): der Trip-Radar/Onset-Kopf verliert den
+    Trip-Namen -- er trug auf einer Kurznachricht an den Trip-Teilnehmer
+    selbst keine Information. AUSNAHME (AC-10/AC-12): traegt das fuehrende
+    Event ein `location_label` (gebuendelter Ortsvergleich-Onset,
+    `to_multi_location_onset_alert_message`), ist `msg.trip_short` in
+    Wahrheit der Orts-Sammelname (z.B. 'Zermatt, Chamoni') und bleibt
+    unangetastet -- die Trip/Compare-Weiche selbst."""
     e = msg.events[0]
     token = f"TH!{e.onset_minutes}" if e.is_convective else f"R!{e.onset_minutes}"
-    trip = _ascii(msg.trip_short)[:16].rstrip(" (-_")
     a, b = int(round(e.km_from)), int(round(e.km_to))
-    body = f"{trip} km{a}-{b}: {token}"
+    if getattr(e, "location_label", None):
+        trip = _ascii(msg.trip_short)[:16].rstrip(" (-_")
+        body = f"{trip} km{a}-{b}: {token}"
+    else:
+        body = f"km{a}-{b}: {token}"
     return body if len(body) <= limit else body[:limit]
 
 
@@ -355,8 +377,10 @@ def render_subject(msg: AlertMessage) -> str:
     # Issue #978 (PO-Nachtrag): Top-3-Auswahl UND Anzeige-Reihenfolge sind
     # severity-absteigend (kritischster zuerst), kanal-konsistent mit
     # render_email() und render_telegram().
+    # Issue #1935/#1779 (E5): Einheit immer anhaengen (nicht mehr nur bei
+    # '%') -- dieselbe Regel wie im E-Mail-Zweig (AC-11).
     top3 = ", ".join(
-        f"{_label(e)} {_num(e, e.value_to)}{'%' if _unit_display(e) == '%' else ''}"
+        f"{_label(e)} {_num(e, e.value_to)}{_unit_suffix(e)}"
         for e in over_evs[:3]
     )
     return f"[{msg.trip_short}] {km} · {arrow(over_evs[0])} {n} über Schwelle: {top3}"
@@ -395,16 +419,18 @@ def _verdict_single(e: AlertEvent) -> str:
     )
 
 
-# Issue #1865: aus dem Fragment "Änderung über ✗" wird ein vollstaendiger
-# Satz. side_label() selbst bleibt unveraendert (#958-Kernsemantik).
-_SIDE_ADVERB = {"über": "darüber", "unter": "darunter"}
-
-
 def _datablock_single(e: AlertEvent, location_label: str | None = None) -> list[tuple[str, str]]:
     """3 (label, value)-Zeilen: Wert-Vergleich / Schwellwert-Status / Wo & wann.
 
     Issue #1169: gesetztes `location_label` (Compare-Punkt-Alert) ersetzt die
     km-Spanne; Trip-Pfad übergibt es nie (bit-identisch, AC-7).
+
+    Issue #1935/#1779 (E1): Zeile 2 nannte bisher `Alarm-Schwelle {wert}` als
+    Label und `jetzt {über|unter} {mark}` als Wert -- beides zeigte auf den
+    MESSWERT, obwohl `threshold` per ADR-0013 (#958) immer die Δ-Schwelle
+    ist. Neu: Label nennt den tatsaechlichen Aenderungsbetrag, Wert stellt ihn
+    der Schwelle gegenueber -- deckungsgleich mit `_verdict_single` eine Zeile
+    hoeher (AC-3). `over_thr()`/`side_label()` bleiben unveraendert.
     """
     unit = get_metric(e.metric_id).unit
     d = _delta_text(e)
@@ -415,8 +441,8 @@ def _datablock_single(e: AlertEvent, location_label: str | None = None) -> list[
     )
     mark = "✓" if not over_thr(e) else "✗"
     row2 = (
-        f"Alarm-Schwelle {_val(e, e.threshold)}",
-        f"jetzt {_SIDE_ADVERB[side_label(e)]} {mark}",
+        f"Änderung {_val(e, abs(e.value_to - e.value_from))}",
+        f"{side_label(e)} Alarm-Schwelle {_val(e, e.threshold)} {mark}",
     )
     # Issue #1744 A1 (AC-6): DIESELBE Aufloesung wie im Betreff — vorher stand
     # hier ein dritter, eigener km-Bauer (`_km_str_events`), weshalb der
@@ -550,9 +576,15 @@ def render_email(msg: AlertMessage) -> tuple[str, str]:
             loc_prefix = f"{e.location_label} · " if e.location_label else ""
             where_when = f" · {_where_when(e)}" if with_where_when else ""
             if over_thr(e):
+                # Issue #1935/#1779 (E2): dieselbe Ambiguitaet wie E1, nur im
+                # gebuendelten Fall -- Label nennt zusaetzlich zur Schwelle
+                # den tatsaechlichen Aenderungsbetrag (zwei unterscheidbare
+                # Zahlen in derselben Zeile, AC-4).
                 threshold_suffix = " %" if unit == "%" else ""
+                delta = abs(e.value_to - e.value_from)
                 data_rows.append((
                     f"{loc_prefix}{_label(e)}{where_when} · "
+                    f"Änderung {_num(e, delta)}{threshold_suffix} · "
                     f"Schwelle {_num(e, e.threshold)}{threshold_suffix}",
                     f"{_num(e, e.value_from)} {arrow(e)} {_num(e, e.value_to)}"
                     f"{unit_suffix} {side_label(e)}",
@@ -640,10 +672,11 @@ def render_telegram(msg: AlertMessage) -> str:
         # Issue #1861: derselbe Ort-/Zeit-Zusatz wie im E-Mail-Datenblock
         # (Kanalkonsistenz, Issue #978-Praezedenz).
         with_where_when = _per_event_where_when(evs)
+        # Issue #1935/#1779 (E5): Einheit immer anhaengen (AC-11).
         metric_line = " · ".join(
             f"{_label(e)}{f' {_where_when(e)}' if with_where_when else ''} "
             f"{_num(e, e.value_from)}→{_num(e, e.value_to)}"
-            f"{'%' if _unit_display(e) == '%' else ''}"
+            f"{_unit_suffix(e)}"
             for e in evs
         )
         lines = [f"<b>{_esc(verdict)}</b>", metric_line]
@@ -661,10 +694,21 @@ def _sms_token(
     `to_multi_point_alert_message()` nur im gebuendelten Mehr-Orte-Fall
     (`project.py:215`) —, wird die Ortsposition als ZAHL vorangestellt (PO E2:
     Orte werden als Zahl gefuehrt, nicht ausgeschrieben). Ohne den Parameter
-    bleibt das Token byte-identisch zum bisherigen Verhalten (Trip-Δ,
-    Trip-Radar, Compare-Radar — AC-26-Zusicherung fuer SMS)."""
+    bleibt das Token byte-identisch zum bisherigen Verhalten fuer Trip-Radar
+    und Compare-Radar — AC-26-Zusicherung fuer SMS.
+
+    Issue #1935/#1779 (E3): traegt das Ereignis KEINE Ortsposition (also der
+    Trip-Δ-Pfad, `location_positions is None`), fuehrt das Token zusaetzlich
+    den Von-Wert (`{sign}{code}{von}>{bis}` statt nur `{sign}{code}{bis}`) --
+    der Ausschlag wird lesbar, ohne dass der Empfaenger den letzten Mailstand
+    kennen muss (AC-6). Der Ortsvergleich-Aenderungspfad (`location_positions`
+    gesetzt) behaelt sein Token byte-identisch (AC-9, #1467 S2 AG3b).
+    """
     sign = "+" if e.value_to >= e.value_from else "-"
-    tok = f"{sign}{_code(e)}{int(round(e.value_to))}"
+    if location_positions is None:
+        tok = f"{sign}{_code(e)}{int(round(e.value_from))}>{int(round(e.value_to))}"
+    else:
+        tok = f"{sign}{_code(e)}{int(round(e.value_to))}"
     if e.occurred_at:
         tok = tok + f"@{e.occurred_at[:2]}"
     pos = (location_positions or {}).get(e.location_label or "")
@@ -705,9 +749,16 @@ def render_sms(
     im Mehr-Orte-Fall stand die Ortsliste doppelt (`trip_short` UND
     `location_label` tragen denselben `collective_label`,
     `project.py:217-220`), im Ein-Ort-Fall der Name zweimal hintereinander
-    (`'Graz Graz: '`). Aufrufer OHNE `location_positions` (Trip-Δ,
-    Trip-Radar, Compare-Radar, amtliche Warnungen) behalten ihren Kopf
-    byte-identisch.
+    (`'Graz Graz: '`). Aufrufer OHNE `location_positions` UND OHNE
+    `location_label`/`multi_location` (Trip-Radar, Compare-Radar, amtliche
+    Warnungen) behalten ihren Kopf byte-identisch.
+
+    Issue #1935/#1779 (E3/E4): der Trip-Δ-Kopf (kein `location_positions`,
+    kein `multi_location`, kein `msg.location_label`) spricht seither
+    dieselbe Ortssprache wie Betreff/E-Mail/Telegram (`_km_str`/
+    `format_alert_location`) statt einer km-Spanne, und fuehrt keinen
+    Trip-Namen mehr -- PO-Entscheid 2026-08-17, hebt AC-5 von
+    `fix_1744_alarm_format_angleichen.md` fuer diesen Pfad auf.
     """
     if msg.source is not None:
         return _render_sms_onset(msg, limit)
@@ -730,8 +781,10 @@ def render_sms(
     elif msg.location_label:
         head = f"{trip} {_ascii(msg.location_label)[:24]}: "
     else:
-        a, b = km_span(msg.events)
-        head = f"{trip} km{int(round(a))}-{int(round(b))}: "
+        # Issue #1935/#1779 (E3/E4): Trip-Δ-Pfad -- dieselbe Ortsaufloesung
+        # wie Betreff/E-Mail/Telegram (`_km_str`), Emoji ENTFERNT statt
+        # transliteriert (AC-7), kein Trip-Name mehr (AC-5).
+        head = f"{_ascii_alert_location(_km_str(msg))}: "
     # Issue #1916 (AC-3/AC-4): der Referenz-Zeitpunkt gehoert in den KOPF
     # (immer enthalten), NICHT in die Token-Liste -- sonst wuerde er bei
     # Laengendruck wie ein normales Event-Token weggekuerzt statt "notfalls
@@ -788,6 +841,32 @@ def _ascii(text: str) -> str:
     for bad, good in _ASCII_EXTENSION_REPLACEMENTS:
         text = text.replace(bad, good)
     return fold_ascii(text)
+
+
+def _strip_pictographs(text: str) -> str:
+    """Entfernt Piktogramm-Zeichen (Unicode-Kategorie 'So', z.B. 🏁) samt
+    einem direkt folgenden Leerzeichen (Issue #1935/#1779 AC-7): das Emoji
+    wird ENTFERNT statt transliteriert -- `fold_ascii()`/`anyascii` wuerde
+    sonst z.B. ':checkered_flag:' bauen, was auf einer SMS unlesbar waere."""
+    out: list[str] = []
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if unicodedata.category(ch) == "So":
+            i += 1
+            if i < len(text) and text[i] == " ":
+                i += 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _ascii_alert_location(text: str) -> str:
+    """SMS-Kopf-Ortstext (Issue #1935/#1779 AC-5/AC-7/AC-8): Piktogramme
+    ZUERST entfernen, danach dieselbe ASCII/GSM-7-Faltung wie jeder andere
+    SMS-Text -- sonst faellt die Reihenfolge in `fold_ascii()`."""
+    return _ascii(_strip_pictographs(text))
 
 
 def _esc(text: str) -> str:

--- a/tests/tdd/test_978_deviation_line_readability.py
+++ b/tests/tdd/test_978_deviation_line_readability.py
@@ -141,11 +141,11 @@ def _thousand_cape_msg() -> AlertMessage:
 class TestAC1EmailMultiLineUnitOnce:
     def test_email_datablock_line_unit_once_and_threshold_without_unit(self):
         html, plain = render_email(_multi_msg())
-        assert "Böen · Schwelle 40" in html, (
+        assert "Böen · Änderung 60 · Schwelle 40" in html, (
             f"Schwelle ohne Einheit fehlt (SOLL laut Design-Vorlage "
             f"Zeile 220): {html!r}"
         )
-        assert "Böen · Schwelle 40" in plain
+        assert "Böen · Änderung 60 · Schwelle 40" in plain
         assert "20 ↑ 80 km/h" in html, (
             f"Wertespanne mit Einheit genau einmal fehlt (SOLL laut Design-"
             f"Vorlage Zeile 221): {html!r}"
@@ -217,10 +217,14 @@ class TestAC2RoundingNoiseAndThousandSeparator:
 
 class TestAC3SubjectTop3JustNumbers:
     def test_subject_top3_exact_literal(self):
+        # Issue #1935/#1779 E5: Einheit immer anhaengen (nicht mehr nur bei
+        # '%') -- Niedersch (mm) und Böen (km/h) tragen seither ihre Einheit,
+        # Gewitter (Einheit "") bleibt unveraendert ohne Suffix.
         subject = render_subject(_multi_msg())
-        assert "Niedersch 30, Gewitter 90, Böen 80" in subject, (
+        assert "Niedersch 30 mm, Gewitter 90, Böen 80 km/h" in subject, (
             f"Betreff-Top3 nicht im SOLL-Format (PO-Nachtrag 2026-07-02: "
-            f"kritischster zuerst, severity-absteigend): {subject!r}"
+            f"kritischster zuerst, severity-absteigend; Issue #1935/#1779 E5: "
+            f"Einheit immer): {subject!r}"
         )
 
 
@@ -231,10 +235,12 @@ class TestAC3SubjectTop3JustNumbers:
 
 class TestAC4TelegramMultiLineNoUnitsExceptPercent:
     def test_telegram_multiline_exact_literal(self):
+        # Issue #1935/#1779 E5: Einheit immer anhaengen (analog Betreff).
         tg = render_telegram(_multi_msg())
-        assert "Niedersch 2→30 · Gewitter 20→90 · Böen 20→80" in tg, (
+        assert "Niedersch 2→30 mm · Gewitter 20→90 · Böen 20→80 km/h" in tg, (
             f"Telegram-Multi-Zeile nicht im SOLL-Format (PO-Nachtrag "
-            f"2026-07-02: kritischster zuerst, severity-absteigend): {tg!r}"
+            f"2026-07-02: kritischster zuerst, severity-absteigend; Issue "
+            f"#1935/#1779 E5: Einheit immer): {tg!r}"
         )
 
     def test_metric_line_has_no_schwelle_word(self):
@@ -271,12 +277,15 @@ class TestChannelOrderConsistency:
         )
 
         html, plain = render_email(msg)
-        email_order = re.findall(r"(Niedersch|Gewitter|Böen) · Schwelle", plain)
+        # Issue #1935/#1779 E2: die Zeile nennt seither zusaetzlich den
+        # Änderungsbetrag vor "Schwelle" -- die Reihenfolge-Zusicherung
+        # zielt auf "Änderung", nicht mehr direkt auf "Schwelle".
+        email_order = re.findall(r"(Niedersch|Gewitter|Böen) · Änderung", plain)
         assert email_order == expected_order, (
             f"E-Mail-Datenblock-Reihenfolge nicht severity-absteigend: "
             f"{email_order!r} (erwartet {expected_order!r}) — {plain!r}"
         )
-        html_order = re.findall(r"(Niedersch|Gewitter|Böen) · Schwelle", html)
+        html_order = re.findall(r"(Niedersch|Gewitter|Böen) · Änderung", html)
         assert html_order == expected_order
 
         tg = render_telegram(msg)
@@ -331,8 +340,12 @@ class TestMixedOverUnderOrdering:
 
         _, plain = render_email(_mixed_over_under_msg())
         # Issue #980: unter-Schwelle-Zeilen tragen das Label "· unter Schwelle"
-        # (ohne Schwellen-Zahl), über-Schwelle "· Schwelle N" — beide erfassen.
-        order = re.findall(r"(Niedersch|Gewitter|Regen%|Böen) · (?:unter )?Schwelle", plain)
+        # (ohne Schwellen-Zahl), über-Schwelle "· Änderung N · Schwelle N"
+        # (Issue #1935/#1779 E2) — beide erfassen.
+        order = re.findall(
+            r"(Niedersch|Gewitter|Regen%|Böen) · (?:Änderung \S+(?: %)? · )?(?:unter )?Schwelle",
+            plain,
+        )
         assert order == ["Böen", "Gewitter", "Regen%", "Niedersch"], (
             f"unter-Schwelle-Event (Niedersch) muss trotz hoher abs(severity) "
             f"gedämpft zuletzt stehen: {order!r} — {plain!r}"
@@ -349,10 +362,12 @@ class TestMixedOverUnderOrdering:
         )
 
     def test_subject_top3_excludes_under_threshold_event(self):
+        # Issue #1935/#1779 E5: Böen (km/h) traegt seither seine Einheit;
+        # Regen% traegt "%" bereits seit jeher (Prozent-Metrik, unveraendert).
         subject = render_subject(_mixed_over_under_msg())
-        assert "Böen 80, Gewitter 55, Regen% 55%" in subject, (
+        assert "Böen 80 km/h, Gewitter 55, Regen% 55%" in subject, (
             f"Top-3 muss die drei über-Schwelle-Events severity-absteigend "
-            f"zeigen: {subject!r}"
+            f"zeigen (Issue #1935/#1779 E5: Einheit immer): {subject!r}"
         )
         assert "Niedersch 2" not in subject, (
             f"unter-Schwelle-Event (höchste severity) darf NICHT im Top-3 "
@@ -370,7 +385,7 @@ class TestMixedOverUnderOrdering:
 class TestAC6HtmlPlainStructuralParity:
     def test_html_and_plain_share_same_kuerzel_schwelle_content(self):
         html, plain = render_email(_multi_msg())
-        for literal in ("Böen · Schwelle 40", "20 ↑ 80 km/h"):
+        for literal in ("Böen · Änderung 60 · Schwelle 40", "20 ↑ 80 km/h"):
             assert literal in html, f"{literal!r} fehlt im HTML: {html!r}"
             assert literal in plain, f"{literal!r} fehlt im Plain-Text: {plain!r}"
 

--- a/tests/tdd/test_alert_bundle_958ff.py
+++ b/tests/tdd/test_alert_bundle_958ff.py
@@ -128,10 +128,11 @@ def test_ac2_render_email_change_wording_and_datablock():
     """AC-2: Given dasselbe Event (Bug-Report-Werte) / When render_email() die
     Single-Metrik-Verdict-Pill und den Datenblock rendert / Then enthält der
     Verdict-Text 'Änderung über deiner Alarm-Schwelle (400 m)' (nicht mehr
-    'jetzt über Schwelle 400 m') und der Datenblock zeigt den vollstaendigen
-    Satz 'jetzt darüber ✗' (#1865-Fix — Fragment 'Änderung über ✗' war
-    unverstaendlich, over_thr()/side_label() selbst bleiben unveraendert)
-    in der Alarm-Schwelle-Zeile — in html UND plain."""
+    'jetzt über Schwelle 400 m') und der Datenblock zeigt den Änderungsbetrag
+    gegen die Schwelle ('über Alarm-Schwelle 400 m ✗', Issue #1935/#1779 E1 —
+    loest den fruehreren Satz 'jetzt darüber ✗' ab, over_thr()/side_label()
+    selbst bleiben unveraendert) in der Alarm-Schwelle-Zeile — in html UND
+    plain."""
     from output.renderers.alert.model import AlertEvent, AlertMessage
     from output.renderers.alert.render import render_email
 
@@ -147,9 +148,15 @@ def test_ac2_render_email_change_wording_and_datablock():
             f"Verdikt-Text fehlt oder ist noch die alte Formulierung "
             f"('jetzt über Schwelle ...'): {content!r}"
         )
-        assert "jetzt darüber ✗" in content, (
-            f"Datenblock-Zeile 'Alarm-Schwelle' zeigt nicht den vollstaendigen "
-            f"Satz 'jetzt darüber ✗' (#1865): {content!r}"
+        assert "über Alarm-Schwelle 400 m ✗" in content, (
+            f"Datenblock-Zeile 'Alarm-Schwelle' zeigt nicht den Änderungsbetrag "
+            f"gegen die Schwelle (Issue #1935/#1779 E1): {content!r}"
+        )
+        assert "Änderung 430 m" in content, (
+            f"Datenblock-Zeile nennt nicht den Änderungsbetrag (430 m): {content!r}"
+        )
+        assert "jetzt darüber ✗" not in content, (
+            f"Altes Fragment 'jetzt darüber ✗' (vor #1935/#1779) noch vorhanden: {content!r}"
         )
         assert "Änderung über ✗" not in content, (
             f"Altes Fragment 'Änderung über ✗' (#1865-Bug) noch vorhanden: {content!r}"
@@ -252,7 +259,9 @@ def test_ac10_multi_datablock_under_threshold_row_format():
     When der E-Mail-Datenblock gerendert wird / Then zeigt die Zeile links
     'Regen% · unter Schwelle' (OHNE Schwellen-Zahl) und rechts '70 → 90 %'
     (neutraler Pfeil, KEIN über/unter-Wort am Ende) — exakt wie Design-Vorlage
-    Zeile 231-234."""
+    Zeile 231-234. Ergaenzung (Issue #1935/#1779 E2): die über-Schwelle-Zeile
+    derselben Nachricht (Böen 30→80, Schwelle 40, Δ=50) traegt zusaetzlich zur
+    Schwelle den Änderungsbetrag."""
     from output.renderers.alert.render import render_email
 
     html, plain = render_email(_bundle_multi_msg())
@@ -267,6 +276,10 @@ def test_ac10_multi_datablock_under_threshold_row_format():
         assert "Regen% · Schwelle" not in content, (
             f"Alte Zeile mit Schwellen-Zahl ('Regen% · Schwelle ...') noch "
             f"vorhanden: {content!r}"
+        )
+        assert "Böen · Änderung 50 · Schwelle 40" in content, (
+            f"Ueber-Schwelle-Zeile nennt nicht den Änderungsbetrag (Issue "
+            f"#1935/#1779 E2): {content!r}"
         )
 
 

--- a/tests/tdd/test_alert_change_amount_wording.py
+++ b/tests/tdd/test_alert_change_amount_wording.py
@@ -1,0 +1,304 @@
+"""TDD RED — Issue #1935/#1779: Alarm-Datenzeile nennt den Änderungsbetrag,
+nicht den Messwert.
+
+SPEC: docs/specs/modules/fix_1935_1779_alarm_nachricht_klarheit.md
+      (AC-1 bis AC-4, AC-11)
+KONTEXT: docs/context/fix-1935-1779-alarm-nachricht-klarheit.md
+
+Die zweite Datenzeile der Abweichungs-Mail (`Alarm-Schwelle 1.000 m: jetzt
+darüber ✗`) behauptet etwas ueber den MESSWERT, obwohl `threshold` per
+ADR-0013 (#958) immer eine Δ-Auslöseschwelle ist. Diese Suite prueft die
+Umstellung auf einen Änderungsbetrag-Wortlaut — ausschliesslich ueber echte
+Renderer-Aufrufe (`render_email`/`render_subject`/`render_telegram`) mit
+echten `AlertEvent`/`AlertMessage`-Objekten (Vorbild: `_delta_message()` in
+`test_alert_location_vocabulary.py:99-146`). Kein Mock, keine
+Dateiinhalt-Checks — Zeilen werden aus dem gerenderten Text extrahiert
+(zeilenweise), nicht per Substring-Suche im Volltext.
+
+Pfadregel #1409: der Pruefling wird relativ zur Testdatei aufgeloest (uebliche
+`pythonpath`-Konfiguration in `pyproject.toml`, kein fester Hauptrepo-Pfad).
+"""
+from __future__ import annotations
+
+import re
+
+from app.metric_catalog import format_metric_value, get_metric
+from output.renderers.alert.model import AlertEvent, AlertMessage, side_label
+from output.renderers.alert.render import render_email, render_subject, render_telegram
+
+# ---------------------------------------------------------------------------
+# Fixtures — echte AlertEvent/AlertMessage (Fall aus #1935: Sicht 1.400→280 m)
+# ---------------------------------------------------------------------------
+
+
+def _single_event(*, value_from: float, value_to: float, threshold: float = 1000.0) -> AlertEvent:
+    return AlertEvent(
+        metric_id="visibility", value_from=value_from, value_to=value_to,
+        threshold=threshold, cmp="unter", occurred_at=None,
+        km_from=8.0, km_to=8.0, segment_id="Ziel",
+    )
+
+
+def _single_msg(*, value_from: float, value_to: float, threshold: float = 1000.0) -> AlertMessage:
+    e = _single_event(value_from=value_from, value_to=value_to, threshold=threshold)
+    return AlertMessage(trip_short="KHW 403", stand_at="10:00", events=(e,))
+
+
+def _multi_msg() -> AlertMessage:
+    """Böen 20→80, Schwelle 40, Δ=60 — dasselbe Fixture-Muster wie
+    `test_978_deviation_line_readability.py::_multi_msg` (nur ein Event
+    genuegt hier, weil der Multi-Zweig ab >=2 Events greift)."""
+    e_gust = AlertEvent(
+        metric_id="gust", value_from=20.0, value_to=80.0, threshold=40.0,
+        cmp="über", occurred_at="11:00", km_from=0.0, km_to=4.0,
+    )
+    e_thunder = AlertEvent(
+        metric_id="thunder", value_from=20.0, value_to=90.0, threshold=40.0,
+        cmp="über", occurred_at="11:30", km_from=1.0, km_to=4.0,
+    )
+    return AlertMessage(
+        trip_short="KHW 403", stand_at="14:30", events=(e_gust, e_thunder), source=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Extraktion — zeilenweise, kein Substring-Scan im Volltext
+# ---------------------------------------------------------------------------
+
+
+def _second_data_line_plain(plain: str) -> str:
+    """Zweite Datenzeile (Label: Wert) des Einzel-Ereignis-Datenblocks —
+    direkt VOR der 'Wo & wann: '-Zeile (render.py:_datablock_single, feste
+    3-Zeilen-Struktur row1/row2/row3)."""
+    lines = plain.splitlines()
+    hits = [i for i, ln in enumerate(lines) if ln.startswith("Wo & wann: ")]
+    assert len(hits) == 1, f"Genau eine 'Wo & wann'-Zeile erwartet: {lines!r}"
+    idx = hits[0]
+    assert idx >= 1, f"Keine Zeile vor 'Wo & wann': {lines!r}"
+    return lines[idx - 1]
+
+
+def _second_data_row_html(html: str) -> tuple[str, str]:
+    """Label/Wert der zweiten `<table>`-Zeile im HTML-Datenblock."""
+    tds = re.findall(r"<td[^>]*>(.*?)</td>", html)
+    assert len(tds) >= 4, f"Weniger als zwei Tabellenzeilen im HTML: {html!r}"
+    return tds[2], tds[3]
+
+
+def _verdict_line_plain(plain: str) -> str:
+    """Verdict-Chip-Zeile (`_verdict_single`) — dritte Zeile des Plain-Texts
+    (h1, '', verdict, ...)."""
+    lines = plain.splitlines()
+    assert len(lines) >= 3, f"Zu wenige Zeilen fuer einen Verdict-Chip: {lines!r}"
+    return lines[2]
+
+
+def _multi_line_for(plain: str, label: str) -> str:
+    """Die Multi-Ereignis-Datenzeile fuer ein bestimmtes Label — zeilenweise
+    gesucht (`label + ' ·'` als Zeilenanfang), nicht per Volltext-Substring.
+
+    Korrektur (RED-Vertrag-Praezisierung, Issue #1935/#1779 E2): der
+    Multi-Ereignis-Datenblock baut die Zeile als `f"{k}: {v}"`, wobei `k`
+    (das eigentliche Label, z.B. "Böen · Änderung 60 · Schwelle 40") SELBST
+    Änderungsbetrag UND Schwelle traegt (spec-pseudocode E2) -- anders als im
+    Einzel-Ereignis-Datenblock, wo der Aenderungsbetrag im `k`-Anteil UND die
+    Schwelle im `v`-Anteil eines eigenen row2-Tupels stehen. Ein Abschneiden
+    hinter dem ersten ": " wuerde deshalb genau den Teil verwerfen, den AC-4
+    pruefen soll -- die volle Zeile ist die richtige Datenbasis."""
+    lines = plain.splitlines()
+    data_hits = [ln for ln in lines if ln.startswith(f"{label} · ")]
+    assert len(data_hits) == 1, (
+        f"Genau eine Datenzeile fuer {label!r} erwartet, gefunden: {lines!r}"
+    )
+    return data_hits[0]
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — Über-Schwelle-Fall (#1935-Fall)
+# ---------------------------------------------------------------------------
+
+
+def test_ac1_datenzeile_nennt_aenderungsbetrag_statt_messwert_ueber_schwelle():
+    """AC-1: Änderung 1.120 m: über Alarm-Schwelle 1.000 m ✗ — weder 'jetzt'
+    noch die Einheit direkt am Schwellwert-Label; in `plain` UND `html`."""
+    msg = _single_msg(value_from=1400.0, value_to=280.0, threshold=1000.0)
+    html, plain = render_email(msg)
+
+    row2 = _second_data_line_plain(plain)
+    assert row2 == "Änderung 1.120 m: über Alarm-Schwelle 1.000 m ✗", (
+        f"Datenzeile 2 (plain): {row2!r}"
+    )
+    assert "jetzt" not in row2, f"'jetzt' zeigt weiterhin auf den Messwert: {row2!r}"
+
+    label_html, value_html = _second_data_row_html(html)
+    assert label_html == "Änderung 1.120 m", f"HTML-Label: {label_html!r}"
+    assert value_html == "über Alarm-Schwelle 1.000 m ✗", f"HTML-Wert: {value_html!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — Unter-Schwelle-Fall (Symmetrie)
+# ---------------------------------------------------------------------------
+
+
+def test_ac2_datenzeile_nennt_aenderungsbetrag_statt_messwert_unter_schwelle():
+    """AC-2: Änderung 100 m: unter Alarm-Schwelle 1.000 m ✓ — dieselbe
+    Umstellung fuer den unter-Schwelle-Fall, nicht nur fuer den gemeldeten
+    Fehlerfall."""
+    msg = _single_msg(value_from=280.0, value_to=380.0, threshold=1000.0)
+    html, plain = render_email(msg)
+
+    row2 = _second_data_line_plain(plain)
+    assert row2 == "Änderung 100 m: unter Alarm-Schwelle 1.000 m ✓", (
+        f"Datenzeile 2 (plain): {row2!r}"
+    )
+
+    label_html, value_html = _second_data_row_html(html)
+    assert label_html == "Änderung 100 m", f"HTML-Label: {label_html!r}"
+    assert value_html == "unter Alarm-Schwelle 1.000 m ✓", f"HTML-Wert: {value_html!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC-3 — Verdict-Chip und Datenzeile widersprechen sich nicht
+# ---------------------------------------------------------------------------
+
+
+def test_ac3_verdict_chip_und_datenzeile_nennen_dieselbe_aenderungsaussage():
+    """AC-3: fuer über- UND unter-Schwelle-Fixtures muessen Verdict-Chip
+    (`_verdict_single`) und zweite Datenzeile dasselbe `side_label`-Wort und
+    denselben formatierten Schwellwert enthalten -- kein isolierter Blick auf
+    nur einen der beiden Texte."""
+    fixtures = [
+        _single_event(value_from=1400.0, value_to=280.0, threshold=1000.0),
+        _single_event(value_from=280.0, value_to=380.0, threshold=1000.0),
+    ]
+    for e in fixtures:
+        msg = AlertMessage(trip_short="KHW 403", stand_at="10:00", events=(e,))
+        html, plain = render_email(msg)
+        verdict = _verdict_line_plain(plain)
+        row2 = _second_data_line_plain(plain)
+
+        expected_side = side_label(e)
+        expected_threshold = format_metric_value(
+            get_metric(e.metric_id).unit, e.threshold,
+        )
+
+        assert expected_side in verdict, (
+            f"Verdict nennt nicht {expected_side!r}: {verdict!r}"
+        )
+        assert expected_side in row2, (
+            f"Datenzeile 2 nennt nicht {expected_side!r}: {row2!r}"
+        )
+        # Kein Widerspruch: "jetzt" zeigt zeitlich auf den MESSWERT (Root
+        # Cause #1935/#1779) -- die Datenzeile darf es nach dem Fix nicht
+        # mehr fuehren, unabhaengig davon, dass "über"/"unter" als Substring
+        # auch im alten Wortlaut ("jetzt darüber") vorkam.
+        assert "jetzt" not in row2, (
+            f"Datenzeile 2 zeigt weiterhin auf den Messwert ('jetzt'): {row2!r}"
+        )
+        assert expected_threshold in verdict, (
+            f"Verdict nennt nicht den Schwellwert {expected_threshold!r}: {verdict!r}"
+        )
+        assert expected_threshold in row2, (
+            f"Datenzeile 2 nennt nicht den Schwellwert {expected_threshold!r}: {row2!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-4 — Mehr-Ereignis-Zweig: Änderungsbetrag zusätzlich zur Schwelle
+# ---------------------------------------------------------------------------
+
+
+def test_ac4_mehrereignis_zeile_nennt_aenderungsbetrag_und_schwelle():
+    """AC-4: die Böen-Datenzeile im Mehr-Ereignis-Zweig enthaelt BEIDE Zahlen
+    -- den Änderungsbetrag (60) UND die Schwelle (40) -- als zwei
+    unterscheidbare Zahlen in derselben Zeile."""
+    msg = _multi_msg()
+    _, plain = render_email(msg)
+
+    line = _multi_line_for(plain, "Böen")
+    numbers = re.findall(r"\d+", line)
+    assert "60" in numbers, f"Änderungsbetrag (60) fehlt in der Böen-Zeile: {line!r}"
+    assert "40" in numbers, f"Schwelle (40) fehlt in der Böen-Zeile: {line!r}"
+    assert numbers.count("60") >= 1 and numbers.count("40") >= 1 and "60" != "40", (
+        f"Änderungsbetrag und Schwelle muessen zwei VERSCHIEDENE Zahlen sein: {line!r}"
+    )
+
+
+def _multi_msg_mit_fallendem_ereignis() -> AlertMessage:
+    """Böen steigend (20→80, Δ=60) UND Sicht FALLEND (1.400→280 m, Δ=1.120),
+    beide über Schwelle -- Regressionsschutz gegen Adversary-Finding F001:
+    alle bisherigen Mehr-Ereignis-Fixtures (`_multi_msg`) enthalten nur
+    steigende Werte, sodass `abs(e.value_to - e.value_from)` an render.py:584
+    ungeprueft bliebe. Ein fallendes Ereignis macht das Vorzeichen sichtbar."""
+    e_gust = AlertEvent(
+        metric_id="gust", value_from=20.0, value_to=80.0, threshold=40.0,
+        cmp="über", occurred_at="11:00", km_from=0.0, km_to=4.0,
+    )
+    e_visibility = AlertEvent(
+        metric_id="visibility", value_from=1400.0, value_to=280.0, threshold=1000.0,
+        cmp="unter", occurred_at="11:30", km_from=1.0, km_to=4.0,
+    )
+    return AlertMessage(
+        trip_short="KHW 403", stand_at="14:30",
+        events=(e_gust, e_visibility), source=None,
+    )
+
+
+def test_ac4_mehrereignis_fallendes_ereignis_zeigt_vorzeichenlosen_aenderungsbetrag():
+    """AC-4 Regressionsschutz (Adversary-Finding F001, Issue #1935/#1779):
+    ein FALLENDES Ereignis über der Schwelle (Sicht 1.400→280 m) muss
+    denselben vorzeichenlosen Änderungsbetrag zeigen wie ein steigendes --
+    'Änderung 1.120', NIEMALS 'Änderung -1.120' (der genau die Verwirrung
+    waere, die dieser Fix im Einzel-Ereignis-Zweig beseitigt)."""
+    msg = _multi_msg_mit_fallendem_ereignis()
+    _, plain = render_email(msg)
+
+    line = _multi_line_for(plain, "Sicht")
+    assert "Änderung 1.120" in line, (
+        f"Änderungsbetrag muss vorzeichenlos '1.120' lauten: {line!r}"
+    )
+    assert "-1.120" not in line, (
+        f"Änderungsbetrag darf kein Minuszeichen fuehren: {line!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-11 (Regressionsschutz Betreff/Telegram) — Einheit immer am Wert
+# ---------------------------------------------------------------------------
+
+
+def test_ac11_betreff_fuehrt_einheit_bei_nicht_prozent_metrik():
+    """AC-11: `render_subject()`s Top-3-Auswahl haengt die Einheit einer
+    Nicht-Prozent-Metrik an (z.B. 'Böen 80 km/h' statt 'Böen 80')."""
+    subject = render_subject(_multi_msg())
+    assert "Böen 80 km/h" in subject, (
+        f"Betreff fuehrt die Einheit nicht am Böen-Wert: {subject!r}"
+    )
+
+
+def test_ac11_telegram_fuehrt_einheit_bei_nicht_prozent_metrik():
+    """AC-11: `render_telegram()`s Multi-Zeile haengt die Einheit einer
+    Nicht-Prozent-Metrik an."""
+    tg = render_telegram(_multi_msg())
+    metric_line = tg.splitlines()[1]
+    assert "80 km/h" in metric_line, (
+        f"Telegram-Metrikzeile fuehrt die Einheit nicht am Böen-Wert: {metric_line!r}"
+    )
+
+
+def test_ac11_prozent_metrik_bleibt_unveraendert_mit_prozentzeichen():
+    """AC-11 (Regressionsschutz, HEUTE GRUEN): Prozent-Metriken bleiben mit
+    angehaengtem '%' -- die Umstellung betrifft nur Nicht-Prozent-Metriken."""
+    e_prob = AlertEvent(
+        metric_id="rain_probability", value_from=10.0, value_to=90.0, threshold=30.0,
+        cmp="über", occurred_at="11:00", km_from=0.0, km_to=4.0,
+    )
+    e_gust = AlertEvent(
+        metric_id="gust", value_from=20.0, value_to=80.0, threshold=40.0,
+        cmp="über", occurred_at="11:00", km_from=0.0, km_to=4.0,
+    )
+    msg = AlertMessage(trip_short="KHW 403", stand_at="14:30", events=(e_prob, e_gust))
+    subject = render_subject(msg)
+    assert "90%" in subject or "90 %" in subject, (
+        f"Prozent-Metrik verliert ihr '%'-Zeichen: {subject!r}"
+    )

--- a/tests/tdd/test_alert_location_vocabulary.py
+++ b/tests/tdd/test_alert_location_vocabulary.py
@@ -36,6 +36,7 @@ NICHT Gegenstand dieser Datei: AC-8 bis AC-12 (Mail-Koerper, Scheibe A2).
 from __future__ import annotations
 
 import re
+import unicodedata
 from datetime import date, datetime, timezone
 from zoneinfo import ZoneInfo
 
@@ -362,7 +363,14 @@ def test_ortsvergleich_aenderungsalarm_nennt_weiterhin_den_ortsnamen():
 
 def test_ortsvergleich_mehrere_orte_nennen_weiterhin_ihre_namen():
     """AC-4 (HEUTE GRUEN, Invariante): derselbe Nachweis fuer den gebuendelten
-    Mehr-Orte-Alarm (`to_multi_point_alert_message`, #1170)."""
+    Mehr-Orte-Alarm (`to_multi_point_alert_message`, #1170).
+
+    Issue #1935/#1779 E5 (nachgezogen, PO-Entscheid 2026-08-17): der
+    Top-3-Ausdruck haengt seither die Einheit IMMER an (nicht mehr nur bei
+    '%'), auch im Ortsvergleich-Pfad -- 'Böen' (km/h) traegt sie deshalb
+    seither. Die eigentliche AC-4-Zusicherung dieses Tests -- die Ortsnamen
+    ('Toulon, Hyères') bleiben ERHALTEN, die Segment-Sprache verdraengt sie
+    NICHT -- ist davon unberuehrt und bleibt als exakte Gleichheit bestehen."""
     from output.renderers.alert.project import to_multi_point_alert_message
     from output.renderers.alert.render import render_subject, render_telegram
 
@@ -376,7 +384,7 @@ def test_ortsvergleich_mehrere_orte_nennen_weiterhin_ihre_namen():
     )
 
     assert render_subject(msg) == (
-        "[Toulon, Hyères] Toulon, Hyères · ↑ 2 über Schwelle: Böen 80, Böen 70"
+        "[Toulon, Hyères] Toulon, Hyères · ↑ 2 über Schwelle: Böen 80 km/h, Böen 70 km/h"
     )
     assert render_telegram(msg).splitlines()[0] == (
         "<b>Toulon, Hyères · Toulon, Hyères · 2 über Schwelle</b>"
@@ -460,12 +468,95 @@ def test_ortsname_schlaegt_die_segment_kennung():
 
 
 # ---------------------------------------------------------------------------
-# AC-5 — Kurznachricht nennt keinen Ort und bleibt <= 140 Zeichen
+# AC-5 — Kurznachricht-Ortsbezug
 # ---------------------------------------------------------------------------
+#
+# PO-Entscheid 2026-08-04 (#1467 S2 AG3b) hatte hier zunaechst festgelegt:
+# Alarm-Kurznachrichten nennen KEINEN Ort. PO-Entscheid 2026-08-17 nimmt das
+# fuer den TRIP-Δ-PFAD ausdruecklich zurueck (Spec
+# `docs/specs/modules/fix_1935_1779_alarm_nachricht_klarheit.md`, AC-5/AC-8,
+# loest AC-5 von `fix_1744_alarm_format_angleichen.md` fuer diesen Pfad ab):
+# die Kurznachricht nennt seither DENSELBEN Ortstext wie der Betreff (Segment-
+# /Ziel-Sprache statt km-Spanne), aber weiterhin KEINEN Trip-Namen. Der
+# Radar-/Nowcast-Pfad (`_render_sms_onset` ohne `location_label`) ist von
+# dieser Ablösung NICHT betroffen und bleibt bei der km-Spanne (AC-10/AC-12).
+
+
+def _strip_leading_pictograph(text: str) -> str:
+    """Entfernt ein fuehrendes Piktogramm (z.B. 🏁) samt folgendem Leerzeichen.
+
+    Unabhaengige Testerwartung -- KEINE Wiederverwendung von Produktivcode
+    (Vorbild `test_alert_sms_segment_head.py::_strip_leading_pictograph`)."""
+    if not text:
+        return text
+    if unicodedata.category(text[0]) == "So":
+        return text[1:].lstrip()
+    return text
+
+
+def _assert_kurznachricht_nennt_ortstext_wie_betreff(sms: str, ort_im_betreff: str) -> None:
+    """Issue #1935/#1779 AC-5/AC-8 (PO-Entscheid 2026-08-17): die Kurznachricht
+    des Trip-Δ-Pfads beginnt mit demselben (emoji-freien, ASCII-gefalteten)
+    Ortstext wie der Betreff, statt einer km-Spanne, und bleibt <= 140 Zeichen.
+    Der Gedankenstrich in Segment-Bereichen ('Segment 3–5') wird auf der SMS
+    zu einem einfachen Bindestrich gefaltet (GSM-7) -- dieselbe, andernorts
+    bereits bewachte Faltungsregel, hier nur zur Vergleichsbildung nachgebaut."""
+    erwartet = ort_im_betreff.replace("–", "-")
+    assert sms.startswith(f"{erwartet}: "), (
+        f"Kurznachricht beginnt nicht mit dem Betreff-Ortstext {erwartet!r}: {sms!r}"
+    )
+    assert not re.search(r"km\d", sms), (
+        f"Kurznachricht nennt noch eine km-Spanne statt der Betreff-Ortssprache: {sms!r}"
+    )
+    # Alarm-Grenze ist 140, NICHT 160 (render.py:285/621, official_alerts.py:1836).
+    assert len(sms) <= 140, f"Kurznachricht ist {len(sms)} Zeichen lang: {sms!r}"
+
+
+def test_kurznachricht_des_abweichungsalarms_nennt_denselben_ort_wie_der_betreff():
+    """AC-5/AC-8 (Issue #1935/#1779, PO-Entscheid 2026-08-17): Given ein
+    Trip-Abweichungsalarm auf dem Ziel-Segment / When die Kurznachricht
+    gerendert wird / Then beginnt sie mit demselben Ortstext wie der Betreff
+    ('Ziel', ohne Emoji) statt einer km-Spanne, und traegt weiterhin KEINEN
+    Trip-Namen.
+
+    Dreht die vormalige Invariante dieser Datei ('nennt keinen Ort') fuer
+    genau diesen Pfad um -- s. Spec `fix_1935_1779_alarm_nachricht_klarheit.md`
+    AC-5, die `fix_1744_alarm_format_angleichen.md` AC-5 hierfuer ablöst.
+    """
+    from output.renderers.alert.render import render_sms, render_subject
+
+    msg = _delta_message([("Ziel", 8.0, 8.0)])
+    ort_im_betreff = _strip_leading_pictograph(_location_slot(render_subject(msg)))
+    sms = render_sms(msg)
+
+    _assert_kurznachricht_nennt_ortstext_wie_betreff(sms, ort_im_betreff)
+    assert msg.trip_short not in sms, (
+        f"Kurznachricht traegt weiterhin den Trip-Namen: {sms!r}"
+    )
+
+
+def test_kurznachricht_des_abweichungsalarms_ueber_mehrere_segmente_nennt_denselben_ort_wie_der_betreff():
+    """AC-5/AC-8 (Issue #1935/#1779, PO-Entscheid 2026-08-17): dieselbe
+    Zusicherung fuer den Mehr-Segment-Fall aus AC-2 ('Segment 3–5' im
+    Betreff) -- loest `fix_1744_alarm_format_angleichen.md` AC-5 fuer den
+    Trip-Δ-Pfad ab."""
+    from output.renderers.alert.render import render_sms, render_subject
+
+    msg = _delta_message([("3", 4.0, 6.0), ("4", 6.0, 8.0), ("5", 8.0, 10.0)])
+    ort_im_betreff = _strip_leading_pictograph(_location_slot(render_subject(msg)))
+    sms = render_sms(msg)
+
+    _assert_kurznachricht_nennt_ortstext_wie_betreff(sms, ort_im_betreff)
+    assert msg.trip_short not in sms, (
+        f"Kurznachricht traegt weiterhin den Trip-Namen: {sms!r}"
+    )
+
 
 def _assert_kurznachricht_ohne_ort(sms: str) -> None:
     """PO-Entscheid 2026-08-04 (#1467 S2 AG3b): Alarm-Kurznachrichten nennen
-    keinen Ort. SMS und Premium-SMS teilen denselben gerenderten Text
+    keinen Ort. Gilt seit PO-Entscheid 2026-08-17 NUR NOCH fuer den
+    Radar-/Nowcast-Pfad ohne `location_label` (Trip-Δ-Pfad s.o. abgeloest,
+    AC-10/AC-12). SMS und Premium-SMS teilen denselben gerenderten Text
     (`render_alert_sms`, notification_service.py:1318 -> :1488 SMS / :1502
     Premium-SMS) — ein Nachweis deckt beide Kanaele.
     """
@@ -479,32 +570,10 @@ def _assert_kurznachricht_ohne_ort(sms: str) -> None:
     assert len(sms) <= 140, f"Kurznachricht ist {len(sms)} Zeichen lang: {sms!r}"
 
 
-def test_kurznachricht_des_abweichungsalarms_nennt_keinen_ort():
-    """AC-5 (HEUTE GRUEN, Invariante): Given ein Trip-Abweichungsalarm auf dem
-    Ziel-Segment / When die Kurznachricht gerendert wird / Then nennt sie
-    weiterhin keinen Ortsnamen und bleibt <= 140 Zeichen.
-
-    Der Alarm laeuft ueber `to_alert_message()` mit einer echten Etappe
-    `segment_id='Ziel'` — also genau der Eingabe, aus der der BETREFF nach
-    AC-1 kuenftig '🏁 Ziel' bildet. Der Test bewacht, dass diese Umstellung
-    NICHT in die Kurznachricht durchschlaegt.
-    """
-    from output.renderers.alert.render import render_sms
-
-    _assert_kurznachricht_ohne_ort(render_sms(_delta_message([("Ziel", 8.0, 8.0)])))
-
-
-def test_kurznachricht_des_abweichungsalarms_ueber_mehrere_segmente_nennt_keinen_ort():
-    """AC-5 (HEUTE GRUEN, Invariante): dieselbe Zusicherung fuer den
-    Mehr-Segment-Fall aus AC-2 ('Segment 3–5' im Betreff)."""
-    from output.renderers.alert.render import render_sms
-
-    msg = _delta_message([("3", 4.0, 6.0), ("4", 6.0, 8.0), ("5", 8.0, 10.0)])
-    _assert_kurznachricht_ohne_ort(render_sms(msg))
-
-
 def test_kurznachricht_des_nowcasts_nennt_keinen_ort():
-    """AC-5: dieselbe Zusicherung fuer den Radar-Nowcast.
+    """AC-5 (weiterhin GRUEN, Invariante fuer den Radar-/Nowcast-Pfad):
+    dieselbe Zusicherung fuer den Radar-Nowcast -- dieser Pfad ist von der
+    Ablösung 2026-08-17 NICHT betroffen (AC-10/AC-12).
 
     ROT bis der RED-Vertrag Punkt 1 erfuellt ist (`OnsetEvent.segment_id`):
     ohne das Feld laesst sich der Fall „Nowcast KENNT das Ziel-Segment" gar

--- a/tests/tdd/test_alert_sms_location_positions.py
+++ b/tests/tdd/test_alert_sms_location_positions.py
@@ -916,7 +916,10 @@ def test_regression_trip_deviation_alert_sms_text_unchanged():
             trip=_trip(), weather=[_segment_weather_data()], changes=[_change()],
             effective_channels={"sms"},
         )
-        assert stub.texts() == ["ProbeTrip km12-18: +R30"], (
+        # Issue #1935/#1779 (E3/E4): Kopf spricht seither die Segment-Sprache
+        # statt einer km-Spanne (kein Trip-Name mehr), Token traegt Von- UND
+        # Bis-Wert (`_trip_segment().segment_id=1` -> "Segment 1").
+        assert stub.texts() == ["Segment 1: +R2>30"], (
             "Regression: der SMS-Text des Trip-Aenderungsalarms muss ohne "
             "Orts-Positionszuordnung unveraendert bleiben, gemessen: "
             f"{stub.texts()!r}"
@@ -941,7 +944,9 @@ def test_regression_trip_radar_alert_sms_text_unchanged():
             trip=_trip(), request=req, source="Radar (DWD)",
             cooldown_display="2 Stunden", effective_channels={"sms"},
         )
-        assert stub.texts() == ["ProbeTrip km5-18: R!12"], (
+        # Issue #1935/#1779 (E4): Trip-Radar/Onset-Kopf verliert den Trip-Namen,
+        # km-Spanne bleibt (kein Segment-Bezug im Radar-Request dieser Fixture).
+        assert stub.texts() == ["km5-18: R!12"], (
             "Regression: der SMS-Text des Trip-Radar-Alarms muss unveraendert "
             f"bleiben, gemessen: {stub.texts()!r}"
         )

--- a/tests/tdd/test_alert_sms_segment_head.py
+++ b/tests/tdd/test_alert_sms_segment_head.py
@@ -1,0 +1,221 @@
+"""TDD RED — Issue #1935/#1779: Alarm-SMS spricht dieselbe Ortssprache wie
+E-Mail/Betreff (statt einer km-Spanne), fuehrt keinen Trip-Namen mehr auf dem
+Trip-Δ-Pfad, und traegt den Von-Wert im Token.
+
+SPEC: docs/specs/modules/fix_1935_1779_alarm_nachricht_klarheit.md
+      (AC-5 bis AC-8, AC-12)
+KONTEXT: docs/context/fix-1935-1779-alarm-nachricht-klarheit.md
+
+Nimmt AC-5 der abgeloesten Spec `fix_1744_alarm_format_angleichen.md`
+("Kurznachricht nennt weiterhin keinen Ortsbezug") ausdruecklich zurueck --
+PO-Entscheid 2026-08-17.
+
+Betrifft AUSSCHLIESSLICH den Trip-Δ-Pfad von `render_sms()` (kein
+`location_positions`, kein `multi_location`, kein `msg.location_label`) sowie
+den Trip-Zweig von `_render_sms_onset` (`OnsetEvent.location_label is None`).
+Der Ortsvergleich-Pfad bleibt unangetastet (AC-9/AC-10, Regressionsschutz --
+bereits durch `tests/tdd/test_alert_sms_location_positions.py` bewacht, hier
+NICHT dupliziert).
+
+Kein Mock, keine Dateiinhalt-Checks -- echte `AlertEvent`/`AlertMessage`/
+`OnsetEvent` (Vorbild `_onset_message()` in `test_alert_location_vocabulary.py
+:116-146`) durch die echten Renderer.
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from output.renderers.alert.model import AlertEvent, AlertMessage, OnsetEvent
+from output.renderers.alert.render import render_sms, render_subject
+
+_SUBJECT_RE = re.compile(r"^\[[^\]]*\]\s+(?P<where>.+?)\s+·\s+.+$")
+
+# Token-Muster nach AC-6: Vorzeichen + 1-2 Buchstaben-Kuerzel + Von-Wert +
+# '>' + Bis-Wert, optional '@HH'-Suffix.
+_TOKEN_RE = re.compile(r"[+-][A-Z]{1,2}\d+>\d+(?:@\d{2})?")
+
+
+def _location_slot(subject: str) -> str:
+    match = _SUBJECT_RE.match(subject)
+    assert match, f"Betreff hat nicht die Bauform '[Trip] <Ort> · <Kern>': {subject!r}"
+    return match.group("where")
+
+
+def _strip_leading_pictograph(text: str) -> str:
+    """Entfernt ein fuehrendes Piktogramm (z.B. 🏁) samt folgendem Leerzeichen.
+
+    Unabhaengige Testerwartung -- KEINE Wiederverwendung von Produktivcode
+    (der Prueflings-eigene Emoji-Entfernungsschritt ist genau das, was AC-7
+    zusichert; ihn hier nachzubauen wuerde die Zusicherung entwerten)."""
+    if not text:
+        return text
+    if unicodedata.category(text[0]) == "So":
+        return text[1:].lstrip()
+    return text
+
+
+def _delta_event(*, segment_id: str, value_from: float, value_to: float,
+                  threshold: float = 1000.0, occurred_at: str | None = None) -> AlertEvent:
+    return AlertEvent(
+        metric_id="visibility", value_from=value_from, value_to=value_to,
+        threshold=threshold, cmp="unter", occurred_at=occurred_at,
+        km_from=8.0, km_to=8.0, segment_id=segment_id,
+    )
+
+
+def _delta_msg(*events: AlertEvent, trip_short: str = "KHW 403") -> AlertMessage:
+    return AlertMessage(trip_short=trip_short, stand_at="10:00", events=events)
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — Kopf nennt denselben Ortstext wie der Betreff, kein Trip-Name
+# ---------------------------------------------------------------------------
+
+
+def test_ac5_sms_kopf_nennt_denselben_ortstext_wie_der_betreff():
+    """AC-5: Given ein Trip-Δ-Alarm fuer das Ziel-Segment / When Betreff UND
+    SMS gerendert werden / Then kehrt der (emoji-freie) Ortsteil aus dem
+    Betreff als Kopf-Praefix in der SMS wieder -- kein km-Spanne, kein
+    Trip-Name."""
+    msg = _delta_msg(_delta_event(segment_id="Ziel", value_from=1400.0, value_to=280.0))
+
+    subject_location = _location_slot(render_subject(msg))
+    expected_head_text = _strip_leading_pictograph(subject_location)
+    sms = render_sms(msg)
+
+    assert sms.startswith(f"{expected_head_text}: "), (
+        f"SMS-Kopf {sms!r} beginnt nicht mit dem Betreff-Ortstext {expected_head_text!r}"
+    )
+    assert msg.trip_short not in sms, f"SMS traegt weiterhin den Trip-Namen: {sms!r}"
+    assert not re.search(r"km\d", sms), f"SMS nennt weiterhin eine km-Spanne: {sms!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC-6 — Token traegt Von- UND Bis-Wert
+# ---------------------------------------------------------------------------
+
+
+def test_ac6_sms_token_traegt_von_und_bis_wert():
+    """AC-6: Given denselben Fall wie AC-5 / When das Token gerendert wird /
+    Then lautet es exakt '-VS1400>280' -- Von- UND Bis-Wert, nicht mehr nur
+    der Bis-Wert von heute ('-VS280')."""
+    msg = _delta_msg(_delta_event(segment_id="Ziel", value_from=1400.0, value_to=280.0))
+    sms = render_sms(msg)
+
+    match = _TOKEN_RE.search(sms)
+    assert match, f"Kein Von>Bis-Token im Muster [+-][A-Z]{{1,2}}\\d+>\\d+ gefunden: {sms!r}"
+    assert match.group() == "-VS1400>280", f"Token: {match.group()!r} (SMS: {sms!r})"
+    assert "-VS280" not in sms, f"Alter Nur-Bis-Wert-Token noch vorhanden: {sms!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC-7 — Emoji wird entfernt, nicht transliteriert
+# ---------------------------------------------------------------------------
+
+
+def test_ac7_sms_kopf_entfernt_emoji_statt_es_zu_transliterieren():
+    """AC-7: Given ein Trip-Δ-Alarm fuer das Ziel-Segment (Ortstext enthaelt
+    🏁) / When der SMS-Kopf gerendert wird / Then steht dort 'Ziel: ' -- ohne
+    Emoji UND ohne dessen Transliteration (':checkered_flag:' darf NICHT
+    vorkommen). Kopf ist dadurch nicht laenger als der reine Textname."""
+    msg = _delta_msg(_delta_event(segment_id="Ziel", value_from=1400.0, value_to=280.0))
+    sms = render_sms(msg)
+
+    assert ":checkered_flag:" not in sms, (
+        f"Emoji wurde transliteriert statt entfernt: {sms!r}"
+    )
+    assert sms.startswith("Ziel: "), f"SMS-Kopf: {sms!r}"
+    assert len("Ziel: ") == 6, "Sanity: Referenzlaenge des reinen Textkopfs"
+
+
+# ---------------------------------------------------------------------------
+# AC-8 — Segment-Buendel-Kopf, jedes Token mit eigenem Von/Bis-Wert
+# ---------------------------------------------------------------------------
+
+
+def test_ac8_sms_buendelkopf_traegt_zusammengefasste_segmentsprache():
+    """AC-8: Given einen Trip-Δ-Alarm ueber die Segmente 2, 3 und Ziel (je ein
+    Ereignis, drei verschiedene Metriken) / When render_sms() rendert / Then
+    traegt der Kopf 'Segment 2-3, Ziel: ' (ASCII-gefaltet, Bindestrich statt
+    Gedankenstrich, Ziel-Emoji entfernt) und jedes Ereignis sein eigenes
+    Von/Bis-Token nach AC-6.
+
+    Anmerkung (Spec-Ungenauigkeit, s. Bericht): das Golden-Beispiel der Spec
+    nennt fuer diesen Fall nur zwei Token-Beispiele ('beide Token'), obwohl
+    fuer drei Segmente mit je einem Ereignis eigentlich drei Token entstehen.
+    Dieser Test verlangt deshalb bewusst DREI verschiedene Metriken (Boeen,
+    Sicht, Niederschlag) statt der engeren Nacherzaehlung -- so ist jedes
+    Token unabhaengig und eindeutig pruefbar, unabhaengig davon, ob die
+    GREEN-Phase zwei oder drei Segmente mit je eigenem Token abbildet.
+    """
+    e_gust = AlertEvent(
+        metric_id="gust", value_from=30.0, value_to=80.0, threshold=20.0,
+        cmp="über", occurred_at="15:12", km_from=2.0, km_to=4.0, segment_id="2",
+    )
+    e_visibility = AlertEvent(
+        metric_id="visibility", value_from=1400.0, value_to=280.0, threshold=1000.0,
+        cmp="unter", occurred_at="14:30", km_from=4.0, km_to=6.0, segment_id="3",
+    )
+    e_precip = AlertEvent(
+        metric_id="precipitation", value_from=2.0, value_to=30.0, threshold=10.0,
+        cmp="über", occurred_at="16:00", km_from=8.0, km_to=8.0, segment_id="Ziel",
+    )
+    msg = _delta_msg(e_gust, e_visibility, e_precip)
+    sms = render_sms(msg)
+
+    assert sms.startswith("Segment 2-3, Ziel: "), f"SMS-Kopf: {sms!r}"
+    assert ":checkered_flag:" not in sms, f"Ziel-Emoji transliteriert: {sms!r}"
+
+    tokens = _TOKEN_RE.findall(sms)
+    assert "+G30>80@15" in tokens, f"Boeen-Token fehlt/falsch: {sms!r} ({tokens!r})"
+    assert "-VS1400>280@14" in tokens, f"Sicht-Token fehlt/falsch: {sms!r} ({tokens!r})"
+    assert "+R2>30@16" in tokens, f"Niederschlags-Token fehlt/falsch: {sms!r} ({tokens!r})"
+
+
+# ---------------------------------------------------------------------------
+# AC-12 — Trip/Compare-Weiche in `_render_sms_onset` (Vergleich, nicht isoliert)
+# ---------------------------------------------------------------------------
+
+
+def _onset_event(*, location_label: str | None) -> OnsetEvent:
+    return OnsetEvent(
+        onset_minutes=12, onset_time="14:08", km_from=5.0, km_to=18.0,
+        is_convective=False, intensity_label="kraeftiger Regen",
+        source_label="Radar (GeoSphere INCA)", location_label=location_label,
+    )
+
+
+def test_ac12_trip_radar_sms_verliert_den_namen_compare_radar_sms_behaelt_ihn():
+    """AC-12: Given zwei AlertMessages ueber `_render_sms_onset` -- eine mit
+    `OnsetEvent.location_label=None` (echter Trip-Radar/Onset-Alarm) und eine
+    mit gesetztem `location_label` (Ortsvergleich-Buendel-Onset), ansonsten
+    identisch (gleiche `onset_minutes`/`km_from`/`km_to`) / When `render_sms()`
+    beide rendert / Then enthaelt NUR die zweite den Trip-Kurznamen im Kopf;
+    die erste beginnt direkt mit der km-Spanne.
+
+    Die Zusicherung ist der VERGLEICH beider Ergebnisse -- nicht die isolierte
+    Pruefung des Trip-Falls (der isoliert schon durch #1744-Bestandstests lief).
+    """
+    trip_msg = AlertMessage(
+        trip_short="KHW 403", stand_at="10:00",
+        events=(_onset_event(location_label=None),),
+        source="radar", cooldown_display="60 Min",
+    )
+    compare_msg = AlertMessage(
+        trip_short="Vergleich", stand_at="10:00",
+        events=(_onset_event(location_label="Vergleich"),),
+        source="radar", cooldown_display="60 Min",
+    )
+
+    sms_trip = render_sms(trip_msg)
+    sms_compare = render_sms(compare_msg)
+
+    assert sms_trip.startswith("km5-18: "), (
+        f"Trip-Radar-SMS traegt weiterhin einen Namens-Kopf: {sms_trip!r}"
+    )
+    assert "KHW 403" not in sms_trip, f"Trip-Name noch in der SMS: {sms_trip!r}"
+
+    assert sms_compare.startswith("Vergleich km5-18: "), (
+        f"Compare-Radar-SMS hat ihren Sammelnamen verloren: {sms_compare!r}"
+    )

--- a/tests/tdd/test_ascii_folding.py
+++ b/tests/tdd/test_ascii_folding.py
@@ -206,30 +206,46 @@ class _FakeActiveSegment:
 
 
 def test_radar_alert_trip_short_survives_double_truncation():
-    """AC-7: Given ein Trip-Name mit Umlaut nahe der 16-Zeichen-Grenze
-    (`Wandergruppe München`) / When der SMS-Titelzeilen-Pfad ueber
-    `radar_alert_service.py::build_onset_alert_message` (roh vorgekuerztes
-    `trip.name[:16]`, Zeile 71) UND den kanonischen SMS-Renderer laeuft /
-    Then entspricht das Ergebnis `fold_ascii(trip.name)[:16]` -- ERST falten,
-    DANN kuerzen (sms_format.md:66), statt der heutigen Doppelkuerzung (roh
-    kuerzen, dann falten, dann nochmal kuerzen), die Buchstaben frisst, weil
-    'ü' -> 'ue' beim Falten waechst."""
+    """AC-7: Given einen Namen mit Umlaut nahe der 16-Zeichen-Grenze
+    (`Wandergruppe München`) als `trip_short` / When der kanonische
+    SMS-Renderer (`_render_sms_onset`) den Kopf baut / Then entspricht das
+    Ergebnis `fold_ascii(trip_short)[:16]` -- ERST falten, DANN kuerzen
+    (sms_format.md:66), statt der aelteren Doppelkuerzung (roh kuerzen, dann
+    falten, dann nochmal kuerzen), die Buchstaben frisst, weil 'ü' -> 'ue'
+    beim Falten waechst.
+
+    Retargeted (Issue #1935/#1779 E4, PO-Entscheid 2026-08-17): der reine
+    TRIP-Radar/Onset-Pfad (`OnsetEvent.location_label=None`, wie ihn
+    `radar_alert_service.py::build_onset_alert_message` baut) fuehrt seither
+    KEINEN Namen mehr im SMS-Kopf — die urspruengliche Fixture ueber
+    `build_onset_alert_message` wuerde den Pruefling (die Doppelkuerzungs-
+    Logik `_ascii(msg.trip_short)[:16].rstrip(...)`) gar nicht mehr
+    durchlaufen und still bedeutungslos gruen bleiben (kein `trip_short` mehr
+    im Kopf, also nichts mehr zu kuerzen). Dieselbe Kuerzungslogik greift
+    unveraendert im Compare-Radar-Buendel-Pfad (`OnsetEvent.location_label`
+    gesetzt, Issue #1935/#1779 AC-10/AC-12 — dort ist `trip_short` der
+    Orts-Sammelname und bleibt bewusst stehen), dorthin verlegt dieser Test
+    die Fixture, ohne die Pruefling-Logik selbst zu aendern."""
+    from output.renderers.alert.model import AlertMessage, OnsetEvent
     from output.renderers.alert.render import render_sms
-    from services.radar_alert_service import build_onset_alert_message
     from utils.ascii_fold import fold_ascii
 
-    trip = _FakeTripForRadar("Wandergruppe München")
-    active = _FakeActiveSegment()
-
-    msg = build_onset_alert_message(
-        trip, active, onset_minutes=12, onset_time="14:00",
-        intensity_label="leichter Regen", source_label="Radar",
+    trip_short = "Wandergruppe München"
+    onset = OnsetEvent(
+        onset_minutes=12, onset_time="14:00", km_from=0.0, km_to=5.0,
+        is_convective=False, intensity_label="leichter Regen",
+        source_label="Radar", location_label="Buendel-Ort",
     )
+    msg = AlertMessage(
+        trip_short=trip_short, stand_at="14:00", events=(onset,),
+        source="Radar", cooldown_display="60 Min",
+    )
+
     sms = render_sms(msg)
-    expected_prefix = fold_ascii(trip.name)[:16].rstrip(" (-_")
+    expected_prefix = fold_ascii(trip_short)[:16].rstrip(" (-_")
 
     assert sms.startswith(expected_prefix), (
-        f"Doppelkuerzung verstuemmelt den Trip-Namen mitten im Wort: "
+        f"Doppelkuerzung verstuemmelt den Ortsnamen mitten im Wort: "
         f"SMS={sms!r} erwarteter Kopf={expected_prefix!r}"
     )
 

--- a/tests/tdd/test_channel_metric_matrix.py
+++ b/tests/tdd/test_channel_metric_matrix.py
@@ -1804,12 +1804,18 @@ _GEWITTER_ID = _ALERT_METRIC_TO_CATALOG_ID[AlertMetric.THUNDER_LEVEL][0]
 _UNIT_PROBE_VALUE = 12.0
 _EINHEITEN_UNTER_BEOBACHTUNG = sorted({m.unit for m in _METRICS} | set(_HANDLED_UNITS))
 
-# Alarm-SMS-Tokengrammatik (render.py:596-601 ``_sms_token``,
-# render.py:136-137 ``_sms_corridor_token``): {Vorzeichen}{Kuerzel}{Wert}[@HH],
-# optional mit vorangestellter Ortsposition "{n}:". Eine reine Teilstring-Suche
-# waere hier unbrauchbar -- 'N' (temperature_cold) ist Wortanfang von 'NL'
-# (freezing_level) und 'NS' (fresh_snow), s. AC-S1-2-Gegenprobe.
-_ALERT_SMS_TOKEN = re.compile(r"^(?:\d+:)?[+\-!]([A-Za-z][A-Za-z/]*)-?\d+(?:@\d+)?$")
+# Alarm-SMS-Tokengrammatik (render.py ``_sms_token`` / ``_sms_corridor_token``):
+# {Vorzeichen}{Kuerzel}{Wert}[>{Bis}][@HH], optional mit vorangestellter
+# Ortsposition "{n}:". Der ``>{Bis}``-Teil ist neu seit #1935/#1779 (AC-6):
+# der Trip-Δ-Pfad ohne Ortsposition fuehrt seither Von- UND Bis-Wert
+# ("+VS1400>280"), damit der Ausschlag ohne Kenntnis des letzten Mailstands
+# lesbar ist; der Ortsvergleich-Aenderungspfad (Ortsposition gesetzt) bleibt
+# beim reinen Bis-Wert (AC-9, #1467 S2 AG3b). Eine reine Teilstring-Suche
+# waere hier unbrauchbar -- 'N' (temperature_cold) ist Wortanfang von 'NS'
+# (fresh_snow), s. AC-S1-2-Gegenprobe.
+_ALERT_SMS_TOKEN = re.compile(
+    r"^(?:\d+:)?[+\-!]([A-Za-z][A-Za-z/]*)-?\d+(?:>-?\d+)?(?:@\d+)?$"
+)
 
 
 def _alert_sms_codes(sms: str) -> list[str]:

--- a/tests/tdd/test_issue_1169_compare_alert_consumer.py
+++ b/tests/tdd/test_issue_1169_compare_alert_consumer.py
@@ -714,10 +714,12 @@ def test_ac7_trip_alert_rendering_unchanged():
     ausgeführte Rendering-Ergebnis — dieser Test ist bereits heute grün und
     MUSS es nach der Implementierung bleiben.
 
-    Ausnahme (#1861/#1865, nachgezogen): die "Alarm-Schwelle"-Datenblock-Zeile
-    wechselt von Fragment ("Änderung über ✗") zu vollstaendigem Satz ("jetzt
-    darüber ✗") — reine Textaenderung, `over_thr()`/`side_label()` bleiben
-    unveraendert (#958-Invariante). Alle anderen Zeilen bleiben byte-identisch.
+    Ausnahme (#1935/#1779, nachgezogen): die "Alarm-Schwelle"-Datenblock-Zeile
+    nennt seither den Änderungsbetrag statt eines Messwert-Bezugs ("Änderung
+    16,0 mm: über Alarm-Schwelle 10,0 mm ✗" statt "Alarm-Schwelle 10,0 mm:
+    jetzt darüber ✗") — reine Textaenderung, `over_thr()`/`side_label()`
+    bleiben unveraendert (#958-Invariante). Alle anderen Zeilen bleiben
+    byte-identisch.
     """
     from output.renderers.alert.project import to_alert_message
     from output.renderers.alert.render import render_email, render_subject, render_telegram
@@ -754,7 +756,7 @@ def test_ac7_trip_alert_rendering_unchanged():
         "Niedersch +800% seit dem Briefing\n\n"
         "↑ +800 % · Änderung über deiner Alarm-Schwelle (10,0 mm)\n\n"
         "Niedersch · mm: 2,0 mm ↑ 18,0 mm +800 %\n"
-        "Alarm-Schwelle 10,0 mm: jetzt darüber ✗\n"
+        "Änderung 16,0 mm: über Alarm-Schwelle 10,0 mm ✗\n"
         "Wo & wann: Segment 1\n\n"
         "Stand: heute 14:00 · verglichen mit dem letzten Briefing"
         # Issue #1241: geteilte Herkunfts-Fußzeile (deviation-alert). Zeile 2

--- a/tests/tdd/test_multi_location_onset_alert.py
+++ b/tests/tdd/test_multi_location_onset_alert.py
@@ -96,7 +96,8 @@ EXPECTED_HTML = (
 EXPECTED_TELEGRAM = (
     '<b>GR20-Test · km 5–18 · Regen in 12 Min</b>\n14:35 · leichter Regen · Radar (DWD)'
 )
-EXPECTED_SMS = 'GR20-Test km5-18: R!12'
+# Issue #1935/#1779 (E4): Trip-Radar/Onset-Kopf verliert den Trip-Namen.
+EXPECTED_SMS = 'km5-18: R!12'
 
 
 def _fresh_user(prefix: str) -> str:


### PR DESCRIPTION
## Was war das Problem

Zwei PO-Beanstandungen an derselben Alarm-Nachricht, fünf Tage auseinander (#1779, dann konkreter #1935):

**(1) Die E-Mail widersprach sich selbst.** Die Datenzeile `Alarm-Schwelle 1.000 m: jetzt darüber ✗` liest sich als Aussage über den Messwert — der aber 280 m beträgt und damit klar *unter* 1.000 liegt. `threshold` ist per ADR-0013 immer eine Δ-Auslöseschwelle, nie ein Messwert-Grenzwert. Der Verdict-Chip eine Zeile höher sagte es bereits richtig; dieselbe Mail behauptete also zweierlei über dieselbe Tatsache.

**(2) Die SMS nannte den Ort als nutzlose km-Spanne.** `KHW 403 km12-12: -VS280` — mit Trip-Namen, den der Trip-Teilnehmer selbst nicht braucht, und ohne die Etappen-/Zielsprache, die Betreff und E-Mail längst sprechen. Der Token zeigte nur den Endwert, nicht den Ausschlag.

## Was sich ändert

| | vorher | nachher |
|---|---|---|
| E-Mail Datenzeile | `Alarm-Schwelle 1.000 m: jetzt darüber ✗` | `Änderung 1.120 m: über Alarm-Schwelle 1.000 m ✗` |
| SMS | `KHW 403 km12-12: -VS280` | `Ziel: -VS1400>280` |

Die zugrundeliegende Δ-Semantik (#958 / ADR-0013) bleibt **unangetastet** — `over_thr()`, `side_label()` und die Auslöselogik ändern sich nicht, nur der Satz um ihre Rückgabewerte. Der Ortsvergleich-Pfad bleibt byte-identisch (AC-9/AC-10), damit die Positionszahl-Kodierung aus #1467 nicht kippt.

## Nachweis

- **12 ACs**, alle mit Test belegt; zwei neue Verhaltens-Testdateien plus sieben nachgezogene Bestandsdateien
- **Adversary VERIFIED:** 581 Tests grün, **9 von 9 Mutationen gefangen**, keine ungefangene Verfälschung, keine offenen Findings
- **79 Alarm-/SMS-Testdateien** auf der aktuellen `main` (inkl. #1926) vollständig grün

## Ein Wächter war blind geworden

Das neue Von>Bis-Tokenformat hat die Token-Grammatik des Metrik-Matrix-Wächters (#1514) gebrochen: `_alert_sms_codes()` erkannte in `+VS10>20@09` **gar kein** Kürzel mehr und lieferte eine leere Liste — 15 Tests fielen aus. Das ist kein Produktfehler, aber ein Wächter, der sein Prüfobjekt nicht mehr zerlegen kann, bewacht nichts.

Commit `6d8052ef` zieht die Grammatik nach. Belegt ist, dass sie dabei nicht zu weit geöffnet wurde: eine Mutation, die das Trennzeichen verfälscht, wird vom Wächter abgelehnt statt durchgewunken, und das Entfernen des Kürzels macht weiterhin alle elf Parametrisierungen rot.

Nebenbei korrigiert: der erklärende Kommentar nannte als Präfix-Beispiel noch `NL` für `freezing_level` — die Kennung heißt seit #1926 `FZ`.

Betrifft #1935 (Schluss erst nach Prod-Selftest)
Betrifft #1779 (Schluss erst nach Prod-Selftest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
